### PR TITLE
Related to armbian/documentation#842, update extensions/gen-sample-extension-docs.sh to reference the opt-out docs for hooks

### DIFF
--- a/extensions/gen-sample-extension-docs.sh
+++ b/extensions/gen-sample-extension-docs.sh
@@ -58,6 +58,7 @@ MULTIPLE_CALLS_WARNING
 
 	cat << PRE_HOOKS_HEADER
 ## Hooks
+- Individual/specific hook functions can be [skipped/ignored/opted-out](/Developer-Guide_Extensions#opt-out-of-individual-hook-functions).
 - Hooks are listed in the order they are called.
 PRE_HOOKS_HEADER
 


### PR DESCRIPTION
# Description

Replaces armbian/build#8897, tied to armbian/documentation#842

`extensions/gen-sample-extension-docs.sh` claims to have been used to generate https://github.com/armbian/documentation/blob/main/docs/Developer-Guide_Extensions-Hooks.md, so add the same link in the extension that we added in armbian/documentation#842

# How Has This Been Tested?

see #8897 for more details of testing & other discussion. Note that  this PR is purely documentation, no operative changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated generated documentation to clarify that individual hook functions can be skipped or opted-out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->