### PR TITLE
add CAINIAO CNIoT-CORE initial support

### DIFF
--- a/config/boards/cainiao-cniot-core.csc
+++ b/config/boards/cainiao-cniot-core.csc
@@ -10,6 +10,9 @@ FULL_DESKTOP="yes"
 SERIALCON="ttyAML0"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="amlogic/meson-g12b-a311d-cainiao-cniot-core.dtb"
+# playback via HDMI: aplay -D plughw:CNIoTCORE,0 /usr/share/sounds/alsa/Front_Center.wav
+# playback via internal speaker: aplay -D plughw:CNIoTCORE,1 /usr/share/sounds/alsa/Front_Center.wav
+ASOUND_STATE="asound.state.cainiao-cniot-core"
 
 BOOTBRANCH_BOARD="tag:v2025.04"
 BOOTPATCHDIR="v2025.04" # This has a patch that adds support for CAINIAO CNIoT-CORE.

--- a/config/boards/cainiao-cniot-core.csc
+++ b/config/boards/cainiao-cniot-core.csc
@@ -1,0 +1,87 @@
+# Amlogic A311D 2GB RAM 16GB eMMC GBE USB3 RTL8822CS WiFi/BT
+BOARD_NAME="CAINIAO CNIoT-CORE"
+BOARDFAMILY="meson-g12b"
+BOARD_MAINTAINER=""
+BOOTCONFIG="cainiao-cniot-core_defconfig"
+KERNEL_TARGET="current,edge"
+KERNEL_TEST_TARGET="current"
+MODULES_BLACKLIST="simpledrm" # SimpleDRM conflicts with Panfrost on the CAINIAO CNIoT-CORE
+FULL_DESKTOP="yes"
+SERIALCON="ttyAML0"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="amlogic/meson-g12b-a311d-cainiao-cniot-core.dtb"
+
+BOOTBRANCH_BOARD="tag:v2025.04"
+BOOTPATCHDIR="v2025.04" # This has a patch that adds support for CAINIAO CNIoT-CORE.
+
+function post_family_config__use_repacked_fip() {
+	declare -g UBOOT_TARGET_MAP="u-boot.bin"
+	unset write_uboot_platform
+
+	function write_uboot_platform() {
+		dd if="$1/u-boot.bin" of="$2" bs=512 seek=1 conv=fsync 2>&1
+	}
+}
+
+function fetch_sources_tools__get_vendor_fip_and_gxlimg_source() {
+	fetch_from_repo "https://github.com/retro98boy/cainiao-cniot-core-linux.git" "cainiao-cniot-core-linux" "commit:30273c25aeabf75f609cff2c4fa7264335c295a8"
+	fetch_from_repo "https://github.com/repk/gxlimg.git" "gxlimg" "commit:0d0e5ba9cf396d1338067e8dc37a8bcd2e6874f1"
+}
+
+function build_host_tools__install_gxlimg() {
+	# Compile and install only if git commit hash changed
+	cd "${SRC}/cache/sources/gxlimg" || exit
+	# need to check if /usr/local/bin/gxlimg to detect new Docker containers with old cached sources
+	if [[ ! -f .commit_id || $(git rev-parse @ 2> /dev/null) != $(< .commit_id) || ! -f /usr/local/bin/gxlimg ]]; then
+		display_alert "Compiling" "gxlimg" "info"
+		run_host_command_logged make distclean
+		run_host_command_logged make
+		install -Dm0755 gxlimg /usr/local/bin/gxlimg
+		git rev-parse @ 2> /dev/null > .commit_id
+	fi
+}
+
+function post_uboot_custom_postprocess__repack_vendor_fip_with_mainline_uboot() {
+	display_alert "${BOARD}" "Repacking vendor FIP with mainline u-boot.bin" "info"
+
+	BLOBS_DIR="${SRC}/cache/sources/cainiao-cniot-core-linux"
+	EXTRACT_DIR="${BLOBS_DIR}/extract"
+	AML_ENCRYPT="${SRC}/cache/sources/amlogic-boot-fip/khadas-vim3/aml_encrypt_g12b"
+
+	if [ ! -f "$AML_ENCRYPT" ]; then
+		display_alert "${BOARD}" "amlogic-boot-fip/khadas-vim3/aml_encrypt_g12b not exist" "err"
+		exit 1
+	fi
+
+	mv u-boot.bin raw-u-boot.bin
+	rm -f "${EXTRACT_DIR}/bl33.enc"
+	# The current version of gxlimg has a problem with the handling of bl3x,
+	# which may cause the produced fip to fail to boot.
+	# see https://github.com/repk/gxlimg/issues/19
+	# run_host_command_logged gxlimg -t bl3x -s raw-u-boot.bin "${EXTRACT_DIR}/bl33.enc"
+	run_host_x86_binary_logged "$AML_ENCRYPT" --bl3sig \
+		--input raw-u-boot.bin \
+		--output "${EXTRACT_DIR}/bl33.enc" \
+		--level v3 --type bl33
+	run_host_command_logged gxlimg \
+		-t fip \
+		--bl2 "${EXTRACT_DIR}/bl2.sign" \
+		--ddrfw "${EXTRACT_DIR}/ddr4_1d.fw" \
+		--ddrfw "${EXTRACT_DIR}/ddr4_2d.fw" \
+		--ddrfw "${EXTRACT_DIR}/ddr3_1d.fw" \
+		--ddrfw "${EXTRACT_DIR}/piei.fw" \
+		--ddrfw "${EXTRACT_DIR}/lpddr4_1d.fw" \
+		--ddrfw "${EXTRACT_DIR}/lpddr4_2d.fw" \
+		--ddrfw "${EXTRACT_DIR}/diag_lpddr4.fw" \
+		--ddrfw "${EXTRACT_DIR}/aml_ddr.fw" \
+		--ddrfw "${EXTRACT_DIR}/lpddr3_1d.fw" \
+		--bl30 "${EXTRACT_DIR}/bl30.enc" \
+		--bl31 "${EXTRACT_DIR}/bl31.enc" \
+		--bl33 "${EXTRACT_DIR}/bl33.enc" \
+		--rev v3 u-boot.bin
+
+	if [ ! -s u-boot.bin ]; then
+		display_alert "${BOARD}" "FIP repack produced empty u-boot.bin" "err"
+		exit 1
+	fi
+}

--- a/config/sources/families/meson-g12b.conf
+++ b/config/sources/families/meson-g12b.conf
@@ -24,6 +24,9 @@ function uboot_custom_postprocess() {
 	elif [[ $BOARD == khadas-vim3 ]]; then
 		# do nothing. VIM3 has its own post_uboot_custom_postprocess hook, directly in the board file.
 		:
+	elif [[ $BOARD == cainiao-cniot-core ]]; then
+		# do nothing. CAINIAO CNIoT-CORE has its own post_uboot_custom_postprocess hook, directly in the board file.
+		:
 	elif [[ $BOARD == radxa-zero2 ]]; then
 		uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/radxa-zero2 g12b
 	elif [[ $BOARD == bananapim2s ]]; then

--- a/packages/blobs/asound.state/asound.state.cainiao-cniot-core
+++ b/packages/blobs/asound.state/asound.state.cainiao-cniot-core
@@ -1,0 +1,621 @@
+state.CNIoTCORE {
+	control.1 {
+		iface MIXER
+		name 'TOACODEC Lane Select'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 3'
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'ACODEC Playback Channel Mode'
+		value Stereo
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Stereo
+			item.1 Mono
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'ACODEC Playback Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'ACODEC Playback Volume'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'ACODEC Ramp Rate'
+		value Fast
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Fast
+			item.1 Slow
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'ACODEC Volume Ramp Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'ACODEC Mute Ramp Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'ACODEC Unmute Ramp Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'TDMOUT_C Lane 0 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'TDMOUT_C Lane 1 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'TDMOUT_C Lane 2 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'TDMOUT_C Lane 3 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'TDMOUT_C Gain Enable Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'TDMOUT_B Lane 0 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'TDMOUT_B Lane 1 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'TDMOUT_B Lane 2 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'TDMOUT_B Lane 3 Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'TDMOUT_B Gain Enable Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.19 {
+		iface PCM
+		device 7
+		name 'Playback Channel Map'
+		value.0 0
+		value.1 0
+		value.2 0
+		value.3 0
+		value.4 0
+		value.5 0
+		value.6 0
+		value.7 0
+		comment {
+			access 'read volatile'
+			type INTEGER
+			count 8
+			range '0 - 36'
+		}
+	}
+	control.20 {
+		iface PCM
+		device 7
+		name 'IEC958 Playback Mask'
+		value ffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+		comment {
+			access read
+			type IEC958
+			count 1
+		}
+	}
+	control.21 {
+		iface PCM
+		device 7
+		name 'IEC958 Playback Default'
+		value '0400000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write'
+			type IEC958
+			count 1
+		}
+	}
+	control.22 {
+		iface PCM
+		device 7
+		name ELD
+		value '100008006d10000100000000000000003669c2ac4d414732373451205144204532097f070000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 128
+		}
+	}
+	control.23 {
+		iface MIXER
+		name 'FRDDR_A SRC 1 EN Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.24 {
+		iface MIXER
+		name 'FRDDR_A SRC 2 EN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.25 {
+		iface MIXER
+		name 'FRDDR_A SRC 3 EN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.26 {
+		iface MIXER
+		name 'FRDDR_A SINK 1 SEL'
+		value 'OUT 1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.27 {
+		iface MIXER
+		name 'FRDDR_A SINK 2 SEL'
+		value 'OUT 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.28 {
+		iface MIXER
+		name 'FRDDR_A SINK 3 SEL'
+		value 'OUT 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'FRDDR_B SRC 1 EN Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'FRDDR_B SRC 2 EN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.31 {
+		iface MIXER
+		name 'FRDDR_B SRC 3 EN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.32 {
+		iface MIXER
+		name 'FRDDR_B SINK 1 SEL'
+		value 'OUT 2'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.33 {
+		iface MIXER
+		name 'FRDDR_B SINK 2 SEL'
+		value 'OUT 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.34 {
+		iface MIXER
+		name 'FRDDR_B SINK 3 SEL'
+		value 'OUT 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.35 {
+		iface MIXER
+		name 'FRDDR_C SRC 1 EN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.36 {
+		iface MIXER
+		name 'FRDDR_C SRC 2 EN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.37 {
+		iface MIXER
+		name 'FRDDR_C SRC 3 EN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.38 {
+		iface MIXER
+		name 'FRDDR_C SINK 1 SEL'
+		value 'OUT 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.39 {
+		iface MIXER
+		name 'FRDDR_C SINK 2 SEL'
+		value 'OUT 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.40 {
+		iface MIXER
+		name 'FRDDR_C SINK 3 SEL'
+		value 'OUT 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'OUT 0'
+			item.1 'OUT 1'
+			item.2 'OUT 2'
+			item.3 'OUT 3'
+			item.4 'OUT 4'
+			item.5 'OUT 5'
+			item.6 'OUT 6'
+			item.7 'OUT 7'
+		}
+	}
+	control.41 {
+		iface MIXER
+		name 'TOHDMITX I2S SRC'
+		value 'I2S B'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'I2S A'
+			item.1 'I2S B'
+			item.2 'I2S C'
+		}
+	}
+	control.42 {
+		iface MIXER
+		name 'TOHDMITX Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.43 {
+		iface MIXER
+		name 'TOHDMITX SPDIF SRC'
+		value 'SPDIF A'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'SPDIF A'
+			item.1 'SPDIF B'
+		}
+	}
+	control.44 {
+		iface MIXER
+		name 'TOACODEC SRC'
+		value 'I2S C'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'I2S A'
+			item.1 'I2S B'
+			item.2 'I2S C'
+		}
+	}
+	control.45 {
+		iface MIXER
+		name 'TOACODEC OUT EN Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.46 {
+		iface MIXER
+		name 'ACODEC Right DAC Sel'
+		value Right
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Right
+			item.1 Left
+		}
+	}
+	control.47 {
+		iface MIXER
+		name 'ACODEC Left DAC Sel'
+		value Left
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Left
+			item.1 Right
+		}
+	}
+	control.48 {
+		iface MIXER
+		name 'TDMOUT_C SRC SEL'
+		value 'IN 1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'IN 0'
+			item.1 'IN 1'
+			item.2 'IN 2'
+		}
+	}
+	control.49 {
+		iface MIXER
+		name 'TDMOUT_B SRC SEL'
+		value 'IN 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'IN 0'
+			item.1 'IN 1'
+			item.2 'IN 2'
+		}
+	}
+}

--- a/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -1,0 +1,483 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2019 BayLibre, SAS
+ * Author: Neil Armstrong <narmstrong@baylibre.com>
+ * Copyright (c) 2019 Christian Hewitt <christianshewitt@gmail.com>
+ * Copyright (c) 2025 retro98boy <retro98boy@qq.com>
+ */
+
+/dts-v1/;
+
+#include "meson-g12b-a311d.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
+
+/ {
+	compatible = "CAINIAO,CNIoT-CORE", "amlogic,a311d", "amlogic,g12b";
+	model = "CAINIAO CNIoT-CORE";
+
+	aliases {
+		serial0 = &uart_AO;
+		ethernet0 = &ethmac;
+		rtc99 = &vrtc;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x0 0x0 0x80000000>;
+	};
+
+	fan0: pwm-fan {
+		compatible = "pwm-fan";
+		#cooling-cells = <2>;
+		cooling-levels = <0 120 170 220>;
+		pwms = <&pwm_cd 1 40000 1>;
+		tach-gpio = <&gpio GPIOA_4 GPIO_ACTIVE_HIGH>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		pwr-btn {
+			label = "pwr-btn";
+			linux,code = <KEY_POWER>;
+			gpios = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	adc-keys {
+		compatible = "adc-keys";
+		io-channels = <&saradc 2>;
+		io-channel-names = "buttons";
+		keyup-threshold-microvolt = <1710000>;
+		poll-interval = <100>;
+
+		button-recovery {
+			label = "Recovery";
+			linux,code = <KEY_VENDOR>;
+			press-threshold-microvolt = <10000>;
+		};
+	};
+
+	emmc_pwrseq: emmc-pwrseq {
+		compatible = "mmc-pwrseq-emmc";
+		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>; /* In the vendor DTS, this is BOOT_10, but the actual test result is BOOT_12. */
+	};
+
+	hdmi-connector {
+		compatible = "hdmi-connector";
+		type = "a";
+
+		port {
+			hdmi_connector_in: endpoint {
+				remote-endpoint = <&hdmi_tx_tmds_out>;
+			};
+		};
+	};
+
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		reset-gpios = <&gpio GPIOX_6 GPIO_ACTIVE_LOW>;
+		clocks = <&wifi32k>;
+		clock-names = "ext_clock";
+	};
+
+	wifi32k: wifi32k {
+		compatible = "pwm-clock";
+		#clock-cells = <0>;
+		clock-frequency = <32768>;
+		pwms = <&pwm_ef 0 30518 0>; /* PWM_E at 32.768KHz */
+	};
+
+	dc_in: regulator-dc-in {
+		compatible = "regulator-fixed";
+		regulator-name = "dc_in";
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
+	/* important to usb hub */
+	amp_power: regulator-amp-power {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio GPIOH_8 GPIO_ACTIVE_HIGH>;
+		regulator-name = "amp_power";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	vddao_1v8: regulator-vddao-1v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "vddao_1v8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	vddcpu_a: regulator-vddcpu-a {
+		compatible = "pwm-regulator";
+		regulator-name = "VDDCPU_A";
+		regulator-min-microvolt = <690000>;
+		regulator-max-microvolt = <1050000>;
+		pwm-supply = <&dc_in>;
+		pwms = <&pwm_ab 0 1250 0>;
+		pwm-dutycycle-range = <100 0>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	vddcpu_b: regulator-vddcpu-b {
+		compatible = "pwm-regulator";
+		regulator-name = "VDDCPU_B";
+		regulator-min-microvolt = <690000>;
+		regulator-max-microvolt = <1050000>;
+		pwm-supply = <&dc_in>;
+		pwms = <&pwm_AO_cd 1 1250 0>;
+		pwm-dutycycle-range = <100 0>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	vsys_3v3: regulator-vsys-3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "vsys_3v3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	usb_pwr: regulator-usb-pwr {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio_ao GPIOAO_6 GPIO_ACTIVE_HIGH>; /* always keep usb hub reset pin high */
+		regulator-name = "usb_pwr";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	sound {
+		compatible = "amlogic,axg-sound-card";
+		model = "CNIoT-CORE";
+		audio-aux-devs = <&tdmout_b>;
+		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
+				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
+				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
+				"TDM_B Playback", "TDMOUT_B OUT";
+
+		clocks = <&clkc CLKID_MPLL2>,
+			 <&clkc CLKID_MPLL0>,
+			 <&clkc CLKID_MPLL1>;
+
+		assigned-clocks = <&clkc CLKID_MPLL2>,
+				  <&clkc CLKID_MPLL0>,
+				  <&clkc CLKID_MPLL1>;
+		assigned-clock-parents = <0>, <0>, <0>;
+		assigned-clock-rates = <294912000>,
+				       <270950400>,
+				       <393216000>;
+
+		dai-link-0 {
+			sound-dai = <&frddr_a>;
+		};
+
+		dai-link-1 {
+			sound-dai = <&frddr_b>;
+		};
+
+		dai-link-2 {
+			sound-dai = <&frddr_c>;
+		};
+
+		/* 8ch hdmi interface */
+		dai-link-3 {
+			sound-dai = <&tdmif_b>;
+			dai-format = "i2s";
+			dai-tdm-slot-tx-mask-0 = <1 1>;
+			dai-tdm-slot-tx-mask-1 = <1 1>;
+			dai-tdm-slot-tx-mask-2 = <1 1>;
+			dai-tdm-slot-tx-mask-3 = <1 1>;
+			mclk-fs = <256>;
+
+			codec {
+				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
+			};
+		};
+
+		/* hdmi glue */
+		dai-link-4 {
+			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
+
+			codec {
+				sound-dai = <&hdmi_tx>;
+			};
+		};
+	};
+};
+
+&arb {
+	status = "okay";
+};
+
+&clkc_audio {
+	status = "okay";
+};
+
+&cecb_AO {
+	pinctrl-0 = <&cec_ao_b_h_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	hdmi-phandle = <&hdmi_tx>;
+};
+
+&cpu0 {
+	cpu-supply = <&vddcpu_b>;
+	operating-points-v2 = <&cpu_opp_table_0>;
+	clocks = <&clkc CLKID_CPU_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu1 {
+	cpu-supply = <&vddcpu_b>;
+	operating-points-v2 = <&cpu_opp_table_0>;
+	clocks = <&clkc CLKID_CPU_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu100 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu101 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu102 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu103 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu_thermal {
+	trips {
+		cpu_active: cpu-active {
+			temperature = <60000>; /* millicelsius */
+			hysteresis = <5000>; /* millicelsius */
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map2 {
+			trip = <&cpu_active>;
+			cooling-device = <&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+		};
+	};
+};
+
+&ethmac {
+	pinctrl-0 = <&eth_pins>, <&eth_rgmii_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	phy-mode = "rgmii";
+	phy-handle = <&rtl8211f>;
+	amlogic,tx-delay-ns = <2>;
+};
+
+&ext_mdio {
+	rtl8211f: rtl8211f@0 {
+		reg = <0>;
+		max-speed = <1000>;
+
+		reset-assert-us = <10000>;
+		reset-deassert-us = <80000>;
+		reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
+
+		interrupt-parent = <&gpio_intc>;
+		/* MAC_INTR on GPIOZ_14 */
+		interrupts = <IRQID_GPIOZ_14 IRQ_TYPE_LEVEL_LOW>; /* tested by voltmeter */
+	};
+};
+
+&frddr_a {
+	status = "okay";
+};
+
+&frddr_b {
+	status = "okay";
+};
+
+&frddr_c {
+	status = "okay";
+};
+
+&hdmi_tx {
+	status = "okay";
+	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
+	pinctrl-names = "default";
+};
+
+&hdmi_tx_tmds_port {
+	hdmi_tx_tmds_out: endpoint {
+		remote-endpoint = <&hdmi_connector_in>;
+	};
+};
+
+&npu {
+	status = "okay";
+};
+
+&pwm_ab {
+	status = "okay";
+	pinctrl-0 = <&pwm_a_e_pins>;
+	pinctrl-names = "default";
+	clocks = <&xtal>;
+	clock-names = "clkin0";
+};
+
+&pwm_cd {
+	status = "okay";
+	pinctrl-0 = <&pwm_d_a_pins>;
+	pinctrl-names = "default";
+};
+
+&pwm_ef {
+	status = "okay";
+	pinctrl-0 = <&pwm_e_pins>;
+	pinctrl-names = "default";
+};
+
+&pwm_AO_cd {
+	pinctrl-0 = <&pwm_ao_d_e_pins>;
+	pinctrl-names = "default";
+	clocks = <&xtal>;
+	clock-names = "clkin1";
+	status = "okay";
+};
+
+&saradc {
+	status = "okay";
+	vref-supply = <&vddao_1v8>;
+};
+
+&sd_emmc_a {
+	status = "okay";
+	pinctrl-0 = <&sdio_pins>;
+	pinctrl-1 = <&sdio_clk_gate_pins>;
+	pinctrl-names = "default", "clk-gate";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	bus-width = <4>;
+	max-frequency = <100000000>;
+	cap-sdio-irq;
+	cap-sd-highspeed;
+	non-removable;
+
+	/* WiFi firmware requires power in suspend */
+	keep-power-in-suspend;
+	mmc-pwrseq = <&sdio_pwrseq>;
+	vmmc-supply = <&vsys_3v3>;
+	vqmmc-supply = <&vddao_1v8>;
+
+	rtl8822cs: wifi@1 {
+		reg = <1>;
+		/*
+		 * tested by voltmeter
+		 * WL_REG_ON GPIOX_6
+		 * WL_WAKE_HOST GPIOX_5
+		 */
+	};
+};
+
+&sd_emmc_c {
+	status = "okay";
+	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
+	pinctrl-1 = <&emmc_clk_gate_pins>;
+	pinctrl-names = "default", "clk-gate";
+
+	max-frequency = <200000000>;
+	bus-width = <8>;
+	cap-mmc-highspeed;
+	mmc-ddr-1_8v;
+	mmc-hs200-1_8v;
+	non-removable;
+
+	mmc-pwrseq = <&emmc_pwrseq>;
+	vmmc-supply = <&vsys_3v3>;
+	vqmmc-supply = <&vddao_1v8>;
+};
+
+&tdmif_b {
+	status = "okay";
+};
+
+&tdmout_b {
+	status = "okay";
+};
+
+&tohdmitx {
+	status = "okay";
+};
+
+&uart_A {
+	status = "okay";
+	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
+	pinctrl-names = "default";
+	uart-has-rtscts;
+
+	bluetooth {
+		compatible = "realtek,rtl8822cs-bt";
+		enable-gpios = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
+		host-wake-gpios = <&gpio GPIOX_18 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
+		device-wake-gpios = <&gpio GPIOX_19 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
+	};
+};
+
+&uart_AO {
+	status = "okay";
+	pinctrl-0 = <&uart_ao_a_pins>;
+	pinctrl-names = "default";
+};
+
+&usb2_phy0 {
+	phy-supply = <&amp_power>;
+};
+
+&usb2_phy1 {
+	phy-supply = <&amp_power>;
+};
+
+&usb3_pcie_phy {
+	phy-supply = <&usb_pwr>;
+};
+
+&usb {
+	status = "okay";
+	dr_mode = "host";
+};

--- a/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -11,6 +11,7 @@
 #include "meson-g12b-a311d.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/sound/meson-g12a-toacodec.h>
 #include <dt-bindings/sound/meson-g12a-tohdmitx.h>
 
 / {
@@ -79,6 +80,14 @@
 				remote-endpoint = <&hdmi_tx_tmds_out>;
 			};
 		};
+	};
+
+	ht6872: ht6872 {
+		compatible = "simple-audio-amplifier";
+		enable-gpios = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
+		VCC-supply = <&vdd_amp>;
+		sound-name-prefix = "HT6872";
+		status = "okay";
 	};
 
 	sdio_pwrseq: sdio-pwrseq {
@@ -167,14 +176,33 @@
 		vin-supply = <&dc_in>;
 	};
 
+	vdd_amp: regulator-vdd-amp {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio GPIOH_7 GPIO_ACTIVE_HIGH>;
+		regulator-name = "vdd_amp";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
 	sound {
 		compatible = "amlogic,axg-sound-card";
 		model = "CNIoT-CORE";
-		audio-aux-devs = <&tdmout_b>;
+		audio-widgets = "Line", "Lineout";
+		audio-aux-devs = <&tdmout_b>, <&tdmout_c>, <&ht6872>;
 		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
 				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
 				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
-				"TDM_B Playback", "TDMOUT_B OUT";
+				"TDM_B Playback", "TDMOUT_B OUT",
+				"TDMOUT_C IN 0", "FRDDR_A OUT 2",
+				"TDMOUT_C IN 1", "FRDDR_B OUT 2",
+				"TDMOUT_C IN 2", "FRDDR_C OUT 2",
+				"TDM_C Playback", "TDMOUT_C OUT",
+				"HT6872 INL", "ACODEC LOLP",
+				"HT6872 INR", "ACODEC LORP",
+				"Lineout", "HT6872 OUTL",
+				"Lineout", "HT6872 OUTR";
 
 		clocks = <&clkc CLKID_MPLL2>,
 			 <&clkc CLKID_MPLL0>,
@@ -215,15 +243,40 @@
 			};
 		};
 
-		/* hdmi glue */
 		dai-link-4 {
+			sound-dai = <&tdmif_c>;
+			dai-format = "i2s";
+			dai-tdm-slot-tx-mask-0 = <1 1>;
+			mclk-fs = <256>;
+
+			codec {
+				sound-dai = <&toacodec TOACODEC_IN_C>;
+			};
+		};
+
+		/* hdmi glue */
+		dai-link-5 {
 			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
 
 			codec {
 				sound-dai = <&hdmi_tx>;
 			};
 		};
+
+		/* acodec glue */
+		dai-link-6 {
+			sound-dai = <&toacodec TOACODEC_OUT>;
+
+			codec {
+				sound-dai = <&acodec>;
+			};
+		};
 	};
+};
+
+&acodec {
+	AVDD-supply = <&vddao_1v8>;
+	status = "okay";
 };
 
 &arb {
@@ -460,7 +513,19 @@
 	status = "okay";
 };
 
+&tdmif_c {
+	status = "okay";
+};
+
 &tdmout_b {
+	status = "okay";
+};
+
+&tdmout_c {
+	status = "okay";
+};
+
+&toacodec {
 	status = "okay";
 };
 

--- a/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -176,6 +176,23 @@
 		vin-supply = <&dc_in>;
 	};
 
+	/*
+	 * The Type-C port on the host is switched with the four USB contacts on the side of the host via GPIOA_14.
+	 * Since the Type-C port on the host is either used for power supply or blocked by the dock,
+	 * switching USB 2.0 access to the four contacts on the side of the host is a better choice.
+	 * To use the Type-C port for data transmission,
+	 * you only need to set GPIOA_14 in the node below to a high level.
+	 */
+	usb_switch: regulator-usb-switch {
+		compatible = "regulator-fixed";
+		enable-active-low;
+		gpio = <&gpio GPIOA_14 GPIO_ACTIVE_LOW>;
+		regulator-name = "usb_switch";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
 	vdd_amp: regulator-vdd-amp {
 		compatible = "regulator-fixed";
 		enable-active-high;
@@ -558,7 +575,7 @@
 };
 
 &usb2_phy1 {
-	phy-supply = <&amp_power>;
+	phy-supply = <&usb_switch>;
 };
 
 &usb3_pcie_phy {

--- a/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -433,6 +433,29 @@
 	vqmmc-supply = <&vddao_1v8>;
 };
 
+/*
+ * GPIOH_4 is connected to 6 WS2812 LEDs.
+ * Reusing GPIOH_4 as SPI MOSI to control the WS2812 offers superior performance compared to the GPIO method.
+ */
+&spicc1_pins {
+	mux {
+		groups = "spi1_mosi";
+	};
+};
+
+/* Controlling WS2812 LEDs via spidev in user space. */
+&spicc1 {
+	status = "okay";
+	pinctrl-0 = <&spicc1_pins>;
+	pinctrl-names = "default";
+
+	spidev@0 {
+		compatible = "rohm,dh2228fv";
+		reg = <0>;
+		spi-max-frequency = <3340000>;
+	};
+};
+
 &tdmif_b {
 	status = "okay";
 };

--- a/patch/kernel/archive/meson64-6.12/meson-g12b-pinctrl-Add-missing-pinmux-for-pwm.patch
+++ b/patch/kernel/archive/meson64-6.12/meson-g12b-pinctrl-Add-missing-pinmux-for-pwm.patch
@@ -1,7 +1,7 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From e1e66c32b7a9ce7cf52922fe073c4bff40054599 Mon Sep 17 00:00:00 2001
 From: Yuntian Zhang <yt@radxa.com>
 Date: Thu, 13 Jan 2022 21:34:10 +0800
-Subject: pinctrl: meson: Add several missing pinmux for pwm functions
+Subject: [PATCH] pinctrl: meson: Add several missing pinmux for pwm functions
 
 The following pin definitions are mentioned in A311D Quick
 Reference Manual and S922X Public Datasheet, but not in S905Y2
@@ -11,15 +11,15 @@ They are currently exposed in Radxa Zero 2's GPIO header.
 
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 ---
- arch/arm64/boot/dts/amlogic/meson-g12b.dtsi | 34 ++++++++++
- drivers/pinctrl/meson/pinctrl-meson-g12a.c  | 14 +++-
- 2 files changed, 45 insertions(+), 3 deletions(-)
+ arch/arm64/boot/dts/amlogic/meson-g12b.dtsi | 42 +++++++++++++++++++++
+ drivers/pinctrl/meson/pinctrl-meson-g12a.c  | 16 ++++++--
+ 2 files changed, 55 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
-index 111111111111..222222222222 100644
+index 86e6ceb31..b2f9a09b2 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
-@@ -149,3 +149,37 @@ &pmu {
+@@ -149,3 +149,45 @@ &pmu {
  &npu {
  	power-domains = <&pwrc PWRC_G12A_NNA_ID>;
  };
@@ -56,12 +56,20 @@ index 111111111111..222222222222 100644
 +			bias-disable;
 +		};
 +	};
++
++	pwm_d_a_pins: pwm-d-a {
++		mux {
++			groups = "pwm_d_a";
++			function = "pwm_d";
++			bias-disable;
++		};
++	};
 +};
 diff --git a/drivers/pinctrl/meson/pinctrl-meson-g12a.c b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
-index 111111111111..222222222222 100644
+index e2788bfc5..c94360afc 100644
 --- a/drivers/pinctrl/meson/pinctrl-meson-g12a.c
 +++ b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
-@@ -271,17 +271,21 @@ static const unsigned int eth_act_led_pins[]		= { GPIOZ_15 };
+@@ -268,17 +268,22 @@ static const unsigned int eth_act_led_pins[]		= { GPIOZ_15 };
  static const unsigned int pwm_a_pins[]			= { GPIOX_6 };
  
  /* pwm_b */
@@ -80,20 +88,22 @@ index 111111111111..222222222222 100644
  static const unsigned int pwm_d_x3_pins[]		= { GPIOX_3 };
  static const unsigned int pwm_d_x6_pins[]		= { GPIOX_6 };
 +static const unsigned int pwm_d_z_pins[]		= { GPIOZ_2 };
++static const unsigned int pwm_d_a_pins[]		= { GPIOA_4 };
  
  /* pwm_e */
  static const unsigned int pwm_e_pins[]			= { GPIOX_16 };
-@@ -594,6 +598,9 @@ static const struct meson_pmx_group meson_g12a_periphs_groups[] = {
+@@ -591,6 +596,10 @@ static const struct meson_pmx_group meson_g12a_periphs_groups[] = {
  	GROUP(bt565_a_din5,		2),
  	GROUP(bt565_a_din6,		2),
  	GROUP(bt565_a_din7,		2),
 +	GROUP(pwm_b_z,			5),
 +	GROUP(pwm_c_z,			5),
 +	GROUP(pwm_d_z,			2),
++	GROUP(pwm_d_a,			3),
  	GROUP(tsin_b_valid_z,		3),
  	GROUP(tsin_b_sop_z,		3),
  	GROUP(tsin_b_din0_z,		3),
-@@ -726,6 +733,7 @@ static const struct meson_pmx_group meson_g12a_periphs_groups[] = {
+@@ -723,6 +732,7 @@ static const struct meson_pmx_group meson_g12a_periphs_groups[] = {
  	GROUP(uart_c_rts,		2),
  	GROUP(iso7816_clk_h,		1),
  	GROUP(iso7816_data_h,		1),
@@ -101,7 +111,7 @@ index 111111111111..222222222222 100644
  	GROUP(pwm_f_h,			4),
  	GROUP(cec_ao_a_h,		4),
  	GROUP(cec_ao_b_h,		5),
-@@ -1066,15 +1074,15 @@ static const char * const pwm_a_groups[] = {
+@@ -1058,15 +1068,15 @@ static const char * const pwm_a_groups[] = {
  };
  
  static const char * const pwm_b_groups[] = {
@@ -116,10 +126,10 @@ index 111111111111..222222222222 100644
  
  static const char * const pwm_d_groups[] = {
 -	"pwm_d_x3", "pwm_d_x6",
-+	"pwm_d_x3", "pwm_d_x6", "pwm_d_z",
++	"pwm_d_x3", "pwm_d_x6", "pwm_d_z", "pwm_d_a",
  };
  
  static const char * const pwm_e_groups[] = {
 -- 
-Armbian
+2.49.0
 

--- a/patch/kernel/archive/meson64-6.15/dt/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/patch/kernel/archive/meson64-6.15/dt/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -1,0 +1,483 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2019 BayLibre, SAS
+ * Author: Neil Armstrong <narmstrong@baylibre.com>
+ * Copyright (c) 2019 Christian Hewitt <christianshewitt@gmail.com>
+ * Copyright (c) 2025 retro98boy <retro98boy@qq.com>
+ */
+
+/dts-v1/;
+
+#include "meson-g12b-a311d.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
+
+/ {
+	compatible = "CAINIAO,CNIoT-CORE", "amlogic,a311d", "amlogic,g12b";
+	model = "CAINIAO CNIoT-CORE";
+
+	aliases {
+		serial0 = &uart_AO;
+		ethernet0 = &ethmac;
+		rtc99 = &vrtc;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x0 0x0 0x80000000>;
+	};
+
+	fan0: pwm-fan {
+		compatible = "pwm-fan";
+		#cooling-cells = <2>;
+		cooling-levels = <0 120 170 220>;
+		pwms = <&pwm_cd 1 40000 1>;
+		tach-gpio = <&gpio GPIOA_4 GPIO_ACTIVE_HIGH>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		pwr-btn {
+			label = "pwr-btn";
+			linux,code = <KEY_POWER>;
+			gpios = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	adc-keys {
+		compatible = "adc-keys";
+		io-channels = <&saradc 2>;
+		io-channel-names = "buttons";
+		keyup-threshold-microvolt = <1710000>;
+		poll-interval = <100>;
+
+		button-recovery {
+			label = "Recovery";
+			linux,code = <KEY_VENDOR>;
+			press-threshold-microvolt = <10000>;
+		};
+	};
+
+	emmc_pwrseq: emmc-pwrseq {
+		compatible = "mmc-pwrseq-emmc";
+		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>; /* In the vendor DTS, this is BOOT_10, but the actual test result is BOOT_12. */
+	};
+
+	hdmi-connector {
+		compatible = "hdmi-connector";
+		type = "a";
+
+		port {
+			hdmi_connector_in: endpoint {
+				remote-endpoint = <&hdmi_tx_tmds_out>;
+			};
+		};
+	};
+
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		reset-gpios = <&gpio GPIOX_6 GPIO_ACTIVE_LOW>;
+		clocks = <&wifi32k>;
+		clock-names = "ext_clock";
+	};
+
+	wifi32k: wifi32k {
+		compatible = "pwm-clock";
+		#clock-cells = <0>;
+		clock-frequency = <32768>;
+		pwms = <&pwm_ef 0 30518 0>; /* PWM_E at 32.768KHz */
+	};
+
+	dc_in: regulator-dc-in {
+		compatible = "regulator-fixed";
+		regulator-name = "dc_in";
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
+	/* important to usb hub */
+	amp_power: regulator-amp-power {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio GPIOH_8 GPIO_ACTIVE_HIGH>;
+		regulator-name = "amp_power";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	vddao_1v8: regulator-vddao-1v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "vddao_1v8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	vddcpu_a: regulator-vddcpu-a {
+		compatible = "pwm-regulator";
+		regulator-name = "VDDCPU_A";
+		regulator-min-microvolt = <690000>;
+		regulator-max-microvolt = <1050000>;
+		pwm-supply = <&dc_in>;
+		pwms = <&pwm_ab 0 1250 0>;
+		pwm-dutycycle-range = <100 0>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	vddcpu_b: regulator-vddcpu-b {
+		compatible = "pwm-regulator";
+		regulator-name = "VDDCPU_B";
+		regulator-min-microvolt = <690000>;
+		regulator-max-microvolt = <1050000>;
+		pwm-supply = <&dc_in>;
+		pwms = <&pwm_AO_cd 1 1250 0>;
+		pwm-dutycycle-range = <100 0>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	vsys_3v3: regulator-vsys-3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "vsys_3v3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	usb_pwr: regulator-usb-pwr {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio_ao GPIOAO_6 GPIO_ACTIVE_HIGH>; /* always keep usb hub reset pin high */
+		regulator-name = "usb_pwr";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	sound {
+		compatible = "amlogic,axg-sound-card";
+		model = "CNIoT-CORE";
+		audio-aux-devs = <&tdmout_b>;
+		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
+				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
+				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
+				"TDM_B Playback", "TDMOUT_B OUT";
+
+		clocks = <&clkc CLKID_MPLL2>,
+			 <&clkc CLKID_MPLL0>,
+			 <&clkc CLKID_MPLL1>;
+
+		assigned-clocks = <&clkc CLKID_MPLL2>,
+				  <&clkc CLKID_MPLL0>,
+				  <&clkc CLKID_MPLL1>;
+		assigned-clock-parents = <0>, <0>, <0>;
+		assigned-clock-rates = <294912000>,
+				       <270950400>,
+				       <393216000>;
+
+		dai-link-0 {
+			sound-dai = <&frddr_a>;
+		};
+
+		dai-link-1 {
+			sound-dai = <&frddr_b>;
+		};
+
+		dai-link-2 {
+			sound-dai = <&frddr_c>;
+		};
+
+		/* 8ch hdmi interface */
+		dai-link-3 {
+			sound-dai = <&tdmif_b>;
+			dai-format = "i2s";
+			dai-tdm-slot-tx-mask-0 = <1 1>;
+			dai-tdm-slot-tx-mask-1 = <1 1>;
+			dai-tdm-slot-tx-mask-2 = <1 1>;
+			dai-tdm-slot-tx-mask-3 = <1 1>;
+			mclk-fs = <256>;
+
+			codec {
+				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
+			};
+		};
+
+		/* hdmi glue */
+		dai-link-4 {
+			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
+
+			codec {
+				sound-dai = <&hdmi_tx>;
+			};
+		};
+	};
+};
+
+&arb {
+	status = "okay";
+};
+
+&clkc_audio {
+	status = "okay";
+};
+
+&cecb_AO {
+	pinctrl-0 = <&cec_ao_b_h_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	hdmi-phandle = <&hdmi_tx>;
+};
+
+&cpu0 {
+	cpu-supply = <&vddcpu_b>;
+	operating-points-v2 = <&cpu_opp_table_0>;
+	clocks = <&clkc CLKID_CPU_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu1 {
+	cpu-supply = <&vddcpu_b>;
+	operating-points-v2 = <&cpu_opp_table_0>;
+	clocks = <&clkc CLKID_CPU_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu100 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu101 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu102 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu103 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu_thermal {
+	trips {
+		cpu_active: cpu-active {
+			temperature = <60000>; /* millicelsius */
+			hysteresis = <5000>; /* millicelsius */
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map2 {
+			trip = <&cpu_active>;
+			cooling-device = <&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+		};
+	};
+};
+
+&ethmac {
+	pinctrl-0 = <&eth_pins>, <&eth_rgmii_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	phy-mode = "rgmii";
+	phy-handle = <&rtl8211f>;
+	amlogic,tx-delay-ns = <2>;
+};
+
+&ext_mdio {
+	rtl8211f: rtl8211f@0 {
+		reg = <0>;
+		max-speed = <1000>;
+
+		reset-assert-us = <10000>;
+		reset-deassert-us = <80000>;
+		reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
+
+		interrupt-parent = <&gpio_intc>;
+		/* MAC_INTR on GPIOZ_14 */
+		interrupts = <IRQID_GPIOZ_14 IRQ_TYPE_LEVEL_LOW>; /* tested by voltmeter */
+	};
+};
+
+&frddr_a {
+	status = "okay";
+};
+
+&frddr_b {
+	status = "okay";
+};
+
+&frddr_c {
+	status = "okay";
+};
+
+&hdmi_tx {
+	status = "okay";
+	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
+	pinctrl-names = "default";
+};
+
+&hdmi_tx_tmds_port {
+	hdmi_tx_tmds_out: endpoint {
+		remote-endpoint = <&hdmi_connector_in>;
+	};
+};
+
+&npu {
+	status = "okay";
+};
+
+&pwm_ab {
+	status = "okay";
+	pinctrl-0 = <&pwm_a_e_pins>;
+	pinctrl-names = "default";
+	clocks = <&xtal>;
+	clock-names = "clkin0";
+};
+
+&pwm_cd {
+	status = "okay";
+	pinctrl-0 = <&pwm_d_a_pins>;
+	pinctrl-names = "default";
+};
+
+&pwm_ef {
+	status = "okay";
+	pinctrl-0 = <&pwm_e_pins>;
+	pinctrl-names = "default";
+};
+
+&pwm_AO_cd {
+	pinctrl-0 = <&pwm_ao_d_e_pins>;
+	pinctrl-names = "default";
+	clocks = <&xtal>;
+	clock-names = "clkin1";
+	status = "okay";
+};
+
+&saradc {
+	status = "okay";
+	vref-supply = <&vddao_1v8>;
+};
+
+&sd_emmc_a {
+	status = "okay";
+	pinctrl-0 = <&sdio_pins>;
+	pinctrl-1 = <&sdio_clk_gate_pins>;
+	pinctrl-names = "default", "clk-gate";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	bus-width = <4>;
+	max-frequency = <100000000>;
+	cap-sdio-irq;
+	cap-sd-highspeed;
+	non-removable;
+
+	/* WiFi firmware requires power in suspend */
+	keep-power-in-suspend;
+	mmc-pwrseq = <&sdio_pwrseq>;
+	vmmc-supply = <&vsys_3v3>;
+	vqmmc-supply = <&vddao_1v8>;
+
+	rtl8822cs: wifi@1 {
+		reg = <1>;
+		/*
+		 * tested by voltmeter
+		 * WL_REG_ON GPIOX_6
+		 * WL_WAKE_HOST GPIOX_5
+		 */
+	};
+};
+
+&sd_emmc_c {
+	status = "okay";
+	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
+	pinctrl-1 = <&emmc_clk_gate_pins>;
+	pinctrl-names = "default", "clk-gate";
+
+	max-frequency = <200000000>;
+	bus-width = <8>;
+	cap-mmc-highspeed;
+	mmc-ddr-1_8v;
+	mmc-hs200-1_8v;
+	non-removable;
+
+	mmc-pwrseq = <&emmc_pwrseq>;
+	vmmc-supply = <&vsys_3v3>;
+	vqmmc-supply = <&vddao_1v8>;
+};
+
+&tdmif_b {
+	status = "okay";
+};
+
+&tdmout_b {
+	status = "okay";
+};
+
+&tohdmitx {
+	status = "okay";
+};
+
+&uart_A {
+	status = "okay";
+	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
+	pinctrl-names = "default";
+	uart-has-rtscts;
+
+	bluetooth {
+		compatible = "realtek,rtl8822cs-bt";
+		enable-gpios = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
+		host-wake-gpios = <&gpio GPIOX_18 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
+		device-wake-gpios = <&gpio GPIOX_19 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
+	};
+};
+
+&uart_AO {
+	status = "okay";
+	pinctrl-0 = <&uart_ao_a_pins>;
+	pinctrl-names = "default";
+};
+
+&usb2_phy0 {
+	phy-supply = <&amp_power>;
+};
+
+&usb2_phy1 {
+	phy-supply = <&amp_power>;
+};
+
+&usb3_pcie_phy {
+	phy-supply = <&usb_pwr>;
+};
+
+&usb {
+	status = "okay";
+	dr_mode = "host";
+};

--- a/patch/kernel/archive/meson64-6.15/dt/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/patch/kernel/archive/meson64-6.15/dt/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -11,6 +11,7 @@
 #include "meson-g12b-a311d.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/sound/meson-g12a-toacodec.h>
 #include <dt-bindings/sound/meson-g12a-tohdmitx.h>
 
 / {
@@ -79,6 +80,14 @@
 				remote-endpoint = <&hdmi_tx_tmds_out>;
 			};
 		};
+	};
+
+	ht6872: ht6872 {
+		compatible = "simple-audio-amplifier";
+		enable-gpios = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
+		VCC-supply = <&vdd_amp>;
+		sound-name-prefix = "HT6872";
+		status = "okay";
 	};
 
 	sdio_pwrseq: sdio-pwrseq {
@@ -167,14 +176,33 @@
 		vin-supply = <&dc_in>;
 	};
 
+	vdd_amp: regulator-vdd-amp {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio GPIOH_7 GPIO_ACTIVE_HIGH>;
+		regulator-name = "vdd_amp";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
 	sound {
 		compatible = "amlogic,axg-sound-card";
 		model = "CNIoT-CORE";
-		audio-aux-devs = <&tdmout_b>;
+		audio-widgets = "Line", "Lineout";
+		audio-aux-devs = <&tdmout_b>, <&tdmout_c>, <&ht6872>;
 		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
 				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
 				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
-				"TDM_B Playback", "TDMOUT_B OUT";
+				"TDM_B Playback", "TDMOUT_B OUT",
+				"TDMOUT_C IN 0", "FRDDR_A OUT 2",
+				"TDMOUT_C IN 1", "FRDDR_B OUT 2",
+				"TDMOUT_C IN 2", "FRDDR_C OUT 2",
+				"TDM_C Playback", "TDMOUT_C OUT",
+				"HT6872 INL", "ACODEC LOLP",
+				"HT6872 INR", "ACODEC LORP",
+				"Lineout", "HT6872 OUTL",
+				"Lineout", "HT6872 OUTR";
 
 		clocks = <&clkc CLKID_MPLL2>,
 			 <&clkc CLKID_MPLL0>,
@@ -215,15 +243,40 @@
 			};
 		};
 
-		/* hdmi glue */
 		dai-link-4 {
+			sound-dai = <&tdmif_c>;
+			dai-format = "i2s";
+			dai-tdm-slot-tx-mask-0 = <1 1>;
+			mclk-fs = <256>;
+
+			codec {
+				sound-dai = <&toacodec TOACODEC_IN_C>;
+			};
+		};
+
+		/* hdmi glue */
+		dai-link-5 {
 			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
 
 			codec {
 				sound-dai = <&hdmi_tx>;
 			};
 		};
+
+		/* acodec glue */
+		dai-link-6 {
+			sound-dai = <&toacodec TOACODEC_OUT>;
+
+			codec {
+				sound-dai = <&acodec>;
+			};
+		};
 	};
+};
+
+&acodec {
+	AVDD-supply = <&vddao_1v8>;
+	status = "okay";
 };
 
 &arb {
@@ -460,7 +513,19 @@
 	status = "okay";
 };
 
+&tdmif_c {
+	status = "okay";
+};
+
 &tdmout_b {
+	status = "okay";
+};
+
+&tdmout_c {
+	status = "okay";
+};
+
+&toacodec {
 	status = "okay";
 };
 

--- a/patch/kernel/archive/meson64-6.15/dt/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/patch/kernel/archive/meson64-6.15/dt/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -176,6 +176,23 @@
 		vin-supply = <&dc_in>;
 	};
 
+	/*
+	 * The Type-C port on the host is switched with the four USB contacts on the side of the host via GPIOA_14.
+	 * Since the Type-C port on the host is either used for power supply or blocked by the dock,
+	 * switching USB 2.0 access to the four contacts on the side of the host is a better choice.
+	 * To use the Type-C port for data transmission,
+	 * you only need to set GPIOA_14 in the node below to a high level.
+	 */
+	usb_switch: regulator-usb-switch {
+		compatible = "regulator-fixed";
+		enable-active-low;
+		gpio = <&gpio GPIOA_14 GPIO_ACTIVE_LOW>;
+		regulator-name = "usb_switch";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
 	vdd_amp: regulator-vdd-amp {
 		compatible = "regulator-fixed";
 		enable-active-high;
@@ -558,7 +575,7 @@
 };
 
 &usb2_phy1 {
-	phy-supply = <&amp_power>;
+	phy-supply = <&usb_switch>;
 };
 
 &usb3_pcie_phy {

--- a/patch/kernel/archive/meson64-6.15/dt/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/patch/kernel/archive/meson64-6.15/dt/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -433,6 +433,29 @@
 	vqmmc-supply = <&vddao_1v8>;
 };
 
+/*
+ * GPIOH_4 is connected to 6 WS2812 LEDs.
+ * Reusing GPIOH_4 as SPI MOSI to control the WS2812 offers superior performance compared to the GPIO method.
+ */
+&spicc1_pins {
+	mux {
+		groups = "spi1_mosi";
+	};
+};
+
+/* Controlling WS2812 LEDs via spidev in user space. */
+&spicc1 {
+	status = "okay";
+	pinctrl-0 = <&spicc1_pins>;
+	pinctrl-names = "default";
+
+	spidev@0 {
+		compatible = "rohm,dh2228fv";
+		reg = <0>;
+		spi-max-frequency = <3340000>;
+	};
+};
+
 &tdmif_b {
 	status = "okay";
 };

--- a/patch/kernel/archive/meson64-6.15/meson-g12b-pinctrl-Add-missing-pinmux-for-pwm.patch
+++ b/patch/kernel/archive/meson64-6.15/meson-g12b-pinctrl-Add-missing-pinmux-for-pwm.patch
@@ -1,7 +1,7 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From e1e66c32b7a9ce7cf52922fe073c4bff40054599 Mon Sep 17 00:00:00 2001
 From: Yuntian Zhang <yt@radxa.com>
 Date: Thu, 13 Jan 2022 21:34:10 +0800
-Subject: pinctrl: meson: Add several missing pinmux for pwm functions
+Subject: [PATCH] pinctrl: meson: Add several missing pinmux for pwm functions
 
 The following pin definitions are mentioned in A311D Quick
 Reference Manual and S922X Public Datasheet, but not in S905Y2
@@ -11,15 +11,15 @@ They are currently exposed in Radxa Zero 2's GPIO header.
 
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 ---
- arch/arm64/boot/dts/amlogic/meson-g12b.dtsi | 34 ++++++++++
- drivers/pinctrl/meson/pinctrl-meson-g12a.c  | 14 +++-
- 2 files changed, 45 insertions(+), 3 deletions(-)
+ arch/arm64/boot/dts/amlogic/meson-g12b.dtsi | 42 +++++++++++++++++++++
+ drivers/pinctrl/meson/pinctrl-meson-g12a.c  | 16 ++++++--
+ 2 files changed, 55 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
-index 111111111111..222222222222 100644
+index 86e6ceb31..b2f9a09b2 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
-@@ -149,3 +149,37 @@ &pmu {
+@@ -149,3 +149,45 @@ &pmu {
  &npu {
  	power-domains = <&pwrc PWRC_G12A_NNA_ID>;
  };
@@ -56,12 +56,20 @@ index 111111111111..222222222222 100644
 +			bias-disable;
 +		};
 +	};
++
++	pwm_d_a_pins: pwm-d-a {
++		mux {
++			groups = "pwm_d_a";
++			function = "pwm_d";
++			bias-disable;
++		};
++	};
 +};
 diff --git a/drivers/pinctrl/meson/pinctrl-meson-g12a.c b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
-index 111111111111..222222222222 100644
+index e2788bfc5..c94360afc 100644
 --- a/drivers/pinctrl/meson/pinctrl-meson-g12a.c
 +++ b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
-@@ -271,17 +271,21 @@ static const unsigned int eth_act_led_pins[]		= { GPIOZ_15 };
+@@ -268,17 +268,22 @@ static const unsigned int eth_act_led_pins[]		= { GPIOZ_15 };
  static const unsigned int pwm_a_pins[]			= { GPIOX_6 };
  
  /* pwm_b */
@@ -80,20 +88,22 @@ index 111111111111..222222222222 100644
  static const unsigned int pwm_d_x3_pins[]		= { GPIOX_3 };
  static const unsigned int pwm_d_x6_pins[]		= { GPIOX_6 };
 +static const unsigned int pwm_d_z_pins[]		= { GPIOZ_2 };
++static const unsigned int pwm_d_a_pins[]		= { GPIOA_4 };
  
  /* pwm_e */
  static const unsigned int pwm_e_pins[]			= { GPIOX_16 };
-@@ -594,6 +598,9 @@ static const struct meson_pmx_group meson_g12a_periphs_groups[] = {
+@@ -591,6 +596,10 @@ static const struct meson_pmx_group meson_g12a_periphs_groups[] = {
  	GROUP(bt565_a_din5,		2),
  	GROUP(bt565_a_din6,		2),
  	GROUP(bt565_a_din7,		2),
 +	GROUP(pwm_b_z,			5),
 +	GROUP(pwm_c_z,			5),
 +	GROUP(pwm_d_z,			2),
++	GROUP(pwm_d_a,			3),
  	GROUP(tsin_b_valid_z,		3),
  	GROUP(tsin_b_sop_z,		3),
  	GROUP(tsin_b_din0_z,		3),
-@@ -726,6 +733,7 @@ static const struct meson_pmx_group meson_g12a_periphs_groups[] = {
+@@ -723,6 +732,7 @@ static const struct meson_pmx_group meson_g12a_periphs_groups[] = {
  	GROUP(uart_c_rts,		2),
  	GROUP(iso7816_clk_h,		1),
  	GROUP(iso7816_data_h,		1),
@@ -101,7 +111,7 @@ index 111111111111..222222222222 100644
  	GROUP(pwm_f_h,			4),
  	GROUP(cec_ao_a_h,		4),
  	GROUP(cec_ao_b_h,		5),
-@@ -1066,15 +1074,15 @@ static const char * const pwm_a_groups[] = {
+@@ -1058,15 +1068,15 @@ static const char * const pwm_a_groups[] = {
  };
  
  static const char * const pwm_b_groups[] = {
@@ -116,10 +126,10 @@ index 111111111111..222222222222 100644
  
  static const char * const pwm_d_groups[] = {
 -	"pwm_d_x3", "pwm_d_x6",
-+	"pwm_d_x3", "pwm_d_x6", "pwm_d_z",
++	"pwm_d_x3", "pwm_d_x6", "pwm_d_z", "pwm_d_a",
  };
  
  static const char * const pwm_e_groups[] = {
 -- 
-Armbian
+2.49.0
 

--- a/patch/u-boot/v2025.04/board_cainiao-cniot-core/add-board-cainiao-cniot-core.patch
+++ b/patch/u-boot/v2025.04/board_cainiao-cniot-core/add-board-cainiao-cniot-core.patch
@@ -128,10 +128,10 @@ index 00000000..345d9b86
 +CONFIG_ZSTD=y
 diff --git a/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts b/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts
 new file mode 100644
-index 00000000..e1deb707
+index 00000000..767b6e71
 --- /dev/null
 +++ b/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts
-@@ -0,0 +1,483 @@
+@@ -0,0 +1,506 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2019 BayLibre, SAS
@@ -565,6 +565,29 @@ index 00000000..e1deb707
 +	mmc-pwrseq = <&emmc_pwrseq>;
 +	vmmc-supply = <&vsys_3v3>;
 +	vqmmc-supply = <&vddao_1v8>;
++};
++
++/*
++ * GPIOH_4 is connected to 6 WS2812 LEDs.
++ * Reusing GPIOH_4 as SPI MOSI to control the WS2812 offers superior performance compared to the GPIO method.
++ */
++&spicc1_pins {
++	mux {
++		groups = "spi1_mosi";
++	};
++};
++
++/* Controlling WS2812 LEDs via spidev in user space. */
++&spicc1 {
++	status = "okay";
++	pinctrl-0 = <&spicc1_pins>;
++	pinctrl-names = "default";
++
++	spidev@0 {
++		compatible = "rohm,dh2228fv";
++		reg = <0>;
++		spi-max-frequency = <3340000>;
++	};
 +};
 +
 +&tdmif_b {

--- a/patch/u-boot/v2025.04/board_cainiao-cniot-core/add-board-cainiao-cniot-core.patch
+++ b/patch/u-boot/v2025.04/board_cainiao-cniot-core/add-board-cainiao-cniot-core.patch
@@ -128,10 +128,10 @@ index 00000000..345d9b86
 +CONFIG_ZSTD=y
 diff --git a/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts b/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts
 new file mode 100644
-index 00000000..767b6e71
+index 00000000..40b81e87
 --- /dev/null
 +++ b/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts
-@@ -0,0 +1,506 @@
+@@ -0,0 +1,571 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2019 BayLibre, SAS
@@ -145,6 +145,7 @@ index 00000000..767b6e71
 +#include "meson-g12b-a311d.dtsi"
 +#include <dt-bindings/input/input.h>
 +#include <dt-bindings/gpio/meson-g12a-gpio.h>
++#include <dt-bindings/sound/meson-g12a-toacodec.h>
 +#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
 +
 +/ {
@@ -213,6 +214,14 @@ index 00000000..767b6e71
 +				remote-endpoint = <&hdmi_tx_tmds_out>;
 +			};
 +		};
++	};
++
++	ht6872: ht6872 {
++		compatible = "simple-audio-amplifier";
++		enable-gpios = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
++		VCC-supply = <&vdd_amp>;
++		sound-name-prefix = "HT6872";
++		status = "okay";
 +	};
 +
 +	sdio_pwrseq: sdio-pwrseq {
@@ -301,14 +310,33 @@ index 00000000..767b6e71
 +		vin-supply = <&dc_in>;
 +	};
 +
++	vdd_amp: regulator-vdd-amp {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio GPIOH_7 GPIO_ACTIVE_HIGH>;
++		regulator-name = "vdd_amp";
++		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&dc_in>;
++	};
++
 +	sound {
 +		compatible = "amlogic,axg-sound-card";
 +		model = "CNIoT-CORE";
-+		audio-aux-devs = <&tdmout_b>;
++		audio-widgets = "Line", "Lineout";
++		audio-aux-devs = <&tdmout_b>, <&tdmout_c>, <&ht6872>;
 +		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
 +				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
 +				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
-+				"TDM_B Playback", "TDMOUT_B OUT";
++				"TDM_B Playback", "TDMOUT_B OUT",
++				"TDMOUT_C IN 0", "FRDDR_A OUT 2",
++				"TDMOUT_C IN 1", "FRDDR_B OUT 2",
++				"TDMOUT_C IN 2", "FRDDR_C OUT 2",
++				"TDM_C Playback", "TDMOUT_C OUT",
++				"HT6872 INL", "ACODEC LOLP",
++				"HT6872 INR", "ACODEC LORP",
++				"Lineout", "HT6872 OUTL",
++				"Lineout", "HT6872 OUTR";
 +
 +		clocks = <&clkc CLKID_MPLL2>,
 +			 <&clkc CLKID_MPLL0>,
@@ -349,15 +377,40 @@ index 00000000..767b6e71
 +			};
 +		};
 +
-+		/* hdmi glue */
 +		dai-link-4 {
++			sound-dai = <&tdmif_c>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			mclk-fs = <256>;
++
++			codec {
++				sound-dai = <&toacodec TOACODEC_IN_C>;
++			};
++		};
++
++		/* hdmi glue */
++		dai-link-5 {
 +			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
 +
 +			codec {
 +				sound-dai = <&hdmi_tx>;
 +			};
 +		};
++
++		/* acodec glue */
++		dai-link-6 {
++			sound-dai = <&toacodec TOACODEC_OUT>;
++
++			codec {
++				sound-dai = <&acodec>;
++			};
++		};
 +	};
++};
++
++&acodec {
++	AVDD-supply = <&vddao_1v8>;
++	status = "okay";
 +};
 +
 +&arb {
@@ -594,7 +647,19 @@ index 00000000..767b6e71
 +	status = "okay";
 +};
 +
++&tdmif_c {
++	status = "okay";
++};
++
 +&tdmout_b {
++	status = "okay";
++};
++
++&tdmout_c {
++	status = "okay";
++};
++
++&toacodec {
 +	status = "okay";
 +};
 +

--- a/patch/u-boot/v2025.04/board_cainiao-cniot-core/add-board-cainiao-cniot-core.patch
+++ b/patch/u-boot/v2025.04/board_cainiao-cniot-core/add-board-cainiao-cniot-core.patch
@@ -128,10 +128,10 @@ index 00000000..345d9b86
 +CONFIG_ZSTD=y
 diff --git a/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts b/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts
 new file mode 100644
-index 00000000..40b81e87
+index 00000000..53318e9d
 --- /dev/null
 +++ b/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts
-@@ -0,0 +1,571 @@
+@@ -0,0 +1,588 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2019 BayLibre, SAS
@@ -305,6 +305,23 @@ index 00000000..40b81e87
 +		enable-active-high;
 +		gpio = <&gpio_ao GPIOAO_6 GPIO_ACTIVE_HIGH>; /* always keep usb hub reset pin high */
 +		regulator-name = "usb_pwr";
++		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&dc_in>;
++	};
++
++	/*
++	 * The Type-C port on the host is switched with the four USB contacts on the side of the host via GPIOA_14.
++	 * Since the Type-C port on the host is either used for power supply or blocked by the dock,
++	 * switching USB 2.0 access to the four contacts on the side of the host is a better choice.
++	 * To use the Type-C port for data transmission,
++	 * you only need to set GPIOA_14 in the node below to a high level.
++	 */
++	usb_switch: regulator-usb-switch {
++		compatible = "regulator-fixed";
++		enable-active-low;
++		gpio = <&gpio GPIOA_14 GPIO_ACTIVE_LOW>;
++		regulator-name = "usb_switch";
 +		regulator-always-on;
 +		regulator-boot-on;
 +		vin-supply = <&dc_in>;
@@ -692,7 +709,7 @@ index 00000000..40b81e87
 +};
 +
 +&usb2_phy1 {
-+	phy-supply = <&amp_power>;
++	phy-supply = <&usb_switch>;
 +};
 +
 +&usb3_pcie_phy {

--- a/patch/u-boot/v2025.04/board_cainiao-cniot-core/add-board-cainiao-cniot-core.patch
+++ b/patch/u-boot/v2025.04/board_cainiao-cniot-core/add-board-cainiao-cniot-core.patch
@@ -1,0 +1,617 @@
+diff --git a/arch/arm/dts/meson-g12b-a311d-cainiao-cniot-core-u-boot.dtsi b/arch/arm/dts/meson-g12b-a311d-cainiao-cniot-core-u-boot.dtsi
+new file mode 100644
+index 00000000..236f2468
+--- /dev/null
++++ b/arch/arm/dts/meson-g12b-a311d-cainiao-cniot-core-u-boot.dtsi
+@@ -0,0 +1,7 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 BayLibre, SAS.
++ * Author: Neil Armstrong <narmstrong@baylibre.com>
++ */
++
++#include "meson-g12-common-u-boot.dtsi"
+diff --git a/configs/cainiao-cniot-core_defconfig b/configs/cainiao-cniot-core_defconfig
+new file mode 100644
+index 00000000..345d9b86
+--- /dev/null
++++ b/configs/cainiao-cniot-core_defconfig
+@@ -0,0 +1,109 @@
++# Reference from khadas-vim3_defconfig
++CONFIG_ARM=y
++CONFIG_SYS_BOARD="w400"
++CONFIG_ARCH_MESON=y
++CONFIG_TEXT_BASE=0x01000000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x20000000
++CONFIG_ENV_SIZE=0x2000
++CONFIG_DM_GPIO=y
++CONFIG_DEFAULT_DEVICE_TREE="amlogic/meson-g12b-a311d-cainiao-cniot-core"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_DM_RESET=y
++CONFIG_MESON_G12A=y
++CONFIG_SYS_LOAD_ADDR=0x1000000
++CONFIG_DEBUG_UART_BASE=0xff803000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_IDENT_STRING=" cainiao-cniot-core"
++CONFIG_DEBUG_UART=y
++CONFIG_REMAKE_ELF=y
++CONFIG_FIT=y
++CONFIG_FIT_SIGNATURE=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_OF_BOARD_SETUP=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_MISC_INIT_R=y
++CONFIG_SYS_MAXARGS=32
++# CONFIG_CMD_BDI is not set
++# CONFIG_CMD_IMI is not set
++CONFIG_CMD_DFU=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_I2C=y
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_SPI=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++CONFIG_CMD_REGULATOR=y
++CONFIG_OF_CONTROL=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_ADC=y
++CONFIG_SARADC_MESON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_ADC=y
++CONFIG_DFU_RAM=y
++CONFIG_DM_I2C=y
++CONFIG_SYS_I2C_MESON=y
++# to support erasing the bootloader on eMMC boot area
++CONFIG_SUPPORT_EMMC_BOOT=y
++#
++CONFIG_MMC_MESON_GX=y
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_PHY_REALTEK=y
++CONFIG_DM_MDIO=y
++CONFIG_DM_MDIO_MUX=y
++CONFIG_ETH_DESIGNWARE_MESON8B=y
++CONFIG_MDIO_MUX_MESON_G12A=y
++CONFIG_NVME=y
++CONFIG_MESON_G12A_USB_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCTRL_MESON_G12A=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MESON_EE_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DEBUG_UART_ANNOUNCE=y
++CONFIG_DEBUG_UART_SKIP_INIT=y
++CONFIG_MESON_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MESON_SPIFC=y
++CONFIG_SYSINFO=y
++CONFIG_SYSINFO_SMBIOS=y
++CONFIG_USB=y
++CONFIG_DM_USB_GADGET=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
++CONFIG_USB_DWC3_MESON_G12A=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_VENDOR_NUM=0x1b8e
++CONFIG_USB_GADGET_PRODUCT_NUM=0xfada
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_USB_GADGET_DWC2_OTG_PHY_BUS_WIDTH_8=y
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_VIDEO=y
++# CONFIG_VIDEO_BPP8 is not set
++# CONFIG_VIDEO_BPP16 is not set
++CONFIG_SYS_WHITE_ON_BLACK=y
++CONFIG_VIDEO_MESON=y
++CONFIG_VIDEO_DT_SIMPLEFB=y
++CONFIG_SPLASH_SCREEN=y
++CONFIG_SPLASH_SCREEN_ALIGN=y
++CONFIG_VIDEO_BMP_RLE8=y
++CONFIG_BMP_16BPP=y
++CONFIG_BMP_24BPP=y
++CONFIG_BMP_32BPP=y
++CONFIG_LZO=y
++CONFIG_ZLIB_UNCOMPRESS=y
++CONFIG_BZIP2=y
++CONFIG_ZSTD=y
+diff --git a/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts b/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts
+new file mode 100644
+index 00000000..e1deb707
+--- /dev/null
++++ b/dts/upstream/src/arm64/amlogic/meson-g12b-a311d-cainiao-cniot-core.dts
+@@ -0,0 +1,483 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 BayLibre, SAS
++ * Author: Neil Armstrong <narmstrong@baylibre.com>
++ * Copyright (c) 2019 Christian Hewitt <christianshewitt@gmail.com>
++ * Copyright (c) 2025 retro98boy <retro98boy@qq.com>
++ */
++
++/dts-v1/;
++
++#include "meson-g12b-a311d.dtsi"
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
++
++/ {
++	compatible = "CAINIAO,CNIoT-CORE", "amlogic,a311d", "amlogic,g12b";
++	model = "CAINIAO CNIoT-CORE";
++
++	aliases {
++		serial0 = &uart_AO;
++		ethernet0 = &ethmac;
++		rtc99 = &vrtc;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x80000000>;
++	};
++
++	fan0: pwm-fan {
++		compatible = "pwm-fan";
++		#cooling-cells = <2>;
++		cooling-levels = <0 120 170 220>;
++		pwms = <&pwm_cd 1 40000 1>;
++		tach-gpio = <&gpio GPIOA_4 GPIO_ACTIVE_HIGH>;
++	};
++
++	gpio-keys-polled {
++		compatible = "gpio-keys-polled";
++		poll-interval = <100>;
++
++		pwr-btn {
++			label = "pwr-btn";
++			linux,code = <KEY_POWER>;
++			gpios = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 2>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1710000>;
++		poll-interval = <100>;
++
++		button-recovery {
++			label = "Recovery";
++			linux,code = <KEY_VENDOR>;
++			press-threshold-microvolt = <10000>;
++		};
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>; /* In the vendor DTS, this is BOOT_10, but the actual test result is BOOT_12. */
++	};
++
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&gpio GPIOX_6 GPIO_ACTIVE_LOW>;
++		clocks = <&wifi32k>;
++		clock-names = "ext_clock";
++	};
++
++	wifi32k: wifi32k {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		clock-frequency = <32768>;
++		pwms = <&pwm_ef 0 30518 0>; /* PWM_E at 32.768KHz */
++	};
++
++	dc_in: regulator-dc-in {
++		compatible = "regulator-fixed";
++		regulator-name = "dc_in";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	/* important to usb hub */
++	amp_power: regulator-amp-power {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio GPIOH_8 GPIO_ACTIVE_HIGH>;
++		regulator-name = "amp_power";
++		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&dc_in>;
++	};
++
++	vddao_1v8: regulator-vddao-1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "vddao_1v8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&dc_in>;
++	};
++
++	vddcpu_a: regulator-vddcpu-a {
++		compatible = "pwm-regulator";
++		regulator-name = "VDDCPU_A";
++		regulator-min-microvolt = <690000>;
++		regulator-max-microvolt = <1050000>;
++		pwm-supply = <&dc_in>;
++		pwms = <&pwm_ab 0 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	vddcpu_b: regulator-vddcpu-b {
++		compatible = "pwm-regulator";
++		regulator-name = "VDDCPU_B";
++		regulator-min-microvolt = <690000>;
++		regulator-max-microvolt = <1050000>;
++		pwm-supply = <&dc_in>;
++		pwms = <&pwm_AO_cd 1 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	vsys_3v3: regulator-vsys-3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vsys_3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&dc_in>;
++	};
++
++	usb_pwr: regulator-usb-pwr {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio_ao GPIOAO_6 GPIO_ACTIVE_HIGH>; /* always keep usb hub reset pin high */
++		regulator-name = "usb_pwr";
++		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&dc_in>;
++	};
++
++	sound {
++		compatible = "amlogic,axg-sound-card";
++		model = "CNIoT-CORE";
++		audio-aux-devs = <&tdmout_b>;
++		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
++				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
++				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
++				"TDM_B Playback", "TDMOUT_B OUT";
++
++		clocks = <&clkc CLKID_MPLL2>,
++			 <&clkc CLKID_MPLL0>,
++			 <&clkc CLKID_MPLL1>;
++
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				       <270950400>,
++				       <393216000>;
++
++		dai-link-0 {
++			sound-dai = <&frddr_a>;
++		};
++
++		dai-link-1 {
++			sound-dai = <&frddr_b>;
++		};
++
++		dai-link-2 {
++			sound-dai = <&frddr_c>;
++		};
++
++		/* 8ch hdmi interface */
++		dai-link-3 {
++			sound-dai = <&tdmif_b>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			dai-tdm-slot-tx-mask-1 = <1 1>;
++			dai-tdm-slot-tx-mask-2 = <1 1>;
++			dai-tdm-slot-tx-mask-3 = <1 1>;
++			mclk-fs = <256>;
++
++			codec {
++				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
++			};
++		};
++
++		/* hdmi glue */
++		dai-link-4 {
++			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
++
++			codec {
++				sound-dai = <&hdmi_tx>;
++			};
++		};
++	};
++};
++
++&arb {
++	status = "okay";
++};
++
++&clkc_audio {
++	status = "okay";
++};
++
++&cecb_AO {
++	pinctrl-0 = <&cec_ao_b_h_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&cpu0 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu1 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu100 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu101 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu102 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu103 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu_thermal {
++	trips {
++		cpu_active: cpu-active {
++			temperature = <60000>; /* millicelsius */
++			hysteresis = <5000>; /* millicelsius */
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map2 {
++			trip = <&cpu_active>;
++			cooling-device = <&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&ethmac {
++	pinctrl-0 = <&eth_pins>, <&eth_rgmii_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	phy-mode = "rgmii";
++	phy-handle = <&rtl8211f>;
++	amlogic,tx-delay-ns = <2>;
++};
++
++&ext_mdio {
++	rtl8211f: rtl8211f@0 {
++		reg = <0>;
++		max-speed = <1000>;
++
++		reset-assert-us = <10000>;
++		reset-deassert-us = <80000>;
++		reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
++
++		interrupt-parent = <&gpio_intc>;
++		/* MAC_INTR on GPIOZ_14 */
++		interrupts = <IRQID_GPIOZ_14 IRQ_TYPE_LEVEL_LOW>; /* tested by voltmeter */
++	};
++};
++
++&frddr_a {
++	status = "okay";
++};
++
++&frddr_b {
++	status = "okay";
++};
++
++&frddr_c {
++	status = "okay";
++};
++
++&hdmi_tx {
++	status = "okay";
++	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
++	pinctrl-names = "default";
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
++	};
++};
++
++&npu {
++	status = "okay";
++};
++
++&pwm_ab {
++	status = "okay";
++	pinctrl-0 = <&pwm_a_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin0";
++};
++
++&pwm_cd {
++	status = "okay";
++	/* pinctrl-0 = <&pwm_d_a_pins>; */
++	pinctrl-names = "default";
++};
++
++&pwm_ef {
++	status = "okay";
++	pinctrl-0 = <&pwm_e_pins>;
++	pinctrl-names = "default";
++};
++
++&pwm_AO_cd {
++	pinctrl-0 = <&pwm_ao_d_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin1";
++	status = "okay";
++};
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vddao_1v8>;
++};
++
++&sd_emmc_a {
++	status = "okay";
++	pinctrl-0 = <&sdio_pins>;
++	pinctrl-1 = <&sdio_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	bus-width = <4>;
++	max-frequency = <100000000>;
++	cap-sdio-irq;
++	cap-sd-highspeed;
++	non-removable;
++
++	/* WiFi firmware requires power in suspend */
++	keep-power-in-suspend;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	vmmc-supply = <&vsys_3v3>;
++	vqmmc-supply = <&vddao_1v8>;
++
++	rtl8822cs: wifi@1 {
++		reg = <1>;
++		/*
++		 * tested by voltmeter
++		 * WL_REG_ON GPIOX_6
++		 * WL_WAKE_HOST GPIOX_5
++		 */
++	};
++};
++
++&sd_emmc_c {
++	status = "okay";
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	max-frequency = <200000000>;
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	non-removable;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vsys_3v3>;
++	vqmmc-supply = <&vddao_1v8>;
++};
++
++&tdmif_b {
++	status = "okay";
++};
++
++&tdmout_b {
++	status = "okay";
++};
++
++&tohdmitx {
++	status = "okay";
++};
++
++&uart_A {
++	status = "okay";
++	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
++	pinctrl-names = "default";
++	uart-has-rtscts;
++
++	bluetooth {
++		compatible = "realtek,rtl8822cs-bt";
++		enable-gpios = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
++		host-wake-gpios = <&gpio GPIOX_18 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
++		device-wake-gpios = <&gpio GPIOX_19 GPIO_ACTIVE_HIGH>; /* tested by voltmeter */
++	};
++};
++
++&uart_AO {
++	status = "okay";
++	pinctrl-0 = <&uart_ao_a_pins>;
++	pinctrl-names = "default";
++};
++
++&usb2_phy0 {
++	phy-supply = <&amp_power>;
++};
++
++&usb2_phy1 {
++	phy-supply = <&amp_power>;
++};
++
++&usb3_pcie_phy {
++	phy-supply = <&usb_pwr>;
++};
++
++&usb {
++	status = "okay";
++	dr_mode = "host";
++};


### PR DESCRIPTION
# How Has This Been Tested?

build the armbian.img, flash to eMMC/USB drive，then boot and use it

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

# Hardware

Cainiao Logistics Terminal A311D Edition, detachable into two parts: the main unit and the base.

![overview](https://github.com/user-attachments/assets/15b14aab-8a9c-4dd4-bc1b-444ef8182b4c)

## Main Unit

Amlogic A311D SoC, 2 GB DDR, 16 GB eMMC

No SD card slot, so the A311D can only load FIP from eMMC.

Gigabit Ethernet port and RTL8822CS WiFi/BT.

One USB Type-C port for power and data transfer in USB download mode. When the main unit is used with the base, it is unclear if this Type-C can function as a Host under Linux, as it is obstructed by the base, making it difficult to plug in devices for testing.

## Base

The base comes in different models, but the software should be universal.

Equipped with a USB HUB, display (HDMI or VGA), and power supply (USB Type-C or DC).

## Debug Points

Debug UART

![debug-uart](https://github.com/user-attachments/assets/6c79e452-b87e-4c9e-b9e0-e78e9225b948)

eMMC Shorting Point

![emmc-short](https://github.com/user-attachments/assets/799cb777-d3e3-4de5-a476-8e2dae9c90fd)

# Armbian Peripheral Status

| Component          | Status                     |
|--------------------|----------------------------|
| GBE                | Working                    |
| WiFi               | Working                    |
| BT                 | Working                    |
| PWM Fan            | Working                    |
| eMMC               | Working                    |
| USB                | Working                    |
| HDMI Display       | Working                    |
| HDMI Audio         | Working                    |
| Internal Speaker   | Not Working                |
| Power Button       | Working                    |
| ADC Key            | Working                    |
| Side Lights?       | Not Working                |
| Four Dots on Side  | Not Working (USB? SPI?)    |

# Installing Armbian

The Amlogic USB Burning Tool uses a proprietary firmware format. Although the firmware extension is .img, it is not a disk image file.

There are tools available for unpacking/repacking it:

[Amlogic binary only executable](https://github.com/khadas/utils/blob/master/aml_image_v2_packer)

[hzyitc/AmlImg](https://github.com/hzyitc/AmlImg)

[7Ji/ampack](https://github.com/7Ji/ampack)

Repacking all system image .img files into USB flashing packages is not cost-effective.

You can pack an FIP with mainline U-Boot into a USB flashing package to restore the device to a state with mainline U-Boot. Mainline U-Boot includes drivers for Ethernet, USB, and eMMC, which is sufficient for many tasks.

An FIP with mainline U-Boot is available [here](https://github.com/retro98boy/cainiao-cniot-core-linux/releases/tag/v2025.05.18).

## Flashing Mainline U-Boot

### Using dd Command

If the device has a working system like Android or Linux with root access, you can simply write fip-with-mainline-uboot.bin to the eMMC:

```
dd if=path-to-fip-with-mainline-uboot.bin of=/dev/mmcblk1 bs=512 seek=1
```

It is also recommended to flash the FIP to the eMMC boot area, as the A311D will try to load the FIP from the eMMC boot area if it cannot find it in the user area.

On Linux, you can:

```
# Check if write access to boot area is available
blockdev --getro /dev/mmcblk1boot0
blockdev --getro /dev/mmcblk1boot1

# Unlock write access to boot area
echo 0 | sudo tee /sys/block/mmcblk1boot0/force_ro
echo 0 | sudo tee /sys/block/mmcblk1boot1/force_ro

dd if=path-to-fip-with-mainline-uboot.bin of=/dev/mmcblk1boot0 bs=512 seek=1
dd if=path-to-fip-with-mainline-uboot.bin of=/dev/mmcblk1boot1 bs=512 seek=1
```

### Using USB Download Mode

If you cannot gain root access to the existing system on the device, you can use the Amlogic USB Burning Tool with the prepared USB flashing package fip-with-mainline-uboot.burn.img to directly flash mainline U-Boot to the eMMC. See **Flashing eMMC in USB Download Mode** for the USB download process.

> The Amlogic USB Burning Tool will write the FIP to the eMMC boot area.

## Flashing Armbian Image

### Flashing Armbian Image to USB Drive

If you frequently test different systems, considering the lifespan of eMMC and convenience, you may prefer booting from a USB drive. Simply flash the .img file to a USB drive, insert it into the device, and power on. The mainline U-Boot on the eMMC will automatically scan devices like eMMC, USB, and Ethernet in sequence to find a suitable boot environment, such as a U-Boot script, extlinux, or TFTP.

> If the A311D still boots from eMMC, it means there is a bootable system on the eMMC. To force booting from USB, you need to destroy the system on the eMMC, such as by deleting the MBR partition table. Alternatively, in the U-Boot command line, enter `setenv boot_targets usb0 && boot` if you have a UART cable connected.

### Flashing Armbian Image to eMMC

#### Method 1

This method requires a USB drive and network access for the device.

First, flash the Armbian system image to a USB drive and boot the device from it. Then, transfer the system image to be installed to the USB drive via the network, and use the dd command to flash it to the eMMC:

```
dd if=path-to-your-os-img of=/dev/mmcblk1 status=progress
```

Alternatively, use a trick to avoid transferring the system image to the USB drive.

On the Armbian system booted from the USB drive, install Netcat and run:

```
nc -l -p 1234 > /dev/mmcblk1
```

On a Linux PC, install Netcat and run:

```
nc -w 3 your-cainiao-cniot-core-ip 1234 < path-to-your-os-img
```

> Netcat has two variants: GNU and OpenBSD. If you have GNU Netcat installed on the PC, the command should be:
> ```
> nc -w 3 -c your-cainiao-cniot-core-ip 1234 < path-to-your-os-img
> ```
>
> To install OpenBSD Netcat:
> ```
> # ArchLinux
> sudo pacman -S openbsd-netcat
> # Ubuntu/Debian
> apt install netcat-openbsd
> ```
>
> To install GNU Netcat:
> ```
> # ArchLinux
> sudo pacman -S gnu-netcat
> # Ubuntu/Debian
> sudo apt install netcat-traditional
> ```

#### Method 2

This method requires connecting the device's UART to a PC and ensuring both the device and PC are on the same LAN via Ethernet.

First, place the system image to be installed on the Linux PC and rename it, e.g., armbian.img.

Split the image on the Linux PC, as the device's memory cannot hold the entire image at once:

```
split -b 512M armbian.img armbian.img.
# Assume armbian.img is split into armbian.img.aa, armbian.img.ab, armbian.img.ac; note the filenames.
```

Set up a TFTP server on the PC.

Windows users can use [Tftpd64](https://pjo2.github.io/tftpd64/).

On Linux, use a similar tool like [puhitaku/tftp-now](https://github.com/puhitaku/tftp-now). Download the binary from Releases, install it to PATH, and run `sudo tftp-now serve -root dir-to-armbian.img.aX`.

When powering on the device, press the spacebar in the UART session to enter the U-Boot command line.

Configure the device's network:

```
setenv ipaddr 172.24.0.241
setenv netmask 255.255.252.0
setenv gatewayip 172.24.0.1
setenv serverip 172.24.0.248
```

The IP 172.24.0.248 is the PC's IP.

Set the RAM address for temporarily storing the image:

```
setenv loadaddr 0x20000000
```

Start downloading the image from the PC's TFTP server and write it to the eMMC:

```
setenv mmcscript 'setenv files "armbian.img.aa armbian.img.ab armbian.img.ac"; setenv offset 0x0; for file in ${files}; do tftpboot ${loadaddr} ${file}; setexpr nblk ${filesize} / 0x200; mmc write ${loadaddr} ${offset} ${nblk}; setexpr offset ${offset} + ${nblk}; done'
mmc dev 1 && run mmcscript
```

Finally, reboot the device.

# Flashing eMMC in USB Download Mode

The USB Type-C port on the main unit is the USB download port.

Shorting the eMMC shorting point and powering on will put the device into USB download mode.

Alternatively, while the device is running, you can erase the header of the eMMC user/boot area and reboot to enter USB download mode. Example commands:

```
# Under Linux
sudo dd if=/dev/zero of=/dev/mmcblk1 bs=1MiB count=4 status=progress

echo 0 | sudo tee /sys/block/mmcblk1boot0/force_ro
echo 0 | sudo tee /sys/block/mmcblk1boot1/force_ro

sudo dd if=/dev/zero of=/dev/mmcblk1boot0 bs=1MiB count=4 status=progress
sudo dd if=/dev/zero of=/dev/mmcblk1boot1 bs=1MiB count=4 status=progress

# Under U-Boot command line
mmc dev 1
mmc erase 0 8192
mmc partconf 1 1 1 1
mmc erase 0 8192
mmc partconf 1 1 2 2
mmc erase 0 8192
```

Finally, use Amlogic USB Burning Tool v2.x.x to flash the image.
