### PR TITLE
sunxi64: bump ATF to latest LTS tag

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -9,7 +9,7 @@
 enable_extension "sunxi-tools"
 declare -g ARCH=arm64
 declare -g ATF_TARGET_MAP="PLAT=$ATF_PLAT DEBUG=1 bl31;;build/$ATF_PLAT/debug/bl31.bin"
-declare -g ATFBRANCH="tag:v2.9.0"
+declare -g ATFBRANCH="tag:lts-v2.12.1"
 declare -g BOOTDELAY=1
 declare -g BOOTPATCHDIR="${BOOTPATCHDIR:-"u-boot-sunxi"}"
 declare -g BOOTBRANCH="${BOOTBRANCH:-"tag:v2024.01"}"


### PR DESCRIPTION
# Description

Follow-up to https://github.com/armbian/build/pull/8097
Bump ATF for sunxi64 family to latest available LTS tag. Fixes https://paste.armbian.com/afekovivus

**This needs excessive testing on sunxi64 boards to avoid regressions.**

# How Has This Been Tested?

- [x] build on arm64 noble host without Docker: https://paste.armbian.eu/fowacifusi

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
