### PR TITLE
Add warning for rockchip uboot on modern hosts

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -44,6 +44,15 @@ esac
 
 prepare_boot_configuration
 
+pre_config_uboot_target() {
+	# Check if building Radxa U-Boot on a host other than Ubuntu Jammy
+	if [[ "${BOOTSOURCE}" == "https://github.com/radxa/u-boot.git" ]]; then
+		if [[ "${HOSTRELEASE}" != "jammy" ]]; then
+			display_alert "Building Rockchip BSP U-Boot from Radxa repository" "on Ubuntu ${HOSTRELEASE} (newer than Jammy) can lead to unintended bugs" "wrn"
+		fi
+	fi
+}
+
 family_tweaks_bsp() {
 	:
 }

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -42,6 +42,15 @@ esac
 
 prepare_boot_configuration
 
+pre_config_uboot_target() {
+	# Check if building Radxa U-Boot on a host other than Ubuntu Jammy
+	if [[ "${BOOTSOURCE}" == "https://github.com/radxa/u-boot.git" ]]; then
+		if [[ "${HOSTRELEASE}" != "jammy" ]]; then
+			display_alert "Building Rockchip BSP U-Boot from Radxa repository" "on Ubuntu ${HOSTRELEASE} (newer than Jammy) can lead to unintended bugs" "wrn"
+		fi
+	fi
+}
+
 family_tweaks_bsp() {
 	:
 }


### PR DESCRIPTION
# Description

Add simple warning to keep in mind that not all rockchip uboot aspects work correct on >Jammy hosts. Related to #8227 

One example being UFS boot on RK3576 which only works when compiled on Jammy hosts.
