### PR TITLE
Radxa-e52c.  Device NIC port rename to match device labels and network LED config via radxa-e52c.conf

### DIFF
--- a/config/boards/radxa-e52c.conf
+++ b/config/boards/radxa-e52c.conf
@@ -1,10 +1,52 @@
 # Rockchip RK3582 SoC octa core 4-16GB SoC eMMC USB3
 BOARD_NAME="Radxa E52C"
 BOARDFAMILY="rockchip-rk3588"
-BOARD_MAINTAINER="amazingfate"
+BOARD_MAINTAINER="amazingfate schwar3kat"
 BOOTCONFIG="radxa-e52c-rk3588s_defconfig"
 KERNEL_TARGET="vendor"
 BOOT_FDT_FILE="rockchip/rk3588s-radxa-e52c.dtb"
 BOOT_SCENARIO="spl-blobs"
 BOOT_SOC="rk3588"
 IMAGE_PARTITION_TABLE="gpt"
+
+function post_family_tweaks_bsp__enable_leds_radxa-e52c() {
+	display_alert "Creating board support LEDs config for radxa-e52c."
+	cat <<- EOF > "${destination}"/etc/armbian-leds.conf
+	[/sys/class/leds/lan-led]
+		trigger=netdev
+		interval=52
+		brightness=1
+		link=1
+		tx=0
+		rx=1
+		device_name=lan
+		
+		[/sys/class/leds/wan-led]
+		trigger=netdev
+		interval=52
+		brightness=1
+		link=1
+		tx=0
+		rx=1
+		device_name=wan
+		
+		[/sys/class/leds/mmc0::]
+		trigger=mmc0
+		brightness=0
+		
+		[/sys/class/leds/sys-led]
+		trigger=heartbeat
+		brightness=0
+		invert=0
+
+	EOF
+
+	# add a network rule to rename interfaces to match device labeling.
+	display_alert "Creating board support network rename rule to to rename interfaces to match device labeling for radxa-e52c"
+	mkdir -p "${destination}"/etc/udev/rules.d/
+	cat <<- EOF > "${destination}"/etc/udev/rules.d/70-rename-lan.rules
+		    SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", KERNEL=="enP3p49s0", NAME="wan"
+		    SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", KERNEL=="enP4p65s0", NAME="lan"
+	EOF
+}
+


### PR DESCRIPTION
# Description
In radxa-e52c.conf, use a post_family_tweaks_bsp function to add config files to:
1. Add a network rule to rename interfaces to match device port labeling (wan,lan) in /etc/udev/rules.d/70-rename-lan.rules
2. Add network activity LEDs config for wan and lan for radxa-e52c in /etc/armbian-leds.conf

Add myself as a maintainer of radxa-e52c.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2753]

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

- [ ] Built trixie vendor cli image and tested on raxda-e52c

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
