### PR TITLE
add initial support of NanoPi M5

### DIFF
--- a/config/boards/nanopi-m5.conf
+++ b/config/boards/nanopi-m5.conf
@@ -1,0 +1,23 @@
+# Rockchip RK3576 SoC octa core 4-16GB RAM SoC 2xGbE UFS USB3 WIFI NvME
+BOARD_NAME="NanoPi M5"
+BOARDFAMILY="rk35xx"
+BOOTCONFIG="nanopi-m5-rk3576_defconfig"
+KERNEL_TARGET="vendor" # WIP: current, edge kernel
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3576-nanopi-m5.dtb"
+BOOT_SCENARIO="spl-blobs"
+SERIALCON="ttyS0"
+BOOT_SUPPORT_SPI="yes"
+BOOT_SPI_RKSPI_LOADER="yes"
+IMAGE_PARTITION_TABLE="gpt"
+BOARD_MAINTAINER="SuperKali"
+
+
+function post_family_tweaks__nanopi-m5_naming_audios() {
+	display_alert "$BOARD" "Renaming NanoPi M5 audio" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi-sound", ENV{SOUND_DESCRIPTION}="HDMI Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	return 0
+}

--- a/config/boards/nanopi-m5.conf
+++ b/config/boards/nanopi-m5.conf
@@ -19,5 +19,6 @@ function post_family_tweaks__nanopi-m5_naming_audios() {
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
 	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi-sound", ENV{SOUND_DESCRIPTION}="HDMI Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-rt5616-sound", ENV{SOUND_DESCRIPTION}="RT5616 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
 	return 0
 }

--- a/patch/u-boot/legacy/u-boot-radxa-rk35xx/add-board-nanopi-m5.patch
+++ b/patch/u-boot/legacy/u-boot-radxa-rk35xx/add-board-nanopi-m5.patch
@@ -1,0 +1,409 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Thu, 18 Sep 2025 18:39:18 +0200
+Subject: arm: dts: rk3576: Add support for NanoPi M5 board
+
+This patch adds initial support for the NanoPi M5 board based on the RK3576 SoC.
+
+Features enabled:
+- PCIe support with M.2 connector power control
+- SPI NOR flash (SFC1) support for boot
+- SD card support
+- NVMe support via PCIe
+- GPIO-based system LED control
+- ADC-based volume up key
+- Debug UART support
+
+Note: UFS support is compiled but disabled in the device tree due a compiling issue on the vendor uboot, 
+we will enabled it when we find a solution.
+
+The board supports multiple boot sources including SD card, SPI NOR flash,
+and NVMe drives via the PCIe M.2 slot, with proper boot order configuration
+in U-Boot SPL.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ arch/arm/dts/rk3576-nanopi-m5.dts  | 131 ++++++
+ configs/nanopi-m5-rk3576_defconfig | 234 ++++++++++
+ 2 files changed, 365 insertions(+)
+
+diff --git a/arch/arm/dts/rk3576-nanopi-m5.dts b/arch/arm/dts/rk3576-nanopi-m5.dts
+new file mode 100644
+index 00000000000..f4c13995442
+--- /dev/null
++++ b/arch/arm/dts/rk3576-nanopi-m5.dts
+@@ -0,0 +1,131 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * (C) Copyright 2025 FriendlyElec Computer Tech. Co., Ltd.
++ * (http://www.friendlyelec.com)
++ *
++ * Copyright (c) 2024 Rockchip Electronics Co., Ltd.
++ */
++
++
++/dts-v1/;
++#include "rk3576.dtsi"
++#include "rk3576-u-boot.dtsi"
++#include <dt-bindings/input/input.h>
++
++/ {
++	model = "NanoPi M5";
++	compatible = "nanopi,m5", "rockchip,rk3576";
++
++	chosen {
++		u-boot,spl-boot-order = &sdmmc, "same-as-spl", &fspi_nor;
++	};
++
++	vcc3v3_m2_keym: vcc3v3-m2_keym {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_m2_keym";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		enable-active-high;
++		gpios = <&gpio0 RK_PD3 GPIO_ACTIVE_HIGH>;
++		startup-delay-us = <5000>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie_m2_pwren>;
++	};
++
++	sys_led: sys-led {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "use_led";
++		enable-active-high;
++		gpio = <&gpio2 RK_PB3 GPIO_ACTIVE_HIGH>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 1>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1800000>;
++		u-boot,dm-pre-reloc;
++		status = "okay";
++
++		volumeup-key {
++			u-boot,dm-pre-reloc;
++			linux,code = <KEY_VOLUMEUP>;
++			label = "volume up";
++			press-threshold-microvolt = <1750>;
++		};
++	};
++};
++
++&combphy0_ps {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++};
++
++&pcie0 {
++	u-boot,dm-pre-reloc;
++	reset-gpios = <&gpio2 RK_PB4 GPIO_ACTIVE_HIGH>;
++	rockchip,skip-scan-in-resume;
++	vpcie3v3-supply = <&vcc3v3_m2_keym>;
++	status = "okay";
++};
++
++&pcie0_intc {
++	u-boot,dm-pre-reloc;
++};
++
++&sdmmc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_det &sdmmc0_bus4>;
++};
++
++&fspi1m1_pins {
++	rockchip,pins =
++		/* clk, d0~4 */
++		<1 RK_PD5 3 &pcfg_pull_none>,
++		<1 RK_PC4 3 &pcfg_pull_none>,
++		<1 RK_PC5 3 &pcfg_pull_none>,
++		<1 RK_PC6 3 &pcfg_pull_none>,
++		<1 RK_PC7 3 &pcfg_pull_none>;
++};
++
++&sfc0 {
++	status = "disabled";
++};
++
++&sfc1 {
++	u-boot,dm-spl;
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspi1m1_csn0 &fspi1m1_pins>;
++	#address-cells = <1>;
++	#size-cells = <0>;
++	status = "okay";
++
++	fspi_nor: flash@0 {
++		u-boot,dm-spl;
++		compatible = "jedec,spi-nor";
++		label = "sfc_nor";
++		reg = <0>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++		spi-max-frequency = <80000000>;
++	};
++};
++
++&pinctrl {
++	u-boot,dm-pre-reloc;
++	pcie {
++		u-boot,dm-pre-reloc;
++		pcie_m2_pwren: pcie-m2-pwren {
++			u-boot,dm-pre-reloc;
++			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&ufs {
++	status = "disabled";
++};
+diff --git a/configs/nanopi-m5-rk3576_defconfig b/configs/nanopi-m5-rk3576_defconfig
+new file mode 100644
+index 00000000000..11081e7b0e6
+--- /dev/null
++++ b/configs/nanopi-m5-rk3576_defconfig
+@@ -0,0 +1,234 @@
++CONFIG_ARM=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SPL_GPIO_SUPPORT=y
++CONFIG_SPL_LIBCOMMON_SUPPORT=y
++CONFIG_SPL_LIBGENERIC_SUPPORT=y
++CONFIG_SYS_MALLOC_F_LEN=0x80000
++CONFIG_SPL_FIT_GENERATOR="arch/arm/mach-rockchip/make_fit_atf.sh"
++CONFIG_ROCKCHIP_RK3576=y
++CONFIG_ROCKCHIP_FIT_IMAGE=y
++CONFIG_ROCKCHIP_VENDOR_PARTITION=y
++CONFIG_USING_KERNEL_DTB_V2=y
++CONFIG_ROCKCHIP_FIT_IMAGE_PACK=y
++CONFIG_ROCKCHIP_NEW_IDB=y
++CONFIG_SANITY_CPU_SWAP=y
++CONFIG_SPL_SERIAL_SUPPORT=y
++CONFIG_SPL_DRIVERS_MISC_SUPPORT=y
++CONFIG_TARGET_EVB_RK3576=y
++CONFIG_SPL_LIBDISK_SUPPORT=y
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI_SUPPORT=y
++CONFIG_ARMV8_CRYPTO=y
++CONFIG_DEFAULT_DEVICE_TREE="rk3576-nanopi-m5"
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_FIT_IMAGE_POST_PROCESS=y
++CONFIG_FIT_HW_CRYPTO=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_SPL_FIT_IMAGE_POST_PROCESS=y
++CONFIG_SPL_FIT_HW_CRYPTO=y
++# CONFIG_SPL_SYS_DCACHE_OFF is not set
++CONFIG_BOOTDELAY=0
++CONFIG_SYS_CONSOLE_INFO_QUIET=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_ANDROID_BOOTLOADER=y
++CONFIG_ANDROID_AVB=y
++CONFIG_ANDROID_BOOT_IMAGE_HASH=y
++CONFIG_BOARD_RNG_SEED=y
++CONFIG_SPL_BOARD_INIT=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++# CONFIG_SPL_LEGACY_IMAGE_SUPPORT is not set
++CONFIG_SPL_SEPARATE_BSS=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_USE_PARTITION=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_PARTITION=0x1
++CONFIG_SPL_MTD_SUPPORT=y
++CONFIG_SPL_UFS_SUPPORT=y
++CONFIG_SPL_ATF=y
++CONFIG_SPL_AB=y
++CONFIG_FASTBOOT_BUF_ADDR=0x40c00800
++CONFIG_FASTBOOT_BUF_SIZE=0x07000000
++CONFIG_FASTBOOT_FLASH=y
++CONFIG_FASTBOOT_FLASH_MMC_DEV=0
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_DTIMG=y
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_IMI is not set
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_XIMG is not set
++# CONFIG_CMD_LZMADEC is not set
++# CONFIG_CMD_UNZIP is not set
++# CONFIG_CMD_FLASH is not set
++# CONFIG_CMD_FPGA is not set
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++# CONFIG_CMD_LOADB is not set
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_BOOT_ANDROID=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_SF=y
++CONFIG_CMD_SPI=y
++CONFIG_CMD_UFS=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++# CONFIG_CMD_ITEST is not set
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TFTPPUT=y
++CONFIG_CMD_TFTP_BOOTM=y
++CONFIG_CMD_TFTP_FLASH=y
++# CONFIG_CMD_MISC is not set
++CONFIG_CMD_MTD_BLK=y
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_ISO_PARTITION is not set
++CONFIG_EFI_PARTITION_ENTRIES_NUMBERS=64
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_SPL_DTB_MINIMUM=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++# CONFIG_NET_TFTP_VARS is not set
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++# CONFIG_SARADC_ROCKCHIP is not set
++CONFIG_SARADC_ROCKCHIP_V2=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_CLK_SCMI=y
++CONFIG_DM_CRYPTO=y
++CONFIG_SPL_DM_CRYPTO=y
++CONFIG_ROCKCHIP_CRYPTO_V2=y
++CONFIG_SPL_ROCKCHIP_CRYPTO_V2=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_ROCKCHIP=y
++CONFIG_SCMI_FIRMWARE=y
++CONFIG_GPIO_HOG=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_ROCKCHIP_GPIO_V2=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_I2C_MUX=y
++CONFIG_DM_KEY=y
++CONFIG_RK8XX_PWRKEY=y
++CONFIG_ADC_KEY=y
++CONFIG_MISC=y
++CONFIG_SPL_MISC=y
++CONFIG_MISC_DECOMPRESS=y
++CONFIG_SPL_MISC_DECOMPRESS=y
++CONFIG_ROCKCHIP_OTP=y
++CONFIG_ROCKCHIP_HW_DECOMPRESS=y
++CONFIG_SPL_ROCKCHIP_HW_DECOMPRESS=y
++CONFIG_SPL_ROCKCHIP_SECURE_OTP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_SDMA=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_MTD=y
++CONFIG_MTD_BLK=y
++CONFIG_MTD_DEVICE=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_SPI_FLASH=y
++CONFIG_SF_DEFAULT_MODE=0x1
++CONFIG_SF_DEFAULT_SPEED=50000000
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_MTD=y
++CONFIG_DM_ETH=y
++CONFIG_DM_ETH_PHY=y
++CONFIG_DWC_ETH_QOS=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_NVME=y
++CONFIG_PCI=y
++CONFIG_DM_PCI=y
++CONFIG_DM_PCI_COMPAT=y
++CONFIG_PCIE_DW_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_NANENG_COMBOPHY=y
++CONFIG_PHY_ROCKCHIP_SAMSUNG_HDPTX=y
++CONFIG_PHY_ROCKCHIP_SNPS_PCIE3=y
++CONFIG_PHY_ROCKCHIP_USBDP=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_FUEL_GAUGE=y
++CONFIG_POWER_FG_CW201X=y
++CONFIG_POWER_FG_CW221X=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_DM_POWER_DELIVERY=y
++CONFIG_TYPEC_TCPM=y
++CONFIG_TYPEC_TCPCI=y
++CONFIG_TYPEC_HUSB311=y
++CONFIG_TYPEC_FUSB302=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_CHARGER_BQ25700=y
++CONFIG_CHARGER_BQ25890=y
++CONFIG_CHARGER_SGM41542=y
++CONFIG_DM_CHARGE_DISPLAY=y
++CONFIG_CHARGE_ANIMATION=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_DM_RESET=y
++CONFIG_SPL_DM_RESET=y
++CONFIG_SPL_RESET_ROCKCHIP=y
++CONFIG_SCSI=y
++CONFIG_DM_SCSI=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_BASE=0x2ad40000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_ROCKCHIP_SFC=y
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_XHCI_PCI=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GADGET=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_USB_STORAGE=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_MANUFACTURER="Rockchip"
++CONFIG_USB_GADGET_VENDOR_NUM=0x2207
++CONFIG_USB_GADGET_PRODUCT_NUM=0x350e
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_UFS=y
++CONFIG_ROCKCHIP_UFS=y
++CONFIG_DM_VIDEO=y
++CONFIG_DISPLAY=y
++CONFIG_DRM_ROCKCHIP=y
++CONFIG_DRM_ROCKCHIP_DW_HDMI_QP=y
++CONFIG_DRM_ROCKCHIP_DW_MIPI_DSI2=y
++CONFIG_DRM_ROCKCHIP_DW_DP=y
++CONFIG_DRM_ROCKCHIP_ANALOGIX_DP=y
++CONFIG_DRM_ROCKCHIP_RGB=y
++CONFIG_DRM_ROCKCHIP_SAMSUNG_MIPI_DCPHY=y
++CONFIG_PHY_ROCKCHIP_SAMSUNG_HDPTX_HDMI=y
++CONFIG_USE_TINY_PRINTF=y
++CONFIG_LIB_RAND=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_RSA=y
++CONFIG_SPL_RSA=y
++CONFIG_RSA_N_SIZE=0x200
++CONFIG_RSA_E_SIZE=0x10
++CONFIG_RSA_C_SIZE=0x20
++CONFIG_XBC=y
++CONFIG_LZ4=y
++CONFIG_SPL_GZIP=y
++CONFIG_ERRNO_STR=y
++# CONFIG_EFI_LOADER is not set
++CONFIG_AVB_LIBAVB=y
++CONFIG_AVB_LIBAVB_AB=y
++CONFIG_AVB_LIBAVB_ATX=y
++CONFIG_AVB_LIBAVB_USER=y
++CONFIG_RK_AVB_LIBAVB_USER=y
++CONFIG_ID_EEPROM=y
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

This PR adds initial support for the NanoPi M5 board based on the Rockchip RK3576 SoC. The implementation includes U-Boot device tree support and Armbian board configuration for a complete working system.

## Summary of changes:
- **U-Boot Device Tree**: Added `rk3576-nanopi-m5.dts` with hardware initialization for all major components
- **U-Boot Config**: Added `nanopi-m5-rk3576_defconfig` with optimized build configuration 
- **Board Configuration**: Added Armbian board file for NanoPi M5 with RK35xx family integration

## Hardware features enabled:
- PCIe support with M.2 connector power control via GPIO
- SPI NOR flash (SFC1) support for bootloader storage
- SD card support for primary boot and storage
- NVMe support via PCIe M.2 slot
- GPIO-based system LED control
- Debug UART support (ttyS0 at 1.5M baud)
- Multiple boot sources (SD card, SPI NOR flash, NVMe drives)

**Note**: UFS support is compiled but disabled in device tree due to vendor U-Boot compilation issues. Will be enabled when resolved. look here #8647 

# How Has This Been Tested?

The implementation has been tested with the following configurations:

- [x] **SD Card Boot Test**: Successfully boots from SD card with full desktop environment
- [x] **SPI Flash Boot Test**: U-Boot loads from SPI NOR flash, boots kernel from SD/NVMe
- [x] **NVMe Boot Test**: Complete boot chain from NVMe drive via PCIe M.2 slot


**Test Configuration**:
- Board: NanoPi M5 with 16GB RAM
- Storage: 32GB SD card, 256GB NVMe SSD, 16MB SPI NOR flash
- OS: Armbian Trixie with vendor kernel
- Network: Both Ethernet ports tested, WiFi module verified

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
