### PR TITLE
Radxa Nio 12l: dropping vendor kernel as its broken and generally in bad shape

### DIFF
--- a/config/boards/radxa-nio-12l.conf
+++ b/config/boards/radxa-nio-12l.conf
@@ -2,7 +2,7 @@
 BOARD_NAME="Radxa Nio 12L"
 BOARDFAMILY="genio"
 BOARD_MAINTAINER="HeyMeco"
-KERNEL_TARGET="collabora,vendor"
+KERNEL_TARGET="collabora"
 KERNEL_TEST_TARGET="collabora"
 BOOT_FDT_FILE="mediatek/mt8395-radxa-nio-12l.dtb"
 enable_extension "grub-with-dtb"


### PR DESCRIPTION
# Description

Dropping vendor kernel.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
