### PR TITLE
rockchip64-6.18: fix helios64 pcie patch

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/board-helios64-remove-pcie-ep-gpios.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-helios64-remove-pcie-ep-gpios.patch
@@ -17,9 +17,9 @@ index 111111111111..222222222222 100644
  
  &pcie0 {
 -	ep-gpios = <&gpio2 RK_PD4 GPIO_ACTIVE_HIGH>;
- 	max-link-speed = <2>;
  	num-lanes = <2>;
  	pinctrl-names = "default";
+ 	status = "okay";
 -- 
 Armbian
 


### PR DESCRIPTION
# Description

[Remove ep-gpios property and max-link-speed, set status to okay for pcie0.](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts?h=v6.18.8&id=18d2d227ccd77d2aea9893122a5538c5abde48f8)

# How Has This Been Tested?

- [x] Patching works

# Checklist:

- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helios64 board PCI Express endpoint configuration to enhance system stability, hardware compatibility, and peripheral device communication reliability.
  * Optimized endpoint link speed parameters and GPIO signal handling for better power management and overall system performance.
  * Enhanced device communication protocols to ensure stable connections with attached peripherals and improved user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->