### PR TITLE
thinkpad-x13s: bump to jhovold's wip/sc8280xp-6.13-rc4

### DIFF
--- a/config/boards/thinkpad-x13s.conf
+++ b/config/boards/thinkpad-x13s.conf
@@ -10,18 +10,16 @@ declare -g BOOT_LOGO=desktop
 # Absolutely watch this video https://www.youtube.com/watch?v=qffWt4o334Y - jhovold explains it all there.
 # @TODO list
 #  - cleanup the .config using jhovold's defconfig.
-#  - consider dropping steev's kernel in favor of jhovold's.
+#  - consider dropping steev's kernel in favor of jhovold's. [DONE]
 #  - rework the initramfs firmware/modules required, according to jhovold's defconfig-commit-msg instructions
 ###########################################################################################################
 # Userspace TO-DO:
-# - (mantic/others?) hangs waiting for the EFI partition via UUID, why? [yeah WHY?!]
 # - deploy fprintd/libpam-fprintd (sic) for fingerprint authentication [done]
 # - (ubuntu, mantic for sure): protection-domain-mapper's pd-mapper.service has a condition on "-laptop" kernel, use override to get rid of it [done]
 
 # This board boots via EFI/Grub, but requires a DTB to be passed, from Grub, to the Kernel.
 declare -g GRUB_CMDLINE_LINUX_DEFAULT="clk_ignore_unused pd_ignore_unused arm64.nopauth efi=noruntime" # iommu.passthrough=0 iommu.strict=0 pcie_aspm.policy=powersupersave
 declare -g BOOT_FDT_FILE="qcom/sc8280xp-lenovo-thinkpad-x13s.dtb"
-# declare -g UEFI_MOUNT_POINT_SKIP_FSTAB="yes" # If we leave the /boot/efi in fstab, systemd hangs waiting for it; FIXED: by adding mtools pkg
 
 enable_extension "grub-with-dtb" # important, puts the whole DTB handling in place.
 
@@ -29,8 +27,8 @@ enable_extension "grub-with-dtb" # important, puts the whole DTB handling in pla
 declare -g BOARD_FIRMWARE_INSTALL="-full"
 
 function post_family_config_branch_sc8280xp__jhovolds_wip_kernel() {
-	declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.12' # @TODO: this is down to 27 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
+	declare -g KERNEL_MAJOR_MINOR="6.13" # Major and minor versions of this kernel.
+	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.13-rc1' # @TODO: this is down to 27 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
 	declare -g KERNELSOURCE='https://github.com/jhovold/linux.git'
 	declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}" # for this board: linux-arm64-sc8280xp
 	display_alert "Set up jhovold's kernel ${KERNELBRANCH} for" "${BOARD}" "info"

--- a/config/boards/thinkpad-x13s.conf
+++ b/config/boards/thinkpad-x13s.conf
@@ -28,7 +28,7 @@ declare -g BOARD_FIRMWARE_INSTALL="-full"
 
 function post_family_config_branch_sc8280xp__jhovolds_wip_kernel() {
 	declare -g KERNEL_MAJOR_MINOR="6.13" # Major and minor versions of this kernel.
-	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.13-rc3' # @TODO: this is down to 16 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
+	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.13-rc4' # @TODO: this is down to 16 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
 	declare -g KERNELSOURCE='https://github.com/jhovold/linux.git'
 	declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}" # for this board: linux-arm64-sc8280xp
 	display_alert "Set up jhovold's kernel ${KERNELBRANCH} for" "${BOARD}" "info"

--- a/config/boards/thinkpad-x13s.conf
+++ b/config/boards/thinkpad-x13s.conf
@@ -28,7 +28,7 @@ declare -g BOARD_FIRMWARE_INSTALL="-full"
 
 function post_family_config_branch_sc8280xp__jhovolds_wip_kernel() {
 	declare -g KERNEL_MAJOR_MINOR="6.13" # Major and minor versions of this kernel.
-	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.13-rc1' # @TODO: this is down to 27 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
+	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.13-rc3' # @TODO: this is down to 16 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
 	declare -g KERNELSOURCE='https://github.com/jhovold/linux.git'
 	declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}" # for this board: linux-arm64-sc8280xp
 	display_alert "Set up jhovold's kernel ${KERNELBRANCH} for" "${BOARD}" "info"


### PR DESCRIPTION
#### thinkpad-x13s: bump to jhovold's wip/sc8280xp-6.13-rc4

- thinkpad-x13s: bump to jhovold's wip/sc8280xp-6.13-rc1
  - this is down to 19 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
  - cleanup some outdated comments
- thinkpad-x13s: bump to jhovold's wip/sc8280xp-6.13-rc3
  - this is down to 16 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel
- thinkpad-x13s: bump to jhovold's wip/sc8280xp-6.13-rc4
  - this is down to 16 patches, from hundreds back in the day. Considering merging this with default arm64 uefi kernel