### PR TITLE
nanopi-r3s: add support for `current`

### DIFF
--- a/config/boards/nanopi-r3s.csc
+++ b/config/boards/nanopi-r3s.csc
@@ -3,26 +3,29 @@ BOARD_NAME="FriendlyElec NanoPi R3S"
 BOARDFAMILY="rk35xx"
 BOARD_MAINTAINER=""
 BOOTCONFIG="nanopi-r3s-rk3566_defconfig"
-KERNEL_TARGET="edge"
-#KERNEL_TEST_TARGET="edge"
-FULL_DESKTOP="yes"
-BOOT_LOGO="desktop"
+KERNEL_TARGET="current,edge"
+KERNEL_TEST_TARGET="current,edge"
 BOOT_FDT_FILE="rockchip/rk3566-nanopi-r3s.dtb"
 IMAGE_PARTITION_TABLE="gpt"
 BOOT_SCENARIO="spl-blobs"
-BOOTFS_TYPE="fat" # Only for vendor/legacy
+
 
 function post_family_config_branch_edge__use_mainline_dtb_name() {
 	unset BOOT_FDT_FILE # boot.scr will use whatever u-boot detects and sets 'fdtfile' to
 	unset BOOTFS_TYPE   # mainline u-boot can boot ext4 directly
 }
 
-# Override family config for this board; let's avoid conditionals in family config.
-# vendor support not there yet
-function post_family_config__nanopi-r3s_use_vendor_uboot() {
-	BOOTSOURCE='https://github.com/radxa/u-boot.git'
-	BOOTBRANCH='branch:rk35xx-2024.01'
-	BOOTPATCHDIR="u-boot-radxa-latest"
+function post_family_config_branch_current__use_mainline_dtb_name() {
+	unset BOOT_FDT_FILE # boot.scr will use whatever u-boot detects and sets 'fdtfile' to
+	unset BOOTFS_TYPE   # mainline u-boot can boot ext4 directly
+}
+
+
+function post_family_config_branch_current__nanopi-r3s_use_mainline_uboot() {
+	BOOTCONFIG="nanopi-r3s-rk3566_defconfig"
+	BOOTSOURCE="https://github.com/u-boot/u-boot"
+	BOOTBRANCH="tag:v2024.10"
+	BOOTPATCHDIR="v2024.10"
 
 	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 
@@ -36,8 +39,8 @@ function post_family_config__nanopi-r3s_use_vendor_uboot() {
 function post_family_config_branch_edge__nanopi-r3s_use_mainline_uboot() {
 	BOOTCONFIG="nanopi-r3s-rk3566_defconfig"
 	BOOTSOURCE="https://github.com/u-boot/u-boot"
-	BOOTBRANCH="tag:v2024.10"
-	BOOTPATCHDIR="v2024.10"
+	BOOTBRANCH="tag:v2025.01"
+	BOOTPATCHDIR="v2025.01"
 
 	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 

--- a/config/boards/nanopi-r3s.csc
+++ b/config/boards/nanopi-r3s.csc
@@ -1,5 +1,5 @@
-# Rockchip RK3566 quad core, dual GBe NIC
-BOARD_NAME="FriendlyElec NanoPi R3S"
+# Rockchip RK3566 quad core 2GB RAM eMMC 2x GbE USB3
+BOARD_NAME="NanoPi R3S"
 BOARDFAMILY="rk35xx"
 BOARD_MAINTAINER=""
 BOOTCONFIG="nanopi-r3s-rk3566_defconfig"

--- a/patch/kernel/archive/rockchip64-6.12/board-nanopi-r3s-fix-leds.patch
+++ b/patch/kernel/archive/rockchip64-6.12/board-nanopi-r3s-fix-leds.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Doe <john.doe@somewhere.on.planet>
+Date: Tue, 28 Jan 2025 12:13:35 +0800
+Subject: Patching NanoPi-R3S LEDs
+
+Signed-off-by: John Doe <john.doe@somewhere.on.planet>
+---
+ arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts | 41 +++++++---
+ drivers/net/ethernet/realtek/r8169_main.c          | 11 +++
+ drivers/net/phy/realtek.c                          | 11 +++
+ 3 files changed, 53 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/net/ethernet/realtek/r8169_main.c b/drivers/net/ethernet/realtek/r8169_main.c
+index 8a3959bb2..f8c046a69 100644
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -19,10 +19,11 @@
+ #include <linux/phy.h>
+ #include <linux/if_vlan.h>
+ #include <linux/in.h>
+ #include <linux/io.h>
+ #include <linux/ip.h>
++#include <linux/of.h>
+ #include <linux/tcp.h>
+ #include <linux/interrupt.h>
+ #include <linux/dma-mapping.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/bitfield.h>
+@@ -2404,10 +2405,19 @@ void r8169_apply_firmware(struct rtl8169_private *tp)
+ 				      !(val & BMCR_RESET),
+ 				      50000, 600000, true);
+ 	}
+ }
+ 
++static void rtl8168_led_of_init(struct rtl8169_private *tp)
++{
++	struct device *d = tp_to_dev(tp);
++	u32 val;
++
++	if (!of_property_read_u32(d->of_node, "realtek,ledsel", &val))
++		RTL_W16(tp, LED_CTRL, val);
++}
++
+ static void rtl8168_config_eee_mac(struct rtl8169_private *tp)
+ {
+ 	/* Adjust EEE LED frequency */
+ 	if (tp->mac_version != RTL_GIGA_MAC_VER_38)
+ 		RTL_W8(tp, EEE_LED, RTL_R8(tp, EEE_LED) & ~0x07);
+@@ -3389,10 +3399,11 @@ static void rtl_hw_start_8168h_1(struct rtl8169_private *tp)
+ 
+ 	rtl_eri_write(tp, 0xc0, ERIAR_MASK_0011, 0x0000);
+ 	rtl_eri_write(tp, 0xb8, ERIAR_MASK_0011, 0x0000);
+ 
+ 	rtl8168_config_eee_mac(tp);
++	rtl8168_led_of_init(tp);
+ 
+ 	RTL_W8(tp, DLLPR, RTL_R8(tp, DLLPR) & ~PFM_EN);
+ 	RTL_W8(tp, MISC_1, RTL_R8(tp, MISC_1) & ~PFM_D3COLD_EN);
+ 
+ 	RTL_W8(tp, DLLPR, RTL_R8(tp, DLLPR) & ~TX_10M_PS_EN);
+diff --git a/drivers/net/phy/realtek.c b/drivers/net/phy/realtek.c
+index f65d7f1f3..f5d831924 100644
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -121,10 +121,19 @@ static int rtl821x_read_page(struct phy_device *phydev)
+ static int rtl821x_write_page(struct phy_device *phydev, int page)
+ {
+ 	return __phy_write(phydev, RTL821x_PAGE_SELECT, page);
+ }
+ 
++static void rtl821x_led_of_init(struct phy_device *phydev)
++{
++	struct device *dev = &phydev->mdio.dev;
++	u32 val;
++
++	if (!of_property_read_u32(dev->of_node, "realtek,ledsel", &val))
++		phy_write_paged(phydev, 0xd04, 0x10, val);
++}
++
+ static int rtl821x_probe(struct phy_device *phydev)
+ {
+ 	struct device *dev = &phydev->mdio.dev;
+ 	struct rtl821x_priv *priv;
+ 	u32 phy_id = phydev->drv->phy_id;
+@@ -440,10 +449,12 @@ static int rtl8211f_config_init(struct phy_device *phydev)
+ 		dev_dbg(dev,
+ 			"2ns RX delay was already %s (by pin-strapping RXD0 or bootloader configuration)\n",
+ 			val_rxdly ? "enabled" : "disabled");
+ 	}
+ 
++	rtl821x_led_of_init(phydev);
++
+ 	if (priv->has_phycr2) {
+ 		ret = phy_modify_paged(phydev, 0xa43, RTL8211F_PHYCR2,
+ 				       RTL8211F_CLKOUT_EN, priv->phycr2);
+ 		if (ret < 0) {
+ 			dev_err(dev, "clkout configuration failed: %pe\n",
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3566-nanopi-r3s.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3566-nanopi-r3s.dts
@@ -52,19 +52,21 @@
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_POWER;
 			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
-			default-state = "on";
+			linux,default-trigger = "heartbeat";
 		};
 
 		lan_led: led-1 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_LAN;
 			gpios = <&gpio3 RK_PC2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "r8169-0-100:00:link";
 		};
 
 		wan_led: led-2 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WAN;
 			gpios = <&gpio3 RK_PC3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "stmmac-0:01:link";
 		};
 	};
 
@@ -137,18 +139,27 @@
 };
 
 &gmac1 {
+	phy-mode = "rgmii";
+	clock_in_out = "output";
+
+	snps,reset-gpio = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
+	snps,reset-active-low;
+	/* Reset time is 15ms, 50ms for rtl8211f */
+	snps,reset-delays-us = <0 15000 50000>;
 	assigned-clocks = <&cru SCLK_GMAC1_RX_TX>, <&cru SCLK_GMAC1>;
 	assigned-clock-parents = <&cru SCLK_GMAC1_RGMII_SPEED>, <&cru CLK_MAC1_2TOP>;
 	assigned-clock-rates = <0>, <125000000>;
-	clock_in_out = "output";
-	phy-mode = "rgmii-id";
-	phy-handle = <&rgmii_phy1>;
+
 	pinctrl-names = "default";
 	pinctrl-0 = <&gmac1m0_miim
 		     &gmac1m0_tx_bus2_level3
 		     &gmac1m0_rx_bus2
 		     &gmac1m0_rgmii_clk_level2
 		     &gmac1m0_rgmii_bus_level3>;
+	tx_delay = <0x3c>;
+	rx_delay = <0x2f>;
+
+	phy-handle = <&rgmii_phy1>;
 	status = "okay";
 };
 
@@ -409,10 +420,8 @@
 		interrupt-parent = <&gpio4>;
 		interrupts = <RK_PC3 IRQ_TYPE_LEVEL_LOW>;
 		pinctrl-names = "default";
-		pinctrl-0 = <&eth_phy_reset_pin>;
-		reset-assert-us = <20000>;
-		reset-deassert-us = <100000>;
-		reset-gpios = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
+		pinctrl-0 = <&gmac_int>;
+		realtek,ledsel = <0xae00>;
 	};
 };
 
@@ -421,6 +430,18 @@
 	pinctrl-0 = <&pcie_reset_h>;
 	reset-gpios = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
 	status = "okay";
+	
+	pcie@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		r8169: pcie@1,0 {
+			reg = <0x000000 0 0 0 0>;
+			local-mac-address = [ 00 00 00 00 00 00 ];
+			realtek,ledsel = <0x870>;
+		};
+	};
 };
 
 &pinctrl {
@@ -439,8 +460,8 @@
 	};
 
 	gmac {
-		eth_phy_reset_pin: eth-phy-reset-pin {
-			rockchip,pins = <4 RK_PC2 RK_FUNC_GPIO &pcfg_pull_up>;
+		gmac_int: gmac-int {
+			rockchip,pins = <4 RK_PC3 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 	};
 

--- a/patch/u-boot/v2025.01/board_nanopi-r3s/0001-rockchip-rk3566-add-nanopi-r3s.patch
+++ b/patch/u-boot/v2025.01/board_nanopi-r3s/0001-rockchip-rk3566-add-nanopi-r3s.patch
@@ -1,0 +1,812 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Werner <werner@armbian.com>
+Date: Sun, 9 Dec 2024 07:36:02 +0200
+Subject: add support for Nanopi R3S
+
+diff --git a/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+new file mode 100644
+index 0000000000..a7a55d68db
+--- /dev/null
++++ b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+@@ -0,0 +1,554 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++/*
++ * Copyright (c) 2020 Rockchip Electronics Co., Ltd.
++ *
++ * Copyright (c) 2024 FriendlyElec Computer Tech. Co., Ltd.
++ * (http://www.friendlyarm.com)
++ *
++ * Copyright (c) 2024 Tianling Shen <cnsztl@gmail.com>
++ */
++
++/dts-v1/;
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/soc/rockchip,vop2.h>
++#include "rk3566.dtsi"
++
++/ {
++	model = "FriendlyARM NanoPi R3S";
++	compatible = "friendlyarm,nanopi-r3s", "rockchip,rk3566";
++
++	aliases {
++		ethernet0 = &gmac1;
++		mmc0 = &sdmmc0;
++		mmc1 = &sdhci;
++	};
++
++	chosen: chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		pinctrl-names = "default";
++		pinctrl-0 = <&reset_button_pin>;
++
++		button-reset {
++			label = "reset";
++			gpios = <&gpio0 RK_PC2 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++			debounce-interval = <50>;
++		};
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&power_led_pin>, <&lan_led_pin>, <&wan_led_pin>;
++
++		power_led: led-0 {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_POWER;
++			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++		};
++
++		lan_led: led-1 {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_LAN;
++			gpios = <&gpio3 RK_PC2 GPIO_ACTIVE_HIGH>;
++		};
++
++		wan_led: led-2 {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_WAN;
++			gpios = <&gpio3 RK_PC3 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	vcc3v3_sys: regulator-vcc3v3-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc5v0_sys: regulator-vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vdd_usbc>;
++	};
++
++	vcc5v0_usb: regulator-vcc5v0_usb {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_usb_host_en>;
++		regulator-name = "vcc5v0_usb";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vdd_usbc: regulator-vdd-usbc {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_usbc";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++};
++
++&combphy1 {
++	status = "okay";
++};
++
++&combphy2 {
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&gmac1 {
++	assigned-clocks = <&cru SCLK_GMAC1_RX_TX>, <&cru SCLK_GMAC1>;
++	assigned-clock-parents = <&cru SCLK_GMAC1_RGMII_SPEED>, <&cru CLK_MAC1_2TOP>;
++	assigned-clock-rates = <0>, <125000000>;
++	clock_in_out = "output";
++	phy-mode = "rgmii-id";
++	phy-handle = <&rgmii_phy1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&gmac1m0_miim
++		     &gmac1m0_tx_bus2_level3
++		     &gmac1m0_rx_bus2
++		     &gmac1m0_rgmii_clk_level2
++		     &gmac1m0_rgmii_bus_level3>;
++	snps,reset-gpio = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	/* Reset time is 20ms, 100ms for rtl8211f */
++	snps,reset-delays-us = <0 20000 100000>;
++	status = "okay";
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu>;
++	status = "okay";
++};
++
++&i2c0 {
++	status = "okay";
++
++	vdd_cpu: regulator@1c {
++		compatible = "tcs,tcs4525";
++		reg = <0x1c>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <800000>;
++		regulator-max-microvolt = <1150000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc5v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	rk809: pmic@20 {
++		compatible = "rockchip,rk809";
++		reg = <0x20>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_LOW>;
++		#clock-cells = <1>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int>;
++		system-power-controller;
++		vcc1-supply = <&vcc3v3_sys>;
++		vcc2-supply = <&vcc3v3_sys>;
++		vcc3-supply = <&vcc3v3_sys>;
++		vcc4-supply = <&vcc3v3_sys>;
++		vcc5-supply = <&vcc3v3_sys>;
++		vcc6-supply = <&vcc3v3_sys>;
++		vcc7-supply = <&vcc3v3_sys>;
++		vcc8-supply = <&vcc3v3_sys>;
++		vcc9-supply = <&vcc3v3_sys>;
++		wakeup-source;
++
++		regulators {
++			vdd_logic: DCDC_REG1 {
++				regulator-name = "vdd_logic";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-initial-mode = <0x2>;
++				regulator-min-microvolt = <500000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_gpu: DCDC_REG2 {
++				regulator-name = "vdd_gpu";
++				regulator-always-on;
++				regulator-initial-mode = <0x2>;
++				regulator-min-microvolt = <500000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-name = "vcc_ddr";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-initial-mode = <0x2>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vdd_npu: DCDC_REG4 {
++				regulator-name = "vdd_npu";
++				regulator-initial-mode = <0x2>;
++				regulator-min-microvolt = <500000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8: DCDC_REG5 {
++				regulator-name = "vcc_1v8";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdda0v9_image: LDO_REG1 {
++				regulator-name = "vdda0v9_image";
++				regulator-min-microvolt = <950000>;
++				regulator-max-microvolt = <950000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdda_0v9: LDO_REG2 {
++				regulator-name = "vdda_0v9";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <900000>;
++				regulator-max-microvolt = <900000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdda0v9_pmu: LDO_REG3 {
++				regulator-name = "vdda0v9_pmu";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <900000>;
++				regulator-max-microvolt = <900000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <900000>;
++				};
++			};
++
++			vccio_acodec: LDO_REG4 {
++				regulator-name = "vccio_acodec";
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vccio_sd: LDO_REG5 {
++				regulator-name = "vccio_sd";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc3v3_pmu: LDO_REG6 {
++				regulator-name = "vcc3v3_pmu";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcca_1v8: LDO_REG7 {
++				regulator-name = "vcca_1v8";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcca1v8_pmu: LDO_REG8 {
++				regulator-name = "vcca1v8_pmu";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcca1v8_image: LDO_REG9 {
++				regulator-name = "vcca1v8_image";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_3v3: SWITCH_REG1 {
++				regulator-name = "vcc_3v3";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc3v3_sd: SWITCH_REG2 {
++				regulator-name = "vcc3v3_sd";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++};
++
++&i2c1 {
++	status = "okay";
++
++	hym8563: rtc@51 {
++		compatible = "haoyu,hym8563";
++		reg = <0x51>;
++		#clock-cells = <0>;
++		clock-output-names = "hym8563";
++		pinctrl-names = "default";
++		pinctrl-0 = <&hym8563_int>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PD3 IRQ_TYPE_LEVEL_LOW>;
++		wakeup-source;
++	};
++};
++
++&mdio1 {
++	rgmii_phy1: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <1>;
++		interrupt-parent = <&gpio4>;
++		interrupts = <RK_PC3 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&eth_phy_reset_pin>;
++	};
++};
++
++&pcie2x1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie_reset_h>;
++	reset-gpios = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++&pinctrl {
++	gpio-leds {
++		lan_led_pin: lan-led-pin {
++			rockchip,pins = <3 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		power_led_pin: power-led-pin {
++			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		wan_led_pin: wan-led-pin {
++			rockchip,pins = <3 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	gmac {
++		eth_phy_reset_pin: eth-phy-reset-pin {
++			rockchip,pins = <4 RK_PC2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	pcie {
++		pcie_reset_h: pcie-reset-h {
++			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	pmic {
++		pmic_int: pmic-int {
++			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	rockchip-key {
++		reset_button_pin: reset-button-pin {
++			rockchip,pins = <0 RK_PC2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	rtc {
++		hym8563_int: hym8563-int {
++			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	usb {
++		vcc5v0_usb_host_en: vcc5v0-usb-host-en {
++			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&pmu_io_domains {
++	status = "okay";
++	pmuio1-supply = <&vcc3v3_pmu>;
++	pmuio2-supply = <&vcc3v3_pmu>;
++	vccio1-supply = <&vccio_acodec>;
++	vccio2-supply = <&vcc_1v8>;
++	vccio3-supply = <&vccio_sd>;
++	vccio4-supply = <&vcc_3v3>;
++	vccio5-supply = <&vcc_1v8>;
++	vccio6-supply = <&vcc_3v3>;
++	vccio7-supply = <&vcc_3v3>;
++};
++
++&sdhci {
++	bus-width = <8>;
++	max-frequency = <200000000>;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_datastrobe>;
++	status = "okay";
++};
++
++&sdmmc0 {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	no-sdio;
++	no-mmc;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd &sdmmc0_det>;
++	sd-uhs-sdr50;
++	vmmc-supply = <&vcc3v3_sd>;
++	vqmmc-supply = <&vccio_sd>;
++	status = "okay";
++};
++
++&tsadc {
++	status = "okay";
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&usb2phy0 {
++	status = "okay";
++};
++
++&usb2phy0_host {
++	phy-supply = <&vcc5v0_usb>;
++	status = "okay";
++};
++
++&usb2phy0_otg {
++	status = "okay";
++};
++
++&usb_host0_xhci {
++	extcon = <&usb2phy0>;
++	status = "okay";
++};
++
++&usb_host1_xhci {
++	status = "okay";
++};
++
++&vop {
++	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
++	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Werner <werner@armbian.com>
+Date: Sun, 9 Dec 2024 07:36:02 +0200
+Subject: add support for Nanopi R3S
+
+---
+ dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+index a7a55d68db..6bc17f755b 100644
+--- a/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
++++ b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+@@ -3,7 +3,7 @@
+  * Copyright (c) 2020 Rockchip Electronics Co., Ltd.
+  *
+  * Copyright (c) 2024 FriendlyElec Computer Tech. Co., Ltd.
+- * (http://www.friendlyarm.com)
++ * (http://www.friendlyelec.com)
+  *
+  * Copyright (c) 2024 Tianling Shen <cnsztl@gmail.com>
+  */
+@@ -17,7 +17,7 @@
+ #include "rk3566.dtsi"
+ 
+ / {
+-	model = "FriendlyARM NanoPi R3S";
++	model = "FriendlyElec NanoPi R3S";
+ 	compatible = "friendlyarm,nanopi-r3s", "rockchip,rk3566";
+ 
+ 	aliases {
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Werner <werner@armbian.com>
+Date: Sun, 9 Dec 2024 07:36:02 +0200
+Subject: add support for Nanopi R3S
+
+---
+ dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+index 6bc17f755b..66a00cddda 100644
+--- a/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
++++ b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+@@ -149,10 +149,6 @@
+ 		     &gmac1m0_rx_bus2
+ 		     &gmac1m0_rgmii_clk_level2
+ 		     &gmac1m0_rgmii_bus_level3>;
+-	snps,reset-gpio = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
+-	snps,reset-active-low;
+-	/* Reset time is 20ms, 100ms for rtl8211f */
+-	snps,reset-delays-us = <0 20000 100000>;
+ 	status = "okay";
+ };
+ 
+@@ -414,6 +410,9 @@
+ 		interrupts = <RK_PC3 IRQ_TYPE_LEVEL_LOW>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&eth_phy_reset_pin>;
++		reset-assert-us = <20000>;
++		reset-deassert-us = <100000>;
++		reset-gpios = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
+ 	};
+ };
+ 
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Werner <werner@armbian.com>
+Date: Sun, 9 Dec 2024 07:36:02 +0200
+Subject: add support for Nanopi R3S
+
+---
+ dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+index 66a00cddda..243574f8da 100644
+--- a/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
++++ b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+@@ -476,7 +476,6 @@
+ };
+ 
+ &pmu_io_domains {
+-	status = "okay";
+ 	pmuio1-supply = <&vcc3v3_pmu>;
+ 	pmuio2-supply = <&vcc3v3_pmu>;
+ 	vccio1-supply = <&vccio_acodec>;
+@@ -486,6 +485,7 @@
+ 	vccio5-supply = <&vcc_1v8>;
+ 	vccio6-supply = <&vcc_3v3>;
+ 	vccio7-supply = <&vcc_3v3>;
++	status = "okay";
+ };
+ 
+ &sdhci {
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Werner <werner@armbian.com>
+Date: Sun, 9 Dec 2024 07:36:02 +0200
+Subject: add support for Nanopi R3S
+
+---
+ dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+index 243574f8da..03a2f90f62 100644
+--- a/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
++++ b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+@@ -491,6 +491,7 @@
+ &sdhci {
+ 	bus-width = <8>;
+ 	max-frequency = <200000000>;
++	mmc-hs200-1_8v;
+ 	non-removable;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_datastrobe>;
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Werner <werner@armbian.com>
+Date: Sun, 9 Dec 2024 07:36:02 +0200
+Subject: add support for Nanopi R3S
+
+---
+ dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+index 03a2f90f62..fb1f65c868 100644
+--- a/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
++++ b/dts/upstream/src/arm64/rockchip/rk3566-nanopi-r3s.dts
+@@ -22,8 +22,8 @@
+ 
+ 	aliases {
+ 		ethernet0 = &gmac1;
+-		mmc0 = &sdmmc0;
+-		mmc1 = &sdhci;
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc0;
+ 	};
+ 
+ 	chosen: chosen {
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Werner <werner@armbian.com>
+Date: Sun, 9 Dec 2024 07:36:02 +0200
+Subject: add support for Nanopi R3S
+
+diff --git a/arch/arm/dts/rk3566-nanopi-r3s-u-boot.dtsi b/arch/arm/dts/rk3566-nanopi-r3s-u-boot.dtsi
+new file mode 100644
+index 0000000000..b66e5015d6
+--- /dev/null
++++ b/arch/arm/dts/rk3566-nanopi-r3s-u-boot.dtsi
+@@ -0,0 +1,8 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++
++#include "rk356x-u-boot.dtsi"
++
++&vcc5v0_usb {
++	/delete-property/ regulator-always-on;
++	/delete-property/ regulator-boot-on;
++};
+diff --git a/configs/nanopi-r3s-rk3566_defconfig b/configs/nanopi-r3s-rk3566_defconfig
+new file mode 100644
+index 0000000000..f21c703ca7
+--- /dev/null
++++ b/configs/nanopi-r3s-rk3566_defconfig
+@@ -0,0 +1,74 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_COUNTER_FREQUENCY=24000000
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3566-nanopi-r3s"
++CONFIG_ROCKCHIP_RK3568=y
++CONFIG_SPL_SERIAL=y
++CONFIG_SYS_LOAD_ADDR=0xc00800
++CONFIG_DEBUG_UART_BASE=0xFE660000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_PCI=y
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_FIT_SIGNATURE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3566-nanopi-r3s.dtb"
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++CONFIG_SPL_MAX_SIZE=0x40000
++CONFIG_SPL_PAD_TO=0x7f8000
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_ATF=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_I2C=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_PMIC=y
++CONFIG_CMD_REGULATOR=y
++# CONFIG_SPL_DOS_PARTITION is not set
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_SPL_DM_SEQ_ALIAS=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SPL_SYSCON=y
++CONFIG_SPL_CLK=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_LED=y
++CONFIG_LED_GPIO=y
++CONFIG_MISC=y
++CONFIG_SUPPORT_EMMC_RPMB=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_SDMA=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_PHY_REALTEK=y
++CONFIG_DWC_ETH_QOS=y
++CONFIG_DWC_ETH_QOS_ROCKCHIP=y
++CONFIG_RTL8169=y
++CONFIG_NVME_PCI=y
++CONFIG_PCIE_DW_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_NANENG_COMBOPHY=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_SPL_RAM=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_ERRNO_STR=y


### PR DESCRIPTION
# Description

- Bump `edge` u-boot to 2025.01
- Add `current` kernel support
- Remove `vendor` related stuff from board config

# How Has This Been Tested?

- [x] Build
- [ ] Boot - untested, no hw

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# ToDo:

Verify functionality of test images:
https://fi.mirror.armbian.de/.testing/Armbian-unofficial_25.02.0-trunk_Nanopi-r3s_trixie_edge_6.13.0_minimal.img.xz
https://fi.mirror.armbian.de/.testing/Armbian-unofficial_25.02.0-trunk_Nanopi-r3s_trixie_current_6.12.11_minimal.img.xz

Check whether it is a good idea to make changes to the network driver board specific only