### PR TITLE
Rockchip64 EDGE: fix broken patch

### DIFF
--- a/patch/kernel/archive/rockchip64-6.16/general-workaround-broadcom-bt-serdev.patch
+++ b/patch/kernel/archive/rockchip64-6.16/general-workaround-broadcom-bt-serdev.patch
@@ -9,18 +9,22 @@ Subject: Workaround to make several broadcom bluetooth serdev devices work
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
-index 111111111111..222222222222 100644
+index 3a3a56ddbb06..de66fe473595 100644
 --- a/drivers/bluetooth/btbcm.c
 +++ b/drivers/bluetooth/btbcm.c
-@@ -135,7 +135,7 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
+@@ -133,11 +133,11 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
+ 	    !bacmp(&bda->bdaddr, BDADDR_BCM43341B)) {
+ 		/* Try falling back to BDADDR EFI variable */
  		if (btbcm_set_bdaddr_from_efi(hdev) != 0) {
  			bt_dev_info(hdev, "BCM: Using default device address (%pMR)",
  				    &bda->bdaddr);
--			set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
-+			//set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
+-			hci_set_quirk(hdev, HCI_QUIRK_INVALID_BDADDR);
++			//hci_set_quirk(hdev, HCI_QUIRK_INVALID_BDADDR);
  		}
  	}
  
--- 
+ 	kfree_skb(skb);
+ 
+--
 Armbian
 


### PR DESCRIPTION
# Description

Fixing broken patch. Compilation still fails as there is another problem in the EXTRAWIFI section.

# How Has This Been Tested?

- [x] with EXTRAWIFI=no
- [x] with EXTRAWIFI=yes (FAILS!)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
