### PR TITLE
orangepi-5-max: switch `edge` u-boot to mainline

### DIFF
--- a/config/boards/orangepi5-max.csc
+++ b/config/boards/orangepi5-max.csc
@@ -39,9 +39,6 @@ function post_family_config_branch_edge__orangepi5max_use_mainline_uboot() {
 	}
 }
 
-
-
-
 function post_family_tweaks__orangepi5max_naming_audios() {
 	display_alert "$BOARD" "Renaming orangepi5max audios" "info"
 

--- a/config/boards/orangepi5-max.csc
+++ b/config/boards/orangepi5-max.csc
@@ -16,6 +16,32 @@ IMAGE_PARTITION_TABLE="gpt"
 enable_extension "bcmdhd"
 BCMDHD_TYPE="sdio"
 
+# Mainline U-Boot for edge kernel
+function post_family_config_branch_edge__orangepi5max_use_mainline_uboot() {
+	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
+	unset BOOT_FDT_FILE                                          # boot.scr will use whatever u-boot detects and sets 'fdtfile' to
+	declare -g BOOTCONFIG="orangepi-5-max-rk3588_defconfig"      # override the default for the board/family
+	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ mainline U-Boot
+	declare -g BOOTBRANCH="tag:v2025.04"
+	declare -g BOOTPATCHDIR="v2025.04"
+	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+
+	function write_uboot_platform_mtd() {
+		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
+	}
+}
+
+
+
+
 function post_family_tweaks__orangepi5max_naming_audios() {
 	display_alert "$BOARD" "Renaming orangepi5max audios" "info"
 

--- a/patch/u-boot/v2025.04/board_orangepi5-max/orangepi-5-max-add-support.patch
+++ b/patch/u-boot/v2025.04/board_orangepi5-max/orangepi-5-max-add-support.patch
@@ -1,0 +1,152 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JIlya Katsnelson <me@0upti.me>
+Date: Sun, 13 Apr 2025 10:40:15 +0200
+Subject: board: rockchip: add Xunlong Orange Pi 5 Max
+
+Signed-off-by: Ilya Katsnelson <me@0upti.me>
+---
+ arch/arm/dts/rk3588-orangepi-5-max-u-boot.dtsi | 20 +++
+ board/rockchip/evb_rk3588/MAINTAINERS          |  7 +
+ configs/orangepi-5-max-rk3588_defconfig        | 89 ++++++++++
+ doc/board/rockchip/rockchip.rst                |  1 +
+ 4 files changed, 117 insertions(+)
+
+diff --git a/arch/arm/dts/rk3588-orangepi-5-max-u-boot.dtsi b/arch/arm/dts/rk3588-orangepi-5-max-u-boot.dtsi
+new file mode 100644
+index 00000000000..afd33dd3248
+--- /dev/null
++++ b/arch/arm/dts/rk3588-orangepi-5-max-u-boot.dtsi
+@@ -0,0 +1,20 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++#include "rk3588-u-boot.dtsi"
++
++&fspim2_pins {
++       bootph-pre-ram;
++       bootph-some-ram;
++};
++
++&sdhci {
++       cap-mmc-highspeed;
++       mmc-hs200-1_8v;
++};
++
++&sfc {
++       flash@0 {
++               bootph-pre-ram;
++               bootph-some-ram;
++       };
++};
+diff --git a/configs/orangepi-5-max-rk3588_defconfig b/configs/orangepi-5-max-rk3588_defconfig
+new file mode 100644
+index 00000000000..a655dfe2d64
+--- /dev/null
++++ b/configs/orangepi-5-max-rk3588_defconfig
+@@ -0,0 +1,89 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_COUNTER_FREQUENCY=24000000
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SF_DEFAULT_SPEED=24000000
++CONFIG_SF_DEFAULT_MODE=0x2000
++CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3588-orangepi-5-max"
++CONFIG_ROCKCHIP_RK3588=y
++CONFIG_ROCKCHIP_SPI_IMAGE=y
++CONFIG_SPL_SERIAL=y
++CONFIG_TARGET_EVB_RK3588=y
++CONFIG_SYS_LOAD_ADDR=0xc00800
++CONFIG_SF_DEFAULT_BUS=5
++CONFIG_DEBUG_UART_BASE=0xFEB50000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI=y
++CONFIG_PCI=y
++CONFIG_DEBUG_UART=y
++CONFIG_AHCI=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_FIT_SIGNATURE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3588-orangepi-5-max.dtb"
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++CONFIG_SPL_MAX_SIZE=0x40000
++CONFIG_SPL_PAD_TO=0x7f8000
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_SPI_LOAD=y
++CONFIG_SYS_SPI_U_BOOT_OFFS=0x60000
++CONFIG_SPL_ATF=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_I2C=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_REGULATOR=y
++# CONFIG_SPL_DOS_PARTITION is not set
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_SPL_DM_SEQ_ALIAS=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SPL_SYSCON=y
++CONFIG_AHCI_PCI=y
++CONFIG_DWC_AHCI=y
++CONFIG_SPL_CLK=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MISC=y
++CONFIG_SUPPORT_EMMC_RPMB=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_SDMA=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_SPI_FLASH_SFDP_SUPPORT=y
++CONFIG_SPI_FLASH_XMC=y
++CONFIG_PHYLIB=y
++CONFIG_RTL8169=y
++CONFIG_NVME_PCI=y
++CONFIG_PCIE_DW_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_NANENG_COMBOPHY=y
++CONFIG_PHY_ROCKCHIP_USBDP=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_SPL_RAM=y
++CONFIG_SCSI=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_ROCKCHIP_SFC=y
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_ERRNO_STR=y
+diff --git a/doc/board/rockchip/rockchip.rst b/doc/board/rockchip/rockchip.rst
+index 1407080f1f4..00d9587e988 100644
+--- a/doc/board/rockchip/rockchip.rst
++++ b/doc/board/rockchip/rockchip.rst
+@@ -147,10 +147,11 @@ List of mainline supported Rockchip boards:
+      - Rockchip Toybrick TB-RK3588X (toybrick-rk3588)
+      - Theobroma Systems RK3588-SBC Jaguar (jaguar-rk3588)
+      - Theobroma Systems SOM-RK3588-Q7 - Tiger (tiger-rk3588)
+      - Turing Machines RK1 (turing-rk1-rk3588)
+      - Xunlong Orange Pi 5 (orangepi-5-rk3588s)
++     - Xunlong Orange Pi 5 Max (orangepi-5-max-rk3588)
+      - Xunlong Orange Pi 5 Plus (orangepi-5-plus-rk3588)
+      - Yanyi Tech CoolPi 4 Model B (coolpi-4b-rk3588s)
+      - Yanyi Tech CoolPi CM5 EVB (coolpi-cm5-evb-rk3588)
+      - Yanyi Tech CoolPi CM5 GenBook (coolpi-cm5-genbook-rk3588)
+
+--
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/u-boot/v2025.04/board_orangepi5-max/orangepi-5-max-add-upstream-dts.patch
+++ b/patch/u-boot/v2025.04/board_orangepi5-max/orangepi-5-max-add-upstream-dts.patch
@@ -1,0 +1,5150 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Werner <werner@armbian.com>
+Date: Sun, 13 Apr 2025 11:06:27 +0200
+Subject: orangepi-5-max: add upstream dts
+
+Extracted via kernel-dtb from Linux 6.14.2
+
+Signed-off-by: Werner <werner@armbian.com>
+---
+ dts/upstream/src/arm64/rockchip/rk3588-orangepi-5-max.dts | 5129 ++++++++++
+ 1 file changed, 5129 insertions(+)
+
+diff --git a/dts/upstream/src/arm64/rockchip/rk3588-orangepi-5-max.dts b/dts/upstream/src/arm64/rockchip/rk3588-orangepi-5-max.dts
+new file mode 100644
+index 00000000000..2f6dcca673c
+--- /dev/null
++++ b/dts/upstream/src/arm64/rockchip/rk3588-orangepi-5-max.dts
+@@ -0,0 +1,5129 @@
++/dts-v1/;
++
++/ {
++	compatible = "xunlong,orangepi-5-max", "rockchip,rk3588";
++	interrupt-parent = <0x01>;
++	#address-cells = <0x02>;
++	#size-cells = <0x02>;
++	model = "Xunlong Orange Pi 5 Max";
++
++	aliases {
++		gpio0 = "/pinctrl/gpio@fd8a0000";
++		gpio1 = "/pinctrl/gpio@fec20000";
++		gpio2 = "/pinctrl/gpio@fec30000";
++		gpio3 = "/pinctrl/gpio@fec40000";
++		gpio4 = "/pinctrl/gpio@fec50000";
++		i2c0 = "/i2c@fd880000";
++		i2c1 = "/i2c@fea90000";
++		i2c2 = "/i2c@feaa0000";
++		i2c3 = "/i2c@feab0000";
++		i2c4 = "/i2c@feac0000";
++		i2c5 = "/i2c@fead0000";
++		i2c6 = "/i2c@fec80000";
++		i2c7 = "/i2c@fec90000";
++		i2c8 = "/i2c@feca0000";
++		serial0 = "/serial@fd890000";
++		serial1 = "/serial@feb40000";
++		serial2 = "/serial@feb50000";
++		serial3 = "/serial@feb60000";
++		serial4 = "/serial@feb70000";
++		serial5 = "/serial@feb80000";
++		serial6 = "/serial@feb90000";
++		serial7 = "/serial@feba0000";
++		serial8 = "/serial@febb0000";
++		serial9 = "/serial@febc0000";
++		spi0 = "/spi@feb00000";
++		spi1 = "/spi@feb10000";
++		spi2 = "/spi@feb20000";
++		spi3 = "/spi@feb30000";
++		spi4 = "/spi@fecb0000";
++		mmc0 = "/mmc@fe2e0000";
++		mmc1 = "/mmc@fe2c0000";
++	};
++
++	cpus {
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++
++		cpu-map {
++
++			cluster0 {
++
++				core0 {
++					cpu = <0x02>;
++				};
++
++				core1 {
++					cpu = <0x03>;
++				};
++
++				core2 {
++					cpu = <0x04>;
++				};
++
++				core3 {
++					cpu = <0x05>;
++				};
++			};
++
++			cluster1 {
++
++				core0 {
++					cpu = <0x06>;
++				};
++
++				core1 {
++					cpu = <0x07>;
++				};
++			};
++
++			cluster2 {
++
++				core0 {
++					cpu = <0x08>;
++				};
++
++				core1 {
++					cpu = <0x09>;
++				};
++			};
++		};
++
++		cpu_l0: cpu@0 {
++			device_type = "cpu";
++			compatible = "arm,cortex-a55";
++			reg = <0x00>;
++			enable-method = "psci";
++			capacity-dmips-mhz = <0x212>;
++			clocks = <0x0a 0x00>;
++			assigned-clocks = <0x0a 0x00>;
++			assigned-clock-rates = <0x30a32c00>;
++			cpu-idle-states = <0x0b>;
++			i-cache-size = <0x8000>;
++			i-cache-line-size = <0x40>;
++			i-cache-sets = <0x80>;
++			d-cache-size = <0x8000>;
++			d-cache-line-size = <0x40>;
++			d-cache-sets = <0x80>;
++			next-level-cache = <0x0c>;
++			dynamic-power-coefficient = <0xe4>;
++			#cooling-cells = <0x02>;
++			operating-points-v2 = <0x0d>;
++			cpu-supply = <0x0e>;
++			phandle = <0x02>;
++		};
++
++		cpu_l1: cpu@100 {
++			device_type = "cpu";
++			compatible = "arm,cortex-a55";
++			reg = <0x100>;
++			enable-method = "psci";
++			capacity-dmips-mhz = <0x212>;
++			clocks = <0x0a 0x00>;
++			cpu-idle-states = <0x0b>;
++			i-cache-size = <0x8000>;
++			i-cache-line-size = <0x40>;
++			i-cache-sets = <0x80>;
++			d-cache-size = <0x8000>;
++			d-cache-line-size = <0x40>;
++			d-cache-sets = <0x80>;
++			next-level-cache = <0x0f>;
++			dynamic-power-coefficient = <0xe4>;
++			#cooling-cells = <0x02>;
++			operating-points-v2 = <0x0d>;
++			cpu-supply = <0x0e>;
++			phandle = <0x03>;
++		};
++
++		cpu_l2: cpu@200 {
++			device_type = "cpu";
++			compatible = "arm,cortex-a55";
++			reg = <0x200>;
++			enable-method = "psci";
++			capacity-dmips-mhz = <0x212>;
++			clocks = <0x0a 0x00>;
++			cpu-idle-states = <0x0b>;
++			i-cache-size = <0x8000>;
++			i-cache-line-size = <0x40>;
++			i-cache-sets = <0x80>;
++			d-cache-size = <0x8000>;
++			d-cache-line-size = <0x40>;
++			d-cache-sets = <0x80>;
++			next-level-cache = <0x10>;
++			dynamic-power-coefficient = <0xe4>;
++			#cooling-cells = <0x02>;
++			operating-points-v2 = <0x0d>;
++			cpu-supply = <0x0e>;
++			phandle = <0x04>;
++		};
++
++		cpu_l3: cpu@300 {
++			device_type = "cpu";
++			compatible = "arm,cortex-a55";
++			reg = <0x300>;
++			enable-method = "psci";
++			capacity-dmips-mhz = <0x212>;
++			clocks = <0x0a 0x00>;
++			cpu-idle-states = <0x0b>;
++			i-cache-size = <0x8000>;
++			i-cache-line-size = <0x40>;
++			i-cache-sets = <0x80>;
++			d-cache-size = <0x8000>;
++			d-cache-line-size = <0x40>;
++			d-cache-sets = <0x80>;
++			next-level-cache = <0x11>;
++			dynamic-power-coefficient = <0xe4>;
++			#cooling-cells = <0x02>;
++			operating-points-v2 = <0x0d>;
++			cpu-supply = <0x0e>;
++			phandle = <0x05>;
++		};
++
++		cpu_b0: cpu@400 {
++			device_type = "cpu";
++			compatible = "arm,cortex-a76";
++			reg = <0x400>;
++			enable-method = "psci";
++			capacity-dmips-mhz = <0x400>;
++			clocks = <0x0a 0x02>;
++			assigned-clocks = <0x0a 0x02>;
++			assigned-clock-rates = <0x30a32c00>;
++			cpu-idle-states = <0x0b>;
++			i-cache-size = <0x10000>;
++			i-cache-line-size = <0x40>;
++			i-cache-sets = <0x100>;
++			d-cache-size = <0x10000>;
++			d-cache-line-size = <0x40>;
++			d-cache-sets = <0x100>;
++			next-level-cache = <0x12>;
++			dynamic-power-coefficient = <0x1a0>;
++			#cooling-cells = <0x02>;
++			operating-points-v2 = <0x13>;
++			cpu-supply = <0x14>;
++			phandle = <0x06>;
++		};
++
++		cpu_b1: cpu@500 {
++			device_type = "cpu";
++			compatible = "arm,cortex-a76";
++			reg = <0x500>;
++			enable-method = "psci";
++			capacity-dmips-mhz = <0x400>;
++			clocks = <0x0a 0x02>;
++			cpu-idle-states = <0x0b>;
++			i-cache-size = <0x10000>;
++			i-cache-line-size = <0x40>;
++			i-cache-sets = <0x100>;
++			d-cache-size = <0x10000>;
++			d-cache-line-size = <0x40>;
++			d-cache-sets = <0x100>;
++			next-level-cache = <0x15>;
++			dynamic-power-coefficient = <0x1a0>;
++			#cooling-cells = <0x02>;
++			operating-points-v2 = <0x13>;
++			cpu-supply = <0x14>;
++			phandle = <0x07>;
++		};
++
++		cpu_b2: cpu@600 {
++			device_type = "cpu";
++			compatible = "arm,cortex-a76";
++			reg = <0x600>;
++			enable-method = "psci";
++			capacity-dmips-mhz = <0x400>;
++			clocks = <0x0a 0x03>;
++			assigned-clocks = <0x0a 0x03>;
++			assigned-clock-rates = <0x30a32c00>;
++			cpu-idle-states = <0x0b>;
++			i-cache-size = <0x10000>;
++			i-cache-line-size = <0x40>;
++			i-cache-sets = <0x100>;
++			d-cache-size = <0x10000>;
++			d-cache-line-size = <0x40>;
++			d-cache-sets = <0x100>;
++			next-level-cache = <0x16>;
++			dynamic-power-coefficient = <0x1a0>;
++			#cooling-cells = <0x02>;
++			operating-points-v2 = <0x17>;
++			cpu-supply = <0x18>;
++			phandle = <0x08>;
++		};
++
++		cpu_b3: cpu@700 {
++			device_type = "cpu";
++			compatible = "arm,cortex-a76";
++			reg = <0x700>;
++			enable-method = "psci";
++			capacity-dmips-mhz = <0x400>;
++			clocks = <0x0a 0x03>;
++			cpu-idle-states = <0x0b>;
++			i-cache-size = <0x10000>;
++			i-cache-line-size = <0x40>;
++			i-cache-sets = <0x100>;
++			d-cache-size = <0x10000>;
++			d-cache-line-size = <0x40>;
++			d-cache-sets = <0x100>;
++			next-level-cache = <0x19>;
++			dynamic-power-coefficient = <0x1a0>;
++			#cooling-cells = <0x02>;
++			operating-points-v2 = <0x17>;
++			cpu-supply = <0x18>;
++			phandle = <0x09>;
++		};
++
++		idle-states {
++			entry-method = "psci";
++
++			CPU_SLEEP: cpu-sleep {
++				compatible = "arm,idle-state";
++				local-timer-stop;
++				arm,psci-suspend-param = <0x10000>;
++				entry-latency-us = <0x64>;
++				exit-latency-us = <0x78>;
++				min-residency-us = <0x3e8>;
++				phandle = <0x0b>;
++			};
++		};
++
++		l2_cache_l0: l2-cache-l0 {
++			compatible = "cache";
++			cache-size = <0x20000>;
++			cache-line-size = <0x40>;
++			cache-sets = <0x200>;
++			cache-level = <0x02>;
++			cache-unified;
++			next-level-cache = <0x1a>;
++			phandle = <0x0c>;
++		};
++
++		l2_cache_l1: l2-cache-l1 {
++			compatible = "cache";
++			cache-size = <0x20000>;
++			cache-line-size = <0x40>;
++			cache-sets = <0x200>;
++			cache-level = <0x02>;
++			cache-unified;
++			next-level-cache = <0x1a>;
++			phandle = <0x0f>;
++		};
++
++		l2_cache_l2: l2-cache-l2 {
++			compatible = "cache";
++			cache-size = <0x20000>;
++			cache-line-size = <0x40>;
++			cache-sets = <0x200>;
++			cache-level = <0x02>;
++			cache-unified;
++			next-level-cache = <0x1a>;
++			phandle = <0x10>;
++		};
++
++		l2_cache_l3: l2-cache-l3 {
++			compatible = "cache";
++			cache-size = <0x20000>;
++			cache-line-size = <0x40>;
++			cache-sets = <0x200>;
++			cache-level = <0x02>;
++			cache-unified;
++			next-level-cache = <0x1a>;
++			phandle = <0x11>;
++		};
++
++		l2_cache_b0: l2-cache-b0 {
++			compatible = "cache";
++			cache-size = <0x80000>;
++			cache-line-size = <0x40>;
++			cache-sets = <0x400>;
++			cache-level = <0x02>;
++			cache-unified;
++			next-level-cache = <0x1a>;
++			phandle = <0x12>;
++		};
++
++		l2_cache_b1: l2-cache-b1 {
++			compatible = "cache";
++			cache-size = <0x80000>;
++			cache-line-size = <0x40>;
++			cache-sets = <0x400>;
++			cache-level = <0x02>;
++			cache-unified;
++			next-level-cache = <0x1a>;
++			phandle = <0x15>;
++		};
++
++		l2_cache_b2: l2-cache-b2 {
++			compatible = "cache";
++			cache-size = <0x80000>;
++			cache-line-size = <0x40>;
++			cache-sets = <0x400>;
++			cache-level = <0x02>;
++			cache-unified;
++			next-level-cache = <0x1a>;
++			phandle = <0x16>;
++		};
++
++		l2_cache_b3: l2-cache-b3 {
++			compatible = "cache";
++			cache-size = <0x80000>;
++			cache-line-size = <0x40>;
++			cache-sets = <0x400>;
++			cache-level = <0x02>;
++			cache-unified;
++			next-level-cache = <0x1a>;
++			phandle = <0x19>;
++		};
++	};
++
++	l3_cache: l3-cache {
++		compatible = "cache";
++		cache-size = <0x300000>;
++		cache-line-size = <0x40>;
++		cache-sets = <0x1000>;
++		cache-level = <0x03>;
++		cache-unified;
++		phandle = <0x1a>;
++	};
++
++	display_subsystem: display-subsystem {
++		compatible = "rockchip,display-subsystem";
++		ports = <0x1b>;
++	};
++
++	firmware {
++
++		optee: optee {
++			compatible = "linaro,optee-tz";
++			method = "smc";
++		};
++
++		scmi: scmi {
++			compatible = "arm,scmi-smc";
++			arm,smc-id = <0x82000010>;
++			shmem = <0x1c>;
++			#address-cells = <0x01>;
++			#size-cells = <0x00>;
++
++			scmi_clk: protocol@14 {
++				reg = <0x14>;
++				#clock-cells = <0x01>;
++				phandle = <0x0a>;
++			};
++
++			scmi_reset: protocol@16 {
++				reg = <0x16>;
++				#reset-cells = <0x01>;
++				phandle = <0x94>;
++			};
++		};
++	};
++
++	hdmi0_sound: hdmi0-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <0x80>;
++		simple-audio-card,name = "hdmi0";
++		status = "okay";
++
++		simple-audio-card,codec {
++			sound-dai = <0x1d>;
++		};
++
++		simple-audio-card,cpu {
++			sound-dai = <0x1e>;
++		};
++	};
++
++	pmu-a55 {
++		compatible = "arm,cortex-a55-pmu";
++		interrupts = <0x01 0x07 0x04 0x1f>;
++	};
++
++	pmu-a76 {
++		compatible = "arm,cortex-a76-pmu";
++		interrupts = <0x01 0x07 0x04 0x20>;
++	};
++
++	psci {
++		compatible = "arm,psci-1.0";
++		method = "smc";
++	};
++
++	spll: clock-0 {
++		compatible = "fixed-clock";
++		clock-frequency = <0x29d7ab80>;
++		clock-output-names = "spll";
++		#clock-cells = <0x00>;
++	};
++
++	timer {
++		compatible = "arm,armv8-timer";
++		interrupts = <0x01 0x0d 0x04 0x00>, <0x01 0x0e 0x04 0x00>, <0x01 0x0b 0x04 0x00>, <0x01 0x0a 0x04 0x00>, <0x01 0x0c 0x04 0x00>;
++		interrupt-names = "sec-phys", "phys", "virt", "hyp-phys", "hyp-virt";
++	};
++
++	xin24m: clock-1 {
++		compatible = "fixed-clock";
++		clock-frequency = <0x16e3600>;
++		clock-output-names = "xin24m";
++		#clock-cells = <0x00>;
++	};
++
++	xin32k: clock-2 {
++		compatible = "fixed-clock";
++		clock-frequency = <0x8000>;
++		clock-output-names = "xin32k";
++		#clock-cells = <0x00>;
++	};
++
++	pmu_sram: sram@10f000 {
++		compatible = "mmio-sram";
++		reg = <0x00 0x10f000 0x00 0x100>;
++		ranges = <0x00 0x00 0x10f000 0x100>;
++		#address-cells = <0x01>;
++		#size-cells = <0x01>;
++
++		scmi_shmem: sram@0 {
++			compatible = "arm,scmi-shmem";
++			reg = <0x00 0x100>;
++			phandle = <0x1c>;
++		};
++	};
++
++	gpu: gpu@fb000000 {
++		compatible = "rockchip,rk3588-mali", "arm,mali-valhall-csf";
++		reg = <0x00 0xfb000000 0x00 0x200000>;
++		#cooling-cells = <0x02>;
++		assigned-clocks = <0x0a 0x05>;
++		assigned-clock-rates = <0xbebc200>;
++		clocks = <0x21 0x106>, < 0x21 0x107>, < 0x21 0x108>;
++		clock-names = "core", "coregroup", "stacks";
++		dynamic-power-coefficient = <0xba6>;
++		interrupts = <0x00 0x5c 0x04 0x00>, <0x00 0x5d 0x04 0x00>, <0x00 0x5e 0x04 0x00>;
++		interrupt-names = "job", "mmu", "gpu";
++		power-domains = <0x22 0x0c>;
++		status = "okay";
++		operating-points-v2 = <0x23>;
++		mali-supply = <0x24>;
++		phandle = <0xe0>;
++	};
++
++	usb_host0_xhci: usb@fc000000 {
++		compatible = "rockchip,rk3588-dwc3", "snps,dwc3";
++		reg = <0x00 0xfc000000 0x00 0x400000>;
++		interrupts = <0x00 0xdc 0x04 0x00>;
++		clocks = <0x21 0x194>, < 0x21 0x193>, < 0x21 0x192>;
++		clock-names = "ref_clk", "suspend_clk", "bus_clk";
++		dr_mode = "host";
++		phys = <0x25>, < 0x26 0x04>;
++		phy-names = "usb2-phy", "usb3-phy";
++		phy_type = "utmi_wide";
++		power-domains = <0x22 0x1f>;
++		resets = <0x21 0x152>;
++		snps,dis_enblslpm_quirk;
++		snps,dis-u1-entry-quirk;
++		snps,dis-u2-entry-quirk;
++		snps,dis-u2-freeclk-exists-quirk;
++		snps,dis-del-phy-power-chg-quirk;
++		snps,dis-tx-ipgap-linecheck-quirk;
++		status = "okay";
++	};
++
++	usb_host0_ehci: usb@fc800000 {
++		compatible = "rockchip,rk3588-ehci", "generic-ehci";
++		reg = <0x00 0xfc800000 0x00 0x40000>;
++		interrupts = <0x00 0xd7 0x04 0x00>;
++		clocks = <0x21 0x18e>, < 0x21 0x18f>, < 0x21 0x2c0>, < 0x27>;
++		phys = <0x28>;
++		phy-names = "usb";
++		power-domains = <0x22 0x1f>;
++		status = "okay";
++	};
++
++	usb_host0_ohci: usb@fc840000 {
++		compatible = "rockchip,rk3588-ohci", "generic-ohci";
++		reg = <0x00 0xfc840000 0x00 0x40000>;
++		interrupts = <0x00 0xd8 0x04 0x00>;
++		clocks = <0x21 0x18e>, < 0x21 0x18f>, < 0x21 0x2c0>, < 0x27>;
++		phys = <0x28>;
++		phy-names = "usb";
++		power-domains = <0x22 0x1f>;
++		status = "okay";
++	};
++
++	usb_host1_ehci: usb@fc880000 {
++		compatible = "rockchip,rk3588-ehci", "generic-ehci";
++		reg = <0x00 0xfc880000 0x00 0x40000>;
++		interrupts = <0x00 0xda 0x04 0x00>;
++		clocks = <0x21 0x190>, < 0x21 0x191>, < 0x21 0x2c0>, < 0x29>;
++		phys = <0x2a>;
++		phy-names = "usb";
++		power-domains = <0x22 0x1f>;
++		status = "okay";
++	};
++
++	usb_host1_ohci: usb@fc8c0000 {
++		compatible = "rockchip,rk3588-ohci", "generic-ohci";
++		reg = <0x00 0xfc8c0000 0x00 0x40000>;
++		interrupts = <0x00 0xdb 0x04 0x00>;
++		clocks = <0x21 0x190>, < 0x21 0x191>, < 0x21 0x2c0>, < 0x29>;
++		phys = <0x2a>;
++		phy-names = "usb";
++		power-domains = <0x22 0x1f>;
++		status = "okay";
++	};
++
++	usb_host2_xhci: usb@fcd00000 {
++		compatible = "rockchip,rk3588-dwc3", "snps,dwc3";
++		reg = <0x00 0xfcd00000 0x00 0x400000>;
++		interrupts = <0x00 0xde 0x04 0x00>;
++		clocks = <0x21 0x16a>, < 0x21 0x169>, < 0x21 0x168>, < 0x21 0x16b>, < 0x21 0x172>;
++		clock-names = "ref_clk", "suspend_clk", "bus_clk", "utmi", "pipe";
++		dr_mode = "host";
++		phys = <0x2b 0x04>;
++		phy-names = "usb3-phy";
++		phy_type = "utmi_wide";
++		resets = <0x21 0x134>;
++		snps,dis_enblslpm_quirk;
++		snps,dis-u2-freeclk-exists-quirk;
++		snps,dis-del-phy-power-chg-quirk;
++		snps,dis-tx-ipgap-linecheck-quirk;
++		snps,dis_rxdet_inp3_quirk;
++		status = "disabled";
++	};
++
++	mmu600_pcie: iommu@fc900000 {
++		compatible = "arm,smmu-v3";
++		reg = <0x00 0xfc900000 0x00 0x200000>;
++		interrupts = <0x00 0x171 0x01 0x00>, <0x00 0x173 0x01 0x00>, <0x00 0x176 0x01 0x00>, <0x00 0x16f 0x01 0x00>;
++		interrupt-names = "eventq", "gerror", "priq", "cmdq-sync";
++		#iommu-cells = <0x01>;
++		phandle = <0x7e>;
++	};
++
++	mmu600_php: iommu@fcb00000 {
++		compatible = "arm,smmu-v3";
++		reg = <0x00 0xfcb00000 0x00 0x200000>;
++		interrupts = <0x00 0x17d 0x01 0x00>, <0x00 0x17f 0x01 0x00>, <0x00 0x182 0x01 0x00>, <0x00 0x17b 0x01 0x00>;
++		interrupt-names = "eventq", "gerror", "priq", "cmdq-sync";
++		#iommu-cells = <0x01>;
++		status = "disabled";
++	};
++
++	pmu1grf: syscon@fd58a000 {
++		compatible = "rockchip,rk3588-pmugrf", "syscon", "simple-mfd";
++		reg = <0x00 0xfd58a000 0x00 0x10000>;
++		phandle = <0x7b>;
++	};
++
++	sys_grf: syscon@fd58c000 {
++		compatible = "rockchip,rk3588-sys-grf", "syscon";
++		reg = <0x00 0xfd58c000 0x00 0x1000>;
++		phandle = <0x6e>;
++	};
++
++	vop_grf: syscon@fd5a4000 {
++		compatible = "rockchip,rk3588-vop-grf", "syscon";
++		reg = <0x00 0xfd5a4000 0x00 0x2000>;
++		phandle = <0x6f>;
++	};
++
++	vo0_grf: syscon@fd5a6000 {
++		compatible = "rockchip,rk3588-vo0-grf", "syscon";
++		reg = <0x00 0xfd5a6000 0x00 0x2000>;
++		clocks = <0x21 0x1e9>;
++		phandle = <0xf1>;
++	};
++
++	vo1_grf: syscon@fd5a8000 {
++		compatible = "rockchip,rk3588-vo1-grf", "syscon";
++		reg = <0x00 0xfd5a8000 0x00 0x4000>;
++		clocks = <0x21 0x2d1>;
++		phandle = <0x70>;
++	};
++
++	usb_grf: syscon@fd5ac000 {
++		compatible = "rockchip,rk3588-usb-grf", "syscon";
++		reg = <0x00 0xfd5ac000 0x00 0x4000>;
++		phandle = <0xef>;
++	};
++
++	php_grf: syscon@fd5b0000 {
++		compatible = "rockchip,rk3588-php-grf", "syscon";
++		reg = <0x00 0xfd5b0000 0x00 0x1000>;
++		phandle = <0x2e>;
++	};
++
++	pipe_phy0_grf: syscon@fd5bc000 {
++		compatible = "rockchip,rk3588-pipe-phy-grf", "syscon";
++		reg = <0x00 0xfd5bc000 0x00 0x100>;
++		phandle = <0xf2>;
++	};
++
++	pipe_phy2_grf: syscon@fd5c4000 {
++		compatible = "rockchip,rk3588-pipe-phy-grf", "syscon";
++		reg = <0x00 0xfd5c4000 0x00 0x100>;
++		phandle = <0xf3>;
++	};
++
++	usbdpphy0_grf: syscon@fd5c8000 {
++		compatible = "rockchip,rk3588-usbdpphy-grf", "syscon";
++		reg = <0x00 0xfd5c8000 0x00 0x4000>;
++		phandle = <0xf0>;
++	};
++
++	usb2phy0_grf: syscon@fd5d0000 {
++		compatible = "rockchip,rk3588-usb2phy-grf", "syscon", "simple-mfd";
++		reg = <0x00 0xfd5d0000 0x00 0x4000>;
++		#address-cells = <0x01>;
++		#size-cells = <0x01>;
++		phandle = <0xee>;
++
++		u2phy0: usb2phy@0 {
++			compatible = "rockchip,rk3588-usb2phy";
++			reg = <0x00 0x10>;
++			#clock-cells = <0x00>;
++			clocks = <0x21 0x2a0>;
++			clock-names = "phyclk";
++			clock-output-names = "usb480m_phy0";
++			interrupts = <0x00 0x189 0x04 0x00>;
++			resets = <0x21 0x26d>, < 0x21 0x21d>;
++			reset-names = "phy", "apb";
++			status = "okay";
++			phandle = <0xed>;
++
++			u2phy0_otg: otg-port {
++				#phy-cells = <0x00>;
++				status = "okay";
++				phy-supply = <0x2c>;
++				phandle = <0x25>;
++			};
++		};
++	};
++
++	usb2phy2_grf: syscon@fd5d8000 {
++		compatible = "rockchip,rk3588-usb2phy-grf", "syscon", "simple-mfd";
++		reg = <0x00 0xfd5d8000 0x00 0x4000>;
++		#address-cells = <0x01>;
++		#size-cells = <0x01>;
++
++		u2phy2: usb2phy@8000 {
++			compatible = "rockchip,rk3588-usb2phy";
++			reg = <0x8000 0x10>;
++			#clock-cells = <0x00>;
++			clocks = <0x21 0x2a0>;
++			clock-names = "phyclk";
++			clock-output-names = "usb480m_phy2";
++			interrupts = <0x00 0x187 0x04 0x00>;
++			resets = <0x21 0x26f>, < 0x21 0x21f>;
++			reset-names = "phy", "apb";
++			status = "okay";
++			phandle = <0x27>;
++
++			u2phy2_host: host-port {
++				#phy-cells = <0x00>;
++				status = "okay";
++				phy-supply = <0x2d>;
++				phandle = <0x28>;
++			};
++		};
++	};
++
++	usb2phy3_grf: syscon@fd5dc000 {
++		compatible = "rockchip,rk3588-usb2phy-grf", "syscon", "simple-mfd";
++		reg = <0x00 0xfd5dc000 0x00 0x4000>;
++		#address-cells = <0x01>;
++		#size-cells = <0x01>;
++
++		u2phy3: usb2phy@c000 {
++			compatible = "rockchip,rk3588-usb2phy";
++			reg = <0xc000 0x10>;
++			#clock-cells = <0x00>;
++			clocks = <0x21 0x2a0>;
++			clock-names = "phyclk";
++			clock-output-names = "usb480m_phy3";
++			interrupts = <0x00 0x188 0x04 0x00>;
++			resets = <0x21 0x270>, < 0x21 0x220>;
++			reset-names = "phy", "apb";
++			status = "okay";
++			phandle = <0x29>;
++
++			u2phy3_host: host-port {
++				#phy-cells = <0x00>;
++				status = "okay";
++				phy-supply = <0x2d>;
++				phandle = <0x2a>;
++			};
++		};
++	};
++
++	hdptxphy0_grf: syscon@fd5e0000 {
++		compatible = "rockchip,rk3588-hdptxphy-grf", "syscon";
++		reg = <0x00 0xfd5e0000 0x00 0x100>;
++		phandle = <0xec>;
++	};
++
++	ioc: syscon@fd5f0000 {
++		compatible = "rockchip,rk3588-ioc", "syscon";
++		reg = <0x00 0xfd5f0000 0x00 0x10000>;
++		phandle = <0xf4>;
++	};
++
++	system_sram1: sram@fd600000 {
++		compatible = "mmio-sram";
++		reg = <0x00 0xfd600000 0x00 0x100000>;
++		ranges = <0x00 0x00 0xfd600000 0x100000>;
++		#address-cells = <0x01>;
++		#size-cells = <0x01>;
++	};
++
++	cru: clock-controller@fd7c0000 {
++		compatible = "rockchip,rk3588-cru";
++		reg = <0x00 0xfd7c0000 0x00 0x5c000>;
++		assigned-clocks = <0x21 0x08>, < 0x21 0x04>, < 0x21 0x07>, < 0x21 0x06>, < 0x21 0xcc>, < 0x21 0xce>, < 0x21 0xcd>, < 0x21 0x100>, < 0x21 0x101>, < 0x21 0x102>, < 0x21 0x286>, < 0x21 0x287>, < 0x21 0x25d>, < 0x21 0x71>, < 0x21 0xe0>, < 0x21 0x106>;
++		assigned-clock-rates = <0x4190ab00>, <0x2ee00000>, <0x32a9f880>, <0x46cf7100>, <0x29d7ab80>, <0x17d78400>, <0x1dcd6500>, <0x2faf0800>, <0x5f5e100>, <0x17d78400>, <0x5f5e100>, <0xbebc200>, <0x1dcd6500>, <0x165a0bc0>, <0x8f0d180>, <0xbebc200>;
++		rockchip,grf = <0x2e>;
++		#clock-cells = <0x01>;
++		#reset-cells = <0x01>;
++		phandle = <0x21>;
++	};
++
++	i2c0: i2c@fd880000 {
++		compatible = "rockchip,rk3588-i2c", "rockchip,rk3399-i2c";
++		reg = <0x00 0xfd880000 0x00 0x1000>;
++		interrupts = <0x00 0x13d 0x04 0x00>;
++		clocks = <0x21 0x274>, < 0x21 0x273>;
++		clock-names = "i2c", "pclk";
++		pinctrl-0 = <0x2f>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "okay";
++
++		vdd_cpu_big0_s0: regulator@42 {
++			compatible = "rockchip,rk8602";
++			reg = <0x42>;
++			fcs,suspend-voltage-selector = <0x01>;
++			regulator-name = "vdd_cpu_big0_s0";
++			regulator-always-on;
++			regulator-boot-on;
++			regulator-min-microvolt = <0x86470>;
++			regulator-max-microvolt = <0x100590>;
++			regulator-ramp-delay = <0x8fc>;
++			vin-supply = <0x30>;
++			phandle = <0x14>;
++
++			regulator-state-mem {
++				regulator-off-in-suspend;
++			};
++		};
++
++		vdd_cpu_big1_s0: regulator@43 {
++			compatible = "rockchip,rk8603", "rockchip,rk8602";
++			reg = <0x43>;
++			fcs,suspend-voltage-selector = <0x01>;
++			regulator-name = "vdd_cpu_big1_s0";
++			regulator-always-on;
++			regulator-boot-on;
++			regulator-min-microvolt = <0x86470>;
++			regulator-max-microvolt = <0x100590>;
++			regulator-ramp-delay = <0x8fc>;
++			vin-supply = <0x30>;
++			phandle = <0x18>;
++
++			regulator-state-mem {
++				regulator-off-in-suspend;
++			};
++		};
++	};
++
++	uart0: serial@fd890000 {
++		compatible = "rockchip,rk3588-uart", "snps,dw-apb-uart";
++		reg = <0x00 0xfd890000 0x00 0x100>;
++		interrupts = <0x00 0x14b 0x04 0x00>;
++		clocks = <0x21 0x29b>, < 0x21 0x29c>;
++		clock-names = "baudclk", "apb_pclk";
++		dmas = <0x31 0x06>, < 0x31 0x07>;
++		dma-names = "tx", "rx";
++		pinctrl-0 = <0x32>;
++		pinctrl-names = "default";
++		reg-shift = <0x02>;
++		reg-io-width = <0x04>;
++		status = "disabled";
++	};
++
++	pwm0: pwm@fd8b0000 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfd8b0000 0x00 0x10>;
++		clocks = <0x21 0x292>, < 0x21 0x291>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0x33>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pwm1: pwm@fd8b0010 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfd8b0010 0x00 0x10>;
++		clocks = <0x21 0x292>, < 0x21 0x291>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0x34>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pwm2: pwm@fd8b0020 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfd8b0020 0x00 0x10>;
++		clocks = <0x21 0x292>, < 0x21 0x291>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0x35>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pwm3: pwm@fd8b0030 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfd8b0030 0x00 0x10>;
++		clocks = <0x21 0x292>, < 0x21 0x291>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0x36>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pmu: power-management@fd8d8000 {
++		compatible = "rockchip,rk3588-pmu", "syscon", "simple-mfd";
++		reg = <0x00 0xfd8d8000 0x00 0x400>;
++		phandle = <0x71>;
++
++		power: power-controller {
++			compatible = "rockchip,rk3588-power-controller";
++			#address-cells = <0x01>;
++			#power-domain-cells = <0x01>;
++			#size-cells = <0x00>;
++			status = "okay";
++			phandle = <0x22>;
++
++			power-domain@8 {
++				reg = <0x08>;
++				#power-domain-cells = <0x00>;
++				#address-cells = <0x01>;
++				#size-cells = <0x00>;
++
++				power-domain@9 {
++					reg = <0x09>;
++					clocks = <0x21 0x121>, < 0x21 0x123>, < 0x21 0x122>, < 0x21 0x118>;
++					pm_qos = <0x37>, < 0x38>, < 0x39>;
++					#power-domain-cells = <0x00>;
++					#address-cells = <0x01>;
++					#size-cells = <0x00>;
++
++					power-domain@10 {
++						reg = <0x0a>;
++						clocks = <0x21 0x121>, < 0x21 0x123>, < 0x21 0x122>;
++						pm_qos = <0x3a>;
++						#power-domain-cells = <0x00>;
++					};
++
++					power-domain@11 {
++						reg = <0x0b>;
++						clocks = <0x21 0x121>, < 0x21 0x123>, < 0x21 0x122>;
++						pm_qos = <0x3b>;
++						#power-domain-cells = <0x00>;
++					};
++				};
++			};
++
++			power-domain@12 {
++				reg = <0x0c>;
++				clocks = <0x21 0x106>, < 0x21 0x107>, < 0x21 0x108>;
++				pm_qos = <0x3c>, < 0x3d>, < 0x3e>, < 0x3f>;
++				#power-domain-cells = <0x00>;
++			};
++
++			power-domain@13 {
++				reg = <0x0d>;
++				#address-cells = <0x01>;
++				#size-cells = <0x00>;
++				#power-domain-cells = <0x00>;
++
++				power-domain@14 {
++					reg = <0x0e>;
++					clocks = <0x21 0x180>, < 0x21 0x1af>, < 0x21 0x1ad>, < 0x21 0x181>, < 0x21 0x17f>;
++					pm_qos = <0x40>;
++					#power-domain-cells = <0x00>;
++				};
++
++				power-domain@15 {
++					reg = <0x0f>;
++					clocks = <0x21 0x185>, < 0x21 0x1af>, < 0x21 0x1ad>, < 0x21 0x186>;
++					pm_qos = <0x41>;
++					#power-domain-cells = <0x00>;
++				};
++
++				power-domain@16 {
++					reg = <0x10>;
++					clocks = <0x21 0x1b5>, < 0x21 0x1b6>;
++					pm_qos = <0x42>, < 0x43>, < 0x44>;
++					#address-cells = <0x01>;
++					#size-cells = <0x00>;
++					#power-domain-cells = <0x00>;
++
++					power-domain@17 {
++						reg = <0x11>;
++						clocks = <0x21 0x1ba>, < 0x21 0x1b5>, < 0x21 0x1b6>, < 0x21 0x1bb>;
++						pm_qos = <0x45>, < 0x46>, < 0x47>;
++						#power-domain-cells = <0x00>;
++					};
++				};
++			};
++
++			power-domain@21 {
++				reg = <0x15>;
++				clocks = <0x21 0x1af>, < 0x21 0x1ae>, < 0x21 0x1ad>, < 0x21 0x1b0>, < 0x21 0x19b>, < 0x21 0x19a>, < 0x21 0x19d>, < 0x21 0x19e>, < 0x21 0x19f>, < 0x21 0x1a0>, < 0x21 0x1a1>, < 0x21 0x1a2>, < 0x21 0x1a3>, < 0x21 0x1a4>, < 0x21 0x1a5>, < 0x21 0x1a6>, < 0x21 0x1a8>, < 0x21 0x1a7>;
++				pm_qos = <0x48>, < 0x49>, < 0x4a>, < 0x4b>, < 0x4c>, < 0x4d>, < 0x4e>, < 0x4f>;
++				#address-cells = <0x01>;
++				#size-cells = <0x00>;
++				#power-domain-cells = <0x00>;
++
++				power-domain@23 {
++					reg = <0x17>;
++					clocks = <0x21 0x43>, < 0x21 0x41>, < 0x21 0x1af>;
++					pm_qos = <0x50>;
++					#power-domain-cells = <0x00>;
++				};
++
++				power-domain@14 {
++					reg = <0x0e>;
++					clocks = <0x21 0x180>, < 0x21 0x1af>, < 0x21 0x1ad>, < 0x21 0x181>;
++					pm_qos = <0x40>;
++					#power-domain-cells = <0x00>;
++				};
++
++				power-domain@15 {
++					reg = <0x0f>;
++					clocks = <0x21 0x185>, < 0x21 0x1af>, < 0x21 0x1ad>;
++					pm_qos = <0x41>;
++					#power-domain-cells = <0x00>;
++				};
++
++				power-domain@22 {
++					reg = <0x16>;
++					clocks = <0x21 0x1ab>, < 0x21 0x1aa>;
++					pm_qos = <0x51>;
++					#power-domain-cells = <0x00>;
++				};
++			};
++
++			power-domain@24 {
++				reg = <0x18>;
++				clocks = <0x21 0x25b>, < 0x21 0x25a>, < 0x21 0x25d>;
++				pm_qos = <0x52>, < 0x53>;
++				#address-cells = <0x01>;
++				#size-cells = <0x00>;
++				#power-domain-cells = <0x00>;
++
++				power-domain@25 {
++					reg = <0x19>;
++					clocks = <0x21 0x1e7>, < 0x21 0x1e8>, < 0x21 0x1e6>, < 0x21 0x1e4>, < 0x21 0x1df>, < 0x21 0x1de>, < 0x21 0x25a>;
++					pm_qos = <0x54>;
++					#power-domain-cells = <0x00>;
++				};
++			};
++
++			power-domain@26 {
++				reg = <0x1a>;
++				clocks = <0x21 0x21d>, < 0x21 0x21e>, < 0x21 0x21c>, < 0x21 0x207>, < 0x21 0x206>, < 0x21 0x21a>, < 0x21 0x251>;
++				pm_qos = <0x55>, < 0x56>;
++				#power-domain-cells = <0x00>;
++			};
++
++			power-domain@27 {
++				reg = <0x1b>;
++				clocks = <0x21 0x1d2>, < 0x21 0x1d3>, < 0x21 0x1d0>, < 0x21 0x1cf>, < 0x21 0x1d6>, < 0x21 0x1d5>;
++				pm_qos = <0x57>, < 0x58>, < 0x59>, < 0x5a>;
++				#address-cells = <0x01>;
++				#size-cells = <0x00>;
++				#power-domain-cells = <0x00>;
++
++				power-domain@28 {
++					reg = <0x1c>;
++					clocks = <0x21 0x113>, < 0x21 0x112>, < 0x21 0x1d2>, < 0x21 0x1d3>;
++					pm_qos = <0x5b>, < 0x5c>;
++					#power-domain-cells = <0x00>;
++				};
++
++				power-domain@29 {
++					reg = <0x1d>;
++					clocks = <0x21 0x1c7>, < 0x21 0x1c6>, < 0x21 0x1ca>, < 0x21 0x1c9>, < 0x21 0x1d3>;
++					pm_qos = <0x5d>, < 0x5e>;
++					#power-domain-cells = <0x00>;
++				};
++			};
++
++			power-domain@30 {
++				reg = <0x1e>;
++				clocks = <0x21 0x17a>, < 0x21 0x17b>;
++				pm_qos = <0x5f>;
++				#power-domain-cells = <0x00>;
++			};
++
++			power-domain@31 {
++				reg = <0x1f>;
++				clocks = <0x21 0x157>, < 0x21 0x18c>, < 0x21 0x2c0>, < 0x21 0x18d>, < 0x21 0x18e>, < 0x21 0x18f>, < 0x21 0x190>, < 0x21 0x191>;
++				pm_qos = <0x60>, < 0x61>, < 0x62>, < 0x63>;
++				#power-domain-cells = <0x00>;
++			};
++
++			power-domain@33 {
++				reg = <0x21>;
++				clocks = <0x21 0x157>, < 0x21 0x15a>, < 0x21 0x15b>;
++				#power-domain-cells = <0x00>;
++			};
++
++			power-domain@34 {
++				reg = <0x22>;
++				clocks = <0x21 0x157>, < 0x21 0x15a>, < 0x21 0x15b>;
++				#power-domain-cells = <0x00>;
++			};
++
++			power-domain@37 {
++				reg = <0x25>;
++				clocks = <0x21 0x18a>, < 0x21 0x132>;
++				pm_qos = <0x64>;
++				#power-domain-cells = <0x00>;
++			};
++
++			power-domain@38 {
++				reg = <0x26>;
++				clocks = <0x21 0x34>, < 0x21 0x35>;
++				#power-domain-cells = <0x00>;
++			};
++
++			power-domain@40 {
++				reg = <0x28>;
++				pm_qos = <0x65>;
++				#power-domain-cells = <0x00>;
++			};
++		};
++	};
++
++	vpu121: video-codec@fdb50000 {
++		compatible = "rockchip,rk3588-vpu121", "rockchip,rk3328-vpu";
++		reg = <0x00 0xfdb50000 0x00 0x800>;
++		interrupts = <0x00 0x77 0x04 0x00>;
++		interrupt-names = "vdpu";
++		clocks = <0x21 0x1b1>, < 0x21 0x1b2>;
++		clock-names = "aclk", "hclk";
++		iommus = <0x66>;
++		power-domains = <0x22 0x15>;
++	};
++
++	vpu121_mmu: iommu@fdb50800 {
++		compatible = "rockchip,rk3588-iommu", "rockchip,rk3568-iommu";
++		reg = <0x00 0xfdb50800 0x00 0x40>;
++		interrupts = <0x00 0x76 0x04 0x00>;
++		clock-names = "aclk", "iface";
++		clocks = <0x21 0x1b1>, < 0x21 0x1b2>;
++		power-domains = <0x22 0x15>;
++		#iommu-cells = <0x00>;
++		phandle = <0x66>;
++	};
++
++	rga: rga@fdb80000 {
++		compatible = "rockchip,rk3588-rga", "rockchip,rk3288-rga";
++		reg = <0x00 0xfdb80000 0x00 0x180>;
++		interrupts = <0x00 0x74 0x04 0x00>;
++		clocks = <0x21 0x1a8>, < 0x21 0x1a7>, < 0x21 0x1a9>;
++		clock-names = "aclk", "hclk", "sclk";
++		resets = <0x21 0x172>, < 0x21 0x171>, < 0x21 0x170>;
++		reset-names = "core", "axi", "ahb";
++		power-domains = <0x22 0x15>;
++	};
++
++	vepu121_0: video-codec@fdba0000 {
++		compatible = "rockchip,rk3588-vepu121";
++		reg = <0x00 0xfdba0000 0x00 0x800>;
++		interrupts = <0x00 0x7a 0x04 0x00>;
++		clocks = <0x21 0x19d>, < 0x21 0x19e>;
++		clock-names = "aclk", "hclk";
++		iommus = <0x67>;
++		power-domains = <0x22 0x15>;
++	};
++
++	vepu121_0_mmu: iommu@fdba0800 {
++		compatible = "rockchip,rk3588-iommu", "rockchip,rk3568-iommu";
++		reg = <0x00 0xfdba0800 0x00 0x40>;
++		interrupts = <0x00 0x79 0x04 0x00>;
++		clocks = <0x21 0x19d>, < 0x21 0x19e>;
++		clock-names = "aclk", "iface";
++		power-domains = <0x22 0x15>;
++		#iommu-cells = <0x00>;
++		phandle = <0x67>;
++	};
++
++	vepu121_1: video-codec@fdba4000 {
++		compatible = "rockchip,rk3588-vepu121";
++		reg = <0x00 0xfdba4000 0x00 0x800>;
++		interrupts = <0x00 0x7c 0x04 0x00>;
++		clocks = <0x21 0x19f>, < 0x21 0x1a0>;
++		clock-names = "aclk", "hclk";
++		iommus = <0x68>;
++		power-domains = <0x22 0x15>;
++	};
++
++	vepu121_1_mmu: iommu@fdba4800 {
++		compatible = "rockchip,rk3588-iommu", "rockchip,rk3568-iommu";
++		reg = <0x00 0xfdba4800 0x00 0x40>;
++		interrupts = <0x00 0x7b 0x04 0x00>;
++		clocks = <0x21 0x19f>, < 0x21 0x1a0>;
++		clock-names = "aclk", "iface";
++		power-domains = <0x22 0x15>;
++		#iommu-cells = <0x00>;
++		phandle = <0x68>;
++	};
++
++	vepu121_2: video-codec@fdba8000 {
++		compatible = "rockchip,rk3588-vepu121";
++		reg = <0x00 0xfdba8000 0x00 0x800>;
++		interrupts = <0x00 0x7e 0x04 0x00>;
++		clocks = <0x21 0x1a1>, < 0x21 0x1a2>;
++		clock-names = "aclk", "hclk";
++		iommus = <0x69>;
++		power-domains = <0x22 0x15>;
++	};
++
++	vepu121_2_mmu: iommu@fdba8800 {
++		compatible = "rockchip,rk3588-iommu", "rockchip,rk3568-iommu";
++		reg = <0x00 0xfdba8800 0x00 0x40>;
++		interrupts = <0x00 0x7d 0x04 0x00>;
++		clocks = <0x21 0x1a1>, < 0x21 0x1a2>;
++		clock-names = "aclk", "iface";
++		power-domains = <0x22 0x15>;
++		#iommu-cells = <0x00>;
++		phandle = <0x69>;
++	};
++
++	vepu121_3: video-codec@fdbac000 {
++		compatible = "rockchip,rk3588-vepu121";
++		reg = <0x00 0xfdbac000 0x00 0x800>;
++		interrupts = <0x00 0x80 0x04 0x00>;
++		clocks = <0x21 0x1a3>, < 0x21 0x1a4>;
++		clock-names = "aclk", "hclk";
++		iommus = <0x6a>;
++		power-domains = <0x22 0x15>;
++	};
++
++	vepu121_3_mmu: iommu@fdbac800 {
++		compatible = "rockchip,rk3588-iommu", "rockchip,rk3568-iommu";
++		reg = <0x00 0xfdbac800 0x00 0x40>;
++		interrupts = <0x00 0x7f 0x04 0x00>;
++		clocks = <0x21 0x1a3>, < 0x21 0x1a4>;
++		clock-names = "aclk", "iface";
++		power-domains = <0x22 0x15>;
++		#iommu-cells = <0x00>;
++		phandle = <0x6a>;
++	};
++
++	av1d: video-codec@fdc70000 {
++		compatible = "rockchip,rk3588-av1-vpu";
++		reg = <0x00 0xfdc70000 0x00 0x800>;
++		interrupts = <0x00 0x6c 0x04 0x00>;
++		interrupt-names = "vdpu";
++		assigned-clocks = <0x21 0x41>, < 0x21 0x43>;
++		assigned-clock-rates = <0x17d78400>, <0x17d78400>;
++		clocks = <0x21 0x41>, < 0x21 0x43>;
++		clock-names = "aclk", "hclk";
++		power-domains = <0x22 0x17>;
++		resets = <0x21 0x1fe>, < 0x21 0x200>, < 0x21 0x1fd>, < 0x21 0x1ff>;
++	};
++
++	vop: vop@fdd90000 {
++		compatible = "rockchip,rk3588-vop";
++		reg = <0x00 0xfdd90000 0x00 0x4200>, <0x00 0xfdd95000 0x00 0x1000>;
++		reg-names = "vop", "gamma-lut";
++		interrupts = <0x00 0x9c 0x04 0x00>;
++		clocks = <0x21 0x25d>, < 0x21 0x25c>, < 0x21 0x261>, < 0x21 0x262>, < 0x21 0x263>, < 0x21 0x264>, < 0x21 0x25b>, < 0x6b>, < 0x6c>;
++		clock-names = "aclk", "hclk", "dclk_vp0", "dclk_vp1", "dclk_vp2", "dclk_vp3", "pclk_vop", "pll_hdmiphy0", "pll_hdmiphy1";
++		iommus = <0x6d>;
++		power-domains = <0x22 0x18>;
++		resets = <0x21 0x19d>, < 0x21 0x1a0>, < 0x21 0x1a1>, < 0x21 0x1a2>;
++		reset-names = "dclk_vp0", "dclk_vp1", "dclk_vp2", "dclk_vp3";
++		rockchip,grf = <0x6e>;
++		rockchip,vop-grf = <0x6f>;
++		rockchip,vo1-grf = <0x70>;
++		rockchip,pmu = <0x71>;
++		status = "okay";
++
++		vop_out: ports {
++			#address-cells = <0x01>;
++			#size-cells = <0x00>;
++			phandle = <0x1b>;
++
++			vp0: port@0 {
++				#address-cells = <0x01>;
++				#size-cells = <0x00>;
++				reg = <0x00>;
++
++				vp0_out_hdmi0: endpoint@2 {
++					reg = <0x02>;
++					remote-endpoint = <0x72>;
++					phandle = <0x79>;
++				};
++			};
++
++			vp1: port@1 {
++				#address-cells = <0x01>;
++				#size-cells = <0x00>;
++				reg = <0x01>;
++
++				vp1_out_hdmi1: endpoint@8 {
++					reg = <0x08>;
++					remote-endpoint = <0x73>;
++					phandle = <0x109>;
++				};
++			};
++
++			vp2: port@2 {
++				#address-cells = <0x01>;
++				#size-cells = <0x00>;
++				reg = <0x02>;
++			};
++
++			vp3: port@3 {
++				#address-cells = <0x01>;
++				#size-cells = <0x00>;
++				reg = <0x03>;
++			};
++		};
++	};
++
++	vop_mmu: iommu@fdd97e00 {
++		compatible = "rockchip,rk3588-iommu", "rockchip,rk3568-iommu";
++		reg = <0x00 0xfdd97e00 0x00 0x100>, <0x00 0xfdd97f00 0x00 0x100>;
++		interrupts = <0x00 0x9c 0x04 0x00>;
++		clocks = <0x21 0x25d>, < 0x21 0x25c>;
++		clock-names = "aclk", "iface";
++		#iommu-cells = <0x00>;
++		power-domains = <0x22 0x18>;
++		status = "okay";
++		phandle = <0x6d>;
++	};
++
++	i2s4_8ch: i2s@fddc0000 {
++		compatible = "rockchip,rk3588-i2s-tdm";
++		reg = <0x00 0xfddc0000 0x00 0x1000>;
++		interrupts = <0x00 0xb8 0x04 0x00>;
++		clocks = <0x21 0x1ec>, < 0x21 0x1ec>, < 0x21 0x1e1>;
++		clock-names = "mclk_tx", "mclk_rx", "hclk";
++		assigned-clocks = <0x21 0x1ea>;
++		assigned-clock-parents = <0x21 0x04>;
++		dmas = <0x74 0x00>;
++		dma-names = "tx";
++		power-domains = <0x22 0x19>;
++		resets = <0x21 0x1b8>;
++		reset-names = "tx-m";
++		#sound-dai-cells = <0x00>;
++		status = "disabled";
++	};
++
++	i2s5_8ch: i2s@fddf0000 {
++		compatible = "rockchip,rk3588-i2s-tdm";
++		reg = <0x00 0xfddf0000 0x00 0x1000>;
++		interrupts = <0x00 0xb9 0x04 0x00>;
++		clocks = <0x21 0x234>, < 0x21 0x234>, < 0x21 0x235>;
++		clock-names = "mclk_tx", "mclk_rx", "hclk";
++		assigned-clocks = <0x21 0x231>;
++		assigned-clock-parents = <0x21 0x04>;
++		dmas = <0x74 0x02>;
++		dma-names = "tx";
++		power-domains = <0x22 0x1a>;
++		resets = <0x21 0x1d8>;
++		reset-names = "tx-m";
++		#sound-dai-cells = <0x00>;
++		status = "okay";
++		phandle = <0x1e>;
++	};
++
++	i2s9_8ch: i2s@fddfc000 {
++		compatible = "rockchip,rk3588-i2s-tdm";
++		reg = <0x00 0xfddfc000 0x00 0x1000>;
++		interrupts = <0x00 0xbd 0x04 0x00>;
++		clocks = <0x21 0x230>, < 0x21 0x230>, < 0x21 0x22c>;
++		clock-names = "mclk_tx", "mclk_rx", "hclk";
++		assigned-clocks = <0x21 0x22d>;
++		assigned-clock-parents = <0x21 0x04>;
++		dmas = <0x74 0x17>;
++		dma-names = "rx";
++		power-domains = <0x22 0x1a>;
++		resets = <0x21 0x1ec>;
++		reset-names = "rx-m";
++		#sound-dai-cells = <0x00>;
++		status = "disabled";
++	};
++
++	hdmi0: hdmi@fde80000 {
++		compatible = "rockchip,rk3588-dw-hdmi-qp";
++		reg = <0x00 0xfde80000 0x00 0x20000>;
++		clocks = <0x21 0x210>, < 0x21 0x211>, < 0x21 0x212>, < 0x21 0x234>, < 0x21 0x252>, < 0x21 0x2cd>;
++		clock-names = "pclk", "earc", "ref", "aud", "hdp", "hclk_vo1";
++		interrupts = <0x00 0xa9 0x04 0x00>, <0x00 0xaa 0x04 0x00>, <0x00 0xab 0x04 0x00>, <0x00 0xac 0x04 0x00>, <0x00 0x168 0x04 0x00>;
++		interrupt-names = "avp", "cec", "earc", "main", "hpd";
++		phys = <0x6b>;
++		pinctrl-names = "default";
++		pinctrl-0 = <0x75 0x76 0x77 0x78>;
++		power-domains = <0x22 0x1a>;
++		resets = <0x21 0x1ce>, < 0x21 0x230>;
++		reset-names = "ref", "hdp";
++		rockchip,grf = <0x6e>;
++		rockchip,vo-grf = <0x70>;
++		#sound-dai-cells = <0x00>;
++		status = "okay";
++		phandle = <0x1d>;
++
++		ports {
++			#address-cells = <0x01>;
++			#size-cells = <0x00>;
++
++			hdmi0_in: port@0 {
++				reg = <0x00>;
++
++				hdmi0_in_vp0: endpoint {
++					remote-endpoint = <0x79>;
++					phandle = <0x72>;
++				};
++			};
++
++			hdmi0_out: port@1 {
++				reg = <0x01>;
++
++				hdmi0_out_con: endpoint {
++					remote-endpoint = <0x7a>;
++					phandle = <0x128>;
++				};
++			};
++		};
++	};
++
++	qos_gpu_m0: qos@fdf35000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf35000 0x00 0x20>;
++		phandle = <0x3c>;
++	};
++
++	qos_gpu_m1: qos@fdf35200 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf35200 0x00 0x20>;
++		phandle = <0x3d>;
++	};
++
++	qos_gpu_m2: qos@fdf35400 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf35400 0x00 0x20>;
++		phandle = <0x3e>;
++	};
++
++	qos_gpu_m3: qos@fdf35600 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf35600 0x00 0x20>;
++		phandle = <0x3f>;
++	};
++
++	qos_rga3_1: qos@fdf36000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf36000 0x00 0x20>;
++		phandle = <0x5f>;
++	};
++
++	qos_sdio: qos@fdf39000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf39000 0x00 0x20>;
++		phandle = <0x64>;
++	};
++
++	qos_sdmmc: qos@fdf3d800 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf3d800 0x00 0x20>;
++		phandle = <0x65>;
++	};
++
++	qos_usb3_1: qos@fdf3e000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf3e000 0x00 0x20>;
++		phandle = <0x61>;
++	};
++
++	qos_usb3_0: qos@fdf3e200 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf3e200 0x00 0x20>;
++		phandle = <0x60>;
++	};
++
++	qos_usb2host_0: qos@fdf3e400 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf3e400 0x00 0x20>;
++		phandle = <0x62>;
++	};
++
++	qos_usb2host_1: qos@fdf3e600 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf3e600 0x00 0x20>;
++		phandle = <0x63>;
++	};
++
++	qos_fisheye0: qos@fdf40000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf40000 0x00 0x20>;
++		phandle = <0x5d>;
++	};
++
++	qos_fisheye1: qos@fdf40200 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf40200 0x00 0x20>;
++		phandle = <0x5e>;
++	};
++
++	qos_isp0_mro: qos@fdf40400 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf40400 0x00 0x20>;
++		phandle = <0x57>;
++	};
++
++	qos_isp0_mwo: qos@fdf40500 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf40500 0x00 0x20>;
++		phandle = <0x58>;
++	};
++
++	qos_vicap_m0: qos@fdf40600 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf40600 0x00 0x20>;
++		phandle = <0x59>;
++	};
++
++	qos_vicap_m1: qos@fdf40800 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf40800 0x00 0x20>;
++		phandle = <0x5a>;
++	};
++
++	qos_isp1_mwo: qos@fdf41000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf41000 0x00 0x20>;
++		phandle = <0x5b>;
++	};
++
++	qos_isp1_mro: qos@fdf41100 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf41100 0x00 0x20>;
++		phandle = <0x5c>;
++	};
++
++	qos_rkvenc0_m0ro: qos@fdf60000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf60000 0x00 0x20>;
++		phandle = <0x42>;
++	};
++
++	qos_rkvenc0_m1ro: qos@fdf60200 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf60200 0x00 0x20>;
++		phandle = <0x43>;
++	};
++
++	qos_rkvenc0_m2wo: qos@fdf60400 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf60400 0x00 0x20>;
++		phandle = <0x44>;
++	};
++
++	qos_rkvenc1_m0ro: qos@fdf61000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf61000 0x00 0x20>;
++		phandle = <0x45>;
++	};
++
++	qos_rkvenc1_m1ro: qos@fdf61200 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf61200 0x00 0x20>;
++		phandle = <0x46>;
++	};
++
++	qos_rkvenc1_m2wo: qos@fdf61400 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf61400 0x00 0x20>;
++		phandle = <0x47>;
++	};
++
++	qos_rkvdec0: qos@fdf62000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf62000 0x00 0x20>;
++		phandle = <0x40>;
++	};
++
++	qos_rkvdec1: qos@fdf63000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf63000 0x00 0x20>;
++		phandle = <0x41>;
++	};
++
++	qos_av1: qos@fdf64000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf64000 0x00 0x20>;
++		phandle = <0x50>;
++	};
++
++	qos_iep: qos@fdf66000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf66000 0x00 0x20>;
++		phandle = <0x48>;
++	};
++
++	qos_jpeg_dec: qos@fdf66200 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf66200 0x00 0x20>;
++		phandle = <0x49>;
++	};
++
++	qos_jpeg_enc0: qos@fdf66400 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf66400 0x00 0x20>;
++		phandle = <0x4a>;
++	};
++
++	qos_jpeg_enc1: qos@fdf66600 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf66600 0x00 0x20>;
++		phandle = <0x4b>;
++	};
++
++	qos_jpeg_enc2: qos@fdf66800 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf66800 0x00 0x20>;
++		phandle = <0x4c>;
++	};
++
++	qos_jpeg_enc3: qos@fdf66a00 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf66a00 0x00 0x20>;
++		phandle = <0x4d>;
++	};
++
++	qos_rga2_mro: qos@fdf66c00 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf66c00 0x00 0x20>;
++		phandle = <0x4e>;
++	};
++
++	qos_rga2_mwo: qos@fdf66e00 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf66e00 0x00 0x20>;
++		phandle = <0x4f>;
++	};
++
++	qos_rga3_0: qos@fdf67000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf67000 0x00 0x20>;
++		phandle = <0x51>;
++	};
++
++	qos_vdpu: qos@fdf67200 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf67200 0x00 0x20>;
++	};
++
++	qos_npu1: qos@fdf70000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf70000 0x00 0x20>;
++		phandle = <0x3a>;
++	};
++
++	qos_npu2: qos@fdf71000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf71000 0x00 0x20>;
++		phandle = <0x3b>;
++	};
++
++	qos_npu0_mwr: qos@fdf72000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf72000 0x00 0x20>;
++		phandle = <0x37>;
++	};
++
++	qos_npu0_mro: qos@fdf72200 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf72200 0x00 0x20>;
++		phandle = <0x38>;
++	};
++
++	qos_mcu_npu: qos@fdf72400 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf72400 0x00 0x20>;
++		phandle = <0x39>;
++	};
++
++	qos_hdcp0: qos@fdf80000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf80000 0x00 0x20>;
++		phandle = <0x54>;
++	};
++
++	qos_hdcp1: qos@fdf81000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf81000 0x00 0x20>;
++		phandle = <0x55>;
++	};
++
++	qos_hdmirx: qos@fdf81200 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf81200 0x00 0x20>;
++		phandle = <0x56>;
++	};
++
++	qos_vop_m0: qos@fdf82000 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf82000 0x00 0x20>;
++		phandle = <0x52>;
++	};
++
++	qos_vop_m1: qos@fdf82200 {
++		compatible = "rockchip,rk3588-qos", "syscon";
++		reg = <0x00 0xfdf82200 0x00 0x20>;
++		phandle = <0x53>;
++	};
++
++	dfi: dfi@fe060000 {
++		reg = <0x00 0xfe060000 0x00 0x10000>;
++		compatible = "rockchip,rk3588-dfi";
++		interrupts = <0x00 0x1c 0x04 0x00>, <0x00 0x26 0x04 0x00>, <0x00 0x30 0x04 0x00>, <0x00 0x3a 0x04 0x00>;
++		rockchip,pmu = <0x7b>;
++	};
++
++	pcie2x1l1: pcie@fe180000 {
++		compatible = "rockchip,rk3588-pcie", "rockchip,rk3568-pcie";
++		bus-range = <0x30 0x3f>;
++		clocks = <0x21 0x143>, < 0x21 0x148>, < 0x21 0x13e>, < 0x21 0x14d>, < 0x21 0x152>, < 0x21 0x2b0>;
++		clock-names = "aclk_mst", "aclk_slv", "aclk_dbi", "pclk", "aux", "pipe";
++		device_type = "pci";
++		interrupts = <0x00 0xf8 0x04 0x00>, <0x00 0xf7 0x04 0x00>, <0x00 0xf6 0x04 0x00>, <0x00 0xf5 0x04 0x00>, <0x00 0xf4 0x04 0x00>;
++		interrupt-names = "sys", "pmc", "msg", "legacy", "err";
++		#interrupt-cells = <0x01>;
++		interrupt-map-mask = <0x00 0x00 0x00 0x07>;
++		interrupt-map = <0x00 0x00 0x00 0x01 0x7c 0x00>, <0x00 0x00 0x00 0x02 0x7c 0x01>, <0x00 0x00 0x00 0x03 0x7c 0x02>, <0x00 0x00 0x00 0x04 0x7c 0x03>;
++		linux,pci-domain = <0x03>;
++		max-link-speed = <0x02>;
++		msi-map = <0x3000 0x7d 0x3000 0x1000>;
++		iommu-map = <0x3000 0x7e 0x3000 0x1000>;
++		num-lanes = <0x01>;
++		phys = <0x2b 0x02>;
++		phy-names = "pcie-phy";
++		power-domains = <0x22 0x22>;
++		ranges = <0x1000000 0x00 0xf3100000 0x00 0xf3100000 0x00 0x100000>, <0x2000000 0x00 0xf3200000 0x00 0xf3200000 0x00 0xe00000>, <0x3000000 0x00 0x40000000 0x09 0xc0000000 0x00 0x40000000>;
++		reg = <0x0a 0x40c00000 0x00 0x400000>, <0x00 0xfe180000 0x00 0x10000>, <0x00 0xf3000000 0x00 0x100000>;
++		reg-names = "dbi", "apb", "config";
++		resets = <0x21 0x129>, < 0x21 0x12e>;
++		reset-names = "pwr", "pipe";
++		#address-cells = <0x03>;
++		#size-cells = <0x02>;
++		status = "okay";
++		reset-gpios = <0x7f 0x1c 0x00>;
++		vpcie3v3-supply = <0x80>;
++
++		pcie2x1l1_intc: legacy-interrupt-controller {
++			interrupt-controller;
++			#address-cells = <0x00>;
++			#interrupt-cells = <0x01>;
++			interrupt-parent = <0x01>;
++			interrupts = <0x00 0xf5 0x01 0x00>;
++			phandle = <0x7c>;
++		};
++	};
++
++	pcie2x1l2: pcie@fe190000 {
++		compatible = "rockchip,rk3588-pcie", "rockchip,rk3568-pcie";
++		bus-range = <0x40 0x4f>;
++		clocks = <0x21 0x144>, < 0x21 0x149>, < 0x21 0x13f>, < 0x21 0x14e>, < 0x21 0x153>, < 0x21 0x173>;
++		clock-names = "aclk_mst", "aclk_slv", "aclk_dbi", "pclk", "aux", "pipe";
++		device_type = "pci";
++		interrupts = <0x00 0xfd 0x04 0x00>, <0x00 0xfc 0x04 0x00>, <0x00 0xfb 0x04 0x00>, <0x00 0xfa 0x04 0x00>, <0x00 0xf9 0x04 0x00>;
++		interrupt-names = "sys", "pmc", "msg", "legacy", "err";
++		#interrupt-cells = <0x01>;
++		interrupt-map-mask = <0x00 0x00 0x00 0x07>;
++		interrupt-map = <0x00 0x00 0x00 0x01 0x81 0x00>, <0x00 0x00 0x00 0x02 0x81 0x01>, <0x00 0x00 0x00 0x03 0x81 0x02>, <0x00 0x00 0x00 0x04 0x81 0x03>;
++		linux,pci-domain = <0x04>;
++		max-link-speed = <0x02>;
++		msi-map = <0x4000 0x7d 0x4000 0x1000>;
++		iommu-map = <0x4000 0x7e 0x4000 0x1000>;
++		num-lanes = <0x01>;
++		phys = <0x82 0x02>;
++		phy-names = "pcie-phy";
++		power-domains = <0x22 0x22>;
++		ranges = <0x1000000 0x00 0xf4100000 0x00 0xf4100000 0x00 0x100000>, <0x2000000 0x00 0xf4200000 0x00 0xf4200000 0x00 0xe00000>, <0x3000000 0x00 0x40000000 0x0a 0x00 0x00 0x40000000>;
++		reg = <0x0a 0x41000000 0x00 0x400000>, <0x00 0xfe190000 0x00 0x10000>, <0x00 0xf4000000 0x00 0x100000>;
++		reg-names = "dbi", "apb", "config";
++		resets = <0x21 0x12a>, < 0x21 0x12f>;
++		reset-names = "pwr", "pipe";
++		#address-cells = <0x03>;
++		#size-cells = <0x02>;
++		status = "disabled";
++
++		pcie2x1l2_intc: legacy-interrupt-controller {
++			interrupt-controller;
++			#address-cells = <0x00>;
++			#interrupt-cells = <0x01>;
++			interrupt-parent = <0x01>;
++			interrupts = <0x00 0xfa 0x01 0x00>;
++			phandle = <0x81>;
++		};
++	};
++
++	gmac1: ethernet@fe1c0000 {
++		compatible = "rockchip,rk3588-gmac", "snps,dwmac-4.20a";
++		reg = <0x00 0xfe1c0000 0x00 0x10000>;
++		interrupts = <0x00 0xea 0x04 0x00>, <0x00 0xe9 0x04 0x00>;
++		interrupt-names = "macirq", "eth_wake_irq";
++		clocks = <0x21 0x136>, < 0x21 0x137>, < 0x21 0x159>, < 0x21 0x15e>, < 0x21 0x135>;
++		clock-names = "stmmaceth", "clk_mac_ref", "pclk_mac", "aclk_mac", "ptp_ref";
++		power-domains = <0x22 0x21>;
++		resets = <0x21 0x124>;
++		reset-names = "stmmaceth";
++		rockchip,grf = <0x6e>;
++		rockchip,php-grf = <0x2e>;
++		snps,axi-config = <0x83>;
++		snps,mixed-burst;
++		snps,mtl-rx-config = <0x84>;
++		snps,mtl-tx-config = <0x85>;
++		snps,tso;
++		status = "disabled";
++
++		mdio1: mdio {
++			compatible = "snps,dwmac-mdio";
++			#address-cells = <0x01>;
++			#size-cells = <0x00>;
++		};
++
++		gmac1_stmmac_axi_setup: stmmac-axi-config {
++			snps,blen = <0x00 0x00 0x00 0x00 0x10 0x08 0x04>;
++			snps,wr_osr_lmt = <0x04>;
++			snps,rd_osr_lmt = <0x08>;
++			phandle = <0x83>;
++		};
++
++		gmac1_mtl_rx_setup: rx-queues-config {
++			snps,rx-queues-to-use = <0x02>;
++			phandle = <0x84>;
++
++			queue0 {
++			};
++
++			queue1 {
++			};
++		};
++
++		gmac1_mtl_tx_setup: tx-queues-config {
++			snps,tx-queues-to-use = <0x02>;
++			phandle = <0x85>;
++
++			queue0 {
++			};
++
++			queue1 {
++			};
++		};
++	};
++
++	sata0: sata@fe210000 {
++		compatible = "rockchip,rk3588-dwc-ahci", "snps,dwc-ahci";
++		reg = <0x00 0xfe210000 0x00 0x1000>;
++		interrupts = <0x00 0x111 0x04 0x00>;
++		clocks = <0x21 0x162>, < 0x21 0x15f>, < 0x21 0x165>, < 0x21 0x154>, < 0x21 0x16f>;
++		clock-names = "sata", "pmalive", "rxoob", "ref", "asic";
++		ports-implemented = <0x01>;
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++
++		sata-port@0 {
++			reg = <0x00>;
++			hba-port-cap = <0x400000>;
++			phys = <0x82 0x01>;
++			phy-names = "sata-phy";
++			snps,rx-ts-max = <0x20>;
++			snps,tx-ts-max = <0x20>;
++		};
++	};
++
++	sata2: sata@fe230000 {
++		compatible = "rockchip,rk3588-dwc-ahci", "snps,dwc-ahci";
++		reg = <0x00 0xfe230000 0x00 0x1000>;
++		interrupts = <0x00 0x113 0x04 0x00>;
++		clocks = <0x21 0x164>, < 0x21 0x161>, < 0x21 0x167>, < 0x21 0x156>, < 0x21 0x171>;
++		clock-names = "sata", "pmalive", "rxoob", "ref", "asic";
++		ports-implemented = <0x01>;
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++
++		sata-port@0 {
++			reg = <0x00>;
++			hba-port-cap = <0x400000>;
++			phys = <0x2b 0x01>;
++			phy-names = "sata-phy";
++			snps,rx-ts-max = <0x20>;
++			snps,tx-ts-max = <0x20>;
++		};
++	};
++
++	sfc: spi@fe2b0000 {
++		compatible = "rockchip,sfc";
++		reg = <0x00 0xfe2b0000 0x00 0x4000>;
++		interrupts = <0x00 0xce 0x04 0x00>;
++		clocks = <0x21 0x12f>, < 0x21 0x130>;
++		clock-names = "clk_sfc", "hclk_sfc";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "okay";
++		pinctrl-names = "default";
++		pinctrl-0 = <0x86>;
++
++		spi_flash: flash@0 {
++			compatible = "jedec,spi-nor";
++			reg = <0x00>;
++			spi-max-frequency = <0x5f5e100>;
++			spi-rx-bus-width = <0x04>;
++			spi-tx-bus-width = <0x01>;
++		};
++	};
++
++	sdmmc: mmc@fe2c0000 {
++		compatible = "rockchip,rk3588-dw-mshc", "rockchip,rk3288-dw-mshc";
++		reg = <0x00 0xfe2c0000 0x00 0x4000>;
++		interrupts = <0x00 0xcb 0x04 0x00>;
++		clocks = <0x0a 0x17>, < 0x0a 0x09>, < 0x21 0x2ad>, < 0x21 0x2ae>;
++		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
++		fifo-depth = <0x100>;
++		max-frequency = <0x8f0d180>;
++		pinctrl-names = "default";
++		pinctrl-0 = <0x87 0x88 0x89 0x8a>;
++		power-domains = <0x22 0x28>;
++		status = "okay";
++		bus-width = <0x04>;
++		cap-sd-highspeed;
++		cd-gpios = <0x8b 0x04 0x01>;
++		disable-wp;
++		no-sdio;
++		no-mmc;
++		sd-uhs-sdr104;
++		vmmc-supply = <0x8c>;
++		vqmmc-supply = <0x8d>;
++	};
++
++	sdio: mmc@fe2d0000 {
++		compatible = "rockchip,rk3588-dw-mshc", "rockchip,rk3288-dw-mshc";
++		reg = <0x00 0xfe2d0000 0x00 0x4000>;
++		interrupts = <0x00 0xcc 0x04 0x00>;
++		clocks = <0x21 0x18a>, < 0x21 0x18b>, < 0x21 0x2ab>, < 0x21 0x2ac>;
++		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
++		fifo-depth = <0x100>;
++		max-frequency = <0xbebc200>;
++		pinctrl-names = "default";
++		pinctrl-0 = <0x8e>;
++		power-domains = <0x22 0x25>;
++		status = "disabled";
++	};
++
++	sdhci: mmc@fe2e0000 {
++		compatible = "rockchip,rk3588-dwcmshc";
++		reg = <0x00 0xfe2e0000 0x00 0x10000>;
++		interrupts = <0x00 0xcd 0x04 0x00>;
++		assigned-clocks = <0x21 0x12d>, < 0x21 0x12e>, < 0x21 0x12c>;
++		assigned-clock-rates = <0xbebc200>, <0x16e3600>, <0xbebc200>;
++		clocks = <0x21 0x12c>, < 0x21 0x12a>, < 0x21 0x12b>, < 0x21 0x12d>, < 0x21 0x12e>;
++		clock-names = "core", "bus", "axi", "block", "timer";
++		max-frequency = <0xbebc200>;
++		pinctrl-0 = <0x8f>, < 0x90>, < 0x91>, < 0x92>, < 0x93>;
++		pinctrl-names = "default";
++		resets = <0x21 0x118>, < 0x21 0x116>, < 0x21 0x117>, < 0x21 0x119>, < 0x21 0x11a>;
++		reset-names = "core", "bus", "axi", "block", "timer";
++		status = "okay";
++		bus-width = <0x08>;
++		no-sdio;
++		no-sd;
++		non-removable;
++		mmc-hs400-1_8v;
++		mmc-hs400-enhanced-strobe;
++	};
++
++	crypto: crypto@fe370000 {
++		compatible = "rockchip,rk3588-crypto";
++		reg = <0x00 0xfe370000 0x00 0x2000>;
++		interrupts = <0x00 0xd1 0x04 0x00>;
++		clocks = <0x0a 0x14>, < 0x0a 0x0b>, < 0x0a 0x0c>;
++		clock-names = "core", "aclk", "hclk";
++		resets = <0x94 0x0f>;
++		reset-names = "core";
++		status = "okay";
++	};
++
++	i2s0_8ch: i2s@fe470000 {
++		compatible = "rockchip,rk3588-i2s-tdm";
++		reg = <0x00 0xfe470000 0x00 0x1000>;
++		interrupts = <0x00 0xb4 0x04 0x00>;
++		clocks = <0x21 0x2b>, < 0x21 0x2f>, < 0x21 0x28>;
++		clock-names = "mclk_tx", "mclk_rx", "hclk";
++		assigned-clocks = <0x21 0x29>, < 0x21 0x2d>;
++		assigned-clock-parents = <0x21 0x04>, < 0x21 0x04>;
++		dmas = <0x31 0x00>, < 0x31 0x01>;
++		dma-names = "tx", "rx";
++		power-domains = <0x22 0x26>;
++		resets = <0x21 0x2a>, < 0x21 0x2b>;
++		reset-names = "tx-m", "rx-m";
++		rockchip,trcm-sync-tx-only;
++		pinctrl-names = "default";
++		pinctrl-0 = <0x95 0x96 0x97 0x98 0x99>;
++		#sound-dai-cells = <0x00>;
++		status = "okay";
++		phandle = <0x123>;
++	};
++
++	i2s1_8ch: i2s@fe480000 {
++		compatible = "rockchip,rk3588-i2s-tdm";
++		reg = <0x00 0xfe480000 0x00 0x1000>;
++		interrupts = <0x00 0xb5 0x04 0x00>;
++		clocks = <0x21 0x279>, < 0x21 0x27d>, < 0x21 0x275>;
++		clock-names = "mclk_tx", "mclk_rx", "hclk";
++		dmas = <0x31 0x02>, < 0x31 0x03>;
++		dma-names = "tx", "rx";
++		resets = <0x21 0x25e>, < 0x21 0x25f>;
++		reset-names = "tx-m", "rx-m";
++		rockchip,trcm-sync-tx-only;
++		pinctrl-names = "default";
++		pinctrl-0 = <0x9a 0x9b 0x9c 0x9d 0x9e 0x9f 0xa0 0xa1 0xa2 0xa3>;
++		#sound-dai-cells = <0x00>;
++		status = "disabled";
++	};
++
++	i2s2_2ch: i2s@fe490000 {
++		compatible = "rockchip,rk3588-i2s", "rockchip,rk3066-i2s";
++		reg = <0x00 0xfe490000 0x00 0x1000>;
++		interrupts = <0x00 0xb6 0x04 0x00>;
++		clocks = <0x21 0x1f>, < 0x21 0x1a>;
++		clock-names = "i2s_clk", "i2s_hclk";
++		assigned-clocks = <0x21 0x1c>;
++		assigned-clock-parents = <0x21 0x04>;
++		dmas = <0xa4 0x00>, < 0xa4 0x01>;
++		dma-names = "tx", "rx";
++		power-domains = <0x22 0x26>;
++		pinctrl-names = "default";
++		pinctrl-0 = <0xa5 0xa6 0xa7 0xa8>;
++		#sound-dai-cells = <0x00>;
++		status = "okay";
++	};
++
++	i2s3_2ch: i2s@fe4a0000 {
++		compatible = "rockchip,rk3588-i2s", "rockchip,rk3066-i2s";
++		reg = <0x00 0xfe4a0000 0x00 0x1000>;
++		interrupts = <0x00 0xb7 0x04 0x00>;
++		clocks = <0x21 0x25>, < 0x21 0x1b>;
++		clock-names = "i2s_clk", "i2s_hclk";
++		assigned-clocks = <0x21 0x22>;
++		assigned-clock-parents = <0x21 0x04>;
++		dmas = <0xa4 0x02>, < 0xa4 0x03>;
++		dma-names = "tx", "rx";
++		power-domains = <0x22 0x26>;
++		pinctrl-names = "default";
++		pinctrl-0 = <0xa9 0xaa 0xab 0xac>;
++		#sound-dai-cells = <0x00>;
++		status = "disabled";
++	};
++
++	gic: interrupt-controller@fe600000 {
++		compatible = "arm,gic-v3";
++		reg = <0x00 0xfe600000 0x00 0x10000>, <0x00 0xfe680000 0x00 0x100000>;
++		interrupts = <0x01 0x09 0x04 0x00>;
++		interrupt-controller;
++		mbi-alias = <0x00 0xfe610000>;
++		mbi-ranges = <0x1a8 0x38>;
++		msi-controller;
++		ranges;
++		#address-cells = <0x02>;
++		#interrupt-cells = <0x04>;
++		#size-cells = <0x02>;
++		phandle = <0x01>;
++
++		its0: msi-controller@fe640000 {
++			compatible = "arm,gic-v3-its";
++			reg = <0x00 0xfe640000 0x00 0x20000>;
++			msi-controller;
++			#msi-cells = <0x01>;
++			phandle = <0x7d>;
++		};
++
++		its1: msi-controller@fe660000 {
++			compatible = "arm,gic-v3-its";
++			reg = <0x00 0xfe660000 0x00 0x20000>;
++			msi-controller;
++			#msi-cells = <0x01>;
++			phandle = <0x10c>;
++		};
++
++		ppi-partitions {
++
++			ppi_partition0: interrupt-partition-0 {
++				affinity = <0x02 0x03 0x04 0x05>;
++				phandle = <0x1f>;
++			};
++
++			ppi_partition1: interrupt-partition-1 {
++				affinity = <0x06 0x07 0x08 0x09>;
++				phandle = <0x20>;
++			};
++		};
++	};
++
++	dmac0: dma-controller@fea10000 {
++		compatible = "arm,pl330", "arm,primecell";
++		reg = <0x00 0xfea10000 0x00 0x4000>;
++		interrupts = <0x00 0x56 0x04 0x00>, <0x00 0x57 0x04 0x00>;
++		arm,pl330-periph-burst;
++		clocks = <0x21 0x6e>;
++		clock-names = "apb_pclk";
++		#dma-cells = <0x01>;
++		phandle = <0x31>;
++	};
++
++	dmac1: dma-controller@fea30000 {
++		compatible = "arm,pl330", "arm,primecell";
++		reg = <0x00 0xfea30000 0x00 0x4000>;
++		interrupts = <0x00 0x58 0x04 0x00>, <0x00 0x59 0x04 0x00>;
++		arm,pl330-periph-burst;
++		clocks = <0x21 0x6f>;
++		clock-names = "apb_pclk";
++		#dma-cells = <0x01>;
++		phandle = <0xa4>;
++	};
++
++	i2c1: i2c@fea90000 {
++		compatible = "rockchip,rk3588-i2c", "rockchip,rk3399-i2c";
++		reg = <0x00 0xfea90000 0x00 0x1000>;
++		clocks = <0x21 0x83>, < 0x21 0x7b>;
++		clock-names = "i2c", "pclk";
++		interrupts = <0x00 0x13e 0x04 0x00>;
++		pinctrl-0 = <0xad>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++	};
++
++	i2c2: i2c@feaa0000 {
++		compatible = "rockchip,rk3588-i2c", "rockchip,rk3399-i2c";
++		reg = <0x00 0xfeaa0000 0x00 0x1000>;
++		clocks = <0x21 0x84>, < 0x21 0x7c>;
++		clock-names = "i2c", "pclk";
++		interrupts = <0x00 0x13f 0x04 0x00>;
++		pinctrl-0 = <0xae>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++	};
++
++	i2c3: i2c@feab0000 {
++		compatible = "rockchip,rk3588-i2c", "rockchip,rk3399-i2c";
++		reg = <0x00 0xfeab0000 0x00 0x1000>;
++		clocks = <0x21 0x85>, < 0x21 0x7d>;
++		clock-names = "i2c", "pclk";
++		interrupts = <0x00 0x140 0x04 0x00>;
++		pinctrl-0 = <0xaf>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++	};
++
++	i2c4: i2c@feac0000 {
++		compatible = "rockchip,rk3588-i2c", "rockchip,rk3399-i2c";
++		reg = <0x00 0xfeac0000 0x00 0x1000>;
++		clocks = <0x21 0x86>, < 0x21 0x7e>;
++		clock-names = "i2c", "pclk";
++		interrupts = <0x00 0x141 0x04 0x00>;
++		pinctrl-0 = <0xb0>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++	};
++
++	i2c5: i2c@fead0000 {
++		compatible = "rockchip,rk3588-i2c", "rockchip,rk3399-i2c";
++		reg = <0x00 0xfead0000 0x00 0x1000>;
++		clocks = <0x21 0x87>, < 0x21 0x7f>;
++		clock-names = "i2c", "pclk";
++		interrupts = <0x00 0x142 0x04 0x00>;
++		pinctrl-0 = <0xb1>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++	};
++
++	timer0: timer@feae0000 {
++		compatible = "rockchip,rk3588-timer", "rockchip,rk3288-timer";
++		reg = <0x00 0xfeae0000 0x00 0x20>;
++		interrupts = <0x00 0x121 0x04 0x00>;
++		clocks = <0x21 0x54>, < 0x21 0x57>;
++		clock-names = "pclk", "timer";
++	};
++
++	wdt: watchdog@feaf0000 {
++		compatible = "rockchip,rk3588-wdt", "snps,dw-wdt";
++		reg = <0x00 0xfeaf0000 0x00 0x100>;
++		clocks = <0x21 0x64>, < 0x21 0x63>;
++		clock-names = "tclk", "pclk";
++		interrupts = <0x00 0x13b 0x04 0x00>;
++	};
++
++	spi0: spi@feb00000 {
++		compatible = "rockchip,rk3588-spi", "rockchip,rk3066-spi";
++		reg = <0x00 0xfeb00000 0x00 0x1000>;
++		interrupts = <0x00 0x146 0x04 0x00>;
++		clocks = <0x21 0x97>, < 0x21 0x92>;
++		clock-names = "spiclk", "apb_pclk";
++		dmas = <0x31 0x0e>, < 0x31 0x0f>;
++		dma-names = "tx", "rx";
++		num-cs = <0x02>;
++		pinctrl-0 = <0xb2 0xb3 0xb4>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++	};
++
++	spi1: spi@feb10000 {
++		compatible = "rockchip,rk3588-spi", "rockchip,rk3066-spi";
++		reg = <0x00 0xfeb10000 0x00 0x1000>;
++		interrupts = <0x00 0x147 0x04 0x00>;
++		clocks = <0x21 0x98>, < 0x21 0x93>;
++		clock-names = "spiclk", "apb_pclk";
++		dmas = <0x31 0x10>, < 0x31 0x11>;
++		dma-names = "tx", "rx";
++		num-cs = <0x02>;
++		pinctrl-0 = <0xb5 0xb6 0xb7>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++	};
++
++	spi2: spi@feb20000 {
++		compatible = "rockchip,rk3588-spi", "rockchip,rk3066-spi";
++		reg = <0x00 0xfeb20000 0x00 0x1000>;
++		interrupts = <0x00 0x148 0x04 0x00>;
++		clocks = <0x21 0x99>, < 0x21 0x94>;
++		clock-names = "spiclk", "apb_pclk";
++		dmas = <0xa4 0x0f>, < 0xa4 0x10>;
++		dma-names = "tx", "rx";
++		num-cs = <0x01>;
++		pinctrl-0 = <0xb8 0xb9>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "okay";
++		assigned-clocks = <0x21 0x99>;
++		assigned-clock-rates = <0xbebc200>;
++
++		pmic@0 {
++			compatible = "rockchip,rk806";
++			reg = <0x00>;
++			interrupt-parent = <0x8b>;
++			interrupts = <0x07 0x08>;
++			pinctrl-names = "default";
++			pinctrl-0 = <0xba>, < 0xbb>, < 0xbc>, < 0xbd>;
++			spi-max-frequency = <0xf4240>;
++			system-power-controller;
++			vcc1-supply = <0x30>;
++			vcc2-supply = <0x30>;
++			vcc3-supply = <0x30>;
++			vcc4-supply = <0x30>;
++			vcc5-supply = <0x30>;
++			vcc6-supply = <0x30>;
++			vcc7-supply = <0x30>;
++			vcc8-supply = <0x30>;
++			vcc9-supply = <0x30>;
++			vcc10-supply = <0x30>;
++			vcc11-supply = <0xbe>;
++			vcc12-supply = <0x30>;
++			vcc13-supply = <0xbf>;
++			vcc14-supply = <0xbf>;
++			vcca-supply = <0x30>;
++			gpio-controller;
++			#gpio-cells = <0x02>;
++
++			rk806_dvs1_null: dvs1-null-pins {
++				pins = "gpio_pwrctrl1";
++				function = "pin_fun0";
++				phandle = <0xbb>;
++			};
++
++			rk806_dvs2_null: dvs2-null-pins {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun0";
++				phandle = <0xbc>;
++			};
++
++			rk806_dvs3_null: dvs3-null-pins {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun0";
++				phandle = <0xbd>;
++			};
++
++			regulators {
++
++				vdd_gpu_s0: dcdc-reg1 {
++					regulator-name = "vdd_gpu_s0";
++					regulator-boot-on;
++					regulator-enable-ramp-delay = <0x190>;
++					regulator-min-microvolt = <0x86470>;
++					regulator-max-microvolt = <0xe7ef0>;
++					regulator-ramp-delay = <0x30d4>;
++					phandle = <0x24>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++					};
++				};
++
++				vdd_cpu_lit_s0: dcdc-reg2 {
++					regulator-name = "vdd_cpu_lit_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0x86470>;
++					regulator-max-microvolt = <0xe7ef0>;
++					regulator-ramp-delay = <0x30d4>;
++					phandle = <0x0e>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++					};
++				};
++
++				vdd_log_s0: dcdc-reg3 {
++					regulator-name = "vdd_log_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0xa4cb8>;
++					regulator-max-microvolt = <0xc96a8>;
++					regulator-ramp-delay = <0x30d4>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++						regulator-suspend-microvolt = <0xb71b0>;
++					};
++				};
++
++				vdd_vdenc_s0: dcdc-reg4 {
++					regulator-name = "vdd_vdenc_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0x86470>;
++					regulator-max-microvolt = <0xc96a8>;
++					regulator-ramp-delay = <0x30d4>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++					};
++				};
++
++				vdd_ddr_s0: dcdc-reg5 {
++					regulator-name = "vdd_ddr_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0xa4cb8>;
++					regulator-max-microvolt = <0xdbba0>;
++					regulator-ramp-delay = <0x30d4>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++						regulator-suspend-microvolt = <0xcf850>;
++					};
++				};
++
++				vdd2_ddr_s3: dcdc-reg6 {
++					regulator-name = "vdd2_ddr_s3";
++					regulator-always-on;
++					regulator-boot-on;
++					phandle = <0xbf>;
++
++					regulator-state-mem {
++						regulator-on-in-suspend;
++					};
++				};
++
++				vcc_2v0_pldo_s3: dcdc-reg7 {
++					regulator-name = "vdd_2v0_pldo_s3";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0x1e8480>;
++					regulator-max-microvolt = <0x1e8480>;
++					regulator-ramp-delay = <0x30d4>;
++					phandle = <0xbe>;
++
++					regulator-state-mem {
++						regulator-on-in-suspend;
++						regulator-suspend-microvolt = <0x1e8480>;
++					};
++				};
++
++				vcc_3v3_s3: dcdc-reg8 {
++					regulator-name = "vcc_3v3_s3";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0x325aa0>;
++					regulator-max-microvolt = <0x325aa0>;
++					phandle = <0x8c>;
++
++					regulator-state-mem {
++						regulator-on-in-suspend;
++						regulator-suspend-microvolt = <0x325aa0>;
++					};
++				};
++
++				vddq_ddr_s0: dcdc-reg9 {
++					regulator-name = "vddq_ddr_s0";
++					regulator-always-on;
++					regulator-boot-on;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++					};
++				};
++
++				vcc_1v8_s3: dcdc-reg10 {
++					regulator-name = "vcc_1v8_s3";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0x1b7740>;
++					regulator-max-microvolt = <0x1b7740>;
++
++					regulator-state-mem {
++						regulator-on-in-suspend;
++						regulator-suspend-microvolt = <0x1b7740>;
++					};
++				};
++
++				avcc_1v8_s0: pldo-reg1 {
++					regulator-name = "avcc_1v8_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0x1b7740>;
++					regulator-max-microvolt = <0x1b7740>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++						regulator-suspend-microvolt = <0x1b7740>;
++					};
++				};
++
++				vcc_1v8_s0: pldo-reg2 {
++					regulator-name = "vcc_1v8_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0x1b7740>;
++					regulator-max-microvolt = <0x1b7740>;
++					phandle = <0xe3>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++						regulator-suspend-microvolt = <0x1b7740>;
++					};
++				};
++
++				avdd_1v2_s0: pldo-reg3 {
++					regulator-name = "avdd_1v2_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0x124f80>;
++					regulator-max-microvolt = <0x124f80>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++					};
++				};
++
++				vcc_3v3_s0: pldo-reg4 {
++					regulator-name = "vcc_3v3_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0x325aa0>;
++					regulator-max-microvolt = <0x325aa0>;
++					regulator-ramp-delay = <0x30d4>;
++					phandle = <0xe7>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++					};
++				};
++
++				vccio_sd_s0: pldo-reg5 {
++					regulator-name = "vccio_sd_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0x1b7740>;
++					regulator-max-microvolt = <0x325aa0>;
++					regulator-ramp-delay = <0x30d4>;
++					phandle = <0x8d>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++					};
++				};
++
++				pldo6_s3: pldo-reg6 {
++					regulator-name = "pldo6_s3";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0x1b7740>;
++					regulator-max-microvolt = <0x1b7740>;
++
++					regulator-state-mem {
++						regulator-on-in-suspend;
++						regulator-suspend-microvolt = <0x1b7740>;
++					};
++				};
++
++				vdd_0v75_s3: nldo-reg1 {
++					regulator-name = "vdd_0v75_s3";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0xb71b0>;
++					regulator-max-microvolt = <0xb71b0>;
++
++					regulator-state-mem {
++						regulator-on-in-suspend;
++						regulator-suspend-microvolt = <0xb71b0>;
++					};
++				};
++
++				vdd_ddr_pll_s0: nldo-reg2 {
++					regulator-name = "vdd_ddr_pll_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0xcf850>;
++					regulator-max-microvolt = <0xcf850>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++						regulator-suspend-microvolt = <0xcf850>;
++					};
++				};
++
++				avdd_0v75_s0: nldo-reg3 {
++					regulator-name = "avdd_0v75_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0xc96a8>;
++					regulator-max-microvolt = <0xc96a8>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++					};
++				};
++
++				vdd_0v85_s0: nldo-reg4 {
++					regulator-name = "vdd_0v85_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0xcf850>;
++					regulator-max-microvolt = <0xcf850>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++					};
++				};
++
++				vdd_0v75_s0: nldo-reg5 {
++					regulator-name = "vdd_0v75_s0";
++					regulator-always-on;
++					regulator-boot-on;
++					regulator-min-microvolt = <0xb71b0>;
++					regulator-max-microvolt = <0xb71b0>;
++
++					regulator-state-mem {
++						regulator-off-in-suspend;
++					};
++				};
++			};
++		};
++	};
++
++	spi3: spi@feb30000 {
++		compatible = "rockchip,rk3588-spi", "rockchip,rk3066-spi";
++		reg = <0x00 0xfeb30000 0x00 0x1000>;
++		interrupts = <0x00 0x149 0x04 0x00>;
++		clocks = <0x21 0x9a>, < 0x21 0x95>;
++		clock-names = "spiclk", "apb_pclk";
++		dmas = <0xa4 0x11>, < 0xa4 0x12>;
++		dma-names = "tx", "rx";
++		num-cs = <0x02>;
++		pinctrl-0 = <0xc0 0xc1 0xc2>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++	};
++
++	uart1: serial@feb40000 {
++		compatible = "rockchip,rk3588-uart", "snps,dw-apb-uart";
++		reg = <0x00 0xfeb40000 0x00 0x100>;
++		interrupts = <0x00 0x14c 0x04 0x00>;
++		clocks = <0x21 0xab>, < 0x21 0x9f>;
++		clock-names = "baudclk", "apb_pclk";
++		dmas = <0x31 0x08>, < 0x31 0x09>;
++		dma-names = "tx", "rx";
++		pinctrl-0 = <0xc3>;
++		pinctrl-names = "default";
++		reg-io-width = <0x04>;
++		reg-shift = <0x02>;
++		status = "disabled";
++	};
++
++	uart2: serial@feb50000 {
++		compatible = "rockchip,rk3588-uart", "snps,dw-apb-uart";
++		reg = <0x00 0xfeb50000 0x00 0x100>;
++		interrupts = <0x00 0x14d 0x04 0x00>;
++		clocks = <0x21 0xaf>, < 0x21 0xa0>;
++		clock-names = "baudclk", "apb_pclk";
++		dmas = <0x31 0x0a>, < 0x31 0x0b>;
++		dma-names = "tx", "rx";
++		pinctrl-0 = <0xc4>;
++		pinctrl-names = "default";
++		reg-io-width = <0x04>;
++		reg-shift = <0x02>;
++		status = "okay";
++	};
++
++	uart3: serial@feb60000 {
++		compatible = "rockchip,rk3588-uart", "snps,dw-apb-uart";
++		reg = <0x00 0xfeb60000 0x00 0x100>;
++		interrupts = <0x00 0x14e 0x04 0x00>;
++		clocks = <0x21 0xb3>, < 0x21 0xa1>;
++		clock-names = "baudclk", "apb_pclk";
++		dmas = <0x31 0x0c>, < 0x31 0x0d>;
++		dma-names = "tx", "rx";
++		pinctrl-0 = <0xc5>;
++		pinctrl-names = "default";
++		reg-io-width = <0x04>;
++		reg-shift = <0x02>;
++		status = "disabled";
++	};
++
++	uart4: serial@feb70000 {
++		compatible = "rockchip,rk3588-uart", "snps,dw-apb-uart";
++		reg = <0x00 0xfeb70000 0x00 0x100>;
++		interrupts = <0x00 0x14f 0x04 0x00>;
++		clocks = <0x21 0xb7>, < 0x21 0xa2>;
++		clock-names = "baudclk", "apb_pclk";
++		dmas = <0xa4 0x09>, < 0xa4 0x0a>;
++		dma-names = "tx", "rx";
++		pinctrl-0 = <0xc6>;
++		pinctrl-names = "default";
++		reg-io-width = <0x04>;
++		reg-shift = <0x02>;
++		status = "disabled";
++	};
++
++	uart5: serial@feb80000 {
++		compatible = "rockchip,rk3588-uart", "snps,dw-apb-uart";
++		reg = <0x00 0xfeb80000 0x00 0x100>;
++		interrupts = <0x00 0x150 0x04 0x00>;
++		clocks = <0x21 0xbb>, < 0x21 0xa3>;
++		clock-names = "baudclk", "apb_pclk";
++		dmas = <0xa4 0x0b>, < 0xa4 0x0c>;
++		dma-names = "tx", "rx";
++		pinctrl-0 = <0xc7>;
++		pinctrl-names = "default";
++		reg-io-width = <0x04>;
++		reg-shift = <0x02>;
++		status = "disabled";
++	};
++
++	uart6: serial@feb90000 {
++		compatible = "rockchip,rk3588-uart", "snps,dw-apb-uart";
++		reg = <0x00 0xfeb90000 0x00 0x100>;
++		interrupts = <0x00 0x151 0x04 0x00>;
++		clocks = <0x21 0xbf>, < 0x21 0xa4>;
++		clock-names = "baudclk", "apb_pclk";
++		dmas = <0xa4 0x0d>, < 0xa4 0x0e>;
++		dma-names = "tx", "rx";
++		pinctrl-0 = <0xc8>;
++		pinctrl-names = "default";
++		reg-io-width = <0x04>;
++		reg-shift = <0x02>;
++		status = "disabled";
++	};
++
++	uart7: serial@feba0000 {
++		compatible = "rockchip,rk3588-uart", "snps,dw-apb-uart";
++		reg = <0x00 0xfeba0000 0x00 0x100>;
++		interrupts = <0x00 0x152 0x04 0x00>;
++		clocks = <0x21 0xc3>, < 0x21 0xa5>;
++		clock-names = "baudclk", "apb_pclk";
++		dmas = <0x74 0x07>, < 0x74 0x08>;
++		dma-names = "tx", "rx";
++		pinctrl-0 = <0xc9>;
++		pinctrl-names = "default";
++		reg-io-width = <0x04>;
++		reg-shift = <0x02>;
++		status = "disabled";
++	};
++
++	uart8: serial@febb0000 {
++		compatible = "rockchip,rk3588-uart", "snps,dw-apb-uart";
++		reg = <0x00 0xfebb0000 0x00 0x100>;
++		interrupts = <0x00 0x153 0x04 0x00>;
++		clocks = <0x21 0xc7>, < 0x21 0xa6>;
++		clock-names = "baudclk", "apb_pclk";
++		dmas = <0x74 0x09>, < 0x74 0x0a>;
++		dma-names = "tx", "rx";
++		pinctrl-0 = <0xca>;
++		pinctrl-names = "default";
++		reg-io-width = <0x04>;
++		reg-shift = <0x02>;
++		status = "disabled";
++	};
++
++	uart9: serial@febc0000 {
++		compatible = "rockchip,rk3588-uart", "snps,dw-apb-uart";
++		reg = <0x00 0xfebc0000 0x00 0x100>;
++		interrupts = <0x00 0x154 0x04 0x00>;
++		clocks = <0x21 0xcb>, < 0x21 0xa7>;
++		clock-names = "baudclk", "apb_pclk";
++		dmas = <0x74 0x0b>, < 0x74 0x0c>;
++		dma-names = "tx", "rx";
++		pinctrl-0 = <0xcb>;
++		pinctrl-names = "default";
++		reg-io-width = <0x04>;
++		reg-shift = <0x02>;
++		status = "disabled";
++	};
++
++	pwm4: pwm@febd0000 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebd0000 0x00 0x10>;
++		clocks = <0x21 0x4c>, < 0x21 0x4b>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xcc>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "okay";
++		phandle = <0x11e>;
++	};
++
++	pwm5: pwm@febd0010 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebd0010 0x00 0x10>;
++		clocks = <0x21 0x4c>, < 0x21 0x4b>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xcd>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "okay";
++		phandle = <0x11f>;
++	};
++
++	pwm6: pwm@febd0020 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebd0020 0x00 0x10>;
++		clocks = <0x21 0x4c>, < 0x21 0x4b>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xce>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pwm7: pwm@febd0030 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebd0030 0x00 0x10>;
++		clocks = <0x21 0x4c>, < 0x21 0x4b>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xcf>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pwm8: pwm@febe0000 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebe0000 0x00 0x10>;
++		clocks = <0x21 0x4f>, < 0x21 0x4e>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xd0>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pwm9: pwm@febe0010 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebe0010 0x00 0x10>;
++		clocks = <0x21 0x4f>, < 0x21 0x4e>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xd1>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "okay";
++		phandle = <0x11d>;
++	};
++
++	pwm10: pwm@febe0020 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebe0020 0x00 0x10>;
++		clocks = <0x21 0x4f>, < 0x21 0x4e>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xd2>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pwm11: pwm@febe0030 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebe0030 0x00 0x10>;
++		clocks = <0x21 0x4f>, < 0x21 0x4e>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xd3>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pwm12: pwm@febf0000 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebf0000 0x00 0x10>;
++		clocks = <0x21 0x52>, < 0x21 0x51>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xd4>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pwm13: pwm@febf0010 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebf0010 0x00 0x10>;
++		clocks = <0x21 0x52>, < 0x21 0x51>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xd5>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pwm14: pwm@febf0020 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebf0020 0x00 0x10>;
++		clocks = <0x21 0x52>, < 0x21 0x51>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xd6>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	pwm15: pwm@febf0030 {
++		compatible = "rockchip,rk3588-pwm", "rockchip,rk3328-pwm";
++		reg = <0x00 0xfebf0030 0x00 0x10>;
++		clocks = <0x21 0x52>, < 0x21 0x51>;
++		clock-names = "pwm", "pclk";
++		pinctrl-0 = <0xd7>;
++		pinctrl-names = "default";
++		#pwm-cells = <0x03>;
++		status = "disabled";
++	};
++
++	thermal_zones: thermal-zones {
++
++		package_thermal: package-thermal {
++			polling-delay-passive = <0x00>;
++			polling-delay = <0x3e8>;
++			thermal-sensors = <0xd8 0x00>;
++
++			trips {
++
++				package_crit: package-crit {
++					temperature = <0x1c138>;
++					hysteresis = <0x00>;
++					type = "critical";
++				};
++
++				package_fan0: package-fan0 {
++					temperature = <0xd6d8>;
++					hysteresis = <0x7d0>;
++					type = "active";
++					phandle = <0xd9>;
++				};
++
++				package_fan1: package-fan1 {
++					temperature = <0xfde8>;
++					hysteresis = <0x7d0>;
++					type = "active";
++					phandle = <0xdb>;
++				};
++			};
++
++			cooling-maps {
++
++				map0 {
++					trip = <0xd9>;
++					cooling-device = <0xda 0xffffffff 0x01>;
++				};
++
++				map1 {
++					trip = <0xdb>;
++					cooling-device = <0xda 0x02 0xffffffff>;
++				};
++			};
++		};
++
++		bigcore0_thermal: bigcore0-thermal {
++			polling-delay-passive = <0x64>;
++			polling-delay = <0x00>;
++			thermal-sensors = <0xd8 0x01>;
++
++			trips {
++
++				bigcore0_alert: bigcore0-alert {
++					temperature = <0x14c08>;
++					hysteresis = <0x7d0>;
++					type = "passive";
++					phandle = <0xdc>;
++				};
++
++				bigcore0_crit: bigcore0-crit {
++					temperature = <0x1c138>;
++					hysteresis = <0x00>;
++					type = "critical";
++				};
++			};
++
++			cooling-maps {
++
++				map0 {
++					trip = <0xdc>;
++					cooling-device = <0x06 0xffffffff 0xffffffff>, < 0x07 0xffffffff 0xffffffff>;
++				};
++			};
++		};
++
++		bigcore2_thermal: bigcore2-thermal {
++			polling-delay-passive = <0x64>;
++			polling-delay = <0x00>;
++			thermal-sensors = <0xd8 0x02>;
++
++			trips {
++
++				bigcore2_alert: bigcore2-alert {
++					temperature = <0x14c08>;
++					hysteresis = <0x7d0>;
++					type = "passive";
++					phandle = <0xdd>;
++				};
++
++				bigcore2_crit: bigcore2-crit {
++					temperature = <0x1c138>;
++					hysteresis = <0x00>;
++					type = "critical";
++				};
++			};
++
++			cooling-maps {
++
++				map0 {
++					trip = <0xdd>;
++					cooling-device = <0x08 0xffffffff 0xffffffff>, < 0x09 0xffffffff 0xffffffff>;
++				};
++			};
++		};
++
++		little_core_thermal: littlecore-thermal {
++			polling-delay-passive = <0x64>;
++			polling-delay = <0x00>;
++			thermal-sensors = <0xd8 0x03>;
++
++			trips {
++
++				littlecore_alert: littlecore-alert {
++					temperature = <0x14c08>;
++					hysteresis = <0x7d0>;
++					type = "passive";
++					phandle = <0xde>;
++				};
++
++				littlecore_crit: littlecore-crit {
++					temperature = <0x1c138>;
++					hysteresis = <0x00>;
++					type = "critical";
++				};
++			};
++
++			cooling-maps {
++
++				map0 {
++					trip = <0xde>;
++					cooling-device = <0x02 0xffffffff 0xffffffff>, < 0x03 0xffffffff 0xffffffff>, < 0x04 0xffffffff 0xffffffff>, < 0x05 0xffffffff 0xffffffff>;
++				};
++			};
++		};
++
++		center_thermal: center-thermal {
++			polling-delay-passive = <0x00>;
++			polling-delay = <0x00>;
++			thermal-sensors = <0xd8 0x04>;
++
++			trips {
++
++				center_crit: center-crit {
++					temperature = <0x1c138>;
++					hysteresis = <0x00>;
++					type = "critical";
++				};
++			};
++		};
++
++		gpu_thermal: gpu-thermal {
++			polling-delay-passive = <0x64>;
++			polling-delay = <0x00>;
++			thermal-sensors = <0xd8 0x05>;
++
++			trips {
++
++				gpu_alert: gpu-alert {
++					temperature = <0x14c08>;
++					hysteresis = <0x7d0>;
++					type = "passive";
++					phandle = <0xdf>;
++				};
++
++				gpu_crit: gpu-crit {
++					temperature = <0x1c138>;
++					hysteresis = <0x00>;
++					type = "critical";
++				};
++			};
++
++			cooling-maps {
++
++				map0 {
++					trip = <0xdf>;
++					cooling-device = <0xe0 0xffffffff 0xffffffff>;
++				};
++			};
++		};
++
++		npu_thermal: npu-thermal {
++			polling-delay-passive = <0x00>;
++			polling-delay = <0x00>;
++			thermal-sensors = <0xd8 0x06>;
++
++			trips {
++
++				npu_crit: npu-crit {
++					temperature = <0x1c138>;
++					hysteresis = <0x00>;
++					type = "critical";
++				};
++			};
++		};
++	};
++
++	tsadc: tsadc@fec00000 {
++		compatible = "rockchip,rk3588-tsadc";
++		reg = <0x00 0xfec00000 0x00 0x400>;
++		interrupts = <0x00 0x18d 0x04 0x00>;
++		clocks = <0x21 0x9e>, < 0x21 0x9d>;
++		clock-names = "tsadc", "apb_pclk";
++		assigned-clocks = <0x21 0x9e>;
++		assigned-clock-rates = <0x1e8480>;
++		resets = <0x21 0x56>, < 0x21 0x57>;
++		reset-names = "tsadc-apb", "tsadc";
++		rockchip,hw-tshut-temp = <0x1d4c0>;
++		rockchip,hw-tshut-mode = <0x00>;
++		rockchip,hw-tshut-polarity = <0x00>;
++		pinctrl-0 = <0xe1>;
++		pinctrl-1 = <0xe2>;
++		pinctrl-names = "default", "sleep";
++		#thermal-sensor-cells = <0x01>;
++		status = "okay";
++		phandle = <0xd8>;
++	};
++
++	saradc: adc@fec10000 {
++		compatible = "rockchip,rk3588-saradc";
++		reg = <0x00 0xfec10000 0x00 0x10000>;
++		interrupts = <0x00 0x18e 0x04 0x00>;
++		#io-channel-cells = <0x01>;
++		clocks = <0x21 0x91>, < 0x21 0x90>;
++		clock-names = "saradc", "apb_pclk";
++		resets = <0x21 0x55>;
++		reset-names = "saradc-apb";
++		status = "okay";
++		vref-supply = <0xe3>;
++		phandle = <0x11c>;
++	};
++
++	i2c6: i2c@fec80000 {
++		compatible = "rockchip,rk3588-i2c", "rockchip,rk3399-i2c";
++		reg = <0x00 0xfec80000 0x00 0x1000>;
++		clocks = <0x21 0x88>, < 0x21 0x80>;
++		clock-names = "i2c", "pclk";
++		interrupts = <0x00 0x143 0x04 0x00>;
++		pinctrl-0 = <0xe4>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "okay";
++		clock-frequency = <0x61a80>;
++
++		hym8563: rtc@51 {
++			compatible = "haoyu,hym8563";
++			reg = <0x51>;
++			#clock-cells = <0x00>;
++			clock-output-names = "hym8563";
++			wakeup-source;
++			interrupt-parent = <0x8b>;
++			interrupts = <0x14 0x08>;
++			pinctrl-names = "default";
++			pinctrl-0 = <0xe5>;
++		};
++	};
++
++	i2c7: i2c@fec90000 {
++		compatible = "rockchip,rk3588-i2c", "rockchip,rk3399-i2c";
++		reg = <0x00 0xfec90000 0x00 0x1000>;
++		clocks = <0x21 0x89>, < 0x21 0x81>;
++		clock-names = "i2c", "pclk";
++		interrupts = <0x00 0x144 0x04 0x00>;
++		pinctrl-0 = <0xe6>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "okay";
++
++		es8388: audio-codec@11 {
++			compatible = "everest,es8388";
++			reg = <0x11>;
++			clocks = <0x21 0x31>;
++			AVDD-supply = <0xe7>;
++			DVDD-supply = <0xe3>;
++			HPVDD-supply = <0xe7>;
++			PVDD-supply = <0xe3>;
++			assigned-clocks = <0x21 0x31>;
++			assigned-clock-rates = <0xbb8000>;
++			#sound-dai-cells = <0x00>;
++			phandle = <0x124>;
++		};
++	};
++
++	i2c8: i2c@feca0000 {
++		compatible = "rockchip,rk3588-i2c", "rockchip,rk3399-i2c";
++		reg = <0x00 0xfeca0000 0x00 0x1000>;
++		clocks = <0x21 0x8a>, < 0x21 0x82>;
++		clock-names = "i2c", "pclk";
++		interrupts = <0x00 0x145 0x04 0x00>;
++		pinctrl-0 = <0xe8>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++	};
++
++	spi4: spi@fecb0000 {
++		compatible = "rockchip,rk3588-spi", "rockchip,rk3066-spi";
++		reg = <0x00 0xfecb0000 0x00 0x1000>;
++		interrupts = <0x00 0x14a 0x04 0x00>;
++		clocks = <0x21 0x9b>, < 0x21 0x96>;
++		clock-names = "spiclk", "apb_pclk";
++		dmas = <0x74 0x0d>, < 0x74 0x0e>;
++		dma-names = "tx", "rx";
++		num-cs = <0x02>;
++		pinctrl-0 = <0xe9 0xea 0xeb>;
++		pinctrl-names = "default";
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++	};
++
++	otp: efuse@fecc0000 {
++		compatible = "rockchip,rk3588-otp";
++		reg = <0x00 0xfecc0000 0x00 0x400>;
++		clocks = <0x21 0x8c>, < 0x21 0x8b>, < 0x21 0x8f>, < 0x21 0x8d>;
++		clock-names = "otp", "apb_pclk", "phy", "arb";
++		resets = <0x21 0xa7>, < 0x21 0xa6>, < 0x21 0xa8>;
++		reset-names = "otp", "apb", "arb";
++		#address-cells = <0x01>;
++		#size-cells = <0x01>;
++
++		cpu_code: cpu-code@2 {
++			reg = <0x02 0x02>;
++		};
++
++		otp_id: id@7 {
++			reg = <0x07 0x10>;
++		};
++
++		cpub0_leakage: cpu-leakage@17 {
++			reg = <0x17 0x01>;
++		};
++
++		cpub1_leakage: cpu-leakage@18 {
++			reg = <0x18 0x01>;
++		};
++
++		cpul_leakage: cpu-leakage@19 {
++			reg = <0x19 0x01>;
++		};
++
++		log_leakage: log-leakage@1a {
++			reg = <0x1a 0x01>;
++		};
++
++		gpu_leakage: gpu-leakage@1b {
++			reg = <0x1b 0x01>;
++		};
++
++		otp_cpu_version: cpu-version@1c {
++			reg = <0x1c 0x01>;
++			bits = <0x03 0x03>;
++		};
++
++		npu_leakage: npu-leakage@28 {
++			reg = <0x28 0x01>;
++		};
++
++		codec_leakage: codec-leakage@29 {
++			reg = <0x29 0x01>;
++		};
++	};
++
++	dmac2: dma-controller@fed10000 {
++		compatible = "arm,pl330", "arm,primecell";
++		reg = <0x00 0xfed10000 0x00 0x4000>;
++		interrupts = <0x00 0x5a 0x04 0x00>, <0x00 0x5b 0x04 0x00>;
++		arm,pl330-periph-burst;
++		clocks = <0x21 0x70>;
++		clock-names = "apb_pclk";
++		#dma-cells = <0x01>;
++		phandle = <0x74>;
++	};
++
++	hdptxphy0: phy@fed60000 {
++		compatible = "rockchip,rk3588-hdptx-phy";
++		reg = <0x00 0xfed60000 0x00 0x2000>;
++		clocks = <0x21 0x2a0>, < 0x21 0x254>;
++		clock-names = "ref", "apb";
++		#clock-cells = <0x00>;
++		#phy-cells = <0x00>;
++		resets = <0x21 0x223>, < 0x21 0x21a>, < 0x21 0x263>, < 0x21 0x264>, < 0x21 0x265>, < 0x21 0x221>, < 0x21 0x222>;
++		reset-names = "phy", "apb", "init", "cmn", "lane", "ropll", "lcpll";
++		rockchip,grf = <0xec>;
++		status = "okay";
++		phandle = <0x6b>;
++	};
++
++	usbdp_phy0: phy@fed80000 {
++		compatible = "rockchip,rk3588-usbdp-phy";
++		reg = <0x00 0xfed80000 0x00 0x10000>;
++		#phy-cells = <0x01>;
++		clocks = <0x21 0x2a1>, < 0x21 0x26c>, < 0x21 0x256>, < 0xed>;
++		clock-names = "refclk", "immortal", "pclk", "utmi";
++		resets = <0x21 0x0b>, < 0x21 0x0c>, < 0x21 0x0d>, < 0x21 0x0e>, < 0x21 0x217>;
++		reset-names = "init", "cmn", "lane", "pcs_apb", "pma_apb";
++		rockchip,u2phy-grf = <0xee>;
++		rockchip,usb-grf = <0xef>;
++		rockchip,usbdpphy-grf = <0xf0>;
++		rockchip,vo-grf = <0xf1>;
++		status = "okay";
++		phandle = <0x26>;
++	};
++
++	combphy0_ps: phy@fee00000 {
++		compatible = "rockchip,rk3588-naneng-combphy";
++		reg = <0x00 0xfee00000 0x00 0x100>;
++		clocks = <0x21 0x2a8>, < 0x21 0x176>, < 0x21 0x157>;
++		clock-names = "ref", "apb", "pipe";
++		assigned-clocks = <0x21 0x2a8>;
++		assigned-clock-rates = <0x5f5e100>;
++		#phy-cells = <0x01>;
++		resets = <0x21 0x23c>, < 0x21 0x243>;
++		reset-names = "phy", "apb";
++		rockchip,pipe-grf = <0x2e>;
++		rockchip,pipe-phy-grf = <0xf2>;
++		status = "disabled";
++		phandle = <0x82>;
++	};
++
++	combphy2_psu: phy@fee20000 {
++		compatible = "rockchip,rk3588-naneng-combphy";
++		reg = <0x00 0xfee20000 0x00 0x100>;
++		clocks = <0x21 0x2aa>, < 0x21 0x178>, < 0x21 0x157>;
++		clock-names = "ref", "apb", "pipe";
++		assigned-clocks = <0x21 0x2aa>;
++		assigned-clock-rates = <0x5f5e100>;
++		#phy-cells = <0x01>;
++		resets = <0x21 0x23e>, < 0x21 0x245>;
++		reset-names = "phy", "apb";
++		rockchip,pipe-grf = <0x2e>;
++		rockchip,pipe-phy-grf = <0xf3>;
++		status = "okay";
++		phandle = <0x2b>;
++	};
++
++	system_sram2: sram@ff001000 {
++		compatible = "mmio-sram";
++		reg = <0x00 0xff001000 0x00 0xef000>;
++		ranges = <0x00 0x00 0xff001000 0xef000>;
++		#address-cells = <0x01>;
++		#size-cells = <0x01>;
++
++		vdec0_sram: rkvdec-sram@0 {
++			reg = <0x00 0x78000>;
++			pool;
++			phandle = <0xfd>;
++		};
++
++		vdec1_sram: rkvdec-sram@1 {
++			reg = <0x78000 0x77000>;
++			pool;
++			phandle = <0xfe>;
++		};
++	};
++
++	pinctrl: pinctrl {
++		compatible = "rockchip,rk3588-pinctrl";
++		ranges;
++		rockchip,grf = <0xf4>;
++		#address-cells = <0x02>;
++		#size-cells = <0x02>;
++		phandle = <0xf5>;
++
++		gpio0: gpio@fd8a0000 {
++			compatible = "rockchip,gpio-bank";
++			reg = <0x00 0xfd8a0000 0x00 0x100>;
++			interrupts = <0x00 0x115 0x04 0x00>;
++			clocks = <0x21 0x271>, < 0x21 0x272>;
++			gpio-controller;
++			gpio-ranges = <0xf5 0x00 0x00 0x20>;
++			interrupt-controller;
++			#gpio-cells = <0x02>;
++			#interrupt-cells = <0x02>;
++			phandle = <0x8b>;
++		};
++
++		gpio1: gpio@fec20000 {
++			compatible = "rockchip,gpio-bank";
++			reg = <0x00 0xfec20000 0x00 0x100>;
++			interrupts = <0x00 0x116 0x04 0x00>;
++			clocks = <0x21 0x73>, < 0x21 0x74>;
++			gpio-controller;
++			gpio-ranges = <0xf5 0x00 0x20 0x20>;
++			interrupt-controller;
++			#gpio-cells = <0x02>;
++			#interrupt-cells = <0x02>;
++		};
++
++		gpio2: gpio@fec30000 {
++			compatible = "rockchip,gpio-bank";
++			reg = <0x00 0xfec30000 0x00 0x100>;
++			interrupts = <0x00 0x117 0x04 0x00>;
++			clocks = <0x21 0x75>, < 0x21 0x76>;
++			gpio-controller;
++			gpio-ranges = <0xf5 0x00 0x40 0x20>;
++			interrupt-controller;
++			#gpio-cells = <0x02>;
++			#interrupt-cells = <0x02>;
++			phandle = <0x125>;
++		};
++
++		gpio3: gpio@fec40000 {
++			compatible = "rockchip,gpio-bank";
++			reg = <0x00 0xfec40000 0x00 0x100>;
++			interrupts = <0x00 0x118 0x04 0x00>;
++			clocks = <0x21 0x77>, < 0x21 0x78>;
++			gpio-controller;
++			gpio-ranges = <0xf5 0x00 0x60 0x20>;
++			interrupt-controller;
++			#gpio-cells = <0x02>;
++			#interrupt-cells = <0x02>;
++			phandle = <0x7f>;
++		};
++
++		gpio4: gpio@fec50000 {
++			compatible = "rockchip,gpio-bank";
++			reg = <0x00 0xfec50000 0x00 0x100>;
++			interrupts = <0x00 0x119 0x04 0x00>;
++			clocks = <0x21 0x79>, < 0x21 0x7a>;
++			gpio-controller;
++			gpio-ranges = <0xf5 0x00 0x80 0x20>;
++			interrupt-controller;
++			#gpio-cells = <0x02>;
++			#interrupt-cells = <0x02>;
++			phandle = <0x10e>;
++		};
++
++		pcfg_pull_up: pcfg-pull-up {
++			bias-pull-up;
++			phandle = <0xfa>;
++		};
++
++		pcfg_pull_down: pcfg-pull-down {
++			bias-pull-down;
++			phandle = <0xf8>;
++		};
++
++		pcfg_pull_none: pcfg-pull-none {
++			bias-disable;
++			phandle = <0xf6>;
++		};
++
++		pcfg_pull_none_drv_level_2: pcfg-pull-none-drv-level-2 {
++			bias-disable;
++			drive-strength = <0x02>;
++			phandle = <0xfc>;
++		};
++
++		pcfg_pull_up_drv_level_1: pcfg-pull-up-drv-level-1 {
++			bias-pull-up;
++			drive-strength = <0x01>;
++			phandle = <0xfb>;
++		};
++
++		pcfg_pull_up_drv_level_2: pcfg-pull-up-drv-level-2 {
++			bias-pull-up;
++			drive-strength = <0x02>;
++			phandle = <0xf7>;
++		};
++
++		pcfg_pull_none_smt: pcfg-pull-none-smt {
++			bias-disable;
++			input-schmitt-enable;
++			phandle = <0xf9>;
++		};
++
++		auddsm {
++		};
++
++		bt1120 {
++		};
++
++		can0 {
++		};
++
++		can1 {
++		};
++
++		can2 {
++		};
++
++		cif {
++		};
++
++		clk32k {
++		};
++
++		cpu {
++		};
++
++		ddrphych0 {
++		};
++
++		ddrphych1 {
++		};
++
++		ddrphych2 {
++		};
++
++		ddrphych3 {
++		};
++
++		dp0 {
++		};
++
++		dp1 {
++		};
++
++		emmc {
++
++			emmc_rstnout: emmc-rstnout {
++				rockchip,pins = <0x02 0x03 0x01 0xf6>;
++				phandle = <0x8f>;
++			};
++
++			emmc_bus8: emmc-bus8 {
++				rockchip,pins = <0x02 0x18 0x01 0xf7>, <0x02 0x19 0x01 0xf7>, <0x02 0x1a 0x01 0xf7>, <0x02 0x1b 0x01 0xf7>, <0x02 0x1c 0x01 0xf7>, <0x02 0x1d 0x01 0xf7>, <0x02 0x1e 0x01 0xf7>, <0x02 0x1f 0x01 0xf7>;
++				phandle = <0x90>;
++			};
++
++			emmc_clk: emmc-clk {
++				rockchip,pins = <0x02 0x01 0x01 0xf7>;
++				phandle = <0x91>;
++			};
++
++			emmc_cmd: emmc-cmd {
++				rockchip,pins = <0x02 0x00 0x01 0xf7>;
++				phandle = <0x92>;
++			};
++
++			emmc_data_strobe: emmc-data-strobe {
++				rockchip,pins = <0x02 0x02 0x01 0xf8>;
++				phandle = <0x93>;
++			};
++		};
++
++		eth1 {
++		};
++
++		fspi {
++
++			fspim2_pins: fspim2-pins {
++				rockchip,pins = <0x03 0x05 0x05 0xf7>, <0x03 0x14 0x02 0xf7>, <0x03 0x00 0x05 0xf7>, <0x03 0x01 0x05 0xf7>, <0x03 0x02 0x05 0xf7>, <0x03 0x03 0x05 0xf7>;
++				phandle = <0x86>;
++			};
++		};
++
++		gmac1 {
++		};
++
++		gpu {
++		};
++
++		hdmi {
++
++			hdmim0_tx0_cec: hdmim0-tx0-cec {
++				rockchip,pins = <0x04 0x11 0x05 0xf6>;
++				phandle = <0x75>;
++			};
++
++			hdmim0_tx0_hpd: hdmim0-tx0-hpd {
++				rockchip,pins = <0x01 0x05 0x05 0xf6>;
++				phandle = <0x76>;
++			};
++
++			hdmim0_tx0_scl: hdmim0-tx0-scl {
++				rockchip,pins = <0x04 0x0f 0x05 0xf6>;
++				phandle = <0x77>;
++			};
++
++			hdmim0_tx0_sda: hdmim0-tx0-sda {
++				rockchip,pins = <0x04 0x10 0x05 0xf6>;
++				phandle = <0x78>;
++			};
++
++			hdmim0_tx1_hpd: hdmim0-tx1-hpd {
++				rockchip,pins = <0x01 0x06 0x05 0xf6>;
++				phandle = <0x106>;
++			};
++
++			hdmim1_rx: hdmim1-rx {
++				rockchip,pins = <0x03 0x19 0x05 0xf6>, <0x03 0x1a 0x05 0xf9>, <0x03 0x1b 0x05 0xf9>, <0x03 0x1c 0x05 0xf6>;
++				phandle = <0x104>;
++			};
++
++			hdmim1_tx1_scl: hdmim1-tx1-scl {
++				rockchip,pins = <0x03 0x16 0x05 0xf6>;
++				phandle = <0x107>;
++			};
++
++			hdmim1_tx1_sda: hdmim1-tx1-sda {
++				rockchip,pins = <0x03 0x15 0x05 0xf6>;
++				phandle = <0x108>;
++			};
++
++			hdmim0_tx1_cec: hdmim0-tx1-cec {
++				rockchip,pins = <0x02 0x14 0x04 0xf6>;
++				phandle = <0x105>;
++			};
++		};
++
++		i2c0 {
++
++			i2c0m2_xfer: i2c0m2-xfer {
++				rockchip,pins = <0x00 0x19 0x03 0xf9>, <0x00 0x1a 0x03 0xf9>;
++				phandle = <0x2f>;
++			};
++		};
++
++		i2c1 {
++
++			i2c1m0_xfer: i2c1m0-xfer {
++				rockchip,pins = <0x00 0x0d 0x09 0xf9>, <0x00 0x0e 0x09 0xf9>;
++				phandle = <0xad>;
++			};
++		};
++
++		i2c2 {
++
++			i2c2m0_xfer: i2c2m0-xfer {
++				rockchip,pins = <0x00 0x0f 0x09 0xf9>, <0x00 0x10 0x09 0xf9>;
++				phandle = <0xae>;
++			};
++		};
++
++		i2c3 {
++
++			i2c3m0_xfer: i2c3m0-xfer {
++				rockchip,pins = <0x01 0x11 0x09 0xf9>, <0x01 0x10 0x09 0xf9>;
++				phandle = <0xaf>;
++			};
++		};
++
++		i2c4 {
++
++			i2c4m0_xfer: i2c4m0-xfer {
++				rockchip,pins = <0x03 0x06 0x09 0xf9>, <0x03 0x05 0x09 0xf9>;
++				phandle = <0xb0>;
++			};
++		};
++
++		i2c5 {
++
++			i2c5m0_xfer: i2c5m0-xfer {
++				rockchip,pins = <0x03 0x17 0x09 0xf9>, <0x03 0x18 0x09 0xf9>;
++				phandle = <0xb1>;
++			};
++		};
++
++		i2c6 {
++
++			i2c6m0_xfer: i2c6m0-xfer {
++				rockchip,pins = <0x00 0x18 0x09 0xf9>, <0x00 0x17 0x09 0xf9>;
++				phandle = <0xe4>;
++			};
++		};
++
++		i2c7 {
++
++			i2c7m0_xfer: i2c7m0-xfer {
++				rockchip,pins = <0x01 0x18 0x09 0xf9>, <0x01 0x19 0x09 0xf9>;
++				phandle = <0xe6>;
++			};
++		};
++
++		i2c8 {
++
++			i2c8m0_xfer: i2c8m0-xfer {
++				rockchip,pins = <0x04 0x1a 0x09 0xf9>, <0x04 0x1b 0x09 0xf9>;
++				phandle = <0xe8>;
++			};
++		};
++
++		i2s0 {
++
++			i2s0_lrck: i2s0-lrck {
++				rockchip,pins = <0x01 0x15 0x01 0xf6>;
++				phandle = <0x95>;
++			};
++
++			i2s0_mclk: i2s0-mclk {
++				rockchip,pins = <0x01 0x12 0x01 0xf6>;
++				phandle = <0x96>;
++			};
++
++			i2s0_sclk: i2s0-sclk {
++				rockchip,pins = <0x01 0x13 0x01 0xf6>;
++				phandle = <0x97>;
++			};
++
++			i2s0_sdi0: i2s0-sdi0 {
++				rockchip,pins = <0x01 0x1c 0x02 0xf6>;
++				phandle = <0x98>;
++			};
++
++			i2s0_sdo0: i2s0-sdo0 {
++				rockchip,pins = <0x01 0x17 0x01 0xf6>;
++				phandle = <0x99>;
++			};
++		};
++
++		i2s1 {
++
++			i2s1m0_lrck: i2s1m0-lrck {
++				rockchip,pins = <0x04 0x02 0x03 0xf6>;
++				phandle = <0x9a>;
++			};
++
++			i2s1m0_sclk: i2s1m0-sclk {
++				rockchip,pins = <0x04 0x01 0x03 0xf6>;
++				phandle = <0x9b>;
++			};
++
++			i2s1m0_sdi0: i2s1m0-sdi0 {
++				rockchip,pins = <0x04 0x05 0x03 0xf6>;
++				phandle = <0x9c>;
++			};
++
++			i2s1m0_sdi1: i2s1m0-sdi1 {
++				rockchip,pins = <0x04 0x06 0x03 0xf6>;
++				phandle = <0x9d>;
++			};
++
++			i2s1m0_sdi2: i2s1m0-sdi2 {
++				rockchip,pins = <0x04 0x07 0x03 0xf6>;
++				phandle = <0x9e>;
++			};
++
++			i2s1m0_sdi3: i2s1m0-sdi3 {
++				rockchip,pins = <0x04 0x08 0x03 0xf6>;
++				phandle = <0x9f>;
++			};
++
++			i2s1m0_sdo0: i2s1m0-sdo0 {
++				rockchip,pins = <0x04 0x09 0x03 0xf6>;
++				phandle = <0xa0>;
++			};
++
++			i2s1m0_sdo1: i2s1m0-sdo1 {
++				rockchip,pins = <0x04 0x0a 0x03 0xf6>;
++				phandle = <0xa1>;
++			};
++
++			i2s1m0_sdo2: i2s1m0-sdo2 {
++				rockchip,pins = <0x04 0x0b 0x03 0xf6>;
++				phandle = <0xa2>;
++			};
++
++			i2s1m0_sdo3: i2s1m0-sdo3 {
++				rockchip,pins = <0x04 0x0c 0x03 0xf6>;
++				phandle = <0xa3>;
++			};
++		};
++
++		i2s2 {
++
++			i2s2m0_lrck: i2s2m0-lrck {
++				rockchip,pins = <0x02 0x10 0x02 0xf6>;
++				phandle = <0xa5>;
++			};
++
++			i2s2m0_sclk: i2s2m0-sclk {
++				rockchip,pins = <0x02 0x0f 0x02 0xf6>;
++				phandle = <0xa6>;
++			};
++
++			i2s2m0_sdi: i2s2m0-sdi {
++				rockchip,pins = <0x02 0x13 0x02 0xf6>;
++				phandle = <0xa7>;
++			};
++
++			i2s2m0_sdo: i2s2m0-sdo {
++				rockchip,pins = <0x04 0x13 0x02 0xf6>;
++				phandle = <0xa8>;
++			};
++		};
++
++		i2s3 {
++
++			i2s3_lrck: i2s3-lrck {
++				rockchip,pins = <0x03 0x02 0x03 0xf6>;
++				phandle = <0xa9>;
++			};
++
++			i2s3_sclk: i2s3-sclk {
++				rockchip,pins = <0x03 0x01 0x03 0xf6>;
++				phandle = <0xaa>;
++			};
++
++			i2s3_sdi: i2s3-sdi {
++				rockchip,pins = <0x03 0x04 0x03 0xf6>;
++				phandle = <0xab>;
++			};
++
++			i2s3_sdo: i2s3-sdo {
++				rockchip,pins = <0x03 0x03 0x03 0xf6>;
++				phandle = <0xac>;
++			};
++		};
++
++		jtag {
++		};
++
++		litcpu {
++		};
++
++		mcu {
++		};
++
++		mipi {
++		};
++
++		npu {
++		};
++
++		pcie20x1 {
++		};
++
++		pcie30phy {
++		};
++
++		pcie30x1 {
++		};
++
++		pcie30x2 {
++		};
++
++		pcie30x4 {
++		};
++
++		pdm0 {
++		};
++
++		pdm1 {
++		};
++
++		pmic {
++
++			pmic_pins: pmic-pins {
++				rockchip,pins = <0x00 0x07 0x00 0xfa>, <0x00 0x02 0x01 0xf6>, <0x00 0x03 0x01 0xf6>, <0x00 0x11 0x01 0xf6>, <0x00 0x12 0x01 0xf6>, <0x00 0x13 0x01 0xf6>, <0x00 0x1e 0x01 0xf6>;
++				phandle = <0xba>;
++			};
++		};
++
++		pmu {
++		};
++
++		pwm0 {
++
++			pwm0m0_pins: pwm0m0-pins {
++				rockchip,pins = <0x00 0x0f 0x03 0xf6>;
++				phandle = <0x33>;
++			};
++		};
++
++		pwm1 {
++
++			pwm1m0_pins: pwm1m0-pins {
++				rockchip,pins = <0x00 0x10 0x03 0xf6>;
++				phandle = <0x34>;
++			};
++		};
++
++		pwm2 {
++
++			pwm2m0_pins: pwm2m0-pins {
++				rockchip,pins = <0x00 0x14 0x03 0xf6>;
++				phandle = <0x35>;
++			};
++		};
++
++		pwm3 {
++
++			pwm3m0_pins: pwm3m0-pins {
++				rockchip,pins = <0x00 0x1c 0x03 0xf6>;
++				phandle = <0x36>;
++			};
++		};
++
++		pwm4 {
++
++			pwm4m0_pins: pwm4m0-pins {
++				rockchip,pins = <0x00 0x15 0x0b 0xf6>;
++				phandle = <0xcc>;
++			};
++		};
++
++		pwm5 {
++
++			pwm5m1_pins: pwm5m1-pins {
++				rockchip,pins = <0x00 0x16 0x0b 0xf6>;
++				phandle = <0xcd>;
++			};
++		};
++
++		pwm6 {
++
++			pwm6m0_pins: pwm6m0-pins {
++				rockchip,pins = <0x00 0x17 0x0b 0xf6>;
++				phandle = <0xce>;
++			};
++		};
++
++		pwm7 {
++
++			pwm7m0_pins: pwm7m0-pins {
++				rockchip,pins = <0x00 0x18 0x0b 0xf6>;
++				phandle = <0xcf>;
++			};
++		};
++
++		pwm8 {
++
++			pwm8m0_pins: pwm8m0-pins {
++				rockchip,pins = <0x03 0x07 0x0b 0xf6>;
++				phandle = <0xd0>;
++			};
++		};
++
++		pwm9 {
++
++			pwm9m2_pins: pwm9m2-pins {
++				rockchip,pins = <0x03 0x19 0x0b 0xf6>;
++				phandle = <0xd1>;
++			};
++		};
++
++		pwm10 {
++
++			pwm10m0_pins: pwm10m0-pins {
++				rockchip,pins = <0x03 0x00 0x0b 0xf6>;
++				phandle = <0xd2>;
++			};
++		};
++
++		pwm11 {
++
++			pwm11m0_pins: pwm11m0-pins {
++				rockchip,pins = <0x03 0x01 0x0b 0xf6>;
++				phandle = <0xd3>;
++			};
++		};
++
++		pwm12 {
++
++			pwm12m0_pins: pwm12m0-pins {
++				rockchip,pins = <0x03 0x0d 0x0b 0xf6>;
++				phandle = <0xd4>;
++			};
++		};
++
++		pwm13 {
++
++			pwm13m0_pins: pwm13m0-pins {
++				rockchip,pins = <0x03 0x0e 0x0b 0xf6>;
++				phandle = <0xd5>;
++			};
++		};
++
++		pwm14 {
++
++			pwm14m0_pins: pwm14m0-pins {
++				rockchip,pins = <0x03 0x12 0x0b 0xf6>;
++				phandle = <0xd6>;
++			};
++		};
++
++		pwm15 {
++
++			pwm15m0_pins: pwm15m0-pins {
++				rockchip,pins = <0x03 0x13 0x0b 0xf6>;
++				phandle = <0xd7>;
++			};
++		};
++
++		refclk {
++		};
++
++		sata {
++		};
++
++		sata0 {
++		};
++
++		sata1 {
++		};
++
++		sata2 {
++		};
++
++		sdio {
++
++			sdiom1_pins: sdiom1-pins {
++				rockchip,pins = <0x03 0x05 0x02 0xf6>, <0x03 0x04 0x02 0xfa>, <0x03 0x00 0x02 0xfa>, <0x03 0x01 0x02 0xfa>, <0x03 0x02 0x02 0xfa>, <0x03 0x03 0x02 0xfa>;
++				phandle = <0x8e>;
++			};
++		};
++
++		sdmmc {
++
++			sdmmc_bus4: sdmmc-bus4 {
++				rockchip,pins = <0x04 0x18 0x01 0xf7>, <0x04 0x19 0x01 0xf7>, <0x04 0x1a 0x01 0xf7>, <0x04 0x1b 0x01 0xf7>;
++				phandle = <0x8a>;
++			};
++
++			sdmmc_clk: sdmmc-clk {
++				rockchip,pins = <0x04 0x1d 0x01 0xf7>;
++				phandle = <0x87>;
++			};
++
++			sdmmc_cmd: sdmmc-cmd {
++				rockchip,pins = <0x04 0x1c 0x01 0xf7>;
++				phandle = <0x88>;
++			};
++
++			sdmmc_det: sdmmc-det {
++				rockchip,pins = <0x00 0x04 0x01 0xfa>;
++				phandle = <0x89>;
++			};
++		};
++
++		spdif0 {
++		};
++
++		spdif1 {
++		};
++
++		spi0 {
++
++			spi0m0_pins: spi0m0-pins {
++				rockchip,pins = <0x00 0x16 0x08 0xfb>, <0x00 0x17 0x08 0xfb>, <0x00 0x10 0x08 0xfb>;
++				phandle = <0xb4>;
++			};
++
++			spi0m0_cs0: spi0m0-cs0 {
++				rockchip,pins = <0x00 0x19 0x08 0xfb>;
++				phandle = <0xb2>;
++			};
++
++			spi0m0_cs1: spi0m0-cs1 {
++				rockchip,pins = <0x00 0x0f 0x08 0xfb>;
++				phandle = <0xb3>;
++			};
++		};
++
++		spi1 {
++
++			spi1m1_pins: spi1m1-pins {
++				rockchip,pins = <0x03 0x11 0x08 0xfb>, <0x03 0x10 0x08 0xfb>, <0x03 0x0f 0x08 0xfb>;
++				phandle = <0xb7>;
++			};
++
++			spi1m1_cs0: spi1m1-cs0 {
++				rockchip,pins = <0x03 0x12 0x08 0xfb>;
++				phandle = <0xb5>;
++			};
++
++			spi1m1_cs1: spi1m1-cs1 {
++				rockchip,pins = <0x03 0x13 0x08 0xfb>;
++				phandle = <0xb6>;
++			};
++		};
++
++		spi2 {
++
++			spi2m2_pins: spi2m2-pins {
++				rockchip,pins = <0x00 0x05 0x01 0xfb>, <0x00 0x0b 0x01 0xfb>, <0x00 0x06 0x01 0xfb>;
++				phandle = <0xb9>;
++			};
++
++			spi2m2_cs0: spi2m2-cs0 {
++				rockchip,pins = <0x00 0x09 0x01 0xfb>;
++				phandle = <0xb8>;
++			};
++		};
++
++		spi3 {
++
++			spi3m1_pins: spi3m1-pins {
++				rockchip,pins = <0x04 0x0f 0x08 0xfb>, <0x04 0x0d 0x08 0xfb>, <0x04 0x0e 0x08 0xfb>;
++				phandle = <0xc2>;
++			};
++
++			spi3m1_cs0: spi3m1-cs0 {
++				rockchip,pins = <0x04 0x10 0x08 0xfb>;
++				phandle = <0xc0>;
++			};
++
++			spi3m1_cs1: spi3m1-cs1 {
++				rockchip,pins = <0x04 0x11 0x08 0xfb>;
++				phandle = <0xc1>;
++			};
++		};
++
++		spi4 {
++
++			spi4m0_pins: spi4m0-pins {
++				rockchip,pins = <0x01 0x12 0x08 0xfb>, <0x01 0x10 0x08 0xfb>, <0x01 0x11 0x08 0xfb>;
++				phandle = <0xeb>;
++			};
++
++			spi4m0_cs0: spi4m0-cs0 {
++				rockchip,pins = <0x01 0x13 0x08 0xfb>;
++				phandle = <0xe9>;
++			};
++
++			spi4m0_cs1: spi4m0-cs1 {
++				rockchip,pins = <0x01 0x14 0x08 0xfb>;
++				phandle = <0xea>;
++			};
++		};
++
++		tsadc {
++
++			tsadc_shut_org: tsadc-shut-org {
++				rockchip,pins = <0x00 0x01 0x01 0xf6>;
++				phandle = <0xe1>;
++			};
++		};
++
++		uart0 {
++
++			uart0m1_xfer: uart0m1-xfer {
++				rockchip,pins = <0x00 0x08 0x04 0xfa>, <0x00 0x09 0x04 0xfa>;
++				phandle = <0x32>;
++			};
++		};
++
++		uart1 {
++
++			uart1m1_xfer: uart1m1-xfer {
++				rockchip,pins = <0x01 0x0f 0x0a 0xfa>, <0x01 0x0e 0x0a 0xfa>;
++				phandle = <0xc3>;
++			};
++		};
++
++		uart2 {
++
++			uart2m0_xfer: uart2m0-xfer {
++				rockchip,pins = <0x00 0x0e 0x0a 0xfa>, <0x00 0x0d 0x0a 0xfa>;
++				phandle = <0xc4>;
++			};
++		};
++
++		uart3 {
++
++			uart3m1_xfer: uart3m1-xfer {
++				rockchip,pins = <0x03 0x0e 0x0a 0xfa>, <0x03 0x0d 0x0a 0xfa>;
++				phandle = <0xc5>;
++			};
++		};
++
++		uart4 {
++
++			uart4m1_xfer: uart4m1-xfer {
++				rockchip,pins = <0x03 0x18 0x0a 0xfa>, <0x03 0x19 0x0a 0xfa>;
++				phandle = <0xc6>;
++			};
++		};
++
++		uart5 {
++
++			uart5m1_xfer: uart5m1-xfer {
++				rockchip,pins = <0x03 0x15 0x0a 0xfa>, <0x03 0x14 0x0a 0xfa>;
++				phandle = <0xc7>;
++			};
++		};
++
++		uart6 {
++
++			uart6m1_xfer: uart6m1-xfer {
++				rockchip,pins = <0x01 0x00 0x0a 0xfa>, <0x01 0x01 0x0a 0xfa>;
++				phandle = <0xc8>;
++			};
++		};
++
++		uart7 {
++
++			uart7m1_xfer: uart7m1-xfer {
++				rockchip,pins = <0x03 0x11 0x0a 0xfa>, <0x03 0x10 0x0a 0xfa>;
++				phandle = <0xc9>;
++			};
++		};
++
++		uart8 {
++
++			uart8m1_xfer: uart8m1-xfer {
++				rockchip,pins = <0x03 0x03 0x0a 0xfa>, <0x03 0x02 0x0a 0xfa>;
++				phandle = <0xca>;
++			};
++		};
++
++		uart9 {
++
++			uart9m1_xfer: uart9m1-xfer {
++				rockchip,pins = <0x04 0x0d 0x0a 0xfa>, <0x04 0x0c 0x0a 0xfa>;
++				phandle = <0xcb>;
++			};
++		};
++
++		vop {
++		};
++
++		bt656 {
++		};
++
++		gpio-func {
++
++			tsadc_gpio_func: tsadc-gpio-func {
++				rockchip,pins = <0x00 0x01 0x00 0xf6>;
++				phandle = <0xe2>;
++			};
++		};
++
++		eth0 {
++		};
++
++		gmac0 {
++		};
++
++		hym8563 {
++
++			rtc_int_l: hym8563-int {
++				rockchip,pins = <0x00 0x14 0x00 0xf6>;
++				phandle = <0xe5>;
++			};
++		};
++
++		sound {
++
++			hp_detect: hp-detect {
++				rockchip,pins = <0x03 0x1a 0x00 0xf6>;
++				phandle = <0x121>;
++			};
++		};
++
++		usb {
++
++			usb_host_pwren: usb-host-pwren {
++				rockchip,pins = <0x03 0x1d 0x00 0xf6>;
++				phandle = <0x126>;
++			};
++
++			usb_otg_pwren: usb-otg-pwren {
++				rockchip,pins = <0x04 0x0b 0x00 0xf6>;
++				phandle = <0x127>;
++			};
++		};
++	};
++
++	vdec0: video-decoder@fdc38000 {
++		compatible = "rockchip,rk3588-vdec";
++		reg = <0x00 0xfdc38000 0x00 0x100>, <0x00 0xfdc38100 0x00 0x500>, <0x00 0xfdc38600 0x00 0x100>;
++		reg-names = "link", "function", "cache";
++		interrupts = <0x00 0x5f 0x04 0x00>;
++		clocks = <0x21 0x181>, < 0x21 0x180>, < 0x21 0x182>, < 0x21 0x184>, < 0x21 0x183>;
++		clock-names = "axi", "ahb", "cabac", "core", "hevc_cabac";
++		assigned-clocks = <0x21 0x181>, < 0x21 0x184>, < 0x21 0x182>, < 0x21 0x183>;
++		assigned-clock-rates = <0x2faf0800>, <0x23c34600>, <0x23c34600>, <0x3b9aca00>;
++		resets = <0x21 0x143>, < 0x21 0x142>, < 0x21 0x146>, < 0x21 0x148>, < 0x21 0x147>;
++		reset-names = "rst_axi", "rst_ahb", "rst_cabac", "rst_core", "rst_hevc_cabac";
++		power-domains = <0x22 0x0e>;
++		sram = <0xfd>;
++	};
++
++	vdec1: video-decoder@fdc40000 {
++		compatible = "rockchip,rk3588-vdec";
++		reg = <0x00 0xfdc40000 0x00 0x100>, <0x00 0xfdc40100 0x00 0x500>, <0x00 0xfdc40600 0x00 0x100>;
++		reg-names = "link", "function", "cache";
++		interrupts = <0x00 0x61 0x04 0x00>;
++		clocks = <0x21 0x186>, < 0x21 0x185>, < 0x21 0x187>, < 0x21 0x189>, < 0x21 0x188>;
++		clock-names = "axi", "ahb", "cabac", "core", "hevc_cabac";
++		assigned-clocks = <0x21 0x186>, < 0x21 0x189>, < 0x21 0x187>, < 0x21 0x188>;
++		assigned-clock-rates = <0x2faf0800>, <0x23c34600>, <0x23c34600>, <0x3b9aca00>;
++		resets = <0x21 0x14a>, < 0x21 0x149>, < 0x21 0x14d>, < 0x21 0x14f>, < 0x21 0x14e>;
++		reset-names = "rst_axi", "rst_ahb", "rst_cabac", "rst_core", "rst_hevc_cabac";
++		power-domains = <0x22 0x0f>;
++		sram = <0xfe>;
++	};
++
++	reserved-memory {
++		#address-cells = <0x02>;
++		#size-cells = <0x02>;
++		ranges;
++
++		hdmi_receiver_cma: hdmi-receiver-cma {
++			compatible = "shared-dma-pool";
++			alloc-ranges = <0x00 0x00 0x00 0xffffffff>;
++			size = <0x00 0xa000000>;
++			no-map;
++			status = "disabled";
++			phandle = <0x103>;
++		};
++	};
++
++	hdmi1_sound: hdmi1-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <0x80>;
++		simple-audio-card,name = "hdmi1";
++		status = "okay";
++
++		simple-audio-card,codec {
++			sound-dai = <0xff>;
++		};
++
++		simple-audio-card,cpu {
++			sound-dai = <0x100>;
++		};
++	};
++
++	usb_host1_xhci: usb@fc400000 {
++		compatible = "rockchip,rk3588-dwc3", "snps,dwc3";
++		reg = <0x00 0xfc400000 0x00 0x400000>;
++		interrupts = <0x00 0xdd 0x04 0x00>;
++		clocks = <0x21 0x197>, < 0x21 0x196>, < 0x21 0x195>;
++		clock-names = "ref_clk", "suspend_clk", "bus_clk";
++		dr_mode = "host";
++		phys = <0x101>, < 0x102 0x04>;
++		phy-names = "usb2-phy", "usb3-phy";
++		phy_type = "utmi_wide";
++		power-domains = <0x22 0x1f>;
++		resets = <0x21 0x153>;
++		snps,dis_enblslpm_quirk;
++		snps,dis-u2-freeclk-exists-quirk;
++		snps,dis-del-phy-power-chg-quirk;
++		snps,dis-tx-ipgap-linecheck-quirk;
++		status = "okay";
++	};
++
++	pcie30_phy_grf: syscon@fd5b8000 {
++		compatible = "rockchip,rk3588-pcie3-phy-grf", "syscon";
++		reg = <0x00 0xfd5b8000 0x00 0x10000>;
++		phandle = <0x11b>;
++	};
++
++	pipe_phy1_grf: syscon@fd5c0000 {
++		compatible = "rockchip,rk3588-pipe-phy-grf", "syscon";
++		reg = <0x00 0xfd5c0000 0x00 0x100>;
++		phandle = <0x11a>;
++	};
++
++	usbdpphy1_grf: syscon@fd5cc000 {
++		compatible = "rockchip,rk3588-usbdpphy-grf", "syscon";
++		reg = <0x00 0xfd5cc000 0x00 0x4000>;
++		phandle = <0x119>;
++	};
++
++	usb2phy1_grf: syscon@fd5d4000 {
++		compatible = "rockchip,rk3588-usb2phy-grf", "syscon", "simple-mfd";
++		reg = <0x00 0xfd5d4000 0x00 0x4000>;
++		#address-cells = <0x01>;
++		#size-cells = <0x01>;
++		phandle = <0x118>;
++
++		u2phy1: usb2phy@4000 {
++			compatible = "rockchip,rk3588-usb2phy";
++			reg = <0x4000 0x10>;
++			#clock-cells = <0x00>;
++			clocks = <0x21 0x2a0>;
++			clock-names = "phyclk";
++			clock-output-names = "usb480m_phy1";
++			interrupts = <0x00 0x18a 0x04 0x00>;
++			resets = <0x21 0x26e>, < 0x21 0x21e>;
++			reset-names = "phy", "apb";
++			status = "okay";
++			phandle = <0x117>;
++
++			u2phy1_otg: otg-port {
++				#phy-cells = <0x00>;
++				status = "okay";
++				phy-supply = <0x2d>;
++				phandle = <0x101>;
++			};
++		};
++	};
++
++	hdptxphy1_grf: syscon@fd5e4000 {
++		compatible = "rockchip,rk3588-hdptxphy-grf", "syscon";
++		reg = <0x00 0xfd5e4000 0x00 0x100>;
++		phandle = <0x116>;
++	};
++
++	i2s8_8ch: i2s@fddc8000 {
++		compatible = "rockchip,rk3588-i2s-tdm";
++		reg = <0x00 0xfddc8000 0x00 0x1000>;
++		interrupts = <0x00 0xbc 0x04 0x00>;
++		clocks = <0x21 0x1f1>, < 0x21 0x1f1>, < 0x21 0x1ee>;
++		clock-names = "mclk_tx", "mclk_rx", "hclk";
++		assigned-clocks = <0x21 0x1ef>;
++		assigned-clock-parents = <0x21 0x04>;
++		dmas = <0x74 0x16>;
++		dma-names = "tx";
++		power-domains = <0x22 0x19>;
++		resets = <0x21 0x1ba>;
++		reset-names = "tx-m";
++		#sound-dai-cells = <0x00>;
++		status = "disabled";
++	};
++
++	i2s6_8ch: i2s@fddf4000 {
++		compatible = "rockchip,rk3588-i2s-tdm";
++		reg = <0x00 0xfddf4000 0x00 0x1000>;
++		interrupts = <0x00 0xba 0x04 0x00>;
++		clocks = <0x21 0x239>, < 0x21 0x239>, < 0x21 0x23f>;
++		clock-names = "mclk_tx", "mclk_rx", "hclk";
++		assigned-clocks = <0x21 0x236>;
++		assigned-clock-parents = <0x21 0x04>;
++		dmas = <0x74 0x04>;
++		dma-names = "tx";
++		power-domains = <0x22 0x1a>;
++		resets = <0x21 0x1da>;
++		reset-names = "tx-m";
++		#sound-dai-cells = <0x00>;
++		status = "okay";
++		phandle = <0x100>;
++	};
++
++	i2s7_8ch: i2s@fddf8000 {
++		compatible = "rockchip,rk3588-i2s-tdm";
++		reg = <0x00 0xfddf8000 0x00 0x1000>;
++		interrupts = <0x00 0xbb 0x04 0x00>;
++		clocks = <0x21 0x22b>, < 0x21 0x22b>, < 0x21 0x227>;
++		clock-names = "mclk_tx", "mclk_rx", "hclk";
++		assigned-clocks = <0x21 0x228>;
++		assigned-clock-parents = <0x21 0x04>;
++		dmas = <0x74 0x15>;
++		dma-names = "rx";
++		power-domains = <0x22 0x1a>;
++		resets = <0x21 0x1c7>;
++		reset-names = "rx-m";
++		#sound-dai-cells = <0x00>;
++		status = "disabled";
++	};
++
++	i2s10_8ch: i2s@fde00000 {
++		compatible = "rockchip,rk3588-i2s-tdm";
++		reg = <0x00 0xfde00000 0x00 0x1000>;
++		interrupts = <0x00 0xbe 0x04 0x00>;
++		clocks = <0x21 0x226>, < 0x21 0x226>, < 0x21 0x222>;
++		clock-names = "mclk_tx", "mclk_rx", "hclk";
++		assigned-clocks = <0x21 0x223>;
++		assigned-clock-parents = <0x21 0x04>;
++		dmas = <0x74 0x18>;
++		dma-names = "rx";
++		power-domains = <0x22 0x1a>;
++		resets = <0x21 0x1ee>;
++		reset-names = "rx-m";
++		#sound-dai-cells = <0x00>;
++		status = "disabled";
++	};
++
++	hdmi_receiver: hdmi_receiver@fdee0000 {
++		compatible = "rockchip,rk3588-hdmirx-ctrler", "snps,dw-hdmi-rx";
++		reg = <0x00 0xfdee0000 0x00 0x6000>;
++		power-domains = <0x22 0x1a>;
++		rockchip,grf = <0x6e>;
++		rockchip,vo1-grf = <0x70>;
++		interrupts = <0x00 0xb1 0x04 0x00>, <0x00 0x1b4 0x04 0x00>, <0x00 0xb3 0x04 0x00>;
++		interrupt-names = "cec", "hdmi", "dma";
++		clocks = <0x21 0x209>, < 0x21 0x20e>, < 0x21 0x29f>, < 0x21 0x20a>, < 0x21 0x20b>, < 0x21 0x221>, < 0x21 0x2cd>;
++		clock-names = "aclk", "audio", "cr_para", "pclk", "ref", "hclk_s_hdmirx", "hclk_vo1";
++		resets = <0x21 0x1d1>, < 0x21 0x1d2>, < 0x21 0x1d3>, < 0x21 0x294>;
++		reset-names = "axi", "apb", "ref", "biu";
++		memory-region = <0x103>;
++		pinctrl-0 = <0x104>;
++		pinctrl-names = "default";
++		status = "disabled";
++	};
++
++	hdmi1: hdmi@fdea0000 {
++		compatible = "rockchip,rk3588-dw-hdmi-qp";
++		reg = <0x00 0xfdea0000 0x00 0x20000>;
++		clocks = <0x21 0x213>, < 0x21 0x214>, < 0x21 0x215>, < 0x21 0x239>, < 0x21 0x253>, < 0x21 0x2cd>;
++		clock-names = "pclk", "earc", "ref", "aud", "hdp", "hclk_vo1";
++		interrupts = <0x00 0xad 0x04 0x00>, <0x00 0xae 0x04 0x00>, <0x00 0xaf 0x04 0x00>, <0x00 0xb0 0x04 0x00>, <0x00 0x169 0x04 0x00>;
++		interrupt-names = "avp", "cec", "earc", "main", "hpd";
++		phys = <0x6c>;
++		pinctrl-names = "default";
++		pinctrl-0 = <0x105 0x106 0x107 0x108>;
++		power-domains = <0x22 0x1a>;
++		resets = <0x21 0x1d0>, < 0x21 0x231>;
++		reset-names = "ref", "hdp";
++		rockchip,grf = <0x6e>;
++		rockchip,vo-grf = <0x70>;
++		#sound-dai-cells = <0x00>;
++		status = "okay";
++		phandle = <0xff>;
++
++		ports {
++			#address-cells = <0x01>;
++			#size-cells = <0x00>;
++
++			hdmi1_in: port@0 {
++				reg = <0x00>;
++
++				hdmi1_in_vp1: endpoint {
++					remote-endpoint = <0x109>;
++					phandle = <0x73>;
++				};
++			};
++
++			hdmi1_out: port@1 {
++				reg = <0x01>;
++
++				hdmi1_out_con: endpoint {
++					remote-endpoint = <0x10a>;
++					phandle = <0x129>;
++				};
++			};
++		};
++	};
++
++	pcie3x4: pcie@fe150000 {
++		compatible = "rockchip,rk3588-pcie", "rockchip,rk3568-pcie";
++		#address-cells = <0x03>;
++		#size-cells = <0x02>;
++		bus-range = <0x00 0x0f>;
++		clocks = <0x21 0x140>, < 0x21 0x145>, < 0x21 0x13b>, < 0x21 0x14a>, < 0x21 0x14f>, < 0x21 0x174>;
++		clock-names = "aclk_mst", "aclk_slv", "aclk_dbi", "pclk", "aux", "pipe";
++		device_type = "pci";
++		interrupts = <0x00 0x107 0x04 0x00>, <0x00 0x106 0x04 0x00>, <0x00 0x105 0x04 0x00>, <0x00 0x104 0x04 0x00>, <0x00 0x103 0x04 0x00>;
++		interrupt-names = "sys", "pmc", "msg", "legacy", "err";
++		#interrupt-cells = <0x01>;
++		interrupt-map-mask = <0x00 0x00 0x00 0x07>;
++		interrupt-map = <0x00 0x00 0x00 0x01 0x10b 0x00>, <0x00 0x00 0x00 0x02 0x10b 0x01>, <0x00 0x00 0x00 0x03 0x10b 0x02>, <0x00 0x00 0x00 0x04 0x10b 0x03>;
++		linux,pci-domain = <0x00>;
++		max-link-speed = <0x03>;
++		msi-map = <0x00 0x10c 0x00 0x1000>;
++		iommu-map = <0x00 0x7e 0x00 0x1000>;
++		num-lanes = <0x04>;
++		phys = <0x10d>;
++		phy-names = "pcie-phy";
++		power-domains = <0x22 0x22>;
++		ranges = <0x1000000 0x00 0xf0100000 0x00 0xf0100000 0x00 0x100000>, <0x2000000 0x00 0xf0200000 0x00 0xf0200000 0x00 0xe00000>, <0x3000000 0x00 0x40000000 0x09 0x00 0x00 0x40000000>;
++		reg = <0x0a 0x40000000 0x00 0x400000>, <0x00 0xfe150000 0x00 0x10000>, <0x00 0xf0000000 0x00 0x100000>;
++		reg-names = "dbi", "apb", "config";
++		resets = <0x21 0x126>, < 0x21 0x12b>;
++		reset-names = "pwr", "pipe";
++		status = "okay";
++		reset-gpios = <0x10e 0x0e 0x00>;
++		vpcie3v3-supply = <0x10f>;
++
++		pcie3x4_intc: legacy-interrupt-controller {
++			interrupt-controller;
++			#address-cells = <0x00>;
++			#interrupt-cells = <0x01>;
++			interrupt-parent = <0x01>;
++			interrupts = <0x00 0x104 0x01 0x00>;
++			phandle = <0x10b>;
++		};
++	};
++
++	pcie3x4_ep: pcie-ep@fe150000 {
++		compatible = "rockchip,rk3588-pcie-ep";
++		reg = <0x0a 0x40000000 0x00 0x100000>, <0x0a 0x40100000 0x00 0x100000>, <0x00 0xfe150000 0x00 0x10000>, <0x09 0x00 0x00 0x40000000>, <0x0a 0x40300000 0x00 0x100000>;
++		reg-names = "dbi", "dbi2", "apb", "addr_space", "atu";
++		clocks = <0x21 0x140>, < 0x21 0x145>, < 0x21 0x13b>, < 0x21 0x14a>, < 0x21 0x14f>, < 0x21 0x174>;
++		clock-names = "aclk_mst", "aclk_slv", "aclk_dbi", "pclk", "aux", "pipe";
++		interrupts = <0x00 0x107 0x04 0x00>, <0x00 0x106 0x04 0x00>, <0x00 0x105 0x04 0x00>, <0x00 0x104 0x04 0x00>, <0x00 0x103 0x04 0x00>, <0x00 0x10f 0x04 0x00>, <0x00 0x110 0x04 0x00>, <0x00 0x10d 0x04 0x00>, <0x00 0x10e 0x04 0x00>;
++		interrupt-names = "sys", "pmc", "msg", "legacy", "err", "dma0", "dma1", "dma2", "dma3";
++		max-link-speed = <0x03>;
++		num-lanes = <0x04>;
++		phys = <0x10d>;
++		phy-names = "pcie-phy";
++		power-domains = <0x22 0x22>;
++		resets = <0x21 0x126>, < 0x21 0x12b>;
++		reset-names = "pwr", "pipe";
++		status = "disabled";
++	};
++
++	pcie3x2: pcie@fe160000 {
++		compatible = "rockchip,rk3588-pcie", "rockchip,rk3568-pcie";
++		#address-cells = <0x03>;
++		#size-cells = <0x02>;
++		bus-range = <0x10 0x1f>;
++		clocks = <0x21 0x141>, < 0x21 0x146>, < 0x21 0x13c>, < 0x21 0x14b>, < 0x21 0x150>, < 0x21 0x175>;
++		clock-names = "aclk_mst", "aclk_slv", "aclk_dbi", "pclk", "aux", "pipe";
++		device_type = "pci";
++		interrupts = <0x00 0x102 0x04 0x00>, <0x00 0x101 0x04 0x00>, <0x00 0x100 0x04 0x00>, <0x00 0xff 0x04 0x00>, <0x00 0xfe 0x04 0x00>;
++		interrupt-names = "sys", "pmc", "msg", "legacy", "err";
++		#interrupt-cells = <0x01>;
++		interrupt-map-mask = <0x00 0x00 0x00 0x07>;
++		interrupt-map = <0x00 0x00 0x00 0x01 0x110 0x00>, <0x00 0x00 0x00 0x02 0x110 0x01>, <0x00 0x00 0x00 0x03 0x110 0x02>, <0x00 0x00 0x00 0x04 0x110 0x03>;
++		linux,pci-domain = <0x01>;
++		max-link-speed = <0x03>;
++		msi-map = <0x1000 0x10c 0x1000 0x1000>;
++		iommu-map = <0x1000 0x7e 0x1000 0x1000>;
++		num-lanes = <0x02>;
++		phys = <0x10d>;
++		phy-names = "pcie-phy";
++		power-domains = <0x22 0x22>;
++		ranges = <0x1000000 0x00 0xf1100000 0x00 0xf1100000 0x00 0x100000>, <0x2000000 0x00 0xf1200000 0x00 0xf1200000 0x00 0xe00000>, <0x3000000 0x00 0x40000000 0x09 0x40000000 0x00 0x40000000>;
++		reg = <0x0a 0x40400000 0x00 0x400000>, <0x00 0xfe160000 0x00 0x10000>, <0x00 0xf1000000 0x00 0x100000>;
++		reg-names = "dbi", "apb", "config";
++		resets = <0x21 0x127>, < 0x21 0x12c>;
++		reset-names = "pwr", "pipe";
++		status = "disabled";
++
++		pcie3x2_intc: legacy-interrupt-controller {
++			interrupt-controller;
++			#address-cells = <0x00>;
++			#interrupt-cells = <0x01>;
++			interrupt-parent = <0x01>;
++			interrupts = <0x00 0xff 0x01 0x00>;
++			phandle = <0x110>;
++		};
++	};
++
++	pcie2x1l0: pcie@fe170000 {
++		compatible = "rockchip,rk3588-pcie", "rockchip,rk3568-pcie";
++		bus-range = <0x20 0x2f>;
++		clocks = <0x21 0x142>, < 0x21 0x147>, < 0x21 0x13d>, < 0x21 0x14c>, < 0x21 0x151>, < 0x21 0x2af>;
++		clock-names = "aclk_mst", "aclk_slv", "aclk_dbi", "pclk", "aux", "pipe";
++		device_type = "pci";
++		interrupts = <0x00 0xf3 0x04 0x00>, <0x00 0xf2 0x04 0x00>, <0x00 0xf1 0x04 0x00>, <0x00 0xf0 0x04 0x00>, <0x00 0xef 0x04 0x00>;
++		interrupt-names = "sys", "pmc", "msg", "legacy", "err";
++		#interrupt-cells = <0x01>;
++		interrupt-map-mask = <0x00 0x00 0x00 0x07>;
++		interrupt-map = <0x00 0x00 0x00 0x01 0x111 0x00>, <0x00 0x00 0x00 0x02 0x111 0x01>, <0x00 0x00 0x00 0x03 0x111 0x02>, <0x00 0x00 0x00 0x04 0x111 0x03>;
++		linux,pci-domain = <0x02>;
++		max-link-speed = <0x02>;
++		msi-map = <0x2000 0x7d 0x2000 0x1000>;
++		iommu-map = <0x2000 0x7e 0x2000 0x1000>;
++		num-lanes = <0x01>;
++		phys = <0x112 0x02>;
++		phy-names = "pcie-phy";
++		power-domains = <0x22 0x22>;
++		ranges = <0x1000000 0x00 0xf2100000 0x00 0xf2100000 0x00 0x100000>, <0x2000000 0x00 0xf2200000 0x00 0xf2200000 0x00 0xe00000>, <0x3000000 0x00 0x40000000 0x09 0x80000000 0x00 0x40000000>;
++		reg = <0x0a 0x40800000 0x00 0x400000>, <0x00 0xfe170000 0x00 0x10000>, <0x00 0xf2000000 0x00 0x100000>;
++		reg-names = "dbi", "apb", "config";
++		resets = <0x21 0x128>, < 0x21 0x12d>;
++		reset-names = "pwr", "pipe";
++		#address-cells = <0x03>;
++		#size-cells = <0x02>;
++		status = "disabled";
++
++		pcie2x1l0_intc: legacy-interrupt-controller {
++			interrupt-controller;
++			#address-cells = <0x00>;
++			#interrupt-cells = <0x01>;
++			interrupt-parent = <0x01>;
++			interrupts = <0x00 0xf0 0x01 0x00>;
++			phandle = <0x111>;
++		};
++	};
++
++	gmac0: ethernet@fe1b0000 {
++		compatible = "rockchip,rk3588-gmac", "snps,dwmac-4.20a";
++		reg = <0x00 0xfe1b0000 0x00 0x10000>;
++		interrupts = <0x00 0xe3 0x04 0x00>, <0x00 0xe2 0x04 0x00>;
++		interrupt-names = "macirq", "eth_wake_irq";
++		clocks = <0x21 0x136>, < 0x21 0x137>, < 0x21 0x158>, < 0x21 0x15d>, < 0x21 0x134>;
++		clock-names = "stmmaceth", "clk_mac_ref", "pclk_mac", "aclk_mac", "ptp_ref";
++		power-domains = <0x22 0x21>;
++		resets = <0x21 0x123>;
++		reset-names = "stmmaceth";
++		rockchip,grf = <0x6e>;
++		rockchip,php-grf = <0x2e>;
++		snps,axi-config = <0x113>;
++		snps,mixed-burst;
++		snps,mtl-rx-config = <0x114>;
++		snps,mtl-tx-config = <0x115>;
++		snps,tso;
++		status = "disabled";
++
++		mdio0: mdio {
++			compatible = "snps,dwmac-mdio";
++			#address-cells = <0x01>;
++			#size-cells = <0x00>;
++		};
++
++		gmac0_stmmac_axi_setup: stmmac-axi-config {
++			snps,blen = <0x00 0x00 0x00 0x00 0x10 0x08 0x04>;
++			snps,wr_osr_lmt = <0x04>;
++			snps,rd_osr_lmt = <0x08>;
++			phandle = <0x113>;
++		};
++
++		gmac0_mtl_rx_setup: rx-queues-config {
++			snps,rx-queues-to-use = <0x02>;
++			phandle = <0x114>;
++
++			queue0 {
++			};
++
++			queue1 {
++			};
++		};
++
++		gmac0_mtl_tx_setup: tx-queues-config {
++			snps,tx-queues-to-use = <0x02>;
++			phandle = <0x115>;
++
++			queue0 {
++			};
++
++			queue1 {
++			};
++		};
++	};
++
++	sata1: sata@fe220000 {
++		compatible = "rockchip,rk3588-dwc-ahci", "snps,dwc-ahci";
++		reg = <0x00 0xfe220000 0x00 0x1000>;
++		interrupts = <0x00 0x112 0x04 0x00>;
++		clocks = <0x21 0x163>, < 0x21 0x160>, < 0x21 0x166>, < 0x21 0x155>, < 0x21 0x170>;
++		clock-names = "sata", "pmalive", "rxoob", "ref", "asic";
++		ports-implemented = <0x01>;
++		#address-cells = <0x01>;
++		#size-cells = <0x00>;
++		status = "disabled";
++
++		sata-port@0 {
++			reg = <0x00>;
++			hba-port-cap = <0x400000>;
++			phys = <0x112 0x01>;
++			phy-names = "sata-phy";
++			snps,rx-ts-max = <0x20>;
++			snps,tx-ts-max = <0x20>;
++		};
++	};
++
++	hdptxphy1: phy@fed70000 {
++		compatible = "rockchip,rk3588-hdptx-phy";
++		reg = <0x00 0xfed70000 0x00 0x2000>;
++		clocks = <0x21 0x2a0>, < 0x21 0x255>;
++		clock-names = "ref", "apb";
++		#clock-cells = <0x00>;
++		#phy-cells = <0x00>;
++		resets = <0x21 0x226>, < 0x21 0x21b>, < 0x21 0x266>, < 0x21 0x267>, < 0x21 0x268>, < 0x21 0x224>, < 0x21 0x225>;
++		reset-names = "phy", "apb", "init", "cmn", "lane", "ropll", "lcpll";
++		rockchip,grf = <0x116>;
++		status = "okay";
++		phandle = <0x6c>;
++	};
++
++	usbdp_phy1: phy@fed90000 {
++		compatible = "rockchip,rk3588-usbdp-phy";
++		reg = <0x00 0xfed90000 0x00 0x10000>;
++		#phy-cells = <0x01>;
++		clocks = <0x21 0x2a1>, < 0x21 0x26d>, < 0x21 0x257>, < 0x117>;
++		clock-names = "refclk", "immortal", "pclk", "utmi";
++		resets = <0x21 0x0f>, < 0x21 0x10>, < 0x21 0x11>, < 0x21 0x12>, < 0x21 0x219>;
++		reset-names = "init", "cmn", "lane", "pcs_apb", "pma_apb";
++		rockchip,u2phy-grf = <0x118>;
++		rockchip,usb-grf = <0xef>;
++		rockchip,usbdpphy-grf = <0x119>;
++		rockchip,vo-grf = <0xf1>;
++		status = "okay";
++		phandle = <0x102>;
++	};
++
++	combphy1_ps: phy@fee10000 {
++		compatible = "rockchip,rk3588-naneng-combphy";
++		reg = <0x00 0xfee10000 0x00 0x100>;
++		clocks = <0x21 0x2a9>, < 0x21 0x177>, < 0x21 0x157>;
++		clock-names = "ref", "apb", "pipe";
++		assigned-clocks = <0x21 0x2a9>;
++		assigned-clock-rates = <0x5f5e100>;
++		#phy-cells = <0x01>;
++		resets = <0x21 0x23d>, < 0x21 0x244>;
++		reset-names = "phy", "apb";
++		rockchip,pipe-grf = <0x2e>;
++		rockchip,pipe-phy-grf = <0x11a>;
++		status = "disabled";
++		phandle = <0x112>;
++	};
++
++	pcie30phy: phy@fee80000 {
++		compatible = "rockchip,rk3588-pcie3-phy";
++		reg = <0x00 0xfee80000 0x00 0x20000>;
++		#phy-cells = <0x00>;
++		clocks = <0x21 0x179>;
++		clock-names = "pclk";
++		resets = <0x21 0x248>;
++		reset-names = "phy";
++		rockchip,pipe-grf = <0x2e>;
++		rockchip,phy-grf = <0x11b>;
++		status = "okay";
++		phandle = <0x10d>;
++	};
++
++	cluster0_opp_table: opp-table-cluster0 {
++		compatible = "operating-points-v2";
++		opp-shared;
++		phandle = <0x0d>;
++
++		opp-1008000000 {
++			opp-hz = /bits/ 64 <0x3c14dc00>;
++			opp-microvolt = <0xa4cb8 0xa4cb8 0xe7ef0>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-1200000000 {
++			opp-hz = /bits/ 64 <0x47868c00>;
++			opp-microvolt = <0xadf34 0xadf34 0xe7ef0>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-1416000000 {
++			opp-hz = /bits/ 64 <0x54667200>;
++			opp-microvolt = <0xba284 0xba284 0xe7ef0>;
++			clock-latency-ns = <0x9c40>;
++			opp-suspend;
++		};
++
++		opp-1608000000 {
++			opp-hz = /bits/ 64 <0x5fd82200>;
++			opp-microvolt = <0xcf850 0xcf850 0xe7ef0>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-1800000000 {
++			opp-hz = /bits/ 64 <0x6b49d200>;
++			opp-microvolt = <0xe7ef0 0xe7ef0 0xe7ef0>;
++			clock-latency-ns = <0x9c40>;
++		};
++	};
++
++	cluster1_opp_table: opp-table-cluster1 {
++		compatible = "operating-points-v2";
++		opp-shared;
++		phandle = <0x13>;
++
++		opp-1200000000 {
++			opp-hz = /bits/ 64 <0x47868c00>;
++			opp-microvolt = <0xa4cb8 0xa4cb8 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-1416000000 {
++			opp-hz = /bits/ 64 <0x54667200>;
++			opp-microvolt = <0xb1008 0xb1008 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-1608000000 {
++			opp-hz = /bits/ 64 <0x5fd82200>;
++			opp-microvolt = <0xba284 0xba284 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-1800000000 {
++			opp-hz = /bits/ 64 <0x6b49d200>;
++			opp-microvolt = <0xcf850 0xcf850 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-2016000000 {
++			opp-hz = /bits/ 64 <0x7829b800>;
++			opp-microvolt = <0xe1d48 0xe1d48 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-2208000000 {
++			opp-hz = /bits/ 64 <0x839b6800>;
++			opp-microvolt = <0xf116c 0xf116c 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-2400000000 {
++			opp-hz = /bits/ 64 <0x8f0d1800>;
++			opp-microvolt = <0xf4240 0xf4240 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++	};
++
++	cluster2_opp_table: opp-table-cluster2 {
++		compatible = "operating-points-v2";
++		opp-shared;
++		phandle = <0x17>;
++
++		opp-1200000000 {
++			opp-hz = /bits/ 64 <0x47868c00>;
++			opp-microvolt = <0xa4cb8 0xa4cb8 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-1416000000 {
++			opp-hz = /bits/ 64 <0x54667200>;
++			opp-microvolt = <0xb1008 0xb1008 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-1608000000 {
++			opp-hz = /bits/ 64 <0x5fd82200>;
++			opp-microvolt = <0xba284 0xba284 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-1800000000 {
++			opp-hz = /bits/ 64 <0x6b49d200>;
++			opp-microvolt = <0xcf850 0xcf850 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-2016000000 {
++			opp-hz = /bits/ 64 <0x7829b800>;
++			opp-microvolt = <0xe1d48 0xe1d48 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-2208000000 {
++			opp-hz = /bits/ 64 <0x839b6800>;
++			opp-microvolt = <0xf116c 0xf116c 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++
++		opp-2400000000 {
++			opp-hz = /bits/ 64 <0x8f0d1800>;
++			opp-microvolt = <0xf4240 0xf4240 0xf4240>;
++			clock-latency-ns = <0x9c40>;
++		};
++	};
++
++	gpu_opp_table: opp-table {
++		compatible = "operating-points-v2";
++		phandle = <0x23>;
++
++		opp-300000000 {
++			opp-hz = /bits/ 64 <0x11e1a300>;
++			opp-microvolt = <0xa4cb8 0xa4cb8 0xcf850>;
++		};
++
++		opp-400000000 {
++			opp-hz = /bits/ 64 <0x17d78400>;
++			opp-microvolt = <0xa4cb8 0xa4cb8 0xcf850>;
++		};
++
++		opp-500000000 {
++			opp-hz = /bits/ 64 <0x1dcd6500>;
++			opp-microvolt = <0xa4cb8 0xa4cb8 0xcf850>;
++		};
++
++		opp-600000000 {
++			opp-hz = /bits/ 64 <0x23c34600>;
++			opp-microvolt = <0xa4cb8 0xa4cb8 0xcf850>;
++		};
++
++		opp-700000000 {
++			opp-hz = /bits/ 64 <0x29b92700>;
++			opp-microvolt = <0xaae60 0xaae60 0xcf850>;
++		};
++
++		opp-800000000 {
++			opp-hz = /bits/ 64 <0x2faf0800>;
++			opp-microvolt = <0xb71b0 0xb71b0 0xcf850>;
++		};
++
++		opp-900000000 {
++			opp-hz = /bits/ 64 <0x35a4e900>;
++			opp-microvolt = <0xc3500 0xc3500 0xcf850>;
++		};
++
++		opp-1000000000 {
++			opp-hz = /bits/ 64 <0x3b9aca00>;
++			opp-microvolt = <0xcf850 0xcf850 0xcf850>;
++		};
++	};
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	adc-keys-0 {
++		compatible = "adc-keys";
++		io-channels = <0x11c 0x00>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <0x1b7740>;
++		poll-interval = <0x64>;
++
++		button-maskrom {
++			label = "Mask Rom";
++			linux,code = <0x8d>;
++			press-threshold-microvolt = <0x7d0>;
++		};
++	};
++
++	recovery_button: adc-keys-1 {
++		compatible = "adc-keys";
++		io-channels = <0x11c 0x01>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <0x1b7740>;
++		poll-interval = <0x64>;
++		status = "disabled";
++
++		button-recovery {
++			label = "Recovery";
++			linux,code = <0x168>;
++			press-threshold-microvolt = <0x7d0>;
++		};
++	};
++
++	speaker_amp: speaker-audio-amplifier {
++		compatible = "simple-audio-amplifier";
++		sound-name-prefix = "Speaker Amp";
++		status = "disabled";
++	};
++
++	headphone_amp: headphones-audio-amplifier {
++		compatible = "simple-audio-amplifier";
++		sound-name-prefix = "Headphones Amp";
++		enable-gpios = <0x10e 0x08 0x00>;
++		phandle = <0x122>;
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++
++		led_blue_gpio: led {
++			color = <0x03>;
++			function = "indicator";
++			function-enumerator = <0x01>;
++			status = "disabled";
++		};
++	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		cooling-levels = <0x00 0x46 0x4b 0x50 0x64>;
++		fan-supply = <0x30>;
++		#cooling-cells = <0x02>;
++		pwms = <0x11d 0x00 0xc350 0x00>;
++		phandle = <0xda>;
++	};
++
++	pwm-leds {
++		compatible = "pwm-leds";
++
++		led_blue_pwm: led-1 {
++			color = <0x03>;
++			function = "status";
++			linux,default-trigger = "heartbeat";
++			max-brightness = <0xff>;
++			status = "okay";
++			pwms = <0x11e 0x00 0x61a8 0x00>;
++		};
++
++		led_green_pwm: led-2 {
++			color = <0x02>;
++			function = "heartbeat";
++			function-enumerator = <0x02>;
++			max-brightness = <0xff>;
++			pwms = <0x11f 0x00 0x61a8 0x00>;
++		};
++	};
++
++	rfkill {
++		compatible = "rfkill-gpio";
++		label = "rfkill-pcie-wlan";
++		radio-type = "wlan";
++		shutdown-gpios = <0x8b 0x14 0x00>;
++	};
++
++	analog_sound: sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "Analog";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <0x100>;
++		simple-audio-card,bitclock-master = <0x120>;
++		simple-audio-card,frame-master = <0x120>;
++		pinctrl-names = "default";
++		pinctrl-0 = <0x121>;
++		simple-audio-card,aux-devs = <0x122>;
++		simple-audio-card,hp-det-gpios = <0x7f 0x1a 0x00>;
++		simple-audio-card,routing = "Headphones", "LOUT1", "Headphones", "ROUT1", "LINPUT1", "Microphone Jack", "RINPUT1", "Microphone Jack", "LINPUT2", "Onboard Microphone", "RINPUT2", "Onboard Microphone";
++		simple-audio-card,widgets = "Microphone", "Microphone Jack", "Microphone", "Onboard Microphone", "Headphone", "Headphones";
++
++		daicpu: simple-audio-card,cpu {
++			sound-dai = <0x123>;
++			system-clock-frequency = <0xbb8000>;
++			phandle = <0x120>;
++		};
++
++		daicodec: simple-audio-card,codec {
++			sound-dai = <0x124>;
++			system-clock-frequency = <0xbb8000>;
++		};
++	};
++
++	vcc3v3_pcie30: regulator-vcc3v3-pcie30 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <0x125 0x0e 0x00>;
++		regulator-name = "vcc3v3_pcie30";
++		regulator-min-microvolt = <0x325aa0>;
++		regulator-max-microvolt = <0x325aa0>;
++		startup-delay-us = <0x1388>;
++		vin-supply = <0x30>;
++		phandle = <0x10f>;
++	};
++
++	vcc3v3_pcie_eth: regulator-vcc3v3-pcie-eth {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie_eth";
++		regulator-min-microvolt = <0x325aa0>;
++		regulator-max-microvolt = <0x325aa0>;
++		startup-delay-us = <0xc350>;
++		vin-supply = <0x8c>;
++		gpios = <0x8b 0x1b 0x01>;
++		phandle = <0x80>;
++	};
++
++	vcc3v3_wf: regulator-vcc3v3-wf {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <0x125 0x15 0x00>;
++		regulator-name = "vcc3v3_wf";
++		regulator-min-microvolt = <0x325aa0>;
++		regulator-max-microvolt = <0x325aa0>;
++		startup-delay-us = <0xc350>;
++		vin-supply = <0x30>;
++		status = "disabled";
++	};
++
++	vcc5v0_sys: regulator-vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <0x4c4b40>;
++		regulator-max-microvolt = <0x4c4b40>;
++		phandle = <0x30>;
++	};
++
++	vcc5v0_usb20: regulator-vcc5v0-usb20 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		regulator-name = "vcc5v0_usb20";
++		regulator-min-microvolt = <0x4c4b40>;
++		regulator-max-microvolt = <0x4c4b40>;
++		vin-supply = <0x30>;
++		gpios = <0x7f 0x1d 0x00>;
++		pinctrl-names = "default";
++		pinctrl-0 = <0x126>;
++		phandle = <0x2d>;
++	};
++
++	vcc5v0_usb30_otg: vcc5v0-usb30-otg-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <0x10e 0x0b 0x00>;
++		pinctrl-names = "default";
++		pinctrl-0 = <0x127>;
++		regulator-name = "vcc5v0_usb30_otg";
++		regulator-min-microvolt = <0x4c4b40>;
++		regulator-max-microvolt = <0x4c4b40>;
++		vin-supply = <0x30>;
++		phandle = <0x2c>;
++	};
++
++	hdmi0-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++
++			hdmi0_con_in: endpoint {
++				remote-endpoint = <0x128>;
++				phandle = <0x7a>;
++			};
++		};
++	};
++
++	hdmi1-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++
++			hdmi1_con_in: endpoint {
++				remote-endpoint = <0x129>;
++				phandle = <0x10a>;
++			};
++		};
++	};
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

As per title.

- In u-boot v2025.04 the upstream dtb is missing. I assume it will land with v2025.07 later this year. Until then extracted via `kernel-dtb` from Linux 6.14.2.
- Had to strip the `MAINTAINERS` part from [Ilya's patch](https://patchwork.ozlabs.org/project/uboot/patch/20250412-add-opi5-max-v2-1-585197588511@0upti.me/) since for unknown reason it failed to apply after converting into Armbian patch format and I didn't want to spent additional time on fixing. Apologies for that.

# How Has This Been Tested?

- [x] build
- [ ] boot: nope, no hw
Test image: https://fi.mirror.armbian.de/.testing/Armbian-unofficial_25.05.0-trunk_Orangepi5-max_bookworm_edge_6.14.2_minimal.img.xz

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules