### PR TITLE
framework: split armbian-bsp-cli into bsp-cli and bsp-generic.

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-bsp-generic.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-generic.sh
@@ -25,17 +25,9 @@ function artifact_armbian-bsp-generic_prepare_version() {
 	# Generic package has no board/family hooks
 	declare hash_hooks_short="0000"
 
-	# get the bootscript info...
-	declare -A bootscript_info=()
-	get_bootscript_info # fills in bootscript_info array
-
-	# Hash variables/bootscripts that affect the contents of bsp-generic package.
+	# Hash variables that affect the contents of bsp-generic package.
 	# Those contain /armbian a lot, so don't normalize them.
-	#FIXME: what's a bootscript for bsp-generic?
-	declare -a vars_to_hash_no_normalize=(
-		"bootscript_file_contents: ${bootscript_info[bootscript_file_contents]}"
-		"bootenv_file_contents: ${bootscript_info[bootenv_file_contents]}"
-	)
+	declare -a vars_to_hash_no_normalize=()
 	declare hash_variables="undetermined"                                                     # will be set by calculate_hash_for_variables(), but without normalization
 	do_normalize_src_path="no" calculate_hash_for_variables "${vars_to_hash_no_normalize[@]}" # don't normalize
 	declare hash_vars_no_normalize="${hash_variables}"

--- a/lib/functions/artifacts/artifact-armbian-bsp-generic.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-generic.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2013-2023 Igor Pecovnik, igor@armbian.com
+#
+# This file is a part of the Armbian Build Framework
+# https://github.com/armbian/build/
+
+function artifact_armbian-bsp-generic_config_dump() {
+	artifact_input_variables[RELEASE]="${RELEASE}"
+	artifact_input_variables[BRANCH]="${BRANCH}"
+}
+
+function artifact_armbian-bsp-generic_prepare_version() {
+	: "${BRANCH:?BRANCH is not set}"
+
+	artifact_version="undetermined"        # outer scope
+	artifact_version_reason="undetermined" # outer scope
+
+	declare short_hash_size=4
+
+	declare fake_unchanging_base_version="1"
+
+	# Generic package has no board/family hooks
+	declare hash_hooks_short="0000"
+
+	# get the bootscript info...
+	declare -A bootscript_info=()
+	get_bootscript_info # fills in bootscript_info array
+
+	# Hash variables/bootscripts that affect the contents of bsp-generic package.
+	# Those contain /armbian a lot, so don't normalize them.
+	#FIXME: what's a bootscript for bsp-generic?
+	declare -a vars_to_hash_no_normalize=(
+		"bootscript_file_contents: ${bootscript_info[bootscript_file_contents]}"
+		"bootenv_file_contents: ${bootscript_info[bootenv_file_contents]}"
+	)
+	declare hash_variables="undetermined"                                                     # will be set by calculate_hash_for_variables(), but without normalization
+	do_normalize_src_path="no" calculate_hash_for_variables "${vars_to_hash_no_normalize[@]}" # don't normalize
+	declare hash_vars_no_normalize="${hash_variables}"
+
+	declare -a vars_to_hash=(
+		"KEEP_ORIGINAL_OS_RELEASE: ${KEEP_ORIGINAL_OS_RELEASE:-"no"}" # /etc/os-release
+		"IMAGE_TYPE: ${IMAGE_TYPE}"                                   # /etc/armbian-release
+		"hash_vars_no_normalize: ${hash_vars_no_normalize}"           # The non-normalized part, above
+	)
+	declare hash_variables="undetermined" # will be set by calculate_hash_for_variables(), which normalizes the input
+	calculate_hash_for_variables "${vars_to_hash[@]}"
+	declare vars_config_hash="${hash_variables}"
+	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
+
+	declare -a dirs_to_hash=(
+		"${SRC}/packages/bsp/common" # common stuff
+	)
+	declare hash_files="undetermined"
+	calculate_hash_for_all_files_in_dirs "${dirs_to_hash[@]}"
+	packages_config_hash="${hash_files}"
+	declare packages_config_hash_short="${packages_config_hash:0:${short_hash_size}}"
+
+	# get the hashes of the lib/ bash sources involved...
+	declare hash_files="undetermined"
+	#FIXME: do we need to fork bsp/armbian-bsp-cli-deb.sh ?
+	calculate_hash_for_bash_deb_artifact "bsp/armbian-bsp-cli-deb.sh" "bsp/utils-bsp.sh"
+	declare bash_hash="${hash_files}"
+	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
+
+	# outer scope
+	artifact_version="${fake_unchanging_base_version}-PC${packages_config_hash_short}-V${var_config_hash_short}-H${hash_hooks_short}-B${bash_hash_short}"
+
+	declare -a reasons=(
+		"Armbian package armbian-bsp-generic"
+		"BRANCH \"${BRANCH}\""
+		"EXTRA_BSP_NAME \"${EXTRA_BSP_NAME}\""
+		"Packages and config files hash \"${packages_config_hash}\""
+		"Hooks hash \"${hash_hooks}\""
+		"Variables/bootscripts hash \"${vars_config_hash}\""
+		"framework bash hash \"${bash_hash}\""
+	)
+
+	artifact_version_reason="${reasons[*]}" # outer scope
+
+	artifact_deb_repo="global"  # "global" meaning: release-independent repo. could be '${RELEASE}' for a release-specific package.
+	artifact_deb_arch="all"     # arch-specific package, or 'all' for arch-independent package.
+	#FIXME: BRANCH for sure, RELEASE maybe?
+	artifact_name="armbian-bsp-generic-${BRANCH}"
+	artifact_type="deb-tar"
+
+	artifact_map_packages=(["armbian-bsp-generic"]="${artifact_name}")
+
+	# Register the function used to re-version the _contents_ of the bsp-cli deb file (non-transitional)
+	# FIXME: can we live without this?
+	#artifact_debs_reversion_functions+=("reversion_armbian-bsp-generic_deb_contents")
+
+	# there is no transitional package, this is just boilerplate
+	#if artifact_armbian-bsp-generic_needs_transitional_package; then
+	#	artifact_map_packages+=(["armbian-bsp-generic-transitional"]="armbian-bsp-generic-${BOARD}${EXTRA_BSP_NAME}")
+	#	# Register the function used to re-version the _contents_ of the bsp-cli deb file (transitional)
+	#	artifact_debs_reversion_functions+=("reversion_armbian-bsp-generic-transitional_deb_contents")
+	#fi
+
+	return 0
+}
+
+function artifact_armbian-bsp-generic_build_from_sources() {
+	LOG_SECTION="compile_armbian-bsp-generic" do_with_logging compile_armbian-bsp-generic
+
+	# Generate transitional package when needed.
+	if artifact_armbian-bsp-generic_needs_transitional_package; then
+		: # we don't have this hook, it's just boilerplate
+		#LOG_SECTION="compile_armbian-bsp-generic" do_with_logging compile_armbian-bsp-generic-transitional
+	fi
+}
+
+function artifact_armbian-bsp-generic_cli_adapter_pre_run() {
+	declare -g ARMBIAN_COMMAND_REQUIRE_BASIC_DEPS="yes" # Require prepare_host_basic to run before the command.
+
+	# "gimme root on a Linux machine"
+	cli_standard_relaunch_docker_or_sudo
+}
+
+function artifact_armbian-bsp-generic_cli_adapter_config_prep() {
+	# there is no need for aggregation here.
+	use_board="no" allow_no_family="no" skip_kernel="no" prep_conf_main_minimal_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
+}
+
+function artifact_armbian-bsp-generic_get_default_oci_target() {
+	artifact_oci_target_base="${GHCR_SOURCE}/armbian/os/"
+}
+
+function artifact_armbian-bsp-generic_is_available_in_local_cache() {
+	is_artifact_available_in_local_cache
+}
+
+function artifact_armbian-bsp-generic_is_available_in_remote_cache() {
+	is_artifact_available_in_remote_cache
+}
+
+function artifact_armbian-bsp-generic_obtain_from_remote_cache() {
+	obtain_artifact_from_remote_cache
+}
+
+function artifact_armbian-bsp-generic_deploy_to_remote_cache() {
+	upload_artifact_to_oci
+}
+
+function artifact_armbian-bsp-generic_needs_transitional_package() {
+	return 1 # we're too new to need a transitional package. Note that this follows the C/bash errno convention where 0 is true
+	# see equivalent for artifact_armbian-bsp-cli
+}

--- a/lib/functions/artifacts/artifact-armbian-bsp-generic.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-generic.sh
@@ -44,6 +44,7 @@ function artifact_armbian-bsp-generic_prepare_version() {
 
 	declare -a dirs_to_hash=(
 		"${SRC}/packages/bsp/common" # common stuff
+		"${SRC}/config/optional/_any_board/_packages/bsp-generic"
 	)
 	declare hash_files="undetermined"
 	calculate_hash_for_all_files_in_dirs "${dirs_to_hash[@]}"
@@ -63,7 +64,6 @@ function artifact_armbian-bsp-generic_prepare_version() {
 	declare -a reasons=(
 		"Armbian package armbian-bsp-generic"
 		"BRANCH \"${BRANCH}\""
-		"EXTRA_BSP_NAME \"${EXTRA_BSP_NAME}\""
 		"Packages and config files hash \"${packages_config_hash}\""
 		"Hooks hash \"${hash_hooks}\""
 		"Variables/bootscripts hash \"${vars_config_hash}\""
@@ -113,7 +113,7 @@ function artifact_armbian-bsp-generic_cli_adapter_pre_run() {
 
 function artifact_armbian-bsp-generic_cli_adapter_config_prep() {
 	# there is no need for aggregation here.
-	use_board="no" allow_no_family="no" skip_kernel="no" prep_conf_main_minimal_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
+	use_board="no" allow_no_family="yes" skip_kernel="no" prep_conf_main_minimal_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
 }
 
 function artifact_armbian-bsp-generic_get_default_oci_target() {

--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -61,7 +61,7 @@ function initialize_artifact() {
 	[[ "${chosen_artifact}" == *","* ]] && exit_with_error "Artifact name cannot contain commas"
 
 	armbian_register_artifacts
-	declare -g chosen_artifact_impl="${ARMBIAN_ARTIFACTS_TO_HANDLERS_DICT["${chosen_artifact}"]}"
+	declare -g chosen_artifact_impl="${ARMBIAN_ARTIFACTS_TO_HANDLERS_DICT["${chosen_artifact}"]}" #"
 	[[ "x${chosen_artifact_impl}x" == "xx" ]] && exit_with_error "Unknown artifact '${chosen_artifact}'"
 	display_alert "artifact" "${chosen_artifact} :: ${chosen_artifact_impl}()" "info"
 	create_artifact_functions

--- a/lib/functions/artifacts/artifacts-registry.sh
+++ b/lib/functions/artifacts/artifacts-registry.sh
@@ -23,6 +23,7 @@ function armbian_register_artifacts() {
 		["armbian-plymouth-theme"]="armbian-plymouth-theme"
 		["armbian-base-files"]="armbian-base-files"
 		["armbian-bsp-cli"]="armbian-bsp-cli"
+		["armbian-bsp-generic"]="armbian-bsp-generic"
 		["armbian-bsp-desktop"]="armbian-bsp-desktop"
 		["armbian-desktop"]="armbian-desktop"
 

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -54,6 +54,20 @@ function reversion_armbian-bsp-cli-transitional_deb_contents() {
 
 }
 
+function reversion_armbian-bsp-generic-transitional_deb_contents() {
+	if [[ "${1}" != "armbian-bsp-generic-transitional" ]]; then
+		return 0 # Not our deb, nothing to do.
+	fi
+	display_alert "Reversion" "reversion_armbian-bsp-generic-transitional_deb_contents: '$*'" "debug"
+
+	# Depends on the new package
+	cat <<- EOF >> "${control_file_new}"
+		Depends: ${artifact_name} (= ${REVISION})
+	EOF
+
+}
+
+
 function compile_armbian-bsp-cli() {
 	: "${artifact_version:?artifact_version is not set}"
 	: "${artifact_name:?artifact_name is not set}"
@@ -121,12 +135,6 @@ function compile_armbian-bsp-cli() {
 	# in practice: packages/bsp-cli and variations of config/optional/...
 	copy_all_packages_files_for "bsp-cli"
 
-	# copy common files from a premade directory structure
-	# @TODO this includes systemd config, assumes things about serial console, etc, that need dynamism or just to not exist with modern systemd
-	display_alert "Copying common bsp files" "packages/bsp/common" "info"
-	run_host_command_logged rsync -av "${SRC}"/packages/bsp/common/* "${destination}"
-	wait_for_disk_sync "after rsync'ing package/bsp/common for bsp-cli"
-
 	mkdir -p "${destination}"/usr/share/armbian/
 
 	# get bootscript information.
@@ -179,24 +187,24 @@ function compile_armbian-bsp-cli() {
 	# TODO: Add proper handling for updated conffiles
 	# We are runing this script each time apt runs. If this package is removed, file is removed and error is triggered.
 	# Keeping armbian-apt-updates as a configuration, solve the problem
-	cat <<- EOF > "${destination}"/DEBIAN/conffiles
-		/usr/lib/armbian/armbian-apt-updates
-		/etc/X11/xorg.conf.d/01-armbian-defaults.conf
-	EOF
+	#cat <<- EOF > "${destination}"/DEBIAN/conffiles
+	#	/usr/lib/armbian/armbian-apt-updates
+	#	/etc/X11/xorg.conf.d/01-armbian-defaults.conf
+	#EOF
 
 	# trigger uInitrd creation after installation, to apply
 	# /etc/initramfs/post-update.d/99-uboot
-	cat <<- EOF > "${destination}"/DEBIAN/triggers
-		activate update-initramfs
-	EOF
+	#cat <<- EOF > "${destination}"/DEBIAN/triggers
+	#	activate update-initramfs
+	#EOF
 
 	# copy distribution support and upgrade status
 	# this information is used in motd to show status and within armbian-config to perform upgrades
-	declare -a releases=()
-	mapfile -t releases < <(for relorder in "${SRC}"/config/distributions/*/order; do echo "${relorder} $(xargs echo < "${relorder}")"; done | sort -nk2 | sed "s/\/order.*//g")
-	for i in "${releases[@]}"; do
-		echo "$(echo "$i" | sed 's/.*\///')=$(cat "$i"/support)$(echo ";upgrade" | sed 's/.*\///')=$(cat "$i"/upgrade)" >> "${destination}"/etc/armbian-distribution-status
-	done
+	#declare -a releases=()
+	#mapfile -t releases < <(for relorder in "${SRC}"/config/distributions/*/order; do echo "${relorder} $(xargs echo < "${relorder}")"; done | sort -nk2 | sed "s/\/order.*//g")
+	#for i in "${releases[@]}"; do
+	#	echo "$(echo "$i" | sed 's/.*\///')=$(cat "$i"/support)$(echo ";upgrade" | sed 's/.*\///')=$(cat "$i"/upgrade)" >> "${destination}"/etc/armbian-distribution-status
+	#done
 
 	# execute $LINUXFAMILY-specific tweaks
 	if [[ $(type -t family_tweaks_bsp) == function ]]; then
@@ -205,6 +213,13 @@ function compile_armbian-bsp-cli() {
 		display_alert "Done with family_tweaks_bsp" "${LINUXFAMILY} - ${BOARDFAMILY}" "debug"
 	fi
 
+	#FIXME: this is just the dir structure from packages/bsp/common. Likely that many of these directories are unneeded.
+	# we add them because of the below hook that may want to add contents.
+	#FIXME: it may be better to make those hooks add the directories instead.
+	mkdir -p "${destination}/lib/systemd/system" "${destination}/lib/udev"
+	mkdir -p "${destination}"/etc/{NetworkManager/conf.d,X11/xorg.conf.d,apt/apt.conf.d,apt/preferences.d}
+	mkdir -p "${destination}"/etc/{cron.d,cron.daily,default,initramfs/post-update.d}
+	mkdir -p "${destination}"/etc/kernel/{postinst.d,postrm.d} "${destination}"/etc/{modprobe.d,profile.d,systemd/system,udev/rules.d,update-motd.d,skel}
 	call_extension_method "post_family_tweaks_bsp" <<- 'POST_FAMILY_TWEAKS_BSP'
 		*family_tweaks_bsp overrrides what is in the config, so give it a chance to override the family tweaks*
 		This should be implemented by the config to tweak the BSP, after the board or family has had the chance to.
@@ -265,6 +280,100 @@ function compile_armbian-bsp-cli() {
 	display_alert "Done building BSP CLI package" "${destination}" "debug"
 }
 
+function compile_armbian-bsp-generic() {
+	: "${artifact_version:?artifact_version is not set}"
+	: "${artifact_name:?artifact_name is not set}"
+	: "${BRANCH:?BRANCH is not set}"
+
+	display_alert "Creating bsp-generic on branch '${BRANCH}'" "${artifact_name} :: ${artifact_version}" "info"
+
+	# "destination" is used a lot in hooks already. keep this name, even if only for compatibility.
+	declare cleanup_id="" destination=""
+	prepare_temp_dir_in_workdir_and_schedule_cleanup "deb-bsp-generic" cleanup_id destination # namerefs
+
+	mkdir -p "${destination}"/DEBIAN
+	cd "${destination}" || exit_with_error "Failed to cd to ${destination}"
+
+	# array of code to be included in preinst, postinst, prerm and postrm scripts (more than default code)
+	declare -a preinst_functions=()
+	declare -a postinst_functions=()
+	declare -a postrm_functions=()
+
+	declare -a extra_description=()
+	[[ "${EXTRA_BSP_NAME}" != "" ]] && extra_description+=("(variant '${EXTRA_BSP_NAME}')")
+
+	# armbianmonitor needs curl, but if it's not there it will install it.
+	# armbian-resize-filesystem needs parted and fdisk
+	cat <<- EOF > "${destination}"/DEBIAN/control
+		Package: ${artifact_name}
+		Version: ${artifact_version}
+		Architecture: all
+		Maintainer: Armbian
+		Section: kernel
+		Priority: optional
+		Depends: bash, linux-base, parted, fdisk, bc, u-boot-tools, initramfs-tools, lsb-release, fping
+		Recommends: bsdutils, util-linux, toilet, curl
+		Provides: armbian-ramlog, armbian-resize-filesystem, armbian-zram-config, armbian-allwinner-battery, armbian-firstrun, armbian-hardware-monitor, armbian-hardware-optimization, armbian-led-state
+		Description: Armbian Generic BSP for branch '${BRANCH}' ${extra_description[@]}
+	EOF
+
+	# armhwinfo, firstrun, armbianmonitor, etc. config file; also sourced in postinst
+	mkdir -p "${destination}"/etc
+
+	# copy general overlay from packages/bsp-cli
+	# in practice: packages/bsp-cli and variations of config/optional/...
+	copy_all_packages_files_for "bsp-generic"
+
+	# copy common files from a premade directory structure
+	# @TODO this includes systemd config, assumes things about serial console, etc, that need dynamism or just to not exist with modern systemd
+	display_alert "Copying common bsp files" "packages/bsp/common" "info"
+	run_host_command_logged rsync -av "${SRC}"/packages/bsp/common/* "${destination}"
+	wait_for_disk_sync "after rsync'ing package/bsp/common for bsp-cli"
+
+	mkdir -p "${destination}"/usr/share/armbian/
+
+	# get bootscript information.
+	#declare -A bootscript_info=()
+	#get_bootscript_info
+
+	# won't recreate files if they were removed by user
+	# TODO: Add proper handling for updated conffiles
+	# We are runing this script each time apt runs. If this package is removed, file is removed and error is triggered.
+	# Keeping armbian-apt-updates as a configuration, solve the problem
+	cat <<- EOF > "${destination}"/DEBIAN/conffiles
+		/usr/lib/armbian/armbian-apt-updates
+		/etc/X11/xorg.conf.d/01-armbian-defaults.conf
+	EOF
+
+	# Render the postinst/postrm/etc
+	# set up pre install script; use inline functions
+	# This is never run in build context; instead, it's source code is dumped inside a file that is packaged.
+	# It is done this way so we get shellcheck and formatting instead of a huge heredoc.
+	### preinst
+	#FIXME: this mentions boards, is this relevant to bsp-generic? see below for postrm & postinst too
+	artifact_package_hook_helper_board_side_functions "preinst" board_side_bsp_cli_preinst "${preinst_functions[@]}"
+	unset board_side_bsp_cli_preinst
+
+	### postrm
+	artifact_package_hook_helper_board_side_functions "postrm" board_side_bsp_cli_postrm "${postrm_functions[@]}"
+	unset board_side_bsp_cli_postrm
+
+	### postinst -- a bit more complex, extendable via postinst_functions which can be customized in hook above
+	artifact_package_hook_helper_board_side_functions "postinst" board_side_bsp_cli_postinst_base "${postinst_functions[@]}" board_side_bsp_cli_postinst_finish
+	unset board_side_bsp_cli_postinst_base board_side_bsp_cli_postinst_update_uboot_bootscript board_side_bsp_cli_postinst_finish
+
+	# fixing permissions (basic), reference: dh_fixperms
+	find "${destination}" -print0 2> /dev/null | xargs -0r chown --no-dereference 0:0
+	find "${destination}" ! -type l -print0 2> /dev/null | xargs -0r chmod 'go=rX,u+rw,a-s'
+
+	# Build / close the package. This will run shellcheck / show the generated files if debugging
+	dpkg_deb_build "${destination}" "armbian-bsp-generic"
+
+	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
+
+	display_alert "Done building BSP Generic package" "${destination}" "debug"
+}
+
 # Reversion function is called with the following parameters:
 # ${1} == deb_id
 function reversion_armbian-bsp-cli_deb_contents() {
@@ -282,7 +391,7 @@ function reversion_armbian-bsp-cli_deb_contents() {
 		depends_base_files=""
 	fi
 	cat <<- EOF >> "${control_file_new}"
-		Depends: bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping, device-tree-compiler${depends_base_files}
+		Depends: armbian-bsp-generic, bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping, device-tree-compiler${depends_base_files}
 		Replaces: zram-config, armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
 		Breaks: armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
 		Provides: armbian-bsp-cli

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -351,16 +351,16 @@ function compile_armbian-bsp-generic() {
 	# It is done this way so we get shellcheck and formatting instead of a huge heredoc.
 	### preinst
 	#FIXME: this mentions boards, is this relevant to bsp-generic? see below for postrm & postinst too
-	artifact_package_hook_helper_board_side_functions "preinst" board_side_bsp_cli_preinst "${preinst_functions[@]}"
-	unset board_side_bsp_cli_preinst
+	artifact_package_hook_helper_board_side_functions "preinst" board_side_bsp_generic_preinst "${preinst_functions[@]}"
+	unset board_side_bsp_generic_preinst "${preinst_functions[@]}"
 
 	### postrm
-	artifact_package_hook_helper_board_side_functions "postrm" board_side_bsp_cli_postrm "${postrm_functions[@]}"
-	unset board_side_bsp_cli_postrm
+	artifact_package_hook_helper_board_side_functions "postrm" board_side_bsp_generic_postrm "${postrm_functions[@]}"
+	unset board_side_bsp_generic_postrm "${postrm_functions[@]}"
 
 	### postinst -- a bit more complex, extendable via postinst_functions which can be customized in hook above
-	artifact_package_hook_helper_board_side_functions "postinst" board_side_bsp_cli_postinst_base "${postinst_functions[@]}" board_side_bsp_cli_postinst_finish
-	unset board_side_bsp_cli_postinst_base board_side_bsp_cli_postinst_update_uboot_bootscript board_side_bsp_cli_postinst_finish
+	artifact_package_hook_helper_board_side_functions "postinst" board_side_bsp_generic_postinst_base "${postinst_functions[@]}" board_side_bsp_generic_postinst_finish
+	unset board_side_bsp_generic_postinst_base board_side_bsp_generic_postinst_finish "${postinst_functions[@]}"
 
 	# fixing permissions (basic), reference: dh_fixperms
 	find "${destination}" -print0 2> /dev/null | xargs -0r chown --no-dereference 0:0
@@ -480,8 +480,14 @@ function board_side_bsp_cli_postinst_update_uboot_bootscript() {
 		[ -f /boot/boot.cmd ] && mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr > /dev/null 2>&1
 	fi
 }
+function board_side_bsp_generic_postinst_update_uboot_bootscript() {
+/bin/true
+}
 
 function board_side_bsp_cli_preinst() {
+/bin/true
+}
+function board_side_bsp_generic_preinst() {
 	# tell people to reboot at next login
 	[ "$1" = "upgrade" ] && touch /var/run/.reboot_required
 
@@ -538,7 +544,11 @@ function board_side_bsp_cli_preinst() {
 	)
 }
 
-function board_side_bsp_cli_postrm() { # not run here
+function board_side_bsp_cli_postrm() {
+/bin/true
+}
+function board_side_bsp_generic_postrm() { # not run here
+#FIXME: if/when zram vs hardware-monitor etc are split, this gets more complicated
 	if [[ remove == "$1" ]] || [[ abort-install == "$1" ]]; then
 		systemctl disable armbian-hardware-monitor.service armbian-hardware-optimize.service > /dev/null 2>&1
 		systemctl disable armbian-zram-config.service armbian-ramlog.service > /dev/null 2>&1
@@ -547,6 +557,9 @@ function board_side_bsp_cli_postrm() { # not run here
 }
 
 function board_side_bsp_cli_postinst_base() {
+/bin/true
+}
+function board_side_bsp_generic_postinst_base() {
 	# Source the armbian-release information file
 	# shellcheck source=/dev/null
 	[ -f /etc/armbian-release ] && . /etc/armbian-release
@@ -570,6 +583,9 @@ function board_side_bsp_cli_postinst_base() {
 }
 
 function board_side_bsp_cli_postinst_finish() {
+/bin/true
+}
+function board_side_bsp_generic_postinst_finish() {
 	ln -sf /var/run/motd /etc/motd
 	rm -f /etc/update-motd.d/00-header /etc/update-motd.d/10-help-text
 

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -391,7 +391,7 @@ function reversion_armbian-bsp-cli_deb_contents() {
 		depends_base_files=""
 	fi
 	cat <<- EOF >> "${control_file_new}"
-		Depends: armbian-bsp-generic, bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping, device-tree-compiler${depends_base_files}
+		Depends: armbian-bsp-generic-${BRANCH}, bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping, device-tree-compiler${depends_base_files}
 		Replaces: zram-config, armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
 		Breaks: armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
 		Provides: armbian-bsp-cli

--- a/lib/functions/main/build-packages.sh
+++ b/lib/functions/main/build-packages.sh
@@ -50,6 +50,7 @@ function determine_artifacts_to_build_for_image() {
 			artifacts_to_build+=("armbian-desktop")
 			artifacts_to_build+=("armbian-bsp-desktop")
 		fi
+		artifacts_to_build+=("armbian-bsp-generic")
 	fi
 
 	# If we're only dumping the config, include the rootfs artifact.

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -220,7 +220,7 @@ function install_distribution_agnostic() {
 			DEFAULT_OVERLAYS_ARR=("${DEFAULT_OVERLAYS_ARR[@]/%/".dtbo"}")
 			DEFAULT_OVERLAYS_ARR=("${DEFAULT_OVERLAYS_ARR[@]/#/"${bootpart_prefix}dtb/${BOOT_FDT_FILE%%/*}/overlay/${OVERLAY_PREFIX}-"}")
 
-			display_alert "Adding to extlinux.conf" "fdtoverlays=${DEFAULT_OVERLAYS_ARR[*]}" "debug"
+			display_alert "Adding to extlinux.conf" "fdtoverlays=${DEFAULT_OVERLAYS_ARR[*]}" "debug" #"
 			echo "  fdtoverlays ${DEFAULT_OVERLAYS_ARR[*]}" >> "$SDCARD/boot/extlinux/extlinux.conf"
 		fi
 
@@ -403,6 +403,8 @@ function install_distribution_agnostic() {
 		fi
 	fi
 
+	#FIXME: this belongs in rootfs not image
+	install_artifact_deb_chroot "armbian-bsp-generic"
 	# install board support packages
 	install_artifact_deb_chroot "armbian-bsp-cli"
 

--- a/lib/library-functions.sh
+++ b/lib/library-functions.sh
@@ -33,6 +33,15 @@ source "${SRC}"/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
 #set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
 set -o errtrace # trace ERR through - enabled
 set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
+### lib/functions/artifacts/artifact-armbian-bsp-generic.sh
+# shellcheck source=lib/functions/artifacts/artifact-armbian-bsp-generic.sh
+source "${SRC}"/lib/functions/artifacts/artifact-armbian-bsp-generic.sh
+
+# no errors tolerated. invoked before each sourced file to make sure.
+#set -o pipefail  # trace ERR through pipes - will be enabled "soon"
+#set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
+set -o errtrace # trace ERR through - enabled
+set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
 ### lib/functions/artifacts/artifact-armbian-desktop.sh
 # shellcheck source=lib/functions/artifacts/artifact-armbian-desktop.sh
 source "${SRC}"/lib/functions/artifacts/artifact-armbian-desktop.sh


### PR DESCRIPTION
# Description

Another fun project spun out of discussions around APA & armbian/apa#36.

There's been some discussion of splitting `armbian-bsp-cli` into `bsp-generic` & `bsp-board-specific`.
Specifically, this lets us stuff most of the generic stuff into the rootfs, and have `bsp-board-specific` `Depend` on `linux-image`.
There's a lot of stuff hidden in this PR, possibly too much.

- we keep `armbian-bsp-cli`, we don't actually create `bsp-board-specific`, as in practice `bsp-board-specific` is aka `armbian-bsp-cli-tritium-h5-current` & friends.
- `armbian-bsp-generic` isn't necessarily the right name, as this really is closer to Armbian Support than Board Support. So we could use a better name
- `Provides: armbian-ramlog, armbian-resize-filesystem, armbian-zram-config, armbian-allwinner-battery, armbian-firstrun, armbian-hardware-monitor, armbian-hardware-optimization, armbian-led-state`
  - the idea is we can later split the package further. But we'd have to simplify the machinery, there is too much boilerplate per package.
  - the list of `Provides` isn't complete, or maybe has too many entries.
- 🚧 Still Under Construction 🚧 - FIXMEs everywhere. Still figuring out how this part of the framework works.
- and a lot more copy :spaghetti:  to clean up. 

# Documentation summary for feature / change

Documentation Shmocumentation.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `time ./compile.sh build BOARD=orangepi5 BRANCH=current BUILD_MINIMAL=yes RELEASE=bookworm KERNEL_CONFIGURE=no KERNEL_GIT=full MANAGE_ACNG='http://squid.tabris.net:3142/' COMPRESS_OUTPUTIMAGE=xz DEB_COMPRESS=xz EXPERT=yes`
  - I don't have an OPi5, this was just a test run. No attempt has been made boot it yet.
  - https://paste.armbian.com/emeqoruzev

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds full lifecycle support for a generic BSP artifact: versioning, build-from-sources scaffolding, packaging and transitional-package handling.
  * Integrates local/remote cache checks, obtain/deploy operations, and CLI/OCI adapter hooks for non-interactive and remote builds.
  * Automatically included in desktop release builds and installed into images during image creation.

* **Chores**
  * Load-time guards and minor comment/packaging flow scaffolding updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->