### PR TITLE
Switch from rkr5 to rkr5.1

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -37,7 +37,7 @@ case $BRANCH in
 		declare -g KERNEL_MAJOR_MINOR="6.1"    # Major and minor versions of this kernel.
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-		KERNELBRANCH='branch:rk-6.1-rkr5'
+		KERNELBRANCH='branch:rk-6.1-rkr5.1'
 		KERNELPATCHDIR='rk35xx-vendor-6.1'
 		;;
 esac

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -34,7 +34,7 @@ case $BRANCH in
 		declare -g KERNEL_MAJOR_MINOR="6.1"    # Major and minor versions of this kernel.
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-		KERNELBRANCH='branch:rk-6.1-rkr5'
+		KERNELBRANCH='branch:rk-6.1-rkr5.1'
 		KERNELPATCHDIR='rk35xx-vendor-6.1'
 		LINUXFAMILY=rk35xx
 		;;

--- a/patch/kernel/rk35xx-vendor-6.1/0000.patching_config.yaml
+++ b/patch/kernel/rk35xx-vendor-6.1/0000.patching_config.yaml
@@ -4,7 +4,7 @@ config:
   name: rk35xx-6.1
   kind: kernel
   type: vendor # or: vendor
-  branch: rk-6.1-rkr5
+  branch: rk-6.1-rkr5.1
   last-known-good-tag: v6.1.99
 
   # .dts files in these directories will be copied as-is to the build tree; later ones overwrite earlier ones.


### PR DESCRIPTION
# Description

This PR updates the rockchip vendor kernel from rkr5 to rkr5.1 (naming is made up here since it is based on rockchip-linux/develop6.1 which is **6.1.115**)

# How Has This Been Tested?

## ToDo:
- [x] Build and run on RK3588 based boards
  - [x] Confirmed on Rock-5B-Plus
  - [x] Confirmed on Orangepi5plus (by @EvilOlaf)
- [x] Build and run on RK3576 based boards
  - [x] Confirmed on Armsom Sige5 (by @amazingfate)

## My Checklist:

- [x] Test Gnome Desktop with mesa-vpu extension
- [x]  Wifi
- [x]  Ethernet
- [x]  Bluetooth
- [x]  GPU

---

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
