### PR TITLE
extensions: gxlimg: Update repo URL

### DIFF
--- a/extensions/gxlimg.sh
+++ b/extensions/gxlimg.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 function fetch_sources_tools__gxlimg() {
-	fetch_from_repo "${GITHUB_SOURCE}/retro98boy/gxlimg" "gxlimg" "commit:fde6a3dd0e13875a5b219389c0a6137616eaebdb"
+	# Branch: master, Commit date: Nov 10, 2025 (please update when updating commit ref)
+	fetch_from_repo "${GITHUB_SOURCE}/repk/gxlimg" "gxlimg" "commit:37a3ea072ca81bb3872441a09fe758340fd67dcb"
 }
 
 function build_host_tools__compile_gxlimg() {


### PR DESCRIPTION
# Description

Because the previous version of repk/gxlimg had some issues when handling bl3x, I forked the repository and made a simple fix. The implementation used in extensions/gxlimg.sh is also mine.

After this [PR](https://github.com/repk/gxlimg/pull/26) is merged, the fix in my repository becomes meaningless, so the URL can be switched to repk/gxlimg.

# How Has This Been Tested?

`./compile.sh BOARD=cainiao-cniot-core BRANCH=current RELEASE=noble`, then update U-Boot and test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the source repository for gxlimg to a new upstream source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->