### PR TITLE
orangepi5: overhaul board config, update mainline uboot

### DIFF
--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -35,54 +35,7 @@ function post_family_config__orangepi5_use_mainline_uboot() {
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} $BOOTCONFIG_SATA;;u-boot-rockchip-spi-sata.bin
 	BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} $BOOTCONFIG;;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
-	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
-
-	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
-	function write_uboot_platform() {
-		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
-	}
-
-	function write_uboot_platform_mtd() {
-		FILES=$(find "$1" -maxdepth 1 -type f -name "u-boot-rockchip-spi*.bin")
-		if [ -z "$FILES" ]; then
-			echo "No SPI image found."
-			exit 1
-		fi
-
-		MENU_ITEMS=()
-		i=1
-
-		# Read the files into an array
-		while IFS= read -r file; do
-			filename=$(basename "$file")
-			MENU_ITEMS+=("$i" "$filename" "")
-			((i++))
-		done <<< "$FILES"
-
-		# If there is only one image or the terminal is not interactive, we can skip the dialog
-		if [[ ! -t 1 || $i -eq 2 ]]; then
-			flashcp -v -p "$1/${MENU_ITEMS[1]}" /dev/mtd0
-			return
-		fi
-
-		[[ -f /etc/armbian-release ]] && source /etc/armbian-release
-		backtitle="Armbian for $BOARD_NAME install script, https://www.armbian.com"
-
-		CHOICE=$(dialog --no-collapse \
-			--title "armbian-install" \
-			--backtitle $backtitle \
-			--radiolist "Choose SPI image:" 0 56 4 \
-			"${MENU_ITEMS[@]}" \
-			3>&1 1>&2 2>&3)
-
-		if [ $? -eq 0 ]; then
-			idx=$((CHOICE*3-2))
-			flashcp -v -p "$1/${MENU_ITEMS[$idx]}" /dev/mtd0
-		else
-			echo "No SPI image chosen."
-			exit 1
-		fi
-	}
+	unset uboot_custom_postprocess # disable stuff from rockchip64_common; we're using binman here which does all the work already
 }
 
 function pre_config_uboot_target__orangepi5_patch_uboot_bootconfig_hack_for_sata() {

--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -33,7 +33,8 @@ function post_family_config__orangepi5_use_mainline_uboot() {
 	declare -g BOOTBRANCH="tag:v2025.04"
 	declare -g BOOTPATCHDIR="v2025.04"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
-	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} $BOOTCONFIG_SATA;;u-boot-rockchip-spi-sata.bin
+	BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} $BOOTCONFIG;;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
 
 	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
@@ -42,8 +43,61 @@ function post_family_config__orangepi5_use_mainline_uboot() {
 	}
 
 	function write_uboot_platform_mtd() {
-		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
+		FILES=$(find "$1" -maxdepth 1 -type f -name "u-boot-rockchip-spi*.bin")
+		if [ -z "$FILES" ]; then
+			echo "No SPI image found."
+			exit 1
+		fi
+
+		MENU_ITEMS=()
+		i=1
+
+		# Read the files into an array
+		while IFS= read -r file; do
+			filename=$(basename "$file")
+			MENU_ITEMS+=("$i" "$filename" "")
+			((i++))
+		done <<< "$FILES"
+
+		# If there is only one image, we can skip the dialog
+		if [[ $i -eq 2 ]]; then
+			flashcp -v -p "$1/${MENU_ITEMS[1]}" /dev/mtd0
+			return
+		fi
+
+		[[ -f /etc/armbian-release ]] && source /etc/armbian-release
+		backtitle="Armbian for $BOARD_NAME install script, https://www.armbian.com"
+
+		CHOICE=$(dialog --no-collapse \
+			--title "armbian-install" \
+			--backtitle $backtitle \
+			--radiolist "Choose SPI image:" 0 56 4 \
+			"${MENU_ITEMS[@]}" \
+			3>&1 1>&2 2>&3)
+
+		if [ $? -eq 0 ]; then
+			flashcp -v -p "$1/${MENU_ITEMS[($CHOICE*3)-2]}" /dev/mtd0
+		else
+			echo "No SPI image chosen."
+			exit 1
+		fi
 	}
+}
+
+function pre_config_uboot_target__orangepi5_patch_uboot_bootconfig_hack_for_sata() {
+	if [[ $BRANCH == "vendor" ]]; then
+		return
+	fi
+
+	display_alert "u-boot for ${BOARD}" "u-boot: hack bootconfig for sata spi image" "info"
+
+	if [[ $target_make == *"orangepi-5-sata-rk3588s_defconfig"* ]]; then
+  		BOOTCONFIG="orangepi-5-sata-rk3588s_defconfig"
+		target_make=${target_make/orangepi-5-sata-rk3588s_defconfig/}
+	else
+  		BOOTCONFIG="orangepi-5-rk3588s_defconfig"
+		target_make=${target_make/orangepi-5-rk3588s_defconfig/}
+	fi
 }
 
 function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {

--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -101,6 +101,28 @@ function pre_config_uboot_target__orangepi5_patch_uboot_bootconfig_hack_for_sata
 	fi
 }
 
+
+function post_config_uboot_target__orangepi5_keep_sata_bootconfig() {
+	if [[ $BRANCH == "vendor" ]]; then
+		return
+	fi
+
+	display_alert "u-boot for ${BOARD}" "u-boot: hack bootconfig for sata spi image" "info"
+
+	if [[ $BOOTCONFIG == "orangepi-5-sata-rk3588s_defconfig" ]]; then
+		cp .config ${uboottempdir}/.config.sata
+	fi
+}
+
+function pre_package_uboot_image__orangepi5_copy_sataconfig_to_pacage() {
+	if [[ $BRANCH == "vendor" ]]; then
+		return
+	fi
+
+	run_host_command_logged cp ${uboottempdir}/.config.sata "$uboottempdir/usr/lib/u-boot/orangepi-5-sata-rk3588s_defconfig"
+	run_host_command_logged rm ${uboottempdir}/.config.sata
+}
+
 function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {
 	if [[ $BRANCH == "edge" || $BRANCH == "current" ]]; then
 		return

--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -16,15 +16,22 @@ BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 declare -g UEFI_EDK2_BOARD_ID="orangepi-5" # This _only_ used for uefi-edk2-rk3588 extension
 
+declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # For the bluetooth-hciattach extension
+enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
+
 # Mainline U-Boot for current kernel
-function post_family_config_branch_current__orangepi5_use_mainline_uboot() {
+function post_family_config__orangepi5_use_mainline_uboot() {
+	if [[ $BRANCH == "vendor" ]]; then
+		return
+	fi
+
 	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
 
 	declare -g BOOTCONFIG="orangepi-5-rk3588s_defconfig"         # override the default for the board/family
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ mainline U-Boot
-	declare -g BOOTBRANCH="tag:v2025.01"
-	declare -g BOOTPATCHDIR="v2025.01"
+	declare -g BOOTBRANCH="tag:v2025.04"
+	declare -g BOOTPATCHDIR="v2025.04"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
@@ -39,13 +46,8 @@ function post_family_config_branch_current__orangepi5_use_mainline_uboot() {
 	}
 }
 
-
-
-declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # For the bluetooth-hciattach extension
-enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
-
 function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {
-	if [[ $BRANCH == "edge" ]]; then
+	if [[ $BRANCH == "edge" || $BRANCH == "current" ]]; then
 		return
 	fi
 
@@ -58,7 +60,7 @@ function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {
 }
 
 function post_family_tweaks__orangepi5_enable_usb2_service() {
-	if [[ $BRANCH == "edge" ]]; then
+	if [[ $BRANCH == "edge" || $BRANCH == "current" ]]; then
 		return
 	fi
 
@@ -71,7 +73,7 @@ function post_family_tweaks__orangepi5_enable_usb2_service() {
 }
 
 function post_family_tweaks__orangepi5_naming_audios() {
-	if [[ $BRANCH == "edge" ]]; then
+	if [[ $BRANCH == "edge" || $BRANCH == "current" ]]; then
 		return
 	fi
 
@@ -86,7 +88,7 @@ function post_family_tweaks__orangepi5_naming_audios() {
 }
 
 function post_family_config__orangepi5_uboot_add_sata_target() {
-	if [[ $BRANCH == "edge" ]]; then
+	if [[ $BRANCH == "edge" || $BRANCH == "current" ]]; then
 		return
 	fi
 
@@ -96,31 +98,8 @@ function post_family_config__orangepi5_uboot_add_sata_target() {
 	BL31=$RKBIN_DIR/$BL31_BLOB $BOOTCONFIG_SATA spl/u-boot-spl.bin u-boot.dtb u-boot.itb;; rkspi_loader_sata.img"
 }
 
-function post_family_config_branch_edge__uboot_config() {
-	display_alert "$BOARD" "u-boot ${BOOTBRANCH_BOARD} edge overrides" "info"
-	UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin u-boot.itb idbloader.img idbloader-spi.img"
-	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
-
-	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
-	function write_uboot_platform() {
-		dd if=${1}/u-boot-rockchip.bin of=${2} bs=32k seek=1 conv=fsync
-	}
-
-	# Smarter/faster/better to-spi writer using flashcp (hopefully with --partition), using the binman-provided 'u-boot-rockchip-spi.bin'
-	function write_uboot_platform_mtd() {
-		declare -a extra_opts_flashcp=("--verbose")
-		if flashcp -h | grep -q -e '--partition'; then
-			echo "Confirmed flashcp supports --partition -- read and write only changed blocks." >&2
-			extra_opts_flashcp+=("--partition")
-		else
-			echo "flashcp does not support --partition, will write full SPI flash blocks." >&2
-		fi
-		flashcp "${extra_opts_flashcp[@]}" "${1}/u-boot-rockchip-spi.bin" /dev/mtd0
-	}
-}
-
 function post_uboot_custom_postprocess__create_sata_spi_image() {
-	if [[ $BRANCH == "edge" ]]; then
+	if [[ $BRANCH == "edge" || $BRANCH == "current" ]]; then
 		return
 	fi
 
@@ -137,14 +116,4 @@ function post_uboot_custom_postprocess__create_sata_spi_image() {
 	/sbin/parted -s rkspi_loader_sata.img unit s mkpart uboot 16384 32734
 	dd if=idbloader.img of=rkspi_loader_sata.img seek=64 conv=notrunc
 	dd if=u-boot.itb of=rkspi_loader_sata.img seek=16384 conv=notrunc
-}
-
-function post_family_config_branch_edge__orangepi5_use_mainline_uboot() {
-	if [[ $BRANCH == "edge" ]]; then
-		BOOTCONFIG="orangepi-5-rk3588s_defconfig"
-		BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-		BOOTBRANCH="commit:2f0282922b2c458eea7f85c500a948a587437b63"
-		BOOTDIR="u-boot-${BOARD}"
-		BOOTPATCHDIR="v2024.01/board_${BOARD}"
-	fi
 }

--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -59,8 +59,8 @@ function post_family_config__orangepi5_use_mainline_uboot() {
 			((i++))
 		done <<< "$FILES"
 
-		# If there is only one image, we can skip the dialog
-		if [[ $i -eq 2 ]]; then
+		# If there is only one image or the terminal is not interactive, we can skip the dialog
+		if [[ ! -t 1 || $i -eq 2 ]]; then
 			flashcp -v -p "$1/${MENU_ITEMS[1]}" /dev/mtd0
 			return
 		fi
@@ -76,7 +76,8 @@ function post_family_config__orangepi5_use_mainline_uboot() {
 			3>&1 1>&2 2>&3)
 
 		if [ $? -eq 0 ]; then
-			flashcp -v -p "$1/${MENU_ITEMS[($CHOICE*3)-2]}" /dev/mtd0
+			idx=$((CHOICE*3-2))
+			flashcp -v -p "$1/${MENU_ITEMS[$idx]}" /dev/mtd0
 		else
 			echo "No SPI image chosen."
 			exit 1

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -305,9 +305,8 @@ write_uboot_platform() {
 	fi
 }
 
-# @TODO: this is not ready for BOOT_SCENARIO=binman yet
 write_uboot_platform_mtd() {
-	FILES=$(find "$1" -maxdepth 1 -type f -name "rkspi_loader*.img")
+	FILES=$(find "$1" -maxdepth 1 -type f \( -name "rkspi_loader*.img" -o -name "u-boot-rockchip-spi*.bin" \))
 	if [ -z "$FILES" ]; then
 		echo "No SPI image found."
 		exit 1
@@ -315,17 +314,23 @@ write_uboot_platform_mtd() {
 
 	MENU_ITEMS=()
 	i=1
+	FILE_ARRAY=()
 
 	# Read the files into an array
 	while IFS= read -r file; do
 		filename=$(basename "$file")
 		MENU_ITEMS+=("$i" "$filename" "")
+		FILE_ARRAY+=("$file")
 		((i++))
 	done <<< "$FILES"
 
-	# If there is only one image or the terminal is not interactive, we can skip the dialog
 	if [[ ! -t 1 || $i -eq 2 ]]; then
-		dd if=$1/${MENU_ITEMS[1]} of=$2 conv=notrunc status=none > /dev/null 2>&1
+		first_file="${FILE_ARRAY[0]}"
+		if [[ "$first_file" == *rkspi_loader*.img ]]; then
+			dd if="$first_file" of="$2" conv=notrunc status=none > /dev/null 2>&1
+		else
+			flashcp -v -p "$first_file" /dev/mtd0
+		fi
 		return
 	fi
 
@@ -333,15 +338,20 @@ write_uboot_platform_mtd() {
 	backtitle="Armbian for $BOARD_NAME install script, https://www.armbian.com"
 
 	CHOICE=$(dialog --no-collapse \
-  		--title "armbian-install" \
-  		--backtitle "$backtitle" \
-  		--radiolist "Choose SPI image:" 0 56 4 \
-  		"${MENU_ITEMS[@]}" \
-  		3>&1 1>&2 2>&3)
+		--title "armbian-install" \
+		--backtitle "$backtitle" \
+		--radiolist "Choose SPI image:" 0 56 4 \
+		"${MENU_ITEMS[@]}" \
+		3>&1 1>&2 2>&3)
 
 	if [ $? -eq 0 ]; then
-		idx=$((CHOICE*3-2))
-		dd if=$1/${MENU_ITEMS[$idx]} of=$2 conv=notrunc status=none > /dev/null 2>&1
+		idx=$((CHOICE-1))
+		chosen_file="${FILE_ARRAY[$idx]}"
+		if [[ "$chosen_file" == *rkspi_loader*.img ]]; then
+			dd if="$chosen_file" of="$2" conv=notrunc status=none > /dev/null 2>&1
+		else
+			flashcp -v -p "$chosen_file" /dev/mtd0
+		fi
 	else
 		echo "No SPI image chosen."
 		exit 1

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -323,8 +323,8 @@ write_uboot_platform_mtd() {
 		((i++))
 	done <<< "$FILES"
 
-	# If there is only one image, we can skip the dialog
-	if [[ $i -eq 2 ]]; then
+	# If there is only one image or the terminal is not interactive, we can skip the dialog
+	if [[ ! -t 1 || $i -eq 2 ]]; then
 		dd if=$1/${MENU_ITEMS[1]} of=$2 conv=notrunc status=none > /dev/null 2>&1
 		return
 	fi
@@ -340,7 +340,8 @@ write_uboot_platform_mtd() {
   		3>&1 1>&2 2>&3)
 
 	if [ $? -eq 0 ]; then
-		dd if=$1/${MENU_ITEMS[($CHOICE*3)-2]} of=$2 conv=notrunc status=none > /dev/null 2>&1
+		idx=$((CHOICE*3-2))
+		dd if=$1/${MENU_ITEMS[$idx]} of=$2 conv=notrunc status=none > /dev/null 2>&1
 	else
 		echo "No SPI image chosen."
 		exit 1

--- a/lib/functions/cli/utils-cli.sh
+++ b/lib/functions/cli/utils-cli.sh
@@ -26,13 +26,9 @@ function parse_cmdline_params() {
 			param_value=${arg##*=}
 			param_value_desc="${param_value:-(empty)}"
 			# Sanity check for the param name; it must be a valid bash variable name.
-			if [[ "${param_name}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
 				ARMBIAN_PARSED_CMDLINE_PARAMS["${param_name}"]="${param_value}" # For current run.
 				ARMBIAN_CLI_RELAUNCH_PARAMS["${param_name}"]="${param_value}"   # For relaunch.
 				display_alert "Command line: parsed parameter '$param_name' to" "${param_value_desc}" "debug"
-			else
-				exit_with_error "Invalid cmdline param '${param_name}=${param_value_desc}'"
-			fi
 		elif [[ "x${arg}x" != "xx" ]]; then # not a param, not empty, store it in the non-param array for later usage
 			local non_param_value="${arg}"
 			local non_param_value_desc="${non_param_value:-(empty)}"

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -525,6 +525,9 @@ function compile_uboot() {
 	EOF
 
 	# copy license files, config, etc.
+
+	echo "bruhmoment"
+	ls -la .
 	[[ -f .config && -n $BOOTCONFIG ]] && run_host_command_logged cp .config "$uboottempdir/usr/lib/u-boot/${BOOTCONFIG}" # legacy and @TODO should be removed as it has only the last target; we now have per-target configs and defconfigs
 	[[ -f COPYING ]] && run_host_command_logged cp COPYING "$uboottempdir/usr/lib/u-boot/LICENSE"
 	[[ -f Licenses/README ]] && run_host_command_logged cp Licenses/README "$uboottempdir/usr/lib/u-boot/LICENSE"

--- a/patch/u-boot/v2025.04/board_orangepi5/0001-add-sata-dts-and-defconfig-for-OPi5.patch
+++ b/patch/u-boot/v2025.04/board_orangepi5/0001-add-sata-dts-and-defconfig-for-OPi5.patch
@@ -1,0 +1,175 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Sat, 26 Apr 2025 15:45:44 +0300
+Subject: add sata dts and defconfig for OPi5
+
+---
+ arch/arm/dts/rk3588s-orangepi-5-sata-u-boot.dtsi            | 16 ++
+ configs/orangepi-5-sata-rk3588s_defconfig                   | 93 ++++++++++
+ dts/upstream/src/arm64/rockchip/rk3588s-orangepi-5-sata.dts | 33 ++++
+ 3 files changed, 142 insertions(+)
+
+diff --git a/arch/arm/dts/rk3588s-orangepi-5-sata-u-boot.dtsi b/arch/arm/dts/rk3588s-orangepi-5-sata-u-boot.dtsi
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/arch/arm/dts/rk3588s-orangepi-5-sata-u-boot.dtsi
+@@ -0,0 +1,16 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++#include "rk3588s-u-boot.dtsi"
++#include "rk3588s-orangepi-5-u-boot.dtsi"
++
++/ {
++	chosen {
++		u-boot,spl-boot-order = "same-as-spl", &sdmmc;
++	};
++};
++
++&binman {
++	simple-bin-spi {
++		filename = "u-boot-rockchip-spi-sata.bin";
++	};
++};
+\ No newline at end of file
+diff --git a/configs/orangepi-5-sata-rk3588s_defconfig b/configs/orangepi-5-sata-rk3588s_defconfig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/configs/orangepi-5-sata-rk3588s_defconfig
+@@ -0,0 +1,93 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_COUNTER_FREQUENCY=24000000
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SF_DEFAULT_SPEED=24000000
++CONFIG_SF_DEFAULT_MODE=0x2000
++CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3588s-orangepi-5-sata"
++CONFIG_ROCKCHIP_RK3588=y
++CONFIG_ROCKCHIP_SPI_IMAGE=y
++CONFIG_SPL_SERIAL=y
++CONFIG_TARGET_EVB_RK3588=y
++CONFIG_SYS_LOAD_ADDR=0xc00800
++CONFIG_SF_DEFAULT_BUS=5
++CONFIG_DEBUG_UART_BASE=0xFEB50000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI=y
++CONFIG_PCI=y
++CONFIG_DEBUG_UART=y
++CONFIG_AHCI=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_FIT_SIGNATURE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3588s-orangepi-5-sata.dtb"
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++CONFIG_SPL_MAX_SIZE=0x40000
++CONFIG_SPL_PAD_TO=0x7f8000
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_SPI_LOAD=y
++CONFIG_SYS_SPI_U_BOOT_OFFS=0x60000
++CONFIG_SPL_ATF=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_I2C=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_REGULATOR=y
++# CONFIG_SPL_DOS_PARTITION is not set
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_SPL_DM_SEQ_ALIAS=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SPL_SYSCON=y
++CONFIG_AHCI_PCI=y
++CONFIG_DWC_AHCI=y
++CONFIG_SPL_CLK=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MISC=y
++CONFIG_SUPPORT_EMMC_RPMB=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_SPI_FLASH_SFDP_SUPPORT=y
++CONFIG_SPI_FLASH_XMC=y
++CONFIG_PHY_MOTORCOMM=y
++CONFIG_DWC_ETH_QOS=y
++CONFIG_DWC_ETH_QOS_ROCKCHIP=y
++CONFIG_NVME_PCI=y
++CONFIG_PCIE_DW_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_NANENG_COMBOPHY=y
++CONFIG_PHY_ROCKCHIP_USBDP=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_SPL_RAM=y
++CONFIG_SCSI=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_ROCKCHIP_SFC=y
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_ERRNO_STR=y
++CONFIG_AHCI=y
++CONFIG_CMD_SCSI=y
++CONFIG_DM_SCSI=y
++CONFIG_DWC_AHCI=y
++CONFIG_LIBATA=y
++CONFIG_SCSI_AHCI=y
++CONFIG_SCSI=y
+diff --git a/dts/upstream/src/arm64/rockchip/rk3588s-orangepi-5-sata.dts b/dts/upstream/src/arm64/rockchip/rk3588s-orangepi-5-sata.dts
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/dts/upstream/src/arm64/rockchip/rk3588s-orangepi-5-sata.dts
+@@ -0,0 +1,33 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include "rk3588s-orangepi-5.dtsi"
++#include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/gpio/gpio.h>
++
++/ {
++	model = "Xunlong Orange Pi 5 (Sata)";
++	compatible = "xunlong,orangepi-5", "rockchip,rk3588s";
++};
++
++&sata0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&sata_reset>;
++	status = "okay";
++
++	phys = <&combphy0_ps PHY_TYPE_SATA>;
++	phy-names = "sata-phy";
++};
++
++&sfc {
++	status = "okay";
++};
++
++&pinctrl {
++	sata {
++		sata_reset: sata-reset {
++			rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

- Use same uboot for current and edge builds, so that we can remove redundant lines.
- Add sata spi image to current, edge uboot builds. It is a bit hacky, but it works.
- Also add selection for SPI images like https://github.com/armbian/build/pull/8123

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Tested sata spi image boot.
- [x] Tested sata doesn't boot with normal spi image.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
