### PR TITLE
Debian desktops: disable Pidgin as its broken. Can stay that way.

### DIFF
--- a/config/desktop/common/appgroups/chat/packages
+++ b/config/desktop/common/appgroups/chat/packages
@@ -1,4 +1,4 @@
 hexchat
-pidgin
-purple-discord
-purple-rocketchat
+#pidgin
+#purple-discord
+#purple-rocketchat


### PR DESCRIPTION
# Description

Disabling broken packages.