### PR TITLE
sunxi-current: recover lost Makefile entries

### DIFF
--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/Add-wifi-nodes-for-Inovato-Quadra.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/Add-wifi-nodes-for-Inovato-Quadra.patch
@@ -4,9 +4,22 @@ Date: Tue, 19 Sep 2023 11:06:01 +0000
 Subject: Add wifi nodes for Inovato Quadra
 
 ---
+ arch/arm64/boot/dts/allwinner/Makefile                     |  1 +
  arch/arm64/boot/dts/allwinner/sun50i-h6-inovato-quadra.dts | 56 ++++++++++
- 1 file changed, 56 insertions(+)
+ 2 files changed, 57 insertions(+)
 
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -49,6 +49,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-one-plus.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64-model-b.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-inovato-quadra.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h313-tanix-tx1.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-manta.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-inovato-quadra.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-inovato-quadra.dts
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/add-initial-support-for-orangepi3-lts.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/add-initial-support-for-orangepi3-lts.patch
@@ -4,9 +4,22 @@ Date: Sat, 16 Apr 2022 11:51:35 +0300
 Subject: add initial support for orangepi3-lts
 
 ---
+ arch/arm64/boot/dts/allwinner/Makefile                     |   1 +
  arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3-lts.dts | 399 ++++++++++
- 1 file changed, 399 insertions(+)
+ 2 files changed, 400 insertions(+)
 
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -43,6 +43,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-beelink-gs1.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-3.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-3-lts.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-lite2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-one-plus.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3-lts.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3-lts.dts
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm-dts-Add-sun8i-h2-plus-nanopi-duo-device.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm-dts-Add-sun8i-h2-plus-nanopi-duo-device.patch
@@ -4,9 +4,22 @@ Date: Mon, 24 Jan 2022 15:00:36 +0300
 Subject: arm:dts: Add sun8i-h2-plus-nanopi-duo device
 
 ---
+ arch/arm/boot/dts/allwinner/Makefile                     |   1 +
  arch/arm/boot/dts/allwinner/sun8i-h2-plus-nanopi-duo.dts | 164 ++++++++++
- 1 file changed, 164 insertions(+)
+ 2 files changed, 165 insertions(+)
 
+diff --git a/arch/arm/boot/dts/allwinner/Makefile b/arch/arm/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm/boot/dts/allwinner/Makefile
++++ b/arch/arm/boot/dts/allwinner/Makefile
+@@ -221,6 +221,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+ 	sun8i-a83t-tbs-a711.dtb \
+ 	sun8i-h2-plus-bananapi-m2-zero.dtb \
+ 	sun8i-h2-plus-libretech-all-h3-cc.dtb \
++	sun8i-h2-plus-nanopi-duo.dtb \
+ 	sun8i-h2-plus-orangepi-r1.dtb \
+ 	sun8i-h2-plus-orangepi-zero.dtb \
+ 	sun8i-h3-bananapi-m2-plus.dtb \
 diff --git a/arch/arm/boot/dts/allwinner/sun8i-h2-plus-nanopi-duo.dts b/arch/arm/boot/dts/allwinner/sun8i-h2-plus-nanopi-duo.dts
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm-dts-Add-sun8i-h2-plus-sunvell-r69-device.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm-dts-Add-sun8i-h2-plus-sunvell-r69-device.patch
@@ -4,9 +4,22 @@ Date: Mon, 24 Jan 2022 15:23:33 +0300
 Subject: arm:dts: Add sun8i-h2-plus-sunvell-r69 device
 
 ---
+ arch/arm/boot/dts/allwinner/Makefile                      |   1 +
  arch/arm/boot/dts/allwinner/sun8i-h2-plus-sunvell-r69.dts | 225 ++++++++++
- 1 file changed, 225 insertions(+)
+ 2 files changed, 226 insertions(+)
 
+diff --git a/arch/arm/boot/dts/allwinner/Makefile b/arch/arm/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm/boot/dts/allwinner/Makefile
++++ b/arch/arm/boot/dts/allwinner/Makefile
+@@ -224,6 +224,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+ 	sun8i-h2-plus-nanopi-duo.dtb \
+ 	sun8i-h2-plus-orangepi-r1.dtb \
+ 	sun8i-h2-plus-orangepi-zero.dtb \
++	sun8i-h2-plus-sunvell-r69.dtb \
+ 	sun8i-h3-bananapi-m2-plus.dtb \
+ 	sun8i-h3-bananapi-m2-plus-v1.2.dtb \
+ 	sun8i-h3-beelink-x2.dtb \
 diff --git a/arch/arm/boot/dts/allwinner/sun8i-h2-plus-sunvell-r69.dts b/arch/arm/boot/dts/allwinner/sun8i-h2-plus-sunvell-r69.dts
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-allwinner-Add-sun50i-h618-bananapi-m4-berry-support.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-allwinner-Add-sun50i-h618-bananapi-m4-berry-support.patch
@@ -4,10 +4,23 @@ Date: Mon, 24 Mar 2025 22:19:31 +0300
 Subject: arm64: allwinner: Add sun50i-h618-bananapi-m4-berry support
 
 ---
+ arch/arm64/boot/dts/allwinner/Makefile                          |   1 +
  arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi                  |   4 +-
  arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-berry.dts | 355 ++++++++++
- 2 files changed, 357 insertions(+), 2 deletions(-)
+ 3 files changed, 358 insertions(+), 2 deletions(-)
 
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -59,6 +59,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-pi.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-bananapi-m4-berry.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-longanpi-3h.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero2w.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-k1-plus-device.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-k1-plus-device.patch
@@ -4,9 +4,22 @@ Date: Mon, 27 Nov 2017 10:23:51 +0800
 Subject: arm64:dts: Add sun50i-h5-nanopi-k1-plus device
 
 ---
+ arch/arm64/boot/dts/allwinner/Makefile                     |   1 +
  arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-k1-plus.dts | 396 ++++++++++
- 1 file changed, 396 insertions(+)
+ 2 files changed, 397 insertions(+)
 
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -29,6 +29,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s-h5.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-pc2.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-k1-plus.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-prime.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus2.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-k1-plus.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-k1-plus.dts
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-m1-plus2-device.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-m1-plus2-device.patch
@@ -4,9 +4,22 @@ Date: Mon, 24 Jan 2022 18:54:36 +0300
 Subject: arm64:dts: Add sun50i-h5-nanopi-m1-plus2 device
 
 ---
+ arch/arm64/boot/dts/allwinner/Makefile                      |   1 +
  arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-m1-plus2.dts | 240 ++++++++++
- 1 file changed, 240 insertions(+)
+ 2 files changed, 241 insertions(+)
 
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -32,6 +32,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-core2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s-h5.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-pc2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-k1-plus.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-m1-plus2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-prime.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus2.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-m1-plus2.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-m1-plus2.dts
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo-core2-device.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo-core2-device.patch
@@ -4,9 +4,22 @@ Date: Mon, 24 Jan 2022 18:43:42 +0300
 Subject: arm64:dts: Add sun50i-h5-nanopi-neo-core2 device
 
 ---
+ arch/arm64/boot/dts/allwinner/Makefile                       |   1 +
  arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-core2.dts | 210 ++++++++++
- 1 file changed, 210 insertions(+)
+ 2 files changed, 211 insertions(+)
 
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -27,6 +27,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-it.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h5-cc.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-core2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s-h5.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-pc2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-k1-plus.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-core2.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-core2.dts
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo2-v1.1-device.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo2-v1.1-device.patch
@@ -4,9 +4,22 @@ Date: Mon, 24 Jan 2022 18:49:55 +0300
 Subject: arm64:dts: Add sun50i-h5-nanopi-neo2-v1.1 device
 
 ---
+ arch/arm64/boot/dts/allwinner/Makefile                       |   1 +
  arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo2-v1.1.dts | 180 ++++++++++
- 1 file changed, 180 insertions(+)
+ 2 files changed, 181 insertions(+)
 
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -26,6 +26,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-cc.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-it.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h5-cc.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2-v1.1.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-core2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s-h5.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo2-v1.1.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo2-v1.1.dts
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-a64-olinuxino-add-boards.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-a64-olinuxino-add-boards.patch
@@ -4,13 +4,30 @@ Date: Wed, 5 Feb 2020 15:03:08 +0200
 Subject: arm64:dts:sun50i-a64-olinuxino add boards
 
 ---
+ arch/arm64/boot/dts/allwinner/Makefile                         |   5 +
  arch/arm64/boot/dts/allwinner/sun50i-a64-olinuxino-1G.dts      | 362 ++++++++++
  arch/arm64/boot/dts/allwinner/sun50i-a64-olinuxino-1Ge16GW.dts |  20 +
  arch/arm64/boot/dts/allwinner/sun50i-a64-olinuxino-1Ge4GW.dts  |  97 +++
  arch/arm64/boot/dts/allwinner/sun50i-a64-olinuxino-1Gs16M.dts  |  31 +
  arch/arm64/boot/dts/allwinner/sun50i-a64-olinuxino-2Ge8G.dts   |  25 +
- 5 files changed, 535 insertions(+)
+ 6 files changed, 540 insertions(+)
 
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -5,6 +5,11 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-nanopi-a64.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-oceanic-5205-5inmfd.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-olinuxino.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-olinuxino-emmc.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-olinuxino-1G.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-olinuxino-1Ge4GW.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-olinuxino-1Ge16GW.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-olinuxino-1Gs16M.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-olinuxino-2Ge8G.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-orangepi-win.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pine64-lts.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pine64-plus.dtb sun50i-a64-pine64.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-olinuxino-1G.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-olinuxino-1G.dts
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h313-x96q-lpddr3.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h313-x96q-lpddr3.patch
@@ -8,10 +8,23 @@ Add support X96Q TV Box LPDDR3 H313
 Author: sicXnull <notifications@github.com>
 Signed-off-by: The-going <48602507+The-going@users.noreply.github.com>
 ---
+ arch/arm64/boot/dts/allwinner/Makefile                    |   1 +
  arch/arm64/boot/dts/allwinner/sun50i-h313-cpu-opp.dtsi    |  92 +++
  arch/arm64/boot/dts/allwinner/sun50i-h313-x96q-lpddr3.dts | 305 ++++++++++
- 2 files changed, 397 insertions(+)
+ 3 files changed, 398 insertions(+)
 
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -52,6 +52,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-inovato-quadra.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h313-tanix-tx1.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h313-x96q-lpddr3.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-manta.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h313-cpu-opp.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h313-cpu-opp.dtsi
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-sd-emmc.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-sd-emmc.patch
@@ -35,11 +35,25 @@ Subject: arm64: dts: sun50i-h616-bigtreetech-cb1(sd, emmc)
 > X-Git-Archeology:   Subject: Allwinner: Add kernel patches for 6.7 kernel
 > X-Git-Archeology:
 ---
+ arch/arm64/boot/dts/allwinner/Makefile                             |   2 +
  arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1-emmc.dts |  44 ++
  arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1-sd.dts   |  35 ++
  arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi     | 223 +++++++++-
- 3 files changed, 285 insertions(+), 17 deletions(-)
+ 4 files changed, 287 insertions(+), 17 deletions(-)
 
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -51,6 +51,8 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h313-tanix-tx1.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-manta.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-pi.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1-emmc.dts b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1-emmc.dts
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.megous/Add-support-for-my-private-Sapomat-device.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.megous/Add-support-for-my-private-Sapomat-device.patch
@@ -4,9 +4,22 @@ Date: Fri, 18 Aug 2017 13:56:06 +0200
 Subject: Add support for my private Sapomat device
 
 ---
+ arch/arm/boot/dts/allwinner/Makefile                         |  1 +
  arch/arm/boot/dts/allwinner/sun8i-h3-orangepi-pc-sapomat.dts | 34 ++++++++++
- 1 file changed, 34 insertions(+)
+ 2 files changed, 35 insertions(+)
 
+diff --git a/arch/arm/boot/dts/allwinner/Makefile b/arch/arm/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm/boot/dts/allwinner/Makefile
++++ b/arch/arm/boot/dts/allwinner/Makefile
+@@ -238,6 +238,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+ 	sun8i-h3-orangepi-lite.dtb \
+ 	sun8i-h3-orangepi-one.dtb \
+ 	sun8i-h3-orangepi-pc.dtb \
++	sun8i-h3-orangepi-pc-sapomat.dtb \
+ 	sun8i-h3-orangepi-pc-plus.dtb \
+ 	sun8i-h3-orangepi-plus.dtb \
+ 	sun8i-h3-orangepi-plus2e.dtb \
 diff --git a/arch/arm/boot/dts/allwinner/sun8i-h3-orangepi-pc-sapomat.dts b/arch/arm/boot/dts/allwinner/sun8i-h3-orangepi-pc-sapomat.dts
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/kernel/archive/sunxi-6.12/patches.megous/arm64-dts-sun50i-a64-pinephone-Add-support-for-Pinephone-1.2-be.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.megous/arm64-dts-sun50i-a64-pinephone-Add-support-for-Pinephone-1.2-be.patch
@@ -7,10 +7,23 @@ Beta versions uses a different magnetometer chip.
 
 Signed-off-by: Ondrej Jirman <megi@xff.cz>
 ---
+ arch/arm64/boot/dts/allwinner/Makefile                      |  1 +
  arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-1.2b.dts | 29 ++++++++++
  arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi     | 12 ----
- 2 files changed, 29 insertions(+), 12 deletions(-)
+ 3 files changed, 30 insertions(+), 12 deletions(-)
 
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -12,6 +12,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pinebook.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pinephone-1.0.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pinephone-1.1.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pinephone-1.2.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pinephone-1.2b.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pinetab.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pinetab-early-adopter.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-sopine-baseboard.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-1.2b.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-1.2b.dts
 new file mode 100644
 index 000000000000..111111111111


### PR DESCRIPTION
# Description

With the rewrite of the patches in https://github.com/armbian/build/pull/9195 patching_config stripped Makefile entries, causing multiple device trees not being built.

This was caused by patching_config stripping commits to Makefile. Since nobody ever before attempted to rewrite the patchset, nobody noticed this being an issue. Easy fix for the future is to avoid rewriting or rebuild the whole patchset properly like it was done for sunxi-6.18....I prefer former. I won't do that again.

# How Has This Been Tested?

- [x] build sunxi64-current https://paste.armbian.de/kumofagugi


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added support for multiple Allwinner-based single-board computers and embedded devices, including Inovato Quadra, OrangePi 3 LTS, NanoPi series (Duo, K1 Plus, M1 Plus2, Neo Core2, Neo2), BananaPi M4 Berry, OLinuXino boards, X96Q TV Box, BigTreeTech CB1, PinePhone 1.2b, and Sapomat device.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->