### PR TITLE
rk35xx: Bump Radxa vendor U-Boot to branch:next-dev-v2024.10

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -10,7 +10,7 @@
 source "${BASH_SOURCE%/*}/include/rockchip64_common.inc"
 
 BOOTSOURCE='https://github.com/radxa/u-boot.git'
-BOOTBRANCH='branch:next-dev-v2024.03' # Always use same version as rk3588, they share a patch dir
+BOOTBRANCH='branch:next-dev-v2024.10' # Always use same version as rk3588, they share a patch dir
 BOOTPATCHDIR="legacy/u-boot-radxa-rk35xx"
 OVERLAY_PREFIX='rk35xx'
 


### PR DESCRIPTION
# Description

This is the current actively maintained branch of radxa. 
And contains some critical fixes for the Rock 2 series: https://github.com/radxa/u-boot/pull/113/commits.

# How Has This Been Tested?

- [x] Build the rock 2a image and successfully boot with it.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
