### PR TITLE
Improve armbian-firstlogin script

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -674,18 +674,11 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	then
 		echo "Both NetworkManager and systemd-networkd services are enabled."
 		echo "This is known to cause problems with network startup."
-		# If no display manager was found, assume this is a server
-		# with network managed by systemd-networkd. Otherwise, assume
-		# it is a workstation with network managed by NetworkManager.
-		if [[ "${desktop_dm}" == "none" ]]; then
-			echo "No Display Manager detected: NetworkManager will be disabled"
-			systemctl stop NetworkManager
-			systemctl disable NetworkManager
-		else
-			echo "${desktop_dm} Display Manager detected: systemd-networkd will be disabled"
-			systemctl stop systemd-networkd
-			systemctl disable systemd-networkd
-		fi
+		echo "systemd-networkd will be disabled..."
+		sleep 30 # Give the user time to see the message
+		systemctl stop systemd-networkd
+		systemctl disable systemd-networkd
+		echo "systemd-networkd has been disabled."
 	fi
 
 	if

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -662,6 +662,52 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	echo -e "\nWaiting for system to finish booting ..."
 	systemctl is-system-running --wait > /dev/null
 
+	# enable networkManager-wait-online.service
+	# When NM is used the NetworkManager-wait-online.service must be enabled so that network-online.target is not reached until
+	# NetworkManager has brought up all the interfaces. Service units that require the network to be up before starting rely
+	# on network-online.target working correctly otherwise they will likely fail on boot
+	# Same goes for systemd-networkd stack
+	# https://github.com/armbian/build/issues/7896
+	if
+		systemctl is-enabled --quiet NetworkManager &&
+		systemctl is-enabled --quiet systemd-networkd
+	then
+		echo "Both NetworkManager and systemd-networkd services are enabled."
+		echo "This is known to cause problems with network startup."
+		# If no display manager was found, assume this is a server
+		# with network managed by systemd-networkd. Otherwise, assume
+		# it is a workstation with network managed by NetworkManager.
+		if [[ "${desktop_dm}" == "none" ]]; then
+			echo "No Display Manager detected: NetworkManager will be disabled"
+			systemctl stop NetworkManager
+			systemctl disable NetworkManager
+		else
+			echo "${desktop_dm} Display Manager detected: systemd-networkd will be disabled"
+			systemctl stop systemd-networkd
+			systemctl disable systemd-networkd
+		fi
+	fi
+
+	if
+		systemctl is-enabled --quiet NetworkManager &&
+		! systemctl is-enabled --quiet NetworkManager-wait-online
+	then
+		systemctl enable NetworkManager-wait-online
+		# @TODO: determine if there is any value in starting it now
+		echo "Waiting for network startup to complete..."
+		systemctl start NetworkManager-wait-online
+	fi
+
+	if
+		systemctl is-enabled --quiet systemd-networkd &&
+		! systemctl is-enabled --quiet systemd-networkd-wait-online
+	then
+		systemctl enable systemd-networkd-wait-online
+		# @TODO: determine if there is any value in starting it now
+		echo "Waiting for network startup to complete..."
+		systemctl start systemd-networkd-wait-online
+	fi
+
 	# enable hiDPI support
 	if [[ "$(cut -d, -f1 < /sys/class/graphics/fb0/virtual_size 2> /dev/null)" -gt 1920 ]]; then
 		# lightdm
@@ -704,21 +750,6 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 				mkdir -p /root/.ssh/
 				curl --retry 5 --connect-timeout 3 "${PRESET_ROOT_KEY}" > /root/.ssh/authorized_keys 2> /dev/null
 			fi
-		fi
-
-		# enable networkManager-wait-online.service
-		# When NM is used the NetworkManager-wait-online.service must be enabled so that network-online.target is not reached until
-		# NetworkManager has brought up all the interfaces. Service units that require the network to be up before starting rely
-		# on network-online.target working correctly otherwise they will likely fail on boot
-		# Same goes for systemd-networkd stack
-		# https://github.com/armbian/build/issues/7896
-		if systemctl is-active --quiet NetworkManager; then
-			systemctl enable NetworkManager-wait-online.service
-			systemctl start NetworkManager-wait-online.service
-		fi
-		if systemctl is-active --quiet systemd-networkd; then
-			systemctl enable systemd-networkd-wait-online.service
-			systemctl start systemd-networkd-wait-online.service
 		fi
 
 		# only allow one login. Once you enter root password, kill others.


### PR DESCRIPTION
Avoid waiting for the NetworkManager-wait-online or systemd-networkd-wait-online service to complete in the midst of prompting for root account password.

# Description

This is a revision of the armbian-firstlogin script to avoid delays while setting root account password on systems where network initialization cannot be completed promptly.

Move the code that enables and starts the NetworkManager-wait-online and systemd-networkd-wait-online services out of the loop that sets root account password.  Instead, do this immediately after detecting the desktop display manager, before beginning user interaction to set root password.

Ensure that NetworkManager and systemd-networkd are not both enabled. If both are enabled, disable systemd-networkd if a display manager is detected, otherwise disable NetworkManager.

Only enable and start NetworkManager-wait-online if NetworkManager is enabled and NetworkManager-wait-online is not already enabled.

Only enable and start systemd-networkd-wait-online if systemd-networkd is enabled and systemd-networkd-wait-online is not already enabled.

There may not be any value in starting NetworkManager-wait-online or systemd-networkd-wait-online in the armbian-firstlogin script. By the time this script runs, any systemd units that should have waited for the network-online target to be reached will already have been started or failed. Running the wait-online one-shot after boot has completed will not correct any faults that might have resulted from starting units before network initialization completed. But it will significantly delay the armbian-firstlogin script if the network cannot be fully initialized. Therefore, it would be better to enable these services but leave starting them to the next boot when they will be started at the appropriate time to delay startup of units that depend on the network. None the less, this implementation starts these services after enabling them because that is what the original implementation did.

The wait-online services wait for initialization of all managed network interfaces to be completed or until a timeout of two minutes, by default. In the case of an interface configured to obtain configuration by DHCP which is not connected to a network with a DHCP server, initialization cannot be completed. And it may not be uncommon to connect console but not connect any network at first boot, until after first login and configuration of the system. In such case, the wait-online service if started will block until timeout.  At least one unconnected network port at first boot is more likely on systems that have multiple network ports.

This should fix the delays reported in Issue #7939.

# How Has This Been Tested?

I have exercised the code dealing with NetworkManager and system-networkd outside the armbian-firstlogin script, to ensure it handles various combinations of the services being enabled or not as expected.

I have built an image for my NanoPi R2S Plus with the modified armbian-firstlogin script, booted it and completed setup without the delay experienced with the previous implementation. In this case, one of the network ports was not connected so could not complete initialization while NetworkManager was disabled and systemd-networkd and systemd-networkd-wait-online were already both enabled, so there is no benefit to enabling and starting systemd-networkd-wait-online.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings - none that I have seen, at least
