### PR TITLE
helios64: restore hs400 support after enabling strobe line internal p…

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.12/add-board-helios64.patch
@@ -358,7 +358,7 @@ index 111111111111..222222222222 100644
  };
  
  &cpu_l0 {
-@@ -275,6 +467,20 @@ &cpu_l3 {
+@@ -275,6 +467,21 @@ &cpu_l3 {
  	cpu-supply = <&vdd_cpu_l>;
  };
  
@@ -377,6 +377,7 @@ index 111111111111..222222222222 100644
 +};
 +
  &emmc_phy {
++	rockchip,enable-strobe-pulldown;
  	status = "okay";
  };
 @@ -295,6 +501,11 @@ &gmac {
@@ -813,7 +814,7 @@ index 111111111111..222222222222 100644
  		};
  	};
  };
-@@ -505,10 +981,29 @@ &pwm1 {
+@@ -505,10 +981,28 @@ &pwm1 {
  	status = "okay";
  };
  
@@ -834,9 +835,8 @@ index 111111111111..222222222222 100644
 +	assigned-clock-rates = <150000000>;
  	bus-width = <8>;
  	mmc-hs200-1_8v;
-+	// hs400 is broken on Helios64 since 5.10.60
-+	// mmc-hs400-1_8v;
-+	// mmc-hs400-enhanced-strobe;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
 +	supports-emmc;
  	non-removable;
 +	disable-wp;

--- a/patch/kernel/archive/rockchip64-6.13/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.13/add-board-helios64.patch
@@ -338,7 +338,7 @@ index 111111111111..222222222222 100644
  };
  
  &cpu_l0 {
-@@ -275,6 +447,20 @@ &cpu_l3 {
+@@ -275,6 +447,21 @@ &cpu_l3 {
  	cpu-supply = <&vdd_cpu_l>;
  };
  
@@ -357,6 +357,7 @@ index 111111111111..222222222222 100644
 +};
 +
  &emmc_phy {
++	rockchip,enable-strobe-pulldown;
  	status = "okay";
  };
 @@ -295,6 +481,11 @@ &gmac {
@@ -793,7 +794,7 @@ index 111111111111..222222222222 100644
  		};
  	};
  };
-@@ -505,10 +961,29 @@ &pwm1 {
+@@ -505,10 +961,28 @@ &pwm1 {
  	status = "okay";
  };
  
@@ -814,9 +815,8 @@ index 111111111111..222222222222 100644
 +	assigned-clock-rates = <150000000>;
  	bus-width = <8>;
  	mmc-hs200-1_8v;
-+	// hs400 is broken on Helios64 since 5.10.60
-+	// mmc-hs400-1_8v;
-+	// mmc-hs400-enhanced-strobe;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
 +	supports-emmc;
  	non-removable;
 +	disable-wp;


### PR DESCRIPTION
…ulldown

Since v5.11, Linux upstream commit 8b5c2b45b8f0 disabled the internal pull-down for the strobe line explicitly instead of leaving it in its default state (the opposite of Rockchip Kernel which force enable this intrnal pulldown by default) thus causing I/O errors in HS400 mode for various eMMC modules (the ones that did not have an external pulldown on the strobe line likely).
Discussed upstream and the choice has been made to keep this behavior as it has been there for too long and reverting might break other boards http://lists.infradead.org/pipermail/linux-rockchip/2024-April/046416.html

HS400 for helios64 was disabled in commit 5f2e23e90 "Disabled hs400 on Helios64 (hopefully only temporarily) (#3126)" but for 5.10.63i (ie before the above commit disabled internal pulldown). Back then I had bisected the emmc I/O issue to a double init of the emmc regulator introduced while adding deferred support to the regulator driver core, ie commit 06653ebc0ad2 "regulator: core: resolve supply for boot-on/always-on regulators" in 5.10.60. But due to the new default for the strobe line internal  pulldown introduced in 5.6.11 when this double voltage regulator init issue was fixed likely by 8a866d527ac0 "regulator: core: Resolve supply name earlier to prevent double-init" in Linux 6.1.

# Description

Enables internal pulldown for strobe line of the eMMC. This allows to reenable hs400 without getting I/O errors.

# How Has This Been Tested?


- [ x ] build current bookworm 6.12.11, boot from eMMC, test read, test write to the emmc with `dd`
- [ x ] build edge bookworm 6.13, boot from eMMC, test read, test write to the emmc with `dd`

# Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] My changes generate no new warnings
