### PR TITLE
rockchip64: Helios64: fix Type-C PD negotiation

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.18/add-board-helios64.patch
@@ -596,7 +596,7 @@ index 111111111111..222222222222 100644
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&fusb0_int>;
 +		vbus-supply = <&vcc5v0_typec>;
-+		usb-role-switch = <&typec_extcon_bridge>;
++		extcon = <&typec_extcon_bridge>;
 +
 +		connector {
 +			compatible = "usb-c-connector";

--- a/patch/kernel/archive/rockchip64-6.19/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.19/add-board-helios64.patch
@@ -252,7 +252,7 @@ index 111111111111..222222222222 100644
  	vcc12v_dcin: regulator-vcc12v-dcin {
  		compatible = "regulator-fixed";
  		regulator-name = "vcc12v_dcin";
-@@ -227,36 +375,60 @@ vcc12v_dcin_bkup: regulator-vcc12v-dcin-bkup {
+@@ -227,36 +375,68 @@ vcc12v_dcin_bkup: regulator-vcc12v-dcin-bkup {
  		regulator-max-microvolt = <12000000>;
  		vin-supply = <&vcc12v_dcin>;
  	};
@@ -336,6 +336,14 @@ index 111111111111..222222222222 100644
 +		rockchip,cpu = <&i2s2>;
 +		rockchip,codec = <&cdn_dp>;
 +	};
++
++	typec_extcon_bridge: typec-extcon {
++		compatible = "linux,typec-extcon-bridge";
++		usb-role-switch;
++		orientation-switch;
++		mode-switch;
++		svid = /bits/ 16 <0xff01>;
++	};
  };
  
  &cpu_l0 {
@@ -353,7 +361,7 @@ index 111111111111..222222222222 100644
 +
 +&cdn_dp {
 +	status = "okay";
-+	extcon = <&fusb0>;
++	extcon = <&typec_extcon_bridge>;
 +	phys = <&tcphy0_dp>;
 +};
 +
@@ -550,7 +558,7 @@ index 111111111111..222222222222 100644
  		vin-supply = <&vcc5v0_sys>;
  
  		regulator-state-mem {
-@@ -404,17 +696,101 @@ &i2c2 {
+@@ -404,17 +696,108 @@ &i2c2 {
  	i2c-scl-falling-time-ns = <30>;
  	status = "okay";
  
@@ -588,6 +596,7 @@ index 111111111111..222222222222 100644
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&fusb0_int>;
 +		vbus-supply = <&vcc5v0_typec>;
++		extcon = <&typec_extcon_bridge>;
 +
 +		connector {
 +			compatible = "usb-c-connector";
@@ -595,12 +604,18 @@ index 111111111111..222222222222 100644
 +			power-role = "dual";
 +			data-role = "dual";
 +			try-power-role = "sink";
-+			source-pdos = <PDO_FIXED(5000, 1200, PDO_FIXED_USB_COMM)>;
-+			sink-pdos = <PDO_FIXED(5000, 500, PDO_FIXED_USB_COMM)>;
++			source-pdos = <PDO_FIXED(5000, 1200, PDO_FIXED_USB_COMM | PDO_FIXED_DUAL_ROLE | PDO_FIXED_DATA_SWAP)>;
++			sink-pdos = <PDO_FIXED(5000, 500, PDO_FIXED_USB_COMM | PDO_FIXED_DUAL_ROLE | PDO_FIXED_DATA_SWAP)>;
 +			op-sink-microwatt = <5000000>;
++			mode-switch = <&typec_extcon_bridge>;
++			orientation-switch = <&typec_extcon_bridge>;
 +
-+			extcon-cables = <1 2 5 6 9 10 12 44>;
-+			typec-altmodes = <0xff01 1 0x001c0000 1>;
++			altmodes {
++				dp {
++					svid = /bits/ 16 <0xff01>;
++					vdo = <0x1c46>;
++				};
++			};
 +
 +			ports {
 +				#address-cells = <1>;
@@ -841,7 +856,7 @@ index 111111111111..222222222222 100644
  };
  
 +&tcphy0 {
-+	extcon = <&fusb0>;
++	extcon = <&typec_extcon_bridge>;
 +	status = "okay";
 +};
 +
@@ -864,12 +879,14 @@ index 111111111111..222222222222 100644
  &tcphy1 {
  	/* phy for &usbdrd_dwc3_1 */
  	status = "okay";
-@@ -559,61 +1056,118 @@ &tsadc {
+@@ -559,61 +1056,122 @@ &tsadc {
  	status = "okay";
  };
  
 -&u2phy1 {
 +&u2phy0 {
++	extcon = <&typec_extcon_bridge>;
++	extcon,ignore-usb;
  	status = "okay";
  
 -	otg-port {
@@ -923,6 +940,8 @@ index 111111111111..222222222222 100644
 +&usbdrd_dwc3_0 {
 +	status = "okay";
 +	dr_mode = "otg";
++	extcon = <&typec_extcon_bridge>;
++	snps,usb3-phy-reset-quirk;
 +};
 +
  &usbdrd3_1 {


### PR DESCRIPTION
Remove usb-role-switch property from fusb302 node and replace with extcon property. The usb-role-switch property breaks PD negotiation and DP alt mode on kernel 6.18+.

Fix based on PR #9245 (Pinebook Pro) by amazingfate.

Apply Helios64: fix Type-C PHY registration #9158 to 6.19.

- [x] Build image for Helios64 with kernel 6.18, check hardware status
- [x] Build image for Helios64 with kernel 6.19-rc5, check hardware status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced USB-C Power Delivery capabilities with improved connector support
  * Added LED status indicators for network, USB, SATA, and system monitoring
  * Improved power management with updated regulator configurations
  * Expanded device connectivity with additional I2C controllers and USB host configurations
  * Enhanced PCIe power sequencing and control

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->