### PR TITLE
cm3588-nas: u-boot: 2025.01-rc6 with working UMS

### DIFF
--- a/config/boards/cm3588-nas.csc
+++ b/config/boards/cm3588-nas.csc
@@ -10,6 +10,7 @@ BOOT_LOGO="desktop"
 IMAGE_PARTITION_TABLE="gpt"
 BOOT_FDT_FILE="rockchip/rk3588-friendlyelec-cm3588-nas.dtb"
 BOOT_SCENARIO="spl-blobs"
+UEFI_EDK2_BOARD_ID="nanopc-cm3588-nas" # This _only_ used for uefi-edk2-rk3588 extension; cm3588-nas was introduced in v0.12 of edk2-porting/edk2-rk3588
 
 function post_family_tweaks__cm3588_nas_udev_naming_audios() {
 	display_alert "$BOARD" "Renaming CM3588 audio interfaces to human-readable form" "info"

--- a/config/boards/cm3588-nas.csc
+++ b/config/boards/cm3588-nas.csc
@@ -65,6 +65,18 @@ function pre_config_uboot_target__cm3588_patch_uboot_dtsi_for_ums() {
 	UBOOT_BOARD_DTSI_OTG
 }
 
+# "rockchip-common: boot SD card first, then NVMe, then mmc"
+# include/configs/rockchip-common.h
+# -#define BOOT_TARGETS "mmc1 mmc0 nvme scsi usb pxe dhcp spi"
+# +#define BOOT_TARGETS "mmc0 nvme mmc1 scsi usb pxe dhcp spi"
+# On cm3588-nas, mmc0 is the eMMC, mmc1 is the SD card slot
+function pre_config_uboot_target__cm3588_patch_rockchip_common_boot_order() {
+	declare -a rockchip_uboot_targets=("mmc1" "nvme" "mmc0" "scsi" "usb" "pxe" "dhcp" "spi") # for future make-this-generic delight
+	display_alert "u-boot for ${BOARD}" "u-boot: adjust boot order to '${rockchip_uboot_targets[*]}'" "info"
+	sed -i -e "s/#define BOOT_TARGETS.*/#define BOOT_TARGETS \"${rockchip_uboot_targets[*]}\"/" include/configs/rockchip-common.h
+	regular_git diff -u include/configs/rockchip-common.h || true
+}
+
 function post_config_uboot_target__extra_configs_for_cm3588-nas_uboot() {
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable preboot & flash user LED in preboot" "info"
 	run_host_command_logged scripts/config --enable CONFIG_USE_PREBOOT


### PR DESCRIPTION
#### cm3588-nas: u-boot: 2025.01-rc6 with working UMS

- cm3588-nas: u-boot: 2025.01-rc6 with working UMS
  - once done for t6, let the copypasta reign
  - bunch of fancy stuff enabled in u-boot
- cm3588-nas: enable usage with `EXT=uefi-edk2-rk3588`
  - cm3588-nas was introduced in v0.12 of edk2-porting/edk2-rk3588
- cm3588-nas: u-boot: boot SD card first, then NVMe, then mmc
  - sans-patches, `sed` and bash arrays ftw