### PR TITLE
When updating u-boot on Rockchip64 to NVMe, script fails

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -332,7 +332,7 @@ write_uboot_platform_mtd() {
 
 	CHOICE=$(dialog --no-collapse \
   		--title "armbian-install" \
-  		--backtitle $backtitle \
+  		--backtitle "$backtitle" \
   		--radiolist "Choose SPI image:" 0 56 4 \
   		"${MENU_ITEMS[@]}" \
   		3>&1 1>&2 2>&3)


### PR DESCRIPTION
# Description

Found with Orange Pi 5: The script exits with "No SPI image chosen."

Fixed by adding missing quotes for $backtitle.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
