### PR TITLE
rock-5b: u-boot: edge: bump to v2026.01-rc2; use mainline ATF; bootorder; fancy u-boot

### DIFF
--- a/config/boards/rock-5b.conf
+++ b/config/boards/rock-5b.conf
@@ -31,13 +31,17 @@ function post_family_tweaks__rock5b_naming_audios() {
 function post_family_config_branch_edge__rock-5b_use_mainline_uboot() {
 	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
 
+	# To reuse ATF code in rockchip64_common, let's change the BOOT_SCENARIO and call prepare_boot_configuration() again
+	BOOT_SCENARIO="tpl-blob-atf-mainline"
+	prepare_boot_configuration
+
 	declare -g BOOTCONFIG="rock5b-rk3588_defconfig"
 	declare -g BOOTDELAY=1
-	declare -g BOOTSOURCE="https://github.com/Kwiboo/u-boot-rockchip.git"
-	declare -g BOOTBRANCH="branch:rk3xxx-2024.04" # commit:31522fe7b3c7733313e1c5eb4e340487f6000196 as of 2024-04-01
-	declare -g BOOTPATCHDIR="v2024.04-rock5b-radxa"
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
+	declare -g BOOTBRANCH="tag:v2026.01-rc2"
+	declare -g BOOTPATCHDIR="v2026.01"
 	declare -g BOOTDIR="u-boot-${BOARD}"
-	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
 
 	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
@@ -50,16 +54,69 @@ function post_family_config_branch_edge__rock-5b_use_mainline_uboot() {
 	}
 }
 
+function pre_config_uboot_target__rock5b_patch_uboot_dtsi_for_ums() {
+	[[ "${BRANCH}" == "vendor" ]] && return 0 # Not for 'vendor' branch, which uses 2017.09 vendor u-boot from Radxa
+
+	# IMPORTANT: this typical copypasta is not needed for rock5b, which already has it all in arch/arm/dts/rk3588-rock-5b-u-boot.dtsi
+	display_alert "u-boot for ${BOARD}" "u-boot: upstream u-boot for ${BOARD} is *already* UMS-enabled" "info"
+}
+
+# "rockchip-common: boot SD card first, then NVMe, then mmc"
+# include/configs/rockchip-common.h
+# -#define BOOT_TARGETS "mmc1 mmc0 nvme scsi usb pxe dhcp spi"
+# +#define BOOT_TARGETS "mmc0 nvme mmc1 scsi usb pxe dhcp spi"
+# On rock-5b, mmc0 is the eMMC, mmc1 is the SD card slot
+function pre_config_uboot_target__rock5b_patch_rockchip_common_boot_order() {
+	declare -a rockchip_uboot_targets=("mmc1" "nvme" "mmc0" "scsi" "usb" "pxe" "dhcp" "spi") # for future make-this-generic delight
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: adjust boot order to '${rockchip_uboot_targets[*]}'" "info"
+	sed -i -e "s/#define BOOT_TARGETS.*/#define BOOT_TARGETS \"${rockchip_uboot_targets[*]}\"/" include/configs/rockchip-common.h
+	regular_git diff -u include/configs/rockchip-common.h || true
+}
+
 function post_config_uboot_target__extra_configs_for_rock5b_mainline_environment_in_spi() {
 	[[ "${BRANCH}" != "edge" ]] && return 0
 
-	display_alert "$BOARD" "u-boot configs for ${BOOTBRANCH} u-boot config BRANCH=${BRANCH}" "info"
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable board-specific configs (env in SPI)" "info"
+	run_host_command_logged scripts/config --enable CONFIG_DM_PMIC_FAN53555
+	run_host_command_logged scripts/config --enable CONFIG_CMD_MISC
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_NOWHERE "n"
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_IN_SPI_FLASH "y"
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_SECT_SIZE_AUTO "y"
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_OVERWRITE "y"
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_SIZE "0x20000"
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_OFFSET "0xc00000"
+
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable EFI debugging commands" "info"
+	run_host_command_logged scripts/config --enable CMD_EFIDEBUG
+	run_host_command_logged scripts/config --enable CMD_NVEDIT_EFI
+
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable more filesystems support" "info"
+	run_host_command_logged scripts/config --enable CONFIG_CMD_BTRFS
+
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable more compression support" "info"
+	run_host_command_logged scripts/config --enable CONFIG_LZO
+	run_host_command_logged scripts/config --enable CONFIG_BZIP2
+	run_host_command_logged scripts/config --enable CONFIG_ZSTD
+
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable gpio LED support" "info"
+	run_host_command_logged scripts/config --enable CONFIG_LED
+	run_host_command_logged scripts/config --enable CONFIG_LED_GPIO
+
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable networking cmds" "info"
+	run_host_command_logged scripts/config --enable CONFIG_CMD_NFS
+	run_host_command_logged scripts/config --enable CONFIG_CMD_WGET
+	run_host_command_logged scripts/config --enable CONFIG_CMD_DNS
+	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP
+	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP_SACK
+
+	# UMS, RockUSB, gadget stuff
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable UMS/RockUSB gadget" "info"
+	declare -a enable_configs=("CONFIG_CMD_USB_MASS_STORAGE" "CONFIG_USB_GADGET" "USB_GADGET_DOWNLOAD" "CONFIG_USB_FUNCTION_ROCKUSB" "CONFIG_USB_FUNCTION_ACM" "CONFIG_CMD_ROCKUSB" "CONFIG_CMD_USB_MASS_STORAGE")
+	for config in "${enable_configs[@]}"; do
+		run_host_command_logged scripts/config --enable "${config}"
+	done
+	# Auto-enabled by the above, force off...
+	run_host_command_logged scripts/config --disable USB_FUNCTION_FASTBOOT
 }
 
 # Include fw_setenv, configured to point to the correct spot on the SPI Flash
@@ -68,8 +125,8 @@ function post_family_tweaks__config_rock5b_fwenv() {
 	[[ "${BRANCH}" != "edge" ]] && return 0
 	display_alert "Configuring fw_printenv and fw_setenv" "for ${BOARD} and u-boot ${BOOTBRANCH}" "info"
 	# Addresses below come from CONFIG_ENV_OFFSET and CONFIG_ENV_SIZE in defconfig
-	cat <<- 'FW_ENV_CONFIG' > "${SDCARD}"/etc/fw_env.config
-		# MTD/SPI u-boot env for the Rock-5b
+	cat <<- FW_ENV_CONFIG > "${SDCARD}"/etc/fw_env.config
+		# MTD/SPI u-boot env for the ${BOARD_NAME}
 		# MTD device name Device offset Env. size Flash sector size Number of sectors
 		/dev/mtd0         0xc00000      0x20000
 	FW_ENV_CONFIG


### PR DESCRIPTION
- boot order: SD -> NVMe -> eMMC -> USB -> PXE
- enable compression, EFI stuff, BTRFS, LED support
- this is large bump from a custom-Kwiboo 24.04 to 26.01
  - upstream has handled the whole fusb302 acrobatics for PD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Rock 5B mainline U-Boot configuration with improved boot handling.
  * Added SPI environment support with enabled gadget features and expanded device options.

* **Chores**
  * Updated board configuration for Rock 5B boot preparation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->