### PR TITLE
atf: once again `no-warn-rwx-segment` woes

### DIFF
--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -80,9 +80,10 @@ function artifact_uboot_prepare_version() {
 	declare hash_hooks="undetermined"
 	hash_hooks="$(echo "${extension_hooks_hashed[@]}" | sha256sum | cut -d' ' -f1)"
 
-	# Hash the old-timey hooks
+	# Hash the old-timey hooks and regular core functions (atf code, used by u-boot build process)
 	declare hash_functions="undetermined"
-	calculate_hash_for_function_bodies "uboot_custom_postprocess" "write_uboot_platform" "write_uboot_platform_mtd" "setup_write_uboot_platform"
+	calculate_hash_for_function_bodies "uboot_custom_postprocess" "write_uboot_platform" "write_uboot_platform_mtd" \
+		"setup_write_uboot_platform" "compile_atf"
 	declare hash_uboot_functions="${hash_functions}"
 
 	# Hash those two together


### PR DESCRIPTION
- turns out everybody was wrong, including me
- some (older?) ATF sources won't work, ever; thus
  - introduce ATF_SKIP_LDFLAGS=yes to skip it completely
  - introduce ATF_SKIP_LDFLAGS_WL=yes to only skip the `-Wl,` prefix
    - this is for ATF's that pass flag directly to linker, not gcc
- artifact-uboot: hash atf-building code into artifact version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Changes**
  * U-Boot artifact versioning updated with expanded hash calculation, resulting in modified artifact versions.
  * ATF compilation now uses dynamic feature detection for compiler flag compatibility instead of static version checks, improving robustness across different toolchains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->