### PR TITLE
Limit curl execution time to 2s to find WAN IP

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -56,7 +56,7 @@ for f in $MOTD_DISABLE; do
 done
 
 function get_wan_address() {
-	curl --connect-timeout 2 -s http://whatismyip.akamai.com/
+	curl --max-time 2 -s http://whatismyip.akamai.com/
 } # get wan ip address
 
 function get_ip_addresses() {


### PR DESCRIPTION
Option "--connect-timeout" used to determine external IP covers only connection phase. Curl may "hans" in a different phase and this makes login to the system impossible if MOTD "header" module enabled.

Using "--max-time" is more reliable and prevents hanging for hours.

Fixes issue https://github.com/armbian/build/issues/7753

# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ ] Test A
- [ ] Test B

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
