### PR TITLE
docs: improve README and add Armbian Imager promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,19 @@
-<h2 align="center">
+<h3 align="center">
   <a href=#><img src="https://raw.githubusercontent.com/armbian/.github/master/profile/logosmall.png" alt="Armbian logo"></a>
   <br><br>
-</h2>
+</h3>
 
-### Purpose of This Repository
+## Purpose of This Repository
 
-The **Armbian Linux Build Framework** creates minimal, efficient, and fully [customizable operating system images](https://docs.armbian.com/#key-features) based on **Debian** or **Ubuntu**. It is designed specifically for **low-resource single board computers (SBCs)** and other embedded devices.
+The **Armbian Linux Build Framework** creates customizable OS images based on **Debian** or **Ubuntu** for **single-board computers (SBCs)** and embedded devices.
 
-This toolchain compiles a custom **Linux kernel**, **bootloader**, and **root filesystem**, providing fine-grained control over:
+It builds a complete Linux system including kernel, bootloader, and root filesystem, giving you control over versions, configuration, firmware, device trees, and system optimizations.
 
-- Kernel versions and configuration
-- Bootloader selection and customization
-- Filesystem layout and compression
-- Additional firmware, overlays, and device trees
-- System optimizations for performance and size
+The framework supports **native**, **cross**, and **containerized** builds for multiple architectures (`x86_64`, `aarch64`, `armhf`, `riscv64`) and is suitable for development, testing, production, or automation.
 
-The framework supports **native**, **cross**, and **containerized** builds for multiple architectures (`x86_64`, `aarch64`, `armhf`, `riscv64`), and is suitable for development, testing, production deployment, or automation pipelines.
+> **Looking for prebuilt images?** Use [Armbian Imager](https://github.com/armbian/imager/releases) — the easiest way to download and flash Armbian to your SD card or USB drive. Available for Linux, macOS, and Windows.
 
-It ensures **consistency across devices** while remaining modular and extensible through a variety of configuration files, templates, and user patches.
-
-### Quick Start
+## Quick Start
 
 ```bash
 git clone https://github.com/armbian/build
@@ -27,59 +21,57 @@ cd build
 ./compile.sh
 ```
 
-### Resources
+<a href="#how-to-build-an-image-or-a-kernel"><img src=".github/README.gif" alt="Build demonstration" width="100%"></a>
 
-[Documentation](https://docs.armbian.com/Developer-Guide_Overview/) • [Website](https://www.armbian.com) • [Blog](https://blog.armbian.com) • [Community Forums](https://forum.armbian.com)
+## Build Host Requirements
 
+### Hardware
+- **RAM:** ≥8GB (less with `KERNEL_BTF=no`)
+- **Disk:** ~50GB free space
+- **Architecture:** x86_64, aarch64, or riscv64
 
+### Operating System
+- **Native builds:** Armbian or Ubuntu 24.04 (Noble)
+- **Containerized:** Any Docker-capable Linux
+- **Windows:** WSL2 with Armbian/Ubuntu 24.04
 
-<a href="#how-to-build-an-image-or-a-kernel"><img src=".github/README.gif" alt="Armbian logo" width="100%"></a>
+### Software
+- Superuser privileges (`sudo` or root)
+- Up-to-date system (outdated Docker or other tools can cause failures)
 
-### Build Host Requirements
+## Resources
 
-- **Supported Architectures:** `x86_64`, `aarch64`, `riscv64`
-- **System:** VM, container, or bare-metal with:
-  - **≥ 8GB RAM** (less with `KERNEL_BTF=no`)
-  - **~50GB disk space**
-- **Operating System:**
-  - Armbian / Ubuntu 24.04 (Noble) for native builds
-  - Any Docker-capable Linux for containerized setup
-- **Windows:** Windows 10/11 with WSL2 running Armbian / Ubuntu 24.04
-- **Access:** Superuser rights (`sudo` or `root`)
-- **Important:** Keep your system up-to-date — outdated tools (e.g., Docker) can cause issues.
+- **[Documentation](https://docs.armbian.com/Developer-Guide_Overview/)** — Comprehensive guides for building, configuring, and customizing
+- **[Website](https://www.armbian.com)** — News, features, and board information
+- **[Blog](https://blog.armbian.com)** — Development updates and technical articles
+- **[Forums](https://forum.armbian.com)** — Community support and discussions
 
-### Download
+## Contributing
 
-Prebuilt Armbian OS Images: <https://www.armbian.com/download>
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on reporting issues, submitting changes, and contributing code.
 
-### Contribute
+## Support
 
-Learn how to report issues, suggest improvements, or submit code: [CONTRIBUTING.md](CONTRIBUTING.md)
+### Community Forums
+Get help from users and contributors on troubleshooting, configuration, and development.
+👉 [forum.armbian.com](https://forum.armbian.com)
 
-### Support
+### Real-time Chat
+Join discussions with developers and community members on Discord, IRC, or Matrix.
+👉 [Community Chat](https://docs.armbian.com/Community_IRC/)
 
-Armbian offers multiple support channels, depending on your needs:
+### Paid Consultation
+For commercial projects, guaranteed response times, or advanced needs, paid support is available from Armbian maintainers.
+👉 [Contact us](https://www.armbian.com/contact)
 
-- **Community Forums**  
-  Get help from fellow users and contributors on a wide range of topics — from troubleshooting to development.  
-  👉 [forum.armbian.com](https://forum.armbian.com)
+## Contributors
 
-- **Discord / IRC/ Matrix Chat**  
-  Join real-time discussions with developers and community members for faster feedback and collaboration.  
-  👉 [Community Chat](https://docs.armbian.com/Community_IRC/)
-
-- **Paid Consultation**  
-  For advanced needs, commercial projects, or guaranteed response times, paid support is available directly from Armbian maintainers.  
-  👉 [Contact us](https://www.armbian.com/contact) to discuss consulting options.
-
-### Contributors
-
-Thank you to all the people who already contributed to Armbian!
+Thank you to everyone who has contributed to Armbian!
 
 <a href="https://github.com/armbian/build/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=armbian/build" />
+  <img alt="Contributors" src="https://contrib.rocks/image?repo=armbian/build" />
 </a>
 
 ## Armbian Partners
 
-Armbian's [partnership program](https://forum.armbian.com/subscriptions) helps to support Armbian and the Armbian community! Please take a moment to familiarize yourself with [our Partners](https://armbian.com/partners).
+Our [partnership program](https://forum.armbian.com/subscriptions) supports Armbian's development and community. Learn more about [our Partners](https://armbian.com/partners).


### PR DESCRIPTION
## Summary
- Restructured README for better scannability and information hierarchy
- Added prominent Armbian Imager recommendation at the top with callout block
- Improved Build Host Requirements organization (Hardware/OS/Software subsections)
- Simplified and clarified language throughout
- Added descriptive link text in Resources section
- Removed redundant "Download Prebuilt Images" section

## Key Changes
1. **Armbian Imager Promotion**
   - Added callout blockquote near the top linking to Armbian Imager
   - Clear guidance that Imager is the recommended way to flash images

2. **Better Structure**
   - Consistent heading levels throughout
   - Grouped related information under clear sections
   - Improved information hierarchy (most important info first)

3. **Improved Clarity**
   - Removed redundant wording
   - Better flow: purpose → quick start → requirements → resources
   - Descriptive link text instead of bare URLs

## Test Plan
- [x] README renders correctly
- [x] All links are valid
- [x] Information is accurate and up-to-date
- [x] Armbian Imager link points to correct location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Restructured sections for improved clarity and navigation.
  * Expanded build model descriptions to include native, cross, and containerized build options with explicit multi-architecture support.
  * Added prominent callout highlighting Armbian Imager as a source for prebuilt images.
  * Reorganized Resources section with focused guidance on contributions, community channels, and partnerships.
  * Refined language and tone throughout for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->