### PR TITLE
build machinery - fixup compilation for uboot/atf BRANCH=edge, pass --no-warn-rwx-segments to linker, not compiler

### DIFF
--- a/lib/functions/compilation/atf.sh
+++ b/lib/functions/compilation/atf.sh
@@ -74,8 +74,8 @@ compile_atf() {
 		display_alert "Binutils version for ATF" ">= 2.39 and < 2.42, adding -Wl,--no-warn-rwx-segment" "info"
 		binutils_flags_atf="-Wl,--no-warn-rwx-segment"
 	elif linux-version compare "${binutils_version}" ge "2.42"; then
-		display_alert "Binutils version for ATF" ">= 2.42, adding --no-warn-rwx-segments" "info"
-		binutils_flags_atf="--no-warn-rwx-segments"
+		display_alert "Binutils version for ATF" ">= 2.42, adding -Wl,--no-warn-rwx-segments" "info"
+		binutils_flags_atf="-Wl,--no-warn-rwx-segments"
 	fi
  
 	# - ENABLE_BACKTRACE="0" has been added to workaround a regression in ATF. Check: https://github.com/armbian/build/issues/1157


### PR DESCRIPTION
# Description

Fix apparent error from armbian/build#8583
https://paste.armbian.com/owuwetikov <-- error
```
[🐳|🔨]   aarch64-linux-gnu-gcc: error: unrecognized command-line option ‘--no-warn-rwx-segments’
[🐳|🔨]   make: *** [Makefile:1669: /armbian/cache/sources/arm-trusted-firmware/v2.13.0/build/rk3399/release/bl31/bl31.elf] Error 1
```

from several sources [see below for links], plus the line one block up, `--no-warn-rwx-segments` needs to be prefixed with `-Wl,` so it goes to the linker, not the compiler/driver.

note the usage with `-Wl,` appears correct per 
https://groups.google.com/g/efibootguard-dev/c/-9IHhl4XeRQ
and 
https://build.opensuse.org/projects/home:lalala123:x86_succeed_pro/packages/arm-trusted-firmware/files/arm-trusted-firmware.spec?expand=0 line 235

This has been shown to break/fix-breakage with `BOARD=bananapir4` [where I found it related to #8746] & `BOARD=nanopct4`

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh uboot BRANCH=edge` build succeeds

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
-