### PR TITLE
RV1106: Limit udev children to prevent early OOM

### DIFF
--- a/config/sources/families/rockchip-rv1106.conf
+++ b/config/sources/families/rockchip-rv1106.conf
@@ -22,7 +22,12 @@ BOOTDELAY=1
 SERIALCON="ttyFIQ0"
 RKBIN_DIR="$SRC/cache/sources/rkbin-tools"
 SRC_EXTLINUX="yes"
-SRC_CMDLINE="cma=0 video=off console=ttyFIQ0,115200n8"
+# Bootargs:
+# cma=0 -- disable CMA allocations (used by video / ipc) to save memory
+# video=off -- disable video subsystem to save memory
+# udev.children-max=1 -- limit number of udev child processes to save memory early in boot
+# console=ttyFIQ0,115200n8 -- set console to FIQ0 serial port at 115200 baud
+SRC_CMDLINE="cma=0 video=off udev.children-max=1 console=ttyFIQ0,115200n8"
 OVERLAY_PREFIX="rv1106"
 OFFSET=16
 SPL_FIT_GENERATOR="arch/arm/mach-rockchip/make_fit_optee.sh"


### PR DESCRIPTION
# Description
RV1106 family

Add `udev.children-max=1` to bootargs. This saves memory *very* early in the boot process by preventing udev process sprawl. Prevents intermittent udev OOM errors early in the boot.

https://www.freedesktop.org/software/systemd/man/latest/udev.conf.html#children_max=

# How Has This Been Tested?

- [x] Luckfox Pico Mini Ubuntu Noble
- Rebooted several times, while monitoring serial console. No more udev OOMs. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated boot configuration to limit device-child handling and added explanatory comments. Improves device-handling stability; no other functional changes and defaults remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->