### PR TITLE
lib / prepare-host: debian-archive-keyring is not a host-dependency for RISCv64

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -266,7 +266,6 @@ function adaptative_prepare_host_dependencies() {
 
 	if [[ "${wanted_arch}" == "riscv64" || "${wanted_arch}" == "all" ]]; then
 		host_dependencies+=("gcc-riscv64-linux-gnu") # crossbuild-essential-riscv64 is not even available "yet"
-		host_dependencies+=("debian-archive-keyring")
 	fi
 
 	if [[ "${wanted_arch}" == "loong64" ]]; then


### PR DESCRIPTION
This was introduced in 2a8cb5793f as a relaxation to the previous state when RISCv64 was not yet officially supported by Debian and lived in Debian Ports.