### PR TITLE
First login: create docker group and add normal user to it

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -601,9 +601,13 @@ add_user() {
 				passwd -d "$RealUserName" > /dev/null 2>&1
 			fi
 
-			# add Docker group by default
+			# Pre-create docker group to ensure user membership is set up before Docker installation.
+			# (docker-ce package creates this group automatically during postinst, but we create it early
+			# to guarantee group membership is ready immediately after user creation.)
 			if ! getent group docker >/dev/null; then
-				addgroup --system docker
+				if ! addgroup --system docker 2>/dev/null; then
+					echo "Warning: Failed to create docker group" >&2
+				fi
 			fi
 			for additionalgroup in sudo netdev audio video disk tty users games dialout plugdev input bluetooth systemd-journal ssh render docker; do
 				usermod -aG "${additionalgroup}" "${RealUserName}" 2> /dev/null


### PR DESCRIPTION
# Description

This way we ensure, user is added to the Docker group even Docker is installed later. 

The Docker package’s post-install script runs:

```
if ! getent group docker >/dev/null; then
    addgroup --system docker
fi
```

So since the group already exists → it does nothing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New users now automatically receive Docker group membership during account creation.
  * If the Docker group is missing, the system attempts to create it and will emit a warning if creation fails, ensuring users get immediate membership when possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->