### PR TITLE
work-around Ubuntu Rust coreutils bug in dirname affecting linux-headers board-side compile of scripts/mod

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -538,7 +538,7 @@ function kernel_package_callback_linux_headers() {
 			make ARCH="${SRC_ARCH}" -j\$NCPU scripts
 
 			echo "Compiling kernel-headers scripts/mod (${kernel_version_family}) using \$NCPU CPUs - please wait ..."
-			make ARCH="${SRC_ARCH}" -j\$NCPU M=scripts/mod/
+			make ARCH="${SRC_ARCH}" -j\$NCPU M=scripts/mod
 
 			echo "Compiling resolve_btfids tools for assigning stable BTF type IDs to kernel symbols"
 			make ARCH="${SRC_ARCH}" -j\$NCPU tools/bpf/resolve_btfids


### PR DESCRIPTION
## Summary

~~Since kernel 6.18, `make M=scripts/mod/` no longer works due to kbuild changes (commit 13b25489b6f8). The standard `make scripts` doesn't build scripts/mod (modpost, mk_elfconfig) which are required for DKMS/external module builds.~~

Actually it was Ubuntu Rust coreutils. See comments below.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kernel package compilation process for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->