### PR TITLE
compilation: armbian-kernel: Do not make built-in drivers modules

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -367,8 +367,14 @@ function armbian_kernel_config__restore_enable_gpio_sysfs() {
 #
 function kernel_config_set_m() {
 	declare module="$1"
-	display_alert "Enabling kernel module" "${module}=m" "debug"
-	run_host_command_logged ./scripts/config --module "$module"
+	state=$(./scripts/config --state "$module")
+
+	if [ "$state" == "y" ]; then
+		display_alert "${module} is already enabled as built-in"
+	else
+		display_alert "Enabling kernel module" "${module}=m" "debug"
+		run_host_command_logged ./scripts/config --module "$module"
+	fi
 }
 
 function kernel_config_set_y() {


### PR DESCRIPTION
# Description

The current script can overwrite drivers which are set as built-in in the board-specific config. This is not desirable.

Add a check to ensure we do not convert built-in stuff into modules.

First encountered it when pocketbeagle 2 kernels was enabling EXT4 as module instead of being built-in, which makes the current rootfs (using ext4) fail to run.

# How Has This Been Tested?

Tested on PocketBeagle 2

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
