### PR TITLE
build framework - MANAGE_ACNG, allow to specify your own mirror/URL

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -53,6 +53,15 @@ function create_new_rootfs_cache_via_debootstrap() {
 	if [[ "${MANAGE_ACNG}" == "yes" ]]; then
 		local debootstrap_apt_mirror="http://localhost:3142/${APT_MIRROR}"
 		acng_check_status_or_restart
+	elif [[ "${MANAGE_ACNG}" == "no" ]]; then
+		: # do nothing
+	else
+		if [[ ! "${MANAGE_ACNG}" =~ ^https?:// ]]; then
+			exit_with_error "MANAGE_ACNG must be yes/no OR be a full URL with http/https" "${MANAGE_ACNG}"
+		else
+			# FIXME: although this works with mmdebstrap, there's a more idiomatic way with `--aptopt`
+			local debootstrap_apt_mirror="${MANAGE_ACNG}/${APT_MIRROR}"
+		fi
 	fi
 
 	# @TODO: one day: https://gitlab.mister-muffin.de/josch/mmdebstrap/src/branch/main/mmdebstrap


### PR DESCRIPTION
# Description

It's tiny, it's toony, but hopefully it's not considered loony! 🐇🦆🐷🐈🐔

This modifies the `MANAGE_ACNG` build switch from a strict boolean, allowing it to contain the string for a locally managed `apt-cacher-ng` instance.

# Documentation summary for feature / change

armbian/documentation#835

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] ran a test build
- [x] also tested it with #8785 `mmdebstrap`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
