### PR TITLE
fix: update jq in apt-utils to use filter arguments

### DIFF
--- a/lib/functions/general/apt-utils.sh
+++ b/lib/functions/general/apt-utils.sh
@@ -51,7 +51,10 @@ function apt_find_upstream_package_version_and_download_url() {
 	esac
 	package_info_download_url_file="$(mktemp)"
 	curl --silent --show-error --max-time 10 $package_info_download_url -o $package_info_download_url_file
-	found_package_filename=$(jq -r .[\"${package_download_release}\"].${ARCH} $package_info_download_url_file)
+	found_package_filename=$(
+		jq -r --arg release "${package_download_release}" --arg arch "${ARCH}" \
+			'.[$release][$arch]' $package_info_download_url_file
+	)
 
 	if [[ "${found_package_filename}" == "${sought_package_name}_"* ]]; then
 		display_alert "Found upstream base-files package filename" "${found_package_filename}" "info"


### PR DESCRIPTION
This fixes the issue where jq sometimes fails to compile the filter when parsing base-files.json

# Description

Rewrite the usage of `jq` to pass variables by argument, to avoid potential shell quoting issues.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: #7886 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2617]

# How Has This Been Tested?

Multiple builds on my development machine both with and without docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


[AR-2617]: https://armbian.atlassian.net/browse/AR-2617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ