### PR TITLE
xiaomi-elish: fix bsp package build

### DIFF
--- a/config/boards/xiaomi-elish.conf
+++ b/config/boards/xiaomi-elish.conf
@@ -35,6 +35,7 @@ function post_family_tweaks_bsp__xiaomi-elish_firmware() {
 	# USB Gadget Network service
 	mkdir -p $destination/usr/local/bin/
 	mkdir -p $destination/usr/lib/systemd/system/
+	mkdir -p $destination/etc/initramfs-tools/scripts/init-bottom/
 	install -Dm655 $SRC/packages/bsp/usb-gadget-network/setup-usbgadget-network.sh $destination/usr/local/bin/
 	install -Dm655 $SRC/packages/bsp/usb-gadget-network/remove-usbgadget-network.sh $destination/usr/local/bin/
 	install -Dm644 $SRC/packages/bsp/usb-gadget-network/usbgadget-rndis.service $destination/usr/lib/systemd/system/


### PR DESCRIPTION
# Description

I only tested onplus kebab when adding the dropbear into initramfs. We have to create /etc/initramfs-tools/scripts/init-bottom/ before adding initramfs script.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] ./compile.sh BOARD=xiaomi-elish BRANCH=current GITHUB_MIRROR=ghproxy KERNEL_GIT=shallow DEB_COMPRESS=xz RELEASE=noble BUILD_DESKTOP=yes BUILD_MINIMAL=no KERNEL_CONFIGURE=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
