### PR TITLE
ODroid-N2: switch uBoot v2022.10 to v2026.01

### DIFF
--- a/config/boards/odroidn2.conf
+++ b/config/boards/odroidn2.conf
@@ -8,12 +8,11 @@ MODULES_BLACKLIST="simpledrm" # SimpleDRM conflicts with Panfrost
 FULL_DESKTOP="yes"
 FORCE_BOOTSCRIPT_UPDATE="yes"
 BOOT_LOGO="desktop"
-BOOTFS_TYPE="ext4"
 BOOTCONFIG="odroid-n2_defconfig" # For mainline uboot
 
-# Newer u-boot for the N2/N2+, less patches: a single boot order patch
-BOOTBRANCH_BOARD="tag:v2022.10"
-BOOTPATCHDIR="v2022.10"
+# Newer u-boot for the N2/N2+
+BOOTBRANCH_BOARD="tag:v2026.01-rc2"
+BOOTPATCHDIR="v2026.01"
 
 # Enable writing u-boot to SPI on the N2(+) for current and edge
 # @TODO: replace this with an overlay, after meson64 overlay revamp
@@ -22,6 +21,11 @@ BOOTPATCHDIR="v2022.10"
 UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin.sd.bin:u-boot.bin u-boot-dtb.img u-boot.bin:u-boot-spi.bin"
 write_uboot_platform_mtd() {
 	dd if=$1/u-boot-spi.bin of=/dev/mtdblock0
+}
+
+function post_config_uboot_target__extra_configs_for_odroid_n2() {
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable BTRFS filesystem support" "info"
+	run_host_command_logged scripts/config --enable CONFIG_CMD_BTRFS
 }
 
 # MAX might be different for N2/N2+, for now use N2+'s

--- a/patch/u-boot/v2026.01/board_odroidn2/0001-mmc-meson_gx_mmc-limit-f_max-to-24-MHz.patch
+++ b/patch/u-boot/v2026.01/board_odroidn2/0001-mmc-meson_gx_mmc-limit-f_max-to-24-MHz.patch
@@ -1,0 +1,42 @@
+From dc847a8091517dea6b4c07f7ed3b11cb8123b726 Mon Sep 17 00:00:00 2001
+From: Martin Pietryka <martin@pietryka.at>
+Date: Fri, 26 Apr 2024 15:43:21 +0200
+Subject: [PATCH] mmc: meson_gx_mmc: limit f_max to 24 MHz
+
+This fixes issues on the Odroid N2+ where reading from the eMMC is
+unreliable in U-Boot and probably being temperature dependent.
+
+Changing the clock phase to CLK_CO_PHASE_270 also improved stability, but
+a mailing-list post indicates that this could lead to other instabilities
+with other eMMC cards, see:
+ - https://lists.denx.de/pipermail/u-boot/2020-December/434954.html
+
+Signed-off-by: Martin Pietryka <martin@pietryka.at>
+---
+ drivers/mmc/meson_gx_mmc.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
+index fcf4f03d1e..9ecffccee4 100644
+--- a/drivers/mmc/meson_gx_mmc.c
++++ b/drivers/mmc/meson_gx_mmc.c
+@@ -279,7 +279,15 @@ static int meson_mmc_probe(struct udevice *dev)
+ 	cfg->host_caps = MMC_MODE_8BIT | MMC_MODE_4BIT |
+ 			MMC_MODE_HS_52MHz | MMC_MODE_HS;
+ 	cfg->f_min = DIV_ROUND_UP(SD_EMMC_CLKSRC_24M, CLK_MAX_DIV);
+-	cfg->f_max = 100000000; /* 100 MHz */
++
++	/*
++	 * Some SoCs have issues with higher frequencies and combinations
++	 * of CLK_CO_PHASE_* values. So limit it to 24 MHz, which according
++	 * to a mailing list post seems to be more stable:
++	 * - https://lists.denx.de/pipermail/u-boot/2020-December/434954.html
++	 */
++	cfg->f_max = 24000000; /* 24 MHz */
++
+ 	cfg->b_max = 511; /* max 512 - 1 blocks */
+ 	cfg->name = dev->name;
+ 
+-- 
+2.44.0
+

--- a/patch/u-boot/v2026.01/board_odroidn2/meson64-boot-usb-nvme-scsi-first.patch
+++ b/patch/u-boot/v2026.01/board_odroidn2/meson64-boot-usb-nvme-scsi-first.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 14 Nov 2022 14:59:45 +0100
+Subject: meson64 u-boot v2022.10: change `BOOT_TARGET_DEVICES to try to boot
+ USB, NVME and SCSI before SD, MMC, PXE, DHCP
+
+---
+ include/configs/meson64.h | 2 +-
+ 1 file changed, 1 insertions(+), 1 deletions(-)
+ 
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index f3275b37a51..db27b6a6909 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -119,10 +119,10 @@
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
+ 	func(USB_DFU, usbdfu, na)  \
+-	BOOT_TARGET_MMC(func) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+ 	BOOT_TARGET_NVME(func) \
+ 	BOOT_TARGET_SCSI(func) \
++	BOOT_TARGET_MMC(func) \
+ 	BOOT_TARGET_PXE(func) \
+ 	BOOT_TARGET_DHCP(func)
+ #endif


### PR DESCRIPTION
ODroid-N2: switch uBoot v2022.10 to v2026.01
reapply patches
enable BTRFS support in uBoot

Now possible to create bootable image with single partition BTRFS fs, no need separate ext /boot partition.

- [X] create image with single ext4 partition, it boots
- [x] create image with single btrfs partition, it boots

I did successful tests only with emmc card: seems my N2 now have broken sdcard slot, it only shows `Card did not respond to voltage select! : -110` with any images on card, including downloaded from armbian website.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Limited MMC clock frequency for improved stability on ODROID N2 devices.

* **Chores**
  * Updated ODROID N2 bootloader configuration to newer release version.
  * Adjusted system boot device priority order to prioritize USB, NVME, and SCSI devices before MMC storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->