### PR TITLE
bcm2711: don't skip deploying firmware if on Debian

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -77,7 +77,6 @@ function post_family_tweaks_bsp__add_hooks_to_move_kernel_initrd_and_dtb() {
 	# By default, kernel post-install scripts use filenames starting with "z50-".
 	# However, Debian's 'raspi-firmware' package already uses this naming, which can cause conflicts.
 	# To avoid this, we rename our script to /etc/kernel/postinst.d/z51-raspi-firmware
-	# and include a runtime check for the distribution name.
 	# This prevents issues on Debian where the conflict exists, while Ubuntu is unaffected.
 	display_alert "Setting up z51-raspi-firmware" "bcm2711 - from ${RASPI_FIRMWARE_DIR}" "info"
 	run_host_command_logged cat <<- z51-raspi-firmware > "${destination}"/etc/kernel/postinst.d/z51-raspi-firmware
@@ -87,10 +86,6 @@ function post_family_tweaks_bsp__add_hooks_to_move_kernel_initrd_and_dtb() {
 		# only need to run this script on ubuntu. Debian's package has a postinst
 		# section capable of copying files, but Ubuntu relies on flash-kernel
 		[[ -d ${RASPI_FIRMWARE_DIR} ]] || exit 0
-
-		if grep -q '^ID=debian' /etc/os-release; then
-		   exit 0
-		fi
 
 		# Play nice when run under debconf.
 		exec </dev/null >&2
@@ -119,7 +114,7 @@ function post_family_tweaks_bsp__add_hooks_to_move_kernel_initrd_and_dtb() {
 		target=/boot/firmware
 		dtb_dir=/usr/lib/linux-image-$abi/
 
-        # The kernel image can be named either "Image" (standardized for ARM platforms) 
+        # The kernel image can be named either "Image" (standardized for ARM platforms)
         #   or "vmlinuz-${abi}" (default naming convention for Linux kernels). We need
 		#   too support both conventions.
 		if [[ -f /boot/Image ]]; then

--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -214,7 +214,7 @@ function post_family_tweaks_bsp__rpi_firmware_in_bsp() {
 	fi
 
 	display_alert "Using in-BSP firmware files for" "bcm2711::${BOARD}" "info"
-	declare firmware_commit_sha1="9cafcd85f8aed1ec0c0f609b98af591fae367ba2" # Keep this inside this file, so hashing detect changes and bumps the version of the bsp package
+	declare firmware_commit_sha1="a6827c1b30eabf41d53b3fa5e87d6ff8c0f28ae6" # Keep this inside this file, so hashing detect changes and bumps the version of the bsp package
 
 	declare destdir="${destination}/usr/lib/armbian-firmware-raspi"
 	run_host_command_logged mkdir -p "${destdir}"


### PR DESCRIPTION
#### bcm2711: don't skip deploying firmware if on Debian

- bcm2711: don't skip deploying firmware if on Debian
  - partial revert of ca1f302ec6dd1e8d80815cdf7b9e69a52517ed2c
- bcm2711: bump raspfw version to a6827c1b30eabf41d53b3fa5e87d6ff8c0f28ae6