### PR TITLE
Gnome desktops: add gvfs-backends package as its missing only here

### DIFF
--- a/config/desktop/bookworm/environments/gnome/config_base/packages
+++ b/config/desktop/bookworm/environments/gnome/config_base/packages
@@ -31,6 +31,7 @@ libpulsedsp
 gdm3
 lm-sensors
 nautilus
+nautilus-extension-gnome-terminal
 pavucontrol
 #printer-driver-all
 profile-sync-daemon

--- a/config/desktop/bookworm/environments/gnome/config_base/packages
+++ b/config/desktop/bookworm/environments/gnome/config_base/packages
@@ -24,6 +24,7 @@ gnome-system-monitor
 gnome-terminal
 gnome-session
 gnome-shell
+gvfs-backends
 inputattach
 libnotify-bin
 libpulsedsp

--- a/config/desktop/common/environments/gnome/config_base/packages
+++ b/config/desktop/common/environments/gnome/config_base/packages
@@ -31,6 +31,7 @@ libnotify-bin
 gdm3
 lm-sensors
 nautilus
+nautilus-extension-gnome-terminal
 pavucontrol
 printer-driver-all
 profile-sync-daemon

--- a/config/desktop/common/environments/gnome/config_base/packages
+++ b/config/desktop/common/environments/gnome/config_base/packages
@@ -25,6 +25,7 @@ gnome-packagekit
 gnome-session
 gnome-shell
 gnome-shell-extension-appindicator
+gvfs-backends
 inputattach
 libnotify-bin
 gdm3

--- a/config/desktop/jammy/environments/gnome/config_base/packages
+++ b/config/desktop/jammy/environments/gnome/config_base/packages
@@ -26,6 +26,7 @@ gnome-packagekit
 gnome-session
 gnome-shell
 gnome-shell-extension-appindicator
+gvfs-backends
 inputattach
 libasound2
 libasound2-plugins

--- a/config/desktop/jammy/environments/gnome/config_base/packages
+++ b/config/desktop/jammy/environments/gnome/config_base/packages
@@ -35,6 +35,7 @@ libpulsedsp
 gdm3
 lm-sensors
 nautilus
+nautilus-extension-gnome-terminal
 pavucontrol
 printer-driver-all
 profile-sync-daemon


### PR DESCRIPTION
# Description

Re-add missing package.

# How Has This Been Tested?

Manually install on Jammy.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules