### PR TITLE
enable wifi on opi3b v1.1 with 6.11 kernel

### DIFF
--- a/patch/kernel/archive/rockchip64-6.11/board-orangepi3b-add-uwe5622-wifi-bt-nodes.patch
+++ b/patch/kernel/archive/rockchip64-6.11/board-orangepi3b-add-uwe5622-wifi-bt-nodes.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Fri, 25 Oct 2024 14:48:47 +0800
+Subject: arch: arm64: dts: add uwe5622 wifi/bt nodes to orangepi3b v1.1
+
+---
+ arch/arm64/boot/dts/rockchip/rk3566-orangepi-3b-v1.1.dts | 17 ++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-orangepi-3b-v1.1.dts b/arch/arm64/boot/dts/rockchip/rk3566-orangepi-3b-v1.1.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-orangepi-3b-v1.1.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-orangepi-3b-v1.1.dts
+@@ -7,6 +7,23 @@
+ / {
+ 	model = "Xunlong Orange Pi 3B v1.1";
+ 	compatible = "xunlong,orangepi-3b-v1.1", "xunlong,orangepi-3b", "rockchip,rk3566";
++
++	sprd-mtty {
++		compatible = "sprd,mtty";
++		sprd,name = "ttyBT";
++	};
++
++	uwe-bsp {
++		compatible = "unisoc,uwe_bsp";
++		wl-reg-on = <&gpio0 RK_PD3 GPIO_ACTIVE_HIGH>;
++		bt-reg-on = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
++		wl-wake-host-gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_HIGH>;
++		bt-wake-host-gpio = <&gpio2 RK_PC0 GPIO_ACTIVE_HIGH>;
++		sdio-ext-int-gpio = <&gpio2 RK_PC1 GPIO_ACTIVE_HIGH>;
++		data-irq;
++		blksz-512;
++		keep-power-on;
++	};
+ };
+ 
+ &pmu_io_domains {
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.11/general-driver-tm16xx-led-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.11/general-driver-tm16xx-led-driver.patch
@@ -1,22 +1,21 @@
-From b305f05351984645293a9b7b2047779f6d8fbdd2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 5 Oct 2024 16:07:14 +0200
-Subject: [PATCH] Add tm16xx led auxiliary display driver
+Subject: Add tm16xx led auxiliary display driver
 
 ---
  drivers/auxdisplay/Kconfig  |   10 +
  drivers/auxdisplay/Makefile |    1 +
- drivers/auxdisplay/tm16xx.c | 1167 +++++++++++++++++++++++++++++++++++
+ drivers/auxdisplay/tm16xx.c | 1167 ++++++++++
  3 files changed, 1178 insertions(+)
- create mode 100644 drivers/auxdisplay/tm16xx.c
 
 diff --git a/drivers/auxdisplay/Kconfig b/drivers/auxdisplay/Kconfig
-index 64012cda4d12..3fe0088b7f1f 100644
+index 111111111111..222222222222 100644
 --- a/drivers/auxdisplay/Kconfig
 +++ b/drivers/auxdisplay/Kconfig
-@@ -183,6 +183,16 @@ config HT16K33
- 	  Say yes here to add support for Holtek HT16K33, RAM mapping 16*8
- 	  LED controller driver with keyscan.
+@@ -49,6 +49,16 @@ config HD44780
+ 	  kernel and started at boot.
+ 	  If you don't understand what all this is about, say N.
  
 +config TM16XX
 +	tristate "TM16xx/FD6xx LED controller driver and compatibles"
@@ -32,7 +31,7 @@ index 64012cda4d12..3fe0088b7f1f 100644
  	tristate "lcd2s 20x4 character display over I2C console"
  	depends on I2C
 diff --git a/drivers/auxdisplay/Makefile b/drivers/auxdisplay/Makefile
-index f5c13ed1cd4f..066f452b1e26 100644
+index 111111111111..222222222222 100644
 --- a/drivers/auxdisplay/Makefile
 +++ b/drivers/auxdisplay/Makefile
 @@ -9,6 +9,7 @@ obj-$(CONFIG_CHARLCD)		+= charlcd.o
@@ -45,7 +44,7 @@ index f5c13ed1cd4f..066f452b1e26 100644
  obj-$(CONFIG_LCD2S)		+= lcd2s.o
 diff --git a/drivers/auxdisplay/tm16xx.c b/drivers/auxdisplay/tm16xx.c
 new file mode 100644
-index 000000000000..d938b0166e74
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/auxdisplay/tm16xx.c
 @@ -0,0 +1,1167 @@
@@ -1217,6 +1216,5 @@ index 000000000000..d938b0166e74
 +MODULE_ALIAS("spi:tm16xx");
 +MODULE_ALIAS("i2c:tm16xx");
 -- 
-2.34.1
-
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.11/general-hdmi-clock-fixes.patch
+++ b/patch/kernel/archive/rockchip64-6.11/general-hdmi-clock-fixes.patch
@@ -7,9 +7,8 @@ Subject: hdmi timing core changes and fixes
  drivers/clk/rockchip/clk-rk3399.c           | 49 ++++++++--
  drivers/gpu/drm/bridge/synopsys/dw-hdmi.c   | 12 +--
  drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c | 44 ++++++++-
- drivers/gpu/drm/rockchip/rockchip_drm_vop.c | 15 ++-
  drivers/gpu/drm/rockchip/rockchip_vop_reg.c |  7 ++
- 5 files changed, 109 insertions(+), 18 deletions(-)
+ 4 files changed, 98 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/clk/rockchip/clk-rk3399.c b/drivers/clk/rockchip/clk-rk3399.c
 index 111111111111..222222222222 100644
@@ -206,7 +205,7 @@ diff --git a/drivers/gpu/drm/rockchip/rockchip_vop_reg.c b/drivers/gpu/drm/rockc
 index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
 +++ b/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
-@@ -763,6 +763,7 @@ static const struct vop_intr rk3288_vop_intr = {
+@@ -765,6 +765,7 @@ static const struct vop_intr rk3288_vop_intr = {
  static const struct vop_data rk3288_vop = {
  	.version = VOP_VERSION(3, 1),
  	.feature = VOP_FEATURE_OUTPUT_RGB10,
@@ -214,7 +213,7 @@ index 111111111111..222222222222 100644
  	.intr = &rk3288_vop_intr,
  	.common = &rk3288_common,
  	.modeset = &rk3288_modeset,
-@@ -870,6 +871,7 @@ static const struct vop_misc rk3368_misc = {
+@@ -872,6 +873,7 @@ static const struct vop_misc rk3368_misc = {
  
  static const struct vop_data rk3368_vop = {
  	.version = VOP_VERSION(3, 2),
@@ -222,7 +221,7 @@ index 111111111111..222222222222 100644
  	.intr = &rk3368_vop_intr,
  	.common = &rk3288_common,
  	.modeset = &rk3288_modeset,
-@@ -892,6 +894,7 @@ static const struct vop_intr rk3366_vop_intr = {
+@@ -894,6 +896,7 @@ static const struct vop_intr rk3366_vop_intr = {
  
  static const struct vop_data rk3366_vop = {
  	.version = VOP_VERSION(3, 4),
@@ -230,7 +229,7 @@ index 111111111111..222222222222 100644
  	.intr = &rk3366_vop_intr,
  	.common = &rk3288_common,
  	.modeset = &rk3288_modeset,
-@@ -1045,6 +1048,7 @@ static const struct vop_afbc rk3399_vop_afbc = {
+@@ -1047,6 +1050,7 @@ static const struct vop_afbc rk3399_vop_afbc = {
  static const struct vop_data rk3399_vop_big = {
  	.version = VOP_VERSION(3, 5),
  	.feature = VOP_FEATURE_OUTPUT_RGB10,
@@ -238,7 +237,7 @@ index 111111111111..222222222222 100644
  	.intr = &rk3366_vop_intr,
  	.common = &rk3399_common,
  	.modeset = &rk3288_modeset,
-@@ -1073,6 +1077,7 @@ static const struct vop_win_yuv2yuv_data rk3399_vop_lit_win_yuv2yuv_data[] = {
+@@ -1075,6 +1079,7 @@ static const struct vop_win_yuv2yuv_data rk3399_vop_lit_win_yuv2yuv_data[] = {
  
  static const struct vop_data rk3399_vop_lit = {
  	.version = VOP_VERSION(3, 6),
@@ -246,7 +245,7 @@ index 111111111111..222222222222 100644
  	.intr = &rk3366_vop_intr,
  	.common = &rk3399_common,
  	.modeset = &rk3288_modeset,
-@@ -1095,6 +1100,7 @@ static const struct vop_win_data rk3228_vop_win_data[] = {
+@@ -1097,6 +1102,7 @@ static const struct vop_win_data rk3228_vop_win_data[] = {
  static const struct vop_data rk3228_vop = {
  	.version = VOP_VERSION(3, 7),
  	.feature = VOP_FEATURE_OUTPUT_RGB10,
@@ -254,7 +253,7 @@ index 111111111111..222222222222 100644
  	.intr = &rk3366_vop_intr,
  	.common = &rk3288_common,
  	.modeset = &rk3288_modeset,
-@@ -1167,6 +1173,7 @@ static const struct vop_win_data rk3328_vop_win_data[] = {
+@@ -1169,6 +1175,7 @@ static const struct vop_win_data rk3328_vop_win_data[] = {
  static const struct vop_data rk3328_vop = {
  	.version = VOP_VERSION(3, 8),
  	.feature = VOP_FEATURE_OUTPUT_RGB10,


### PR DESCRIPTION
# Description

Mainline devicetree of opi3b v1.1 doesn't have devicetree node of downstream uwe5622 driver. Now I add them back. 
I also rewrote the patches of rockchip64-6.11 with command `./compile.sh rewrite-kernel-patches BOARD=orangepi3b BRANCH=edge BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=no`

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel-dtb BOARD=orangepi3b BRANCH=edge BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=no`
- [x] Uwe5622 wifi works.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
