### PR TITLE
cm3588-nas: bump u-boot to v2025.10 final

### DIFF
--- a/config/boards/cm3588-nas.csc
+++ b/config/boards/cm3588-nas.csc
@@ -43,7 +43,7 @@ function post_family_config__cm3588_nas_use_mainline_uboot() {
 
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline U-Boot
-	declare -g BOOTBRANCH="tag:v2025.10-rc4"
+	declare -g BOOTBRANCH="tag:v2025.10"
 	declare -g BOOTPATCHDIR="v2025.10"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"


### PR DESCRIPTION
#### cm3588-nas: bump u-boot to v2025.10 final

- cm3588-nas: u-boot: bump 2025.01 -> 2025.10-rc4
- cm3588-nas: bump u-boot to v2025.10 final