### PR TITLE
nanopct6(-lts): u-boot: edge: bump to 2025.01 final

### DIFF
--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -72,13 +72,21 @@ function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
 # @TODO this probably can be removed for 2025.04
 function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
 	[[ "${BRANCH}" != "edge" ]] && return 0
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: pull in upstream/dts for UMS" "info"
 
-	regular_git add . || true
-	regular_git commit -m "commit pre update OF upstream so that tree is clean" || true
-	run_host_command_logged bash tools/update-subtree.sh pull dts v6.13-rc5-dts "||" true # do not fail as conflicts are expected
-	regular_git checkout --theirs dts/upstream                                            # "accept theirs" on all conflicts
-	regular_git add dts/upstream
-	regular_git commit -m "Update OF upstream to v6.13-rc5-dts and accept theirs on all conflicts"
+	# Need to specify params and envs so git doesn't break when commiter/author/gpg/HOME/etc is unset.
+	declare -a common_envs=("HOME=${HOME}" "PATH=${PATH}")
+	declare -a git_params=("-c" "commit.gpgsign=false")
+	declare -a commit_params=(--author="${MAINTAINER} <${MAINTAINERMAIL}>")
+	declare -a commit_envs=("GIT_COMMITTER_NAME=${MAINTAINER}" "GIT_COMMITTER_EMAIL=${MAINTAINERMAIL}" "GIT_AUTHOR_NAME=${MAINTAINER}" "GIT_AUTHOR_EMAIL=${MAINTAINERMAIL}")
+
+	run_host_command_logged env -i "${common_envs[@]@Q}" git add . || true
+	run_host_command_logged env -i "${common_envs[@]@Q}" "${commit_envs[@]@Q}" git "${git_params[@]@Q}" commit "${commit_params[@]@Q}" -m "'commit pre update OF upstream so that tree is clean'" || true
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: running tools/update-subtree.sh" "info"
+	run_host_command_logged env -i "${common_envs[@]@Q}" "${commit_envs[@]@Q}" bash tools/update-subtree.sh pull dts v6.13-rc5-dts "||" true # do not fail as conflicts are expected
+	run_host_command_logged env -i "${common_envs[@]@Q}" git checkout --theirs dts/upstream
+	run_host_command_logged env -i "${common_envs[@]@Q}" git add dts/upstream
+	run_host_command_logged env -i "${common_envs[@]@Q}" "${commit_envs[@]@Q}" git "${git_params[@]@Q}" commit "${commit_params[@]@Q}" -m "'Update OF upstream to v6.13-rc5-dts and accept theirs on all conflicts'"
 }
 
 function post_config_uboot_target__extra_configs_for_nanopct6_mainline_environment_in_spi() {

--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -35,7 +35,7 @@ function post_family_config_branch_edge__nanopct6_use_mainline_uboot() {
 	declare -g BOOTCONFIG="nanopc-t6-rk3588_defconfig"
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline
-	declare -g BOOTBRANCH="tag:v2025.01-rc6"
+	declare -g BOOTBRANCH="tag:v2025.01"
 	declare -g BOOTPATCHDIR="v2025.01"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"

--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -89,6 +89,18 @@ function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
 	run_host_command_logged env -i "${common_envs[@]@Q}" "${commit_envs[@]@Q}" git "${git_params[@]@Q}" commit "${commit_params[@]@Q}" -m "'Update OF upstream to v6.13-rc5-dts and accept theirs on all conflicts'"
 }
 
+# "rockchip-common: boot SD card first, then NVMe, then mmc"
+# include/configs/rockchip-common.h
+# -#define BOOT_TARGETS "mmc1 mmc0 nvme scsi usb pxe dhcp spi"
+# +#define BOOT_TARGETS "mmc0 nvme mmc1 scsi usb pxe dhcp spi"
+# On nanopct6, mmc0 is the eMMC, mmc1 is the SD card slot
+function pre_config_uboot_target__nanopct6_patch_rockchip_common_boot_order() {
+	declare -a rockchip_uboot_targets=("mmc1" "nvme" "mmc0" "scsi" "usb" "pxe" "dhcp" "spi") # for future make-this-generic delight
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: adjust boot order to '${rockchip_uboot_targets[*]}'" "info"
+	sed -i -e "s/#define BOOT_TARGETS.*/#define BOOT_TARGETS \"${rockchip_uboot_targets[*]}\"/" include/configs/rockchip-common.h
+	regular_git diff -u include/configs/rockchip-common.h || true
+}
+
 function post_config_uboot_target__extra_configs_for_nanopct6_mainline_environment_in_spi() {
 	[[ "${BRANCH}" != "edge" ]] && return 0
 


### PR DESCRIPTION
#### nanopct6(-lts): u-boot: edge: bump to 2025.01 final

- nanopct6(-lts): u-boot: edge: fix for pulling devicetree-rebasing using git
  - otherwise git breaks when unconfigured
- nanopct6(-lts): u-boot: edge: bump to 2025.01 final
- nanopct6(-lts): u-boot: edge: boot order SD -> NVMe -> eMMC