### PR TITLE
mainline-kernel: bump 6.14 to -rc7

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0           # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "6.14" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v6.14-rc4"
+		declare -g KERNELBRANCH="tag:v6.14-rc7"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }

--- a/patch/kernel/archive/rockchip64-6.14/board-orangepi-r1-plus.patch
+++ b/patch/kernel/archive/rockchip64-6.14/board-orangepi-r1-plus.patch
@@ -176,7 +176,7 @@ index 111111111111..222222222222 100644
  &gmac2io {
  	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
  	assigned-clock-parents = <&gmac_clk>, <&gmac_clk>;
-@@ -121,6 +159,10 @@ mdio {
+@@ -120,6 +158,10 @@ mdio {
  	};
  };
  
@@ -187,7 +187,7 @@ index 111111111111..222222222222 100644
  &i2c1 {
  	status = "okay";
  
-@@ -150,6 +192,7 @@ vdd_log: DCDC_REG1 {
+@@ -149,6 +191,7 @@ vdd_log: DCDC_REG1 {
  				regulator-name = "vdd_log";
  				regulator-always-on;
  				regulator-boot-on;
@@ -195,7 +195,7 @@ index 111111111111..222222222222 100644
  				regulator-min-microvolt = <712500>;
  				regulator-max-microvolt = <1450000>;
  				regulator-ramp-delay = <12500>;
-@@ -164,6 +207,7 @@ vdd_arm: DCDC_REG2 {
+@@ -163,6 +206,7 @@ vdd_arm: DCDC_REG2 {
  				regulator-name = "vdd_arm";
  				regulator-always-on;
  				regulator-boot-on;
@@ -203,7 +203,7 @@ index 111111111111..222222222222 100644
  				regulator-min-microvolt = <712500>;
  				regulator-max-microvolt = <1450000>;
  				regulator-ramp-delay = <12500>;
-@@ -345,6 +389,7 @@ &usbdrd3 {
+@@ -344,6 +388,7 @@ &usbdrd3 {
  	rtl8153: device@2 {
  		compatible = "usbbda,8153";
  		reg = <2>;

--- a/patch/kernel/archive/rockchip64-6.14/board-pbp-add-dp-alt-mode.patch
+++ b/patch/kernel/archive/rockchip64-6.14/board-pbp-add-dp-alt-mode.patch
@@ -292,7 +292,7 @@ index 111111111111..222222222222 100644
  }
  
  static void tcpm_src_detach(struct tcpm_port *port)
-@@ -7165,6 +7209,64 @@ static void tcpm_fw_get_timings(struct tcpm_port *port, struct fwnode_handle *fw
+@@ -7164,6 +7208,64 @@ static void tcpm_fw_get_timings(struct tcpm_port *port, struct fwnode_handle *fw
  		port->timings.snk_bc12_cmpletion_time = val;
  }
  
@@ -357,7 +357,7 @@ index 111111111111..222222222222 100644
  static int tcpm_fw_get_caps(struct tcpm_port *port, struct fwnode_handle *fwnode)
  {
  	struct fwnode_handle *capabilities, *child, *caps = NULL;
-@@ -7178,6 +7280,23 @@ static int tcpm_fw_get_caps(struct tcpm_port *port, struct fwnode_handle *fwnode
+@@ -7177,6 +7279,23 @@ static int tcpm_fw_get_caps(struct tcpm_port *port, struct fwnode_handle *fwnode
  	if (!fwnode)
  		return -EINVAL;
  
@@ -381,7 +381,7 @@ index 111111111111..222222222222 100644
  	/*
  	 * This fwnode has a "compatible" property, but is never populated as a
  	 * struct device. Instead we simply parse it to read the properties.
-@@ -7749,6 +7868,17 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
+@@ -7748,6 +7867,17 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
  	tcpm_fw_get_pd_revision(port, tcpc->fwnode);
  
  	port->try_role = port->typec_caps.prefer_role;
@@ -399,7 +399,7 @@ index 111111111111..222222222222 100644
  
  	port->typec_caps.revision = 0x0120;	/* Type-C spec release 1.2 */
  
-@@ -7798,6 +7928,12 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
+@@ -7797,6 +7927,12 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
  				      &tcpm_cable_ops);
  	port->registered = true;
  

--- a/patch/kernel/archive/rockchip64-6.14/board-station-m2.patch
+++ b/patch/kernel/archive/rockchip64-6.14/board-station-m2.patch
@@ -1,14 +1,14 @@
-From d2e93589de2c195b51efb93d76d039492964a53c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: chainsx <chainsx@outlook.com>
 Date: Fri, 21 Feb 2025 19:36:41 +0800
-Subject: [PATCH] fix rk3566-roc-pc
+Subject: fix rk3566-roc-pc
 
 ---
- .../arm64/boot/dts/rockchip/rk3566-roc-pc.dts | 110 +++++++++++++-----
+ arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts | 110 +++++++---
  1 file changed, 80 insertions(+), 30 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts
-index 67e7801..192a952 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts
 @@ -52,6 +52,16 @@ led-user {
@@ -43,7 +43,7 @@ index 67e7801..192a952 100644
  	sdio_pwrseq: sdio-pwrseq {
  		status = "okay";
  		compatible = "mmc-pwrseq-simple";
-@@ -124,7 +142,7 @@ vcc5v0_usb30_host: vcc5v0-usb30-host-regulator {
+@@ -124,7 +142,7 @@ vcc5v0_usb30_host: regulator-vcc5v0-usb30-host {
  		compatible = "regulator-fixed";
  		regulator-name = "vcc5v0_usb30_host";
  		enable-active-high;
@@ -52,7 +52,7 @@ index 67e7801..192a952 100644
  		pinctrl-names = "default";
  		pinctrl-0 = <&vcc5v0_usb30_host_en_h>;
  		regulator-always-on;
-@@ -137,7 +155,7 @@ vcc5v0_usb_otg: vcc5v0-usb-otg-regulator {
+@@ -137,7 +155,7 @@ vcc5v0_usb_otg: regulator-vcc5v0-usb-otg {
  		compatible = "regulator-fixed";
  		regulator-name = "vcc5v0_usb_otg";
  		enable-active-high;
@@ -244,5 +244,5 @@ index 67e7801..192a952 100644
  	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
  	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.14/general-clk-rockchip-rk3568-Add-PLL-rate-for-33.3MHz.patch
+++ b/patch/kernel/archive/rockchip64-6.14/general-clk-rockchip-rk3568-Add-PLL-rate-for-33.3MHz.patch
@@ -1,7 +1,7 @@
-From ca7b6ebfe6f8a718cdb14b3fdc82ad1e5a26b4c9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Vasily Khoruzhick <anarsoul@gmail.com>
 Date: Mon, 17 Mar 2025 22:22:46 -0700
-Subject: [PATCH] clk: rockchip: rk3568: Add PLL rate for 33.3MHz
+Subject: clk: rockchip: rk3568: Add PLL rate for 33.3MHz
 
 Add PLL rate for 33.3 MHz to allow BTT HDMI5 screen to run at its native
 mode of 800x480
@@ -12,7 +12,7 @@ Signed-off-by: Vasily Khoruzhick <anarsoul@gmail.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/clk/rockchip/clk-rk3568.c b/drivers/clk/rockchip/clk-rk3568.c
-index 53d10b1c627b..1c73e18a9862 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/rockchip/clk-rk3568.c
 +++ b/drivers/clk/rockchip/clk-rk3568.c
 @@ -89,6 +89,7 @@ static struct rockchip_pll_rate_table rk3568_pll_rates[] = {
@@ -24,5 +24,5 @@ index 53d10b1c627b..1c73e18a9862 100644
  };
  
 -- 
-2.49.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.14/general-disable-mtu-validation.patch
+++ b/patch/kernel/archive/rockchip64-6.14/general-disable-mtu-validation.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/eth
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -5873,27 +5873,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
+@@ -5878,27 +5878,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
  static int stmmac_change_mtu(struct net_device *dev, int new_mtu)
  {
  	struct stmmac_priv *priv = netdev_priv(dev);

--- a/patch/kernel/archive/rockchip64-6.14/general-pl330-05-fix-unbalanced-power-down.patch
+++ b/patch/kernel/archive/rockchip64-6.14/general-pl330-05-fix-unbalanced-power-down.patch
@@ -67,7 +67,7 @@ diff --git a/drivers/dma/pl330.c b/drivers/dma/pl330.c
 index 111111111111..222222222222 100644
 --- a/drivers/dma/pl330.c
 +++ b/drivers/dma/pl330.c
-@@ -2282,7 +2282,7 @@ static void pl330_tasklet(struct tasklet_struct *t)
+@@ -2274,7 +2274,7 @@ static void pl330_tasklet(struct tasklet_struct *t)
  		spin_lock(&pch->thread->dmac->lock);
  		_stop(pch->thread);
  		spin_unlock(&pch->thread->dmac->lock);

--- a/patch/kernel/archive/rockchip64-6.14/general-pl330-06-fix-buffer-underruns.patch
+++ b/patch/kernel/archive/rockchip64-6.14/general-pl330-06-fix-buffer-underruns.patch
@@ -1,7 +1,7 @@
-From 4acf270a6310f5e2dbadac1d5f21d8e7477fade6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sun, 16 Feb 2025 11:15:55 +0100
-Subject: [PATCH] pl330: fix buffer underrun with cyclic dma
+Subject: pl330: fix buffer underrun with cyclic dma
 
 userspace applications (notably, pulseaudio) were
 suffering frequent buffer underruns when cyclic DMA
@@ -10,11 +10,11 @@ the buffer underruns avoiding to juggle with the
 descriptor state, keeping it in BUSY state as long
 as it is actual transfer is progressing.
 ---
- drivers/dma/pl330.c | 24 ++++++++++++------------
+ drivers/dma/pl330.c | 24 +++++-----
  1 file changed, 12 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/dma/pl330.c b/drivers/dma/pl330.c
-index 208e2a089a4d..6dac00995765 100644
+index 111111111111..222222222222 100644
 --- a/drivers/dma/pl330.c
 +++ b/drivers/dma/pl330.c
 @@ -1737,11 +1737,11 @@ static void dma_pl330_rqcb(struct dma_pl330_desc *desc, enum pl330_op_err err)
@@ -34,7 +34,7 @@ index 208e2a089a4d..6dac00995765 100644
  
  	tasklet_schedule(&pch->task);
  }
-@@ -2256,23 +2256,23 @@ static void pl330_tasklet(struct tasklet_struct *t)
+@@ -2248,23 +2248,23 @@ static void pl330_tasklet(struct tasklet_struct *t)
  
  	/* Pick up ripe tomatoes */
  	list_for_each_entry_safe(desc, _dt, &pch->work_list, node) {
@@ -66,5 +66,5 @@ index 208e2a089a4d..6dac00995765 100644
  
  	/* Try to submit a req imm. next to the last completed cookie */
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.14/rk3308-internal-rgb-lcdc.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3308-internal-rgb-lcdc.patch
@@ -9,12 +9,10 @@ Signed-off-by: TheSnowfield <17957399+TheSnowfield@users.noreply.github.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/gpu/drm/rockchip/rockchip_rgb.c b/drivers/gpu/drm/rockchip/rockchip_rgb.c
-index c677b71ae516..43e9120bbad4 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/rockchip/rockchip_rgb.c
 +++ b/drivers/gpu/drm/rockchip/rockchip_rgb.c
-@@ -6,10 +6,11 @@
-  */
- 
+@@ -8,6 +8,7 @@
  #include <linux/component.h>
  #include <linux/media-bus-format.h>
  #include <linux/of_graph.h>
@@ -22,11 +20,7 @@ index c677b71ae516..43e9120bbad4 100644
  
  #include <drm/display/drm_dp_helper.h>
  #include <drm/drm_atomic_helper.h>
- #include <drm/drm_bridge.h>
- #include <drm/drm_bridge_connector.h>
-@@ -167,10 +168,12 @@ struct rockchip_rgb *rockchip_rgb_init(struct device *dev,
- 		DRM_DEV_ERROR(drm_dev->dev,
- 			      "failed to attach encoder: %d\n", ret);
+@@ -168,6 +169,8 @@ struct rockchip_rgb *rockchip_rgb_init(struct device *dev,
  		goto err_free_connector;
  	}
  
@@ -35,8 +29,6 @@ index c677b71ae516..43e9120bbad4 100644
  	return rgb;
  
  err_free_connector:
- 	drm_connector_cleanup(connector);
- err_free_encoder:
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.14/rk3308-vop-output.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3308-vop-output.patch
@@ -11,12 +11,10 @@ Signed-off-by: TheSnowfield <17957399+TheSnowfield@users.noreply.github.com>
  3 files changed, 272 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-index e6b57ae06934..10b8605631d1 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-@@ -141,10 +141,16 @@ arm-pmu {
- 			     <GIC_SPI 85 IRQ_TYPE_LEVEL_HIGH>,
- 			     <GIC_SPI 86 IRQ_TYPE_LEVEL_HIGH>;
+@@ -143,6 +143,12 @@ arm-pmu {
  		interrupt-affinity = <&cpu0>, <&cpu1>, <&cpu2>, <&cpu3>;
  	};
  
@@ -29,11 +27,7 @@ index e6b57ae06934..10b8605631d1 100644
  	mac_clkin: external-mac-clock {
  		compatible = "fixed-clock";
  		clock-frequency = <50000000>;
- 		clock-output-names = "mac_clkin";
- 		#clock-cells = <0>;
-@@ -685,10 +691,30 @@ dmac1: dma-controller@ff2d0000 {
- 		clocks = <&cru ACLK_DMAC1>;
- 		clock-names = "apb_pclk";
+@@ -687,6 +693,26 @@ dmac1: dma-controller@ff2d0000 {
  		#dma-cells = <1>;
  	};
  
@@ -60,11 +54,7 @@ index e6b57ae06934..10b8605631d1 100644
         i2s_8ch_0: i2s@ff300000 {
  		compatible = "rockchip,rk3308-i2s-tdm";
  		reg = <0x0 0xff300000 0x0 0x1000>;
- 		interrupts = <GIC_SPI 48 IRQ_TYPE_LEVEL_HIGH>;
- 		clocks = <&cru SCLK_I2S0_8CH_TX>, <&cru SCLK_I2S0_8CH_RX>, <&cru HCLK_I2S0_8CH>,
-@@ -2109,7 +2135,91 @@ uart4_rts: uart4-rts {
- 			uart4_rts_pin: uart4-rts-pin {
- 				rockchip,pins =
+@@ -2111,5 +2137,89 @@ uart4_rts_pin: uart4-rts-pin {
  					<4 RK_PA7 0 &pcfg_pull_none>;
  			};
  		};
@@ -155,12 +145,10 @@ index e6b57ae06934..10b8605631d1 100644
  	};
  };
 diff --git a/drivers/gpu/drm/rockchip/rockchip_vop_reg.c b/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
-index 37602d9c2690..17547f375ea0 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
 +++ b/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
-@@ -1184,10 +1184,110 @@ static const struct vop_data rk3328_vop = {
- 	.win = rk3328_vop_win_data,
- 	.win_size = ARRAY_SIZE(rk3328_vop_win_data),
+@@ -1186,6 +1186,106 @@ static const struct vop_data rk3328_vop = {
  	.max_output = { 4096, 2160 },
  };
  
@@ -267,11 +255,7 @@ index 37602d9c2690..17547f375ea0 100644
  static const struct vop_common rv1126_common = {
  	.standby = VOP_REG_SYNC(PX30_SYS_CTRL2, 0x1, 1),
  	.out_mode = VOP_REG(PX30_DSP_CTRL2, 0xf, 16),
- 	.dsp_blank = VOP_REG(PX30_DSP_CTRL2, 0x1, 14),
- 	.dither_down_en = VOP_REG(PX30_DSP_CTRL2, 0x1, 8),
-@@ -1252,10 +1352,12 @@ static const struct of_device_id vop_driver_dt_match[] = {
- 	  .data = &rk3066_vop },
- 	{ .compatible = "rockchip,rk3188-vop",
+@@ -1254,6 +1354,8 @@ static const struct of_device_id vop_driver_dt_match[] = {
  	  .data = &rk3188_vop },
  	{ .compatible = "rockchip,rk3288-vop",
  	  .data = &rk3288_vop },
@@ -280,15 +264,11 @@ index 37602d9c2690..17547f375ea0 100644
  	{ .compatible = "rockchip,rk3368-vop",
  	  .data = &rk3368_vop },
  	{ .compatible = "rockchip,rk3366-vop",
- 	  .data = &rk3366_vop },
- 	{ .compatible = "rockchip,rk3399-vop-big",
 diff --git a/drivers/gpu/drm/rockchip/rockchip_vop_reg.h b/drivers/gpu/drm/rockchip/rockchip_vop_reg.h
-index fbf1bcc68625..5f345dd66dc1 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/rockchip/rockchip_vop_reg.h
 +++ b/drivers/gpu/drm/rockchip/rockchip_vop_reg.h
-@@ -1031,6 +1031,66 @@
- #define RK3066_MCU_BYPASS_RPORT		0x200
- #define RK3066_WIN2_LUT_ADDR		0x400
+@@ -1033,4 +1033,64 @@
  #define RK3066_DSP_LUT_ADDR		0x800
  /* rk3066 register definition end */
  
@@ -354,5 +334,5 @@ index fbf1bcc68625..5f345dd66dc1 100644
 +
  #endif /* _ROCKCHIP_VOP_REG_H */
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-0130-add-hdmi1-support.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-0130-add-hdmi1-support.patch
@@ -161,7 +161,7 @@ index 111111111111..222222222222 100644
  	i2s8_8ch: i2s@fddc8000 {
  		compatible = "rockchip,rk3588-i2s-tdm";
  		reg = <0x0 0xfddc8000 0x0 0x1000>;
-@@ -455,6 +460,22 @@ sata-port@0 {
+@@ -454,6 +459,22 @@ sata-port@0 {
  		};
  	};
  

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-0133-vop2-hdmi1-disp-modes-support.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-0133-vop2-hdmi1-disp-modes-support.patch
@@ -106,7 +106,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi b/arch/arm64/boot/dt
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
-@@ -506,6 +506,7 @@ hdptxphy1: phy@fed70000 {
+@@ -505,6 +505,7 @@ hdptxphy1: phy@fed70000 {
  		reg = <0x0 0xfed70000 0x0 0x2000>;
  		clocks = <&cru CLK_USB2PHY_HDPTXRXPHY_REF>, <&cru PCLK_HDPTX1>;
  		clock-names = "ref", "apb";
@@ -143,7 +143,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi b/arch/arm64/boot/dt
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
-@@ -569,3 +569,24 @@ pcie30phy: phy@fee80000 {
+@@ -568,3 +568,24 @@ pcie30phy: phy@fee80000 {
  		status = "disabled";
  	};
  };

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-0180-drm-bridge-dw-hdmi-qp.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-0180-drm-bridge-dw-hdmi-qp.patch
@@ -1,26 +1,19 @@
-From: Detlev Casanova <detlev.casanova@collabora.com>
-Subject: [PATCH v7 1/3] drm/bridge: synopsys: Add audio support for dw-hdmi-qp
-Date: Mon, 17 Feb 2025 16:47:40 -0500
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: palachzzz <7zzzzzzz@mail.ru>
+Date: Thu, 27 Feb 2025 23:06:51 +0800
+Subject: [ARCHEOLOGY] RK3588 add HDMI sound, add support for OPi5 Max #7884
 
-Register the dw-hdmi-qp bridge driver as an HDMI audio codec.
-
-The register values computation functions (for n) are based on the
-downstream driver, as well as the register writing functions.
-
-The driver uses the generic HDMI Codec framework in order to implement
-the HDMI audio support.
-
-Signed-off-by: Sugar Zhang <sugar.zhang@rock-chips.com>
-Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
-Tested-by: Quentin Schulz <quentin.schulz@cherry.de>
-Reviewed-by: Robert Foss <rfoss@kernel.org>
-Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
+> X-Git-Archeology: - Revision 0b88561ec332114404ff8075ab6bc2419ca66a47: https://github.com/armbian/build/commit/0b88561ec332114404ff8075ab6bc2419ca66a47
+> X-Git-Archeology:   Date: Thu, 27 Feb 2025 23:06:51 +0800
+> X-Git-Archeology:   From: palachzzz <7zzzzzzz@mail.ru>
+> X-Git-Archeology:   Subject: RK3588 add HDMI sound, add support for OPi5 Max #7884
+> X-Git-Archeology:
 ---
- drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c | 489 +++++++++++++++++++
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c | 489 ++++++++++
  1 file changed, 489 insertions(+)
 
 diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
-index b281cabfe992e..7bbe39546163d 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
 +++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
 @@ -36,6 +36,88 @@
@@ -583,4 +576,5 @@ index b281cabfe992e..7bbe39546163d 100644
  	if (ret)
  		return ERR_PTR(ret);
 -- 
-2.48.1
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-0181-arm64-dts-rockchip-extra-sound.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-0181-arm64-dts-rockchip-extra-sound.patch
@@ -1,29 +1,20 @@
-From: Detlev Casanova <detlev.casanova@collabora.com>
-Subject: [PATCH v7 2/3] arm64: dts: rockchip: Add HDMI audio outputs for rk3588 SoC
-Date: Mon, 17 Feb 2025 16:47:41 -0500	[thread overview]
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: palachzzz <7zzzzzzz@mail.ru>
+Date: Thu, 27 Feb 2025 23:06:51 +0800
+Subject: [ARCHEOLOGY] RK3588 add HDMI sound, add support for OPi5 Max #7884
 
-For hdmi0_sound, use the simple-audio-card driver with the hdmi0 QP node
-as CODEC and the i2s5 device as CPU.
-
-Similarly for hdmi1_sound, the CODEC is the hdmi1 node and the CPU is
-i2s6, but only added in the rk3588-extra.dtsi device tree as the second
-TX HDMI port is not available on base versions of the SoC.
-
-The simple-audio-card,mclk-fs value is set to 128 as it is done in
-the downstream driver.
-
-The #sound-dai-cells value is set to 0 in the hdmi0 and hdmi1 nodes so
-that they can be used as audio codec nodes.
-
-Tested-by: Quentin Schulz <quentin.schulz@cherry.de> # RK3588 Tiger Haikou
-Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
+> X-Git-Archeology: - Revision 0b88561ec332114404ff8075ab6bc2419ca66a47: https://github.com/armbian/build/commit/0b88561ec332114404ff8075ab6bc2419ca66a47
+> X-Git-Archeology:   Date: Thu, 27 Feb 2025 23:06:51 +0800
+> X-Git-Archeology:   From: palachzzz <7zzzzzzz@mail.ru>
+> X-Git-Archeology:   Subject: RK3588 add HDMI sound, add support for OPi5 Max #7884
+> X-Git-Archeology:
 ---
- arch/arm64/boot/dts/rockchip/rk3588-base.dtsi  | 17 +++++++++++++++++
- arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi | 17 +++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3588-base.dtsi  | 17 ++++++++++
+ arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi | 17 ++++++++++
  2 files changed, 34 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-index 8cfa30837ce72..f9f888dedd8f0 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 @@ -382,6 +382,22 @@ scmi_reset: protocol@16 {
@@ -49,7 +40,7 @@ index 8cfa30837ce72..f9f888dedd8f0 100644
  	pmu-a55 {
  		compatible = "arm,cortex-a55-pmu";
  		interrupts = <GIC_PPI 7 IRQ_TYPE_LEVEL_HIGH &ppi_partition0>;
-@@ -1394,6 +1410,7 @@ hdmi0: hdmi@fde80000 {
+@@ -1404,6 +1420,7 @@ hdmi0: hdmi@fde80000 {
  		reset-names = "ref", "hdp";
  		rockchip,grf = <&sys_grf>;
  		rockchip,vo-grf = <&vo1_grf>;
@@ -61,10 +52,10 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi b/arch/arm64/boot/dt
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
-@@ -27,6 +27,22 @@ hdmi_receiver_cma: hdmi-receiver-cma {
-               };
-       };
-
+@@ -30,6 +30,22 @@ hdmi_receiver_cma: hdmi-receiver-cma {
+ 		};
+ 	};
+ 
 +	hdmi1_sound: hdmi1-sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,format = "i2s";
@@ -84,7 +75,7 @@ index 111111111111..222222222222 100644
  	usb_host1_xhci: usb@fc400000 {
  		compatible = "rockchip,rk3588-dwc3", "snps,dwc3";
  		reg = <0x0 0xfc400000 0x0 0x400000>;
-@@ -165,6 +181,7 @@ hdmi1: hdmi@fdea0000 {
+@@ -221,6 +237,7 @@ hdmi1: hdmi@fdea0000 {
  		reset-names = "ref", "hdp";
  		rockchip,grf = <&sys_grf>;
  		rockchip,vo-grf = <&vo1_grf>;
@@ -93,4 +84,5 @@ index 111111111111..222222222222 100644
  
  		ports {
 -- 
-2.48.1
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-1010-arm64-dts-rock-5b-Slow-down-emmc-to-hs200-and-add-ts.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-1010-arm64-dts-rock-5b-Slow-down-emmc-to-hs200-and-add-ts.patch
@@ -4,8 +4,8 @@ Date: Wed, 27 Dec 2023 15:03:57 +0800
 Subject: arm64: dts: rock-5b: Slow down emmc freq and add tsadc node
 
 ---
- arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 7 +++++--
- 1 file changed, 5 insertions(+), 2 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
 index 111111111111..222222222222 100644
@@ -19,7 +19,7 @@ index 111111111111..222222222222 100644
  	mmc-hs400-1_8v;
  	mmc-hs400-enhanced-strobe;
  	status = "okay";
-@@ -495,6 +494,10 @@ flash@0 {
+@@ -495,6 +496,10 @@ flash@0 {
  	};
  };
  

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-1011-rock5b-hdmi1.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-1011-rock5b-hdmi1.patch
@@ -67,7 +67,7 @@ index 111111111111..222222222222 100644
  &i2c0 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&i2c0m2_xfer>;
-@@ -894,11 +927,11 @@ &usb_host2_xhci {
+@@ -896,11 +929,11 @@ &usb_host2_xhci {
  	status = "okay";
  };
  
@@ -81,7 +81,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-@@ -908,3 +941,10 @@ vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
+@@ -910,3 +943,10 @@ vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
  		remote-endpoint = <&hdmi0_in_vp0>;
  	};
  };

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-1012-arm64-dts-rockchip-add-hdmi1-support-to-ROCK-5-ITX.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-1012-arm64-dts-rockchip-add-hdmi1-support-to-ROCK-5-ITX.patch
@@ -7,8 +7,8 @@ Enable the HDMI port next to ethernet port.
 
 Signed-off-by: Jianfeng Liu <liujianfeng1994@gmail.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts | 53 ++++++++++
- 1 file changed, 53 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts | 49 ++++++++++
+ 1 file changed, 49 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
 index 111111111111..222222222222 100644
@@ -69,7 +69,7 @@ index 111111111111..222222222222 100644
  &i2c0 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&i2c0m2_xfer>;
-@@ -1209,3 +1247,18 @@ &usbdp_phy1 {
+@@ -1209,3 +1243,18 @@ &usbdp_phy1 {
  	rockchip,dp-lane-mux = <2 3>;
  	status = "okay";
  };

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-1013-arm64-dts-rockchip-disable-emmc-hs400-for-rock-5-itx.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-1013-arm64-dts-rockchip-disable-emmc-hs400-for-rock-5-itx.patch
@@ -11,7 +11,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts b/arch/arm64/boo
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
-@@ -656,10 +656,9 @@ &saradc {
+@@ -724,10 +724,9 @@ &saradc {
  
  &sdhci {
  	bus-width = <8>;

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-1100-arm64-dts-rockchip-opi5-max-add-2nd-hdmi.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-1100-arm64-dts-rockchip-opi5-max-add-2nd-hdmi.patch
@@ -1,10 +1,19 @@
-From: Pavel Novikov <palachzzz.wl@gmail.com>
-Subject: arm64: dts: orange pi 5 max: Add HDMI second port
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: palachzzz <7zzzzzzz@mail.ru>
+Date: Thu, 27 Feb 2025 23:06:51 +0800
+Subject: [ARCHEOLOGY] RK3588 add HDMI sound, add support for OPi5 Max #7884
 
-Adding second HDMI port support for Orange Pi 5 Max
+> X-Git-Archeology: - Revision 0b88561ec332114404ff8075ab6bc2419ca66a47: https://github.com/armbian/build/commit/0b88561ec332114404ff8075ab6bc2419ca66a47
+> X-Git-Archeology:   Date: Thu, 27 Feb 2025 23:06:51 +0800
+> X-Git-Archeology:   From: palachzzz <7zzzzzzz@mail.ru>
+> X-Git-Archeology:   Subject: RK3588 add HDMI sound, add support for OPi5 Max #7884
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts | 42 ++++++++++
+ 1 file changed, 42 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
-index ce44549babf4..0afd4ec8e367 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
 @@ -21,6 +21,17 @@ hdmi0_con_in: endpoint {
@@ -60,3 +69,6 @@ index ce44549babf4..0afd4ec8e367 100644
 +		remote-endpoint = <&hdmi1_in_vp1>;
 +	};
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.14/rk3588-1101-arm64-dts-rockchip-opi5-max-add-hdmi-sound.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3588-1101-arm64-dts-rockchip-opi5-max-add-hdmi-sound.patch
@@ -1,13 +1,22 @@
-From: Pavel Novikov <palachzzz.wl@gmail.com>
-Subject: arm64: dts: orange pi 5 max: Add HDMI sound for both ports
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: palachzzz <7zzzzzzz@mail.ru>
+Date: Thu, 27 Feb 2025 23:06:51 +0800
+Subject: [ARCHEOLOGY] RK3588 add HDMI sound, add support for OPi5 Max #7884
 
-Based on [PATCH v7 3/3] arm64: dts: rockchip: Enable HDMI audio outputs for Rock 5B by Detlev Casanova <detlev.casanova@collabora.com>
+> X-Git-Archeology: - Revision 0b88561ec332114404ff8075ab6bc2419ca66a47: https://github.com/armbian/build/commit/0b88561ec332114404ff8075ab6bc2419ca66a47
+> X-Git-Archeology:   Date: Thu, 27 Feb 2025 23:06:51 +0800
+> X-Git-Archeology:   From: palachzzz <7zzzzzzz@mail.ru>
+> X-Git-Archeology:   Subject: RK3588 add HDMI sound, add support for OPi5 Max #7884
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts | 16 ++++++++++
+ 1 file changed, 16 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
-index ce44549babf4..c8e32488ebe5 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
-@@ -27,6 +27,22 @@ &hdmi0 {
+@@ -38,6 +38,22 @@ &hdmi0 {
  	status = "okay";
  };
  
@@ -30,3 +39,6 @@ index ce44549babf4..c8e32488ebe5 100644
  &hdmi0_in {
  	hdmi0_in_vp0: endpoint {
  		remote-endpoint = <&vp0_out_hdmi0>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.14/rk35xx-montjoie-crypto-v2-rk35xx.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk35xx-montjoie-crypto-v2-rk35xx.patch
@@ -102,7 +102,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-@@ -1931,6 +1931,18 @@ sdhci: mmc@fe2e0000 {
+@@ -1948,6 +1948,18 @@ sdhci: mmc@fe2e0000 {
  		status = "disabled";
  	};
  


### PR DESCRIPTION
#### mainline-kernel: bump 6.14 to -rc7

- rockchip64-6.14: rebase/rewrite patches against -rc4
- mainline-kernel: bump 6.14 to -rc7