### PR TITLE
KDE Neon: drop conflicting packages in order to assemble KDE desktop

### DIFF
--- a/config/desktop/noble/environments/kde-neon/config_base/packages
+++ b/config/desktop/noble/environments/kde-neon/config_base/packages
@@ -1,5 +1,4 @@
 neon-desktop
-kde-standard
 sddm
 plasma-nm
 plasma-pa


### PR DESCRIPTION
# Description

kde-standard is an Ubuntu meta-package that breaks everything.

# How Has This Been Tested?

- [x] Generated and boot x86 image

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated KDE Neon desktop environment configuration by removing a package entry from the base package set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->