### PR TITLE
allow extending or overriding the patching config from the userpatche…

### DIFF
--- a/lib/tools/common/patching_config.py
+++ b/lib/tools/common/patching_config.py
@@ -53,11 +53,9 @@ class PatchingToGitConfig:
 class PatchingConfig:
 	def __init__(self, yaml_config_file_paths: list[str]):
 		self.yaml_config_file_paths = yaml_config_file_paths
-		if len(yaml_config_file_paths) == 0:
-			self.yaml_config = {}
-		else:
-			# I'm lazy, single one for now.
-			self.yaml_config = self.read_yaml_config(yaml_config_file_paths[0])["config"]
+		self.yaml_config = {}
+		for p in yaml_config_file_paths:
+			self.yaml_config.update(self.read_yaml_config(p)["config"])
 
 		self.patches_to_git_config: PatchingToGitConfig = PatchingToGitConfig(self.yaml_config.get("patches-to-git", {}))
 


### PR DESCRIPTION
# Description

Motivation: allow adding extra device tree overlays in the user patches folder, similar to the patch folder.
Summary: with this change it becomes possible to add a `userpatches/kernel/<variant>/0000.patching_config.yaml` file in the `userpatches` directory which extends/overrides settings in the Armbian-build provided  `patch/kernel/<variant>/0000.patching_config.yaml`.

# Documentation summary for feature / change

I'm not sure if documentation is really needed, since this change makes the build system more consistent with respect to adding patches in the userpatches folder.

# How Has This Been Tested?

Add a `userpatches/kernel/<variant>/0000.patching_config.yaml` file and make sure that it changes/overrides settings from the original `patch/kernel/<variant>/0000.patching_config.yaml`.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration loading now merges settings from all provided configuration files, ensuring values from multiple files are applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->