### PR TITLE
uefi-loong64-6.16: add revert patches to fix xe driver

### DIFF
--- a/patch/kernel/archive/uefi-loong64-6.16/0007-Revert-drm-xe-guc-Set-RCS-CCS-yield-policy.patch
+++ b/patch/kernel/archive/uefi-loong64-6.16/0007-Revert-drm-xe-guc-Set-RCS-CCS-yield-policy.patch
@@ -1,0 +1,215 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jianfeng Liu <liujianfeng1994@gmail.com>
+Date: Sun, 28 Sep 2025 14:31:09 +0800
+Subject: Revert "drm/xe/guc: Set RCS/CCS yield policy"
+
+This reverts commit dd1a415dcfd5984bf83abd804c3cd9e0ff9dde30.
+---
+ drivers/gpu/drm/xe/abi/guc_actions_abi.h |  1 -
+ drivers/gpu/drm/xe/abi/guc_klvs_abi.h    | 25 ----
+ drivers/gpu/drm/xe/xe_gt.c               |  3 +-
+ drivers/gpu/drm/xe/xe_guc.c              |  6 +-
+ drivers/gpu/drm/xe/xe_guc_submit.c       | 66 ----------
+ drivers/gpu/drm/xe/xe_guc_submit.h       |  2 -
+ 6 files changed, 5 insertions(+), 98 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/abi/guc_actions_abi.h b/drivers/gpu/drm/xe/abi/guc_actions_abi.h
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/abi/guc_actions_abi.h
++++ b/drivers/gpu/drm/xe/abi/guc_actions_abi.h
+@@ -117,7 +117,6 @@ enum xe_guc_action {
+ 	XE_GUC_ACTION_ENTER_S_STATE = 0x501,
+ 	XE_GUC_ACTION_EXIT_S_STATE = 0x502,
+ 	XE_GUC_ACTION_GLOBAL_SCHED_POLICY_CHANGE = 0x506,
+-	XE_GUC_ACTION_UPDATE_SCHEDULING_POLICIES_KLV = 0x509,
+ 	XE_GUC_ACTION_SCHED_CONTEXT = 0x1000,
+ 	XE_GUC_ACTION_SCHED_CONTEXT_MODE_SET = 0x1001,
+ 	XE_GUC_ACTION_SCHED_CONTEXT_MODE_DONE = 0x1002,
+diff --git a/drivers/gpu/drm/xe/abi/guc_klvs_abi.h b/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
++++ b/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
+@@ -17,7 +17,6 @@
+  *  | 0 | 31:16 | **KEY** - KLV key identifier                                 |
+  *  |   |       |   - `GuC Self Config KLVs`_                                  |
+  *  |   |       |   - `GuC Opt In Feature KLVs`_                               |
+- *  |   |       |   - `GuC Scheduling Policies KLVs`_                          |
+  *  |   |       |   - `GuC VGT Policy KLVs`_                                   |
+  *  |   |       |   - `GuC VF Configuration KLVs`_                             |
+  *  |   |       |                                                              |
+@@ -140,30 +139,6 @@ enum  {
+ #define GUC_KLV_OPT_IN_FEATURE_EXT_CAT_ERR_TYPE_KEY 0x4001
+ #define GUC_KLV_OPT_IN_FEATURE_EXT_CAT_ERR_TYPE_LEN 0u
+ 
+-/**
+- * DOC: GuC Scheduling Policies KLVs
+- *
+- * `GuC KLV`_ keys available for use with UPDATE_SCHEDULING_POLICIES_KLV.
+- *
+- * _`GUC_KLV_SCHEDULING_POLICIES_RENDER_COMPUTE_YIELD` : 0x1001
+- *      Some platforms do not allow concurrent execution of RCS and CCS
+- *      workloads from different address spaces. By default, the GuC prioritizes
+- *      RCS submissions over CCS ones, which can lead to CCS workloads being
+- *      significantly (or completely) starved of execution time. This KLV allows
+- *      the driver to specify a quantum (in ms) and a ratio (percentage value
+- *      between 0 and 100), and the GuC will prioritize the CCS for that
+- *      percentage of each quantum. For example, specifying 100ms and 30% will
+- *      make the GuC prioritize the CCS for 30ms of every 100ms.
+- *      Note that this does not necessarly mean that RCS and CCS engines will
+- *      only be active for their percentage of the quantum, as the restriction
+- *      only kicks in if both classes are fully busy with non-compatible address
+- *      spaces; i.e., if one engine is idle or running the same address space,
+- *      a pending job on the other engine will still be submitted to the HW no
+- *      matter what the ratio is
+- */
+-#define GUC_KLV_SCHEDULING_POLICIES_RENDER_COMPUTE_YIELD_KEY	0x1001
+-#define GUC_KLV_SCHEDULING_POLICIES_RENDER_COMPUTE_YIELD_LEN	2u
+-
+ /**
+  * DOC: GuC VGT Policy KLVs
+  *
+diff --git a/drivers/gpu/drm/xe/xe_gt.c b/drivers/gpu/drm/xe/xe_gt.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/xe_gt.c
++++ b/drivers/gpu/drm/xe/xe_gt.c
+@@ -41,7 +41,6 @@
+ #include "xe_gt_topology.h"
+ #include "xe_guc_exec_queue_types.h"
+ #include "xe_guc_pc.h"
+-#include "xe_guc_submit.h"
+ #include "xe_hw_fence.h"
+ #include "xe_hw_engine_class_sysfs.h"
+ #include "xe_irq.h"
+@@ -98,7 +97,7 @@ void xe_gt_sanitize(struct xe_gt *gt)
+ 	 * FIXME: if xe_uc_sanitize is called here, on TGL driver will not
+ 	 * reload
+ 	 */
+-	xe_guc_submit_disable(&gt->uc.guc);
++	gt->uc.guc.submission_state.enabled = false;
+ }
+ 
+ static void xe_gt_enable_host_l2_vram(struct xe_gt *gt)
+diff --git a/drivers/gpu/drm/xe/xe_guc.c b/drivers/gpu/drm/xe/xe_guc.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/xe_guc.c
++++ b/drivers/gpu/drm/xe/xe_guc.c
+@@ -825,7 +825,9 @@ int xe_guc_post_load_init(struct xe_guc *guc)
+ 			return ret;
+ 	}
+ 
+-	return xe_guc_submit_enable(guc);
++	guc->submission_state.enabled = true;
++
++	return 0;
+ }
+ 
+ int xe_guc_reset(struct xe_guc *guc)
+@@ -1519,7 +1521,7 @@ void xe_guc_sanitize(struct xe_guc *guc)
+ {
+ 	xe_uc_fw_sanitize(&guc->fw);
+ 	xe_guc_ct_disable(&guc->ct);
+-	xe_guc_submit_disable(guc);
++	guc->submission_state.enabled = false;
+ }
+ 
+ int xe_guc_reset_prepare(struct xe_guc *guc)
+diff --git a/drivers/gpu/drm/xe/xe_guc_submit.c b/drivers/gpu/drm/xe/xe_guc_submit.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/xe_guc_submit.c
++++ b/drivers/gpu/drm/xe/xe_guc_submit.c
+@@ -32,7 +32,6 @@
+ #include "xe_guc_ct.h"
+ #include "xe_guc_exec_queue_types.h"
+ #include "xe_guc_id_mgr.h"
+-#include "xe_guc_klv_helpers.h"
+ #include "xe_guc_submit_types.h"
+ #include "xe_hw_engine.h"
+ #include "xe_hw_fence.h"
+@@ -317,71 +316,6 @@ int xe_guc_submit_init(struct xe_guc *guc, unsigned int num_ids)
+ 	return drmm_add_action_or_reset(&xe->drm, guc_submit_fini, guc);
+ }
+ 
+-/*
+- * Given that we want to guarantee enough RCS throughput to avoid missing
+- * frames, we set the yield policy to 20% of each 80ms interval.
+- */
+-#define RC_YIELD_DURATION	80	/* in ms */
+-#define RC_YIELD_RATIO		20	/* in percent */
+-static u32 *emit_render_compute_yield_klv(u32 *emit)
+-{
+-	*emit++ = PREP_GUC_KLV_TAG(SCHEDULING_POLICIES_RENDER_COMPUTE_YIELD);
+-	*emit++ = RC_YIELD_DURATION;
+-	*emit++ = RC_YIELD_RATIO;
+-
+-	return emit;
+-}
+-
+-#define SCHEDULING_POLICY_MAX_DWORDS 16
+-static int guc_init_global_schedule_policy(struct xe_guc *guc)
+-{
+-	u32 data[SCHEDULING_POLICY_MAX_DWORDS];
+-	u32 *emit = data;
+-	u32 count = 0;
+-	int ret;
+-
+-	if (GUC_SUBMIT_VER(guc) < MAKE_GUC_VER(1, 1, 0))
+-		return 0;
+-
+-	*emit++ = XE_GUC_ACTION_UPDATE_SCHEDULING_POLICIES_KLV;
+-
+-	if (CCS_MASK(guc_to_gt(guc)))
+-		emit = emit_render_compute_yield_klv(emit);
+-
+-	count = emit - data;
+-	if (count > 1) {
+-		xe_assert(guc_to_xe(guc), count <= SCHEDULING_POLICY_MAX_DWORDS);
+-
+-		ret = xe_guc_ct_send_block(&guc->ct, data, count);
+-		if (ret < 0) {
+-			xe_gt_err(guc_to_gt(guc),
+-				  "failed to enable GuC sheduling policies: %pe\n",
+-				  ERR_PTR(ret));
+-			return ret;
+-		}
+-	}
+-
+-	return 0;
+-}
+-
+-int xe_guc_submit_enable(struct xe_guc *guc)
+-{
+-	int ret;
+-
+-	ret = guc_init_global_schedule_policy(guc);
+-	if (ret)
+-		return ret;
+-
+-	guc->submission_state.enabled = true;
+-
+-	return 0;
+-}
+-
+-void xe_guc_submit_disable(struct xe_guc *guc)
+-{
+-	guc->submission_state.enabled = false;
+-}
+-
+ static void __release_guc_id(struct xe_guc *guc, struct xe_exec_queue *q, u32 xa_count)
+ {
+ 	int i;
+diff --git a/drivers/gpu/drm/xe/xe_guc_submit.h b/drivers/gpu/drm/xe/xe_guc_submit.h
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/xe_guc_submit.h
++++ b/drivers/gpu/drm/xe/xe_guc_submit.h
+@@ -13,8 +13,6 @@ struct xe_exec_queue;
+ struct xe_guc;
+ 
+ int xe_guc_submit_init(struct xe_guc *guc, unsigned int num_ids);
+-int xe_guc_submit_enable(struct xe_guc *guc);
+-void xe_guc_submit_disable(struct xe_guc *guc);
+ 
+ int xe_guc_submit_reset_prepare(struct xe_guc *guc);
+ void xe_guc_submit_reset_wait(struct xe_guc *guc);
+-- 
+Armbian
+

--- a/patch/kernel/archive/uefi-loong64-6.16/0008-Revert-drm-xe-guc-Enable-extended-CAT-error-reportin.patch
+++ b/patch/kernel/archive/uefi-loong64-6.16/0008-Revert-drm-xe-guc-Enable-extended-CAT-error-reportin.patch
@@ -1,0 +1,223 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jianfeng Liu <liujianfeng1994@gmail.com>
+Date: Sun, 28 Sep 2025 14:31:16 +0800
+Subject: Revert "drm/xe/guc: Enable extended CAT error reporting"
+
+This reverts commit 97207a4fed5348ff5c5e71a7300db9b638640879.
+---
+ drivers/gpu/drm/xe/abi/guc_actions_abi.h |  4 -
+ drivers/gpu/drm/xe/abi/guc_klvs_abi.h    | 15 ---
+ drivers/gpu/drm/xe/xe_guc.c              | 56 ----------
+ drivers/gpu/drm/xe/xe_guc.h              |  1 -
+ drivers/gpu/drm/xe/xe_guc_submit.c       | 21 +---
+ drivers/gpu/drm/xe/xe_uc.c               |  4 -
+ 6 files changed, 3 insertions(+), 98 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/abi/guc_actions_abi.h b/drivers/gpu/drm/xe/abi/guc_actions_abi.h
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/abi/guc_actions_abi.h
++++ b/drivers/gpu/drm/xe/abi/guc_actions_abi.h
+@@ -142,7 +142,6 @@ enum xe_guc_action {
+ 	XE_GUC_ACTION_SET_ENG_UTIL_BUFF = 0x550A,
+ 	XE_GUC_ACTION_SET_DEVICE_ENGINE_ACTIVITY_BUFFER = 0x550C,
+ 	XE_GUC_ACTION_SET_FUNCTION_ENGINE_ACTIVITY_BUFFER = 0x550D,
+-	XE_GUC_ACTION_OPT_IN_FEATURE_KLV = 0x550E,
+ 	XE_GUC_ACTION_NOTIFY_MEMORY_CAT_ERROR = 0x6000,
+ 	XE_GUC_ACTION_REPORT_PAGE_FAULT_REQ_DESC = 0x6002,
+ 	XE_GUC_ACTION_PAGE_FAULT_RES_DESC = 0x6003,
+@@ -241,7 +240,4 @@ enum xe_guc_g2g_type {
+ #define XE_G2G_DEREGISTER_TILE	REG_GENMASK(15, 12)
+ #define XE_G2G_DEREGISTER_TYPE	REG_GENMASK(11, 8)
+ 
+-/* invalid type for XE_GUC_ACTION_NOTIFY_MEMORY_CAT_ERROR */
+-#define XE_GUC_CAT_ERR_TYPE_INVALID 0xdeadbeef
+-
+ #endif
+diff --git a/drivers/gpu/drm/xe/abi/guc_klvs_abi.h b/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
++++ b/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
+@@ -16,7 +16,6 @@
+  *  +===+=======+==============================================================+
+  *  | 0 | 31:16 | **KEY** - KLV key identifier                                 |
+  *  |   |       |   - `GuC Self Config KLVs`_                                  |
+- *  |   |       |   - `GuC Opt In Feature KLVs`_                               |
+  *  |   |       |   - `GuC VGT Policy KLVs`_                                   |
+  *  |   |       |   - `GuC VF Configuration KLVs`_                             |
+  *  |   |       |                                                              |
+@@ -125,20 +124,6 @@ enum  {
+ 	GUC_CONTEXT_POLICIES_KLV_NUM_IDS = 5,
+ };
+ 
+-/**
+- * DOC: GuC Opt In Feature KLVs
+- *
+- * `GuC KLV`_ keys available for use with OPT_IN_FEATURE_KLV
+- *
+- *  _`GUC_KLV_OPT_IN_FEATURE_EXT_CAT_ERR_TYPE` : 0x4001
+- *      Adds an extra dword to the XE_GUC_ACTION_NOTIFY_MEMORY_CAT_ERROR G2H
+- *      containing the type of the CAT error. On HW that does not support
+- *      reporting the CAT error type, the extra dword is set to 0xdeadbeef.
+- */
+-
+-#define GUC_KLV_OPT_IN_FEATURE_EXT_CAT_ERR_TYPE_KEY 0x4001
+-#define GUC_KLV_OPT_IN_FEATURE_EXT_CAT_ERR_TYPE_LEN 0u
+-
+ /**
+  * DOC: GuC VGT Policy KLVs
+  *
+diff --git a/drivers/gpu/drm/xe/xe_guc.c b/drivers/gpu/drm/xe/xe_guc.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/xe_guc.c
++++ b/drivers/gpu/drm/xe/xe_guc.c
+@@ -29,7 +29,6 @@
+ #include "xe_guc_db_mgr.h"
+ #include "xe_guc_engine_activity.h"
+ #include "xe_guc_hwconfig.h"
+-#include "xe_guc_klv_helpers.h"
+ #include "xe_guc_log.h"
+ #include "xe_guc_pc.h"
+ #include "xe_guc_relay.h"
+@@ -571,57 +570,6 @@ static int guc_g2g_start(struct xe_guc *guc)
+ 	return err;
+ }
+ 
+-static int __guc_opt_in_features_enable(struct xe_guc *guc, u64 addr, u32 num_dwords)
+-{
+-	u32 action[] = {
+-		XE_GUC_ACTION_OPT_IN_FEATURE_KLV,
+-		lower_32_bits(addr),
+-		upper_32_bits(addr),
+-		num_dwords
+-	};
+-
+-	return xe_guc_ct_send_block(&guc->ct, action, ARRAY_SIZE(action));
+-}
+-
+-#define OPT_IN_MAX_DWORDS 16
+-int xe_guc_opt_in_features_enable(struct xe_guc *guc)
+-{
+-	struct xe_device *xe = guc_to_xe(guc);
+-	CLASS(xe_guc_buf, buf)(&guc->buf, OPT_IN_MAX_DWORDS);
+-	u32 count = 0;
+-	u32 *klvs;
+-	int ret;
+-
+-	if (!xe_guc_buf_is_valid(buf))
+-		return -ENOBUFS;
+-
+-	klvs = xe_guc_buf_cpu_ptr(buf);
+-
+-	/*
+-	 * The extra CAT error type opt-in was added in GuC v70.17.0, which maps
+-	 * to compatibility version v1.7.0.
+-	 * Note that the GuC allows enabling this KLV even on platforms that do
+-	 * not support the extra type; in such case the returned type variable
+-	 * will be set to a known invalid value which we can check against.
+-	 */
+-	if (GUC_SUBMIT_VER(guc) >= MAKE_GUC_VER(1, 7, 0))
+-		klvs[count++] = PREP_GUC_KLV_TAG(OPT_IN_FEATURE_EXT_CAT_ERR_TYPE);
+-
+-	if (count) {
+-		xe_assert(xe, count <= OPT_IN_MAX_DWORDS);
+-
+-		ret = __guc_opt_in_features_enable(guc, xe_guc_buf_flush(buf), count);
+-		if (ret < 0) {
+-			xe_gt_err(guc_to_gt(guc),
+-				  "failed to enable GuC opt-in features: %pe\n",
+-				  ERR_PTR(ret));
+-			return ret;
+-		}
+-	}
+-
+-	return 0;
+-}
+-
+ static void guc_fini_hw(void *arg)
+ {
+ 	struct xe_guc *guc = arg;
+@@ -815,10 +763,6 @@ int xe_guc_post_load_init(struct xe_guc *guc)
+ 
+ 	xe_guc_ads_populate_post_load(&guc->ads);
+ 
+-	ret = xe_guc_opt_in_features_enable(guc);
+-	if (ret)
+-		return ret;
+-
+ 	if (xe_guc_g2g_wanted(guc_to_xe(guc))) {
+ 		ret = guc_g2g_start(guc);
+ 		if (ret)
+diff --git a/drivers/gpu/drm/xe/xe_guc.h b/drivers/gpu/drm/xe/xe_guc.h
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/xe_guc.h
++++ b/drivers/gpu/drm/xe/xe_guc.h
+@@ -36,7 +36,6 @@ int xe_guc_reset(struct xe_guc *guc);
+ int xe_guc_upload(struct xe_guc *guc);
+ int xe_guc_min_load_for_hwconfig(struct xe_guc *guc);
+ int xe_guc_enable_communication(struct xe_guc *guc);
+-int xe_guc_opt_in_features_enable(struct xe_guc *guc);
+ int xe_guc_suspend(struct xe_guc *guc);
+ void xe_guc_notify(struct xe_guc *guc);
+ int xe_guc_auth_huc(struct xe_guc *guc, u32 rsa_addr);
+diff --git a/drivers/gpu/drm/xe/xe_guc_submit.c b/drivers/gpu/drm/xe/xe_guc_submit.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/xe_guc_submit.c
++++ b/drivers/gpu/drm/xe/xe_guc_submit.c
+@@ -2088,16 +2088,12 @@ int xe_guc_exec_queue_memory_cat_error_handler(struct xe_guc *guc, u32 *msg,
+ 	struct xe_gt *gt = guc_to_gt(guc);
+ 	struct xe_exec_queue *q;
+ 	u32 guc_id;
+-	u32 type = XE_GUC_CAT_ERR_TYPE_INVALID;
+ 
+-	if (unlikely(!len || len > 2))
++	if (unlikely(len < 1))
+ 		return -EPROTO;
+ 
+ 	guc_id = msg[0];
+ 
+-	if (len == 2)
+-		type = msg[1];
+-
+ 	if (guc_id == GUC_ID_UNKNOWN) {
+ 		/*
+ 		 * GuC uses GUC_ID_UNKNOWN if it can not map the CAT fault to any PF/VF
+@@ -2111,19 +2107,8 @@ int xe_guc_exec_queue_memory_cat_error_handler(struct xe_guc *guc, u32 *msg,
+ 	if (unlikely(!q))
+ 		return -EPROTO;
+ 
+-	/*
+-	 * The type is HW-defined and changes based on platform, so we don't
+-	 * decode it in the kernel and only check if it is valid.
+-	 * See bspec 54047 and 72187 for details.
+-	 */
+-	if (type != XE_GUC_CAT_ERR_TYPE_INVALID)
+-		xe_gt_dbg(gt,
+-			  "Engine memory CAT error [%u]: class=%s, logical_mask: 0x%x, guc_id=%d",
+-			  type, xe_hw_engine_class_to_str(q->class), q->logical_mask, guc_id);
+-	else
+-		xe_gt_dbg(gt,
+-			  "Engine memory CAT error: class=%s, logical_mask: 0x%x, guc_id=%d",
+-			  xe_hw_engine_class_to_str(q->class), q->logical_mask, guc_id);
++	xe_gt_dbg(gt, "Engine memory cat error: engine_class=%s, logical_mask: 0x%x, guc_id=%d",
++		  xe_hw_engine_class_to_str(q->class), q->logical_mask, guc_id);
+ 
+ 	trace_xe_exec_queue_memory_cat_error(q);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_uc.c b/drivers/gpu/drm/xe/xe_uc.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/xe/xe_uc.c
++++ b/drivers/gpu/drm/xe/xe_uc.c
+@@ -165,10 +165,6 @@ static int vf_uc_init_hw(struct xe_uc *uc)
+ 
+ 	uc->guc.submission_state.enabled = true;
+ 
+-	err = xe_guc_opt_in_features_enable(&uc->guc);
+-	if (err)
+-		return err;
+-
+ 	err = xe_gt_record_default_lrcs(uc_to_gt(uc));
+ 	if (err)
+ 		return err;
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

These two commits merged to 6.16.9 has broken intel xe driver and I can't get into gdm or gnome desktop:
- [drm/xe/guc: Set RCS/CCS yield policy](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/drivers/gpu/drm/xe?h=v6.16.9&id=dd1a415dcfd5984bf83abd804c3cd9e0ff9dde30)
- [drm/xe/guc: Enable extended CAT error reporting](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/drivers/gpu/drm/xe?h=v6.16.9&id=97207a4fed5348ff5c5e71a7300db9b638640879)

After reverting it everything is fine.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `PREFER_DOCKER=no ./compile.sh kernel BOARD=uefi-loong64 BRANCH=edge KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes KERNEL_GIT=shallow NO_HOST_RELEASE_CHECK=yes RELEASE=sid`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
