### PR TITLE
KDE Neon: add konsole terminal emulator to base packages

### DIFF
--- a/config/desktop/noble/environments/kde-neon/config_base/packages
+++ b/config/desktop/noble/environments/kde-neon/config_base/packages
@@ -1,9 +1,13 @@
+bluedevil
+konsole
+kscreen
 neon-desktop
-sddm
+pipewire-audio
+pipewire-pulse
+plasma-discover
 plasma-nm
 plasma-pa
-plasma-discover
 plasma-vault
 scdaemon
-kscreen
-bluedevil
+sddm
+wireplumber


### PR DESCRIPTION
## Summary
- Add konsole terminal emulator to kde-neon base packages
- Also add bluedevil, kscreen, pipewire-audio, pipewire-pulse, and wireplumber
- Sort the entire package list alphabetically

## Test plan
- [x] Build completes successfully
- [x] All packages are properly installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system packages including audio components (pipewire, wireplumber), desktop environment utilities (konsole, plasma-discover), and hardware management tools (bluedevil, kscreen).
  * Removed display manager component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->