### PR TITLE
arm64: dts: rockchip: fix gpio-line-names to radxa-rock-3a

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/board-rock3a-0003-add-gpio-names.patch
+++ b/patch/kernel/archive/rockchip64-6.12/board-rock3a-0003-add-gpio-names.patch
@@ -1,84 +1,102 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Werner <werner@armbian.com>
-Date: Wed, 23 Oct 2024 12:27:21 +0200
-Subject: add gpio names for rock-3a
+Date: Mon, 24 Feb 2025 05:13:09 +0000
+Subject: arm64: dts: rockchip: add gpio-line-names to radxa-rock-3a
 
 Signed-off-by: Werner <werner@armbian.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts | 60 ++++++++++
- 1 file changed, 60 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts | 76 ++++++++++
+ 1 file changed, 76 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
-index 111111111111..222222222222 100644
+index bb9bdabf1..d2423cd67 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
-@@ -277,6 +277,66 @@ &gpu {
- 	status = "okay";
+@@ -275,10 +275,86 @@ &gmac1m1_clkinout
+ &gpu {
+        mali-supply = <&vdd_gpu>;
+        status = "okay";
  };
- 
+
 +&gpio0 {
-+		gpio-line-names =
-+				/* GPIO0_A0 - A7 */
-+				"", "", "", "", "", "", "", "",
-+				/* GPIO0_B0 - B7 */
-+				"", "", "", "pin-28 [GPIO0_B3]", "pin-27 [GPIO0_B4]", "pin-7 [GPIO0_B5]", "pin-16 [GPIO0_B6]", "",
-+				/* GPIO0_C0 - C7 */
-+				"", "pin-22 [GPIO0_C1]", "", "", "", "", "", "",
-+				/* GPIO0_D0 - D7 */
-+				"pin-10 [GPIO0_D0]", "pin-8 [GPIO0_D1]", "", "", "", "", "", "";
++       gpio-line-names =
++               /* GPIO0_A0 - A7 */
++               "", "", "", "", "", "", "", "",
++               /* GPIO0_B0 - B7 */
++               "",                  "",                  "",
++               "pin-28 [GPIO0_B3]", "pin-27 [GPIO0_B4]", "pin-07 [GPIO0_B5]",
++               "pin-16 [GPIO0_B6]", "",
++               /* GPIO0_C0 - C7 */
++               "",                  "pin-22 [GPIO0_C1]", "",
++               "", "", "", "", "",
++               /* GPIO0_D0 - D7 */
++               "pin-10 [GPIO0_D0]", "pin-08 [GPIO0_D1]", "",
++               "", "", "", "", "";
 +};
 +
 +&gpio1 {
-+		gpio-line-names =
-+				/* GPIO1_A0 - A7 */
-+				"pin-3 [GPIO1_A0]", "pin-5 [GPIO1_A1]", "", "", "", "", "", "",
-+				/* GPIO1_B0 - B7 */
-+				"", "", "", "", "", "", "", "",
-+				/* GPIO1_C0 - C7 */
-+				"pin-15 [GPIO0_C0]", "", "", "", "", "", "", "",
-+				/* GPIO1_D0 - D7 */
-+				"", "", "", "", "", "", "", "";
++       gpio-line-names =
++               /* GPIO1_A0 - A7 */
++               "pin-03 [GPIO1_A0]", "pin-05 [GPIO1_A1]", "", "",
++               "", "", "", "",
++               /* GPIO1_B0 - B7 */
++               "", "", "", "", "", "", "", "",
++               /* GPIO1_C0 - C7 */
++               "pin-15 [GPIO0_C0]", "", "",
++               "", "", "", "", "",
++               /* GPIO1_D0 - D7 */
++               "", "", "", "", "", "", "", "";
 +};
 +
 +&gpio2 {
-+		gpio-line-names =
-+				/* GPIO2_A0 - A7 */
-+				"", "", "", "", "", "", "", "",
-+				/* GPIO2_B0 - B7 */
-+				"", "", "", "", "", "", "", "",
-+				/* GPIO2_C0 - C7 */
-+				"", "", "", "", "", "", "", "",
-+				/* GPIO2_D0 - D7 */
-+				"", "", "", "", "", "", "", "pin-29 [GPIO2_D7]";
++       gpio-line-names =
++               /* GPIO2_A0 - A7 */
++               "", "", "", "", "", "", "", "",
++               /* GPIO2_B0 - B7 */
++               "", "", "", "", "", "", "", "",
++               /* GPIO2_C0 - C7 */
++               "", "", "", "", "", "", "", "",
++               /* GPIO2_D0 - D7 */
++               "", "", "", "",
++               "", "", "", "pin-29 [GPIO2_D7]";
 +};
 +
 +&gpio3 {
-+		gpio-line-names =
-+				/* GPIO3_A0 - A7 */
-+				"pin-31 [GPIO3_A0]", "", "pin-36 [GPIO3_A2]", "pin-12 [GPIO3_A3]", "pin-35 [GPIO3_A4]", "pin-40 [GPIO3_A5]", "pin-38 [GPIO3_A6]", "",
-+				/* GPIO3_B0 - B7 */
-+				"", "", "pin-18 [GPIO3_B2]", "", "", "", "", "",
-+				/* GPIO3_C0 - C7 */
-+				"", "", "pin-32 [GPIO3_C2]", "pin-33 [GPIO3_C3]", "pin-11 [GPIO3_C4]", "pin-13 [GPIO3_C5]", "", "",
-+				/* GPIO3_D0 - D7 */
-+				"", "", "", "", "", "", "", "";
++       gpio-line-names =
++               /* GPIO3_A0 - A7 */
++               "pin-31 [GPIO3_A0]", "",                  "pin-36 [GPIO3_A2]",
++               "pin-12 [GPIO3_A3]", "pin-35 [GPIO3_A4]", "pin-40 [GPIO3_A5]",
++               "pin-38 [GPIO3_A6]", "",
++               /* GPIO3_B0 - B7 */
++               "",                  "",                  "pin-18 [GPIO3_B2]",
++               "", "", "", "", "",
++               /* GPIO3_C0 - C7 */
++               "",                  "",                  "pin-32 [GPIO3_C2]",
++               "pin-33 [GPIO3_C3]", "pin-11 [GPIO3_C4]", "pin-13 [GPIO3_C5]",
++               "",                  "",
++               /* GPIO3_D0 - D7 */
++               "", "", "", "", "", "", "", "";
 +};
 +
 +&gpio4 {
-+		gpio-line-names =
-+				/* GPIO4_A0 - A7 */
-+				"", "", "", "", "", "", "", "",
-+				/* GPIO4_B0 - B7 */
-+				"", "", "", "", "", "", "", "",
-+				/* GPIO4_C0 - C7 */
-+				"", "", "pin-21 [GPIO4_C2]", "pin-19 [GPIO4_C3]", "", "pin-21 [GPIO4_C5]", "pin-24 [GPIO4_C6]", "",
-+				/* GPIO4_D0 - D7 */
-+				"", "pin-26 [GPIO4_D1]", "", "", "", "", "", "";
++       gpio-line-names =
++               /* GPIO4_A0 - A7 */
++               "", "", "", "", "", "", "", "",
++               /* GPIO4_B0 - B7 */
++               "", "", "", "", "", "", "", "",
++               /* GPIO4_C0 - C7 */
++               "",                  "",                  "pin-23 [GPIO4_C2]",
++               "pin-19 [GPIO4_C3]", "",                  "pin-21 [GPIO4_C5]",
++               "pin-24 [GPIO4_C6]", "",
++               /* GPIO4_D0 - D7 */
++               "",                  "pin-26 [GPIO4_D1]", "",
++               "", "", "", "", "";
 +};
 +
++
  &hdmi {
- 	avdd-0v9-supply = <&vdda0v9_image>;
- 	avdd-1v8-supply = <&vcca1v8_image>;
--- 
-Armbian
-
+        avdd-0v9-supply = <&vdda0v9_image>;
+        avdd-1v8-supply = <&vcca1v8_image>;
+        pinctrl-names = "default";
+        pinctrl-0 = <&hdmitx_scl &hdmitx_sda &hdmitxm1_cec>;
+--

--- a/patch/kernel/archive/rockchip64-6.12/board-rock3a-0003-add-gpio-names.patch
+++ b/patch/kernel/archive/rockchip64-6.12/board-rock3a-0003-add-gpio-names.patch
@@ -1,23 +1,23 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Werner <werner@armbian.com>
-Date: Mon, 24 Feb 2025 05:13:09 +0000
+Date: Mon, 24 Feb 2025 06:33:04 +0100
 Subject: arm64: dts: rockchip: add gpio-line-names to radxa-rock-3a
 
 Signed-off-by: Werner <werner@armbian.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts | 76 ++++++++++
- 1 file changed, 76 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts | 75 ++++++++++
+ 1 file changed, 75 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
-index bb9bdabf1..d2423cd67 100644
+index bb9bdabf1..86953e46e 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
-@@ -275,10 +275,86 @@ &gmac1m1_clkinout
+@@ -275,10 +275,85 @@ &gmac1m1_clkinout
  &gpu {
-        mali-supply = <&vdd_gpu>;
-        status = "okay";
+ 	mali-supply = <&vdd_gpu>;
+ 	status = "okay";
  };
-
+ 
 +&gpio0 {
 +       gpio-line-names =
 +               /* GPIO0_A0 - A7 */
@@ -93,10 +93,11 @@ index bb9bdabf1..d2423cd67 100644
 +               "", "", "", "", "";
 +};
 +
-+
  &hdmi {
-        avdd-0v9-supply = <&vdda0v9_image>;
-        avdd-1v8-supply = <&vcca1v8_image>;
-        pinctrl-names = "default";
-        pinctrl-0 = <&hdmitx_scl &hdmitx_sda &hdmitxm1_cec>;
---
+ 	avdd-0v9-supply = <&vdda0v9_image>;
+ 	avdd-1v8-supply = <&vcca1v8_image>;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&hdmitx_scl &hdmitx_sda &hdmitxm1_cec>;
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

This patch adjust formatting of the gpio-line-names according to kernel documentation...well, not really. Actually it (mostly) follows Trevor Woerners submission of the gpio names to the radxa-zero-3 series and since it was accepted upstream I assume it should be fine.

If anyone wants to send this upstream, feel free to do so. I don't mind about copyright or whatever. Just do it.

# How Has This Been Tested?

- [x] build
- [x] boot https://paste.next.armbian.com/turucidole
- [x] `gpioinfo` https://paste.armbian.de/ecocupetam.yaml

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
