### PR TITLE
enable APA extension for Debian Unstable builds

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -319,6 +319,9 @@ function do_main_configuration() {
 			;;
 	esac
 
+        # enable APA extension for Debian Unstable release
+        [ "$RELEASE" = "sid" ] && enable_extension "apa"
+
 	## Extensions: at this point we've sourced all the config files that will be used,
 	##             and (hopefully) not yet invoked any extension methods. So this is the perfect
 	##             place to initialize the extension manager. It will create functions


### PR DESCRIPTION
# Description

Eventually, we want to move packaging logic out of Armbian core and let [APA](https://github.com/armbian/apa/) handle that.  It was decided to use Debian Unstable release pocket as a canary testing ground.  That's what this commit implements.  After this commit is applied, Debian Unstable images will have APA enabled by default.

how to use: "./compile.sh RELEASE=sid"