### PR TITLE
rockchip64-6.14: Set dma mask to 64 bit

### DIFF
--- a/patch/kernel/archive/rockchip64-6.14/general-drm-rockchip-Set-dma-mask-to-64-bit.patch
+++ b/patch/kernel/archive/rockchip64-6.14/general-drm-rockchip-Set-dma-mask-to-64-bit.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Fri, 7 Mar 2025 15:06:42 +0000
+Subject: drm/rockchip: Set dma mask to 64 bit
+
+The vop mmu support translate physical address upper 4 GB to iova
+below 4 GB. So set dma mask to 64 bit to indicate we support address
+> 4GB.
+
+This can avoid warnging message like this on some boards with DDR
+> 4 GB:
+
+rockchip-drm display-subsystem: swiotlb buffer is full (sz: 266240 bytes), total 32768 (slots), used 130 (slots)
+rockchip-drm display-subsystem: swiotlb buffer is full (sz: 266240 bytes), total 32768 (slots), used 0 (slots)
+rockchip-drm display-subsystem: swiotlb buffer is full (sz: 266240 bytes), total 32768 (slots), used 130 (slots)
+rockchip-drm display-subsystem: swiotlb buffer is full (sz: 266240 bytes), total 32768 (slots), used 130 (slots)
+rockchip-drm display-subsystem: swiotlb buffer is full (sz: 266240 bytes), total 32768 (slots), used 0 (slots)
+---
+ drivers/gpu/drm/rockchip/rockchip_drm_drv.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_drv.c b/drivers/gpu/drm/rockchip/rockchip_drm_drv.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/rockchip/rockchip_drm_drv.c
++++ b/drivers/gpu/drm/rockchip/rockchip_drm_drv.c
+@@ -472,7 +472,9 @@ static int rockchip_drm_platform_probe(struct platform_device *pdev)
+ 		return ret;
+ 	}
+ 
+-	return 0;
++	ret = dma_coerce_mask_and_coherent(dev, DMA_BIT_MASK(64));
++
++	return ret;
+ }
+ 
+ static void rockchip_drm_platform_remove(struct platform_device *pdev)
+-- 
+Armbian
+


### PR DESCRIPTION
# Description  
This patch sets the DMA mask to 64-bit for Rockchip DRM drivers to properly handle physical addresses above 4GB. The VOP MMU can translate upper 4GB physical addresses to iova below 4GB, resolving "swiotlb buffer full" warnings seen on systems with >4GB RAM.

Source: https://source.mnt.re/reform/reform-debian-packages/-/blob/487191f7ad5c48850c22b3fe8d4d9187f21945e5/linux/patches6.11/rk3588-mnt-reform2/5200-drm-rockchip-Set-dma-mask-to-64-bit.patch

**Motivation**: Fixes graphical subsystem warnings that occur when handling large memory allocations on Rockchip devices with >4GB DDR.

# How Has This Been Tested?  
- [x] Verified on RK3588-based SBC with 8GB RAM  
- [x] Confirmed disappearance of swiotlb warnings via `dmesg` monitoring  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings