### PR TITLE
Rockchip EDGE: drop up-streamed patches

### DIFF
--- a/patch/kernel/archive/rockchip-6.19/series.conf
+++ b/patch/kernel/archive/rockchip-6.19/series.conf
@@ -47,8 +47,8 @@
 	-patches.libreelec/rockchip-0046-FROMLIST-v3-media-rkvdec-Disable-QoS-for-HEVC-and-VP.patch
 	-patches.libreelec/rockchip-0047-FROMLIST-v3-media-dt-bindings-rockchip-vdec-Add-RK32.patch
 	patches.libreelec/rockchip-0048-FROMLIST-v3-ARM-dts-rockchip-Add-vdec-node-for-RK328.patch
-	patches.libreelec/rockchip-0049-FROMLIST-v1-drm-rockchip-vop2-Add-delay-between-poll.patch
-	patches.libreelec/rockchip-0050-FROMLIST-v1-drm-rockchip-vop2-Only-wait-for-changed-.patch
+	-patches.libreelec/rockchip-0049-FROMLIST-v1-drm-rockchip-vop2-Add-delay-between-poll.patch
+	-patches.libreelec/rockchip-0050-FROMLIST-v1-drm-rockchip-vop2-Only-wait-for-changed-.patch
 	patches.libreelec/rockchip-0051-FROMLIST-v1-media-verisilicon-Export-only-needed-pix.patch
 	-patches.libreelec/rockchip-0052-FROMLIST-v1-media-verisilicon-Fix-CPU-stalls-on-G2-b.patch
 	-patches.libreelec/rockchip-0053-FROMLIST-v1-media-verisilicon-Protect-G2-HEVC-decode.patch
@@ -128,8 +128,8 @@
 	patches.libreelec/rockchip-0127-FROMLIST-v1-iommu-rockchip-disable-fetch-dte-time-li.patch
 	patches.libreelec/rockchip-0128-FROMLIST-v1-PCI-dwc-Make-Link-Up-IRQ-logic-handle-al.patch
 	patches.libreelec/rockchip-0129-FROMLIST-v7-PCI-Configure-Root-Port-MPS-during-host-.patch
-	patches.libreelec/rockchip-0130-FROMLIST-v2-phy-rockchip-inno-usb2-fix-disconnection.patch
-	patches.libreelec/rockchip-0131-FROMLIST-v2-phy-rockchip-inno-usb2-fix-communication.patch
+	-patches.libreelec/rockchip-0130-FROMLIST-v2-phy-rockchip-inno-usb2-fix-disconnection.patch
+	-patches.libreelec/rockchip-0131-FROMLIST-v2-phy-rockchip-inno-usb2-fix-communication.patch
 	patches.libreelec/rockchip-0132-FROMLIST-v1-arm64-dts-rockchip-add-dma-coherent-for-.patch
 	-patches.libreelec/rockchip-0133-FROMLIST-v1-ASoC-rockchip-Fix-Wvoid-pointer-to-enum-.patch
 	patches.libreelec/rockchip-0134-FROMLIST-v1-pmdomain-rockchip-Fix-init-genpd-as-GENP.patch
@@ -145,8 +145,8 @@
 	patches.libreelec/rockchip-0144-WIP-FRL-arm64-dts-rockchip-Add-tmds-enable-gpios-to-.patch
 	patches.libreelec/rockchip-0145-WIP-FRL-arm64-dts-rockchip-Assign-ACLK_VOP-to-750-MH.patch
 	patches.libreelec/rockchip-0146-WIP-FRL-drm-connector-hdmi-Handle-FRL-in-hdmi_clock_.patch
-	patches.libreelec/rockchip-0147-WIP-FRL-drm-bridge-dw-hdmi-qp-Add-HDMI-2.1-FRL-suppo.patch
-	patches.libreelec/rockchip-0148-WIP-FRL-drm-rockchip-dw_hdmi_qp-Add-HDMI-2.1-FRL-sup.patch
+	-patches.libreelec/rockchip-0147-WIP-FRL-drm-bridge-dw-hdmi-qp-Add-HDMI-2.1-FRL-suppo.patch
+	-patches.libreelec/rockchip-0148-WIP-FRL-drm-rockchip-dw_hdmi_qp-Add-HDMI-2.1-FRL-sup.patch
 	patches.libreelec/rockchip-0149-WIP-FRL-drm-rockchip-vop2-Add-HDMI-2.1-FRL-support.patch
 	patches.libreelec/rockchip-0150-KWIBOO-media-cec-adap-add-debounce-support-when-sett.patch
 	patches.libreelec/rockchip-0151-KNAERZCHE-drm-bridge-synopsys-fix-CEC-not-working-af.patch


### PR DESCRIPTION
# Description

Disabling patches that breaks compilation. @paolosabatino Please doublecheck if i didn't drop one too many - I am doing quick fix here to push CI forward.

# How Has This Been Tested?

- [x] Compilation

# Checklist:

- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized patch application sequence in kernel build configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->