### PR TITLE
fix(build): eliminate the error message when no extensions found in a folder in building

### DIFF
--- a/lib/functions/general/extensions.sh
+++ b/lib/functions/general/extensions.sh
@@ -577,10 +577,14 @@ function enable_extensions_with_hostdeps_builtin_and_user() {
 
 	# Extensions are files of the format <dir>/extension_name.sh or <dir>/extension_name/extension_name.sh
 	for ext_dir in "${ext_dirs[@]}"; do
+		display_alert "Extension search" "Searching in directory: \"${ext_dir}\"" ""
 		if [[ -d "${ext_dir}" ]]; then
 			declare -a ext_list_dir=()
-			mapfile -t ext_list_dir < <(find "${ext_dir}" -maxdepth 2 -type f -name "*.sh" -print0 | xargs -0 grep -l "${grep_args[@]}")
+			mapfile -t ext_list_dir < <(find "${ext_dir}" -maxdepth 2 -type f -name "*.sh" -print0 | xargs -0 -r grep -l "${grep_args[@]}" 2>/dev/null || true)
+			display_alert "Extension search result" "Found ${#ext_list_dir[@]} extensions in \"${ext_dir}\"" ""
 			extension_list+=("${ext_list_dir[@]}")
+		else
+			display_alert "Extension search" "Directory does not exist: \"${ext_dir}\"" "wrn"
 		fi
 	done
 


### PR DESCRIPTION
# Description

In the building when there is not any extensions with given pattern exist, 'enable_extensions_with_hostdeps_builtin_and_user()' will throw errors such as: 'Error 123 occurred in SUBSHELL SUBSHELL at /<some-path>/lib/functions/general/extensions.sh:582'. Though this may not fail the building, but it will make the user confused.

# Documentation summary for feature / change

The changes will eliminate the error message and add prints to show the current searched folder and extensions count found in the folder.

# How Has This Been Tested?

- [ ] build and no more errors in 'Annotation' section

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings