### PR TITLE
disable ccache in a friendly way

### DIFF
--- a/lib/functions/configuration/compilation-config.sh
+++ b/lib/functions/configuration/compilation-config.sh
@@ -9,7 +9,9 @@
 
 function prepare_compilation_vars() {
 	#  moved from config: rpardini: ccache belongs in compilation, not config. I think.
-	if [[ $USE_CCACHE != no ]]; then
+	if [[ $USE_CCACHE == yes || ${PRIVATE_CCACHE} == yes ]]; then
+		display_alert "using CCACHE" "USE_CCACHE or PRIVATE_CCACHE is set to yes" "warn"
+
 		CCACHE=ccache
 		export PATH="/usr/lib/ccache:$PATH" # this actually needs export'ing
 		# private ccache directory to avoid permission issues when using build script with "sudo"

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -60,6 +60,7 @@ function do_main_configuration() {
 	display_alert "DEST_LANG..." "DEST_LANG: ${DEST_LANG}" "debug"
 
 	declare -g SKIP_EXTERNAL_TOOLCHAINS="${SKIP_EXTERNAL_TOOLCHAINS:-yes}" # don't use any external toolchains, by default.
+	declare -g USE_CCACHE="${USE_CCACHE:-no}"                              # stop using ccache as our worktree is more effective
 
 	# Armbian config is central tool used in all builds. As its build externally, we have moved it to extension. Enable it here.
 	enable_extension "armbian-config"


### PR DESCRIPTION
should make this the default..    enables in case PRIVATE_CCACHE=yes is set

reasoning per @rpardini:

* ccache has 0 cache hit ratio during any kernel version change (version.h)
* but causes every build to be slower to gather/compare cache
* armbian/build already tries hard to keep your (worktree) cache make-hot during rebuilds/repatching/reconfigs
