### PR TITLE
Add missing deps for armbian-config

### DIFF
--- a/lib/functions/compilation/packages/armbian-config-deb.sh
+++ b/lib/functions/compilation/packages/armbian-config-deb.sh
@@ -47,7 +47,7 @@ compile_armbian-config() {
 		Version: ${artifact_version}
 		Architecture: all
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
-		Depends: whiptail, jq, sudo, procps, systemd, iproute2
+		Depends: iproute2, jq, procps, sudo, systemd, whiptail
 		Section: utils
 		Priority: optional
 		Description: Armbian configuration utility - The new generation

--- a/lib/functions/compilation/packages/armbian-config-deb.sh
+++ b/lib/functions/compilation/packages/armbian-config-deb.sh
@@ -47,7 +47,7 @@ compile_armbian-config() {
 		Version: ${artifact_version}
 		Architecture: all
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
-		Depends: iproute2, jq, procps, sudo, systemd, whiptail
+		Depends: debconf, iproute2, jq, libtext-iconv-perl, procps, sudo, systemd, whiptail
 		Section: utils
 		Priority: optional
 		Description: Armbian configuration utility - The new generation


### PR DESCRIPTION
# Description

`armbian-config` uses `debconf-apt-progress` which is part of `debconf`, so it should be listed as a dependency, and missing `libtext-iconv-perl` causes an error as described in https://github.com/armbian/configng/pull/272#issue-2699631052.

# How Has This Been Tested?

- `debconf` is obvious. It's also pulled in by a number of other packages, so it hasn't come up as a problem. But, since `armbian-config` uses it directly, it should specify it as a direct dependency.

- `libtext-iconv-perl` is a bit less obvious. It's probably also pulled in by other packages on most systems, so it hasn't been caught before. But, on a minimal Armbian image where it's not present, I was getting the error mentioned above. Manually installing this package handled the error.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings