### PR TITLE
Add configurable cache bind for chroot

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,5 @@
+# Configuration Directory
+
+This directory contains the build-time configuration files, templates, and data consumed by the Armbian build framework.
+
+- `ARMBIAN_CACHE_DIR` (default `/armbian/cache`): Host path that, when present, is bind-mounted into the chroot at `/armbian/cache` to share downloaded artifacts (keyrings, packages, etc.) between builds. Override this if your cache lives elsewhere or needs to be relocated for containerized builds.

--- a/lib/functions/general/chroot-helpers.sh
+++ b/lib/functions/general/chroot-helpers.sh
@@ -16,39 +16,75 @@ function mount_chroot() {
 	local target cache_src
 	target="$(realpath "$1")" # normalize, remove last slash if dir
 	display_alert "mount_chroot" "$target" "debug"
+	# Track mounts we create so we can unwind on failure.
+	local -a mounted_points=()
+	cleanup_mounted_points() {
+		local -i i
+		for (( i=${#mounted_points[@]}-1; i>=0; i-- )); do
+			umount --recursive "${mounted_points[i]}" &> /dev/null || true
+		done
+	}
 	if ! mkdir -p "${target}/run/user/0"; then
 		display_alert "Failed to prepare chroot runtime directory" "${target}/run/user/0" "err"
 		return 1
 	fi
 
 	# tmpfs size=50% is the Linux default, but we need more.
-	if ! mountpoint -q "${target}/tmp" && ! mount -t tmpfs -o "size=99%" tmpfs "${target}/tmp"; then
-		display_alert "Failed to mount tmpfs inside chroot" "${target}/tmp" "err"
-		return 1
+	if ! mountpoint -q "${target}/tmp"; then
+		if ! mount -t tmpfs -o "size=99%" tmpfs "${target}/tmp"; then
+			display_alert "Failed to mount tmpfs inside chroot" "${target}/tmp" "err"
+			cleanup_mounted_points
+			return 1
+		fi
+		mounted_points+=("${target}/tmp")
 	fi
-	if ! mountpoint -q "${target}/var/tmp" && ! mount -t tmpfs -o "size=99%" tmpfs "${target}/var/tmp"; then
-		display_alert "Failed to mount tmpfs inside chroot" "${target}/var/tmp" "err"
-		return 1
+	if ! mountpoint -q "${target}/var/tmp"; then
+		if ! mount -t tmpfs -o "size=99%" tmpfs "${target}/var/tmp"; then
+			display_alert "Failed to mount tmpfs inside chroot" "${target}/var/tmp" "err"
+			cleanup_mounted_points
+			return 1
+		fi
+		mounted_points+=("${target}/var/tmp")
 	fi
-	if ! mountpoint -q "${target}/run/user/0" && ! mount -t tmpfs -o "size=99%" tmpfs "${target}/run/user/0"; then
-		display_alert "Failed to mount tmpfs inside chroot" "${target}/run/user/0" "err"
-		return 1
+	if ! mountpoint -q "${target}/run/user/0"; then
+		if ! mount -t tmpfs -o "size=99%" tmpfs "${target}/run/user/0"; then
+			display_alert "Failed to mount tmpfs inside chroot" "${target}/run/user/0" "err"
+			cleanup_mounted_points
+			return 1
+		fi
+		mounted_points+=("${target}/run/user/0")
 	fi
-	if ! mountpoint -q "${target}/proc" && ! mount -t proc chproc "${target}/proc"; then
-		display_alert "Failed to mount proc inside chroot" "${target}/proc" "err"
-		return 1
+	if ! mountpoint -q "${target}/proc"; then
+		if ! mount -t proc chproc "${target}/proc"; then
+			display_alert "Failed to mount proc inside chroot" "${target}/proc" "err"
+			cleanup_mounted_points
+			return 1
+		fi
+		mounted_points+=("${target}/proc")
 	fi
-	if ! mountpoint -q "${target}/sys" && ! mount -t sysfs chsys "${target}/sys"; then
-		display_alert "Failed to mount sysfs inside chroot" "${target}/sys" "err"
-		return 1
+	if ! mountpoint -q "${target}/sys"; then
+		if ! mount -t sysfs chsys "${target}/sys"; then
+			display_alert "Failed to mount sysfs inside chroot" "${target}/sys" "err"
+			cleanup_mounted_points
+			return 1
+		fi
+		mounted_points+=("${target}/sys")
 	fi
-	if ! mountpoint -q "${target}/dev" && ! mount --bind /dev "${target}/dev"; then
-		display_alert "Failed to bind /dev into chroot" "${target}/dev" "err"
-		return 1
+	if ! mountpoint -q "${target}/dev"; then
+		if ! mount --bind /dev "${target}/dev"; then
+			display_alert "Failed to bind /dev into chroot" "${target}/dev" "err"
+			cleanup_mounted_points
+			return 1
+		fi
+		mounted_points+=("${target}/dev")
 	fi
-	if ! mountpoint -q "${target}/dev/pts" && ! mount -t devpts chpts "${target}/dev/pts" && ! mount --bind /dev/pts "${target}/dev/pts"; then
-		display_alert "Failed to mount devpts inside chroot" "${target}/dev/pts" "err"
-		return 1
+	if ! mountpoint -q "${target}/dev/pts"; then
+		if ! mount -t devpts chpts "${target}/dev/pts" && ! mount --bind /dev/pts "${target}/dev/pts"; then
+			display_alert "Failed to mount devpts inside chroot" "${target}/dev/pts" "err"
+			cleanup_mounted_points
+			return 1
+		fi
+		mounted_points+=("${target}/dev/pts")
 	fi
 
 	# Bind host cache into chroot if present (configurable via ARMBIAN_CACHE_DIR)


### PR DESCRIPTION
# Description

This reimplements this pull request, while fixing the edge case (hopefully). https://github.com/armbian/build/pull/8186

I don't have a bare metal device to test.

# How Has This Been Tested?

I haven't checked this yet, I'll run it with a Qt buildout that I have


# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build environment now tracks mounts and unmounts in reverse order, with guarded per-path mounting and earlier creation of runtime directories.
  * Host cache bind-mounting added (driven by ARMBIAN_CACHE_DIR), skipping if absent and warning on failures.
* **Bug Fixes**
  * Improved error handling to reduce failed mounts and ensure reliable cleanup.
* **Documentation**
  * Added config docs explaining the config directory and ARMBIAN_CACHE_DIR behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->