### PR TITLE
Fix permissions for label `Ready to Merge` on approved pull requests

### DIFF
--- a/.github/workflows/pr-label-on-approved.yml
+++ b/.github/workflows/pr-label-on-approved.yml
@@ -1,5 +1,11 @@
 on: pull_request_review
 name: Label approved pull requests
+
+permissions:
+  contents: read          # Required for checking changed files
+  pull-requests: write    # Required for labeling PRs
+  issues: write           # Required for adding/removing labels
+
 jobs:
   labelWhenApproved:
     if: ${{ github.repository_owner == 'armbian' }}


### PR DESCRIPTION
# Description

For labels to set we need issue write permission for GITHUB_TOKEN.

# Checklist:

- [x] My changes generate no new warnings