### PR TITLE
BSP: make -cli packages provide the armbian-bsp-cli virtual package

### DIFF
--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -269,6 +269,7 @@ function reversion_armbian-bsp-cli_deb_contents() {
 		Depends: bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping, device-tree-compiler${depends_base_files}
 		Replaces: zram-config, armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
 		Breaks: armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
+		Provides: armbian-bsp-cli
 	EOF
 
 	artifact_deb_reversion_unpack_data_deb


### PR DESCRIPTION
# Description

For easier packaging and dependencies in the future, the -bsp-cli- packages should all provide the virtual armbian-bsp-cli package.  This is also a preparation for the rollout of APA.  Frankly, I'm surprised, this isn't yet the case.  It might have been an oversight, since the armbian-bsp-desktop virtual package does exist already.