### PR TITLE
bananapi-r4 bpi-r4 board config - no video output

### DIFF
--- a/config/boards/bananapir4.csc
+++ b/config/boards/bananapir4.csc
@@ -8,6 +8,7 @@ BOOTCONFIG="mt7988a_bananapi_bpi-r4-sdmmc_defconfig"
 BOOT_FDT_FILE="mediatek/mt7988a-bananapi-bpi-r4-sd.dtb"
 SRC_EXTLINUX="yes"
 SRC_CMDLINE="console=ttyS0,115200n1 earlyprintk loglevel=8 initcall_debug=0 swiotlb=512 cgroup_enable cgroup_memory=1 init=/sbin/init"
+HAS_VIDEO_OUTPUT="no"
 
 function post_family_tweaks__bpi-r4() {
 	display_alert "Applying eth blobs"


### PR DESCRIPTION
# Description

Board has no HDMI, it should be assumed headless.

The goal is to avoid any desktop image builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated board configuration for bananapir4 to reflect video output specifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->