### PR TITLE
fix URI to report armbian-config bugs against -ng now.  Fixes #7976 AR-2632

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -16,7 +16,7 @@ contact_links:
     url: https://bugzilla.kernel.org/
     about: If you are using upstream Linux kernel
   - name: Issue with armbian-config
-    url: https://github.com/armbian/config/issues/new
+    url: https://github.com/armbian/configng/issues/new
     about: Utility for configuring your board, adjusting services and installing applications.
   - name: Issue with infrastructure
     url: https://github.com/armbian/mirror/issues/new

--- a/lib/functions/host/basic-deps.sh
+++ b/lib/functions/host/basic-deps.sh
@@ -14,7 +14,7 @@
 function prepare_host_basic() {
 
 	# command:package1 package2 ...
-	# list of commands that are neeeded:packages where this command is
+	# list of commands that are needed:packages where this command is
 	local check_pack install_pack
 	local checklist=(
 		"dialog:dialog"


### PR DESCRIPTION
fix URI to report armbian-config bugs against -ng now.  Fixes #7976 [AR-2632](https://armbian.atlassian.net/browse/AR-2632)

[AR-2632]: https://armbian.atlassian.net/browse/AR-2632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ