### PR TITLE
Bullseye: drop backport repository as it doesn't exists anymore

### DIFF
--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -92,7 +92,7 @@ function create_sources_list_and_deploy_repo_key() {
 			declare -a security_suites=("${release}-security")
 			declare -a components=(main contrib non-free)
 
-			if [[ "$release" == "buster" ]]; then
+			if [[ "$release" == "buster" || "$release" == "bullseye" ]]; then
 				security_suites=("${release}/updates")
 			else
 			  suites+=("${release}-backports")


### PR DESCRIPTION
# Description

Closing https://github.com/armbian/build/issues/8436

# How Has This Been Tested?

Not tested as just adding new conditon.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
