### PR TITLE
Add Support for Rock 5T

### DIFF
--- a/config/boards/rock-5t.conf
+++ b/config/boards/rock-5t.conf
@@ -1,0 +1,28 @@
+# Rockchip RK3588 SoC octa core 4-16GB SoC 2.5GBe eMMC USB3 NvME
+BOARD_NAME="Rock 5T"
+BOARDFAMILY="rockchip-rk3588"
+BOARD_MAINTAINER="HeyMeco"
+BOOTCONFIG="rock-5t-rk3588_defconfig"
+KERNEL_TARGET="vendor"
+KERNEL_TEST_TARGET="vendor"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3588-rock-5t.dtb"
+BOOT_SCENARIO="spl-blobs"
+BOOT_SUPPORT_SPI="yes"
+BOOT_SPI_RKSPI_LOADER="yes"
+IMAGE_PARTITION_TABLE="gpt"
+declare -g UEFI_EDK2_BOARD_ID="rock-5t" # This _only_ used for uefi-edk2-rk3588 extension
+
+function post_family_tweaks__rock5b_naming_audios() {
+	display_alert "$BOARD" "Renaming rock5b audios" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi1-sound", ENV{SOUND_DESCRIPTION}="HDMI1 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmiin-sound", ENV{SOUND_DESCRIPTION}="HDMI-In Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-dp0-sound", ENV{SOUND_DESCRIPTION}="DP0 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-dp1-sound", ENV{SOUND_DESCRIPTION}="DP1 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-es8316-sound", ENV{SOUND_DESCRIPTION}="ES8316 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+
+	return 0
+}


### PR DESCRIPTION
# Description

This config adds support for the Radxa Rock-5T and I'm taking the role as maintainer for this board.
I have tested this with the vendor kernel 6.1.99 and it's working.
The device-tree has been merged in this commit https://github.com/armbian/linux-rockchip/commit/dd32a98c5029d98a2adc39b9e13b91d6e05cd199 

# How Has This Been Tested?

- [x] Boot Rock-5T into Armbian Debian 12 CLI Standard
- [x] Connect to WiFi
- [x] Use USB-DP to connect to a monitor and use mouse and keyboard peripherals

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
