### PR TITLE
Add support for Friendlyelec NanoPi Zero2

### DIFF
--- a/config/boards/nanopi-zero2.csc
+++ b/config/boards/nanopi-zero2.csc
@@ -1,5 +1,6 @@
 # Rockchip RK3528 quad core 1/2GB RAM SoC GBe eMMC USB2 USB-C PCIe 2.1
 BOARD_NAME="NanoPi Zero2"
+BOARD_VENDOR="friendlyelec"
 BOARDFAMILY="rk35xx"
 BOOTCONFIG="hinlink_rk3528_defconfig"
 KERNEL_TARGET="vendor"


### PR DESCRIPTION
# Description

Add support for Friendlyelec NanoPi Zero2.
- dts / dtsi files from [friendlyarm kernel-rockchip](https://github.com/friendlyarm/kernel-rockchip/tree/nanopi6-v6.1.y)


# How Has This Been Tested?
- [x] build
- [x] microSD
- [x] debug UART   
- [x] USB
- [x] Ethernet
- [x] m.2 WIFI / Bluethooth 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NanoPi Zero2 board support — users can now generate optimized system images for this hardware with complete boot configuration options, kernel target selection, optional full desktop and video output, filesystem type choice, and partition sizing controls.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->