### PR TITLE
rock-5c: Enable thermal sensors for `current`

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3588s-rock-5c.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3588s-rock-5c.dts
@@ -803,6 +803,12 @@
 	};
 };
 
+&tsadc {
+	rockchip,hw-tshut-mode = <1>; /* tshut mode 0:CRU 1:GPIO */
+	rockchip,hw-tshut-polarity = <0>; /* tshut polarity 0:LOW 1:HIGH */
+	status = "okay";
+};
+
 &u2phy0 {
 	status = "okay";
 };


### PR DESCRIPTION
# Description

This PR ports thermal sensors enablement from BSP / `edge` linux kernels to `current`.
Example of enablement in most recent mainline linux kernel: https://github.com/torvalds/linux/blob/5f33ebd2018ced2600b3fad2f8e2052498eb4072/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts#L879

# How Has This Been Tested?

- [x] Build `current` for Rock 5C
  - Burn & run OS image on Rock 5C (Lite, with all 8 cores functional, GPU disabled)
  - [x] Armbian's greeting screen on SSH login picks up CPU temperature
  - [x] Using `lm-sensors` user is able to see thermal sensors (CPUs, GPU, NPU, etc.)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
