### PR TITLE
extensions: radxa-aic8800: allow 6.17; skip DKMS only on >= 6.18

### DIFF
--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -10,7 +10,7 @@ function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
 function post_install_kernel_debs__install_aic8800_dkms_package() {
 
-	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.17; then
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.18; then
 		display_alert "Kernel version is too recent" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi


### PR DESCRIPTION
The upstream driver in radxa-pkg/aic8800 builds successfully against Linux 6.17. Relax the version guard so we only skip installing the aic8800 DKMS package on kernels >= 6.18.

Relax radxa-aic8800's build restriction (skip >= 6.17 to skip >= 6.18) to allow it to be built on 6.17.
As [raxda-pkg/aic8800](https://github.com/radxa-pkg/aic8800) have [fixed its build for linux 6.17](https://github.com/radxa-pkg/aic8800/commit/0061531da3f8ace187e44fd374b4414c38870bb4). 

Fix: https://github.com/armbian/build/issues/8732

# How Has This Been Tested?

- [x] In another PR https://github.com/armbian/build/pull/8665 I have built a board against 6.17.0 using the following board config. Log: https://paste.next.armbian.com/esativazit

```conf
ENABLE_EXTENSIONS="radxa-aic8800"
AIC8800_TYPE="usb"
```

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
