### PR TITLE
Hinlink-H88k: some fix to dts

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
@@ -92,6 +92,17 @@
 		};
 	};
 
+	hdmi0-con {
+		compatible = "hdmi-connector";
+		type = "a";
+
+		port {
+			hdmi0_con_in: endpoint {
+				remote-endpoint = <&hdmi0_out_con>;
+			};
+		};
+	};
+
 	rfkilli-wifi {
 		compatible = "rfkill-gpio";
 		label = "rfkill-pcie-wlan";
@@ -277,6 +288,12 @@
 &hdmi0_in {
 	hdmi0_in_vp0: endpoint {
 		remote-endpoint = <&vp0_out_hdmi0>;
+	};
+};
+
+&hdmi0_out {
+	hdmi0_out_con: endpoint {
+		remote-endpoint = <&hdmi0_con_in>;
 	};
 };
 

--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
@@ -26,7 +26,7 @@
 		simple-audio-card,name = "Analog";
 		simple-audio-card,format = "i2s";
 		simple-audio-card,mclk-fs = <256>;
-		simple-audio-card,hp-det-gpio = <&gpio1 RK_PD5 GPIO_ACTIVE_LOW>;
+		simple-audio-card,hp-det-gpios = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
 		simple-audio-card,bitclock-master = <&daicpu>;
 		simple-audio-card,frame-master = <&daicpu>;
 
@@ -349,7 +349,6 @@
 };
 
 &i2c7 {
-	pinctrl-0 = <&i2c7m0_xfer>;
 	status = "okay";
 
 	es8388: audio-codec@11 {
@@ -359,17 +358,10 @@
 		assigned-clock-rates = <12288000>;
 		AVDD-supply = <&vcc_3v3_s3>;
 		clocks = <&cru I2S0_8CH_MCLKOUT>;
-		clock-names = "mclk";
 		DVDD-supply = <&vcc_1v8_s3>;
 		HPVDD-supply = <&vcc_3v3_s3>;
 		PVDD-supply = <&vcc_1v8_s3>;
 		#sound-dai-cells = <0>;
-
-		port {
-			es8388_p0_0: endpoint {
-				remote-endpoint = <&i2s0_8ch_p0_0>;
-			};
-		};
 	};
 };
 
@@ -381,14 +373,6 @@
 		     &i2s0_sdi0
 		     &i2s0_sdo0>;
 	status = "okay";
-
-	i2s0_8ch_p0: port {
-		i2s0_8ch_p0_0: endpoint {
-			dai-format = "i2s";
-			mclk-fs = <256>;
-			remote-endpoint = <&es8388_p0_0>;
-		};
-	};
 };
 
 &mdio0 {

--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
@@ -103,6 +103,17 @@
 		};
 	};
 
+	hdmi1-con {
+		compatible = "hdmi-connector";
+		type = "a";
+
+		port {
+			hdmi1_con_in: endpoint {
+				remote-endpoint = <&hdmi1_out_con>;
+			};
+		};
+	};
+
 	rfkilli-wifi {
 		compatible = "rfkill-gpio";
 		label = "rfkill-pcie-wlan";
@@ -295,6 +306,26 @@
 	hdmi0_out_con: endpoint {
 		remote-endpoint = <&hdmi0_con_in>;
 	};
+};
+
+&hdmi1 {
+	status = "okay";
+};
+
+&hdmi1_in {
+	hdmi1_in_vp1: endpoint {
+		remote-endpoint = <&vp1_out_hdmi1>;
+	};
+};
+
+&hdmi1_out {
+	hdmi1_out_con: endpoint {
+		remote-endpoint = <&hdmi1_con_in>;
+	};
+};
+
+&hdptxphy1 {
+	status = "okay";
 };
 
 &hdmi_receiver_cma {
@@ -931,5 +962,12 @@
 	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
 		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
 		remote-endpoint = <&hdmi0_in_vp0>;
+	};
+};
+
+&vp1 {
+	vp1_out_hdmi1: endpoint@ROCKCHIP_VOP2_EP_HDMI1 {
+		reg = <ROCKCHIP_VOP2_EP_HDMI1>;
+		remote-endpoint = <&hdmi1_in_vp1>;
 	};
 };

--- a/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
@@ -280,6 +280,18 @@
 	};
 };
 
+&hdmi_receiver_cma {
+	status = "okay";
+};
+
+&hdmi_receiver {
+	status = "okay";
+	hpd-gpios = <&gpio2 RK_PB5 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_hpd>;
+	pinctrl-names = "default";
+	memory-region = <&hdmi_receiver_cma>;
+};
+
 &i2c0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c0m2_xfer>;
@@ -419,6 +431,12 @@
 };
 
 &pinctrl {
+	hdmirx {
+		hdmirx_hpd: hdmirx-hpd {
+			rockchip,pins = <2 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
 	hym8563 {
 		hym8563_int: hym8563-int {
 			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
@@ -483,15 +501,17 @@
 
 &sdhci {
 	bus-width = <8>;
+	max-frequency = <200000000>;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
 	no-sdio;
 	no-sd;
 	non-removable;
-	mmc-hs200-1_8v;
 	status = "okay";
 };
 
 &sdmmc {
-	max-frequency = <200000000>;
+	max-frequency = <150000000>;
 	no-sdio;
 	no-mmc;
 	bus-width = <4>;
@@ -499,6 +519,7 @@
 	cap-sd-highspeed;
 	disable-wp;
 	sd-uhs-sdr104;
+	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
 	vmmc-supply = <&vcc_3v3_s3>;
 	vqmmc-supply = <&vccio_sd_s0>;
 	status = "okay";

--- a/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
@@ -92,6 +92,17 @@
 		};
 	};
 
+	hdmi0-con {
+		compatible = "hdmi-connector";
+		type = "a";
+
+		port {
+			hdmi0_con_in: endpoint {
+				remote-endpoint = <&hdmi0_out_con>;
+			};
+		};
+	};
+
 	rfkilli-wifi {
 		compatible = "rfkill-gpio";
 		label = "rfkill-pcie-wlan";
@@ -277,6 +288,12 @@
 &hdmi0_in {
 	hdmi0_in_vp0: endpoint {
 		remote-endpoint = <&vp0_out_hdmi0>;
+	};
+};
+
+&hdmi0_out {
+	hdmi0_out_con: endpoint {
+		remote-endpoint = <&hdmi0_con_in>;
 	};
 };
 

--- a/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
@@ -26,7 +26,7 @@
 		simple-audio-card,name = "Analog";
 		simple-audio-card,format = "i2s";
 		simple-audio-card,mclk-fs = <256>;
-		simple-audio-card,hp-det-gpio = <&gpio1 RK_PD5 GPIO_ACTIVE_LOW>;
+		simple-audio-card,hp-det-gpios = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
 		simple-audio-card,bitclock-master = <&daicpu>;
 		simple-audio-card,frame-master = <&daicpu>;
 
@@ -349,7 +349,6 @@
 };
 
 &i2c7 {
-	pinctrl-0 = <&i2c7m0_xfer>;
 	status = "okay";
 
 	es8388: audio-codec@11 {
@@ -359,17 +358,10 @@
 		assigned-clock-rates = <12288000>;
 		AVDD-supply = <&vcc_3v3_s3>;
 		clocks = <&cru I2S0_8CH_MCLKOUT>;
-		clock-names = "mclk";
 		DVDD-supply = <&vcc_1v8_s3>;
 		HPVDD-supply = <&vcc_3v3_s3>;
 		PVDD-supply = <&vcc_1v8_s3>;
 		#sound-dai-cells = <0>;
-
-		port {
-			es8388_p0_0: endpoint {
-				remote-endpoint = <&i2s0_8ch_p0_0>;
-			};
-		};
 	};
 };
 
@@ -381,14 +373,6 @@
 		     &i2s0_sdi0
 		     &i2s0_sdo0>;
 	status = "okay";
-
-	i2s0_8ch_p0: port {
-		i2s0_8ch_p0_0: endpoint {
-			dai-format = "i2s";
-			mclk-fs = <256>;
-			remote-endpoint = <&es8388_p0_0>;
-		};
-	};
 };
 
 &mdio0 {

--- a/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.13/dt/rk3588-hinlink-h88k.dts
@@ -103,6 +103,17 @@
 		};
 	};
 
+	hdmi1-con {
+		compatible = "hdmi-connector";
+		type = "a";
+
+		port {
+			hdmi1_con_in: endpoint {
+				remote-endpoint = <&hdmi1_out_con>;
+			};
+		};
+	};
+
 	rfkilli-wifi {
 		compatible = "rfkill-gpio";
 		label = "rfkill-pcie-wlan";
@@ -295,6 +306,26 @@
 	hdmi0_out_con: endpoint {
 		remote-endpoint = <&hdmi0_con_in>;
 	};
+};
+
+&hdmi1 {
+	status = "okay";
+};
+
+&hdmi1_in {
+	hdmi1_in_vp1: endpoint {
+		remote-endpoint = <&vp1_out_hdmi1>;
+	};
+};
+
+&hdmi1_out {
+	hdmi1_out_con: endpoint {
+		remote-endpoint = <&hdmi1_con_in>;
+	};
+};
+
+&hdptxphy1 {
+	status = "okay";
 };
 
 &hdmi_receiver_cma {
@@ -931,5 +962,12 @@
 	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
 		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
 		remote-endpoint = <&hdmi0_in_vp0>;
+	};
+};
+
+&vp1 {
+	vp1_out_hdmi1: endpoint@ROCKCHIP_VOP2_EP_HDMI1 {
+		reg = <ROCKCHIP_VOP2_EP_HDMI1>;
+		remote-endpoint = <&hdmi1_in_vp1>;
 	};
 };


### PR DESCRIPTION
1. sync `rockchip64-6.12/dt/rk3588-hinlink-h88k.dts` to `rockchip64-6.13/dt/rk3588-hinlink-h88k.dts` due to missing fixup in this pr: https://github.com/armbian/build/pull/7840
2. fix headphones jack det pin, gpio active level should be high accroding to upstream vendor dts see https://github.com/armbian/linux-rockchip/blob/e0908710633e847beac6e515cc8131b64544623b/arch/arm64/boot/dts/rockchip/rk3588-hinlink-h88k.dts#L201
3. add missing hdmi0_con port
4. second hdmi output support 

My test on the second hdmi output has a limited output resolution up to 1920*1080 60Hz

wait for pr https://github.com/armbian/build/pull/7835 and need to solve some rebase conflicts