### PR TITLE
Starfive: fix broken patch due to kernel upgrade

### DIFF
--- a/patch/kernel/archive/starfive-6.1/1016-serial-8250_dw-Add-starfive-jh7100-hsuart-compatible.patch
+++ b/patch/kernel/archive/starfive-6.1/1016-serial-8250_dw-Add-starfive-jh7100-hsuart-compatible.patch
@@ -8,22 +8,26 @@ RISC-V SoC. Just like the regular uarts we also need to keep the input
 clocks at their default rate and rely only on the divisor in the UART.
 
 Signed-off-by: Emil Renner Berthing <kernel@esmil.dk>
+Signed-off-by: Armbian Linux <info@armbian.com>
 ---
  drivers/tty/serial/8250/8250_dw.c | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/tty/serial/8250/8250_dw.c b/drivers/tty/serial/8250/8250_dw.c
-index 7db51781289e..b749f2805df7 100644
+index 72f9aab75ab1..33aa972c0de1 100644
 --- a/drivers/tty/serial/8250/8250_dw.c
 +++ b/drivers/tty/serial/8250/8250_dw.c
-@@ -777,6 +777,7 @@ static const struct of_device_id dw8250_of_match[] = {
+@@ -779,10 +779,11 @@ static const struct of_device_id dw8250_of_match[] = {
+ 	{ .compatible = "snps,dw-apb-uart", .data = &dw8250_dw_apb },
  	{ .compatible = "cavium,octeon-3860-uart", .data = &dw8250_octeon_3860_data },
  	{ .compatible = "marvell,armada-38x-uart", .data = &dw8250_armada_38x_data },
  	{ .compatible = "renesas,rzn1-uart", .data = &dw8250_renesas_rzn1_data },
+ 	{ .compatible = "sophgo,sg2044-uart", .data = &dw8250_skip_set_rate_data },
 +	{ .compatible = "starfive,jh7100-hsuart", .data = &dw8250_starfive_jh7100_data },
- 	{ .compatible = "starfive,jh7100-uart", .data = &dw8250_starfive_jh7100_data },
+ 	{ .compatible = "starfive,jh7100-uart", .data = &dw8250_skip_set_rate_data },
  	{ /* Sentinel */ }
  };
+ MODULE_DEVICE_TABLE(of, dw8250_of_match);
+ 
 -- 
-Armbian
-
+Created with Armbian build tools https://github.com/armbian/build


### PR DESCRIPTION
# Description

Kernel maintenance. 


[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: https://paste.armbian.de/oniwaperov

# How Has This Been Tested?

- [x] Patching passes

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
