### PR TITLE
Add option to disable kernel patching

### DIFF
--- a/config/sources/common.conf
+++ b/config/sources/common.conf
@@ -117,10 +117,16 @@ function late_family_config__common_defaults_for_mainline_kernel() {
 		KERNEL_PATCH_ARCHIVE_BASE="$LINUXFAMILY"
 	fi
 
-	# If KERNELPATCHDIR is unset, set it to "archive/${KERNELPATCHDIR}-${KERNEL_MAJOR_MINOR}" # @TODO: no, use LINUXFAMILY directly
-	if [[ -z ${KERNELPATCHDIR} ]]; then
-		display_alert "KERNELPATCHDIR is unset; using 'archive/${KERNEL_PATCH_ARCHIVE_BASE}-${KERNEL_MAJOR_MINOR}'" "common_defaults_for_mainline" "info"
-		KERNELPATCHDIR="archive/${KERNEL_PATCH_ARCHIVE_BASE}-${KERNEL_MAJOR_MINOR}" # previously was KERNELPATCHDIR="$LINUXFAMILY-$BRANCH"
+	if [[ ${DISABLE_KERNEL_PATCHES:-} == "yes" ]]; then
+		display_alert "Kernel patches disabled; Using empty KERNELPATCHDIR and disabling WiFi" "common_defaults_for_mainline" "info"
+		KERNELPATCHDIR=
+		EXTRAWIFI="no"
+	else
+		# If KERNELPATCHDIR is unset, set it to "archive/${KERNELPATCHDIR}-${KERNEL_MAJOR_MINOR}" # @TODO: no, use LINUXFAMILY directly
+		if [[ -z ${KERNELPATCHDIR} ]]; then
+			display_alert "KERNELPATCHDIR is unset; using 'archive/${KERNEL_PATCH_ARCHIVE_BASE}-${KERNEL_MAJOR_MINOR}'" "common_defaults_for_mainline" "info"
+			KERNELPATCHDIR="archive/${KERNEL_PATCH_ARCHIVE_BASE}-${KERNEL_MAJOR_MINOR}" # previously was KERNELPATCHDIR="$LINUXFAMILY-$BRANCH"
+		fi
 	fi
 
 	# if LINUXCONFIG is unset... default to linux-${LINUXFAMILY}-${BRANCH} # Attention: no KERNEL_MAJOR_MINOR here, so manual file rollover is necessary


### PR DESCRIPTION
# Description

This change allows developers to build an image with an unpatched kernel.

When the option `DISABLE_KERNEL_PATCHES=yes` is set a kernel without armbian specific patches is built. When the value of this variable is something else than `yes` or when it is not set the default behaviour (applying patches) is executed.

Motivation and additional discussion can be found here: #8120 

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change

Documentation PR will follow

# How Has This Been Tested?

Run builds with and without this option.


# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
