### PR TITLE
uefi-loong64-6.16: add patch to enable xe driver build

### DIFF
--- a/patch/kernel/archive/uefi-loong64-6.16/0006-enable-xe-on-16K-pagesize.patch
+++ b/patch/kernel/archive/uefi-loong64-6.16/0006-enable-xe-on-16K-pagesize.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jianfeng Liu <liujianfeng1994@gmail.com>
+Date: Tue, 16 Sep 2025 09:14:47 +0800
+Subject: gpu: xe: enable build with 16KB page size
+
+---
+ drivers/gpu/drm/xe/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/Kconfig b/drivers/gpu/drm/xe/Kconfig
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/Kconfig
++++ b/drivers/gpu/drm/xe/Kconfig
+@@ -5,7 +5,7 @@ config DRM_XE
+ 	depends on KUNIT || !KUNIT
+ 	depends on INTEL_VSEC || !INTEL_VSEC
+ 	depends on X86_PLATFORM_DEVICES || !(X86 && ACPI)
+-	depends on PAGE_SIZE_4KB || COMPILE_TEST || BROKEN
++	depends on PAGE_SIZE_4KB || PAGE_SIZE_16KB || COMPILE_TEST || BROKEN
+ 	select INTERVAL_TREE
+ 	# we need shmfs for the swappable backing store, and in particular
+ 	# the shmem_readpage() which depends upon tmpfs
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Upstream has disabled xe driver build on non-4K page size kernel since v6.16.4: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/drivers/gpu/drm/xe/Kconfig?h=v6.16.4&id=23a94fc0fcd2f09d626557a7f7fbfbd9ac0f17ab

Since we have added patches to support 16K page size, add a patch to enable xe build.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=uefi-loong64 BRANCH=edge KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes KERNEL_GIT=shallow NO_HOST_RELEASE_CHECK=yes RELEASE=sid`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
