### PR TITLE
mksklipad50: add DT overlays for edge kernel

### DIFF
--- a/patch/kernel/archive/rockchip64-6.14/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.14/overlay/Makefile
@@ -21,6 +21,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3318-box-wlan-ext.dtbo \
 	rockchip-rk3328-i2c0.dtbo \
 	rockchip-rk3328-i2s1-pcm5102.dtbo \
+	rockchip-rk3328-mksklipad50-enable-rtc-end1.dtbo \
+	rockchip-rk3328-mksklipad50-enable-v4l2.dtbo \
 	rockchip-rk3328-mkspi-disable-lcd-spi.dtbo \
 	rockchip-rk3328-opp-1.4ghz.dtbo \
 	rockchip-rk3328-opp-1.5ghz.dtbo \

--- a/patch/kernel/archive/rockchip64-6.14/overlay/rockchip-rk3328-mksklipad50-enable-rtc-end1.dtso
+++ b/patch/kernel/archive/rockchip64-6.14/overlay/rockchip-rk3328-mksklipad50-enable-rtc-end1.dtso
@@ -1,0 +1,7 @@
+/dts-v1/;
+/plugin/;
+
+// enable end1 ethernet adapter
+&gmac2phy {
+        status = "okay";
+};

--- a/patch/kernel/archive/rockchip64-6.14/overlay/rockchip-rk3328-mksklipad50-enable-v4l2.dtso
+++ b/patch/kernel/archive/rockchip64-6.14/overlay/rockchip-rk3328-mksklipad50-enable-v4l2.dtso
@@ -1,0 +1,18 @@
+/dts-v1/;
+/plugin/;
+
+// disable /dev/video1 + /dev/media0
+&vpu {
+        status = "okay";
+};
+
+// disable /dev/video2 + /dev/media1
+&vdec {
+        status = "okay";
+};
+
+// disable /dev/video0
+&rga {
+        status = "okay";
+};
+


### PR DESCRIPTION
# Description

Add devicetree overlays for enabling end1 network adapter and v4l2 devices on edge kernels.

# How Has This Been Tested?

- [X] Full bookworm-minimal edge build
- [X] Checked resulting image and overlays

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
