### PR TITLE
fix(armbian-firstlogin): Enable wlan dhcp by default

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -51,8 +51,6 @@ createYAML() {
    local YAML="network:\n"
     YAML+="  $DEVTYPE:\n"
     YAML+="    $DEVICE_NAME:\n"
-	if [[ "${PRESET_NET_USE_STATIC}" == 0 ]]; then		YAML+="      dhcp4: yes\n";fi
-	if [[ "${PRESET_NET_USE_STATIC}" == 0 ]]; then		YAML+="      dhcp6: yes\n";fi
 	if [[ "${PRESET_NET_USE_STATIC}" == 1 ]]; then
 		YAML+="      addresses:\n"
 		YAML+="        - $PRESET_NET_STATIC_IP/$PRESET_NET_STATIC_MASK\n"
@@ -61,6 +59,9 @@ createYAML() {
 		if [[ -n "${PRESET_NET_STATIC_GATEWAY}" ]]; then   YAML+="          via: ${PRESET_NET_STATIC_GATEWAY}\n";fi
 		if [[ -n "${PRESET_NET_STATIC_DNS}" ]]; then       YAML+="      nameservers:\n"; fi
 		if [[ -n "${PRESET_NET_STATIC_DNS}" ]]; then       YAML+="        addresses: [$PRESET_NET_STATIC_DNS]\n"; fi
+	else
+		YAML+="      dhcp4: yes\n"
+		YAML+="      dhcp6: yes\n"
 	fi
 	if [[ "${PRESET_NET_WIFI_ENABLED}" == 1 ]]; then
 		if [[ -n "${PRESET_NET_WIFI_COUNTRYCODE}" ]]; then YAML+="      regulatory-domain: $PRESET_NET_WIFI_COUNTRYCODE\n"; fi


### PR DESCRIPTION
Currently, WLAN DHCP is only enabled when the value of PRESET_NET_USE_STATIC is explicitly set to 0. It is not enabled when this configuration is uncommented or omitted. This change adjusts the behavior so that DHCP is enabled by default unless a static network configuration is used.

# Description

Addresses issue #8808

[Jira](https://armbian.atlassian.net/browse/AR-2769) reference number [AR-2769]

# How Has This Been Tested?

__TBD__


[AR-2769]: https://armbian.atlassian.net/browse/AR-2769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ