### PR TITLE
sun55iw3.conf bump u-boot to v2026.01 (final)

### DIFF
--- a/config/sources/families/sun55iw3.conf
+++ b/config/sources/families/sun55iw3.conf
@@ -12,7 +12,7 @@ declare -g ATFSOURCE='https://github.com/jernejsk/arm-trusted-firmware'
 declare -g ATF_TARGET_MAP="PLAT=sun55i_a523 DEBUG=1 bl31;;build/sun55i_a523/debug/bl31.bin"
 declare -g ATFBRANCH="branch:a523-v4"
 declare -g BOOTPATCHDIR="sunxi-dev-u-boot-a523"
-declare -g BOOTBRANCH="tag:v2026.01-rc5"
+declare -g BOOTBRANCH="tag:v2026.01"
 
 write_uboot_platform() {
 	dd if=$1/u-boot-sunxi-with-spl.bin of=$2 bs=512 seek=256 status=noxfer > /dev/null 2>&1


### PR DESCRIPTION
Based on (https://github.com/armbian/build/pull/9179)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated boot configuration to use the final stable release (v2026.01) instead of a pre-release version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->