### PR TITLE
u-boot: prepare v2026.01 patch directory

### DIFF
--- a/patch/u-boot/v2026.01/0000.patching_config.yaml
+++ b/patch/u-boot/v2026.01/0000.patching_config.yaml
@@ -1,0 +1,6 @@
+config:
+
+  overlay-directories:
+    - { source: "defconfig", target: "configs" } # copies all files in defconfig dir to the configs/ dir in the u-boot source tree
+    - { source: "dt_upstream_rockchip", target: "dts/upstream/src/arm64/rockchip" } # copies all files in dt_upstream_rockchip dir to the dts/upstream/src/arm64/rockchip dir in the u-boot source tree
+    - { source: "dt_uboot", target: "arch/arm/dts" } # copies all files in dt_uboot dir to the arch/arm/dts dir in the u-boot source tree

--- a/patch/u-boot/v2026.01/cmd-fileenv-read-string-from-file-into-env.patch
+++ b/patch/u-boot/v2026.01/cmd-fileenv-read-string-from-file-into-env.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Fri, 31 Jan 2025 15:52:03 +0100
+Subject: cmd: fileenv: read string from file into env
+
+- rpardini: adapted from vendor/legacy patch from 2018
+
+Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ cmd/Kconfig   |  5 +
+ cmd/Makefile  |  1 +
+ cmd/fileenv.c | 46 ++++++++++
+ 3 files changed, 52 insertions(+)
+
+diff --git a/cmd/Kconfig b/cmd/Kconfig
+index 111111111111..222222222222 100644
+--- a/cmd/Kconfig
++++ b/cmd/Kconfig
+@@ -1898,6 +1898,11 @@ config CMD_XXD
+ 	help
+ 	  Print file as hexdump to standard output
+ 
++config CMD_FILEENV
++	bool "fileenv"
++	help
++	   Read a file into memory and store it to env.
++
+ endmenu
+ 
+ if NET || NET_LWIP
+diff --git a/cmd/Makefile b/cmd/Makefile
+index 111111111111..222222222222 100644
+--- a/cmd/Makefile
++++ b/cmd/Makefile
+@@ -175,6 +175,7 @@ obj-$(CONFIG_CMD_SHA1SUM) += sha1sum.o
+ obj-$(CONFIG_CMD_SEAMA) += seama.o
+ obj-$(CONFIG_CMD_SETEXPR) += setexpr.o
+ obj-$(CONFIG_CMD_SETEXPR_FMT) += printf.o
++obj-$(CONFIG_CMD_FILEENV) += fileenv.o
+ obj-$(CONFIG_CMD_SPI) += spi.o
+ obj-$(CONFIG_CMD_STRINGS) += strings.o
+ obj-$(CONFIG_CMD_SMBIOS) += smbios.o
+diff --git a/cmd/fileenv.c b/cmd/fileenv.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/cmd/fileenv.c
+@@ -0,0 +1,46 @@
++#include <config.h>
++#include <command.h>
++#include <fs.h>
++#include <linux/ctype.h>
++#include <vsprintf.h>
++#include "env.h"
++static char *fs_argv[5];
++
++int do_fileenv(struct cmd_tbl *cmdtp, int flag, int argc, char * const argv[])
++{
++	if (argc < 6)
++		return CMD_RET_USAGE;
++
++	fs_argv[0] = "fatload";
++	fs_argv[1] = argv[1];
++	fs_argv[2] = argv[2];
++	fs_argv[3] = argv[3];
++	fs_argv[4] = argv[4];
++
++	if (do_fat_fsload(cmdtp, 0, 5, fs_argv) != 0)
++		return 1;
++
++	char *addr = (char *)simple_strtoul(argv[3], NULL, 16);
++	size_t size = env_get_hex("filesize", 0);
++
++	// Prepare string
++	addr[size] = 0x00;
++	char *s = addr;
++	while(*s != 0x00) {
++		if (isprint(*s)) {
++			s++;
++		}
++		else {
++			*s = 0x00;
++		}
++	}
++
++	return env_set(argv[5], addr);
++}
++
++U_BOOT_CMD(
++	fileenv, 6, 0, do_fileenv,
++	"Read file and store it into env.",
++	"<interface> <dev:part> <addr> <filename> <envname>\n"
++	"    - Read file from fat32 and store it as env."
++);
+-- 
+Armbian
+


### PR DESCRIPTION
- fileenv patch, generic for all
- 0000.patching_config.yaml for null-patch-free future

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command to read files from FAT32 storage and store their contents as environment variables, with automatic content sanitization to printable strings.
  * Updated U-Boot v2026.01 configuration to support the new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->