### PR TITLE
thinkpad-x13s: bump to jhovold's wip/sc8280xp-6.12-rc4

### DIFF
--- a/config/boards/thinkpad-x13s.wip
+++ b/config/boards/thinkpad-x13s.wip
@@ -30,7 +30,7 @@ declare -g BOARD_FIRMWARE_INSTALL="-full"
 
 function post_family_config_branch_sc8280xp__jhovolds_wip_kernel() {
 	declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.12-rc3' # @TODO: this is down to 35 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
+	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.12-rc4' # @TODO: this is down to 27 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
 	declare -g KERNELSOURCE='https://github.com/jhovold/linux.git'
 	declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}" # for this board: linux-arm64-sc8280xp
 	display_alert "Set up jhovold's kernel ${KERNELBRANCH} for" "${BOARD}" "info"

--- a/config/boards/thinkpad-x13s.wip
+++ b/config/boards/thinkpad-x13s.wip
@@ -28,9 +28,9 @@ enable_extension "grub-with-dtb" # important, puts the whole DTB handling in pla
 # Use the full firmware, complete linux-firmware plus Armbian's
 declare -g BOARD_FIRMWARE_INSTALL="-full"
 
-function post_family_config_branch_sc8280xp__jhovolds_69y_kernel() {
+function post_family_config_branch_sc8280xp__jhovolds_wip_kernel() {
 	declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.12-rc2' # @TODO: this is down to 35 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
+	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.12-rc3' # @TODO: this is down to 35 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
 	declare -g KERNELSOURCE='https://github.com/jhovold/linux.git'
 	declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}" # for this board: linux-arm64-sc8280xp
 	display_alert "Set up jhovold's kernel ${KERNELBRANCH} for" "${BOARD}" "info"


### PR DESCRIPTION
#### thinkpad-x13s: bump to jhovold's wip/sc8280xp-6.12-rc4

- thinkpad-x13s: bump to jhovold's wip/sc8280xp-6.12-rc3
  - this is down to 35 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
- thinkpad-x13s: bump to jhovold's wip/sc8280xp-6.12-rc4
  - this is down to 27 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel