### PR TITLE
cm3588-nas: u-boot: bump to v2026.01-rc2, enable BTRFS support

### DIFF
--- a/config/boards/cm3588-nas.csc
+++ b/config/boards/cm3588-nas.csc
@@ -43,8 +43,8 @@ function post_family_config__cm3588_nas_use_mainline_uboot() {
 
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-	declare -g BOOTBRANCH="tag:v2025.10"
-	declare -g BOOTPATCHDIR="v2025.10"
+	declare -g BOOTBRANCH="tag:v2026.01-rc2"
+	declare -g BOOTPATCHDIR="v2026.01"
 	declare -g BOOTDIR="u-boot-${BOARD}"
 	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # Disable stuff from rockchip64_common; we're using binman here which does all the work
@@ -85,6 +85,9 @@ function post_config_uboot_target__extra_configs_for_cm3588-nas_uboot() {
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable EFI debugging commands" "info"
 	run_host_command_logged scripts/config --enable CMD_EFIDEBUG
 	run_host_command_logged scripts/config --enable CMD_NVEDIT_EFI
+
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable more filesystems support" "info"
+	run_host_command_logged scripts/config --enable CONFIG_CMD_BTRFS
 
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable more compression support" "info"
 	run_host_command_logged scripts/config --enable CONFIG_LZO


### PR DESCRIPTION
#### cm3588-nas: u-boot: bump to v2026.01-rc2, enable BTRFS support

- cm3588-nas: u-boot: fix `led-1` to `green` for preboot blinking
- cm3588-nas: u-boot: bump to v2026.01-rc2, enable BTRFS support