### PR TITLE
rockchip64-edge: fix RK3576 CPU OPP voltages for cpufreq

### DIFF
--- a/patch/kernel/archive/rockchip64-6.16/rk3576-fix-cpu-opp-voltages.patch
+++ b/patch/kernel/archive/rockchip64-6.16/rk3576-fix-cpu-opp-voltages.patch
@@ -1,0 +1,196 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Tue, 30 Sep 2025 16:44:07 +0000
+Subject: [PATCH] arm64: dts: rockchip: fix RK3576 CPU OPP voltages for cpufreq
+
+Fix severe CPU performance issues on RK3576 mainline kernel 6.16 caused
+by incorrect OPP voltage values. Current values are too conservative,
+preventing proper cpufreq scaling and causing suboptimal performance.
+
+Update voltage tables for both CPU clusters based on Rockchip vendor BSP:
+- Increase base voltage from 700mV to 712.5mV for stability
+- Adjust high-frequency OPP voltages for proper scaling
+- Add intermediate frequency points (1920MHz cluster0, 2112MHz cluster1)
+- Remove unstable frequency points
+
+This enables proper CPU frequency scaling and significantly improves
+system performance.
+
+Fixes: 57b1ce903966 ("arm64: dts: rockchip: Add rk3576 SoC base DT")
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ arch/arm64/boot/dts/rockchip/rk3576.dtsi | 54 +++++-----
+ 1 file changed, 28 insertions(+), 26 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3576.dtsi b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+index 8264feec6ba9..09bf1c5f97d7 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+@@ -222,65 +222,67 @@ cluster0_opp_table: opp-table-cluster0 {
+ 		compatible = "operating-points-v2";
+ 		opp-shared;
+ 
+ 		opp-408000000 {
+ 			opp-hz = /bits/ 64 <408000000>;
+-			opp-microvolt = <700000 700000 950000>;
++			opp-microvolt = <712500 712500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-600000000 {
+ 			opp-hz = /bits/ 64 <600000000>;
+-			opp-microvolt = <700000 700000 950000>;
++			opp-microvolt = <712500 712500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-816000000 {
+ 			opp-hz = /bits/ 64 <816000000>;
+-			opp-microvolt = <700000 700000 950000>;
++			opp-microvolt = <712500 712500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-1008000000 {
+ 			opp-hz = /bits/ 64 <1008000000>;
+-			opp-microvolt = <700000 700000 950000>;
++			opp-microvolt = <712500 712500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-1200000000 {
+ 			opp-hz = /bits/ 64 <1200000000>;
+-			opp-microvolt = <700000 700000 950000>;
++			opp-microvolt = <712500 712500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-1416000000 {
+ 			opp-hz = /bits/ 64 <1416000000>;
+-			opp-microvolt = <725000 725000 950000>;
++			opp-microvolt = <712500 712500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-1608000000 {
+ 			opp-hz = /bits/ 64 <1608000000>;
+-			opp-microvolt = <750000 750000 950000>;
++			opp-microvolt = <812500 812500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-1800000000 {
+ 			opp-hz = /bits/ 64 <1800000000>;
+-			opp-microvolt = <825000 825000 950000>;
++			opp-microvolt = <887500 887500 950000>;
+ 			clock-latency-ns = <40000>;
+ 			opp-suspend;
+ 		};
+ 
+-		opp-2016000000 {
+-			opp-hz = /bits/ 64 <2016000000>;
+-			opp-microvolt = <900000 900000 950000>;
++		opp-1920000000 {
++			opp-hz = /bits/ 64 <1920000000>;
++			opp-microvolt = <925000 92500 950000>;
+ 			clock-latency-ns = <40000>;
++			opp-suspend;
+ 		};
+ 
+-		opp-2208000000 {
+-			opp-hz = /bits/ 64 <2208000000>;
++
++		opp-2016000000 {
++			opp-hz = /bits/ 64 <2016000000>;
+ 			opp-microvolt = <950000 950000 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 	};
+ 
+@@ -288,36 +290,36 @@ cluster1_opp_table: opp-table-cluster1 {
+ 		compatible = "operating-points-v2";
+ 		opp-shared;
+ 
+ 		opp-408000000 {
+ 			opp-hz = /bits/ 64 <408000000>;
+-			opp-microvolt = <700000 700000 950000>;
++			opp-microvolt = <712500 712500 950000>;
+ 			clock-latency-ns = <40000>;
+ 			opp-suspend;
+ 		};
+ 
+ 		opp-600000000 {
+ 			opp-hz = /bits/ 64 <600000000>;
+-			opp-microvolt = <700000 700000 950000>;
++			opp-microvolt = <712500 712500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-816000000 {
+ 			opp-hz = /bits/ 64 <816000000>;
+-			opp-microvolt = <700000 700000 950000>;
++			opp-microvolt = <712500 712500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-1008000000 {
+ 			opp-hz = /bits/ 64 <1008000000>;
+-			opp-microvolt = <700000 700000 950000>;
++			opp-microvolt = <712500 712500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-1200000000 {
+ 			opp-hz = /bits/ 64 <1200000000>;
+-			opp-microvolt = <700000 700000 950000>;
++			opp-microvolt = <712500 712500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-1416000000 {
+ 			opp-hz = /bits/ 64 <1416000000>;
+@@ -325,34 +327,34 @@ opp-1416000000 {
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-1608000000 {
+ 			opp-hz = /bits/ 64 <1608000000>;
+-			opp-microvolt = <737500 737500 950000>;
++			opp-microvolt = <725000 725000 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-1800000000 {
+ 			opp-hz = /bits/ 64 <1800000000>;
+-			opp-microvolt = <800000 800000 950000>;
++			opp-microvolt = <825000 825000 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+ 		opp-2016000000 {
+ 			opp-hz = /bits/ 64 <2016000000>;
+-			opp-microvolt = <862500 862500 950000>;
++			opp-microvolt = <887500 887500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+-		opp-2208000000 {
+-			opp-hz = /bits/ 64 <2208000000>;
+-			opp-microvolt = <925000 925000 950000>;
++		opp-2112000000 {
++			opp-hz = /bits/ 64 <2112000000>;
++			opp-microvolt = <937500 937500 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 
+-		opp-2304000000 {
+-			opp-hz = /bits/ 64 <2304000000>;
++		opp-2208000000 {
++			opp-hz = /bits/ 64 <2208000000>;
+ 			opp-microvolt = <950000 950000 950000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 	};
+ 
+-- 
+Armbian


### PR DESCRIPTION
# Description

Fix severe CPU performance issues on RK3576 SoC running mainline kernel 6.16 caused by incorrect Operating Performance Point (OPP) voltage values in the device tree.

The current voltage tables are too conservative and prevent proper cpufreq scaling, resulting in CPU cores stuck at low frequencies and significantly reduced system performance.

This patch updates OPP voltage values for both CPU clusters (Cortex-A53 and Cortex-A72) based on validated values from Rockchip's vendor BSP, enabling proper CPU frequency scaling.

# How Has This Been Tested?

- [x] Tested on RK3576-based board (NanoPi M5)
- [x] Verified cpufreq scaling works properly with ondemand/schedutil governors
- [x] CPU frequencies scale correctly from 408MHz to maximum (2016MHz cluster0, 2208MHz cluster1)
- [x] System stability tested under load at all frequency points
- [x] Temperature and voltage monitoring during stress tests

Before: https://browser.geekbench.com/v6/cpu/14169917
After: https://browser.geekbench.com/v6/cpu/14171819

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings