### PR TITLE
mvebu: bootscript fixes & enhancements

### DIFF
--- a/config/bootscripts/boot-mvebu.cmd
+++ b/config/bootscripts/boot-mvebu.cmd
@@ -3,9 +3,9 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-setenv load_addr      "0x00300000"
-setenv fdt_addr_r     "0x02040000" # max size 256 KiB (=dtb+dto+fdt_extrasize)
-setenv kernel_addr_r  "0x02080000" # max size 16 MiB
+setenv load_addr "0x00300000"
+setenv fdt_addr_r "0x02040000" # max size 256 KiB (=dtb+dto+fdt_extrasize)
+setenv kernel_addr_r "0x02080000" # max size 16 MiB
 setenv ramdisk_addr_r "0x03080000"
 
 # default values
@@ -21,7 +21,8 @@ setenv eth2addr "00:50:43:84:25:2f"
 setenv eth3addr "00:50:43:0d:19:18"
 setenv fdt_extrasize "0x00010000"
 setenv align_to "0x00001000"
-setenv align_addr_next 'setexpr modulo ${addr_next} % ${align_to} ; if itest $modulo -gt 0 ; then setexpr addr_next ${addr_next} / ${align_to} ; setexpr addr_next ${addr_next} + 1 ; setexpr addr_next ${addr_next} * ${align_to} ; fi'
+setenv align_overlap_oboe_avoidance "on"
+setenv align_addr_next 'if test "${align_overlap_oboe_avoidance}" = "on" ; then setexpr addr_next ${addr_next} + 1 ; fi ; setexpr modulo ${addr_next} % ${align_to} ; if itest ${modulo} -gt 0 ; then setexpr addr_next ${addr_next} / ${align_to} ; setexpr addr_next ${addr_next} + 1 ; setexpr addr_next ${addr_next} * ${align_to} ; fi'
 
 echo "Boot script loaded from ${devtype}"
 


### PR DESCRIPTION
# Description
1.  Avoid oboe overlap trip during loading of images   
    - Add switch to turn avoidance on/off
    - Increment base address before alignment to resolve the oboe
    - oboe observed in U-Boot v2021.04 and in particular with DT loading
1. Add early exits for critical errors
    - Check all load actions
    - Add optional early exit with explanation in case a load fails
1. Bootscript enhancements
    - Added FDT resize/trim to allow big DT and overlays and still use
      configured load addresses in case `setexpr` not available
    - Moved FDT resize and next load address alignment
    - Added filename information to load instructions
    - Moved all "global" variable determinations to the top of the
      bootscript

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: [8178](https://github.com/armbian/build/issues/8178)
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2680](https://armbian.atlassian.net/browse/AR-2680)

# Documentation summary for feature / change

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- overlap oboe avoidance
  - [x] short description (copy / paste of PR title) 
     [Bug]: U-Boot load address calculation bug and DT overlap oobe
  - [x] summary (description relevant for end users)
     In U-Boot v2021.04 the `bootm_find_images()` function has an oboe when checking for overlap. To avoid this, a setting was added to simply add `1` to the load address during alignment.
  - [x] example of usage (how to see this in function)
     The overlap avoidance is enabled per default, but it can be disabled by adding `align_overlap_oboe_avoidance=off` to **armbianEnv.txt**.

- ease boot issue troubleshooting  
  - [x] short description (copy / paste of PR title) 
     Stop processing the bootscript whenever a situation arises that cannot be recovered from.
  - [x] summary (description relevant for end users)
     The bootscript will continue even when certain mandatory/required things fail to process. To speed up advancin to the next `bootmeth[od]`, add early exits in these situations. Such as, if device tree cannot be loaded, if device tree cannot be restored after an overlay failed to apply, when kernel image fails to load, initial ramdisk fails to load. 
  - [x] example of usage (how to see this in function)
     The early exit is enabled per default, but can be disabled by adding `exit_on_critical_errors=off` to **armbianEnv.txt**.
  
# How Has This Been Tested?

- [x] Test A
   Good weather tested updated `boot.scr` on `25.5.0-trunk.435`.
    ```
    U-Boot 2019.04 (May 10 2025 - 20:29:15 -0700)
    
    SoC:   MV88F6828-A0 at 1600 MHz
    DRAM:  2 GiB (800 MHz, 32-bit, ECC enabled)
    MMC:   mv_sdh: 0
    Loading Environment from MMC... *** Warning - bad CRC, using default environment
    
    Model: Helios4
    Board: Helios4
    SCSI:  MVEBU SATA INIT
    Target spinup took 0 ms.
    Target spinup took 0 ms.
    AHCI 0001.0000 32 slots 2 ports 6 Gbps 0x3 impl SATA mode
    flags: 64bit ncq led only pmp fbss pio slum part sxs 
    
    Net:   
    Warning: ethernet@70000 (eth1) using random MAC address - c2:92:1b:ee:5a:8e
    eth1: ethernet@70000
    Hit any key to stop autoboot:  0 
    switch to partitions #0, OK
    mmc0 is current device
    Scanning mmc 0:1...
    Found U-Boot script /boot/boot.scr
    6586 bytes read in 418 ms (14.6 KiB/s)
    ## Executing script at 00200000
    Boot script loaded from mmc
    Loading environment /boot/armbianEnv.txt from mmc to 0x00300000 ...
    177 bytes read in 403 ms (0 Bytes/s)
    Loading DT /boot/dtb/armada-388-helios4.dtb from mmc to 0x02040000 ...
    28834 bytes read in 843 ms (33.2 KiB/s)
    Trimming DT ...
    Loading kernel /boot/zImage from mmc to 2049000 ...
    8858728 bytes read in 2051 ms (4.1 MiB/s)
    Loading initial ramdisk /boot/uInitrd from mmc to 28bc000 ...
    11504566 bytes read in 2451 ms (4.5 MiB/s)
    Booting kernel from 2049000 ...
    ## Loading init Ramdisk from Legacy Image at 028bc000 ...
       Image Name:   uInitrd
       Image Type:   ARM Linux RAMDisk Image (gzip compressed)
       Data Size:    11504502 Bytes = 11 MiB
       Load Address: 00000000
       Entry Point:  00000000
       Verifying Checksum ... OK
    ## Flattened Device Tree blob at 02040000
       Booting using the fdt blob at 0x2040000
       Loading Ramdisk to 0f507000, end 0ffffb76 ... OK
       Loading Device Tree to 0f4fc000, end 0f506fff ... OK
    
    Starting kernel ...
    ```

- [x] Test B
   Changed DT filename to test DT load failure on `25.5.0-trunk.435`.
    ```
    U-Boot 2019.04 (May 10 2025 - 20:29:15 -0700)
    
    SoC:   MV88F6828-A0 at 1600 MHz
    DRAM:  2 GiB (800 MHz, 32-bit, ECC enabled)
    MMC:   mv_sdh: 0
    Loading Environment from MMC... *** Warning - bad CRC, using default environment
    
    Model: Helios4
    Board: Helios4
    SCSI:  MVEBU SATA INIT
    Target spinup took 0 ms.
    Target spinup took 0 ms.
    AHCI 0001.0000 32 slots 2 ports 6 Gbps 0x3 impl SATA mode
    flags: 64bit ncq led only pmp fbss pio slum part sxs 
    
    Net:   
    Warning: ethernet@70000 (eth1) using random MAC address - c2:92:1b:ee:5a:8e
    eth1: ethernet@70000
    Hit any key to stop autoboot:  0 
    switch to partitions #0, OK
    mmc0 is current device
    Scanning mmc 0:1...
    Found U-Boot script /boot/boot.scr
    6413 bytes read in 409 ms (14.6 KiB/s)
    ## Executing script at 00200000
    Boot script loaded from mmc
    Loading environment from mmc to 0x00300000 ...
    177 bytes read in 395 ms (0 Bytes/s)
    Loading DT from mmc to 0x02040000 ...
    !! CRITICAL - Could not load DT from mmc to 0x02040000
    SCRIPT FAILED: continuing...
    starting USB...
    ```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
   Warnings have been added to `boot-mvebu.cmd` to ease boot issue investigation.
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2680]: https://armbian.atlassian.net/browse/AR-2680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ