### PR TITLE
sunxi-6.6: add NextThing C.H.I.P (PocketChip) initial support

### DIFF
--- a/config/boards/pocketchip.csc
+++ b/config/boards/pocketchip.csc
@@ -1,0 +1,8 @@
+# Allwinner R8(A13) single core 512Mb (NextThing C.H.I.P.)
+BOARD_NAME="NextThing C.H.I.P."
+BOARDFAMILY="sun5i"
+BOARD_MAINTAINER="TheSnowfield"
+HAS_VIDEO_OUTPUT="yes"
+BOOTCONFIG="CHIP_defconfig"
+KERNEL_TARGET="current"
+KERNEL_TEST_TARGET="current"

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-sun5i-r8-pocketchip-disable-usb-otg-to-bypass-boot-hanging.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-sun5i-r8-pocketchip-disable-usb-otg-to-bypass-boot-hanging.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TheSnowfield <17957399+TheSnowfield@users.noreply.github.com>
+Date: Sun, 22 Dec 2024 18:30:42 +0000
+Subject: arm:dts:sun5i-r8-chip disable USB OTG to bypass boot hanging
+ arch/arm/boot/dts/allwinner/sun5i-r8-chip.dts
+
+Signed-off-by: TheSnowfield <17957399+TheSnowfield@users.noreply.github.com>
+---
+ arch/arm/boot/dts/allwinner/sun5i-r8-chip.dts | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/boot/dts/allwinner/sun5i-r8-chip.dts b/arch/arm/boot/dts/allwinner/sun5i-r8-chip.dts
+index 4192c23848c3..0a1e9cb1535e 100644
+--- a/arch/arm/boot/dts/allwinner/sun5i-r8-chip.dts
++++ b/arch/arm/boot/dts/allwinner/sun5i-r8-chip.dts
+@@ -273,10 +273,10 @@ &usb_power_supply {
+ };
+ 
+ &usbphy {
+ 	status = "okay";
+ 
+-	usb0_id_det-gpios = <&pio 6 2 GPIO_ACTIVE_HIGH>; /* PG2 */
+-	usb0_vbus_power-supply = <&usb_power_supply>;
+-	usb0_vbus-supply = <&reg_usb0_vbus>;
++	// usb0_id_det-gpios = <&pio 6 2 GPIO_ACTIVE_HIGH>; /* PG2 */
++	// usb0_vbus_power-supply = <&usb_power_supply>;
++	// usb0_vbus-supply = <&reg_usb0_vbus>;
+ 	usb1_vbus-supply = <&reg_vcc5v0>;
+ };
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -318,6 +318,7 @@
 	patches.armbian/arm-dts-sun8i-r40-add-clk_out_a-fix-bananam2ultra.patch
 	patches.armbian/arm-dts-sun8i-h3-bananapi-m2-plus-add-wifi_pwrseq.patch
 	patches.armbian/arm-dts-sun7i-a20-bananapro-add-hdmi-connector-de.patch
+	patches.armbian/arm-dts-sun5i-r8-pocketchip-disable-usb-otg-to-bypass-boot-hanging.patch
 	patches.armbian/Correct-perf-interrupt-source-number-as-referenced-in-the-Allwi.patch
 	patches.armbian/Enable-DMA-support-for-the-Allwinner-A10-EMAC-which-already-exi.patch
 	patches.armbian/Bananapro-add-AXP209-regulators.patch


### PR DESCRIPTION
# Description
Add initial support for #529.

# How Has This Been Tested?

`./compile.sh BOARD=pocketchip BRANCH=current`

use `sunxi-fel` to boot, then boot the image from the USB storage device,
currently, it can't boot from the NAND.

# Not work
- NAND device
- RGB display
- on-board keyboard

