### PR TITLE
Radxa Zero 3W: Add ext antenna overlay

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	hinlink-h88k-240x135-lcd.dtbo \
+	rk35xx-radxa-zero-3w-ext-ant.dtbo \
 	rk3308-otg-host.dtbo \
 	rk3308-s0-ext-antenna.dtbo \
 	rk3308-b@1.3ghz.dtbo \

--- a/patch/kernel/archive/rockchip64-6.12/overlay/rk35xx-radxa-zero-3w-ext-ant.dtso
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/rk35xx-radxa-zero-3w-ext-ant.dtso
@@ -1,0 +1,37 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+/ {
+	compatible = "radxa,zero-3w", "rockchip,rk3566";
+
+	fragment@0 {
+		target-path = "/";
+			__overlay__ {
+			board_antenna: board-antenna {
+				compatible = "regulator-fixed";
+				enable-active-low;
+				gpio = <&gpio3 RK_PD2 GPIO_ACTIVE_LOW>;
+				pinctrl-0 = <&ant_1>;
+				pinctrl-names = "default";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-name = "board-antenna";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&pinctrl>;
+			__overlay__ {
+			antenna {
+				ant_1: ant-1 {
+					rockchip,pins = <3 RK_PD2 RK_FUNC_GPIO &pcfg_pull_down>;
+				};
+			};
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip64-6.18/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/Makefile
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0
 dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	hinlink-h88k-240x135-lcd.dtbo \
-  rk3308-otg-host.dtbo \
+	rk35xx-radxa-zero-3w-ext-ant.dtbo \
+	rk3308-otg-host.dtbo \
 	rk3308-s0-ext-antenna.dtbo \
 	rk3308-b@1.3ghz.dtbo \
 	rk3308-bs.dtbo rk3308-bs@1.3ghz.dtbo \

--- a/patch/kernel/archive/rockchip64-6.18/overlay/rk35xx-radxa-zero-3w-ext-ant.dtso
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/rk35xx-radxa-zero-3w-ext-ant.dtso
@@ -1,0 +1,37 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+/ {
+	compatible = "radxa,zero-3w", "rockchip,rk3566";
+
+	fragment@0 {
+		target-path = "/";
+			__overlay__ {
+			board_antenna: board-antenna {
+				compatible = "regulator-fixed";
+				enable-active-low;
+				gpio = <&gpio3 RK_PD2 GPIO_ACTIVE_LOW>;
+				pinctrl-0 = <&ant_1>;
+				pinctrl-names = "default";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-name = "board-antenna";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&pinctrl>;
+			__overlay__ {
+			antenna {
+				ant_1: ant-1 {
+					rockchip,pins = <3 RK_PD2 RK_FUNC_GPIO &pcfg_pull_down>;
+				};
+			};
+		};
+	};
+};


### PR DESCRIPTION
**Radxa Zero 3W**
* Add external antenna overlay

Boot tested; https://paste.armbian.com/ifagaboluh.bash

Based on the following; https://github.com/armbian/linux-rockchip/blob/rk-6.1-rkr5.1/arch/arm64/boot/dts/rockchip/overlay/radxa-zero3-external-antenna.dts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for external antenna hardware on Radxa Zero 3W SBC devices
  * Enables automatic antenna regulator initialization and active GPIO control during system boot
  * Implements pin configuration for stable antenna operation
  * Support provided for both kernel versions 6.12 and 6.18

<!-- end of auto-generated comment: release notes by coderabbit.ai -->