### PR TITLE
partitioning: Add BTRFS_ROOT_SUBVOLUME switch

### DIFF
--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -353,7 +353,7 @@ function prepare_partitions() {
 
 			run_host_command_logged umount $rootdevice
 			display_alert "Remounting rootfs" "$rootdevice (UUID=${ROOT_PART_UUID})"
-			run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=$btrfs_root_subvolume $rootdevice $MOUNT/
+			run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]} $rootdevice $MOUNT/
 		fi
 		rootfs="UUID=$(blkid -s UUID -o value $rootdevice)"
 		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults,${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -330,12 +330,13 @@ function prepare_partitions() {
 		fi
 
 		if [[ $ROOTFS_TYPE == btrfs ]]; then
+			btrfs_root_subvolume="${BTRFS_ROOT_SUBVOLUME:-@}"
 			mountopts[$ROOTFS_TYPE]='commit=120'
-			run_host_command_logged btrfs subvolume create $MOUNT/@
+			run_host_command_logged btrfs subvolume create $MOUNT/$btrfs_root_subvolume
 			# getting the subvolume id of the newly created volume @ to install it
 			# as the default volume for mounting without explicit reference
 
-			run_host_command_logged "btrfs subvolume list $MOUNT | grep 'path @' | cut -d' ' -f2 \
+			run_host_command_logged "btrfs subvolume list $MOUNT | grep 'path $btrfs_root_subvolume' | cut -d' ' -f2 \
 				| xargs -I{} btrfs subvolume set-default {} $MOUNT/ "
 
 			call_extension_method "btrfs_root_add_subvolumes" <<- 'BTRFS_ROOT_ADD_SUBVOLUMES'
@@ -352,7 +353,7 @@ function prepare_partitions() {
 
 			run_host_command_logged umount $rootdevice
 			display_alert "Remounting rootfs" "$rootdevice (UUID=${ROOT_PART_UUID})"
-			run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@ $rootdevice $MOUNT/
+			run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=$btrfs_root_subvolume $rootdevice $MOUNT/
 		fi
 		rootfs="UUID=$(blkid -s UUID -o value $rootdevice)"
 		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults,${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -336,8 +336,7 @@ function prepare_partitions() {
 			# getting the subvolume id of the newly created volume @ to install it
 			# as the default volume for mounting without explicit reference
 
-			run_host_command_logged "btrfs subvolume list $MOUNT | grep 'path $btrfs_root_subvolume' | cut -d' ' -f2 \
-				| xargs -I{} btrfs subvolume set-default {} $MOUNT/ "
+			run_host_command_logged "btrfs subvolume set-default $MOUNT/$btrfs_root_subvolume"
 
 			call_extension_method "btrfs_root_add_subvolumes" <<- 'BTRFS_ROOT_ADD_SUBVOLUMES'
 				# *custom post btrfs rootfs creation hook*


### PR DESCRIPTION
# Description

This allows changing the default root subvolume from @ to any user
 defined subvolume name

We currently ship an image using @root/[revision], which allows us to ship offline updates using btrfs send/receive. It would be easy enough to just add our root subvolume in `btrfs_root_add_subvolumes`, however the subsequent "Remounting rootfs" `mount` call specifies the subvolume by name instead of relying on the previously set default. To work around this for our needs, I would have to abuse `btrfs_root_add_subvolumes_fstab` to `umount/mount` to change the volume name there as well.

To this end, I've changed the remounting rootfs call to not explicitly pass a subvolume, mounting the current default. This allows users to customize subvolumes further in `btrfs_root_add_subvolumes` (for example, creating a/b rootfs subvolumes).

# Documentation summary for feature / change

- [ ] Add BTRFS_ROOT_SUBVOLUME switch
- [ ] This allows customizing the name of the root subvolume when using ROOTFS_TYPE=btrfs

# How Has This Been Tested?

A test extension was used to create a nested custom root subvolumes

```bash
function btrfs_root_add_subvolumes__nested_root() {
	display_alert "Extension $EXTENSION: Creating custom versioned root subvolume"
	run_host_command_logged btrfs subvolume create $MOUNT/$BTRFS_ROOT_SUBVOLUME/0
	run_host_command_logged btrfs subvolume set-default $MOUNT/$BTRFS_ROOT_SUBVOLUME/0
}
```

Then I mounted the output images and verified the changed default was used during remounting and image build

- [x] `bash compile.sh BOARD=uefi-x86 BUILD_MINIMAL=yes RELEASE=trixie BRANCH=current KERNEL_CONFIGURE=no ROOTFS_TYPE=btrfs BTRFS_ROOT_SUBVOLUME=@root ENABLE_EXTENSIONS=test-btrfs-subvol`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
