### PR TITLE
armbianmonitor: fix error message at the end of every report

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -977,7 +977,7 @@ CollectSupportInfo() {
 	echo -e "\n"
 	[[ "$(id -u)" -eq "0" ]] && for sysfsnode in /proc/sys/vm/*; do sysctl $(echo ${sysfsnode} | sed 's|/proc/sys/vm/|vm.|'); done
 	echo -e "\n### interrupts:\n$(cat /proc/interrupts)"
-	ls /tmp/armbianmonitor_checks_* > /dev/null 2>&1 || return
+	ls /tmp/armbianmonitor_checks_* > /dev/null 2>&1 || return 0
 	for file in /tmp/armbianmonitor_checks_*; do
 		echo -e "\n### \c"
 		ls "${file}" | cut -f1 -d.


### PR DESCRIPTION
# Description

Since quite a while I noticed that every report sent via `armbianmonitor -u` ends with  
`Error collecting support info via CollectSupportInfo`

This is caused by a condition that in 99,99% of all cases fails.

# How Has This Been Tested?

- [x] armbianmonitor -u before has error at the end
- [x] armbianmonitor -u after has no error at the end

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for system monitoring operations to allow processes to continue when certain configuration data is unavailable, enabling partial reports to generate successfully.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->