### PR TITLE
Fix rtl8189fs driver commit version

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -87,7 +87,7 @@ driver_rtl8189FS() {
 	if linux-version compare "${version}" ge 3.14; then
 
 		# Attach to specific commit (was "branch:rtl8189fs")
-		local rtl8189fsver='commit:fcf2a5746e6fe11d9d71337ee5dac6cf43423a97' # Commit date: Feb 25, 2025 (please update when updating commit ref)
+		local rtl8189fsver='commit:3f34f380715b88e4a3ef049b3a60e2fc69ccc9bd' # Commit date: Feb 25, 2025 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8189FS chipsets ${rtl8189fsver}" "info"
 


### PR DESCRIPTION
# Description

The kernel was missing drivers for RTL8189FS wifi chipset because of an incorrectly set commit hash set in 3777676009cc7ce4a9522526dce97711acb5b13a. This PR corrects it by using the `rtl8189fs` branch instead of `master` of the repository https://github.com/jwrdegoede/rtl8189ES_linux/. The `master` branch only contains the driver for rtl8189es from what I can see. Prior to the breaking commit, the hashes were different.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: https://github.com/armbian/build/issues/8075 https://github.com/armbian/build/issues/8015
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2645] [AR-2656]

Also reported on the forum, for bigtreetech cb1: https://forum.armbian.com/topic/51055-lost-wifi-after-upgrade-on-latest-bookwormnoble-images/

# How Has This Been Tested?

- [x] build and test for bigtreetech-cb1 current (sunxi64)
- [ ] build and test on other reported boards (meson64, orange pi pc plus (sunxi))

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2645]: https://armbian.atlassian.net/browse/AR-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AR-2656]: https://armbian.atlassian.net/browse/AR-2656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ