### PR TITLE
sunxi-current: bump to latest 6.12.y version

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -31,7 +31,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.58"
+		declare -g KERNELBRANCH="tag:v6.12.61"
 		;;
 
 	edge)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -32,7 +32,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.58"
+		declare -g KERNELBRANCH="tag:v6.12.61"
 		;;
 
 	edge)


### PR DESCRIPTION
# Description

bump both sunxi and sunxi64 to 6.12.61

# How Has This Been Tested?

- [x] build sunxi kernel
- [x] build sunxi64 kernel

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated kernel version to v6.12.61 for 32-bit and 64-bit SunXI platforms (previously v6.12.58). This patch release provides the latest maintenance and performance improvements for ARM-based devices, ensuring system stability across all supported configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->