### PR TITLE
We need to escape $ otherwise this will be executed on host

### DIFF
--- a/config/boards/bananapim4berry.csc
+++ b/config/boards/bananapim4berry.csc
@@ -25,7 +25,7 @@ function post_family_tweaks_bsp__bananapi_module_conf() {
 		#
 		# To see all options that are available:
 		#
-		# for f in /sys/module/8821cu/parameters/*;do echo "$(basename $f): $(sudo cat $f)";done
+		# for f in /sys/module/8821cu/parameters/*;do echo "\$(basename \$f): \$(sudo cat \$f)";done
 		#
 		blacklist rtw88_8821cu
 		#


### PR DESCRIPTION
# Description

Fixing:

```
--> (11) INFO: bananapim4berry [ Configuring rlt8821cu wifi module ]
--> (11) ERROR: Error  1 occurred in SUBSHELL [ SUBSHELL at /armbian/config/boards/bananapim4berry.csc:23 ]
--> (11) ERROR: Error  127 occurred in SUBSHELL [ SUBSHELL at /armbian/config/boards/bananapim4berry.csc:23 ]
--> (11) COMMAND: cat /armbian/.tmp/work-no-uuidgen-yet-2663-8482/deb-bsp-cli-Y84qB/DEBIAN/preinst
--> (11) COMMAND: cat /armbian/.tmp/work-no-uuidgen-yet-2663-8482/deb-bsp-cli-Y84qB/DEBIAN/postrm
--> (11) COMMAND: cat /armbian/.tmp/work-no-uuidgen-yet-2663-8482/deb-bsp-cli-Y84qB/DEBIAN/postinst
```

# Checklist:

- [x] My changes generate no new warnings