### PR TITLE
Add initial support for BeagleBone AI-64

### DIFF
--- a/config/boards/beaglebone-ai64.conf
+++ b/config/boards/beaglebone-ai64.conf
@@ -1,0 +1,18 @@
+# BeagleBone® AI-64 dual core 4GB GBE USB3 OSPI DisplayPort HDMI
+
+BOARD_NAME="BeagleBone AI-64"
+BOARDFAMILY="k3"
+BOARD_MAINTAINER="grippy98"
+BOOTCONFIG="j721e_beagleboneai64_a72_defconfig"
+BOOTFS_TYPE="fat"
+BOOT_FDT_FILE="ti/k3-j721e-beagleboneai64.dts"
+TIBOOT3_BOOTCONFIG="j721e_beagleboneai64_r5_defconfig"
+TIBOOT3_FILE="tiboot3-j721e-gp-evm.bin"
+SYSFW_FILE="sysfw-j721e-gp-evm.itb"
+TISPL_FILE="tispl.bin_unsigned"
+UBOOT_FILE="u-boot.img_unsigned"
+DEFAULT_CONSOLE="serial"
+KERNEL_TARGET="current,edge"
+KERNEL_TEST_TARGET="current"
+SERIALCON="ttyS2"
+ATF_BOARD="generic"


### PR DESCRIPTION
Howdy all last one this week,

This PR adds support for the Texas Instruments TDA4VM based BeagleBone AI-64 SbC. Features,
schematics, and purchase links can be found on the board page[0].

Notable features:

2x 64-bit Arm-Cortex A72 microprocessor
Six Arm Cortex-R5F MCUs and C7x DSP Cores up to 8TOPS
Programmable Real Time Unit (PRU) Cores
4GB LDDR4
16GB eMMC onboard
BeagleBone Black Cape Compatible

Thanks!

[0] https://www.beagleboard.org/boards/beaglebone-ai-64

How Has This Been Tested?

Build/Boot tested Trixie CLI/Minimal on Current(v6.6) and Edge(v6.12) kernels
Build/Boot tested Noble CLI/Minimal on Current(v6.6) and Edge(v6.12) kernels
Gbit Ethernet works
HDMI works
USB 3.0 port work
Checklist:

My code follows the style guidelines of this project
I have performed a self-review of my own code
My changes generate no new warnings
Any dependent changes have been merged and published in downstream modules