### PR TITLE
rockchip64: current: fix display mode patches for rk3588 boards

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/board-pbp-add-dp-alt-mode.patch
+++ b/patch/kernel/archive/rockchip64-6.12/board-pbp-add-dp-alt-mode.patch
@@ -276,7 +276,7 @@ index 111111111111..222222222222 100644
  					*response_tx_sop_type = TCPC_TX_SOP_PRIME;
  					response[0] = VDO(USB_SID_PD, 1,
  							  typec_get_cable_svdm_version(typec),
-@@ -4401,6 +4443,7 @@ static void tcpm_typec_disconnect(struct tcpm_port *port)
+@@ -4405,6 +4447,7 @@ static void tcpm_typec_disconnect(struct tcpm_port *port)
  	port->cable = NULL;
  	if (port->connected) {
  		if (port->partner) {
@@ -284,7 +284,7 @@ index 111111111111..222222222222 100644
  			typec_partner_set_usb_power_delivery(port->partner, NULL);
  			typec_unregister_partner(port->partner);
  			port->partner = NULL;
-@@ -4495,6 +4538,8 @@ static void tcpm_detach(struct tcpm_port *port)
+@@ -4499,6 +4542,8 @@ static void tcpm_detach(struct tcpm_port *port)
  	}
  
  	tcpm_reset_port(port);
@@ -293,7 +293,7 @@ index 111111111111..222222222222 100644
  }
  
  static void tcpm_src_detach(struct tcpm_port *port)
-@@ -7124,6 +7169,64 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
+@@ -7128,6 +7173,64 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
  	return ret;
  }
  
@@ -358,7 +358,7 @@ index 111111111111..222222222222 100644
  static int tcpm_fw_get_caps(struct tcpm_port *port, struct fwnode_handle *fwnode)
  {
  	struct fwnode_handle *capabilities, *child, *caps = NULL;
-@@ -7137,6 +7240,23 @@ static int tcpm_fw_get_caps(struct tcpm_port *port, struct fwnode_handle *fwnode
+@@ -7141,6 +7244,23 @@ static int tcpm_fw_get_caps(struct tcpm_port *port, struct fwnode_handle *fwnode
  	if (!fwnode)
  		return -EINVAL;
  
@@ -382,7 +382,7 @@ index 111111111111..222222222222 100644
  	/*
  	 * This fwnode has a "compatible" property, but is never populated as a
  	 * struct device. Instead we simply parse it to read the properties.
-@@ -7682,6 +7802,17 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
+@@ -7686,6 +7806,17 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
  		goto out_destroy_wq;
  
  	port->try_role = port->typec_caps.prefer_role;
@@ -400,7 +400,7 @@ index 111111111111..222222222222 100644
  
  	port->typec_caps.revision = 0x0120;	/* Type-C spec release 1.2 */
  	port->typec_caps.pd_revision = 0x0300;	/* USB-PD spec release 3.0 */
-@@ -7725,6 +7856,12 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
+@@ -7729,6 +7860,12 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
  				      &tcpm_cable_ops);
  	port->registered = true;
  

--- a/patch/kernel/archive/rockchip64-6.12/rk3399-rp64-pcie-Reimplement-rockchip-PCIe-bus-scan-delay.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk3399-rp64-pcie-Reimplement-rockchip-PCIe-bus-scan-delay.patch
@@ -77,7 +77,7 @@ diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/adm
 index 111111111111..222222222222 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
-@@ -4724,6 +4724,14 @@
+@@ -4725,6 +4725,14 @@
  		nomsi	Do not use MSI for native PCIe PME signaling (this makes
  			all PCIe root ports use INTx for all services).
  

--- a/patch/kernel/archive/rockchip64-6.12/rk3588-0135-arm64-dts-rockchip-Add-HDMI0-bridge-CLK-to-rk3588.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk3588-0135-arm64-dts-rockchip-Add-HDMI0-bridge-CLK-to-rk3588.patch
@@ -68,7 +68,7 @@ Armbian
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 16 Jan 2024 03:13:38 +0200
-Subject: [WIP] arm64: dts: rockchip: Enable HDMI0 PHY clk provider on rk3588
+Subject: arm64: dts: rockchip: Enable HDMI0 PHY clk provider on rk3588
 
 The HDMI0 PHY can be used as a clock provider on RK3588, hence add the
 missing #clock-cells property.
@@ -88,6 +88,42 @@ index 111111111111..222222222222 100644
  		#phy-cells = <0>;
  		resets = <&cru SRST_HDPTX0>, <&cru SRST_P_HDPTX0>,
  			 <&cru SRST_HDPTX0_INIT>, <&cru SRST_HDPTX0_CMN>,
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Wed, 8 Oct 2025 20:14:53 +0200
+Subject: arm64: dts: rockchip: Add HDMI0 PHY PLL clock source to VOP2 on
+ RK3588
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588-base.dtsi | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -1261,14 +1261,16 @@ vop: vop@fdd90000 {
+ 			 <&cru DCLK_VOP1>,
+ 			 <&cru DCLK_VOP2>,
+ 			 <&cru DCLK_VOP3>,
+-			 <&cru PCLK_VOP_ROOT>;
++			 <&cru PCLK_VOP_ROOT>,
++			 <&hdptxphy_hdmi0>;
+ 		clock-names = "aclk",
+ 			      "hclk",
+ 			      "dclk_vp0",
+ 			      "dclk_vp1",
+ 			      "dclk_vp2",
+ 			      "dclk_vp3",
+-			      "pclk_vop";
++			      "pclk_vop",
++			      "pll_hdmiphy0";
+ 		iommus = <&vop_mmu>;
+ 		power-domains = <&power RK3588_PD_VOP>;
+ 		rockchip,grf = <&sys_grf>;
 -- 
 Armbian
 

--- a/patch/kernel/archive/rockchip64-6.12/rk3588-0170-drm-rockchip-vop2-add-clocks-reset-support.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk3588-0170-drm-rockchip-vop2-add-clocks-reset-support.patch
@@ -167,8 +167,8 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-@@ -1271,6 +1271,14 @@ vop: vop@fdd90000 {
- 			      "pclk_vop";
+@@ -1273,6 +1273,14 @@ vop: vop@fdd90000 {
+ 			      "pll_hdmiphy0";
  		iommus = <&vop_mmu>;
  		power-domains = <&power RK3588_PD_VOP>;
 +		resets = <&cru SRST_D_VOP0>,

--- a/patch/kernel/archive/rockchip64-6.12/rk35xx-montjoie-crypto-v2-rk35xx.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk35xx-montjoie-crypto-v2-rk35xx.patch
@@ -102,7 +102,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-@@ -1927,6 +1927,18 @@ sdhci: mmc@fe2e0000 {
+@@ -1929,6 +1929,18 @@ sdhci: mmc@fe2e0000 {
  		status = "disabled";
  	};
  


### PR DESCRIPTION
# Description

This PR fixes display modes problem for rk3588 boards occurred after merging of https://patchwork.freedesktop.org/patch/635308/ to 6.12 with some missing devicetree parts.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?
- [x] Tested with Nanopi R6S and Khadas Edge 2

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
