### PR TITLE
Restore qemu performance fix for Ubuntu Noble

### DIFF
--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -39,6 +39,6 @@ fi
 
 # IMPORTANT - Prevents ~5x slowdown caused by CVE-2023-4039 patchset, when
 # emulating ARM64 software via qemu. Has no effect when run on native ARM64.
-export QEMU_CPU=cortex-a53
+declare -gx QEMU_CPU="cortex-a53"
 
 true # make sure to exit with 0 status; this protects against shortcircuits etc above.


### PR DESCRIPTION
# Description

This restores a performance boost introduced via https://github.com/armbian/build/pull/6644, which appears to have been accidentally reverted in https://github.com/armbian/build/commit/021af5dd9f79959aa1f9990a522d60234ae31c2a. Additionally, a note was added to the config to indicate why that setting is important.

# Documentation summary for feature / change

A write up for this issue was posted to the Armbian forums at https://forum.armbian.com/topic/57887-arm64-performance-regression-in-qemu/.

# How Has This Been Tested?

The fix was tested by running:

`time ./compile.sh build BOARD=nanopim4v2 BRANCH=current BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=noble`

Without the fix, the image build took 26 minutes, 7 seconds.

With the fix, the image build took 5 minutes, 8 seconds. An 80% time reduction.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved ARM64 emulation performance during testing and builds by adding an environment export that reduces QEMU emulation overhead (~5× faster). This change does not affect native ARM64 systems and preserves existing behavior otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->