### PR TITLE
common: kernels: warnings for when LINUXCONFIG is set to something nonstandard

### DIFF
--- a/config/boards/beagley-ai.conf
+++ b/config/boards/beagley-ai.conf
@@ -25,7 +25,7 @@ function post_family_config_branch_current__beagley_ai_use_beagle_kernel_uboot()
 	declare -g KERNEL_MAJOR_MINOR="6.6"
 	declare -g KERNELBRANCH="branch:v6.6.58-ti-arm64-r21"
 	declare -g LINUXFAMILY="k3-beagle" # Separate kernel package from the regular `k3` family
-	declare -g LINUXCONFIG="linux-k3-${BRANCH}"
+	declare -g LINUXCONFIG="linux-k3-${BRANCH}" # TODO: wrong! shared .config with `k3` family; should use its own
 
 	declare -g BOOTSOURCE="https://github.com/glneo/u-boot" # v2025.04-rc3 + BeagleY-AI support
 	declare -g BOOTBRANCH="branch:beagley-ai"

--- a/config/sources/common.conf
+++ b/config/sources/common.conf
@@ -132,7 +132,17 @@ function late_family_config__common_defaults_for_mainline_kernel() {
 	# if LINUXCONFIG is unset... default to linux-${LINUXFAMILY}-${BRANCH} # Attention: no KERNEL_MAJOR_MINOR here, so manual file rollover is necessary
 	if [[ -z ${LINUXCONFIG} ]]; then
 		display_alert "LINUXCONFIG is unset; using 'linux-${LINUXFAMILY}-${BRANCH}'" "common_defaults_for_mainline" "debug"
-		LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
+		declare -g -r LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}" # READ-ONLY from here!
+	else
+		# LINUXCONFIG is set. Historically there's a large chance that it is a mistake, as LINUXCONFIG should _always_ be "linux-${LINUXFAMILY}-${BRANCH}"
+		# Exception are uefi family members, as for those we're skipping the uefi- prefix in LINUXFAMILY.
+		if [[ "${LINUXCONFIG}" == "linux-uefi-${LINUXFAMILY}-${BRANCH}" ]]; then
+			: # let it be
+		elif [[ "${LINUXCONFIG}" != "linux-${LINUXFAMILY}-${BRANCH}" ]]; then
+			display_alert "LINUXCONFIG ('${LINUXCONFIG}') does not match expected 'linux-${LINUXFAMILY}-${BRANCH}'" "you probably should use a separate LINUXFAMILY instead of setting LINUXCONFIG" "warn"
+		else
+			display_alert "LINUXCONFIG is set to '${LINUXCONFIG}'" "common_defaults_for_mainline: you shouldn't set LINUXCONFIG, it is auto-determined from LINUXFAMILY and BRANCH." "warn"
+		fi
 	fi
 
 	# Mainline defaults

--- a/config/sources/families/sun55iw3.conf
+++ b/config/sources/families/sun55iw3.conf
@@ -20,7 +20,7 @@ declare -g BOOTENV_FILE='sunxi.txt'
 declare -g UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-BINMAN_ALLOW_MISSING=1;;u-boot-sunxi-with-spl.bin}"
 declare -g OVERLAY_DIR="/boot/dtb/allwinner/overlay"
 declare -g LINUXFAMILY="sun55iw3"
-declare -g LINUXCONFIG="linux-sunxi64-${BRANCH}"
+declare -g LINUXCONFIG="linux-sunxi64-${BRANCH}" # @TODO: this is wrong; it is sharing a single .config with 2 LINUXFAMILYs: sunxi64 and sun55iw3
 
 case "${BRANCH}" in
 


### PR DESCRIPTION
- board: beagley-ai.conf: mark TODO
- family: sun55iw3: mark TODO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved configuration validation logic to detect and warn about incorrect settings.

* **Documentation**
  * Added clarifying comments to configuration files documenting configuration requirements and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->