### PR TITLE
nanopct6(-lts): edge: bump u-boot to 2025.01-rc6; enable UMS and fix non-LTS dtsi

### DIFF
--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -62,8 +62,9 @@ function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
 		&usb_host0_xhci { dr_mode = "peripheral";  maximum-speed = "high-speed";  status = "okay"; };
 	EOD
 
-	# @TODO: I notified Kwiboo about the missing lts-u-boot.dtsi in 2025.01; this is a workaround and probably should be removed for 2025.04
-	run_host_command_logged cp "arch/arm/dts/rk3588-nanopc-t6-u-boot.dtsi" "arch/arm/dts/rk3588-nanopc-t6-lts-u-boot.dtsi" # copy non-lts to lts as well.
+	# @TODO: I notified Kwiboo about the missing lts-u-boot.dtsi in 2025.01; this is a workaround and should be removed for 2025.04
+	#        (few minutes later) Kwiboo is done already https://lore.kernel.org/u-boot/20250106182232.3741304-1-jonas@kwiboo.se/
+	run_host_command_logged cp "arch/arm/dts/rk3588-nanopc-t6-u-boot.dtsi" "arch/arm/dts/rk3588-nanopc-t6-lts-u-boot.dtsi"
 }
 
 function post_config_uboot_target__extra_configs_for_nanopct6_mainline_environment_in_spi() {

--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -67,6 +67,20 @@ function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
 	run_host_command_logged cp "arch/arm/dts/rk3588-nanopc-t6-u-boot.dtsi" "arch/arm/dts/rk3588-nanopc-t6-lts-u-boot.dtsi"
 }
 
+# Pull in a newer upstream/dts, which has a fix for the USB3 Type-A (host); this enables booting high speed USB3 devices (https://github.com/torvalds/linux/commit/a6ae420439dc47a58550a6e61e596e9dd1562caf)
+# See https://docs.u-boot.org/en/latest/develop/devicetree/control.html#resyncing-with-devicetree-rebasing
+# @TODO this probably can be removed for 2025.04
+function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
+	[[ "${BRANCH}" != "edge" ]] && return 0
+
+	regular_git add . || true
+	regular_git commit -m "commit pre update OF upstream so that tree is clean" || true
+	run_host_command_logged bash tools/update-subtree.sh pull dts v6.13-rc5-dts "||" true # do not fail as conflicts are expected
+	regular_git checkout --theirs dts/upstream                                            # "accept theirs" on all conflicts
+	regular_git add dts/upstream
+	regular_git commit -m "Update OF upstream to v6.13-rc5-dts and accept theirs on all conflicts"
+}
+
 function post_config_uboot_target__extra_configs_for_nanopct6_mainline_environment_in_spi() {
 	[[ "${BRANCH}" != "edge" ]] && return 0
 

--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -33,11 +33,11 @@ function post_family_config_branch_edge__nanopct6_use_mainline_uboot() {
 	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
 
 	declare -g BOOTCONFIG="nanopc-t6-rk3588_defconfig"
-	declare -g BOOTDELAY=1                                                # Wait for UART interrupt to enter UMS/RockUSB mode etc
-	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" 		  # We ❤️ Mainline
-	declare -g BOOTBRANCH="tag:v2024.10"
-	declare -g BOOTPATCHDIR="v2024.10"
-	declare -g BOOTDIR="u-boot-${BOARD}"                                  # do not share u-boot directory
+	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline
+	declare -g BOOTBRANCH="tag:v2025.01-rc6"
+	declare -g BOOTPATCHDIR="v2025.01"
+	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
 
@@ -51,10 +51,27 @@ function post_family_config_branch_edge__nanopct6_use_mainline_uboot() {
 	}
 }
 
+function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
+	[[ "${BRANCH}" != "edge" ]] && return 0
+
+	display_alert "u-boot for ${BOARD}" "u-boot: add to u-boot dtsi for UMS" "info" # avoid a patch, just append to the dtsi file
+	cat <<- EOD >> arch/arm/dts/rk3588-nanopc-t6-u-boot.dtsi                        # Append to the t6 u-boot dtsi file with stuff for enabling gadget/otg/peripheral mode
+		&u2phy0 { status = "okay"; };
+		&u2phy0_otg { status = "okay"; };
+		&usbdp_phy0 { status = "okay"; };
+		&usb_host0_xhci { dr_mode = "peripheral";  maximum-speed = "high-speed";  status = "okay"; };
+	EOD
+
+	# @TODO: I notified Kwiboo about the missing lts-u-boot.dtsi in 2025.01; this is a workaround and probably should be removed for 2025.04
+	run_host_command_logged cp "arch/arm/dts/rk3588-nanopc-t6-u-boot.dtsi" "arch/arm/dts/rk3588-nanopc-t6-lts-u-boot.dtsi" # copy non-lts to lts as well.
+}
+
 function post_config_uboot_target__extra_configs_for_nanopct6_mainline_environment_in_spi() {
 	[[ "${BRANCH}" != "edge" ]] && return 0
 
-	display_alert "$BOARD" "u-boot configs for ${BOOTBRANCH} u-boot config BRANCH=${BRANCH}" "info"
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable board-specific configs (env in SPI)" "info"
+	run_host_command_logged scripts/config --enable CONFIG_DM_PMIC_FAN53555
+	run_host_command_logged scripts/config --enable CONFIG_CMD_MISC
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_NOWHERE "n"
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_IN_SPI_FLASH "y"
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_SECT_SIZE_AUTO "y"
@@ -62,24 +79,24 @@ function post_config_uboot_target__extra_configs_for_nanopct6_mainline_environme
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_SIZE "0x20000"
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_OFFSET "0xc00000"
 
-	display_alert "u-boot for ${BOARD}" "u-boot: enable preboot & flash user LED in preboot" "info"
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable preboot & flash user LED in preboot" "info"
 	run_host_command_logged scripts/config --enable CONFIG_USE_PREBOOT
 	run_host_command_logged scripts/config --set-str CONFIG_PREBOOT "'led user-led on; sleep 0.1; led user-led off'" # double quotes required due to run_host_command_logged's quirks
 
-	display_alert "u-boot for ${BOARD}" "u-boot: enable EFI debugging command" "info"
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable EFI debugging commands" "info"
 	run_host_command_logged scripts/config --enable CMD_EFIDEBUG
 	run_host_command_logged scripts/config --enable CMD_NVEDIT_EFI
 
-	display_alert "u-boot for ${BOARD}" "u-boot: enable more compression support" "info"
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable more compression support" "info"
 	run_host_command_logged scripts/config --enable CONFIG_LZO
 	run_host_command_logged scripts/config --enable CONFIG_BZIP2
 	run_host_command_logged scripts/config --enable CONFIG_ZSTD
 
-	display_alert "u-boot for ${BOARD}" "u-boot: enable gpio LED support" "info"
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable gpio LED support" "info"
 	run_host_command_logged scripts/config --enable CONFIG_LED
 	run_host_command_logged scripts/config --enable CONFIG_LED_GPIO
 
-	display_alert "u-boot for ${BOARD}" "u-boot: enable networking cmds" "info"
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable networking cmds" "info"
 	run_host_command_logged scripts/config --enable CONFIG_CMD_NFS
 	run_host_command_logged scripts/config --enable CONFIG_CMD_WGET
 	run_host_command_logged scripts/config --enable CONFIG_CMD_DNS
@@ -87,14 +104,13 @@ function post_config_uboot_target__extra_configs_for_nanopct6_mainline_environme
 	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP_SACK
 
 	# UMS, RockUSB, gadget stuff
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable UMS/RockUSB gadget" "info"
 	declare -a enable_configs=("CONFIG_CMD_USB_MASS_STORAGE" "CONFIG_USB_GADGET" "USB_GADGET_DOWNLOAD" "CONFIG_USB_FUNCTION_ROCKUSB" "CONFIG_USB_FUNCTION_ACM" "CONFIG_CMD_ROCKUSB" "CONFIG_CMD_USB_MASS_STORAGE")
 	for config in "${enable_configs[@]}"; do
-		display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable ${config}" "info"
 		run_host_command_logged scripts/config --enable "${config}"
 	done
 	# Auto-enabled by the above, force off...
 	run_host_command_logged scripts/config --disable USB_FUNCTION_FASTBOOT
-
 }
 
 # Include fw_setenv, configured to point to the correct spot on the SPI Flash


### PR DESCRIPTION
#### nanopct6(-lts): edge: bump u-boot to 2025.01-rc6; enable UMS and fix non-LTS dtsi

- nanopct6(-lts): edge: bump u-boot to 2025.01-rc6; enable UMS and fix non-LTS dtsi
- nanopct6(-lts): edge: u-boot: note that Kwiboo already sent a fix upstream ref the LTS dtsi
- nanopct6(-lts): edge: u-boot: pull `upstream/dts` `v6.13-rc5-dts` for USB3 Type-A
  - to enable USB3 Type-A host port (
    - ref https://github.com/torvalds/linux/commit/a6ae420439dc47a58550a6e61e596e9dd1562caf