### PR TITLE
compilation: armbian-kernel: Change forced uncompressed modules option for kernels >=v6.12

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -23,7 +23,9 @@ function armbian_kernel_config__disable_various_options() {
 		kernel_config_set_n CONFIG_MODULE_COMPRESS_ZSTD
 		kernel_config_set_n CONFIG_MODULE_COMPRESS_GZIP
 
-		if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.0; then
+		if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.12; then
+			kernel_config_set_n CONFIG_MODULE_COMPRESS # Introduced in 6.12 (see https://github.com/torvalds/linux/commit/c7ff693fa2094ba0a9d0a20feb4ab1658eff9c33)
+		elif linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.0; then
 			kernel_config_set_y CONFIG_MODULE_COMPRESS_NONE # Introduced in 6.0
 		else
 			kernel_config_set_n CONFIG_MODULE_COMPRESS # Only available up to 5.12


### PR DESCRIPTION
# Description

When building rk3588-edge v6.12, the build script nicely outputs the following warning:

```
[🚸] Forced kernel options introduced misconfigurations or missing dependencies! [ Please re-run rewrite-kernel-config ]
[🚸] If this warning persists after re-run [ please remove dependent options using kernel-config or adapt your custom_kernel_config hooks ]
[🔨]   -MODULE_COMPRESS_NONE y
[🚸] See options above which have been changed automatically [ to solve dependencies and/or misconfigurations ]
```

The kernel option `CONFIG_MODULE_COMPRESS_NONE`  was superseded by `CONFIG_MODULE_COMPRESS` in 6.12 (source: https://github.com/torvalds/linux/commit/c7ff693fa2094ba0a9d0a20feb4ab1658eff9c33). Adapt the kernel compilation script accordingly to force the correct kernel option.

Yes, I do know that `CONFIG_MODULE_COMPRESS` was also used pre-6.0, but that was a slightly different config option, so I left the if-else as is for future reference and better visibilty.

# How Has This Been Tested?

- [x] Build warning on compiling rk3588-edge v6.12 disappears

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
