### PR TITLE
Revert "Disable broken AIC8800 wifi driver on Rockchip vendor kernel"

### DIFF
--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -10,11 +10,6 @@ function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
 function post_install_kernel_debs__install_aic8800_dkms_package() {
 
-	if [[ ${BRANCH} == vendor ]]; then
-		display_alert "Compilation on vendor kernel is currently broken" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
-		return 0
-	fi
-
 	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.15; then
 		display_alert "Kernel version is too recent" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0


### PR DESCRIPTION
This reverts commit e2b5c430e629db6a6429fca74e072e4498f455c4.

# Description

https://github.com/radxa-pkg/aic8800/pull/33 is merged upstream, now vendor kernel can build aic8800 dkms.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] ./compile.sh BOARD=rock-2a BRANCH=vendor KERNEL_CONFIGURE=no KERNEL_GIT=shallow

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
