### PR TITLE
partitioning: fix malformed fstab double comma and switch to relatime

### DIFF
--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -366,7 +366,7 @@ function prepare_partitions() {
 			run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]} ${fscreateopt} $rootdevice $MOUNT/
 		fi
 		rootfs="UUID=$(blkid -s UUID -o value $rootdevice)"
-		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults,${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab
+		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults,relatime${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab
 		if [[ $ROOTFS_TYPE == btrfs ]]; then
 			call_extension_method "btrfs_root_add_subvolumes_fstab" <<- 'BTRFS_ROOT_ADD_SUBVOLUMES_FSTAB'
 				run_host_command_logged mkdir -p $MOUNT/home


### PR DESCRIPTION
# Description

The `partitioning.sh` script was generating a malformed `/etc/fstab` file when constructing mount options for the root filesystem. Specifically, logic errors produced double commas (e.g., `defaults,,commit=120`), causing ext4 systems to fail during the boot process. 

This PR fixes the string concatenation to ensure valid formatting. Additionally, I have switched the default mount option from `noatime` to `relatime` to improve performance while maintaining standard file access metadata.

[GitHub issue](github.com) reference: Fixes #9201
[Jira](armbian.atlassian.net) reference number: [AR-2805]

# Documentation summary for feature / change

- [x] short description: Fix malformed fstab double commas and update to relatime.
- [x] summary: Corrects root filesystem mount options in generated images to prevent boot failures.
- [x] example of usage: Inspecting `/etc/fstab` on a built image will show clean options: `defaults,relatime,commit=120`.

# How Has This Been Tested?

- [x] Test A: Built an image using partitioning.sh and verified /etc/fstab syntax is correct.
- [x] Test B: Booted the resulting image on hardware to confirm the fix resolves the boot failure.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2805]: https://armbian.atlassian.net/browse/AR-2805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized root filesystem mount options to improve access time performance while maintaining compatibility with existing mount configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->