### PR TITLE
rockchip64: fix rocks0 patch breaking current compilation

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/board-rocks0-0001-deviceTree.patch
+++ b/patch/kernel/archive/rockchip64-6.12/board-rocks0-0001-deviceTree.patch
@@ -1,15 +1,16 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Brent Roman <genosenosor@gmail.com>
-Date: Wed, 7 Feb 2024 18:02:07 -0800
-Subject: Added Linux device tree for Rock S0
+From fd50c186b02442b59790c1a31fc4f10f542e22d6 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 9 Feb 2025 21:48:44 +0100
+Subject: [PATCH] Added Linux device tree for Rock S0
 
-Signed-off-by: Brent Roman <genosenosor@gmail.com>
+ * original author Brent Roman <genosenosor@gmail.com>, reworked
+   for kernel 6.12.13 by Paolo Sabatino <paolo.sabatino@gmail.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts | 346 ++++++----
- 1 file changed, 200 insertions(+), 146 deletions(-)
+ .../boot/dts/rockchip/rk3308-rock-s0.dts      | 338 +++++++++++-------
+ 1 file changed, 199 insertions(+), 139 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts b/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts
-index 111111111111..222222222222 100644
+index 8311af4c8689..58eacc68fc61 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3308-rock-s0.dts
 @@ -1,21 +1,17 @@
@@ -106,8 +107,9 @@ index 111111111111..222222222222 100644
 +				sound-dai = <&pcm5102a>;
 +			};
 +		};
-+	};
-+
+ 	};
+ 
+-	vcc_1v8: regulator-1v8-vcc {
 +	pcm5102a: pcm5102a {
 +			#sound-dai-cells = <0>;
 +			compatible = "ti,pcm5102a";
@@ -125,9 +127,8 @@ index 111111111111..222222222222 100644
 +		 * - PDN (power down when low)
 +		 */
 +		reset-gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_LOW>;
- 	};
- 
--	vcc_1v8: regulator-1v8-vcc {
++	};
++
 +	vcc_1v8: vcc-1v8 {
  		compatible = "regulator-fixed";
  		regulator-name = "vcc_1v8";
@@ -141,8 +142,8 @@ index 111111111111..222222222222 100644
  		compatible = "regulator-fixed";
  		regulator-name = "vcc_io";
  		regulator-always-on;
-@@ -74,7 +102,28 @@ vcc_io: regulator-3v3-vcc-io {
- 		vin-supply = <&vcc5v0_sys>;
+@@ -91,7 +119,28 @@ vcc_sd: regulator-3v3-vcc-sd {
+ 		vin-supply = <&vcc_io>;
  	};
  
 -	vcc5v0_sys: regulator-5v0-vcc-sys {
@@ -171,7 +172,7 @@ index 111111111111..222222222222 100644
  		compatible = "regulator-fixed";
  		regulator-name = "vcc5v0_sys";
  		regulator-always-on;
-@@ -83,119 +132,150 @@ vcc5v0_sys: regulator-5v0-vcc-sys {
+@@ -100,24 +149,46 @@ vcc5v0_sys: regulator-5v0-vcc-sys {
  		regulator-max-microvolt = <5000000>;
  	};
  
@@ -181,14 +182,12 @@ index 111111111111..222222222222 100644
  		pwms = <&pwm0 0 5000 1>;
  		pwm-supply = <&vcc5v0_sys>;
  		regulator-name = "vdd_core";
--		regulator-always-on;
--		regulator-boot-on;
+ 		regulator-always-on;
+ 		regulator-boot-on;
++		regulator-init-microvolt = <1015000>;
  		regulator-min-microvolt = <827000>;
  		regulator-max-microvolt = <1340000>;
-+		regulator-init-microvolt = <1015000>;
  		regulator-settling-time-up-us = <250>;
-+		regulator-always-on;
-+		regulator-boot-on;
  	};
  
 -	sdio_pwrseq: sdio-pwrseq {
@@ -216,28 +215,28 @@ index 111111111111..222222222222 100644
 -		reset-gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_LOW>;
 +		regulator-name = "board_antenna";
  	};
- };
- 
++
++};
++
 +&codec {
 +	status = "okay";
 +	#sound-dai-cells = <0>;
-+};
-+
- &cpu0 {
- 	cpu-supply = <&vdd_core>;
  };
+ 
+ &cpu0 {
+@@ -126,75 +197,84 @@ &cpu0 {
  
  &emmc {
  	cap-mmc-highspeed;
 -	no-sd;
 -	no-sdio;
-+	mmc-hs200-1_8v;
  	non-removable;
 -	pinctrl-names = "default";
 -	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_pwren>;
 -	vmmc-supply = <&vcc_io>;
-+	vmmc-supply = <&vcc_io>;  //was vin-supply
-+        status = "okay";
++	mmc-hs200-1_8v;
++	vmmc-supply = <&vcc_io>; //was vin-supply
++	status = "okay";
 +};
 +
 +&sdmmc {
@@ -271,10 +270,9 @@ index 111111111111..222222222222 100644
 +};
 +
  &gmac {
--	clock_in_out = "output";
+ 	clock_in_out = "output";
 -	phy-handle = <&rtl8201f>;
  	phy-supply = <&vcc_io>;
-+	clock_in_out = "output";
 +	assigned-clocks = <&cru SCLK_MAC>;
 +	assigned-clock-parents = <&cru SCLK_MAC_SRC>;
 +	snps,reset-gpio = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
@@ -356,6 +354,9 @@ index 111111111111..222222222222 100644
  		};
  	};
  
+@@ -205,14 +285,21 @@ sdmmc_2030: sdmmc-2030 {
+ 	};
+ 
  	wifi {
 -		wifi_reg_on: wifi-reg-on {
 -			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
@@ -363,25 +364,21 @@ index 111111111111..222222222222 100644
 +			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
  		};
  
--		wifi_wake_host: wifi-wake-host {
--			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
-+	};
+ 		wifi_wake_host: wifi-wake-host {
+ 			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
+ 		};
+ 	};
++
 +	antenna {
 +		ant_1: ant-1 {
 +			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_down>;
- 		};
- 	};
++		};
++	};
++
  };
  
  &pwm0 {
--	pinctrl-names = "default";
--	pinctrl-0 = <&pwm0_pin_pull_down>;
- 	status = "okay";
-+	pinctrl-0 = <&pwm0_pin_pull_down>;
- };
- 
- &saradc {
-@@ -203,91 +283,65 @@ &saradc {
+@@ -226,88 +313,61 @@ &saradc {
  	status = "okay";
  };
  
@@ -418,7 +415,7 @@ index 111111111111..222222222222 100644
 -	cap-mmc-highspeed;
 -	cap-sd-highspeed;
 -	disable-wp;
--	vmmc-supply = <&vcc_io>;
+-	vmmc-supply = <&vcc_sd>;
 +&i2c1 {
  	status = "okay";
  };
@@ -497,10 +494,6 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
- &wdt {
- 	status = "okay";
- };
-+
 -- 
-Armbian
+2.43.0
 


### PR DESCRIPTION
# Description

A patch that reworks rocks0 board has been reworked as well to compile on kernel 6.12.13.
@brentr I just did a quick rework of the patch, but cannot test if it is resulting in a working device or not. Perhaps it would be better, in the future, to rewrite the patch to fit the changes on top of the mainline kernel device tree?

# How Has This Been Tested?

- [x] Compiled rockchip64 current kernel without errors

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
