### PR TITLE
RaspberryPi: add brcm firmware package to fix missing wireless support

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -245,7 +245,7 @@ function pre_install_distribution_specific__add_rpi_packages() {
 		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.sources
 		do_with_retries 3 chroot_sdcard_apt_get_update
 		if [[ "${DISTRIBUTION}" == "Debian" ]]; then
-			chroot_sdcard_apt_get_install rpi-eeprom raspi-firmware raspberrypi-sys-mods bluez-firmware bluez pi-bluetooth busybox raspi-config
+			chroot_sdcard_apt_get_install firmware-brcm80211 rpi-eeprom raspi-firmware raspberrypi-sys-mods bluez-firmware bluez pi-bluetooth busybox raspi-config
 		else
 			chroot_sdcard_apt_get_install rpi-eeprom linux-firmware-raspi pi-bluetooth libraspberrypi-bin busybox raspi-config
 		fi


### PR DESCRIPTION
# Description

Adding package that fell out during last packages jungle.

# How Has This Been Tested?

- [x] WiFi works after installing it, tested on Bookworm image

# Checklist:

_Please delete options that are not relevant._

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
