### PR TITLE
patching: integrate `b4`-based lore link processing

### DIFF
--- a/lib/tools/common/b4_caller.py
+++ b/lib/tools/common/b4_caller.py
@@ -1,0 +1,75 @@
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+#  SPDX-License-Identifier: GPL-2.0
+#  Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+#  This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+import argparse
+import logging
+
+import b4
+import b4.mbox
+
+log: logging.Logger = logging.getLogger("b4_caller")
+
+#
+# Automatic grabbing of patches from mailing lists, using 'b4' tool 'am' command.
+# Patches will be grabbed and written to disk in the order they are listed here, before any other processing is done.
+#b4-am:
+#  - { prefix: "0666", lore: "https://lore.kernel.org/r/20230706-topic-amlogic-upstream-dt-fixes-take3-v1-0-63ed070eeab2@linaro.org" }
+
+def get_patch_via_b4(lore_link):
+	# Fool get_msgid with a fake argparse.Namespace
+	msgid_args = argparse.Namespace()
+	msgid_args.msgid = lore_link
+	msgid = b4.get_msgid(msgid_args)
+	log.debug(f"msgid: {msgid}")
+
+	msgs = b4.get_pi_thread_by_msgid(msgid)
+
+	count = len(msgs)
+	log.debug('Analyzing %s messages in the thread', count)
+
+	lmbx = b4.LoreMailbox()
+	for msg in msgs:
+		lmbx.add_message(msg)
+
+	lser = lmbx.get_series()
+
+	# hack at the "main config" to avoid attestation etc; b4's config is a global MAIN_CONFIG
+	config = b4.get_main_config()
+	config['attestation-policy'] = "off"
+
+	# hack at the "user config", since there is not really an user here; its a global USER_CONFIG
+	uconfig = b4.get_user_config()
+	uconfig['name'] = "Armbian Autopatcher"
+	uconfig['email'] = "auto.patcher@next.armbian.com"
+	log.debug(f"uconfig: {uconfig}")
+
+	# prepare for git am
+	am_msgs = lser.get_am_ready(addlink=True, linkmask='https://lore.kernel.org/r/%s')
+	log.debug('Total patches: %s', len(am_msgs))
+
+	top_msgid = None
+	for lmsg in lser.patches:
+		if lmsg is not None:
+			top_msgid = lmsg.msgid
+			break
+
+	if top_msgid is None:
+		raise Exception(f"Could not find any patches in the series '{lore_link}'.")
+
+	# slug for possibly naming the file
+	slug = lser.get_slug(extended=True)
+	log.debug('slug: %s', slug)
+
+	# final contents of patch file for our purposes
+	body = b''
+
+	for msg in am_msgs:
+		body += b'From git@z Thu Jan  1 00:00:00 1970\n'  # OH! the b4-marker!
+		body += b4.LoreMessage.get_msg_as_bytes(msg, headers='decode')
+
+	log.info("Done")
+
+	return {"body": body, "slug": slug}
+

--- a/lib/tools/common/patching_config.py
+++ b/lib/tools/common/patching_config.py
@@ -40,6 +40,15 @@ class PatchingOverlayDirectoryConfig:
 		return f"PatchingOverlayDirectoryConfig(source={self.source}, target={self.target})"
 
 
+class PatchingB4AMConfig:
+	def __init__(self, data: dict):
+		self.prefix: str = data.get("prefix", None)
+		self.lore: str = data.get("lore", None)
+
+	def __str__(self):
+		return f"PatchingB4AMConfig(prefix={self.prefix}, lore={self.lore})"
+
+
 class PatchingToGitConfig:
 	def __init__(self, data: dict):
 		self.do_not_commit_files: list[str] = data.get("do-not-commit-files", [])
@@ -78,6 +87,13 @@ class PatchingConfig:
 			PatchingOverlayDirectoryConfig(data) for data in self.yaml_config.get("overlay-directories", [])
 		]
 		self.has_overlay_directories: bool = len(self.overlay_directories) > 0
+
+		# 'b4' auto 'am' patching config
+		# DTS directories to copy config
+		self.b4_am_configs: list[PatchingB4AMConfig] = [
+			PatchingB4AMConfig(data) for data in self.yaml_config.get("b4-am", [])
+		]
+		self.has_b4_am_configs: bool = len(self.b4_am_configs) > 0
 
 	def read_yaml_config(self, yaml_config_file_path):
 		with open(yaml_config_file_path) as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ Jinja2 == 3.1.6        # for templating
 rich == 14.0.0         # for rich text formatting
 dtschema == 2025.2     # for checking dts files and dt bindings
 yamllint == 1.37.1     # for checking dts files and dt bindings
+b4==0.12.3             # b4: patch/mailing list workhorse from kernel.org


### PR DESCRIPTION
- give the yaml lore link and prefix in `000.patching.config.yaml`
- if prefix not found in any file in main patch dir, will
  - grab full patch using `b4`
  - write it out with the prefix to main patch dir
  - force a rewrite
- if file with prefix found, it will skip
  - just delete the file to re-do
- prefixes should not ever change, and the full b4-provided slug
  will be appended; respect the "standard" of the patching dir
  by using the correct prefix