### PR TITLE
feat: Use deb822 APT source for armbian-config

### DIFF
--- a/extensions/armbian-config.sh
+++ b/extensions/armbian-config.sh
@@ -2,8 +2,14 @@
 # and they are moved to main armbian repo periodically
 
 
-function custom_apt_repo__add_armbian-github-repo(){
-	echo "deb ${SIGNED_BY}https://github.armbian.com/configng stable main" > "${SDCARD}"/etc/apt/sources.list.d/armbian-config.list
+function custom_apt_repo__add_armbian-github-repo() {
+	cat <<- EOF > "${SDCARD}"/etc/apt/sources.list.d/armbian-config.sources
+	Types: deb
+	URIs: https://github.armbian.com/configng
+	Suites: stable
+	Components: main
+	Signed-By: "${APT_SIGNING_KEY_FILE}"
+	EOF
 }
 
 

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -160,8 +160,9 @@ function create_sources_list_and_deploy_repo_key() {
 	display_alert "Adding Armbian repository and authentication key" "${when} :: /etc/apt/sources.list.d/armbian.list" "info"
 	mkdir -p "${basedir}"/usr/share/keyrings
 	# change to binary form
-	gpg --dearmor < "${SRC}"/config/armbian.key > "${basedir}"/usr/share/keyrings/armbian.gpg
-	SIGNED_BY="[signed-by=/usr/share/keyrings/armbian.gpg] "
+	APT_SIGNING_KEY_FILE="/usr/share/keyrings/armbian.gpg"
+	gpg --dearmor < "${SRC}"/config/armbian.key > "${basedir}${APT_SIGNING_KEY_FILE}"
+	SIGNED_BY="[signed-by=${APT_SIGNING_KEY_FILE}] "
 
 	# lets keep old way for old distributions
 	if [[ "${RELEASE}" =~ (focal|bullseye) ]]; then


### PR DESCRIPTION
Replace creation of `armbian-config.list` with `armbian-config.sources`. This holds the same information in a newer format, deb822. APT has supported this format since version 1.1, released in 2015.

This does not affect `armbian.list`.

See also:

- https://github.com/armbian/configng/pull/407
- https://github.com/armbian/documentation/pull/616

# How Has This Been Tested?

None

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
