### PR TITLE
fix build dep gcc-loongarch64-linux-gnu introduced by new arch loong64

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -269,7 +269,7 @@ function adaptative_prepare_host_dependencies() {
 		host_dependencies+=("debian-archive-keyring")
 	fi
 
-	if [[ "${wanted_arch}" == "loong64" || "${wanted_arch}" == "all" ]]; then
+	if [[ "${wanted_arch}" == "loong64" ]]; then
 		host_dependencies+=("gcc-loongarch64-linux-gnu") # crossbuild-essential-loongarch64 is not even available "yet"
 		host_dependencies+=("debian-ports-archive-keyring")
 	fi


### PR DESCRIPTION
# Description

Fixes #8459

#8419 has introduced a new build dep `gcc-loongarch64-linux-gnu` which is only available in trixie. Function `adaptative_prepare_host_dependencies` runs twice: first time without env `target_arch` so `wanted_arch` is all, second time with env `target_arch` and then it will install arch specific deps.

I let host only install `gcc-loongarch64-linux-gnu` for loong64 at second time so it will not harm other architectures.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=rock-5b`
- [x] `DOCKER_ARMBIAN_BASE_IMAGE="debian:trixie" ./compile.sh BOARD=uefi-loong64`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
