### PR TITLE
dont fail on no custom/userpatches folder

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -147,7 +147,9 @@ runs:
         # copy os userpatches and custom
         mkdir -pv build/userpatches
         rsync -av os/userpatches/. build/userpatches/
-        [[ -d custom/userpatches ]] && rsync -av custom/userpatches/. build/userpatches/ || true # if that folder doesnt exist, don't fail the build
+        if [[ -d custom/userpatches ]]; then
+          rsync -av custom/userpatches/. build/userpatches/
+        fi
 
     - shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -147,7 +147,7 @@ runs:
         # copy os userpatches and custom
         mkdir -pv build/userpatches
         rsync -av os/userpatches/. build/userpatches/
-        [[ -d custom/userpatches ]] && rsync -av custom/userpatches/. build/userpatches/
+        [[ -d custom/userpatches ]] && rsync -av custom/userpatches/. build/userpatches/ || true # if that folder doesnt exist, don't fail the build
 
     - shell: bash
       run: |


### PR DESCRIPTION
# Description

The recommended action from the readme fails because the check for the custom/userpatches folder fails. This should not fail.
This PR just ignores the exit code of the ```[[ -d custom/userpatches ]]``` check.

# How Has This Been Tested?

https://github.com/ArendJan/mirte_base_images/actions/runs/14069826635/attempts/2 (second attempt as I forgot to turn on write permissions for artifact upload)

Workflow ( https://github.com/ArendJan/mirte_base_images/actions/runs/14069826635/workflow ) uses the recommended workflow from the readme (with push and duplication added).

- fixed uses this branch and the run succeeds
- main uses main branch, but run fails after the rsync command of line https://github.com/ArendJan/build/blob/main/action.yml#L149
Log from the run:
```
...
gha/chunks/950.single_footer.yaml

sent 178,975 bytes  received 784 bytes  359,518.00 bytes/sec
total size is 175,837  speedup is 0.98
Error: Process completed with exit code 1.
```
