### PR TITLE
add description for .conf

### DIFF
--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -156,8 +156,9 @@ function interactive_config_ask_board_list() {
 		if [[ $STATUS == 3 ]]; then
 			if [[ $WIP_STATE == supported ]]; then
 				[[ $SHOW_WARNING == yes ]] && show_developer_warning
-				STATE_DESCRIPTION=' - \Z1(CSC)\Zn - Community Supported Configuration\n - \Z1(WIP)\Zn - Work In Progress
-				\n - \Z1(EOS)\Zn - End Of Support\n - \Z1(TVB)\Zn - TV boxes'
+				STATE_DESCRIPTION=' - \Z1(conf)\Zn - Boards with high level of software maturity
+				\n - \Z1(CSC)\Zn  - Community Supported Configuration\n - \Z1(WIP)\Zn  - Work In Progress
+				\n - \Z1(EOS)\Zn  - End Of Support\n - \Z1(TVB)\Zn  - TV boxes'
 				WIP_STATE=unsupported
 				WIP_BUTTON='matured'
 				EXPERT=yes


### PR DESCRIPTION
# Description

Either when selecting all boards in interactive mode or starting with `EXPERT=yes` all boards are listed. However there is no description what `(conf)` means.

# How Has This Been Tested?

- [x] Run ./compile.sh and select all boards

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
