### PR TITLE
sync disks before freeing loop device

### DIFF
--- a/lib/functions/image/loop.sh
+++ b/lib/functions/image/loop.sh
@@ -106,6 +106,7 @@ function write_uboot_to_loop_image() {
 
 # This exists to prevent silly failures; sometimes the user is inspecting the directory outside of build, etc.
 function free_loop_device_insistent() {
+	wait_for_disk_sync
 	display_alert "Freeing loop device" "${1}"
 	do_with_retries 10 free_loop_device_retried "${1}"
 }

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -252,15 +252,21 @@ function prepare_partitions() {
 
 	# stage: mount image
 	# lock access to loop devices
-	if [[ -z $LOOP ]]; then
+	if [[ -z "${LOOP}" ]]; then
 		exec {FD}> /var/lock/armbian-debootstrap-losetup
 		flock -x $FD
 
 		LOOP=$(losetup -f)
 		[[ -z $LOOP ]] && exit_with_error "Unable to find free loop device" 
 		display_alert "Allocated loop device" "LOOP=${LOOP}"
+		
+
 		check_loop_device "${LOOP}"
-		losetup $LOOP ${SDCARD}.raw
+		run_host_command_logged losetup "${LOOP}" || true
+		
+		losetup --partscan "${LOOP}" ${SDCARD}.raw
+		
+		run_host_command_logged losetup "${LOOP}" || true
 
 		# loop device was grabbed here, unlock
 		flock -u $FD


### PR DESCRIPTION
# Description
see comments in https://github.com/armbian/build/pull/7527
freeing loop devices seems unstable and fails freeing the loop device.
syncing disks helped at least addressing (loop) device problems in my last contribution (fix lvm,luks extension)

# How Has This Been Tested?
- copied the config from the repo
- compiled with mentioned failing command from the daily builds
`shell
./compile.sh armbian-images build BOARD=uefi-x86 BRANCH=current BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base ENABLE_EXTENSIONS=image-output-qcow2,v4l2loopback-dkms EXPERT=yes IMAGE_XZ_COMPRESSION_RATIO=1 KERNEL_CONFIGURE=no RELEASE=bookworm SHARE_LOG=yes SHOW_DEBUB=yes
`

multiple compile runs, could not reproduce getting an error anymore - but not confident that this was it.