### PR TITLE
radxa-zero3: enable wifi extension by default

### DIFF
--- a/config/boards/radxa-zero3.csc
+++ b/config/boards/radxa-zero3.csc
@@ -3,7 +3,7 @@ BOARD_NAME="Radxa ZERO 3"
 BOARDFAMILY="rk35xx"
 BOARD_MAINTAINER=""
 BOOTCONFIG="radxa-zero3-rk3566_defconfig"
-KERNEL_TARGET="vendor,edge"
+KERNEL_TARGET="vendor,current,edge"
 KERNEL_TEST_TARGET="vendor"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
@@ -11,6 +11,10 @@ BOOT_FDT_FILE="rockchip/rk3566-radxa-zero3.dtb"
 IMAGE_PARTITION_TABLE="gpt"
 BOOT_SCENARIO="spl-blobs"
 BOOTFS_TYPE="fat" # Only for vendor/legacy
+
+
+AIC8800_TYPE="sdio"
+enable_extension "radxa-aic8800"
 
 function post_family_config__use_mainline_uboot_except_vendor() {
 	# use mainline u-boot for _current_ and _edge_

--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -10,7 +10,7 @@ function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
 function post_install_kernel_debs__install_aic8800_dkms_package() {
 
-	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.12; then
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.15; then
 		display_alert "Kernel version is too recent" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi


### PR DESCRIPTION
# Description

Supersedes https://github.com/armbian/build/pull/7992

- enable `current` builds (was working before already but not officially)
- enable the wifi extension by default so 3W model wifi should work oob. Should not bother 3E besides...
- ... increased image size by roughly 70MB

# How Has This Been Tested?

- [x] building `vendor`, `current` and `edge`
https://paste.next.armbian.com/ifitazikis https://paste.next.armbian.com/izalofobiy https://paste.next.armbian.com/iwaboqozuf
- [ ] none yet, also I have 3E on hand only

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
