### PR TITLE
odroidm1: u-boot: enable `setexpr`; patch 2025.01 for `fileenv`; enable squashfs support

### DIFF
--- a/config/boards/odroidm1.conf
+++ b/config/boards/odroidm1.conf
@@ -137,6 +137,13 @@ function post_config_uboot_target__extra_configs_for_odroid-m1() {
 	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP
 	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP_SACK
 
+	display_alert "u-boot for ${BOARD}" "u-boot: enable more cmdline commands" "info" # for extra compat with eg HAOS
+	run_host_command_logged scripts/config --enable CONFIG_CMD_SQUASHFS
+	run_host_command_logged scripts/config --enable CONFIG_CMD_SETEXPR
+	run_host_command_logged scripts/config --enable CONFIG_CMD_FILEENV # added via cmd-fileenv-read-string-from-file-into-env.patch
+	run_host_command_logged scripts/config --enable CONFIG_CMD_CAT
+	run_host_command_logged scripts/config --enable CONFIG_CMD_XXD
+
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enabling UMS/RockUSB Gadget functionality" "info"
 	declare -a enable_configs=("CONFIG_CMD_USB_MASS_STORAGE" "CONFIG_USB_GADGET" "USB_GADGET_DOWNLOAD" "CONFIG_USB_FUNCTION_ROCKUSB" "CONFIG_USB_FUNCTION_ACM" "CONFIG_CMD_ROCKUSB" "CONFIG_CMD_USB_MASS_STORAGE")
 	for config in "${enable_configs[@]}"; do

--- a/patch/u-boot/v2025.01/cmd-fileenv-read-string-from-file-into-env.patch
+++ b/patch/u-boot/v2025.01/cmd-fileenv-read-string-from-file-into-env.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Fri, 31 Jan 2025 15:52:03 +0100
+Subject: cmd: fileenv: read string from file into env
+
+- rpardini: adapted from vendor/legacy patch from 2018
+
+Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ cmd/Kconfig   |  5 +
+ cmd/Makefile  |  1 +
+ cmd/fileenv.c | 46 ++++++++++
+ 3 files changed, 52 insertions(+)
+
+diff --git a/cmd/Kconfig b/cmd/Kconfig
+index 111111111111..222222222222 100644
+--- a/cmd/Kconfig
++++ b/cmd/Kconfig
+@@ -1792,6 +1792,11 @@ config CMD_XXD
+ 	help
+ 	  Print file as hexdump to standard output
+ 
++config CMD_FILEENV
++	bool "fileenv"
++	help
++	   Read a file into memory and store it to env.
++
+ endmenu
+ 
+ if NET || NET_LWIP
+diff --git a/cmd/Makefile b/cmd/Makefile
+index 111111111111..222222222222 100644
+--- a/cmd/Makefile
++++ b/cmd/Makefile
+@@ -170,6 +170,7 @@ obj-$(CONFIG_CMD_SHA1SUM) += sha1sum.o
+ obj-$(CONFIG_CMD_SEAMA) += seama.o
+ obj-$(CONFIG_CMD_SETEXPR) += setexpr.o
+ obj-$(CONFIG_CMD_SETEXPR_FMT) += printf.o
++obj-$(CONFIG_CMD_FILEENV) += fileenv.o
+ obj-$(CONFIG_CMD_SPI) += spi.o
+ obj-$(CONFIG_CMD_STRINGS) += strings.o
+ obj-$(CONFIG_CMD_SMBIOS) += smbios.o
+diff --git a/cmd/fileenv.c b/cmd/fileenv.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/cmd/fileenv.c
+@@ -0,0 +1,46 @@
++#include <config.h>
++#include <command.h>
++#include <fs.h>
++#include <linux/ctype.h>
++#include <vsprintf.h>
++
++static char *fs_argv[5];
++
++int do_fileenv(struct cmd_tbl *cmdtp, int flag, int argc, char * const argv[])
++{
++	if (argc < 6)
++		return CMD_RET_USAGE;
++
++	fs_argv[0] = "fatload";
++	fs_argv[1] = argv[1];
++	fs_argv[2] = argv[2];
++	fs_argv[3] = argv[3];
++	fs_argv[4] = argv[4];
++
++	if (do_fat_fsload(cmdtp, 0, 5, fs_argv) != 0)
++		return 1;
++
++	char *addr = (char *)simple_strtoul(argv[3], NULL, 16);
++	size_t size = env_get_hex("filesize", 0);
++
++	// Prepare string
++	addr[size] = 0x00;
++	char *s = addr;
++	while(*s != 0x00) {
++		if (isprint(*s)) {
++			s++;
++		}
++		else {
++			*s = 0x00;
++		}
++	}
++
++	return env_set(argv[5], addr);
++}
++
++U_BOOT_CMD(
++	fileenv, 6, 0, do_fileenv,
++	"Read file and store it into env.",
++	"<interface> <dev:part> <addr> <filename> <envname>\n"
++	"    - Read file from fat32 and store it as env."
++);
+-- 
+Armbian
+


### PR DESCRIPTION
- as Armbian u-boot is possibly deployed to SPI (replacing Petitboot),
  try to make as compatible as possible; eg enable squashfs support
- in this case, `setexpr` and `fileenv` are used by HAOS
  - found `fileenv` here https://github.com/spikerguy/khadas-uboot/commit/049e1a1949438e5193dcf598061c418d8a31e862
Signed-off-by: Ricardo Pardini <ricardo@pardini.net>