### PR TITLE
Add community support for Rock5B+

### DIFF
--- a/config/boards/rock-5b-plus.csc
+++ b/config/boards/rock-5b-plus.csc
@@ -1,0 +1,27 @@
+# Rockchip RK3588 SoC octa core 4-16GB SoC 2.5GBe eMMC USB3 NvME
+BOARD_NAME="Rock 5B Plus"
+BOARDFAMILY="rockchip-rk3588"
+BOARD_MAINTAINER=""
+BOOTCONFIG="rock-5b-plus-rk3588_defconfig"
+KERNEL_TARGET="vendor"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3588-radxa-rock-5b+.dtb"
+BOOT_SCENARIO="spl-blobs"
+BOOT_SUPPORT_SPI="yes"
+BOOT_SPI_RKSPI_LOADER="yes"
+IMAGE_PARTITION_TABLE="gpt"
+declare -g UEFI_EDK2_BOARD_ID="rock-5bplus" # This _only_ used for uefi-edk2-rk3588 extension
+
+function post_family_tweaks__rock5b_naming_audios() {
+	display_alert "$BOARD" "Renaming rock5b audios" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi1-sound", ENV{SOUND_DESCRIPTION}="HDMI1 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmiin-sound", ENV{SOUND_DESCRIPTION}="HDMI-In Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-dp0-sound", ENV{SOUND_DESCRIPTION}="DP0 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-dp1-sound", ENV{SOUND_DESCRIPTION}="DP1 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-es8316-sound", ENV{SOUND_DESCRIPTION}="ES8316 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+
+	return 0
+}


### PR DESCRIPTION
# Description

After [adding the device tree to armbian/rockchip-linux](https://github.com/armbian/linux-rockchip/commit/34dcf4a7ac5c37315236e9961690ac0005f18122) and it being tested on real HW to confirm functionality this is the last step to add Rock5B+ to the build system.
I'm considering maintaining this board in the future but for now this is a community addition

# How Has This Been Tested?

- [x] Build the image successfully locally
- [x] Ran the image on real HW (see the link above to armbian/rockchip-linux)

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
