### PR TITLE
sunxi: fix missing dt overlays

### DIFF
--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
@@ -4852,6 +4852,18 @@ index 000000000000..111111111111
 +        uart7_pi_pins = "/fragment@1/__overlay__:pinctrl-0:0";
 +    };
 +};
+diff --git a/arch/arm/boot/dts/allwinner/Makefile b/arch/arm/boot/dts/allwinner/Makefile
+index f71392a55df8..36fb1355c415 100644
+--- a/arch/arm/boot/dts/allwinner/Makefile
++++ b/arch/arm/boot/dts/allwinner/Makefile
+@@ -279,5 +279,7 @@ dtb-$(CONFIG_MACH_SUN9I) += \
+ 	sun9i-a80-cubieboard4.dtb
+ dtb-$(CONFIG_MACH_SUNIV) += \
+ 	suniv-f1c100s-licheepi-nano.dtb \
+ 	suniv-f1c200s-lctech-pi.dtb \
+ 	suniv-f1c200s-popstick-v1.1.dtb
++
++subdir-y       := $(dts-dirs) overlay
 -- 
 Armbian
 


### PR DESCRIPTION
# Description

overlay subdir was missing vom Makefile, so the overlay creation was skipped.
Has been reported here: https://forum.armbian.com/topic/56756-no-overlays-when-kernel-6181-edge-sunxi-compile/

# How Has This Been Tested?

- [x] build https://paste.armbian.de/inebuseleb

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device tree overlay support is now built into Armbian, providing enhanced hardware configuration capabilities and greater customization options for Armbian devices on Allwinner platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->