### PR TITLE
U-boot: stop using Denx Git as they have some weird protection in place

### DIFF
--- a/config/sources/families/sun50iw9-bpi.conf
+++ b/config/sources/families/sun50iw9-bpi.conf
@@ -15,7 +15,6 @@ GOVERNOR=ondemand
 
 case $BRANCH in
 	current | edge)
-		declare -g BOOTSOURCE='https://source.denx.de/u-boot/u-boot.git'
 		declare -g BOOTBRANCH="${BOOTBRANCH_BOARD}"
 		declare -g ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
 		declare -g ATFBRANCH='tag:lts-v2.12.1'


### PR DESCRIPTION
# Description

It doesn't like our CI
Sources are defined globally, so we don't need to define them here again.

# How Has This Been Tested?

- [x] Run nightly images re-build

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
