### PR TITLE
rockchip64 - egde - bump mainline to 6.13-rc5

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0           # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "6.13" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v6.13-rc4"
+		declare -g KERNELBRANCH="tag:v6.13-rc5"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }

--- a/patch/kernel/archive/rockchip64-6.13/rk3588-0130-add-hdmi1-support.patch
+++ b/patch/kernel/archive/rockchip64-6.13/rk3588-0130-add-hdmi1-support.patch
@@ -1,49 +1,4 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
-Date: Wed, 23 Oct 2024 20:29:54 +0300
-Subject: phy: rockchip: samsung-hdptx: Set drvdata before enabling runtime PM
-
-In some cases, rk_hdptx_phy_runtime_resume() may be invoked before
-platform_set_drvdata() is executed in ->probe(), leading to a NULL
-pointer dereference when using the return of dev_get_drvdata().
-
-Ensure platform_set_drvdata() is called before devm_pm_runtime_enable().
-
-Reported-by: Dmitry Osipenko <dmitry.osipenko@collabora.com>
-Fixes: 553be2830c5f ("phy: rockchip: Add Samsung HDMI/eDP Combo PHY driver")
-Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
-Reviewed-by: Heiko Stuebner <heiko@sntech.de>
-Link: https://lore.kernel.org/r/20241023-phy-sam-hdptx-rpm-fix-v1-1-87f4c994e346@collabora.com
-Signed-off-by: Vinod Koul <vkoul@kernel.org>
----
- drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
-
-diff --git a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
-index 111111111111..222222222222 100644
---- a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
-+++ b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
-@@ -1101,6 +1101,8 @@ static int rk_hdptx_phy_probe(struct platform_device *pdev)
- 		return dev_err_probe(dev, PTR_ERR(hdptx->grf),
- 				     "Could not get GRF syscon\n");
- 
-+	platform_set_drvdata(pdev, hdptx);
-+
- 	ret = devm_pm_runtime_enable(dev);
- 	if (ret)
- 		return dev_err_probe(dev, ret, "Failed to enable runtime PM\n");
-@@ -1110,7 +1112,6 @@ static int rk_hdptx_phy_probe(struct platform_device *pdev)
- 		return dev_err_probe(dev, PTR_ERR(hdptx->phy),
- 				     "Failed to create HDMI PHY\n");
- 
--	platform_set_drvdata(pdev, hdptx);
- 	phy_set_drvdata(hdptx->phy, hdptx);
- 	phy_set_bus_width(hdptx->phy, 8);
- 
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Heiko Stuebner <heiko.stuebner@cherry.de>
 Date: Fri, 6 Dec 2024 11:34:01 +0100
 Subject: phy: phy-rockchip-samsung-hdptx: Don't use dt aliases to determine


### PR DESCRIPTION
# Description

- Bump Linux version to recent rc5
- Remove up-streamed patch causing failure

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?

- [x] build https://paste.armbian.de/inezabozet
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
