### PR TITLE
armbian build machinery - allow kernel module compression.

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -56,37 +56,25 @@ function armbian_kernel_config__netkit() {
 #
 # Globals:
 #   kernel_config_modifying_hashes - Array tracking the configuration option changes.
-#   KERNEL_MAJOR_MINOR            - Kernel version used to apply version-specific configuration updates.
 #
 # Outputs:
 #   Displays alerts to notify about the configuration changes being applied.
 #
 # Description:
-#   This function disables several kernel configuration options such as module compression, module signing,
-#   and automatic versioning to speed up the build process and ensure compatibility with Armbian requirements.
-#   It forces EXPERT mode (EXPERT=y) to ensure hidden configurations are visible and applies different module
-#   compression settings based on the kernel version. All modifications are only performed if the .config file exists.
+#    This function disables several kernel configuration options such as 
+#    module signing and automatic versioning to speed up the build 
+#    process and ensure compatibility with Armbian requirements. 
+#    Additionally, it forces EXPERT mode (EXPERT=y) to ensure otherwise 
+#    hidden configurations are visible. All modifications are only 
+#    performed if the .config file exists.
 #
 function armbian_kernel_config__disable_various_options() {
-	kernel_config_modifying_hashes+=("CONFIG_MODULE_COMPRESS_NONE=y" "CONFIG_MODULE_SIG=n" "CONFIG_LOCALVERSION_AUTO=n" "EXPERT=y")
+	kernel_config_modifying_hashes+=("CONFIG_MODULE_SIG=n" "CONFIG_LOCALVERSION_AUTO=n" "EXPERT=y")
 	if [[ -f .config ]]; then
 		display_alert "Enable CONFIG_EXPERT=y" "armbian-kernel" "debug"
 		kernel_config_set_y EXPERT # Too many config options are hidden behind EXPERT=y, lets have it always on
 
-		display_alert "Disabling module compression and signing / debug / auto version" "armbian-kernel" "debug"
-		# DONE: Disable: signing, and compression of modules, for speed.
-		kernel_config_set_n CONFIG_MODULE_COMPRESS_XZ # No use double-compressing modules
-		kernel_config_set_n CONFIG_MODULE_COMPRESS_ZSTD
-		kernel_config_set_n CONFIG_MODULE_COMPRESS_GZIP
-
-		if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.12; then
-			kernel_config_set_n CONFIG_MODULE_COMPRESS # Introduced in 6.12 (see https://github.com/torvalds/linux/commit/c7ff693fa2094ba0a9d0a20feb4ab1658eff9c33)
-		elif linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.0; then
-			kernel_config_set_y CONFIG_MODULE_COMPRESS_NONE # Introduced in 6.0
-		else
-			kernel_config_set_n CONFIG_MODULE_COMPRESS # Only available up to 5.12
-		fi
-
+		display_alert "Disabling module signing / debug / auto version" "armbian-kernel" "debug"
 		kernel_config_set_n CONFIG_SECURITY_LOCKDOWN_LSM
 		kernel_config_set_n CONFIG_MODULE_SIG     # No use signing modules
 		kernel_config_set_n CONFIG_MODULE_SIG_ALL # No use auto-signing modules


### PR DESCRIPTION
a) it's not fully redundant. Yes, Armbian's kernel packages get compressed, but the compression is also valuable on disc in `/lib/modules`.

Incidentally, kernel builds using `compile.sh` don't seem to reliably compress the kernel packages. This may be a kernel tree issue, or a not-obviously-documented option for `compile.sh`

b) it's not particularly expensive... at least ZSTD isn't. In my testing, it took approximately 4-6 seconds [depending on some overheads of parallelization with `xargs`] on a Ryzen 5950x. This is NOT wall-clock, but user time.
https://github.com/armbian/build/pull/8538#issuecomment-3229205896

This isn't zero, and assuming [likely incorrectly] that we do build the kernel for all ~300 boards, this does add approximately 25 minutes to the overall time. This author does not know if the armbian organization is responsible to pay github or some other CI provider for the build time.

Slightly more optimistically, if we build all 85 kernel configs and cache them appropriately, compressing would add 85*6=510 or a little under 9 minutes.

prereq for #8538.

# How Has This Been Tested?

built/installed DEBs for `tritium-h5`
```
tabris@navi:~$ lsmod |wc -l
51
tabris@navi:~$ dpkg -l|grep ' linux-'
ii  linux-base                         4.9                                     all          Linux image base package
ii  linux-dtb-current-sunxi64          25.11.0-trunk                           arm64        Armbian Linux current DTBs in /boot/dtb-6.12.43-current-sunxi64
ii  linux-image-current-sunxi64        25.11.0-trunk                           arm64        Armbian Linux current kernel image 6.12.43-current-sunxi64
ii  linux-libc-dev:arm64               6.1.147-1                               arm64        Linux support headers for userspace development
ii  linux-u-boot-tritium-h5-current    25.8.1                                  arm64        Das U-Boot for tritium-h5
tabris@navi:~$ grep . du-6.12.43-current-sunxi64*.txt
du-6.12.43-current-sunxi64.txt:168M     /lib/modules/6.12.43-current-sunxi64/
du-6.12.43-current-sunxi64.txt:168M     total
du-6.12.43-current-sunxi64-zst.txt:59M  /lib/modules/6.12.43-current-sunxi64/
du-6.12.43-current-sunxi64-zst.txt:59M  total
```
ditto `rock-5-itx` [actually a `rock-5-itx-plus`]
```
root@ganga:~# grep . du-6.12.44-current-rockchip64*.txt; lsmod |wc -l
du-6.12.44-current-rockchip64.txt:213M  /lib/modules/6.12.44-current-rockchip64/
du-6.12.44-current-rockchip64-zstd.txt:77M      /lib/modules/6.12.44-current-rockchip64/
72
```
built with
`time for b in bananapir4 tritium-h5 rock-5-itx; do ./compile.sh build PREFER_DOCKER=yes BOARD=$b BRANCH=current KERNEL_CONFIGURE=no RELEASE=bookworm BUILD_MINIMAL=yes KERNEL_GIT=full ARTIFACT_IGNORE_CACHE=yes ;  done`

[built/deployed image to another `tritium-h5`](https://github.com/armbian/build/pull/8561#issuecomment-3252957977)