### PR TITLE
Rock5B+: Use Collabora u-boot for all branches

### DIFF
--- a/config/boards/rock-5b-plus.conf
+++ b/config/boards/rock-5b-plus.conf
@@ -34,9 +34,9 @@ function post_family_config_branch_vendor__rock-5b_use_mainline_uboot() {
 
 	declare -g BOOTCONFIG="rock5b-rk3588_defconfig"              # override the default for the board/family
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
-	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline tree
-	declare -g BOOTBRANCH="branch:master"                         #
-	declare -g BOOTPATCHDIR="master"                           # empty; defconfig changes are done in hook below
+	declare -g BOOTSOURCE="https://gitlab.collabora.com/hardware-enablement/rockchip-3588/u-boot.git" # We ❤️ Mainline tree
+	declare -g BOOTBRANCH="branch:rockchip"                         #
+	declare -g BOOTPATCHDIR="collabora-rockchip"                           # empty; defconfig changes are done in hook below
 	declare -g BOOTDIR="u-boot-${BOARD}"                         # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
@@ -60,9 +60,9 @@ function post_family_config_branch_edge__rock-5b_use_mainline_uboot() {
 
 	declare -g BOOTCONFIG="rock5b-rk3588_defconfig"              # override the default for the board/family
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
-	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline tree
-	declare -g BOOTBRANCH="branch:master"                         #
-	declare -g BOOTPATCHDIR="master"                           # empty; defconfig changes are done in hook below
+	declare -g BOOTSOURCE="https://gitlab.collabora.com/hardware-enablement/rockchip-3588/u-boot.git" # We ❤️ Mainline tree
+	declare -g BOOTBRANCH="branch:rockchip"                         #
+	declare -g BOOTPATCHDIR="collabora-rockchip"                           # empty; defconfig changes are done in hook below
 	declare -g BOOTDIR="u-boot-${BOARD}"                         # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already

--- a/config/boards/rock-5b-plus.conf
+++ b/config/boards/rock-5b-plus.conf
@@ -28,7 +28,30 @@ function post_family_tweaks__rock5b_naming_audios() {
 }
 
 # Mainline u-boot tree
-# see rock-5b.conf and https://github.com/armbian/build/pull/7135
+# Vendor:
+function post_family_config_branch_vendor__rock-5b_use_mainline_uboot() {
+	display_alert "$BOARD" "vendor u-boot overrides for $BOARD / $BRANCH" "info"
+
+	declare -g BOOTCONFIG="rock5b-rk3588_defconfig"              # override the default for the board/family
+	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline tree
+	declare -g BOOTBRANCH="branch:master"                         #
+	declare -g BOOTPATCHDIR="master"                           # empty; defconfig changes are done in hook below
+	declare -g BOOTDIR="u-boot-${BOARD}"                         # do not share u-boot directory
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+
+	function write_uboot_platform_mtd() {
+		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
+	}
+}
+
+# Edge:
 function post_family_config_branch_edge__rock-5b_use_mainline_uboot() {
 	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
 
@@ -38,8 +61,8 @@ function post_family_config_branch_edge__rock-5b_use_mainline_uboot() {
 	declare -g BOOTCONFIG="rock5b-rk3588_defconfig"              # override the default for the board/family
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline tree
-	declare -g BOOTBRANCH="tag:v2025.04"                         #
-	declare -g BOOTPATCHDIR="v2025.04"                           # empty; defconfig changes are done in hook below
+	declare -g BOOTBRANCH="branch:master"                         #
+	declare -g BOOTPATCHDIR="master"                           # empty; defconfig changes are done in hook below
 	declare -g BOOTDIR="u-boot-${BOARD}"                         # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
@@ -55,8 +78,6 @@ function post_family_config_branch_edge__rock-5b_use_mainline_uboot() {
 }
 
 function post_config_uboot_target__extra_configs_for_rock5b_mainline_environment_in_spi() {
-	[[ "${BRANCH}" != "edge" ]] && return 0
-
 	display_alert "$BOARD" "u-boot configs for ${BOOTBRANCH} u-boot config BRANCH=${BRANCH}" "info"
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_NOWHERE "n"
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_IN_SPI_FLASH "y"

--- a/patch/u-boot/collabora-rockchip/0001-nvme-before-emmc.patch
+++ b/patch/u-boot/collabora-rockchip/0001-nvme-before-emmc.patch
@@ -1,0 +1,23 @@
+From 185bf38642ba3fd90c247cd9e37c45ff3d2be0d4 Mon Sep 17 00:00:00 2001
+From: Mecid <mecid@mecomediagroup.de>
+Date: Sun, 3 Aug 2025 20:43:14 +0200
+Subject: [PATCH] Rockchip: Change boot order to nvme before emmc
+
+Many boards have soldered emmc but optional m.2 slots. If NVMe has a boot target it's likely the user wants to boot of it instead of emmc.
+---
+ include/configs/rockchip-common.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/rockchip-common.h b/include/configs/rockchip-common.h
+index d5550a46575..fb7f120eb99 100644
+--- a/include/configs/rockchip-common.h
++++ b/include/configs/rockchip-common.h
+@@ -14,7 +14,7 @@
+ #ifndef CONFIG_XPL_BUILD
+ 
+ #ifndef BOOT_TARGETS
+-#define BOOT_TARGETS	"mmc1 mmc0 nvme scsi usb pxe dhcp spi"
++#define BOOT_TARGETS	"mmc1 nvme mmc0 scsi usb pxe dhcp spi"
+ #endif
+ 
+ #ifdef CONFIG_ARM64

--- a/patch/u-boot/collabora-rockchip/cmd-fileenv-read-string-from-file-into-env.patch
+++ b/patch/u-boot/collabora-rockchip/cmd-fileenv-read-string-from-file-into-env.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Fri, 31 Jan 2025 15:52:03 +0100
+Subject: cmd: fileenv: read string from file into env
+
+- rpardini: adapted from vendor/legacy patch from 2018
+
+Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ cmd/Kconfig   |  5 +
+ cmd/Makefile  |  1 +
+ cmd/fileenv.c | 46 ++++++++++
+ 3 files changed, 52 insertions(+)
+
+diff --git a/cmd/Kconfig b/cmd/Kconfig
+index 111111111111..222222222222 100644
+--- a/cmd/Kconfig
++++ b/cmd/Kconfig
+@@ -1825,6 +1825,11 @@ config CMD_XXD
+ 	help
+ 	  Print file as hexdump to standard output
+ 
++config CMD_FILEENV
++	bool "fileenv"
++	help
++	   Read a file into memory and store it to env.
++
+ endmenu
+ 
+ if NET || NET_LWIP
+diff --git a/cmd/Makefile b/cmd/Makefile
+index 111111111111..222222222222 100644
+--- a/cmd/Makefile
++++ b/cmd/Makefile
+@@ -173,6 +173,7 @@ obj-$(CONFIG_CMD_SHA1SUM) += sha1sum.o
+ obj-$(CONFIG_CMD_SEAMA) += seama.o
+ obj-$(CONFIG_CMD_SETEXPR) += setexpr.o
+ obj-$(CONFIG_CMD_SETEXPR_FMT) += printf.o
++obj-$(CONFIG_CMD_FILEENV) += fileenv.o
+ obj-$(CONFIG_CMD_SPI) += spi.o
+ obj-$(CONFIG_CMD_STRINGS) += strings.o
+ obj-$(CONFIG_CMD_SMBIOS) += smbios.o
+diff --git a/cmd/fileenv.c b/cmd/fileenv.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/cmd/fileenv.c
+@@ -0,0 +1,46 @@
++#include <config.h>
++#include <command.h>
++#include <fs.h>
++#include <linux/ctype.h>
++#include <vsprintf.h>
++
++static char *fs_argv[5];
++
++int do_fileenv(struct cmd_tbl *cmdtp, int flag, int argc, char * const argv[])
++{
++	if (argc < 6)
++		return CMD_RET_USAGE;
++
++	fs_argv[0] = "fatload";
++	fs_argv[1] = argv[1];
++	fs_argv[2] = argv[2];
++	fs_argv[3] = argv[3];
++	fs_argv[4] = argv[4];
++
++	if (do_fat_fsload(cmdtp, 0, 5, fs_argv) != 0)
++		return 1;
++
++	char *addr = (char *)simple_strtoul(argv[3], NULL, 16);
++	size_t size = env_get_hex("filesize", 0);
++
++	// Prepare string
++	addr[size] = 0x00;
++	char *s = addr;
++	while(*s != 0x00) {
++		if (isprint(*s)) {
++			s++;
++		}
++		else {
++			*s = 0x00;
++		}
++	}
++
++	return env_set(argv[5], addr);
++}
++
++U_BOOT_CMD(
++	fileenv, 6, 0, do_fileenv,
++	"Read file and store it into env.",
++	"<interface> <dev:part> <addr> <filename> <envname>\n"
++	"    - Read file from fat32 and store it as env."
++);
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

The 2024.10 Rockchip vendor u-boot has issues with Ubuntu Noble hosts. 
To mitigate on Rock5B+ (platinum support) we can switch to collabora u-boot for both vendor and edge scenarios.

Note: `rock5b-rk3588_defconfig` in collabora includes a DDR5 check that determines it to be a Rock-5B-Plus or DDR4 for Rock5B

GitHub Issue: https://github.com/armbian/build/issues/8227
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2699]

# Documentation summary for feature / change

1. Add Family overwrite in board config to use collabora u-boot
2. Switch both configurations to collabora `rockchip` branch
3. Add boot order patch SD - NVME - EMMC -...

# How Has This Been Tested?

- [x] Boot Image with vendor kernel
- [x] Boot Image with edge kernel
- [x]  Install to NVMe & SPI
- [x] Switch NVMe drive slots and preserve booting functionality 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2699]: https://armbian.atlassian.net/browse/AR-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ