### PR TITLE
uwe5622: fix compilation with clang on Linux 6.19

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -571,6 +571,10 @@ driver_uwe5622() {
                         process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-v6.18.patch" "applying"
         fi
 
+		if linux-version compare "${version}" ge 6.19; then
+			process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-v6.19.patch" "applying"
+		fi
+
 	fi
 }
 

--- a/patch/misc/wireless-uwe5622/uwe5622-v6.19.patch
+++ b/patch/misc/wireless-uwe5622/uwe5622-v6.19.patch
@@ -1,0 +1,54 @@
+--- a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
+@@ -394,7 +394,7 @@
+ 	struct sprdwl_priv *priv = vif->priv;
+ 	enum nl80211_iftype type = vif->wdev.iftype;
+ 	enum sprdwl_mode mode;
+-	u8 *mac;
++	u8 mac[ETH_ALEN];
+ 	u8 vif_ctx_id = 0;
+ 
+ 	wl_ndev_log(L_DBG, vif->ndev, "%s type %d, mode %d\n", __func__, type,
+@@ -427,9 +427,9 @@
+ 
+ 	vif->mode = mode;
+ 	if (!vif->ndev)
+-		mac = vif->wdev.address;
++		ether_addr_copy(mac, vif->wdev.address);
+ 	else
+-		mac = vif->ndev->dev_addr;
++		ether_addr_copy(mac, vif->ndev->dev_addr);
+ 
+ 	if (sprdwl_open_fw(priv, &vif_ctx_id, vif->mode, mac)) {
+ 		wl_ndev_log(L_ERR, vif->ndev, "%s failed!\n", __func__);
+--- a/drivers/net/wireless/uwe5622/unisocwifi/main.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/main.c
+@@ -944,12 +944,12 @@
+ 		if (!is_zero_ether_addr(sa->sa_data)) {
+ 			vif->has_rand_mac = true;
+ 			memcpy(vif->random_mac, sa->sa_data, ETH_ALEN);
+-			memcpy(dev->dev_addr, sa->sa_data, ETH_ALEN);
++			dev_addr_set(dev, sa->sa_data);
+ 		} else {
+ 			vif->has_rand_mac = false;
+ 			netdev_info(dev, "need clear random mac for sta/softap mode\n");
+ 			memset(vif->random_mac, 0, ETH_ALEN);
+-			memcpy(dev->dev_addr, vif->mac, ETH_ALEN);
++			dev_addr_set(dev, vif->mac);
+ 		}
+ 	}
+ 	/*return success to pass vts test*/
+@@ -1448,7 +1448,12 @@
+ 	ndev->features |= NETIF_F_SG;
+ 	SET_NETDEV_DEV(ndev, wiphy_dev(priv->wiphy));
+ 
+-	sprdwl_set_mac_addr(vif, addr, ndev->dev_addr);
++	{
++		u8 mac_addr_buf[ETH_ALEN];
++		ether_addr_copy(mac_addr_buf, ndev->dev_addr);
++		sprdwl_set_mac_addr(vif, addr, mac_addr_buf);
++		dev_addr_set(ndev, mac_addr_buf);
++	}
+ 
+ #ifdef CONFIG_P2P_INTF
+ 	if (type == NL80211_IFTYPE_P2P_DEVICE)


### PR DESCRIPTION
In Linux 6.19, net_device->dev_addr is const unsigned char *. Clang with -Werror,-Wincompatible-pointer-types-discards-qualifiers rejects passing dev_addr to non-const parameters and memcpy into it.

Fix by:
- Replacing memcpy(dev->dev_addr, ...) with dev_addr_set()
- Using local buffer + ether_addr_copy for sprdwl_set_mac_addr call that needs mutable addr (the function modifies it in-place)
- Changing u8 *mac pointer to u8 mac[ETH_ALEN] array in cfg80211.c where dev_addr was assigned to a non-const pointer

Relates to #9049

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] build with clang
- [x] build with gcc

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Linux kernel version 6.19 in wireless driver
  
* **Bug Fixes**
  * Improved MAC address handling in wireless driver for enhanced stability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->