### PR TITLE
orangepi5-plus: u-boot: use mainline ATF; bump to v2026.01; drop funky CE config options

### DIFF
--- a/config/boards/orangepi5-plus.conf
+++ b/config/boards/orangepi5-plus.conf
@@ -10,9 +10,7 @@ KERNEL_TEST_TARGET="vendor,current"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3588-orangepi-5-plus.dtb"
-BOOT_SCENARIO="spl-blobs"
-BOOT_SUPPORT_SPI="yes"
-BOOT_SPI_RKSPI_LOADER="yes"
+BOOT_SCENARIO="tpl-blob-atf-mainline"
 IMAGE_PARTITION_TABLE="gpt"
 declare -g UEFI_EDK2_BOARD_ID="orangepi-5plus" # This _only_ used for uefi-edk2-rk3588 extension
 
@@ -37,10 +35,10 @@ function post_family_config__orangepi5plus_use_mainline_uboot() {
 	declare -g BOOTCONFIG="orangepi-5-plus-rk3588_defconfig"
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-	declare -g BOOTBRANCH="tag:v2025.10"
-	declare -g BOOTPATCHDIR="v2025.10"
+	declare -g BOOTBRANCH="tag:v2026.01"
+	declare -g BOOTPATCHDIR="v2026.01"
 	declare -g BOOTDIR="u-boot-${BOARD}"
-	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
 
 	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
@@ -51,14 +49,4 @@ function post_family_config__orangepi5plus_use_mainline_uboot() {
 	function write_uboot_platform_mtd() {
 		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
 	}
-}
-
-function post_config_uboot_target__extra_configs_for_rock5b_mainline_environment_in_spi() {
-	[[ "${BRANCH}" == "vendor" ]] && return 0
-
-	display_alert "$BOARD" "u-boot configs for ${BOOTBRANCH} u-boot config BRANCH=${BRANCH}" "info"
-	run_host_command_logged scripts/config --set-val CONFIG_BOARD_RNG_SEED "y"
-	run_host_command_logged scripts/config --set-val ARMV8_CRYPTO "y"
-	run_host_command_logged scripts/config --set-val ARMV8_CE_SHA1 "y"
-	run_host_command_logged scripts/config --set-val ARMV8_CE_SHA256 "y"
 }


### PR DESCRIPTION
- 🌱 also drop BOOT_SUPPORT_SPI & BOOT_SPI_RKSPI_LOADER as those are for vendor u-boot, not used here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated U-Boot version to 2026.01
  * Refined boot configuration for Orange Pi 5 Plus

* **Changes**
  * Switched boot scenario to the new mainline/ATF approach
  * Removed SPI boot support options
  * Adjusted U-Boot binary mapping and write behavior for the board

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->