### PR TITLE
actions(update-tools): avoid notifying our outdated deps everywhere

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -81,13 +81,6 @@ jobs:
           version_latest=$(curl --silent "https://api.github.com/repos/${{ matrix.tool.PROJECT_NAME }}/releases/latest" | jq -r .tag_name)
           version_latest=${version_latest#v}                        # Removing the 'v' prefix since the script uses only plain numbers
           echo "version_latest=$version_latest" >> $GITHUB_OUTPUT                                                                                
-          {
-            echo "CHANGE_LOG<<EOFFEOFFF42"                          # Has to be a unique delimiter that doesn't appear in the changelog itself
-            curl --silent "https://api.github.com/repos/${{ matrix.tool.PROJECT_NAME }}/releases/latest" | jq -r .body \
-            | sed -E -e 's/(#([0-9]+))/${{ matrix.tool.USER_NAME }}\/${{ matrix.tool.REPO_NAME }}\1/g' \
-            -e 's/https\:\/\/github\.com/https\:\/\/redirect.github.com/g'
-            echo "EOFFEOFFF42"
-          } >> "$GITHUB_ENV"
 
       - name: Update ${{ matrix.tool.VERSION_VAR}} in script
         # @TODO Make sure that the version is actually higher, not lower (the 'latest' tag does not neccessarily mean that the version is higher!)
@@ -106,13 +99,6 @@ jobs:
           body: |
             Bump [${{ matrix.tool.PROJECT_NAME}}](https://github.com/${{ matrix.tool.PROJECT_NAME }}) from ${{ steps.get-version-current.outputs.version_current }} to ${{ steps.get-version-latest.outputs.version_latest }} by bumping `${{ matrix.tool.VERSION_VAR}}` in `${{ matrix.tool.VAR_FILE}}`.
 
-            <details><summary><b>Release notes</b></summary>
-            <p><em>Sourced from <a href="https://github.com/${{ matrix.tool.PROJECT_NAME }}/releases">${{ matrix.tool.PROJECT_NAME }}'s releases</a>.
-            <br>Please note that this only shows the release notes for the latest release.</em></p>
-            <blockquote>
-
-            ${{ env.CHANGE_LOG }}
-
-            </blockquote>
-            </details>
+            Check <a href="https://github.com/${{ matrix.tool.PROJECT_NAME }}/releases/latest">the upstream release notes</a>.
+            <p><em>Please note that the above link only shows the release notes for the latest release.</em></p>
           labels: Dependencies, Bash


### PR DESCRIPTION
# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

In the current main branch, workflow `update-tools` includes the content of the upstream release notes in the created GitHub Issue.  This triggers a notification to every upstream contributor mentioned in the release note. This also creates a cross-reference link to our GitHub issue, which reports that our dependency is not up-to-date, in every issue and pull request in the upstream.  The information that we need to update our dependency is not relevant to the upstream contributors, issues, and pull requests at all. We should avoid this situation.

In addition, this project has thousands of forks, and all the fork repositories that enabled GitHub Actions do the same at the same time, i.e., an upstream contributor receives several tens of notifications from fork repositories, and an upstream issue receives several tens of cross-reference links to fork repositories. We should have avoided this situation, but it's kind of too late. Even if we update the workflow specification in this repository, the workflow of the fork won't be updated unless the fork pulls our latest commit. We need to ask all these 54 fork repositories currently generating notifications one by one. Anyway, we should still consider updating our workflow to prevent future forks from starting to create an even larger number of notifications to the upstream contributors and issues.

First, we do not need to include a copy of the upstream release note.  We can just put a link to the upstream release note. Currently, we anyway hide the content in the `<details>` tag and require the reader to press the button.  The user experience is not so different from pressing a link and visiting the upstream release note.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: #7706
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

I have run the workflow in my fork repository:

https://github.com/akinomyoga/armbian-build/actions/workflows/update-tools.yml

and observed the results:

https://github.com/akinomyoga/armbian-build/pulls

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: This change essentially removes the code, so there is no new hard-to-understand part.
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: This change is unrelated to any dependency.
