### PR TITLE
Rockchip - Adjustin broken patch for EDGE kernel

### DIFF
--- a/patch/kernel/archive/rockchip-6.14/patches.libreelec/linux-1000-drm-rockchip.patch
+++ b/patch/kernel/archive/rockchip-6.14/patches.libreelec/linux-1000-drm-rockchip.patch
@@ -218,8 +218,8 @@ index 38dded2baaf7..9e460b7e14a4 100644
  	if (IS_ERR(hdmi->phy)) {
  		ret = PTR_ERR(hdmi->phy);
  		if (ret != -EPROBE_DEFER)
--			drm_err(hdmi, "failed to get phy\n");
-+			drm_err(hdmi, "failed to get phy: %d\n", ret);
+-			dev_err(hdmi->dev, "failed to get phy\n");
++			dev_err(hdmi->dev, "failed to get phy: %d\n", ret);
  		return ret;
  	}
  


### PR DESCRIPTION
# Description

Adjusting broken patch.

# How Has This Been Tested?

- [x] Build test only

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
