### PR TITLE
extensions: add APA extension

### DIFF
--- a/extensions/apa.sh
+++ b/extensions/apa.sh
@@ -1,0 +1,23 @@
+# Install armbian-common etc. from APA
+
+function extension_prepare_config__apa() {
+	display_alert "Target image will have Armbian Package Archive (APA) enabled by default" "${EXTENSION}" "info"
+}
+
+function custom_apt_repo__add_apa() {
+	run_host_command_logged echo "deb [signed-by=${APT_SIGNING_KEY_FILE}] https://github.armbian.com/apa current main" "|" tee "${SDCARD}"/etc/apt/sources.list.d/armbian-apa.list
+}
+
+function post_armbian_repo_customize_image__install_from_apa() {
+	# do not install armbian recommends for minimal images
+	[[ "${BUILD_MINIMAL,,}" =~ ^(true|yes)$ ]] && INSTALL_RECOMMENDS="no" || INSTALL_RECOMMENDS="yes"
+	chroot_sdcard_apt_get --install-recommends=$INSTALL_RECOMMENDS install "armbian-common armbian-bsp"
+
+	# install desktop environmnent if requested
+	case ${DESKTOP_ENVIRONMENT^^} in
+		XFCE|KDE|GNOME)
+			display_alert "installing ${DESKTOP_ENVIRONMENT^^} desktop environment" "${EXTENSION}: ${DESKTOP_ENVIRONMENT^^}" "info"
+			chroot_sdcard_apt_get --install-recommends=yes "armbian-desktop-${DESKTOP_ENVIRONMENT,,}"
+			;;
+	esac
+}


### PR DESCRIPTION
using this extension allows for activation of the APA armbian package archive and installation of the provided binary packages at image creation time from within the Armbian Build Framework.

The goal of APA is to simplify maintenance of Armbian Core by moving dependency logic and other packaging information into a separate space and handle that meta-data with the proper distribution-creation and -publication tools.  Currently, much of this is done with fragile bash scripting in Armbian Core instead.