### PR TITLE
dts: orangepi-4-lts: fix mispelled disable properites

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3399-orangepi-4-lts.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3399-orangepi-4-lts.dts
@@ -210,7 +210,7 @@
 	};
 
 	spdif-sound {
-		status = "disable";
+		status = "disabled";
 		compatible = "simple-audio-card";
 		simple-audio-card,name = "ROCKCHIP,SPDIF";
 		simple-audio-card,cpu {
@@ -222,13 +222,13 @@
 	};
 
 	spdif_out: spdif-out {
-		status = "disable";
+		status = "disabled";
 		compatible = "linux,spdif-dit";
 		#sound-dai-cells = <0>;
 	};
 
 	pwm_bl: backlight {
-		status = "disable";
+		status = "disabled";
 		compatible = "pwm-backlight";
 		pwms = <&pwm0 0 25000 0>;
 		brightness-levels = <
@@ -455,7 +455,7 @@
 };
 
 &spi1 {
-	status = "disable";
+	status = "disabled";
 	pinctrl-names = "default", "sleep";
 	pinctrl-1 = <&spi1_gpio>;
 
@@ -868,7 +868,7 @@
 };
 
 &spdif {
-	status = "disable";
+	status = "disabled";
 	pinctrl-0 = <&spdif_bus>;
 	i2c-scl-rising-time-ns = <450>;
 	i2c-scl-falling-time-ns = <15>;
@@ -1258,11 +1258,11 @@
 };
 
 &hdmi_in_vopl {
-	status = "disable";
+	status = "disabled";
 };
 
 &dp_in_vopb {
-	status = "disable";
+	status = "disabled";
 };
 &dp_in_vopl {
 	status = "okay";


### PR DESCRIPTION
# Description

Backports a fix for Orangepi 4 LTS where status values were mispelled ('disable' instead of 'disabled').

I'm not sure if these nodes were actually active due to this typo (it seems like this kind of issue is silently ignored by dtc).

# How Has This Been Tested?

- [x] build
- [ ] boot - nope, no hw

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected hardware component status configuration on OrangePi 4 LTS boards, affecting audio, backlight, SPI, and display interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->