### PR TITLE
Update current cb1-overlay.patch

### DIFF
--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/cb1-overlay.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/cb1-overlay.patch
@@ -75,9 +75,9 @@ index 000000000000..2bde77cb082d
 +setenv decompose_pin 'setexpr tmp_bank sub "P(C|G|H|I)\\d+" "\\1";
 +setexpr tmp_pin sub "P\\S(\\d+)" "\\1";
 +test "${tmp_bank}" = "C" && setenv tmp_bank 2;
-+test "${tmp_bank}" = "G" && setenv tmp_bank 6'
++test "${tmp_bank}" = "G" && setenv tmp_bank 6;
 +test "${tmp_bank}" = "H" && setenv tmp_bank 7;
-+test "${tmp_bank}" = "I" && setenv tmp_bank 8;
++test "${tmp_bank}" = "I" && setenv tmp_bank 8'
 +
 +if test -n "${param_spinor_spi_bus}"; then
 +	test "${param_spinor_spi_bus}" = "0" && setenv tmp_spi_path "spi@5010000"


### PR DESCRIPTION
Same as in edge 6.15, fix minor typo in sun50i-h616-fixup.scr , to make Zero2W GPIO work.

Sorry for not combined it in one PR.

