### PR TITLE
nanopct6(-lts): bump u-boot to 2025.04-rc1

### DIFF
--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -51,6 +51,13 @@ function post_family_config_branch_edge__nanopct6_use_mainline_uboot() {
 	}
 }
 
+# U-boot 2025.04+ can detect and set fdtfile automatically across T6 and T6-LTS boards.
+# So if using mainline u-boot, unset BOOT_FDT_FILE to let u-boot handle it.
+# That way, both variants can boot from the same image; lets keep the -lts board file for vendor kernel/u-boot.
+function post_family_config_branch_edge__t6_and_t6_lts_auto_dtb_name_via_uboot_detection() {
+	unset BOOT_FDT_FILE
+}
+
 function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
 	[[ "${BRANCH}" != "edge" ]] && return 0
 

--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -35,8 +35,8 @@ function post_family_config_branch_edge__nanopct6_use_mainline_uboot() {
 	declare -g BOOTCONFIG="nanopc-t6-rk3588_defconfig"
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline
-	declare -g BOOTBRANCH="tag:v2025.01"
-	declare -g BOOTPATCHDIR="v2025.01"
+	declare -g BOOTBRANCH="tag:v2025.04-rc1"
+	declare -g BOOTPATCHDIR="v2025.04"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
@@ -62,31 +62,6 @@ function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
 		&usb_host0_xhci { dr_mode = "peripheral";  maximum-speed = "high-speed";  status = "okay"; };
 	EOD
 
-	# @TODO: I notified Kwiboo about the missing lts-u-boot.dtsi in 2025.01; this is a workaround and should be removed for 2025.04
-	#        (few minutes later) Kwiboo is done already https://lore.kernel.org/u-boot/20250106182232.3741304-1-jonas@kwiboo.se/
-	run_host_command_logged cp "arch/arm/dts/rk3588-nanopc-t6-u-boot.dtsi" "arch/arm/dts/rk3588-nanopc-t6-lts-u-boot.dtsi"
-}
-
-# Pull in a newer upstream/dts, which has a fix for the USB3 Type-A (host); this enables booting high speed USB3 devices (https://github.com/torvalds/linux/commit/a6ae420439dc47a58550a6e61e596e9dd1562caf)
-# See https://docs.u-boot.org/en/latest/develop/devicetree/control.html#resyncing-with-devicetree-rebasing
-# @TODO this probably can be removed for 2025.04
-function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
-	[[ "${BRANCH}" != "edge" ]] && return 0
-	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: pull in upstream/dts for UMS" "info"
-
-	# Need to specify params and envs so git doesn't break when commiter/author/gpg/HOME/etc is unset.
-	declare -a common_envs=("HOME=${HOME}" "PATH=${PATH}")
-	declare -a git_params=("-c" "commit.gpgsign=false")
-	declare -a commit_params=(--author="${MAINTAINER} <${MAINTAINERMAIL}>")
-	declare -a commit_envs=("GIT_COMMITTER_NAME=${MAINTAINER}" "GIT_COMMITTER_EMAIL=${MAINTAINERMAIL}" "GIT_AUTHOR_NAME=${MAINTAINER}" "GIT_AUTHOR_EMAIL=${MAINTAINERMAIL}")
-
-	run_host_command_logged env -i "${common_envs[@]@Q}" git add . || true
-	run_host_command_logged env -i "${common_envs[@]@Q}" "${commit_envs[@]@Q}" git "${git_params[@]@Q}" commit "${commit_params[@]@Q}" -m "'commit pre update OF upstream so that tree is clean'" || true
-	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: running tools/update-subtree.sh" "info"
-	run_host_command_logged env -i "${common_envs[@]@Q}" "${commit_envs[@]@Q}" bash tools/update-subtree.sh pull dts v6.13-rc5-dts "||" true # do not fail as conflicts are expected
-	run_host_command_logged env -i "${common_envs[@]@Q}" git checkout --theirs dts/upstream
-	run_host_command_logged env -i "${common_envs[@]@Q}" git add dts/upstream
-	run_host_command_logged env -i "${common_envs[@]@Q}" "${commit_envs[@]@Q}" git "${git_params[@]@Q}" commit "${commit_params[@]@Q}" -m "'Update OF upstream to v6.13-rc5-dts and accept theirs on all conflicts'"
 }
 
 # "rockchip-common: boot SD card first, then NVMe, then mmc"


### PR DESCRIPTION
#### nanopct6(-lts): bump u-boot to 2025.04-rc1

- nanopct6(-lts): bump u-boot to 2025.04-rc1
  - this allows us to drop a bunch of code needed for 2025.01
  - UMS works out of the box (simple dr_mode = peripheral change enough)
  - USB3 Type-A port works out of the box
  - SPI works out of the box
- nanopct6(-lts): if using mainline u-boot, let u-boot determine fdtfile