### PR TITLE
add hdmi rx configuration for friendlyelec cm3588

### DIFF
--- a/patch/kernel/archive/rockchip64-6.13/rk3588-1090-arm64-dts-rockchip-Add-HDMI-RX-config-to-FriendlyElec-CM3588.patch
+++ b/patch/kernel/archive/rockchip64-6.13/rk3588-1090-arm64-dts-rockchip-Add-HDMI-RX-config-to-FriendlyElec-CM3588.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Surber <me@timsurber.de>
+Date: Fri, 3 Jan 2025 23:12:26 +0100
+Subject: Add HDMI-RX configuration for friendlyelec-cm3588
+
+Signed-off-by: Tim Surber <me@timsurber.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts | 14 ++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts b/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
+index b3a04ca370bb..6e79aba4c6a0 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
+@@ -99,10 +99,17 @@ hdmi0_con_in: endpoint {
+ 				remote-endpoint = <&hdmi0_out_con>;
+ 			};
+ 		};
+ 	};
+ 
++	hdmi_receiver@fdee0000 {
++		compatible = "rockchip,rk3588-hdmirx-ctrler", "snps,dw-hdmi-rx";     
++		power-domains = <&power RK3588_PD_VO1>;
++		pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_hpd>;
++		hpd-gpios = <&gpio1 29 GPIO_ACTIVE_LOW>;
++	};
++
+ 	ir-receiver {
+ 		compatible = "gpio-ir-receiver";
+ 		gpios = <&gpio0 RK_PD4 GPIO_ACTIVE_LOW>;
+ 	};
+ 
+@@ -476,10 +483,17 @@ gpio-key {
+ 		key1_pin: key1-pin {
+ 			rockchip,pins = <0 RK_PD5 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};
+ 
++
++	hdmirx {
++		hdmirx_hpd: hdmirx-5v-detection {
++			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	pcie {
+ 		pcie2_0_rst: pcie2-0-rst {
+ 			rockchip,pins = <4 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

While there is an overlay which allows to enable HDMI-RX on CM3588 it will throw an error in dmesg and will not work, because the 5V detection pin is not configured.

This patch adds it for FriendlyElec CM3588



# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ x] compiled and tested on CM3588 

# Checklist:

_Please delete options that are not relevant._

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] My changes generate no new warnings
