### PR TITLE
MBa8MPxL: cleanup fix X11 settings

### DIFF
--- a/config/boards/mba8mpxl-ras314.conf
+++ b/config/boards/mba8mpxl-ras314.conf
@@ -22,28 +22,27 @@ function post_family_tweaks_bsp__mba8mpxl-ras314() {
 	run_host_command_logged cp -Pv "pcieuart8997_combo_v4.bin" "$destination/lib/firmware/mrvl/" || exit_with_error "Unable to copy mrvl firmware"
 
 	# Add udev rule to delay btnxpuart loading
-	cat <<- EOF > "${destination}"/etc/udev/rules.d/10-nxp-bluetooth-delay.rules
+	cat <<- NXP_UDEV_RULE > "${destination}"/etc/udev/rules.d/10-nxp-bluetooth-delay.rules
 		# wait until combo FW is loaded by wifi driver
 		KERNEL=="mlan*", ACTION=="add", RUN+="/sbin/modprobe btnxpuart"
-	EOF
+	NXP_UDEV_RULE
 
-	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then
-		# fix X11 config
-		mkdir -p "$destination"/etc/X11/xorg.conf.d
-		cat <<- XORG_HDMI_CONF > "$destination"/etc/X11/xorg.conf.d/10-hdmi.conf
-			Section "Device"
-				Identifier "etnaviv"
-				Driver     "modesetting"
-				Option     "kmsdev"      "/dev/dri/card1"
-				Option     "AccelMethod" "none" ### "glamor" to enable 3D acceleration, "none" to disable.
-				Option     "Atomic"      "On"
-			EndSection
+	# fix X11 config
+	mkdir -p "$destination"/etc/X11/xorg.conf.d
 
-			Section "ServerFlags"
-				Option     "AutoAddGPU"  "false"
-				Option     "DRI"         "3"
-			EndSection
-		XORG_HDMI_CONF
-	fi
+	cat <<- XORG_HDMI_CONF > "$destination"/etc/X11/xorg.conf.d/10-hdmi.conf
+		Section "Device"
+			Identifier "etnaviv"
+			Driver     "modesetting"
+			Option     "kmsdev"      "/dev/dri/card1"
+			Option     "AccelMethod" "none" ### "glamor" to enable 3D acceleration, "none" to disable.
+			Option     "Atomic"      "On"
+		EndSection
+
+		Section "ServerFlags"
+			Option     "AutoAddGPU"  "false"
+			Option     "DRI"         "3"
+		EndSection
+	XORG_HDMI_CONF
 
 }

--- a/config/boards/mba8mpxl.conf
+++ b/config/boards/mba8mpxl.conf
@@ -14,22 +14,22 @@ ASOUND_STATE="asound.state.tqma"
 
 function post_family_tweaks_bsp__mba8mpxl() {
 
-	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then
-		# fix X11 config
-		mkdir -p "$destination"/etc/X11/xorg.conf.d
-		cat <<- XORG_HDMI_CONF > "$destination"/etc/X11/xorg.conf.d/10-hdmi.conf
-			Section "Device"
-				Identifier "etnaviv"
-				Driver     "modesetting"
-				Option     "kmsdev"      "/dev/dri/card1"
-				Option     "AccelMethod" "none" ### "glamor" to enable 3D acceleration, "none" to disable.
-				Option     "Atomic"      "On"
-			EndSection
+	# fix X11 config
+	mkdir -p "$destination"/etc/X11/xorg.conf.d
 
-			Section "ServerFlags"
-				Option     "AutoAddGPU"  "false"
-				Option     "DRI"         "3"
-			EndSection
-		XORG_HDMI_CONF
-	fi
+	cat <<- XORG_HDMI_CONF > "$destination"/etc/X11/xorg.conf.d/10-hdmi.conf
+		Section "Device"
+			Identifier "etnaviv"
+			Driver     "modesetting"
+			Option     "kmsdev"      "/dev/dri/card1"
+			Option     "AccelMethod" "none" ### "glamor" to enable 3D acceleration, "none" to disable.
+			Option     "Atomic"      "On"
+		EndSection
+
+		Section "ServerFlags"
+			Option     "AutoAddGPU"  "false"
+			Option     "DRI"         "3"
+		EndSection
+	XORG_HDMI_CONF
+
 }


### PR DESCRIPTION
# Description

post_family_tweaks_bsp_ is called during the build of armbian-bsp-cli-xxx-current.

Since the cli package is built separately on the build server, comparisons on build parameters such as DESKTOP_ENVIRONMENT or BUILD_DESKTOP do not work.

So the X11 config is simply adapted for everyone.

# How Has This Been Tested?

- [x] Build and Boot xfce image on mba8mp-ras314 and check X11 conf

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
