### PR TITLE
kernel-debs: use dynamic kernel image name installed by installkernel

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -202,8 +202,11 @@ function kernel_package_callback_linux_image() {
 
 	# @TODO: we expect _all_ kernels to produce this, which is... not true.
 	declare kernel_pre_package_path="${tmp_kernel_install_dirs[INSTALL_PATH]}"
-	declare kernel_image_pre_package_path="${kernel_pre_package_path}/vmlinuz-${kernel_version_family}"
-	declare installed_image_path="boot/vmlinuz-${kernel_version_family}" # using old mkdebian terminology here for compatibility
+	kernel_image_installed_file_name=$(basename $(ls ${kernel_pre_package_path}/vmlinu*-${kernel_version_family}))
+	kernel_image_name=${kernel_image_installed_file_name%%-*}
+	display_alert "linux-image deb packaging kernel_image_name" "${kernel_image_name}" "info"
+	declare kernel_image_pre_package_path="${kernel_pre_package_path}/${kernel_image_name}-${kernel_version_family}"
+	declare installed_image_path="boot/${kernel_image_name}-${kernel_version_family}" # using old mkdebian terminology here for compatibility
 
 	display_alert "Showing contents of Kbuild produced /boot" "linux-image" "debug"
 	run_host_command_logged tree -C --du -h "${tmp_kernel_install_dirs[INSTALL_PATH]}"


### PR DESCRIPTION
# Description

`debianutils` has changed kernel image filename for `make Image` from `vmlinuz` to `vmlinux` since v5.20:
https://salsa.debian.org/debian/debianutils/-/commit/b42bb50e142e73e2d9942f2206977ee3836071a0

I'm building kernel on debian trixie host and get error:
```
[🌱] Kernel .deb package version [ 6.16.0-S038d-D50bd-P88eb-C42acH3d80-HK01ba-Vc222-Ba566-R448a ]
[🌱] Packaging linux-image [ arm64 linux-uefi-arm64-edge ]
[🔨]   [ 48M]  /home/jfliu/dev/armbian/build/.tmp/work-33649cea-51ce-43cc-8edf-9817f72aab1c/kernel_dest_install_dir-Om0fE/image/boot
[🔨]   ├── [338K]  config-6.16.0-edge-arm64
[🔨]   ├── [6.8M]  System.map-6.16.0-edge-arm64
[🔨]   └── [ 41M]  vmlinux-6.16.0-edge-arm64
[🔨]   
[🔨]     48M used in 1 directory, 3 files
[🌱] Kernel-built image filetype [ vmlinuz-6.16.0-edge-arm64: cannot open `/home/jfliu/dev/armbian/build/.tmp/work-33649cea-51ce-43cc-8edf-9817f72aab1c/kernel_dest_install_dir-Om0fE/image/boot/vmlinuz-6.16.0-edge-arm64' (No such file or directory) ]
[🔨]   ls: cannot access '/home/jfliu/dev/armbian/build/.tmp/work-33649cea-51ce-43cc-8edf-9817f72aab1c/kernel_dest_install_dir-Om0fE/image/boot/vmlinuz-6.16.0-edge-arm64': No such file or directory
[🔨]   /home/jfliu/dev/armbian/build/.tmp/work-33649cea-51ce-43cc-8edf-9817f72aab1c/kernel_dest_install_dir-Om0fE/image/boot:
[🔨]   total 49144
[🔨]   drwxrwxr-x 2 root root      100 Aug  1 17:34 .
[🔨]   drwxrwxr-x 3 root root       60 Aug  1 17:33 ..
[🔨]   -rw-rw-r-- 1 root root   345986 Aug  1 17:34 config-6.16.0-edge-arm64
[🔨]   -rw-rw-r-- 1 root root  7174907 Aug  1 17:34 System.map-6.16.0-edge-arm64
[🔨]   -rw-rw-r-- 1 root root 42797568 Aug  1 17:34 vmlinux-6.16.0-edge-arm64
```
I use a detected image filename instead.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `PREFER_DOCKER=no ./compile.sh kernel BOARD=uefi-arm64 BRANCH=edge KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes KERNEL_GIT=shallow`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
