### PR TITLE
Normalize kernel config hash inputs

### DIFF
--- a/extensions/kernel-version-toolchain.sh
+++ b/extensions/kernel-version-toolchain.sh
@@ -1,0 +1,35 @@
+# Add compiler (gcc/clang) identifier to kernel artifact version string.
+# This ensures cache invalidation when the toolchain changes.
+# Enable with: ENABLE_EXTENSIONS="kernel-version-toolchain"
+
+function artifact_kernel_version_parts__add_toolchain() {
+	# Determine compiler binary
+	declare kernel_compiler_bin="${KERNEL_COMPILER}gcc"
+	if [[ "${KERNEL_COMPILER}" == "clang" ]]; then
+		kernel_compiler_bin="clang"
+	fi
+
+	# Get compiler version (major.minor only)
+	declare toolchain_id="unknown"
+	if command -v "${kernel_compiler_bin}" &> /dev/null; then
+		declare full_version
+		full_version="$(${kernel_compiler_bin} -dumpfullversion -dumpversion 2>/dev/null || echo "")"
+		if [[ -n "${full_version}" ]]; then
+			# Extract major.minor, drop patch version
+			declare short_version
+			short_version="$(echo "${full_version}" | cut -d'.' -f1-2)"
+			# Build identifier: gcc13.3 or clang18.1
+			if [[ "${KERNEL_COMPILER}" == "clang" ]]; then
+				toolchain_id="clang${short_version}"
+			else
+				toolchain_id="gcc${short_version}"
+			fi
+		fi
+	fi
+
+	display_alert "Extension: ${EXTENSION}: Adding toolchain to kernel version" "${toolchain_id}" "debug"
+
+	# Add to version parts
+	artifact_version_parts["_T"]="${toolchain_id}"
+	artifact_version_part_order+=("0085-_T")
+}

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -131,7 +131,7 @@ function artifact_kernel_prepare_version() {
 	# tac reverses order so last becomes first, then sort -uk keeps first occurrence of each key.
 	declare -a kernel_config_modifying_hashes_reduced=()
 	mapfile -t kernel_config_modifying_hashes_reduced < <(
-		printf '%s\n' "${kernel_config_modifying_hashes[@]}" | tac | LC_ALL=C sort -t '=' -uk 1,1
+		printf '%s\n' "${kernel_config_modifying_hashes[@]}" | tac | LC_ALL=C sort -s -t '=' -uk 1,1
 	)
 	kernel_config_modification_hash="$(printf '%s\n' "${kernel_config_modifying_hashes_reduced[@]}" | sha256sum | cut -d' ' -f1)"
 	kernel_config_modification_hash="${kernel_config_modification_hash:0:16}" # "long hash"


### PR DESCRIPTION
## Summary

Three improvements to kernel artifact versioning.

### 1. Deduplicate config hash inputs

**Problem**  
The kernel config hash (`kernel_config_modification_hash`) was sensitive to:
- Option insertion order from different hooks
- Overridden assignments (same key set multiple times with different values)

This caused identical effective configurations to produce different hashes.

**Solution**  
Use `tac | sort -t '=' -uk 1,1` pipeline to keep only the last assignment per key:
- `tac` reverses order so last occurrence becomes first
- `sort -uk 1,1` keeps first occurrence of each unique key

Result: same effective config always produces the same hash.

### 2. Add hook for customizing version parts

Add `artifact_kernel_version_parts` hook that allows extensions to customize the kernel artifact version string:

- `artifact_version_parts`: associative array of key=value pairs. Extensions can add, modify, or remove parts.
- `artifact_version_part_order`: array defining assembly order. Extensions can reorder or add new keys.

### 3. Extension: kernel-version-toolchain

Example extension that adds compiler identifier (e.g., `gcc13.3`, `clang18.1`) to kernel artifact version string.

Enable with: `ENABLE_EXTENSIONS="kernel-version-toolchain"`

This ensures kernel cache invalidation when the toolchain changes.

## Result
- Hash is stable for the same effective option set
- Extensions can customize artifact version string
- Toolchain identification available as opt-in extension

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More stable, deterministic kernel-version hashing via a deduplication step (last assignment wins), producing a compact suffix only when non-empty.
  * Final version assembly uses a predictable numeric base when makefile version is bypassed and consistently appends computed suffixes.
  * Internal/private keys are rendered as values only in the suffix.

* **New Features**
  * Structured, ordered composition of version-suffix parts with extension hooks to customize parts and ordering; public state exposed for parts and order.
  * Optional extension to include the toolchain major.minor (gcc/clang) as a version component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->