### PR TITLE
rockchip64-6.12: fix compatible for CPU regulator on BTT PI2/CB2

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3566-bigtreetech-pi2.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3566-bigtreetech-pi2.dts
@@ -320,7 +320,7 @@
 	status = "okay";
 
 	vdd_cpu: tsc4525@1c {
-		compatible = "tcs,tcs452x";
+		compatible = "tcs,tcs4525";
 		reg = <0x1c>;
 		vin-supply = <&vcc5v0_sys>;
 		regulator-compatible = "fan53555-reg";


### PR DESCRIPTION
# Description

fan53555 driver doesn't accept "tcs,tcs452x" as a compatible, it should be "tcs,tcs4525" instead.

This change fixes CPUFREQ on CB2 on 6.12

# How Has This Been Tested?

- [x] Rebuilt the kernel and installed `linux-dtb-current-rockchip64` deb on my CB2, confirmed that cpufreq is working

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
