### PR TITLE
rockchip: dts: rk3588-nanopc-t6: disable HS400 Enhanced Strobe

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/rk3588-1054-board-nanopc-t6-fix-A3A444-eMMC-HS400-enhanced-strobe.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk3588-1054-board-nanopc-t6-fix-A3A444-eMMC-HS400-enhanced-strobe.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Thu, 9 Oct 2025 10:52:24 +0000
+Subject: arm64: dts: rockchip: rk3588-nanopc-t6: disable HS400-ES for FORESEE A3A444
+
+The FORESEE A3A444 eMMC (manfid 0x0000d6) exhibits I/O errors under
+sustained heavy load when operating in HS400 Enhanced Strobe mode.
+The chip's data strobe output shows timing instability that causes
+read failures after extended operation, particularly under thermal
+stress.
+
+Disable Enhanced Strobe and retain standard HS400 mode, which uses
+host-controlled sampling instead of device-generated strobe signal.
+This should maintains the same ~400MB/s throughput while eliminating I/O
+errors under load.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+index 30fc1ebf6fac..9990ace10ee2 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -752,11 +752,13 @@ &sdhci {
+ 	no-sdio;
+ 	no-sd;
+ 	non-removable;
+ 	max-frequency = <200000000>;
+ 	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
++	/delete-property/ mmc-hs400-enhanced-strobe;
++	pinctrl-0 = <&emmc_rstnout>, <&emmc_bus8>, <&emmc_clk>,
++		<&emmc_cmd>;
+ 	status = "okay";
+ };
+ 
+ &sdmmc {
+ 	bus-width = <4>;
+-- 
+Armbian 
+

--- a/patch/kernel/archive/rockchip64-6.17/rk3588-1053-board-nanopc-t6-fix-A3A444-eMMC-HS400-enhanced-strobe.patch
+++ b/patch/kernel/archive/rockchip64-6.17/rk3588-1053-board-nanopc-t6-fix-A3A444-eMMC-HS400-enhanced-strobe.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Thu, 9 Oct 2025 10:52:24 +0000
+Subject: arm64: dts: rockchip: rk3588-nanopc-t6: disable HS400-ES for FORESEE A3A444
+
+The FORESEE A3A444 eMMC (manfid 0x0000d6) exhibits I/O errors under
+sustained heavy load when operating in HS400 Enhanced Strobe mode.
+The chip's data strobe output shows timing instability that causes
+read failures after extended operation, particularly under thermal
+stress.
+
+Disable Enhanced Strobe and retain standard HS400 mode, which uses
+host-controlled sampling instead of device-generated strobe signal.
+This should maintains the same ~400MB/s throughput while eliminating I/O
+errors under load.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+index 30fc1ebf6fac..9990ace10ee2 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -752,11 +752,13 @@ &sdhci {
+ 	no-sdio;
+ 	no-sd;
+ 	non-removable;
+ 	max-frequency = <200000000>;
+ 	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
++	/delete-property/ mmc-hs400-enhanced-strobe;
++	pinctrl-0 = <&emmc_rstnout>, <&emmc_bus8>, <&emmc_clk>,
++		<&emmc_cmd>;
+ 	status = "okay";
+ };
+ 
+ &sdmmc {
+ 	bus-width = <4>;
+-- 
+Armbian 
+


### PR DESCRIPTION
# Description

Fix eMMC I/O errors under heavy load on NanoPC-T6 / LTS boards equipped with FORESEE A3A444 eMMC chip.

The A3A444 eMMC exhibits sector read/write failures when operating in HS400 Enhanced Strobe mode under sustained I/O load. Errors manifest after extended operation due to timing instability in the device-generated data strobe signal.

This patch disables HS400 Enhanced Strobe while maintaining standard HS400 mode at 200MHz, using host-controlled clock sampling. while eliminating I/O errors.

**Affected kernels**: `edge` (6.17.x) and `current` (6.12.x)

**Related**:
- [Armbian Forum Discussion](https://forum.armbian.com/topic/55503-nanopc-t6-emmc-io-errors-under-heavy-load-due-to-hs400-mode/)
- #8725 

## Changes

- Remove `mmc-hs400-enhanced-strobe` property from sdhci node

# How Has This Been Tested?

- [x] **Stress test**: Continuous I/O operations (apt upgrade, dd writes, compilation)
- [x] **Verification**: `dmesg | grep mmc` confirms `HS400` mode active (timing spec: 9), Enhanced Strobe disabled

**Test hardware**: NanoPC-T6 LTS with 64GB eMMC

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
