### PR TITLE
UX bugfix: on first run we display some warnings if userspace is unsupported

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -11,7 +11,7 @@
 [[ -f /etc/lsb-release ]] && . /etc/lsb-release
 [[ -f /etc/os-release ]] && . /etc/os-release
 [[ -z "$DISTRIB_CODENAME" ]] && DISTRIB_CODENAME="${VERSION_CODENAME}"
-[[ -n "$DISTRIB_CODENAME" && -f /etc/armbian-distribution-status ]] && DISTRIBUTION_STATUS=$(grep "$DISTRIB_CODENAME" /etc/armbian-distribution-status | cut -d"=" -f2)
+[[ -n "$DISTRIB_CODENAME" && -f /etc/armbian-distribution-status ]] && DISTRIBUTION_STATUS=$(grep "$DISTRIB_CODENAME" /etc/armbian-distribution-status | cut -d"=" -f2 | cut -d";" -f1)
 
 . /etc/armbian-release
 


### PR DESCRIPTION
# Description

Since expanding distribution status with upgrade target, this condition stop working

Related: https://github.com/armbian/build/pull/7303

# How Has This Been Tested?

Manually.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings