### PR TITLE
Add initial support for BeaglePlay

### DIFF
--- a/config/boards/beagleplay.conf
+++ b/config/boards/beagleplay.conf
@@ -1,0 +1,17 @@
+# TI AM62 quad core 2GB DDR4 16GB eMMC 1xGBE 1xSPE HDMI
+
+BOARD_NAME="BeaglePlay"
+BOARDFAMILY="k3"
+BOARD_MAINTAINER="grippy98"
+BOOTCONFIG="am62x_beagleplay_a53_defconfig"
+BOOTFS_TYPE="fat"
+BOOT_FDT_FILE="ti/k3-am625-beagleplay.dts"
+TIBOOT3_BOOTCONFIG="am62x_beagleplay_r5_defconfig"
+TIBOOT3_FILE="tiboot3-am62x-gp-evm.bin"
+TISPL_FILE="tispl.bin_unsigned"
+UBOOT_FILE="u-boot.img_unsigned"
+DEFAULT_CONSOLE="serial"
+KERNEL_TARGET="current,edge"
+KERNEL_TEST_TARGET="current"
+SERIALCON="ttyS2"
+ATF_BOARD="lite"


### PR DESCRIPTION
Howdy all,

This PR adds support for the Texas Instruments AM62 based BeaglePlay SbC. Features,
schematics, and purchase links can be found on the board page[0].

Note - GP Silicon on BeaglePlay, one of the last on AM62. 

Notable features:

4x 64-bit Arm-Cortex A53 microprocessor
M4 MCU Core
2GB DDR4
16GB eMMC onboard
CC1352 2.4/SubG Radio on board - makes for a great Zigbee coordinator
MikroE Click Board Compatible + Qwiic + Grove

Thanks!

[0] https://www.beagleboard.org/boards/beagleplay

How Has This Been Tested?

* Build/Boot tested Trixie CLI/Minimal on Current(v6.6) and Edge(v6.12) kernels
* Build/Boot tested Noble CLI/Minimal on Current(v6.6) and Edge(v6.12) kernels
* Gbit Ethernet works
* HDMI works
* USB 2.0 port work

Checklist:

*  My code follows the style guidelines of this project
*  I have performed a self-review of my own code
*  My changes generate no new warnings
 * Any dependent changes have been merged and published in downstream modules