### PR TITLE
extensions: image-output-abl: set rootfs image larger for kde

### DIFF
--- a/extensions/image-output-abl.sh
+++ b/extensions/image-output-abl.sh
@@ -21,7 +21,7 @@ function post_build_image__900_convert_to_abl_img() {
 	old_rootfs_image_mount_dir=${DESTIMG}/rootfs-old
 	new_rootfs_image_mount_dir=${DESTIMG}/rootfs-new
 	mkdir -p ${old_rootfs_image_mount_dir} ${new_rootfs_image_mount_dir}
-	truncate --size=9216M ${ROOTFS_IMAGE_FILE}
+	truncate --size=9728M ${ROOTFS_IMAGE_FILE}
 	mkfs.ext4 -F ${ROOTFS_IMAGE_FILE}
 	new_rootfs_image_uuid=$(blkid -s UUID -o value ${ROOTFS_IMAGE_FILE})
 	old_image_loop_device=$(losetup -f -P --show ${DESTIMG}/${version}.img)


### PR DESCRIPTION
# Description

KDE image with all appgroups is larger than 9216M, so increase the abl image size to 9728

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=xiaomi-elish BRANCH=current GITHUB_MIRROR=ghproxy KERNEL_GIT=shallow DEB_COMPRESS=xz RELEASE=noble BUILD_DESKTOP=yes BUILD_MINIMAL=no KERNEL_CONFIGURE=no DESKTOP_APPGROUPS_SELECTED="chat,desktop_tools,editors,email,internet,languages,multimedia,office,programming,remote_desktop" DESKTOP_ENVIRONMENT=kde-neon DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base EXPERT=yes`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
