### PR TITLE
DO NOT MERGE: rotate default paste server due to random breakage

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -82,7 +82,7 @@
 ############################################################################
 
 # Config:
-declare -a paste_servers=("paste.armbian.com" "paste.next.armbian.com" "paste.armbian.de")
+declare -a paste_servers=("paste.next.armbian.com" "paste.next.armbian.de" "paste.armbian.com")
 if [[ "${PASTE_SERVER_HOST}" != "" ]]; then
 	echo "Using custom paste server: '${PASTE_SERVER_HOST}'"
 	paste_servers=("${PASTE_SERVER_HOST}" "${paste_servers[@]}")

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -82,7 +82,7 @@
 ############################################################################
 
 # Config:
-declare -a paste_servers=("paste.next.armbian.com" "paste.next.armbian.de" "paste.armbian.com")
+declare -a paste_servers=("paste.next.armbian.com" "paste.armbian.de" "paste.armbian.com")
 if [[ "${PASTE_SERVER_HOST}" != "" ]]; then
 	echo "Using custom paste server: '${PASTE_SERVER_HOST}'"
 	paste_servers=("${PASTE_SERVER_HOST}" "${paste_servers[@]}")


### PR DESCRIPTION
# Description

https://forum.armbian.com/topic/47932-problems-to-drive-the-gpios/#findComment-207797
Another report of might be broken main paste server. 
Rotate the defaults for now.
Sent as draft, awaiting confirmation from forum thread linked above.

# How Has This Been Tested?

- [ ] hasn't

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
