### PR TITLE
[RFC] Armbianmonitor refactor

### DIFF
--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -1,0 +1,159 @@
+#!/bin/bash
+#
+# armbian-debug
+#
+# Collect and upload system debug information for Armbian support.
+# Part of the Armbian project - https://www.armbian.com
+#
+############################################################################
+
+# Config:
+declare -a paste_servers=("paste.armbian.com" "paste.next.armbian.com" "paste.armbian.de")
+if [[ "${PASTE_SERVER_HOST}" != "" ]]; then
+	echo "Using custom paste server: '${PASTE_SERVER_HOST}'"
+	paste_servers=("${PASTE_SERVER_HOST}" "${paste_servers[@]}")
+fi
+
+# Set up colors if available
+if test -t 1; then
+	ncolors=$(tput colors)
+	if test -n "$ncolors" && test $ncolors -ge 8; then
+		BOLD="$(tput bold)"
+		NC='\033[0m' # No Color
+	fi
+fi
+
+Main() {
+	export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+	# Check if curl is available, install if not
+	if ! command -v curl > /dev/null 2>&1; then
+		echo "curl not found in PATH. Trying to install it..." >&2
+		if [ "$(id -u)" = "0" ]; then
+			apt-get -f -y install curl
+		else
+			echo "Please install curl: sudo apt-get install curl" >&2
+			exit 1
+		fi
+	fi
+
+	# 5 second countdown with option to force stdout output
+	force_stdout=false
+	echo -e "\n${BOLD}Collecting debug information for Armbian support${NC}"
+	echo -e "Press any key within 5 seconds to output to stdout instead of uploading..."
+	for i in {5..1}; do
+		echo -ne "\r$i seconds remaining... "
+		# Read with timeout (works in bash)
+		if read -s -n 1 -t 1; then
+			force_stdout=true
+			echo -e "\n${BOLD}Key pressed - will output to stdout${NC}\n"
+			break
+		fi
+	done
+	if [ "$force_stdout" = false ]; then
+		echo -e "\rStarting upload...        "
+	fi
+
+	# Collect and process the info
+	if [ "$force_stdout" = true ]; then
+		# Output to stdout with line numbers
+		CollectSupportInfo |
+			sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
+			awk '!NF{$0=" "}1' | nl -
+		echo -e "\nPlease upload the ${BOLD}whole output${NC} above to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
+	else
+		# Try to upload to paste servers
+		upload_success=false
+
+		for paste_server in "${paste_servers[@]}"; do
+			echo "Collecting info and sending to ${paste_server}..."
+			declare -i counter=0
+			{
+				LC_ALL=C date
+				echo "-----------------------------------------------------------------------------------------------------------------------------"
+				dmesg --color=always
+				echo "-----------------------------------------------------------------------------------------------------------------------------"
+				CollectSupportInfo || echo "Error collecting support info"
+			} |
+				sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
+				curl -s --fail --data-binary @- "https://${paste_server}/log"
+
+			# Check PIPESTATUS
+			for i in "${PIPESTATUS[@]}"; do
+				counter=$((counter + 1))
+				if [[ $i -ne 0 ]]; then
+					echo "Failed (pipe ${counter} returned ${i})."
+					continue 2
+				fi
+			done
+
+			# If we get here, upload succeeded
+			upload_success=true
+			break
+		done
+
+		if [ "$upload_success" = true ]; then
+			echo -e "\n${BOLD}Upload successful!${NC} Please post the URL above in the forum.\n"
+		else
+			echo -e "\n${BOLD}All upload attempts failed. Outputting to stdout instead:${NC}\n"
+			CollectSupportInfo |
+				sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
+				awk '!NF{$0=" "}1' | nl -
+			echo -e "\nPlease upload the ${BOLD}whole output${NC} above to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
+		fi
+	fi
+}
+
+CollectSupportInfo() {
+	[[ -s /var/log/armbian-hardware-monitor.log ]] && cat /var/log/armbian-hardware-monitor.log || zcat /var/log/armbian-hardware-monitor.log.1.gz 2> /dev/null
+	[[ -f /boot/armbianEnv.txt ]] && LOGLEVEL=$(awk -F'=' '/^verbosity/ {print $2}' /boot/armbianEnv.txt)
+	LOGLEVEL=${LOGLEVEL:-1}
+	if [ ${LOGLEVEL} -gt 4 ]; then
+		VERBOSE='-v'
+		which lshw > /dev/null 2>&1 && (
+			echo -e "\n### lshw:"
+			lshw -quiet -sanitize -numeric
+		)
+	fi
+	lsusb > /dev/null 2>&1 && (
+		echo -e "\n### lsusb:\n"
+		lsusb ${VERBOSE} 2> /dev/null
+		echo ""
+		lsusb -t 2> /dev/null
+	)
+	lspci > /dev/null 2>&1 && (
+		echo -e "\n### lspci:\n"
+		lspci ${VERBOSE} 2> /dev/null
+	)
+	nvme > /dev/null 2>&1 && (
+		echo -e "\n### nvme:\n"
+		nvme list 2> /dev/null
+	)
+	[ -z $SUDO_USER ] || echo -e "\n### Group membership of $(groups $SUDO_USER)"
+	echo -en "\n### Userland"
+	[[ -f /etc/armbian-release ]] && echo -en " generated with Armbian Build Framework"
+	echo -en ":\n"
+	echo -e "\n$(grep PRETTY_NAME /etc/os-release)"
+	echo -e "\n### Installed packages:\n\n$(dpkg -l | grep -E "openmediavault|armbian| linux-")"
+	KernelVersion=$(awk -F" " '{print $3}' < /proc/version)
+	case ${KernelVersion} in
+		3.*)
+			[[ -e /boot/script.bin ]] && echo -e "\n### fex settings: $(ls -la /boot/script.bin)\n\n$(bin2fex /boot/script.bin 2> /dev/null)"
+			;;
+	esac
+	echo -e "\n### Loaded modules:\n\n$(lsmod)"
+	[[ -f /var/log/nand-sata-install.log ]] && echo -e "\n### nand-sata-install.log:\n\n$(cat /var/log/nand-sata-install.log)"
+	echo -e "\n### Current sysinfo:\n\n$(command -v iostat >/dev/null 2>&1 && iostat -p ALL | grep -v "^loop")\n\n$(vmstat -w)\n\n$(free -h)\n\n$(zramctl 2> /dev/null)\n\n$(uptime)\n\n$(dmesg | tail -n 250)"
+	echo -e "\n"
+	[[ "$(id -u)" -eq "0" ]] && for sysfsnode in /proc/sys/vm/*; do sysctl $(echo ${sysfsnode} | sed 's|/proc/sys/vm/|vm.|'); done
+	echo -e "\n### interrupts:\n$(cat /proc/interrupts)"
+	ls /tmp/armbianmonitor_checks_* > /dev/null 2>&1 || return 0
+	for file in /tmp/armbianmonitor_checks_*; do
+		echo -e "\n### \c"
+		ls "${file}" | cut -f1 -d.
+		echo
+		cat "${file}"
+	done
+} # CollectSupportInfo
+
+Main "$@"

--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -78,8 +78,11 @@ Main() {
 				sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
 				curl -s --fail --data-binary @- "https://${paste_server}/log"
 
+			# Save PIPESTATUS before any other command
+			pipe_status=("${PIPESTATUS[@]}")
+
 			# Check PIPESTATUS
-			for i in "${PIPESTATUS[@]}"; do
+			for i in "${pipe_status[@]}"; do
 				counter=$((counter + 1))
 				if [[ $i -ne 0 ]]; then
 					echo "Failed (pipe ${counter} returned ${i})."
@@ -93,7 +96,7 @@ Main() {
 		done
 
 		if [ "$upload_success" = true ]; then
-			echo -e "\n${BOLD}Upload successful!${NC} Please post the URL above in the forum.\n"
+			echo -e "\n${BOLD}Upload successful!${NC} Please post the URL at the place where you have been asked for.\n"
 		else
 			echo -e "\n${BOLD}All upload attempts failed. Outputting to stdout instead:${NC}\n"
 			CollectSupportInfo |
@@ -108,7 +111,7 @@ CollectSupportInfo() {
 	[[ -s /var/log/armbian-hardware-monitor.log ]] && cat /var/log/armbian-hardware-monitor.log || zcat /var/log/armbian-hardware-monitor.log.1.gz 2> /dev/null
 	[[ -f /boot/armbianEnv.txt ]] && LOGLEVEL=$(awk -F'=' '/^verbosity/ {print $2}' /boot/armbianEnv.txt)
 	LOGLEVEL=${LOGLEVEL:-1}
-	if [ ${LOGLEVEL} -gt 4 ]; then
+	if [ "$LOGLEVEL" -gt 4 ]; then
 		VERBOSE='-v'
 		which lshw > /dev/null 2>&1 && (
 			echo -e "\n### lshw:"
@@ -129,23 +132,21 @@ CollectSupportInfo() {
 		echo -e "\n### nvme:\n"
 		nvme list 2> /dev/null
 	)
-	[ -z $SUDO_USER ] || echo -e "\n### Group membership of $(groups $SUDO_USER)"
+	[ -z "$SUDO_USER" ] || echo -e "\n### Group membership of $(groups "$SUDO_USER")"
 	echo -en "\n### Userland"
 	[[ -f /etc/armbian-release ]] && echo -en " generated with Armbian Build Framework"
 	echo -en ":\n"
 	echo -e "\n$(grep PRETTY_NAME /etc/os-release)"
 	echo -e "\n### Installed packages:\n\n$(dpkg -l | grep -E "openmediavault|armbian| linux-")"
-	KernelVersion=$(awk -F" " '{print $3}' < /proc/version)
-	case ${KernelVersion} in
-		3.*)
-			[[ -e /boot/script.bin ]] && echo -e "\n### fex settings: $(ls -la /boot/script.bin)\n\n$(bin2fex /boot/script.bin 2> /dev/null)"
-			;;
-	esac
 	echo -e "\n### Loaded modules:\n\n$(lsmod)"
 	[[ -f /var/log/nand-sata-install.log ]] && echo -e "\n### nand-sata-install.log:\n\n$(cat /var/log/nand-sata-install.log)"
 	echo -e "\n### Current sysinfo:\n\n$(command -v iostat >/dev/null 2>&1 && iostat -p ALL | grep -v "^loop")\n\n$(vmstat -w)\n\n$(free -h)\n\n$(zramctl 2> /dev/null)\n\n$(uptime)\n\n$(dmesg | tail -n 250)"
 	echo -e "\n"
-	[[ "$(id -u)" -eq "0" ]] && for sysfsnode in /proc/sys/vm/*; do sysctl $(echo ${sysfsnode} | sed 's|/proc/sys/vm/|vm.|'); done
+	if [[ "$(id -u)" -eq "0" ]]; then
+		for sysfsnode in /proc/sys/vm/*; do
+			sysctl "${sysfsnode/\/proc\/sys\/vm\//vm.}"
+		done
+	fi
 	echo -e "\n### interrupts:\n$(cat /proc/interrupts)"
 	ls /tmp/armbianmonitor_checks_* > /dev/null 2>&1 || return 0
 	for file in /tmp/armbianmonitor_checks_*; do

--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
-# armbian-debug
+# Copyright (c) Authors: https://www.armbian.com/authors
 #
 # Collect and upload system debug information for Armbian support.
-# Part of the Armbian project - https://www.armbian.com
 #
 ############################################################################
 
@@ -60,7 +59,7 @@ Main() {
 		CollectSupportInfo |
 			sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
 			awk '!NF{$0=" "}1' | nl -
-		echo -e "\nPlease upload the ${BOLD}whole output${NC} above to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
+		echo -e "\nPlease upload the ${BOLD}whole output${NC} above to an online pasteboard service\nand provide the URL at the place where you have been asked for this.\n"
 	else
 		# Try to upload to paste servers
 		upload_success=false

--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -8,7 +8,7 @@
 ############################################################################
 
 # Config:
-declare -a paste_servers=("paste.armbian.com" "paste.next.armbian.com" "paste.armbian.de")
+declare -a paste_servers=("paste.armbian.com" "paste.next.armbian.com" "paste.armbian.de" "paste.armbian.eu")
 if [[ "${PASTE_SERVER_HOST}" != "" ]]; then
 	echo "Using custom paste server: '${PASTE_SERVER_HOST}'"
 	paste_servers=("${PASTE_SERVER_HOST}" "${paste_servers[@]}")

--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -75,7 +75,7 @@ Main() {
 				CollectSupportInfo || echo "Error collecting support info"
 			} |
 				sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
-				curl -s --fail --data-binary @- "https://${paste_server}/log"
+				curl -s --fail --connect-timeout 10 --max-time 30 --data-binary @- "https://${paste_server}/log"
 
 			# Save PIPESTATUS before any other command
 			pipe_status=("${PIPESTATUS[@]}")

--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -29,9 +29,12 @@ Main() {
 	if ! command -v curl > /dev/null 2>&1; then
 		echo "curl not found in PATH. Trying to install it..." >&2
 		if [ "$(id -u)" = "0" ]; then
-			apt-get -f -y install curl
+			apt-get update && apt-get -f -y install curl || {
+				echo "Failed to install curl. Please run 'apt-get update' and retry, or install curl manually." >&2
+				exit 1
+			}
 		else
-			echo "Please install curl: sudo apt-get install curl" >&2
+			echo "Please install curl: sudo apt-get update && sudo apt-get install curl" >&2
 			exit 1
 		fi
 	fi
@@ -117,22 +120,22 @@ CollectSupportInfo() {
 	LOGLEVEL=${LOGLEVEL:-1}
 	if [ "$LOGLEVEL" -gt 4 ]; then
 		VERBOSE='-v'
-		which lshw > /dev/null 2>&1 && (
+		command -v lshw > /dev/null 2>&1 && (
 			echo -e "\n### lshw:"
 			lshw -quiet -sanitize -numeric
 		)
 	fi
-	lsusb > /dev/null 2>&1 && (
+	command -v lsusb > /dev/null 2>&1 && (
 		echo -e "\n### lsusb:\n"
 		lsusb ${VERBOSE} 2> /dev/null
 		echo ""
 		lsusb -t 2> /dev/null
 	)
-	lspci > /dev/null 2>&1 && (
+	command -v lspci > /dev/null 2>&1 && (
 		echo -e "\n### lspci:\n"
 		lspci ${VERBOSE} 2> /dev/null
 	)
-	nvme > /dev/null 2>&1 && (
+	command -v nvme > /dev/null 2>&1 && (
 		echo -e "\n### nvme:\n"
 		nvme list 2> /dev/null
 	)

--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -53,11 +53,23 @@ Main() {
 		echo -e "\rStarting upload...        "
 	fi
 
-	# Collect and process the info
+	# Create temp file for collected data
+	temp_file=$(mktemp) || { echo "Failed to create temp file" >&2; exit 1; }
+	trap "rm -f '${temp_file}'" EXIT
+
+	# Collect all info once into temp file
+	{
+		LC_ALL=C date
+		echo "-----------------------------------------------------------------------------------------------------------------------------"
+		dmesg --color=always
+		echo "-----------------------------------------------------------------------------------------------------------------------------"
+		CollectSupportInfo || echo "Error collecting support info"
+	} > "${temp_file}"
+
+	# Process the collected info
 	if [ "$force_stdout" = true ]; then
 		# Output to stdout with line numbers
-		CollectSupportInfo |
-			sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
+		sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' < "${temp_file}" |
 			awk '!NF{$0=" "}1' | nl -
 		echo -e "\nPlease upload the ${BOLD}whole output${NC} above to an online pasteboard service\nand provide the URL at the place where you have been asked for this.\n"
 	else
@@ -65,16 +77,10 @@ Main() {
 		upload_success=false
 
 		for paste_server in "${paste_servers[@]}"; do
-			echo "Collecting info and sending to ${paste_server}..."
+			echo "Sending to ${paste_server}..."
 			declare -i counter=0
-			{
-				LC_ALL=C date
-				echo "-----------------------------------------------------------------------------------------------------------------------------"
-				dmesg --color=always
-				echo "-----------------------------------------------------------------------------------------------------------------------------"
-				CollectSupportInfo || echo "Error collecting support info"
-			} |
-				sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
+
+			sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' < "${temp_file}" |
 				curl -s --fail --connect-timeout 10 --max-time 30 --data-binary @- "https://${paste_server}/log"
 
 			# Save PIPESTATUS before any other command
@@ -98,8 +104,7 @@ Main() {
 			echo -e "\n${BOLD}Upload successful!${NC} Please post the URL at the place where you have been asked for.\n"
 		else
 			echo -e "\n${BOLD}All upload attempts failed. Outputting to stdout instead:${NC}\n"
-			CollectSupportInfo |
-				sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
+			sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' < "${temp_file}" |
 				awk '!NF{$0=" "}1' | nl -
 			echo -e "\nPlease upload the ${BOLD}whole output${NC} above to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
 		fi

--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -6,6 +6,15 @@
 #
 ############################################################################
 
+# root check:
+if [[ $EUID != 0 ]]; then
+	if command -v sudo > /dev/null 2>&1; then
+		exec sudo "$0" "$@"
+	fi
+	echo "This script must be run as root." >&2
+	exit 1
+fi
+
 # Config:
 declare -a paste_servers=("paste.armbian.com" "paste.next.armbian.com" "paste.armbian.de" "paste.armbian.eu")
 if [[ "${PASTE_SERVER_HOST}" != "" ]]; then

--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -147,6 +147,7 @@ CollectSupportInfo() {
 	echo -e "\n$(grep PRETTY_NAME /etc/os-release)"
 	echo -e "\n### Installed packages:\n\n$(dpkg -l | grep -E "openmediavault|armbian| linux-")"
 	echo -e "\n### Loaded modules:\n\n$(lsmod)"
+	[[ -f /var/log/armbian-install.log ]] && echo -e "\n### armbian-install.log:\n\n$(cat /var/log/armbian-install.log)"
 	[[ -f /var/log/nand-sata-install.log ]] && echo -e "\n### nand-sata-install.log:\n\n$(cat /var/log/nand-sata-install.log)"
 	echo -e "\n### Current sysinfo:\n\n$(command -v iostat >/dev/null 2>&1 && iostat -p ALL | grep -v "^loop")\n\n$(vmstat -w)\n\n$(free -h)\n\n$(zramctl 2> /dev/null)\n\n$(uptime)\n\n$(dmesg | tail -n 250)"
 	echo -e "\n"

--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -25,20 +25,6 @@ fi
 Main() {
 	export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-	# Check if curl is available, install if not
-	if ! command -v curl > /dev/null 2>&1; then
-		echo "curl not found in PATH. Trying to install it..." >&2
-		if [ "$(id -u)" = "0" ]; then
-			apt-get update && apt-get -f -y install curl || {
-				echo "Failed to install curl. Please run 'apt-get update' and retry, or install curl manually." >&2
-				exit 1
-			}
-		else
-			echo "Please install curl: sudo apt-get update && sudo apt-get install curl" >&2
-			exit 1
-		fi
-	fi
-
 	# 5 second countdown with option to force stdout output
 	force_stdout=false
 	echo -e "\n${BOLD}Collecting debug information for Armbian support${NC}"
@@ -53,6 +39,21 @@ Main() {
 		fi
 	done
 	if [ "$force_stdout" = false ]; then
+
+		# Check if curl is available, install if not
+		if ! command -v curl > /dev/null 2>&1; then
+			echo "curl not found in PATH. Trying to install it..." >&2
+			if [ "$(id -u)" = "0" ]; then
+				apt-get update && apt-get -f -y install curl || {
+					echo "Failed to install curl. Please run 'apt-get update' and retry, or install curl manually." >&2
+					exit 1
+				}
+			else
+				echo "Please install curl: sudo apt-get update && sudo apt-get install curl" >&2
+				exit 1
+			fi
+		fi
+
 		echo -e "\rStarting upload...        "
 	fi
 

--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -28,16 +28,23 @@ Main() {
 	# 5 second countdown with option to force stdout output
 	force_stdout=false
 	echo -e "\n${BOLD}Collecting debug information for Armbian support${NC}"
-	echo -e "Press any key within 5 seconds to output to stdout instead of uploading..."
-	for i in {5..1}; do
-		echo -ne "\r$i seconds remaining... "
-		# Read with timeout (works in bash)
-		if read -s -n 1 -t 1; then
-			force_stdout=true
-			echo -e "\n${BOLD}Key pressed - will output to stdout${NC}\n"
-			break
-		fi
-	done
+	if [ -t 0 ]; then
+		echo -e "Press any key within 5 seconds to output to stdout instead of uploading..."
+		for i in {5..1}; do
+			echo -ne "\r$i seconds remaining... "
+			# Read with timeout (works in bash)
+			if read -r -s -n 1 -t 1; then
+				force_stdout=true
+				echo -e "\n${BOLD}Key pressed - will output to stdout${NC}\n"
+				break
+			fi
+		done
+	else
+		# Non-interactive: read returns instantly at EOF, countdown would elapse
+		# without anyone able to opt out - never upload silently
+		force_stdout=true
+		echo "Non-interactive run, outputting to stdout instead of uploading" >&2
+	fi
 	if [ "$force_stdout" = false ]; then
 
 		# Check if curl is available, install if not

--- a/packages/bsp/common/usr/bin/armbian-debug
+++ b/packages/bsp/common/usr/bin/armbian-debug
@@ -157,7 +157,7 @@ CollectSupportInfo() {
 	echo -e "\n### interrupts:\n$(cat /proc/interrupts)"
 	ls /tmp/armbianmonitor_checks_* > /dev/null 2>&1 || return 0
 	for file in /tmp/armbianmonitor_checks_*; do
-		echo -e "\n### \c"
+		printf "\n### "
 		ls "${file}" | cut -f1 -d.
 		echo
 		cat "${file}"

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -203,68 +203,6 @@ ParseOptions() {
 				echo -e "\nPlease upload the ${BOLD}whole output${NC} above to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
 				exit 0
 				;;
-			r | R)
-				# Installs RPi-Monitor and patches templates (heavily on sun8i)
-				fping armbian.com 2> /dev/null | grep -q alive ||
-					(
-						echo "Network/firewall problem detected. Please fix this prior to installing RPi-Monitor." >&2
-						exit 1
-					)
-				InstallRPiMonitor
-				case $(awk '/Hardware/ {print $3$4}' < /proc/cpuinfo) in
-					*sun8i*)
-						PatchRPiMonitor_for_sun8i
-						case $(uname -r) in
-							3.4.*)
-								sed -i 's|H3_Extended_Mainline.conf|H3_Extended.conf|' /etc/rpimonitor/template/OrangePi_H3.conf
-								systemctl restart rpimonitor > /dev/null 2>&1
-								;;
-						esac
-						;;
-					*)
-						# On other SoCs than H3 make minor adjustments to config to reflect Armbian reality:
-						. /etc/armbian-release
-						sed -e "s/^web.status.1.name=.*/web.status.1.name=$BOARD_NAME/" \
-							-e "s/^web.statistics.1.name=.*/web.statistics.1.name=$BOARD_NAME/" \
-							< /etc/rpimonitor/template/raspbian.conf > /etc/rpimonitor/template/armbian.conf
-						cd /etc/rpimonitor/
-						ln -sf /etc/rpimonitor/template/armbian.conf data.conf
-						# fix temperature everywhere
-						sed -i -e 's|^dynamic.12.source=.*|dynamic.12.source=/etc/armbianmonitor/datasources/soctemp|' \
-							-e 's|^dynamic.12.postprocess=.*|dynamic.12.postprocess=sprintf("%.1f", $1/1000)|' \
-							/etc/rpimonitor/template/temperature.conf
-						# monitor big cores on big.LITTLE
-						if [ $(grep -c '^processor' /proc/cpuinfo) -ge 4 ]; then
-							sed -i 's|/sys/devices/system/cpu/cpu0/cpufreq/|/sys/devices/system/cpu/cpu4/cpufreq/|g' \
-								/etc/rpimonitor/template/cpu.conf
-						fi
-						# display processor architecture instead of undefined
-						sed -i -e "s_^static.4.source=.*_static.4.source=lscpu | awk -F' ' '/^Architecture/ {print \$2}'_" \
-							-e "s/^static.4.regexp=.*/static.4.regexp=/" /etc/rpimonitor/template/version.conf
-						;;
-				esac
-				echo -e "\nNow you're able to enjoy RPi-Monitor at http://$(ip a | awk -F" " '/inet / {print $2}' | grep -v '127.0.0.1' | cut -f1 -d/ | head -n1):8888"
-				exit 0
-				;;
-			p | P)
-				# Installs cpuminer on 32-bit platforms
-				fping armbian.com 2> /dev/null | grep -q alive ||
-					(
-						echo "Network/firewall problem detected. Please fix this prior to installing cpuminer." >&2
-						exit 1
-					)
-				cd /usr/local/src/
-				wget http://downloads.sourceforge.net/project/cpuminer/pooler-cpuminer-2.5.1.tar.gz
-				tar xf pooler-cpuminer-2.5.1.tar.gz && rm pooler-cpuminer-2.5.1.tar.gz
-				cd cpuminer-2.5.1/
-				apt-get -f -qq -y install libcurl4-gnutls-dev
-				autoreconf --force --install --verbose
-				./configure CFLAGS="-O3"
-				make && make install
-				echo -e "\n\nNow you can use /usr/local/bin/minerd to do automated benchmarking.\nIn case you also installed RPi-Monitor you can do a"
-				echo -e "\n    touch /root/.cpuminer\n\nto ensure minerd is running after reboot and results are recorded\nwith RPi-Monitor"
-				exit 0
-				;;
 			d)
 				# monitors write activity to disk
 				MonitorIO "${OPTARG}"
@@ -328,7 +266,7 @@ DisplayUsage() {
 	#		grep "^#" "$0" | grep -v "^#\!/bin/bash" | sed 's/^#//'
 	#	fi
 	echo
-	echo "Usage: $(basename $0) [-h] [-b] [-c \$path] [-d \$device] [-D] [-m] [-p] [-r] [-u]"
+	echo "Usage: $(basename $0) [-h] [-b] [-c \$path] [-d \$device] [-D] [-m] [-u]"
 	echo
 	echo "Options:"
 	echo "  -c /path/to/test   Performs disk health/performance tests"
@@ -338,8 +276,6 @@ DisplayUsage() {
 	echo "  -M                 Provides simple CLI monitoring - fixed-line output"
 	echo "  -n                 Provides simple CLI network monitoring - scrolling output"
 	echo "  -N                 Provides simple CLI network monitoring - fixed-line output"
-	echo "  -p                 Tries to install cpuminer for performance measurements"
-	echo "  -r                 Tries to install RPi-Monitor"
 	echo "  -u                 Tries to upload armbian-hardware-monitor.log for support purposes"
 	echo "  -v                 Tries to verify installed package integrity"
 	echo "  -z                 Runs a quick 7-zip benchmark to estimate CPU performance"
@@ -749,180 +685,6 @@ CreateTempDir() {
 		chmod 644 "${MyTempDir}/${file}"
 	done
 } #CreateTempFiles
-
-InstallRPiMonitor() {
-	# Installs rpimonitord loosely based on the official instructions from
-	# http://rpi-experiences.blogspot.fr/p/rpi-monitor-installation.html
-	# but using the package from our own repository
-	if [ "$(id -u)" != "0" ]; then
-		echo "Installing RPi-Monitor requires root privileges, try sudo please. Exiting" >&2
-		exit 1
-	fi
-	echo -e "Installing RPi-Monitor. This can take up to 5 minutes. Be patient please\c"
-	apt-get -qq -y update
-	apt-get -f -qq -y install rpimonitor
-	/usr/share/rpimonitor/scripts/updatePackagesStatus.pl &
-} # InstallRPiMonitor
-
-PatchRPiMonitor_for_sun8i() {
-	echo -e "\nNow patching RPi-Monitor to deal correctly with H3"
-	cd / && echo "H4sIAOYyv1cAA+xc/XbayJLPv/AUPZg7NrkGIfyVk4yzS5xk4jNO4mOTZOaM7+QK1BhdhETUwoSJ
-ead9hn2y/VV1S2ph7CTztbtnlzMxSOqqru+qrm7NTCVOGA+80FH9IHKSaTCJoyCNk+ZIhlOZtNTo
-3u/9tPE52Nvjb3z0937HXO/s7Oy799zOwd7B/o6703Hvtd39vYO9e6L9u2f+gs9MpV4ixL0kjtO7
-xmHYcPhXEPTXfja+cUjvfU+NqhvVDTGYzkQYe77wIl/4V0MlfE/CJMQwTsSLHR7z7GOaeINU6edB
-hEcTLw1oUBJPhBokwTRtAS0jCWUqvAxL6KUyoWni6EomKU03TOQHIElj8XYQJ7IluqGKxaWMZILB
-ioYwQVBAGqg0GCieBkicaRIPHLovVBANpLlBo72rSxEoEcWpmCZyECgpZBTPLjWTR/F0kQSXo1R0
-2u5eE3/2RVP0RvHEU+IHD6MTXI/SdPrQccZ83ZT+VcuXDsP3RsCNuS4Tb0LTgAUpVDxM514iH4pF
-PBMDLxKJ9EFwEvRnqRRBStJwIMVJ7AfDBdDg1izyMVc6kgJymSgRD/ni+1dvxPcsgVCczvphMBAn
-wUBGYAMUTumOGklf9AkNATwnCs4NBeJ5DLyskW0hAzxPBKStSEM72RQG37aISR9bkCHITkQ8JbAG
-aF1oZWWQrbWcFwz60CEjHsVTcDMCQvA3D8JQ9KWYKTmchdvAgLHi3XHvxes3PdF99ZN41z07677q
-/fQIY9NRjKfySmpMwWQaBkAMnhIvShcgHQhePjs7egGI7pPjk+PeT6BfPD/uvXp2fi6evz4TXXHa
-PesdH7056Z6J0zdnp6/Pn7WEOJdElAT8HbIdsnYgQF+mXhAqzfNPUKcCZaEvRt6VhFoHMrgCXR7M
-eLr4vM6Awwvj6JI5xNhChCDseEhWui0UCPzOmNx8Pm9dRrNWnFw6ocahnMetavVoJAfj4whqufLC
-w4PWntAfGEEwkaQBJeFavoLM07kkOc5jMSAoVX0aqHEZwX77bmBod5xBM2Q3DAmLOnzePTl/ZqYO
-hgBMBRwYRgPuwKgMFdtAJPRAmNYmJEdD/H8h4lbFLZ8NbYUwXhJuGMoBxxXgT4FXPRT9GCKMPNBL
-sSWRl/LjFCEj8u9ACTamobdwIPHpKMeV6dSjcIP4NRixGgfwnZR0ejfCsTIxh2AgyxkiFZmPB3sf
-kvuZQZkDzJMgTWV0B1I19QZkeWEwCcidICwdFyZTMQxCBMZ3ZD67BjEFmQnFsDtQwutuf3oXfwtI
-OBi03E6LRH048n0iw902PzrZj53sx+6XYVNQ7kAeOulk6hAbBPplkFrTh79sXZz/vXGh1nz9Jk5h
-OGIaSg/mOpZySk4wCXCP4xebv4xmE8pEZIYsb3LXOzBC11OKmAraRsgfJLFSsNM+yguYTIzngxjW
-OwRjYYDKg2LCXSr05ZVIZqFU20A2kEoZ/fcX4s2b46cU/qBm4WAci9TpL5qB79yBcrMfjgN/kx1o
-k/B7/oSzuGg2P8xksjhEdAIPCLjNJuufkSvf27wDK+Ud9t1hEkgKIoSeaki21JQyeqqjui89CmXT
-2TkydzkguW3SuhwGEcej+SiAVwbmqTg6fWNXAcZ/IXCiGomiWu3BnlYwPmgzeccRUrJiEpFPIg5X
-zKyQHzE0Avq59DhV8hRxpMRV4IkXvd7pXRaqaUWgy6kECh2cdKjTuUGmz8w0PfbnWcSBrUpVQEHZ
-JqWemAIom14iKQPDGKVKtTxJyDwR7uiMm1U3RPkEs09gy7NETmB8StcGEYoMmBzdYVoiMCxCUI3H
-N1OCW62+9IJoqyE+VSsbhH7qaetX1Qo8MEbRdtrtvTh0ZqWVw0PrOr8sHvAPfYk/1QpPepqAkQ+z
-QAVgr1b/91q1WkgWSQ98QCkkFIqeJBYojUIhFZ0QAIpCxGm1mIAbZKgM9iiBIiXJ+WmQVIkLTmGw
-Jsn6ncvMdKj05xoUPo8HFL9h91zOUmjvy2gwmnjJGFNXK0hzP4vmUDi0UnBaOdQ/HrGUq5XKOaGD
-kb7k+99WK8PA5giChKK4Zk69fqiNZMDEkoG8PaLKA5bBhpGBnRLQ07fPz3sEkt/WgVToQAqMTcbI
-zGqm2NMiGCdyCQr6eEqyMxmV02u1Au8CEWkyk+IRzA4MbLCTMiG4SkjAYOc5FejfOWqhKA6gHFH0
-G6HbgQzoX9sxZbyjoH4I6/1glrynG8CSc1b/ZHAtxWOmW8/D02oFsdFTSqB4C+VvqQaSHir3j3JA
-JTRXTnEULqhEhOfWP92w36XJyow1SDfhNqKPOnQQqxRwW+etl61u66zVa5mgQVNgcA8V0Kt4fljf
-2hL1LZ9UUvv731StIZz10zQagCKT+BnPDfRSNC9TXJ54Ks1BluIfhYVUTK3FlYJVXrWoDISA7Bpr
-SfW1Lp/IULIYDGkEFA7mUuNjeehIxvLRKhIxmfqcIgNVJN4Vylm2uS2dwxA0oziSxIT2RZ5SY5xN
-mX+tEyIXFoU0jWclxg4LvvGMTJ2AszBn61EvC1fDKw+/W+43wrmRO9ect0k+B1qVPNszQqa0Scxr
-NyKxA5UMhwhKCJVz2TdeZsRiB3DQuxLSG3oQEbAy8NyDDwa/yrc0EWi0Hy8NzeV716DM+HZGa1qe
-IuexrIQNREd8aZeaUmcj/axtr8vDnzdvG6os51MswVGl0FOV2Yw9er3ZZNHUzHp3nK3Q4kw0owda
-RvmIa+HNx6L5vCZqYtPpxSlykfg0TZAxRX13uUmC1ZCuCUHjEfU9KhVarxBiORihCopEe+W5JlOF
-VCIaN81lVa348KTqEhGeMqdZpNm5zUqm+T26pqwmxSmKOMTmaeBTatvOEh8WApIzgRZIfUM0EYZd
-SwxMbL0uHtfqn9xlDXdSLHBELZmIC751UUNgR7hIRbsGllzY945w93RequQpFgm5M5QftwWn0W1h
-SnqOOgrpL53EURrHoRKm/oBdIY/4nEFQnzEYBEYBKpoh2nQef+uKa2hjmjYpoUCZzQ8fRHORwWqQ
-DN7M/3UY1Cz6GDSZrAxPRvdX4TFAGQ7md5CGX0mMLSWI9hSRrnPObbAnQXToUPFv9PgNgUM75SFL
-p2ia1SwVryCqwX2HK2b+ywVReuFMJgPU9e2pW5j8/nKzUcs86qsmNlWGsbHaEepbaqUNaWlUALTE
-M2NBMfXZIIOAl0nIQhNaRUu/Jh5/2yHHCuPLS3jo78CUEyUqbNKudkv+N4uoAXHSffV9dSVHtfWN
-Il6aG2+UTCgkZdevkDPt63MucOw7x35YGnH8+p0XpKU7yYcSini4eqsUB9scMm4Ei2q1VEbq2MFq
-2H1A7XJY5tdUYhPvo6nEGIdd3n4dossYNVcUI0KXK32HY6+PpWJeLpvgmcdldiAqh1H1BJSB9zu7
-xMkDd5++3Hb7AX93eD8gK0Z1tHXzQBf8Zs7z+FySbLVarq2zKC11d1s8Peu+LLrgeddotcUNnkzJ
-lSYSSYTXcvWtGfeomklD0HKnstu6b9L3BDmCVl9iDHHKcJuWI9xWpBzAK4SnPdRIs+GQxj953T17
-isxtPP6QPV7fLPy8g9T2nSPTgeMlk37gRU2sHKmnwVNqgj4x0FJTU6lEXhRPg/vXceJFl3IKX5P5
-7xBZiSErlae9Jzp6OX7adxBzHwTN0U4zG9kEWAtP9OBHj/j7/hfCTgeroFJ5A/p+zYUjpH2KtXCq
-wL6fDkTzWGC8aL7Gl6KivPdkacXCQ46GcQbanDJsWUjXUCMsVYpN5XznOJvm5+NH+N3I839tA9hX
-aFjWjFFbi628XgCSiyhb55AZbYrH60Zre+uxta2ZopoJYqeVmUuWGr/7TODuWOnqWlywUOUl1u6i
-9svJ29b7a/x9f02WLSfXpJP3Azjw+Jod5PoXP/Em72srkM0rUYNP6SE8gn7RKL1w5HLa+KotubNn
-pyc/cTnCjrdObl8tOu062j1WnmatJfZSFO60pqPhhnvUy+BfU74KCXOgdkYzuYUnSioZP3zDLGAP
-67t8qZch9sKWSrS2XalWNnJGazz4ou6ijKYIsWUDOhQF2yi7M+CL6CLNqtH6JxbP8gLx4mJQW29c
-mKkP8seGsqyixc8KQ8OLtFq7Loul3lknkLw+LhUZVg3dyJD+VWzdEDFMqiziP4G/ddyFfwZ3vF7T
-CYrFupaVk7furRb8ZQzl7Ci5nsZhcBEtbyGSYhKHZkqhK/2oqh3TdAYNDusbWXPpZ0rbucbYrTIO
-SZLfBJYQ8WxrK2g2+Vfuafm4lQG3KKhQzm9TidbEbxdXIaKeEVCpG5nVGKbr5wnlDfUWD9JishB+
-kGSbhNTuok1d3e+kzok0G+pZw5MiH89frbxcmAkgsAnvqoimrx8WJzpaP/KnUaxEfFoQ5LBLe+VR
-YFzFUj/rvnr6+uXN7zopaDbx1Fi0Dw7Et9+KyZgYsqdo0EJqSyeL5zBdvc9lxMF0A6Ilun0EZmRG
-Xj9ki1i3oat9KiNJKlRJ6tai6XUIu1sisv0lYflLXpLywj6L9Jl+a1gmPy6LxKl/oqk4naG4jX2x
-v7t7+5Aw4tWhEusGaH2Yi8zUNNID111RBVlSYTrPyQhMZ4E7dZkhvcv6dGabP+8Smq3IovHXp4Rv
-SlWFap03nL0+qnruRrJVYgVL+wYOfiisR1DPSz6SUC81Jo391H5cbVhyEfYjtyxroumJ5ongip2n
-ZqoK+yKIopOWXeX0k4tnK7lb+mjZo6yHVlxb/bPMCIDPZMQcY40URqzTGFPCw6JKFN/Pi4Gc5WI0
-+P3mUGz+WIbYLOWmM29+F6c2uo2N+85Sp5+CRovNmxKwkMOxuOLifGLSSU5yPkgrSNh+Xjb+8sbs
-Sl+sVsJ0Y6xZjOeLWm0rVYvnzGi5XLN7/XQ+hLZ3sg7Olh9LFW2mYu6N8WwqeC2Y7YvprbBxFM+V
-GMVzCiC+9ELuqFHsLHq4erQ/0ycPaI9uEM58xBzaAOnTuogBCJU57ABnBM+NVrVC6CBgo7l8O8vJ
-aOR84C7t0hvKsyDMaBStE9E80oOvhamtPyC3pGCjv7jOeKtRaCzmyTtRiNIKsQ3+ZFCUmpxFl/39
-kczbnUOxVftbu9Ue1rbrbrvxSHAdkBuEodLYg20OG8JPAoSEQOUy5xVqIjFFJNpZtGzn/qQX5zlK
-Q9/mGjruU6JnWnQcJwn3+MQFb05Kv+i+DTw+NRFCu9QCkrRh65HeBQV3hPiUiOQdUerne5NpqMPY
-m/MnHMq05u1mP4JZGFOPSenNfWplZusHL1JzBM+bm0PFGY8FbUMS5vNuD+RNCfQhrunWn6c0M4F1
-AqkPqvmMFzNBrTS9F5azJ9RsSru0GZvZYQZFpw4gnmYaN8FDl5npJ4F/Kel8wodZQE3n3HVo13ci
-ITuFdH3ZEpvgaKb6/5oEgySONimBcNfCEzQvbzGOBW03bPC5OWVOMZU6o3yeaR6MA+dc0yj990TR
-U5OUmFapUu2VuSzTOAsa+nxOktAeJu/bZGevspteak6jkQevio4P+pTl55mds/6imM4L595CcehR
-N2NPS5zHLLrg1gMFnmV1ZI8cWHibDg7Ie5KRydYmBECNST4N4SZBZPiJvUK58AbLAGnHLxpTFp/x
-Ocdh8JF3yQFSdiUWKG8Owwr0Ea0wGBcG/EfFqlYrk7t93iKlvclMOpNZmAbkrivHmMCkT+LWui+R
-aVCaRparm1gb3AvO6wVxe4QGUYLWMCWIfuMWt4WRT5M4DIbBIHfftRgGjT9ObiZcFPPk6y0rfWKx
-Ze2t6WTKLYqt0n4AneC12l61i7RW3+G/u/x3j//u898D/vuA+4f5YVpkirw9Xnerlbw3Xu9UK1Zj
-vL5TreRdcWqJWC3x+h4uTfO7vg8wqxleP6DYT1M8RbgxS7xsRizwTT1X3KEFHxFhDc9oKoYXd2i4
-JtMCKOguQOx7BETMWCAZbwVAcYeHM7s2QM6/BWLdY6Dkgw2hRWINz24wE1poNheFGC027JsEV63w
-3qclWUKxFH83giuuCjHp60wC5ipn0FxrWgxoQZyeFSvvk9jzeVaal2nQVBZoG+I+rff17r4e0DD2
-lgPbJN9fM1gTbQ23uVgHQDxbwwsRrBusmbaG21JYC5B8OIoncGfpl/i/Q1pr8VTzKttIcpmzll1l
-YloaLrLfBc1LPbFNUF6rZycCVnbALN9b2Quz3OzGrljJo1Z2yCzXubFXVvKS8r5Z4Q43N9DKpq/b
-LPZBg+rKcYxsqZEdtNPpnhvIVE+mMm5NRwsVjFuzKGhOaKmLArjl66JyglDtzaXv4QZhsc+yWGd9
-XwJ2MNLHuOIJkOtGzaQl3tGxOzOSig3kZ8KDaqVPZ4OVPpfHNQEl61gf0eeKJjswrCtuFMXFSR4a
-ipor8S5Blc2tm61QKKno3lCTqrDWEEVMc0avLwAG6WDzZfwr8HvOXqsttl56A3rvQo0eCTrNEArc
-EK/PxY9w0ff4b7chulOk6ney/0OQOvvtduug5XbE1g8vei9Ptjk3I0ENxnFDvNVvCTgPWhgkzr2h
-lwQ5BMpFf4aMXLPOt9+lBMePxzMuFOkHBk3/LfAP5zIFyw9hw376cALVzzihlkrrk9kwLbS1rrLe
-LZYhjbIUO/8bpWhZqqMFRAd8ImdVMN2ZGs4ejpIQFivXyaVTkou1WCyJaM2ScUWEpfHuktaJa1G5
-n0HlHq5OzYcf+eiKXnOaOFtGytG2DCfooFOHYqwpqOzH1Wqpq5LFDT4Mnp2pNY5s3m/h/Uty5fZ/
-/sdRE0LDl1knctlKB+bstwLI/yeeUlixwt2pUjehQCPSCzREAz48za8oYNk5o3WY3mumU318PtAz
-72cA4+WMj/PSKh0rKX5JhnHoRqpeQmShwsQVFOBqEtPbE2aOLf1ODkey05dvmJDz+Mj0CX7WxWwz
-TKl3v3LoqBnpBoA9EBO5ev9+zWgakncMNBTsoZNbwJp+lAa5cTLLaN0lPXdQTOyxdvf19oDVgipp
-VZ9p1keM/7tfuPsf9qFTA0Vz36HGWAtG9oe+6cjvfx4c3PL+p77ndvY7e/udnYMD3O/sdjr790TH
-WaGOIjsdiXdes++cBu9f7Pxeav+Pv/95m4S7YTgPokgmEPF7CpiRL/3fKGtW9+7uLfp39w529/X7
-v3sHO51d2EnH3XPb///+71/x2fiDPsVrweLFTumd4GaT22FkP9m7pBgsTpGaHgqXfh5bo8sfKu5n
-Kv+pX/whkCa/qEyb4lQ1LiyQplhIZf3Uo+n8yrrh60dnmZPfO3a3xd62cPdux80vi4K7/N3pu3DT
-IHNETWRn6m6MjuJ8sLL28D5D9q9xJF0HOby0YLmV7JW3Le7GXTo0b0GsJZtf5BZXcZiSFD9H9iCO
-WRq0OL179B9lq/l7hfr1xuyUE9uG9TB7W/FLTh3im4y+ePOlQGNeXdyiM13F3Wms0qlewh4qXY2j
-GG/toBZHeePoWqptQySJf/h99833z6r5TfN+Jhmdu01/9/ivu2eNyLiw3423Ht/xYqU1yqbWBr5J
-0o4m6cax0eL514j1DjTrxLqzntAdJrSgcbfQO7/uaz3IiMvWgZgiEVRt/jO/ZZZVD3W71UwWJyvn
-Mc3/jMDYhTBtX4LPjuz805p2HTO765nZXSf1Pc1RfkyvbMr/1d7R7rZtA/dbT0EobmIv/tBHFCdN
-nKJN0ixD87F2HQZ0hWHHbmLUtjxLTpq1fac9wH5tLzbekZQoi7Ist2tXgAe0kcXj6Xg88kgddecp
-ZQ6GHibeBjtL3+tNUeS0mIk+cTel156SZ6+wXnuq5mxzJfKv0Lkc3xbtkA67yktX/sFOI11RZnYt
-vp3BrS1xWzHU6DLxdAuarAXyiRSpTP4OOgNFJd1mMX6bKsZ2uKYIx318X/lxdlysYminGEM7KoZ2
-GUO3YDO4yZDKZKbYB4NxmYqj3SyOHCVHuyqObCueH8AoVdnsxK7hPRC7GtNRxK4G/l1nEPLr6e94
-IVOTGyHewkrF+d+2Z8zLtK5SI4GmolnC3DF7i+ZWLlTNEbeDaTjrDBv8VUiD122zcgunhRQhpcGz
-M1hV2jUReCD6LCwjhgD7PisdJiD56AzzZSfs112/Ww9wuUlNLT8JJRYIh5cvs8oH9BLYrE/G11k4
-cNy/brd+pB1/QrX7SWdaNuHNPFVI06bto3+tKp5JqTNLTtwqvEypkh2rsmkSc1NZ1UtX9Zasaivq
-2snKCxvjtEz4GD8E78VDst89MKmFZO8O+Jihv80H+43uASm/uA/AVnIEaSwhTpWA+0FCiAYYLz5t
-XBAYXhKKNN44EjgqJIRoaGJxxVzYGJc1JjKb6QbFGwdK7uSHP7Bd6+NuMNnDr0QyqiatsVR3MT9b
-LfOEL3eS9OYXQ0BRYuXxFZ6KgbbAXBqk28FimyRr4Vo9iSpPxQLbzBghfLknHWnJwhMjpQ12BYfL
-WgamarzQXQ0o7t9/0j9Ca7mVJ0xp4d+OVaVsXFEyh/7QnwZVz6o2VQMBfOopetGJ0QUEtyxKU0Hw
-7J+/0HuRIpo4k7qAsGtVXS9j1H2bIjnk+zrYufeBckxWNkEE9tdKwnbVqcRqxzb/6ckZ5jTSIIdw
-ADOY9Pu9gP5S6aOCAL4Kp3LF+S8f0UFELx/RbfFtWC7m1tzuM7eCN7/Iz62xLW10cpGb0aI7F3Un
-uWbLxd+NF535XWJFq68lkO3kmia/ghOvLBYg94I24rdZULSAmcn6sNPtD5na2eAqLkzCk0l4K5Gw
-EzTs4kQSWsdpgeXAYURwHJEyNVeVT6B633k3CFpOIQpJ5eaMoZH9NM7m6K7CWjSKOFexvQ1WpLMK
-F3x4ch7Eyz5SptN24b7CEcAp4VK6UbgljMRKPc0nA9HH4nXkCk2R5yFOjr2CLP/yCYRW0hFpHhKj
-SjaDqxNbVWMBVxrfuGQn5QcL5ZKkcm/jo98TuovCz/LpQnvYfxNSk057/yFx6cZh1Hn3kDQ98rEA
-WSdNFoNympRKNhm+MzwSL92hUewM0IIqws7n2xQnMvXSRiUf3W1F25Z85K1WtD/JR/Za0m4nH327
-Fb2AWID7mTRFQUiSmpii8E5hQpE8ORnYJRYmEsmZE4FtYmEikvw5GbElLU6K942g8/ynBoSNpbfz
-SBUbkhYfkXDMkA6mBYceCvl/22c8eEExR3Ce/3e76cX+X3ptOa4L/n/t//3v4bP51LT/V/t/tf9X
-+3+1/1f7f//n/t+V3b/az6v9vNrPq/282s+r/bzdg3M/jNfm2q2r3braravdutqtq9262q2r3bra
-ravdutqtq9262q2r3bpfwa27NHyBL6xz/L+WbbsOz//r2N6W+51lN7dsR/t/vwSAbk7ALOI+fmMw
-um4M/WsfNvIbRlQ46o9n4SAc9lsbF5eD2hnTFkL2g1n3oLyxibu/Gz8IYRLf3KjsN6BAIgD/KQgo
-qm7MvZFAs8C0kVwO0mNprtzgMT5bmbEDRD5b0Op87NkEAnow5LVcbPnUxJIPWOKgRT6RUX/kT++X
-5TK460yWJBz0rjrT3pLI435450/fMmwdaOObAOhLSBJY76Vzv3+uZyzO/265rgPnf7Zda9trYrnt
-OZ6r5/8vATz/O2R/X1sjT45PTs/J6fnpz/S/pxcGRlm7HfTgrXMEKT2haM9ZANle7QWk2EHk0pRO
-SmG//SYgJbp8pFYliedPGE0l3lH/TWc2DCVymLxsi3iJQkEDs5tt06Jfa5iXrYN7eFYGCS5pyYsb
-fxrWjvosbQqurZ5LlojnE4ONatSoBDIDuQrDE5ntMXkoCgt2hdz7F1T5WZgOTwgtH59BiR+fH0ny
-Bj5ZZs8ocN1w0IXUAHWjThr0ujEMujhgawIjMIyjx8dnF+ctcy4na3pE14Mb07g8PXp6+uyYot92
-po3pTIU3GfRMw3hFau9IiVEnryF2KcsmZxgYdB6GTLny3iAsD4pZKg96pDarYFx0iCcuwjqB5Fhw
-Q8wfz6RKRpAdFyLdzcYQ3BmomQyV5ffCYF90mQsDNMTAXLQz/dnVDSnxJkB2VZT7AOPllspXnTAq
-rGDoduw1yl6ZvIXAejWLlAD7gMzld6tIrApmFZ1Nue8MIUvMPbA9pl1dN/d4JbZkEb9ExOw9EbaM
-EIjLvgc8Ux1vM7Vpj4JrYqKWg9qkn2jS3fN874CUYAsE8bDs3aiDRMPJuiGYaZUe8cfRZQU+q8QK
-mFz9iVqsKg79yaQYh0t0DOsS21P3CZfYEo2h0h7F3NOmQX7kWGmgofAHE4o5jN405KpF6zMdjgLh
-K7qd4dHdmNB1zKYXCTyt5+Ab5Aoi6bRlcE1YWjZZ6rq+HvP7ivxGbegre891Rv5bvLZG5DXGGo6R
-8L5rj54+Pn3GcV6j6jKtZIyDTKKhbWDAZbNkmxBwmUuNpVlnAiQQrJiJV9xGQfO7ILIInXUTlvDO
-YUX8hyj7viIJ8WWAZ0RLFnmPSB+A/gde4wMj+tFkVTFgssGl/LWNqgYNGjRo0KBBgwYNGjRo0KBB
-gwYNGjRo0KBBw1eEfwH4UoBHAKAAAA==" | base64 --decode | tar xzf -
-	which systemctl > /dev/null 2>&1
-	case $? in
-		0)
-			# Jessie|Stretch|Xenial|Bionic
-			systemctl enable rpimonitor-helper > /dev/null 2>&1
-			systemctl start rpimonitor-helper > /dev/null 2>&1
-			systemctl restart rpimonitor > /dev/null 2>&1
-			;;
-		*)
-			# Wheezy|Trusty
-			insserv rpimonitor-helper > /dev/null 2>&1 || update-rc.d rpimonitor-helper defaults 90 10 > /dev/null 2>&1
-			cd /tmp && nohup /usr/local/sbin/rpimonitor-helper.sh &
-			> /dev/null 2>&1
-			/etc/init.d/rpimonitor stop > /dev/null 2>&1
-			/etc/init.d/rpimonitor start > /dev/null 2>&1
-			;;
-	esac
-} # PatchRPiMonitor_for_sun8i
 
 CollectSupportInfo() {
 	[[ -s /var/log/armbian-hardware-monitor.log ]] && cat /var/log/armbian-hardware-monitor.log || zcat /var/log/armbian-hardware-monitor.log.1.gz 2> /dev/null

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -86,13 +86,13 @@ ParseOptions() {
 
 The -u and -U options are deprecated. This functionality has been moved to the
 dedicated 'armbian-debug' tool.
-
-Launching armbian-debug now...
 EOF
 				# Check if armbian-debug exists
 				if [ -x /usr/bin/armbian-debug ]; then
+					echo "Launching armbian-debug now..."
 					exec /usr/bin/armbian-debug
 				elif [ -x "$(dirname "$0")/armbian-debug" ]; then
+					echo "Launching armbian-debug now..."
 					exec "$(dirname "$0")/armbian-debug"
 				else
 					echo "Error: armbian-debug not found." >&2

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
-# armbianmonitor
+# Copyright (c) Authors: https://www.armbian.com/authors
 #
 # System monitoring and debugging utility for Armbian.
-# Part of the Armbian project - https://www.armbian.com
 #
 # Features:
 # - Live system monitoring (CPU, temp, voltage, etc.)

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -81,13 +81,6 @@
 #
 ############################################################################
 
-# Config:
-declare -a paste_servers=("paste.armbian.com" "paste.next.armbian.com" "paste.armbian.de")
-if [[ "${PASTE_SERVER_HOST}" != "" ]]; then
-	echo "Using custom paste server: '${PASTE_SERVER_HOST}'"
-	paste_servers=("${PASTE_SERVER_HOST}" "${paste_servers[@]}")
-fi
-
 Main() {
 	export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -156,52 +149,24 @@ ParseOptions() {
 				NetworkMonitorMode ${OPTARG}
 				exit 0
 				;;
-			u)
-				# Upload /var/log/armbian-hardware-monitor.log with additional support info
-				# NOTE(rpardini): was here. briefly. just because this uses the paste server and I want ANSI dmesgs
-				# check if curl binary is available in path, if not try to install it. use command, not which
-				if ! command -v curl > /dev/null 2>&1; then
-					echo "curl not found in PATH. Trying to install it." >&2
-					apt-get -f -y install curl
+			u | U)
+				# DEPRECATED: Support info collection has been moved to armbian-debug
+				cat << 'EOF'
+
+The -u and -U options are deprecated. This functionality has been moved to the
+dedicated 'armbian-debug' tool.
+
+Launching armbian-debug now...
+EOF
+				# Check if armbian-debug exists
+				if [ -x /usr/bin/armbian-debug ]; then
+					exec /usr/bin/armbian-debug
+				elif [ -x "$(dirname "$0")/armbian-debug" ]; then
+					exec "$(dirname "$0")/armbian-debug"
+				else
+					echo "Error: armbian-debug not found." >&2
+					exit 1
 				fi
-				# loop over the paste_servers; first to work wins.
-				for paste_server in "${paste_servers[@]}"; do # defined at top of file
-					echo "Collecting info and sending to ${paste_server}, wait..."
-					declare -i counter=0
-					{
-						LC_ALL=C date # include timestamp
-						echo "-----------------------------------------------------------------------------------------------------------------------------"
-						dmesg --color=always # output in ANSI color. The paste service handles this.
-						echo "-----------------------------------------------------------------------------------------------------------------------------"
-						CollectSupportInfo || echo "Error collecting support info via CollectSupportInfo"
-					} |
-						# we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
-						# in clear since otherwise the log becomes worthless due to randomly generated
-						# addresses here and there that might conflict
-						sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
-						curl -s --fail --data-binary @- "https://${paste_server}/log"
-					# Check PIPESTATUS to know if everything worked. Any non-zero exit status means something didn't work.
-					for i in "${PIPESTATUS[@]}"; do
-						counter=$((counter + 1))
-						if [[ $i -ne 0 ]]; then
-							echo "Failed grabbing info (pipe ${counter} result ${i}) and sending to server ${paste_server}."
-							continue 2 # continue the outer loop (paste_servers)
-						fi
-					done
-					echo -e "Please post the URL in the forum where you've been asked for.\n"
-					exit 0
-				done
-
-				;;
-
-			U)
-				# Send support info to stdout to be uploaded manually. Add line numbers to prevent
-				# users being creative and supressing everything that's important
-				CollectSupportInfo |
-					sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
-					awk '!NF{$0=" "}1' | nl -
-				echo -e "\nPlease upload the ${BOLD}whole output${NC} above to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
-				exit 0
 				;;
 			d)
 				# monitors write activity to disk
@@ -266,7 +231,7 @@ DisplayUsage() {
 	#		grep "^#" "$0" | grep -v "^#\!/bin/bash" | sed 's/^#//'
 	#	fi
 	echo
-	echo "Usage: $(basename $0) [-h] [-b] [-c \$path] [-d \$device] [-D] [-m] [-u]"
+	echo "Usage: $(basename $0) [-h] [-c \$path] [-d \$device] [-D] [-m] [-n] [-v] [-z]"
 	echo
 	echo "Options:"
 	echo "  -c /path/to/test   Performs disk health/performance tests"
@@ -276,9 +241,11 @@ DisplayUsage() {
 	echo "  -M                 Provides simple CLI monitoring - fixed-line output"
 	echo "  -n                 Provides simple CLI network monitoring - scrolling output"
 	echo "  -N                 Provides simple CLI network monitoring - fixed-line output"
-	echo "  -u                 Tries to upload armbian-hardware-monitor.log for support purposes"
 	echo "  -v                 Tries to verify installed package integrity"
 	echo "  -z                 Runs a quick 7-zip benchmark to estimate CPU performance"
+	echo
+	echo "Note: The -u/-U options for support info upload are deprecated."
+	echo "      Use the 'armbian-debug' command instead."
 	echo
 
 } # DisplayUsage

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -695,7 +695,7 @@ CheckCard() {
 		if [ "X$2" = "XMB/s" ]; then
 			RawReadSpead=$(echo "$1 * 1000" | bc -s | cut -f1 -d.)
 		else
-			RawReadSpead$(echo "$1" | cut -f1 -d.)
+			RawReadSpead=$(echo "$1" | cut -f1 -d.)
 		fi
 		echo -e "\n${NC}${BOLD}Performance summary:${NC}\nSequential reading speed:$(printf "%6s" $1) $2 \c"
 		[ ${RawReadSpead} -le 2500 ] && Exclamation="${LRED}${BOLD}way " || Exclamation=""
@@ -776,6 +776,9 @@ NetworkMonitorMode() {
 
 	# Allow armbianmonitor to return back to armbian-config
 	trap "echo ; exit 0" 0 1 2 3 15
+
+	# Ensure net-tools is installed for 'route' command
+	which route > /dev/null 2>&1 || (apt-get update && apt-get -f -y install net-tools)
 
 	# Count interfaces - multiple routes causing interfaces to show up more than once, filtering...
 	ifacecount=$(route -n | grep -E UG | grep -Eo '[^ ]*$' | sort | uniq)

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -2,82 +2,33 @@
 #
 # armbianmonitor
 #
-# This script serves different purposes based on how it is called:
+# System monitoring and debugging utility for Armbian.
+# Part of the Armbian project - https://www.armbian.com
 #
-# - toggle boot verbosity (works)
-# - monitoring mode: continually print monitoring info (WiP)
-# - uploading /var/log/armbian-hardware-monitor.log to online pastebin service
+# Features:
+# - Live system monitoring (CPU, temp, voltage, etc.)
+# - Network monitoring
+# - Disk I/O monitoring
+# - Disk health/performance testing
+# - Package integrity verification
 #
-# Without arguments called it should present a simple user
-# interface that guides through:
+# For support info collection and upload, use 'armbian-debug'.
 #
-# - installation of RPi-Monitor if not already installed by user
-# - active basic or more verbose monitoring mode
-# - provides monitoring parameters for connected disks
+# Disk Configuration Format:
+# When checking disks, proposals are generated for /etc/armbianmonitor/disks.conf:
 #
-# The second part is WiP and all the user interaction part
-# still completely missing.
+#   ${GUID}:${Name}:${smartctl_prefix}:${temp_call}:${CRC}:${LCC}
 #
-# This script is used to configure armbianmonitor behaviour.
-# It will ask the user whether to activate monitoring or not,
-# whether to enable debug monitoring and also how to deal with
-# connected disks. In fact it walks through the list of available
-# disks, checks them, tries to patch hddtemp.db if necessary
-# and provides a proposal for /etc/armbianmonitor/disks.conf
-# when a new disk is found.
+# Fields:
+#   - GUID: Disk identifier from gdisk
+#   - Name: Display name (defaults to device model)
+#   - smartctl_prefix: USB disk type prefix (e.g., '-d sat', '-d usbjmicron')
+#   - temp_call: Command to get temperature (omit to use hddtemp)
+#   - CRC: S.M.A.R.T. attribute number for CRC errors
+#   - LCC: S.M.A.R.T. attribute number for load cycle count
 #
-# In case monitoring should be activated the following file
-# will be created: /etc/armbianmonitor/start-monitoring. If
-# debug output has been chosen, then DEBUG will be written to
-# the file.
-#
-# The script will install smartmontools/gdisk if not already
-# installed and patches smartmontools' update-smart-drivedb
-# script if necessary. For disks the 'device model' will be
-# shown but internally we rely always on the GUID. This is the
-# key for entry in /etc/armbianmonitor/disks.conf
-#
-# When the script exits and the user activated monitoring it
-# recommends doing a restart since on the next reboot the
-# setup-armbian-monitoring-environment script will configure
-# monitoring sources and decides based on the existence and
-# contents of /etc/armbianmonitor/start-monitoring whether
-# rpimonitord should be started or not.
-#
-# The format of /etc/armbianmonitor/disks.conf is as follows:
-#
-# ${GUID}:${Name}:${smartctl prefix}:${temp call}:${CRC}:${LCC}
-#
-# Two examples:
-#
-# A57BF307-7D82-4783-BD1D-B346CA8C195B:WD Green::199:193 # WD HDD on SATA
-# F8D372DC-63DB-494B-B802-87DC47FAD4E1:Samsung EVO:sat::199: # SSD in USB enclosure
-#
-# - GUID is the GUID as determined by gdisk
-# - 'Name': The name as it will later be shown in RPi-Monitor, defaults to
-#   the 'device model' read out through smartctl but can be changed to
-#   be more significant (beware that this string must contain colons!)
-# - "smartctl prefix" can be empty or should be the the necessary prefix for
-#   USB disks, eg. '-d sat' or '-d usbjmicron' and so on -- please have a
-#   look at https://www.smartmontools.org/wiki/Supported_USB-Devices
-# - "temp call" when being omitted indicates that hddtemp should be used.
-#   Otherwise it should contain the complete command line ('DISK' will be
-#   dynamically replaced by the device node when the actual monitoring
-#   happens), for example:
-#   /sbin/hdparm -C DISK | grep -Eq "standby|sleeping" || \
-#   /usr/sbin/smartctl -d sat -a DISK | awk -F" " '/Temperature_Cel/ {printf $10}'
-# - 'CRC attribute': The decimal value of the S.M.A.R.T. attribute that
-#   is used to store the count of checksum errors between disk and host
-#   controller (might be omitted if the drive doesn't support it)
-# - 'LCC attribute': The decimal value of the S.M.A.R.T. attribute that
-#   should contain the load cycle counter value (might be omitted
-#   if the drive doesn't support it)
-#
-# TODO:
-#
-# - develop main functionality ;) asking the user regarding monitoring
-# - deal with 'SMART overall-health self-assessment test result:'
-# - write documentation
+# Example:
+#   A57BF307-7D82-4783-BD1D-B346CA8C195B:WD Green::199:193
 #
 ############################################################################
 
@@ -102,29 +53,10 @@ Main() {
 	)
 
 	ParseOptions "$@"
-
-	exit 0
-	PreRequisits
-
-	# check whether user runs rpimonitord on his own or we activated it
-	if [ -f /etc/armbianmonitor/start-monitoring ]; then
-		# we should already provide monitoring, check whether DEBUG
-		# is also set
-		ArmbianMonitoring=TRUE
-		read -r DebugMode < /etc/armbianmonitor/start-monitoring 2> /dev/null
-	fi
-
-	# check whether rpimonitord is running and compare with ${ArmbianMonitoring}
-	# In case the user chose to run rpimonitord on his own, we skip the config
-	# part and only output disk info
-	:
-
-	# check available disk devices
-	CheckDisks
 } # Main
 
 ParseOptions() {
-	while getopts 'hHuUrRmMsnNd:Dc:C:pPvz' c; do
+	while getopts 'hHuUrRmMsnNd:c:C:pPv' c; do
 		case ${c} in
 			H)
 				# display full help test
@@ -173,31 +105,6 @@ EOF
 				MonitorIO "${OPTARG}"
 				exit 0
 				;;
-			D)
-				fping ix.io 2> /dev/null | grep -q alive ||
-					(
-						echo "Network/firewall problem detected. Please fix this prior to installing RPi-Monitor." >&2
-						exit 1
-					)
-				DebugOutput="$(mktemp /tmp/${0##*/}.XXXXXX)"
-				trap "rm \"${DebugOutput}\" ; exit 0" 0 1 2 3 15
-				set -x
-				exec 2> "${DebugOutput}"
-				PreRequisits > /dev/null 2>&1
-				CheckDisks
-				which curl > /dev/null 2>&1 || apt-get -f -qq -y install curl
-				echo -e "\nDebug output has been collected at the following URL: \c"
-				(
-					cat "${DebugOutput}"
-					echo -e "\n\n\ngdisk.txt contents:\n"
-					cat "${MyTempDir}/gdisk.txt"
-					echo -e "\n\n\nsmartctl.txt contents:\n"
-					cat "${MyTempDir}/smartctl.txt"
-				) |
-					curl -F 'f:1=<-' ix.io
-				echo -e "Please post the URL in the Armbian forum where you've been asked for."
-				exit 0
-				;;
 			c | C)
 				# check card mode
 				CheckCard "${OPTARG}"
@@ -207,12 +114,6 @@ EOF
 				# Verify installation integrity
 				VerifyRepairExcludes="/etc/|/boot/|cache|getty|/var/lib/smartmontools/"
 				VerifyInstallation
-				exit 0
-				;;
-			z)
-				# Do a quick 7-zip benchmark to estimate CPU performance
-				runs=$2
-				Run7ZipBenchmark 2> /dev/null
 				exit 0
 				;;
 			*)
@@ -231,18 +132,16 @@ DisplayUsage() {
 	#		grep "^#" "$0" | grep -v "^#\!/bin/bash" | sed 's/^#//'
 	#	fi
 	echo
-	echo "Usage: $(basename $0) [-h] [-c \$path] [-d \$device] [-D] [-m] [-n] [-v] [-z]"
+	echo "Usage: $(basename $0) [-h] [-c \$path] [-d \$device] [-m] [-n] [-v]"
 	echo
 	echo "Options:"
 	echo "  -c /path/to/test   Performs disk health/performance tests"
 	echo "  -d                 Monitors writes to \$device"
-	echo "  -D                 Tries to upload debug disk info to improve armbianmonitor"
 	echo "  -m                 Provides simple CLI monitoring - scrolling output"
 	echo "  -M                 Provides simple CLI monitoring - fixed-line output"
 	echo "  -n                 Provides simple CLI network monitoring - scrolling output"
 	echo "  -N                 Provides simple CLI network monitoring - fixed-line output"
 	echo "  -v                 Tries to verify installed package integrity"
-	echo "  -z                 Runs a quick 7-zip benchmark to estimate CPU performance"
 	echo
 	echo "Note: The -u/-U options for support info upload are deprecated."
 	echo "      Use the 'armbian-debug' command instead."
@@ -993,33 +892,5 @@ kickAllStatsDown() {
 	stxP=0
 	cnt=0
 }
-
-Run7ZipBenchmark() {
-	echo -e "Preparing benchmark. Be patient please..."
-	# Do a quick 7-zip benchmark, check whether binary is there. If not install it
-	MyTool=$(which 7za || which 7zr)
-	[ -z "${MyTool}" ] && apt-get -f -qq -y install p7zip && MyTool=/usr/bin/7zr
-	[ -z "${MyTool}" ] && (
-		echo "No 7-zip binary found and could not be installed. Aborting" >&2
-		exit 1
-	)
-	# Send CLI monitoring to the background to be able to spot throttling and other problems
-	MonitoringOutput="$(mktemp /tmp/${0##*/}.XXXXXX)"
-	trap "rm \"${MonitoringOutput}\" ; exit 0" 0 1 2 3 15
-	armbianmonitor -m > ${MonitoringOutput} &
-	MonitoringPID=$!
-	# run 7-zip benchmarks after waiting 10 seconds to spot whether the system was idle before.
-	# We run the benchmark a single time by default unless otherwise specified on the command line
-	RunHowManyTimes=${runs:-1}
-	sleep 10
-	for ((i = 1; i <= RunHowManyTimes; i++)); do
-		"${MyTool}" b
-	done
-	# report CLI monitoring results as well
-	kill ${MonitoringPID}
-	echo -e "\nMonitoring output recorded while running the benchmark:\n"
-	sed -e '/^\s*$/d' -e '/^Stop/d' < ${MonitoringOutput}
-	echo -e "\n"
-} # Run7ZipBenchmark
 
 Main "$@"

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -82,11 +82,11 @@ ParseOptions() {
 				;;
 			u | U)
 				# DEPRECATED: Support info collection has been moved to armbian-debug
-				cat << 'EOF'
+				cat <<- 'EOF'
 
-The -u and -U options are deprecated. This functionality has been moved to the
-dedicated 'armbian-debug' tool.
-EOF
+					The -u and -U options are deprecated. This functionality has been moved to the
+					dedicated 'armbian-debug' tool.
+					EOF
 				# Check if armbian-debug exists
 				if [ -x /usr/bin/armbian-debug ]; then
 					echo "Launching armbian-debug now..."
@@ -550,69 +550,6 @@ CreateTempDir() {
 		chmod 644 "${MyTempDir}/${file}"
 	done
 } #CreateTempFiles
-
-CollectSupportInfo() {
-	[[ -s /var/log/armbian-hardware-monitor.log ]] && cat /var/log/armbian-hardware-monitor.log || zcat /var/log/armbian-hardware-monitor.log.1.gz 2> /dev/null
-	[[ -f /boot/armbianEnv.txt ]] && LOGLEVEL=$(awk -F'=' '/^verbosity/ {print $2}' /boot/armbianEnv.txt)
-	LOGLEVEL=${LOGLEVEL:-1}
-	if [ ${LOGLEVEL} -gt 4 ]; then
-		VERBOSE='-v'
-		which lshw > /dev/null 2>&1 && (
-			echo -e "\n### lshw:"
-			lshw -quiet -sanitize -numeric
-		)
-	fi
-	lsusb > /dev/null 2>&1 && (
-		echo -e "\n### lsusb:\n"
-		lsusb ${VERBOSE} 2> /dev/null
-		echo ""
-		lsusb -t 2> /dev/null
-	)
-	lspci > /dev/null 2>&1 && (
-		echo -e "\n### lspci:\n"
-		lspci ${VERBOSE} 2> /dev/null
-	)
-	nvme > /dev/null 2>&1 && (
-		echo -e "\n### nvme:\n"
-		nvme list 2> /dev/null
-	)
-	[ -z $SUDO_USER ] || echo -e "\n### Group membership of $(groups $SUDO_USER)"
-	echo -en "\n### Userland"
-	[[ -f /etc/armbian-release ]] && echo -en " generated with Armbian Build Framework"
-	echo -en ":\n"
-	echo -e "\n$(grep PRETTY_NAME /etc/os-release)"
-	echo -e "\n### Installed packages:\n\n$(dpkg -l | grep -E "openmediavault|armbian| linux-")"
-	KernelVersion=$(awk -F" " '{print $3}' < /proc/version)
-	case ${KernelVersion} in
-		3.*)
-			[[ -e /boot/script.bin ]] && echo -e "\n### fex settings: $(ls -la /boot/script.bin)\n\n$(bin2fex /boot/script.bin 2> /dev/null)"
-			;;
-	esac
-	echo -e "\n### Loaded modules:\n\n$(lsmod)"
-	[[ -f /var/log/armbian-install.log ]] && echo -e "\n### armbian-install.log:\n\n$(cat /var/log/armbian-install.log)"
-	[[ -f /var/log/nand-sata-install.log ]] && echo -e "\n### nand-sata-install.log:\n\n$(cat /var/log/nand-sata-install.log)"
-	echo -e "\n### Current system health:\n\n$("$0" -s | grep -E "^Time|^[0-9]")"
-	stress -t 3 -c $(grep -c processor /proc/cpuinfo) --backoff 250 > /dev/null 2>&1 &
-	"$0" -s | grep "^[0-9]"
-	# Include name resolving information only if upload is not possible
-	fping ix.io 2> /dev/null | grep -q alive ||
-		[ -f /etc/resolv.conf ] && echo -e "\n### resolv.conf\n\n$(
-		ls -la /etc/resolv.conf
-		cat /etc/resolv.conf
-	)" ||
-		echo -e "\n### resolv.conf does not exist or readable"
-	echo -e "\n### Current sysinfo:\n\n$(command -v iostat >/dev/null 2>&1 && iostat -p ALL | grep -v "^loop")\n\n$(vmstat -w)\n\n$(free -h)\n\n$(zramctl 2> /dev/null)\n\n$(uptime)\n\n$(dmesg | tail -n 250)"
-	echo -e "\n"
-	[[ "$(id -u)" -eq "0" ]] && for sysfsnode in /proc/sys/vm/*; do sysctl $(echo ${sysfsnode} | sed 's|/proc/sys/vm/|vm.|'); done
-	echo -e "\n### interrupts:\n$(cat /proc/interrupts)"
-	ls /tmp/armbianmonitor_checks_* > /dev/null 2>&1 || return 0
-	for file in /tmp/armbianmonitor_checks_*; do
-		echo -e "\n### \c"
-		ls "${file}" | cut -f1 -d.
-		echo
-		cat "${file}"
-	done
-} # CollectSupportInfo
 
 CheckCard() {
 	if [ "$(id -u)" = "0" ]; then

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -99,6 +99,18 @@ ParseOptions() {
 					exit 1
 				fi
 				;;
+			r | R)
+				# REMOVED: RPi-Monitor support has been dropped
+				echo "The -r and -R options (RPi-Monitor installation) have been removed." >&2
+				echo "RPi-Monitor is no longer shipped with Armbian. Use 'armbianmonitor -m' for monitoring." >&2
+				exit 1
+				;;
+			p | P)
+				# REMOVED: cpuminer based performance test has been dropped
+				echo "The -p and -P options (cpuminer performance test) have been removed." >&2
+				echo "Please use 'sbc-bench' instead." >&2
+				exit 1
+				;;
 			d)
 				# monitors write activity to disk
 				MonitorIO "${OPTARG}"
@@ -144,6 +156,7 @@ DisplayUsage() {
 	echo
 	echo "Note: The -u/-U options for support info upload are deprecated."
 	echo "      Use the 'armbian-debug' command instead."
+	echo "Note: The -r/-R and -p/-P options (RPi-Monitor, cpuminer performance test) have been removed."
 	echo
 
 } # DisplayUsage

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -125,7 +125,7 @@ EOF
 
 DisplayUsage() {
 
-	# Kept for referance.
+	# Kept for reference.
 	#	if [ ${FullUsage} ]; then
 	#		echo -e "\nDetailed Description:"
 	#		grep "^#" "$0" | grep -v "^#\!/bin/bash" | sed 's/^#//'
@@ -342,7 +342,7 @@ MonitorIO() {
 	if grep -q "$1" /proc/diskstats; then
 		LastWrite=$(awk -v d="$1" '{if($3 == d) print $8}' < /proc/diskstats)
 	else
-		echo "Bud argument: [$1]"
+		echo "Bad argument: [$1]"
 		echo "Disks valid for monitoring: $(
 			awk '{if($8 != 0) printf "%s ", $3}' /proc/diskstats
 		)"
@@ -378,7 +378,7 @@ CheckDisks() {
 		DeviceNode=/dev/${i##*/}
 		# get GUID/UUID for disk and check whether a partition table is existent. If
 		# not GUID will always be random
-		gdisk -l ${DeviceNode} > "${MyTempDir}/gdisk.txt"
+		gdisk -l "${DeviceNode}" > "${MyTempDir}/gdisk.txt"
 		GUID=$(awk -F" " '/^Disk identifier/ {print $4}' < "${MyTempDir}/gdisk.txt")
 		CountOfUnavailablePartitionTables=$(grep ': not present' "${MyTempDir}/gdisk.txt" | wc -l)
 		if [ ${CountOfUnavailablePartitionTables} -eq 4 ]; then
@@ -389,10 +389,10 @@ CheckDisks() {
 		fi
 
 		# get name hddtemp needs
-		HddtempName="$(hddtemp --debug ${DeviceNode} | awk -F": " '/^Model: / {print $2}' |
+		HddtempName="$(hddtemp --debug "${DeviceNode}" | awk -F": " '/^Model: / {print $2}' |
 			cut -c-40 | sed 's/^[ \t]*//;s/[ \t]*$//')"
 		# store smartctl output in temporary file
-		smartctl -q noserial -s on -a ${DeviceNode} > "${MyTempDir}/smartctl.txt" 2>&1
+		smartctl -q noserial -s on -a "${DeviceNode}" > "${MyTempDir}/smartctl.txt" 2>&1
 		DeviceModel="$(awk -F": " '/^Device Model/ {print $2}' < "${MyTempDir}/smartctl.txt" |
 			sed 's/^[ \t]*//;s/[ \t]*$//')"
 		if [ "X${DeviceModel}" = "X" ]; then
@@ -429,10 +429,10 @@ CheckDisks() {
 				grep "Temperature" "${MyTempDir}/smartctl.txt"
 				# check hddtemp result
 				HddtempResult=$(hddtemp -n ${DeviceNode} | grep -v 'not available' | awk -F" " '{print $1}')
-				if [ "X${HddtempResult}" != "X${DeviceNode}:" ]; then
+				if [ "X${HddtempResult}" != "X"${DeviceNode}":" ]; then
 					# hddtemp isn't able to query the disk
 					HddtempStatus="does not work. Please check with smartctl and adjust config accordingly"
-					echo -e "\nhddtemp output: $(hddtemp ${DeviceNode})"
+					echo -e "\nhddtemp output: $(hddtemp "${DeviceNode}")"
 					echo -e "\nIt seems we can not rely on hddtemp to query this disk. Please try smartctl instead\n"
 				else
 					HddtempStatus="will work"
@@ -472,7 +472,7 @@ CheckDisks() {
 					*)
 						echo -e "Proposal for /etc/armbianmonitor/disks.conf:\n${GUID}:${DeviceModel}:${SMARTPrefix}:FIXME:${CRCAttribute}:${LCCAttribute}"
 						echo -e "You have to figure out how to query the disk for its thermal sensor."
-						echo -e "Please check the output of \"hddtemp --debug ${DeviceNode}\" and smartctl\n"
+						echo -e "Please check the output of \"hddtemp --debug "${DeviceNode}"\" and smartctl\n"
 						;;
 				esac
 				;;
@@ -514,16 +514,16 @@ PreRequisits() {
 	DISTROCODE=$(lsb_release -s -c)
 
 	# check whether gdisk/smartctl are available and up to date
-	echo -e "Check whether necessary software is available\c"
+	printf "Check whether necessary software is available"
 	which gdisk > /dev/null 2>&1 || (
-		echo -e " Installing gdisk\c"
+		printf " Installing gdisk"
 		apt-get -f -qq -y install gdisk
 	)
 	which smartctl > /dev/null 2>&1 || (
-		echo -e " Installing smartmontools\c"
+		printf " Installing smartmontools"
 		apt-get -f -qq -y install smartmontools
 	)
-	echo -e " [done]\nUpdating smartmontools' drivedb\c"
+	printf " [done]\nUpdating smartmontools' drivedb"
 	/usr/sbin/update-smart-drivedb > /dev/null 2>&1
 	if [ $? -ne 0 -a "X${DISTROCODE}" = "Xwheezy" ]; then
 		sed -i "/^SRCEXPR/{s#=.*#='http://sourceforge.net/p/smartmontools/code/HEAD/tree/\$location/smartmontools/drivedb.h?format=raw'#}" /usr/sbin/update-smart-drivedb
@@ -538,7 +538,7 @@ CreateTempDir() {
 	MyTempDir=$(mktemp -d /tmp/${0##*/}.XXXXXX)
 	if [ ! -d "${MyTempDir}" ]; then
 		MyTempDir=/tmp/${0##*/}.$RANDOM.$RANDOM.$RANDOM.$$
-		(umask 066 && mkdir ${MyTempDir}) || (
+		(umask 066 && mkdir "${MyTempDir}") || (
 			echo "Failed to create temp dir. Aborting" >&2
 			exit 1
 		)
@@ -668,11 +668,11 @@ CheckCard() {
 	echo -e "\n${BOLD}The results from testing ${DeviceName} (${FileSystem}):${NC}"
 	grep -E "Average|Data" "${LogFile}" | sort -r
 	echo "                                            random    random"
-	echo -e "reclen    write  rewrite    read    reread    read     write\c"
+	printf "reclen    write  rewrite    read    reread    read     write"
 	awk -F"102400  " '/102400/ {print $2}' < "${LogFile}"
 
 	# check health
-	echo -e "\n${BOLD}Health summary: \c"
+	printf "\n${BOLD}Health summary: "
 	grep -Eq "Read-only|Input/output error" "${LogFile}" && (
 		echo -e "${LRED}${BOLD}${DeviceName} failed${NC}"
 		exit 0
@@ -688,24 +688,24 @@ CheckCard() {
 	if [ "X${RandomSpeed}" != "X" ]; then
 		# Only continue when we're able to read out iozone results
 		set ${RandomSpeed}
-		RandomReadSpead=$1
-		RandomWriteSpead=$2
+		RandomReadSpeed=$1
+		RandomWriteSpeed=$2
 		ReadSpeed=$(awk -F" " '/Average reading speed/ {print $4"\t"$5}' < "${LogFile}")
 		set ${ReadSpeed}
 		if [ "X$2" = "XMB/s" ]; then
-			RawReadSpead=$(echo "$1 * 1000" | bc -s | cut -f1 -d.)
+			RawReadSpeed=$(echo "$1 * 1000" | bc -s | cut -f1 -d.)
 		else
-			RawReadSpead=$(echo "$1" | cut -f1 -d.)
+			RawReadSpeed=$(echo "$1" | cut -f1 -d.)
 		fi
-		echo -e "\n${NC}${BOLD}Performance summary:${NC}\nSequential reading speed:$(printf "%6s" $1) $2 \c"
-		[ ${RawReadSpead} -le 2500 ] && Exclamation="${LRED}${BOLD}way " || Exclamation=""
-		[ ${RawReadSpead} -le 5000 ] && Exclamation="${Exclamation}${BOLD}too "
-		[ ${RawReadSpead} -le 7500 ] && echo -e "(${Exclamation}low${NC})\c"
+		printf "\n${NC}${BOLD}Performance summary:${NC}\nSequential reading speed:$(printf "%6s" $1) $2 "
+		[ ${RawReadSpeed} -le 2500 ] && Exclamation="${LRED}${BOLD}way " || Exclamation=""
+		[ ${RawReadSpeed} -le 5000 ] && Exclamation="${Exclamation}${BOLD}too "
+		[ ${RawReadSpeed} -le 7500 ] && printf "(${Exclamation}low${NC})"
 		echo "${Exclamation}" | grep -q "too" && ShowWarning=true
-		printf "\n 4K random reading speed: %6s KB/s " "$RandomReadSpead"
-		[ ${RandomReadSpead} -le 700 ] && Exclamation="${LRED}${BOLD}way " || Exclamation=""
-		[ ${RandomReadSpead} -le 1400 ] && Exclamation="${Exclamation}${BOLD}too "
-		[ ${RandomReadSpead} -le 2500 ] && echo -e "(${Exclamation}low${NC})\c"
+		printf "\n 4K random reading speed: %6s KB/s " "$RandomReadSpeed"
+		[ ${RandomReadSpeed} -le 700 ] && Exclamation="${LRED}${BOLD}way " || Exclamation=""
+		[ ${RandomReadSpeed} -le 1400 ] && Exclamation="${Exclamation}${BOLD}too "
+		[ ${RandomReadSpeed} -le 2500 ] && printf "(${Exclamation}low${NC})"
 		echo "${Exclamation}" | grep -q "too" && ShowWarning=true
 		WriteSpeed=$(awk -F" " '/Average writing speed/ {print $4"\t"$5}' < "${LogFile}")
 		set ${WriteSpeed}
@@ -717,18 +717,18 @@ CheckCard() {
 		printf "\nSequential writing speed: %6s %s " "$1" "$2"
 		[ ${RawWriteSpeed} -le 2500 ] && Exclamation="${LRED}${BOLD}way " || Exclamation=""
 		[ ${RawWriteSpeed} -le 4000 ] && Exclamation="${Exclamation}${BOLD}too "
-		[ ${RawWriteSpeed} -le 6000 ] && echo -e "(${Exclamation}low${NC})\c"
+		[ ${RawWriteSpeed} -le 6000 ] && printf "(${Exclamation}low${NC})"
 		echo "${Exclamation}" | grep -q "too" && ShowWarning=true
-		printf "\n 4K random writing speed: %6s KB/s " "$RandomWriteSpead"
-		[ ${RandomWriteSpead} -le 400 ] && Exclamation="${LRED}${BOLD}way " || Exclamation=""
-		[ ${RandomWriteSpead} -le 750 ] && Exclamation="${Exclamation}${BOLD}too "
-		[ ${RandomWriteSpead} -lt 1000 ] && echo -e "(${Exclamation}low${NC})\c"
+		printf "\n 4K random writing speed: %6s KB/s " "$RandomWriteSpeed"
+		[ ${RandomWriteSpeed} -le 400 ] && Exclamation="${LRED}${BOLD}way " || Exclamation=""
+		[ ${RandomWriteSpeed} -le 750 ] && Exclamation="${Exclamation}${BOLD}too "
+		[ ${RandomWriteSpeed} -lt 1000 ] && printf "(${Exclamation}low${NC})"
 		echo "${Exclamation}" | grep -q "too" && ShowWarning=true
 		if [ "X${ShowWarning}" = "Xtrue" ]; then
 			echo -e "\n\n${BOLD}The device you tested seems to perform too slow to be used with Armbian."
 			echo -e "This applies especially to desktop images where slow storage is responsible"
 			echo -e "for sluggish behaviour. If you want to have fun with your device do NOT use"
-			echo -e "this media to put the OS image or the user homedirs on.${NC}\c"
+			printf "this media to put the OS image or the user homedirs on.${NC}"
 		fi
 		echo -e "\n\nTo interpret the results above correctly or search for better storage
 alternatives please refer to http://oss.digirati.com.br/f3/ and also
@@ -747,7 +747,7 @@ GetDevice() {
 	if TestPath=$(findmnt --noheadings --output SOURCE,FSTYPE --target "$1" --uniq); then
 		echo "${TestPath}"
 	else
-		echo "Bud Path: $1" >&2
+		echo "Bad Path: $1" >&2
 		exit 1
 	fi
 } # GetDevice
@@ -761,7 +761,7 @@ VerifyInstallation() {
 
 	echo -e "Starting package integrity check. This might take some time. Be patient please..."
 	OUTPUT=$(dpkg --verify | grep -Evi "${VerifyRepairExcludes}" | awk -F" /" '{print "/"$2}')
-	if [[ -z $OUTPUT ]]; then
+	if [[ -z "$OUTPUT" ]]; then
 		echo -e "\n${LGREEN}${BOLD}It appears you don't have any corrupt files or packages!${NC}"
 	else
 		echo -e "\n${LRED}${BOLD}It appears you may have corrupt packages.${NC}\n"
@@ -800,7 +800,7 @@ NetworkMonitorMode() {
 	timerStart
 	kickAllStatsDown
 
-	printf "\nruntime network statistics: %s\m" "$(uname -n)"
+	printf "\nruntime network statistics: %s\n" "$(uname -n)"
 	printf "network interface: %s\n" "$iface"
 	printf "[tap 'd' to display column headings]\n"
 	printf "[tap 'z' to reset counters]\n"


### PR DESCRIPTION
# Description

- split log upload into dedicated tool
- - adjust its logic to auto upload but allow user to output to stdout by simple key press
- - leave `-u/-U` in  `armbianmonitor` intact but add deprecation notice
- armbianmonitor
- - remove tons of dead code
- - remove old benchmark tools
- - remove `rpimonitor` and dirty binary patch hack
- - remove references to EOL userspaces and 3.y kernel from middle-age
- - - perhaps add references to `sbcbench` later for proper results

- - remove old debug mode
- - - was referencing to `ix.io` which has been dead for years and nobody ever complained
- - various fixes

@rpardini you may wanna have a look at this...or not :D

# How Has This Been Tested?

- [x] only armbian-debug has been tested so far

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a diagnostic utility that collects system information, sanitizes network data, and uploads or prints reports when uploads fail.
  - Added fallback support for launching diagnostics from the existing monitoring tool.

- **Bug Fixes**
  - Improved disk and storage checks, sequential-read parsing, output formatting, quoting, and network-monitoring setup.
  - Updated command-line help and option handling.

- **Changes**
  - Removed support-info collection, monitoring integrations, benchmarking, and related upload functionality from the existing monitoring tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->