### PR TITLE
UFS: Fix CI behavior

### DIFF
--- a/extensions/ufs.sh
+++ b/extensions/ufs.sh
@@ -1,5 +1,5 @@
 # Create UFS aligned image (requires >= Debian 13 (Trixie) Host)
-declare -g DOCKER_ARMBIAN_BASE_IMAGE=debian:trixie
+# declare -g DOCKER_ARMBIAN_BASE_IMAGE=debian:trixie # Use this env variable manually
 function extension_prepare_config__ufs {
     # Skip version check if only generating config definitions
     if [[ "${CONFIG_DEFS_ONLY}" != "yes" ]]; then


### PR DESCRIPTION
# Description

Commented out the declaration of DOCKER_ARMBIAN_BASE_IMAGE as it needs to be set manually outside.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * UFS extension Docker base image configuration now requires manual environment variable setup instead of automatic assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->