### PR TITLE
Radxa-e52c: reopen disabled nodes for mainline u-boot

### DIFF
--- a/patch/u-boot/v2026.01/board_radxa-e52c/9000-reopen-disabled-nodes-for-rk3582.patch
+++ b/patch/u-boot/v2026.01/board_radxa-e52c/9000-reopen-disabled-nodes-for-rk3582.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: weosx <MB6wFudgUmttIcfwjCwGBC+weosx@noreply.cnb.cool>
+Date: Mon, 9 Feb 2026 17:45:09 +0800
+Subject: reopen disabled nodes for rk3582
+
+---
+ arch/arm/mach-rockchip/rk3588/rk3588.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm/mach-rockchip/rk3588/rk3588.c b/arch/arm/mach-rockchip/rk3588/rk3588.c
+index 111111111111..222222222222 100644
+--- a/arch/arm/mach-rockchip/rk3588/rk3588.c
++++ b/arch/arm/mach-rockchip/rk3588/rk3588.c
+@@ -349,6 +349,7 @@ int ft_system_setup(void *blob, struct bd_info *bd)
+ 	log_debug("ip-state: %02x %02x %02x (otp)\n",
+ 		  ip_state[0], ip_state[1], ip_state[2]);
+ 
++#if 0
+ 	/* policy: fail entire big core cluster when one or more core is bad */
+ 	if (ip_state[0] & FAIL_CPU_CLUSTER1)
+ 		ip_state[0] |= FAIL_CPU_CLUSTER1;
+@@ -369,6 +370,7 @@ int ft_system_setup(void *blob, struct bd_info *bd)
+ 	/* policy: always fail one rkvenc core on rk3582 */
+ 	if (!(ip_state[2] & (FAIL_RKVENC0 | FAIL_RKVENC1)))
+ 		ip_state[2] |= FAIL_RKVENC1;
++#endif
+ 
+ 	log_debug("ip-state: %02x %02x %02x (policy)\n",
+ 		  ip_state[0], ip_state[1], ip_state[2]);
+-- 
+Armbian
+


### PR DESCRIPTION
# **⚠️ Warning**
**Please test if it works properly.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bootloader behavior on RK3582/RK3588 boards adjusted: several automatic core-failure policies have been disabled while diagnostic logging of core states remains active. This changes how the bootloader reports and responds to individual core faults during startup, preserving logs but preventing previously enforced cluster-level or per-core shutdown actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->