### PR TITLE
bump `edge` to 6.16.0-rc7

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0           # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "6.16" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v6.16-rc3"
+		declare -g KERNELBRANCH="tag:v6.16-rc7"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }


### PR DESCRIPTION
# Description

There were some commits to rockchip related things between rc6 and rc7 so maybe give this another test...or just merge and see what happens.

For the sake of completion full changes between rc3 and rc7: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/diff/?id=v6.16-rc7&id2=v6.16-rc3&dt=2

# How Has This Been Tested?

- [ ] build, pending, not yet, tag not visible to framework yet
- [ ] boot, pending, reason above

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [?] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
