### PR TITLE
Revert "rootfs: allow APA to handle GPG keys when it is active"

### DIFF
--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -162,7 +162,7 @@ function create_sources_list_and_deploy_repo_key() {
 	mkdir -p "${basedir}"/usr/share/keyrings
 	# change to binary form
 	APT_SIGNING_KEY_FILE="/usr/share/keyrings/armbian-archive-keyring.gpg"
-	gpg --dearmor < "${SRC}"/config/armbian.key > "${basedir}${APT_SIGNING_KEY_FILE}"
+	gpg --batch --yes --dearmor < "${SRC}"/config/armbian.key > "${basedir}${APT_SIGNING_KEY_FILE}"
 
 	# lets link to the old file as armbian-config uses it and we can't set there to new file
 	# we user force linking as some old caches still exists

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -80,8 +80,6 @@ function create_sources_list_and_deploy_repo_key() {
 
 	declare distro=""
 
-	APT_SIGNING_KEY_FILE="/usr/share/keyrings/armbian-archive-keyring.gpg"
-
 	# Drop deboostrap sources leftovers
 	rm -f "${basedir}/etc/apt/sources.list"
 
@@ -159,23 +157,21 @@ function create_sources_list_and_deploy_repo_key() {
 			;;
 	esac
 
-	# code to be made obsolete by making APA part of Armbian Core. #XXX
-	if [[ "${APA_IS_ACTIVE}" != "true" ]]; then
-		# add armbian key
-		display_alert "Adding Armbian repository and authentication key" "${when} :: /etc/apt/sources.list.d/armbian.sources" "info"
-		mkdir -p "${basedir}"/usr/share/keyrings
-		# change to binary form
-		gpg --dearmor < "${SRC}"/config/armbian.key > "${basedir}${APT_SIGNING_KEY_FILE}"
+	# add armbian key
+	display_alert "Adding Armbian repository and authentication key" "${when} :: /etc/apt/sources.list.d/armbian.sources" "info"
+	mkdir -p "${basedir}"/usr/share/keyrings
+	# change to binary form
+	APT_SIGNING_KEY_FILE="/usr/share/keyrings/armbian-archive-keyring.gpg"
+	gpg --dearmor < "${SRC}"/config/armbian.key > "${basedir}${APT_SIGNING_KEY_FILE}"
 
-		# lets link to the old file as armbian-config uses it and we can't set there to new file
-		# we user force linking as some old caches still exists
-		chroot "${basedir}" /bin/bash -c "ln -fs armbian-archive-keyring.gpg /usr/share/keyrings/armbian.gpg"
+	# lets link to the old file as armbian-config uses it and we can't set there to new file
+	# we user force linking as some old caches still exists
+	chroot "${basedir}" /bin/bash -c "ln -fs armbian-archive-keyring.gpg /usr/share/keyrings/armbian.gpg"
 
-		# lets keep old way for old distributions
-		if [[ "${RELEASE}" =~ (focal|bullseye) ]]; then
-			cp "${SRC}"/config/armbian.key "${basedir}"
-			chroot "${basedir}" /bin/bash -c "cat armbian.key | apt-key add - > /dev/null 2>&1"
-		fi
+	# lets keep old way for old distributions
+	if [[ "${RELEASE}" =~ (focal|bullseye) ]]; then
+		cp "${SRC}"/config/armbian.key "${basedir}"
+		chroot "${basedir}" /bin/bash -c "cat armbian.key | apt-key add - > /dev/null 2>&1"
 	fi
 
 	# Add Armbian APT repository


### PR DESCRIPTION
This reverts commit 034e9253cdf2 from #8316.  That commit was trying to take a misguided step in obsoleting some code and move it into APA.  The code is currently needed and will result in FTBFS if absent although that is masked if armbian-common is present in the debs cache during build-time.
