### PR TITLE
rockchip64-6.14: Add patch to fix USB 3.0 A on NanoPC T6

### DIFF
--- a/patch/kernel/archive/rockchip64-6.14/rk3588-1053-board-nanopc-t6-fix-usb3-a.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-1053-board-nanopc-t6-fix-usb3-a.patch
@@ -1,0 +1,137 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Tue, 18 Mar 2025 09:14:27 +0000
+Subject: Fix USB3-A on NanoPC T6
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 49 +++-------
+ 1 file changed, 16 insertions(+), 33 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -191,20 +191,6 @@ vbus5v0_typec: regulator-vbus5v0-typec {
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+-	vbus5v0_usb: regulator-vbus5v0-usb {
+-		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&usb5v_pwren>;
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-name = "vbus5v0_usb";
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+ 	vcc3v3_pcie2x1l0: regulator-vcc3v3-pcie2x1l0 {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+@@ -717,12 +703,8 @@ typec5v_pwren: typec5v-pwren {
+ 			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
+-		usb5v_pwren: usb5v_pwren {
+-			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+ 		vcc5v0_host30_en: vcc5v0-host30-en {
+-			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 
+ 		usbc0_int: usbc0-int {
+@@ -1119,35 +1101,36 @@ &u2phy0 {
+ 	status = "okay";
+ };
+ 
+-&u2phy0_otg {
++&u2phy1 {
+ 	status = "okay";
+ };
+ 
+-&u2phy1 {
++&u2phy2 {
+ 	status = "okay";
+ };
+ 
+-&u2phy1_otg {
+-	phy-supply = <&vcc5v0_host_30>;
++&u2phy3 {
+ 	status = "okay";
+ };
+ 
+-&u2phy2_host {
++&u2phy0_otg {
++	phy-supply = <&vcc5v0_host_30>;
+ 	status = "okay";
+ };
+ 
+-&u2phy3_host {
++&u2phy1_otg {
+ 	status = "okay";
+ };
+ 
+-&u2phy2 {
++&u2phy2_host {
+ 	status = "okay";
+ };
+ 
+-&u2phy3 {
++&u2phy3_host {
+ 	status = "okay";
+ };
+ 
++
+ &usbdp_phy0 {
+ 	mode-switch;
+ 	orientation-switch;
+@@ -1172,7 +1155,6 @@ usbdp_phy0_typec_sbu: endpoint@1 {
+ };
+ 
+ &usbdp_phy1 {
+-	phy-supply = <&vbus5v0_usb>;
+ 	status = "okay";
+ };
+ 
+@@ -1186,8 +1168,9 @@ &usb_host0_ohci {
+ 
+ &usb_host0_xhci {
+ 	dr_mode = "host";
+-	status = "okay";
++	extcon = <&u2phy0>;
+ 	usb-role-switch;
++	status = "okay";
+ 
+ 	port {
+ 		usb_host0_xhci_drd_sw: endpoint {
+@@ -1196,16 +1179,16 @@ usb_host0_xhci_drd_sw: endpoint {
+ 	};
+ };
+ 
+-&usb_host1_xhci {
+-	dr_mode = "host";
++&usb_host1_ehci {
+ 	status = "okay";
+ };
+ 
+-&usb_host1_ehci {
++&usb_host1_ohci {
+ 	status = "okay";
+ };
+ 
+-&usb_host1_ohci {
++&usb_host1_xhci {
++	dr_mode = "host";
+ 	status = "okay";
+ };
+ 
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

This patch is intended to resolve a critical upstream issue. Although it appears to be a patch that enables USB 3.0 A support, it does not work correctly (the device is not detected by the system). Link to the patch:

https://lore.kernel.org/all/20241106130314.1289055-1-rick.wertenbroek@gmail.com/

# How Has This Been Tested?

- [x] `./compile.sh kernel BOARD=nanopct6 BRANCH=edge KERNEL_BTF=no`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
