### PR TITLE
rockchip64: fix crash dump on eager led setting with tm16xx led driver

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/general-driver-tm16xx-led-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.12/general-driver-tm16xx-led-driver.patch
@@ -987,6 +987,10 @@ index 000000000000..111111111111
 +		return ret;
 +	}
 +
++	mutex_init(&display->lock);
++	INIT_WORK(&display->flush_brightness, tm16xx_display_flush_brightness);
++	INIT_WORK(&display->flush_display, tm16xx_display_flush_data);
++
 +	display->main_led.name = TM16XX_DEVICE_NAME;
 +	display->main_led.brightness = display->controller->max_brightness;
 +	display->main_led.max_brightness = display->controller->max_brightness;
@@ -1035,10 +1039,6 @@ index 000000000000..111111111111
 +
 +		i++;
 +	}
-+
-+	mutex_init(&display->lock);
-+	INIT_WORK(&display->flush_brightness, tm16xx_display_flush_brightness);
-+	INIT_WORK(&display->flush_display, tm16xx_display_flush_data);
 +
 +	ret = tm16xx_display_init(display);
 +	if (ret < 0) {

--- a/patch/kernel/archive/rockchip64-6.6/general-driver-tm16xx-led-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.6/general-driver-tm16xx-led-driver.patch
@@ -988,6 +988,10 @@ index 000000000000..d938b0166e74
 +		return ret;
 +	}
 +
++	mutex_init(&display->lock);
++	INIT_WORK(&display->flush_brightness, tm16xx_display_flush_brightness);
++	INIT_WORK(&display->flush_display, tm16xx_display_flush_data);
++
 +	display->main_led.name = TM16XX_DEVICE_NAME;
 +	display->main_led.brightness = display->controller->max_brightness;
 +	display->main_led.max_brightness = display->controller->max_brightness;
@@ -1036,10 +1040,6 @@ index 000000000000..d938b0166e74
 +
 +		i++;
 +	}
-+
-+	mutex_init(&display->lock);
-+	INIT_WORK(&display->flush_brightness, tm16xx_display_flush_brightness);
-+	INIT_WORK(&display->flush_display, tm16xx_display_flush_data);
 +
 +	ret = tm16xx_display_init(display);
 +	if (ret < 0) {


### PR DESCRIPTION
# Description

Minor change in tm16xx prevents crashing at boot when leds are set very early

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2530]

# How Has This Been Tested?

- [x] Built edge kernel and tested on live rk3318-box system

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


[AR-2530]: https://armbian.atlassian.net/browse/AR-2530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ