### PR TITLE
Add support for rk3566-box-demo

### DIFF
--- a/config/boards/rk3566-box-demo.csc
+++ b/config/boards/rk3566-box-demo.csc
@@ -1,0 +1,32 @@
+# Rockchip RK3566 with 4GB DDR HDMI USB3 WIFI GMAC
+BOARD_NAME="RK3566 BOX DEMO"
+BOOT_SOC="rk3566"
+BOARDFAMILY="rk35xx"
+BOARD_MAINTAINER="andyshrk"
+BOOTCONFIG="generic-rk3568_defconfig"
+KERNEL_TARGET="current,edge"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3566-box-demo.dtb"
+BOOT_SCENARIO="spl-blobs"
+IMAGE_PARTITION_TABLE="gpt"
+
+# Mainline U-Boot
+function post_family_config__rk3566_box_demo_use_mainline_uboot() {
+	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"
+
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
+	declare -g BOOTBRANCH="tag:v2025.10"
+	declare -g BOOTPATCHDIR="v2025.10"
+	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
+
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
+
+	# Disable stuff from rockchip64_common; we're using binman here which does all the work already
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+}


### PR DESCRIPTION
This is a rk3566 tv box evaluation demo board.

Specification:
- Rockchip RK3566
- DDR4 4GB
- TF sd scard slot
- eMMC
- AP6398S for WiFi + BT
- Gigabit ethernet
- HDMI out
- USB HOST 2.0 x 2
- USB 3.0 x 1
- USB OTG 2.0  x 1
- 12V DC Power supply

# Description

Add support for rk3566-box-demo board.


# How Has This Been Tested?
 1. compile success
 2. write image to tf card by Etcher, insert the tf card to the board, and power on the board with hdmi connected, the board can boot into desktop .

# Checklist:
- [&#10003;] My code follows the style guidelines of this project
- [&#10003;] I have performed a self-review of my own code
- [&#10003;] I have commented my code, particularly in hard-to-understand areas
- [&#10003;] My changes generate no new warnings
- [&#10003;] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration support for the RK3566 BOX DEMO board, enabling full-desktop boot settings and board metadata.

* **Improvements**
  * Configured the board to use mainline U-Boot with a prebuilt bootloader image for simpler deployment.
  * Simplified bootloader placement and removed board-specific post-processing to rely on packaged artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->