### PR TITLE
station-p2: bump u-boot to 2025.04

### DIFF
--- a/config/boards/station-p2.csc
+++ b/config/boards/station-p2.csc
@@ -2,6 +2,7 @@
 BOARD_NAME="Station P2"
 BOARDFAMILY="rockchip64"
 BOOT_SOC="rk3568"
+BOOTCONFIG="roc-pc-rk3568_defconfig"
 BOARD_MAINTAINER=""
 KERNEL_TARGET="current,edge"
 KERNEL_TEST_TARGET="current"
@@ -11,23 +12,6 @@ BOOT_FDT_FILE="rockchip/rk3568-roc-pc.dtb"
 ASOUND_STATE="asound.state.station-p2"
 IMAGE_PARTITION_TABLE="gpt"
 
-# Mainline U-Boot
-function post_family_config__station_p2_use_mainline_uboot() {
-	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"
-
-	declare -g BOOTCONFIG="generic-rk3568_defconfig"             # Use generic defconfig which should boot all RK3568 boards
-	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline U-Boot
-	declare -g BOOTBRANCH="tag:v2024.07"
-	declare -g BOOTPATCHDIR="v2024.07/board_${BOARD}"
-	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
-
-	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
-
-	# Disable stuff from rockchip64_common; we're using binman here which does all the work already
-	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd
-
-	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
-	function write_uboot_platform() {
-		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
-	}
-}
+BOOT_SCENARIO="binman"
+BOOTBRANCH_BOARD="tag:v2025.04"
+BOOTPATCHDIR="v2025.04"

--- a/patch/u-boot/v2025.04/board_station-p2/0001-add-support-for-station-p2.patch
+++ b/patch/u-boot/v2025.04/board_station-p2/0001-add-support-for-station-p2.patch
@@ -1,0 +1,786 @@
+From fe47e9129691deb2a78a25fa315a48b3b7e1f499 Mon Sep 17 00:00:00 2001
+From: chainsx <chainsx@outlook.com>
+Date: Sun, 13 Apr 2025 13:03:47 +0800
+Subject: [PATCH] add support for station-p2
+
+---
+ arch/arm/dts/rk3568-roc-pc-u-boot.dtsi        |  16 +
+ binman-fake/tee-os                            |   0
+ configs/roc-pc-rk3568_defconfig               | 100 +++++
+ .../src/arm64/rockchip/rk3568-roc-pc.dts      | 394 +++++++++++++++---
+ 4 files changed, 448 insertions(+), 62 deletions(-)
+ create mode 100644 arch/arm/dts/rk3568-roc-pc-u-boot.dtsi
+ create mode 100644 binman-fake/tee-os
+ create mode 100644 configs/roc-pc-rk3568_defconfig
+
+diff --git a/arch/arm/dts/rk3568-roc-pc-u-boot.dtsi b/arch/arm/dts/rk3568-roc-pc-u-boot.dtsi
+new file mode 100644
+index 00000000..ab511878
+--- /dev/null
++++ b/arch/arm/dts/rk3568-roc-pc-u-boot.dtsi
+@@ -0,0 +1,16 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++#include "rk356x-u-boot.dtsi"
++
++&sfc {
++	flash@0 {
++		bootph-pre-ram;
++		bootph-some-ram;
++	};
++};
++
++&vdd_npu {
++	regulator-always-on;
++	regulator-boot-on;
++	regulator-init-microvolt = <900000>;
++};
+diff --git a/binman-fake/tee-os b/binman-fake/tee-os
+new file mode 100644
+index 00000000..e69de29b
+diff --git a/configs/roc-pc-rk3568_defconfig b/configs/roc-pc-rk3568_defconfig
+new file mode 100644
+index 00000000..97679f93
+--- /dev/null
++++ b/configs/roc-pc-rk3568_defconfig
+@@ -0,0 +1,100 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_COUNTER_FREQUENCY=24000000
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SF_DEFAULT_SPEED=24000000
++CONFIG_SF_DEFAULT_MODE=0x2000
++CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3568-roc-pc"
++CONFIG_ROCKCHIP_RK3568=y
++CONFIG_ROCKCHIP_SPI_IMAGE=y
++CONFIG_SPL_SERIAL=y
++CONFIG_SYS_LOAD_ADDR=0xc00800
++CONFIG_SF_DEFAULT_BUS=4
++CONFIG_DEBUG_UART_BASE=0xFE660000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI=y
++CONFIG_PCI=y
++CONFIG_DEBUG_UART=y
++CONFIG_AHCI=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_FIT_SIGNATURE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3568-roc-pc.dtb"
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++CONFIG_SPL_MAX_SIZE=0x40000
++CONFIG_SPL_PAD_TO=0x7f8000
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_SPI_LOAD=y
++CONFIG_SYS_SPI_U_BOOT_OFFS=0x60000
++CONFIG_SPL_ATF=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_I2C=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_POWEROFF=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_ROCKUSB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_PMIC=y
++CONFIG_CMD_REGULATOR=y
++# CONFIG_SPL_DOS_PARTITION is not set
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_SPL_DM_SEQ_ALIAS=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SPL_SYSCON=y
++CONFIG_SCSI_AHCI=y
++CONFIG_AHCI_PCI=y
++CONFIG_SPL_CLK=y
++# CONFIG_USB_FUNCTION_FASTBOOT is not set
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_LED=y
++CONFIG_LED_GPIO=y
++CONFIG_MISC=y
++CONFIG_SUPPORT_EMMC_RPMB=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_SDMA=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_SPI_FLASH_SFDP_SUPPORT=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_XTX=y
++CONFIG_PHY_REALTEK=y
++CONFIG_DWC_ETH_QOS=y
++CONFIG_DWC_ETH_QOS_ROCKCHIP=y
++CONFIG_NVME_PCI=y
++CONFIG_PCIE_DW_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_NANENG_COMBOPHY=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_DM_PMIC_FAN53555=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_SPL_RAM=y
++CONFIG_SCSI=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_ROCKCHIP_SFC=y
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_USB_FUNCTION_ROCKUSB=y
++CONFIG_ERRNO_STR=y
+diff --git a/dts/upstream/src/arm64/rockchip/rk3568-roc-pc.dts b/dts/upstream/src/arm64/rockchip/rk3568-roc-pc.dts
+index 60faa0c8..7204d1d3 100644
+--- a/dts/upstream/src/arm64/rockchip/rk3568-roc-pc.dts
++++ b/dts/upstream/src/arm64/rockchip/rk3568-roc-pc.dts
+@@ -25,7 +25,7 @@
+ 		stdout-path = "serial2:1500000n8";
+ 	};
+ 
+-	dc_12v: regulator-dc-12v {
++	dc_12v: dc-12v-regulator {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "dc_12v";
+ 		regulator-always-on;
+@@ -48,17 +48,15 @@
+ 		#clock-cells = <0>;
+ 	};
+ 
+-	leds {
++	firefly_leds: leds {
+ 		compatible = "gpio-leds";
+-
+-		led-user {
+-			label = "user-led";
++		power_led: power {
++			label = "firefly:blue:power";
++			linux,default-trigger = "ir-power-click";
+ 			default-state = "on";
+ 			gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+ 			pinctrl-names = "default";
+-			pinctrl-0 = <&user_led_enable_h>;
+-			retain-state-suspended;
++			pinctrl-0 = <&led_power>;
+ 		};
+ 	};
+ 
+@@ -73,7 +71,7 @@
+ 		};
+ 	};
+ 
+-	pcie30_avdd0v9: regulator-pcie30-avdd0v9 {
++	pcie30_avdd0v9: pcie30-avdd0v9-regulator {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "pcie30_avdd0v9";
+ 		regulator-always-on;
+@@ -83,7 +81,7 @@
+ 		vin-supply = <&vcc3v3_sys>;
+ 	};
+ 
+-	pcie30_avdd1v8: regulator-pcie30-avdd1v8 {
++	pcie30_avdd1v8: pcie30-avdd1v8-regulator {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "pcie30_avdd1v8";
+ 		regulator-always-on;
+@@ -93,7 +91,7 @@
+ 		vin-supply = <&vcc3v3_sys>;
+ 	};
+ 
+-	vcc3v3_sys: regulator-vcc3v3-sys {
++	vcc3v3_sys: vcc3v3-sys-regulator {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc3v3_sys";
+ 		regulator-always-on;
+@@ -103,7 +101,7 @@
+ 		vin-supply = <&dc_12v>;
+ 	};
+ 
+-	vcc3v3_pcie: regulator-vcc3v3-pcie {
++	vcc3v3_pcie: vcc3v3-pcie-regulator {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc3v3_pcie";
+ 		enable-active-high;
+@@ -116,7 +114,7 @@
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+-	vcc5v0_sys: regulator-vcc5v0-sys {
++	vcc5v0_sys: vcc5v0-sys-regulator {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_sys";
+ 		regulator-always-on;
+@@ -126,41 +124,134 @@
+ 		vin-supply = <&dc_12v>;
+ 	};
+ 
+-	vcc5v0_usb: regulator-vcc5v0-usb {
++	vcc5v0_host: vcc5v0-host-regulator {
+ 		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_usb";
++		regulator-name = "vcc5v0_host";
++		enable-active-high;
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_host_en>;
++		regulator-always-on;
++	};
++
++	vcc5v0_otg: vcc5v0-otg-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_otg_en>;
++		regulator-name = "vcc5v0_otg";
++	};
++
++	vcc2v5_sys: vcc2v5-ddr-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc2v5-sys";
+ 		regulator-always-on;
+ 		regulator-boot-on;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-		vin-supply = <&vcc5v0_sys>;
++		regulator-min-microvolt = <2500000>;
++		regulator-max-microvolt = <2500000>;
++		vin-supply = <&vcc3v3_sys>;
+ 	};
+ 
+-	vcc5v0_host: regulator-vcc5v0-host {
++	vcc_hub_power: vcc-hub-power-regulator {
+ 		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_host";
+ 		enable-active-high;
+ 		gpio = <&gpio0 RK_PA6 GPIO_ACTIVE_HIGH>;
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&vcc5v0_host_en>;
++		pinctrl-0 = <&vcc_hub_power_en>;
++		regulator-name = "vcc_hub_power_en";
+ 		regulator-always-on;
+-		vin-supply = <&vcc5v0_usb>;
+ 	};
+ 
+-	vcc5v0_otg: regulator-vcc5v0-otg {
++	vcc_hub_reset: vcc-hub-reset-regulator {
+ 		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_otg";
+ 		enable-active-high;
+-		gpio = <&gpio0 RK_PA5 GPIO_ACTIVE_HIGH>;
++		gpio = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&vcc5v0_otg_en>;
+-		vin-supply = <&vcc5v0_usb>;
++		pinctrl-0 = <&vcc_hub_reset_en>;
++		regulator-name = "vcc_hub_reset_en";
++		regulator-always-on;
+ 	};
+-};
+ 
+-&combphy0 {
+-	/* used for USB3 */
+-	status = "okay";
++	pcie_pi6c_oe: pcie-pi6c-oe-regulator {
++		compatible = "regulator-fixed";
++		//enable-active-high;
++		gpio = <&gpio3 RK_PA7 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie_pi6c_oe_en>;
++		regulator-name = "pcie_pi6c_oe_en";
++		regulator-always-on;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		status = "okay";
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rk809 1>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++		reset-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_LOW>;
++		post-power-on-delay-ms = <100>;
++	};
++
++	wireless_wlan: wireless-wlan {
++		compatible = "wlan-platdata";
++		rockchip,grf = <&grf>;
++		wifi_chip_type = "ap6275s";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_host_wake_irq>;
++		WIFI,host_wake_irq = <&gpio3 RK_PD4 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	wireless_bluetooth: wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		clocks = <&rk809 1>;
++		clock-names = "ext_clock";
++		//wifi-bt-power-toggle;
++		uart_rts_gpios = <&gpio2 RK_PB1 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default", "rts_gpio";
++		pinctrl-0 = <&uart8m0_rtsn>;
++		pinctrl-1 = <&uart8_gpios>;
++		BT,reset_gpio    = <&gpio3 RK_PA0 GPIO_ACTIVE_HIGH>;
++		BT,wake_gpio     = <&gpio3 RK_PA1 GPIO_ACTIVE_HIGH>;
++		BT,wake_host_irq = <&gpio3 RK_PA2 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	flash_led: flash-led {
++		compatible = "led,rgb13h";
++		label = "pwm-flash-led";
++		led-max-microamp = <20000>;
++		flash-max-microamp = <20000>;
++		flash-max-timeout-us = <1000000>;
++		pwms = <&pwm11 0 25000 0>;
++		rockchip,camera-module-index = <1>;
++		rockchip,camera-module-facing = "front";
++		status = "disabled";
++	};
++
++	rk809-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,name = "Analog RK809";
++		simple-audio-card,mclk-fs = <256>;
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s1_8ch>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&rk809>;
++		};
++	};
++
++	rk_headset: rk-headset {
++		compatible = "rockchip_headset";
++		headset_gpio = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&hp_det>;
++		io-channels = <&saradc 2>;    //HP_HOOK pin
++	};
+ };
+ 
+ &combphy1 {
+@@ -247,15 +338,59 @@
+ &i2c0 {
+ 	status = "okay";
+ 
++	fusb0: fusb30x@22 {
++		compatible = "fairchild,fusb302";
++		reg = <0x22>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&fusb0_int>;
++		int-n-gpios = <&gpio0 RK_PC1 GPIO_ACTIVE_HIGH>;
++		fusb340-switch-gpios = <&gpio3 RK_PC2 GPIO_ACTIVE_HIGH>;
++		vbus-5v-gpios = <&gpio0 RK_PA5 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	vdd_cpu: regulator@1c {
++		compatible = "tcs,tcs4525";
++		reg = <0x1c>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "fan53555-reg";
++		regulator-name = "vdd_cpu";
++		regulator-min-microvolt = <712500>;
++		regulator-max-microvolt = <1390000>;
++		regulator-ramp-delay = <2300>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-boot-on;
++		regulator-always-on;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
+ 	rk809: pmic@20 {
+ 		compatible = "rockchip,rk809";
+ 		reg = <0x20>;
+ 		interrupt-parent = <&gpio0>;
+ 		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_LOW>;
++		assigned-clocks = <&cru I2S1_MCLKOUT_TX>;
++		assigned-clock-rates = <12288000>;
++		assigned-clock-parents = <&cru CLK_I2S1_8CH_TX>;
+ 		#clock-cells = <1>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pmic_int>;
+-		system-power-controller;
++		clock-names = "mclk";
++		clocks = <&cru I2S1_MCLKOUT_TX>;
++		pinctrl-names = "default", "pmic-sleep",
++				"pmic-power-off", "pmic-reset";
++		pinctrl-0 = <&pmic_int>, <&i2s1m0_mclk>;
++
++		rockchip,system-power-controller;
++		#sound-dai-cells = <0>;
++		clock-output-names = "rk808-clkout1", "rk808-clkout2";
++		//fb-inner-reg-idxs = <2>;
++		/* 1: rst regs (default in codes), 0: rst the pmic */
++		pmic-reset-func = <0>;
++		/* not save the PMIC_POWER_EN register in uboot */
++		not-save-power-en = <1>;
++
+ 		vcc1-supply = <&vcc3v3_sys>;
+ 		vcc2-supply = <&vcc3v3_sys>;
+ 		vcc3-supply = <&vcc3v3_sys>;
+@@ -283,6 +418,8 @@
+ 			};
+ 
+ 			vdd_gpu: DCDC_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-name = "vdd_gpu";
+ 				regulator-initial-mode = <0x2>;
+ 				regulator-min-microvolt = <500000>;
+@@ -317,19 +454,9 @@
+ 				};
+ 			};
+ 
+-			vcc_1v8: DCDC_REG5 {
+-				regulator-name = "vcc_1v8";
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+ 			vdda0v9_image: LDO_REG1 {
++				regulator-boot-on;
++				regulator-always-on;
+ 				regulator-name = "vdda0v9_image";
+ 				regulator-min-microvolt = <900000>;
+ 				regulator-max-microvolt = <900000>;
+@@ -365,6 +492,8 @@
+ 			};
+ 
+ 			vccio_acodec: LDO_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-name = "vccio_acodec";
+ 				regulator-min-microvolt = <3300000>;
+ 				regulator-max-microvolt = <3300000>;
+@@ -376,6 +505,8 @@
+ 
+ 			vccio_sd: LDO_REG5 {
+ 				regulator-name = "vccio_sd";
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <3300000>;
+ 
+@@ -423,6 +554,8 @@
+ 			};
+ 
+ 			vcca1v8_image: LDO_REG9 {
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-name = "vcca1v8_image";
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <1800000>;
+@@ -432,6 +565,17 @@
+ 				};
+ 			};
+ 
++			vcc_1v8: DCDC_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
+ 			vcc_3v3: SWITCH_REG1 {
+ 				regulator-name = "vcc_3v3";
+ 				regulator-always-on;
+@@ -452,6 +596,10 @@
+ 				};
+ 			};
+ 		};
++
++		codec {
++			mic-in-differential;
++		};
+ 	};
+ };
+ 
+@@ -474,7 +622,7 @@
+ };
+ 
+ &pcie30phy {
+-	status = "okay";
++	tatus = "okay";
+ };
+ 
+ &pcie3x2 {
+@@ -487,19 +635,27 @@
+ 
+ &pinctrl {
+ 	leds {
+-		user_led_enable_h: user-led-enable-h {
+-			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
++		led_power: led-power {
++			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
+ 	usb {
+ 		vcc5v0_host_en: vcc5v0-host-en {
+-			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <0 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
+ 		vcc5v0_otg_en: vcc5v0-otg-en {
+ 			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
++
++		vcc_hub_power_en: vcc-hub-power-en {
++			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		vcc_hub_reset_en: vcc-hub-reset-en {
++			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
+ 	};
+ 
+ 	pcie {
+@@ -509,21 +665,53 @@
+ 		vcc3v3_pcie_en_pin: vcc3v3-pcie-en-pin {
+ 			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
++		pcie_pi6c_oe_en: pcie-pi6c-oe-en {
++			rockchip,pins = <3 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
+ 	};
+ 
+ 	pmic {
+-		pmic_int: pmic-int {
++		pmic_int: pmic_int {
+ 			rockchip,pins =
+ 				<0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins = <3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wireless-wlan {
++		wifi_host_wake_irq: wifi-host-wake-irq {
++			rockchip,pins = <3 RK_PD4 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	wireless-bluetooth {
++		uart8_gpios: uart8-gpios {
++			rockchip,pins = <2 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	fusb30x {
++		fusb0_int: fusb0-int {
++			rockchip,pins = <0 RK_PC1 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	headphone {
++		hp_det: hp-det {
++			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
+ };
+ 
+ &pmu_io_domains {
+ 	pmuio1-supply = <&vcc3v3_pmu>;
+ 	pmuio2-supply = <&vcc3v3_pmu>;
+ 	vccio1-supply = <&vccio_acodec>;
+-	vccio2-supply = <&vcc_1v8>;
+ 	vccio3-supply = <&vccio_sd>;
+ 	vccio4-supply = <&vcc_1v8>;
+ 	vccio5-supply = <&vcc_3v3>;
+@@ -545,25 +733,44 @@
+ 	bus-width = <8>;
+ 	max-frequency = <200000000>;
+ 	non-removable;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_datastrobe>;
++	supports-emmc;
+ 	status = "okay";
+ };
+ 
+ &sdmmc0 {
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
+-	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+ 	disable-wp;
+-	pinctrl-names = "default";
+ 	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd &sdmmc0_det>;
+ 	sd-uhs-sdr104;
+ 	vmmc-supply = <&vcc3v3_sd>;
+ 	vqmmc-supply = <&vccio_sd>;
++	max-frequency = <150000000>;
++	supports-sd;
++	cap-mmc-highspeed;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&sdmmc2 {
++	max-frequency = <150000000>;
++	supports-sdio;
++	bus-width = <4>;
++	disable-wp;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	keep-power-in-suspend;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc2m0_bus4 &sdmmc2m0_cmd &sdmmc2m0_clk>;
++	sd-uhs-sdr104;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
+ 	status = "okay";
+ };
+ 
+ &tsadc {
++	rockchip,hw-tshut-mode = <1>;
++	rockchip,hw-tshut-polarity = <0>;
+ 	status = "okay";
+ };
+ 
+@@ -585,6 +792,7 @@
+ };
+ 
+ &usb2phy0_otg {
++	vbus-supply = <&vcc5v0_otg>;
+ 	status = "okay";
+ };
+ 
+@@ -606,6 +814,10 @@
+ 	status = "okay";
+ };
+ 
++&usb_host0_xhci {
++	status = "okay";
++};
++
+ &usb_host1_ehci {
+ 	status = "okay";
+ };
+@@ -614,11 +826,13 @@
+ 	status = "okay";
+ };
+ 
+-&usb_host0_xhci {
++&usb_host1_xhci {
+ 	status = "okay";
+ };
+ 
+-&usb_host1_xhci {
++&vop {
++	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
++	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
+ 	status = "okay";
+ };
+ 
+@@ -629,12 +843,68 @@
+ 	};
+ };
+ 
+-&vop {
+-	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
+-	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
++&vop_mmu {
+ 	status = "okay";
+ };
+ 
+-&vop_mmu {
++&i2s1_8ch {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s1m0_sclktx
++		     &i2s1m0_lrcktx
++		     &i2s1m0_sdi0
++		     &i2s1m0_sdo0>;
++	rockchip,trcm-sync-tx-only;
++	status = "okay";
++};
++
++&i2c1 {
++    status = "okay";
++};
++
++&i2c4 {
++	status = "okay";
++};
++
++&i2c5 {
++    status = "okay";
++};
++
++&gic {
++    status = "okay";
++};
++
++&uart3 {
++//	status = "disabled";
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart4m1_xfer>;
++        status = "okay";
++};
++
++&uart8 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart8m0_xfer &uart8m0_ctsn>;
++};
++
++&rk809 {
++    rtc {
++        status = "disabled";
++    };
++};
++
++&pwm4 {
++	status = "okay";
++};
++
++&pwm5 {
++	status = "okay";
++};
++
++&pwm7 {
+ 	status = "okay";
+ };
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

Bump u-boot to v2025.04 for station-m2.

Dts patch is from: https://github.com/armbian/build/blob/main/patch/kernel/archive/rockchip64-6.14/board-station-p2.patch

# How Has This Been Tested?

- [x] startup

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
