### PR TITLE
extensions: add missing "install" instruction to APA extension

### DIFF
--- a/extensions/apa.sh
+++ b/extensions/apa.sh
@@ -18,7 +18,7 @@ function post_armbian_repo_customize_image__install_from_apa() {
 	case ${DESKTOP_ENVIRONMENT^^} in
 		XFCE|KDE|GNOME)
 			display_alert "installing ${DESKTOP_ENVIRONMENT^^} desktop environment" "${EXTENSION}: ${DESKTOP_ENVIRONMENT^^}" "info"
-			chroot_sdcard_apt_get --install-recommends=yes "armbian-desktop-${DESKTOP_ENVIRONMENT,,}"
+			chroot_sdcard_apt_get install --install-recommends=yes "armbian-desktop-${DESKTOP_ENVIRONMENT,,}"
 			;;
 	esac
 }


### PR DESCRIPTION
Compilation of desktop images currently fails because of a missing "install" instruction.  This PR fixes that.