### PR TITLE
mesa-vpu: add chromium back for debian and noble

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -87,9 +87,13 @@ function post_install_kernel_debs__3d() {
 			Pin: release o=LP-PPA-kisak-kisak-mesa
 			Pin-Priority: 1001
 		EOF
+	fi
 
-		# Add chromium if building a desktop
-		if [[ "${BUILD_DESKTOP}" == "yes" ]]; then
+	# Add chromium if building a desktop
+	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then
+		if [[ "${DISTRIBUTION}" == "Debian" ]]; then
+			pkgs+=("chromium")
+		elif [[ "${DISTRIBUTION}" == "Ubuntu" && "${RELEASE}" =~ ^(jammy|noble)$ ]]; then
 			pkgs+=("chromium")
 		fi
 	fi


### PR DESCRIPTION
# Description

Chromium is no longer installed since #7779, so add it back for all debian an ubuntu jammy/noble.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=rock-5-itx BRANCH=edge BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no RELEASE=noble ENABLE_EXTENSIONS=mesa-vpu`
- [x] `./compile.sh BOARD=rock-5-itx BRANCH=edge BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no RELEASE=bokworm ENABLE_EXTENSIONS=mesa-vpu`
- [x] `./compile.sh BOARD=rock-5-itx BRANCH=edge BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no RELEASE=trixie ENABLE_EXTENSIONS=mesa-vpu`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
