### PR TITLE
add spi flash overlay for NanoPi M6 edge, current kernels

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/Makefile
@@ -90,7 +90,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-uart6-m1.dtbo \
 	rockchip-rk3588-uart7-m2.dtbo \
 	rockchip-rk3588-uart8-m1.dtbo \
-	rockchip-rk3588-rkvenc-overlay.dtbo
+	rockchip-rk3588-rkvenc-overlay.dtbo \
+	rockchip-rk3588-nanopi-m6-spi-nor-flash.dtbo
 
 scr-$(CONFIG_ARCH_ROCKCHIP) += \
        rockchip-fixup.scr

--- a/patch/kernel/archive/rockchip64-6.12/overlay/rockchip-rk3588-nanopi-m6-spi-nor-flash.dtso
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/rockchip-rk3588-nanopi-m6-spi-nor-flash.dtso
@@ -1,0 +1,30 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&sdhci>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&sfc>;
+
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&fspim0_pins>;
+			status = "okay";
+
+			flash@0 {
+				compatible = "jedec,spi-nor";
+				reg = <0x0>;
+				spi-max-frequency = <50000000>;
+				spi-rx-bus-width = <4>;
+				spi-tx-bus-width = <1>;
+			};
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip64-6.13/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.13/overlay/Makefile
@@ -88,7 +88,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-uart6-m1.dtbo \
 	rockchip-rk3588-uart7-m2.dtbo \
 	rockchip-rk3588-uart8-m1.dtbo \
-	rockchip-rk3588-rkvenc-overlay.dtbo
+	rockchip-rk3588-rkvenc-overlay.dtbo \
+	rockchip-rk3588-nanopi-m6-spi-nor-flash.dtbo
 
 scr-$(CONFIG_ARCH_ROCKCHIP) += \
        rockchip-fixup.scr

--- a/patch/kernel/archive/rockchip64-6.13/overlay/rockchip-rk3588-nanopi-m6-spi-nor-flash.dtso
+++ b/patch/kernel/archive/rockchip64-6.13/overlay/rockchip-rk3588-nanopi-m6-spi-nor-flash.dtso
@@ -1,0 +1,30 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&sdhci>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&sfc>;
+
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&fspim0_pins>;
+			status = "okay";
+
+			flash@0 {
+				compatible = "jedec,spi-nor";
+				reg = <0x0>;
+				spi-max-frequency = <50000000>;
+				spi-rx-bus-width = <4>;
+				spi-tx-bus-width = <1>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
# Description

Add SPI flash overlay to edge and current kernels in order to be used for NanoPi M6.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?
- [x] Tested availability of spi flash under 6.12 rockchip64 kernel.
- [x] Compiled edge kernel.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
