### PR TITLE
Add AM62P Starter Kit Support

### DIFF
--- a/config/boards/sk-am62p.conf
+++ b/config/boards/sk-am62p.conf
@@ -1,0 +1,18 @@
+# TI AM62P quad core 8GB 2xGBE OSPI HDMI
+
+BOARD_NAME="SK-AM62P"
+BOARDFAMILY="k3"
+BOARD_MAINTAINER="grippy98"
+BOOTCONFIG="am62px_evm_a53_defconfig"
+BOOTFS_TYPE="fat"
+BOOT_FDT_FILE="ti/k3-am62p5-sk.dts"
+TIBOOT3_BOOTCONFIG="am62px_evm_r5_defconfig"
+TIBOOT3_FILE="tiboot3-am62px-hs-fs-evm.bin"
+DEFAULT_CONSOLE="serial"
+KERNEL_TARGET="current,edge"
+KERNEL_TEST_TARGET="current"
+SERIALCON="ttyS2"
+ATF_BOARD="lite"
+OPTEE_ARGS="CFG_TEE_CORE_LOG_LEVEL=1"
+OPTEE_PLATFORM="k3-am62x"
+CC33XX_SUPPORT="yes"


### PR DESCRIPTION
# Description

This adds support for the AM62P Starter Kit

A beefier version of AM62x with 8GB of RAM by default, video encode/decode etc. 

# How Has This Been Tested?

<img width="585" height="454" alt="Screenshot 2025-09-12 at 4 28 19 PM" src="https://github.com/user-attachments/assets/abb1eca4-79c8-4680-ae0d-e19adff4cd66" />

- [x  ] Boot test.

# Checklist:

_Please delete options that are not relevant._

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
