### PR TITLE
Helios64: fix Type-C PHY  registration

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.18/add-board-helios64.patch
@@ -252,7 +252,7 @@ index 111111111111..222222222222 100644
  	vcc12v_dcin: regulator-vcc12v-dcin {
  		compatible = "regulator-fixed";
  		regulator-name = "vcc12v_dcin";
-@@ -227,36 +375,60 @@ vcc12v_dcin_bkup: regulator-vcc12v-dcin-bkup {
+@@ -227,36 +375,68 @@ vcc12v_dcin_bkup: regulator-vcc12v-dcin-bkup {
  		regulator-max-microvolt = <12000000>;
  		vin-supply = <&vcc12v_dcin>;
  	};
@@ -336,6 +336,14 @@ index 111111111111..222222222222 100644
 +		rockchip,cpu = <&i2s2>;
 +		rockchip,codec = <&cdn_dp>;
 +	};
++
++	typec_extcon_bridge: typec-extcon {
++		compatible = "linux,typec-extcon-bridge";
++		usb-role-switch;
++		orientation-switch;
++		mode-switch;
++		svid = /bits/ 16 <0xff01>;
++	};
  };
  
  &cpu_l0 {
@@ -353,7 +361,7 @@ index 111111111111..222222222222 100644
 +
 +&cdn_dp {
 +	status = "okay";
-+	extcon = <&fusb0>;
++	extcon = <&typec_extcon_bridge>;
 +	phys = <&tcphy0_dp>;
 +};
 +
@@ -550,7 +558,7 @@ index 111111111111..222222222222 100644
  		vin-supply = <&vcc5v0_sys>;
  
  		regulator-state-mem {
-@@ -404,17 +696,101 @@ &i2c2 {
+@@ -404,17 +696,108 @@ &i2c2 {
  	i2c-scl-falling-time-ns = <30>;
  	status = "okay";
  
@@ -588,6 +596,7 @@ index 111111111111..222222222222 100644
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&fusb0_int>;
 +		vbus-supply = <&vcc5v0_typec>;
++		usb-role-switch = <&typec_extcon_bridge>;
 +
 +		connector {
 +			compatible = "usb-c-connector";
@@ -595,12 +604,18 @@ index 111111111111..222222222222 100644
 +			power-role = "dual";
 +			data-role = "dual";
 +			try-power-role = "sink";
-+			source-pdos = <PDO_FIXED(5000, 1200, PDO_FIXED_USB_COMM)>;
-+			sink-pdos = <PDO_FIXED(5000, 500, PDO_FIXED_USB_COMM)>;
++			source-pdos = <PDO_FIXED(5000, 1200, PDO_FIXED_USB_COMM | PDO_FIXED_DUAL_ROLE | PDO_FIXED_DATA_SWAP)>;
++			sink-pdos = <PDO_FIXED(5000, 500, PDO_FIXED_USB_COMM | PDO_FIXED_DUAL_ROLE | PDO_FIXED_DATA_SWAP)>;
 +			op-sink-microwatt = <5000000>;
++			mode-switch = <&typec_extcon_bridge>;
++			orientation-switch = <&typec_extcon_bridge>;
 +
-+			extcon-cables = <1 2 5 6 9 10 12 44>;
-+			typec-altmodes = <0xff01 1 0x001c0000 1>;
++			altmodes {
++				dp {
++					svid = /bits/ 16 <0xff01>;
++					vdo = <0x1c46>;
++				};
++			};
 +
 +			ports {
 +				#address-cells = <1>;
@@ -841,7 +856,7 @@ index 111111111111..222222222222 100644
  };
  
 +&tcphy0 {
-+	extcon = <&fusb0>;
++	extcon = <&typec_extcon_bridge>;
 +	status = "okay";
 +};
 +
@@ -864,12 +879,14 @@ index 111111111111..222222222222 100644
  &tcphy1 {
  	/* phy for &usbdrd_dwc3_1 */
  	status = "okay";
-@@ -559,61 +1056,118 @@ &tsadc {
+@@ -559,61 +1056,122 @@ &tsadc {
  	status = "okay";
  };
  
 -&u2phy1 {
 +&u2phy0 {
++	extcon = <&typec_extcon_bridge>;
++	extcon,ignore-usb;
  	status = "okay";
  
 -	otg-port {
@@ -923,6 +940,8 @@ index 111111111111..222222222222 100644
 +&usbdrd_dwc3_0 {
 +	status = "okay";
 +	dr_mode = "otg";
++	extcon = <&typec_extcon_bridge>;
++	snps,usb3-phy-reset-quirk;
 +};
 +
  &usbdrd3_1 {


### PR DESCRIPTION
Problem:
On Helios64 boot, the Type-C PHY (ff7c0000.phy) gets stuck in "deferred probe" state with unknown reason. This causes:
- USB 3.0 SuperSpeed via Type-C port not working
- DisplayPort via Type-C (Alt Mode) not working

The following messages appear in dmesg:
  platform ff7c0000.phy: deferred probe pending: (reason unknown) platform fe800000.usb: deferred probe pending: wait for supplier /phy@ff7c0000/usb3-port platform fec00000.dp: deferred probe pending: wait for supplier /phy@ff7c0000/dp-port

Along with dependency cycle warnings:
  /phy@ff7c0000/dp-port: Fixed dependency cycle(s) with /i2c@ff3d0000/typec-portc@22/connector

Root cause:
The Helios64 DTS uses a legacy Type-C connection method:

  &tcphy0 {
      extcon = <&fusb0>;  // Expects extcon from fusb302
  };

However:
1. The FUSB302 driver with TCPM support (since kernel ~4.14) does NOT create extcon devices
2. Instead, it uses the Type-C connector class (/sys/class/typec/)
3. The phy-rockchip-typec driver calls extcon_get_edev_by_phandle(), fails to find an extcon device at the specified phandle, and returns -EPROBE_DEFER
4. The PHY remains in deferred probe indefinitely

The extcon-cables property is present in the DTS, but without a typec_extcon_bridge node it serves no purpose.

This bug has existed since Type-C support was added to Helios64 (at least since kernel 6.6). It likely worked with older fusb302 driver versions, but broke after the transition to TCPM.

Solution:
Use the typec-extcon-bridge driver (Armbian patch from Ondrej Jirman/megi) which translates Type-C connector class events to the extcon interface.

The Pinebook Pro patch (board-pbp-add-dp-alt-mode.patch) implements this correctly: it has a typec_extcon_bridge node, and all extcon references point to it rather than directly to fusb0.

Changes:
1. Add typec_extcon_bridge node with compatible = "linux,typec-extcon-bridge"
2. Change extcon = <&fusb0> to extcon = <&typec_extcon_bridge> in tcphy0, cdn_dp, u2phy0, usbdrd_dwc3_0 nodes
3. Add usb-role-switch, mode-switch, orientation-switch properties to fusb0 connector for integration with the bridge
4. Update PDO definitions with DUAL_ROLE and DATA_SWAP flags
5. Convert typec-altmodes property to modern altmodes subnode format (required for TCPM port registration)
6. Add extcon,ignore-usb to u2phy0 (following Pinebook Pro pattern)
7. Add snps,usb3-phy-reset-quirk to usbdrd_dwc3_0

After this fix:
- Type-C PHY (ff7c0000.phy) no longer stuck in deferred probe
- USB 3.0 SuperSpeed via Type-C port should work
- DisplayPort via Type-C (Alt Mode) should work
- Correct cable orientation detection
- USB role switching (host/device)

Known remaining issues:
- FUSB302 fails to register TCPM port with error:
    4-0022    typec_fusb302: cannot register tcpm port
  This prevents USB Power Delivery negotiation. The root cause
  appears to be in the connector configuration and requires
  further investigation.

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced USB Type-C Power Delivery and controller support with improved wiring infrastructure
  * Improved power regulator configuration for better suspend and resume management
  * Status LED indicators for network activity, USB 3.0, and storage operations
  * Additional I2C and external connectivity support for peripheral devices

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->