### PR TITLE
station-m3: delete the redundant function.

### DIFF
--- a/config/boards/station-m3.csc
+++ b/config/boards/station-m3.csc
@@ -12,14 +12,6 @@ BOOT_SOC="rk3588"
 IMAGE_PARTITION_TABLE="gpt"
 declare -g UEFI_EDK2_BOARD_ID="station-m3" # This _only_ used for uefi-edk2-rk3588 extension
 
-function post_family_tweaks__station_m3() {
-	display_alert "$BOARD" "Installing board tweaks" "info"
-
-	cp -R $SRC/packages/blobs/rtl8723bt_fw/* $SDCARD/lib/firmware/rtl_bt/
-	cp -R $SRC/packages/blobs/station/firmware/* $SDCARD/lib/firmware/
-	return 0
-}
-
 function post_family_tweaks__station-m3_naming_audios() {
 	display_alert "$BOARD" "Renaming station-m3 audios" "info"
 


### PR DESCRIPTION
# Description

Station-m3 uses the 8821CU, and the firmware is already included in armbian-firmware:

https://github.com/armbian/firmware/blob/master/rtl_bt/rtl8821c_config.bin

https://github.com/armbian/firmware/blob/master/rtl_bt/rtl8821c_fw.bin

Moreover, the 8821CU firmware is not present in the following folders, so this function has been removed.

https://github.com/armbian/build/tree/main/packages/blobs/station/firmware/rtlbt

# How Has This Been Tested?

- [x] WiFi
- [x] Bluetooth

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
