### PR TITLE
Fix IPv4 and IPv6 output in Armbian welcome MOTD

### DIFF
--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -7,6 +7,7 @@
 MOTD_DISABLE="clear"
 ONE_WIRE=""
 HIDE_IP_PATTERN="^dummy0|^lo|^docker|^hassio|^br-|^veth|^vnet|^virbr"
+HIDE_LOCAL_IPV6="true"
 PRIMARY_INTERFACE="$(ip route | grep '^default' | sed "s/.*dev //" | cut -d" " -f1)"
 PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1

--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -108,6 +108,7 @@ KERNELID=$(uname -r)
 ip_address=$(get_ip_addresses &)
 wan_ip_address=$(get_wan_address &)
 wan_ip6_address=$(get_wan6_address &)
+
 # Get access point info
 if systemctl is-active --quiet service hostapd && [[ -f /etc/hostapd/hostapd.conf ]]; then
 	. /etc/hostapd/hostapd.conf
@@ -185,19 +186,31 @@ fi
 
 # Display IP addresses
 IFS='|' read -r ipv4s ipv6s <<< "${ip_address}"
-if [[ -n ${ipv4s} ]]; then
-	all_ip_address=" IPv4 addresses: "
-	all_ip_address+="\x1B[93m(LAN)\x1B[0m \x1B[92m${ipv4s// /, }\x1B[0m "
+# remove WAN IPv4 from the list of all IPv4
+if [[ "${ipv4s}" == *${wan_ip_address}* ]]; then
+        ipv4s=$(echo $ipv4s | sed "s/"${wan_ip_address}"//g" | xargs )
+fi
+if [[ -n ${ipv4s} || -n ${wan_ip_address} ]]; then
+	all_ip_address=" IPv4:        "
+	if [[ -n ${ipv4s} ]]; then
+		all_ip_address+=" \x1B[93m(LAN)\x1B[0m "
+	fi
+	all_ip_address+="\x1B[92m${ipv4s// /, }\x1B[0m "
 	if [[ -n ${wan_ip_address} ]]; then
 		all_ip_address+="\x1B[93m(WAN)\x1B[0m \x1B[95m${wan_ip_address}\x1B[0m "
 	fi
 	echo -e "${all_ip_address}"
 fi
+# remove WAN IPv6 from the list of all IPv6
+if [[ -n "${wan_ip6_address}" && "${ipv6s}" == *${wan_ip6_address}* ]]; then
+	ipv6s=$(echo $ipv6s | sed "s/"${wan_ip6_address}"//g" | xargs )
+fi
+
 if [[ -n ${ipv6s} ]]; then
-	all_ip6_address=" IPv6 addresses: "
-	all_ip6_address+="\x1B[93m(All)\x1B[0m \x1B[96m${ipv6s// /, }\x1B[0m "
+	all_ip6_address=" IPv6:         "
+	all_ip6_address+="\x1B[96m${ipv6s// /, }\x1B[0m "
 	if [[ -n ${wan_ip6_address} ]]; then
-		all_ip6_address+="\x1B[93m(Outgoing WAN)\x1B[0m \x1B[95m${wan_ip6_address}\x1B[0m "
+		all_ip6_address+="\x1B[93m(WAN)\x1B[0m \x1B[95m${wan_ip6_address}\x1B[0m "
 	fi
 	echo -e "${all_ip6_address}"
 fi

--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -24,58 +24,81 @@ VENDORTEMP="${VENDOR}"
 [[ -n "${VENDORTEMP}" && "${VENDORTEMP}" != "${VENDOR}" ]] && VENDOR="${VENDORTEMP}"
 
 # If VENDORPRETTYNAME is defined, used that
-[[ -n $VENDORPRETTYNAME ]] && VENDOR="$VENDORPRETTYNAME"
+[[ -n ${VENDORPRETTYNAME} ]] && VENDOR="${VENDORPRETTYNAME}"
 
 if [[ -f /etc/armbian-distribution-status ]]; then
 	. /etc/armbian-distribution-status
 	# Find a way that works
 	[[ -f /etc/lsb-release ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2)
 	[[ -f /etc/lsb-release ]] && DISTRIBUTION_ID=$(grep DISTRIB_ID /etc/lsb-release | cut -d"=" -f2)
-	[[ -z "$DISTRIBUTION_CODENAME" && -f /etc/os-release ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2)
-	[[ -z "$DISTRIBUTION_ID" && -f /etc/os-release ]] && DISTRIBUTION_ID=$(grep "^ID" /etc/os-release | cut -d"=" -f2)
-	[[ -z "$DISTRIBUTION_CODENAME" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_CODENAME=$(/usr/bin/lsb_release -c | cut -d":" -f2 | tr -d "\t")
-	[[ -z "$DISTRIBUTION_ID" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_ID=$(/usr/bin/lsb_release -i | cut -d":" -f2 | tr -d "\t")
+	[[ -z "${DISTRIBUTION_CODENAME}" && -f /etc/os-release ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2)
+	[[ -z "${DISTRIBUTION_ID}" && -f /etc/os-release ]] && DISTRIBUTION_ID=$(grep "^ID" /etc/os-release | cut -d"=" -f2)
+	[[ -z "${DISTRIBUTION_CODENAME}" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_CODENAME=$(/usr/bin/lsb_release -c | cut -d":" -f2 | tr -d "\t")
+	[[ -z "${DISTRIBUTION_ID}" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_ID=$(/usr/bin/lsb_release -i | cut -d":" -f2 | tr -d "\t")
 	# Read Armbian distribution status
 	DISTRIBUTION_STATUS=$(grep "^${DISTRIBUTION_CODENAME}" /etc/armbian-distribution-status | cut -d"=" -f2 | cut -d";" -f1)
 
 	# Read upgrade possibilities on stable channel
 	filter=$(grep "supported" /etc/armbian-distribution-status | cut -d"=" -f1)
-	upgrade=$(for j in $filter; do
+	upgrade=$(for j in ${filter}; do
 		for i in $(grep "^${DISTRIBUTION_CODENAME}" /etc/armbian-distribution-status | cut -d";" -f2 | cut -d"=" -f2 | sed "s/,/ /g"); do
-			if [[ $i == $j ]]; then
-				echo $i
+			if [[ "${i}" == "${j}" ]]; then
+				echo "${i}"
 			fi
 		done
 	done | tail -1)
-
 fi
-[[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd
 
-for f in $MOTD_DISABLE; do
-	[[ $f == $THIS_SCRIPT ]] && exit 0
+[[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd
+for f in ${MOTD_DISABLE}; do
+	[[ "${f}" == "${THIS_SCRIPT}" ]] && exit 0
 done
 
 function get_wan_address() {
-	curl --max-time 2 -s http://whatismyip.akamai.com/
+	curl -4 --max-time 2 -s https://ipv4.whatismyip.akamai.com/
 } # get wan ip address
+
+function get_wan6_address() {
+	curl -6 --max-time 2 -s https://ipv6.whatismyip.akamai.com/
+} # get wan ip6 address
 
 function get_ip_addresses() {
 	local ipv4s=()
+	local ipv4
+	local address4
 	local ipv6s=()
+	local ipv6
+	local address6
+	local intf
+	local f
 
 	for f in /sys/class/net/*; do
-		local intf=$(basename $f)
+		intf=$(basename "${f}")
 		# match only interface names
-		if [[ $intf =~ $HIDE_IP_PATTERN ]]; then
+		if [[ ${intf} =~ ${HIDE_IP_PATTERN} ]]; then
 			continue
 		else
-			local ipv4=$(ip -4 addr show dev $intf | grep -v "$intf:avahi" | awk '/inet/ {print $2}' | cut -d'/' -f1 | uniq)
-			local ipv6=$(ip -6 addr show dev $intf | grep -v "$intf:avahi" | awk '/inet6/ {print $2}' | cut -d'/' -f1 | uniq)
+			# List all IP addresses without reordering or duplicates
+			ipv4=$(ip -4 addr show dev "${intf}")
+			ipv4=$(echo "${ipv4}" | grep -v "${intf}:avahi")
+			ipv4=$(echo "${ipv4}" | awk '/inet/ {print $2}')
+			ipv4=$(echo "${ipv4}" | cut -d'/' -f1)
+			ipv4=$(echo "${ipv4}" | awk '!x[$0]++')
+			ipv6=$(ip -6 addr show dev "${intf}")
+			ipv6=$(echo "${ipv6}" | grep -v "${intf}:avahi")
+			ipv6=$(echo "${ipv6}" | awk '/inet6/ {print $2}')
+			ipv6=$(echo "${ipv6}" | cut -d'/' -f1)
+			ipv6=$(echo "${ipv6}" | awk '!x[$0]++')
 
-			[[ -n $ipv4 ]] && ipv4s+=("$ipv4")
-			[[ -n $ipv6 ]] && ipv6s+=("$ipv6")
+			for address4 in ${ipv4}; do
+				ipv4s+=("${address4}")
+			done
+			for address6 in ${ipv6}; do
+				ipv6s+=("${address6}")
+			done
 		fi
 	done
+
 	echo "${ipv4s[*]}|${ipv6s[*]}"
 } # get_ip_addresses
 
@@ -84,100 +107,109 @@ KERNELID=$(uname -r)
 # Get other variables
 ip_address=$(get_ip_addresses &)
 wan_ip_address=$(get_wan_address &)
+wan_ip6_address=$(get_wan6_address &)
 # Get access point info
-if systemctl is-active --quiet service hostapd && [ -f /etc/hostapd/hostapd.conf ]; then
-. /etc/hostapd/hostapd.conf
+if systemctl is-active --quiet service hostapd && [[ -f /etc/hostapd/hostapd.conf ]]; then
+	. /etc/hostapd/hostapd.conf
 fi
 
 # Display software vendor logo
-echo -e "\e[1;91m$(figlet -f small " $VENDOR")\e[0m";
+echo -e "\e[1;91m$(figlet -f small " ${VENDOR}")\e[0m"
 
 # Read RPI model from cpuinfo
-if [[ $BOARD == rpi4b ]]; then
-BOARD_NAME=$(cat /proc/device-tree/model | tr '\0' '\n' | sed -E 's/ Rev [0-9.]+$//')
+if [[ ${BOARD:-} == rpi4b ]]; then
+	BOARD_NAME=$(tr '\0' '\n' < /proc/device-tree/model | sed -E 's/ Rev [0-9.]+$//')
 fi
 
 # Display version, board, and kernel version
-[[ $VERSION == *trunk* ]] && VERSION=$(echo -e $VERSION | cut -d"." -f1-2 | sed "s/\$/ rolling/")
-echo -e " \e[0;92mv${VERSION}\x1B[0m for $BOARD_NAME running Armbian Linux \e[0;92m${KERNELID^}\x1B[0m"
+[[ ${VERSION} == *trunk* ]] && VERSION=$(echo -e ${VERSION} | cut -d"." -f1-2 | sed "s/\$/ rolling/")
+echo -e " \e[0;92mv${VERSION}\x1B[0m for ${BOARD_NAME} running Armbian Linux \e[0;92m${KERNELID^}\x1B[0m"
 
 # render image and board type
-if [[ "$IMAGE_TYPE" != "stable" ]]; then
-	[[ "$IMAGE_TYPE" == "user-built" ]] && HARDWARE_STATUS="\e[0;91mDIY\x1B[0m (custom image)\x1B[0m"
-	[[ "$IMAGE_TYPE" == "nightly" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (rolling release)\x1B[0m"
+if [[ "${IMAGE_TYPE:-}" != "stable" ]]; then
+	[[ "${IMAGE_TYPE}" == "user-built" ]] && HARDWARE_STATUS="\e[0;91mDIY\x1B[0m (custom image)\x1B[0m"
+	[[ "${IMAGE_TYPE}" == "nightly" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (rolling release)\x1B[0m"
 else
-	[[ "$BOARD_TYPE" == "csc" || "$BOARD_TYPE" == "tvb" ]] && HARDWARE_STATUS="\e[0;91mDIY (community maintained)\x1B[0m"
-	[[ "$BOARD_TYPE" == "wip" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (work in progress)\x1B[0m"
-	[[ "$BOARD_TYPE" == "eos" ]] && HARDWARE_STATUS="\e[0;91mend of life\x1B[0m"
+	[[ "${BOARD_TYPE:-}" == "csc" || "${BOARD_TYPE}" == "tvb" ]] && HARDWARE_STATUS="\e[0;91mDIY (community maintained)\x1B[0m"
+	[[ "${BOARD_TYPE}" == "wip" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (work in progress)\x1B[0m"
+	[[ "${BOARD_TYPE}" == "eos" ]] && HARDWARE_STATUS="\e[0;91mend of life\x1B[0m"
 fi
 
 # render distribution status
-if [[ $DISTRIBUTION_STATUS == supported ]]; then
-	DISTRO_STATUS="\e[0;92mstable\e[0m ($DISTRIBUTION_CODENAME)"
-elif [[ $DISTRIBUTION_STATUS == eos ]]; then
-	DISTRO_STATUS="\e[0;91mend of life\e[0m ($DISTRIBUTION_CODENAME)"
+if [[ ${DISTRIBUTION_STATUS} == supported ]]; then
+	DISTRO_STATUS="\e[0;92mstable\e[0m (${DISTRIBUTION_CODENAME})"
+elif [[ ${DISTRIBUTION_STATUS} == eos ]]; then
+	DISTRO_STATUS="\e[0;91mend of life\e[0m (${DISTRIBUTION_CODENAME})"
 else
-	DISTRO_STATUS="\e[0;93mrolling\e[0m ($DISTRIBUTION_CODENAME)"
+	DISTRO_STATUS="\e[0;93mrolling\e[0m (${DISTRIBUTION_CODENAME})"
 fi
 
-
 # read packages update status
-NUM_UPDATES=0
-NUM_UPDATES_ONHOLD=0
-NUM_SECURITY_UPDATES=0
 [[ -f /var/cache/apt/archives/updates.number ]] && . /var/cache/apt/archives/updates.number
-if [[ $NUM_UPDATES -gt 0 ]]; then
-	if apt-mark showhold | grep -q linux-image 2>/dev/null; then
+if [[ ${NUM_UPDATES:-} -gt 0 ]]; then
+	if apt-mark showhold | grep -q linux-image 2> /dev/null; then
 		UPDATE_STATUS="Kernel upgrade \e[0;91mdisabled\e[0m"
-		else
+	else
 		UPDATE_STATUS="Kernel upgrade \e[0;92menabled\e[0m"
 	fi
-	UPDATE_STATUS+=" and \e[1;92m$NUM_UPDATES\e[0m package"
+	UPDATE_STATUS+=" and \e[1;92m${NUM_UPDATES}\e[0m package"
 	# Cosmetic is important
-	[[ $NUM_UPDATES -gt 1 ]] && UPDATE_STATUS+="s"
+	[[ ${NUM_UPDATES} -gt 1 ]] && UPDATE_STATUS+="s"
 	UPDATE_STATUS+=" available for upgrade\e[0m "
 fi
 
 # read running Docker containers if any
-if systemctl is-active docker >/dev/null; then
+if systemctl is-active docker > /dev/null; then
 	CONTAINERS_STATUS=$(docker ps --format "{{.Names}}" | tr '\n' ',' | sed 's/,/, /g' | sed 's/, $//')
 fi
 
 echo ""
 
 # Display packages status
-if [[ -n $DISTRO_STATUS ]]; then
+if [[ -n ${DISTRO_STATUS} ]]; then
 	if [[ -n "${upgrade}" ]]; then
-		DISTRO_STATUS+=", possible distro upgrade ($upgrade)"
+		DISTRO_STATUS+=", possible distro upgrade (${upgrade})"
 	fi
 	echo -e " Packages:     ${DISTRIBUTION_ID^} ${DISTRO_STATUS}"
 fi
 
 # Display available updates
-if [[ -n $UPDATE_STATUS ]]; then
-        echo -e " Updates:      $UPDATE_STATUS"
+if [[ -n ${UPDATE_STATUS} ]]; then
+	echo -e " Updates:      ${UPDATE_STATUS}"
 fi
 
 # Display hardware support status
-if [[ -n $HARDWARE_STATUS ]]; then
-        echo -e " Support:      $HARDWARE_STATUS"
+if [[ -n ${HARDWARE_STATUS} ]]; then
+	echo -e " Support:      ${HARDWARE_STATUS}"
 fi
 
-IFS='|' read -r ipv4s ipv6s <<< "$ip_address"
-echo -en " IP addresses: \x1B[93m(LAN)\x1B[0m IPv4: \x1B[92m${ipv4s// /, }\x1B[0m IPv6: \x1B[96m${ipv6s// /, }\x1B[0m "
-if [[ -n $wan_ip_address ]]; then
-echo -e "\x1B[93m(WAN)\x1B[0m $wan_ip_address"
+# Display IP addresses
+IFS='|' read -r ipv4s ipv6s <<< "${ip_address}"
+if [[ -n ${ipv4s} ]]; then
+	all_ip_address=" IPv4 addresses: "
+	all_ip_address+="\x1B[93m(LAN)\x1B[0m \x1B[92m${ipv4s// /, }\x1B[0m "
+	if [[ -n ${wan_ip_address} ]]; then
+		all_ip_address+="\x1B[93m(WAN)\x1B[0m \x1B[95m${wan_ip_address}\x1B[0m "
+	fi
+	echo -e "${all_ip_address}"
+fi
+if [[ -n ${ipv6s} ]]; then
+	all_ip6_address=" IPv6 addresses: "
+	all_ip6_address+="\x1B[93m(All)\x1B[0m \x1B[96m${ipv6s// /, }\x1B[0m "
+	if [[ -n ${wan_ip6_address} ]]; then
+		all_ip6_address+="\x1B[93m(Outgoing WAN)\x1B[0m \x1B[95m${wan_ip6_address}\x1B[0m "
+	fi
+	echo -e "${all_ip6_address}"
 fi
 
 # Display running docker containers
 if [[ -n "${CONTAINERS_STATUS}" ]]; then
-        echo -e " Containers:   \x1B[92m$CONTAINERS_STATUS\x1B[0m"
+	echo -e " Containers:   \x1B[92m${CONTAINERS_STATUS}\x1B[0m"
 fi
 
 # Display hostapd
-if [[ -n $ssid ]]; then
-        echo -e " WiFi AP:      SSID: (\x1B[91m$ssid\x1B[0m), $(iw $interface info | grep channel | xargs)"
+if [[ -n ${ssid} ]]; then
+	echo -e " WiFi AP:      SSID: (\x1B[91m${ssid}\x1B[0m), $(iw dev "${interface:-}" info | grep channel | xargs)"
 fi
-
 
 echo ""

--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -12,6 +12,7 @@
 THIS_SCRIPT="header"
 MOTD_DISABLE=""
 HIDE_IP_PATTERN="^dummy0|^lo|^docker|^hassio|^br-|^veth|^vnet|^virbr"
+HIDE_LOCAL_IPV6="true"
 
 # Read image configuration
 [[ -f /etc/armbian-image-release ]] && . /etc/armbian-image-release
@@ -85,6 +86,9 @@ function get_ip_addresses() {
 			ipv4=$(echo "${ipv4}" | cut -d'/' -f1)
 			ipv4=$(echo "${ipv4}" | awk '!x[$0]++')
 			ipv6=$(ip -6 addr show dev "${intf}")
+			if [[ "${HIDE_LOCAL_IPV6}" == true ]]; then
+				ipv6=$(ip -6 addr show dev "${intf}" | grep -v fe80)
+			fi
 			ipv6=$(echo "${ipv6}" | grep -v "${intf}:avahi")
 			ipv6=$(echo "${ipv6}" | awk '/inet6/ {print $2}')
 			ipv6=$(echo "${ipv6}" | cut -d'/' -f1)
@@ -206,9 +210,11 @@ if [[ -n "${wan_ip6_address}" && "${ipv6s}" == *${wan_ip6_address}* ]]; then
 	ipv6s=$(echo $ipv6s | sed "s/"${wan_ip6_address}"//g" | xargs )
 fi
 
-if [[ -n ${ipv6s} ]]; then
+if [[ -n ${ipv6s} || -n ${wan_ip6_address} ]]; then
 	all_ip6_address=" IPv6:         "
-	all_ip6_address+="\x1B[96m${ipv6s// /, }\x1B[0m "
+	if [[ -n ${ipv6s} ]]; then
+		all_ip6_address+="\x1B[96m${ipv6s// /, }\x1B[0m "
+	fi
 	if [[ -n ${wan_ip6_address} ]]; then
 		all_ip6_address+="\x1B[93m(WAN)\x1B[0m \x1B[95m${wan_ip6_address}\x1B[0m "
 	fi


### PR DESCRIPTION
# Description

Now "Armbian welcome MOTD" only prints one LAN IPv4 address and does not print any IPv6 address if you have more than one.

I changed to print all IPv4 and IPv6 addresses. I also made some cosmetic changes (based on .editorconfig from this repository).

Added by @igorpecovnik
- sort out duplicate addresses. When LAN and WAN is the same, only show WAN.
- add variable to hide all local IPV6 addresses. This is handy if have large number of containers and we probably don't want to see them all.
- cosmetic changes / column alignment

# How Has This Been Tested?

- [x] On dev machine.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
