### PR TITLE
sunxi: backport allwinner a523 patches from linux-next

### DIFF
--- a/patch/kernel/archive/sunxi-6.18/patches.backports/11-spi--dt-bindings--sun6i--Add-compatibles-for-A523-s-SPI-controllers.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.backports/11-spi--dt-bindings--sun6i--Add-compatibles-for-A523-s-SPI-controllers.patch
@@ -1,0 +1,54 @@
+From e0c8755d44eb85afd40100586076c3dc4b62ee3b Mon Sep 17 00:00:00 2001
+From: Chen-Yu Tsai <wens@kernel.org>
+Date: Sun, 21 Dec 2025 19:05:08 +0800
+Subject: spi: dt-bindings: sun6i: Add compatibles for A523's SPI controllers
+
+The A523 has four SPI controllers. One of them supports MIPI DBI mode
+in addition to standard SPI.
+
+Compared to older generations, this newer controller now has a combined
+counter for the RX FIFO ad buffer levels. In older generations, the
+RX buffer level was a separate bitfield in the FIFO status register.
+
+In practice this difference is negligible. The buffer is mostly
+invisible to the implementation. If programmed I/O transfers are limited
+to the FIFO size, then the contents of the buffer seem to always be
+flushed over to the FIFO. For DMA, the DRQ trigger levels are only tied
+to the FIFO levels. In all other aspects, the controller is the same as
+the one in the R329.
+
+Add new compatible strings for the new controllers.
+
+Signed-off-by: Chen-Yu Tsai <wens@kernel.org>
+Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
+Link: https://patch.msgid.link/20251221110513.1850535-2-wens@kernel.org
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ Documentation/devicetree/bindings/spi/allwinner,sun6i-a31-spi.yaml | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/spi/allwinner,sun6i-a31-spi.yaml b/Documentation/devicetree/bindings/spi/allwinner,sun6i-a31-spi.yaml
+index 3b47b68b92cb8a..1b91d1566c9530 100644
+--- a/Documentation/devicetree/bindings/spi/allwinner,sun6i-a31-spi.yaml
++++ b/Documentation/devicetree/bindings/spi/allwinner,sun6i-a31-spi.yaml
+@@ -17,6 +17,7 @@ properties:
+   compatible:
+     oneOf:
+       - const: allwinner,sun50i-r329-spi
++      - const: allwinner,sun55i-a523-spi
+       - const: allwinner,sun6i-a31-spi
+       - const: allwinner,sun8i-h3-spi
+       - items:
+@@ -35,6 +36,9 @@ properties:
+           - const: allwinner,sun20i-d1-spi-dbi
+           - const: allwinner,sun50i-r329-spi-dbi
+           - const: allwinner,sun50i-r329-spi
++      - items:
++          - const: allwinner,sun55i-a523-spi-dbi
++          - const: allwinner,sun55i-a523-spi
+ 
+   reg:
+     maxItems: 1
+-- 
+cgit 1.2.3-korg
+

--- a/patch/kernel/archive/sunxi-6.18/patches.backports/12-spi--sun6i--Support-A523-s-SPI-controllers.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.backports/12-spi--sun6i--Support-A523-s-SPI-controllers.patch
@@ -1,0 +1,58 @@
+From c81f30bde5b0449d9d82d31a66f0ffd608e610b5 Mon Sep 17 00:00:00 2001
+From: Chen-Yu Tsai <wens@kernel.org>
+Date: Sun, 21 Dec 2025 19:05:09 +0800
+Subject: spi: sun6i: Support A523's SPI controllers
+
+The A523 has four SPI controllers. One of them supports MIPI DBI mode
+in addition to standard SPI.
+
+Compared to older generations, this newer controller now has a combined
+counter for the RX FIFO ad buffer levels. In older generations, the
+RX buffer level was a separate bitfield in the FIFO status register.
+
+In practice this difference is negligible. The buffer is mostly
+invisible to the implementation. If programmed I/O transfers are limited
+to the FIFO size, then the contents of the buffer seem to always be
+flushed over to the FIFO. For DMA, the DRQ trigger levels are only tied
+to the FIFO levels. In all other aspects, the controller is the same as
+the one in the R329.
+
+Support the standard SPI mode controllers using the settings for R329.
+DBI is left out as there currently is no infrastructure for enabling a
+DBI host controller, as was the case for the R329.
+
+Also fold the entry for the R329 to make the style consistent.
+
+Signed-off-by: Chen-Yu Tsai <wens@kernel.org>
+Reviewed-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+Link: https://patch.msgid.link/20251221110513.1850535-3-wens@kernel.org
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ drivers/spi/spi-sun6i.c | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/spi/spi-sun6i.c b/drivers/spi/spi-sun6i.c
+index 871dfd3e77be28..d1de6c99e7622f 100644
+--- a/drivers/spi/spi-sun6i.c
++++ b/drivers/spi/spi-sun6i.c
+@@ -795,10 +795,13 @@ static const struct sun6i_spi_cfg sun50i_r329_spi_cfg = {
+ static const struct of_device_id sun6i_spi_match[] = {
+ 	{ .compatible = "allwinner,sun6i-a31-spi", .data = &sun6i_a31_spi_cfg },
+ 	{ .compatible = "allwinner,sun8i-h3-spi",  .data = &sun8i_h3_spi_cfg },
+-	{
+-		.compatible = "allwinner,sun50i-r329-spi",
+-		.data = &sun50i_r329_spi_cfg
+-	},
++	{ .compatible = "allwinner,sun50i-r329-spi", .data = &sun50i_r329_spi_cfg },
++	/*
++	 * A523's SPI controller has a combined RX buffer + FIFO counter
++	 * at offset 0x400, instead of split buffer count in FIFO status
++	 * register. But in practice we only care about the FIFO level.
++	 */
++	{ .compatible = "allwinner,sun55i-a523-spi", .data = &sun50i_r329_spi_cfg },
+ 	{}
+ };
+ MODULE_DEVICE_TABLE(of, sun6i_spi_match);
+-- 
+cgit 1.2.3-korg
+

--- a/patch/kernel/archive/sunxi-6.18/patches.backports/13-arm64--dts--allwinner--sun55i--Add-SPI-controllers.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.backports/13-arm64--dts--allwinner--sun55i--Add-SPI-controllers.patch
@@ -1,0 +1,139 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chen-Yu Tsai <wens@kernel.org>
+Date: Sun, 21 Dec 2025 19:05:10 +0800
+Subject: arm64: dts: allwinner: sun55i: Add SPI controllers
+
+The A523 family SoCs have four SPI controllers. One of them also
+supports DBI mode.
+
+Add device nodes for all of them. Also add pinmux nodes for spi0 on the
+PC pins, which is commonly used for SPI-NOR boot flash.
+
+Signed-off-by: Chen-Yu Tsai <wens@kernel.org>
+---
+ .../arm64/boot/dts/allwinner/sun55i-a523.dtsi | 94 +++++++++++++++++++
+ 1 file changed, 94 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
+index 42dab01e3f56..9335977751e2 100644
+--- a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
+@@ -214,6 +214,43 @@ spdif_out_pi_pin: spdif-pi-pin {
+ 				allwinner,pinmux = <2>;
+ 			};
+ 
++			/omit-if-no-ref/
++			spi0_pc_pins: spi0-pc-pins {
++				pins = "PC2", "PC4", "PC12";
++				function = "spi0";
++				allwinner,pinmux = <4>;
++			};
++
++			/omit-if-no-ref/
++			spi0_cs0_pc_pin: spi0-cs0-pc-pin {
++				pins = "PC3";
++				function = "spi0";
++				allwinner,pinmux = <4>;
++			};
++
++			/omit-if-no-ref/
++			spi0_cs1_pc_pin: spi0-cs1-pc-pin {
++				pins = "PC7";
++				function = "spi0";
++				allwinner,pinmux = <4>;
++			};
++
++			/omit-if-no-ref/
++			spi0_hold_pc_pin: spi0-hold-pc-pin {
++				/* conflicts with eMMC D7 */
++				pins = "PC16";
++				function = "spi0";
++				allwinner,pinmux = <4>;
++			};
++
++			/omit-if-no-ref/
++			spi0_wp_pc_pin: spi0-wp-pc-pin {
++				/* conflicts with eMMC D2 */
++				pins = "PC15";
++				function = "spi0";
++				allwinner,pinmux = <4>;
++			};
++
+ 			uart0_pb_pins: uart0-pb-pins {
+ 				pins = "PB9", "PB10";
+ 				allwinner,pinmux = <2>;
+@@ -563,6 +600,49 @@ mmc2: mmc@4022000 {
+ 			#size-cells = <0>;
+ 		};
+ 
++		spi0: spi@4025000 {
++			compatible = "allwinner,sun55i-a523-spi";
++			reg = <0x04025000 0x1000>;
++			interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_SPI0>, <&ccu CLK_SPI0>;
++			clock-names = "ahb", "mod";
++			dmas = <&dma 22>, <&dma 22>;
++			dma-names = "rx", "tx";
++			resets = <&ccu RST_BUS_SPI0>;
++			status = "disabled";
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++
++		spi1: spi@4026000 {
++			compatible = "allwinner,sun55i-a523-spi-dbi",
++				     "allwinner,sun55i-a523-spi";
++			reg = <0x04026000 0x1000>;
++			interrupts = <GIC_SPI 17 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_SPI1>, <&ccu CLK_SPI1>;
++			clock-names = "ahb", "mod";
++			dmas = <&dma 23>, <&dma 23>;
++			dma-names = "rx", "tx";
++			resets = <&ccu RST_BUS_SPI1>;
++			status = "disabled";
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++
++		spi2: spi@4027000 {
++			compatible = "allwinner,sun55i-a523-spi";
++			reg = <0x04027000 0x1000>;
++			interrupts = <GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_SPI2>, <&ccu CLK_SPI2>;
++			clock-names = "ahb", "mod";
++			dmas = <&dma 24>, <&dma 24>;
++			dma-names = "rx", "tx";
++			resets = <&ccu RST_BUS_SPI2>;
++			status = "disabled";
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++
+ 		usb_otg: usb@4100000 {
+ 			compatible = "allwinner,sun55i-a523-musb",
+ 				     "allwinner,sun8i-a33-musb";
+@@ -815,6 +895,20 @@ rtc: rtc@7090000 {
+ 			#clock-cells = <1>;
+ 		};
+ 
++		r_spi0: spi@7092000 {
++			compatible = "allwinner,sun55i-a523-spi";
++			reg = <0x07092000 0x1000>;
++			interrupts = <GIC_SPI 172 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&r_ccu CLK_BUS_R_SPI>, <&r_ccu CLK_R_SPI>;
++			clock-names = "ahb", "mod";
++			dmas = <&dma 53>, <&dma 53>;
++			dma-names = "rx", "tx";
++			resets = <&r_ccu RST_BUS_R_SPI>;
++			status = "disabled";
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++
+ 		mcu_ccu: clock-controller@7102000 {
+ 			compatible = "allwinner,sun55i-a523-mcu-ccu";
+ 			reg = <0x7102000 0x200>;
+-- 
+2.47.3
+
+

--- a/patch/kernel/archive/sunxi-6.18/patches.backports/14-arm64--dts--allwinner--t527--orangepi-4a--Enable-SPI-NOR-flash.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.backports/14-arm64--dts--allwinner--t527--orangepi-4a--Enable-SPI-NOR-flash.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chen-Yu Tsai <wens@kernel.org>
+Date: Sun, 21 Dec 2025 19:05:11 +0800
+Subject: arm64: dts: allwinner: t527: orangepi-4a: Enable SPI-NOR flash
+
+The Orangepi 4A has a SPI-NOR flash connected to spi0 on the PC pins.
+The HOLD and WP pins are not connected, and are instead pulled up by the
+supply rail.
+
+Enable spi0 and add a device node for the SPI-NOR flash.
+
+Signed-off-by: Chen-Yu Tsai <wens@kernel.org>
+---
+ .../dts/allwinner/sun55i-t527-orangepi-4a.dts     | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun55i-t527-orangepi-4a.dts b/arch/arm64/boot/dts/allwinner/sun55i-t527-orangepi-4a.dts
+index 9e6b21cf293e..055be86e5fae 100644
+--- a/arch/arm64/boot/dts/allwinner/sun55i-t527-orangepi-4a.dts
++++ b/arch/arm64/boot/dts/allwinner/sun55i-t527-orangepi-4a.dts
+@@ -400,6 +400,21 @@ &rtc {
+ 	assigned-clock-rates = <32768>;
+ };
+ 
++&spi0  {
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi0_pc_pins>, <&spi0_cs0_pc_pin>;
++	status = "okay";
++
++	flash@0 {
++		#address-cells = <1>;
++		#size-cells = <1>;
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <20000000>;
++		vcc-supply = <&reg_cldo1>;
++	};
++};
++
+ &uart0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart0_pb_pins>;
+-- 
+2.47.3
+
+

--- a/patch/kernel/archive/sunxi-6.18/series.conf
+++ b/patch/kernel/archive/sunxi-6.18/series.conf
@@ -409,6 +409,17 @@
 
 ################################################################################
 #
+#                  Backported from linux-next
+#
+################################################################################
+
+	patches.backports/11-spi--dt-bindings--sun6i--Add-compatibles-for-A523-s-SPI-controllers.patch
+	patches.backports/12-spi--sun6i--Support-A523-s-SPI-controllers.patch
+	patches.backports/13-arm64--dts--allwinner--sun55i--Add-SPI-controllers.patch
+	patches.backports/14-arm64--dts--allwinner--t527--orangepi-4a--Enable-SPI-NOR-flash.patch
+
+################################################################################
+#
 #                  Armbian patches
 #
 ################################################################################


### PR DESCRIPTION
# Description

Include the upstream support for:
- arm64: allwinner: a523: Support SPI controllers
  - https://lore.kernel.org/lkml/176642387228.913099.2681822678465821683.b4-ty@kernel.org/
  - https://lore.kernel.org/lkml/176650487726.2524343.9774305641530243477.b4-ty@kernel.org/

# How Has This Been Tested?

- [X] build sunxi64
  - This has been built since #9106
  - Run tested with Armbian_community_26.2.0-trunk.100_Radxa-cubie-a5e_trixie_edge_6.16.0_minimal.img updated to `Linux version 6.18.2-edge-sunxi64` on `Radxa Cubie A5E`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Allwinner A523 SPI controllers with multiple instances and pin configurations
  * Enabled SPI-NOR flash device support on the Orangepi 4A board

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->