### PR TITLE
blobs: rk3576: update BL31 to v1.20 and DDR to v1.09

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -143,8 +143,8 @@ case "$BOOT_SOC" in
 
 	rk3576)
 		BOOT_SCENARIO="${BOOT_SCENARIO:=spl-blobs}"
-		DDR_BLOB="${DDR_BLOB:-"rk35/rk3576_ddr_lp4_2112MHz_lp5_2736MHz_v1.03.bin"}"
-		BL31_BLOB="${BL31_BLOB:-"rk35/rk3576_bl31_v1.04.elf"}"
+		DDR_BLOB="${DDR_BLOB:-"rk35/rk3576_ddr_lp4_2112MHz_lp5_2736MHz_v1.09.bin"}"
+		BL31_BLOB="${BL31_BLOB:-"rk35/rk3576_bl31_v1.20.elf"}"
 		;;
 
 	rk3588) #CPUMAX undefined?


### PR DESCRIPTION
# Description

Taken from upstream repository and opened PR here https://github.com/armbian/rkbin/pull/38

# How Has This Been Tested?

Tested on NanoPi R76s:

```bash
root@nanopi-r76s:~# dmesg | grep "v1.20"
[    8.417457] Kernel command line: root=/dev/mmcblk0p1 rootwait rootfstype=ext4 splash=verbose console=ttyS2,1500000 console=tty1 consoleblank=0 loglevel=1 ubootpart=a7a94881-e6b2-4414-8eda-940a1c144fb6 usb-storage.quirks=   cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory androidboot.fwver=ddr-v1.03-81dd75088a,bl31-v1.20,uboot-rmbian-201-09/08/2025
```

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings