### PR TITLE
framework - enable NTSYNC as a module on most kernels

### DIFF
--- a/config/sources/families/filogic.conf
+++ b/config/sources/families/filogic.conf
@@ -20,6 +20,9 @@ declare -g BOOTSCRIPT='boot-filogic.cmd:boot.cmd'
 declare -g IMAGE_PARTITION_TABLE="gpt"
 declare -g LINUXFAMILY=filogic
 
+# filogic is a network platform so Proton/WINE isn't probable.
+unset -f armbian_kernel_config__enable_ntsync
+
 # This build requires xxd
 function add_host_dependencies__filogic_add_xxd_hostdep() {
 	display_alert "Adding xxd dep" "for ${BOARD} bootloader compile" "debug"

--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -438,6 +438,20 @@ function armbian_kernel_config__restore_enable_gpio_sysfs() {
 	opts_y+=("GPIO_SYSFS") # This was a victim of not having EXPERT=y due to some _DEBUG conflicts in old times. Re-enable it forcefully.
 }
 
+# NTSYNC support for Windows NT synchronization primitives (Wine/Proton performance)
+# Available and functional since kernel 6.14 (was marked BROKEN in 6.10-6.13)
+# Skip vendor kernels due to their inconsistent upstream merge status
+function armbian_kernel_config__enable_ntsync() {
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.14; then
+		if [[ "${BRANCH}" =~ 'vendor' ]]; then
+			display_alert "Skipping NTSYNC for vendor kernel" "${BRANCH} branch, ${KERNEL_MAJOR_MINOR} version" "debug"
+		else
+			display_alert "Enabling NTSYNC support" "for Wine/Proton compatibility" "debug"
+			opts_m+=("NTSYNC")
+		fi
+	fi
+}
+
 # +++++++++++ HELPERS CORNER +++++++++++
 #
 # Helpers for manipulating kernel config.


### PR DESCRIPTION
# Description

requested feature #9021
Explicitly exclude `filogic`, not so much because it's necessary but because it also serves as an example for armbian/documentation#842

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `time ./compile.sh rewrite-kernel-config BOARD=pocketbeagle2 BRANCH=edge KERNEL_GIT=full MANAGE_ACNG='http://squid.tabris.net:3142/'`
- [x] `time ./compile.sh rewrite-kernel-config BOARD=bananapir4 BRANCH=current KERNEL_GIT=full MANAGE_ACNG='http://squid.tabris.net:3142/'`
- [x] `time ./compile.sh rewrite-kernel-config BOARD=bananapir4 BRANCH=edge KERNEL_GIT=full MANAGE_ACNG='http://squid.tabris.net:3142/'`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
