### PR TITLE
lib / bsp: bump up BSP package to 'required' priority

### DIFF
--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -83,7 +83,7 @@ function compile_armbian-bsp-cli() {
 		Architecture: $ARCH
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
 		Section: kernel
-		Priority: optional
+		Priority: required
 		Recommends: bsdutils, parted, util-linux, toilet
 		Description: Armbian CLI BSP for board '${BOARD}' branch '${BRANCH}' ${extra_description[@]}
 	EOF


### PR DESCRIPTION
the BSP package is priority required not optional as it is required to boot

https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html#priority

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Debian package metadata classification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->