### PR TITLE
extension: grub: deploy qemu binary when doing cross build

### DIFF
--- a/extensions/grub.sh
+++ b/extensions/grub.sh
@@ -153,6 +153,8 @@ pre_umount_final_image__install_grub() {
 		The chroot ($MOUNT) is mounted.
 	GRUB_PRE_INSTALL
 
+	deploy_qemu_binary_to_chroot "$chroot_target" "grub" # undeployed near the end of this function
+
 	if [[ "${UEFI_GRUB_TARGET_BIOS}" != "" ]]; then
 		display_alert "Extension: ${EXTENSION}: Installing GRUB BIOS..." "${UEFI_GRUB_TARGET_BIOS} device ${LOOP}" ""
 		chroot_custom "$chroot_target" grub-install --target=${UEFI_GRUB_TARGET_BIOS} "${LOOP}" || {
@@ -236,6 +238,7 @@ pre_umount_final_image__install_grub() {
 	# Remove host-side config.
 	rm -f "${MOUNT}"/etc/default/grub.d/99-armbian-host-side.cfg
 
+	undeploy_qemu_binary_from_chroot "$chroot_target" "grub"
 	umount_chroot "$chroot_target/"
 
 }


### PR DESCRIPTION
# Description

I'm building arm64 image on a x86 host, and missing qemu binary will cause grub-install fall. Deploying qemu binaries fixes it.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `PREFER_DOCKER=no ./compile.sh BOARD=uefi-arm64 BRANCH=current KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes KERNEL_GIT=shallow REGIONAL_MIRROR=china GHPROXY_ADDRESS=gitboost.haguro.top DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base RELEASE=trixie BUILD_DESKTOP=yes`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GRUB bootloader installation process with enhanced system component management during boot environment preparation and cleanup phases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->