### PR TITLE
ghproxy: update GHPROXY_ADDRESS to ghfast.top

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -239,7 +239,7 @@ function do_main_configuration() {
 			declare -g -r GITHUB_SOURCE='https://hub.fastgit.xyz'
 			;;
 		ghproxy)
-			[[ -z $GHPROXY_ADDRESS ]] && GHPROXY_ADDRESS=ghgo.xyz
+			[[ -z $GHPROXY_ADDRESS ]] && GHPROXY_ADDRESS=ghfast.top
 			declare -g -r GITHUB_SOURCE="https://${GHPROXY_ADDRESS}/https://github.com"
 			;;
 		gitclone)


### PR DESCRIPTION
# Description

ghgo.xyz is not reachable from China, and there is a new domain ghfast.top: https://ghproxy.link/

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=orangepi5-max BRANCH=vendor GITHUB_MIRROR=ghproxy`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
