### PR TITLE
bump to next rc

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -7,8 +7,8 @@
 # Shared versioning logic for Armbian mainline kernels.
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0           # if already set, don't touch it; that way other hooks can run in any order
-	if [[ "${KERNEL_MAJOR_MINOR}" == "6.20" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v6.20-rc1"
+	if [[ "${KERNEL_MAJOR_MINOR}" == "7.0" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
+		declare -g KERNELBRANCH="tag:v7.0-rc1"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }


### PR DESCRIPTION
as per title

no tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Selected kernel release candidate updated to v7.0-rc1 (replacing v6.19-rc8).
  * User-facing notification behavior for the selection remains unchanged.
  * No changes to public interfaces or exported behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->