### PR TITLE
rockchip64/rk3328: U-Boot v2022.04/07 add setexpr

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -230,7 +230,7 @@ function adaptative_prepare_host_dependencies() {
 
 	# Some versions of U-Boot do not require/import 'python3-setuptools' properly, so add them explicitly.
 	if [[ 'tag:v2022.04' == "${BOOTBRANCH:-}" || 'tag:v2022.07' == "${BOOTBRANCH:-}" ]]; then
-		display_alert "Adding 'python3-setuptools' to host_dependencies"
+		display_alert "Adding package to 'host_dependencies'" "python3-setuptools" "info"
 		host_dependencies+=("python3-setuptools")
 	fi
 

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -203,7 +203,7 @@ function adaptative_prepare_host_dependencies() {
 		udev # causes initramfs rebuild, but is usually pre-installed.
 		uuid-dev
 		zlib1g-dev
-		gcc-arm-linux-gnueabi # necessary for rockchip64 (and maybe other too) ATF compilation  
+		gcc-arm-linux-gnueabi # necessary for rockchip64 (and maybe other too) ATF compilation
 
 		# by-category below
 		file tree expect                         # logging utilities; expect is needed for 'unbuffer' command
@@ -227,6 +227,12 @@ function adaptative_prepare_host_dependencies() {
 
 	# Needed for some u-boot's, lest "tools/mkeficapsule.c:21:10: fatal error: gnutls/gnutls.h"
 	host_dependencies+=("libgnutls28-dev")
+
+	# Some versions of U-Boot do not require/import 'python3-setuptools' properly, so add them explicitly.
+	if [[ 'tag:v2022.04' == "${BOOTBRANCH:-}" || 'tag:v2022.07' == "${BOOTBRANCH:-}" ]]; then
+		display_alert "Adding 'python3-setuptools' to host_dependencies"
+		host_dependencies+=("python3-setuptools")
+	fi
 
 	### Python2 -- required for some older u-boot builds
 	# Debian newer than 'bookworm' and Ubuntu newer than 'lunar'/'mantic' does not carry python2 anymore; in this case some u-boot's might fail to build.

--- a/patch/u-boot/u-boot-rockchip64-v2022.04/nanopi-r2s-rk3328_defconfig-0001-enable-setexpr-fmt-regex.patch
+++ b/patch/u-boot/u-boot-rockchip64-v2022.04/nanopi-r2s-rk3328_defconfig-0001-enable-setexpr-fmt-regex.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Urlings <tom.urlings(at)gmail(dot)com>
+Date: Tue May 27 12:45:35 PDT 2025
+Subject: Enable monitor command setexpr w/fmt and sub/gsub/regex options
+
+This will enable bootscripts to calculate load address dynamically during boot,
+removing the need for updating load addresses whenever kernel/initial ramdisk 
+change size.
+
+Also, this will enable bootscripts to find device tree files in folder structures
+that contain a vendor path component, e.g. dtb/allwinnner/...
+---
+ configs/nanopi-r2s-rk3328_defconfig | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/configs/nanopi-r2s-rk3328_defconfig b/configs/nanopi-r2s-rk3328_defconfig
+index cafb38ffcee..7941af4ff2e 100644
+--- a/configs/nanopi-r2s-rk3328_defconfig
++++ b/configs/nanopi-r2s-rk3328_defconfig
+@@ -34,11 +34,12 @@ CONFIG_SPL_ATF=y
+ CONFIG_SPL_ATF_NO_PLATFORM_PARAM=y
+ CONFIG_CMD_BOOTZ=y
+ CONFIG_CMD_GPT=y
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
+-# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_SETEXPR=y
++CONFIG_CMD_SETEXPR_FMT=y
+ CONFIG_CMD_TIME=y
+ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_TPL_OF_CONTROL=y
+ CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
+ CONFIG_TPL_OF_PLATDATA=y
+@@ -94,8 +95,9 @@ CONFIG_USB_OHCI_GENERIC=y
+ CONFIG_USB_DWC2=y
+ CONFIG_USB_DWC3=y
+ # CONFIG_USB_DWC3_GADGET is not set
+ CONFIG_USB_GADGET=y
+ CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_REGEX=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_TPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/u-boot/u-boot-rockchip64/nanopi-r2s-rk3328_defconfig-0001-enable-setexpr-fmt-regex.patch
+++ b/patch/u-boot/u-boot-rockchip64/nanopi-r2s-rk3328_defconfig-0001-enable-setexpr-fmt-regex.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Urlings <tom.urlings(at)gmail(dot)com>
+Date: Tue May 27 12:45:35 PDT 2025
+Subject: Enable monitor command setexpr w/fmt and sub/gsub/regex options
+
+This will enable bootscripts to calculate load address dynamically during boot,
+removing the need for updating load addresses whenever kernel/initial ramdisk 
+change size.
+
+Also, this will enable bootscripts to find device tree files in folder structures
+that contain a vendor path component, e.g. dtb/allwinnner/...
+---
+ configs/nanopi-r2s-rk3328_defconfig | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/configs/nanopi-r2s-rk3328_defconfig b/configs/nanopi-r2s-rk3328_defconfig
+index ed6b8030216..be1906e8deb 100644
+--- a/configs/nanopi-r2s-rk3328_defconfig
++++ b/configs/nanopi-r2s-rk3328_defconfig
+@@ -35,11 +35,12 @@ CONFIG_SPL_ATF=y
+ CONFIG_SPL_ATF_NO_PLATFORM_PARAM=y
+ CONFIG_CMD_BOOTZ=y
+ CONFIG_CMD_GPT=y
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
+-# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_SETEXPR=y
++CONFIG_CMD_SETEXPR_FMT=y
+ CONFIG_CMD_TIME=y
+ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_TPL_OF_CONTROL=y
+ CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
+ CONFIG_TPL_OF_PLATDATA=y
+@@ -96,8 +97,9 @@ CONFIG_USB_OHCI_GENERIC=y
+ CONFIG_USB_DWC2=y
+ CONFIG_USB_DWC3=y
+ # CONFIG_USB_DWC3_GADGET is not set
+ CONFIG_USB_GADGET=y
+ CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_REGEX=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_TPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
- aimed at nanopi-r2s and nanopineo3
- impacts:
  - boards (re)using 'nanopi-r2s-rk3328_defconfig' (rk3328) and:
  - boards using U-Boot v2022.04 or
  - boards using U-Boot v2022.07
- added explicit dependency on python3-setuptools as (at least) U-Boot v2022.04 and v2022.07 fail building due to missing 'distutils' for boards that use U-Boot v2022.04 or v2022.07

# Description

Preparation for updating the U-Boot boot.cmd bootscripts for Nanopi R2s and Nanopi Neo3.
Enable the setexpr commands, including the fmt, sub and gsub options.

Host prep script needed adjustment to allow for U-Boot to build. The package `python3-distutils` was not available anymore. This module was apparantly offered by `python3-setuptools`, but that package was not installed. Host prep will now add `python3-setuptools` explicitly for U-Boot tags v2022.04 and v2022.07.

# Documentation summary for feature / change

# How Has This Been Tested?

- [x] Build nanopi-r2s: **OK**
- [x] Build nanopineo3: **OK**

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
