### PR TITLE
Ubuntu Resolute requires that there be a "scripts/mod/modpost" binary…

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -473,6 +473,10 @@ function kernel_package_callback_linux_headers() {
 	[[ -f "${kernel_work_dir}/scripts/module.lds" ]] &&
 		run_host_command_logged cp -v "${kernel_work_dir}/scripts/module.lds" "${headers_target_dir}/scripts/module.lds"
 
+	# Ubuntu Resolute requires that there be a "scripts/mod/modpost" binary during header compilation
+	[[ -f "${kernel_work_dir}/scripts/mod/modpost" ]] &&
+		run_host_command_logged cp -v "${kernel_work_dir}/scripts/mod/modpost" "${headers_target_dir}/scripts/mod/modpost"
+
 	if [[ "${DEBUG}" == "yes" ]]; then
 		# Check that no binaries are included by now. Expensive... @TODO: remove after me make sure.
 		display_alert "Checking for binaries in kernel headers" "${headers_target_dir}" "debug"


### PR DESCRIPTION
Ubuntu Resolute
* Requires that there be a "scripts/mod/modpost" binary during header compilation

Fail: **https://paste.armbian.com/bacifoqope.bash**

Success: https://paste.armbian.com/picelafexa.bash

NOTE: For reasons I am unable to generate a Ubuntu Resolute Armbian Image. Tests were run in a chroot after debootstraping Ubuntu Resolute.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved kernel headers packaging process to ensure proper build compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->