### PR TITLE
hack: trixie has lost its software-properties-common package so get rid of it for all Debian releases

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -343,8 +343,6 @@ function do_main_configuration() {
 	declare -g -r PACKAGE_LIST_FAMILY="${PACKAGE_LIST_FAMILY}"
 	declare -g -r PACKAGE_LIST_FAMILY_REMOVE="${PACKAGE_LIST_FAMILY_REMOVE}"
 
-	if [[ $RELEASE == trixie || $ARCH == riscv64 ]]; then remove_packages "cpufrequtils"; fi # this will remove from rootfs as well
-
 	display_alert "Done with do_main_configuration" "do_main_configuration" "debug"
 }
 

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -300,6 +300,9 @@ function config_post_main() {
 	# Do some sanity checks for userspace stuff, if RELEASE/DESKTOP_ENVIRONMENT is set.
 	check_config_userspace_release_and_desktop
 
+	# late Userspace / package list fixes; RELEASE and DISTRIBUTION must be set.
+	fix_userspace_packages_release_and_distro
+
 	track_general_config_variables "before calling extension_finish_config"
 	display_alert "Extensions: finish configuration" "extension_finish_config" "debug"
 	call_extension_method "extension_finish_config" <<- 'EXTENSION_FINISH_CONFIG'
@@ -378,6 +381,19 @@ function check_config_userspace_release_and_desktop() {
 	fi
 
 	return 0
+}
+
+function fix_userspace_packages_release_and_distro() {
+	display_alert "fix_userspace_packages_release_and_distro" "For distro '${DISTRIBUTION}' release '${RELEASE}'" "debug"
+
+	# Some old hack from the past, not sure if it's still needed. Originally from https://github.com/armbian/build/pull/5881
+	if [[ $RELEASE == trixie || $ARCH == riscv64 ]]; then remove_packages "cpufrequtils"; fi # this will remove from rootfs as well
+
+	# Debian: no need for this package in the rootfs, as it provides add-apt-repository which is not used on our Debian builds
+	if [[ "${DISTRIBUTION}" == "Debian" ]]; then
+		display_alert "Not-installing software-properties-common" "For distro '${DISTRIBUTION}' release '${RELEASE}'" "warn"
+		remove_packages "software-properties-common" "software-properties-gtk" "software-properties-common"
+	fi
 }
 
 # Some utility functions


### PR DESCRIPTION
#### hack: trixie has lost its software-properties-common package so get rid of it for all Debian releases

- hack: trixie has lost its software-properties-common package so get rid of it for all Debian releases
  - https://tracker.debian.org/news/1579223/software-properties-removed-from-testing/
  - that provides add-apt-repository, but we don't use that on Debian, hopefully
  - move also cpufrequtils hack (which requires release) to specific function after userspace checks and when DISTRIBUTION is set
  - `software-properties-gtk` if of course also gone, so remove that for desktop's sake