### PR TITLE
sunxi: bump `current` to latest minor

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -31,7 +31,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.61"
+		declare -g KERNELBRANCH="tag:v6.12.62"
 		;;
 
 	edge)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -32,7 +32,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.61"
+		declare -g KERNELBRANCH="tag:v6.12.62"
 		;;
 
 	edge)


### PR DESCRIPTION
# Description

- Bump sunxi and sunxi64  `current` to latest minor LTS.
- No fuzz at patch alignment, still clean

# Documentation summary for feature / change

# How Has This Been Tested?

- [x] build sunxi kernel
- [x] build sunxi64 kernel

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kernel version from v6.12.61 to v6.12.62 for Sunxi and Sunxi64 platforms. Users deploying these ARM-based systems will now receive the latest kernel version. This update ensures systems utilizing these platform branches are running the most current kernel infrastructure available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->