### PR TITLE
rpi4b: enable `EXTRAWIFI` again for `edge`

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -35,7 +35,6 @@ case "${BRANCH}" in
 		;;
 
 	edge)
-		declare -g EXTRAWIFI="no"
 		declare -g KERNELSOURCE='https://github.com/raspberrypi/linux'
 		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel. For mainline caching.
 		declare -g KERNELBRANCH="branch:rpi-6.18.y"


### PR DESCRIPTION
# Description

as per title. Probably has been disabled due to breakage at some point. Seems fine now though.

# How Has This Been Tested?

- [x] build kernel package

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a WiFi-related configuration variable declaration from the BCM2711 edge branch settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->