### PR TITLE
Fix pcie sata link training rkvendor 6.1 for rock-5-itx

### DIFF
--- a/patch/kernel/rk35xx-vendor-6.1/0001-phy-rockchip-snps-pcie3-add-support-for-rockchip-rx-.patch
+++ b/patch/kernel/rk35xx-vendor-6.1/0001-phy-rockchip-snps-pcie3-add-support-for-rockchip-rx-.patch
@@ -1,0 +1,111 @@
+From a1fe1eca0d8be69ccc1f3d615e5a529df1c82e66 Mon Sep 17 00:00:00 2001
+From: Niklas Cassel <cassel@kernel.org>
+Date: Fri, 12 Apr 2024 14:58:16 +0200
+Subject: [PATCH] phy: rockchip-snps-pcie3: add support for
+ rockchip,rx-common-refclk-mode
+
+>From the RK3588 Technical Reference Manual, Part1,
+section 6.19 PCIe3PHY_GRF Register Description:
+"rxX_cmn_refclk_mode"
+RX common reference clock mode for lane X. This mode should be enabled
+only when the far-end and near-end devices are running with a common
+reference clock.
+
+The hardware reset value for this field is 0x1 (enabled).
+Note that this register field is only available on RK3588, not on RK3568.
+
+The link training either fails or is highly unstable (link state will jump
+continuously between L0 and recovery) when this mode is enabled while
+using an endpoint running in Separate Reference Clock with No SSC (SRNS)
+mode or Separate Reference Clock with SSC (SRIS) mode.
+(Which is usually the case when using a real SoC as endpoint, e.g. the
+RK3588 PCIe controller can run in both Root Complex and Endpoint mode.)
+
+Add support for the device tree property rockchip,rx-common-refclk-mode,
+such that the PCIe PHY can be used in configurations where the Root
+Complex and Endpoint are not using a common reference clock.
+
+Signed-off-by: Niklas Cassel <cassel@kernel.org>
+Link: https://lore.kernel.org/r/20240412125818.17052-3-cassel@kernel.org
+Signed-off-by: Vinod Koul <vkoul@kernel.org>
+---
+ .../phy/rockchip/phy-rockchip-snps-pcie3.c    | 37 +++++++++++++++++++
+ 1 file changed, 37 insertions(+)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-snps-pcie3.c b/drivers/phy/rockchip/phy-rockchip-snps-pcie3.c
+index bc8c2cb3cd01..8b9681580a06 100644
+--- a/drivers/phy/rockchip/phy-rockchip-snps-pcie3.c
++++ b/drivers/phy/rockchip/phy-rockchip-snps-pcie3.c
+@@ -35,11 +35,17 @@
+ #define RK3588_PCIE3PHY_GRF_CMN_CON0		0x0
+ #define RK3588_PCIE3PHY_GRF_PHY0_STATUS1	0x904
+ #define RK3588_PCIE3PHY_GRF_PHY1_STATUS1	0xa04
++#define RK3588_PCIE3PHY_GRF_PHY0_LN0_CON1	0x1004
++#define RK3588_PCIE3PHY_GRF_PHY0_LN1_CON1	0x1104
++#define RK3588_PCIE3PHY_GRF_PHY1_LN0_CON1	0x2004
++#define RK3588_PCIE3PHY_GRF_PHY1_LN1_CON1	0x2104
+ #define RK3588_SRAM_INIT_DONE(reg)		((reg & 0xf) == 0xf)
+ 
+ #define RK3588_BIFURCATION_LANE_0_1		BIT(0)
+ #define RK3588_BIFURCATION_LANE_2_3		BIT(1)
+ #define RK3588_LANE_AGGREGATION		BIT(2)
++#define RK3588_RX_CMN_REFCLK_MODE_EN		((BIT(7) << 16) |  BIT(7))
++#define RK3588_RX_CMN_REFCLK_MODE_DIS		(BIT(7) << 16)
+ #define RK3588_PCIE1LN_SEL_EN			(GENMASK(1, 0) << 16)
+ #define RK3588_PCIE30_PHY_MODE_EN		(GENMASK(2, 0) << 16)
+ 
+@@ -59,6 +65,7 @@ struct rockchip_p3phy_priv {
+ 	struct clk_bulk_data *clks;
+ 	int num_clks;
+ 	bool is_bifurcation;
++	u32 rx_cmn_refclk_mode[4];
+ };
+ 
+ struct rockchip_p3phy_ops {
+@@ -164,6 +171,19 @@ static const struct rockchip_p3phy_ops rk3568_ops = {
+ 
+ static int rockchip_p3phy_rk3588_init(struct rockchip_p3phy_priv *priv)
+ {
++	regmap_write(priv->phy_grf, RK3588_PCIE3PHY_GRF_PHY0_LN0_CON1,
++		     priv->rx_cmn_refclk_mode[0] ? RK3588_RX_CMN_REFCLK_MODE_EN :
++		     RK3588_RX_CMN_REFCLK_MODE_DIS);
++	regmap_write(priv->phy_grf, RK3588_PCIE3PHY_GRF_PHY0_LN1_CON1,
++		     priv->rx_cmn_refclk_mode[1] ? RK3588_RX_CMN_REFCLK_MODE_EN :
++		     RK3588_RX_CMN_REFCLK_MODE_DIS);
++	regmap_write(priv->phy_grf, RK3588_PCIE3PHY_GRF_PHY1_LN0_CON1,
++		     priv->rx_cmn_refclk_mode[2] ? RK3588_RX_CMN_REFCLK_MODE_EN :
++		     RK3588_RX_CMN_REFCLK_MODE_DIS);
++	regmap_write(priv->phy_grf, RK3588_PCIE3PHY_GRF_PHY1_LN1_CON1,
++		     priv->rx_cmn_refclk_mode[3] ? RK3588_RX_CMN_REFCLK_MODE_EN :
++		     RK3588_RX_CMN_REFCLK_MODE_DIS);
++
+ 	/* Deassert PCIe PMA output clamp mode */
+ 	regmap_write(priv->phy_grf, RK3588_PCIE3PHY_GRF_CMN_CON0, BIT(8) | BIT(24));
+ 
+@@ -294,6 +314,23 @@ static int rockchip_p3phy_probe(struct platform_device *pdev)
+ 				     (reg << 16) | reg);
+ 	};
+ 
++	ret = of_property_read_variable_u32_array(dev->of_node,
++						  "rockchip,rx-common-refclk-mode",
++						  priv->rx_cmn_refclk_mode, 1,
++						  ARRAY_SIZE(priv->rx_cmn_refclk_mode));
++	/*
++	 * if no rockchip,rx-common-refclk-mode, assume enabled for all lanes in
++	 * order to be DT backwards compatible. (Since HW reset val is enabled.)
++	 */
++	if (ret == -EINVAL) {
++		for (int i = 0; i < ARRAY_SIZE(priv->rx_cmn_refclk_mode); i++)
++			priv->rx_cmn_refclk_mode[i] = 1;
++	} else if (ret < 0) {
++		dev_err(dev, "failed to read rockchip,rx-common-refclk-mode property %d\n",
++			ret);
++		return ret;
++	}
++
+ 	priv->phy = devm_phy_create(dev, NULL, &rockchip_p3phy_ops);
+ 	if (IS_ERR(priv->phy)) {
+ 		dev_err(dev, "failed to create combphy\n");
+-- 
+Armbian
+

--- a/patch/kernel/rk35xx-vendor-6.1/board-rock-5-itx-dts-fix-sata-pcie.patch
+++ b/patch/kernel/rk35xx-vendor-6.1/board-rock-5-itx-dts-fix-sata-pcie.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alban Browaeys <alban.browaeys@gmail.com>
+Date: Thu, 7 Aug 2025 21:51:52 +0000
+Subject: Fix PCI SATA link training instability on rock-5-itx
+
+Based on upstream initial dts definition.
+
+Signed-off-by: Alban Browaeys <alban.browaeys@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+index 78e385e5d7bc..aa88daac6568 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+@@ -984,8 +994,10 @@ &pcie2x1l0 {
+ };
+ 
+ &pcie30phy {
++	/* separate clock lines from the clock generator to phy and devices */
++	rockchip,rx-common-refclk-mode = <0 0 0 0>;
+ 	rockchip,pcie30-phymode = <PHY_MODE_PCIE_NANBNB>;
+ 	status = "okay";
+ };
+ 
+ &pcie3x2 {
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Disable common refclk for the pcie phy on rock-5-itx.
On Radxa rock-5-itx the SATA endpoint was unstable. Most of the time, the drives attached to it were not detected.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2561] (though this fix is only applied for the vendor kernel on rock-5-itx)

Mind it could be, this PR should go to https://github.com/armbian/linux-rockchip.


# How Has This Been Tested?

Booted ten times in a row. Usually three times was enough to get no drives detected.
- [x] `lsblk -f`
- [x] `smartcl -a /dev/sda`
both on 6.1.115-vendor-rk35xx

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


[AR-2561]: https://armbian.atlassian.net/browse/AR-2561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ