### PR TITLE
[hk1-k8s] initialize. work HDMI(partial), ethernet, sdcard slot. emmc

### DIFF
--- a/config/boards/hk1-k8s.csc
+++ b/config/boards/hk1-k8s.csc
@@ -1,0 +1,15 @@
+# Rockchip RK3528 quad core 4GB SoC WIFI/BT AIC8800D80 64GB eMMC - LEMFO HK1 RBOX K8S
+BOARD_NAME="HK1 K8S"
+BOARDFAMILY="rk35xx"
+BOOTCONFIG="rock-2-rk3528_defconfig"
+BOARD_MAINTAINER="leXiaLim"
+KERNEL_TARGET="vendor"
+KERNEL_BTF="no"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3528-hk1-k8s.dtb"
+BOOT_SCENARIO="spl-blobs"
+IMAGE_PARTITION_TABLE="gpt"
+
+# HK1 K8S uses AIC8800D80 for WiFi/BT via SDIO
+# Firmware: aic8800 (included in vendor kernel)

--- a/patch/kernel/rk35xx-vendor-6.1/dt/rk3528-add-hk1-k8s-dts.patch
+++ b/patch/kernel/rk35xx-vendor-6.1/dt/rk3528-add-hk1-k8s-dts.patch
@@ -1,0 +1,631 @@
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3528-hk1-k8s.dts
+@@ -0,0 +1,628 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Rockchip Electronics Co., Ltd.
++ * Copyright (c) 2025 Adapted for LEMFO HK1 RBOX K8S
++ *
++ * Based on Radxa Rock 2F
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/rk-input.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include "rk3528.dtsi"
++#include "rk3528-linux.dtsi"
++
++/ {
++	model = "LEMFO HK1 RBOX K8S";
++	compatible = "lemfo,hk1-k8s", "rockchip,rk3528";
++
++	/delete-node/ chosen;
++
++	aliases {
++		mmc0 = &sdhci;  /* eMMC */
++		mmc1 = &sdmmc;  /* SD card */
++		mmc2 = &sdio1;  /* SDIO WiFi - RTL8822CS at ffc20000 */
++	};
++
++	vcc5v0_sys: vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vdd_0v9_s3: vdd-0v9-s3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_0v9_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <900000>;
++		regulator-max-microvolt = <900000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc_3v3_s3: vcc-3v3-s3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_3v3_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vdd_1v8_s3: vdd-1v8-s3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_1v8_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
++	vcc_ddr_s3: vcc-ddr-s3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_ddr_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1200000>;
++		regulator-max-microvolt = <1200000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	/* AIC8800D80 WiFi/BT power sequence - SDIO ID: C8A1:0082 */
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_reset_h>;
++		post-power-on-delay-ms = <100>;
++		power-off-delay-us = <500000>;
++		reset-gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_LOW>; /* GPIO3_C4 */
++	};
++
++	/* AIC8800D80 Bluetooth */
++	wireless_bluetooth: wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		pinctrl-names = "default", "rts_gpio";
++		pinctrl-0 = <&bt_pins>;
++		pinctrl-1 = <&bt_rts_gpio>;
++		uart_rts_gpios = <&gpio3 RK_PA2 GPIO_ACTIVE_LOW>; /* GPIO3_A2 (GPIO 98) - UART2 RTS */
++		BT,reset_gpio = <&gpio3 RK_PD2 GPIO_ACTIVE_HIGH>; /* GPIO3_D2 (GPIO 114) - Android verified */
++		BT,wake_host_irq = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>; /* GPIO3_D1 (GPIO 113) - Android verified */
++		status = "okay";
++	};
++
++	/* AIC8800D80 WiFi platform data */
++	wireless_wlan: wireless-wlan {
++		compatible = "wlan-platdata";
++		wifi_chip_type = "aic8800";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_pins>;
++		WIFI,host_wake_irq = <&gpio3 RK_PB3 GPIO_ACTIVE_HIGH>; /* GPIO3_PB3 */
++		WIFI,poweren_gpio = <&gpio3 RK_PC4 GPIO_ACTIVE_HIGH>; /* GPIO3_C4 (GPIO 108) - WiFi reset - Android verified */
++		status = "okay";
++	};
++
++	/* USB Host power */
++	vcc5v0_host: vcc5v0-host-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_host";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio0 RK_PA1 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc5v0_sys>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_host_en>;
++	};
++
++	vcc5v0_otg: vcc5v0-otg-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_otg";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	/* FD628 LED Display Controller */
++	fd628_dev: fd628-dev {
++		compatible = "amlogic,fd628_dev";
++		fd628_gpio_clk = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
++		fd628_gpio_dat = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	/* GPU and Logic voltage - PWM controlled */
++	vdd_gpu: vdd_logic: vdd-logic {
++		compatible = "pwm-regulator";
++		pwms = <&pwm2 0 5000 1>;
++		regulator-name = "vdd_logic";
++		regulator-min-microvolt = <705000>;
++		regulator-max-microvolt = <1006000>;
++		regulator-init-microvolt = <900000>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-settling-time-up-us = <250>;
++		pwm-supply = <&vcc5v0_sys>;
++		status = "okay";
++	};
++
++	/* CPU voltage - PWM controlled */
++	vdd_cpu: vdd-cpu {
++		compatible = "pwm-regulator";
++		pwms = <&pwm1 0 5000 1>;
++		regulator-name = "vdd_cpu";
++		regulator-min-microvolt = <746000>;
++		regulator-max-microvolt = <1201000>;
++		regulator-init-microvolt = <953000>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-settling-time-up-us = <250>;
++		pwm-supply = <&vcc5v0_sys>;
++		status = "okay";
++	};
++
++	/* HDMI Sound */
++	hdmi_sound: hdmi-sound {
++		status = "okay";
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,name = "rockchip-hdmi0";
++		simple-audio-card,cpu {
++			sound-dai = <&sai3>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&hdmi>;
++		};
++	};
++
++	/* Front Panel LEDs - 7-segment display control */
++	gpio_leds: gpio-leds {
++		compatible = "gpio-leds";
++
++		pwr-red {
++			gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "none";
++			default-state = "off";
++			retain-state-suspended;
++			retain-state-shutdown;
++		};
++
++		pwr-green {
++			gpios = <&gpio4 RK_PB5 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "none";
++			default-state = "on";
++			retain-state-suspended;
++			retain-state-shutdown;
++		};
++	};
++
++	/* IR Receiver */
++	ir-receiver {
++		compatible = "gpio-ir-receiver";
++		gpios = <&gpio3 RK_PC3 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pwm3_pin>;
++		linux,rc-map-name = "rc-beelink-gs1";
++	};
++
++};
++
++&pwm1 {
++	status = "okay";
++};
++
++&pwm2 {
++	status = "okay";
++};
++
++/* PWM3 for IR receiver */
++&pwm3 {
++	status = "okay";
++	pinctrl-names = "active";
++	pinctrl-0 = <&pwm3_pin>;
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&crypto {
++	status = "okay";
++};
++
++&dfi {
++	status = "okay";
++};
++
++&dmc {
++	center-supply = <&vdd_logic>;
++	status = "okay";
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu>;
++	status = "okay";
++};
++
++&gpu_bus {
++	bus-supply = <&vdd_logic>;
++	status = "okay";
++};
++
++&display_subsystem {
++	status = "okay";
++};
++
++&hdmi {
++	status = "okay";
++	avdd-0v9-supply = <&vdd_0v9_s3>;
++	avdd-1v8-supply = <&vdd_1v8_s3>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&hdmim0_tx0_hpd &hdmim0_tx0_scl &hdmim0_tx0_cec>;
++	/* DDC I2C timing from Android DTB - fixes EDID read issues */
++	ddc-i2c-scl-high-time-ns = <9625>;
++	ddc-i2c-scl-low-time-ns = <10000>;
++	/* HPD GPIO from Android DTB */
++	hpd-gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_HIGH>;
++	cec-enable;
++	rockchip,phy-table =
++		<92812500  0x8009 0x0000 0x0270>,
++		<165000000 0x800b 0x0000 0x026d>,
++		<185625000 0x800b 0x0000 0x01ed>,
++		<297000000 0x8029 0x0000 0x0090>,
++		<594000000 0x8039 0x0000 0x00f6>;
++};
++
++&hdmi_in_vp0 {
++	status = "okay";
++};
++
++&hdmiphy {
++	status = "okay";
++	phy-supply = <&vdd_0v9_s3>;
++};
++
++&tve {
++	status = "okay";
++};
++
++&tve_in_vp1 {
++	status = "okay";
++};
++
++&iep {
++	status = "okay";
++};
++
++&iep_mmu {
++	status = "okay";
++};
++
++&jpegd {
++	status = "okay";
++};
++
++&jpegd_mmu {
++	status = "okay";
++};
++
++&mpp_srv {
++	status = "okay";
++};
++
++&rga2 {
++	status = "okay";
++};
++
++&rga2_mmu {
++	status = "okay";
++};
++
++&rkvdec {
++	status = "okay";
++};
++
++&rkvdec_mmu {
++	status = "okay";
++};
++
++&rkvenc {
++	status = "okay";
++};
++
++&rkvenc_mmu {
++	status = "okay";
++};
++
++&rkvtunnel {
++	status = "okay";
++};
++
++&rockchip_suspend {
++	status = "okay";
++	rockchip,sleep-debug-en = <1>;
++	rockchip,virtual-poweroff = <1>;
++	rockchip,sleep-mode-config = <
++		(0
++		| RKPM_SLP_ARMPD
++		)
++	>;
++	rockchip,wakeup-config = <
++		(0
++		| RKPM_CPU0_WKUP_EN
++		| RKPM_GPIO_WKUP_EN
++		)
++	>;
++	rockchip,pwm-regulator-config = <
++		(0
++		| RKPM_PWM0_M0_REGULATOR_EN
++		| RKPM_PWM1_M0_REGULATOR_EN
++		)
++	>;
++};
++
++&vdpp {
++	status = "okay";
++};
++
++&vdpu {
++	status = "okay";
++};
++
++&vdpu_mmu {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&tsadc {
++	status = "okay";
++};
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vdd_1v8_s3>;
++};
++
++&sai3 {
++	status = "okay";
++};
++
++/* SD Card - following Android DTB configuration */
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	max-frequency = <150000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_bus4>;
++	supports-sd;
++	card-detect-delay = <500>;
++	vmmc-supply = <&vcc_3v3_s3>;
++	vqmmc-supply = <&vcc_3v3_s3>;
++	status = "okay";
++};
++
++/* eMMC */
++&sdhci {
++	bus-width = <8>;
++	no-sd;
++	no-sdio;
++	non-removable;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	max-frequency = <200000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_strb>;
++	vmmc-supply = <&vcc_3v3_s3>;
++	vqmmc-supply = <&vdd_1v8_s3>;
++	status = "okay";
++};
++
++/* SDIO0 - not used, disable it */
++&sdio0 {
++	status = "disabled";
++};
++
++/* AIC8800D80 WiFi + BT on SDIO1 (ffc20000) - SDIO_ID: C8A1:0082 */
++&sdio1 {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	disable-wp;
++	keep-power-in-suspend;
++	max-frequency = <150000000>;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	no-sd;
++	no-mmc;
++	non-removable;
++	supports-sdio;
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-ddr50;
++	sd-uhs-sdr104;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdio1_bus4 &sdio1_cmd &sdio1_clk>;
++	vmmc-supply = <&vdd_0v9_s3>;
++	vqmmc-supply = <&vdd_1v8_s3>;
++	post-power-on-delay-ms = <100>;
++	status = "okay";
++};
++
++&u2phy_host {
++	phy-supply = <&vcc5v0_host>;
++	status = "okay";
++};
++
++&u2phy_otg {
++	vbus-supply = <&vcc5v0_otg>;
++	status = "okay";
++};
++
++&usb2phy {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usbdrd30 {
++	status = "okay";
++};
++
++&usbdrd_dwc3 {
++	dr_mode = "host";
++	extcon = <&usb2phy>;
++	phys = <&u2phy_otg>;
++	phy-names = "usb2-phy";
++	maximum-speed = "high-speed";
++	snps,dis_u2_susphy_quirk;
++	snps,usb2-lpm-disable;
++	status = "okay";
++};
++
++/* UART2 for Bluetooth (AIC8800D80) */
++&uart2 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart2m0_xfer &uart2m0_ctsn &uart2m0_rtsn>;
++	dma-names = "!tx", "!rx";
++};
++
++/* Integrated 100Mbps Ethernet - uses built-in MACPHY from rk3528.dtsi */
++&gmac0 {
++	status = "okay";
++};
++
++&gmac1 {
++	status = "disabled";
++};
++
++&pinctrl {
++	usb {
++		vcc5v0_host_en: vcc5v0-host-en {
++			rockchip,pins = <0 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wifi {
++		/* GPIO3_B2 - WiFi power enable */
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins = <3 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		/* GPIO3_C4 - WiFi reset */
++		wifi_reset_h: wifi-reset-h {
++			rockchip,pins = <3 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		/* GPIO3_PB3 - WiFi host wake IRQ */
++		wifi_host_wake: wifi-host-wake {
++			rockchip,pins = <3 RK_PB3 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	bluetooth {
++		/* Combined pinctrl for BT default state */
++		bt_pins: bt-pins {
++			rockchip,pins =
++				<3 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>,  /* BT reset */
++				<3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_down>;  /* BT wake_host */
++		};
++
++		/* UART2 RTS as GPIO for BT */
++		bt_rts_gpio: bt-rts-gpio {
++			rockchip,pins = <3 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		/* Legacy nodes for compatibility */
++		bt_reset: bt-reset {
++			rockchip,pins = <3 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_wake_host: bt-wake-host {
++			rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++
++		uart2m0_gpios: uart2m0-gpios {
++			rockchip,pins = <3 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wifi_aic8800 {
++		/* Combined pinctrl for WiFi */
++		wifi_pins: wifi-pins {
++			rockchip,pins =
++				<3 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>,  /* WiFi power/reset */
++				<3 RK_PB3 RK_FUNC_GPIO &pcfg_pull_down>;  /* WiFi host_wake */
++		};
++	};
++
++	sdio1 {
++		sdio1_bus4: sdio1-bus4 {
++			rockchip,pins =
++				/* sdio1_d0 */
++				<3 RK_PA6 1 &pcfg_pull_up_drv_level_2>,
++				/* sdio1_d1 */
++				<3 RK_PA7 1 &pcfg_pull_up_drv_level_2>,
++				/* sdio1_d2 */
++				<3 RK_PB0 1 &pcfg_pull_up_drv_level_2>,
++				/* sdio1_d3 */
++				<3 RK_PB1 1 &pcfg_pull_up_drv_level_2>;
++		};
++
++		sdio1_clk: sdio1-clk {
++			rockchip,pins =
++				/* sdio1_clk */
++				<3 RK_PA4 1 &pcfg_pull_up_drv_level_2>;
++		};
++
++		sdio1_cmd: sdio1-cmd {
++			rockchip,pins =
++				/* sdio1_cmd */
++				<3 RK_PA5 1 &pcfg_pull_up_drv_level_2>;
++		};
++	};
++
++	ir {
++		pwm3_pin: pwm3-pin {
++			rockchip,pins = <3 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	hdmi {
++		hdmim0_tx0_cec: hdmim0-tx0-cec {
++			rockchip,pins = <0 RK_PA3 1 &pcfg_pull_none>;
++		};
++
++		hdmim0_tx0_hpd: hdmim0-tx0-hpd {
++			rockchip,pins = <0 RK_PA4 1 &pcfg_pull_none>;
++		};
++
++		hdmim0_tx0_scl: hdmim0-tx0-scl {
++			rockchip,pins = <0 RK_PA5 1 &pcfg_pull_none>;
++		};
++	};
++};

--- a/patch/kernel/rk35xx-vendor-6.1/dt/rk3528-add-hk1-k8s-to-makefile.patch
+++ b/patch/kernel/rk35xx-vendor-6.1/dt/rk3528-add-hk1-k8s-to-makefile.patch
@@ -1,0 +1,14 @@
+Add LEMFO HK1 RBOX K8S board support to RK3528 Makefile
+
+Signed-off-by: Armbian Builder <build@armbian.com>
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -112,6 +112,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-evb4-ddr4-v10.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-iotest-lp3-v10.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-hinlink-h28k.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-hinlink-ht2.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-hk1-k8s.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-h96max-v56.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-mangopi-m28k.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-radxa-e20c.dtb


### PR DESCRIPTION
아래는 요청한 내용을 **PR 템플릿에 맞춰 영어로 정리한 버전**입니다.

---

# Description

Initial bring-up work for **KH1-K8S**.

The following components have been verified:

* Internal SD card slot working
* HDMI output working (partially; not working in U-Boot stage)
* Ethernet working
* Internal eMMC working

The following component is still in progress:

* Wi-Fi / Bluetooth (AIC8800D80)

Related issues:

# Documentation summary for feature / change

Documentation update may be required for initial board support.

* [ ] short description: KH1-K8S initial board support
* [ ] summary: Adds initial support for storage, HDMI, and network functionality
* [ ] example of usage: After building the image, verify basic boot and device functionality

# How Has This Been Tested?

Verification performed through the following tests:

* [ ] Test A: Boot test and validation of storage and network interfaces
* [ ] Test B: HDMI output test and U-Boot stage behavior check

# Checklist:

* [ ] Code follows the project’s style guidelines
* [ ] Self-review completed
* [ ] Comments added to complex areas
* [ ] No new warnings generated
* [ ] Dependent modules verified and compatible



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the LEMFO HK1 RBOX K8S board with Rockchip RK3528 processor, including complete hardware configuration and support for integrated peripherals, power management, storage interfaces, wireless modules, and display functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->