### PR TITLE
add _extensions_ folder to _userpatches_ in folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Function | Armbian | Yocto | Buildroot |
     ├── config-example.conf              User: example user config file
     ├── customize-image.sh               User: script will execute just before closing the image
     ├── atf                              User: ARM trusted firmware
+    ├── extensions                       User: Extend build system with specific functionality
     ├── kernel                           User: Linux kernel per kernel family
     ├── misc                             User: various
     └── u-boot                           User: universal boot loader patches


### PR DESCRIPTION
# Description

_userpatches/extensions_ folder is missing in folder description.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
