### PR TITLE
rockchip64: Add Kernel overlay to reduce eMMC frequency for FriendlyElec NanoPC-T6 boards

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/Makefile
@@ -94,7 +94,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-uart7-m2.dtbo \
 	rockchip-rk3588-uart8-m1.dtbo \
 	rockchip-rk3588-rkvenc-overlay.dtbo \
-	rockchip-rk3588-nanopi-m6-spi-nor-flash.dtbo
+	rockchip-rk3588-nanopi-m6-spi-nor-flash.dtbo \
+	rockchip-rk3588-nanopc-t6-mmc-frequency.dtbo
 
 scr-$(CONFIG_ARCH_ROCKCHIP) += \
        rockchip-fixup.scr

--- a/patch/kernel/archive/rockchip64-6.12/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/README.rockchip-overlays
@@ -261,3 +261,13 @@ overlay enables (overclocked) operation at 1.3ghz
 1.3Ghz operation appears stable on the two boards I've tested.
 
 The legacy kernel is not supported on the Rock S0
+
+**********************************
+Details for NanoPC-T6 overlays  (11 Oct 2025):
+
+### rockchip-rk3588-nanopc-t6-mmc-frequency
+
+Some NanoPC-T6 boards use a A3A444 eMMC chip. Under heavy I/O load when running
+in HS400 mode, this will often result in I/O errors.
+Reducing the eMMC frequency from the default 200000000 Hz to 150000000 Hz improves
+stability and eliminates the I/O errors.

--- a/patch/kernel/archive/rockchip64-6.12/overlay/rockchip-rk3588-nanopc-t6-mmc-frequency.dtso
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/rockchip-rk3588-nanopc-t6-mmc-frequency.dtso
@@ -1,0 +1,12 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&sdhci>;
+		__overlay__ {
+			status = "okay";
+			max-frequency = <150000000>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip64-6.17/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.17/overlay/Makefile
@@ -97,6 +97,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-rkvenc-overlay.dtbo \
 	rockchip-rk3588-nanopi-m6-spi-nor-flash.dtbo \
 	rockchip-rk3588-nanopi-m6-display-dsi1-yx35.dtbo \
+	rockchip-rk3588-nanopc-t6-mmc-frequency.dtbo
 
 scr-$(CONFIG_ARCH_ROCKCHIP) += \
        rockchip-fixup.scr

--- a/patch/kernel/archive/rockchip64-6.17/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.17/overlay/README.rockchip-overlays
@@ -251,3 +251,13 @@ The legacy kernel is not supported on the Rock S0
 
 Enable pcm5102a analog codec connected to i2s0 bus:
 ### rk3308-pcm5102a
+
+**********************************
+Details for NanoPC-T6 overlays  (11 Oct 2025):
+
+### rockchip-rk3588-nanopc-t6-mmc-frequency
+
+Some NanoPC-T6 boards use a A3A444 eMMC chip. Under heavy I/O load when running
+in HS400 mode, this will often result in I/O errors.
+Reducing the eMMC frequency from the default 200000000 Hz to 150000000 Hz improves
+stability and eliminates the I/O errors.

--- a/patch/kernel/archive/rockchip64-6.17/overlay/rockchip-rk3588-nanopc-t6-mmc-frequency.dtso
+++ b/patch/kernel/archive/rockchip64-6.17/overlay/rockchip-rk3588-nanopc-t6-mmc-frequency.dtso
@@ -1,0 +1,12 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&sdhci>;
+		__overlay__ {
+			status = "okay";
+			max-frequency = <150000000>;
+		};
+	};
+};


### PR DESCRIPTION


# Description

Some FriendlyElec NanoPC-T6 boards use a A3A444 eMMC chip. Under heavy I/O load when running in HS400 mode, this will often result in I/O errors.

Reducing the eMMC frequency from the default 200000000 Hz to 150000000 Hz improves stability and eliminates the I/O errors.

This PR is an alternative to:

* https://github.com/armbian/build/pull/8725 - which reduced the eMMC mode to HS200 for all NanoPC-T6 boards, even if they didn't use the A3A444 eMMC chip.
* https://github.com/armbian/build/pull/8736 - which disabled HS400 enhanced strobe mode for all NanoPC-T6 boards, which did not resolve the I/O errors.

@SuperKali suggested reducing the frequency, and this was successful. As this is easy to change via an overlay, add it as an overlay so that any users with a A3A444 eMMC chip on this board can opt-in to it.

# Documentation summary for feature / change

Documentation has been added to `README.rockchip-overlays`. However, it wasn't clear to me as to how this file should be structured. Therefore, i've added it to the end of the file emulating the recent "Rock S0 overlays" documentation.

# How Has This Been Tested?


- [x] Manually applied this overlay to my NanoPC-T6 board. [No errors observed during a test which generates heavy I/O](https://github.com/armbian/build/pull/8736#issuecomment-3387760536).


# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
