### PR TITLE
station-m3: Fix fan speed and enable USB 3.0 Type-A port

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/rk3588-1212-arm64-dts-Automatic-fan-speed-and-USB-3.0-Type-A-por.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3588-1212-arm64-dts-Automatic-fan-speed-and-USB-3.0-Type-A-por.patch
@@ -1,0 +1,67 @@
+From bd96d53d233d7c476e4e681e9cba7847a6fc0db6 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sat, 10 Jan 2026 11:47:20 +0800
+Subject: [PATCH] arm64: dts: Automatic fan speed and USB 3.0 Type-A port
+ support
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ .../boot/dts/rockchip/rk3588s-roc-pc.dts      | 35 ++++++++++++++++++-
+ 1 file changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
+index 449e457ca..a28445845 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
+@@ -364,7 +364,35 @@ rgmii_phy1: ethernet-phy@1 {
+ 	};
+ };
+ 
+-&pcie2x1l1 {
++&package_thermal {
++	polling-delay = <1000>;
++
++	trips {
++		package_fan0: package-fan0 {
++			hysteresis = <2000>;
++			temperature = <55000>;
++			type = "active";
++		};
++		package_fan1: package-fan1 {
++			hysteresis = <2000>;
++			temperature = <65000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map1 {
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++			trip = <&package_fan0>;
++		};
++		map2 {
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++			trip = <&package_fan1>;
++		};
++	};
++};
++
++&pcie2x1l2 {
+ 	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
+ 	vpcie3v3-supply = <&vcc3v3_pcie20>;
+ 	status = "okay";
+@@ -832,6 +860,11 @@ &usb_host1_ohci {
+ 	status = "okay";
+ };
+ 
++&usb_host2_xhci {
++	status = "okay";
++	dr_mode = "host";
++};
++
+ &vop {
+ 	status = "okay";
+ };
+-- 
+2.43.0
+

--- a/patch/kernel/archive/rockchip64-6.19/rk3588-1212-arm64-dts-Automatic-fan-speed-and-USB-3.0-Type-A-por.patch
+++ b/patch/kernel/archive/rockchip64-6.19/rk3588-1212-arm64-dts-Automatic-fan-speed-and-USB-3.0-Type-A-por.patch
@@ -1,0 +1,67 @@
+From bd96d53d233d7c476e4e681e9cba7847a6fc0db6 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sat, 10 Jan 2026 11:47:20 +0800
+Subject: [PATCH] arm64: dts: Automatic fan speed and USB 3.0 Type-A port
+ support
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ .../boot/dts/rockchip/rk3588s-roc-pc.dts      | 35 ++++++++++++++++++-
+ 1 file changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
+index 449e457ca..a28445845 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
+@@ -364,7 +364,35 @@ rgmii_phy1: ethernet-phy@1 {
+ 	};
+ };
+ 
+-&pcie2x1l1 {
++&package_thermal {
++	polling-delay = <1000>;
++
++	trips {
++		package_fan0: package-fan0 {
++			hysteresis = <2000>;
++			temperature = <55000>;
++			type = "active";
++		};
++		package_fan1: package-fan1 {
++			hysteresis = <2000>;
++			temperature = <65000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map1 {
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++			trip = <&package_fan0>;
++		};
++		map2 {
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++			trip = <&package_fan1>;
++		};
++	};
++};
++
++&pcie2x1l2 {
+ 	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
+ 	vpcie3v3-supply = <&vcc3v3_pcie20>;
+ 	status = "okay";
+@@ -832,6 +860,11 @@ &usb_host1_ohci {
+ 	status = "okay";
+ };
+ 
++&usb_host2_xhci {
++	status = "okay";
++	dr_mode = "host";
++};
++
+ &vop {
+ 	status = "okay";
+ };
+-- 
+2.43.0
+


### PR DESCRIPTION
# Description
This PR includes following changes
1.Adjust fan speed to CPU core temperature
2.Enable USB 3.0 support on the Type-A port

# How Has This Been Tested?
1.Check the fan speed should be low when booting into desktop
2.Run command "stress-ng -v --cpu 8" to burn CPU and check if the fan speed is increased
3.Check if the USB 3.0 device is connected correctly via "lsusb"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented automatic fan speed control with temperature-based regulation for improved thermal management
  * Added USB 3.0 Type-A port support to expand device connectivity options
  * Enhanced PCIe configuration for improved hardware compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->