### PR TITLE
Rock5 mainline hs400 mode fix

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/rk3588-1010-arm64-dts-rock-5b-Slow-down-emmc-to-hs200-and-add-ts.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk3588-1010-arm64-dts-rock-5b-Slow-down-emmc-to-hs200-and-add-ts.patch
@@ -1,27 +1,25 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: amazingfate <liujianfeng1994@gmail.com>
 Date: Wed, 27 Dec 2023 15:03:57 +0800
-Subject: arm64: dts: rock-5b: Slow down emmc to hs200 and add tsadc node
+Subject: arm64: dts: rock-5b: Slow down emmc freq and add tsadc node
 
 ---
- arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 7 +++++--
- 1 file changed, 5 insertions(+), 2 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
-@@ -408,8 +408,7 @@ &sdhci {
+@@ -408,6 +408,7 @@ &sdhci {
  	no-sdio;
  	no-sd;
  	non-removable;
--	mmc-hs400-1_8v;
--	mmc-hs400-enhanced-strobe;
-+	mmc-hs200-1_8v;
++	max-frequency = <150000000>;
+ 	mmc-hs400-1_8v;
+ 	mmc-hs400-enhanced-strobe;
  	status = "okay";
- };
- 
-@@ -463,6 +462,10 @@ flash@0 {
+@@ -463,6 +464,10 @@ flash@0 {
  	};
  };
  

--- a/patch/kernel/archive/rockchip64-6.12/rk3588-1013-arm64-dts-rockchip-disable-emmc-hs400-for-rock-5-itx.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk3588-1013-arm64-dts-rockchip-disable-emmc-hs400-for-rock-5-itx.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jianfeng Liu <liujianfeng1994@gmail.com>
+Date: Fri, 28 Feb 2025 22:04:34 +0800
+Subject: arm64: dts: rockchip: slow down emmc freq for rock 5 itx
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+@@ -656,10 +656,9 @@ &saradc {
+ 
+ &sdhci {
+ 	bus-width = <8>;
+-	max-frequency = <200000000>;
++	max-frequency = <150000000>;
+ 	mmc-hs400-1_8v;
+ 	mmc-hs400-enhanced-strobe;
+-	mmc-hs200-1_8v;
+ 	no-sdio;
+ 	no-sd;
+ 	non-removable;
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-1010-arm64-dts-rock-5b-Slow-down-emmc-to-hs200-and-add-ts.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-1010-arm64-dts-rock-5b-Slow-down-emmc-to-hs200-and-add-ts.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: amazingfate <liujianfeng1994@gmail.com>
 Date: Wed, 27 Dec 2023 15:03:57 +0800
-Subject: arm64: dts: rock-5b: Slow down emmc to hs200 and add tsadc node
+Subject: arm64: dts: rock-5b: Slow down emmc freq and add tsadc node
 
 ---
  arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 7 +++++--
@@ -11,16 +11,14 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/d
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
-@@ -440,8 +440,7 @@ &sdhci {
+@@ -440,6 +440,7 @@ &sdhci {
  	no-sdio;
  	no-sd;
  	non-removable;
--	mmc-hs400-1_8v;
--	mmc-hs400-enhanced-strobe;
-+	mmc-hs200-1_8v;
++	max-frequency = <150000000>;
+ 	mmc-hs400-1_8v;
+ 	mmc-hs400-enhanced-strobe;
  	status = "okay";
- };
- 
 @@ -495,6 +494,10 @@ flash@0 {
  	};
  };

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-1013-arm64-dts-rockchip-disable-emmc-hs400-for-rock-5-itx.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-1013-arm64-dts-rockchip-disable-emmc-hs400-for-rock-5-itx.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jianfeng Liu <liujianfeng1994@gmail.com>
+Date: Fri, 28 Feb 2025 22:04:34 +0800
+Subject: arm64: dts: rockchip: slow down emmc freq for rock 5 itx
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+@@ -656,10 +656,9 @@ &saradc {
+ 
+ &sdhci {
+ 	bus-width = <8>;
+-	max-frequency = <200000000>;
++	max-frequency = <150000000>;
+ 	mmc-hs400-1_8v;
+ 	mmc-hs400-enhanced-strobe;
+-	mmc-hs200-1_8v;
+ 	no-sdio;
+ 	no-sd;
+ 	non-removable;
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Rock5b is using HS200 mode on mainline kernel for emmc because of stable issues. While slowing down the freq from 200000000 to 150000000 can also make HS400 stable.
Also slow down the emmc freq so that it is usable with mainline kernel.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel-dtb BOARD=rock-5b BRANCH=edge DEB_COMPRESS=xz`
- [x] ``./compile.sh kernel-dtb BOARD=rock-5b BRANCH=current DEB_COMPRESS=xz``

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
