### PR TITLE
update rtl8822cs driver link to latest commit (update for kernel 6.13+)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -413,7 +413,7 @@ driver_rtl88x2cs() {
 	if linux-version compare "${version}" ge 5.9 && [[ "$LINUXFAMILY" == meson64 ]]; then
 
 		# Attach to specific commit (track branch:tune_for_jethub)
-		local rtl88x2csver='commit:40450f759c8a930d271b5f0a663685f412debc72' # Commit date: Jan 24, 2024 (please update when updating commit ref)
+		local rtl88x2csver='commit:e2fce3c61059d1977f0ae65e648db2720dcba5f5' # Commit date: Jan 13, 2025 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 88x2cs chipsets ${rtl88x2csver}" "info"
 


### PR DESCRIPTION
# Description

Update rtl8822cs wifi driver to latest version

support for kernel 6.13+

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2585]



[AR-2585]: https://armbian.atlassian.net/browse/AR-2585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ