### PR TITLE
Orangepi5 maintenance

### DIFF
--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -14,7 +14,6 @@ BOOT_SCENARIO="spl-blobs"
 BOOT_SUPPORT_SPI="yes"
 BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
-KERNEL_UPGRADE_FREEZE="vendor-rk35xx@24.8.1"
 declare -g UEFI_EDK2_BOARD_ID="orangepi-5" # This _only_ used for uefi-edk2-rk3588 extension
 
 # Mainline U-Boot for current kernel

--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -21,6 +21,31 @@ declare -g UEFI_EDK2_BOARD_ID="orangepi-5" # This _only_ used for uefi-edk2-rk35
 DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.15.bin'
 BL31_BLOB='rk35/rk3588_bl31_v1.44.elf'
 
+# Mainline U-Boot for current kernel
+function post_family_config_branch_current__orangepi5_use_mainline_uboot() {
+	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
+
+	declare -g BOOTCONFIG="orangepi-5-rk3588s_defconfig"         # override the default for the board/family
+	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ mainline U-Boot
+	declare -g BOOTBRANCH="tag:v2025.01"
+	declare -g BOOTPATCHDIR="v2025.01"
+	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+
+	function write_uboot_platform_mtd() {
+		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
+	}
+}
+
+
+
 declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # For the bluetooth-hciattach extension
 enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
 

--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -17,10 +17,6 @@ IMAGE_PARTITION_TABLE="gpt"
 KERNEL_UPGRADE_FREEZE="vendor-rk35xx@24.8.1"
 declare -g UEFI_EDK2_BOARD_ID="orangepi-5" # This _only_ used for uefi-edk2-rk3588 extension
 
-# @TODO: consider removing those, as the defaults in rockchip64_common have been bumped up
-DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.15.bin'
-BL31_BLOB='rk35/rk3588_bl31_v1.44.elf'
-
 # Mainline U-Boot for current kernel
 function post_family_config_branch_current__orangepi5_use_mainline_uboot() {
 	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"


### PR DESCRIPTION
# Description

- bump `current` u-boot to something more recent than old vendor bsp one
- unfix versions of BL31 and DDR
- unfreeze `vendor` kernel upgrades, seems good again.

Sata stuff may need testing since I cannot test myself.

# How Has This Been Tested?

- [x] build u-boot and image
- [x] boot from microsd
- [x] upgrade an existing setup with `vendor` kernel on NVMe/SPI combo from 24.05.y to 25.2.y Armbian kernel release, reboot
- [x] same setup as above, but overwrite vendor bsp u-boot with 2025.01, reboot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
