### PR TITLE
meson64-6.18: temporary patch for pcie vs aspm woes on Amlogic

### DIFF
--- a/patch/kernel/archive/meson64-6.18/temporary-6.18-rc4-temporary-fix-for-pcie-probe-failure-due-to.patch
+++ b/patch/kernel/archive/meson64-6.18/temporary-6.18-rc4-temporary-fix-for-pcie-probe-failure-due-to.patch
@@ -1,0 +1,88 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 3 Nov 2025 21:02:03 +0100
+Subject: 6.18-rc4: temporary fixes for pcie probe failure due to ASPM stuff
+
+- https://lore.kernel.org/linux-amlogic/20251031161323.GA1688975@bhelgaas/
+- https://lists.infradead.org/pipermail/linux-amlogic/2025-November/025692.html
+---
+ arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi |  2 +-
+ drivers/pci/controller/dwc/pci-meson.c            | 42 +---------
+ 2 files changed, 5 insertions(+), 39 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
+@@ -138,7 +138,7 @@ pcie: pcie@fc000000 {
+ 			reg = <0x0 0xfc000000 0x0 0x400000>,
+ 			      <0x0 0xff648000 0x0 0x2000>,
+ 			      <0x0 0xfc400000 0x0 0x200000>;
+-			reg-names = "elbi", "cfg", "config";
++			reg-names = "dbi", "cfg", "config";
+ 			interrupts = <GIC_SPI 221 IRQ_TYPE_LEVEL_HIGH>;
+ 			#interrupt-cells = <1>;
+ 			interrupt-map-mask = <0 0 0 0>;
+diff --git a/drivers/pci/controller/dwc/pci-meson.c b/drivers/pci/controller/dwc/pci-meson.c
+index 111111111111..222222222222 100644
+--- a/drivers/pci/controller/dwc/pci-meson.c
++++ b/drivers/pci/controller/dwc/pci-meson.c
+@@ -109,10 +109,6 @@ static int meson_pcie_get_mems(struct platform_device *pdev,
+ {
+ 	struct dw_pcie *pci = &mp->pci;
+ 
+-	pci->dbi_base = devm_platform_ioremap_resource_byname(pdev, "elbi");
+-	if (IS_ERR(pci->dbi_base))
+-		return PTR_ERR(pci->dbi_base);
+-
+ 	mp->cfg_base = devm_platform_ioremap_resource_byname(pdev, "cfg");
+ 	if (IS_ERR(mp->cfg_base))
+ 		return PTR_ERR(mp->cfg_base);
+@@ -338,40 +334,10 @@ static struct pci_ops meson_pci_ops = {
+ static bool meson_pcie_link_up(struct dw_pcie *pci)
+ {
+ 	struct meson_pcie *mp = to_meson_pcie(pci);
+-	struct device *dev = pci->dev;
+-	u32 speed_okay = 0;
+-	u32 cnt = 0;
+-	u32 state12, state17, smlh_up, ltssm_up, rdlh_up;
+-
+-	do {
+-		state12 = meson_cfg_readl(mp, PCIE_CFG_STATUS12);
+-		state17 = meson_cfg_readl(mp, PCIE_CFG_STATUS17);
+-		smlh_up = IS_SMLH_LINK_UP(state12);
+-		rdlh_up = IS_RDLH_LINK_UP(state12);
+-		ltssm_up = IS_LTSSM_UP(state12);
+-
+-		if (PM_CURRENT_STATE(state17) < PCIE_GEN3)
+-			speed_okay = 1;
+-
+-		if (smlh_up)
+-			dev_dbg(dev, "smlh_link_up is on\n");
+-		if (rdlh_up)
+-			dev_dbg(dev, "rdlh_link_up is on\n");
+-		if (ltssm_up)
+-			dev_dbg(dev, "ltssm_up is on\n");
+-		if (speed_okay)
+-			dev_dbg(dev, "speed_okay\n");
+-
+-		if (smlh_up && rdlh_up && ltssm_up && speed_okay)
+-			return true;
+-
+-		cnt++;
+-
+-		udelay(10);
+-	} while (cnt < WAIT_LINKUP_TIMEOUT);
+-
+-	dev_err(dev, "error: wait linkup timeout\n");
+-	return false;
++	u32 state12;
++
++	state12 = meson_cfg_readl(mp, PCIE_CFG_STATUS12);
++	return IS_SMLH_LINK_UP(state12) && IS_RDLH_LINK_UP(state12);
+ }
+ 
+ static int meson_pcie_host_init(struct dw_pcie_rp *pp)
+-- 
+Armbian
+


### PR DESCRIPTION
- See https://lore.kernel.org/linux-amlogic/20251031161323.GA1688975@bhelgaas/
  - and Neil's https://lists.infradead.org/pipermail/linux-amlogic/2025-November/025692.html