### PR TITLE
ssv6051 and panel-dsi-simple driver patch for kernel 6.6, 6.9, 6.12 and 6.13

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/general-add-panel-simple-dsi.patch
+++ b/patch/kernel/archive/rockchip64-6.12/general-add-panel-simple-dsi.patch
@@ -388,7 +388,7 @@ index 000000000000..111111111111
 +	if (!mode)
 +		return 0;
 +
-+	ret = of_get_drm_display_mode(panel->dev->of_node, mode, p->desc->bus_format,
++	ret = of_get_drm_display_mode(panel->dev->of_node, mode, &p->desc->bus_format,
 +				      OF_USE_NATIVE_MODE);
 +	if (ret) {
 +		dev_dbg(panel->dev, "failed to find dts display timings\n");

--- a/patch/kernel/archive/rockchip64-6.12/wifi-4003-ssv-6051-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.12/wifi-4003-ssv-6051-driver.patch
@@ -118,8 +118,8 @@ index 000000000000..111111111111
 +include $(src)/platform-config.mak
 +
 +ccflags-y += \
-+	-I $(srctree)/$(src) \
-+        -I $(srctree)/$(src)/include
++	-I $(src) \
++        -I $(src)/include
 +
 +obj-$(CONFIG_SSV6051) += ssv6051.o
 +ssv6051-objs += \

--- a/patch/kernel/archive/rockchip64-6.13/general-add-panel-simple-dsi.patch
+++ b/patch/kernel/archive/rockchip64-6.13/general-add-panel-simple-dsi.patch
@@ -388,7 +388,7 @@ index 000000000000..111111111111
 +	if (!mode)
 +		return 0;
 +
-+	ret = of_get_drm_display_mode(panel->dev->of_node, mode, p->desc->bus_format,
++	ret = of_get_drm_display_mode(panel->dev->of_node, mode, &p->desc->bus_format,
 +				      OF_USE_NATIVE_MODE);
 +	if (ret) {
 +		dev_dbg(panel->dev, "failed to find dts display timings\n");

--- a/patch/kernel/archive/rockchip64-6.13/wifi-4003-ssv-6051-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.13/wifi-4003-ssv-6051-driver.patch
@@ -118,8 +118,8 @@ index 000000000000..111111111111
 +include $(src)/platform-config.mak
 +
 +ccflags-y += \
-+	-I $(srctree)/$(src) \
-+        -I $(srctree)/$(src)/include
++	-I $(src) \
++        -I $(src)/include
 +
 +obj-$(CONFIG_SSV6051) += ssv6051.o
 +ssv6051-objs += \

--- a/patch/kernel/archive/rockchip64-6.6/general-add-panel-simple-dsi.patch
+++ b/patch/kernel/archive/rockchip64-6.6/general-add-panel-simple-dsi.patch
@@ -388,7 +388,7 @@ index 000000000000..e3c8dcf8cb5e
 +	if (!mode)
 +		return 0;
 +
-+	ret = of_get_drm_display_mode(panel->dev->of_node, mode, p->desc->bus_format,
++	ret = of_get_drm_display_mode(panel->dev->of_node, mode, &p->desc->bus_format,
 +				      OF_USE_NATIVE_MODE);
 +	if (ret) {
 +		dev_dbg(panel->dev, "failed to find dts display timings\n");

--- a/patch/kernel/archive/rockchip64-6.6/wifi-4003-ssv-6051-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.6/wifi-4003-ssv-6051-driver.patch
@@ -118,8 +118,8 @@ index 000000000000..985d730f3d50
 +include $(src)/platform-config.mak
 +
 +ccflags-y += \
-+	-I $(srctree)/$(src) \
-+        -I $(srctree)/$(src)/include
++	-I $(src) \
++        -I $(src)/include
 +
 +obj-$(CONFIG_SSV6051) += ssv6051.o
 +ssv6051-objs += \

--- a/patch/kernel/archive/rockchip64-6.9/general-add-panel-simple-dsi.patch
+++ b/patch/kernel/archive/rockchip64-6.9/general-add-panel-simple-dsi.patch
@@ -388,7 +388,7 @@ index 000000000000..e3c8dcf8cb5e
 +	if (!mode)
 +		return 0;
 +
-+	ret = of_get_drm_display_mode(panel->dev->of_node, mode, p->desc->bus_format,
++	ret = of_get_drm_display_mode(panel->dev->of_node, mode, &p->desc->bus_format,
 +				      OF_USE_NATIVE_MODE);
 +	if (ret) {
 +		dev_dbg(panel->dev, "failed to find dts display timings\n");

--- a/patch/kernel/archive/rockchip64-6.9/wifi-4003-ssv-6051-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.9/wifi-4003-ssv-6051-driver.patch
@@ -176,8 +176,8 @@ index 000000000000..985d730f3d50
 +include $(src)/platform-config.mak
 +
 +ccflags-y += \
-+	-I $(srctree)/$(src) \
-+        -I $(srctree)/$(src)/include
++	-I $(src) \
++        -I $(src)/include
 +
 +obj-$(CONFIG_SSV6051) += ssv6051.o
 +ssv6051-objs += \


### PR DESCRIPTION
# Description

patch for ssv6051 fix build failure on nix sandbox.
patch for panel-dsi-simple fix build failure with gcc14. 

Both patch are tested on kernel 6.12 and 6.13 and should work for 6.6 and 6.9 due to unchanged api.
