### PR TITLE
radxa-zero2/khadas-vim3l: u-boot: disable LWIP

### DIFF
--- a/config/boards/khadas-vim3l.conf
+++ b/config/boards/khadas-vim3l.conf
@@ -89,9 +89,10 @@ function post_config_uboot_target__extra_configs_for_khadas_vim3l() {
 	run_host_command_logged scripts/config --enable CONFIG_CMD_DNS
 	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP
 
-	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable LWIP (new networking stack)" "info"
-	run_host_command_logged scripts/config --enable CONFIG_CMD_MII
-	run_host_command_logged scripts/config --enable CONFIG_NET_LWIP
+	# @TODO: disabled; v2026.01 lwip has a few issues; check after v2026.04 as Kwiboo is already at-it
+	#display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable LWIP (new networking stack)" "info"
+	#run_host_command_logged scripts/config --enable CONFIG_CMD_MII
+	#run_host_command_logged scripts/config --enable CONFIG_NET_LWIP
 
 	# UMS, RockUSB, gadget stuff
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable UMS/RockUSB gadget" "info"

--- a/config/boards/radxa-zero2.csc
+++ b/config/boards/radxa-zero2.csc
@@ -50,9 +50,10 @@ function post_config_uboot_target__radxa-zero2_fancy_uboot() {
 	run_host_command_logged scripts/config --enable CONFIG_CMD_DNS
 	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP
 
-	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable LWIP (new networking stack)" "info"
-	run_host_command_logged scripts/config --enable CONFIG_CMD_MII
-	run_host_command_logged scripts/config --enable CONFIG_NET_LWIP
+	# @TODO: disabled; v2026.01 lwip has a few issues; check after v2026.04 as Kwiboo is already at-it
+	#display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable LWIP (new networking stack)" "info"
+	#run_host_command_logged scripts/config --enable CONFIG_CMD_MII
+	#run_host_command_logged scripts/config --enable CONFIG_NET_LWIP
 
 	# UMS, RockUSB, gadget stuff
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable UMS/RockUSB gadget" "info"


### PR DESCRIPTION
- 🌱 LWIP has issues with TFTP (serverip/tftpserverip) on v2026.01
- 🌿 Kwiboo is already sending fixes, few separate series; check v2026.04 one day
- 🍃 for now just disable the 2 boards I had enabled it for and use the legacy network stack again
- 🍀 Fixes: 332e43bc8c2be6fba0a4c1b499b30a6525d45903
- 🐸 Fixes: d88d32b2485206ce0a29e5c5e0cbccd13bc4249d