### PR TITLE
Enable `CONFIG_NETKIT=y` feature for all armbian-kernels => 6.7

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -25,6 +25,15 @@ function armbian_kernel_config__extrawifi_enable_wifi_opts_80211() {
 	fi
 }
 
+function armbian_kernel_config__netkit() {
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.7; then
+		if [[ -f .config ]]; then
+			display_alert "Enable NETKIT=y" "armbian-kernel" "debug"
+			kernel_config_set_y NETKIT
+		fi
+	fi
+}
+
 function armbian_kernel_config__disable_various_options() {
 	kernel_config_modifying_hashes+=("CONFIG_MODULE_COMPRESS_NONE=y" "CONFIG_MODULE_SIG=n" "CONFIG_LOCALVERSION_AUTO=n" "EXPERT=y")
 	if [[ -f .config ]]; then

--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -21,8 +21,6 @@
 #   KERNEL_MAJOR_MINOR            - Current kernel version in major.minor format.
 #   kernel_config_modifying_hashes - Array accumulating configuration changes.
 #
-# Example:
-#   armbian_kernel_config__extrawifi_enable_wifi_opts_80211
 function armbian_kernel_config__extrawifi_enable_wifi_opts_80211() {
 	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.13; then
 		kernel_config_modifying_hashes+=("CONFIG_CFG80211=m" "CONFIG_MAC80211=m" "CONFIG_MAC80211_MESH=y" "CONFIG_CFG80211_WEXT=y")
@@ -45,8 +43,6 @@ function armbian_kernel_config__extrawifi_enable_wifi_opts_80211() {
 # This function checks if the current kernel's version is at least 6.7 and confirms the presence of a .config file.
 # If both conditions are met, it alerts the user about enabling NETKIT and sets the NETKIT option to 'y' in the kernel configuration.
 #
-# Example:
-#   armbian_kernel_config__netkit
 function armbian_kernel_config__netkit() {
 	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.7; then
 		if [[ -f .config ]]; then
@@ -71,8 +67,6 @@ function armbian_kernel_config__netkit() {
 #   It forces EXPERT mode (EXPERT=y) to ensure hidden configurations are visible and applies different module
 #   compression settings based on the kernel version. All modifications are only performed if the .config file exists.
 #
-# Example:
-#   armbian_kernel_config__disable_various_options
 function armbian_kernel_config__disable_various_options() {
 	kernel_config_modifying_hashes+=("CONFIG_MODULE_COMPRESS_NONE=y" "CONFIG_MODULE_SIG=n" "CONFIG_LOCALVERSION_AUTO=n" "EXPERT=y")
 	if [[ -f .config ]]; then
@@ -137,8 +131,6 @@ function armbian_kernel_config__force_pa_va_48_bits_on_arm64() {
 # Returns:
 #   0 on successful configuration application.
 #
-# Example:
-#   armbian_kernel_config__600_enable_ebpf_and_btf_info
 function armbian_kernel_config__600_enable_ebpf_and_btf_info() {
 	declare -A opts_val=()
 	declare -a opts_y=() opts_n=()
@@ -187,8 +179,6 @@ function armbian_kernel_config__600_enable_ebpf_and_btf_info() {
 # Globals:
 #   kernel_config_modifying_hashes - Array used to store configuration changes.
 #
-# Example:
-#   armbian_kernel_config__enable_zram_support
 function armbian_kernel_config__enable_zram_support() {
 	kernel_config_modifying_hashes+=("CONFIG_ZRAM=y")
 	if [[ -f .config ]]; then
@@ -212,9 +202,6 @@ function armbian_kernel_config__enable_zram_support() {
 #   filesystems (e.g., BTRFS, EXT4), control groups (cgroups), networking, security, and various netfilter
 #   components. These settings ensure that the kernel is properly configured to support containerized environments.
 #
-# Example:
-#   To enable Docker support in the kernel configuration, simply call:
-#     armbian_kernel_config__enable_docker_support
 function armbian_kernel_config__enable_docker_support() {
 	kernel_config_modifying_hashes+=("CONFIG_DOCKER=y")
 	if [[ -f .config ]]; then
@@ -359,8 +346,6 @@ function armbian_kernel_config__enable_docker_support() {
 # Globals:
 #   kernel_config_modifying_hashes - Array holding pending kernel configuration changes.
 #
-# Example:
-#   armbian_kernel_config__enable_config_access_in_live_system
 function armbian_kernel_config__enable_config_access_in_live_system() {
 	kernel_config_modifying_hashes+=("CONFIG_IKCONFIG_PROC=y")
 	if [[ -f .config ]]; then

--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -10,7 +10,19 @@
 # Forced .config options for all Armbian kernels.
 # Please note: Manually changing options doesn't check the validity of the .config file. This is done at next make time. Check for warnings in build log.
 
-# This is an internal/core extension.
+# Enables additional wireless configuration options for Wi-Fi drivers on kernels 6.13 and later.
+#
+# This internal function updates the kernel configuration by adding necessary wireless options
+# to a global modification list, and if a .config file exists, it applies these changes directly.
+# It ensures that settings for wireless drivers (e.g. cfg80211 and mac80211) are properly enabled
+# to avoid build errors due to recent kernel updates.
+#
+# Globals:
+#   KERNEL_MAJOR_MINOR            - Current kernel version in major.minor format.
+#   kernel_config_modifying_hashes - Array accumulating configuration changes.
+#
+# Example:
+#   armbian_kernel_config__extrawifi_enable_wifi_opts_80211
 function armbian_kernel_config__extrawifi_enable_wifi_opts_80211() {
 	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.13; then
 		kernel_config_modifying_hashes+=("CONFIG_CFG80211=m" "CONFIG_MAC80211=m" "CONFIG_MAC80211_MESH=y" "CONFIG_CFG80211_WEXT=y")
@@ -25,6 +37,16 @@ function armbian_kernel_config__extrawifi_enable_wifi_opts_80211() {
 	fi
 }
 
+# Enables the NETKIT kernel configuration option for kernels version 6.7 and above.
+#
+# Globals:
+#   KERNEL_MAJOR_MINOR - The kernel version string used to verify the minimum required version.
+#
+# This function checks if the current kernel's version is at least 6.7 and confirms the presence of a .config file.
+# If both conditions are met, it alerts the user about enabling NETKIT and sets the NETKIT option to 'y' in the kernel configuration.
+#
+# Example:
+#   armbian_kernel_config__netkit
 function armbian_kernel_config__netkit() {
 	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.7; then
 		if [[ -f .config ]]; then
@@ -34,6 +56,23 @@ function armbian_kernel_config__netkit() {
 	fi
 }
 
+# Disables various kernel configuration options that conflict with Armbian's kernel build requirements.
+#
+# Globals:
+#   kernel_config_modifying_hashes - Array tracking the configuration option changes.
+#   KERNEL_MAJOR_MINOR            - Kernel version used to apply version-specific configuration updates.
+#
+# Outputs:
+#   Displays alerts to notify about the configuration changes being applied.
+#
+# Description:
+#   This function disables several kernel configuration options such as module compression, module signing,
+#   and automatic versioning to speed up the build process and ensure compatibility with Armbian requirements.
+#   It forces EXPERT mode (EXPERT=y) to ensure hidden configurations are visible and applies different module
+#   compression settings based on the kernel version. All modifications are only performed if the .config file exists.
+#
+# Example:
+#   armbian_kernel_config__disable_various_options
 function armbian_kernel_config__disable_various_options() {
 	kernel_config_modifying_hashes+=("CONFIG_MODULE_COMPRESS_NONE=y" "CONFIG_MODULE_SIG=n" "CONFIG_LOCALVERSION_AUTO=n" "EXPERT=y")
 	if [[ -f .config ]]; then


### PR DESCRIPTION
# Description

Set this feature armbian global, instead of per rockchip only https://github.com/armbian/build/pull/8030

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
