### PR TITLE
kernel-config: don't leak grep stuff to stdout; mention Armbian and defconfig in rewritten .config comment

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -491,9 +491,9 @@ function armbian_kernel_config_apply_opts_from_arrays() {
 		actual_opt_value='m'
 		# NOTE: this isn't perfect, there may be something already
 		# in defconfig, but we can't see it from here.
-		if egrep "(CONFIG_)?${opt_m}=m" "${kernel_config_source_filename}"; then
+		if egrep -q "(CONFIG_)?${opt_m}=m" "${kernel_config_source_filename}"; then
 			: # do nothing
-		elif egrep "(CONFIG_)?${opt_m}=y" "${kernel_config_source_filename}"; then
+		elif egrep -q "(CONFIG_)?${opt_m}=y" "${kernel_config_source_filename}"; then
 			actual_opt_value='y'
 		fi
 		kernel_config_modifying_hashes+=("${opt_m}=${actual_opt_value}")
@@ -516,7 +516,7 @@ function armbian_kernel_config_apply_opts_from_arrays() {
 
 		for opt_m in "${opts_m[@]}"; do
 			actual_opt_value='m'
-			if egrep "(CONFIG_)?${opt_m}=y" "${kernel_config_source_filename}" .config; then
+			if egrep -q "(CONFIG_)?${opt_m}=y" "${kernel_config_source_filename}" .config; then
 				actual_opt_value='y'
 				kernel_config_set_y "${opt_m}"
 			else

--- a/lib/functions/compilation/kernel-config.sh
+++ b/lib/functions/compilation/kernel-config.sh
@@ -146,7 +146,7 @@ function kernel_config_export() {
 	# store kernel defconfig in easily reachable place (output dir)
 	mkdir -p "${DEST}"/config
 	display_alert "Exporting new kernel defconfig" "$DEST/config/$LINUXCONFIG.config" "info"
-	echo "# File generated with ${KERNEL_MAJOR_MINOR}" > "${DEST}/config/${LINUXCONFIG}.config"
+	echo "# Armbian defconfig generated with ${KERNEL_MAJOR_MINOR}" > "${DEST}/config/${LINUXCONFIG}.config"
 	run_host_command_logged cat defconfig >> "${DEST}/config/${LINUXCONFIG}.config"
 
 	# store back into original LINUXCONFIG too, if it came from there, so it's pending commits when done.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized shell script output handling in kernel compilation functions.
  * Updated generated configuration file header formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->