### PR TITLE
nanopct6(-lts): switch to mainline A-TF; use mainline u-boot also for 'current' branch

### DIFF
--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -30,8 +30,14 @@ function post_family_tweaks__nanopct6_naming_audios() {
 }
 
 # Mainline u-boot
-function post_family_config_branch_edge__nanopct6_use_mainline_uboot() {
-	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
+function post_family_config__nanopct6_use_mainline_uboot() {
+	[[ "${BRANCH}" == "vendor" ]] && return 0 # Not for 'vendor' branch, which uses 2017.09 vendor u-boot from Radxa
+
+	display_alert "$BOARD" "u-boot overrides for $BOARD / $BRANCH" "info"
+
+	# To reuse ATF code in rockchip64_common, let's change the BOOT_SCENARIO and call prepare_boot_configuration() again
+	BOOT_SCENARIO="tpl-blob-atf-mainline"
+	prepare_boot_configuration
 
 	declare -g BOOTCONFIG="nanopc-t6-rk3588_defconfig"
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
@@ -39,7 +45,7 @@ function post_family_config_branch_edge__nanopct6_use_mainline_uboot() {
 	declare -g BOOTBRANCH="tag:v2025.04-rc1"
 	declare -g BOOTPATCHDIR="v2025.04"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
-	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
 
 	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
@@ -55,12 +61,13 @@ function post_family_config_branch_edge__nanopct6_use_mainline_uboot() {
 # U-boot 2025.04+ can detect and set fdtfile automatically across T6 and T6-LTS boards.
 # So if using mainline u-boot, unset BOOT_FDT_FILE to let u-boot handle it.
 # That way, both variants can boot from the same image; lets keep the -lts board file for vendor kernel/u-boot.
-function post_family_config_branch_edge__t6_and_t6_lts_auto_dtb_name_via_uboot_detection() {
+function post_family_config__t6_and_t6_lts_auto_dtb_name_via_uboot_detection() {
+	[[ "${BRANCH}" == "vendor" ]] && return 0 # Not for 'vendor' branch, which uses 2017.09 vendor u-boot from Radxa
 	unset BOOT_FDT_FILE
 }
 
 function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
-	[[ "${BRANCH}" != "edge" ]] && return 0
+	[[ "${BRANCH}" == "vendor" ]] && return 0 # Not for 'vendor' branch, which uses 2017.09 vendor u-boot from Radxa
 
 	display_alert "u-boot for ${BOARD}" "u-boot: add to u-boot dtsi for UMS" "info" # avoid a patch, just append to the dtsi file
 	cat <<- EOD >> arch/arm/dts/rk3588-nanopc-t6-u-boot.dtsi                        # Append to the t6 u-boot dtsi file with stuff for enabling gadget/otg/peripheral mode
@@ -69,6 +76,9 @@ function pre_config_uboot_target__nanoptc6_patch_uboot_dtsi_for_ums() {
 		&usbdp_phy0 { status = "okay"; };
 		&usb_host0_xhci { dr_mode = "peripheral";  maximum-speed = "high-speed";  status = "okay"; };
 	EOD
+	# Append to the t6 u-boot dtsi file with stuff for enabling gadget/otg/peripheral mode
+	# Append to the t6 u-boot dtsi file with stuff for enabling gadget/otg/peripheral mode
+	# Append to the t6 u-boot dtsi file with stuff for enabling gadget/otg/peripheral mode
 
 }
 
@@ -85,7 +95,7 @@ function pre_config_uboot_target__nanopct6_patch_rockchip_common_boot_order() {
 }
 
 function post_config_uboot_target__extra_configs_for_nanopct6_mainline_environment_in_spi() {
-	[[ "${BRANCH}" != "edge" ]] && return 0
+	[[ "${BRANCH}" == "vendor" ]] && return 0 # Not for 'vendor' branch, which uses 2017.09 vendor u-boot from Radxa
 
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable board-specific configs (env in SPI)" "info"
 	run_host_command_logged scripts/config --enable CONFIG_DM_PMIC_FAN53555
@@ -134,7 +144,7 @@ function post_config_uboot_target__extra_configs_for_nanopct6_mainline_environme
 # Include fw_setenv, configured to point to the correct spot on the SPI Flash
 PACKAGE_LIST_BOARD="libubootenv-tool" # libubootenv-tool provides fw_printenv and fw_setenv, for talking to U-Boot environment
 function post_family_tweaks__config_nanopct6_fwenv() {
-	[[ "${BRANCH}" != "edge" ]] && return 0
+	[[ "${BRANCH}" == "vendor" ]] && return 0 # Not for 'vendor' branch, which uses 2017.09 vendor u-boot from Radxa
 	display_alert "Configuring fw_printenv and fw_setenv" "for ${BOARD} and u-boot ${BOOTBRANCH}" "info"
 	# Addresses below come from CONFIG_ENV_OFFSET and CONFIG_ENV_SIZE in defconfig
 	cat <<- 'FW_ENV_CONFIG' > "${SDCARD}"/etc/fw_env.config


### PR DESCRIPTION
- keep vendor u-boot for vendor branch (with rk's BL31)