### PR TITLE
coolpi-cm5: fix uboot patch dir

### DIFF
--- a/config/boards/coolpi-cm5.csc
+++ b/config/boards/coolpi-cm5.csc
@@ -20,7 +20,7 @@ function post_family_config_branch_edge__coolpi-cm5_use_mainline_uboot() {
 
 	declare -g BOOTSOURCE="https://github.com/Kwiboo/u-boot-rockchip.git" # Kwiboo U-Boot
 	unset BOOTBRANCH
-	unset BOOTPATCHDIR
+	declare -g BOOTPATCHDIR="v2024.07-coolpi-cm5"
 	declare -g BOOTBRANCH_BOARD="tag:v2024.07"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"

--- a/config/boards/coolpi-genbook.csc
+++ b/config/boards/coolpi-genbook.csc
@@ -20,7 +20,7 @@ function post_family_config_branch_edge__coolpi-genbook_use_mainline_uboot() {
 
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # Mainline U-Boot
 	unset BOOTBRANCH
-	unset BOOTPATCHDIR
+	declare -g BOOTPATCHDIR="v2025.01-rc3-coolpi-cm5"
 	declare -g BOOTBRANCH_BOARD="tag:v2025.01-rc3"
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already


### PR DESCRIPTION
# Description

Coolpi cm5 is using mainline u-boot with `BOOTPATCHDIR` unset because it doesn't want patches. And the uboot patch dir fallback to u-boot-rockchip64, which has a lot of patches for rockchip64 families.
Now we declare a fake patch dir for uboot to pass build.

I find the two boards affected by command:
```
git grep "unset BOOTPATCHDIR"
```

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh uboot BOARD=coolpi-genbook BRANCH=edge DEB_COMPRESS=xz`
- [x] `./compile.sh uboot BOARD=coolpi-cm5 BRANCH=edge DEB_COMPRESS=xz`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
