### PR TITLE
Support BTRFS on NanoPi R3S-LTS

### DIFF
--- a/config/boards/nanopi-r3s-lts.conf
+++ b/config/boards/nanopi-r3s-lts.conf
@@ -9,17 +9,9 @@ KERNEL_TEST_TARGET="current,edge"
 BOOT_FDT_FILE="rockchip/rk3566-nanopi-r3s-lts.dtb"
 IMAGE_PARTITION_TABLE="gpt"
 BOOT_SCENARIO="spl-blobs"
+enable_extension "uboot-btrfs"
 
 function post_family_config__use_mainline_uboot() {
-
-	# Mainline U-Boot can read ext4 directly, so no separate boot partition needed for ext4 root
-	# However, for filesystems U-Boot cannot read (btrfs, f2fs, etc.), we need a boot partition
-	if [[ "$ROOTFS_TYPE" =~ btrfs|f2fs|nilfs2|xfs ]]; then
-		BOOTFS_TYPE=${BOOTFS_TYPE:-ext4}
-		BOOTSIZE=${BOOTSIZE:-512}
-	else
-		unset BOOTFS_TYPE  # ext4 root can be read directly by U-Boot
-	fi
 	BOOTCONFIG="nanopi-r3s-lts-rk3566_defconfig"
 	BOOTSOURCE="https://github.com/u-boot/u-boot"
 	BOOTBRANCH="tag:v2026.01"

--- a/config/boards/nanopi-r3s.csc
+++ b/config/boards/nanopi-r3s.csc
@@ -10,7 +10,7 @@ KERNEL_TEST_TARGET="current,edge"
 BOOT_FDT_FILE="rockchip/rk3566-nanopi-r3s.dtb"
 IMAGE_PARTITION_TABLE="gpt"
 BOOT_SCENARIO="spl-blobs"
-
+enable_extension "uboot-btrfs"
 
 function post_family_config__use_mainline_uboot() {
 	if [[ "$BRANCH" == "vendor" ]]; then
@@ -18,15 +18,6 @@ function post_family_config__use_mainline_uboot() {
 	fi
 
 	unset BOOT_FDT_FILE # boot.scr will use whatever u-boot detects and sets 'fdtfile' to
-	
-	# Mainline U-Boot can read ext4 directly, so no separate boot partition needed for ext4 root
-	# However, for filesystems U-Boot cannot read (btrfs, f2fs, etc.), we need a boot partition
-	if [[ "$ROOTFS_TYPE" =~ btrfs|f2fs|nilfs2|xfs ]]; then
-		BOOTFS_TYPE=${BOOTFS_TYPE:-ext4}
-		BOOTSIZE=${BOOTSIZE:-512}
-	else
-		unset BOOTFS_TYPE  # ext4 root can be read directly by U-Boot
-	fi
 	BOOTCONFIG="nanopi-r3s-rk3566_defconfig"
 	BOOTSOURCE="https://github.com/u-boot/u-boot"
 	BOOTBRANCH="tag:v2025.04"


### PR DESCRIPTION
# Description

Support `ROOTFS_TYPE=btrfs` option on NanoPi R3S-LTS. On the current `main` branch, I found that the device would fail to boot from the SD card. AI determined that mainline u-boot cannot boot from a btrfs filesystem, so the boot partition should stay ext4 while the root partition could be btrfs, however, the current r3s-lts board config specifically prevents this from happening.

I followed the pattern already used by the [Helios64 board](https://github.com/armbian/build/blob/6f022174747f14f1b022f0eb707ff35cf1f5133c/config/boards/helios64.conf#L22-L25) to get the R3S-LTS to support btrfs.

Disclaimer: Claude Sonnet 4.5 was used to identify and implement the fix. 

# How Has This Been Tested?

I personally compiled and tested the resulting image on a NanoPi R3S-LTS using the following command, and there were no obvious issues. I confirmed that the boot filesystem was ext4 while the root filesystem was btrfs.

```
./compile.sh build BOARD=nanopi-r3s-lts ROOTFS_TYPE=btrfs BRANCH=current RELEASE=trixie
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot partition handling on NanoPi R3S boards to preserve and respect the configured root filesystem type.
  * Restored support for Btrfs-based root filesystems during boot setup for more reliable startup across configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->