### PR TITLE
Fix uwe5622 "spanning-writes" warning messages in dmesg

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -520,6 +520,11 @@ driver_uwe5622() {
 			process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-v6.11.patch" "applying"
 		fi
 
+		# Fix "spanning-writes" warning in dmesg, applicable when kernel is compiled with FORTIFY_SOURCE 
+		if linux-version compare "${version}" ge 6.12; then
+			process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-fix-spanning-writes.patch" "applying"
+		fi
+
 	fi
 }
 

--- a/patch/misc/wireless-uwe5622/uwe5622-fix-spanning-writes.patch
+++ b/patch/misc/wireless-uwe5622/uwe5622-fix-spanning-writes.patch
@@ -1,0 +1,279 @@
+From a772f7d12293e197edb51abc08c57bc80d10b597 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Thu, 26 Dec 2024 15:47:04 +0100
+Subject: [PATCH] use DECLARE_FLEX_ARRAY() macro to avoid spanning-write
+ warning
+
+---
+ .../net/wireless/uwe5622/unisocwifi/cmdevt.c  |  4 +--
+ .../net/wireless/uwe5622/unisocwifi/cmdevt.h  | 34 +++++++++----------
+ .../wireless/uwe5622/unisocwifi/edma_test.c   |  2 +-
+ drivers/net/wireless/uwe5622/unisocwifi/msg.h |  4 +--
+ drivers/net/wireless/uwe5622/unisocwifi/nan.h |  2 +-
+ drivers/net/wireless/uwe5622/unisocwifi/rtt.c |  2 +-
+ .../net/wireless/uwe5622/unisocwifi/sprdwl.h  |  2 +-
+ .../net/wireless/uwe5622/unisocwifi/work.h    |  2 +-
+ 8 files changed, 26 insertions(+), 26 deletions(-)
+
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c
+index dfe03b0636da..093878c82fb5 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c
+@@ -1323,7 +1323,7 @@ int sprdwl_scan(struct sprdwl_priv *priv, u8 vif_ctx_id,
+ 
+ 	struct sprdwl_5g_chn {
+ 		u16 n_5g_chn;
+-		u16 chns[0];
++		DECLARE_FLEX_ARRAY(u16, chns);
+ 	} *ext_5g;
+ 
+ 	chns_len_5g = chn_count_5g * sizeof(*chns_5g);
+@@ -3561,7 +3561,7 @@ int sprdwl_set_wowlan(struct sprdwl_priv *priv, int subcmd, void *pad, int pad_l
+ 	struct wowlan_cmd {
+ 		u8 sub_cmd_id;
+ 		u8 pad_len;
+-		char pad[0];
++		DECLARE_FLEX_ARRAY(u8, pad);
+ 	} *cmd;
+ 
+ 	if (priv == NULL)
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h
+index ce8c774e8968..9f7a61fa3587 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h
++++ b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h
+@@ -372,7 +372,7 @@ struct sprdwl_cmd_add_key {
+ 	u8 keyseq[16];
+ 	u8 cypher_type;
+ 	u8 key_len;
+-	u8 value[0];
++	DECLARE_FLEX_ARRAY(u8, value);
+ } __packed;
+ 
+ struct sprdwl_cmd_del_key {
+@@ -402,13 +402,13 @@ struct sprdwl_cmd_set_ie {
+ #define	SPRDWL_IE_BEACON_TAIL		6
+ 	u8 type;
+ 	__le16 len;
+-	u8 data[0];
++	DECLARE_FLEX_ARRAY(u8, data);
+ } __packed;
+ 
+ /* WIFI_CMD_START_AP */
+ struct sprdwl_cmd_start_ap {
+ 	__le16 len;
+-	u8 value[0];
++	DECLARE_FLEX_ARRAY(u8, value);
+ } __packed;
+ 
+ /* WIFI_CMD_DEL_STATION */
+@@ -454,7 +454,7 @@ struct sprdwl_cmd_scan {
+ 	__le32 channels;	/* One bit for one channel */
+ 	__le32 reserved;
+ 	u16 ssid_len;
+-	u8 ssid[0];
++	DECLARE_FLEX_ARRAY(u8, ssid);
+ } __packed;
+ 
+ /* WIFI_CMD_SCHED_SCAN */
+@@ -549,7 +549,7 @@ struct sprdwl_cmd_mgmt_tx {
+ 	__le32 wait;		/* wait time */
+ 	__le64 cookie;		/* cookie */
+ 	__le16 len;		/* mac length */
+-	u8 value[0];		/* mac */
++	DECLARE_FLEX_ARRAY(u8, value);		/* mac */
+ } __packed;
+ 
+ /* WIFI_CMD_REGISTER_FRAME */
+@@ -574,7 +574,7 @@ struct sprdwl_cmd_cqm_rssi {
+ struct sprdwl_cmd_roam_offload_data {
+ 	u8 type;
+ 	u8 len;
+-	u8 value[0];
++	DECLARE_FLEX_ARRAY(u8, value);
+ } __packed;
+ 
+ struct sprdwl_cmd_tdls_mgmt {
+@@ -604,7 +604,7 @@ struct sprdwl_cmd_tdls_mgmt {
+ 		} __packed discover_resp;
+ 	} u;
+ 	__le32 len;
+-	u8 frame[0];
++	DECLARE_FLEX_ARRAY(u8, frame);
+ } __packed;
+ 
+ struct sprdwl_cmd_tdls {
+@@ -613,13 +613,13 @@ struct sprdwl_cmd_tdls {
+ 	u8 initiator;
+ 	u8 rsvd;
+ 	u8 paylen;
+-	u8 payload[0];
++	DECLARE_FLEX_ARRAY(u8, payload);
+ } __packed;
+ 
+ struct sprdwl_cmd_blacklist {
+ 	u8 sub_type;
+ 	u8 num;
+-	u8 mac[0];
++	DECLARE_FLEX_ARRAY(u8, mac);
+ } __packed;
+ 
+ struct sprdwl_cmd_tdls_channel_switch {
+@@ -631,7 +631,7 @@ struct sprdwl_cmd_tdls_channel_switch {
+ struct sprdwl_cmd_set_mac_addr {
+ 	u8 sub_type;
+ 	u8 num;
+-	u8 mac[0];
++	DECLARE_FLEX_ARRAY(u8, mac);
+ } __packed;
+ 
+ struct sprdwl_cmd_rsp_state_code {
+@@ -644,7 +644,7 @@ struct sprdwl_cmd_11v {
+ 	u16 len;
+ 	union {
+ 		u32 value;
+-		u8 buf[0];
++		DECLARE_FLEX_ARRAY(u8, buf);
+ 	};
+ } __packed;
+ 
+@@ -714,7 +714,7 @@ struct sprdwl_event_mgmt_frame {
+ 	u8 reserved;
+ 	u8 bssid[ETH_ALEN];	/* roaming frame */
+ 	__le16 len;
+-	u8 data[0];
++	DECLARE_FLEX_ARRAY(u8, data);
+ } __packed;
+ 
+ /* WIFI_EVENT_SCAN_COMP */
+@@ -737,7 +737,7 @@ struct sprdwl_event_mgmt_tx_status {
+ 	__le64 cookie;		/* cookie */
+ 	u8 ack;			/* status */
+ 	__le16 len;		/* frame len */
+-	u8 buf[0];		/* mgmt frame */
++	DECLARE_FLEX_ARRAY(u8, buf);		/* mgmt frame */
+ } __packed;
+ 
+ /* WIFI_EVENT_NEW_STATION  */
+@@ -745,7 +745,7 @@ struct sprdwl_event_new_station {
+ 	u8 is_connect;
+ 	u8 mac[ETH_ALEN];
+ 	__le16 ie_len;
+-	u8 ie[0];
++	DECLARE_FLEX_ARRAY(u8, ie);
+ } __packed;
+ 
+ /* WIFI_EVENT_MIC_FAIL */
+@@ -772,7 +772,7 @@ struct sprdwl_event_tdls {
+ struct sprd_cmd_gscan_header {
+ 	u16 subcmd;
+ 	u16 data_len;
+-	u8 data[0];
++	DECLARE_FLEX_ARRAY(u8, data);
+ } __packed;
+ 
+ struct sprdwl_llc_hdr {
+@@ -898,7 +898,7 @@ struct sprdwl_priv;
+ struct sprdwl_tlv_data {
+ 	u16 type;
+ 	u16 len;
+-	u8 data[0];
++	DECLARE_FLEX_ARRAY(u8, data);
+ } __packed;
+ 
+ /* TLV rbuf size */
+@@ -938,7 +938,7 @@ struct sprdwl_cmd_packet_offload {
+ 	u8 enable;
+ 	u32 period;
+ 	u16 len;
+-	u8 data[0];
++	DECLARE_FLEX_ARRAY(u8, data);
+ } __packed;
+ 
+ int sprdwl_cmd_rsp(struct sprdwl_priv *priv, u8 *msg);
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/edma_test.c b/drivers/net/wireless/uwe5622/unisocwifi/edma_test.c
+index f45bc8043f9c..59e1a1eb70db 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/edma_test.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/edma_test.c
+@@ -35,7 +35,7 @@ static unsigned int chn_tx_fail[8];
+ struct edma_test_cmd_header {
+ 	u16 subcmd;
+ 	u16 len;
+-	u8 data[0];
++	DECLARE_FLEX_ARRAY(u8, data);
+ } __packed;
+ 
+ struct task_struct *task_array[PCIE_CHANNEL_PAIR];
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/msg.h b/drivers/net/wireless/uwe5622/unisocwifi/msg.h
+index dd57521ae708..ed2416b91db4 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/msg.h
++++ b/drivers/net/wireless/uwe5622/unisocwifi/msg.h
+@@ -94,12 +94,12 @@ struct sprdwl_cmd_hdr {
+ 	s8 status;
+ 	u8 rsp_cnt;
+ 	u8 reserv[2];
+-	u8 paydata[0];
++	DECLARE_FLEX_ARRAY(u8, paydata);
+ } __packed;
+ 
+ struct sprdwl_addr_hdr {
+ 	struct sprdwl_common_hdr common;
+-	u8 paydata[0];
++	DECLARE_FLEX_ARRAY(u8, paydata);
+ } __packed;
+ 
+ #define SPRDWL_GET_CMD_PAYDATA(msg) \
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/nan.h b/drivers/net/wireless/uwe5622/unisocwifi/nan.h
+index fd6d980b4d78..4ba67060245f 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/nan.h
++++ b/drivers/net/wireless/uwe5622/unisocwifi/nan.h
+@@ -291,7 +291,7 @@ struct nan_capa {
+ 
+ struct nan_cmd_header {
+ 	u16 data_len;
+-	u8 data[0];
++	DECLARE_FLEX_ARRAY(u8, data);
+ } __packed;
+ 
+ /* cmd handler*/
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/rtt.c b/drivers/net/wireless/uwe5622/unisocwifi/rtt.c
+index 9f0e9f2d3dd0..15410fbfc4e5 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/rtt.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/rtt.c
+@@ -151,7 +151,7 @@ struct ftm_session_start {
+ struct sprdwl_cmd_rtt {
+ 	u8 sub_cmd;
+ 	__le16 len;
+-	u8 data[0];
++	DECLARE_FLEX_ARRAY(u8, data);
+ } __packed;
+ 
+ static const struct
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/sprdwl.h b/drivers/net/wireless/uwe5622/unisocwifi/sprdwl.h
+index f612a9e9967b..bd411154556b 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/sprdwl.h
++++ b/drivers/net/wireless/uwe5622/unisocwifi/sprdwl.h
+@@ -75,7 +75,7 @@ struct sprdwl_mc_filter {
+ 	bool mc_change;
+ 	u8 subtype;
+ 	u8 mac_num;
+-	u8 mac_addr[0];
++	DECLARE_FLEX_ARRAY(u8, mac_addr);
+ };
+ 
+ struct android_wifi_priv_cmd {
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/work.h b/drivers/net/wireless/uwe5622/unisocwifi/work.h
+index 4e745903eedc..10647f1676dc 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/work.h
++++ b/drivers/net/wireless/uwe5622/unisocwifi/work.h
+@@ -50,7 +50,7 @@ struct sprdwl_work {
+ #define SPRDWL_WORK_VOWIFI_DATA_PROTECTION 18
+ 	u8 id;
+ 	u32 len;
+-	u8 data[0];
++	DECLARE_FLEX_ARRAY(u8, data);
+ };
+ 
+ struct sprdwl_reg_mgmt {
+-- 
+2.43.0
+


### PR DESCRIPTION
# Description

Spreadtrum/Unisoc wifi uwe5622 driver is producing a lot of warning messages with consequent kernel dumps in dmesg when run with a recent kernel. The driver is functional, but the kernel complaints.

This PR will fix the problem with kernel >= 6.12 using `DECLARE_FLEX_ARRAY()` macro in place of `u8 data[0]` flexible array declarations that are causing the warnings. Note that this probably could be applied to older kernels as well, since the `DECLARE_FLEX_ARRAY()` macro is available from 5.15 onwards.

This applies to both rockchip64 (OrangePi 4 LTS uses this part), but also to some sunxi boards.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2574]

# How Has This Been Tested?

- [x] Compiled rockchip64 edge 6.13-rc4 kernel debs and tested on a live installation
- [x] Compiled rockchip64 current 6.12 kernel debs and tested on a live installation
- [x] iperf3 benchmarks, performance is ok
- [x] ssh tests, connectivity is ok

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


[AR-2574]: https://armbian.atlassian.net/browse/AR-2574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ