### PR TITLE
x96q: rewrite uboot patches

### DIFF
--- a/patch/u-boot/u-boot-sunxi/Allwinner-Fix-incorrect-ram-size-detection-for-H6-boards.patch
+++ b/patch/u-boot/u-boot-sunxi/Allwinner-Fix-incorrect-ram-size-detection-for-H6-boards.patch
@@ -1,7 +1,7 @@
-From 671801e0eeeedda435cbebf42db4957f59a511ec Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunjan Gupta <viraniac@gmail.com>
 Date: Fri, 29 Sep 2023 08:26:47 +0000
-Subject: [PATCH] Allwinner: Fix incorrect ram size detection for H6 boards
+Subject: Allwinner: Fix incorrect ram size detection for H6 boards
 
 ---
  arch/arm/mach-sunxi/dram_helpers.c   | 1 +
@@ -9,7 +9,7 @@ Subject: [PATCH] Allwinner: Fix incorrect ram size detection for H6 boards
  2 files changed, 5 insertions(+)
 
 diff --git a/arch/arm/mach-sunxi/dram_helpers.c b/arch/arm/mach-sunxi/dram_helpers.c
-index cdf2750f1c5..5758c58e070 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/dram_helpers.c
 +++ b/arch/arm/mach-sunxi/dram_helpers.c
 @@ -32,6 +32,7 @@ void mctl_await_completion(u32 *reg, u32 mask, u32 val)
@@ -21,10 +21,10 @@ index cdf2750f1c5..5758c58e070 100644
  	writel(0, CFG_SYS_SDRAM_BASE);
  	writel(0xaa55aa55, (ulong)CFG_SYS_SDRAM_BASE + offset);
 diff --git a/arch/arm/mach-sunxi/dram_sun50i_h6.c b/arch/arm/mach-sunxi/dram_sun50i_h6.c
-index b332f3a3e4a..4675ec932e3 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/dram_sun50i_h6.c
 +++ b/arch/arm/mach-sunxi/dram_sun50i_h6.c
-@@ -611,6 +611,8 @@ static void mctl_auto_detect_dram_size(struct dram_para *para)
+@@ -612,6 +612,8 @@ static void mctl_auto_detect_dram_size(struct dram_para *para)
  	para->rows = 18;
  	mctl_core_init(para);
  
@@ -33,7 +33,7 @@ index b332f3a3e4a..4675ec932e3 100644
  	for (para->rows = 13; para->rows < 18; para->rows++) {
  		/* 8 banks, 8 bit per byte and 16/32 bit width */
  		if (mctl_mem_matches((1 << (para->rows + para->cols +
-@@ -622,6 +624,8 @@ static void mctl_auto_detect_dram_size(struct dram_para *para)
+@@ -623,6 +625,8 @@ static void mctl_auto_detect_dram_size(struct dram_para *para)
  	para->cols = 11;
  	mctl_core_init(para);
  
@@ -43,5 +43,5 @@ index b332f3a3e4a..4675ec932e3 100644
  		/* 8 bits per byte and 16/32 bit width */
  		if (mctl_mem_matches(1 << (para->cols + 1 +
 -- 
-2.34.1
+Armbian
 

--- a/patch/u-boot/u-boot-sunxi/allwinner-a10-fix-pmu-irq-number.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-a10-fix-pmu-irq-number.patch
@@ -1,7 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ryzer58 <ryestar101@gmail.com>
 Date: Tue, 20 Aug 2024 20:36:36 +0100
-Subject: Correct perf interrupt source number as referenced in the Allwinner A10 User manual to resolve conflict with UART2.
+Subject: Correct perf interrupt source number as referenced in the Allwinner
+ A10 User manual to resolve conflict with UART2.
 
 Signed-off-by: Ryzer58 <ryestar101@gmail.com>
 ---
@@ -9,12 +10,10 @@ Signed-off-by: Ryzer58 <ryestar101@gmail.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm/dts/sun4i-a10.dtsi b/arch/arm/dts/sun4i-a10.dtsi
-index 51a6464aab..cabf619c2e 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/sun4i-a10.dtsi
 +++ b/arch/arm/dts/sun4i-a10.dtsi
-@@ -183,11 +183,11 @@
- 		status = "disabled";
- 	};
+@@ -185,7 +185,7 @@
  
  	pmu {
  		compatible = "arm,cortex-a8-pmu";
@@ -23,8 +22,6 @@ index 51a6464aab..cabf619c2e 100644
  	};
  
  	reserved-memory {
- 		#address-cells = <1>;
- 		#size-cells = <1>;
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/u-boot/u-boot-sunxi/allwinner-add-support-for-Recore.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-add-support-for-Recore.patch
@@ -1,21 +1,19 @@
-From 0d986679b1a17d80ce2cef42b36b0ee5a5e42aa7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Elias Bakken <elias@iagent.no>
 Date: Tue, 7 Feb 2023 21:56:20 +0100
-Subject: [PATCH] Add support for Recore
+Subject: Add support for Recore
 
 ---
  arch/arm/dts/Makefile              |   1 +
- arch/arm/dts/sun50i-a64-recore.dts | 271 +++++++++++++++++++++++++++++
- configs/recore_defconfig           |  32 ++++
+ arch/arm/dts/sun50i-a64-recore.dts | 271 ++++++++++
+ configs/recore_defconfig           |  32 ++
  3 files changed, 304 insertions(+)
- create mode 100644 arch/arm/dts/sun50i-a64-recore.dts
- create mode 100644 configs/recore_defconfig
 
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 43951a7731..1badd2e38e 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -735,6 +735,7 @@ dtb-$(CONFIG_MACH_SUN50I) += \
+@@ -853,6 +853,7 @@ dtb-$(CONFIG_MACH_SUN50I) += \
  	sun50i-a64-pinephone-1.1.dtb \
  	sun50i-a64-pinephone-1.2.dtb \
  	sun50i-a64-pinetab.dtb \
@@ -25,7 +23,7 @@ index 43951a7731..1badd2e38e 100644
  dtb-$(CONFIG_MACH_SUN9I) += \
 diff --git a/arch/arm/dts/sun50i-a64-recore.dts b/arch/arm/dts/sun50i-a64-recore.dts
 new file mode 100644
-index 0000000000..d704731873
+index 000000000000..111111111111
 --- /dev/null
 +++ b/arch/arm/dts/sun50i-a64-recore.dts
 @@ -0,0 +1,271 @@
@@ -302,7 +300,7 @@ index 0000000000..d704731873
 +};
 diff --git a/configs/recore_defconfig b/configs/recore_defconfig
 new file mode 100644
-index 0000000000..2a7c40d276
+index 000000000000..111111111111
 --- /dev/null
 +++ b/configs/recore_defconfig
 @@ -0,0 +1,32 @@
@@ -339,5 +337,5 @@ index 0000000000..2a7c40d276
 +CONFIG_DM_REGULATOR_FIXED=y
 +CONFIG_CMD_REGULATOR=y
 -- 
-2.34.1
+Armbian
 

--- a/patch/u-boot/u-boot-sunxi/allwinner-boot-splash.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-boot-splash.patch
@@ -1,19 +1,19 @@
-From f0df8777f6d406d5022eaec8ac3ec20f5b12aa3c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: The Going <48602507+The-going@users.noreply.github.com>
 Date: Fri, 1 Apr 2022 22:57:09 +0300
-Subject: [PATCH] sunxi boot splash
+Subject: sunxi boot splash
 
 ---
  cmd/Kconfig                     |  1 +
- include/config_distro_bootcmd.h |  9 +++++++++
- include/configs/sunxi-common.h  | 30 ++++++++++++++++++++++++++++++
+ include/config_distro_bootcmd.h |  9 +++
+ include/configs/sunxi-common.h  | 30 ++++++++++
  3 files changed, 40 insertions(+)
 
 diff --git a/cmd/Kconfig b/cmd/Kconfig
-index 43ca10f69cc..9051800d6d1 100644
+index 111111111111..222222222222 100644
 --- a/cmd/Kconfig
 +++ b/cmd/Kconfig
-@@ -2017,6 +2017,7 @@ config CMD_BMP
+@@ -2044,6 +2044,7 @@ config CMD_BMP
  	bool "Enable 'bmp' command"
  	depends on VIDEO
  	select BMP
@@ -22,7 +22,7 @@ index 43ca10f69cc..9051800d6d1 100644
  	  This provides a way to obtain information about a BMP-format image
  	  and to display it. BMP (which presumably stands for BitMaP) is a
 diff --git a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
-index 2a136b96a6d..fac28ceb155 100644
+index 111111111111..222222222222 100644
 --- a/include/config_distro_bootcmd.h
 +++ b/include/config_distro_bootcmd.h
 @@ -492,6 +492,15 @@
@@ -42,7 +42,7 @@ index 2a136b96a6d..fac28ceb155 100644
  	"boot_script_dhcp=boot.scr.uimg\0" \
  	BOOTENV_BOOT_TARGETS \
 diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
-index d2d70f0fc23..b318baf17c4 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/sunxi-common.h
 +++ b/include/configs/sunxi-common.h
 @@ -97,6 +97,30 @@
@@ -92,5 +92,5 @@ index d2d70f0fc23..b318baf17c4 100644
  #define CONSOLE_STDIN_SETTINGS \
  	"stdin=serial\0"
 -- 
-2.34.1
+Armbian
 

--- a/patch/u-boot/u-boot-sunxi/allwinner-disable-de2-to-improve-edid-detection.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-disable-de2-to-improve-edid-detection.patch
@@ -1,86 +1,161 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+Date: Fri, 17 Apr 2020 23:44:35 +0200
+Subject: [ARCHEOLOGY] Switch sunxi and sunxi64 to u-boot v2020.04 (#1894)
+
+> X-Git-Archeology: > recovered message: > * Disable DE2 in u-boot to improve EDID detection
+> X-Git-Archeology: > recovered message: > * Remove deprecated patches
+> X-Git-Archeology: > recovered message: > * Define BOOTBRANCH in top level
+> X-Git-Archeology: > recovered message: > Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology: - Revision 5e8cbd8e6aaa87ee03d08c761d5e765e81c4c686: https://github.com/armbian/build/commit/5e8cbd8e6aaa87ee03d08c761d5e765e81c4c686
+> X-Git-Archeology:   Date: Fri, 17 Apr 2020 23:44:35 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Switch sunxi and sunxi64 to u-boot v2020.04 (#1894)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4ba494ae6ec0515c9e076624bb0ec7fa7f97655d: https://github.com/armbian/build/commit/4ba494ae6ec0515c9e076624bb0ec7fa7f97655d
+> X-Git-Archeology:   Date: Sat, 19 Sep 2020 10:09:05 -0700
+> X-Git-Archeology:   From: 5kft <5kft@users.noreply.github.com>
+> X-Git-Archeology:   Subject: [ sunxi-dev ] move u-boot to v2020.07
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ce6783c07ff7a4b0e44bd69521253756ad08f368: https://github.com/armbian/build/commit/ce6783c07ff7a4b0e44bd69521253756ad08f368
+> X-Git-Archeology:   Date: Thu, 15 Oct 2020 21:30:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Adjust remaining Allwinner u-boot patches due to u-boot upgrade to 2020.10
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 21fc940aaf761bc65f8d81c6e68584757b43c8fb: https://github.com/armbian/build/commit/21fc940aaf761bc65f8d81c6e68584757b43c8fb
+> X-Git-Archeology:   Date: Sun, 31 Jul 2022 10:34:48 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Several small bug fixes mainly outside supported areas (#4032)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f6a09def35e647a5442e0f92f399485be29f19a9: https://github.com/armbian/build/commit/f6a09def35e647a5442e0f92f399485be29f19a9
+> X-Git-Archeology:   Date: Thu, 10 Nov 2022 21:49:36 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Moving patches to per board and removing obsolete (#4409)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision bc46fd509a50db4bcef014d79569b68287ecc19b: https://github.com/armbian/build/commit/bc46fd509a50db4bcef014d79569b68287ecc19b
+> X-Git-Archeology:   Date: Tue, 13 Jun 2023 20:19:36 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: allwinner: bump u-boot to v2022.10
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9525b2d16c0aa0ec5cf446322e58a0dabb26c857: https://github.com/armbian/build/commit/9525b2d16c0aa0ec5cf446322e58a0dabb26c857
+> X-Git-Archeology:   Date: Mon, 26 Jun 2023 20:54:19 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: Allwinner: Bump u-boot to 2023.01
+> X-Git-Archeology:
+---
+ configs/Mele_A1000_defconfig                  | 1 +
+ configs/Orangepi_mini_defconfig               | 1 +
+ configs/a64-olinuxino-emmc_defconfig          | 1 +
+ configs/a64-olinuxino_defconfig               | 1 +
+ configs/bananapi_m1_plus_defconfig            | 1 +
+ configs/bananapi_m2_plus_h3_defconfig         | 1 +
+ configs/bananapi_m2_plus_h5_defconfig         | 1 +
+ configs/bananapi_m2_zero_defconfig            | 1 +
+ configs/bananapi_m64_defconfig                | 1 +
+ configs/libretech_all_h3_cc_h2_plus_defconfig | 1 +
+ configs/libretech_all_h3_cc_h3_defconfig      | 1 +
+ configs/libretech_all_h3_cc_h5_defconfig      | 1 +
+ configs/libretech_all_h5_cc_h5_defconfig      | 1 +
+ configs/nanopi_a64_defconfig                  | 1 +
+ configs/nanopi_m1_defconfig                   | 1 +
+ configs/orangepi_lite2_defconfig              | 1 +
+ configs/orangepi_lite_defconfig               | 1 +
+ configs/orangepi_one_defconfig                | 1 +
+ configs/orangepi_one_plus_defconfig           | 1 +
+ configs/orangepi_pc2_defconfig                | 1 +
+ configs/orangepi_pc_defconfig                 | 1 +
+ configs/orangepi_plus2e_defconfig             | 1 +
+ configs/orangepi_plus_defconfig               | 1 +
+ configs/orangepi_prime_defconfig              | 1 +
+ configs/orangepi_win_defconfig                | 1 +
+ configs/pine64-lts_defconfig                  | 1 +
+ configs/pine64_plus_defconfig                 | 1 +
+ configs/pine_h64_defconfig                    | 1 +
+ 28 files changed, 28 insertions(+)
+
 diff --git a/configs/Mele_A1000_defconfig b/configs/Mele_A1000_defconfig
-index f5b6d908cd..9adced2d4b 100644
+index 111111111111..222222222222 100644
 --- a/configs/Mele_A1000_defconfig
 +++ b/configs/Mele_A1000_defconfig
-@@ -19,3 +19,4 @@ CONFIG_SUN4I_EMAC=y
+@@ -18,3 +18,4 @@ CONFIG_SUN4I_EMAC=y
  CONFIG_SCSI=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/Orangepi_mini_defconfig b/configs/Orangepi_mini_defconfig
-index 2d0315b655..dbc6a2556d 100644
+index 111111111111..222222222222 100644
 --- a/configs/Orangepi_mini_defconfig
 +++ b/configs/Orangepi_mini_defconfig
-@@ -28,3 +28,4 @@ CONFIG_SUN7I_GMAC=y
+@@ -25,3 +25,4 @@ CONFIG_SUN7I_GMAC=y
  CONFIG_SCSI=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/a64-olinuxino-emmc_defconfig b/configs/a64-olinuxino-emmc_defconfig
-index 8ec9eb3e9c..4ccb4c8467 100644
+index 111111111111..222222222222 100644
 --- a/configs/a64-olinuxino-emmc_defconfig
 +++ b/configs/a64-olinuxino-emmc_defconfig
-@@ -10,3 +10,4 @@ CONFIG_SUPPORT_EMMC_BOOT=y
+@@ -9,3 +9,4 @@ CONFIG_SUPPORT_EMMC_BOOT=y
  CONFIG_SUN8I_EMAC=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/a64-olinuxino_defconfig b/configs/a64-olinuxino_defconfig
-index 99fa24ae23..d00bd9e7e3 100644
+index 111111111111..222222222222 100644
 --- a/configs/a64-olinuxino_defconfig
 +++ b/configs/a64-olinuxino_defconfig
-@@ -11,3 +11,4 @@ CONFIG_DRAM_ZQ=3881949
+@@ -8,3 +8,4 @@ CONFIG_MMC_SUNXI_SLOT_EXTRA=2
  CONFIG_SUN8I_EMAC=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/bananapi_m1_plus_defconfig b/configs/bananapi_m1_plus_defconfig
-index 0fbb619d62..f3b1651fa5 100644
+index 111111111111..222222222222 100644
 --- a/configs/bananapi_m1_plus_defconfig
 +++ b/configs/bananapi_m1_plus_defconfig
-@@ -24,3 +24,4 @@ CONFIG_SUN7I_GMAC=y
+@@ -23,3 +23,4 @@ CONFIG_SUN7I_GMAC=y
  CONFIG_SCSI=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/bananapi_m2_plus_h3_defconfig b/configs/bananapi_m2_plus_h3_defconfig
-index 26ced59fb0..a723dc4847 100644
+index 111111111111..222222222222 100644
 --- a/configs/bananapi_m2_plus_h3_defconfig
 +++ b/configs/bananapi_m2_plus_h3_defconfig
-@@ -11,3 +11,4 @@ CONFIG_SUN8I_EMAC=y
+@@ -10,3 +10,4 @@ CONFIG_SUN8I_EMAC=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
  CONFIG_USB_MUSB_GADGET=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/bananapi_m2_plus_h5_defconfig b/configs/bananapi_m2_plus_h5_defconfig
-index fb6c945919..2e4ecdfbe8 100644
+index 111111111111..222222222222 100644
 --- a/configs/bananapi_m2_plus_h5_defconfig
 +++ b/configs/bananapi_m2_plus_h5_defconfig
-@@ -11,3 +11,4 @@ CONFIG_SUN8I_EMAC=y
+@@ -10,3 +10,4 @@ CONFIG_SUN8I_EMAC=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
  CONFIG_USB_MUSB_GADGET=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/bananapi_m2_zero_defconfig b/configs/bananapi_m2_zero_defconfig
-index ac3f8f5ab8..58ce3e170f 100644
+index 111111111111..222222222222 100644
 --- a/configs/bananapi_m2_zero_defconfig
 +++ b/configs/bananapi_m2_zero_defconfig
-@@ -6,3 +6,4 @@ CONFIG_MACH_SUN8I_H3=y
+@@ -5,3 +5,4 @@ CONFIG_SPL=y
+ CONFIG_MACH_SUN8I_H3=y
  CONFIG_DRAM_CLK=408
- CONFIG_MMC0_CD_PIN=""
  # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/bananapi_m64_defconfig b/configs/bananapi_m64_defconfig
-index 5463b046fd..073e7fd911 100644
+index 111111111111..222222222222 100644
 --- a/configs/bananapi_m64_defconfig
 +++ b/configs/bananapi_m64_defconfig
-@@ -12,3 +12,4 @@ CONFIG_SUN8I_EMAC=y
+@@ -10,3 +10,4 @@ CONFIG_SUN8I_EMAC=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
  CONFIG_USB_MUSB_GADGET=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/libretech_all_h3_cc_h2_plus_defconfig b/configs/libretech_all_h3_cc_h2_plus_defconfig
-index 8725fe64cd..e2b58e47f5 100644
+index 111111111111..222222222222 100644
 --- a/configs/libretech_all_h3_cc_h2_plus_defconfig
 +++ b/configs/libretech_all_h3_cc_h2_plus_defconfig
 @@ -9,3 +9,4 @@ CONFIG_MMC_SUNXI_SLOT_EXTRA=2
@@ -89,7 +164,7 @@ index 8725fe64cd..e2b58e47f5 100644
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/libretech_all_h3_cc_h3_defconfig b/configs/libretech_all_h3_cc_h3_defconfig
-index 5275fdc36d..11cd4e0fe3 100644
+index 111111111111..222222222222 100644
 --- a/configs/libretech_all_h3_cc_h3_defconfig
 +++ b/configs/libretech_all_h3_cc_h3_defconfig
 @@ -9,3 +9,4 @@ CONFIG_MMC_SUNXI_SLOT_EXTRA=2
@@ -98,7 +173,7 @@ index 5275fdc36d..11cd4e0fe3 100644
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/libretech_all_h3_cc_h5_defconfig b/configs/libretech_all_h3_cc_h5_defconfig
-index 9627401949..6fefb6756d 100644
+index 111111111111..222222222222 100644
 --- a/configs/libretech_all_h3_cc_h5_defconfig
 +++ b/configs/libretech_all_h3_cc_h5_defconfig
 @@ -9,3 +9,4 @@ CONFIG_MMC_SUNXI_SLOT_EXTRA=2
@@ -107,7 +182,7 @@ index 9627401949..6fefb6756d 100644
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/libretech_all_h5_cc_h5_defconfig b/configs/libretech_all_h5_cc_h5_defconfig
-index c3aa4b1061..55e4313961 100644
+index 111111111111..222222222222 100644
 --- a/configs/libretech_all_h5_cc_h5_defconfig
 +++ b/configs/libretech_all_h5_cc_h5_defconfig
 @@ -12,3 +12,4 @@ CONFIG_SUN8I_EMAC=y
@@ -116,16 +191,16 @@ index c3aa4b1061..55e4313961 100644
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/nanopi_a64_defconfig b/configs/nanopi_a64_defconfig
-index 70fc257eeb..3eb285ee98 100644
+index 111111111111..222222222222 100644
 --- a/configs/nanopi_a64_defconfig
 +++ b/configs/nanopi_a64_defconfig
-@@ -8,3 +8,4 @@ CONFIG_RESERVE_ALLWINNER_BOOT0_HEADER=y
+@@ -7,3 +7,4 @@ CONFIG_MACH_SUN50I=y
  CONFIG_SUN8I_EMAC=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/nanopi_m1_defconfig b/configs/nanopi_m1_defconfig
-index dc2dbd6290..5abf34aa34 100644
+index 111111111111..222222222222 100644
 --- a/configs/nanopi_m1_defconfig
 +++ b/configs/nanopi_m1_defconfig
 @@ -7,3 +7,4 @@ CONFIG_DRAM_CLK=408
@@ -134,52 +209,52 @@ index dc2dbd6290..5abf34aa34 100644
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/orangepi_lite2_defconfig b/configs/orangepi_lite2_defconfig
-index 75c97d6b89..389687a456 100644
+index 111111111111..222222222222 100644
 --- a/configs/orangepi_lite2_defconfig
 +++ b/configs/orangepi_lite2_defconfig
-@@ -9,3 +9,4 @@ CONFIG_MMC0_CD_PIN="PF6"
+@@ -8,3 +8,4 @@ CONFIG_SUNXI_DRAM_H6_LPDDR3=y
  # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/orangepi_lite_defconfig b/configs/orangepi_lite_defconfig
-index ab64319875..1a5ea7fe4d 100644
+index 111111111111..222222222222 100644
 --- a/configs/orangepi_lite_defconfig
 +++ b/configs/orangepi_lite_defconfig
-@@ -9,3 +9,4 @@ CONFIG_DRAM_ODT_EN=y
+@@ -7,3 +7,4 @@ CONFIG_DRAM_CLK=672
  # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/orangepi_one_defconfig b/configs/orangepi_one_defconfig
-index cbe2c97f2b..4572c76579 100644
+index 111111111111..222222222222 100644
 --- a/configs/orangepi_one_defconfig
 +++ b/configs/orangepi_one_defconfig
-@@ -10,3 +10,4 @@ CONFIG_DRAM_ODT_EN=y
+@@ -8,3 +8,4 @@ CONFIG_DRAM_CLK=672
  CONFIG_SUN8I_EMAC=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/orangepi_one_plus_defconfig b/configs/orangepi_one_plus_defconfig
-index 55a8b003fb..19db83a680 100644
+index 111111111111..222222222222 100644
 --- a/configs/orangepi_one_plus_defconfig
 +++ b/configs/orangepi_one_plus_defconfig
-@@ -9,3 +9,4 @@ CONFIG_MMC0_CD_PIN="PF6"
+@@ -8,3 +8,4 @@ CONFIG_SUNXI_DRAM_H6_LPDDR3=y
  # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/orangepi_pc2_defconfig b/configs/orangepi_pc2_defconfig
-index 5a7dbd45e8..cb8ca5d981 100644
+index 111111111111..222222222222 100644
 --- a/configs/orangepi_pc2_defconfig
 +++ b/configs/orangepi_pc2_defconfig
-@@ -20,3 +20,4 @@ CONFIG_SPI=y
+@@ -18,3 +18,4 @@ CONFIG_SPI=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
  CONFIG_USB_MUSB_GADGET=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/orangepi_pc_defconfig b/configs/orangepi_pc_defconfig
-index 905ff7b127..4aacb83bab 100644
+index 111111111111..222222222222 100644
 --- a/configs/orangepi_pc_defconfig
 +++ b/configs/orangepi_pc_defconfig
 @@ -12,3 +12,4 @@ CONFIG_SUN8I_EMAC=y
@@ -188,61 +263,61 @@ index 905ff7b127..4aacb83bab 100644
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/orangepi_plus2e_defconfig b/configs/orangepi_plus2e_defconfig
-index 879f01dcd8..96ce325066 100644
+index 111111111111..222222222222 100644
 --- a/configs/orangepi_plus2e_defconfig
 +++ b/configs/orangepi_plus2e_defconfig
-@@ -16,3 +16,4 @@ CONFIG_SUN8I_EMAC=y
+@@ -13,3 +13,4 @@ CONFIG_SUN8I_EMAC=y
  CONFIG_SY8106A_POWER=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/orangepi_plus_defconfig b/configs/orangepi_plus_defconfig
-index aa3f51e97b..4b2ac4e05c 100644
+index 111111111111..222222222222 100644
 --- a/configs/orangepi_plus_defconfig
 +++ b/configs/orangepi_plus_defconfig
-@@ -18,3 +18,4 @@ CONFIG_SUN8I_EMAC=y
+@@ -15,3 +15,4 @@ CONFIG_SUN8I_EMAC=y
  CONFIG_SY8106A_POWER=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/orangepi_prime_defconfig b/configs/orangepi_prime_defconfig
-index 551348f8c6..2e19c27942 100644
+index 111111111111..222222222222 100644
 --- a/configs/orangepi_prime_defconfig
 +++ b/configs/orangepi_prime_defconfig
-@@ -12,3 +12,4 @@ CONFIG_SUN8I_EMAC=y
+@@ -11,3 +11,4 @@ CONFIG_SUN8I_EMAC=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
  CONFIG_USB_MUSB_GADGET=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/orangepi_win_defconfig b/configs/orangepi_win_defconfig
-index 3b78ad7e52..eba4af1bda 100644
+index 111111111111..222222222222 100644
 --- a/configs/orangepi_win_defconfig
 +++ b/configs/orangepi_win_defconfig
-@@ -13,3 +13,4 @@ CONFIG_SUN8I_EMAC=y
+@@ -11,3 +11,4 @@ CONFIG_SUN8I_EMAC=y
  CONFIG_SPI=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/pine64-lts_defconfig b/configs/pine64-lts_defconfig
-index 7e7c2d7910..dca89ec763 100644
+index 111111111111..222222222222 100644
 --- a/configs/pine64-lts_defconfig
 +++ b/configs/pine64-lts_defconfig
-@@ -16,3 +16,4 @@ CONFIG_SUN8I_EMAC=y
+@@ -15,3 +15,4 @@ CONFIG_SUN8I_EMAC=y
  CONFIG_SPI=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/pine64_plus_defconfig b/configs/pine64_plus_defconfig
-index f42f4e5923..400519cd89 100644
+index 111111111111..222222222222 100644
 --- a/configs/pine64_plus_defconfig
 +++ b/configs/pine64_plus_defconfig
-@@ -11,3 +11,4 @@ CONFIG_PHY_REALTEK=y
+@@ -10,3 +10,4 @@ CONFIG_PHY_REALTEK=y
  CONFIG_SUN8I_EMAC=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
 +CONFIG_VIDEO_DE2=n
 diff --git a/configs/pine_h64_defconfig b/configs/pine_h64_defconfig
-index 09a4275f0e..9c4a01fa21 100644
+index 111111111111..222222222222 100644
 --- a/configs/pine_h64_defconfig
 +++ b/configs/pine_h64_defconfig
 @@ -2,6 +2,7 @@ CONFIG_ARM=y
@@ -252,4 +327,7 @@ index 09a4275f0e..9c4a01fa21 100644
 +CONFIG_VIDEO_DE2=n
  CONFIG_MACH_SUN50I_H6=y
  CONFIG_SUNXI_DRAM_H6_LPDDR3=y
- CONFIG_MACPWR="PC16"
+ CONFIG_MMC_SUNXI_SLOT_EXTRA=2
+-- 
+Armbian
+

--- a/patch/u-boot/u-boot-sunxi/allwinner-enable-autoboot-keyed.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-enable-autoboot-keyed.patch
@@ -1,8 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+Date: Tue, 24 Oct 2017 17:44:22 +0300
+Subject: [ARCHEOLOGY] Enable USB keyboards in sunxi u-boot
+
+> X-Git-Archeology: > recovered message: > Switch to AUTOBOOT_KEYED with <Space> and <Ctrl-C> as autoboot abort
+> X-Git-Archeology: > recovered message: > methods
+> X-Git-Archeology: > recovered message: > Increase sunxi bootdelay to 1
+> X-Git-Archeology: > recovered message: > Closes #789
+> X-Git-Archeology: - Revision dd48a784f5a202d84aa2dc8b5553a571c1866b11: https://github.com/armbian/build/commit/dd48a784f5a202d84aa2dc8b5553a571c1866b11
+> X-Git-Archeology:   Date: Tue, 24 Oct 2017 17:44:22 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Enable USB keyboards in sunxi u-boot
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5f4c4c77b28b4d15fd0165809ccfaed7af5c73e5: https://github.com/armbian/build/commit/5f4c4c77b28b4d15fd0165809ccfaed7af5c73e5
+> X-Git-Archeology:   Date: Sat, 25 Nov 2017 15:11:13 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: [WIP] Update sunxi u-boot to v2017.11
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9363e3ec4d3a3234c5bdab6b7a1e3fd606b68102: https://github.com/armbian/build/commit/9363e3ec4d3a3234c5bdab6b7a1e3fd606b68102
+> X-Git-Archeology:   Date: Mon, 14 Jan 2019 16:52:22 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: u-boot v2018.11 migration + tons of patches touchups
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision c474e35fe1fc795154baf88dec36cc01c6a5b567: https://github.com/armbian/build/commit/c474e35fe1fc795154baf88dec36cc01c6a5b567
+> X-Git-Archeology:   Date: Fri, 12 Apr 2019 20:29:43 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: [ sunxi64 ] Moved A64 boards to mainline u-boot 2019.04 Tested basic functions with eMMC install on A64 Notebooks and Olinuxino
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5e8cbd8e6aaa87ee03d08c761d5e765e81c4c686: https://github.com/armbian/build/commit/5e8cbd8e6aaa87ee03d08c761d5e765e81c4c686
+> X-Git-Archeology:   Date: Fri, 17 Apr 2020 23:44:35 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Switch sunxi and sunxi64 to u-boot v2020.04 (#1894)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8277822addfb690716f431c2f29a59effe7dd16f: https://github.com/armbian/build/commit/8277822addfb690716f431c2f29a59effe7dd16f
+> X-Git-Archeology:   Date: Tue, 06 Apr 2021 11:42:56 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump Allwinner u-boot to 2021.04 (#2745)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 3cb7175c667da480e59ef5b9bb23e238b4955cdf: https://github.com/armbian/build/commit/3cb7175c667da480e59ef5b9bb23e238b4955cdf
+> X-Git-Archeology:   Date: Thu, 15 Sep 2022 11:08:20 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Upgrade Allwinner boot loader to 2022.08 (#4168)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 38db7daaf700a985036bb3d00be21c50f71e731c: https://github.com/armbian/build/commit/38db7daaf700a985036bb3d00be21c50f71e731c
+> X-Git-Archeology:   Date: Thu, 10 Nov 2022 13:24:06 +0100
+> X-Git-Archeology:   From: Markus Hoffrogge <mhoffrogge@gmail.com>
+> X-Git-Archeology:   Subject: Fix U-Boot SUNXI enable-autoboot-keyed.patch for U-Boot v2022.07 [AR-1322] (#4403)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f6a09def35e647a5442e0f92f399485be29f19a9: https://github.com/armbian/build/commit/f6a09def35e647a5442e0f92f399485be29f19a9
+> X-Git-Archeology:   Date: Thu, 10 Nov 2022 21:49:36 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Moving patches to per board and removing obsolete (#4409)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision bc46fd509a50db4bcef014d79569b68287ecc19b: https://github.com/armbian/build/commit/bc46fd509a50db4bcef014d79569b68287ecc19b
+> X-Git-Archeology:   Date: Tue, 13 Jun 2023 20:19:36 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: allwinner: bump u-boot to v2022.10
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9525b2d16c0aa0ec5cf446322e58a0dabb26c857: https://github.com/armbian/build/commit/9525b2d16c0aa0ec5cf446322e58a0dabb26c857
+> X-Git-Archeology:   Date: Mon, 26 Jun 2023 20:54:19 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: Allwinner: Bump u-boot to 2023.01
+> X-Git-Archeology:
+---
+ arch/arm/Kconfig | 2 ++
+ boot/Kconfig     | 3 ++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
 diff --git a/arch/arm/Kconfig b/arch/arm/Kconfig
-index cac4fa09fd..ff46730bfb 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/Kconfig
 +++ b/arch/arm/Kconfig
-@@ -1121,6 +1121,8 @@ config ARCH_SUNXI
+@@ -1151,6 +1151,8 @@ config ARCH_SUNXI
  	select USB_KEYBOARD if DISTRO_DEFAULTS && USB_HOST
  	select USB_STORAGE if DISTRO_DEFAULTS && USB_HOST
  	select SPL_USE_TINY_PRINTF
@@ -12,10 +81,10 @@ index cac4fa09fd..ff46730bfb 100644
  	select SYS_RELOC_GD_ENV_ADDR
  	imply BOARD_LATE_INIT
 diff --git a/boot/Kconfig b/boot/Kconfig
-index 424ad0e466..d139ff9203 100644
+index 111111111111..222222222222 100644
 --- a/boot/Kconfig
 +++ b/boot/Kconfig
-@@ -1189,7 +1189,7 @@ config AUTOBOOT_FLUSH_STDIN
+@@ -1235,7 +1235,7 @@ config AUTOBOOT_FLUSH_STDIN
  config AUTOBOOT_PROMPT
  	string "Autoboot stop prompt"
  	depends on AUTOBOOT_KEYED
@@ -24,7 +93,7 @@ index 424ad0e466..d139ff9203 100644
  	help
  	  This string is displayed before the boot delay selected by
  	  CONFIG_BOOTDELAY starts. If it is not defined	there is no
-@@ -1244,6 +1244,7 @@ config AUTOBOOT_DELAY_STR
+@@ -1290,6 +1290,7 @@ config AUTOBOOT_DELAY_STR
  config AUTOBOOT_STOP_STR
  	string "Stop autobooting via specific input key / string"
  	depends on AUTOBOOT_KEYED && !AUTOBOOT_ENCRYPTION
@@ -32,3 +101,6 @@ index 424ad0e466..d139ff9203 100644
  	help
  	  This option enables stopping (aborting) of the automatic
  	  boot feature only by issuing a specific input key or
+-- 
+Armbian
+

--- a/patch/u-boot/u-boot-sunxi/allwinner-enable-r_pio-gpio-access-h3-h5.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-enable-r_pio-gpio-access-h3-h5.patch
@@ -1,8 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: 5kft <5kft@5kft.org>
+Date: Sat, 4 Aug 2018 14:06:50 +0000
+Subject: [ARCHEOLOGY] update R_PIO GPIO block enable (H3/H5)
+
+> X-Git-Archeology: > recovered message: > Move the previous "R_PIO enable" change to initial board gpio_init (from clock_init)
+> X-Git-Archeology: - Revision c3f02be362aa216f2d3ee011916f9a18baf58291: https://github.com/armbian/build/commit/c3f02be362aa216f2d3ee011916f9a18baf58291
+> X-Git-Archeology:   Date: Sat, 04 Aug 2018 14:06:50 +0000
+> X-Git-Archeology:   From: 5kft <5kft@5kft.org>
+> X-Git-Archeology:   Subject: update R_PIO GPIO block enable (H3/H5)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5e8cbd8e6aaa87ee03d08c761d5e765e81c4c686: https://github.com/armbian/build/commit/5e8cbd8e6aaa87ee03d08c761d5e765e81c4c686
+> X-Git-Archeology:   Date: Fri, 17 Apr 2020 23:44:35 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Switch sunxi and sunxi64 to u-boot v2020.04 (#1894)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f6a09def35e647a5442e0f92f399485be29f19a9: https://github.com/armbian/build/commit/f6a09def35e647a5442e0f92f399485be29f19a9
+> X-Git-Archeology:   Date: Thu, 10 Nov 2022 21:49:36 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Moving patches to per board and removing obsolete (#4409)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision bc46fd509a50db4bcef014d79569b68287ecc19b: https://github.com/armbian/build/commit/bc46fd509a50db4bcef014d79569b68287ecc19b
+> X-Git-Archeology:   Date: Tue, 13 Jun 2023 20:19:36 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: allwinner: bump u-boot to v2022.10
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9525b2d16c0aa0ec5cf446322e58a0dabb26c857: https://github.com/armbian/build/commit/9525b2d16c0aa0ec5cf446322e58a0dabb26c857
+> X-Git-Archeology:   Date: Mon, 26 Jun 2023 20:54:19 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: Allwinner: Bump u-boot to 2023.01
+> X-Git-Archeology:
+---
+ arch/arm/mach-sunxi/board.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
 diff --git a/arch/arm/mach-sunxi/board.c b/arch/arm/mach-sunxi/board.c
-index 0c4b6dd1ca..5d0bb5e451 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/board.c
 +++ b/arch/arm/mach-sunxi/board.c
-@@ -26,6 +26,7 @@
+@@ -27,6 +27,7 @@
  #include <asm/arch/timer.h>
  #include <asm/arch/tzpc.h>
  #include <asm/arch/mmc.h>
@@ -10,7 +45,7 @@ index 0c4b6dd1ca..5d0bb5e451 100644
  
  #include <linux/compiler.h>
  
-@@ -78,6 +79,11 @@ phys_size_t board_get_usable_ram_top(phys_size_t total_size)
+@@ -78,6 +79,11 @@ phys_addr_t board_get_usable_ram_top(phys_size_t total_size)
  #ifdef CONFIG_SPL_BUILD
  static int gpio_init(void)
  {
@@ -22,3 +57,6 @@ index 0c4b6dd1ca..5d0bb5e451 100644
  	__maybe_unused uint val;
  #if CONFIG_CONS_INDEX == 1 && defined(CONFIG_UART0_PORT_F)
  #if defined(CONFIG_MACH_SUN4I) || \
+-- 
+Armbian
+

--- a/patch/u-boot/u-boot-sunxi/allwinner-fdt-setprop-fix-unaligned-access.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-fdt-setprop-fix-unaligned-access.patch
@@ -1,5 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+Date: Fri, 22 Sep 2017 21:07:18 +0300
+Subject: [ARCHEOLOGY] Fix sunxi u-boot crash in fdt setprop
+
+> X-Git-Archeology: - Revision a717f1a5061e7611545ef0ed1a05f1e8077e109a: https://github.com/armbian/build/commit/a717f1a5061e7611545ef0ed1a05f1e8077e109a
+> X-Git-Archeology:   Date: Fri, 22 Sep 2017 21:07:18 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Fix sunxi u-boot crash in fdt setprop
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f6a09def35e647a5442e0f92f399485be29f19a9: https://github.com/armbian/build/commit/f6a09def35e647a5442e0f92f399485be29f19a9
+> X-Git-Archeology:   Date: Thu, 10 Nov 2022 21:49:36 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Moving patches to per board and removing obsolete (#4409)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision bc46fd509a50db4bcef014d79569b68287ecc19b: https://github.com/armbian/build/commit/bc46fd509a50db4bcef014d79569b68287ecc19b
+> X-Git-Archeology:   Date: Tue, 13 Jun 2023 20:19:36 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: allwinner: bump u-boot to v2022.10
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9525b2d16c0aa0ec5cf446322e58a0dabb26c857: https://github.com/armbian/build/commit/9525b2d16c0aa0ec5cf446322e58a0dabb26c857
+> X-Git-Archeology:   Date: Mon, 26 Jun 2023 20:54:19 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: Allwinner: Bump u-boot to 2023.01
+> X-Git-Archeology:
+---
+ cmd/fdt.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
 diff --git a/cmd/fdt.c b/cmd/fdt.c
-index 8e51a43126..0e94bf30ee 100644
+index 111111111111..222222222222 100644
 --- a/cmd/fdt.c
 +++ b/cmd/fdt.c
 @@ -18,6 +18,7 @@
@@ -10,7 +39,7 @@ index 8e51a43126..0e94bf30ee 100644
  
  #define MAX_LEVEL	32		/* how deeply nested we will go */
  #define SCRATCHPAD	1024		/* bytes of scratchpad memory */
-@@ -802,7 +803,10 @@ static int fdt_parse_prop(char * const *newval, int count, char *data, int *len)
+@@ -830,7 +831,10 @@ static int fdt_parse_prop(char * const *newval, int count, char *data, int *len)
  			cp = newp;
  			tmp = simple_strtoul(cp, &newp, 0);
  			if (*cp != '?')
@@ -22,3 +51,6 @@ index 8e51a43126..0e94bf30ee 100644
  			else
  				newp++;
  
+-- 
+Armbian
+

--- a/patch/u-boot/u-boot-sunxi/allwinner-h3-fix-pll1-setup-to-never-use-dividers.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-h3-fix-pll1-setup-to-never-use-dividers.patch
@@ -1,7 +1,7 @@
-From 2bd59104066b4daf9157c573e2ac747accd1ebd6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ondrej Jirman <megous@megous.com>
 Date: Tue, 20 Dec 2016 11:25:12 +0100
-Subject: [PATCH] sunxi: h3: Fix PLL1 setup to never use dividers
+Subject: sunxi: h3: Fix PLL1 setup to never use dividers
 
 Kernel would lower the divider on first CLK change and cause the
 lock up.
@@ -10,7 +10,7 @@ lock up.
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/arch/arm/mach-sunxi/clock_sun6i.c b/arch/arm/mach-sunxi/clock_sun6i.c
-index 6bd75a15f6..86f08ab717 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/clock_sun6i.c
 +++ b/arch/arm/mach-sunxi/clock_sun6i.c
 @@ -134,11 +134,10 @@ void clock_set_pll1(unsigned int clk)
@@ -29,5 +29,5 @@ index 6bd75a15f6..86f08ab717 100644
  
  	/* Switch to 24MHz clock while changing PLL1 */
 -- 
-2.34.1
+Armbian
 

--- a/patch/u-boot/u-boot-sunxi/allwinner-h3-set-safe-axi_apb-clock-dividers.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-h3-set-safe-axi_apb-clock-dividers.patch
@@ -1,5 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ThomasKaiser <github@kaiser-edv.de>
+Date: Sat, 9 Apr 2016 16:02:53 +0200
+Subject: [ARCHEOLOGY] Define safe voltage/cpufreq defaults for sun8i/dev
+
+> X-Git-Archeology: - Revision da11a8c01fae54c17503d2ded7c0f972fd5d384a: https://github.com/armbian/build/commit/da11a8c01fae54c17503d2ded7c0f972fd5d384a
+> X-Git-Archeology:   Date: Sat, 09 Apr 2016 16:02:53 +0200
+> X-Git-Archeology:   From: ThomasKaiser <github@kaiser-edv.de>
+> X-Git-Archeology:   Subject: Define safe voltage/cpufreq defaults for sun8i/dev
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dddf22832564dda0102ea07bcc56fbbefae3b050: https://github.com/armbian/build/commit/dddf22832564dda0102ea07bcc56fbbefae3b050
+> X-Git-Archeology:   Date: Tue, 29 Nov 2016 14:27:57 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Merge and rename u-boot patch directories
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a6140729064068b611a546d0580cfc34ee561b8b: https://github.com/armbian/build/commit/a6140729064068b611a546d0580cfc34ee561b8b
+> X-Git-Archeology:   Date: Sun, 11 Dec 2016 17:40:27 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Rename and remove obsolete u-boot patches
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 3cb7175c667da480e59ef5b9bb23e238b4955cdf: https://github.com/armbian/build/commit/3cb7175c667da480e59ef5b9bb23e238b4955cdf
+> X-Git-Archeology:   Date: Thu, 15 Sep 2022 11:08:20 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Upgrade Allwinner boot loader to 2022.08 (#4168)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f6a09def35e647a5442e0f92f399485be29f19a9: https://github.com/armbian/build/commit/f6a09def35e647a5442e0f92f399485be29f19a9
+> X-Git-Archeology:   Date: Thu, 10 Nov 2022 21:49:36 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Moving patches to per board and removing obsolete (#4409)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision bc46fd509a50db4bcef014d79569b68287ecc19b: https://github.com/armbian/build/commit/bc46fd509a50db4bcef014d79569b68287ecc19b
+> X-Git-Archeology:   Date: Tue, 13 Jun 2023 20:19:36 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: allwinner: bump u-boot to v2022.10
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9525b2d16c0aa0ec5cf446322e58a0dabb26c857: https://github.com/armbian/build/commit/9525b2d16c0aa0ec5cf446322e58a0dabb26c857
+> X-Git-Archeology:   Date: Mon, 26 Jun 2023 20:54:19 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: Allwinner: Bump u-boot to 2023.01
+> X-Git-Archeology:
+---
+ arch/arm/include/asm/arch-sunxi/clock_sun6i.h | 1 +
+ arch/arm/mach-sunxi/clock_sun6i.c             | 8 +++++---
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
 diff --git a/arch/arm/include/asm/arch-sunxi/clock_sun6i.h b/arch/arm/include/asm/arch-sunxi/clock_sun6i.h
-index 7fcf340db6..723113b10b 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/include/asm/arch-sunxi/clock_sun6i.h
 +++ b/arch/arm/include/asm/arch-sunxi/clock_sun6i.h
 @@ -208,6 +208,7 @@ struct sunxi_ccm_reg {
@@ -11,7 +56,7 @@ index 7fcf340db6..723113b10b 100644
  #define CCM_PLL3_CTRL_M_SHIFT		0
  #define CCM_PLL3_CTRL_M_MASK		(0xf << CCM_PLL3_CTRL_M_SHIFT)
 diff --git a/arch/arm/mach-sunxi/clock_sun6i.c b/arch/arm/mach-sunxi/clock_sun6i.c
-index 86f08ab717..0c403204c5 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/clock_sun6i.c
 +++ b/arch/arm/mach-sunxi/clock_sun6i.c
 @@ -158,15 +158,17 @@ void clock_set_pll1(unsigned int clk)
@@ -35,3 +80,6 @@ index 86f08ab717..0c403204c5 100644
  		       CPU_CLK_SRC_PLL1 << CPU_CLK_SRC_SHIFT,
  		       &ccm->cpu_axi_cfg);
  	}
+-- 
+Armbian
+

--- a/patch/u-boot/u-boot-sunxi/allwinner-h616-GPU-enable-hack.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-h616-GPU-enable-hack.patch
@@ -1,7 +1,7 @@
-From 8064f0b57b15ff957b9b33099662870302e42664 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@gmail.com>
 Date: Sat, 16 Oct 2021 21:33:35 +0200
-Subject: [PATCH] sunxi: H616 GPU enable hack
+Subject: sunxi: H616 GPU enable hack
 
 Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/arch/arm/mach-sunxi/clock_sun50i_h6.c b/arch/arm/mach-sunxi/clock_sun50i_h6.c
-index 7926394cf7..f12f962530 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/clock_sun50i_h6.c
 +++ b/arch/arm/mach-sunxi/clock_sun50i_h6.c
 @@ -16,6 +16,8 @@ void clock_init_safe(void)
@@ -20,7 +20,7 @@ index 7926394cf7..f12f962530 100644
 +		writel(0, 0x7010254);
  	}
  
- 	clrbits_le32(&prcm->res_cal_ctrl, 1);
+ 	if (IS_ENABLED(CONFIG_MACH_SUN50I_H616) ||
 -- 
-2.34.1
+Armbian
 

--- a/patch/u-boot/u-boot-sunxi/allwinner-h616-THS-workaround.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-h616-THS-workaround.patch
@@ -1,7 +1,7 @@
-From ed7573fab40ebbfebbce0f1e1f23e63096417f26 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kali Prasad <kprasadvnsi@protonmail.com>
 Date: Sat, 18 Sep 2021 22:57:05 +0530
-Subject: [PATCH] Adding h616 THS workaround.
+Subject: Adding h616 THS workaround.
 
 Signed-off-by: Kali Prasad <kprasadvnsi@protonmail.com>
 ---
@@ -9,12 +9,12 @@ Signed-off-by: Kali Prasad <kprasadvnsi@protonmail.com>
  1 file changed, 9 insertions(+)
 
 diff --git a/board/sunxi/board.c b/board/sunxi/board.c
-index 7d343a93b2..3079ac0002 100644
+index 111111111111..222222222222 100644
 --- a/board/sunxi/board.c
 +++ b/board/sunxi/board.c
-@@ -247,6 +247,15 @@ int board_init(void)
- 		}
- 	}
+@@ -226,6 +226,15 @@ int board_init(void)
+ 	if (ret)
+ 		return ret;
  
 +#if CONFIG_MACH_SUN50I_H616
 +	/*
@@ -29,5 +29,5 @@ index 7d343a93b2..3079ac0002 100644
  	/*
  	 * Temporary workaround for enabling I2C clocks until proper sunxi DM
 -- 
-2.34.1
+Armbian
 

--- a/patch/u-boot/u-boot-sunxi/allwinner-lower-default-DRAM-freq-A64-H5.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-lower-default-DRAM-freq-A64-H5.patch
@@ -1,8 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+Date: Wed, 1 Nov 2017 13:04:00 +0300
+Subject: [ARCHEOLOGY] Lower default CPU and DRAM frequencies for H5 and A64
+ devices
+
+> X-Git-Archeology: - Revision 46e082773acb379ce3b3aa0c8fec42bb48750830: https://github.com/armbian/build/commit/46e082773acb379ce3b3aa0c8fec42bb48750830
+> X-Git-Archeology:   Date: Wed, 01 Nov 2017 13:04:00 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Lower default CPU and DRAM frequencies for H5 and A64 devices
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9363e3ec4d3a3234c5bdab6b7a1e3fd606b68102: https://github.com/armbian/build/commit/9363e3ec4d3a3234c5bdab6b7a1e3fd606b68102
+> X-Git-Archeology:   Date: Mon, 14 Jan 2019 16:52:22 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: u-boot v2018.11 migration + tons of patches touchups
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f6a09def35e647a5442e0f92f399485be29f19a9: https://github.com/armbian/build/commit/f6a09def35e647a5442e0f92f399485be29f19a9
+> X-Git-Archeology:   Date: Thu, 10 Nov 2022 21:49:36 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Moving patches to per board and removing obsolete (#4409)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision bc46fd509a50db4bcef014d79569b68287ecc19b: https://github.com/armbian/build/commit/bc46fd509a50db4bcef014d79569b68287ecc19b
+> X-Git-Archeology:   Date: Tue, 13 Jun 2023 20:19:36 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: allwinner: bump u-boot to v2022.10
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9525b2d16c0aa0ec5cf446322e58a0dabb26c857: https://github.com/armbian/build/commit/9525b2d16c0aa0ec5cf446322e58a0dabb26c857
+> X-Git-Archeology:   Date: Mon, 26 Jun 2023 20:54:19 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: Allwinner: Bump u-boot to 2023.01
+> X-Git-Archeology:
+---
+ arch/arm/mach-sunxi/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/arch/arm/mach-sunxi/Kconfig b/arch/arm/mach-sunxi/Kconfig
-index dbe6005daa..41e19ba102 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/Kconfig
 +++ b/arch/arm/mach-sunxi/Kconfig
-@@ -467,7 +467,7 @@ config DRAM_CLK
+@@ -555,7 +555,7 @@ config DRAM_CLK
  	default 312 if MACH_SUN6I || MACH_SUN8I
  	default 360 if MACH_SUN4I || MACH_SUN5I || MACH_SUN7I || \
  		       MACH_SUN8I_V3S
@@ -11,3 +46,6 @@ index dbe6005daa..41e19ba102 100644
  	default 744 if MACH_SUN50I_H6
  	default 720 if MACH_SUN50I_H616
  	---help---
+-- 
+Armbian
+

--- a/patch/u-boot/u-boot-sunxi/allwinner-sun8i-set-machid.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-sun8i-set-machid.patch
@@ -1,5 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+Date: Wed, 22 Feb 2017 15:26:26 +0300
+Subject: [ARCHEOLOGY] Convert boot_mode and sun8i machid tou-boot patch
+
+> X-Git-Archeology: > recovered message: > Needs testing on A10, A20, ... with legacy kernel
+> X-Git-Archeology: - Revision b64408698796b0df34068e255981f78f5f627ab3: https://github.com/armbian/build/commit/b64408698796b0df34068e255981f78f5f627ab3
+> X-Git-Archeology:   Date: Wed, 22 Feb 2017 15:26:26 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Convert boot_mode and sun8i machid tou-boot patch
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f6a09def35e647a5442e0f92f399485be29f19a9: https://github.com/armbian/build/commit/f6a09def35e647a5442e0f92f399485be29f19a9
+> X-Git-Archeology:   Date: Thu, 10 Nov 2022 21:49:36 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Moving patches to per board and removing obsolete (#4409)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision bc46fd509a50db4bcef014d79569b68287ecc19b: https://github.com/armbian/build/commit/bc46fd509a50db4bcef014d79569b68287ecc19b
+> X-Git-Archeology:   Date: Tue, 13 Jun 2023 20:19:36 +0200
+> X-Git-Archeology:   From: Gunjan Gupta <viraniac@gmail.com>
+> X-Git-Archeology:   Subject: allwinner: bump u-boot to v2022.10
+> X-Git-Archeology:
+---
+ include/configs/sun8i.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
 diff --git a/include/configs/sun8i.h b/include/configs/sun8i.h
-index b6cd8d39a8..608a055892 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/sun8i.h
 +++ b/include/configs/sun8i.h
 @@ -10,4 +10,6 @@
@@ -9,3 +34,6 @@ index b6cd8d39a8..608a055892 100644
 +#define CONFIG_MACH_TYPE	(0x1029)
 +
  #endif /* __CONFIG_H */
+-- 
+Armbian
+

--- a/patch/u-boot/u-boot-sunxi/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
+++ b/patch/u-boot/u-boot-sunxi/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
@@ -1,8 +1,7 @@
-From 031e83fa0b2b87625af012ab6c5e4424813e5030 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Sun, 24 Jul 2022 13:56:50 +0300
-Subject: [PATCH 170/170] arm64: dts: sun50i-h6-orangepi.dtsi: Rollback r_rsb
- to r_i2c
+Subject: arm64: dts: sun50i-h6-orangepi.dtsi: Rollback r_rsb to r_i2c
 
 This fix affects two boards:
 sun50i-h6-orangepi-lite2.dts
@@ -17,10 +16,10 @@ in which the patch is written in the series.conf file.
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm/dts/sun50i-h6-orangepi.dtsi b/arch/arm/dts/sun50i-h6-orangepi.dtsi
-index ee1919b80..15f4d7de9 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/sun50i-h6-orangepi.dtsi
 +++ b/arch/arm/dts/sun50i-h6-orangepi.dtsi
-@@ -129,12 +129,12 @@ &r_pio {
+@@ -120,12 +120,12 @@
  	vcc-pm-supply = <&reg_bldo3>;
  };
  
@@ -34,8 +33,8 @@ index ee1919b80..15f4d7de9 100644
 -		reg = <0x745>;
 +		reg = <0x36>;
  		interrupt-parent = <&r_intc>;
- 		interrupts = <GIC_SPI 96 IRQ_TYPE_LEVEL_LOW>;
+ 		interrupts = <0 IRQ_TYPE_LEVEL_LOW>;
  		interrupt-controller;
 -- 
-2.35.3
+Armbian
 

--- a/patch/u-boot/u-boot-sunxi/board_x96q/arm64-sun50i-h313-add-x96q-lpddr3-defconfig.patch
+++ b/patch/u-boot/u-boot-sunxi/board_x96q/arm64-sun50i-h313-add-x96q-lpddr3-defconfig.patch
@@ -1,53 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: sic <31908995+sicXnull@users.noreply.github.com>
+Date: Tue, 20 Aug 2024 08:35:00 +0200
+Subject: [ARCHEOLOGY] Add Board X96Q TV Box LPDDR3 H313 (#7101)
+
+> X-Git-Archeology: > recovered message: > * X96-Q TV Box Support
+> X-Git-Archeology: > recovered message: > * Update x96q-tvbox.csc
+> X-Git-Archeology: > recovered message: > * Rename x96q-tvbox.csc to x96q.tvb
+> X-Git-Archeology: - Revision 100a004aa5985b82184f1f00855461ee8f7a9f56: https://github.com/armbian/build/commit/100a004aa5985b82184f1f00855461ee8f7a9f56
+> X-Git-Archeology:   Date: Tue, 20 Aug 2024 08:35:00 +0200
+> X-Git-Archeology:   From: sic <31908995+sicXnull@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Add Board X96Q TV Box LPDDR3 H313 (#7101)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5e54e2beb8dc78c374e6ad741b86f7b01b466e1a: https://github.com/armbian/build/commit/5e54e2beb8dc78c374e6ad741b86f7b01b466e1a
+> X-Git-Archeology:   Date: Wed, 18 Sep 2024 16:31:00 +0200
+> X-Git-Archeology:   From: sicXnull <cvanhauterjr@gmail.com>
+> X-Git-Archeology:   Subject: X96Q LPDDR3 Improvements
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8bc31a28823328451506e7788dde967433ba7254: https://github.com/armbian/build/commit/8bc31a28823328451506e7788dde967433ba7254
+> X-Git-Archeology:   Date: Thu, 19 Sep 2024 10:10:20 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor@armbian.com>
+> X-Git-Archeology:   Subject: Bugfix: resolve boot loader compilation issues on X96-mate and Orangepizero2
+> X-Git-Archeology:
+---
+ arch/arm/dts/Makefile                    |   1 +
+ arch/arm/dts/sun50i-h313-x96q-lpddr3.dts | 162 ++++++++++
+ configs/x96q_lpddr3_defconfig            |  31 ++
+ 3 files changed, 194 insertions(+)
+
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -836,6 +836,7 @@
+@@ -836,6 +836,7 @@ dtb-$(CONFIG_MACH_SUN50I_H6) += \
  dtb-$(CONFIG_MACH_SUN50I_H616) += \
  	sun50i-h616-orangepi-zero2.dtb \
  	sun50i-h618-orangepi-zero3.dtb \
 +	sun50i-h313-x96q-lpddr3.dtb \
  	sun50i-h616-x96-mate.dtb
- 	
- 
-diff --git a/configs/x96q_lpddr3_defconfig b/configs/x96q_lpddr3_defconfig
-+ new file mode 100755
-+ index 000000000..306157b84
-+++ b/configs/x96q_lpddr3_defconfig
-@@ -0,0 +1,31 @@
-+CONFIG_ARM=y
-+CONFIG_ARCH_SUNXI=y
-+CONFIG_DEFAULT_DEVICE_TREE="sun50i-h313-x96q-lpddr3"
-+CONFIG_SPL=y
-+CONFIG_SUNXI_DRAM_H616_LPDDR3=y
-+CONFIG_DRAM_CLK=600
-+CONFIG_DRAM_SUN50I_H616_DX_ODT=0x06060606
-+CONFIG_DRAM_SUN50I_H616_DX_DRI=0x0d0d0d0d
-+CONFIG_DRAM_SUN50I_H616_CA_DRI=0x00000d0d
-+CONFIG_DRAM_SUN50I_H616_ODT_EN=0x00000001
-+CONFIG_DRAM_SUN50I_H616_TPR0=0x0
-+CONFIG_DRAM_SUN50I_H616_TPR2=0x00000000
-+CONFIG_DRAM_SUN50I_H616_TPR10=0x002f3359
-+CONFIG_DRAM_SUN50I_H616_TPR11=0xaa889967
-+CONFIG_DRAM_SUN50I_H616_TPR12=0xeeee8979
-+CONFIG_MACH_SUN50I_H616=y
-+CONFIG_R_I2C_ENABLE=y
-+CONFIG_SPL_I2C=y
-+CONFIG_SPL_I2C_SUPPORT=y
-+CONFIG_SPL_SYS_I2C_LEGACY=y
-+CONFIG_SYS_I2C_MVTWSI=y
-+CONFIG_SYS_I2C_SLAVE=0x7f
-+CONFIG_SYS_I2C_SPEED=100000
-+CONFIG_SYS_MONITOR_LEN=786432
-+CONFIG_PHY_REALTEK=y
-+CONFIG_SUN8I_EMAC=y
-+CONFIG_I2C3_ENABLE=y
-+CONFIG_AXP313_POWER=y
-+CONFIG_USB_EHCI_HCD=y
-+CONFIG_USB_OHCI_HCD=y
-+CONFIG_USB_MUSB_GADGET=y
+ dtb-$(CONFIG_MACH_SUN50I) += \
+ 	sun50i-a64-amarula-relic.dtb \
 diff --git a/arch/arm/dts/sun50i-h313-x96q-lpddr3.dts b/arch/arm/dts/sun50i-h313-x96q-lpddr3.dts
 new file mode 100644
-index 000000000..306157b84
+index 000000000000..111111111111
 --- /dev/null
 +++ b/arch/arm/dts/sun50i-h313-x96q-lpddr3.dts
 @@ -0,0 +1,162 @@
@@ -213,3 +207,43 @@ index 000000000..306157b84
 +	pinctrl-0 = <&uart0_ph_pins>;
 +	status = "okay";
 +};
+diff --git a/configs/x96q_lpddr3_defconfig b/configs/x96q_lpddr3_defconfig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/configs/x96q_lpddr3_defconfig
+@@ -0,0 +1,31 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-h313-x96q-lpddr3"
++CONFIG_SPL=y
++CONFIG_SUNXI_DRAM_H616_LPDDR3=y
++CONFIG_DRAM_CLK=600
++CONFIG_DRAM_SUN50I_H616_DX_ODT=0x06060606
++CONFIG_DRAM_SUN50I_H616_DX_DRI=0x0d0d0d0d
++CONFIG_DRAM_SUN50I_H616_CA_DRI=0x00000d0d
++CONFIG_DRAM_SUN50I_H616_ODT_EN=0x00000001
++CONFIG_DRAM_SUN50I_H616_TPR0=0x0
++CONFIG_DRAM_SUN50I_H616_TPR2=0x00000000
++CONFIG_DRAM_SUN50I_H616_TPR10=0x002f3359
++CONFIG_DRAM_SUN50I_H616_TPR11=0xaa889967
++CONFIG_DRAM_SUN50I_H616_TPR12=0xeeee8979
++CONFIG_MACH_SUN50I_H616=y
++CONFIG_R_I2C_ENABLE=y
++CONFIG_SPL_I2C=y
++CONFIG_SPL_I2C_SUPPORT=y
++CONFIG_SPL_SYS_I2C_LEGACY=y
++CONFIG_SYS_I2C_MVTWSI=y
++CONFIG_SYS_I2C_SLAVE=0x7f
++CONFIG_SYS_I2C_SPEED=100000
++CONFIG_SYS_MONITOR_LEN=786432
++CONFIG_PHY_REALTEK=y
++CONFIG_SUN8I_EMAC=y
++CONFIG_I2C3_ENABLE=y
++CONFIG_AXP313_POWER=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_MUSB_GADGET=y
+-- 
+Armbian
+

--- a/patch/u-boot/u-boot-sunxi/board_x96q/sunsi-add-h616-internal-eth-phy-support.patch
+++ b/patch/u-boot/u-boot-sunxi/board_x96q/sunsi-add-h616-internal-eth-phy-support.patch
@@ -1,5 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: sicXnull <cvanhauterjr@gmail.com>
+Date: Wed, 18 Sep 2024 16:31:00 +0200
+Subject: [ARCHEOLOGY] X96Q LPDDR3 Improvements
+
+> X-Git-Archeology: - Revision 5e54e2beb8dc78c374e6ad741b86f7b01b466e1a: https://github.com/armbian/build/commit/5e54e2beb8dc78c374e6ad741b86f7b01b466e1a
+> X-Git-Archeology:   Date: Wed, 18 Sep 2024 16:31:00 +0200
+> X-Git-Archeology:   From: sicXnull <cvanhauterjr@gmail.com>
+> X-Git-Archeology:   Subject: X96Q LPDDR3 Improvements
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6ee98e7f51fb4ad8cb8dfbda3a2903427d8ee205: https://github.com/armbian/build/commit/6ee98e7f51fb4ad8cb8dfbda3a2903427d8ee205
+> X-Git-Archeology:   Date: Wed, 18 Sep 2024 20:18:11 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor@armbian.com>
+> X-Git-Archeology:   Subject: Bugfix: u-boot changes for x96q broke most of other Allwinner uboot compilation
+> X-Git-Archeology:
+---
+ arch/arm/dts/sun50i-h616.dtsi         | 27 +++++++++
+ arch/arm/include/asm/arch-sunxi/i2c.h |  3 +
+ arch/arm/mach-sunxi/Kconfig           |  9 +++
+ arch/arm/mach-sunxi/board.c           |  1 +
+ arch/arm/mach-sunxi/clock_sun50i_h6.c |  4 ++
+ board/sunxi/board.c                   | 30 ++++++++++
+ drivers/net/sun8i_emac.c              |  7 +++
+ drivers/pinctrl/sunxi/pinctrl-sunxi.c |  1 +
+ 8 files changed, 82 insertions(+)
+
 diff --git a/arch/arm/dts/sun50i-h616.dtsi b/arch/arm/dts/sun50i-h616.dtsi
-index 74aed0d232a..091d52be962 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/sun50i-h616.dtsi
 +++ b/arch/arm/dts/sun50i-h616.dtsi
 @@ -209,6 +209,14 @@
@@ -44,7 +70,7 @@ index 74aed0d232a..091d52be962 100644
  			compatible = "allwinner,sun50i-h616-musb",
  				     "allwinner,sun8i-h3-musb";
 diff --git a/arch/arm/include/asm/arch-sunxi/i2c.h b/arch/arm/include/asm/arch-sunxi/i2c.h
-index f0da46d863c..914f16b2c46 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/include/asm/arch-sunxi/i2c.h
 +++ b/arch/arm/include/asm/arch-sunxi/i2c.h
 @@ -13,6 +13,9 @@
@@ -58,10 +84,10 @@ index f0da46d863c..914f16b2c46 100644
  #define CFG_I2C_MVTWSI_BASE2 SUNXI_R_TWI_BASE
  #endif
 diff --git a/arch/arm/mach-sunxi/Kconfig b/arch/arm/mach-sunxi/Kconfig
-index 6dcbb096f74..fa9d67e09a0 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/Kconfig
 +++ b/arch/arm/mach-sunxi/Kconfig
-@@ -771,6 +771,15 @@ config I2C1_ENABLE
+@@ -809,6 +809,15 @@ config I2C1_ENABLE
  	---help---
  	See I2C0_ENABLE help text.
  
@@ -78,10 +104,10 @@ index 6dcbb096f74..fa9d67e09a0 100644
  config R_I2C_ENABLE
  	bool "Enable the PRCM I2C/TWI controller"
 diff --git a/arch/arm/mach-sunxi/board.c b/arch/arm/mach-sunxi/board.c
-index 391a65a5495..b44e741627e 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/board.c
 +++ b/arch/arm/mach-sunxi/board.c
-@@ -460,6 +460,7 @@ void board_init_f(ulong dummy)
+@@ -481,6 +481,7 @@ void board_init_f(ulong dummy)
  	/* Needed early by sunxi_board_init if PMU is enabled */
  	i2c_init_board();
  	i2c_init(CONFIG_SYS_I2C_SPEED, CONFIG_SYS_I2C_SLAVE);
@@ -90,10 +116,10 @@ index 391a65a5495..b44e741627e 100644
  	sunxi_board_init();
  }
 diff --git a/arch/arm/mach-sunxi/clock_sun50i_h6.c b/arch/arm/mach-sunxi/clock_sun50i_h6.c
-index 7926394cf76..7c84d731f84 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/clock_sun50i_h6.c
 +++ b/arch/arm/mach-sunxi/clock_sun50i_h6.c
-@@ -46,6 +46,10 @@ void clock_init_safe(void)
+@@ -53,6 +53,10 @@ void clock_init_safe(void)
  	 * DRAM initialization code.
  	 */
  	writel(MBUS_CLK_SRC_PLL6X2 | MBUS_CLK_M(3), &ccm->mbus_cfg);
@@ -105,7 +131,7 @@ index 7926394cf76..7c84d731f84 100644
  #endif
  
 diff --git a/board/sunxi/board.c b/board/sunxi/board.c
-index f321cd58a6e..d5633ad5ca6 100644
+index 111111111111..222222222222 100644
 --- a/board/sunxi/board.c
 +++ b/board/sunxi/board.c
 @@ -15,6 +15,7 @@
@@ -116,7 +142,7 @@ index f321cd58a6e..d5633ad5ca6 100644
  #include <image.h>
  #include <init.h>
  #include <log.h>
-@@ -107,6 +108,17 @@ void i2c_init_board(void)
+@@ -109,6 +110,17 @@ void i2c_init_board(void)
  #endif
  #endif
  
@@ -134,7 +160,7 @@ index f321cd58a6e..d5633ad5ca6 100644
  #ifdef CONFIG_R_I2C_ENABLE
  #ifdef CONFIG_MACH_SUN50I
  	clock_twi_onoff(5, 1);
-@@ -572,6 +584,7 @@ static void sunxi_spl_store_dram_size(phys_addr_t dram_size)
+@@ -566,6 +578,7 @@ static void sunxi_spl_store_dram_size(phys_addr_t dram_size)
  void sunxi_board_init(void)
  {
  	int power_failed = 0;
@@ -142,7 +168,7 @@ index f321cd58a6e..d5633ad5ca6 100644
  
  #ifdef CONFIG_LED_STATUS
  	if (IS_ENABLED(CONFIG_SPL_DRIVERS_MISC))
-@@ -666,6 +679,23 @@ void sunxi_board_init(void)
+@@ -656,6 +669,23 @@ void sunxi_board_init(void)
  		clock_set_pll1(get_board_sys_clk());
  	else
  		printf("Failed to set core voltage! Can't set CPU frequency\n");
@@ -165,12 +191,12 @@ index f321cd58a6e..d5633ad5ca6 100644
 +	i2c_write(0x10, 0, 1, data, 2);
  }
  #endif /* CONFIG_SPL_BUILD */
-
+ 
 diff --git a/drivers/net/sun8i_emac.c b/drivers/net/sun8i_emac.c
-index 04c3274fbe1..d0b80d4cec1 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/sun8i_emac.c
 +++ b/drivers/net/sun8i_emac.c
-@@ -909,6 +909,11 @@ static const struct emac_variant emac_variant_h6 = {
+@@ -906,6 +906,11 @@ static const struct emac_variant emac_variant_h6 = {
  	.support_rmii		= true,
  };
  
@@ -182,7 +208,7 @@ index 04c3274fbe1..d0b80d4cec1 100644
  static const struct udevice_id sun8i_emac_eth_ids[] = {
  	{ .compatible = "allwinner,sun8i-a83t-emac",
  	  .data = (ulong)&emac_variant_a83t },
-@@ -920,6 +925,8 @@ static const struct udevice_id sun8i_emac_eth_ids[] = {
+@@ -917,6 +922,8 @@ static const struct udevice_id sun8i_emac_eth_ids[] = {
  	  .data = (ulong)&emac_variant_a64 },
  	{ .compatible = "allwinner,sun50i-h6-emac",
  	  .data = (ulong)&emac_variant_h6 },
@@ -192,10 +218,10 @@ index 04c3274fbe1..d0b80d4cec1 100644
  };
  
 diff --git a/drivers/pinctrl/sunxi/pinctrl-sunxi.c b/drivers/pinctrl/sunxi/pinctrl-sunxi.c
-index e5102180902..8f4517c177f 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pinctrl/sunxi/pinctrl-sunxi.c
 +++ b/drivers/pinctrl/sunxi/pinctrl-sunxi.c
-@@ -710,6 +710,7 @@ static const struct sunxi_pinctrl_desc __maybe_unused sun50i_h6_r_pinctrl_desc =
+@@ -737,6 +737,7 @@ static const struct sunxi_pinctrl_desc __maybe_unused sun50i_h6_r_pinctrl_desc =
  
  static const struct sunxi_pinctrl_function sun50i_h616_pinctrl_functions[] = {
  	{ "emac0",	2 },	/* PI0-PI16 */
@@ -203,3 +229,6 @@ index e5102180902..8f4517c177f 100644
  	{ "gpio_in",	0 },
  	{ "gpio_out",	1 },
  	{ "mmc0",	2 },	/* PF0-PF5 */
+-- 
+Armbian
+

--- a/patch/u-boot/u-boot-sunxi/opizero3-1.5GB-trim-from-u-boot-v2024.01.patch
+++ b/patch/u-boot/u-boot-sunxi/opizero3-1.5GB-trim-from-u-boot-v2024.01.patch
@@ -1,17 +1,16 @@
-From f9aa935084d24fbbe5e7b2c62948a8f08b228f18 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: voapilro <voapilro@gmail.com>
 Date: Mon, 6 May 2024 11:36:47 +0200
-Subject: [PATCH 1/3] Fix memory size detection for 1.5GB Orange Pi Zero 3
- board
+Subject: Fix memory size detection for 1.5GB Orange Pi Zero 3 board
 
 ---
  arch/arm/include/asm/arch-sunxi/dram.h |  1 +
- arch/arm/mach-sunxi/dram_helpers.c     | 20 ++++++++++++++++++++
- arch/arm/mach-sunxi/dram_sun50i_h616.c |  9 ++++++++-
+ arch/arm/mach-sunxi/dram_helpers.c     | 20 ++++++++++
+ arch/arm/mach-sunxi/dram_sun50i_h616.c |  9 ++++-
  3 files changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm/include/asm/arch-sunxi/dram.h b/arch/arm/include/asm/arch-sunxi/dram.h
-index 682daae6b1a..a1379631d62 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/include/asm/arch-sunxi/dram.h
 +++ b/arch/arm/include/asm/arch-sunxi/dram.h
 @@ -40,5 +40,6 @@
@@ -22,10 +21,10 @@ index 682daae6b1a..a1379631d62 100644
  
  #endif /* _SUNXI_DRAM_H */
 diff --git a/arch/arm/mach-sunxi/dram_helpers.c b/arch/arm/mach-sunxi/dram_helpers.c
-index cdf2750f1c5..36fabb3bcd5 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/dram_helpers.c
 +++ b/arch/arm/mach-sunxi/dram_helpers.c
-@@ -40,4 +40,24 @@ bool mctl_mem_matches(u32 offset)
+@@ -41,4 +41,24 @@ bool mctl_mem_matches(u32 offset)
  	return readl(CFG_SYS_SDRAM_BASE) ==
  	       readl((ulong)CFG_SYS_SDRAM_BASE + offset);
  }
@@ -51,7 +50,7 @@ index cdf2750f1c5..36fabb3bcd5 100644
 +}
  #endif
 diff --git a/arch/arm/mach-sunxi/dram_sun50i_h616.c b/arch/arm/mach-sunxi/dram_sun50i_h616.c
-index c5c1331a4c3..5287ef79c43 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/dram_sun50i_h616.c
 +++ b/arch/arm/mach-sunxi/dram_sun50i_h616.c
 @@ -1350,9 +1350,16 @@ static void mctl_auto_detect_dram_size(const struct dram_para *para,
@@ -72,11 +71,13 @@ index c5c1331a4c3..5287ef79c43 100644
  }
  
  static const struct dram_para para = {
+-- 
+Armbian
 
-From 371388504b9b67459dfd13d2585090961ad51cc5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: voapilro <voapilro@gmail.com>
 Date: Mon, 6 May 2024 15:13:29 +0200
-Subject: [PATCH 2/3] Added some logs regarding memory size detection
+Subject: Added some logs regarding memory size detection
 
 ---
  arch/arm/include/asm/arch-sunxi/dram.h |  1 +
@@ -86,7 +87,7 @@ Subject: [PATCH 2/3] Added some logs regarding memory size detection
  4 files changed, 20 insertions(+), 4 deletions(-)
 
 diff --git a/arch/arm/include/asm/arch-sunxi/dram.h b/arch/arm/include/asm/arch-sunxi/dram.h
-index a1379631d62..c7543d35698 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/include/asm/arch-sunxi/dram.h
 +++ b/arch/arm/include/asm/arch-sunxi/dram.h
 @@ -41,5 +41,6 @@ unsigned long sunxi_dram_init(void);
@@ -97,10 +98,10 @@ index a1379631d62..c7543d35698 100644
  
  #endif /* _SUNXI_DRAM_H */
 diff --git a/arch/arm/mach-sunxi/dram_helpers.c b/arch/arm/mach-sunxi/dram_helpers.c
-index 36fabb3bcd5..5a80159759c 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/dram_helpers.c
 +++ b/arch/arm/mach-sunxi/dram_helpers.c
-@@ -49,7 +49,7 @@ bool mctl_mem_matches_top(ulong offset)
+@@ -50,7 +50,7 @@ bool mctl_mem_matches_top(ulong offset)
  	static const unsigned value= 0xaa55aa55;
  
  	/* Take last usable memory address */
@@ -109,7 +110,7 @@ index 36fabb3bcd5..5a80159759c 100644
  	dsb();
  	/* Set zero at last usable memory address */
  	writel(0, (ulong)CONFIG_SYS_SDRAM_BASE + offset);
-@@ -60,4 +60,12 @@ bool mctl_mem_matches_top(ulong offset)
+@@ -61,4 +61,12 @@ bool mctl_mem_matches_top(ulong offset)
  	/* Check if the same value is actually observed when reading back */
  	return readl((ulong)CONFIG_SYS_SDRAM_BASE + offset) == value;
  }
@@ -123,7 +124,7 @@ index 36fabb3bcd5..5a80159759c 100644
 +}
  #endif
 diff --git a/arch/arm/mach-sunxi/dram_sun50i_h616.c b/arch/arm/mach-sunxi/dram_sun50i_h616.c
-index 5287ef79c43..6a247ecaa05 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/dram_sun50i_h616.c
 +++ b/arch/arm/mach-sunxi/dram_sun50i_h616.c
 @@ -1355,9 +1355,17 @@ static unsigned long mctl_calc_size(const struct dram_config *config)
@@ -146,10 +147,10 @@ index 5287ef79c43..6a247ecaa05 100644
  	return size;
  }
 diff --git a/board/sunxi/board.c b/board/sunxi/board.c
-index 8c12c8deade..62228936774 100644
+index 111111111111..222222222222 100644
 --- a/board/sunxi/board.c
 +++ b/board/sunxi/board.c
-@@ -632,9 +632,8 @@ void sunxi_board_init(void)
+@@ -641,9 +641,8 @@ void sunxi_board_init(void)
  	power_failed |= axp_set_sw(IS_ENABLED(CONFIG_AXP_SW_ON));
  #endif
  #endif	/* CONFIG_AXPxxx_POWER */
@@ -160,22 +161,23 @@ index 8c12c8deade..62228936774 100644
  	if (!gd->ram_size)
  		hang();
  
+-- 
+Armbian
 
-From 4b5089810e7adac0801185e82a39c5849bf2bb91 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: voapilro <voapilro@gmail.com>
 Date: Mon, 6 May 2024 19:36:47 +0200
-Subject: [PATCH 3/3] Updated name from CONFIG_SYS_SDRAM_BASE to
- CFG_SYS_SDRAM_BASE
+Subject: Updated name from CONFIG_SYS_SDRAM_BASE to CFG_SYS_SDRAM_BASE
 
 ---
  arch/arm/mach-sunxi/dram_helpers.c | 8 ++++----
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/arch/arm/mach-sunxi/dram_helpers.c b/arch/arm/mach-sunxi/dram_helpers.c
-index 5a80159759c..0d7fbac61bf 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-sunxi/dram_helpers.c
 +++ b/arch/arm/mach-sunxi/dram_helpers.c
-@@ -52,13 +52,13 @@ bool mctl_mem_matches_top(ulong offset)
+@@ -53,13 +53,13 @@ bool mctl_mem_matches_top(ulong offset)
  	offset -= sizeof(value);
  	dsb();
  	/* Set zero at last usable memory address */
@@ -192,7 +194,7 @@ index 5a80159759c..0d7fbac61bf 100644
  }
  
  /*
-@@ -66,6 +66,6 @@ bool mctl_mem_matches_top(ulong offset)
+@@ -67,6 +67,6 @@ bool mctl_mem_matches_top(ulong offset)
   */
  ulong mctl_mem_address(ulong offset)
  {
@@ -200,3 +202,6 @@ index 5a80159759c..0d7fbac61bf 100644
 +	return (ulong)CFG_SYS_SDRAM_BASE + offset;
  }
  #endif
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Noticed from https://github.com/armbian/build/issues/8967 that the patches seem quite messy. So let's rewrite 'em.

# How Has This Been Tested?

- [x] build https://paste.armbian.com/dopigabaze

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added boot splash screen support for Sunxi boards.
  * Added support for Recore, X96Q LPDDR3, and OPi Zero3 1.5GB boards.
  * Enabled GPU support and internal Ethernet PHY for H616.
  * Enabled keyboard-controlled autoboot.

* **Bug Fixes & Improvements**
  * Fixed H6 RAM size detection.
  * Fixed A10 PMU interrupt conflicts.
  * Improved EDID detection on supported boards.
  * Fixed GPIO access on H3/H5 boards.
  * Improved clock stability and reduced default DRAM frequency on A64/H5 boards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->