### PR TITLE
Add board KickPi K2B and AIC8800 SDIO Wireless

### DIFF
--- a/config/boards/kickpik2b.conf
+++ b/config/boards/kickpik2b.conf
@@ -22,6 +22,7 @@ function post_family_tweaks_bsp__kickpi_k2b_aic8800() {
 	mkdir -p "${destination}"/usr/bin
 	# Install firmware
 	git clone --depth=1 -q -b aic8800_sdio https://github.com/pyavitz/firmware.git "${destination}"/lib/firmware/updates/aic8800
+	rm -fdr "${destination}"/lib/firmware/updates/aic8800/.git
 	# Add udev rule
 	cat <<EOF > "${destination}"/etc/modprobe.d/aic8800-wireless.conf
 options aic8800_fdrv aicwf_dbg_level=0 custregd=0 ps_on=0

--- a/config/boards/kickpik2b.conf
+++ b/config/boards/kickpik2b.conf
@@ -1,0 +1,77 @@
+# Allwinner H618 quad core 1/2/4GB RAM SoC WiFi SPI USB-C
+BOARD_NAME="KickPi K2B"
+BOARDFAMILY="sun50iw9-bpi"
+BOARD_MAINTAINER="pyavitz"
+BOOTCONFIG="kickpi_k2b_defconfig"
+OVERLAY_PREFIX="sun50i-h616"
+BOOT_FDT_FILE="sun50i-h618-kickpi-k2b.dtb"
+BOOT_LOGO="desktop"
+KERNEL_TARGET="current,edge"
+KERNEL_TEST_TARGET="current"
+FORCE_BOOTSCRIPT_UPDATE="yes"
+BOOTBRANCH_BOARD="tag:v2025.01"
+BOOTPATCHDIR="v2025.01"
+PACKAGE_LIST_BOARD="rfkill bluetooth bluez bluez-tools"
+
+function post_family_tweaks_bsp__kickpi_k2b_aic8800() {
+	display_alert "$BOARD" "Installing AIC8800 Support" "info"
+	mkdir -p "${destination}"/etc/modprobe.d
+	mkdir -p "${destination}"/etc/modules-load.d
+	mkdir -p "${destination}"/etc/systemd/system
+	mkdir -p "${destination}"/lib/firmware/updates
+	mkdir -p "${destination}"/usr/bin
+	# Install firmware
+	git clone --depth=1 -q -b aic8800_sdio https://github.com/pyavitz/firmware.git "${destination}"/lib/firmware/updates/aic8800
+	# Add udev rule
+	cat <<EOF > "${destination}"/etc/modprobe.d/aic8800-wireless.conf
+options aic8800_fdrv aicwf_dbg_level=0 custregd=0 ps_on=0
+EOF
+	# Add needed bluetooth modules
+	cat <<EOF > "${destination}"/etc/modules-load.d/aic8800-btlpm.conf
+hidp
+rfcomm
+bnep
+aic8800_btlpm
+EOF
+	# Install Bluetooth helper script and service
+	cat <<EOF > "${destination}"/usr/bin/aic-bthelper
+#!/bin/bash
+
+# HW Reset
+hciattach -r -s 1500000 /dev/ttyS1 any 1500000 flow nosleep > /dev/null 2>&1
+
+# Kill hciattach
+sleep .50
+killall hciattach
+
+# Attach Bluetooth HCI UART
+sleep .50
+hciattach -s 1500000 /dev/ttyS1 any 1500000 flow nosleep > /dev/null 2>&1
+rfkill unblock all
+
+exit 0
+EOF
+	chmod +x "${destination}"/usr/bin/aic-bthelper
+	cat <<EOF > "${destination}"/etc/systemd/system/bthelper.service
+[Unit]
+Description=Bluetooth Helper
+After=bluetooth.service bluetooth.target getty.target
+Requires=bluetooth.service bluetooth.target getty.target
+
+[Service]
+Type=idle
+ExecStartPre=/usr/sbin/rfkill unblock all
+ExecStart=/usr/bin/aic-bthelper
+TimeoutStartSec=0
+RemainAfterExit=yes
+SysVStartPriority=99
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+function post_family_tweaks__enable_aic8800_bthelper() {
+	display_alert "$BOARD" "Enabling AIC8800 Bluetooth Helper" "info"
+	chroot_sdcard systemctl --no-reload enable bthelper.service
+}

--- a/lib/functions/compilation/patch/drivers-harness.sh
+++ b/lib/functions/compilation/patch/drivers-harness.sh
@@ -103,6 +103,7 @@ function kernel_drivers_prepare_harness() {
 		driver_generic_bring_back_ipx
 		driver_mt7921u_add_pids
 		driver_rtl8152_rtl8153
+		driver_aic8800_sdio
 		driver_rtl8189ES
 		driver_rtl8189FS
 		driver_rtl8192EU

--- a/patch/kernel/archive/sunxi-6.12/0000.patching_config.yaml
+++ b/patch/kernel/archive/sunxi-6.12/0000.patching_config.yaml
@@ -1,0 +1,38 @@
+config:
+
+  # Just some info stuff; not used by the patching scripts
+  name: sunxi-6.12
+  kind: kernel
+  type: mainline # or: mainline
+  branch: linux-6.12.y
+  last-known-good-tag: v6.7.0
+  maintainers:
+    - { github: pyavitz, name: Patrick Yavitz, email: pyavitz@gmail.com, armbian-forum: c0rnelius }
+
+  # .dts files in these directories will be copied as-is to the build tree; later ones overwrite earlier ones.
+  # This is meant to provide a way to "add a board DTS" without having to null-patch them in.
+  dts-directories:
+    # will copy patch/kernel/archive/meson64-MAJOR.MINOR/dt-boards/*.dts to arch/arm64/boot/dts/allwinner
+    - { source: "dt", target: "arch/arm64/boot/dts/allwinner" }
+
+  # every file in these directories will be copied as-is to the build tree; later ones overwrite earlier ones
+  # This is meant as a way to have overlays, bare, in a directory, without having to null-patch them in.
+  # @TODO need a solution to auto-Makefile the overlays as well
+#  overlay-directories:
+    # will copy patch/kernel/archive/meson64-MAJOR.MINOR/overlay/**/* to arch/arm64/boot/dts/allwinner/overlay
+#    - { source: "overlay", target: "arch/arm64/boot/dts/allwinner/overlay" }
+
+  # the Makefile in each of these directories will be magically patched to include the dts files copied
+  #  or patched-in; overlay subdir will be included "-y" if it exists.
+  # No more Makefile patching needed, yay!
+  auto-patch-dt-makefile:
+    - { directory: "arch/arm64/boot/dts/allwinner", config-var: "CONFIG_ARCH_SUNXI" }
+
+  # configuration for when applying patches to git / auto-rewriting patches (development cycle helpers)
+  patches-to-git:
+    do-not-commit-files:
+      - "MAINTAINERS" # constant churn, drop them. sorry.
+      - "Documentation/devicetree/bindings/arm/allwinner.yaml" # constant churn, conflicts on every bump, drop it. sorry.
+    do-not-commit-regexes: # Python-style regexes
+      - "^arch/([a-zA-Z0-9]+)/boot/dts/([a-zA-Z0-9]+)/Makefile$" # ignore DT Makefile patches, we've an auto-patcher now
+

--- a/patch/kernel/archive/sunxi-6.12/dt/sun50i-h618-kickpi-k2b.dts
+++ b/patch/kernel/archive/sunxi-6.12/dt/sun50i-h618-kickpi-k2b.dts
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (C) 2025 Patrick Yavitz <pyavitz@gmail.com>
+ */
+
+/dts-v1/;
+
+#include "sun50i-h616.dtsi"
+#include "sun50i-h616-cpu-opp.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/input/linux-event-codes.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "KickPi K2B";
+	compatible = "kickpi,k2b", "allwinner,sun50i-h618";
+
+	aliases {
+		ethernet0 = &emac0;
+		i2c1 = &i2c1;
+		i2c2 = &i2c2;
+		i2c3 = &i2c3;
+		i2c4 = &i2c4;
+		serial0 = &uart0;
+		serial1 = &uart1;
+		serial2 = &uart2;
+		serial5 = &uart5;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	connector {
+		compatible = "hdmi-connector";
+		type = "d";
+
+		port {
+			hdmi_con_in: endpoint {
+				remote-endpoint = <&hdmi_out_con>;
+			};
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		button-power {
+			label = "power";
+			linux,code = <KEY_POWER>;
+			gpios = <&pio 2 2 GPIO_ACTIVE_LOW>; /* PC2 */
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 8 16 GPIO_ACTIVE_HIGH>; /* PI16 */
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	reg_usb_vbus: regulator-usb-vbus {
+		/* Separate discrete regulator for the USB ports */
+		compatible = "regulator-fixed";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-name = "usb-vbus";
+		vin-supply = <&reg_vcc5v>;
+	};
+
+	reg_vcc5v: regulator-vcc5v {
+		/* Board wide 5V supply directly from the USB-C socket */
+		compatible = "regulator-fixed";
+		regulator-always-on;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-name = "vcc-5v";
+	};
+
+	reg_vcc3v3: vcc3v3 {
+		/* Discrete 3.3V regulator */
+		compatible = "regulator-fixed";
+		regulator-always-on;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-name = "vcc-3v3";
+		vin-supply = <&reg_vcc5v>;
+	};
+
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		clocks = <&rtc CLK_OSC32K_FANOUT>;
+		clock-names = "ext_clock";
+		pinctrl-0 = <&x32clk_fanout_pin>;
+		pinctrl-names = "default";
+		post-power-on-delay-ms = <100>;
+		power-off-delay-us = <5000000>;
+		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>, /* PG18 */
+			      <&pio 6 19 GPIO_ACTIVE_LOW>; /* PG19 */
+	};
+};
+
+&ahub_dam_plat {
+	status = "okay";
+};
+
+&ahub_i2s2 {
+	status = "okay";
+};
+
+&ahub1_mach {
+	status = "okay";
+};
+
+&ahub1_plat {
+	status = "okay";
+};
+
+&codec {
+	status = "okay";
+	allwinner,audio-routing = "Line Out", "LINEOUT";
+};
+
+&cpu0 {
+	cpu-supply = <&reg_dcdc2>;
+};
+
+&de {
+	status = "okay";
+};
+
+&emac0 {
+	status = "okay";
+	pinctrl-0 = <&ext_rgmii_pins>;
+	pinctrl-names = "default";
+	phy-mode = "rgmii";
+	phy-handle = <&ext_rgmii_phy>;
+	allwinner,tx-delay-ps = <700>;
+	allwinner,rx-delay-ps = <1700>;
+};
+
+&ehci0 {
+	status = "okay";
+};
+
+&ehci1 {
+	status = "okay";
+};
+
+&ehci2 {
+	status = "okay";
+};
+
+&ehci3 {
+	status = "disabled";
+};
+
+&gpu {
+	status = "okay";
+	mali-supply = <&reg_dcdc1>;
+};
+
+&hdmi {
+	status = "okay";
+};
+
+&hdmi_out {
+	hdmi_out_con: endpoint {
+		remote-endpoint = <&hdmi_con_in>;
+	};
+};
+
+&i2c1 {
+	status = "disabled";
+	pinctrl-0 = <&i2c1_ph_pins>;
+	pinctrl-names = "default";
+};
+
+&i2c2 {
+	status = "disabled";
+	pinctrl-0 = <&i2c2_ph_pins>;
+	pinctrl-names = "default";
+};
+
+&i2c3 {
+	status = "disabled";
+	pinctrl-0 = <&i2c3_ph_pins>;
+	pinctrl-names = "default";
+};
+
+&i2c4 {
+	status = "disabled";
+	pinctrl-0 = <&i2c4_ph_pins>;
+	pinctrl-names = "default";
+};
+
+&ir {
+	status = "okay";
+	pinctrl-0 = <&ir_rx_pin>;
+	pinctrl-names = "default";
+};
+
+&mdio0 {
+	ext_rgmii_phy: ethernet-phy@1 {
+		compatible = "ethernet-phy-id001c.c916";
+		reg = <1>;
+		reset-assert-us = <20000>;
+		reset-deassert-us = <100000>;
+		reset-gpios = <&pio 8 6 GPIO_ACTIVE_LOW>; /* PI6 */
+	};
+};
+
+/* SD card */
+&mmc0 {
+	status = "okay";
+	bus-width = <4>;
+	cd-gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>;	/* PF6 */
+	cd-inverted;
+	disable-wp;
+	max-frequency = <50000000>;
+	vmmc-supply = <&reg_dldo1>;
+};
+
+/* SDIO */
+&mmc1 {
+	status = "okay";
+	bus-width = <4>;
+	keep-power-in-suspend;
+	max-frequency = <100000000>;
+	mmc-pwrseq = <&sdio_pwrseq>;
+	no-mmc;
+	no-sd;
+	non-removable;
+	vmmc-supply = <&reg_dldo1>;
+	vqmmc-supply = <&reg_aldo1>;
+
+	sdio: wifi@1 {
+		reg = <1>;
+	};
+};
+
+/* eMMC */
+&mmc2 {
+	status = "okay";
+	bus-width = <8>;
+	cap-mmc-hw-reset;
+	mmc-hs200-1_8v;
+	non-removable;
+	vmmc-supply = <&reg_dldo1>;
+	vqmmc-supply = <&reg_aldo1>;
+};
+
+&ohci0 {
+	status = "okay";
+};
+
+&ohci1 {
+	status = "okay";
+};
+
+&ohci2 {
+	status = "okay";
+};
+
+&ohci3 {
+	status = "disabled";
+};
+
+&pio {
+	vcc-pc-supply = <&reg_dldo1>;
+	vcc-pf-supply = <&reg_dldo1>;
+	vcc-pg-supply = <&reg_aldo1>;
+	vcc-ph-supply = <&reg_dldo1>;
+	vcc-pi-supply = <&reg_dldo1>;
+	vcc-pl-supply = <&reg_aldo1>;
+
+	// PI16 required for sys_led
+	ext_rgmii_pins: rgmii-pins {
+		pins = "PI0", "PI1", "PI2", "PI3", "PI4",
+		       "PI5", "PI7", "PI8", "PI9", "PI10",
+		       "PI11", "PI12", "PI13", "PI14", "PI15";
+		function = "emac0";
+		drive-strength = <40>;
+	};
+
+	//  Add I2C PH Pins
+	i2c1_ph_pins: i2c1-ph-pins {
+		pins = "PH0", "PH1";
+		function = "i2c1";
+	};
+
+	i2c2_ph_pins: i2c2-ph-pins {
+		pins = "PH2", "PH3";
+		function = "i2c2";
+	};
+
+	i2c4_ph_pins: i2c4-ph-pins {
+		pins = "PH6", "PH7";
+		function = "i2c4";
+	};
+
+	// PC0 required for spi0
+	mmc2_pins: mmc2-pins {
+		pins = "PC1", "PC5", "PC6",
+		       "PC8", "PC9", "PC10", "PC11",
+		       "PC13", "PC14", "PC15", "PC16";
+		function = "mmc2";
+		drive-strength = <30>;
+		bias-pull-up;
+	};
+};
+
+&r_i2c {
+	status = "okay";
+	axp313: pmic@36 {
+		compatible = "x-powers,axp313a";
+		reg = <0x36>;
+		#interrupt-cells = <1>;
+		interrupt-controller;
+		interrupt-parent = <&pio>;
+
+		vin1-supply = <&reg_vcc5v>;
+		vin2-supply = <&reg_vcc5v>;
+		vin3-supply = <&reg_vcc5v>;
+
+		regulators {
+			reg_aldo1: aldo1 {
+				regulator-always-on;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-name = "vcc-1v8-pll";
+			};
+
+			reg_dldo1: dldo1 {
+				regulator-always-on;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-name = "vcc-3v3-io";
+			};
+
+			reg_dcdc1: dcdc1 {
+				regulator-always-on;
+				regulator-min-microvolt = <810000>;
+				regulator-max-microvolt = <990000>;
+				regulator-name = "vdd-gpu-sys";
+			};
+
+			reg_dcdc2: dcdc2 {
+				regulator-always-on;
+				regulator-min-microvolt = <810000>;
+				regulator-max-microvolt = <1100000>;
+				regulator-name = "vdd-cpu";
+			};
+
+			reg_dcdc3: dcdc3 {
+				regulator-always-on;
+				regulator-min-microvolt = <1100000>;
+				regulator-max-microvolt = <1500000>;
+				regulator-name = "vdd-dram";
+			};
+		};
+	};
+};
+
+&spi1 {
+	status = "disabled";
+	pinctrl-0 = <&spi1_pins>, <&spi1_cs1_pin>;
+	pinctrl-names = "default";
+
+	spidev@1 {
+		compatible = "rohm,dh2228fv";
+		reg = <1>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_ph_pins>;
+};
+
+&uart1 {
+	status = "okay";
+	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
+	pinctrl-names = "default";
+	uart-has-rtscts;
+};
+
+&uart2 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart2_ph_pins>;
+};
+
+&uart5 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart5_pins>;
+};
+
+&usbotg {
+	status = "okay";
+	dr_mode = "peripheral";
+};
+
+&usbphy {
+	status = "okay";
+	usb1_vbus-supply = <&reg_usb_vbus>;
+};

--- a/patch/kernel/archive/sunxi-6.15/0000.patching_config.yaml
+++ b/patch/kernel/archive/sunxi-6.15/0000.patching_config.yaml
@@ -1,0 +1,38 @@
+config:
+
+  # Just some info stuff; not used by the patching scripts
+  name: sunxi-6.12
+  kind: kernel
+  type: mainline # or: mainline
+  branch: linux-6.12.y
+  last-known-good-tag: v6.7.0
+  maintainers:
+    - { github: pyavitz, name: Patrick Yavitz, email: pyavitz@gmail.com, armbian-forum: c0rnelius }
+
+  # .dts files in these directories will be copied as-is to the build tree; later ones overwrite earlier ones.
+  # This is meant to provide a way to "add a board DTS" without having to null-patch them in.
+  dts-directories:
+    # will copy patch/kernel/archive/meson64-MAJOR.MINOR/dt-boards/*.dts to arch/arm64/boot/dts/allwinner
+    - { source: "dt", target: "arch/arm64/boot/dts/allwinner" }
+
+  # every file in these directories will be copied as-is to the build tree; later ones overwrite earlier ones
+  # This is meant as a way to have overlays, bare, in a directory, without having to null-patch them in.
+  # @TODO need a solution to auto-Makefile the overlays as well
+#  overlay-directories:
+    # will copy patch/kernel/archive/meson64-MAJOR.MINOR/overlay/**/* to arch/arm64/boot/dts/allwinner/overlay
+#    - { source: "overlay", target: "arch/arm64/boot/dts/allwinner/overlay" }
+
+  # the Makefile in each of these directories will be magically patched to include the dts files copied
+  #  or patched-in; overlay subdir will be included "-y" if it exists.
+  # No more Makefile patching needed, yay!
+  auto-patch-dt-makefile:
+    - { directory: "arch/arm64/boot/dts/allwinner", config-var: "CONFIG_ARCH_SUNXI" }
+
+  # configuration for when applying patches to git / auto-rewriting patches (development cycle helpers)
+  patches-to-git:
+    do-not-commit-files:
+      - "MAINTAINERS" # constant churn, drop them. sorry.
+      - "Documentation/devicetree/bindings/arm/allwinner.yaml" # constant churn, conflicts on every bump, drop it. sorry.
+    do-not-commit-regexes: # Python-style regexes
+      - "^arch/([a-zA-Z0-9]+)/boot/dts/([a-zA-Z0-9]+)/Makefile$" # ignore DT Makefile patches, we've an auto-patcher now
+

--- a/patch/kernel/archive/sunxi-6.15/dt/sun50i-h618-kickpi-k2b.dts
+++ b/patch/kernel/archive/sunxi-6.15/dt/sun50i-h618-kickpi-k2b.dts
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (C) 2025 Patrick Yavitz <pyavitz@gmail.com>
+ */
+
+/dts-v1/;
+
+#include "sun50i-h616.dtsi"
+#include "sun50i-h616-cpu-opp.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/input/linux-event-codes.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "KickPi K2B";
+	compatible = "kickpi,k2b", "allwinner,sun50i-h618";
+
+	aliases {
+		ethernet0 = &emac0;
+		i2c1 = &i2c1;
+		i2c2 = &i2c2;
+		i2c3 = &i2c3;
+		i2c4 = &i2c4;
+		serial0 = &uart0;
+		serial1 = &uart1;
+		serial2 = &uart2;
+		serial5 = &uart5;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	connector {
+		compatible = "hdmi-connector";
+		type = "d";
+
+		port {
+			hdmi_con_in: endpoint {
+				remote-endpoint = <&hdmi_out_con>;
+			};
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		button-power {
+			label = "power";
+			linux,code = <KEY_POWER>;
+			gpios = <&pio 2 2 GPIO_ACTIVE_LOW>; /* PC2 */
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 8 16 GPIO_ACTIVE_HIGH>; /* PI16 */
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	reg_usb_vbus: regulator-usb-vbus {
+		/* Separate discrete regulator for the USB ports */
+		compatible = "regulator-fixed";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-name = "usb-vbus";
+		vin-supply = <&reg_vcc5v>;
+	};
+
+	reg_vcc5v: regulator-vcc5v {
+		/* Board wide 5V supply directly from the USB-C socket */
+		compatible = "regulator-fixed";
+		regulator-always-on;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-name = "vcc-5v";
+	};
+
+	reg_vcc3v3: vcc3v3 {
+		/* Discrete 3.3V regulator */
+		compatible = "regulator-fixed";
+		regulator-always-on;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-name = "vcc-3v3";
+		vin-supply = <&reg_vcc5v>;
+	};
+
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		clocks = <&rtc CLK_OSC32K_FANOUT>;
+		clock-names = "ext_clock";
+		pinctrl-0 = <&x32clk_fanout_pin>;
+		pinctrl-names = "default";
+		post-power-on-delay-ms = <100>;
+		power-off-delay-us = <5000000>;
+		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>, /* PG18 */
+			      <&pio 6 19 GPIO_ACTIVE_LOW>; /* PG19 */
+	};
+};
+
+&ahub_dam_plat {
+	status = "okay";
+};
+
+&ahub_i2s2 {
+	status = "okay";
+};
+
+&ahub1_mach {
+	status = "okay";
+};
+
+&ahub1_plat {
+	status = "okay";
+};
+
+&codec {
+	status = "okay";
+	allwinner,audio-routing = "Line Out", "LINEOUT";
+};
+
+&cpu0 {
+	cpu-supply = <&reg_dcdc2>;
+};
+
+&de {
+	status = "okay";
+};
+
+&emac0 {
+	status = "okay";
+	pinctrl-0 = <&ext_rgmii_pins>;
+	pinctrl-names = "default";
+	phy-mode = "rgmii";
+	phy-handle = <&ext_rgmii_phy>;
+	allwinner,tx-delay-ps = <700>;
+	allwinner,rx-delay-ps = <1700>;
+};
+
+&ehci0 {
+	status = "okay";
+};
+
+&ehci1 {
+	status = "okay";
+};
+
+&ehci2 {
+	status = "okay";
+};
+
+&ehci3 {
+	status = "disabled";
+};
+
+&gpu {
+	status = "okay";
+	mali-supply = <&reg_dcdc1>;
+};
+
+&hdmi {
+	status = "okay";
+};
+
+&hdmi_out {
+	hdmi_out_con: endpoint {
+		remote-endpoint = <&hdmi_con_in>;
+	};
+};
+
+&i2c1 {
+	status = "disabled";
+	pinctrl-0 = <&i2c1_ph_pins>;
+	pinctrl-names = "default";
+};
+
+&i2c2 {
+	status = "disabled";
+	pinctrl-0 = <&i2c2_ph_pins>;
+	pinctrl-names = "default";
+};
+
+&i2c3 {
+	status = "disabled";
+	pinctrl-0 = <&i2c3_ph_pins>;
+	pinctrl-names = "default";
+};
+
+&i2c4 {
+	status = "disabled";
+	pinctrl-0 = <&i2c4_ph_pins>;
+	pinctrl-names = "default";
+};
+
+&ir {
+	status = "okay";
+	pinctrl-0 = <&ir_rx_pin>;
+	pinctrl-names = "default";
+};
+
+&mdio0 {
+	ext_rgmii_phy: ethernet-phy@1 {
+		compatible = "ethernet-phy-id001c.c916";
+		reg = <1>;
+		reset-assert-us = <20000>;
+		reset-deassert-us = <100000>;
+		reset-gpios = <&pio 8 6 GPIO_ACTIVE_LOW>; /* PI6 */
+	};
+};
+
+/* SD card */
+&mmc0 {
+	status = "okay";
+	bus-width = <4>;
+	cd-gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>;	/* PF6 */
+	cd-inverted;
+	disable-wp;
+	max-frequency = <50000000>;
+	vmmc-supply = <&reg_dldo1>;
+};
+
+/* SDIO */
+&mmc1 {
+	status = "okay";
+	bus-width = <4>;
+	keep-power-in-suspend;
+	max-frequency = <100000000>;
+	mmc-pwrseq = <&sdio_pwrseq>;
+	no-mmc;
+	no-sd;
+	non-removable;
+	vmmc-supply = <&reg_dldo1>;
+	vqmmc-supply = <&reg_aldo1>;
+
+	sdio: wifi@1 {
+		reg = <1>;
+	};
+};
+
+/* eMMC */
+&mmc2 {
+	status = "okay";
+	bus-width = <8>;
+	cap-mmc-hw-reset;
+	mmc-hs200-1_8v;
+	non-removable;
+	vmmc-supply = <&reg_dldo1>;
+	vqmmc-supply = <&reg_aldo1>;
+};
+
+&ohci0 {
+	status = "okay";
+};
+
+&ohci1 {
+	status = "okay";
+};
+
+&ohci2 {
+	status = "okay";
+};
+
+&ohci3 {
+	status = "disabled";
+};
+
+&pio {
+	vcc-pc-supply = <&reg_dldo1>;
+	vcc-pf-supply = <&reg_dldo1>;
+	vcc-pg-supply = <&reg_aldo1>;
+	vcc-ph-supply = <&reg_dldo1>;
+	vcc-pi-supply = <&reg_dldo1>;
+	vcc-pl-supply = <&reg_aldo1>;
+
+	// PI16 required for sys_led
+	ext_rgmii_pins: rgmii-pins {
+		pins = "PI0", "PI1", "PI2", "PI3", "PI4",
+		       "PI5", "PI7", "PI8", "PI9", "PI10",
+		       "PI11", "PI12", "PI13", "PI14", "PI15";
+		function = "emac0";
+		drive-strength = <40>;
+	};
+
+	//  Add I2C PH Pins
+	i2c1_ph_pins: i2c1-ph-pins {
+		pins = "PH0", "PH1";
+		function = "i2c1";
+	};
+
+	i2c2_ph_pins: i2c2-ph-pins {
+		pins = "PH2", "PH3";
+		function = "i2c2";
+	};
+
+	i2c4_ph_pins: i2c4-ph-pins {
+		pins = "PH6", "PH7";
+		function = "i2c4";
+	};
+
+	// PC0 required for spi0
+	mmc2_pins: mmc2-pins {
+		pins = "PC1", "PC5", "PC6",
+		       "PC8", "PC9", "PC10", "PC11",
+		       "PC13", "PC14", "PC15", "PC16";
+		function = "mmc2";
+		drive-strength = <30>;
+		bias-pull-up;
+	};
+};
+
+&r_i2c {
+	status = "okay";
+	axp313: pmic@36 {
+		compatible = "x-powers,axp313a";
+		reg = <0x36>;
+		#interrupt-cells = <1>;
+		interrupt-controller;
+		interrupt-parent = <&pio>;
+
+		vin1-supply = <&reg_vcc5v>;
+		vin2-supply = <&reg_vcc5v>;
+		vin3-supply = <&reg_vcc5v>;
+
+		regulators {
+			reg_aldo1: aldo1 {
+				regulator-always-on;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-name = "vcc-1v8-pll";
+			};
+
+			reg_dldo1: dldo1 {
+				regulator-always-on;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-name = "vcc-3v3-io";
+			};
+
+			reg_dcdc1: dcdc1 {
+				regulator-always-on;
+				regulator-min-microvolt = <810000>;
+				regulator-max-microvolt = <990000>;
+				regulator-name = "vdd-gpu-sys";
+			};
+
+			reg_dcdc2: dcdc2 {
+				regulator-always-on;
+				regulator-min-microvolt = <810000>;
+				regulator-max-microvolt = <1100000>;
+				regulator-name = "vdd-cpu";
+			};
+
+			reg_dcdc3: dcdc3 {
+				regulator-always-on;
+				regulator-min-microvolt = <1100000>;
+				regulator-max-microvolt = <1500000>;
+				regulator-name = "vdd-dram";
+			};
+		};
+	};
+};
+
+&spi1 {
+	status = "disabled";
+	pinctrl-0 = <&spi1_pins>, <&spi1_cs1_pin>;
+	pinctrl-names = "default";
+
+	spidev@1 {
+		compatible = "rohm,dh2228fv";
+		reg = <1>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_ph_pins>;
+};
+
+&uart1 {
+	status = "okay";
+	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
+	pinctrl-names = "default";
+	uart-has-rtscts;
+};
+
+&uart2 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart2_ph_pins>;
+};
+
+&uart5 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart5_pins>;
+};
+
+&usbotg {
+	status = "okay";
+	dr_mode = "peripheral";
+};
+
+&usbphy {
+	status = "okay";
+	usb1_vbus-supply = <&reg_usb_vbus>;
+};

--- a/patch/misc/aic8800_sdio/001-Aicsemi-aic8800-fixups.patch
+++ b/patch/misc/aic8800_sdio/001-Aicsemi-aic8800-fixups.patch
@@ -1,0 +1,645 @@
+From c4299ad3697820e3dd53aff9142c0b3f32de4b2d Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@gmail.com>
+Date: Sun, 6 Jul 2025 21:36:50 -0400
+Subject: [PATCH] Aicsemi aic8800 fixups
+
+Source: https://github.com/radxa-pkg/aic8800
+
+Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
+---
+ .../aic8800_sdio/aic8800_bsp/Makefile         |  9 ++-
+ .../aic8800_sdio/aic8800_bsp/aic_bsp_driver.c |  4 ++
+ .../aic8800_sdio/aic8800_bsp/aicsdio.c        |  8 +++
+ .../aic8800_sdio/aic8800_fdrv/Makefile        |  5 ++
+ .../aic8800_sdio/aic8800_fdrv/aicwf_sdio.c    |  8 +++
+ .../aic8800_sdio/aic8800_fdrv/aicwf_tcp_ack.c | 16 ++++++
+ .../aic8800_sdio/aic8800_fdrv/rwnx_main.c     | 57 ++++++++++++++++++-
+ .../aic8800_fdrv/rwnx_mod_params.c            | 15 ++++-
+ .../aic8800_sdio/aic8800_fdrv/rwnx_msg_tx.c   |  2 +
+ .../aic8800_sdio/aic8800_fdrv/rwnx_platform.c |  4 ++
+ .../aic8800_sdio/aic8800_fdrv/rwnx_radar.c    |  8 +++
+ .../aic8800_sdio/aic8800_fdrv/rwnx_rx.c       | 24 ++++++++
+ .../aic8800_sdio/aic8800_fdrv/rwnx_tdls.c     |  1 +
+ .../aic8800_sdio/aic8800_fdrv/rwnx_tx.c       |  1 +
+ .../aic8800_sdio/aic8800_fdrv/rwnx_txq.c      |  1 +
+ .../aic8800_sdio/aic8800_fdrv/rwnx_wakelock.c |  6 ++
+ 16 files changed, 162 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/Makefile b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/Makefile
+index 138bacd97709..c37d921b087c 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/Makefile
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/Makefile
+@@ -1,7 +1,7 @@
+ CONFIG_SDIO_SUPPORT := y
+ CONFIG_SDIO_PWRCTRL := n
+-CONFIG_AIC_FW_PATH = "/vendor/etc/firmware"
+-#CONFIG_AIC_FW_PATH = "/lib/firmware/aic8800"
++#CONFIG_AIC_FW_PATH = "/vendor/etc/firmware"
++CONFIG_AIC_FW_PATH = "/lib/firmware/aic8800/SDIO/"
+ export CONFIG_AIC_FW_PATH
+ ccflags-y += -DCONFIG_AIC_FW_PATH=\"$(CONFIG_AIC_FW_PATH)\"
+ 
+@@ -130,6 +130,11 @@ KVER ?= $(shell uname -r)
+ MODDESTDIR ?= /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+ ARCH ?= x86_64
+ CROSS_COMPILE ?=
++
++ifeq ($(CONFIG_AW_BSP), y)
++ccflags-y += -DCONFIG_PLATFORM_ALLWINNER
++endif
++
+ endif
+ ###########################################
+ 
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aic_bsp_driver.c b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aic_bsp_driver.c
+index 929c58bc3c5f..ecb1f44225ff 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aic_bsp_driver.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aic_bsp_driver.c
+@@ -468,8 +468,12 @@ void rwnx_rx_handle_msg(struct aic_sdio_dev *sdiodev, struct ipc_e2a_msg *msg)
+ }
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
++MODULE_IMPORT_NS("VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver");
++#else
+ MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+ #endif
++#endif
+ 
+ #define MD5(x) x[0],x[1],x[2],x[3],x[4],x[5],x[6],x[7],x[8],x[9],x[10],x[11],x[12],x[13],x[14],x[15]
+ #define MD5PINRT "file md5:%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\r\n"
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aicsdio.c b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aicsdio.c
+index 813c0f39f8ed..9ed440f912eb 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aicsdio.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aicsdio.c
+@@ -1390,7 +1390,11 @@ int aicwf_sdio_busrx_thread(void *data)
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
+ static void aicwf_sdio_bus_pwrctl(struct timer_list *t)
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	struct aic_sdio_dev *sdiodev = timer_container_of(sdiodev, t, timer);
++#else
+ 	struct aic_sdio_dev *sdiodev = from_timer(sdiodev, t, timer);
++#endif
+ #else
+ static void aicwf_sdio_bus_pwrctl(ulong data)
+ {
+@@ -1592,7 +1596,11 @@ void aicwf_sdio_pwrctl_timer(struct aic_sdio_dev *sdiodev, uint duration)
+ 	spin_lock_bh(&sdiodev->pwrctl_lock);
+ 	if (!duration) {
+ 		if (timer_pending(&sdiodev->timer))
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete_sync(&sdiodev->timer);
++#else
+ 			del_timer_sync(&sdiodev->timer);
++#endif
+ 	} else {
+ 		sdiodev->active_duration = duration;
+ 		timeout = msecs_to_jiffies(sdiodev->active_duration);
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/Makefile b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/Makefile
+index 2b24142d6e56..c2441977e48e 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/Makefile
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/Makefile
+@@ -389,6 +389,11 @@ KVER ?= $(shell uname -r)
+ MODDESTDIR ?= /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+ ARCH ?= x86_64
+ CROSS_COMPILE ?=
++
++ifeq ($(CONFIG_AW_BSP), y)
++ccflags-y += -DCONFIG_PLATFORM_ALLWINNER
++endif
++
+ endif
+ ###########################################
+ 
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_sdio.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_sdio.c
+index 455b5bd1e126..e1c4ee392b65 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_sdio.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_sdio.c
+@@ -2287,8 +2287,12 @@ static void aicwf_sdio_bus_pwrctl(struct timer_list *t)
+ {
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+ 	struct aic_sdio_dev *sdiodev = (struct aic_sdio_dev *) data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	struct aic_sdio_dev *sdiodev = timer_container_of(sdiodev, t, timer);
+ #else
+ 	struct aic_sdio_dev *sdiodev = from_timer(sdiodev, t, timer);
++#endif
+ #endif
+ 
+ 	if (sdiodev->bus_if->state == BUS_DOWN_ST) {
+@@ -2478,7 +2482,11 @@ void aicwf_sdio_pwrctl_timer(struct aic_sdio_dev *sdiodev, uint duration)
+ 	spin_lock_bh(&sdiodev->pwrctl_lock);
+ 	if (!duration) {
+ 		if (timer_pending(&sdiodev->timer))
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete_sync(&sdiodev->timer);
++#else
+ 			del_timer_sync(&sdiodev->timer);
++#endif
+ 	} else {
+ 		sdiodev->active_duration = duration;
+ 		timeout = msecs_to_jiffies(sdiodev->active_duration);
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_tcp_ack.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_tcp_ack.c
+index ca47b26cd28c..d74bd8d1f420 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_tcp_ack.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_tcp_ack.c
+@@ -106,7 +106,11 @@ void tcp_ack_deinit(struct rwnx_hw *priv)
+ 		drop_msg = NULL;
+ 
+ 		write_seqlock_bh(&ack_m->ack_info[i].seqlock);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++		timer_delete(&ack_m->ack_info[i].timer);
++#else
+ 		del_timer(&ack_m->ack_info[i].timer);
++#endif
+ 		drop_msg = ack_m->ack_info[i].msgbuf;
+ 		ack_m->ack_info[i].msgbuf = NULL;
+ 		write_sequnlock_bh(&ack_m->ack_info[i].seqlock);
+@@ -375,7 +379,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
+ 				//printk("%lx \n",ack_info->msgbuf);
+ 				drop_msg = ack_info->msgbuf;
+ 				ack_info->msgbuf = NULL;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++				timer_delete(&ack_info->timer);
++#else
+ 				del_timer(&ack_info->timer);
++#endif
+ 			}else{
+ 				//printk("msgbuf is NULL \n");
+ 			}
+@@ -409,7 +417,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
+ 				   atomic_read(&ack_m->max_drop_cnt)))) {
+ 			ack_info->drop_cnt = 0;
+ 			ack_info->in_send_msg = new_msgbuf;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_info->timer);
++#else
+ 			del_timer(&ack_info->timer);
++#endif
+ 		} else {
+ 			ret = 1;
+ 			ack_info->msgbuf = new_msgbuf;
+@@ -472,7 +484,11 @@ int tcp_ack_handle_new(struct msg_buf *new_msgbuf,
+ 			ack_info->drop_cnt = 0;
+ 			//send_msg = new_msgbuf;
+ 			ack_info->in_send_msg = new_msgbuf;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_info->timer);
++#else
+ 			del_timer(&ack_info->timer);
++#endif
+ 		}else{
+ 			ret = 1;
+ 			ack_info->msgbuf = new_msgbuf;
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_main.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_main.c
+index 3ee11ae36939..0db733f485a1 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_main.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_main.c
+@@ -785,7 +785,9 @@ static void rwnx_csa_finish(struct work_struct *ws)
+ 		} else
+ 			rwnx_txq_vif_stop(vif, RWNX_TXQ_STOP_CHAN, rwnx_hw);
+ 		spin_unlock_bh(&rwnx_hw->cb_lock);
+-#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION3)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
++		cfg80211_ch_switch_notify(vif->ndev, &csa->chandef, 0);
++#elif (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION3)
+ 		cfg80211_ch_switch_notify(vif->ndev, &csa->chandef, 0, 0);
+ #elif (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION)
+ 		cfg80211_ch_switch_notify(vif->ndev, &csa->chandef, 0);
+@@ -1580,6 +1582,7 @@ static struct rwnx_vif *rwnx_interface_add(struct rwnx_hw *rwnx_hw,
+ 		vif->ap.mesh_pm = NL80211_MESH_POWER_ACTIVE;
+ 		vif->ap.next_mesh_pm = NL80211_MESH_POWER_ACTIVE;
+ 		// no break
++		__attribute__((__fallthrough__));
+ 	case NL80211_IFTYPE_AP:
+ 		INIT_LIST_HEAD(&vif->ap.sta_list);
+ 		memset(&vif->ap.bcn, 0, sizeof(vif->ap.bcn));
+@@ -1679,7 +1682,11 @@ void aicwf_p2p_alive_timeout(struct timer_list *t)
+ 	rwnx_vif = (struct rwnx_vif *)data;
+ 	rwnx_hw = rwnx_vif->rwnx_hw;
+ 	#else
++	#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	rwnx_hw = timer_container_of(rwnx_hw, t, p2p_alive_timer);
++	#else
+ 	rwnx_hw = from_timer(rwnx_hw, t, p2p_alive_timer);
++	#endif
+ 	rwnx_vif = rwnx_hw->p2p_dev_vif;
+ 	#endif
+ 
+@@ -1997,6 +2004,7 @@ static int rwnx_cfg80211_change_iface(struct wiphy *wiphy,
+ 		vif->ap.create_path = false;
+ 		vif->ap.generation = 0;
+ 		// no break
++		__attribute__((__fallthrough__));
+ 	case NL80211_IFTYPE_AP:
+ 	case NL80211_IFTYPE_P2P_GO:
+ 		INIT_LIST_HEAD(&vif->ap.sta_list);
+@@ -2121,7 +2129,11 @@ static void rwnx_cfgp2p_stop_p2p_device(struct wiphy *wiphy, struct wireless_dev
+ 	if (rwnx_vif == rwnx_hw->p2p_dev_vif) {
+ 		rwnx_hw->is_p2p_alive = 0;
+ 		if (timer_pending(&rwnx_hw->p2p_alive_timer)) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete_sync(&rwnx_hw->p2p_alive_timer);
++#else
+ 			del_timer_sync(&rwnx_hw->p2p_alive_timer);
++#endif
+ 		}
+ 
+ 		if (rwnx_vif->up) {
+@@ -3345,8 +3357,13 @@ static int rwnx_cfg80211_start_ap(struct wiphy *wiphy, struct net_device *dev,
+  * @change_beacon: Change the beacon parameters for an access point mode
+  *	interface. This should reject the call when AP mode wasn't started.
+  */
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
++static int rwnx_cfg80211_change_beacon(struct wiphy *wiphy, struct net_device *dev,
++									   struct cfg80211_ap_update *params)
++#else
+ static int rwnx_cfg80211_change_beacon(struct wiphy *wiphy, struct net_device *dev,
+ 									   struct cfg80211_beacon_data *info)
++#endif
+ {
+ 	struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+ 	struct rwnx_vif *vif = netdev_priv(dev);
+@@ -3359,7 +3376,11 @@ static int rwnx_cfg80211_change_beacon(struct wiphy *wiphy, struct net_device *d
+ 	RWNX_DBG(RWNX_FN_ENTRY_STR);
+ 
+ 	// Build the beacon
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
++	buf = rwnx_build_bcn(bcn, &params->beacon);
++#else
+ 	buf = rwnx_build_bcn(bcn, info);
++#endif
+ 	if (!buf)
+ 		return -ENOMEM;
+ 
+@@ -3427,6 +3448,9 @@ static int rwnx_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *dev)
+  * configured at firmware level.
+  */
+ static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 13, 0)
++											 struct net_device *,
++#endif
+ 											 struct cfg80211_chan_def *chandef)
+ {
+ 	struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+@@ -3481,7 +3505,11 @@ static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
+ 
+ int rwnx_cfg80211_set_monitor_channel_(struct wiphy *wiphy,
+                                              struct cfg80211_chan_def *chandef){
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 13, 0)
++    return rwnx_cfg80211_set_monitor_channel(wiphy, NULL, chandef);
++#else
+     return rwnx_cfg80211_set_monitor_channel(wiphy, chandef);
++#endif
+ }
+ 
+ 
+@@ -3582,6 +3610,9 @@ static int rwnx_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *
+ static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+  struct wireless_dev *wdev,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 14, 0)
++ unsigned int link_id,
++#endif
+ #endif
+ 	int *mbm)
+ {
+@@ -3900,7 +3931,11 @@ static int rwnx_cfg80211_get_channel(struct wiphy *wiphy,
+ 
+ 	if (rwnx_vif->vif_index == rwnx_hw->monitor_vif) {
+ 		//retrieve channel from firmware
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 13, 0)
++		rwnx_cfg80211_set_monitor_channel(wiphy, NULL, NULL);
++#else
+ 		rwnx_cfg80211_set_monitor_channel(wiphy, NULL);
++#endif
+ 	}
+ 
+ 	//Check if channel context is valid
+@@ -3952,6 +3987,7 @@ static int rwnx_cfg80211_mgmt_tx(struct wiphy *wiphy, struct wireless_dev *wdev,
+ 	switch (RWNX_VIF_TYPE(rwnx_vif)) {
+ 	case NL80211_IFTYPE_AP_VLAN:
+ 		rwnx_vif = rwnx_vif->ap_vlan.master;
++		__attribute__((__fallthrough__));
+ 	case NL80211_IFTYPE_AP:
+ 	case NL80211_IFTYPE_P2P_GO:
+ 	case NL80211_IFTYPE_MESH_POINT:
+@@ -4035,6 +4071,9 @@ int rwnx_cfg80211_start_radar_detection(struct wiphy *wiphy,
+ 										struct cfg80211_chan_def *chandef
+ 									#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0))
+ 										, u32 cac_time_ms
++									#endif
++									#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
++										, int link_id
+ 									#endif
+ 										)
+ {
+@@ -4176,7 +4215,9 @@ int rwnx_cfg80211_channel_switch (struct wiphy *wiphy,
+ 		goto end;
+ 	} else {
+ 		INIT_WORK(&csa->work, rwnx_csa_finish);
+-#if LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION4
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
++		cfg80211_ch_switch_started_notify(dev, &csa->chandef, 0, params->count, false);
++#elif LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION4
+ 		cfg80211_ch_switch_started_notify(dev, &csa->chandef, 0, params->count, false, 0);
+ #elif LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2
+ 		cfg80211_ch_switch_started_notify(dev, &csa->chandef, 0, params->count, false);
+@@ -4204,6 +4245,9 @@ rwnx_cfg80211_tdls_mgmt(struct wiphy *wiphy,
+ 	const u8 *peer,
+ #else
+ 	u8 *peer,
++#endif
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0))
++	int link_id,
+ #endif
+ 	u8 action_code,
+ 	u8 dialog_token,
+@@ -4594,6 +4638,7 @@ static int rwnx_fill_station_info(struct rwnx_sta *sta, struct rwnx_vif *vif,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+ 	case FORMATMOD_HE_MU:
+ 		sinfo->rxrate.he_ru_alloc = rx_vect1->he.ru_size;
++		__attribute__((__fallthrough__));
+ 	case FORMATMOD_HE_SU:
+ 	case FORMATMOD_HE_ER:
+ 		sinfo->rxrate.flags = RATE_INFO_FLAGS_HE_MCS;
+@@ -5925,7 +5970,11 @@ void rwnx_cfg80211_deinit(struct rwnx_hw *rwnx_hw)
+ 		list_for_each_entry(defrag_ctrl, &rwnx_hw->defrag_list, list) {
+ 			list_del_init(&defrag_ctrl->list);
+ 			if (timer_pending(&defrag_ctrl->defrag_timer))
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++				timer_delete_sync(&defrag_ctrl->defrag_timer);
++#else
+ 				del_timer_sync(&defrag_ctrl->defrag_timer);
++#endif
+ 			dev_kfree_skb(defrag_ctrl->skb);
+ 			kfree(defrag_ctrl);
+ 		}
+@@ -6052,8 +6101,12 @@ static void __exit rwnx_mod_exit(void)
+ 
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
++MODULE_IMPORT_NS("VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver");
++#else
+ MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+ #endif
++#endif
+ 
+ module_init(rwnx_mod_init);
+ module_exit(rwnx_mod_exit);
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_mod_params.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_mod_params.c
+index 4a9a29853437..acc005ed9908 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_mod_params.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_mod_params.c
+@@ -1585,7 +1585,10 @@ if (rwnx_hw->mod_params->custregd) {
+                "\n\n%s: CAUTION: USING PERMISSIVE CUSTOM REGULATORY RULES\n\n",
+                __func__);
+         wiphy->regulatory_flags |= REGULATORY_CUSTOM_REG;
++		/* From kernel 6.5.0, this bit is removed and will be reused later */
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39) || LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 0))
+         wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
++#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) */
+         wiphy_apply_custom_regulatory(wiphy, regdomain);
+ #elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0))
+         memcpy(country_code, default_ccode, sizeof(default_ccode));
+@@ -1619,7 +1622,10 @@ if (rwnx_hw->mod_params->custregd) {
+ 			   "\n\n%s: CAUTION: USING PERMISSIVE CUSTOM REGULATORY RULES\n\n",
+ 			   __func__);
+ 		wiphy->regulatory_flags |= REGULATORY_CUSTOM_REG;
+-		wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
++		/* From kernel 6.5.0, this bit is removed and will be reused later */
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39) || LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 0))
++        wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
++#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) */
+ 		wiphy_apply_custom_regulatory(wiphy, &rwnx_regdom);
+ #endif
+ 		// Check if custom channel set shall be enabled. In such case only monitor mode is
+@@ -1762,8 +1768,11 @@ void rwnx_custregd(struct rwnx_hw *rwnx_hw, struct wiphy *wiphy)
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0)
+     if (!rwnx_hw->mod_params->custregd)
+         return;
+-
+-    wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
++    
++	/* From kernel 6.5.0, this bit is removed and will be reused later */
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39) || LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 0))
++	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
++#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) */
+     wiphy->regulatory_flags |= REGULATORY_WIPHY_SELF_MANAGED;
+ 
+     rtnl_lock();
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_msg_tx.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_msg_tx.c
+index 8b368ca6984f..73845d59cfc7 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_msg_tx.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_msg_tx.c
+@@ -525,6 +525,7 @@ int rwnx_send_add_if (struct rwnx_hw *rwnx_hw, const unsigned char *mac,
+ 	case NL80211_IFTYPE_P2P_CLIENT:
+ 		add_if_req_param->p2p = true;
+ 		// no break
++		__attribute__((__fallthrough__));
+ 	#endif /* CONFIG_RWNX_FULLMAC */
+ 	case NL80211_IFTYPE_STATION:
+ 		add_if_req_param->type = MM_STA;
+@@ -538,6 +539,7 @@ int rwnx_send_add_if (struct rwnx_hw *rwnx_hw, const unsigned char *mac,
+ 	case NL80211_IFTYPE_P2P_GO:
+ 		add_if_req_param->p2p = true;
+ 		// no break
++		__attribute__((__fallthrough__));
+ 	#endif /* CONFIG_RWNX_FULLMAC */
+ 	case NL80211_IFTYPE_AP:
+ 		add_if_req_param->type = MM_AP;
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_platform.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_platform.c
+index 07682f4e18cc..c7b172d3fde2 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_platform.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_platform.c
+@@ -309,8 +309,12 @@ static int rwnx_plat_tl4_fw_upload(struct rwnx_plat *rwnx_plat, u8 *fw_addr,
+ #endif
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
++MODULE_IMPORT_NS("VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver");
++#else
+ MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+ #endif
++#endif
+ 
+ #if 0
+ /**
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_radar.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_radar.c
+index 358e260c5fe2..f7b9a79613f2 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_radar.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_radar.c
+@@ -1400,7 +1400,11 @@ static void rwnx_radar_cac_work(struct work_struct *ws)
+ 					#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+ 					   &ctxt->chan_def,
+ 					#endif
++					#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++					   NL80211_RADAR_CAC_FINISHED, GFP_KERNEL, 0);
++					#else
+ 					   NL80211_RADAR_CAC_FINISHED, GFP_KERNEL);
++					#endif
+ 	rwnx_send_apm_stop_cac_req(rwnx_hw, radar->cac_vif);
+ 	rwnx_chanctx_unlink(radar->cac_vif);
+ 
+@@ -1500,7 +1504,11 @@ void rwnx_radar_cancel_cac(struct rwnx_radar *radar)
+ 						#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+ 						   &ctxt->chan_def,
+ 						#endif
++						#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++						   NL80211_RADAR_CAC_ABORTED, GFP_KERNEL, 0);
++						#else
+ 						   NL80211_RADAR_CAC_ABORTED, GFP_KERNEL);
++						#endif
+ 		rwnx_chanctx_unlink(radar->cac_vif);
+ 	}
+ 
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_rx.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_rx.c
+index 7b42358c3b1c..5d462cfe918e 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_rx.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_rx.c
+@@ -1408,7 +1408,11 @@ int reord_flush_tid(struct aicwf_rx_priv *rx_priv, struct sk_buff *skb, u8 tid)
+ 	preorder_ctrl->enable = false;
+ 	spin_unlock_irqrestore(&preorder_ctrl->reord_list_lock, flags);
+ 	if (timer_pending(&preorder_ctrl->reord_timer))
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++		ret = timer_delete_sync(&preorder_ctrl->reord_timer);
++#else
+ 		ret = del_timer_sync(&preorder_ctrl->reord_timer);
++#endif
+ 	cancel_work_sync(&preorder_ctrl->reord_timer_work);
+ 
+ 	return 0;
+@@ -1433,7 +1437,11 @@ void reord_deinit_sta(struct aicwf_rx_priv *rx_priv, struct reord_ctrl_info *reo
+ 		if(preorder_ctrl->enable){
+ 			preorder_ctrl->enable = false;
+ 			if (timer_pending(&preorder_ctrl->reord_timer)) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++ 				ret = timer_delete_sync(&preorder_ctrl->reord_timer);
++#else
+ 				ret = del_timer_sync(&preorder_ctrl->reord_timer);
++#endif
+ 			}
+ 			cancel_work_sync(&preorder_ctrl->reord_timer_work);
+ 		}
+@@ -1643,9 +1651,13 @@ void reord_timeout_handler (struct timer_list *t)
+ {
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+ 	struct reord_ctrl *preorder_ctrl = (struct reord_ctrl *)data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	struct reord_ctrl *preorder_ctrl = timer_container_of(preorder_ctrl, t, reord_timer);
+ #else
+ 	struct reord_ctrl *preorder_ctrl = from_timer(preorder_ctrl, t, reord_timer);
+ #endif
++#endif
+ 
+ #if 0 //AIDEN
+ 	struct aicwf_rx_priv *rx_priv = preorder_ctrl->rx_priv;
+@@ -1795,7 +1807,11 @@ int reord_process_unit(struct aicwf_rx_priv *rx_priv, struct sk_buff *skb, u16 s
+ 		}
+ 	} else {
+ 	if (timer_pending(&preorder_ctrl->reord_timer)) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			ret = timer_delete(&preorder_ctrl->reord_timer);
++#else
+ 			ret = del_timer(&preorder_ctrl->reord_timer);
++#endif
+ 	}
+ 	}
+ 	
+@@ -1893,8 +1909,12 @@ void defrag_timeout_cb(struct timer_list *t)
+ 	struct defrag_ctrl_info *defrag_ctrl = NULL;
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+ 	defrag_ctrl = (struct defrag_ctrl_info *)data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	defrag_ctrl = timer_container_of(defrag_ctrl, t, defrag_timer);
+ #else
+ 	defrag_ctrl = from_timer(defrag_ctrl, t, defrag_timer);
++#endif
+ #endif
+ 
+ 	printk("%s:%p\r\n", __func__, defrag_ctrl);
+@@ -2352,7 +2372,11 @@ u8 rwnx_rxdataind_aicwf(struct rwnx_hw *rwnx_hw, void *hostid, void *rx_priv)
+ 							skb_tmp = defrag_info->skb;
+ 							list_del_init(&defrag_info->list);
+ 							if (timer_pending(&defrag_info->defrag_timer)) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++								ret = timer_delete(&defrag_info->defrag_timer);
++#else
+ 								ret = del_timer(&defrag_info->defrag_timer);
++#endif
+ 							}
+ 							kfree(defrag_info);
+ 							spin_unlock_bh(&rwnx_hw->defrag_lock);
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tdls.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tdls.c
+index 34196edac508..7d9afb935ac7 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tdls.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tdls.c
+@@ -257,6 +257,7 @@ static u8 rwnx_ac_from_wmm(int ac)
+ 	switch (ac) {
+ 	default:
+ 		WARN_ON_ONCE(1);
++		__attribute__((__fallthrough__));
+ 	case 0:
+ 		return AC_BE;
+ 	case 1:
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tx.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tx.c
+index 3f36531c38c9..1621be4173b9 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tx.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tx.c
+@@ -332,6 +332,7 @@ u16 rwnx_select_txq(struct rwnx_vif *rwnx_vif, struct sk_buff *skb)
+ 		/* AP_VLAN interface is not used for a 4A STA,
+ 		   fallback searching sta amongs all AP's clients */
+ 		rwnx_vif = rwnx_vif->ap_vlan.master;
++		__attribute__((__fallthrough__));
+ 	case NL80211_IFTYPE_AP:
+ 	case NL80211_IFTYPE_P2P_GO:
+ 	{
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_txq.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_txq.c
+index 5468c3a5e067..9bdc07268407 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_txq.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_txq.c
+@@ -640,6 +640,7 @@ static inline void rwnx_txq_vif_for_each_sta(struct rwnx_hw *rwnx_hw, struct rwn
+ 	}
+ 	case NL80211_IFTYPE_AP_VLAN:
+ 		rwnx_vif = rwnx_vif->ap_vlan.master;
++		__attribute__((__fallthrough__));
+ 	case NL80211_IFTYPE_AP:
+ 	case NL80211_IFTYPE_MESH_POINT:
+ 	case NL80211_IFTYPE_P2P_GO:
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_wakelock.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_wakelock.c
+index 1d1529627e5e..7c785e952c3d 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_wakelock.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_wakelock.c
+@@ -11,18 +11,24 @@
+ 
+ struct wakeup_source *rwnx_wakeup_init(const char *name)
+ {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+ 	struct wakeup_source *ws;
+ 	ws = wakeup_source_create(name);
+ 	wakeup_source_add(ws);
+ 	return ws;
++#else
++	return NULL;
++#endif
+ }
+ 
+ void rwnx_wakeup_deinit(struct wakeup_source *ws)
+ {
+ 	if (ws && ws->active)
+ 		__pm_relax(ws);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+ 	wakeup_source_remove(ws);
+ 	wakeup_source_destroy(ws);
++#endif
+ }
+ 
+ struct wakeup_source *rwnx_wakeup_register(struct device *dev, const char *name)
+-- 
+2.43.0
+

--- a/patch/u-boot/v2025.01/board_kickpik2b/001-Add-board-KickPi-K2B.patch
+++ b/patch/u-boot/v2025.01/board_kickpik2b/001-Add-board-KickPi-K2B.patch
@@ -1,0 +1,409 @@
+From 6439547a82e1350ee611fef746914ec12fc049af Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@gmail.com>
+Date: Sun, 11 May 2025 18:02:27 -0400
+Subject: [PATCH] Add board KickPi K2B
+
+Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
+---
+ configs/kickpi_k2b_defconfig                  |  34 ++
+ .../allwinner/sun50i-h618-kickpi-k2b.dts      | 318 ++++++++++++++++++
+ 2 files changed, 352 insertions(+)
+ create mode 100644 configs/kickpi_k2b_defconfig
+ create mode 100644 dts/upstream/src/arm64/allwinner/sun50i-h618-kickpi-k2b.dts
+
+diff --git a/configs/kickpi_k2b_defconfig b/configs/kickpi_k2b_defconfig
+new file mode 100644
+index 00000000000..36f0d30a855
+--- /dev/null
++++ b/configs/kickpi_k2b_defconfig
+@@ -0,0 +1,34 @@
++CONFIG_OF_UPSTREAM=y
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_DEFAULT_DEVICE_TREE="allwinner/sun50i-h618-kickpi-k2b"
++CONFIG_SPL=y
++CONFIG_DRAM_SUN50I_H616_DX_ODT=0x07070707
++CONFIG_DRAM_SUN50I_H616_DX_DRI=0x0e0e0e0e
++CONFIG_DRAM_SUN50I_H616_CA_DRI=0x0e0e
++CONFIG_DRAM_SUN50I_H616_ODT_EN=0xaaaaeeee
++CONFIG_DRAM_SUN50I_H616_TPR6=0x48808080
++CONFIG_DRAM_SUN50I_H616_TPR10=0x402f6663
++CONFIG_DRAM_SUN50I_H616_TPR11=0x26262524
++CONFIG_DRAM_SUN50I_H616_TPR12=0x100f100f
++CONFIG_MACH_SUN50I_H616=y
++CONFIG_SUNXI_DRAM_H616_LPDDR4=y
++CONFIG_DRAM_CLK=792
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++CONFIG_R_I2C_ENABLE=y
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_SPL_I2C=y
++CONFIG_SPL_SYS_I2C_LEGACY=y
++CONFIG_SYS_I2C_MVTWSI=y
++CONFIG_SYS_I2C_SLAVE=0x7f
++CONFIG_SYS_I2C_SPEED=400000
++CONFIG_SUN8I_EMAC=y
++CONFIG_SUPPORT_EMMC_BOOT=y
++CONFIG_PHY_REALTEK=y
++CONFIG_RTL8211F_PHY_FORCE_EEE_RXC_ON=y
++CONFIG_RGMII=y
++CONFIG_RMII=y
++CONFIG_AXP313_POWER=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_MUSB_GADGET=y
+diff --git a/dts/upstream/src/arm64/allwinner/sun50i-h618-kickpi-k2b.dts b/dts/upstream/src/arm64/allwinner/sun50i-h618-kickpi-k2b.dts
+new file mode 100644
+index 00000000000..4da345ca659
+--- /dev/null
++++ b/dts/upstream/src/arm64/allwinner/sun50i-h618-kickpi-k2b.dts
+@@ -0,0 +1,318 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (C) 2025 Patrick Yavitz <pyavitz@gmail.com>
++ */
++
++/dts-v1/;
++
++#include "sun50i-h616.dtsi"
++#include "sun50i-h616-cpu-opp.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/interrupt-controller/arm-gic.h>
++#include <dt-bindings/input/linux-event-codes.h>
++#include <dt-bindings/leds/common.h>
++
++/ {
++	model = "KickPi K2B";
++	compatible = "kickpi,k2b", "allwinner,sun50i-h618";
++
++	aliases {
++		ethernet0 = &emac0;
++		serial0 = &uart0;
++		serial5 = &uart5;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	gpio-keys-polled {
++		compatible = "gpio-keys-polled";
++		poll-interval = <100>;
++
++		button-power {
++			label = "power";
++			linux,code = <KEY_POWER>;
++			gpios = <&pio 2 2 GPIO_ACTIVE_LOW>; /* PC2 */
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			color = <LED_COLOR_ID_BLUE>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&pio 8 16 GPIO_ACTIVE_HIGH>; /* PI6 */
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	reg_usb_vbus: regulator-usb-vbus {
++		/* Separate discrete regulator for the USB ports */
++		compatible = "regulator-fixed";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-name = "usb-vbus";
++		vin-supply = <&reg_vcc5v>;
++	};
++
++	reg_vcc5v: regulator-vcc5v {
++		/* Board wide 5V supply directly from the USB-C socket */
++		compatible = "regulator-fixed";
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-name = "vcc-5v";
++	};
++
++	reg_vcc3v3: vcc3v3 {
++		/* Discrete 3.3V regulator */
++		compatible = "regulator-fixed";
++		regulator-always-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-name = "vcc-3v3";
++		vin-supply = <&reg_vcc5v>;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rtc CLK_OSC32K_FANOUT>;
++		clock-names = "ext_clock";
++		pinctrl-0 = <&x32clk_fanout_pin>;
++		pinctrl-names = "default";
++		post-power-on-delay-ms = <100>;
++		power-off-delay-us = <5000000>;
++		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>, /* PG18 */
++			      <&pio 6 19 GPIO_ACTIVE_LOW>; /* PG19 */
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&reg_dcdc2>;
++};
++
++&emac0 {
++	status = "okay";
++	pinctrl-0 = <&ext_rgmii_pins>;
++	pinctrl-names = "default";
++	phy-mode = "rgmii";
++	phy-handle = <&ext_rgmii_phy>;
++	allwinner,tx-delay-ps = <700>;
++	allwinner,rx-delay-ps = <1700>;
++};
++
++&ehci0 {
++	status = "okay";
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&ehci2 {
++	status = "okay";
++};
++
++&ehci3 {
++	status = "disabled";
++};
++
++&ir {
++	status = "okay";
++	pinctrl-0 = <&ir_rx_pin>;
++	pinctrl-names = "default";
++};
++
++&mdio0 {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-id001c.c916";
++		reg = <1>;
++		reset-assert-us = <20000>;
++		reset-deassert-us = <100000>;
++		reset-gpios = <&pio 8 6 GPIO_ACTIVE_LOW>; /* PI6 */
++	};
++};
++
++/* SD card */
++&mmc0 {
++	status = "okay";
++	bus-width = <4>;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>;	/* PF6 */
++	cd-inverted;
++	disable-wp;
++	max-frequency = <50000000>;
++	vmmc-supply = <&reg_dldo1>;
++};
++
++/* SDIO */
++&mmc1 {
++	status = "okay";
++	bus-width = <4>;
++	keep-power-in-suspend;
++	max-frequency = <100000000>;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	no-mmc;
++	no-sd;
++	non-removable;
++	vmmc-supply = <&reg_dldo1>;
++	vqmmc-supply = <&reg_aldo1>;
++
++	sdio: wifi@1 {
++		reg = <1>;
++	};
++};
++
++/* eMMC */
++&mmc2 {
++	status = "okay";
++	bus-width = <8>;
++	cap-mmc-hw-reset;
++	mmc-hs200-1_8v;
++	non-removable;
++	vmmc-supply = <&reg_dldo1>;
++	vqmmc-supply = <&reg_aldo1>;
++};
++
++&ohci0 {
++	status = "okay";
++};
++
++&ohci1 {
++	status = "okay";
++};
++
++&ohci2 {
++	status = "okay";
++};
++
++&ohci3 {
++	status = "disabled";
++};
++
++&pio {
++	vcc-pc-supply = <&reg_dldo1>;
++	vcc-pf-supply = <&reg_dldo1>;
++	vcc-pg-supply = <&reg_aldo1>;
++	vcc-ph-supply = <&reg_dldo1>;
++	vcc-pi-supply = <&reg_dldo1>;
++	vcc-pl-supply = <&reg_aldo1>;
++
++	// PI16 required for sys_led
++	ext_rgmii_pins: rgmii-pins {
++		pins = "PI0", "PI1", "PI2", "PI3", "PI4",
++		       "PI5", "PI7", "PI8", "PI9", "PI10",
++		       "PI11", "PI12", "PI13", "PI14", "PI15";
++		function = "emac0";
++		drive-strength = <40>;
++	};
++
++	//  Add I2C PH Pins
++	i2c1_ph_pins: i2c1-ph-pins {
++		pins = "PH0", "PH1";
++		function = "i2c1";
++	};
++
++	i2c2_ph_pins: i2c2-ph-pins {
++		pins = "PH2", "PH3";
++		function = "i2c2";
++	};
++
++	i2c4_ph_pins: i2c4-ph-pins {
++		pins = "PH6", "PH7";
++		function = "i2c4";
++	};
++
++	// PC0 required for spi0
++	mmc2_pins: mmc2-pins {
++		pins = "PC1", "PC5", "PC6",
++		       "PC8", "PC9", "PC10", "PC11",
++		       "PC13", "PC14", "PC15", "PC16";
++		function = "mmc2";
++		drive-strength = <30>;
++		bias-pull-up;
++	};
++};
++
++&r_i2c {
++	status = "okay";
++	axp313: pmic@36 {
++		compatible = "x-powers,axp313a";
++		reg = <0x36>;
++		#interrupt-cells = <1>;
++		interrupt-controller;
++		interrupt-parent = <&pio>;
++
++		vin1-supply = <&reg_vcc5v>;
++		vin2-supply = <&reg_vcc5v>;
++		vin3-supply = <&reg_vcc5v>;
++
++		regulators {
++			reg_aldo1: aldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc-1v8-pll";
++			};
++
++			reg_dldo1: dldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc-3v3-io";
++			};
++
++			reg_dcdc1: dcdc1 {
++				regulator-always-on;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <990000>;
++				regulator-name = "vdd-gpu-sys";
++			};
++
++			reg_dcdc2: dcdc2 {
++				regulator-always-on;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <1100000>;
++				regulator-name = "vdd-cpu";
++			};
++
++			reg_dcdc3: dcdc3 {
++				regulator-always-on;
++				regulator-min-microvolt = <1100000>;
++				regulator-max-microvolt = <1500000>;
++				regulator-name = "vdd-dram";
++			};
++		};
++	};
++};
++
++&uart0 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_ph_pins>;
++};
++
++&uart1 {
++	status = "okay";
++	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	pinctrl-names = "default";
++	uart-has-rtscts;
++};
++
++&uart5 {
++	status = "disabled";
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart5_ph_pins>;
++};
++
++&usbotg {
++	status = "okay";
++	dr_mode = "peripheral";
++};
++
++&usbphy {
++	status = "okay";
++	usb1_vbus-supply = <&reg_usb_vbus>;
++};
+-- 
+2.39.5
+
+diff --git a/dts/upstream/src/arm64/allwinner/sun50i-h616.dtsi b/dts/upstream/src/arm64/allwinner/sun50i-h616.dtsi
+index e88c1fbac6a..9a23d4bd05b 100644
+--- a/dts/upstream/src/arm64/allwinner/sun50i-h616.dtsi
++++ b/dts/upstream/src/arm64/allwinner/sun50i-h616.dtsi
+@@ -335,6 +335,24 @@
+ 				function = "uart1";
+ 			};
+ 
++			/omit-if-no-ref/
++			uart4_pi_pins: uart4-pi-pins {
++				pins = "PI13", "PI14";
++				function = "uart4";
++			};
++
++			/omit-if-no-ref/
++			uart4_pi_rts_cts_pins: uart4-pi-rts-cts-pins {
++				pins = "PI15", "PI16";
++				function = "uart4";
++			};
++
++			/omit-if-no-ref/
++			uart5_ph_pins: uart5-ph-pins {
++				pins = "PH2", "PH3";
++				function = "uart5";
++			};
++
+ 			/omit-if-no-ref/
+ 			x32clk_fanout_pin: x32clk-fanout-pin {
+ 				pins = "PG10";

--- a/patch/u-boot/v2025.01/board_kickpik2b/002-sunxi-mmc-Improve-reset-procedure.patch
+++ b/patch/u-boot/v2025.01/board_kickpik2b/002-sunxi-mmc-Improve-reset-procedure.patch
@@ -1,0 +1,116 @@
+From 110909494f8eeae7470321399978c25d9e3af554 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Subject: [PATCH] sunxi: mmc: Improve reset procedure
+Date: Sun,  9 Mar 2025 07:12:41 +0100
+
+Cards should always be reset and threshold set. This fixes eMMC on H616.
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+---
+ drivers/mmc/sunxi_mmc.c | 28 ++++++++++++++++++++++------
+ drivers/mmc/sunxi_mmc.h | 15 +++++++++++++--
+ 2 files changed, 35 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/mmc/sunxi_mmc.c b/drivers/mmc/sunxi_mmc.c
+index 0b56d1405bee..335def4b9738 100644
+--- a/drivers/mmc/sunxi_mmc.c
++++ b/drivers/mmc/sunxi_mmc.c
+@@ -442,6 +442,26 @@ out:
+ 	return error;
+ }
+ 
++static void sunxi_mmc_reset(struct sunxi_mmc *regs)
++{
++	/* Reset controller */
++	writel(SUNXI_MMC_GCTRL_RESET, &regs->gctrl);
++	udelay(1000);
++
++	if (IS_ENABLED(CONFIG_SUN50I_GEN_H6) || IS_ENABLED(CONFIG_SUNXI_GEN_NCAT2)) {
++		/* Reset card */
++		writel(SUNXI_MMC_HWRST_ASSERT, &regs->hwrst);
++		udelay(10);
++		writel(SUNXI_MMC_HWRST_DEASSERT, &regs->hwrst);
++		udelay(300);
++
++		/* Setup FIFO R/W threshold. Needed on H616. */
++		writel(SUNXI_MMC_THLDC_READ_THLD(512) |
++		       SUNXI_MMC_THLDC_WRITE_EN |
++		       SUNXI_MMC_THLDC_READ_EN, &regs->thldc);
++	}
++}
++
+ /* non-DM code here is used by the (ARM) SPL only */
+ 
+ #if !CONFIG_IS_ENABLED(DM_MMC)
+@@ -489,9 +509,7 @@ static int sunxi_mmc_core_init(struct mmc *mmc)
+ {
+ 	struct sunxi_mmc_priv *priv = mmc->priv;
+ 
+-	/* Reset controller */
+-	writel(SUNXI_MMC_GCTRL_RESET, &priv->reg->gctrl);
+-	udelay(1000);
++	sunxi_mmc_reset(priv->reg);
+ 
+ 	return 0;
+ }
+@@ -684,9 +702,7 @@ static int sunxi_mmc_probe(struct udevice *dev)
+ 
+ 	upriv->mmc = &plat->mmc;
+ 
+-	/* Reset controller */
+-	writel(SUNXI_MMC_GCTRL_RESET, &priv->reg->gctrl);
+-	udelay(1000);
++	sunxi_mmc_reset(priv->reg);
+ 
+ 	return 0;
+ }
+diff --git a/drivers/mmc/sunxi_mmc.h b/drivers/mmc/sunxi_mmc.h
+index f4ae5a790c87..9d55904c213c 100644
+--- a/drivers/mmc/sunxi_mmc.h
++++ b/drivers/mmc/sunxi_mmc.h
+@@ -37,7 +37,9 @@ struct sunxi_mmc {
+ 	u32 res0;		/* 0x54 reserved */
+ 	u32 a12a;		/* 0x58 Auto command 12 argument */
+ 	u32 ntsr;		/* 0x5c	New timing set register */
+-	u32 res1[8];
++	u32 res1[6];
++	u32 hwrst;		/* 0x78 Hardware Reset */
++	u32 res5;
+ 	u32 dmac;		/* 0x80 internal DMA control */
+ 	u32 dlba;		/* 0x84 internal DMA descr list base address */
+ 	u32 idst;		/* 0x88 internal DMA status */
+@@ -46,7 +48,8 @@ struct sunxi_mmc {
+ 	u32 cbda;		/* 0x94 */
+ 	u32 res2[26];
+ #if defined(CONFIG_SUNXI_GEN_SUN6I) || defined(CONFIG_SUN50I_GEN_H6) || defined(CONFIG_SUNXI_GEN_NCAT2)
+-	u32 res3[17];
++	u32 thldc;		/* 0x100 Threshold control */
++	u32 res3[16];
+ 	u32 samp_dl;
+ 	u32 res4[46];
+ #endif
+@@ -123,6 +126,9 @@ struct sunxi_mmc {
+ 
+ #define SUNXI_MMC_NTSR_MODE_SEL_NEW		(0x1 << 31)
+ 
++#define SUNXI_MMC_HWRST_ASSERT		(0x0 << 0)
++#define SUNXI_MMC_HWRST_DEASSERT	(0x1 << 0)
++
+ #define SUNXI_MMC_IDMAC_RESET		(0x1 << 0)
+ #define SUNXI_MMC_IDMAC_FIXBURST	(0x1 << 1)
+ #define SUNXI_MMC_IDMAC_ENABLE		(0x1 << 7)
+@@ -133,6 +139,11 @@ struct sunxi_mmc {
+ #define SUNXI_MMC_COMMON_CLK_GATE		(1 << 16)
+ #define SUNXI_MMC_COMMON_RESET			(1 << 18)
+ 
++#define SUNXI_MMC_THLDC_READ_EN		(0x1 << 0)
++#define SUNXI_MMC_THLDC_BSY_CLR_INT_EN	(0x1 << 1)
++#define SUNXI_MMC_THLDC_WRITE_EN	(0x1 << 2)
++#define SUNXI_MMC_THLDC_READ_THLD(x)	(((x) & 0xfff) << 16)
++
+ #define SUNXI_MMC_CAL_DL_SW_EN		(0x1 << 7)
+ 
+ #endif /* _SUNXI_MMC_H */
+-- 
+2.48.1
+

--- a/patch/u-boot/v2025.01/board_kickpik2b/003-sunxi-h616-fix-DRAM-size-detection.patch
+++ b/patch/u-boot/v2025.01/board_kickpik2b/003-sunxi-h616-fix-DRAM-size-detection.patch
@@ -1,0 +1,198 @@
+From 110909494f8eeae7470321399978c25d9e3af554 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Subject: [PATCH 1/2] sunxi: h616: dram: Rework size detection
+Date: Sun,  9 Mar 2025 07:31:42 +0100
+
+Since there is quite a few possible DRAM configurations in terms of bus
+width, rank and rows and columns count, size detection algorithm must be
+very careful not to test combination which would be bigger than H616 is
+actually capable of handling.
+
+Ideally, we should always detect memory aliasing, even for 4 GB memory
+size, which is the maximum amount of memory that H616 is capable of
+handling. For this reason, we have to configure minimum amount of
+supported rows when testing for columns and vice versa. This way test
+code will never step out of 4 GB boundary.
+
+While at it, check for 17 rows maximum. This aligns code with BSP DRAM
+driver. There is probably no such configuration which would make sense
+with 4 GB memory.
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+---
+ arch/arm/mach-sunxi/dram_sun50i_h616.c | 20 ++++++++++++--------
+ 1 file changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/arch/arm/mach-sunxi/dram_sun50i_h616.c b/arch/arm/mach-sunxi/dram_sun50i_h616.c
+index b3554cc64bf5..6f84e59e39cd 100644
+--- a/arch/arm/mach-sunxi/dram_sun50i_h616.c
++++ b/arch/arm/mach-sunxi/dram_sun50i_h616.c
+@@ -1363,7 +1363,7 @@ static void mctl_auto_detect_rank_width(const struct dram_para *para,
+ static void mctl_auto_detect_dram_size(const struct dram_para *para,
+ 				       struct dram_config *config)
+ {
+-	unsigned int shift;
++	unsigned int shift, cols, rows;
+ 
+ 	/* max. config for columns, but not rows */
+ 	config->cols = 11;
+@@ -1373,23 +1373,27 @@ static void mctl_auto_detect_dram_size(const struct dram_para *para,
+ 	shift = config->bus_full_width + 1;
+ 
+ 	/* detect column address bits */
+-	for (config->cols = 8; config->cols < 11; config->cols++) {
+-		if (mctl_mem_matches(1ULL << (config->cols + shift)))
++	for (cols = 8; cols < 11; cols++) {
++		if (mctl_mem_matches(1ULL << (cols + shift)))
+ 			break;
+ 	}
+-	debug("detected %u columns\n", config->cols);
++	debug("detected %u columns\n", cols);
+ 
+ 	/* reconfigure to make sure that all active rows are accessible */
+-	config->rows = 18;
++	config->cols = 8;
++	config->rows = 17;
+ 	mctl_core_init(para, config);
+ 
+ 	/* detect row address bits */
+ 	shift = config->bus_full_width + 4 + config->cols;
+-	for (config->rows = 13; config->rows < 18; config->rows++) {
+-		if (mctl_mem_matches(1ULL << (config->rows + shift)))
++	for (rows = 13; rows < 17; rows++) {
++		if (mctl_mem_matches(1ULL << (rows + shift)))
+ 			break;
+ 	}
+-	debug("detected %u rows\n", config->rows);
++	debug("detected %u rows\n", rows);
++
++	config->cols = cols;
++	config->rows = rows;
+ }
+ 
+ static unsigned long mctl_calc_size(const struct dram_config *config)
+-- 
+2.48.1
+
+
+From 110909494f8eeae7470321399978c25d9e3af554 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Subject: [PATCH 2/2] sunxi: H616: dram: Improve address wrapping detection
+Date: Sun,  9 Mar 2025 07:31:43 +0100
+
+It turns out that checking just one write is not enough. Due to
+unexplained reasons scan procedure detected double the size. By making
+16 dword writes and comparisons that never happens.
+
+New procedure is also inverted. Instead of writing two different values
+to base address and some offset and then reading both and comparing
+values, simplify this by writing pattern at the base address and then
+search for this pattern at some offset.
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+---
+ arch/arm/mach-sunxi/dram_sun50i_h616.c | 58 +++++++++++++++++++++++++-
+ 1 file changed, 56 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/mach-sunxi/dram_sun50i_h616.c b/arch/arm/mach-sunxi/dram_sun50i_h616.c
+index 6f84e59e39cd..1e21f5dd451f 100644
+--- a/arch/arm/mach-sunxi/dram_sun50i_h616.c
++++ b/arch/arm/mach-sunxi/dram_sun50i_h616.c
+@@ -1360,38 +1360,92 @@ static void mctl_auto_detect_rank_width(const struct dram_para *para,
+ 	panic("This DRAM setup is currently not supported.\n");
+ }
+ 
++static void mctl_write_pattern(void)
++{
++	unsigned int i;
++	u32 *ptr, val;
++
++	ptr = (u32 *)CFG_SYS_SDRAM_BASE;
++	for (i = 0; i < 16; ptr++, i++) {
++		if (i & 1)
++			val = ~(ulong)ptr;
++		else
++			val = (ulong)ptr;
++		writel(val, ptr);
++	}
++}
++
++static bool mctl_check_pattern(ulong offset)
++{
++	unsigned int i;
++	u32 *ptr, val;
++
++	ptr = (u32 *)CFG_SYS_SDRAM_BASE;
++	for (i = 0; i < 16; ptr++, i++) {
++		if (i & 1)
++			val = ~(ulong)ptr;
++		else
++			val = (ulong)ptr;
++		if (val != *(ptr + offset / 4))
++			return false;
++	}
++
++	return true;
++}
++
+ static void mctl_auto_detect_dram_size(const struct dram_para *para,
+ 				       struct dram_config *config)
+ {
+ 	unsigned int shift, cols, rows;
++	u32 buffer[16];
+ 
+ 	/* max. config for columns, but not rows */
+ 	config->cols = 11;
+ 	config->rows = 13;
+ 	mctl_core_init(para, config);
+ 
++	/*
++	 * Store content so it can be restored later. This is important
++	 * if controller was already initialized and holds any data
++	 * which is important for restoring system.
++	 */
++	memcpy(buffer, (u32 *)CFG_SYS_SDRAM_BASE, sizeof(buffer));
++
++	mctl_write_pattern();
++
+ 	shift = config->bus_full_width + 1;
+ 
+ 	/* detect column address bits */
+ 	for (cols = 8; cols < 11; cols++) {
+-		if (mctl_mem_matches(1ULL << (cols + shift)))
++		if (mctl_check_pattern(1ULL << (cols + shift)))
+ 			break;
+ 	}
+ 	debug("detected %u columns\n", cols);
+ 
++	/* restore data */
++	memcpy((u32 *)CFG_SYS_SDRAM_BASE, buffer, sizeof(buffer));
++
+ 	/* reconfigure to make sure that all active rows are accessible */
+ 	config->cols = 8;
+ 	config->rows = 17;
+ 	mctl_core_init(para, config);
+ 
++	/* store data again as it might be moved */
++	memcpy(buffer, (u32 *)CFG_SYS_SDRAM_BASE, sizeof(buffer));
++
++	mctl_write_pattern();
++
+ 	/* detect row address bits */
+ 	shift = config->bus_full_width + 4 + config->cols;
+ 	for (rows = 13; rows < 17; rows++) {
+-		if (mctl_mem_matches(1ULL << (rows + shift)))
++		if (mctl_check_pattern(1ULL << (rows + shift)))
+ 			break;
+ 	}
+ 	debug("detected %u rows\n", rows);
+ 
++	/* restore data again */
++	memcpy((u32 *)CFG_SYS_SDRAM_BASE, buffer, sizeof(buffer));
++
+ 	config->cols = cols;
+ 	config->rows = rows;
+ }
+-- 
+2.48.1
+

--- a/patch/u-boot/v2025.01/board_kickpik2b/004-HACK-sunxi-h616-gpu-enable.patch
+++ b/patch/u-boot/v2025.01/board_kickpik2b/004-HACK-sunxi-h616-gpu-enable.patch
@@ -1,0 +1,26 @@
+From e297186797d90041e3f554d5759878e9fd72ed8e Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Date: Wed, 28 Feb 2024 14:15:33 -0500
+Subject: [PATCH] HACK: sunxi: h616 gpu enable
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+---
+ arch/arm/mach-sunxi/clock_sun50i_h6.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm/mach-sunxi/clock_sun50i_h6.c b/arch/arm/mach-sunxi/clock_sun50i_h6.c
+index bea91c78bc..7f60b8c79f 100644
+--- a/arch/arm/mach-sunxi/clock_sun50i_h6.c
++++ b/arch/arm/mach-sunxi/clock_sun50i_h6.c
+@@ -16,6 +16,8 @@ void clock_init_safe(void)
+ 		/* this seems to enable PLLs on H616 */
+ 		setbits_le32(&prcm->sys_pwroff_gating, 0x10);
+ 		setbits_le32(&prcm->res_cal_ctrl, 2);
++		/* enable GPU */
++		writel(0, 0x7010254);
+ 	}
+ 
+ 	if (IS_ENABLED(CONFIG_MACH_SUN50I_H616) ||
+-- 
+2.39.2
+

--- a/patch/u-boot/v2025.01/board_kickpik2b/005-sunxi-h616-ths-workaround.patch
+++ b/patch/u-boot/v2025.01/board_kickpik2b/005-sunxi-h616-ths-workaround.patch
@@ -1,0 +1,33 @@
+From ad10cf66b98acbdc21f431e262633e18b2e93c70 Mon Sep 17 00:00:00 2001
+From: Kali Prasad <kprasadvnsi@protonmail.com>
+Date: Sun, 24 Nov 2024 07:51:12 -0500
+Subject: [PATCH] sunxi: h616 ths workaround
+
+Signed-off-by: Kali Prasad <kprasadvnsi@protonmail.com>
+---
+ board/sunxi/board.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/board/sunxi/board.c b/board/sunxi/board.c
+index 961cdcde74..af2b372a56 100644
+--- a/board/sunxi/board.c
++++ b/board/sunxi/board.c
+@@ -225,6 +225,15 @@ int board_init(void)
+ 	if (ret)
+ 		return ret;
+ 
++#if CONFIG_MACH_SUN50I_H616
++	/*
++	 * The bit[16] of register reg[0x03000000] must be zero for the THS
++	 * driver to work properly in the kernel. The BSP u-boot is putting
++	 * the whole register to zero so we are doing the same.
++	 */
++	writel(0x0, SUNXI_SRAMC_BASE);
++#endif
++
+ 	eth_init_board();
+ 
+ 	return 0;
+-- 
+2.39.5
+

--- a/patch/u-boot/v2025.01/board_kickpik2b/006-mach-sunxi-dram_helpers-add-delay-to-steady-dram-detection.patch
+++ b/patch/u-boot/v2025.01/board_kickpik2b/006-mach-sunxi-dram_helpers-add-delay-to-steady-dram-detection.patch
@@ -1,0 +1,33 @@
+From 110909494f8eeae7470321399978c25d9e3af554 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@gmail.com>
+Date: Mon, 13 May 2024 17:45:57 -0400
+Subject: [PATCH] mach-sunxi: dram_helpers: add delay to steady dram detection
+
+Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
+---
+ arch/arm/mach-sunxi/dram_helpers.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm/mach-sunxi/dram_helpers.c b/arch/arm/mach-sunxi/dram_helpers.c
+index 83dbe4ca98..df7845502d 100644
+--- a/arch/arm/mach-sunxi/dram_helpers.c
++++ b/arch/arm/mach-sunxi/dram_helpers.c
+@@ -11,6 +11,7 @@
+ #include <asm/barriers.h>
+ #include <asm/io.h>
+ #include <asm/arch/dram.h>
++#include <linux/delay.h>
+ 
+ /*
+  * Wait up to 1s for value to be set in given part of reg.
+@@ -45,6 +46,7 @@ bool mctl_mem_matches_base(u32 offset, ulong base)
+ 	writel(0, base);
+ 	writel(0xaa55aa55, base + offset);
+ 	dsb();
++	udelay(150);
+ 	/* Check if the same value is actually observed when reading back */
+ 	ret = readl(base) == readl(base + offset);
+ 
+-- 
+2.39.2
+

--- a/patch/u-boot/v2025.01/board_kickpik2b/007-sunxi-pmic_bus-Move-SPL-I2C-addresses-into-Kconfig.patch
+++ b/patch/u-boot/v2025.01/board_kickpik2b/007-sunxi-pmic_bus-Move-SPL-I2C-addresses-into-Kconfig.patch
@@ -1,0 +1,106 @@
+From 110909494f8eeae7470321399978c25d9e3af554 Mon Sep 17 00:00:00 2001
+From: Andre Przywara <andre.przywara@arm.com>
+Subject: [PATCH] sunxi: pmic_bus: Move SPL I2C addresses into Kconfig
+Date: Tue, 18 Mar 2025 00:39:43 +0000
+
+Some of the X-Power AXP PMICs can be ordered with an alternative I2C
+address, for instance an AXP717 could be shipped with address 0x34 or
+with address 0x35. Similarly the AXP803 lists two possible addresses.
+For DM (DT) based drivers this is no problem, but the Allwinner SPL
+code relies on exactly one hardcoded address per PMIC so far.
+
+Add a Kconfig variable that holds the I2C address used by the PMIC
+accessed in the SPL, and provide the (mostly only one) supported address
+as its default, for the PMICs we use. Boards using the other address
+can easily set this in their defconfig.
+This effectively moves the hardcoding from C code to Kconfig.
+
+That enables to use the AXP717 on some boards with the new Allwinner
+A523 chip, which use the other I2C address there.
+
+Signed-off-by: Andre Przywara <andre.przywara@arm.com>
+---
+ arch/arm/mach-sunxi/pmic_bus.c | 27 ++-------------------------
+ drivers/power/Kconfig          | 10 ++++++++++
+ 2 files changed, 12 insertions(+), 25 deletions(-)
+
+diff --git a/arch/arm/mach-sunxi/pmic_bus.c b/arch/arm/mach-sunxi/pmic_bus.c
+index 8e19324c8ac..c77dc538456 100644
+--- a/arch/arm/mach-sunxi/pmic_bus.c
++++ b/arch/arm/mach-sunxi/pmic_bus.c
+@@ -16,33 +16,10 @@
+ #include <power/pmic.h>
+ #include <asm/arch/pmic_bus.h>
+ 
+-#define AXP152_I2C_ADDR			0x30
+-
+-#define AXP209_I2C_ADDR			0x34
+-#define AXP717_I2C_ADDR			0x34
+-
+-#define AXP305_I2C_ADDR			0x36
+-#define AXP313_I2C_ADDR			0x36
+-
+ #define AXP221_CHIP_ADDR		0x68
+ 
+ #if CONFIG_IS_ENABLED(PMIC_AXP)
+ static struct udevice *pmic;
+-#else
+-static int pmic_i2c_address(void)
+-{
+-	if (IS_ENABLED(CONFIG_AXP152_POWER))
+-		return AXP152_I2C_ADDR;
+-	if (IS_ENABLED(CONFIG_AXP305_POWER))
+-		return AXP305_I2C_ADDR;
+-	if (IS_ENABLED(CONFIG_AXP313_POWER))
+-		return AXP313_I2C_ADDR;
+-	if (IS_ENABLED(CONFIG_AXP717_POWER))
+-		return AXP717_I2C_ADDR;
+-
+-	/* Other AXP2xx and AXP8xx variants */
+-	return AXP209_I2C_ADDR;
+-}
+ #endif
+ 
+ int pmic_bus_init(void)
+@@ -88,7 +65,7 @@ int pmic_bus_read(u8 reg, u8 *data)
+ 	if (IS_ENABLED(CONFIG_SYS_I2C_SUN8I_RSB))
+ 		return rsb_read(AXP_PMIC_PRI_RUNTIME_ADDR, reg, data);
+ 
+-	return i2c_read(pmic_i2c_address(), reg, 1, data, 1);
++	return i2c_read(CONFIG_AXP_I2C_ADDRESS, reg, 1, data, 1);
+ #endif
+ }
+ 
+@@ -102,7 +79,7 @@ int pmic_bus_write(u8 reg, u8 data)
+ 	if (IS_ENABLED(CONFIG_SYS_I2C_SUN8I_RSB))
+ 		return rsb_write(AXP_PMIC_PRI_RUNTIME_ADDR, reg, data);
+ 
+-	return i2c_write(pmic_i2c_address(), reg, 1, &data, 1);
++	return i2c_write(CONFIG_AXP_I2C_ADDRESS, reg, 1, &data, 1);
+ #endif
+ }
+ 
+diff --git a/drivers/power/Kconfig b/drivers/power/Kconfig
+index 5c73bc75a15..eed65058e66 100644
+--- a/drivers/power/Kconfig
++++ b/drivers/power/Kconfig
+@@ -148,6 +148,16 @@ config SY8106A_POWER
+ 
+ endchoice
+ 
++config AXP_I2C_ADDRESS
++	hex "AXP PMIC I2C address"
++	depends on ARCH_SUNXI && !SUNXI_NO_PMIC
++	default 0x36 if AXP305_POWER
++	default 0x36 if AXP313_POWER
++	default 0x30 if AXP152_POWER
++	default 0x34
++	---help---
++	I2C address of the AXP PMIC, used for the SPL only.
++
+ config AXP_DCDC1_VOLT
+ 	int "axp pmic dcdc1 voltage"
+ 	depends on AXP221_POWER || AXP809_POWER || AXP818_POWER || AXP803_POWER
+-- 
+2.46.3
+


### PR DESCRIPTION
The KickPi K2B is another cheap H618 unit.
https://www.kickpi.com/product/k2b/
https://a.co/d/aqIJ3gA

AIC8800 SDIO
```
Firmware is hardcoded to: /lib/firmware/updates/aic8800
aic_powerlimit_8800d80.txt           fmacfw_patch_tbl_8800dc_ipc_u02.bin
aic_powerlimit_8800d80x2.txt         fmacfw_patch_tbl_8800dc_u02.bin
aic_userconfig_8800d80.txt           fmacfw_rf.bin
aic_userconfig_8800d80x2.txt         fw_adid_8800d80_u02.bin
aic_userconfig_8800dc.txt            fw_adid_8800d80x2_u05.bin
aic_userconfig_8800dw.txt            fw_adid_8800dc_u02.bin
aic_userconfig.txt                   fw_adid_8800dc_u02h.bin
fmacfw_8800d80_h_u02.bin             fw_adid.bin
fmacfw_8800d80_h_u02_ipc.bin         fw_adid_u03.bin
fmacfw_8800d80_u02.bin               fw_patch_8800d80_u02.bin
fmacfw_8800d80_u02_ipc.bin           fw_patch_8800d80_u02_ext0.bin
fmacfw_8800d80x2.bin                 fw_patch_8800d80x2_u05.bin
fmacfw_8800m_custmsg.bin             fw_patch_8800dc_u02.bin
fmacfw.bin                           fw_patch_8800dc_u02_ext0.bin
fmacfwbt_8800d80_h_u02.bin           fw_patch_8800dc_u02h.bin
fmacfwbt_8800d80_u02.bin             fw_patch.bin
fmacfwbt.bin                         fw_patch_table_8800d80_u02.bin
fmacfw_calib_8800dc_hbt_u02.bin      fw_patch_table_8800d80x2_u05.bin
fmacfw_calib_8800dc_h_u02.bin        fw_patch_table_8800dc_u02.bin
fmacfw_calib_8800dc_u02.bin          fw_patch_table_8800dc_u02h.bin
fmacfw_patch_8800dc_hbt_u02.bin      fw_patch_table.bin
fmacfw_patch_8800dc_h_u02.bin        fw_patch_table_u03.bin
fmacfw_patch_8800dc_ipc_u02.bin      fw_patch_test.bin
fmacfw_patch_8800dc_u02.bin          fw_patch_u03.bin
fmacfw_patch.bin                     lmacfw_rf_8800d80_u02.bin
fmacfw_patch_tbl_8800dc_hbt_u02.bin  lmacfw_rf_8800d80x2.bin
fmacfw_patch_tbl_8800dc_h_u02.bin    lmacfw_rf_8800dc.bin

Current state of armbian/firmware: /lib/firmware/aic8800/SDIO
aic8800  aic8800D80  aic8800DC <-- these are dir.

Having each variant segregated in a dir is counter productive.
There is no overlap in the firmware. The KickPi K2B can load the
firmware from the same place as the Radxa Zero 3W.
Diff FW; Same location.

We should consider updating the firmware location.
/lib/firmware/aic8800_sdio ?
```

https://paste.armbian.com/iqodabitet.yaml