### PR TITLE
MBa8MPxL: fix overlays for lvds and camera

### DIFF
--- a/patch/kernel/archive/imx8m-6.12/0003-TQMa8MPXL-LDO5-Fix.patch
+++ b/patch/kernel/archive/imx8m-6.12/0003-TQMa8MPXL-LDO5-Fix.patch
@@ -1,18 +1,18 @@
-From 17f6e064d93013f2aaca40e9f44bf2c5b45652eb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Schmiedel <martin.schmiedel@tq-group.com>
 Date: Thu, 5 Jun 2025 13:11:40 +0200
-Subject: [PATCH] TQMa8MPXL LDO5 Fix
+Subject: TQMa8MPXL LDO5 Fix
 
 Signed-off-by: Martin Schmiedel <martin.schmiedel@tq-group.com>
 Signed-off-by: Markus Niebel <Markus.Niebel@ew.tq-group.com>
 ---
- .../imx8mp-tqma8mpql-mba8mp-ras314.dts        | 13 ++---
- .../freescale/imx8mp-tqma8mpql-mba8mpxl.dts   | 13 ++---
- .../boot/dts/freescale/imx8mp-tqma8mpql.dtsi  | 48 +++++++++++++++----
+ arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mp-ras314.dts | 13 +--
+ arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mpxl.dts      | 13 +--
+ arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql.dtsi              | 48 ++++++++--
  3 files changed, 53 insertions(+), 21 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mp-ras314.dts b/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mp-ras314.dts
-index d7fd9d36f824..f7346b3d35fe 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mp-ras314.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mp-ras314.dts
 @@ -467,6 +467,10 @@ &pwm4 {
@@ -57,7 +57,7 @@ index d7fd9d36f824..f7346b3d35fe 100644
  
  	pinctrl_usdhc2_gpio: usdhc2-gpiogrp {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mpxl.dts b/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mpxl.dts
-index ae64731266f3..e7c16a7ee6c2 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mpxl.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mpxl.dts
 @@ -603,6 +603,10 @@ &pwm3 {
@@ -102,7 +102,7 @@ index ae64731266f3..e7c16a7ee6c2 100644
  
  	pinctrl_usdhc2_gpio: usdhc2-gpiogrp {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql.dtsi b/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql.dtsi
-index 3ddc5aaa7c5f..05a518209b59 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql.dtsi
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql.dtsi
 @@ -16,13 +16,26 @@ memory@40000000 {
@@ -255,5 +255,5 @@ index 3ddc5aaa7c5f..05a518209b59 100644
  		fsl,pins = <MX8MP_IOMUXC_NAND_WE_B__USDHC3_CLK		0x194>,
  			   <MX8MP_IOMUXC_NAND_WP_B__USDHC3_CMD		0x1d4>,
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/imx8m-6.12/0004-TQMa8MPXL-build-device-tree-overlays.patch
+++ b/patch/kernel/archive/imx8m-6.12/0004-TQMa8MPXL-build-device-tree-overlays.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Schmiedel <martin.schmiedel@tq-group.com>
+Date: Mon, 4 Aug 2025 10:02:56 +0200
+Subject: TQMa8MPXL: build device-tree overlays
+
+Signed-off-by: Martin Schmiedel <martin.schmiedel@tq-group.com>
+---
+ arch/arm64/boot/dts/freescale/Makefile | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/freescale/Makefile b/arch/arm64/boot/dts/freescale/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/freescale/Makefile
++++ b/arch/arm64/boot/dts/freescale/Makefile
+@@ -209,6 +209,10 @@ dtb-$(CONFIG_ARCH_MXC) += imx8mp-tqma8mpql-mba8mpxl-lvds-g133han01.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-tqma8mpql-mba8mp-ras314-imx219.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-tqma8mpql-mba8mp-ras314-lvds.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-tqma8mpql-mba8mp-ras314-lvds-imx219.dtb
++# build device-tree overlays
++dtb-$(CONFIG_ARCH_MXC) += imx8mp-tqma8mpql-mba8mpxl-lvds.dtbo
++dtb-$(CONFIG_ARCH_MXC) += imx8mp-tqma8mpql-mba8mpxl-lvds-g133han01.dtbo
++dtb-$(CONFIG_ARCH_MXC) += imx8mp-tqma8mpql-mba8mp-ras314-imx219.dtbo
+ 
+ dtb-$(CONFIG_ARCH_MXC) += imx8mq-evk.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mq-hummingboard-pulse.dtb
+@@ -293,3 +297,7 @@ dtb-$(CONFIG_ARCH_S32) += s32g274a-evb.dtb
+ dtb-$(CONFIG_ARCH_S32) += s32g274a-rdb2.dtb
+ dtb-$(CONFIG_ARCH_S32) += s32g399a-rdb3.dtb
+ dtb-$(CONFIG_ARCH_S32) += s32v234-evb.dtb
++
++# Enable support for device-tree overlays
++DTC_FLAGS_imx8mp-tqma8mpql-mba8mpxl += -@
++DTC_FLAGS_imx8mp-tqma8mpql-mba8mp-ras314 += -@
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Add standalone dtbo's to Makefile so they are built and packaged.

# How Has This Been Tested?

- [x] Build and Boot CLI/Gnome image on mba8mp
- [x] Build and Boot CLI/Gnome image on mba8mp-ras314
- [x] add lvds overlay to extlinux.conf and test with display on mba8mp-ras314

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

