### PR TITLE
Radxa Zero, fix for overlay prefix name

### DIFF
--- a/config/boards/radxa-zero.conf
+++ b/config/boards/radxa-zero.conf
@@ -13,6 +13,7 @@ FORCE_BOOTSCRIPT_UPDATE="yes"
 BOOT_LOGO="desktop"
 ASOUND_STATE="asound.state.radxa-zero"
 BOOT_FDT_FILE="amlogic/meson-g12a-radxa-zero.dtb"
+OVERLAY_PREFIX="meson-g12a"
 
 # Newer u-boot for the Zero
 BOOTBRANCH_BOARD="tag:v2023.07.02"

--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -32,6 +32,11 @@ if [[ $BOARD == lafrite ]]; then
 	UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin:u-boot.bin u-boot-dtb.img"
 fi
 
+# @TODO: this is temporary measure before to figure out why it doesn't load from `config/boards/radxa-zero.conf`
+if [[ $BOARD == radxa-zero ]]; then
+    OVERLAY_PREFIX="meson-g12a"
+fi
+
 # Set CPUMIN et al if not already set in the board config.
 CPUMIN=${CPUMIN:-500000}
 CPUMAX=${CPUMAX:-1536000}


### PR DESCRIPTION
# Description

The list of available overlays is displaying correctly now.

![u14u014](https://github.com/user-attachments/assets/de67ff20-51b0-4d44-8eaa-6a2e1e22b16a)
![j2i3o4i3](https://github.com/user-attachments/assets/c6ad61a2-1cdc-42e4-96a4-27a5f0640792)

GitHub issue reference:  #7544 
Jira reference number: N/A

# How Has This Been Tested?

The latest builds (both Debian and Ubuntu) with stable kernel are working correctly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
