### PR TITLE
mixtile-edge2: bump vendor to `branch:rk-6.1-rkr4.1`

### DIFF
--- a/config/boards/mixtile-edge2.csc
+++ b/config/boards/mixtile-edge2.csc
@@ -40,7 +40,7 @@ function post_family_config_branch_vendor__kernel_and_uboot_rk35xx_mixtile_edge2
 	# Copypasta from rockchip-rk3588.conf family file -- we _really_ gotta find a better way!
 	declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
 	declare -g KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-	declare -g KERNELBRANCH='branch:rk-6.1-rkr3'
+	declare -g KERNELBRANCH='branch:rk-6.1-rkr4.1'
 	declare -g KERNELPATCHDIR='rk35xx-vendor-6.1'
 	declare -g LINUXFAMILY=rk35xx
 	declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes


### PR DESCRIPTION
#### mixtile-edge2: bump vendor to `branch:rk-6.1-rkr4.1`

- mixtile-edge2: bump vendor to `branch:rk-6.1-rkr4.1`
  - In line with 35352fa288cedcee806caa83bb5de6c9162758b7 (bump to rkr4.1)
  - "Copypasta from rockchip-rk3588.conf family file -- we _really_ gotta find a better way!"
  - I'm not proud of having done it this way, but now it broke (two vendor debs are produced in different versions) so lets fix it