### PR TITLE
rockchip64: rk3318-box: fix wifi with alternate sdio bus

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3318-box.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3318-box.dts
@@ -327,8 +327,10 @@
 	 * To handle the most critical situation, the controller will be configured as
 	 * sdcard controller by default. An overlay can be set to disable the sdmmc_ext
 	 * node and enable this sdio_ext in case wifi chips are attached to this.
+	 * Note also that the node name is a non-convential "sdio@...", to differentiate 
+	 * it from the mmc@ff5f0000 node in the base device tree.
 	 */
-	sdio_ext: mmc@ff5f0000 {
+	sdio_ext: sdio@ff5f0000 {
 		compatible = "rockchip,rk3328-dw-mshc", "rockchip,rk3288-dw-mshc";
 		reg = <0x0 0xff5f0000 0x0 0x4000>;
 		interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;

--- a/patch/kernel/archive/rockchip64-6.14/dt/rk3318-box.dts
+++ b/patch/kernel/archive/rockchip64-6.14/dt/rk3318-box.dts
@@ -327,8 +327,10 @@
 	 * To handle the most critical situation, the controller will be configured as
 	 * sdcard controller by default. An overlay can be set to disable the sdmmc_ext
 	 * node and enable this sdio_ext in case wifi chips are attached to this.
+	 * Note also that the node name is a non-convential "sdio@...", to differentiate 
+	 * it from the mmc@ff5f0000 node in the base device tree.
 	 */
-	sdio_ext: mmc@ff5f0000 {
+	sdio_ext: sdio@ff5f0000 {
 		compatible = "rockchip,rk3328-dw-mshc", "rockchip,rk3288-dw-mshc";
 		reg = <0x0 0xff5f0000 0x0 0x4000>;
 		interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;


### PR DESCRIPTION
# Description

Some rk3318 tv box boards (x88 pro v10), use the `sdmmc_ext` mmc controller for sdio-operated wifi. A workaround that was used to work seeems to not work anymore, hence these boards, even if properly configured, did not show the wifi device.

This PR fixes the workaround and now (as reported on the [forum](https://forum.armbian.com/topic/26978-csc-armbian-for-rk3318rk3328-tv-box-boards/page/63/#findComment-214700) ) restores proper functionality: there were two nodes with same name (`mmc@ff5f0000`), and this caused issues when translating aliases to names during overlay application.

Nothing else is affected rather than CSC rk3318-box targets.

# How Has This Been Tested?

- [x] Tested on a live installation by user from the forum, reported it works
- [x] Tested on a live installation to be sure it does not break other models

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
