### PR TITLE
rk3576: update DDR_BLOB to v1.08

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -143,7 +143,9 @@ case "$BOOT_SOC" in
 
 	rk3576)
 		BOOT_SCENARIO="${BOOT_SCENARIO:=spl-blobs}"
-		DDR_BLOB="${DDR_BLOB:-"rk35/rk3576_ddr_lp4_2112MHz_lp5_2736MHz_v1.09.bin"}"
+		# FIXME(rk3576): v1.09 caused boot failures on some boards (see PR #8596, #8600).
+		# Pinning to v1.08 until newer DDR binaries are validated across rk3576 boards.
+		DDR_BLOB="${DDR_BLOB:-"rk35/rk3576_ddr_lp4_2112MHz_lp5_2736MHz_v1.08.bin"}"
 		BL31_BLOB="${BL31_BLOB:-"rk35/rk3576_bl31_v1.20.elf"}"
 		;;
 


### PR DESCRIPTION
# Description

#8596 has updated DDR blob to v1.09 without test, which will cause armsom sige5 not bootable, while v1.08 works.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh uboot BOARD=armsom-sige5 BRANCH=vendor DEB_COMPRESS=xz`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
