### PR TITLE
u-boot: check the produced `platform_install.sh` (created from functions like write_uboot_platform) for shellcheck errors

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -301,18 +301,15 @@ write_uboot_platform_mtd() {
 }
 
 setup_write_uboot_platform() {
-
 	if grep -q "ubootpart" /proc/cmdline; then
-
-		local tmp=$(cat /proc/cmdline)
+		local tmp part dev
+		tmp=$(cat /proc/cmdline)
 		tmp="${tmp##*ubootpart=}"
 		tmp="${tmp%% *}"
-		[[ -n $tmp ]] && local part=$(findfs PARTUUID=$tmp 2> /dev/null)
-		[[ -n $part ]] && local dev=$(lsblk -n -o PKNAME $part 2> /dev/null)
+		[[ -n $tmp ]] && part=$(findfs PARTUUID=$tmp 2> /dev/null)
+		[[ -n $part ]] && dev=$(lsblk -n -o PKNAME $part 2> /dev/null)
 		[[ -n $dev ]] && DEVICE="/dev/$dev"
-
 	fi
-
 }
 
 family_tweaks() {

--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -54,21 +54,22 @@ write_uboot_platform() {
 }
 
 setup_write_uboot_platform() {
+	local tmp part dev
 	if grep -q "ubootpart" /proc/cmdline; then
 		# mainline with new boot script
-		local tmp=$(cat /proc/cmdline)
+		tmp=$(cat /proc/cmdline)
 		tmp="${tmp##*ubootpart=}"
 		tmp="${tmp%% *}"
-		[[ -n $tmp ]] && local part=$(findfs PARTUUID=$tmp 2> /dev/null)
-		[[ -n $part ]] && local dev=$(lsblk -n -o PKNAME $part 2> /dev/null)
+		[[ -n $tmp ]] && part=$(findfs PARTUUID=$tmp 2> /dev/null)
+		[[ -n $part ]] && dev=$(lsblk -n -o PKNAME $part 2> /dev/null)
 		[[ -n $dev ]] && DEVICE="/dev/$dev"
 	else
 		# legacy or old boot script
-		local tmp=$(cat /proc/cmdline)
+		tmp=$(cat /proc/cmdline)
 		tmp="${tmp##*root=}"
 		tmp="${tmp%% *}"
-		[[ -n $tmp ]] && local part=$(findfs $tmp 2> /dev/null)
-		[[ -n $part ]] && local dev=$(lsblk -n -o PKNAME $part 2> /dev/null)
+		[[ -n $tmp ]] && part=$(findfs $tmp 2> /dev/null)
+		[[ -n $part ]] && dev=$(lsblk -n -o PKNAME $part 2> /dev/null)
 		# do not try to write u-boot to USB devices
 		[[ -n $dev && $dev == mmcblk* ]] && DEVICE="/dev/$dev"
 	fi

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -63,12 +63,13 @@ write_uboot_platform() {
 }
 
 setup_write_uboot_platform() {
+	local tmp part dev
 	if grep -q "ubootpart" /proc/cmdline; then
-		local tmp=$(cat /proc/cmdline)
+		tmp=$(cat /proc/cmdline)
 		tmp="${tmp##*ubootpart=}"
 		tmp="${tmp%% *}"
-		[[ -n $tmp ]] && local part=$(findfs PARTUUID=$tmp 2> /dev/null)
-		[[ -n $part ]] && local dev=$(lsblk -n -o PKNAME $part 2> /dev/null)
+		[[ -n $tmp ]] && part=$(findfs PARTUUID=$tmp 2> /dev/null)
+		[[ -n $part ]] && dev=$(lsblk -n -o PKNAME $part 2> /dev/null)
 		[[ -n $dev ]] && DEVICE="/dev/$dev"
 	elif [[ -f /var/lib/armbian/force_search_uboot ]]; then
 		# This may cause overwriting u-boot for android or other non-Armbian OS installed on eMMC

--- a/config/sources/families/odroidxu4.conf
+++ b/config/sources/families/odroidxu4.conf
@@ -52,17 +52,16 @@ function custom_kernel_config__hack_odroidxu4_firmware() {
 }
 
 setup_write_uboot_platform() {
-
 	# this will update u-boot on the device rootfs is located on
 	# in case it's a mmc device, otherwise DEVICE will not be changed
 	# and will default to /dev/mmcblk0
-	local tmp=$(cat /proc/cmdline)
+	local tmp part dev
+	tmp=$(cat /proc/cmdline)
 	tmp="${tmp##*root=}"
 	tmp="${tmp%% *}"
-	[[ -n $tmp ]] && local part=$(findfs $tmp 2> /dev/null)
-	[[ -n $part ]] && local dev=$(lsblk -n -o PKNAME $part 2> /dev/null)
+	[[ -n $tmp ]] && part=$(findfs $tmp 2> /dev/null)
+	[[ -n $part ]] && dev=$(lsblk -n -o PKNAME $part 2> /dev/null)
 	[[ -n $dev && $dev == mmcblk* ]] && DEVICE="/dev/${dev}"
-
 }
 
 write_uboot_platform() {

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -414,12 +414,22 @@ function compile_uboot() {
 	unset uboot_postinst_base postinst_functions destination
 
 	# declare -f on non-defined function does not do anything (but exits with errors, so ignore them with "|| true")
-	cat <<- EOF > "$uboottempdir/usr/lib/u-boot/platform_install.sh"
+	cat <<- EOF > "${uboottempdir}/usr/lib/u-boot/platform_install.sh"
+		# Armbian u-boot install script for linux-u-boot-${BOARD}-${BRANCH} ${artifact_version}
+		# This file provides functions for deploying u-boot to a block device.
 		DIR=/usr/lib/$uboot_name
 		$(declare -f write_uboot_platform || true)
 		$(declare -f write_uboot_platform_mtd || true)
 		$(declare -f setup_write_uboot_platform || true)
 	EOF
+
+	if [[ "${SHOW_DEBUG}" == "yes" ]]; then
+		display_alert "Showing contents of" "usr/lib/u-boot/platform_install.sh" "info"
+		run_tool_batcat --file-name "usr/lib/u-boot/platform_install.sh" "${uboottempdir}/usr/lib/u-boot/platform_install.sh"
+	fi
+
+	display_alert "Running shellcheck" "usr/lib/u-boot/platform_install.sh" "info"
+	shellcheck_debian_control_scripts "${uboottempdir}/usr/lib/u-boot/platform_install.sh"
 
 	display_alert "Das U-Boot .deb package version" "${artifact_version}" "info"
 


### PR DESCRIPTION
#### u-boot: check the produced `platform_install.sh` (created from functions like write_uboot_platform) for shellcheck errors

- u-boot: check the produced `platform_install.sh` (created from functions like write_uboot_platform) for shellcheck errors
  - we've some smelly stuff in write_uboot_platform for some families that we'd rather catch early
  - implement small syntax fixes in setup_write_uboot_platform