### PR TITLE
Github issues config: fix broken link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -19,5 +19,5 @@ contact_links:
     url: https://github.com/armbian/configng/issues/new
     about: Utility for configuring your board, adjusting services and installing applications.
   - name: Issue with infrastructure
-    url: https://github.com/armbian/mirror/issues/new
+    url: https://github.com/armbian/armbian-router/issues/new
     about: Broken download links or just slow download


### PR DESCRIPTION
# Description

Since we deprecate mirror repository, issues can't be open for infra anymore. GitHub issue: Closing https://github.com/armbian/build/issues/8821

# Checklist:

- [x] I have performed a self-review of my own code