### PR TITLE
Missing upstream package mousetweaks

### DIFF
--- a/config/desktop/trixie/environments/cinnamon/config_base/packages
+++ b/config/desktop/trixie/environments/cinnamon/config_base/packages
@@ -65,7 +65,7 @@ lm-sensors
 lxtask
 mesa-utils
 mousepad
-mousetweaks
+#mousetweaks
 nemo
 nemo-data
 nemo-fileroller

--- a/config/desktop/trixie/environments/xfce/config_base/packages
+++ b/config/desktop/trixie/environments/xfce/config_base/packages
@@ -55,7 +55,7 @@ lm-sensors
 lxtask
 mesa-utils
 mousepad
-mousetweaks
+#mousetweaks
 numix-gtk-theme
 numix-icon-theme
 numix-icon-theme-circle


### PR DESCRIPTION
# Description

https://packages.debian.org/trixie/mousetweaks

Not sure that this is urgently needed anyway

# How Has This Been Tested?

- [x] Generated matrix from branch

# Checklist:

- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed mousetweaks from default Cinnamon and XFCE desktop environment installations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->