### PR TITLE
prepare-host: add squid-deb-proxy-client to host dependencies

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -197,6 +197,7 @@ function adaptative_prepare_host_dependencies() {
 		patchutils pkg-config pv
 		"qemu-user-static" "arch-test"
 		rsync
+		squid-deb-proxy-client
 		swig # swig is needed for some u-boot's. example: "bananapi.conf"
 		u-boot-tools
 		udev # causes initramfs rebuild, but is usually pre-installed.


### PR DESCRIPTION
squid-deb-proxy-client is a small script to transparently detect and use a caching packages proxy in the LAN like apt-cacher-ng. It is incredibly convenient and useful to cut down on unnecessary downloads and speed up the build.
