### PR TITLE
radxa-e54c: board config: remove wayland-sessions-mask extension

### DIFF
--- a/config/boards/radxa-e54c.conf
+++ b/config/boards/radxa-e54c.conf
@@ -9,7 +9,6 @@ BOOT_FDT_FILE="rockchip/rk3588s-radxa-e54c.dtb"
 BOOT_SCENARIO="spl-blobs"
 BOOT_SOC="rk3588"
 IMAGE_PARTITION_TABLE="gpt"
-enable_extension "wayland-sessions-mask"
 
 # Enable system and network LEDs
 function post_family_tweaks_bsp__radxa_e54c_enable_leds() {


### PR DESCRIPTION


# Description

Wayland is now working on  radxa-e54c, so the Wayland masking extension is no longer necessary.

# How Has This Been Tested?
- [x] Board radxa-e54c Vendor Noble Gnome - Wayland functions correctly.

# Checklist:

- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Disabled Wayland session extension for the Radxa E54C board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->