### PR TITLE
Add AIC8800 SDIO Support

### DIFF
--- a/config/boards/radxa-zero3.csc
+++ b/config/boards/radxa-zero3.csc
@@ -11,10 +11,7 @@ BOOT_FDT_FILE="rockchip/rk3566-radxa-zero3.dtb"
 IMAGE_PARTITION_TABLE="gpt"
 BOOT_SCENARIO="spl-blobs"
 BOOTFS_TYPE="fat" # Only for vendor/legacy
-
-
-AIC8800_TYPE="sdio"
-enable_extension "radxa-aic8800"
+PACKAGE_LIST_BOARD="rfkill bluetooth bluez bluez-tools"
 
 function post_family_config__use_mainline_uboot_except_vendor() {
 	# use mainline u-boot for _current_ and _edge_
@@ -50,4 +47,36 @@ function post_family_config_branch_vendor__radxa-zero3_use_vendor_uboot() {
 	function write_uboot_platform() {
 		dd if=$1/u-boot-rockchip.bin of=$2 seek=64 conv=notrunc status=none
 	}
+}
+
+# AIC8800 Wireless
+function post_family_tweaks_bsp__aic8800_wireless() {
+	display_alert "$BOARD" "Installing AIC8800 Tweaks" "info"
+	mkdir -p "${destination}"/etc/modprobe.d
+	mkdir -p "${destination}"/etc/modules-load.d
+	# Add udev rule
+	cat <<EOF > "${destination}"/etc/modprobe.d/aic8800-wireless.conf
+options aic8800_fdrv aicwf_dbg_level=0 custregd=0 ps_on=0
+options aic8800_bsp aic_fw_path=/lib/firmware/aic8800_sdio
+EOF
+	# Add needed bluetooth modules
+	cat <<EOF > "${destination}"/etc/modules-load.d/aic8800-btlpm.conf
+hidp
+rfcomm
+bnep
+aic8800_btlpm
+EOF
+	if [[ -d "$SRC/packages/bsp/aic8800" ]]; then
+		mkdir -p "${destination}"/etc/systemd/system
+		mkdir -p "${destination}"/usr/bin
+		cp -f "$SRC/packages/bsp/aic8800/aic-bluetooth" "${destination}"/usr/bin
+		chmod +x "${destination}"/usr/bin/aic-bluetooth
+		cp -f "$SRC/packages/bsp/aic8800/aic-bluetooth.service" "${destination}"/etc/systemd/system
+	fi
+}
+
+# Enable AIC8800 Bluetooth Service
+function post_family_tweaks__enable_aic8800_bluetooth_service() {
+	display_alert "$BOARD" "Enabling AIC8800 Bluetooth Service" "info"
+	chroot_sdcard systemctl --no-reload enable aic-bluetooth.service
 }

--- a/lib/functions/compilation/patch/drivers-harness.sh
+++ b/lib/functions/compilation/patch/drivers-harness.sh
@@ -100,6 +100,7 @@ function kernel_drivers_prepare_harness() {
 	# outer scope variable: target_patch_file
 
 	declare -a all_drivers=(
+		driver_aic8800_sdio
 		driver_generic_bring_back_ipx
 		driver_mt7921u_add_pids
 		driver_rtl8152_rtl8153

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -24,6 +24,61 @@
 ### Only 'patch/misc' is hashed to produce drivers hash for the kernel versioning, and using patches that don't
 ### reside there will also lead to problems.
 
+driver_aic8800_sdio() {
+	# Aicsemi aic8800 Wi-Fi driver
+	# https://github.com/radxa-pkg/aic8800
+
+	if linux-version compare "${version}" ge 6.1 && [[ "$LINUXFAMILY" =~ ^(rockchip64)$ ]]; then
+		local aic8800_sdio_ver="commit:fc7cbdd1791416c2457fa27a59e508bf325c9c3f"
+		display_alert "Adding" "Wireless AIC8800 SDIO ${aic8800_sdio_ver}" "info"
+		fetch_from_repo "$GITHUB_SOURCE/radxa-pkg/aic8800.git" "aic8800" "${aic8800_sdio_ver}" "yes"
+		cd "$kerneldir" || exit
+		rm -fdr $kerneldir/drivers/net/wireless/aic8800_sdio
+		cp -fr "${SRC}/cache/sources/aic8800/${aic8800_sdio_ver#*:}/src/SDIO/driver_fw/driver/aic8800" $kerneldir/drivers/net/wireless/aic8800_sdio
+		echo "obj-\$(CONFIG_AIC_WLAN_SUPPORT) += aic8800_sdio/" >> $kerneldir/drivers/net/wireless/Makefile
+		sed -i 's/MAKEFLAGS +=-j$(shell nproc)/#MAKEFLAGS +=-j$(shell nproc)/g' $kerneldir/drivers/net/wireless/aic8800_sdio/Makefile
+		sed -i 's/CONFIG_GPIO_WAKEUP = n/CONFIG_GPIO_WAKEUP = y/g' $kerneldir/drivers/net/wireless/aic8800_sdio/Makefile
+		sed -i 's/CONFIG_SDIO_PWRCTRL := y/CONFIG_SDIO_PWRCTRL := n/g' $kerneldir/drivers/net/wireless/aic8800_sdio/aic8800_bsp/Makefile
+		sed -i '/source "drivers\/net\/wireless\/admtek\/Kconfig"/a source "drivers\/net\/wireless\/aic8800_sdio\/Kconfig"' \
+		"$kerneldir/drivers/net/wireless/Kconfig"
+		# Enable AIC8800 SDIO Modules
+		cat <<EOF > $kerneldir/drivers/net/wireless/aic8800_sdio/Kconfig
+config AIC_WLAN_SUPPORT
+	bool "AIC wireless SDIO Support"
+	default m
+	help
+	  This is support for aic wireless SDIO chips.
+
+config AIC_FW_PATH
+	depends on AIC_WLAN_SUPPORT
+	string "Firmware & config file path"
+	default "/lib/firmware/aic8800_sdio"
+	help
+	  Path to the firmware & config file.
+
+source "drivers/net/wireless/aic8800_sdio/aic8800_fdrv/Kconfig"
+source "drivers/net/wireless/aic8800_sdio/aic8800_btlpm/Kconfig"
+EOF
+		cat <<EOF > $kerneldir/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/Kconfig
+config AIC8800_WLAN_SUPPORT
+	tristate "AIC8800 wlan Support"
+	default m
+	help
+	  This is support for aic wifi driver.
+EOF
+		cat <<EOF > $kerneldir/drivers/net/wireless/aic8800_sdio/aic8800_btlpm/Kconfig
+config AIC8800_BTLPM_SUPPORT
+	tristate "AIC8800 bluetooth Support"
+	default m
+	help
+	  This is support for aic bluetooh driver.
+EOF
+	fi
+	if [[ -f "${SRC}/patch/misc/aic8800_sdio/001-Aicsemi-aic8800-fixups.patch" ]]; then
+		process_patch_file "${SRC}/patch/misc/aic8800_sdio/001-Aicsemi-aic8800-fixups.patch" "applying"
+	fi
+}
+
 function driver_generic_bring_back_ipx() {
 	#
 	# Returning headers needed for some wireless drivers

--- a/packages/bsp/aic8800/aic-bluetooth
+++ b/packages/bsp/aic8800/aic-bluetooth
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# HW Reset
+hciattach -r -s 1500000 /dev/ttyS1 any 1500000 flow nosleep > /dev/null 2>&1
+
+# Kill hciattach
+sleep .50
+killall hciattach
+
+# Attach Bluetooth HCI UART
+sleep .50
+hciattach -s 1500000 /dev/ttyS1 any 1500000 flow nosleep > /dev/null 2>&1
+rfkill unblock all
+
+exit 0

--- a/packages/bsp/aic8800/aic-bluetooth.service
+++ b/packages/bsp/aic8800/aic-bluetooth.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=AIC8800 Bluetooth
+After=bluetooth.service bluetooth.target
+Requires=bluetooth.service bluetooth.target
+
+[Service]
+Type=idle
+ExecStartPre=/usr/sbin/rfkill unblock all
+ExecStart=/usr/bin/aic-bluetooth
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/patch/misc/aic8800_sdio/001-Aicsemi-aic8800-fixups.patch
+++ b/patch/misc/aic8800_sdio/001-Aicsemi-aic8800-fixups.patch
@@ -1,0 +1,645 @@
+From c4299ad3697820e3dd53aff9142c0b3f32de4b2d Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@gmail.com>
+Date: Sun, 6 Jul 2025 21:36:50 -0400
+Subject: [PATCH] Aicsemi aic8800 fixups
+
+Source: https://github.com/radxa-pkg/aic8800
+
+Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
+---
+ .../aic8800_sdio/aic8800_bsp/Makefile         |  9 ++-
+ .../aic8800_sdio/aic8800_bsp/aic_bsp_driver.c |  4 ++
+ .../aic8800_sdio/aic8800_bsp/aicsdio.c        |  8 +++
+ .../aic8800_sdio/aic8800_fdrv/Makefile        |  5 ++
+ .../aic8800_sdio/aic8800_fdrv/aicwf_sdio.c    |  8 +++
+ .../aic8800_sdio/aic8800_fdrv/aicwf_tcp_ack.c | 16 ++++++
+ .../aic8800_sdio/aic8800_fdrv/rwnx_main.c     | 57 ++++++++++++++++++-
+ .../aic8800_fdrv/rwnx_mod_params.c            | 15 ++++-
+ .../aic8800_sdio/aic8800_fdrv/rwnx_msg_tx.c   |  2 +
+ .../aic8800_sdio/aic8800_fdrv/rwnx_platform.c |  4 ++
+ .../aic8800_sdio/aic8800_fdrv/rwnx_radar.c    |  8 +++
+ .../aic8800_sdio/aic8800_fdrv/rwnx_rx.c       | 24 ++++++++
+ .../aic8800_sdio/aic8800_fdrv/rwnx_tdls.c     |  1 +
+ .../aic8800_sdio/aic8800_fdrv/rwnx_tx.c       |  1 +
+ .../aic8800_sdio/aic8800_fdrv/rwnx_txq.c      |  1 +
+ .../aic8800_sdio/aic8800_fdrv/rwnx_wakelock.c |  6 ++
+ 16 files changed, 162 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/Makefile b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/Makefile
+index 138bacd97709..c37d921b087c 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/Makefile
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/Makefile
+@@ -1,7 +1,7 @@
+ CONFIG_SDIO_SUPPORT := y
+ CONFIG_SDIO_PWRCTRL := n
+-CONFIG_AIC_FW_PATH = "/vendor/etc/firmware"
+-#CONFIG_AIC_FW_PATH = "/lib/firmware/aic8800"
++#CONFIG_AIC_FW_PATH = "/vendor/etc/firmware"
++CONFIG_AIC_FW_PATH = "/lib/firmware/aic8800/SDIO/"
+ export CONFIG_AIC_FW_PATH
+ ccflags-y += -DCONFIG_AIC_FW_PATH=\"$(CONFIG_AIC_FW_PATH)\"
+ 
+@@ -130,6 +130,11 @@ KVER ?= $(shell uname -r)
+ MODDESTDIR ?= /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+ ARCH ?= x86_64
+ CROSS_COMPILE ?=
++
++ifeq ($(CONFIG_AW_BSP), y)
++ccflags-y += -DCONFIG_PLATFORM_ALLWINNER
++endif
++
+ endif
+ ###########################################
+ 
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aic_bsp_driver.c b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aic_bsp_driver.c
+index 929c58bc3c5f..ecb1f44225ff 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aic_bsp_driver.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aic_bsp_driver.c
+@@ -468,8 +468,12 @@ void rwnx_rx_handle_msg(struct aic_sdio_dev *sdiodev, struct ipc_e2a_msg *msg)
+ }
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
++MODULE_IMPORT_NS("VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver");
++#else
+ MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+ #endif
++#endif
+ 
+ #define MD5(x) x[0],x[1],x[2],x[3],x[4],x[5],x[6],x[7],x[8],x[9],x[10],x[11],x[12],x[13],x[14],x[15]
+ #define MD5PINRT "file md5:%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\r\n"
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aicsdio.c b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aicsdio.c
+index 813c0f39f8ed..9ed440f912eb 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aicsdio.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_bsp/aicsdio.c
+@@ -1390,7 +1390,11 @@ int aicwf_sdio_busrx_thread(void *data)
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
+ static void aicwf_sdio_bus_pwrctl(struct timer_list *t)
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	struct aic_sdio_dev *sdiodev = timer_container_of(sdiodev, t, timer);
++#else
+ 	struct aic_sdio_dev *sdiodev = from_timer(sdiodev, t, timer);
++#endif
+ #else
+ static void aicwf_sdio_bus_pwrctl(ulong data)
+ {
+@@ -1592,7 +1596,11 @@ void aicwf_sdio_pwrctl_timer(struct aic_sdio_dev *sdiodev, uint duration)
+ 	spin_lock_bh(&sdiodev->pwrctl_lock);
+ 	if (!duration) {
+ 		if (timer_pending(&sdiodev->timer))
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete_sync(&sdiodev->timer);
++#else
+ 			del_timer_sync(&sdiodev->timer);
++#endif
+ 	} else {
+ 		sdiodev->active_duration = duration;
+ 		timeout = msecs_to_jiffies(sdiodev->active_duration);
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/Makefile b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/Makefile
+index 2b24142d6e56..c2441977e48e 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/Makefile
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/Makefile
+@@ -389,6 +389,11 @@ KVER ?= $(shell uname -r)
+ MODDESTDIR ?= /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+ ARCH ?= x86_64
+ CROSS_COMPILE ?=
++
++ifeq ($(CONFIG_AW_BSP), y)
++ccflags-y += -DCONFIG_PLATFORM_ALLWINNER
++endif
++
+ endif
+ ###########################################
+ 
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_sdio.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_sdio.c
+index 455b5bd1e126..e1c4ee392b65 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_sdio.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_sdio.c
+@@ -2287,8 +2287,12 @@ static void aicwf_sdio_bus_pwrctl(struct timer_list *t)
+ {
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+ 	struct aic_sdio_dev *sdiodev = (struct aic_sdio_dev *) data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	struct aic_sdio_dev *sdiodev = timer_container_of(sdiodev, t, timer);
+ #else
+ 	struct aic_sdio_dev *sdiodev = from_timer(sdiodev, t, timer);
++#endif
+ #endif
+ 
+ 	if (sdiodev->bus_if->state == BUS_DOWN_ST) {
+@@ -2478,7 +2482,11 @@ void aicwf_sdio_pwrctl_timer(struct aic_sdio_dev *sdiodev, uint duration)
+ 	spin_lock_bh(&sdiodev->pwrctl_lock);
+ 	if (!duration) {
+ 		if (timer_pending(&sdiodev->timer))
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete_sync(&sdiodev->timer);
++#else
+ 			del_timer_sync(&sdiodev->timer);
++#endif
+ 	} else {
+ 		sdiodev->active_duration = duration;
+ 		timeout = msecs_to_jiffies(sdiodev->active_duration);
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_tcp_ack.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_tcp_ack.c
+index ca47b26cd28c..d74bd8d1f420 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_tcp_ack.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/aicwf_tcp_ack.c
+@@ -106,7 +106,11 @@ void tcp_ack_deinit(struct rwnx_hw *priv)
+ 		drop_msg = NULL;
+ 
+ 		write_seqlock_bh(&ack_m->ack_info[i].seqlock);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++		timer_delete(&ack_m->ack_info[i].timer);
++#else
+ 		del_timer(&ack_m->ack_info[i].timer);
++#endif
+ 		drop_msg = ack_m->ack_info[i].msgbuf;
+ 		ack_m->ack_info[i].msgbuf = NULL;
+ 		write_sequnlock_bh(&ack_m->ack_info[i].seqlock);
+@@ -375,7 +379,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
+ 				//printk("%lx \n",ack_info->msgbuf);
+ 				drop_msg = ack_info->msgbuf;
+ 				ack_info->msgbuf = NULL;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++				timer_delete(&ack_info->timer);
++#else
+ 				del_timer(&ack_info->timer);
++#endif
+ 			}else{
+ 				//printk("msgbuf is NULL \n");
+ 			}
+@@ -409,7 +417,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
+ 				   atomic_read(&ack_m->max_drop_cnt)))) {
+ 			ack_info->drop_cnt = 0;
+ 			ack_info->in_send_msg = new_msgbuf;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_info->timer);
++#else
+ 			del_timer(&ack_info->timer);
++#endif
+ 		} else {
+ 			ret = 1;
+ 			ack_info->msgbuf = new_msgbuf;
+@@ -472,7 +484,11 @@ int tcp_ack_handle_new(struct msg_buf *new_msgbuf,
+ 			ack_info->drop_cnt = 0;
+ 			//send_msg = new_msgbuf;
+ 			ack_info->in_send_msg = new_msgbuf;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete(&ack_info->timer);
++#else
+ 			del_timer(&ack_info->timer);
++#endif
+ 		}else{
+ 			ret = 1;
+ 			ack_info->msgbuf = new_msgbuf;
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_main.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_main.c
+index 3ee11ae36939..0db733f485a1 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_main.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_main.c
+@@ -785,7 +785,9 @@ static void rwnx_csa_finish(struct work_struct *ws)
+ 		} else
+ 			rwnx_txq_vif_stop(vif, RWNX_TXQ_STOP_CHAN, rwnx_hw);
+ 		spin_unlock_bh(&rwnx_hw->cb_lock);
+-#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION3)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
++		cfg80211_ch_switch_notify(vif->ndev, &csa->chandef, 0);
++#elif (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION3)
+ 		cfg80211_ch_switch_notify(vif->ndev, &csa->chandef, 0, 0);
+ #elif (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION)
+ 		cfg80211_ch_switch_notify(vif->ndev, &csa->chandef, 0);
+@@ -1580,6 +1582,7 @@ static struct rwnx_vif *rwnx_interface_add(struct rwnx_hw *rwnx_hw,
+ 		vif->ap.mesh_pm = NL80211_MESH_POWER_ACTIVE;
+ 		vif->ap.next_mesh_pm = NL80211_MESH_POWER_ACTIVE;
+ 		// no break
++		__attribute__((__fallthrough__));
+ 	case NL80211_IFTYPE_AP:
+ 		INIT_LIST_HEAD(&vif->ap.sta_list);
+ 		memset(&vif->ap.bcn, 0, sizeof(vif->ap.bcn));
+@@ -1679,7 +1682,11 @@ void aicwf_p2p_alive_timeout(struct timer_list *t)
+ 	rwnx_vif = (struct rwnx_vif *)data;
+ 	rwnx_hw = rwnx_vif->rwnx_hw;
+ 	#else
++	#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	rwnx_hw = timer_container_of(rwnx_hw, t, p2p_alive_timer);
++	#else
+ 	rwnx_hw = from_timer(rwnx_hw, t, p2p_alive_timer);
++	#endif
+ 	rwnx_vif = rwnx_hw->p2p_dev_vif;
+ 	#endif
+ 
+@@ -1997,6 +2004,7 @@ static int rwnx_cfg80211_change_iface(struct wiphy *wiphy,
+ 		vif->ap.create_path = false;
+ 		vif->ap.generation = 0;
+ 		// no break
++		__attribute__((__fallthrough__));
+ 	case NL80211_IFTYPE_AP:
+ 	case NL80211_IFTYPE_P2P_GO:
+ 		INIT_LIST_HEAD(&vif->ap.sta_list);
+@@ -2121,7 +2129,11 @@ static void rwnx_cfgp2p_stop_p2p_device(struct wiphy *wiphy, struct wireless_dev
+ 	if (rwnx_vif == rwnx_hw->p2p_dev_vif) {
+ 		rwnx_hw->is_p2p_alive = 0;
+ 		if (timer_pending(&rwnx_hw->p2p_alive_timer)) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			timer_delete_sync(&rwnx_hw->p2p_alive_timer);
++#else
+ 			del_timer_sync(&rwnx_hw->p2p_alive_timer);
++#endif
+ 		}
+ 
+ 		if (rwnx_vif->up) {
+@@ -3345,8 +3357,13 @@ static int rwnx_cfg80211_start_ap(struct wiphy *wiphy, struct net_device *dev,
+  * @change_beacon: Change the beacon parameters for an access point mode
+  *	interface. This should reject the call when AP mode wasn't started.
+  */
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
++static int rwnx_cfg80211_change_beacon(struct wiphy *wiphy, struct net_device *dev,
++									   struct cfg80211_ap_update *params)
++#else
+ static int rwnx_cfg80211_change_beacon(struct wiphy *wiphy, struct net_device *dev,
+ 									   struct cfg80211_beacon_data *info)
++#endif
+ {
+ 	struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+ 	struct rwnx_vif *vif = netdev_priv(dev);
+@@ -3359,7 +3376,11 @@ static int rwnx_cfg80211_change_beacon(struct wiphy *wiphy, struct net_device *d
+ 	RWNX_DBG(RWNX_FN_ENTRY_STR);
+ 
+ 	// Build the beacon
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
++	buf = rwnx_build_bcn(bcn, &params->beacon);
++#else
+ 	buf = rwnx_build_bcn(bcn, info);
++#endif
+ 	if (!buf)
+ 		return -ENOMEM;
+ 
+@@ -3427,6 +3448,9 @@ static int rwnx_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *dev)
+  * configured at firmware level.
+  */
+ static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 13, 0)
++											 struct net_device *,
++#endif
+ 											 struct cfg80211_chan_def *chandef)
+ {
+ 	struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+@@ -3481,7 +3505,11 @@ static int rwnx_cfg80211_set_monitor_channel(struct wiphy *wiphy,
+ 
+ int rwnx_cfg80211_set_monitor_channel_(struct wiphy *wiphy,
+                                              struct cfg80211_chan_def *chandef){
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 13, 0)
++    return rwnx_cfg80211_set_monitor_channel(wiphy, NULL, chandef);
++#else
+     return rwnx_cfg80211_set_monitor_channel(wiphy, chandef);
++#endif
+ }
+ 
+ 
+@@ -3582,6 +3610,9 @@ static int rwnx_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *
+ static int rwnx_cfg80211_get_tx_power(struct wiphy *wiphy,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+  struct wireless_dev *wdev,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 14, 0)
++ unsigned int link_id,
++#endif
+ #endif
+ 	int *mbm)
+ {
+@@ -3900,7 +3931,11 @@ static int rwnx_cfg80211_get_channel(struct wiphy *wiphy,
+ 
+ 	if (rwnx_vif->vif_index == rwnx_hw->monitor_vif) {
+ 		//retrieve channel from firmware
++#if LINUX_VERSION_CODE >= KERNEL_VERSION (6, 13, 0)
++		rwnx_cfg80211_set_monitor_channel(wiphy, NULL, NULL);
++#else
+ 		rwnx_cfg80211_set_monitor_channel(wiphy, NULL);
++#endif
+ 	}
+ 
+ 	//Check if channel context is valid
+@@ -3952,6 +3987,7 @@ static int rwnx_cfg80211_mgmt_tx(struct wiphy *wiphy, struct wireless_dev *wdev,
+ 	switch (RWNX_VIF_TYPE(rwnx_vif)) {
+ 	case NL80211_IFTYPE_AP_VLAN:
+ 		rwnx_vif = rwnx_vif->ap_vlan.master;
++		__attribute__((__fallthrough__));
+ 	case NL80211_IFTYPE_AP:
+ 	case NL80211_IFTYPE_P2P_GO:
+ 	case NL80211_IFTYPE_MESH_POINT:
+@@ -4035,6 +4071,9 @@ int rwnx_cfg80211_start_radar_detection(struct wiphy *wiphy,
+ 										struct cfg80211_chan_def *chandef
+ 									#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0))
+ 										, u32 cac_time_ms
++									#endif
++									#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
++										, int link_id
+ 									#endif
+ 										)
+ {
+@@ -4176,7 +4215,9 @@ int rwnx_cfg80211_channel_switch (struct wiphy *wiphy,
+ 		goto end;
+ 	} else {
+ 		INIT_WORK(&csa->work, rwnx_csa_finish);
+-#if LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION4
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
++		cfg80211_ch_switch_started_notify(dev, &csa->chandef, 0, params->count, false);
++#elif LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION4
+ 		cfg80211_ch_switch_started_notify(dev, &csa->chandef, 0, params->count, false, 0);
+ #elif LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2
+ 		cfg80211_ch_switch_started_notify(dev, &csa->chandef, 0, params->count, false);
+@@ -4204,6 +4245,9 @@ rwnx_cfg80211_tdls_mgmt(struct wiphy *wiphy,
+ 	const u8 *peer,
+ #else
+ 	u8 *peer,
++#endif
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0))
++	int link_id,
+ #endif
+ 	u8 action_code,
+ 	u8 dialog_token,
+@@ -4594,6 +4638,7 @@ static int rwnx_fill_station_info(struct rwnx_sta *sta, struct rwnx_vif *vif,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+ 	case FORMATMOD_HE_MU:
+ 		sinfo->rxrate.he_ru_alloc = rx_vect1->he.ru_size;
++		__attribute__((__fallthrough__));
+ 	case FORMATMOD_HE_SU:
+ 	case FORMATMOD_HE_ER:
+ 		sinfo->rxrate.flags = RATE_INFO_FLAGS_HE_MCS;
+@@ -5925,7 +5970,11 @@ void rwnx_cfg80211_deinit(struct rwnx_hw *rwnx_hw)
+ 		list_for_each_entry(defrag_ctrl, &rwnx_hw->defrag_list, list) {
+ 			list_del_init(&defrag_ctrl->list);
+ 			if (timer_pending(&defrag_ctrl->defrag_timer))
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++				timer_delete_sync(&defrag_ctrl->defrag_timer);
++#else
+ 				del_timer_sync(&defrag_ctrl->defrag_timer);
++#endif
+ 			dev_kfree_skb(defrag_ctrl->skb);
+ 			kfree(defrag_ctrl);
+ 		}
+@@ -6052,8 +6101,12 @@ static void __exit rwnx_mod_exit(void)
+ 
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
++MODULE_IMPORT_NS("VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver");
++#else
+ MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+ #endif
++#endif
+ 
+ module_init(rwnx_mod_init);
+ module_exit(rwnx_mod_exit);
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_mod_params.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_mod_params.c
+index 4a9a29853437..acc005ed9908 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_mod_params.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_mod_params.c
+@@ -1585,7 +1585,10 @@ if (rwnx_hw->mod_params->custregd) {
+                "\n\n%s: CAUTION: USING PERMISSIVE CUSTOM REGULATORY RULES\n\n",
+                __func__);
+         wiphy->regulatory_flags |= REGULATORY_CUSTOM_REG;
++		/* From kernel 6.5.0, this bit is removed and will be reused later */
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39) || LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 0))
+         wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
++#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) */
+         wiphy_apply_custom_regulatory(wiphy, regdomain);
+ #elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0))
+         memcpy(country_code, default_ccode, sizeof(default_ccode));
+@@ -1619,7 +1622,10 @@ if (rwnx_hw->mod_params->custregd) {
+ 			   "\n\n%s: CAUTION: USING PERMISSIVE CUSTOM REGULATORY RULES\n\n",
+ 			   __func__);
+ 		wiphy->regulatory_flags |= REGULATORY_CUSTOM_REG;
+-		wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
++		/* From kernel 6.5.0, this bit is removed and will be reused later */
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39) || LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 0))
++        wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
++#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) */
+ 		wiphy_apply_custom_regulatory(wiphy, &rwnx_regdom);
+ #endif
+ 		// Check if custom channel set shall be enabled. In such case only monitor mode is
+@@ -1762,8 +1768,11 @@ void rwnx_custregd(struct rwnx_hw *rwnx_hw, struct wiphy *wiphy)
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0)
+     if (!rwnx_hw->mod_params->custregd)
+         return;
+-
+-    wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
++    
++	/* From kernel 6.5.0, this bit is removed and will be reused later */
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39) || LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 0))
++	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
++#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) */
+     wiphy->regulatory_flags |= REGULATORY_WIPHY_SELF_MANAGED;
+ 
+     rtnl_lock();
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_msg_tx.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_msg_tx.c
+index 8b368ca6984f..73845d59cfc7 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_msg_tx.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_msg_tx.c
+@@ -525,6 +525,7 @@ int rwnx_send_add_if (struct rwnx_hw *rwnx_hw, const unsigned char *mac,
+ 	case NL80211_IFTYPE_P2P_CLIENT:
+ 		add_if_req_param->p2p = true;
+ 		// no break
++		__attribute__((__fallthrough__));
+ 	#endif /* CONFIG_RWNX_FULLMAC */
+ 	case NL80211_IFTYPE_STATION:
+ 		add_if_req_param->type = MM_STA;
+@@ -538,6 +539,7 @@ int rwnx_send_add_if (struct rwnx_hw *rwnx_hw, const unsigned char *mac,
+ 	case NL80211_IFTYPE_P2P_GO:
+ 		add_if_req_param->p2p = true;
+ 		// no break
++		__attribute__((__fallthrough__));
+ 	#endif /* CONFIG_RWNX_FULLMAC */
+ 	case NL80211_IFTYPE_AP:
+ 		add_if_req_param->type = MM_AP;
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_platform.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_platform.c
+index 07682f4e18cc..c7b172d3fde2 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_platform.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_platform.c
+@@ -309,8 +309,12 @@ static int rwnx_plat_tl4_fw_upload(struct rwnx_plat *rwnx_plat, u8 *fw_addr,
+ #endif
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
++MODULE_IMPORT_NS("VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver");
++#else
+ MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+ #endif
++#endif
+ 
+ #if 0
+ /**
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_radar.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_radar.c
+index 358e260c5fe2..f7b9a79613f2 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_radar.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_radar.c
+@@ -1400,7 +1400,11 @@ static void rwnx_radar_cac_work(struct work_struct *ws)
+ 					#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+ 					   &ctxt->chan_def,
+ 					#endif
++					#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++					   NL80211_RADAR_CAC_FINISHED, GFP_KERNEL, 0);
++					#else
+ 					   NL80211_RADAR_CAC_FINISHED, GFP_KERNEL);
++					#endif
+ 	rwnx_send_apm_stop_cac_req(rwnx_hw, radar->cac_vif);
+ 	rwnx_chanctx_unlink(radar->cac_vif);
+ 
+@@ -1500,7 +1504,11 @@ void rwnx_radar_cancel_cac(struct rwnx_radar *radar)
+ 						#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+ 						   &ctxt->chan_def,
+ 						#endif
++						#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++						   NL80211_RADAR_CAC_ABORTED, GFP_KERNEL, 0);
++						#else
+ 						   NL80211_RADAR_CAC_ABORTED, GFP_KERNEL);
++						#endif
+ 		rwnx_chanctx_unlink(radar->cac_vif);
+ 	}
+ 
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_rx.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_rx.c
+index 7b42358c3b1c..5d462cfe918e 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_rx.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_rx.c
+@@ -1408,7 +1408,11 @@ int reord_flush_tid(struct aicwf_rx_priv *rx_priv, struct sk_buff *skb, u8 tid)
+ 	preorder_ctrl->enable = false;
+ 	spin_unlock_irqrestore(&preorder_ctrl->reord_list_lock, flags);
+ 	if (timer_pending(&preorder_ctrl->reord_timer))
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++		ret = timer_delete_sync(&preorder_ctrl->reord_timer);
++#else
+ 		ret = del_timer_sync(&preorder_ctrl->reord_timer);
++#endif
+ 	cancel_work_sync(&preorder_ctrl->reord_timer_work);
+ 
+ 	return 0;
+@@ -1433,7 +1437,11 @@ void reord_deinit_sta(struct aicwf_rx_priv *rx_priv, struct reord_ctrl_info *reo
+ 		if(preorder_ctrl->enable){
+ 			preorder_ctrl->enable = false;
+ 			if (timer_pending(&preorder_ctrl->reord_timer)) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++ 				ret = timer_delete_sync(&preorder_ctrl->reord_timer);
++#else
+ 				ret = del_timer_sync(&preorder_ctrl->reord_timer);
++#endif
+ 			}
+ 			cancel_work_sync(&preorder_ctrl->reord_timer_work);
+ 		}
+@@ -1643,9 +1651,13 @@ void reord_timeout_handler (struct timer_list *t)
+ {
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+ 	struct reord_ctrl *preorder_ctrl = (struct reord_ctrl *)data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	struct reord_ctrl *preorder_ctrl = timer_container_of(preorder_ctrl, t, reord_timer);
+ #else
+ 	struct reord_ctrl *preorder_ctrl = from_timer(preorder_ctrl, t, reord_timer);
+ #endif
++#endif
+ 
+ #if 0 //AIDEN
+ 	struct aicwf_rx_priv *rx_priv = preorder_ctrl->rx_priv;
+@@ -1795,7 +1807,11 @@ int reord_process_unit(struct aicwf_rx_priv *rx_priv, struct sk_buff *skb, u16 s
+ 		}
+ 	} else {
+ 	if (timer_pending(&preorder_ctrl->reord_timer)) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++			ret = timer_delete(&preorder_ctrl->reord_timer);
++#else
+ 			ret = del_timer(&preorder_ctrl->reord_timer);
++#endif
+ 	}
+ 	}
+ 	
+@@ -1893,8 +1909,12 @@ void defrag_timeout_cb(struct timer_list *t)
+ 	struct defrag_ctrl_info *defrag_ctrl = NULL;
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+ 	defrag_ctrl = (struct defrag_ctrl_info *)data;
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++	defrag_ctrl = timer_container_of(defrag_ctrl, t, defrag_timer);
+ #else
+ 	defrag_ctrl = from_timer(defrag_ctrl, t, defrag_timer);
++#endif
+ #endif
+ 
+ 	printk("%s:%p\r\n", __func__, defrag_ctrl);
+@@ -2352,7 +2372,11 @@ u8 rwnx_rxdataind_aicwf(struct rwnx_hw *rwnx_hw, void *hostid, void *rx_priv)
+ 							skb_tmp = defrag_info->skb;
+ 							list_del_init(&defrag_info->list);
+ 							if (timer_pending(&defrag_info->defrag_timer)) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++								ret = timer_delete(&defrag_info->defrag_timer);
++#else
+ 								ret = del_timer(&defrag_info->defrag_timer);
++#endif
+ 							}
+ 							kfree(defrag_info);
+ 							spin_unlock_bh(&rwnx_hw->defrag_lock);
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tdls.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tdls.c
+index 34196edac508..7d9afb935ac7 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tdls.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tdls.c
+@@ -257,6 +257,7 @@ static u8 rwnx_ac_from_wmm(int ac)
+ 	switch (ac) {
+ 	default:
+ 		WARN_ON_ONCE(1);
++		__attribute__((__fallthrough__));
+ 	case 0:
+ 		return AC_BE;
+ 	case 1:
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tx.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tx.c
+index 3f36531c38c9..1621be4173b9 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tx.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_tx.c
+@@ -332,6 +332,7 @@ u16 rwnx_select_txq(struct rwnx_vif *rwnx_vif, struct sk_buff *skb)
+ 		/* AP_VLAN interface is not used for a 4A STA,
+ 		   fallback searching sta amongs all AP's clients */
+ 		rwnx_vif = rwnx_vif->ap_vlan.master;
++		__attribute__((__fallthrough__));
+ 	case NL80211_IFTYPE_AP:
+ 	case NL80211_IFTYPE_P2P_GO:
+ 	{
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_txq.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_txq.c
+index 5468c3a5e067..9bdc07268407 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_txq.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_txq.c
+@@ -640,6 +640,7 @@ static inline void rwnx_txq_vif_for_each_sta(struct rwnx_hw *rwnx_hw, struct rwn
+ 	}
+ 	case NL80211_IFTYPE_AP_VLAN:
+ 		rwnx_vif = rwnx_vif->ap_vlan.master;
++		__attribute__((__fallthrough__));
+ 	case NL80211_IFTYPE_AP:
+ 	case NL80211_IFTYPE_MESH_POINT:
+ 	case NL80211_IFTYPE_P2P_GO:
+diff --git a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_wakelock.c b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_wakelock.c
+index 1d1529627e5e..7c785e952c3d 100644
+--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_wakelock.c
++++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_wakelock.c
+@@ -11,18 +11,24 @@
+ 
+ struct wakeup_source *rwnx_wakeup_init(const char *name)
+ {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+ 	struct wakeup_source *ws;
+ 	ws = wakeup_source_create(name);
+ 	wakeup_source_add(ws);
+ 	return ws;
++#else
++	return NULL;
++#endif
+ }
+ 
+ void rwnx_wakeup_deinit(struct wakeup_source *ws)
+ {
+ 	if (ws && ws->active)
+ 		__pm_relax(ws);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+ 	wakeup_source_remove(ws);
+ 	wakeup_source_destroy(ws);
++#endif
+ }
+ 
+ struct wakeup_source *rwnx_wakeup_register(struct device *dev, const char *name)
+-- 
+2.43.0
+


### PR DESCRIPTION
Add AIC8800 SDIO Support
Add AIC8800 Bluetooth script and service
Radxa Zero 3: Add AIC8800 Wireless Support
Depends-on: https://github.com/armbian/firmware/pull/113

The Radxa Zero 3W was used as a test bed in this case. So we may not want to enable the Bluetooth service out of the box, as there are `RADXA ZERO 3's` that don't use AIC.

NOTE:
This has also been tested on a KickPi K2B (sun50i-h618)
