### PR TITLE
Preserve timestamps when copying log files

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -152,8 +152,9 @@ case "$1" in
 		cd $HDD_LOG
 		find . -type f -print | grep -E -v "(\.gz|\.xz|\.[0-9]|armbian-ramlog)|\.journal" | while IFS= read -r  file
 		do
-	    		dest="/var/log/$file"
-	    		cat $file > $dest	    
+			dest="/var/log/$file"
+			cat $file > $dest
+			touch -r $file $dest
 		done
 		;;
 	*)


### PR DESCRIPTION
# Description

The `armbian-ramlog` utility includes a postrotate action that copies log file contents from persistent storage ("HDD") to RAM using `cat source > dest`. This approach was likely chosen to ensure compatibility with log files that remain open for writing.  

However, this method resets the file modification timestamp. While this typically has no impact on actively written log files, it can cause unwanted behavior for certain files in `/var/log`. Any subsequent synchronization from RAM to persistent storage will propagate these altered timestamps.  

Ideally, the postrotate action could handle this more gracefully, but as a simple and non-invasive solution, this change adds a timestamp preservation step using `touch`.

# How Has This Been Tested?

The change is very trivial. Nevertheless, I verified it on my Orange Pi One (`v25.8.2 for Orange Pi One running Armbian Linux 6.12.51-current-sunxi`).

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log rotation now preserves original file timestamps when archiving logs, ensuring accurate log history tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->