### PR TITLE
h96max-v56: u-boot: bump to 2025.01

### DIFF
--- a/config/boards/h96-tvbox-3566.tvb
+++ b/config/boards/h96-tvbox-3566.tvb
@@ -2,29 +2,25 @@
 BOARD_NAME="h96-tvbox-3566"
 BOARDFAMILY="rockchip64"
 BOARD_MAINTAINER="hqnicolas"
-BOOTCONFIG="rk3568_defconfig"
-KERNEL_TARGET="current,edge"
-FULL_DESKTOP="yes"
-BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3566-h96-tvbox.dtb"
+BOOT_LOGO="desktop"
+BOOT_SCENARIO="spl-blobs"
+FULL_DESKTOP="yes"
 IMAGE_PARTITION_TABLE="gpt"
+KERNEL_TARGET="current,edge"
+
+DDR_BLOB="rk35/rk3568_ddr_1560MHz_v1.21.bin"
+BL31_BLOB="rk35/rk3568_bl31_v1.44.elf"
 
 # Mainline U-Boot
 function post_family_config__h96_max_use_mainline_uboot() {
 	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"
-
-	declare -g BOOTCONFIG="generic-rk3568_defconfig"             # Use generic defconfig which should boot all RK3568 boards
-	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline U-Boot
-	declare -g BOOTBRANCH="tag:v2024.07"
-	declare -g BOOTPATCHDIR="v2024.07/board_${BOARD}"
-	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
-
-	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
-
-	# Disable stuff from rockchip64_common; we're using binman here which does all the work already
+	declare -g BOOTCONFIG="h96max-v56_defconfig"
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
+	declare -g BOOTBRANCH="tag:v2025.01"
+	declare -g BOOTPATCHDIR="v2025.01/board_${BOARD}"
+	declare -g UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd
-
-	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
 	function write_uboot_platform() {
 		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
 	}

--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3566-h96-tvbox.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3566-h96-tvbox.dts
@@ -26,6 +26,12 @@
 		stdout-path = "serial2:1500000n8";
 	};
 
+	openvfd {
+		compatible = "open,vfd";
+		dev_name = "openvfd";
+		status = "okay";
+	};
+
 	vcc5v0_in: vcc5v0_in {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc5v0_in";

--- a/patch/kernel/archive/rockchip64-6.6/dt/rk3566-h96-tvbox.dts
+++ b/patch/kernel/archive/rockchip64-6.6/dt/rk3566-h96-tvbox.dts
@@ -26,6 +26,12 @@
 		stdout-path = "serial2:1500000n8";
 	};
 
+	openvfd {
+		compatible = "open,vfd";
+		dev_name = "openvfd";
+		status = "okay";
+	};
+
 	vcc5v0_in: vcc5v0_in {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc5v0_in";
@@ -58,6 +64,15 @@
 		gpios = <&gpio0 RK_PC2 GPIO_ACTIVE_LOW>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&ir_receiver_pin>;
+		linux,rc-map-name = "rc-h96-max-v56";
+	};
+	
+	fddis_dev {
+		compatible = "fddis_dev";
+		fddis_gpio_clk = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
+		fddis_gpio_dat = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
+		pinctrl-0 = <&dis_ctl_clk &dis_ctl_dat>;
+		status = "okay";
 	};
 
 	spdif_dit: spdif-dit {
@@ -615,6 +630,16 @@
 	headphone {
 		hp_det: hp-det {
 			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
+	
+	fddis_ctr {
+		dis_ctl_clk: dis-ctl-clk {
+			rockchip,pins = <0 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+		
+		dis_ctl_dat: dis-ctl-dat {
+			rockchip,pins = <0 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 };

--- a/patch/u-boot/v2025.01/board_h96-tvbox-3566/001-Add-board-h96max-v56-rk3566.patch
+++ b/patch/u-boot/v2025.01/board_h96-tvbox-3566/001-Add-board-h96max-v56-rk3566.patch
@@ -1,0 +1,320 @@
+diff --git a/arch/arm/dts/rk3568-h96max-v56.dts b/arch/arm/dts/rk3568-h96max-v56.dts
+new file mode 100644
+index 0000000000..fe64d25a19
+--- /dev/null
++++ b/arch/arm/dts/rk3568-h96max-v56.dts
+@@ -0,0 +1,82 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Minimal generic DT for RK3566/RK3568 with eMMC, SD-card, SPI flash and USB OTG enabled
++ */
++
++/dts-v1/;
++#include "rk356x.dtsi"
++
++/ {
++	model = "Generic RK3566/RK3568";
++	compatible = "rockchip,rk3568";
++
++	aliases {
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc0;
++	};
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++};
++
++&saradc {
++	vdd-microvolts = <1800000>;
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-hs200-1_8v;
++	no-sd;
++	no-sdio;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_datastrobe>;
++	status = "okay";
++};
++
++&sdmmc0 {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	disable-wp;
++	no-mmc;
++	no-sdio;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd &sdmmc0_det>;
++	status = "okay";
++};
++
++&sfc {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <24000000>;
++	};
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&usb_host0_xhci {
++	dr_mode = "peripheral";
++	extcon = <&usb2phy0>;
++	maximum-speed = "high-speed";
++	phys = <&usb2phy0_otg>;
++	phy-names = "usb2-phy";
++	status = "okay";
++};
++
++&usb2phy0 {
++	status = "okay";
++};
++
++&usb2phy0_otg {
++	status = "okay";
++};
+diff --git a/arch/arm/mach-rockchip/boot_mode.c b/arch/arm/mach-rockchip/boot_mode.c
+index 55e9456668..f64d8ac69a 100644
+--- a/arch/arm/mach-rockchip/boot_mode.c
++++ b/arch/arm/mach-rockchip/boot_mode.c
+@@ -22,25 +22,20 @@ int setup_boot_mode(void)
+ 
+ #else
+ 
+-void set_back_to_bootrom_dnl_flag(void)
+-{
+-	writel(BOOT_BROM_DOWNLOAD, CONFIG_ROCKCHIP_BOOT_MODE_REG);
+-}
+-
+ /*
+- * detect download key status by adc, most rockchip
+- * based boards use adc sample the download key status,
+- * but there are also some use gpio. So it's better to
+- * make this a weak function that can be override by
+- * some special boards.
++ * Detect download key status by adc. Most rockchip
++ * based boards use adc to sample the download key status,
++ * but there are also some that use gpio. So it's better to
++ * make this a weak function that can be overridden by
++ * implementations for other boards.
+  */
+-#define KEY_DOWN_MIN_VAL	0
+-#define KEY_DOWN_MAX_VAL	30
++#define ADC_CHANNEL_ID		2
++#define KEY_DOWN_MIN_VAL	83
+ 
+ __weak int rockchip_dnl_key_pressed(void)
+ {
+ #if CONFIG_IS_ENABLED(ADC)
+-	unsigned int val;
++	unsigned int val = 0;
+ 	struct udevice *dev;
+ 	struct uclass *uc;
+ 	int ret;
+@@ -51,21 +46,22 @@ __weak int rockchip_dnl_key_pressed(void)
+ 
+ 	ret = -ENODEV;
+ 	uclass_foreach_dev(dev, uc) {
+-		if (!strncmp(dev->name, "saradc", 6)) {
+-			ret = adc_channel_single_shot(dev->name, 1, &val);
++		if (strncmp(dev->name, "saradc", 6) == 0) {
++			ret = adc_channel_single_shot(dev->name, ADC_CHANNEL_ID, &val);
++			printf("ADC channel %d value read: %d\n", ADC_CHANNEL_ID, val);
+ 			break;
+ 		}
+ 	}
+ 
+ 	if (ret == -ENODEV) {
+-		pr_warn("%s: no saradc device found\n", __func__);
++		pr_warn("%s: No saradc device found!\n", __func__);
+ 		return false;
+ 	} else if (ret) {
+-		pr_err("%s: adc_channel_single_shot fail!\n", __func__);
++		pr_err("%s: Invalid read from ADC channel %d! Error code: %d\n", __func__, ADC_CHANNEL_ID, ret);
+ 		return false;
+ 	}
+ 
+-	if ((val >= KEY_DOWN_MIN_VAL) && (val <= KEY_DOWN_MAX_VAL))
++	if (val <= KEY_DOWN_MIN_VAL)
+ 		return true;
+ 	else
+ 		return false;
+@@ -77,8 +73,8 @@ __weak int rockchip_dnl_key_pressed(void)
+ void rockchip_dnl_mode_check(void)
+ {
+ 	if (rockchip_dnl_key_pressed()) {
+-		printf("download key pressed, entering download mode...");
+-		set_back_to_bootrom_dnl_flag();
++		printf("Recovery button pressed.\n");
++		writel(BOOT_BROM_DOWNLOAD, CONFIG_ROCKCHIP_BOOT_MODE_REG);
+ 		do_reset(NULL, 0, 0, NULL);
+ 	}
+ }
+@@ -86,25 +82,25 @@ void rockchip_dnl_mode_check(void)
+ int setup_boot_mode(void)
+ {
+ 	void *reg = (void *)CONFIG_ROCKCHIP_BOOT_MODE_REG;
+-	int boot_mode = readl(reg);
++	int boot_mode = 0;
+ 
+ 	rockchip_dnl_mode_check();
+ 
+ 	boot_mode = readl(reg);
+-	debug("%s: boot mode 0x%08x\n", __func__, boot_mode);
++	printf("%s: Boot mode 0x%08x\n", __func__, boot_mode);
+ 
+ 	/* Clear boot mode */
+ 	writel(BOOT_NORMAL, reg);
+ 
+ 	switch (boot_mode) {
+-	case BOOT_FASTBOOT:
+-		debug("%s: enter fastboot!\n", __func__);
+-		env_set("preboot", "setenv preboot; fastboot usb 0");
+-		break;
+-	case BOOT_UMS:
+-		debug("%s: enter UMS!\n", __func__);
+-		env_set("preboot", "setenv preboot; ums mmc 0");
+-		break;
++		case BOOT_FASTBOOT:
++			printf("%s: Entering fastboot mode...\n", __func__);
++			env_set("preboot", "setenv preboot; fastboot usb 0");
++			break;
++		case BOOT_UMS:
++			printf("%s: Entering USB mass storage mode...\n", __func__);
++			env_set("preboot", "setenv preboot; ums mmc 0");
++			break;
+ 	}
+ 
+ 	return 0;
+diff --git a/configs/h96max-v56_defconfig b/configs/h96max-v56_defconfig
+new file mode 100644
+index 0000000000..b0bf88fd1c
+--- /dev/null
++++ b/configs/h96max-v56_defconfig
+@@ -0,0 +1,83 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_COUNTER_FREQUENCY=24000000
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SF_DEFAULT_SPEED=24000000
++CONFIG_DEFAULT_DEVICE_TREE="rk3568-h96max-v56"
++CONFIG_ROCKCHIP_RK3568=y
++CONFIG_ROCKCHIP_SPI_IMAGE=y
++CONFIG_SPL_SERIAL=y
++CONFIG_SYS_LOAD_ADDR=0xc00800
++CONFIG_SF_DEFAULT_BUS=4
++CONFIG_DEBUG_UART_BASE=0xFE660000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI=y
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_FIT_SIGNATURE=y
++CONFIG_SPL_LOAD_FIT=y
++# CONFIG_BOOTMETH_VBE is not set
++CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3568-h96max-v56.dtb"
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_SPL_MAX_SIZE=0x40000
++CONFIG_SPL_PAD_TO=0x7f8000
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_SPI_LOAD=y
++CONFIG_SYS_SPI_U_BOOT_OFFS=0x60000
++CONFIG_SPL_ATF=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MISC=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_ROCKUSB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++# CONFIG_CMD_SETEXPR is not set
++# CONFIG_SPL_DOS_PARTITION is not set
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_OF_LIVE=y
++# CONFIG_OF_UPSTREAM is not set
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_NO_NET=y
++CONFIG_SPL_DM_SEQ_ALIAS=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SPL_SYSCON=y
++CONFIG_ADC=y
++CONFIG_SPL_CLK=y
++CONFIG_SARADC_ROCKCHIP=y
++# CONFIG_USB_FUNCTION_FASTBOOT is not set
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_MISC=y
++# CONFIG_ROCKCHIP_IODOMAIN is not set
++CONFIG_SUPPORT_EMMC_RPMB=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_SDMA=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_SPI_FLASH_SFDP_SUPPORT=y
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_SILICONKAISER=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_XMC=y
++CONFIG_SPI_FLASH_XTX=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_SPL_RAM=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_ROCKCHIP_SFC=y
++CONFIG_SYSRESET=y
++CONFIG_SYSRESET_PSCI=y
++CONFIG_USB=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_USB_FUNCTION_ROCKUSB=y
++CONFIG_ERRNO_STR=y
+\ No newline at end of file
+diff --git a/drivers/adc/rockchip-saradc.c b/drivers/adc/rockchip-saradc.c
+index 7cf9735f60..f19eea5149 100644
+--- a/drivers/adc/rockchip-saradc.c
++++ b/drivers/adc/rockchip-saradc.c
+@@ -339,6 +339,15 @@ static const struct rockchip_saradc_data rk3399_saradc_data = {
+ 	.stop = rockchip_saradc_stop_v1,
+ };
+ 
++static const struct rockchip_saradc_data rk3568_saradc_data = {
++	.num_bits = 10,
++	.num_channels = 8,
++	.clk_rate = 1000000,
++	.channel_data = rockchip_saradc_channel_data_v1,
++	.start_channel = rockchip_saradc_start_channel_v1,
++	.stop = rockchip_saradc_stop_v1,
++};
++
+ static const struct rockchip_saradc_data rk3588_saradc_data = {
+ 	.num_bits = 12,
+ 	.num_channels = 8,
+@@ -354,6 +363,8 @@ static const struct udevice_id rockchip_saradc_ids[] = {
+ 	  .data = (ulong)&rk3066_tsadc_data },
+ 	{ .compatible = "rockchip,rk3399-saradc",
+ 	  .data = (ulong)&rk3399_saradc_data },
++	{ .compatible = "rockchip,rk3568-saradc",
++	  .data = (ulong)&rk3568_saradc_data },
+ 	{ .compatible = "rockchip,rk3588-saradc",
+ 	  .data = (ulong)&rk3588_saradc_data },
+ 	{ }


### PR DESCRIPTION
# Description

Bump U-boot to 2025.01 and fix maskrom mode buttom.
[Community Post](https://forum.armbian.com/topic/28895-efforts-to-develop-firmware-for-h96-max-v56-rk3566-8g64g/#findComment-211385)

# How Has This Been Tested?

H96 MAX V56 RK3566 4G/32G desktop jammy, server jammy, kernel 6.12.11

# Checklist:
- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] My changes generate no new warnings
- [ X ] Any dependent changes have been merged and published in downstream modules
