### PR TITLE
nanopi-r3s, radxa-zero3, rock-3a: board config cleanup & maint

### DIFF
--- a/config/boards/nanopi-r3s.csc
+++ b/config/boards/nanopi-r3s.csc
@@ -19,8 +19,8 @@ function post_family_config__use_mainline_uboot() {
 	unset BOOTFS_TYPE   # mainline u-boot can boot ext4 directly
 	BOOTCONFIG="nanopi-r3s-rk3566_defconfig"
 	BOOTSOURCE="https://github.com/u-boot/u-boot"
-	BOOTBRANCH="tag:v2024.10"
-	BOOTPATCHDIR="v2024.10"
+	BOOTBRANCH="tag:v2025.01"
+	BOOTPATCHDIR="v2025.01"
 
 	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 

--- a/config/boards/nanopi-r3s.csc
+++ b/config/boards/nanopi-r3s.csc
@@ -11,37 +11,16 @@ IMAGE_PARTITION_TABLE="gpt"
 BOOT_SCENARIO="spl-blobs"
 
 
-function post_family_config_branch_edge__use_mainline_dtb_name() {
+function post_family_config__use_mainline_uboot() {
+	if [[ "$BRANCH" != "current" && "$BRANCH" != "edge" ]]; then
+    	return 0
+	fi
 	unset BOOT_FDT_FILE # boot.scr will use whatever u-boot detects and sets 'fdtfile' to
 	unset BOOTFS_TYPE   # mainline u-boot can boot ext4 directly
-}
-
-function post_family_config_branch_current__use_mainline_dtb_name() {
-	unset BOOT_FDT_FILE # boot.scr will use whatever u-boot detects and sets 'fdtfile' to
-	unset BOOTFS_TYPE   # mainline u-boot can boot ext4 directly
-}
-
-
-function post_family_config_branch_current__nanopi-r3s_use_mainline_uboot() {
 	BOOTCONFIG="nanopi-r3s-rk3566_defconfig"
 	BOOTSOURCE="https://github.com/u-boot/u-boot"
 	BOOTBRANCH="tag:v2024.10"
 	BOOTPATCHDIR="v2024.10"
-
-	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
-
-	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd
-
-	function write_uboot_platform() {
-		dd if=$1/u-boot-rockchip.bin of=$2 seek=64 conv=notrunc status=none
-	}
-}
-
-function post_family_config_branch_edge__nanopi-r3s_use_mainline_uboot() {
-	BOOTCONFIG="nanopi-r3s-rk3566_defconfig"
-	BOOTSOURCE="https://github.com/u-boot/u-boot"
-	BOOTBRANCH="tag:v2025.01"
-	BOOTPATCHDIR="v2025.01"
 
 	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 

--- a/config/boards/radxa-zero3.csc
+++ b/config/boards/radxa-zero3.csc
@@ -12,16 +12,17 @@ IMAGE_PARTITION_TABLE="gpt"
 BOOT_SCENARIO="spl-blobs"
 BOOTFS_TYPE="fat" # Only for vendor/legacy
 
-function post_family_config_branch_edge__use_mainline_dtb_name() {
+function post_family_config__use_mainline_uboot_except_vendor() {
+	# use mainline u-boot for _current_ and _edge_
+	if [[ "$BRANCH" != "current" && "$BRANCH" != "edge" ]]; then
+    	return 0
+	fi
 	unset BOOT_FDT_FILE # boot.scr will use whatever u-boot detects and sets 'fdtfile' to
 	unset BOOTFS_TYPE   # mainline u-boot can boot ext4 directly
-}
-
-# Override family config for this board; let's avoid conditionals in family config.
-function post_family_config__radxa-zero3_use_vendor_uboot() {
-	BOOTSOURCE='https://github.com/radxa/u-boot.git'
-	BOOTBRANCH='branch:rk35xx-2024.01'
-	BOOTPATCHDIR="u-boot-radxa-latest"
+	BOOTCONFIG="radxa-zero-3-rk3566_defconfig"
+	BOOTSOURCE="https://github.com/u-boot/u-boot"
+	BOOTBRANCH="tag:v2024.10"
+	BOOTPATCHDIR="v2024.10"
 
 	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 
@@ -32,11 +33,11 @@ function post_family_config__radxa-zero3_use_vendor_uboot() {
 	}
 }
 
-function post_family_config_branch_edge__radxa-zero3_use_mainline_uboot() {
-	BOOTCONFIG="radxa-zero-3-rk3566_defconfig"
-	BOOTSOURCE="https://github.com/u-boot/u-boot"
-	BOOTBRANCH="tag:v2024.10"
-	BOOTPATCHDIR="v2024.10"
+# Override family config for this board; let's avoid conditionals in family config.
+function post_family_config_branch_vendor__radxa-zero3_use_vendor_uboot() {
+	BOOTSOURCE='https://github.com/radxa/u-boot.git'
+	BOOTBRANCH='branch:rk35xx-2024.01'
+	BOOTPATCHDIR="u-boot-radxa-latest"
 
 	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 

--- a/config/boards/radxa-zero3.csc
+++ b/config/boards/radxa-zero3.csc
@@ -21,8 +21,8 @@ function post_family_config__use_mainline_uboot_except_vendor() {
 	unset BOOTFS_TYPE   # mainline u-boot can boot ext4 directly
 	BOOTCONFIG="radxa-zero-3-rk3566_defconfig"
 	BOOTSOURCE="https://github.com/u-boot/u-boot"
-	BOOTBRANCH="tag:v2024.10"
-	BOOTPATCHDIR="v2024.10"
+	BOOTBRANCH="tag:v2025.01"
+	BOOTPATCHDIR="v2025.01"
 
 	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 

--- a/config/boards/rock-3a.conf
+++ b/config/boards/rock-3a.conf
@@ -5,7 +5,7 @@ BOARD_MAINTAINER="ZazaBR amazingfate catalinii vamzii"
 BOOTCONFIG="rock-3a-rk3568_defconfig"
 BOOTCONFIG_SATA="rock-3a-sata-rk3568_defconfig"
 KERNEL_TARGET="current,edge,vendor"
-KERNEL_TEST_TARGET="current"
+KERNEL_TEST_TARGET="current,vendor"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3568-rock-3a.dtb"
@@ -15,29 +15,12 @@ BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 BOOTFS_TYPE="fat"
 
-function post_family_config_branch_edge__rock-3a_use_mainline_uboot() {
-	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
-	unset BOOTFS_TYPE # fixes armbian-install and unneeded for modern uboot anyway
-	declare -g BOOTCONFIG="rock-3a-rk3568_defconfig"
-	declare -g BOOTDELAY=1
-	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot"
-	declare -g BOOTBRANCH="tag:v2025.01"
-	declare -g BOOTPATCHDIR="v2025.01"
-	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
-	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
-	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+function post_family_config__rock-3a_use_mainline_uboot_except_vendor() {
+	# use mainline uboot for _current_ and _edge_
+	if [[ "$BRANCH" != "current" && "$BRANCH" != "edge" ]]; then
+		return 0
+	fi
 
-	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
-	function write_uboot_platform() {
-		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
-	}
-
-	function write_uboot_platform_mtd() {
-		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
-	}
-}
-
-function post_family_config_branch_current__rock-3a_use_mainline_uboot() {
 	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
 	unset BOOTFS_TYPE # fixes armbian-install and unneeded for modern uboot anyway
 	declare -g BOOTCONFIG="rock-3a-rk3568_defconfig"
@@ -68,7 +51,6 @@ function post_family_config__rock3a_uboot_add_sata_target() {
 }
 
 function post_uboot_custom_postprocess__create_sata_spi_image() {
-
 	display_alert "$BOARD" "Create rkspi_loader_sata.img" "info"
 
 	dd if=/dev/zero of=rkspi_loader_sata.img bs=1M count=0 seek=16

--- a/config/boards/rock-3a.conf
+++ b/config/boards/rock-3a.conf
@@ -5,7 +5,7 @@ BOARD_MAINTAINER="ZazaBR amazingfate catalinii vamzii"
 BOOTCONFIG="rock-3a-rk3568_defconfig"
 BOOTCONFIG_SATA="rock-3a-sata-rk3568_defconfig"
 KERNEL_TARGET="current,edge,vendor"
-KERNEL_TEST_TARGET="current,vendor"
+KERNEL_TEST_TARGET="current"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3568-rock-3a.dtb"
@@ -15,12 +15,29 @@ BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 BOOTFS_TYPE="fat"
 
-function post_family_config__rock-3a_use_mainline_uboot_except_vendor() {
-	# use mainline uboot for _current_ and _edge_
-	if [[ "$BRANCH" != "current" && "$BRANCH" != "edge" ]]; then
-		return 0
-	fi
+function post_family_config_branch_edge__rock-3a_use_mainline_uboot() {
+	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
+	unset BOOTFS_TYPE # fixes armbian-install and unneeded for modern uboot anyway
+	declare -g BOOTCONFIG="rock-3a-rk3568_defconfig"
+	declare -g BOOTDELAY=1
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot"
+	declare -g BOOTBRANCH="tag:v2025.01"
+	declare -g BOOTPATCHDIR="v2025.01"
+	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
 
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+
+	function write_uboot_platform_mtd() {
+		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
+	}
+}
+
+function post_family_config_branch_current__rock-3a_use_mainline_uboot() {
 	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
 	unset BOOTFS_TYPE # fixes armbian-install and unneeded for modern uboot anyway
 	declare -g BOOTCONFIG="rock-3a-rk3568_defconfig"
@@ -51,6 +68,7 @@ function post_family_config__rock3a_uboot_add_sata_target() {
 }
 
 function post_uboot_custom_postprocess__create_sata_spi_image() {
+
 	display_alert "$BOARD" "Create rkspi_loader_sata.img" "info"
 
 	dd if=/dev/zero of=rkspi_loader_sata.img bs=1M count=0 seek=16

--- a/config/boards/rock-3a.conf
+++ b/config/boards/rock-3a.conf
@@ -15,7 +15,12 @@ BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 BOOTFS_TYPE="fat"
 
-function post_family_config__rock-3a_use_mainline_uboot_except_vendor() {
+function post_family_config__rock-3a_use_mainline_uboot_except_vendor_and_add_sata_target() {
+	display_alert "$BOARD" "Configuring ($BOARD) standard and sata uboot target map" "info"
+	UBOOT_TARGET_MAP="
+	BL31=$RKBIN_DIR/$BL31_BLOB $BOOTCONFIG spl/u-boot-spl.bin u-boot.dtb u-boot.itb;;idbloader.img u-boot.itb rkspi_loader.img
+	BL31=$RKBIN_DIR/$BL31_BLOB $BOOTCONFIG_SATA spl/u-boot-spl.bin u-boot.dtb u-boot.itb;; rkspi_loader_sata.img"
+	
 	# use mainline uboot for _current_ and _edge_
 	if [[ "$BRANCH" != "current" && "$BRANCH" != "edge" ]]; then
 		return 0
@@ -40,14 +45,6 @@ function post_family_config__rock-3a_use_mainline_uboot_except_vendor() {
 	function write_uboot_platform_mtd() {
 		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
 	}
-}
-
-function post_family_config__rock3a_uboot_add_sata_target() {
-    display_alert "$BOARD" "Configuring ($BOARD) standard and sata uboot target map" "info"
-
-	UBOOT_TARGET_MAP="
-	BL31=$RKBIN_DIR/$BL31_BLOB $BOOTCONFIG spl/u-boot-spl.bin u-boot.dtb u-boot.itb;;idbloader.img u-boot.itb rkspi_loader.img
-	BL31=$RKBIN_DIR/$BL31_BLOB $BOOTCONFIG_SATA spl/u-boot-spl.bin u-boot.dtb u-boot.itb;; rkspi_loader_sata.img"
 }
 
 function post_uboot_custom_postprocess__create_sata_spi_image() {


### PR DESCRIPTION
# Description

nanopi-r3s, radxa-zero3, rock-3a: 
- remove duplicate code by putting behind `if` statement as suggested by Ricardo.
- Bump uboot to latest mainline

Ignore the two "Revert" commits, they cancel each other out.

# How Has This Been Tested?

- [x] build `vendor`, `current` and `edge` for rock-3a and radxa-zero3
- [x] boot overall good enough, results below in the comments
- [x] build `current` and `edge` for nanopi-r3s
- [x] boot nanopi-r3s, comment below

**All test images: http://fi.mirror.armbian.de/.testing/maint/**

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
