### PR TITLE
rockchip rk3566: h96-TVbox: prepare i2c Leds to mainline 6.18

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3566-h96-tvbox.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3566-h96-tvbox.dts
@@ -68,11 +68,13 @@
 		linux,rc-map-name = "rc-h96-max-v56";
 	};
 	
-	i2c-display {
+	i2c_aux_display: i2c-aux-display {
 		compatible = "i2c-gpio";
 		sda-gpios = <&gpio0 RK_PB4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		scl-gpios = <&gpio0 RK_PB3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		i2c-gpio,delay-us = <5>;
+		i2c-gpio,sda-output-only;
+		i2c-gpio,scl-output-only;
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -85,95 +87,91 @@
 				#size-cells = <0>;
 				digit@0 {
 					reg = <0>;
-					segments = <1 3>,
-						   <1 1>,
-						   <1 2>,
-						   <1 6>,
-						   <1 4>,
-						   <1 5>,
-						   <1 0>;
+					segments = <4 0>,
+						   <4 1>,
+						   <4 2>,
+						   <4 3>,
+						   <4 4>,
+						   <4 5>,
+						   <4 6>;
 				};
 				digit@1 {
 					reg = <1>;
-					segments = <2 3>,
-						   <2 1>,
-						   <2 2>,
-						   <2 6>,
-						   <2 4>,
-						   <2 5>,
-						   <2 0>;
+					segments = <3 0>,
+						   <3 1>,
+						   <3 2>,
+						   <3 3>,
+						   <3 4>,
+						   <3 5>,
+						   <3 6>;
 				};
 				digit@2 {
 					reg = <2>;
-					segments = <3 3>,
-						   <3 1>,
-						   <3 2>,
-						   <3 6>,
-						   <3 4>,
-						   <3 5>,
-						   <3 0>;
+					segments = <2 0>,
+						   <2 1>,
+						   <2 2>,
+						   <2 3>,
+						   <2 4>,
+						   <2 5>,
+						   <2 6>;
 				};
 				digit@3 {
 					reg = <3>;
-					segments = <4 3>,
-						   <4 1>,
-						   <4 2>,
-						   <4 6>,
-						   <4 4>,
-						   <4 5>,
-						   <4 0>;
+					segments = <1 0>,
+						   <1 1>,
+						   <1 2>,
+						   <1 3>,
+						   <1 4>,
+						   <1 5>,
+						   <1 6>;
 				};
 			};
 
 			leds {
 				#address-cells = <2>;
 				#size-cells = <0>;
-				
+
 				led@0,0 {
 					reg = <0 0>;
 					function = LED_FUNCTION_ALARM;
 				};
-				
+
 				led@0,1 {
 					reg = <0 1>;
-					function = LED_FUNCTION_USB;
+					function = "usb";
+					linux,default-trigger = "usb-host";
 				};
-				
-				led@0,3 {
-					reg = <0 3>;
-					function = "play";
-				};
-				
+
 				led@0,2 {
 					reg = <0 2>;
 					function = "pause";
+					linux,default-trigger = "mmc2";
 				};
-				
+
+				led@0,3 {
+					reg = <0 3>;
+					function = "play";
+					linux,default-trigger = "mmc0";
+				};
+
 				led@0,4 {
 					reg = <0 4>;
 					function = "colon";
 				};
-				
+
 				led@0,5 {
 					reg = <0 5>;
 					function = LED_FUNCTION_LAN;
+					linux,default-trigger = "stmmac-0:00:link";
 				};
-				
+
 				led@0,6 {
 					reg = <0 6>;
 					function = LED_FUNCTION_WLAN;
+					linux,default-trigger = "mmc1";
 				};
 			};
-
 		};
-	};
-
-	fddis_dev {
-		compatible = "fddis_dev";
-		fddis_gpio_clk = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
-		fddis_gpio_dat = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
-		pinctrl-0 = <&dis_ctl_clk &dis_ctl_dat>;
-		status = "okay";
 	};
 
 	spdif_dit: spdif-dit {
@@ -731,16 +729,6 @@
 	headphone {
 		hp_det: hp-det {
 			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_up>;
-		};
-	};
-	
-	fddis_ctr {
-		dis_ctl_clk: dis-ctl-clk {
-			rockchip,pins = <0 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-		
-		dis_ctl_dat: dis-ctl-dat {
-			rockchip,pins = <0 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 };

--- a/patch/kernel/archive/rockchip64-6.17/dt/rk3566-h96-tvbox.dts
+++ b/patch/kernel/archive/rockchip64-6.17/dt/rk3566-h96-tvbox.dts
@@ -62,11 +62,13 @@
 		linux,rc-map-name = "rc-h96-max-v56";
 	};
 
-	i2c-display {
+	i2c_aux_display: i2c-aux-display {
 		compatible = "i2c-gpio";
 		sda-gpios = <&gpio0 RK_PB4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		scl-gpios = <&gpio0 RK_PB3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		i2c-gpio,delay-us = <5>;
+		i2c-gpio,sda-output-only;
+		i2c-gpio,scl-output-only;
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -79,95 +81,91 @@
 				#size-cells = <0>;
 				digit@0 {
 					reg = <0>;
-					segments = <1 3>,
-						   <1 1>,
-						   <1 2>,
-						   <1 6>,
-						   <1 4>,
-						   <1 5>,
-						   <1 0>;
+					segments = <4 0>,
+						   <4 1>,
+						   <4 2>,
+						   <4 3>,
+						   <4 4>,
+						   <4 5>,
+						   <4 6>;
 				};
 				digit@1 {
 					reg = <1>;
-					segments = <2 3>,
-						   <2 1>,
-						   <2 2>,
-						   <2 6>,
-						   <2 4>,
-						   <2 5>,
-						   <2 0>;
+					segments = <3 0>,
+						   <3 1>,
+						   <3 2>,
+						   <3 3>,
+						   <3 4>,
+						   <3 5>,
+						   <3 6>;
 				};
 				digit@2 {
 					reg = <2>;
-					segments = <3 3>,
-						   <3 1>,
-						   <3 2>,
-						   <3 6>,
-						   <3 4>,
-						   <3 5>,
-						   <3 0>;
+					segments = <2 0>,
+						   <2 1>,
+						   <2 2>,
+						   <2 3>,
+						   <2 4>,
+						   <2 5>,
+						   <2 6>;
 				};
 				digit@3 {
 					reg = <3>;
-					segments = <4 3>,
-						   <4 1>,
-						   <4 2>,
-						   <4 6>,
-						   <4 4>,
-						   <4 5>,
-						   <4 0>;
+					segments = <1 0>,
+						   <1 1>,
+						   <1 2>,
+						   <1 3>,
+						   <1 4>,
+						   <1 5>,
+						   <1 6>;
 				};
 			};
 
 			leds {
 				#address-cells = <2>;
 				#size-cells = <0>;
-				
+
 				led@0,0 {
 					reg = <0 0>;
 					function = LED_FUNCTION_ALARM;
 				};
-				
+
 				led@0,1 {
 					reg = <0 1>;
-					function = LED_FUNCTION_USB;
+					function = "usb";
+					linux,default-trigger = "usb-host";
 				};
-				
-				led@0,3 {
-					reg = <0 3>;
-					function = "play";
-				};
-				
+
 				led@0,2 {
 					reg = <0 2>;
 					function = "pause";
+					linux,default-trigger = "mmc2";
 				};
-				
+
+				led@0,3 {
+					reg = <0 3>;
+					function = "play";
+					linux,default-trigger = "mmc0";
+				};
+
 				led@0,4 {
 					reg = <0 4>;
 					function = "colon";
 				};
-				
+
 				led@0,5 {
 					reg = <0 5>;
 					function = LED_FUNCTION_LAN;
+					linux,default-trigger = "stmmac-0:00:link";
 				};
-				
+
 				led@0,6 {
 					reg = <0 6>;
 					function = LED_FUNCTION_WLAN;
+					linux,default-trigger = "mmc1";
 				};
 			};
-
 		};
-	};
-	
-	fddis_dev {
-		compatible = "fddis_dev";
-		fddis_gpio_clk = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
-		fddis_gpio_dat = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
-		pinctrl-0 = <&dis_ctl_clk &dis_ctl_dat>;
-		status = "okay";
 	};
 
 	spdif_dit: spdif-dit {
@@ -725,16 +723,6 @@
 	headphone {
 		hp_det: hp-det {
 			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_up>;
-		};
-	};
-	
-	fddis_ctr {
-		dis_ctl_clk: dis-ctl-clk {
-			rockchip,pins = <0 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-		
-		dis_ctl_dat: dis-ctl-dat {
-			rockchip,pins = <0 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 };

--- a/patch/kernel/archive/rockchip64-6.6/dt/rk3566-h96-tvbox.dts
+++ b/patch/kernel/archive/rockchip64-6.6/dt/rk3566-h96-tvbox.dts
@@ -68,11 +68,13 @@
 		linux,rc-map-name = "rc-h96-max-v56";
 	};
 
-	i2c-display {
+	i2c_aux_display: i2c-aux-display {
 		compatible = "i2c-gpio";
 		sda-gpios = <&gpio0 RK_PB4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		scl-gpios = <&gpio0 RK_PB3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		i2c-gpio,delay-us = <5>;
+		i2c-gpio,sda-output-only;
+		i2c-gpio,scl-output-only;
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -85,95 +87,91 @@
 				#size-cells = <0>;
 				digit@0 {
 					reg = <0>;
-					segments = <1 3>,
-						   <1 1>,
-						   <1 2>,
-						   <1 6>,
-						   <1 4>,
-						   <1 5>,
-						   <1 0>;
+					segments = <4 0>,
+						   <4 1>,
+						   <4 2>,
+						   <4 3>,
+						   <4 4>,
+						   <4 5>,
+						   <4 6>;
 				};
 				digit@1 {
 					reg = <1>;
-					segments = <2 3>,
-						   <2 1>,
-						   <2 2>,
-						   <2 6>,
-						   <2 4>,
-						   <2 5>,
-						   <2 0>;
+					segments = <3 0>,
+						   <3 1>,
+						   <3 2>,
+						   <3 3>,
+						   <3 4>,
+						   <3 5>,
+						   <3 6>;
 				};
 				digit@2 {
 					reg = <2>;
-					segments = <3 3>,
-						   <3 1>,
-						   <3 2>,
-						   <3 6>,
-						   <3 4>,
-						   <3 5>,
-						   <3 0>;
+					segments = <2 0>,
+						   <2 1>,
+						   <2 2>,
+						   <2 3>,
+						   <2 4>,
+						   <2 5>,
+						   <2 6>;
 				};
 				digit@3 {
 					reg = <3>;
-					segments = <4 3>,
-						   <4 1>,
-						   <4 2>,
-						   <4 6>,
-						   <4 4>,
-						   <4 5>,
-						   <4 0>;
+					segments = <1 0>,
+						   <1 1>,
+						   <1 2>,
+						   <1 3>,
+						   <1 4>,
+						   <1 5>,
+						   <1 6>;
 				};
 			};
 
 			leds {
 				#address-cells = <2>;
 				#size-cells = <0>;
-				
+
 				led@0,0 {
 					reg = <0 0>;
 					function = LED_FUNCTION_ALARM;
 				};
-				
+
 				led@0,1 {
 					reg = <0 1>;
-					function = LED_FUNCTION_USB;
+					function = "usb";
+					linux,default-trigger = "usb-host";
 				};
-				
-				led@0,3 {
-					reg = <0 3>;
-					function = "play";
-				};
-				
+
 				led@0,2 {
 					reg = <0 2>;
 					function = "pause";
+					linux,default-trigger = "mmc2";
 				};
-				
+
+				led@0,3 {
+					reg = <0 3>;
+					function = "play";
+					linux,default-trigger = "mmc0";
+				};
+
 				led@0,4 {
 					reg = <0 4>;
 					function = "colon";
 				};
-				
+
 				led@0,5 {
 					reg = <0 5>;
 					function = LED_FUNCTION_LAN;
+					linux,default-trigger = "stmmac-0:00:link";
 				};
-				
+
 				led@0,6 {
 					reg = <0 6>;
 					function = LED_FUNCTION_WLAN;
+					linux,default-trigger = "mmc1";
 				};
 			};
-
 		};
-	};
-	
-	fddis_dev {
-		compatible = "fddis_dev";
-		fddis_gpio_clk = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
-		fddis_gpio_dat = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
-		pinctrl-0 = <&dis_ctl_clk &dis_ctl_dat>;
-		status = "okay";
 	};
 
 	spdif_dit: spdif-dit {
@@ -731,16 +729,6 @@
 	headphone {
 		hp_det: hp-det {
 			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_up>;
-		};
-	};
-	
-	fddis_ctr {
-		dis_ctl_clk: dis-ctl-clk {
-			rockchip,pins = <0 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-		
-		dis_ctl_dat: dis-ctl-dat {
-			rockchip,pins = <0 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 };

--- a/patch/kernel/archive/rockchip64-6.9/dt/rk3566-h96-tvbox.dts
+++ b/patch/kernel/archive/rockchip64-6.9/dt/rk3566-h96-tvbox.dts
@@ -62,11 +62,13 @@
 		linux,rc-map-name = "rc-h96-max-v56";
 	};
 
-	i2c-display {
+	i2c_aux_display: i2c-aux-display {
 		compatible = "i2c-gpio";
 		sda-gpios = <&gpio0 RK_PB4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		scl-gpios = <&gpio0 RK_PB3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		i2c-gpio,delay-us = <5>;
+		i2c-gpio,sda-output-only;
+		i2c-gpio,scl-output-only;
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -79,95 +81,91 @@
 				#size-cells = <0>;
 				digit@0 {
 					reg = <0>;
-					segments = <1 3>,
-						   <1 1>,
-						   <1 2>,
-						   <1 6>,
-						   <1 4>,
-						   <1 5>,
-						   <1 0>;
+					segments = <4 0>,
+						   <4 1>,
+						   <4 2>,
+						   <4 3>,
+						   <4 4>,
+						   <4 5>,
+						   <4 6>;
 				};
 				digit@1 {
 					reg = <1>;
-					segments = <2 3>,
-						   <2 1>,
-						   <2 2>,
-						   <2 6>,
-						   <2 4>,
-						   <2 5>,
-						   <2 0>;
+					segments = <3 0>,
+						   <3 1>,
+						   <3 2>,
+						   <3 3>,
+						   <3 4>,
+						   <3 5>,
+						   <3 6>;
 				};
 				digit@2 {
 					reg = <2>;
-					segments = <3 3>,
-						   <3 1>,
-						   <3 2>,
-						   <3 6>,
-						   <3 4>,
-						   <3 5>,
-						   <3 0>;
+					segments = <2 0>,
+						   <2 1>,
+						   <2 2>,
+						   <2 3>,
+						   <2 4>,
+						   <2 5>,
+						   <2 6>;
 				};
 				digit@3 {
 					reg = <3>;
-					segments = <4 3>,
-						   <4 1>,
-						   <4 2>,
-						   <4 6>,
-						   <4 4>,
-						   <4 5>,
-						   <4 0>;
+					segments = <1 0>,
+						   <1 1>,
+						   <1 2>,
+						   <1 3>,
+						   <1 4>,
+						   <1 5>,
+						   <1 6>;
 				};
 			};
 
 			leds {
 				#address-cells = <2>;
 				#size-cells = <0>;
-				
+
 				led@0,0 {
 					reg = <0 0>;
 					function = LED_FUNCTION_ALARM;
 				};
-				
+
 				led@0,1 {
 					reg = <0 1>;
-					function = LED_FUNCTION_USB;
+					function = "usb";
+					linux,default-trigger = "usb-host";
 				};
-				
-				led@0,3 {
-					reg = <0 3>;
-					function = "play";
-				};
-				
+
 				led@0,2 {
 					reg = <0 2>;
 					function = "pause";
+					linux,default-trigger = "mmc2";
 				};
-				
+
+				led@0,3 {
+					reg = <0 3>;
+					function = "play";
+					linux,default-trigger = "mmc0";
+				};
+
 				led@0,4 {
 					reg = <0 4>;
 					function = "colon";
 				};
-				
+
 				led@0,5 {
 					reg = <0 5>;
 					function = LED_FUNCTION_LAN;
+					linux,default-trigger = "stmmac-0:00:link";
 				};
-				
+
 				led@0,6 {
 					reg = <0 6>;
 					function = LED_FUNCTION_WLAN;
+					linux,default-trigger = "mmc1";
 				};
 			};
-
 		};
-	};
-	
-	fddis_dev {
-		compatible = "fddis_dev";
-		fddis_gpio_clk = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
-		fddis_gpio_dat = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
-		pinctrl-0 = <&dis_ctl_clk &dis_ctl_dat>;
-		status = "okay";
 	};
 
 	spdif_dit: spdif-dit {
@@ -725,16 +723,6 @@
 	headphone {
 		hp_det: hp-det {
 			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_up>;
-		};
-	};
-	
-	fddis_ctr {
-		dis_ctl_clk: dis-ctl-clk {
-			rockchip,pins = <0 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-		
-		dis_ctl_dat: dis-ctl-dat {
-			rockchip,pins = <0 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 };


### PR DESCRIPTION
# Description

Aligning h96-max-v56 device tree code for updates coming from mainline 6.18
@jefflessard

https://lwn.net/ml/all/20250926141913.25919-1-jefflessard3@gmail.com/

Armbian drivers enabled:
https://github.com/armbian/build/pull/8679

# Documentation summary for feature / change

# How Has This Been Tested?

- [Kernel 6.16 with 6.18 patches for i2c](https://forum.armbian.com/topic/43667-help-wanted-to-test-a-new-openvfd-alternative/page/5/#findComment-226414)

# Checklist:
- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] My changes generate no new warnings
- [ X ] Any dependent changes have been merged and published in downstream modules
