### PR TITLE
rpi4b: bump `edge` to 6.16

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -37,8 +37,8 @@ case "${BRANCH}" in
 	edge)
 		declare -g EXTRAWIFI="no"
 		declare -g KERNELSOURCE='https://github.com/raspberrypi/linux'
-		declare -g KERNEL_MAJOR_MINOR="6.15" # Major and minor versions of this kernel. For mainline caching.
-		declare -g KERNELBRANCH="branch:rpi-6.15.y"
+		declare -g KERNEL_MAJOR_MINOR="6.16" # Major and minor versions of this kernel. For mainline caching.
+		declare -g KERNELBRANCH="branch:rpi-6.16.y"
 		;;
 esac
 


### PR DESCRIPTION
# Description

Bump `edge` kernel for Raspberry Pi models to latest RC.

# How Has This Been Tested?

- [x] build
- [x] boot on actual RPi4B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
