### PR TITLE
edge: bump to 6.18 stable and rewrite patches

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -7,8 +7,8 @@
 # Shared versioning logic for Armbian mainline kernels.
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0           # if already set, don't touch it; that way other hooks can run in any order
-	if [[ "${KERNEL_MAJOR_MINOR}" == "6.18" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v6.18-rc7"
+	if [[ "${KERNEL_MAJOR_MINOR}" == "6.19" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
+		declare -g KERNELBRANCH="tag:v6.19-rc1"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }

--- a/patch/kernel/archive/rockchip64-6.18/net-ethernet-realtek-add-r8169-LED-configuration-from-OF.patch
+++ b/patch/kernel/archive/rockchip64-6.18/net-ethernet-realtek-add-r8169-LED-configuration-from-OF.patch
@@ -20,7 +20,7 @@ index 111111111111..222222222222 100644
  #include <linux/tcp.h>
  #include <linux/interrupt.h>
  #include <linux/dma-mapping.h>
-@@ -2373,6 +2374,15 @@ void r8169_apply_firmware(struct rtl8169_private *tp)
+@@ -2382,6 +2383,15 @@ void r8169_apply_firmware(struct rtl8169_private *tp)
  	}
  }
  
@@ -36,7 +36,7 @@ index 111111111111..222222222222 100644
  static void rtl8168_config_eee_mac(struct rtl8169_private *tp)
  {
  	/* Adjust EEE LED frequency */
-@@ -3390,6 +3400,7 @@ static void rtl_hw_start_8168h_1(struct rtl8169_private *tp)
+@@ -3399,6 +3409,7 @@ static void rtl_hw_start_8168h_1(struct rtl8169_private *tp)
  	rtl_eri_write(tp, 0xb8, ERIAR_MASK_0011, 0x0000);
  
  	rtl8168_config_eee_mac(tp);

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-phy-rockchip-naneng-Add-fallback-for-old-DTs.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-phy-rockchip-naneng-Add-fallback-for-old-DTs.patch
@@ -16,7 +16,7 @@ diff --git a/drivers/usb/dwc3/core.c b/drivers/usb/dwc3/core.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/dwc3/core.c
 +++ b/drivers/usb/dwc3/core.c
-@@ -152,7 +152,7 @@ void dwc3_set_prtcap(struct dwc3 *dwc, u32 mode, bool ignore_susphy)
+@@ -153,7 +153,7 @@ void dwc3_set_prtcap(struct dwc3 *dwc, u32 mode, bool ignore_susphy)
  	}
  
  	reg &= ~(DWC3_GCTL_PRTCAPDIR(DWC3_GCTL_PRTCAP_OTG));
@@ -25,7 +25,7 @@ index 111111111111..222222222222 100644
  	dwc3_writel(dwc->regs, DWC3_GCTL, reg);
  
  	dwc->current_dr_role = mode;
-@@ -192,6 +192,7 @@ static void __dwc3_set_mode(struct work_struct *work)
+@@ -193,6 +193,7 @@ static void __dwc3_set_mode(struct work_struct *work)
  		dwc3_host_exit(dwc);
  		break;
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -33,7 +33,7 @@ index 111111111111..222222222222 100644
  		dwc3_gadget_exit(dwc);
  		dwc3_event_buffers_cleanup(dwc);
  		break;
-@@ -211,12 +212,43 @@ static void __dwc3_set_mode(struct work_struct *work)
+@@ -212,12 +213,43 @@ static void __dwc3_set_mode(struct work_struct *work)
  	 * Only perform GCTL.CoreSoftReset when there's DRD role switching.
  	 */
  	if (dwc->current_dr_role && ((DWC3_IP_IS(DWC3) ||
@@ -78,7 +78,7 @@ index 111111111111..222222222222 100644
  		/*
  		 * Wait for internal clocks to synchronized. DWC_usb31 and
  		 * DWC_usb32 may need at least 50ms (less for DWC_usb3). To
-@@ -258,6 +290,7 @@ static void __dwc3_set_mode(struct work_struct *work)
+@@ -259,6 +291,7 @@ static void __dwc3_set_mode(struct work_struct *work)
  		}
  		break;
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -86,7 +86,7 @@ index 111111111111..222222222222 100644
  		dwc3_core_soft_reset(dwc);
  
  		dwc3_event_buffers_setup(dwc);
-@@ -1845,6 +1878,8 @@ static void dwc3_get_properties(struct dwc3 *dwc)
+@@ -1846,6 +1879,8 @@ static void dwc3_get_properties(struct dwc3 *dwc)
  
  	dwc->dis_split_quirk = device_property_read_bool(dev,
  				"snps,dis-split-quirk");
@@ -95,7 +95,7 @@ index 111111111111..222222222222 100644
  
  	dwc->lpm_nyet_threshold = lpm_nyet_threshold;
  	dwc->tx_de_emphasis = tx_de_emphasis;
-@@ -2441,6 +2476,7 @@ static int dwc3_suspend_common(struct dwc3 *dwc, pm_message_t msg)
+@@ -2442,6 +2477,7 @@ static int dwc3_suspend_common(struct dwc3 *dwc, pm_message_t msg)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -103,7 +103,7 @@ index 111111111111..222222222222 100644
  		if (pm_runtime_suspended(dwc->dev))
  			break;
  		ret = dwc3_gadget_suspend(dwc);
-@@ -2505,11 +2541,12 @@ static int dwc3_resume_common(struct dwc3 *dwc, pm_message_t msg)
+@@ -2506,11 +2542,12 @@ static int dwc3_resume_common(struct dwc3 *dwc, pm_message_t msg)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -117,7 +117,7 @@ index 111111111111..222222222222 100644
  		dwc3_gadget_resume(dwc);
  		break;
  	case DWC3_GCTL_PRTCAP_HOST:
-@@ -2573,6 +2610,7 @@ static int dwc3_runtime_checks(struct dwc3 *dwc)
+@@ -2574,6 +2611,7 @@ static int dwc3_runtime_checks(struct dwc3 *dwc)
  {
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -125,7 +125,7 @@ index 111111111111..222222222222 100644
  		if (dwc->connected)
  			return -EBUSY;
  		break;
-@@ -2611,6 +2649,7 @@ int dwc3_runtime_resume(struct dwc3 *dwc)
+@@ -2612,6 +2650,7 @@ int dwc3_runtime_resume(struct dwc3 *dwc)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -133,7 +133,7 @@ index 111111111111..222222222222 100644
  		if (dwc->pending_events) {
  			pm_runtime_put(dev);
  			dwc->pending_events = false;
-@@ -2635,6 +2674,7 @@ int dwc3_runtime_idle(struct dwc3 *dwc)
+@@ -2636,6 +2675,7 @@ int dwc3_runtime_idle(struct dwc3 *dwc)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-dwc3-Track-the-power-state-of-usb3_generic_phy.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-dwc3-Track-the-power-state-of-usb3_generic_phy.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/usb/dwc3/core.c b/drivers/usb/dwc3/core.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/dwc3/core.c
 +++ b/drivers/usb/dwc3/core.c
-@@ -932,6 +932,7 @@ static int dwc3_phy_power_on(struct dwc3 *dwc)
+@@ -933,6 +933,7 @@ static int dwc3_phy_power_on(struct dwc3 *dwc)
  			goto err_power_off_usb3_phy;
  	}
  
@@ -26,7 +26,7 @@ index 111111111111..222222222222 100644
  	return 0;
  
  err_power_off_usb3_phy:
-@@ -952,8 +953,10 @@ static void dwc3_phy_power_off(struct dwc3 *dwc)
+@@ -953,8 +954,10 @@ static void dwc3_phy_power_off(struct dwc3 *dwc)
  {
  	int i;
  


### PR DESCRIPTION
# Description

- roll-over mainline tag to 6.19-rc1
- rockchip64: rewrite patches. minor changes
- meson64: rewrite patches. no changes
- uefi-arm64: rewrite patches. no changes

# How Has This Been Tested?

- [x] build orangepi5 kernel for rockchip64
- [x] build odroidn2 kernel for meson64

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Realtek network adapter LED configuration support
  * Improved USB3 power management efficiency
  * Enhanced USB-C device compatibility for RK3399

* **Chores**
  * Updated kernel version to 6.19

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->