### PR TITLE
motd: fix alignments on login screen. Closes: #7984

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -113,8 +113,8 @@ echo "" # fixed newline
 echo ""
 display " Load" "${load%% *}" "${critical_load}" "0" "%" ""
 
-printf "Up time:       \x1B[92m%s\x1B[0m\t" "$time"
-display "Local users" "${users##* }" "3" "2" ""
+printf " Uptime:       \x1B[92m%s\x1B[0m\t" "$time"
+display " Local users" "${users##* }" "3" "2" ""
 echo "" # fixed newline
 if [[ ${memory_total} -gt 1000 ]]; then
 	memory_total=$(awk '{printf("%.2f",$1/1024)}' <<<${memory_total})"G"
@@ -129,7 +129,7 @@ else
 fi
 
 display " Memory usage" "$memory_usage" "70" "0" "%" " of ${memory_total}"
-display "Zram usage" "$swap_usage" "75" "0" "%" " of ${swap_total}"
+display " Zram usage" "$swap_usage" "75" "0" "%" " of ${swap_total}"
 echo "" # fixed newline
 display " CPU temp" "$board_temp" $CPU_TEMP_LIMIT "0" "°C" ""
 display " Ambient temp" "$amb_temp" $AMB_TEMP_LIMIT "0" "°C" ""
@@ -139,9 +139,9 @@ echo -ne "\x1B[91m(read only rootfs)\x1B[0m"
 fi
 echo "" # fixed newline
 a=0
-display "storage/" "$storage_usage" "90" "1" "%" " of $storage_total" ; a=$((a+$?))
-display "storage temp" "$storage_temp" $HDD_TEMP_LIMIT "0" "°C" "" ; a=$((a+$?))
-display "Battery" "$battery_percent" "20" "1" "%" "$status_battery_text" ; a=$((a+$?))
+display " storage/" "$storage_usage" "90" "1" "%" " of $storage_total" ; a=$((a+$?))
+display " storage temp" "$storage_temp" $HDD_TEMP_LIMIT "0" "°C" "" ; a=$((a+$?))
+display " Battery" "$battery_percent" "20" "1" "%" "$status_battery_text" ; a=$((a+$?))
 (( $a > 0 )) && echo "" # new line only if some value is displayed
 
 line=0
@@ -163,7 +163,7 @@ if [[ -n "$PRIMARY_INTERFACE" ]] && vnstat -i "$PRIMARY_INTERFACE" &> /dev/null;
 		;;
 		both)
 			display " TX today" "$traffic_tx" 500 0 "" "$traffic_tx_unit" ""
-			display "RX today" "$traffic_rx" 500 0 "" "$traffic_rx_unit" ""
+			display " RX today" "$traffic_rx" 500 0 "" "$traffic_rx_unit" ""
 			line=$((line+1))
 		;;
 		*) #off or whatever


### PR DESCRIPTION
# Description

fix alignment issues discussed in #7984 

in general all strings start with a space
