### PR TITLE
Upstream releases: update release upgrade paths

### DIFF
--- a/config/distributions/focal/upgrade
+++ b/config/distributions/focal/upgrade
@@ -1,1 +1,1 @@
-jammy,noble,oracular
+jammy,noble,oracular,plucky

--- a/config/distributions/jammy/upgrade
+++ b/config/distributions/jammy/upgrade
@@ -1,1 +1,1 @@
-noble,oracular
+noble,oracular,plucky

--- a/config/distributions/noble/upgrade
+++ b/config/distributions/noble/upgrade
@@ -1,1 +1,1 @@
-oracular
+oracular,plucky

--- a/config/distributions/oracular/upgrade
+++ b/config/distributions/oracular/upgrade
@@ -1,1 +1,1 @@
-none
+plucky


### PR DESCRIPTION
# Description

Since Ubuntu Plucky was introduced, we have to provide possibility to upgrade to that.

# How Has This Been Tested?

- [x] Tested upgrades from Jammy, Noble, Bookworm

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
