### PR TITLE
Actions: Disable merge-announce workflow on forks

### DIFF
--- a/.github/workflows/merge-announce.yml
+++ b/.github/workflows/merge-announce.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   announcepush:
+    # Do not run this workflow in forks
+    if: ${{ github.repository == 'armbian/build' }}
     runs-on: ubuntu-latest
     steps:
       - name: Get repo


### PR DESCRIPTION
# Description

Tiny GitHub Actions change. Disable `merge-announce` workflow on forked repos.
This fails every time I sync the `main` branch of my fork from origin and it's just annoying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow to execute only in the main repository, preventing unnecessary runs in forked repositories and reducing resource consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->