### PR TITLE
spacemit: shellfmt again after quoting fixes

### DIFF
--- a/config/sources/families/spacemit.conf
+++ b/config/sources/families/spacemit.conf
@@ -76,8 +76,8 @@ write_uboot_platform() {
 
 	declare -A d
 	d=(
-		[${1} / bootinfo_emmc.bin]="0:$(du -b ${1}/bootinfo_emmc.bin | awk '{print $1}')"
-		[${1} / FSBL.bin]="512:$(du -b ${1}/FSBL.bin | awk '{print $1}')"
+	[${1}/bootinfo_emmc.bin]="0:$(du -b ${1}/bootinfo_emmc.bin | awk '{print $1}')"
+	[${1}/FSBL.bin]="512:$(du -b ${1}/FSBL.bin | awk '{print $1}')"
 	)
 
 	if [ -b ${2}boot0 ]; then
@@ -86,9 +86,11 @@ write_uboot_platform() {
 		sync
 	fi
 
-	for f in "${!d[@]}"; do
+	for f in "${!d[@]}"
+	do
 		if $(dd if=${device} bs=1 skip="${d[$f]%:*}" count="${d[$f]#*:}" \
-			conv=notrunc status=noxfer 2> /dev/null | cmp --quiet "${f}"); then
+			conv=notrunc status=noxfer 2>/dev/null | cmp --quiet "${f}")
+		then
 			echo "Skip $(basename $f), it is equal to the existing one"
 		else
 			echo "# Write =: $(basename $f) to ${device}"

--- a/config/sources/families/spacemit.conf
+++ b/config/sources/families/spacemit.conf
@@ -76,8 +76,8 @@ write_uboot_platform() {
 
 	declare -A d
 	d=(
-	["${1}/bootinfo_emmc.bin"]="0:$(du -b "${1}/bootinfo_emmc.bin" | awk '{print $1}')"
-	["${1}/FSBL.bin"]="512:$(du -b "${1}/FSBL.bin" | awk '{print $1}')"
+		["${1}/bootinfo_emmc.bin"]="0:$(du -b "${1}/bootinfo_emmc.bin" | awk '{print $1}')"
+		["${1}/FSBL.bin"]="512:$(du -b "${1}/FSBL.bin" | awk '{print $1}')"
 	)
 
 	if [ -b ${2}boot0 ]; then
@@ -86,12 +86,10 @@ write_uboot_platform() {
 		sync
 	fi
 
-	for f in "${!d[@]}"
-	do
+	for f in "${!d[@]}"; do
 		# @TODO: "if $(...)" works by accident, should be "if ..." instead
 		if $(dd if=${device} bs=1 skip="${d[$f]%:*}" count="${d[$f]#*:}" \
-			conv=notrunc status=noxfer 2>/dev/null | cmp --quiet "${f}")
-		then
+			conv=notrunc status=noxfer 2> /dev/null | cmp --quiet "${f}"); then
 			echo "Skip $(basename $f), it is equal to the existing one"
 		else
 			echo "# Write =: $(basename $f) to ${device}"

--- a/config/sources/families/spacemit.conf
+++ b/config/sources/families/spacemit.conf
@@ -76,31 +76,32 @@ write_uboot_platform() {
 
 	declare -A d
 	d=(
-	[${1}/bootinfo_emmc.bin]="0:$(du -b ${1}/bootinfo_emmc.bin | awk '{print $1}')"
-	[${1}/FSBL.bin]="512:$(du -b ${1}/FSBL.bin | awk '{print $1}')"
+	["${1}/bootinfo_emmc.bin"]="0:$(du -b "${1}/bootinfo_emmc.bin" | awk '{print $1}')"
+	["${1}/FSBL.bin"]="512:$(du -b "${1}/FSBL.bin" | awk '{print $1}')"
 	)
 
 	if [ -b ${2}boot0 ]; then
 		device=${2}boot0
-		echo 0 > /sys/block/$(basename ${device})/force_ro
+		echo 0 > "/sys/block/$(basename "${device}")/force_ro"
 		sync
 	fi
 
 	for f in "${!d[@]}"
 	do
+		# @TODO: "if $(...)" works by accident, should be "if ..." instead
 		if $(dd if=${device} bs=1 skip="${d[$f]%:*}" count="${d[$f]#*:}" \
 			conv=notrunc status=noxfer 2>/dev/null | cmp --quiet "${f}")
 		then
 			echo "Skip $(basename $f), it is equal to the existing one"
 		else
 			echo "# Write =: $(basename $f) to ${device}"
-			dd if=$f of=${device} bs=1 seek="${d[$f]%:*}" conv=notrunc status=noxfer
+			dd "if=$f" "of=${device}" bs=1 seek="${d[$f]%:*}" conv=notrunc status=noxfer
 			sync
 		fi
 	done
 
-	dd if=$1/fw_dynamic.itb of=${2} bs=512 seek=1280 conv=notrunc
+	dd "if=$1/fw_dynamic.itb" "of=${2}" bs=512 seek=1280 conv=notrunc
 	sync
-	dd if=$1/u-boot.itb of=${2} bs=512 seek=2048 conv=notrunc
+	dd "if=$1/u-boot.itb of=${2}" bs=512 seek=2048 conv=notrunc
 	sync
 }


### PR DESCRIPTION
#### spacemit: shellfmt again after quoting fixes

- spacemit: revert shellfmt that messed up
  - revert spacemit.conf changes from 2f63a9cd987a32a3e87ae6026f116025aec0b2a8
- spacemit: apply quoting to fix more glaring problems
  - add a TODO for the original author of a "if $(...)" statement which I can't understand; it's still wrong
- spacemit: shellfmt again after quoting fixes
  - problematic `if $(...)` remains; just indent changed