### PR TITLE
Rock 5B Plus: Add GPIO names to edge dts

### DIFF
--- a/patch/kernel/archive/rockchip64-6.19/rk3588-rock-5b-plus-add-gpio-line-names.patch
+++ b/patch/kernel/archive/rockchip64-6.19/rk3588-rock-5b-plus-add-gpio-line-names.patch
@@ -1,0 +1,138 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JohnTheCoolingFan <ivan8215145640@gmail.com>
+Date: Tue, 3 Feb 2026 15:20:07 +0000
+Subject: RK3588 Rock 5B Plus: add gpio-line-names
+
+Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts | 115 ++++++++++
+ 1 file changed, 115 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
+index 07a840d9b..a89621bef 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
+@@ -126,5 +126,120 @@ &vcc5v0_host {
+ 	enable-active-high;
+ 	gpio = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&vcc5v0_host_en>;
+ };
++
++&gpio0 {
++	gpio-line-names =
++		/* GPIO0_A0-A3 */
++		"", "", "", "",
++		/* GPIO0_A4-A7 */
++		"", "", "", "",
++
++		/* GPIO0_B0-B3 */
++		"", "", "", "",
++		/* GPIO0_B4-B7 */
++		"", "PIN_8", "PIN_10", "",
++
++		/* GPIO0_C0-C3 */
++		"", "", "", "",
++		/* GPIO0_C4-C7 */
++		"", "", "", "",
++
++		/* GPIO0_D0-D3 */
++		"", "", "", "",
++		/* GPIO0_D4-D7 */
++		"", "", "", "";
++};
++
++&gpio1 {
++	gpio-line-names =
++		/* GPIO1_A0-A3 */
++		"", "", "PIN_31", "PIN_29",
++		/* GPIO1_A4-A7 */
++		"", "", "", "",
++
++		/* GPIO1_B0-B3 */
++		"", "PIN_21", "PIN_19", "PIN_23",
++		/* GPIO1_B4-B7 */
++		"PIN_24", "PIN_26", "", "",
++
++		/* GPIO1_C0-C3 */
++		"", "", "", "",
++		/* GPIO1_C4-C7 */
++		"", "", "", "",
++
++		/* GPIO1_D0-D3 */
++		"", "", "", "",
++		/* GPIO1_D4-D7 */
++		"", "", "", "";
++};
++
++&gpio2 {
++	gpio-line-names =
++		/* GPIO2_A0-A3 */
++		"", "", "", "",
++		/* GPIO2_A4-A7 */
++		"", "", "", "",
++
++		/* GPIO2_B0-B3 */
++		"", "", "", "",
++		/* GPIO2_B4-B7 */
++		"", "", "", "",
++
++		/* GPIO2_C0-C3 */
++		"", "", "", "",
++		/* GPIO2_C4-C7 */
++		"", "", "", "",
++
++		/* GPIO2_D0-D3 */
++		"", "", "", "",
++		/* GPIO2_D4-D7 */
++		"", "", "", "";
++};
++
++&gpio3 {
++	gpio-line-names =
++		/* GPIO3_A0-A3 */
++		"", "", "", "",
++		/* GPIO3_A4-A7 */
++		"PIN_16", "", "", "PIN_33",
++
++		/* GPIO3_B0-B3 */
++		"", "PIN_36", "PIN_38", "PIN_40",
++		/* GPIO3_B4-B7 */
++		"", "PIN_12", "PIN_35", "PIN_13",
++
++		/* GPIO3_C0-C3 */
++		"PIN_15", "PIN_11", "PIN_32", "PIN_7",
++		/* GPIO3_C4-C7 */
++		"", "", "", "",
++
++		/* GPIO3_D0-D3 */
++		"", "", "", "",
++		/* GPIO3_D4-D7 */
++		"", "", "", "";
++};
++
++&gpio4 {
++	gpio-line-names =
++		/* GPIO4_A0-A3 */
++		"", "", "", "",
++		/* GPIO4_A4-A7 */
++		"", "", "", "",
++
++		/* GPIO4_B0-B3 */
++		"", "", "PIN_5", "PIN_3",
++		/* GPIO4_B4-B7 */
++		"", "", "", "",
++
++		/* GPIO4_C0-C3 */
++		"", "", "", "",
++		/* GPIO4_C4-C7 */
++		"PIN_18", "PIN_28", "PIN_27", "",
++
++		/* GPIO4_D0-D3 */
++		"", "", "", "",
++		/* GPIO4_D4-D7 */
++		"", "", "", "";
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

Adds names to the gpios that correspond to the 40pin header, making it easier to identify them. They were already added in the vendor branch, this adds them to `edge` (mainline kernel) branch. The `vendor` branch is where the code was copied from.

# How Has This Been Tested?

- [x] Build and boot on rock 5b+
- [x] Check gpio names with `gpioinfo`

# Checklist:

- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GPIO line name mappings for the RK3588 Rock 5B Plus device. Enhanced GPIO pin identification across five GPIO banks with descriptive labels for improved hardware reference and configuration clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->