### PR TITLE
Deprecate Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Get help from users and contributors on troubleshooting, configuration, and deve
 👉 [forum.armbian.com](https://forum.armbian.com)
 
 ### Real-time Chat
-Join discussions with developers and community members on IRc or Discord.
+Join discussions with developers and community members on IRC or Discord.
 👉 [Community Chat](https://docs.armbian.com/Community_IRC/)
 
 ### Paid Consultation


### PR DESCRIPTION
close to nobody is using Matrix. The bridge doesn't run reliable too. Get rid of maintenance burden.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Real-time Chat section to list only IRC and Discord (Matrix entry removed); adjusted the platform ordering and related wording to reflect this change across the documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->