### PR TITLE
kernel: call oldconfig _after_ kernel config hooks; add hook for `CONFIG_CFG80211=m` and `CONFIG_MAC80211=m` on 6.13+

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -11,6 +11,20 @@
 # Please note: Manually changing options doesn't check the validity of the .config file. This is done at next make time. Check for warnings in build log.
 
 # This is an internal/core extension.
+function armbian_kernel_config__extrawifi_enable_wifi_opts_80211() {
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.13; then
+		kernel_config_modifying_hashes+=("CONFIG_CFG80211=m" "CONFIG_MAC80211=m" "CONFIG_MAC80211_MESH=y" "CONFIG_CFG80211_WEXT=y")
+		if [[ -f .config ]]; then
+			# Required by many wifi drivers; otherwise "error: 'struct net_device' has no member named 'ieee80211_ptr'"
+			# In 6.13 something changed ref CONFIG_MAC80211 and CONFIG_CFG80211; enable both to preserve wireless drivers
+			kernel_config_set_m CONFIG_CFG80211
+			kernel_config_set_m CONFIG_MAC80211
+			kernel_config_set_y CONFIG_MAC80211_MESH
+			kernel_config_set_y CONFIG_CFG80211_WEXT
+		fi
+	fi
+}
+
 function armbian_kernel_config__disable_various_options() {
 	kernel_config_modifying_hashes+=("CONFIG_MODULE_COMPRESS_NONE=y" "CONFIG_MODULE_SIG=n" "CONFIG_LOCALVERSION_AUTO=n" "EXPERT=y")
 	if [[ -f .config ]]; then

--- a/lib/functions/compilation/kernel-config.sh
+++ b/lib/functions/compilation/kernel-config.sh
@@ -29,7 +29,6 @@ function kernel_config() {
 	[[ ! -d "${kernel_work_dir}" ]] && exit_with_error "kernel_work_dir does not exist: ${kernel_work_dir}"
 	declare previous_config_filename=".config.armbian.previous"
 	declare kernel_config_source_filename="" # which actual .config was used?
-	declare config_after_kernel_config_extension_filename=".config_after_kernel_config_extension"
 
 	LOG_SECTION="kernel_config_initialize" do_with_logging do_with_hooks kernel_config_initialize
 
@@ -70,20 +69,16 @@ function kernel_config_initialize() {
 		run_host_command_logged cp -pv "${kernel_config_source_filename}" "${kernel_work_dir}/.config"
 	fi
 
-	# Start by running olddefconfig -- always.
+	# Call the extensions. This is _also_ done during the kernel artifact's prepare_version, for consistent caching.
+	cd "${kernel_work_dir}" || exit_with_error "kernel_work_dir does not exist before call_extensions_kernel_config: ${kernel_work_dir}"
+	call_extensions_kernel_config
+
+	# Run olddefconfig; this is the "safe" way to update the kernel config.
 	# It "updates" the config, using defaults from Kbuild files in the source tree.
 	# It is worthy noting that on the first run, it builds the tools, so the host-side compiler has to be working,
 	# regardless of the cross-build toolchain.
 	cd "${kernel_work_dir}" || exit_with_error "kernel_work_dir does not exist: ${kernel_work_dir}"
 	run_kernel_make olddefconfig
-
-	# Call the extensions. This is _also_ done during the kernel artifact's prepare_version, for consistent caching.
-	call_extensions_kernel_config
-
-	# Save the config state after the extensions forced some kernel options, for later checks
-	run_host_command_logged cp -pv ".config" "${config_after_kernel_config_extension_filename}"
-	# Check sanity of kernel config and repair the config if necessary
-	kernel_config_check_and_repair
 
 	display_alert "Kernel configuration" "${LINUXCONFIG}" "info"
 }
@@ -147,27 +142,5 @@ function kernel_config_export() {
 	if [[ "${kernel_config_source_filename}" != "" ]]; then
 		display_alert "Exporting new kernel config - git commit pending" "${kernel_config_source_filename}" "info"
 		run_host_command_logged cp -pv defconfig "${kernel_config_source_filename}"
-	fi
-}
-
-# Manually forcing kernel options with 'call_extensions_kernel_config()' can introduce missing dependencies or misconfigurations
-# This function checks the config, re-establishes its sanity if necessary and outputs any changes to the user
-function kernel_config_check_and_repair() {
-	# Re-run kernel make to automatically solve any dependencies and/or misconfigurations
-	run_kernel_make olddefconfig
-
-	# Compare the previously saved config file with the current one
-	if cmp --silent "${kernel_work_dir}/.config" "${kernel_work_dir}/${config_after_kernel_config_extension_filename}"; then
-		# Do nothing if both files are the same
-		display_alert "No misconfigurations or missing kernel option dependencies detected" "info"
-	else
-		# Warn user and output diffs if make had to change anything because of missing dependencies or misconfigurations
-		display_alert "Forced kernel options introduced misconfigurations or missing dependencies!" "Please re-run rewrite-kernel-config" "warn"
-		display_alert "If this warning persists after re-run" "please remove dependent options using kernel-config or adapt your custom_kernel_config hooks" "warn"
-		display_alert "In some cases, the issue might also be" "misconfigured options in armbian_kernel_config hooks" "debug"
-
-		run_host_command_logged scripts/diffconfig "${config_after_kernel_config_extension_filename}" ".config"
-
-		display_alert "See options above which have been changed automatically" "to solve dependencies and/or misconfigurations" "warn"
 	fi
 }


### PR DESCRIPTION
- we need to run the hooks _before_ running oldconfig, otherwise it is too late
- drop `kernel_config_check_and_repair()` since it won't ever detect anything now