### PR TITLE
Fix errors in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ trim_trailing_whitespace = false
 [*.md]
 indent_style = space
 indent_size = 4
-insert_final_newline = false
+trim_trailing_whitespace = false
 
 [*.json]
 indent_style = space
@@ -36,7 +36,6 @@ function_next_line = false
 [*.{yaml,yml}]
 indent_style = space
 indent_size = 2
-insert_final_newline = false
 
 [*.py]
 indent_size = 4


### PR DESCRIPTION
Fix two errors in `.editorconfig` since #4266:

1. **`[*.md]` section**: Replace incorrect `insert_final_newline = false` with
`trim_trailing_whitespace = false`.
   Markdown uses trailing whitespace (two spaces at end of line) to produce hard line
breaks per the [CommonMark spec](https://spec.commonmark.org/0.31.2/#hard-line-breaks).
 Trimming trailing whitespace would break this functionality. Meanwhile, disabling
`insert_final_newline` for markdown files was unintentional — final newlines should be
preserved per POSIX and the global `[*]` section already sets it to `true`.

2. **`[*.{yaml,yml}]` section**: Remove redundant `insert_final_newline = false`.
   YAML files should end with a final newline, as required by [POSIX](https://pubs.open
group.org/onlinepubs/9699919799.2008edition/basedefs/V1_chap03.html#tag_03_403) and
expected by most YAML linters. The global `[*]` section already sets
`insert_final_newline = true`, so the per-section override to `false` was incorrect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration settings for code formatting standards across project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->