### PR TITLE
[RFC] qcs6490: fix patched dtb not compiled

### DIFF
--- a/patch/kernel/archive/qcs6490-6.18/0000.patching_config.yaml
+++ b/patch/kernel/archive/qcs6490-6.18/0000.patching_config.yaml
@@ -18,7 +18,7 @@ config: # This is file 'patch/kernel/archive/sm8250-6.7/0000.patching_config.yam
   #  or patched-in; overlay subdir will be included "-y" if it exists.
   # No more Makefile patching needed, yay!
   auto-patch-dt-makefile:
-    - { directory: "arch/arm64/boot/dts/qcom", config-var: "CONFIG_ARCH_QCOM" }
+    - { directory: "arch/arm64/boot/dts/qcom", config-var: "CONFIG_ARCH_QCOM", add-only: false}
 
   # configuration for when applying patches to git / auto-rewriting patches (development cycle helpers)
   patches-to-git:


### PR DESCRIPTION
# Description

Fixes #9295 

The patch adding devicetree of radxa q6a doesn't modify the Makefile, and we have to declare `add-only: false` so that armbian can regenerate the Makefile for all dtbs, that's the way it works before.

But it will destroy the upstream Makefile, we have to remove the Makefile part when adding patches from other kernel source or mailing list.

We can choose:
- The old way this pr fixes, only include dts file in patches, qsc6490 should be the only family using it
- Standard way, we have to modify Makefile when adding devicetree in patches, Maybe it's better to add dts in dt subdir if we don't want to touch Makefile.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `PREFER_DOCKER=no ./compile.sh kernel BOARD=radxa-dragon-q6a BRANCH=edge KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes KERNEL_GIT=shallow`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kernel patch configuration settings to refine auto-patching behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->