### PR TITLE
Add missing firmware package for build-in driver cfg80211

### DIFF
--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -40,4 +40,5 @@ u-boot-tools
 usbutils
 wget
 wireguard-tools
+wireless-regdb
 wpasupplicant


### PR DESCRIPTION
# Description

This makes warning:

```
W: Possible missing firmware /lib/firmware/regulatory.db for built-in driver cfg80211 
W: Possible missing firmware /lib/firmware/regulatory.db.p7s for built-in driver cfg80211 

```
go away.

[AR-1638]

# How Has This Been Tested?

- Switching kernels where this was present

# Checklist:

- [x] My changes generate no new warnings

[AR-1638]: https://armbian.atlassian.net/browse/AR-1638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ