### PR TITLE
rockchip64: add u-boot binman-mainline-atf boot scenario

### DIFF
--- a/config/boards/orangepi4-lts.conf
+++ b/config/boards/orangepi4-lts.conf
@@ -15,7 +15,7 @@ ASOUND_STATE="asound.state.rk3399"
 BOOT_LOGO="desktop"
 BOOTBRANCH_BOARD="tag:v2025.01"
 BOOTPATCHDIR="v2025.01"
-BOOT_SCENARIO="binman"
+BOOT_SCENARIO="binman-mainline-atf"
 
 function post_family_tweaks_bsp__OPi4lts() {
 	display_alert "Installing BSP firmware and fixups"

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -57,6 +57,11 @@ esac
 # - tpl-blob-atf-mainline: proprietary rockchip ddrbin + mainline u-boot SPL + mainline ATF
 # - blobless: mainline u-boot TPL + mainline u-boot SPL + mainline ATF
 # - binman:  u-boot builds full boot image from information in device tree.  See: https://docs.u-boot.org/en/latest/develop/package/binman.html
+# - binman-mainline-atf: like "binman" scenario, but also compiles mainline opensource ATF instead of proprietary blob
+#
+# A note about binman configurations and use of ddrbin blob or u-boot TPL: 
+# - if CONFIG_ROCKCHIP_EXTERNAL_TPL=y, ROCKCHIP_TPL env variable must point to the ddrbin binary blob that will be shipped in the final binary
+# - if CONFIG_ROCKCHIP_EXTERNAL_TPL is unset, then ROCKCHIP_TPL env var is ignored and then u-boot TPL is built and shipped in the final binary
 
 #BOOT_SOC=`expr $BOOTCONFIG : '.*\(rk[[:digit:]]\+.*\)_.*'`
 BOOT_SOC=${BOOT_SOC:=$(expr $BOOTCONFIG : '.*\(rk[[:digit:]]\+.*\)_.*' || true)}
@@ -157,19 +162,25 @@ case "$BOOT_SOC" in
 esac
 
 prepare_boot_configuration() {
+
+	# We setup the necessary bits to compile mainline Arm Trusted Firmware
+	# but ATF_COMPILE='no' means that, by default, we don't want to compile it.
+	# Scenarios using mainline ATF just have to set ATF_COMPILE='yes'
+	# to trigger the compilation
 	ATFSOURCE=''
 	ATF_COMPILE='no'
+	ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
+	ATF_COMPILER='aarch64-linux-gnu-'
+	ATFDIR='arm-trusted-firmware'
+	ATFBRANCH='tag:v2.13.0'
+	ATF_USE_GCC='> 6.3'
+	ATF_TARGET_MAP="M0_CROSS_COMPILE=arm-linux-gnueabi- PLAT=$BOOT_SOC bl31;;build/$BOOT_SOC/release/bl31/bl31.elf:bl31.elf"
+	ATF_TOOLCHAIN2="arm-linux-gnueabi-:< 10.0"
+
 	case "$BOOT_SCENARIO" in
 		blobless | tpl-blob-atf-mainline)
 			UBOOT_TARGET_MAP="BL31=bl31.elf idbloader.img u-boot.itb;;idbloader.img u-boot.itb"
 			ATF_COMPILE=yes
-			ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
-			ATF_COMPILER='aarch64-linux-gnu-'
-			ATFDIR='arm-trusted-firmware'
-			ATFBRANCH='tag:v2.13.0'
-			ATF_USE_GCC='> 6.3'
-			ATF_TARGET_MAP="M0_CROSS_COMPILE=arm-linux-gnueabi- PLAT=$BOOT_SOC bl31;;build/$BOOT_SOC/release/bl31/bl31.elf:bl31.elf"
-			ATF_TOOLCHAIN2="arm-linux-gnueabi-:< 10.0"
 
 			[[ $BOOT_SCENARIO == tpl-blob-atf-mainline ]] &&
 				UBOOT_TARGET_MAP="BL31=bl31.elf idbloader.img u-boot.itb;;idbloader.img u-boot.itb"
@@ -185,6 +196,10 @@ prepare_boot_configuration() {
 			;;
 		binman)
 			UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
+			;;
+		binman-mainline-atf)
+			ATF_COMPILE='yes'
+			UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"
 			;;
 	esac
 
@@ -209,7 +224,7 @@ uboot_custom_postprocess() {
 	display_alert "${BOARD}" "boots with ${BOOT_SCENARIO} scenario" "info"
 
 	case "$BOOT_SCENARIO" in
-		blobless | tpl-spl-blob | binman)
+		blobless | tpl-spl-blob | binman | binman-mainline-atf)
 			:
 			;;
 


### PR DESCRIPTION
# Description

Introduces a new u-boot boot scenario `binman-mainline-atf`, allowing the usage of binman and also the compilation of mainline opensource ATF.

A discussion about possible broader compatibility arose from [this](https://github.com/armbian/community/issues/39#issuecomment-3147988149) gihtub issue about Radxa Rock4 SE board

As a proof of working functionality, Orange PI 4 LTS has been switched to this new boot scenario.

I moved the ATF env variables outside the `blobless` scenario to avoid code duplication; as long as `ATF_COMPILE='no'` they should pose no problems with other non-binman boards, but if someone can confirm this I will be happier.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2722]

# How Has This Been Tested?

- [x] Orange PI 4 LTS fresh image built and tested with success

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


[AR-2722]: https://armbian.atlassian.net/browse/AR-2722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ