### PR TITLE
RK3506: Pin U-Boot to known-working commit

### DIFF
--- a/config/boards/armsom-forge1.csc
+++ b/config/boards/armsom-forge1.csc
@@ -2,7 +2,7 @@
 BOARD_NAME="ArmSoM Forge1"
 BOARD_VENDOR="armsom"
 BOARDFAMILY="rockchip"
-BOOTCONFIG="forge1-rk3506j_defconfig"
+BOOTCONFIG="forge1-rk3506b_defconfig"
 BOARD_MAINTAINER="amazingfate"
 KERNEL_TARGET="vendor"
 BOOT_FDT_FILE="rk3506b-armsom-forge1.dtb"

--- a/config/sources/families/rockchip.conf
+++ b/config/sources/families/rockchip.conf
@@ -55,7 +55,8 @@ elif [[ "$BOOT_SOC" == "rk3506" ]]; then
 	TEE_BLOB="${TEE_BLOB:-"rk35/rk3506_tee_v2.10.bin"}"
 	UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} TEE=${RKBIN_DIR}/${TEE_BLOB};;u-boot-rockchip.bin"
 	BOOTSOURCE="https://source.denx.de/u-boot/contributors/kwiboo/u-boot.git"
-	BOOTBRANCH="branch:rk3506"
+	# kwiboo's 'rk3506' branch is WIP / rebased often. Pin to a tested commit until upstream work is complete.
+	BOOTBRANCH="commit:0b8e25bd9e16e8043b600e8f49b926b95572dc47"
 	BOOTPATCHDIR="u-boot-rk3506"
 	BOOTDIR="u-boot-rk3506"
 fi

--- a/patch/u-boot/u-boot-rk3506/forge1-btrfs.patch
+++ b/patch/u-boot/u-boot-rk3506/forge1-btrfs.patch
@@ -1,13 +1,12 @@
-diff --git a/configs/forge1-rk3506j_defconfig b/configs/forge1-rk3506j_defconfig
+diff --git a/configs/forge1-rk3506b_defconfig b/configs/forge1-rk3506b_defconfig
 index d006413eec1..a191a649d66 100644
---- a/configs/forge1-rk3506j_defconfig
-+++ b/configs/forge1-rk3506j_defconfig
-@@ -27,6 +27,8 @@ CONFIG_CMD_USB_MASS_STORAGE=y
+--- a/configs/forge1-rk3506b_defconfig
++++ b/configs/forge1-rk3506b_defconfig
+@@ -27,6 +27,7 @@ CONFIG_CMD_USB_MASS_STORAGE=y
  # CONFIG_CMD_SETEXPR is not set
  CONFIG_CMD_RNG=y
  CONFIG_CMD_REGULATOR=y
 +CONFIG_CMD_BTRFS=y
-+CONFIG_OPTEE_IMAGE=y
  # CONFIG_SPL_DOS_PARTITION is not set
  CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
  CONFIG_BUTTON=y


### PR DESCRIPTION
# Description

RK3506 targets (all of them) fail to boot with the current uboot branch.

Kwiboo's `rk3506` branch is WIP / rebased often. Pin to commit hash while upstreaming work is underway.

Also reverts changes in #9326 that attempted to keep up with this branch.

# How Has This Been Tested?

- [x] Compiled for `armsom-forge1` and `luckfox-lyra-zero-w`
- [x] Run-tested on `armsom-forge1` -- confirmed this allows the board to boot correctly again.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced bootloader configuration for the Forge1 board to improve overall system stability and boot reliability.
  * Improved boot process stability by switching from an experimental development branch to a tested, pinned reference.
  * Enabled BTRFS filesystem support, expanding available storage management options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->