### PR TITLE
firstlogin: bring up wifi device before scanning

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -301,6 +301,8 @@ set_timezone_and_locales() {
 					WIFI_DEVICE=$(echo ${WIFI_DEVICES[$input-1]} | cut -d"," -f2)
 				fi
 
+				# bring up wifi device (not done by networkd, only by NetworkManager)
+				ip link set ${WIFI_DEVICE} up
 				# get list of wireless networks
 				scanning=0
 				broken=1


### PR DESCRIPTION
# Description

Firstlogin on a *minimal* image is not able to configure and use wifi.
(Server and desktop images work OK, as they have NetworkManager installed.)

Scanning accesspoints requires an activated wifi device.
An unconfigured networkd does not activate it (only NetworkManager does so).
As a result, firstlogin fails to scan for APs and skips setting up timezone and locales.
Activating the wifi device using `ip link set ${WIFI_DEVICE} up` before scanning fixes this.
(And can safely be done - there is no problem activating it multiple times, like it is the case with NetworkManager installed.)

# How Has This Been Tested?
- [X] Initiated AP scan with deactivated wifi: `command failed: Network is down (-100)`
- [X] Activated an already active wifi device multiple times: No error.
- [X] Initiated AP scan with activated wifi: No error.
- [X] Built minimal image with modified armbian-firstlogin: Wifi is usable
- [X] Replaced armbian-firstlogin in server image before booting: Wifi is usable

Both images (with and without NetworkManager) were able to bring up and use wifi during armbian-firstlogin without any errors.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
