### PR TITLE
build sсript: The error of applying Wi-Fi driver patches has been fixed.

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -245,6 +245,8 @@ driver_xradio_xr819() {
 			>> "$kerneldir/drivers/net/wireless/Makefile"
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/xradio\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
+
+		process_patch_file "${SRC}/patch/misc/xradio-Switching-from-del_timer_sync-to-timer_delete_sync.patch" "applying"
 	fi
 }
 

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -525,7 +525,11 @@ driver_uwe5622() {
 		fi
 
 		if linux-version compare "${version}" ge 6.15; then
-			process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-v6.15-timer-api-changes.patch" "applying"
+			if [[ "$LINUXFAMILY" == sunxi* ]]; then
+				process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-fix-timer-api-changes-for-6.15-only-sunxi.patch" "applying"
+			else
+				process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-v6.15-timer-api-changes.patch" "applying"
+			fi
 		fi
 	fi
 }

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -166,7 +166,11 @@ function config_early_init() {
 
 	display_alert "Starting single build process" "${BOARD:-"no BOARD set"}" "info"
 
-	declare -g -a KERNEL_DRIVERS_SKIP=() # Prepare array to be filled in by board/family/extensions
+	# Do not initialize an empty array if it exists.
+	if [ "${KERNEL_DRIVERS_SKIP[*]}" == "" ]; then
+		# Prepare array to be filled in by board/family/extensions
+		declare -g -a KERNEL_DRIVERS_SKIP=()
+	fi
 
 	silent="yes" track_general_config_variables "after config_early_init" # don't log anything, just init the change tracking
 

--- a/patch/misc/wireless-uwe5622/uwe5622-fix-timer-api-changes-for-6.15-only-sunxi.patch
+++ b/patch/misc/wireless-uwe5622/uwe5622-fix-timer-api-changes-for-6.15-only-sunxi.patch
@@ -1,0 +1,214 @@
+From bfd891cd42cc395760879b928d902803ac489f3f Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Fri, 23 May 2025 09:30:35 +0200
+Subject: uwe5622: fix timer api changes for 6.15 (only sunxi)
+
+Signed-off-by: The-going <48602507+The-going@users.noreply.github.com>
+---
+ .../wireless/uwe5622/unisocwifi/cfg80211.c    |  8 +++++++
+ drivers/net/wireless/uwe5622/unisocwifi/qos.c | 22 +++++++++++++++++++
+ .../net/wireless/uwe5622/unisocwifi/reorder.c | 20 +++++++++++++++++
+ .../net/wireless/uwe5622/unisocwifi/tcp_ack.c | 16 ++++++++++++++
+ 4 files changed, 66 insertions(+)
+
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
+index 34b2e5e4274d..b68e63b57f51 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
+@@ -1247,7 +1247,11 @@ void sprdwl_cancel_scan(struct sprdwl_vif *vif)
+ 
+ 	if (priv->scan_vif && priv->scan_vif == vif) {
+ 		if (timer_pending(&priv->scan_timer))
++		#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete_sync(&priv->scan_timer);
++		#else
+ 			del_timer_sync(&priv->scan_timer);
++		#endif
+ 
+ 		spin_lock_bh(&priv->scan_lock);
+ 
+@@ -1307,7 +1311,11 @@ void sprdwl_scan_done(struct sprdwl_vif *vif, bool abort)
+ 
+ 	if (priv->scan_vif && priv->scan_vif == vif) {
+ 		if (timer_pending(&priv->scan_timer))
++		#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete_sync(&priv->scan_timer);
++		#else
+ 			del_timer_sync(&priv->scan_timer);
++		#endif
+ 
+ 		spin_lock_bh(&priv->scan_lock);
+ 		if (priv->scan_request) {
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/qos.c b/drivers/net/wireless/uwe5622/unisocwifi/qos.c
+index d0e42a882cb4..4625c1df08ed 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/qos.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/qos.c
+@@ -573,6 +573,16 @@ void reset_wmmac_parameters(struct sprdwl_priv *priv)
+ 		g_wmmac_available[ac] = false;
+ 		g_wmmac_admittedtime[ac] = 0;
+ 	}
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++	if (timer_pending(&priv->wmmac.wmmac_edcaf_timer))
++		timer_delete_sync(&priv->wmmac.wmmac_edcaf_timer);
++
++	if (timer_pending(&priv->wmmac.wmmac_vo_timer))
++		timer_delete_sync(&priv->wmmac.wmmac_vo_timer);
++
++	if (timer_pending(&priv->wmmac.wmmac_vi_timer))
++		timer_delete_sync(&priv->wmmac.wmmac_vi_timer);
++#else
+ 	if (timer_pending(&priv->wmmac.wmmac_edcaf_timer))
+ 		del_timer_sync(&priv->wmmac.wmmac_edcaf_timer);
+ 
+@@ -581,6 +591,7 @@ void reset_wmmac_parameters(struct sprdwl_priv *priv)
+ 
+ 	if (timer_pending(&priv->wmmac.wmmac_vi_timer))
+ 		del_timer_sync(&priv->wmmac.wmmac_vi_timer);
++#endif
+ 
+ 	memset(&priv->wmmac.ac[0], 0, 4*sizeof(struct wmm_ac_params));
+ }
+@@ -710,6 +721,16 @@ void update_admitted_time(struct sprdwl_priv *priv, u8 tsid, u16 medium_time, bo
+ 			g_wmmac_admittedtime[ac] -= (medium_time<<5);
+ 		else {
+ 			g_wmmac_admittedtime[ac] = 0;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			if (timer_pending(&priv->wmmac.wmmac_edcaf_timer))
++				timer_delete_sync(&priv->wmmac.wmmac_edcaf_timer);
++
++			if (timer_pending(&priv->wmmac.wmmac_vo_timer))
++				timer_delete_sync(&priv->wmmac.wmmac_vo_timer);
++
++			if (timer_pending(&priv->wmmac.wmmac_vi_timer))
++				timer_delete_sync(&priv->wmmac.wmmac_vi_timer);
++#else
+ 			if (timer_pending(&priv->wmmac.wmmac_edcaf_timer))
+ 				del_timer_sync(&priv->wmmac.wmmac_edcaf_timer);
+ 
+@@ -718,6 +739,7 @@ void update_admitted_time(struct sprdwl_priv *priv, u8 tsid, u16 medium_time, bo
+ 
+ 			if (timer_pending(&priv->wmmac.wmmac_vi_timer))
+ 				del_timer_sync(&priv->wmmac.wmmac_vi_timer);
++#endif
+ 		}
+ 	}
+ 
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/reorder.c b/drivers/net/wireless/uwe5622/unisocwifi/reorder.c
+index c6c77648ddde..12535a597221 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/reorder.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/reorder.c
+@@ -108,7 +108,11 @@ static inline void mod_reorder_timer(struct rx_ba_node *ba_node)
+ 		mod_timer(&ba_node->reorder_timer,
+ 			  jiffies + RX_BA_LOSS_RECOVERY_TIMEOUT);
+ 	} else {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++		timer_delete(&ba_node->reorder_timer);
++#else
+ 		del_timer(&ba_node->reorder_timer);
++#endif
+ 		ba_node->timeout_cnt = 0;
+ 	}
+ }
+@@ -436,7 +440,11 @@ static void reorder_msdu_process(struct sprdwl_rx_ba_entry *ba_entry,
+ 			}
+ 		} else if (unlikely(!ba_node_desc->buff_cnt)) {
+ 			/* Should never happen */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ba_node->reorder_timer);
++#else
+ 			del_timer(&ba_node->reorder_timer);
++#endif
+ 			ba_node->timeout_cnt = 0;
+ 		}
+ 	} else {
+@@ -645,7 +653,11 @@ static void wlan_delba_event(struct sprdwl_rx_ba_entry *ba_entry,
+ 		return;
+ 	}
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++	timer_delete_sync(&ba_node->reorder_timer);
++#else
+ 	del_timer_sync(&ba_node->reorder_timer);
++#endif
+ 	spin_lock_bh(&ba_node->ba_node_lock);
+ 	if (ba_node->active) {
+ 		ba_node_desc = ba_node->rx_ba;
+@@ -876,7 +888,11 @@ void sprdwl_reorder_deinit(struct sprdwl_rx_ba_entry *ba_entry)
+ 			continue;
+ 
+ 		hlist_for_each_entry_safe(ba_node, node, head, hlist) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete_sync(&ba_node->reorder_timer);
++#else
+ 			del_timer_sync(&ba_node->reorder_timer);
++#endif
+ 			spin_lock_bh(&ba_node->ba_node_lock);
+ 			ba_node->active = 0;
+ 			flush_reorder_buffer(ba_node->rx_ba);
+@@ -983,7 +999,11 @@ void peer_entry_delba(void *hw_intf, unsigned char lut_index)
+ 		if (ba_node) {
+ 			wl_info("%s: del ba lut_index: %d, tid %d\n",
+ 				__func__, lut_index, tid);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete_sync(&ba_node->reorder_timer);
++#else
+ 			del_timer_sync(&ba_node->reorder_timer);
++#endif
+ 			spin_lock_bh(&ba_node->ba_node_lock);
+ 			if (ba_node->active) {
+ 				ba_node_desc = ba_node->rx_ba;
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c b/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c
+index 4db766fbac3b..26469dfeb83f 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c
+@@ -84,7 +84,11 @@ void sprdwl_tcp_ack_deinit(struct sprdwl_priv *priv)
+ 		drop_msg = NULL;
+ 
+ 		write_seqlock_bh(&ack_m->ack_info[i].seqlock);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++		timer_delete(&ack_m->ack_info[i].timer);
++#else
+ 		del_timer(&ack_m->ack_info[i].timer);
++#endif
+ 		drop_msg = ack_m->ack_info[i].msgbuf;
+ 		ack_m->ack_info[i].msgbuf = NULL;
+ 		write_sequnlock_bh(&ack_m->ack_info[i].seqlock);
+@@ -342,7 +346,11 @@ int sprdwl_tcp_ack_handle(struct sprdwl_msg_buf *new_msgbuf,
+ 			if (ack_info->msgbuf) {
+ 				drop_msg = ack_info->msgbuf;
+ 				ack_info->msgbuf = NULL;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++				timer_delete(&ack_info->timer);
++#else
+ 				del_timer(&ack_info->timer);
++#endif
+ 			}
+ 
+ 			ack_info->in_send_msg = NULL;
+@@ -374,7 +382,11 @@ int sprdwl_tcp_ack_handle(struct sprdwl_msg_buf *new_msgbuf,
+ 				   atomic_read(&ack_m->max_drop_cnt)))) {
+ 			ack_info->drop_cnt = 0;
+ 			ack_info->in_send_msg = new_msgbuf;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_info->timer);
++#else
+ 			del_timer(&ack_info->timer);
++#endif
+ 		} else {
+ 			ret = 1;
+ 			ack_info->msgbuf = new_msgbuf;
+@@ -537,7 +549,11 @@ void enable_tcp_ack_delay(char *buf, unsigned char offset)
+ 			write_seqlock_bh(&ack_m->ack_info[i].seqlock);
+ 			drop_msg = ack_m->ack_info[i].msgbuf;
+ 			ack_m->ack_info[i].msgbuf = NULL;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_m->ack_info[i].timer);
++#else
+ 			del_timer(&ack_m->ack_info[i].timer);
++#endif
+ 			write_sequnlock_bh(&ack_m->ack_info[i].seqlock);
+ 
+ 			if (drop_msg)
+-- 
+2.34.1
+

--- a/patch/misc/xradio-Switching-from-del_timer_sync-to-timer_delete_sync.patch
+++ b/patch/misc/xradio-Switching-from-del_timer_sync-to-timer_delete_sync.patch
@@ -1,0 +1,123 @@
+From 4cec41678369fae41c37ccfecaa4e0eadc04f472 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Sat, 7 Jun 2025 17:00:14 +0000
+Subject: xradio: Switching from del_timer_sync to timer_delete_sync
+
+This was introduced in 6.2 but was removed from the kernel code
+in 6.15.
+We are currently building cores for sunxi starting from 6.6.
+Therefore, a simple replacement without conditions.
+
+Signed-off-by: The-going <48602507+The-going@users.noreply.github.com>
+---
+ drivers/net/wireless/xradio/ap.c    | 4 ++--
+ drivers/net/wireless/xradio/main.c  | 2 +-
+ drivers/net/wireless/xradio/pm.c    | 2 +-
+ drivers/net/wireless/xradio/queue.c | 2 +-
+ drivers/net/wireless/xradio/sta.c   | 8 ++++----
+ 5 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/net/wireless/xradio/ap.c b/drivers/net/wireless/xradio/ap.c
+index 649d6bf97674..266106322143 100644
+--- a/drivers/net/wireless/xradio/ap.c
++++ b/drivers/net/wireless/xradio/ap.c
+@@ -874,7 +874,7 @@ void xradio_multicast_stop_work(struct work_struct *work)
+ 		container_of(work, struct xradio_vif, multicast_stop_work);
+ 
+ 	if (priv->aid0_bit_set) {
+-		del_timer_sync(&priv->mcast_timeout);
++		timer_delete_sync(&priv->mcast_timeout);
+ 		wsm_lock_tx(priv->hw_priv);
+ 		priv->aid0_bit_set = false;
+ 		xradio_set_tim_impl(priv, false);
+@@ -954,7 +954,7 @@ void xradio_suspend_resume(struct xradio_vif *priv, struct wsm_suspend_resume *a
+ 		}
+ 		spin_unlock_bh(&priv->ps_state_lock);
+ 		if (cancel_tmo)
+-			del_timer_sync(&priv->mcast_timeout);
++			timer_delete_sync(&priv->mcast_timeout);
+ 	} else {
+ 		spin_lock_bh(&priv->ps_state_lock);
+ 		xradio_ps_notify(priv, arg->link_id, arg->stop);
+diff --git a/drivers/net/wireless/xradio/main.c b/drivers/net/wireless/xradio/main.c
+index a30c604f5337..902c173c03e8 100644
+--- a/drivers/net/wireless/xradio/main.c
++++ b/drivers/net/wireless/xradio/main.c
+@@ -440,7 +440,7 @@ void xradio_free_common(struct ieee80211_hw *dev)
+ 	struct xradio_common *hw_priv = dev->priv;
+ 
+ 	cancel_work_sync(&hw_priv->query_work);
+-	del_timer_sync(&hw_priv->ba_timer);
++	timer_delete_sync(&hw_priv->ba_timer);
+ 	mutex_destroy(&hw_priv->wsm_oper_lock);
+ 	mutex_destroy(&hw_priv->conf_mutex);
+ 	mutex_destroy(&hw_priv->wsm_cmd_mux);
+diff --git a/drivers/net/wireless/xradio/pm.c b/drivers/net/wireless/xradio/pm.c
+index 0a7bd14b5c8c..85ca676d69ad 100644
+--- a/drivers/net/wireless/xradio/pm.c
++++ b/drivers/net/wireless/xradio/pm.c
+@@ -291,7 +291,7 @@ int xradio_pm_init(struct xradio_pm_state *pm,
+ 
+ void xradio_pm_deinit(struct xradio_pm_state *pm)
+ {
+-	del_timer_sync(&pm->stay_awake);
++	timer_delete_sync(&pm->stay_awake);
+ 	xradio_pm_deinit_common(pm);
+ }
+ 
+diff --git a/drivers/net/wireless/xradio/queue.c b/drivers/net/wireless/xradio/queue.c
+index 1bb7f0e90330..103259f4d869 100644
+--- a/drivers/net/wireless/xradio/queue.c
++++ b/drivers/net/wireless/xradio/queue.c
+@@ -328,7 +328,7 @@ void xradio_queue_deinit(struct xradio_queue *queue)
+ 	int i;
+ 
+ 	xradio_queue_clear(queue, XRWL_ALL_IFS);
+-	del_timer_sync(&queue->gc);
++	timer_delete_sync(&queue->gc);
+ 	INIT_LIST_HEAD(&queue->free_pool);
+ 	kfree(queue->pool);
+ 	for (i = 0; i < XRWL_MAX_VIFS; i++) {
+diff --git a/drivers/net/wireless/xradio/sta.c b/drivers/net/wireless/xradio/sta.c
+index 2dddb26a905d..53013de18743 100644
+--- a/drivers/net/wireless/xradio/sta.c
++++ b/drivers/net/wireless/xradio/sta.c
+@@ -139,7 +139,7 @@ void xradio_stop(struct ieee80211_hw *dev)
+ 	cancel_delayed_work_sync(&hw_priv->scan.probe_work);
+ 	cancel_delayed_work_sync(&hw_priv->scan.timeout);
+ 	flush_workqueue(hw_priv->workqueue);
+-	del_timer_sync(&hw_priv->ba_timer);
++	timer_delete_sync(&hw_priv->ba_timer);
+ 
+ 	mutex_lock(&hw_priv->conf_mutex);
+ 
+@@ -169,7 +169,7 @@ void xradio_stop(struct ieee80211_hw *dev)
+ 		cancel_delayed_work_sync(&priv->bss_loss_work);
+ 		cancel_delayed_work_sync(&priv->connection_loss_work);
+ 		cancel_delayed_work_sync(&priv->link_id_gc_work);
+-		del_timer_sync(&priv->mcast_timeout);
++		timer_delete_sync(&priv->mcast_timeout);
+ 	}
+ 
+ 	wsm_unlock_tx(hw_priv);
+@@ -329,7 +329,7 @@ void xradio_remove_interface(struct ieee80211_hw *dev,
+ 	cancel_delayed_work_sync(&priv->set_cts_work);
+ 	cancel_delayed_work_sync(&priv->pending_offchanneltx_work);
+ 
+-	del_timer_sync(&priv->mcast_timeout);
++	timer_delete_sync(&priv->mcast_timeout);
+ 	/* TODO:COMBO: May be reset of these variables "delayed_link_loss and
+ 	 * join_status to default can be removed as dev_priv will be freed by
+ 	 * mac80211 */
+@@ -1571,7 +1571,7 @@ void xradio_unjoin_work(struct work_struct *work)
+ 	priv->ht_compat_cnt = 0;
+ #endif
+ 
+-	del_timer_sync(&hw_priv->ba_timer);
++	timer_delete_sync(&hw_priv->ba_timer);
+ 	mutex_lock(&hw_priv->conf_mutex);
+ 	if (unlikely(atomic_read(&hw_priv->scan.in_progress))) {
+ 		if (atomic_xchg(&priv->delayed_unjoin, 1)) {
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

- config-prepare: Initialize an empty KERNEL_DRIVERS_SKIP array unless it exists

    If the array exists in this location, initializing an empty array
    will destroy all the data that was stored in it.
    Do not initialize an empty KERNEL_DRIVERS_SKIP array if it exists.
    
    This allows us to create an array anywhere in the script,
    including the user configuration, in a secure way.

- patch: misc: uwe5622: fix timer api changes for 6.15 (only sunxi)
- sunxi: xradio: Switching from del_timer_sync to timer_delete_sync
    
    This was introduced in 6.2 but was removed from the kernel code
    in 6.15.
    We are currently building cores for sunxi starting from 6.6.
    Therefore, a simple replacement without conditions.

# How Has This Been Tested?
The sequence of patch application is defined here:
[lib/functions/compilation/patch/drivers-harness.sh](https://github.com/armbian/build/blob/28ae76b468908349936e310f7020f5570166f4ce/lib/functions/compilation/patch/drivers-harness.sh#L102-L122)
I have created an array in the user configuration file.
```bash
declare -g  -a KERNEL_DRIVERS_SKIP=(
#               driver_generic_bring_back_ipx
#               driver_mt7921u_add_pids
#               driver_rtl8152_rtl8153
#               driver_rtl8189ES
#               driver_rtl8189FS
#               driver_rtl8192EU
#               driver_rtl8811_rtl8812_rtl8814_rtl8821
#               driver_xradio_xr819
#               driver_rtl8811CU_rtl8821C
#               driver_rtl8188EU_rtl8188ETV
#               driver_rtl88x2bu
#               driver_rtw88
#               driver_rtl8852bs
#               driver_rtl88x2cs
#               driver_rtl8822cs_bt
#               driver_rtl8723DS
#               driver_rtl8723DU
               driver_uwe5622
               driver_rtl8723cs
)
```
This allowed the build system to apply only those patches that go up to driver_uwe5622 
and therefore allows me to make fixes by applying patches for driver_uwe5622 manually.
As `./compile.sh test kernel-patch`
Here, the `test` is the name of my custom configuration.

- [x] Test build kernel for sunxi64

this pull request must be combined before doing this [8270](https://github.com/armbian/build/pull/8270).
