### PR TITLE
hinlink-h88k: edge: add rfkill nodes to devicetree for m.2 wifi and b…

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.12/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.12/dt/rk3588-hinlink-h88k.dts
@@ -92,6 +92,20 @@
 		};
 	};
 
+	rfkilli-wifi {
+		compatible = "rfkill-gpio";
+		label = "rfkill-pcie-wlan";
+		radio-type = "wlan";
+		shutdown-gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_HIGH>;
+	};
+
+	rfkill-bt {
+		compatible = "rfkill-gpio";
+		label = "rfkill-m2-bt";
+		radio-type = "bluetooth";
+		shutdown-gpios = <&gpio3 RK_PA6 GPIO_ACTIVE_HIGH>;
+	};
+
 	vcc12v_dcin: vcc12v-dcin {
 		compatible = "regulator-fixed";
 		regulator-always-on;


### PR DESCRIPTION
…luetooth

# Description

Sch of h88k:
https://www.nas-ya.com/wp-content/uploads/2024/03/20240625111001816016.pdf
GPIO `WIFI_REG_ON` and `BT_REG_ON` is controlling rfkill of m.2 pcie wifi and m.2 bluetooth.
Test with rtl8852be.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=hinlink-h88k BRANCH=edge DEB_COMPRESS=xz KERNEL_CONFIGURE=no KERNEL_GIT=shallow`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
