### PR TITLE
mvebu64: re-revitalize `espressobin` - can build (under noble) again

### DIFF
--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -20,16 +20,16 @@ function add_host_dependencies__mvebu64_add_32_bit_c_compiler() {
 	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} gcc-arm-linux-gnueabi" # @TODO: convert to array later
 }
 
-ARCH=arm64
-BOOTBRANCH='tag:v2025.10'
-BOOTPATCHDIR='v2025.10'
-BOOTENV_FILE='mvebu64.txt'
-BOOTSCRIPT_OUTPUT='boot.scr'
-OVERLAY_DIR="/boot/dtb/marvell/overlay"
-ATFSOURCE='https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git'
-ATFDIR='arm-trusted-firmware-espressobin'
-ATFBRANCH='tag:lts-v2.12.8'
-ATF_USE_GCC='> 7.2'
+declare -g ARCH=arm64
+declare -g BOOTBRANCH='tag:v2025.10'
+declare -g BOOTPATCHDIR='v2025.10'
+declare -g BOOTENV_FILE='mvebu64.txt'
+declare -g BOOTSCRIPT_OUTPUT='boot.scr'
+declare -g OVERLAY_DIR="/boot/dtb/marvell/overlay"
+declare -g ATFSOURCE='https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git'
+declare -g ATFDIR='arm-trusted-firmware-espressobin'
+declare -g ATFBRANCH='tag:lts-v2.12.8'
+declare -g ATF_USE_GCC='> 7.2'
 
 if [[ "${SKIP_EXTERNAL_TOOLCHAINS}" == "yes" ]]; then
 	ATF_COMPILER='aarch64-linux-gnu-'
@@ -40,17 +40,17 @@ fi
 if [[ $BOARD = macchiatobin-doubleshot ]]; then
 	export SCP_BL2=$SRC/cache/sources/marvell-binaries/mrvl_scp_bl2.img # ATTENTION! This is actually a required 'export', since it's picked up by ATF's make.
 
-	ATF_TARGET_MAP="USE_COHERENT_MEM=0 LOG_LEVEL=20 MV_DDR_PATH=$SRC/cache/sources/marvell-ddr SECURE=0 PLAT=a80x0_mcbin;;build/a80x0_mcbin/release/bl31.bin"
-	UBOOT_TARGET_MAP="DEVICE_TREE=armada-8040-mcbin ;;flash-image.bin"
+	declare -g ATF_TARGET_MAP="USE_COHERENT_MEM=0 LOG_LEVEL=20 MV_DDR_PATH=$SRC/cache/sources/marvell-ddr SECURE=0 PLAT=a80x0_mcbin;;build/a80x0_mcbin/release/bl31.bin"
+	declare -g UBOOT_TARGET_MAP="DEVICE_TREE=armada-8040-mcbin ;;flash-image.bin"
 
-	BOOTSCRIPT="boot-macchiatobin-doubleshot.cmd:boot.cmd"
-	SERIALCON='ttyS0'
+	declare -g BOOTSCRIPT="boot-macchiatobin-doubleshot.cmd:boot.cmd"
+	declare -g SERIALCON='ttyS0'
 else
-	ATF_TARGET_MAP="USE_COHERENT_MEM=0 LOG_LEVEL=20 SECURE=0 CLOCKSPRESET=CPU_800_DDR_800 DDR_TOPOLOGY=2 BOOTDEV=SPINOR PARTNUM=0 PLAT=a3700;;build/a3700/release/bl31.bin"
-	UBOOT_TARGET_MAP="DEVICE_TREE=armada-3720-espressobin ;;flash-image-*.bin"
+	declare -g ATF_TARGET_MAP="USE_COHERENT_MEM=0 LOG_LEVEL=20 SECURE=0 CLOCKSPRESET=CPU_800_DDR_800 DDR_TOPOLOGY=2 BOOTDEV=SPINOR PARTNUM=0 PLAT=a3700;;build/a3700/release/bl31.bin"
+	declare -g UBOOT_TARGET_MAP="DEVICE_TREE=armada-3720-espressobin ;;flash-image-*.bin"
 
-	BOOTSCRIPT="boot-espressobin.cmd:boot.cmd"
-	SERIALCON='ttyMV0'
+	declare -g BOOTSCRIPT="boot-espressobin.cmd:boot.cmd"
+	declare -g SERIALCON='ttyMV0'
 fi
 
 case $BRANCH in
@@ -70,11 +70,11 @@ case $BRANCH in
 
 esac
 
-CPUMIN=200000
-CPUMAX=1300000
-GOVERNOR=ondemand
+declare -g CPUMIN=200000
+declare -g CPUMAX=1300000
+declare -g GOVERNOR=ondemand
 
-write_uboot_platform() {
+function write_uboot_platform() {
 	if [[ $BOARD = macchiatobin-doubleshot ]]; then
 		dd if=$1/flash-image.bin of=$2 bs=512 seek=1 status=noxfer > /dev/null 2>&1
 	else
@@ -83,83 +83,89 @@ write_uboot_platform() {
 	fi
 }
 
-family_tweaks() {
+function family_tweaks() {
 	if [[ $BOARD = "espressobin" ]]; then
-		echo "#Marvell Espressobin Console" >> $SDCARD/etc/securetty
-		echo "ttyMV0" >> $SDCARD/etc/securetty
+		echo "#Marvell Espressobin Console" >> "${SDCARD}/etc/securetty"
+		echo "ttyMV0" >> "${SDCARD}/etc/securetty"
 	fi
 }
 
-family_tweaks_bsp() {
+function family_tweaks_bsp() {
+	: "${destination:?destination is not set}"
 	if [[ $BOARD = "espressobin" ]]; then
 		cp "$SRC/packages/bsp/mvebu64/initramfs/99-uboot-fit" "$destination/etc/initramfs/post-update.d/"
 	fi
 }
 
-atf_custom_postprocess() {
+function atf_custom_postprocess() {
 	# prepare compilers for postprocess
 	ubootdir="$SRC/cache/sources/u-boot-worktree/$BOOTDIR/${BOOTBRANCH##*:}"
-	declare -g ATF1=$toolchain/$ATF_COMPILER
-	if [[ "${SKIP_EXTERNAL_TOOLCHAINS}" == "yes" ]]; then
-		declare -g TOOLCHAIN_NAME="arm-linux-gnueabi-"
-	else
-		declare -g TOOLCHAIN_NAME="arm-none-linux-gnueabihf-"
-	fi
-	declare -g ATF2=$(find_toolchain "$TOOLCHAIN_NAME" "> 10.0")/$TOOLCHAIN_NAME
-	declare -g BL33=$ubootdir"/u-boot.bin"
+	declare -g ATF1="${ATF_COMPILER}"
+	declare -g ATF2="arm-linux-gnueabi-"
+	declare -g BL33="${ubootdir}/u-boot.bin"
 }
 
-uboot_custom_postprocess() {
+function uboot_custom_postprocess() {
 	# clean previous
 	run_host_command_logged rm -f "$ubootdir"/flash-image*
-	local atfdir="$SRC/cache/sources/$ATFDIR/${ATFBRANCH##*:}"
-	local ubootdir="$SRC/cache/sources/u-boot-worktree/$BOOTDIR/${BOOTBRANCH##*:}"
-	local moxbootdir="$SRC/cache/sources/mox-boot"
-	cd $atfdir
+
+	declare atfdir="$SRC/cache/sources/$ATFDIR/${ATFBRANCH##*:}"
+	declare ubootdir="$SRC/cache/sources/u-boot-worktree/$BOOTDIR/${BOOTBRANCH##*:}"
+	declare moxbootdir="$SRC/cache/sources/mox-boot"
+
+	cd "${atfdir}" || exit_with_error "Cannot enter ATF directory ${atfdir}"
 
 	if [[ $BOARD = macchiatobin-doubleshot ]]; then
 		run_host_command_logged make distclean
 
 		FILENAME="flash-image.bin"
-		display_alert "Building $FILENAME" "" "info"
+		display_alert "Building mvebu64 ${BOARD}" "$FILENAME" "info"
 		# http://wiki.macchiatobin.net/tiki-index.php?page=Build+from+source+-+Bootloader#Building_ATF
 		run_host_command_logged make distclean
 		run_host_command_logged "CFLAGS=-fdiagnostics-color=always" pipetty make USE_COHERENT_MEM=0 LOG_LEVEL=20 MV_DDR_PATH=$SRC/cache/sources/marvell-ddr PLAT=a80x0_mcbin CROSS_COMPILE=$ATF1 BL33=$BL33 mrvl_flash $CTHREADS
 		run_host_command_logged cp -pv build/a80x0_mcbin/release/flash-image.bin $ubootdir/$FILENAME
 	else
-		cd $moxbootdir
+
+		cd "${moxbootdir}" || exit_with_error "Cannot enter mox-boot directory ${moxbootdir}"
+
+		display_alert "Patching mox-boot for mvebu64 ${BOARD}" "crazy toolchain thing" "info"
 		[[ -f Makefile ]] && sed -i "s/aarch64-unknown-linux-gnu-/aarch64-linux-gnu-/" Makefile
 		[[ -f wtmi/a53_helper/Makefile ]] && sed -i "s/aarch64-unknown-linux-gnu-/aarch64-linux-gnu-/" wtmi/a53_helper/Makefile
-		make clean # @TODO: rpardini: why?
-		run_host_command_logged "CFLAGS=-fdiagnostics-color=always" pipetty make CROSS_CM3=$ATF2 wtmi_app.bin
-		cd $atfdir
+		run_host_command_logged pipetty regular_git diff -u || true
 
-		clocks=(600_600 800_800 1000_800 1200_750)
-		topology=(512m_1cs_0 1g_2cs_2 1g_1cs_4 2g_2cs_7 1g_1cs_5 2g_2cs_6)
+		display_alert "Building" "mox-boot for mvebu64 ${BOARD}" "info"
+		run_host_command_logged make clean
+		run_host_command_logged "CFLAGS=-fdiagnostics-color=always" pipetty make "CROSS_CM3=$ATF2" wtmi_app.bin
+
+		cd "${atfdir}" || exit_with_error "Cannot enter ATF directory ${atfdir}"
+		display_alert "Building atf for mvebu64 ${BOARD}" "" "info"
+		declare -a clocks=("600_600" "800_800" "1000_800" "1200_750")
+		declare -a topology=("512m_1cs_0" "1g_2cs_2" "1g_1cs_4" "2g_2cs_7" "1g_1cs_5" "2g_2cs_6")
 		for i in "${clocks[@]}"; do
 			for j in "${topology[@]}"; do
-				if [[ $j = *cs_5 || $j = *cs_6 ]]; then local ddrname="DDR4"; else ddrname="DDR3"; fi
+				declare ddrname="undetermined"
+				if [[ $j = *cs_5 || $j = *cs_6 ]]; then ddrname="DDR4"; else ddrname="DDR3"; fi
 				FILENAME="flash-image-$ddrname-$j-$i.bin"
 				DDR_TOPOLOGY="${j##*_}"
 				CLOCKSPRESET="CPU_${i%_*}_DDR_${i##*_}"
-				display_alert "Building $FILENAME" "mvebu64" "info"
+				display_alert "Building mvebu64 not-macchiatobin-doubleshot: ${BOARD}" "$FILENAME" "info"
 				run_host_command_logged make distclean
-				run_host_command_logged "CFLAGS=-fdiagnostics-color=always" pipetty make CROSS_COMPILE=$ATF1 \
-					CROSS_CM3=$ATF2 \
+				run_host_command_logged "CFLAGS=-fdiagnostics-color=always" pipetty make "CROSS_COMPILE=$ATF1" \
+					"CROSS_CM3=$ATF2" \
 					USE_COHERENT_MEM=0 \
 					PLAT=a3700 \
-					CLOCKSPRESET=$CLOCKSPRESET DDR_TOPOLOGY=$DDR_TOPOLOGY \
-					MV_DDR_PATH=$SRC/cache/sources/marvell-ddr \
-					WTP=$SRC/cache/sources/marvell-tools \
-					CRYPTOPP_PATH=$SRC/cache/sources/cryptopp \
-					BL33=$BL33 \
-					WTMI_IMG=$moxbootdir/wtmi_app.bin \
+					"CLOCKSPRESET=$CLOCKSPRESET" "DDR_TOPOLOGY=$DDR_TOPOLOGY" \
+					"MV_DDR_PATH=$SRC/cache/sources/marvell-ddr" \
+					"WTP=$SRC/cache/sources/marvell-tools" \
+					"CRYPTOPP_PATH=$SRC/cache/sources/cryptopp" \
+					"BL33=$BL33" \
+					"WTMI_IMG=$moxbootdir/wtmi_app.bin" \
 					BOOTDEV=SPINOR PARTNUM=0 \
 					LOG_LEVEL=20 all fip mrvl_flash $CTHREADS
-				run_host_command_logged cp -pv build/a3700/release/flash-image.bin $ubootdir/$FILENAME
+				run_host_command_logged cp -pv build/a3700/release/flash-image.bin "${ubootdir}/${FILENAME}"
 			done
 		done
 	fi
 
-	cd $ubootdir
+	cd "${ubootdir}" || exit_with_error "Cannot enter ATF directory ${ubootdir}"
 }


### PR DESCRIPTION
- 🌱 try to squash all shellcheck warnings
- 🌿 drop toolchain stuff we don't have anymore
- 🍃 then it becomes obvious there was a spurious `/` in `ATF1`
- 🍀 requires & works with `compile_atf()`'s LDFLAGS handling in https://github.com/armbian/build/pull/9162
- 🐸 build-tested on noble (default Docker image)
- 🌳 does NOT build on trixie+:
  - and apparently never will: https://lists.trustedfirmware.org/archives/list/tf-a@lists.trustedfirmware.org/thread/A2NLSTWUNTSH3WAGOW4LGATKYYCTZXXZ/
    - the whole thing has been dropped from TF-A CI, so it's effectively junk now
- 🌴 also fixes `macchiatobin-doubleshot`, but that is .eos anyway
  - that builds on noble & trixie
- 🌵 Fixes: 81ad50f257a7c3f8f57c6e62cc220e4290d34f28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code structure and variable declarations for better stability and maintainability.
  * Enhanced error handling for critical operations to prevent silent failures.
  * Standardized function definitions for consistency and improved code readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->