### PR TITLE
board: NanoPi R6C and R6S: Bump U-Boot from 2024.07 to 2024.10

### DIFF
--- a/config/boards/nanopi-r6c.csc
+++ b/config/boards/nanopi-r6c.csc
@@ -2,7 +2,7 @@
 BOARD_NAME="NanoPi R6C"
 BOARDFAMILY="rockchip-rk3588"
 BOARD_MAINTAINER="ColorfulRhino"
-BOOTCONFIG="nanopi-r6c-rk3588s_defconfig" # vendor name, not standard, see hook below, set BOOT_SOC below to compensate
+BOOTCONFIG="nanopi-r6c-rk3588s_defconfig" # Mainline defconfig, enables booting from NVMe
 BOOT_SOC="rk3588"
 KERNEL_TARGET="edge,current,vendor"
 FULL_DESKTOP="yes"
@@ -34,11 +34,10 @@ function post_family_tweaks__nanopi_r6c_naming_udev_network_interfaces() {
 function post_family_config__nanopi_r6c_use_mainline_uboot() {
 	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"
 
-	declare -g BOOTCONFIG="generic-rk3588_defconfig"             # Use generic defconfig which should boot all RK3588 boards
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline U-Boot
-	declare -g BOOTBRANCH="tag:v2024.07"
-	declare -g BOOTPATCHDIR="v2024.07/board_${BOARD}"
+	declare -g BOOTBRANCH="tag:v2024.10"
+	declare -g BOOTPATCHDIR="v2024.10"
 	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
 
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"

--- a/config/boards/nanopi-r6s.conf
+++ b/config/boards/nanopi-r6s.conf
@@ -2,7 +2,7 @@
 BOARD_NAME="NanoPi R6S"
 BOARDFAMILY="rockchip-rk3588"
 BOARD_MAINTAINER="efectn"
-BOOTCONFIG="nanopi-r6s-rk3588s_defconfig" # vendor name, not standard, see hook below, set BOOT_SOC below to compensate
+BOOTCONFIG="nanopi-r6s-rk3588s_defconfig" # Mainline defconfig
 BOOT_SOC="rk3588"
 KERNEL_TARGET="edge,current,vendor"
 KERNEL_TEST_TARGET="vendor,current"
@@ -38,11 +38,10 @@ function post_family_tweaks__nanopir6s_naming_udev_network_interfaces() {
 function post_family_config__nanopi_r6s_use_mainline_uboot() {
 	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"
 
-	declare -g BOOTCONFIG="generic-rk3588_defconfig"             # Use generic defconfig which should boot all RK3588 boards
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline U-Boot
-	declare -g BOOTBRANCH="tag:v2024.07"
-	declare -g BOOTPATCHDIR="v2024.07"
+	declare -g BOOTBRANCH="tag:v2024.10"
+	declare -g BOOTPATCHDIR="v2024.10"
 	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
 
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"

--- a/patch/u-boot/v2024.10/0000.patching_config.yaml
+++ b/patch/u-boot/v2024.10/0000.patching_config.yaml
@@ -1,0 +1,18 @@
+config: # This is file 'patch/u-boot/v2024.10/0000.patching_config.yaml'
+
+  # PATCH NUMBERING INFO
+  #
+  # Patches should be ordered in such a way that general patches are applied first, then specific SoC-related patches.
+  #
+  # Patch numbers in this folder are sorted by category:
+  #
+  # 0*** for general patches
+  # 1*** for SoC specific patches, e.g.:
+  # 11** for Rockchip
+  # 12** for bcm2711
+
+
+  # configuration for when applying patches to git / auto-rewriting patches (development cycle helpers)
+  patches-to-git:
+    do-not-commit-files:
+      - "MAINTAINERS" # constant churn, drop them. sorry.

--- a/patch/u-boot/v2024.10/0010-general-dw-hdmi-disable.patch
+++ b/patch/u-boot/v2024.10/0010-general-dw-hdmi-disable.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 30 Jun 2024 17:36:02 +0200
+Subject: add dw_hdmi_disable() function to DW-HDMI driver
+
+---
+ drivers/video/dw_hdmi.c | 17 ++++++++++
+ include/dw_hdmi.h       |  1 +
+ 2 files changed, 18 insertions(+)
+
+diff --git a/drivers/video/dw_hdmi.c b/drivers/video/dw_hdmi.c
+index 111111111111..222222222222 100644
+--- a/drivers/video/dw_hdmi.c
++++ b/drivers/video/dw_hdmi.c
+@@ -1025,6 +1025,23 @@ int dw_hdmi_enable(struct dw_hdmi *hdmi, const struct display_timing *edid)
+ 	return 0;
+ }
+ 
++int dw_hdmi_disable(struct dw_hdmi *hdmi)
++{
++	uint clkdis;
++
++	/* disable pixel clock and tmds data path */
++	clkdis = 0x7f;
++	hdmi_write(hdmi, clkdis, HDMI_MC_CLKDIS);
++
++	/* disable phy */
++	hdmi_phy_sel_interface_control(hdmi, 0);
++	hdmi_phy_enable_tmds(hdmi, 0);
++	hdmi_phy_enable_power(hdmi, 0);
++
++	return 0;
++
++}
++
+ static const struct dw_hdmi_phy_ops dw_hdmi_synopsys_phy_ops = {
+ 	.phy_set = dw_hdmi_phy_cfg,
+ };
+diff --git a/include/dw_hdmi.h b/include/dw_hdmi.h
+index 111111111111..222222222222 100644
+--- a/include/dw_hdmi.h
++++ b/include/dw_hdmi.h
+@@ -561,6 +561,7 @@ int dw_hdmi_phy_wait_for_hpd(struct dw_hdmi *hdmi);
+ void dw_hdmi_phy_init(struct dw_hdmi *hdmi);
+ 
+ int dw_hdmi_enable(struct dw_hdmi *hdmi, const struct display_timing *edid);
++int dw_hdmi_disable(struct dw_hdmi *hdmi);
+ int dw_hdmi_read_edid(struct dw_hdmi *hdmi, u8 *buf, int buf_size);
+ void dw_hdmi_init(struct dw_hdmi *hdmi);
+ int dw_hdmi_detect_hpd(struct dw_hdmi *hdmi);
+-- 
+Armbian
+

--- a/patch/u-boot/v2024.10/0011-general-dwc-otg-usb-fix.patch
+++ b/patch/u-boot/v2024.10/0011-general-dwc-otg-usb-fix.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Fri, 12 Mar 2021 20:20:12 +0000
+Subject: [ARCHEOLOGY] Changes and fixes to rk322x uboot and kernel config
+
+> X-Git-Archeology: > recovered message: > - Enabled nfc on rk322x-dev and disable on rk322x-current (need further development)
+> X-Git-Archeology: > recovered message: > - Tidied up rk322x-current device tree
+> X-Git-Archeology: > recovered message: > - enabled nfc rockchip driver enabled in rk322x-dev kernel config
+> X-Git-Archeology: > recovered message: > - Enabled EHCI controller in u-boot (added patch for inno-phy, device tree and config bits), better device detection for dwc2 usb otg port
+> X-Git-Archeology: > recovered message: > - Removed SPL_FIT_GENERATOR from u-boot configuration, fixed .its file to use binman
+> X-Git-Archeology: > recovered message: > - fixed rk322x its file (now includes dtb), reverted u-boot to v2020.10 and changed dev_* into log_debug() calls
+> X-Git-Archeology: - Revision 95425c27b9d3bbb96e7936cc531638c9150538f9: https://github.com/armbian/build/commit/95425c27b9d3bbb96e7936cc531638c9150538f9
+> X-Git-Archeology:   Date: Fri, 12 Mar 2021 20:20:12 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Changes and fixes to rk322x uboot and kernel config
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5130cc32fd9b18ecf71d5d26b688859ede0ffe03: https://github.com/armbian/build/commit/5130cc32fd9b18ecf71d5d26b688859ede0ffe03
+> X-Git-Archeology:   Date: Mon, 20 Jun 2022 08:35:13 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: fix u-boot USB OTG patch name
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision d4daf41404853fc13813dc4eb9f6cad76f95945c: https://github.com/armbian/build/commit/d4daf41404853fc13813dc4eb9f6cad76f95945c
+> X-Git-Archeology:   Date: Mon, 20 Jun 2022 08:35:13 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: add sdmmc_ext node, mmc reset properties and otg usb fix to u-boot
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision efee17f217e58a93e795c165e303bfd0a2a0a32a: https://github.com/armbian/build/commit/efee17f217e58a93e795c165e303bfd0a2a0a32a
+> X-Git-Archeology:   Date: Mon, 22 Apr 2024 12:39:09 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: bump rk3318-box uboot to v2024.01
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 7876017d0b77bbfefbb3d112045b32d9b50db928: https://github.com/armbian/build/commit/7876017d0b77bbfefbb3d112045b32d9b50db928
+> X-Git-Archeology:   Date: Tue, 02 Jul 2024 23:31:50 +0000
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Bump rk322x-box and rk3318-box to u-boot v2024.07-rc5 (#6855)
+> X-Git-Archeology:
+---
+ drivers/usb/host/dwc2.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/usb/host/dwc2.c b/drivers/usb/host/dwc2.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/host/dwc2.c
++++ b/drivers/usb/host/dwc2.c
+@@ -440,6 +440,8 @@ static void dwc_otg_core_init(struct udevice *dev)
+ 
+ 	writel(usbcfg, &regs->gusbcfg);
+ 
++	mdelay(10);
++
+ 	/* Program the GAHBCFG Register. */
+ 	switch (readl(&regs->ghwcfg2) & DWC2_HWCFG2_ARCHITECTURE_MASK) {
+ 	case DWC2_HWCFG2_ARCHITECTURE_SLAVE_ONLY:
+-- 
+Armbian
+

--- a/patch/u-boot/v2024.10/1010-rockchip-fix-rng-seed.patch
+++ b/patch/u-boot/v2024.10/1010-rockchip-fix-rng-seed.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Shumsky <alexthreed@gmail.com>
+Date: Fri, 11 Oct 2024 17:54:53 +0000
+Subject: Make rockchip rng-seed sufficient size to initialize modern linux
+
+Signed-off-by: Alex Shumsky <alexthreed@gmail.com>
+---
+ arch/arm/mach-rockchip/board.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/mach-rockchip/board.c b/arch/arm/mach-rockchip/board.c
+index 111111111111..222222222222 100644
+--- a/arch/arm/mach-rockchip/board.c
++++ b/arch/arm/mach-rockchip/board.c
+@@ -480,7 +480,7 @@ __weak int misc_init_r(void)
+ __weak int board_rng_seed(struct abuf *buf)
+ {
+ 	struct udevice *dev;
+-	size_t len = 0x8;
++	size_t len = 32;
+ 	u64 *data;
+ 
+ 	data = malloc(len);
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Support for the NanoPi R6C and R6S has been added in v2024.10, so don't use the `generic-rk3588_defconfig` anymore.

Also copy relevant general patches from the 2024.07 patch folder to 2024.10.

@efectn I have bumped the R6S as well. it should work without problems, but you might want to test anyway since your R6S is a .conf board :)

# How Has This Been Tested?

- [x] `./compile.sh uboot BOARD=nanopi-r6c BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=trixie`
- [x] `./compile.sh uboot BOARD=nanopi-r6s BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=trixie`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
