### PR TITLE
hinlink-h88k: fix usb dr_mode

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
@@ -126,6 +126,36 @@
 		vin-supply = <&vcc12v_dcin>;
 	};
 
+	/* it's modem reset pin */
+	modem_enable: modem-enable {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		regulator-always-on;
+		regulator-boot-on;
+		gpios = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-name = "modem-enable";
+		vin-supply = <&vcc_3v3_s3>;
+		startup-delay-us = <500000>;
+		pinctrl-names = "default";
+		pintctrl-0 = <&modem_reset_en>;
+	};
+
+	vcc3v3_modem: vcc3v3-modem {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		regulator-always-on;
+		regulator-boot-on;
+		gpios = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-name = "vcc3v3_modem";
+		pinctrl-names = "default";
+		pintctrl-0 = <&modem_power_en>;
+		vin-supply = <&vcc_3v3_s3>;
+	};
+
 	vcc5v0_host: vcc5v0-host-regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc5v0_host";
@@ -410,6 +440,16 @@
 
 		led_work_en: led_work_en {
 			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	modem {
+		modem_power_en: modem-power-en {
+			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		modem_reset_en: modem-reset-en {
+			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 

--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
@@ -849,6 +849,7 @@
 };
 
 &usb_host1_xhci {
+	dr_mode = "host";
 	status = "okay";
 };
 

--- a/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
@@ -126,6 +126,36 @@
 		vin-supply = <&vcc12v_dcin>;
 	};
 
+	/* it's modem reset pin */
+	modem_enable: modem-enable {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		regulator-always-on;
+		regulator-boot-on;
+		gpios = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-name = "modem-enable";
+		vin-supply = <&vcc_3v3_s3>;
+		startup-delay-us = <500000>;
+		pinctrl-names = "default";
+		pintctrl-0 = <&modem_reset_en>;
+	};
+
+	vcc3v3_modem: vcc3v3-modem {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		regulator-always-on;
+		regulator-boot-on;
+		gpios = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-name = "vcc3v3_modem";
+		pinctrl-names = "default";
+		pintctrl-0 = <&modem_power_en>;
+		vin-supply = <&vcc_3v3_s3>;
+	};
+
 	vcc5v0_host: vcc5v0-host-regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc5v0_host";
@@ -410,6 +440,16 @@
 
 		led_work_en: led_work_en {
 			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	modem {
+		modem_power_en: modem-power-en {
+			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		modem_reset_en: modem-reset-en {
+			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 

--- a/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
@@ -849,6 +849,7 @@
 };
 
 &usb_host1_xhci {
+	dr_mode = "host";
 	status = "okay";
 };
 


### PR DESCRIPTION
hinlink-h88k have two two usb_xhci port, namely usb_xhci0 (type C port) and usb_xhci1 (type A port).
We should set usb_xhci1.dr_mode = "host" to connect to GL3523 usb hub, then 5G modem and other usb peripheral devices.
usb_xhci0 (type C port) requires driver for "husb311" which is not available in mainline kernel, We can just leave it disabled.

The second patch add 5g modem enable and reset pin so as to use it.