### PR TITLE
phytiumpi - ATF_SKIP_LDFLAGS_WL="yes"

### DIFF
--- a/config/boards/phytiumpi.conf
+++ b/config/boards/phytiumpi.conf
@@ -10,6 +10,7 @@ FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 SRC_EXTLINUX="yes"
 SRC_CMDLINE="console=ttyAMA1,115200 earlycon=pl011,0x2800d000 rootfstype=ext4 rootwait cma=256m"
+declare -g ATF_SKIP_LDFLAGS_WL="yes"
 
 function post_family_tweaks__phytiumpi() {
 	display_alert "Applying bt blobs"


### PR DESCRIPTION
# Description

more `LDFLAGS` vs `CFLAGS` and `--no-warn-rwx-segments` pain :bread: 
https://paste.armbian.com/ekulogumex <-- shows bug
https://paste.armbian.com/gexirupepe <-- shows it apparently fixed.

partially related to #9162 

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `time nice -n 19 ./compile.sh artifact BETA=yes BOARD=phytiumpi BRANCH=current BUILD_DESKTOP=no BUILD_MINIMAL=yes  RELEASE=forky KERNEL_CONFIGURE=no KERNEL_GIT=full MANAGE_ACNG='http://squid.tabris.net:3142/' COMPRESS_OUTPUTIMAGE=xz DEB_COMPRESS=xz EXPERT=yes  WHAT=uboot REVISION=26.2.0-trunk.450 ARTIFACT_IGNORE_CACHE=yes`
  - https://paste.armbian.com/gexirupepe <-- shows it apparently fixed.


# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for PhytiumPi board to optimize the compilation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->