### PR TITLE
Update K3 Family to use Github Mirror over TI Cgit

### DIFF
--- a/config/sources/families/k3.conf
+++ b/config/sources/families/k3.conf
@@ -19,7 +19,7 @@ case "${BRANCH}" in
 
 	current)
 
-		declare -g KERNELSOURCE="https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel"
+		declare -g KERNELSOURCE="https://github.com/TexasInstruments-Sandbox/ti-linux-kernel"
 		declare -g KERNEL_MAJOR_MINOR="6.6"
 		declare -g KERNELBRANCH="branch:ti-linux-6.6.y"
 		;;
@@ -49,7 +49,7 @@ function add_host_dependencies__k3_python3_dep() {
 
 function compile_k3_bootgen() {
 	# Source code checkout
-	(fetch_from_repo "https://git.ti.com/cgit/processor-firmware/ti-linux-firmware" "ti-linux-firmware" "branch:ti-linux-firmware")
+	(fetch_from_repo "https://github.com/TexasInstruments-Sandbox/ti-linux-firmware" "ti-linux-firmware" "branch:ti-linux-firmware")
 
 	pushd ${SRC}/cache/sources/u-boot-worktree/${BOOTDIR}/${BOOTBRANCH##*:} || exit
 


### PR DESCRIPTION
# Description

Updated Kernel and Linux Firmware sources to pull from the Github Mirrors we setup for Texas Instruments devices. 

# Documentation summary for feature / change

# How Has This Been Tested?

- [x] Minimal builds for TI target boards.  

# Checklist:

_Please delete options that are not relevant._

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
