### PR TITLE
Enable HiDPI support only if the framebuffer size is detectable

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -687,15 +687,30 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		systemctl start systemd-networkd-wait-online
 	fi
 
-	# enable hiDPI support
-	if [[ "$(cut -d, -f1 < /sys/class/graphics/fb0/virtual_size 2> /dev/null)" -gt 1920 ]]; then
-		# lightdm
-		[[ -f /etc/lightdm/slick-greeter.conf ]] && echo "enable-hidpi = on" >> /etc/lightdm/slick-greeter.conf
-		# xfce
-		[[ -f /etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml ]] && sed -i 's|<property name="WindowScalingFactor" type="int" value=".*|<property name="WindowScalingFactor" type="int" value="2">|g' /etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
+	# Enable HiDPI support only if the framebuffer size is detectable
+	FB_VIRTUAL_SIZE="/sys/class/graphics/fb0/virtual_size"
+	HIDPI_THRESHOLD="1920"
+	if [[ -r "$FB_VIRTUAL_SIZE" ]]; then
+		fb_virtual_width=$(cut -d, -f1 < "$FB_VIRTUAL_SIZE" 2>/dev/null)
+		if [[ "$fb_virtual_width" =~ ^[0-9]+$ && "$fb_virtual_width" -gt "${HIDPI_THRESHOLD}" ]]; then
+			# Enable HiDPI in LightDM slick-greeter
+			if [[ -f /etc/lightdm/slick-greeter.conf ]]; then
+				if ! grep -q "^enable-hidpi *= *on" /etc/lightdm/slick-greeter.conf; then
+					echo "enable-hidpi = on" >> /etc/lightdm/slick-greeter.conf
+				fi
+			fi
 
-		# framebuffer console larger font
-		setfont /usr/share/consolefonts/Uni3-TerminusBold32x16.psf.gz
+			# Set XFCE scaling factor in skeleton config
+			XFCE_XSETTINGS="/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml"
+			if [[ -f "$XFCE_XSETTINGS" ]]; then
+				sed -i 's|\(<property name="WindowScalingFactor" type="int" value="\)[^"]*\(">\)|\12\2|' "$XFCE_XSETTINGS"
+			fi
+
+			# Set a larger console font for framebuffer
+			if [[ -f /usr/share/consolefonts/Uni3-TerminusBold32x16.psf.gz ]]; then
+				setfont /usr/share/consolefonts/Uni3-TerminusBold32x16.psf.gz
+			fi
+		fi
 	fi
 
 	clear


### PR DESCRIPTION
# Description

When fb0 is not present, errors is thrown to the console. Since clear screen is right after this, it was not that critical. This PR should address this.

Ref: https://github.com/armbian/build/pull/8235#issuecomment-2917988738

# How Has This Been Tested?

- [ ] Run where fb is present

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
