### PR TITLE
rootfs-to-image: preserve sparse files when moving artefacts to final destination with rsync

### DIFF
--- a/lib/functions/image/rootfs-to-image.sh
+++ b/lib/functions/image/rootfs-to-image.sh
@@ -215,7 +215,7 @@ function move_images_to_final_destination() {
 		done
 	else
 		display_alert "Moving artefacts using rsync to final destination" "${version}" "info"
-		run_host_command_logged rsync -av --no-owner --no-group --remove-source-files "${DESTIMG}/${version}"* "${FINALDEST}"
+		run_host_command_logged rsync -av --sparse --no-owner --no-group --remove-source-files "${DESTIMG}/${version}"* "${FINALDEST}"
 		run_host_command_logged rm -rfv --one-file-system "${DESTIMG}"
 	fi
 	return 0


### PR DESCRIPTION
# Description

Images built on macos did not preserve sparseness and did occupy full apparent size (when created with `FIXED_IMAGE_SIZE`).
Fix it by rsync `--sparse` option

# How Has This Been Tested?

- [x] Build image on MacOS

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
