### PR TITLE
khadas-edge2: fix uboot

### DIFF
--- a/config/boards/khadas-edge2.conf
+++ b/config/boards/khadas-edge2.conf
@@ -33,7 +33,7 @@ function post_family_config__uboot_kedge2() {
 	display_alert "$BOARD" "Configuring ($BOARD) u-boot" "info"
 
 	declare -g BOOTSOURCE='https://github.com/khadas/u-boot.git'
-	declare -g BOOTBRANCH='branch:khadas-edges-v2017.09'
+	declare -g BOOTBRANCH="commit:df276095a29a02f8e7ce4f451770c06486106594"
 	declare -g BOOTPATCHDIR="legacy/u-boot-khadas-edge2-rk3588"
 	declare -g BOOTCONFIG="khadas-edge2-rk3588s_defconfig"
 	declare -g SRC_EXTLINUX="yes" # For now, use extlinux. Thanks Monka


### PR DESCRIPTION
# Description

Latest merge in Khadas uboot tree breaks Uboot built itb images and itb no longer contains devicetree after that commit. Fix it by setting BOOTBRANCH to old commit as a temporary fix.
[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?
- [x] It boots

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
