### PR TITLE
Enable hs200 mode for RockPi S, set CMA to 16M

### DIFF
--- a/config/boards/rockpi-s.conf
+++ b/config/boards/rockpi-s.conf
@@ -66,7 +66,16 @@ function post_family_config___uboot_config() {
 		rules=etc/udev/rules.d
 
 		install -m 755 $bsp/lib/udev/fixEtherAddr $destination/lib/udev &&
-			install -m 644 $bsp/$rules/05-fixMACaddress.rules $destination/$rules
+		install -m 644 $bsp/$rules/05-fixMACaddress.rules $destination/$rules
 	}
 
+}
+
+function pre_install_kernel_debs__enforce_cma() {
+	# Set CMA to 16 megabytes, to provide more usable RAM since Rock Pi S
+	# has usually a small amount of DRAM (512MB)
+	display_alert "$BOARD" "set CMA size to 16MB due to small DRAM size"
+	run_host_command_logged echo "extraargs=cma=16M" ">>" "${SDCARD}"/boot/armbianEnv.txt
+
+        return 0
 }

--- a/patch/kernel/archive/rockchip64-6.12/board-rockpis-0030-arm64-dts-rk3308-enable-hs200-mode.patch
+++ b/patch/kernel/archive/rockchip64-6.12/board-rockpis-0030-arm64-dts-rk3308-enable-hs200-mode.patch
@@ -1,0 +1,24 @@
+From 395bc247144869b1a78c40872d38049f56ebfaf9 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Thu, 7 Nov 2024 18:37:34 +0100
+Subject: [PATCH] rockpi-s emmc support hs200 mode, enable it
+
+---
+ arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts b/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
+index 5ca0cc19f92c..d189eceb6fb2 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
+@@ -139,6 +139,7 @@ &emmc {
+ 	non-removable;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd>;
++	mmc-hs200-1_8v;
+ 	vmmc-supply = <&vcc_io>;
+ 	status = "okay";
+ };
+-- 
+2.43.0
+

--- a/patch/kernel/archive/rockchip64-6.6/board-rockpis-0030-arm64-dts-rk3308-enable-hs200-mode.patch
+++ b/patch/kernel/archive/rockchip64-6.6/board-rockpis-0030-arm64-dts-rk3308-enable-hs200-mode.patch
@@ -1,0 +1,24 @@
+From 395bc247144869b1a78c40872d38049f56ebfaf9 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Thu, 7 Nov 2024 18:37:34 +0100
+Subject: [PATCH] rockpi-s emmc support hs200 mode, enable it
+
+---
+ arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts b/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
+index 5ca0cc19f92c..d189eceb6fb2 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
+@@ -139,6 +139,7 @@ &emmc {
+ 	non-removable;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd>;
++	mmc-hs200-1_8v;
+ 	vmmc-supply = <&vcc_io>;
+ 	status = "okay";
+ };
+-- 
+2.43.0
+


### PR DESCRIPTION
# Description

Rock Pi S (and it's SoM variant) eMMC should be capable of handling HS200 mode instead of regular High Speed, with improved throughtput (~130mb/s vs. ~45mb/s).

Also these boards have a small amount of DRAM (usually 512MB), so set `extraargs=cma=16M` in `/boot/armbianEnv.txt` to keep more memory available for general system.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2515]

# How Has This Been Tested?

- [x] Image built with current 6.6 kernel and tested on Rock Pi S Core SoM
```
root@rockpi-s:~# dmesg
...
[    0.000000] cma: Reserved 16 MiB at 0x000000001e600000 on node -1
[    0.000000] Kernel command line: root=UUID=9de0bf09-c190-436b-bc84-7377053017af rootwait rootfstype=ext4 splash=verbose console=ttyS0,1500000  consoleblank=0 loglevel=1 ubootpart=ed524a94-01 usb-storage.quirks= cma=16M  cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory
[    0.000000] Memory: 449724K/522240K available (17024K kernel code, 2320K rwdata, 5264K rodata, 4736K init, 604K bss, 56132K reserved, 16384K cma-reserved)
...
[    2.201708] mmc_host mmc0: card is non-removable.
[    2.214697] mmc_host mmc0: Bus speed (slot 0) = 400000Hz (slot req 400000Hz, actual 400000HZ div = 0)
[    2.293256] mmc_host mmc0: Bus speed (slot 0) = 50176000Hz (slot req 52000000Hz, actual 50176000HZ div = 0)
[    2.293412] mmc_host mmc0: Bus speed (slot 0) = 147456000Hz (slot req 150000000Hz, actual 147456000HZ div = 0)
[    3.005722] mmc0: new HS200 MMC card at address 0001
[    3.008719] mmcblk0: mmc0:0001 AJTD4R 14.6 GiB
[    3.017024] mmcblk0boot0: mmc0:0001 AJTD4R 4.00 MiB
[    3.024627] mmcblk0boot1: mmc0:0001 AJTD4R 4.00 MiB
[    3.029896] mmcblk0rpmb: mmc0:0001 AJTD4R 4.00 MiB, chardev (243:0)
...
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


[AR-2515]: https://armbian.atlassian.net/browse/AR-2515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ