### PR TITLE
Use next patch version when using main action script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -140,9 +140,33 @@ runs:
     - shell: bash
       run: |
 
-        # read version from upstream Armbian OS
-        cat os/stable.json | jq '.version' | sed "s/\"//g" | sed 's/^/ARMBIAN_VERSION=/' >> $GITHUB_ENV
-        [[ "${{ inputs.armbian_version }}" != '' ]] && echo "ARMBIAN_VERSION=${{ inputs.armbian_version }}" >> $GITHUB_ENV
+        # Resolve base version (prefer workflow input if provided)
+        BASE_VERSION="${{ inputs.armbian_version }}"
+        if [ -z "$BASE_VERSION" ]; then
+          BASE_VERSION="$(jq -r '.version' os/stable.json)"
+        fi
+
+        # Preserve optional 'v' prefix but strip it for math
+        PREFIX=''
+        if [[ "$BASE_VERSION" == v* ]]; then
+          PREFIX='v'
+          BASE_NO_PREFIX="${BASE_VERSION#v}"
+        else
+          BASE_NO_PREFIX="$BASE_VERSION"
+        fi
+
+        # Drop any pre-release/build metadata (e.g., -rc1, +meta)
+        CORE="${BASE_NO_PREFIX%%[-+]*}"
+
+        # Split and increment patch
+        IFS='.' read -r MAJOR MINOR PATCH <<<"$CORE"
+        PATCH=${PATCH:-0}
+        NEXT_PATCH=$((PATCH + 1))
+        NEXT_VERSION="${PREFIX}${MAJOR}.${MINOR}.${NEXT_PATCH}"
+
+        {
+          echo "ARMBIAN_VERSION=${NEXT_VERSION}"
+        } >> "$GITHUB_ENV"
 
         # copy os userpatches and custom
         mkdir -pv build/userpatches


### PR DESCRIPTION
# Description

Updated the version resolution logic to prefer workflow input and increment the patch version correctly.

This will prevent auto downgrading from stable repository.

# How Has This Been Tested?

- [x] Generating image

Our JSON file contains v25.8.2 and image that was build had v25.8.3

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented robust version parsing logic with automatic patch version incrementation.
  * Enhanced support for flexible version input from multiple sources, including workflow parameters and configuration files.
  * Improved version metadata handling with better prefix preservation and prerelease/build information stripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->