### PR TITLE
rockchip-rk3308-current: fix uart dma

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/rk3308-fix-uart-dma.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk3308-fix-uart-dma.patch
@@ -1,0 +1,123 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ssp97 <zhang@yuanpai.win>
+Date: Fri, 11 Apr 2025 23:35:49 +0800
+Subject: rk3308: fix uart dma.
+
+Signed-off-by: ssp97 <zhang@yuanpai.win>
+---
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 10 ++++++++++
+ drivers/soc/rockchip/grf.c | 14 ++++++++++
+ 2 file changed, 24 insertions(+)
+
+diff --git a/drivers/soc/rockchip/grf.c b/drivers/soc/rockchip/grf.c
+index 5fd62046b..78138cee6 100644
+--- a/drivers/soc/rockchip/grf.c
++++ b/drivers/soc/rockchip/grf.c
+@@ -84,10 +84,21 @@ static const struct rockchip_grf_value rk3328_defaults[] __initconst = {
+ static const struct rockchip_grf_info rk3328_grf __initconst = {
+ 	.values = rk3328_defaults,
+ 	.num_values = ARRAY_SIZE(rk3328_defaults),
+ };
+ 
++#define RK3308_GRF_SOC_CON3		0x30c
++
++static const struct rockchip_grf_value rk3308_defaults[] __initconst = {
++	 { "uart dma mask", RK3308_GRF_SOC_CON3, HIWORD_UPDATE(0, 0x1f, 10) },
++};
++
++static const struct rockchip_grf_info rk3308_grf __initconst = {
++	.values = rk3308_defaults,
++	.num_values = ARRAY_SIZE(rk3308_defaults),
++};
++
+ #define RK3368_GRF_SOC_CON15		0x43c
+ 
+ static const struct rockchip_grf_value rk3368_defaults[] __initconst = {
+ 	{ "jtag switching", RK3368_GRF_SOC_CON15, HIWORD_UPDATE(0, 1, 13) },
+ };
+@@ -147,10 +158,13 @@ static const struct of_device_id rockchip_grf_dt_match[] __initconst = {
+ 		.compatible = "rockchip,rk3288-grf",
+ 		.data = (void *)&rk3288_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3328-grf",
+ 		.data = (void *)&rk3328_grf,
++	}, {
++		.compatible = "rockchip,rk3308-grf",
++		.data = (void *)&rk3308_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3368-grf",
+ 		.data = (void *)&rk3368_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3399-grf",
+diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+index 7d1571e4f..a6b8dc8df 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+@@ -351,10 +351,12 @@ uart0: serial@ff0a0000 {
+ 		interrupts = <GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART0>, <&cru PCLK_UART0>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 4>, <&dmac0 5>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -364,10 +366,12 @@ uart1: serial@ff0b0000 {
+ 		interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART1>, <&cru PCLK_UART1>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 6>, <&dmac0 7>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart1_xfer &uart1_cts &uart1_rts>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -377,10 +381,12 @@ uart2: serial@ff0c0000 {
+ 		interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART2>, <&cru PCLK_UART2>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 8>, <&dmac0 9>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart2m0_xfer>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -390,10 +396,12 @@ uart3: serial@ff0d0000 {
+ 		interrupts = <GIC_SPI 21 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART3>, <&cru PCLK_UART3>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 10>, <&dmac0 11>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart3_xfer>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -403,10 +411,12 @@ uart4: serial@ff0e0000 {
+ 		interrupts = <GIC_SPI 22 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART4>, <&cru PCLK_UART4>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac1 18>, <&dmac1 19>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart4_xfer &uart4_cts &uart4_rts>;
+ 		status = "disabled";
+ 	};
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-6.14/rk3308-fix-uart-dma.patch
+++ b/patch/kernel/archive/rockchip64-6.14/rk3308-fix-uart-dma.patch
@@ -1,0 +1,123 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ssp97 <zhang@yuanpai.win>
+Date: Fri, 11 Apr 2025 23:35:49 +0800
+Subject: rk3308: fix uart dma.
+
+Signed-off-by: ssp97 <zhang@yuanpai.win>
+---
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 10 ++++++++++
+ drivers/soc/rockchip/grf.c | 14 ++++++++++
+ 2 file changed, 24 insertions(+)
+
+diff --git a/drivers/soc/rockchip/grf.c b/drivers/soc/rockchip/grf.c
+index 5fd62046b..78138cee6 100644
+--- a/drivers/soc/rockchip/grf.c
++++ b/drivers/soc/rockchip/grf.c
+@@ -84,10 +84,21 @@ static const struct rockchip_grf_value rk3328_defaults[] __initconst = {
+ static const struct rockchip_grf_info rk3328_grf __initconst = {
+ 	.values = rk3328_defaults,
+ 	.num_values = ARRAY_SIZE(rk3328_defaults),
+ };
+ 
++#define RK3308_GRF_SOC_CON3		0x30c
++
++static const struct rockchip_grf_value rk3308_defaults[] __initconst = {
++	 { "uart dma mask", RK3308_GRF_SOC_CON3, HIWORD_UPDATE(0, 0x1f, 10) },
++};
++
++static const struct rockchip_grf_info rk3308_grf __initconst = {
++	.values = rk3308_defaults,
++	.num_values = ARRAY_SIZE(rk3308_defaults),
++};
++
+ #define RK3368_GRF_SOC_CON15		0x43c
+ 
+ static const struct rockchip_grf_value rk3368_defaults[] __initconst = {
+ 	{ "jtag switching", RK3368_GRF_SOC_CON15, HIWORD_UPDATE(0, 1, 13) },
+ };
+@@ -147,10 +158,13 @@ static const struct of_device_id rockchip_grf_dt_match[] __initconst = {
+ 		.compatible = "rockchip,rk3288-grf",
+ 		.data = (void *)&rk3288_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3328-grf",
+ 		.data = (void *)&rk3328_grf,
++	}, {
++		.compatible = "rockchip,rk3308-grf",
++		.data = (void *)&rk3308_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3368-grf",
+ 		.data = (void *)&rk3368_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3399-grf",
+diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+index 7d1571e4f..a6b8dc8df 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+@@ -351,10 +351,12 @@ uart0: serial@ff0a0000 {
+ 		interrupts = <GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART0>, <&cru PCLK_UART0>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 4>, <&dmac0 5>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -364,10 +366,12 @@ uart1: serial@ff0b0000 {
+ 		interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART1>, <&cru PCLK_UART1>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 6>, <&dmac0 7>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart1_xfer &uart1_cts &uart1_rts>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -377,10 +381,12 @@ uart2: serial@ff0c0000 {
+ 		interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART2>, <&cru PCLK_UART2>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 8>, <&dmac0 9>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart2m0_xfer>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -390,10 +396,12 @@ uart3: serial@ff0d0000 {
+ 		interrupts = <GIC_SPI 21 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART3>, <&cru PCLK_UART3>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 10>, <&dmac0 11>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart3_xfer>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -403,10 +411,12 @@ uart4: serial@ff0e0000 {
+ 		interrupts = <GIC_SPI 22 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART4>, <&cru PCLK_UART4>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac1 18>, <&dmac1 19>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart4_xfer &uart4_cts &uart4_rts>;
+ 		status = "disabled";
+ 	};
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-6.6/rk3308-fix-uart-dma.patch
+++ b/patch/kernel/archive/rockchip64-6.6/rk3308-fix-uart-dma.patch
@@ -1,0 +1,123 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ssp97 <zhang@yuanpai.win>
+Date: Fri, 11 Apr 2025 23:35:49 +0800
+Subject: rk3308: fix uart dma.
+
+Signed-off-by: ssp97 <zhang@yuanpai.win>
+---
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 10 ++++++++++
+ drivers/soc/rockchip/grf.c | 14 ++++++++++
+ 2 file changed, 24 insertions(+)
+
+diff --git a/drivers/soc/rockchip/grf.c b/drivers/soc/rockchip/grf.c
+index 5fd62046b..78138cee6 100644
+--- a/drivers/soc/rockchip/grf.c
++++ b/drivers/soc/rockchip/grf.c
+@@ -84,10 +84,21 @@ static const struct rockchip_grf_value rk3328_defaults[] __initconst = {
+ static const struct rockchip_grf_info rk3328_grf __initconst = {
+ 	.values = rk3328_defaults,
+ 	.num_values = ARRAY_SIZE(rk3328_defaults),
+ };
+ 
++#define RK3308_GRF_SOC_CON3		0x30c
++
++static const struct rockchip_grf_value rk3308_defaults[] __initconst = {
++	 { "uart dma mask", RK3308_GRF_SOC_CON3, HIWORD_UPDATE(0, 0x1f, 10) },
++};
++
++static const struct rockchip_grf_info rk3308_grf __initconst = {
++	.values = rk3308_defaults,
++	.num_values = ARRAY_SIZE(rk3308_defaults),
++};
++
+ #define RK3368_GRF_SOC_CON15		0x43c
+ 
+ static const struct rockchip_grf_value rk3368_defaults[] __initconst = {
+ 	{ "jtag switching", RK3368_GRF_SOC_CON15, HIWORD_UPDATE(0, 1, 13) },
+ };
+@@ -147,10 +158,13 @@ static const struct of_device_id rockchip_grf_dt_match[] __initconst = {
+ 		.compatible = "rockchip,rk3288-grf",
+ 		.data = (void *)&rk3288_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3328-grf",
+ 		.data = (void *)&rk3328_grf,
++	}, {
++		.compatible = "rockchip,rk3308-grf",
++		.data = (void *)&rk3308_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3368-grf",
+ 		.data = (void *)&rk3368_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3399-grf",
+diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+index 7d1571e4f..a6b8dc8df 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+@@ -351,10 +351,12 @@ uart0: serial@ff0a0000 {
+ 		interrupts = <GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART0>, <&cru PCLK_UART0>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 4>, <&dmac0 5>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -364,10 +366,12 @@ uart1: serial@ff0b0000 {
+ 		interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART1>, <&cru PCLK_UART1>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 6>, <&dmac0 7>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart1_xfer &uart1_cts &uart1_rts>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -377,10 +381,12 @@ uart2: serial@ff0c0000 {
+ 		interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART2>, <&cru PCLK_UART2>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 8>, <&dmac0 9>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart2m0_xfer>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -390,10 +396,12 @@ uart3: serial@ff0d0000 {
+ 		interrupts = <GIC_SPI 21 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART3>, <&cru PCLK_UART3>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 10>, <&dmac0 11>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart3_xfer>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -403,10 +411,12 @@ uart4: serial@ff0e0000 {
+ 		interrupts = <GIC_SPI 22 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART4>, <&cru PCLK_UART4>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac1 18>, <&dmac1 19>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart4_xfer &uart4_cts &uart4_rts>;
+ 		status = "disabled";
+ 	};
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-6.9/rk3308-fix-uart-dma.patch
+++ b/patch/kernel/archive/rockchip64-6.9/rk3308-fix-uart-dma.patch
@@ -1,0 +1,123 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ssp97 <zhang@yuanpai.win>
+Date: Fri, 11 Apr 2025 23:35:49 +0800
+Subject: rk3308: fix uart dma.
+
+Signed-off-by: ssp97 <zhang@yuanpai.win>
+---
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 10 ++++++++++
+ drivers/soc/rockchip/grf.c | 14 ++++++++++
+ 2 file changed, 24 insertions(+)
+
+diff --git a/drivers/soc/rockchip/grf.c b/drivers/soc/rockchip/grf.c
+index 5fd62046b..78138cee6 100644
+--- a/drivers/soc/rockchip/grf.c
++++ b/drivers/soc/rockchip/grf.c
+@@ -84,10 +84,21 @@ static const struct rockchip_grf_value rk3328_defaults[] __initconst = {
+ static const struct rockchip_grf_info rk3328_grf __initconst = {
+ 	.values = rk3328_defaults,
+ 	.num_values = ARRAY_SIZE(rk3328_defaults),
+ };
+ 
++#define RK3308_GRF_SOC_CON3		0x30c
++
++static const struct rockchip_grf_value rk3308_defaults[] __initconst = {
++	 { "uart dma mask", RK3308_GRF_SOC_CON3, HIWORD_UPDATE(0, 0x1f, 10) },
++};
++
++static const struct rockchip_grf_info rk3308_grf __initconst = {
++	.values = rk3308_defaults,
++	.num_values = ARRAY_SIZE(rk3308_defaults),
++};
++
+ #define RK3368_GRF_SOC_CON15		0x43c
+ 
+ static const struct rockchip_grf_value rk3368_defaults[] __initconst = {
+ 	{ "jtag switching", RK3368_GRF_SOC_CON15, HIWORD_UPDATE(0, 1, 13) },
+ };
+@@ -147,10 +158,13 @@ static const struct of_device_id rockchip_grf_dt_match[] __initconst = {
+ 		.compatible = "rockchip,rk3288-grf",
+ 		.data = (void *)&rk3288_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3328-grf",
+ 		.data = (void *)&rk3328_grf,
++	}, {
++		.compatible = "rockchip,rk3308-grf",
++		.data = (void *)&rk3308_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3368-grf",
+ 		.data = (void *)&rk3368_grf,
+ 	}, {
+ 		.compatible = "rockchip,rk3399-grf",
+diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+index 7d1571e4f..a6b8dc8df 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+@@ -351,10 +351,12 @@ uart0: serial@ff0a0000 {
+ 		interrupts = <GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART0>, <&cru PCLK_UART0>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 4>, <&dmac0 5>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -364,10 +366,12 @@ uart1: serial@ff0b0000 {
+ 		interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART1>, <&cru PCLK_UART1>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 6>, <&dmac0 7>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart1_xfer &uart1_cts &uart1_rts>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -377,10 +381,12 @@ uart2: serial@ff0c0000 {
+ 		interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART2>, <&cru PCLK_UART2>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 8>, <&dmac0 9>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart2m0_xfer>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -390,10 +396,12 @@ uart3: serial@ff0d0000 {
+ 		interrupts = <GIC_SPI 21 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART3>, <&cru PCLK_UART3>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac0 10>, <&dmac0 11>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart3_xfer>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -403,10 +411,12 @@ uart4: serial@ff0e0000 {
+ 		interrupts = <GIC_SPI 22 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru SCLK_UART4>, <&cru PCLK_UART4>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
++		dmas = <&dmac1 18>, <&dmac1 19>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart4_xfer &uart4_cts &uart4_rts>;
+ 		status = "disabled";
+ 	};
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

fix the DMA issue for RK3308B, append the DMA probe into rk3308.dtsi.

# How Has This Been Tested?

- [x] Compiled and tested on Linux kernel 6.6 running on sakurapi hardware.
- [x] Compiled and tested on Linux kernel 6.12 running on sakurapi hardware.

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
