### PR TITLE
Revert "build(deps): bump oras from 0.2.33 to 0.2.34"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ GitPython == 3.1.44    # for manipulating git repos
 unidecode == 1.4.0     # for converting strings to ascii
 coloredlogs == 15.0.1  # for colored logging
 PyYAML == 6.0.2        # for parsing/writing YAML
-oras == 0.2.34         # for OCI stuff in mapper-oci-update
+oras == 0.2.33         # for OCI stuff in mapper-oci-update
 Jinja2 == 3.1.6        # for templating
 rich == 14.0.0         # for rich text formatting
 dtschema == 2025.2     # for checking dts files and dt bindings


### PR DESCRIPTION
# Description

This reverts commit f29414a0ea6e99dde7dd28a1122ee5009074798d.

Apparently broken.
