### PR TITLE
don't fail distro agnostic sshd adjustments when config is not found

### DIFF
--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -487,7 +487,7 @@ function install_distribution_agnostic() {
 		echo "nameserver $NAMESERVER" > "${SDCARD}"/etc/resolvconf/resolv.conf.d/head
 	fi
 
-	# don't fail if dropbear is used instead of OpenSSH
+	# don't fail if OpenSSH is missing, e.g. if dropbear is installed instead
 	if [[ -f "${SDCARD}"/etc/ssh/sshd_config ]]; then
 		# permit root login via SSH for the first boot
 		sed -i 's/#\?PermitRootLogin .*/PermitRootLogin yes/' "${SDCARD}"/etc/ssh/sshd_config


### PR DESCRIPTION
# Description

This will allow building without openssh-server package installed. Some people may want to use dropbear instead or no ssh at all.
If it is insisted to have an ssh daemon by default, this could later be hardened again to check for dropbear or sshd config and only fail if neither is found.

# How Has This Been Tested?

- [x] build random image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
