### PR TITLE
rockchip64/uboot: increase rng-seed size to make it sufficient for modern linux

### DIFF
--- a/patch/u-boot/v2024.07/rockchip-fix-rng-seed.patch
+++ b/patch/u-boot/v2024.07/rockchip-fix-rng-seed.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Shumsky <alexthreed@gmail.com>
+Date: Fri, 11 Oct 2024 17:54:53 +0000
+Subject: Make rockchip rng-seed sufficient size to initialize modern linux
+
+Signed-off-by: Alex Shumsky <alexthreed@gmail.com>
+---
+ arch/arm/mach-rockchip/board.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/mach-rockchip/board.c b/arch/arm/mach-rockchip/board.c
+index cd226844b6..e84fc0c7fa 100644
+--- a/arch/arm/mach-rockchip/board.c
++++ b/arch/arm/mach-rockchip/board.c
+@@ -478,11 +478,11 @@ __weak int misc_init_r(void)
+ 
+ /* Use hardware rng to seed Linux random. */
+ __weak int board_rng_seed(struct abuf *buf)
+ {
+ 	struct udevice *dev;
+-	size_t len = 0x8;
++	size_t len = 32;
+ 	u64 *data;
+ 
+ 	data = malloc(len);
+ 	if (!data) {
+ 		printf("Out of memory\n");
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

Modern linux [requires](https://github.com/torvalds/linux/blob/7234e2ea0edd00bfb6bb2159e55878c19885ce68/drivers/char/random.c#L632
) 32 byte seed to initialise random pool, but u-boot currently provides only 8 bytes. Increase rng-seed size to make linux happy and initialise instantly.
This significantly speeds-up encrypted overlayroot mount (by 5 sec or so), and I expect cryptroot would benefit either.  

Without patch:
```
# dmesg | grep crng
[   12.089286] random: crng init done
```
With patch:
```
# dmesg | grep crng
[    0.000000] random: crng init done
```
# How Has This Been Tested?

- [x] Ruild and run on rk3318-box

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code