### PR TITLE
Sm8250: build abl boot recovery image

### DIFF
--- a/config/boards/oneplus-kebab.conf
+++ b/config/boards/oneplus-kebab.conf
@@ -25,9 +25,14 @@ function post_family_tweaks_bsp__oneplus-kebab_firmware() {
 	# USB Gadget Network service
 	mkdir -p $destination/usr/local/bin/
 	mkdir -p $destination/usr/lib/systemd/system/
+	mkdir -p $destination/etc/initramfs-tools/scripts/init-bottom/
 	install -Dm655 $SRC/packages/bsp/usb-gadget-network/setup-usbgadget-network.sh $destination/usr/local/bin/
 	install -Dm655 $SRC/packages/bsp/usb-gadget-network/remove-usbgadget-network.sh $destination/usr/local/bin/
 	install -Dm644 $SRC/packages/bsp/usb-gadget-network/usbgadget-rndis.service $destination/usr/lib/systemd/system/
+	install -Dm655 $SRC/packages/bsp/usb-gadget-network/usb-gadget-initramfs-hook $destination/etc/initramfs-tools/hooks/usb-gadget
+	install -Dm655 $SRC/packages/bsp/usb-gadget-network/usb-gadget-initramfs-premount $destination/etc/initramfs-tools/scripts/init-premount/usb-gadget
+	install -Dm655 $SRC/packages/bsp/usb-gadget-network/dropbear $destination/etc/initramfs-tools/scripts/init-premount/
+	install -Dm655 $SRC/packages/bsp/usb-gadget-network/kill-dropbear $destination/etc/initramfs-tools/scripts/init-bottom/
 
 	# Bluetooth MAC addr setup service
 	install -Dm655 $SRC/packages/bsp/generate-bt-mac-addr/bt-fixed-mac.sh $destination/usr/local/bin/
@@ -64,7 +69,7 @@ function post_family_tweaks__oneplus-kebab_enable_services() {
 
 	do_with_retries 3 chroot_sdcard_apt_get_update
 	display_alert "$BOARD" "Installing board tweaks" "info"
-	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools unudhcpd mkbootimg
+	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools unudhcpd mkbootimg dropbear-bin
 
 	# disable armbian repo back
 	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled

--- a/config/boards/xiaomi-elish.conf
+++ b/config/boards/xiaomi-elish.conf
@@ -38,6 +38,10 @@ function post_family_tweaks_bsp__xiaomi-elish_firmware() {
 	install -Dm655 $SRC/packages/bsp/usb-gadget-network/setup-usbgadget-network.sh $destination/usr/local/bin/
 	install -Dm655 $SRC/packages/bsp/usb-gadget-network/remove-usbgadget-network.sh $destination/usr/local/bin/
 	install -Dm644 $SRC/packages/bsp/usb-gadget-network/usbgadget-rndis.service $destination/usr/lib/systemd/system/
+	install -Dm655 $SRC/packages/bsp/usb-gadget-network/usb-gadget-initramfs-hook $destination/etc/initramfs-tools/hooks/usb-gadget
+	install -Dm655 $SRC/packages/bsp/usb-gadget-network/usb-gadget-initramfs-premount $destination/etc/initramfs-tools/scripts/init-premount/usb-gadget
+	install -Dm655 $SRC/packages/bsp/usb-gadget-network/dropbear $destination/etc/initramfs-tools/scripts/init-premount/
+	install -Dm655 $SRC/packages/bsp/usb-gadget-network/kill-dropbear $destination/etc/initramfs-tools/scripts/init-bottom/
 
 	# Bluetooth MAC addr setup service
 	install -Dm655 $SRC/packages/bsp/generate-bt-mac-addr/bt-fixed-mac.sh $destination/usr/local/bin/
@@ -67,7 +71,7 @@ function post_family_tweaks__xiaomi-elish_enable_services() {
 
 	do_with_retries 3 chroot_sdcard_apt_get_update
 	display_alert "$BOARD" "Installing board tweaks" "info"
-	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools unudhcpd mkbootimg
+	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools unudhcpd mkbootimg dropbear-bin
 
 	# Install hexagonrpc userspace service for kernel after 6.11, hexagonrpc in only packaged for noble now
 	if [[ "${RELEASE}" == "noble" ]]; then

--- a/extensions/image-output-abl.sh
+++ b/extensions/image-output-abl.sh
@@ -55,6 +55,18 @@ function post_build_image__900_convert_to_abl_img() {
 				--pagesize 4096 \
 				-o ${DESTIMG}/${version}.boot_${dtb_name}.img
 		done
+		display_alert "Creatng abl kernel boot recovery image with dtb ${ABL_DTB_LIST[0]}" "${EXTENSION}" "info"
+		cat ${DESTIMG}/Image.gz ${new_rootfs_image_mount_dir}/usr/lib/linux-image-*/qcom/${dtb_name}.dtb > ${DESTIMG}/Image.gz-${dtb_name}
+		/usr/bin/mkbootimg \
+			--kernel ${DESTIMG}/Image.gz-${ABL_DTB_LIST[0]} \
+			--ramdisk ${new_rootfs_image_mount_dir}/boot/initrd.img-*-* \
+			--base 0x0 \
+			--second_offset 0x00f00000 \
+			--kernel_offset 0x8000 \
+			--ramdisk_offset 0x1000000 \
+			--tags_offset 0x100 \
+			--pagesize 4096 \
+			-o ${DESTIMG}/${version}.boot_recovery.img
 	fi
 
 	umount ${new_rootfs_image_mount_dir}

--- a/packages/bsp/usb-gadget-network/dropbear
+++ b/packages/bsp/usb-gadget-network/dropbear
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+prereqs()
+{
+	echo "${PREREQ}"
+}
+
+case ${1} in
+	prereqs)
+		prereqs
+		exit 0
+		;;
+esac
+
+nohup /usr/sbin/dropbear -j -k -F -E -R >> /run/initramfs/dropbear.log 2>&1 &

--- a/packages/bsp/usb-gadget-network/kill-dropbear
+++ b/packages/bsp/usb-gadget-network/kill-dropbear
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+prereqs()
+{
+	echo "${PREREQ}"
+}
+
+case ${1} in
+	prereqs)
+		prereqs
+		exit 0
+		;;
+esac
+
+logsave -a -s /run/initramfs/kill-dropbear.log pkill dropbear
+exit 0

--- a/packages/bsp/usb-gadget-network/setup-usbgadget-network.sh
+++ b/packages/bsp/usb-gadget-network/setup-usbgadget-network.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-deviceinfo_name="Armbian USB Gadget Network"
+deviceinfo_name="USB Gadget Network"
 deviceinfo_manufacturer="Armbian"
 #deviceinfo_usb_idVendor=
 #deviceinfo_usb_idProduct=
@@ -15,17 +15,24 @@ setup_usb_network_configfs() {
 		return
 	fi
 
+	if [ -e "$CONFIGFS/g1" ]; then
+		echo "  $CONFIGFS/g1 already exists, skipping configfs usb gadget"
+		return
+	fi
+
 	# Default values for USB-related deviceinfo variables
-	usb_idVendor="${deviceinfo_usb_idVendor:-0x18D1}"   # default: Google Inc.
-	usb_idProduct="${deviceinfo_usb_idProduct:-0xD001}" # default: Nexus 4 (fastboot)
-	usb_serialnumber="${deviceinfo_usb_serialnumber:-postmarketOS}"
-	usb_network_function="rndis.0"
+	usb_idVendor="${deviceinfo_usb_idVendor:-0x1D6B}"   # Linux Foundation
+	usb_idProduct="${deviceinfo_usb_idProduct:-0x0103}" # NCM (Ethernet) Gadget
+	usb_serialnumber="${deviceinfo_usb_serialnumber:-0123456789}"
+	usb_network_function="ncm.usb0"
 
 	echo "  Setting up an USB gadget through configfs"
 	# Create an usb gadet configuration
 	mkdir $CONFIGFS/g1 || echo "  Couldn't create $CONFIGFS/g1"
 	echo "$usb_idVendor" > "$CONFIGFS/g1/idVendor"
 	echo "$usb_idProduct" > "$CONFIGFS/g1/idProduct"
+	echo 0x0100 > "$CONFIGFS/g1/bcdDevice"
+	echo 0x0200 > "$CONFIGFS/g1/bcdUSB"
 
 	# Create english (0x409) strings
 	mkdir $CONFIGFS/g1/strings/0x409 || echo "  Couldn't create $CONFIGFS/g1/strings/0x409"
@@ -43,27 +50,15 @@ setup_usb_network_configfs() {
 	# Create configuration instance for the gadget
 	mkdir $CONFIGFS/g1/configs/c.1 ||
 		echo "  Couldn't create $CONFIGFS/g1/configs/c.1"
+	echo 250 > $CONFIGFS/g1/configs/c.1/MaxPower
 	mkdir $CONFIGFS/g1/configs/c.1/strings/0x409 ||
 		echo "  Couldn't create $CONFIGFS/g1/configs/c.1/strings/0x409"
-	echo "USB network" > $CONFIGFS/g1/configs/c.1/strings/0x409/configuration ||
+	echo "NCM Configuration" > $CONFIGFS/g1/configs/c.1/strings/0x409/configuration ||
 		echo "  Couldn't write configration name"
 
 	# Link the network instance to the configuration
 	ln -s $CONFIGFS/g1/functions/"$usb_network_function" $CONFIGFS/g1/configs/c.1 ||
 		echo "  Couldn't symlink $usb_network_function"
-
-	echo 0xEF > $CONFIGFS/g1/functions/"$usb_network_function"/class ||
-		echo "  Couldn't write class"
-	echo 0x04 > $CONFIGFS/g1/functions/"$usb_network_function"/subclass ||
-		echo "  Couldn't write subclass"
-	echo 0x01 > $CONFIGFS/g1/functions/"$usb_network_function"/protocol ||
-		echo "  Couldn't write protocol"
-	echo 0xEF > $CONFIGFS/g1/bDeviceClass ||
-		echo "  Couldn't write g1 class"
-	echo 0x04 > $CONFIGFS/g1/bDeviceSubClass ||
-		echo "  Couldn't write g1 subclass"
-	echo 0x01 > $CONFIGFS/g1/bDeviceProtocol ||
-		echo "  Couldn't write g1 protocol"
 
 	# Check if there's an USB Device Controller
 	if [ -z "$(ls /sys/class/udc)" ]; then
@@ -80,13 +75,15 @@ setup_usb_network_configfs() {
 set_usbgadget_ipaddress() {
 	local host_ip="${unudhcpd_host_ip:-172.16.42.1}"
 	local client_ip="${unudhcpd_client_ip:-172.16.42.2}"
+	unudhcpd_pid=$(pgrep unudhcpd)
+	if [ "x$unudhcpd_pid" != "x" ]; then
+		echo "unudhcpd process already exists, skip setting usb gadget ip, unudhcpd_pid is $unudhcpd_pid"
+		return
+	fi
 	echo "Starting dnsmasq with server ip $host_ip, client ip: $client_ip"
 	# Get usb interface
 	INTERFACE=""
-	ip a add "${host_ip}/255.255.0.0" dev rndis0 2> /dev/null && ip link set rndis0 up && INTERFACE=rndis0
-	if [ -z $INTERFACE ]; then
-		ip a add "${host_ip}/255.255.0.0" dev usb0 2> /dev/null && ip link set usb0 up && INTERFACE=usb0
-	fi
+	ip a add "${host_ip}/255.255.0.0" dev usb0 2> /dev/null && ip link set usb0 up && INTERFACE=usb0
 	if [ -z $INTERFACE ]; then
 		ip a add "${host_ip}/255.255.0.0" dev eth0 2> /dev/null && eth0 && INTERFACE=eth0
 	fi
@@ -101,7 +98,8 @@ set_usbgadget_ipaddress() {
 	echo "  Using interface $INTERFACE"
 	echo "  Starting the DHCP daemon"
 	ip a show $INTERFACE > /var/log/unudhcpd.log
-	nohup /usr/bin/unudhcpd -i "$INTERFACE" -s "$host_ip" -c "$client_ip" 2>&1 >> /var/log/unudhcpd.log &
+	nohup /usr/bin/unudhcpd -i "$INTERFACE" -s "$host_ip" -c "$client_ip" >> /var/log/unudhcpd.log 2>&1 &
+	return
 }
 setup_usb_network_configfs
 set_usbgadget_ipaddress

--- a/packages/bsp/usb-gadget-network/usb-gadget-initramfs-hook
+++ b/packages/bsp/usb-gadget-network/usb-gadget-initramfs-hook
@@ -1,0 +1,17 @@
+#!/bin/bash
+[[ "$1" == "prereqs" ]] && exit 0
+. /usr/share/initramfs-tools/hook-functions
+
+copy_exec "/usr/local/bin/setup-usbgadget-network.sh"
+copy_exec "/bin/bash"
+copy_exec "/bin/ip"
+copy_exec "/usr/bin/nohup"
+copy_exec "/usr/bin/unudhcpd"
+copy_exec "/usr/bin/pgrep"
+copy_exec "/usr/sbin/dropbear"
+copy_exec "/usr/bin/pkill"
+copy_exec "/usr/sbin/parted"
+copy_file config "/etc/protocols"
+copy_file config "/etc/shadow"
+
+mkdir -p "${DESTDIR}/etc/dropbear"

--- a/packages/bsp/usb-gadget-network/usb-gadget-initramfs-premount
+++ b/packages/bsp/usb-gadget-network/usb-gadget-initramfs-premount
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+prereqs()
+{
+	echo "${PREREQ}"
+}
+
+case ${1} in
+	prereqs)
+		prereqs
+		exit 0
+		;;
+esac
+
+mount -t configfs none /sys/kernel/config
+mkdir -p /var/log
+logsave -a -s /run/initramfs/usb-gadget-rndis.log /usr/local/bin/setup-usbgadget-network.sh
+exit 0


### PR DESCRIPTION
# Description

For devices with android boot loader, we used to create partition with thirdparty android recovery such as TWRP. While mainline linux can also do it. We can boot into initramfs busybox and modify the partition with tools like parted.

I move usb gadget network(toggled from RNDIS to NCM) to initramfs and add a light weight ssh server dropbear. Then we can ssh into the initramfs by usb network and do a lot of things.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] ./compile.sh BOARD=oneplus-kebab BRANCH=current KERNEL_GIT=shallow DEB_COMPRESS=xz RELEASE=noble BUILD_DESKTOP=yes BUILD_MINIMAL=no KERNEL_CONFIGURE=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base
- [x] Tested with oneplus 8T, boot built recovery and ssh into it with armbian's default password root/1234. 

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
