### PR TITLE
python3: do not rely on hostdeps python3-pip nor python3-dev; deploy pip via get-pip.py

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -219,17 +219,11 @@ function adaptative_prepare_host_dependencies() {
 
 	### Python3 -- required for Armbian's Python tooling, and also for more recent u-boot builds. Needs 3.9+; ffi-dev is needed for some Python packages when the wheel is not prebuilt
 	### 'python3-setuptools' and 'python3-pyelftools' moved to requirements.txt to make sure build hosts use the same/latest versions of these tools.
-	host_dependencies+=("python3-dev" "python3-pip" "libffi-dev")
+	### 'python3-dev' depends on distutils, so instead depend on libpython3-dev which doesn't.
+	host_dependencies+=("python3" "libpython3-dev" "libffi-dev")
 
 	# Needed for some u-boot's, lest "tools/mkeficapsule.c:21:10: fatal error: gnutls/gnutls.h"
 	host_dependencies+=("libgnutls28-dev")
-
-	# Noble/Trixie and later releases do not carry "python3-distutils" https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated
-	if [[ "$host_release" =~ ^(trixie|sid|noble|wilma)$ ]]; then
-		display_alert "python3-distutils not available on host release '${host_release}'" "distutils was deprecated with Python 3.12" "debug"
-	else
-		host_dependencies+=("python3-distutils")
-	fi
 
 	### Python2 -- required for some older u-boot builds
 	# Debian newer than 'bookworm' and Ubuntu newer than 'lunar'/'mantic' does not carry python2 anymore; in this case some u-boot's might fail to build.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 # Always use a fixed version, this is important for correct hashing.
 # Dependabot will keep these versions up to date.
 
+pip == 25.0.1          # pip is the package installer for Python
 setuptools == 75.8.0   # for building Python packages
 pyelftools == 0.31     # for building U-Boot
 unidiff == 0.7.5       # for parsing unified diff


### PR DESCRIPTION
- python3-pip implies a very old setuptools (which is system-wide and takes precedence)
- python3-dev implies python3-distutils (which is long deprecated)
- get-pip.py allows us to version pip in requirements.txt just like everything else
- in the end this fixes the conundrum with pylibfdt / dtschema on Jammy
- and, finally, the setuptools we specify in requirements.txt will be actually used