### PR TITLE
bcm2711 Family: Remove post_family_tweaks_bsp__rpi_firmware func

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -180,12 +180,6 @@ function post_family_tweaks_bsp__add_hooks_to_move_kernel_initrd_and_dtb() {
 	run_host_command_logged chmod a+x "${destination}"/etc/initramfs/post-update.d/zzz-update-initramfs
 }
 
-function post_family_tweaks_bsp__rpi_firmware() {
-	display_alert "$BOARD" "Installing firmware" "info"
-	git clone https://github.com/pyavitz/firmware.git --depth=1 -q "${destination}"/lib/firmware/updates/brcm
-	rm -fdr "${destination}"/lib/firmware/updates/brcm/{.git,README.md}
-}
-
 function post_family_tweaks_bsp__add_x11_config() {
 	display_alert "rpi5b" "Adding X11 configuration" "info"
 	run_host_command_logged mkdir -p "${destination}"/etc/X11/xorg.conf.d/


### PR DESCRIPTION
No longer required using linux-6.18.y and up. https://github.com/armbian/build/pull/9330#issuecomment-3832365484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified Raspberry Pi firmware handling during system installation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->