### PR TITLE
BTRFS: move btrfs support packages from additional to main package list

### DIFF
--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -1,6 +1,7 @@
 alsa-utils
 bash-completion
 bc
+btrfs-progs
 console-setup
 cron
 curl

--- a/config/cli/common/main/packages.additional
+++ b/config/cli/common/main/packages.additional
@@ -4,7 +4,6 @@ aptitude
 automake
 avahi-autoipd
 bison
-btrfs-progs
 build-essential
 command-not-found
 cracklib-runtime

--- a/config/cli/noble/main/packages.additional
+++ b/config/cli/noble/main/packages.additional
@@ -5,7 +5,6 @@ automake
 avahi-autoipd
 bash-completion
 bison
-btrfs-progs
 build-essential
 cracklib-runtime
 dkms

--- a/config/cli/sid/main/packages.additional
+++ b/config/cli/sid/main/packages.additional
@@ -5,7 +5,6 @@ automake
 avahi-autoipd
 bash-completion
 bison
-btrfs-progs
 build-essential
 cracklib-runtime
 dkms

--- a/config/cli/trixie/main/packages.additional
+++ b/config/cli/trixie/main/packages.additional
@@ -5,7 +5,6 @@ automake
 avahi-autoipd
 bash-completion
 bison
-btrfs-progs
 build-essential
 cracklib-runtime
 dkms


### PR DESCRIPTION
# Description

This will ensure support is also present in minimal images by default.

Fixes https://github.com/armbian/configng/issues/663
Closes https://github.com/armbian/configng/issues/662

# How Has This Been Tested?

```
grep -R btrfs
trixie/main/packages:btrfs-progs
oracular/main/packages:btrfs-progs
buster/main/packages:btrfs-progs
plucky/main/packages:btrfs-progs
forky/main/packages:btrfs-progs
bookworm/main/packages:btrfs-progs
sid/main/packages:btrfs-progs
common/main/packages:btrfs-progs
noble/main/packages:btrfs-progs
```

Won't be tested. We are moving one basic package from full CLI to minimal.

# Checklist:

- [x] My code follows the style guidelines of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized package configuration by consolidating btrfs-progs to the common base package set across all distributions, removing it from distribution-specific additional packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->