### PR TITLE
abl: feat: add extraargs from armbianEnv for mkbootimg

### DIFF
--- a/extensions/image-output-abl.sh
+++ b/extensions/image-output-abl.sh
@@ -35,7 +35,7 @@ function post_build_image__900_convert_to_abl_img() {
 	display_alert "Replace root partition uuid from ${old_rootfs_image_uuid} to ${new_rootfs_image_uuid} in /etc/fstab" "${EXTENSION}" "info"
 	sed -i "s|${old_rootfs_image_uuid}|${new_rootfs_image_uuid}|g" ${new_rootfs_image_mount_dir}/etc/fstab
 	source ${new_rootfs_image_mount_dir}/boot/armbianEnv.txt
-	declare -g bootimg_cmdline="${BOOTIMG_CMDLINE_EXTRA} root=UUID=${new_rootfs_image_uuid} slot_suffix=${abl_boot_partition_label#boot}"
+	declare -g bootimg_cmdline="${BOOTIMG_CMDLINE_EXTRA} root=UUID=${new_rootfs_image_uuid} slot_suffix=${abl_boot_partition_label#boot} ${extraargs}"
 
 	if [ ${#ABL_DTB_LIST[@]} -ne 0 ]; then
 		display_alert "Going to create abl kernel boot image" "${EXTENSION}" "info"

--- a/packages/bsp/oneplus-kebab/zz-update-abl-kernel
+++ b/packages/bsp/oneplus-kebab/zz-update-abl-kernel
@@ -11,7 +11,7 @@ source /boot/armbianEnv.txt
         --ramdisk /boot/initrd.img-*-sm8250 \
         --base 0x0 \
         --second_offset 0x00f00000 \
-        --cmdline "root=UUID=${new_rootfs_image_uuid} slot_suffix=${abl_boot_partition_label#boot}" \
+        --cmdline "root=UUID=${new_rootfs_image_uuid} slot_suffix=${abl_boot_partition_label#boot} ${extraargs}" \
         --kernel_offset 0x8000 \
         --ramdisk_offset 0x1000000 \
         --tags_offset 0x100 \

--- a/packages/bsp/xiaomi-elish/zz-update-abl-kernel
+++ b/packages/bsp/xiaomi-elish/zz-update-abl-kernel
@@ -24,7 +24,7 @@ source /boot/armbianEnv.txt
         --ramdisk /boot/initrd.img-*-sm8250 \
         --base 0x0 \
         --second_offset 0x00f00000 \
-        --cmdline "root=UUID=${new_rootfs_image_uuid} slot_suffix=${abl_boot_partition_label#boot}" \
+        --cmdline "root=UUID=${new_rootfs_image_uuid} slot_suffix=${abl_boot_partition_label#boot} ${extraargs}" \
         --kernel_offset 0x8000 \
         --ramdisk_offset 0x1000000 \
         --tags_offset 0x100 \


### PR DESCRIPTION
# Description

Add extraargs from armbianENV.txt to the cmdline option for mkbootimg

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- After applying this modification and reinstalling the kernel：
```
chen@xiaomi-elish:~$ cat /boot/armbianEnv.txt 
abl_boot_partition_label=boot_b
rootdev=UUID=940c68fe-1909-4918-9f8a-198b1582f0b2
rootfstype=ext4
extraargs=cpufreq.default_governor=schedutil
usbstoragequirks=0x2537:0x1066:u,0x2537:0x1068:u
chen@xiaomi-elish:~$ cat /proc/cmdline 
root=UUID=0552a964-89db-4af3-ade9-5f49d671df7e slot_suffix=_b cpufreq.default_governor=schedutil androidboot.verifiedbootstate=orange androidboot.keymaster=1 androidboot.vbmeta.device=PARTUUID=cd1cfbb7-7a7f-9f61-e1dc-df3128bdbcc9 androidboot.vbmeta.avb_version=1.0 androidboot.vbmeta.device_state=unlocked androidboot.vbmeta.hash_alg=sha256 androidboot.vbmeta.size=7872 androidboot.vbmeta.digest=05846afbe0b8ecc7023969e198f2b8b5822adb9573514e81abf0341964144c7f androidboot.vbmeta.invalidate_on_error=yes androidboot.veritymode=enforcing androidboot.bootdevice=1d84000.ufshc androidboot.fstab_suffix=default androidboot.boot_devices=soc/1d84000.ufshc androidboot.serialno=c1a6c19b androidboot.secureboot=1 androidboot.hwversion=C.9.0 androidboot.cpuid=0x3c53066a androidboot.hwc=CN androidboot.hwlevel=MP androidboot.baseband=apq msm_drm.dsi_display0=qcom,mdss_dsi_k81_42_02_0a_dual_cphy_video: androidboot.oled_wp=858286 androidboot.force_normal_boot=1 androidboot.ramdump=disable block2mtd.block2mtd=/dev/block/sda15,2097152 mtdoops.mtddev=0 mtdoops.record_size=2097152 mtdoops.dump_oops=0 printk.always_kmsg_dump=1 androidboot.dp=0x0 androidboot.cert=M2105K81AC
```

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kernel boot parameter configurations for OnePlus Kebab and Xiaomi Elish device models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->