### PR TITLE
enable apa extension by default for BPi M2+ board

### DIFF
--- a/config/boards/bananapim2plus.conf
+++ b/config/boards/bananapim2plus.conf
@@ -9,3 +9,5 @@ MODULES_LEGACY="g_serial"
 SERIALCON="ttyS0,ttyGS0"
 KERNEL_TARGET="legacy,current,edge"
 KERNEL_TEST_TARGET="current"
+
+enable_extension "apa"


### PR DESCRIPTION
As the maintainer of the BPi M2+ I would like to enable APA extension by default for this board.