### PR TITLE
Workaround for building Helios64 

### DIFF
--- a/lib/functions/general/chroot-helpers.sh
+++ b/lib/functions/general/chroot-helpers.sh
@@ -41,7 +41,7 @@ function umount_chroot() {
 		umount "${target}"/dev/pts || true
 		umount --recursive "${target}"/dev || true
 		umount "${target}"/proc || true
-		umount "${target}"/sys || true
+		umount --recursive "${target}"/sys || true
 		umount "${target}"/tmp || true
 		umount "${target}"/var/tmp || true
 		umount "${target}"/run/user/0 || true


### PR DESCRIPTION
# Description

Addresses https://github.com/armbian/build/issues/8468

This is **not a proper fix** but a workaround to allow successful Helios64 building.
The actual cause still needs to be investigated. There must be an explanation why this specific board fails but others don't.

This needs more testing
- for once on other hosts when building Helios64
- and for the other if this causes trouble with other boards

I suggest to defer this after August release and then run a full build train on it to check for issues.


# How Has This Been Tested?

- [x] Build Trixie minimal current image
- [x] Build Noble minimal current image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
