### PR TITLE
Extend chroot mount helper to include cache directories

### DIFF
--- a/lib/functions/general/chroot-helpers.sh
+++ b/lib/functions/general/chroot-helpers.sh
@@ -16,7 +16,9 @@ function mount_chroot() {
 	local target
 	target="$(realpath "$1")" # normalize, remove last slash if dir
 	display_alert "mount_chroot" "$target" "debug"
+
 	mkdir -p "${target}/run/user/0"
+	mkdir -p "${target}/armbian/cache"
 
 	# tmpfs size=50% is the Linux default, but we need more.
 	mount -t tmpfs -o "size=99%" tmpfs "${target}/tmp"
@@ -26,6 +28,8 @@ function mount_chroot() {
 	mount -t sysfs chsys "${target}"/sys
 	mount --bind /dev "${target}"/dev
 	mount -t devpts chpts "${target}"/dev/pts || mount --bind /dev/pts "${target}"/dev/pts
+
+	mount --bind /armbian/cache "${target}/armbian/cache"
 }
 
 # umount_chroot <target>
@@ -36,7 +40,7 @@ function umount_chroot() {
 	local target
 	target="$(realpath "$1")" # normalize, remove last slash if dir
 	display_alert "Unmounting" "$target" "info"
-	while grep -Eq "${target}\/(dev|proc|sys|tmp|var\/tmp|run\/user\/0)" /proc/mounts; do
+	while grep -Eq "${target}\/(dev|proc|sys|tmp|var\/tmp|run\/user\/0|armbian\/cache)" /proc/mounts; do
 		display_alert "Unmounting..." "target: ${target}" "debug"
 		umount "${target}"/dev/pts || true
 		umount --recursive "${target}"/dev || true
@@ -45,6 +49,7 @@ function umount_chroot() {
 		umount "${target}"/tmp || true
 		umount "${target}"/var/tmp || true
 		umount "${target}"/run/user/0 || true
+		umount "${target}"/armbian/cache || true
 		wait_for_disk_sync "after umount chroot"
 		run_host_command_logged grep -E "'${target}/(dev|proc|sys|tmp)'" /proc/mounts "||" true
 	done


### PR DESCRIPTION
# Description

This change enhances the mount_chroot() and umount_chroot() helper functions to:

- Bind-mount the host’s /armbian/cache into ${target}/armbian/cache so that build artifacts and source caches are shared between host and chroot.
- Update the unmount logic to detect and cleanly unmount the new mount.

# Motivation & Context:
Current chroot helper does not  bind the Armbian cache directory. When customizing the image, each build starts “from cold,” losing all previously downloaded sources and compiled artifacts. By adding this mounts, we:

- Reuse download/build caches across chroot sessions, dramatically speeding up iterative development.

No downstream dependencies introduced.

# How Has This Been Tested?

Tested working both cache and check the image to make sure that the cache was not included in the image.

Checklist

- [x] My code follows the project’s style guidelines
- [x] I have performed a self-review of my own code
- [] I have commented hard-to-understand areas
- [] My changes generate no new warnings
- [] Any dependent changes have been merged and published in downstream modules

