### PR TITLE
armbian-kernel: add AMD DC support for UEFI boards

### DIFF
--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -87,3 +87,16 @@ function pre_customize_image__disable_few_armbian_services() {
 	chroot_sdcard systemctl disable armbian-hardware-optimize.service "||" true
 	chroot_sdcard systemctl disable armbian-led-state.service "||" true
 }
+
+function custom_kernel_config__enable_amd_dc() {
+	# Enables AMD Display Controller (DC) support for AMD GPUs
+	# This enables the display engine for AMD Radeon graphics cards,
+	# including DCN (Display Core Next) and DSC (Display Stream Compression)
+	# Only enabled for UEFI boards, excluding cloud branch
+	if [[ "${BRANCH}" != "cloud" ]]; then
+		display_alert "Enabling AMD DC support" "UEFI family ${LINUXFAMILY}" "debug"
+		opts_y+=("DRM_AMD_DC")
+		opts_y+=("DRM_AMD_DC_DCN")
+		opts_y+=("DRM_AMD_DC_DSC_SUPPORT")
+	fi
+}


### PR DESCRIPTION
## Summary
- Enable AMD Display Controller (DC) support for UEFI boards
- Adds kernel config options: `DRM_AMD_DC`, `DRM_AMD_DC_DCN`, `DRM_AMD_DC_DSC_SUPPORT`
- Targets UEFI boards only: `uefi-x86`, `uefi-arm64`, `uefi-loong64`
- Excludes `cloud` branch (headless/server images don't need GPU display support)

## Test plan
- [x] Build uefi-x86 board with current/edge/legacy branches
- [x] Verify AMD GPU detection and display output works
- [x] Ensure cloud branch builds without these options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AMD Display Controller on select platforms (x86, arm64, loong64), improving AMD GPU display capabilities; this support is enabled for non-cloud builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->