### PR TITLE
Fix partitioning root UUID bug in /etc/crypttab. New option: CRYPTROOT_MAPPER.

### DIFF
--- a/extensions/fs-cryptroot-support.sh
+++ b/extensions/fs-cryptroot-support.sh
@@ -26,10 +26,10 @@ function prepare_root_device__encrypt_root_device() {
 	check_loop_device "$rootdevice"
 	display_alert "Extension: ${EXTENSION}: Encrypting root partition with LUKS..." "cryptsetup luksFormat $rootdevice" ""
 	echo -n $CRYPTROOT_PASSPHRASE | cryptsetup luksFormat $CRYPTROOT_PARAMETERS $rootdevice -
-	echo -n $CRYPTROOT_PASSPHRASE | cryptsetup luksOpen $rootdevice $ROOT_MAPPER -
+	echo -n $CRYPTROOT_PASSPHRASE | cryptsetup luksOpen $rootdevice $CRYPTROOT_MAPPER -
 	display_alert "Extension: ${EXTENSION}: Root partition encryption complete." "" "ext"
 	# TODO: pass /dev/mapper to Docker
-	rootdevice=/dev/mapper/$ROOT_MAPPER # used by `mkfs` and `mount` commands
+	rootdevice=/dev/mapper/$CRYPTROOT_MAPPER # used by `mkfs` and `mount` commands
 }
 
 function pre_install_kernel_debs__adjust_dropbear_configuration() {

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -166,10 +166,10 @@ function do_main_configuration() {
 	# Support for LUKS / cryptroot
 	if [[ $CRYPTROOT_ENABLE == yes ]]; then
 		enable_extension "fs-cryptroot-support" # add the tooling needed, cryptsetup
-		ROOT_MAPPER="armbian-root"              # TODO: fixed name can't be used for parallel image building (rpardini: ?)
 		if [[ -z $CRYPTROOT_PASSPHRASE ]]; then # a passphrase is mandatory if rootfs encryption is enabled
 			exit_with_error "Root encryption is enabled but CRYPTROOT_PASSPHRASE is not set"
 		fi
+		[[ -z $CRYPTROOT_MAPPER ]] && CRYPTROOT_MAPPER="armbian-root" # TODO: fixed name can't be used for parallel image building (rpardini: ?)
 		[[ -z $CRYPTROOT_SSH_UNLOCK ]] && CRYPTROOT_SSH_UNLOCK=yes
 		[[ -z $CRYPTROOT_SSH_UNLOCK_PORT ]] && CRYPTROOT_SSH_UNLOCK_PORT=2022
 		# Default to pdkdf2, this used to be the default with cryptroot <= 2.0, however

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -310,7 +310,7 @@ function prepare_partitions() {
 		local rootfs
 		if [[ $CRYPTROOT_ENABLE == yes ]]; then
 			# map the LUKS container partition via its UUID to be the 'cryptroot' device
-			echo "$ROOT_MAPPER UUID=${root_part_uuid} none luks" >> $SDCARD/etc/crypttab
+			echo "$CRYPTROOT_MAPPER UUID=${root_part_uuid} none luks" >> $SDCARD/etc/crypttab
 			rootfs=$rootdevice # used in fstab
 		else
 			rootfs="UUID=$(blkid -s UUID -o value $rootdevice)"
@@ -369,7 +369,7 @@ function prepare_partitions() {
 	if [[ -f $SDCARD/boot/armbianEnv.txt ]]; then
 		display_alert "Found armbianEnv.txt" "${SDCARD}/boot/armbianEnv.txt" "debug"
 		if [[ $CRYPTROOT_ENABLE == yes ]]; then
-			echo "rootdev=$rootdevice cryptdevice=UUID=${root_part_uuid}:$ROOT_MAPPER" >> "${SDCARD}/boot/armbianEnv.txt"
+			echo "rootdev=$rootdevice cryptdevice=UUID=${root_part_uuid}:$CRYPTROOT_MAPPER" >> "${SDCARD}/boot/armbianEnv.txt"
 		else
 			echo "rootdev=$rootfs" >> "${SDCARD}/boot/armbianEnv.txt"
 		fi
@@ -389,7 +389,7 @@ function prepare_partitions() {
 		sed -i -e "s/rootfstype \"ext4\"/rootfstype \"$ROOTFS_TYPE\"/" $SDCARD/boot/boot.ini
 		if [[ $CRYPTROOT_ENABLE == yes ]]; then
 			rootpart="UUID=${root_part_uuid}"
-			sed -i 's/^setenv rootdev .*/setenv rootdev "\/dev\/mapper\/'$ROOT_MAPPER' cryptdevice='$rootpart':'$ROOT_MAPPER'"/' $SDCARD/boot/boot.ini
+			sed -i 's/^setenv rootdev .*/setenv rootdev "\/dev\/mapper\/'$CRYPTROOT_MAPPER' cryptdevice='$rootpart':'$CRYPTROOT_MAPPER'"/' $SDCARD/boot/boot.ini
 		else
 			sed -i 's/^setenv rootdev .*/setenv rootdev "'$rootfs'"/' $SDCARD/boot/boot.ini
 		fi

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -300,7 +300,7 @@ function prepare_partitions() {
 		wait_for_disk_sync "after mkfs" # force writes to be really flushed
 
 		# store in readonly global for usage in later hooks
-		root_part_uuid="$(blkid -s UUID -o value ${rootdevice})"
+		root_part_uuid="$(blkid -s UUID -o value ${LOOP}p${rootpart})"
 		declare -g -r ROOT_PART_UUID="${root_part_uuid}"
 
 		display_alert "Mounting rootfs" "$rootdevice (UUID=${ROOT_PART_UUID})"

--- a/lib/functions/image/rootfs-to-image.sh
+++ b/lib/functions/image/rootfs-to-image.sh
@@ -119,7 +119,7 @@ function create_image_from_sdcard_rootfs() {
 	wait_for_disk_sync "before umount MOUNT"
 
 	umount_chroot_recursive "${MOUNT}" "MOUNT"
-	[[ $CRYPTROOT_ENABLE == yes ]] && cryptsetup luksClose "$ROOT_MAPPER"
+	[[ $CRYPTROOT_ENABLE == yes ]] && cryptsetup luksClose "$CRYPTROOT_MAPPER"
 
 	call_extension_method "post_umount_final_image" "config_post_umount_final_image" <<- 'POST_UMOUNT_FINAL_IMAGE'
 		*allow config to hack into the image after the unmount*

--- a/lib/functions/rootfs/trap-rootfs.sh
+++ b/lib/functions/rootfs/trap-rootfs.sh
@@ -63,7 +63,7 @@ function trap_handler_cleanup_rootfs_and_image() {
 	# unmount tmpfs mounted on SDCARD if it exists. #@TODO: move to new tmpfs-utils scheme
 	mountpoint -q "${SDCARD}" && umount "${SDCARD}"
 
-	[[ $CRYPTROOT_ENABLE == yes ]] && cryptsetup luksClose "${ROOT_MAPPER}"
+	[[ $CRYPTROOT_ENABLE == yes ]] && cryptsetup luksClose "${CRYPTROOT_MAPPER}"
 
 	if [[ "${PRESERVE_SDCARD_MOUNT}" == "yes" ]]; then
 		display_alert "Preserving SD card mount" "trap_handler_cleanup_rootfs_and_image" "warn"


### PR DESCRIPTION
# Description
Fix partitioning root UUID bug in /etc/crypttab.
New option: CRYPTROOT_MAPPER. Make ROOT_MAPPER name for CRYPTROOT changable.

# How Has This Been Tested?
- [x] Build before patch and get error 
- [x] Build after patch and check image 

# How To Repoduce
1) Build with command `./compile.sh build CRYPTROOT_ENABLE=yes CRYPTROOT_PASSPHRASE="toor" CRYPTROOT_SSH_UNLOCK=yes`
2) `sudo losetup --show --partscan --find Armbian-unofficial_*-crypt.img`
3) `sudo blkid /dev/loop*`
4) Mount boot from loop (for example /dev/loop0p1) 
5) Check that UUID in armbianEnv.txt (`rootdev=/dev/mapper/armbian-root cryptdevice=UUID=${UUID}:armbian-root`) not exists in blkid output
6) Try to write into sd and get unknown UUID error in initramfs
7) Retry with patch
