### PR TITLE
kernel: fix for 6.14 make clean fail at tools dir due to upstream dir change

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -435,6 +435,16 @@ function kernel_package_callback_linux_headers() {
 		echo -e "clean:\n\techo fake clean for tools/vm" > "${headers_target_dir}/tools/vm/Makefile"
 	fi
 
+	# Small detour: in v6.14-rc1, in commit https://github.com/torvalds/linux/commit/e19bde2269ca,
+	#               the tools/pci dir was renamed to tools/testing/selftests/pci_endpoint.
+	#               Unfortunately tools/Makefile still expects it to exist,
+	#               and "make clean" in the "/tools" dir fails. Drop in a fake Makefile there to work around this.
+	if [[ ! -f "${headers_target_dir}/tools/pci/Makefile" ]] && [[ "${KERNEL_MAJOR_MINOR}" == "6.14" ]]; then
+		display_alert "Creating fake tools/pci/Makefile" "6.14 hackfix" "debug"
+		run_host_command_logged mkdir -p "${headers_target_dir}/tools/pci"
+		echo -e "clean:\n\techo fake clean for tools/pci" > "${headers_target_dir}/tools/pci/Makefile"
+	fi
+
 	# Hack for 6.5-rc1: create include/linux dir so the 'clean' step below doesn't fail. I've reported upstream...
 	display_alert "Creating fake counter/include/linux" "6.5-rc1 hackfix" "debug"
 	run_host_command_logged mkdir -p "${headers_target_dir}/tools/counter/include/linux"


### PR DESCRIPTION
# Description

I have sent a patch upstream which will get merged to v6.15, but we still need to fix the build issue for 6.14. So I use a hack similar with https://github.com/armbian/build/commit/9218401cd80b3f93ae4ca0b47c043e0eab310014 so that we don't need to copy one patch to dirs of all families.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=rock-5-itx BRANCH=edge KERNEL_CONFIGURE=no`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
