### PR TITLE
Fix odroid-c4 i2c overlays, meson64-6.15

### DIFF
--- a/patch/kernel/archive/meson64-6.15/overlay/meson-sm1-odroid-c4-i2c0.dtso
+++ b/patch/kernel/archive/meson64-6.15/overlay/meson-sm1-odroid-c4-i2c0.dtso
@@ -21,4 +21,12 @@
 		};
 	};
 
+	fragment@2 {
+		target = <&periphs_pinctrl>;
+		__overlay__ {
+			i2c2_sda_x_pins: i2c2-sda-x { };
+			i2c2_sck_x_pins: i2c2-sck-x { };
+		};
+	};
+
 };

--- a/patch/kernel/archive/meson64-6.15/overlay/meson-sm1-odroid-c4-i2c1.dtso
+++ b/patch/kernel/archive/meson64-6.15/overlay/meson-sm1-odroid-c4-i2c1.dtso
@@ -21,4 +21,12 @@
 		};
 	};
 
+	fragment@2 {
+		target = <&periphs_pinctrl>;
+		__overlay__ {
+			i2c3_sck_a_pins: i2c3-sda-a { };
+			i2c3_sda_a_pins: i2c3-sck-a { };
+		};
+	};
+
 };


### PR DESCRIPTION
This is a follow up of #8352. This PR is for the `meson64-6.15` kernel, where #8352 was for `meson64-6.12`.

The contents of #8352 are copied below.

# Description

The existing odroid-c4 specific i2c overlay files that are shipped with Armbian 25.5.2 bookworm do not enable i2c functionality.  
Applying this small modification to the source files, adding to the system and rebooting, i2c functionality is observed and able to be used.

# How Has This Been Tested?

- [x] Apply the original dtbo overlays. After a reboot, observe that i2c functionality is not enabled.
- [x] Apply the fixed dts, compile to dtbo. After a reboot, observe that i2c functionality _is_ enabled.

* Using existing overlay files, both `meson-sm1-odroid-c4-i2c0.dtbo` and `meson-sm1-odroid-c4-i2c1.dtbo` from `/boot/dtb-6.12.32-current-meson64/amlogic/overlay/` with a `/boot/armbianEnv.txt` like so:  
```
verbosity=1
console=both
overlay_prefix=meson
rootdev=UUID=4d762a48-122d-482b-9803-7eabc89c2bd8
rootfstype=ext4
user_overlays=
overlays=meson-sm1-odroid-c4-i2c0 meson-sm1-odroid-c4-i2c1
usbstoragequirks=0x2537:0x1066:u,0x2537:0x1068:u
```
After a reboot, observe:
```
~# ls -al /sys/class/i2c-dev/
total 0
drwxr-xr-x  2 root root 0 Dec 31  1969 .
drwxr-xr-x 72 root root 0 Dec 31  1969 ..
lrwxrwxrwx  1 root root 0 Dec 31  1969 i2c-0 -> ../../devices/platform/soc/ff600000.bus/ff600000.hdmi-tx/i2c-0/i2c-dev/i2c-0
```

* Using the included fixed overlay files, both `meson-sm1-odroid-c4-i2c0.dtso` and `meson-sm1-odroid-c4-i2c1.dtso` (files renamed to *.dts on my test system to allow `armbian-add-overlay` compatibility) with a `/boot/armbianEnv.txt` like so:  
```
verbosity=1
console=both
overlay_prefix=meson
rootdev=UUID=4d762a48-122d-482b-9803-7eabc89c2bd8
rootfstype=ext4
user_overlays=meson-sm1-odroid-c4-i2c0 meson-sm1-odroid-c4-i2c1
overlays=
usbstoragequirks=0x2537:0x1066:u,0x2537:0x1068:u
```
After a reboot, observe:
```
~# ls -al /sys/class/i2c-dev/
total 0
drwxr-xr-x  2 root root 0 Dec 31  1969 .
drwxr-xr-x 72 root root 0 Dec 31  1969 ..
lrwxrwxrwx  1 root root 0 Dec 31  1969 i2c-0 -> ../../devices/platform/soc/ffd00000.bus/ffd1d000.i2c/i2c-0/i2c-dev/i2c-0
lrwxrwxrwx  1 root root 0 Dec 31  1969 i2c-1 -> ../../devices/platform/soc/ffd00000.bus/ffd1c000.i2c/i2c-1/i2c-dev/i2c-1
lrwxrwxrwx  1 root root 0 Dec 31  1969 i2c-2 -> ../../devices/platform/soc/ff600000.bus/ff600000.hdmi-tx/i2c-2/i2c-dev/i2c-2
```

We can see that the i2c-0 and i2c-1 devices are now present, and they are aliased as expected to maintain HardKernel compatibility (i.e. i2c2 is aliased to i2c-0 and i2c3 is aliased to i2c-1).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

