### PR TITLE
drivers_network: bump rtl8812au for 6.14.y

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -175,12 +175,11 @@ driver_rtl8811_rtl8812_rtl8814_rtl8821() {
 	if linux-version compare "${version}" ge 3.14; then
 
 		# Attach to specific commit (is branch:v5.6.4.2)
-		local rtl8812auver="commit:40ace7013407c147e0c40c9afef908319a99733c" # Commit date: Mar 25, 2025 (please update when updating commit ref)
+		local rtl8812auver="commit:80d4ba5a672f69a4a8b2c4b4dacfe804844e6952" # Commit date: Feb 10, 2025 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8811, 8812, 8814 and 8821 chipsets ${rtl8812auver}" "info"
 
-		fetch_from_repo "$GITHUB_SOURCE/rpardini/aircrack-ng-rtl8812au-kernel-bump-fixes" "rtl8812au" "${rtl8812auver}" "yes" # https://github.com/aircrack-ng/rtl8812au
-
+		fetch_from_repo "$GITHUB_SOURCE/aircrack-ng/rtl8812au" "rtl8812au" "${rtl8812auver}" "yes" # https://github.com/aircrack-ng/rtl8812au
 		cd "$kerneldir" || exit
 
 		# Brief detour. Turns out that HardKernel's vendor odroidxu4 kernel already has this driver

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -175,7 +175,7 @@ driver_rtl8811_rtl8812_rtl8814_rtl8821() {
 	if linux-version compare "${version}" ge 3.14; then
 
 		# Attach to specific commit (is branch:v5.6.4.2)
-		local rtl8812auver="commit:80d4ba5a672f69a4a8b2c4b4dacfe804844e6952" # Commit date: Feb 10, 2025 (please update when updating commit ref)
+		local rtl8812auver="commit:c3fb89a2f7066f4bf4e4d9d85d84f9791f14c83e" # Commit date: Mar 30, 2025 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8811, 8812, 8814 and 8821 chipsets ${rtl8812auver}" "info"
 


### PR DESCRIPTION
#### drivers_network: bump rtl8812au for 6.14.y

- Revert "drivers_network: HACK: bump rtl8812au (forked until PR merged upstream)"
  This reverts commit 6b74df6f2c522f797daaff84e266ba0fed32eb83.
- drivers_network: bump rtl8812au for 6.14.y
  - https://github.com/aircrack-ng/rtl8812au/pull/1226 landed