### PR TITLE
IMX8: fix ATF build error (again)

### DIFF
--- a/patch/atf/atf-imx8/0001-fix-needed-by-armbian-build-system.patch
+++ b/patch/atf/atf-imx8/0001-fix-needed-by-armbian-build-system.patch
@@ -1,4 +1,4 @@
-From 230e25fbcd0a36dfaaa8f3b9f0ad7d9cd0500736 Mon Sep 17 00:00:00 2001
+From 5b8d60b91f18b31343ee26f25d1ec7c70ce9187e Mon Sep 17 00:00:00 2001
 From: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 Date: Wed, 28 May 2025 14:02:39 +0200
 Subject: [PATCH] fix needed by armbian build system
@@ -11,7 +11,7 @@ Signed-off-by: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
  1 file changed, 4 insertions(+)
 
 diff --git a/Makefile b/Makefile
-index ea5701347..7a4ff1244 100644
+index ea5701347..5213a1199 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -343,6 +343,10 @@ GCC_V_OUTPUT		:=	$(shell $(CC) -v 2>&1)
@@ -19,7 +19,7 @@ index ea5701347..7a4ff1244 100644
  TF_LDFLAGS		+=	-z noexecstack
  
 +# remove possibly contained gcc linker flags we use the linker directly
-+gcc_linker_flags        =	-Wl,--no-warn-rwx-segment
++gcc_linker_flags        =	-Wl,--no-warn-rwx-segments -Wl,--no-warn-rwx-segment
 +TF_LDFLAGS		:= 	$(filter-out $(gcc_linker_flags), $(TF_LDFLAGS))
 +
  # LD = armlink


### PR DESCRIPTION
# Description

- fixes: unrecognized option '-Wl,--no-warn-rwx-segment(s)'
- adjust patch to atf that removes the unrecognized linker options

# How Has This Been Tested?

Compile ATF with both Boards:

- [x] `./compile.sh uboot ARTIFACT_IGNORE_CACHE=yes BOARD=mba8mpxl BRANCH=current`
- [x] `./compile.sh uboot ARTIFACT_IGNORE_CACHE=yes BOARD=mba8mpxl-ras314 BRANCH=current`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
