### PR TITLE
Meson64: linux-6.18.y: Improve 6.18.y support for G12/SM1

### DIFF
--- a/patch/kernel/archive/meson64-6.18/x-PATCH-arm64-dts-amlogic-meson-g12b-Fix-L2-cache-reference-for-S922X-CPUs.patch
+++ b/patch/kernel/archive/meson64-6.18/x-PATCH-arm64-dts-amlogic-meson-g12b-Fix-L2-cache-reference-for-S922X-CPUs.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Guillaume La Roque <glaroque@baylibre.com>
+Date: Sun, 23 Nov 2025 18:14:10 +0100
+Subject: [PATCH] arm64: dts: amlogic: meson-g12b: Fix L2 cache reference
+ for S922X CPUs
+
+The original addition of cache information for the Amlogic S922X SoC
+used the wrong next-level cache node for CPU cores 100 and 101,
+incorrectly referencing `l2_cache_l`. These cores actually belong to
+the big cluster and should reference `l2_cache_b`. Update the device
+tree accordingly.
+
+Fixes: e7f85e6c155a ("arm64: dts: amlogic: Add cache information to the Amlogic S922X SoC")
+Signed-off-by: Guillaume La Roque <glaroque@baylibre.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12b.dtsi | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
+index f04efa828256..23358d94844c 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
+@@ -87,7 +87,7 @@ cpu100: cpu@100 {
+ 			i-cache-line-size = <32>;
+ 			i-cache-size = <0x8000>;
+ 			i-cache-sets = <32>;
+-			next-level-cache = <&l2_cache_l>;
++			next-level-cache = <&l2_cache_b>;
+ 			#cooling-cells = <2>;
+ 		};
+ 
+@@ -103,7 +103,7 @@ cpu101: cpu@101 {
+ 			i-cache-line-size = <32>;
+ 			i-cache-size = <0x8000>;
+ 			i-cache-sets = <32>;
+-			next-level-cache = <&l2_cache_l>;
++			next-level-cache = <&l2_cache_b>;
+ 			#cooling-cells = <2>;
+ 		};
+ 
+
+-- 
+2.34.1
+

--- a/patch/kernel/archive/meson64-6.18/x-PATCH-v7-2-2-PCI-dwc-Remove-redundant-MPS-configuration.patch
+++ b/patch/kernel/archive/meson64-6.18/x-PATCH-v7-2-2-PCI-dwc-Remove-redundant-MPS-configuration.patch
@@ -1,0 +1,123 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hans Zhang <18255117159@163.com>
+Subject: [PATCH v7 2/2] PCI: dwc: Remove redundant MPS configuration
+Date: Fri, 28 Nov 2025 01:09:08 +0800
+
+The Meson PCIe controller driver manually configures maximum payload
+size (MPS) through meson_set_max_payload, duplicating functionality now
+centralized in the PCI core.  Deprecating redundant code simplifies the
+driver and aligns it with the consolidated MPS management strategy,
+improving long-term maintainability.
+
+Signed-off-by: Hans Zhang <18255117159@163.com>
+---
+ drivers/pci/controller/dwc/pci-meson.c | 17 -----------------
+ 1 file changed, 17 deletions(-)
+
+diff --git a/drivers/pci/controller/dwc/pci-meson.c b/drivers/pci/controller/dwc/pci-meson.c
+index 787469d1b396..3d12e1a9bb0c 100644
+--- a/drivers/pci/controller/dwc/pci-meson.c
++++ b/drivers/pci/controller/dwc/pci-meson.c
+@@ -261,22 +261,6 @@ static int meson_size_to_payload(struct meson_pcie *mp, int size)
+ 	return fls(size) - 8;
+ }
+ 
+-static void meson_set_max_payload(struct meson_pcie *mp, int size)
+-{
+-	struct dw_pcie *pci = &mp->pci;
+-	u32 val;
+-	u16 offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+-	int max_payload_size = meson_size_to_payload(mp, size);
+-
+-	val = dw_pcie_readl_dbi(pci, offset + PCI_EXP_DEVCTL);
+-	val &= ~PCI_EXP_DEVCTL_PAYLOAD;
+-	dw_pcie_writel_dbi(pci, offset + PCI_EXP_DEVCTL, val);
+-
+-	val = dw_pcie_readl_dbi(pci, offset + PCI_EXP_DEVCTL);
+-	val |= PCIE_CAP_MAX_PAYLOAD_SIZE(max_payload_size);
+-	dw_pcie_writel_dbi(pci, offset + PCI_EXP_DEVCTL, val);
+-}
+-
+ static void meson_set_max_rd_req_size(struct meson_pcie *mp, int size)
+ {
+ 	struct dw_pcie *pci = &mp->pci;
+@@ -381,7 +365,6 @@ static int meson_pcie_host_init(struct dw_pcie_rp *pp)
+ 
+ 	pp->bridge->ops = &meson_pci_ops;
+ 
+-	meson_set_max_payload(mp, MAX_PAYLOAD_SIZE);
+ 	meson_set_max_rd_req_size(mp, MAX_READ_REQ_SIZE);
+ 
+ 	return 0;
+-- 
+2.34.1
+
+
+_______________________________________________
+linux-amlogic mailing list
+linux-amlogic@lists.infradead.org
+http://lists.infradead.org/mailman/listinfo/linux-amlogic
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hans Zhang <18255117159@163.com>
+Subject: [PATCH v7 1/2] PCI: Configure Root Port MPS during host probing
+Date: Fri, 28 Nov 2025 01:09:07 +0800
+
+Current PCIe initialization logic may leave Root Ports operating with
+non-optimal Maximum Payload Size (MPS) settings. The existing code in
+pci_configure_mps() returns early for devices without an upstream bridge
+which includes Root Ports, so their MPS values remain at firmware
+defaults. This fails to utilize the controller's full capabilities,
+leading to suboptimal data transfer efficiency across the PCIe hierarchy.
+
+With this patch, during the host controller probing phase:
+- When PCIe bus tuning is enabled (not PCIE_BUS_TUNE_OFF) and not
+  PCIE_BUS_PEER2PEER (which requires the default 128 bytes for optimal
+  peer-to-peer operation), and
+- The device is a Root Port, the Root Port's MPS is set to its maximum
+  supported value.
+
+Note that this initial maximum MPS setting may be reduced later, during
+downstream device enumeration, if any downstream device does not support
+the Root Port's maximum MPS.
+
+This change ensures Root Ports are initialized to their maximum MPS before
+downstream devices negotiate MPS, while maintaining backward compatibility
+via the PCIE_BUS_TUNE_OFF check and not interfering with the
+PCIE_BUS_PEER2PEER strategy.
+
+Suggested-by: Niklas Cassel <cassel@kernel.org>
+Suggested-by: Manivannan Sadhasivam <mani@kernel.org>
+Signed-off-by: Hans Zhang <18255117159@163.com>
+Tested-by: Mahesh Vaidya <mahesh.vaidya@altera.com>
+Tested-by: Shawn Lin <shawn.lin@rock-chips.com>
+---
+ drivers/pci/probe.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/pci/probe.c b/drivers/pci/probe.c
+index 9cd032dff31e..3970d964d868 100644
+--- a/drivers/pci/probe.c
++++ b/drivers/pci/probe.c
+@@ -2203,6 +2203,18 @@ static void pci_configure_mps(struct pci_dev *dev)
+ 		return;
+ 	}
+ 
++	/*
++	 * Unless MPS strategy is PCIE_BUS_TUNE_OFF (don't touch MPS at all) or
++	 * PCIE_BUS_PEER2PEER (use minimum MPS for peer-to-peer), set Root Ports'
++	 * MPS to their maximum supported value. Depending on the MPS strategy
++	 * and MPSS of downstream devices, a Root Port's MPS may be reduced
++	 * later during device enumeration.
++	 */
++	if (pci_pcie_type(dev) == PCI_EXP_TYPE_ROOT_PORT &&
++	    pcie_bus_config != PCIE_BUS_TUNE_OFF &&
++	    pcie_bus_config != PCIE_BUS_PEER2PEER)
++		pcie_set_mps(dev, 128 << dev->pcie_mpss);
++
+ 	if (!bridge || !pci_is_pcie(bridge))
+ 		return;
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
https://forum.armbian.com/topic/56466-low-performance-on-n2-if-kernel-version-617/#comment-229511

https://lore.kernel.org/linux-amlogic/20251127170908.14850-1-18255117159@163.com/T/#t
https://lore.kernel.org/linux-amlogic/176397825606.3590190.10935817124468233062.b4-ty@linaro.org/T/#t


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed L2 cache linkage for Amlogic Meson-G12B S922X CPU cores to ensure proper cache hierarchy.

* **Refactor**
  * Streamlined PCI device Maximum Payload Size configuration during host initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->