### PR TITLE
partitioning: fix compressed BTRFS creation

### DIFF
--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -352,7 +352,7 @@ function prepare_partitions() {
 
 			run_host_command_logged umount $rootdevice
 			display_alert "Remounting rootfs" "$rootdevice (UUID=${ROOT_PART_UUID})"
-			run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]} $rootdevice $MOUNT/
+			run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]} ${fscreateopt} $rootdevice $MOUNT/
 		fi
 		rootfs="UUID=$(blkid -s UUID -o value $rootdevice)"
 		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults,${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab


### PR DESCRIPTION
# Description

Compressed BTRFS mount options was lost in recent changes (ab6587ac05b519553fc05e8506b9c4e5d4f2a8bb). Fix it.

# How Has This Been Tested?

- [x] build image with compressed BTRFS rootfs partition

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
