### PR TITLE
armbianmonitor: call `curl` with `--fail` flag so server 400/500 errors actually trigger a retry

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -179,7 +179,7 @@ ParseOptions() {
 						# in clear since otherwise the log becomes worthless due to randomly generated
 						# addresses here and there that might conflict
 						sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
-						curl -s --data-binary @- "https://${paste_server}/log"
+						curl -s --fail --data-binary @- "https://${paste_server}/log"
 					# Check PIPESTATUS to know if everything worked. Any non-zero exit status means something didn't work.
 					for i in "${PIPESTATUS[@]}"; do
 						counter=$((counter + 1))


### PR DESCRIPTION
#### armbianmonitor: call `curl` with `--fail` flag so server 400/500 errors actually trigger a retry

- armbianmonitor: call `curl` with `--fail` flag so server 400/500 errors actually trigger a retry
  - otherwise, curl thinks a 4xx or 5xx error is perfectly acceptable. who knew?