### PR TITLE
ti: extensions: ti-debpkgs: Switch pkg install from rootfs to image

### DIFF
--- a/extensions/ti-debpkgs.sh
+++ b/extensions/ti-debpkgs.sh
@@ -1,6 +1,6 @@
 function extension_prepare_config__add_packages() {
 	if [[ ${#TI_PACKAGES[@]} -gt 0 ]] ; then
-		add_packages_to_rootfs "${TI_PACKAGES[@]}"
+		add_packages_to_image "${TI_PACKAGES[@]}"
 	fi
 }
 


### PR DESCRIPTION
# Description

Per request of @igorpecovnik, this switches TI debian packages to be added to the image package list instead of being cached in the rootfs. Our previous use of `add_packages_to_rootfs` had caused immediate miss on any cached/standard rootfs, which this commit fixes.

# How Has This Been Tested?

- [x] SK-AM62B - [build log](https://paste.armbian.com/gerorihefu)
- [x] SK-AM62P - [build log](https://paste.armbian.com/bupokihipe)
- [x] SK-AM64B - [build log](https://paste.armbian.com/kimeqoguse)
- [x] SK-AM68 - [build log](https://paste.armbian.com/ilituvevup)
- [x] SK-AM69 - [build log](https://paste.armbian.com/dusepegale)
- [x] SK-TDA4VM - [build log](https://paste.armbian.com/qonucaveka)

Note: the git status changes in the logs are proxy-related only.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (as far as I can tell)
