### PR TITLE
lib / kernel-make.sh: drop undefined make_filter call. Closes #8529

### DIFF
--- a/lib/functions/compilation/kernel-make.sh
+++ b/lib/functions/compilation/kernel-make.sh
@@ -72,7 +72,7 @@ function run_kernel_make_internal() {
 
 	# last statement, so it passes the result to calling function. "env -i" is used for empty env
 	full_command=("${KERNEL_MAKE_RUNNER:-run_host_command_logged}" "env" "-i" "${common_make_envs[@]}"
-		make "${common_make_params_quoted[@]@Q}" "$@" "${make_filter}")
+		make "${common_make_params_quoted[@]@Q}" "$@")
 	"${full_command[@]}" # and exit with it's code, since it's the last statement
 }
 

--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -244,7 +244,6 @@ function kernel_build() {
 	cd "${kernel_work_dir}" || exit_with_error "Can't cd to kernel_work_dir: ${kernel_work_dir}"
 
 	display_alert "Building kernel" "${LINUXFAMILY} ${LINUXCONFIG} ${build_targets[*]}" "info"
-	# make_filter="| grep --line-buffered -v -e 'LD' -e 'AR' -e 'INSTALL' -e 'SIGN' -e 'XZ' " \ # @TODO this will be summarised in the log file eventually, but shown in realtime in screen
 	do_with_ccache_statistics \
 		run_kernel_make_long_running "${install_make_params_quoted[@]@Q}" "${build_targets[@]}" # "V=1" # "-s" silent mode, "V=1" verbose mode
 


### PR DESCRIPTION
# Description

GHA currently fails on lintian checks.  See #8529 for examples.  Root cause is "SC2154 (warning): make_filter is referenced but not assigned."  This PR fixes this error by dropping the call to make_filter.

# How Has This Been Tested?

Compile test via `PREFER_DOCKER=no ./compile.sh kernel-dtb BOARD=rock-5b BRANCH=current`