### PR TITLE
Fix minor typo in sun8i-h616-fixup.scr to correct PH and PI port parse

### DIFF
--- a/patch/kernel/archive/sunxi-6.15/patches.armbian/cb1-overlay.patch
+++ b/patch/kernel/archive/sunxi-6.15/patches.armbian/cb1-overlay.patch
@@ -75,9 +75,9 @@ index 000000000000..2bde77cb082d
 +setenv decompose_pin 'setexpr tmp_bank sub "P(C|G|H|I)\\d+" "\\1";
 +setexpr tmp_pin sub "P\\S(\\d+)" "\\1";
 +test "${tmp_bank}" = "C" && setenv tmp_bank 2;
-+test "${tmp_bank}" = "G" && setenv tmp_bank 6'
++test "${tmp_bank}" = "G" && setenv tmp_bank 6;
 +test "${tmp_bank}" = "H" && setenv tmp_bank 7;
-+test "${tmp_bank}" = "I" && setenv tmp_bank 8;
++test "${tmp_bank}" = "I" && setenv tmp_bank 8'
 +
 +if test -n "${param_spinor_spi_bus}"; then
 +	test "${param_spinor_spi_bus}" = "0" && setenv tmp_spi_path "spi@5010000"


### PR DESCRIPTION
Fix minor typo in sun50i-h616-fixup.scr to correct PH and PI port parse, make Zero2W GPIO works.

Now pps-gpio and w1-gpio can used on Zero2W

![pps](https://github.com/user-attachments/assets/0ba112e8-ee92-42f5-9056-05e90f8b9862)

/boot/armbianEnv.txt
```
#Zero 2w
param_w1_pin=PI16
param_w1_pin_int_pullup=0
param_pps_pin=PI5
```