### PR TITLE
rockchip64: fix compilation issues for kernel 6.12

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/general-v4l2-rkvdec-01-vp9.patch
+++ b/patch/kernel/archive/rockchip64-6.12/general-v4l2-rkvdec-01-vp9.patch
@@ -357,24 +357,31 @@ Required to proper decode H.264@4K
 
 Signed-off-by: Alex Bee <knaerzche@gmail.com>
 ---
- drivers/media/platform/verisilicon/rockchip_vpu_hw.c | 14 ++++++++--
- 1 file changed, 11 insertions(+), 3 deletions(-)
+ drivers/media/platform/verisilicon/rockchip_vpu_hw.c | 15 ++++++++--
+ 1 file changed, 12 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/media/platform/verisilicon/rockchip_vpu_hw.c b/drivers/media/platform/verisilicon/rockchip_vpu_hw.c
-index 111111111111..222222222222 100644
+index 07d4ed41f2bd..579e5413bb7f 100644
 --- a/drivers/media/platform/verisilicon/rockchip_vpu_hw.c
 +++ b/drivers/media/platform/verisilicon/rockchip_vpu_hw.c
-@@ -16,7 +16,8 @@
+@@ -14,11 +14,13 @@
+ #include "hantro_h1_regs.h"
+ #include "rockchip_vpu2_regs.h"
  #include "rockchip_vpu981_regs.h"
  
  #define RK3066_ACLK_MAX_FREQ (300 * 1000 * 1000)
 -#define RK3288_ACLK_MAX_FREQ (400 * 1000 * 1000)
 +#define RK3288_ACLK_MAX_FREQ (600 * 1000 * 1000)
 +#define RK3399_ACLK_MAX_FREQ (400 * 1000 * 1000)
- #define RK3588_ACLK_MAX_FREQ (300 * 1000 * 1000)
++#define RK3588_ACLK_MAX_FREQ (300 * 1000 * 1000)
  
  #define ROCKCHIP_VPU981_MIN_SIZE 64
-@@ -447,13 +448,20 @@ static int rk3588_vpu981_hw_init(struct hantro_dev *vpu)
+ 
+ /*
+  * Supported formats.
+@@ -437,17 +439,24 @@ static int rk3066_vpu_hw_init(struct hantro_dev *vpu)
+ 	clk_set_rate(vpu->clocks[0].clk, RK3066_ACLK_MAX_FREQ);
+ 	clk_set_rate(vpu->clocks[2].clk, RK3066_ACLK_MAX_FREQ);
  	return 0;
  }
  
@@ -396,7 +403,11 @@ index 111111111111..222222222222 100644
  static void rk3066_vpu_dec_reset(struct hantro_ctx *ctx)
  {
  	struct hantro_dev *vpu = ctx->dev;
-@@ -709,7 +717,7 @@ const struct hantro_variant rk3288_vpu_variant = {
+ 
+ 	vdpu_write(vpu, G1_REG_INTERRUPT_DEC_IRQ_DIS, G1_REG_INTERRUPT);
+@@ -699,11 +708,11 @@ const struct hantro_variant rk3288_vpu_variant = {
+ 	.codec = HANTRO_JPEG_ENCODER | HANTRO_MPEG2_DECODER |
+ 		 HANTRO_VP8_DECODER | HANTRO_H264_DECODER,
  	.codec_ops = rk3288_vpu_codec_ops,
  	.irqs = rockchip_vpu1_irqs,
  	.num_irqs = ARRAY_SIZE(rockchip_vpu1_irqs),
@@ -405,7 +416,9 @@ index 111111111111..222222222222 100644
  	.clk_names = rockchip_vpu_clk_names,
  	.num_clocks = ARRAY_SIZE(rockchip_vpu_clk_names)
  };
--- 
+ 
+ /* VDPU2/VEPU2 */
+--
 Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001

--- a/patch/kernel/archive/rockchip64-6.12/rk3588-1053-board-nanopc-t6-fix-usb3-a.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk3588-1053-board-nanopc-t6-fix-usb3-a.patch
@@ -60,7 +60,7 @@ index 111111111111..222222222222 100644
  };
  
  &u2phy0_otg {
-+	phy-supply = <&vbus5v0_usb>;
++	phy-supply = <&vcc5v0_host_30>;
  	status = "okay";
  };
  


### PR DESCRIPTION
# Description

Updated VPU driver and board patches to resolve build failures:

- **drivers/media/platform/verisilicon/rockchip_vpu_hw.c**  
  Patch context mismatch due to kernel version update

<img width="2096" height="796" alt="image" src="https://github.com/user-attachments/assets/84259862-d43b-4d36-8290-2d1bb633cf3e" />

- **arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi**  
  Compilation error reported by @igorpecovnik  
  Reference: https://paste.armbian.com/icunixeran


https://paste.next.armbian.com/jiyiqitubo

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
