### PR TITLE
Revert "Move support of nanopc t6 & lts from edge to current"

### DIFF
--- a/config/boards/nanopct6-lts.conf
+++ b/config/boards/nanopct6-lts.conf
@@ -5,4 +5,5 @@ BOARD_NAME="NanoPC T6 LTS"
 BOARDFAMILY="rockchip-rk3588"
 BOARD_MAINTAINER="SuperKali Tonymac32"
 BOOT_FDT_FILE="rockchip/rk3588-nanopc-t6-lts.dtb" # As opposed to "rockchip/rk3588-nanopc-t6.dtb" for the non-LTS version
-KERNEL_TARGET="current,vendor"
+KERNEL_TARGET="edge,current,vendor"
+KERNEL_TEST_TARGET="vendor,current"

--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -4,7 +4,8 @@ BOARDFAMILY="rockchip-rk3588"
 BOARD_MAINTAINER="SuperKali Tonymac32"
 BOOTCONFIG="nanopc_t6_defconfig" # vendor name, not standard, see hook below, set BOOT_SOC below to compensate
 BOOT_SOC="rk3588"
-KERNEL_TARGET="current,vendor"
+KERNEL_TARGET="edge,current,vendor"
+KERNEL_TEST_TARGET="vendor,current"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3588-nanopc-t6.dtb"
@@ -28,7 +29,7 @@ function post_family_tweaks__nanopct6_naming_audios() {
 }
 
 # Mainline u-boot
-function post_family_config_branch_current__nanopct6_use_mainline_uboot() {
+function post_family_config_branch_edge__nanopct6_use_mainline_uboot() {
 	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
 
 	declare -g BOOTCONFIG="nanopc-t6-rk3588_defconfig"


### PR DESCRIPTION
Reverts armbian/build#7476