### PR TITLE
sakurapi-rk3308b: add pcm5102a dt overlay

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/overlay/rockchip-sakurapi-rk3308b-pcm5102a.dtso
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/rockchip-sakurapi-rk3308b-pcm5102a.dtso
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0+
+
+/*
+ * For SakuraPi Rk3308B: Enable external i2s audio module
+ *
+ * Board                  Module     Desc.
+ * I2S_LRCK_TX(2PA7) ->   LRCK       Stereo L and R
+ * I2S_MCLK(2PA4)    ->   SCK        Master Clock
+ * I2S_TXCK(2PA5)    ->   BCK        Transfer Bit Clock
+ * I2S_SD0O(2PB1)    ->   DIN        Bit Data
+ *
+ * (C) Copyright 2025 TheSnowfield <thesnowfield@sakurapi.org>
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+  fragment@0 {
+    target-path = "/";
+    __overlay__ {
+      sound {
+        compatible = "simple-audio-card";
+        simple-audio-card,format = "i2s";
+        simple-audio-card,mclk-fs = <256>;
+        simple-audio-card,name = "i2s_8ch_0";
+
+        simple-audio-card,dai-link@1 {
+          format = "i2s";
+          cpu {
+            sound-dai = <&i2s_8ch_0>;
+          };
+          codec {
+            sound-dai = <&pcm5102a>;
+          };
+        };
+      };
+
+      pcm5102a: pcm5102a {
+        #sound-dai-cells = <0>;
+        compatible = "ti,pcm5102a";
+        pcm510x,format = "i2s";
+      };
+    };
+  };
+
+  fragment@1 {
+    target = <&i2s_8ch_0>;
+    __overlay__ {
+      #sound-dai-cells = <0>;
+      status = "okay";
+    };
+  };
+};

--- a/patch/kernel/archive/rockchip64-6.16/overlay/rockchip-sakurapi-rk3308b-pcm5102a.dtso
+++ b/patch/kernel/archive/rockchip64-6.16/overlay/rockchip-sakurapi-rk3308b-pcm5102a.dtso
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0+
+
+/*
+ * For SakuraPi Rk3308B: Enable external i2s audio module
+ *
+ * Board                  Module     Desc.
+ * I2S_LRCK_TX(2PA7) ->   LRCK       Stereo L and R
+ * I2S_MCLK(2PA4)    ->   SCK        Master Clock
+ * I2S_TXCK(2PA5)    ->   BCK        Transfer Bit Clock
+ * I2S_SD0O(2PB1)    ->   DIN        Bit Data
+ *
+ * (C) Copyright 2025 TheSnowfield <thesnowfield@sakurapi.org>
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+  fragment@0 {
+    target-path = "/";
+    __overlay__ {
+      sound {
+        compatible = "simple-audio-card";
+        simple-audio-card,format = "i2s";
+        simple-audio-card,mclk-fs = <256>;
+        simple-audio-card,name = "i2s_8ch_0";
+
+        simple-audio-card,dai-link@1 {
+          format = "i2s";
+          cpu {
+            sound-dai = <&i2s_8ch_0>;
+          };
+          codec {
+            sound-dai = <&pcm5102a>;
+          };
+        };
+      };
+
+      pcm5102a: pcm5102a {
+        #sound-dai-cells = <0>;
+        compatible = "ti,pcm5102a";
+        pcm510x,format = "i2s";
+      };
+    };
+  };
+
+  fragment@1 {
+    target = <&i2s_8ch_0>;
+    __overlay__ {
+      #sound-dai-cells = <0>;
+      status = "okay";
+    };
+  };
+};


### PR DESCRIPTION
# Description
This PR adds a DT overlay to make the Sakura Pi RK3308B drive an external I2S module(PCM5102A). 

# Checklist:

- [x] I have tested on Sakura Pi RK3308B
- [x] Stereo Output is operational
- [x] HiFi (yes!)