### PR TITLE
imx6: move current to 6.12.y

### DIFF
--- a/config/sources/families/imx6.conf
+++ b/config/sources/families/imx6.conf
@@ -18,17 +18,17 @@ case $BRANCH in
 
 	legacy)
 
-		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
 		;;
 
 	current)
 
-		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
 		;;
 
 	edge)
 
-		declare -g KERNEL_MAJOR_MINOR="6.10" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.13" # Major and minor versions of this kernel.
 		;;
 
 esac


### PR DESCRIPTION
# Description

Move current kernel to 6.12.y

# How Has This Been Tested?

Tested with Udoo: https://paste.next.armbian.com/ojixapowaq

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
