### PR TITLE
board: youyeetoo-r1 v3 – Bumped U-Boot and reorder kernel targets

### DIFF
--- a/config/boards/youyeetoo-r1-v3.csc
+++ b/config/boards/youyeetoo-r1-v3.csc
@@ -4,7 +4,8 @@ BOARDFAMILY="rockchip-rk3588"
 BOARD_MAINTAINER="SuperKali"
 BOOTCONFIG="generic-rk3588_defconfig" # vendor name, not standard, see hook below, set BOOT_SOC below to compensate
 BOOT_SOC="rk3588"
-KERNEL_TARGET="current,edge,vendor"
+KERNEL_TARGET="vendor,current,edge"
+KERNEL_TEST_TARGET="vendor,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 IMAGE_PARTITION_TABLE="gpt"
@@ -37,8 +38,8 @@ function post_family_config__youyeetoo_r1_use_mainline_uboot() {
 	declare -g BOOTCONFIG="generic-rk3588_defconfig"             # Use generic defconfig which should boot all RK3588 boards
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline U-Boot
-	declare -g BOOTBRANCH="tag:v2025.01"
-	declare -g BOOTPATCHDIR="v2025.01"
+	declare -g BOOTBRANCH="tag:v2025.04"
+	declare -g BOOTPATCHDIR="v2025.04"
 	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
 
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"


### PR DESCRIPTION
# Description

This PR includes a U-Boot version bump and a reordering of kernel targets to prioritize builds with the vendor kernel.
Currently, the current and edge kernels have some limitations that prevent certain peripherals from functioning properly. I'm actively monitoring these two branches to identify possible fixes and will prepare a patch once a solution is found.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings