### PR TITLE
ignore unsupported format modifier errors

### DIFF
--- a/patch/kernel/rk35xx-vendor-6.1/drm_log_flood.patch
+++ b/patch/kernel/rk35xx-vendor-6.1/drm_log_flood.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+index 12d8d96c8727..2dc37c3a6dfe 100644
+--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
++++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+@@ -2583,7 +2583,7 @@ static bool rockchip_vop2_mod_supported(struct drm_plane *plane, u32 format, u64
+ 	if (!rockchip_afbc(plane, modifier) &&
+ 	    !rockchip_rfbc(plane, modifier) &&
+ 	    !rockchip_tiled(plane, modifier)) {
+-		DRM_ERROR("%s unsupported format modifier 0x%llx\n", plane->name, modifier);
++		//DRM_ERROR("%s unsupported format modifier 0x%llx\n", plane->name, modifier);
+ 
+ 		return false;
+ 	}


### PR DESCRIPTION
# Description

This change adds a kernel vendor patch that will remove an error message in the logs that floods the system journal when playing videos in full screen in Wayland. 
See [this](https://forum.armbian.com/topic/51135-patch-kernel-drm-video-kernel-message-flooding-logs/) and [this](https://github.com/Joshua-Riek/ubuntu-rockchip/issues/86)

# How Has This Been Tested?

Compiled kernel locally and installed on orange pi 5

- [X] System boots correctly
- [X] All drivers are working
- [X] journalctl is not flooded anymore

# Checklist:

_Please delete options that are not relevant._

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
