### PR TITLE
Mesa VPU: allow package downgrading at apt upgrade

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -140,7 +140,7 @@ function post_install_kernel_debs__3d() {
 	fi
 
 	display_alert "Upgrading all packages, including hopefully all mesa packages" "${EXTENSION}" "info"
-	do_with_retries 3 chroot_sdcard_apt_get -o Dpkg::Options::="--force-confold" dist-upgrade
+	do_with_retries 3 chroot_sdcard_apt_get -o Dpkg::Options::="--force-confold" --allow-downgrades dist-upgrade
 
 	# KDE neon downgrade hack undo
 	do_with_retries 3 chroot_sdcard apt-mark unhold base-files


### PR DESCRIPTION
# Description

When packages are having same or older version, function will errors out.

```
[🐳|🔨]   dpkg: warning: downgrading libdrm2:arm64 from 2.4.122-1~ubuntu0.24.04.1 to 2.4.122-1~kisak~n
[🐳|🔨]   (Reading database ... 90090 files and directories currently installed.)
[🐳|🔨]   Preparing to unpack .../libdrm2_2.4.122-1~kisak~n_arm64.deb ...
[🐳|🔨]   Unpacking libdrm2:arm64 (2.4.122-1~kisak~n) over (2.4.122-1~ubuntu0.24.04.1) ...
[🐳|🔨]   dpkg: warning: downgrading libdrm-common from 2.4.122-1~ubuntu0.24.04.1 to 2.4.122-1~kisak~n
[🐳|🔨]   Preparing to unpack .../libdrm-common_2.4.122-1~kisak~n_all.deb ...
[🐳|🔨]   Unpacking libdrm-common (2.4.122-1~kisak~n) over (2.4.122-1~ubuntu0.24.04.1) ...
[🐳|🔨]   dpkg: warning: downgrading libdrm-amdgpu1:arm64 from 2.4.122-1~ubuntu0.24.04.1 to 2.4.122-1~kisak~n
[🐳|🔨]   Preparing to unpack .../libdrm-amdgpu1_2.4.122-1~kisak~n_arm64.deb ...
[🐳|🔨]   Unpacking libdrm-amdgpu1:arm64 (2.4.122-1~kisak~n) over (2.4.122-1~ubuntu0.24.04.1) ...
[🐳|🔨]   dpkg: warning: downgrading libdrm-radeon1:arm64 from 2.4.122-1~ubuntu0.24.04.1 to 2.4.122-1~kisak~n
[🐳|🔨]   Preparing to unpack .../libdrm-radeon1_2.4.122-1~kisak~n_arm64.deb ...
[🐳|🔨]   Unpacking libdrm-radeon1:arm64 (2.4.122-1~kisak~n) over (2.4.122-1~ubuntu0.24.04.1) ...
```

# How Has This Been Tested?

- [x] Manual compilation

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
