### PR TITLE
[bugfix] Update binutils version checks in atf.sh

### DIFF
--- a/lib/functions/compilation/atf.sh
+++ b/lib/functions/compilation/atf.sh
@@ -69,10 +69,15 @@ compile_atf() {
 	declare binutils_version binutils_flags_atf=""
 	binutils_version=$(env PATH="${toolchain}:${toolchain2}:${PATH}" aarch64-linux-gnu-ld.bfd --version | head -1 | cut -d ")" -f 2 | xargs echo -n)
 	display_alert "Binutils version for ATF" "${binutils_version}" "info"
-	if linux-version compare "${binutils_version}" ge "2.39"; then
-		display_alert "Binutils version for ATF" ">= 2.39, adding --no-warn-rwx-segment" "info"
+
+	if linux-version compare "${binutils_version}" gt "2.39" && linux-version compare "${binutils_version}" lt "2.42"; then
+		display_alert "Binutils version for ATF" ">= 2.39 and < 2.42, adding -Wl,--no-warn-rwx-segment" "info"
 		binutils_flags_atf="-Wl,--no-warn-rwx-segment"
+	elif linux-version compare "${binutils_version}" ge "2.42"; then
+		display_alert "Binutils version for ATF" ">= 2.42, adding --no-warn-rwx-segments" "info"
+		binutils_flags_atf="--no-warn-rwx-segments"
 	fi
+ 
 	# - ENABLE_BACKTRACE="0" has been added to workaround a regression in ATF. Check: https://github.com/armbian/build/issues/1157
 
 	run_host_command_logged "CROSS_COMPILE='ccache ${ATF_COMPILER}'" CCACHE_BASEDIR="$(pwd)" "CC='ccache ${ATF_COMPILER}gcc'" PATH="${toolchain}:${toolchain2}:${PATH}" \


### PR DESCRIPTION
# Description

Compiling ATF with binutils 2.42 fails with "`/usr/bin/aarch64-linux-gnu-ld.bfd: unrecognized option '-Wl,--no-warn-rwx-segment'`"

log: 

```
...
[🐳|🌱] Binutils version for ATF [ 2.42 ]
[🐳|🌱] Binutils version for ATF [ >= 2.39, adding --no-warn-rwx-segment ]
...
[🐳|🔨]   /usr/bin/aarch64-linux-gnu-ld.bfd: unrecognized option '-Wl,--no-warn-rwx-segment'
[🐳|🔨]   /usr/bin/aarch64-linux-gnu-ld.bfd: use the --help option for usage information
...
```

ENV: Docker image: ghcr.io/armbian/docker-armbian-build:armbian-ubuntu-noble-latest, Ubuntu 24.04

I have referred to https://developer.trustedfirmware.org/T996, and the method mentioned there for adding the `-Wl,--no-warn-rwx-segment` parameter is not applicable to binutils 2.42.

When I looked up the parameter on binutils 2.42, the output was as follows:  
```
aarch64-linux-gnu-ld.bfd --help | grep "no-warn-rwx-segment"  
  --no-warn-rwx-segments      Do not generate a warning if a LOAD segment has RWX permissions
```

Also referred to here:

https://github.com/ARM-software/arm-trusted-firmware/blob/master/make_helpers/cflags.mk#L213

```
# With ld.bfd version 2.39 and newer new warnings are added. Skip those since we
# are not loaded by a elf loader.
	TF_LDFLAGS		+=	$(call ld_option, --no-warn-rwx-segments)
	TF_LDFLAGS		+=	-O1
	TF_LDFLAGS		+=	--gc-sections

	TF_LDFLAGS		+=	-z common-page-size=4096 # Configure page size constants
	TF_LDFLAGS		+=	-z max-page-size=4096
	TF_LDFLAGS		+=	--build-id=none
```

(**But why is binutils 2.39 mentioned here?**)

Therefore, on binutils 2.42, the parameter should be changed to: `--no-warn-rwx-segments`

# How Has This Been Tested?

- [x] The system image can be generated normally.
- [x] ATF can be compiled successfully.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
