### PR TITLE
fix regression leading to FTBFS introduced in #7910

### DIFF
--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -57,7 +57,9 @@ function git_ensure_safe_directory() {
 		local git_dir="$1"
 		if [[ -e "$1/.git" ]]; then
 			display_alert "git: Marking all directories as safe, which should include" "$git_dir" "debug"
-			git config --local --get safe.directory "$1" > /dev/null || regular_git config --local --add safe.directory "$1"
+			cd "$1" # make sure we are in the right directory for the next command
+			git config --local --get safe.directory > /dev/null || regular_git config --local --add safe.directory
+			cd -
 		fi
 	else
 		display_alert "git not installed" "a true wonder how you got this far without git - it will be installed for you" "warn"

--- a/lib/functions/host/basic-deps.sh
+++ b/lib/functions/host/basic-deps.sh
@@ -14,7 +14,7 @@
 function prepare_host_basic() {
 
 	# command:package1 package2 ...
-	# list of commands that are neeeded:packages where this command is
+	# list of commands that are needed:packages where this command is
 	local check_pack install_pack
 	local checklist=(
 		"dialog:dialog"


### PR DESCRIPTION
# Description

#7910 is a step in the right direction but uses incorrect syntax or incorrect assumptions: git needs to be called from within $GITDIR.  This leads to [build failures ](https://github.com/armbian/os/actions/runs/13882805130/job/38845415332#step:8:1784).

    git.sh currently fails because git is usually called from outside the
    git directory it is supposed to work on.  Before ccde662ccbdea2b0a1089
    git config was called with --global which was wrong (#7907) but worked
    from any directory.  Now git config is called correctly with --local
    but that only works when cd'ing into the git directory first.

I added an unrelated, small typo nitpick commit for good measure in this PR.

# How Has This Been Tested?

Untested, but code inspection and studies of the relevant docs and testing with regards to the general working of git was done locally.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
