### PR TITLE
Reduce the size of the Rock S0 CMA to match Rock PI-S + include fixMACaddress script

### DIFF
--- a/config/boards/rock-s0.conf
+++ b/config/boards/rock-s0.conf
@@ -28,5 +28,21 @@ function post_family_config__rocks0() {
 	declare -g BOOTDIR="u-boot-${BOARD}"
 	declare -g BOOTSCRIPT=boot-rockchip64-ttyS0.cmd:boot.cmd
 
-	unset family_tweaks_bsp # disable from rockchip64_common
+	family_tweaks_bsp() { #overrides rockchip64_common.inc
+		#Install udev script that derives fixed, unique MAC addresses for net interfaces
+		#that are assigned random ones
+		bsp=$SRC/packages/bsp/rockpis
+		rules=etc/udev/rules.d
+
+		install -m 755 $bsp/lib/udev/fixEtherAddr $destination/lib/udev
+	}
+}
+
+function pre_install_kernel_debs__enforce_cma() {
+	# Set CMA to 16 megabytes, to provide more usable RAM since Rock Pi S
+	# has usually a small amount of DRAM (512MB)
+	display_alert "$BOARD" "set CMA size to 16MB due to small DRAM size"
+	run_host_command_logged echo "extraargs=cma=16M" ">>" "${SDCARD}"/boot/armbianEnv.txt
+
+	return 0
 }

--- a/packages/bsp/rockpis/etc/udev/rules.d/05-fixMACaddress.rules
+++ b/packages/bsp/rockpis/etc/udev/rules.d/05-fixMACaddress.rules
@@ -1,6 +1,13 @@
-#If a network interface is being assigned a new, different address on each boot,
-#enable the corresponding line below to derive its MAC addr from UUID of rootfs
-#Beware that all the two digit hex code prefixes below must be unique!
+#If a network interface is being assigned a different MAC address on each boot,
+#or the MAC address is based on a disk image (rather than a hardware serial #),
+#enable the corresponding line below to derive that interface's MAC address from
+#the RK3308 SOC's unique serial number.
+
+#All the two digit hex code prefixes passed to fixEtherAddr should be unique
+#and chosen such that (n-2)%4 == 0
 
 KERNEL=="wlan0", ACTION=="add" RUN+="fixEtherAddr %k 0a"
 KERNEL=="p2p0", ACTION=="add" RUN+="fixEtherAddr %k 0e"
+
+#U-Boot >=V2024.10 sets the built-in Ethernet MAC adr from the SOC serial number
+#KERNEL=="end0", ACTION=="add" RUN+="fixEtherAddr %k 06"


### PR DESCRIPTION
in the S0 image to assign end0 MAC address from CPU serial #
in case running U-Boot earlier than 2024.10

# Description

Correct misleading comments in /etc/udev/rules.d/05-fixMACaddress.rules
Add fixMACaddress script to Rock S0 image

[Jira](https://armbian.atlassian.net/browse/AR-2545)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] build and verified new S0 image still works and contains fixMACaddress script

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
