### PR TITLE
RFC: https_proxy extension: initial commit

### DIFF
--- a/extensions/https_proxy.sh
+++ b/extensions/https_proxy.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# squid must be configured to do ssl-bumping
+# Also a self-signed cert with ca needs to be created
+# the ca needs to be stored as "squid-self-signed.crt" in userpatches/
+
+# to do
+# check if https_proxy/HTTPS_PROXY are set and then if cert is available.
+
+# HOST
+# if a cert file is there copy into docker container or host machine and enable it
+function post_family_config__prepare_host_for_https_proxy() {
+    if [ -f ${USERPATCHES_PATH}/squid-self-signed.crt ]; then
+        display_alert "Found cert file: ${USERPATCHES_PATH}/squid-self-signed.crt" "${EXTENSION}" "info"
+        run_host_command_logged mkdir -p /usr/share/ca-certificates/extra/
+        run_host_command_logged cp ${USERPATCHES_PATH}/squid-self-signed.crt /usr/share/ca-certificates/extra/squid-self-signed.crt
+        run_host_command_logged echo "extra/squid-self-signed.crt" >> /etc/ca-certificates.conf
+        run_host_command_logged update-ca-certificates
+        display_alert "Host/Docker prepared for https proxy" "${EXTENSION}" "info"
+    else
+        display_alert "Cert file not found" "${EXTENSION}" "error"
+        exit 1
+    fi
+}
+
+# CHROOT
+# Add cert into chroot before customization so customization won't fail on https downloads
+function pre_customize_image__prepare_https_proxy_inside_chroot() {
+    display_alert "Found cert file" "${EXTENSION}" "info"
+    chroot_sdcard mkdir -p /usr/share/ca-certificates/extra/ 
+    run_host_command_logged cp ${USERPATCHES_PATH}/squid-self-signed.crt "${SDCARD}"/usr/share/ca-certificates/extra/squid-self-signed.crt
+    run_host_command_logged echo "extra/squid-self-signed.crt" >> "${SDCARD}"/etc/ca-certificates.conf
+    chroot_sdcard cat /etc/ca-certificates.conf
+    chroot_sdcard update-ca-certificates
+}
+
+# CHROOT
+# Remove cert after "apt_lists_copy_from_host_to_image_and_update" has been executed
+function pre_umount_final_image__unprepare_https_proxy_inside_chroot() {
+    chroot_sdcard rm /usr/share/ca-certificates/extra/squid-self-signed.crt
+    run_host_command_logged sed -i "'/extra\/squid-self-signed.crt/d'" "${SDCARD}/etc/ca-certificates.conf"
+    chroot_sdcard update-ca-certificates
+}
+
+# HOST
+# remove 
+#function post_umount_final_image__unprepare_host_for_https_proxy() {
+#    if [ -f /usr/share/ca-certificates/extra/squid-self-signed.crt ]; then
+#        display_alert "Found cert file: /usr/share/ca-certificates/extra/squid-self-signed.crt. Removing..." "${EXTENSION}" "info"
+#        run_host_command_logged rm /usr/share/ca-certificates/extra/squid-self-signed.crt
+#        run_host_command_logged sed -i "'/extra\/squid-self-signed.crt/d'" /etc/ca-certificates.conf
+#        run_host_command_logged update-ca-certificates
+#        display_alert "Host unprepared for https proxy" "${EXTENSION}" "info"
+#    else
+#        display_alert "Cert file not found" "${EXTENSION}" "error"
+#        exit 1
+#    fi
+#}
+# removing cert casuses log upload to fail


### PR DESCRIPTION
# Description

This is a draft/wip for adding https proxy caching. This is especially designed for machines hosting lots of github runners to reduce their bandwidth usage by sacrificing disk space. http caching has been merged already and only needed minor changes.

Caching https however is way more complicated. Encryption needs to be broken and rewrapped and then obviously downloads will fail due to cert issues. Classic MITM. So a new certificate authority (CA) needs to be put in place to allow these "fake" certs.

Why is this even necessary?
Well one major part is downloads from upstream apt repositories. The other major part is downloading 3rd party repositories and artifacts from OCI/ORAS/whatever the correct name for that system is. They do not allow plain http downloads but redirect to https.
So in order to cache these encryption must be broken on the fly.

On custom runs this works already with the mentioned extension.  However when the build framework is used within a GH Actions Runner environment it would need to detect this and enable the extension automatically. No clue how to do that or overall if it is worth diving even deeper into this topic. Therefore this RFC to collect feedback.

Also lots of fail-safe checks are missing.
Sometimes I had to mix `run_host_command_logged` and `chroot_sdcard` since pipes don't work using latter.


# Documentation summary for feature / change

Yes, this would need documentation.

# How Has This Been Tested?

- [x] custom builds with `ENABLE_EXTENSION`
- [ ] Test B

# Checklist:

- [no idea] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
