### PR TITLE
Add patch reverting radxa/u-boot PR "Add Booting Android/Buildroot/Yoto systems"

### DIFF
--- a/patch/u-boot/legacy/u-boot-radxa-rk35xx/Revert-Add-Booting-Android-Buildroot-Yoto-systems.patch
+++ b/patch/u-boot/legacy/u-boot-radxa-rk35xx/Revert-Add-Booting-Android-Buildroot-Yoto-systems.patch
@@ -1,0 +1,543 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JohnTheCoolingFan <ivan8215145640@gmail.com>
+Date: Sun, 10 Aug 2025 10:28:06 +0000
+Subject: Revert "Add Booting Android/Buildroot/Yoto systems"
+
+Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
+---
+ arch/arm/mach-rockchip/boot_mode.c     |  3 +-
+ arch/arm/mach-rockchip/fit.c           |  3 +-
+ arch/arm/mach-rockchip/resource_img.c  |  5 +--
+ arch/arm/mach-rockchip/rk3576/rk3576.c |  3 +-
+ arch/arm/mach-rockchip/vendor.c        |  5 +--
+ common/android_bootloader.c            | 22 +++-------
+ common/image-android.c                 |  5 +--
+ include/android_bootloader.h           |  7 ---
+ include/config_distro_bootcmd.h        |  1 -
+ include/configs/rockchip-common.h      |  7 +--
+ lib/avb/libavb_user/avb_ops_user.c     | 11 +++--
+ lib/avb/rk_avb_user/rk_avb_ops_user.c  |  3 +-
+ 12 files changed, 26 insertions(+), 49 deletions(-)
+
+diff --git a/arch/arm/mach-rockchip/boot_mode.c b/arch/arm/mach-rockchip/boot_mode.c
+index a9305441830..6f4858bbada 100644
+--- a/arch/arm/mach-rockchip/boot_mode.c
++++ b/arch/arm/mach-rockchip/boot_mode.c
+@@ -7,11 +7,10 @@
+ #include <common.h>
+ #include <boot_rkimg.h>
+ #include <malloc.h>
+ #include <asm/io.h>
+ #include <asm/arch/boot_mode.h>
+-#include <android_bootloader.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+ enum {
+ 	PH = 0,	/* P: Priority, H: high, M: middle, L: low*/
+@@ -24,11 +23,11 @@ static int misc_require_recovery(u32 bcb_offset, int *bcb_recovery_msg)
+ 	struct bootloader_message *bmsg;
+ 	struct blk_desc *dev_desc;
+ 	disk_partition_t part;
+ 	int cnt, recovery = 0;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("dev_desc is NULL!\n");
+ 		goto out;
+ 	}
+ 
+diff --git a/arch/arm/mach-rockchip/fit.c b/arch/arm/mach-rockchip/fit.c
+index 57d34bb7b0e..c15c9a4498b 100644
+--- a/arch/arm/mach-rockchip/fit.c
++++ b/arch/arm/mach-rockchip/fit.c
+@@ -8,11 +8,10 @@
+ #include <image.h>
+ #include <malloc.h>
+ #include <sysmem.h>
+ #include <asm/arch/fit.h>
+ #include <asm/arch/resource_img.h>
+-#include <android_bootloader.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+ #define FIT_PLACEHOLDER_ADDR		0xffffff00
+ 
+@@ -398,11 +397,11 @@ void *fit_image_load_bootables(ulong *size)
+ 	struct blk_desc *dev_desc;
+ 	disk_partition_t part;
+ 	int blk_num;
+ 	void *fit;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc)
+ 		return NULL;
+ 
+ 	fit = fit_get_blob(dev_desc, &part, false);
+ 	if (!fit) {
+diff --git a/arch/arm/mach-rockchip/resource_img.c b/arch/arm/mach-rockchip/resource_img.c
+index 2e1165248d3..82db9e05284 100644
+--- a/arch/arm/mach-rockchip/resource_img.c
++++ b/arch/arm/mach-rockchip/resource_img.c
+@@ -12,11 +12,10 @@
+ #include <linux/list.h>
+ #include <asm/arch/resource_img.h>
+ #include <asm/arch/rk_hwid.h>
+ #include <asm/arch/uimage.h>
+ #include <asm/arch/fit.h>
+-#include <android_bootloader.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+ #define PART_RESOURCE			"resource"
+ #define RESOURCE_MAGIC			"RSCE"
+@@ -360,11 +359,11 @@ static int resource_default(struct blk_desc *desc,
+ }
+ #endif
+ 
+ static int resource_scan(void)
+ {
+-	struct blk_desc *desc = android_get_bootdev();
++	struct blk_desc *desc = rockchip_get_bootdev();
+ 	__maybe_unused int ret;
+ 
+ 	if (!desc) {
+ 		printf("RESC: No bootdev\n");
+ 		return -ENODEV;
+@@ -429,11 +428,11 @@ static struct resource_file *resource_get_file(const char *name)
+ 	return NULL;
+ }
+ 
+ int rockchip_read_resource_file(void *buf, const char *name, int blk_offset, int len)
+ {
+-	struct blk_desc *desc = android_get_bootdev();
++	struct blk_desc *desc = rockchip_get_bootdev();
+ 	struct resource_file *f;
+ 	int blk_cnt;
+ 	ulong pos;
+ 
+ 	if (!desc)
+diff --git a/arch/arm/mach-rockchip/rk3576/rk3576.c b/arch/arm/mach-rockchip/rk3576/rk3576.c
+index 4ec56a94a48..61533f90d5d 100644
+--- a/arch/arm/mach-rockchip/rk3576/rk3576.c
++++ b/arch/arm/mach-rockchip/rk3576/rk3576.c
+@@ -17,11 +17,10 @@
+ #include <asm/arch/hardware.h>
+ #include <asm/arch/boot_mode.h>
+ #include <asm/arch/ioc_rk3576.h>
+ #include <asm/arch/rockchip_smccc.h>
+ #include <asm/system.h>
+-#include <android_bootloader.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+ #define SYS_GRF_BASE		0x2600A000
+ #define SYS_GRF_SOC_CON2	0x0008
+@@ -418,11 +417,11 @@ int arch_cpu_init(void)
+ #endif
+ 
+ #if defined(CONFIG_SCSI) && defined(CONFIG_CMD_SCSI) && defined(CONFIG_UFS)
+ int rk_board_dm_fdt_fixup(const void *blob)
+ {
+-	struct blk_desc *desc = android_get_bootdev();
++	struct blk_desc *desc = rockchip_get_bootdev();
+ 	const char *status = NULL;
+ 	int node = -1;
+ 
+ 	/*
+ 	 * 1. Kernel DTS will enable UFS by default.
+diff --git a/arch/arm/mach-rockchip/vendor.c b/arch/arm/mach-rockchip/vendor.c
+index 0d941b9a798..7391059948f 100644
+--- a/arch/arm/mach-rockchip/vendor.c
++++ b/arch/arm/mach-rockchip/vendor.c
+@@ -10,11 +10,10 @@
+ #include <boot_rkimg.h>
+ #include <nand.h>
+ #include <part.h>
+ #include <fdt_support.h>
+ #include <usbplug.h>
+-#include <android_bootloader.h>
+ 
+ /* tag for vendor check */
+ #define VENDOR_TAG		0x524B5644
+ /* The Vendor partition contains the number of Vendor blocks */
+ #define MTD_VENDOR_PART_NUM	1
+@@ -316,11 +315,11 @@ static int vendor_ops(u8 *buffer, u32 addr, u32 n_sec, int write)
+ {
+ 	struct blk_desc *dev_desc;
+ 	unsigned int lba = 0;
+ 	int ret = 0;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("%s: dev_desc is NULL!\n", __func__);
+ 		return -ENODEV;
+ 	}
+ 
+@@ -434,11 +433,11 @@ int vendor_storage_init(void)
+ 	u32 max_index = 0;
+ 	u16 data_offset, hash_offset, part_num;
+ 	u16 version2_offset, part_size;
+ 	struct blk_desc *dev_desc;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("[Vendor ERROR]:Invalid boot device type(%d)\n",
+ 		       bootdev_type);
+ 		return -ENODEV;
+ 	}
+diff --git a/common/android_bootloader.c b/common/android_bootloader.c
+index a9953dae1ab..9107d4af72b 100644
+--- a/common/android_bootloader.c
++++ b/common/android_bootloader.c
+@@ -28,16 +28,10 @@
+ #include <optee_include/OpteeClientInterface.h>
+ #include <bidram.h>
+ #include <console.h>
+ #include <sysmem.h>
+ 
+-struct blk_desc *android_dev_desc = NULL;
+-
+-struct blk_desc *android_get_bootdev(void) {
+-    return android_dev_desc;
+-}
+-
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+ int android_bootloader_message_load(
+ 	struct blk_desc *dev_desc,
+ 	const disk_partition_t *part_info,
+@@ -137,11 +131,11 @@ int android_bcb_write(char *cmd)
+ 		return -ENOMEM;
+ 
+ 	if (strlen(cmd) >= 32)
+ 		return -ENOMEM;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("%s: dev_desc is NULL!\n", __func__);
+ 		return -ENODEV;
+ 	}
+ 
+@@ -200,11 +194,11 @@ static int android_bootloader_get_fdt(const char *part_name,
+ 	loff_t len_read;
+ 	unsigned long addr = 0;
+ 	int part_num = -1;
+ 	int ret;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("%s: dev_desc is NULL!\n", __func__);
+ 		return -1;
+ 	}
+ 
+@@ -775,11 +769,11 @@ static AvbSlotVerifyResult android_slot_verify(char *boot_partname,
+ 	char can_boot = 1;
+ 	char retry_no_vbmeta_partition = 1;
+ 	unsigned long load_address = *android_load_address;
+ 	int ret;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc)
+ 		return AVB_IO_RESULT_ERROR_IO;
+ 
+ 	if (part_get_info_by_name(dev_desc, boot_partname, &part_info) < 0) {
+ 		printf("Could not find \"%s\" partition\n", boot_partname);
+@@ -1009,11 +1003,11 @@ static int android_get_dtbo(ulong *fdt_dtbo,
+ 	u32 e_size;
+ 	int e_idx;
+ 	int ret;
+ 
+ 	/* Get partition info */
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc)
+ 		return -ENODEV;
+ 
+ 	ret = part_get_info_by_name(dev_desc, part_dtbo, &part_info);
+ 	if (ret < 0) {
+@@ -1117,11 +1111,11 @@ int android_fdt_overlay_apply(void *fdt_addr)
+ 		part_boot = PART_RECOVERY;
+ 		part_dtbo = PART_RECOVERY;
+ #endif
+ 	}
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc)
+ 		return -ENODEV;
+ 
+ 	ret = part_get_info_by_name(dev_desc, part_boot, &part_info);
+ 	if (ret < 0)
+@@ -1230,12 +1224,10 @@ int android_bootloader_boot_flow(struct blk_desc *dev_desc,
+ 	char *command_line;
+ 	char slot_suffix[3] = {0};
+ 	const char *mode_cmdline = NULL;
+ 	char *boot_partname = ANDROID_PARTITION_BOOT;
+ 
+-	android_dev_desc = dev_desc;
+-
+ 	/*
+ 	 * 1. Load MISC partition and determine the boot mode
+ 	 *   clear its value for the next boot if needed.
+ 	 */
+ 	part_num = part_get_info_by_name(dev_desc, ANDROID_PARTITION_MISC,
+@@ -1412,11 +1404,11 @@ int android_avb_boot_flow(unsigned long kernel_address)
+ {
+ 	struct blk_desc *dev_desc;
+ 	disk_partition_t boot_part_info;
+ 	int ret;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("%s: dev_desc is NULL!\n", __func__);
+ 		return -1;
+ 	}
+ 
+@@ -1445,11 +1437,11 @@ int android_boot_flow(unsigned long kernel_address)
+ {
+ 	struct blk_desc *dev_desc;
+ 	disk_partition_t boot_part_info;
+ 	int ret;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("%s: dev_desc is NULL!\n", __func__);
+ 		return -1;
+ 	}
+ 	/* Load the kernel from the desired "boot" partition. */
+diff --git a/common/image-android.c b/common/image-android.c
+index 30674451033..c2703b5ea3e 100644
+--- a/common/image-android.c
++++ b/common/image-android.c
+@@ -23,11 +23,10 @@
+ #include <android_avb/avb_slot_verify.h>
+ #include <android_avb/avb_ops_user.h>
+ #include <android_avb/rk_avb_ops_user.h>
+ #endif
+ #include <optee_include/OpteeClientInterface.h>
+-#include <android_bootloader.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+ #define ANDROID_IMAGE_DEFAULT_KERNEL_ADDR	0x10008000
+ #define ANDROID_PARTITION_VENDOR_BOOT		"vendor_boot"
+@@ -45,11 +44,11 @@ static int android_version_init(void)
+ 	struct blk_desc *desc;
+ 	const char *part_name = PART_BOOT;
+ 	disk_partition_t part;
+ 	int os_version;
+ 
+-	desc = android_get_bootdev();
++	desc = rockchip_get_bootdev();
+ 	if (!desc) {
+ 		printf("No bootdev\n");
+ 		return -1;
+ 	}
+ 
+@@ -423,11 +422,11 @@ static sha1_context sha1_ctx;
+ #endif
+ 
+ static int image_load(img_t img, struct andr_img_hdr *hdr,
+ 		      ulong blkstart, void *ram_base)
+ {
+-	struct blk_desc *desc = android_get_bootdev();
++	struct blk_desc *desc = rockchip_get_bootdev();
+ 	disk_partition_t part_vendor_boot;
+ 	disk_partition_t part_init_boot;
+ 	__maybe_unused u32 typesz;
+ 	u32 andr_version = (hdr->os_version >> 25) & 0x7f;
+ 	ulong pgsz = hdr->page_size;
+diff --git a/include/android_bootloader.h b/include/android_bootloader.h
+index c34b43d82a9..e4e47f767a3 100644
+--- a/include/android_bootloader.h
++++ b/include/android_bootloader.h
+@@ -7,12 +7,10 @@
+ #ifndef __ANDROID_BOOTLOADER_H
+ #define __ANDROID_BOOTLOADER_H
+ 
+ #include <common.h>
+ 
+-extern struct blk_desc *android_dev_desc;
+-
+ enum android_boot_mode {
+ 	ANDROID_BOOT_MODE_NORMAL = 0,
+ 
+ 	/* "recovery" mode is triggered by the "reboot recovery" command or
+ 	 * equivalent adb/fastboot command. It can also be triggered by writing
+@@ -27,15 +25,10 @@ enum android_boot_mode {
+ 	 * fastboot.
+ 	 */
+ 	ANDROID_BOOT_MODE_BOOTLOADER,
+ };
+ 
+-/** android_get_bootdev- Get the devtype passed by bootcmd.
+- *
+- */
+-struct blk_desc *android_get_bootdev(void);
+-
+ /** android_bootloader_boot_flow - Execute the Android Bootloader Flow.
+  * Performs the Android Bootloader boot flow, loading the appropriate Android
+  * image (normal kernel, recovery kernel or "bootloader" mode) and booting it.
+  * The boot mode is determined by the contents of the Android Bootloader
+  * Message. On success it doesn't return.
+diff --git a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
+index 7c46af2f2db..13ce636c8ed 100644
+--- a/include/config_distro_bootcmd.h
++++ b/include/config_distro_bootcmd.h
+@@ -395,11 +395,10 @@
+ 		"\0"                                                      \
+ 	\
+ 	"scan_dev_for_boot_part="                                         \
+ 		"part list ${devtype} ${devnum} -bootable devplist; "     \
+ 		"env exists devplist || setenv devplist 1; "              \
+-		"boot_android ${devtype} ${devnum}; "                      \
+ 		"for distro_bootpart in ${devplist}; do "                 \
+ 			"if fstype ${devtype} "                           \
+ 					"${devnum}:${distro_bootpart} "   \
+ 					"bootfstype; then "               \
+ 				"run scan_dev_for_boot; "                 \
+diff --git a/include/configs/rockchip-common.h b/include/configs/rockchip-common.h
+index 0d780378aac..b2c8880a0b2 100644
+--- a/include/configs/rockchip-common.h
++++ b/include/configs/rockchip-common.h
+@@ -201,13 +201,14 @@
+ 	"boot_android ${devtype} ${devnum};"
+ #elif defined(CONFIG_FIT_SIGNATURE)
+ #define RKIMG_BOOTCOMMAND			\
+ 	"boot_fit;"
+ #else
+-#define RKIMG_BOOTCOMMAND           \
+-	"run distro_bootcmd; " \
+-	"boot_fit; " \
++#define RKIMG_BOOTCOMMAND			\
++	"run distro_bootcmd;"			\
++	"boot_android ${devtype} ${devnum};"	\
++	"boot_fit;"				\
+ 	"bootrkp;"
+ #endif
+ 
+ #endif /* CONFIG_SPL_BUILD */
+ 
+diff --git a/lib/avb/libavb_user/avb_ops_user.c b/lib/avb/libavb_user/avb_ops_user.c
+index 931d5f7f52d..4f57e7e6173 100644
+--- a/lib/avb/libavb_user/avb_ops_user.c
++++ b/lib/avb/libavb_user/avb_ops_user.c
+@@ -40,11 +40,10 @@
+ #include <optee_include/OpteeClientInterface.h>
+ #include <optee_include/tee_api_defines.h>
+ #include <android_avb/avb_vbmeta_image.h>
+ #include <android_avb/avb_atx_validate.h>
+ #include <boot_rkimg.h>
+-#include <android_bootloader.h>
+ 
+ static void byte_to_block(int64_t *offset,
+ 			  size_t *num_bytes,
+ 			  lbaint_t *offset_blk,
+ 			  lbaint_t *blkcnt)
+@@ -74,11 +73,11 @@ static AvbIOResult get_size_of_partition(AvbOps *ops,
+ 					 uint64_t *out_size_in_bytes)
+ {
+ 	struct blk_desc *dev_desc;
+ 	disk_partition_t part_info;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("%s: Could not find device\n", __func__);
+ 		return AVB_IO_RESULT_ERROR_NO_SUCH_PARTITION;
+ 	}
+ 
+@@ -110,11 +109,11 @@ static AvbIOResult read_from_partition(AvbOps *ops,
+ 
+ 		offset = partition_size - (-offset);
+ 	}
+ 
+ 	byte_to_block(&offset, &num_bytes, &offset_blk, &blkcnt);
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("%s: Could not find device\n", __func__);
+ 		return AVB_IO_RESULT_ERROR_NO_SUCH_PARTITION;
+ 	}
+ 
+@@ -161,11 +160,11 @@ static AvbIOResult write_to_partition(AvbOps *ops,
+ 	if (!buffer_temp) {
+ 		printf("malloc error!\n");
+ 		return AVB_IO_RESULT_ERROR_OOM;
+ 	}
+ 	memset(buffer_temp, 0, 512 * blkcnt);
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("%s: Could not find device\n", __func__);
+ 		return AVB_IO_RESULT_ERROR_NO_SUCH_PARTITION;
+ 	}
+ 
+@@ -348,11 +347,11 @@ static AvbIOResult get_unique_guid_for_partition(AvbOps *ops,
+ 						 size_t guid_buf_size)
+ {
+ 	struct blk_desc *dev_desc;
+ 	disk_partition_t part_info;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("%s: Could not find device\n", __func__);
+ 		return AVB_IO_RESULT_ERROR_NO_SUCH_PARTITION;
+ 	}
+ 
+@@ -445,11 +444,11 @@ static AvbIOResult get_preloaded_partition(AvbOps* ops,
+ 	disk_partition_t part_info;
+ 	ulong load_addr;
+ 	AvbIOResult ret;
+ 	int full_preload = 0;
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc)
+ 		return AVB_IO_RESULT_ERROR_IO;
+ 
+ 	if (part_get_info_by_name(dev_desc, partition, &part_info) < 0) {
+ 		printf("Could not find \"%s\" partition\n", partition);
+diff --git a/lib/avb/rk_avb_user/rk_avb_ops_user.c b/lib/avb/rk_avb_user/rk_avb_ops_user.c
+index 923a1e9c64d..78e0d9aa5f7 100644
+--- a/lib/avb/rk_avb_user/rk_avb_ops_user.c
++++ b/lib/avb/rk_avb_user/rk_avb_ops_user.c
+@@ -24,11 +24,10 @@
+ #include <android_avb/avb_atx_validate.h>
+ #include <android_avb/rk_avb_ops_user.h>
+ #include <boot_rkimg.h>
+ #include <u-boot/sha256.h>
+ #include <asm/arch/rk_atags.h>
+-#include <android_bootloader.h>
+ 
+ /* rk used */
+ int rk_avb_get_pub_key(struct rk_pub_key *pub_key)
+ {
+ 	struct tag *t = NULL;
+@@ -570,11 +569,11 @@ int rk_avb_get_part_has_slot_info(const char *base_name)
+ 	size_t part_name_len;
+ 	disk_partition_t part_info;
+ 	struct blk_desc *dev_desc;
+ 	const char *slot_suffix = "_a";
+ 
+-	dev_desc = android_get_bootdev();
++	dev_desc = rockchip_get_bootdev();
+ 	if (!dev_desc) {
+ 		printf("%s: Could not find device!\n", __func__);
+ 		return -1;
+ 	}
+ 
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

Adds a patch reverting https://github.com/radxa/u-boot/pull/148

The changes in the PR cause u-boot build errors for boards `rpck-5-cmio` and `rock-5-cm-rpi-cm4-io` (https://paste.armbian.com/jomegemugo)

# How Has This Been Tested?

- [x] `./compile.sh uboot BUILD_DESKTOP=no BUILD_MINIMAL=no COMPRESS_OUTPUTIMAGE=sha,xz IMAGE_XZ_COMPRESSION_RATIO=9 KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=bookworm ARTIFACT_IGNORE_CACHE=yes BOARD=rock-5-cmio BRANCH=vendor`
- [x] ./compile.sh uboot BUILD_DESKTOP=no BUILD_MINIMAL=no COMPRESS_OUTPUTIMAGE=sha,xz IMAGE_XZ_COMPRESSION_RATIO=9 KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=bookworm ARTIFACT_IGNORE_CACHE=yes BOARD=rock-5-cm-rpi-cm4-io BRANCH=vendor

# Checklist:

- [x] My changes generate no new warnings
