### PR TITLE
Move Meson GX to LibreElec FIP

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -55,45 +55,6 @@ function custom_kernel_config__enable_rtl88x2cs_driver() {
 	fi
 }
 
-# this helper function includes postprocess for p212 and its variants.
-# $1 PATH for uboot blob repo
-# $2 dir name in uboot blob repo
-uboot_gxl_postprocess() {
-	run_host_command_logged mv -v u-boot.bin bl33.bin
-
-	run_host_command_logged $1/blx_fix.sh $1/$2/bl30.bin \
-		$1/$2/zero_tmp \
-		$1/$2/bl30_zero.bin \
-		$1/$2/bl301.bin \
-		$1/$2/bl301_zero.bin \
-		$1/$2/bl30_new.bin bl30
-
-	run_host_command_logged python2 $1/acs_tool.pyc $1/$2/bl2.bin \
-		$1/$2/bl2_acs.bin \
-		$1/$2/acs.bin 0
-
-	run_host_command_logged $1/blx_fix.sh $1/$2/bl2_acs.bin \
-		$1/$2/zero_tmp \
-		$1/$2/bl2_zero.bin \
-		$1/$2/bl21.bin \
-		$1/$2/bl21_zero.bin \
-		$1/$2/bl2_new.bin bl2
-
-	run_host_x86_binary_logged $1/$2/aml_encrypt_gxl --bl3enc --input $1/$2/bl30_new.bin
-	run_host_x86_binary_logged $1/$2/aml_encrypt_gxl --bl3enc --input $1/$2/bl31.img
-	run_host_x86_binary_logged $1/$2/aml_encrypt_gxl --bl3enc --input bl33.bin
-
-	run_host_x86_binary_logged $1/$2/aml_encrypt_gxl --bl2sig --input $1/$2/bl2_new.bin \
-		--output bl2.n.bin.sig
-
-	run_host_x86_binary_logged $1/$2/aml_encrypt_gxl --bootmk \
-		--output u-boot.bin \
-		--bl2 bl2.n.bin.sig \
-		--bl30 $1/$2/bl30_new.bin.enc \
-		--bl31 $1/$2/bl31.img.enc \
-		--bl33 bl33.bin.enc
-}
-
 # this helper function includes postprocess for s400 and its variants.
 # $1 PATH for uboot blob repo
 # $2 dir name in uboot blob repo

--- a/config/sources/families/meson-gxbb.conf
+++ b/config/sources/families/meson-gxbb.conf
@@ -9,28 +9,23 @@
 # shellcheck source=config/sources/families/include/meson64_common.inc
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 
-# Fetch c2 blobs. Those are ancient, when first released by HK. Also used in meson-gxl.conf
-function fetch_sources_tools__amlogic_odroidc2_blobs_fip() {
-	fetch_from_repo "https://github.com/armbian/odroidc2-blobs" "odroidc2-blobs" "branch:master"
-}
-
 if [[ $BOARD == odroidc2 ]]; then
-	UBOOT_TARGET_MAP=";;$SRC/cache/sources/odroidc2-blobs/bl1.bin.hardkernel u-boot.bin"
+	UBOOT_TARGET_MAP=";;$SRC/cache/sources/amlogic-boot-fip/odroid-c2/bl1.bin.hardkernel u-boot.bin"
 fi
 
 uboot_custom_postprocess() {
-	local fip_blobs_dir="$SRC/cache/sources/odroidc2-blobs/"
+	local fip_blobs_dir="$SRC/cache/sources/amlogic-boot-fip"
 
 	if [[ $BOARD == odroidc2 ]]; then
-		run_host_x86_binary_logged $fip_blobs_dir/fip_create --bl30 $fip_blobs_dir/gxb/bl30.bin \
-			--bl301 $fip_blobs_dir/gxb/bl301.bin \
-			--bl31 $fip_blobs_dir/gxb/bl31.bin \
+		run_host_x86_binary_logged $fip_blobs_dir/odroid-c2/fip_create --bl30 $fip_blobs_dir/odroid-c2/bl30.bin \
+			--bl301 $fip_blobs_dir/odroid-c2/bl301.bin \
+			--bl31 $fip_blobs_dir/odroid-c2/bl31.bin \
 			--bl33 u-boot.bin \
 			fip.bin
-		run_host_x86_binary_logged $fip_blobs_dir/fip_create --dump fip.bin
-		run_host_command_logged cat $fip_blobs_dir/gxb/bl2.package fip.bin ">" boot_new.bin
+		run_host_x86_binary_logged $fip_blobs_dir/odroid-c2/fip_create --dump fip.bin
+		run_host_command_logged cat $fip_blobs_dir/odroid-c2/bl2.package fip.bin ">" boot_new.bin
 		run_host_command_logged rm -fv u-boot.img
-		run_host_x86_binary_logged $fip_blobs_dir/gxb/aml_encrypt_gxb --bootsig \
+		run_host_x86_binary_logged $fip_blobs_dir/odroid-c2/aml_encrypt_gxb --bootsig \
 			--input boot_new.bin \
 			--output u-boot.img
 		run_host_command_logged rm -fv u-boot.bin
@@ -40,34 +35,34 @@ uboot_custom_postprocess() {
 	if [[ $BOARD == nanopik2-s905 ]]; then
 		run_host_command_logged mv -v u-boot.bin bl33.bin
 
-		run_host_command_logged $fip_blobs_dir/blx_fix.sh $fip_blobs_dir/k2/bl30.bin \
-			$fip_blobs_dir/k2/zero_tmp \
-			$fip_blobs_dir/k2/bl30_zero.bin \
-			$fip_blobs_dir/k2/bl301.bin \
-			$fip_blobs_dir/k2/bl301_zero.bin \
-			$fip_blobs_dir/k2/bl30_new.bin bl30
+		run_host_command_logged $fip_blobs_dir/nanopi-k2/blx_fix.sh $fip_blobs_dir/nanopi-k2/bl30.bin \
+			$fip_blobs_dir/nanopi-k2/zero_tmp \
+			$fip_blobs_dir/nanopi-k2/bl30_zero.bin \
+			$fip_blobs_dir/nanopi-k2/bl301.bin \
+			$fip_blobs_dir/nanopi-k2/bl301_zero.bin \
+			$fip_blobs_dir/nanopi-k2/bl30_new.bin bl30
 
-		run_host_x86_binary_logged $fip_blobs_dir/k2/fip_create --bl30 $fip_blobs_dir/k2/bl30_new.bin \
-			--bl31 $fip_blobs_dir/k2/bl31.img \
+		run_host_x86_binary_logged $fip_blobs_dir/nanopi-k2/fip_create --bl30 $fip_blobs_dir/nanopi-k2/bl30_new.bin \
+			--bl31 $fip_blobs_dir/nanopi-k2/bl31.img \
 			--bl33 bl33.bin \
-			$fip_blobs_dir/k2/fip.bin
+			$fip_blobs_dir/nanopi-k2/fip.bin
 
-		run_host_x86_binary_logged $fip_blobs_dir/k2/fip_create --dump $fip_blobs_dir/k2/fip.bin
+		run_host_x86_binary_logged $fip_blobs_dir/nanopi-k2/fip_create --dump $fip_blobs_dir/nanopi-k2/fip.bin
 
-		run_host_command_logged python2 $fip_blobs_dir/acs_tool.pyc $fip_blobs_dir/k2/bl2.bin \
-			$fip_blobs_dir/k2/bl2_acs.bin \
-			$fip_blobs_dir/k2/acs.bin 0
+		run_host_command_logged python2 $fip_blobs_dir/nanopi-k2/acs_tool.py $fip_blobs_dir/nanopi-k2/bl2.bin \
+			$fip_blobs_dir/nanopi-k2/bl2_acs.bin \
+			$fip_blobs_dir/nanopi-k2/acs.bin 0
 
-		run_host_command_logged $fip_blobs_dir/blx_fix.sh $fip_blobs_dir/k2/bl2_acs.bin \
-			$fip_blobs_dir/k2/zero_tmp \
-			$fip_blobs_dir/k2/bl2_zero.bin \
-			$fip_blobs_dir/k2/bl21.bin \
-			$fip_blobs_dir/k2/bl21_zero.bin \
-			$fip_blobs_dir/k2/bl2_new.bin bl2
+		run_host_command_logged $fip_blobs_dir/nanopi-k2/blx_fix.sh $fip_blobs_dir/nanopi-k2/bl2_acs.bin \
+			$fip_blobs_dir/nanopi-k2/zero_tmp \
+			$fip_blobs_dir/nanopi-k2/bl2_zero.bin \
+			$fip_blobs_dir/nanopi-k2/bl21.bin \
+			$fip_blobs_dir/nanopi-k2/bl21_zero.bin \
+			$fip_blobs_dir/nanopi-k2/bl2_new.bin bl2
 
-		run_host_command_logged cat $fip_blobs_dir/k2/bl2_new.bin $fip_blobs_dir/k2/fip.bin ">" boot_new.bin
+		run_host_command_logged cat $fip_blobs_dir/nanopi-k2/bl2_new.bin $fip_blobs_dir/nanopi-k2/fip.bin ">" boot_new.bin
 
-		run_host_x86_binary_logged $fip_blobs_dir/k2/aml_encrypt_gxb --bootsig \
+		run_host_x86_binary_logged $fip_blobs_dir/nanopi-k2/aml_encrypt_gxb --bootsig \
 			--input boot_new.bin \
 			--output u-boot.bin
 

--- a/config/sources/families/meson-gxl.conf
+++ b/config/sources/families/meson-gxl.conf
@@ -9,11 +9,6 @@
 # shellcheck source=config/sources/families/include/meson64_common.inc
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 
-# Fetch c2 blobs. Those are ancient, when first released by HK. Also used in meson-gxbb.conf
-function fetch_sources_tools__amlogic_odroidc2_blobs_fip() {
-	fetch_from_repo "https://github.com/armbian/odroidc2-blobs" "odroidc2-blobs" "branch:master"
-}
-
 if [[ $BOARD == lafrite ]] || [[ $BOARD == sweet-potato ]]; then
 	UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin:u-boot.bin u-boot-dtb.img"
 	BOOTSCRIPT="boot-meson-gx.cmd:boot.cmd"


### PR DESCRIPTION
# Description

Move Meson GX boards to LibreELEC FIP source, clean up config files now that we no longer use the unmaintained Armbian mirror of the HK ones.

Boards Affected:  

- [x] Odroid C2
- [x] NanoPi K2 

# How Has This Been Tested?

- [x] Build/boot NanoPi K2
- [x] Build/boot Odroid C2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
