### PR TITLE
rockchip64: add multiple SPI images support to armbian-install

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -299,10 +299,42 @@ write_uboot_platform() {
 
 # @TODO: this is not ready for BOOT_SCENARIO=binman yet
 write_uboot_platform_mtd() {
-	if [[ -f $1/rkspi_loader.img ]]; then
-		dd if=$1/rkspi_loader.img of=$2 conv=notrunc status=none > /dev/null 2>&1
+	FILES=$(find "$1" -maxdepth 1 -type f -name "rkspi_loader*.img")
+	if [ -z "$FILES" ]; then
+		echo "No SPI image found."
+		exit 1
+	fi
+
+	MENU_ITEMS=()
+	i=1
+
+	# Read the files into an array
+	while IFS= read -r file; do
+		filename=$(basename "$file")
+		MENU_ITEMS+=("$i" "$filename" "")
+		((i++))
+	done <<< "$FILES"
+
+	# If there is only one image, we can skip the dialog
+	if [[ $i -eq 2 ]]; then
+		dd if=$1/${MENU_ITEMS[1]} of=$2 conv=notrunc status=none > /dev/null 2>&1
+		return
+	fi
+
+	[[ -f /etc/armbian-release ]] && source /etc/armbian-release
+	backtitle="Armbian for $BOARD_NAME install script, https://www.armbian.com"
+
+	CHOICE=$(dialog --no-collapse \
+  		--title "armbian-install" \
+  		--backtitle $backtitle \
+  		--radiolist "Choose SPI image:" 0 56 4 \
+  		"${MENU_ITEMS[@]}" \
+  		3>&1 1>&2 2>&3)
+
+	if [ $? -eq 0 ]; then
+		dd if=$1/${MENU_ITEMS[($CHOICE*3)-2]} of=$2 conv=notrunc status=none > /dev/null 2>&1
 	else
-		echo "SPI u-boot image not found!"
+		echo "No SPI image chosen."
 		exit 1
 	fi
 }


### PR DESCRIPTION
# Description

This PR adds multiple SPI image selection option to armbian-install for rockchip boards when there are `rkspi_loader*.img` files more than one. This is useful for boards like Orange Pi 5 as there should be different SPI image for mSata boot scenario.

![image](https://github.com/user-attachments/assets/66a65f80-748e-499f-aae0-b1052c9f60e1)


[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?
- [x] Tested both SPI images writing with OPi5.
- [x] Tested single SPI image case.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
