### PR TITLE
rock-3a: unset `BOOTFS_TYPE` for non-vendor builds

### DIFF
--- a/config/boards/rock-3a.conf
+++ b/config/boards/rock-3a.conf
@@ -13,7 +13,6 @@ BOOT_SCENARIO="spl-blobs"
 BOOT_SUPPORT_SPI="yes"
 BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
-BOOTFS_TYPE="fat"
 
 function post_family_config__rock-3a_use_mainline_uboot_except_vendor_and_add_sata_target() {
 	display_alert "$BOARD" "Configuring ($BOARD) standard and sata uboot target map" "info"
@@ -25,7 +24,6 @@ function post_family_config__rock-3a_use_mainline_uboot_except_vendor_and_add_sa
 	[[ "${BRANCH}" == "vendor" ]] && return 0
 
 	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
-	unset BOOTFS_TYPE
 	declare -g BOOTCONFIG="rock-3a-rk3568_defconfig"
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot"


### PR DESCRIPTION
# Description

Perhaps needed for `vendor`, did not test. However mainline just works fine from ext4.

# How Has This Been Tested?

- [x] build
- [x] boot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected bootloader filesystem type handling for Rock-3A board systems to avoid an incorrect default being applied.
  * Prevents unintended filesystem selection during startup, improving boot reliability and reducing configuration ambiguity for affected devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->