### PR TITLE
helios64: fix fancontrol service on trixie

### DIFF
--- a/config/boards/helios64.conf
+++ b/config/boards/helios64.conf
@@ -40,6 +40,7 @@ function post_family_tweaks_bsp__helios64() {
 	install -m 644 $SRC/packages/bsp/helios64/90-helios64-hwmon.rules $destination/etc/udev/rules.d/
 
 	install -m 644 $SRC/packages/bsp/helios64/fancontrol.service.pid-override $destination/etc/systemd/system/fancontrol.service.d/pid.conf
+	install -m 644 $SRC/packages/bsp/helios64/fancontrol.service.noprivdev-override $destination/etc/systemd/system/fancontrol.service.d/noprivdev.conf
 
 	# copy fancontrol config
 	install -m 644 $SRC/packages/bsp/helios64/fancontrol.conf $destination/etc/fancontrol

--- a/packages/bsp/helios64/fancontrol.service.noprivdev-override
+++ b/packages/bsp/helios64/fancontrol.service.noprivdev-override
@@ -1,0 +1,2 @@
+[Service]
+PrivateDevices=no


### PR DESCRIPTION
# Description

fancontrol.service was "hardened" in Debian trixie. See [Debian bug #944808](https://bugs.debian.org/944808).
fancontrol can't access fans in /dev after that.
This change returns full access to /dev for fancontrol.service

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
