### PR TITLE
config / families: drop collabora kernel for RK3588 (#7381)

### DIFF
--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -38,17 +38,6 @@ case $BRANCH in
 		KERNELPATCHDIR='rk35xx-vendor-6.1'
 		LINUXFAMILY=rk35xx
 		;;
-
-	collabora)
-		# Collabora's rk3588, where the action is these days
-		LINUXFAMILY=rockchip-rk3588
-		LINUXCONFIG='linux-rockchip-rk3588-'$BRANCH
-		KERNEL_MAJOR_MINOR="6.9"                                                                # Major and minor versions of this kernel.
-		KERNELPATCHDIR='rockchip-rk3588-collabora'                                              # Try to keep this as empty as possible. We won't work on top of Collabora's branch, they rebase all the time. New DTs are ok.
-		KERNELSOURCE='https://gitlab.collabora.com/hardware-enablement/rockchip-3588/linux.git' # Directly from Collabora...
-		KERNELBRANCH='branch:rk3588-v6.9'                                                       # Rolling kernel branch, will be rebased
-		KERNEL_DRIVERS_SKIP+=(driver_rtw88)                                                     # This is a custom kernel, while the rtw88 driver patching expects pure mainline
-		;;
 esac
 
 prepare_boot_configuration


### PR DESCRIPTION
drop support for the RK3588 collabora kernel (abandoned)