### PR TITLE
rockchip/64: bump rk322x-box and rk3318-box to u-boot v2025.01

### DIFF
--- a/config/boards/rk3318-box.tvb
+++ b/config/boards/rk3318-box.tvb
@@ -10,8 +10,8 @@ BOOT_SCENARIO="tpl-blob-atf-mainline"
 DDR_BLOB="rk33/rk3318_ddr_333Mhz_v1.16.bin"
 BOOT_SOC="rk3328"
 
-BOOTBRANCH_BOARD="tag:v2024.07"
-BOOTPATCHDIR="v2024.07"
+BOOTBRANCH_BOARD="tag:v2025.01"
+BOOTPATCHDIR="v2025.01"
 
 enable_extension xorg-lima-serverflags
 

--- a/config/sources/families/rockchip.conf
+++ b/config/sources/families/rockchip.conf
@@ -42,8 +42,8 @@ elif [[ "$BOOT_SOC" == "rk322x" ]]; then
 	OVERLAY_PREFIX='rk322x'
 	UBOOT_TARGET_MAP="ROCKCHIP_TPL=$SRC/packages/blobs/rockchip/rk322x_ddr_333MHz_v1.11_2t.bin TEE=$SRC/packages/blobs/rockchip/rk322x_tee.bin;;u-boot-rk322x-with-spl.bin"
 
-	BOOTBRANCH='tag:v2024.07'
-	BOOTPATCHDIR='v2024.07'
+	BOOTBRANCH='tag:v2025.01'
+	BOOTPATCHDIR='v2025.01'
 
 fi
 

--- a/patch/u-boot/v2025.01/board_rk322x-box/rk3228-hdmi-clk-fixes.patch
+++ b/patch/u-boot/v2025.01/board_rk322x-box/rk3228-hdmi-clk-fixes.patch
@@ -1,0 +1,227 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Mon, 29 Apr 2024 16:18:46 +0200
+Subject: clock entries to accomodate rk3228 HDMI features
+
+---
+ arch/arm/include/asm/arch-rockchip/cru_rk322x.h |  14 +
+ drivers/clk/rockchip/clk_rk322x.c               | 129 +++++++++-
+ 2 files changed, 140 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/include/asm/arch-rockchip/cru_rk322x.h b/arch/arm/include/asm/arch-rockchip/cru_rk322x.h
+index 111111111111..222222222222 100644
+--- a/arch/arm/include/asm/arch-rockchip/cru_rk322x.h
++++ b/arch/arm/include/asm/arch-rockchip/cru_rk322x.h
+@@ -193,6 +193,10 @@ enum {
+ 	/* CRU_CLKSEL27_CON */
+ 	VOP_DCLK_DIV_SHIFT	= 8,
+ 	VOP_DCLK_DIV_MASK	= 0xff << VOP_DCLK_DIV_SHIFT,
++	VOP_DCLK_PLL_SEL_SHIFT	= 0,
++	VOP_DCLK_PLL_SEL_MASK	= 1 << VOP_DCLK_PLL_SEL_SHIFT,
++	VOP_DCLK_SEL_GPLL	= 0,
++	VOP_DCLK_SEL_CPLL	= 1,
+ 	VOP_PLL_SEL_SHIFT	= 1,
+ 	VOP_PLL_SEL_MASK	= 1 << VOP_PLL_SEL_SHIFT,
+ 
+@@ -200,6 +204,16 @@ enum {
+ 	GMAC_CLK_SRC_SHIFT	= 12,
+ 	GMAC_CLK_SRC_MASK	= 1 << GMAC_CLK_SRC_SHIFT,
+ 
++	/* CRU_CLKSEL33_CON */
++	VOP_ACLK_DIV_SHIFT	= 0,
++	VOP_ACLK_DIV_MASK	= 0x1f << VOP_ACLK_DIV_SHIFT,
++	VOP_ACLK_PLL_SEL_SHIFT	= 5,
++	VOP_ACLK_PLL_SEL_MASK	= 3 << VOP_ACLK_PLL_SEL_SHIFT,
++	VOP_ACLK_SEL_CPLL	= 0,
++	VOP_ACLK_SEL_GPLL	= 1,
++	VOP_ACLK_SEL_HDMIPHY	= 2,
++	VOP_ACLK_SEL_USBPHY	= 3,
++
+ 	/* CRU_SOFTRST5_CON */
+ 	DDRCTRL_PSRST_SHIFT	= 11,
+ 	DDRCTRL_SRST_SHIFT	= 10,
+diff --git a/drivers/clk/rockchip/clk_rk322x.c b/drivers/clk/rockchip/clk_rk322x.c
+index 111111111111..222222222222 100644
+--- a/drivers/clk/rockchip/clk_rk322x.c
++++ b/drivers/clk/rockchip/clk_rk322x.c
+@@ -367,6 +367,14 @@ static ulong rk322x_clk_get_rate(struct clk *clk)
+ 	case SCLK_SDMMC:
+ 		rate = rockchip_mmc_get_clk(priv->cru, gclk_rate, clk->id);
+ 		break;
++	case SCLK_HDMI_PHY:
++	case PCLK_HDMI_PHY:
++	case DCLK_HDMI_PHY:
++	case SCLK_HDMI_HDCP:
++	case PCLK_HDMI_CTRL:
++	case SCLK_HDMI_CEC:
++		printf("Attempt to get clk id %ld\n", clk->id);
++		return 0;
+ 	default:
+ 		return -ENOENT;
+ 	}
+@@ -374,6 +382,68 @@ static ulong rk322x_clk_get_rate(struct clk *clk)
+ 	return rate;
+ }
+ 
++#ifndef CONFIG_SPL_BUILD
++static ulong rk3228_vop_get_clk(struct rk322x_cru *cru, ulong clk_id)
++{
++	u32 div, con, parent;
++
++	switch (clk_id) {
++		case DCLK_VOP:
++			con = readl(&cru->cru_clksel_con[27]);
++			div = (con & VOP_DCLK_DIV_MASK) >> VOP_DCLK_DIV_SHIFT;
++			parent = GPLL_HZ;
++			break;
++		case ACLK_VOP:
++			con = readl(&cru->cru_clksel_con[33]);
++			div = (con & VOP_ACLK_DIV_MASK) >> VOP_ACLK_DIV_SHIFT;
++			parent = GPLL_HZ;
++			break;
++		default:
++			debug("%s: Unsupported vop get clk#%ld\n", __func__, clk_id);
++			return -ENOENT;
++	}
++
++	return DIV_TO_RATE(parent, div);
++}
++
++static ulong rk3228_vop_set_clk(struct rk322x_cru *cru,
++				ulong clk_id, uint hz)
++{
++	int src_clk_div;
++
++	src_clk_div = DIV_ROUND_UP(GPLL_HZ, hz);
++	assert(src_clk_div - 1 < 31);
++
++	switch (clk_id) {
++		case DCLK_VOP:
++
++			/*
++			 * Set HDMI parent clock to HDMIPHY. Normally, this is done
++			 * by .set_parent, but u-boot does not seem to work well with
++			 * device tree references
++			 */
++			rk_clrsetreg(&cru->cru_misc_con, BIT(13), 0);
++
++			rk_clrsetreg(&cru->cru_clksel_con[27],
++				VOP_DCLK_DIV_MASK | VOP_DCLK_PLL_SEL_MASK,
++				VOP_DCLK_SEL_GPLL << VOP_DCLK_PLL_SEL_SHIFT |
++				(src_clk_div - 1) << VOP_DCLK_DIV_SHIFT);
++			break;
++		case ACLK_VOP:
++			rk_clrsetreg(&cru->cru_clksel_con[33],
++				VOP_ACLK_DIV_MASK | VOP_ACLK_PLL_SEL_MASK,
++				VOP_ACLK_SEL_GPLL << VOP_ACLK_PLL_SEL_SHIFT |
++				(src_clk_div - 1) << VOP_ACLK_DIV_SHIFT);
++			break;
++		default:
++			printf("%s: Unable to set vop clk#%ld\n", __func__, clk_id);
++			return -EINVAL;
++	}
++
++	return rk3228_vop_get_clk(cru, clk_id);
++}
++#endif
++
+ static ulong rk322x_clk_set_rate(struct clk *clk, ulong rate)
+ {
+ 	struct rk322x_clk_priv *priv = dev_get_priv(clk->dev);
+@@ -395,7 +465,29 @@ static ulong rk322x_clk_set_rate(struct clk *clk, ulong rate)
+ 		new_rate = rk322x_mac_set_clk(priv->cru, rate);
+ 		break;
+ 	case PLL_GPLL:
+-		return 0;
++	case PLL_CPLL:
++	case ACLK_PERI:
++	case HCLK_PERI:
++	case PCLK_PERI:
++	case ACLK_CPU:
++	case HCLK_CPU:
++	case PCLK_CPU:
++	case ARMCLK:
++	case SCLK_HDMI_PHY:
++	case PCLK_HDMI_PHY:
++	case DCLK_HDMI_PHY:
++	case SCLK_HDMI_HDCP:
++	case PCLK_HDMI_CTRL:
++	case SCLK_HDMI_CEC:
++		debug("Attempt to set clkid %ld, rate=%ld\n", clk->id, rate);
++		return rate;
++#ifndef CONFIG_SPL_BUILD
++	case ACLK_VOP:
++	case DCLK_VOP:
++		debug("VOP set rate clkid %ld, rate=%ld\n", clk->id, rate);
++		rate = rk3228_vop_set_clk(priv->cru, clk->id, rate);
++		break;
++#endif
+ 	default:
+ 		return -ENOENT;
+ 	}
+@@ -456,13 +548,44 @@ static int rk322x_gmac_extclk_set_parent(struct clk *clk, struct clk *parent)
+ 	return -EINVAL;
+ }
+ 
++static int rk322x_hdmi_set_parent(struct clk *clk, struct clk *parent)
++{
++	struct rk322x_clk_priv *priv = dev_get_priv(clk->dev);
++	const char *clock_output_name;
++	struct rk322x_cru *cru = priv->cru;
++	int ret;
++
++	ret = dev_read_string_index(parent->dev, "clock-output-names",
++				    parent->id, &clock_output_name);
++	if (ret < 0)
++		return -ENODATA;
++
++	if (!strcmp(clock_output_name, "hdmiphy_phy")) {
++		debug("%s: switching hdmi_sclk to hdmiphy_phy\n", __func__);
++		rk_clrsetreg(&cru->cru_misc_con, BIT(13), 0);
++		return 0;
++	} else if (!strcmp(clock_output_name, "xin24m")) {
++		debug("%s: switching hdmi_sclk to xin24m\n", __func__);
++		rk_clrsetreg(&cru->cru_misc_con, BIT(13), BIT(13));
++		return 0;
++	}
++
++	return -EINVAL;
++
++}
++
+ static int rk322x_clk_set_parent(struct clk *clk, struct clk *parent)
+ {
++
++	debug("%s, clkid=%ld, parent=%ld\n", __func__, clk->id, parent->id);
++
+ 	switch (clk->id) {
+ 	case SCLK_MAC:
+ 		return rk322x_gmac_set_parent(clk, parent);
+ 	case SCLK_MAC_EXTCLK:
+ 		return rk322x_gmac_extclk_set_parent(clk, parent);
++	case SCLK_HDMI_PHY:
++		return rk322x_hdmi_set_parent(clk, parent);
+ 	}
+ 
+ 	debug("%s: unsupported clk %ld\n", __func__, clk->id);
+@@ -520,7 +643,7 @@ static int rk322x_clk_bind(struct udevice *dev)
+ 		debug("Warning: software reset driver bind failed\n");
+ #endif
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ static const struct udevice_id rk322x_clk_ids[] = {
+@@ -529,7 +652,7 @@ static const struct udevice_id rk322x_clk_ids[] = {
+ };
+ 
+ U_BOOT_DRIVER(rockchip_rk322x_cru) = {
+-	.name		= "clk_rk322x",
++	.name		= "rockchip_rk322x_cru",
+ 	.id		= UCLASS_CLK,
+ 	.of_match	= rk322x_clk_ids,
+ 	.priv_auto	= sizeof(struct rk322x_clk_priv),
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk322x-box/rk3228-hdmi-driver.patch
+++ b/patch/u-boot/v2025.01/board_rk322x-box/rk3228-hdmi-driver.patch
@@ -1,0 +1,198 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 30 Jun 2024 17:37:39 +0200
+Subject: rk3228 hdmi driver
+
+---
+ drivers/video/rockchip/Makefile      |   1 +
+ drivers/video/rockchip/rk3228_hdmi.c | 168 ++++++++++
+ 2 files changed, 169 insertions(+)
+
+diff --git a/drivers/video/rockchip/Makefile b/drivers/video/rockchip/Makefile
+index 111111111111..222222222222 100644
+--- a/drivers/video/rockchip/Makefile
++++ b/drivers/video/rockchip/Makefile
+@@ -10,6 +10,7 @@ obj-$(CONFIG_ROCKCHIP_RK3328) += rk3328_vop.o
+ obj-$(CONFIG_ROCKCHIP_RK3399) += rk3399_vop.o
+ obj-$(CONFIG_DISPLAY_ROCKCHIP_EDP) += rk_edp.o
+ obj-$(CONFIG_DISPLAY_ROCKCHIP_LVDS) += rk_lvds.o
++obj-hdmi-$(CONFIG_ROCKCHIP_RK322X) += rk3228_hdmi.o
+ obj-hdmi-$(CONFIG_ROCKCHIP_RK3288) += rk3288_hdmi.o
+ obj-hdmi-$(CONFIG_ROCKCHIP_RK3328) += rk3328_hdmi.o
+ obj-hdmi-$(CONFIG_ROCKCHIP_RK3399) += rk3399_hdmi.o
+diff --git a/drivers/video/rockchip/rk3228_hdmi.c b/drivers/video/rockchip/rk3228_hdmi.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/video/rockchip/rk3228_hdmi.c
+@@ -0,0 +1,167 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (c) 2023 Edgeble AI Technologies Pvt. Ltd.
++ */
++#include <clk.h>
++#include <display.h>
++#include <reset.h>
++#include <linux/delay.h>
++#include <dm.h>
++#include <dw_hdmi.h>
++#include <asm/io.h>
++#include "rk_hdmi.h"
++
++#define HIWORD_UPDATE(val, mask)	(val | (mask) << 16)
++
++#define RK3228_GRF_SOC_CON2	0x0408
++#define RK3228_GRF_SOC_CON6	0x0418
++
++#define RK3228_HDMI_HPD_VSEL	BIT(6)
++#define RK3228_HDMI_SDA_VSEL	BIT(5)
++#define RK3228_HDMI_SCL_VSEL	BIT(4)
++
++#define RK3228_HDMI_SDAIN_MSK	BIT(14)
++#define RK3228_HDMI_SCLIN_MSK	BIT(13)
++
++static int rk3228_hdmi_enable(struct udevice *dev, int panel_bpp,
++			      const struct display_timing *edid)
++{
++	struct rk_hdmi_priv *priv = dev_get_priv(dev);
++
++	return dw_hdmi_enable(&priv->hdmi, edid);
++}
++
++static int rk3228_dw_hdmi_phy_cfg(struct dw_hdmi *hdmi, uint pixclock)
++{
++	struct rk_hdmi_priv *priv = container_of(hdmi, struct rk_hdmi_priv, hdmi);
++	int ret;
++
++	ret = generic_phy_init(&priv->phy);
++	if (ret < 0) {
++		printf("failed to init phy (ret=%d)\n", ret);
++		return ret;
++	}
++
++	ret = generic_phy_power_on(&priv->phy);
++	if (ret) {
++		printf("failed to power on hdmi phy (ret=%d)\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static void rk3228_dw_hdmi_setup_hpd(struct dw_hdmi *hdmi)
++{
++	struct rk_hdmi_priv *priv = container_of(hdmi, struct rk_hdmi_priv, hdmi);
++	void *grf = priv->grf;
++
++	/*
++	 * Undocumented registers, write them to get correct access to EDID
++	 */
++	writel(HIWORD_UPDATE(RK3228_HDMI_HPD_VSEL | RK3228_HDMI_SDA_VSEL | RK3228_HDMI_SCL_VSEL,
++		RK3228_HDMI_HPD_VSEL | RK3228_HDMI_SDA_VSEL | RK3228_HDMI_SCL_VSEL),
++		grf + RK3228_GRF_SOC_CON6);
++
++	writel(HIWORD_UPDATE(RK3228_HDMI_SDAIN_MSK | RK3228_HDMI_SCLIN_MSK,
++		RK3228_HDMI_SDAIN_MSK | RK3228_HDMI_SCLIN_MSK),
++		grf + RK3228_GRF_SOC_CON2);
++
++}
++
++static const struct dw_hdmi_phy_ops dw_hdmi_rk3228_phy_ops = {
++	.phy_set = rk3228_dw_hdmi_phy_cfg,
++	.setup_hpd = rk3228_dw_hdmi_setup_hpd,
++};
++
++static int rk3228_hdmi_of_to_plat(struct udevice *dev)
++{
++	struct rk_hdmi_priv *priv = dev_get_priv(dev);
++	struct dw_hdmi *hdmi = &priv->hdmi;
++
++	hdmi->i2c_clk_high = 0x71;
++	hdmi->i2c_clk_low = 0x76;
++
++	rk_hdmi_of_to_plat(dev);
++
++	hdmi->ops = &dw_hdmi_rk3228_phy_ops;
++
++	return 0;
++}
++
++static int rk3228_hdmi_probe(struct udevice *dev)
++{
++	struct rk_hdmi_priv *priv = dev_get_priv(dev);
++	int ret;
++
++	ret = generic_phy_get_by_name(dev, "hdmi", &priv->phy);
++	if (ret) {
++		printf("failed to get hdmi phy\n");
++		return ret;
++	};
++
++	ret = rk_hdmi_probe(dev);
++	if (ret) {
++		printf("failed to probe rk hdmi\n");
++		return ret;
++	}
++
++	return 0;
++}
++
++/*
++ * Asserting and deasserting the HDMI resets allows the vendor kernel
++ * to turn on HDMI when necessary. Mainline kernel does not need it though
++ */
++static int rk3228_hdmi_remove(struct udevice *dev)
++{
++	struct rk_hdmi_priv *priv = dev_get_priv(dev);
++	struct reset_ctl_bulk resets;
++	int ret;
++
++	debug("%s\n", __func__);
++
++	dw_hdmi_disable(&priv->hdmi);
++
++	ret = generic_phy_power_off(&priv->phy);
++	if (ret) {
++		printf("failed to on hdmi phy (ret=%d)\n", ret);
++	}
++
++	ret = reset_get_bulk(dev, &resets);
++	if (ret) {
++		printf("failed to get resets (ret=%d)\n", ret);
++		return ret;
++	}
++
++	reset_assert_bulk(&resets);
++	udelay(20);
++
++	reset_deassert_bulk(&resets);
++	udelay(20);
++
++	return 0;
++
++}
++
++static const struct dm_display_ops rk3228_hdmi_ops = {
++	.read_edid = rk_hdmi_read_edid,
++	.enable = rk3228_hdmi_enable,
++};
++
++static const struct udevice_id rk3228_hdmi_ids[] = {
++	{ .compatible = "rockchip,rk3228-dw-hdmi" },
++	{ }
++};
++
++U_BOOT_DRIVER(rk3228_hdmi_rockchip) = {
++	.name = "rk3228_hdmi_rockchip",
++	.id = UCLASS_DISPLAY,
++	.of_match = rk3228_hdmi_ids,
++	.ops = &rk3228_hdmi_ops,
++	.of_to_plat = rk3228_hdmi_of_to_plat,
++	.probe = rk3228_hdmi_probe,
++	.priv_auto	= sizeof(struct rk_hdmi_priv),
++	.remove = rk3228_hdmi_remove,
++	.flags	= DM_FLAG_OS_PREPARE
++};
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk322x-box/rk3228-inno-phy-driver.patch
+++ b/patch/u-boot/v2025.01/board_rk322x-box/rk3228-inno-phy-driver.patch
@@ -1,0 +1,493 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 30 Jun 2024 17:18:22 +0200
+Subject: add rk3228 support to inno hdmi driver
+
+---
+ drivers/phy/rockchip/phy-rockchip-inno-hdmi.c | 379 ++++++++++
+ 1 file changed, 379 insertions(+)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-inno-hdmi.c b/drivers/phy/rockchip/phy-rockchip-inno-hdmi.c
+index 111111111111..222222222222 100644
+--- a/drivers/phy/rockchip/phy-rockchip-inno-hdmi.c
++++ b/drivers/phy/rockchip/phy-rockchip-inno-hdmi.c
+@@ -19,6 +19,110 @@
+ 
+ #define UPDATE(x, h, l)		(((x) << (l)) & GENMASK((h), (l)))
+ 
++/*
++ * ---- Registers for RK322x
++ */
++/* REG: 0x00 */
++#define RK3228_PRE_PLL_REFCLK_SEL_MASK			BIT(0)
++#define RK3228_PRE_PLL_REFCLK_SEL_PCLK			BIT(0)
++#define RK3228_PRE_PLL_REFCLK_SEL_OSCCLK		0
++/* REG: 0x01 */
++#define RK3228_BYPASS_RXSENSE_EN			BIT(2)
++#define RK3228_BYPASS_PWRON_EN				BIT(1)
++#define RK3228_BYPASS_PLLPD_EN				BIT(0)
++/* REG: 0x02 */
++#define RK3228_INT_POL_HIGH				BIT(7)
++#define RK3228_BYPASS_PDATA_EN				BIT(4)
++#define RK3328_PDATA_EN				BIT(0)
++#define RK3228_PDATA_EN_DISABLE			BIT(0)
++/* REG: 0x03 */
++#define RK3228_BYPASS_AUTO_TERM_RES_CAL		BIT(7)
++#define RK3228_AUDO_TERM_RES_CAL_SPEED_14_8(x)		UPDATE(x, 6, 0)
++/* REG: 0x04 */
++#define RK3228_AUDO_TERM_RES_CAL_SPEED_7_0(x)		UPDATE(x, 7, 0)
++/* REG: 0xaa */
++#define RK3228_POST_PLL_CTRL_MANUAL			BIT(0)
++/* REG: 0xe0 */
++#define RK3228_POST_PLL_POWER_DOWN			BIT(5)
++#define RK3228_POST_PLL_POWER_UP			0
++#define RK3228_PRE_PLL_POWER_DOWN			BIT(4)
++#define RK3228_RXSENSE_CLK_CH_MASK			BIT(3)
++#define RK3228_RXSENSE_CLK_CH_ENABLE			BIT(3)
++#define RK3228_RXSENSE_DATA_CH2_MASK			BIT(2)
++#define RK3228_RXSENSE_DATA_CH2_ENABLE			BIT(2)
++#define RK3228_RXSENSE_DATA_CH1_MASK			BIT(1)
++#define RK3228_RXSENSE_DATA_CH1_ENABLE			BIT(1)
++#define RK3228_RXSENSE_DATA_CH0_MASK			BIT(0)
++#define RK3228_RXSENSE_DATA_CH0_ENABLE			BIT(0)
++/* REG: 0xe1 */
++#define RK3228_BANDGAP_ENABLE				BIT(4)
++#define RK3228_TMDS_DRIVER_ENABLE			GENMASK(3, 0)
++/* REG: 0xe2 */
++#define RK3228_PRE_PLL_FB_DIV_8_MASK			BIT(7)
++#define RK3228_PRE_PLL_FB_DIV_8(x)			UPDATE((x) >> 8, 7, 7)
++#define RK3228_PCLK_VCO_DIV_5_MASK			BIT(5)
++#define RK3228_PCLK_VCO_DIV_5(x)			UPDATE(x, 5, 5)
++#define RK3228_PRE_PLL_PRE_DIV_MASK			GENMASK(4, 0)
++#define RK3228_PRE_PLL_PRE_DIV(x)			UPDATE(x, 4, 0)
++/* REG: 0xe3 */
++#define RK3228_PRE_PLL_FB_DIV_7_0(x)			UPDATE(x, 7, 0)
++/* REG: 0xe4 */
++#define RK3228_PRE_PLL_PCLK_DIV_B_MASK			GENMASK(6, 5)
++#define RK3228_PRE_PLL_PCLK_DIV_B_SHIFT			5
++#define RK3228_PRE_PLL_PCLK_DIV_B(x)			UPDATE(x, 6, 5)
++#define RK3228_PRE_PLL_PCLK_DIV_A_MASK			GENMASK(4, 0)
++#define RK3228_PRE_PLL_PCLK_DIV_A(x)			UPDATE(x, 4, 0)
++/* REG: 0xe5 */
++#define RK3228_PRE_PLL_PCLK_DIV_C_MASK			GENMASK(6, 5)
++#define RK3228_PRE_PLL_PCLK_DIV_C(x)			UPDATE(x, 6, 5)
++#define RK3228_PRE_PLL_PCLK_DIV_D_MASK			GENMASK(4, 0)
++#define RK3228_PRE_PLL_PCLK_DIV_D(x)			UPDATE(x, 4, 0)
++/* REG: 0xe6 */
++#define RK3228_PRE_PLL_TMDSCLK_DIV_C_MASK		GENMASK(5, 4)
++#define RK3228_PRE_PLL_TMDSCLK_DIV_C(x)			UPDATE(x, 5, 4)
++#define RK3228_PRE_PLL_TMDSCLK_DIV_A_MASK		GENMASK(3, 2)
++#define RK3228_PRE_PLL_TMDSCLK_DIV_A(x)			UPDATE(x, 3, 2)
++#define RK3228_PRE_PLL_TMDSCLK_DIV_B_MASK		GENMASK(1, 0)
++#define RK3228_PRE_PLL_TMDSCLK_DIV_B(x)			UPDATE(x, 1, 0)
++/* REG: 0xe8 */
++#define RK3228_PRE_PLL_LOCK_STATUS			BIT(0)
++/* REG: 0xe9 */
++#define RK3228_POST_PLL_POST_DIV_ENABLE			UPDATE(3, 7, 6)
++#define RK3228_POST_PLL_PRE_DIV_MASK			GENMASK(4, 0)
++#define RK3228_POST_PLL_PRE_DIV(x)			UPDATE(x, 4, 0)
++/* REG: 0xea */
++#define RK3228_POST_PLL_FB_DIV_7_0(x)			UPDATE(x, 7, 0)
++/* REG: 0xeb */
++#define RK3228_POST_PLL_FB_DIV_8_MASK			BIT(7)
++#define RK3228_POST_PLL_FB_DIV_8(x)			UPDATE((x) >> 8, 7, 7)
++#define RK3228_POST_PLL_POST_DIV_MASK			GENMASK(5, 4)
++#define RK3228_POST_PLL_POST_DIV(x)			UPDATE(x, 5, 4)
++#define RK3228_POST_PLL_LOCK_STATUS			BIT(0)
++/* REG: 0xee */
++#define RK3228_TMDS_CH_TA_ENABLE			GENMASK(7, 4)
++/* REG: 0xef */
++#define RK3228_TMDS_CLK_CH_TA(x)			UPDATE(x, 7, 6)
++#define RK3228_TMDS_DATA_CH2_TA(x)			UPDATE(x, 5, 4)
++#define RK3228_TMDS_DATA_CH1_TA(x)			UPDATE(x, 3, 2)
++#define RK3228_TMDS_DATA_CH0_TA(x)			UPDATE(x, 1, 0)
++/* REG: 0xf0 */
++#define RK3228_TMDS_DATA_CH2_PRE_EMPHASIS_MASK		GENMASK(5, 4)
++#define RK3228_TMDS_DATA_CH2_PRE_EMPHASIS(x)		UPDATE(x, 5, 4)
++#define RK3228_TMDS_DATA_CH1_PRE_EMPHASIS_MASK		GENMASK(3, 2)
++#define RK3228_TMDS_DATA_CH1_PRE_EMPHASIS(x)		UPDATE(x, 3, 2)
++#define RK3228_TMDS_DATA_CH0_PRE_EMPHASIS_MASK		GENMASK(1, 0)
++#define RK3228_TMDS_DATA_CH0_PRE_EMPHASIS(x)		UPDATE(x, 1, 0)
++/* REG: 0xf1 */
++#define RK3228_TMDS_CLK_CH_OUTPUT_SWING(x)		UPDATE(x, 7, 4)
++#define RK3228_TMDS_DATA_CH2_OUTPUT_SWING(x)		UPDATE(x, 3, 0)
++/* REG: 0xf2 */
++#define RK3228_TMDS_DATA_CH1_OUTPUT_SWING(x)		UPDATE(x, 7, 4)
++#define RK3228_TMDS_DATA_CH0_OUTPUT_SWING(x)		UPDATE(x, 3, 0)
++
++
++/*
++ * ---- Registers for RK3328
++ */
+ /* REG: 0x01 */
+ #define RK3328_BYPASS_RXSENSE_EN			BIT(2)
+ #define RK3328_BYPASS_POWERON_EN			BIT(1)
+@@ -177,6 +281,7 @@ struct inno_hdmi_phy_plat_ops {
+ };
+ 
+ enum inno_hdmi_phy_type {
++	INNO_HDMI_PHY_RK3228,
+ 	INNO_HDMI_PHY_RK3328,
+ };
+ 
+@@ -388,6 +493,25 @@ static const struct post_pll_config post_pll_cfg_table[] = {
+ 	{ /* sentinel */ }
+ };
+ 
++/* phy tuning values for an undocumented set of registers */
++static const struct phy_config rk3228_phy_cfg[] = {
++	{	165000000, {
++		0xaa, 0x00, 0x44, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00,
++		0x00, 0x00, 0x00, 0x00, 0x00,
++	},
++	}, {
++		340000000, {
++			0xaa, 0x15, 0x6a, 0xaa, 0x00, 0x00, 0x00, 0x00, 0x00,
++			0x00, 0x00, 0x00, 0x00, 0x00,
++		},
++	}, {
++		594000000, {
++			0xaa, 0x15, 0x7a, 0xaa, 0x00, 0x00, 0x00, 0x00, 0x00,
++			0x00, 0x00, 0x00, 0x00, 0x00,
++		},
++	}, { /* sentinel */ },
++};
++
+ /* phy tuning values for an undocumented set of registers */
+ static const struct phy_config rk3328_phy_cfg[] = {
+ 	{	165000000, {
+@@ -453,6 +577,46 @@ static unsigned long inno_hdmi_phy_get_tmdsclk(struct inno_hdmi_phy *inno,
+ 	}
+ }
+ 
++static
++unsigned long inno_hdmi_phy_rk3228_clk_recalc_rate(struct phy *phy,
++						   unsigned long parent_rate)
++{
++	struct inno_hdmi_phy *inno = dev_get_priv(phy->dev);
++	u64 rate, vco;
++	u8 nd, no_a, no_b, no_d;
++	__maybe_unused u8 no_c;
++	u16 nf;
++
++	nd = inno_read(inno, 0xe2) & RK3228_PRE_PLL_PRE_DIV_MASK;
++	nf = (inno_read(inno, 0xe2) & RK3228_PRE_PLL_FB_DIV_8_MASK) << 1;
++	nf |= inno_read(inno, 0xe3);
++	vco = parent_rate * nf;
++
++	if (inno_read(inno, 0xe2) & RK3228_PCLK_VCO_DIV_5_MASK) {
++		rate = vco / (nd * 5);
++	} else {
++		no_a = inno_read(inno, 0xe4) & RK3228_PRE_PLL_PCLK_DIV_A_MASK;
++		if (!no_a)
++			no_a = 1;
++		no_b = inno_read(inno, 0xe4) & RK3228_PRE_PLL_PCLK_DIV_B_MASK;
++		no_b >>= RK3228_PRE_PLL_PCLK_DIV_B_SHIFT;
++		no_b += 2;
++		no_d = inno_read(inno, 0xe5) & RK3228_PRE_PLL_PCLK_DIV_D_MASK;
++
++		if (no_a == 1)
++			rate = vco / (nd * no_b * no_d * 2);
++		else
++			rate = vco / (nd * no_a * no_d * 2);
++
++	}
++
++	inno->pixclock = rate;
++
++	dev_info(phy->dev, "rate %lu vco %llu\n", inno->pixclock, vco);
++
++	return inno->pixclock;
++}
++
+ static
+ unsigned long inno_hdmi_phy_rk3328_clk_recalc_rate(struct phy *phy,
+ 						   unsigned long parent_rate)
+@@ -494,6 +658,23 @@ unsigned long inno_hdmi_phy_rk3328_clk_recalc_rate(struct phy *phy,
+ 	return inno->pixclock;
+ }
+ 
++static long inno_hdmi_phy_rk3228_clk_round_rate(struct phy *phy,
++						unsigned long rate)
++{
++	const struct pre_pll_config *cfg = pre_pll_cfg_table;
++
++	rate = (rate / 1000) * 1000;
++
++	for (; cfg->pixclock != 0; cfg++)
++		if (cfg->pixclock == rate)
++			break;
++
++	if (cfg->pixclock == 0)
++		return -EINVAL;
++
++	return cfg->pixclock;
++}
++
+ static long inno_hdmi_phy_rk3328_clk_round_rate(struct phy *phy,
+ 						unsigned long rate)
+ {
+@@ -528,6 +709,71 @@ struct pre_pll_config *inno_hdmi_phy_get_pre_pll_cfg(struct inno_hdmi_phy *inno,
+ 	return cfg;
+ }
+ 
++static int
++inno_hdmi_phy_rk3228_clk_set_rate(struct phy *phy,
++				  unsigned long rate,
++				  unsigned long parent_rate)
++{
++
++	struct inno_hdmi_phy *inno = dev_get_priv(phy->dev);
++	unsigned long tmdsclock = inno_hdmi_phy_get_tmdsclk(inno, rate);
++	const struct pre_pll_config *cfg;
++
++	int ret;
++	u32 val;
++
++	dev_info(phy->dev, "rate %lu tmdsclk %lu\n", rate, tmdsclock);
++
++	if (inno->pixclock == rate && inno->tmdsclock == tmdsclock)
++		return 0;
++
++	cfg = inno_hdmi_phy_get_pre_pll_cfg(inno, rate);
++	if (IS_ERR(cfg))
++		return PTR_ERR(cfg);
++
++	/* Power down PRE-PLL */
++	inno_update_bits(inno, 0xe0, RK3228_PRE_PLL_POWER_DOWN,
++			 RK3228_PRE_PLL_POWER_DOWN);
++
++	inno_update_bits(inno, 0xe2, RK3228_PRE_PLL_FB_DIV_8_MASK |
++	RK3228_PCLK_VCO_DIV_5_MASK |
++	RK3228_PRE_PLL_PRE_DIV_MASK,
++	RK3228_PRE_PLL_FB_DIV_8(cfg->fbdiv) |
++	RK3228_PCLK_VCO_DIV_5(cfg->vco_div_5_en) |
++	RK3228_PRE_PLL_PRE_DIV(cfg->prediv));
++	inno_write(inno, 0xe3, RK3228_PRE_PLL_FB_DIV_7_0(cfg->fbdiv));
++	inno_update_bits(inno, 0xe4, RK3228_PRE_PLL_PCLK_DIV_B_MASK |
++	RK3228_PRE_PLL_PCLK_DIV_A_MASK,
++	RK3228_PRE_PLL_PCLK_DIV_B(cfg->pclk_div_b) |
++	RK3228_PRE_PLL_PCLK_DIV_A(cfg->pclk_div_a));
++	inno_update_bits(inno, 0xe5, RK3228_PRE_PLL_PCLK_DIV_C_MASK |
++	RK3228_PRE_PLL_PCLK_DIV_D_MASK,
++	RK3228_PRE_PLL_PCLK_DIV_C(cfg->pclk_div_c) |
++	RK3228_PRE_PLL_PCLK_DIV_D(cfg->pclk_div_d));
++	inno_update_bits(inno, 0xe6, RK3228_PRE_PLL_TMDSCLK_DIV_C_MASK |
++	RK3228_PRE_PLL_TMDSCLK_DIV_A_MASK |
++	RK3228_PRE_PLL_TMDSCLK_DIV_B_MASK,
++	RK3228_PRE_PLL_TMDSCLK_DIV_C(cfg->tmds_div_c) |
++	RK3228_PRE_PLL_TMDSCLK_DIV_A(cfg->tmds_div_a) |
++	RK3228_PRE_PLL_TMDSCLK_DIV_B(cfg->tmds_div_b));
++
++	/* Power up PRE-PLL */
++	inno_update_bits(inno, 0xe0, RK3228_PRE_PLL_POWER_DOWN, 0);
++
++	/* Wait for Pre-PLL lock */
++	ret = inno_poll(inno, 0xe8, val, val & RK3228_PRE_PLL_LOCK_STATUS,
++			1000, 10000);
++	if (ret) {
++		dev_err(phy->dev, "Pre-PLL locking failed\n");
++		return ret;
++	}
++
++	inno->pixclock = rate;
++	inno->tmdsclock = tmdsclock;
++
++	return 0;
++}
++
+ static int
+ inno_hdmi_phy_rk3328_clk_set_rate(struct phy *phy,
+ 				  unsigned long rate,
+@@ -588,6 +834,13 @@ inno_hdmi_phy_rk3328_clk_set_rate(struct phy *phy,
+ 	return 0;
+ }
+ 
++static void inno_hdmi_phy_rk3228_clk_enable(struct phy *phy)
++{
++	struct inno_hdmi_phy *inno = dev_get_priv(phy->dev);
++
++	inno_update_bits(inno, 0xe0, RK3228_PRE_PLL_POWER_DOWN, 0);
++}
++
+ static void inno_hdmi_phy_rk3328_clk_enable(struct phy *phy)
+ {
+ 	struct inno_hdmi_phy *inno = dev_get_priv(phy->dev);
+@@ -595,6 +848,14 @@ static void inno_hdmi_phy_rk3328_clk_enable(struct phy *phy)
+ 	inno_update_bits(inno, 0xa0, RK3328_PRE_PLL_POWER_DOWN, 0);
+ }
+ 
++static void inno_hdmi_phy_rk3228_clk_disable(struct phy *phy)
++{
++	struct inno_hdmi_phy *inno = dev_get_priv(phy->dev);
++
++	inno_update_bits(inno, 0xe0, RK3228_PRE_PLL_POWER_DOWN,
++			 RK3228_PRE_PLL_POWER_DOWN);
++}
++
+ static void inno_hdmi_phy_rk3328_clk_disable(struct phy *phy)
+ {
+ 	struct inno_hdmi_phy *inno = dev_get_priv(phy->dev);
+@@ -603,6 +864,65 @@ static void inno_hdmi_phy_rk3328_clk_disable(struct phy *phy)
+ 			 RK3328_PRE_PLL_POWER_DOWN);
+ }
+ 
++static int
++inno_hdmi_phy_rk3228_power_on(struct phy *phy,
++			      const struct post_pll_config *cfg,
++			      const struct phy_config *phy_cfg)
++{
++	struct inno_hdmi_phy *inno = dev_get_priv(phy->dev);
++	u32 val;
++	int ret;
++
++	/* set pdata_en to 0 */
++	inno_update_bits(inno, 0x02, RK3228_PDATA_EN_DISABLE, RK3228_PDATA_EN_DISABLE);
++	inno_update_bits(inno, 0xe0, RK3228_PRE_PLL_POWER_DOWN | RK3228_POST_PLL_POWER_DOWN,
++			 RK3228_PRE_PLL_POWER_DOWN | RK3228_POST_PLL_POWER_DOWN);
++
++	/* Post-PLL update */
++	inno_update_bits(inno, 0xe9, RK3228_POST_PLL_PRE_DIV_MASK,
++			 RK3228_POST_PLL_PRE_DIV(cfg->prediv));
++	inno_update_bits(inno, 0xeb, RK3228_POST_PLL_FB_DIV_8_MASK,
++			 RK3228_POST_PLL_FB_DIV_8(cfg->fbdiv));
++	inno_write(inno, 0xea, RK3228_POST_PLL_FB_DIV_7_0(cfg->fbdiv));
++
++	if (cfg->postdiv == 1) {
++		inno_update_bits(inno, 0xe9, RK3228_POST_PLL_POST_DIV_ENABLE, 0);
++	} else {
++		int div = cfg->postdiv / 2 - 1;
++
++		inno_update_bits(inno, 0xe9, RK3228_POST_PLL_POST_DIV_ENABLE,
++				 RK3228_POST_PLL_POST_DIV_ENABLE);
++		inno_update_bits(inno, 0xeb, RK3228_POST_PLL_POST_DIV_MASK,
++				 RK3228_POST_PLL_POST_DIV(div));
++	}
++
++	for (val = 0; val < 4; val++)
++		inno_write(inno, 0xef + val, phy_cfg->regs[val]);
++
++	inno_update_bits(inno, 0xe0, RK3228_PRE_PLL_POWER_DOWN |
++	RK3228_POST_PLL_POWER_DOWN, 0);
++	inno_update_bits(inno, 0xe1, RK3228_BANDGAP_ENABLE,
++			 RK3228_BANDGAP_ENABLE);
++	inno_update_bits(inno, 0xe1, RK3228_TMDS_DRIVER_ENABLE,
++			 RK3228_TMDS_DRIVER_ENABLE);
++
++	/* Wait for post PLL lock */
++	ret = inno_poll(inno, 0xeb, val, val & RK3228_POST_PLL_LOCK_STATUS,
++			1000, 10000);
++	if (ret) {
++		dev_err(phy->dev, "Post-PLL locking failed\n");
++		return ret;
++	}
++
++	if (phy_cfg->tmdsclock > 340000000)
++		mdelay(100);
++
++	/* set pdata_en_disable to 0 */
++	inno_update_bits(inno, 0x02, RK3228_PDATA_EN_DISABLE, 0);
++
++	return 0;
++}
++
+ static int
+ inno_hdmi_phy_rk3328_power_on(struct phy *phy,
+ 			      const struct post_pll_config *cfg,
+@@ -695,6 +1015,18 @@ inno_hdmi_phy_rk3328_power_on(struct phy *phy,
+ 	return 0;
+ }
+ 
++static void inno_hdmi_phy_rk3228_power_off(struct phy *phy)
++{
++	struct inno_hdmi_phy *inno = dev_get_priv(phy->dev);
++
++	debug("%s\n", __func__);
++
++	inno_update_bits(inno, 0xe1, RK3228_TMDS_DRIVER_ENABLE, 0);
++	inno_update_bits(inno, 0xe1, RK3228_BANDGAP_ENABLE, 0);
++	inno_update_bits(inno, 0xe0, RK3228_POST_PLL_POWER_DOWN,
++			 RK3228_POST_PLL_POWER_DOWN);
++}
++
+ static void inno_hdmi_phy_rk3328_power_off(struct phy *phy)
+ {
+ 	struct inno_hdmi_phy *inno = dev_get_priv(phy->dev);
+@@ -709,6 +1041,32 @@ static void inno_hdmi_phy_rk3328_power_off(struct phy *phy)
+ 	inno_write(inno, 0x07, 0);
+ }
+ 
++static void inno_hdmi_phy_rk3228_init(struct phy *phy)
++{
++	struct inno_hdmi_phy *inno = dev_get_priv(phy->dev);
++	const struct inno_hdmi_phy_plat_ops *plat_ops = inno->data->plat_ops;
++
++	debug("[PHY] %s: begin!\n", __func__);
++
++	/*
++	 * Use phy internal register control
++	 * rxsense/poweron/pllpd/pdataen signal.
++	 */
++	inno_write(inno, 0x01, RK3228_BYPASS_RXSENSE_EN | RK3228_BYPASS_PWRON_EN | RK3228_BYPASS_PLLPD_EN);
++	inno_update_bits(inno, 0x02, RK3228_BYPASS_PDATA_EN, RK3228_BYPASS_PDATA_EN);
++
++	/* manual power down post-PLL */
++	inno_update_bits(inno, 0xaa, RK3228_POST_PLL_CTRL_MANUAL, RK3228_POST_PLL_CTRL_MANUAL);
++
++	if (plat_ops->clk_recalc_rate)
++		plat_ops->clk_recalc_rate(phy, clk_get_rate(&inno->refoclk));
++
++	if (plat_ops->clk_round_rate)
++		plat_ops->clk_round_rate(phy, inno->pixclock);
++
++	debug("[PHY] %s: done!\n", __func__);
++}
++
+ static void inno_hdmi_phy_rk3328_init(struct phy *phy)
+ {
+ 	struct inno_hdmi_phy *inno = dev_get_priv(phy->dev);
+@@ -735,6 +1093,17 @@ static void inno_hdmi_phy_rk3328_init(struct phy *phy)
+ 		plat_ops->clk_round_rate(phy, inno->pixclock);
+ }
+ 
++static const struct inno_hdmi_phy_plat_ops rk3228_hdmi_phy_plat_ops = {
++	.init = inno_hdmi_phy_rk3228_init,
++	.power_on = inno_hdmi_phy_rk3228_power_on,
++	.power_off = inno_hdmi_phy_rk3228_power_off,
++	.clk_enable = inno_hdmi_phy_rk3228_clk_enable,
++	.clk_disable = inno_hdmi_phy_rk3228_clk_disable,
++	.clk_recalc_rate = inno_hdmi_phy_rk3228_clk_recalc_rate,
++	.clk_round_rate = inno_hdmi_phy_rk3228_clk_round_rate,
++	.clk_set_rate = inno_hdmi_phy_rk3228_clk_set_rate,
++};
++
+ static const struct inno_hdmi_phy_plat_ops rk3328_hdmi_phy_plat_ops = {
+ 	.init = inno_hdmi_phy_rk3328_init,
+ 	.power_on = inno_hdmi_phy_rk3328_power_on,
+@@ -861,6 +1230,12 @@ static int inno_hdmi_phy_probe(struct udevice *dev)
+ 	return 0;
+ }
+ 
++static const struct inno_hdmi_phy_data rk3228_inno_hdmi_phy_drv_data = {
++	.phy_type = INNO_HDMI_PHY_RK3228,
++	.plat_ops = &rk3228_hdmi_phy_plat_ops,
++	.phy_cfg_table = rk3228_phy_cfg,
++};
++
+ static const struct inno_hdmi_phy_data rk3328_inno_hdmi_phy_drv_data = {
+ 	.phy_type = INNO_HDMI_PHY_RK3328,
+ 	.plat_ops = &rk3328_hdmi_phy_plat_ops,
+@@ -868,6 +1243,10 @@ static const struct inno_hdmi_phy_data rk3328_inno_hdmi_phy_drv_data = {
+ };
+ 
+ static const struct udevice_id inno_hdmi_phy_ids[] = {
++	{
++		.compatible = "rockchip,rk3228-hdmi-phy",
++		.data = (ulong)&rk3228_inno_hdmi_phy_drv_data,
++	},
+ 	{
+ 		.compatible = "rockchip,rk3328-hdmi-phy",
+ 		.data = (ulong)&rk3328_inno_hdmi_phy_drv_data,
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk322x-box/rk3228-vop-driver.patch
+++ b/patch/u-boot/v2025.01/board_rk322x-box/rk3228-vop-driver.patch
@@ -1,0 +1,137 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 30 Jun 2024 17:41:01 +0200
+Subject: rk3228 vop driver
+
+---
+ drivers/video/rockchip/Makefile     |   1 +
+ drivers/video/rockchip/rk3228_vop.c | 107 ++++++++++
+ 2 files changed, 108 insertions(+)
+
+diff --git a/drivers/video/rockchip/Makefile b/drivers/video/rockchip/Makefile
+index 111111111111..222222222222 100644
+--- a/drivers/video/rockchip/Makefile
++++ b/drivers/video/rockchip/Makefile
+@@ -5,6 +5,7 @@
+ 
+ ifdef CONFIG_VIDEO_ROCKCHIP
+ obj-y += rk_vop.o
++obj-$(CONFIG_ROCKCHIP_RK322X) += rk3228_vop.o
+ obj-$(CONFIG_ROCKCHIP_RK3288) += rk3288_vop.o
+ obj-$(CONFIG_ROCKCHIP_RK3328) += rk3328_vop.o
+ obj-$(CONFIG_ROCKCHIP_RK3399) += rk3399_vop.o
+diff --git a/drivers/video/rockchip/rk3228_vop.c b/drivers/video/rockchip/rk3228_vop.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/video/rockchip/rk3228_vop.c
+@@ -0,0 +1,106 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (c) 2023 Edgeble AI Technologies Pvt. Ltd.
++ */
++#include <dm.h>
++#include <video.h>
++#include <asm/io.h>
++#include <reset.h>
++#include <clk.h>
++#include <linux/delay.h>
++#include "rk_vop.h"
++
++DECLARE_GLOBAL_DATA_PTR;
++
++static void rk3228_set_pin_polarity(struct udevice *dev,
++				    enum vop_modes mode, u32 polarity)
++{
++	struct rk_vop_priv *priv = dev_get_priv(dev);
++	struct rk3288_vop *regs = priv->regs;
++
++	switch (mode) {
++		case VOP_MODE_HDMI:
++			clrsetbits_le32(&regs->dsp_ctrl1,
++					M_RK3399_DSP_HDMI_POL,
++		   V_RK3399_DSP_HDMI_POL(polarity));
++			break;
++		default:
++			debug("%s: unsupported output mode %x\n", __func__, mode);
++	}
++}
++
++static int rk3228_vop_probe(struct udevice *dev)
++{
++	/* Before relocation we don't need to do anything */
++	if (!(gd->flags & GD_FLG_RELOC))
++		return 0;
++
++	return rk_vop_probe(dev);
++}
++
++/**
++ * During remove phase we assert the resets and deassert them,
++ * so in practice we "turn off" the VOP resetting it and then
++ * "turn on" it. This is especially true for the dlck because
++ * this avoids iommu complaining later during kernel boot
++ * @see https://lore.kernel.org/linux-arm-kernel/20230330131746.1475514-1-jagan@amarulasolutions.com/
++ */
++static int rk3228_vop_remove(struct udevice *dev)
++{
++	struct rk_vop_priv *priv = dev_get_priv(dev);
++	struct rk3288_vop *regs = priv->regs;
++	struct reset_ctl_bulk resets;
++
++	int ret;
++
++	debug("%s\n", __func__);
++
++	/* set to standby */
++	setbits_le32(&regs->sys_ctrl, V_STANDBY_EN(1));
++	clrsetbits_le32(&regs->sys_ctrl, M_ALL_OUT_EN, 0x0);
++
++	ret = reset_get_bulk(dev, &resets);
++	if (ret) {
++		printf("failed to get resets (ret=%d)\n", ret);
++		return ret;
++	}
++
++	reset_assert_bulk(&resets);
++	udelay(20);
++
++	reset_deassert_bulk(&resets);
++	udelay(20);
++
++	return 0;
++
++}
++
++struct rkvop_driverdata rk3228_driverdata = {
++	.dsp_offset = 0x0,
++	.win_offset = 0x0,
++	.features = VOP_FEATURE_OUTPUT_10BIT,
++	.set_pin_polarity = rk3228_set_pin_polarity,
++};
++
++static const struct udevice_id rk3228_vop_ids[] = {
++	{
++		.compatible = "rockchip,rk3228-vop",
++		.data = (ulong)&rk3228_driverdata
++	},
++	{ /* sentile */ }
++};
++
++static const struct video_ops rk3228_vop_ops = {
++};
++
++U_BOOT_DRIVER(rockchip_rk3228_vop) = {
++	.name	= "rockchip_rk3228_vop",
++	.id	= UCLASS_VIDEO,
++	.of_match = rk3228_vop_ids,
++	.ops	= &rk3228_vop_ops,
++	.bind	= rk_vop_bind,
++	.probe	= rk3228_vop_probe,
++	.remove = rk3228_vop_remove,
++	.priv_auto	= sizeof(struct rk_vop_priv),
++	.flags	= DM_FLAG_OS_PREPARE
++};
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk322x-box/rk322x-add-usb-reset-props.patch
+++ b/patch/u-boot/v2025.01/board_rk322x-box/rk322x-add-usb-reset-props.patch
@@ -1,0 +1,87 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sat, 4 May 2024 15:07:27 +0200
+Subject: add reset properties for usb otg/ehci
+
+---
+ arch/arm/dts/rk322x.dtsi        | 8 ++++++++
+ drivers/usb/host/dwc2.c         | 5 ++++-
+ drivers/usb/host/ehci-generic.c | 6 +++---
+ 3 files changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm/dts/rk322x.dtsi b/arch/arm/dts/rk322x.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm/dts/rk322x.dtsi
++++ b/arch/arm/dts/rk322x.dtsi
+@@ -799,6 +799,8 @@
+ 		g-tx-fifo-size = <256 128 128 64 32 16>;
+ 		phys = <&u2phy0_otg>;
+ 		phy-names = "usb2-phy";
++		resets = <&cru SRST_USBOTG>;
++		reset-names = "dwc2";
+ 		status = "disabled";
+ 	};
+ 
+@@ -809,6 +811,8 @@
+ 		clocks = <&cru HCLK_HOST0>, <&u2phy0>;
+ 		phys = <&u2phy0_host>;
+ 		phy-names = "usb";
++		resets = <&cru SRST_USBHOST0>;
++		reset-names = "ehci";
+ 		status = "disabled";
+ 	};
+ 
+@@ -829,6 +833,8 @@
+ 		clocks = <&cru HCLK_HOST1>, <&u2phy1>;
+ 		phys = <&u2phy1_otg>;
+ 		phy-names = "usb";
++		resets = <&cru SRST_USBHOST1>;
++		reset-names = "ehci";
+ 		status = "disabled";
+ 	};
+ 
+@@ -849,6 +855,8 @@
+ 		clocks = <&cru HCLK_HOST2>, <&u2phy1>;
+ 		phys = <&u2phy1_host>;
+ 		phy-names = "usb";
++		resets = <&cru SRST_USBHOST2>;
++		reset-names = "ehci";
+ 		status = "disabled";
+ 	};
+ 
+diff --git a/drivers/usb/host/dwc2.c b/drivers/usb/host/dwc2.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/host/dwc2.c
++++ b/drivers/usb/host/dwc2.c
+@@ -1438,7 +1438,10 @@ static int dwc2_usb_remove(struct udevice *dev)
+ 
+ 	dwc2_uninit_common(priv->regs);
+ 
+-	reset_release_bulk(&priv->resets);
++	// Assert first and then leave the resets deasserted
++	reset_assert_bulk(&priv->resets);
++	reset_deassert_bulk(&priv->resets);
++
+ 	clk_disable_bulk(&priv->clks);
+ 	clk_release_bulk(&priv->clks);
+ 
+diff --git a/drivers/usb/host/ehci-generic.c b/drivers/usb/host/ehci-generic.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/host/ehci-generic.c
++++ b/drivers/usb/host/ehci-generic.c
+@@ -148,9 +148,9 @@ static int ehci_usb_remove(struct udevice *dev)
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = reset_release_bulk(&priv->resets);
+-	if (ret)
+-		return ret;
++	// Assert first and then leave the resets deasserted
++	reset_assert_bulk(&priv->resets);
++	reset_deassert_bulk(&priv->resets);
+ 
+ 	return clk_release_bulk(&priv->clocks);
+ }
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk322x-box/rk322x-box-add-defconfig.patch
+++ b/patch/u-boot/v2025.01/board_rk322x-box/rk322x-box-add-defconfig.patch
@@ -1,0 +1,207 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo <paolo.sabatino@gmail.com>
+Date: Fri, 19 Jun 2020 17:27:27 +0200
+Subject: [ARCHEOLOGY] Introducing Rockchip RK322X SoC support (#2032)
+
+> X-Git-Archeology: > recovered message: > * Introducing Rockchip rk322x SoC support
+> X-Git-Archeology: > recovered message: > Main features:
+> X-Git-Archeology: > recovered message: > - Legacy kernel flavour based upon stable v2.x rk3288 Rockchip branch (https://github.com/rockchip-linux/kernel/tree/stable-4.4-rk3288-linux-v2.x)
+> X-Git-Archeology: > recovered message: > - Current kernel flavour based on mainline 5.6.y kernel
+> X-Git-Archeology: > recovered message: > - Mainline u-boot (v2020.04)
+> X-Git-Archeology: > recovered message: > - Single generic tv box target (rk322x-box) which boots on all the known tv boxes
+> X-Git-Archeology: > recovered message: > - Hardware devices (eMMC/NAND, led wiring configuration, SoC variant selection) modulation done by user at runtime via device tree overlays - a script (rk322x-config) is provided for autodetection and simple configuration by inexperienced users;
+> X-Git-Archeology: > recovered message: > - Bits added to armbian-hardware-optimization to set affinity for irq handlers
+> X-Git-Archeology: > recovered message: > - rk322x-box targets already added to targets.conf for automatic image creation
+> X-Git-Archeology: > recovered message: > * Removed disabled patches
+> X-Git-Archeology: > recovered message: > * Restored mysteriously removed comment character
+> X-Git-Archeology: - Revision 23604e8a0dcdf81ec6c28ccd4b2a64b90816d8e7: https://github.com/armbian/build/commit/23604e8a0dcdf81ec6c28ccd4b2a64b90816d8e7
+> X-Git-Archeology:   Date: Fri, 19 Jun 2020 17:27:27 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Introducing Rockchip RK322X SoC support (#2032)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 3e7409eb1aa98c339cf35a03e305ec635e4c6292: https://github.com/armbian/build/commit/3e7409eb1aa98c339cf35a03e305ec635e4c6292
+> X-Git-Archeology:   Date: Sat, 10 Oct 2020 07:07:59 +0000
+> X-Git-Archeology:   From: paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Moving rk322x to u-boot v2020.10, using static FIT image source file instead of now removed fit_spl_optee.sh script
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 95425c27b9d3bbb96e7936cc531638c9150538f9: https://github.com/armbian/build/commit/95425c27b9d3bbb96e7936cc531638c9150538f9
+> X-Git-Archeology:   Date: Fri, 12 Mar 2021 20:20:12 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Changes and fixes to rk322x uboot and kernel config
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e4d895607e5ac380b186e523ce28c6f9c36289cb: https://github.com/armbian/build/commit/e4d895607e5ac380b186e523ce28c6f9c36289cb
+> X-Git-Archeology:   Date: Sun, 04 Apr 2021 15:52:22 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: uboot: upgrade to v2021.04-rc5
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 71d6e7db63d6d85b7b1374b37432e0e8dcd3a73a: https://github.com/armbian/build/commit/71d6e7db63d6d85b7b1374b37432e0e8dcd3a73a
+> X-Git-Archeology:   Date: Fri, 18 Mar 2022 17:26:46 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: bump to u-boot v2022.01
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0777be9e754c8bd24cff0297226b5158564bbc96: https://github.com/armbian/build/commit/0777be9e754c8bd24cff0297226b5158564bbc96
+> X-Git-Archeology:   Date: Sun, 10 Apr 2022 16:45:06 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: move edge flavour to kernel 5.17, adapt patches were necessary
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 97c34489831f2146940f52915428263b7edfcbe1: https://github.com/armbian/build/commit/97c34489831f2146940f52915428263b7edfcbe1
+> X-Git-Archeology:   Date: Fri, 24 Mar 2023 23:13:42 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: put all rockchip 32 bit into uboot/v2022.04 directory
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision fb7484f3f9f50bbbae033c251978e00fa59fd080: https://github.com/armbian/build/commit/fb7484f3f9f50bbbae033c251978e00fa59fd080
+> X-Git-Archeology:   Date: Wed, 01 May 2024 08:29:03 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: bump rk322x u-boot to v2024.01
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5657ec0798045ad9cff0df0033ff1c963dfcdd66: https://github.com/armbian/build/commit/5657ec0798045ad9cff0df0033ff1c963dfcdd66
+> X-Git-Archeology:   Date: Mon, 06 May 2024 15:50:14 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: add reset props for usb on rk322x
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 7876017d0b77bbfefbb3d112045b32d9b50db928: https://github.com/armbian/build/commit/7876017d0b77bbfefbb3d112045b32d9b50db928
+> X-Git-Archeology:   Date: Tue, 02 Jul 2024 23:31:50 +0000
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Bump rk322x-box and rk3318-box to u-boot v2024.07-rc5 (#6855)
+> X-Git-Archeology:
+---
+ configs/rk322x-box_defconfig | 128 ++++++++++
+ 1 file changed, 128 insertions(+)
+
+diff --git a/configs/rk322x-box_defconfig b/configs/rk322x-box_defconfig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/configs/rk322x-box_defconfig
+@@ -0,0 +1,128 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_SPL_SKIP_LOWLEVEL_INIT=y
++CONFIG_TPL_SKIP_LOWLEVEL_INIT=y
++CONFIG_SYS_ARCH_TIMER=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_TEXT_BASE=0x61000000
++CONFIG_SYS_MALLOC_F_LEN=0x2000
++CONFIG_NR_DRAM_BANKS=2
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x61100000
++CONFIG_ENV_SIZE=0x8000
++CONFIG_DEFAULT_DEVICE_TREE="rk322x-box"
++CONFIG_SPL_TEXT_BASE=0x60000000
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_DM_RESET=y
++CONFIG_ROCKCHIP_RK322X=y
++CONFIG_SPL_ROCKCHIP_BACK_TO_BROM=y
++CONFIG_ROCKCHIP_EXTERNAL_TPL=y
++CONFIG_SPL_MMC=y
++CONFIG_TARGET_RK322X_BOX=y
++CONFIG_SPL_STACK_R_ADDR=0x60600000
++CONFIG_SPL_STACK_R=y
++CONFIG_DEBUG_UART_BASE=0x11030000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SYS_LOAD_ADDR=0x61800800
++CONFIG_DEBUG_UART=y
++CONFIG_LOCALVERSION="-armbian"
++# CONFIG_LOCALVERSION_AUTO is not set
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_SYS_BOOTM_LEN=0x4000000
++CONFIG_SD_BOOT=y
++CONFIG_BOOTDELAY=1
++CONFIG_USE_PREBOOT=y
++CONFIG_DEFAULT_FDT_FILE="rk322x-box.dtb"
++CONFIG_LOGLEVEL=6
++CONFIG_SILENT_CONSOLE=y
++# CONFIG_SPL_SILENT_CONSOLE is not set
++# CONFIG_TPL_SILENT_CONSOLE is not set
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++CONFIG_BOARD_EARLY_INIT_R=y
++CONFIG_MISC_INIT_R=y
++CONFIG_SPL_MAX_SIZE=0x100000
++CONFIG_SPL_PAD_TO=0x7f8000
++CONFIG_SPL_NO_BSS_LIMIT=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR=0x200
++# CONFIG_BOOTM_EFI is not set
++# CONFIG_CMD_BOOTEFI is not set
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++# CONFIG_CMD_CLS is not set
++CONFIG_CMD_TIME=y
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_SPL_EFI_PARTITION is not set
++CONFIG_PARTITION_TYPE_GUID=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_TPL_OF_CONTROL=y
++CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_ENV_IS_IN_EXT4=y
++CONFIG_ENV_EXT4_INTERFACE="mmc"
++CONFIG_ENV_EXT4_DEVICE_AND_PART="0:auto"
++CONFIG_ENV_EXT4_FILE="/boot/boot.env"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_TPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++CONFIG_TPL_SYSCON=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_TPL_CLK=y
++CONFIG_CLK_CCF=y
++CONFIG_CLK_COMPOSITE_CCF=y
++CONFIG_CLK_GPIO=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_LED=y
++CONFIG_LED_GPIO=y
++CONFIG_MISC=y
++CONFIG_ROCKCHIP_EFUSE=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_HDMI=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PINCTRL=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_SPL_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++# CONFIG_RAM_ROCKCHIP is not set
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_SYSRESET=y
++CONFIG_TEE=y
++CONFIG_OPTEE=y
++CONFIG_USB=y
++# CONFIG_SPL_DM_USB is not set
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC2=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_VIDEO=y
++# CONFIG_BACKLIGHT_PWM is not set
++# CONFIG_PANEL is not set
++CONFIG_DISPLAY=y
++CONFIG_VIDEO_ROCKCHIP=y
++CONFIG_DISPLAY_ROCKCHIP_HDMI=y
++CONFIG_FS_BTRFS=y
++CONFIG_TPL_TINY_MEMSET=y
++CONFIG_SPL_CRC32=y
++CONFIG_ERRNO_STR=y
++CONFIG_BOOTM_OPTEE=y
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk322x-box/rk322x-box-add-device-tree-makefile.patch
+++ b/patch/u-boot/v2025.01/board_rk322x-box/rk322x-box-add-device-tree-makefile.patch
@@ -1,0 +1,240 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Thu, 25 Apr 2024 21:24:15 +0200
+Subject: Makefile and basic configuration for rk322x-box
+
+---
+ arch/arm/dts/Makefile                  |  3 +-
+ arch/arm/mach-rockchip/rk322x/Kconfig  |  5 +
+ board/rockchip/rk322x-box/Kconfig      | 15 ++
+ board/rockchip/rk322x-box/MAINTAINERS  |  6 +
+ board/rockchip/rk322x-box/Makefile     |  7 +
+ board/rockchip/rk322x-box/README       | 72 ++++++++++
+ board/rockchip/rk322x-box/rk322x-box.c | 21 +++
+ include/configs/rk322x-box.h           | 29 ++++
+ 8 files changed, 157 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -73,7 +73,8 @@ dtb-$(CONFIG_ROCKCHIP_RK3188) += \
+ 	rk3188-radxarock.dtb
+ 
+ dtb-$(CONFIG_ROCKCHIP_RK322X) += \
+-	rk3229-evb.dtb
++	rk3229-evb.dtb \
++	rk322x-box.dtb
+ 
+ dtb-$(CONFIG_ROCKCHIP_RK3288) += \
+ 	rk3288-evb.dtb \
+diff --git a/arch/arm/mach-rockchip/rk322x/Kconfig b/arch/arm/mach-rockchip/rk322x/Kconfig
+index 111111111111..222222222222 100644
+--- a/arch/arm/mach-rockchip/rk322x/Kconfig
++++ b/arch/arm/mach-rockchip/rk322x/Kconfig
+@@ -11,6 +11,10 @@ config ROCKCHIP_BOOT_MODE_REG
+ config ROCKCHIP_STIMER_BASE
+ 	default 0x110d0020
+ 
++config TARGET_RK322X_BOX
++	bool "RK322X-BOX"
++	select BOARD_LATE_INIT
++
+ config SYS_SOC
+ 	default "rk322x"
+ 
+@@ -33,5 +37,6 @@ config TPL_TEXT_BASE
+         default 0x10081000
+ 
+ source "board/rockchip/evb_rk3229/Kconfig"
++source "board/rockchip/rk322x-box/Kconfig"
+ 
+ endif
+diff --git a/board/rockchip/rk322x-box/Kconfig b/board/rockchip/rk322x-box/Kconfig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/board/rockchip/rk322x-box/Kconfig
+@@ -0,0 +1,15 @@
++if TARGET_RK322X_BOX
++
++config SYS_BOARD
++	default "rk322x-box"
++
++config SYS_VENDOR
++	default "rockchip"
++
++config SYS_CONFIG_NAME
++	default "rk322x-box"
++
++config BOARD_SPECIFIC_OPTIONS # dummy
++	def_bool y
++
++endif
+diff --git a/board/rockchip/rk322x-box/MAINTAINERS b/board/rockchip/rk322x-box/MAINTAINERS
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/board/rockchip/rk322x-box/MAINTAINERS
+@@ -0,0 +1,6 @@
++XT-MX4VR-V10
++M:      Paolo Sabatino <paolo.sabatino@gmail.com>
++S:      Out of tree
++F:      board/rockchip/rk322x-box
++F:      include/configs/rk322x-box.h
++F:      configs/rk322x-box_defconfig
+diff --git a/board/rockchip/rk322x-box/Makefile b/board/rockchip/rk322x-box/Makefile
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/board/rockchip/rk322x-box/Makefile
+@@ -0,0 +1,7 @@
++#
++# (C) Copyright 2015 Google, Inc
++#
++# SPDX-License-Identifier:     GPL-2.0+
++#
++
++obj-y	+= rk322x-box.o
+diff --git a/board/rockchip/rk322x-box/README b/board/rockchip/rk322x-box/README
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/board/rockchip/rk322x-box/README
+@@ -0,0 +1,72 @@
++Get the Source and prebuild binary
++==================================
++
++  > mkdir ~/rk322x-box
++  > cd ~/rk322x-box
++  > git clone git://git.denx.de/u-boot.git
++  > git clone https://github.com/OP-TEE/optee_os.git
++  > git clone https://github.com/rockchip-linux/rkbin.git
++  > git clone https://github.com/rockchip-linux/rkdeveloptool.git
++
++Compile the OP-TEE
++===============
++
++  > cd optee_os
++  > make clean
++  > make CROSS_COMPILE_ta_arm32=arm-none-eabi- PLATFORM=rockchip-rk322x
++  Get tee.bin in this step, copy it to U-Boot root dir:
++  > cp out/arm-plat-rockchip/core/tee-pager.bin ../u-boot/tee.bin
++
++Compile the U-Boot
++==================
++
++  > cd ../u-boot
++  > export CROSS_COMPILE=arm-linux-gnueabihf-
++  > export ARCH=arm
++  > make rk322x-box_defconfig
++  > make
++  > make u-boot.itb
++
++  Get tpl/u-boot-tpl.bin, spl/u-boot-spl.bin and u-boot.itb in this step.
++
++Compile the rkdeveloptool
++=======================
++  Follow instructions in latest README
++  > cd ../rkflashtool
++  > autoreconf -i
++  > ./configure
++  > make
++  > sudo make install
++
++  Get rkdeveloptool in you Host in this step.
++
++Both origin binaries and Tool are ready now, choose either option 1 or
++option 2 to deploy U-Boot.
++
++Package the image
++=================
++
++  > cd ../u-boot
++  > tools/mkimage -n rk322x -T rksd -d tpl/u-boot-spl.bin idbloader.img
++  > cat spl/u-boot-spl.bin >> idbloader.img
++
++  Get idbloader.img in this step.
++
++Flash the image to eMMC
++=======================
++Power on(or reset with RESET KEY) with MASKROM KEY preesed, and then:
++  > cd ..
++  > rkdeveloptool db rkbin/rk32/rk322x_loader_v1.04.232.bin
++  > rkdeveloptool wl 64 u-boot/idbloader.img
++  > rkdeveloptool wl 0x4000 u-boot/u-boot.itb
++  > rkdeveloptool rd
++
++Flash the image to SD card
++==========================
++  > dd if=u-boot/idbloader.img of=/dev/sdb seek=64
++  > dd if=u-boot/u-boot.itb of=/dev/sdb seek=16384
++
++You should be able to get U-Boot log message with OP-TEE boot info.
++
++For more detail, please reference to:
++http://opensource.rock-chips.com/wiki_Boot_option
+diff --git a/board/rockchip/rk322x-box/rk322x-box.c b/board/rockchip/rk322x-box/rk322x-box.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/board/rockchip/rk322x-box/rk322x-box.c
+@@ -0,0 +1,20 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2017 Rockchip Electronics Co., Ltd
++ */
++
++#include <dm.h>
++#include <asm/io.h>
++#include <asm/arch-rockchip/uart.h>
++#include <led.h>
++
++int board_early_init_r(void) {
++
++        /* LED setup */
++	//if (IS_ENABLED(CONFIG_LED))
++		//led_default_state();
++
++	return 0;
++
++}
++
+diff --git a/include/configs/rk322x-box.h b/include/configs/rk322x-box.h
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/include/configs/rk322x-box.h
+@@ -0,0 +1,29 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * (C) Copyright 2017 Rockchip Electronics Co., Ltd
++ */
++
++#ifndef __CONFIG_H
++#define __CONFIG_H
++
++#include <configs/rk322x_common.h>
++
++#define ROCKCHIP_DEVICE_SETTINGS \
++	"stdin=serial,usbkbd\0" \
++	"stdout=serial,vidconsole\0" \
++	"stderr=serial,vidconsole\0" \
++	"fdt_high=0xffffffff\0" \
++	"initrd_high=0xffffffff\0"
++
++#undef BOOT_TARGETS
++#undef CFG_EXTRA_ENV_SETTINGS
++
++#define BOOT_TARGETS	"mmc0 usb mmc1 pxe dhcp"
++
++#define CFG_EXTRA_ENV_SETTINGS \
++	"fdtfile=" CONFIG_DEFAULT_FDT_FILE "\0" \
++	ENV_MEM_LAYOUT_SETTINGS \
++	ROCKCHIP_DEVICE_SETTINGS \
++	"boot_targets=" BOOT_TARGETS "\0"
++
++#endif
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk322x-box/rk322x-box-add-device-tree.patch
+++ b/patch/u-boot/v2025.01/board_rk322x-box/rk322x-box-add-device-tree.patch
@@ -1,0 +1,327 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo <paolo.sabatino@gmail.com>
+Date: Fri, 19 Jun 2020 17:27:27 +0200
+Subject: [ARCHEOLOGY] Introducing Rockchip RK322X SoC support (#2032)
+
+> X-Git-Archeology: > recovered message: > * Introducing Rockchip rk322x SoC support
+> X-Git-Archeology: > recovered message: > Main features:
+> X-Git-Archeology: > recovered message: > - Legacy kernel flavour based upon stable v2.x rk3288 Rockchip branch (https://github.com/rockchip-linux/kernel/tree/stable-4.4-rk3288-linux-v2.x)
+> X-Git-Archeology: > recovered message: > - Current kernel flavour based on mainline 5.6.y kernel
+> X-Git-Archeology: > recovered message: > - Mainline u-boot (v2020.04)
+> X-Git-Archeology: > recovered message: > - Single generic tv box target (rk322x-box) which boots on all the known tv boxes
+> X-Git-Archeology: > recovered message: > - Hardware devices (eMMC/NAND, led wiring configuration, SoC variant selection) modulation done by user at runtime via device tree overlays - a script (rk322x-config) is provided for autodetection and simple configuration by inexperienced users;
+> X-Git-Archeology: > recovered message: > - Bits added to armbian-hardware-optimization to set affinity for irq handlers
+> X-Git-Archeology: > recovered message: > - rk322x-box targets already added to targets.conf for automatic image creation
+> X-Git-Archeology: > recovered message: > * Removed disabled patches
+> X-Git-Archeology: > recovered message: > * Restored mysteriously removed comment character
+> X-Git-Archeology: - Revision 23604e8a0dcdf81ec6c28ccd4b2a64b90816d8e7: https://github.com/armbian/build/commit/23604e8a0dcdf81ec6c28ccd4b2a64b90816d8e7
+> X-Git-Archeology:   Date: Fri, 19 Jun 2020 17:27:27 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Introducing Rockchip RK322X SoC support (#2032)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 95425c27b9d3bbb96e7936cc531638c9150538f9: https://github.com/armbian/build/commit/95425c27b9d3bbb96e7936cc531638c9150538f9
+> X-Git-Archeology:   Date: Fri, 12 Mar 2021 20:20:12 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Changes and fixes to rk322x uboot and kernel config
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 97c34489831f2146940f52915428263b7edfcbe1: https://github.com/armbian/build/commit/97c34489831f2146940f52915428263b7edfcbe1
+> X-Git-Archeology:   Date: Fri, 24 Mar 2023 23:13:42 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: put all rockchip 32 bit into uboot/v2022.04 directory
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision fb7484f3f9f50bbbae033c251978e00fa59fd080: https://github.com/armbian/build/commit/fb7484f3f9f50bbbae033c251978e00fa59fd080
+> X-Git-Archeology:   Date: Wed, 01 May 2024 08:29:03 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: bump rk322x u-boot to v2024.01
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5657ec0798045ad9cff0df0033ff1c963dfcdd66: https://github.com/armbian/build/commit/5657ec0798045ad9cff0df0033ff1c963dfcdd66
+> X-Git-Archeology:   Date: Mon, 06 May 2024 15:50:14 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: add reset props for usb on rk322x
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 7876017d0b77bbfefbb3d112045b32d9b50db928: https://github.com/armbian/build/commit/7876017d0b77bbfefbb3d112045b32d9b50db928
+> X-Git-Archeology:   Date: Tue, 02 Jul 2024 23:31:50 +0000
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Bump rk322x-box and rk3318-box to u-boot v2024.07-rc5 (#6855)
+> X-Git-Archeology:
+---
+ arch/arm/dts/rk322x-box.dts | 268 ++++++++++
+ 1 file changed, 268 insertions(+)
+
+diff --git a/arch/arm/dts/rk322x-box.dts b/arch/arm/dts/rk322x-box.dts
+new file mode 100755
+index 000000000000..111111111111
+--- /dev/null
++++ b/arch/arm/dts/rk322x-box.dts
+@@ -0,0 +1,268 @@
++// SPDX-License-Identifier: GPL-2.0+ OR X11
++/*
++ * (C) Copyright 2019 Paolo Sabatino
++ *
++ * Generic rk322x tv box device tree include file.
++ *
++ * This dtsi covers most of the common hardware included in generic tv boxes around the market.
++ * Include this dtsi in your configuration and make the necessary adjustments there for base support.
++ *
++ */
++
++/dts-v1/;
++
++#include "rk322x.dtsi"
++
++/ {
++	model = "Generic Rockchip RK322x TV Box board";
++	compatible = "rockchip,rk322x-box";
++
++	chosen {
++		bootph-all;
++		stdout-path = &uart2;
++		u-boot,spl-boot-order = "same-as-spl", &emmc, &sdmmc;
++	};
++
++	memory@60000000 {
++		device_type = "memory";
++		reg = <0x60000000 0x40000000>;
++	};
++
++	leds: leds {
++		compatible = "gpio-leds";
++
++		/*
++		 * Main led is available on all boards.
++		 * Default state is honoured only if led_default_state() is called inside
++		 * an early init hook function.
++		 */
++		main {
++			label = "working";
++			gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++
++	};
++
++	vcc_sys: vcc-sys-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_phy: vcc-phy-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		regulator-name = "vcc_phy";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	vcc_otg_vbus: otg-vbus-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio3 RK_PC6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&otg_vbus_drv>;
++		regulator-name = "vcc_otg_vbus";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-boot-on;
++		//  		regulator-always-on;
++		enable-active-high;
++		vin-supply = <&vcc_sys>;
++	};
++
++	vcc_host_vbus: vcc-host-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio3 RK_PC4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&host_vbus_drv>;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-name = "vcc_host";
++		// 		regulator-always-on;
++		regulator-boot-on;
++		enable-active-high;
++		vin-supply = <&vcc_sys>;
++	};
++
++};
++
++&gmac {
++
++	assigned-clocks = <&cru SCLK_MAC_SRC>;
++	assigned-clock-rates = <50000000>;
++
++	clock_in_out = "output";
++	phy-supply = <&vcc_phy>;
++	phy-mode = "rmii";
++	phy-is-integrated;
++
++	tx_delay = < 0x26 >; // Default is 0x30, but original dts proposes 0x26
++	rx_delay = < 0x11 >; // Default is 0x10, but original dts proposes 0x11
++
++	pinctrl-names = "default";
++	pinctrl-0 = <&phy_pins>;
++
++	status = "okay";
++
++};
++
++&emmc {
++
++	bootph-pre-ram;
++	clock-frequency = <50000000>;
++	clock-freq-min-max = <400000 50000000>;
++	broken-cd;
++	cap-mmc-highspeed;
++	mmc-hs200-1_8v;
++	supports-emmc;
++	disable-wp;
++	non-removable;
++	/delete-property/ pinctrl-names;
++	/delete-property/ pinctrl-0;
++	status = "okay";
++
++};
++
++&sdmmc {
++
++	bootph-pre-ram;
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	card-detect-delay = <200>;
++	cd-gpios = <&gpio1 RK_PC1 GPIO_ACTIVE_LOW>;
++	disable-wp;
++	num-slots = <1>;
++	supports-sd;
++
++	status = "okay";
++
++};
++
++&uart2 {
++	pinctrl-0 = <&uart21_xfer>;
++	pinctrl-names = "default";
++	bootph-all;
++	status = "okay";
++};
++
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	status = "okay";
++};
++
++&u2phy0_host {
++	status = "okay";
++};
++
++&u2phy1 {
++	status = "okay";
++};
++
++&u2phy1_otg {
++	status = "okay";
++};
++
++&u2phy1_host {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	vbus-supply = <&vcc_host_vbus>;
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	vbus-supply = <&vcc_host_vbus>;
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	vbus-supply = <&vcc_host_vbus>;
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	vbus-supply = <&vcc_host_vbus>;
++	status = "okay";
++};
++
++&usb_host2_ehci {
++	vbus-supply = <&vcc_host_vbus>;
++	status = "okay";
++};
++
++&usb_host2_ohci {
++	vbus-supply = <&vcc_host_vbus>;
++	status = "okay";
++};
++
++&usb_otg {
++	dr_mode = "host";
++	hnp-srp-disable;
++	vbus-supply = <&vcc_otg_vbus>;
++	status = "okay";
++};
++
++&pinctrl {
++
++	pinctrl-names = "default";
++	pinctrl-0 = <&gpio_leds>;
++
++	gpio {
++		gpio_leds: gpio-leds {
++			rockchip,pins = <3 21 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	usb {
++		host_vbus_drv: host-vbus-drv {
++			rockchip,pins = <3 RK_PC4 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++
++		otg_vbus_drv: otg-vbus-drv {
++			rockchip,pins = <3 RK_PC6 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	uart2 {
++		uart21_xfer: uart21-xfer {
++			rockchip,pins = <1 RK_PB2 2 &pcfg_pull_up>,
++			<1 RK_PB1 2 &pcfg_pull_none>;
++		};
++	};
++
++};
++
++&hdmi {
++	/*
++	 * u-boot clk driver is not yet capable to handle parents correctly;
++	 * these properties will prevent the video output features if present
++	 */
++	/delete-property/assigned-clocks;
++	/delete-property/assigned-clock-parents;
++	status = "okay";
++};
++
++&hdmi_phy {
++	status = "okay";
++};
++
++&vop {
++	bootph-all;
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk322x-box/u-boot-1002-support-rockchip-gmac-rmii.patch
+++ b/patch/u-boot/v2025.01/board_rk322x-box/u-boot-1002-support-rockchip-gmac-rmii.patch
@@ -1,0 +1,420 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Thu, 25 Apr 2024 21:44:55 +0200
+Subject: support gmac rmii phy for rk322x
+
+---
+ arch/arm/dts/rk322x.dtsi                        |   8 +-
+ arch/arm/include/asm/arch-rockchip/cru_rk322x.h |   1 +
+ doc/device-tree-bindings/net/phy.txt            |  13 +
+ drivers/clk/rockchip/clk_rk322x.c               |  14 +-
+ drivers/net/gmac_rockchip.c                     | 186 +++++++++-
+ 5 files changed, 205 insertions(+), 17 deletions(-)
+
+diff --git a/arch/arm/dts/rk322x.dtsi b/arch/arm/dts/rk322x.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm/dts/rk322x.dtsi
++++ b/arch/arm/dts/rk322x.dtsi
+@@ -878,13 +878,13 @@
+ 		clocks = <&cru SCLK_MAC>, <&cru SCLK_MAC_RX>,
+ 			<&cru SCLK_MAC_TX>, <&cru SCLK_MAC_REF>,
+ 			<&cru SCLK_MAC_REFOUT>, <&cru ACLK_GMAC>,
+-			<&cru PCLK_GMAC>;
++			<&cru PCLK_GMAC>, <&cru SCLK_MAC_PHY>;
+ 		clock-names = "stmmaceth", "mac_clk_rx",
+ 			"mac_clk_tx", "clk_mac_ref",
+ 			"clk_mac_refout", "aclk_mac",
+-			"pclk_mac";
+-		resets = <&cru SRST_GMAC>;
+-		reset-names = "stmmaceth";
++			"pclk_mac", "clk_macphy";
++		resets = <&cru SRST_GMAC>, <&cru SRST_MACPHY>;
++		reset-names = "stmmaceth", "mac-phy";
+ 		rockchip,grf = <&grf>;
+ 		status = "disabled";
+ 	};
+diff --git a/arch/arm/include/asm/arch-rockchip/cru_rk322x.h b/arch/arm/include/asm/arch-rockchip/cru_rk322x.h
+index 111111111111..222222222222 100644
+--- a/arch/arm/include/asm/arch-rockchip/cru_rk322x.h
++++ b/arch/arm/include/asm/arch-rockchip/cru_rk322x.h
+@@ -10,6 +10,7 @@
+ 
+ #define APLL_HZ		(600 * MHz)
+ #define GPLL_HZ		(594 * MHz)
++#define CPLL_HZ		(500 * MHz)
+ 
+ #define CORE_PERI_HZ	150000000
+ #define CORE_ACLK_HZ	300000000
+diff --git a/doc/device-tree-bindings/net/phy.txt b/doc/device-tree-bindings/net/phy.txt
+index 111111111111..222222222222 100644
+--- a/doc/device-tree-bindings/net/phy.txt
++++ b/doc/device-tree-bindings/net/phy.txt
+@@ -8,6 +8,19 @@ Required properties:
+ 
+  - reg : The ID number for the phy, usually a small integer
+ 
++Optional Properties:
++
++- compatible: Compatible list, may contain
++  "ethernet-phy-ieee802.3-c22" or "ethernet-phy-ieee802.3-c45" for
++  PHYs that implement IEEE802.3 clause 22 or IEEE802.3 clause 45
++  specifications. If neither of these are specified, the default is to
++  assume clause 22.
++
++- phy-is-integrated: If set, indicates that the PHY is integrated into the same
++  physical package as the Ethernet MAC. If needed, muxers should be configured
++  to ensure the integrated PHY is used. The absence of this property indicates
++  the muxers should be configured so that the external PHY is used.
++
+ Example:
+ 
+ ethernet-phy@0 {
+diff --git a/drivers/clk/rockchip/clk_rk322x.c b/drivers/clk/rockchip/clk_rk322x.c
+index 111111111111..222222222222 100644
+--- a/drivers/clk/rockchip/clk_rk322x.c
++++ b/drivers/clk/rockchip/clk_rk322x.c
+@@ -42,6 +42,7 @@ enum {
+ /* use integer mode*/
+ static const struct pll_div apll_init_cfg = PLL_DIVISORS(APLL_HZ, 1, 3, 1);
+ static const struct pll_div gpll_init_cfg = PLL_DIVISORS(GPLL_HZ, 2, 2, 1);
++static const struct pll_div cpll_init_cfg = PLL_DIVISORS(CPLL_HZ, 2, 3, 1);
+ 
+ static int rkclk_set_pll(struct rk322x_cru *cru, enum rk_clk_id clk_id,
+ 			 const struct pll_div *div)
+@@ -91,11 +92,13 @@ static void rkclk_init(struct rk322x_cru *cru)
+ 	rk_clrsetreg(&cru->cru_mode_con,
+ 		     GPLL_MODE_MASK | APLL_MODE_MASK,
+ 		     GPLL_MODE_SLOW << GPLL_MODE_SHIFT |
+-		     APLL_MODE_SLOW << APLL_MODE_SHIFT);
++		     APLL_MODE_SLOW << APLL_MODE_SHIFT |
++		     CPLL_MODE_SLOW << CPLL_MODE_SHIFT);
+ 
+ 	/* init pll */
+ 	rkclk_set_pll(cru, CLK_ARM, &apll_init_cfg);
+ 	rkclk_set_pll(cru, CLK_GENERAL, &gpll_init_cfg);
++	rkclk_set_pll(cru, CLK_CODEC, &cpll_init_cfg);
+ 
+ 	/*
+ 	 * select apll as cpu/core clock pll source and
+@@ -168,7 +171,8 @@ static void rkclk_init(struct rk322x_cru *cru)
+ 	rk_clrsetreg(&cru->cru_mode_con,
+ 		     GPLL_MODE_MASK | APLL_MODE_MASK,
+ 		     GPLL_MODE_NORM << GPLL_MODE_SHIFT |
+-		     APLL_MODE_NORM << APLL_MODE_SHIFT);
++		     APLL_MODE_NORM << APLL_MODE_SHIFT |
++		     CPLL_MODE_NORM << CPLL_MODE_SHIFT);
+ }
+ 
+ /* Get pll rate by id */
+@@ -258,11 +262,10 @@ static ulong rk322x_mac_set_clk(struct rk322x_cru *cru, uint freq)
+ 		ulong pll_rate;
+ 		u8 div;
+ 
+-		if ((con >> MAC_PLL_SEL_SHIFT) & MAC_PLL_SEL_MASK)
++		if (con & MAC_PLL_SEL_MASK)
+ 			pll_rate = GPLL_HZ;
+ 		else
+-			/* CPLL is not set */
+-			return -EPERM;
++			pll_rate = CPLL_HZ;
+ 
+ 		div = DIV_ROUND_UP(pll_rate, freq) - 1;
+ 		if (div <= 0x1f)
+@@ -461,6 +464,7 @@ static ulong rk322x_clk_set_rate(struct clk *clk, ulong rate)
+ 	case CLK_DDR:
+ 		new_rate = rk322x_ddr_set_clk(priv->cru, rate);
+ 		break;
++	case SCLK_MAC_SRC:
+ 	case SCLK_MAC:
+ 		new_rate = rk322x_mac_set_clk(priv->cru, rate);
+ 		break;
+
+diff --git a/drivers/net/gmac_rockchip.c b/drivers/net/gmac_rockchip.c
+index 8cfeeffe95..c215b1b3f4 100644
+--- a/drivers/net/gmac_rockchip.c
++++ b/drivers/net/gmac_rockchip.c
+@@ -10,6 +10,7 @@
+ #include <log.h>
+ #include <net.h>
+ #include <phy.h>
++#include <reset.h>
+ #include <syscon.h>
+ #include <asm/global_data.h>
+ #include <asm/arch-rockchip/periph.h>
+@@ -24,6 +25,8 @@
+ #include <asm/arch-rockchip/grf_rk3399.h>
+ #include <asm/arch-rockchip/grf_rv1108.h>
+ #include <dm/pinctrl.h>
++#include <dm/of_access.h>
++#include <linux/delay.h>
+ #include <dt-bindings/clock/rk3288-cru.h>
+ #include <linux/bitops.h>
+ #include "designware.h"
+@@ -41,20 +44,29 @@ DECLARE_GLOBAL_DATA_PTR;
+ struct gmac_rockchip_plat {
+ 	struct dw_eth_pdata dw_eth_pdata;
+ 	bool clock_input;
++	bool integrated_phy;
++	struct reset_ctl phy_reset;
+ 	int tx_delay;
+ 	int rx_delay;
+ };
+ 
+ struct rk_gmac_ops {
+ 	int (*fix_mac_speed)(struct dw_eth_dev *priv);
++	int (*fix_rmii_speed)(struct gmac_rockchip_plat *pdata,
++		struct dw_eth_dev *priv);
++	int (*fix_rgmii_speed)(struct gmac_rockchip_plat *pdata,
++		struct dw_eth_dev *priv);
+ 	void (*set_to_rmii)(struct gmac_rockchip_plat *pdata);
+ 	void (*set_to_rgmii)(struct gmac_rockchip_plat *pdata);
++	void (*integrated_phy_powerup)(struct gmac_rockchip_plat *pdata);
+ };
+ 
+ static int gmac_rockchip_of_to_plat(struct udevice *dev)
+ {
+ 	struct gmac_rockchip_plat *pdata = dev_get_plat(dev);
++	struct ofnode_phandle_args args;
+ 	const char *string;
++	int ret;
+ 
+ 	string = dev_read_string(dev, "clock_in_out");
+ 	if (!strcmp(string, "input"))
+@@ -62,6 +74,25 @@ static int gmac_rockchip_of_to_plat(struct udevice *dev)
+ 	else
+ 		pdata->clock_input = false;
+ 
++	/* If phy-handle property is passed from DT, use it as the PHY */
++	ret = dev_read_phandle_with_args(dev, "phy-handle", NULL, 0, 0, &args);
++	if (ret) {
++		debug("Cannot get phy phandle: ret=%d\n", ret);
++		pdata->integrated_phy = dev_read_bool(dev, "phy-is-integrated");
++	} else {
++		debug("Found phy-handle subnode\n");
++		pdata->integrated_phy = ofnode_read_bool(args.node,
++							 "phy-is-integrated");
++	}
++
++	if (pdata->integrated_phy) {
++		ret = reset_get_by_name(dev, "mac-phy", &pdata->phy_reset);
++		if (ret) {
++			debug("No PHY reset control found: ret=%d\n", ret);
++			return ret;
++		}
++	}
++
+ 	/* Check the new naming-style first... */
+ 	pdata->tx_delay = dev_read_u32_default(dev, "tx_delay", -ENOENT);
+ 	pdata->rx_delay = dev_read_u32_default(dev, "rx_delay", -ENOENT);
+@@ -116,7 +147,43 @@ static int px30_gmac_fix_mac_speed(struct dw_eth_dev *priv)
+ 	return 0;
+ }
+ 
+-static int rk3228_gmac_fix_mac_speed(struct dw_eth_dev *priv)
++static int rk3228_gmac_fix_rmii_speed(struct gmac_rockchip_plat *pdata,
++				      struct dw_eth_dev *priv)
++{
++	struct rk322x_grf *grf;
++	int clk;
++	enum {
++		RK3228_GMAC_RMII_CLK_MASK   = BIT(7),
++		RK3228_GMAC_RMII_CLK_2_5M   = 0,
++		RK3228_GMAC_RMII_CLK_25M    = BIT(7),
++
++		RK3228_GMAC_RMII_SPEED_MASK = BIT(2),
++		RK3228_GMAC_RMII_SPEED_10   = 0,
++		RK3228_GMAC_RMII_SPEED_100  = BIT(2),
++	};
++
++	switch (priv->phydev->speed) {
++	case 10:
++		clk = RK3228_GMAC_RMII_CLK_2_5M | RK3228_GMAC_RMII_SPEED_10;
++		break;
++	case 100:
++		clk = RK3228_GMAC_RMII_CLK_25M | RK3228_GMAC_RMII_SPEED_100;
++		break;
++	default:
++		debug("Unknown phy speed: %d\n", priv->phydev->speed);
++		return -EINVAL;
++	}
++
++	grf = syscon_get_first_range(ROCKCHIP_SYSCON_GRF);
++	rk_clrsetreg(&grf->mac_con[1],
++		     RK3228_GMAC_RMII_CLK_MASK | RK3228_GMAC_RMII_SPEED_MASK,
++		     clk);
++
++	return 0;
++}
++
++static int rk3228_gmac_fix_rgmii_speed(struct gmac_rockchip_plat *pdata,
++				       struct dw_eth_dev *priv)
+ {
+ 	struct rk322x_grf *grf;
+ 	int clk;
+@@ -358,6 +425,28 @@ static void px30_gmac_set_to_rmii(struct gmac_rockchip_plat *pdata)
+ 		     PX30_GMAC_PHY_INTF_SEL_RMII);
+ }
+ 
++static void rk3228_gmac_set_to_rmii(struct gmac_rockchip_plat *pdata)
++{
++       struct rk322x_grf *grf;
++       enum {
++               RK3228_GRF_CON_RMII_MODE_MASK = BIT(11),
++               RK3228_GRF_CON_RMII_MODE_SEL = BIT(11),
++               RK3228_RMII_MODE_MASK = BIT(10),
++               RK3228_RMII_MODE_SEL = BIT(10),
++               RK3228_GMAC_PHY_INTF_SEL_MASK  = GENMASK(6, 4),
++               RK3228_GMAC_PHY_INTF_SEL_RMII = BIT(6),
++       };
++
++       grf = syscon_get_first_range(ROCKCHIP_SYSCON_GRF);
++       rk_clrsetreg(&grf->mac_con[1],
++                    RK3228_GRF_CON_RMII_MODE_MASK |
++                    RK3228_RMII_MODE_MASK |
++                    RK3228_GMAC_PHY_INTF_SEL_MASK,
++                    RK3228_GRF_CON_RMII_MODE_SEL |
++                    RK3228_RMII_MODE_SEL |
++                    RK3228_GMAC_PHY_INTF_SEL_RMII);
++}
++
+ static void rk3228_gmac_set_to_rgmii(struct gmac_rockchip_plat *pdata)
+ {
+ 	struct rk322x_grf *grf;
+@@ -551,6 +640,66 @@ static void rv1108_gmac_set_to_rmii(struct gmac_rockchip_plat *pdata)
+ 		     RV1108_GMAC_PHY_INTF_SEL_RMII);
+ }
+ 
++static void rk3228_gmac_integrated_phy_powerup(struct gmac_rockchip_plat *pdata)
++{
++	struct rk322x_grf *grf;
++	enum {
++		RK3228_GRF_CON_MUX_GMAC_INTEGRATED_PHY_MASK = BIT(15),
++		RK3228_GRF_CON_MUX_GMAC_INTEGRATED_PHY = BIT(15),
++	};
++	enum {
++		RK3228_MACPHY_CFG_CLK_50M_MASK = BIT(14),
++		RK3228_MACPHY_CFG_CLK_50M = BIT(14),
++
++		RK3228_MACPHY_RMII_MODE_MASK = GENMASK(7, 6),
++		RK3228_MACPHY_RMII_MODE = BIT(6),
++
++		RK3228_MACPHY_ENABLE_MASK = BIT(0),
++		RK3228_MACPHY_DISENABLE = 0,
++		RK3228_MACPHY_ENABLE = BIT(0),
++	};
++	enum {
++		RK3228_RK_GRF_CON2_MACPHY_ID_MASK = GENMASK(6, 0),
++		RK3228_RK_GRF_CON2_MACPHY_ID = 0x1234,
++	};
++	enum {
++		RK3228_RK_GRF_CON3_MACPHY_ID_MASK = GENMASK(5, 0),
++		RK3228_RK_GRF_CON3_MACPHY_ID = 0x35,
++	};
++
++	grf = syscon_get_first_range(ROCKCHIP_SYSCON_GRF);
++	rk_clrsetreg(&grf->con_iomux,
++		     RK3228_GRF_CON_MUX_GMAC_INTEGRATED_PHY_MASK,
++		     RK3228_GRF_CON_MUX_GMAC_INTEGRATED_PHY);
++
++	rk_clrsetreg(&grf->macphy_con[2],
++		     RK3228_RK_GRF_CON2_MACPHY_ID_MASK,
++		     RK3228_RK_GRF_CON2_MACPHY_ID);
++
++	rk_clrsetreg(&grf->macphy_con[3],
++		     RK3228_RK_GRF_CON3_MACPHY_ID_MASK,
++		     RK3228_RK_GRF_CON3_MACPHY_ID);
++
++	/* disabled before trying to reset it */
++	rk_clrsetreg(&grf->macphy_con[0],
++		     RK3228_MACPHY_CFG_CLK_50M_MASK |
++		     RK3228_MACPHY_RMII_MODE_MASK |
++		     RK3228_MACPHY_ENABLE_MASK,
++		     RK3228_MACPHY_CFG_CLK_50M |
++		     RK3228_MACPHY_RMII_MODE |
++		     RK3228_MACPHY_DISENABLE);
++
++	reset_assert(&pdata->phy_reset);
++	udelay(10);
++	reset_deassert(&pdata->phy_reset);
++	udelay(10);
++
++	rk_clrsetreg(&grf->macphy_con[0],
++		     RK3228_MACPHY_ENABLE_MASK,
++		     RK3228_MACPHY_ENABLE);
++	udelay(30 * 1000);
++}
++
+ static int gmac_rockchip_probe(struct udevice *dev)
+ {
+ 	struct gmac_rockchip_plat *pdata = dev_get_plat(dev);
+@@ -570,6 +719,9 @@ static int gmac_rockchip_probe(struct udevice *dev)
+ 	if (ret)
+ 		return ret;
+ 
++	if (pdata->integrated_phy && ops->integrated_phy_powerup)
++		ops->integrated_phy_powerup(pdata);
++
+ 	switch (eth_pdata->phy_interface) {
+ 	case PHY_INTERFACE_MODE_RGMII:
+ 		/* Set to RGMII mode */
+@@ -653,7 +805,7 @@ static int gmac_rockchip_probe(struct udevice *dev)
+ 		break;
+ 
+ 	default:
+-		debug("NO interface defined!\n");
++		debug("%s: no interface defined!\n", __func__);
+ 		return -ENXIO;
+ 	}
+ 
+@@ -662,18 +814,33 @@ static int gmac_rockchip_probe(struct udevice *dev)
+ 
+ static int gmac_rockchip_eth_start(struct udevice *dev)
+ {
+-	struct eth_pdata *pdata = dev_get_plat(dev);
++	struct eth_pdata *eth_pdata = dev_get_plat(dev);
+ 	struct dw_eth_dev *priv = dev_get_priv(dev);
+ 	struct rk_gmac_ops *ops =
+ 		(struct rk_gmac_ops *)dev_get_driver_data(dev);
++	struct gmac_rockchip_plat *pdata = dev_get_plat(dev);
+ 	int ret;
+ 
+-	ret = designware_eth_init(priv, pdata->enetaddr);
+-	if (ret)
+-		return ret;
+-	ret = ops->fix_mac_speed(priv);
++	ret = designware_eth_init(priv, eth_pdata->enetaddr);
+ 	if (ret)
+ 		return ret;
++
++	switch (eth_pdata->phy_interface) {
++		case PHY_INTERFACE_MODE_RGMII:
++			ret = ops->fix_rgmii_speed(pdata, priv);
++			if (ret)
++				return ret;
++			 break;
++		case PHY_INTERFACE_MODE_RMII:
++			ret = ops->fix_rmii_speed(pdata, priv);
++			if (ret)
++				return ret;
++			break;
++		default:
++			debug("%s: no interface defined!\n", __func__);
++			return -ENXIO;
++	}
++
+ 	ret = designware_eth_enable(priv);
+ 	if (ret)
+ 		return ret;
+@@ -696,8 +863,11 @@ const struct rk_gmac_ops px30_gmac_ops = {
+ };
+ 
+ const struct rk_gmac_ops rk3228_gmac_ops = {
+-	.fix_mac_speed = rk3228_gmac_fix_mac_speed,
++	.fix_rmii_speed = rk3228_gmac_fix_rmii_speed,
++	.fix_rgmii_speed = rk3228_gmac_fix_rgmii_speed,
++	.set_to_rmii = rk3228_gmac_set_to_rmii,
+ 	.set_to_rgmii = rk3228_gmac_set_to_rgmii,
++	.integrated_phy_powerup = rk3228_gmac_integrated_phy_powerup,
+ };
+ 
+ const struct rk_gmac_ops rk3288_gmac_ops = {

--- a/patch/u-boot/v2025.01/board_rk322x-box/u-boot-1005-support-rockchip-tee-binary.patch
+++ b/patch/u-boot/v2025.01/board_rk322x-box/u-boot-1005-support-rockchip-tee-binary.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Thu, 25 Apr 2024 21:48:17 +0200
+Subject: Set register r1 to CONFIG_SYS_TEXT_BASE to support rockchip
+ proprietary OP-TEE binaries
+
+---
+ common/spl/spl_optee.S | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/common/spl/spl_optee.S b/common/spl/spl_optee.S
+index 111111111111..222222222222 100644
+--- a/common/spl/spl_optee.S
++++ b/common/spl/spl_optee.S
+@@ -8,5 +8,6 @@
+ 
+ ENTRY(spl_optee_entry)
+ 	ldr lr, =CONFIG_TEXT_BASE
++	ldr r1, =CONFIG_TEXT_BASE
+ 	mov pc, r3
+ ENDPROC(spl_optee_entry)
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk322x-box/u-boot-1006-usbphy-otg-ehci-support.patch
+++ b/patch/u-boot/v2025.01/board_rk322x-box/u-boot-1006-usbphy-otg-ehci-support.patch
@@ -1,0 +1,213 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 30 Jun 2024 16:46:51 +0200
+Subject: OTG/EHCI USB support for rk322x
+
+---
+ arch/arm/mach-rockchip/rk322x/syscon_rk322x.c |   3 +
+ drivers/clk/rockchip/clk_rk322x.c             | 121 ++++++++++
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c |  32 +++
+ 3 files changed, 156 insertions(+)
+
+diff --git a/arch/arm/mach-rockchip/rk322x/syscon_rk322x.c b/arch/arm/mach-rockchip/rk322x/syscon_rk322x.c
+index 111111111111..222222222222 100644
+--- a/arch/arm/mach-rockchip/rk322x/syscon_rk322x.c
++++ b/arch/arm/mach-rockchip/rk322x/syscon_rk322x.c
+@@ -17,5 +17,8 @@ static const struct udevice_id rk322x_syscon_ids[] = {
+ U_BOOT_DRIVER(syscon_rk322x) = {
+ 	.name = "rk322x_syscon",
+ 	.id = UCLASS_SYSCON,
++#if !CONFIG_IS_ENABLED(OF_PLATDATA)
++        .bind = dm_scan_fdt_dev,
++#endif
+ 	.of_match = rk322x_syscon_ids,
+ };
+diff --git a/drivers/clk/rockchip/clk_rk322x.c b/drivers/clk/rockchip/clk_rk322x.c
+index 111111111111..222222222222 100644
+--- a/drivers/clk/rockchip/clk_rk322x.c
++++ b/drivers/clk/rockchip/clk_rk322x.c
+@@ -596,10 +596,131 @@ static int rk322x_clk_set_parent(struct clk *clk, struct clk *parent)
+ 	return -ENOENT;
+ }
+ 
++static int rk322x_clk_enable(struct clk *clk)
++{
++
++	struct rk322x_clk_priv *priv = dev_get_priv(clk->dev);
++        struct rk322x_cru *cru = priv->cru;
++
++	switch (clk->id) {
++        case SCLK_OTGPHY0:
++                rk_clrreg(&cru->cru_clkgate_con[1], BIT(5));
++                break;
++        case SCLK_OTGPHY1:
++                rk_clrreg(&cru->cru_clkgate_con[1], BIT(6));
++                break;
++	case HCLK_OTG:
++		rk_clrreg(&cru->cru_clkgate_con[11], BIT(12));
++		break;
++	case HCLK_HOST0:
++		rk_clrreg(&cru->cru_clkgate_con[11], BIT(6));
++		break;
++	case HCLK_HOST1:
++		rk_clrreg(&cru->cru_clkgate_con[11], BIT(8));
++		break;
++	case HCLK_HOST2:
++		rk_clrreg(&cru->cru_clkgate_con[11], BIT(10));
++		break;
++	case SCLK_MAC:
++		rk_clrreg(&cru->cru_clkgate_con[1], BIT(6));
++		break;
++	case SCLK_MAC_SRC:
++		rk_clrreg(&cru->cru_clkgate_con[1], BIT(7));
++		break;
++	case SCLK_MAC_RX:
++		rk_clrreg(&cru->cru_clkgate_con[5], BIT(5));
++		break;
++	case SCLK_MAC_TX:
++		rk_clrreg(&cru->cru_clkgate_con[5], BIT(6));
++		break;
++	case SCLK_MAC_REF:
++		rk_clrreg(&cru->cru_clkgate_con[5], BIT(3));
++		break;
++	case SCLK_MAC_REFOUT:
++		rk_clrreg(&cru->cru_clkgate_con[5], BIT(4));
++		break;
++	case SCLK_MAC_PHY:
++		rk_clrreg(&cru->cru_clkgate_con[5], BIT(7));
++		break;
++	case ACLK_GMAC:
++		rk_clrreg(&cru->cru_clkgate_con[11], BIT(4));
++		break;
++	case PCLK_GMAC:
++		rk_clrreg(&cru->cru_clkgate_con[11], BIT(5));
++		break;
++	default:
++		log_debug("%s: unsupported clk %ld\n", __func__, clk->id);
++		return -ENOENT;
++	}
++
++	return 0;
++
++}
++
++static int rk322x_clk_disable(struct clk *clk)
++{
++
++	struct rk322x_clk_priv *priv = dev_get_priv(clk->dev);
++        struct rk322x_cru *cru = priv->cru;
++
++	switch (clk->id) {
++        case SCLK_OTGPHY0:
++                rk_setreg(&cru->cru_clkgate_con[1], BIT(5));
++                break;
++        case SCLK_OTGPHY1:
++                rk_setreg(&cru->cru_clkgate_con[1], BIT(6));
++                break;
++	case HCLK_OTG:
++		rk_setreg(&cru->cru_clkgate_con[11], BIT(12));
++		break;
++	case HCLK_HOST0:
++		rk_setreg(&cru->cru_clkgate_con[11], BIT(6));
++		break;
++	case HCLK_HOST1:
++		rk_setreg(&cru->cru_clkgate_con[11], BIT(8));
++		break;
++	case HCLK_HOST2:
++		rk_setreg(&cru->cru_clkgate_con[11], BIT(10));
++		break;
++	case SCLK_MAC_SRC:
++		rk_setreg(&cru->cru_clkgate_con[1], BIT(7));
++		break;
++	case SCLK_MAC_RX:
++		rk_setreg(&cru->cru_clkgate_con[5], BIT(5));
++		break;
++	case SCLK_MAC_TX:
++		rk_setreg(&cru->cru_clkgate_con[5], BIT(6));
++		break;
++	case SCLK_MAC_REF:
++		rk_setreg(&cru->cru_clkgate_con[5], BIT(3));
++		break;
++	case SCLK_MAC_REFOUT:
++		rk_setreg(&cru->cru_clkgate_con[5], BIT(4));
++		break;
++	case SCLK_MAC_PHY:
++		rk_setreg(&cru->cru_clkgate_con[5], BIT(7));
++		break;
++	case ACLK_GMAC:
++		rk_setreg(&cru->cru_clkgate_con[11], BIT(4));
++		break;
++	case PCLK_GMAC:
++		rk_setreg(&cru->cru_clkgate_con[11], BIT(5));
++		break;
++	default:
++		log_debug("%s: unsupported clk %ld\n", __func__, clk->id);
++		return -ENOENT;
++	}
++
++	return 0;
++
++}
++
+ static struct clk_ops rk322x_clk_ops = {
+ 	.get_rate	= rk322x_clk_get_rate,
+ 	.set_rate	= rk322x_clk_set_rate,
+ 	.set_parent	= rk322x_clk_set_parent,
++	.enable     = rk322x_clk_enable,
++	.disable    = rk322x_clk_disable
+ };
+ 
+ static int rk322x_clk_of_to_plat(struct udevice *dev)
+diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
+index 111111111111..222222222222 100644
+--- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
++++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
+@@ -361,6 +361,34 @@ static const struct rockchip_usb2phy_cfg rk3328_usb2phy_cfgs[] = {
+ 	{ /* sentinel */ }
+ };
+ 
++static const struct rockchip_usb2phy_cfg rk3228_phy_cfgs[] = {
++        {
++                .reg = 0x760,
++                .clkout_ctl     = { 0x0768, 4, 4, 1, 0 },
++                .port_cfgs      = {
++                        [USB2PHY_PORT_OTG] = {
++                                .phy_sus        = { 0x0760, 15, 0, 0, 0x1d1 },
++                        },
++                        [USB2PHY_PORT_HOST] = {
++                                .phy_sus        = { 0x0764, 15, 0, 0, 0x1d1 },
++                        }
++                },
++        },
++        {
++                .reg = 0x800,
++                .clkout_ctl     = { 0x0808, 4, 4, 1, 0 },
++                .port_cfgs      = {
++                        [USB2PHY_PORT_OTG] = {
++                                .phy_sus        = { 0x800, 15, 0, 0, 0x1d1 },
++                        },
++                        [USB2PHY_PORT_HOST] = {
++                                .phy_sus        = { 0x804, 15, 0, 0, 0x1d1 },
++                        }
++                },
++        },
++        { /* sentinel */ }
++};
++
+ static const struct rockchip_usb2phy_cfg rk3399_usb2phy_cfgs[] = {
+ 	{
+ 		.reg		= 0xe450,
+@@ -466,6 +494,10 @@ static const struct udevice_id rockchip_usb2phy_ids[] = {
+ 		.compatible = "rockchip,rk3328-usb2phy",
+ 		.data = (ulong)&rk3328_usb2phy_cfgs,
+ 	},
++	{
++		.compatible = "rockchip,rk3228-usb2phy",
++		.data = (ulong)&rk3228_phy_cfgs,
++	},
+ 	{
+ 		.compatible = "rockchip,rk3399-usb2phy",
+ 		.data = (ulong)&rk3399_usb2phy_cfgs,
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk3318-box/general-support-rmii-integrated-phy.patch
+++ b/patch/u-boot/v2025.01/board_rk3318-box/general-support-rmii-integrated-phy.patch
@@ -1,0 +1,420 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Thu, 25 Apr 2024 21:44:55 +0200
+Subject: support gmac rmii phy for rk322x
+
+---
+ arch/arm/dts/rk322x.dtsi                        |   8 +-
+ arch/arm/include/asm/arch-rockchip/cru_rk322x.h |   1 +
+ doc/device-tree-bindings/net/phy.txt            |  13 +
+ drivers/clk/rockchip/clk_rk322x.c               |  14 +-
+ drivers/net/gmac_rockchip.c                     | 186 +++++++++-
+ 5 files changed, 205 insertions(+), 17 deletions(-)
+
+diff --git a/arch/arm/dts/rk322x.dtsi b/arch/arm/dts/rk322x.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm/dts/rk322x.dtsi
++++ b/arch/arm/dts/rk322x.dtsi
+@@ -878,13 +878,13 @@
+ 		clocks = <&cru SCLK_MAC>, <&cru SCLK_MAC_RX>,
+ 			<&cru SCLK_MAC_TX>, <&cru SCLK_MAC_REF>,
+ 			<&cru SCLK_MAC_REFOUT>, <&cru ACLK_GMAC>,
+-			<&cru PCLK_GMAC>;
++			<&cru PCLK_GMAC>, <&cru SCLK_MAC_PHY>;
+ 		clock-names = "stmmaceth", "mac_clk_rx",
+ 			"mac_clk_tx", "clk_mac_ref",
+ 			"clk_mac_refout", "aclk_mac",
+-			"pclk_mac";
+-		resets = <&cru SRST_GMAC>;
+-		reset-names = "stmmaceth";
++			"pclk_mac", "clk_macphy";
++		resets = <&cru SRST_GMAC>, <&cru SRST_MACPHY>;
++		reset-names = "stmmaceth", "mac-phy";
+ 		rockchip,grf = <&grf>;
+ 		status = "disabled";
+ 	};
+diff --git a/arch/arm/include/asm/arch-rockchip/cru_rk322x.h b/arch/arm/include/asm/arch-rockchip/cru_rk322x.h
+index 111111111111..222222222222 100644
+--- a/arch/arm/include/asm/arch-rockchip/cru_rk322x.h
++++ b/arch/arm/include/asm/arch-rockchip/cru_rk322x.h
+@@ -10,6 +10,7 @@
+ 
+ #define APLL_HZ		(600 * MHz)
+ #define GPLL_HZ		(594 * MHz)
++#define CPLL_HZ		(500 * MHz)
+ 
+ #define CORE_PERI_HZ	150000000
+ #define CORE_ACLK_HZ	300000000
+diff --git a/doc/device-tree-bindings/net/phy.txt b/doc/device-tree-bindings/net/phy.txt
+index 111111111111..222222222222 100644
+--- a/doc/device-tree-bindings/net/phy.txt
++++ b/doc/device-tree-bindings/net/phy.txt
+@@ -8,6 +8,19 @@ Required properties:
+ 
+  - reg : The ID number for the phy, usually a small integer
+ 
++Optional Properties:
++
++- compatible: Compatible list, may contain
++  "ethernet-phy-ieee802.3-c22" or "ethernet-phy-ieee802.3-c45" for
++  PHYs that implement IEEE802.3 clause 22 or IEEE802.3 clause 45
++  specifications. If neither of these are specified, the default is to
++  assume clause 22.
++
++- phy-is-integrated: If set, indicates that the PHY is integrated into the same
++  physical package as the Ethernet MAC. If needed, muxers should be configured
++  to ensure the integrated PHY is used. The absence of this property indicates
++  the muxers should be configured so that the external PHY is used.
++
+ Example:
+ 
+ ethernet-phy@0 {
+diff --git a/drivers/clk/rockchip/clk_rk322x.c b/drivers/clk/rockchip/clk_rk322x.c
+index 111111111111..222222222222 100644
+--- a/drivers/clk/rockchip/clk_rk322x.c
++++ b/drivers/clk/rockchip/clk_rk322x.c
+@@ -42,6 +42,7 @@ enum {
+ /* use integer mode*/
+ static const struct pll_div apll_init_cfg = PLL_DIVISORS(APLL_HZ, 1, 3, 1);
+ static const struct pll_div gpll_init_cfg = PLL_DIVISORS(GPLL_HZ, 2, 2, 1);
++static const struct pll_div cpll_init_cfg = PLL_DIVISORS(CPLL_HZ, 2, 3, 1);
+ 
+ static int rkclk_set_pll(struct rk322x_cru *cru, enum rk_clk_id clk_id,
+ 			 const struct pll_div *div)
+@@ -91,11 +92,13 @@ static void rkclk_init(struct rk322x_cru *cru)
+ 	rk_clrsetreg(&cru->cru_mode_con,
+ 		     GPLL_MODE_MASK | APLL_MODE_MASK,
+ 		     GPLL_MODE_SLOW << GPLL_MODE_SHIFT |
+-		     APLL_MODE_SLOW << APLL_MODE_SHIFT);
++		     APLL_MODE_SLOW << APLL_MODE_SHIFT |
++		     CPLL_MODE_SLOW << CPLL_MODE_SHIFT);
+ 
+ 	/* init pll */
+ 	rkclk_set_pll(cru, CLK_ARM, &apll_init_cfg);
+ 	rkclk_set_pll(cru, CLK_GENERAL, &gpll_init_cfg);
++	rkclk_set_pll(cru, CLK_CODEC, &cpll_init_cfg);
+ 
+ 	/*
+ 	 * select apll as cpu/core clock pll source and
+@@ -168,7 +171,8 @@ static void rkclk_init(struct rk322x_cru *cru)
+ 	rk_clrsetreg(&cru->cru_mode_con,
+ 		     GPLL_MODE_MASK | APLL_MODE_MASK,
+ 		     GPLL_MODE_NORM << GPLL_MODE_SHIFT |
+-		     APLL_MODE_NORM << APLL_MODE_SHIFT);
++		     APLL_MODE_NORM << APLL_MODE_SHIFT |
++		     CPLL_MODE_NORM << CPLL_MODE_SHIFT);
+ }
+ 
+ /* Get pll rate by id */
+@@ -258,11 +262,10 @@ static ulong rk322x_mac_set_clk(struct rk322x_cru *cru, uint freq)
+ 		ulong pll_rate;
+ 		u8 div;
+ 
+-		if ((con >> MAC_PLL_SEL_SHIFT) & MAC_PLL_SEL_MASK)
++		if (con & MAC_PLL_SEL_MASK)
+ 			pll_rate = GPLL_HZ;
+ 		else
+-			/* CPLL is not set */
+-			return -EPERM;
++			pll_rate = CPLL_HZ;
+ 
+ 		div = DIV_ROUND_UP(pll_rate, freq) - 1;
+ 		if (div <= 0x1f)
+@@ -461,6 +464,7 @@ static ulong rk322x_clk_set_rate(struct clk *clk, ulong rate)
+ 	case CLK_DDR:
+ 		new_rate = rk322x_ddr_set_clk(priv->cru, rate);
+ 		break;
++	case SCLK_MAC_SRC:
+ 	case SCLK_MAC:
+ 		new_rate = rk322x_mac_set_clk(priv->cru, rate);
+ 		break;
+
+diff --git a/drivers/net/gmac_rockchip.c b/drivers/net/gmac_rockchip.c
+index 8cfeeffe95..c215b1b3f4 100644
+--- a/drivers/net/gmac_rockchip.c
++++ b/drivers/net/gmac_rockchip.c
+@@ -10,6 +10,7 @@
+ #include <log.h>
+ #include <net.h>
+ #include <phy.h>
++#include <reset.h>
+ #include <syscon.h>
+ #include <asm/global_data.h>
+ #include <asm/arch-rockchip/periph.h>
+@@ -24,6 +25,8 @@
+ #include <asm/arch-rockchip/grf_rk3399.h>
+ #include <asm/arch-rockchip/grf_rv1108.h>
+ #include <dm/pinctrl.h>
++#include <dm/of_access.h>
++#include <linux/delay.h>
+ #include <dt-bindings/clock/rk3288-cru.h>
+ #include <linux/bitops.h>
+ #include "designware.h"
+@@ -41,20 +44,29 @@ DECLARE_GLOBAL_DATA_PTR;
+ struct gmac_rockchip_plat {
+ 	struct dw_eth_pdata dw_eth_pdata;
+ 	bool clock_input;
++	bool integrated_phy;
++	struct reset_ctl phy_reset;
+ 	int tx_delay;
+ 	int rx_delay;
+ };
+ 
+ struct rk_gmac_ops {
+ 	int (*fix_mac_speed)(struct dw_eth_dev *priv);
++	int (*fix_rmii_speed)(struct gmac_rockchip_plat *pdata,
++		struct dw_eth_dev *priv);
++	int (*fix_rgmii_speed)(struct gmac_rockchip_plat *pdata,
++		struct dw_eth_dev *priv);
+ 	void (*set_to_rmii)(struct gmac_rockchip_plat *pdata);
+ 	void (*set_to_rgmii)(struct gmac_rockchip_plat *pdata);
++	void (*integrated_phy_powerup)(struct gmac_rockchip_plat *pdata);
+ };
+ 
+ static int gmac_rockchip_of_to_plat(struct udevice *dev)
+ {
+ 	struct gmac_rockchip_plat *pdata = dev_get_plat(dev);
++	struct ofnode_phandle_args args;
+ 	const char *string;
++	int ret;
+ 
+ 	string = dev_read_string(dev, "clock_in_out");
+ 	if (!strcmp(string, "input"))
+@@ -62,6 +74,25 @@ static int gmac_rockchip_of_to_plat(struct udevice *dev)
+ 	else
+ 		pdata->clock_input = false;
+ 
++	/* If phy-handle property is passed from DT, use it as the PHY */
++	ret = dev_read_phandle_with_args(dev, "phy-handle", NULL, 0, 0, &args);
++	if (ret) {
++		debug("Cannot get phy phandle: ret=%d\n", ret);
++		pdata->integrated_phy = dev_read_bool(dev, "phy-is-integrated");
++	} else {
++		debug("Found phy-handle subnode\n");
++		pdata->integrated_phy = ofnode_read_bool(args.node,
++							 "phy-is-integrated");
++	}
++
++	if (pdata->integrated_phy) {
++		ret = reset_get_by_name(dev, "mac-phy", &pdata->phy_reset);
++		if (ret) {
++			debug("No PHY reset control found: ret=%d\n", ret);
++			return ret;
++		}
++	}
++
+ 	/* Check the new naming-style first... */
+ 	pdata->tx_delay = dev_read_u32_default(dev, "tx_delay", -ENOENT);
+ 	pdata->rx_delay = dev_read_u32_default(dev, "rx_delay", -ENOENT);
+@@ -116,7 +147,43 @@ static int px30_gmac_fix_mac_speed(struct dw_eth_dev *priv)
+ 	return 0;
+ }
+ 
+-static int rk3228_gmac_fix_mac_speed(struct dw_eth_dev *priv)
++static int rk3228_gmac_fix_rmii_speed(struct gmac_rockchip_plat *pdata,
++				      struct dw_eth_dev *priv)
++{
++	struct rk322x_grf *grf;
++	int clk;
++	enum {
++		RK3228_GMAC_RMII_CLK_MASK   = BIT(7),
++		RK3228_GMAC_RMII_CLK_2_5M   = 0,
++		RK3228_GMAC_RMII_CLK_25M    = BIT(7),
++
++		RK3228_GMAC_RMII_SPEED_MASK = BIT(2),
++		RK3228_GMAC_RMII_SPEED_10   = 0,
++		RK3228_GMAC_RMII_SPEED_100  = BIT(2),
++	};
++
++	switch (priv->phydev->speed) {
++	case 10:
++		clk = RK3228_GMAC_RMII_CLK_2_5M | RK3228_GMAC_RMII_SPEED_10;
++		break;
++	case 100:
++		clk = RK3228_GMAC_RMII_CLK_25M | RK3228_GMAC_RMII_SPEED_100;
++		break;
++	default:
++		debug("Unknown phy speed: %d\n", priv->phydev->speed);
++		return -EINVAL;
++	}
++
++	grf = syscon_get_first_range(ROCKCHIP_SYSCON_GRF);
++	rk_clrsetreg(&grf->mac_con[1],
++		     RK3228_GMAC_RMII_CLK_MASK | RK3228_GMAC_RMII_SPEED_MASK,
++		     clk);
++
++	return 0;
++}
++
++static int rk3228_gmac_fix_rgmii_speed(struct gmac_rockchip_plat *pdata,
++				       struct dw_eth_dev *priv)
+ {
+ 	struct rk322x_grf *grf;
+ 	int clk;
+@@ -358,6 +425,28 @@ static void px30_gmac_set_to_rmii(struct gmac_rockchip_plat *pdata)
+ 		     PX30_GMAC_PHY_INTF_SEL_RMII);
+ }
+ 
++static void rk3228_gmac_set_to_rmii(struct gmac_rockchip_plat *pdata)
++{
++       struct rk322x_grf *grf;
++       enum {
++               RK3228_GRF_CON_RMII_MODE_MASK = BIT(11),
++               RK3228_GRF_CON_RMII_MODE_SEL = BIT(11),
++               RK3228_RMII_MODE_MASK = BIT(10),
++               RK3228_RMII_MODE_SEL = BIT(10),
++               RK3228_GMAC_PHY_INTF_SEL_MASK  = GENMASK(6, 4),
++               RK3228_GMAC_PHY_INTF_SEL_RMII = BIT(6),
++       };
++
++       grf = syscon_get_first_range(ROCKCHIP_SYSCON_GRF);
++       rk_clrsetreg(&grf->mac_con[1],
++                    RK3228_GRF_CON_RMII_MODE_MASK |
++                    RK3228_RMII_MODE_MASK |
++                    RK3228_GMAC_PHY_INTF_SEL_MASK,
++                    RK3228_GRF_CON_RMII_MODE_SEL |
++                    RK3228_RMII_MODE_SEL |
++                    RK3228_GMAC_PHY_INTF_SEL_RMII);
++}
++
+ static void rk3228_gmac_set_to_rgmii(struct gmac_rockchip_plat *pdata)
+ {
+ 	struct rk322x_grf *grf;
+@@ -551,6 +640,66 @@ static void rv1108_gmac_set_to_rmii(struct gmac_rockchip_plat *pdata)
+ 		     RV1108_GMAC_PHY_INTF_SEL_RMII);
+ }
+ 
++static void rk3228_gmac_integrated_phy_powerup(struct gmac_rockchip_plat *pdata)
++{
++	struct rk322x_grf *grf;
++	enum {
++		RK3228_GRF_CON_MUX_GMAC_INTEGRATED_PHY_MASK = BIT(15),
++		RK3228_GRF_CON_MUX_GMAC_INTEGRATED_PHY = BIT(15),
++	};
++	enum {
++		RK3228_MACPHY_CFG_CLK_50M_MASK = BIT(14),
++		RK3228_MACPHY_CFG_CLK_50M = BIT(14),
++
++		RK3228_MACPHY_RMII_MODE_MASK = GENMASK(7, 6),
++		RK3228_MACPHY_RMII_MODE = BIT(6),
++
++		RK3228_MACPHY_ENABLE_MASK = BIT(0),
++		RK3228_MACPHY_DISENABLE = 0,
++		RK3228_MACPHY_ENABLE = BIT(0),
++	};
++	enum {
++		RK3228_RK_GRF_CON2_MACPHY_ID_MASK = GENMASK(6, 0),
++		RK3228_RK_GRF_CON2_MACPHY_ID = 0x1234,
++	};
++	enum {
++		RK3228_RK_GRF_CON3_MACPHY_ID_MASK = GENMASK(5, 0),
++		RK3228_RK_GRF_CON3_MACPHY_ID = 0x35,
++	};
++
++	grf = syscon_get_first_range(ROCKCHIP_SYSCON_GRF);
++	rk_clrsetreg(&grf->con_iomux,
++		     RK3228_GRF_CON_MUX_GMAC_INTEGRATED_PHY_MASK,
++		     RK3228_GRF_CON_MUX_GMAC_INTEGRATED_PHY);
++
++	rk_clrsetreg(&grf->macphy_con[2],
++		     RK3228_RK_GRF_CON2_MACPHY_ID_MASK,
++		     RK3228_RK_GRF_CON2_MACPHY_ID);
++
++	rk_clrsetreg(&grf->macphy_con[3],
++		     RK3228_RK_GRF_CON3_MACPHY_ID_MASK,
++		     RK3228_RK_GRF_CON3_MACPHY_ID);
++
++	/* disabled before trying to reset it */
++	rk_clrsetreg(&grf->macphy_con[0],
++		     RK3228_MACPHY_CFG_CLK_50M_MASK |
++		     RK3228_MACPHY_RMII_MODE_MASK |
++		     RK3228_MACPHY_ENABLE_MASK,
++		     RK3228_MACPHY_CFG_CLK_50M |
++		     RK3228_MACPHY_RMII_MODE |
++		     RK3228_MACPHY_DISENABLE);
++
++	reset_assert(&pdata->phy_reset);
++	udelay(10);
++	reset_deassert(&pdata->phy_reset);
++	udelay(10);
++
++	rk_clrsetreg(&grf->macphy_con[0],
++		     RK3228_MACPHY_ENABLE_MASK,
++		     RK3228_MACPHY_ENABLE);
++	udelay(30 * 1000);
++}
++
+ static int gmac_rockchip_probe(struct udevice *dev)
+ {
+ 	struct gmac_rockchip_plat *pdata = dev_get_plat(dev);
+@@ -570,6 +719,9 @@ static int gmac_rockchip_probe(struct udevice *dev)
+ 	if (ret)
+ 		return ret;
+ 
++	if (pdata->integrated_phy && ops->integrated_phy_powerup)
++		ops->integrated_phy_powerup(pdata);
++
+ 	switch (eth_pdata->phy_interface) {
+ 	case PHY_INTERFACE_MODE_RGMII:
+ 		/* Set to RGMII mode */
+@@ -653,7 +805,7 @@ static int gmac_rockchip_probe(struct udevice *dev)
+ 		break;
+ 
+ 	default:
+-		debug("NO interface defined!\n");
++		debug("%s: no interface defined!\n", __func__);
+ 		return -ENXIO;
+ 	}
+ 
+@@ -662,18 +814,33 @@ static int gmac_rockchip_probe(struct udevice *dev)
+ 
+ static int gmac_rockchip_eth_start(struct udevice *dev)
+ {
+-	struct eth_pdata *pdata = dev_get_plat(dev);
++	struct eth_pdata *eth_pdata = dev_get_plat(dev);
+ 	struct dw_eth_dev *priv = dev_get_priv(dev);
+ 	struct rk_gmac_ops *ops =
+ 		(struct rk_gmac_ops *)dev_get_driver_data(dev);
++	struct gmac_rockchip_plat *pdata = dev_get_plat(dev);
+ 	int ret;
+ 
+-	ret = designware_eth_init(priv, pdata->enetaddr);
+-	if (ret)
+-		return ret;
+-	ret = ops->fix_mac_speed(priv);
++	ret = designware_eth_init(priv, eth_pdata->enetaddr);
+ 	if (ret)
+ 		return ret;
++
++	switch (eth_pdata->phy_interface) {
++		case PHY_INTERFACE_MODE_RGMII:
++			ret = ops->fix_rgmii_speed(pdata, priv);
++			if (ret)
++				return ret;
++			 break;
++		case PHY_INTERFACE_MODE_RMII:
++			ret = ops->fix_rmii_speed(pdata, priv);
++			if (ret)
++				return ret;
++			break;
++		default:
++			debug("%s: no interface defined!\n", __func__);
++			return -ENXIO;
++	}
++
+ 	ret = designware_eth_enable(priv);
+ 	if (ret)
+ 		return ret;
+@@ -696,8 +863,11 @@ const struct rk_gmac_ops px30_gmac_ops = {
+ };
+ 
+ const struct rk_gmac_ops rk3228_gmac_ops = {
+-	.fix_mac_speed = rk3228_gmac_fix_mac_speed,
++	.fix_rmii_speed = rk3228_gmac_fix_rmii_speed,
++	.fix_rgmii_speed = rk3228_gmac_fix_rgmii_speed,
++	.set_to_rmii = rk3228_gmac_set_to_rmii,
+ 	.set_to_rgmii = rk3228_gmac_set_to_rgmii,
++	.integrated_phy_powerup = rk3228_gmac_integrated_phy_powerup,
+ };
+ 
+ const struct rk_gmac_ops rk3288_gmac_ops = {

--- a/patch/u-boot/v2025.01/board_rk3318-box/rk3318-box-add-defconfig.patch
+++ b/patch/u-boot/v2025.01/board_rk3318-box/rk3318-box-add-defconfig.patch
@@ -1,0 +1,200 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Oleg <balbes-150@yandex.ru>
+Date: Wed, 27 Oct 2021 18:56:02 +0200
+Subject: [ARCHEOLOGY] u-boot usb m1 (#3221)
+
+> X-Git-Archeology: - Revision 7789fef83f10954ab442401a86a0e5a166e5db55: https://github.com/armbian/build/commit/7789fef83f10954ab442401a86a0e5a166e5db55
+> X-Git-Archeology:   Date: Wed, 27 Oct 2021 18:56:02 +0200
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: u-boot usb m1 (#3221)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision fd33c6545bbb4bf2383fc212dd305f3b09e47fac: https://github.com/armbian/build/commit/fd33c6545bbb4bf2383fc212dd305f3b09e47fac
+> X-Git-Archeology:   Date: Wed, 27 Oct 2021 20:28:50 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Moved remaining u-boot rockchip64 mainline patches to new directory
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2b431a49151f7bc1e0e593b4b1b4fea9dfefe229: https://github.com/armbian/build/commit/2b431a49151f7bc1e0e593b4b1b4fea9dfefe229
+> X-Git-Archeology:   Date: Thu, 16 Jun 2022 19:29:16 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Adjust u-boot configs for Station M1 and Station P1 (#3900)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2ca6a9381db4b875533926e0eae9d3d17f68ad06: https://github.com/armbian/build/commit/2ca6a9381db4b875533926e0eae9d3d17f68ad06
+> X-Git-Archeology:   Date: Thu, 23 Jun 2022 08:30:54 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: add rk3318-box tvbox board patch and configurations (#3921)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4707e71e35ce43f35509ca65b1406d74d3e1c16f: https://github.com/armbian/build/commit/4707e71e35ce43f35509ca65b1406d74d3e1c16f
+> X-Git-Archeology:   Date: Sun, 26 Nov 2023 13:58:04 +0100
+> X-Git-Archeology:   From: Alex Shumsky <alexthreed@gmail.com>
+> X-Git-Archeology:   Subject: rk3318-box: Enable uboot BTRFS support
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision eec57ef6ce5837cf9a69b1ef03422a3ebeb9d556: https://github.com/armbian/build/commit/eec57ef6ce5837cf9a69b1ef03422a3ebeb9d556
+> X-Git-Archeology:   Date: Mon, 18 Dec 2023 10:03:17 +0100
+> X-Git-Archeology:   From: Alex Shumsky <alexthreed@gmail.com>
+> X-Git-Archeology:   Subject: rk3318: add uboot Recovery button support
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6154b98851b93e868acfa0dc5e2a9abedfce2308: https://github.com/armbian/build/commit/6154b98851b93e868acfa0dc5e2a9abedfce2308
+> X-Git-Archeology:   Date: Fri, 23 Feb 2024 11:20:57 +0100
+> X-Git-Archeology:   From: Alex Shumsky <alexthreed@gmail.com>
+> X-Git-Archeology:   Subject: rk3318: enable uboot gpio command
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision efee17f217e58a93e795c165e303bfd0a2a0a32a: https://github.com/armbian/build/commit/efee17f217e58a93e795c165e303bfd0a2a0a32a
+> X-Git-Archeology:   Date: Mon, 22 Apr 2024 12:39:09 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: bump rk3318-box uboot to v2024.01
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e127109e2dddb7ed48a9fef0b1b60fc8d064cff0: https://github.com/armbian/build/commit/e127109e2dddb7ed48a9fef0b1b60fc8d064cff0
+> X-Git-Archeology:   Date: Fri, 14 Jun 2024 00:35:08 +0200
+> X-Git-Archeology:   From: Alex Shumsky <alexthreed@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64/rk3318-box: move stack further from base addr to allow bigger uboot image
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 7876017d0b77bbfefbb3d112045b32d9b50db928: https://github.com/armbian/build/commit/7876017d0b77bbfefbb3d112045b32d9b50db928
+> X-Git-Archeology:   Date: Tue, 02 Jul 2024 23:31:50 +0000
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Bump rk322x-box and rk3318-box to u-boot v2024.07-rc5 (#6855)
+> X-Git-Archeology:
+---
+ configs/rk3318-box_defconfig | 131 ++++++++++
+ 1 file changed, 131 insertions(+)
+
+diff --git a/configs/rk3318-box_defconfig b/configs/rk3318-box_defconfig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/configs/rk3318-box_defconfig
+@@ -0,0 +1,132 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_COUNTER_FREQUENCY=24000000
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_SF_DEFAULT_SPEED=20000000
++CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3318-box"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_DM_RESET=y
++CONFIG_ROCKCHIP_RK3328=y
++CONFIG_ROCKCHIP_EXTERNAL_TPL=y
++CONFIG_SPL_DRIVERS_MISC=y
++CONFIG_TARGET_BOX_RK3318=y
++CONFIG_PRE_CON_BUF_ADDR=0xf200000
++CONFIG_DEBUG_UART_BASE=0xFF130000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SYS_LOAD_ADDR=0x800800
++CONFIG_DEBUG_UART=y
++CONFIG_LOCALVERSION="-armbian"
++# CONFIG_LOCALVERSION_AUTO is not set
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_FIT_SIGNATURE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_BOOTDELAY=1
++CONFIG_USE_PREBOOT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3318-box.dtb"
++CONFIG_LOGLEVEL=6
++CONFIG_SILENT_CONSOLE=y
++# CONFIG_SPL_SILENT_CONSOLE is not set
++# CONFIG_TPL_SILENT_CONSOLE is not set
++# CONFIG_SYS_DEVICE_NULLDEV is not set
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++CONFIG_LAST_STAGE_INIT=y
++CONFIG_SPL_MAX_SIZE=0x40000
++CONFIG_SPL_PAD_TO=0x7f8000
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_ATF=y
++CONFIG_SPL_ATF_NO_PLATFORM_PARAM=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TIME=y
++CONFIG_CMD_BTRFS=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_TPL_OF_CONTROL=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_TPL_OF_PLATDATA=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_SYS_MMC_ENV_DEV=1
++CONFIG_TPL_DM=y
++CONFIG_SPL_DM_SEQ_ALIAS=y
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_TPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++CONFIG_TPL_SYSCON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_ADC=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_DM_MDIO=y
++CONFIG_DM_ETH_PHY=y
++CONFIG_PHY_GIGE=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_RGMII=y
++CONFIG_MII=y
++CONFIG_RMII=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_NOP_PHY=y
++CONFIG_PHY_ROCKCHIP_INNO_HDMI=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++# CONFIG_SPL_DM_PMIC is not set
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_ROCKCHIP=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_DEBUG_UART_ANNOUNCE=y
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_SYSINFO=y
++CONFIG_SYSRESET=y
++# CONFIG_TPL_SYSRESET is not set
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC2=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_USB_KEYBOARD_FN_KEYS=y
++CONFIG_VIDEO=y
++# CONFIG_BACKLIGHT_PWM is not set
++CONFIG_VIDEO_ANSI=y
++# CONFIG_PANEL is not set
++CONFIG_DISPLAY=y
++CONFIG_VIDEO_ROCKCHIP=y
++CONFIG_DISPLAY_ROCKCHIP_HDMI=y
++CONFIG_VIDEO_SIMPLE=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_TPL_TINY_MEMSET=y
++CONFIG_ERRNO_STR=y
++# CONFIG_EFI_LOADER is not set
++CONFIG_BOARD_RNG_SEED=y
++CONFIG_CMD_RNG=y
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk3318-box/rk3318-box-add-dts.patch
+++ b/patch/u-boot/v2025.01/board_rk3318-box/rk3318-box-add-dts.patch
@@ -1,0 +1,751 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 16 Jun 2024 16:00:41 +0200
+Subject: Add rk3318-box device tree
+
+---
+ arch/arm/dts/Makefile                          |   3 +
+ arch/arm/dts/rk3318-box-u-boot.dtsi            |  58 +
+ dts/upstream/src/arm64/rockchip/rk3318-box.dts | 648 ++++++++++
+ 3 files changed, 709 insertions(+)
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -90,6 +90,9 @@ dtb-$(CONFIG_ROCKCHIP_RK3288) += \
+ 	rk3288-veyron-speedy.dtb \
+ 	rk3288-vyasa.dtb
+ 
++dtb-$(CONFIG_ROCKCHIP_RK3328) += \
++	rk3318-box.dtb
++
+ dtb-$(CONFIG_ROCKCHIP_RK3368) += \
+ 	rk3368-lion-haikou.dtb \
+ 	rk3368-sheep.dtb \
+diff --git a/arch/arm/dts/rk3318-box-u-boot.dtsi b/arch/arm/dts/rk3318-box-u-boot.dtsi
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/arch/arm/dts/rk3318-box-u-boot.dtsi
+@@ -0,0 +1,62 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2020 Armbian project (jock)
++ */
++
++#include "rk3328-u-boot.dtsi"
++#include "rk3328-sdram-ddr3-666.dtsi"
++
++/*
++ * Remove the OP-TEE binary node from the binman assembly to avoid
++ * the relative u-boot warning. rk3318-box has not op-tee binary.
++ * The absolute path of the offending binary is: 
++ * 	/binman/simple-bin/fit/images/@tee-SEQ/tee-os
++ *
++ * see rockchip-u-boot.dtsi for the binman mayhem
++ * 
++ */
++&fit {
++	images {
++		/delete-node/ @tee-SEQ;
++	};
++};
++
++/ {
++	chosen {
++		u-boot,spl-boot-order = "same-as-spl", &sdmmc, &sdmmc_ext, &emmc;
++	};
++
++};
++
++/*
++&usb_host0_xhci {
++	vbus-supply = <&vcc_host_vbus>;
++	status = "okay";
++};
++*/
++
++&usb20_otg {
++	hnp-srp-disable;
++};
++
++&sdio {
++	status="disabled";
++};
++
++&pinctrl {
++
++	sdmmc0-1 {
++		sdmmc0m1_pwren: sdmmc0m1-pwren {
++			rockchip,pins = <0 RK_PD6 3 &pcfg_pull_up_4ma>;
++		};
++
++		sdmmc0m1_pin: sdmmc0m1-pin {
++			rockchip,pins = <0 RK_PD6 RK_FUNC_GPIO &pcfg_pull_up_4ma>;
++		};
++	};
++
++};
++
++&vdd_arm {
++	regulator-init-microvolt = <1200000>;
++};
+diff --git a/dts/upstream/src/arm64/rockchip/rk3318-box.dts b/dts/upstream/src/arm64/rockchip/rk3318-box.dts
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/dts/upstream/src/arm64/rockchip/rk3318-box.dts
+@@ -0,0 +1,649 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
++ * Copyright (c) 2020 Armbian project (jock)
++ */
++
++/dts-v1/;
++#include "rk3328.dtsi"
++
++/ {
++	model = "Rockchip RK3318 BOX";
++	compatible = "rockchip,rk3318-box", "rockchip,rk3328-box", "rockchip,rk3328";
++
++	aliases {
++		mmc0 = &sdmmc;
++		mmc1 = &sdio;
++		mmc2 = &emmc;
++		mmc3 = &sdmmc_ext;
++	};
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	adc_keys: adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 0>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1800000>;
++		poll-interval = <100>;
++
++		button-recovery {
++			label = "Recovery";
++			linux,code = <0x168>; /*KEY_VENDOR*/
++			press-threshold-microvolt = <17000>;
++		};
++	};
++
++	xin32k: xin32k {
++		compatible = "fixed-clock";
++		clock-frequency = <32768>;
++		clock-output-names = "xin32k";
++		#clock-cells = <0>;
++	};
++
++	gmac_clkin: gmac-clkin {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "gmac_clkin";
++		#clock-cells = <0x00>;
++	};
++
++	regulators {
++		compatible = "simple-bus";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++
++		vcc_18: regulator@0 {
++			compatible = "regulator-fixed";
++			regulator-name = "vccio_1v8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-always-on;
++		};
++
++		vcc_io: regulator@1 {
++			compatible = "regulator-fixed";
++			regulator-name = "vccio_3v3";
++			regulator-min-microvolt = <3300000>;
++			regulator-max-microvolt = <3300000>;
++			regulator-always-on;
++		};
++	};
++
++	vcc_phy: vcc-phy-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_phy";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	vcc_sys: vcc-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_sd: sdmmc-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&sdmmc0m1_pin>;
++		regulator-name = "vcc_sd";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_io>;
++	};
++
++	/*
++	 * USB3 vbus
++	 */
++	vcc_host_vbus: vcc-host-vbus {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb30_host_drv>;
++		regulator-name = "vcc_host_vbus";
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sys>;
++	};
++
++	/*
++	 * USB2 OTG vbus
++	 */
++	vcc_otg_vbus: vcc-otg-vbus {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb20_host_drv>;
++		regulator-name = "vcc_otg_vbus";
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sys>;
++	};
++
++	vdd_arm: vdd-arm {
++		compatible = "pwm-regulator";
++		pwms = <&pwm0 0 5000 1>;
++		pwm-supply = <&vcc_sys>;
++		regulator-name = "vdd_arm";
++		regulator-init-microvolt = <1000000>;
++		regulator-min-microvolt = <950000>;
++		regulator-max-microvolt = <1400000>;
++		regulator-ramp-delay = <12500>;
++		regulator-settling-time-up-us = <250>;
++		regulator-always-on;
++		regulator-boot-on;
++
++	};
++
++	vdd_logic: vdd-log {
++		compatible = "pwm-regulator";
++		pwms = <&pwm1 0 5000 1>;
++		pwm-supply = <&vcc_sys>;
++		regulator-name = "vdd_log";
++		regulator-init-microvolt = <1000000>;
++		regulator-min-microvolt = <900000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <12500>;
++		regulator-settling-time-up-us = <250>;
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&working_led>;
++
++		working {
++			gpios = <&gpio2 RK_PC7 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "default-on";
++			default-state = "on";
++		};
++
++	};
++
++	ir-receiver {
++		compatible = "gpio-ir-receiver";
++		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
++		pinctrl-0 = <&ir_int>;
++		pinctrl-names = "default";
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++
++		/*
++		 * On the module itself this is one of these (depending
++		 * on the actual card populated):
++		 * - SDIO_RESET_L_WL_REG_ON
++		 * - PDN (power down when low)
++		 */
++		reset-gpios = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
++	};
++
++	fd628_dev {
++		compatible = "fd628_dev";
++		fd628_gpio_clk = <&gpio2 RK_PC0 GPIO_ACTIVE_HIGH>;
++		fd628_gpio_dat = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	analog-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "ANALOG";
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s1>;
++		};
++
++		simple-audio-card,codec {
++			sound-dai = <&codec>;
++		};
++	};
++
++	hdmi-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,name = "HDMI";
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s0>;
++		};
++
++		simple-audio-card,codec {
++			sound-dai = <&hdmi>;
++		};
++	};
++
++};
++
++&codec {
++	status = "okay";
++	mute-gpios = <&grf_gpio 0 GPIO_ACTIVE_LOW>;
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_arm>;
++};
++
++/*
++&dmc {
++	center-supply = <&vdd_logic>;
++	status = "disabled";
++};
++*/
++
++&display_subsystem {
++	status = "okay";
++};
++
++&emmc {
++
++	supports-emmc;
++	no-sdio;
++	no-sd;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	disable-wp;
++	non-removable;
++	bus-width = <8>;
++	num-slots = <0x01>;
++
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
++
++	vmmc-supply = <&vcc_io>;
++	vqmmc-supply = <&vcc_18>;
++
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	card-detect-delay = <200>;
++	disable-wp;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
++	supports-sd;
++	vmmc-supply = <&vcc_sd>;
++	status = "okay";
++};
++
++&sdio {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	bus-width = <4>;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	disable-wp;
++	keep-power-in-suspend;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
++	num-slots = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc1_bus4 &sdmmc1_cmd &sdmmc1_clk>;
++	supports-sdio;
++	status = "okay";
++
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++		brcm,drive-strength = <4>;
++		interrupt-parent = <&gpio1>;
++		interrupt-names = "host_wake";
++		interrupts = <RK_PC3 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&sdio_host_wake>;
++	};
++
++};
++
++&sdmmc_ext {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	card-detect-delay = <200>;
++	disable-wp;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0ext_clk &sdmmc0ext_cmd &sdmmc0ext_dectn &sdmmc0ext_bus4>;
++	supports-sd;
++	vmmc-supply = <&vcc_sd>;
++	status = "okay";
++};
++
++&gmac2phy {
++	phy-supply = <&vcc_phy>;
++
++	phy-mode = "rmii";
++
++	clock_in_out = "output";
++	assigned-clocks = <&cru SCLK_MAC2PHY>;
++	assigned-clock-rate = <50000000>;
++	assigned-clock-parents = <&cru SCLK_MAC2PHY_SRC>;
++	tx_delay = <0x30>;
++	rx_delay = <0x10>;
++
++	status = "okay";
++
++};
++
++&gpu {
++	status = "okay";
++	mali-supply = <&vdd_logic>;
++};
++
++/*
++&h265e {
++	status = "okay";
++};
++*/
++
++&h265e_mmu {
++	status = "okay";
++};
++
++&hdmi {
++	status = "okay";
++};
++
++/*
++&spdif {
++	pinctrl-0 = <&spdifm0_tx>;
++	status = "okay";
++};
++
++&spdif_out {
++	status = "okay";
++};
++
++&spdif_sound {
++	status = "okay";
++};
++*/
++
++&hdmiphy {
++	status = "okay";
++};
++
++&i2s0 {
++	status = "okay";
++};
++
++&i2s1 {
++	status = "okay";
++};
++
++&io_domains {
++	status = "okay";
++
++	vccio1-supply = <&vcc_io>;
++	vccio2-supply = <&vcc_18>;
++	vccio3-supply = <&vcc_io>;
++	vccio4-supply = <&vcc_18>;
++	vccio5-supply = <&vcc_io>;
++	vccio6-supply = <&vcc_io>;
++	pmuio-supply = <&vcc_io>;
++};
++
++&pinctrl {
++	pinctrl-names = "default";
++	pinctrl-0 = <&clk_32k_out>;
++
++	clk_32k {
++		clk_32k_out: clk-32k-out {
++			rockchip,pins = <1 RK_PD4 1 &pcfg_pull_none>;
++		};
++	};
++
++	leds {
++		working_led: working-led {
++			rockchip,pins = <2 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none_2ma>;
++		};
++	};
++
++	ir {
++		ir_int: ir-int {
++			rockchip,pins = <2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none_4ma>;/*,
++				<1 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none_4ma>;*/
++		};
++	};
++
++	usb2 {
++		usb20_host_drv: usb20-host-drv {
++			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb3 {
++		usb30_host_drv: usb30-host-drv {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wireless-bluetooth {
++		uart0_gpios: uart0-gpios {
++			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wireless-wlan {
++		sdio_host_wake: sdio-host-wake {
++			rockchip,pins = <1 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++};
++
++/*
++&rkvdec {
++	status = "okay";
++	vcodec-supply = <&vdd_logic>;
++};
++
++
++&rkvdec_mmu {
++	status = "okay";
++};
++*/
++&threshold {
++	temperature = <80000>; /* millicelsius */
++};
++
++&target {
++	temperature = <95000>; /* millicelsius */
++};
++
++&soc_crit {
++	temperature = <100000>; /* millicelsius */
++};
++
++&tsadc {
++	rockchip,hw-tshut-mode = <0>;
++	rockchip,hw-tshut-polarity = <0>;
++	status = "okay";
++};
++
++&uart0 {
++
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_xfer &uart0_cts>;
++	status = "okay";
++
++	bluetooth {
++		compatbile = "brcm,bcm43341-bt";
++		max-speed = <1500000>;
++		shutdown-gpios = <&gpio1 RK_PC5 GPIO_ACTIVE_HIGH>;
++		interrupt-names = "host-wakeup";
++		interrupts = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
++		brcm,bt-pcm-int-params = [01 02 00 01 01];
++	};
++
++};
++
++&uart2 {
++	/delete-property/ dmas;
++	/delete-property/ dma-names;
++
++	status = "okay";
++};
++
++&u2phy {
++	status = "okay";
++
++	u2phy_host: host-port {
++		status = "okay";
++	};
++
++	u2phy_otg: otg-port {
++		status = "okay";
++	};
++};
++
++&usb20_otg {
++	dr_mode = "host";
++	status = "okay";
++};
++
++/*
++&u3phy {
++	vbus-supply = <&vcc_host_vbus>;
++	status = "okay";
++};
++
++&u3phy_utmi {
++	status = "okay";
++};
++
++&u3phy_pipe {
++	status = "okay";
++};
++*/
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usbdrd3 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++/*
++&usbdrd_dwc3 {
++	dr_mode = "host";
++	status = "okay";
++};
++*/
++
++&vop {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vpu {
++	status = "okay";
++	vcodec-supply = <&vdd_logic>;
++};
++
++&vpu_mmu {
++	status = "okay";
++};
++
++/*
++&vepu {
++	status = "okay";
++};
++*/
++
++&vepu_mmu {
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&vcc_18>;
++	status = "okay";
++};
++
++/*
++&rga {
++	status = "okay";
++};
++*/
++
++&pwm0 {
++	status = "okay";
++};
++
++&pwm1 {
++	status = "okay";
++};
++
++&cpu0_opp_table {
++
++	opp-1512000000 {
++		status = "disabled";
++	};
++
++};
++
++&hdmi_sound {
++	status = "okay";
++};
++
++&analog_sound {
++	status = "okay";
++};
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk3318-box/rk3318-box-add-makefile.patch
+++ b/patch/u-boot/v2025.01/board_rk3318-box/rk3318-box-add-makefile.patch
@@ -1,0 +1,253 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo <paolo.sabatino@gmail.com>
+Date: Thu, 23 Jun 2022 08:30:54 +0200
+Subject: [ARCHEOLOGY] rockchip64: add rk3318-box tvbox board patch and
+ configurations (#3921)
+
+> X-Git-Archeology: > recovered message: > * rockchip64: add rk3318-box tvbox board patch and configurations
+> X-Git-Archeology: > recovered message: > * rockchip64: add missing bcm43342 patch for edge kernel
+> X-Git-Archeology: - Revision 2ca6a9381db4b875533926e0eae9d3d17f68ad06: https://github.com/armbian/build/commit/2ca6a9381db4b875533926e0eae9d3d17f68ad06
+> X-Git-Archeology:   Date: Thu, 23 Jun 2022 08:30:54 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: add rk3318-box tvbox board patch and configurations (#3921)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2813365dd25e3ad110936cbf014b95b38d7090ec: https://github.com/armbian/build/commit/2813365dd25e3ad110936cbf014b95b38d7090ec
+> X-Git-Archeology:   Date: Mon, 07 Nov 2022 21:29:00 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move known non working rockhip64 boards to previous boot loader (#4392)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision efee17f217e58a93e795c165e303bfd0a2a0a32a: https://github.com/armbian/build/commit/efee17f217e58a93e795c165e303bfd0a2a0a32a
+> X-Git-Archeology:   Date: Mon, 22 Apr 2024 12:39:09 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: bump rk3318-box uboot to v2024.01
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 7876017d0b77bbfefbb3d112045b32d9b50db928: https://github.com/armbian/build/commit/7876017d0b77bbfefbb3d112045b32d9b50db928
+> X-Git-Archeology:   Date: Tue, 02 Jul 2024 23:31:50 +0000
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Bump rk322x-box and rk3318-box to u-boot v2024.07-rc5 (#6855)
+> X-Git-Archeology:
+---
+ arch/arm/mach-rockchip/rk3328/Kconfig  |  8 ++
+ board/rockchip/rk3318_box/Kconfig      | 15 ++
+ board/rockchip/rk3318_box/MAINTAINERS  | 26 ++++
+ board/rockchip/rk3318_box/Makefile     |  7 +
+ board/rockchip/rk3318_box/README       | 70 ++++++++++
+ board/rockchip/rk3318_box/rk3318-box.c |  5 +
+ include/configs/rk3318-box.h           | 28 ++++
+ 7 files changed, 159 insertions(+)
+
+diff --git a/arch/arm/mach-rockchip/rk3328/Kconfig b/arch/arm/mach-rockchip/rk3328/Kconfig
+index 111111111111..222222222222 100644
+--- a/arch/arm/mach-rockchip/rk3328/Kconfig
++++ b/arch/arm/mach-rockchip/rk3328/Kconfig
+@@ -10,6 +10,13 @@ config TARGET_EVB_RK3328
+ 	  with full function and phisical connectors support like
+ 	  usb2.0 host ports, LVDS, JTAG, MAC, SDcard, HDMI, USB-2-serial...
+ 
++config TARGET_BOX_RK3318
++	bool "Generic RK3318 Box"
++	help
++	  Generic RK3318/RK3328 Tvbox appliance,
++	  with full function and phisical connectors support like
++	  usb2.0 and usb3.0 ports, MAC, SDcard, HDMI, eMMC, WiFi, ...
++
+ endchoice
+ 
+ config ROCKCHIP_BOOT_MODE_REG
+@@ -37,5 +44,6 @@ config TPL_SYS_MALLOC_F_LEN
+ 	default 0x800
+ 
+ source "board/rockchip/evb_rk3328/Kconfig"
++source "board/rockchip/rk3318_box/Kconfig"
+ 
+ endif
+diff --git a/board/rockchip/rk3318_box/Kconfig b/board/rockchip/rk3318_box/Kconfig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/board/rockchip/rk3318_box/Kconfig
+@@ -0,0 +1,15 @@
++if TARGET_BOX_RK3318
++
++config SYS_BOARD
++	default "rk3318_box"
++
++config SYS_VENDOR
++	default "rockchip"
++
++config SYS_CONFIG_NAME
++	default "rk3318-box"
++
++config BOARD_SPECIFIC_OPTIONS # dummy
++	def_bool y
++
++endif
+diff --git a/board/rockchip/rk3318_box/MAINTAINERS b/board/rockchip/rk3318_box/MAINTAINERS
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/board/rockchip/rk3318_box/MAINTAINERS
+@@ -0,0 +1,26 @@
++EVB-RK3328
++M:      Kever Yang <kever.yang@rock-chips.com>
++S:      Maintained
++F:      board/rockchip/evb_rk3328
++F:      include/configs/evb_rk3328.h
++F:      configs/evb-rk3328_defconfig
++
++ROC-RK3328-CC
++M:      Loic Devulder <ldevulder@suse.com>
++M:      Chen-Yu Tsai <wens@csie.org>
++S:      Maintained
++F:      configs/roc-cc-rk3328_defconfig
++F:      arch/arm/dts/rk3328-roc-cc-u-boot.dtsi
++
++ROCK64-RK3328
++M:      Matwey V. Kornilov <matwey.kornilov@gmail.com>
++S:      Maintained
++F:      configs/rock64-rk3328_defconfig
++F:      arch/arm/dts/rk3328-rock64-u-boot.dtsi
++
++ROCKPIE-RK3328
++M:      Banglang Huang <banglang.huang@foxmail.com>
++S:      Maintained
++F:      configs/rock-pi-e-rk3328_defconfig
++F:      arch/arm/dts/rk3328-rock-pi-e.dts
++F:      arch/arm/dts/rk3328-rock-pi-e-u-boot.dtsi
+diff --git a/board/rockchip/rk3318_box/Makefile b/board/rockchip/rk3318_box/Makefile
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/board/rockchip/rk3318_box/Makefile
+@@ -0,0 +1,7 @@
++#
++# (C) Copyright 2016 Rockchip Electronics Co., Ltd
++#
++# SPDX-License-Identifier:     GPL-2.0+
++#
++
++obj-y	+= rk3318-box.o
+diff --git a/board/rockchip/rk3318_box/README b/board/rockchip/rk3318_box/README
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/board/rockchip/rk3318_box/README
+@@ -0,0 +1,70 @@
++Introduction
++============
++
++RK3328 key features we might use in U-Boot:
++* CPU: ARMv8 64bit quad-core Cortex-A53
++* IRAM: 36KB
++* DRAM: 4GB-16MB dual-channel
++* eMMC: support eMMC 5.0/5.1, suport HS400, HS200, DDR50
++* SD/MMC: support SD 3.0, MMC 4.51
++* USB: USB2.0 EHCI host port *2
++* Display: RGB/HDMI/DP/MIPI/EDP
++
++evb key features:
++* regulator: pwm regulator for CPU B/L
++* PMIC: rk808
++* debug console: UART2
++
++In order to support Arm Trust Firmware(ATF), we need to use the
++miniloader from rockchip which:
++* do DRAM init
++* load and verify ATF image
++* load and verify U-Boot image
++
++Here is the step-by-step to boot to U-Boot on rk3328.
++
++Get the Source and prebuild binary
++==================================
++
++  > mkdir ~/evb_rk3328
++  > cd ~/evb_rk3328
++  > git clone https://github.com/ARM-software/arm-trusted-firmware.git
++  > git clone https://github.com/rockchip-linux/rkbin
++  > git clone https://github.com/rockchip-linux/rkflashtool
++
++Compile ATF
++===============
++
++  > cd arm-trusted-firmware
++  > make realclean
++  > make CROSS_COMPILE=aarch64-linux-gnu- PLAT=rk3328 bl31
++
++Compile U-Boot
++==================
++
++  > cd ../u-boot
++  > make CROSS_COMPILE=aarch64-linux-gnu- evb-rk3328_defconfig all
++
++Compile rkflashtool
++=======================
++
++  > cd ../rkflashtool
++  > make
++
++Package image for miniloader
++================================
++  > cd ..
++  > cp arm-trusted-firmware/build/rk3328/release/bl31.bin rkbin/rk33
++  > ./rkbin/tools/trust_merger rkbin/tools/RK3328TRUST.ini
++  > ./rkbin/tools/loaderimage --pack --uboot u-boot/u-boot-dtb.bin uboot.img
++  > mkdir image
++  > mv trust.img ./image/
++  > mv uboot.img ./image/rk3328evb-uboot.bin
++
++Flash image
++===============
++Power on(or reset with RESET KEY) with MASKROM KEY preesed, and then:
++
++  > ./rkflashtool/rkflashloader rk3328evb
++
++You should be able to get U-Boot log message in console/UART2 now.
+diff --git a/board/rockchip/rk3318_box/rk3318-box.c b/board/rockchip/rk3318_box/rk3318-box.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/board/rockchip/rk3318_box/rk3318-box.c
+@@ -0,0 +1,5 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2016 Rockchip Electronics Co., Ltd
++ */
++
+diff --git a/include/configs/rk3318-box.h b/include/configs/rk3318-box.h
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/include/configs/rk3318-box.h
+@@ -0,0 +1,28 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * (C) Copyright 2016 Rockchip Electronics Co., Ltd
++ */
++
++#ifndef __RK3318_BOX_H
++#define __RK3318_BOX_H
++
++#include <configs/rk3328_common.h>
++
++#undef BOOT_TARGETS
++
++#define BOOT_TARGETS	"mmc1 mmc3 usb mmc0 pxe dhcp"
++
++#undef CFG_EXTRA_ENV_SETTINGS
++
++#define CFG_EXTRA_ENV_SETTINGS \
++        ENV_MEM_LAYOUT_SETTINGS \
++        "stdin=serial,usbkbd\0" \
++        "stdout=serial,vidconsole\0" \
++        "stderr=serial,vidconsole\0" \
++        "fdtfile=" CONFIG_DEFAULT_FDT_FILE "\0" \
++        "fdt_high=0xffffffffffffffff\0" \
++        "initrd_high=0xffffffffffffffff\0" \
++        "boot_targets=" BOOT_TARGETS "\0"
++
++
++#endif
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk3318-box/rk3328-add-usb-reset-props.patch
+++ b/patch/u-boot/v2025.01/board_rk3318-box/rk3328-add-usb-reset-props.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Mon, 6 May 2024 15:50:14 +0100
+Subject: [ARCHEOLOGY] rockchip: add reset props for usb on rk322x
+
+> X-Git-Archeology: - Revision 5657ec0798045ad9cff0df0033ff1c963dfcdd66: https://github.com/armbian/build/commit/5657ec0798045ad9cff0df0033ff1c963dfcdd66
+> X-Git-Archeology:   Date: Mon, 06 May 2024 15:50:14 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: add reset props for usb on rk322x
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4b51f88e56c54e3b517e584916241c4942dbfc5f: https://github.com/armbian/build/commit/4b51f88e56c54e3b517e584916241c4942dbfc5f
+> X-Git-Archeology:   Date: Sun, 02 Jun 2024 09:23:31 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: keep usb resets deasserted on exit
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 7876017d0b77bbfefbb3d112045b32d9b50db928: https://github.com/armbian/build/commit/7876017d0b77bbfefbb3d112045b32d9b50db928
+> X-Git-Archeology:   Date: Tue, 02 Jul 2024 23:31:50 +0000
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Bump rk322x-box and rk3318-box to u-boot v2024.07-rc5 (#6855)
+> X-Git-Archeology:
+---
+ drivers/usb/host/dwc2.c                     | 5 ++++-
+ drivers/usb/host/ehci-generic.c             | 6 +++---
+ dts/upstream/src/arm64/rockchip/rk3328.dtsi | 8 ++++++++
+ 3 files changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/usb/host/dwc2.c b/drivers/usb/host/dwc2.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/host/dwc2.c
++++ b/drivers/usb/host/dwc2.c
+@@ -1438,7 +1438,10 @@ static int dwc2_usb_remove(struct udevice *dev)
+ 
+ 	dwc2_uninit_common(priv->regs);
+ 
+-	reset_release_bulk(&priv->resets);
++	// Assert first and then leave the resets deasserted
++	reset_assert_bulk(&priv->resets);
++	reset_deassert_bulk(&priv->resets);
++
+ 	clk_disable_bulk(&priv->clks);
+ 	clk_release_bulk(&priv->clks);
+ 
+diff --git a/drivers/usb/host/ehci-generic.c b/drivers/usb/host/ehci-generic.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/host/ehci-generic.c
++++ b/drivers/usb/host/ehci-generic.c
+@@ -148,9 +148,9 @@ static int ehci_usb_remove(struct udevice *dev)
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = reset_release_bulk(&priv->resets);
+-	if (ret)
+-		return ret;
++	// Assert first and then leave the resets deasserted
++	reset_assert_bulk(&priv->resets);
++	reset_deassert_bulk(&priv->resets);
+ 
+ 	return clk_release_bulk(&priv->clocks);
+ }
+diff --git a/dts/upstream/src/arm64/rockchip/rk3328.dtsi b/dts/upstream/src/arm64/rockchip/rk3328.dtsi
+index 111111111111..222222222222 100644
+--- a/dts/upstream/src/arm64/rockchip/rk3328.dtsi
++++ b/dts/upstream/src/arm64/rockchip/rk3328.dtsi
+@@ -977,6 +977,8 @@
+ 		g-tx-fifo-size = <256 128 128 64 32 16>;
+ 		phys = <&u2phy_otg>;
+ 		phy-names = "usb2-phy";
++		resets = <&cru SRST_USB2OTG>;
++		reset-names = "otg";
+ 		status = "disabled";
+ 	};
+ 
+@@ -987,6 +989,8 @@
+ 		clocks = <&cru HCLK_HOST0>, <&u2phy>;
+ 		phys = <&u2phy_host>;
+ 		phy-names = "usb";
++		resets = <&cru SRST_USB2HOST_EHCIPHY>;
++		reset-names = "ehci";
+ 		status = "disabled";
+ 	};
+ 
+@@ -997,6 +1001,8 @@
+ 		clocks = <&cru HCLK_HOST0>, <&u2phy>;
+ 		phys = <&u2phy_host>;
+ 		phy-names = "usb";
++		resets = <&cru SRST_USB2HOST_EHCIPHY>;
++		reset-names = "ehci";
+ 		status = "disabled";
+ 	};
+ 
+@@ -1010,6 +1016,8 @@
+ 			      "bus_clk";
+ 		dr_mode = "otg";
+ 		phy_type = "utmi_wide";
++		resets = <&cru SRST_USB3OTG>;
++		reset-names = "otg";
+ 		snps,dis-del-phy-power-chg-quirk;
+ 		snps,dis_enblslpm_quirk;
+ 		snps,dis-tx-ipgap-linecheck-quirk;
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk3318-box/rk3328-resets-for-mmc-controllers.patch
+++ b/patch/u-boot/v2025.01/board_rk3318-box/rk3328-resets-for-mmc-controllers.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Fri, 5 Nov 2021 16:03:11 +0000
+Subject: rk3328: resets for mmc controllers
+
+---
+ dts/upstream/src/arm64/rockchip/rk3328.dtsi | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/dts/upstream/src/arm64/rockchip/rk3328.dtsi b/dts/upstream/src/arm64/rockchip/rk3328.dtsi
+index 111111111111..222222222222 100644
+--- a/dts/upstream/src/arm64/rockchip/rk3328.dtsi
++++ b/dts/upstream/src/arm64/rockchip/rk3328.dtsi
+@@ -872,6 +872,8 @@
+ 		clocks = <&cru HCLK_SDMMC>, <&cru SCLK_SDMMC>,
+ 			 <&cru SCLK_SDMMC_DRV>, <&cru SCLK_SDMMC_SAMPLE>;
+ 		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
++		resets = <&cru SRST_MMC0>;
++		reset-names = "reset";
+ 		fifo-depth = <0x100>;
+ 		max-frequency = <150000000>;
+ 		status = "disabled";
+@@ -884,6 +886,8 @@
+ 		clocks = <&cru HCLK_SDIO>, <&cru SCLK_SDIO>,
+ 			 <&cru SCLK_SDIO_DRV>, <&cru SCLK_SDIO_SAMPLE>;
+ 		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
++		resets = <&cru SRST_SDIO>;
++		reset-names = "reset";
+ 		fifo-depth = <0x100>;
+ 		max-frequency = <150000000>;
+ 		status = "disabled";
+@@ -896,8 +900,11 @@
+ 		clocks = <&cru HCLK_EMMC>, <&cru SCLK_EMMC>,
+ 			 <&cru SCLK_EMMC_DRV>, <&cru SCLK_EMMC_SAMPLE>;
+ 		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
++		resets = <&cru SRST_EMMC>;
++		reset-names = "reset";
+ 		fifo-depth = <0x100>;
+ 		max-frequency = <150000000>;
++
+ 		status = "disabled";
+ 	};
+ 
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/board_rk3318-box/rk3328-sdmmc_ext-node.patch
+++ b/patch/u-boot/v2025.01/board_rk3318-box/rk3328-sdmmc_ext-node.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Fri, 5 Nov 2021 16:03:53 +0000
+Subject: rk3328: sdmmc_ext node
+
+---
+ dts/upstream/src/arm64/rockchip/rk3328.dtsi | 14 ++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/dts/upstream/src/arm64/rockchip/rk3328.dtsi b/dts/upstream/src/arm64/rockchip/rk3328.dtsi
+index 111111111111..222222222222 100644
+--- a/dts/upstream/src/arm64/rockchip/rk3328.dtsi
++++ b/dts/upstream/src/arm64/rockchip/rk3328.dtsi
+@@ -908,6 +908,20 @@
+ 		status = "disabled";
+ 	};
+ 
++	sdmmc_ext: mmc@ff5f0000 {
++		compatible = "rockchip,rk3328-dw-mshc", "rockchip,rk3288-dw-mshc";
++		reg = <0x0 0xff5f0000 0x0 0x4000>;
++		interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
++		clocks = <&cru HCLK_SDMMC_EXT>, <&cru SCLK_SDMMC_EXT>,
++			 <&cru SCLK_SDMMC_EXT_DRV>, <&cru SCLK_SDMMC_EXT_SAMPLE>;
++		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
++		fifo-depth = <0x100>;
++		max-frequency = <150000000>;
++		resets = <&cru SRST_SDMMCEXT>;
++		reset-names = "reset";
++		status = "disabled";
++	};
++
+ 	gmac2io: ethernet@ff540000 {
+ 		compatible = "rockchip,rk3328-gmac";
+ 		reg = <0x0 0xff540000 0x0 0x10000>;
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/general-dw-hdmi-disable.patch
+++ b/patch/u-boot/v2025.01/general-dw-hdmi-disable.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 30 Jun 2024 17:36:02 +0200
+Subject: add dw_hdmi_disable() function to DW-HDMI driver
+
+---
+ drivers/video/dw_hdmi.c | 17 ++++++++++
+ include/dw_hdmi.h       |  1 +
+ 2 files changed, 18 insertions(+)
+
+diff --git a/drivers/video/dw_hdmi.c b/drivers/video/dw_hdmi.c
+index 111111111111..222222222222 100644
+--- a/drivers/video/dw_hdmi.c
++++ b/drivers/video/dw_hdmi.c
+@@ -1025,6 +1025,23 @@ int dw_hdmi_enable(struct dw_hdmi *hdmi, const struct display_timing *edid)
+ 	return 0;
+ }
+ 
++int dw_hdmi_disable(struct dw_hdmi *hdmi)
++{
++	uint clkdis;
++
++	/* disable pixel clock and tmds data path */
++	clkdis = 0x7f;
++	hdmi_write(hdmi, clkdis, HDMI_MC_CLKDIS);
++
++	/* disable phy */
++	hdmi_phy_sel_interface_control(hdmi, 0);
++	hdmi_phy_enable_tmds(hdmi, 0);
++	hdmi_phy_enable_power(hdmi, 0);
++
++	return 0;
++
++}
++
+ static const struct dw_hdmi_phy_ops dw_hdmi_synopsys_phy_ops = {
+ 	.phy_set = dw_hdmi_phy_cfg,
+ };
+diff --git a/include/dw_hdmi.h b/include/dw_hdmi.h
+index 111111111111..222222222222 100644
+--- a/include/dw_hdmi.h
++++ b/include/dw_hdmi.h
+@@ -562,6 +562,7 @@ int dw_hdmi_phy_wait_for_hpd(struct dw_hdmi *hdmi);
+ void dw_hdmi_phy_init(struct dw_hdmi *hdmi);
+ 
+ int dw_hdmi_enable(struct dw_hdmi *hdmi, const struct display_timing *edid);
++int dw_hdmi_disable(struct dw_hdmi *hdmi);
+ int dw_hdmi_read_edid(struct dw_hdmi *hdmi, u8 *buf, int buf_size);
+ void dw_hdmi_init(struct dw_hdmi *hdmi);
+ int dw_hdmi_detect_hpd(struct dw_hdmi *hdmi);
+-- 
+Armbian
+

--- a/patch/u-boot/v2025.01/general-dwc-otg-usb-fix.patch
+++ b/patch/u-boot/v2025.01/general-dwc-otg-usb-fix.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Fri, 12 Mar 2021 20:20:12 +0000
+Subject: [ARCHEOLOGY] Changes and fixes to rk322x uboot and kernel config
+
+> X-Git-Archeology: > recovered message: > - Enabled nfc on rk322x-dev and disable on rk322x-current (need further development)
+> X-Git-Archeology: > recovered message: > - Tidied up rk322x-current device tree
+> X-Git-Archeology: > recovered message: > - enabled nfc rockchip driver enabled in rk322x-dev kernel config
+> X-Git-Archeology: > recovered message: > - Enabled EHCI controller in u-boot (added patch for inno-phy, device tree and config bits), better device detection for dwc2 usb otg port
+> X-Git-Archeology: > recovered message: > - Removed SPL_FIT_GENERATOR from u-boot configuration, fixed .its file to use binman
+> X-Git-Archeology: > recovered message: > - fixed rk322x its file (now includes dtb), reverted u-boot to v2020.10 and changed dev_* into log_debug() calls
+> X-Git-Archeology: - Revision 95425c27b9d3bbb96e7936cc531638c9150538f9: https://github.com/armbian/build/commit/95425c27b9d3bbb96e7936cc531638c9150538f9
+> X-Git-Archeology:   Date: Fri, 12 Mar 2021 20:20:12 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Changes and fixes to rk322x uboot and kernel config
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5130cc32fd9b18ecf71d5d26b688859ede0ffe03: https://github.com/armbian/build/commit/5130cc32fd9b18ecf71d5d26b688859ede0ffe03
+> X-Git-Archeology:   Date: Mon, 20 Jun 2022 08:35:13 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: fix u-boot USB OTG patch name
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision d4daf41404853fc13813dc4eb9f6cad76f95945c: https://github.com/armbian/build/commit/d4daf41404853fc13813dc4eb9f6cad76f95945c
+> X-Git-Archeology:   Date: Mon, 20 Jun 2022 08:35:13 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: add sdmmc_ext node, mmc reset properties and otg usb fix to u-boot
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision efee17f217e58a93e795c165e303bfd0a2a0a32a: https://github.com/armbian/build/commit/efee17f217e58a93e795c165e303bfd0a2a0a32a
+> X-Git-Archeology:   Date: Mon, 22 Apr 2024 12:39:09 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: bump rk3318-box uboot to v2024.01
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 7876017d0b77bbfefbb3d112045b32d9b50db928: https://github.com/armbian/build/commit/7876017d0b77bbfefbb3d112045b32d9b50db928
+> X-Git-Archeology:   Date: Tue, 02 Jul 2024 23:31:50 +0000
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Bump rk322x-box and rk3318-box to u-boot v2024.07-rc5 (#6855)
+> X-Git-Archeology:
+---
+ drivers/usb/host/dwc2.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/usb/host/dwc2.c b/drivers/usb/host/dwc2.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/host/dwc2.c
++++ b/drivers/usb/host/dwc2.c
+@@ -441,6 +441,8 @@ static void dwc_otg_core_init(struct udevice *dev)
+ 
+ 	writel(usbcfg, &regs->gusbcfg);
+ 
++	mdelay(10);
++
+ 	/* Program the GAHBCFG Register. */
+ 	switch (readl(&regs->ghwcfg2) & DWC2_HWCFG2_ARCHITECTURE_MASK) {
+ 	case DWC2_HWCFG2_ARCHITECTURE_SLAVE_ONLY:
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

As per subject, bump u-boot for TV Box rk322x-box and rk3318-box target to v2025.01.
More other serious targets within the same perimeter will come soon, these are just the ice breakers.

# How Has This Been Tested?

- [x] Built Debian minimal image for rk322x-box, tested boot from sdcard, emmc and verified expected boot priority (sdcard -> usb -> emmc)
- [x] Built Debian minimal image for rk3318-box, tested boot from sdcard, emmc and verified expected boot priority (sdcard -> usb -> emmc)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
