### PR TITLE
cli: kernel-dtb: don't output preprocessed dts unless BOOT_FDT_FILE is in `<vendor>/<board>.dtb` format

### DIFF
--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -174,59 +174,69 @@ function kernel_prepare_build_and_package() {
 }
 
 function kernel_dtb_only_build() {
-	display_alert "Kernel DTB-only for development" "KERNEL_DTB_ONLY: ${KERNEL_DTB_ONLY}" "warn"
+	display_alert "Kernel DTB-only for development" "KERNEL_DTB_ONLY: ${KERNEL_DTB_ONLY}" "info"
 	# Do it in two separate steps, first build the dtbs then install them.
 	build_targets=("dtbs")
 	LOG_SECTION="kernel_build" do_with_logging do_with_hooks kernel_build
 
-	display_alert "Kernel DTB-only for development" "Installing DTBs" "warn"
+	display_alert "Kernel DTB-only for development" "Installing DTBs" "info"
 	build_targets=("dtbs_install")
 	LOG_SECTION="kernel_build" do_with_logging do_with_hooks kernel_build
 
-	# If BOOT_FDT_FILE is set...
-	if [[ -n "${BOOT_FDT_FILE}" ]]; then
-		display_alert "Kernel DTB-only for development" "Copying preprocessed version of ${BOOT_FDT_FILE}" "warn"
+	display_alert "Kernel DTB-only .deb, for development/convenience" "kernel dtb build done" "info"
 
-		# Take BOOT_FDT_FILE (eg: "rockchip/rk3588-smth.dtb") and parse fdt_dir and fdt_file out of it
-		declare fdt_dir fdt_file
-		[[ "${BOOT_FDT_FILE}" =~ ^(.*)/(.*)$ ]] && fdt_dir="${BASH_REMATCH[1]}" && fdt_file="${BASH_REMATCH[2]}"
+	display_alert "Considering further .dts convenience processing" "for board '${BOARD}' branch '${BRANCH}'" "info"
 
-		# Check it worked, or bail
-		if [[ -z "${fdt_dir}" || -z "${fdt_file}" ]]; then
-			exit_with_error "Failed to parse BOOT_FDT_FILE: ${BOOT_FDT_FILE}"
-		fi
-
-		# Copy the bin dtb for convenience
-		display_alert "Kernel DTB-only for development" "Copying binary ${BOOT_FDT_FILE}" "warn"
-		declare binary_dtb="${kernel_work_dir}/arch/${ARCH}/boot/dts/${fdt_dir}/${fdt_file}"
-		declare binary_dtb_dest="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.dtb"
-		run_host_command_logged cp -v "${binary_dtb}" "${binary_dtb_dest}"
-
-		# Kernel build should produce a preprocessed version of all DTS files built into DTBs at arch/arm64/boot/dts/${fdt_dir}/.${fdt_file}.dts.tmp
-		declare preprocessed_fdt_source="${kernel_work_dir}/arch/${ARCH}/boot/dts/${fdt_dir}/.${fdt_file}.dts.tmp"
-
-		# Check it exists, or bail
-		if [[ ! -f "${preprocessed_fdt_source}" ]]; then
-			exit_with_error "Preprocessed FDT source not found: ${preprocessed_fdt_source}"
-		fi
-
-		declare preprocessed_fdt_dest="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.preprocessed.dts"
-		run_host_command_logged cp -v "${preprocessed_fdt_source}" "${preprocessed_fdt_dest}"
-
-		# Include a normalization pass through the dtc tool, with DTS as both input and output formats; this introduces phandles, unfortunately
-		declare preprocessed_fdt_normalized="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.preprocessed.normalized.dts"
-		run_host_command_logged dtc -I dts -O dts -o "${preprocessed_fdt_normalized}" "${preprocessed_fdt_dest}"
-
-		# Remove phandles and hex references, probably the worst way possible (grep) -- somehow the diff is reasonable then.
-		declare preprocessed_fdt_normalized_nophandles="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.preprocessed.normalized.nophandles.dts"
-		grep -v -e "phandle =" -e "connect =" -e '= <0x' "${preprocessed_fdt_normalized}" > "${preprocessed_fdt_normalized_nophandles}"
-
-		display_alert "Kernel DTB-only for development" "Preprocessed FDT dest: ${preprocessed_fdt_dest}" "warn"
-		display_alert "Kernel DTB-only for development" "Preprocessed FDT normalized: ${preprocessed_fdt_normalized}" "warn"
-		display_alert "Kernel DTB-only for development" "Preprocessed FDT normalized, no phandles: ${preprocessed_fdt_normalized_nophandles}" "warn"
+	# If BOOT_FDT_FILE is not set, bail.
+	if [[ -z "${BOOT_FDT_FILE}" ]]; then
+		display_alert "Board '${BOARD}' branch '${BRANCH}'" "No BOOT_FDT_FILE set for board, skipping further processing" "warn"
+		return 0
 	fi
 
-	return 0
+	display_alert "Kernel DTB-only for development" "Copying preprocessed versions of ${BOOT_FDT_FILE}" "info"
+
+	declare fdt_dir fdt_file                 # we need to parse these out of BOOT_FDT_FILE
+	if [[ "${BOOT_FDT_FILE}" == */* ]]; then # If BOOT_FDT_FILE contains a slash (/), means it's using vendor/board.dtb scheme;  we can parse that.
+		[[ "${BOOT_FDT_FILE}" =~ ^(.*)/(.*)$ ]] && fdt_dir="${BASH_REMATCH[1]}" && fdt_file="${BASH_REMATCH[2]}"
+	else
+		display_alert "Kernel DTB-only for development" "BOOT_FDT_FILE does not contain a slash, skipping further processing" "warn"
+		return 0
+	fi
+
+	if [[ -z "${fdt_dir}" || -z "${fdt_file}" ]]; then # Check it worked, or bail
+		display_alert "Failed to parse BOOT_FDT_FILE" "BOOT_FDT_FILE: '${BOOT_FDT_FILE}'" "err"
+		return 0
+	fi
+
+	# Copy the bin dtb for convenience
+	display_alert "Kernel DTB-only for development" "Copying binary ${BOOT_FDT_FILE}" "info"
+	declare binary_dtb="${kernel_work_dir}/arch/${KERNEL_SRC_ARCH}/boot/dts/${fdt_dir}/${fdt_file}"
+	declare binary_dtb_dest="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.dtb"
+	run_host_command_logged cp -v "${binary_dtb}" "${binary_dtb_dest}"
+
+	# Kernel build should produce a preprocessed version of all DTS files built into DTBs at arch/arm64/boot/dts/${fdt_dir}/.${fdt_file}.dts.tmp
+	declare preprocessed_fdt_source="${kernel_work_dir}/arch/${KERNEL_SRC_ARCH}/boot/dts/${fdt_dir}/.${fdt_file}.dts.tmp"
+
+	# Check it exists, or bail
+	if [[ ! -f "${preprocessed_fdt_source}" ]]; then
+		exit_with_error "Preprocessed FDT source not found: ${preprocessed_fdt_source}"
+	fi
+
+	declare preprocessed_fdt_dest="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.preprocessed.dts"
+	run_host_command_logged cp -v "${preprocessed_fdt_source}" "${preprocessed_fdt_dest}"
+
+	# Include a normalization pass through the dtc tool, with DTS as both input and output formats; this introduces phandles, unfortunately
+	display_alert "Kernel DTB-only for development" "Normalizing (dtc dts-to-dts) preprocessed FDT" "info"
+	declare preprocessed_fdt_normalized="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.preprocessed.normalized.dts"
+	run_host_command_logged dtc -I dts -O dts -o "${preprocessed_fdt_normalized}" "${preprocessed_fdt_dest}"
+
+	# Remove phandles and hex references, probably the worst way possible (grep) -- somehow the diff is reasonable then, but also phandle references are gone. Less useful.
+	declare preprocessed_fdt_normalized_nophandles="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.preprocessed.normalized.nophandles.dts"
+	grep -v -e "phandle =" -e "connect =" -e '= <0x' "${preprocessed_fdt_normalized}" > "${preprocessed_fdt_normalized_nophandles}"
+
+	display_alert "Kernel DTB-only for development" "Preprocessed FDT dest: ${preprocessed_fdt_dest}" "info"
+	display_alert "Kernel DTB-only for development" "Preprocessed FDT normalized: ${preprocessed_fdt_normalized}" "info"
+	display_alert "Kernel DTB-only for development" "Preprocessed FDT normalized, no phandles: ${preprocessed_fdt_normalized_nophandles}" "info"
 }
 
 function kernel_build() {


### PR DESCRIPTION
#### cli: kernel-dtb: don't output preprocessed dts unless BOOT_FDT_FILE is in `<vendor>/<board>.dtb` format

- cli: kernel-dtb: don't output preprocessed dts unless BOOT_FDT_FILE is in `<vendor>/<board>.dtb` format
  - so the .deb can be produced sans-errors for some armhf boards
  - some better logging, curb the warnings a bit