### PR TITLE
docker: add automatic image pull cronjob and cleanup system

### DIFF
--- a/lib/functions/cli/cli-docker.sh
+++ b/lib/functions/cli/cli-docker.sh
@@ -48,6 +48,12 @@ function cli_docker_run() {
 
 	LOG_SECTION="docker_cli_prepare" do_with_logging docker_cli_prepare
 
+	# Ensure Docker auto-pull cronjob is installed (controlled by ARMBIAN_DOCKER_AUTO_PULL flag)
+	# Only run this when not generating Dockerfile only
+	if [[ "${DOCKERFILE_GENERATE_ONLY}" != "yes" ]]; then
+		docker_ensure_auto_pull_cronjob
+	fi
+
 	# @TODO: and can be very well said that in CI, we always want FAST_DOCKER=yes, unless we're building the Docker image itself.
 	if [[ "${FAST_DOCKER:-"no"}" != "yes" ]]; then # "no, I want *slow* docker" -- no one, ever
 		LOG_SECTION="docker_cli_prepare_dockerfile" do_with_logging docker_cli_prepare_dockerfile

--- a/lib/functions/cli/cli-requirements.sh
+++ b/lib/functions/cli/cli-requirements.sh
@@ -47,10 +47,4 @@ function cli_requirements_run() {
 	fi
 
 	display_alert "Done with" "@host dependencies" "cachehit"
-
-	# Ensure Docker auto-pull cronjob is installed if Docker is available
-	if [[ -n "$(command -v docker)" ]]; then
-		display_alert "Docker" "ensuring auto-pull cronjob is installed" "info"
-		docker_ensure_auto_pull_cronjob
-	fi
 }


### PR DESCRIPTION
## Motivation

Tired of waiting on pull to complete. This is especially annoying on not very good network connection.

## Summary
- Add automatic Docker image pulling via system cronjob (every 12 hours)
- Add automatic cleanup of old Docker images (keeps only 2 most recent per tag)
- Use hash-based detection to ensure cronjob and wrapper script stay up-to-date
- **NEW**: Add `ARMBIAN_DOCKER_AUTO_PULL` environment variable for opt-in control
- **NEW**: Move cronjob setup from `requirements` command to Docker CLI
- **NEW**: Automatic cleanup when feature is disabled

## Changes
- **`docker_cleanup_old_images()`** - Removes dangling images and keeps only 2 most recent per tag
- **`docker_pull_with_marker()`** - Pulls images and updates marker files tracking last pull time
- **`docker_setup_auto_pull_cronjob()`** - Creates/updates system cronjob and wrapper script via hash-based detection
- **`docker_ensure_auto_pull_cronjob()`** - Ensures cronjob is installed/up-to-date OR removed if disabled
- **`docker CLI`** - Now handles cronjob setup instead of requirements command
- **Opt-in via `ARMBIAN_DOCKER_AUTO_PULL=yes`** - Must be explicitly set to enable cronjob

## System files created/managed:
- `/usr/local/bin/armbian-docker-pull` - Self-contained wrapper script for cron execution
- `/etc/cron.d/armbian-docker-pull` - Cronjob (runs every 12 hours at 00:00 and 12:00)
- `/var/lib/armbian/docker-pull.hash` - Configuration hash for smart update detection

## Environment Variables
- **`ARMBIAN_DOCKER_AUTO_PULL=yes`** - Enable auto-pull cronjob (default: disabled)
- **`ARMBIAN_DOCKER_AUTO_PULL=no`** - Disable and remove any existing cronjob

## Benefits
- **Opt-in behavior**: Cronjob only installed when `ARMBIAN_DOCKER_AUTO_PULL=yes` is explicitly set
- **Automatic cleanup**: Removes cronjob files when flag is disabled or removed
- **Better separation**: Docker-specific feature now handled by Docker CLI, not requirements
- **Cleaner output**: Silent operation when nothing needs to be done
- Prevents "12 hours since last pull, pulling again" delay during builds
- Automatically keeps Docker images fresh via background cronjob
- Manages disk space by removing old images automatically
- Hash-based update detection ensures system files are always current
- Self-contained wrapper script requires no external dependencies

## Usage Examples

```bash
# Enable auto-pull cronjob
export ARMBIAN_DOCKER_AUTO_PULL=yes
./compile.sh docker

# Disable and remove auto-pull cronjob
export ARMBIAN_DOCKER_AUTO_PULL=no
./compile.sh docker

# Normal Docker build without cronjob (default)
./compile.sh docker
```

## Test plan
- [x] Verify cronjob is installed when `ARMBIAN_DOCKER_AUTO_PULL=yes` is set
- [x] Verify wrapper script is created and executable
- [x] Verify images are pulled automatically by cron
- [x] Verify marker files are updated after pulls
- [x] Verify old images are cleaned up automatically
- [x] Verify system files update when configuration changes
- [x] Verify cronjob is removed when `ARMBIAN_DOCKER_AUTO_PULL=no`
- [x] Verify no cronjob is installed when flag is unset
- [x] Verify feature moved from requirements to Docker CLI
- [x] Verify clean output (no spurious messages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic Docker image cleanup that prunes dangling images and keeps only the two most recent versions per tag.
  * Automatic periodic Docker image refresh every 12 hours via an auto-pull wrapper and cron job.
  * Pull tracking that records last-pull timestamps and image checksums.

* **Chores**
  * Integrated automatic cleanup and auto-pull setup into Docker initialization flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->