### PR TITLE
Radxa Zero 3W/E - edge - switch to mainline uboot 2024.10

### DIFF
--- a/config/boards/radxa-zero3.csc
+++ b/config/boards/radxa-zero3.csc
@@ -37,7 +37,6 @@ function post_family_config_branch_edge__radxa-zero3_use_mainline_uboot() {
 	BOOTSOURCE="https://github.com/u-boot/u-boot"
 	BOOTBRANCH="tag:v2024.10"
 	BOOTPATCHDIR="v2024.10"
-	BOOTPATCHDIR="u-boot-zero3" # Empty
 
 	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 

--- a/config/boards/radxa-zero3.csc
+++ b/config/boards/radxa-zero3.csc
@@ -32,10 +32,11 @@ function post_family_config__radxa-zero3_use_vendor_uboot() {
 	}
 }
 
-function post_family_config_branch_edge__radxa-zero3_use_kwiboo_uboot() {
+function post_family_config_branch_edge__radxa-zero3_use_mainline_uboot() {
 	BOOTCONFIG="radxa-zero-3-rk3566_defconfig"
-	BOOTSOURCE='https://github.com/Kwiboo/u-boot-rockchip.git'
-	BOOTBRANCH='branch:rk3xxx-2024.07'
+	BOOTSOURCE="https://github.com/u-boot/u-boot"
+	BOOTBRANCH="tag:v2024.10"
+	BOOTPATCHDIR="v2024.10"
 	BOOTPATCHDIR="u-boot-zero3" # Empty
 
 	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"


### PR DESCRIPTION
# Description

Use latest mainline u-boot tag instead of fork.
Needs to be tested by somebody with 3W model on hand as well.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?

- [x] built for Radxa Zero 3 https://paste.armbian.com/domadegile
- [x] boot Radxa Zero 3E 
- - uboot: https://paste.armbian.de/xiwokehiko.yaml
- - armbianmonitor -u: https://paste.armbian.com/cihijetipu
- [ ] boot Radxa Zero 3W

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
