### PR TITLE
rpi5b: drop `LINUXFAMILY=bcm2712` as it is exactly the same as `bcm2711`

### DIFF
--- a/config/boards/rpi5b.csc
+++ b/config/boards/rpi5b.csc
@@ -5,27 +5,3 @@ declare -g BOARD_MAINTAINER=""
 declare -g KERNEL_TARGET="current,edge"
 declare -g KERNEL_TEST_TARGET="current"
 declare -g ASOUND_STATE="asound.state.rpi"
-
-function post_family_config__rename_linux_family() {
-	display_alert "rpi5b" "Changing LINUXFAMILY" "info"
-	declare -g LINUXFAMILY=bcm2712
-}
-
-#function custom_kernel_config__rpi5b_16k_variant() {
-#	display_alert "rpi5b" "Enabling 16K page size" "info"
-#	kernel_config_modifying_hashes+=(
-#		"CONFIG_ARM64_16K_PAGES=y"
-#		"CONFIG_ARCH_MMAP_RND_BITS=18"
-#		"CONFIG_ARCH_MMAP_RND_COMPAT_BITS=11"
-#	)
-
-#	# As kernel config is shared between two variants, override the settings
-#	# but make sure not to write them back to config/kernel directory
-#	if [[ -f .config ]] && [[ "${KERNEL_CONFIGURE:-yes}" != "yes" ]]; then
-#		display_alert "Enabling 16K page size" "armbian-kernel" "debug"
-#		kernel_config_set_y CONFIG_ARM64_16K_PAGES
-#		run_host_command_logged ./scripts/config --set-val CONFIG_ARCH_MMAP_RND_BITS 18
-#		run_host_command_logged ./scripts/config --set-val CONFIG_ARCH_MMAP_RND_COMPAT_BITS 11
-#		run_kernel_make olddefconfig
-#	fi
-#}


### PR DESCRIPTION
#### rpi5b: drop `LINUXFAMILY=bcm2712` as it is exactly the same as `bcm2711`

- rpi5b: drop `LINUXFAMILY=bcm2712` as it is exactly the same as `bcm2711`
  - in f3f10a9517d76c75c2badec2d6bfd6fe8e8547d0 the 16k-page stuff was dropped
    - and that was the only reason for a separate kernel
    - thus drop the change and unify; 2 less kernels to build and same result