### PR TITLE
sunxi: bump `current` and `edge` to latest minor

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -31,12 +31,12 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.64"
+		declare -g KERNELBRANCH="tag:v6.12.65"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.18.4"
+		declare -g KERNELBRANCH="tag:v6.18.5"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -32,12 +32,12 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.64"
+		declare -g KERNELBRANCH="tag:v6.12.65"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.18.4"
+		declare -g KERNELBRANCH="tag:v6.18.5"
 		;;
 esac
 


### PR DESCRIPTION
# Description

as per title
no rewrites necessary

# How Has This Been Tested?

- [x] build `current` sunxi and sunxi64 kernels
- [x] build `edge` sunxi and sunxi64 kernels

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kernel versions for Sunxi-based device configurations: current branch kernel updated to v6.12.65, edge branch kernel updated to v6.18.5.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->