### PR TITLE
Enable wait-online.service in first-login config

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -706,6 +706,21 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 			fi
 		fi
 
+		# enable networkManager-wait-online.service
+		# When NM is used the NetworkManager-wait-online.service must be enabled so that network-online.target is not reached until
+		# NetworkManager has brought up all the interfaces. Service units that require the network to be up before starting rely
+		# on network-online.target working correctly otherwise they will likely fail on boot
+		# Same goes for systemd-networkd stack
+		# https://github.com/armbian/build/issues/7896
+		if systemctl is-active --quiet NetworkManager; then
+			systemctl enable NetworkManager-wait-online.service
+			systemctl start NetworkManager-wait-online.service
+		fi
+		if systemctl is-active --quiet systemd-networkd; then
+			systemctl enable systemd-networkd-wait-online.service
+			systemctl start systemd-networkd-wait-online.service
+		fi
+
 		# only allow one login. Once you enter root password, kill others.
 		loginfrom=$(who am i | awk '{print $2}')
 		who -la | grep root | grep -v "$loginfrom" | awk '{print $7}' | xargs --no-run-if-empty kill -9


### PR DESCRIPTION
# Description

Reasoning in the code and closing https://github.com/armbian/build/issues/7896

# How Has This Been Tested?

- [x] Network manager Noble image
- [x] Bookworm systemd-networkd minimal image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
