### PR TITLE
Drop libproxy1-plugin-gsettings from XFCE Trixie / Forky / Sid 

### DIFF
--- a/config/desktop/trixie/environments/xfce/config_base/packages
+++ b/config/desktop/trixie/environments/xfce/config_base/packages
@@ -48,7 +48,6 @@ libgsettings-qt1
 libgtk2.0-bin
 libnotify-bin
 libpam-gnome-keyring
-libproxy1-plugin-gsettings
 libwmf-0.2-7-gtk
 libxcursor1
 lightdm


### PR DESCRIPTION
# Description

Its gone from Forky / Sid and is replaced with libproxy1v5. Not sure that is needed ...

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a package from the XFCE desktop environment configuration to streamline the system installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->