### PR TITLE
Install to nvme: place root volume to separate subvolume on btrfs 

### DIFF
--- a/packages/bsp/common/usr/bin/armbian-install
+++ b/packages/bsp/common/usr/bin/armbian-install
@@ -96,7 +96,7 @@ mkopts[f2fs]='-f'
 
 # @TODO source these options from one source, this is mostly defined in partioning.sh
 mountopts[ext4]='defaults,noatime,commit=120,errors=remount-ro,x-gvfs-hide	0	1'
-mountopts[btrfs]='defaults,noatime,commit=120,compress=lzo,x-gvfs-hide			0	2'
+mountopts[btrfs]="defaults,commit=120,compress=lzo,x-gvfs-hide,subvol=@	0	2"
 mountopts[f2fs]='defaults,noatime,x-gvfs-hide	0	2'
 
 # Create boot and root file system #
@@ -119,6 +119,16 @@ create_armbian()
 	else
 		[[ -n $2 ]] && ( mount -o compress-force=zlib "$2" "${TempDir}"/rootfs 2> /dev/null || mount "$2" "${TempDir}"/rootfs )
 		[[ -n $1 && $1 != "mtd" ]] && mount "$1" "${TempDir}"/bootfs
+	fi
+
+	# make separate subvolume for rootfs on btrfs
+	if [[ $eMMCFilesystemChoosen =~ ^(btrfs)$ ]]; then
+		btrfs subvolume create "${TempDir}"/rootfs/@
+		sync
+		btrfs subvolume list ${TempDir}/rootfs/ | grep 'path @$' | cut -d' ' -f2 \
+			| xargs -I{} btrfs subvolume set-default {} ${TempDir}/rootfs/
+		umount "${TempDir}"/rootfs
+		mount -o compress-force=zlib,subvol=@ "$2" "${TempDir}"/rootfs 2> /dev/null
 	fi
 	rm -rf "${TempDir}"/bootfs/* "${TempDir}"/rootfs/*
 


### PR DESCRIPTION
Realisation #8067 during installation from sdcard to nvme internal storage.
It makes possible to work with snapshots of a root filesystem on btrfs.

Using snapshots of a rootfs on btrfs needs to place root on a btrfs subvolume, not on root of btrfs volume itself.
Sometimes some of directories have to be placed on separate subvolumes.

After this change snapper can be installed, and do auto-snapshots on timer and apt operations.

