### PR TITLE
docker: make `DOCKER_ARMBIAN_BASE_IMAGE` readonly after resolving `DOCKER_ARMBIAN_BASE_COORDINATE_PREFIX`

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -137,6 +137,9 @@ function docker_cli_prepare() {
 		display_alert "Using prebuilt Armbian image as base for '${wanted_os_tag}-${DOCKER_WANTED_RELEASE}'" "DOCKER_ARMBIAN_BASE_IMAGE: ${DOCKER_ARMBIAN_BASE_IMAGE}" "info"
 	fi
 
+	# Make DOCKER_ARMBIAN_BASE_IMAGE readonly; no changes allowed after this point.
+	declare -g -r DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE}"
+
 	#############################################################################################################
 	# Stop here if Docker can't be used at all.
 	if ! is_docker_ready_to_go; then


### PR DESCRIPTION
- otherwise stuff (eg extensions) might be tempted to change it, but that will only lead to pain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code stability by implementing stricter controls on Docker configuration variable assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->