### PR TITLE
framework run_host_x86_binary_logged - unset QEMU_CPU

### DIFF
--- a/lib/functions/logging/runners.sh
+++ b/lib/functions/logging/runners.sh
@@ -192,7 +192,8 @@ function run_host_x86_binary_logged() {
 	else
 		display_alert "Not using qemu for running x86 binary on $(uname -m)" "$1 (${target_bin_arch})" "debug"
 	fi
-	run_host_command_logged "${qemu_invocation[@]}" # Exit with this result code
+	# `env -u QEMU_CPU` will unset any possible specified CPUs to emulate, as in config/sources/arm64.conf
+	run_host_command_logged env -u QEMU_CPU "${qemu_invocation[@]}" # Exit with this result code
 }
 
 # Run simple and exit with it's code. Exactly the same as run_host_command_logged(). Used to have pv pipe, but that causes chaos.


### PR DESCRIPTION
# Description

followup to #9371 and specifically [this issue](https://github.com/armbian/build/pull/9371#issuecomment-3885292562) 
the idea of 9371 was to emulate a lighter-weight CPU, so it would be faster.
But this then broke when we need to explicitly run an x86/amd64 program, and `qemu-x86_64` can't emulate an ARM processor [natch].

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `time nice -n 19 ./compile.sh artifact BETA=yes BOARD=odroidhc4 BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=yes  RELEASE=trixie WHAT=uboot`
  - https://paste.armbian.com/ovoyahorug
- [x] `time nice -n 19 ./compile.sh kernel BOARD=odroidhc4 BRANCH=current BUILD_MINIMAL=yes RELEASE=bookworm KERNEL_CONFIGURE=no KERNEL_GIT=full MANAGE_ACNG='http://squid.tabris.net:3142/' COMPRESS_OUTPUTIMAGE=xz DEB_COMPRESS=xz EXPERT=yes ARTIFACT_IGNORE_CACHE=yes`
  - https://paste.armbian.com/juyusozabu
- [x] `time nice -n 19 ./compile.sh build BOARD=odroidhc4 BRANCH=current BUILD_MINIMAL=yes RELEASE=trixie KERNEL_CONFIGURE=no KERNEL_GIT=full MANAGE_ACNG='http://squid.tabris.net:3142/' COMPRESS_OUTPUTIMAGE=xz DEB_COMPRESS=xz EXPERT=yes `
  - https://paste.armbian.com/oxowemalub

Executed in the above order

re-ran the test on an RK3588 Rock5-ITX
- [x] `time nice -n 19 ./compile.sh artifact BETA=yes BOARD=odroidhc4 BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=yes  RELEASE=trixie WHAT=uboot`

  - https://paste.armbian.com/isozoxowew
# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured CPU emulation settings are cleared before running x86 binaries so external or cached environment values no longer interfere with emulation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->