### PR TITLE
bump mainline `edge` to rc5

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0           # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "6.18" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v6.18-rc4"
+		declare -g KERNELBRANCH="tag:v6.18-rc5"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }


### PR DESCRIPTION
# Description

- rewrite rockchip64 patches: no changes
- rewrite meson64 patches: no changes
- rewrite uefi-arm64 patches: no changes
- rewrite loong64 patches: wasn't possible due to lack of sid build host. Anyone else need to do this

# How Has This Been Tested?

- [x] build kernel for orangepi5 as rockchip64 edge target
- [x] build kernel for uefi-arm64

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mainline kernel version from 6.18-rc4 to 6.18-rc5 for upstream release candidate selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->