### PR TITLE
Add e2fspros as it fell out of default dependency

### DIFF
--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -9,6 +9,7 @@ dialog
 debconf-utils
 debsums
 dosfstools
+e2fspros
 fake-hwclock
 fdisk
 figlet

--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -9,7 +9,7 @@ dialog
 debconf-utils
 debsums
 dosfstools
-e2fspros
+e2fsprogs
 fake-hwclock
 fdisk
 figlet


### PR DESCRIPTION
# Description

This caused that root filesystem didn't complete due to missing resize2fs tools. On Debian Trixie.

GitHub issue: https://github.com/armbian/build/issues/7890
Jira: [AR-2620]

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2620]: https://armbian.atlassian.net/browse/AR-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ