### PR TITLE
Armbian-config sources lists - remove double quotes from EOT

### DIFF
--- a/extensions/armbian-config.sh
+++ b/extensions/armbian-config.sh
@@ -8,7 +8,7 @@ function custom_apt_repo__add_armbian-github-repo() {
 	URIs: https://github.armbian.com/configng
 	Suites: stable
 	Components: main
-	Signed-By: "${APT_SIGNING_KEY_FILE}"
+	Signed-By: ${APT_SIGNING_KEY_FILE}
 	EOF
 }
 


### PR DESCRIPTION
# Description

EOT doesn't like double quoted variables.

@blieque

# How Has This Been Tested?

- [ ] Generating image

# Checklist:

- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
