### PR TITLE
lib / main-config.sh: enable APA extension for questing and resolute builds

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -321,9 +321,10 @@ function do_main_configuration() {
 			;;
 	esac
 
-        # enable APA extension for Debian Unstable release
-	# loong64 is not supported now
-        [ "$RELEASE" = "sid" ] && [ "$ARCH" != "loong64" ] && enable_extension "apa"
+	# enable APA extension for latest Ubuntu and Debian releases
+	# FIXME: drop this paragraph when APA becomes the default
+	# FIXME: loong64 is not supported now
+	[[ "$RELEASE" =~ ^(sid|questing|resolute)$ ]] && [[ "$ARCH" != "loong64" ]] && enable_extension "apa"
 
 	## Extensions: at this point we've sourced all the config files that will be used,
 	##             and (hopefully) not yet invoked any extension methods. So this is the perfect


### PR DESCRIPTION
alternative to #8966 to solve #8965 using APA for the latest Ubuntu releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * APA extension now activates for more release types (broader release matching).

* **Chores**
  * Updated configuration to preserve existing architecture exclusions while expanding release matching.
  * Added notes for future follow-ups on default APA behavior and specific architecture handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->