### PR TITLE
extensions: add gxlimg and amlogic-fip-blobs

### DIFF
--- a/config/boards/cainiao-cniot-core.csc
+++ b/config/boards/cainiao-cniot-core.csc
@@ -20,50 +20,26 @@ function post_family_config__use_repacked_fip() {
 	unset write_uboot_platform
 
 	function write_uboot_platform() {
-		dd if="$1/u-boot.bin" of="$2" bs=512 seek=1 conv=fsync 2>&1
+		dd if="$1/u-boot.bin" of="$2" bs=512 seek=1 conv=fsync,notrunc 2>&1
 	}
-}
-
-function fetch_sources_tools__get_vendor_fip_and_gxlimg_source() {
-	fetch_from_repo "https://github.com/retro98boy/cainiao-cniot-core-linux.git" "cainiao-cniot-core-linux" "commit:30273c25aeabf75f609cff2c4fa7264335c295a8"
-	fetch_from_repo "https://github.com/repk/gxlimg.git" "gxlimg" "commit:0d0e5ba9cf396d1338067e8dc37a8bcd2e6874f1"
-}
-
-function build_host_tools__install_gxlimg() {
-	# Compile and install only if git commit hash changed
-	cd "${SRC}/cache/sources/gxlimg" || exit
-	# need to check if /usr/local/bin/gxlimg to detect new Docker containers with old cached sources
-	if [[ ! -f .commit_id || $(git rev-parse @ 2> /dev/null) != $(< .commit_id) || ! -f /usr/local/bin/gxlimg ]]; then
-		display_alert "Compiling" "gxlimg" "info"
-		run_host_command_logged make distclean
-		run_host_command_logged make
-		install -Dm0755 gxlimg /usr/local/bin/gxlimg
-		git rev-parse @ 2> /dev/null > .commit_id
-	fi
 }
 
 function post_uboot_custom_postprocess__repack_vendor_fip_with_mainline_uboot() {
 	display_alert "${BOARD}" "Repacking vendor FIP with mainline u-boot.bin" "info"
 
-	BLOBS_DIR="${SRC}/cache/sources/cainiao-cniot-core-linux"
+	BLOBS_DIR="${SRC}/cache/sources/amlogic-fip-blobs/cainiao-cniot-core"
 	EXTRACT_DIR="${BLOBS_DIR}/extract"
-	AML_ENCRYPT="${SRC}/cache/sources/amlogic-boot-fip/khadas-vim3/aml_encrypt_g12b"
 
-	if [ ! -f "$AML_ENCRYPT" ]; then
-		display_alert "${BOARD}" "amlogic-boot-fip/khadas-vim3/aml_encrypt_g12b not exist" "err"
-		exit 1
-	fi
+	rm -rf "$EXTRACT_DIR"
+	mkdir "$EXTRACT_DIR"
+	run_host_command_logged gxlimg -e "${BLOBS_DIR}/DDR.USB" "$EXTRACT_DIR"
 
 	mv u-boot.bin raw-u-boot.bin
 	rm -f "${EXTRACT_DIR}/bl33.enc"
-	# The current version of gxlimg has a problem with the handling of bl3x,
-	# which may cause the produced fip to fail to boot.
-	# see https://github.com/repk/gxlimg/issues/19
-	# run_host_command_logged gxlimg -t bl3x -s raw-u-boot.bin "${EXTRACT_DIR}/bl33.enc"
-	run_host_x86_binary_logged "$AML_ENCRYPT" --bl3sig \
-		--input raw-u-boot.bin \
-		--output "${EXTRACT_DIR}/bl33.enc" \
-		--level v3 --type bl33
+	run_host_command_logged gxlimg \
+		-t bl3x \
+		-s raw-u-boot.bin \
+		"${EXTRACT_DIR}/bl33.enc"
 	run_host_command_logged gxlimg \
 		-t fip \
 		--bl2 "${EXTRACT_DIR}/bl2.sign" \

--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -6,6 +6,8 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+enable_extension "gxlimg"
+enable_extension "amlogic-fip-blobs"
 UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-u-boot-dtb.img;;u-boot.bin.sd.bin:u-boot.bin u-boot-dtb.img}"
 BOOTSCRIPT="boot-meson64.cmd:boot.cmd"
 BOOTENV_FILE='meson.txt'

--- a/extensions/amlogic-fip-blobs.sh
+++ b/extensions/amlogic-fip-blobs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+function fetch_sources_tools__amlogic-fip-blobs() {
+	fetch_from_repo "https://github.com/retro98boy/amlogic-fip-blobs" "amlogic-fip-blobs" "commit:f090bd4a5420c12f8ef5932c472afee9fb590787"
+}

--- a/extensions/gxlimg.sh
+++ b/extensions/gxlimg.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+function fetch_sources_tools__gxlimg() {
+	fetch_from_repo "https://github.com/retro98boy/gxlimg" "gxlimg" "commit:fde6a3dd0e13875a5b219389c0a6137616eaebdb"
+}
+
+function build_host_tools__compile_gxlimg() {
+	# Compile and install only if git commit hash changed
+	cd "${SRC}/cache/sources/gxlimg" || exit
+	# need to check if /usr/local/bin/gxlimg to detect new Docker containers with old cached sources
+	if [[ ! -f .commit_id || $(git rev-parse @ 2> /dev/null) != $(< .commit_id) || ! -f /usr/local/bin/gxlimg ]]; then
+		display_alert "Compiling" "gxlimg" "info"
+		run_host_command_logged make distclean
+		run_host_command_logged make
+		run_host_command_logged install -Dm0755 gxlimg /usr/local/bin/gxlimg
+		git rev-parse @ 2> /dev/null > .commit_id
+	fi
+}


### PR DESCRIPTION
# Description

Using gxlimg as a public tool, it offers a way for Amlogic devices without U-Boot source code to utilize mainline U-Boot: extract bl2 and bl3x from the vendor FIP, then repackage mainline U-Boot with bl2 and bl3x into a new FIP

Temporarily use my fork of the gxlimg repository, which fixes the sign bug for bl3x files

# How Has This Been Tested?

build Armbian image, burn it to CAINIAO CNIoT-CORE eMMC，then boot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
