### PR TITLE
Improve first login for automated builds

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -805,9 +805,9 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	else
 
 		echo -e "\e[0;31m\nDeveloper Preview Build\x1B[0m\n"
-		echo -e "This Armbian image was generated automatically for development and testing."
+		echo -e "This Armbian image was generated automatically for development and testing purpose."
 		echo -e "It may include unfinished features or unstable components.\n"
-		echo -e "If you’re not here to test or report issues, \e[0;31mplease don’t use this image in production.\x1B[0m"
+		echo -e "If you are not here to report issues or just test it, \e[0;31mplease do not use this image in production.\x1B[0m"
 		echo -e "Expect things to change — or even break — as improvements are made."
 
 	fi


### PR DESCRIPTION
# Description

First login text for automated builds changed to:

<img width="1157" height="208" alt="image" src="https://github.com/user-attachments/assets/363814f9-0c21-405e-8f02-cf2ba259bed2" />

# How Has This Been Tested?

- [x] Manual execution

# Checklist:

- [x] My code follows the style guidelines of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Simplified the initial login/welcome message to a concise "Developer Preview Build" notice, clarifying the build is for development/testing, may contain unfinished or unstable features, and advising caution for production use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->