### PR TITLE
qcs6490: VP9 fix backported from mailing list

### DIFF
--- a/patch/kernel/archive/qcs6490-6.18/0050-6.18-VP9-Fix.patch
+++ b/patch/kernel/archive/qcs6490-6.18/0050-6.18-VP9-Fix.patch
@@ -1,6 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mecid Urganci <mecid@mecomediagroup.de>
+Date: Tue, 10 Dec 2025 00:00:00 +0000
+Subject: Fix VP9 decode on SC7280 by restricting EOS quirk to IRIS2
+
+Send NULL EOS addr for only IRIS2 (SM8250), for firmware <= 1.0.87.
+SC7280 also reports "1.0.<hash>" parsed as 1.0.0; restricting to IRIS2
+avoids misapplying this quirk and breaking VP9 decode on SC7280.
+---
+ drivers/media/platform/qcom/venus/vdec.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
 diff --git a/drivers/media/platform/qcom/venus/vdec.c b/drivers/media/platform/qcom/venus/vdec.c
---- drivers/media/platform/qcom/venus/vdec.c
-+++ drivers/media/platform/qcom/venus/vdec.c
+index 111111111111..222222222222 100644
+--- a/drivers/media/platform/qcom/venus/vdec.c
++++ b/drivers/media/platform/qcom/venus/vdec.c
 @@ -566,9 +566,15 @@
  			goto unlock;
  


### PR DESCRIPTION
# Description

Upstream Venus driver has a broken implementation regarding VP9 playback. After reporting it to qcom this patch was proposed in the [LKML](https://lore.kernel.org/lkml/20251125-venus-vp9-fix-v2-1-8bfcea128b95@oss.qualcomm.com/). 

Please squash merge this PR

# Test

- [x] Playback of [Big-Buck-Bunny-1080P-VP9](https://test-videos.co.uk/vids/bigbuckbunny/webm/vp9/1080/Big_Buck_Bunny_1080_10s_10MB.webm) on V4L2 enabled chromium by @amazingfate making sure decoder is `V4L2VideoDecoder`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VP9 decoder End of Stream (EOS) handling for IRIS2 devices running older firmware (<= v1.0.87), improving video decoding reliability on those platforms.
  * Preserved previous EOS behavior for other hardware so non-IRIS2 platforms remain unaffected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->