### PR TITLE
lubancat2: bump u-boot to v2025.04

### DIFF
--- a/config/boards/lubancat2.csc
+++ b/config/boards/lubancat2.csc
@@ -16,8 +16,8 @@ function post_family_config_branch_edge__lubancat_2_use_mainline_uboot() {
 	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"
 
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline U-Boot
-	declare -g BOOTBRANCH="tag:v2024.07"
-	declare -g BOOTPATCHDIR="v2024.07"
+	declare -g BOOTBRANCH="tag:v2025.04"
+	declare -g BOOTPATCHDIR="v2025.04"
 	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
 
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"


### PR DESCRIPTION
# Description

Bump u-boot for Lubancat2 to the latest v2025.04


# How Has This Been Tested?

Build with command:
`./compile.sh build BOARD=lubancat2 BRANCH=edge BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED='browsers chat desktop_tools editors email internet multimedia office programming remote_desktop' DESKTOP_ENVIRONMENT=xfce DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base DOWNLOAD_MIRROR=bfsu EXPERT=yes EXTRAWIFI=no KERNEL_CONFIGURE=no RELEASE=noble`

Write output img to sdcard, inserd sdcard to the board, the board can bootup.
The migration the system to on board eMMC with nand-sata-install, the board can still bootup.

# Checklist:

_Please delete options that are not relevant._

- [&#x2705;] My code follows the style guidelines of this project
- [&#x2705;] I have performed a self-review of my own code
- [&#x2705;] I have commented my code, particularly in hard-to-understand areas
- [&#x2705; ] My changes generate no new warnings
- [&#x2705;] Any dependent changes have been merged and published in downstream modules
