### PR TITLE
mvebu: bootscript load address calculation a.o.

### DIFF
--- a/config/bootscripts/boot-mvebu.cmd
+++ b/config/bootscripts/boot-mvebu.cmd
@@ -58,7 +58,7 @@ setenv func_critical_error '
 	sleep 10 ;
 	if test "${exit_on_critical_errors}" = "on" ; then
 		false ;
-	else ;
+	else
 		true ;
 	fi'
 

--- a/config/bootscripts/boot-mvebu.cmd
+++ b/config/bootscripts/boot-mvebu.cmd
@@ -55,7 +55,6 @@ setenv func_inform 'test "${verbosity}" = "" || itest ${verbosity} -gt 0 && echo
 setenv func_warn 'echo "** WARNING: ${l_message}"'
 setenv func_critical_error '
 	echo "!! CRITICAL: ${l_message}" ;
-	sleep 10 ;
 	if test "${exit_on_critical_errors}" = "on" ; then
 		false ;
 	else

--- a/config/bootscripts/boot-mvebu.cmd
+++ b/config/bootscripts/boot-mvebu.cmd
@@ -3,187 +3,540 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
+# NOTE
+# If you intend to use 'outside' of 'global' variables from U-Boot, make sure that you do not change them!
+# The boot logic will attempt a list of 'boot_targets' that all might rely on (environment) variables that
+# have been set by U-Boot, either compile-time or as part of U-Boot's default 'bootcmd'.
+# Any variable that this bootscript uses needs to be set explicitly and not conflict with any pre-set variables.
+# Variables that we might change will be saved in preset_x and variables we use will be copied into l_x.
+
+# default environment variables
+setenv align_overlap_oboe_avoidance "on"
+setenv align_to "0x00001000"
+setenv console "both"
+setenv docker_optimizations "on"
+setenv earlycon "off"
+setenv emmc_fix "off"
+setenv eth1addr "00:50:43:25:fb:84"
+setenv eth2addr "00:50:43:84:25:2f"
+setenv eth3addr "00:50:43:0d:19:18"
+setenv ethaddr "00:50:43:84:fb:2f"
+setenv exit_on_critical_errors "on"
+setenv fdt_extrasize "0x00010000"
+setenv kver
+setenv load_addr_calc
+setenv overlay_error "false"
+setenv preset_fdtdir "${fdtdir}"
+setenv preset_fdtfile "${fdtfile}"
+setenv preset_kernel_comp_addr_r "${kernel_comp_addr_r}"
+setenv preset_kernel_comp_size "${kernel_comp_size}"
+setenv rootdev "/dev/mmcblk${devnum}p${distro_bootpart}"
+setenv rootfstype "ext4"
+setenv spi_workaround "off"
+setenv vendor "marvell"
+setenv verbosity "1"
+
+# load addresses
 setenv load_addr "0x00300000"
 setenv fdt_addr_r "0x02040000" # max size 256 KiB (=dtb+dto+fdt_extrasize)
 setenv kernel_addr_r "0x02080000" # max size 16 MiB
 setenv ramdisk_addr_r "0x03080000"
 
-# default values
-setenv overlay_error "false"
-setenv rootdev "/dev/mmcblk0p1"
-setenv rootfstype "ext4"
-setenv verbosity "1"
-setenv emmc_fix "off"
-setenv spi_workaround "off"
-setenv ethaddr "00:50:43:84:fb:2f"
-setenv eth1addr "00:50:43:25:fb:84"
-setenv eth2addr "00:50:43:84:25:2f"
-setenv eth3addr "00:50:43:0d:19:18"
-setenv exit_on_critical_errors "on"
-setenv fdt_extrasize "0x00010000"
-setenv align_to "0x00001000"
-setenv align_overlap_oboe_avoidance "on"
-setenv align_addr_next 'if test "${align_overlap_oboe_avoidance}" = "on" ; then setexpr addr_next ${addr_next} + 1 ; fi ; setexpr modulo ${addr_next} % ${align_to} ; if itest ${modulo} -gt 0 ; then setexpr addr_next ${addr_next} / ${align_to} ; setexpr addr_next ${addr_next} + 1 ; setexpr addr_next ${addr_next} * ${align_to} ; fi'
-
-if setexpr setexpr 1 + 1 ; then
-	setenv setexpr "available"
-else
-	echo "** Command `setexpr` not available - using configured load addresses"
-fi
-
-echo "Boot script loaded from ${devtype}"
-
-setenv something "environment ${prefix}armbianEnv.txt from ${devtype} to ${load_addr}"
-echo "Loading ${something} ..."
-if load ${devtype} ${devnum} ${load_addr} ${prefix}armbianEnv.txt; then
-	env import -t ${load_addr} ${filesize}
-else
-	echo "** Could not load ${something} - using default environment"
-fi
-
-setenv bootargs "console=ttyS0,115200 root=${rootdev} rootwait rootfstype=${rootfstype} ubootdev=${devtype} scandelay loglevel=${verbosity} usb-storage.quirks=${usbstoragequirks} ${extraargs}"
-
-setenv something "DT ${prefix}dtb/${fdtfile} from ${devtype} to ${fdt_addr_r}"
-echo "Loading ${something} ..."
-if load ${devtype} ${devnum} ${fdt_addr_r} ${prefix}dtb/${fdtfile} ; then
-else
-	echo "!! CRITICAL - Could not load ${something}"
+# environment run variables
+setenv func_align_addr_next '
+	test "${align_overlap_oboe_avoidance}" = "on" && setexpr l_addr_next ${l_addr_next} + 1 ;
+	setexpr modulo ${l_addr_next} % ${align_to} ;
+	if itest ${modulo} -gt 0 ; then
+		setexpr l_addr_next ${l_addr_next} / ${align_to} ;
+		setexpr l_addr_next ${l_addr_next} + 1 ;
+		setexpr l_addr_next ${l_addr_next} * ${align_to} ;
+	fi'
+setenv func_inform 'test "${verbosity}" = "" || itest ${verbosity} -gt 0 && echo "${l_message}"'
+setenv func_warn 'echo "** WARNING: ${l_message}"'
+setenv func_critical_error '
+	echo "!! CRITICAL: ${l_message}" ;
+	sleep 10 ;
 	if test "${exit_on_critical_errors}" = "on" ; then
-		exit
+		false ;
+	else ;
+		true ;
+	fi'
+
+# set some defaults in case there are no pre-sets
+if test "${envfile}" = "" ; then
+	setenv l_envfile 'armbianEnv.txt'
+else
+	setenv l_envfile "${envfile}"
+fi
+
+echo "Boot script loaded from ${devtype} ${devnum}:${distro_bootpart}."
+
+# load (merge) on-disk environment
+setenv l_file "${prefix}${l_envfile}"
+if test -e ${devtype} ${devnum}:${distro_bootpart} ${l_file} ; then
+	if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${l_file} ; then
+		if env import -t ${load_addr} ${filesize} ; then
+			setenv l_message "Loaded/imported environment ${l_file} to/from ${load_addr}."
+			run func_inform
+		else
+			setenv l_message "Could not import environment ${l_file} - using default environment!"
+			run func_warn
+		fi
+	else
+		setenv l_message "Could not load environment ${l_file} - using default environment!"
+		run func_warn
 	fi
 fi
 
-setenv fdt_filesize ${filesize}
-fdt addr ${fdt_addr_r}
-fdt resize ${fdt_extrasize}
+# compose kernel commandline options (bootargs)
+setenv consoleargs
+if test "${console}" = "display" || test "${console}" = "both" ; then
+	setenv consoleargs "console=tty1"
+fi
+if test "${console}" = "serial" || test "${console}" = "both" ; then
+	setenv consoleargs "console=ttyS0,115200 ${consoleargs}"
+fi
+if test "${earlycon}" = "on" ; then
+	setenv consoleargs "earlycon ${consoleargs}"
+fi
+if test "${bootlogo}" = "true" ; then
+	setenv consoleargs "splash plymouth.ignore-serial-consoles ${consoleargs}"
+else
+	setenv consoleargs "splash=verbose ${consoleargs}"
+fi
 
-for overlay_file in ${overlays}; do
-	setenv something "kernel provided DT overlay ${overlay_prefix}-${overlay_file}.dtbo from ${devtype} to ${load_addr}"
-	echo "Loading ${something} ..."
-	if load ${devtype} ${devnum} ${load_addr} ${prefix}dtb/overlay/${overlay_prefix}-${overlay_file}.dtbo; then
-		fdt apply ${load_addr} || setenv overlay_error "true"
-	else
-		echo "** Could not load ${something}"
+part uuid ${devtype} ${devnum}:${distro_bootpart} l_ubootpart
+
+setenv bootargs "root=${rootdev} rootfstype=${rootfstype} rootwait ${consoleargs} consoleblank=0 loglevel=${verbosity} ubootpart=${l_ubootpart} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
+
+if test "${docker_optimizations}" = "on" ; then
+	setenv bootargs "${bootargs} cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory"
+fi
+
+if test "${vendor}" = "allwinner" ; then
+	if test "${disp_mem_reserves}" = "off" ; then
+		setenv bootargs "${bootargs} sunxi_ve_mem_reserve=0 sunxi_g2d_mem_reserve=0 sunxi_fb_mem_reserve=16"
 	fi
-done
+fi
+if test "${vendor}" = "marvell" ; then
+	# nothing here yet
+fi
+if test "${vendor}" = "rockchip" ; then
+	# nothing here yet
+fi
 
-for overlay_file in ${user_overlays}; do
-	setenv something "user provided DT overlay ${overlay_file}.dtbo from ${devtype} to ${load_addr}"
-	echo "Loading ${something}"
-	if load ${devtype} ${devnum} ${load_addr} ${prefix}overlay-user/${overlay_file}.dtbo; then
-		fdt apply ${load_addr} || setenv overlay_error "true"
+# check if we are requested (or are able to) use load address calculation
+if test "${load_addr_calc}" = "" ; then
+	if setexpr load_addr_calc 1 + 1 ; then
+		setenv load_addr_calc 'on'
 	else
-		echo "** Could not load ${something}"
+		setenv load_addr_calc 'off'
 	fi
-done
+fi
+if test "${load_addr_calc}" != "on" ; then
+	setenv load_addr_calc 'off'
 
-if test "${overlay_error}" = "true"; then
-	echo "** Error applying DT overlays"
-	setenv something "original DT ${prefix}dtb/${fdtfile} from ${devtype} to ${fdt_addr_r}"
-	echo "Restoring ${something} ..."
-	if load ${devtype} ${devnum} ${fdt_addr_r} ${prefix}dtb/${fdtfile} ; then
+	setenv l_message "Using fixed load addresses."
+	run func_inform
+	setenv l_message "  fdt_addr_r:     ${fdt_addr_r}"
+	run func_inform
+	setenv l_message "  kernel_addr_r:  ${kernel_addr_r}"
+	run func_inform
+	setenv l_message "  ramdisk_addr_r: ${ramdisk_addr_r}"
+	run func_inform
+fi
+
+if test "${kver}" != "" ; then
+	setenv l_message "Using version override ${kver} for image loading."
+	run func_inform
+fi
+
+# set a default kernel image type in case 'setexpr' not available
+if test "${cpu}" = "armv8" ; then
+	# aarch64 uses a flat kernel image
+	setenv l_kernel_image_type "flat"
+	setenv l_bootfile "Image${kver}"
+else
+	if test "${cpu}" = "armv7" ; then
+		# aarch32 mostly uses compressed kernel image
+		setenv l_kernel_image_type "compressed"
+		setenv l_bootfile "zImage${kver}"
+	else
+		# per default use compressed kernel image
+		setenv l_kernel_image_type "compressed"
+		setenv l_bootfile "zImage${kver}"
+	fi
+fi
+
+setenv l_ramdiskfile "uInitrd${kver}"
+
+# $fdtdir:
+#   some boards use "${prefix}dtb/" others use "${prefix}dtb/${vendor}/" as base location for the DT files
+#   user can also override by specifying an fdtdir=... in armbianEnv.txt
+#   try any U-Boot built-in (or pre-set) fdtdir as last resort
+# $fdtfile:
+#   some boards use a "filename.dts" others use "${vendor}/filename.dts"
+#   user can also override by specifying an fdtfile=... in armbianEnv.txt
+#   strip any leading path components and try any U-Boot built-in (or pre-set) fdtfile as last resort
+
+setenv l_fdtfile_basename
+setexpr l_fdtfile_basename sub ".*/" "" "${fdtfile}"
+if test "${l_fdtfile_basename}" = "" ; then
+	setenv l_fdtfile_basename "${fdtfile}"
+fi
+
+setenv l_fdtdir "${fdtdir}"
+setenv l_fdtfile "${l_fdtfile_basename}"
+if test -e ${devtype} ${devnum}:${distro_bootpart} "${l_fdtdir}/${l_fdtfile}" ; then
+	true
+else
+	setenv l_fdtdir "${prefix}dtb${kver}/${vendor}"
+	setenv l_fdtfile "${l_fdtfile_basename}"
+	if test -e ${devtype} ${devnum}:${distro_bootpart} "${l_fdtdir}/${l_fdtfile}" ; then
+		true
+	else
+		setenv l_fdtdir "${prefix}dtb${kver}"
+		setenv l_fdtfile "${l_fdtfile_basename}"
+		if test -e ${devtype} ${devnum}:${distro_bootpart} "${l_fdtdir}/${l_fdtfile}" ; then
+			true
+		else
+			setenv l_fdtdir "${fdtdir}"
+			setenv l_fdtfile "${fdtfile}"
+			if test -e ${devtype} ${devnum}:${distro_bootpart} "${l_fdtdir}/${l_fdtfile}" ; then
+				true
+			else
+				setenv l_fdtdir "${preset_fdtdir}"
+				setenv l_fdtfile "${preset_fdtfile}"
+				if test -e ${devtype} ${devnum}:${distro_bootpart} "${l_fdtdir}/${l_fdtfile}" ; then
+					true
+				else
+					false
+				fi
+			fi
+		fi
+	fi
+fi
+if itest $? -ne 0 ; then
+	setenv l_message "Cannot find DT!"
+	run func_critical_error || exit
+fi
+
+# load the device tree blob
+setenv l_file "${l_fdtdir}/${l_fdtfile}"
+if load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${l_file} ; then
+	setenv l_message "Loaded DT ${l_file} to ${fdt_addr_r}."
+	run func_inform
+
+	setenv l_fdt_filesize ${filesize}
+	fdt addr ${fdt_addr_r}
+	fdt resize ${fdt_extrasize}
+else
+	setenv l_message "Could not load DT ${l_file}!"
+	run func_critical_error || exit
+fi
+
+# process "overlays=..." from $l_envfile
+if test "${overlays}" != "" ; then
+	setenv l_message "Loading kernel provided DT overlay(s) from ${l_fdtdir}/overlay to ${load_addr} .."
+	run func_inform
+
+	# as some families offer overlays with different (or no) prefixes, try to guess the most commonly seen ones
+	# just changing overlay_prefix= will not work for all available overlays, as some have prefixes and some do not
+
+	setenv each_overlay
+	for each_overlay in ${overlays} ; do
+		setenv l_overlay_prefix "${overlay_prefix}"
+		setenv l_file "${l_fdtdir}/overlay/${l_overlay_prefix}-${each_overlay}.dtbo"
+		if test -e ${devtype} ${devnum}:${distro_bootpart} ${l_file} ; then
+			true
+		else
+			setenv l_overlay_prefix "${vendor}"
+			setenv l_file "${l_fdtdir}/overlay/${l_overlay_prefix}-${each_overlay}.dtbo"
+			if test -e ${devtype} ${devnum}:${distro_bootpart} ${l_file} ; then
+				setenv l_message "Found DT overlay ${l_overlay_prefix}-${each_overlay} instead of ${overlay_prefix}-${each_overlay} in ${l_fdtdir}/overlay!"
+				run func_warn
+				setenv l_message "Consider setting overlay_prefix=${l_overlay_prefix} in your ${l_envfile}."
+				run func_inform
+				true
+			else
+				setenv l_overlay_prefix "${vendor}-${soc}"
+				setenv l_file "${l_fdtdir}/overlay/${l_overlay_prefix}-${each_overlay}.dtbo"
+				if test -e ${devtype} ${devnum}:${distro_bootpart} ${l_file} ; then
+					setenv l_message "Found DT overlay ${l_overlay_prefix}-${each_overlay} instead of ${overlay_prefix}-${each_overlay} in ${l_fdtdir}/overlay!"
+					run func_warn
+					setenv l_message "Consider setting overlay_prefix=${l_overlay_prefix} in your ${l_envfile}."
+					run func_inform
+					true
+				else
+					false
+				fi
+			fi
+		fi
+		if itest $? -eq 0 ; then
+			if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${l_file} ; then
+				if fdt apply ${load_addr} ; then
+					setenv l_message "Applied DT overlay ${each_overlay} (${l_file})."
+					run func_inform
+				else
+					setenv overlay_error "true"
+					setenv l_message "Could NOT apply DT overlay ${each_overlay} (${l_file})!"
+					run func_warn
+				fi
+			else
+				setenv l_message "Could NOT load DT overlay ${each_overlay} (${l_file})!"
+				run func_warn
+			fi
+		else
+			setenv l_message "Could NOT find DT overlay ${each_overlay}!"
+			run func_warn
+		fi
+	done
+fi
+
+# process "user_overlays=..." from $l_envfile
+if test "${user_overlays}" != "" ; then
+	setenv l_message "Loading user provided DT overlay(s) from ${prefix}overlay-user to ${load_addr} .."
+	run func_inform
+
+	setenv each_user_overlay
+	for each_user_overlay in ${user_overlays} ; do
+		setenv l_file "${prefix}overlay-user/${each_user_overlay}.dtbo"
+		if test -e ${devtype} ${devnum}:${distro_bootpart} ${l_file} ; then
+			if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${l_file} ; then
+				if fdt apply ${load_addr} ; then
+					setenv l_message "Applied user DT overlay ${each_user_overlay} (${l_file})."
+					run func_inform
+				else
+					setenv overlay_error "true"
+					setenv l_message "Could NOT apply user DT overlay ${each_user_overlay} (${l_file})!"
+					run func_warn
+				fi
+			else
+				setenv l_message "Could NOT load user DT overlay ${each_user_overlay} (${l_file})!"
+				run func_warn
+			fi
+		else
+			setenv l_message "Could NOT find user DT overlay ${each_user_overlay} (${l_file})!"
+			run func_warn
+		fi
+	done
+fi
+if test "${overlay_error}" = "true" ; then
+	setenv l_message "Could not apply DT overlays!"
+	run func_warn
+
+	setenv l_file "${l_fdtdir}/${l_fdtfile}"
+	if load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${l_file} ; then
+		setenv l_message "Loaded original DT ${l_file} to ${fdt_addr_r}."
+		run func_inform
+
+		setenv l_fdt_filesize ${filesize}
 		fdt addr ${fdt_addr_r}
 		fdt resize ${fdt_extrasize}
 	else
-		echo "!! CRITICAL - Could not restore ${something}"
-		if test "${exit_on_critical_errors}" = "on" ; then
-			exit
-		fi
+		setenv l_message "Could not load original DT ${l_file}!"
+		run func_critical_error || exit
 	fi
 else
-	if test -e ${devtype} ${devnum} ${prefix}dtb/overlay/${overlay_prefix}-fixup.scr; then
-		setenv something "kernel provided DT fixup script (${overlay_prefix}-fixup.scr) from ${devtype} to ${load_addr}"
-		echo "Loading ${something} ..."
-		if load ${devtype} ${devnum} ${load_addr} ${prefix}dtb/overlay/${overlay_prefix}-fixup.scr ; then
-			source ${load_addr}
-		else
-			echo "** Could not load ${something}"
+	# process any available DT fixup scripts
+	setenv l_fixup_scripts "${prefix}fixup.scr"
+	if test "${overlay_prefix}" != "" ; then
+		setenv l_fixup_scripts "${l_fdtdir}/overlay/${overlay_prefix}-fixup.scr ${l_fixup_scripts}"
+	fi
+	if test "${vendor}" != "" ; then
+		if test "${vendor}" != "${overlay_prefix}" ; then
+			setenv l_fixup_scripts "${l_fdtdir}/overlay/${vendor}-fixup.scr ${l_fixup_scripts}"
 		fi
 	fi
-	if test -e ${devtype} ${devnum} ${prefix}fixup.scr; then
-		setenv something "user provided fixup script (fixup.scr) from ${devtype} to ${load_addr}"
-		echo "Loading ${something} ..."
-		if load ${devtype} ${devnum} ${load_addr} ${prefix}fixup.scr ; then
-			source ${load_addr}
-		else
-			echo "** Could not load ${something}"
+
+	setenv each_fixup_script
+	for each_fixup_script in ${l_fixup_scripts} ; do
+		if test -e ${devtype} ${devnum}:${distro_bootpart} ${each_fixup_script} ; then
+			if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${each_fixup_script} ; then
+				if source ${load_addr} ; then
+					setenv l_message "Loaded/sourced fixup script ${each_fixup_script} to/at ${load_addr}."
+					run func_inform
+				else
+					setenv l_message "Fixup script ${each_fixup_script} returned an error!"
+					run func_warn
+				fi
+			else
+				setenv l_message "Could not load fixup script ${each_fixup_script}!"
+				run func_warn
+			fi
 		fi
-	fi
+	done
 fi
 
 # eMMC fix
 if test "${emmc_fix}" = "on"; then
-	echo "Applying eMMC compatibility fix to the DT"
+	echo "Applying eMMC compatibility fix to the DT."
 	fdt rm /soc/internal-regs/sdhci@d8000/ cd-gpios
 	fdt set /soc/internal-regs/sdhci@d8000/ non-removable
 fi
 
 # SPI - SATA workaround
 if test "${spi_workaround}" = "on"; then
-	echo "Applying SPI workaround to the DT"
+	echo "Applying SPI workaround to the DT."
 	fdt set /soc/internal-regs/sata@e0000 status "disabled"
 	fdt set /soc/internal-regs/sata@a8000 status "disabled"
 	fdt set /soc/spi@10680 status "okay"
 	fdt set /soc/spi@10680/spi-flash@0 status "okay"
 fi
 
-echo "Trimming DT ..."
+# resize (trim) device tree after all overlays have been applied and fixup scripts have been run
 fdt resize
 
-if test "${setexpr}" = "available" ; then
-	fdt header get fdt_totalsize totalsize
-	if test "${fdt_totalsize}" = "" ; then
-		echo "** Command `fdt header` does not support `get <var> <member>` - calculating DT size"
+# determine the load address for the kernel image
+if test "${load_addr_calc}" = "on" ; then
+	# get the total size of the DT
+	setenv l_fdt_totalsize
+	fdt header get l_fdt_totalsize totalsize
+
+	if test "${l_fdt_totalsize}" = "" ; then
+		# could not get the total size of the DT so calculate it instead
+		setenv l_message "Calculating DT size."
+		run func_inform
 
 		# 'fdt resize' will align upwards to 4k address boundary
-		setexpr fdt_totalsize ${fdt_filesize} / 0x1000
-		setexpr fdt_totalsize ${fdt_totalsize} + 1
-		setexpr fdt_totalsize ${fdt_totalsize} * 0x1000
+		setexpr l_fdt_totalsize ${l_fdt_filesize} / 0x1000
+		setexpr l_fdt_totalsize ${l_fdt_totalsize} + 1
+		setexpr l_fdt_totalsize ${l_fdt_totalsize} * 0x1000
 		if test "${fdt_extrasize}" != "" ; then
-			# add 'extrasize' before aligning
-			setexpr fdt_totalsize ${fdt_totalsize} + ${fdt_extrasize}
+			setexpr l_fdt_totalsize ${l_fdt_totalsize} + ${fdt_extrasize}
 		fi
 	fi
-	setexpr addr_next ${fdt_addr_r} + ${fdt_totalsize}
-	run align_addr_next
-	setenv kernel_addr_r ${addr_next}
+
+	setexpr l_addr_next ${fdt_addr_r} + ${l_fdt_totalsize}
+	run func_align_addr_next
+
+	setenv l_kernel_addr_r ${l_addr_next}
+else
+	setenv l_kernel_addr_r ${kernel_addr_r}
 fi
 
-setenv something "kernel ${prefix}zImage from ${devtype} to ${kernel_addr_r}"
-echo "Loading ${something} ..."
-if load ${devtype} ${devnum} ${kernel_addr_r} ${prefix}zImage ; then
+setenv l_file "${prefix}${l_bootfile}"
+if load ${devtype} ${devnum}:${distro_bootpart} ${l_kernel_addr_r} ${l_file} ; then
+	if test "${load_addr_calc}" = "on" ; then
+		setenv kernel_comp_size ${filesize}
+	fi
+
+	setenv l_message "Loaded ${l_kernel_image_type} kernel image ${l_file} to ${l_kernel_addr_r}."
+	run func_inform
 else
-	echo "!! CRITICAL - Could not load ${something}"
-	if test "${exit_on_critical_errors}" = "on" ; then
-		exit
+	if test "${load_addr_calc}" = "on" ; then
+		setenv kernel_comp_addr_r "${preset_kernel_comp_addr_r}"
+		setenv kernel_comp_size "${preset_kernel_comp_size}"
+	fi
+	setenv l_message "Could not load ${l_kernel_image_type} kernel image ${l_file}!"
+	run func_critical_error || exit
+fi
+
+# determine the load address for the initial ramdisk
+if test "${load_addr_calc}" = "on" ; then
+	# vmlinux image + 0x38 contain magic (le-double) 'ARMd'
+	setexpr l_ptr ${l_kernel_addr_r} + 0x00000038
+	setexpr.w l_magic_lsw *${l_ptr}
+
+	setexpr l_ptr ${l_kernel_addr_r} + 0x0000003a
+	setexpr.w l_magic_msw *${l_ptr}
+
+	if test "${l_magic_msw}${l_magic_lsw}" != "" && itest "${l_magic_msw}${l_magic_lsw}" -eq 0x644d5241 ; then
+		setenv l_kernel_image_type "flat"
+	else
+		setenv l_kernel_image_type "compressed"
+	fi
+
+	if test "${l_kernel_image_type}" = "flat" ; then
+		# vmlinux image + 0x10 contains image_size
+		setexpr l_ptr ${l_kernel_addr_r} + 0x00000010
+		setexpr.l l_image_size *${l_ptr}
+
+		setenv l_message "Using ${l_kernel_image_type} kernel image image_size 0x${l_image_size} bytes to calculate initial ramdisk load address."
+		run func_inform
+
+		# vmlinux image + 0x08 contains text_offset
+		setexpr l_ptr ${l_kernel_addr_r} + 0x00000008
+		setexpr.l l_text_offset *${l_ptr}
+
+		setenv l_message "Using ${l_kernel_image_type} kernel image text_offset 0x${l_text_offset} bytes to offset initial ramdisk load address."
+		run func_inform
+
+		setexpr l_addr_next ${l_kernel_addr_r} + ${l_image_size}
+		run func_align_addr_next
+
+		# take into account that U-Boot's booti_setup() might relocate the kernel image
+		setexpr l_addr_next ${l_addr_next} + ${l_text_offset}
+	else
+		setexpr l_addr_next ${l_kernel_addr_r} + ${filesize}
+		run func_align_addr_next
+
+		setenv l_message "Using ${l_kernel_image_type} kernel image filesize 0x${filesize} bytes to calculate initial ramdisk load address."
+		run func_inform
+	fi
+
+	setenv l_ramdisk_addr_r ${l_addr_next}
+else
+	setenv l_ramdisk_addr_r ${ramdisk_addr_r}
+fi
+
+setenv l_file "${prefix}${l_ramdiskfile}"
+if load ${devtype} ${devnum}:${distro_bootpart} ${l_ramdisk_addr_r} ${l_file} ; then
+	if test "${load_addr_calc}" = "on" ; then
+		setexpr l_addr_next ${l_ramdisk_addr_r} + ${filesize}
+		run func_align_addr_next
+
+		setenv kernel_comp_addr_r ${l_addr_next}
+	fi
+
+	setenv l_message "Loaded initial ramdisk ${l_file} to ${l_ramdisk_addr_r}."
+	run func_inform
+else
+	if test "${load_addr_calc}" = "on" ; then
+		setenv kernel_comp_addr_r "${preset_kernel_comp_addr_r}"
+		setenv kernel_comp_size "${preset_kernel_comp_size}"
+	fi
+	setenv l_message "Could not load initial ramdisk ${l_file}!"
+	run func_critical_error || exit
+fi
+
+# attempt to prepare for kernel address space randomization
+if kaslrseed ; then
+else
+	setenv l_message "Not able to prepare for KASLR."
+	run func_inform
+fi
+
+setenv l_message "Kernel commandline arguments:"
+run func_inform
+
+setenv each_bootarg
+for each_bootarg in ${bootargs} ; do
+	setenv l_message "  ${each_bootarg}"
+	run func_inform
+done
+
+if test "${l_kernel_image_type}" = "flat" ; then
+	booti ${l_kernel_addr_r} ${l_ramdisk_addr_r} ${fdt_addr_r}
+else
+	if test "${l_kernel_image_type}" = "compressed" ; then
+		bootz ${l_kernel_addr_r} ${l_ramdisk_addr_r} ${fdt_addr_r}
+	else
+		# default booting command
+		bootz ${l_kernel_addr_r} ${l_ramdisk_addr_r} ${fdt_addr_r}
 	fi
 fi
 
-if test "${setexpr}" = "available" ; then
-	setexpr addr_next ${kernel_addr_r} + ${filesize}
-	run align_addr_next
-	setenv ramdisk_addr_r ${addr_next}
+# booting failed, restore environment variables that are not unique
+# to this bootmeth
+if test "${load_addr_calc}" = "on" ; then
+	# restore original presets
+	setenv kernel_comp_addr_r "${preset_kernel_comp_addr_r}"
+	setenv kernel_comp_size "${preset_kernel_comp_size}"
 fi
 
-setenv something "initial ramdisk ${prefix}uInitrd from ${devtype} to ${ramdisk_addr_r}"
-echo "Loading ${something} ..."
-if load ${devtype} ${devnum} ${ramdisk_addr_r} ${prefix}uInitrd ; then
-else
-	echo "!! CRITICAL - Could not load ${something}"
-	if test "${exit_on_critical_errors}" = "on" ; then
-		exit
-	fi
-fi
-
-setenv something "kernel from ${kernel_addr_r}"
-echo "Booting ${something} ..."
-if bootz ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr_r} ; then
-else
-	echo "!! CRITICAL - Could not boot ${something}"
-	if test "${exit_on_critical_errors}" = "on" ; then
-		exit
-	fi
-fi
+setenv l_message "Could not boot kernel!"
+run func_critical_error || exit
 
 # Recompile with:
 # mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr


### PR DESCRIPTION
# Description

Attempt to work towards one U-Boot bootscript for (at least) mvebu, sunxi and rockchip64.
This adds:
- (Aligned) load address calculations
    This will remove the need to update any `kernel_load_addr_r` or `ramdisk_addr_r` in case kernel image increases.
    Calculation is based on either
    - Flat kernel image `image_size` + `text_offset` as specified in the vmlinux(/Image) header info
    - Compressed kernel image filesize (vmlinuz/zImage)
- Clear warnings to user in case files are not found, not able to load or application failed.
- Merge of armbianEnv.txt kernel options was attempted for sunxi, mvebu and rockchip64.
- DT folder determination based on sunxi approach.
- DT file determination based on sunxi approach.
- Compat with /boot/dtb/fdtfile.dtb and /boot/dtb/vendor/fdtfile.dtb.
- Simplified some constructs by assuming U-Boot has successfully sourced us with a set of pre-set variables, like ${prefix} ${devtype} etc.
- Actively set the ${kernel_comp_*} parameters based on calculations of load addresses.
- Ability to select different kernel/initrd by setting `kver` in `armbianEnv.txt`

Also:
- Any warning or error includes a 10 second delay to make sure the user is able to see and read them.
- Any "informative" message added by the bootscript can be silenced by setting `verbosity` to `0`
- Attempted to make the bootscript 'reentrant' in away: all variables required for proper (re)execution are set, which should allow for the entire bootscript to be re-run on a next boot_target.
- All variables used in for-loops are actively cleared from the environment to ensure for loops work as expected.
- Any pre-set variable that might be used in next boot_target will be reset whenever necessary.

# Documentation summary for feature / change

- [ ] short description (copy / paste of PR title)
- [x] summary (description relevant for end users)
    Load address calculation can be disabled by adding `load_addr_calc=off` to `armbianEnv.txt`
    Load address calculation OBOE avoidance can be disabled by adding `align_overlap_oboe_avoidance=off` to `armbianEnv.txt`
    User can set custom `fdtdir` and `fdtfile` in `armbianEnv.txt`, but make sure to only specify DT filename in `fdtfile`. `fdtdir` will be used to both load DT, DT overlays and fixup scripts
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

- [x] Helios4: **OK**
    ```
    [16:10:38] U-Boot SPL 2019.04-armbian-2019.04-S3c99-Pcd6a-H9530-V0854-Bb703-R448a (May 10 2025 - 09:39:24 +0000)
    [16:10:38] High speed PHY - Version: 2.0
    [16:10:38] Detected Device ID 6828
    [16:10:38] board SerDes lanes topology details:
    [16:10:38]  | Lane #  | Speed |  Type       |
    [16:10:38]  --------------------------------
    [16:10:38]  |   0    |  6   |  SATA0    |
    [16:10:38]  |   1    |  5   |  USB3 HOST0       |
    [16:10:38]  |   2    |  6   |  SATA1    |
    [16:10:38]  |   3    |  6   |  SATA3    |
    [16:10:38]  |   4    |  6   |  SATA2    |
    [16:10:38]  |   5    |  5   |  USB3 HOST1       |
    [16:10:38]  --------------------------------
    [16:10:39] High speed PHY - Ended Successfully
    [16:10:39] mv_ddr: mv_ddr-armada-18.09.2 
    [16:10:39] DDR3 Training Sequence - Switching XBAR Window to FastPath Window
    [16:10:39] DDR Training Sequence - Start scrubbing
    [16:10:40] DDR3 Training Sequence - End scrubbing
    [16:10:40] mv_ddr: completed successfully
    [16:10:40] Trying to boot from MMC1


    [16:10:40] U-Boot 2019.04-armbian-2019.04-S3c99-Pcd6a-H9530-V0854-Bb703-R448a (May 10 2025 - 09:39:24 +0000)

    [16:10:40] SoC:   MV88F6828-A0 at 1600 MHz
    [16:10:40] DRAM:  2 GiB (800 MHz, 32-bit, ECC enabled)
    [16:10:40] MMC:   mv_sdh: 0
    [16:10:41] Loading Environment from EXT4... ** File not found /boot/boot.env **

    [16:10:41] ** Unable to read "/boot/boot.env" from mmc0:1 **
    [16:10:41] Model: Helios4
    [16:10:41] Board: Helios4
    [16:10:41] SCSI:  MVEBU SATA INIT
    [16:10:41] Target spinup took 0 ms.
    [16:10:41] Target spinup took 0 ms.
    [16:10:41] AHCI 0001.0000 32 slots 2 ports 6 Gbps 0x3 impl SATA mode
    [16:10:41] flags: 64bit ncq led only pmp fbss pio slum part sxs 

    [16:10:41] Net:   
    [16:10:41] Warning: ethernet@70000 (eth1) using random MAC address - 42:21:01:47:98:72
    [16:10:41] eth1: ethernet@70000
    [16:10:41] Hit any key to stop autoboot:  0 
    [16:10:44] switch to partitions #0, OK
    [16:10:44] mmc0 is current device
    [16:10:44] Scanning mmc 0:1...
    [16:10:45] Found U-Boot script /boot/boot.scr
    [16:10:46] 18398 bytes read in 359 ms (49.8 KiB/s)
    [16:10:46] ## Executing script at 03000000
    [16:10:46] Boot script loaded from mmc 0:1.
    [16:10:46] 241 bytes read in 371 ms (0 Bytes/s)
    [16:10:46] Loaded/imported environment /boot/armbianEnv.txt to/from 0x00300000.
    [16:10:46] armada-388-helios4.dtb: No match
    [16:10:48] 28834 bytes read in 704 ms (39.1 KiB/s)
    [16:10:48] Loaded DT /boot/dtb/armada-388-helios4.dtb to 0x02040000.
    [16:10:48] Loading kernel provided DT overlay(s) from /boot/dtb/overlay to 0x00300000 ..
    [16:10:49] ** WARNING: Could NOT find DT overlay notfound!
    [16:10:49] Loading user provided DT overlay(s) from /boot/overlay-user to 0x00300000 ..
    [16:10:50] ** WARNING: Could NOT find user DT overlay notfoud (/boot/overlay-user/notfoud.dtbo)!
    [16:10:53] 8856168 bytes read in 1903 ms (4.4 MiB/s)
    [16:10:53] Loaded compressed kernel image /boot/zImage to 2049000.
    [16:10:53] Using compressed kernel image filesize 0x872268 bytes to calculate initial ramdisk load address.
    [16:10:55] 10998232 bytes read in 2295 ms (4.6 MiB/s)
    [16:10:55] Loaded initial ramdisk /boot/uInitrd to 28bc000.
    [16:10:55] Unknown command 'kaslrseed' - try 'help'
    [16:10:55] Not able to prepare for KASLR.
    [16:10:55] Kernel commandline arguments:
    [16:10:55]   root=UUID=a36c9a2d-e1ed-469d-b1bb-2a1bc453df43
    [16:10:55]   rootfstype=ext4
    [16:10:55]   rootwait
    [16:10:55]   splash=verbose
    [16:10:55]   console=ttyS0,115200
    [16:10:55]   console=tty1
    [16:10:55]   consoleblank=0
    [16:10:55]   loglevel=8
    [16:10:55]   ubootpart=cb16300f-01
    [16:10:55]   usb-storage.quirks=
    [16:10:55]   rw
    [16:10:55]   net.ifnames=0
    [16:10:55]   ipv6.disable=1
    [16:10:55]   cgroup_enable=cpuset
    [16:10:55]   cgroup_memory=1
    [16:10:55]   cgroup_enable=memory
    [16:10:55] ## Loading init Ramdisk from Legacy Image at 028bc000 ...
    [16:10:55]    Image Name:   uInitrd
    [16:10:55]    Created:      2025-05-29   3:04:11 UTC
    [16:10:55]    Image Type:   ARM Linux RAMDisk Image (gzip compressed)
    [16:10:55]    Data Size:    10998168 Bytes = 10.5 MiB
    [16:10:55]    Load Address: 00000000
    [16:10:55]    Entry Point:  00000000
    [16:10:55]    Verifying Checksum ... OK
    [16:10:55] ## Flattened Device Tree blob at 02040000
    [16:10:55]    Booting using the fdt blob at 0x2040000
    [16:10:55]    Loading Ramdisk to 0f582000, end 0ffff198 ... OK
    [16:10:55]    Loading Device Tree to 0f577000, end 0f581fff ... OK

    [16:10:55] Starting kernel ...

    [16:10:57] [    0.000000] Booting Linux on physical CPU 0x0
    ```
    Note: Added a non-existent DT and non-existant user DT overlay to test the warnings.
    
# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
   New warnings introduced:
   - Environment load failed
   - Environment import failed
   - DT load/application failed
   - DT (user) overlay load/application failed
   - Initial ramdisk load failed
   - Kernel image load failed
   - Boot failed
- [x] Any dependent changes have been merged and published in downstream modules
   Prequisite U-Boot `setexpr` command already merged via https://github.com/armbian/build/pull/8260.