### PR TITLE
v4l2loopback-dkms: do not restrict to desktops only

### DIFF
--- a/extensions/v4l2loopback-dkms.sh
+++ b/extensions/v4l2loopback-dkms.sh
@@ -3,14 +3,12 @@ function extension_finish_config__build_v4l2loopback_dkms_kernel_module() {
 		display_alert "Kernel version has no working headers package" "skipping v4l2loopback-dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi
-	[[ "${BUILD_DESKTOP}" != "yes" ]] && return 0
 	declare -g INSTALL_HEADERS="yes"
 	display_alert "Forcing INSTALL_HEADERS=yes; for use with v4l2loopback-dkms" "${EXTENSION}" "debug"
 }
 
 function post_install_kernel_debs__build_v4l2loopback_dkms_kernel_module() {
 	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
-	[[ "${BUILD_DESKTOP}" != "yes" ]] && return 0
 	display_alert "Install v4l2loopback-dkms packages, will build kernel module in chroot" "${EXTENSION}" "info"
 	declare -g if_error_detail_message="v4l2loopback-dkms build failed, extension 'v4l2loopback-dkms'"
 	declare -ag if_error_find_files_sdcard=("/var/lib/dkms/v4l2loopback*/*/build/*.log")


### PR DESCRIPTION
#### v4l2loopback-dkms: do not restrict to desktops only

- v4l2loopback-dkms: do not restrict to desktops only
  - undoes baeaee6f2051654b13f55c08028ceddbb52f8fb6
  - as I use this for debugging general dkms issues, even in non-desktops