### PR TITLE
Fix station-m2 (rk3566-roc-pc) vendor branch compiling

### DIFF
--- a/patch/kernel/rk35xx-vendor-6.1/board-station-m2.patch
+++ b/patch/kernel/rk35xx-vendor-6.1/board-station-m2.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Armbian <info@armbian.com>
+Date: Sat, 30 Nov 2025 00:00:00 +0000
+Subject: arm64: dts: rockchip: Fix rk3566-roc-pc for Firefly Station M2
+
+Enable build and fix device tree for Firefly Station M2 (rk3566-roc-pc):
+- Add rk3566-roc-pc.dtb to Makefile so it gets built
+- Fix GMAC1 Ethernet clock assignments and add phy-supply
+- Adjust RGMII TX/RX delay values for stable networking
+- Set cursor-win-id for VOP2 display output
+
+
+---
+ arch/arm64/boot/dts/rockchip/Makefile | 1 +
+ arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts | 13 +++++++++----
+ 2 files changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -449,6 +449,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-roc-pc.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-tablet-rk806-single-v10.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-tablet-v10.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-tablet-v11.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-roc-pc.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-luckfox-core3566.dtb
+ 
+ subdir-y := $(dts-dirs) overlay
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts
+@@ -1543,6 +1544,7 @@
+     snps,reset-delays-us = <0 20000 100000>;
+ 
+-    assigned-clocks = <&cru SCLK_GMAC1_RX_TX>, <&cru SCLK_GMAC1>;
+-    assigned-clock-parents = <&cru SCLK_GMAC1_RGMII_SPEED>, <&gmac1_clkin>;
++    assigned-clocks = <&cru SCLK_GMAC1_RX_TX>, <&cru SCLK_GMAC1_RGMII_SPEED>, <&cru SCLK_GMAC1>;
++    assigned-clock-parents = <&cru SCLK_GMAC1_RGMII_SPEED>, <&cru SCLK_GMAC1>, <&gmac1_clkin>;
++    phy-supply = <&vcc_3v3>;
+ 
+     pinctrl-names = "default";
+@@ -1553,8 +1554,8 @@
+ 		     &gmac1m0_rgmii_bus
+ 		     &gmac1m0_clkinout>;
+ 
+-    tx_delay = <0x4e>;
+-    rx_delay = <0x2c>;
++    tx_delay = <0x4f>;
++    rx_delay = <0x24>;
+ 
+     phy-handle = <&rgmii_phy1>;
+     status = "okay";
+@@ -1594,4 +1595,8 @@
+ &route_hdmi {
+ 	status = "okay";
+ 	connect = <&vp0_out_hdmi>;
+ };
++
++&vp0 {
++	cursor-win-id = <ROCKCHIP_VOP2_ESMART0>;
++};
+-- 
+Armbian


### PR DESCRIPTION
In the current version station-m2 armbian build with vendor kernel is broken. Image is assembled, but does not boot on the board. I have added rk3566-roc-pc.dtb to Makefile and ported fixes from 6.12 linux kernel to fix critical issues with broken lan and cursor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Firefly Station M2 hardware platform.

* **Bug Fixes**
  * Improved network connectivity with optimized clock and signal configuration.
  * Enhanced display output stability through improved driver settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->