### PR TITLE
H88k

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
@@ -483,15 +483,17 @@
 
 &sdhci {
 	bus-width = <8>;
+	max-frequency = <200000000>;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
 	no-sdio;
 	no-sd;
 	non-removable;
-	mmc-hs200-1_8v;
 	status = "okay";
 };
 
 &sdmmc {
-	max-frequency = <200000000>;
+	max-frequency = <150000000>;
 	no-sdio;
 	no-mmc;
 	bus-width = <4>;
@@ -499,6 +501,7 @@
 	cap-sd-highspeed;
 	disable-wp;
 	sd-uhs-sdr104;
+	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
 	vmmc-supply = <&vcc_3v3_s3>;
 	vqmmc-supply = <&vccio_sd_s0>;
 	status = "okay";

--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
@@ -280,6 +280,18 @@
 	};
 };
 
+&hdmi_receiver_cma {
+	status = "okay";
+};
+
+&hdmi_receiver {
+	status = "okay";
+	hpd-gpios = <&gpio2 RK_PB5 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_hpd>;
+	pinctrl-names = "default";
+	memory-region = <&hdmi_receiver_cma>;
+};
+
 &i2c0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c0m2_xfer>;
@@ -419,6 +431,12 @@
 };
 
 &pinctrl {
+	hdmirx {
+		hdmirx_hpd: hdmirx-hpd {
+			rockchip,pins = <2 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
 	hym8563 {
 		hym8563_int: hym8563-int {
 			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;


### PR DESCRIPTION
hdmi_rx tested and captured
```
v4l2-ctl --list-devices 
...
snps_hdmirx (platform:fdee0000.hdmi_receiver):
        /dev/video3
...
```

mmc speed fixed and tested
```
# cat /sys/kernel/debug/mmc0/ios 
clock:          200000000 Hz
actual clock:   187500000 Hz
vdd:            18 (3.0 ~ 3.1 V)
bus mode:       2 (push-pull)
chip select:    0 (don't care)
power mode:     2 (on)
bus width:      3 (8 bits)
timing spec:    10 (mmc HS400)
signal voltage: 1 (1.80 V)
driver type:    0 (driver type B)
# cat /sys/kernel/debug/mmc1/ios 
clock:          150000000 Hz
actual clock:   148500000 Hz
vdd:            21 (3.3 ~ 3.4 V)
bus mode:       2 (push-pull)
chip select:    0 (don't care)
power mode:     2 (on)
bus width:      2 (4 bits)
timing spec:    6 (sd uhs SDR104)
signal voltage: 1 (1.80 V)
driver type:    0 (driver type B)
```

also added a cd-gpio pin for sdmmc detection
```
cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
```

gpio and max mmc frequence are specified by vendor
![image](https://github.com/user-attachments/assets/e963c515-4198-4db0-a39e-8610727a6957)
