### PR TITLE
Fix git submodule updates

### DIFF
--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -276,10 +276,6 @@ function fetch_from_repo() {
 			else
 				display_alert "Updating submodules" "" "ext"
 				git submodule update --init --recursive --checkout
-				if [[ $? -ne 0 ]]; then
-					display_alert "Submodule update failed" "" "error"
-					exit 1
-				fi
 			fi
 		fi
 	else


### PR DESCRIPTION
# Description

Building images using specified Commits for tags would break builds because of Git submodule update logic
ATFBRANCH="commit:e0c4d3903b382bf34f552af53e6d955fae5283ab"

<img width="1075" height="654" alt="Screenshot 2025-11-17 at 8 34 26 AM" src="https://github.com/user-attachments/assets/7378432b-c357-470c-8d5d-5fe11c377b94" />

Running builds with GIT_SKIP_SUBMODULES=yes would fix issue temporarily until cached. 

Looks like old parsing code is no longer needed and 

```git submodule update --init --recursive --checkout```

Should work fine on modern git. 

# Documentation summary for feature / change

Should not need updates

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Builds after clearing cache for TI SK Boards that use specific commits
- [x] Builds for other boards like banapim5 

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified submodule update to a single recursive init/checkout operation, replacing the previous per-submodule loop.

* **Bug Fixes**
  * Removed legacy per-submodule fetch logic, reducing update failures and making submodule updates more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->