### PR TITLE
Firstlogin: run provision script if it does exists

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -125,6 +125,9 @@ do_firstrun_automated_network_configuration()
 				# - Ethernet enable
 				elif [[ $PRESET_NET_ETHERNET_ENABLED == 1 ]]; then
 
+						# remove dhcp config
+						rm -f /etc/netplan/10-dhcp-all-interfaces.yaml
+
 						DEVICE_NAME=${eth_index}
 						DEVTYPE=ethernets
 						echo -e "$(createYAML)" > /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml
@@ -607,7 +610,6 @@ add_user() {
 			echo -e "\nDear \e[0;92m${RealName}\x1B[0m, your account \e[0;92m${RealUserName}\x1B[0m has been created and is sudo enabled."
 			echo -e "Please use this account for your daily work from now on.\n"
 			rm -f /root/.not_logged_in_yet
-			chmod +x /etc/update-motd.d/*
 			# set up profile sync daemon on desktop systems
 			if command -v psd > /dev/null 2>&1; then
 				echo -e "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> /etc/sudoers
@@ -705,6 +707,9 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		# only allow one login. Once you enter root password, kill others.
 		loginfrom=$(who am i | awk '{print $2}')
 		who -la | grep root | grep -v "$loginfrom" | awk '{print $7}' | xargs --no-run-if-empty kill -9
+
+		# enable motd
+		chmod +x /etc/update-motd.d/*
 
 		first_input="$password"
 		if [ -z "$PRESET_ROOT_PASSWORD" ];then
@@ -932,5 +937,11 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 			printf "\n\n\e[0;91mWarning: a reboot is needed to finish resizing the filesystem \x1B[0m \n"
 			printf "\e[0;91mPlease reboot the system now \x1B[0m \n\n"
 		fi
+
 	fi
+fi
+
+# Run provisioning script if exists
+if [[ -f /root/provisioning.sh ]]; then
+	. /root/provisioning.sh
 fi


### PR DESCRIPTION
# Description

Small fixes + experimental feature. Need this for automation purposes. Can be later done inside https://github.com/x13-me/armbian-init

- fixing motd setting executing bit at wrong place
- when setting fixed address with 1st run, remove DHCP on all lan networks

Reference: https://github.com/armbian/configng/pull/365

# How Has This Been Tested?

- [x] Made image and run with 1st config + provisioning script

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
