### PR TITLE
BananaPi BPI-M4-Zero: `Enable GPU and add Audio nodes`

### DIFF
--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
@@ -405,3 +405,69 @@ index 000000000000..e9640439e02c
 -- 
 2.35.3
 
+From 428ceff436e4c0e85214085a19d4546ac097f36d Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@armbian.com>
+Date: Wed, 14 May 2025 06:57:54 -0400
+Subject: [PATCH] BananaPi BPI-M4-Zero: Enable GPU and add Audio nodes
+
+Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
+---
+ .../allwinner/sun50i-h618-bananapi-m4-zero.dts |  5 +++++
+ .../dts/allwinner/sun50i-h618-bananapi-m4.dtsi | 18 +++++++++++++++++-
+ 2 files changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
+index 46e07893c653..12cdbdccf133 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
+@@ -34,6 +34,11 @@ led-0 {
+ 	};
+ };
+ 
++&codec {
++	status = "okay";
++	allwinner,audio-routing = "Hdmi", "HDMI";
++};
++
+ /* Connected to an on-board RTL8821CU USB WiFi chip. */
+ &ehci1 {
+ 	status = "okay";
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
+index e9640439e02c..6e52232105ae 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
+@@ -80,6 +80,22 @@ wifi_pwrseq: wifi-pwrseq {
+ 	};
+ };
+ 
++&ahub_dam_plat {
++	status = "okay";
++};
++
++&ahub1_plat {
++	status = "okay";
++};
++
++&ahub1_mach {
++	status = "okay";
++};
++
++/* &ahub_i2s2 {
++	status = "okay";
++}; */
++
+ &cpu0 {
+ 	cpu-supply = <&reg_dcdc2>;
+ };
+@@ -89,7 +105,7 @@ &de {
+ };
+ 
+ &gpu {
+-	status = "disabled";
++	status = "okay";
+ 	mali-supply = <&reg_dcdc1>;
+ };
+ 
+-- 
+2.39.5
+

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
@@ -424,10 +424,10 @@ index 46e07893c653..12cdbdccf133 100644
  	};
  };
  
-+&codec {
++/* &codec {
 +	status = "okay";
 +	allwinner,audio-routing = "Hdmi", "HDMI";
-+};
++}; */
 +
  /* Connected to an on-board RTL8821CU USB WiFi chip. */
  &ehci1 {

--- a/patch/kernel/archive/sunxi-6.13/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
+++ b/patch/kernel/archive/sunxi-6.13/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
@@ -405,3 +405,69 @@ index 000000000000..e9640439e02c
 -- 
 2.35.3
 
+From 428ceff436e4c0e85214085a19d4546ac097f36d Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@armbian.com>
+Date: Wed, 14 May 2025 06:57:54 -0400
+Subject: [PATCH] BananaPi BPI-M4-Zero: Enable GPU and add Audio nodes
+
+Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
+---
+ .../allwinner/sun50i-h618-bananapi-m4-zero.dts |  5 +++++
+ .../dts/allwinner/sun50i-h618-bananapi-m4.dtsi | 18 +++++++++++++++++-
+ 2 files changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
+index 46e07893c653..12cdbdccf133 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
+@@ -34,6 +34,11 @@ led-0 {
+ 	};
+ };
+ 
++&codec {
++	status = "okay";
++	allwinner,audio-routing = "Hdmi", "HDMI";
++};
++
+ /* Connected to an on-board RTL8821CU USB WiFi chip. */
+ &ehci1 {
+ 	status = "okay";
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
+index e9640439e02c..6e52232105ae 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4.dtsi
+@@ -80,6 +80,22 @@ wifi_pwrseq: wifi-pwrseq {
+ 	};
+ };
+ 
++&ahub_dam_plat {
++	status = "okay";
++};
++
++&ahub1_plat {
++	status = "okay";
++};
++
++&ahub1_mach {
++	status = "okay";
++};
++
++/* &ahub_i2s2 {
++	status = "okay";
++}; */
++
+ &cpu0 {
+ 	cpu-supply = <&reg_dcdc2>;
+ };
+@@ -89,7 +105,7 @@ &de {
+ };
+ 
+ &gpu {
+-	status = "disabled";
++	status = "okay";
+ 	mali-supply = <&reg_dcdc1>;
+ };
+ 
+-- 
+2.39.5
+

--- a/patch/kernel/archive/sunxi-6.13/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
+++ b/patch/kernel/archive/sunxi-6.13/patches.armbian/Add-board-BananaPi-BPI-M4-Zero.patch
@@ -424,10 +424,10 @@ index 46e07893c653..12cdbdccf133 100644
  	};
  };
  
-+&codec {
++/* &codec {
 +	status = "okay";
 +	allwinner,audio-routing = "Hdmi", "HDMI";
-+};
++}; */
 +
  /* Connected to an on-board RTL8821CU USB WiFi chip. */
  &ehci1 {


### PR DESCRIPTION
Audio tested via cmdline using mpg123

```
patrick@bananapim4zero:~$ mpg123 '1-01 New York.mp3'
High Performance MPEG 1.0/2.0/2.5 Audio Player for Layers 1, 2 and 3
	version 1.31.2; written and copyright by Michael Hipp and others
	free software (LGPL) without any warranty but with best wishes


Terminal control enabled, press 'h' for listing of keys and functions.

Playing MPEG stream 1 of 1: 1-01 New York.mp3 ...

MPEG 1.0 L III cbr320 44100 stereo

Title:   New York                         Artist: Cat Power                       
Comment: 12+6CB63EB4B422303C9C9C8A931D96704A+10566090
Album:   Jukebox
Year:    2008                             Genre:  Indépendant                     


[2:00] Decoding of 1-01 New York.mp3 finished.
```

I didn't test GPU on Armbian, but I have in my personal builds and it appeared to work fine. `Same patching.`