### PR TITLE
Fix OP-TEE build on Ubuntu Jammy (older binutils)

### DIFF
--- a/config/sources/families/nuvoton-ma35d1.conf
+++ b/config/sources/families/nuvoton-ma35d1.conf
@@ -116,6 +116,13 @@ function uboot_custom_postprocess() {
 
 		local cross_compile="aarch64-linux-gnu-"
 
+		# Check if linker supports --no-warn-rwx-segments (binutils 2.39+)
+		# Workaround for ubuntu:jammy older toolchain
+		local ldflags=""
+		if ${cross_compile}ld --help 2>&1 | grep -q "no-warn-rwx-segments"; then
+			ldflags="--no-warn-rwx-segments"
+		fi
+
 		run_host_command_logged make -C "${optee_src_dir}" clean PLATFORM=nuvoton-MA35D1 2>/dev/null || true
 
 		display_alert "Building OP-TEE" "PLATFORM=nuvoton-MA35D1" "info"
@@ -125,7 +132,7 @@ function uboot_custom_postprocess() {
 			PLATFORM=nuvoton-MA35D1 \
 			CFG_ARM64_core=y \
 			CFG_TEE_CORE_LOG_LEVEL=1 \
-			LDFLAGS="--no-warn-rwx-segments" \
+			LDFLAGS="${ldflags}" \
 			NOWERROR=1 \
 			-j$(nproc)
 


### PR DESCRIPTION
## Summary
- Fix OP-TEE build failure on Ubuntu Jammy due to unsupported linker flag
- The `--no-warn-rwx-segments` flag is only available in binutils 2.39+
- Added conditional check before using the flag

## Changes
```bash
# Check if linker supports --no-warn-rwx-segments (binutils 2.39+)
# Workaround for ubuntu:jammy older toolchain
local ldflags=""
if ${cross_compile}ld --help 2>&1 | grep -q "no-warn-rwx-segments"; then
    ldflags="--no-warn-rwx-segments"
fi
```

## Testing

- Successfully built u-boot on ubuntu:jammy with DOCKER_ARMBIAN_BASE_IMAGE="ubuntu:jammy"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced build compatibility by implementing runtime detection for linker flag support, enabling the OP-TEE build system to work seamlessly with a broader range of cross-compiler toolchains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->