### PR TITLE
fix(rootfs): unset GIT_FIXED_WORKDIR after debootstrap/mmdebstrap clone

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -100,35 +100,38 @@ function create_new_rootfs_cache_via_debootstrap() {
 	case "${DISTRIBUTION}" in
 		Ubuntu)
 			if [[ "${LEGACY_DEBOOTSTRAP,,}" == "yes" ]]; then
-				export GIT_FIXED_WORKDIR="debootstrap-ubuntu-devel"
-				fetch_from_repo "https://git.launchpad.net/ubuntu/+source/debootstrap" "debootstrap-ubuntu-devel" "tag:import/1.0.118ubuntu1.13"
-				debootstrap_wanted_dir="${SRC}/cache/sources/${GIT_FIXED_WORKDIR}"
+				declare debootstrap_name="debootstrap-ubuntu-devel"
+				GIT_FIXED_WORKDIR="${debootstrap_name}" \
+					fetch_from_repo "https://git.launchpad.net/ubuntu/+source/debootstrap" "${debootstrap_name}" "tag:import/1.0.118ubuntu1.13"
+				debootstrap_wanted_dir="${SRC}/cache/sources/${debootstrap_name}"
 				debootstrap_default_script="gutsy"
 				debootstrap_version="$(sed 's/.*(\(.*\)).*/\1/; q' "${debootstrap_wanted_dir}/debian/changelog")"
 				debootstrap_bin="${debootstrap_wanted_dir}/debootstrap"
 			else
-				export GIT_FIXED_WORKDIR="mmdebstrap-ubuntu-devel"
+				declare debootstrap_name="mmdebstrap-ubuntu-devel"
 				#FIXME: branch should be a variable eventually
-				fetch_from_repo "https://git.launchpad.net/ubuntu/+source/mmdebstrap" "${GIT_FIXED_WORKDIR}" "branch:ubuntu/noble"
-				debootstrap_wanted_dir="${SRC}/cache/sources/${GIT_FIXED_WORKDIR}"
+				GIT_FIXED_WORKDIR="${debootstrap_name}" \
+					fetch_from_repo "https://git.launchpad.net/ubuntu/+source/mmdebstrap" "${debootstrap_name}" "branch:ubuntu/noble"
+				debootstrap_wanted_dir="${SRC}/cache/sources/${debootstrap_name}"
 				debootstrap_version="$(sed 's/.*(\(.*\)).*/\1/; q' "${debootstrap_wanted_dir}/debian/changelog")"
 				debootstrap_bin="${debootstrap_wanted_dir}/mmdebstrap"
 			fi
 			;;
 		Debian)
 			if [[ "${LEGACY_DEBOOTSTRAP,,}" == "yes" ]]; then
-				export GIT_FIXED_WORKDIR="debootstrap-debian-devel"
-				fetch_from_repo "https://salsa.debian.org/installer-team/debootstrap.git" "debootstrap-debian-devel" "branch:master"
-				debootstrap_wanted_dir="${SRC}/cache/sources/${GIT_FIXED_WORKDIR}"
+				declare debootstrap_name="debootstrap-debian-devel"
+				GIT_FIXED_WORKDIR="${debootstrap_name}" \
+					fetch_from_repo "https://salsa.debian.org/installer-team/debootstrap.git" "${debootstrap_name}" "branch:master"
+				debootstrap_wanted_dir="${SRC}/cache/sources/${debootstrap_name}"
 				debootstrap_default_script="sid"
 				debootstrap_version="$(sed 's/.*(\(.*\)).*/\1/; q' "${debootstrap_wanted_dir}/debian/changelog")"
 				debootstrap_bin="${debootstrap_wanted_dir}/debootstrap"
 			else
-				export GIT_FIXED_WORKDIR="mmdebstrap-debian-devel"
+				declare debootstrap_name="mmdebstrap-debian-devel"
 				#FIXME: branch should be a variable eventually
-				fetch_from_repo "https://gitlab.mister-muffin.de/josch/mmdebstrap" "${GIT_FIXED_WORKDIR}" "branch:main"
-				debootstrap_wanted_dir="${SRC}/cache/sources/${GIT_FIXED_WORKDIR}"
-				debootstrap_default_script="sid"
+				GIT_FIXED_WORKDIR="${debootstrap_name}" \
+					fetch_from_repo "https://gitlab.mister-muffin.de/josch/mmdebstrap" "${debootstrap_name}" "branch:main"
+				debootstrap_wanted_dir="${SRC}/cache/sources/${debootstrap_name}"
 				debootstrap_version="$(sed 's/^## \[\([^]]*\)\].*/\1/; q' "${debootstrap_wanted_dir}/CHANGELOG.md")"
 				debootstrap_bin="${debootstrap_wanted_dir}/mmdebstrap"
 			fi
@@ -137,9 +140,6 @@ function create_new_rootfs_cache_via_debootstrap() {
 			exit_with_error "Unknown distribution for ${LOG_NAME}" "${DISTRIBUTION}"
 			;;
 	esac
-
-	# Clear GIT_FIXED_WORKDIR after use to prevent it from affecting subsequent fetch_from_repo calls
-	unset GIT_FIXED_WORKDIR
 
 	run_host_command_logged chmod a+x "${debootstrap_bin}"
 	display_alert "${LOG_NAME} version" "'${debootstrap_version}' for ${debootstrap_bin}" "info"


### PR DESCRIPTION
# Description

Fix GIT_FIXED_WORKDIR environment variable leak after mmdebstrap/debootstrap clone in rootfs creation.

When building rootfs, "GIT_FIXED_WORKDIR" is exported and set to "mmdebstrap-debian-devel" (or "mmdebstrap-ubuntu-devel" for Ubuntu), but never unset after use. This causes any subsequent "fetch_from_repo()" calls (from extensions in "post_build_image" hook) to clone repositories into the wrong directory, as "fetch_from_repo()" uses "GIT_FIXED_WORKDIR" to override the target directory.

This fix adds unset GIT_FIXED_WORKDIR after the debootstrap/mmdebstrap clone block.

# How Has This Been Tested?
- [x] Build image from scratch with extension using "fetch_from_repo()"

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal workspace handling to avoid exporting build environment variables, reducing unintended side effects during image/bootstrap creation and making behavior consistent across distributions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->