### PR TITLE
switch `current` u-boot to v2025.01

### DIFF
--- a/config/boards/rock-3a.conf
+++ b/config/boards/rock-3a.conf
@@ -37,6 +37,28 @@ function post_family_config_branch_edge__rock-3a_use_mainline_uboot() {
 	}
 }
 
+function post_family_config_branch_current__rock-3a_use_mainline_uboot() {
+	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
+	unset BOOTFS_TYPE # fixes armbian-install and unneeded for modern uboot anyway
+	declare -g BOOTCONFIG="rock-3a-rk3568_defconfig"
+	declare -g BOOTDELAY=1
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot"
+	declare -g BOOTBRANCH="tag:v2025.01"
+	declare -g BOOTPATCHDIR="v2025.01"
+	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+
+	function write_uboot_platform_mtd() {
+		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
+	}
+}
+
 function post_family_config__rock3a_uboot_add_sata_target() {
     display_alert "$BOARD" "Configuring ($BOARD) standard and sata uboot target map" "info"
 


### PR DESCRIPTION
# Description

Use  mainline u-boot for `current` on Radxa Rock 3A.
At least for me NVMe/SPI boot is broken for me when using old vendor uboot with `current` kernel.



# How Has This Been Tested?

- [x] build minimal current bookworm
- [x] boot from microsd
- [x] armbian-install to nvme/mtd
- [x] boot from nvme

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Todo:

Maybe it is worth considering using mainline uboot for `current` and `edge` in general for the whole family. Will also eliminate duplicate code introduced with this PR.