### PR TITLE
Allow Helios64 to do separate /boot partition only if root placed on fs than unbootable on device

### DIFF
--- a/config/boards/helios64.conf
+++ b/config/boards/helios64.conf
@@ -9,7 +9,7 @@ KERNEL_TEST_TARGET="current"
 MODULES="lm75 ledtrig-netdev"
 MODULES_LEGACY="lm75"
 FULL_DESKTOP="yes"
-PACKAGE_LIST_BOARD="mdadm i2c-tools fancontrol"
+PACKAGE_LIST_BOARD="mdadm i2c-tools fancontrol watchdog"
 PACKAGE_LIST_BOARD_REMOVE="fake-hwclock"
 CPUMAX="1800000"
 


### PR DESCRIPTION
Allow Helios64 to do separate /boot partition only if root placed on fs than unbootable on device.
follow up #8927


# How Has This Been Tested?

Do build with different ROOTFS_TYPE, and look into result image for separate ext3 /boot partition.
```
./compile.sh iav BOARD=helios64 ROOTFS_TYPE=nilfs2
./compile.sh iav BOARD=helios64 ROOTFS_TYPE=btrfs
./compile.sh iav BOARD=helios64 ROOTFS_TYPE=xfs
```
/boot present
```
./compile.sh iav BOARD=helios64
```
no separeted /boot, root ext4
```
./compile.sh iav BOARD=helios64 ROOTFS_TYPE=nilfs2 BOOTPART_REQUIRED=no
```
no /boot, rootfs nilfs2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated watchdog monitoring service for improved system reliability and automatic detection of critical hardware failures

* **Chores**
  * Enhanced system configuration packages to include additional management and monitoring capabilities
  * Implemented intelligent boot partition configuration with conditional filesystem type detection and selection
  * Optimized system defaults to automatically adapt based on specified root filesystem configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->