### PR TITLE
Bugfix: Move Bananapi R2PRO to most recent boot loader

### DIFF
--- a/config/boards/bananapim2pro.conf
+++ b/config/boards/bananapim2pro.conf
@@ -10,8 +10,8 @@ MODULES_BLACKLIST="simpledrm" # SimpleDRM conflicts with Panfrost
 FULL_DESKTOP="yes"
 SERIALCON="ttyAML0"
 BOOT_LOGO="desktop"
-BOOTBRANCH_BOARD="tag:v2023.07.02"
-BOOTPATCHDIR="v2023.07.02"
+BOOTBRANCH_BOARD="tag:v2024.07"
+BOOTPATCHDIR="v2024.07"
 
 function fetch_sources_tools__libreelec_amlogic_fip_pre_m2-pro_blob_update() {
 	fetch_from_repo "https://github.com/Dangku/amlogic-boot-fip" "amlogic-boot-fip" "branch:master"


### PR DESCRIPTION
# Description

Current is causing boot loop.

# How Has This Been Tested?

- [ ] Build and boot image with those changes

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings