### PR TITLE
helios64: fix helios64-heartbeat-led.service

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.12/add-board-helios64.patch
@@ -128,6 +128,7 @@ index 111111111111..222222222222 100644
 +		};
  
 -		led-0 {
+-			label = "helios64:green:status";
 +		sata_err5 {
 +			label = "helios64:red:ata5-err";
 +			gpios = <&gpio2 RK_PA6 GPIO_ACTIVE_HIGH>;
@@ -163,7 +164,7 @@ index 111111111111..222222222222 100644
 +		pinctrl-0 = <&system_led>;
 +
 +		status-led {
- 			label = "helios64:green:status";
++			label = "helios64::status";
  			gpios = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
 +			linux,default-trigger = "none";
  			default-state = "on";

--- a/patch/kernel/archive/rockchip64-6.13/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.13/add-board-helios64.patch
@@ -97,6 +97,7 @@ index 111111111111..222222222222 100644
 +		};
  
 -		led-0 {
+-			label = "helios64:green:status";
 +		sata	{
 +			label = "helios64:blue:hdd-status";
 +			gpios = <&gpio4 RK_PD4 GPIO_ACTIVE_HIGH>;
@@ -163,7 +164,7 @@ index 111111111111..222222222222 100644
 +		pinctrl-0 = <&system_led>;
 +
 +		status-led {
- 			label = "helios64:green:status";
++			label = "helios64::status";
  			gpios = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
 +			linux,default-trigger = "none";
  			default-state = "on";

--- a/patch/kernel/archive/rockchip64-6.9/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.9/add-board-helios64.patch
@@ -128,6 +128,7 @@ index 9586bb12a5d8..09e2cfe40696 100644
 +		};
  
 -		led-0 {
+-			label = "helios64:green:status";
 +		sata_err5 {
 +			label = "helios64:red:ata5-err";
 +			gpios = <&gpio2 RK_PA6 GPIO_ACTIVE_HIGH>;
@@ -163,7 +164,7 @@ index 9586bb12a5d8..09e2cfe40696 100644
 +		pinctrl-0 = <&system_led>;
 +
 +		status-led {
- 			label = "helios64:green:status";
++			label = "helios64::status";
  			gpios = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
 +			linux,default-trigger = "none";
  			default-state = "on";


### PR DESCRIPTION
While syncing with upstream Linux helios64 dts for 6.9 I missed the diff for the helios64 status led label (upstream was helios64:green:status instead of Armbian helios64::status) and thus broke armbian helios64-heartbeat-led.service.

This commit restores the Armbian label helios64::status to let helios64-heartbeat-led.service starts.

Fixes: cbaf67f00 ("Sync helios64 to its updated 6.9 dts")

# Description

I revert to helios64::status label for the Helios64 status led. The change to upstream label helios64:green:status breaks helios64-heartbeat-led.service (either way the LED is not green but blue). Keep old Armbian label helios64::status for now.

Issue reported by BipBI1981 on 6.12.
```
 root@helios64:~# systemctl status helios64-heartbeat-led.service
× helios64-heartbeat-led.service - Enable heartbeat & network activity led on Helios64
     Loaded: loaded (/etc/systemd/system/helios64-heartbeat-led.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Thu 2025-01-16 20:26:24 CET; 34min ago
    Process: 2899 ExecStart=bash -c echo heartbeat | tee /sys/class/leds/helios64\:\:status/trigger (code=exited, status=1/FAILURE)
   Main PID: 2899 (code=exited, status=1/FAILURE)
        CPU: 20ms

Jan 16 20:26:24 helios64 systemd[1]: Starting helios64-heartbeat-led.service - Enable heartbeat & network activity led on Helios64...
Jan 16 20:26:24 helios64 bash[2906]: tee: '/sys/class/leds/helios64::status/trigger': No such file or directory
Jan 16 20:26:24 helios64 bash[2906]: heartbeat
Jan 16 20:26:24 helios64 systemd[1]: helios64-heartbeat-led.service: Main process exited, code=exited, status=1/FAILURE
Jan 16 20:26:24 helios64 systemd[1]: helios64-heartbeat-led.service: Failed with result 'exit-code'.
Jan 16 20:26:24 helios64 systemd[1]: Failed to start helios64-heartbeat-led.service - Enable heartbeat & network activity led on Helios64. 
```

# How Has This Been Tested?

- [x] Boot on 6.12 current. Verified led sysfs file is now /sys/class/leds/helios64::status and that helios64-heartbeat-led.service starts successfully.
- [x] Boot on 6.13 edge. Verified led sysfs file is now /sys/class/leds/helios64::status and that helios64-heartbeat-led.service starts successfully.
- [x] Boot on 6.9 build. Verified led sysfs file is now /sys/class/leds/helios64::status and that helios64-heartbeat-led.service starts successfully.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings