### PR TITLE
rockchip64-6.13: NanoPi R6C/R6S SD card detect patch

### DIFF
--- a/patch/kernel/archive/rockchip64-6.13/rk3588-1081-arm64-dts-rockchip-nanopi-r6c-r6s-fix_the_sd_card_detection.patch
+++ b/patch/kernel/archive/rockchip64-6.13/rk3588-1081-arm64-dts-rockchip-nanopi-r6c-r6s-fix_the_sd_card_detection.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anton Kirilov <anton.kirilov@arm.com>
+Date: Thu, 19 Dec 2024 11:31:45 +0000
+Subject: arm64: dts: rockchip: Fix the SD card detection on NanoPi R6C/R6S
+
+Fix the SD card detection on FriendlyElec NanoPi R6C/R6S boards.
+
+Signed-off-by: Anton Kirilov <anton.kirilov@arm.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
+@@ -434,6 +434,7 @@ &sdhci {
+ &sdmmc {
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
++	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+ 	disable-wp;
+ 	max-frequency = <150000000>;
+ 	no-mmc;
+-- 
+Armbian
+


### PR DESCRIPTION
#### rockchip64-6.13: NanoPi R6C/R6S SD card detect patch

- rockchip64-6.13: NanoPi R6C/R6S SD card detect patch
  - from https://lore.kernel.org/linux-rockchip/20241219113145.483205-1-anton.kirilov@arm.com/T/#u
  - also https://lore.kernel.org/linux-rockchip/20241219112532.482891-1-anton.kirilov@arm.com/T/#u (USB3) was already done by Efe