### PR TITLE
Switch CM3588 to mainline A-TF

### DIFF
--- a/config/boards/cm3588-nas.csc
+++ b/config/boards/cm3588-nas.csc
@@ -9,7 +9,7 @@ FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 IMAGE_PARTITION_TABLE="gpt"
 BOOT_FDT_FILE="rockchip/rk3588-friendlyelec-cm3588-nas.dtb"
-BOOT_SCENARIO="spl-blobs"
+BOOT_SCENARIO="tpl-blob-atf-mainline"
 UEFI_EDK2_BOARD_ID="nanopc-cm3588-nas" # This _only_ used for uefi-edk2-rk3588 extension; cm3588-nas was introduced in v0.12 of edk2-porting/edk2-rk3588
 
 function post_family_tweaks__cm3588_nas_udev_naming_audios() {
@@ -46,7 +46,7 @@ function post_family_config__cm3588_nas_use_mainline_uboot() {
 	declare -g BOOTBRANCH="tag:v2025.01"
 	declare -g BOOTPATCHDIR="v2025.01"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
-	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
+	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # Disable stuff from rockchip64_common; we're using binman here which does all the work
 
 	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go


### PR DESCRIPTION
# Description

Switch the CM3588 to mainline arm-trusted-firmware, which is supported since the latest release, the version bump for this was merged in armbian a while ago.

Everything works, and this is required for the future HDMI-RX patches on lkml.

I think every RK3588 based boards should be switched, but I can't test that.



# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ x] Actual Board boots and everything seems to be working
- [ x] The UART boot output shows that the change was applied

# Checklist:


- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
