### PR TITLE
UFS: Fix ci config generation

### DIFF
--- a/extensions/ufs.sh
+++ b/extensions/ufs.sh
@@ -1,18 +1,21 @@
 # Create UFS aligned image (requires >= Debian 13 (Trixie) Host)
 declare -g DOCKER_ARMBIAN_BASE_IMAGE=debian:trixie
 function extension_prepare_config__ufs {
-    # Check sfdisk version is >= 2.41 for UFS support
-    local sfdisk_version
-    if ! command -v sfdisk >/dev/null 2>&1; then
-        exit_with_error "sfdisk not found. Please install util-linux (provides sfdisk) >= 2.41."
-    fi
-    # Extract the util-linux version and strip any non-numeric characters for robustness
-    sfdisk_version="$(sfdisk --version 2>/dev/null | awk '/util-linux/ {print $NF}' | tr -cd '0-9.')"
-    if [[ -z "${sfdisk_version}" ]]; then
-        exit_with_error "Unable to determine util-linux version from 'sfdisk --version'."
-    fi
-    if linux-version compare "${sfdisk_version}" lt "2.41"; then
-        exit_with_error "UFS extension requires sfdisk >= 2.41 (from util-linux). Current version: ${sfdisk_version}"
+    # Skip version check if only generating config definitions
+    if [[ "${CONFIG_DEFS_ONLY}" != "yes" ]]; then
+        # Check sfdisk version is >= 2.41 for UFS support
+        local sfdisk_version
+        if ! command -v sfdisk >/dev/null 2>&1; then
+            exit_with_error "sfdisk not found. Please install util-linux (provides sfdisk) >= 2.41."
+        fi
+        # Extract the util-linux version and strip any non-numeric characters for robustness
+        sfdisk_version="$(sfdisk --version 2>/dev/null | awk '/util-linux/ {print $NF}' | tr -cd '0-9.')"
+        if [[ -z "${sfdisk_version}" ]]; then
+            exit_with_error "Unable to determine util-linux version from 'sfdisk --version'."
+        fi
+        if linux-version compare "${sfdisk_version}" lt "2.41"; then
+            exit_with_error "UFS extension requires sfdisk >= 2.41 (from util-linux). Current version: ${sfdisk_version}"
+        fi
     fi
     EXTRA_IMAGE_SUFFIXES+=("-ufs")
     declare -g SECTOR_SIZE=4096


### PR DESCRIPTION
# Description

Don't check sfdisk version for ci config generation as that is running on the build host and not docker

ToDo for the future: Use docker image for matrix preparer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated extension initialization with configuration-aware conditional logic that intelligently optimizes the startup sequence by bypassing specific validation steps when certain operational modes are active, improving performance while maintaining full compatibility with existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->