### PR TITLE
Rpi bugfix: Split Debian and Ubuntu packages 

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -37,8 +37,8 @@ case "${BRANCH}" in
 	edge)
 		declare -g EXTRAWIFI="no"
 		declare -g KERNELSOURCE='https://github.com/raspberrypi/linux'
-		declare -g KERNEL_MAJOR_MINOR="6.13" # Major and minor versions of this kernel. For mainline caching.
-		declare -g KERNELBRANCH="branch:rpi-6.13.y"
+		declare -g KERNEL_MAJOR_MINOR="6.14" # Major and minor versions of this kernel. For mainline caching.
+		declare -g KERNELBRANCH="branch:rpi-6.14.y"
 		;;
 esac
 
@@ -74,14 +74,23 @@ function post_family_tweaks_bsp__add_hooks_to_move_kernel_initrd_and_dtb() {
 	run_host_command_logged mkdir -p "${destination}"/etc/kernel/post{inst,rm}.d
 
 	# Copy new files to /boot/firmware; RASPI_FIRMWARE_DIR determines where they come from (at build time only!)
-	display_alert "Setting up z50-raspi-firmware" "bcm2711 - from ${RASPI_FIRMWARE_DIR}" "info"
-	run_host_command_logged cat <<- z50-raspi-firmware > "${destination}"/etc/kernel/postinst.d/z50-raspi-firmware
+	# By default, kernel post-install scripts use filenames starting with "z50-".
+	# However, Debian's 'raspi-firmware' package already uses this naming, which can cause conflicts.
+	# To avoid this, we rename our script to /etc/kernel/postinst.d/z51-raspi-firmware
+	# and include a runtime check for the distribution name.
+	# This prevents issues on Debian where the conflict exists, while Ubuntu is unaffected.
+	display_alert "Setting up z51-raspi-firmware" "bcm2711 - from ${RASPI_FIRMWARE_DIR}" "info"
+	run_host_command_logged cat <<- z51-raspi-firmware > "${destination}"/etc/kernel/postinst.d/z51-raspi-firmware
 		#!/bin/bash -e
 
 		# We are using same name as the debian's raspi-firmware script, but we
 		# only need to run this script on ubuntu. Debian's package has a postinst
 		# section capable of copying files, but Ubuntu relies on flash-kernel
 		[[ -d ${RASPI_FIRMWARE_DIR} ]] || exit 0
+
+		if grep -q '^ID=debian' /etc/os-release; then
+		   exit 0
+		fi
 
 		# Play nice when run under debconf.
 		exec </dev/null >&2
@@ -97,7 +106,7 @@ function post_family_tweaks_bsp__add_hooks_to_move_kernel_initrd_and_dtb() {
 		done
 
 		exit 0
-	z50-raspi-firmware
+	z51-raspi-firmware
 
 	# Copy new files to /boot/firmware
 	run_host_command_logged cat <<- 'zzz-copy-new-files' > "${destination}"/etc/kernel/postinst.d/zzz-copy-new-files
@@ -146,7 +155,7 @@ function post_family_tweaks_bsp__add_hooks_to_move_kernel_initrd_and_dtb() {
 		exit 0
 	zzz-remove-old-files
 
-	run_host_command_logged chmod a+rx "${destination}"/etc/kernel/postinst.d/z50-raspi-firmware
+	run_host_command_logged chmod a+rx "${destination}"/etc/kernel/postinst.d/z51-raspi-firmware
 	run_host_command_logged chmod a+rx "${destination}"/etc/kernel/postinst.d/zzz-copy-new-files
 	run_host_command_logged chmod a+rx "${destination}"/etc/kernel/postrm.d/zzz-remove-old-files
 
@@ -192,7 +201,7 @@ function post_family_tweaks__populate_boot_firmware_directory() {
 	modules_dir="$(find "${SDCARD}/lib/modules"/ -maxdepth 1 -type d -name "*${IMAGE_INSTALLED_KERNEL_VERSION}*")"
 	kern_ver="$(basename "$modules_dir")"
 	run_host_command_logged mkdir -p "${SDCARD}"/boot/firmware
-	chroot_sdcard /etc/kernel/postinst.d/z50-raspi-firmware "${kern_ver}"
+	chroot_sdcard /etc/kernel/postinst.d/z51-raspi-firmware "${kern_ver}"
 	chroot_sdcard /etc/kernel/postinst.d/zzz-copy-new-files "${kern_ver}"
 	display_alert "Populating /boot/firmware directory" "bcm2711 - done" "info"
 }
@@ -235,7 +244,12 @@ function pre_install_distribution_specific__add_rpi_packages() {
 		display_alert "Enable Armbian repository to fetch Rpi packages" "" "info"
 		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.sources
 		do_with_retries 3 chroot_sdcard_apt_get_update
-		chroot_sdcard_apt_get_install rpi-eeprom linux-firmware-raspi pi-bluetooth libraspberrypi-bin busybox raspi-config
+		if [[ "${DISTRIBUTION}" == "Debian" ]]; then
+			chroot_sdcard_apt_get_install rpi-eeprom raspi-firmware raspberrypi-sys-mods bluez-firmware bluez pi-bluetooth busybox raspi-config
+		else
+			chroot_sdcard_apt_get_install rpi-eeprom linux-firmware-raspi pi-bluetooth libraspberrypi-bin busybox raspi-config
+		fi
+
 		## disable armbian repository
 		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled
 	fi


### PR DESCRIPTION
# Description

Rpi bugfix: Split Debian and Ubuntu packages when installing from Armbian repository

- change name of /etc/kernel/postinst.d/z51-raspi-firmware and check for distribution in runtime. This will prevent conflict with raspi-firmware on Debian, while Ubuntu don't have that.
- install packages depending on Distribution. Ubuntu gets what it was, while Debian gets different packages, mirroed from official Rpi bookwork repo: raspi-firmware raspberrypi-sys-mods bluez-firmware bluez
- bump EDGE kernel to 6.14.y
- fixes has also been applied to Armbian repository:

https://github.com/armbian/os/pull/314
https://github.com/armbian/os/pull/313
https://github.com/armbian/os/pull/312
https://github.com/armbian/os/pull/310
https://github.com/armbian/os/pull/309

Closing https://github.com/armbian/build/issues/8069 https://github.com/armbian/build/issues/8052

# How Has This Been Tested?

- [x] Build and boot Debian bookworm image
- [x] Build and boot Ubuntu Noble image
- [x] Build Ubuntu Plucky
- [x] Build Debian Trixie

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
