### PR TITLE
rockchip: only install ap6330-initramfs-firmware hook when armbian firmware is installed

### DIFF
--- a/config/sources/families/rockchip.conf
+++ b/config/sources/families/rockchip.conf
@@ -238,8 +238,10 @@ family_tweaks_bsp() {
 	fi
 
 	# AP6330 (BCM4330) firmware initramfs hook for in-kernel btbcm driver
-	mkdir -p $destination/etc/initramfs-tools/hooks
-	install -m 550 $SRC/packages/bsp/rockchip/ap6330-initramfs-firmware $destination/etc/initramfs-tools/hooks
+	if [[ "$INSTALL_ARMBIAN_FIRMWARE" == "yes" ]]; then
+		mkdir -p $destination/etc/initramfs-tools/hooks
+		install -m 550 $SRC/packages/bsp/rockchip/ap6330-initramfs-firmware $destination/etc/initramfs-tools/hooks
+	fi
 
 	# Board selection script, only for rk322x-box
 	if [[ "$BOARD" == "rk322x-box" ]]; then


### PR DESCRIPTION
INSTALL_ARMBIAN_FIRMWARE is set yes by default. While I'm tring to build a minimal image without armbian-firmware, and the initramfs hook  `ap6330-initramfs-firmware` will try to copy firmware file from armbian-firmware, so there has to be a check.



# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=tinkerboard BRANCH=edge KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes KERNEL_GIT=shallow INSTALL_ARMBIAN_FIRMWARE=no BUILD_DESKTOP=no BUILD_MINIMAL=yes RELEASE=trixie`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
