### PR TITLE
grub-with-dtb: accept `GRUB_FDT_FILE` if `BOOT_FDT_FILE` is unset

### DIFF
--- a/config/boards/nanopct6-lts.conf
+++ b/config/boards/nanopct6-lts.conf
@@ -7,3 +7,4 @@ BOARD_MAINTAINER="SuperKali Tonymac32"
 BOOT_FDT_FILE="rockchip/rk3588-nanopc-t6-lts.dtb" # As opposed to "rockchip/rk3588-nanopc-t6.dtb" for the non-LTS version
 KERNEL_TARGET="current,edge,vendor"
 KERNEL_TEST_TARGET="vendor,current"
+declare -g GRUB_FDT_FILE="${BOOT_FDT_FILE}" # u-boot autodetects, but grub needs to know; store it here so we can unset later

--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -13,7 +13,8 @@ BOOT_SCENARIO="spl-blobs"
 BOOT_SUPPORT_SPI="yes"
 BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
-declare -g UEFI_EDK2_BOARD_ID="nanopc-t6" # This _only_ used for uefi-edk2-rk3588 extension
+declare -g UEFI_EDK2_BOARD_ID="nanopc-t6"   # This _only_ used for uefi-edk2-rk3588 extension
+declare -g GRUB_FDT_FILE="${BOOT_FDT_FILE}" # u-boot autodetects, but grub needs to know; store it here so we can unset later
 
 function post_family_tweaks__nanopct6_naming_audios() {
 	display_alert "$BOARD" "Renaming nanopct6 audio" "info"

--- a/extensions/grub-with-dtb.sh
+++ b/extensions/grub-with-dtb.sh
@@ -15,8 +15,8 @@ enable_extension "grub"
 
 # Ensure config is sufficient for operation
 function extension_prepare_config__prepare_grub_with_dtb() {
-	# Make sure BOOT_FDT_FILE is set and not empty
-	[[ -n "${BOOT_FDT_FILE}" ]] || exit_with_error "BOOT_FDT_FILE is not set, required for grub-with-dtb"
+	# Make sure BOOT_FDT_FILE, or GRUB_FDT_FILE is set and not empty
+	[[ -n "${BOOT_FDT_FILE:-"${GRUB_FDT_FILE}"}" ]] || exit_with_error "BOOT_FDT_FILE/GRUB_FDT_FILE is not set, required for grub-with-dtb"
 
 	display_alert "Extension: ${EXTENSION}: Initializing config" "${BOARD}" "info"
 }
@@ -30,7 +30,7 @@ function post_family_tweaks_bsp__add_grub_with_dtb_config_file() {
 	display_alert "Extension: ${EXTENSION}: Adding grub-with-dtb config file" "${BOARD}" "info"
 	# maybe add this to conffiles?
 	cat <<- EOD > "${destination}"/etc/armbian-grub-with-dtb
-		BOOT_FDT_FILE="${BOOT_FDT_FILE}"
+		BOOT_FDT_FILE="${BOOT_FDT_FILE:-"${GRUB_FDT_FILE}"}"
 	EOD
 }
 


### PR DESCRIPTION
- some boards have u-boot auto-detect the board variant, and thus we unset `BOOT_FDT_FILE`
- but grub needs to know...
- so introduce a `GRUB_FDT_FILE` that is checked in case `BOOT_FDT_FILE` is not set
- this way we can keep u-boot autodetecting and grub happy
- preserve BOOT_FDT_FILE into GRUB_FDT_FILE for `nanopct6`/`nanopct6-lts`