### PR TITLE
sakurapi-rk3308b: fix usb20phy_otg&u2phy_host, update the regulator name

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3308-sakurapi-rk3308b.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3308-sakurapi-rk3308b.dts
@@ -30,7 +30,7 @@
 		reset-gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_LOW>;
 	};
 
-	vcc5v0_sys: vcc5v0-sys {
+	vcc5v0_sys: regulator-vcc5v0-sys {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc5v0_sys";
 		regulator-always-on;
@@ -39,7 +39,7 @@
 		regulator-max-microvolt = <5000000>;
 	};
 
-	vdd_core: vdd-core {
+	vdd_core: regulator-vdd-core {
 		compatible = "pwm-regulator";
 		pwms = <&pwm0 0 5000 1>;
 		regulator-name = "vdd_core";
@@ -52,7 +52,7 @@
 		pwm-supply = <&vcc5v0_sys>;
 	};
 
-	vdd_log: vdd-log {
+	vdd_log: regulator-vdd-log {
 		compatible = "regulator-fixed";
 		regulator-name = "vdd_log";
 		regulator-always-on;
@@ -62,7 +62,7 @@
 		vin-supply = <&vcc5v0_sys>;
 	};
 
-	vcc_ddr: vcc-ddr {
+	vcc_ddr: regulator-vcc-ddr {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc_ddr";
 		regulator-always-on;
@@ -72,7 +72,7 @@
 		vin-supply = <&vcc5v0_sys>;
 	};
 
-	vcc_1v8: vcc-1v8 {
+	vcc_1v8: regulator-vcc-1v8 {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc_1v8";
 		regulator-always-on;
@@ -82,7 +82,7 @@
 		vin-supply = <&vcc_io>;
 	};
 
-	vcc_io: vcc-io {
+	vcc_io: regulator-vcc-io {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc_io";
 		regulator-always-on;
@@ -92,14 +92,14 @@
 		vin-supply = <&vcc5v0_sys>;
 	};
 
-	vcc_phy: vcc-phy-regulator {
+	vcc_phy: regulator-vcc-phy-regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc_phy";
 		regulator-always-on;
 		regulator-boot-on;
 	};
 
-	vcc5v0_otg: vcc5v0-otg {
+	vcc5v0_otg: regulator-vcc5v0-otg {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc5v0_otg";
 		regulator-always-on;
@@ -312,6 +312,7 @@
 };
 
 &usb20_otg {
+	dr_mode = "peripheral";
 	status = "okay";
 };
 
@@ -324,7 +325,7 @@
 };
 
 &u2phy_host {
-	state = "okay";
+	status = "okay";
 };
 
 &usb_host_ehci {

--- a/patch/kernel/archive/rockchip64-6.14/dt/rk3308-sakurapi-rk3308b.dts
+++ b/patch/kernel/archive/rockchip64-6.14/dt/rk3308-sakurapi-rk3308b.dts
@@ -30,7 +30,7 @@
 		reset-gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_LOW>;
 	};
 
-	vcc5v0_sys: vcc5v0-sys {
+	vcc5v0_sys: regulator-vcc5v0-sys {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc5v0_sys";
 		regulator-always-on;
@@ -39,7 +39,7 @@
 		regulator-max-microvolt = <5000000>;
 	};
 
-	vdd_core: vdd-core {
+	vdd_core: regulator-vdd-core {
 		compatible = "pwm-regulator";
 		pwms = <&pwm0 0 5000 1>;
 		regulator-name = "vdd_core";
@@ -52,7 +52,7 @@
 		pwm-supply = <&vcc5v0_sys>;
 	};
 
-	vdd_log: vdd-log {
+	vdd_log: regulator-vdd-log {
 		compatible = "regulator-fixed";
 		regulator-name = "vdd_log";
 		regulator-always-on;
@@ -62,7 +62,7 @@
 		vin-supply = <&vcc5v0_sys>;
 	};
 
-	vcc_ddr: vcc-ddr {
+	vcc_ddr: regulator-vcc-ddr {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc_ddr";
 		regulator-always-on;
@@ -72,7 +72,7 @@
 		vin-supply = <&vcc5v0_sys>;
 	};
 
-	vcc_1v8: vcc-1v8 {
+	vcc_1v8: regulator-vcc-1v8 {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc_1v8";
 		regulator-always-on;
@@ -82,7 +82,7 @@
 		vin-supply = <&vcc_io>;
 	};
 
-	vcc_io: vcc-io {
+	vcc_io: regulator-vcc-io {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc_io";
 		regulator-always-on;
@@ -92,14 +92,14 @@
 		vin-supply = <&vcc5v0_sys>;
 	};
 
-	vcc_phy: vcc-phy-regulator {
+	vcc_phy: regulator-vcc-phy-regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc_phy";
 		regulator-always-on;
 		regulator-boot-on;
 	};
 
-	vcc5v0_otg: vcc5v0-otg {
+	vcc5v0_otg: regulator-vcc5v0-otg {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc5v0_otg";
 		regulator-always-on;
@@ -312,6 +312,7 @@
 };
 
 &usb20_otg {
+	dr_mode = "peripheral";
 	status = "okay";
 };
 
@@ -324,7 +325,7 @@
 };
 
 &u2phy_host {
-	state = "okay";
+	status = "okay";
 };
 
 &usb_host_ehci {


### PR DESCRIPTION
# Description

1. fix usb20phy_otg&u2phy_host

2. update the name of regulator

# How Has This Been Tested?

- [x] OTG

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
