### PR TITLE
Unlocking radios on RPI with a dedicated service

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -255,6 +255,26 @@ function pre_install_distribution_specific__add_rpi_packages() {
 	fi
 }
 
+function pre_install_distribution_specific__unblock_rfkill() {
+	# Create a systemd service to unblock rfkill
+	cat > "${SDCARD}/etc/systemd/system/unblock-rfkill.service" <<- EOT
+	[Unit]
+	Description=Unblock rfkill manually (no rfkill binary)
+	After=multi-user.target
+
+	[Service]
+	Type=oneshot
+	ExecStart=/bin/bash -c 'for f in /sys/class/rfkill/*/state; do echo 1 > "\$f"; done'
+	RemainAfterExit=true
+
+	[Install]
+	WantedBy=multi-user.target
+	EOT
+	# Enable the service to run at boot
+	display_alert "Enabling unblock-rfkill service" "bcm2711" "info"
+	chroot_sdcard systemctl enable unblock-rfkill.service
+}
+
 # Our default paritioning system is leaving esp on. Rpi3 is the only board that have issues with this.
 # Removing the ESP flag from the boot partition should allow the image to boot on both the RPi3 and RPi4.
 function pre_umount_final_image__remove_esp() {


### PR DESCRIPTION
# Description

While doing last prerelease testing I tried booting on Zero2W, which only has wireless connection. I could not enable connection because rfblock comes up enabled, thus nothing wireless wise works.

Adding a systemd service that ublock it without adding additional dependency rfkill.

Does it make sense to make this OS wide?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
