### PR TITLE
kenrel makefile: use Makefile url from ghproxy github repo for mainli…

### DIFF
--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -120,7 +120,14 @@ function memoized_git_ref_to_info() {
 
 				"https://kernel.googlesource.com/pub/scm/linux/kernel/git/stable/linux-stable.git" | "https://mirrors.tuna.tsinghua.edu.cn/git/linux-stable.git" | "https://mirrors.bfsu.edu.cn/git/linux-stable.git")
 					# for mainline kernel source, only the origin source support curl
-					url="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/Makefile?h=${sha1}"
+					case "${GITHUB_MIRROR}" in
+						"ghproxy")
+							url="https://${GHPROXY_ADDRESS}/https://raw.githubusercontent.com/torvalds/linux/${sha1}/Makefile"
+							;;
+						*)
+							url="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/Makefile?h=${sha1}"
+							;;
+					esac
 					;;
 
 				"https://gitverse.ru/"*)


### PR DESCRIPTION
…ne kernel if GITHUB_MIRROR is set to ghproxy

# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

The default mainline kernel Makefile https://git.kernel.org usually get timeout in my network environment, while ghproxy works.
This commit will fetch Makefile from ghproxy accelerated github url `https://github.com/torvalds/linux` if ghproxy is set to `GITHUB_MIRROR`. If `GITHUB_MIRROR` is not set, it will still fetch from the default git.kernel.org url.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=armsom-sige5 BRANCH=edge KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes KERNEL_GIT=shallow REGIONAL_MIRROR=china`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
