### PR TITLE
Change to different method of getting changed files

### DIFF
--- a/.github/workflows/pr-kernel-security-analysis.yml
+++ b/.github/workflows/pr-kernel-security-analysis.yml
@@ -1,11 +1,27 @@
 name: Kernel Hardening Analysis
 run-name: 'Check kernel security options - PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}")'
+
+# -----------------------------------------------------------------------------
+# This workflow analyzes Linux kernel configuration files to check for 
+# security hardening options using the kernel-hardening-checker tool.
 #
-#  Check the Linux kernel options against security hardening
+# ⚠️ Important: 
+# Modifying security parameters may impact system performance and 
+# functionality of userspace software.
 #
-#  Attention! Changing security parameters may also affect system performance and functionality of userspace software!
-#  More info:
-#  https://github.com/a13xp0p0v/kernel-hardening-checker
+# More info:
+# https://github.com/a13xp0p0v/kernel-hardening-checker
+#
+# Triggers:
+# - Manually via workflow_dispatch
+# - On pull request events: ready_for_review, opened, reopened, or synchronized
+#
+# Features:
+# - Runs only for PRs targeting the 'Armbian' repository
+# - Validates kernel `.config` files for security best practices
+# - Skips RISC-V configurations due to known compatibility issues
+# - Provides a formatted security report in GitHub Actions summary
+# -----------------------------------------------------------------------------
 
 on:
   workflow_dispatch:
@@ -17,7 +33,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pipeline-security-${{github.event.pull_request.number}}
+  group: pipeline-security-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -33,22 +49,23 @@ jobs:
           fetch-depth: 0
 
       - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v45
+        id: files
+        uses: UplandJacob/retrieve-changed-files@v4
 
-      - name: Checkout repository
+      - name: Checkout kernel-hardening-checker
         uses: actions/checkout@v4
         with:
           repository: a13xp0p0v/kconfig-hardened-check
           path: kconfig-hardened-check
 
-      - name: Check kernel config for security issues
-        # Run kernel-hardening-checker for each kernel config file excluding RISC-V configs, since they are not supported yet.
-        # See https://github.com/a13xp0p0v/kernel-hardening-checker/issues/56
-        # sed explanation: 1) Put spaces in front of every line 2) replace colored output with emojis since GitHub Actions job summaries don't support colored output
+      - name: Run kernel security analysis
         run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          for file in ${{ steps.files.outputs.all }}; do
+              # Process only kernel configuration files and skip RISC-V configs
               if [[ "${file}" = config/kernel/*.config && ! $(head -n 10 "${file}" | grep -q "riscv") ]]; then
-                  kconfig-hardened-check/bin/kernel-hardening-checker -m show_fail -c $file | sed 's/^/     /; s/\x1b\[32m/✅ /; s/\x1b\[31m/❌ /; s/\x1b\[0m//' >> $GITHUB_STEP_SUMMARY
+                  # Run security checks and format output for GitHub Actions summary
+                  kconfig-hardened-check/bin/kernel-hardening-checker -m show_fail -c $file \
+                      | sed 's/^/     /; s/\x1b\[32m/✅ /; s/\x1b\[31m/❌ /; s/\x1b\[0m//' \
+                      >> $GITHUB_STEP_SUMMARY
               fi
           done

--- a/.github/workflows/pr-lint-scripts.yml
+++ b/.github/workflows/pr-lint-scripts.yml
@@ -1,8 +1,21 @@
 name: Lint on Scripts
-run-name: 'Shellcheck - PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}")'
+run-name: 'ShellCheck - PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}")'
+
+# -----------------------------------------------------------------------------
+# This workflow runs ShellCheck on all relevant shell scripts in the repository
+# to ensure code quality, best practices, and prevent common scripting errors.
+# It generates a linting report and provides feedback for pull requests.
 #
-# Run ShellCheck on all scripts and generate report as build artifact
+# Triggers:
+# - Manually via workflow_dispatch
+# - On pull request events: opened, reopened, or synchronized with new commits
 #
+# Features:
+# - Runs only for PRs targeting the 'Armbian' repository
+# - Checks only modified shell scripts while ignoring non-shell files
+# - Ensures accurate analysis by leveraging framework-specific mechanisms
+# - Uses concurrency control to prevent redundant executions
+# -----------------------------------------------------------------------------
 
 on:
   workflow_dispatch:
@@ -13,7 +26,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pipeline-lint-${{github.event.pull_request.number}}
+  group: pipeline-lint-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -29,31 +42,25 @@ jobs:
           fetch-depth: 2
 
       - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v45
+        id: files
+        uses: UplandJacob/retrieve-changed-files@v4
 
-      - name: List all changed files
+      - name: List and analyze changed shell scripts
         run: |
-
-          # Use framework internal mechanism for checking `lib` and `extensions` code only one file is passed,
-          # and source's are followed, thus the whole project is "understood" by shellcheck.
-          # For example, when checking individual files, one variable might be thought "unused" because it
-          # is only used in another file, which does not happen when done properly.
-
+          # Utilize the framework's internal mechanism to check `lib/` and `extensions/` scripts.
+          # This ensures correct context resolution, avoiding false positives in variable usage.
           bash lib/tools/shellcheck.sh
 
           ret=0
 
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-
+          for file in ${{ steps.files.outputs.all }}; do
+              # Ignore non-shell files
               if [[ ! "${file}" =~ lib/|extensions/|.py|.service|.rules|.network|.netdev ]]; then
-                  if grep -qE "^#\!/.*bash" $file; then
-
-                      shellcheck --severity=error $file || ret=$?
-
+                  # Check if the file has a bash shebang and run ShellCheck
+                  if grep -qE "^#\!/.*bash" "$file"; then
+                      shellcheck --severity=error "$file" || ret=$?
                   fi
               fi
-
           done
 
           exit $ret


### PR DESCRIPTION
# Description

The workflow files have been updated to change to different external GitHub Action. Addressing security issue: https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/

# How Has This Been Tested?

- [x] Tested at PR

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
