### PR TITLE
Revert "Implement option to skip certain kernel configs that don't want to play along"

### DIFF
--- a/.github/workflows/rewrite-kernel-configs.yml
+++ b/.github/workflows/rewrite-kernel-configs.yml
@@ -27,22 +27,12 @@ jobs:
         id: gen
         shell: bash
         run: |
-
           set -euo pipefail
           JSON="output/info/image-info.json"
 
-          # === Kernel config files to skip (filenames under config/kernel/) ===
-          # Add more entries as needed.
-          SKIP_CONFIGS=(
-            "linux-rockchip-rv1106-vendor.config"
-          )
-
-          # Convert bash array -> JSON array for jq
-          SKIP_JSON="$(printf '%s\n' "${SKIP_CONFIGS[@]}" | jq -R . | jq -s .)"
-
           tmp="$(mktemp)"
 
-          jq -c --argjson skip "$SKIP_JSON" '
+          jq -c '
             def norm_branches:
               if . == null then []
               elif (type=="string") then ( gsub("[,\\s]+";" ") | split(" ") | map(select(length>0)) )
@@ -71,12 +61,6 @@ jobs:
             # 4) If multiple boards share same (family,branch), keep smallest board (lexicographic)
             | sort_by(.linuxfamily, .branch, .board)
             | group_by([.linuxfamily,.branch]) | map(.[0])
-            # 5) Filter out rows whose kernel config filename is in skip list
-            | map(
-                . as $row
-                | ( "linux-" + $row.linuxfamily + "-" + $row.branch + ".config" ) as $fname
-                | select( ($skip | index($fname)) | not )
-              )
           ' "$JSON" > "$tmp"
 
           echo "count=$(jq 'length' "$tmp")" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Description

This reverts commit 73a43c993dd53eb6aacc18fe4222c293a7a31589.

Not useful - just generating inconsistency.
https://github.com/armbian/build/pull/8896#issuecomment-3508199022

# Checklist:

- [x] My code follows the style guidelines of this project


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the skip mechanism from the kernel config processing workflow, allowing all kernel configuration files to be processed without exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->