### PR TITLE
fix(rockchip-rk3588): Enable mesa-vpu extension for GPU acceleration

### DIFF
--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -55,6 +55,11 @@ family_tweaks_bsp() {
 	:
 }
 
+function extension_prepare_config__enable_mesa_vpu() {
+	# Auto-enable mesa-vpu for RK3588 GPU acceleration
+	enable_extension "mesa-vpu"
+}
+
 # Additional CFLAGS were previously needed to disable certain errors when building vendor U-Boot.
 # This is now fixed in Radxa U-Boot sources, but left here (commented out) for reference in case new errors appear in the future.
 


### PR DESCRIPTION
# Description

This PR enables GPU acceleration for all RK3588 boards (Orange Pi 5/5B/5+, Rock 5A/5B/5C, etc.). For desktop use it's probably not noticeable, but for 3D graphics, ML inference, and video processing expect 10-100x improvement.

The issue is that RK3588 boards ship with llvmpipe software rendering instead of GPU acceleration on desktop images due to driver binding precedence. The proprietary `mali` driver is selected by default, which Mesa cannot use. The `panthor-gpu` overlay resolves this.

The `mesa-vpu` extension (May 2024) was created for this purpose, with the author intending this to be ["enabled on all for rk3588 distributions"](https://github.com/armbian/build/blob/d2e208ace18b8003f926057ddfc038f8cce0bce0/extensions/mesa-vpu.sh#L30). However, the rockchip family config was defined before this and was never updated. 

Fixes the root cause of issues like #7507, #7504.

# Documentation summary for feature / change

**Short description:** Enable mesa-vpu extension for RK3588 GPU acceleration

**Summary:** Desktop images will now use hardware GPU acceleration (Mali-G610/Panfrost) as the default instead of software rendering (llvmpipe). The extension automatically configures the panthor-gpu overlay for vendor kernel builds.

**Example of usage:** After flashing desktop image, `glxinfo | grep renderer` shows `Mali-G610 (Panfrost)` instead of `llvmpipe`

**Workaround for existing systems:** Add `overlays=panthor-gpu` to `/boot/armbianEnv.txt` and reboot.

# How Has This Been Tested?

Tested on Orange Pi 5 Plus 16GB with Armbian 25.8.1 Noble vendor 6.1.115 XFCE:
- Before: `glxinfo` shows `llvmpipe (LLVM 20.1.2, 128 bits)`
- After: `glxinfo` shows `OpenGL renderer string: Mali-G610 (Panfrost)`
- Verified with `eglinfo` showing GPU acceleration working
- Community validation: https://forum.armbian.com/topic/55941-custom-build-on-new-version25110-is-not-enabling-panfrost-mali-gpu-driver-boardorangepi5-plus-branchvendor-releasenoble-desktopcinnamon/#comment-227661 

## Additional Acknowledgement
Shout out to [@pollen-robotics](https://github.com/pollen-robotics/) for letting me beta test Reachy Mini, a project cool enough to inspire me to actually need this GPU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mesa VPU hardware acceleration is now enabled by default on Rockchip RK3588 devices, improving graphics and video processing performance and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->