### PR TITLE
Framework: Add "Repeat Build Options" string at the end in case of er…

### DIFF
--- a/lib/functions/logging/trap-logging.sh
+++ b/lib/functions/logging/trap-logging.sh
@@ -73,6 +73,11 @@ function trap_handler_cleanup_logging() {
 	produce_repeat_args_array # produces repeat_args
 	declare repeat_args_string="${repeat_args[*]}"
 
+	# Display repeat build options on error or interrupt (successful builds show this in main_default_end_build)
+	if [[ ${cleanup_exit_code:-0} -gt 0 ]]; then
+		display_alert "Repeat Build Options" "${repeat_args_string}" "ext"
+	fi
+
 	## Here -- we need to definitely stop logging, cos we're gonna consolidate and delete the logs.
 	display_alert "End of logging" "STOP LOGGING: CURRENT_LOGFILE: ${CURRENT_LOGFILE}" "debug"
 


### PR DESCRIPTION
# Description

With this patch "Repeat Build Options" string shows at the end of screen log in case of error or break.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] break build process
- [x] build process finish successful

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Build system now displays repeat build options when errors occur or builds are interrupted, showing all previously configured parameters. Users can easily review and retry failed builds with identical settings, streamlining the rebuild process without manual parameter reconfiguration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->