### PR TITLE
rename rtc99 to rtc1 in the dts of some boards

### DIFF
--- a/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -21,7 +21,7 @@
 	aliases {
 		serial0 = &uart_AO;
 		ethernet0 = &ethmac;
-		rtc99 = &vrtc;
+		rtc1 = &vrtc;
 	};
 
 	chosen {

--- a/patch/kernel/archive/meson64-6.17/dt/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/patch/kernel/archive/meson64-6.17/dt/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -21,7 +21,7 @@
 	aliases {
 		serial0 = &uart_AO;
 		ethernet0 = &ethmac;
-		rtc99 = &vrtc;
+		rtc1 = &vrtc;
 	};
 
 	chosen {

--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3399-am40.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3399-am40.dts
@@ -22,9 +22,9 @@
 		rtc0 = &pt7c4563;
 		/*
 		 * The rk808 circuit design on this board does not have the ability to maintain real-time time after a power outage.
-		 * Registering rk808 as rtc99 (most kernel configurations read time from rtc0) can prevent the kernel from reading the time (2013) from rk808 during startup.
+		 * Registering rk808 as rtc1 (most kernel configurations read time from rtc0) can prevent the kernel from reading the time (2013) from rk808 during startup.
 		 */
-		rtc99 = &rk808;
+		rtc1 = &rk808;
 	};
 
 	chosen {

--- a/patch/kernel/archive/rockchip64-6.17/dt/rk3399-am40.dts
+++ b/patch/kernel/archive/rockchip64-6.17/dt/rk3399-am40.dts
@@ -22,9 +22,9 @@
 		rtc0 = &pt7c4563;
 		/*
 		 * The rk808 circuit design on this board does not have the ability to maintain real-time time after a power outage.
-		 * Registering rk808 as rtc99 (most kernel configurations read time from rtc0) can prevent the kernel from reading the time (2013) from rk808 during startup.
+		 * Registering rk808 as rtc1 (most kernel configurations read time from rtc0) can prevent the kernel from reading the time (2013) from rk808 during startup.
 		 */
-		rtc99 = &rk808;
+		rtc1 = &rk808;
 	};
 
 	chosen {

--- a/patch/u-boot/v2025.04/board_cainiao-cniot-core/add-board-cainiao-cniot-core.patch
+++ b/patch/u-boot/v2025.04/board_cainiao-cniot-core/add-board-cainiao-cniot-core.patch
@@ -155,7 +155,7 @@ index 00000000..1907347f
 +	aliases {
 +		serial0 = &uart_AO;
 +		ethernet0 = &ethmac;
-+		rtc99 = &vrtc;
++		rtc1 = &vrtc;
 +	};
 +
 +	chosen {

--- a/patch/u-boot/v2025.04/board_smart-am40/add-board-smart-am40.patch
+++ b/patch/u-boot/v2025.04/board_smart-am40/add-board-smart-am40.patch
@@ -122,9 +122,9 @@ index 00000000..195ad794
 +		rtc0 = &pt7c4563;
 +		/*
 +		 * The rk808 circuit design on this board does not have the ability to maintain real-time time after a power outage.
-+		 * Registering rk808 as rtc99 (most kernel configurations read time from rtc0) can prevent the kernel from reading the time (2013) from rk808 during startup.
++		 * Registering rk808 as rtc1 (most kernel configurations read time from rtc0) can prevent the kernel from reading the time (2013) from rk808 during startup.
 +		 */
-+		rtc99 = &rk808;
++		rtc1 = &rk808;
 +	};
 +
 +	chosen {


### PR DESCRIPTION
These RTCs don't have any practical function. If registered as rtc0, the device will read incorrect time from them every boot. Previously, I registered them as rtc99. Later, I noticed that most SBCs register such invalid RTCs as rtc1, while the actual functional RTC is registered as rtc0 (since most kernel configurations are set to read the time from rtc0 at boot).