### PR TITLE
youyeetoo-r1: enable OUT1/OUT2 switches for es8323 headphone output on vendor kernel

### DIFF
--- a/packages/blobs/asound.state/asound.state.youyeetoo-r1
+++ b/packages/blobs/asound.state/asound.state.youyeetoo-r1
@@ -405,4 +405,24 @@ state.rockchipes8323 {
                         count 1
                 }
         }
+        control.33 {
+                iface MIXER
+                name 'OUT1 Switch'
+                value true
+                comment {
+                        access 'read write'
+                        type BOOLEAN
+                        count 1
+                }
+        }
+        control.34 {
+                iface MIXER
+                name 'OUT2 Switch'
+                value true
+                comment {
+                        access 'read write'
+                        type BOOLEAN
+                        count 1
+                }
+        }
 }


### PR DESCRIPTION
# Description

Enable OUT1 and OUT2 ALSA mixer switches for the ES8323 audio codec on YouYeeToo-R1 board when using the vendor kernel. These switches are required to route audio to the headphone jack on the vendor kernel implementation, while the mainline kernel does not require these additional controls.

This change adds two ALSA mixer control switches (OUT1 and OUT2) to the asound.state configuration file for the youyeetoo-r1 board, both enabled by default.

# How Has This Been Tested?

- [x] Tested on YouYeeToo-R1 hardware with vendor kernel (6.1.x rockchip BSP)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings