### PR TITLE
Revert commit that breaks compilation

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/board-rocks0-0001-Revert-arm64-dts-rockchip-Fix-sdmmc-access-on-rk3308.patch
+++ b/patch/kernel/archive/rockchip64-6.12/board-rocks0-0001-Revert-arm64-dts-rockchip-Fix-sdmmc-access-on-rk3308.patch
@@ -1,0 +1,64 @@
+From 78c6d6c875dc82ab1f595dac580dcfe705923234 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor@armbian.com>
+Date: Sat, 8 Feb 2025 17:54:03 +0100
+Subject: [PATCH 1/1] Revert "arm64: dts: rockchip: Fix sdmmc access on
+ rk3308-rock-s0 v1.1 boards"
+
+This reverts commit 8810a8368b6075595715c4231322ca906a6b2f6f.
+---
+ .../boot/dts/rockchip/rk3308-rock-s0.dts      | 25 +------------------
+ 1 file changed, 1 insertion(+), 24 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts b/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts
+index 8311af4c8689..bd6419a5c20a 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts
+@@ -74,23 +74,6 @@ vcc_io: regulator-3v3-vcc-io {
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+-	/*
+-	 * HW revision prior to v1.2 must pull GPIO4_D6 low to access sdmmc.
+-	 * This is modeled as an always-on active low fixed regulator.
+-	 */
+-	vcc_sd: regulator-3v3-vcc-sd {
+-		compatible = "regulator-fixed";
+-		gpios = <&gpio4 RK_PD6 GPIO_ACTIVE_LOW>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&sdmmc_2030>;
+-		regulator-name = "vcc_sd";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		vin-supply = <&vcc_io>;
+-	};
+-
+ 	vcc5v0_sys: regulator-5v0-vcc-sys {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_sys";
+@@ -198,12 +181,6 @@ pwr_led: pwr-led {
+ 		};
+ 	};
+ 
+-	sdmmc {
+-		sdmmc_2030: sdmmc-2030 {
+-			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+ 	wifi {
+ 		wifi_reg_on: wifi-reg-on {
+ 			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
+@@ -256,7 +233,7 @@ &sdmmc {
+ 	cap-mmc-highspeed;
+ 	cap-sd-highspeed;
+ 	disable-wp;
+-	vmmc-supply = <&vcc_sd>;
++	vmmc-supply = <&vcc_io>;
+ 	status = "okay";
+ };
+ 
+-- 
+2.43.0
+

--- a/patch/kernel/archive/rockchip64-6.13/board-rocks0-0001-Revert-arm64-dts-rockchip-Fix-sdmmc-access-on-rk3308.patch
+++ b/patch/kernel/archive/rockchip64-6.13/board-rocks0-0001-Revert-arm64-dts-rockchip-Fix-sdmmc-access-on-rk3308.patch
@@ -1,0 +1,64 @@
+From 78c6d6c875dc82ab1f595dac580dcfe705923234 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor@armbian.com>
+Date: Sat, 8 Feb 2025 17:54:03 +0100
+Subject: [PATCH 1/1] Revert "arm64: dts: rockchip: Fix sdmmc access on
+ rk3308-rock-s0 v1.1 boards"
+
+This reverts commit 8810a8368b6075595715c4231322ca906a6b2f6f.
+---
+ .../boot/dts/rockchip/rk3308-rock-s0.dts      | 25 +------------------
+ 1 file changed, 1 insertion(+), 24 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts b/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts
+index 8311af4c8689..bd6419a5c20a 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts
+@@ -74,23 +74,6 @@ vcc_io: regulator-3v3-vcc-io {
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+-	/*
+-	 * HW revision prior to v1.2 must pull GPIO4_D6 low to access sdmmc.
+-	 * This is modeled as an always-on active low fixed regulator.
+-	 */
+-	vcc_sd: regulator-3v3-vcc-sd {
+-		compatible = "regulator-fixed";
+-		gpios = <&gpio4 RK_PD6 GPIO_ACTIVE_LOW>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&sdmmc_2030>;
+-		regulator-name = "vcc_sd";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		vin-supply = <&vcc_io>;
+-	};
+-
+ 	vcc5v0_sys: regulator-5v0-vcc-sys {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_sys";
+@@ -198,12 +181,6 @@ pwr_led: pwr-led {
+ 		};
+ 	};
+ 
+-	sdmmc {
+-		sdmmc_2030: sdmmc-2030 {
+-			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+ 	wifi {
+ 		wifi_reg_on: wifi-reg-on {
+ 			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
+@@ -256,7 +233,7 @@ &sdmmc {
+ 	cap-mmc-highspeed;
+ 	cap-sd-highspeed;
+ 	disable-wp;
+-	vmmc-supply = <&vcc_sd>;
++	vmmc-supply = <&vcc_io>;
+ 	status = "okay";
+ };
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
# Description

There were upstream changes that are related to board Rockpi S0, rev. 1.2 which breaks our patch. This needs deeper analysis and testing, so lets revert to known situation so compilation from main on rockchip64 moves on.

@brentr Check when you can and remove this revert patch once fixed.

# How Has This Been Tested?

- [x] CI test

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
