### PR TITLE
mixtible-blade3: u-boot: back to radxa's v2024.03, as .10 breaks GMAC stable MAC patch

### DIFF
--- a/config/boards/mixtile-blade3.csc
+++ b/config/boards/mixtile-blade3.csc
@@ -12,8 +12,13 @@ declare -g UEFI_EDK2_BOARD_ID="blade3" # This _only_ used for uefi-edk2-rk3588 e
 
 # Vendor u-boot; use the default family (rockchip-rk3588) u-boot. See config/sources/families/rockchip-rk3588.conf
 function post_family_config__vendor_uboot_mekotronics() {
-	display_alert "$BOARD" "Configuring $BOARD vendor u-boot" "info"
+	display_alert "$BOARD" "Configuring $BOARD vendor u-boot (using Radxa's older next-dev-v2024.03)" "info"
 	declare -g BOOTDELAY=1 # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
+
+	# Override the stuff from rockchip-rk3588 family; Meko's have a patch for stable MAC address that breaks with Radxa's next-dev-v2024.10+
+	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
+	declare -g BOOTBRANCH='branch:next-dev-v2024.03' # NOT next-dev-v2024.10
+	declare -g BOOTPATCHDIR="legacy/u-boot-radxa-rk35xx"
 }
 
 function post_family_config_branch_edge__different_dtb_for_edge() {


### PR DESCRIPTION
- similar to e9708b8c335d0462e5ab06fdc5e852faed06caf8, but for the Blade3
- this reverts d048673c004f99c715b88ac517736f802c28d572 just for the Blade3
- there is little to be gained from .10 anyway on those machines (IMHO)
- it is still vendor 2017.09 after all, dunno why Radxa calls them "2024.x"