### PR TITLE
Fix ORAS tooling download due to absense of `wget`

### DIFF
--- a/lib/functions/host/basic-deps.sh
+++ b/lib/functions/host/basic-deps.sh
@@ -26,6 +26,7 @@ function prepare_host_basic() {
 		"linux-version:linux-base"
 		"locale-gen:locales"
 		"git:git"
+		"wget:wget"
 	)
 
 	for check_pack in "${checklist[@]}"; do

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -209,7 +209,7 @@ function adaptative_prepare_host_dependencies() {
 		colorized-logs                           # for ansi2html, ansi2txt, pipetty
 		unzip zip pigz xz-utils pbzip2 lzop zstd # compressors et al
 		parted gdisk fdisk                       # partition tools @TODO why so many?
-		aria2 curl wget axel                     # downloaders et al
+		aria2 curl axel                     # downloaders et al
 		parallel                                 # do things in parallel (used for fast md5 hashing in initrd cache)
 		rdfind                                   # armbian-firmware-full/linux-firmware symlink creation step
 	)

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -209,7 +209,7 @@ function adaptative_prepare_host_dependencies() {
 		colorized-logs                           # for ansi2html, ansi2txt, pipetty
 		unzip zip pigz xz-utils pbzip2 lzop zstd # compressors et al
 		parted gdisk fdisk                       # partition tools @TODO why so many?
-		aria2 curl axel                     # downloaders et al
+		aria2 curl axel                          # downloaders et al
 		parallel                                 # do things in parallel (used for fast md5 hashing in initrd cache)
 		rdfind                                   # armbian-firmware-full/linux-firmware symlink creation step
 	)


### PR DESCRIPTION
# Description

Addresses https://github.com/armbian/build/issues/8103

First I was like 'rewrite it to `curl`'  but then I realized that for once lots lots of other stuff uses  `wget` as well and I would get installed after the ORAS thingy anyway. So just move wget to the top.


# How Has This Been Tested?

- [x] uninstall `wget`, clear `cache/` directory, run random build: `wget` gets installed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
