### PR TITLE
rk3566: fix m2 sata drives

### DIFF
--- a/patch/kernel/archive/rockchip64-6.16/overlay/rockchip-rk3566-sata2.dtso
+++ b/patch/kernel/archive/rockchip64-6.16/overlay/rockchip-rk3566-sata2.dtso
@@ -2,14 +2,6 @@
 /plugin/;
 
 / {
-	fragment@0 {
-		target = <&pcie2x1>;
-
-		__overlay__ {
-			status = "disabled";
-		};
-	};
-
 	fragment@1 {
 		target = <&sata2>;
 


### PR DESCRIPTION
# Description

A person reported in discord that removing the disabling of pcie fragment fixes m2 sata detection.
Cannot test by myself.


# How Has This Been Tested?

- [ ] Hasn't, neither build nor on hw

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
