### PR TITLE
generate_CODEOWNERS.sh: fix issues and support BOOTPATCHDIR and ATFPATCHDIR

### DIFF
--- a/.github/generate_CODEOWNERS.sh
+++ b/.github/generate_CODEOWNERS.sh
@@ -7,6 +7,13 @@ function display_alert() { :; }
 function enable_extension() { :; }
 function add_packages_to_image() { :; }
 
+function run_hook() {
+	local hook_point="$1"
+	while read -r hook_point_function; do
+		"${hook_point_function}"
+	done < <(compgen -A function | grep "^${hook_point}__" | LC_ALL=C.UTF-8 sort)
+}
+
 # $1: board config
 function generate_for_board() {
 	local board_config="$1"
@@ -22,6 +29,9 @@ function generate_for_board() {
 				source "${SRC}/config/sources/families/${LINUXFAMILY}.conf"
 				source "${SRC}/config/sources/common.conf"
 				source "${SRC}/config/sources/${ARCH}.conf"
+
+				run_hook "post_family_config"
+				run_hook "post_family_config_branch_${BRANCH,,}"
 
 				[[ -z $LINUXCONFIG ]] && LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
 				[[ -z $KERNELPATCHDIR ]] && KERNELPATCHDIR="archive/${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}"

--- a/.github/generate_CODEOWNERS.sh
+++ b/.github/generate_CODEOWNERS.sh
@@ -18,7 +18,9 @@ function run_hook() {
 function generate_for_board() {
 	local board_config="$1"
 	(
+		BOARD="${board_config%.*}"
 		source "${SRC}/config/boards/${board_config}"
+
 		LINUXFAMILY="${BOARDFAMILY}"
 
 		[[ -n "${BOARD_MAINTAINER}" ]] || return

--- a/.github/generate_CODEOWNERS.sh
+++ b/.github/generate_CODEOWNERS.sh
@@ -24,7 +24,7 @@ function generate_for_board() {
 				source "${SRC}/config/sources/${ARCH}.conf"
 
 				[[ -z $LINUXCONFIG ]] && LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
-				[[ -z $KERNELPATCHDIR ]] && KERNELPATCHDIR="$LINUXFAMILY-$BRANCH"
+				[[ -z $KERNELPATCHDIR ]] && KERNELPATCHDIR="archive/${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}"
 
 				cat <<-EOF
 					config/boards/${board_config}			${maintainers}

--- a/.github/generate_CODEOWNERS.sh
+++ b/.github/generate_CODEOWNERS.sh
@@ -68,9 +68,9 @@ function merge() {
 	local file
 	while read -r file; do
 		declare -a maintainers
-		readarray -t maintainers < <(echo "${codeowners["$file"]}" | xargs -n1 | sort -u)
+		readarray -t maintainers < <(echo "${codeowners["$file"]}" | xargs -n1 | LC_ALL=C.UTF-8 sort -u)
 		echo "${file}		${maintainers[*]}"
-	done < <(printf "%s\n" "${!codeowners[@]}" | sort)
+	done < <(printf "%s\n" "${!codeowners[@]}" | LC_ALL=C.UTF-8 sort)
 }
 
 cat <<-EOF >"${SRC}/.github/CODEOWNERS"

--- a/.github/generate_CODEOWNERS.sh
+++ b/.github/generate_CODEOWNERS.sh
@@ -39,7 +39,7 @@ function generate_for_board() {
 				cat <<-EOF
 					config/boards/${board_config}			${maintainers}
 					config/kernel/${LINUXCONFIG%-*}-*.config	${maintainers}
-					sources/families/${LINUXFAMILY}.conf		${maintainers}
+					sources/families/${BOARDFAMILY}.conf		${maintainers}
 					patch/kernel/${KERNELPATCHDIR%-*}-*/		${maintainers}
 				EOF
 

--- a/.github/generate_CODEOWNERS.sh
+++ b/.github/generate_CODEOWNERS.sh
@@ -36,6 +36,7 @@ function generate_for_board() {
 				[[ -z $LINUXCONFIG ]] && LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
 				[[ -z $KERNELPATCHDIR ]] && KERNELPATCHDIR="archive/${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}"
 				[[ -z $BOOTPATCHDIR ]] && BOOTPATCHDIR="u-boot-${LINUXFAMILY}"
+				[[ -z $ATFPATCHDIR ]] && ATFPATCHDIR="atf-${LINUXFAMILY}"
 
 				cat <<-EOF
 					config/boards/${board_config}			${maintainers}
@@ -54,6 +55,10 @@ function generate_for_board() {
 					while read -r d; do
 						echo "patch/u-boot/${d}/		${maintainers}"
 					done < <(echo "${BOOTPATCHDIR}" | xargs -n1)
+				fi
+
+				if [[ -n "${ATFSOURCE}" && "${ATFSOURCE}" != "none" ]]; then
+					echo "patch/atf/${ATFPATCHDIR}/			${maintainers}"
 				fi
 			)
 		done < <(echo "${KERNEL_TARGET}" | tr ',' '\n')

--- a/.github/generate_CODEOWNERS.sh
+++ b/.github/generate_CODEOWNERS.sh
@@ -3,12 +3,9 @@
 SRC="$(realpath "${BASH_SOURCE%/*}/../")"
 
 # Dummy function for successful source
-function display_alert() {
-	:
-}
-function enable_extension() {
-	:
-}
+function display_alert() { :; }
+function enable_extension() { :; }
+function add_packages_to_image() { :; }
 
 # $1: board config
 function generate_for_board() {

--- a/.github/generate_CODEOWNERS.sh
+++ b/.github/generate_CODEOWNERS.sh
@@ -35,6 +35,7 @@ function generate_for_board() {
 
 				[[ -z $LINUXCONFIG ]] && LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
 				[[ -z $KERNELPATCHDIR ]] && KERNELPATCHDIR="archive/${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}"
+				[[ -z $BOOTPATCHDIR ]] && BOOTPATCHDIR="u-boot-${LINUXFAMILY}"
 
 				cat <<-EOF
 					config/boards/${board_config}			${maintainers}
@@ -47,6 +48,12 @@ function generate_for_board() {
 				if [[ -n "${patch_archive}" ]]; then
 					patch_archive="${patch_archive%/}"
 					echo "patch/kernel/${patch_archive%-*}-*/	${maintainers}"
+				fi
+
+				if [[ -n "${BOOTCONFIG}" && "${BOOTCONFIG}" != "none" ]]; then
+					while read -r d; do
+						echo "patch/u-boot/${d}/		${maintainers}"
+					done < <(echo "${BOOTPATCHDIR}" | xargs -n1)
 				fi
 			)
 		done < <(echo "${KERNEL_TARGET}" | tr ',' '\n')


### PR DESCRIPTION
# Description

update generate_CODEOWNERS.sh:
  - support defined in hook
  - correct default KERNELPATCHDIR
  - support BOOTPATCHDIR and ATFPATCHDIR

# How Has This Been Tested?

- [X] Run

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
