### PR TITLE
Modify radxa-e54c board config to fix leds, network and Gnome desktop init.

### DIFF
--- a/config/boards/radxa-e54c.conf
+++ b/config/boards/radxa-e54c.conf
@@ -64,7 +64,6 @@ function post_family_tweaks_bsp__radxa_e54c_enable_leds() {
 	display_alert "$BOARD" "Creating Board Support Internal Switch Config" "info"
 	cat <<- EOF > "${destination}"/etc/NetworkManager/conf.d/99-unmanaged-devices.conf
 	[main]
-	plugins=ifconfig-rh,keyfile
 
 	[keyfile]
 	unmanaged-devices=interface-name:end1


### PR DESCRIPTION


# Description

Modify led setup section of the radxa-e54c board config to use new led device names.

Modify the radxa-e54c board config to add a keyfile /etc/NetworkManager/conf.d/99-unmanaged-devices.conf on the board to set the internal ethernet, end1, used to connect to the internal switch chip to unmanaged.  This interface doesn't accept DHCP IP addresses and Network Manager attempts to connect it via DHCP causing errors.

Modify the radxa-e54c board config to modify the boards /usr/lib/armbian/armbian-firstlogin file to set WaylandEnable = false if the build is for a vendor kernel with a Gnome desktop to prevent vendor kernel build with Gnome desktop attempting to use Wayland unsuccessfully causing the desktop to take over 10 minutes to initialize eventually using X11.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2801]

# How Has This Been Tested?

- [x] Test on vendor kernel with trixie minimal build, noble minimal build, trixie with xfce desktop and noble with gnome desktop that wan,  lan1, lan2, lan3 LEDs work when the network is connected to a matching Ethernet port.
- [x] Test on vendor kernel with trixie minimal build, noble minimal build, trixie with xfce desktop and noble with gnome desktop that NetworkManager does not attempt to manage the end1 network adapter.
- [x] Test that on a vendor kernel with Gnome desktop,  the Gnome desktop initializes quickly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


[AR-2801]: https://armbian.atlassian.net/browse/AR-2801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected network LED mappings so status indicators display accurately.
  * Ensured the internal Ethernet interface is left unmanaged to prevent connection conflicts.

* **Chores**
  * Updated first-login desktop setup for vendor GNOME: disables Wayland and refines automatic login behavior.

These changes improve network status clarity and first‑login reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->