### PR TITLE
Kernel config rewrite: use our strong servers for matrix generation

### DIFF
--- a/.github/workflows/rewrite-kernel-configs.yml
+++ b/.github/workflows/rewrite-kernel-configs.yml
@@ -270,8 +270,6 @@ jobs:
             echo
             printf "**Files:** %d  •  **Lines:** +%d / -%d  (Δ %d)\n" "$files" "$total_add" "$total_del" "$(( total_add - total_del ))"
             echo
-            echo "@coderabbitai review"
-            echo
 
             if compgen -G "output/info/annotated-configs/*.md" > /dev/null; then
               echo "## Annotated configs"


### PR DESCRIPTION
Matrix generation should ran on our infra as its significantly faster then on GitHub runners.