### PR TITLE
rockchip64: rk3399 fix pcie being stuck at 1x width after a warm phy reset

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/rk3399-fix-pci-lanes.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk3399-fix-pci-lanes.patch
@@ -1,0 +1,44 @@
+From 77f6dfcb20c2dc6a4a2f5303709c6fa0c7b65f30 Mon Sep 17 00:00:00 2001
+From: Valmantas Paliksa <walmis@gmail.com>
+Date: Thu, 12 Dec 2024 12:24:33 +0200
+Subject: [PATCH] Disable PHY_LANE_IDLE_OFF for each instance of
+ rockchip_pcie_phy_power_one
+
+Previously PHY_LANE_IDLE_OFF was only disabled for the first lane
+---
+ drivers/phy/rockchip/phy-rockchip-pcie.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-pcie.c b/drivers/phy/rockchip/phy-rockchip-pcie.c
+index 8234b83fdd88..240cb27a0e9e 100644
+--- a/drivers/phy/rockchip/phy-rockchip-pcie.c
++++ b/drivers/phy/rockchip/phy-rockchip-pcie.c
+@@ -167,6 +167,12 @@ static int rockchip_pcie_phy_power_on(struct phy *phy)
+ 
+ 	mutex_lock(&rk_phy->pcie_mutex);
+ 
++	regmap_write(rk_phy->reg_base,
++		     rk_phy->phy_data->pcie_laneoff,
++		     HIWORD_UPDATE(!PHY_LANE_IDLE_OFF,
++				   PHY_LANE_IDLE_MASK,
++				   PHY_LANE_IDLE_A_SHIFT + inst->index));
++
+ 	if (rk_phy->pwr_cnt++)
+ 		goto err_out;
+ 
+@@ -181,12 +187,6 @@ static int rockchip_pcie_phy_power_on(struct phy *phy)
+ 				   PHY_CFG_ADDR_MASK,
+ 				   PHY_CFG_ADDR_SHIFT));
+ 
+-	regmap_write(rk_phy->reg_base,
+-		     rk_phy->phy_data->pcie_laneoff,
+-		     HIWORD_UPDATE(!PHY_LANE_IDLE_OFF,
+-				   PHY_LANE_IDLE_MASK,
+-				   PHY_LANE_IDLE_A_SHIFT + inst->index));
+-
+ 	/*
+ 	 * No documented timeout value for phy operation below,
+ 	 * so we make it large enough here. And we use loop-break
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-6.6/rk3399-fix-pci-lanes.patch
+++ b/patch/kernel/archive/rockchip64-6.6/rk3399-fix-pci-lanes.patch
@@ -1,0 +1,44 @@
+From 77f6dfcb20c2dc6a4a2f5303709c6fa0c7b65f30 Mon Sep 17 00:00:00 2001
+From: Valmantas Paliksa <walmis@gmail.com>
+Date: Thu, 12 Dec 2024 12:24:33 +0200
+Subject: [PATCH] Disable PHY_LANE_IDLE_OFF for each instance of
+ rockchip_pcie_phy_power_one
+
+Previously PHY_LANE_IDLE_OFF was only disabled for the first lane
+---
+ drivers/phy/rockchip/phy-rockchip-pcie.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-pcie.c b/drivers/phy/rockchip/phy-rockchip-pcie.c
+index 8234b83fdd88..240cb27a0e9e 100644
+--- a/drivers/phy/rockchip/phy-rockchip-pcie.c
++++ b/drivers/phy/rockchip/phy-rockchip-pcie.c
+@@ -167,6 +167,12 @@ static int rockchip_pcie_phy_power_on(struct phy *phy)
+ 
+ 	mutex_lock(&rk_phy->pcie_mutex);
+ 
++	regmap_write(rk_phy->reg_base,
++		     rk_phy->phy_data->pcie_laneoff,
++		     HIWORD_UPDATE(!PHY_LANE_IDLE_OFF,
++				   PHY_LANE_IDLE_MASK,
++				   PHY_LANE_IDLE_A_SHIFT + inst->index));
++
+ 	if (rk_phy->pwr_cnt++)
+ 		goto err_out;
+ 
+@@ -181,12 +187,6 @@ static int rockchip_pcie_phy_power_on(struct phy *phy)
+ 				   PHY_CFG_ADDR_MASK,
+ 				   PHY_CFG_ADDR_SHIFT));
+ 
+-	regmap_write(rk_phy->reg_base,
+-		     rk_phy->phy_data->pcie_laneoff,
+-		     HIWORD_UPDATE(!PHY_LANE_IDLE_OFF,
+-				   PHY_LANE_IDLE_MASK,
+-				   PHY_LANE_IDLE_A_SHIFT + inst->index));
+-
+ 	/*
+ 	 * No documented timeout value for phy operation below,
+ 	 * so we make it large enough here. And we use loop-break
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-6.9/rk3399-fix-pci-lanes.patch
+++ b/patch/kernel/archive/rockchip64-6.9/rk3399-fix-pci-lanes.patch
@@ -1,0 +1,44 @@
+From 77f6dfcb20c2dc6a4a2f5303709c6fa0c7b65f30 Mon Sep 17 00:00:00 2001
+From: Valmantas Paliksa <walmis@gmail.com>
+Date: Thu, 12 Dec 2024 12:24:33 +0200
+Subject: [PATCH] Disable PHY_LANE_IDLE_OFF for each instance of
+ rockchip_pcie_phy_power_one
+
+Previously PHY_LANE_IDLE_OFF was only disabled for the first lane
+---
+ drivers/phy/rockchip/phy-rockchip-pcie.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-pcie.c b/drivers/phy/rockchip/phy-rockchip-pcie.c
+index 8234b83fdd88..240cb27a0e9e 100644
+--- a/drivers/phy/rockchip/phy-rockchip-pcie.c
++++ b/drivers/phy/rockchip/phy-rockchip-pcie.c
+@@ -167,6 +167,12 @@ static int rockchip_pcie_phy_power_on(struct phy *phy)
+ 
+ 	mutex_lock(&rk_phy->pcie_mutex);
+ 
++	regmap_write(rk_phy->reg_base,
++		     rk_phy->phy_data->pcie_laneoff,
++		     HIWORD_UPDATE(!PHY_LANE_IDLE_OFF,
++				   PHY_LANE_IDLE_MASK,
++				   PHY_LANE_IDLE_A_SHIFT + inst->index));
++
+ 	if (rk_phy->pwr_cnt++)
+ 		goto err_out;
+ 
+@@ -181,12 +187,6 @@ static int rockchip_pcie_phy_power_on(struct phy *phy)
+ 				   PHY_CFG_ADDR_MASK,
+ 				   PHY_CFG_ADDR_SHIFT));
+ 
+-	regmap_write(rk_phy->reg_base,
+-		     rk_phy->phy_data->pcie_laneoff,
+-		     HIWORD_UPDATE(!PHY_LANE_IDLE_OFF,
+-				   PHY_LANE_IDLE_MASK,
+-				   PHY_LANE_IDLE_A_SHIFT + inst->index));
+-
+ 	/*
+ 	 * No documented timeout value for phy operation below,
+ 	 * so we make it large enough here. And we use loop-break
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

This patch fixes an issue in the Rockchip PCIe PHY driver where, after a warm restart of the `rockchip_pcie_phy` module, PCIe lanes other than lane 0 could remain stuck in the `PHY_LANE_IDLE_OFF` state. This resulted in the PCIe link being restricted to x1 mode, even in configurations designed to use multiple lanes.

The patch moves the `regmap_write` block, which disables the `PHY_LANE_IDLE_OFF` state, to a position before the `if (rk_phy->pwr_cnt++) goto err_out;` condition. This ensures that all lanes are properly re-enabled during the `rockchip_pcie_phy_power_on` function, which is called for each pcie lane, fixing the multi-lane handling issue.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference:  
https://github.com/armbian/build/issues/6655

# Documentation summary for feature / change

- **Short description:** Fix multi-lane PCIe initialization issue after warm restart.
- **Summary:** Ensures proper re-enabling of all PCIe lanes in `rockchip_pcie_phy_power_on` by addressing a warm restart issue that left non-zero lanes in the `PHY_LANE_IDLE_OFF` state. This fixes scenarios where the PCIe link was incorrectly limited to x1 mode.  
- **Example of usage:** Changes are internal to the driver. End users can verify functionality by ensuring PCIe links initialize correctly with the expected lane count after warm restarts.

# How Has This Been Tested?

This patch has been tested with the following:

- [x] Multi-lane PCIe configurations to verify proper initialization after a warm restart.
- [x] Single-lane PCIe configurations to confirm no regressions were introduced.
- [ ] Regression tests for other PHY-related operations.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.