### PR TITLE
rockchip64-6.18: Enable audio for HDMI0 on station-m3

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/rk3588-1211-arm64-dts-rk3588s-roc-pc-Enable-HDMI-audio.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3588-1211-arm64-dts-rk3588s-roc-pc-Enable-HDMI-audio.patch
@@ -1,0 +1,39 @@
+From 8f9e516e8d971abdd52a56c2a29144c7ca6716b6 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sun, 9 Nov 2025 19:26:25 +0800
+Subject: [PATCH] arm64: dts: rk3588s-roc-pc: Enable HDMI audio
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
+index 7e179862da6e5..449e457caa2a4 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
+@@ -243,6 +243,10 @@ &hdptxphy0 {
+ 	status = "okay";
+ };
+ 
++&hdmi0_sound {
++	status = "okay";
++};
++
+ &i2c0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c0m2_xfer>;
+@@ -344,6 +348,10 @@ &i2s0_sdi0
+ 	status = "okay";
+ };
+ 
++&i2s5_8ch {
++	status = "okay";
++};
++
+ &mdio1 {
+ 	rgmii_phy1: ethernet-phy@1 {
+ 		compatible = "ethernet-phy-ieee802.3-c22";
+-- 
+2.43.0
+


### PR DESCRIPTION
# Description

Enable audio output on HDMI port on station-m3

# How Has This Been Tested?

1. Boot with new kernel image
2. Check "aplay -l" output and ensure "hdmi0" is in playback devices
3. Use command "aplay -D hw:CARD=hdmi0,DEV=0 /path/to/a/wav/file" and check if audio output can be heard



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled HDMI audio output on rk3588s-roc-pc devices, allowing audio to be routed through HDMI connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->