### PR TITLE
sakurapi-rk3308b: add high speed conf for emmc and ufs for tf slot

### DIFF
--- a/patch/kernel/archive/rockchip64-6.16/dt/rk3308-sakurapi-rk3308b.dts
+++ b/patch/kernel/archive/rockchip64-6.16/dt/rk3308-sakurapi-rk3308b.dts
@@ -145,6 +145,7 @@
 &emmc {
 	bus-width = <8>;
 	cap-mmc-highspeed;
+	mmc-hs200-1_8v;
 	non-removable;
 	status = "okay";
 };
@@ -156,7 +157,11 @@
 &sdmmc {
 	cap-mmc-highspeed;
 	cap-sd-highspeed;
+	sd-uhs-sdr25;
+	sd-uhs-sdr50;
+	sd-uhs-sdr104;
 	disable-wp;
+	broken-cd;
 	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_det &sdmmc_bus4>;
 	card-detect-delay = <800>;
 	status = "okay";


### PR DESCRIPTION
# Description

Add HS200 and UHS flags to Sakura Pi

# How Has This Been Tested?
#### Before:
<img width="1255" height="775" alt="image" src="https://github.com/user-attachments/assets/834d2237-57f8-40a2-a923-5f4ccee9f23b" />
#### After:
<img width="1364" height="725" alt="image" src="https://github.com/user-attachments/assets/bdac9497-a3f2-42e0-83ed-af0f0112248f" />
<img width="356" height="114" alt="afd3f3e2992511c3580f62ecfb2319e0" src="https://github.com/user-attachments/assets/63aae63e-2dc4-4782-9573-6bdc9329f486" />

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

/cc @TheSnowfield 