### PR TITLE
Revert "Stop altering global git config file and set safe per cloned repository

### DIFF
--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -57,7 +57,7 @@ function git_ensure_safe_directory() {
 		local git_dir="$1"
 		if [[ -e "$1/.git" ]]; then
 			display_alert "git: Marking all directories as safe, which should include" "$git_dir" "debug"
-			git config --local --get safe.directory "$1" > /dev/null || regular_git config --local --add safe.directory "$1"
+			git config --global --get safe.directory "$1" > /dev/null || regular_git config --global --add safe.directory "$1"
 		fi
 	else
 		display_alert "git not installed" "a true wonder how you got this far without git - it will be installed for you" "warn"


### PR DESCRIPTION
# Description

This reverts commit ccde662ccbdea2b0a1089eb1c047f23b5c01163e.

git config --local needs to have initialed repository at the location.