### PR TITLE
Bugfix: patch writing style caused breakage

### DIFF
--- a/patch/kernel/archive/rockchip64-6.11/board-rock3a-0003-add-gpio-names.patch
+++ b/patch/kernel/archive/rockchip64-6.11/board-rock3a-0003-add-gpio-names.patch
@@ -14,74 +14,74 @@ index bb9bdabf1b8e..9536f14b66d9 100644
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
 @@ -275,10 +275,70 @@ &gmac1m1_clkinout
  &gpu {
-        mali-supply = <&vdd_gpu>;
-        status = "okay";
+ 	mali-supply = <&vdd_gpu>;
+ 	status = "okay";
  };
  
 +&gpio0 {
-+        gpio-line-names =
-+                /* GPIO0_A0 - A7 */
-+                "", "", "", "", "", "", "", "",
-+                /* GPIO0_B0 - B7 */
-+                "", "", "", "pin-28 [GPIO0_B3]", "pin-27 [GPIO0_B4]", "pin-7 [GPIO0_B5]", "pin-16 [GPIO0_B6]", "",
-+                /* GPIO0_C0 - C7 */
-+                "", "pin-22 [GPIO0_C1]", "", "", "", "", "", "",
-+                /* GPIO0_D0 - D7 */
-+                "pin-10 [GPIO0_D0]", "pin-8 [GPIO0_D1]", "", "", "", "", "", "";
++		gpio-line-names =
++				/* GPIO0_A0 - A7 */
++				"", "", "", "", "", "", "", "",
++				/* GPIO0_B0 - B7 */
++				"", "", "", "pin-28 [GPIO0_B3]", "pin-27 [GPIO0_B4]", "pin-7 [GPIO0_B5]", "pin-16 [GPIO0_B6]", "",
++				/* GPIO0_C0 - C7 */
++				"", "pin-22 [GPIO0_C1]", "", "", "", "", "", "",
++				/* GPIO0_D0 - D7 */
++				"pin-10 [GPIO0_D0]", "pin-8 [GPIO0_D1]", "", "", "", "", "", "";
 +};
 +
 +&gpio1 {
-+        gpio-line-names =
-+                /* GPIO1_A0 - A7 */
-+                "pin-3 [GPIO1_A0]", "pin-5 [GPIO1_A1]", "", "", "", "", "", "",
-+                /* GPIO1_B0 - B7 */
-+                "", "", "", "", "", "", "", "",
-+                /* GPIO1_C0 - C7 */
-+                "pin-15 [GPIO0_C0]", "", "", "", "", "", "", "",
-+                /* GPIO1_D0 - D7 */
-+                "", "", "", "", "", "", "", "";
++		gpio-line-names =
++				/* GPIO1_A0 - A7 */
++				"pin-3 [GPIO1_A0]", "pin-5 [GPIO1_A1]", "", "", "", "", "", "",
++				/* GPIO1_B0 - B7 */
++				"", "", "", "", "", "", "", "",
++				/* GPIO1_C0 - C7 */
++				"pin-15 [GPIO0_C0]", "", "", "", "", "", "", "",
++				/* GPIO1_D0 - D7 */
++				"", "", "", "", "", "", "", "";
 +};
 +
 +&gpio2 {
-+        gpio-line-names =
-+                /* GPIO2_A0 - A7 */
-+                "", "", "", "", "", "", "", "",
-+                /* GPIO2_B0 - B7 */
-+                "", "", "", "", "", "", "", "",
-+                /* GPIO2_C0 - C7 */
-+                "", "", "", "", "", "", "", "",
-+                /* GPIO2_D0 - D7 */
-+                "", "", "", "", "", "", "", "pin-29 [GPIO2_D7]";
++		gpio-line-names =
++				/* GPIO2_A0 - A7 */
++				"", "", "", "", "", "", "", "",
++				/* GPIO2_B0 - B7 */
++				"", "", "", "", "", "", "", "",
++				/* GPIO2_C0 - C7 */
++				"", "", "", "", "", "", "", "",
++				/* GPIO2_D0 - D7 */
++				"", "", "", "", "", "", "", "pin-29 [GPIO2_D7]";
 +};
 +
 +&gpio3 {
-+        gpio-line-names =
-+                /* GPIO3_A0 - A7 */
-+                "pin-31 [GPIO3_A0]", "", "pin-36 [GPIO3_A2]", "pin-12 [GPIO3_A3]", "pin-35 [GPIO3_A4]", "pin-40 [GPIO3_A5]", "pin-38 [GPIO3_A6]", "",
-+                /* GPIO3_B0 - B7 */
-+                "", "", "pin-18 [GPIO3_B2]", "", "", "", "", "",
-+                /* GPIO3_C0 - C7 */
-+                "", "", "pin-32 [GPIO3_C2]", "pin-33 [GPIO3_C3]", "pin-11 [GPIO3_C4]", "pin-13 [GPIO3_C5]", "", "",
-+                /* GPIO3_D0 - D7 */
-+                "", "", "", "", "", "", "", "";
++		gpio-line-names =
++				/* GPIO3_A0 - A7 */
++				"pin-31 [GPIO3_A0]", "", "pin-36 [GPIO3_A2]", "pin-12 [GPIO3_A3]", "pin-35 [GPIO3_A4]", "pin-40 [GPIO3_A5]", "pin-38 [GPIO3_A6]", "",
++				/* GPIO3_B0 - B7 */
++				"", "", "pin-18 [GPIO3_B2]", "", "", "", "", "",
++				/* GPIO3_C0 - C7 */
++				"", "", "pin-32 [GPIO3_C2]", "pin-33 [GPIO3_C3]", "pin-11 [GPIO3_C4]", "pin-13 [GPIO3_C5]", "", "",
++				/* GPIO3_D0 - D7 */
++				"", "", "", "", "", "", "", "";
 +};
 +
 +&gpio4 {
-+        gpio-line-names =
-+                /* GPIO4_A0 - A7 */
-+                "", "", "", "", "", "", "", "",
-+                /* GPIO4_B0 - B7 */
-+                "", "", "", "", "", "", "", "",
-+                /* GPIO4_C0 - C7 */
-+                "", "", "pin-21 [GPIO4_C2]", "pin-19 [GPIO4_C3]", "", "pin-21 [GPIO4_C5]", "pin-24 [GPIO4_C6]", "",
-+                /* GPIO4_D0 - D7 */
-+                "", "pin-26 [GPIO4_D1]", "", "", "", "", "", "";
++		gpio-line-names =
++				/* GPIO4_A0 - A7 */
++				"", "", "", "", "", "", "", "",
++				/* GPIO4_B0 - B7 */
++				"", "", "", "", "", "", "", "",
++				/* GPIO4_C0 - C7 */
++				"", "", "pin-21 [GPIO4_C2]", "pin-19 [GPIO4_C3]", "", "pin-21 [GPIO4_C5]", "pin-24 [GPIO4_C6]", "",
++				/* GPIO4_D0 - D7 */
++				"", "pin-26 [GPIO4_D1]", "", "", "", "", "", "";
 +};
 +
  &hdmi {
-        avdd-0v9-supply = <&vdda0v9_image>;
-        avdd-1v8-supply = <&vcca1v8_image>;
-        pinctrl-names = "default";
-        pinctrl-0 = <&hdmitx_scl &hdmitx_sda &hdmitxm1_cec>;
+ 	avdd-0v9-supply = <&vdda0v9_image>;
+ 	avdd-1v8-supply = <&vcca1v8_image>;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&hdmitx_scl &hdmitx_sda &hdmitxm1_cec>;
 -- 
 Created with Armbian build tools https://github.com/armbian/build


### PR DESCRIPTION
# Description

For some reason added patch had spaces instead of tabs. It could be a bug in the IDE / wrong readout of editor config. 

@EvilOlaf I also experienced some troubles with Code recently. Perhaps its related.

# How Has This Been Tested?

- [x] Manual patch apply works after this

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
