### PR TITLE
armbian build machinery - force all iptables/nftables to be built

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -191,6 +191,213 @@ function armbian_kernel_config__enable_zram_support() {
 	fi
 }
 
+# Enables almost all IPTABLES/NFTABLES options as modules [whilst 
+# allowing them to be built-in]. no particular modules are intentionally 
+# excluded, but this author doesn't want to claim it's 100.00% 
+# comprehensive, in case more are added or some oversight is found. 
+# split in part from armbian_kernel_config__enable_docker_support.
+#
+function armbian_kernel_config__select_nftables() {
+	if [[ -f .config ]]; then
+		kernel_config_set_m BRIDGE_NETFILTER                # Enables netfilter support for the bridge
+		kernel_config_set_m IP6_NF_FILTER                   # Enables IPv6 netfilter filtering support
+		kernel_config_set_m IP6_NF_IPTABLES                 # IP6 tables support (required for filtering)
+		kernel_config_set_m IP6_NF_MANGLE                   # Enables IPv6 netfilter mangling support
+		kernel_config_set_m IP6_NF_MATCH_AH                 # "ah" match support
+		kernel_config_set_m IP6_NF_MATCH_EUI64              # "eui64" address check
+		kernel_config_set_m IP6_NF_MATCH_FRAG               # "frag" Fragmentation header match support
+		kernel_config_set_m IP6_NF_MATCH_HL                 # "hl" hoplimit match support
+		kernel_config_set_m IP6_NF_MATCH_IPV6HEADER         # "ipv6header" IPv6 Extension Headers Match
+		kernel_config_set_m IP6_NF_MATCH_MH                 # "mh" match support
+		kernel_config_set_m IP6_NF_MATCH_OPTS               # "hbh" hop-by-hop and "dst" opts header match support
+		kernel_config_set_m IP6_NF_MATCH_RPFILTER           # "rpfilter" reverse path filter match support
+		kernel_config_set_m IP6_NF_MATCH_RT                 # "rt" Routing header match support
+		kernel_config_set_m IP6_NF_MATCH_SRH                # "srh" Segment Routing header match support
+		kernel_config_set_m IP6_NF_NAT                      # Enables IPv6 network address translation support
+		kernel_config_set_m IP6_NF_RAW                      # Enables raw support for IPv6 netfilter
+		kernel_config_set_m IP6_NF_SECURITY                 # Enables IPv6 netfilter security features
+		kernel_config_set_m IP6_NF_TARGET_HL                # "HL" hoplimit target support
+		kernel_config_set_m IP6_NF_TARGET_MASQUERADE        # Enables IPv6 netfilter target for masquerading (NAT)
+		kernel_config_set_m IP6_NF_TARGET_NPT               # NPT (Network Prefix translation) target support
+		kernel_config_set_m IP6_NF_TARGET_REJECT            # REJECT target support
+		kernel_config_set_m IP6_NF_TARGET_SYNPROXY          # SYNPROXY target support
+		kernel_config_set_m IP_NF_IPTABLES                  # Enables iptables for IPv4
+		kernel_config_set_m IP_NF_FILTER                    # filter table
+		kernel_config_set_m IP_NF_MANGLE                    # mangle table
+		kernel_config_set_m IP_NF_TARGET_MASQUERADE         # Enables IPv4 netfilter target for masquerading (NAT)
+		kernel_config_set_m IP_NF_TARGET_NETMAP             # Enables IPv4 netfilter target for netmap
+		kernel_config_set_m IP_NF_TARGET_REDIRECT           # Enables IPv4 netfilter target for redirect
+		kernel_config_set_m IP_NF_NAT                       # Enables NAT (Network Address Translation) support for IPv4
+		kernel_config_set_m IP_NF_RAW                       # Enables raw support for IPv4 netfilter
+		kernel_config_set_m IP_NF_SECURITY                  # Enables security features for IPv4 netfilter
+		kernel_config_set_m NET_ACT_IPT
+		kernel_config_set_m NET_EMATCH_IPT                  # IPtables Matches
+		kernel_config_set_y NETFILTER_BPF_LINK              # BPF link support for netfilter hooks
+		kernel_config_set_m NETFILTER_CONNCOUNT
+		kernel_config_set_y NETFILTER_EGRESS                # Netfilter egress support
+		kernel_config_set_y NETFILTER_FAMILY_ARP
+		kernel_config_set_y NETFILTER_FAMILY_BRIDGE
+		kernel_config_set_y NETFILTER_INGRESS               # Netfilter ingress support
+		kernel_config_set_m NETFILTER_NETLINK_ACCT          # Netfilter NFACCT over NFNETLINK interface
+		kernel_config_set_y NETFILTER_NETLINK_GLUE_CT
+		kernel_config_set_m NETFILTER_NETLINK_HOOK          # Netfilter base hook dump support
+		kernel_config_set_m NETFILTER_NETLINK_LOG           # Netfilter LOG over NFNETLINK interface
+		kernel_config_set_m NETFILTER_NETLINK
+		kernel_config_set_m NETFILTER_NETLINK_OSF           # Netfilter OSF over NFNETLINK interface
+		kernel_config_set_m NETFILTER_NETLINK_QUEUE         # Netfilter NFQUEUE over NFNETLINK interface
+		kernel_config_set_m NETFILTER_SYNPROXY
+		kernel_config_set_y NETFILTER_XTABLES_COMPAT        # Netfilter Xtables 32bit support
+		kernel_config_set_m NETFILTER_XTABLES               # Enables x_tables support in netfilter
+		kernel_config_set_m NETFILTER_XT_CONNMARK           # ctmark target and match support
+		kernel_config_set_m NETFILTER_XT_MARK               # Enables mark matching for netfilter
+		kernel_config_set_m NETFILTER_XT_MATCH_ADDRTYPE     # Enables address type matching for netfilter
+		kernel_config_set_m NETFILTER_XT_MATCH_BPF          # Enables BPF match support in netfilter
+		kernel_config_set_m NETFILTER_XT_MATCH_CGROUP       # "control group" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_CLUSTER      # "cluster" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_COMMENT      # "comment" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_CONNBYTES    # "connbytes" per-connection counter match support
+		kernel_config_set_m NETFILTER_XT_MATCH_CONNLABEL    # "connlabel" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_CONNLIMIT    # "connlimit" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_CONNMARK     # "connmark" connection mark match support
+		kernel_config_set_m NETFILTER_XT_MATCH_CONNTRACK    # Enables connection tracking match support in netfilter
+		kernel_config_set_m NETFILTER_XT_MATCH_CPU          # "cpu" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_DCCP         # "dccp" protocol match support
+		kernel_config_set_m NETFILTER_XT_MATCH_DEVGROUP     # "devgroup" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_DSCP         # "dscp" and "tos" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_ECN          # "ecn" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_ESP          # "esp" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_HASHLIMIT    # "hashlimit" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_HELPER       # "helper" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_HL           # "hl" hoplimit/TTL match support
+		kernel_config_set_m NETFILTER_XT_MATCH_IPCOMP       # "ipcomp" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_IPRANGE      # "iprange" address range match support
+		kernel_config_set_m NETFILTER_XT_MATCH_IPVS         # Enables IPVS match support in netfilter
+		kernel_config_set_m NETFILTER_XT_MATCH_L2TP         # "l2tp" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_LENGTH       # "length" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_LIMIT        # "limit" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_MAC          # "mac" address match support
+		kernel_config_set_m NETFILTER_XT_MATCH_MARK         # "mark" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_MULTIPORT    # "multiport" Multiple port match support
+		kernel_config_set_m NETFILTER_XT_MATCH_NFACCT       # "nfacct" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_OSF          # "osf" Passive OS fingerprint match
+		kernel_config_set_m NETFILTER_XT_MATCH_OWNER        # "owner" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_PHYSDEV      # "physdev" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_PKTTYPE      # "pkttype" packet type match support
+		kernel_config_set_m NETFILTER_XT_MATCH_POLICY       # IPsec "policy" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_QUOTA        # "quota" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_RATEEST      # "rateest" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_REALM        # "realm" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_RECENT       # "recent" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_SCTP         # "sctp" protocol match support
+		kernel_config_set_m NETFILTER_XT_MATCH_SOCKET       # "socket" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_STATE        # "state" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_STATISTIC    # "statistic" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_STRING       # "string" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_TCPMSS       # "tcpmss" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_TIME         # "time" match support
+		kernel_config_set_m NETFILTER_XT_MATCH_U32          # "u32" match support
+		kernel_config_set_m NETFILTER_XT_NAT                # "SNAT and DNAT" targets support
+		kernel_config_set_m NETFILTER_XT_SET                # set target and match support
+		kernel_config_set_m NETFILTER_XT_TARGET_AUDIT       # AUDIT target support
+		kernel_config_set_m NETFILTER_XT_TARGET_CHECKSUM    # CHECKSUM target support
+		kernel_config_set_m NETFILTER_XT_TARGET_CLASSIFY    # "CLASSIFY" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_CONNMARK    # "CONNMARK" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_CONNSECMARK # "CONNSECMARK" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_CT          # "CT" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_DSCP        # "DSCP" and "TOS" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_FLOWOFFLOAD
+		kernel_config_set_m NETFILTER_XT_TARGET_HL          # "HL" hoplimit target support
+		kernel_config_set_m NETFILTER_XT_TARGET_HMARK       # "HMARK" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_IDLETIMER   # IDLETIMER target support
+		kernel_config_set_m NETFILTER_XT_TARGET_LED         # "LED" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_LOG         # LOG target support
+		kernel_config_set_m NETFILTER_XT_TARGET_MARK        # "MARK" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_MASQUERADE  # Enables masquerade target for netfilter
+		kernel_config_set_m NETFILTER_XT_TARGET_NETMAP      # "NETMAP" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_NFLOG       # "NFLOG" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_NFQUEUE     # "NFQUEUE" target Support
+		kernel_config_set_m NETFILTER_XT_TARGET_NOTRACK     # "NOTRACK" target support (DEPRECATED)
+		kernel_config_set_m NETFILTER_XT_TARGET_RATEEST     # "RATEEST" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_REDIRECT    # REDIRECT target support
+		kernel_config_set_m NETFILTER_XT_TARGET_SECMARK     # "SECMARK" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_TCPMSS      # "TCPMSS" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_TCPOPTSTRIP # "TCPOPTSTRIP" target support
+		kernel_config_set_m NETFILTER_XT_TARGET_TEE         # "TEE" - packet cloning to alternate destination
+		kernel_config_set_m NETFILTER_XT_TARGET_TPROXY      # "TPROXY" target transparent proxying support
+		kernel_config_set_m NETFILTER_XT_TARGET_TRACE       # "TRACE" target support
+		kernel_config_set_y NETFILTER                       # Enables support for netfilter framework
+		kernel_config_set_y NETFILTER_ADVANCED              # Enables advanced netfilter options
+		kernel_config_set_m NET_IP_TUNNEL
+		kernel_config_set_y NF_TABLES_ARP                   # ARP nf_tables support
+		kernel_config_set_m NF_TABLES_BRIDGE
+		kernel_config_set_y NF_TABLES_INET                  # Enables IPv4 and IPv6 support for nf_tables
+		kernel_config_set_y NF_TABLES_IPV4
+		kernel_config_set_y NF_TABLES_IPV6
+		kernel_config_set_m NF_TABLES                       # Enables nf_tables framework support
+		kernel_config_set_y NF_TABLES_NETDEV                # Enables netdevice support for nf_tables
+		kernel_config_set_m NF_CONNTRACK                    # Enables connection tracking support
+		kernel_config_set_m NF_CONNTRACK_FTP                # Enables FTP connection tracking support
+		kernel_config_set_m NF_CONNTRACK_IRC                # Enables IRC connection tracking support
+		kernel_config_set_y NF_CONNTRACK_MARK               # Enables connection mark support in netfilter
+		kernel_config_set_m NF_CONNTRACK_PPTP               # Enables PPTP connection tracking support
+		kernel_config_set_m NF_CONNTRACK_TFTP               # Enables TFTP connection tracking support
+		kernel_config_set_y NF_CONNTRACK_ZONES              # Enables connection tracking zones support
+		kernel_config_set_y NF_CONNTRACK_EVENTS             # Enables connection tracking events support
+		kernel_config_set_y NF_CONNTRACK_LABELS             # Enables connection tracking labels support
+		kernel_config_set_m NF_NAT                          # Enables NAT support in nf_conntrack
+		kernel_config_set_m NF_NAT_MASQUERADE_IPV4          # Enables IPv4 masquerading for NAT in nf_conntrack
+		kernel_config_set_m NF_NAT_IPV4                     # Enables IPv4 NAT support in nf_conntrack
+		kernel_config_set_m NF_NAT_FTP                      # Enables FTP NAT support in nf_conntrack
+		kernel_config_set_m NF_NAT_TFTP                     # Enables TFTP NAT support in nf_conntrack
+		kernel_config_set_m NFT_BRIDGE_META                 # Netfilter nf_table bridge meta support
+		kernel_config_set_m NFT_BRIDGE_REJECT               # Netfilter nf_tables bridge reject support
+		kernel_config_set_m NFT_COMPAT_ARP
+		kernel_config_set_m NFT_COMPAT                      # Enables compatibility support for older nftables versions
+		kernel_config_set_m NFT_CONNLIMIT                   # Netfilter nf_tables connlimit module
+		kernel_config_set_m NFT_COUNTER
+		kernel_config_set_m NFT_CT                          # Netfilter nf_tables conntrack module
+		kernel_config_set_m NFT_DUP_IPV4                    # IPv4 nf_tables packet duplication support
+		kernel_config_set_m NFT_DUP_IPV6                    # IPv6 nf_tables packet duplication support
+		kernel_config_set_m NFT_DUP_NETDEV                  # Enables duplicate netdev (network device) support in nftables
+		kernel_config_set_m NFT_FIB_INET
+		kernel_config_set_m NFT_FIB_IPV4                    # nf_tables fib / ip route lookup support
+		kernel_config_set_m NFT_FIB_IPV6                    # nf_tables fib / ipv6 route lookup support
+		kernel_config_set_m NFT_FIB
+		kernel_config_set_m NFT_FIB_NETDEV                  # Netfilter nf_tables netdev fib lookups support
+		kernel_config_set_m NFT_FLOW_OFFLOAD                # Netfilter nf_tables hardware flow offload module
+		kernel_config_set_m NFT_FWD_NETDEV                  # Enables forward netdev support in nftables
+		kernel_config_set_m NFT_HASH                        # Enables hash-based set operations support in nftables
+		kernel_config_set_m NFT_LIMIT                       # Netfilter nf_tables limit module
+		kernel_config_set_m NFT_LOG                         # Netfilter nf_tables log module
+		kernel_config_set_m NFT_MASQ
+		kernel_config_set_m NFT_NAT                         # Enables NAT (Network Address Translation) support in nftables
+		kernel_config_set_m NFT_NUMGEN                      # Netfilter nf_tables number generator module
+		kernel_config_set_m NFT_OBJREF
+		kernel_config_set_m NFT_OSF
+		kernel_config_set_m NFT_QUEUE                       # Netfilter nf_tables queue module
+		kernel_config_set_m NFT_QUOTA                       # Enables quota support in nftables
+		kernel_config_set_m NFT_REDIR
+		kernel_config_set_m NFT_REJECT_INET
+		kernel_config_set_m NFT_REJECT_IPV4
+		kernel_config_set_m NFT_REJECT_IPV6
+		kernel_config_set_m NFT_REJECT                      # Enables reject target support in nftables
+		kernel_config_set_m NFT_REJECT_NETDEV               # Enables reject netdev support in nftables
+		kernel_config_set_m NFT_SOCKET                      # Enables socket operations support in nftables
+		kernel_config_set_m NFT_SYNPROXY                    # Enables SYN proxy support in nftables
+		kernel_config_set_m NFT_TPROXY                      # Enables transparent proxy support in nftables
+		kernel_config_set_m NFT_TUNNEL                      # Enables tunneling support in nftables
+		kernel_config_set_m NFT_XFRM                        # Enables transformation support in nftables
+		kernel_config_set_m IP_SET                          # IP Set core
+		kernel_config_set_m IP_SET_HASH_IP
+		kernel_config_set_m IP_SET_HASH_NET
+		kernel_config_set_m IP_SET_HASH_IPPORT
+		kernel_config_set_m IP_SET_HASH_NETPORT
+		kernel_config_set_m IP_SET_HASH_IPPORTNET
+		kernel_config_set_m IP_SET_BITMAP_IP
+		kernel_config_set_m IP_SET_BITMAP_PORT
+	fi
+}
+
 # Enables Docker support by configuring a comprehensive set of kernel options required for Docker functionality.
 #
 # Globals:
@@ -210,7 +417,6 @@ function armbian_kernel_config__enable_docker_support() {
 		kernel_config_set_y BLK_CGROUP                      # Enables block layer control groups (cgroups)
 		kernel_config_set_y BLK_DEV_THROTTLING              # Enables block device IO throttling
 		kernel_config_set_y BRIDGE_VLAN_FILTERING           # Enables VLAN filtering on network bridges
-		kernel_config_set_m BRIDGE_NETFILTER                # Enables netfilter support for the bridge
 		kernel_config_set_y BRIDGE                          # Enables support for Ethernet bridges
 		kernel_config_set_y CFQ_GROUP_IOSCHED               # Enables CFQ (Completely Fair Queueing) I/O scheduler for cgroups
 		kernel_config_set_y CGROUP_BPF                      # Enables BPF-based control groups
@@ -232,9 +438,6 @@ function armbian_kernel_config__enable_docker_support() {
 		kernel_config_set_m CRYPTO_SEQIV                    # Enables sequential initialization vector support for cryptographic operations
 		kernel_config_set_y EVENTFD                         # Enables eventfd system calls for event notification
 		kernel_config_set_y BPF_SYSCALL                     # Enables BPF (Berkeley Packet Filter) system call support
-		kernel_config_set_y NF_TABLES                       # Enables nf_tables framework support
-		kernel_config_set_y NF_TABLES_INET                  # Enables IPv4 and IPv6 support for nf_tables
-		kernel_config_set_y NF_TABLES_NETDEV                # Enables netdevice support for nf_tables
 		kernel_config_set_y CFS_BANDWIDTH                   # Enables bandwidth control for CFS (Completely Fair Scheduler)
 		kernel_config_set_m DUMMY                           # Enables dummy network driver module
 		kernel_config_set_y DEVPTS_MULTIPLE_INSTANCES       # Enables multiple instances of devpts (pseudo-terminal master/slave pairs)
@@ -242,24 +445,10 @@ function armbian_kernel_config__enable_docker_support() {
 		kernel_config_set_m EXT4_FS                         # Enables EXT4 file system support as a module
 		kernel_config_set_y EXT4_FS_POSIX_ACL               # Enables POSIX ACL support for EXT4
 		kernel_config_set_y EXT4_FS_SECURITY                # Enables security extensions for EXT4 file system
-		kernel_config_set_m IP6_NF_FILTER                   # Enables IPv6 netfilter filtering support
-		kernel_config_set_m IP6_NF_MANGLE                   # Enables IPv6 netfilter mangling support
-		kernel_config_set_m IP6_NF_NAT                      # Enables IPv6 network address translation support
-		kernel_config_set_m IP6_NF_RAW                      # Enables raw support for IPv6 netfilter
-		kernel_config_set_m IP6_NF_SECURITY                 # Enables IPv6 netfilter security features
-		kernel_config_set_m IP6_NF_TARGET_MASQUERADE        # Enables IPv6 netfilter target for masquerading (NAT)
 		kernel_config_set_m IPVLAN                          # Enables IPvlan network driver support
 		kernel_config_set_y INET                            # Enables Internet protocol (IPv4) support
 		kernel_config_set_y FAIR_GROUP_SCHED                # Enables fair group scheduling support
 		kernel_config_set_m INET_ESP                        # Enables ESP (Encapsulating Security Payload) for IPv4
-		kernel_config_set_y IP_NF_FILTER                    # Enables IPv4 netfilter filtering support
-		kernel_config_set_m IP_NF_TARGET_MASQUERADE         # Enables IPv4 netfilter target for masquerading (NAT)
-		kernel_config_set_m IP_NF_TARGET_NETMAP             # Enables IPv4 netfilter target for netmap
-		kernel_config_set_m IP_NF_TARGET_REDIRECT           # Enables IPv4 netfilter target for redirect
-		kernel_config_set_y IP_NF_IPTABLES                  # Enables iptables for IPv4
-		kernel_config_set_m IP_NF_NAT                       # Enables NAT (Network Address Translation) support for IPv4
-		kernel_config_set_m IP_NF_RAW                       # Enables raw support for IPv4 netfilter
-		kernel_config_set_y IP_NF_SECURITY                  # Enables security features for IPv4 netfilter
 		kernel_config_set_y IP_VS_NFCT                      # Enables connection tracking for IPVS (IP Virtual Server)
 		kernel_config_set_y IP_VS_PROTO_TCP                 # Enables TCP protocol support for IPVS
 		kernel_config_set_y IP_VS_PROTO_UDP                 # Enables UDP protocol support for IPVS
@@ -270,49 +459,11 @@ function armbian_kernel_config__enable_docker_support() {
 		kernel_config_set_m MACVLAN                         # Enables MACVLAN network driver support
 		kernel_config_set_y MEMCG                           # Enables memory controller for cgroups
 		kernel_config_set_y MEMCG_KMEM                      # Enables memory controller for kmem (kernel memory) cgroups
-		kernel_config_set_m NFT_NAT                         # Enables NAT (Network Address Translation) support in nftables
-		kernel_config_set_m NFT_TUNNEL                      # Enables tunneling support in nftables
-		kernel_config_set_m NFT_QUOTA                       # Enables quota support in nftables
-		kernel_config_set_m NFT_REJECT                      # Enables reject target support in nftables
-		kernel_config_set_m NFT_COMPAT                      # Enables compatibility support for older nftables versions
-		kernel_config_set_m NFT_HASH                        # Enables hash-based set operations support in nftables
-		kernel_config_set_m NFT_XFRM                        # Enables transformation support in nftables
-		kernel_config_set_m NFT_SOCKET                      # Enables socket operations support in nftables
-		kernel_config_set_m NFT_TPROXY                      # Enables transparent proxy support in nftables
-		kernel_config_set_m NFT_SYNPROXY                    # Enables SYN proxy support in nftables
-		kernel_config_set_m NFT_DUP_NETDEV                  # Enables duplicate netdev (network device) support in nftables
-		kernel_config_set_m NFT_FWD_NETDEV                  # Enables forward netdev support in nftables
-		kernel_config_set_m NFT_REJECT_NETDEV               # Enables reject netdev support in nftables
-		kernel_config_set_m NF_CONNMARK_IPV4                # Enables connection mark support for IPv4 netfilter
-		kernel_config_set_y NF_CONNTRACK                    # Enables connection tracking support
-		kernel_config_set_m NF_CONNTRACK_FTP                # Enables FTP connection tracking support
-		kernel_config_set_m NF_CONNTRACK_IRC                # Enables IRC connection tracking support
-		kernel_config_set_y NF_CONNTRACK_MARK               # Enables connection mark support in netfilter
-		kernel_config_set_m NF_CONNTRACK_PPTP               # Enables PPTP connection tracking support
-		kernel_config_set_m NF_CONNTRACK_TFTP               # Enables TFTP connection tracking support
-		kernel_config_set_y NF_CONNTRACK_ZONES              # Enables connection tracking zones support
-		kernel_config_set_y NF_CONNTRACK_EVENTS             # Enables connection tracking events support
-		kernel_config_set_y NF_CONNTRACK_LABELS             # Enables connection tracking labels support
-		kernel_config_set_m NF_NAT                          # Enables NAT support in nf_conntrack
-		kernel_config_set_m NF_NAT_MASQUERADE_IPV4          # Enables IPv4 masquerading for NAT in nf_conntrack
-		kernel_config_set_m NF_NAT_IPV4                     # Enables IPv4 NAT support in nf_conntrack
-		kernel_config_set_m NF_NAT_NEEDED                   # Enables NAT support in nf_conntrack when needed
-		kernel_config_set_m NF_NAT_FTP                      # Enables FTP NAT support in nf_conntrack
-		kernel_config_set_m NF_NAT_TFTP                     # Enables TFTP NAT support in nf_conntrack
 		kernel_config_set_m NET_CLS_CGROUP                  # Enables network classification using cgroups
 		kernel_config_set_y NET_CORE                        # Enables core networking stack support
 		kernel_config_set_y NET_L3_MASTER_DEV               # Enables master device support for Layer 3 (L3) networking
 		kernel_config_set_y NET_NS                          # Enables network namespace support
 		kernel_config_set_y NET_SCHED                       # Enables network scheduler support
-		kernel_config_set_y NETFILTER                       # Enables support for netfilter framework
-		kernel_config_set_y NETFILTER_ADVANCED              # Enables advanced netfilter options
-		kernel_config_set_m NETFILTER_XT_MATCH_ADDRTYPE     # Enables address type matching for netfilter
-		kernel_config_set_m NETFILTER_XT_MATCH_BPF          # Enables BPF match support in netfilter
-		kernel_config_set_m NETFILTER_XT_MATCH_CONNTRACK    # Enables connection tracking match support in netfilter
-		kernel_config_set_m NETFILTER_XT_MATCH_IPVS         # Enables IPVS match support in netfilter
-		kernel_config_set_m NETFILTER_XT_MARK               # Enables mark matching for netfilter
-		kernel_config_set_m NETFILTER_XTABLES               # Enables x_tables support in netfilter
-		kernel_config_set_m NETFILTER_XT_TARGET_MASQUERADE  # Enables masquerade target for netfilter
 		kernel_config_set_y NETDEVICES                      # Enables support for network devices
 		kernel_config_set_y NAMESPACES                      # Enables support for namespaces (including network namespaces)
 		kernel_config_set_m OVERLAY_FS                      # Enables support for OverlayFS


### PR DESCRIPTION
# Description

Rather than just modify `armbian_kernel_config__enable_docker_support` to make modules instead of built-ins, just build all `iptables`/`nftables` modules as modules.
Also yanks the `iptables`/`nftables` `kernel_config_set_m` or `kernel_config_set_y` from `armbian_kernel_config__enable_docker_support`

this is an alternative to #8658

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] built kernels for `nanopim4v2`, `tritium-h3`, `rock-5-itx`, `bananapir4`, `pine64so`, `orangepizero2`
- [ ] 
# Checklist:

_Please delete options that are not relevant._

- [?] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
