### PR TITLE
Board: NanoPC T6 & LTS - Bump uboot from 2024.07 to 2024.10 mainline

### DIFF
--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -2,7 +2,7 @@
 BOARD_NAME="NanoPC T6"
 BOARDFAMILY="rockchip-rk3588"
 BOARD_MAINTAINER="SuperKali Tonymac32"
-BOOTCONFIG="nanopc_t6_defconfig" # vendor name, not standard, see hook below, set BOOT_SOC below to compensate
+BOOTCONFIG="nanopc-t6-rk3588_defconfig" # Mainline defconfig
 BOOT_SOC="rk3588"
 KERNEL_TARGET="edge,current,vendor"
 KERNEL_TEST_TARGET="vendor,current"
@@ -32,11 +32,10 @@ function post_family_tweaks__nanopct6_naming_audios() {
 function post_family_config_branch_edge__nanopct6_use_mainline_uboot() {
 	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
 
-	declare -g BOOTCONFIG="nanopc-t6-rk3588_defconfig"                    # override the default for the board/family
 	declare -g BOOTDELAY=1                                                # Wait for UART interrupt to enter UMS/RockUSB mode etc
-	declare -g BOOTSOURCE="https://github.com/Kwiboo/u-boot-rockchip.git" # We ❤️ Kwiboo's tree
-	declare -g BOOTBRANCH="branch:rk3xxx-2024.07"                         # commit:xx as of 2024-06-04
-	declare -g BOOTPATCHDIR="v2024.04/board_${BOARD}"                     # empty; defconfig changes are done in hook below
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" 		  # We ❤️ Mainline
+	declare -g BOOTBRANCH="tag:v2024.10"
+	declare -g BOOTPATCHDIR="v2024.10/board_${BOARD}"                     # empty; defconfig changes are done in hook below
 	declare -g BOOTDIR="u-boot-${BOARD}"                                  # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already

--- a/patch/kernel/archive/rockchip-rk3588-6.11/1051-arm64-dts-rockchip-nanopct6-lts-and-fixes-v7.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/1051-arm64-dts-rockchip-nanopct6-lts-and-fixes-v7.patch
@@ -1,24 +1,84 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
-Date: Thu, 29 Aug 2024 14:26:53 +0200
-Subject: arm64: dts: rockchip: prepare NanoPC-T6 for LTS board
+From 2b5feaf4c9d31aef72d29fa39f54e295364909f4 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Mon, 21 Oct 2024 06:54:59 +0000
+Subject: [PATCH] Add support NanoPC T6 & LTS and various fixes
 
-FriendlyELEC introduced a second version of NanoPC-T6 SBC.
-
-Create common include file and make NanoPC-T6 use it. Following
-patches will add LTS version.
-
-Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
 ---
- arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts  | 932 +--------
- arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 945 ++++++++++
- 2 files changed, 947 insertions(+), 930 deletions(-)
+ .../dts/rockchip/rk3588-nanopc-t6-lts.dts     |   57 +
+ .../boot/dts/rockchip/rk3588-nanopc-t6.dts    |  908 +-------------
+ .../boot/dts/rockchip/rk3588-nanopc-t6.dtsi   | 1103 +++++++++++++++++
+ 3 files changed, 1162 insertions(+), 906 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
 
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts
+new file mode 100644
+index 000000000000..1a349fc56d0e
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts
+@@ -0,0 +1,57 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
++ * Copyright (c) 2023 Thomas McKahan
++ * Copyright (c) 2024 Linaro Ltd.
++ *
++ */
++
++/dts-v1/;
++
++#include "rk3588-nanopc-t6.dtsi"
++
++/ {
++	model = "FriendlyElec NanoPC-T6 LTS";
++	compatible = "friendlyarm,nanopc-t6-lts", "rockchip,rk3588";
++
++	/* provide power for on-board USB 2.0 hub */
++	vcc5v0_usb20_host: vcc5v0-usb20-host-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
++		pinctrl-0 = <&usb20_host_pwren>;
++		pinctrl-names = "default";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-max-microvolt = <5000000>;
++		regulator-min-microvolt = <5000000>;
++		regulator-name = "vcc5v0_usb20_host";
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&pinctrl {
++	usb {
++		usb20_host_pwren: usb20-host-pwren {
++			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&u2phy1 {
++	status = "okay";
++};
++
++&u2phy2_host {
++	phy-supply = <&vcc5v0_usb20_host>;
++	status = "okay";
++};
++
++&usbdp_phy1 {
++	status = "okay";
++};
++
++&usb_host1_xhci {
++	dr_mode = "host";
++	status = "okay";
++};
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
-index 111111111111..222222222222 100644
+index ad8e36a339dc..6a16aec7107a 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
-@@ -2,944 +2,16 @@
+@@ -2,175 +2,18 @@
  /*
   * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
   * Copyright (c) 2023 Thomas McKahan
@@ -193,19 +253,13 @@ index 111111111111..222222222222 100644
 -		vin-supply = <&vcc_3v3_s3>;
 -	};
 -
--	vdd_4g_3v3: vdd-4g-3v3-regulator {
--		compatible = "regulator-fixed";
--		enable-active-high;
--		gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
--		pinctrl-names = "default";
--		pinctrl-0 = <&pin_4g_lte_pwren>;
--		regulator-name = "vdd_4g_3v3";
--		regulator-min-microvolt = <3300000>;
--		regulator-max-microvolt = <3300000>;
--		vin-supply = <&vcc5v0_sys>;
--	};
--};
--
+ 	vdd_4g_3v3: vdd-4g-3v3-regulator {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+@@ -184,762 +27,15 @@ vdd_4g_3v3: vdd-4g-3v3-regulator {
+ 	};
+ };
+ 
 -&combphy0_ps {
 -	status = "okay";
 -};
@@ -503,7 +557,7 @@ index 111111111111..222222222222 100644
 -	status = "okay";
 -};
 -
--&pinctrl {
+ &pinctrl {
 -	gpio-leds {
 -		sys_led_pin: sys-led-pin {
 -			rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
@@ -548,10 +602,10 @@ index 111111111111..222222222222 100644
 -		};
 -	};
 -
--	usb {
--		pin_4g_lte_pwren: 4g-lte-pwren {
--			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
--		};
+ 	usb {
+ 		pin_4g_lte_pwren: 4g-lte-pwren {
+ 			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
 -
 -		typec5v_pwren: typec5v-pwren {
 -			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
@@ -560,9 +614,9 @@ index 111111111111..222222222222 100644
 -		usbc0_int: usbc0-int {
 -			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
 -		};
--	};
--};
--
+ 	};
+ };
+ 
 -&pwm1 {
 -	pinctrl-0 = <&pwm1m1_pins>;
 -	status = "okay";
@@ -933,10 +987,10 @@ index 111111111111..222222222222 100644
 -	status = "okay";
 -};
 -
--&u2phy2_host {
--	phy-supply = <&vdd_4g_3v3>;
--	status = "okay";
--};
+ &u2phy2_host {
+ 	phy-supply = <&vdd_4g_3v3>;
+ 	status = "okay";
+ };
 -
 -&u2phy3_host {
 -	status = "okay";
@@ -964,13 +1018,13 @@ index 111111111111..222222222222 100644
 -
 -&usb_host1_ohci {
 -	status = "okay";
- };
+-};
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..eb144fc894d8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-@@ -0,0 +1,945 @@
+@@ -0,0 +1,1103 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
@@ -981,6 +1035,7 @@ index 000000000000..111111111111
 +/dts-v1/;
 +
 +#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
 +#include <dt-bindings/pinctrl/rockchip.h>
 +#include <dt-bindings/usb/pd.h>
 +#include "rk3588.dtsi"
@@ -994,8 +1049,29 @@ index 000000000000..111111111111
 +		mmc1 = &sdmmc;
 +	};
 +
++	adc-keys-0 {
++		compatible = "adc-keys";
++		io-channels = <&saradc 0>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1800000>;
++		poll-interval = <100>;
++
++		button-maskrom {
++			label = "Mask Rom";
++			linux,code = <KEY_SETUP>;
++			press-threshold-microvolt = <2000>;
++		};
++	};
++
 +	chosen {
 +		stdout-path = "serial2:1500000n8";
++	};
++
++	ir-receiver {
++		compatible = "gpio-ir-receiver";
++		gpios = <&gpio0 RK_PD4 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&ir_receiver_pin>;
 +	};
 +
 +	leds {
@@ -1015,6 +1091,15 @@ index 000000000000..111111111111
 +			pinctrl-names = "default";
 +			pinctrl-0 = <&usr_led_pin>;
 +		};
++	};
++
++	/* FAN */
++	fan0: pwm-fan {
++		compatible = "pwm-fan";
++		#cooling-cells = <2>;
++		cooling-levels = <100 160 190 200 215 235 255>;
++		pwms = <&pwm1 0 50000 0>;
++        	fan-supply = <&vcc5v0_sys>;
 +	};
 +
 +	sound {
@@ -1103,6 +1188,8 @@ index 000000000000..111111111111
 +		gpio = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&typec5v_pwren>;
++		regulator-always-on;
++		regulator-boot-on;
 +		regulator-name = "vbus5v0_typec";
 +		regulator-min-microvolt = <5000000>;
 +		regulator-max-microvolt = <5000000>;
@@ -1118,6 +1205,18 @@ index 000000000000..111111111111
 +		regulator-name = "vcc3v3_pcie2x1l0";
 +		regulator-min-microvolt = <3300000>;
 +		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc5v0_host_30: vcc5v0-host-30 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_host30_en>;
++		regulator-name = "vcc5v0_host_30";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
 +		vin-supply = <&vcc5v0_sys>;
 +	};
 +
@@ -1142,18 +1241,6 @@ index 000000000000..111111111111
 +		regulator-min-microvolt = <3300000>;
 +		regulator-name = "vcc3v3_sd_s0";
 +		vin-supply = <&vcc_3v3_s3>;
-+	};
-+
-+	vdd_4g_3v3: vdd-4g-3v3-regulator {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
-+		gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&pin_4g_lte_pwren>;
-+		regulator-name = "vdd_4g_3v3";
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&vcc5v0_sys>;
 +	};
 +};
 +
@@ -1213,7 +1300,7 @@ index 000000000000..111111111111
 +			  "HEADER_10", "HEADER_08", "HEADER_32", "",
 +			  /* GPIO0 D0-D7 */
 +			  "", "", "", "",
-+			  "", "", "", "";
++			  "IR receiver [PWM3_IR_M0]", "", "", "";
 +};
 +
 +&gpio1 {
@@ -1274,6 +1361,11 @@ index 000000000000..111111111111
 +			  /* GPIO4 D0-D7 */
 +			  "", "", "", "",
 +			  "", "", "", "";
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	status = "okay";
 +};
 +
 +&i2c0 {
@@ -1354,11 +1446,34 @@ index 000000000000..111111111111
 +			compatible = "usb-c-connector";
 +			data-role = "dual";
 +			label = "USB-C";
-+			power-role = "dual";
-+			try-power-role = "sink";
++			power-role = "source";
 +			source-pdos = <PDO_FIXED(5000, 2000, PDO_FIXED_USB_COMM)>;
-+			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
-+			op-sink-microwatt = <1000000>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++					usbc0_hs: endpoint {
++						remote-endpoint = <&usb_host0_xhci_drd_sw>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++					usbc0_ss: endpoint {
++						remote-endpoint = <&usbdp_phy0_typec_ss>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++					usbc0_sbu: endpoint {
++						remote-endpoint = <&usbdp_phy0_typec_sbu>;
++					};
++				};
++			};
 +		};
 +	};
 +
@@ -1420,6 +1535,34 @@ index 000000000000..111111111111
 +	};
 +};
 +
++&package_thermal {
++	polling-delay = <1000>;
++
++	trips {
++		package_fan0: package-fan0 {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++		package_fan1: package-fan1 {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map1 {
++			trip = <&package_fan0>;
++			cooling-device = <&fan0 THERMAL_NO_LIMIT 1>;
++		};
++		map2 {
++			trip = <&package_fan1>;
++			cooling-device = <&fan0 2 THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
 +&pcie2x1l0 {
 +	reset-gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
 +	vpcie3v3-supply = <&vcc_3v3_pcie20>;
@@ -1477,6 +1620,12 @@ index 000000000000..111111111111
 +		};
 +	};
 +
++	ir-receiver {
++		ir_receiver_pin: ir-receiver-pin {
++			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
 +	pcie {
 +		pcie2_0_rst: pcie2-0-rst {
 +			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
@@ -1500,12 +1649,12 @@ index 000000000000..111111111111
 +	};
 +
 +	usb {
-+		pin_4g_lte_pwren: 4g-lte-pwren {
-+			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
 +		typec5v_pwren: typec5v-pwren {
 +			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		vcc5v0_host30_en: vcc5v0-host30-en {
++			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
 +
 +		usbc0_int: usbc0-int {
@@ -1547,6 +1696,21 @@ index 000000000000..111111111111
 +	vmmc-supply = <&vcc3v3_sd_s0>;
 +	vqmmc-supply = <&vccio_sd_s0>;
 +	status = "okay";
++};
++
++/* optional on non-LTS, populated on LTS version */
++&sfc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspim1_pins>;
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <104000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++	};
 +};
 +
 +&spi2 {
@@ -1884,8 +2048,20 @@ index 000000000000..111111111111
 +	status = "okay";
 +};
 +
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	status = "okay";
++};
++
++&u2phy1_otg {
++	phy-supply = <&vcc5v0_host_30>;
++	status = "okay";
++};
++
 +&u2phy2_host {
-+	phy-supply = <&vdd_4g_3v3>;
 +	status = "okay";
 +};
 +
@@ -1901,421 +2077,6 @@ index 000000000000..111111111111
 +	status = "okay";
 +};
 +
-+&usb_host0_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host0_ohci {
-+	status = "okay";
-+};
-+
-+&usb_host1_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host1_ohci {
-+	status = "okay";
-+};
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
-Date: Thu, 29 Aug 2024 14:26:54 +0200
-Subject: arm64: dts: rockchip: move NanoPC-T6 parts to DTS
-
-MiniPCIe slot is present only in first version of NanoPC-T6 (2301).
-
-Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
----
- arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts  | 24 ++++++++++
- arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 17 -------
- 2 files changed, 24 insertions(+), 17 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
-index 111111111111..222222222222 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
-@@ -14,4 +14,28 @@ / {
- 	model = "FriendlyElec NanoPC-T6";
- 	compatible = "friendlyarm,nanopc-t6", "rockchip,rk3588";
- 
-+	vdd_4g_3v3: vdd-4g-3v3-regulator {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
-+		gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&pin_4g_lte_pwren>;
-+		regulator-name = "vdd_4g_3v3";
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&vcc5v0_sys>;
-+	};
-+};
-+
-+&pinctrl {
-+	usb {
-+		pin_4g_lte_pwren: 4g-lte-pwren {
-+			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+};
-+
-+&u2phy2_host {
-+	phy-supply = <&vdd_4g_3v3>;
-+	status = "okay";
- };
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-index 111111111111..222222222222 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-@@ -170,18 +170,6 @@ vcc3v3_sd_s0: vcc3v3-sd-s0-regulator {
- 		regulator-name = "vcc3v3_sd_s0";
- 		vin-supply = <&vcc_3v3_s3>;
- 	};
--
--	vdd_4g_3v3: vdd-4g-3v3-regulator {
--		compatible = "regulator-fixed";
--		enable-active-high;
--		gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
--		pinctrl-names = "default";
--		pinctrl-0 = <&pin_4g_lte_pwren>;
--		regulator-name = "vdd_4g_3v3";
--		regulator-min-microvolt = <3300000>;
--		regulator-max-microvolt = <3300000>;
--		vin-supply = <&vcc5v0_sys>;
--	};
- };
- 
- &combphy0_ps {
-@@ -527,10 +515,6 @@ pcie_m2_1_pwren: pcie-m21-pwren {
- 	};
- 
- 	usb {
--		pin_4g_lte_pwren: 4g-lte-pwren {
--			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
--		};
--
- 		typec5v_pwren: typec5v-pwren {
- 			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
-@@ -912,7 +896,6 @@ &uart2 {
- };
- 
- &u2phy2_host {
--	phy-supply = <&vdd_4g_3v3>;
- 	status = "okay";
- };
- 
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
-Date: Thu, 29 Aug 2024 14:26:55 +0200
-Subject: arm64: dts: rockchip: add NanoPC-T6 LTS
-
-In the LTS (2310) version the miniPCIe slot got removed and USB 2.0
-setup has changed. There are two external accessible ports and two ports
-on the internal header.
-
-There is an on-board USB hub which provides:
-- one external connector (bottom one)
-- two internal ports on pin header
-- one port for m.2 E connector
-
-The top USB 2.0 connector comes directly from the SoC.
-
-Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
----
- arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts | 61 ++++++++++
- 1 file changed, 61 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts
-new file mode 100644
-index 000000000000..111111111111
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts
-@@ -0,0 +1,61 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+/*
-+ * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
-+ * Copyright (c) 2023 Thomas McKahan
-+ * Copyright (c) 2024 Linaro Ltd.
-+ *
-+ */
-+
-+/dts-v1/;
-+
-+#include "rk3588-nanopc-t6.dtsi"
-+
-+/ {
-+	model = "FriendlyElec NanoPC-T6 LTS";
-+	compatible = "friendlyarm,nanopc-t6-lts", "rockchip,rk3588";
-+
-+	/* provide power for on-board USB 2.0 hub */
-+	vcc5v0_usb20_host: vcc5v0-usb20-host-regulator {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
-+		gpio = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
-+		pinctrl-0 = <&usb20_host_pwren>;
-+		pinctrl-names = "default";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-max-microvolt = <5000000>;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-name = "vcc5v0_usb20_host";
-+		vin-supply = <&vcc5v0_sys>;
-+	};
-+};
-+
-+&pinctrl {
-+	usb {
-+		usb20_host_pwren: usb20-host-pwren {
-+			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+};
-+
-+&u2phy1 {
-+	status = "okay";
-+};
-+
-+&u2phy1_otg {
-+	status = "okay";
-+};
-+
-+&u2phy2_host {
-+	phy-supply = <&vcc5v0_usb20_host>;
-+	status = "okay";
-+};
-+
-+&usbdp_phy1 {
-+	status = "okay";
-+};
-+
-+&usb_host1_xhci {
-+	dr_mode = "host";
-+	status = "okay";
-+};
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
-Date: Thu, 29 Aug 2024 14:26:56 +0200
-Subject: arm64: dts: rockchip: add SPI flash on NanoPC-T6
-
-FriendlyELEC NanoPC-T6 has optional SPI flash chip on-board.
-It is populated with 32MB one on LTS version.
-
-Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
-Reviewed-by: Jonas Karlman <jonas@kwiboo.se>
----
- arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 15 ++++++++++
- 1 file changed, 15 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-index 111111111111..222222222222 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-@@ -560,6 +560,21 @@ &sdmmc {
- 	status = "okay";
- };
- 
-+/* optional on non-LTS, populated on LTS version */
-+&sfc {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&fspim1_pins>;
-+	status = "okay";
-+
-+	flash@0 {
-+		compatible = "jedec,spi-nor";
-+		reg = <0>;
-+		spi-max-frequency = <104000000>;
-+		spi-rx-bus-width = <4>;
-+		spi-tx-bus-width = <1>;
-+	};
-+};
-+
- &spi2 {
- 	status = "okay";
- 	assigned-clocks = <&cru CLK_SPI2>;
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
-Date: Thu, 29 Aug 2024 14:26:57 +0200
-Subject: arm64: dts: rockchip: add IR-receiver to NanoPC-T6
-
-FriendlyELEC NanoPC-T6 has IR receiver connected to PWM3_IR_M0 line
-which ends as GPIO0_D4.
-
-Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
----
- arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 15 +++++++++-
- 1 file changed, 14 insertions(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-index 111111111111..222222222222 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-@@ -25,6 +25,13 @@ chosen {
- 		stdout-path = "serial2:1500000n8";
- 	};
- 
-+	ir-receiver {
-+		compatible = "gpio-ir-receiver";
-+		gpios = <&gpio0 RK_PD4 GPIO_ACTIVE_LOW>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&ir_receiver_pin>;
-+	};
-+
- 	leds {
- 		compatible = "gpio-leds";
- 
-@@ -228,7 +235,7 @@ &gpio0 {
- 			  "HEADER_10", "HEADER_08", "HEADER_32", "",
- 			  /* GPIO0 D0-D7 */
- 			  "", "", "", "",
--			  "", "", "", "";
-+			  "IR receiver [PWM3_IR_M0]", "", "", "";
- };
- 
- &gpio1 {
-@@ -492,6 +499,12 @@ hym8563_int: hym8563-int {
- 		};
- 	};
- 
-+	ir-receiver {
-+		ir_receiver_pin: ir-receiver-pin {
-+			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
- 	pcie {
- 		pcie2_0_rst: pcie2-0-rst {
- 			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
-Date: Thu, 29 Aug 2024 14:26:58 +0200
-Subject: arm64: dts: rockchip: enable GPU on NanoPC-T6
-
-Enable the Mali GPU on FriendlyELEC NanoPC-T6
-
-Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
----
- arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 5 +++++
- 1 file changed, 5 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-index 111111111111..222222222222 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-@@ -298,6 +298,11 @@ &gpio4 {
- 			  "", "", "", "";
- };
- 
-+&gpu {
-+	mali-supply = <&vdd_gpu_s0>;
-+	status = "okay";
-+};
-+
- &i2c0 {
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&i2c0m2_xfer>;
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
-Date: Thu, 29 Aug 2024 14:26:59 +0200
-Subject: arm64: dts: rockchip: enable USB-C on NanoPC-T6
-
-Enable the USB-C port on FriendlyELEC NanoPC-T6.
-
-Works one way so far but still better than before.
-
-Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
----
- arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 76 +++++++++-
- 1 file changed, 72 insertions(+), 4 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-index 111111111111..222222222222 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-@@ -137,6 +137,8 @@ vbus5v0_typec: vbus5v0-typec-regulator {
- 		gpio = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
- 		pinctrl-names = "default";
- 		pinctrl-0 = <&typec5v_pwren>;
-+		regulator-always-on;
-+		regulator-boot-on;
- 		regulator-name = "vbus5v0_typec";
- 		regulator-min-microvolt = <5000000>;
- 		regulator-max-microvolt = <5000000>;
-@@ -381,11 +383,34 @@ connector {
- 			compatible = "usb-c-connector";
- 			data-role = "dual";
- 			label = "USB-C";
--			power-role = "dual";
--			try-power-role = "sink";
-+			power-role = "source";
- 			source-pdos = <PDO_FIXED(5000, 2000, PDO_FIXED_USB_COMM)>;
--			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
--			op-sink-microwatt = <1000000>;
-+
-+			ports {
-+				#address-cells = <1>;
-+				#size-cells = <0>;
-+
-+				port@0 {
-+					reg = <0>;
-+					usbc0_hs: endpoint {
-+						remote-endpoint = <&usb_host0_xhci_drd_sw>;
-+					};
-+				};
-+
-+				port@1 {
-+					reg = <1>;
-+					usbc0_ss: endpoint {
-+						remote-endpoint = <&usbdp_phy0_typec_ss>;
-+					};
-+				};
-+
-+				port@2 {
-+					reg = <2>;
-+					usbc0_sbu: endpoint {
-+						remote-endpoint = <&usbdp_phy0_typec_sbu>;
-+					};
-+				};
-+			};
- 		};
- 	};
- 
-@@ -928,6 +953,14 @@ &uart2 {
- 	status = "okay";
- };
- 
-+&u2phy0 {
-+	status = "okay";
-+};
-+
-+&u2phy0_otg {
-+	status = "okay";
-+};
-+
- &u2phy2_host {
- 	status = "okay";
- };
-@@ -944,6 +977,29 @@ &u2phy3 {
- 	status = "okay";
- };
- 
 +&usbdp_phy0 {
 +	mode-switch;
 +	orientation-switch;
@@ -2339,13 +2100,14 @@ index 111111111111..222222222222 100644
 +	};
 +};
 +
- &usb_host0_ehci {
- 	status = "okay";
- };
-@@ -952,6 +1008,18 @@ &usb_host0_ohci {
- 	status = "okay";
- };
- 
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
 +&usb_host0_xhci {
 +	dr_mode = "host";
 +	status = "okay";
@@ -2358,57 +2120,14 @@ index 111111111111..222222222222 100644
 +	};
 +};
 +
- &usb_host1_ehci {
- 	status = "okay";
- };
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
-Date: Thu, 29 Aug 2024 14:27:00 +0200
-Subject: arm64: dts: rockchip: add Mask Rom key on NanoPC-T6
-
-Mask Rom key is connected to SARADC and can be read from OS.
-
-Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
----
- arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 15 ++++++++++
- 1 file changed, 15 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-index 111111111111..222222222222 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-@@ -8,6 +8,7 @@
- /dts-v1/;
- 
- #include <dt-bindings/gpio/gpio.h>
-+#include <dt-bindings/input/input.h>
- #include <dt-bindings/pinctrl/rockchip.h>
- #include <dt-bindings/usb/pd.h>
- #include "rk3588.dtsi"
-@@ -21,6 +22,20 @@ aliases {
- 		mmc1 = &sdmmc;
- 	};
- 
-+	adc-keys-0 {
-+		compatible = "adc-keys";
-+		io-channels = <&saradc 0>;
-+		io-channel-names = "buttons";
-+		keyup-threshold-microvolt = <1800000>;
-+		poll-interval = <100>;
++&usb_host1_ehci {
++	status = "okay";
++};
 +
-+		button-maskrom {
-+			label = "Mask Rom";
-+			linux,code = <KEY_SETUP>;
-+			press-threshold-microvolt = <2000>;
-+		};
-+	};
++&usb_host1_ohci {
++	status = "okay";
++};
 +
- 	chosen {
- 		stdout-path = "serial2:1500000n8";
- 	};
 -- 
-Armbian
+2.34.1
 


### PR DESCRIPTION
# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

- Bump uboot from 2024.07 to 2024.10 mainline
- Replaced edge patch with v7 that enable power-supply on USB3.0 and add fan control through pwm.


[Jira](https://armbian.atlassian.net/jira) reference number [AR-2517]

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh  BOARD=nanopct6-lts BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=trixie`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings