### PR TITLE
filogic: fix build u-boot

### DIFF
--- a/config/sources/families/filogic.conf
+++ b/config/sources/families/filogic.conf
@@ -15,7 +15,7 @@ declare -g BOOTDELAY=1
 declare -g BOOTPATCHDIR="${BOOTPATCHDIR:-"u-boot-filogic"}"
 declare -g BOOTBRANCH="${BOOTBRANCH:-"tag:v2025.04"}"
 declare -g BOOTENV_FILE='filogic.txt'
-declare -g UBOOT_TARGET_MAP=";;u-boot.bin"
+declare -g UBOOT_TARGET_MAP=";;u-boot.bin u-boot_sdmmc.fip bl2.img"
 declare -g BOOTSCRIPT='boot-filogic.cmd:boot.cmd'
 declare -g IMAGE_PARTITION_TABLE="gpt"
 declare -g LINUXFAMILY=filogic
@@ -28,11 +28,15 @@ function add_host_dependencies__filogic_add_xxd_hostdep() {
 
 # Handling of FIP blobs
 function uboot_custom_postprocess() {
-	run_host_command_logged rm -f "$SRC"/cache/u-boot_sdmmc.fip
+	run_host_command_logged rm -f "$SRC"/cache/sources/u-boot-worktree/u-boot/v2025.04/bl2.img
+	run_host_command_logged cp "$SRC"/cache/sources/arm-trusted-firmware/mtksoc-20250212/build/mt7988/release/bl2.img \
+	  "$SRC"/cache/sources/u-boot-worktree/u-boot/v2025.04
+
+	run_host_command_logged rm -f "$SRC"/cache/sources/u-boot-worktree/u-boot/v2025.04/u-boot_sdmmc.fip
 	run_host_command_logged fiptool create \
 	  --soc-fw "$SRC"/cache/sources/arm-trusted-firmware/mtksoc-20250212/build/mt7988/release/bl31.bin \
 	  --nt-fw "$SRC"/cache/sources/u-boot-worktree/u-boot/v2025.04/u-boot.bin \
-	  "$SRC"/cache/u-boot_sdmmc.fip
+	  "$SRC"/cache/sources/u-boot-worktree/u-boot/v2025.04/u-boot_sdmmc.fip
 }
 
 case $BRANCH in
@@ -50,8 +54,8 @@ esac
 #KERNELPATCHDIR="archive/filogic-${KERNEL_MAJOR_MINOR}"
 
 write_uboot_platform() {
-	dd if="$SRC"/cache/sources/arm-trusted-firmware/mtksoc-20250212/build/mt7988/release/bl2.img of=$2 bs=512 seek=34 status=noxfer > /dev/null 2>&1
-	dd if="$SRC"/cache/u-boot_sdmmc.fip of=$2 bs=512 seek=13312 status=noxfer >/dev/null 2>&1
+	dd if=$1/bl2.img of=$2 bs=512 seek=34 status=noxfer > /dev/null 2>&1
+	dd if=$1/u-boot_sdmmc.fip of=$2 bs=512 seek=13312 status=noxfer >/dev/null 2>&1
 	
 	# backup gpt table
 	LAST_START=$(parted "$2" unit s print | grep -v "^$" | tail -n 1 | awk '{print $2}' | tr -d 's')


### PR DESCRIPTION
# Description

https://github.com/armbian/build/pull/8407#issuecomment-3157853995

https://paste.armbian.com/seruponiso

Fixed the issue of reading u-boot from cache and writing it, changed to packaging the target into the u-boot package and then writing it.

# How Has This Been Tested?

- [x] Successfully compiled without errors.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
