### PR TITLE
Allow NetworkManager and systemd-networkd

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -670,19 +670,6 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	# https://github.com/armbian/build/issues/7896
 	if
 		systemctl is-enabled --quiet NetworkManager &&
-		systemctl is-enabled --quiet systemd-networkd
-	then
-		echo "Both NetworkManager and systemd-networkd services are enabled."
-		echo "This is known to cause problems with network startup."
-		echo "systemd-networkd will be disabled..."
-		sleep 30 # Give the user time to see the message
-		systemctl stop systemd-networkd
-		systemctl disable systemd-networkd
-		echo "systemd-networkd has been disabled."
-	fi
-
-	if
-		systemctl is-enabled --quiet NetworkManager &&
 		! systemctl is-enabled --quiet NetworkManager-wait-online
 	then
 		systemctl enable NetworkManager-wait-online


### PR DESCRIPTION
Commit 28df43d introduced a provision to ensure that NetworkManager and systemd-networkd are not both enabled. This was done in consideration of reports on various forums of problems when both are enabled and frequent conclusion that the root cause of the problem was having them both enabled and the solution was, therefore, to disable one of them.

Investigating this further, I have reached the conclusion that enabling both is unusual but that they are not fundamentally incompatible. Issues that arise when they are both enabled are generally the result of misconfiguration. There can be problems, for example, when both try to manage the same interface. But there are people who intentionally and successfully enable both.

Further, Armbian build should not produce an image in which both are enabled: the build is intended to enable one or the other but not both. Given this, if both are enabled, it is probably due to manual modification of the image, and probably best not to interfere with such intentional modification.

Therefore, this change removes the code from the armbian-firstlogin script that disables systemd-networkd if both it and NetworkManager are enabled.

# Description

Change the armbian-firstlogin script so that it does not disable systemd-networkd if both systemd-networkd and NetworkManager are enabled.

# How Has This Been Tested?

I built a new image for one of my systems and successfully completed the armbian-firstlogin script.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
