### PR TITLE
Magicsee C400-Plus: Switch to standard support

### DIFF
--- a/config/boards/aml-c400-plus.conf
+++ b/config/boards/aml-c400-plus.conf
@@ -5,7 +5,6 @@ BOARD_MAINTAINER="jomadeto"
 BOOTSIZE="512"
 BOOTFS_TYPE="fat"
 KERNEL_TARGET="current,edge"
-MODULES_BLACKLIST="simpledrm" # SimpleDRM conflicts with Panfrost
 KERNEL_TEST_TARGET="current"
 SERIALCON="ttyAML0"
 FULL_DESKTOP="yes"


### PR DESCRIPTION
Switch to standard support and remove SimpleDRM from blacklist.