### PR TITLE
Armbian install progress bar wasn't working for awhile

### DIFF
--- a/packages/bsp/common/usr/bin/armbian-install
+++ b/packages/bsp/common/usr/bin/armbian-install
@@ -181,7 +181,7 @@ create_armbian()
 
 	# count files is needed for progress bar
 	dialog --title " $title " --backtitle "$backtitle" --infobox "\n  Counting files ... few seconds." 5 60
-	TODO=$(rsync -avx --delete --stats --exclude-from=$EX_LIST / "${TempDir}"/rootfs | grep "Number of files:"|awk '{print $4}' | tr -d '.,')
+	TODO=$(rsync -anvx --delete --stats --exclude-from=$EX_LIST / "${TempDir}"/rootfs | grep "Number of files:"|awk '{print $4}' | tr -d '.,')
 	echo -e "\nCopying ${TODO} files to $2. \c" >> $logfile
 
 	# creating rootfs
@@ -194,15 +194,21 @@ create_armbian()
 	echo 0 >"${nsi_conn_progress}"
 	echo no >"${nsi_conn_done}"
 
-	 # Launch rsync in background
-	{ \
-	rsync -avx --delete --exclude-from=$EX_LIST / "${TempDir}"/rootfs | \
-	nl | awk '{ printf "%.0f\n", 100*$1/"'"$TODO"'" }' \
-	> "${nsi_conn_progress}" ;
-	 # create empty persistent journal directory if it exists before install
-	[ -d /var/log.hdd/journal ] && mkdir "${TempDir}"/rootfs/var/log/journal
-	 # save exit code from rsync
-	echo  ${PIPESTATUS[0]} >"${nsi_conn_done}"
+	# Launch rsync in background and stream progress percentages
+	{
+	rsync -avx --delete --exclude-from="$EX_LIST" / "${TempDir}/rootfs" \
+	| stdbuf -oL awk -v todo="${TODO:-1}" '{
+			pct = int((100 * NR) / (todo == 0 ? 1 : todo));
+			if (pct > 100) pct = 100;
+			print pct;
+			fflush();      # ensure the progress file gets new lines promptly
+		}' > "${nsi_conn_progress}"
+
+	# create empty persistent journal dir if it existed before install
+	[ -d /var/log.hdd/journal ] && mkdir -p "${TempDir}/rootfs/var/log/journal"
+
+	# save rsync exit code (first cmd in the pipe)
+	echo ${PIPESTATUS[0]} > "${nsi_conn_done}"
 	} &
 
 	 # while variables
@@ -241,7 +247,7 @@ create_armbian()
 	 This will take approximately $(( $((USAGE/300)) * 1 )) minutes to finish. Please wait!\n\n" 11 80
 
 	# run rsync again to silently catch outstanding changes between / and "${TempDir}"/rootfs/
-	dialog --title "$title" --backtitle "$backtitle" --infobox "\n               Cleaning up ... Almost done." 5 60
+	dialog --title "$title" --backtitle "$backtitle" --infobox "\n    Finalizing file sync ... Please wait." 5 60
 	rsync -avx --delete --exclude-from=$EX_LIST / "${TempDir}"/rootfs >/dev/null 2>&1
 
 	# mark OS as transferred


### PR DESCRIPTION
# Description

At certain point in time, we broke progress bar for armbian-install. This PR put's it back in operation. Its not very accurate, but it remain fast. 

# How Has This Been Tested?

- [x] Executed and tested several installations

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file sync progress tracking accuracy during installation.
  * Enhanced reliability of progress reporting with better error handling.

* **Documentation**
  * Updated user-facing messages to provide clearer feedback during file synchronization ("Finalizing file sync ... Please wait.").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->