### PR TITLE
Enable OrangePi 4A CSC Initial Support

### DIFF
--- a/config/boards/orangepi-4a.csc
+++ b/config/boards/orangepi-4a.csc
@@ -1,5 +1,6 @@
 # Allwinner Cortex-A55 octa-core 2/4GB SoC
 BOARD_NAME="Orange Pi 4A"
+BOARD_VENDOR="xunlong"
 BOARDFAMILY="sun55iw3"
 BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_4a_defconfig"


### PR DESCRIPTION
# Description

Enable OrangePi 4A adding the board config file, the rest of work is ready in repo. so enable this is easy in this moment.
whit the work of @EvilOlaf (https://github.com/armbian/build/pull/8330)

Build log (https://paste.armbian.eu/qepumudori)
Gdrive link (https://drive.google.com/drive/folders/1dx0TApPAEjFDz24Rm22J4jgtIbJrYYHC?usp=drive_link) for test.
Forum post (https://forum.armbian.com/topic/49353-opi-4a-allwinner-t527/page/5/#findComment-231340)

# How Has This Been Tested?

Testing requiered...

- [ ] Tester name A
- [ ] Tester name B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Orange Pi 4A: platform-specific boot and partitioning configuration (GPT partitioning, FAT boot filesystem, kernel/FDT selection, and boot/root offsets) to enable device images for this board.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->