### PR TITLE
rootfs-to-image: do not use --sparse, it's _very slow_ on certain IO/FS combos

### DIFF
--- a/lib/functions/image/rootfs-to-image.sh
+++ b/lib/functions/image/rootfs-to-image.sh
@@ -215,7 +215,7 @@ function move_images_to_final_destination() {
 		done
 	else
 		display_alert "Moving artefacts using rsync to final destination" "${version}" "info"
-		run_host_command_logged rsync -av --sparse --no-owner --no-group --remove-source-files "${DESTIMG}/${version}"* "${FINALDEST}"
+		run_host_command_logged rsync -av --no-owner --no-group --remove-source-files "${DESTIMG}/${version}"* "${FINALDEST}"
 		run_host_command_logged rm -rfv --one-file-system "${DESTIMG}"
 	fi
 	return 0


### PR DESCRIPTION
- Revert "rootfs-to-image: preserve sparse files when moving artefacts to final destination with rsync"
This reverts commit 4fd0e0c29d3f8e58c182f6c5042307bbb15163b2.