### PR TITLE
clang: enable colored diagnostic output for kernel compilation

### DIFF
--- a/lib/functions/compilation/kernel-make.sh
+++ b/lib/functions/compilation/kernel-make.sh
@@ -44,7 +44,7 @@ function run_kernel_make_internal() {
 		# Do NOT add -Wno-error=unknown-warning-option here - it breaks cc-option detection
 		# in kernel Makefiles (btrfs, drm, coresight) causing GCC-specific flags to be
 		# incorrectly added when building with clang
-		extra_warnings="-Wno-error=unused-command-line-argument"
+		extra_warnings="-fcolor-diagnostics -Wno-error=unused-command-line-argument"
 	else
 		cc_name="CROSS_COMPILE"
 		extra_warnings=""


### PR DESCRIPTION
## Summary
- When building kernels with `KERNEL_COMPILER=clang`, compiler warnings were displayed without color
- The GCC-native flag `-fdiagnostics-color=always` (set in `KCFLAGS`) is not reliably honored by clang when invoked through ccache and the kernel build system with `LLVM=1`
- Added `-fcolor-diagnostics` (clang's native flag) to the clang-specific `extra_warnings` to ensure colored output

## Test plan
- [x] Built kernel with `KERNEL_COMPILER=clang` — warnings now have ANSI color codes
- [x] Verify no regressions with default GCC builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced compiler output formatting with colored diagnostics support for improved build log readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->