### PR TITLE
CI: Improve automatic labelling system on pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,10 @@
 #
 # Please keep the labels sorted and deduplicated.
 
+"Needs review":
+- changed-files:
+  - any-glob-to-any-file: '**'
+
 "Hardware":
 - all:
   - changed-files:

--- a/.github/workflows/pr-label-on-approved.yml
+++ b/.github/workflows/pr-label-on-approved.yml
@@ -1,0 +1,14 @@
+on: pull_request_review
+name: Label approved pull requests
+jobs:
+  labelWhenApproved:
+    name: Label when approved
+    runs-on: ubuntu-latest
+    steps:
+    - name: Label when approved
+      uses: pullreminders/label-when-approved-action@master
+      env:
+        APPROVALS: "1"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ADD_LABEL: "Ready to merge"
+        REMOVE_LABEL: "Needs%20review"


### PR DESCRIPTION
# Description

- Set "Need review" label to all PR's by default
- Label approved pull requests with "Ready to merge"

# How Has This Been Tested?

Tested on private repo.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
