### PR TITLE
opi5plus - board config maintenance

### DIFF
--- a/config/boards/orangepi5-plus.conf
+++ b/config/boards/orangepi5-plus.conf
@@ -27,7 +27,7 @@ function post_family_tweaks__orangepi5plus_naming_audios() {
 
 	return 0
 }
-# Mainline U-Boot for edge kernel
+
 function post_family_config__orangepi5plus_use_mainline_uboot() {
 	[[ "${BRANCH}" == "vendor" ]] && return 0 # skip for vendor branch
 


### PR DESCRIPTION
# Description

- Bump uboot for both _current_ and _edge_ to v2025.10.
- consoldidate/simplify board config
- re-enable previously broken stuff

Note: It might be possible to get rid of _vendor_ uboot altogether. Needs further testing though.

# How Has This Been Tested?

- [x] build uboot package
- [x] boot from microSD with edge kernel, but w/o crypto options yet
- [x] boot from SPI with vendor kernel on nvme, but w/o crypto options yet

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
