### PR TITLE
rockchip64: bump orangepi4 lts uboot to v2025.01

### DIFF
--- a/config/boards/orangepi4-lts.conf
+++ b/config/boards/orangepi4-lts.conf
@@ -13,8 +13,8 @@ MODULES_EDGE="sprdbt_tty sprdwl_ng"
 FULL_DESKTOP="yes"
 ASOUND_STATE="asound.state.rk3399"
 BOOT_LOGO="desktop"
-BOOTBRANCH_BOARD="tag:v2024.10"
-BOOTPATCHDIR="v2024.10"
+BOOTBRANCH_BOARD="tag:v2025.01"
+BOOTPATCHDIR="v2025.01"
 BOOT_SCENARIO="binman"
 
 function post_family_tweaks_bsp__OPi4lts() {

--- a/patch/u-boot/v2025.01/board_orangepi4-lts/board-orangepi4-rockchip-tpl.patch
+++ b/patch/u-boot/v2025.01/board_orangepi4-lts/board-orangepi4-rockchip-tpl.patch
@@ -1,0 +1,16 @@
+Alter the orangepi-rk3399_defconfig file to enable "External TPL", 
+because we want to use the Rockchip ddrbin in place of the u-boot TPL
+It has to be set with the env variable ROCKCHIP_TPL when invoking make
+
+diff --git a/configs/orangepi-rk3399_defconfig b/configs/orangepi-rk3399_defconfig
+index 5dfbdeaf17..167c2b3f60 100644
+--- a/configs/orangepi-rk3399_defconfig
++++ b/configs/orangepi-rk3399_defconfig
+@@ -8,6 +8,7 @@ CONFIG_ENV_OFFSET=0x3F8000
+ CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3399-orangepi"
+ CONFIG_DM_RESET=y
+ CONFIG_ROCKCHIP_RK3399=y
++CONFIG_ROCKCHIP_EXTERNAL_TPL=y
+ CONFIG_TARGET_EVB_RK3399=y
+ CONFIG_DEBUG_UART_BASE=0xFF1A0000
+ CONFIG_DEBUG_UART_CLOCK=24000000


### PR DESCRIPTION
# Description

Bump OrangePi4 LTS u-boot to v2025.01 from v2024.10. Nothing fancy, the previous version already was using binman, so no big surprises here.

# How Has This Been Tested?

- [x] Compiled u-boot with compile.sh
- [x] Tested produced binary in a live sdcard installation
- [x] Tested produced binary in a live eMMC installation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
