### PR TITLE
Use logo with white border color

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h2 align="center">
-  <img src="https://raw.githubusercontent.com/armbian/.github/master/profile/logo.png" alt="Armbian logo" width="25%">
+  <img src="https://raw.githubusercontent.com/armbian/.github/master/profile/logowithborder.png" alt="Armbian logo" width="25%">
   <br><br>
 </h2>
 


### PR DESCRIPTION
# Description

Logo is not visible on dark Github theme. Adding a logo with white border fixes it.

Closing https://github.com/armbian/build/issues/8397

# How Has This Been Tested?

<img width="1188" height="612" alt="image" src="https://github.com/user-attachments/assets/14e73f9a-ab60-43a9-897d-3926d50e6d9e" />

# Checklist:

- [x] My code follows the style guidelines of this project
