### PR TITLE
rockchip64: Use HS200 mode for eMMC on NanoPC-T6 to fix I/O errors

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/rk3588-1053-board-nanopc-t6-emmc-use-hs200-mode.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk3588-1053-board-nanopc-t6-emmc-use-hs200-mode.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kingsley Jarrett <kj@kingj.net>
+Date: Mon, 6 Oct 2025 21:17:18 +0000
+Subject: rockchip64: Use HS200 mode for eMMC on NanoPC-T6 to fix I/O errors
+
+Signed-off-by: Kingsley Jarrett <kj@kingj.net>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+index ea105dbe0df2..123d72add087 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -669,12 +669,11 @@ &sdhci {
+ 	bus-width = <8>;
+ 	no-sdio;
+ 	no-sd;
+ 	non-removable;
+ 	max-frequency = <200000000>;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
++	mmc-hs200-1_8v;
+ 	status = "okay";
+ };
+ 
+ &sdmmc {
+ 	bus-width = <4>;
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION


# Description

The A3A444 eMMC chip used on some FriendlyElec NanoPC-T6 boards does not work well in HS400 mode, causing corruption and I/O errors. Therefore, downgrade to HS200 mode to improve stability.

This is a similar change to one made recently on the OpenWRT project:

* https://github.com/openwrt/openwrt/issues/18844
* https://github.com/openwrt/openwrt/pull/19926

There's some more details on [my post on the Armbian forum](https://forum.armbian.com/topic/55503-nanopc-t6-emmc-io-errors-under-heavy-load-due-to-hs400-mode/).

This is the first time i've raised a change to Armbian, or submitted any kernel patches, so there's a chance i've done something wrong!

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Manually decompiled the device tree, applied this patch, then recompiled the device tree on my device. No I/O errors observed afterwards, even under heavy I/O load.


# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
