### PR TITLE
BPI-M4-Zero: Add KASLR Support and re-enable h616 RTC patches on current

### DIFF
--- a/patch/kernel/archive/sunxi-6.12/dt/sun50i-h618-bananapi-m4.dtsi
+++ b/patch/kernel/archive/sunxi-6.12/dt/sun50i-h618-bananapi-m4.dtsi
@@ -20,6 +20,7 @@
 
 	chosen {
 		stdout-path = "serial0:115200n8";
+		kaslr-seed = <0xfeedbeef 0xc0def00d>;
 	};
 
 	connector {

--- a/patch/kernel/archive/sunxi-6.12/series.conf
+++ b/patch/kernel/archive/sunxi-6.12/series.conf
@@ -301,7 +301,7 @@
 ################################################################################
 	patches.armbian/Doc-dt-bindings-usb-add-binding-for-DWC3-controller-on-Allwinne.patch
 	patches.armbian/drv-pinctrl-pinctrl-sun50i-a64-disable_strict_mode.patch
--	patches.armbian/drv-rtc-sun6i-support-RTCs-without-external-LOSCs.patch
+	patches.armbian/drv-rtc-sun6i-support-RTCs-without-external-LOSCs.patch
 	patches.armbian/drv-gpu-drm-gem-dma-Export-with-handle-allocator.patch
 	patches.armbian/drv-gpu-drm-sun4i-Add-GEM-allocator.patch
 	patches.armbian/Revert-drm-sun4i-hdmi-switch-to-struct-drm_edid.patch
@@ -325,7 +325,7 @@
 	patches.armbian/drv-mfd-axp20x-add-sysfs-interface.patch
 	patches.armbian/drv-spi-spidev-Add-armbian-spi-dev-compatible.patch
 -	patches.armbian/drv-spi-spi-sun4i.c-spi-bug-low-on-sck.patch
--	patches.armbian/drv-rtc-sun6i-Add-Allwinner-H616-support.patch
+	patches.armbian/drv-rtc-sun6i-Add-Allwinner-H616-support.patch
 	patches.armbian/drv-nvmem-sunxi_sid-Support-SID-on-H616.patch
 	patches.armbian/drv-iio-adc-axp20x_adc-arm64-dts-axp803-hwmon-enable-thermal.patch
 	patches.armbian/drv-gpu-drm-panel-simple-Add-compability-olinuxino-lcd.patch

--- a/patch/kernel/archive/sunxi-6.15/dt/sun50i-h618-bananapi-m4.dtsi
+++ b/patch/kernel/archive/sunxi-6.15/dt/sun50i-h618-bananapi-m4.dtsi
@@ -20,6 +20,7 @@
 
 	chosen {
 		stdout-path = "serial0:115200n8";
+		kaslr-seed = <0xfeedbeef 0xc0def00d>;
 	};
 
 	connector {

--- a/patch/u-boot/v2025.07/board_bananapim4zero/001-Add-board-BananaPi-BPI-M4-Zero.patch
+++ b/patch/u-boot/v2025.07/board_bananapim4zero/001-Add-board-BananaPi-BPI-M4-Zero.patch
@@ -338,3 +338,36 @@ index 00000000000..d0442ca9692
 -- 
 2.43.0
 
+From 99cf1c27b0e94fee704f683ba0f338b239de6bdf Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@gmail.com>
+Date: Sun, 3 Aug 2025 09:13:29 -0400
+Subject: [PATCH] Enable KASLR
+
+Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
+---
+ configs/bananapi_m4zero_defconfig | 2 ++
+ 1 files changed, 2 insertions(+)
+
+diff --git a/configs/bananapi_m4zero_defconfig b/configs/bananapi_m4zero_defconfig
+index 6d70efd1a50..0c41226db49 100644
+--- a/configs/bananapi_m4zero_defconfig
++++ b/configs/bananapi_m4zero_defconfig
+@@ -17,6 +17,7 @@ CONFIG_DRAM_CLK=792
+ CONFIG_MMC_SUNXI_SLOT_EXTRA=2
+ CONFIG_R_I2C_ENABLE=y
+ # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_CMD_KASLRSEED=y
+ CONFIG_SPL_I2C=y
+ CONFIG_SPL_SYS_I2C_LEGACY=y
+ CONFIG_SYS_I2C_MVTWSI=y
+@@ -25,6 +26,7 @@ CONFIG_SYS_I2C_SPEED=400000
+ CONFIG_SUN8I_EMAC=y
+ CONFIG_SUPPORT_EMMC_BOOT=y
+ CONFIG_AXP313_POWER=y
++CONFIG_DM_RNG=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_OHCI_HCD=y
+ CONFIG_USB_MUSB_GADGET=y
+-- 
+2.43.0
+


### PR DESCRIPTION
Kernel Address Space Layout Randomization (KASLR) is a security feature in the Linux kernel that randomizes the location where the kernel is loaded into memory at boot time. This randomization makes it more difficult for attackers to predict the kernel's memory layout, which is often necessary for successful exploitation of vulnerabilities.

---

RTC Patches:
https://forum.armbian.com/topic/51641-not-getting-any-wireless/#findComment-223439

They were originally disabled as they were found to be faulty, which lead to me also needing to re-work the defconfigs. My work on `CURRENT` was halted, but was allowed to continue on `EDGE`. As a result, the patches never got re-enabled on CURRENT `due to my own stupidity` and this is breaking the SDIO pwrseq.

Simply re-enabling them fixes the issue on CURRENT.
