### PR TITLE
lib / prepare-host: make installation of gcc-arm-linux-gnueabi conditional

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -203,7 +203,6 @@ function adaptative_prepare_host_dependencies() {
 		udev # causes initramfs rebuild, but is usually pre-installed.
 		uuid-dev
 		zlib1g-dev
-		gcc-arm-linux-gnueabi # necessary for rockchip64 (and maybe other too) ATF compilation
 
 		# by-category below
 		file tree expect                         # logging utilities; expect is needed for 'unbuffer' command
@@ -256,7 +255,9 @@ function adaptative_prepare_host_dependencies() {
 	fi
 
 	if [[ "${wanted_arch}" == "arm64" || "${wanted_arch}" == "all" ]]; then
-		host_dependencies+=("gcc-aarch64-linux-gnu") # from crossbuild-essential-arm64
+		# gcc-aarch64-linux-gnu: from crossbuild-essential-arm64
+		# gcc-arm-linux-gnueabi: necessary for rockchip64 (and maybe other too) ATF compilation
+		host_dependencies+=("gcc-aarch64-linux-gnu" "gcc-arm-linux-gnueabi")
 	fi
 
 	if [[ "${wanted_arch}" == "armhf" || "${wanted_arch}" == "all" ]]; then

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -270,7 +270,7 @@ function adaptative_prepare_host_dependencies() {
 	fi
 
 	if [[ "${wanted_arch}" != "amd64" ]]; then
-		host_dependencies+=(libc6-amd64-cross) # Support for running x86 binaries (under qemu on other arches)
+		host_dependencies+=("libc6-amd64-cross") # Support for running x86 binaries (under qemu on other arches)
 	fi
 
 	if [[ "${KERNEL_COMPILER}" == "clang" ]]; then


### PR DESCRIPTION
relax host dependencies and do not install gcc-arm-linux-gnueabi unless targetting arm64 arch [suggested by coderabbitAI](https://github.com/armbian/build/pull/8260#discussion_r2118608963) in #8260

reviewed and implemented by leggewie
