### PR TITLE
rockchip: Add CSC board Luckfox Lyra Plus + adjust RK3506 BOOT_SOC

### DIFF
--- a/config/boards/luckfox-lyra-plus.csc
+++ b/config/boards/luckfox-lyra-plus.csc
@@ -1,0 +1,15 @@
+# Rockchip RK3506G2 triple core 128MB SoC 1x100MBe NAND SD USB2
+BOARD_NAME="Luckfox Lyra Plus"
+BOARDFAMILY="rockchip"
+BOOTCONFIG="luckfox-lyra-rk3506_defconfig"
+BOARD_MAINTAINER="vidplace7"
+KERNEL_TARGET="vendor"
+BOOT_FDT_FILE="rk3506g-luckfox-lyra-plus-sd.dtb"
+BOOT_SCENARIO="spl-blobs"
+IMAGE_PARTITION_TABLE="gpt"
+SERIALCON="ttyFIQ0"
+BOOT_SOC="rk3506"
+DDR_BLOB="rk35/rk3506_ddr_750MHz_v1.06.bin"
+
+# Board only has 128MB RAM; use 'lowmem' extension to optimize for this.
+enable_extension "lowmem"

--- a/config/bootenv/rk3506.txt
+++ b/config/bootenv/rk3506.txt
@@ -1,0 +1,3 @@
+verbosity=1
+extraargs=coherent_pool=4M
+bootlogo=false

--- a/config/bootscripts/boot-rk3506.cmd
+++ b/config/bootscripts/boot-rk3506.cmd
@@ -4,6 +4,7 @@
 #
 
 setenv load_addr "0x2000000"
+setenv ramdisk_addr_r "0x02800000"
 setenv overlay_error "false"
 # default values
 setenv rootdev "/dev/mmcblk0p1"

--- a/config/sources/families/rockchip.conf
+++ b/config/sources/families/rockchip.conf
@@ -14,7 +14,7 @@ BOOT_SOC=${BOOT_SOC:="rk3288"}
 
 ARCH=armhf
 BOOTDELAY=1
-SERIALCON=ttyS2
+SERIALCON=${SERIALCON:="ttyS2"}
 RKBIN_DIR="$SRC/cache/sources/rkbin-tools"
 if [[ "$BOOT_SOC" == "rk3288" ]]; then
 
@@ -48,7 +48,7 @@ elif [[ "$BOOT_SOC" == "rk322x" ]]; then
 elif [[ "$BOOT_SOC" == "rk3506" ]]; then
 
 	BOOTSCRIPT="boot-rk3506.cmd:boot.cmd"
-	BOOTENV_FILE='rockchip.txt'
+	BOOTENV_FILE='rk3506.txt'
 	OVERLAY_PREFIX='rockchip'
 	OFFSET=16
 	DDR_BLOB="${DDR_BLOB:-"rk35/rk3506_ddr_750MHz_v1.06.bin"}"


### PR DESCRIPTION
# Description

Add new RK3506 CSC board "Luckfox Lyra Plus".
Additionally, tweaks RK3506 BOOT_SOC-specific settings to allow RK3506g2 to boot. (Else fails with memory allocation issues)

Depends on:
- https://github.com/armbian/linux-rockchip/pull/411

Relates to:
- https://github.com/armbian/build/pull/8839

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- `./compile.sh BOARD=luckfox-lyra-plus BRANCH=vendor KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes INSTALL_ARMBIAN_FIRMWARE=yes BUILD_DESKTOP=no BUILD_MINIMAL=yes RELEASE=trixie`
- Luckfox Lyra Plus boots, shell works over UART0
- Ethernet working
- Boot from SD working

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules