### PR TITLE
K3: enable APA by default for Texas Instruments K3 family SBC

### DIFF
--- a/config/sources/families/k3.conf
+++ b/config/sources/families/k3.conf
@@ -27,7 +27,7 @@ if [[ "${CC33XX_SUPPORT}" == "yes" ]] ; then
 	fi
 fi
 
-enable_extension "ti-debpkgs"
+enable_extension "ti-debpkgs apa"
 
 case "${BRANCH}" in
 


### PR DESCRIPTION
I would like to invite Texas Instrument to offload some of the worries of creating and maintaining a distribution for their hardware to [APA](https://github.com/armbian/apa/).  This PR commits a very minimal change affecting not much more than that, it would enable the APA repository and install the armbian-common package (plus the empty armbian-bsp package).  Further steps can be discussed as we did in #8305.

armbian-common allows better management after image flashing, let's say for example if a GPG needs to be updated a year or two from now.  To that end, I have already [included a TI's GPG signing key in armbian-common](https://github.com/armbian/apa/blob/main/files/armbian-common/usr/share/keyrings/texasinstruments-keyring.gpg).  If ever the key became compromised, TI currently has no easy way of sending out an update.  With APA there would be.  I am happy to keep your key in armbian-common or move it to a dedicated package in the future.