### PR TITLE
Switch linux-rockchip to from rkr4.1 to rkr5

### DIFF
--- a/config/boards/mixtile-edge2.csc
+++ b/config/boards/mixtile-edge2.csc
@@ -40,7 +40,7 @@ function post_family_config_branch_vendor__kernel_and_uboot_rk35xx_mixtile_edge2
 	# Copypasta from rockchip-rk3588.conf family file -- we _really_ gotta find a better way!
 	declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
 	declare -g KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-	declare -g KERNELBRANCH='branch:rk-6.1-rkr4.1'
+	declare -g KERNELBRANCH='branch:rk-6.1-rkr5'
 	declare -g KERNELPATCHDIR='rk35xx-vendor-6.1'
 	declare -g LINUXFAMILY=rk35xx
 	declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes

--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -37,7 +37,7 @@ case $BRANCH in
 		declare -g KERNEL_MAJOR_MINOR="6.1"    # Major and minor versions of this kernel.
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-		KERNELBRANCH='branch:rk-6.1-rkr4.1'
+		KERNELBRANCH='branch:rk-6.1-rkr5'
 		KERNELPATCHDIR='rk35xx-vendor-6.1'
 		;;
 esac

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -34,7 +34,7 @@ case $BRANCH in
 		declare -g KERNEL_MAJOR_MINOR="6.1"    # Major and minor versions of this kernel.
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-		KERNELBRANCH='branch:rk-6.1-rkr4.1'
+		KERNELBRANCH='branch:rk-6.1-rkr5'
 		KERNELPATCHDIR='rk35xx-vendor-6.1'
 		LINUXFAMILY=rk35xx
 		;;

--- a/patch/kernel/rk35xx-vendor-6.1/0000.patching_config.yaml
+++ b/patch/kernel/rk35xx-vendor-6.1/0000.patching_config.yaml
@@ -4,8 +4,8 @@ config:
   name: rk35xx-6.1
   kind: kernel
   type: vendor # or: vendor
-  branch: rk-6.1-rkr4.1
-  last-known-good-tag: v6.1.84
+  branch: rk-6.1-rkr5
+  last-known-good-tag: v6.1.99
 
   # .dts files in these directories will be copied as-is to the build tree; later ones overwrite earlier ones.
   # This is meant to provide a way to "add a board DTS" without having to null-patch them in.


### PR DESCRIPTION
# Description

This PR switches all references to rkr4.1 to rkr5 and updates the patching kernel major minor to 6.1.99

[AR-2596]

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Build & Boot image for Rock5B+ 

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2596]: https://armbian.atlassian.net/browse/AR-2596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ