### PR TITLE
Re-Enable BeagleY As Supported and fix Wifi

### DIFF
--- a/config/boards/beagley-ai.conf
+++ b/config/boards/beagley-ai.conf
@@ -1,4 +1,4 @@
-#Texas Instruments AM67A quad core 4GB USB3 DDR4 4TOPS
+# Texas Instruments AM67A quad core 4GB USB3 DDR4 4TOPS
 
 BOARD_NAME="BeagleY-AI"
 BOARDFAMILY="k3"
@@ -15,6 +15,7 @@ SERIALCON="ttyS2"
 ATF_BOARD="lite"
 OPTEE_ARGS=""
 OPTEE_PLATFORM="k3-am62x"
+CC33XX_SUPPORT="yes"
 
 # Use these branches until BeagleY-AI goes upstream
 function post_family_config_branch_current__beagley_ai_use_beagle_kernel_uboot() {


### PR DESCRIPTION
# Description

Puts BeagleY back to Conf status and adds CC33x FW so Wifi now works as expected. 

Will look at cleaning up config further in next PR. 

# How Has This Been Tested?

- [ * ] Built, booted and tested that Wifi works. 

# Checklist:

_Please delete options that are not relevant._

- [ * ] My code follows the style guidelines of this project
- [ * ] I have performed a self-review of my own code
- [ * ] My changes generate no new warnings