### PR TITLE
Update SHA1 for armbian/linux-rockchip source

### DIFF
--- a/config/sources/git_sources.json
+++ b/config/sources/git_sources.json
@@ -32,7 +32,7 @@
   {
     "source": "https://github.com/armbian/linux-rockchip.git",
     "branch": "rk-6.1-rkr5.1",
-    "sha1": "95c7ac23400364707173a0ef93f8ace61974a4f4"
+    "sha1": "f6a897ba2e98161966b4e49496a6788c90b216b2"
   },
   {
     "source": "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git",


### PR DESCRIPTION
To accommodate for the Rock-5B-Plus device tree name alignment with upstream and fixing the bug where uboot doesn't find the device tree.

Depends on https://github.com/armbian/build/pull/8994