### PR TITLE
radxa-rock-4d: Enable Wi-Fi & Bluetooth (same logic as rock-2a Commit 501f5a7 @CodeChenL)

### DIFF
--- a/config/boards/radxa-rock-4d.conf
+++ b/config/boards/radxa-rock-4d.conf
@@ -12,6 +12,8 @@ BOOT_SCENARIO="spl-blobs"
 BOOT_SUPPORT_SPI="yes"
 BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
+enable_extension "radxa-aic8800"
+AIC8800_TYPE="usb"
 
 function post_family_tweaks__rock-4d_naming_audios() {
 	display_alert "$BOARD" "Renaming Rock-4D audios" "info"


### PR DESCRIPTION
# Description
install scripts has aic8800 drivers, but missing.
so, I apply same vendor config. Wi-Fi and Bluetooth Enabled !

by porting the configuration from the [rock-2a config](https://github.com/armbian/build/commit/501f5a77c256c68a415f84a9576802cb6cfe1f6e)

[GitHub issue](https://github.com/armbian/build/issues/9024) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2791](https://armbian.atlassian.net/browse/AR-2791)

# Documentation summary for feature / change
radxa-rock-4d: Enable Wi-Fi & Bluetooth
- [x] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

build normal kernel (this option add).

- [x] On board (radxa-rock-4d,Armbian v26.2.0-trunk.12). **Verified that both Wi-Fi and Bluetooth are now operational.**

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


[AR-2791]: https://armbian.atlassian.net/browse/AR-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for AIC8800 module on Radxa Rock 4D board configuration via USB connectivity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->