### PR TITLE
Extension method for building board-level drivers

### DIFF
--- a/lib/functions/compilation/patch/drivers-harness.sh
+++ b/lib/functions/compilation/patch/drivers-harness.sh
@@ -121,6 +121,19 @@ function kernel_drivers_prepare_harness() {
 		driver_rtl8723cs
 	)
 
+	# Extension method for building board level drivers
+	custom_drivers=$(call_extension_method "build_board_drivers" <<- 'BUILD_BOARD_DRIVERS'
+		*allow extensions to build custom driver for their boards*
+	BUILD_BOARD_DRIVERS
+	)
+
+	if [[ -n "$custom_drivers" ]]; then
+		declare -a drvlist=()
+		readarray -t drvlist <<< "${custom_drivers}"
+		display_alert "Use custom board drivers: " "${drvlist[*]}"
+		all_drivers+=("${drvlist[@]}")
+	fi
+
 	declare -a skip_drivers=("${KERNEL_DRIVERS_SKIP[@]}")
 	declare -a drivers=()
 


### PR DESCRIPTION
# Description

In order to avoid adding the driver through the patches(https://github.com/armbian/build/pull/8047#issuecomment-2768899543), this PR offers a 'build_board_drivers' extension, keep the same code taste with `drivers_network.sh`

It can bring us many benefits, and we can easily add board-level drivers without breaking other board compilations.

# Documentation summary for feature / change

In the board config (\*.conf):
```bash
function build_board_drivers__my_awesome_drivers() {
  echo driver_my_awesome_driver1
  echo driver_my_awesome_driver2
}

function driver_my_awesome_driver1() {
  // do clone repo or something
}

function driver_my_awesome_driver2() {
  // do clone repo or something
}
```
The output will be
```
[🐳|🌿] Use custom board drivers:  [ driver_my_awesome_driver1 driver_my_awesome_driver2 ]
[🐳|🌱] Preparing driver [ driver_rtl8152_rtl8153 ]
[🐳|🌱] Preparing driver [ driver_rtl8189ES ]
.......
[🐳|🌱] Preparing driver [ driver_my_awesome_driver1 ]
[🐳|🌱] Preparing driver [ driver_my_awesome_driver2 ]
```

# Tested?
- [x] Tested board compilation with(and without) this extension

