### PR TITLE
BananaPi BPI-M4-Zero: REV1 uart1 support via overlay

### DIFF
--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/Add-BananaPi-BPI-M4-Zero-overlays.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/Add-BananaPi-BPI-M4-Zero-overlays.patch
@@ -1,33 +1,49 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From dfee1d3e9957e15537f3b05e13e6970eeaccfe94 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
-Date: Thu, 12 Dec 2024 06:53:20 -0500
-Subject: Add BananaPi BPI-M4-Zero overlays
+Date: Tue, 7 Jan 2025 06:39:30 -0500
+Subject: [PATCH] Add BananaPi BPI-M4-Zero overlays
 
 Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
- arch/arm64/boot/dts/allwinner/overlay/Makefile                                            | 11 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso          | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso          | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso           | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-13-14-uart4.dtso         | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtso | 16 +++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso            | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso            | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso           | 29 +++++++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso    | 32 ++++++++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtso        | 24 +++++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtso        | 13 ++++
- 12 files changed, 203 insertions(+)
+ .../arm64/boot/dts/allwinner/overlay/Makefile | 13 ++++++
+ ...sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso | 13 ++++++
+ ...sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso | 13 ++++++
+ .../sun50i-h616-bananapi-m4-pg-6-7-uart1.dtso | 13 ++++++
+ ...h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtso | 16 +++++++
+ .../sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso | 13 ++++++
+ ...un50i-h616-bananapi-m4-pi-13-14-uart4.dtso | 13 ++++++
+ ...16-bananapi-m4-pi-15-16-rts-cts-uart4.dtso | 16 +++++++
+ .../sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso  | 13 ++++++
+ .../sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso  | 13 ++++++
+ .../sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso | 44 +++++++++++++++++++
+ ...-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso | 32 ++++++++++++++
+ ...n50i-h616-bananapi-m4-spi1-cs0-spidev.dtso | 24 ++++++++++
+ ...n50i-h616-bananapi-m4-spi1-cs1-spidev.dtso | 13 ++++++
+ 14 files changed, 249 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-6-7-uart1.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-13-14-uart4.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtso
 
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-index 111111111111..222222222222 100644
+index 24383cb63770..16c739b56350 100644
 --- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-@@ -49,6 +49,17 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
+@@ -49,6 +49,19 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
  	sun50i-h6-uart2.dtbo \
  	sun50i-h6-uart3.dtbo \
  	sun50i-h6-w1-gpio.dtbo \
-+	sun50i-h616-bananapi-m4-sdio-wifi-bt.dtbo \
++	sun50i-h616-bananapi-m4-pg-6-7-uart1.dtbo \
++	sun50i-h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtbo \
 +	sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtbo \
 +	sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtbo \
 +	sun50i-h616-bananapi-m4-ph-2-3-uart5.dtbo \
@@ -35,6 +51,7 @@ index 111111111111..222222222222 100644
 +	sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtbo \
 +	sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtbo \
 +	sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtbo \
++	sun50i-h616-bananapi-m4-sdio-wifi-bt.dtbo \
 +	sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtbo \
 +	sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtbo \
 +	sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtbo \
@@ -43,7 +60,7 @@ index 111111111111..222222222222 100644
  	sun50i-h616-i2c4-ph.dtbo \
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..4e78aa8f1f27
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso
 @@ -0,0 +1,13 @@
@@ -62,7 +79,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..3419eee0b70b
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso
 @@ -0,0 +1,13 @@
@@ -79,9 +96,50 @@ index 000000000000..111111111111
 +		};
 +	};
 +};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-6-7-uart1.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-6-7-uart1.dtso
+new file mode 100644
+index 000000000000..7001781f42d2
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-6-7-uart1.dtso
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "sinovoip,bpi-m4-zero", "allwinner,sun50i-h616", "allwinner,sun50i-h618";
++
++	fragment@0 {
++		target = <&uart1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtso
+new file mode 100644
+index 000000000000..1317a9b3b52f
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtso
+@@ -0,0 +1,16 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "sinovoip,bpi-m4-zero", "allwinner,sun50i-h616", "allwinner,sun50i-h618";
++
++	fragment@0 {
++		target = <&uart1>;
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++			pinctrl-names = "default";
++			uart-has-rtscts;
++		};
++	};
++};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..aaa96e46d708
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso
 @@ -0,0 +1,13 @@
@@ -100,7 +158,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-13-14-uart4.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-13-14-uart4.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..0373f7d25449
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-13-14-uart4.dtso
 @@ -0,0 +1,13 @@
@@ -119,7 +177,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..ef9394c8519c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtso
 @@ -0,0 +1,16 @@
@@ -141,7 +199,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..60c75e4d61b5
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso
 @@ -0,0 +1,13 @@
@@ -160,7 +218,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..99c7e2b8c5f6
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso
 @@ -0,0 +1,13 @@
@@ -179,12 +237,14 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..307f6e5e921c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,44 @@
 +/dts-v1/;
 +/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
 +
 +/ {
 +	compatible = "sinovoip,bpi-m4-zero", "allwinner,sun50i-h616", "allwinner,sun50i-h618";
@@ -209,12 +269,25 @@ index 000000000000..111111111111
 +		target = <&uart1>;
 +		__overlay__ {
 +			status = "okay";
++			pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++			pinctrl-names = "default";
++			uart-has-rtscts;
++
++			bluetooth {
++				compatible = "brcm,bcm43540-bt";
++				host-wakeup-gpios = <&pio 6 16 GPIO_ACTIVE_HIGH>;
++				device-wakeup-gpios = <&pio 6 17 GPIO_ACTIVE_HIGH>;
++				shutdown-gpios = <&pio 6 19 GPIO_ACTIVE_HIGH>;
++				max-speed = <1500000>;
++				vbat-supply = <&reg_vcc3v3>;
++				vddio-supply = <&reg_vcc1v8>;
++			};
 +		};
 +	};
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..7fa3b94bcc8d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso
 @@ -0,0 +1,32 @@
@@ -252,7 +325,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..fef73f1afa52
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtso
 @@ -0,0 +1,24 @@
@@ -282,7 +355,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..840357f2e9e0
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtso
 @@ -0,0 +1,13 @@
@@ -300,5 +373,5 @@ index 000000000000..111111111111
 +	};
 +};
 -- 
-Armbian
+2.39.5
 

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
@@ -1,20 +1,22 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 0db8b2bef6fdd2bda67296809de46ad57e08ab00 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
-Date: Thu, 12 Dec 2024 06:51:36 -0500
-Subject: Add board BananaPi BPI-M4-Zero
+Date: Tue, 7 Jan 2025 06:58:55 -0500
+Subject: [PATCH] Add board BananaPi BPI-M4-Zero
 
 Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
- arch/arm64/boot/dts/allwinner/Makefile                         |   1 +
- arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts | 126 +++++
- arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi     | 248 ++++++++++
- 3 files changed, 375 insertions(+)
+ arch/arm64/boot/dts/allwinner/Makefile        |   1 +
+ .../sun50i-h618-bananapi-m4-zero.dts          | 110 ++++++++
+ .../allwinner/sun50i-h618-bananapi-m4.dtsi    | 256 ++++++++++++++++++
+ 3 files changed, 367 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 111111111111..222222222222 100644
+index 87ecd81bcb9f..0a206c422625 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -59,6 +59,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
+@@ -58,6 +58,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-pi.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
@@ -24,10 +26,10 @@ index 111111111111..222222222222 100644
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..73da25a79fdd
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
-@@ -0,0 +1,126 @@
+@@ -0,0 +1,110 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
@@ -95,6 +97,7 @@ index 000000000000..111111111111
 +	};
 +};
 +
++/* SDIO */
 +&mmc1 {
 +	status = "disabled";
 +	bus-width = <4>;
@@ -129,23 +132,6 @@ index 000000000000..111111111111
 +	status = "okay";
 +};
 +
-+&uart1 {
-+	status = "disabled";
-+	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
-+	pinctrl-names = "default";
-+	uart-has-rtscts;
-+
-+	bluetooth {
-+		compatible = "brcm,bcm43540-bt";
-+		host-wakeup-gpios = <&pio 6 16 GPIO_ACTIVE_HIGH>;
-+		device-wakeup-gpios = <&pio 6 17 GPIO_ACTIVE_HIGH>;
-+		shutdown-gpios = <&pio 6 19 GPIO_ACTIVE_HIGH>;
-+		max-speed = <1500000>;
-+		vbat-supply = <&reg_vcc3v3>;
-+		vddio-supply = <&reg_vcc1v8>;
-+	};
-+};
-+
 +&usbotg {
 +	status = "okay";
 +	dr_mode = "peripheral";
@@ -156,10 +142,10 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..32359f169124
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
-@@ -0,0 +1,248 @@
+@@ -0,0 +1,256 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
@@ -295,6 +281,7 @@ index 000000000000..111111111111
 +	pinctrl-names = "default";
 +};
 +
++/* SD card */
 +&mmc0 {
 +	status = "okay";
 +	bus-width = <4>;
@@ -306,6 +293,7 @@ index 000000000000..111111111111
 +	vmmc-supply = <&reg_vcc3v3>;
 +};
 +
++/* eMMC */
 +&mmc2 {
 +	status = "okay";
 +	bus-width = <8>;
@@ -397,6 +385,12 @@ index 000000000000..111111111111
 +	pinctrl-names = "default";
 +};
 +
++&uart1 {
++	status = "disabled";
++	pinctrl-0 = <&uart1_pins>;
++	pinctrl-names = "default";
++};
++
 +&uart4 {
 +	status = "disabled";
 +	pinctrl-0 = <&uart4_pi_pins>;
@@ -409,5 +403,5 @@ index 000000000000..111111111111
 +	pinctrl-names = "default";
 +};
 -- 
-Armbian
+2.39.5
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-BananaPi-BPI-M4-Zero-overlays.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-BananaPi-BPI-M4-Zero-overlays.patch
@@ -1,33 +1,49 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From dfee1d3e9957e15537f3b05e13e6970eeaccfe94 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
-Date: Wed, 11 Dec 2024 12:23:10 -0500
-Subject: Add BananaPi BPI-M4-Zero overlays
+Date: Tue, 7 Jan 2025 06:39:30 -0500
+Subject: [PATCH] Add BananaPi BPI-M4-Zero overlays
 
 Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
- arch/arm64/boot/dts/allwinner/overlay/Makefile                                            | 11 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso          | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso          | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso           | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-13-14-uart4.dtso         | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtso | 16 +++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso            | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso            | 13 ++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso           | 29 +++++++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso    | 32 ++++++++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtso        | 24 +++++++
- arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtso        | 13 ++++
- 12 files changed, 203 insertions(+)
+ .../arm64/boot/dts/allwinner/overlay/Makefile | 13 ++++++
+ ...sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso | 13 ++++++
+ ...sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso | 13 ++++++
+ .../sun50i-h616-bananapi-m4-pg-6-7-uart1.dtso | 13 ++++++
+ ...h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtso | 16 +++++++
+ .../sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso | 13 ++++++
+ ...un50i-h616-bananapi-m4-pi-13-14-uart4.dtso | 13 ++++++
+ ...16-bananapi-m4-pi-15-16-rts-cts-uart4.dtso | 16 +++++++
+ .../sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso  | 13 ++++++
+ .../sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso  | 13 ++++++
+ .../sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso | 44 +++++++++++++++++++
+ ...-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso | 32 ++++++++++++++
+ ...n50i-h616-bananapi-m4-spi1-cs0-spidev.dtso | 24 ++++++++++
+ ...n50i-h616-bananapi-m4-spi1-cs1-spidev.dtso | 13 ++++++
+ 14 files changed, 249 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-6-7-uart1.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-13-14-uart4.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtso
 
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-index 111111111111..222222222222 100644
+index 24383cb63770..16c739b56350 100644
 --- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-@@ -49,6 +49,17 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
+@@ -49,6 +49,19 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
  	sun50i-h6-uart2.dtbo \
  	sun50i-h6-uart3.dtbo \
  	sun50i-h6-w1-gpio.dtbo \
-+	sun50i-h616-bananapi-m4-sdio-wifi-bt.dtbo \
++	sun50i-h616-bananapi-m4-pg-6-7-uart1.dtbo \
++	sun50i-h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtbo \
 +	sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtbo \
 +	sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtbo \
 +	sun50i-h616-bananapi-m4-ph-2-3-uart5.dtbo \
@@ -35,6 +51,7 @@ index 111111111111..222222222222 100644
 +	sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtbo \
 +	sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtbo \
 +	sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtbo \
++	sun50i-h616-bananapi-m4-sdio-wifi-bt.dtbo \
 +	sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtbo \
 +	sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtbo \
 +	sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtbo \
@@ -43,7 +60,7 @@ index 111111111111..222222222222 100644
  	sun50i-h616-i2c4-ph.dtbo \
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..4e78aa8f1f27
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-15-16-i2c4.dtso
 @@ -0,0 +1,13 @@
@@ -62,7 +79,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..3419eee0b70b
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-17-18-i2c3.dtso
 @@ -0,0 +1,13 @@
@@ -79,9 +96,50 @@ index 000000000000..111111111111
 +		};
 +	};
 +};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-6-7-uart1.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-6-7-uart1.dtso
+new file mode 100644
+index 000000000000..7001781f42d2
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-6-7-uart1.dtso
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "sinovoip,bpi-m4-zero", "allwinner,sun50i-h616", "allwinner,sun50i-h618";
++
++	fragment@0 {
++		target = <&uart1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtso
+new file mode 100644
+index 000000000000..1317a9b3b52f
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pg-8-9-rts-cts-uart1.dtso
+@@ -0,0 +1,16 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "sinovoip,bpi-m4-zero", "allwinner,sun50i-h616", "allwinner,sun50i-h618";
++
++	fragment@0 {
++		target = <&uart1>;
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++			pinctrl-names = "default";
++			uart-has-rtscts;
++		};
++	};
++};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..aaa96e46d708
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-ph-2-3-uart5.dtso
 @@ -0,0 +1,13 @@
@@ -100,7 +158,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-13-14-uart4.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-13-14-uart4.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..0373f7d25449
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-13-14-uart4.dtso
 @@ -0,0 +1,13 @@
@@ -119,7 +177,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..ef9394c8519c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-15-16-rts-cts-uart4.dtso
 @@ -0,0 +1,16 @@
@@ -141,7 +199,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..60c75e4d61b5
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-5-6-i2c0.dtso
 @@ -0,0 +1,13 @@
@@ -160,7 +218,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..99c7e2b8c5f6
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-pi-7-8-i2c1.dtso
 @@ -0,0 +1,13 @@
@@ -179,12 +237,14 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..307f6e5e921c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-sdio-wifi-bt.dtso
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,44 @@
 +/dts-v1/;
 +/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
 +
 +/ {
 +	compatible = "sinovoip,bpi-m4-zero", "allwinner,sun50i-h616", "allwinner,sun50i-h618";
@@ -209,12 +269,25 @@ index 000000000000..111111111111
 +		target = <&uart1>;
 +		__overlay__ {
 +			status = "okay";
++			pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++			pinctrl-names = "default";
++			uart-has-rtscts;
++
++			bluetooth {
++				compatible = "brcm,bcm43540-bt";
++				host-wakeup-gpios = <&pio 6 16 GPIO_ACTIVE_HIGH>;
++				device-wakeup-gpios = <&pio 6 17 GPIO_ACTIVE_HIGH>;
++				shutdown-gpios = <&pio 6 19 GPIO_ACTIVE_HIGH>;
++				max-speed = <1500000>;
++				vbat-supply = <&reg_vcc3v3>;
++				vddio-supply = <&reg_vcc1v8>;
++			};
 +		};
 +	};
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..7fa3b94bcc8d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtso
 @@ -0,0 +1,32 @@
@@ -252,7 +325,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..fef73f1afa52
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtso
 @@ -0,0 +1,24 @@
@@ -282,7 +355,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtso
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..840357f2e9e0
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtso
 @@ -0,0 +1,13 @@
@@ -300,5 +373,5 @@ index 000000000000..111111111111
 +	};
 +};
 -- 
-Armbian
+2.39.5
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
@@ -1,20 +1,22 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 49eb52ecb53d46b5ac7e4775ad5adbb87333f560 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
-Date: Thu, 12 Dec 2024 03:52:49 -0500
-Subject: Add board BananaPi BPI-M4-Zero
+Date: Tue, 7 Jan 2025 06:24:13 -0500
+Subject: [PATCH] Add board BananaPi BPI-M4-Zero
 
 Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
- arch/arm64/boot/dts/allwinner/Makefile                         |   1 +
- arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts | 126 +++++
- arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi     | 253 ++++++++++
- 3 files changed, 380 insertions(+)
+ arch/arm64/boot/dts/allwinner/Makefile        |   1 +
+ .../sun50i-h618-bananapi-m4-zero.dts          | 110 ++++++++
+ .../allwinner/sun50i-h618-bananapi-m4.dtsi    | 261 ++++++++++++++++++
+ 3 files changed, 372 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 111111111111..222222222222 100644
+index f3bbee2fcc5f..733e76270ea5 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -53,6 +53,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
+@@ -52,6 +52,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
@@ -24,10 +26,10 @@ index 111111111111..222222222222 100644
  subdir-y	:= $(dts-dirs) overlay
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..73da25a79fdd
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
-@@ -0,0 +1,126 @@
+@@ -0,0 +1,110 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
@@ -95,6 +97,7 @@ index 000000000000..111111111111
 +	};
 +};
 +
++/* SDIO */
 +&mmc1 {
 +	status = "disabled";
 +	bus-width = <4>;
@@ -129,23 +132,6 @@ index 000000000000..111111111111
 +	status = "okay";
 +};
 +
-+&uart1 {
-+	status = "disabled";
-+	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
-+	pinctrl-names = "default";
-+	uart-has-rtscts;
-+
-+	bluetooth {
-+		compatible = "brcm,bcm43540-bt";
-+		host-wakeup-gpios = <&pio 6 16 GPIO_ACTIVE_HIGH>;
-+		device-wakeup-gpios = <&pio 6 17 GPIO_ACTIVE_HIGH>;
-+		shutdown-gpios = <&pio 6 19 GPIO_ACTIVE_HIGH>;
-+		max-speed = <1500000>;
-+		vbat-supply = <&reg_vcc3v3>;
-+		vddio-supply = <&reg_vcc1v8>;
-+	};
-+};
-+
 +&usbotg {
 +	status = "okay";
 +	dr_mode = "peripheral";
@@ -156,10 +142,10 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..05d95a271d83
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
-@@ -0,0 +1,253 @@
+@@ -0,0 +1,261 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
@@ -295,6 +281,7 @@ index 000000000000..111111111111
 +	pinctrl-names = "default";
 +};
 +
++/* SD card */
 +&mmc0 {
 +	status = "okay";
 +	bus-width = <4>;
@@ -306,6 +293,7 @@ index 000000000000..111111111111
 +	vmmc-supply = <&reg_vcc3v3>;
 +};
 +
++/* eMMC */
 +&mmc2 {
 +	status = "okay";
 +	bus-width = <8>;
@@ -402,6 +390,12 @@ index 000000000000..111111111111
 +	pinctrl-names = "default";
 +};
 +
++&uart1 {
++	status = "disabled";
++	pinctrl-0 = <&uart1_pins>;
++	pinctrl-names = "default";
++};
++
 +&uart4 {
 +	status = "disabled";
 +	pinctrl-0 = <&uart4_pi_pins>;
@@ -414,5 +408,5 @@ index 000000000000..111111111111
 +	pinctrl-names = "default";
 +};
 -- 
-Armbian
+2.39.5
 

--- a/patch/u-boot/v2024.04/board_bananapim4zero/001-Add-board-BananaPi-BPI-M4-Zero.patch
+++ b/patch/u-boot/v2024.04/board_bananapim4zero/001-Add-board-BananaPi-BPI-M4-Zero.patch
@@ -1,57 +1,64 @@
-From 541e7fa9913826de6712faedbb895293e77f1921 Mon Sep 17 00:00:00 2001
+From 6c977d4b0ef9d4cbbb28157b3843b9cbda468ad9 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
-Date: Mon, 7 Oct 2024 06:59:53 -0400
-Subject: [PATCH] Add board BananaPi BPI-M4-ZERO
-
-sun50i-h618-bananapi-m4-zero.dts
-sun50i-h618-bananapi-m4.dtsi
-bananapi_m4zero_defconfig
+Date: Tue, 7 Jan 2025 07:32:05 -0500
+Subject: [PATCH] Add board BananaPi BPI-M4-Zero
 
 Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
  arch/arm/dts/Makefile                         |   1 +
- arch/arm/dts/sun50i-h616.dtsi                 |  12 +-
- arch/arm/dts/sun50i-h618-bananapi-m4-zero.dts |  43 +++
- arch/arm/dts/sun50i-h618-bananapi-m4.dtsi     | 244 ++++++++++++++++++
+ arch/arm/dts/sun50i-h616.dtsi                 |  25 ++-
+ arch/arm/dts/sun50i-h618-bananapi-m4-zero.dts |  77 +++++++
+ arch/arm/dts/sun50i-h618-bananapi-m4.dtsi     | 208 ++++++++++++++++++
  configs/bananapi_m4zero_defconfig             |  29 +++
- 5 files changed, 327 insertions(+), 2 deletions(-)
+ 5 files changed, 339 insertions(+), 1 deletion(-)
  create mode 100644 arch/arm/dts/sun50i-h618-bananapi-m4-zero.dts
  create mode 100644 arch/arm/dts/sun50i-h618-bananapi-m4.dtsi
  create mode 100644 configs/bananapi_m4zero_defconfig
 
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 8fb6a8a1f1..380b326ad0 100644
+index b102ffb5f68..57f94860fd5 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -679,6 +679,7 @@ dtb-$(CONFIG_MACH_SUN50I_H6) += \
- 	sun50i-h6-tanix-tx6.dtb \
+@@ -839,6 +839,7 @@ dtb-$(CONFIG_MACH_SUN50I_H6) += \
  	sun50i-h6-tanix-tx6-mini.dtb
  dtb-$(CONFIG_MACH_SUN50I_H616) += \
-+	sun50i-h618-bananapi-m4-zero.dtb \
  	sun50i-h616-orangepi-zero2.dtb \
++	sun50i-h618-bananapi-m4-zero.dtb \
  	sun50i-h618-orangepi-zero2w.dtb \
  	sun50i-h618-orangepi-zero3.dtb \
+ 	sun50i-h618-transpeed-8k618-t.dtb \
 diff --git a/arch/arm/dts/sun50i-h616.dtsi b/arch/arm/dts/sun50i-h616.dtsi
-index d549d277d9..3a424a249e 100644
+index d549d277d97..ccd83ba1b9c 100644
 --- a/arch/arm/dts/sun50i-h616.dtsi
 +++ b/arch/arm/dts/sun50i-h616.dtsi
-@@ -245,17 +245,25 @@
- 				function = "uart0";
+@@ -176,7 +176,7 @@
  			};
  
--			/omit-if-no-ref/
- 			uart1_pins: uart1-pins {
- 				pins = "PG6", "PG7";
- 				function = "uart1";
+ 			i2c0_pins: i2c0-pins {
+-				pins = "PI6", "PI7";
++				pins = "PI5", "PI6";
+ 				function = "i2c0";
  			};
  
--			/omit-if-no-ref/
- 			uart1_rts_cts_pins: uart1-rts-cts-pins {
+@@ -256,6 +256,29 @@
  				pins = "PG8", "PG9";
  				function = "uart1";
  			};
 +
-+			uart5_ph_pins: uart5-ph-pins {
++			/omit-if-no-ref/
++			uart4_pi_pins: uart4-pi-pins {
++				pins = "PI13", "PI14";
++				function = "uart4";
++			};
++
++			/omit-if-no-ref/
++			uart4_pi_rts_cts_pins: uart4-pi-rts-cts-pins {
++				pins = "PI15", "PI16";
++				function = "uart4";
++			};
++
++			/omit-if-no-ref/
++			uart5_pins: uart5-pins {
 +				pins = "PH2", "PH3";
 +				function = "uart5";
 +			};
@@ -65,10 +72,10 @@ index d549d277d9..3a424a249e 100644
  		gic: interrupt-controller@3021000 {
 diff --git a/arch/arm/dts/sun50i-h618-bananapi-m4-zero.dts b/arch/arm/dts/sun50i-h618-bananapi-m4-zero.dts
 new file mode 100644
-index 0000000000..76ba077bc6
+index 00000000000..dde03092cf0
 --- /dev/null
 +++ b/arch/arm/dts/sun50i-h618-bananapi-m4-zero.dts
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,77 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
@@ -85,11 +92,22 @@ index 0000000000..76ba077bc6
 +	aliases {
 +		serial5 = &uart5;
 +	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&pio 2 12 GPIO_ACTIVE_HIGH>;	/* PC12 */
++			linux,default-trigger = "heartbeat";
++		};
++	};
 +};
 +
 +/* Connected to an on-board RTL8821CU USB WiFi chip. */
 +&ehci1 {
-+	status = "okay";
++	status = "disabled";
 +};
 +
 +&ehci3 {
@@ -98,6 +116,29 @@ index 0000000000..76ba077bc6
 +
 +&emac0 {
 +	status = "disabled";
++};
++
++/* SDIO */
++&mmc1 {
++	status = "disabled";
++	bus-width = <4>;
++	max-frequency = <100000000>;
++
++	non-removable;
++	disable-wp;
++
++	/* WiFi firmware requires power to be kept while in suspend */
++	keep-power-in-suspend;
++
++	mmc-pwrseq = <&wifi_pwrseq>;
++
++	cd-gpios = <&pio 6 15 GPIO_ACTIVE_HIGH>; /* PG15 */
++	vmmc-supply = <&reg_vcc3v3>;
++
++	sdio: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++	};
 +};
 +
 +&ohci3 {
@@ -114,10 +155,10 @@ index 0000000000..76ba077bc6
 +};
 diff --git a/arch/arm/dts/sun50i-h618-bananapi-m4.dtsi b/arch/arm/dts/sun50i-h618-bananapi-m4.dtsi
 new file mode 100644
-index 0000000000..dd0e2ea7bf
+index 00000000000..650f533e8b4
 --- /dev/null
 +++ b/arch/arm/dts/sun50i-h618-bananapi-m4.dtsi
-@@ -0,0 +1,244 @@
+@@ -0,0 +1,208 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
@@ -139,17 +180,6 @@ index 0000000000..dd0e2ea7bf
 +
 +	chosen {
 +		stdout-path = "serial0:115200n8";
-+	};
-+
-+	leds {
-+		compatible = "gpio-leds";
-+
-+		led-0 {
-+			color = <LED_COLOR_ID_RED>;
-+			function = LED_FUNCTION_STATUS;
-+			gpios = <&pio 2 12 GPIO_ACTIVE_HIGH>;	/* PC12 */
-+			linux,default-trigger = "heartbeat";
-+		};
 +	};
 +
 +	reg_usb_vbus: regulator-usb-vbus {
@@ -227,6 +257,7 @@ index 0000000000..dd0e2ea7bf
 +	};
 +};
 +
++/* SD card */
 +&mmc0 {
 +	status = "okay";
 +	bus-width = <4>;
@@ -238,28 +269,7 @@ index 0000000000..dd0e2ea7bf
 +	vmmc-supply = <&reg_vcc3v3>;
 +};
 +
-+&mmc1 {
-+	status = "okay";
-+	bus-width = <4>;
-+	max-frequency = <100000000>;
-+
-+	non-removable;
-+	disable-wp;
-+
-+	/* WiFi firmware requires power to be kept while in suspend */
-+	keep-power-in-suspend;
-+
-+	mmc-pwrseq = <&wifi_pwrseq>;
-+
-+	cd-gpios = <&pio 6 15 GPIO_ACTIVE_HIGH>; /* PG15 */
-+	vmmc-supply = <&reg_vcc3v3>;
-+
-+	sdio: wifi@1 {
-+		reg = <1>;
-+		compatible = "brcm,bcm4329-fmac";
-+	};
-+};
-+
++/* eMMC */
 +&mmc2 {
 +	status = "okay";
 +	bus-width = <8>;
@@ -341,30 +351,25 @@ index 0000000000..dd0e2ea7bf
 +};
 +
 +&uart1 {
-+	status = "okay";
-+	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	status = "disabled";
++	pinctrl-0 = <&uart1_pins>;
 +	pinctrl-names = "default";
-+	uart-has-rtscts;
++};
 +
-+	bluetooth {
-+		compatible = "brcm,bcm43540-bt";
-+		host-wakeup-gpios = <&pio 6 16 GPIO_ACTIVE_HIGH>;
-+		device-wakeup-gpios = <&pio 6 17 GPIO_ACTIVE_HIGH>;
-+		shutdown-gpios = <&pio 6 19 GPIO_ACTIVE_HIGH>;
-+		max-speed = <1500000>;
-+		vbat-supply = <&reg_vcc3v3>;
-+		vddio-supply = <&reg_vcc1v8>;
-+	};
++&uart4 {
++	status = "disabled";
++	pinctrl-0 = <&uart4_pi_pins>;
++	pinctrl-names = "default";
 +};
 +
 +&uart5 {
 +	status = "okay";
-+	pinctrl-0 = <&uart5_ph_pins>;
++	pinctrl-0 = <&uart5_pins>;
 +	pinctrl-names = "default";
 +};
 diff --git a/configs/bananapi_m4zero_defconfig b/configs/bananapi_m4zero_defconfig
 new file mode 100644
-index 0000000000..3442bd0c77
+index 00000000000..3442bd0c77b
 --- /dev/null
 +++ b/configs/bananapi_m4zero_defconfig
 @@ -0,0 +1,29 @@


### PR DESCRIPTION
Add back the ability to use UART1 on REV1.

Edit:
* Update U-Boot to reflect changes made in the Linux DTS.
