### PR TITLE
xpressreal-t3: Load modules for HW video decoding/encoding

### DIFF
--- a/packages/bsp/xpressreal-t3/load-rtk-modules.sh
+++ b/packages/bsp/xpressreal-t3/load-rtk-modules.sh
@@ -9,6 +9,8 @@ modules=(
 	snd_soc_hifi_realtek
 	snd_soc_realtek
 	rtk_drm
+	rtkve1
+	rtkve2
 )
 
 for module in "${modules[@]}"; do


### PR DESCRIPTION
# Description

This PR add video decoding/encoding modules in xpressreal-t3's module loading script. The kernel driver was added in this [commit](https://github.com/XpressReal/linux/commit/88e58e0607aec006d6d7c44a690df5591b98c3b9)

# How Has This Been Tested?

- [x] build/boot test with minimal and gnome desktop image
- [x] test video decoding in ffmpeg with HW acceleration 

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
