### PR TITLE
rockchip64: station-m3: Enable USB type-C port

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/rk3588-1213-arm64-dts-rk3588s-roc-pc-Enable-USB-type-C-port.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3588-1213-arm64-dts-rk3588s-roc-pc-Enable-USB-type-C-port.patch
@@ -1,0 +1,144 @@
+From 3e3aee95bc3f1dbc3da203a04f0e0d4a70b193e7 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sat, 13 Apr 2024 18:25:27 +0800
+Subject: [PATCH] arm64: dts: rk3588s-roc-pc: Enable USB type-C port
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ .../boot/dts/rockchip/rk3588s-roc-pc.dts      | 98 ++++++++++++++++++-
+ 1 file changed, 97 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
+index c5d6206b49bb9..c6d8e126ff633 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
+@@ -319,6 +319,57 @@ hym8563: rtc@51 {
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&hym8563_int>;
+ 	};
++
++	usbc0: fusb302@22 {
++		status = "okay";
++		compatible = "fcs,fusb302";
++		reg = <0x22>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PC4 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usbc0_int>;
++		vbus-supply = <&vbus5v0_typec>;
++
++		connector {
++			compatible = "usb-c-connector";
++			data-role = "dual";
++			label = "USB-C";
++			op-sink-microwatt = <1000000>;
++			power-role = "dual";
++			self-powered;
++			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++				     PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
++				     PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)>;
++			source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
++			try-power-role = "sink";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++					usbc0_orien_sw: endpoint {
++						remote-endpoint = <&usbdp_phy0_orientation_switch>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++					usbc0_role_sw: endpoint {
++						remote-endpoint = <&dwc3_0_role_switch>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++					dp_altmode_mux: endpoint {
++						remote-endpoint = <&usbdp_phy0_dp_altmode_mux>;
++					};
++				};
++			};
++		};
++	};
+ };
+ 
+ &i2c3 {
+@@ -434,6 +485,16 @@ typec5v_pwren: typec5v-pwren {
+ 			rockchip,pins = <1 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
++		usbc0_int: usbc0-int {
++			rockchip,pins = <0 RK_PC4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		usbc_sbu_dc: usbc-sbu-dc {
++			rockchip,pins =
++				<4 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>,
++				<4 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
+ 		vcc5v0_host_en: vcc5v0-host-en {
+ 			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+@@ -848,8 +909,17 @@ &usb_host0_ohci {
+ };
+ 
+ &usb_host0_xhci {
+-	extcon = <&u2phy0>;
++	usb-role-switch;
+ 	status = "okay";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		dwc3_0_role_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_role_sw>;
++		};
++	};
+ };
+ 
+ &usb_host1_ehci {
+@@ -864,6 +934,32 @@ &usb_host2_xhci {
+ 	status = "okay";
+ };
+ 
++&usbdp_phy0 {
++	mode-switch;
++	orientation-switch;
++	pinctrl-0 = <&usbc_sbu_dc>;
++	pinctrl-names = "default";
++	sbu1-dc-gpios = <&gpio4 RK_PB5 GPIO_ACTIVE_HIGH>;
++	sbu2-dc-gpios = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
++	rockchip,dp-lane-mux = <2 3>;
++	status = "okay";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		usbdp_phy0_orientation_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_orien_sw>;
++		};
++
++		usbdp_phy0_dp_altmode_mux: endpoint@1 {
++			reg = <1>;
++			remote-endpoint = <&dp_altmode_mux>;
++		};
++	};
++};
++
+ &vop {
+ 	status = "okay";
+ };
+-- 
+2.43.0
+

--- a/patch/kernel/archive/rockchip64-6.19/rk3588-1213-arm64-dts-rk3588s-roc-pc-Enable-USB-type-C-port.patch
+++ b/patch/kernel/archive/rockchip64-6.19/rk3588-1213-arm64-dts-rk3588s-roc-pc-Enable-USB-type-C-port.patch
@@ -1,0 +1,144 @@
+From 3e3aee95bc3f1dbc3da203a04f0e0d4a70b193e7 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sat, 13 Apr 2024 18:25:27 +0800
+Subject: [PATCH] arm64: dts: rk3588s-roc-pc: Enable USB type-C port
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ .../boot/dts/rockchip/rk3588s-roc-pc.dts      | 98 ++++++++++++++++++-
+ 1 file changed, 97 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
+index c5d6206b49bb9..c6d8e126ff633 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
+@@ -319,6 +319,57 @@ hym8563: rtc@51 {
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&hym8563_int>;
+ 	};
++
++	usbc0: fusb302@22 {
++		status = "okay";
++		compatible = "fcs,fusb302";
++		reg = <0x22>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PC4 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usbc0_int>;
++		vbus-supply = <&vbus5v0_typec>;
++
++		connector {
++			compatible = "usb-c-connector";
++			data-role = "dual";
++			label = "USB-C";
++			op-sink-microwatt = <1000000>;
++			power-role = "dual";
++			self-powered;
++			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++				     PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
++				     PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)>;
++			source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
++			try-power-role = "sink";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++					usbc0_orien_sw: endpoint {
++						remote-endpoint = <&usbdp_phy0_orientation_switch>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++					usbc0_role_sw: endpoint {
++						remote-endpoint = <&dwc3_0_role_switch>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++					dp_altmode_mux: endpoint {
++						remote-endpoint = <&usbdp_phy0_dp_altmode_mux>;
++					};
++				};
++			};
++		};
++	};
+ };
+ 
+ &i2c3 {
+@@ -434,6 +485,16 @@ typec5v_pwren: typec5v-pwren {
+ 			rockchip,pins = <1 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
++		usbc0_int: usbc0-int {
++			rockchip,pins = <0 RK_PC4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		usbc_sbu_dc: usbc-sbu-dc {
++			rockchip,pins =
++				<4 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>,
++				<4 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
+ 		vcc5v0_host_en: vcc5v0-host-en {
+ 			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+@@ -848,8 +909,17 @@ &usb_host0_ohci {
+ };
+ 
+ &usb_host0_xhci {
+-	extcon = <&u2phy0>;
++	usb-role-switch;
+ 	status = "okay";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		dwc3_0_role_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_role_sw>;
++		};
++	};
+ };
+ 
+ &usb_host1_ehci {
+@@ -864,6 +934,32 @@ &usb_host2_xhci {
+ 	status = "okay";
+ };
+ 
++&usbdp_phy0 {
++	mode-switch;
++	orientation-switch;
++	pinctrl-0 = <&usbc_sbu_dc>;
++	pinctrl-names = "default";
++	sbu1-dc-gpios = <&gpio4 RK_PB5 GPIO_ACTIVE_HIGH>;
++	sbu2-dc-gpios = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
++	rockchip,dp-lane-mux = <2 3>;
++	status = "okay";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		usbdp_phy0_orientation_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_orien_sw>;
++		};
++
++		usbdp_phy0_dp_altmode_mux: endpoint@1 {
++			reg = <1>;
++			remote-endpoint = <&dp_altmode_mux>;
++		};
++	};
++};
++
+ &vop {
+ 	status = "okay";
+ };
+-- 
+2.43.0
+


### PR DESCRIPTION
# Description

Enable the USB Type-C port on station-m3

# How Has This Been Tested?

1. Connect a USB device to the type-C port
2. Check lsusb output
3. Verify the USB device functionality
4. Disconnect USB device
5. Check lsusb output again


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * USB Type-C port enabled with Power Delivery for improved charging and power negotiation.
  * USB On-The-Go (OTG) and dynamic host/device role switching activated.
  * Automatic connector orientation detection and DisplayPort alt-mode support for video over USB-C.
  * Added hardware-level controls for VBUS/5V host enable and SBU signal handling to improve interoperability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->