### PR TITLE
extension: mesa-vpu: remove adding chromium ppa

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -90,34 +90,6 @@ function post_install_kernel_debs__3d() {
 
 		# Add chromium if building a desktop
 		if [[ "${BUILD_DESKTOP}" == "yes" ]]; then
-			if [[ "${ARCH}" == "arm64" ]]; then
-
-				display_alert "Adding Amazingfate Chromium PPAs" "${EXTENSION}" "info"
-				do_with_retries 3 chroot_sdcard add-apt-repository ppa:liujianfeng1994/chromium --yes --no-update
-				sed -i "s/oracular/noble/g" "${SDCARD}"/etc/apt/sources.list.d/liujianfeng1994-ubuntu-chromium-"${RELEASE}".*
-
-				display_alert "Pinning amazingfated's Chromium PPAs" "${EXTENSION}" "info"
-				cat <<- EOF > "${SDCARD}"/etc/apt/preferences.d/liujianfeng1994-chromium-pin
-					Package: chromium
-					Pin: release o=LP-PPA-liujianfeng1994-chromium
-					Pin-Priority: 1001
-				EOF
-
-			else
-
-				display_alert "Adding Xtradebs Apps PPAs" "${EXTENSION}" "info"
-				do_with_retries 3 chroot_sdcard add-apt-repository ppa:xtradeb/apps --yes --no-update
-				sed -i "s/oracular/noble/g" "${SDCARD}"/etc/apt/sources.list.d/xtradeb-ubuntu-apps-"${RELEASE}".*
-
-				display_alert "Pinning Xtradebs PPAs" "${EXTENSION}" "info"
-				cat <<- EOF > "${SDCARD}"/etc/apt/preferences.d/xtradebs-apps-pin
-					Package: chromium
-					Pin: release o=LP-PPA-xtradebs-apps
-					Pin-Priority: 1001
-				EOF
-
-			fi
-
 			pkgs+=("chromium")
 		fi
 	fi


### PR DESCRIPTION
We already have imported chromium debs from ppa to armbian's repo

# Description

https://github.com/armbian/os/blob/main/external/chromium-aarch64-jammy.conf
https://github.com/armbian/os/blob/main/external/chromium-aarch64-noble.conf

Pacakges will be in armbian's repo once there are updates in ppa.
And there are also pacakges in oracular-desktop.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
