### PR TITLE
Updating maintainers: switch to new location of JSON file

### DIFF
--- a/.github/workflows/adjust-maintainers.yml
+++ b/.github/workflows/adjust-maintainers.yml
@@ -6,8 +6,6 @@ name: "Sync maintainers status"
 # spdx-id: GPL-2.0-or-later
 # copyright-owner: @igorpecovnik
 
-# Dependencies: lftp, jq
-
 on:
   schedule:
     - cron: "0 * * * *"
@@ -36,16 +34,11 @@ jobs:
           known_hosts: ${{ secrets.KNOWN_HOSTS_ARMBIAN_UPLOAD }}
           if_key_exists: replace
 
-      - name: "Install dependencies"
-        run: |
-
-          sudo apt-get -y -qq install jq
-
       - name: "Download JSON file"
         run: |
 
-          # download json that is prepared for this action in another cron job
-          rsync -e "ssh -p ${{ secrets.HOST_UPLOAD_PORT }}" -arvc ${{ secrets.HOST_UPLOAD_USER }}@${{ secrets.HOST_UPLOAD }}:/incoming/json/armbian_maintainers.json /tmp/
+          # download json that is prepared in https://github.com/armbian/armbian.github.io
+          curl -o /tmp/armbian_maintainers.json https://github.armbian.com/maintainers.json
 
       - name: "Update maintainers"
         run: |


### PR DESCRIPTION
# Description

We are generating JSON file at https://github.com/armbian/armbian.github.io so we need to download artefacts from another location. Previous one was deprecated and action was disabled for couple of weeks. After this, it can be re-enabled.

# How Has This Been Tested?

- [x] Test run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
