### PR TITLE
forge1: switch to RK3506J variant and add OPTEE support

### DIFF
--- a/config/boards/armsom-forge1.csc
+++ b/config/boards/armsom-forge1.csc
@@ -2,7 +2,7 @@
 BOARD_NAME="ArmSoM Forge1"
 BOARD_VENDOR="armsom"
 BOARDFAMILY="rockchip"
-BOOTCONFIG="forge1-rk3506b_defconfig"
+BOOTCONFIG="forge1-rk3506j_defconfig"
 BOARD_MAINTAINER="amazingfate"
 KERNEL_TARGET="vendor"
 BOOT_FDT_FILE="rk3506b-armsom-forge1.dtb"

--- a/patch/u-boot/u-boot-rk3506/forge1-btrfs.patch
+++ b/patch/u-boot/u-boot-rk3506/forge1-btrfs.patch
@@ -1,12 +1,13 @@
-diff --git a/configs/forge1-rk3506b_defconfig b/configs/forge1-rk3506b_defconfig
+diff --git a/configs/forge1-rk3506j_defconfig b/configs/forge1-rk3506j_defconfig
 index d006413eec1..a191a649d66 100644
---- a/configs/forge1-rk3506b_defconfig
-+++ b/configs/forge1-rk3506b_defconfig
-@@ -27,6 +27,7 @@ CONFIG_CMD_USB_MASS_STORAGE=y
+--- a/configs/forge1-rk3506j_defconfig
++++ b/configs/forge1-rk3506j_defconfig
+@@ -27,6 +27,8 @@ CONFIG_CMD_USB_MASS_STORAGE=y
  # CONFIG_CMD_SETEXPR is not set
  CONFIG_CMD_RNG=y
  CONFIG_CMD_REGULATOR=y
 +CONFIG_CMD_BTRFS=y
++CONFIG_OPTEE_IMAGE=y
  # CONFIG_SPL_DOS_PARTITION is not set
  CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
  CONFIG_BUTTON=y


### PR DESCRIPTION
## Summary

Following build bug: https://paste.armbian.com/origaramem

- Switch BOOTCONFIG from rk3506b to rk3506j variant
- Update btrfs patch to target correct defconfig  
- Add OPTEE image support for secure boot functionality

## Test plan

- [x] Build succeeds for armsom-forge1
- [ ] Boot test with RK3506J variant
- [ ] Verify OPTEE support is functional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Armsom Forge1 board configuration to support the RK3506J processor variant.
  * Added BTRFS filesystem and OPTEE image support to the board configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->