### PR TITLE
RPi CM5: Enable DWC2 host mode support by default

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -284,6 +284,9 @@ function pre_umount_final_image__write_raspi_config() {
 		# (e.g. for USB device mode) or if USB support is not required.
 		otg_mode=1
 
+		[cm5]
+		dtoverlay=dwc2,dr_mode=host
+
 		[all]
 		kernel=vmlinuz
 		initramfs initrd.img followkernel


### PR DESCRIPTION

# Description

This makes USB work in host mode by default on more boards. It is already the default on RPi OS: https://github.com/RPi-Distro/pi-gen/commit/ca5eb625d8892212838c4b3b972d9e7e03bfcb29

# How Has This Been Tested?

- [x] Changed config.txt on an existing image, tested on CM5 IO board
- [x] Changed config.txt on an existing image, tested on a custom board

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
