### PR TITLE
Revert "shellfmt: config/sources; no changes"

### DIFF
--- a/config/sources/families/spacemit.conf
+++ b/config/sources/families/spacemit.conf
@@ -76,8 +76,8 @@ write_uboot_platform() {
 
 	declare -A d
 	d=(
-		[${1} / bootinfo_emmc.bin]="0:$(du -b ${1}/bootinfo_emmc.bin | awk '{print $1}')"
-		[${1} / FSBL.bin]="512:$(du -b ${1}/FSBL.bin | awk '{print $1}')"
+	[${1}/bootinfo_emmc.bin]="0:$(du -b ${1}/bootinfo_emmc.bin | awk '{print $1}')"
+	[${1}/FSBL.bin]="512:$(du -b ${1}/FSBL.bin | awk '{print $1}')"
 	)
 
 	if [ -b ${2}boot0 ]; then
@@ -86,9 +86,11 @@ write_uboot_platform() {
 		sync
 	fi
 
-	for f in "${!d[@]}"; do
+	for f in "${!d[@]}"
+	do
 		if $(dd if=${device} bs=1 skip="${d[$f]%:*}" count="${d[$f]#*:}" \
-			conv=notrunc status=noxfer 2> /dev/null | cmp --quiet "${f}"); then
+			conv=notrunc status=noxfer 2>/dev/null | cmp --quiet "${f}")
+		then
 			echo "Skip $(basename $f), it is equal to the existing one"
 		else
 			echo "# Write =: $(basename $f) to ${device}"


### PR DESCRIPTION
This reverts commit 2f63a9cd987a32a3e87ae6026f116025aec0b2a8.

`[${1} / bootinfo_emmc.bin]`
`[${1} / FSBL.bin]` 
         - This is the path to the file.
            It cannot contain spaces.

# Description

The shellfmt utility can be run manually and makes changes to all files defined here:
[lib/tools/shellfmt.sh#L66](https://github.com/armbian/build/blob/2d1bbca7312102e5263514c86925075bbc6c7746/lib/tools/shellfmt.sh#L66)
In some cases, the changes have a clear defect and can be detected by simply reading the changes.
In some cases, we need a thorough check of the system script run in the environment in which it is to be executed.
The syntax in the system script should work equally well in both old ubuntu\debian and new operating systems.

No automatic/machine changes to system scripts should be performed without subsequent manual health checks.

It also has to do with the changes that the shellcheck utility offers. [lib/tools/shellcheck.sh](https://github.com/armbian/build/blob/main/lib/tools/shellcheck.sh)

**Discussion. The work is in progress.**



