### PR TITLE
Disable broken AIC8800 wifi driver on Rockchip vendor kernel

### DIFF
--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -10,6 +10,11 @@ function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
 function post_install_kernel_debs__install_aic8800_dkms_package() {
 
+	if [[ ${BRANCH} == vendor ]]; then
+		display_alert "Compilation on vendor kernel is currently broken" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
+		return 0
+	fi
+
 	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.15; then
 		display_alert "Kernel version is too recent" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0


### PR DESCRIPTION
# Description

Recent Rockchip vendor bump caused this driver to break. I have looked a bit, but I don't have this WiFi except on Allwinner, disabling it to make CI working, is what I can do.

@schwar3kat  @HeyMeco 
If any of you have time for this. Revert it back, once it gets fixed.

# How Has This Been Tested?

- [x] Building image which has this extension enabled.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
