### PR TITLE
kernel configs: disable unprivileged BPF

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -120,6 +120,7 @@ function armbian_kernel_config__600_enable_ebpf_and_btf_info() {
 		opts_n+=("DEBUG_INFO_NONE") # Make sure the "none" option is disabled
 		opts_y+=(
 			"BPF_JIT" "BPF_JIT_DEFAULT_ON" "FTRACE_SYSCALLS" "PROBE_EVENTS_BTF_ARGS" "BPF_KPROBE_OVERRIDE" # eBPF == on
+			"BPF_UNPRIV_DEFAULT_OFF"
 			"DEBUG_INFO" "DEBUG_INFO_DWARF5" "DEBUG_INFO_BTF" "DEBUG_INFO_BTF_MODULES"                     # BTF & CO-RE == off
 		)
 


### PR DESCRIPTION
Fixes wrong CPU vulnerability output:

/sys/devices/system/cpu/vulnerabilities/spectre_v2:Mitigation:Vulnerable: Unprivileged eBPF enabled

It's enabled but CONFIG_BPF_UNPRIV_DEFAULT_OFF being unset causes the warning.

This warning happens on ARM32 and ARM64 devices.

Edited with:
find -name "*.config" -exec sed -i 's/# CONFIG_BPF_UNPRIV_DEFAULT_OFF is not set/CONFIG_BPF_UNPRIV_DEFAULT_OFF=y/g' '{}' \;

`CONFIG_BPF_UNPRIV_DEFAULT_OFF` is a Linux kernel build-time hardening option that **disables unprivileged use of the `bpf()` syscall (and thus unprivileged eBPF loading) by default** by setting `kernel.unprivileged_bpf_disabled=2` at boot. With this default, only privileged processes (e.g., with `CAP_SYS_ADMIN` / `CAP_BPF`, depending on kernel) can load eBPF unless an administrator explicitly relaxes it. [1], [2]
### Operational behavior you should know
`kernel.unprivileged_bpf_disabled` semantics (as documented in the kernel sysctl docs/patch):
- `0`: unprivileged `bpf()` allowed  
- `1`: unprivileged `bpf()` blocked **and cannot be re-enabled until reboot** (no transition back to `0` while running)  
- `2`: unprivileged `bpf()` blocked **but admin can later switch to `0` or `1`** if needed  
If `CONFIG_BPF_UNPRIV_DEFAULT_OFF=y`, the default becomes `2` instead of `0`. [2]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted kernel build defaults to enable an additional eBPF security option when sufficient RAM is detected during compilation, changing the default eBPF behavior to reduce unprivileged access and increase runtime safety of eBPF features without altering user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->