### PR TITLE
linux-image: provide wireguard-modules

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -262,7 +262,7 @@ function kernel_package_callback_linux_image() {
 		Maintainer: ${MAINTAINER} <${MAINTAINERMAIL}>
 		Section: kernel
 		Priority: optional
-		Provides: linux-image, linux-image-armbian, armbian-$BRANCH
+		Provides: linux-image, linux-image-armbian, armbian-$BRANCH, wireguard-modules
 		Description: Armbian Linux $BRANCH kernel image $kernel_version_family
 		 This package contains the Linux kernel, modules and corresponding other files.
 		 ${artifact_version_reason:-"${kernel_version_family}"}


### PR DESCRIPTION
# Description

I'm trying to generate a debian iso with armbian's kernel, but live-build keep installing linux-image-rt-arm64. I find it as rec dependency of wireguard-tools. And both linux-image-rt-arm64 from debian and linux-image-generic from ubuntu are providing it.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=rock-5b BRANCH=vendor DEB_COMPRESS=xz`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
