### PR TITLE
fix firstlogin failed to create password on sid

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -746,9 +746,17 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 			fi
 		fi
 
-		# only allow one login. Once you enter root password, kill others.
-		loginfrom=$(who am i | awk '{print $2}')
-		who -la | grep root | grep -v "$loginfrom" | awk '{print $7}' | xargs --no-run-if-empty kill -9
+		# Get current session identifiers
+		current_tty=$(tty | sed 's:/dev/::')  # e.g., "tty1"
+		current_pid=$$
+
+		# Kill ONLY other active root SHELL sessions (not login processes)
+		ps -u root -o pid,tty,comm |
+		  awk -v me="$current_tty" -v mypid="$current_pid" '
+		    NR>1 && $2 != "?" && $2 != me && $1 != mypid && $3 ~ /sh$/ {
+		      print $1
+		    }' |
+		  xargs --no-run-if-empty kill -9
 
 		# enable motd
 		chmod +x /etc/update-motd.d/*


### PR DESCRIPTION
# Description

I'm testing sid images. After input of root password at first login, the script will kill the session itself is at, which makes it impossible to go through the fist login.
This is caused by the output of `who -la`:
```
root ? seat0 2025-07-22 08:41 ? 2180
```
which doesn't have something like tty1, then the session itself is killed.

The solution is anwsered by AI.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `PREFER_DOCKER=no ./compile.sh BOARD=uefi-loong64 BRANCH=edge KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes KERNEL_GIT=shallow RELEASE=sid EXPERT=yes BUILD_DESKTOP=no BUILD_MINIMAL=no`
- [x] At first login, both serial and tty1 are logged in, after typing password at tty1, session in serial console is killed and I can retype password.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
