### PR TITLE
coolpi-genbook: Add Support for vendor branch

### DIFF
--- a/config/boards/coolpi-genbook.csc
+++ b/config/boards/coolpi-genbook.csc
@@ -5,7 +5,7 @@ BOARD_MAINTAINER="andyshrk"
 BOARD_FIRMWARE_INSTALL="-full"
 BOOT_SOC="rk3588"
 BOOTCONFIG="coolpi-cm5-genbook-rk3588_defconfig"
-KERNEL_TARGET="edge"
+KERNEL_TARGET="edge,vendor"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3588-coolpi-cm5-genbook.dtb"
@@ -15,13 +15,13 @@ BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 
 # Mainline U-Boot
-function post_family_config_branch_edge__coolpi-genbook_use_mainline_uboot() {
+function post_family_config__coolpi-genbook_use_mainline_uboot() {
 	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
 
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # Mainline U-Boot
 	unset BOOTBRANCH
 	declare -g BOOTPATCHDIR="v2025.01-rc3-coolpi-cm5"
-	declare -g BOOTBRANCH_BOARD="tag:v2025.01"
+	declare -g BOOTBRANCH_BOARD="tag:v2025.04"
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
 


### PR DESCRIPTION
# Description

The dts for vendor kernel has been merged .
Add vendor branch support for Cool Pi Genbook
And use mainline u-boot for vendor branch。

# How Has This Been Tested?
Compiled with command：
`./compile.sh build BOARD=coolpi-genbook BRANCH=vendor BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED='browsers chat desktop_tools editors email internet multimedia office programming remote_desktop' DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base DOWNLOAD_MIRROR=bfsu EXPERT=yes EXTRAWIFI=no KERNEL_CONFIGURE=no RELEASE=noble`

flash the img to sdcard， insert the sdcard to a usb disk， insert usb disk to genbook，the Armbian system can boot from
usb disk。

# Checklist:

- [&#x2705; ] My code follows the style guidelines of this project
- [&#x2705;] I have performed a self-review of my own code
- [&#x2705;] I have commented my code, particularly in hard-to-understand areas
- [&#x2705;] My changes generate no new warnings
- [&#x2705;] Any dependent changes have been merged and published in downstream modules
