### PR TITLE
IMX8: switch u-boot sources to last known working commit 

### DIFF
--- a/config/sources/families/imx8m.conf
+++ b/config/sources/families/imx8m.conf
@@ -24,6 +24,7 @@ case $BOARD in
 		ATFBRANCH="branch:TQM-lf_v2.10"
 		BOOTSOURCE='https://github.com/tq-systems/u-boot-tqmaxx.git' # u-boot mainlining is hard and has low-priority
 		BOOTBRANCH='branch:TQMa8-v2020.04_imx_5.4.70_2.3.0'
+		BOOTBRANCH='commit:673acba389cfe6c9e8639e8009fc9403492f5061'
 		BOOTPATCHDIR="u-boot-tqma" # could be removed when distro boot patches are integrated
 		;;
 esac


### PR DESCRIPTION
# Description

Fixing broken compilation Due to upstream changes.

@schmiedelm Remove commit id once it works.

# How Has This Been Tested?

- [x] CI build

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
