### PR TITLE
mesa-vpu: only add kisak ppa for jammy

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -21,7 +21,7 @@ function extension_prepare_config__3d() {
 	# Define image suffix
 	if [[ "${LINUXFAMILY}" =~ ^(rockchip-rk3588|rk35xx)$ && "$BRANCH" =~ ^(legacy)$ && "${RELEASE}" =~ ^(jammy|noble)$ ]]; then
 		EXTRA_IMAGE_SUFFIXES+=("-panfork")
-	elif [[ "${DISTRIBUTION}" == "Ubuntu" ]]; then
+	elif [[ "${DISTRIBUTION}" == "Ubuntu" && "${RELEASE}" =~ ^(jammy)$ ]]; then
 		EXTRA_IMAGE_SUFFIXES+=("-kisak")
 	elif [[ "${DISTRIBUTION}" == "Debian" && "${RELEASE}" == "bookworm" ]]; then
 		EXTRA_IMAGE_SUFFIXES+=("-backported-mesa")
@@ -76,7 +76,7 @@ function post_install_kernel_debs__3d() {
 
 		sed -i "s/noble/jammy/g" "${SDCARD}"/etc/apt/sources.list.d/liujianfeng1994-ubuntu-panfork-mesa-"${RELEASE}".*
 
-	elif [[ "${DISTRIBUTION}" == "Ubuntu" ]]; then
+	elif [[ "${DISTRIBUTION}" == "Ubuntu" && "${RELEASE}" =~ ^(jammy)$ ]]; then
 
 		display_alert "Adding kisak PPAs" "${EXTENSION}" "info"
 		do_with_retries 3 chroot_sdcard add-apt-repository ppa:kisak/kisak-mesa --yes --no-update


### PR DESCRIPTION
# Description

Ubuntu has backported mesa 24.2.8 to noble-updates: https://packages.ubuntu.com/source/noble-updates/mesa, so now we only need kisak ppa for rk3588 panthor gpu driver only in jammy.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=armsom-sige7 BRANCH=vendor GITHUB_MIRROR=ghproxy KERNEL_GIT=shallow BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no ENABLE_EXTENSIONS=mesa-vpu RELEASE=noble`
- [x] `./compile.sh BOARD=armsom-sige7 BRANCH=vendor GITHUB_MIRROR=ghproxy KERNEL_GIT=shallow BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no ENABLE_EXTENSIONS=mesa-vpu RELEASE=jammy`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
