### PR TITLE
riscv64: enable support in Debian Trixie, enable UEFI grub

### DIFF
--- a/config/distributions/trixie/architectures
+++ b/config/distributions/trixie/architectures
@@ -1,1 +1,1 @@
-arm64,armhf,amd64
+arm64,armhf,riscv64,amd64

--- a/extensions/grub-riscv64.sh
+++ b/extensions/grub-riscv64.sh
@@ -19,10 +19,6 @@ function extension_prepare_config__prepare_grub-riscv64() {
 	declare -g EXTRA_BSP_NAME="${EXTRA_BSP_NAME}-grub"                               # Unique bsp name.
 	declare -g UEFI_GRUB_TARGET="riscv64-efi"                                        # Default for x86_64
 
-	if [[ "${DISTRIBUTION}" != "Ubuntu" && "${BUILDING_IMAGE}" == "yes" ]]; then
-		exit_with_error "Extension: ${EXTENSION}: ${DISTRIBUTION} is not supported yet"
-	fi
-
 	add_packages_to_image efibootmgr efivar cloud-initramfs-growroot busybox os-prober "grub-efi-${ARCH}-bin" "grub-efi-${ARCH}"
 
 	display_alert "Activating" "GRUB with SERIALCON=${SERIALCON}; timeout ${UEFI_GRUB_TIMEOUT}; target=${UEFI_GRUB_TARGET}" ""


### PR DESCRIPTION
# Description

Apparently works, tested for assembly only. Support remains CSC.

Reference:  https://github.com/armbian/build/pull/7616

# How Has This Been Tested?

- [ ] Build of UEFI riscv64 Trixie image

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
