### PR TITLE
Remove libfuse2t64 from package list

### DIFF
--- a/config/cli/trixie/main/packages.additional
+++ b/config/cli/trixie/main/packages.additional
@@ -26,7 +26,6 @@ iperf3
 iptables
 keyboard-configuration
 libdigest-sha-perl
-libfuse2t64
 libnl-3-dev
 libnl-genl-3-dev
 libnss-myhostname


### PR DESCRIPTION
# Description

Drop dropped package.

# How Has This Been Tested?

- [x] Generate artifacts

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB-C/DisplayPort alt-mode handling to validate connector pin compatibility, add compatibility warnings, fix an allocation-related resource-release path, and enhance logging for diagnostics.
* **Chores**
  * Removed an unused package dependency from the system configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->