### PR TITLE
board: youyeetoo-r1-v3: fix boot order to prioritize SD card over eMMC

### DIFF
--- a/config/boards/youyeetoo-r1-v3.csc
+++ b/config/boards/youyeetoo-r1-v3.csc
@@ -54,13 +54,13 @@ function post_family_config__youyeetoo_r1_use_mainline_uboot() {
 	}
 }
 
-# "rockchip-common: boot SD card first, then NVMe, then mmc"
+# "rockchip-common: boot SD card first, then NVMe, then eMMC"
 # include/configs/rockchip-common.h
-# -#define BOOT_TARGETS "mmc1 mmc0 nvme scsi usb pxe dhcp"
-# +#define BOOT_TARGETS "mmc0 nvme mmc1 scsi usb pxe dhcp"
-# On Youyeetoo R1, mmc0 is the SD card, mmc1 is the eMMC slot
+# -#define BOOT_TARGETS "mmc1 mmc0 nvme scsi usb pxe dhcp" (default)
+# +#define BOOT_TARGETS "mmc1 nvme mmc0 scsi usb pxe dhcp"
+# On Youyeetoo R1, mmc0 is the eMMC (sdhci), mmc1 is the SD card (sdmmc)
 function pre_config_uboot_target__youyeetoo_r1_patch_rockchip_common_boot_order() {
-	declare -a rockchip_uboot_targets=("mmc0" "nvme" "mmc1" "scsi" "usb" "pxe" "dhcp") # for future make-this-generic delight
+	declare -a rockchip_uboot_targets=("mmc1" "nvme" "mmc0" "scsi" "usb" "pxe" "dhcp") # mmc1=SD, mmc0=eMMC
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: adjust boot order to '${rockchip_uboot_targets[*]}'" "info"
 	sed -i -e "s/#define BOOT_TARGETS.*/#define BOOT_TARGETS \"${rockchip_uboot_targets[*]}\"/" include/configs/rockchip-common.h
 	regular_git diff -u include/configs/rockchip-common.h || true
@@ -72,7 +72,7 @@ function post_family_tweaks__youyeetoo_r1 {
 	[[ "${BRANCH}" == "vendor" ]] && return 0
 
 	display_alert "$BOARD" "Adjusting rtw89_8852be module" "info"
-	
+
 	cat <<- EOF > "${SDCARD}/etc/modprobe.d/rtw8852be.conf"
 		options rtw89_pci disable_aspm_l1=y disable_aspm_l1ss=y
 		options rtw89pci disable_aspm_l1=y disable_aspm_l1ss=y


### PR DESCRIPTION
# Description
Device tree aliases configuration:
- mmc0 = sdhci (eMMC, 8-bit, non-removable)
- mmc1 = sdmmc (SD card, 4-bit, removable)

Changed boot order from (mmc0, nvme, mmc1) to (mmc1, nvme, mmc0) to prioritize:
1. SD card
2. NVMe
3. eMMC

This ensures the system boots from SD card when present, instead of always defaulting to eMMC.

# How Has This Been Tested?
- [x] Tested boot from SD card with eMMC present
- [x] Verified NVMe boot priority over eMMC
- [x] Confirmed eMMC boots when no other devices present

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated boot device priority sequence: SD card storage now boots first, followed by NVMe, then eMMC for improved boot behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->