### PR TITLE
SpacemiT: Fixup eMMC boot on the MusePi Pro "SPINOR"

### DIFF
--- a/patch/u-boot/legacy/u-boot-spacemit-k1/003-SpacemiT-K1X-Fixups.patch
+++ b/patch/u-boot/legacy/u-boot-spacemit-k1/003-SpacemiT-K1X-Fixups.patch
@@ -1,17 +1,17 @@
-From 45378fb7a03cf3e68f3e887843d27e99fe468843 Mon Sep 17 00:00:00 2001
+From 08b4f3a1e38621cdef2d5a41d048770057d9fa66 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@gmail.com>
-Date: Fri, 12 Dec 2025 14:05:48 -0500
+Date: Sat, 27 Dec 2025 18:12:33 -0500
 Subject: [PATCH] SpacemiT K1X Fixups
 
 Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
 ---
- board/spacemit/k1-x/k1x.c | 20 ++++++++++----------
+ board/spacemit/k1-x/k1x.c | 28 ++++++++++------------------
  configs/k1_defconfig      |  1 +
  include/configs/k1-x.h    | 22 ++++++++++------------
- 3 files changed, 21 insertions(+), 22 deletions(-)
+ 3 files changed, 21 insertions(+), 30 deletions(-)
 
 diff --git a/board/spacemit/k1-x/k1x.c b/board/spacemit/k1-x/k1x.c
-index c48b4e74..27661d32 100644
+index c48b4e74..ab1d1264 100644
 --- a/board/spacemit/k1-x/k1x.c
 +++ b/board/spacemit/k1-x/k1x.c
 @@ -529,8 +529,8 @@ void _load_env_from_blk(struct blk_desc *dev_desc, const char *dev_name, int dev
@@ -25,7 +25,7 @@ index c48b4e74..27661d32 100644
  
  	/*load env.txt and import to uboot*/
  	memset((void *)CONFIG_SPL_LOAD_FIT_ADDRESS, 0, CONFIG_ENV_SIZE);
-@@ -747,7 +747,7 @@ void setenv_boot_mode(void)
+@@ -747,34 +747,26 @@ void setenv_boot_mode(void)
  	u32 boot_mode = get_boot_mode();
  	switch (boot_mode) {
  	case BOOT_MODE_NAND:
@@ -33,15 +33,18 @@ index c48b4e74..27661d32 100644
 +		env_set("devtype", "nand");
  		break;
  	case BOOT_MODE_NOR:
- 		char *blk_name;
-@@ -758,23 +758,23 @@ void setenv_boot_mode(void)
- 			return;
- 		}
- 
+-		char *blk_name;
+-		int blk_index;
+-
+-		if (get_available_boot_blk_dev(&blk_name, &blk_index)){
+-			printf("can not get available blk dev\n");
+-			return;
+-		}
+-
 -		env_set("boot_device", "nor");
 -		env_set("boot_devnum", simple_itoa(blk_index));
-+		env_set("devtype", "nor");
-+		env_set("devnum", simple_itoa(blk_index));
++		env_set("devtype", "mmc");
++		env_set("devnum", simple_itoa(MMC_DEV_EMMC));
  		break;
  	case BOOT_MODE_EMMC:
 -		env_set("boot_device", "mmc");
@@ -66,10 +69,10 @@ index c48b4e74..27661d32 100644
  	}
  }
 diff --git a/configs/k1_defconfig b/configs/k1_defconfig
-index 8861f32a..1b388a24 100644
+index 29aca4ce..949ab18b 100644
 --- a/configs/k1_defconfig
 +++ b/configs/k1_defconfig
-@@ -291,3 +291,4 @@ CONFIG_PRINT_TIMESTAMP=y
+@@ -293,3 +293,4 @@ CONFIG_PRINT_TIMESTAMP=y
  # CONFIG_SPL_SHA256 is not set
  CONFIG_ZSTD=y
  # CONFIG_HEXDUMP is not set
@@ -124,5 +127,5 @@ index b15d2e0b..b7311ac0 100644
  
  
 -- 
-2.47.3
+2.51.0
 


### PR DESCRIPTION
Its a minor change that allows the unit to boot from eMMC without any unnecessary dancing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded bootloader version to 2.51.0
  * Enhanced boot device initialization with improved error handling for unavailable devices
  * Updated memory address configurations for kernel, ramdisk, device tree, and overlay images
  * Refined boot environment variable assignments for greater flexibility
  * Removed legacy splash image and LED-related boot configurations
  * Added device tree overlay support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->