### PR TITLE
extensions: radxa-aic8800: allow 6.19; skip DKMS only on >= 6.20

### DIFF
--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -10,7 +10,7 @@ function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
 function post_install_kernel_debs__install_aic8800_dkms_package() {
 
-	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.19; then
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.20; then
 		display_alert "Kernel version is too recent" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi


### PR DESCRIPTION
# How Has This Been Tested?

It builds on Linux 6.19.0-edge-rockchip64, and I have tested the functionality on my photonicat2 device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted kernel version compatibility requirements to improve driver installation stability and reliability across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->