### PR TITLE
rockchip: Add CSC board Luckfox Pico Pro / Pico Max (RV1106)

### DIFF
--- a/config/boards/luckfox-pico-max.csc
+++ b/config/boards/luckfox-pico-max.csc
@@ -1,0 +1,12 @@
+# Rockchip RV1106 single core 128-256MB SoC 1x100MBe NAND USB2
+BOARD_NAME="Luckfox Pico Pro / Pico Max"
+BOARDFAMILY="rockchip-rv1106"
+BOOTCONFIG="luckfox_rv1106_uboot_defconfig"
+BOARD_MAINTAINER="vidplace7"
+KERNEL_TARGET="vendor"
+BOOT_FDT_FILE="rv1106g-luckfox-pico-pro-max.dtb"
+IMAGE_PARTITION_TABLE="gpt"
+BOOT_SOC="rv1106"
+
+# Board has 128MB - 256MB RAM; use 'lowmem' extension to optimize for this.
+enable_extension "lowmem"


### PR DESCRIPTION
# Description

Add new RV1106 CSC board "Luckfox Pico Max" (256MB RAM); also covers "Luckfox Pico Pro" (128MB RAM).
Depends on:
- https://github.com/armbian/linux-rockchip/pull/412

# How Has This Been Tested?

- `./compile.sh BOARD=luckfox-pico-max BRANCH=vendor KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes INSTALL_ARMBIAN_FIRMWARE=no BUILD_DESKTOP=no BUILD_MINIMAL=yes RELEASE=trixie`
- `./compile.sh BOARD=luckfox-pico-max BRANCH=vendor KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes INSTALL_ARMBIAN_FIRMWARE=no BUILD_DESKTOP=no BUILD_MINIMAL=yes RELEASE=noble`
- Shell works over UART2
- Ethernet works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the Luckfox Pico Pro / Pico Max board with optimized configuration for low-memory environments (128MB–256MB RAM).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->