### PR TITLE
IMX8 kernel 6.12.y: fix to latest known version that compiles

### DIFF
--- a/config/sources/families/include/imx8_common.inc
+++ b/config/sources/families/include/imx8_common.inc
@@ -29,6 +29,7 @@ case $BOARD in
 
 			current) # mainline stable kernel
 				KERNEL_MAJOR_MINOR="6.12"
+				KERNELBRANCH="tag:v6.12.45"
 				;;
 
 			edge | default) # use for tests with recent mainline kernels


### PR DESCRIPTION
# Description

Setting BRANCH to fixed version - drop it once patches are adjusted.

https://github.com/armbian/build/issues/8615

# How Has This Been Tested?

- [x] CI

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
