### PR TITLE
Rockchip 6.19: drop upstreamed patches

### DIFF
--- a/patch/kernel/archive/rockchip-6.19/series.conf
+++ b/patch/kernel/archive/rockchip-6.19/series.conf
@@ -132,7 +132,7 @@
 	-patches.libreelec/rockchip-0131-FROMLIST-v2-phy-rockchip-inno-usb2-fix-communication.patch
 	patches.libreelec/rockchip-0132-FROMLIST-v1-arm64-dts-rockchip-add-dma-coherent-for-.patch
 	-patches.libreelec/rockchip-0133-FROMLIST-v1-ASoC-rockchip-Fix-Wvoid-pointer-to-enum-.patch
-	patches.libreelec/rockchip-0134-FROMLIST-v1-pmdomain-rockchip-Fix-init-genpd-as-GENP.patch
+	-patches.libreelec/rockchip-0134-FROMLIST-v1-pmdomain-rockchip-Fix-init-genpd-as-GENP.patch
 	patches.libreelec/rockchip-0135-FROMLIST-v1-drm-bridge-dw-hdmi-qp-fix-multi-channel-.patch
 	patches.libreelec/rockchip-0136-FROMLIST-v2-media-verisilicon-AV1-Fix-enable-cdef-co.patch
 	patches.libreelec/rockchip-0137-FROMLIST-v2-media-verisilicon-AV1-Fix-tx-mode-bit-se.patch


### PR DESCRIPTION
# Description

Maint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rockchip kernel patch series configuration, modifying patch entry references for the 6.19 series.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->