### PR TITLE
Add missing node for youyeetoo r1 on current kernel

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.12/dt/rk3588s-youyeetoo-r1.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.12/dt/rk3588s-youyeetoo-r1.dts
@@ -226,6 +226,11 @@
 	mem-supply = <&vdd_cpu_lit_mem_s0>;
 };
 
+&display_subsystem {
+	clocks = <&hdptxphy_hdmi0>;
+	clock-names = "hdmi0_phy_pll";
+};
+
 &gpu {
 	mali-supply = <&vdd_gpu_s0>;
 	status = "okay";


### PR DESCRIPTION
# Description

Lacking such this node on the dts, the hdmi was not working properly

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Direct testing on the device

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings