### PR TITLE
switch cubie a5e (sun55i-a523/t527) to edge 6.18

### DIFF
--- a/config/boards/radxa-cubie-a5e.csc
+++ b/config/boards/radxa-cubie-a5e.csc
@@ -7,7 +7,7 @@ BOOTCONFIG="radxa-cubie-a5e_defconfig"
 OVERLAY_PREFIX="sun55i-a527"
 #BOOT_LOGO="desktop"
 KERNEL_TARGET="edge"
-BOOT_FDT_FILE="sun55i-a527-radxa-a5e.dtb"
+BOOT_FDT_FILE="sun55i-a527-cubie-a5e.dtb"
 IMAGE_PARTITION_TABLE="gpt"
 #IMAGE_PARTITION_TABLE="msdos"
 BOOTFS_TYPE="fat"
@@ -58,4 +58,3 @@ function post_family_tweaks__enable_aic8800_bluetooth_service() {
 		display_alert "$BOARD" "aic-bluetooth.service not found in image; skipping enable" "warn"
 	fi
 }
-

--- a/config/sources/families/sun55iw3.conf
+++ b/config/sources/families/sun55iw3.conf
@@ -10,7 +10,7 @@ enable_extension "sunxi-tools"
 declare -g ARCH=arm64
 declare -g ATFSOURCE='https://github.com/jernejsk/arm-trusted-firmware'
 declare -g ATF_TARGET_MAP="PLAT=sun55i_a523 DEBUG=1 bl31;;build/sun55i_a523/debug/bl31.bin"
-declare -g ATFBRANCH="branch:a523"
+declare -g ATFBRANCH="branch:a523-v4"
 declare -g BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'
 declare -g BOOTDELAY=1
 declare -g BOOTSOURCE='https://github.com/u-boot/u-boot.git'
@@ -25,9 +25,9 @@ declare -g LINUXCONFIG="linux-sunxi64-${BRANCH}"
 case "${BRANCH}" in
 
 	edge)
-		declare -g KERNEL_MAJOR_MINOR="6.16" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.16"
-		declare -g KERNELPATCHDIR="archive/sunxi-dev-${KERNEL_MAJOR_MINOR}"
+		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH="tag:v6.18.2"
+		declare -g KERNELPATCHDIR="archive/sunxi-${KERNEL_MAJOR_MINOR}"
 		;;
 esac
 


### PR DESCRIPTION
# Description

Migrate Cubie A5e from 6.16-dev to Edge 6.18

# Documentation summary for feature / change

This change doesn't add any patches; it only changes the branch to mainline edge so that specific patches can be added later.

- [x] Build Log: https://paste.armbian.eu/juvuhihojo
- [x] Boot log on serial adapter: https://paste.armbian.com/vatiteboqu.yaml


# How Has This Been Tested?

- [x] Boot test on Radxa Cubie A5E v1.1 2GB Ram

