### PR TITLE
AIC wifi and v4l2 extensions: disable them for kernel 6.12 and higher

### DIFF
--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -10,6 +10,10 @@ function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
 function post_install_kernel_debs__install_aic8800_dkms_package() {
 
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.12; then
+		display_alert "Kernel version is too recent" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
+		return 0
+	fi
 	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
 	[[ -z $AIC8800_TYPE ]] && return 0
 	api_url="https://api.github.com/repos/radxa-pkg/aic8800/releases/latest"

--- a/extensions/v4l2loopback-dkms.sh
+++ b/extensions/v4l2loopback-dkms.sh
@@ -8,6 +8,10 @@ function extension_finish_config__build_v4l2loopback_dkms_kernel_module() {
 }
 
 function post_install_kernel_debs__build_v4l2loopback_dkms_kernel_module() {
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.12; then
+		display_alert "Kernel version is too recent" "skipping v4l2loopback-dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
+		return 0
+	fi
 	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
 	display_alert "Install v4l2loopback-dkms packages, will build kernel module in chroot" "${EXTENSION}" "info"
 	declare -g if_error_detail_message="v4l2loopback-dkms build failed, extension 'v4l2loopback-dkms'"


### PR DESCRIPTION
# Description

Disable extensions that are not compatible with K6.12 until we have a solution.

# How Has This Been Tested?

- [x] Manual compilation

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
