### PR TITLE
nanopi-m5: Fixes the assignment of KERNEL_TARGET in the board configuration file

### DIFF
--- a/config/boards/nanopi-m5.conf
+++ b/config/boards/nanopi-m5.conf
@@ -2,7 +2,7 @@
 BOARD_NAME="NanoPi M5"
 BOARDFAMILY="rk35xx"
 BOOTCONFIG="nanopi-m5-rk3576_defconfig"
-KERNEL_TARGET="vendor, edge" # WIP: current kernel
+KERNEL_TARGET="vendor,edge" # WIP: current kernel
 FULL_DESKTOP="yes"
 ASOUND_STATE="asound.state.nanopi-m5"
 BOOT_LOGO="desktop"


### PR DESCRIPTION
# Description

The space in the KERNEL_TARGET assignment was causing issues. This commit removes the space to ensure the variable is parsed correctly.
