### PR TITLE
unset QEMU_CPU for aml_image_packer

### DIFF
--- a/extensions/jethub-burn.sh
+++ b/extensions/jethub-burn.sh
@@ -100,7 +100,7 @@ function make_burn__run() {
   cp "$uboot_bin"          "$tmpdir/u-boot.bin"
 
   display_alert "make_burn" "Packing burn image..." "info"
-  "$PACKER" -r "$tmpdir/image.cfg" "$tmpdir" "$OUT_IMG" || exit_with_error "Image pack FAILED"
+  env -u QEMU_CPU "$PACKER" -r "$tmpdir/image.cfg" "$tmpdir" "$OUT_IMG" || exit_with_error "Image pack FAILED"
 
   [[ -f "$OUT_IMG" ]] || exit_with_error "Burn image not produced"
   display_alert "make_burn" "Burn image created: $(basename "$OUT_IMG")" "ok"


### PR DESCRIPTION
# Description

Fix JetHub burn image build on aarch64 hosts. The extension uses Amlogic tool "aml_image_v2_packer_new" which is an i386 binary, on aarch64 it runs via binfmt_misc/qemu-i386, which inherits QEMU_CPU=cortex-a53 from arm64.conf and fails because cortex-a53 is not a valid x86 CPU model. The uses fix env -u QEMU_CPU to unset it only for the packer process.

Note: run_host_x86_binary_logged added in d8e24d7 already does env -u QEMU_CPU, but it only supports x86_64 binaries not i386.

# How Has This Been Tested?
Build works on aarch64 and x86 platforms


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with the image burn packaging process affecting build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->