### PR TITLE
station-p2: delete the redundant function.

### DIFF
--- a/config/boards/station-p2.csc
+++ b/config/boards/station-p2.csc
@@ -11,15 +11,6 @@ BOOT_FDT_FILE="rockchip/rk3568-roc-pc.dtb"
 ASOUND_STATE="asound.state.station-p2"
 IMAGE_PARTITION_TABLE="gpt"
 
-function post_family_tweaks__station_p2() {
-	display_alert "$BOARD" "Installing board tweaks" "info"
-
-	cp -R $SRC/packages/blobs/rtl8723bt_fw/* $SDCARD/lib/firmware/rtl_bt/
-	cp -R $SRC/packages/blobs/station/firmware/* $SDCARD/lib/firmware/
-
-	return 0
-}
-
 # Mainline U-Boot
 function post_family_config__station_p2_use_mainline_uboot() {
 	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"


### PR DESCRIPTION
# Description

station-p2: delete the redundant function.

The firmware required by the device is as follows, all of which is included in the armbian-firmware package.

https://github.com/armbian/firmware/blob/master/brcm/brcmfmac43752-sdio.bin

https://github.com/armbian/firmware/blob/master/brcm/brcmfmac43752-sdio.clm_blob

https://github.com/armbian/firmware/blob/master/brcm/brcmfmac43752-sdio.txt

https://github.com/armbian/firmware/blob/master/brcm/BCM4362A2.hcd

This PR depends on the following PR:

https://github.com/armbian/firmware/pull/101

# How Has This Been Tested?

- [x] WiFi
- [x] BT

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
