### PR TITLE
JetHome: update JetHub D2 support for current revision

### DIFF
--- a/patch/kernel/archive/meson64-6.12/dt/meson-sm1-jethome-jethub-j200.dts
+++ b/patch/kernel/archive/meson64-6.12/dt/meson-sm1-jethome-jethub-j200.dts
@@ -2,6 +2,8 @@
 /*
  * Copyright (c) 2024 JetHome
  * Author: Viacheslav Bocharov <adeep@lexina.in>
+ *
+ * JetHub D2 rev 1.3
  */
 
 /dts-v1/;
@@ -230,7 +232,7 @@
 		led-green {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
-			gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "heartbeat";
 			panic-indicator;
 		};
@@ -238,7 +240,7 @@
 		led-red {
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_POWER;
-			gpios = <&gpio GPIOH_5 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio GPIOH_5 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
@@ -355,7 +357,8 @@
 		"RS485_TX", /* GPIOX_6 */
 		"RS485_RX", /* GPIOX_7 */
 		"", "", "", "", "", "", /* GPIOX_8 - GPIOX_13 */
-		"", "", "", /* GPIOX_14 - GPIOX_16 */
+		"", "",  /* GPIOX_14 - GPIOX_15 */
+		"GPIO_EXPANDER_INT",  /* GPIOX_16 */
 		"I2C_SDA_LCDBUS",  /* GPIOX_17 */
 		"I2C_SCL_LCDBUS",  /* GPIOX_18 */
 		""; /* GPIOX_19 */
@@ -384,7 +387,7 @@
 		"MCU_RESET", /* GPIOAO_4 */
 		"POWER_GOOD", /* GPIOAO_5 */
 		"TF_3V3N_1V8_EN",  /* GPIOAO_6 */
-		"GPIO_EXPANDER_INT", /* GPIOAO_7 */
+		"MCU_BOOT", /* GPIOAO_7 */
 		"MCU_UART_TX", /* GPIOAO_8 */
 		"MCU_UART_RX", /* GPIOAO_9 */
 		"BUTTON_USR", /* GPIOAO_10 */
@@ -531,7 +534,7 @@
 		interrupt-controller;
 		#interrupt-cells = <2>;
 		interrupt-parent = <&gpio_intc>;
-		interrupts = <IRQID_GPIOAO_7 IRQ_TYPE_LEVEL_LOW>;
+		interrupts = <IRQID_GPIOX_16 IRQ_TYPE_LEVEL_LOW>;
 
 		gpio-line-names =
 			"RELAY_1", "RELAY_2",

--- a/patch/kernel/archive/meson64-6.6/dt/meson-sm1-jethome-jethub-j200.dts
+++ b/patch/kernel/archive/meson64-6.6/dt/meson-sm1-jethome-jethub-j200.dts
@@ -2,6 +2,8 @@
 /*
  * Copyright (c) 2024 JetHome
  * Author: Viacheslav Bocharov <adeep@lexina.in>
+ *
+ * JetHub D2 rev 1.3
  */
 
 /dts-v1/;
@@ -230,7 +232,7 @@
 		led-green {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
-			gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "heartbeat";
 			panic-indicator;
 		};
@@ -238,7 +240,7 @@
 		led-red {
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_POWER;
-			gpios = <&gpio GPIOH_5 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio GPIOH_5 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
@@ -355,7 +357,8 @@
 		"RS485_TX", /* GPIOX_6 */
 		"RS485_RX", /* GPIOX_7 */
 		"", "", "", "", "", "", /* GPIOX_8 - GPIOX_13 */
-		"", "", "", /* GPIOX_14 - GPIOX_16 */
+		"", "",  /* GPIOX_14 - GPIOX_15 */
+		"GPIO_EXPANDER_INT",  /* GPIOX_16 */
 		"I2C_SDA_LCDBUS",  /* GPIOX_17 */
 		"I2C_SCL_LCDBUS",  /* GPIOX_18 */
 		""; /* GPIOX_19 */
@@ -384,7 +387,7 @@
 		"MCU_RESET", /* GPIOAO_4 */
 		"POWER_GOOD", /* GPIOAO_5 */
 		"TF_3V3N_1V8_EN",  /* GPIOAO_6 */
-		"GPIO_EXPANDER_INT", /* GPIOAO_7 */
+		"MCU_BOOT", /* GPIOAO_7 */
 		"MCU_UART_TX", /* GPIOAO_8 */
 		"MCU_UART_RX", /* GPIOAO_9 */
 		"BUTTON_USR", /* GPIOAO_10 */
@@ -531,7 +534,7 @@
 		interrupt-controller;
 		#interrupt-cells = <2>;
 		interrupt-parent = <&gpio_intc>;
-		interrupts = <IRQID_GPIOAO_7 IRQ_TYPE_LEVEL_LOW>;
+		interrupts = <IRQID_GPIOX_16 IRQ_TYPE_LEVEL_LOW>;
 
 		gpio-line-names =
 			"RELAY_1", "RELAY_2",


### PR DESCRIPTION
# Description

Update JetHub D2 support for latest revision of cpu board.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2028]


[AR-2028]: https://armbian.atlassian.net/browse/AR-2028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ