### PR TITLE
create rewrite-patches workflow

### DIFF
--- a/.github/workflows/maintenance-rewrite-kernel-patches.yml
+++ b/.github/workflows/maintenance-rewrite-kernel-patches.yml
@@ -61,6 +61,8 @@ jobs:
           ./compile.sh "BOARD=$BOARD" "BRANCH=$BRANCH" "$WHATTODO" KERNEL_GIT=shallow
 
       - name: Check for changes
+        env:
+          WHATTODO: ${{ inputs.whattodo }}
         id: check_changes
         run: |
           set -euo pipefail
@@ -73,6 +75,8 @@ jobs:
           fi
 
       - name: Build PR body
+        env:
+          WHATTODO: ${{ inputs.whattodo }}
         id: build_pr_body
         if: steps.check_changes.outputs.has_changes == 'true'
         run: |


### PR DESCRIPTION
Rewriting kernel or uboot patches can take a lot of time. The reason is that this task heavily depends on single core performance as it cannot be executed in parallel across multiple cores.
For example our strongest CI server with 88C/176T manages to rewrite around one patch per second. Do the math for the Allwinner patchset.

This workflow is intended to run only on systems with fast single core performance, like the Intel 285H or better. It may not sound much but it manages to do around 2 patches per second which is a relieve already.
The target box sits on my desk atm. Let's just hope this doesn't become a (noise) issue :D

The workflow code is probably pretty messy, heavily influenced by AI, but it works:
<img width="418" height="481" alt="grafik" src="https://github.com/user-attachments/assets/88eb0ff2-9885-4593-986f-e7309fe14d8b" />

- executed from GH webinterface
- clone flat *build* repo or force pull if existing already
- grab shallow kernel tree
- do the rewrite of either uboot or kernel patches, depending on user choice
- create a PR from diff
- - Example: https://github.com/EvilOlaf/build/pull/28

**Possible problems/concerns/weird thinking:**
- if a PR/branch with the requested combination already exists, it will probably fail. Means one has to do proper cleanup afterwards (either merge or close the pr and then **delete the branch**).
- I'm actually not a fan to have development branches in the main repo if such things could be done in one's own forks. But since this can be classified as maintenance task I think it'll be fine. Again, depends on proper cleanup. Whoever uses it is responsible.
- Also means when bumping kernel versions a rewrite cannot be included in the PR directly but again, doing the rewrite is maintenance and optional as a `patch` can work with fuzz.

**setup:**
- A new runner group `rewrite` needs to be created and one or two runners added on the machine.
- Permissions need further adjustments to restrict usage to board maintainers

@rpardini This is what I mean when I said I may have a solution for that :)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated maintenance workflow that clones or updates a target repository, runs rewrite logic, detects changes, generates per-file and summary statistics, and automatically creates or updates a pull request only when modifications exist. Ensures safe temporary file handling, robust clone/update behavior, conditional PR creation, cleanup, and error-safe operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->