### PR TITLE
repo: add loong64 support

### DIFF
--- a/tools/repository/repo
+++ b/tools/repository/repo
@@ -135,7 +135,7 @@ publishing(){
 
 		aptly publish \
 			-skip-signing \
-			-architectures="armhf,arm64,amd64,riscv64,i386,all" \
+			-architectures="armhf,arm64,amd64,riscv64,i386,loong64,all" \
 			-passphrase="${4}" \
 			-origin="Armbian" \
 			-label="Armbian" \


### PR DESCRIPTION
This adds loong64 support to repo script, which will be used in workflow at https://github.com/armbian/os/blob/main/.github/workflows/repository-update.yml