### PR TITLE
rockchip64-current: rewrite patches due to upstream changes in 6.18.8

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.18/add-board-helios64.patch
@@ -669,15 +669,15 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-@@ -427,6 +818,7 @@ &pcie0 {
- 	max-link-speed = <2>;
+@@ -426,6 +817,7 @@ &pcie0 {
+ 	ep-gpios = <&gpio2 RK_PD4 GPIO_ACTIVE_HIGH>;
  	num-lanes = <2>;
  	pinctrl-names = "default";
 +	pinctrl-0 = <&pcie_prst &pcie_clkreqn_cpm>;
  	status = "okay";
  
  	vpcie12v-supply = <&vcc12v_dcin>;
-@@ -436,36 +828,116 @@ &pcie0 {
+@@ -435,36 +827,116 @@ &pcie0 {
  };
  
  &pinctrl {
@@ -802,7 +802,7 @@ index 111111111111..222222222222 100644
  		hdd_a_power_en: hdd-a-power-en {
  			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
-@@ -485,7 +957,7 @@ usb_lan_en: usb-lan-en {
+@@ -484,7 +956,7 @@ usb_lan_en: usb-lan-en {
  
  	vcc3v0-sd {
  		sdmmc0_pwr_h: sdmmc0-pwr-h {
@@ -811,7 +811,7 @@ index 111111111111..222222222222 100644
  		};
  	};
  };
-@@ -505,10 +977,28 @@ &pwm1 {
+@@ -504,10 +976,28 @@ &pwm1 {
  	status = "okay";
  };
  
@@ -840,7 +840,7 @@ index 111111111111..222222222222 100644
  	vqmmc-supply = <&vcc1v8_sys_s0>;
  	status = "okay";
  };
-@@ -516,8 +1006,9 @@ &sdhci {
+@@ -515,8 +1005,9 @@ &sdhci {
  &sdmmc {
  	bus-width = <4>;
  	cap-sd-highspeed;
@@ -851,7 +851,7 @@ index 111111111111..222222222222 100644
  	pinctrl-names = "default";
  	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
  	vmmc-supply = <&vcc3v0_sd>;
-@@ -546,6 +1037,27 @@ &spi5 {
+@@ -545,6 +1036,27 @@ &spi5 {
  	status = "okay";
  };
  
@@ -879,7 +879,7 @@ index 111111111111..222222222222 100644
  &tcphy1 {
  	/* phy for &usbdrd_dwc3_1 */
  	status = "okay";
-@@ -559,61 +1071,122 @@ &tsadc {
+@@ -558,61 +1070,122 @@ &tsadc {
  	status = "okay";
  };
  

--- a/patch/kernel/archive/rockchip64-6.18/board-helios64-remove-pcie-ep-gpios.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-helios64-remove-pcie-ep-gpios.patch
@@ -19,7 +19,7 @@ index 111111111111..222222222222 100644
 -	ep-gpios = <&gpio2 RK_PD4 GPIO_ACTIVE_HIGH>;
  	num-lanes = <2>;
  	pinctrl-names = "default";
- 	status = "okay";
+ 	pinctrl-0 = <&pcie_prst &pcie_clkreqn_cpm>;
 -- 
 Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/media-0003-rk3568-disable-hantro-h264.patch
+++ b/patch/kernel/archive/rockchip64-6.18/media-0003-rk3568-disable-hantro-h264.patch
@@ -20,7 +20,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-@@ -1242,7 +1242,7 @@ rknn_mmu_2: iommu@fdad9000 {
+@@ -1242,7 +1242,7 @@ rknn_mmu_2: iommu@fdada000 {
  	};
  
  	vpu121: video-codec@fdb50000 {


### PR DESCRIPTION
# Description

as per title

# How Has This Been Tested?

- [x] build

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Notes:

From my guts feel rtl8852bs wifi driver create more warnings than before. I guess they will break down again at some point. https://paste.armbian.de/upuvaliyob

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Significantly expanded Helios64 board hardware support including USB 3.0 controllers, display/GPU subsystems, enhanced LED and power management controls, GPIO-based buttons with wake functionality, and integrated USB hub and Ethernet capabilities.

* **Refactor**
  * Streamlined PCIe configuration management.

* **Chores**
  * Removed H.264 codec variant for RK3568 processor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->