### PR TITLE
radxa-zero3: Allow "current" builds, with wifi

### DIFF
--- a/config/boards/radxa-zero3.csc
+++ b/config/boards/radxa-zero3.csc
@@ -3,7 +3,7 @@ BOARD_NAME="Radxa ZERO 3"
 BOARDFAMILY="rk35xx"
 BOARD_MAINTAINER=""
 BOOTCONFIG="radxa-zero3-rk3566_defconfig"
-KERNEL_TARGET="vendor,edge"
+KERNEL_TARGET="vendor,current,edge"
 KERNEL_TEST_TARGET="vendor"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
@@ -12,16 +12,42 @@ IMAGE_PARTITION_TABLE="gpt"
 BOOT_SCENARIO="spl-blobs"
 BOOTFS_TYPE="fat" # Only for vendor/legacy
 
+# technically only needed for 3W
+AIC8800_TYPE="sdio"
+enable_extension "radxa-aic8800"
+
+
+# mainline fdtfile detection is only needed for vendor
+function post_family_config_branch_current__use_mainline_dtb_name() {
+	unset BOOT_FDT_FILE # boot.scr will use whatever u-boot detects and sets 'fdtfile' to
+	unset BOOTFS_TYPE   # mainline u-boot can boot ext4 directly
+}
+
 function post_family_config_branch_edge__use_mainline_dtb_name() {
 	unset BOOT_FDT_FILE # boot.scr will use whatever u-boot detects and sets 'fdtfile' to
 	unset BOOTFS_TYPE   # mainline u-boot can boot ext4 directly
 }
 
 # Override family config for this board; let's avoid conditionals in family config.
-function post_family_config__radxa-zero3_use_vendor_uboot() {
+function post_family_config_branch_vendor__radxa-zero3_use_vendor_uboot() {
 	BOOTSOURCE='https://github.com/radxa/u-boot.git'
 	BOOTBRANCH='branch:rk35xx-2024.01'
 	BOOTPATCHDIR="u-boot-radxa-latest"
+
+	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
+
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd
+
+	function write_uboot_platform() {
+		dd if=$1/u-boot-rockchip.bin of=$2 seek=64 conv=notrunc status=none
+	}
+}
+
+function post_family_config_branch_current__radxa-zero3_use_mainline_uboot() {
+	BOOTCONFIG="radxa-zero-3-rk3566_defconfig"
+	BOOTSOURCE="https://github.com/u-boot/u-boot"
+	BOOTBRANCH="tag:v2025.01"
+	BOOTPATCHDIR="v2025.01"
 
 	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 

--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -10,12 +10,11 @@ function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
 function post_install_kernel_debs__install_aic8800_dkms_package() {
 
-	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.12; then
-		display_alert "Kernel version is too recent" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	if [[ -z $AIC8800_TYPE ]]; then
+		display_alert "AIC8800_TYPE is not set, skipping aic8800 dkms" "${EXTENSION}" "warn"
 		return 0
 	fi
-	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
-	[[ -z $AIC8800_TYPE ]] && return 0
 	api_url="https://api.github.com/repos/radxa-pkg/aic8800/releases/latest"
 	latest_version=$(curl -s "${api_url}" | jq -r '.tag_name')
 	aic8800_firmware_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-firmware_${latest_version}_all.deb"


### PR DESCRIPTION
I tested this with `current` on bookworm, and it works with wifi, and with wayland (not sure if the gpu works, but I'm running a program using the wgpu rust library out-of-the-box on it).

It seems the dtb files got split into zero-3w and zero-3e, and I don't have a 3e to test with, so I wrote a new one for 3w (and left the old one, not sure if anyone uses it, but I'd suggest creating a separate one for 3e, then deleting it).

The upstream aic8800 also works with the latest kernels (up to 6.13), so I removed the kernel version check, and added a warning message when AIC8800_TYPE isn't set, rather than silently failing. That was annoying to debug.

# How Has This Been Tested?

- [x] Ran a build with  ```./compile.sh 
          BOARD=radxa-zero-3w 
          BRANCH=current 
          RELEASE=bookworm 
          BUILD_MINIMAL=yes 
          BUILD_DESKTOP=no 
          KERNEL_CONFIGURE=no```
- [x] Flashed it to my Radxa Zero 3W and had it auto-setup an ssh'able machine over wifi

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
