### PR TITLE
rockchip64-6.18: Enable the NPU on Turing RK1

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/rk3588-1202-arm64-dts-rockchip-Enable-the-NPU-on-Turing-RK1.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3588-1202-arm64-dts-rockchip-Enable-the-NPU-on-Turing-RK1.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Thu, 4 Dec 2025 18:02:02 +0100
+Subject: arm64: dts: rockchip: Enable the NPU on Turing RK1
+
+Enable the NPU on Turing RK1.
+Regulator vdd_npu_s0 was already in place.
+
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi | 34 ++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
+@@ -324,6 +324,10 @@ &pd_gpu {
+ 	domain-supply = <&vdd_gpu_s0>;
+ };
+ 
++&pd_npu {
++	domain-supply = <&vdd_npu_s0>;
++};
++
+ &pinctrl {
+ 	fan {
+ 		fan_int: fan-int {
+@@ -364,6 +368,36 @@ &pwm0 {
+ 	status = "okay";
+ };
+ 
++&rknn_core_0 {
++	npu-supply = <&vdd_npu_s0>;
++	sram-supply = <&vdd_npu_s0>;
++	status = "okay";
++};
++
++&rknn_core_1 {
++	npu-supply = <&vdd_npu_s0>;
++	sram-supply = <&vdd_npu_s0>;
++	status = "okay";
++};
++
++&rknn_core_2 {
++	npu-supply = <&vdd_npu_s0>;
++	sram-supply = <&vdd_npu_s0>;
++	status = "okay";
++};
++
++&rknn_mmu_0 {
++	status = "okay";
++};
++
++&rknn_mmu_1 {
++	status = "okay";
++};
++
++&rknn_mmu_2 {
++	status = "okay";
++};
++
+ &sdhci {
+ 	bus-width = <8>;
+ 	no-sdio;
+-- 
+Armbian
+


### PR DESCRIPTION
- already had the regulator (`vdd_npu_s0`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NPU (Neural Processing Unit) support is now enabled on Turing RK1, providing hardware-accelerated neural network processing capabilities.

* **Improvements**
  * Storage controller configuration updated for enhanced compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->