### PR TITLE
AR-2758 : fix libwmf0.2-7-gtk bad name

### DIFF
--- a/config/desktop/bookworm/environments/budgie/config_base/packages
+++ b/config/desktop/bookworm/environments/budgie/config_base/packages
@@ -85,7 +85,7 @@ libnotify-bin
 libplank1
 libplank-common
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxapp1
 libxcursor1
 gdm3

--- a/config/desktop/bookworm/environments/i3-wm/config_base/packages
+++ b/config/desktop/bookworm/environments/i3-wm/config_base/packages
@@ -72,7 +72,7 @@ libgsettings-qt1
 libjson-xs-perl
 libnotify-bin
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcb-cursor0
 libxcursor1
 lightdm

--- a/config/desktop/bookworm/environments/kde-plasma/config_base/packages
+++ b/config/desktop/bookworm/environments/kde-plasma/config_base/packages
@@ -61,7 +61,7 @@ libgsettings-qt1
 libgtk2.0-bin
 libnotify-bin
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 sddm
 mesa-utils

--- a/config/desktop/bookworm/environments/xfce/config_base/packages
+++ b/config/desktop/bookworm/environments/xfce/config_base/packages
@@ -50,7 +50,7 @@ libgtk2.0-bin
 libnotify-bin
 libpam-gnome-keyring
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 lightdm
 lm-sensors

--- a/config/desktop/bookworm/environments/xmonad/config_base/packages
+++ b/config/desktop/bookworm/environments/xmonad/config_base/packages
@@ -63,7 +63,7 @@ libgnome-bluetooth13
 libgsettings-qt1
 libnotify-bin
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxapp1
 libxcursor1
 lightdm

--- a/config/desktop/common/environments/budgie/config_base/packages
+++ b/config/desktop/common/environments/budgie/config_base/packages
@@ -108,7 +108,7 @@ libnotify-bin
 libplank1
 libplank-common
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 gdm3
 mesa-utils

--- a/config/desktop/common/environments/deepin/config_base/packages
+++ b/config/desktop/common/environments/deepin/config_base/packages
@@ -118,7 +118,7 @@ libgsettings-qt1
 libgtk2.0-bin
 libnotify-bin
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 lightdm
 lightdm-settings

--- a/config/desktop/common/environments/enlightenment/config_base/packages
+++ b/config/desktop/common/environments/enlightenment/config_base/packages
@@ -84,7 +84,7 @@ libnotify-bin
 libplank1
 libplank-common
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 lightdm
 lxtask

--- a/config/desktop/common/environments/i3-wm/config_base/packages
+++ b/config/desktop/common/environments/i3-wm/config_base/packages
@@ -77,7 +77,7 @@ libgsettings-qt1
 libjson-xs-perl
 libnotify-bin
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcb-cursor0
 libxcursor1
 lightdm

--- a/config/desktop/common/environments/kde-plasma/config_base/packages
+++ b/config/desktop/common/environments/kde-plasma/config_base/packages
@@ -80,7 +80,7 @@ libgsettings-qt1
 libgtk2.0-bin
 libnotify-bin
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 sddm
 mesa-utils

--- a/config/desktop/common/environments/mate/config_base/packages
+++ b/config/desktop/common/environments/mate/config_base/packages
@@ -80,7 +80,7 @@ libgsettings-qt1
 libgtk2.0-bin
 libnotify-bin
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 lightdm
 lightdm-settings

--- a/config/desktop/common/environments/xfce/config_base/packages
+++ b/config/desktop/common/environments/xfce/config_base/packages
@@ -51,7 +51,7 @@ libgtk2.0-bin
 libnotify-bin
 libpam-gnome-keyring
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 lightdm
 lm-sensors

--- a/config/desktop/common/environments/xmonad/config_base/packages
+++ b/config/desktop/common/environments/xmonad/config_base/packages
@@ -70,7 +70,7 @@ libghc-xmonad-wallpaper-dev
 libgsettings-qt1
 libnotify-bin
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 lightdm
 lightdm-gtk-greeter

--- a/config/desktop/jammy/environments/budgie/config_base/packages
+++ b/config/desktop/jammy/environments/budgie/config_base/packages
@@ -108,7 +108,7 @@ libplank1
 libplank-common
 libproxy1-plugin-gsettings
 libu2f-udev
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxapp1
 libxcursor1
 gdm3

--- a/config/desktop/jammy/environments/i3-wm/config_base/packages
+++ b/config/desktop/jammy/environments/i3-wm/config_base/packages
@@ -79,7 +79,7 @@ libjson-xs-perl
 libnotify-bin
 libproxy1-plugin-gsettings
 libu2f-udev
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcb-cursor0
 libxcursor1
 lightdm

--- a/config/desktop/jammy/environments/kde-plasma/config_base/packages
+++ b/config/desktop/jammy/environments/kde-plasma/config_base/packages
@@ -80,7 +80,7 @@ libgtk2.0-bin
 libnotify-bin
 libproxy1-plugin-gsettings
 libu2f-udev
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 sddm
 mesa-utils

--- a/config/desktop/jammy/environments/xfce/config_base/packages
+++ b/config/desktop/jammy/environments/xfce/config_base/packages
@@ -54,7 +54,7 @@ libnotify-bin
 libpam-gnome-keyring
 libproxy1-plugin-gsettings
 libu2f-udev
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 lightdm
 lm-sensors

--- a/config/desktop/jammy/environments/xmonad/config_base/packages
+++ b/config/desktop/jammy/environments/xmonad/config_base/packages
@@ -74,7 +74,7 @@ libgsettings-qt1
 libnotify-bin
 libproxy1-plugin-gsettings
 libu2f-udev
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxapp1
 libxcursor1
 lightdm

--- a/config/desktop/noble/environments/i3-wm/config_base/packages
+++ b/config/desktop/noble/environments/i3-wm/config_base/packages
@@ -74,7 +74,7 @@ libjson-xs-perl
 libnotify-bin
 libproxy1-plugin-gsettings
 libu2f-udev
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcb-cursor0
 libxcursor1
 lightdm

--- a/config/desktop/noble/environments/xfce/config_base/packages
+++ b/config/desktop/noble/environments/xfce/config_base/packages
@@ -54,7 +54,7 @@ libnotify-bin
 libpam-gnome-keyring
 libproxy1-plugin-gsettings
 libu2f-udev
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 lightdm
 lm-sensors

--- a/config/desktop/plucky/environments/i3-wm/config_base/packages
+++ b/config/desktop/plucky/environments/i3-wm/config_base/packages
@@ -73,7 +73,7 @@ libjson-xs-perl
 libnotify-bin
 libproxy1-plugin-gsettings
 libu2f-udev
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcb-cursor0
 libxcursor1
 lightdm

--- a/config/desktop/plucky/environments/kde-plasma/config_base/packages
+++ b/config/desktop/plucky/environments/kde-plasma/config_base/packages
@@ -80,7 +80,7 @@ libgtk2.0-bin
 libnotify-bin
 libproxy1-plugin-gsettings
 libu2f-udev
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 sddm
 mesa-utils

--- a/config/desktop/plucky/environments/xfce/config_base/packages
+++ b/config/desktop/plucky/environments/xfce/config_base/packages
@@ -54,7 +54,7 @@ libnotify-bin
 libpam-gnome-keyring
 libproxy1-plugin-gsettings
 libu2f-udev
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 lightdm
 lm-sensors

--- a/config/desktop/sid/environments/xfce/config_base/packages
+++ b/config/desktop/sid/environments/xfce/config_base/packages
@@ -49,7 +49,7 @@ libgtk2.0-bin
 libnotify-bin
 libpam-gnome-keyring
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 lightdm
 lm-sensors

--- a/config/desktop/trixie/environments/budgie/config_base/packages
+++ b/config/desktop/trixie/environments/budgie/config_base/packages
@@ -83,7 +83,7 @@ libnotify-bin
 libplank1
 libplank-common
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxapp1
 libxcursor1
 gdm3

--- a/config/desktop/trixie/environments/i3-wm/config_base/packages
+++ b/config/desktop/trixie/environments/i3-wm/config_base/packages
@@ -72,7 +72,7 @@ libgsettings-qt1
 libjson-xs-perl
 libnotify-bin
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcb-cursor0
 libxcursor1
 lightdm

--- a/config/desktop/trixie/environments/kde-plasma/config_base/packages
+++ b/config/desktop/trixie/environments/kde-plasma/config_base/packages
@@ -60,7 +60,7 @@ libgsettings-qt1
 libgtk2.0-bin
 libnotify-bin
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 sddm
 mesa-utils

--- a/config/desktop/trixie/environments/xfce/config_base/packages
+++ b/config/desktop/trixie/environments/xfce/config_base/packages
@@ -49,7 +49,7 @@ libgtk2.0-bin
 libnotify-bin
 libpam-gnome-keyring
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxcursor1
 lightdm
 lm-sensors

--- a/config/desktop/trixie/environments/xmonad/config_base/packages
+++ b/config/desktop/trixie/environments/xmonad/config_base/packages
@@ -62,7 +62,7 @@ libghc-xmonad-wallpaper-dev
 libgsettings-qt1
 libnotify-bin
 libproxy1-plugin-gsettings
-libwmf0.2-7-gtk
+libwmf-0.2-7-gtk
 libxapp1
 libxcursor1
 lightdm


### PR DESCRIPTION
According to issue https://github.com/armbian/build/issues/8667 (AR-2758)
fix bad name on package
