### PR TITLE
rockchip64: fix clang build error

### DIFF
--- a/patch/kernel/archive/rockchip64-6.19/rk3399-usbc-notify-typec-dp-hpd-state-through-extcon.patch
+++ b/patch/kernel/archive/rockchip64-6.19/rk3399-usbc-notify-typec-dp-hpd-state-through-extcon.patch
@@ -31,7 +31,7 @@ index 111111111111..222222222222 100644
 +/* Notify DP hotplug change via extcon. Current rockchip cdn-dp driver need this signal
 + * to reset DP link. */
 +static void dp_altmode_update_extcon_hpd_status(struct dp_altmode *dp, bool new_hpd) {
-+	const struct device *dev = &dp->alt->dev;
++	struct device *dev = &dp->alt->dev;
 +	struct extcon_dev* edev = NULL;
 +	int ret;
 +


### PR DESCRIPTION
# Description

As suggested by @iav [here](https://github.com/armbian/build/pull/8271#issuecomment-3807681242), this PR fixes a qualifier warning treated as an error when building with clang
 
# How Has This Been Tested?

- [x] compiled rockchip64 edge kernel

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code refinement to improve type consistency in the ARM device USB-C DisplayPort notification system for better code quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->