### PR TITLE
Bugfix: sunxi-6.6: fix inapplicable and Re-export patches, switch to v6.6.54

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -31,7 +31,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.44"
+		declare -g KERNELBRANCH="tag:v6.6.54"
 		;;
 
 	edge)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -32,7 +32,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.44"
+		declare -g KERNELBRANCH="tag:v6.6.54"
 		;;
 
 	edge)

--- a/patch/kernel/archive/sunxi-6.11/patches.armbian/Add-BPI-M4-ZERO-sdio-wifi-bt-overlay.patch
+++ b/patch/kernel/archive/sunxi-6.11/patches.armbian/Add-BPI-M4-ZERO-sdio-wifi-bt-overlay.patch
@@ -1,7 +1,7 @@
-From 57f3aa16ec2a46967b56f7849eaf7f34c09fe5b8 Mon Sep 17 00:00:00 2001
+From f7547788ff73c4e2a5bf1501eac5b0a16f72e66d Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
 Date: Wed, 9 Oct 2024 08:05:54 -0400
-Subject: [PATCH] Add BPI-M4-ZERO sdio wifi bt overlay
+Subject: Add BPI-M4-ZERO sdio wifi bt overlay
 
 sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
 
@@ -13,10 +13,10 @@ Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
 
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-index 76a4952e3ecc..b10db212cdf2 100644
+index 24383cb63770..3d3f715c15d4 100644
 --- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-@@ -66,7 +66,8 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
+@@ -67,7 +67,8 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
  	sun50i-h616-i2c0-pi.dtbo \
  	sun50i-h616-i2c1-pi.dtbo \
  	sun50i-h616-i2c2-pi.dtbo \
@@ -62,5 +62,5 @@ index 000000000000..b672807fab66
 +	};
 +};
 -- 
-2.39.5
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.11/patches.armbian/Add-board-BananaPi-BPI-M4-ZERO.patch
+++ b/patch/kernel/archive/sunxi-6.11/patches.armbian/Add-board-BananaPi-BPI-M4-ZERO.patch
@@ -1,7 +1,7 @@
-From 946c4756a270d64c9a128e629ff7c4789a5ff8c4 Mon Sep 17 00:00:00 2001
+From 55952e38b8976fb03a06dc37341292ddbc27b153 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
 Date: Mon, 7 Oct 2024 08:37:08 -0400
-Subject: [PATCH] Add board BananaPi BPI-M4-ZERO
+Subject: Add board BananaPi BPI-M4-ZERO
 
 sun50i-h618-bananapi-m4-zero.dts
 sun50i-h618-bananapi-m4.dtsi
@@ -16,10 +16,10 @@ Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 717ef4a7ca1c..c2922d51cee2 100644
+index a2ca84f2e3fe..0df5a842ce1f 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -58,6 +58,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
+@@ -56,6 +56,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-pi.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
@@ -29,7 +29,7 @@ index 717ef4a7ca1c..c2922d51cee2 100644
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
 new file mode 100644
-index 000000000000..61829ab55218
+index 000000000000..d7c6e0fdf2ff
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
 @@ -0,0 +1,73 @@
@@ -108,7 +108,7 @@ index 000000000000..61829ab55218
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
 new file mode 100644
-index 000000000000..32fa9588efda
+index 000000000000..f52470634b22
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
 @@ -0,0 +1,280 @@
@@ -393,5 +393,5 @@ index 000000000000..32fa9588efda
 +	pinctrl-names = "default";
 +};
 -- 
-2.39.5
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/arm-patch-call-flush_icache-ASAP-after-writing-new-instruction.patch
+++ b/patch/kernel/archive/sunxi-6.6/arm-patch-call-flush_icache-ASAP-after-writing-new-instruction.patch
@@ -1,0 +1,63 @@
+From d0f6b8b0000847160766e3b9df8a8c2b61d543d0 Mon Sep 17 00:00:00 2001
+From: Mikhail Iakhiaev <mikhailai@gmail.com>
+Date: Mon, 29 Jul 2024 09:50:36 -0700
+Subject: arm/patch: call flush_icache ASAP after writing new instruction.
+
+The patch moves flush_icache before the patch_unmap call.
+The change avoids the possibility of the CPU seeing
+partially-patched instructions if a function from patch_unmap
+call tree has just been patched. That HAS been observed
+in practice, leading to kernel panic or freezing in early boot:
+https://bugzilla.kernel.org/show_bug.cgi?id=219089
+Specifically, the patch_unmap invokes _raw_spin_unlock_irqrestore
+(could be non-inlined) and that function is being patched
+during the ftrace_init, so the original code would run the
+patched code BEFORE flushing the icache.
+
+Note, some arches are more careful about flushing icache early. E.g.
+arch/riscv/kernel/patch.c:
+  __patch_insn_set and __patch_insn_write call the
+  local_flush_icache_range before the patch_unmap and have an
+  explicit comment about this.
+arch/x86/kernel/alternative.c:
+  text_poke_early calls sync_core (flushes icache) before
+  local_irq_restore.
+
+Closes: https://bugzilla.kernel.org/show_bug.cgi?id=219089
+Signed-off-by: Mikhail Iakhiaev <mikhailai@gmail.com>
+
+Signed-off-by: The-going <48602507+The-going@users.noreply.github.com>
+---
+ arch/arm/kernel/patch.c | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/kernel/patch.c b/arch/arm/kernel/patch.c
+index e9e828b6bb30..f003867f085a 100644
+--- a/arch/arm/kernel/patch.c
++++ b/arch/arm/kernel/patch.c
+@@ -99,13 +99,19 @@ void __kprobes __patch_text_real(void *addr, unsigned int insn, bool remap)
+ 		size = sizeof(u32);
+ 	}
+ 
+-	if (waddr != addr) {
++	if (waddr != addr)
+ 		flush_kernel_vmap_range(waddr, twopage ? size / 2 : size);
+-		patch_unmap(FIX_TEXT_POKE0, &flags);
+-	}
+ 
+ 	flush_icache_range((uintptr_t)(addr),
+ 			   (uintptr_t)(addr) + size);
++
++	/* Can only call 'patch_unmap' after flushing dcache and icache,
++	 * because it calls 'raw_spin_unlock_irqrestore', but that may
++	 * happen to be the very function we're currently patching
++	 * (as it happens during the ftrace init).
++	 */
++	if (waddr != addr)
++		patch_unmap(FIX_TEXT_POKE0, &flags);
+ }
+ 
+ static int __kprobes patch_text_stop_machine(void *data)
+-- 
+2.35.3
+

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-DTS-sun50i-h616-overlays-fix-sun50i-h616-light-overlay.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-DTS-sun50i-h616-overlays-fix-sun50i-h616-light-overlay.patch
@@ -1,20 +1,18 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From dace565b9c83d61a0fd8ea91dc69c75cfe02a573 Mon Sep 17 00:00:00 2001
 From: JohnTheCoolingFan <ivan8215145640@gmail.com>
 Date: Sat, 7 Sep 2024 10:57:35 +0000
 Subject: ARM64 DTS: sun50i-h616 overlays: fix sun50i-h616-light overlay
 
 Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
 ---
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-light.dtso | 9 +--------
+ .../boot/dts/allwinner/overlay/sun50i-h616-light.dtso    | 9 +--------
  1 file changed, 1 insertion(+), 8 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-light.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-light.dtso
-index 5010ea6a5..4ab9dc952 100755
+index 5010ea6a57b5..4ab9dc9527e7 100755
 --- a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-light.dtso
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-light.dtso
-@@ -9,19 +9,12 @@ fragment@0 {
- 		 __overlay__ {
- 			status = "okay";
+@@ -11,17 +11,10 @@ __overlay__ {
  		};
  	};
  
@@ -34,5 +32,5 @@ index 5010ea6a5..4ab9dc952 100755
 -	};
  };
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-EMAC1.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-EMAC1.patch
@@ -1,20 +1,18 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 179cc7e62d1603a54f1d2b71185d754694521415 Mon Sep 17 00:00:00 2001
 From: JohnTheCoolingFan <ivan8215145640@gmail.com>
 Date: Thu, 13 Jun 2024 11:50:55 +0000
 Subject: ARM64: dts: sun50i-h616: BigTreeTech CB1: Enable EMAC1
 
 Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 18 ++++++++++
+ .../allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 18 ++++++++++++++++++
  1 file changed, 18 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-index bbff30ccf..b98e85a51 100644
+index bbff30ccf5a9..b98e85a51261 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-@@ -142,10 +142,28 @@ mcp2515_clock: mcp2515_clock {
- 		#clock-cells = <0>;
- 		clock-frequency  = <12000000>;
+@@ -144,6 +144,24 @@ mcp2515_clock: mcp2515_clock {
  	};
  };
  
@@ -39,8 +37,6 @@ index bbff30ccf..b98e85a51 100644
  &mmc0 {
  	vmmc-supply = <&reg_dldo1>;
  	broken-cd;
- 	bus-width = <4>;
- 	max-frequency = <50000000>;
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-HDMI.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-HDMI.patch
@@ -1,20 +1,18 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From fc3ef95a7c02af18308eeb74ae28e85f3e7c3ee2 Mon Sep 17 00:00:00 2001
 From: JohnTheCoolingFan <ivan8215145640@gmail.com>
 Date: Thu, 13 Jun 2024 11:07:35 +0000
 Subject: ARM64: dts: sun50i-h616: BigTreeTech CB1: Enable HDMI
 
 Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 26 ++++++++++
+ .../sun50i-h616-bigtreetech-cb1.dtsi          | 26 +++++++++++++++++++
  1 file changed, 26 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-index e82da4b6e..bbff30ccf 100644
+index e82da4b6e340..bbff30ccf5a9 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-@@ -23,10 +23,21 @@ aliases {
- 
- 	chosen {
+@@ -25,6 +25,17 @@ chosen {
  		stdout-path = "serial0:115200n8";
  	};
  
@@ -32,11 +30,7 @@ index e82da4b6e..bbff30ccf 100644
  	leds {
  		compatible = "gpio-leds";
  
- 		act_led: led-0 {
- 			gpios = <&pio 7 5 GPIO_ACTIVE_LOW>; /* PH5 */
-@@ -255,10 +266,25 @@ reg_dldo1: dldo1 {
- 			};
- 		};
+@@ -257,6 +268,21 @@ reg_dldo1: dldo1 {
  	};
  };
  
@@ -58,8 +52,6 @@ index e82da4b6e..bbff30ccf 100644
  &cpu0 {
  	cpu-supply = <&reg_dcdc2>;
  	status = "okay";
- };
- 
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-IR-receiver.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-IR-receiver.patch
@@ -1,20 +1,18 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From e01b533da5e6181c2a34ccf65a25d79bf6cc545b Mon Sep 17 00:00:00 2001
 From: JohnTheCoolingFan <ivan8215145640@gmail.com>
 Date: Mon, 12 Aug 2024 14:50:16 +0000
 Subject: ARM64: dts: sun50i-h616: BigTreeTech CB1: Enable IR receiver
 
 Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 4 ++++
+ .../arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-index b98e85a51..c2e20408c 100644
+index b98e85a51261..c2e20408cb66 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-@@ -352,10 +352,14 @@ &ehci3 {
- 
- &ohci3 {
+@@ -354,6 +354,10 @@ &ohci3 {
  	status = "okay";
  };
  
@@ -25,8 +23,6 @@ index b98e85a51..c2e20408c 100644
  &usbotg {
  	/*
  	 * PHY0 pins are connected to a USB-C socket, but a role switch
- 	 * is not implemented: both CC pins are pulled to GND.
- 	 * The VBUS pins power the device, so a fixed peripheral mode
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-BPI-M4-ZERO-sdio-wifi-bt-overlay.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-BPI-M4-ZERO-sdio-wifi-bt-overlay.patch
@@ -1,7 +1,7 @@
-From 57f3aa16ec2a46967b56f7849eaf7f34c09fe5b8 Mon Sep 17 00:00:00 2001
+From 8c701c74f295b80294bf06f5ba03472566348145 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
 Date: Wed, 9 Oct 2024 08:05:54 -0400
-Subject: [PATCH] Add BPI-M4-ZERO sdio wifi bt overlay
+Subject: Add BPI-M4-ZERO sdio wifi bt overlay
 
 sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
 
@@ -13,10 +13,10 @@ Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
 
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-index 76a4952e3ecc..b10db212cdf2 100644
+index 24383cb63770..3d3f715c15d4 100644
 --- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-@@ -66,7 +66,8 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
+@@ -67,7 +67,8 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
  	sun50i-h616-i2c0-pi.dtbo \
  	sun50i-h616-i2c1-pi.dtbo \
  	sun50i-h616-i2c2-pi.dtbo \
@@ -62,5 +62,5 @@ index 000000000000..b672807fab66
 +	};
 +};
 -- 
-2.39.5
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-board-BananaPi-BPI-M4-ZERO.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-board-BananaPi-BPI-M4-ZERO.patch
@@ -10,23 +10,23 @@ Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
  arch/arm64/boot/dts/allwinner/Makefile        |   1 +
  .../sun50i-h618-bananapi-m4-zero.dts          |  73 +++++
- .../allwinner/sun50i-h618-bananapi-m4.dtsi    | 280 ++++++++++++++++++
- 3 files changed, 354 insertions(+)
+ .../allwinner/sun50i-h618-bananapi-m4.dtsi    | 285 ++++++++++++++++++
+ 3 files changed, 359 insertions(+)
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 040f735b47aa..2d50381b3665 100644
+index 443344f664b8..cedf4d9bb14d 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -54,6 +54,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
+@@ -53,6 +53,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
 +dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-bananapi-m4-zero.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero2w.dtb
  
+ subdir-y	:= $(dts-dirs) overlay
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
 new file mode 100644
 index 000000000000..d7c6e0fdf2ff
@@ -108,10 +108,10 @@ index 000000000000..d7c6e0fdf2ff
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
 new file mode 100644
-index 000000000000..f52470634b22
+index 000000000000..f0f9c95f4a0d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
-@@ -0,0 +1,280 @@
+@@ -0,0 +1,285 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
@@ -298,6 +298,11 @@ index 000000000000..f52470634b22
 +	vcc-pg-supply = <&reg_dldo1>;
 +	vcc-ph-supply = <&reg_dldo1>;
 +	vcc-pi-supply = <&reg_dldo1>;
++
++	x32clk_fanout_pin: x32clk-fanout-pin {
++		pins = "PG10";
++		function = "clock";
++	};
 +};
 +
 +&r_i2c {
@@ -392,35 +397,6 @@ index 000000000000..f52470634b22
 +	pinctrl-0 = <&uart5_pins>;
 +	pinctrl-names = "default";
 +};
--- 
-2.39.5
-
-From 989d9024453b002f3be88d52747447fc68f47b2b Mon Sep 17 00:00:00 2001
-From: Patrick Yavitz <pyavitz@armbian.com>
-Date: Wed, 9 Oct 2024 09:13:02 -0400
-Subject: [PATCH] Add pinctrl: x32clk_fanout_pin
-
-Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
----
- arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi | 5 +++++
- 1 file changed, 5 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
-index f52470634b22..f0f9c95f4a0d 100644
---- a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
-+++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
-@@ -184,6 +184,11 @@ &pio {
- 	vcc-pg-supply = <&reg_dldo1>;
- 	vcc-ph-supply = <&reg_dldo1>;
- 	vcc-pi-supply = <&reg_dldo1>;
-+
-+	x32clk_fanout_pin: x32clk-fanout-pin {
-+		pins = "PG10";
-+		function = "clock";
-+	};
- };
- 
- &r_i2c {
 -- 
 2.39.5
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-wifi-nodes-for-Inovato-Quadra.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-wifi-nodes-for-Inovato-Quadra.patch
@@ -1,4 +1,4 @@
-From 68e3c93f16478ac7a1fe2d64b79c76b96e5782f6 Mon Sep 17 00:00:00 2001
+From 12fb2e2ec03f07a837c880d7a6fddbd0135a4dc7 Mon Sep 17 00:00:00 2001
 From: Gunjan Gupta <viraniac@gmail.com>
 Date: Tue, 19 Sep 2023 11:06:01 +0000
 Subject: Add wifi nodes for Inovato Quadra
@@ -10,10 +10,10 @@ Subject: Add wifi nodes for Inovato Quadra
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h6-inovato-quadra.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index ad82da8e2aad..8b504ee408e7 100644
+index 1a37d4ec9a60..468d3f235490 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -48,6 +48,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-one-plus.dtb
+@@ -49,6 +49,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-one-plus.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64-model-b.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Sound-for-H616-H618-Allwinner-SOCs.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Sound-for-H616-H618-Allwinner-SOCs.patch
@@ -1,4 +1,4 @@
-From 1a8ee4f49169293e1144c2297db537a1e7de63ed Mon Sep 17 00:00:00 2001
+From 6e527d62e8e118474abae0058e7df10e98afb4ce Mon Sep 17 00:00:00 2001
 From: Stephen Graf <stephen.graf@gmail.com>
 Date: Thu, 9 May 2024 20:59:34 -0700
 Subject: Sound for H616, H618 Allwinner SOCs
@@ -76,7 +76,7 @@ index ce3dc6d9cd66..23553f2249c2 100644
  	status = "okay";
  };
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-index 90e55a6aef1d..3df5b74bf306 100644
+index b7c9d4b02751..f4ff1833e5fe 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 @@ -182,6 +182,78 @@ dma: dma-controller@3002000 {
@@ -158,7 +158,7 @@ index 90e55a6aef1d..3df5b74bf306 100644
  		gpu: gpu@1800000 {
  			compatible = "allwinner,sun50i-h616-mali",
  				     "arm,mali-bifrost";
-@@ -457,6 +529,17 @@ gic: interrupt-controller@3021000 {
+@@ -475,6 +547,17 @@ gic: interrupt-controller@3021000 {
  			#interrupt-cells = <3>;
  		};
  

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/add-bigtreetech-cb1-dts.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/add-bigtreetech-cb1-dts.patch
@@ -1,4 +1,4 @@
-From bbd85618d5e4ba7921e3ac2b648a137d48004022 Mon Sep 17 00:00:00 2001
+From 5260e758e18c5076e3e53d3b17cbf6338addd43f Mon Sep 17 00:00:00 2001
 From: Your Name <you@example.com>
 Date: Tue, 30 May 2023 10:18:55 +0800
 Subject: add bigtreetech-cb1 dts
@@ -14,10 +14,10 @@ Subject: add bigtreetech-cb1 dts
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 4d4d2e5c01f2..74a6e5e0d7b3 100644
+index 4759f09a89cc..443344f664b8 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -50,6 +50,8 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
+@@ -51,6 +51,8 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/add-initial-support-for-orangepi3-lts.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/add-initial-support-for-orangepi3-lts.patch
@@ -1,4 +1,4 @@
-From d476463d4e4271266bfdc2fbec353810fbaa5165 Mon Sep 17 00:00:00 2001
+From 9f88fa1812aa12386fc729a6d618a0b9600a2695 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Sat, 16 Apr 2022 11:51:35 +0300
 Subject: add initial support for orangepi3-lts
@@ -10,10 +10,10 @@ Subject: add initial support for orangepi3-lts
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3-lts.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index fd2f4f11e1fb..ad82da8e2aad 100644
+index cedf4d9bb14d..1a37d4ec9a60 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -42,6 +42,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus.dtb
+@@ -43,6 +43,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-beelink-gs1.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-3.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-Add-sun8i-h2-plus-nanopi-duo-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-Add-sun8i-h2-plus-nanopi-duo-device.patch
@@ -1,4 +1,4 @@
-From d1c82c30050a9447f25890a4099701f039794f4b Mon Sep 17 00:00:00 2001
+From 8e08e10dc5bad9eaa7aac5ec22e06e891af21430 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Mon, 24 Jan 2022 15:00:36 +0300
 Subject: arm:dts: Add sun8i-h2-plus-nanopi-duo device
@@ -10,10 +10,10 @@ Subject: arm:dts: Add sun8i-h2-plus-nanopi-duo device
  create mode 100644 arch/arm/boot/dts/allwinner/sun8i-h2-plus-nanopi-duo.dts
 
 diff --git a/arch/arm/boot/dts/allwinner/Makefile b/arch/arm/boot/dts/allwinner/Makefile
-index eebb5a0c873a..5833777340fd 100644
+index 296be33ec934..aa134fdf6905 100644
 --- a/arch/arm/boot/dts/allwinner/Makefile
 +++ b/arch/arm/boot/dts/allwinner/Makefile
-@@ -281,6 +281,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+@@ -220,6 +220,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
  	sun8i-a83t-tbs-a711.dtb \
  	sun8i-h2-plus-bananapi-m2-zero.dtb \
  	sun8i-h2-plus-libretech-all-h3-cc.dtb \

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-Add-sun8i-h2-plus-sunvell-r69-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-Add-sun8i-h2-plus-sunvell-r69-device.patch
@@ -1,4 +1,4 @@
-From ec9bef87e3b1cbcd2d32f012ce1ed264beb36c09 Mon Sep 17 00:00:00 2001
+From 1d931f8c9f87d7503510bddf09fc2e112ee6ac87 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Mon, 24 Jan 2022 15:23:33 +0300
 Subject: arm:dts: Add sun8i-h2-plus-sunvell-r69 device
@@ -10,10 +10,10 @@ Subject: arm:dts: Add sun8i-h2-plus-sunvell-r69 device
  create mode 100644 arch/arm/boot/dts/allwinner/sun8i-h2-plus-sunvell-r69.dts
 
 diff --git a/arch/arm/boot/dts/allwinner/Makefile b/arch/arm/boot/dts/allwinner/Makefile
-index 5833777340fd..cf12179accb7 100644
+index aa134fdf6905..055d241d7851 100644
 --- a/arch/arm/boot/dts/allwinner/Makefile
 +++ b/arch/arm/boot/dts/allwinner/Makefile
-@@ -284,6 +284,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+@@ -223,6 +223,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
  	sun8i-h2-plus-nanopi-duo.dtb \
  	sun8i-h2-plus-orangepi-r1.dtb \
  	sun8i-h2-plus-orangepi-zero.dtb \

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
@@ -1,4 +1,4 @@
-From 3cf9b6e35340b89f11cb0911e03bbfd963ca5f4b Mon Sep 17 00:00:00 2001
+From 00938ccffe0597300031d75e211f5312914f57c8 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Wed, 2 Feb 2022 12:54:05 +0300
 Subject: arm:dts:overlay Add Overlays for sunxi
@@ -200,10 +200,10 @@ Subject: arm:dts:overlay Add Overlays for sunxi
  create mode 100644 arch/arm/boot/dts/allwinner/overlay/sun8i-r40-uart7.dtso
 
 diff --git a/arch/arm/boot/dts/allwinner/Makefile b/arch/arm/boot/dts/allwinner/Makefile
-index cf12179accb7..bd7f5c844e21 100644
+index 055d241d7851..4104f83a2d33 100644
 --- a/arch/arm/boot/dts/allwinner/Makefile
 +++ b/arch/arm/boot/dts/allwinner/Makefile
-@@ -334,3 +334,5 @@ dtb-$(CONFIG_MACH_SUNIV) += \
+@@ -272,3 +272,5 @@ dtb-$(CONFIG_MACH_SUNIV) += \
  	suniv-f1c100s-licheepi-nano.dtb \
  	suniv-f1c200s-lctech-pi.dtb \
  	suniv-f1c200s-popstick-v1.1.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-k1-plus-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-k1-plus-device.patch
@@ -1,4 +1,4 @@
-From c58846e90da14ec10cf697032867990cb63d5a07 Mon Sep 17 00:00:00 2001
+From 3522343ef2df5a56543a63a5aa7d1ae75f81f2c6 Mon Sep 17 00:00:00 2001
 From: wuweidong <625769020@qq.com>
 Date: Mon, 27 Nov 2017 10:23:51 +0800
 Subject: arm64:dts: Add sun50i-h5-nanopi-k1-plus device
@@ -10,10 +10,10 @@ Subject: arm64:dts: Add sun50i-h5-nanopi-k1-plus device
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-k1-plus.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 358efa5d6abc..29c44ac36599 100644
+index 94aaf6384267..a31fbac871a1 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -28,6 +28,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
+@@ -29,6 +29,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s-h5.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-pc2.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-m1-plus2-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-m1-plus2-device.patch
@@ -1,4 +1,4 @@
-From dda53c73e018e9599dc9d0e637ca01308e1340a8 Mon Sep 17 00:00:00 2001
+From c38b5c605885a07a5806492e9cf4c7967fdf9a31 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Mon, 24 Jan 2022 18:54:36 +0300
 Subject: arm64:dts: Add sun50i-h5-nanopi-m1-plus2 device
@@ -10,10 +10,10 @@ Subject: arm64:dts: Add sun50i-h5-nanopi-m1-plus2 device
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-m1-plus2.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 0250c273de9c..9d813575ca26 100644
+index 8f360b752ad4..b27d424e7731 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -31,6 +31,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-core2.dtb
+@@ -32,6 +32,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-core2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s-h5.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-pc2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-k1-plus.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo-core2-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo-core2-device.patch
@@ -1,4 +1,4 @@
-From 5b2ce3f3ca2aa45dfd3a77a9a5e810f46056fa69 Mon Sep 17 00:00:00 2001
+From 0c9544d024ef8851a1fb8ebc948b4c2e0c9edd2a Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Mon, 24 Jan 2022 18:43:42 +0300
 Subject: arm64:dts: Add sun50i-h5-nanopi-neo-core2 device
@@ -10,10 +10,10 @@ Subject: arm64:dts: Add sun50i-h5-nanopi-neo-core2 device
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-core2.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 29c44ac36599..1764856f6c2d 100644
+index a31fbac871a1..aa75246ef731 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -26,6 +26,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-it.dtb
+@@ -27,6 +27,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-it.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h5-cc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo2-v1.1-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo2-v1.1-device.patch
@@ -1,4 +1,4 @@
-From 5cd23fb9d4492ddbed0bfebcc838c9115e5419cf Mon Sep 17 00:00:00 2001
+From ff109a4c8a7e661d94c18c09915936c0297a4830 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Mon, 24 Jan 2022 18:49:55 +0300
 Subject: arm64:dts: Add sun50i-h5-nanopi-neo2-v1.1 device
@@ -10,10 +10,10 @@ Subject: arm64:dts: Add sun50i-h5-nanopi-neo2-v1.1 device
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo2-v1.1.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 1764856f6c2d..0250c273de9c 100644
+index aa75246ef731..8f360b752ad4 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -25,6 +25,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-cc.dtb
+@@ -26,6 +26,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-cc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-it.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h5-cc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
@@ -1,4 +1,4 @@
-From 44a30e3d24d0930e8eade41e0ece23559a47a013 Mon Sep 17 00:00:00 2001
+From 7dd4e48ccf6d23042982b636f605347a17e62b12 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Wed, 2 Feb 2022 13:02:10 +0300
 Subject: arm64:dts:allwinner:overlay: Add Overlays for sunxi64
@@ -104,10 +104,10 @@ Subject: arm64:dts:allwinner:overlay: Add Overlays for sunxi64
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dtso
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 9d813575ca26..54424ab784a5 100644
+index b27d424e7731..b6d5142c2b01 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -46,3 +46,5 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
+@@ -47,3 +47,5 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h313-x96q-lpddr3.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h313-x96q-lpddr3.patch
@@ -1,8 +1,25 @@
+From d1df1c9d30de8b7e209a5454aa24f552c7fc11c3 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Thu, 10 Oct 2024 14:45:40 +0300
+Subject: [PATCH] arm64: dts: sun50i-h313-x96q-lpddr3
+
+Add support X96Q TV Box LPDDR3 H313
+
+Author: sicXnull <notifications@github.com>
+Signed-off-by: The-going <48602507+The-going@users.noreply.github.com>
+---
+ arch/arm64/boot/dts/allwinner/Makefile        |   1 +
+ .../dts/allwinner/sun50i-h313-cpu-opp.dtsi    |  91 ++++++
+ .../dts/allwinner/sun50i-h313-x96q-lpddr3.dts | 305 ++++++++++++++++++
+ 3 files changed, 397 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h313-cpu-opp.dtsi
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h313-x96q-lpddr3.dts
+
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index a957365..812685d 100644
+index 358efa5d6abc..94aaf6384267 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -23,6 +23,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pinetab-early-adopter.dtb
+@@ -18,6 +18,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pinetab-early-adopter.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-sopine-baseboard.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-teres-i.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a100-allwinner-perf1.dtb
@@ -10,10 +27,106 @@ index a957365..812685d 100644
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-bananapi-m2-plus.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-bananapi-m2-plus-v1.2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-emlid-neutis-n5-devboard.dtb
-
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h313-cpu-opp.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h313-cpu-opp.dtsi
+new file mode 100644
+index 000000000000..a429049d8c50
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h313-cpu-opp.dtsi
+@@ -0,0 +1,91 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++// Copyright (C) 2021 Piotr Oniszczuk <piotr.oniszczuk@gmail.com>
++
++/*
++	X96-q DDR3 vendor Android DT:
++	480000000	900mV
++	600000000	900mV
++	792000000	900mV
++	1008000000	920mV
++	1200000000	980mV
++	1344000000	1120mV
++	1416000000	1140mV
++	1512000000	1160mV
++*/
++
++/ {
++	cpu_opp_table: opp-table-cpu {
++		compatible = "allwinner,sun50i-h616-operating-points";
++		nvmem-cells = <&cpu_speed_grade>;
++		opp-shared;
++
++		opp-480000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <480000000>;
++
++			opp-microvolt-speed0 = <900000 900000 1100000>;
++			opp-microvolt-speed1 = <900000 900000 1100000>;
++			opp-microvolt-speed2 = <900000 900000 1100000>;
++		};
++
++		opp-600000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <600000000>;
++
++			opp-microvolt-speed0 = <900000 900000 1100000>;
++			opp-microvolt-speed1 = <900000 900000 1100000>;
++			opp-microvolt-speed2 = <900000 900000 1100000>;
++		};
++
++		opp-792000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <792000000>;
++		        opp-microvolt-speed0 = <900000 900000 1100000>;
++			opp-microvolt-speed1 = <900000 900000 1100000>;
++			opp-microvolt-speed2 = <900000 900000 1100000>;
++		};
++
++		opp-1008000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1008000000>;
++
++			opp-microvolt-speed0 = <920000 920000 1100000>;
++			opp-microvolt-speed1 = <920000 920000 1100000>;
++			opp-microvolt-speed2 = <920000 920000 1100000>;
++		};
++
++		opp-1200000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1200000000>;
++
++			opp-microvolt-speed0 = <980000 980000 1100000>;
++			opp-microvolt-speed1 = <980000 980000 1100000>;
++			opp-microvolt-speed2 = <980000 980000 1100000>;
++		};
++
++		opp-1512000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1512000000>;
++
++			opp-microvolt-speed0 = <1100000 1100000 1100000>;
++			opp-microvolt-speed1 = <1100000 1100000 1100000>;
++			opp-microvolt-speed2 = <1100000 1100000 1100000>;
++		};
++	};
++};
++
++&cpu0 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu1 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu2 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu3 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h313-x96q-lpddr3.dts b/arch/arm64/boot/dts/allwinner/sun50i-h313-x96q-lpddr3.dts
 new file mode 100644
-index 0000000..ba48e0d
+index 000000000000..4b1faad0e88c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h313-x96q-lpddr3.dts
 @@ -0,0 +1,305 @@
@@ -322,98 +435,6 @@ index 0000000..ba48e0d
 +	status = "okay";
 +};
 +
-diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h313-cpu-opp.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h313-cpu-opp.dtsi
---- a/arch/arm64/boot/dts/allwinner/sun50i-h313-cpu-opp.dtsi
-+++ b/arch/arm64/boot/dts/allwinner/sun50i-h313-cpu-opp.dtsi
-@@ -0,0 +1,91 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+// Copyright (C) 2021 Piotr Oniszczuk <piotr.oniszczuk@gmail.com>
-+
-+/*
-+	X96-q DDR3 vendor Android DT:
-+	480000000	900mV
-+	600000000	900mV
-+	792000000	900mV
-+	1008000000	920mV
-+	1200000000	980mV
-+	1344000000	1120mV
-+	1416000000	1140mV
-+	1512000000	1160mV
-+*/
-+
-+/ {
-+	cpu_opp_table: opp-table-cpu {
-+		compatible = "allwinner,sun50i-h616-operating-points";
-+		nvmem-cells = <&cpu_speed_grade>;
-+		opp-shared;
-+
-+		opp-480000000 {
-+			clock-latency-ns = <244144>; /* 8 32k periods */
-+			opp-hz = /bits/ 64 <480000000>;
-+
-+			opp-microvolt-speed0 = <900000 900000 1100000>;
-+			opp-microvolt-speed1 = <900000 900000 1100000>;
-+			opp-microvolt-speed2 = <900000 900000 1100000>;
-+		};
-+
-+		opp-600000000 {
-+			clock-latency-ns = <244144>; /* 8 32k periods */
-+			opp-hz = /bits/ 64 <600000000>;
-+
-+			opp-microvolt-speed0 = <900000 900000 1100000>;
-+			opp-microvolt-speed1 = <900000 900000 1100000>;
-+			opp-microvolt-speed2 = <900000 900000 1100000>;
-+		};
-+
-+		opp-792000000 {
-+			clock-latency-ns = <244144>; /* 8 32k periods */
-+			opp-hz = /bits/ 64 <792000000>;
-+		        opp-microvolt-speed0 = <900000 900000 1100000>;
-+			opp-microvolt-speed1 = <900000 900000 1100000>;
-+			opp-microvolt-speed2 = <900000 900000 1100000>;
-+		};
-+
-+		opp-1008000000 {
-+			clock-latency-ns = <244144>; /* 8 32k periods */
-+			opp-hz = /bits/ 64 <1008000000>;
-+
-+			opp-microvolt-speed0 = <920000 920000 1100000>;
-+			opp-microvolt-speed1 = <920000 920000 1100000>;
-+			opp-microvolt-speed2 = <920000 920000 1100000>;
-+		};
-+
-+		opp-1200000000 {
-+			clock-latency-ns = <244144>; /* 8 32k periods */
-+			opp-hz = /bits/ 64 <1200000000>;
-+
-+			opp-microvolt-speed0 = <980000 980000 1100000>;
-+			opp-microvolt-speed1 = <980000 980000 1100000>;
-+			opp-microvolt-speed2 = <980000 980000 1100000>;
-+		};
-+
-+		opp-1512000000 {
-+			clock-latency-ns = <244144>; /* 8 32k periods */
-+			opp-hz = /bits/ 64 <1512000000>;
-+
-+			opp-microvolt-speed0 = <1100000 1100000 1100000>;
-+			opp-microvolt-speed1 = <1100000 1100000 1100000>;
-+			opp-microvolt-speed2 = <1100000 1100000 1100000>;
-+		};
-+	};
-+};
-+
-+&cpu0 {
-+	operating-points-v2 = <&cpu_opp_table>;
-+};
-+
-+&cpu1 {
-+	operating-points-v2 = <&cpu_opp_table>;
-+};
-+
-+&cpu2 {
-+	operating-points-v2 = <&cpu_opp_table>;
-+};
-+
-+&cpu3 {
-+	operating-points-v2 = <&cpu_opp_table>;
-+};
+-- 
+2.35.3
+

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h616-bananapi-m4-i2c-spi1-uart-pins.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h616-bananapi-m4-i2c-spi1-uart-pins.patch
@@ -1,7 +1,7 @@
-From 7b11043809bad68dc70da47962a268c8877caf51 Mon Sep 17 00:00:00 2001
+From cb7423cec3810046b28ba92342bd1182412af123 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
 Date: Tue, 1 Oct 2024 12:21:03 -0400
-Subject: [PATCH] arm64: dts: sun50i-h616: bananapi-m4: i2c spi1 uart pins
+Subject: arm64: dts: sun50i-h616: bananapi-m4: i2c spi1 uart pins
 
 BananaPi M4 Pins
 
@@ -11,10 +11,10 @@ Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
  1 file changed, 36 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-index e5573a7f1882..ac717d3d0f51 100644
+index ccaca20eb10b..b7c9d4b02751 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -396,11 +396,23 @@ i2c2_ph_pins: i2c2-ph-pins {
+@@ -324,11 +324,23 @@ i2c2_ph_pins: i2c2-ph-pins {
  				function = "i2c2";
  			};
  
@@ -38,7 +38,7 @@ index e5573a7f1882..ac717d3d0f51 100644
  			i2c4_ph_pins: i2c4-ph-pins {
  				pins = "PH6", "PH7";
  				function = "i2c4";
-@@ -467,6 +479,12 @@ spi1_cs0_pin: spi1-cs0-pin {
+@@ -395,6 +407,12 @@ spi1_cs0_pin: spi1-cs0-pin {
  				function = "spi1";
  			};
  
@@ -51,7 +51,7 @@ index e5573a7f1882..ac717d3d0f51 100644
  			uart0_ph_pins: uart0-ph-pins {
  				pins = "PH0", "PH1";
  				function = "uart0";
-@@ -498,6 +516,24 @@ uart5_pins: uart5-pins {
+@@ -426,6 +444,24 @@ uart5_pins: uart5-pins {
  				pins = "PH2", "PH3";
  				function = "uart5";
  			};
@@ -77,5 +77,5 @@ index e5573a7f1882..ac717d3d0f51 100644
  
  		gic: interrupt-controller@3021000 {
 -- 
-2.39.5
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h618-cherryba-m1.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h618-cherryba-m1.patch
@@ -1,17 +1,32 @@
+From 569252cfc308760e9f1f8e69a83a3e9e5cdd48ed Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Thu, 10 Oct 2024 16:52:59 +0300
+Subject: arm64: dts: sun50i-h618-cherryba-m1
+
+Support CherryBa M1 board
+
+Author: IsMrX <x@ismrx.com>
+---
+ arch/arm64/boot/dts/allwinner/Makefile        |   1 +
+ .../dts/allwinner/sun50i-h618-cherryba-m1.dts | 468 ++++++++++++++++++
+ 2 files changed, 469 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-cherryba-m1.dts
+
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 3b0ad5406238..93401efad817 100644
+index 812685d6740f..c49ed1aed4ac 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -39,5 +39,6 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64-model-b.dtb
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
+@@ -52,6 +52,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-inovato-quadra.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
 +dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-cherryba-m1.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-cherryba-m1.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-cherryba-m1.dts
 new file mode 100644
-index 000000000000..20993f683c3b
+index 000000000000..bcc4fa0444d8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-cherryba-m1.dts
 @@ -0,0 +1,468 @@
@@ -483,3 +498,6 @@ index 000000000000..20993f683c3b
 +		function = "pwm5";
 +	};
 +};
+-- 
+2.35.3
+

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/driver-allwinner-h618-emac.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/driver-allwinner-h618-emac.patch
@@ -1,4 +1,4 @@
-From 9eb9f2e36907405e3644fb1434652a7a13116ad8 Mon Sep 17 00:00:00 2001
+From ce1e497512a063c14df5b34ed0dbffe8fac53fcd Mon Sep 17 00:00:00 2001
 From: chraac <chraac@gmail.com>
 Date: Wed, 1 May 2024 14:32:00 +0800
 Subject: driver: allwinner h618 emac
@@ -29,7 +29,7 @@ commit:
  create mode 100644 include/linux/mfd/ac200.h
 
 diff --git a/drivers/gpio/gpiolib-of.c b/drivers/gpio/gpiolib-of.c
-index d9525d95e818..6842f90f9efe 100644
+index cec9e8f29bbd..5ad3ebcb8c2e 100644
 --- a/drivers/gpio/gpiolib-of.c
 +++ b/drivers/gpio/gpiolib-of.c
 @@ -25,21 +25,6 @@
@@ -54,7 +54,7 @@ index d9525d95e818..6842f90f9efe 100644
  /**
   * of_gpio_named_count() - Count GPIOs for a device
   * @np:		device node to count GPIOs for
-@@ -398,6 +383,20 @@ static struct gpio_desc *of_get_named_gpiod_flags(const struct device_node *np,
+@@ -416,6 +401,20 @@ static struct gpio_desc *of_get_named_gpiod_flags(const struct device_node *np,
  	return desc;
  }
  
@@ -97,7 +97,7 @@ index caed5e75d11f..e532334e024f 100644
  	tristate
  	select MFD_CORE
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index 0c3b4aaf4eb7..bc180cf44009 100644
+index f03188b74d62..f0127d83609a 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
 @@ -141,6 +141,7 @@ obj-$(CONFIG_MFD_DA9052_I2C)	+= da9052-i2c.o

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-gpu-drm-panel-simple-Add-compability-olinuxino-lcd.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-gpu-drm-panel-simple-Add-compability-olinuxino-lcd.patch
@@ -1,4 +1,4 @@
-From 3f4dde3f169acdc6f2421a121541836c5ae62f63 Mon Sep 17 00:00:00 2001
+From 53a66fc1e807b225de51f535aa4e27cb422cc4ae Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Wed, 2 Feb 2022 19:34:55 +0300
 Subject: drv:gpu:drm: panel-simple Add compability olinuxino lcd
@@ -8,10 +8,10 @@ Subject: drv:gpu:drm: panel-simple Add compability olinuxino lcd
  1 file changed, 122 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/gpu/drm/panel/panel-simple.c b/drivers/gpu/drm/panel/panel-simple.c
-index e8d12ec8dbec..cad1bcd383b7 100644
+index 11ade6bac592..a3305a27c7b7 100644
 --- a/drivers/gpu/drm/panel/panel-simple.c
 +++ b/drivers/gpu/drm/panel/panel-simple.c
-@@ -3103,6 +3103,44 @@ static const struct panel_desc okaya_rs800480t_7x0gp = {
+@@ -3104,6 +3104,44 @@ static const struct panel_desc okaya_rs800480t_7x0gp = {
  	.bus_format = MEDIA_BUS_FMT_RGB666_1X18,
  };
  
@@ -56,7 +56,7 @@ index e8d12ec8dbec..cad1bcd383b7 100644
  static const struct drm_display_mode olimex_lcd_olinuxino_43ts_mode = {
  	.clock = 9000,
  	.hdisplay = 480,
-@@ -3115,8 +3153,8 @@ static const struct drm_display_mode olimex_lcd_olinuxino_43ts_mode = {
+@@ -3116,8 +3154,8 @@ static const struct drm_display_mode olimex_lcd_olinuxino_43ts_mode = {
  	.vtotal = 272 + 8 + 5 + 3,
  };
  
@@ -67,7 +67,7 @@ index e8d12ec8dbec..cad1bcd383b7 100644
  	.num_modes = 1,
  	.size = {
  		.width = 95,
-@@ -3125,6 +3163,71 @@ static const struct panel_desc olimex_lcd_olinuxino_43ts = {
+@@ -3126,6 +3164,71 @@ static const struct panel_desc olimex_lcd_olinuxino_43ts = {
  	.bus_format = MEDIA_BUS_FMT_RGB888_1X24,
  };
  
@@ -139,7 +139,7 @@ index e8d12ec8dbec..cad1bcd383b7 100644
  /*
   * 800x480 CVT. The panel appears to be quite accepting, at least as far as
   * pixel clocks, but this is the timing that was being used in the Adafruit
-@@ -4393,8 +4496,23 @@ static const struct of_device_id platform_of_match[] = {
+@@ -4394,8 +4497,23 @@ static const struct of_device_id platform_of_match[] = {
  		.compatible = "okaya,rs800480t-7x0gp",
  		.data = &okaya_rs800480t_7x0gp,
  	}, {

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-spi-spidev-Add-armbian-spi-dev-compatible.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-spi-spidev-Add-armbian-spi-dev-compatible.patch
@@ -11,15 +11,15 @@ diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
 index d13dc15cc191..456eca57ee4f 100644
 --- a/drivers/spi/spidev.c
 +++ b/drivers/spi/spidev.c
-@@ -704,6 +704,7 @@ static const struct file_operations spidev_fops = {
- static struct class *spidev_class;
- 
- static const struct spi_device_id spidev_spi_ids[] = {
+@@ -712,6 +712,7 @@ static const struct spi_device_id spidev_spi_ids[] = {
+ 	{ .name = "bk4" },
+ 	{ .name = "dhcom-board" },
+ 	{ .name = "m53cpld" },
 +	{ .name = "spi-dev" },
- 	{ .name = "dh2228fv" },
- 	{ .name = "ltc2488" },
- 	{ .name = "sx1301" },
-@@ -728,10 +729,12 @@ static int spidev_of_check(struct device *dev)
+ 	{ .name = "spi-petra" },
+ 	{ .name = "spi-authenta" },
+ 	{ .name = "em3581" },
+@@ -730,10 +731,12 @@ static int spidev_of_check(struct device *dev)
  		return 0;
  
  	dev_err(dev, "spidev listed directly in DT is not supported\n");
@@ -31,7 +31,7 @@ index d13dc15cc191..456eca57ee4f 100644
 +	{ .compatible = "armbian,spi-dev", .data = &spidev_of_check },
  	{ .compatible = "cisco,spi-petra", .data = &spidev_of_check },
  	{ .compatible = "dh,dhcom-board", .data = &spidev_of_check },
- 	{ .compatible = "lineartechnology,ltc2488", .data = &spidev_of_check },
+ 	{ .compatible = "elgin,jg10309-01", .data = &spidev_of_check },
 -- 
 Armbian
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/net-usb-r8152-add-LED-configuration-from-OF.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/net-usb-r8152-add-LED-configuration-from-OF.patch
@@ -1,4 +1,4 @@
-From 77997cebd91e706546a64e9a3a7856d9dce209d9 Mon Sep 17 00:00:00 2001
+From 76405c554289dccc73807794323ee5a7918c6d6d Mon Sep 17 00:00:00 2001
 From: David Bauer <mail@david-bauer.net>
 Date: Sun, 26 Jul 2020 02:38:31 +0200
 Subject: net: usb: r8152: add LED configuration from OF
@@ -13,7 +13,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  1 file changed, 23 insertions(+)
 
 diff --git a/drivers/net/usb/r8152.c b/drivers/net/usb/r8152.c
-index 127b34dcc5b3..8099556fef85 100644
+index ce19ebd180f1..3a9ab550257f 100644
 --- a/drivers/net/usb/r8152.c
 +++ b/drivers/net/usb/r8152.c
 @@ -11,6 +11,7 @@
@@ -24,7 +24,7 @@ index 127b34dcc5b3..8099556fef85 100644
  #include <linux/crc32.h>
  #include <linux/if_vlan.h>
  #include <linux/uaccess.h>
-@@ -7002,6 +7003,22 @@ static void rtl_tally_reset(struct r8152 *tp)
+@@ -7011,6 +7012,22 @@ static void rtl_tally_reset(struct r8152 *tp)
  	ocp_write_word(tp, MCU_TYPE_PLA, PLA_RSTTALLY, ocp_data);
  }
  
@@ -47,7 +47,7 @@ index 127b34dcc5b3..8099556fef85 100644
  static void r8152b_init(struct r8152 *tp)
  {
  	u32 ocp_data;
-@@ -7043,6 +7060,8 @@ static void r8152b_init(struct r8152 *tp)
+@@ -7052,6 +7069,8 @@ static void r8152b_init(struct r8152 *tp)
  	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_USB_CTRL);
  	ocp_data &= ~(RX_AGG_DISABLE | RX_ZERO_EN);
  	ocp_write_word(tp, MCU_TYPE_USB, USB_USB_CTRL, ocp_data);
@@ -56,7 +56,7 @@ index 127b34dcc5b3..8099556fef85 100644
  }
  
  static void r8153_init(struct r8152 *tp)
-@@ -7183,6 +7202,8 @@ static void r8153_init(struct r8152 *tp)
+@@ -7192,6 +7211,8 @@ static void r8153_init(struct r8152 *tp)
  		tp->coalesce = COALESCE_SLOW;
  		break;
  	}
@@ -65,7 +65,7 @@ index 127b34dcc5b3..8099556fef85 100644
  }
  
  static void r8153b_init(struct r8152 *tp)
-@@ -7265,6 +7286,8 @@ static void r8153b_init(struct r8152 *tp)
+@@ -7274,6 +7295,8 @@ static void r8153b_init(struct r8152 *tp)
  	rtl_tally_reset(tp);
  
  	tp->coalesce = 15000;	/* 15 us */

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/orangepi-zero2w-add-dtb.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/orangepi-zero2w-add-dtb.patch
@@ -1,4 +1,4 @@
-From aeccb62b0f4c6891a09790f5f4546dff8cc60815 Mon Sep 17 00:00:00 2001
+From 07d859087c42f1c0044d4ba32e1ed95b46d6b64e Mon Sep 17 00:00:00 2001
 From: chraac <chraac@gmail.com>
 Date: Fri, 15 Mar 2024 12:30:26 +0800
 Subject: orangepi-zero2w add dtb
@@ -11,10 +11,10 @@ Subject: orangepi-zero2w add dtb
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 8b504ee408e7..a957365edc1a 100644
+index 468d3f235490..812685d6740f 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -56,5 +56,6 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
+@@ -57,5 +57,6 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-bananapi-m4-zero.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/scripts-add-overlay-compilation-support.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/scripts-add-overlay-compilation-support.patch
@@ -1,16 +1,16 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 9f163479b32bf20cdfb1bd8a25ad1984471f5182 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Tue, 1 Feb 2022 21:04:08 +0300
 Subject: scripts: add overlay compilation support
 
 ---
  .gitignore               |  1 +
- scripts/Makefile.dtbinst | 16 ++++++++--
- scripts/Makefile.lib     |  9 ++++++
+ scripts/Makefile.dtbinst | 16 ++++++++++++++--
+ scripts/Makefile.lib     |  9 +++++++++
  3 files changed, 24 insertions(+), 2 deletions(-)
 
 diff --git a/.gitignore b/.gitignore
-index 0bbae167bf93..d790eee1273d 100644
+index d1a8ab3f98aa..cf2c8311aa56 100644
 --- a/.gitignore
 +++ b/.gitignore
 @@ -42,6 +42,7 @@
@@ -22,7 +22,7 @@ index 0bbae167bf93..d790eee1273d 100644
  *.so.dbg
  *.su
 diff --git a/scripts/Makefile.dtbinst b/scripts/Makefile.dtbinst
-index 4405d5b67578..6e3f7fa513d5 100644
+index fa3ad33a19df..8a53d0e1c2f7 100644
 --- a/scripts/Makefile.dtbinst
 +++ b/scripts/Makefile.dtbinst
 @@ -19,8 +19,10 @@ include $(kbuild-file)
@@ -58,7 +58,7 @@ index 4405d5b67578..6e3f7fa513d5 100644
  
  .PHONY: $(PHONY)
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index 68d0134bdbf9..8fe35137004f 100644
+index e702552fb131..f3ace21906ae 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
 @@ -88,6 +88,9 @@ base-dtb-y := $(foreach m, $(multi-dtb-y), $(firstword $(call suffix-search, $m,
@@ -71,7 +71,7 @@ index 68d0134bdbf9..8fe35137004f 100644
  # Add subdir path
  
  ifneq ($(obj),.)
-@@ -421,6 +424,12 @@ $(obj)/%.dtb: $(src)/%.dts $(DTC) $(DT_TMP_SCHEMA) FORCE
+@@ -425,6 +428,12 @@ $(obj)/%.dtb: $(src)/%.dts $(DTC) $(DT_TMP_SCHEMA) FORCE
  $(obj)/%.dtbo: $(src)/%.dtso $(DTC) FORCE
  	$(call if_changed_dep,dtc)
  
@@ -85,5 +85,5 @@ index 68d0134bdbf9..8fe35137004f 100644
  
  # Bzip2
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/power-supply-axp20x-battery-Add-support-for-POWER_SUPPLY_PROP_E.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/power-supply-axp20x-battery-Add-support-for-POWER_SUPPLY_PROP_E.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 553f3addd1b814302432963da50a6d49acacba9e Mon Sep 17 00:00:00 2001
 From: Ondrej Jirman <megi@xff.cz>
 Date: Thu, 10 Nov 2022 20:05:58 +0100
 Subject: power: supply: axp20x-battery: Add support for
@@ -8,11 +8,11 @@ Report total battery capacity.
 
 Signed-off-by: Ondrej Jirman <megi@xff.cz>
 ---
- drivers/power/supply/axp20x_battery.c | 20 ++++++++--
+ drivers/power/supply/axp20x_battery.c | 20 ++++++++++++++++----
  1 file changed, 16 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/power/supply/axp20x_battery.c b/drivers/power/supply/axp20x_battery.c
-index 2c77a2b1da76..cc79c75a7ba5 100644
+index ff88678e61ad..f60e75465431 100644
 --- a/drivers/power/supply/axp20x_battery.c
 +++ b/drivers/power/supply/axp20x_battery.c
 @@ -85,6 +85,7 @@ struct axp20x_batt_ps {
@@ -40,16 +40,16 @@ index 2c77a2b1da76..cc79c75a7ba5 100644
  	default:
  		return -EINVAL;
  	}
-@@ -563,6 +574,8 @@ static enum power_supply_property axp20x_battery_props[] = {
- 	POWER_SUPPLY_PROP_VOLTAGE_MAX_DESIGN,
- 	POWER_SUPPLY_PROP_VOLTAGE_MIN_DESIGN,
+@@ -564,6 +575,8 @@ static enum power_supply_property axp20x_battery_props[] = {
+ 	POWER_SUPPLY_PROP_VOLTAGE_MAX,
+ 	POWER_SUPPLY_PROP_VOLTAGE_MIN,
  	POWER_SUPPLY_PROP_CAPACITY,
 +	POWER_SUPPLY_PROP_ENERGY_FULL_DESIGN,
 +	POWER_SUPPLY_PROP_ENERGY_EMPTY_DESIGN,
  };
  
  static int axp20x_battery_prop_writeable(struct power_supply *psy,
-@@ -703,7 +716,6 @@ static int axp20x_power_probe(struct platform_device *pdev)
+@@ -704,7 +717,6 @@ static int axp20x_power_probe(struct platform_device *pdev)
  	struct axp20x_dev *axp20x = dev_get_drvdata(pdev->dev.parent);
  	struct axp20x_batt_ps *axp20x_batt;
  	struct power_supply_config psy_cfg = {};
@@ -57,7 +57,7 @@ index 2c77a2b1da76..cc79c75a7ba5 100644
  	struct device *dev = &pdev->dev;
  	const struct axp_irq_data *irq_data;
  	int irq, ret;
-@@ -760,9 +772,9 @@ static int axp20x_power_probe(struct platform_device *pdev)
+@@ -761,9 +773,9 @@ static int axp20x_power_probe(struct platform_device *pdev)
  
  	axp20x_batt->health = POWER_SUPPLY_HEALTH_GOOD;
  
@@ -71,5 +71,5 @@ index 2c77a2b1da76..cc79c75a7ba5 100644
  		if (vmin > 0 && axp20x_set_voltage_min_design(axp20x_batt,
  							      vmin))
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/power-supply-axp20x-battery-Enable-poweron-by-RTC-alarm.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/power-supply-axp20x-battery-Enable-poweron-by-RTC-alarm.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 4f3724e31da5ba29408cdbd893717c145f40af34 Mon Sep 17 00:00:00 2001
 From: Ondrej Jirman <megi@xff.cz>
 Date: Sat, 27 Aug 2022 20:50:43 +0200
 Subject: power: supply: axp20x-battery: Enable poweron by RTC alarm
@@ -15,10 +15,10 @@ Signed-off-by: Ondrej Jirman <megi@xff.cz>
  1 file changed, 5 insertions(+)
 
 diff --git a/drivers/power/supply/axp20x_battery.c b/drivers/power/supply/axp20x_battery.c
-index 4e2d659651e7..2c77a2b1da76 100644
+index 0b7002d6a35d..ff88678e61ad 100644
 --- a/drivers/power/supply/axp20x_battery.c
 +++ b/drivers/power/supply/axp20x_battery.c
-@@ -855,6 +855,11 @@ static int axp20x_power_probe(struct platform_device *pdev)
+@@ -856,6 +856,11 @@ static int axp20x_power_probe(struct platform_device *pdev)
  		ret = regmap_update_bits(axp20x_batt->regmap, 0x84, 0x37, 0x31);
  		if (ret)
  			goto warn_bat;
@@ -31,5 +31,5 @@ index 4e2d659651e7..2c77a2b1da76 100644
  
  	return 0;
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/power-supply-axp20x-battery-Support-POWER_SUPPLY_PROP_CHARGE_BE.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/power-supply-axp20x-battery-Support-POWER_SUPPLY_PROP_CHARGE_BE.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 23bf1ca9d11a1c0160eb3087ebc48d6ba77fe54c Mon Sep 17 00:00:00 2001
 From: Ondrej Jirman <megi@xff.cz>
 Date: Sat, 2 Apr 2022 02:50:14 +0200
 Subject: power: supply: axp20x-battery: Support
@@ -8,11 +8,11 @@ Support force disabling the charger in a more standardized way.
 
 Signed-off-by: Ondrej Jirman <megi@xff.cz>
 ---
- drivers/power/supply/axp20x_battery.c | 30 ++++++++++
- 1 file changed, 30 insertions(+)
+ drivers/power/supply/axp20x_battery.c | 31 +++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
 
 diff --git a/drivers/power/supply/axp20x_battery.c b/drivers/power/supply/axp20x_battery.c
-index b7b3e6b945dd..4e2d659651e7 100644
+index 3c705827af50..0b7002d6a35d 100644
 --- a/drivers/power/supply/axp20x_battery.c
 +++ b/drivers/power/supply/axp20x_battery.c
 @@ -227,6 +227,19 @@ static int axp20x_battery_get_prop(struct power_supply *psy,
@@ -35,10 +35,11 @@ index b7b3e6b945dd..4e2d659651e7 100644
  	case POWER_SUPPLY_PROP_STATUS:
  		ret = regmap_read(axp20x_batt->regmap, AXP20X_PWR_OP_MODE,
  				  &reg);
-@@ -504,6 +517,21 @@ static int axp20x_battery_set_prop(struct power_supply *psy,
+@@ -504,6 +517,22 @@ static int axp20x_battery_set_prop(struct power_supply *psy,
  	case POWER_SUPPLY_PROP_CONSTANT_CHARGE_CURRENT_MAX:
  		return axp20x_set_max_constant_charge_current(axp20x_batt,
  							      val->intval);
++
 +	case POWER_SUPPLY_PROP_CHARGE_BEHAVIOUR:
 +		switch (val->intval) {
 +		case POWER_SUPPLY_CHARGE_BEHAVIOUR_AUTO:
@@ -57,7 +58,7 @@ index b7b3e6b945dd..4e2d659651e7 100644
  	case POWER_SUPPLY_PROP_STATUS:
  		switch (val->intval) {
  		case POWER_SUPPLY_STATUS_CHARGING:
-@@ -525,6 +553,7 @@ static enum power_supply_property axp20x_battery_props[] = {
+@@ -525,6 +554,7 @@ static enum power_supply_property axp20x_battery_props[] = {
  	POWER_SUPPLY_PROP_PRESENT,
  	POWER_SUPPLY_PROP_ONLINE,
  	POWER_SUPPLY_PROP_STATUS,
@@ -65,14 +66,14 @@ index b7b3e6b945dd..4e2d659651e7 100644
  	POWER_SUPPLY_PROP_VOLTAGE_NOW,
  	POWER_SUPPLY_PROP_CURRENT_NOW,
  	POWER_SUPPLY_PROP_CONSTANT_CHARGE_CURRENT,
-@@ -540,6 +569,7 @@ static int axp20x_battery_prop_writeable(struct power_supply *psy,
+@@ -540,6 +570,7 @@ static int axp20x_battery_prop_writeable(struct power_supply *psy,
  					 enum power_supply_property psp)
  {
  	return psp == POWER_SUPPLY_PROP_STATUS ||
 +	       psp == POWER_SUPPLY_PROP_CHARGE_BEHAVIOUR ||
- 	       psp == POWER_SUPPLY_PROP_VOLTAGE_MIN_DESIGN ||
- 	       psp == POWER_SUPPLY_PROP_VOLTAGE_MAX_DESIGN ||
+ 	       psp == POWER_SUPPLY_PROP_VOLTAGE_MIN ||
+ 	       psp == POWER_SUPPLY_PROP_VOLTAGE_MAX ||
  	       psp == POWER_SUPPLY_PROP_CONSTANT_CHARGE_CURRENT ||
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/power-supply-axp20x_battery-Add-support-for-reporting-OCV.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/power-supply-axp20x_battery-Add-support-for-reporting-OCV.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From dc23bd741380f26533b0e21bcaf6081a2d2b4b4d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ond=C5=99ej=20Jirman?= <megi@xff.cz>
 Date: Fri, 28 Feb 2020 19:16:46 +0100
 Subject: power: supply: axp20x_battery: Add support for reporting OCV
@@ -7,11 +7,11 @@ Export OCV reported by PMIC via sysfs.
 
 Signed-off-by: Ondrej Jirman <megi@xff.cz>
 ---
- drivers/power/supply/axp20x_battery.c | 23 ++++++++++
+ drivers/power/supply/axp20x_battery.c | 23 +++++++++++++++++++++++
  1 file changed, 23 insertions(+)
 
 diff --git a/drivers/power/supply/axp20x_battery.c b/drivers/power/supply/axp20x_battery.c
-index f24520719a74..bad981c349ff 100644
+index 30ad3409e865..408f23f0b10c 100644
 --- a/drivers/power/supply/axp20x_battery.c
 +++ b/drivers/power/supply/axp20x_battery.c
 @@ -180,6 +180,25 @@ static int axp20x_get_constant_charge_current(struct axp20x_batt_ps *axp,
@@ -55,9 +55,9 @@ index f24520719a74..bad981c349ff 100644
  	POWER_SUPPLY_PROP_CONSTANT_CHARGE_CURRENT_MAX,
  	POWER_SUPPLY_PROP_HEALTH,
 +	POWER_SUPPLY_PROP_VOLTAGE_OCV,
- 	POWER_SUPPLY_PROP_VOLTAGE_MAX_DESIGN,
- 	POWER_SUPPLY_PROP_VOLTAGE_MIN_DESIGN,
+ 	POWER_SUPPLY_PROP_VOLTAGE_MAX,
+ 	POWER_SUPPLY_PROP_VOLTAGE_MIN,
  	POWER_SUPPLY_PROP_CAPACITY,
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/usb-quirks-Add-USB_QUIRK_RESET-for-Quectel-EG25G-Modem.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/usb-quirks-Add-USB_QUIRK_RESET-for-Quectel-EG25G-Modem.patch
@@ -1,4 +1,4 @@
-From d73ef934b16a409b6e9ea83f270981f4c20526fb Mon Sep 17 00:00:00 2001
+From 3cb45fa702ff5424d1ee744759a814ef844eeb97 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ond=C5=99ej=20Jirman?= <megi@xff.cz>
 Date: Thu, 18 Feb 2021 07:48:07 +0100
 Subject: usb: quirks: Add USB_QUIRK_RESET for Quectel EG25G Modem
@@ -11,10 +11,10 @@ Signed-off-by: Ondrej Jirman <megi@xff.cz>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
-index b4783574b8e6..ecfd4b6ab602 100644
+index 13171454f959..0494c8bb42a7 100644
 --- a/drivers/usb/core/quirks.c
 +++ b/drivers/usb/core/quirks.c
-@@ -549,6 +549,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+@@ -552,6 +552,9 @@ static const struct usb_device_id usb_quirk_list[] = {
  	/* INTEL VALUE SSD */
  	{ USB_DEVICE(0x8086, 0xf1a5), .driver_info = USB_QUIRK_RESET_RESUME },
  

--- a/patch/kernel/archive/sunxi-6.6/series.armbian
+++ b/patch/kernel/archive/sunxi-6.6/series.armbian
@@ -122,7 +122,7 @@
 	patches.armbian/Move-sun50i-h6-pwm-settings-to-its-own-overlay.patch
 	patches.armbian/Compile-the-pwm-overlay.patch
 	patches.armbian/cb1-overlay.patch
-	patches.armbian/cb1-overlay-light-fix.patch
+	patches.armbian/ARM64-DTS-sun50i-h616-overlays-fix-sun50i-h616-light-overlay.patch
 	patches.armbian/arm-dts-sunxi-h3-h5.dtsi-add-i2s0-i2s1-pins.patch
 	patches.armbian/arm-dts-sun5i-a13-olinuxino-micro-add-panel-lcd-olinuxino-4.3.patch
 	patches.armbian/arm-dts-sun5i-a13-olinuxino-Add-panel-lcd-olinuxino-4.3-needed-.patch
@@ -190,7 +190,8 @@
 	patches.armbian/add-dtb-overlay-for-zero2w.patch
 	patches.armbian/Add-BPI-M4-ZERO-sdio-wifi-bt-overlay.patch
 	patches.armbian/adding-dummy-regulators-in-pinctr-arch-arm-boot-dts-allwinner-s.patch
-	patches.armbian/Sound-for-H616-H618-Allwinner-SOCs-arch-arm64-boot-dts-allwinne.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-hdmi.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-emac1.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-ir-receiver.patch
+	patches.armbian/Sound-for-H616-H618-Allwinner-SOCs.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-HDMI.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-EMAC1.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-IR-receiver.patch
+	patches.armbian/arm64-dts-sun50i-h618-cherryba-m1.patch

--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -263,18 +263,18 @@
 	patches.armbian/drv-gpu-drm-sun4i-Add-HDMI-audio-sun4i-hdmi-encoder.patch
 	patches.armbian/drv-net-stmmac-dwmac-sun8i-second-EMAC-clock-register.patch
 	patches.armbian/drv-phy-sun4i-usb-Allow-reset-line-to-be-shared.patch
--	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-rename-A33-specified-registers-to-c.patch
--	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-sampling-start-end-code-readout-reg.patch
--	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-support-clocks-and-reset.patch
--	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-multible-sensors-support.patch
--	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-support-nvmem-calibration-data.patch
--	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-add-interrupt-support.patch
--	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-add-H3-thermal-sensor.patch
--	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-add-A83T-thermal-sensor.patch
--	patches.armbian/drv-iio-adc-Kconfig-enable-A80-A64-H5-for-THS.patch
--	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-add-A80-thermal-sensor.patch
--	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-add-A64-thermal-sensor.patch
--	patches.armbian/drv-iio-sun4i-gpadc-iio-don-t-force-poweroff.patch
+	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-rename-A33-specified-registers-to-c.patch
+	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-sampling-start-end-code-readout-reg.patch
+	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-support-clocks-and-reset.patch
+	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-multible-sensors-support.patch
+	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-support-nvmem-calibration-data.patch
+	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-add-interrupt-support.patch
+	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-add-H3-thermal-sensor.patch
+	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-add-A83T-thermal-sensor.patch
+	patches.armbian/drv-iio-adc-Kconfig-enable-A80-A64-H5-for-THS.patch
+	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-add-A80-thermal-sensor.patch
+	patches.armbian/drv-iio-adc-sun4i-gpadc-iio-add-A64-thermal-sensor.patch
+	patches.armbian/drv-iio-sun4i-gpadc-iio-don-t-force-poweroff.patch
 	patches.armbian/drv-staging-media-sunxi-cedrus-add-H616-variant.patch
 	patches.armbian/drv-soc-sunxi-sram-Add-SRAM-C1-H616-handling.patch
 	patches.armbian/drv-media-dvb-frontends-si2168-fix-cmd-timeout.patch
@@ -374,7 +374,7 @@
 	patches.armbian/Move-sun50i-h6-pwm-settings-to-its-own-overlay.patch
 	patches.armbian/Compile-the-pwm-overlay.patch
 	patches.armbian/cb1-overlay.patch
-	patches.armbian/cb1-overlay-light-fix.patch
+	patches.armbian/ARM64-DTS-sun50i-h616-overlays-fix-sun50i-h616-light-overlay.patch
 	patches.armbian/arm-dts-sunxi-h3-h5.dtsi-add-i2s0-i2s1-pins.patch
 	patches.armbian/arm-dts-sun5i-a13-olinuxino-micro-add-panel-lcd-olinuxino-4.3.patch
 	patches.armbian/arm-dts-sun5i-a13-olinuxino-Add-panel-lcd-olinuxino-4.3-needed-.patch
@@ -442,8 +442,8 @@
 	patches.armbian/add-dtb-overlay-for-zero2w.patch
 	patches.armbian/Add-BPI-M4-ZERO-sdio-wifi-bt-overlay.patch
 	patches.armbian/adding-dummy-regulators-in-pinctr-arch-arm-boot-dts-allwinner-s.patch
-	patches.armbian/Sound-for-H616-H618-Allwinner-SOCs-arch-arm64-boot-dts-allwinne.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-hdmi.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-emac1.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-ir-receiver.patch
-	patches.armbian/cherryba-m1-add-dtb.patch
+	patches.armbian/Sound-for-H616-H618-Allwinner-SOCs.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-HDMI.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-EMAC1.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-IR-receiver.patch
+	patches.armbian/arm64-dts-sun50i-h618-cherryba-m1.patch


### PR DESCRIPTION
# Description

Patches that cannot be applied break the kernel. Fix it.

sunxi-6.11: Re-export armbian patches
sunxi-6.6: megous patches: rebase to v6.6.54, fix and re-export
sunxi-6.6: armbian patches: rebase to v6.6.54, fix and re-export
sunxi-6.6: switch to v6.6.54

# How Has This Been Tested?

- [x] Test build arm64

The kernel with the applied patches is here: [sunxi-6.6-rebase](https://github.com/The-going/linux-sf/tree/sunxi-6.6-rebase)