### PR TITLE
orangepi5-plus: u-boot: restore vendor uboot with blobs

### DIFF
--- a/config/boards/orangepi5-plus.conf
+++ b/config/boards/orangepi5-plus.conf
@@ -10,7 +10,9 @@ KERNEL_TEST_TARGET="vendor,current"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3588-orangepi-5-plus.dtb"
-BOOT_SCENARIO="tpl-blob-atf-mainline"
+BOOT_SCENARIO="spl-blobs"
+BOOT_SUPPORT_SPI="yes"
+BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 declare -g UEFI_EDK2_BOARD_ID="orangepi-5plus" # This _only_ used for uefi-edk2-rk3588 extension
 
@@ -31,6 +33,10 @@ function post_family_config__orangepi5plus_use_mainline_uboot() {
 	[[ "${BRANCH}" == "vendor" ]] && return 0 # skip for vendor branch
 
 	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
+
+	# To reuse ATF code in rockchip64_common, let's change the BOOT_SCENARIO and call prepare_boot_configuration() again
+	declare -g BOOT_SCENARIO="tpl-blob-atf-mainline"
+	prepare_boot_configuration
 
 	declare -g BOOTCONFIG="orangepi-5-plus-rk3588_defconfig"
 	declare -g BOOTDELAY=1


### PR DESCRIPTION
- 🌳 mainline AT-F only for non-vendor BRANCH
- 🍀 vendor branch uses vendor u-boot with rkbin blobs
- 🌱 sorry for the confusion; I overlooked the conditional here
- 🌴 Fixes: f45765e5103ffe98a4088bffea5acd170bb7ce8f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SPI boot support for Orange Pi 5 Plus.

* **Chores**
  * Updated boot configuration for Orange Pi 5 Plus to improve compatibility and mainline U-Boot support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->