### PR TITLE
lib / kernel-debs: add Conflicts:linux-image to kernel deb pkg

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -266,6 +266,7 @@ function kernel_package_callback_linux_image() {
 		Section: kernel
 		Priority: optional
 		Provides: linux-image, linux-image-armbian, armbian-$BRANCH, wireguard-modules
+		Conflicts: linux-image
 		Description: Armbian Linux $BRANCH kernel image $kernel_version_family
 		 This package contains the Linux kernel, modules and corresponding other files.
 		 ${artifact_version_reason:-"${kernel_version_family}"}


### PR DESCRIPTION
we do not want the user to install an upstream kernel package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package conflict metadata for the linux-image package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->