### PR TITLE
Preparation for http proxy caching

### DIFF
--- a/extensions/apa.sh
+++ b/extensions/apa.sh
@@ -5,7 +5,7 @@ function extension_prepare_config__apa() {
 }
 
 function custom_apt_repo__add_apa() {
-	run_host_command_logged echo "deb [signed-by=${APT_SIGNING_KEY_FILE}] https://github.armbian.com/apa current main" "|" tee "${SDCARD}"/etc/apt/sources.list.d/armbian-apa.list
+	run_host_command_logged echo "deb [signed-by=${APT_SIGNING_KEY_FILE}] http://github.armbian.com/apa current main" "|" tee "${SDCARD}"/etc/apt/sources.list.d/armbian-apa.list
 }
 
 function post_armbian_repo_customize_image__install_from_apa() {

--- a/extensions/armbian-config.sh
+++ b/extensions/armbian-config.sh
@@ -5,7 +5,7 @@
 function custom_apt_repo__add_armbian-github-repo() {
 	cat <<- EOF > "${SDCARD}"/etc/apt/sources.list.d/armbian-config.sources
 	Types: deb
-	URIs: https://github.armbian.com/configng
+	URIs: http://github.armbian.com/configng
 	Suites: stable
 	Components: main
 	Signed-By: ${APT_SIGNING_KEY_FILE}

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -411,10 +411,10 @@ function docker_cli_prepare_launch() {
 		"--env" "GITHUB_WORKSPACE=${GITHUB_WORKSPACE}"
 
 		# Pass proxy args
-		"--env" "HTTP_PROXY=${HTTP_PROXY}"
+ 		"--env" "http_proxy=${http_proxy:-${HTTP_PROXY}}"
+ 		"--env" "https_proxy=${https_proxy:-${HTTPS_PROXY}}"
+ 		"--env" "HTTP_PROXY=${HTTP_PROXY}"
 		"--env" "HTTPS_PROXY=${HTTPS_PROXY}"
-		"--env" "http_proxy=${HTTP_PROXY}"
-		"--env" "https_proxy=${HTTPS_PROXY}"
 		"--env" "APT_PROXY_ADDR=${APT_PROXY_ADDR}"
 	)
 

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -409,6 +409,13 @@ function docker_cli_prepare_launch() {
 		"--env" "GITHUB_SHA=${GITHUB_SHA}"
 		"--env" "GITHUB_WORKFLOW=${GITHUB_WORKFLOW}"
 		"--env" "GITHUB_WORKSPACE=${GITHUB_WORKSPACE}"
+
+		# Pass proxy args
+		"--env" "HTTP_PROXY=${HTTP_PROXY}"
+		"--env" "HTTPS_PROXY=${HTTPS_PROXY}"
+		"--env" "http_proxy=${HTTP_PROXY}"
+		"--env" "https_proxy=${HTTPS_PROXY}"
+		"--env" "APT_PROXY_ADDR=${APT_PROXY_ADDR}"
 	)
 
 	# This env var is used super early (in entrypoint.sh), so set it as an env to current value.

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -196,7 +196,7 @@ function create_sources_list_and_deploy_repo_key() {
 	fi
 	cat <<- EOF > "${basedir}"/etc/apt/sources.list.d/armbian.sources
 	Types: deb
-	URIs: https://${armbian_mirror}
+	URIs: http://${armbian_mirror}
 	Suites: $RELEASE
 	Components: ${components[*]}
 	Signed-By: ${APT_SIGNING_KEY_FILE}


### PR DESCRIPTION
# Description

The idea is to introduce the possibility to cache downloads from GH runners to lower downstream bandwidth used and increase overall speed. Especially on machines with lots of runner this could save quite some bandwidth while sacrificing disk space.
*http* caching has been tested and seem to work nicely.

*https* caching is a lot more tricky and may be introduced later.

This PR has two parts:
- set apt repository to *http* instead of *https* where possible. Packages are signed anyways.
- Pass various proxy environment variables to docker so it respects those. Doesn't make sense not to pass them since when using `PREFER_DOCKER=no` and any of these variables are set beforehand they just work. So this more or less just harmonizes overall behavior.

There is still an issue on line 4838 caused by https://github.com/armbian/build/blob/c0da65087aad628ba0714f23d8d29800f152d97c/lib/functions/rootfs/apt-install.sh#L67 due to absence of apt proxy setting there. Not sure why this is not added here?


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] build random image: https://paste.armbian.de/xopitiguyo , look for `10.100.0.87` to see where it is used
- [x] built the same random image but having all proxy env variables unset beforehand: builds just fine as well: https://paste.armbian.de/ozidivugor

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
