### PR TITLE
cli-patch: generalize to-git functionality with PUSH_TO_GITHUB and PUSH_TO_REPO & enable for u-boot as well as kernel

### DIFF
--- a/lib/functions/cli/cli-patch.sh
+++ b/lib/functions/cli/cli-patch.sh
@@ -47,18 +47,10 @@ function cli_patch_kernel_run() {
 	obtain_kernel_git_info_and_makefile # this populates GIT_INFO_KERNEL and sets KERNEL_GIT_SHA1 readonly global
 	# </prepare the git sha1>
 
-	declare ymd vendor_lc target_repo_url summary_url
-	ymd="$(date +%Y%m%d)"
-	# lowercase ${VENDOR} and replace spaces with underscores
-	vendor_lc="$(tr '[:upper:]' '[:lower:]' <<< "${VENDOR}" | tr ' ' '_')-next"
-	target_branch="${vendor_lc}-${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}-${ymd}${PUSH_BRANCH_POSTFIX:-""}"
-	target_repo_url="git@github.com:${PUSH_TO_REPO:-"${PUSH_TO_USER:-"rpardini"}/${PUSH_TO_REPO:-"linux"}"}.git"
-	summary_url="https://${PUSH_TO_USER:-"rpardini"}.github.io/${PUSH_TO_REPO:-"linux"}/${target_branch}.html"
-
-	declare -a push_command
-	push_command=(git -C "${SRC}/cache/git-bare/kernel" push "--force" "--verbose"
-		"${target_repo_url}"
-		"kernel-${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}:${target_branch}")
+	# prepare push details, if set
+	declare target_repo_url target_branch do_push="no"
+	declare -a push_command=()
+	determine_git_push_details "${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}" # fills in the above; parameter is the branch name
 
 	# Prepare the host and build kernel; without using standard build
 	prepare_host   # This handles its own logging sections, and is possibly interactive.
@@ -66,28 +58,16 @@ function cli_patch_kernel_run() {
 
 	display_alert "Done patching kernel" "${BRANCH} - ${LINUXFAMILY} - ${KERNEL_MAJOR_MINOR}" "cachehit"
 
-	declare do_push="no"
-	if git -C "${SRC}" remote get-url origin &> /dev/null; then
-		declare src_origin_url
-		src_origin_url="$(git -C "${SRC}" remote get-url origin | xargs echo -n)"
-
-		declare prefix="git@github.com:${PUSH_TO_USER:-"rpardini"}/" # @TODO refactor var
-		# if the src_origin_url begins with the prefix
-		if [[ "${src_origin_url}" == "${prefix}"* ]]; then
-			do_push="yes"
-		fi
-	fi
-
-	display_alert "Git push command: " "${push_command[*]}" "info"
 	if [[ "${do_push}" == "yes" ]]; then
-		display_alert "Pushing to ${target_branch}" "${target_repo_url}" "info"
+		display_alert "Pushing kernel to Git branch ${target_branch}" "${target_repo_url}" "info"
 		git_ensure_safe_directory "${SRC}/cache/git-bare/kernel"
-		# @TODO: do NOT allow shallow trees here, we need the full history to be able to push
-		GIT_SSH_COMMAND="ssh -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "${push_command[@]}"
-		display_alert "Done pushing to ${target_branch}" "${summary_url}" "info"
+		push_command=(git -C "${SRC}/cache/git-bare/kernel" push "--force" "--verbose" "${target_repo_url}" "kernel-${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}:${target_branch}")
+		display_alert "Git push command: " "${push_command[*]}" "info"
+		execute_git_push
 	fi
 
-	display_alert "Summary URL (after push & gh-pages deploy): " "${summary_url}" "info"
+	return 0
+
 }
 
 ## Similar stuff as kernel, but for u-boot.
@@ -108,6 +88,11 @@ function cli_patch_uboot_run() {
 	[[ "${GIT_INFO_UBOOT[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_UBOOT[SHA1]}'"
 	# </prepare the git sha1>
 
+	# prepare push details, if set
+	declare target_repo_url target_branch do_push="no"
+	declare -a push_command=()
+	determine_git_push_details "${BOARD}-${BRANCH}" # fills in the above; parameter is the branch name
+
 	# Prepare the host
 	prepare_host # This handles its own logging sections, and is possibly interactive.
 
@@ -123,4 +108,45 @@ function cli_patch_uboot_run() {
 	LOG_SECTION="patch_uboot_target" do_with_logging patch_uboot_target
 
 	display_alert "Done patching u-boot" "${BRANCH} - ${LINUXFAMILY} - ${BOOTSOURCE}#${BOOTBRANCH}" "cachehit"
+
+	if [[ "${do_push}" == "yes" ]]; then
+		display_alert "Pushing u-boot to Git branch ${target_branch}" "${target_repo_url}" "info"
+		git_ensure_safe_directory "${SRC}/cache/git-bare/u-boot"
+		push_command=(git -C "${SRC}/cache/git-bare/u-boot" push "--force" "--verbose" "${target_repo_url}" "u-boot-${BRANCH}-${BOARD}:${target_branch}")
+		display_alert "Git push command: " "${push_command[*]}" "info"
+		execute_git_push
+	fi
+
+}
+
+function determine_git_push_details() {
+	if [[ -n "${PUSH_TO_GITHUB}" ]]; then
+		PUSH_TO_REPO="git@github.com:${PUSH_TO_GITHUB}.git"
+		display_alert "Will push to GitHub" "${PUSH_TO_REPO}" "info"
+	fi
+
+	if [[ -n "${PUSH_TO_REPO}" ]]; then
+		do_push="yes"
+		declare ymd vendor_lc
+		ymd="$(date +%Y%m%d)"
+		vendor_lc="$(tr '[:upper:]' '[:lower:]' <<< "${VENDOR}" | tr ' ' '_')" # lowercase ${VENDOR} and replace spaces with underscores
+		target_branch="${vendor_lc}-${1}-${ymd}${PUSH_BRANCH_POSTFIX:-""}"
+		target_repo_url="${PUSH_TO_REPO}"
+		display_alert "Will push to Git" "${target_repo_url} branch ${target_branch}" "info"
+	else
+		display_alert "Will NOT push to Git" "use PUSH_TO_GITHUB=org/repo or PUSH_TO_REPO=<url> to push" "info"
+	fi
+}
+
+function execute_git_push() {
+	display_alert "Pushing to ${target_branch}" "${target_repo_url}" "info"
+	# @TODO: do NOT allow shallow trees here, we need the full history to be able to push
+	GIT_SSH_COMMAND="ssh -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "${push_command[@]}"
+	display_alert "Done pushing to ${target_branch}" "${target_repo_url}" "info"
+
+	# If GitHub, link there to both the branch main view and History view
+	if [[ -n "${PUSH_TO_GITHUB}" ]]; then
+		display_alert "GitHub tree URL" "https://github.com/${PUSH_TO_GITHUB}/tree/${target_branch}" "info"
+		display_alert "GitHub commits URL" "https://github.com/${PUSH_TO_GITHUB}/commits/${target_branch}" "info"
+	fi
 }


### PR DESCRIPTION
- 🌱 `PUSH_TO_REPO=<url>`: set the full git URL to push to
- 🌿 `PUSH_TO_GITHUB=<org>/<repo>`: shorthand for pushing to GitHub; sets `PUSH_TO_REPO`
- 🍃 note: be kind to GitHub, and use forks of torvalds/linux and u-boot/u-boot so GH has a decent base tree
  - still, kernel pushes are huge, mostly due to the all-wifi-drivers commit that's always first and always slightly different
- 🍀 note: when pushing to GitHub, keep in mind the pushed branch contains a GHA workflow, which will only run if you have GHA enabled on the repo
- 🐸 examples (adapt to your username/forks):
  - `./compile.sh BOARD=nanopct6 BRANCH=edge rewrite-kernel-patches PUSH_TO_GITHUB=rpardini/linux`
  - `./compile.sh BOARD=rock-5b BRANCH=legacy rewrite-uboot-patches PUSH_TO_GITHUB=rpardini/armbian-patched-u-boot`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized git push operations for improved consistency across kernel and u-boot patch workflows.
  * Standardized push command construction and execution with enhanced status logging and GitHub URL handling.
  * Simplified push configuration detection to improve reliability of push operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->