### PR TITLE
Add support for Rock 2A and 2F

### DIFF
--- a/config/boards/rock-2a.csc
+++ b/config/boards/rock-2a.csc
@@ -1,0 +1,11 @@
+# Rockchip RK3528 quad core 1-4GB SoC 1xGBe 0-32GB eMMC
+BOARD_NAME="ROCK 2A"
+BOARDFAMILY="rk35xx"
+BOOTCONFIG="rock-2-rk3528_defconfig"
+BOARD_MAINTAINER="CodeChenL"
+KERNEL_TARGET="vendor"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3528-rock-2a.dtb"
+BOOT_SCENARIO="spl-blobs"
+IMAGE_PARTITION_TABLE="gpt"

--- a/config/boards/rock-2f.csc
+++ b/config/boards/rock-2f.csc
@@ -1,0 +1,13 @@
+# Rockchip RK3528 quad core 1-4GB SoC WIFI/BT 0-32GB eMMC
+BOARD_NAME="ROCK 2F"
+BOARDFAMILY="rk35xx"
+BOOTCONFIG="rock-2-rk3528_defconfig"
+BOARD_MAINTAINER="CodeChenL"
+KERNEL_TARGET="vendor"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3528-rock-2f.dtb"
+BOOT_SCENARIO="spl-blobs"
+IMAGE_PARTITION_TABLE="gpt"
+enable_extension "radxa-aic8800"
+AIC8800_TYPE="usb"

--- a/config/boards/rock-5c.conf
+++ b/config/boards/rock-5c.conf
@@ -24,12 +24,3 @@ function post_family_tweaks__rock5c_naming_audios() {
 
 	return 0
 }
-
-function post_family_tweaks__rock5c_naming_wireless_interface() {
-	display_alert "$BOARD" "Renaming rock5c wifi" "info"
-
-	mkdir -p $SDCARD/etc/udev/rules.d/
-	echo 'SUBSYSTEM=="net", ACTION=="add", ATTR{address}=="88:00:*", NAME="$ENV{ID_NET_SLOT}"' > $SDCARD/etc/udev/rules.d/99-radxa-aic8800.rules
-
-	return 0
-}

--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -51,4 +51,13 @@ function post_install_kernel_debs__install_aic8800_dkms_package() {
 	declare -ag if_error_find_files_sdcard=("/var/lib/dkms/aic8800*/*/build/*.log")
 	use_clean_environment="yes" chroot_sdcard_apt_get_install "/tmp/${aic8800_dkms_file_name} /tmp/aic8800-firmware_${latest_version}_all.deb"
 	use_clean_environment="yes" chroot_sdcard "rm -f /tmp/aic8800*.deb"
+	use_clean_environment="yes" chroot_sdcard "mkdir -p /usr/lib/systemd/network/"
+	use_clean_environment="yes" chroot_sdcard 'cat <<- EOF > /usr/lib/systemd/network/50-radxa-aic8800.link
+		[Match]
+		OriginalName=wlan*
+		Driver=usb
+
+		[Link]
+		NamePolicy=kernel
+	EOF'
 }


### PR DESCRIPTION
# Description

1. Add support for Rock 2A and 2F
2. use systemd.link instead of udev rule(99-radxa-aic8800.rules)

# How Has This Been Tested?

- [x] `./compile.sh build BOARD=rock-2a BRANCH=vendor BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no RELEASE=noble DOWNLOAD_MIRROR=china`
- [x] `./compile.sh build BOARD=rock-2f BRANCH=vendor BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no RELEASE=noble DOWNLOAD_MIRROR=china`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
