### PR TITLE
config: boards: pocketbeagle2: Enable better USB Gadget

### DIFF
--- a/config/boards/pocketbeagle2.conf
+++ b/config/boards/pocketbeagle2.conf
@@ -10,12 +10,54 @@ TIBOOT3_FILE="tiboot3-am62x-hs-fs-evm.bin"
 DEFAULT_CONSOLE="serial"
 KERNEL_TARGET="edge"
 KERNEL_TEST_TARGET="edge"
-SERIALCON="ttyS2,ttyGS0"
+SERIALCON="ttyS2"
 ATF_BOARD="lite"
 SRC_EXTLINUX="yes"
-SRC_CMDLINE="root=/dev/mmcblk1p2 rootwait console=ttyS2,115200n8 console=ttyGS0,115200n8 modules-load=dwc2,g_cdc"
+SRC_CMDLINE="root=/dev/mmcblk1p2 rootwait console=ttyS2,115200n8"
 BOOT_FDT_FILE="ti/k3-am6232-pocketbeagle2.dtb"
 OPTEE_PLATFORM="k3-am62x"
+
+# USB Gadget
+function post_family_tweaks_bsp__pocketbeagle2_firmware() {
+	display_alert "Setup USB Gadget for ${BOARD}" "${RELEASE}" "warn"
+
+	# USB Gadget Network service
+	mkdir -p $destination/usr/local/bin/
+	mkdir -p $destination/usr/lib/systemd/system/
+	mkdir -p $destination/etc/initramfs-tools/scripts/init-bottom/
+	# The service expects the name setup-usbgadget-network.sh. Depending on the board vendor, the
+	# usbgadget configuration they would like can be wildly different. However, the same service
+	# will work fine for almost all cases. So better to rename file rather than modifying the service.
+	install -Dm755 $SRC/packages/bsp/usb-gadget-network/setup-usbgadget-network-multi.sh $destination/usr/local/bin/setup-usbgadget-network.sh ||
+		exit_with_error "Failed to install USB gadget setup script"
+	install -Dm755 $SRC/packages/bsp/usb-gadget-network/remove-usbgadget-network.sh $destination/usr/local/bin/ ||
+		exit_with_error "Failed to install USB gadget remove script"
+	install -Dm744 $SRC/packages/bsp/usb-gadget-network/usbgadget-rndis.service $destination/usr/lib/systemd/system/ ||
+		exit_with_error "Failed to install USB gadget service"
+	install -Dm755 $SRC/packages/bsp/usb-gadget-network/usb-gadget-initramfs-hook $destination/etc/initramfs-tools/hooks/usb-gadget ||
+		exit_with_error "Failed to install USB gadget initramfs hook"
+	install -Dm755 $SRC/packages/bsp/usb-gadget-network/usb-gadget-initramfs-premount $destination/etc/initramfs-tools/scripts/init-premount/usb-gadget ||
+		exit_with_error "Failed to install USB gadget initramfs premount script"
+	install -Dm755 $SRC/packages/bsp/usb-gadget-network/dropbear $destination/etc/initramfs-tools/scripts/init-premount/ ||
+		exit_with_error "Failed to install USB gadget initramfs premount dropbear"
+	install -Dm755 $SRC/packages/bsp/usb-gadget-network/kill-dropbear $destination/etc/initramfs-tools/scripts/init-bottom/ ||
+		exit_with_error "Failed to install USB gadget initramfs premount kill dropbear"
+}
+
+function post_family_tweaks__pocketbeagle2_enable_services() {
+	display_alert "Enable Services for ${BOARD}" "${RELEASE}" "warn"
+
+	# We need unudhcpd from armbian repo, so enable it
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.sources
+	do_with_retries 3 chroot_sdcard_apt_get_install unudhcpd
+	# disable armbian repo back
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled
+
+	chroot_sdcard systemctl enable usbgadget-rndis.service
+	# We want custom IPs. systemctl edit does not seem to work in chroot.
+	mkdir -p "${SDCARD}"/etc/systemd/system/usbgadget-rndis.service.d
+	echo -e "[Service]\nEnvironment=\"unudhcpd_host_ip=192.168.7.2\"\nEnvironment=\"unudhcpd_client_ip=192.168.7.3\"" > "${SDCARD}"/etc/systemd/system/usbgadget-rndis.service.d/override.conf
+}
 
 function current_beagle_kernel_uboot() {
 	declare -g KERNELSOURCE="https://github.com/beagleboard/linux" # BeagleBoard kernel

--- a/packages/bsp/usb-gadget-network/setup-usbgadget-network-multi.sh
+++ b/packages/bsp/usb-gadget-network/setup-usbgadget-network-multi.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -euo pipefail
+
+deviceinfo_name="USB Gadget Network"
+deviceinfo_manufacturer="Armbian"
+#deviceinfo_usb_idVendor=
+#deviceinfo_usb_idProduct=
+#deviceinfo_usb_serialnumber=
+
+exit_with_error() {
+	echo "$1"
+	exit 1
+}
+
+setup_usb_network_configfs() {
+	# See: https://www.kernel.org/doc/Documentation/usb/gadget_configfs.txt
+	CONFIGFS=/sys/kernel/config/usb_gadget
+
+	if ! [ -e "$CONFIGFS" ]; then
+		exit_with_error "$CONFIGFS does not exist, skipping configfs usb gadget"
+	fi
+
+	if [ -e "$CONFIGFS/g1" ]; then
+		echo "$CONFIGFS/g1 already exists, skipping configfs usb gadget"
+		return
+	fi
+
+	# Default values for USB-related deviceinfo variables
+	usb_idVendor="${deviceinfo_usb_idVendor:-0x1D6B}"   # Linux Foundation
+	usb_idProduct="${deviceinfo_usb_idProduct:-0x0104}" # Multifunction Composite Gadget
+	usb_serialnumber="${deviceinfo_usb_serialnumber:-0123456789}"
+	usb_network_function="ncm.usb0"
+	usb_serial_function="acm.usb0"
+
+	echo "Setting up an USB gadget through configfs"
+	# Create an usb gadet configuration
+	mkdir $CONFIGFS/g1 || exit_with_error "Couldn't create $CONFIGFS/g1"
+	echo "$usb_idVendor" > "$CONFIGFS/g1/idVendor"
+	echo "$usb_idProduct" > "$CONFIGFS/g1/idProduct"
+	echo 0x0404 > "$CONFIGFS/g1/bcdDevice"
+	echo 0x0200 > "$CONFIGFS/g1/bcdUSB"
+
+	# Create english (0x409) strings
+	mkdir $CONFIGFS/g1/strings/0x409 || echo "Couldn't create $CONFIGFS/g1/strings/0x409"
+
+	# shellcheck disable=SC2154
+	echo "$deviceinfo_manufacturer" > "$CONFIGFS/g1/strings/0x409/manufacturer"
+	echo "$usb_serialnumber" > "$CONFIGFS/g1/strings/0x409/serialnumber"
+	# shellcheck disable=SC2154
+	echo "$deviceinfo_name" > "$CONFIGFS/g1/strings/0x409/product"
+
+	# Create network function.
+	mkdir $CONFIGFS/g1/functions/"$usb_network_function" ||
+		echo "Couldn't create $CONFIGFS/g1/functions/$usb_network_function"
+
+	# Create configuration instance for the gadget
+	mkdir $CONFIGFS/g1/configs/c.1 ||
+		echo "Couldn't create $CONFIGFS/g1/configs/c.1"
+	echo 250 > $CONFIGFS/g1/configs/c.1/MaxPower
+	mkdir $CONFIGFS/g1/configs/c.1/strings/0x409 ||
+		echo "Couldn't create $CONFIGFS/g1/configs/c.1/strings/0x409"
+	echo "NCM Configuration" > $CONFIGFS/g1/configs/c.1/strings/0x409/configuration ||
+		echo "Couldn't write configration name"
+
+	# Link the network instance to the configuration
+	ln -s $CONFIGFS/g1/functions/"$usb_network_function" $CONFIGFS/g1/configs/c.1 ||
+		echo "Couldn't symlink $usb_network_function"
+
+	mkdir -p $CONFIGFS/g1/functions/"$usb_serial_function" ||
+		echo "Couldn't create $CONFIGFS/g1/functions/$usb_serial_function"
+	ln -s $CONFIGFS/g1/functions/"$usb_serial_function" $CONFIGFS/g1/configs/c.1 ||
+		echo "Couldn't symlink $usb_serial_function"
+
+	# Check if there's an USB Device Controller
+	if [ ! -d /sys/class/udc ] || [ -z "$(ls /sys/class/udc 2>/dev/null)" ]; then
+		exit_with_error "No USB Device Controller available"
+	fi
+
+	# Link the gadget instance to an USB Device Controller. This activates the gadget.
+	# See also: https://github.com/postmarketOS/pmbootstrap/issues/338
+	# shellcheck disable=SC2005
+	ls /sys/class/udc | head -1 > $CONFIGFS/g1/UDC || exit_with_error "Couldn't write UDC"
+}
+
+set_usbgadget_ipaddress() {
+	local host_ip="${unudhcpd_host_ip:-172.16.42.1}"
+	local client_ip="${unudhcpd_client_ip:-172.16.42.2}"
+	echo "Starting dnsmasq with server ip $host_ip, client ip: $client_ip"
+	# Get usb interface
+	INTERFACE=""
+	ip addr replace "${host_ip}/16" dev usb0 2>/dev/null && ip link set usb0 up && INTERFACE=usb0
+	if [ -z "$INTERFACE" ]; then
+		echo "Interfaces:"
+		ip link
+		exit_with_error "Could not find an interface to run a dhcp server on"
+	fi
+
+	echo "Using interface $INTERFACE"
+	echo "Starting the DHCP daemon"
+	ip a show $INTERFACE > /var/log/unudhcpd.log
+	nohup /usr/bin/unudhcpd -i "$INTERFACE" -s "$host_ip" -c "$client_ip" >> /var/log/unudhcpd.log 2>&1 &
+	return
+}
+setup_usb_network_configfs
+set_usbgadget_ipaddress


### PR DESCRIPTION
# Description

Enable [Multifunction Composite Gadget](https://www.kernel.org/doc/html/latest/usb/gadget_multi.html) for PocketBeagle 2. This allows ssh over USB with zero configuration by the user.

Currently, enabling `ttyGS0` causes armbian-first-run to not work, so had to disable it. Will work on finding a solution for it.

`setup-usbgadget-network-multi.sh` uses `setup-usbgadget-network.sh` as a base but exposes a Multifunction Composite Gadget instead of just NCM.

# How Has This Been Tested?

- [x] Tested on PocketBeagle 2 rev A0.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
