### PR TITLE
fix(apt-utils): add fallback for Ubuntu LTS releases without -updates suffix in JSON

### DIFF
--- a/lib/functions/general/apt-utils.sh
+++ b/lib/functions/general/apt-utils.sh
@@ -58,6 +58,16 @@ function apt_find_upstream_package_version_and_download_url() {
 			'.[$release][$arch]' $package_info_download_url_file
 	)
 
+	# Fallback for Ubuntu LTS releases: if not found with -updates suffix, try without it
+	if [[ "${found_package_filename}" != "${sought_package_name}_"* ]] && [[ "${DISTRIBUTION}" == "Ubuntu" ]] && [[ "${package_download_release}" == *"-updates" ]]; then
+		display_alert "Package not found with '-updates' suffix, trying without it" "${package_download_release} -> ${RELEASE}" "wrn"
+		package_download_release="${RELEASE}"
+		found_package_filename=$(
+			jq -r --arg release "${package_download_release}" --arg arch "${ARCH}" \
+				'.[$release][$arch]' $package_info_download_url_file
+		)
+	fi
+
 	if [[ "${found_package_filename}" == "${sought_package_name}_"* ]]; then
 		display_alert "Found upstream base-files package filename" "${found_package_filename}" "info"
 	else


### PR DESCRIPTION
# Description

Problem: armbian-base-files artifact for jammy fails to build because apt_find_upstream_package_version_and_download_url() looks for 'jammy-updates' in https://github.armbian.com/base-files.json, but only 'jammy' key exists.

Root cause:
- For Ubuntu LTS (focal, jammy), code sets package_download_release to '${RELEASE}-updates'
- JSON file from github.armbian.com only has base release keys (jammy, noble, etc)
- jq query returns null for 'jammy-updates'
- Artifact excluded from build matrix after 10 retries

Solution: Add fallback logic
- First try with '-updates' suffix (jammy-updates)
- If not found and release ends with '-updates', retry with base release (jammy)
- This allows using base release data when -updates is not available

Impact:
- Fixes jammy base-files artifact build
- Allows jammy images to build (they depend on this artifact)
- Maintains preference for -updates when available
- No impact on other releases (Debian, non-LTS Ubuntu)


# How Has This Been Tested?

Full build release version via workflow.

This is one of the fixes. Fix for base-files.json is described here https://github.com/armbian/armbian.github.io/pull/114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved Ubuntu LTS package download reliability by adding a fallback mechanism that retries without the -updates suffix when the initial package filename is unavailable. The system logs a warning and continues with the alternative filename to prevent download failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->