### PR TITLE
Introduce including user provided first-boot config at build time

### DIFF
--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -109,6 +109,12 @@ function install_distribution_agnostic() {
 	# display welcome message at first root login which is ready by /usr/sbin/armbian/armbian-firstlogin
 	touch "${SDCARD}"/root/.not_logged_in_yet
 
+	# use user provided firstboot config
+	if [[ -f "${USERPATCHES_PATH}/firstboot.conf" ]]; then
+		display_alert "Use user provided firstboot config" "" "info"
+		cp "${USERPATCHES_PATH}/firstboot.conf" "${SDCARD}"/root/.not_logged_in_yet
+	fi
+
 	if [[ ${DESKTOP_AUTOLOGIN} == yes ]]; then
 		# set desktop autologin
 		touch "${SDCARD}"/root/.desktop_autologin


### PR DESCRIPTION
# Description

Inserting `firstboot.conf` from `userpatches/` folder. 

# Documentation summary for feature / change

Config usage: https://docs.armbian.com/User-Guide_Autoconfig/

# How Has This Been Tested?

- [x] Generating SDK images https://github.com/armbian/sdk (images does automatic user creation, locales, ...)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for user-provided firstboot configuration. When detected, the system displays an informational alert and applies the configuration before enabling desktop autologin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->