### PR TITLE
Add Radxa Zero GPIO names to support libgpiod

### DIFF
--- a/patch/kernel/archive/meson64-6.12/meson-g12a-radxa-zero-gpio-pin-names.patch
+++ b/patch/kernel/archive/meson64-6.12/meson-g12a-radxa-zero-gpio-pin-names.patch
@@ -1,0 +1,37 @@
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+index c779a5da7d1e..cb1a167c117c 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -262,6 +262,32 @@ &frddr_c {
+ 	status = "okay";
+ };
+
++/*
++pin-8, pin-36 are mapped referring to: /include/dt-bindings/gpio/meson-g12a-gpio.h
++left as is for future tests
++*/
++/*CHIP0*/
++&gpio {
++    gpio-line-names =
++    /*00*/ "", "", "", "", "", "", "", "", "", "",
++    /*10*/ "", "", "", "", "", "", "", "", "", "",
++    /*20*/ "19 [GPIOH_4]", "21 [GPIOH_5]", "24 [GPIOH_6]", "23 [GPIOH_7]", "36 [GPIOH_8]", "", "", "", "", "",
++    /*30*/ "", "", "", "", "", "", "", "", "", "",
++    /*40*/ "", "", "", "", "", "", "", "", "22 [GPIOC_7]", "",
++    /*50*/ "", "", "", "", "", "", "", "", "", "",
++    /*60*/ "", "", "", "3 [GPIOA_14]", "", "", "", "", "", "",
++    /*70*/ "", "", "", "18 [GPIOX_8]", "12 [GPIOX_9]", "16 [GPIOX_10]", "13 [GPIOX_11]", "", "", "",
++    /*80*/ "", "", "", "", "";
++};
++
++/*CHIP1*/
++&gpio_ao {
++    gpio-line-names =
++    /*00*/ "8 [GPIOAO_0]", "10 [GPIOAO_1]", "11,28 [GPIOAO_2]", "7,27 [GPIOAO_3]", "32 [GPIOAO_4]",
++    /*05*/ "5 [GPIOA_15]", "", "", "35 [GPIOAO_8]", "37 [GPIOAO_9]",
++    /*10*/ "", "40 [GPIOAO_11]", "", "", "";
++};
++
+ &hdmi_tx {
+ 	status = "okay";
+ 	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;

--- a/patch/kernel/archive/meson64-6.6/meson-g12a-radxa-zero-gpio-pin-names.patch
+++ b/patch/kernel/archive/meson64-6.6/meson-g12a-radxa-zero-gpio-pin-names.patch
@@ -1,0 +1,37 @@
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+index c779a5da7d1e..cb1a167c117c 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -262,6 +262,32 @@ &frddr_c {
+ 	status = "okay";
+ };
+
++/*
++pin-8, pin-36 are mapped referring to: /include/dt-bindings/gpio/meson-g12a-gpio.h
++left as is for future tests
++*/
++/*CHIP0*/
++&gpio {
++    gpio-line-names =
++    /*00*/ "", "", "", "", "", "", "", "", "", "",
++    /*10*/ "", "", "", "", "", "", "", "", "", "",
++    /*20*/ "19 [GPIOH_4]", "21 [GPIOH_5]", "24 [GPIOH_6]", "23 [GPIOH_7]", "36 [GPIOH_8]", "", "", "", "", "",
++    /*30*/ "", "", "", "", "", "", "", "", "", "",
++    /*40*/ "", "", "", "", "", "", "", "", "22 [GPIOC_7]", "",
++    /*50*/ "", "", "", "", "", "", "", "", "", "",
++    /*60*/ "", "", "", "3 [GPIOA_14]", "", "", "", "", "", "",
++    /*70*/ "", "", "", "18 [GPIOX_8]", "12 [GPIOX_9]", "16 [GPIOX_10]", "13 [GPIOX_11]", "", "", "",
++    /*80*/ "", "", "", "", "";
++};
++
++/*CHIP1*/
++&gpio_ao {
++    gpio-line-names =
++    /*00*/ "8 [GPIOAO_0]", "10 [GPIOAO_1]", "11,28 [GPIOAO_2]", "7,27 [GPIOAO_3]", "32 [GPIOAO_4]",
++    /*05*/ "5 [GPIOA_15]", "", "", "35 [GPIOAO_8]", "37 [GPIOAO_9]",
++    /*10*/ "", "40 [GPIOAO_11]", "", "", "";
++};
++
+ &hdmi_tx {
+ 	status = "okay";
+ 	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;


### PR DESCRIPTION
# Description

The issue I refer to is specified below. GPIO names for Radxa Zero board, used mainly for purpose of fully functional `libgpiod` are now specified and patches for Kernel [6.6](https://github.com/way5/armbian-build/blob/radxa-zero/patch/kernel/archive/meson64-6.6/meson-g12a-radxa-zero-gpio-pin-names.patch) and [6.12](https://github.com/way5/armbian-build/blob/radxa-zero/patch/kernel/archive/meson64-6.12/meson-g12a-radxa-zero-gpio-pin-names.patch) were added in accordance to project guidelines.

GitHub issue reference: #7541
Jira reference number [AR-2549](https://armbian.atlassian.net/browse/AR-2549)

# How Has This Been Tested?

<details>
<summary>Final result</summary>

```bash

root@radxa-zero:~# gpioinfo
gpiochip0 - 85 lines:
	line   0:      unnamed       unused   input  active-high 
	line   1:      unnamed       unused   input  active-high 
	line   2:      unnamed       unused   input  active-high 
	line   3:      unnamed       unused   input  active-high 
	line   4:      unnamed       unused   input  active-high 
	line   5:      unnamed       unused   input  active-high 
	line   6:      unnamed       unused   input  active-high 
	line   7:      unnamed       unused   input  active-high 
	line   8:      unnamed       unused   input  active-high 
	line   9:      unnamed       unused   input  active-high 
	line  10:      unnamed       unused   input  active-high 
	line  11:      unnamed       unused   input  active-high 
	line  12:      unnamed       unused   input  active-high 
	line  13:      unnamed       unused   input  active-high 
	line  14:      unnamed       unused   input  active-high 
	line  15:      unnamed       unused   input  active-high 
	line  16:      unnamed       unused   input  active-high 
	line  17:      unnamed       unused   input  active-high 
	line  18:      unnamed       unused   input  active-high 
	line  19:      unnamed       unused   input  active-high 
	line  20: "19 [GPIOH_4]" unused input active-high 
	line  21: "21 [GPIOH_5]" unused input active-high 
	line  22: "24 [GPIOH_6]" unused input active-high 
	line  23: "23 [GPIOH_7]" unused input active-high 
	line  24: "36 [GPIOH_8]" unused output active-high 
	line  25:      unnamed       unused   input  active-high 
	line  26:      unnamed       unused   input  active-high 
	line  27:      unnamed       unused   input  active-high 
	line  28:      unnamed       unused   input  active-high 
	line  29:      unnamed       unused   input  active-high 
	line  30:      unnamed       unused   input  active-high 
	line  31:      unnamed       unused   input  active-high 
	line  32:      unnamed       unused   input  active-high 
	line  33:      unnamed       unused   input  active-high 
	line  34:      unnamed       unused   input  active-high 
	line  35:      unnamed       unused   input  active-high 
	line  36:      unnamed       unused   input  active-high 
	line  37:      unnamed      "reset"  output   active-low [used]
	line  38:      unnamed       unused   input  active-high 
	line  39:      unnamed       unused   input  active-high 
	line  40:      unnamed       unused   input  active-high 
	line  41:      unnamed       unused   input  active-high 
	line  42:      unnamed       unused   input  active-high 
	line  43:      unnamed       unused   input  active-high 
	line  44:      unnamed       unused   input  active-high 
	line  45:      unnamed       unused   input  active-high 
	line  46:      unnamed       unused   input  active-high 
	line  47:      unnamed         "cd"   input   active-low [used]
	line  48: "22 [GPIOC_7]" unused input active-high 
	line  49:      unnamed       unused   input  active-high 
	line  50:      unnamed       unused   input  active-high 
	line  51:      unnamed       unused   input  active-high 
	line  52:      unnamed       unused   input  active-high 
	line  53:      unnamed       unused   input  active-high 
	line  54:      unnamed       unused   input  active-high 
	line  55:      unnamed       unused   input  active-high 
	line  56:      unnamed       unused   input  active-high 
	line  57:      unnamed       unused   input  active-high 
	line  58:      unnamed       unused   input  active-high 
	line  59:      unnamed       unused   input  active-high 
	line  60:      unnamed       unused   input  active-high 
	line  61:      unnamed       unused   input  active-high 
	line  62:      unnamed       unused   input  active-high 
	line  63: "3 [GPIOA_14]" unused input active-high 
	line  64:      unnamed       unused   input  active-high 
	line  65:      unnamed       unused   input  active-high 
	line  66:      unnamed       unused   input  active-high 
	line  67:      unnamed       unused   input  active-high 
	line  68:      unnamed       unused   input  active-high 
	line  69:      unnamed       unused   input  active-high 
	line  70:      unnamed       unused   input  active-high 
	line  71:      unnamed      "reset"  output   active-low [used]
	line  72:      unnamed       unused   input  active-high 
	line  73: "18 [GPIOX_8]" unused input active-high 
	line  74: "12 [GPIOX_9]" unused input active-high 
	line  75: "16 [GPIOX_10]" unused input active-high 
	line  76: "13 [GPIOX_11]" unused input active-high 
	line  77:      unnamed       unused   input  active-high 
	line  78:      unnamed       unused   input  active-high 
	line  79:      unnamed       unused   input  active-high 
	line  80:      unnamed       unused   input  active-high 
	line  81:      unnamed       unused   input  active-high 
	line  82:      unnamed   "shutdown"  output  active-high [used]
	line  83:      unnamed       unused   input  active-high 
	line  84:      unnamed       unused   input  active-high 
gpiochip1 - 15 lines:
	line   0: "8 [GPIOAO_0]" unused input active-high 
	line   1: "10 [GPIOAO_1]" unused input active-high 
	line   2: "11,28 [GPIOAO_2]" unused input active-high 
	line   3: "7,27 [GPIOAO_3]" unused input active-high 
	line   4: "32 [GPIOAO_4]" unused input active-high 
	line   5: "5 [GPIOA_15]" unused input active-high 
	line   6:      unnamed       unused   input  active-high 
	line   7:      unnamed       unused   input  active-high 
	line   8: "35 [GPIOAO_8]" unused input active-high 
	line   9: "37 [GPIOAO_9]" unused input active-high 
	line  10:      unnamed       unused   input  active-high 
	line  11: "40 [GPIOAO_11]" unused input active-high 
	line  12:      unnamed       unused   input  active-high 
	line  13:      unnamed       unused   input  active-high 
	line  14:      unnamed       unused   input  active-high

```
</details>

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2549]: https://armbian.atlassian.net/browse/AR-2549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ