### PR TITLE
Drop fastfetch alias - it only make troubles

### DIFF
--- a/packages/bsp/common/etc/skel/.bash_aliases
+++ b/packages/bsp/common/etc/skel/.bash_aliases
@@ -4,4 +4,3 @@ alias la='ls -A'
 alias l='ls -CF'
 alias kernel="uname -r | sed 's/[1-9]\+[0-9]*\.[0-9]\+\.[0-9]\+-//' | sed 's/[1-9]\+[0-9]*\.[0-9]*\-rc[0-9]\+-//'"
 alias showip='ip -4 addr show scope global | grep inet | awk "{print $2}" | cut -d"/" -f1 | sed "s/    inet //g" | paste -s -d, -'
-alias neofetch='fastfetch'


### PR DESCRIPTION
# Description

https://forum.armbian.com/topic/50547-neofetch-says-bash-fastfetch-command-not-found/#comment-214753

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
