### PR TITLE
Armbian-install: disable Docker when installing images

### DIFF
--- a/packages/bsp/common/usr/bin/armbian-install
+++ b/packages/bsp/common/usr/bin/armbian-install
@@ -20,7 +20,7 @@
 #   $4 = :space: separated list of all MTD device names
 #        Note: MTD char device names are passed in format device_name:partition_label - e.g.: mtd0:SPL
 
-trap "exit" INT TERM
+trap "systemctl start docker >/dev/null 2>&1; exit" INT TERM
 [[ $EUID != 0 ]] && exec sudo "$0" "$@"
 
 [[ -f /usr/lib/u-boot/platform_install.sh ]] && source /usr/lib/u-boot/platform_install.sh
@@ -125,6 +125,9 @@ create_armbian()
 	# sata root part
 	# UUID=xxx...
 	satauuid=$(blkid -o export "$2" | grep -w UUID)
+
+	# disable docker before start
+	systemctl is-active --quiet docker && systemctl stop docker
 
 	# write information to log
 	echo -e "\nOld UUID:  ${root_uuid}" >> $logfile


### PR DESCRIPTION
# Description

Stop Docker system running Armbina-install to prevent weird results and to speed up. Does it make sense?

# How Has This Been Tested?

- [x] Manual test, disabling and installing to eMMC, reboot, works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
