### PR TITLE
qemu arm64: bump u-boot and fix wrong boot script parameter

### DIFF
--- a/config/bootscripts/boot-qemu-arm64.cmd
+++ b/config/bootscripts/boot-qemu-arm64.cmd
@@ -10,7 +10,7 @@ echo "INITRD LOAD ADDRESS: ramdisk_addr_r: ${ramdisk_addr_r}"
 echo "FDT LOAD ADDRESS   : fdt_addr      : ${fdt_addr}"
 
 # /vmlinuz and /initrd.img are standard Debian symlinks to the "latest installed kernel"
-load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} /vmlinuz
+load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} ${prefix}vmlinuz
 # Attention, this is uInitrd for uboot/ARM; there's a symlink put there by Armbian hooks
 load ${devtype} ${devnum}:${distro_bootpart} ${ramdisk_addr_r} ${prefix}uInitrd
 

--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -46,7 +46,7 @@ if [[ "${QEMU_UBOOT_BOOTCONFIG}" != "" ]]; then
 	declare -g ATF_COMPILE="no"
 
 	declare -g BOOTDIR="qemu-uboot-${LINUXFAMILY}"
-	declare -g BOOTBRANCH='tag:v2023.10'
+	declare -g BOOTBRANCH='tag:v2025.01'
 	declare -g BOOTSOURCE='https://github.com/u-boot/u-boot' # Gotta set this again, it is unset by grub extension
 
 	declare -g BOOTCONFIG="${QEMU_UBOOT_BOOTCONFIG}"


### PR DESCRIPTION
# Description

Now it boots OOB: https://paste.armbian.com/ololipacam

# How Has This Been Tested?

`apt install dnsmasq virtinst qemu-kvm qemu-utils qemu-system`

Host: RK3588 board running CURRENT kernel.

```
qemu-system-aarch64 -machine virt \
-cpu host \
-enable-kvm \
-m 1512 \
-smp 8 \
-netdev user,id=net0 \
-device e1000,netdev=net0 \
-serial stdio \
-bios u-boot.bin \
-drive if=none,file=image.qcow2,id=mydisk \
-device ich9-ahci,id=ahci \
-device ide-hd,drive=mydisk,bus=ahci.0
````

![image](https://github.com/user-attachments/assets/02f79cca-2fd1-45b7-874b-e090fb71c501)


# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
