### PR TITLE
fix: replace comm with grep to support uutils coreutils

### DIFF
--- a/extensions/gen-sample-extension-docs.sh
+++ b/extensions/gen-sample-extension-docs.sh
@@ -49,7 +49,8 @@ MASTER_HEADER
 
 	[[ $HOOK_POINT_CALLS_COUNT -gt $HOOK_POINT_CALLS_UNIQUE_COUNT ]] && {
 		# Some hook points were called multiple times, determine which.
-		HOOK_POINTS_WITH_MULTIPLE_CALLS=$(comm -13 <(sort < "${EXTENSION_MANAGER_TMP_DIR}/hook_point_calls.txt" | uniq) <(sort < "${EXTENSION_MANAGER_TMP_DIR}/hook_point_calls.txt") | sort | uniq | xargs echo -n)
+		# Find duplicates without comm (uutils coreutils compatible)
+		HOOK_POINTS_WITH_MULTIPLE_CALLS=$(sort < "${EXTENSION_MANAGER_TMP_DIR}/hook_point_calls.txt" | uniq -d | xargs echo -n)
 
 		cat << MULTIPLE_CALLS_WARNING
 - *Important:* The following hook points where called multiple times during the documentation generation. This can be indicative of a bug in the build system. Please check the sources for the invocation of the following hooks: \`${HOOK_POINTS_WITH_MULTIPLE_CALLS}\`.

--- a/lib/functions/general/extensions.sh
+++ b/lib/functions/general/extensions.sh
@@ -510,8 +510,8 @@ function enable_extension() {
 	after_function_list="$(compgen -A function)"
 
 	# compare before and after, thus getting the functions defined by the extension.
-	# comm is oldskool. we like it. go "man comm" to understand -13 below
-	new_function_list="$(comm -13 <(echo "$before_function_list" | sort) <(echo "$after_function_list" | sort))"
+	# Avoid comm for uutils coreutils compatibility
+	new_function_list="$(grep -vxFf <(echo "$before_function_list") <(echo "$after_function_list") || true)"
 
 	# iterate over defined functions, store them in global associative array extension_function_info
 	for newly_defined_function in ${new_function_list}; do

--- a/lib/functions/logging/capture.sh
+++ b/lib/functions/logging/capture.sh
@@ -18,7 +18,8 @@ function do_capturing_defs() {
 
 	post_exec_vars="$(compgen -A variable)"
 
-	new_vars_list="$(comm -13 <(echo "$pre_exec_vars" | grep -E '[[:upper:]]+' | grep -v -e "^BASH_" | sort) <(echo "${post_exec_vars}" | grep -E '[[:upper:]]+' | grep -v -e "^BASH_" | sort))"
+	# Avoid comm for uutils coreutils compatibility
+	new_vars_list="$(grep -vxFf <(echo "$pre_exec_vars" | grep -E '[[:upper:]]+' | grep -v -e "^BASH_") <(echo "${post_exec_vars}" | grep -E '[[:upper:]]+' | grep -v -e "^BASH_") || true)"
 
 	for onevar in ${new_vars_list}; do
 		all_vars_array+=("$(declare -p "${onevar}")")


### PR DESCRIPTION
## Summary

Fix build failure on Ubuntu 25.04+ caused by uutils coreutils compatibility

## Problem

Ubuntu 25.04+ replaced GNU coreutils with [uutils coreutils](https://github.com/uutils/coreutils), a Rust-based reimplementation of Unix core utilities (`sort`, `comm`, `cat`, `ls`, etc.).

**Note:** These are two different projects with the same package name:

| Project | Version | Language | Used by |
|---------|---------|----------|---------|
| GNU coreutils | 9.x | C | Ubuntu ≤24.04, Debian, most distros |
| uutils coreutils | 0.x | Rust | Ubuntu ≥25.04 |

The uutils `comm` doesn't recognize sort output as sorted, causing errors:

```
$ ./compile.sh EXPERT=yes
[🌿] Applying cmdline param [ 'EXPERT': '(unset)' --> 'yes' early ]
[🌱] Using prebuilt Armbian image as base for 'ubuntu-noble' [ DOCKER_ARMBIAN_BASE_IMAGE: ghcr.io/armbian/docker-armbian-build:armbian-ubuntu-noble-latest ]
[🌿] Docker info [ Docker 28.2.2 Kernel:6.17.0-8-generic RAM:6.944GiB CPUs:8 OS:'Ubuntu 25.10' hostname 'user-Orange-Pi-5' under 'Linux' - buildx:no - loop-hacks:yes static-loops:no ]
[🌱] Creating [ .dockerignore ]
[🌱] Docker launcher [ enabling all extensions looking for Docker dependencies ]
[🌿] Extension search [ Searching in directory: "/home/user/build/extensions" ]
[🌿] Extension search result [ Found 15 extensions in "/home/user/build/extensions" ]
[🌿] Extension search [ Searching in directory: "/home/user/build/userpatches/extensions" ]
[🚸] Extension search [ Directory does not exist: "/home/user/build/userpatches/extensions" ]
comm: file 1 is not in sorted order
comm: input is not in sorted order
[💥] Error  1 occurred in SUBSHELL [ SUBSHELL at /home/user/build/lib/functions/general/extensions.sh:514 ]
[💥] Error 1 occurred in main shell [ at /home/user/build/lib/functions/general/extensions.sh:514
               enable_extension() --> lib/functions/general/extensions.sh:514
   enable_extensions_with_hostdeps_builtin_and_user() --> lib/functions/general/extensions.sh:601
   docker_cli_prepare_dockerfile() --> lib/functions/host/docker.sh:261
                do_with_logging() --> lib/functions/logging/section-logging.sh:81
                 cli_docker_run() --> lib/functions/cli/cli-docker.sh:53
        armbian_cli_run_command() --> lib/functions/cli/utils-cli.sh:136
                 cli_entrypoint() --> lib/functions/cli/entrypoint.sh:208
                           main() --> ./compile.sh:50
 ]
[💥] Cleaning up [ please wait for cleanups to finish ]
```

This breaks the build when running on the host (before Docker), specifically in:
- Extension loading (`enable_extension()`)
- Variable capture (`do_capturing_defs()`)
- Documentation generation

## Solution

Replace `comm` with alternatives that don't depend on its sorting requirements:
- `grep -vxFf` for set difference (lines in B but not in A)
- `sort | uniq -d` for finding duplicates

Works identically on GNU coreutils, uutils coreutils, and BSD/macOS.

## Files Changed

| File | Change |
|------|--------|
| `lib/functions/general/extensions.sh` | Replace comm with grep for function list diff |
| `lib/functions/logging/capture.sh` | Replace comm with grep for variable list diff |
| `extensions/gen-sample-extension-docs.sh` | Replace comm with uniq -d for duplicate detection |

## Testing

- [x] Ubuntu 25.10 (uutils coreutils 0.2.2) - build succeeds
- [x] Ubuntu 24.04 (GNU coreutils 9.4) - backward compatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced fragile detection/filter pipelines with more robust sorting/uniqueness and fixed-string filtering to improve compatibility with alternate coreutils.
  * Preserved existing warnings while tolerating missing matches so executions are less brittle.
  * Added safeguards to avoid recording duplicate metadata when detecting newly added items, improving stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->