### PR TITLE
Allow APA to handle installation of GPG keys

### DIFF
--- a/extensions/apa.sh
+++ b/extensions/apa.sh
@@ -2,6 +2,7 @@
 
 function extension_prepare_config__apa() {
 	display_alert "Target image will have Armbian Package Archive (APA) enabled by default" "${EXTENSION}" "info"
+	export APA_IS_ACTIVE="true"
 }
 
 function custom_apt_repo__add_apa() {


### PR DESCRIPTION
# Description

as a small step to wider APA usage, we push a commit to make it discernible if a build uses APA or not -> APA_IS_ACTIVE environment variable.

In a second commit, we disable some code to be eventually deprecated that is already handled with APA's armbian-common package to handle GPG key management.  This serves as a canary to give APA some exposure and testing.  The environment variable APT_SIGNING_KEY is used in other places of core code and needs to be preserved regardless of the status of the APA_IS_ACTIVE var.

It is important that Armbian starts to provide a way to manage and update GPG repo keys on user devices -> armbian/apa#18

# How Has This Been Tested?

Compilation was tested locally.