### PR TITLE
sunxi: bump `current` and `edge` to latest minor, rewrite patches

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -31,12 +31,12 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.62"
+		declare -g KERNELBRANCH="tag:v6.12.63"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.18.1"
+		declare -g KERNELBRANCH="tag:v6.18.2"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -32,12 +32,12 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.62"
+		declare -g KERNELBRANCH="tag:v6.12.63"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.18.1"
+		declare -g KERNELBRANCH="tag:v6.18.2"
 		;;
 esac
 

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/ASoC-AC200-Initial-driver.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/ASoC-AC200-Initial-driver.patch
@@ -22,7 +22,7 @@ index 111111111111..222222222222 100644
  	imply SND_SOC_AC97_CODEC
  	imply SND_SOC_AD1836
  	imply SND_SOC_AD193X_SPI
-@@ -426,6 +427,15 @@ config SND_SOC_AB8500_CODEC
+@@ -427,6 +428,15 @@ config SND_SOC_AB8500_CODEC
  	tristate
  	depends on ABX500_CORE
  
@@ -50,7 +50,7 @@ index 111111111111..222222222222 100644
  snd-soc-ac97-y := ac97.o
  snd-soc-ad1836-y := ad1836.o
  snd-soc-ad193x-y := ad193x.o
-@@ -432,6 +433,7 @@ snd-soc-simple-mux-y := simple-mux.o
+@@ -433,6 +434,7 @@ snd-soc-simple-mux-y := simple-mux.o
  
  obj-$(CONFIG_SND_SOC_88PM860X)	+= snd-soc-88pm860x.o
  obj-$(CONFIG_SND_SOC_AB8500_CODEC)	+= snd-soc-ab8500-codec.o

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-add-overlays.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-add-overlays.patch
@@ -2,11 +2,9 @@ From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Werner <werner@armbian.com>
 Date: Tue, 30 May 2023 12:04:55 +0800
 Subject: sun50i-h616: add overlays and fixup
-Subject: cb1-overlay
 
 Author: unknown
 Signed-off-by: Werner <werner@armbian.com>
-
 ---
  arch/arm64/boot/dts/allwinner/overlay/Makefile                    |  15 +-
  arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-fixup.scr-cmd   | 110 ++++++++++

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/audio-6.18/0011-ASoC-ec25-New-codec-driver-for-the-EC25-modem.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/audio-6.18/0011-ASoC-ec25-New-codec-driver-for-the-EC25-modem.patch
@@ -18,7 +18,7 @@ diff --git a/sound/soc/codecs/Kconfig b/sound/soc/codecs/Kconfig
 index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/Kconfig
 +++ b/sound/soc/codecs/Kconfig
-@@ -1176,6 +1176,9 @@ config SND_SOC_HDMI_CODEC
+@@ -1177,6 +1177,9 @@ config SND_SOC_HDMI_CODEC
  	select SND_PCM_IEC958
  	select HDMI
  
@@ -40,7 +40,7 @@ index 111111111111..222222222222 100644
  snd-soc-es7134-y := es7134.o
  snd-soc-es7241-y := es7241.o
  snd-soc-es83xx-dsm-common-y := es83xx-dsm-common.o
-@@ -555,6 +556,7 @@ obj-$(CONFIG_SND_SOC_DA7219)	+= snd-soc-da7219.o
+@@ -556,6 +557,7 @@ obj-$(CONFIG_SND_SOC_DA7219)	+= snd-soc-da7219.o
  obj-$(CONFIG_SND_SOC_DA732X)	+= snd-soc-da732x.o
  obj-$(CONFIG_SND_SOC_DA9055)	+= snd-soc-da9055.o
  obj-$(CONFIG_SND_SOC_DMIC)	+= snd-soc-dmic.o

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/cw1200-6.18/0003-cw1200-use-kmalloc-allocation-instead-of-stack.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/cw1200-6.18/0003-cw1200-use-kmalloc-allocation-instead-of-stack.patch
@@ -21,7 +21,7 @@ diff --git a/drivers/net/wireless/st/cw1200/bh.c b/drivers/net/wireless/st/cw120
 index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/st/cw1200/bh.c
 +++ b/drivers/net/wireless/st/cw1200/bh.c
-@@ -415,9 +415,13 @@ static int cw1200_bh(void *arg)
+@@ -417,9 +417,13 @@ static int cw1200_bh(void *arg)
  	int pending_tx = 0;
  	int tx_burst;
  	long status;
@@ -36,7 +36,7 @@ index 111111111111..222222222222 100644
  	for (;;) {
  		if (!priv->hw_bufs_used &&
  		    priv->powersave_enabled &&
-@@ -439,7 +443,7 @@ static int cw1200_bh(void *arg)
+@@ -441,7 +445,7 @@ static int cw1200_bh(void *arg)
  		    (atomic_read(&priv->bh_rx) == 0) &&
  		    (atomic_read(&priv->bh_tx) == 0))
  			cw1200_reg_read(priv, ST90TDS_CONFIG_REG_ID,
@@ -45,7 +45,7 @@ index 111111111111..222222222222 100644
  
  		pr_debug("[BH] waiting ...\n");
  		status = wait_event_interruptible_timeout(priv->bh_wq, ({
-@@ -601,5 +605,8 @@ static int cw1200_bh(void *arg)
+@@ -603,5 +607,8 @@ static int cw1200_bh(void *arg)
  		priv->bh_error = 1;
  		/* TODO: schedule_work(recovery) */
  	}


### PR DESCRIPTION
# Description

as per title

# How Has This Been Tested?


- [x] sunxi: build current and edge
- [x] sunxi64: build current and edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AC200 audio codec support
  * Added EC25 modem audio codec support
  * Added device configuration overlays for hardware customization

* **Chores**
  * Bumped kernel patch versions for current and edge tracks
  * Improved wireless driver memory handling to avoid stack allocations and add allocation error handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->