### PR TITLE
indiedroid-nova: fix uboot compilation on Noble hosts

### DIFF
--- a/patch/u-boot/legacy/board_indiedroid-nova/fix-compilation-on-noble.patch
+++ b/patch/u-boot/legacy/board_indiedroid-nova/fix-compilation-on-noble.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Heinrich Schuchardt <heinrich.schuchardt at canonical.com>
+Date: Wed, 7 May 2025 09:13:39 +0000
+Subject: cmd: inconsistent return type of command_process()
+
+Reported-by: Sergei Antonov <saproj at gmail.com>
+Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt at canonical.com>
+Signed-off-by: Werner <werner at armbian.com>
+---
+ include/command.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/command.h b/include/command.h
+index 681084b9ea3..14910ea0b79 100644
+--- a/include/command.h
++++ b/include/command.h
+@@ -137,11 +137,11 @@ enum command_ret_t {
+  *			is left unchanged.
+  * @param ticks		If ticks is not null, this function set it to the
+  *			number of ticks the command took to complete.
+  * @return 0 if the command succeeded, 1 if it failed
+  */
+-int cmd_process(int flag, int argc, char * const argv[],
++enum command_ret_t cmd_process(int flag, int argc, char *const argv[],
+ 			       int *repeatable, unsigned long *ticks);
+ 
+ void fixup_cmdtable(cmd_tbl_t *cmdtp, int size);
+ 
+ /**
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

Attempt to fix https://github.com/armbian/build/issues/8163

I searched for the error message and after some research found a patch that seem to work.


# How Has This Been Tested?

- [x] build https://paste.armbian.eu/wasujiliye
- [ ] boot: nope, no hw

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
