### PR TITLE
UEFI arm64: add cloud branch to the board config

### DIFF
--- a/config/boards/uefi-arm64.conf
+++ b/config/boards/uefi-arm64.conf
@@ -2,6 +2,6 @@
 declare -g BOARD_NAME="UEFI arm64"
 declare -g BOARDFAMILY="uefi-arm64"
 declare -g BOARD_MAINTAINER="rpardini"
-declare -g KERNEL_TARGET="legacy,current,edge"
+declare -g KERNEL_TARGET="legacy,current,edge,cloud"
 declare -g KERNEL_TEST_TARGET="current"
 declare -g BOOT_LOGO=desktop


### PR DESCRIPTION
# Description

While adding cloud branch, we forget to add this to the board config. Everything else exists and images were already tested on netcup VPS instances.