### PR TITLE
remove software-properties-common/gtk for trixie and sid

### DIFF
--- a/config/cli/sid/main/packages.additional
+++ b/config/cli/sid/main/packages.additional
@@ -45,7 +45,6 @@ qrencode
 rfkill
 rng-tools
 screen
-software-properties-common
 smartmontools
 stress
 sudo

--- a/config/cli/trixie/main/packages.additional
+++ b/config/cli/trixie/main/packages.additional
@@ -45,7 +45,6 @@ qrencode
 rfkill
 rng-tools
 screen
-software-properties-common
 smartmontools
 stress
 sudo

--- a/config/desktop/sid/environments/xfce/config_base/packages
+++ b/config/desktop/sid/environments/xfce/config_base/packages
@@ -77,7 +77,6 @@ pulseaudio-module-bluetooth
 redshift
 slick-greeter
 smbclient
-software-properties-gtk
 synaptic
 system-config-printer
 system-config-printer-common


### PR DESCRIPTION
# Description

software-properties is removed from debian trixie now:
https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords=software-properties

software-properties-gtk is a gui app to configure repos of ubuntu, and software-properties-common is for ppa management.

We are removing these two packages for debian now: https://github.com/armbian/build/commit/37d9200e6abcbf56a395c7156c71d43400813283, so I remove them in package list which is only for trixie and sid.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
