### PR TITLE
OrangePi 3 LTS: Fixup u-boot LED nodes

### DIFF
--- a/patch/u-boot/v2026.01/board_orangepi3-lts/001-Add-board-OrangePi-3-LTS.patch
+++ b/patch/u-boot/v2026.01/board_orangepi3-lts/001-Add-board-OrangePi-3-LTS.patch
@@ -1,13 +1,13 @@
-From 5dde625501a285558da56db28a21cb30724f0fad Mon Sep 17 00:00:00 2001
+From db0c4d317a94b03138b8a99ed6124cf266b2880d Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@gmail.com>
-Date: Wed, 4 Feb 2026 05:06:26 -0500
+Date: Wed, 4 Feb 2026 17:37:49 -0500
 Subject: [PATCH] Add board OrangePi 3 LTS
 
 Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
 ---
  arch/arm/dts/Makefile                     |   1 +
- arch/arm/dts/sun50i-h6-orangepi-3-lts.dts | 394 ++++++++++++++++++++++
- 2 files changed, 395 insertions(+)
+ arch/arm/dts/sun50i-h6-orangepi-3-lts.dts | 392 ++++++++++++++++++++++
+ 2 files changed, 393 insertions(+)
  create mode 100644 arch/arm/dts/sun50i-h6-orangepi-3-lts.dts
 
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
@@ -24,10 +24,10 @@ index fcad6fb2fc7..e54213f9599 100644
  	sun50i-h6-pine-h64.dtb \
 diff --git a/arch/arm/dts/sun50i-h6-orangepi-3-lts.dts b/arch/arm/dts/sun50i-h6-orangepi-3-lts.dts
 new file mode 100644
-index 00000000000..143a1442f9a
+index 00000000000..5291792b3f2
 --- /dev/null
 +++ b/arch/arm/dts/sun50i-h6-orangepi-3-lts.dts
-@@ -0,0 +1,394 @@
+@@ -0,0 +1,392 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +// Copyright (C) 2019 Ondřej Jirman <megous@megous.com>
 +// Copyright (C) 2023 Jernej Skrabec <jernej.skrabec@gmail.com>
@@ -51,7 +51,6 @@ index 00000000000..143a1442f9a
 +
 +	chosen {
 +		stdout-path = "serial0:115200n8";
-+		kaslr-seed = <0xfeedbeef 0xc0def00d>;
 +	};
 +
 +	connector {
@@ -79,13 +78,12 @@ index 00000000000..143a1442f9a
 +		led-0 {
 +			label = "orangepi:red:status";
 +			gpios = <&r_pio 0 4 GPIO_ACTIVE_HIGH>; /* PL4 */
-+			linux,default-trigger = "heartbeat";
 +		};
 +
 +		led-1 {
 +			label = "orangepi:green:power";
 +			gpios = <&r_pio 0 7 GPIO_ACTIVE_HIGH>; /* PL7 */
-+			linux,default-trigger = "default-on";
++			default-state = "on";
 +		};
 +	};
 +
@@ -422,31 +420,6 @@ index 00000000000..143a1442f9a
 +&usb3phy {
 +	status = "okay";
 +};
--- 
-2.51.0
-
-From 9e3b0afc0bc45add51c18d3f17f613e33c4cc518 Mon Sep 17 00:00:00 2001
-From: Patrick Yavitz <pyavitz@gmail.com>
-Date: Wed, 4 Feb 2026 05:59:27 -0500
-Subject: [PATCH] OrangePi 3 LTS: Remove property kaslr-seed from chosen node
-
-Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
----
- arch/arm/dts/sun50i-h6-orangepi-3-lts.dts | 1 -
- 1 file changed, 1 deletion(-)
-
-diff --git a/arch/arm/dts/sun50i-h6-orangepi-3-lts.dts b/arch/arm/dts/sun50i-h6-orangepi-3-lts.dts
-index 143a1442f9a..3340809b277 100644
---- a/arch/arm/dts/sun50i-h6-orangepi-3-lts.dts
-+++ b/arch/arm/dts/sun50i-h6-orangepi-3-lts.dts
-@@ -21,7 +21,6 @@
- 
- 	chosen {
- 		stdout-path = "serial0:115200n8";
--		kaslr-seed = <0xfeedbeef 0xc0def00d>;
- 	};
- 
- 	connector {
 -- 
 2.51.0
 


### PR DESCRIPTION
Now when powered on the green LED should light up. When handed over to the kernel the red status LED should start blinking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added U-Boot support for OrangePi 3 LTS board with integrated hardware configuration including power management, storage interfaces, USB connectivity, and ethernet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->