### PR TITLE
Enable HDMI audio outputs for Rock 5B by detlev.casanova@collabora.com

### DIFF
--- a/patch/kernel/archive/rockchip64-6.14/rk3588-1102-arm64-dts-rockchip-Rock-5B-add-hdmi-sound.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-1102-arm64-dts-rockchip-Rock-5B-add-hdmi-sound.patch
@@ -1,0 +1,58 @@
+From: Detlev Casanova <detlev.casanova@collabora.com>
+Subject: [PATCH v7 3/3] arm64: dts: rockchip: Enable HDMI audio outputs for Rock 5B
+Date: Mon, 17 Feb 2025 16:47:42 -0500	[thread overview]
+Message-ID: <20250217215641.372723-4-detlev.casanova@collabora.com> (raw)
+In-Reply-To: <20250217215641.372723-1-detlev.casanova@collabora.com>
+
+HDMI audio is available on the Rock 5B HDMI TX ports.
+Enable it for both ports.
+
+Reviewed-by: Quentin Schulz <quentin.schulz@cherry.de>
+Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+index 27128c6a05a2f..8f42cd0427701 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -231,6 +231,10 @@ hdmi0_out_con: endpoint {
+ 	};
+ };
+ 
++&hdmi0_sound {
++	status = "okay";
++};
++
+ &hdmi1 {
+ 	pinctrl-0 = <&hdmim0_tx1_cec &hdmim0_tx1_hpd
+ 		     &hdmim1_tx1_scl &hdmim1_tx1_sda>;
+@@ -249,6 +253,10 @@ hdmi1_out_con: endpoint {
+ 	};
+ };
+ 
++&hdmi1_sound {
++	status = "okay";
++};
++
+ &hdptxphy0 {
+ 	status = "okay";
+ };
+@@ -351,6 +359,14 @@ i2s0_8ch_p0_0: endpoint {
+ 	};
+ };
+ 
++&i2s5_8ch {
++	status = "okay";
++};
++
++&i2s6_8ch {
++	status = "okay";
++};
++
+ &package_thermal {
+ 	polling-delay = <1000>;
+ 
+-- 
+2.48.1


### PR DESCRIPTION
Just this small patch:
https://lore.kernel.org/all/20250217215641.372723-4-detlev.casanova@collabora.com/
Already merged to linux-rockchip (for-next branch)
https://web.git.kernel.org/pub/scm/linux/kernel/git/mmind/linux-rockchip.git/commit/?h=for-next&id=97aa62ed1e970bf8aa9f57e87c946a95fa3d5bef

# Description

HDMI audio is available on the Rock 5B HDMI TX ports.
Enable it for both ports.

# How Has This Been Tested?

I added patch, then build kernel with `./compile.sh kernel BOARD=rock-5b BRANCH=edge` and install builded debs on my Rock 5B. After that I got `Analog Output - HDMI0 Audio` and now I can hear music =)

# Checklist:

_Please delete options that are not relevant._

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
