### PR TITLE
Bump two leftover radxa rk35xx uboot to next-dev-v2024.10

### DIFF
--- a/config/boards/mixtile-edge2.csc
+++ b/config/boards/mixtile-edge2.csc
@@ -1,6 +1,7 @@
 # Rockchip RK3568 quad core 4GB-8GB GBE PCIe USB3 SATA NVMe
 BOARD_NAME="Mixtile Edge 2"
-BOARDFAMILY="rockchip64"
+BOARDFAMILY="rk35xx"
+BOOTCONFIG="mixtile-edge2-rk3568_defconfig"
 BOARD_MAINTAINER=""
 BOOT_SOC="rk3568"
 KERNEL_TARGET="current,edge,vendor"
@@ -34,21 +35,4 @@ function post_family_config__h96_max_use_mainline_uboot() {
 	function write_uboot_platform() {
 		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
 	}
-}
-
-function post_family_config_branch_vendor__kernel_and_uboot_rk35xx_mixtile_edge2() {
-	# Copypasta from rockchip-rk3588.conf family file -- we _really_ gotta find a better way!
-	declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-	declare -g KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-	declare -g KERNELBRANCH='branch:rk-6.1-rkr5'
-	declare -g KERNELPATCHDIR='rk35xx-vendor-6.1'
-	declare -g LINUXFAMILY=rk35xx
-	declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes
-	declare -g OVERLAY_PREFIX='rk35xx'
-
-	# Use vendor u-boot, same as rk35xx; we've a defconfig and dt in there
-	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
-	declare -g BOOTBRANCH='branch:next-dev-v2024.03' # Always use same version as rk3588, they share a patch dir
-	declare -g BOOTPATCHDIR="legacy/u-boot-radxa-rk35xx"
-	declare -g BOOTCONFIG="mixtile-edge2-rk3568_defconfig"
 }

--- a/config/boards/rock-5c.conf
+++ b/config/boards/rock-5c.conf
@@ -15,14 +15,6 @@ enable_extension "radxa-aic8800"
 AIC8800_TYPE="usb"
 ASOUND_STATE="asound.state.rock-5c"
 
-function post_family_config__uboot_rock5c() {
-	display_alert "$BOARD" "Configuring armsom u-boot" "info"
-	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
-	declare -g BOOTBRANCH="branch:next-dev-v2024.03"
-	declare -g OVERLAY_PREFIX='rockchip-rk3588'
-	declare -g BOOTDELAY=1 # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
-}
-
 function post_family_tweaks__rock5c_naming_audios() {
 	display_alert "$BOARD" "Renaming rock5c audios" "info"
 


### PR DESCRIPTION
# Description

There are two boards that were missed when upgrading to next-dev-v2024.10. Bump version for them too.

```
config/boards/rock-5c.conf
config/boards/mixtile-edge2.csc
```

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh build ARTIFACT_IGNORE_CACHE=yes BOARD=rock-5c BRANCH=vendor BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=yes RELEASE=noble`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
