### PR TITLE
BSP: fix incorrect logging for USB Gadget script

### DIFF
--- a/packages/bsp/usb-gadget-network/setup-usbgadget-network.sh
+++ b/packages/bsp/usb-gadget-network/setup-usbgadget-network.sh
@@ -80,7 +80,7 @@ set_usbgadget_ipaddress() {
 		echo "unudhcpd process already exists, skip setting usb gadget ip, unudhcpd_pid is $unudhcpd_pid"
 		return
 	fi
-	echo "Starting dnsmasq with server ip $host_ip, client ip: $client_ip"
+	echo "Starting unudhcpd service with server ip $host_ip, client ip: $client_ip"
 	# Get usb interface
 	INTERFACE=""
 	ip a add "${host_ip}/255.255.0.0" dev usb0 2> /dev/null && ip link set usb0 up && INTERFACE=usb0


### PR DESCRIPTION
./packages/bsp/usb-gadget-network/setup-usbgadget-network.sh claims to be starting dnsmasq when in fact the DHCP server used is unudhcpd