### PR TITLE
nanopi-r6s: fix mmc0/mmc1 ordering

### DIFF
--- a/patch/u-boot/v2024.10/board_nanopi-r6s/0001-adjust-wrong-mmc0-mmc1-ordering.patch
+++ b/patch/u-boot/v2024.10/board_nanopi-r6s/0001-adjust-wrong-mmc0-mmc1-ordering.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Sat, 30 Nov 2024 02:09:36 +0300
+Subject: adjust wrong mmc0/mmc1 ordering
+
+---
+ arch/arm/dts/rk3588s-nanopi-r6s-u-boot.dtsi | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/arch/arm/dts/rk3588s-nanopi-r6s-u-boot.dtsi b/arch/arm/dts/rk3588s-nanopi-r6s-u-boot.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm/dts/rk3588s-nanopi-r6s-u-boot.dtsi
++++ b/arch/arm/dts/rk3588s-nanopi-r6s-u-boot.dtsi
+@@ -1,3 +1,10 @@
+ // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ 
+ #include "rk3588s-u-boot.dtsi"
++
++/ {
++	aliases {
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc;
++	};
++};
+\ No newline at end of file
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

In mainline devicetree, mmc0 is sdmmc and mmc1 sdhci and uboot tries to boot mmc1 first of all. Thus, even if SD card is mounted, the board still boots from eMMC. This PR fixes it.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?
- [x] Built and tested that SD card has higher priority in case both eMMC and SD card has a bootloader

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
