### PR TITLE
Cloud / QCOW2: set basic image size to 16Gb for all cloud images

### DIFF
--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -26,6 +26,7 @@ case "${BRANCH}" in
 		declare -g INSTALL_ARMBIAN_FIRMWARE="no"
 		declare -g EXTRAWIFI="no"
 		declare -g UEFI_GRUB_TIMEOUT=0
+		declare -g QCOW2_RESIZE_AMOUNT="16G"
 		;;
 
 	legacy)


### PR DESCRIPTION
# Description

Cloud QCOW2 images are as small as they can be, but file-system could should be larger for start

This adds fixed +16Gb of resize, which doesn't make image any bigger, but when importing this as is, it might be better to not start without any free space. Now its 16Gb - cca. 600Mb.

# How Has This Been Tested?

- [x] Generated and booted image

# Checklist:

- [x] My changes generate no new warnings