### PR TITLE
rockchip64: rk356x: add PLL rate for 33.3MHz

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/general-clk-rockchip-rk3568-Add-PLL-rate-for-33.3MHz.patch
+++ b/patch/kernel/archive/rockchip64-6.12/general-clk-rockchip-rk3568-Add-PLL-rate-for-33.3MHz.patch
@@ -1,0 +1,28 @@
+From ca7b6ebfe6f8a718cdb14b3fdc82ad1e5a26b4c9 Mon Sep 17 00:00:00 2001
+From: Vasily Khoruzhick <anarsoul@gmail.com>
+Date: Mon, 17 Mar 2025 22:22:46 -0700
+Subject: [PATCH] clk: rockchip: rk3568: Add PLL rate for 33.3MHz
+
+Add PLL rate for 33.3 MHz to allow BTT HDMI5 screen to run at its native
+mode of 800x480
+
+Signed-off-by: Vasily Khoruzhick <anarsoul@gmail.com>
+---
+ drivers/clk/rockchip/clk-rk3568.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/clk/rockchip/clk-rk3568.c b/drivers/clk/rockchip/clk-rk3568.c
+index 53d10b1c627b..1c73e18a9862 100644
+--- a/drivers/clk/rockchip/clk-rk3568.c
++++ b/drivers/clk/rockchip/clk-rk3568.c
+@@ -89,6 +89,7 @@ static struct rockchip_pll_rate_table rk3568_pll_rates[] = {
+ 	RK3036_PLL_RATE(96000000, 1, 96, 6, 4, 1, 0),
+ 	RK3036_PLL_RATE(78750000, 4, 315, 6, 4, 1, 0),
+ 	RK3036_PLL_RATE(74250000, 2, 99, 4, 4, 1, 0),
++	RK3036_PLL_RATE(33300000, 4, 111, 5, 4, 1, 0),
+ 	{ /* sentinel */ },
+ };
+ 
+-- 
+2.49.0
+

--- a/patch/kernel/archive/rockchip64-6.14/general-clk-rockchip-rk3568-Add-PLL-rate-for-33.3MHz.patch
+++ b/patch/kernel/archive/rockchip64-6.14/general-clk-rockchip-rk3568-Add-PLL-rate-for-33.3MHz.patch
@@ -1,0 +1,28 @@
+From ca7b6ebfe6f8a718cdb14b3fdc82ad1e5a26b4c9 Mon Sep 17 00:00:00 2001
+From: Vasily Khoruzhick <anarsoul@gmail.com>
+Date: Mon, 17 Mar 2025 22:22:46 -0700
+Subject: [PATCH] clk: rockchip: rk3568: Add PLL rate for 33.3MHz
+
+Add PLL rate for 33.3 MHz to allow BTT HDMI5 screen to run at its native
+mode of 800x480
+
+Signed-off-by: Vasily Khoruzhick <anarsoul@gmail.com>
+---
+ drivers/clk/rockchip/clk-rk3568.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/clk/rockchip/clk-rk3568.c b/drivers/clk/rockchip/clk-rk3568.c
+index 53d10b1c627b..1c73e18a9862 100644
+--- a/drivers/clk/rockchip/clk-rk3568.c
++++ b/drivers/clk/rockchip/clk-rk3568.c
+@@ -89,6 +89,7 @@ static struct rockchip_pll_rate_table rk3568_pll_rates[] = {
+ 	RK3036_PLL_RATE(96000000, 1, 96, 6, 4, 1, 0),
+ 	RK3036_PLL_RATE(78750000, 4, 315, 6, 4, 1, 0),
+ 	RK3036_PLL_RATE(74250000, 2, 99, 4, 4, 1, 0),
++	RK3036_PLL_RATE(33300000, 4, 111, 5, 4, 1, 0),
+ 	{ /* sentinel */ },
+ };
+ 
+-- 
+2.49.0
+


### PR DESCRIPTION
# Description

rockchip64: rk356x: add PLL rate for 33.3 MHz to allow BTT HDMI5 screen to run at its native mode of 800x480

# How Has This Been Tested?

- [x] Built the kernel and tested it on my BTT CB2 with BTT HDMI5 screen connected

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
