### PR TITLE
Fix netplan to use DHCP on all `lan*` and `wan*` interfaces as well

### DIFF
--- a/extensions/network/config-networkd/netplan/10-dhcp-all-interfaces.yaml
+++ b/extensions/network/config-networkd/netplan/10-dhcp-all-interfaces.yaml
@@ -14,3 +14,15 @@ network:
       dhcp4: yes
       dhcp6: yes
       ipv6-privacy: yes # Enabled by default on most current systems, but networkd currently doesn't enable IPv6 privacy by default, see https://man.archlinux.org/man/systemd.network.5
+    all-lan-interfaces: # include interfaces that are renamed to 'lanX' by udev, e.g. nanopi-r2s
+      match:
+        name: "lan[0-9]*"
+      dhcp4: yes
+      dhcp6: yes
+      ipv6-privacy: yes # Enabled by default on most current systems, but networkd currently doesn't enable IPv6 privacy by default, see https://man.archlinux.org/man/systemd.network.5
+    all-wan-interfaces: # include interfaces that are renamed to 'wanX' by udev, e.g. nanopi-r1
+      match:
+        name: "wan[0-9]*"
+      dhcp4: yes
+      dhcp6: yes
+      ipv6-privacy: yes # Enabled by default on most current systems, but networkd currently doesn't enable IPv6 privacy by default, see https://man.archlinux.org/man/systemd.network.5


### PR DESCRIPTION
- apply dhcp to all interfaces that are renamed to either 'lanX' or 'wanX' by udev.
- applies to a.o. nanopi-r1, nanopi-r2s.

# Description

When user switches to legacy network interface names on boards with two interfaces, of which one is renamed to either `wan0` or `lan0`, they will not be configured to use DHCP.

# Documentation summary for feature / change

- [x] short description (copy / paste of PR title)
   Enable DHCP on interfaces called `wan*` and `lan*`.
- [x] summary (description relevant for end users)
   Default network naming will enable DHCP on all network interfaces called `e*`. If legacy network naming is configured, only network interfaces called `eth*` will use DHCP, the ones that are renamed by udev to `lan*` or `wan*` will not be configured at all.
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

- [x] Default image with predictable network names:
  ```
  1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
      link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
      inet 127.0.0.1/8 scope host lo
         valid_lft forever preferred_lft forever
      inet6 ::1/128 scope host noprefixroute 
         valid_lft forever preferred_lft forever
  2: end0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
      link/ether c2:22:80:74:b0:d7 brd ff:ff:ff:ff:ff:ff
      inet 10.0.0.194/24 metric 100 brd 10.0.0.255 scope global dynamic end0
         valid_lft 172784sec preferred_lft 172784sec
      inet6 x scope global dynamic noprefixroute 
         valid_lft 86387sec preferred_lft 86387sec
      inet6 x scope global temporary dynamic 
         valid_lft 299sec preferred_lft 299sec
      inet6 x scope global dynamic mngtmpaddr noprefixroute 
         valid_lft 299sec preferred_lft 299sec
      inet6 x scope link 
         valid_lft forever preferred_lft forever
  3: enxc2228074b0f7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
      link/ether c2:22:80:74:b0:f7 brd ff:ff:ff:ff:ff:ff
      inet 192.168.4.6/24 metric 100 brd 192.168.4.255 scope global dynamic enxc2228074b0f7
         valid_lft 3584sec preferred_lft 3584sec
      inet6 x scope link 
         valid_lft forever preferred_lft forever
  ```
- [x] Default image with legacy network names before change:
  ```
  1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
      link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
      inet 127.0.0.1/8 scope host lo
         valid_lft forever preferred_lft forever
      inet6 ::1/128 scope host noprefixroute 
         valid_lft forever preferred_lft forever
  2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
      link/ether c2:22:80:74:b0:d7 brd ff:ff:ff:ff:ff:ff
      altname end0
      inet 10.0.0.194/24 metric 100 brd 10.0.0.255 scope global dynamic eth0
         valid_lft 172783sec preferred_lft 172783sec
      inet6 x scope global dynamic noprefixroute 
         valid_lft 86386sec preferred_lft 86386sec
      inet6 x scope global temporary dynamic 
         valid_lft 299sec preferred_lft 299sec
      inet6 x scope global dynamic mngtmpaddr noprefixroute 
         valid_lft 299sec preferred_lft 299sec
      inet6 x scope link 
         valid_lft forever preferred_lft forever
  3: lan0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
      link/ether c2:22:80:74:b0:f7 brd ff:ff:ff:ff:ff:ff
  ```
- [x] Default image with legacy network names AFTER change:
  ```
  1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
      link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
      inet 127.0.0.1/8 scope host lo
         valid_lft forever preferred_lft forever
      inet6 ::1/128 scope host noprefixroute 
         valid_lft forever preferred_lft forever
  2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
      link/ether c2:22:80:74:b0:d7 brd ff:ff:ff:ff:ff:ff
      altname end0
      inet 10.0.0.194/24 metric 100 brd 10.0.0.255 scope global dynamic eth0
         valid_lft 172788sec preferred_lft 172788sec
      inet6 x scope global dynamic noprefixroute 
         valid_lft 86391sec preferred_lft 86391sec
      inet6 x scope global temporary dynamic 
         valid_lft 300sec preferred_lft 300sec
      inet6 x scope global dynamic mngtmpaddr noprefixroute 
         valid_lft 300sec preferred_lft 300sec
      inet6 x scope link 
         valid_lft forever preferred_lft forever
  3: lan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
      link/ether c2:22:80:74:b0:f7 brd ff:ff:ff:ff:ff:ff
      inet 192.168.4.6/24 metric 100 brd 192.168.4.255 scope global dynamic lan0
         valid_lft 3589sec preferred_lft 3589sec
      inet6 fe80::c022:80ff:fe74:b0f7/64 scope link 
         valid_lft forever preferred_lft forever
  ```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
