### PR TITLE
jethubj200: update JetHub D2 DT file for I2C display and GPIO expande…

### DIFF
--- a/patch/kernel/archive/meson64-6.12/dt/meson-sm1-jethome-jethub-j200.dts
+++ b/patch/kernel/archive/meson64-6.12/dt/meson-sm1-jethome-jethub-j200.dts
@@ -13,6 +13,8 @@
 #include <dt-bindings/gpio/meson-g12a-gpio.h>
 #include <dt-bindings/leds/common.h>
 #include <dt-bindings/sound/meson-g12a-tohdmitx.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
 
 
 / {
@@ -248,6 +250,60 @@
 
 	sound {
 		model = "JETHUB-D2";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		button_up {
+			label = "Joystick Up";
+			gpios = <&exp24 8 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_UP>;
+			debounce-interval = <10>;
+		};
+
+		button_down {
+			label = "Joystick Down";
+			gpios = <&exp24 9 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_DOWN>;
+			debounce-interval = <10>;
+		};
+
+		button_left {
+			label = "Joystick Left";
+			gpios = <&exp24 10 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_LEFT>;
+			debounce-interval = <10>;
+		};
+
+		button_right {
+			label = "Joystick Right";
+			gpios = <&exp24 11 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RIGHT>;
+			debounce-interval = <10>;
+		};
+
+		button_center {
+			label = "Joystick Center";
+			gpios = <&exp24 12 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_ENTER>;
+			debounce-interval = <10>;
+		};
+
+		button_home {
+			label = "Joystick Home";
+			gpios = <&exp24 13 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_HOME>;
+			debounce-interval = <10>;
+		};
+
+		button_back {
+			label = "Joystick Back";
+			gpios = <&exp24 14 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_BACK>;
+			debounce-interval = <10>;
+		};
 	};
 
 };
@@ -628,6 +684,28 @@
 		reg = <0x49>;
 	};
 
+	ssd1306: oled@3c {
+		compatible = "solomon,ssd1306";
+		reg = <0x3c>;
+		solomon,com-invdir;
+		solomon,page-offset = <0x00>;
+		solomon,dclk-div = <1>;
+		solomon,dclk-frq = <8>;
+		solomon,prechargep1 = <2>;
+		solomon,prechargep2 = <8>;
+	};
+
+	exp24: gpio@24 {
+		compatible = "nxp,pca9535";
+		reg = <0x24>;
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		gpio-line-names =
+			"", "", "", "", "", "", "", "",
+			"JOY_UP", "JOY_DOWN", "JOY_LEFT", "JOY_RIGHT",
+			"JOY_CENTER", "JOY_HOME", "JOY_BACK", "";
+	};
 };
 
 &efuse {

--- a/patch/kernel/archive/meson64-6.18/dt/meson-sm1-jethome-jethub-j200.dts
+++ b/patch/kernel/archive/meson64-6.18/dt/meson-sm1-jethome-jethub-j200.dts
@@ -13,6 +13,8 @@
 #include <dt-bindings/gpio/meson-g12a-gpio.h>
 #include <dt-bindings/leds/common.h>
 #include <dt-bindings/sound/meson-g12a-tohdmitx.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
 
 
 / {
@@ -248,6 +250,60 @@
 
 	sound {
 		model = "JETHUB-D2";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		button_up {
+			label = "Joystick Up";
+			gpios = <&exp24 8 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_UP>;
+			debounce-interval = <10>;
+		};
+
+		button_down {
+			label = "Joystick Down";
+			gpios = <&exp24 9 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_DOWN>;
+			debounce-interval = <10>;
+		};
+
+		button_left {
+			label = "Joystick Left";
+			gpios = <&exp24 10 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_LEFT>;
+			debounce-interval = <10>;
+		};
+
+		button_right {
+			label = "Joystick Right";
+			gpios = <&exp24 11 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RIGHT>;
+			debounce-interval = <10>;
+		};
+
+		button_center {
+			label = "Joystick Center";
+			gpios = <&exp24 12 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_ENTER>;
+			debounce-interval = <10>;
+		};
+
+		button_home {
+			label = "Joystick Home";
+			gpios = <&exp24 13 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_HOME>;
+			debounce-interval = <10>;
+		};
+
+		button_back {
+			label = "Joystick Back";
+			gpios = <&exp24 14 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_BACK>;
+			debounce-interval = <10>;
+		};
 	};
 
 };
@@ -628,6 +684,28 @@
 		reg = <0x49>;
 	};
 
+	ssd1306: oled@3c {
+		compatible = "solomon,ssd1306";
+		reg = <0x3c>;
+		solomon,com-invdir;
+		solomon,page-offset = <0x00>;
+		solomon,dclk-div = <1>;
+		solomon,dclk-frq = <8>;
+		solomon,prechargep1 = <2>;
+		solomon,prechargep2 = <8>;
+	};
+
+	exp24: gpio@24 {
+		compatible = "nxp,pca9535";
+		reg = <0x24>;
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		gpio-line-names =
+			"", "", "", "", "", "", "", "",
+			"JOY_UP", "JOY_DOWN", "JOY_LEFT", "JOY_RIGHT",
+			"JOY_CENTER", "JOY_HOME", "JOY_BACK", "";
+	};
 };
 
 &efuse {

--- a/patch/u-boot/v2024.07/board_jethubj200/0003-add-ssd1306-joystick-and-gpio-expander-support.patch
+++ b/patch/u-boot/v2024.07/board_jethubj200/0003-add-ssd1306-joystick-and-gpio-expander-support.patch
@@ -1,0 +1,126 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikita Maslo <nikitamalco203@gmail.com>
+Date: Thu, 27 Nov 2025 17:30:11 +0300
+Subject: add ssd1306, joystick and gpio expander support
+
+---
+ arch/arm/dts/meson-sm1-jethome-jethub-j200.dts | 78 ++++++++++++++++++-
+ 1 file changed, 77 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/dts/meson-sm1-jethome-jethub-j200.dts b/arch/arm/dts/meson-sm1-jethome-jethub-j200.dts
+index 3151a99974c..8acc3785ba3 100644
+--- a/arch/arm/dts/meson-sm1-jethome-jethub-j200.dts
++++ b/arch/arm/dts/meson-sm1-jethome-jethub-j200.dts
+@@ -9,11 +9,12 @@
+ #include "meson-sm1.dtsi"
+
+ #include <dt-bindings/gpio/meson-g12a-gpio.h>
+ #include <dt-bindings/leds/common.h>
+ #include <dt-bindings/sound/meson-g12a-tohdmitx.h>
+-
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/gpio/gpio.h>
+
+ / {
+
+	compatible = "jethome,jethub-j200", "amlogic,sm1";
+	model = "JetHome JetHub D2";
+@@ -245,10 +246,63 @@
+
+	sound {
+		model = "JETHUB-D2";
+	};
+
++	gpio-keys {
++		compatible = "gpio-keys-polled";
++		poll-interval = <100>;
++
++		button_up {
++			label = "Joystick Up";
++			gpios = <&exp24 8 GPIO_ACTIVE_HIGH>;
++			linux,code = <KEY_UP>;
++			debounce-interval = <10>;
++		};
++
++		button_down {
++			label = "Joystick Down";
++			gpios = <&exp24 9 GPIO_ACTIVE_HIGH>;
++			linux,code = <KEY_DOWN>;
++			debounce-interval = <10>;
++		};
++
++		button_left {
++			label = "Joystick Left";
++			gpios = <&exp24 10 GPIO_ACTIVE_HIGH>;
++			linux,code = <KEY_LEFT>;
++			debounce-interval = <10>;
++		};
++
++		button_right {
++			label = "Joystick Right";
++			gpios = <&exp24 11 GPIO_ACTIVE_HIGH>;
++			linux,code = <KEY_RIGHT>;
++			debounce-interval = <10>;
++		};
++
++		button_center {
++			label = "Joystick Center";
++			gpios = <&exp24 12 GPIO_ACTIVE_HIGH>;
++			linux,code = <KEY_ENTER>;
++			debounce-interval = <10>;
++		};
++
++		button_home {
++			label = "Joystick Home";
++			gpios = <&exp24 13 GPIO_ACTIVE_HIGH>;
++			linux,code = <KEY_HOME>;
++			debounce-interval = <10>;
++		};
++
++		button_back {
++			label = "Joystick Back";
++			gpios = <&exp24 14 GPIO_ACTIVE_HIGH>;
++			linux,code = <KEY_BACK>;
++			debounce-interval = <10>;
++		};
++	};
+ };
+
+ &arb {
+	status = "okay";
+ };
+@@ -627,10 +681,32 @@
+	temp2: tmp102@49 {
+		compatible = "ti,tmp102";
+		reg = <0x49>;
+	};
+
++	ssd1306: oled@3c {
++		compatible = "solomon,ssd1306";
++		reg = <0x3c>;
++		solomon,com-invdir;
++		solomon,page-offset = <0x00>;
++		solomon,dclk-div = <1>;
++		solomon,dclk-frq = <8>;
++		solomon,prechargep1 = <2>;
++		solomon,prechargep2 = <8>;
++	};
++
++	exp24: gpio@24 {
++		compatible = "nxp,pca9535";
++		reg = <0x24>;
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		gpio-line-names =
++			"", "", "", "", "", "", "", "",
++			"JOY_UP", "JOY_DOWN", "JOY_LEFT", "JOY_RIGHT",
++			"JOY_CENTER", "JOY_HOME", "JOY_BACK", "";
++	};
+ };
+
+ &efuse {
+	eth_mac: eth-mac@0 {
+		reg = <0x0 0x6>;
+--
+Armbian


### PR DESCRIPTION
# Description

Add device tree support for an I2C display and an I2C GPIO expander.

# How Has This Been Tested?

- Image builds and flashes successfully.
- Display (SSD1306) works as expected.
- GPIO expander works as expected.
- Tested on: JetHub D2.
