### PR TITLE
Add support for rk3588 based GenBook

### DIFF
--- a/config/boards/coolpi-genbook.csc
+++ b/config/boards/coolpi-genbook.csc
@@ -1,0 +1,36 @@
+# Rockchip RK3588 SoC octa core 4-16GB SoC eMMC USB3 NVME
+BOARD_NAME="CoolPi GenBook"
+BOARDFAMILY="rockchip-rk3588"
+BOARD_MAINTAINER="Andyshrk"
+BOARD_FIRMWARE_INSTALL="-full"
+BOOT_SOC="rk3588"
+BOOTCONFIG="coolpi-cm5-genbook-rk3588_defconfig"
+KERNEL_TARGET="edge"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3588-coolpi-cm5-genbook.dtb"
+BOOT_SCENARIO="spl-blobs"
+BOOT_SUPPORT_SPI="yes"
+BOOT_SPI_RKSPI_LOADER="yes"
+IMAGE_PARTITION_TABLE="gpt"
+
+# Mainline U-Boot
+function post_family_config_branch_edge__coolpi-genbook_use_mainline_uboot() {
+	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
+
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # Mainline U-Boot
+	unset BOOTBRANCH
+	unset BOOTPATCHDIR
+	declare -g BOOTBRANCH_BOARD="tag:v2025.01-rc3"
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+
+	function write_uboot_platform_mtd() {
+		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
+	}
+}


### PR DESCRIPTION

# Description
GenBook is a rk3588 based laptop from coolpi.
The armbian can boot from a usb disk, with pre installed mainline u-boot on SPI Nor flash.


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._


Build witch command:
`./compile.sh build BOARD=coolpi-genbook BRANCH=edge BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED='browsers chat desktop_tools editors email internet multimedia office programming remote_desktop' DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base DOWNLOAD_MIRROR=bfsu ENABLE_EXTENSIONS=mesa-vpu EXPERT=yes EXTRAWIFI=no KERNEL_CONFIGURE=no RELEASE=noble VENDOR=Armbian`

Write img to a usb disk by balenaEtcher,  the system can boot from this usb disk.

# Checklist:

_Please delete options that are not relevant._

- [&#10003; ] My code follows the style guidelines of this project
- [&#10003; ] I have performed a self-review of my own code
- [&#10003; ] I have commented my code, particularly in hard-to-understand areas
- [&#10003; ] My changes generate no new warnings

