### PR TITLE
sm8250 current: Add support to load QUP SE Firmware via Linux subsystem

### DIFF
--- a/patch/kernel/archive/sm8250-6.12/0043-dt-bindings-qcom-se-common-Add-QUP-Peripheral-specif.patch
+++ b/patch/kernel/archive/sm8250-6.12/0043-dt-bindings-qcom-se-common-Add-QUP-Peripheral-specif.patch
@@ -1,0 +1,100 @@
+From 606555515f0395b4da4043add31fc54fb7c920a6 Mon Sep 17 00:00:00 2001
+From: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Date: Thu, 11 Sep 2025 10:02:51 +0530
+Subject: [PATCH 1/5] dt-bindings: qcom: se-common: Add QUP Peripheral-specific
+ properties for I2C, SPI, and SERIAL bus
+
+Introduce a new YAML schema for QUP-supported peripherals. Define common
+properties used across QUP-supported peripherals.
+
+Add property `qcom,enable-gsi-dma` to configure the Serial Engine (SE) for
+QCOM GPI DMA mode.
+
+Reference the common schema YAML in the GENI I2C, SPI, and SERIAL YAML
+files.
+
+Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Co-developed-by: Mukesh Kumar Savaliya <mukesh.savaliya@oss.qualcomm.com>
+Signed-off-by: Mukesh Kumar Savaliya <mukesh.savaliya@oss.qualcomm.com>
+Signed-off-by: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20250911043256.3523057-2-viken.dadhaniya@oss.qualcomm.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+---
+ .../bindings/i2c/qcom,i2c-geni-qcom.yaml      |  1 +
+ .../serial/qcom,serial-geni-qcom.yaml         |  1 +
+ .../soc/qcom/qcom,se-common-props.yaml        | 26 +++++++++++++++++++
+ .../bindings/spi/qcom,spi-geni-qcom.yaml      |  1 +
+ 4 files changed, 29 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/soc/qcom/qcom,se-common-props.yaml
+
+diff --git a/Documentation/devicetree/bindings/i2c/qcom,i2c-geni-qcom.yaml b/Documentation/devicetree/bindings/i2c/qcom,i2c-geni-qcom.yaml
+index 9f66a3bb1..51534953a 100644
+--- a/Documentation/devicetree/bindings/i2c/qcom,i2c-geni-qcom.yaml
++++ b/Documentation/devicetree/bindings/i2c/qcom,i2c-geni-qcom.yaml
+@@ -75,6 +75,7 @@ required:
+ 
+ allOf:
+   - $ref: /schemas/i2c/i2c-controller.yaml#
++  - $ref: /schemas/soc/qcom/qcom,se-common-props.yaml#
+   - if:
+       properties:
+         compatible:
+diff --git a/Documentation/devicetree/bindings/serial/qcom,serial-geni-qcom.yaml b/Documentation/devicetree/bindings/serial/qcom,serial-geni-qcom.yaml
+index dd33794b3..ed7b3909d 100644
+--- a/Documentation/devicetree/bindings/serial/qcom,serial-geni-qcom.yaml
++++ b/Documentation/devicetree/bindings/serial/qcom,serial-geni-qcom.yaml
+@@ -12,6 +12,7 @@ maintainers:
+ 
+ allOf:
+   - $ref: /schemas/serial/serial.yaml#
++  - $ref: /schemas/soc/qcom/qcom,se-common-props.yaml#
+ 
+ properties:
+   compatible:
+diff --git a/Documentation/devicetree/bindings/soc/qcom/qcom,se-common-props.yaml b/Documentation/devicetree/bindings/soc/qcom/qcom,se-common-props.yaml
+new file mode 100644
+index 000000000..6a34f05a0
+--- /dev/null
++++ b/Documentation/devicetree/bindings/soc/qcom/qcom,se-common-props.yaml
+@@ -0,0 +1,26 @@
++# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/soc/qcom/qcom,se-common-props.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: QUP Peripheral-specific properties for I2C, SPI and SERIAL bus
++
++description:
++  The Generic Interface (GENI) based Qualcomm Universal Peripheral (QUP) is
++  a programmable module that supports a wide range of serial interfaces
++  such as UART, SPI, I2C, I3C, etc. This defines the common properties used
++  across QUP-supported peripherals.
++
++maintainers:
++  - Mukesh Kumar Savaliya <mukesh.savaliya@oss.qualcomm.com>
++  - Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
++
++properties:
++  qcom,enable-gsi-dma:
++    $ref: /schemas/types.yaml#/definitions/flag
++    description:
++      Configure the Serial Engine (SE) to transfer data in QCOM GPI DMA mode.
++      By default, FIFO mode (PIO/CPU DMA) will be selected.
++
++additionalProperties: true
+diff --git a/Documentation/devicetree/bindings/spi/qcom,spi-geni-qcom.yaml b/Documentation/devicetree/bindings/spi/qcom,spi-geni-qcom.yaml
+index 2e20ca313..d12c5a060 100644
+--- a/Documentation/devicetree/bindings/spi/qcom,spi-geni-qcom.yaml
++++ b/Documentation/devicetree/bindings/spi/qcom,spi-geni-qcom.yaml
+@@ -25,6 +25,7 @@ description:
+ 
+ allOf:
+   - $ref: /schemas/spi/spi-controller.yaml#
++  - $ref: /schemas/soc/qcom/qcom,se-common-props.yaml#
+ 
+ properties:
+   compatible:
+-- 
+2.51.1
+

--- a/patch/kernel/archive/sm8250-6.12/0044-soc-qcom-geni-se-Cleanup-register-defines-and-update.patch
+++ b/patch/kernel/archive/sm8250-6.12/0044-soc-qcom-geni-se-Cleanup-register-defines-and-update.patch
@@ -1,0 +1,106 @@
+From babd3ec5f5172902e08b801efc2cbd6cdd8e2430 Mon Sep 17 00:00:00 2001
+From: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Date: Thu, 11 Sep 2025 10:02:52 +0530
+Subject: [PATCH 2/5] soc: qcom: geni-se: Cleanup register defines and update
+ copyright
+
+Refactor register macros for consistency and clarity and remove redundant
+definitions and update naming for better alignment.
+Update copyright to include Qualcomm Technologies, Inc.
+
+Signed-off-by: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20250911043256.3523057-3-viken.dadhaniya@oss.qualcomm.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+---
+ drivers/soc/qcom/qcom-geni-se.c | 32 ++++++++++++++++----------------
+ 1 file changed, 16 insertions(+), 16 deletions(-)
+
+diff --git a/drivers/soc/qcom/qcom-geni-se.c b/drivers/soc/qcom/qcom-geni-se.c
+index 4cb959106..4968173e1 100644
+--- a/drivers/soc/qcom/qcom-geni-se.c
++++ b/drivers/soc/qcom/qcom-geni-se.c
+@@ -1,5 +1,8 @@
+ // SPDX-License-Identifier: GPL-2.0
+-// Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
++/*
++ *  Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
++ *  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
+ 
+ /* Disable MMIO tracing to prevent excessive logging of unwanted MMIO traces */
+ #define __DISABLE_TRACE_MMIO__
+@@ -110,22 +113,20 @@ struct geni_se_desc {
+ static const char * const icc_path_names[] = {"qup-core", "qup-config",
+ 						"qup-memory"};
+ 
+-#define QUP_HW_VER_REG			0x4
++/* Common QUPV3 registers */
++#define QUPV3_HW_VER_REG		0x4
+ 
+ /* Common SE registers */
+-#define GENI_INIT_CFG_REVISION		0x0
+-#define GENI_S_INIT_CFG_REVISION	0x4
+-#define GENI_OUTPUT_CTRL		0x24
+-#define GENI_CGC_CTRL			0x28
+-#define GENI_CLK_CTRL_RO		0x60
+-#define GENI_FW_S_REVISION_RO		0x6c
++#define SE_GENI_INIT_CFG_REVISION	0x0
++#define SE_GENI_S_INIT_CFG_REVISION	0x4
++#define SE_GENI_CGC_CTRL		0x28
++#define SE_GENI_CLK_CTRL_RO		0x60
++#define SE_GENI_FW_S_REVISION_RO	0x6c
+ #define SE_GENI_BYTE_GRAN		0x254
+ #define SE_GENI_TX_PACKING_CFG0		0x260
+ #define SE_GENI_TX_PACKING_CFG1		0x264
+ #define SE_GENI_RX_PACKING_CFG0		0x284
+ #define SE_GENI_RX_PACKING_CFG1		0x288
+-#define SE_GENI_M_GP_LENGTH		0x910
+-#define SE_GENI_S_GP_LENGTH		0x914
+ #define SE_DMA_TX_PTR_L			0xc30
+ #define SE_DMA_TX_PTR_H			0xc34
+ #define SE_DMA_TX_ATTR			0xc38
+@@ -142,7 +143,6 @@ static const char * const icc_path_names[] = {"qup-core", "qup-config",
+ #define SE_DMA_RX_IRQ_EN		0xd48
+ #define SE_DMA_RX_IRQ_EN_SET		0xd4c
+ #define SE_DMA_RX_IRQ_EN_CLR		0xd50
+-#define SE_DMA_RX_LEN_IN		0xd54
+ #define SE_DMA_RX_MAX_BURST		0xd5c
+ #define SE_DMA_RX_FLUSH			0xd60
+ #define SE_GSI_EVENT_EN			0xe18
+@@ -179,7 +179,7 @@ static const char * const icc_path_names[] = {"qup-core", "qup-config",
+ /* SE_DMA_GENERAL_CFG */
+ #define DMA_RX_CLK_CGC_ON		BIT(0)
+ #define DMA_TX_CLK_CGC_ON		BIT(1)
+-#define DMA_AHB_SLV_CFG_ON		BIT(2)
++#define DMA_AHB_SLV_CLK_CGC_ON		BIT(2)
+ #define AHB_SEC_SLV_CLK_CGC_ON		BIT(3)
+ #define DUMMY_RX_NON_BUFFERABLE		BIT(4)
+ #define RX_DMA_ZERO_PADDING_EN		BIT(5)
+@@ -196,7 +196,7 @@ u32 geni_se_get_qup_hw_version(struct geni_se *se)
+ {
+ 	struct geni_wrapper *wrapper = se->wrapper;
+ 
+-	return readl_relaxed(wrapper->base + QUP_HW_VER_REG);
++	return readl_relaxed(wrapper->base + QUPV3_HW_VER_REG);
+ }
+ EXPORT_SYMBOL_GPL(geni_se_get_qup_hw_version);
+ 
+@@ -220,12 +220,12 @@ static void geni_se_io_init(void __iomem *base)
+ {
+ 	u32 val;
+ 
+-	val = readl_relaxed(base + GENI_CGC_CTRL);
++	val = readl_relaxed(base + SE_GENI_CGC_CTRL);
+ 	val |= DEFAULT_CGC_EN;
+-	writel_relaxed(val, base + GENI_CGC_CTRL);
++	writel_relaxed(val, base + SE_GENI_CGC_CTRL);
+ 
+ 	val = readl_relaxed(base + SE_DMA_GENERAL_CFG);
+-	val |= AHB_SEC_SLV_CLK_CGC_ON | DMA_AHB_SLV_CFG_ON;
++	val |= AHB_SEC_SLV_CLK_CGC_ON | DMA_AHB_SLV_CLK_CGC_ON;
+ 	val |= DMA_TX_CLK_CGC_ON | DMA_RX_CLK_CGC_ON;
+ 	writel_relaxed(val, base + SE_DMA_GENERAL_CFG);
+ 
+-- 
+2.51.1
+

--- a/patch/kernel/archive/sm8250-6.12/0045-soc-qcom-geni-se-Add-support-to-load-QUP-SE-Firmware.patch
+++ b/patch/kernel/archive/sm8250-6.12/0045-soc-qcom-geni-se-Add-support-to-load-QUP-SE-Firmware.patch
@@ -1,0 +1,591 @@
+From d5b72435dcb07b2dab4e4be8459b27c71d7e267b Mon Sep 17 00:00:00 2001
+From: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Date: Thu, 11 Sep 2025 10:02:53 +0530
+Subject: [PATCH 3/5] soc: qcom: geni-se: Add support to load QUP SE Firmware
+ via Linux subsystem
+
+In Qualcomm SoCs, firmware loading for Serial Engines (SE) within the QUP
+hardware has traditionally been managed by TrustZone (TZ). This restriction
+poses a significant challenge for developers, as it limits their ability to
+enable various protocols on any of the SEs from the Linux side, reducing
+flexibility.
+
+Load the firmware to QUP SE based on the 'firmware-name' property specified
+in devicetree at bootup time.
+
+Co-developed-by: Mukesh Kumar Savaliya <mukesh.savaliya@oss.qualcomm.com>
+Signed-off-by: Mukesh Kumar Savaliya <mukesh.savaliya@oss.qualcomm.com>
+Signed-off-by: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20250911043256.3523057-4-viken.dadhaniya@oss.qualcomm.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+---
+ drivers/soc/qcom/qcom-geni-se.c  | 474 ++++++++++++++++++++++++++++++-
+ include/linux/soc/qcom/geni-se.h |   4 +
+ 2 files changed, 475 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/soc/qcom/qcom-geni-se.c b/drivers/soc/qcom/qcom-geni-se.c
+index 4968173e1..359593c8d 100644
+--- a/drivers/soc/qcom/qcom-geni-se.c
++++ b/drivers/soc/qcom/qcom-geni-se.c
+@@ -8,7 +8,9 @@
+ #define __DISABLE_TRACE_MMIO__
+ 
+ #include <linux/acpi.h>
++#include <linux/bitfield.h>
+ #include <linux/clk.h>
++#include <linux/firmware.h>
+ #include <linux/slab.h>
+ #include <linux/dma-mapping.h>
+ #include <linux/io.h>
+@@ -113,8 +115,80 @@ struct geni_se_desc {
+ static const char * const icc_path_names[] = {"qup-core", "qup-config",
+ 						"qup-memory"};
+ 
++static const char * const protocol_name[] = { "None", "SPI", "UART", "I2C", "I3C", "SPI SLAVE" };
++
++/**
++ * struct se_fw_hdr - Serial Engine firmware configuration header
++ *
++ * This structure defines the SE firmware header, which together with the
++ * firmware payload is stored in individual ELF segments.
++ *
++ * @magic: Set to 'SEFW'.
++ * @version: Structure version number.
++ * @core_version: QUPV3 hardware version.
++ * @serial_protocol: Encoded in GENI_FW_REVISION.
++ * @fw_version: Firmware version, from GENI_FW_REVISION.
++ * @cfg_version: Configuration version, from GENI_INIT_CFG_REVISION.
++ * @fw_size_in_items: Number of 32-bit words in GENI_FW_RAM.
++ * @fw_offset: Byte offset to GENI_FW_RAM array.
++ * @cfg_size_in_items: Number of GENI_FW_CFG index/value pairs.
++ * @cfg_idx_offset: Byte offset to GENI_FW_CFG index array.
++ * @cfg_val_offset: Byte offset to GENI_FW_CFG values array.
++ */
++struct se_fw_hdr {
++	__le32 magic;
++	__le32 version;
++	__le32 core_version;
++	__le16 serial_protocol;
++	__le16 fw_version;
++	__le16 cfg_version;
++	__le16 fw_size_in_items;
++	__le16 fw_offset;
++	__le16 cfg_size_in_items;
++	__le16 cfg_idx_offset;
++	__le16 cfg_val_offset;
++};
++
++/*Magic numbers*/
++#define SE_MAGIC_NUM			0x57464553
++
++#define MAX_GENI_CFG_RAMn_CNT		455
++
++#define MI_PBT_NON_PAGED_SEGMENT	0x0
++#define MI_PBT_HASH_SEGMENT		0x2
++#define MI_PBT_NOTUSED_SEGMENT		0x3
++#define MI_PBT_SHARED_SEGMENT		0x4
++
++#define MI_PBT_FLAG_PAGE_MODE		BIT(20)
++#define MI_PBT_FLAG_SEGMENT_TYPE	GENMASK(26, 24)
++#define MI_PBT_FLAG_ACCESS_TYPE		GENMASK(23, 21)
++
++#define MI_PBT_PAGE_MODE_VALUE(x) FIELD_GET(MI_PBT_FLAG_PAGE_MODE, x)
++
++#define MI_PBT_SEGMENT_TYPE_VALUE(x) FIELD_GET(MI_PBT_FLAG_SEGMENT_TYPE, x)
++
++#define MI_PBT_ACCESS_TYPE_VALUE(x) FIELD_GET(MI_PBT_FLAG_ACCESS_TYPE, x)
++
++#define M_COMMON_GENI_M_IRQ_EN	(GENMASK(6, 1) | \
++				M_IO_DATA_DEASSERT_EN | \
++				M_IO_DATA_ASSERT_EN | M_RX_FIFO_RD_ERR_EN | \
++				M_RX_FIFO_WR_ERR_EN | M_TX_FIFO_RD_ERR_EN | \
++				M_TX_FIFO_WR_ERR_EN)
++
+ /* Common QUPV3 registers */
+ #define QUPV3_HW_VER_REG		0x4
++#define QUPV3_SE_AHB_M_CFG		0x118
++#define QUPV3_COMMON_CFG		0x120
++#define QUPV3_COMMON_CGC_CTRL		0x21c
++
++/* QUPV3_COMMON_CFG fields */
++#define FAST_SWITCH_TO_HIGH_DISABLE	BIT(0)
++
++/* QUPV3_SE_AHB_M_CFG fields */
++#define AHB_M_CLK_CGC_ON		BIT(0)
++
++/* QUPV3_COMMON_CGC_CTRL fields */
++#define COMMON_CSR_SLV_CLK_CGC_ON	BIT(0)
+ 
+ /* Common SE registers */
+ #define SE_GENI_INIT_CFG_REVISION	0x0
+@@ -122,11 +196,13 @@ static const char * const icc_path_names[] = {"qup-core", "qup-config",
+ #define SE_GENI_CGC_CTRL		0x28
+ #define SE_GENI_CLK_CTRL_RO		0x60
+ #define SE_GENI_FW_S_REVISION_RO	0x6c
++#define SE_GENI_CFG_REG0		0x100
+ #define SE_GENI_BYTE_GRAN		0x254
+ #define SE_GENI_TX_PACKING_CFG0		0x260
+ #define SE_GENI_TX_PACKING_CFG1		0x264
+ #define SE_GENI_RX_PACKING_CFG0		0x284
+ #define SE_GENI_RX_PACKING_CFG1		0x288
++#define SE_GENI_S_IRQ_ENABLE		0x644
+ #define SE_DMA_TX_PTR_L			0xc30
+ #define SE_DMA_TX_PTR_H			0xc34
+ #define SE_DMA_TX_ATTR			0xc38
+@@ -148,6 +224,15 @@ static const char * const icc_path_names[] = {"qup-core", "qup-config",
+ #define SE_GSI_EVENT_EN			0xe18
+ #define SE_IRQ_EN			0xe1c
+ #define SE_DMA_GENERAL_CFG		0xe30
++#define SE_GENI_FW_REVISION		0x1000
++#define SE_GENI_S_FW_REVISION		0x1004
++#define SE_GENI_CFG_RAMN		0x1010
++#define SE_GENI_CLK_CTRL		0x2000
++#define SE_DMA_IF_EN			0x2004
++#define SE_FIFO_IF_DISABLE		0x2008
++
++/* GENI_FW_REVISION_RO fields */
++#define FW_REV_VERSION_MSK		GENMASK(7, 0)
+ 
+ /* GENI_OUTPUT_CTRL fields */
+ #define DEFAULT_IO_OUTPUT_CTRL_MSK	GENMASK(6, 0)
+@@ -186,6 +271,15 @@ static const char * const icc_path_names[] = {"qup-core", "qup-config",
+ #define RX_DMA_IRQ_DELAY_MSK		GENMASK(8, 6)
+ #define RX_DMA_IRQ_DELAY_SHFT		6
+ 
++/* GENI_CLK_CTRL fields */
++#define SER_CLK_SEL			BIT(0)
++
++/* GENI_DMA_IF_EN fields */
++#define DMA_IF_EN			BIT(0)
++
++#define geni_setbits32(_addr, _v) writel(readl(_addr) |  (_v), _addr)
++#define geni_clrbits32(_addr, _v) writel(readl(_addr) & ~(_v), _addr)
++
+ /**
+  * geni_se_get_qup_hw_version() - Read the QUP wrapper Hardware version
+  * @se:	Pointer to the corresponding serial engine.
+@@ -658,9 +752,12 @@ int geni_se_clk_freq_match(struct geni_se *se, unsigned long req_freq,
+ }
+ EXPORT_SYMBOL_GPL(geni_se_clk_freq_match);
+ 
+-#define GENI_SE_DMA_DONE_EN BIT(0)
+-#define GENI_SE_DMA_EOT_EN BIT(1)
+-#define GENI_SE_DMA_AHB_ERR_EN BIT(2)
++#define GENI_SE_DMA_DONE_EN		BIT(0)
++#define GENI_SE_DMA_EOT_EN		BIT(1)
++#define GENI_SE_DMA_AHB_ERR_EN		BIT(2)
++#define GENI_SE_DMA_RESET_DONE_EN	BIT(3)
++#define GENI_SE_DMA_FLUSH_DONE		BIT(4)
++
+ #define GENI_SE_DMA_EOT_BUF BIT(0)
+ 
+ /**
+@@ -891,6 +988,377 @@ int geni_icc_disable(struct geni_se *se)
+ }
+ EXPORT_SYMBOL_GPL(geni_icc_disable);
+ 
++/**
++ * geni_find_protocol_fw() - Locate and validate SE firmware for a protocol.
++ * @dev: Pointer to the device structure.
++ * @fw: Pointer to the firmware image.
++ * @protocol: Expected serial engine protocol type.
++ *
++ * Identifies the appropriate firmware image or configuration required for a
++ * specific communication protocol instance running on a  Qualcomm GENI
++ * controller.
++ *
++ * Return: pointer to a valid 'struct se_fw_hdr' if found, or NULL otherwise.
++ */
++static struct se_fw_hdr *geni_find_protocol_fw(struct device *dev, const struct firmware *fw,
++					       enum geni_se_protocol_type protocol)
++{
++	const struct elf32_hdr *ehdr;
++	const struct elf32_phdr *phdrs;
++	const struct elf32_phdr	*phdr;
++	struct se_fw_hdr *sefw;
++	u32 fw_end, cfg_idx_end, cfg_val_end;
++	u16 fw_size;
++	int i;
++
++	if (!fw || fw->size < sizeof(struct elf32_hdr))
++		return NULL;
++
++	ehdr = (const struct elf32_hdr *)fw->data;
++	phdrs = (const struct elf32_phdr *)(fw->data + ehdr->e_phoff);
++
++	/*
++	 * The firmware is expected to have at least two program headers (segments).
++	 * One for metadata and the other for the actual protocol-specific firmware.
++	 */
++	if (ehdr->e_phnum < 2) {
++		dev_err(dev, "Invalid firmware: less than 2 program headers\n");
++		return NULL;
++	}
++
++	for (i = 0; i < ehdr->e_phnum; i++) {
++		phdr = &phdrs[i];
++
++		if (fw->size < phdr->p_offset + phdr->p_filesz) {
++			dev_err(dev, "Firmware size (%zu) < expected offset (%u) + size (%u)\n",
++				fw->size, phdr->p_offset, phdr->p_filesz);
++			return NULL;
++		}
++
++		if (phdr->p_type != PT_LOAD || !phdr->p_memsz)
++			continue;
++
++		if (MI_PBT_PAGE_MODE_VALUE(phdr->p_flags) != MI_PBT_NON_PAGED_SEGMENT ||
++		    MI_PBT_SEGMENT_TYPE_VALUE(phdr->p_flags) == MI_PBT_HASH_SEGMENT ||
++		    MI_PBT_ACCESS_TYPE_VALUE(phdr->p_flags) == MI_PBT_NOTUSED_SEGMENT ||
++		    MI_PBT_ACCESS_TYPE_VALUE(phdr->p_flags) == MI_PBT_SHARED_SEGMENT)
++			continue;
++
++		if (phdr->p_filesz < sizeof(struct se_fw_hdr))
++			continue;
++
++		sefw = (struct se_fw_hdr *)(fw->data + phdr->p_offset);
++		fw_size = le16_to_cpu(sefw->fw_size_in_items);
++		fw_end = le16_to_cpu(sefw->fw_offset) + fw_size * sizeof(u32);
++		cfg_idx_end = le16_to_cpu(sefw->cfg_idx_offset) +
++			      le16_to_cpu(sefw->cfg_size_in_items) * sizeof(u8);
++		cfg_val_end = le16_to_cpu(sefw->cfg_val_offset) +
++			      le16_to_cpu(sefw->cfg_size_in_items) * sizeof(u32);
++
++		if (le32_to_cpu(sefw->magic) != SE_MAGIC_NUM || le32_to_cpu(sefw->version) != 1)
++			continue;
++
++		if (le32_to_cpu(sefw->serial_protocol) != protocol)
++			continue;
++
++		if (fw_size % 2 != 0) {
++			fw_size++;
++			sefw->fw_size_in_items = cpu_to_le16(fw_size);
++		}
++
++		if (fw_size >= MAX_GENI_CFG_RAMn_CNT) {
++			dev_err(dev,
++				"Firmware size (%u) exceeds max allowed RAMn count (%u)\n",
++				fw_size, MAX_GENI_CFG_RAMn_CNT);
++			continue;
++		}
++
++		if (fw_end > phdr->p_filesz || cfg_idx_end > phdr->p_filesz ||
++		    cfg_val_end > phdr->p_filesz) {
++			dev_err(dev, "Truncated or corrupt SE FW segment found at index %d\n", i);
++			continue;
++		}
++
++		return sefw;
++	}
++
++	dev_err(dev, "Failed to get %s protocol firmware\n", protocol_name[protocol]);
++	return NULL;
++}
++
++/**
++ * geni_configure_xfer_mode() - Set the transfer mode.
++ * @se: Pointer to the concerned serial engine.
++ * @mode: SE data transfer mode.
++ *
++ * Set the transfer mode to either FIFO or DMA according to the mode specified
++ * by the protocol driver.
++ *
++ * Return: 0 if successful, otherwise return an error value.
++ */
++static int geni_configure_xfer_mode(struct geni_se *se, enum geni_se_xfer_mode mode)
++{
++	/* Configure SE FIFO, DMA or GSI mode. */
++	switch (mode) {
++	case GENI_GPI_DMA:
++		geni_setbits32(se->base + SE_GENI_DMA_MODE_EN, GENI_DMA_MODE_EN);
++		writel(0x0, se->base + SE_IRQ_EN);
++		writel(DMA_RX_EVENT_EN | DMA_TX_EVENT_EN | GENI_M_EVENT_EN | GENI_S_EVENT_EN,
++		       se->base + SE_GSI_EVENT_EN);
++		break;
++
++	case GENI_SE_FIFO:
++		geni_clrbits32(se->base + SE_GENI_DMA_MODE_EN, GENI_DMA_MODE_EN);
++		writel(DMA_RX_IRQ_EN | DMA_TX_IRQ_EN | GENI_M_IRQ_EN | GENI_S_IRQ_EN,
++		       se->base + SE_IRQ_EN);
++		writel(0x0, se->base + SE_GSI_EVENT_EN);
++		break;
++
++	case GENI_SE_DMA:
++		geni_setbits32(se->base + SE_GENI_DMA_MODE_EN, GENI_DMA_MODE_EN);
++		writel(DMA_RX_IRQ_EN | DMA_TX_IRQ_EN | GENI_M_IRQ_EN | GENI_S_IRQ_EN,
++		       se->base + SE_IRQ_EN);
++		writel(0x0, se->base + SE_GSI_EVENT_EN);
++		break;
++
++	default:
++		dev_err(se->dev, "Invalid geni-se transfer mode: %d\n", mode);
++		return -EINVAL;
++	}
++	return 0;
++}
++
++/**
++ * geni_enable_interrupts() - Enable interrupts.
++ * @se: Pointer to the concerned serial engine.
++ *
++ * Enable the required interrupts during the firmware load process.
++ */
++static void geni_enable_interrupts(struct geni_se *se)
++{
++	u32 val;
++
++	/* Enable required interrupts. */
++	writel(M_COMMON_GENI_M_IRQ_EN, se->base + SE_GENI_M_IRQ_EN);
++
++	val = S_CMD_OVERRUN_EN | S_ILLEGAL_CMD_EN | S_CMD_CANCEL_EN | S_CMD_ABORT_EN |
++	      S_GP_IRQ_0_EN | S_GP_IRQ_1_EN | S_GP_IRQ_2_EN | S_GP_IRQ_3_EN |
++	      S_RX_FIFO_WR_ERR_EN | S_RX_FIFO_RD_ERR_EN;
++	writel(val, se->base + SE_GENI_S_IRQ_ENABLE);
++
++	/* DMA mode configuration. */
++	val = GENI_SE_DMA_RESET_DONE_EN | GENI_SE_DMA_AHB_ERR_EN | GENI_SE_DMA_DONE_EN;
++	writel(val, se->base + SE_DMA_TX_IRQ_EN_SET);
++	val = GENI_SE_DMA_FLUSH_DONE | GENI_SE_DMA_RESET_DONE_EN | GENI_SE_DMA_AHB_ERR_EN |
++	      GENI_SE_DMA_DONE_EN;
++	writel(val, se->base + SE_DMA_RX_IRQ_EN_SET);
++}
++
++/**
++ * geni_write_fw_revision() - Write the firmware revision.
++ * @se: Pointer to the concerned serial engine.
++ * @serial_protocol: serial protocol type.
++ * @fw_version: QUP firmware version.
++ *
++ * Write the firmware revision and protocol into the respective register.
++ */
++static void geni_write_fw_revision(struct geni_se *se, u16 serial_protocol, u16 fw_version)
++{
++	u32 reg;
++
++	reg = FIELD_PREP(FW_REV_PROTOCOL_MSK, serial_protocol);
++	reg |= FIELD_PREP(FW_REV_VERSION_MSK, fw_version);
++
++	writel(reg, se->base + SE_GENI_FW_REVISION);
++	writel(reg, se->base + SE_GENI_S_FW_REVISION);
++}
++
++/**
++ * geni_load_se_fw() - Load Serial Engine specific firmware.
++ * @se: Pointer to the concerned serial engine.
++ * @fw: Pointer to the firmware structure.
++ * @mode: SE data transfer mode.
++ * @protocol: Protocol type to be used with the SE (e.g., UART, SPI, I2C).
++ *
++ * Load the protocol firmware into the IRAM of the Serial Engine.
++ *
++ * Return: 0 if successful, otherwise return an error value.
++ */
++static int geni_load_se_fw(struct geni_se *se, const struct firmware *fw,
++			   enum geni_se_xfer_mode mode, enum geni_se_protocol_type protocol)
++{
++	const u32 *fw_data, *cfg_val_arr;
++	const u8 *cfg_idx_arr;
++	u32 i, reg_value;
++	int ret;
++	struct se_fw_hdr *hdr;
++
++	hdr = geni_find_protocol_fw(se->dev, fw, protocol);
++	if (!hdr)
++		return -EINVAL;
++
++	fw_data = (const u32 *)((u8 *)hdr + le16_to_cpu(hdr->fw_offset));
++	cfg_idx_arr = (const u8 *)hdr + le16_to_cpu(hdr->cfg_idx_offset);
++	cfg_val_arr = (const u32 *)((u8 *)hdr + le16_to_cpu(hdr->cfg_val_offset));
++
++	ret = geni_icc_set_bw(se);
++	if (ret)
++		return ret;
++
++	ret = geni_icc_enable(se);
++	if (ret)
++		return ret;
++
++	ret = geni_se_resources_on(se);
++	if (ret)
++		goto out_icc_disable;
++
++	/*
++	 * Disable high-priority interrupts until all currently executing
++	 * low-priority interrupts have been fully handled.
++	 */
++	geni_setbits32(se->wrapper->base + QUPV3_COMMON_CFG, FAST_SWITCH_TO_HIGH_DISABLE);
++
++	/* Set AHB_M_CLK_CGC_ON to indicate hardware controls se-wrapper cgc clock. */
++	geni_setbits32(se->wrapper->base + QUPV3_SE_AHB_M_CFG, AHB_M_CLK_CGC_ON);
++
++	/* Let hardware to control common cgc. */
++	geni_setbits32(se->wrapper->base + QUPV3_COMMON_CGC_CTRL, COMMON_CSR_SLV_CLK_CGC_ON);
++
++	/*
++	 * Setting individual bits in GENI_OUTPUT_CTRL activates corresponding output lines,
++	 * allowing the hardware to drive data as configured.
++	 */
++	writel(0x0, se->base + GENI_OUTPUT_CTRL);
++
++	/* Set SCLK and HCLK to program RAM */
++	geni_setbits32(se->base + SE_GENI_CGC_CTRL, PROG_RAM_SCLK_OFF | PROG_RAM_HCLK_OFF);
++	writel(0x0, se->base + SE_GENI_CLK_CTRL);
++	geni_clrbits32(se->base + SE_GENI_CGC_CTRL, PROG_RAM_SCLK_OFF | PROG_RAM_HCLK_OFF);
++
++	/* Enable required clocks for DMA CSR, TX and RX. */
++	reg_value = AHB_SEC_SLV_CLK_CGC_ON | DMA_AHB_SLV_CLK_CGC_ON |
++		    DMA_TX_CLK_CGC_ON | DMA_RX_CLK_CGC_ON;
++	geni_setbits32(se->base + SE_DMA_GENERAL_CFG, reg_value);
++
++	/* Let hardware control CGC by default. */
++	writel(DEFAULT_CGC_EN, se->base + SE_GENI_CGC_CTRL);
++
++	/* Set version of the configuration register part of firmware. */
++	writel(le16_to_cpu(hdr->cfg_version), se->base + SE_GENI_INIT_CFG_REVISION);
++	writel(le16_to_cpu(hdr->cfg_version), se->base + SE_GENI_S_INIT_CFG_REVISION);
++
++	/* Configure GENI primitive table. */
++	for (i = 0; i < le16_to_cpu(hdr->cfg_size_in_items); i++)
++		writel(cfg_val_arr[i],
++		       se->base + SE_GENI_CFG_REG0 + (cfg_idx_arr[i] * sizeof(u32)));
++
++	/* Configure condition for assertion of RX_RFR_WATERMARK condition. */
++	reg_value = geni_se_get_rx_fifo_depth(se);
++	writel(reg_value - 2, se->base + SE_GENI_RX_RFR_WATERMARK_REG);
++
++	/* Let hardware control CGC */
++	geni_setbits32(se->base + GENI_OUTPUT_CTRL, DEFAULT_IO_OUTPUT_CTRL_MSK);
++
++	ret = geni_configure_xfer_mode(se, mode);
++	if (ret)
++		goto out_resources_off;
++
++	geni_enable_interrupts(se);
++
++	geni_write_fw_revision(se, le16_to_cpu(hdr->serial_protocol), le16_to_cpu(hdr->fw_version));
++
++	/* Program RAM address space. */
++	memcpy_toio(se->base + SE_GENI_CFG_RAMN, fw_data,
++		    le16_to_cpu(hdr->fw_size_in_items) * sizeof(u32));
++
++	/* Put default values on GENI's output pads. */
++	writel_relaxed(0x1, se->base + GENI_FORCE_DEFAULT_REG);
++
++	/* Toggle SCLK/HCLK from high to low to finalize RAM programming and apply config. */
++	geni_setbits32(se->base + SE_GENI_CGC_CTRL, PROG_RAM_SCLK_OFF | PROG_RAM_HCLK_OFF);
++	geni_setbits32(se->base + SE_GENI_CLK_CTRL, SER_CLK_SEL);
++	geni_clrbits32(se->base + SE_GENI_CGC_CTRL, PROG_RAM_SCLK_OFF | PROG_RAM_HCLK_OFF);
++
++	/* Serial engine DMA interface is enabled. */
++	geni_setbits32(se->base + SE_DMA_IF_EN, DMA_IF_EN);
++
++	/* Enable or disable FIFO interface of the serial engine. */
++	if (mode == GENI_SE_FIFO)
++		geni_clrbits32(se->base + SE_FIFO_IF_DISABLE, FIFO_IF_DISABLE);
++	else
++		geni_setbits32(se->base + SE_FIFO_IF_DISABLE, FIFO_IF_DISABLE);
++
++out_resources_off:
++	geni_se_resources_off(se);
++
++out_icc_disable:
++	geni_icc_disable(se);
++	return ret;
++}
++
++/**
++ * geni_load_se_firmware() - Load firmware for SE based on protocol
++ * @se: Pointer to the concerned serial engine.
++ * @protocol: Protocol type to be used with the SE (e.g., UART, SPI, I2C).
++ *
++ * Retrieves the firmware name from device properties and sets the transfer mode
++ * (FIFO or GSI DMA) based on device tree configuration. Enforces FIFO mode for
++ * UART protocol due to lack of GSI DMA support. Requests the firmware and loads
++ * it into the SE.
++ *
++ * Return: 0 on success, negative error code on failure.
++ */
++int geni_load_se_firmware(struct geni_se *se, enum geni_se_protocol_type protocol)
++{
++	const char *fw_name;
++	const struct firmware *fw;
++	enum geni_se_xfer_mode mode = GENI_SE_FIFO;
++	int ret;
++
++	if (protocol >= ARRAY_SIZE(protocol_name)) {
++		dev_err(se->dev, "Invalid geni-se protocol: %d", protocol);
++		return -EINVAL;
++	}
++
++	ret = device_property_read_string(se->wrapper->dev, "firmware-name", &fw_name);
++	if (ret) {
++		dev_err(se->dev, "Failed to read firmware-name property: %d\n", ret);
++		return -EINVAL;
++	}
++
++	if (of_property_read_bool(se->dev->of_node, "qcom,enable-gsi-dma"))
++		mode = GENI_GPI_DMA;
++
++	/* GSI mode is not supported by the UART driver; therefore, setting FIFO mode */
++	if (protocol == GENI_SE_UART)
++		mode = GENI_SE_FIFO;
++
++	ret = request_firmware(&fw, fw_name, se->dev);
++	if (ret) {
++		if (ret == -ENOENT)
++			return -EPROBE_DEFER;
++
++		dev_err(se->dev, "Failed to request firmware '%s' for protocol %d: ret: %d\n",
++			fw_name, protocol, ret);
++		return ret;
++	}
++
++	ret = geni_load_se_fw(se, fw, mode, protocol);
++	release_firmware(fw);
++
++	if (ret) {
++		dev_err(se->dev, "Failed to load SE firmware for protocol %d: ret: %d\n",
++			protocol, ret);
++		return ret;
++	}
++
++	dev_dbg(se->dev, "Firmware load for %s protocol is successful for xfer mode: %d\n",
++		protocol_name[protocol], mode);
++	return 0;
++}
++EXPORT_SYMBOL_GPL(geni_load_se_firmware);
++
+ static int geni_se_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+diff --git a/include/linux/soc/qcom/geni-se.h b/include/linux/soc/qcom/geni-se.h
+index 2996a3c28..0a984e257 100644
+--- a/include/linux/soc/qcom/geni-se.h
++++ b/include/linux/soc/qcom/geni-se.h
+@@ -1,6 +1,7 @@
+ /* SPDX-License-Identifier: GPL-2.0 */
+ /*
+  * Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+  */
+ 
+ #ifndef _LINUX_QCOM_GENI_SE
+@@ -36,6 +37,7 @@ enum geni_se_protocol_type {
+ 	GENI_SE_I2C,
+ 	GENI_SE_I3C,
+ 	GENI_SE_SPI_SLAVE,
++	GENI_SE_INVALID_PROTO = 255,
+ };
+ 
+ struct geni_wrapper;
+@@ -531,5 +533,7 @@ void geni_icc_set_tag(struct geni_se *se, u32 tag);
+ int geni_icc_enable(struct geni_se *se);
+ 
+ int geni_icc_disable(struct geni_se *se);
++
++int geni_load_se_firmware(struct geni_se *se, enum geni_se_protocol_type protocol);
+ #endif
+ #endif
+-- 
+2.51.1
+

--- a/patch/kernel/archive/sm8250-6.12/0046-i2c-qcom-geni-Load-i2c-qup-Firmware-from-linux-side.patch
+++ b/patch/kernel/archive/sm8250-6.12/0046-i2c-qcom-geni-Load-i2c-qup-Firmware-from-linux-side.patch
@@ -1,0 +1,42 @@
+From 6b62f495aa3d5e6c17b61bc27f2f8673b4e4c829 Mon Sep 17 00:00:00 2001
+From: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Date: Thu, 11 Sep 2025 10:02:54 +0530
+Subject: [PATCH 4/5] i2c: qcom-geni: Load i2c qup Firmware from linux side
+
+Add provision to load firmware of Serial engine for I2C protocol from
+Linux Execution Environment on running on APPS processor.
+
+Acked-by: Andi Shyti <andi.shyti@kernel.org>
+Co-developed-by: Mukesh Kumar Savaliya <mukesh.savaliya@oss.qualcomm.com>
+Signed-off-by: Mukesh Kumar Savaliya <mukesh.savaliya@oss.qualcomm.com>
+Signed-off-by: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20250911043256.3523057-5-viken.dadhaniya@oss.qualcomm.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+---
+ drivers/i2c/busses/i2c-qcom-geni.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/busses/i2c-qcom-geni.c b/drivers/i2c/busses/i2c-qcom-geni.c
+index 212336f72..f307aa2ac 100644
+--- a/drivers/i2c/busses/i2c-qcom-geni.c
++++ b/drivers/i2c/busses/i2c-qcom-geni.c
+@@ -858,7 +858,15 @@ static int geni_i2c_probe(struct platform_device *pdev)
+ 		return ret;
+ 	}
+ 	proto = geni_se_read_proto(&gi2c->se);
+-	if (proto != GENI_SE_I2C) {
++	if (proto == GENI_SE_INVALID_PROTO) {
++		ret = geni_load_se_firmware(&gi2c->se, GENI_SE_I2C);
++		if (ret) {
++			dev_err_probe(dev, ret, "i2c firmware load failed ret: %d\n", ret);
++			geni_se_resources_off(&gi2c->se);
++			clk_disable_unprepare(gi2c->core_clk);
++			return ret;
++		}
++	} else if (proto != GENI_SE_I2C) {
+ 		dev_err(dev, "Invalid proto %d\n", proto);
+ 		geni_se_resources_off(&gi2c->se);
+ 		clk_disable_unprepare(gi2c->core_clk);
+-- 
+2.51.1
+

--- a/patch/kernel/archive/sm8250-6.12/0047-spi-geni-qcom-Load-spi-qup-Firmware-from-linux-side.patch
+++ b/patch/kernel/archive/sm8250-6.12/0047-spi-geni-qcom-Load-spi-qup-Firmware-from-linux-side.patch
@@ -1,0 +1,38 @@
+From effd812be82787c08b63254bff71f11bb1b01b55 Mon Sep 17 00:00:00 2001
+From: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Date: Thu, 11 Sep 2025 10:02:55 +0530
+Subject: [PATCH 5/5] spi: geni-qcom: Load spi qup Firmware from linux side
+
+Add provision to load firmware of Serial engine for SPI protocol from
+Linux Execution Environment on running on APPS processor.
+
+Co-developed-by: Mukesh Kumar Savaliya <mukesh.savaliya@oss.qualcomm.com>
+Signed-off-by: Mukesh Kumar Savaliya <mukesh.savaliya@oss.qualcomm.com>
+Signed-off-by: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Acked-by: Mark Brown <broonie@kernel.org>
+Link: https://lore.kernel.org/r/20250911043256.3523057-6-viken.dadhaniya@oss.qualcomm.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+---
+ drivers/spi/spi-geni-qcom.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/spi/spi-geni-qcom.c b/drivers/spi/spi-geni-qcom.c
+index 768d74821..a0d8d3425 100644
+--- a/drivers/spi/spi-geni-qcom.c
++++ b/drivers/spi/spi-geni-qcom.c
+@@ -671,6 +671,12 @@ static int spi_geni_init(struct spi_geni_master *mas)
+ 			goto out_pm;
+ 		}
+ 		spi_slv_setup(mas);
++	} else if (proto == GENI_SE_INVALID_PROTO) {
++		ret = geni_load_se_firmware(se, GENI_SE_SPI);
++		if (ret) {
++			dev_err(mas->dev, "spi master firmware load failed ret: %d\n", ret);
++			goto out_pm;
++		}
+ 	} else if (proto != GENI_SE_SPI) {
+ 		dev_err(mas->dev, "Invalid proto %d\n", proto);
+ 		goto out_pm;
+-- 
+2.51.1
+

--- a/patch/kernel/archive/sm8250-6.12/0048-serial-qcom-geni-Load-UART-qup-Firmware-from-linux-s.patch
+++ b/patch/kernel/archive/sm8250-6.12/0048-serial-qcom-geni-Load-UART-qup-Firmware-from-linux-s.patch
@@ -1,0 +1,39 @@
+From d00c7f54a14f2d1557dc1213f9d11eea1e33dcec Mon Sep 17 00:00:00 2001
+From: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Date: Thu, 11 Sep 2025 10:02:56 +0530
+Subject: [PATCH] serial: qcom-geni: Load UART qup Firmware from linux side
+
+Add provision to load firmware of Serial engine for UART protocol from
+Linux Execution Environment on running on APPS processor.
+
+Co-developed-by: Mukesh Kumar Savaliya <mukesh.savaliya@oss.qualcomm.com>
+Signed-off-by: Mukesh Kumar Savaliya <mukesh.savaliya@oss.qualcomm.com>
+Signed-off-by: Viken Dadhaniya <viken.dadhaniya@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20250911043256.3523057-7-viken.dadhaniya@oss.qualcomm.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+---
+ drivers/tty/serial/qcom_geni_serial.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/tty/serial/qcom_geni_serial.c b/drivers/tty/serial/qcom_geni_serial.c
+index 5dfe4e599..e7e1291e0 100644
+--- a/drivers/tty/serial/qcom_geni_serial.c
++++ b/drivers/tty/serial/qcom_geni_serial.c
+@@ -1145,7 +1145,13 @@ static int qcom_geni_serial_port_setup(struct uart_port *uport)
+ 	int ret;
+ 
+ 	proto = geni_se_read_proto(&port->se);
+-	if (proto != GENI_SE_UART) {
++	if (proto == GENI_SE_INVALID_PROTO) {
++		ret = geni_load_se_firmware(&port->se, GENI_SE_UART);
++		if (ret) {
++			dev_err(uport->dev, "UART firmware load failed ret: %d\n", ret);
++			return ret;
++		}
++	} else if (proto != GENI_SE_UART) {
+ 		dev_err(uport->dev, "Invalid FW loaded, proto: %d\n", proto);
+ 		return -ENXIO;
+ 	}
+-- 
+2.51.1
+


### PR DESCRIPTION
# Description

The backported patch from Linux 6.18 allows loading QUP firmware under the Linux system.

**LKML url:**

https://lore.kernel.org/all/175813699406.66282.993438408948834854.b4-ty@kernel.org/

**The commit for each patch in the GitHub Linux repository:**

https://github.com/torvalds/linux/commit/9bc7130822c4c7f3ef39f20174a379e476586ab3

https://github.com/torvalds/linux/commit/b44a593fb53a6f5e135af2c5351546f80c1285ac

https://github.com/torvalds/linux/commit/d4bf06592ad68ac4353a81c73e8e662cf88aa2cc

https://github.com/torvalds/linux/commit/b645df76536c5b7d40e60450bf8011f70f34415f

https://github.com/torvalds/linux/commit/99cf351ee1c46b39c0581220807290b1dd56488e

https://github.com/torvalds/linux/commit/3f1707306b79cafc5a11350befd5a4081b807760

By appending .patch to the end of these URLs, you get the patches in this PR. The qup i2c patch had some minor errors under the 6.12 kernel, and I have corrected them.

# How Has This Been Tested?

use `./compile.sh BOARD=damo-cockpit8250 BRANCH=current RELEASE=noble` to compile the image for my own QCS8250 device.

Before applying the patches:

```
root@damo-cockpit8250:~# dmesg | grep geni
[    0.142517] geni_se_qup 8c0000.geniqup: Adding to iommu group 1
[    0.143304] geni_i2c 884000.i2c: Bus frequency not specified, default to 100kHz.
[    0.143817] geni_se_qup 9c0000.geniqup: Adding to iommu group 2
[    0.145091] geni_se_qup ac0000.geniqup: Adding to iommu group 3
[    4.336172] geni_spi 988000.spi: Invalid proto 255
[   13.358430] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
[   13.422149] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
[   13.422213] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
[   15.874260] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
[   15.941918] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
[   15.942344] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
[   19.074146] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
[   19.142152] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
[   19.142343] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
[   21.570472] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
[   21.634173] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
[   21.634819] qcom_geni_serial 998000.serial: Invalid FW loaded, proto: 255
root@damo-cockpit8250:~#
```

After applying the patches:

```
root@damo-cockpit8250:~# dmesg | grep geni
[    0.142838] geni_se_qup 8c0000.geniqup: Adding to iommu group 1
[    0.143640] geni_i2c 884000.i2c: Bus frequency not specified, default to 100kHz.
[    0.144167] geni_se_qup 9c0000.geniqup: Adding to iommu group 2
[    0.145014] geni_se_qup ac0000.geniqup: Adding to iommu group 3
root@damo-cockpit8250:~#
```

It is worth noting that the qup firmware needs to be added to the initramfs.

For the mainline armbian/build source code, use `./compile.sh BOARD=xiaomi-elish BRANCH=current RELEASE=noble` to ensure the kernel compiles successfully.

Why can't I build a complete xiaomi-elish image? Because the official mkbootimg in Noble seems to have a bug.For my own device, [there](https://github.com/retro98boy/armbian-build/commit/6efcde0ca5c34ebddbb0156a6bfaf4922e7406f0) is a temporary fix.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * I2C, SPI, and UART GENI serial engines now support automatic on-demand firmware loading for improved driver initialization.

* **Documentation**
  * Added unified device tree binding schema for QUP peripheral common properties shared across I2C, SPI, and UART drivers.

* **Refactor**
  * Standardized internal register macro naming and offset references throughout the GENI SE implementation for improved code consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->