### PR TITLE
Remove deprecated CM3588 devicetree

### DIFF
--- a/patch/kernel/archive/rockchip64-6.14/dt/rk3588-nanopc-cm3588-nas.dts
+++ b/patch/kernel/archive/rockchip64-6.14/dt/rk3588-nanopc-cm3588-nas.dts
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-
-/dts-v1/;
-
-#include "rk3588-friendlyelec-cm3588-nas.dts"
-
-// DO NOT ADD ANYTHING TO THIS DTS!
-// This file only exists for temporary backwards compatibility for existing installations installed before 2024-10-20.
-// THIS COMPATIBILITY PATCH WILL BE DELETED in kernel 6.14, please migrate to the new dts by editing your "/boot/armbianEnv.txt"!


### PR DESCRIPTION
# Description

The deprecated devicetree definition for FriendlyElec CM3588 was scheduled for removal in kernel 6.14 which is now available.


# How Has This Been Tested?

Compile for CM3588
# Checklist:

_Please delete options that are not relevant._

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
