### PR TITLE
track input nice value, propagate to docker

### DIFF
--- a/lib/functions/cli/cli-docker.sh
+++ b/lib/functions/cli/cli-docker.sh
@@ -65,6 +65,9 @@ function cli_docker_run() {
 	ARMBIAN_CLI_RELAUNCH_PARAMS+=(["SET_OWNER_TO_UID"]="${EUID}")                 # fix the owner of files to our UID
 	ARMBIAN_CLI_RELAUNCH_PARAMS+=(["ARMBIAN_BUILD_UUID"]="${ARMBIAN_BUILD_UUID}") # pass down our uuid to the docker instance
 	ARMBIAN_CLI_RELAUNCH_PARAMS+=(["SKIP_LOG_ARCHIVE"]="yes")                     # launched docker instance will not cleanup logs.
+	if [[ -n "${DOCKER_NICE:-}" ]]; then
+		ARMBIAN_CLI_RELAUNCH_PARAMS+=(["DOCKER_NICE"]="${DOCKER_NICE}") # propagated `nice` value
+	fi
 
 	# Produce the re-launch params.
 	declare -g ARMBIAN_CLI_FINAL_RELAUNCH_ARGS=()


### PR DESCRIPTION
# Description

references #8353 - [Feature Request]: ability to set nice level
history in #8581
documentation: armbian/documentation#815

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `nice -n 7 ./compile.sh build PREFER_DOCKER=yes BOARD=tritium-h3 BRANCH=current KERNEL_CONFIGURE=yes RELEASE=bookworm BUILD_MINIMAL=yes KERNEL_GIT=full` and observed the `nice`ness of the resultant processes

# Checklist:

_Please delete options that are not relevant._

- [?] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
