### PR TITLE
Stop altering global git config file and set safe per cloned repository

### DIFF
--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -57,7 +57,7 @@ function git_ensure_safe_directory() {
 		local git_dir="$1"
 		if [[ -e "$1/.git" ]]; then
 			display_alert "git: Marking all directories as safe, which should include" "$git_dir" "debug"
-			git config --global --get safe.directory "$1" > /dev/null || regular_git config --global --add safe.directory "$1"
+			git config --local --get safe.directory "$1" > /dev/null || regular_git config --local --add safe.directory "$1"
 		fi
 	else
 		display_alert "git not installed" "a true wonder how you got this far without git - it will be installed for you" "warn"


### PR DESCRIPTION
# Description

Replace ugly workaround with a proper solution. Now safe folder is added to each cloned repository. 

Closing https://github.com/armbian/build/issues/7907 [AR-2624]

# How Has This Been Tested?

- [x] Run compilation with and without Docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2624]: https://armbian.atlassian.net/browse/AR-2624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ