### PR TITLE
Change development repository domain name to github.armbian.com

### DIFF
--- a/lib/functions/compilation/packages/armbian-config-deb.sh
+++ b/lib/functions/compilation/packages/armbian-config-deb.sh
@@ -66,7 +66,7 @@ compile_armbian-config() {
 
 	# Add development repository to keep rooling release of this tool
 	cat <<- END > ${tmp_dir}/${armbian_config_dir}/etc/apt/sources.list.d/armbian-config.list
-	deb [signed-by=/usr/share/keyrings/armbian.gpg] https://armbian.github.io/configng stable main
+	deb [signed-by=/usr/share/keyrings/armbian.gpg] https://github.armbian.com/configng stable main
 	END
 
 	dpkg_deb_build "${tmp_dir}/${armbian_config_dir}" "armbian-config"


### PR DESCRIPTION
# Description

After bonding Github organisation pages with our domain name, repository pages goes under github.armbian.com/REPOSITORY

# How Has This Been Tested?

- [x] Changed to this repo and install latest armbian-config

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
