### PR TITLE
wifi drivers: update commit id of rtl8811cu and rtl88x2bu

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -254,7 +254,7 @@ driver_rtl8811CU_rtl8821C() {
 	if linux-version compare "${version}" ge 3.14; then
 
 		# Attach to specific commit (is branch:main)
-		local rtl8811cuver="commit:d381f233553bfd958d15add256f077159f7d846e" # Commit date: Jan 21, 2024 (please update when updating commit ref)
+		local rtl8811cuver="commit:96c65c58b544241178638e810b333dcc9aa26b91" # Commit date: Jan 22, 2024 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek RTL8811CU and RTL8821C chipsets ${rtl8811cuver}" "info"
 
@@ -296,7 +296,7 @@ driver_rtl88x2bu() {
 	if linux-version compare "${version}" ge 5.0; then
 
 		# Attach to specific commit (is branch:main)
-		local rtl88x2buver="commit:d3a2ea9f7c6c33a43599a331e8639794fb55fc4a" # Commit date: Jan 21, 2024 (please update when updating commit ref)
+		local rtl88x2buver="commit:da8c42ebf4c055d2095f7a3d9dfae1a3b66c0821" # Commit date: Jan 22, 2024 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 88x2bu chipsets ${rtl88x2buver}" "info"
 


### PR DESCRIPTION
# Description

My pr to upstream 8811cu and 88x2bu are merged:
https://github.com/morrownr/8821cu-20210916/pull/173
https://github.com/morrownr/88x2bu-20210702/pull/242

This just updates the commited after merge, no changes.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=qemu-uboot-x86 BRANCH=edge`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
