### PR TITLE
Drop old tag for ATF that was only set in sun50iw9 / H61x

### DIFF
--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -16,11 +16,8 @@ GOVERNOR=ondemand
 case $BRANCH in
 
 	current | edge)
-		ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
-		ATFBRANCH='tag:lts-v2.10.2'
 		ATF_PLAT="sun50i_h616"
 		ATF_TARGET_MAP='PLAT=sun50i_h616 DEBUG=1 bl31;;build/sun50i_h616/debug/bl31.bin'
-		BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'
 
 		;;
 esac


### PR DESCRIPTION
# Description

Maint / as per title.

This affects all H6x but probably it is not critical.

@The-going @pyavitz 

# How Has This Been Tested?

- [ ] Build test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
