### PR TITLE
enable pd negotiation support for bananapim7

### DIFF
--- a/patch/u-boot/legacy/u-boot-radxa-rk35xx/board_bananapim7
+++ b/patch/u-boot/legacy/u-boot-radxa-rk35xx/board_bananapim7
@@ -1,0 +1,1 @@
+board_armsom-sige7


### PR DESCRIPTION
# Description

Bananapi M7 and ArmSoM Sige7 are just the same board, but the uboot pd negotiation patch of bpim7 is missiong. After this commit, there will be no boot loop when using pd power.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=bananapim7 BRANCH=vendor BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=no ENABLE_EXTENSIONS=mesa-vpu`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
