### PR TITLE
fix `iostat` error on `MINIMAL`

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -973,7 +973,7 @@ CollectSupportInfo() {
 		cat /etc/resolv.conf
 	)" ||
 		echo -e "\n### resolv.conf does not exist or readable"
-	echo -e "\n### Current sysinfo:\n\n$(iostat -p ALL | grep -v "^loop")\n\n$(vmstat -w)\n\n$(free -h)\n\n$(zramctl 2> /dev/null)\n\n$(uptime)\n\n$(dmesg | tail -n 250)"
+	echo -e "\n### Current sysinfo:\n\n$(command -v iostat >/dev/null 2>&1 && iostat -p ALL | grep -v "^loop")\n\n$(vmstat -w)\n\n$(free -h)\n\n$(zramctl 2> /dev/null)\n\n$(uptime)\n\n$(dmesg | tail -n 250)"
 	echo -e "\n"
 	[[ "$(id -u)" -eq "0" ]] && for sysfsnode in /proc/sys/vm/*; do sysctl $(echo ${sysfsnode} | sed 's|/proc/sys/vm/|vm.|'); done
 	echo -e "\n### interrupts:\n$(cat /proc/interrupts)"


### PR DESCRIPTION
# Description

`MINIMAL` do not have `iostat` so suppress the error occurring when doing `armbianmonitor -u` on such systems.
I am pretty sure there is a nicer way to implement this. So some wizard may come up with something better.

# How Has This Been Tested?

- [x] do `armbianmonitor -u` on a minimal system and check if an error occurs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
