### PR TITLE
Add type of bootable fs for ODroid-N2 into board config

### DIFF
--- a/config/boards/odroidn2.conf
+++ b/config/boards/odroidn2.conf
@@ -8,6 +8,7 @@ MODULES_BLACKLIST="simpledrm" # SimpleDRM conflicts with Panfrost
 FULL_DESKTOP="yes"
 FORCE_BOOTSCRIPT_UPDATE="yes"
 BOOT_LOGO="desktop"
+BOOTFS_TYPE="ext4"
 BOOTCONFIG="odroid-n2_defconfig" # For mainline uboot
 
 # Newer u-boot for the N2/N2+, less patches: a single boot order patch


### PR DESCRIPTION
Add type of fs from what ODroid-N2 can boot.

- [x] My code follows the style guidelines of this project
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated board configuration for ODROID-N2 to specify ext4 as the default boot filesystem type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->