### PR TITLE
Reliable PR number relay for labeler workflow

### DIFF
--- a/.github/workflows/pr-label-on-approved.yml
+++ b/.github/workflows/pr-label-on-approved.yml
@@ -1,7 +1,7 @@
 name: PR review labeler
 on:
   workflow_run:
-    workflows: ["PR review listener"]   # must match the other workflow's name
+    workflows: ["PR review listener"]
     types: [completed]
 
 jobs:
@@ -14,33 +14,15 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Find PR by commit SHA
-        id: pr
-        uses: actions/github-script@v7
+      - uses: actions/download-artifact@v4
         with:
-          script: |
-            const { owner, repo } = context.repo;
-            const sha = context.payload.workflow_run.head_sha;
-
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner,
-              repo,
-              commit_sha: sha,
-            });
-
-            if (!prs.length) {
-              core.setFailed(`❌ No PR associated with commit ${sha}`);
-              return;
-            }
-
-            // Prefer open PRs
-            const pr = prs.find(p => p.state === 'open') || prs[0];
-            core.info(`✅ Found PR #${pr.number} for commit ${sha}`);
-            core.setOutput('number', String(pr.number));
+          name: pr-number
+          path: .
+      - id: pr
+        run: echo "number=$(cat pr.txt)" >> $GITHUB_OUTPUT
 
       - name: Label when approved
-        if: ${{ success() }}
-        uses: j-fulbright/label-when-approved-action@v1.2
+        uses: TobKed/label-when-approved-action@v1.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           label: 'Ready to merge'

--- a/.github/workflows/pr-label-on-approved.yml
+++ b/.github/workflows/pr-label-on-approved.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Resolve PR number from head_sha
+      - name: Find PR by commit SHA
         id: pr
         uses: actions/github-script@v7
         with:
@@ -23,17 +23,19 @@ jobs:
             const sha = context.payload.workflow_run.head_sha;
 
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner, repo, commit_sha: sha
+              owner,
+              repo,
+              commit_sha: sha,
             });
 
             if (!prs.length) {
-              core.setFailed(`❌ No PR found for commit ${sha}`);
+              core.setFailed(`❌ No PR associated with commit ${sha}`);
               return;
             }
 
-            // Pick an open PR if possible
+            // Prefer open PRs
             const pr = prs.find(p => p.state === 'open') || prs[0];
-            core.info(`Using PR #${pr.number}`);
+            core.info(`✅ Found PR #${pr.number} for commit ${sha}`);
             core.setOutput('number', String(pr.number));
 
       - name: Label when approved

--- a/.github/workflows/pr-label-on-approved.yml
+++ b/.github/workflows/pr-label-on-approved.yml
@@ -14,10 +14,14 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download PR number artifact from upstream run
+        uses: actions/download-artifact@v4
         with:
-          name: pr-number
+          name: pr-number-${{ github.event.workflow_run.id }}   # same unique name
           path: .
+          run-id: ${{ github.event.workflow_run.id }}           # ← CRITICAL: fetch from the upstream run
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - id: pr
         run: echo "number=$(cat pr.txt)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pr-label-on-approved.yml
+++ b/.github/workflows/pr-label-on-approved.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "number=$(cat pr.txt)" >> $GITHUB_OUTPUT
 
       - name: Label when approved
-        uses: TobKed/label-when-approved-action@v1.4
+        uses: j-fulbright/label-when-approved-action@v1.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           label: 'Ready to merge'

--- a/.github/workflows/pr-review-listener.yml
+++ b/.github/workflows/pr-review-listener.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
       - name: Save PR number
         run: echo "${{ github.event.pull_request.number }}" > pr.txt
+
       - uses: actions/upload-artifact@v4
         with:
-          name: pr-number
+          # unique name: includes workflow run id
+          name: pr-number-${{ github.run_id }}
           path: pr.txt

--- a/.github/workflows/pr-review-listener.yml
+++ b/.github/workflows/pr-review-listener.yml
@@ -6,12 +6,13 @@ on:
 jobs:
   ping:
     if: ${{ github.event.review.state == 'approved' }}
-    outputs:
-      pr: ${{ github.event.pull_request.number }}
-    name: "Listen"
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-    runs-on: ubuntu-latest
     steps:
-      - run:
-          echo "Approved review detected for PR ${{ github.event.pull_request.number }}"
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          path: pr.txt

--- a/.github/workflows/pr-review-listener.yml
+++ b/.github/workflows/pr-review-listener.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   ping:
     if: ${{ github.event.review.state == 'approved' }}
+    outputs:
+      pr: ${{ github.event.pull_request.number }}
     name: "Listen"
     permissions:
       contents: read


### PR DESCRIPTION
# Description

## Reliable PR number relay for labeler workflow

This change fixes the issue where the labeler workflow could not find the correct PR number when triggered via `workflow_run`, leading to **“Artifact not found”** or empty PR resolution for fork PRs.

## Changes

- **Listener workflow (`PR review listener`)**

  - Corrected `run:` step syntax.
  - Saves the PR number into a `pr.txt` file.
  - Uploads the file as a uniquely named artifact: `pr-number-${{ github.run_id }}`.

- **Labeler workflow (`PR review labeler`)**

  - Downloads the PR number artifact from the upstream run using `run-id`.
  - Added `actions: read` permission to allow cross-run artifact download.
  - Reads the PR number and passes it to `TobKed/label-when-approved-action`.
  - Ensures labels are applied reliably for both same-repo and fork PRs.

## Benefits
- ✅ Handles multiple PR approvals simultaneously without artifact collisions.  
- ✅ Works even when commits belong only to forks (before merge).  
- ✅ Ensures the labeler always has the correct PR number.  
- ✅ Cleaner, more robust relay between workflows.  

# How Has This Been Tested?

- [x] Tested opening and approving PR's on fork

# Checklist:

- [x] My changes generate no new warnings