### PR TITLE
hinlink-h88k: revert second hdmi output support for 6.12 kernel

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3588-hinlink-h88k.dts
@@ -103,17 +103,6 @@
 		};
 	};
 
-	hdmi1-con {
-		compatible = "hdmi-connector";
-		type = "a";
-
-		port {
-			hdmi1_con_in: endpoint {
-				remote-endpoint = <&hdmi1_out_con>;
-			};
-		};
-	};
-
 	rfkilli-wifi {
 		compatible = "rfkill-gpio";
 		label = "rfkill-pcie-wlan";
@@ -306,26 +295,6 @@
 	hdmi0_out_con: endpoint {
 		remote-endpoint = <&hdmi0_con_in>;
 	};
-};
-
-&hdmi1 {
-	status = "okay";
-};
-
-&hdmi1_in {
-	hdmi1_in_vp1: endpoint {
-		remote-endpoint = <&vp1_out_hdmi1>;
-	};
-};
-
-&hdmi1_out {
-	hdmi1_out_con: endpoint {
-		remote-endpoint = <&hdmi1_con_in>;
-	};
-};
-
-&hdptxphy1 {
-	status = "okay";
 };
 
 &hdmi_receiver_cma {
@@ -962,12 +931,5 @@
 	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
 		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
 		remote-endpoint = <&hdmi0_in_vp0>;
-	};
-};
-
-&vp1 {
-	vp1_out_hdmi1: endpoint@ROCKCHIP_VOP2_EP_HDMI1 {
-		reg = <ROCKCHIP_VOP2_EP_HDMI1>;
-		remote-endpoint = <&hdmi1_in_vp1>;
 	};
 };


### PR DESCRIPTION
partial revert this commit: https://github.com/armbian/build/pull/7864/commits/89a66548dccf4755d0ff80eef60a2e3f24f7db2b
as second hdmi output is only supported in 6.13 and above.

alternetivly backport second hdmi output patch `rk3588-0130-add-hdmi1-support.patch` to 6.12 