### PR TITLE
config/desktop: update gnome-bluetooth pkg in noble and trixie (#8501)

### DIFF
--- a/config/desktop/noble/environments/i3-wm/config_base/packages
+++ b/config/desktop/noble/environments/i3-wm/config_base/packages
@@ -42,7 +42,7 @@ foomatic-db-compressed-ppds
 gdebi
 ghostscript-x
 gir1.2-appindicator3-0.1
-gnome-bluetooth
+gnome-bluetooth-sendto
 gnome-disk-utility
 gnome-font-viewer
 gnome-power-manager

--- a/config/desktop/trixie/environments/i3-wm/config_base/packages
+++ b/config/desktop/trixie/environments/i3-wm/config_base/packages
@@ -41,7 +41,7 @@ fonts-ubuntu-console
 foomatic-db-compressed-ppds
 gdebi
 ghostscript-x
-gnome-bluetooth
+gnome-bluetooth-sendto
 gnome-disk-utility
 gnome-font-viewer
 gnome-power-manager


### PR DESCRIPTION
gnome-bluetooth in later releases is only transitional package to gnome-bluetooth-sendto.  update config-base package definition for noble and trixie i3-wm.

#FTBFS
Closes: #8501