### PR TITLE
Update radxa-e52c.conf - add HAS_VIDEO_OUTPUT="no"

### DIFF
--- a/config/boards/radxa-e52c.conf
+++ b/config/boards/radxa-e52c.conf
@@ -8,6 +8,7 @@ BOOT_FDT_FILE="rockchip/rk3588s-radxa-e52c.dtb"
 BOOT_SCENARIO="spl-blobs"
 BOOT_SOC="rk3588"
 IMAGE_PARTITION_TABLE="gpt"
+HAS_VIDEO_OUTPUT="no"
 
 function post_family_tweaks_bsp__radxa_e52c_enable_leds() {
 	display_alert "Creating board support LEDs config for radxa-e52c."


### PR DESCRIPTION
# Description

This board has no video out.
Add HAS_VIDEO_OUTPUT="no"

# How Has This Been Tested?

- [x] Built Trixie image

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated board configuration to reflect video output capabilities for a specific hardware variant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->