### PR TITLE
MBa8MPxL update uboot patch and fix firmware installation

### DIFF
--- a/config/boards/mba8mpxl-ras314.conf
+++ b/config/boards/mba8mpxl-ras314.conf
@@ -19,7 +19,7 @@ function post_family_tweaks_bsp__mba8mpxl-ras314() {
 	wget https://github.com/nxp-imx/imx-firmware/raw/lf-6.6.3_1.0.0/nxp/FwImage_8997/pcieuart8997_combo_v4.bin
 	run_host_command_logged mkdir -pv --mode=755 "$destination/lib/firmware/" || exit_with_error "Unable to mkdir firmware"
 	run_host_command_logged mkdir -v --mode=775 "$destination/lib/firmware/mrvl/" || exit_with_error "Unable to mkdir mrvl"
-	run_host_command_logged cp -Pv "pcieuart8997_combo_v4.bin" "$destination/lib/firmware/mrvl/" || exit_with_error "Unable to copy mrvl firmware"
+	run_host_command_logged mv -v "pcieuart8997_combo_v4.bin" "$destination/lib/firmware/mrvl/" || exit_with_error "Unable to copy mrvl firmware"
 
 	# Add udev rule to delay btnxpuart loading
 	cat <<- NXP_UDEV_RULE > "${destination}"/etc/udev/rules.d/10-nxp-bluetooth-delay.rules

--- a/config/sources/families/imx8m.conf
+++ b/config/sources/families/imx8m.conf
@@ -24,7 +24,6 @@ case $BOARD in
 		ATFBRANCH="branch:TQM-lf_v2.10"
 		BOOTSOURCE='https://github.com/tq-systems/u-boot-tqmaxx.git' # u-boot mainlining is hard and has low-priority
 		BOOTBRANCH='branch:TQMa8-v2020.04_imx_5.4.70_2.3.0'
-		BOOTBRANCH='commit:673acba389cfe6c9e8639e8009fc9403492f5061'
 		BOOTPATCHDIR="u-boot-tqma" # could be removed when distro boot patches are integrated
 		;;
 esac

--- a/patch/u-boot/u-boot-tqma/0001-tqma8-enable-distro-boot.patch
+++ b/patch/u-boot/u-boot-tqma/0001-tqma8-enable-distro-boot.patch
@@ -1,14 +1,14 @@
-From e04dcf9f512273afd43b014db110e5823a5869e6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 Date: Mon, 9 Oct 2023 09:50:48 +0200
-Subject: [PATCH] tqma8: enable distro boot
+Subject: tqma8: enable distro boot
 
 Signed-off-by: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 ---
  board/tqc/common/Kconfig                    |   4 +
  board/tqc/common/Makefile                   |   1 +
  board/tqc/common/tqc_bb.h                   |   6 +
- board/tqc/common/tqc_distro.c               |  37 +++
+ board/tqc/common/tqc_distro.c               |  37 ++
  board/tqc/tqma8mpxl/tqma8mpxl.c             |   5 +-
  board/tqc/tqma8mx/tqma8mx.c                 |   5 +-
  board/tqc/tqma8mxml/tqma8mxml.c             |   5 +-
@@ -23,17 +23,14 @@ Signed-off-by: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
  configs/tqma8mxml_4gb_mba8mx_mmc_defconfig  |   1 -
  configs/tqma8mxnl_1gb_mba8mx_defconfig      |   1 -
  configs/tqma8mxnl_1gb_mba8mx_mfg_defconfig  |   1 -
- doc/board/tq/examples/boot-legacy.cmd       |  26 ++
+ doc/board/tq/examples/boot-legacy.cmd       |  26 +
  include/configs/tqma8mxml-mba8mx.h          |  11 +-
- include/configs/tqma8mxml.h                 | 256 ++++----------------
- include/environment/tq/boot.h               |  21 ++
+ include/configs/tqma8mxml.h                 | 256 ++--------
+ include/environment/tq/boot.h               |  21 +
  22 files changed, 167 insertions(+), 221 deletions(-)
- create mode 100644 board/tqc/common/tqc_distro.c
- create mode 100644 doc/board/tq/examples/boot-legacy.cmd
- create mode 100644 include/environment/tq/boot.h
 
 diff --git a/board/tqc/common/Kconfig b/board/tqc/common/Kconfig
-index 7f60d0b686..a34a2cf300 100644
+index 111111111111..222222222222 100644
 --- a/board/tqc/common/Kconfig
 +++ b/board/tqc/common/Kconfig
 @@ -16,6 +16,10 @@ config TQC_ENVLOC
@@ -48,7 +45,7 @@ index 7f60d0b686..a34a2cf300 100644
  	bool
  
 diff --git a/board/tqc/common/Makefile b/board/tqc/common/Makefile
-index 1640cc9cd2..1d04d94aad 100644
+index 111111111111..222222222222 100644
 --- a/board/tqc/common/Makefile
 +++ b/board/tqc/common/Makefile
 @@ -24,6 +24,7 @@ obj-$(CONFIG_TQC_EMMC) += tqc_emmc.o
@@ -60,7 +57,7 @@ index 1640cc9cd2..1d04d94aad 100644
  obj-$(CONFIG_TQC_VARD) += tq_som_features.o
  obj-$(CONFIG_TQC_SPI_NOR) += tqc_spi_nor.o
 diff --git a/board/tqc/common/tqc_bb.h b/board/tqc/common/tqc_bb.h
-index a6dfc1ab97..e9e1415eb3 100644
+index 111111111111..222222222222 100644
 --- a/board/tqc/common/tqc_bb.h
 +++ b/board/tqc/common/tqc_bb.h
 @@ -64,4 +64,10 @@ int tqc_pcf85063_set_clkout(int bus, int address, uint8_t clkout);
@@ -76,7 +73,7 @@ index a6dfc1ab97..e9e1415eb3 100644
  #endif
 diff --git a/board/tqc/common/tqc_distro.c b/board/tqc/common/tqc_distro.c
 new file mode 100644
-index 0000000000..fc525e24c6
+index 000000000000..111111111111
 --- /dev/null
 +++ b/board/tqc/common/tqc_distro.c
 @@ -0,0 +1,37 @@
@@ -118,7 +115,7 @@ index 0000000000..fc525e24c6
 +	env_set("boot_targets", boot_devtype);
 +}
 diff --git a/board/tqc/tqma8mpxl/tqma8mpxl.c b/board/tqc/tqma8mpxl/tqma8mpxl.c
-index bc34c07e84..9077c6cea1 100644
+index 111111111111..222222222222 100644
 --- a/board/tqc/tqma8mpxl/tqma8mpxl.c
 +++ b/board/tqc/tqma8mpxl/tqma8mpxl.c
 @@ -294,9 +294,12 @@ int board_late_init(void)
@@ -136,7 +133,7 @@ index bc34c07e84..9077c6cea1 100644
  
  	return 0;
 diff --git a/board/tqc/tqma8mx/tqma8mx.c b/board/tqc/tqma8mx/tqma8mx.c
-index 25748d4901..8fcd38b5eb 100644
+index 111111111111..222222222222 100644
 --- a/board/tqc/tqma8mx/tqma8mx.c
 +++ b/board/tqc/tqma8mx/tqma8mx.c
 @@ -219,9 +219,12 @@ int board_late_init(void)
@@ -154,10 +151,10 @@ index 25748d4901..8fcd38b5eb 100644
  }
  
 diff --git a/board/tqc/tqma8mxml/tqma8mxml.c b/board/tqc/tqma8mxml/tqma8mxml.c
-index 18c04aded2..1ff4dbea4f 100644
+index 111111111111..222222222222 100644
 --- a/board/tqc/tqma8mxml/tqma8mxml.c
 +++ b/board/tqc/tqma8mxml/tqma8mxml.c
-@@ -223,9 +223,12 @@ int board_late_init(void)
+@@ -179,9 +179,12 @@ int board_late_init(void)
  
  #ifdef CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
  	env_set("board_name", tqc_bb_get_boardname());
@@ -172,7 +169,7 @@ index 18c04aded2..1ff4dbea4f 100644
  }
  
 diff --git a/configs/tqma8mxml_1gb_mba8mx_fspi_defconfig b/configs/tqma8mxml_1gb_mba8mx_fspi_defconfig
-index 141b273a4e..a8bab81a07 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mxml_1gb_mba8mx_fspi_defconfig
 +++ b/configs/tqma8mxml_1gb_mba8mx_fspi_defconfig
 @@ -8,7 +8,6 @@ CONFIG_TQMA8MXX_BOOT_FSPI=y
@@ -184,7 +181,7 @@ index 141b273a4e..a8bab81a07 100644
  CONFIG_ARCH_MISC_INIT=y
  CONFIG_SPL_SEPARATE_BSS=y
 diff --git a/configs/tqma8mxml_1gb_mba8mx_mfg_defconfig b/configs/tqma8mxml_1gb_mba8mx_mfg_defconfig
-index b28dc1cc97..6f7773658e 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mxml_1gb_mba8mx_mfg_defconfig
 +++ b/configs/tqma8mxml_1gb_mba8mx_mfg_defconfig
 @@ -9,7 +9,6 @@ CONFIG_TQMA8MXX_BOOT_SDCARD=y
@@ -196,7 +193,7 @@ index b28dc1cc97..6f7773658e 100644
  CONFIG_ARCH_MISC_INIT=y
  CONFIG_SPL_SEPARATE_BSS=y
 diff --git a/configs/tqma8mxml_1gb_mba8mx_mmc_defconfig b/configs/tqma8mxml_1gb_mba8mx_mmc_defconfig
-index db8c138a52..0b38d87709 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mxml_1gb_mba8mx_mmc_defconfig
 +++ b/configs/tqma8mxml_1gb_mba8mx_mmc_defconfig
 @@ -8,7 +8,6 @@ CONFIG_TQMA8MXX_BOOT_SDCARD=y
@@ -208,7 +205,7 @@ index db8c138a52..0b38d87709 100644
  CONFIG_ARCH_MISC_INIT=y
  CONFIG_SPL_SEPARATE_BSS=y
 diff --git a/configs/tqma8mxml_2gb_mba8mx_fspi_defconfig b/configs/tqma8mxml_2gb_mba8mx_fspi_defconfig
-index 1c558ac3d9..748c35a7ba 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mxml_2gb_mba8mx_fspi_defconfig
 +++ b/configs/tqma8mxml_2gb_mba8mx_fspi_defconfig
 @@ -7,7 +7,6 @@ CONFIG_TQMA8MXX_BOOT_FSPI=y
@@ -220,7 +217,7 @@ index 1c558ac3d9..748c35a7ba 100644
  CONFIG_ARCH_MISC_INIT=y
  CONFIG_SPL_SEPARATE_BSS=y
 diff --git a/configs/tqma8mxml_2gb_mba8mx_mfg_defconfig b/configs/tqma8mxml_2gb_mba8mx_mfg_defconfig
-index e0d6c02086..ef248cfeca 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mxml_2gb_mba8mx_mfg_defconfig
 +++ b/configs/tqma8mxml_2gb_mba8mx_mfg_defconfig
 @@ -8,7 +8,6 @@ CONFIG_TQMA8MXX_BOOT_SDCARD=y
@@ -232,7 +229,7 @@ index e0d6c02086..ef248cfeca 100644
  CONFIG_ARCH_MISC_INIT=y
  CONFIG_SPL_SEPARATE_BSS=y
 diff --git a/configs/tqma8mxml_2gb_mba8mx_mmc_defconfig b/configs/tqma8mxml_2gb_mba8mx_mmc_defconfig
-index 0c9a6cf97b..e27bcfc8fa 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mxml_2gb_mba8mx_mmc_defconfig
 +++ b/configs/tqma8mxml_2gb_mba8mx_mmc_defconfig
 @@ -7,7 +7,6 @@ CONFIG_TQMA8MXX_BOOT_SDCARD=y
@@ -244,7 +241,7 @@ index 0c9a6cf97b..e27bcfc8fa 100644
  CONFIG_ARCH_MISC_INIT=y
  CONFIG_SPL_SEPARATE_BSS=y
 diff --git a/configs/tqma8mxml_4gb_mba8mx_fspi_defconfig b/configs/tqma8mxml_4gb_mba8mx_fspi_defconfig
-index 3267f99fbe..bc6ff38907 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mxml_4gb_mba8mx_fspi_defconfig
 +++ b/configs/tqma8mxml_4gb_mba8mx_fspi_defconfig
 @@ -8,7 +8,6 @@ CONFIG_TQMA8MXX_BOOT_FSPI=y
@@ -256,7 +253,7 @@ index 3267f99fbe..bc6ff38907 100644
  CONFIG_ARCH_MISC_INIT=y
  CONFIG_SPL_SEPARATE_BSS=y
 diff --git a/configs/tqma8mxml_4gb_mba8mx_mfg_defconfig b/configs/tqma8mxml_4gb_mba8mx_mfg_defconfig
-index 4b47cff2cf..1e256fc462 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mxml_4gb_mba8mx_mfg_defconfig
 +++ b/configs/tqma8mxml_4gb_mba8mx_mfg_defconfig
 @@ -9,7 +9,6 @@ CONFIG_TQMA8MXX_BOOT_SDCARD=y
@@ -268,7 +265,7 @@ index 4b47cff2cf..1e256fc462 100644
  CONFIG_ARCH_MISC_INIT=y
  CONFIG_SPL_SEPARATE_BSS=y
 diff --git a/configs/tqma8mxml_4gb_mba8mx_mmc_defconfig b/configs/tqma8mxml_4gb_mba8mx_mmc_defconfig
-index 94855ceb6a..27fa14119a 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mxml_4gb_mba8mx_mmc_defconfig
 +++ b/configs/tqma8mxml_4gb_mba8mx_mmc_defconfig
 @@ -8,7 +8,6 @@ CONFIG_TQMA8MXX_BOOT_SDCARD=y
@@ -280,7 +277,7 @@ index 94855ceb6a..27fa14119a 100644
  CONFIG_ARCH_MISC_INIT=y
  CONFIG_SPL_SEPARATE_BSS=y
 diff --git a/configs/tqma8mxnl_1gb_mba8mx_defconfig b/configs/tqma8mxnl_1gb_mba8mx_defconfig
-index 97f510ec2a..4a0c36d5a7 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mxnl_1gb_mba8mx_defconfig
 +++ b/configs/tqma8mxnl_1gb_mba8mx_defconfig
 @@ -6,7 +6,6 @@ CONFIG_TARGET_TQMA8MXNL=y
@@ -292,7 +289,7 @@ index 97f510ec2a..4a0c36d5a7 100644
  CONFIG_ARCH_MISC_INIT=y
  CONFIG_SPL_SEPARATE_BSS=y
 diff --git a/configs/tqma8mxnl_1gb_mba8mx_mfg_defconfig b/configs/tqma8mxnl_1gb_mba8mx_mfg_defconfig
-index 34c68bbd1f..7f93b46dc1 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mxnl_1gb_mba8mx_mfg_defconfig
 +++ b/configs/tqma8mxnl_1gb_mba8mx_mfg_defconfig
 @@ -7,7 +7,6 @@ CONFIG_TQMA8MXX_MFG_SUPPORT=y
@@ -305,7 +302,7 @@ index 34c68bbd1f..7f93b46dc1 100644
  CONFIG_SPL_SEPARATE_BSS=y
 diff --git a/doc/board/tq/examples/boot-legacy.cmd b/doc/board/tq/examples/boot-legacy.cmd
 new file mode 100644
-index 0000000000..63445aadaa
+index 000000000000..111111111111
 --- /dev/null
 +++ b/doc/board/tq/examples/boot-legacy.cmd
 @@ -0,0 +1,26 @@
@@ -336,7 +333,7 @@ index 0000000000..63445aadaa
 +load "${devtype}" "${devnum}:${bootpart}" "${fdt_addr_r}" "${fdtfile}" || exit 1
 +${boottype} "${loadaddr}" - "${fdt_addr_r}"
 diff --git a/include/configs/tqma8mxml-mba8mx.h b/include/configs/tqma8mxml-mba8mx.h
-index 1dac176bc3..62fff364bf 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/tqma8mxml-mba8mx.h
 +++ b/include/configs/tqma8mxml-mba8mx.h
 @@ -14,9 +14,12 @@
@@ -357,7 +354,7 @@ index 1dac176bc3..62fff364bf 100644
  
  #endif /* __TQMA8MXML_MBA8MX_H */
 diff --git a/include/configs/tqma8mxml.h b/include/configs/tqma8mxml.h
-index 647b177cb3..f850ad7a12 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/tqma8mxml.h
 +++ b/include/configs/tqma8mxml.h
 @@ -10,7 +10,8 @@
@@ -633,14 +630,15 @@ index 647b177cb3..f850ad7a12 100644
  
  /* Size of malloc() pool */
  #define CONFIG_SYS_MALLOC_LEN		SZ_64M
-@@ -389,16 +245,10 @@
- #error
- #endif
+@@ -391,17 +247,11 @@
+ 
+ #include "tqma8-shared-env.h"
  
 -#define CONFIG_EXTRA_ENV_SETTINGS		\
++#define CONFIG_EXTRA_ENV_SETTINGS \
+ 	TQMA8_SHARED_ENV_SETTINGS		\
 -	TQMA8MXML_CM_ENV_SETTINGS		\
 -	TQMA8MX_MODULE_ENV_SETTINGS		\
-+#define CONFIG_EXTRA_ENV_SETTINGS \
 +	TQ_BOOT_ENV_SETTINGS \
 +	BOOTENV \
 +	TQMA8MX_MODULE_ENV_SETTINGS \
@@ -656,7 +654,7 @@ index 647b177cb3..f850ad7a12 100644
  #endif /* __TQMA8MXML_H */
 diff --git a/include/environment/tq/boot.h b/include/environment/tq/boot.h
 new file mode 100644
-index 0000000000..f940bea14d
+index 000000000000..111111111111
 --- /dev/null
 +++ b/include/environment/tq/boot.h
 @@ -0,0 +1,21 @@
@@ -682,5 +680,5 @@ index 0000000000..f940bea14d
 +
 +#endif /* __TQ_BOOT_H */
 -- 
-2.34.1
+Armbian
 

--- a/patch/u-boot/u-boot-tqma/0002-tqma8mpxl-enable-distro-boot.patch
+++ b/patch/u-boot/u-boot-tqma/0002-tqma8mpxl-enable-distro-boot.patch
@@ -1,19 +1,19 @@
-From 34ee47ccf7b67d01e9b44cd6e32a9b109424343c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 Date: Mon, 9 Oct 2023 09:50:48 +0200
-Subject: [PATCH] tqma8mpxl: enable distro boot
+Subject: tqma8mpxl: enable distro boot
 
 Signed-off-by: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 ---
- .../tqma8mpxl_multi_mba8mp_ras314_defconfig   |   3 +-
- configs/tqma8mpxl_multi_mba8mpxl_defconfig    |   2 +-
- include/configs/tqma8mpxl-mba8mp-ras314.h     |   8 +-
- include/configs/tqma8mpxl-mba8mpxl.h          |   8 +-
- include/configs/tqma8mpxl.h                   | 227 ++----------------
+ configs/tqma8mpxl_multi_mba8mp_ras314_defconfig |   3 +-
+ configs/tqma8mpxl_multi_mba8mpxl_defconfig      |   2 +-
+ include/configs/tqma8mpxl-mba8mp-ras314.h       |   8 +-
+ include/configs/tqma8mpxl-mba8mpxl.h            |   8 +-
+ include/configs/tqma8mpxl.h                     | 227 +---------
  5 files changed, 40 insertions(+), 208 deletions(-)
 
 diff --git a/configs/tqma8mpxl_multi_mba8mp_ras314_defconfig b/configs/tqma8mpxl_multi_mba8mp_ras314_defconfig
-index 0cd4aee354..2b84636312 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mpxl_multi_mba8mp_ras314_defconfig
 +++ b/configs/tqma8mpxl_multi_mba8mp_ras314_defconfig
 @@ -15,7 +15,6 @@ CONFIG_FIT_SIGNATURE=y
@@ -35,7 +35,7 @@ index 0cd4aee354..2b84636312 100644
  CONFIG_LMB_MAX_REGIONS=16
 +CONFIG_CMD_IMPORTENV=y
 diff --git a/configs/tqma8mpxl_multi_mba8mpxl_defconfig b/configs/tqma8mpxl_multi_mba8mpxl_defconfig
-index d020405a6b..db20a5c897 100644
+index 111111111111..222222222222 100644
 --- a/configs/tqma8mpxl_multi_mba8mpxl_defconfig
 +++ b/configs/tqma8mpxl_multi_mba8mpxl_defconfig
 @@ -14,7 +14,6 @@ CONFIG_FIT_SIGNATURE=y
@@ -52,7 +52,7 @@ index d020405a6b..db20a5c897 100644
  CONFIG_LMB_MAX_REGIONS=16
 +CONFIG_CMD_IMPORTENV=y
 diff --git a/include/configs/tqma8mpxl-mba8mp-ras314.h b/include/configs/tqma8mpxl-mba8mp-ras314.h
-index 9a38680c83..7eef5bedff 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/tqma8mpxl-mba8mp-ras314.h
 +++ b/include/configs/tqma8mpxl-mba8mp-ras314.h
 @@ -27,6 +27,12 @@
@@ -70,7 +70,7 @@ index 9a38680c83..7eef5bedff 100644
  
  #endif /* __TQMA8MPXL_MBA8MPRAS314_H */
 diff --git a/include/configs/tqma8mpxl-mba8mpxl.h b/include/configs/tqma8mpxl-mba8mpxl.h
-index f652a02eba..351c13ad94 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/tqma8mpxl-mba8mpxl.h
 +++ b/include/configs/tqma8mpxl-mba8mpxl.h
 @@ -27,6 +27,12 @@
@@ -88,7 +88,7 @@ index f652a02eba..351c13ad94 100644
  
  #endif /* __TQMA8MPXL_MBA8MPXL_H */
 diff --git a/include/configs/tqma8mpxl.h b/include/configs/tqma8mpxl.h
-index 6e832128db..4a31298461 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/tqma8mpxl.h
 +++ b/include/configs/tqma8mpxl.h
 @@ -10,10 +10,12 @@
@@ -361,5 +361,5 @@ index 6e832128db..4a31298461 100644
 -
  #endif /* __TQMA8MPXL_H */
 -- 
-2.34.1
+Armbian
 

--- a/patch/u-boot/u-boot-tqma/0003-imx-mkimage_fit_atf_imx8mp.sh-add-script-for-imx8mp.patch
+++ b/patch/u-boot/u-boot-tqma/0003-imx-mkimage_fit_atf_imx8mp.sh-add-script-for-imx8mp.patch
@@ -1,20 +1,19 @@
-From 55a5f1cb804eba8065c8f959d71f334d7dc57eab Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 Date: Mon, 22 Jul 2024 07:48:26 +0200
-Subject: [PATCH] imx: mkimage_fit_atf_imx8mp.sh: add script for imx8mp
+Subject: imx: mkimage_fit_atf_imx8mp.sh: add script for imx8mp
 
 If Varibles can not be exported this script set default value for ATF_LOAD_ADDR
 
 Signed-off-by: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 ---
  Makefile                                    |   2 +
- arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh | 139 ++++++++++++++++++++
+ arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh | 139 ++++++++++
  board/tqc/tqma8mpxl/Kconfig                 |   3 +
  3 files changed, 144 insertions(+)
- create mode 100755 arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh
 
 diff --git a/Makefile b/Makefile
-index 312bb794c3..2d65bebd95 100644
+index 111111111111..222222222222 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1281,6 +1281,8 @@ ifneq ($(CONFIG_SPL_FIT_GENERATOR),"")
@@ -28,7 +27,7 @@ index 312bb794c3..2d65bebd95 100644
  U_BOOT_ITS_DEPS += u-boot
 diff --git a/arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh b/arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh
 new file mode 100755
-index 0000000000..25031ce710
+index 000000000000..111111111111
 --- /dev/null
 +++ b/arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh
 @@ -0,0 +1,139 @@
@@ -172,7 +171,7 @@ index 0000000000..25031ce710
 +};
 +__ITS_EOF
 diff --git a/board/tqc/tqma8mpxl/Kconfig b/board/tqc/tqma8mpxl/Kconfig
-index 19e5d5030f..a8bd61246f 100644
+index 111111111111..222222222222 100644
 --- a/board/tqc/tqma8mpxl/Kconfig
 +++ b/board/tqc/tqma8mpxl/Kconfig
 @@ -15,6 +15,9 @@ config SPL_TEXT_BASE
@@ -186,5 +185,5 @@ index 19e5d5030f..a8bd61246f 100644
  	bool
  	default y
 -- 
-2.34.1
+Armbian
 


### PR DESCRIPTION
# Description

- update uboot patches to fix upstream changes
- while at it rewrite-uboot-patches
- wget and cp lead to remaining firmware file in root
- use mv instead

# How Has This Been Tested?

- [x] Build and Boot CLI image on mba8mp
- [x] Build and Boot CLI image on mba8mp-ras314 and check firmware file position

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
