### PR TITLE
[rockchip] Provide dtb overlay to enable pwm node for rk3288

### DIFF
--- a/patch/kernel/archive/rockchip-6.11/overlay/Makefile
+++ b/patch/kernel/archive/rockchip-6.11/overlay/Makefile
@@ -3,6 +3,9 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-ds1307.dtbo    \
 	rockchip-i2c1.dtbo      \
 	rockchip-i2c4.dtbo      \
+	rockchip-pwm1.dtbo	\
+	rockchip-pwm2.dtbo	\
+	rockchip-pwm3.dtbo	\
 	rockchip-spi0.dtbo      \
 	rockchip-spi2.dtbo      \
 	rockchip-spidev0.dtbo   \

--- a/patch/kernel/archive/rockchip-6.11/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip-6.11/overlay/README.rockchip-overlays
@@ -11,6 +11,9 @@ rockchip (Rockchip)
 - ds1307
 - i2c1
 - i2c4
+- pwm1
+- pwm2
+- pwm3
 - spi0
 - spi2
 - spidev0
@@ -34,6 +37,10 @@ Activate i2c1
 ### i2c4
 
 Activate i2c4
+
+### pwm*
+
+Activate pwm1, pwm2 and pwm3
 
 ### spi0
 

--- a/patch/kernel/archive/rockchip-6.11/overlay/rockchip-pwm1.dtso
+++ b/patch/kernel/archive/rockchip-6.11/overlay/rockchip-pwm1.dtso
@@ -1,0 +1,16 @@
+/* 	Definitions for pwm1
+*/
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "rockchip,rk3288";
+
+	fragment@0 {
+		target = <&pwm1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-6.11/overlay/rockchip-pwm2.dtso
+++ b/patch/kernel/archive/rockchip-6.11/overlay/rockchip-pwm2.dtso
@@ -1,0 +1,16 @@
+/* 	Definitions for pwm2
+*/
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "rockchip,rk3288";
+
+	fragment@0 {
+		target = <&pwm2>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-6.11/overlay/rockchip-pwm3.dtso
+++ b/patch/kernel/archive/rockchip-6.11/overlay/rockchip-pwm3.dtso
@@ -1,0 +1,16 @@
+/* 	Definitions for pwm3
+*/
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "rockchip,rk3288";
+
+	fragment@0 {
+		target = <&pwm3>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-6.6/overlay/Makefile
+++ b/patch/kernel/archive/rockchip-6.6/overlay/Makefile
@@ -3,6 +3,9 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-ds1307.dtbo    \
 	rockchip-i2c1.dtbo      \
 	rockchip-i2c4.dtbo      \
+	rockchip-pwm1.dtbo      \
+	rockchip-pwm2.dtbo      \
+	rockchip-pwm3.dtbo      \
 	rockchip-spi0.dtbo      \
 	rockchip-spi2.dtbo      \
 	rockchip-spidev0.dtbo   \

--- a/patch/kernel/archive/rockchip-6.6/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip-6.6/overlay/README.rockchip-overlays
@@ -11,6 +11,9 @@ rockchip (Rockchip)
 - ds1307
 - i2c1
 - i2c4
+- pwm1
+- pwm2
+- pwm3
 - spi0
 - spi2
 - spidev0
@@ -34,6 +37,10 @@ Activate i2c1
 ### i2c4
 
 Activate i2c4
+
+### pwm*
+
+Activate pwm1, pwm2 and pwm3
 
 ### spi0
 

--- a/patch/kernel/archive/rockchip-6.6/overlay/rockchip-pwm1.dts
+++ b/patch/kernel/archive/rockchip-6.6/overlay/rockchip-pwm1.dts
@@ -1,0 +1,16 @@
+/* 	Definitions for pwm1
+*/
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "rockchip,rk3288";
+
+	fragment@0 {
+		target = <&pwm1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-6.6/overlay/rockchip-pwm2.dts
+++ b/patch/kernel/archive/rockchip-6.6/overlay/rockchip-pwm2.dts
@@ -1,0 +1,16 @@
+/* 	Definitions for pwm2
+*/
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "rockchip,rk3288";
+
+	fragment@0 {
+		target = <&pwm2>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-6.6/overlay/rockchip-pwm3.dts
+++ b/patch/kernel/archive/rockchip-6.6/overlay/rockchip-pwm3.dts
@@ -1,0 +1,16 @@
+/* 	Definitions for pwm3
+*/
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "rockchip,rk3288";
+
+	fragment@0 {
+		target = <&pwm3>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
# Description

As per user request (https://forum.armbian.com/topic/45963-tinkerboard-s-r20-how-to-access-pwm-on-gpio-32-33/#comment-203949), pwm1, pwm2 and pwm3 nodes can now be enabled via device tree overlays. Both current 6.6 and edge 6.11 are involved.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2509]

# How Has This Been Tested?

- [x] Compiled and packaged current kernel 6.6
- [x] Compiled and packaged edge kernel 6.11

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


[AR-2509]: https://armbian.atlassian.net/browse/AR-2509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ