### PR TITLE
framework kernel machinery - always save KERNEL_MAJOR_MINOR into generated config/kernel/foo.config

### DIFF
--- a/lib/functions/compilation/kernel-config.sh
+++ b/lib/functions/compilation/kernel-config.sh
@@ -146,11 +146,12 @@ function kernel_config_export() {
 	# store kernel defconfig in easily reachable place (output dir)
 	mkdir -p "${DEST}"/config
 	display_alert "Exporting new kernel defconfig" "$DEST/config/$LINUXCONFIG.config" "info"
-	run_host_command_logged cp -pv defconfig "${DEST}/config/${LINUXCONFIG}.config"
+	echo "# File generated with ${KERNEL_MAJOR_MINOR}" > "${DEST}/config/${LINUXCONFIG}.config"
+	run_host_command_logged cat defconfig >> "${DEST}/config/${LINUXCONFIG}.config"
 
 	# store back into original LINUXCONFIG too, if it came from there, so it's pending commits when done.
 	if [[ "${kernel_config_source_filename}" != "" ]]; then
 		display_alert "Exporting new kernel config - git commit pending" "${kernel_config_source_filename}" "info"
-		run_host_command_logged cp -pv defconfig "${kernel_config_source_filename}"
+		run_host_command_logged cp -pv "${DEST}/config/${LINUXCONFIG}.config" "${kernel_config_source_filename}"
 	fi
 }


### PR DESCRIPTION
# Description

This came out of an idea from @rpardini on Discord, to always prepend the `KERNEL_MAJOR_MINOR` to the generated config, to more easily track what goes :boom: when updating the kernel version for `current` or `edge`.

# How Has This Been Tested?

- [x] `./compile.sh rewrite-kernel-config BOARD=foo` and checked the change to the config file

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel configuration export mechanism to include version information in configuration files.
  * Enhanced configuration export and import process for better file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->