### PR TITLE
Add bananapim7 description - interactive build fix

### DIFF
--- a/config/boards/bananapim7.conf
+++ b/config/boards/bananapim7.conf
@@ -1,3 +1,4 @@
+# Rockchip RK3588 octa core 8-32GB RAM SoC 2*2.5GBe eMMC USB3 NvME WIFI
 source "${SRC}/config/boards/armsom-sige7.csc"
 BOARD_NAME="Banana Pi M7"
 BOARD_MAINTAINER="amazingfate"


### PR DESCRIPTION
Bananapim7 lacked description so interactive build script showed the second "source" command. 

# How Has This Been Tested?

- [x] Smoke test, builds, this just adds a comment. 

# Note - 

Note to self to look at adding a check to menu builder description to handle missing descriptions by substituting default. 

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
