### PR TITLE
Stop unintended suspend on GNOME desktop images (logind IdleAction override + sane GNOME power defaults)

### DIFF
--- a/config/desktop/bookworm/environments/gnome/debian/postinst
+++ b/config/desktop/bookworm/environments/gnome/debian/postinst
@@ -19,7 +19,10 @@ primary-color='#456789'
 secondary-color='#FFFFFF'
 
 [org/gnome/settings-daemon/plugins/power]
+sleep-inactive-ac-type='nothing'
+sleep-inactive-battery-type='nothing'
 sleep-inactive-ac-timeout='0'
+sleep-inactive-battery-timeout='0'
 
 [org/gnome/desktop/screensaver]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'

--- a/config/desktop/common/environments/gnome/debian/postinst
+++ b/config/desktop/common/environments/gnome/debian/postinst
@@ -18,7 +18,10 @@ echo "
 favorite-apps = ['terminator.desktop', 'org.gnome.Nautilus.desktop', 'google-chrome.desktop', 'thunderbird.desktop', 'code.desktop', 'Zoom.desktop']
 
 [org/gnome/settings-daemon/plugins/power]
+sleep-inactive-ac-type='nothing'
+sleep-inactive-battery-type='nothing'
 sleep-inactive-ac-timeout='0'
+sleep-inactive-battery-timeout='0'
 
 [org/gnome/desktop/background]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'

--- a/config/desktop/trixie/environments/gnome/debian/postinst
+++ b/config/desktop/trixie/environments/gnome/debian/postinst
@@ -19,7 +19,10 @@ primary-color='#456789'
 secondary-color='#FFFFFF'
 
 [org/gnome/settings-daemon/plugins/power]
+sleep-inactive-ac-type='nothing'
+sleep-inactive-battery-type='nothing'
 sleep-inactive-ac-timeout='0'
+sleep-inactive-battery-timeout='0'
 
 [org/gnome/desktop/screensaver]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -35,6 +35,21 @@ function install_distribution_specific() {
 		truncate --size=0 "${SDCARD}"/etc/apt/apt.conf.d/20apt-esm-hook.conf
 	fi
 
+	# power management override on systemd level
+	# we want to prevent system going into suspend
+	mkdir -p "${SDCARD}/etc/systemd/logind.conf.d"
+	cat <<- EOF > "${SDCARD}/etc/systemd/logind.conf.d/90-nosuspend.conf"
+	[Login]
+	HandleLidSwitch=ignore
+	HandleLidSwitchExternalPower=ignore
+	HandleLidSwitchDocked=ignore
+	IdleAction=ignore
+	IdleActionSec=0
+	HandleSuspendKey=ignore
+	HandleHibernateKey=ignore
+	HandlePowerKey=ignore
+	EOF
+
 	# install our base-files package (this replaces the original from Debian/Ubuntu)
 	if [[ "${KEEP_ORIGINAL_OS_RELEASE:-"no"}" != "yes" ]]; then
 		install_artifact_deb_chroot "armbian-base-files" "--allow-downgrades"


### PR DESCRIPTION
# Description

On the GNOME desktop image some systems still suspend after idle, even when the GNOME UI is set to “never.” Journals show systemd-logind initiating suspend (The system will suspend now!), which means system-wide logind IdleAction is firing. Minimal/CLI images don’t show this behavior.

# What’s included

- Systemd/logind policy override (system-wide)
- GNOME per-user defaults (best effort)

# Scope

- Affects: GNOME desktop images only.
- Unchanged: Minimal/CLI images.

# How Has This Been Tested?

Verify logind policy

```
systemd-analyze cat-config systemd/logind.conf
loginctl show-logind | egrep 'IdleAction|Handle(Lid|Power|Suspend|Hibernate)'
```

Expect: IdleAction=ignore and lid switches ignore.

Verify GNOME defaults (as desktop user)

```
gsettings get org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type
gsettings get org.gnome.settings-daemon.plugins.power sleep-inactive-battery-type
gsettings get org.gnome.settings-daemon.plugins.power sleep-inactive-ac-timeout
gsettings get org.gnome.settings-daemon.plugins.power sleep-inactive-battery-timeout

```

Expect: 'nothing' and 0.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
