### PR TITLE
Limit default labelling to opened, reopened and synchronise PR

### DIFF
--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -5,9 +5,23 @@ run-name: 'Set labels - PR #${{ github.event.pull_request.number }} ("${{ github
 #
 
 on:
-  - pull_request_target
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
+  label-remove:
+    permissions:
+      contents: read # for pascalgn/size-label-action to determine modified files
+      pull-requests: write # for pascalgn/size-label-action to add labels to PRs
+    name: "Remove Ready to merge"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: PauMAVA/add-remove-label-action@v1.0.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          add: ""
+          remove: "Ready to merge"
+
   label-category:
     permissions:
       contents: read # for actions/labeler to determine modified files


### PR DESCRIPTION
# Description

Also remove "Ready to merge" in case PR is changed / fresh

# How Has This Been Tested?

On private repo.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
