### PR TITLE
sunxi-6.6: Switch to v6.6.65, re-export patches

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -31,7 +31,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.62"
+		declare -g KERNELBRANCH="tag:v6.6.65"
 		;;
 
 	edge)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -32,7 +32,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.62"
+		declare -g KERNELBRANCH="tag:v6.6.65"
 		;;
 
 	edge)

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-BananaPi-BPI-M4-Zero-overlays.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-BananaPi-BPI-M4-Zero-overlays.patch
@@ -1,24 +1,23 @@
-From ab2682af1cf693ce7043b397c6c9157fe8f9859b Mon Sep 17 00:00:00 2001
+From 4d117355aa136c467962a60a35c14c13c8ccf352 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
 Date: Wed, 11 Dec 2024 12:23:10 -0500
-Subject: [PATCH] Add BananaPi BPI-M4-Zero overlays
+Subject: Add BananaPi BPI-M4-Zero overlays
 
 Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
  .../arm64/boot/dts/allwinner/overlay/Makefile | 11 +++++++
+ ...sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso | 13 ++++++++
+ ...sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso | 13 ++++++++
+ .../sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso | 13 ++++++++
+ ...un50i-h616-bananapi-m4-pi-13-14-uart4.dtso | 13 ++++++++
+ ...16-bananapi-m4-pi-15-16-rts-cts-uart4.dtso | 16 ++++++++++
+ .../sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso  | 13 ++++++++
+ .../sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso  | 13 ++++++++
  .../sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso | 29 +++++++++++++++++
- ...i-h616-bananapi-m4-pg-15-16-i2c4.dtso | 13 ++++++++
- ...i-h616-bananapi-m4-pg-17-18-i2c3.dtso | 13 ++++++++
- ...0i-h616-bananapi-m4-ph-2-3-uart5.dtso | 13 ++++++++
- ...-h616-bananapi-m4-pi-13-14-uart4.dtso | 13 ++++++++
- ...nanapi-m4-pi-15-16-rts-cts-uart4.dtso | 16 ++++++++++
- ...50i-h616-bananapi-m4-pi-5-6-i2c0.dtso | 13 ++++++++
- ...50i-h616-bananapi-m4-pi-7-8-i2c1.dtso | 13 ++++++++
- ...-bananapi-m4-spi1-cs0-cs1-spidev.dtso | 32 +++++++++++++++++++
- ...h616-bananapi-m4-spi1-cs0-spidev.dtso | 24 ++++++++++++++
- ...h616-bananapi-m4-spi1-cs1-spidev.dtso | 13 ++++++++
+ ...-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso | 32 +++++++++++++++++++
+ ...n50i-h616-bananapi-m4-spi1-cs0-spidev.dtso | 24 ++++++++++++++
+ ...n50i-h616-bananapi-m4-spi1-cs1-spidev.dtso | 13 ++++++++
  12 files changed, 203 insertions(+)
- create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso
@@ -26,15 +25,16 @@ Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtso
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtso
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtso
 
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-index 76a4952e3ecc..1e76bbcb67af 100644
+index 24383cb63770..da0e99784b8c 100644
 --- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-@@ -48,6 +48,17 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
+@@ -49,6 +49,17 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
  	sun50i-h6-uart2.dtbo \
  	sun50i-h6-uart3.dtbo \
  	sun50i-h6-w1-gpio.dtbo \
@@ -52,41 +52,6 @@ index 76a4952e3ecc..1e76bbcb67af 100644
  	sun50i-h616-i2c2-ph.dtbo \
  	sun50i-h616-i2c3-ph.dtbo \
  	sun50i-h616-i2c4-ph.dtbo \
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
-new file mode 100644
-index 000000000000..b672807fab66
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
-@@ -0,0 +1,29 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "sinovoip,bpi-m4-zero", "allwinner,sun50i-h616", "allwinner,sun50i-h618";
-+
-+	fragment@0 {
-+		target-path = "/";
-+		__overlay__ {
-+			model = "BananaPi BPI-M4-Zero v2";
-+		};
-+	};
-+
-+	/* SDIO WIFI */
-+	fragment@1 {
-+		target = <&mmc1>;
-+		__overlay__ {
-+			status = "okay";
-+		};
-+	};
-+
-+	/* BLUETOOTH */
-+	fragment@2 {
-+		target = <&uart1>;
-+		__overlay__ {
-+			status = "okay";
-+		};
-+	};
-+};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso
 new file mode 100644
 index 000000000000..4e78aa8f1f27
@@ -223,6 +188,41 @@ index 000000000000..99c7e2b8c5f6
 +		};
 +	};
 +};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
+new file mode 100644
+index 000000000000..b672807fab66
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
+@@ -0,0 +1,29 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "sinovoip,bpi-m4-zero", "allwinner,sun50i-h616", "allwinner,sun50i-h618";
++
++	fragment@0 {
++		target-path = "/";
++		__overlay__ {
++			model = "BananaPi BPI-M4-Zero v2";
++		};
++	};
++
++	/* SDIO WIFI */
++	fragment@1 {
++		target = <&mmc1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	/* BLUETOOTH */
++	fragment@2 {
++		target = <&uart1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso
 new file mode 100644
 index 000000000000..7fa3b94bcc8d
@@ -311,5 +311,5 @@ index 000000000000..840357f2e9e0
 +	};
 +};
 -- 
-2.39.5
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-BananaPi-BPI-M4-Zero-pinctrl.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-BananaPi-BPI-M4-Zero-pinctrl.patch
@@ -1,18 +1,23 @@
-From 6f8e2ef1d8ba018353552278658462cab285fa6f Mon Sep 17 00:00:00 2001
+From 4ca92dbeb0a089f61a831ce9d3dd6cbf20e291b5 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
 Date: Thu, 12 Dec 2024 03:49:35 -0500
-Subject: [PATCH] Add BananaPi BPI-M4-Zero pinctrl
+Subject: Add BananaPi BPI-M4-Zero pinctrl
 
 Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
- .../arm64/boot/dts/allwinner/sun50i-h616.dtsi | 54 +++++++++++++++++++
- 1 file changed, 54 insertions(+)
+ .../arm64/boot/dts/allwinner/sun50i-h616.dtsi | 56 ++++++++++++++++++-
+ 1 file changed, 55 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-index 8cb3ae91909f..fa4d0ef27b44 100644
+index 8cb3ae91909f..4c1b61b3c64f 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -391,6 +391,30 @@ i2c0_pins: i2c0-pins {
+@@ -387,10 +387,34 @@ ext_rgmii_pins: rgmii-pins {
+ 			};
+ 
+ 			i2c0_pins: i2c0-pins {
+-				pins = "PI6", "PI7";
++				pins = "PI5", "PI6";
  				function = "i2c0";
  			};
  
@@ -81,31 +86,5 @@ index 8cb3ae91909f..fa4d0ef27b44 100644
  				pins = "PH0", "PH1";
  				function = "uart0";
 -- 
-2.39.5
-
-From cadd958178c9854df5db40f26dd69e506faf30c0 Mon Sep 17 00:00:00 2001
-From: Patrick Yavitz <pyavitz@armbian.com>
-Date: Thu, 12 Dec 2024 05:49:56 -0500
-Subject: [PATCH] Fixup i2c0 pins
-
-Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
----
- arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-index fa4d0ef27b44..4c1b61b3c64f 100644
---- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -387,7 +387,7 @@ ext_rgmii_pins: rgmii-pins {
- 			};
- 
- 			i2c0_pins: i2c0-pins {
--				pins = "PI6", "PI7";
-+				pins = "PI5", "PI6";
- 				function = "i2c0";
- 			};
- 
--- 
-2.39.5
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-board-LonganPi-3H.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-board-LonganPi-3H.patch
@@ -1,4 +1,34 @@
---- a/arch/arm64/boot/dts/allwinner/sun50i-h618-longan-module-3h.dtsi
+From e1a4c46389ce01b2a3c080f6f4b607893571b86d Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Sun, 15 Dec 2024 13:22:18 +0300
+Subject: [PATCH] Add board LonganPi 3H
+
+Author: chainsx <i@mail.chainsx.cn>
+Signed-off-by: The-going <48602507+The-going@users.noreply.github.com>
+---
+ arch/arm64/boot/dts/allwinner/Makefile        |   1 +
+ .../sun50i-h618-longan-module-3h.dtsi         |  87 +++++++++
+ .../dts/allwinner/sun50i-h618-longanpi-3h.dts | 168 ++++++++++++++++++
+ 3 files changed, 256 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-longan-module-3h.dtsi
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-longanpi-3h.dts
+
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 812685d6740f..cab747308db9 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -56,6 +56,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-bananapi-m4-zero.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-longanpi-3h.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero2w.dtb
+ 
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-longan-module-3h.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h618-longan-module-3h.dtsi
+new file mode 100644
+index 000000000000..45cb11275a23
+--- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-longan-module-3h.dtsi
 @@ -0,0 +1,87 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
@@ -88,8 +118,10 @@
 +	vcc-ph-supply = <&reg_dldo1>;
 +	vcc-pi-supply = <&reg_dldo1>;
 +};
-
---- a/arch/arm64/boot/dts/allwinner/sun50i-h618-longanpi-3h.dts
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-longanpi-3h.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-longanpi-3h.dts
+new file mode 100644
+index 000000000000..f4e8391efffe
+--- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-longanpi-3h.dts
 @@ -0,0 +1,168 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
@@ -260,13 +292,6 @@
 +	usb1_vbus-supply = <&reg_vcc5v>;
 +	status = "okay";
 +};
+-- 
+2.35.3
 
---- a/arch/arm64/boot/dts/allwinner/Makefile
-+++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -57,6 +57,7 @@
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-bananapi-m4-zero.dtb
-+dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-longanpi-3h.dtb
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero2w.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Correct-perf-interrupt-source-number-as-referenced-in-the-Allwi.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Correct-perf-interrupt-source-number-as-referenced-in-the-Allwi.patch
@@ -1,7 +1,9 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From c7b64a9dff925e5887e37230ffe0e194a4d59f38 Mon Sep 17 00:00:00 2001
 From: Ryzer58 <ryestar101@gmail.com>
 Date: Thu, 25 Apr 2024 22:18:22 +0100
-Subject: Correct perf interrupt source number as referenced in the Allwinner A10 User manual
+Subject: Correct perf interrupt source number as referenced in the Allwinner
+ A10 User manual
+
 to resolve conflict with UART2.
 
 Signed-off-by: Ryzer58 <ryestar101@gmail.com>
@@ -13,9 +15,7 @@ diff --git a/arch/arm/boot/dts/allwinner/sun4i-a10.dtsi b/arch/arm/boot/dts/allw
 index 51a6464aab9a..cabf619c2e21 100644
 --- a/arch/arm/boot/dts/allwinner/sun4i-a10.dtsi
 +++ b/arch/arm/boot/dts/allwinner/sun4i-a10.dtsi
-@@ -183,11 +183,11 @@ de: display-engine {
- 		status = "disabled";
- 	};
+@@ -185,7 +185,7 @@ de: display-engine {
  
  	pmu {
  		compatible = "arm,cortex-a8-pmu";
@@ -24,8 +24,6 @@ index 51a6464aab9a..cabf619c2e21 100644
  	};
  
  	reserved-memory {
- 		#address-cells = <1>;
- 		#size-cells = <1>;
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Enable-DMA-support-for-the-Allwinner-A10-EMAC-which-already-exi.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Enable-DMA-support-for-the-Allwinner-A10-EMAC-which-already-exi.patch
@@ -1,7 +1,8 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From df8af1fccb4c20529f7efd46ed4ef5b64e333c9e Mon Sep 17 00:00:00 2001
 From: Ryzer58 <ryestar101@gmail.com>
 Date: Sun, 4 Aug 2024 23:45:50 +0100
-Subject: Enable DMA support for the Allwinner A10 EMAC, which already exist in the sun4i-emac driver
+Subject: Enable DMA support for the Allwinner A10 EMAC, which already exist in
+ the sun4i-emac driver
 
 Signed-off-by: Ryzer58 <ryestar101@gmail.com>
 ---
@@ -12,9 +13,7 @@ diff --git a/arch/arm/boot/dts/allwinner/sun4i-a10.dtsi b/arch/arm/boot/dts/allw
 index cabf619c2e21..08a8433b595e 100644
 --- a/arch/arm/boot/dts/allwinner/sun4i-a10.dtsi
 +++ b/arch/arm/boot/dts/allwinner/sun4i-a10.dtsi
-@@ -313,10 +313,12 @@ emac: ethernet@1c0b000 {
- 			compatible = "allwinner,sun4i-a10-emac";
- 			reg = <0x01c0b000 0x1000>;
+@@ -315,6 +315,8 @@ emac: ethernet@1c0b000 {
  			interrupts = <55>;
  			clocks = <&ccu CLK_AHB_EMAC>;
  			allwinner,sram = <&emac_sram 1>;
@@ -23,8 +22,6 @@ index cabf619c2e21..08a8433b595e 100644
  			pinctrl-names = "default";
  			pinctrl-0 = <&emac_pins>;
  			status = "disabled";
- 		};
- 
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Sound-for-H616-H618-Allwinner-SOCs.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Sound-for-H616-H618-Allwinner-SOCs.patch
@@ -1,4 +1,4 @@
-From 6e527d62e8e118474abae0058e7df10e98afb4ce Mon Sep 17 00:00:00 2001
+From 860fc70719192613893ed1a1b9872fa99ead7714 Mon Sep 17 00:00:00 2001
 From: Stephen Graf <stephen.graf@gmail.com>
 Date: Thu, 9 May 2024 20:59:34 -0700
 Subject: Sound for H616, H618 Allwinner SOCs
@@ -76,7 +76,7 @@ index ce3dc6d9cd66..23553f2249c2 100644
  	status = "okay";
  };
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-index b7c9d4b02751..f4ff1833e5fe 100644
+index ccaca20eb10b..8cb3ae91909f 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 @@ -182,6 +182,78 @@ dma: dma-controller@3002000 {
@@ -158,7 +158,7 @@ index b7c9d4b02751..f4ff1833e5fe 100644
  		gpu: gpu@1800000 {
  			compatible = "allwinner,sun50i-h616-mali",
  				     "arm,mali-bifrost";
-@@ -475,6 +547,17 @@ gic: interrupt-controller@3021000 {
+@@ -439,6 +511,17 @@ gic: interrupt-controller@3021000 {
  			#interrupt-cells = <3>;
  		};
  

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-mmc-host-sunxi-mmc-add-h5-emmc-compatible.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-mmc-host-sunxi-mmc-add-h5-emmc-compatible.patch
@@ -11,7 +11,7 @@ diff --git a/drivers/mmc/host/sunxi-mmc.c b/drivers/mmc/host/sunxi-mmc.c
 index e9370c736497..9c86bd19a95d 100644
 --- a/drivers/mmc/host/sunxi-mmc.c
 +++ b/drivers/mmc/host/sunxi-mmc.c
-@@ -1214,6 +1214,13 @@ static const struct sunxi_mmc_cfg sun50i_a100_emmc_cfg = {
+@@ -1213,6 +1213,13 @@ static const struct sunxi_mmc_cfg sun50i_a100_emmc_cfg = {
  	.needs_new_timings = true,
  };
  
@@ -25,14 +25,14 @@ index e9370c736497..9c86bd19a95d 100644
  static const struct of_device_id sunxi_mmc_of_match[] = {
  	{ .compatible = "allwinner,sun4i-a10-mmc", .data = &sun4i_a10_cfg },
  	{ .compatible = "allwinner,sun5i-a13-mmc", .data = &sun5i_a13_cfg },
-@@ -1225,6 +1232,7 @@ static const struct of_device_id sunxi_mmc_of_match[] = {
+@@ -1224,6 +1231,7 @@ static const struct of_device_id sunxi_mmc_of_match[] = {
  	{ .compatible = "allwinner,sun50i-a64-emmc", .data = &sun50i_a64_emmc_cfg },
- 	{ .compatible = "allwinner,sun50i-a100-mmc", .data = &sun50i_a100_cfg },
+ 	{ .compatible = "allwinner,sun50i-a100-mmc", .data = &sun20i_d1_cfg },
  	{ .compatible = "allwinner,sun50i-a100-emmc", .data = &sun50i_a100_emmc_cfg },
 +	{ .compatible = "allwinner,sun50i-h5-emmc", .data = &sun50i_h5_emmc_cfg },
+ 	{ .compatible = "allwinner,sun50i-h616-mmc", .data = &sun50i_h616_cfg },
  	{ /* sentinel */ }
  };
- MODULE_DEVICE_TABLE(of, sunxi_mmc_of_match);
 -- 
 Armbian
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-usb-gadget-composite-rename-gadget-serial-console-manufactu.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-usb-gadget-composite-rename-gadget-serial-console-manufactu.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 5ca11510c7e08ba82aaba4af656edddc502adb6f Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Wed, 2 Feb 2022 20:08:50 +0300
 Subject: drv:usb:gadget:composite rename gadget serial console manufacturer
@@ -10,10 +10,10 @@ to the Armbian brand.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/usb/gadget/composite.c b/drivers/usb/gadget/composite.c
-index 0ace45b66a31..89b596897733 100644
+index 9225c21d1184..faee433d272c 100644
 --- a/drivers/usb/gadget/composite.c
 +++ b/drivers/usb/gadget/composite.c
-@@ -2758,7 +2758,7 @@ EXPORT_SYMBOL_GPL(usb_composite_setup_continue);
+@@ -2770,7 +2770,7 @@ EXPORT_SYMBOL_GPL(usb_composite_setup_continue);
  
  static char *composite_default_mfr(struct usb_gadget *gadget)
  {
@@ -23,5 +23,5 @@ index 0ace45b66a31..89b596897733 100644
  }
  
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/mmc-host-sunxi-mmc-Fix-H6-emmc.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/mmc-host-sunxi-mmc-Fix-H6-emmc.patch
@@ -12,14 +12,14 @@ diff --git a/drivers/mmc/host/sunxi-mmc.c b/drivers/mmc/host/sunxi-mmc.c
 index 7f336908a21c..a2747093de99 100644
 --- a/drivers/mmc/host/sunxi-mmc.c
 +++ b/drivers/mmc/host/sunxi-mmc.c
-@@ -1233,6 +1233,7 @@ static const struct of_device_id sunxi_mmc_of_match[] = {
- 	{ .compatible = "allwinner,sun50i-a100-mmc", .data = &sun50i_a100_cfg },
+@@ -1232,6 +1232,7 @@ static const struct of_device_id sunxi_mmc_of_match[] = {
+ 	{ .compatible = "allwinner,sun50i-a100-mmc", .data = &sun20i_d1_cfg },
  	{ .compatible = "allwinner,sun50i-a100-emmc", .data = &sun50i_a100_emmc_cfg },
  	{ .compatible = "allwinner,sun50i-h5-emmc", .data = &sun50i_h5_emmc_cfg },
 +	{ .compatible = "allwinner,sun50i-h6-emmc", .data = &sun50i_a64_emmc_cfg },
+ 	{ .compatible = "allwinner,sun50i-h616-mmc", .data = &sun50i_h616_cfg },
  	{ /* sentinel */ }
  };
- MODULE_DEVICE_TABLE(of, sunxi_mmc_of_match);
 @@ -1444,7 +1445,7 @@ static int sunxi_mmc_probe(struct platform_device *pdev)
  				  MMC_CAP_SDIO_IRQ;
  
@@ -33,7 +33,7 @@ index 7f336908a21c..a2747093de99 100644
  	if ((host->cfg->clk_delays || host->use_new_timings) &&
  	    !of_device_is_compatible(pdev->dev.of_node,
  				     "allwinner,sun50i-h5-emmc") &&
-+	    !of_device_is_compatible(pdev->dev.of_node,
++		!of_device_is_compatible(pdev->dev.of_node,
 +				     "allwinner,sun50i-h6-emmc") &&
  	    !of_machine_is_compatible("allwinner,sun7i-a20") &&
  	    !of_machine_is_compatible("olimex,a64-olinuxino-2ge8g"))

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/arm64-dts-sun50i-a64-pinephone-Add-Type-C-support-for-all-PP-va.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/arm64-dts-sun50i-a64-pinephone-Add-Type-C-support-for-all-PP-va.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 0284c4a28309f931a0ca267339734bb938d16b3a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ond=C5=99ej=20Jirman?= <megi@xff.cz>
 Date: Wed, 8 Jul 2020 00:58:16 +0200
 Subject: arm64: dts: sun50i-a64-pinephone: Add Type-C support for all PP
@@ -10,10 +10,10 @@ of 1.0 and 1.1 boards with one DTS. No need for more subvariants.
 
 Signed-off-by: Ondrej Jirman <megi@xff.cz>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-1.0.dts | 86 ++++++++++
- arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-1.1.dts | 86 ++++++++++
- arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-1.2.dts | 60 +++++++
- arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi    | 68 +++++++-
+ .../allwinner/sun50i-a64-pinephone-1.0.dts    | 86 +++++++++++++++++++
+ .../allwinner/sun50i-a64-pinephone-1.1.dts    | 86 +++++++++++++++++++
+ .../allwinner/sun50i-a64-pinephone-1.2.dts    | 60 +++++++++++++
+ .../dts/allwinner/sun50i-a64-pinephone.dtsi   | 68 ++++++++++++++-
  4 files changed, 299 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-1.0.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-1.0.dts
@@ -291,7 +291,7 @@ index bdca3e118ee4..aaa3349ce3d5 100644
 +	};
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
-index 92e77503b591..bf7bd0be9deb 100644
+index 50818303e9a5..6000608d349f 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
 @@ -10,6 +10,7 @@
@@ -391,7 +391,7 @@ index 92e77503b591..bf7bd0be9deb 100644
  &i2c_csi {
  	gc2145: front-camera@3c {
  		compatible = "galaxycore,gc2145";
-@@ -299,6 +361,10 @@ &i2c2 {
+@@ -302,6 +364,10 @@ &i2c2 {
  	status = "okay";
  };
  
@@ -402,7 +402,7 @@ index 92e77503b591..bf7bd0be9deb 100644
  &lradc {
  	vref-supply = <&reg_aldo3>;
  	wakeup-source;
-@@ -592,7 +658,7 @@ &uart3 {
+@@ -595,7 +661,7 @@ &uart3 {
  };
  
  &usb_otg {
@@ -412,5 +412,5 @@ index 92e77503b591..bf7bd0be9deb 100644
  };
  
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/arm64-dts-sun50i-a64-pinephone-Add-detailed-OCV-to-capactiy-con.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/arm64-dts-sun50i-a64-pinephone-Add-detailed-OCV-to-capactiy-con.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 9ebfe917d6ae804d317932e4c62c52ab1a6bf989 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ond=C5=99ej=20Jirman?= <megi@xff.cz>
 Date: Mon, 28 Sep 2020 04:35:13 +0200
 Subject: arm64: dts: sun50i-a64-pinephone: Add detailed OCV to capactiy
@@ -10,11 +10,11 @@ limits are enforced. It also allows for more precise capacity reporting
 
 Signed-off-by: Ondrej Jirman <megi@xff.cz>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi | 151 ++++++++++
+ .../dts/allwinner/sun50i-a64-pinephone.dtsi   | 151 ++++++++++++++++++
  1 file changed, 151 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
-index bf7bd0be9deb..243d9c793227 100644
+index 6000608d349f..d9111801fa0b 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
 @@ -28,6 +28,156 @@ backlight: backlight {
@@ -174,7 +174,7 @@ index bf7bd0be9deb..243d9c793227 100644
  	bt_sco_codec: bt-sco-codec {
  		#sound-dai-cells = <1>;
  		compatible = "linux,bt-sco";
-@@ -468,6 +618,7 @@ axp803: pmic@3a3 {
+@@ -471,6 +621,7 @@ axp803: pmic@3a3 {
  
  &battery_power_supply {
  	status = "okay";
@@ -183,5 +183,5 @@ index bf7bd0be9deb..243d9c793227 100644
  
  &reg_aldo1 {
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/arm64-dts-sun50i-a64-pinephone-Add-mount-matrix-for-acceleromet.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/arm64-dts-sun50i-a64-pinephone-Add-mount-matrix-for-acceleromet.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 1312787511b4b198cfe4992f81825da08eccecfc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ond=C5=99ej=20Jirman?= <megi@xff.cz>
 Date: Tue, 8 Sep 2020 15:31:26 +0200
 Subject: arm64: dts: sun50i-a64-pinephone: Add mount matrix for accelerometer
@@ -7,23 +7,22 @@ Port from pine64 kernel.
 
 Signed-off-by: Ondrej Jirman <megi@xff.cz>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi | 3 +++
- 1 file changed, 3 insertions(+)
+ arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
-index ff1182be8434..9bf23a57172f 100644
+index 07df04d10864..ee9653b78321 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
-@@ -503,6 +503,9 @@ accelerometer@68 {
- 		interrupts = <7 5 IRQ_TYPE_EDGE_RISING>; /* PH5 */
- 		vdd-supply = <&reg_dldo1>;
+@@ -505,7 +505,7 @@ accelerometer@68 {
  		vddio-supply = <&reg_dldo1>;
-+		mount-matrix = "0", "1", "0",
-+				"-1", "0", "0",
-+				"0", "0", "-1";
+ 		mount-matrix = "0", "1", "0",
+ 			       "-1", "0", "0",
+-			       "0", "0", "1";
++			       "0", "0", "-1";
  	};
  };
  
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/arm64-dts-sun50i-a64-pinephone-Shorten-post-power-on-delay-on-m.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/arm64-dts-sun50i-a64-pinephone-Shorten-post-power-on-delay-on-m.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 1c643d54f406046c829dc2d0ed6ba66ca003a8b5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ond=C5=99ej=20Jirman?= <megi@xff.cz>
 Date: Thu, 6 Feb 2020 04:58:32 +0100
 Subject: arm64: dts: sun50i-a64-pinephone: Shorten post-power-on-delay on mmcs
@@ -11,10 +11,10 @@ Signed-off-by: Ondrej Jirman <megi@xff.cz>
  1 file changed, 3 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
-index 243d9c793227..ff1182be8434 100644
+index d9111801fa0b..07df04d10864 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
-@@ -543,6 +543,7 @@ &mmc0 {
+@@ -546,6 +546,7 @@ &mmc0 {
  	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
  	disable-wp;
  	bus-width = <4>;
@@ -22,7 +22,7 @@ index 243d9c793227..ff1182be8434 100644
  	status = "okay";
  };
  
-@@ -553,6 +554,7 @@ &mmc1 {
+@@ -556,6 +557,7 @@ &mmc1 {
  	vqmmc-supply = <&reg_dldo4>;
  	bus-width = <4>;
  	non-removable;
@@ -30,7 +30,7 @@ index 243d9c793227..ff1182be8434 100644
  	status = "okay";
  
  	rtl8723cs: wifi@1 {
-@@ -568,6 +570,7 @@ &mmc2 {
+@@ -571,6 +573,7 @@ &mmc2 {
  	bus-width = <8>;
  	non-removable;
  	cap-mmc-hw-reset;
@@ -39,5 +39,5 @@ index 243d9c793227..ff1182be8434 100644
  };
  
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/dt-bindings-vendor-prefix-add-prefix-for-Voltafield.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/dt-bindings-vendor-prefix-add-prefix-for-Voltafield.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From e416deafa5d3e4a71cae25903b2a5d4c8c04cf03 Mon Sep 17 00:00:00 2001
 From: Ondrej Jirman <megi@xff.cz>
 Date: Fri, 30 Dec 2022 23:23:04 +0100
 Subject: dt-bindings: vendor-prefix: add prefix for Voltafield
@@ -13,10 +13,10 @@ Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/vendor-prefixes.yaml b/Documentation/devicetree/bindings/vendor-prefixes.yaml
-index 573578db9509..326d2a47162e 100644
+index 12a16031d7b6..45cef0307774 100644
 --- a/Documentation/devicetree/bindings/vendor-prefixes.yaml
 +++ b/Documentation/devicetree/bindings/vendor-prefixes.yaml
-@@ -1484,6 +1484,8 @@ patternProperties:
+@@ -1486,6 +1486,8 @@ patternProperties:
      description: VoCore Studio
    "^voipac,.*":
      description: Voipac Technologies s.r.o.
@@ -26,5 +26,5 @@ index 573578db9509..326d2a47162e 100644
      description: Vision Optical Technology Co., Ltd.
    "^vxt,.*":
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/firmware-arm_scpi-Support-unidirectional-mailbox-channels.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/firmware-arm_scpi-Support-unidirectional-mailbox-channels.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From f586d2ac2ae092252c8328ed78f669927703da5d Mon Sep 17 00:00:00 2001
 From: Samuel Holland <samuel@sholland.org>
 Date: Tue, 5 Mar 2019 22:02:41 -0600
 Subject: firmware: arm_scpi: Support unidirectional mailbox channels
@@ -14,11 +14,11 @@ one), this new mode only supports a single SCPI channel.
 
 Signed-off-by: Samuel Holland <samuel@sholland.org>
 ---
- drivers/firmware/arm_scpi.c | 58 ++++++++--
+ drivers/firmware/arm_scpi.c | 58 +++++++++++++++++++++++++++++--------
  1 file changed, 46 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/firmware/arm_scpi.c b/drivers/firmware/arm_scpi.c
-index 634a6cdcc960..ac01512495bc 100644
+index b8aa8bfc1973..35eb153b4fed 100644
 --- a/drivers/firmware/arm_scpi.c
 +++ b/drivers/firmware/arm_scpi.c
 @@ -234,7 +234,8 @@ struct scpi_xfer {
@@ -40,7 +40,7 @@ index 634a6cdcc960..ac01512495bc 100644
  	if (ret < 0 || !rx_buf)
  		goto out;
  
-@@ -866,8 +867,13 @@ static void scpi_free_channels(void *data)
+@@ -869,8 +870,13 @@ static void scpi_free_channels(void *data)
  	struct scpi_drvinfo *info = data;
  	int i;
  
@@ -56,7 +56,7 @@ index 634a6cdcc960..ac01512495bc 100644
  }
  
  static int scpi_remove(struct platform_device *pdev)
-@@ -924,6 +930,7 @@ static int scpi_probe(struct platform_device *pdev)
+@@ -927,6 +933,7 @@ static int scpi_probe(struct platform_device *pdev)
  	struct device *dev = &pdev->dev;
  	struct device_node *np = dev->of_node;
  	struct scpi_drvinfo *scpi_drvinfo;
@@ -64,7 +64,7 @@ index 634a6cdcc960..ac01512495bc 100644
  
  	scpi_drvinfo = devm_kzalloc(dev, sizeof(*scpi_drvinfo), GFP_KERNEL);
  	if (!scpi_drvinfo)
-@@ -937,6 +944,14 @@ static int scpi_probe(struct platform_device *pdev)
+@@ -940,6 +947,14 @@ static int scpi_probe(struct platform_device *pdev)
  		dev_err(dev, "no mboxes property in '%pOF'\n", np);
  		return -ENODEV;
  	}
@@ -79,7 +79,7 @@ index 634a6cdcc960..ac01512495bc 100644
  
  	scpi_drvinfo->channels =
  		devm_kcalloc(dev, count, sizeof(struct scpi_chan), GFP_KERNEL);
-@@ -985,15 +1000,34 @@ static int scpi_probe(struct platform_device *pdev)
+@@ -988,15 +1003,34 @@ static int scpi_probe(struct platform_device *pdev)
  		mutex_init(&pchan->xfers_lock);
  
  		ret = scpi_alloc_xfer_list(dev, pchan);
@@ -123,5 +123,5 @@ index 634a6cdcc960..ac01512495bc 100644
  	}
  
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/firmware-scpi-Add-support-for-sending-a-SCPI_CMD_SET_SYS_PWR_ST.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/firmware-scpi-Add-support-for-sending-a-SCPI_CMD_SET_SYS_PWR_ST.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From c9a463489d34b3b2b4247496a378eb1bbe437b61 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ond=C5=99ej=20Jirman?= <megi@xff.cz>
 Date: Sat, 2 Nov 2019 15:14:10 +0100
 Subject: firmware: scpi: Add support for sending a SCPI_CMD_SET_SYS_PWR_STATE
@@ -22,7 +22,7 @@ Signed-off-by: Ondrej Jirman <megi@xff.cz>
  2 files changed, 11 insertions(+)
 
 diff --git a/drivers/firmware/arm_scpi.c b/drivers/firmware/arm_scpi.c
-index 435d0e2658a4..634a6cdcc960 100644
+index 3de25e9d18ef..b8aa8bfc1973 100644
 --- a/drivers/firmware/arm_scpi.c
 +++ b/drivers/firmware/arm_scpi.c
 @@ -184,6 +184,7 @@ enum scpi_drv_cmds {
@@ -49,7 +49,7 @@ index 435d0e2658a4..634a6cdcc960 100644
  };
  
  struct scpi_xfer {
-@@ -779,6 +782,12 @@ static int scpi_device_set_power_state(u16 dev_id, u8 pstate)
+@@ -782,6 +785,12 @@ static int scpi_device_set_power_state(u16 dev_id, u8 pstate)
  				 sizeof(dev_set), &stat, sizeof(stat));
  }
  
@@ -62,7 +62,7 @@ index 435d0e2658a4..634a6cdcc960 100644
  static struct scpi_ops scpi_ops = {
  	.get_version = scpi_get_version,
  	.clk_get_range = scpi_clk_get_range,
-@@ -795,6 +804,7 @@ static struct scpi_ops scpi_ops = {
+@@ -798,6 +807,7 @@ static struct scpi_ops scpi_ops = {
  	.sensor_get_value = scpi_sensor_get_value,
  	.device_get_power_state = scpi_device_get_power_state,
  	.device_set_power_state = scpi_device_set_power_state,
@@ -83,5 +83,5 @@ index d2176a56828a..6169348c3b72 100644
  
  #if IS_REACHABLE(CONFIG_ARM_SCPI_PROTOCOL)
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/series.armbian
+++ b/patch/kernel/archive/sunxi-6.6/series.armbian
@@ -66,6 +66,8 @@
 	patches.armbian/arm-dts-sun8i-r40-add-clk_out_a-fix-bananam2ultra.patch
 	patches.armbian/arm-dts-sun8i-h3-bananapi-m2-plus-add-wifi_pwrseq.patch
 	patches.armbian/arm-dts-sun7i-a20-bananapro-add-hdmi-connector-de.patch
+	patches.armbian/arm-dts-sun4i-a10-pmu-irq-fix.patch
+	patches.armbian/arm-dts-sun4i-a10-emac-dma-enable.patch
 	patches.armbian/Bananapro-add-AXP209-regulators.patch
 	patches.armbian/arm-dts-sunxi-h3-h5.dtsi-force-mmc0-bus-width.patch
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-wifi-mmc1.patch

--- a/patch/kernel/archive/sunxi-6.6/series.armbian
+++ b/patch/kernel/archive/sunxi-6.6/series.armbian
@@ -186,6 +186,7 @@
 	patches.armbian/drivers-pwm-Add-pwm-sunxi-enhance-driver-for-h616.patch
 	patches.armbian/driver-allwinner-h618-emac.patch
 	patches.armbian/orangepi-zero2w-add-dtb.patch
+	patches.armbian/Add-board-LonganPi-3H.patch
 	patches.armbian/add-dtb-overlay-for-zero2w.patch
 	patches.armbian/Add-BananaPi-BPI-M4-Zero-overlays.patch
 	patches.armbian/adding-dummy-regulators-in-pinctr-arch-arm-boot-dts-allwinner-s.patch

--- a/patch/kernel/archive/sunxi-6.6/series.armbian
+++ b/patch/kernel/archive/sunxi-6.6/series.armbian
@@ -66,8 +66,8 @@
 	patches.armbian/arm-dts-sun8i-r40-add-clk_out_a-fix-bananam2ultra.patch
 	patches.armbian/arm-dts-sun8i-h3-bananapi-m2-plus-add-wifi_pwrseq.patch
 	patches.armbian/arm-dts-sun7i-a20-bananapro-add-hdmi-connector-de.patch
-	patches.armbian/arm-dts-sun4i-a10-pmu-irq-fix.patch
-	patches.armbian/arm-dts-sun4i-a10-emac-dma-enable.patch
+	patches.armbian/Correct-perf-interrupt-source-number-as-referenced-in-the-Allwi.patch
+	patches.armbian/Enable-DMA-support-for-the-Allwinner-A10-EMAC-which-already-exi.patch
 	patches.armbian/Bananapro-add-AXP209-regulators.patch
 	patches.armbian/arm-dts-sunxi-h3-h5.dtsi-force-mmc0-bus-width.patch
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-wifi-mmc1.patch

--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -318,8 +318,8 @@
 	patches.armbian/arm-dts-sun8i-r40-add-clk_out_a-fix-bananam2ultra.patch
 	patches.armbian/arm-dts-sun8i-h3-bananapi-m2-plus-add-wifi_pwrseq.patch
 	patches.armbian/arm-dts-sun7i-a20-bananapro-add-hdmi-connector-de.patch
-	patches.armbian/arm-dts-sun4i-a10-pmu-irq-fix.patch
-	patches.armbian/arm-dts-sun4i-a10-emac-dma-enable.patch
+	patches.armbian/Correct-perf-interrupt-source-number-as-referenced-in-the-Allwi.patch
+	patches.armbian/Enable-DMA-support-for-the-Allwinner-A10-EMAC-which-already-exi.patch
 	patches.armbian/Bananapro-add-AXP209-regulators.patch
 	patches.armbian/arm-dts-sunxi-h3-h5.dtsi-force-mmc0-bus-width.patch
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-wifi-mmc1.patch


### PR DESCRIPTION
# Description

Switch to v6.6.65, re-export patches

- Fix incomplete: add community support for LonganPi 3H (#7547)
- Fix incomplete: Allwinner A10 DTS fix for ARM PMU IRQ and EMAC DMA (#7567)
- re-export megous patches for v6.6.65 version
- re-export armbian patches for v6.6.65

# How Has This Been Tested?

- [x] Test build sunxi & work on BPI-m3
- [x] Test build sunxi64 & work on BPI-m64
