### PR TITLE
radxa-zero3: bump mainline uboot

### DIFF
--- a/config/boards/radxa-zero3.csc
+++ b/config/boards/radxa-zero3.csc
@@ -25,8 +25,8 @@ function post_family_config__use_mainline_uboot_except_vendor() {
 	unset BOOTFS_TYPE   # mainline u-boot can boot ext4 directly
 	BOOTCONFIG="radxa-zero-3-rk3566_defconfig"
 	BOOTSOURCE="https://github.com/u-boot/u-boot"
-	BOOTBRANCH="tag:v2025.01"
-	BOOTPATCHDIR="v2025.01"
+	BOOTBRANCH="tag:v2025.04"
+	BOOTPATCHDIR="v2025.04"
 
 	UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 


### PR DESCRIPTION
# Description

bump mainline uboot to v2025.04 for _current_ and _edge_.


# How Has This Been Tested?

- [x] build
- [x] boot Zero 3E: https://paste.armbian.com/egisexekam
- [ ] boot Zero 3W: Nope, no hw, most likely just fine

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
