### PR TITLE
Armbian-zram-config mkfs detecion gets empty string

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-zram-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-zram-config
@@ -19,7 +19,7 @@
 
 # Read mkfs version as it behaves differently after v2.40.1 (Trixie / Plucky ->)
 # mkfs is used to create the zram devices and the ramlog partition
-MKFS_VERSION=$(mkfs --version | grep -oP '\d+\.\d+\.\d+')
+MKFS_VERSION=$(LC_ALL=C mkfs --version 2>&1 | grep -Po 'util-linux\s+\K[0-9]+(\.[0-9]+)*' | head -n1)
 
 # and script configuration
 . /usr/lib/armbian/armbian-common


### PR DESCRIPTION
# Description

GitHub issue reference: https://github.com/armbian/build/issues/8671 

# How Has This Been Tested?

- [x] Manual execution. Works on Trixie after and it works on Noble and below.

```
[340]: Setting up swapspace version 1, size = 985.7 MiB (1033629696 bytes)
[340]: no label, UUID=9570e9c4-9a32-11f0-b8ef-935aac6ac0e4
[426]: mke2fs 1.47.2 (1-Jan-2025)
[426]: [74B blob data]
[426]: Creating filesystem with 12800 4k blocks and 12800 inodes
[426]: [41B blob data]
[426]: [38B blob data]
[426]: [75B blob data]
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
