### PR TITLE
Update README.md - remove obsolete job opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ We always need those volunteering positions:
 
 - [Code reviewer](https://forum.armbian.com/staffapplications/application/23-code-reviewer/)
 - [Build framework maintainer](https://forum.armbian.com/staffapplications/application/9-build-framework-maintainer/)
-- [Test Automation Engineer](https://forum.armbian.com/staffapplications/application/19-test-automation-engineer/)
 
 Just apply and follow!
 


### PR DESCRIPTION
the position for test automation engineer is no longer vacant, the referenced page is 404.  Update the README.md accordingly.
