### PR TITLE
framework armbian-kernel.sh: our config/kernel should take precedence over kernel tree's defconfig

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -528,9 +528,7 @@ function armbian_kernel_config_apply_opts_from_arrays() {
 
 		for opt_m in "${opts_m[@]}"; do
 			actual_opt_value='m'
-			if egrep -q "(CONFIG_)?${opt_m}=m" "${kernel_config_source_filename}"; then
-				: # do nothing
-			elif egrep -q "(CONFIG_)?${opt_m}=y" "${kernel_config_source_filename}" .config; then
+			if egrep -q "(CONFIG_)?${opt_m}=y" "${kernel_config_source_filename}"; then
 				actual_opt_value='y'
 			fi
 			kernel_config_set_${actual_opt_value} "${opt_m}"


### PR DESCRIPTION
# Description

@rpardini found an edge case in `opts_m` vs `opts_y` handling, where if the kernel's `defconfig` had `=y`, that took precedence over our `config/kernel/linux-${BOARD}-$BRANCH.config`
The specific case was `BOARD=rock-5b BRANCH=vendor` & `CONFIG_DUMMY`. our `config/kernel` had `=m`, but defconfig had `=y` so `rewrite-kernel-config` was changing `config/kernel/` to `=y`.
Note: this is especially interesting, not from an armbian POV but just generically, if it's built-in you can only have one dummy network interface, but a module allows multiple.

along the way I also removed duplicate logging messages as `kernel_config_set_foo` already logs what it's doing.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh rewrite-kernel-config BOARD=rock-5b BRANCH=vendor DEBUG=yes`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed noisy debug alerts during kernel option processing to present clearer output to users.
  * Consolidated and simplified kernel option application so options are determined once and applied consistently.
  * Tightened detection logic distinguishing module vs built-in options for more reliable behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->