### PR TITLE
Genio: Change INSTALL_ARMBIAN_FIRMWARE to 'yes'

### DIFF
--- a/config/sources/families/genio.conf
+++ b/config/sources/families/genio.conf
@@ -2,7 +2,7 @@ declare -g LINUXFAMILY=genio
 declare -g OVERLAY_DIR="/boot/dtb/mediatek/overlay"
 declare -g ARCH=arm64
 declare -g GOVERNOR=performance
-declare -g INSTALL_ARMBIAN_FIRMWARE=no
+declare -g INSTALL_ARMBIAN_FIRMWARE=yes
 
 # U-Boot bootscript configuration
 declare -g BOOTCONFIG="none" # Skip U-Boot compilation


### PR DESCRIPTION
# Description

Fix oversight to allow installing hardware firmware required for mediatek wifi, hw accel, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration to enable automatic Armbian firmware installation for genio devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->