### PR TITLE
Adjusting aml-s9xx as armbian-install was moved to another location

### DIFF
--- a/config/boards/aml-s9xx-box.tvb
+++ b/config/boards/aml-s9xx-box.tvb
@@ -31,7 +31,7 @@ function post_family_tweaks_bsp__config_aml-s9xx-box_bsp() {
 	run_host_command_logged chmod -v 644 "${destination}"/root/fstab.template
 
 	display_alert "${BOARD}" "Removing armbian-install" "info"
-	run_host_command_logged rm -v "${destination}"/usr/sbin/armbian-install
+	run_host_command_logged rm -v "${destination}"/usr/bin/armbian-install
 
 	display_alert "${BOARD}" "Adding bsp-cli preinst logic" "info"
 	# Inline function! So this function is automatically hashed when this hook is hashed.


### PR DESCRIPTION
# Description

Amlogic tvbox has different install method so armbian-install is being removed. As we moved location of it, we need to adjust its build config.

@SteeManMI 

# Checklist:

- [x] My changes generate no new warnings