### PR TITLE
Label on approved is running with wrong permissions

### DIFF
--- a/.github/workflows/pr-label-on-approved.yml
+++ b/.github/workflows/pr-label-on-approved.yml
@@ -1,5 +1,5 @@
-on: pull_request_review
-name: Label approved pull requests
+name: "Label approved pull requests"
+on: pull_request_target
 
 permissions:
   contents: read          # Required for checking changed files
@@ -9,10 +9,10 @@ permissions:
 jobs:
   labelWhenApproved:
     if: ${{ github.repository_owner == 'armbian' }}
-    name: Label when approved
+    name: "Label when approved"
     runs-on: ubuntu-latest
     steps:
-    - name: Label when approved
+    - name: "Label when approved"
       uses: pullreminders/label-when-approved-action@master
       env:
         APPROVALS: "1"


### PR DESCRIPTION
# Description

pull_request_review might not grant required permissions. pull_request_target runs in the context of the base repository (i.e., the one the PR is targeting), giving the correct access to secrets and permissions.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ ] Test A
- [ ] Test B

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
