### PR TITLE
Add configurable EFI partition alignment to support UFS devices

### DIFF
--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -89,6 +89,7 @@ function prepare_partitions() {
 
 	# default BOOTSIZE to use if not specified
 	DEFAULT_BOOTSIZE=256 # MiB
+	SECTOR_SIZE=${SECTOR_SIZE:-512}
 	# size of UEFI partition. 0 for no UEFI. Don't mix UEFISIZE>0 and BOOTSIZE>0
 	UEFISIZE=${UEFISIZE:-0}
 	BIOSSIZE=${BIOSSIZE:-0}
@@ -242,7 +243,16 @@ function prepare_partitions() {
 		)
 		# Output the partitioning options from above to the debug log first and then pipe it into the 'sfdisk' command
 		display_alert "Partitioning with the following options" "$partition_script_output" "debug"
-		echo "${partition_script_output}" | run_host_command_logged sfdisk "${SDCARD}".raw || exit_with_error "Partitioning failed!"
+
+		# Check sfdisk version to determine if --sector-size is supported
+		sfdisk_version=$(sfdisk --version | awk '/util-linux/ {print $NF}')
+		sfdisk_version_num=$(echo "$sfdisk_version" | awk -F. '{printf "%d%02d%02d\n", $1, $2, $3}')
+		if [ "$sfdisk_version_num" -ge "24100" ]; then
+			echo "${partition_script_output}" | run_host_command_logged sfdisk --sector-size "$SECTOR_SIZE" "${SDCARD}".raw || exit_with_error "Partitioning failed!"
+		else
+			echo "${partition_script_output}" | run_host_command_logged sfdisk "${SDCARD}".raw || exit_with_error "Partitioning failed!"
+		fi
+
 	fi
 	
 	call_extension_method "post_create_partitions" <<- 'POST_CREATE_PARTITIONS'
@@ -256,7 +266,11 @@ function prepare_partitions() {
 
 	declare -g LOOP
 	#--partscan is using to force the kernel for scaning partition table in preventing of partprobe errors
-	LOOP=$(losetup --show --partscan --find "${SDCARD}".raw) || exit_with_error "Unable to find free loop device"
+	if [ "$sfdisk_version_num" -ge "24100" ]; then
+		LOOP=$(losetup --show --partscan --find -b "$SECTOR_SIZE" "${SDCARD}".raw) || exit_with_error "Unable to find free loop device"
+	else
+		LOOP=$(losetup --show --partscan --find "${SDCARD}".raw) || exit_with_error "Unable to find free loop device"
+	fi
 	display_alert "Allocated loop device" "LOOP=${LOOP}"
 
 	# loop device was grabbed here, unlock


### PR DESCRIPTION
# Description

Default EFI partition uses 512B alignment, which fails on Qualcomm UFS (4K-aligned) devices. This change introduces a variable to optionally enforce 4K alignment while maintaining backward compatibility.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] No variables set, correctly generated 512 alignment
- [x] Set variables to correctly generate 4096 alignment

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
