### PR TITLE
BananaPi BPI-CM4: `Enable i2c2 via overlay`

### DIFF
--- a/patch/kernel/archive/meson64-6.12/overlay/Makefile
+++ b/patch/kernel/archive/meson64-6.12/overlay/Makefile
@@ -21,6 +21,7 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-g12a-radxa-zero-uart-ao-b-on-gpioao-2-gpioao-3.dtbo \
 	meson-g12a-radxa-zero-uart-ao-b-on-gpioao-8-gpioao-9.dtbo \
 	meson-g12a-radxa-zero-uart-ee-c.dtbo \
+	meson-g12b-bananapi-cm4-i2c2.dtbo \
 	meson-g12b-bananapi-cm4-pwm-gpioh-5-fan.dtbo \
 	meson-g12b-bananapi-cm4-wifi-freq-200mhz.dtbo \
 	meson-g12b-bananapi-m2s-rtl8822cs.dtbo \

--- a/patch/kernel/archive/meson64-6.12/overlay/meson-g12b-bananapi-cm4-i2c2.dtso
+++ b/patch/kernel/archive/meson64-6.12/overlay/meson-g12b-bananapi-cm4-i2c2.dtso
@@ -1,0 +1,20 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "bananapi,bpi-cm4io", "bananapi,bpi-cm4", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&i2c2>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&uart_A>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/patch/kernel/archive/meson64-6.6/overlay/Makefile
+++ b/patch/kernel/archive/meson64-6.6/overlay/Makefile
@@ -21,6 +21,7 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-g12a-radxa-zero-uart-ao-b-on-gpioao-2-gpioao-3.dtbo \
 	meson-g12a-radxa-zero-uart-ao-b-on-gpioao-8-gpioao-9.dtbo \
 	meson-g12a-radxa-zero-uart-ee-c.dtbo \
+	meson-g12b-bananapi-cm4-i2c2.dtbo \
 	meson-g12b-bananapi-cm4-pwm-gpioh-5-fan.dtbo \
 	meson-g12b-bananapi-cm4-wifi-freq-200mhz.dtbo \
 	meson-g12b-bananapi-m2s-rtl8822cs.dtbo \

--- a/patch/kernel/archive/meson64-6.6/overlay/meson-g12b-bananapi-cm4-i2c2.dts
+++ b/patch/kernel/archive/meson64-6.6/overlay/meson-g12b-bananapi-cm4-i2c2.dts
@@ -1,0 +1,20 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "bananapi,bpi-cm4io", "bananapi,bpi-cm4", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target = <&i2c2>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&uart_A>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
Discussion:
https://forum.armbian.com/topic/47842-how-do-i-enable-i2c2-on-armbian-24111-bookworm-minimal/
