### PR TITLE
Add support for MOTD logo colors

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -47,6 +47,7 @@ function do_main_configuration() {
 		unset VENDORSUPPORT,VENDORPRIVACY,VENDORBUGS,VENDORLOGO,ROOTPWD,MAINTAINER,MAINTAINERMAIL
 	fi
 
+	[[ -z $VENDORCOLOR ]] && VENDORCOLOR="247;16;0"                           # RGB values for MOTD logo
 	[[ -z $VENDORURL ]] && VENDORURL="https://duckduckgo.com/"
 	[[ -z $VENDORSUPPORT ]] && VENDORSUPPORT="https://community.armbian.com/"
 	[[ -z $VENDORPRIVACY ]] && VENDORPRIVACY="https://duckduckgo.com/"

--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -119,7 +119,11 @@ if systemctl is-active --quiet service hostapd && [[ -f /etc/hostapd/hostapd.con
 fi
 
 # Display software vendor logo
-echo -e "\e[1;91m$(figlet -f small " ${VENDOR}")\e[0m"
+if [[ -n "${VENDORCOLOR}" ]]; then
+	echo -e "\e[38;2;${VENDORCOLOR}m$(figlet -f small " ${VENDOR}")\e[0m"
+else
+	echo -e "\e[1;91m$(figlet -f small " ${VENDOR}")\e[0m"
+fi
 
 # Read RPI model from cpuinfo
 if [[ ${BOARD:-} == rpi4b ]]; then


### PR DESCRIPTION
# Description

- we might want to have different welcome colors for stable and nightly images
- this adds another branding option alongside with VENDOR, VENDORURL, VENDORSUPPORT, ...

# How Has This Been Tested?

- [x] Manual run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings