### PR TITLE
Fix Panther-X2

### DIFF
--- a/config/boards/panther-x2.csc
+++ b/config/boards/panther-x2.csc
@@ -12,3 +12,13 @@ BOOT_FDT_FILE="rockchip/rk3566-panther-x2.dtb"
 IMAGE_PARTITION_TABLE="gpt"
 BOOT_SCENARIO="spl-blobs"
 BOOTFS_TYPE="fat"
+
+function post_family_config__use_radxa_rock3_uboot() {
+    display_alert "Overriding U-Boot source" "Using Radxa stable-4.19-rock3" "info"
+    
+    BOOTSOURCE="https://github.com/radxa/u-boot.git"
+    BOOTBRANCH="branch:stable-4.19-rock3"
+    BOOTPATCHDIR="none"
+    BOOTPATCHES="none"
+    SKIP_BOOTSPLASH_PATCHES="yes"
+}

--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3566-panther-x2.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3566-panther-x2.dts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
  * Copyright (c) 2023 tdleiyao <tdleiyao@gmail.com>
+ * WiFi, I2C, and SPI additions
  */
  
 /dts-v1/;
@@ -408,6 +409,27 @@
 	};
 };
 
+/* I2C2 - General purpose I2C */
+&i2c2 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2m1_xfer>;
+};
+
+/* I2C3 - General purpose I2C */
+&i2c3 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c3m0_xfer>;
+};
+
+/* I2C4 - General purpose I2C */
+&i2c4 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c4m0_xfer>;
+};
+
 &i2s1_8ch {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2s1m1_sclktx &i2s1m1_sclkrx
@@ -417,6 +439,19 @@
 		     &i2s1m1_sdo0   &i2s1m1_sdo1
 		     &i2s1m1_sdo2   &i2s1m1_sdo3>;
 	status = "disabled";
+};
+
+/* SPI0 - with spidev for userspace access */
+&spi0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	
+	spidev@0 {
+		compatible = "armbian,spi-dev";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+	};
 };
 
 &pinctrl {	
@@ -521,6 +556,8 @@
 	pinctrl-0 = <&sdmmc1_bus4 &sdmmc1_cmd &sdmmc1_clk>;
 	non-removable;
 	mmc-pwrseq = <&sdio_pwrseq>;
+	vmmc-supply = <&vcc3v3_sys>;
+	vqmmc-supply = <&vcc_1v8>;
 	status = "okay";
 
 };


### PR DESCRIPTION
# Description

The current build for PantherX2 is broken at a u-boot level. Upon testing various builds the stable-4.19-rock3 branch allowed for proper booting, which makes sense as these boards were originally shipped with kernel 4.x

Also added i2c and Spidev to match the original functionality of the board (helium miner) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced hardware support for Panther X2 board including new peripheral interfaces and improved SD/MMC power configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->