### PR TITLE
Resolving boot issues

### DIFF
--- a/patch/u-boot/v2026.01/phy-allwinner-add-pcie-usb3-driver.patch
+++ b/patch/u-boot/v2026.01/phy-allwinner-add-pcie-usb3-driver.patch
@@ -7,8 +7,8 @@ Signed-off-by: Marvin Wewer <mwewer37@proton.me>
 ---
  drivers/phy/allwinner/Kconfig                |   8 +
  drivers/phy/allwinner/Makefile               |   1 +
- drivers/phy/allwinner/phy-sun55i-pcie-usb3.c | 661 ++++++++++
- 3 files changed, 670 insertions(+)
+ drivers/phy/allwinner/phy-sun55i-pcie-usb3.c | 656 ++++++++++
+ 3 files changed, 665 insertions(+)
 
 diff --git a/drivers/phy/allwinner/Kconfig b/drivers/phy/allwinner/Kconfig
 index 111111111111..222222222222 100644
@@ -41,7 +41,7 @@ new file mode 100644
 index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/phy/allwinner/phy-sun55i-pcie-usb3.c
-@@ -0,0 +1,661 @@
+@@ -0,0 +1,656 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Allwinner PIPE USB3.0 PCIE Combo Phy driver
@@ -77,9 +77,6 @@ index 000000000000..111111111111
 +/* PCIE USB3 Sub-System Registers */
 +/* Sub-System Version Reset Register */
 +#define PCIE_USB3_SYS_VER		0x00
-+
-+/* PHY CLK Gating Control Register */
-+#define PCIE_REF_CLK_GATING 31
 +
 +/* CCMU Base Address */
 +#define SUNXI_CCMU_BASE                0x02001000
@@ -595,9 +592,7 @@ index 000000000000..111111111111
 +    	reg_value |= (1 << PCIE_BRG_REG_RST);
 +    	writel(reg_value, PCIE_BGR_REG);
 +
-+    	reg_value = readl(0x2001a84);
-+    	reg_value |= (1 << PCIE_REF_CLK_GATING);
-+    	//reg_value = 0x81000001;
++    	reg_value = 0x81000001;
 +    	writel(reg_value, 0x2001a84);
 +
 +	pcie_usb3_sub_system_enable(combphy);


### PR DESCRIPTION
Booting directly from the nvme wasnt possible due to a coding error in the pcie_usb3_sub_system_init method. Also the nvme wasnt showing up due to missing overwrite.

# Description

reg_value = 0x81000001; has been uncommented. Since reg_value is overwritten, the two previous lines can be removed, as can PCIE_REF_CLK_GATING. Here's the Armbian Monitor information: https://paste.armbian.com/sihetinevi from this branch with only this being corrected.
# How Has This Been Tested?



- [x] build
- [x] Flashing the bootloader to the sd-card and booting from the SSD. 

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Allwinner SUN55I INNO combo PHY controller support for PCIe and USB3 interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->