### PR TITLE
Work if no customize-image.sh file present

### DIFF
--- a/lib/functions/rootfs/customize.sh
+++ b/lib/functions/rootfs/customize.sh
@@ -20,8 +20,10 @@ function customize_image() {
 		If you need repos, please consider `post_armbian_repo_customize_image` or `post_repo_customize_image`.
 	PRE_CUSTOMIZE_IMAGE
 
-	cp "$USERPATCHES_PATH"/customize-image.sh "${SDCARD}"/tmp/customize-image.sh
-	chmod +x "${SDCARD}"/tmp/customize-image.sh
+	if [[ -f "$USERPATCHES_PATH"/customize-image.sh ]]; then
+		cp "$USERPATCHES_PATH"/customize-image.sh "${SDCARD}"/tmp/customize-image.sh
+		chmod +x "${SDCARD}"/tmp/customize-image.sh
+	fi
 	mkdir -p "${SDCARD}"/tmp/overlay
 
 	# util-linux >= 2.27 required


### PR DESCRIPTION

- [x] short description (copy / paste of PR title)

# How Has This Been Tested?

- [x] Build with `customize-image.sh` file
- [x] Build without `customize-image.sh` file

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

