### PR TITLE
rockchip64: fix OrangePi 4 LTS boot with BTF, bump uboot to 2024.10

### DIFF
--- a/config/boards/orangepi4-lts.conf
+++ b/config/boards/orangepi4-lts.conf
@@ -4,7 +4,7 @@
 BOARD_NAME="Orange Pi 4 LTS"
 BOARDFAMILY="rockchip64" # Used to be rk3399
 BOARD_MAINTAINER="paolosabatino"
-BOOTCONFIG="orangepi-4-rk3399_defconfig"
+BOOTCONFIG="orangepi-rk3399_defconfig"
 BOOT_FDT_FILE="rockchip/rk3399-orangepi-4-lts.dtb"
 KERNEL_TARGET="current,edge"
 KERNEL_TEST_TARGET="current"
@@ -13,8 +13,9 @@ MODULES_EDGE="sprdbt_tty sprdwl_ng"
 FULL_DESKTOP="yes"
 ASOUND_STATE="asound.state.rk3399"
 BOOT_LOGO="desktop"
-BOOTBRANCH_BOARD="tag:v2022.04"
-BOOTPATCHDIR="u-boot-rockchip64-v2022.04"
+BOOTBRANCH_BOARD="tag:v2024.10"
+BOOTPATCHDIR="v2024.10"
+BOOT_SCENARIO="binman"
 
 function post_family_tweaks_bsp__OPi4lts() {
 	display_alert "Installing BSP firmware and fixups"

--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3399-orangepi-4-lts.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3399-orangepi-4-lts.dts
@@ -1250,7 +1250,7 @@
 &dmc {
 	#cooling-cells = <2>; /* min followed by max */
 
-	status = "okay";
+	status = "disabled";
 	center-supply = <&vdd_log>;
 	operating-points-v2 = <&dmc_opp_table>;
 

--- a/patch/kernel/archive/rockchip64-6.14/dt/rk3399-orangepi-4-lts.dts
+++ b/patch/kernel/archive/rockchip64-6.14/dt/rk3399-orangepi-4-lts.dts
@@ -1250,7 +1250,7 @@
 &dmc {
 	#cooling-cells = <2>; /* min followed by max */
 
-	status = "okay";
+	status = "disabled";
 	center-supply = <&vdd_log>;
 	operating-points-v2 = <&dmc_opp_table>;
 

--- a/patch/u-boot/v2024.10/board_orangepi4-lts/board-orangepi4-rockchip-tpl.patch
+++ b/patch/u-boot/v2024.10/board_orangepi4-lts/board-orangepi4-rockchip-tpl.patch
@@ -1,0 +1,16 @@
+Alter the orangepi-rk3399_defconfig file to enable "External TPL", 
+because we want to use the Rockchip ddrbin in place of the u-boot TPL
+It has to be set with the env variable ROCKCHIP_TPL when invoking make
+
+diff --git a/configs/orangepi-rk3399_defconfig b/configs/orangepi-rk3399_defconfig
+index 5dfbdeaf17..167c2b3f60 100644
+--- a/configs/orangepi-rk3399_defconfig
++++ b/configs/orangepi-rk3399_defconfig
+@@ -8,6 +8,7 @@ CONFIG_ENV_OFFSET=0x3F8000
+ CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3399-orangepi"
+ CONFIG_DM_RESET=y
+ CONFIG_ROCKCHIP_RK3399=y
++CONFIG_ROCKCHIP_EXTERNAL_TPL=y
+ CONFIG_TARGET_EVB_RK3399=y
+ CONFIG_DEBUG_UART_BASE=0xFF1A0000
+ CONFIG_DEBUG_UART_CLOCK=24000000


### PR DESCRIPTION
# Description

At last I found, after quite a lot of headaches, that the OrangePi4 LTS booting issues with BTF-enabled kernels was not due to old u-boot, relocation issues or overlapping segments. Instead it was the utterly crappy (but woking) DMC driver that, when BTF is enabled, becomes an utterly crappy non working driver.

I disabled it and - magically - everything is fixed now.

In the meantime, believing the issue was in u-boot, I bumped u-boot to v2024.10 with little to almost no pain.
Some considerations:
* binman does a great job
* `BOOT_SCENARIO=binman` is already available for rockchip64 targets, idbloader and u-boot.itb are built by u-boot/binman, without doing it "manually" in the armbian family include script
* important is to use `CONFIG_ROCKCHIP_EXTERNAL_TPL=y` in u-boot config if the board wants the proprietary ddrbin, otherwise u-boot will use its own TPL as ddr initialization binary

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2618]

# How Has This Been Tested?

- [x] Built and tested a Debian Bookworm minimal image with current 6.12 kernel

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


[AR-2618]: https://armbian.atlassian.net/browse/AR-2618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ