### PR TITLE
Armbian-install script fixes

### DIFF
--- a/packages/bsp/common/usr/bin/armbian-install
+++ b/packages/bsp/common/usr/bin/armbian-install
@@ -669,6 +669,17 @@ format_disk()
 	[[ $? -ne 0 ]] && exit 10
 	FilesystemChoosen=${FilesystemOptions[(2*$FilesystemChoices)-1]}
 
+	if [[ $FilesystemChoosen == *btrfs* ]] && ! command -v btrfs; then
+		dialog --yes-label "Install" --no-label 'Deny' --title "$title" --backtitle "$backtitle" --yesno "\nThe btrfs-progs package is not installed.\n\nIt is required to format the root partition as btrfs. Install it now?" 10 75
+		if [[ $? -eq 0 ]]; then
+			apt update && apt install --yes btrfs-progs
+		else
+			dialog --title "$title" --backtitle "$backtitle" --colors --infobox\
+			"\nCannot proceed without btrfs-progs" 5 60
+			exit 10
+		fi
+	fi
+
 	dialog --title "$title" --backtitle "$backtitle" --infobox "\nFormating $1 to $FilesystemChoosen ... please wait." 5 60
 	mkfs.${FilesystemChoosen} ${mkopts[$FilesystemChoosen]} "$1" >> $logfile 2>&1
 }

--- a/packages/bsp/common/usr/bin/armbian-install
+++ b/packages/bsp/common/usr/bin/armbian-install
@@ -465,6 +465,7 @@ create_armbian()
 	if [[ $1 == *mtd* ]]; then
 		if [[ -f "${TempDir}"/rootfs/boot/armbianEnv.txt ]]; then
 			sed -e 's,rootdev=.*,rootdev='"$satauuid"',g' -i "${TempDir}"/rootfs/boot/armbianEnv.txt
+			sed -e 's,rootfstype=.*,rootfstype='$FilesystemChoosen',g' -i "${TempDir}"/rootfs/boot/armbianEnv.txt
 		fi
 		if [[ -f "${TempDir}"/rootfs/boot/extlinux/extlinux.conf ]]; then
 			sed -e 's,root='"$root_uuid"',root='"$satauuid"',g' -i "${TempDir}"/rootfs/boot/extlinux/extlinux.conf


### PR DESCRIPTION
# Description

1. Set `rootfstype` in `armbianEnv.txt` in the boot from mtd, system on sata/nvme scenario
2. Add check for `btrfs` command when the btrfs filesystem is selected, and prompt the user whether to install it or not.

The first fix is an attempt to fix AR-2556 (https://github.com/armbian/config/issues/233) but the original issue doesn't provide a way to reproduce, so i cannot verify if this does actually solve the issue. There's no mention of what boot method is used and where the root partition is installed to. If the `rootfstype` in `/boot/armbianEnv.txt` has no effect in the "boot from MTD" scenario, it could be excluded from this PR.

The `btrfs` check was introduced to make it more obvious what the issue is when the user select btrfs root and `btrfs-progs` package is not installed, as the script would only fail on "Partition too small" with `Available: <empty string> MB` as the message.

For the `btrfs` check, I have several points I'd like to get opinions on:
1. Is a dialog needed n the first place? Or should the script just install `btrfs-progs` if the user selected a btrfs filesystem?
2. Should the dialog stop the install process if the user denied installation?
3. Should the apt output be supressed? Or maybe just redirected to the log file?

# How Has This Been Tested?

On Radxa Rock 5B+ with a sata ssd
- [x] `armbian-install` with boot from MTD, selecting `btrfs` filesystem type and checking `/boot/armbianEnv.txt` in the resulting partition for `rootfstype=btrfs`
- [x] `armbian-install`, selecting `btrfs` filesystem type for the root partition with and without `btrfs-progs` installed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
