### PR TITLE
Orange Pi 3B: Generate alternate SPI image for booting from SATA

### DIFF
--- a/patch/u-boot/v2026.01/board_orangepi3b/0003-rk3566-orangepi-3b-enable-boot-from-sata.patch
+++ b/patch/u-boot/v2026.01/board_orangepi3b/0003-rk3566-orangepi-3b-enable-boot-from-sata.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ian Leung <ianleung7@gmail.com>
+Date: Tue, 10 Feb 2026 13:19:24 +0800
+Subject: rk3566-orangepi-3b: Enable boot from SATA
+
+These changes enable U-Boot to communicate with an attached SATA m.2
+SSD, thus allowing booting directly from SPI flash to SSD.
+
+Signed-off-by: Ian Leung <ianleung7@gmail.com>
+---
+ arch/arm/dts/rk3566-orangepi-3b-u-boot.dtsi             |  8 ++++++++
+ dts/upstream/src/arm64/rockchip/rk3566-orangepi-3b.dtsi | 10 ++++++++++
+ 2 files changed, 18 insertions(+)
+
+diff --git a/arch/arm/dts/rk3566-orangepi-3b-u-boot.dtsi b/arch/arm/dts/rk3566-orangepi-3b-u-boot.dtsi
+index 3c40de8e838..e5cce5e8bd2 100644
+--- a/arch/arm/dts/rk3566-orangepi-3b-u-boot.dtsi
++++ b/arch/arm/dts/rk3566-orangepi-3b-u-boot.dtsi
+@@ -1,9 +1,17 @@
+ // SPDX-License-Identifier: GPL-2.0+
+ 
+ #include "rk356x-u-boot.dtsi"
+ 
++#ifdef CONFIG_DWC_AHCI
++&binman {
++	simple-bin-spi {
++		filename = "u-boot-rockchip-spi-sata.bin";
++	};
++};
++#endif
++
+ &gpio4 {
+ 	bootph-pre-ram;
+ };
+ 
+ &sfc {
+diff --git a/dts/upstream/src/arm64/rockchip/rk3566-orangepi-3b.dtsi b/dts/upstream/src/arm64/rockchip/rk3566-orangepi-3b.dtsi
+index d539570f531..2805fa243b2 100644
+--- a/dts/upstream/src/arm64/rockchip/rk3566-orangepi-3b.dtsi
++++ b/dts/upstream/src/arm64/rockchip/rk3566-orangepi-3b.dtsi
+@@ -51,10 +51,13 @@
+ 		enable-active-high;
+ 		gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&pcie20_pwren>;
+ 		regulator-name = "vcc3v3_pcie30";
++#ifdef CONFIG_DWC_AHCI
++		regulator-boot-on;
++#endif
+ 		regulator-min-microvolt = <3300000>;
+ 		regulator-max-microvolt = <3300000>;
+ 		vin-supply = <&vcc3v3_sys>;
+ 	};
+ 
+@@ -447,17 +450,24 @@
+ 		     &i2s1m0_sdo0>;
+ 	rockchip,trcm-sync-tx-only;
+ 	status = "okay";
+ };
+ 
++#ifdef CONFIG_DWC_AHCI
++&sata2 {
++	target-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++};
++#else
+ &pcie2x1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie20_pins>;
+ 	reset-gpios = <&gpio0 RK_PB6 GPIO_ACTIVE_HIGH>;
+ 	vpcie3v3-supply = <&vcc3v3_pcie30>;
+ 	status = "okay";
+ };
++#endif
+ 
+ &pinctrl {
+ 	bluetooth {
+ 		bt_reg_on_h: bt-reg-on-h {
+ 			rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

This PR enables generation of `u-boot-rockchip-spi-sata.bin`. Flashing this to SPI flash enables U-Boot to communicate with an attached SATA m.2 SSD, thereby allowing booting directly from SPI flash to SATA SSD.

The method for creating the secondary spi image is copied from [orangepi5.conf](https://github.com/armbian/build/blob/main/config/boards/orangepi5.conf#L32-L62).

The only change in the SATA defconfig is the addition of `CONFIG_DWC_AHCI=y`.

### Quickstart for SATA SSD users
1. Flash image to SD card and boot.
2. Enable `rockchip-rk3566-sata2` overlay and reboot.
3. From terminal, run `nand-sata-install`.
4. Select option `Boot from MTD Flash - system on SATA, USB or NVMe`.
5. After system is copied over to SSD, there will be a prompt to choose SPI image. Select `u-boot-rockchip-spi-sata.bin`.
6. Poweroff, remove SD card, enjoy!

# How Has This Been Tested?

- Followed steps in quickstart above, works.
- From U-Boot command line, `bootflow scan` succcessfully detects boot.scr on SCSI bootdev.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SATA boot support for Orange Pi 3B, enabling the board to boot from SATA storage devices. The bootloader now includes AHCI support for accessing SATA drives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->