### PR TITLE
Fix: use PRESET_USER_KEY for user SSH key in armbian-firstlogin script

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -587,7 +587,7 @@ add_user() {
 			# download and add SSH key if defined
 			if [[ -n "${PRESET_USER_KEY}" ]]; then
 				mkdir -p /home/"$RealUserName"/.ssh/
-				curl --retry 5 --connect-timeout 3 "${PRESET_ROOT_KEY}" > /home/"$RealUserName"/.ssh/authorized_keys 2> /dev/null
+				curl --retry 5 --connect-timeout 3 "${PRESET_USER_KEY}" > /home/"$RealUserName"/.ssh/authorized_keys 2> /dev/null
 				chown -R "$RealUserName":"$RealUserName" /home/"$RealUserName"/.ssh/
 			fi
 


### PR DESCRIPTION
Closes #8465

# Description

This PR fixes the variable used to fetch the user’s SSH public key during the first login process in the armbian-firstlogin script.
Previously, the script could incorrectly reference the wrong variable for the user’s SSH key. Now, it consistently uses `${PRESET_USER_KEY} when setting up the new user’s authorized_keys.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: https://github.com/armbian/build/issues/8465
[Jira](https://armbian.atlassian.net/jira) reference number: https://armbian.atlassian.net/browse/AR-2725

# Checklist:

_Please delete options that are not relevant._

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
