### PR TITLE
Nanopi R5S: proper pci phy reset - fixing missing LAN1

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/rk3568-bugfix-amadeus_phy_rockchip_naneng_combphy_compatible_reset_with_old_dt.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk3568-bugfix-amadeus_phy_rockchip_naneng_combphy_compatible_reset_with_old_dt.patch
@@ -1,0 +1,46 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH v2 1/1] phy: rockchip: naneng-combphy: compatible reset with old DT
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Mon, 06 Jan 2025 18:00:01 +0800
+Message-Id: <20250106100001.1344418-2-amadeus@jmu.edu.cn>
+To: Vinod Koul <vkoul@kernel.org>
+Cc: Heiko Stuebner <heiko@sntech.de>, Philipp Zabel <p.zabel@pengutronix.de>, Kishon Vijay Abraham I <kishon@kernel.org>, Jianfeng Liu <liujianfeng1994@gmail.com>, linux-arm-kernel@lists.infradead.org, linux-rockchip@lists.infradead.org, linux-phy@lists.infradead.org, linux-kernel@vger.kernel.org, Chukun Pan <amadeus@jmu.edu.cn>
+In-Reply-To: <20250106100001.1344418-1-amadeus@jmu.edu.cn>
+References: <20250106100001.1344418-1-amadeus@jmu.edu.cn>
+List-Id: <linux-kernel.vger.kernel.org>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+The device tree of RK3568 did not specify reset-names before.
+So add fallback to old behaviour to be compatible with old DT.
+
+Fixes: fbcbffbac994 ("phy: rockchip: naneng-combphy: fix phy reset")
+Cc: Jianfeng Liu <liujianfeng1994@gmail.com>
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+Reviewed-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ drivers/phy/rockchip/phy-rockchip-naneng-combphy.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c b/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
+index a1532ef8bbe9..8c3ce57f8915 100644
+--- a/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
++++ b/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
+@@ -324,7 +324,10 @@ static int rockchip_combphy_parse_dt(struct device *dev, struct rockchip_combphy
+ 
+ 	priv->ext_refclk = device_property_present(dev, "rockchip,ext-refclk");
+ 
+-	priv->phy_rst = devm_reset_control_get(dev, "phy");
++	priv->phy_rst = devm_reset_control_get_exclusive(dev, "phy");
++	/* fallback to old behaviour */
++	if (PTR_ERR(priv->phy_rst) == -ENOENT)
++		priv->phy_rst = devm_reset_control_array_get_exclusive(dev);
+ 	if (IS_ERR(priv->phy_rst))
+ 		return dev_err_probe(dev, PTR_ERR(priv->phy_rst), "failed to get phy reset\n");
+ 
+
+-- 
+2.25.1
+
+

--- a/patch/kernel/archive/rockchip64-6.6/rk3568-bugfix-amadeus_phy_rockchip_naneng_combphy_compatible_reset_with_old_dt.patch
+++ b/patch/kernel/archive/rockchip64-6.6/rk3568-bugfix-amadeus_phy_rockchip_naneng_combphy_compatible_reset_with_old_dt.patch
@@ -1,0 +1,46 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH v2 1/1] phy: rockchip: naneng-combphy: compatible reset with old DT
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Mon, 06 Jan 2025 18:00:01 +0800
+Message-Id: <20250106100001.1344418-2-amadeus@jmu.edu.cn>
+To: Vinod Koul <vkoul@kernel.org>
+Cc: Heiko Stuebner <heiko@sntech.de>, Philipp Zabel <p.zabel@pengutronix.de>, Kishon Vijay Abraham I <kishon@kernel.org>, Jianfeng Liu <liujianfeng1994@gmail.com>, linux-arm-kernel@lists.infradead.org, linux-rockchip@lists.infradead.org, linux-phy@lists.infradead.org, linux-kernel@vger.kernel.org, Chukun Pan <amadeus@jmu.edu.cn>
+In-Reply-To: <20250106100001.1344418-1-amadeus@jmu.edu.cn>
+References: <20250106100001.1344418-1-amadeus@jmu.edu.cn>
+List-Id: <linux-kernel.vger.kernel.org>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+The device tree of RK3568 did not specify reset-names before.
+So add fallback to old behaviour to be compatible with old DT.
+
+Fixes: fbcbffbac994 ("phy: rockchip: naneng-combphy: fix phy reset")
+Cc: Jianfeng Liu <liujianfeng1994@gmail.com>
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+Reviewed-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ drivers/phy/rockchip/phy-rockchip-naneng-combphy.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c b/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
+index a1532ef8bbe9..8c3ce57f8915 100644
+--- a/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
++++ b/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
+@@ -324,7 +324,10 @@ static int rockchip_combphy_parse_dt(struct device *dev, struct rockchip_combphy
+ 
+ 	priv->ext_refclk = device_property_present(dev, "rockchip,ext-refclk");
+ 
+-	priv->phy_rst = devm_reset_control_get(dev, "phy");
++	priv->phy_rst = devm_reset_control_get_exclusive(dev, "phy");
++	/* fallback to old behaviour */
++	if (PTR_ERR(priv->phy_rst) == -ENOENT)
++		priv->phy_rst = devm_reset_control_array_get_exclusive(dev);
+ 	if (IS_ERR(priv->phy_rst))
+ 		return dev_err_probe(dev, PTR_ERR(priv->phy_rst), "failed to get phy reset\n");
+ 
+
+-- 
+2.25.1
+
+


### PR DESCRIPTION
A change to Phy reset causes PCIE enumeration to not work properly.   This makes LAN1 missing on the nanopi-r5s among another surprises.   It impacts kernels 6.6.69+ and 6.12.8+

See discussion here https://lore.kernel.org/all/df8e0ff8-355b-4c18-9349-0f04ae16e01b@kwiboo.se/

This adds a patch from the mailing list https://lore.kernel.org/all/20250106100001.1344418-2-amadeus@jmu.edu.cn/ that resolves the issue.

Tested on nanopi r5s 6.6.72 and 6.12.10
