### PR TITLE
radxa-e54c: board config: replace 'hacky' Wayland fix with wayland-sessions-mask extension

### DIFF
--- a/config/boards/radxa-e54c.conf
+++ b/config/boards/radxa-e54c.conf
@@ -9,6 +9,7 @@ BOOT_FDT_FILE="rockchip/rk3588s-radxa-e54c.dtb"
 BOOT_SCENARIO="spl-blobs"
 BOOT_SOC="rk3588"
 IMAGE_PARTITION_TABLE="gpt"
+enable_extension "wayland-sessions-mask"
 
 # Enable system and network LEDs
 function post_family_tweaks_bsp__radxa_e54c_enable_leds() {
@@ -70,7 +71,4 @@ function post_family_tweaks_bsp__radxa_e54c_enable_leds() {
 
 	EOF
 	
-	if [[ $DESKTOP_ENVIRONMENT == gnome && $BRANCH == vendor ]]; then
-		sed -i -e "/AutomaticLogin = \$RealUserName/a\\" -e $'\\t\\t\\tWaylandEnable = false' "${destination}"/usr/lib/armbian/armbian-firstlogin
-	fi	
 }


### PR DESCRIPTION
# Description

This PR removes a board-specific, “hacky” Wayland workaround for **radxa-e54c** and replaces it with the standardized **`wayland-sessions-mask`** extension.

# Changes

* Remove the radxa-e54c-specific Wayland disable hack from the board config
* Enable Wayland masking via the **`wayland-sessions-mask`** extension
* Preserve existing behavior

# How Has This Been Tested?

* **radxa-e54c Vendor Noble Gnome** — Wayland masked
* **radxa-e54c Vendor Trixie Minimal** — Default behavior

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Wayland session management through updated extension-based configuration for improved display environment compatibility.

* **Chores**
  * Streamlined board configuration by removing legacy conditional logic affecting session initialization behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->