### PR TITLE
bsp armbian-ramlog - move HDD_LOG declaration before sourcing /etc/default/armbian-ramlog

### DIFF
--- a/packages/bsp/common/etc/default/armbian-ramlog.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-ramlog.dpkg-dist
@@ -22,4 +22,7 @@ USE_RSYNC=true
 # likely a good idea.
 #XTRA_RSYNC_TO=(--delete)
 XTRA_RSYNC_FROM=()
-XTRA_RSYNC_FROM=()
+
+# uncomment/change this if you want to move the long-term log storage
+# e.g. to use NVMe.
+#HDD_LOG=/mnt/nvme/log

--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -9,6 +9,7 @@
 SIZE=50M
 USE_RSYNC=true
 ENABLED=false
+HDD_LOG=/var/log.hdd
 
 [ -f /etc/default/armbian-ramlog ] && . /etc/default/armbian-ramlog
 
@@ -16,7 +17,6 @@ ENABLED=false
 
 # Never touch anything below here. Only edit /etc/default/armbian-ramlog
 
-HDD_LOG=/var/log.hdd
 RAM_LOG=/var/log
 LOG2RAM_LOG="${HDD_LOG}/armbian-ramlog.log"
 LOG_OUTPUT="tee -a $LOG2RAM_LOG"
@@ -111,9 +111,11 @@ check_if_installed () {
 case "$1" in
 	start)
 		[ -d $HDD_LOG ] || mkdir -p $HDD_LOG
-		mount --bind $RAM_LOG $HDD_LOG
-		mount --make-private $HDD_LOG
-		
+		if [ "$HDD_LOG" == "/var/log.hdd" ]; then
+			mount --bind $RAM_LOG $HDD_LOG
+			mount --make-private $HDD_LOG
+		fi
+
 		# Check whether zram device is available or we need to use tmpfs
 		LOG_TYPE="tmpfs"
 		for rd in /dev/zram*; do
@@ -139,13 +141,15 @@ case "$1" in
 	stop)
 		syncToDisk
 		umount -l $RAM_LOG
-		umount -l $HDD_LOG
+		if [ "$HDD_LOG" == "/var/log.hdd" ]; then
+			umount -l $HDD_LOG
+		fi
 		;;
 	write)
 		syncToDisk
 		;;
 	postrotate)
-		cd /var/log.hdd/
+		cd $HDD_LOG
 		find . -type f -print | grep -E -v "(\.gz|\.xz|\.[0-9]|armbian-ramlog)|\.journal" | while IFS= read -r  file
 		do
 	    		dest="/var/log/$file"


### PR DESCRIPTION
# Description

By moving `HDD_LOG` before we source `/etc/default/armbian-ramlog`, we allow it to be overridden; e.g. if we want the system on eMMC but we want `/var/log` on NVMe.

Note: without the `if` blocks around the `mount` calls, `/proc/mounts` consistently shows `HDD_LOG` on the rootfs' block-device. That defeats the purpose. 

# Documentation summary for feature / change

there is nothing in `armbian/documentation` for `armbian-ramlog` now.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] handpatched on a host, rebooted. using `/srv/log`, for which `/srv` is on NVMe.
