### PR TITLE
patching: Rewriter: actually delete empty patch files on rewrite

### DIFF
--- a/lib/tools/patching.py
+++ b/lib/tools/patching.py
@@ -375,9 +375,11 @@ if apply_patches:
 			parent.rewrite_patch_file(patches)
 		FAILED_PATCHES = [one_patch for one_patch in VALID_PATCHES if (not one_patch.applied_ok) or (one_patch.rewritten_patch is None)]
 		for failed_patch in FAILED_PATCHES:
-			log.info(
-				f"Consider removing {failed_patch.parent.full_file_path()}(:{failed_patch.counter}); "
-				f"it was not applied successfully.")
+			log.warning(
+				f"Removing {failed_patch.parent.full_file_path()}(:{failed_patch.counter}); "
+				f" it failed to apply/was not rewritten.")
+			os.remove(failed_patch.parent.full_file_path())
+
 
 # Create markdown about the patches
 readme_markdown: "str | None" = None


### PR DESCRIPTION
- 🌱 so patches-to-git filtering is actually useful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed patch applications now emit warning-level log messages (instead of info).
  * Unsuccessful patch files are automatically removed from disk after a failed application.
  * Log text updated to indicate a patch failed to apply or was not rewritten.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->