### PR TITLE
rockchip64-6.19: arm64: dts: rockchip: describe pcie ethernets on FriendlyElec NanoPC-T6

### DIFF
--- a/patch/kernel/archive/rockchip64-6.19/rk3588-1220-arm64-dts-rockchip-describe-pcie-ethernets-on-FriendlyElec-NanoPC-T6.patch
+++ b/patch/kernel/archive/rockchip64-6.19/rk3588-1220-arm64-dts-rockchip-describe-pcie-ethernets-on-FriendlyElec-NanoPC-T6.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 12 Jan 2026 19:25:15 +0100
+Subject: arm64: dts: rockchip: describe pcie ethernets on FriendlyElec
+ NanoPC-T6
+
+By fully describing the pcie hardware for the RTL8125s (rtl8169) present on the
+board, we get to alias them to ethernet0/1. In return, (mainline) u-boot will by
+default patch the runtime FDT though it's fdt_fixup_ethernet() implementation,
+hopefully resulting in fully stable MAC addresses without the need to program
+the RTL NIC's EEPROM; as an added benefit, u-boot MAC & kernel MAC would match,
+facilitating network-boot setups.
+
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 36 ++++++++++
+ 1 file changed, 36 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -21,6 +21,8 @@ / {
+ 	aliases {
+ 		mmc0 = &sdhci;
+ 		mmc1 = &sdmmc;
++		ethernet0 = &ethernet0;
++		ethernet1 = &ethernet1;
+ 	};
+ 
+ 	adc-keys-0 {
+@@ -640,6 +642,23 @@ &pcie2x1l1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie2_1_rst>;
+ 	status = "okay";
++
++	pcie@0,0 {
++		reg = <0x200000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++		device_type = "pci";
++		bus-range = <0x20 0x2f>;
++
++		ethernet0: ethernet@0,0 {
++			compatible = "pci10ec,8125";
++			reg = <0x210000 0 0 0 0>;
++			device_type = "network";
++			status = "okay";
++			mac-address = [00 00 00 00 00 00]; // to be patched by U-Boot
++		};
++	};
+ };
+ 
+ &pcie2x1l2 {
+@@ -648,6 +667,23 @@ &pcie2x1l2 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie2_2_rst>;
+ 	status = "okay";
++
++	pcie@0,0 {
++		reg = <0x400000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++		device_type = "pci";
++		bus-range = <0x40 0x4f>;
++
++		ethernet1: ethernet@0,0 {
++			compatible = "pci10ec,8125";
++			reg = <0x410000 0 0 0 0>;
++			device_type = "network";
++			status = "okay";
++			mac-address = [00 00 00 00 00 00]; // to be patched by U-Boot
++		};
++	};
+ };
+ 
+ &pcie30phy {
+-- 
+Armbian
+


### PR DESCRIPTION
- 🌱 By fully describing the pcie hardware for the RTL8125s (rtl8169) present on the board, we get to alias them to ethernet0/1. In return, (mainline) u-boot will by default patch the runtime FDT though it's fdt_fixup_ethernet() implementation, hopefully resulting in fully stable MAC addresses without the need to program the RTL NIC's EEPROM; as an added benefit, u-boot MAC & kernel MAC would match, facilitating network-boot setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PCIe ethernet devices on NanoPC-T6 platform.
  * Configured dual ethernet interfaces (ethernet0 and ethernet1) mapped to PCIe bridges.
  * Updated MAC address configuration for stable network initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->