### PR TITLE
Revert "build(deps): bump setuptools from 80.10.2 to 82.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # Dependabot will keep these versions up to date.
 
 pip == 26.0.1          # pip is the package installer for Python
-setuptools == 82.0.0   # for building Python packages
+setuptools == 80.10.2   # for building Python packages
 pyelftools == 0.32     # for building U-Boot
 unidiff == 0.7.5       # for parsing unified diff
 GitPython == 3.1.46    # for manipulating git repos


### PR DESCRIPTION
Reverts armbian/build#9384 besause https://github.com/armbian/build/pull/9384#issuecomment-3887610185


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies with a minor version adjustment to setuptools, ensuring compatibility with the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->