### PR TITLE
add typec role switch and pd negotiation support to oneplus 8T

### DIFF
--- a/patch/kernel/archive/sm8250-6.12/0042-arm64-dts-qcom-sm8250-oneplus-Add-pm8150b-type-c-nod.patch
+++ b/patch/kernel/archive/sm8250-6.12/0042-arm64-dts-qcom-sm8250-oneplus-Add-pm8150b-type-c-nod.patch
@@ -1,0 +1,85 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Fri, 3 Jan 2025 14:35:47 +0800
+Subject: arm64: dts: qcom: sm8250-oneplus: Add pm8150b type-c node
+
+Add type-c node to feature otg function and set usb-role-switch property
+for usb_1_dwc3 to enable usb otg.
+
+Also add pd negotiation support.
+---
+ arch/arm64/boot/dts/qcom/sm8250-oneplus-common.dtsi | 51 +++++++++-
+ 1 file changed, 50 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/sm8250-oneplus-common.dtsi b/arch/arm64/boot/dts/qcom/sm8250-oneplus-common.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/qcom/sm8250-oneplus-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8250-oneplus-common.dtsi
+@@ -724,6 +724,50 @@ conn-therm@0 {
+ 	};
+ };
+ 
++&pm8150b_typec {
++	vdd-pdphy-supply = <&vreg_l2a_3p1>;
++	status = "okay";
++
++	connector {
++		compatible = "usb-c-connector";
++
++		op-sink-microwatt = <10000000>;
++		power-role = "dual";
++		data-role = "dual";
++		self-powered;
++
++		source-pdos = <PDO_FIXED(5000, 3000,
++					 PDO_FIXED_DUAL_ROLE |
++					 PDO_FIXED_USB_COMM |
++					 PDO_FIXED_DATA_SWAP)>;
++
++		sink-pdos = <PDO_FIXED(5000, 3000,
++				       PDO_FIXED_DUAL_ROLE |
++				       PDO_FIXED_USB_COMM |
++				       PDO_FIXED_DATA_SWAP)
++				       PDO_VAR(5000, 12000, 5000)>;
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++
++				pm8150b_hs_in: endpoint {
++					remote-endpoint = <&usb_1_dwc3_hs_out>;
++				};
++			};
++		};
++	};
++};
++
++&pm8150b_vbus {
++	regulator-min-microamp = <500000>;
++	regulator-max-microamp = <3000000>;
++	status = "okay";
++};
++
+ &pm8150l_adc {
+ 	channel@4e {
+ 		reg = <ADC5_AMUX_THM2_100K_PU>;
+@@ -886,7 +930,12 @@ &usb_1 {
+ };
+ 
+ &usb_1_dwc3 {
+-	dr_mode = "peripheral";
++	dr_mode = "otg";
++	usb-role-switch;
++};
++
++&usb_1_dwc3_hs_out {
++	remote-endpoint = <&pm8150b_hs_in>;
+ };
+ 
+ &usb_1_hsphy {
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

The patch in mailing list is setting typec to device mode by default. Now we add a patch to support otg auto switch. But there is no vbus power, so there has to be external power supply to make host mode work.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] ./compile.sh kernel BOARD=xiaomi-elish BRANCH=current DEB_COMPRESS=xz KERNEL_GIT=shallow

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
