### PR TITLE
fix: booting orangepi5 from nvme drive

### DIFF
--- a/config/bootscripts/boot-rk35xx.cmd
+++ b/config/bootscripts/boot-rk35xx.cmd
@@ -18,8 +18,7 @@ test -n "${distro_bootpart}" || distro_bootpart=1
 
 echo "Boot script loaded from ${devtype} ${devnum}:${distro_bootpart}"
 
-if test -e ${devtype} ${devnum}:${distro_bootpart} ${prefix}armbianEnv.txt; then
-	load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt
+if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt; then
 	env import -t ${load_addr} ${filesize}
 fi
 

--- a/config/bootscripts/boot-rockchip64.cmd
+++ b/config/bootscripts/boot-rockchip64.cmd
@@ -18,8 +18,7 @@ test -n "${distro_bootpart}" || distro_bootpart=1
 
 echo "Boot script loaded from ${devtype} ${devnum}:${distro_bootpart}"
 
-if test -e ${devtype} ${devnum}:${distro_bootpart} ${prefix}armbianEnv.txt; then
-	load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt
+if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt; then
 	env import -t ${load_addr} ${filesize}
 fi
 


### PR DESCRIPTION
# Description

For some reason test -e command that checks for armbianEnv.txt file existence fails to mount the first partition. This leads to ignoring of all boot environment, including the critical rootdev variable. This variable is hardcoded to /dev/mmcblk0p1 which works for the default sdcard case, but doesn't for nvme (and likely sata) At the same time the load command that comes after that works well

Therefore the idea behind this change is to not test for file existence and attempt to load it instead on success - import the env variables

This fixes the issues I had while working on CRYPTROOT_AUTOUNLOCK https://github.com/armbian/build/pull/8805#issuecomment-3448893657 .

# How Has This Been Tested?

First, I did some extra ad-hoc debug while on nvme:
```
# boot.cmd changes

echo "Boot script loaded from ${devtype} ${devnum}:${distro_bootpart}"

if test -e ${devtype} ${devnum}:${distro_bootpart} ${prefix}armbianEnv.txt; then
	echo "Entered the if test -e"
	load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt
	env import -t ${load_addr} ${filesize}
fi

echo "After if test -e, rootdev=${rootdev}"

if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt; then
	echo "Entered the load branch"
	env import -t ${load_addr} ${filesize}
fi

echo "After if load, rootdev=${rootdev}"

# then
# mkimage -C none -A arm -T script -d boot.cmd boot.scr
```

the key output from that test was:
```
Device 0: Vendor: 0x15b7 Rev: 73914104 Prod: 23260804718
           Type: Hard Disk
            Capacity: 244198.3 MB = 238.4 GB (5001189 x 512)
... is now current device
Scaning nvme 0:1...
fs_devread read outside partition 3247954613464064
Failed to moun ext2 filesystem...
                                 ** Unrecognized filesystem type **
Found U-Boot script /oot/boot.scr
4191 bytes read in 3 ms (1.3 MiB/s)
## Executing scrpt at 00500000
Boot scrpt loaded from nvme 0:1
fs_devread read outside partition 18446744073709551608
Faild to mount ext2 fiesystem...
** Unrecognized filesystem type **
After if test -e, rootdev=/dev/mmcblk0p1
196 bytes read in 2 ms (95.7 KiB/s)
Entered the load branch
After if load, rootdev=UUID=66dba06b-8856-40e3-ad52-4f368c5c238c
21112738 bytes read in 64 ms (314.6 MiB/s)
3781688 bytes rad in 111 ms (324.9 MiB/s)
148210 bytes read n 13 ms (10.9 MiB/s)
Failed to iterate over directory boot
Trying kaslrseed command... Info:Unknown command can be safely ignored since kaslrseed does not apply to all boards.
```

-----

Then I did the fix and tested it with the following combinations, and attaching the uboot output received over UART console. I noticed one weird thing though - the uboot output for the sdcard case versus nvme. For example I didn't see the "Boot script loaded from" line when booting from SDCard.

For each test I'm also attaching the output of UART console.

- [x] Current 6.12, SDCard, Before fix - works 🟢 
[opi5-boot-sdcard-current-6.12-before-fix.txt](https://github.com/user-attachments/files/23401921/opi5-boot-sdcard-current-6.12-before-fix.txt)
- [x] Current 6.12, SDCard, After fix - works 🟢 
[opi5-boot-sdcard-current-6.12-after-fix.txt](https://github.com/user-attachments/files/23401925/opi5-boot-sdcard-current-6.12-after-fix.txt)

- [x] Current 6.12, NVME, Before fix - doesn't work 🔴 
[opi5-boot-nvme-current-6.12-before-fix.txt](https://github.com/user-attachments/files/23401934/opi5-boot-nvme-current-6.12-before-fix.txt)
- [x] Current 6.12, NVME, After fix - works 🟢 
[opi5-boot-sdcard-current-6.12-after-fix.txt](https://github.com/user-attachments/files/23401935/opi5-boot-sdcard-current-6.12-after-fix.txt)

- [x] Vendor, Cryptroot 6.1, NVME, Before fix - doesn't work 🔴 
[behavior from this thread](https://github.com/armbian/build/pull/8805#issuecomment-3448893657)
- [x] Vendor, Cryptroot 6.1, NVME, After fix - works 🟢 
[opi5-boot-nvme-crypt-vendor-6.1-after-fix-pr.txt](https://github.com/user-attachments/files/23401958/opi5-boot-nvme-crypt-vendor-6.1-after-fix-pr.txt)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated boot initialization to streamline configuration file loading logic by replacing explicit existence checks with direct load attempts, improving control flow during system startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->