### PR TITLE
rockchip64: bump rockpi-e to u-boot v2025.01

### DIFF
--- a/config/boards/rockpi-e.conf
+++ b/config/boards/rockpi-e.conf
@@ -8,3 +8,7 @@ KERNEL_TEST_TARGET="current"
 DEFAULT_CONSOLE="serial"
 MODULES_BLACKLIST="rockchipdrm analogix_dp dw_mipi_dsi dw_hdmi gpu_sched lima"
 HAS_VIDEO_OUTPUT="no"
+BOOTBRANCH_BOARD="tag:v2025.01"
+BOOTPATCHDIR="v2025.01"
+BOOT_SCENARIO="binman"
+


### PR DESCRIPTION
# Description

Bump u-boot to v2025.01 for RockPi-E boad

# How Has This Been Tested?

- [x] Built succesfully a new image with updated u-boot
- [x] Tested the image boot on sdcard
- [x] Installed the image on eMMC and tested image boot from eMMC
- [x] Verified stable MAC Address

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
