### PR TITLE
K3: Use sfdisk instead of parted for setting flag in boot partition

### DIFF
--- a/config/sources/families/k3.conf
+++ b/config/sources/families/k3.conf
@@ -83,7 +83,7 @@ function post_create_partitions() {
 
 function format_partitions() {
 	# ROM is very particular about partition IDs
-	run_host_command_logged parted ${LOOP} set 1 lba on
+	run_host_command_logged sfdisk --part-type ${LOOP} 1 e
 }
 
 function write_uboot_platform() {


### PR DESCRIPTION
The latest 'parted' package that is shipped with Ubuntu noble does not allow to set the 'lba' flag on MBR/DOS partitions and fails with an error. Use 'sfdisk' instead for the same.

Fixes #6956 

[GitHub issue](https://github.com/armbian/build/issues/6956)
[Jira issue](https://armbian.atlassian.net/browse/AR-2420)

# How Has This Been Tested?
- [ ] Build and Boot tested on SK-AM62B board.
- [ ] Build and Boot tested on SK-TDA4VM board.

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
