### PR TITLE
Set `Work in progress` label for maintainers synhronization

### DIFF
--- a/.github/workflows/adjust-maintainers.yml
+++ b/.github/workflows/adjust-maintainers.yml
@@ -115,7 +115,7 @@ jobs:
               - [Contribute](https://docs.armbian.com/Process_Contribute/)
 
           labels: |
-            Needs review
+            Work in progress
           #assignees: igorpecovnik
           #reviewers: Must be org collaborator
           draft: false


### PR DESCRIPTION
# Description

`Automatic board configs status synchronise` tells if there is a discrepancy between db and config and it becomes alright when all info is set correct. This action then adjust repo accordingly. Setting a different label would likely move it out from review process. This PR is unique and dependent from:

- board status
- database entry

It only become valid for review when all things are set correctly.

# Checklist:

- [x] My code follows the style guidelines of this project