### PR TITLE
Helios4: add fancontrol package and switch to .conf

### DIFF
--- a/config/boards/helios4.conf
+++ b/config/boards/helios4.conf
@@ -10,3 +10,7 @@ HAS_VIDEO_OUTPUT="no"
 FORCE_BOOTSCRIPT_UPDATE="yes"
 KERNEL_TARGET="current,edge"
 KERNEL_TEST_TARGET="current"
+
+function post_family_config__helios4_extra_packages() {
+	add_packages_to_image "fancontrol"
+}


### PR DESCRIPTION
# Description

This PR adds the fancontrol package to the Helios4 board image. Helios4 includes hardware fan support, and fancontrol is necessary for managing fan speed based on system temperature.

# How Has This Been Tested?

- https://forum.armbian.com/topic/44379-fancontrol-bookworm-solved/#comment-209055

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
