### PR TITLE
station-m2: delete the redundant function.

### DIFF
--- a/config/boards/station-m2.csc
+++ b/config/boards/station-m2.csc
@@ -12,14 +12,6 @@ BOOT_SCENARIO="spl-blobs"
 ASOUND_STATE="asound.state.station-m2"
 IMAGE_PARTITION_TABLE="gpt"
 
-function post_family_tweaks__station_m2() {
-	display_alert "$BOARD" "Installing board tweaks" "info"
-
-	cp -R $SRC/packages/blobs/station/firmware/* $SDCARD/lib/firmware/
-
-	return 0
-}
-
 # Override family config for this board; let's avoid conditionals in family config.
 function post_family_config__stationm2_use_radxa_vendor_uboot() {
 	BOOTSOURCE='https://github.com/radxa/u-boot.git'


### PR DESCRIPTION
# Description

station-m2: delete the redundant function.

The firmware required by the device is as follows, all of which is included in the armbian-firmware package.

https://github.com/armbian/firmware/blob/master/brcm/brcmfmac43455-sdio.bin

https://github.com/armbian/firmware/blob/master/brcm/brcmfmac43455-sdio.clm_blob

https://github.com/armbian/firmware/blob/master/brcm/brcmfmac43455-sdio.txt

The PR depends on the following PR:

https://github.com/armbian/firmware/pull/101

# How Has This Been Tested?

- [x] WiFi
- [x] BT

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
