### PR TITLE
Radxa Rock-3a - edge - use mainline uboot

### DIFF
--- a/config/boards/rock-3a.conf
+++ b/config/boards/rock-3a.conf
@@ -13,3 +13,25 @@ BOOT_SUPPORT_SPI="yes"
 BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 BOOTFS_TYPE="fat"
+
+function post_family_config_branch_edge__rock-3a_use_mainline_uboot() {
+	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
+	unset BOOTFS_TYPE # fixes armbian-install and unneeded for modern uboot anyway
+	declare -g BOOTCONFIG="rock-3a-rk3568_defconfig"
+	declare -g BOOTDELAY=1                           
+	declare -g BOOTSOURCE="https://github.com/Kwiboo/u-boot-rockchip"
+	declare -g BOOTBRANCH="branch:rk3xxx-2024.10"
+	declare -g BOOTPATCHDIR="v2024.10"
+	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+
+	function write_uboot_platform_mtd() {
+		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
+	}
+}

--- a/config/boards/rock-3a.conf
+++ b/config/boards/rock-3a.conf
@@ -19,8 +19,8 @@ function post_family_config_branch_edge__rock-3a_use_mainline_uboot() {
 	unset BOOTFS_TYPE # fixes armbian-install and unneeded for modern uboot anyway
 	declare -g BOOTCONFIG="rock-3a-rk3568_defconfig"
 	declare -g BOOTDELAY=1                           
-	declare -g BOOTSOURCE="https://github.com/Kwiboo/u-boot-rockchip"
-	declare -g BOOTBRANCH="branch:rk3xxx-2024.10"
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot"
+	declare -g BOOTBRANCH="tag:v2024.10"
 	declare -g BOOTPATCHDIR="v2024.10"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"


### PR DESCRIPTION
# Description

- switches bleeding edge u-boot to ~~@Kwiboo~~ mainline 2024.10 ~~branch~~ tag
- get rid of separate boot partition since
- - not needed for modern u-boot
- - fixes `armbian-install` failing with separate boot partition present

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]


# How Has This Been Tested?

- [x] build `./compile.sh BOARD=rock-3a BRANCH=edge BUILD_MINIMAL=yes KERNEL_CONFIGURE=no RELEASE=bookworm`
- [x] boot from microSD https://paste.armbian.com/gorewajove
- [x] install to NVME/MTD
- [x] boot from NVME https://paste.armbian.com/erovehisuk

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
