### PR TITLE
aml-c400-plus: Remove duplicated code present in meson-gx-p23x-q20x.dtsi

### DIFF
--- a/patch/kernel/archive/meson64-6.12/dt/meson-gxm-c400-plus.dts
+++ b/patch/kernel/archive/meson64-6.12/dt/meson-gxm-c400-plus.dts
@@ -38,29 +38,5 @@
 
 /* Wireless SDIO Module */
 &sd_emmc_a {
-	status = "okay";
-	pinctrl-0 = <&sdio_pins>;
-	pinctrl-1 = <&sdio_clk_gate_pins>;
-	pinctrl-names = "default", "clk-gate";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	bus-width = <4>;
-	cap-sd-highspeed;
-	sd-uhs-sdr12;
-	sd-uhs-sdr25;
-	sd-uhs-sdr50;
-	sd-uhs-sdr104;
 	max-frequency = <50000000>;
-
-	non-removable;
-	disable-wp;
-
-	/* WiFi firmware requires power to be kept while in suspend */
-	keep-power-in-suspend;
-
-	mmc-pwrseq = <&sdio_pwrseq>;
-
-	vmmc-supply = <&vddao_3v3>;
-	vqmmc-supply = <&vddio_boot>;
 };

--- a/patch/kernel/archive/meson64-6.13/dt/meson-gxm-c400-plus.dts
+++ b/patch/kernel/archive/meson64-6.13/dt/meson-gxm-c400-plus.dts
@@ -38,29 +38,5 @@
 
 /* Wireless SDIO Module */
 &sd_emmc_a {
-	status = "okay";
-	pinctrl-0 = <&sdio_pins>;
-	pinctrl-1 = <&sdio_clk_gate_pins>;
-	pinctrl-names = "default", "clk-gate";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	bus-width = <4>;
-	cap-sd-highspeed;
-	sd-uhs-sdr12;
-	sd-uhs-sdr25;
-	sd-uhs-sdr50;
-	sd-uhs-sdr104;
 	max-frequency = <50000000>;
-
-	non-removable;
-	disable-wp;
-
-	/* WiFi firmware requires power to be kept while in suspend */
-	keep-power-in-suspend;
-
-	mmc-pwrseq = <&sdio_pwrseq>;
-
-	vmmc-supply = <&vddao_3v3>;
-	vqmmc-supply = <&vddio_boot>;
 };


### PR DESCRIPTION
# Description

Remove duplicated code, for this TV Box only need meson-gxm-q201.dts code, add bluetooth driver and revert the patch meson-gxl-gxm-arm64-dts-meson-set-p212-p23x-q20x-SDIO-to-100MH.patch that broke wifi, as explained here:

[GitHub issue](https://github.com/armbian/build/issues/7678) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2582]

# How Has This Been Tested?

Tested locally without problems
- ./compile.sh build BOARD=aml-c400-plus BRANCH=edge BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED='browsers desktop_tools editors internet multimedia office programming' DESKTOP_ENVIRONMENT=kde-plasma DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no RELEASE=noble
# ARGs: 'PREFER_DOCKER=no' 'ARMBIAN_RELAUNCHED=yes' 'SET_OWNER_TO_UID=1000' 'build'

[AR-2582]: https://armbian.atlassian.net/browse/AR-2582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ