### PR TITLE
extensions: fix outdated ghproxy mirror address

### DIFF
--- a/extensions/bcmdhd.sh
+++ b/extensions/bcmdhd.sh
@@ -18,7 +18,7 @@ function post_install_kernel_debs__install_bcmdhd_dkms_package() {
 	bcmdhd_sdio_url="https://github.com/armbian/bcmdhd-dkms/releases/download/${latest_version}/bcmdhd-sdio-dkms_${latest_version}_all.deb"
 	bcmdhd_usb_url="https://github.com/armbian/bcmdhd-dkms/releases/download/${latest_version}/bcmdhd-usb-dkms_${latest_version}_all.deb"
 	if [[ "${GITHUB_MIRROR}" == "ghproxy" ]]; then
-		ghproxy_header="https://mirror.ghproxy.com/"
+		ghproxy_header="https://ghfast.top/"
 		bcmdhd_pcie_url=${ghproxy_header}${bcmdhd_pcie_url}
 		bcmdhd_sdio_url=${ghproxy_header}${bcmdhd_sdio_url}
 		bcmdhd_usb_url=${ghproxy_header}${bcmdhd_usb_url}

--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -23,7 +23,7 @@ function post_install_kernel_debs__install_aic8800_dkms_package() {
 	aic8800_sdio_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-sdio-dkms_${latest_version}_all.deb"
 	aic8800_usb_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-usb-dkms_${latest_version}_all.deb"
 	if [[ "${GITHUB_MIRROR}" == "ghproxy" ]]; then
-		ghproxy_header="https://mirror.ghproxy.com/"
+		ghproxy_header="https://ghfast.top/"
 		aic8800_firmware_url=${ghproxy_header}${aic8800_firmware_url}
 		aic8800_pcie_url=${ghproxy_header}${aic8800_pcie_url}
 		aic8800_sdio_url=${ghproxy_header}${aic8800_sdio_url}


### PR DESCRIPTION
# Description

We have updated ghproxy address by f4457a3df56fccd5701f259336e4aa395b13305f, but the address in wifi extension is missing. Update it.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
