### PR TITLE
Nanopi R6/R5: set wan interface to wan1 as otherwise netplan rules won't catch it

### DIFF
--- a/config/boards/nanopi-r5c.csc
+++ b/config/boards/nanopi-r5c.csc
@@ -30,7 +30,7 @@ function post_family_tweaks__nanopir5c_udev_network_interfaces() {
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
 	cat <<- EOF > "${SDCARD}/etc/udev/rules.d/70-persistent-net.rules"
-		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0001:01:00.0", NAME:="lan"
-		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0002:01:00.0", NAME:="wan"
+		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0001:01:00.0", NAME:="lan1"
+		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0002:01:00.0", NAME:="wan1"
 	EOF
 }

--- a/config/boards/nanopi-r5s.csc
+++ b/config/boards/nanopi-r5s.csc
@@ -26,11 +26,11 @@ function post_family_config__uboot_config() {
 }
 
 function post_family_tweaks__nanopir5s_udev_network_interfaces() {
-	display_alert "$BOARD" "Renaming interfaces WAN LAN1 LAN2" "info"
+	display_alert "$BOARD" "Renaming interfaces WAN1 LAN1 LAN2" "info"
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
 	cat <<- EOF > "${SDCARD}/etc/udev/rules.d/70-persistent-net.rules"
-		SUBSYSTEM=="net", ACTION=="add", KERNELS=="fe2a0000.ethernet", NAME:="wan"
+		SUBSYSTEM=="net", ACTION=="add", KERNELS=="fe2a0000.ethernet", NAME:="wan1"
 		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:01:00.0", NAME:="lan1"
 		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0001:01:00.0", NAME:="lan2"
 	EOF

--- a/config/boards/nanopi-r6c.csc
+++ b/config/boards/nanopi-r6c.csc
@@ -22,12 +22,12 @@ function post_family_tweaks__nanopi_r6c_naming_audios() {
 }
 
 function post_family_tweaks__nanopi_r6c_naming_udev_network_interfaces() {
-	display_alert "$BOARD" "Renaming NanoPi R6C network interfaces to 'wan' and 'lan'" "info"
+	display_alert "$BOARD" "Renaming NanoPi R6C network interfaces to 'wan1' and 'lan1'" "info"
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
 	cat <<- EOF > "${SDCARD}/etc/udev/rules.d/70-persistent-net.rules"
-		SUBSYSTEM=="net", ACTION=="add", KERNELS=="fe1c0000.ethernet", NAME:="wan"
-		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0003:31:00.0", NAME:="lan"
+		SUBSYSTEM=="net", ACTION=="add", KERNELS=="fe1c0000.ethernet", NAME:="wan1"
+		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0003:31:00.0", NAME:="lan1"
 	EOF
 }
 

--- a/config/boards/nanopi-r6s.conf
+++ b/config/boards/nanopi-r6s.conf
@@ -28,7 +28,7 @@ function post_family_tweaks__nanopir6s_naming_udev_network_interfaces() {
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
 	cat <<- EOF > "${SDCARD}/etc/udev/rules.d/70-persistent-net.rules"
-		SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", KERNELS=="fe1c0000.ethernet", NAME:="wan"
+		SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", KERNELS=="fe1c0000.ethernet", NAME:="wan1"
 		SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8169", KERNELS=="0003:31:00.0", NAME:="lan1"
 		SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8169", KERNELS=="0004:41:00.0", NAME:="lan2"
 	EOF


### PR DESCRIPTION
# Description

Reference: https://github.com/armbian/build/blob/main/extensions/network/config-networkd/netplan/10-dhcp-all-interfaces.yaml#L25

# How Has This Been Tested?

- Tested on HW

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
