### PR TITLE
fix: ST7796 kernel module patch

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/general-st7796-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.12/general-st7796-driver.patch
@@ -39,7 +39,7 @@ new file mode 100755
 index 00000000000..c7deedbea69
 --- /dev/null
 +++ b/drivers/staging/fbtft/fb_st7796.c
-@@ -0,0 +1,160 @@
+@@ -0,0 +1,154 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * FB driver for the ST7796 LCD display controller

--- a/patch/kernel/archive/rockchip64-6.6/general-st7796-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.6/general-st7796-driver.patch
@@ -39,7 +39,7 @@ new file mode 100755
 index 00000000000..c7deedbea69
 --- /dev/null
 +++ b/drivers/staging/fbtft/fb_st7796.c
-@@ -0,0 +1,160 @@
+@@ -0,0 +1,154 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * FB driver for the ST7796 LCD display controller

--- a/patch/kernel/archive/rockchip64-6.9/general-st7796-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.9/general-st7796-driver.patch
@@ -39,7 +39,7 @@ new file mode 100755
 index 00000000000..c7deedbea69
 --- /dev/null
 +++ b/drivers/staging/fbtft/fb_st7796.c
-@@ -0,0 +1,160 @@
+@@ -0,0 +1,154 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * FB driver for the ST7796 LCD display controller


### PR DESCRIPTION
# Description

Fix error from https://github.com/armbian/build/pull/7550


# How Has This Been Tested?

The changes was tested on MKS PI-TS35 display together with MKS-PI board as part of custom Armbian image. Touch screen uses an ` ads7846` module.

- [x] MKS-PI + MKS PI-TS35 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
