### PR TITLE
Remove multiple labels on approve and adjust dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
+    labels:
+      - "GitHub Actions"
+      - "Dependencies"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "GitHub Actions"
+      - "Dependencies"
+      - "Python"

--- a/.github/workflows/pr-label-on-approved.yml
+++ b/.github/workflows/pr-label-on-approved.yml
@@ -35,19 +35,20 @@ jobs:
           comment: '✅ This PR has been reviewed and approved — all set for merge!'
           pullRequestNumber: ${{ steps.pr.outputs.number }}
 
-      - name: Remove "Needs review" label
+      - name: Remove review-related labels
         if: ${{ success() }}
         uses: actions/github-script@v7
         with:
           script: |
             const { owner, repo } = context.repo;
             const issue_number = ${{ steps.pr.outputs.number }};
-            try {
-              await github.rest.issues.removeLabel({
-                owner, repo, issue_number,
-                name: "Needs review"
-              });
-              core.info('Removed label "Needs review"');
-            } catch (e) {
-              core.warning(`Could not remove label: ${e.message}`);
+            const labelsToRemove = ["Needs review", "Work in progress"];
+
+            for (const name of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+                core.info(`Removed label "${name}"`);
+              } catch (e) {
+                core.warning(`Could not remove label "${name}": ${e.message}`);
+              }
             }

--- a/.github/workflows/pr-label-on-approved.yml
+++ b/.github/workflows/pr-label-on-approved.yml
@@ -42,7 +42,7 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const issue_number = ${{ steps.pr.outputs.number }};
-            const labelsToRemove = ["Needs review", "Work in progress"];
+            const labelsToRemove = ["Needs review", "Work in progress", "Backlog", "Can be closed?", "Help needed", "Needs Documentation"];
 
             for (const name of labelsToRemove) {
               try {


### PR DESCRIPTION
# Description

When we approve PR, we want to remove labels that are not valid anymore:

- Needs review
- Work in progress
- Backlog
- Can be closed?
- Help needed
- Needs Documentation

# How Has This Been Tested?

- [x] Tested on fork

# Checklist:

- [x] My code follows the style guidelines of this project