### PR TITLE
ramlog: remove obsolete nocache; fixes #6890

### DIFF
--- a/config/optional/architectures/amd64/_config/cli/sid/main/packages
+++ b/config/optional/architectures/amd64/_config/cli/sid/main/packages
@@ -1,3 +1,2 @@
 gpiod
-nocache
 firmware-sof-signed

--- a/config/optional/architectures/arm64/_config/cli/sid/main/packages
+++ b/config/optional/architectures/arm64/_config/cli/sid/main/packages
@@ -1,3 +1,2 @@
 gpiod
 mtd-utils
-nocache

--- a/config/optional/architectures/armhf/_config/cli/noble/main/packages
+++ b/config/optional/architectures/armhf/_config/cli/noble/main/packages
@@ -1,2 +1,1 @@
 gpiod
-nocache

--- a/config/optional/architectures/armhf/_config/cli/sid/main/packages
+++ b/config/optional/architectures/armhf/_config/cli/sid/main/packages
@@ -1,3 +1,2 @@
 gpiod
 mtd-utils
-nocache

--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -23,7 +23,6 @@ LOG_OUTPUT="tee -a $LOG2RAM_LOG"
 
 isSafe () {
 	[ -d $HDD_LOG ] || (echo "ERROR: $HDD_LOG doesn't exist! Can't sync." >&2 ; exit 1)
-	NoCache=$(command -v nocache 2>/dev/null)
 }
 
 RecreateLogs (){
@@ -48,7 +47,7 @@ syncToDisk () {
 	echo -e "\n\n$(date): Syncing logs to storage\n" | $LOG_OUTPUT
 
 	if [ "$USE_RSYNC" = true ]; then
-		${NoCache} rsync -aXWv \
+		rsync -aXWv \
 			--exclude "lost+found" --exclude armbian-ramlog.log \
 			--exclude 'journal*' --one-file-system \
 			--links \
@@ -56,7 +55,7 @@ syncToDisk () {
 			$RAM_LOG/ $HDD_LOG/ 2>&1 | $LOG_OUTPUT
 	else
 		rm -f $RAM_LOG/journal # linked journal cannot copied onto itself, it will be re-created below
-		${NoCache} cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | $LOG_OUTPUT
+		cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | $LOG_OUTPUT
 	fi
 	if [ ! -L $RAM_LOG/journal ] && [ -d $RAM_LOG/journal ]; then # move persistent journal to disk
 		systemctl stop systemd-journald # journal folder can be in use
@@ -83,7 +82,7 @@ syncFromDisk () {
 	echo -e "\n\n$(date): Loading logs from storage\n" | $LOG_OUTPUT
 
 	if [ "$USE_RSYNC" = true ]; then
-		${NoCache} rsync -aXWv --delete \
+		rsync -aXWv --delete \
 			--exclude "lost+found" --exclude armbian-ramlog.log \
 			--exclude '*.gz' --exclude '*.xz' --exclude='*.[0-9]' \
 			--links \
@@ -91,7 +90,7 @@ syncFromDisk () {
 			${XTRA_RSYNC_FROM[@]+"${XTRA_RSYNC_FROM[@]}"} \
 			$HDD_LOG/ $RAM_LOG/ 2>&1 | $LOG_OUTPUT
 	else
-		${NoCache} find $HDD_LOG/* -maxdepth 1 -type f -not \( -name '*.[0-9]' -or -name '*.xz*' -or -name '*.gz' -or -name 'journal*' \) | xargs cp -ut $RAM_LOG/
+		find $HDD_LOG/* -maxdepth 1 -type f -not \( -name '*.[0-9]' -or -name '*.xz*' -or -name '*.gz' -or -name 'journal*' \) | xargs cp -ut $RAM_LOG/
 	fi
 
 	if [ ! -L $RAM_LOG/journal ] && [ -d $HDD_LOG/journal ]; then # link persistent journal if applicable


### PR DESCRIPTION
# Description

`nocache` supposed to make things faster but it actually makes things slower (at least on the current linux kernel). Remove it.
[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference:  #6890

# How Has This Been Tested?

- [x] Compile and run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
