### PR TITLE
armsom-sige5: let uboot use its own dtb for pd negotiation

### DIFF
--- a/patch/u-boot/legacy/u-boot-radxa-rk35xx/defconfig/armsom-sige5-rk3576_defconfig
+++ b/patch/u-boot/legacy/u-boot-radxa-rk35xx/defconfig/armsom-sige5-rk3576_defconfig
@@ -83,7 +83,7 @@ CONFIG_SPL_OF_CONTROL=y
 CONFIG_SPL_DTB_MINIMUM=y
 CONFIG_OF_LIVE=y
 CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
-CONFIG_OF_U_BOOT_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
+CONFIG_OF_U_BOOT_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
 # CONFIG_NET_TFTP_VARS is not set
 CONFIG_REGMAP=y
 CONFIG_SPL_REGMAP=y
@@ -217,8 +217,6 @@ CONFIG_AVB_LIBAVB_AB=y
 CONFIG_AVB_LIBAVB_ATX=y
 CONFIG_AVB_LIBAVB_USER=y
 CONFIG_RK_AVB_LIBAVB_USER=y
-CONFIG_ROCKCHIP_EARLY_DISTRO_DTB=y
-CONFIG_ROCKCHIP_EARLY_DISTRO_DTB_PATH="/boot/dtb/rockchip/rk3576-armsom-sige5.dtb"
 CONFIG_CMD_CHARGE_DISPLAY=y
 CONFIG_CMD_PMIC=y
 CONFIG_CMD_REGULATOR=y

--- a/patch/u-boot/legacy/u-boot-radxa-rk35xx/dt/rk3576-armsom-sige5.dts
+++ b/patch/u-boot/legacy/u-boot-radxa-rk35xx/dt/rk3576-armsom-sige5.dts
@@ -7,8 +7,55 @@
 #include "rk3576.dtsi"
 #include "rk3576-u-boot.dtsi"
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/usb/pd.h>
 
 / {
 	model = "ArmSoM Sige5";
 	compatible = "armsom,sige5", "rockchip,rk3576";
+};
+
+&i2c0 {
+	u-boot,dm-pre-reloc;
+	status = "okay";
+	pinctrl-0 = <&i2c0m1_xfer>;
+	usbc1: fusb302@22 {
+		u-boot,dm-pre-reloc;
+		compatible = "fcs,fusb302";
+		reg = <0x22>;
+		interrupt-parent = <&gpio0>;
+		interrupts = <RK_PC3 IRQ_TYPE_LEVEL_LOW>;
+		int-n-gpios = <&gpio0 RK_PC3 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&usbc1_int>;
+		status = "okay";
+		usb_con1: connector {
+			u-boot,dm-pre-reloc;
+			compatible = "usb-c-connector";
+			label = "USB-C";
+			data-role = "dual";
+			power-role = "sink";
+			op-sink-microwatt = <1000000>;
+			sink-pdos =
+				<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
+				 PDO_VAR(5000, 12000, 5000)>;
+		};
+	};
+};
+
+&i2c0m1_xfer {
+	u-boot,dm-pre-reloc;
+};
+
+&pcfg_pull_none_smt {
+	u-boot,dm-pre-reloc;
+};
+
+&pinctrl {
+	u-boot,dm-pre-reloc;
+	usb {
+		usbc1_int: usbc1-int {
+			u-boot,dm-pre-reloc;
+			rockchip,pins = <0 RK_PC3 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
 };


### PR DESCRIPTION
# Description

We are using dtb from kernel to let uboot support pd negotiation, which will make this uboot hard to support mainline kernel. Now we use the dtb inside uboot so it can boot any kernels.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh uboot BOARD=armsom-sige5 BRANCH=vendor DEB_COMPRESS=xz`
- [x] PD negotiation works:
```
I2c0 speed: 100000Hz
fusb302 device ID: 0x91
vconn is already Off
Start toggling
fusb302 start drp toggling
fusb302@22: init finished
CC connected in CC1 as UFP
Requesting PDO 2: 12000 mV, 1670 mA
PD chip enter low power mode
ret = 0 (dev => 00000000fbc24c50)
```

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
