### PR TITLE
Drop Thunderbolt in desktop packages, but enable in minimal, arch amd64 only

### DIFF
--- a/config/desktop/common/environments/gnome/config_base/packages
+++ b/config/desktop/common/environments/gnome/config_base/packages
@@ -5,7 +5,6 @@ cups
 cups-browsed
 cups-bsd
 cups-pk-helper
-bolt
 bluez-cups
 cifs-utils
 fprintd

--- a/config/optional/architectures/amd64/_config/cli/sid/main/packages
+++ b/config/optional/architectures/amd64/_config/cli/sid/main/packages
@@ -1,2 +1,4 @@
 gpiod
+bolt
+thunderbolt-tools
 firmware-sof-signed

--- a/config/optional/architectures/amd64/_config/cli/trixie/main/packages
+++ b/config/optional/architectures/amd64/_config/cli/trixie/main/packages
@@ -1,2 +1,4 @@
 gpiod
+bolt
+thunderbolt-tools
 firmware-sof-signed


### PR DESCRIPTION
# Description

Enable Thunderbolt support only in amd64 arch.

# How Has This Been Tested?

- [x] Tested on TB4 x86 laptop

# Checklist:

- [x] My code follows the style guidelines of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed bolt package from GNOME desktop configuration
  * Added bolt and thunderbolt-tools packages to amd64 CLI configurations for both sid and trixie environments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->