### PR TITLE
config: update plasma-workspace packages definition for Qualcomm RB5

### DIFF
--- a/config/boards/qcom-robotics-rb5.conf
+++ b/config/boards/qcom-robotics-rb5.conf
@@ -85,7 +85,7 @@ function post_family_tweaks__qcom-robotics-rb5_extra_packages() {
 
 	if [[ "${DESKTOP_ENVIRONMENT}" == "kde-plasma" ]]; then
 		display_alert "Adding Extra KDE Package" "${BOARD}" "info"
-		do_with_retries 3 chroot_sdcard_apt_get_install plasma-workspace-wayland plasma-desktop plasma-systemmonitor plasma-nm kde-standard kde-spectacle kinfocenter kscreen krfb kfind filelight \
+		do_with_retries 3 chroot_sdcard_apt_get_install plasma-workspace plasma-desktop plasma-systemmonitor plasma-nm kde-standard kde-spectacle kinfocenter kscreen krfb kfind filelight \
 		dolphin clinfo vulkan-tools wayland-utils
 	fi
 


### PR DESCRIPTION
Since July of 2024 plasma-workspace package in Debian has usurped plasma-workspace-wayland package

https://salsa.debian.org/qt-kde-team/kde/plasma-workspace/-/commit/c9080bcf02bd85b425eefa2390f74c793eadddd3

This leads to FTBFS for newer distro releases.
