### PR TITLE
SMART AM40: U-Boot: fix DWC DRD could not find phy and thus crashed

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -52,7 +52,7 @@ esac
 #
 # Available options for BOOT_SCENARIO are:
 # - only-blobs: proprietary rockchip ddrbin, miniloader and ATF
-# - spl-blobs: proprietary rockchip ddrin and ATF, but uses mainline u-boot SPL in place of rockchip miniloader
+# - spl-blobs: proprietary rockchip ddrbin and ATF, but uses mainline u-boot SPL in place of rockchip miniloader
 # - tpl-spl-blob: uses mainline u-boot TPL and SPL with proprietary rockchip ATF blob
 # - tpl-blob-atf-mainline: proprietary rockchip ddrbin + mainline u-boot SPL + mainline ATF
 # - blobless: mainline u-boot TPL + mainline u-boot SPL + mainline ATF

--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3399-am40.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3399-am40.dts
@@ -685,6 +685,10 @@
 &u2phy0 {
 	status = "okay";
 
+	u2phy0_otg: otg-port {
+		status = "okay";
+	};
+
 	u2phy0_host: host-port {
 		phy-supply = <&vcc5v0_host>;
 		status = "okay";
@@ -693,6 +697,10 @@
 
 &u2phy1 {
 	status = "okay";
+
+	u2phy1_otg: otg-port {
+		status = "okay";
+	};
 
 	u2phy1_host: host-port {
 		phy-supply = <&vcc5v0_host>;

--- a/patch/kernel/archive/rockchip64-6.16/dt/rk3399-am40.dts
+++ b/patch/kernel/archive/rockchip64-6.16/dt/rk3399-am40.dts
@@ -685,6 +685,10 @@
 &u2phy0 {
 	status = "okay";
 
+	u2phy0_otg: otg-port {
+		status = "okay";
+	};
+
 	u2phy0_host: host-port {
 		phy-supply = <&vcc5v0_host>;
 		status = "okay";
@@ -693,6 +697,10 @@
 
 &u2phy1 {
 	status = "okay";
+
+	u2phy1_otg: otg-port {
+		status = "okay";
+	};
 
 	u2phy1_host: host-port {
 		phy-supply = <&vcc5v0_host>;

--- a/patch/u-boot/v2025.04/board_smart-am40/add-board-smart-am40.patch
+++ b/patch/u-boot/v2025.04/board_smart-am40/add-board-smart-am40.patch
@@ -94,10 +94,10 @@ index 00000000..8ea5266f
 +CONFIG_ERRNO_STR=y
 diff --git a/dts/upstream/src/arm64/rockchip/rk3399-am40.dts b/dts/upstream/src/arm64/rockchip/rk3399-am40.dts
 new file mode 100644
-index 00000000..cf667415
+index 00000000..555b661b
 --- /dev/null
 +++ b/dts/upstream/src/arm64/rockchip/rk3399-am40.dts
-@@ -0,0 +1,779 @@
+@@ -0,0 +1,787 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -785,6 +785,10 @@ index 00000000..cf667415
 +&u2phy0 {
 +	status = "okay";
 +
++	u2phy0_otg: otg-port {
++		status = "okay";
++	};
++
 +	u2phy0_host: host-port {
 +		phy-supply = <&vcc5v0_host>;
 +		status = "okay";
@@ -793,6 +797,10 @@ index 00000000..cf667415
 +
 +&u2phy1 {
 +	status = "okay";
++
++	u2phy1_otg: otg-port {
++		status = "okay";
++	};
 +
 +	u2phy1_host: host-port {
 +		phy-supply = <&vcc5v0_host>;


### PR DESCRIPTION
# Description

If u2phy0_otg and u2phy1_otg are not enabled, entering `usb start` in the U-Boot cmd will cause U-Boot to crash

# How Has This Been Tested?

test USB function in new U-Boot and Armbian shell

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings