### PR TITLE
First login automation - add support for SSH key download

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -472,6 +472,7 @@ set_timezone_and_locales() {
 			if [[ -z ${TZDATA} ]]; then
 				TZDATA=$(tzselect | tail -1)
 			fi
+			echo ""
 		else
 			TZDATA=$PRESET_TIMEZONE
 		fi
@@ -479,8 +480,10 @@ set_timezone_and_locales() {
 		timedatectl set-timezone "${TZDATA}"
 		dpkg-reconfigure --frontend=noninteractive tzdata > /dev/null 2>&1
 
+		# change default locales
+		sed -i "s/=.*/=$(echo ${LOCALES} | cut -d" " -f1)/g" /etc/default/locale
+
 		# generate locales
-		echo ""
 		sed -i 's/# '"${LOCALES}"'/'"${LOCALES}"'/' /etc/locale.gen
 		echo -e "Generating locales: \x1B[92m${LOCALES}\x1B[0m"
 		locale-gen "${LOCALES}" > /dev/null 2>&1
@@ -528,7 +531,7 @@ add_user() {
 	read -r -t 0 _
 	REPEATS=3
 	while [ -f "/root/.not_logged_in_yet" ]; do
-		echo -e "\nPlease provide a username (eg. your first name): \c"
+		[[ -z "${PRESET_USER_NAME}" ]] && echo -e "\nPlease provide a username (eg. your first name): \c"
 		if [ -z "$PRESET_USER_NAME" ];then
 			read -r -e username
 		else
@@ -547,18 +550,18 @@ add_user() {
 	while [ -f "/root/.not_logged_in_yet" ]; do
 		if [ -z "$PRESET_USER_PASSWORD" ];then
 			read_password "Create user ($username)"
+			echo ""
 		else
 			password="$PRESET_USER_PASSWORD"
 		fi
 		first_input="$password"
-		echo ""
 		if [ -z "$PRESET_USER_PASSWORD" ];then
 			read_password "Repeat user ($username)"
+			echo ""
 		else
 			password="$PRESET_USER_PASSWORD"
 		fi
 		second_input="$password"
-		echo ""
 		if [[ "$first_input" == "$second_input" ]]; then
 			# minimal images might not have this
 			if command -v cracklib-check > /dev/null 2>&1; then
@@ -568,14 +571,22 @@ add_user() {
 					echo -e "\n\e[0;31mWarning:\x1B[0m Weak password, $okay \b!"
 				fi
 			fi
-			echo -e ""
 			if [ -z "$PRESET_DEFAULT_REALNAME" ];then
+				echo -e ""
 				read -r -e -p "Please provide your real name: " -i "${RealUserName^}" RealName
 			else
 				RealName="$PRESET_DEFAULT_REALNAME"
 			fi
 
 			adduser --quiet --disabled-password --home /home/"$RealUserName" --gecos "$RealName" "$RealUserName"
+
+			# download and add SSH key if defined
+			if [[ -n "${PRESET_USER_KEY}" ]]; then
+				mkdir -p /home/"$RealUserName"/.ssh/
+				curl --retry 5 --connect-timeout 3 "${PRESET_ROOT_KEY}" > /home/"$RealUserName"/.ssh/authorized_keys 2> /dev/null
+				chown -R "$RealUserName":"$RealUserName" /home/"$RealUserName"/.ssh/
+			fi
+
 			if [[ -n "$first_input" ]]; then
 				(
 					echo "$first_input"
@@ -614,6 +625,14 @@ add_user() {
 }
 
 if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
+
+	. /root/.not_logged_in_yet
+
+	# override configuration from URL
+	if [[ -n "${PRESET_CONFIGURATION}" ]]; then
+		curl --retry 5 --connect-timeout 3 "${PRESET_CONFIGURATION}" > /root/.not_logged_in_yet 2> /dev/null
+	fi
+
 	do_firstrun_automated_network_configuration
 
 	# disable autologin
@@ -662,7 +681,7 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	# Try to get the local IP address (script halts until IP was found or x retries were done)
 	get_local_ip_addr
 
-	echo "" # empty line
+	[[ -z "$PRESET_ROOT_PASSWORD" ]] && echo "" # empty line
 
 	trap '' 2
 	REPEATS=3
@@ -671,10 +690,16 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		if [ -z "$PRESET_ROOT_PASSWORD" ];then
 			read_password "Create root"
 		else
-			if [ "$(who am i | awk '{print $2}')" != "tty1" ];then
-				exit
-			fi
+			# allow automated install also in interactive session
+			#if [ "$(who am i | awk '{print $2}')" != "tty1" ];then
+			#	exit
+			#fi
 			password="$PRESET_ROOT_PASSWORD"
+			# download SSH key if defined
+			if [[ -n "${PRESET_ROOT_KEY}" ]]; then
+				mkdir -p /root/.ssh/
+				curl --retry 5 --connect-timeout 3 "${PRESET_ROOT_KEY}" > /root/.ssh/authorized_keys 2> /dev/null
+			fi
 		fi
 
 		# only allow one login. Once you enter root password, kill others.
@@ -682,14 +707,14 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		who -la | grep root | grep -v "$loginfrom" | awk '{print $7}' | xargs --no-run-if-empty kill -9
 
 		first_input="$password"
-		echo ""
 		if [ -z "$PRESET_ROOT_PASSWORD" ];then
+			echo ""
 			read_password "Repeat root"
+			echo ""
 		else
 			password="$PRESET_ROOT_PASSWORD"
 		fi
 		second_input="$password"
-		echo ""
 		if [[ "$first_input" == "$second_input" ]]; then
 			# minimal might not have this
 			if command -v cracklib-check > /dev/null 2>&1; then
@@ -740,7 +765,7 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	trap check_abort INT
 
 	while [ -f "/root/.not_logged_in_yet" ]; do
-		echo -e "\nCreating a new user account. Press <Ctrl-C> to abort"
+		[[ -z "${PRESET_USER_NAME}" ]] && echo -e "\nCreating a new user account. Press <Ctrl-C> to abort"
 		[[ "${desktop_dm}" != "none" ]] && echo -e "\n\e[0;31mDesktop environment will not be enabled if you abort the new user creation\x1B[0m"
 		add_user
 	done


### PR DESCRIPTION
# Description

- add SSH key download
- allow automation in interactive mode too. It was disabled for no apparent reason.
- improve automation UX / cosmetics

![image](https://github.com/user-attachments/assets/1e682c3e-407f-4620-a5ef-9a4b07c7c209)


# Documentation summary for feature / change

https://github.com/armbian/documentation/pull/497

# How Has This Been Tested?

- [x] Tested Oracular / Jammy / Bookworm with fixed IP address and SSH key insert
- [x] Tested manual login at Noble

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
