### PR TITLE
rk3566: fix m2 sata drives

### DIFF
--- a/patch/kernel/archive/rockchip64-6.17/overlay/rockchip-rk3566-sata2.dtso
+++ b/patch/kernel/archive/rockchip64-6.17/overlay/rockchip-rk3566-sata2.dtso
@@ -2,14 +2,6 @@
 /plugin/;
 
 / {
-	fragment@0 {
-		target = <&pcie2x1>;
-
-		__overlay__ {
-			status = "disabled";
-		};
-	};
-
 	fragment@1 {
 		target = <&sata2>;
 


### PR DESCRIPTION
# Description

Same as https://github.com/armbian/build/pull/8706 but for rockchip64-6.17

A person reported in discord that removing the disabling of pcie fragment fixes m2 sata detection.
Cannot test by myself.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]


# How Has This Been Tested?

- [x] build kernel for rock-3c as random rk3566 device
- [ ] boot: nope, no hw, cannot test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
