### PR TITLE
MOTD: declutter list of commands in motd. Everything starts with armbian-config

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/41-commands
+++ b/packages/bsp/common/etc/update-motd.d/41-commands
@@ -21,9 +21,8 @@ done
 # text, sudo / without, command, condition
 # condition can be fairly complex
 list=(
-    "System config","sudo ","armbian-config","true"
-    "System monitor","","htop","true"
-    "Installer","","armbian-install","! grep -q \"INSTALLED=true\" /etc/armbian-image-release 2> /dev/null && ((($(date +%s) - $(stat -c +%X /etc/armbian-image-release 2> /dev/null)) < 86400))"
+    "Configuration","","armbian-config","true"
+    "Monitoring","","htop","true"
 )
 
 # verify if command exits on the system


### PR DESCRIPTION
# Description

We should provide limited lists of commands and suggest using armbian-config for everything.

![image](https://github.com/user-attachments/assets/9f1a1419-bfab-49bc-aba4-a1f4a8dd2a62)

# How Has This Been Tested?

- [x] Manual

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings