### PR TITLE
Helios64: workaround fancontrol /dev restriction vs Helios64 udev /dev symlinks

### DIFF
--- a/config/boards/helios64.conf
+++ b/config/boards/helios64.conf
@@ -41,6 +41,9 @@ function post_family_tweaks_bsp__helios64() {
 
 	install -m 644 $SRC/packages/bsp/helios64/fancontrol.service.pid-override $destination/etc/systemd/system/fancontrol.service.d/pid.conf
 
+	# helios64 points fancontrol to /dev symlinks created by helios64 udev rules to sysfs hwmon and thermal directories
+	install -m 644 $SRC/packages/bsp/helios64/fancontrol.service.privatedevices-override $destination/etc/systemd/system/fancontrol.service.d/privatedevices.conf
+
 	# copy fancontrol config
 	install -m 644 $SRC/packages/bsp/helios64/fancontrol.conf $destination/etc/fancontrol
 

--- a/packages/bsp/helios64/fancontrol.service.privatedevices-override
+++ b/packages/bsp/helios64/fancontrol.service.privatedevices-override
@@ -1,0 +1,2 @@
+[Service]
+PrivateDevices=no


### PR DESCRIPTION
Debian fancontrol service PrivateDevices=yes default prevents access to these /dev symlinks.

# Description

Trixie fancontrol has PrivateDevices=yes, which prevents access to host /dev. But helios64 sets up
symlinks to thermal and hwmon sysfs entries into /dev via udev rules and uses these links in fancontrol config.
Add a fancontrol systems service drop-in top set PrivateDevices=no in helios64 bsp package to allow
access to these symlinks.

Reported in forum: https://forum.armbian.com/topic/30074-helios64-armbian-2308-bookworm-issues-solved/page/12/#findComment-228274

Likely that also affects helios4, which has the same udev hacks to prepare symlinks to sysfs files for fancontrol.


Mind that I question the requirements for these udev symlinks; this needs to be sorted out if they are needed or were hacks.
Also, there are only 3 boards using fancontrol. I question the use of fancontrol. Maybe we should ship a thermal policy in dts instead.
But for now, let's fix the existing stack.

# How Has This Been Tested?

- [X] build armbian-bsp-cli for trixie current, install it on target board, reload systemd daemon, restart fancontrol service


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated fan control service configuration on Helios64 systems by installing a service override to permit device access, ensuring the fan control daemon can operate correctly with hardware devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->