### PR TITLE
Drop deprecated key management support

### DIFF
--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -156,21 +156,12 @@ function create_sources_list_and_deploy_repo_key() {
 			;;
 	esac
 
+	# add armbian key
 	display_alert "Adding Armbian repository and authentication key" "${when} :: /etc/apt/sources.list.d/armbian.list" "info"
-
-	# apt-key add is getting deprecated
-	APT_VERSION=$(chroot "${basedir}" /bin/bash -c "apt --version | cut -d\" \" -f2")
-	if linux-version compare "${APT_VERSION}" ge 2.4.1; then
-		# add armbian key
-		mkdir -p "${basedir}"/usr/share/keyrings
-		# change to binary form
-		gpg --dearmor < "${SRC}"/config/armbian.key > "${basedir}"/usr/share/keyrings/armbian.gpg
-		SIGNED_BY="[signed-by=/usr/share/keyrings/armbian.gpg] "
-	else
-		# use old method for compatibility reasons # @TODO: rpardini: not gonna fix this?
-		cp "${SRC}"/config/armbian.key "${basedir}"
-		chroot "${basedir}" /bin/bash -c "cat armbian.key | apt-key add -"
-	fi
+	mkdir -p "${basedir}"/usr/share/keyrings
+	# change to binary form
+	gpg --dearmor < "${SRC}"/config/armbian.key > "${basedir}"/usr/share/keyrings/armbian.gpg
+	SIGNED_BY="[signed-by=/usr/share/keyrings/armbian.gpg] "
 
 	declare -a components=()
 	if [[ "${when}" == "image"* ]]; then # only include the 'main' component when deploying to image (early or late)


### PR DESCRIPTION
# Description

We used to have this workaround to support older builds. Binary key support works with Bullseye and Focal, which are the oldes that makes sense. And more recent.

# How Has This Been Tested?

- [ ] Generating and booting Bullseye and Focal

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
