### PR TITLE
Fix broken GitHub Action: Add Label When Approved

### DIFF
--- a/.github/workflows/pr-label-on-approved.yml
+++ b/.github/workflows/pr-label-on-approved.yml
@@ -1,21 +1,31 @@
-on: pull_request_review
-name: Label approved pull requests
-
-permissions:
-  contents: read          # Required for checking changed files
-  pull-requests: write    # Required for labeling PRs
-  issues: write           # Required for adding/removing labels
+name: PR review labeler
+on:
+  workflow_run:
+    workflows: ["PR review listener"]
+    types: [completed]
 
 jobs:
-  labelWhenApproved:
-    if: ${{ github.repository_owner == 'armbian' }}
-    name: Label when approved
+  label:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0] }}
+    name: "Set label"
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - name: Label when approved
-      uses: pullreminders/label-when-approved-action@master
-      env:
-        APPROVALS: "1"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ADD_LABEL: "Ready to merge"
-        REMOVE_LABEL: "Needs%20review"
+      - name: Extract PR number
+        id: pr
+        run: |
+          echo "number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Label when approved
+        uses: j-fulbright/label-when-approved-action@v1.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          label: 'Ready to merge'
+          require_committers_approval: 'true'
+          remove_label_when_approval_missing: 'true'
+          comment: '✅ This PR has been reviewed and approved — all set for merge!'
+          # action runs on workflow_run, so pass PR number explicitly
+          pullRequestNumber: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/pr-review-listener.yml
+++ b/.github/workflows/pr-review-listener.yml
@@ -1,0 +1,15 @@
+name: PR review listener
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  ping:
+    if: ${{ github.event.review.state == 'approved' }}
+    name: "Listen"
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - run:
+          echo "Approved review detected for PR ${{ github.event.pull_request.number }}"


### PR DESCRIPTION
# Description

Previous action for setting a label "Ready to Merge" when PR is approved vanished from GitHub.

- A tiny workflow that runs on pull_request_review (read-only is fine) and simply completes.
- A second workflow that runs on workflow_run of the first one, in the base repo context (has write), and adds the label.

# How Has This Been Tested?

- [x] Tested on fork

# Checklist:

- [x] My changes generate no new warnings