### PR TITLE
Bump arm-trusted-firmware to 2.12 for rockchip64

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -162,7 +162,7 @@ prepare_boot_configuration() {
 			ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
 			ATF_COMPILER='aarch64-linux-gnu-'
 			ATFDIR='arm-trusted-firmware'
-			ATFBRANCH='tag:lts-v2.8.8'
+			ATFBRANCH='tag:v2.12.0'
 			ATF_USE_GCC='> 6.3'
 			ATF_TARGET_MAP="M0_CROSS_COMPILE=arm-linux-gnueabi- PLAT=$BOOT_SOC bl31;;build/$BOOT_SOC/release/bl31/bl31.elf:bl31.elf"
 			ATF_TOOLCHAIN2="arm-linux-gnueabi-:< 10.0"

--- a/lib/functions/compilation/atf.sh
+++ b/lib/functions/compilation/atf.sh
@@ -73,12 +73,12 @@ compile_atf() {
 		display_alert "Binutils version for ATF" ">= 2.39, adding --no-warn-rwx-segment" "info"
 		binutils_flags_atf="--no-warn-rwx-segment"
 	fi
-
 	# - ENABLE_BACKTRACE="0" has been added to workaround a regression in ATF. Check: https://github.com/armbian/build/issues/1157
-	run_host_command_logged CCACHE_BASEDIR="$(pwd)" PATH="${toolchain}:${toolchain2}:${PATH}" \
+
+	run_host_command_logged "CROSS_COMPILE='ccache ${ATF_COMPILER}'" CCACHE_BASEDIR="$(pwd)" "CC='ccache ${ATF_COMPILER}gcc'" PATH="${toolchain}:${toolchain2}:${PATH}" \
 		"CFLAGS='-fdiagnostics-color=always -Wno-error=attributes -Wno-error=incompatible-pointer-types'" \
 		"TF_LDFLAGS='${binutils_flags_atf}'" \
-		make ENABLE_BACKTRACE="0" LOG_LEVEL="40" BUILD_STRING="armbian" $target_make "${CTHREADS}" "CROSS_COMPILE='$CCACHE $ATF_COMPILER'"
+		make ENABLE_BACKTRACE="0" LOG_LEVEL="40" BUILD_STRING="armbian" $target_make "${CTHREADS}"
 
 	# @TODO: severely missing logging
 	[[ $(type -t atf_custom_postprocess) == function ]] && atf_custom_postprocess 2>&1


### PR DESCRIPTION
# Description

Bump arm-trusted-firmware to newest version 2.12 which supports rk3588.

Also change the `make` call to support usage of `ccache` for new version.

# How Has This Been Tested?

Build and installed on CM3588.
# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] My changes generate no new warnings
