### PR TITLE
rockchip64-6.14: Add HDMI audio support and missing stuff on Youyeetoo R1 v3

### DIFF
--- a/patch/kernel/archive/rockchip64-6.14/dt/rk3588s-youyeetoo-r1.dts
+++ b/patch/kernel/archive/rockchip64-6.14/dt/rk3588s-youyeetoo-r1.dts
@@ -36,6 +36,19 @@
 		};
 	};
 
+	/* HDMI 0 CONNECTOR */
+
+	hdmi0-con {
+		compatible = "hdmi-connector";
+		type = "a";
+
+		port {
+			hdmi0_con_in: endpoint {
+				remote-endpoint = <&hdmi0_out_con>;
+			};
+		};
+	};
+
 	/* POWER REGULATOR 12V DC-IN */
 
 	vcc12v_dcin: vcc12v-dcin-regulator {
@@ -231,6 +244,31 @@
 	status = "okay";
 };
 
+&hdmi0 {
+	enable-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+};
+
+&hdmi0_in {
+	hdmi0_in_vp0: endpoint {
+		remote-endpoint = <&vp0_out_hdmi0>;
+	};
+};
+
+&hdmi0_out {
+	hdmi0_out_con: endpoint {
+		remote-endpoint = <&hdmi0_con_in>;
+	};
+};
+
+&hdmi0_sound {
+	status = "okay";
+};
+
+&hdptxphy0 {
+	status = "okay";
+};
+
 &i2c0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c0m2_xfer>;
@@ -307,6 +345,10 @@
         clock-output-names = "hym8563";
         status = "okay";
     };
+};
+
+&i2s5_8ch {
+	status = "okay";
 };
 
 &package_thermal {
@@ -829,24 +871,8 @@
 	status = "okay";
 };
 
-&hdmi0 {
-	enable-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
-	status = "okay";
-	cec-enable = "true";
-};
-
-&hdptxphy0 {
-	status = "okay";
-};
-
 &vop_mmu {
 	status = "okay";
-};
-
-&hdmi0_in {
-	hdmi0_in_vp0: endpoint {
-		remote-endpoint = <&vp0_out_hdmi0>;
-	};
 };
 
 &vop {


### PR DESCRIPTION
# Description

This commit integrates various changes related to HDMI connector configuration. It includes the following updates:
- Addition of HDMI 0 connector configuration (`hdmi0-con`) for endpoint connections.
- Activation of HDMI output (`hdmi0_out`) and HDMI input (`hdmi0_in`) endpoints.
- Updates to enable HDMI sound (`hdmi0_sound`) and HDMI PHY (`hdptxphy0`).



# How Has This Been Tested?


- [x] Test with HDMI display connected to verify input/output functionality.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

@aulyp