### PR TITLE
git: git_ensure_safe_directory(): check safety via git status

### DIFF
--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -57,7 +57,7 @@ function git_ensure_safe_directory() {
 		local git_dir="$1"
 		if [[ -e "$1/.git" ]]; then
 			display_alert "git: Marking all directories as safe, which should include" "$git_dir" "debug"
-			git config --global --get safe.directory "$1" > /dev/null || regular_git config --global --add safe.directory "$1"
+			git -C "$1" status > /dev/null || regular_git config --global --add safe.directory "$1"
 		fi
 	else
 		display_alert "git not installed" "a true wonder how you got this far without git - it will be installed for you" "warn"


### PR DESCRIPTION
# The issue
Consider these two unmatching cases running `git config --global --get safe.directory "/home/armbian/build"`
1. "/home/armbian/build/subdir" in global safe directory: return true. While git does not consider "/home/armbian/build" a safe directory.
2.  "/home/armbian/*" in global safe directory: return false. While git does consider "/home/armbian/build" a safe directory.

# The cause
`git config --get` match driectory name with a tab completion, not exactly the directory name or using glob match pattern

# The solution
use `git -C $1 status` to check the safety of the repo.

# The benefit
less impurity of possible change on user's ~/.git/config file.

# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ ] Test A
- [ ] Test B

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
