### PR TITLE
rk35xx-vendor: bump to 6.1 rkr4.1 sdk kernel

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -37,7 +37,7 @@ case $BRANCH in
 		declare -g KERNEL_MAJOR_MINOR="6.1"    # Major and minor versions of this kernel.
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-		KERNELBRANCH='branch:rk-6.1-rkr3'
+		KERNELBRANCH='branch:rk-6.1-rkr4.1'
 		KERNELPATCHDIR='rk35xx-vendor-6.1'
 		;;
 esac

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -34,7 +34,7 @@ case $BRANCH in
 		declare -g KERNEL_MAJOR_MINOR="6.1"    # Major and minor versions of this kernel.
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-		KERNELBRANCH='branch:rk-6.1-rkr3'
+		KERNELBRANCH='branch:rk-6.1-rkr4.1'
 		KERNELPATCHDIR='rk35xx-vendor-6.1'
 		LINUXFAMILY=rk35xx
 		;;

--- a/patch/kernel/rk35xx-vendor-6.1/0000.patching_config.yaml
+++ b/patch/kernel/rk35xx-vendor-6.1/0000.patching_config.yaml
@@ -4,8 +4,8 @@ config:
   name: rk35xx-6.1
   kind: kernel
   type: vendor # or: vendor
-  branch: rk-6.1-rkr3
-  last-known-good-tag: v6.1.75
+  branch: rk-6.1-rkr4.1
+  last-known-good-tag: v6.1.84
 
   # .dts files in these directories will be copied as-is to the build tree; later ones overwrite earlier ones.
   # This is meant to provide a way to "add a board DTS" without having to null-patch them in.


### PR DESCRIPTION
# Description

Source is already rebased: https://github.com/armbian/linux-rockchip/tree/rk-6.1-rkr4.1
Rebase details: https://github.com/armbian/linux-rockchip/pull/289

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=rock-5b BRANCH=vendor DEB_COMPRESS=xz KERNEL_CONFIGURE=no KERNEL_GIT=shallow`
- [x] armsom sige1(rk3528)
- [x] armsom sige3(rk3568)
- [x] armsom cm5-io(rk3576)
- [x] armsom sige7(rk3588)
- [x] rock5b(rk3588)
- [x] Rock5B+ by @HeyMeco 

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
