### PR TITLE
`kernel-make`: `clang`: Remove -Wno-error=unknown-warning-option from clang KCFLAGS.

### DIFF
--- a/lib/functions/compilation/kernel-make.sh
+++ b/lib/functions/compilation/kernel-make.sh
@@ -40,7 +40,11 @@ function run_kernel_make_internal() {
 	if [[ "${KERNEL_COMPILER}" == "clang" ]]; then
 		llvm_flag="LLVM=1"
 		cc_name="CC"
-		extra_warnings="-Wno-error=unused-command-line-argument -Wno-error=unknown-warning-option" # downgrade errors to warnings
+		# Only suppress unused-command-line-argument errors
+		# Do NOT add -Wno-error=unknown-warning-option here - it breaks cc-option detection
+		# in kernel Makefiles (btrfs, drm, coresight) causing GCC-specific flags to be
+		# incorrectly added when building with clang
+		extra_warnings="-Wno-error=unused-command-line-argument"
 	else
 		cc_name="CROSS_COMPILE"
 		extra_warnings=""


### PR DESCRIPTION
Remove -Wno-error=unknown-warning-option from clang KCFLAGS.

   warning: unknown warning option '-Wrestrict' [-Wunknown-warning-option]
   warning: unknown warning option '-Wpacked-not-aligned'; did you mean '-Wpacked-non-pod'? [-Wunknown-warning-option]
   warning: unknown warning option '-Wstringop-truncation'; did you mean '-Wformat-truncation'? [-Wunknown-warning-option]

This flag was breaking kernel's cc-option detection, causing GCC-specific warnings (-Wpacked-not-aligned, -Wstringop-truncation, -Wmaybe-uninitialized) to be incorrectly added to btrfs/drm/coresight builds when using clang.

# How Has This Been Tested?

- [x] ./compile.sh BOARD=rock64 BRANCH=current BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=noble ARTIFACT_IGNORE_CACHE=yes EXPERT=yes KERNEL_GIT=shallow KERNEL_COMPILER=clang SHARE_LOG=yes KERNEL_BTF=no kernel
- [x] ./compile.sh BOARD=rock64 BRANCH=current BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=noble ARTIFACT_IGNORE_CACHE=yes EXPERT=yes KERNEL_GIT=shallow SHARE_LOG=yes KERNEL_BTF=no kernel

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel compilation warning handling to avoid suppressing warnings that can interfere with build tools.
  * Prevents spurious build or configuration detection failures, making builds more robust and reducing unexpected breakages during compilation.
  * Reduces build interruptions and improves compatibility across compilation environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->