### PR TITLE
khadas-edge2: remove legacy uboot

### DIFF
--- a/config/boards/khadas-edge2.conf
+++ b/config/boards/khadas-edge2.conf
@@ -28,27 +28,8 @@ function post_family_tweaks__kedge2_naming_audios() {
 	return 0
 }
 
-# for the kedge2, we're counting on the blobs+u-boot in SPI working, as it comes from factory. It does not support bootscripts.
-function post_family_config__uboot_kedge2() {
-	if [[ $BRANCH == "edge" || $BRANCH == "current" ]]; then
-		return
-	fi
-
-	display_alert "$BOARD" "Configuring ($BOARD) u-boot" "info"
-
-	declare -g BOOTSOURCE='https://github.com/khadas/u-boot.git'
-	declare -g BOOTBRANCH="commit:df276095a29a02f8e7ce4f451770c06486106594"
-	declare -g BOOTPATCHDIR="legacy/u-boot-khadas-edge2-rk3588"
-	declare -g BOOTCONFIG="khadas-edge2-rk3588s_defconfig"
-	declare -g SRC_EXTLINUX="yes" # For now, use extlinux. Thanks Monka
-}
-
-# Mainline U-Boot for current kernel
+# Mainline U-Boot
 function post_family_config__kedge2_use_mainline_uboot() {
-	if [[ $BRANCH == "vendor" ]]; then
-		return
-	fi
-
 	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
 
 	declare -g BOOTCONFIG="khadas-edge2-rk3588s_defconfig"


### PR DESCRIPTION
# Description

Remove Khadas Edge 2 vendor uboot support as it is broken on recent builds and mainline uboot also has similar functionalities including kbi command with patch.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?
- [x] Tested SD boot
- [x] Tested eMMC boot

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Khadas Edge2 bootloader configuration to consistently use mainline U-Boot settings, removing conditional boot mechanisms and streamlining the boot setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->