### PR TITLE
Multiple sources fix: after changing to deb822 we forgot on leftovers

### DIFF
--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -132,4 +132,4 @@ function extract_rootfs_artifact() {
 }
 
 # This comment strategically introduced to force a rebuild of all rootfs, as this file's contents are hashed into all rootfs versions.
-# Just a number to force rebuild 003
+# Just a number to force rebuild 004

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -80,6 +80,9 @@ function create_sources_list_and_deploy_repo_key() {
 
 	declare distro=""
 
+	# Drop deboostrap sources leftovers
+	rm -f "${basedir}/etc/apt/sources.list"
+
 	# Add upstream (Debian/Ubuntu) APT repository
 	case $release in
 		buster | bullseye | bookworm | trixie)

--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -177,7 +177,7 @@ function create_new_rootfs_cache_via_debootstrap() {
 	# @TODO: use asset logging for this; actually log contents of the files too
 	run_host_command_logged ls -l "${SDCARD}/usr/share/keyrings"
 	run_host_command_logged ls -l "${SDCARD}/etc/apt/sources.list.d"
-	run_host_command_logged cat "${SDCARD}/etc/apt/sources.list"
+	run_host_command_logged cat "${SDCARD}/etc/apt/sources.list.d/${DISTRIBUTION,,}.sources"
 
 	# stage: update packages list
 	display_alert "Updating package list" "$RELEASE" "info"


### PR DESCRIPTION
# Description

- deboostrap still uses old ways and we need to remove this file
- when displaying the content of sources, we need to look correct file

# How Has This Been Tested?

- [x] Generate image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
