### PR TITLE
Update prepare-host.sh to use ntpsec-ntpdate

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -194,7 +194,7 @@ function adaptative_prepare_host_dependencies() {
 		libncurses-dev libssl-dev libusb-1.0-0-dev
 		linux-base locales lsof
 		ncurses-base ncurses-term # for `make menuconfig`
-		ntpdate
+		ntpsec-ntpdate #this is a more secure ntpdate
 		patchutils pkg-config pv
 		"qemu-user-static" "arch-test"
 		rsync


### PR DESCRIPTION
# Description

migrate to ntpsec-ntpdate as a more secure implementation of ntpdate and available in Debian and Ubunbtu

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: #8176 
Jira Ticket: https://armbian.atlassian.net/browse/AR-2679

# How Has This Been Tested?

build the images in Armbian Debian and Ubuntu that didn't have ntpdate installed and the ntpsec-ntpdate package was correctly installed and used.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings