### PR TITLE
sunxi: switch `current` and `edge` back to auto bumping

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -31,12 +31,10 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.65"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.18.5"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -32,12 +32,10 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.12.65"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.18.5"
 		;;
 esac
 


### PR DESCRIPTION
The sunxi patchset for 6.18 is in decent state now and 6.12 will receive bug fixes only. I think we can go back to auto bumping with these versions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed kernel branch metadata declarations from sunxi and sunxi64 device family configurations across current and edge release branches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->