### PR TITLE
fix cpu internal ethernet on nanopi-r4se standard version without EEPROM

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3399-nanopi-r4se.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3399-nanopi-r4se.dts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 
 /dts-v1/;
-#include "rk3399-nanopi-r4s-enterprise.dts"
+#include "rk3399-nanopi-r4s.dts"
 
 / {
 	model = "FriendlyElec NanoPi R4SE";

--- a/patch/kernel/archive/rockchip64-6.13/dt/rk3399-nanopi-r4se.dts
+++ b/patch/kernel/archive/rockchip64-6.13/dt/rk3399-nanopi-r4se.dts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 
 /dts-v1/;
-#include "rk3399-nanopi-r4s-enterprise.dts"
+#include "rk3399-nanopi-r4s.dts"
 
 / {
 	model = "FriendlyElec NanoPi R4SE";


### PR DESCRIPTION
# Description

Like nanopi-r4s, nanopi-r4se has two variants[^1]: enterprise and standard version. The difference between the two variants is that the enterprise version has an extra EEPROM to store globally unique MAC address for rk3399's internal ethernet. Currently Armbian r4se device tree is based on r4s-enterprise device tree, which breaks cpu internal ethernet on the standard version due to lack of valid MAC address from EEPROM.

Kernel logs
```
platform fe300000.ethernet: deferred probe pending: platform: wait for supplier /i2c@ff120000/eeprom@51/mac-address@fa
```

Since Armbian only maintains image for nanopi-r4s standard version (runs on enterprise board too, just ignoring the unique MAC address), I think it's reasonable to do the same for r4se.

[^1]:  Although not well documented like [r4s](https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R4S#Differences_Between_R4S_Standard_Version_.26_R4S_Enterprise_Version), you could see the empty EEPROM paste at the front of r4se board in their [wiki](https://wiki.friendlyelec.com/wiki/index.php/File:NanoPi_R4SE_Front.jpg).

# How Has This Been Tested?

Tested on my nanopi-r4se standard version, by installing the dtb package built with `./compile.sh kernel-dtb BOARD=nanopi-r4se BRANCH=edge`
