### PR TITLE
khadas-vim3l: u-boot: update v2026.01 u-boot fanciness

### DIFF
--- a/config/boards/khadas-vim3l.conf
+++ b/config/boards/khadas-vim3l.conf
@@ -45,34 +45,60 @@ function post_uboot_custom_postprocess__khadas_vim3l_uboot() {
 
 # Enable extra u-boot .config options, this way we avoid patching defconfig
 function post_config_uboot_target__extra_configs_for_khadas_vim3l() {
-	display_alert "u-boot for ${BOARD}" "u-boot: enable EFI debugging command" "info"
-	run_host_command_logged scripts/config --enable CMD_EFIDEBUG
-	run_host_command_logged scripts/config --enable CMD_NVEDIT_EFI
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable preboot & flash user LED in preboot" "info"
+	run_host_command_logged scripts/config --enable CONFIG_USE_PREBOOT
+	run_host_command_logged scripts/config --set-str CONFIG_PREBOOT "'led white:status on; led red:status on; sleep 0.1; led white:status off; led red:status off;'" # double quotes required due to run_host_command_logged's quirks
 
-	display_alert "u-boot for ${BOARD}" "u-boot: enable I2C support" "info"
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable I2C support" "info"
 	run_host_command_logged scripts/config --enable CONFIG_DM_I2C
 	run_host_command_logged scripts/config --enable CONFIG_SYS_I2C_MESON
 	run_host_command_logged scripts/config --enable CONFIG_CMD_I2C
 
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable GPIO expander support" "info" # to drive 'red' led
+	run_host_command_logged scripts/config --enable CONFIG_MAX7320_GPIO
+	run_host_command_logged scripts/config --enable CONFIG_CMD_PCA953X
+	run_host_command_logged scripts/config --enable CONFIG_DM_PCA953X
+
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable EFI debugging commands" "info"
+	run_host_command_logged scripts/config --enable CMD_EFIDEBUG
+	run_host_command_logged scripts/config --enable CMD_NVEDIT_EFI
+
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable more filesystems support" "info"
 	run_host_command_logged scripts/config --enable CONFIG_CMD_BTRFS
 
-	display_alert "u-boot for ${BOARD}" "u-boot: enable more compression support" "info"
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable more compression support" "info"
 	run_host_command_logged scripts/config --enable CONFIG_LZO
 	run_host_command_logged scripts/config --enable CONFIG_BZIP2
 	run_host_command_logged scripts/config --enable CONFIG_ZSTD
 
-	display_alert "u-boot for ${BOARD}" "u-boot: enable kaslrseed support" "info"
-	run_host_command_logged scripts/config --enable CONFIG_CMD_KASLRSEED
-
-	display_alert "u-boot for ${BOARD}" "u-boot: enable gpio LED support" "info"
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable gpio LED support" "info"
 	run_host_command_logged scripts/config --enable CONFIG_LED
 	run_host_command_logged scripts/config --enable CONFIG_LED_GPIO
 
-	display_alert "u-boot for ${BOARD}" "u-boot: enable networking cmds" "info"
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable some USB ethernet drivers" "info"
+	run_host_command_logged scripts/config --enable CONFIG_USB_HOST_ETHER
+	run_host_command_logged scripts/config --enable CONFIG_USB_ETHER_ASIX
+	run_host_command_logged scripts/config --enable CONFIG_USB_ETHER_ASIX88179
+	run_host_command_logged scripts/config --enable CONFIG_USB_ETHER_MCS7830
+	run_host_command_logged scripts/config --enable CONFIG_USB_ETHER_RTL8152
+	run_host_command_logged scripts/config --enable CONFIG_USB_ETHER_SMSC95XX
+
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable networking cmds" "info"
 	run_host_command_logged scripts/config --enable CONFIG_CMD_NFS
 	run_host_command_logged scripts/config --enable CONFIG_CMD_WGET
 	run_host_command_logged scripts/config --enable CONFIG_CMD_DNS
 	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP
-	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP_SACK
+
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable LWIP (new networking stack)" "info"
+	run_host_command_logged scripts/config --enable CONFIG_CMD_MII
+	run_host_command_logged scripts/config --enable CONFIG_NET_LWIP
+
+	# UMS, RockUSB, gadget stuff
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable UMS/RockUSB gadget" "info"
+	declare -a enable_configs=("CONFIG_CMD_USB_MASS_STORAGE" "CONFIG_USB_GADGET" "USB_GADGET_DOWNLOAD" "CONFIG_USB_FUNCTION_ACM")
+	for config in "${enable_configs[@]}"; do
+		run_host_command_logged scripts/config --enable "${config}"
+	done
+	# Auto-enabled by the above, force off...
+	run_host_command_logged scripts/config --disable USB_FUNCTION_FASTBOOT
 }


### PR DESCRIPTION
- 🌱 use LWIP for networking
- 🌿 enable some USB network drivers
- 🍃 drop (now-default) kaslrseed as it was redundant
- 🍀 add gpio expander support (for "red" LED)
- 🐸 flash leds once on preboot (incl red one)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added USB mass storage device support for the Khadas VIM3L board
  * Enabled GPIO expander support for enhanced hardware control
  * Added EFI debugging and editing commands for advanced users

* **Improvements**
  * Enhanced diagnostic messages to include branch information for better troubleshooting
  * Expanded networking capabilities with USB Ethernet driver and LWIP stack support
  * Added preboot LED sequence customization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->