### PR TITLE
Enable direct flashing method in armbian-install menu

### DIFF
--- a/packages/bsp/common/usr/bin/armbian-install
+++ b/packages/bsp/common/usr/bin/armbian-install
@@ -929,6 +929,14 @@ main()
 		$(type -t write_uboot_platform_mtd) == function ]] 		&& options+=(7 'Install/Update the bootloader on MTD Flash')
 	fi
 
+	# show flasher if there are available block devices
+	if command -v armbian-config >/dev/null && [ -x "$(command -v armbian-config)" ]; then
+		armbian-config --api module_images status >/dev/null
+		if [[ $? -eq 0 ]]; then
+			options+=("8" "Download and flash clean image")
+		fi
+	fi
+
 	[[ ${#options[@]} -eq 0 || "$root_uuid" == "$emmcuuid" || "$root_uuid" == "/dev/nand2" ]] && \
 	dialog --ok-label 'Cancel' --title ' Warning ' --backtitle "$backtitle" --colors --no-collapse --msgbox '\n\Z1There are no targets. Please check your drives.\Zn' 7 52
 	cmd=(dialog --title 'Choose an option:' --backtitle "$backtitle" --menu "\nCurrent root: $root_uuid \n              $rootchip (${root_partition_device})\n" 14 75 7)
@@ -1010,6 +1018,10 @@ main()
 				;;
 			7)
 				write_uboot_to_mtd_flash "$DIR" "$mtdcheck"
+				return
+				;;
+			8)
+				armbian-config --cmd FLASH1
 				return
 				;;
 


### PR DESCRIPTION
# Description

Enable block device flasher in armbian-install. Related to https://github.com/armbian/configng/pull/705

<img width="1081" height="734" alt="image" src="https://github.com/user-attachments/assets/b3f9ec9e-93d7-4166-b351-480eec0cef89" />


# Documentation summary for feature / change

https://github.com/armbian/configng/pull/705

# How Has This Been Tested?

- [x] Tested on x86 device
- [x] Tested on Nanopi M6 flashing to eMMC

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new menu option in the installer to download and flash a clean image when block devices are present; the option is shown after existing boot/flash choices and includes a pre-check to ensure image-ready status before proceeding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->