### PR TITLE
lib distro-specific.sh: move armbian GPG to more common location

### DIFF
--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -161,7 +161,7 @@ function create_sources_list_and_deploy_repo_key() {
 	display_alert "Adding Armbian repository and authentication key" "${when} :: /etc/apt/sources.list.d/armbian.sources" "info"
 	mkdir -p "${basedir}"/usr/share/keyrings
 	# change to binary form
-	APT_SIGNING_KEY_FILE="/usr/share/keyrings/armbian.gpg"
+	APT_SIGNING_KEY_FILE="/usr/share/keyrings/armbian-archive-keyring.gpg"
 	gpg --dearmor < "${SRC}"/config/armbian.key > "${basedir}${APT_SIGNING_KEY_FILE}"
 
 	# lets keep old way for old distributions


### PR DESCRIPTION
The armbian GPG key should be at /usr/share/keyrings/armbian-archive-keyring.gpg not /usr/share/keyrings/armbian.gpg, I think.  That'd be in line with where Ubuntu and Debian ship theirs.

I've already made a [change in APA](https://github.com/armbian/apa/commit/42a5bc199192b3ea297dc5a0f440608f8f17f72f) for the armbian-common package to ship the key in the new location but make a symlink from the old and hence work with both scenarios.