### PR TITLE
Create helios4_defconfig-0002-enable-setexpr-command.patch

### DIFF
--- a/patch/u-boot/legacy/u-boot-helios4/board_helios4/helios4_defconfig-0002-enable-setexpr-command.patch
+++ b/patch/u-boot/legacy/u-boot-helios4/board_helios4/helios4_defconfig-0002-enable-setexpr-command.patch
@@ -1,0 +1,13 @@
+diff --git a/configs/helios4_defconfig b/configs/helios4_defconfig
+index 0a1bb8e0362..c36ae95c336 100644
+--- a/configs/helios4_defconfig
++++ b/configs/helios4_defconfig
+@@ -28,7 +28,7 @@ CONFIG_CMD_SF=y
+ CONFIG_CMD_SPI=y
+ CONFIG_CMD_USB=y
+ CONFIG_CMD_DATE=y
+-# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_SETEXPR=y
+ CONFIG_CMD_TFTPPUT=y
+ CONFIG_CMD_CACHE=y
+ CONFIG_CMD_TIME=y


### PR DESCRIPTION
Follow-up for:
- https://github.com/armbian/build/issues/8165
- https://github.com/armbian/build/pull/8166

Enable the `setexpr` command on the U-Boot monitor commandline, to enable calculating the load addresses based on the sizes of the DT, kernel, initial ramdisk.

Due to the way patches are applied in the Armbian build framework, prefixed the patch filename with the actual file being patched (it will be applied after `Add-RTC-to-helios4.patch`).
Not sure what the conventions are for the patch filenames, but prefixing with the filename and numering it as the second patch for `helios4_defconfig` guarantees correct application of the patch.

# Description

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: https://github.com/armbian/build/issues/8165
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2676](https://armbian.atlassian.net/browse/AR-2676)

# Documentation summary for feature / change

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Test A
   Built U-Boot SPL from v2019.04 branch:
   **OK**
  ```
  U-Boot SPL 2019.04djurny-dirty (May 09 2025 - 13:09:45 -0700)
  High speed PHY - Version: 2.0
  Detected Device ID 6828
  board SerDes lanes topology details:
   | Lane #  | Speed |  Type       |
   --------------------------------
   |   0    |  6   |  SATA0       |
   |   1    |  5   |  USB3 HOST0  |
   |   2    |  6   |  SATA1       |
   |   3    |  6   |  SATA3       |
   |   4    |  6   |  SATA2       |
   |   5    |  5   |  USB3 HOST1  |
   --------------------------------
  High speed PHY - Ended Successfully
  mv_ddr: mv_ddr-armada-18.09.2 
  DDR3 Training Sequence - Switching XBAR Window to FastPath Window
  DDR Training Sequence - Start scrubbing
  DDR3 Training Sequence - End scrubbing
  mv_ddr: completed successfully
  Trying to boot from MMC1
  
  
  U-Boot 2019.04djurny-dirty (May 09 2025 - 13:09:45 -0700)
  
  SoC:   MV88F6828-A0 at 1600 MHz
  DRAM:  2 GiB (800 MHz, 32-bit, ECC enabled)
  MMC:   mv_sdh: 0
  Loading Environment from MMC... *** Warning - bad CRC, using default environment
  
  Model: Helios4
  Board: Helios4
  SCSI:  MVEBU SATA INIT
  Target spinup took 0 ms.
  Target spinup took 0 ms.
  AHCI 0001.0000 32 slots 2 ports 6 Gbps 0x3 impl SATA mode
  flags: 64bit ncq led only pmp fbss pio slum part sxs 
  
  Net:   
  Warning: ethernet@70000 (eth1) using random MAC address - 1e:ce:a5:0b:4c:12
  eth1: ethernet@70000
  Hit any key to stop autoboot:  0 
  switch to partitions #0, OK
  mmc0 is current device
  Scanning mmc 0:1...
  Found U-Boot script /boot/boot.scr
  4800 bytes read in 378 ms (11.7 KiB/s)
  ## Executing script at 00200000
  Boot script loaded from mmc
  Loading environment from mmc to 0x00300000 ...
  158 bytes read in 364 ms (0 Bytes/s)
  Loading DT from mmc to 0x02040000 ...
  28834 bytes read in 710 ms (39.1 KiB/s)
  Loading kernel from mmc to 2058000 ...
  8809072 bytes read in 1898 ms (4.4 MiB/s)
  Loading ramdisk from mmc to 28bf000 ...
  10519797 bytes read in 2191 ms (4.6 MiB/s)
  Booting kernel ...
  ## Loading init Ramdisk from Legacy Image at 028bf000 ...
     Image Name:   uInitrd
     Image Type:   ARM Linux RAMDisk Image (gzip compressed)
     Data Size:    10519733 Bytes = 10 MiB
     Load Address: 00000000
     Entry Point:  00000000
     Verifying Checksum ... OK
  ## Flattened Device Tree blob at 02040000
     Booting using the fdt blob at 0x2040000
     Loading Ramdisk to 0f5f7000, end 0ffff4b5 ... OK
     Loading Device Tree to 0f5dc000, end 0f5f6fff ... OK
  
  Starting kernel ...
  
  Loading, please wait...
  Starting systemd-udevd version 252.36-1~deb12u1
  ```

- [x] Test B
   Made a git patch of the change on v2019.04 and inserted it into the Armbian build framework.
   Built `U-Boot 2019.04-armbian-2019.04-S3c99-P2e5c-H9530-V0854-Bb703-R448a (May 09 2025 - 13:46:13 -0700)`:
   **OK**
  ```
  U-Boot SPL 2019.04-armbian-2019.04-S3c99-P2e5c-H9530-V0854-Bb703-R448a (May 09 2025 - 13:46:13 -0700)
  High speed PHY - Version: 2.0
  Detected Device ID 6828
  board SerDes lanes topology details:
   | Lane #  | Speed |  Type       |
   --------------------------------
   |   0    |  6   |  SATA0       |
   |   1    |  5   |  USB3 HOST0  |
   |   2    |  6   |  SATA1       |
   |   3    |  6   |  SATA3       |
   |   4    |  6   |  SATA2       |
   |   5    |  5   |  USB3 HOST1  |
   --------------------------------
  High speed PHY - Ended Successfully
  mv_ddr: mv_ddr-armada-18.09.2 
  DDR3 Training Sequence - Switching XBAR Window to FastPath Window
  DDR Training Sequence - Start scrubbing
  DDR3 Training Sequence - End scrubbing
  mv_ddr: completed successfully
  Trying to boot from MMC1
  
  
  U-Boot 2019.04-armbian-2019.04-S3c99-P2e5c-H9530-V0854-Bb703-R448a (May 09 2025 - 13:46:13 -0700)
  
  SoC:   MV88F6828-A0 at 1600 MHz
  DRAM:  2 GiB (800 MHz, 32-bit, ECC enabled)
  MMC:   mv_sdh: 0
  Loading Environment from EXT4... ** File not found /boot/boot.env **
  
  ** Unable to read "/boot/boot.env" from mmc0:1 **
  Model: Helios4
  Board: Helios4
  SCSI:  MVEBU SATA INIT
  Target spinup took 0 ms.
  Target spinup took 0 ms.
  AHCI 0001.0000 32 slots 2 ports 6 Gbps 0x3 impl SATA mode
  flags: 64bit ncq led only pmp fbss pio slum part sxs 
  
  Net:   
  Warning: ethernet@70000 (eth1) using random MAC address - 46:3a:1c:c2:7e:6e
  eth1: ethernet@70000
  Hit any key to stop autoboot:  0 
  switch to partitions #0, OK
  mmc0 is current device
  Scanning mmc 0:1...
  Found U-Boot script /boot/boot.scr
  4800 bytes read in 375 ms (11.7 KiB/s)
  ## Executing script at 03000000
  Boot script loaded from mmc
  Loading environment from mmc to 0x00300000 ...
  158 bytes read in 362 ms (0 Bytes/s)
  Loading DT from mmc to 0x02040000 ...
  28834 bytes read in 701 ms (40 KiB/s)
  Loading kernel from mmc to 2058000 ...
  8809072 bytes read in 1894 ms (4.4 MiB/s)
  Loading ramdisk from mmc to 28bf000 ...
  10519797 bytes read in 2216 ms (4.5 MiB/s)
  Booting kernel ...
  ## Loading init Ramdisk from Legacy Image at 028bf000 ...
     Image Name:   uInitrd
     Created:      2025-05-09  20:50:28 UTC
     Image Type:   ARM Linux RAMDisk Image (gzip compressed)
     Data Size:    10519733 Bytes = 10 MiB
     Load Address: 00000000
     Entry Point:  00000000
     Verifying Checksum ... OK
  ## Flattened Device Tree blob at 02040000
     Booting using the fdt blob at 0x2040000
     Loading Ramdisk to 0f5f7000, end 0ffff4b5 ... OK
     Loading Device Tree to 0f5dc000, end 0f5f6fff ... OK
  
  Starting kernel ...
  
  Loading, please wait...
  Starting systemd-udevd version 252.36-1~deb12u1
  ```

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


[AR-2676]: https://armbian.atlassian.net/browse/AR-2676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ