### PR TITLE
Radxa uboot 202410 fix

### DIFF
--- a/patch/u-boot/legacy/u-boot-radxa-rk35xx/0001-add-rk3588-fxblox-rk1-board.patch
+++ b/patch/u-boot/legacy/u-boot-radxa-rk35xx/0001-add-rk3588-fxblox-rk1-board.patch
@@ -1,0 +1,468 @@
+From 357924fe8fc6c7654aa39565785d8731f0750501 Mon Sep 17 00:00:00 2001
+From: mahdichi <mahdichi@gmail.com>
+Date: Fri, 25 Oct 2024 10:02:53 -0400
+Subject: [PATCH] add rk3588 fxblox-rk1 board
+
+Link: https://github.com/radxa/u-boot/pull/104
+
+Signed-off-by: mahdichi <mahdichi@gmail.com>
+---
+ arch/arm/dts/rk3588-fxblox-rk1.dts  | 220 ++++++++++++++++++++++++++++
+ configs/fxblox-rk1-rk3588_defconfig | 218 +++++++++++++++++++++++++++
+ 2 files changed, 438 insertions(+)
+ create mode 100644 arch/arm/dts/rk3588-fxblox-rk1.dts
+ create mode 100644 configs/fxblox-rk1-rk3588_defconfig
+
+diff --git a/arch/arm/dts/rk3588-fxblox-rk1.dts b/arch/arm/dts/rk3588-fxblox-rk1.dts
+new file mode 100644
+index 0000000000..ac598edd8c
+--- /dev/null
++++ b/arch/arm/dts/rk3588-fxblox-rk1.dts
+@@ -0,0 +1,220 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 Rockchip Electronics Co., Ltd
++ *
++ */
++
++/dts-v1/;
++#include "rk3588.dtsi"
++#include "rk3588-u-boot.dtsi"
++#include <dt-bindings/input/input.h>
++
++/ {
++	model = "FxBlox RK1";
++	compatible = "Functionland,fxblox-rk1", "rockchip,rk3588";
++
++	chosen {
++		stdout-path = &uart2;
++		u-boot,spl-boot-order = &spi_nor, &sdmmc, &sdhci, &spi_nand;
++	};
++
++	vcc12v_dcin: vcc12v-dcin {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc12v_dcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++	};
++
++	vcc5v0_sys: vcc5v0-sys {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc3v3_pcie30: vcc3v3-pcie30 {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie30";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		enable-active-high;
++		gpio = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
++		regulator-boot-on;
++		regulator-always-on;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc5v0_host: vcc5v0-host-regulator {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_host";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_HIGH>;
++		regulator-boot-on;
++		regulator-always-on;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_host_en>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vbus5v0_typec: vbus5v0-typec {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vbus5v0_typec";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
++		regulator-boot-on;
++		regulator-always-on;
++		vin-supply = <&vcc5v0_sys>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&typec5v_pwren>;
++	};
++
++	led_red_reg: led-red-reg {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "led_red_reg";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
++		regulator-boot-on;
++		regulator-always-on;
++		pinctrl-names = "default";
++		pinctrl-0 = <&gpio_led_red>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	led_blue_reg: led-blue-reg {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "led_blue_reg";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio4 RK_PB4 GPIO_ACTIVE_HIGH>;
++		regulator-boot-on;
++		regulator-always-on;
++		pinctrl-names = "default";
++		pinctrl-0 = <&gpio_led_blue>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&pcie3x4 {
++	u-boot,dm-pre-reloc;
++	reset-gpios = <&gpio0 RK_PD0 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++&pcie30phy {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++};
++
++&usb2phy2_grf {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++	phy-supply = <&vcc5v0_host>;
++};
++
++&u2phy2 {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++	phy-supply = <&vcc5v0_host>;
++};
++
++&u2phy2_host {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++	phy-supply = <&vcc5v0_host>;
++};
++
++&usb_host0_ehci {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++	vbus-supply= <&vbus5v0_typec>;
++};
++
++&usb_host0_ohci {
++	u-boot,dm-pre-reloc;
++	vbus-supply= <&vbus5v0_typec>;
++	status = "okay";
++};
++
++&usb2phy0_grf {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++	phy-supply = <&vbus5v0_typec>;
++};
++
++&u2phy0 {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++	phy-supply = <&vbus5v0_typec>;
++};
++
++&u2phy0_otg {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++	phy-supply = <&vbus5v0_typec>;
++};
++
++&usbdp_phy0 {
++	u-boot,dm-pre-reloc;
++	status = "disable";
++	phy-supply = <&vbus5v0_typec>;
++};
++
++&usbdrd3_0 {
++	u-boot,dm-pre-reloc;
++	vbus-supply= <&vbus5v0_typec>;
++	status = "okay";
++};
++
++&usbdrd_dwc3_0 {
++	u-boot,dm-pre-reloc;
++	dr_mode = "host";
++	vbus-supply= <&vbus5v0_typec>;
++	status = "okay";
++};
++
++&pinctrl {
++	usb {
++		u-boot,dm-pre-reloc;
++		vcc5v0_host_en: vcc5v0-host-en {
++			u-boot,dm-pre-reloc;
++			rockchip,pins = <3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb-typec {
++		u-boot,dm-pre-reloc;
++		typec5v_pwren: typec5v-pwren {
++			u-boot,dm-pre-reloc;
++			rockchip,pins = <4 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	gpio_led {
++		gpio_led_red: gpio-led-red {
++			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		gpio_led_blue: gpio-led-blue {
++			rockchip,pins = <4 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
+diff --git a/configs/fxblox-rk1-rk3588_defconfig b/configs/fxblox-rk1-rk3588_defconfig
+new file mode 100644
+index 0000000000..da7dd82034
+--- /dev/null
++++ b/configs/fxblox-rk1-rk3588_defconfig
+@@ -0,0 +1,218 @@
++CONFIG_ARM=y
++CONFIG_ARM_CPU_SUSPEND=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SPL_GPIO_SUPPORT=y
++CONFIG_SPL_LIBCOMMON_SUPPORT=y
++CONFIG_SPL_LIBGENERIC_SUPPORT=y
++CONFIG_SYS_MALLOC_F_LEN=0x80000
++CONFIG_SPL_FIT_GENERATOR="arch/arm/mach-rockchip/make_fit_atf.sh"
++CONFIG_ROCKCHIP_RK3588=y
++CONFIG_ROCKCHIP_BOOTDEV="mmc 0"
++CONFIG_ROCKCHIP_FIT_IMAGE=y
++CONFIG_ROCKCHIP_HWID_DTB=y
++CONFIG_ROCKCHIP_VENDOR_PARTITION=y
++CONFIG_USING_KERNEL_DTB_V2=y
++CONFIG_ROCKCHIP_FIT_IMAGE_PACK=y
++CONFIG_ROCKCHIP_NEW_IDB=y
++CONFIG_ROCKCHIP_EMMC_IOMUX=y
++CONFIG_LOADER_INI="RK3588MINIALL.ini"
++CONFIG_TRUST_INI="RK3588TRUST.ini"
++CONFIG_SPL_SERIAL_SUPPORT=y
++CONFIG_SPL_DRIVERS_MISC_SUPPORT=y
++CONFIG_TARGET_EVB_RK3588=y
++CONFIG_SPL_LIBDISK_SUPPORT=y
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI_SUPPORT=y
++CONFIG_DEFAULT_DEVICE_TREE="rk3588-fxblox-rk1"
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_FIT_IMAGE_POST_PROCESS=y
++CONFIG_FIT_HW_CRYPTO=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_SPL_FIT_IMAGE_POST_PROCESS=y
++CONFIG_SPL_FIT_HW_CRYPTO=y
++# CONFIG_SPL_SYS_DCACHE_OFF is not set
++CONFIG_BOOTDELAY=1
++# CONFIG_DISABLE_CONSOLE=y
++# CONFIG_SYS_CONSOLE_INFO_QUIET=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_ANDROID_BOOTLOADER=y
++CONFIG_ANDROID_AVB=y
++CONFIG_ANDROID_BOOT_IMAGE_HASH=y
++CONFIG_SPL_BOARD_INIT=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++# CONFIG_SPL_LEGACY_IMAGE_SUPPORT is not set
++CONFIG_SPL_SEPARATE_BSS=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_USE_PARTITION=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_PARTITION=0x1
++CONFIG_SPL_MMC_WRITE=y
++CONFIG_SPL_MTD_SUPPORT=y
++CONFIG_SPL_ATF=y
++CONFIG_FASTBOOT_BUF_ADDR=0xc00800
++CONFIG_FASTBOOT_BUF_SIZE=0x04000000
++CONFIG_FASTBOOT_FLASH=y
++CONFIG_FASTBOOT_FLASH_MMC_DEV=0
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_DTIMG=y
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_IMI is not set
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_XIMG is not set
++# CONFIG_CMD_LZMADEC is not set
++# CONFIG_CMD_UNZIP is not set
++# CONFIG_CMD_FLASH is not set
++# CONFIG_CMD_FPGA is not set
++CONFIG_CMD_GPT=y
++# CONFIG_CMD_LOADB is not set
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_BOOT_ANDROID=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_SF=y
++CONFIG_CMD_SPI=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++# CONFIG_CMD_ITEST is not set
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TFTPPUT=y
++CONFIG_CMD_TFTP_BOOTM=y
++CONFIG_CMD_TFTP_FLASH=y
++# CONFIG_CMD_MISC is not set
++CONFIG_CMD_MTD_BLK=y
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_ISO_PARTITION is not set
++CONFIG_EFI_PARTITION_ENTRIES_NUMBERS=64
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_SPL_DTB_MINIMUM=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++# CONFIG_NET_TFTP_VARS is not set
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++# CONFIG_SARADC_ROCKCHIP is not set
++CONFIG_SARADC_ROCKCHIP_V2=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_CLK_SCMI=y
++CONFIG_SPL_CLK_SCMI=y
++CONFIG_DM_CRYPTO=y
++CONFIG_SPL_DM_CRYPTO=y
++CONFIG_ROCKCHIP_CRYPTO_V2=y
++CONFIG_SPL_ROCKCHIP_CRYPTO_V2=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_ROCKCHIP=y
++CONFIG_SCMI_FIRMWARE=y
++CONFIG_SPL_SCMI_FIRMWARE=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_ROCKCHIP_GPIO_V2=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_DM_KEY=y
++CONFIG_ADC_KEY=y
++CONFIG_MISC=y
++CONFIG_SPL_MISC=y
++CONFIG_MISC_DECOMPRESS=y
++CONFIG_SPL_MISC_DECOMPRESS=y
++CONFIG_ROCKCHIP_OTP=y
++CONFIG_ROCKCHIP_HW_DECOMPRESS=y
++CONFIG_SPL_ROCKCHIP_HW_DECOMPRESS=y
++CONFIG_SPL_ROCKCHIP_SECURE_OTP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_SDMA=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_MTD=y
++CONFIG_MTD_BLK=y
++CONFIG_MTD_DEVICE=y
++CONFIG_NAND=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_SPI_FLASH=y
++CONFIG_SF_DEFAULT_SPEED=80000000
++CONFIG_SPI_FLASH_EON=y
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_SST=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_XMC=y
++CONFIG_SPI_FLASH_XTX=y
++CONFIG_SPI_FLASH_MTD=y
++CONFIG_DM_ETH=y
++CONFIG_DM_ETH_PHY=y
++CONFIG_DWC_ETH_QOS=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_NVME=y
++CONFIG_PCI=y
++CONFIG_DM_PCI=y
++CONFIG_DM_PCI_COMPAT=y
++CONFIG_PCIE_DW_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_SAMSUNG_HDPTX=y
++CONFIG_PHY_ROCKCHIP_SNPS_PCIE3=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_SPI_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_REGULATOR_RK860X=y
++CONFIG_REGULATOR_RK806=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_ROCKCHIP_SDRAM_COMMON=y
++CONFIG_ROCKCHIP_TPL_INIT_DRAM_TYPE=0
++CONFIG_DM_RESET=y
++CONFIG_SPL_DM_RESET=y
++CONFIG_SPL_RESET_ROCKCHIP=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_BASE=0xFEB50000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_ROCKCHIP_SPI=y
++CONFIG_ROCKCHIP_SFC=y
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_XHCI_PCI=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GADGET=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_USB_STORAGE=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_MANUFACTURER="Rockchip"
++CONFIG_USB_GADGET_VENDOR_NUM=0x2207
++CONFIG_USB_GADGET_PRODUCT_NUM=0x350a
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_DM_VIDEO=y
++CONFIG_DISPLAY=y
++CONFIG_DRM_ROCKCHIP=y
++CONFIG_DRM_ROCKCHIP_DW_MIPI_DSI2=y
++CONFIG_DRM_ROCKCHIP_ANALOGIX_DP=y
++CONFIG_DRM_ROCKCHIP_SAMSUNG_MIPI_DCPHY=y
++CONFIG_USE_TINY_PRINTF=y
++CONFIG_LIB_RAND=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_RSA=y
++CONFIG_SPL_RSA=y
++CONFIG_RSA_N_SIZE=0x200
++CONFIG_RSA_E_SIZE=0x10
++CONFIG_RSA_C_SIZE=0x20
++CONFIG_LZ4=y
++CONFIG_ERRNO_STR=y
++# CONFIG_EFI_LOADER is not set
++CONFIG_AVB_LIBAVB=y
++CONFIG_AVB_LIBAVB_AB=y
++CONFIG_AVB_LIBAVB_ATX=y
++CONFIG_AVB_LIBAVB_USER=y
++CONFIG_RK_AVB_LIBAVB_USER=y
++CONFIG_OPTEE_CLIENT=y
++CONFIG_OPTEE_V2=y
+-- 
+2.43.0
+

--- a/patch/u-boot/legacy/u-boot-radxa-rk35xx/dt/rk3588s-retro-lite-cm5.dts
+++ b/patch/u-boot/legacy/u-boot-radxa-rk35xx/dt/rk3588s-retro-lite-cm5.dts
@@ -5,7 +5,9 @@
  */
 
 /dts-v1/;
-#include "rk3588s-radxa-cm5.dtsi"
+#include "rk3588.dtsi"
+#include "rk3588-u-boot.dtsi"
+#include <dt-bindings/input/input.h>
 
 / {
 	model = "Retro Lite CM5";


### PR DESCRIPTION
# Description

Radxa is missing commit https://github.com/radxa/u-boot/commit/22849bf1cf13c2f0a6f2741a51d4802793d2aecc when switching to new branch, so I add it as patch incase radxa merge it in the future.

Radxa also toggle dts of radxa-cm5 to kernel dts, I add the fix to let rk3588s-retro-lite-cm5.dts build with old u-boot dts.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh uboot BOARD=retro-lite-cm5 BRANCH=vendor DEB_COMPRESS=xz`
- [x] `./compile.sh uboot BOARD=fxblox-rk1 BRANCH=vendor DEB_COMPRESS=xz`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
