### PR TITLE
sunxi 6.11: Switch to v6.11.6, bugfix temperature interface for h616, h618

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -36,7 +36,7 @@ case $BRANCH in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.11" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.11.2"
+		declare -g KERNELBRANCH="tag:v6.11.6"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -37,7 +37,7 @@ case $BRANCH in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.11" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.11.2"
+		declare -g KERNELBRANCH="tag:v6.11.6"
 		;;
 esac
 

--- a/patch/kernel/archive/sunxi-6.11/Fix-broken-allwinner-sram-dependency-on-h616-h618.patch
+++ b/patch/kernel/archive/sunxi-6.11/Fix-broken-allwinner-sram-dependency-on-h616-h618.patch
@@ -1,0 +1,53 @@
+From 44a2030f79e43ec5300d94da2dbd5b7053d62fce Mon Sep 17 00:00:00 2001
+From: "Steinar H. Gunderson" <steinar+kernel@gunderson.no>
+Date: Mon, 4 Nov 2024 15:35:38 +0000
+Subject: Fix broken allwinner,sram dependency on h616, h618
+
+On BigTreeTech CB1, the thermal sensor has an allwinner,sram
+property pointing to <&syscon>. However, Armbian has an out-of-tree
+kernel patch that creates dependencies based on allwinner,sram
+properties, which assumes that they point to sram nodes exactly
+two levels below the syscon node (instead of the syscon itself).
+This manifests itself as the thermal sensor refusing to load with
+a nonsensical error message:
+
+  [   23.775976] platform 5070400.thermal-sensor: deferred probe pending: platform: wait for supplier
+
+Note that it does not say _which_ supplier it is waiting for
+(the message ends in a space and then no supplier). The patch
+was unproblematic in the 5.6 megous patch set, where it was
+introduced, and in 6.6, which is current for Armbian, but in
+6.8, the sun8i-thermal driver got mainlined, with this extra
+property compared to the out-of-tree version we used before
+(since it wants to clear a special bit at 0x300000 instead of
+relying on the firmware to do so before kernel boot).
+
+Fix by being a bit more flexible when we walk up the tree,
+so that we always stop at the syscon node.
+
+Tested on a Sovol SV08, which is CB1-based.
+
+Signed-off-by: Steinar H. Gunderson <steinar+kernel@gunderson.no>
+---
+ drivers/of/property.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/of/property.c b/drivers/of/property.c
+index 6fcfcda9d9ad..f00f2b129df8 100644
+--- a/drivers/of/property.c
++++ b/drivers/of/property.c
+@@ -1370,8 +1370,9 @@ static struct device_node *parse_allwinner_sram(struct device_node *np,
+ 		return NULL;
+ 
+ 	sram_node = of_parse_phandle(np, prop_name, 0);
+-	sram_node = of_get_parent(sram_node);
+-	sram_node = of_get_parent(sram_node);
++	while (sram_node && !of_node_is_type(sram_node, "syscon")) {
++		sram_node = of_get_parent(sram_node);
++	}
+ 
+ 	return sram_node;
+ }
+-- 
+2.35.3
+

--- a/patch/kernel/archive/sunxi-6.11/patches.megous/usb-serial-option-add-reset_resume-callback-for-WWAN-devices.patch
+++ b/patch/kernel/archive/sunxi-6.11/patches.megous/usb-serial-option-add-reset_resume-callback-for-WWAN-devices.patch
@@ -1,4 +1,4 @@
-From 5b647b27a9a1727a43c7e616d0afa20b4c247b33 Mon Sep 17 00:00:00 2001
+From 27d4fc73c42a991fe4daf0731eee913491757cd7 Mon Sep 17 00:00:00 2001
 From: Thomas Thorne <Thomas.Thorne@Net2Edge.com>
 Date: Tue, 20 Sep 2022 20:34:57 -0400
 Subject: usb: serial: option: add 'reset_resume' callback for WWAN devices
@@ -17,10 +17,10 @@ However the rest of the patch is not needed/already upstreamed.
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
-index 176f38750ad5..ec784468f05a 100644
+index 55886b64cadd..df641a38f274 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
-@@ -2404,6 +2404,7 @@ static struct usb_serial_driver option_1port_device = {
+@@ -2412,6 +2412,7 @@ static struct usb_serial_driver option_1port_device = {
  #ifdef CONFIG_PM
  	.suspend           = usb_wwan_suspend,
  	.resume            = usb_wwan_resume,


### PR DESCRIPTION
# Description

- Switch to v6.11.6 and re-extract patches
- Fix broken allwinner,sram dependency on h616, h618
  The discussion: https://forum.armbian.com/topic/46871-sv08-cant-find-thermal-zone-on-6112/

# How Has This Been Tested?

- [ ] Tested on a Sovol SV08, which is CB1-based.
- [x] Test build

