### PR TITLE
feat: Use deb822 APT sources

### DIFF
--- a/config/boards/ayn-odin2.csc
+++ b/config/boards/ayn-odin2.csc
@@ -43,7 +43,7 @@ function post_family_tweaks__enable_services() {
 	fi
 
 	# We need unudhcpd from armbian repo, so enable it
-	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.sources
 
 	# Add Gamepad udev rule
 	echo 'SUBSYSTEM=="input", ATTRS{name}=="Ayn Odin2 Gamepad", MODE="0666", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_JOYSTICK}="1"' > "${SDCARD}"/etc/udev/rules.d/99-ignore-gamepad.rules
@@ -59,7 +59,7 @@ function post_family_tweaks__enable_services() {
 	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf unudhcpd mkbootimg git
 
 	# Disable armbian repo back
-	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled
 	do_with_retries 3 chroot_sdcard_apt_get_update
 
 	do_with_retries 3 chroot_sdcard_apt_get_install mesa-vulkan-drivers qbootctl qrtr-tools protection-domain-mapper tqftpserv
@@ -133,7 +133,7 @@ function post_family_tweaks_bsp__firmware_in_initrd() {
 		# Extra one for bt
 		for f in /lib/firmware/qca/* ; do
 			add_firmware "${f#/lib/firmware/}"
-		done 
+		done
 	FIRMWARE_HOOK
 	run_host_command_logged chmod -v +x "${file_added_to_bsp_destination}"
 }

--- a/config/boards/oneplus-kebab.conf
+++ b/config/boards/oneplus-kebab.conf
@@ -65,14 +65,14 @@ function post_family_tweaks__oneplus-kebab_enable_services() {
 	fi
 
 	# we need unudhcpd from armbian repo, so enable it
-	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.sources
 
 	do_with_retries 3 chroot_sdcard_apt_get_update
 	display_alert "$BOARD" "Installing board tweaks" "info"
 	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools unudhcpd mkbootimg dropbear-bin
 
 	# disable armbian repo back
-	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled
 	do_with_retries 3 chroot_sdcard_apt_get_update
 
 	chroot_sdcard systemctl enable qbootctl.service

--- a/config/boards/xiaomi-elish.conf
+++ b/config/boards/xiaomi-elish.conf
@@ -68,7 +68,7 @@ function post_family_tweaks__xiaomi-elish_enable_services() {
 	fi
 
 	# we need unudhcpd from armbian repo, so enable it
-	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.sources
 
 	do_with_retries 3 chroot_sdcard_apt_get_update
 	display_alert "$BOARD" "Installing board tweaks" "info"
@@ -80,7 +80,7 @@ function post_family_tweaks__xiaomi-elish_enable_services() {
 		chroot_sdcard systemctl enable hexagonrpcd-sdsp.service
 	fi
 	# disable armbian repo back
-	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled
 	do_with_retries 3 chroot_sdcard_apt_get_update
 
 	chroot_sdcard systemctl enable qbootctl.service

--- a/config/boards/xiaomi-umi.eos
+++ b/config/boards/xiaomi-umi.eos
@@ -58,14 +58,14 @@ function post_family_tweaks__xiaomi-umi_enable_services() {
 	fi
 
 	# We need unudhcpd from armbian repo, so enable it
-	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.sources
 
 	do_with_retries 3 chroot_sdcard_apt_get_update
 	display_alert "$BOARD" "Installing board tweaks" "info"
 	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools unudhcpd mkbootimg
 
 	# Disable armbian repo back
-	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled
 	do_with_retries 3 chroot_sdcard_apt_get_update
 
 	chroot_sdcard systemctl enable qbootctl.service

--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -222,11 +222,11 @@ function pre_install_distribution_specific__add_rpi_packages() {
 		# we store Rpi firmware packages in our repository
 		# https://github.com/armbian/os/wiki/Import-3rd-party-packages
 		display_alert "Enable Armbian repository to fetch Rpi packages" "" "info"
-		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.sources
 		do_with_retries 3 chroot_sdcard_apt_get_update
 		chroot_sdcard_apt_get_install rpi-eeprom linux-firmware-raspi pi-bluetooth libraspberrypi-bin busybox raspi-config
 		## disable armbian repository
-		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
+		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled
 	fi
 }
 

--- a/lib/functions/main/rootfs-image.sh
+++ b/lib/functions/main/rootfs-image.sh
@@ -47,9 +47,9 @@ function build_rootfs_and_image() {
 	create_sources_list_and_deploy_repo_key "image-late" "${RELEASE}" "${SDCARD}/"
 
 	# We call this above method too many times. @TODO: find out why and fix the same
-	# We may have a armbian.list.disabled file lying around. Remove the same
-	if [[ -e "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled ]]; then
-		rm "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
+	# We may have a armbian.sources.disabled file lying around. Remove the same
+	if [[ -e "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled ]]; then
+		rm "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled
 	fi
 
 	LOG_SECTION="post_repo_apt_update" do_with_logging post_repo_apt_update

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -400,8 +400,8 @@ function install_distribution_agnostic() {
 	[[ -f "${SDCARD}"/lib/systemd/system/armbian-led-state.service ]] && chroot_sdcard systemctl --no-reload enable armbian-led-state.service
 
 	# switch to beta repository at this stage if building nightly images
-	if [[ $IMAGE_TYPE == nightly && -f "${SDCARD}"/etc/apt/sources.list.d/armbian.list ]]; then
-		sed -i 's/apt/beta/' "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+	if [[ $IMAGE_TYPE == nightly && -f "${SDCARD}"/etc/apt/sources.list.d/armbian.sources ]]; then
+		sed -i 's/apt/beta/' "${SDCARD}"/etc/apt/sources.list.d/armbian.sources
 	fi
 
 	# fix for https://bugs.launchpad.net/ubuntu/+source/blueman/+bug/1542723 @TODO: from ubuntu 15. maybe gone?

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -78,91 +78,88 @@ function create_sources_list_and_deploy_repo_key() {
 	declare basedir="${3}" # @TODO: rpardini: this is SDCARD in all practical senses. Why not just use SDCARD?
 	[[ -z $basedir ]] && exit_with_error "No basedir passed to create_sources_list_and_deploy_repo_key"
 
+	declare distro=""
+
+	# Add upstream (Debian/Ubuntu) APT repository
 	case $release in
-		buster)
-			cat <<- EOF > "${basedir}"/etc/apt/sources.list
-				deb http://${DEBIAN_MIRROR} $release main contrib non-free
-				#deb-src http://${DEBIAN_MIRROR} $release main contrib non-free
+		buster | bullseye | bookworm | trixie)
+			distro="debian"
 
-				deb http://${DEBIAN_MIRROR} ${release}-updates main contrib non-free
-				#deb-src http://${DEBIAN_MIRROR} ${release}-updates main contrib non-free
+			declare -a suites=("${release}" "${release}-updates")
+			declare -a security_suites=("${release}-security")
+			declare -a components=(main contrib non-free)
 
-				deb http://${DEBIAN_SECURTY} ${release}/updates main contrib non-free
-				#deb-src http://${DEBIAN_SECURTY} ${release}/updates main contrib non-free
+			if [[ "$release" == "buster" ]]; then
+				security_suites=("${release}/updates")
+			else
+			  suites+=("${release}-backports")
+			fi
+
+			if [[ "$release" != "buster" && "$release" != "bullseye" ]]; then
+			  components+=("non-free-firmware")
+			fi
+
+			cat <<- EOF > "${basedir}/etc/apt/sources.list.d/${distro}.sources"
+			Types: deb
+			URIs: http://${DEBIAN_MIRROR}
+			Suites: ${suites[@]}
+			Components: ${components[@]}
+			Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+			Types: deb
+			URIs: http://${DEBIAN_SECURTY}
+			Suites: ${security_suites[@]}
+			Components: ${components[@]}
+			Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 			EOF
 			;;
 
-		bullseye)
-			cat <<- EOF > "${basedir}"/etc/apt/sources.list
-				deb http://${DEBIAN_MIRROR} $release main contrib non-free
-				#deb-src http://${DEBIAN_MIRROR} $release main contrib non-free
+		sid | unstable)
+			distro="debian"
 
-				deb http://${DEBIAN_MIRROR} ${release}-updates main contrib non-free
-				#deb-src http://${DEBIAN_MIRROR} ${release}-updates main contrib non-free
-
-				deb http://${DEBIAN_MIRROR} ${release}-backports main contrib non-free
-				#deb-src http://${DEBIAN_MIRROR} ${release}-backports main contrib non-free
-
-				deb http://${DEBIAN_SECURTY} ${release}-security main contrib non-free
-				#deb-src http://${DEBIAN_SECURTY} ${release}-security main contrib non-free
-			EOF
-			;;
-
-		bookworm | trixie)
-			# non-free firmware in bookworm and later has moved from the non-free archive component to a new non-free-firmware component (alongside main/contrib/non-free). This was implemented on 2023-01-27, see also https://lists.debian.org/debian-boot/2023/01/msg00235.html
-			cat <<- EOF > "${basedir}"/etc/apt/sources.list
-				deb http://${DEBIAN_MIRROR} $release main contrib non-free non-free-firmware
-				#deb-src http://${DEBIAN_MIRROR} $release main contrib non-free non-free-firmware
-
-				deb http://${DEBIAN_MIRROR} ${release}-updates main contrib non-free non-free-firmware
-				#deb-src http://${DEBIAN_MIRROR} ${release}-updates main contrib non-free non-free-firmware
-
-				deb http://${DEBIAN_MIRROR} ${release}-backports main contrib non-free non-free-firmware
-				#deb-src http://${DEBIAN_MIRROR} ${release}-backports main contrib non-free non-free-firmware
-
-				deb http://${DEBIAN_SECURTY} ${release}-security main contrib non-free non-free-firmware
-				#deb-src http://${DEBIAN_SECURTY} ${release}-security main contrib non-free non-free-firmware
-			EOF
-			;;
-
-		sid | unstable) # sid is permanent unstable development and has no such thing as updates or security
-			cat <<- EOF > "${basedir}"/etc/apt/sources.list
-				deb http://${DEBIAN_MIRROR} $release main contrib non-free non-free-firmware
-				#deb-src http://${DEBIAN_MIRROR} $release main contrib non-free non-free-firmware
-
+			# sid is permanent unstable development and has no such thing as updates or security
+			cat <<- EOF > "${basedir}/etc/apt/sources.list.d/${distro}.sources"
+			Types: deb
+			URIs: http://${DEBIAN_MIRROR}
+			Suites: ${release}
+			Components: main contrib non-free non-free-firmware
+			Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 			EOF
 
-			# Exception: with riscv64 not everything was moved from ports
-			# https://lists.debian.org/debian-riscv/2023/07/msg00053.html
+			# Required for some packages on riscv64.
+			# See: http://lists.debian.org/debian-riscv/2023/07/msg00053.html
 			if [[ "${ARCH}" == riscv64 ]]; then
-				echo "deb http://deb.debian.org/debian-ports/ sid main " >> "${basedir}"/etc/apt/sources.list
+				cat <<- EOF >> "${basedir}/etc/apt/sources.list.d/${distro}.sources"
+
+				Types: deb
+				URIs: http://deb.debian.org/debian-ports/
+				Suites: ${release}
+				Components: main
+				Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+				Architectures: riscv64
+				EOF
 			fi
 			;;
 
 		focal | jammy | noble | oracular | plucky)
-			cat <<- EOF > "${basedir}"/etc/apt/sources.list
-				deb http://${UBUNTU_MIRROR} $release main restricted universe multiverse
-				#deb-src http://${UBUNTU_MIRROR} $release main restricted universe multiverse
+			distro="ubuntu"
 
-				deb http://${UBUNTU_MIRROR} ${release}-security main restricted universe multiverse
-				#deb-src http://${UBUNTU_MIRROR} ${release}-security main restricted universe multiverse
-
-				deb http://${UBUNTU_MIRROR} ${release}-updates main restricted universe multiverse
-				#deb-src http://${UBUNTU_MIRROR} ${release}-updates main restricted universe multiverse
-
-				deb http://${UBUNTU_MIRROR} ${release}-backports main restricted universe multiverse
-				#deb-src http://${UBUNTU_MIRROR} ${release}-backports main restricted universe multiverse
+			cat <<- EOF > "${basedir}/etc/apt/sources.list.d/${distro}.sources"
+			Types: deb
+			URIs: http://${UBUNTU_MIRROR}
+			Suites: ${release} ${release}-security ${release}-updates ${release}-backports
+			Components: main restricted universe multiverse
+			Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 			EOF
 			;;
 	esac
 
 	# add armbian key
-	display_alert "Adding Armbian repository and authentication key" "${when} :: /etc/apt/sources.list.d/armbian.list" "info"
+	display_alert "Adding Armbian repository and authentication key" "${when} :: /etc/apt/sources.list.d/armbian.sources" "info"
 	mkdir -p "${basedir}"/usr/share/keyrings
 	# change to binary form
 	APT_SIGNING_KEY_FILE="/usr/share/keyrings/armbian.gpg"
 	gpg --dearmor < "${SRC}"/config/armbian.key > "${basedir}${APT_SIGNING_KEY_FILE}"
-	SIGNED_BY="[signed-by=${APT_SIGNING_KEY_FILE}] "
 
 	# lets keep old way for old distributions
 	if [[ "${RELEASE}" =~ (focal|bullseye) ]]; then
@@ -170,6 +167,7 @@ function create_sources_list_and_deploy_repo_key() {
 		chroot "${basedir}" /bin/bash -c "cat armbian.key | apt-key add - > /dev/null 2>&1"
 	fi
 
+	# Add Armbian APT repository
 	declare -a components=()
 	if [[ "${when}" == "image"* ]]; then # only include the 'main' component when deploying to image (early or late)
 		components+=("main")
@@ -178,23 +176,31 @@ function create_sources_list_and_deploy_repo_key() {
 	components+=("${RELEASE}-desktop") # desktop contains packages Igor picks from other repos
 
 	# stage: add armbian repository and install key
-	if [[ $DOWNLOAD_MIRROR == "china" ]]; then
-		echo "deb ${SIGNED_BY}https://mirrors.tuna.tsinghua.edu.cn/armbian $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
+	# armbian_mirror="http://$([[ $BETA == yes ]] && echo "beta" || echo "apt").armbian.com"
+	declare armbian_mirror="apt.armbian.com"
+	if [[ -n $LOCAL_MIRROR ]]; then
+		armbian_mirror="$LOCAL_MIRROR"
+	elif [[ $DOWNLOAD_MIRROR == "china" ]]; then
+		armbian_mirror="mirrors.tuna.tsinghua.edu.cn/armbian"
 	elif [[ $DOWNLOAD_MIRROR == "bfsu" ]]; then
-		echo "deb ${SIGNED_BY}http://mirrors.bfsu.edu.cn/armbian $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
-	else
-		echo "deb ${SIGNED_BY}http://$([[ $BETA == yes ]] && echo "beta" || echo "apt").armbian.com $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
+		armbian_mirror="mirrors.bfsu.edu.cn/armbian"
+	elif [[ $BETA == "yes" ]]; then
+		armbian_mirror="beta.armbian.com"
 	fi
-
-	# replace local package server if defined. Suitable for development
-	[[ -n $LOCAL_MIRROR ]] && echo "deb ${SIGNED_BY}http://$LOCAL_MIRROR $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
+	cat <<- EOF > "${basedir}"/etc/apt/sources.list.d/armbian.sources
+	Types: deb
+	URIs: https://${armbian_mirror}
+	Suites: $RELEASE
+	Components: ${components[*]}
+	Signed-By: ${APT_SIGNING_KEY_FILE}
+	EOF
 
 	# disable repo if DISTRIBUTION_STATUS==eos, or if SKIP_ARMBIAN_REPO==yes, or if when==image-early.
 	if [[ "${when}" == "image-early" ||
 		"$(cat "${SRC}/config/distributions/${RELEASE}/support")" == "eos" ||
 		"${SKIP_ARMBIAN_REPO}" == "yes" ]]; then
 		display_alert "Disabling Armbian repo" "${ARCH}-${RELEASE} :: skip:${SKIP_ARMBIAN_REPO:-"no"} when:${when}" "info"
-		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
+		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled
 	fi
 
 	declare CUSTOM_REPO_WHEN="${when}"
@@ -202,9 +208,9 @@ function create_sources_list_and_deploy_repo_key() {
 	# Let user customize
 	call_extension_method "custom_apt_repo" <<- 'CUSTOM_APT_REPO'
 		*customize apt sources.list.d and/or deploy repo keys*
-		Called after core Armbian has finished setting up SDCARD's sources.list and sources.list.d/armbian.list.
-		If SKIP_ARMBIAN_REPO=yes, armbian.list.disabled is present instead.
-		The global Armbian GPG key has been deployed to SDCARD's /usr/share/keyrings/armbian.gpg, de-armored.
+		Called after core Armbian has finished setting up SDCARD's debian.sources/ubuntu.sources and armbian.sources in /etc/apt/sources.list.d/.
+		If SKIP_ARMBIAN_REPO=yes, armbian.sources.disabled is present instead.
+		The global Armbian GPG key has been deployed to SDCARD's ${APT_SIGNING_KEY_FILE}, de-armored.
 		You can implement this hook to add, remove, or modify sources.list.d entries, and/or deploy additional GPG keys.
 		Important: honor $CUSTOM_REPO_WHEN; if it's ==rootfs, don't add repos/components that carry the .debs produced by armbian/build.
 		Ideally, also don't add any possibly-conflicting repo if `$CUSTOM_REPO_WHEN==image-early`.


### PR DESCRIPTION
> This PR and the related PRs will require discussion or RFC before merging, particularly around handling migration of existing installations.

Replace `armbian.list` with `armbian.sources`. This holds the same information in a newer format, deb822. APT has supported this format since version 1.1, released in 2015.

This follows the migration of the [APT configuration for armbian-config](https://github.com/armbian/configng/pull/407) – `armbian-config.list` to `armbian-config.sources`.

There are some things to note:

- HTTP has been replaced with HTTPS for Armbian repositories since it was used for armbian-config.

- The previous configuration included commented-out `deb-src` lines. This PR effectively removes them, but one of the following equivalents could be added:

  ```
  Types: deb
  #Types: deb deb-src
  ```

  ```
  # Add " deb-src" to this line to include source packages.
  Types: deb
  ```

  As I interpret the documentation, the deb822 format only allows comments beginning at the start of a line, so the following is not valid.

  ```
  Types: deb #deb-src
  ```

- What was `sources.list` has been renamed to `debian.sources` or `ubuntu.sources`. Alternatively, this could be something more generic like `upstream.sources`.

- The new upstream repository configuration uses `Signed-By` to refer to signing keys:

  - Debian: `/usr/share/keyrings/debian-archive-keyring.gpg` from package `debian-archive-keyring`.

  - Ubuntu: `/usr/share/keyrings/ubuntu-archive-keyring.gpg` from package `ubuntu-keyring`.

- When generating a build for Debian "unstable", the APT configuration will now reference "unstable" rather than "sid" in the `Suites` field.

- The `Architectures` field is used for riscv64-specific packages in `debian.sources`. I think this means that the architecture check in the build script could be omitted at the cost of a bit of clutter in non-riscv64 images.

- I've made use of shell variables in `call_extension_method` in `distro-specific.sh`. Will this variable substitution work, or is this text extracted by reflection somehow?

References to `armbian.list` also exist in other repositories:

- armbian/autotests
- armbian/actions
- armbian/configng: https://github.com/armbian/configng/pull/423
- armbian/documentation: https://github.com/armbian/documentation/pull/619
- armbian/scripts: https://github.com/armbian/scripts/pull/84

Related documentation: [deb822](https://manpages.debian.org/bookworm/dpkg-dev/deb822.5.en.html)

Related PRs:
- https://github.com/armbian/build/pull/7782
- https://github.com/armbian/configng/pull/407
- https://github.com/armbian/documentation/pull/616

## Testing

The following script can be saved in `./lib/functions/rootfs/`. Running it will generate a directory called `test` containing `.list` or `.sources` files, depending on whether this PR has been applied or not. Uncomment the second `ARCH` line to test the riscv64-specific configuration.

**Important:** Add `return` before `image-early` line in `distro-specific.sh` before running this script.

```sh
# test-create_sources_list_and_deploy_repo_key.sh

source distro-specific.sh

DEBIAN_MIRROR="deb.debian.org/debian"
DEBIAN_SECURTY="security.debian.org/"
UBUNTU_MIRROR="archive.ubuntu.com/ubuntu/"
ARCH="amd64"
# ARCH="riscv64"

mkdir -p ./test

for release in buster bullseye bookworm trixie sid unstable focal jammy noble oracular plucky; do
  mkdir -p ./test/$release/etc/apt
  create_sources_list_and_deploy_repo_key "" "$release" ./test/$release
  mv ./test/$release/etc/apt/*.list ./test/$release.list \
    || true > /dev/null
  mv ./test/$release/etc/apt/*.sources ./test/$release.sources \
    || true > /dev/null
done
```

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
