### PR TITLE
MBa8MPxL: cleanup board configs

### DIFF
--- a/config/boards/mba8mpxl-ras314.conf
+++ b/config/boards/mba8mpxl-ras314.conf
@@ -1,5 +1,5 @@
-# MBa8MPxL-RAS314 with TQMa8MPxL
-BOARD_NAME="TQ8MP-RAS314"
+# MBa8MP-RAS314 with TQMa8MPxL
+BOARD_NAME="MBa8MP-RAS314"
 BOARDFAMILY="imx8m"
 BOARD_MAINTAINER="schmiedelm"
 HAS_VIDEO_OUTPUT="yes"
@@ -27,20 +27,23 @@ function post_family_tweaks_bsp__mba8mpxl-ras314() {
 		KERNEL=="mlan*", ACTION=="add", RUN+="/sbin/modprobe btnxpuart"
 	EOF
 
-	# Define a function to be run board-side during postinst of the BSP
-	display_alert "Adding to bsp-cli" "${BOARD}: postinst for periferial access" "info"
-	postinst_functions+=("board_side_imx8m_bsp_cli_postinst") # add to the postinst function list
-	function board_side_imx8mpxl_bsp_cli_postinst() {
-		# Peripheral access for specific groups
-		addgroup --system --quiet periphery
-	}
+	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then
+		# fix X11 config
+		mkdir -p "$destination"/etc/X11/xorg.conf.d
+		cat <<- XORG_HDMI_CONF > "$destination"/etc/X11/xorg.conf.d/10-hdmi.conf
+			Section "Device"
+				Identifier "etnaviv"
+				Driver     "modesetting"
+				Option     "kmsdev"      "/dev/dri/card1"
+				Option     "AccelMethod" "none" ### "glamor" to enable 3D acceleration, "none" to disable.
+				Option     "Atomic"      "On"
+			EndSection
 
-	mkdir -p "$destination"/etc/X11/xorg.conf.d
-	cat <<- EOF > "$destination"/etc/X11/xorg.conf.d/02-driver.conf
-		Section "Device"
-		Identifier              "main"
-		driver                  "fbdev"
-		Option                  "fbdev" "/dev/fb0"
-		EndSection
-	EOF
+			Section "ServerFlags"
+				Option     "AutoAddGPU"  "false"
+				Option     "DRI"         "3"
+			EndSection
+		XORG_HDMI_CONF
+	fi
+
 }

--- a/config/boards/mba8mpxl.conf
+++ b/config/boards/mba8mpxl.conf
@@ -13,12 +13,23 @@ BOOT_FDT_FILE="freescale/imx8mp-tqma8mpql-mba8mpxl.dtb"
 ASOUND_STATE="asound.state.tqma"
 
 function post_family_tweaks_bsp__mba8mpxl() {
-	mkdir -p "$destination"/etc/X11/xorg.conf.d
-	cat <<- EOF > "$destination"/etc/X11/xorg.conf.d/02-driver.conf
-		Section "Device"
-		Identifier              "main"
-		driver                  "fbdev"
-		Option                  "fbdev" "/dev/fb0"
-		EndSection
-	EOF
+
+	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then
+		# fix X11 config
+		mkdir -p "$destination"/etc/X11/xorg.conf.d
+		cat <<- XORG_HDMI_CONF > "$destination"/etc/X11/xorg.conf.d/10-hdmi.conf
+			Section "Device"
+				Identifier "etnaviv"
+				Driver     "modesetting"
+				Option     "kmsdev"      "/dev/dri/card1"
+				Option     "AccelMethod" "none" ### "glamor" to enable 3D acceleration, "none" to disable.
+				Option     "Atomic"      "On"
+			EndSection
+
+			Section "ServerFlags"
+				Option     "AutoAddGPU"  "false"
+				Option     "DRI"         "3"
+			EndSection
+		XORG_HDMI_CONF
+	fi
 }


### PR DESCRIPTION
# Description

cleanup board configs

- remove unused group periphery
- fix desktop related X11 settings
- harmonize BOARD_NAME

# How Has This Been Tested?

- [x] Build and Boot xfce image on mba8mp-ras314 and check X11 conf
- [x] Boot gnome image on mba8mp-ras314
- [x] Build and boot CLI image on mba8mpxl

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

