### PR TITLE
Enable BTRFS support in uBoot for Helios64

### DIFF
--- a/config/boards/helios64.conf
+++ b/config/boards/helios64.conf
@@ -21,8 +21,10 @@ fi
 function pre_config_uboot_target__helios64_patch_enable_btrfs() {
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable BTRFS support" "info"
 	# defconfig may not contain stub like " is not set", then just insert string
-	sed -i '/^# CONFIG_CMD_BTRFS/c\CONFIG_CMD_BTRFS=y' "configs/${BOOTCONFIG}" \
-		&& echo "CONFIG_CMD_BTRFS=y" >> "configs/${BOOTCONFIG}"
+	if ! grep -q "^CONFIG_CMD_BTRFS=y" "configs/${BOOTCONFIG}"; then
+		sed -i '/^# CONFIG_CMD_BTRFS/c\CONFIG_CMD_BTRFS=y' "configs/${BOOTCONFIG}"
+		grep -q "^CONFIG_CMD_BTRFS=y" "configs/${BOOTCONFIG}" || echo "CONFIG_CMD_BTRFS=y" >> "configs/${BOOTCONFIG}"
+	fi
 	regular_git diff -u "configs/${BOOTCONFIG}" || true
 }
 


### PR DESCRIPTION
I tried enabling BTRFS support in uBoot v2022.07 for Helios64. As was recently done for several other devices, but with a more recent version of uBoot.

All I did was add `CONFIG_CMD_BTRFS=y` to the uBoot .config file.

However, an image with such uBoot is not loaded, even if it is on ext4.

The simplest conclusion from this is "enabling BTRFS support in this version of uBoot breaks it completely, so just don't do it."
However, maybe someone more familiar with uBoot knows that something else is wrong, and this can be fixed very simply?
Posting this PR as a question.

Here is the boot log from this image
```
DDR Version 1.25 20210517
In
channel 0
CS = 0
MR0=0x18
MR4=0x1
MR5=0x1
MR8=0x10
MR12=0x72
MR14=0x72
MR18=0x0
MR19=0x0
MR24=0x8
MR25=0x0
channel 1
CS = 0
MR0=0x18
MR4=0x1
MR5=0x1
MR8=0x10
MR12=0x72
MR14=0x72
MR18=0x0
MR19=0x0
MR24=0x8
MR25=0x0
channel 0 training pass!
channel 1 training pass!
change freq to 416MHz 0,1
Channel 0: LPDDR4,416MHz
Bus Width=32 Col=10 Bank=8 Row=16 CS=1 Die Bus-Width=16 Size=2048MB
Channel 1: LPDDR4,416MHz
Bus Width=32 Col=10 Bank=8 Row=16 CS=1 Die Bus-Width=16 Size=2048MB
256B stride
channel 0
CS = 0
MR0=0x18
MR4=0x1
MR5=0x1
MR8=0x10
MR12=0x72
MR14=0x72
MR18=0x0
MR19=0x0
MR24=0x8
MR25=0x0
channel 1
CS = 0
MR0=0x18
MR4=0x1
MR5=0x1
MR8=0x10
MR12=0x72
MR14=0x72
MR18=0x0
MR19=0x0
MR24=0x8
MR25=0x0
channel 0 training pass!
channel 1 training pass!
channel 0, cs 0, advanced training done
channel 1, cs 0, advanced training done
change freq to 856MHz 1,0
ch 0 ddrconfig = 0x101, ddrsize = 0x40
ch 1 ddrconfig = 0x101, ddrsize = 0x40
pmugrf_os_reg[2] = 0x32C1F2C1, stride = 0xD
ddr_set_rate to 328MHZ
ddr_set_rate to 666MHZ
ddr_set_rate to 928MHZ
channel 0, cs 0, advanced training done
channel 1, cs 0, advanced training done
ddr_set_rate to 416MHZ, ctl_index 0
ddr_set_rate to 856MHZ, ctl_index 1
support 416 856 328 666 928 MHz, current 856MHz
OUT

U-Boot SPL 2022.07_armbian-2022.07-Se092-P3fcd-Hee64-V0d63-Bbf55-R448a (Dec 10 2025 - 01:57:34 +0000)
Trying to boot from MMC1
NOTICE:  BL31: v2.13.0(release):armbian
NOTICE:  BL31: Built : 18:55:15, Oct 27 2025
INFO:    GICv3 with legacy support detected.
INFO:    ARM GICv3 driver initialized in EL3
INFO:    Maximum SPI INTID supported: 287
INFO:    plat_rockchip_pmu_init(1624): pd status 3e
INFO:    BL31: Initializing runtime services
INFO:    BL31: Preparing for EL3 exit to normal world
INFO:    Entry point address = 0x200000
INFO:    SPSR = 0x3c9


U-Boot 2022.07_armbian-2022.07-Se092-P3fcd-Hee64-V0d63-Bbf55-R448a (Dec 10 2025 - 01:57:34 +0000)

SoC: Rockchip rk3399
Reset cause: POR
DRAM:  initcall sequence 00000000002a8900 failed at call 00000000002037e0 (err=-19)
### ERROR ### Please RESET the board ###
```
``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined Helios64 board configuration to optimize btrfs filesystem support during bootloader initialization with improved configuration verification and diagnostic output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->