### PR TITLE
Allwinner: Replace bc with awk for floating-point comparison in temperature check

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-allwinner-battery
+++ b/packages/bsp/common/usr/lib/armbian/armbian-allwinner-battery
@@ -11,11 +11,11 @@
 function getboardtemp() {
 	if [ -f /etc/armbianmonitor/datasources/soctemp ]; then
 		read raw_temp </etc/armbianmonitor/datasources/soctemp 2>/dev/null
-		if [ ! -z $(echo "$raw_temp" | grep -o "^[1-9][0-9]*\.\?[0-9]*$") ] && (( $(echo "${raw_temp} < 200" |bc -l) )); then
-			# Allwinner legacy kernels output degree C
+		if [[ "$raw_temp" =~ ^[1-9][0-9]*\.?[0-9]*$ ]] && awk "BEGIN {exit !($raw_temp < 200)}"; then
+		# Allwinner legacy kernels output degree C
 			board_temp=${raw_temp}
 		else
-			board_temp=$(awk '{printf("%d",$1/1000)}' <<<${raw_temp})
+			board_temp=$(awk '{printf("%d",$1/1000)}' <<<"${raw_temp}")
 		fi
 	elif [ -f /etc/armbianmonitor/datasources/pmictemp ]; then
 		# fallback to PMIC temperature


### PR DESCRIPTION
# Description

This pull request removes the dependency on bc for floating-point comparisons in the temperature checking logic. The updated implementation uses awk, which is more portable and avoids spawning an extra process for bc.

Closing https://github.com/armbian/build/issues/8143

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
