### PR TITLE
LowMem: Slim down initramfs and set /run size

### DIFF
--- a/extensions/lowmem.sh
+++ b/extensions/lowmem.sh
@@ -8,6 +8,28 @@
 # at build time.
 #
 
+function post_family_tweaks_bsp__initramfs() {
+	local LOWMEM_TMPFS_RUN_MB=${LOWMEM_TMPFS_RUN_MB:-20}
+	display_alert "${EXTENSION}" "Set initramfs config for low memory" "debug"
+
+	# Create /etc/initramfs-tools/conf.d/armbian-lowmem.conf configuration file
+	if [ ! -f "$destination/etc/initramfs-tools/conf.d/armbian-lowmem.conf" ]; then
+		mkdir -p "$destination/etc/initramfs-tools/conf.d"
+		install -m 644 /dev/null "$destination/etc/initramfs-tools/conf.d/armbian-lowmem.conf"
+
+		# Load only modules needed for boot
+		echo "MODULES=dep" >> "$destination/etc/initramfs-tools/conf.d/armbian-lowmem.conf"
+
+		# /run is 10% of RAM by default
+		# systemd throws errors when <16MB is *free* in this partition
+		# during daemon-reload operations.
+		# Address with a fixed /run size of ${LOWMEM_TMPFS_RUN_MB}
+		echo "RUNSIZE=${LOWMEM_TMPFS_RUN_MB}M" >> "$destination/etc/initramfs-tools/conf.d/armbian-lowmem.conf"
+	fi
+
+	return 0
+}
+
 function post_family_tweaks_bsp__copy_lowmem_config() {
 	display_alert "${EXTENSION}" "Installing default configuration" "debug"
 
@@ -41,23 +63,12 @@ function post_family_tweaks__enable_lowmem_mkswap() {
 }
 
 function pre_umount_final_image__memory_optimize_defaults() {
-	local LOWMEM_TMPFS_RUN_MB=${LOWMEM_TMPFS_RUN_MB:-20}
 	# Optimize /etc/default settings to reduce memory usage
 	display_alert "${EXTENSION}" "Disabling ramlog by default to save memory" "debug"
 	sed -i "s/^ENABLED=.*/ENABLED=false/" "${MOUNT}"/etc/default/armbian-ramlog
 
 	display_alert "${EXTENSION}" "Disabling zram swap by default" "debug"
 	sed -i "s/^#\?\s*SWAP=.*/SWAP=false/" "${MOUNT}"/etc/default/armbian-zram-config
-
-	# /run is 10% of RAM by default
-	# systemd throws errors when <16MB is *free* in this partition
-	# during daemon-reload operations.
-	# Address with a fixed /run size of ${LOWMEM_TMPFS_RUN_MB}
-	if ! grep -qE "tmpfs[[:space:]]+/run[[:space:]]+tmpfs" "${MOUNT}/etc/fstab"; then
-		# Skip if /run entry already exists in fstab (userpatches, etc)
-		display_alert "${EXTENSION}" "Fixing /run size in /etc/fstab" "debug"
-		echo "tmpfs /run tmpfs rw,nosuid,nodev,noexec,relatime,size=${LOWMEM_TMPFS_RUN_MB}M,mode=755 0 0" >> "${MOUNT}"/etc/fstab
-	fi
 
 	return 0
 }


### PR DESCRIPTION
# Description

LowMem Extension Modifications:
- Change initramfs `MODULES=most` to `MODULES=dep` for initramfs memory savings.
  - https://manpages.debian.org/trixie/initramfs-tools-core/initramfs.conf.5.en.html#MODULES
  > **dep** tries to guess which modules are necessary for the running box and only adds those modules.
- Set `/run` tmpfs size using initramfs config. A bit cleaner than the current implementation.

# How Has This Been Tested?

- Tested with Luckfox Pico Mini board / Luckfox Lyra Plus boards + ubuntu noble.
- Confirmed booting still works.
- Shaves ~1M from initramfs.
- Confirmed `/run` tmpfs size is still set correctly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
