### PR TITLE
[RFD] lib / rootfs-create: add post-debootstrap hook

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -300,6 +300,11 @@ function create_new_rootfs_cache_via_debootstrap() {
 		chroot_sdcard_apt_get_install "${AGGREGATED_PACKAGES_DESKTOP[@]}"
 	fi
 
+	# customization hook after debootstrap phase
+	call_extension_method "post_debootstrap_customize" <<- 'POST_DEBOOTSTRAP_CUSTOMIZE'
+		allow customization of rootfs after debootstrap has completed
+	POST_DEBOOTSTRAP_CUSTOMIZE
+
 	# stage: check md5 sum of installed packages. Just in case. @TODO: rpardini: this should also be done when a cache is used, not only when it is created
 	# lets check only for supported targets only unless forced
 	if [[ "${DISTRIBUTION_STATUS}" == "supported" && "${FORCE_CHECK_MD5_PACKAGES:-"no"}" == "yes" ]]; then


### PR DESCRIPTION
another carve-out from #9000 

Apparently, [it might be advantageous / necessary to add a hook to the framework to allow for customization of the rootfs just after debootstrap has done its thing](https://github.com/armbian/build/pull/9000#issuecomment-3652499811).  Now, this is certainly way ahead of my comprehension so I add this here only as an RFD to see if this would be a step in the right direction and if I got anything completely wrong.

- is this in about the right place in terms of sequence
- is this a good choice of naming for the hook
- anything to expand in terms of hook description
- ....

this is completely untested as of now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new customization extension point in the build pipeline for enhanced flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->