### PR TITLE
add new board radxa-cm5-io

### DIFF
--- a/config/boards/radxa-cm5-io.csc
+++ b/config/boards/radxa-cm5-io.csc
@@ -1,0 +1,24 @@
+# Rockchip RK3588s SoC octa core 4-16GB SoC eMMC USB3
+BOARD_NAME="Radxa CM5 IO"
+BOARDFAMILY="rockchip-rk3588"
+BOARD_MAINTAINER="amazingfate"
+BOOTCONFIG="radxa-cm5-io-rk3588s_defconfig"
+KERNEL_TARGET="vendor"
+KERNEL_TEST_TARGET="vendor"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3588s-radxa-cm5-io.dtb"
+BOOT_SCENARIO="spl-blobs"
+BOOT_SOC="rk3588"
+IMAGE_PARTITION_TABLE="gpt"
+
+function post_family_tweaks__radxa-cm5-io_naming_audios() {
+	display_alert "$BOARD" "Renaming radxa-cm5-io audios" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-dp0-sound", ENV{SOUND_DESCRIPTION}="DP0 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-es8316-sound", ENV{SOUND_DESCRIPTION}="ES8316 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+
+	return 0
+}


### PR DESCRIPTION
# Description

Kernel devicetree is already in repo armbian/linux-rockchip. Adding board config file is enough.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh build BOARD=radxa-cm5-io BRANCH=vendor BUILD_DESKTOP=yes BUILD_MINIMAL=no DEB_COMPRESS=xz DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base ENABLE_EXTENSIONS=mesa-vpu KERNEL_BTF=yes KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=trixie`
- [x] Boot fine via emmc and sd card

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Radxa CM5 IO development board
  * Configured audio device naming rules for enhanced audio device identification across HDMI, DisplayPort, and ES8316 interfaces

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->