### PR TITLE
rk35xx: fix pre_config_uboot_target prevent board-specific hooks from running

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -44,7 +44,7 @@ esac
 
 prepare_boot_configuration
 
-pre_config_uboot_target() {
+pre_config_uboot_target__warn_modern_hosts() {
 	# Check if building Radxa U-Boot on a host other than Ubuntu Jammy
 	if [[ "${BOOTSOURCE}" == "https://github.com/radxa/u-boot.git" ]]; then
 		if [[ "${HOSTRELEASE}" != "jammy" ]]; then

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -42,7 +42,7 @@ esac
 
 prepare_boot_configuration
 
-pre_config_uboot_target() {
+pre_config_uboot_target__warn_modern_hosts() {
 	# Check if building Radxa U-Boot on a host other than Ubuntu Jammy
 	if [[ "${BOOTSOURCE}" == "https://github.com/radxa/u-boot.git" ]]; then
 		if [[ "${HOSTRELEASE}" != "jammy" ]]; then


### PR DESCRIPTION
# Description

This PR fixes the problem i mentioned in https://github.com/armbian/build/pull/8783#issuecomment-3427485498

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?
- [x] Opi5 edge/current uboot now compiles.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
