### PR TITLE
config/desktop: point sid links to trixie instead of bookworm

### DIFF
--- a/config/desktop/sid/environments/cinnamon
+++ b/config/desktop/sid/environments/cinnamon
@@ -1,1 +1,1 @@
-../../bookworm/environments/cinnamon
+../../trixie/environments/cinnamon

--- a/config/desktop/sid/environments/gnome
+++ b/config/desktop/sid/environments/gnome
@@ -1,1 +1,1 @@
-../../bookworm/environments/gnome
+../../trixie/environments/gnome

--- a/config/desktop/sid/environments/kde-plasma
+++ b/config/desktop/sid/environments/kde-plasma
@@ -1,1 +1,1 @@
-../../bookworm/environments/kde-plasma
+../../trixie/environments/kde-plasma

--- a/config/desktop/sid/environments/mate
+++ b/config/desktop/sid/environments/mate
@@ -1,1 +1,1 @@
-../../bookworm/environments/mate
+../../trixie/environments/mate


### PR DESCRIPTION
this update should hopefully deal with current breakage of image builds in our CI