### PR TITLE
lib / distro-agnostic.sh: drop chmod on /bin/ping

### DIFF
--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -131,11 +131,6 @@ function install_distribution_agnostic() {
 	# add the /dev/urandom path to the rng config file
 	echo "HRNGDEVICE=/dev/urandom" >> "${SDCARD}"/etc/default/rng-tools
 
-	# @TODO: security problem?
-	# ping needs privileged action to be able to create raw network socket
-	# this is working properly but not with (at least) Debian Buster
-	chroot_sdcard chmod u+s /bin/ping
-
 	# change time zone data
 	echo "${TZDATA}" > "${SDCARD}"/etc/timezone
 	chroot_sdcard dpkg-reconfigure -f noninteractive tzdata


### PR DESCRIPTION
we are way past buster now (if ever this was needed to begin with)

let's stop mucking around with permissions this way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed privilege escalation configuration for the ping binary during system installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->