### PR TITLE
sunxi-6.11: Switch to v6.11.9; Fix build dtb package

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -36,7 +36,7 @@ case $BRANCH in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.11" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.11.7"
+		declare -g KERNELBRANCH="tag:v6.11.9"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -37,7 +37,7 @@ case $BRANCH in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.11" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.11.7"
+		declare -g KERNELBRANCH="tag:v6.11.9"
 		;;
 esac
 

--- a/patch/kernel/archive/sunxi-6.11/patches.armbian/scripts-add-overlay-compilation-support.patch
+++ b/patch/kernel/archive/sunxi-6.11/patches.armbian/scripts-add-overlay-compilation-support.patch
@@ -1,13 +1,13 @@
-From 0184e44b9caf2fa96cc058f0bb34fd5ca4ca4498 Mon Sep 17 00:00:00 2001
+From 9834ff87ee93495982c223bea78206bda5955e89 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Tue, 1 Feb 2022 21:04:08 +0300
 Subject: scripts: add overlay compilation support
 
 ---
  .gitignore               |  1 +
- scripts/Makefile.dtbinst |  9 ++++++++-
+ scripts/Makefile.dtbinst | 12 +++++++++++-
  scripts/Makefile.lib     | 12 +++++++++++-
- 3 files changed, 20 insertions(+), 2 deletions(-)
+ 3 files changed, 23 insertions(+), 2 deletions(-)
 
 diff --git a/.gitignore b/.gitignore
 index 58fdbb35e2f1..0d683e66d33b 100644
@@ -22,7 +22,7 @@ index 58fdbb35e2f1..0d683e66d33b 100644
  *.so.dbg
  *.su
 diff --git a/scripts/Makefile.dtbinst b/scripts/Makefile.dtbinst
-index 9d920419a62c..b66af344040d 100644
+index 9d920419a62c..d0703c2148cf 100644
 --- a/scripts/Makefile.dtbinst
 +++ b/scripts/Makefile.dtbinst
 @@ -23,6 +23,11 @@ $(dst)/%: $(obj)/%
@@ -37,14 +37,17 @@ index 9d920419a62c..b66af344040d 100644
  
  ifdef CONFIG_ARCH_WANT_FLAT_DTB_INSTALL
  
-@@ -33,7 +38,9 @@ endef
+@@ -33,7 +38,12 @@ endef
  
  $(foreach d, $(sort $(dir $(dtbs))), $(eval $(call gen_install_rules,$(d))))
  
 -dtbs := $(notdir $(dtbs))
-+# Armbian uses subdirectories <overlay> but not <allwinner/overlay>.
-+# delete the vendor's directory
++# Armbian uses subdirectories <overlay> for arm
++# and <allwinner/overlay> for arm64.
++# delete the vendor's directory if the target architecture is an arm.
++ifdef CONFIG_ARM
 +dtbs := $(patsubst $(vendor)%,%,$(dtbs))
++endif
  
  endif # CONFIG_ARCH_WANT_FLAT_DTB_INSTALL
  

--- a/patch/kernel/archive/sunxi-6.11/patches.megous/usb-musb-sunxi-Avoid-enabling-host-side-code-on-SoCs-where-it-s.patch
+++ b/patch/kernel/archive/sunxi-6.11/patches.megous/usb-musb-sunxi-Avoid-enabling-host-side-code-on-SoCs-where-it-s.patch
@@ -1,4 +1,4 @@
-From 2d9f83e8ad93abcdf6da745e3fc7b46d5d75b405 Mon Sep 17 00:00:00 2001
+From 6bfa3907a9179979a96b125a6f753603164bd64a Mon Sep 17 00:00:00 2001
 From: Ondrej Jirman <megi@xff.cz>
 Date: Mon, 6 Mar 2023 01:19:52 +0100
 Subject: usb: musb: sunxi: Avoid enabling host side code on SoCs where it's
@@ -42,10 +42,10 @@ index b24adb5b399f..8b3ad9101180 100644
  		WARNING("unhandled DISCONNECT transition (%s)\n",
  			musb_otg_state_string(musb));
 diff --git a/drivers/usb/musb/sunxi.c b/drivers/usb/musb/sunxi.c
-index d54283fd026b..7e7703de28a3 100644
+index 05b6e7e52e02..63ad86def2ad 100644
 --- a/drivers/usb/musb/sunxi.c
 +++ b/drivers/usb/musb/sunxi.c
-@@ -352,12 +352,6 @@ static int sunxi_musb_set_mode(struct musb *musb, u8 mode)
+@@ -350,12 +350,6 @@ static int sunxi_musb_set_mode(struct musb *musb, u8 mode)
  	if (glue->phy_mode == new_mode)
  		return 0;
  
@@ -58,7 +58,7 @@ index d54283fd026b..7e7703de28a3 100644
  	if (musb->port1_status & USB_PORT_STAT_ENABLE)
  		musb_root_disconnect(musb);
  
-@@ -676,13 +670,22 @@ static const struct musb_hdrc_config sunxi_musb_hdrc_config_4eps = {
+@@ -674,13 +668,22 @@ static const struct musb_hdrc_config sunxi_musb_hdrc_config_4eps = {
  	.ram_bits	= SUNXI_MUSB_RAM_BITS,
  };
  
@@ -82,7 +82,7 @@ index d54283fd026b..7e7703de28a3 100644
  	int ret;
  
  	if (!np) {
-@@ -763,6 +766,19 @@ static int sunxi_musb_probe(struct platform_device *pdev)
+@@ -761,6 +764,19 @@ static int sunxi_musb_probe(struct platform_device *pdev)
  		return dev_err_probe(&pdev->dev, PTR_ERR(glue->phy),
  				     "Error getting phy\n");
  

--- a/patch/kernel/archive/sunxi-6.11/patches.megous/usb-serial-option-add-reset_resume-callback-for-WWAN-devices.patch
+++ b/patch/kernel/archive/sunxi-6.11/patches.megous/usb-serial-option-add-reset_resume-callback-for-WWAN-devices.patch
@@ -1,4 +1,4 @@
-From 27d4fc73c42a991fe4daf0731eee913491757cd7 Mon Sep 17 00:00:00 2001
+From e670f01dab550fc98212f8b7c1422403a4f43442 Mon Sep 17 00:00:00 2001
 From: Thomas Thorne <Thomas.Thorne@Net2Edge.com>
 Date: Tue, 20 Sep 2022 20:34:57 -0400
 Subject: usb: serial: option: add 'reset_resume' callback for WWAN devices
@@ -17,10 +17,10 @@ However the rest of the patch is not needed/already upstreamed.
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
-index 55886b64cadd..df641a38f274 100644
+index 04f511adc002..d4377793ea5e 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
-@@ -2412,6 +2412,7 @@ static struct usb_serial_driver option_1port_device = {
+@@ -2418,6 +2418,7 @@ static struct usb_serial_driver option_1port_device = {
  #ifdef CONFIG_PM
  	.suspend           = usb_wwan_suspend,
  	.resume            = usb_wwan_resume,


### PR DESCRIPTION
# Description

- Switch to v6.11.9, reextract megous patches
- Fix build dtb package
  Armbian uses subdirectories <overlay> for arm  and <allwinner/overlay> for arm64.
  Delete the vendor's directory if the target architecture  is an arm.

# How Has This Been Tested?

- [ ] Test build and install on bananapi-m3 (arm) board.
- [ ] Test build and install on bananapi-m64 (arm64) board.
