### PR TITLE
lib/tools/info: mapper-oci-uptodate: adapt to oras-py 0.2 api change

### DIFF
--- a/lib/tools/cli-oci-up2date.py
+++ b/lib/tools/cli-oci-up2date.py
@@ -24,3 +24,16 @@ oci_target = "ghcr.io/armsurvivors/armbian-release/uboot-rockpro64-edge:2025.01-
 container = client.get_container(oci_target)
 manifest = client.get_manifest(container)
 log.debug(f"Got manifest for existing '{oci_target}'.")
+
+oci_target_does_not_exist = "ghcr.io/armsurvivors/armbian-release/uboot-rockpro64-edge:does-not-exist"
+try:
+	container = client.get_container(oci_target_does_not_exist)
+	manifest = client.get_manifest(container)
+	log.info(f"Got manifest for non-existing '{oci_target_does_not_exist}'.")
+except Exception as e:
+	message: str = str(e)
+	# A known-good cache miss.
+	if ": Not Found" in message:
+		log.info("Got expected 'Not Found' error for non-existing OCI target.")
+	else:
+		log.warning(f"Failed to get manifest for '{oci_target_does_not_exist}': {e}")

--- a/lib/tools/cli-oci-up2date.py
+++ b/lib/tools/cli-oci-up2date.py
@@ -21,7 +21,6 @@ log.info(f"OCI client version: {client.version()}")
 
 oci_target = "ghcr.io/armsurvivors/armbian-release/uboot-rockpro64-edge:2025.01-S6d41-P295c-Ha5a3-V9ecd-B1e5e-R448a"
 
-container = client.remote.get_container(oci_target)
-client.remote.load_configs(container)
-manifest = client.remote.get_manifest(container)
-log.debug(f"Got manifest for '{oci_target}'.")
+container = client.get_container(oci_target)
+manifest = client.get_manifest(container)
+log.debug(f"Got manifest for existing '{oci_target}'.")

--- a/lib/tools/cli-oci-up2date.py
+++ b/lib/tools/cli-oci-up2date.py
@@ -1,0 +1,27 @@
+import logging
+import os
+import sys
+
+import oras.client
+import oras.logger
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common import armbian_utils
+
+# Prepare logging
+armbian_utils.setup_logging()
+log: logging.Logger = logging.getLogger("mapper-oci-up-to-date")
+
+# Extra logging for ORAS library
+oras.logger.setup_logger(quiet=(not armbian_utils.is_debug()), debug=(armbian_utils.is_debug()))
+
+client = oras.client.OrasClient(insecure=False)
+log.info(f"OCI client version: {client.version()}")
+
+oci_target = "ghcr.io/armsurvivors/armbian-release/uboot-rockpro64-edge:2025.01-S6d41-P295c-Ha5a3-V9ecd-B1e5e-R448a"
+
+container = client.remote.get_container(oci_target)
+client.remote.load_configs(container)
+manifest = client.remote.get_manifest(container)
+log.debug(f"Got manifest for '{oci_target}'.")

--- a/lib/tools/info/mapper-oci-uptodate.py
+++ b/lib/tools/info/mapper-oci-uptodate.py
@@ -99,9 +99,8 @@ def check_oci_up_to_date_cache(oci_target: str, really_check: bool = False):
 		log.debug(f"No cache file for '{oci_target}'")
 
 		try:
-			container = client.remote.get_container(oci_target)
-			client.remote.load_configs(container)
-			manifest = client.remote.get_manifest(container)
+			container = client.get_container(oci_target)
+			manifest = client.get_manifest(container)
 			log.debug(f"Got manifest for '{oci_target}'.")
 			ret["up-to-date"] = True
 			ret["reason"] = "manifest_exists"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ GitPython == 3.1.44    # for manipulating git repos
 unidecode == 1.3.8     # for converting strings to ascii
 coloredlogs == 15.0.1  # for colored logging
 PyYAML == 6.0.2        # for parsing/writing YAML
-oras == 0.1.30         # for OCI stuff in mapper-oci-update
+oras == 0.2.28         # for OCI stuff in mapper-oci-update
 Jinja2 == 3.1.6        # for templating
 rich == 14.0.0         # for rich text formatting
 dtschema == 2025.2     # for checking dts files and dt bindings


### PR DESCRIPTION
#### lib/tools/info: mapper-oci-uptodate: adapt to oras-py 0.2 api change

- lib/tools: Python CLI for ORAS (0.1.y)
- bump python oras 0.1.30 -> 0.2.28
- lib/tools: Python CLI for ORAS (bump to 0.2.y, api change, not too bad)
- lib/tools: Python CLI for ORAS (add non-existing case)
- lib/tools/info: mapper-oci-uptodate: adapt to oras-py 0.2 api change