### PR TITLE
Orangepizero: drop Crust support that is preventing succesful reboot

### DIFF
--- a/config/boards/orangepizero.csc
+++ b/config/boards/orangepizero.csc
@@ -11,7 +11,7 @@ HAS_VIDEO_OUTPUT="yes"
 SERIALCON="ttyS0,ttyGS0"
 KERNEL_TARGET="legacy,current,edge"
 KERNEL_TEST_TARGET="current"
-CRUSTCONFIG="orangepi_zero_defconfig"
+# CRUSTCONFIG="orangepi_zero_defconfig" # Crust is failing https://github.com/armbian/build/issues/8197
 
 function orange_pi_zero_enable_xradio_workarounds() {
 	/usr/bin/systemctl enable xradio_unload.service


### PR DESCRIPTION
# Description

Closing https://github.com/armbian/build/issues/8197

# How Has This Been Tested?

- [x] Tested by reporter

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
