### PR TITLE
Powere management - make it conditional, enable on UEFI targets, else disabled

### DIFF
--- a/config/boards/README.md
+++ b/config/boards/README.md
@@ -63,6 +63,11 @@ If you are unsure about the documentation then invoke `$ grep -r -A5 -B5 "BUILD_
     - Values:
         - yes: Include (default)
         - no: Do NO include
+- **POWER_MANAGEMENT_FEATURES** (boolean): Controls whether system sleep functionality (suspend, hibernate, hybrid sleep) is allowed on the built image.
+    - Values:
+         - yes: Enable power-management sleep features (allow systemd sleep modes)
+         - no: Disable all sleep modes (default), as suspend/hibernate are unstable
+      on most single-board computers
 - **HAS_VIDEO_OUTPUT** ( boolean ): defines whether the system has video output such as eye candy, bootsplash, etc..
 	- Values:
 		- yes: Enable video-related configuration

--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -10,6 +10,7 @@ declare -g SERIALCON="${SERIALCON:-tty1}"            # Consistent serial console
 declare -g UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-3} # Default 3-seconds timeout for GRUB menu.
 declare -g BOARD_FIRMWARE_INSTALL="-full"            # Install full firmware for UEFI boards
 declare -g DISTRO_GENERIC_KERNEL=no
+declare -g POWER_MANAGEMENT_FEATURES=yes             # Suspend and resume might work well in UEFI, elsewhere is disabled by default
 
 case "${BRANCH}" in
 


### PR DESCRIPTION
# Description

Only when POWER_MANAGEMENT_FEATURES is exactly "yes" block does not run and suspend/hibernate remain enabled.

Ref: https://github.com/armbian/build/pull/8720#issuecomment-3544749544

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Power management is now configurable through a new feature flag. Users can enable power management capabilities according to their specific needs and deployment requirements. Previously, power management was unconditionally disabled on all systems. This change provides greater operational flexibility and customization options for different environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->