### PR TITLE
tqma-current and xfce: fixes

### DIFF
--- a/config/desktop/noble/environments/xfce/config_base/packages
+++ b/config/desktop/noble/environments/xfce/config_base/packages
@@ -1,3 +1,4 @@
+accountsservice
 anacron
 apt-xapian-index
 blueman

--- a/config/kernel/linux-tqma-current.config
+++ b/config/kernel/linux-tqma-current.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.11.3 Kernel Configuration
+# Linux/arm64 6.11.5 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y
@@ -8178,7 +8178,7 @@ CONFIG_SQUASHFS_COMPILE_DECOMP_SINGLE=y
 CONFIG_SQUASHFS_ZLIB=y
 # CONFIG_SQUASHFS_LZ4 is not set
 # CONFIG_SQUASHFS_LZO is not set
-# CONFIG_SQUASHFS_XZ is not set
+CONFIG_SQUASHFS_XZ=y
 # CONFIG_SQUASHFS_ZSTD is not set
 # CONFIG_SQUASHFS_4K_DEVBLK_SIZE is not set
 # CONFIG_SQUASHFS_EMBEDDED is not set


### PR DESCRIPTION
# Description

Found some Issues while testing, add some fixes.

# Documentation summary for change

- [x] enable SQUASHFS_XZ to solve "Filesystem uses "xz" compression. This is not supported" error
- [x] xfce: add accountsservice solves lightdm warning 'Error getting user list

# How Has This Been Tested?

- [x]  Boot xfce image on mba8mp-ras314 and check the logs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

