### PR TITLE
build framework - MANAGE_ACNG - allow switch to be empty

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -50,19 +50,24 @@ function create_new_rootfs_cache_via_debootstrap() {
 
 	# this is different between debootstrap and regular apt-get; here we use acng as a prefix to the real repo
 	declare debootstrap_apt_mirror="http://${APT_MIRROR}"
-	if [[ "${MANAGE_ACNG}" == "yes" ]]; then
-		local debootstrap_apt_mirror="http://localhost:3142/${APT_MIRROR}"
-		acng_check_status_or_restart
-	elif [[ "${MANAGE_ACNG}" == "no" ]]; then
-		: # do nothing
-	else
-		if [[ ! "${MANAGE_ACNG}" =~ ^https?:// ]]; then
-			exit_with_error "MANAGE_ACNG must be yes/no OR be a full URL with http/https" "${MANAGE_ACNG}"
-		else
-			# FIXME: although this works with mmdebstrap, there's a more idiomatic way with `--aptopt`
-			local debootstrap_apt_mirror="${MANAGE_ACNG}/${APT_MIRROR}"
-		fi
-	fi
+	case "${MANAGE_ACNG}" in
+		yes)
+			local debootstrap_apt_mirror="http://localhost:3142/${APT_MIRROR}"
+			acng_check_status_or_restart
+			;;
+		no)     ;& # do nothing, fallthrough
+		"")
+			:  # still do nothing
+			;; # stop falling
+		*)
+			if [[ ! "${MANAGE_ACNG}" =~ ^https?:// ]]; then
+				exit_with_error "MANAGE_ACNG must be yes/no OR be a full URL with http/https" "${MANAGE_ACNG}"
+			else
+				# FIXME: although this works with mmdebstrap, there's a more idiomatic way with `--aptopt`
+				local debootstrap_apt_mirror="${MANAGE_ACNG}/${APT_MIRROR}"
+			fi
+			;;
+	esac
 
 	# @TODO: one day: https://gitlab.mister-muffin.de/josch/mmdebstrap/src/branch/main/mmdebstrap
 


### PR DESCRIPTION
# Description

followup/bugfix  to #8811.
right now, if you do not specify `MANAGE_ACNG=no` it bombs out over the variable being empty.

Note, if you view the diff with whitespace changes hidden, it's more obvious nothing substantial has changed.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] basic build with `MANAGE_ACNG` not specified
