### PR TITLE
framework extensions deep magic - add extension_optout for boards/families

### DIFF
--- a/config/sources/families/rockchip-rv1106.conf
+++ b/config/sources/families/rockchip-rv1106.conf
@@ -36,6 +36,7 @@ BOOTSOURCE="https://github.com/radxa/u-boot.git"
 BOOTBRANCH="branch:next-dev-buildroot"
 BOOTPATCHDIR="legacy/u-boot-rockchip-buildroot"
 BOOTDIR="u-boot-rockchip"
+declare -ga extension_optout=( armbian_kernel_config__enable_docker_support )
 
 # Set defaults based on BOOT_SOC (overridable in board config)
 if [[ "$BOOT_SOC" == "rv1103" ]]; then


### PR DESCRIPTION
The goal here is that some boards may want to opt out entirely [at their own risk of course] of an extension or hook. Here I pick on the `rockchip-rv1106` as an example.
this supplements but does not replace #8896.

# Documentation summary for feature / change

likely needs to be documented here: https://docs.armbian.com/Developer-Guide_Extensions-Hooks/
But that needs some discussion.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] - edited `linux-rockchip-rv1106-vendor.config` to disable EXT4 entirely. ran `rewrite-kernel-config`. EXT4 remained disabled
- [x] took `linux-filogic-current.config`, flipped `EXT4_FS=n`, it changed it to `m` [in `main` it is currently `y`]
  - so it appears to preserve expected behaviour in the non-optout case 

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-device opt-out for specific extensions, letting device configs disable selected extension behavior.
  * Extension manager now respects these opt-outs when assembling hook lists so opted-out extension hooks are excluded from final processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->