### PR TITLE
Fix ZRAM service due to parameter deprecation in mkfs > 2.40.1 (Trixie / Plucky)

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-zram-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-zram-config
@@ -16,6 +16,11 @@
 
 # Read in basic OS image information
 . /etc/armbian-release
+
+# Read mkfs version as it behaves differently after v2.40.1 (Trixie / Plucky ->)
+# mkfs is used to create the zram devices and the ramlog partition
+MKFS_VERSION=$(mkfs --version | grep -oP '\d+\.\d+\.\d+')
+
 # and script configuration
 . /usr/lib/armbian/armbian-common
 
@@ -123,7 +128,12 @@ activate_ramlog_partition() {
 		echo -n ${disksize} > /sys/block/${log_device}/disksize
 	fi
 
-	mkfs.ext4 -O ^has_journal -s 1024 -L log2ram /dev/${log_device}
+	if dpkg --compare-versions "$MKFS_VERSION" gt "2.40.1"; then
+		mkfs.ext4 -O ^has_journal -L log2ram /dev/${log_device}
+	else
+		mkfs.ext4 -O ^has_journal -s 1024 -L log2ram /dev/${log_device}
+	fi
+
 	algo=$(sed 's/.*\[\([^]]*\)\].*/\1/g' </sys/block/${log_device}/comp_algorithm)
 	printf "### Activated Armbian ramlog partition with %s compression\n" "${algo}" >> ${Log}
 } # activate_ramlog_partition
@@ -142,7 +152,12 @@ activate_compressed_tmp() {
 		fi
 	fi
 	[[ -z ${TMP_SIZE} ]] && echo -n $(( memory_total / 2 )) > /sys/block/${tmp_device}/disksize || echo -n ${TMP_SIZE} > /sys/block/${tmp_device}/disksize
-	mkfs.ext4 -O ^has_journal -s 1024 -L tmp /dev/${tmp_device}
+	if dpkg --compare-versions "$MKFS_VERSION" gt "2.40.1"; then
+		mkfs.ext4 -O ^has_journal -L tmp /dev/${tmp_device}
+	else
+		mkfs.ext4 -O ^has_journal -s 1024 -L tmp /dev/${tmp_device}
+	fi
+
 	mount -o nosuid,discard /dev/${tmp_device} /tmp
 	chmod 1777 /tmp
 	algo=$(sed 's/.*\[\([^]]*\)\].*/\1/g' </sys/block/${tmp_device}/comp_algorithm)


### PR DESCRIPTION
# Description

As per title.

# How Has This Been Tested?

- [x] Applied and test on Debian Trixie

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
