### PR TITLE
rootfs: enable loong64 in qemu binfmt registration

### DIFF
--- a/lib/functions/rootfs/qemu-static.sh
+++ b/lib/functions/rootfs/qemu-static.sh
@@ -132,7 +132,7 @@ function prepare_host_binfmt_qemu_cross() {
 
 	declare host_arch
 	host_arch="$(arch)"
-	declare -a wanted_arches=("arm" "aarch64" "x86_64" "riscv64")
+	declare -a wanted_arches=("arm" "aarch64" "x86_64" "riscv64" "loongarch64")
 	declare -A arch_aliases=(["aarch64"]="arm64" ["x86_64"]="amd64")
 	display_alert "Preparing binfmts for arch" "binfmts: host '${host_arch}', wanted arches '${wanted_arches[*]}'" "debug"
 	declare wanted_arch arch_alias


### PR DESCRIPTION
# Description

This PR adds `loong64` to the list of architectures prepared by
`prepare_host_binfmt_qemu_cross()`.

This enables automatic registration and use of QEMU user-mode emulation for LoongArch64, making it possible to:

- Bootstrap loong64 root filesystems
- Run loong64 binaries transparently via binfmt
- Enable CI workflows for LoongArch targets
- Prepare Armbian for Debian’s native `loong64` support

The change mirrors existing handling for other foreign architectures such as `riscv64` and keeps the implementation intentionally minimal.

# How Has This Been Tested?

- [x] Emulation works with Trixie host
- [ ] Tested on older build hosts

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loongarch64 architecture support for cross-compilation and emulation environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->