### PR TITLE
rockchip rk3566: h96-TVbox: Include i2c Led Pins into dts

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3566-h96-tvbox.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3566-h96-tvbox.dts
@@ -9,6 +9,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/pinctrl/rockchip.h>
 #include <dt-bindings/soc/rockchip,vop2.h>
+#include <dt-bindings/leds/common.h>
 #include "rk3566.dtsi"
 
 / {
@@ -67,6 +68,106 @@
 		linux,rc-map-name = "rc-h96-max-v56";
 	};
 	
+	i2c-display {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 RK_PB4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 RK_PB3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <5>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		display@24 {
+			compatible = "fdhisi,fd6551";
+			reg = <0x24>;
+
+			digits {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				digit@0 {
+					reg = <0>;
+					segments = <1 3>,
+						   <1 1>,
+						   <1 2>,
+						   <1 6>,
+						   <1 4>,
+						   <1 5>,
+						   <1 0>;
+				};
+				digit@1 {
+					reg = <1>;
+					segments = <2 3>,
+						   <2 1>,
+						   <2 2>,
+						   <2 6>,
+						   <2 4>,
+						   <2 5>,
+						   <2 0>;
+				};
+				digit@2 {
+					reg = <2>;
+					segments = <3 3>,
+						   <3 1>,
+						   <3 2>,
+						   <3 6>,
+						   <3 4>,
+						   <3 5>,
+						   <3 0>;
+				};
+				digit@3 {
+					reg = <3>;
+					segments = <4 3>,
+						   <4 1>,
+						   <4 2>,
+						   <4 6>,
+						   <4 4>,
+						   <4 5>,
+						   <4 0>;
+				};
+			};
+
+			leds {
+				#address-cells = <2>;
+				#size-cells = <0>;
+				
+				led@0,0 {
+					reg = <0 0>;
+					function = LED_FUNCTION_ALARM;
+				};
+				
+				led@0,1 {
+					reg = <0 1>;
+					function = LED_FUNCTION_USB;
+				};
+				
+				led@0,3 {
+					reg = <0 3>;
+					function = "play";
+				};
+				
+				led@0,2 {
+					reg = <0 2>;
+					function = "pause";
+				};
+				
+				led@0,4 {
+					reg = <0 4>;
+					function = "colon";
+				};
+				
+				led@0,5 {
+					reg = <0 5>;
+					function = LED_FUNCTION_LAN;
+				};
+				
+				led@0,6 {
+					reg = <0 6>;
+					function = LED_FUNCTION_WLAN;
+				};
+			};
+
+		};
+	};
+
 	fddis_dev {
 		compatible = "fddis_dev";
 		fddis_gpio_clk = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;

--- a/patch/kernel/archive/rockchip64-6.16/dt/rk3566-h96-tvbox.dts
+++ b/patch/kernel/archive/rockchip64-6.16/dt/rk3566-h96-tvbox.dts
@@ -9,6 +9,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/pinctrl/rockchip.h>
 #include <dt-bindings/soc/rockchip,vop2.h>
+#include <dt-bindings/leds/common.h>
 #include "rk3566.dtsi"
 
 / {
@@ -59,6 +60,106 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&ir_receiver_pin>;
 		linux,rc-map-name = "rc-h96-max-v56";
+	};
+
+	i2c-display {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 RK_PB4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 RK_PB3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <5>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		display@24 {
+			compatible = "fdhisi,fd6551";
+			reg = <0x24>;
+
+			digits {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				digit@0 {
+					reg = <0>;
+					segments = <1 3>,
+						   <1 1>,
+						   <1 2>,
+						   <1 6>,
+						   <1 4>,
+						   <1 5>,
+						   <1 0>;
+				};
+				digit@1 {
+					reg = <1>;
+					segments = <2 3>,
+						   <2 1>,
+						   <2 2>,
+						   <2 6>,
+						   <2 4>,
+						   <2 5>,
+						   <2 0>;
+				};
+				digit@2 {
+					reg = <2>;
+					segments = <3 3>,
+						   <3 1>,
+						   <3 2>,
+						   <3 6>,
+						   <3 4>,
+						   <3 5>,
+						   <3 0>;
+				};
+				digit@3 {
+					reg = <3>;
+					segments = <4 3>,
+						   <4 1>,
+						   <4 2>,
+						   <4 6>,
+						   <4 4>,
+						   <4 5>,
+						   <4 0>;
+				};
+			};
+
+			leds {
+				#address-cells = <2>;
+				#size-cells = <0>;
+				
+				led@0,0 {
+					reg = <0 0>;
+					function = LED_FUNCTION_ALARM;
+				};
+				
+				led@0,1 {
+					reg = <0 1>;
+					function = LED_FUNCTION_USB;
+				};
+				
+				led@0,3 {
+					reg = <0 3>;
+					function = "play";
+				};
+				
+				led@0,2 {
+					reg = <0 2>;
+					function = "pause";
+				};
+				
+				led@0,4 {
+					reg = <0 4>;
+					function = "colon";
+				};
+				
+				led@0,5 {
+					reg = <0 5>;
+					function = LED_FUNCTION_LAN;
+				};
+				
+				led@0,6 {
+					reg = <0 6>;
+					function = LED_FUNCTION_WLAN;
+				};
+			};
+
+		};
 	};
 	
 	fddis_dev {

--- a/patch/kernel/archive/rockchip64-6.6/dt/rk3566-h96-tvbox.dts
+++ b/patch/kernel/archive/rockchip64-6.6/dt/rk3566-h96-tvbox.dts
@@ -9,6 +9,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/pinctrl/rockchip.h>
 #include <dt-bindings/soc/rockchip,vop2.h>
+#include <dt-bindings/leds/common.h>
 #include "rk3566.dtsi"
 
 / {
@@ -65,6 +66,106 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&ir_receiver_pin>;
 		linux,rc-map-name = "rc-h96-max-v56";
+	};
+
+	i2c-display {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 RK_PB4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 RK_PB3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <5>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		display@24 {
+			compatible = "fdhisi,fd6551";
+			reg = <0x24>;
+
+			digits {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				digit@0 {
+					reg = <0>;
+					segments = <1 3>,
+						   <1 1>,
+						   <1 2>,
+						   <1 6>,
+						   <1 4>,
+						   <1 5>,
+						   <1 0>;
+				};
+				digit@1 {
+					reg = <1>;
+					segments = <2 3>,
+						   <2 1>,
+						   <2 2>,
+						   <2 6>,
+						   <2 4>,
+						   <2 5>,
+						   <2 0>;
+				};
+				digit@2 {
+					reg = <2>;
+					segments = <3 3>,
+						   <3 1>,
+						   <3 2>,
+						   <3 6>,
+						   <3 4>,
+						   <3 5>,
+						   <3 0>;
+				};
+				digit@3 {
+					reg = <3>;
+					segments = <4 3>,
+						   <4 1>,
+						   <4 2>,
+						   <4 6>,
+						   <4 4>,
+						   <4 5>,
+						   <4 0>;
+				};
+			};
+
+			leds {
+				#address-cells = <2>;
+				#size-cells = <0>;
+				
+				led@0,0 {
+					reg = <0 0>;
+					function = LED_FUNCTION_ALARM;
+				};
+				
+				led@0,1 {
+					reg = <0 1>;
+					function = LED_FUNCTION_USB;
+				};
+				
+				led@0,3 {
+					reg = <0 3>;
+					function = "play";
+				};
+				
+				led@0,2 {
+					reg = <0 2>;
+					function = "pause";
+				};
+				
+				led@0,4 {
+					reg = <0 4>;
+					function = "colon";
+				};
+				
+				led@0,5 {
+					reg = <0 5>;
+					function = LED_FUNCTION_LAN;
+				};
+				
+				led@0,6 {
+					reg = <0 6>;
+					function = LED_FUNCTION_WLAN;
+				};
+			};
+
+		};
 	};
 	
 	fddis_dev {

--- a/patch/kernel/archive/rockchip64-6.9/dt/rk3566-h96-tvbox.dts
+++ b/patch/kernel/archive/rockchip64-6.9/dt/rk3566-h96-tvbox.dts
@@ -9,6 +9,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/pinctrl/rockchip.h>
 #include <dt-bindings/soc/rockchip,vop2.h>
+#include <dt-bindings/leds/common.h>
 #include "rk3566.dtsi"
 
 / {
@@ -59,6 +60,106 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&ir_receiver_pin>;
 		linux,rc-map-name = "rc-h96-max-v56";
+	};
+
+	i2c-display {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 RK_PB4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 RK_PB3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <5>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		display@24 {
+			compatible = "fdhisi,fd6551";
+			reg = <0x24>;
+
+			digits {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				digit@0 {
+					reg = <0>;
+					segments = <1 3>,
+						   <1 1>,
+						   <1 2>,
+						   <1 6>,
+						   <1 4>,
+						   <1 5>,
+						   <1 0>;
+				};
+				digit@1 {
+					reg = <1>;
+					segments = <2 3>,
+						   <2 1>,
+						   <2 2>,
+						   <2 6>,
+						   <2 4>,
+						   <2 5>,
+						   <2 0>;
+				};
+				digit@2 {
+					reg = <2>;
+					segments = <3 3>,
+						   <3 1>,
+						   <3 2>,
+						   <3 6>,
+						   <3 4>,
+						   <3 5>,
+						   <3 0>;
+				};
+				digit@3 {
+					reg = <3>;
+					segments = <4 3>,
+						   <4 1>,
+						   <4 2>,
+						   <4 6>,
+						   <4 4>,
+						   <4 5>,
+						   <4 0>;
+				};
+			};
+
+			leds {
+				#address-cells = <2>;
+				#size-cells = <0>;
+				
+				led@0,0 {
+					reg = <0 0>;
+					function = LED_FUNCTION_ALARM;
+				};
+				
+				led@0,1 {
+					reg = <0 1>;
+					function = LED_FUNCTION_USB;
+				};
+				
+				led@0,3 {
+					reg = <0 3>;
+					function = "play";
+				};
+				
+				led@0,2 {
+					reg = <0 2>;
+					function = "pause";
+				};
+				
+				led@0,4 {
+					reg = <0 4>;
+					function = "colon";
+				};
+				
+				led@0,5 {
+					reg = <0 5>;
+					function = LED_FUNCTION_LAN;
+				};
+				
+				led@0,6 {
+					reg = <0 6>;
+					function = LED_FUNCTION_WLAN;
+				};
+			};
+
+		};
 	};
 	
 	fddis_dev {


### PR DESCRIPTION
# Description

Include i2c Led Pins into dts

https://forum.armbian.com/topic/28895-efforts-to-develop-firmware-for-h96-max-v56-rk3566-8g64g/page/18/#findComment-225962

# How Has This Been Tested?

- [Kernel 6.12.48  ] 

# Checklist:

_Please delete options that are not relevant._

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new warnings
- [X ] Any dependent changes have been merged and published in downstream modules
