### PR TITLE
ORAS download folder doesn't need Git safe

### DIFF
--- a/lib/functions/compilation/kernel-git-oras.sh
+++ b/lib/functions/compilation/kernel-git-oras.sh
@@ -229,7 +229,8 @@ function kernel_prepare_bare_repo_from_oras_gitball() {
 		display_alert "Kernel bare tree already exists" "${kernel_git_bare_tree}" "cachehit"
 	fi
 
-	git_ensure_safe_directory "${kernel_git_bare_tree}"
+	# If we tell git to set this folder as safe it fails as not a git directory
+	# git_ensure_safe_directory "${kernel_git_bare_tree}"
 
 	return 0
 }


### PR DESCRIPTION
# Description

After switching https://github.com/armbian/build/pull/7910 using git safe per cloned repository, this errors out as "not a git directory". After dropping, compilation proceeded. 

@leggewie

# How Has This Been Tested?

- kernel compilation natively

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
