### PR TITLE
khadas-vim3: u-boot: bump to `2025.04-rc5`; boot SD first; enable `setexpr`; patch 2025.04 for `fileenv`; enable `squashfs` support

### DIFF
--- a/config/boards/khadas-vim3.conf
+++ b/config/boards/khadas-vim3.conf
@@ -12,8 +12,8 @@ BOOT_LOGO="desktop"
 BOOT_FDT_FILE="amlogic/meson-g12b-a311d-khadas-vim3.dtb" # there is also a s922x dtb, but vim3 is a311d only
 ASOUND_STATE="asound.state.khadas-vim3"
 
-BOOTBRANCH_BOARD="tag:v2024.01"
-BOOTPATCHDIR="v2024.01" # this has 'board_khadas-vim3' which has a patch to boot USB/NVMe/SCSI first
+BOOTBRANCH_BOARD="tag:v2025.04-rc5"
+BOOTPATCHDIR="v2025.04" # this has 'board_khadas-vim3' which has a patch to boot USB/NVMe/SCSI first
 
 declare -g KHADAS_OOWOW_BOARD_ID="VIM3" # for use with EXT=output-image-oowow
 
@@ -53,6 +53,12 @@ function post_config_uboot_target__extra_configs_for_khadas_vim3() {
 	display_alert "u-boot for ${BOARD}" "u-boot: enable gpio LED support" "info"
 	run_host_command_logged scripts/config --enable CONFIG_LED
 	run_host_command_logged scripts/config --enable CONFIG_LED_GPIO
+	display_alert "u-boot for ${BOARD}" "u-boot: enable more cmdline commands" "info" # for extra compat with eg HAOS
+	run_host_command_logged scripts/config --enable CONFIG_CMD_SQUASHFS
+	run_host_command_logged scripts/config --enable CONFIG_CMD_SETEXPR
+	run_host_command_logged scripts/config --enable CONFIG_CMD_FILEENV # added via cmd-fileenv-read-string-from-file-into-env.patch
+	run_host_command_logged scripts/config --enable CONFIG_CMD_CAT
+	run_host_command_logged scripts/config --enable CONFIG_CMD_XXD
 	display_alert "u-boot for ${BOARD}" "u-boot: enable networking cmds" "info"
 	run_host_command_logged scripts/config --enable CONFIG_CMD_NFS
 	run_host_command_logged scripts/config --enable CONFIG_CMD_WGET

--- a/patch/u-boot/v2025.04/board_khadas-vim3/meson64-boot-usb-nvme-scsi-first.patch
+++ b/patch/u-boot/v2025.04/board_khadas-vim3/meson64-boot-usb-nvme-scsi-first.patch
@@ -1,32 +1,29 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Sun, 14 Jan 2024 13:44:58 +0100
-Subject: meson64: change `BOOT_TARGET_DEVICES` to try to boot USB, NVME and
- SCSI before SD, MMC, PXE, DHCP
+Subject: meson64: boot order: SD -> USB -> NVMe -> eMMC
 
 ---
- include/configs/meson64.h | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ include/configs/meson64.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/include/configs/meson64.h b/include/configs/meson64.h
-index efab9a624dc5..32c25098e674 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/meson64.h
 +++ b/include/configs/meson64.h
-@@ -99,12 +99,12 @@
+@@ -119,10 +119,12 @@
  #define BOOT_TARGET_DEVICES(func) \
  	func(ROMUSB, romusb, na)  \
  	func(USB_DFU, usbdfu, na)  \
--	func(MMC, mmc, 0) \
--	func(MMC, mmc, 1) \
--	func(MMC, mmc, 2) \
+-	BOOT_TARGET_MMC(func) \
++	func(MMC, mmc, 0) \
++	func(MMC, mmc, 1) \
  	BOOT_TARGET_DEVICES_USB(func) \
  	BOOT_TARGET_NVME(func) \
  	BOOT_TARGET_SCSI(func) \
-+	func(MMC, mmc, 0) \
-+	func(MMC, mmc, 1) \
 +	func(MMC, mmc, 2) \
- 	func(PXE, pxe, na) \
- 	func(DHCP, dhcp, na)
+ 	BOOT_TARGET_PXE(func) \
+ 	BOOT_TARGET_DHCP(func)
  #endif
 -- 
 Armbian

--- a/patch/u-boot/v2025.04/cmd-fileenv-read-string-from-file-into-env.patch
+++ b/patch/u-boot/v2025.04/cmd-fileenv-read-string-from-file-into-env.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Fri, 31 Jan 2025 15:52:03 +0100
+Subject: cmd: fileenv: read string from file into env
+
+- rpardini: adapted from vendor/legacy patch from 2018
+
+Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ cmd/Kconfig   |  5 +
+ cmd/Makefile  |  1 +
+ cmd/fileenv.c | 46 ++++++++++
+ 3 files changed, 52 insertions(+)
+
+diff --git a/cmd/Kconfig b/cmd/Kconfig
+index 111111111111..222222222222 100644
+--- a/cmd/Kconfig
++++ b/cmd/Kconfig
+@@ -1825,6 +1825,11 @@ config CMD_XXD
+ 	help
+ 	  Print file as hexdump to standard output
+ 
++config CMD_FILEENV
++	bool "fileenv"
++	help
++	   Read a file into memory and store it to env.
++
+ endmenu
+ 
+ if NET || NET_LWIP
+diff --git a/cmd/Makefile b/cmd/Makefile
+index 111111111111..222222222222 100644
+--- a/cmd/Makefile
++++ b/cmd/Makefile
+@@ -173,6 +173,7 @@ obj-$(CONFIG_CMD_SHA1SUM) += sha1sum.o
+ obj-$(CONFIG_CMD_SEAMA) += seama.o
+ obj-$(CONFIG_CMD_SETEXPR) += setexpr.o
+ obj-$(CONFIG_CMD_SETEXPR_FMT) += printf.o
++obj-$(CONFIG_CMD_FILEENV) += fileenv.o
+ obj-$(CONFIG_CMD_SPI) += spi.o
+ obj-$(CONFIG_CMD_STRINGS) += strings.o
+ obj-$(CONFIG_CMD_SMBIOS) += smbios.o
+diff --git a/cmd/fileenv.c b/cmd/fileenv.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/cmd/fileenv.c
+@@ -0,0 +1,46 @@
++#include <config.h>
++#include <command.h>
++#include <fs.h>
++#include <linux/ctype.h>
++#include <vsprintf.h>
++
++static char *fs_argv[5];
++
++int do_fileenv(struct cmd_tbl *cmdtp, int flag, int argc, char * const argv[])
++{
++	if (argc < 6)
++		return CMD_RET_USAGE;
++
++	fs_argv[0] = "fatload";
++	fs_argv[1] = argv[1];
++	fs_argv[2] = argv[2];
++	fs_argv[3] = argv[3];
++	fs_argv[4] = argv[4];
++
++	if (do_fat_fsload(cmdtp, 0, 5, fs_argv) != 0)
++		return 1;
++
++	char *addr = (char *)simple_strtoul(argv[3], NULL, 16);
++	size_t size = env_get_hex("filesize", 0);
++
++	// Prepare string
++	addr[size] = 0x00;
++	char *s = addr;
++	while(*s != 0x00) {
++		if (isprint(*s)) {
++			s++;
++		}
++		else {
++			*s = 0x00;
++		}
++	}
++
++	return env_set(argv[5], addr);
++}
++
++U_BOOT_CMD(
++	fileenv, 6, 0, do_fileenv,
++	"Read file and store it into env.",
++	"<interface> <dev:part> <addr> <filename> <envname>\n"
++	"    - Read file from fat32 and store it as env."
++);
+-- 
+Armbian
+


### PR DESCRIPTION
- **CHANGE**: This version tries to boot SD first (thus SD -> USB -> NVMe -> eMMC); before it would boot USB before SD
- as Armbian u-boot is possibly deployed to SPI, try to make as compatible as possible; eg enable squashfs support
- enable `setexpr` and `fileenv`, used by HAOS
  - HAOS already has support for booting VIM3 from NVMe: https://github.com/home-assistant/operating-system/pull/3784
- borrowed `fileenv` patch from v2025.01 to .04
- Similar treatment that `odroidm1` got in https://github.com/armbian/build/pull/7769
- note: I will be leaving my VIM3 behind in the other side of the globe, so this is my last chance to test