### PR TITLE
Repository management: disable broken and not needed functionality `Acquire-By-Hash`

### DIFF
--- a/tools/repository/repo
+++ b/tools/repository/repo
@@ -134,7 +134,6 @@ publishing(){
 		echo "Publishing $release"
 
 		aptly publish \
-			-acquire-by-hash \
 			-architectures="armhf,arm64,amd64,riscv64,i386,all" \
 			-passphrase="${4}" \
 			-origin="Armbian" \


### PR DESCRIPTION
# Description

After examining repository indexes, there were broken symbolic links in the hashing folders. This is optional feature and is not used / can't be used as its broken by Aptly.

Disabling this improves:

- faster repo generation
- cleaner repository

# Documentation summary for feature / change

https://wiki.debian.org/DebianRepository/Format#Acquire-By-Hash

# How Has This Been Tested?

- [x] Repository generate

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
