### PR TITLE
hinlink-h88k: add spi lcd firmware to bsp package

### DIFF
--- a/config/boards/hinlink-h88k.csc
+++ b/config/boards/hinlink-h88k.csc
@@ -24,3 +24,15 @@ function post_family_tweaks__hinlink_h88k_naming_audios() {
 
 	return 0
 }
+
+function post_family_tweaks_bsp__hinlink_h88k_bsp_firmware_in_initrd() {
+	display_alert "Adding to bsp-cli" "${BOARD}: firmware in initrd" "info"
+	declare file_added_to_bsp_destination # will be filled in by add_file_from_stdin_to_bsp_destination
+	add_file_from_stdin_to_bsp_destination "/etc/initramfs-tools/hooks/hinlink-h88k-firmware" <<- 'FIRMWARE_HOOK'
+		#!/bin/bash
+		[[ "$1" == "prereqs" ]] && exit 0
+		. /usr/share/initramfs-tools/hook-functions
+		add_firmware "hinlink-h88k-240x135-lcd.bin" # firmware for 240x135 spi lcd
+	FIRMWARE_HOOK
+	run_host_command_logged chmod -v +x "${file_added_to_bsp_destination}"
+}


### PR DESCRIPTION
# Description

This pr depens on https://github.com/armbian/firmware/pull/94.
panel-mipi-dbi driver is built in kernel and need firmware of lcd screen, so the firmware need to be in initramfs.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh build BOARD=hinlink-h88k BRANCH=vendor BUILD_DESKTOP=yes BUILD_MINIMAL=no DEB_COMPRESS=xz DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base ENABLE_EXTENSIONS=mesa-vpu KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=noble`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
