### PR TITLE
Implement label removal on PR approval

### DIFF
--- a/.github/workflows/pr-label-on-approved.yml
+++ b/.github/workflows/pr-label-on-approved.yml
@@ -34,3 +34,20 @@ jobs:
           remove_label_when_approval_missing: 'true'
           comment: '✅ This PR has been reviewed and approved — all set for merge!'
           pullRequestNumber: ${{ steps.pr.outputs.number }}
+
+      - name: Remove "Needs review" label
+        if: ${{ success() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = ${{ steps.pr.outputs.number }};
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number,
+                name: "Needs review"
+              });
+              core.info('Removed label "Needs review"');
+            } catch (e) {
+              core.warning(`Could not remove label: ${e.message}`);
+            }


### PR DESCRIPTION
# Description

Once we set label "Ready to merge" lets remove "Review needed". If its set.

# How Has This Been Tested?

- [x] Tested on fork

# Checklist:

- [x] My changes generate no new warnings