### PR TITLE
Allwinner kernel: bump current to 6.12.35 and edge to 6.15.4

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -31,12 +31,12 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.30"
+		declare -g KERNELBRANCH="tag:v6.12.35"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.15"
+		declare -g KERNELBRANCH="tag:v6.15.4"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -32,12 +32,12 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.30"
+		declare -g KERNELBRANCH="tag:v6.12.35"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.15"
+		declare -g KERNELBRANCH="tag:v6.15.4"
 		;;
 esac
 

--- a/patch/kernel/archive/sunxi-6.12/patches.megous/power-supply-axp20x-battery-Add-support-for-POWER_SUPPLY_PROP_E.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.megous/power-supply-axp20x-battery-Add-support-for-POWER_SUPPLY_PROP_E.patch
@@ -15,11 +15,12 @@ diff --git a/drivers/power/supply/axp20x_battery.c b/drivers/power/supply/axp20x
 index 67e35b27382c..950490fc9740 100644
 --- a/drivers/power/supply/axp20x_battery.c
 +++ b/drivers/power/supply/axp20x_battery.c
-@@ -127,6 +127,7 @@ struct axp20x_batt_ps {
+@@ -127,7 +127,8 @@ struct axp20x_batt_ps {
  	/* Maximum constant charge current */
  	unsigned int max_ccc;
  	const struct axp_data	*data;
 +	struct power_supply_battery_info *info;
+ 	bool ts_disable;
  };
  
  static int axp20x_battery_get_max_voltage(struct axp20x_batt_ps *axp20x_batt,

--- a/patch/kernel/archive/sunxi-6.12/series.armbian
+++ b/patch/kernel/archive/sunxi-6.12/series.armbian
@@ -26,7 +26,7 @@
 	patches.armbian/drv-mtd-nand-raw-nand_ids.c-add-H27UBG8T2BTR-BC-nand.patch
 	patches.armbian/drv-mfd-axp20x-add-sysfs-interface.patch
 	patches.armbian/drv-spi-spidev-Add-armbian-spi-dev-compatible.patch
-	patches.armbian/drv-spi-spi-sun4i.c-spi-bug-low-on-sck.patch
+-	patches.armbian/drv-spi-spi-sun4i.c-spi-bug-low-on-sck.patch
 	patches.armbian/drv-rtc-sun6i-Add-Allwinner-H616-support.patch
 	patches.armbian/drv-nvmem-sunxi_sid-Support-SID-on-H616.patch
 	patches.armbian/drv-iio-adc-axp20x_adc-arm64-dts-axp803-hwmon-enable-thermal.patch
@@ -147,7 +147,7 @@
 	patches.armbian/arm-dts-sun8i-h2-plus-orangepi-zero-fix-xradio-interrupt.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h6-Fix-H6-emmc.patch
 	patches.armbian/arm64-dts-sun50i-h5-nanopi-r1s-h5-add-rtl8153-support.patch
-	patches.armbian/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
+-	patches.armbian/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-sd-emmc.patch
 	patches.armbian/ARM-dts-sun8i-nanopiduo2-Use-key-0-as-power-button.patch
 	patches.armbian/ARM-dts-sun8i-nanopiduo2-enable-ethernet.patch

--- a/patch/kernel/archive/sunxi-6.12/series.conf
+++ b/patch/kernel/archive/sunxi-6.12/series.conf
@@ -322,7 +322,7 @@
 	patches.armbian/drv-mtd-nand-raw-nand_ids.c-add-H27UBG8T2BTR-BC-nand.patch
 	patches.armbian/drv-mfd-axp20x-add-sysfs-interface.patch
 	patches.armbian/drv-spi-spidev-Add-armbian-spi-dev-compatible.patch
-	patches.armbian/drv-spi-spi-sun4i.c-spi-bug-low-on-sck.patch
+-	patches.armbian/drv-spi-spi-sun4i.c-spi-bug-low-on-sck.patch
 	patches.armbian/drv-rtc-sun6i-Add-Allwinner-H616-support.patch
 	patches.armbian/drv-nvmem-sunxi_sid-Support-SID-on-H616.patch
 	patches.armbian/drv-iio-adc-axp20x_adc-arm64-dts-axp803-hwmon-enable-thermal.patch
@@ -445,7 +445,7 @@
 	patches.armbian/arm-dts-sun8i-h2-plus-orangepi-zero-fix-xradio-interrupt.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h6-Fix-H6-emmc.patch
 	patches.armbian/arm64-dts-sun50i-h5-nanopi-r1s-h5-add-rtl8153-support.patch
-	patches.armbian/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
+-	patches.armbian/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-sd-emmc.patch
 	patches.armbian/ARM-dts-sun8i-nanopiduo2-Use-key-0-as-power-button.patch
 	patches.armbian/ARM-dts-sun8i-nanopiduo2-enable-ethernet.patch


### PR DESCRIPTION
# Description

- bump Allwinner to latest.
- disable integrated patches
- adjust broken patches

# How Has This Been Tested?

- [x] Build and boot on H6 device

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
