### PR TITLE
meson64-6.19: de-bork PCIe, again (missed a patch from 6.18)

### DIFF
--- a/patch/kernel/archive/meson64-6.19/x-PATCH-v7-2-2-PCI-dwc-Remove-redundant-MPS-configuration.patch
+++ b/patch/kernel/archive/meson64-6.19/x-PATCH-v7-2-2-PCI-dwc-Remove-redundant-MPS-configuration.patch
@@ -1,59 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <18255117159@163.com>
-Date: Fri, 28 Nov 2025 01:09:08 +0800
-Subject: PCI: dwc: Remove redundant MPS configuration
-
-The Meson PCIe controller driver manually configures maximum payload
-size (MPS) through meson_set_max_payload, duplicating functionality now
-centralized in the PCI core.  Deprecating redundant code simplifies the
-driver and aligns it with the consolidated MPS management strategy,
-improving long-term maintainability.
-
-Signed-off-by: Hans Zhang <18255117159@163.com>
----
- drivers/pci/controller/dwc/pci-meson.c | 17 ----------
- 1 file changed, 17 deletions(-)
-
-diff --git a/drivers/pci/controller/dwc/pci-meson.c b/drivers/pci/controller/dwc/pci-meson.c
-index 111111111111..222222222222 100644
---- a/drivers/pci/controller/dwc/pci-meson.c
-+++ b/drivers/pci/controller/dwc/pci-meson.c
-@@ -273,22 +273,6 @@ static int meson_size_to_payload(struct meson_pcie *mp, int size)
- 	return fls(size) - 8;
- }
- 
--static void meson_set_max_payload(struct meson_pcie *mp, int size)
--{
--	struct dw_pcie *pci = &mp->pci;
--	u32 val;
--	u16 offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
--	int max_payload_size = meson_size_to_payload(mp, size);
--
--	val = dw_pcie_readl_dbi(pci, offset + PCI_EXP_DEVCTL);
--	val &= ~PCI_EXP_DEVCTL_PAYLOAD;
--	dw_pcie_writel_dbi(pci, offset + PCI_EXP_DEVCTL, val);
--
--	val = dw_pcie_readl_dbi(pci, offset + PCI_EXP_DEVCTL);
--	val |= PCIE_CAP_MAX_PAYLOAD_SIZE(max_payload_size);
--	dw_pcie_writel_dbi(pci, offset + PCI_EXP_DEVCTL, val);
--}
--
- static void meson_set_max_rd_req_size(struct meson_pcie *mp, int size)
- {
- 	struct dw_pcie *pci = &mp->pci;
-@@ -393,7 +377,6 @@ static int meson_pcie_host_init(struct dw_pcie_rp *pp)
- 
- 	pp->bridge->ops = &meson_pci_ops;
- 
--	meson_set_max_payload(mp, MAX_PAYLOAD_SIZE);
- 	meson_set_max_rd_req_size(mp, MAX_READ_REQ_SIZE);
- 
- 	return 0;
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Hans Zhang <18255117159@163.com>
 Date: Fri, 28 Nov 2025 01:09:07 +0800
 Subject: PCI: Configure Root Port MPS during host probing
 
@@ -112,6 +58,61 @@ index 111111111111..222222222222 100644
  	if (!bridge || !pci_is_pcie(bridge))
  		return;
  
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hans Zhang <18255117159@163.com>
+Date: Fri, 28 Nov 2025 01:09:08 +0800
+Subject: PCI: dwc: Remove redundant MPS configuration
+
+The Meson PCIe controller driver manually configures maximum payload
+size (MPS) through meson_set_max_payload, duplicating functionality now
+centralized in the PCI core.  Deprecating redundant code simplifies the
+driver and aligns it with the consolidated MPS management strategy,
+improving long-term maintainability.
+
+Signed-off-by: Hans Zhang <18255117159@163.com>
+Reviewed-by: Niklas Cassel <cassel@kernel.org>
+---
+ drivers/pci/controller/dwc/pci-meson.c | 17 ----------
+ 1 file changed, 17 deletions(-)
+
+diff --git a/drivers/pci/controller/dwc/pci-meson.c b/drivers/pci/controller/dwc/pci-meson.c
+index 111111111111..222222222222 100644
+--- a/drivers/pci/controller/dwc/pci-meson.c
++++ b/drivers/pci/controller/dwc/pci-meson.c
+@@ -273,22 +273,6 @@ static int meson_size_to_payload(struct meson_pcie *mp, int size)
+ 	return fls(size) - 8;
+ }
+ 
+-static void meson_set_max_payload(struct meson_pcie *mp, int size)
+-{
+-	struct dw_pcie *pci = &mp->pci;
+-	u32 val;
+-	u16 offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+-	int max_payload_size = meson_size_to_payload(mp, size);
+-
+-	val = dw_pcie_readl_dbi(pci, offset + PCI_EXP_DEVCTL);
+-	val &= ~PCI_EXP_DEVCTL_PAYLOAD;
+-	dw_pcie_writel_dbi(pci, offset + PCI_EXP_DEVCTL, val);
+-
+-	val = dw_pcie_readl_dbi(pci, offset + PCI_EXP_DEVCTL);
+-	val |= PCIE_CAP_MAX_PAYLOAD_SIZE(max_payload_size);
+-	dw_pcie_writel_dbi(pci, offset + PCI_EXP_DEVCTL, val);
+-}
+-
+ static void meson_set_max_rd_req_size(struct meson_pcie *mp, int size)
+ {
+ 	struct dw_pcie *pci = &mp->pci;
+@@ -393,7 +377,6 @@ static int meson_pcie_host_init(struct dw_pcie_rp *pp)
+ 
+ 	pp->bridge->ops = &meson_pci_ops;
+ 
+-	meson_set_max_payload(mp, MAX_PAYLOAD_SIZE);
+ 	meson_set_max_rd_req_size(mp, MAX_READ_REQ_SIZE);
+ 
+ 	return 0;
 -- 
 Armbian
 

--- a/patch/kernel/archive/meson64-6.19/x-PCI-meson-Remove-meson_pcie_link_up-timeout-message-speed-check.patch
+++ b/patch/kernel/archive/meson64-6.19/x-PCI-meson-Remove-meson_pcie_link_up-timeout-message-speed-check.patch
@@ -1,0 +1,86 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjorn Helgaas <bhelgaas@google.com>
+Date: Mon, 3 Nov 2025 16:19:26 -0600
+Subject: PCI: meson: Remove meson_pcie_link_up() timeout, message, speed check
+
+Previously meson_pcie_link_up() only returned true if the link was in the
+L0 state.  This was incorrect because hardware autonomously manages
+transitions between L0, L0s, and L1 while both components on the link stay
+in D0.  Those states should all be treated as "link is active".
+
+Returning false when the device was in L0s or L1 broke config accesses
+because dw_pcie_other_conf_map_bus() fails if the link is down, which
+caused errors like this:
+
+  meson-pcie fc000000.pcie: error: wait linkup timeout
+  pci 0000:01:00.0: BAR 0: error updating (0xfc700004 != 0xffffffff)
+
+Remove the LTSSM state check, timeout, speed check, and error message from
+meson_pcie_link_up(), the dw_pcie_ops.link_up() method, so it is a simple
+boolean check of whether the link is active.  Timeouts and and error
+messages are handled at a higher level, e.g., dw_pcie_wait_for_link().
+
+Fixes: 9c0ef6d34fdb ("PCI: amlogic: Add the Amlogic Meson PCIe controller driver")
+Reported-by: Linnaea Lavia <linnaea-von-lavia@live.com>
+Closes: https://lore.kernel.org/r/DM4PR05MB102707B8CDF84D776C39F22F2C7F0A@DM4PR05MB10270.namprd05.prod.outlook.com
+Signed-off-by: Bjorn Helgaas <bhelgaas@google.com>
+Tested-by: Linnaea Lavia <linnaea-von-lavia@live.com>
+Cc: stable@vger.kernel.org
+Reviewed-by: Neil Armstrong <neil.armstrong@linaro.org>
+Tested-by: Neil Armstrong <neil.armstrong@linaro.org> # on BananaPi M2S
+---
+ drivers/pci/controller/dwc/pci-meson.c | 38 +---------
+ 1 file changed, 4 insertions(+), 34 deletions(-)
+
+diff --git a/drivers/pci/controller/dwc/pci-meson.c b/drivers/pci/controller/dwc/pci-meson.c
+index 111111111111..222222222222 100644
+--- a/drivers/pci/controller/dwc/pci-meson.c
++++ b/drivers/pci/controller/dwc/pci-meson.c
+@@ -334,40 +334,10 @@ static struct pci_ops meson_pci_ops = {
+ static bool meson_pcie_link_up(struct dw_pcie *pci)
+ {
+ 	struct meson_pcie *mp = to_meson_pcie(pci);
+-	struct device *dev = pci->dev;
+-	u32 speed_okay = 0;
+-	u32 cnt = 0;
+-	u32 state12, state17, smlh_up, ltssm_up, rdlh_up;
+-
+-	do {
+-		state12 = meson_cfg_readl(mp, PCIE_CFG_STATUS12);
+-		state17 = meson_cfg_readl(mp, PCIE_CFG_STATUS17);
+-		smlh_up = IS_SMLH_LINK_UP(state12);
+-		rdlh_up = IS_RDLH_LINK_UP(state12);
+-		ltssm_up = IS_LTSSM_UP(state12);
+-
+-		if (PM_CURRENT_STATE(state17) < PCIE_GEN3)
+-			speed_okay = 1;
+-
+-		if (smlh_up)
+-			dev_dbg(dev, "smlh_link_up is on\n");
+-		if (rdlh_up)
+-			dev_dbg(dev, "rdlh_link_up is on\n");
+-		if (ltssm_up)
+-			dev_dbg(dev, "ltssm_up is on\n");
+-		if (speed_okay)
+-			dev_dbg(dev, "speed_okay\n");
+-
+-		if (smlh_up && rdlh_up && ltssm_up && speed_okay)
+-			return true;
+-
+-		cnt++;
+-
+-		udelay(10);
+-	} while (cnt < WAIT_LINKUP_TIMEOUT);
+-
+-	dev_err(dev, "error: wait linkup timeout\n");
+-	return false;
++	u32 state12;
++
++	state12 = meson_cfg_readl(mp, PCIE_CFG_STATUS12);
++	return IS_SMLH_LINK_UP(state12) && IS_RDLH_LINK_UP(state12);
+ }
+ 
+ static int meson_pcie_host_init(struct dw_pcie_rp *pp)
+-- 
+Armbian
+


### PR DESCRIPTION
- `b4 am -o- "https://lore.kernel.org/linux-amlogic/20251103221930.1831376-1-helgaas@kernel.org/"  > patch/kernel/archive/meson64-6.19/x-PCI-meson-Remove-meson_pcie_link_up-timeout-message-speed-check.patch`
  - this was the trick, I had mixed up with a different one in 6.18, half of which (`elbi` stuff) actually landed in 6.19-rc1
- `b4 am -o- "https://lore.kernel.org/linux-amlogic/20251127170908.14850-1-18255117159@163.com/" > patch/kernel/archive/meson64-6.19/x-PATCH-v7-2-2-PCI-dwc-Remove-redundant-MPS-configuration.patch`
  - to de-slow PCIe on meson64 (simple refresh, we already had it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized PCIe driver configuration by consolidating max payload setup during host probing.

* **Refactor**
  * Simplified link detection logic in Meson PCIe driver by removing redundant timeout and speed verification from the detection pathway.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->