### PR TITLE
Rock-5B-Plus: Fix Mainline u-boot

### DIFF
--- a/config/boards/rock-5b-plus.conf
+++ b/config/boards/rock-5b-plus.conf
@@ -2,11 +2,12 @@
 BOARD_NAME="Rock 5B Plus"
 BOARDFAMILY="rockchip-rk3588"
 BOARD_MAINTAINER="HeyMeco fridtjof"
-BOOTCONFIG="rock-5b-plus-rk3588_defconfig"
+BOOTCONFIG="rock5b-rk3588_defconfig"
 KERNEL_TARGET="edge,vendor"
 KERNEL_TEST_TARGET="vendor,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3588-rock-5b-plus.dtb"
 BOOT_SCENARIO="spl-blobs"
 BOOT_SUPPORT_SPI="yes"
 BOOT_SPI_RKSPI_LOADER="yes"
@@ -32,6 +33,10 @@ function post_family_tweaks__rock5bplus_udev_rules() {
 function post_family_config__rock5b_plus_use_mainline_uboot() {
 	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
 
+	# To reuse ATF code in rockchip64_common, let's change the BOOT_SCENARIO and call prepare_boot_configuration() again
+	BOOT_SCENARIO="tpl-blob-atf-mainline"
+	prepare_boot_configuration
+
 	declare -g BOOT_FDT_FILE="rockchip/rk3588-rock-5b-plus.dtb"
 	declare -g BOOTCONFIG="rock5b-rk3588_defconfig"
 	declare -g BOOTDELAY=1
@@ -39,7 +44,7 @@ function post_family_config__rock5b_plus_use_mainline_uboot() {
 	declare -g BOOTBRANCH="tag:v2025.10"
 	declare -g BOOTPATCHDIR="v2025.10"
 	declare -g BOOTDIR="u-boot-${BOARD}"
-	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
 
 	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go


### PR DESCRIPTION
Tested on Rock-5B-Plus:
- SD-Card (empty SPI)
- NVMe (SPI flashed)

Also needs to be applied to the 25.11 branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Rock 5B Plus board boot configuration settings and device tree references to improve boot compatibility and reliability with mainline U-Boot build system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->