### PR TITLE
RFC: Add support for Podman as container engine alternative to Docker

### DIFF
--- a/lib/functions/cli/cli-docker.sh
+++ b/lib/functions/cli/cli-docker.sh
@@ -76,6 +76,8 @@ function cli_docker_run() {
 	fi
 
 	# Produce the re-launch params.
+	# When relaunching inside docker, run 'build' command, not 'docker' again
+	declare -g ARMBIAN_CLI_RELAUNCH_COMMAND="build"
 	declare -g ARMBIAN_CLI_FINAL_RELAUNCH_ARGS=()
 	declare -g ARMBIAN_CLI_FINAL_RELAUNCH_ENVS=()
 	produce_relaunch_parameters # produces ARMBIAN_CLI_FINAL_RELAUNCH_ARGS and ARMBIAN_CLI_FINAL_RELAUNCH_ENVS


### PR DESCRIPTION
# Description

There were multiple requests for podman support:
* https://github.com/armbian/build/issues/7940
* https://github.com/armbian/build/issues/4328

Since rootless podman support is probably intractable at this point I am suggesting the basic support in rootful mode.

This RFC implements Podman support for Armbian builds to address mounting issues experienced with Podman while maintaining Docker compatibility.

Key changes:
- Auto-detect container engine: prefers Docker, falls back to Podman
- Use sudo with Podman (runs in root mode - not more secure than Docker)
- Add required mount options (suid,dev) and --network host for Podman
- Update all docker commands to use dynamic DOCKER_COMMAND variable

Technical notes:
- Podman runs with sudo/root privileges, so security model matches Docker
- Requires sudo access when using Podman (security consideration)
- Solves Podman-specific mount permission and networking issues
- Maintains full backward compatibility with existing Docker workflows
- May need documentation updates

# Documentation summary for feature / change

I believe that if this gets merged we could mention podman support as a note to the docker requirements.

# How Has This Been Tested?

- [x] I tested multiple board image builds: bananapif3, rpi4b, orangepi5 - all OK

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Podman as an alternative container runtime, with automatic detection and configuration while retaining Docker as the default.
  * Container-based builds and related operations now work with either Docker or Podman, including appropriate networking and mount settings.
  * Relaunching a container-based operation now correctly resumes the build workflow instead of repeating the container setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->