### PR TITLE
odroidxu4: fix uboot compilation for Noble hosts

### DIFF
--- a/patch/u-boot/legacy/board_odroidxu4/fix-compilation-on-noble.patch
+++ b/patch/u-boot/legacy/board_odroidxu4/fix-compilation-on-noble.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Werner <werner@armbian.com>
+Date: Fri, 9 May 2025 17:23:19 +0000
+Subject: odroidxu4: fix uboot compilation on Noble
+
+Signed-off-by: From: Werner <werner@armbian.com>
+---
+ lib/libfdt/setup.py | 2 +-
+ tools/Makefile      | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/libfdt/setup.py b/lib/libfdt/setup.py
+index 845a0c2b10d..713e7fcdb52 100644
+--- a/lib/libfdt/setup.py
++++ b/lib/libfdt/setup.py
+@@ -2,11 +2,11 @@
+ 
+ """
+ setup.py file for SWIG libfdt
+ """
+ 
+-from distutils.core import setup, Extension
++from setuptools import setup, Extension
+ import os
+ import sys
+ 
+ # Don't cross-compile - always use the host compiler.
+ del os.environ['CROSS_COMPILE']
+diff --git a/tools/Makefile b/tools/Makefile
+index 2fc4a583d44..b0bbf013435 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -120,11 +120,11 @@ _libfdt.so-sharedobjs += $(LIBFDT_OBJS)
+ libfdt:
+ 
+ tools/_libfdt.so: $(patsubst %.o,%.c,$(LIBFDT_OBJS)) tools/libfdt_wrap.c
+ 	LDFLAGS="$(HOSTLDFLAGS)" CFLAGS= ${PYTHON} $(srctree)/lib/libfdt/setup.py \
+ 		"$(_hostc_flags)" $^
+-	mv _libfdt.so $@
++	mv _libfdt.*so $@
+ 
+ tools/libfdt_wrap.c: $(srctree)/lib/libfdt/libfdt.swig
+ 	swig -python -o $@ $<
+ 
+ # TODO(sjg@chromium.org): Is this correct on Mac OS?
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

Attempt to fix https://github.com/armbian/build/issues/8167

- distuils has been removed from Python 3.12 and upwards. Though setuptools seems to be compatible.
- uboot assumes the file name in question is `_libfdt.so` but it actually has a some long weirdness added...so very improperly just copy whatever it finds.

# How Has This Been Tested?

- [x] build https://paste.armbian.eu/egibeqarec
- [x] boot: nope, no hw

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
