### PR TITLE
u-boot: bump u-boot to v2026.01 (final) for boards that had -rcX

### DIFF
--- a/config/boards/cm3588-nas.csc
+++ b/config/boards/cm3588-nas.csc
@@ -44,7 +44,7 @@ function post_family_config__cm3588_nas_use_mainline_uboot() {
 
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-	declare -g BOOTBRANCH="tag:v2026.01-rc2"
+	declare -g BOOTBRANCH="tag:v2026.01"
 	declare -g BOOTPATCHDIR="v2026.01"
 	declare -g BOOTDIR="u-boot-${BOARD}"
 	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"

--- a/config/boards/khadas-vim3l.conf
+++ b/config/boards/khadas-vim3l.conf
@@ -13,7 +13,7 @@ BOOT_LOGO="desktop"
 BOOT_FDT_FILE="amlogic/meson-sm1-khadas-vim3l.dtb"
 ASOUND_STATE="asound.state.khadas-vim3l"
 
-BOOTBRANCH_BOARD="tag:v2026.01-rc2"
+BOOTBRANCH_BOARD="tag:v2026.01"
 BOOTPATCHDIR="v2026.01" # this has 'board_khadas-vim3' which has a patch to boot USB/NVMe/SCSI first
 
 declare -g KHADAS_OOWOW_BOARD_ID="VIM3L" # for use with EXT=output-image-oowow

--- a/config/boards/mekotronics-r58-4x4.conf
+++ b/config/boards/mekotronics-r58-4x4.conf
@@ -29,7 +29,7 @@ function post_family_config__meko4x4_use_mainline_uboot() {
 	declare -g BOOTCONFIG="mekotronics-r58-4x4-rk3588_defconfig" # mainline
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-	declare -g BOOTBRANCH="tag:v2026.01-rc5"
+	declare -g BOOTBRANCH="tag:v2026.01"
 	declare -g BOOTPATCHDIR="v2026.01"
 	declare -g BOOTDIR="u-boot-${BOARD}"
 

--- a/config/boards/mixtile-core3588e.csc
+++ b/config/boards/mixtile-core3588e.csc
@@ -35,7 +35,7 @@ function post_family_config__core3588e_use_mainline_uboot() {
 
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-	declare -g BOOTBRANCH="tag:v2026.01-rc4"
+	declare -g BOOTBRANCH="tag:v2026.01"
 	declare -g BOOTPATCHDIR="v2026.01"
 	declare -g BOOTDIR="u-boot-${BOARD}"
 

--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -44,7 +44,7 @@ function post_family_config__nanopct6_use_mainline_uboot() {
 	declare -g BOOTCONFIG="nanopc-t6-rk3588_defconfig"
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-	declare -g BOOTBRANCH="tag:v2026.01-rc2"
+	declare -g BOOTBRANCH="tag:v2026.01"
 	declare -g BOOTPATCHDIR="v2026.01"
 	declare -g BOOTDIR="u-boot-${BOARD}"
 	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"

--- a/config/boards/nanopi-r6c.csc
+++ b/config/boards/nanopi-r6c.csc
@@ -38,7 +38,7 @@ function post_family_config__nanopi_r6c_use_mainline_uboot() {
 
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline U-Boot
-	declare -g BOOTBRANCH="tag:v2026.01-rc2"
+	declare -g BOOTBRANCH="tag:v2026.01"
 	declare -g BOOTPATCHDIR="v2026.01"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"

--- a/config/boards/nanopi-r76s.conf
+++ b/config/boards/nanopi-r76s.conf
@@ -29,7 +29,7 @@ function post_family_config__nanopi_r76s_use_mainline_uboot() {
 
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-	declare -g BOOTBRANCH="tag:v2026.01-rc2"
+	declare -g BOOTBRANCH="tag:v2026.01"
 	declare -g BOOTPATCHDIR="v2026.01"
 	unset BOOT_FDT_FILE
 

--- a/config/boards/odroidhc4.csc
+++ b/config/boards/odroidhc4.csc
@@ -13,7 +13,7 @@ BOOT_FDT_FILE="amlogic/meson-sm1-odroid-hc4.dtb"
 PACKAGE_LIST_BOARD="lm-sensors fancontrol" # SPI, sensors, manual fan control via 'pwmconfig'
 
 # Newer u-boot for the HC4. There's patches in `board_odroidhc4` for the defconfigs used in the UBOOT_TARGET_MAP below.
-BOOTBRANCH_BOARD="tag:v2026.01-rc2"
+BOOTBRANCH_BOARD="tag:v2026.01"
 BOOTPATCHDIR="v2026.01"
 
 # We build u-boot twice: C4 config for SD cards, and HC4 (with SATA/PCI/SPI) config for SPI.

--- a/config/boards/odroidn2.conf
+++ b/config/boards/odroidn2.conf
@@ -16,7 +16,7 @@ enable_extension "uboot-btrfs"
 enable_extension "watchdog"
 
 # Newer u-boot for the N2/N2+
-BOOTBRANCH_BOARD="tag:v2026.01-rc2"
+BOOTBRANCH_BOARD="tag:v2026.01"
 BOOTPATCHDIR="v2026.01"
 
 # Enable writing u-boot to SPI on the N2(+) for current and edge

--- a/config/boards/rock-5b.conf
+++ b/config/boards/rock-5b.conf
@@ -39,7 +39,7 @@ function post_family_config_branch_edge__rock-5b_use_mainline_uboot() {
 	declare -g BOOTCONFIG="rock5b-rk3588_defconfig"
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-	declare -g BOOTBRANCH="tag:v2026.01-rc2"
+	declare -g BOOTBRANCH="tag:v2026.01"
 	declare -g BOOTPATCHDIR="v2026.01"
 	declare -g BOOTDIR="u-boot-${BOARD}"
 	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"

--- a/config/sources/vendors/mekotronics/mekotronics-rk3588.hooks.sh
+++ b/config/sources/vendors/mekotronics/mekotronics-rk3588.hooks.sh
@@ -31,7 +31,7 @@ if [[ "${MEKO_USE_MAINLINE_UBOOT:-"no"}" == "yes" ]]; then
 		declare -g BOOTDELAY=1                           # Wait for UART interrupt
 
 		declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-		declare -g BOOTBRANCH="tag:v2026.01-rc5"
+		declare -g BOOTBRANCH="tag:v2026.01"
 		declare -g BOOTPATCHDIR="v2026.01"
 
 		BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory


### PR DESCRIPTION
- 🌱 cm3588-nas: u-boot: bump v2026.01-rc2 -> v2026.01-rc
- 🌿 khadas-vim3l: u-boot: bump v2026.01-rc2 -> v2026.01
- 🍃 mekotronics-458-4x4: : bump v2026.01-rcX -> v2026.01
- 🍀 nanopct6: u-boot: bump v2026.01-rc2 -> v2026.01
- 🐸 nanopi-r6c: u-boot: bump v2026.01-rc2 -> v2026.01
- 🌳 nanopi-r76s: u-boot: bump v2026.01-rcX -> v2026.01
- 🌴 odroidhc4: u-boot: bump v2026.01-rc2 -> v2026.01
- 🌵 odroidn2: u-boot: bump v2026.01-rcX -> v2026.01
- 🌱 rock-5b: u-boot: bump v2026.01-rc2 -> v2026.01
- 🌿 this is tedious. time for `UBOOT_MAJOR_MINOR`?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bootloader configurations for multiple supported boards to use the stable release version instead of release candidate versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->