### PR TITLE
patch/kernel: update docs URI in a number of overlay READMEs

### DIFF
--- a/patch/kernel/archive/meson64-6.12/overlay/README.meson-overlays
+++ b/patch/kernel/archive/meson64-6.12/overlay/README.meson-overlays
@@ -1,6 +1,6 @@
 This document describes overlays provided in the kernel packages
 For generic Armbian overlays documentation please see
-https://docs.armbian.com/User-Guide_Allwinner_overlays/
+https://docs.armbian.com/User-Guide_Armbian_overlays/
 
 ### Platform:
 

--- a/patch/kernel/archive/meson64-6.15/overlay/README.meson-overlays
+++ b/patch/kernel/archive/meson64-6.15/overlay/README.meson-overlays
@@ -1,6 +1,6 @@
 This document describes overlays provided in the kernel packages
 For generic Armbian overlays documentation please see
-https://docs.armbian.com/User-Guide_Allwinner_overlays/
+https://docs.armbian.com/User-Guide_Armbian_overlays/
 
 ### Platform:
 

--- a/patch/kernel/archive/rockchip-6.12/overlay/README.rk322x-overlays
+++ b/patch/kernel/archive/rockchip-6.12/overlay/README.rk322x-overlays
@@ -1,6 +1,6 @@
 This document describes overlays provided in the kernel packages
 For generic Armbian overlays documentation please see
-https://docs.armbian.com/User-Guide_Allwinner_overlays/
+https://docs.armbian.com/User-Guide_Armbian_overlays/
 
 ### Platform:
 

--- a/patch/kernel/archive/rockchip-6.12/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip-6.12/overlay/README.rockchip-overlays
@@ -1,6 +1,6 @@
 This document describes overlays provided in the kernel packages
 For generic Armbian overlays documentation please see
-https://docs.armbian.com/User-Guide_Allwinner_overlays/
+https://docs.armbian.com/User-Guide_Armbian_overlays/
 
 ### Platform:
 

--- a/patch/kernel/archive/rockchip-6.16/overlay/README.rk322x-overlays
+++ b/patch/kernel/archive/rockchip-6.16/overlay/README.rk322x-overlays
@@ -1,6 +1,6 @@
 This document describes overlays provided in the kernel packages
 For generic Armbian overlays documentation please see
-https://docs.armbian.com/User-Guide_Allwinner_overlays/
+https://docs.armbian.com/User-Guide_Armbian_overlays/
 
 ### Platform:
 

--- a/patch/kernel/archive/rockchip-6.16/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip-6.16/overlay/README.rockchip-overlays
@@ -1,6 +1,6 @@
 This document describes overlays provided in the kernel packages
 For generic Armbian overlays documentation please see
-https://docs.armbian.com/User-Guide_Allwinner_overlays/
+https://docs.armbian.com/User-Guide_Armbian_overlays/
 
 ### Platform:
 

--- a/patch/kernel/archive/rockchip64-6.12/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/README.rockchip-overlays
@@ -1,6 +1,6 @@
 This document describes overlays provided in the kernel packages
 For generic Armbian overlays documentation please see
-https://docs.armbian.com/User-Guide_Allwinner_overlays/
+https://docs.armbian.com/User-Guide_Armbian_overlays/
 
 ### Platform:
 

--- a/patch/kernel/archive/rockchip64-6.16/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.16/overlay/README.rockchip-overlays
@@ -1,6 +1,6 @@
 This document describes overlays provided in the kernel packages
 For generic Armbian overlays documentation please see
-https://docs.armbian.com/User-Guide_Allwinner_overlays/
+https://docs.armbian.com/User-Guide_Armbian_overlays/
 
 ### Platform:
 

--- a/patch/kernel/archive/rockchip64-6.6/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.6/overlay/README.rockchip-overlays
@@ -1,6 +1,6 @@
 This document describes overlays provided in the kernel packages
 For generic Armbian overlays documentation please see
-https://docs.armbian.com/User-Guide_Allwinner_overlays/
+https://docs.armbian.com/User-Guide_Armbian_overlays/
 
 ### Platform:
 

--- a/patch/kernel/archive/rockchip64-6.9/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.9/overlay/README.rockchip-overlays
@@ -1,6 +1,6 @@
 This document describes overlays provided in the kernel packages
 For generic Armbian overlays documentation please see
-https://docs.armbian.com/User-Guide_Allwinner_overlays/
+https://docs.armbian.com/User-Guide_Armbian_overlays/
 
 ### Platform:
 

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
@@ -320,7 +320,7 @@ index 000000000000..e0795f13ddf1
 @@ -0,0 +1,278 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -604,7 +604,7 @@ index 000000000000..9f9653f09573
 @@ -0,0 +1,172 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -782,7 +782,7 @@ index 000000000000..362f87961135
 @@ -0,0 +1,348 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -1136,7 +1136,7 @@ index 000000000000..302973491051
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
@@ -387,7 +387,7 @@ index 000000000000..1ac7fbcf62d1
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +

--- a/patch/kernel/archive/sunxi-6.13/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
+++ b/patch/kernel/archive/sunxi-6.13/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
@@ -320,7 +320,7 @@ index 000000000000..e0795f13ddf1
 @@ -0,0 +1,278 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -604,7 +604,7 @@ index 000000000000..9f9653f09573
 @@ -0,0 +1,172 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -782,7 +782,7 @@ index 000000000000..362f87961135
 @@ -0,0 +1,348 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -1136,7 +1136,7 @@ index 000000000000..302973491051
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +

--- a/patch/kernel/archive/sunxi-6.13/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
+++ b/patch/kernel/archive/sunxi-6.13/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
@@ -387,7 +387,7 @@ index 000000000000..1ac7fbcf62d1
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +

--- a/patch/kernel/archive/sunxi-6.14/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
+++ b/patch/kernel/archive/sunxi-6.14/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
@@ -320,7 +320,7 @@ index 000000000000..e0795f13ddf1
 @@ -0,0 +1,278 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -604,7 +604,7 @@ index 000000000000..9f9653f09573
 @@ -0,0 +1,172 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -782,7 +782,7 @@ index 000000000000..362f87961135
 @@ -0,0 +1,348 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -1136,7 +1136,7 @@ index 000000000000..302973491051
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +

--- a/patch/kernel/archive/sunxi-6.14/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
+++ b/patch/kernel/archive/sunxi-6.14/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
@@ -387,7 +387,7 @@ index 000000000000..1ac7fbcf62d1
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +

--- a/patch/kernel/archive/sunxi-6.15/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
+++ b/patch/kernel/archive/sunxi-6.15/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
@@ -320,7 +320,7 @@ index 000000000000..e0795f13ddf1
 @@ -0,0 +1,278 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -604,7 +604,7 @@ index 000000000000..9f9653f09573
 @@ -0,0 +1,172 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -782,7 +782,7 @@ index 000000000000..362f87961135
 @@ -0,0 +1,348 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -1136,7 +1136,7 @@ index 000000000000..302973491051
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +

--- a/patch/kernel/archive/sunxi-6.15/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
+++ b/patch/kernel/archive/sunxi-6.15/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
@@ -387,7 +387,7 @@ index 000000000000..1ac7fbcf62d1
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
@@ -320,7 +320,7 @@ index 000000000000..e0795f13ddf1
 @@ -0,0 +1,278 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -604,7 +604,7 @@ index 000000000000..9f9653f09573
 @@ -0,0 +1,172 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -782,7 +782,7 @@ index 000000000000..362f87961135
 @@ -0,0 +1,348 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -1136,7 +1136,7 @@ index 000000000000..302973491051
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
@@ -387,7 +387,7 @@ index 000000000000..1ac7fbcf62d1
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +

--- a/patch/kernel/archive/sunxi-6.7/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
+++ b/patch/kernel/archive/sunxi-6.7/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
@@ -224,7 +224,7 @@ index 000000000000..e0795f13ddf1
 @@ -0,0 +1,278 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -508,7 +508,7 @@ index 000000000000..9f9653f09573
 @@ -0,0 +1,172 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -686,7 +686,7 @@ index 000000000000..362f87961135
 @@ -0,0 +1,348 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +
@@ -1040,7 +1040,7 @@ index 000000000000..302973491051
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +

--- a/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
+++ b/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
@@ -339,7 +339,7 @@ index 000000000000..1ac7fbcf62d1
 @@ -0,0 +1,250 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
-+https://docs.armbian.com/User-Guide_Allwinner_overlays/
++https://docs.armbian.com/User-Guide_Armbian_overlays/
 +
 +### Platform:
 +


### PR DESCRIPTION
https://docs.armbian.com/User-Guide_Allwinner_overlays/ lives at https://docs.armbian.com/User-Guide_Armbian_overlays/ these days.  Update a couple of overlay READMEs accordingly.

At the same time, we should also implement a redirect for SBC with the old information -> armbian/documentation#803
