### PR TITLE
rockchip64-6.14: rewrite rock5b hdmi audio patch

### DIFF
--- a/patch/kernel/archive/rockchip64-6.14/rk3588-1102-arm64-dts-rockchip-Rock-5B-add-hdmi-sound.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-1102-arm64-dts-rockchip-Rock-5B-add-hdmi-sound.patch
@@ -1,20 +1,21 @@
-From: Detlev Casanova <detlev.casanova@collabora.com>
-Subject: [PATCH v7 3/3] arm64: dts: rockchip: Enable HDMI audio outputs for Rock 5B
-Date: Mon, 17 Feb 2025 16:47:42 -0500	[thread overview]
-Message-ID: <20250217215641.372723-4-detlev.casanova@collabora.com> (raw)
-In-Reply-To: <20250217215641.372723-1-detlev.casanova@collabora.com>
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aleksey Komarov <q4arus@ya.ru>
+Date: Sat, 8 Mar 2025 19:43:05 +0100
+Subject: [ARCHEOLOGY] Enable HDMI audio outputs for Rock 5B by
+ detlev.casanova@collabora.com
 
-HDMI audio is available on the Rock 5B HDMI TX ports.
-Enable it for both ports.
-
-Reviewed-by: Quentin Schulz <quentin.schulz@cherry.de>
-Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
+> X-Git-Archeology: > recovered message: > https://lore.kernel.org/all/20250217215641.372723-4-detlev.casanova@collabora.com/
+> X-Git-Archeology: - Revision bf9ffa6eedd5df804e3f9a86c84e00607289cd59: https://github.com/armbian/build/commit/bf9ffa6eedd5df804e3f9a86c84e00607289cd59
+> X-Git-Archeology:   Date: Sat, 08 Mar 2025 19:43:05 +0100
+> X-Git-Archeology:   From: Aleksey Komarov <q4arus@ya.ru>
+> X-Git-Archeology:   Subject: Enable HDMI audio outputs for Rock 5B by detlev.casanova@collabora.com
+> X-Git-Archeology:
 ---
- arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 16 ++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 16 ++++++++++
  1 file changed, 16 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
-index 27128c6a05a2f..8f42cd0427701 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
 @@ -231,6 +231,10 @@ hdmi0_out_con: endpoint {
@@ -55,4 +56,5 @@ index 27128c6a05a2f..8f42cd0427701 100644
  	polling-delay = <1000>;
  
 -- 
-2.48.1
+Armbian
+


### PR DESCRIPTION
# Description

As my comment on #7925 I rewritten the patch through the Armbian rewrite tool.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
