### PR TITLE
Add hexagonrpc service to xiaomi-elish

### DIFF
--- a/config/boards/oneplus-kebab.conf
+++ b/config/boards/oneplus-kebab.conf
@@ -65,7 +65,7 @@ function post_family_tweaks__oneplus-kebab_enable_services() {
 
 	do_with_retries 3 chroot_sdcard_apt_get_update
 	display_alert "$BOARD" "Installing board tweaks" "info"
-	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools protection-domain-mapper tqftpserv unudhcpd mkbootimg
+	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools unudhcpd mkbootimg
 
 	# disable armbian repo back
 	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
@@ -73,8 +73,6 @@ function post_family_tweaks__oneplus-kebab_enable_services() {
 
 	chroot_sdcard systemctl enable qbootctl.service
 	chroot_sdcard systemctl enable usbgadget-rndis.service
-	chroot_sdcard systemctl enable pd-mapper.service
-	chroot_sdcard systemctl enable tqftpserv.service
 	chroot_sdcard systemctl enable bt-fixed-mac.service
 	return 0
 }

--- a/config/boards/xiaomi-elish.conf
+++ b/config/boards/xiaomi-elish.conf
@@ -65,7 +65,7 @@ function post_family_tweaks__xiaomi-elish_enable_services() {
 
 	do_with_retries 3 chroot_sdcard_apt_get_update
 	display_alert "$BOARD" "Installing board tweaks" "info"
-	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools protection-domain-mapper tqftpserv unudhcpd mkbootimg
+	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools unudhcpd mkbootimg
 
 	# disable armbian repo back
 	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
@@ -73,8 +73,6 @@ function post_family_tweaks__xiaomi-elish_enable_services() {
 
 	chroot_sdcard systemctl enable qbootctl.service
 	chroot_sdcard systemctl enable usbgadget-rndis.service
-	chroot_sdcard systemctl enable pd-mapper.service
-	chroot_sdcard systemctl enable tqftpserv.service
 	chroot_sdcard systemctl enable bt-fixed-mac.service
 	return 0
 }

--- a/config/boards/xiaomi-elish.conf
+++ b/config/boards/xiaomi-elish.conf
@@ -27,6 +27,8 @@ function post_family_tweaks_bsp__xiaomi-elish_firmware() {
 	mkdir -p $destination/usr/share/alsa/ucm2/conf.d/sm8250
 	install -Dm644 $SRC/packages/bsp/xiaomi-elish/elish.conf $destination/usr/share/alsa/ucm2/Xiaomi/elish/elish.conf
 	install -Dm644 $SRC/packages/bsp/xiaomi-elish/elish_HiFi.conf $destination/usr/share/alsa/ucm2/Xiaomi/elish/HiFi.conf
+	# conifg file used by service hexagonrpcd-sdsp
+	install -Dm644 $SRC/packages/bsp/xiaomi-elish/hexagonrpcd-sdsp $destination/etc/conf.d/hexagonrpcd-sdsp
 	ln -sfv ../../Xiaomi/elish/elish.conf \
 		"$destination/usr/share/alsa/ucm2/conf.d/sm8250/Xiaomi Mi Pad 5 Pro.conf"
 
@@ -67,6 +69,11 @@ function post_family_tweaks__xiaomi-elish_enable_services() {
 	display_alert "$BOARD" "Installing board tweaks" "info"
 	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools unudhcpd mkbootimg
 
+	# Install hexagonrpc userspace service for kernel after 6.11, hexagonrpc in only packaged for noble now
+	if [[ "${RELEASE}" == "noble" ]]; then
+		do_with_retries 3 chroot_sdcard_apt_get_install hexagonrpc
+		chroot_sdcard systemctl enable hexagonrpcd-sdsp.service
+	fi
 	# disable armbian repo back
 	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
 	do_with_retries 3 chroot_sdcard_apt_get_update

--- a/config/boards/xiaomi-umi.conf
+++ b/config/boards/xiaomi-umi.conf
@@ -62,7 +62,7 @@ function post_family_tweaks__xiaomi-umi_enable_services() {
 
 	do_with_retries 3 chroot_sdcard_apt_get_update
 	display_alert "$BOARD" "Installing board tweaks" "info"
-	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools protection-domain-mapper tqftpserv unudhcpd mkbootimg
+	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools unudhcpd mkbootimg
 
 	# Disable armbian repo back
 	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
@@ -70,8 +70,6 @@ function post_family_tweaks__xiaomi-umi_enable_services() {
 
 	chroot_sdcard systemctl enable qbootctl.service
 	chroot_sdcard systemctl enable usbgadget-rndis.service
-	chroot_sdcard systemctl enable pd-mapper.service
-	chroot_sdcard systemctl enable tqftpserv.service
 	return 0
 }
 

--- a/packages/bsp/xiaomi-elish/hexagonrpcd-sdsp
+++ b/packages/bsp/xiaomi-elish/hexagonrpcd-sdsp
@@ -1,0 +1,1 @@
+hexagonrpcd_fw_dir=/lib/firmware/qcom/sm8250/xiaomi/elish/


### PR DESCRIPTION
# Description

After updating to kernel 6.11, slpi node of sm8250 will crash, and a userspace service hexagonrpc has to run to avoid that: https://github.com/linux-msm/hexagonrpc
This package is only packaged in my ppa qcom-mainline for noble, so only install and enable the service for noble.

I also remove pd-mapper and tqftp service since they are useless now, pd-mapper is in kernel.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=xiaomi-elish BRANCH=current KERNEL_GIT=shallow DEB_COMPRESS=xz RELEASE=noble BUILD_DESKTOP=yes BUILD_MINIMAL=no KERNEL_CONFIGURE=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
