### PR TITLE
config/desktop: temporarily disable mate-sntray-plugin for trixie mate #FTBFS #RC

### DIFF
--- a/config/desktop/trixie/environments/mate/config_base/packages
+++ b/config/desktop/trixie/environments/mate/config_base/packages
@@ -59,7 +59,7 @@ mate-sensors-applet-common
 mate-session-manager
 mate-settings-daemon
 mate-settings-daemon-common
-mate-sntray-plugin
+#mate-sntray-plugin
 mate-system-monitor
 mate-system-monitor-common
 mate-terminal


### PR DESCRIPTION
mate-sntray-plugin is currently not available due to RC-bugginess

mate-sntray-plugin:  https://bugs.debian.org/1086771