### PR TITLE
SMART AM40: add PHY LED configuration

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3399-am40.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3399-am40.dts
@@ -196,11 +196,11 @@
 		simple-audio-card,name = "dp-sound";
 
 		simple-audio-card,cpu {
-			// sound-dai = <&i2s2>;
+			/* sound-dai = <&i2s2>; */
 			sound-dai = <&spdif>;
 		};
 		simple-audio-card,codec {
-			// sound-dai = <&cdn_dp 0>;
+			/* sound-dai = <&cdn_dp 0>; */
 			sound-dai = <&cdn_dp 1>;
 		};
 	};
@@ -252,11 +252,12 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		rtl8211f: ethernet-phy@0 {
+		rtl8211f: rtl8211f@0 {
 			reg = <0>;
 			reset-assert-us = <10000>;
 			reset-deassert-us = <30000>;
 			reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
+			realtek,ledsel = <0x820b>;
 		};
 	};
 };

--- a/patch/kernel/archive/rockchip64-6.16/dt/rk3399-am40.dts
+++ b/patch/kernel/archive/rockchip64-6.16/dt/rk3399-am40.dts
@@ -196,11 +196,11 @@
 		simple-audio-card,name = "dp-sound";
 
 		simple-audio-card,cpu {
-			// sound-dai = <&i2s2>;
+			/* sound-dai = <&i2s2>; */
 			sound-dai = <&spdif>;
 		};
 		simple-audio-card,codec {
-			// sound-dai = <&cdn_dp 0>;
+			/* sound-dai = <&cdn_dp 0>; */
 			sound-dai = <&cdn_dp 1>;
 		};
 	};
@@ -252,11 +252,12 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		rtl8211f: ethernet-phy@0 {
+		rtl8211f: rtl8211f@0 {
 			reg = <0>;
 			reset-assert-us = <10000>;
 			reset-deassert-us = <30000>;
 			reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
+			realtek,ledsel = <0x820b>;
 		};
 	};
 };

--- a/patch/u-boot/v2025.04/board_smart-am40/add-board-smart-am40.patch
+++ b/patch/u-boot/v2025.04/board_smart-am40/add-board-smart-am40.patch
@@ -94,10 +94,10 @@ index 00000000..8ea5266f
 +CONFIG_ERRNO_STR=y
 diff --git a/dts/upstream/src/arm64/rockchip/rk3399-am40.dts b/dts/upstream/src/arm64/rockchip/rk3399-am40.dts
 new file mode 100644
-index 00000000..174a7eb6
+index 00000000..cf667415
 --- /dev/null
 +++ b/dts/upstream/src/arm64/rockchip/rk3399-am40.dts
-@@ -0,0 +1,778 @@
+@@ -0,0 +1,779 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -296,11 +296,11 @@ index 00000000..174a7eb6
 +		simple-audio-card,name = "dp-sound";
 +
 +		simple-audio-card,cpu {
-+			// sound-dai = <&i2s2>;
++			/* sound-dai = <&i2s2>; */
 +			sound-dai = <&spdif>;
 +		};
 +		simple-audio-card,codec {
-+			// sound-dai = <&cdn_dp 0>;
++			/* sound-dai = <&cdn_dp 0>; */
 +			sound-dai = <&cdn_dp 1>;
 +		};
 +	};
@@ -352,11 +352,12 @@ index 00000000..174a7eb6
 +		#address-cells = <1>;
 +		#size-cells = <0>;
 +
-+		rtl8211f: ethernet-phy@0 {
++		rtl8211f: rtl8211f@0 {
 +			reg = <0>;
 +			reset-assert-us = <10000>;
 +			reset-deassert-us = <30000>;
 +			reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
++			realtek,ledsel = <0x820b>;
 +		};
 +	};
 +};


### PR DESCRIPTION
# Description

add PHY LED configuration for SMART AM40, [This](https://github.com/armbian/build/blob/main/patch/kernel/archive/rockchip64-6.12/board-nanopi-r3s-fix-leds.patch) is the driver patch related to it

# How Has This Been Tested?

boot with new dtb

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules