### PR TITLE
git_fetch_repo doesn't properly handle submodules when GIT_FIXED_WORKDIR is set

### DIFF
--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -296,7 +296,12 @@ function fetch_from_repo() {
 
 					display_alert "Updating submodule" "${name} - ${surl} - ${sref}" "git"
 					git_ensure_safe_directory "$workdir/$path"
-					fetch_from_repo "$surl" "$workdir/$path" "$sref"
+
+					if [[ "${GIT_FIXED_WORKDIR}" != "" ]]; then
+						GIT_FIXED_WORKDIR="${GIT_FIXED_WORKDIR}/${path}" fetch_from_repo "$surl" "$workdir/$path" "$sref"
+					else
+						fetch_from_repo "$surl" "$workdir/$path" "$sref"
+					fi
 
 				done < <(git config -f .gitmodules --get-regexp 'submodule\..*\.path')
 			fi


### PR DESCRIPTION
# Description

While fetching a shallow repository clone with submodules, the fetch_from_repo function does not properly handle GIT_FIXED_WORKDIR.

The issue appears to be that the environment variable GIT_FIXED_WORKDIR is inherited by the recursive call to fetch_from_repo, and proceeds to overwrite the parent directory after this block triggers:

```
	# if GIT_FIXED_WORKDIR has something, ignore above logic and use that directly.
	if [[ "${GIT_FIXED_WORKDIR}" != "" ]]; then
		display_alert "GIT_FIXED_WORKDIR is set to" "${GIT_FIXED_WORKDIR}" "git"
		git_work_dir="${SRC}/cache/sources/${GIT_FIXED_WORKDIR}"
	fi
```

This results in one of the two following outcomes:

1. The subsequent build fails as the checked out code in GIT_FIXED_WORKDIR is not what the call requested

2. Checkout of subsequent submodules fails as they do not exist in the first submodule

# Documentation summary for feature / change

This PR proposes an adjustment to how recursive calls are handled in fetch_from_repo when GIT_FIXED_WORKDIR is set. In short, it sets a modified version for the recursive call that takes into consideration both the original value and the relative path to the submodule within the parent repo.

# How Has This Been Tested?

This was found and tested against a WIP build for the ODroid C5, which can be found at https://github.com/tparys/build/tree/odroidc5, and run as the following:

```
./compile.sh build BOARD=odroidc5 BRANCH=legacy BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=noble SHOW_DEBUG=yes SHOW_COMMAND=yes SHOW_EXTENSIONS=yes
```

The build fails when checking out the Linux kernel from https://github.com/hardkernel/linux.git, and subsequently fails attempting to check out the second submodule. Build log is at https://paste.armbian.com/ohobukafic.

Specifically, it fails on the second case, attempting to pull something from .gitmodules, after the parent directory has been overwritten.

With this change, the odroidc5 build gets farther, although is not currently finishing due to other reasons. However is successfully checking out and building the kernel and dtb packages.

# Checklist:

I've not added comments in the subject patch, as I'm not sure the change is large enough to warrant them. Please let me know if more detail is needed.

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced submodule management for specific working directory configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->