### PR TITLE
Raspberry Pi: Add uncompressed wireless FW to Ubuntu releases

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -254,11 +254,18 @@ function pre_install_distribution_specific__add_rpi_packages() {
 	fi
 }
 
-function pre_install_distribution_specific__ubuntu_raspi_firmware() {
+function pre_install_distribution_specific__ubuntu_brcm_firmware() {
 	# Ubuntu uses compressed "*.zst" firmware of which the kernel has issue.
 	if [[ "${DISTRIBUTION}" == "Ubuntu" ]]; then
-		display_alert "$DISTRIBUTION" "Adding uncompressed raspi-firmware" "info"
-		chroot_sdcard git clone --depth=1 -q https://github.com/pyavitz/firmware.git -b brcm lib/firmware/updates
+		declare destdir="${SDCARD}/lib/firmware/updates"
+		declare firmware_commit_sha1="996423a18fc9c084c494c8ce378a25c7f8f44db4" # Keep this inside this file, so hashing detect changes and bumps the version of the bsp package
+		declare srcdir="${SRC}/cache/sources/brcm/${firmware_commit_sha1}"
+
+		run_host_command_logged mkdir -p "${destdir}"
+		# Get the firmware files from the git repo
+		fetch_from_repo "https://github.com/pyavitz/firmware.git" "brcm" "commit:${firmware_commit_sha1}" "yes"
+		# Copy the files from the git repo to the destdir
+		run_host_command_logged cp -pr "${srcdir}/"* "${destdir}"/
 		rm -fdr "${SDCARD}"/lib/firmware/updates/.git
 	fi
 }


### PR DESCRIPTION
Ubuntu uses compressed "*.zst" firmware of which the kernel has issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted firmware installation flow to introduce Ubuntu-specific handling that fetches and stages Broadcom firmware ahead of system install for more consistent outcomes.
* **Bug Fix**
  * Removed an older Raspberry Pi post-install firmware tweak to simplify and stabilize the installation sequence.
* **Chores**
  * Eliminated a duplicated firmware handling entry to avoid redundant operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->