### PR TITLE
compress-checksum: introduce `COMPRESS_OUTPUTIMAGE=zst`

### DIFF
--- a/lib/functions/image/compress-checksum.sh
+++ b/lib/functions/image/compress-checksum.sh
@@ -41,6 +41,11 @@ function output_images_compress_and_checksum() {
 			display_alert "Compressing with xz" "${uncompressed_file_basename}.xz" "info"
 			xz -T 0 "-${xz_compression_ratio_image}" "${uncompressed_file}" # "If xz is provided with input but no output, it will delete the input"
 			compression_type=".xz"
+		elif [[ $COMPRESS_OUTPUTIMAGE == *zst* ]]; then
+			display_alert "Compressing with zstd" "${uncompressed_file_basename}.zst" "info"
+			zstdmt "-${ZSTD_COMPRESSION_LEVEL:-9}" "${uncompressed_file}" -o "${uncompressed_file}.zst"
+			rm -f "${uncompressed_file}"
+			compression_type=".zst"
 		fi
 
 		if [[ $COMPRESS_OUTPUTIMAGE == *sha* ]]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for zstd compression as an alternative image compression method, with configurable compression levels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->