### PR TITLE
Add HDD park at shutdown for Odroid HC4

### DIFF
--- a/config/sources/families/meson-sm1.conf
+++ b/config/sources/families/meson-sm1.conf
@@ -17,6 +17,14 @@ family_tweaks() {
 	:
 }
 
+family_tweaks_bsp() {
+	if [[ $BOARD == odroidhc4 ]]; then
+		# park HDD heads on shutdown
+		mkdir -p $destination/lib/systemd/system-shutdown
+		install -o root -g root -m 0755 $SRC/packages/bsp/odroid/odroid.shutdown $destination/lib/systemd/system-shutdown/odroid.shutdown
+	fi
+}
+
 uboot_custom_postprocess() {
 	# FIP trees for C4 and HC4 are identical as of 30/06/2021
 	if [[ $BOARD == odroidc4 ]]; then


### PR DESCRIPTION
Odroid HC4 is a NAS.  Needs to park HDD heads prior to reboot or shutdown.  This simple PR adds the already existing [odroid.shutdown](https://github.com/armbian/build/blob/main/packages/bsp/odroid/odroid.shutdown) bsp script (originally used for the XU4) to the meson-sm1.conf file for the HC4.

I have successfully tested the odroid.shutdown script on the HC4 with HDDs, and it properly parks the heads.  Without this, the heads are forced to do an emergency retract, which is a violent action that degrades the HDD over time.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added system-level configuration enhancements for improved shutdown handling on select devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->