### PR TITLE
Fix and improve Armbian GH Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Build minimal CLI Armbian Jammy for Bananapi M5 with LTS kernel:
 ./compile.sh \
 BOARD=bananapim5 \
 BRANCH=current \
-RELEASE=jammy \
+RELEASE=noble \
 BUILD_MINIMAL=yes \
 BUILD_DESKTOP=no \
 KERNEL_CONFIGURE=no
@@ -69,12 +69,12 @@ on:
   workflow_dispatch:
 jobs:
   build-armbian:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm # use ubuntu-24.04 when building x86 or riscv64
     steps:
       - uses: armbian/build@main
         with:
           armbian_token:     "${{ secrets.GITHUB_TOKEN }}"  # GitHub token
-          armbian_release:   "jammy"                        # userspace
+          armbian_release:   "noble"                        # userspace
           armbian_target:    "build"                        # build=image, kernel=kernel
           armbian_board:     "bananapim5"                   # build target
 ```

--- a/action.yml
+++ b/action.yml
@@ -172,6 +172,10 @@ runs:
         # go to build folder
         cd build
 
+        # default build command below doesn't prepare host dependencies
+        sudo ./compile.sh requirements
+        sudo chown -R $USER:$USER .
+
         # execute build command
         ./compile.sh "${{ inputs.armbian_target }}" \
         REVISION="${{ env.ARMBIAN_VERSION }}" \


### PR DESCRIPTION
# Description

Add forced host initialization (@rpardini why [this build](https://github.com/armbian/build/blob/main/action.yml#L175-L190) command doesn't automatically prepare host in actions?). Change build runner to aarch64 by default. This bring time of example image compilation from 15 down to 5 minutes.

Closing https://github.com/armbian/build/issues/8194

# How Has This Been Tested?

- [x] Tested on fork

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
