### PR TITLE
ti: configs: boards: Rename boards to <SoC>-<board>.conf

### DIFF
--- a/config/boards/am62-sk.conf
+++ b/config/boards/am62-sk.conf
@@ -1,13 +1,13 @@
-# TI AM62P quad core 8GB 2xGBE OSPI HDMI
+# Texas Instruments AM62 quad core 2GB 2xGBE OSPI HDMI
 
-BOARD_NAME="SK-AM62P"
+BOARD_NAME="AM62-SK"
 BOARDFAMILY="k3"
 BOARD_MAINTAINER="jonaswood01"
-BOOTCONFIG="am62px_evm_a53_defconfig"
+BOOTCONFIG="am62x_evm_a53_defconfig"
 BOOTFS_TYPE="fat"
-BOOT_FDT_FILE="ti/k3-am62p5-sk.dts"
-TIBOOT3_BOOTCONFIG="am62px_evm_r5_defconfig"
-TIBOOT3_FILE="tiboot3-am62px-hs-fs-evm.bin"
+BOOT_FDT_FILE="ti/k3-am625-sk.dts"
+TIBOOT3_BOOTCONFIG="am62x_evm_r5_defconfig"
+TIBOOT3_FILE="tiboot3-am62x-hs-fs-evm.bin"
 DEFAULT_CONSOLE="serial"
 KERNEL_TARGET="current,edge"
 KERNEL_TEST_TARGET="current"

--- a/config/boards/am62p-sk.conf
+++ b/config/boards/am62p-sk.conf
@@ -1,13 +1,13 @@
-# TI AM62 quad core 2GB 2xGBE OSPI HDMI
+# Texas Instruments AM62P quad core 8GB 2xGBE OSPI HDMI
 
-BOARD_NAME="SK-AM62B"
+BOARD_NAME="AM62P-SK"
 BOARDFAMILY="k3"
 BOARD_MAINTAINER="jonaswood01"
-BOOTCONFIG="am62x_evm_a53_defconfig"
+BOOTCONFIG="am62px_evm_a53_defconfig"
 BOOTFS_TYPE="fat"
-BOOT_FDT_FILE="ti/k3-am625-sk.dts"
-TIBOOT3_BOOTCONFIG="am62x_evm_r5_defconfig"
-TIBOOT3_FILE="tiboot3-am62x-hs-fs-evm.bin"
+BOOT_FDT_FILE="ti/k3-am62p5-sk.dts"
+TIBOOT3_BOOTCONFIG="am62px_evm_r5_defconfig"
+TIBOOT3_FILE="tiboot3-am62px-hs-fs-evm.bin"
 DEFAULT_CONSOLE="serial"
 KERNEL_TARGET="current,edge"
 KERNEL_TEST_TARGET="current"

--- a/config/boards/am64-sk.conf
+++ b/config/boards/am64-sk.conf
@@ -1,6 +1,6 @@
-# TI AM64 dual core 2GB 2xGBE USB3 WiFi OSPI
+# Texas Instruments AM64 dual core 2GB 2xGBE USB3 WiFi OSPI
 
-BOARD_NAME="SK-AM64B"
+BOARD_NAME="AM64-SK"
 BOARDFAMILY="k3"
 BOARD_MAINTAINER="jonaswood01"
 BOOTCONFIG="am64x_evm_a53_defconfig"

--- a/config/boards/am68-sk.conf
+++ b/config/boards/am68-sk.conf
@@ -1,6 +1,6 @@
-# TI SK-AM68 dual core 16GB 8TOPS GBE USB3 OSPI DisplayPort HDMI
+# Texas Instruments AM68 dual core 16GB 8TOPS GBE USB3 OSPI DisplayPort HDMI
 
-BOARD_NAME="SK-AM68"
+BOARD_NAME="AM68-SK"
 BOARDFAMILY="k3"
 BOARD_MAINTAINER="glneo"
 BOOTCONFIG="j721s2_evm_a72_defconfig"

--- a/config/boards/am69-sk.conf
+++ b/config/boards/am69-sk.conf
@@ -1,6 +1,6 @@
-# TI SK-AM69 octa core 32GB 32TOPS GBE USB3 OSPI DisplayPort HDMI
+# Texas Instruments AM69 octa core 32GB 32TOPS GBE USB3 OSPI DisplayPort HDMI
 
-BOARD_NAME="SK-AM69"
+BOARD_NAME="AM69-SK"
 BOARDFAMILY="k3"
 BOARD_MAINTAINER="glneo"
 BOOTCONFIG="am69_sk_a72_defconfig"

--- a/config/boards/tda4vm-sk.conf
+++ b/config/boards/tda4vm-sk.conf
@@ -1,6 +1,6 @@
-# TI TDA4VM dual core 4GB GBE USB3 OSPI DisplayPort HDMI
+# Texas Instruments TDA4VM dual core 4GB GBE USB3 OSPI DisplayPort HDMI
 
-BOARD_NAME="SK-TDA4VM"
+BOARD_NAME="TDA4VM-SK"
 BOARDFAMILY="k3"
 BOARD_MAINTAINER="glneo"
 BOOTCONFIG="j721e_evm_a72_defconfig"


### PR DESCRIPTION
# Description

Renaming TI boards to follow a set standard: `<SoC>-<board>.conf`. This will align best across all TI boards + when adding new boards, especially non-"SK" boards.

# Documentation summary for feature / change

Should not need documentation change. Will need change for board maintainer mapping and Armbian.com image download link mapping

# How Has This Been Tested?

Board renaming shouldn't affect anything in boot, but tested some anyway.

- [x] `am62-sk`: [build log](https://paste.armbian.com/yomakigegu), [boot log](https://paste.armbian.com/cavuvedoro)
- [ ] `am62p-sk`: [build log](https://paste.armbian.com/uxoboduvew), [boot log](https://paste.armbian.com/okuxojabaz): needs further PR to fix boot (issue not caused by this PR)
- [ ] `am64-sk`: [build log](https://paste.armbian.com/ocitezoloy), [boot log](https://paste.armbian.com/ewexefepon): needs further PR to fix boot (issue not caused by this PR)
- [ ] `am68-sk`: [build log](https://paste.armbian.com/gorimezipa), [boot log](https://paste.armbian.com/upayoquqir): needs further PR to fix boot (issue not caused by this PR)
- [x] `am69-sk`: [build log](https://paste.armbian.com/nopigatuyu), don't currently have board to test
- [x] `tda4vm-sk`: [build log](https://paste.armbian.com/iwoyumumay), don't currently have board to test

Note: the git status changes in the logs are proxy-related only.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (as far as I can tell)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized board identifiers and updated product naming conventions across multiple Texas Instruments development boards (AM62, AM62P, AM64, AM68, AM69, TDA4VM) to improve consistency and clarity in configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->