### PR TITLE
Update TI k3.conf to use new official GitHub mirrors

### DIFF
--- a/config/sources/families/k3.conf
+++ b/config/sources/families/k3.conf
@@ -11,9 +11,9 @@ declare -g ARCH="arm64"
 declare -g LINUXFAMILY="k3"
 declare -g OVERLAY_DIR="/boot/dtb/ti/overlay"
 
-declare -g KERNELSOURCE="https://github.com/TexasInstruments-Sandbox/ti-linux-kernel"
+declare -g KERNELSOURCE="https://github.com/TexasInstruments/ti-linux-kernel"
 declare -g ATFSOURCE="https://github.com/TexasInstruments/arm-trusted-firmware"
-declare -g BOOTSOURCE="https://github.com/TexasInstruments-Sandbox/ti-u-boot"
+declare -g BOOTSOURCE="https://github.com/TexasInstruments/ti-u-boot"
 
 declare -g BOOTSCRIPT="boot-k3.cmd:uEnv.txt"
 declare -g SPD_OPTEED="SPD=opteed"
@@ -75,7 +75,7 @@ function add_host_dependencies__k3_python3_dep() {
 
 function compile_k3_bootgen() {
 	# Source code checkout
-	(fetch_from_repo "https://github.com/TexasInstruments-Sandbox/ti-linux-firmware" "ti-linux-firmware" ${TI_LINUX_FIRMWARE_BRANCH})
+	(fetch_from_repo "https://github.com/TexasInstruments/ti-linux-firmware" "ti-linux-firmware" ${TI_LINUX_FIRMWARE_BRANCH})
 
 	pushd ${SRC}/cache/sources/u-boot-worktree/${BOOTDIR}/${BOOTBRANCH##*:} || exit
 


### PR DESCRIPTION
# Description

This update simply moves mirrors from TexasInstruments-Sandbox repos to the new TexasInstruments main account mirrors.

# How Has This Been Tested?

Functional testing. Mirrors still build fine. Repository contents are identical for now. Sandbox repos will be discontinued once I've confirmed they're unused. 

# Checklist:

- [x ] My changes generate no new warnings
