### PR TITLE
Fix patching.sh to include untracked (new) files in patch

### DIFF
--- a/lib/functions/compilation/patch/patching.sh
+++ b/lib/functions/compilation/patch/patching.sh
@@ -181,6 +181,7 @@ function userpatch_create() {
 		fi
 
 		display_alert "OK, here's how your diff looks like" "showing patch diff" "info"
+		git add -N .
 		git "${common_git_params[@]}" diff | run_tool_batcat --file-name "${patch}" -
 
 		# Prompt the user if he is happy with the patch


### PR DESCRIPTION
# Description

In patching.sh, execute `git add -N .` before executing `git diff` to present the state of the patch to the user, so that new, untracked files will be included in the diff.

This appears to address the bug raised in Issue #7912.

If adding new files by way of a patch is truly to be discouraged a better solution might be to detect that a new file has been added, produce an error message explaining that new files should not be added via patch and possibly advising what should be done instead. Without this patch, any new files are not included in the patch as presented before the 'Are you happy with this patch?' prompt, but they are included in the produced patch, if the user responds 'yes'. It might be appropriate to prevent this. In any case, this would require a different change to patching.sh.

# How Has This Been Tested?

I ran compile.sh with command uboot-patch, added a new configuration file and observed that the new file was presented in the patch displayed before the 'Are you happy with this patch?' prompt. 

At the prompt I responded 'stop' and observed no errors.

I repeated the test, creating a different new file and observed that only this second new file appeared in the patch. The file added in the previous execution of compile.sh did not remain.

At the prompt I responded 'yes' and observed that the patch file was produced in output/patch, including diff for the new file.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
