### PR TITLE
feat(drivers): add RTL8812EU/RTL8822EU wireless driver for EXTRA_WIFI

### DIFF
--- a/lib/functions/compilation/patch/drivers-harness.sh
+++ b/lib/functions/compilation/patch/drivers-harness.sh
@@ -108,6 +108,7 @@ function kernel_drivers_prepare_harness() {
 		driver_rtl8189FS
 		driver_rtl8192EU
 		driver_rtl8811_rtl8812_rtl8814_rtl8821
+		driver_rtl8812EU_rtl8822EU
 		driver_xradio_xr819
 		driver_rtl8811CU_rtl8821C
 		driver_rtl8188EU_rtl8188ETV

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -229,6 +229,53 @@ driver_rtl8811_rtl8812_rtl8814_rtl8821() {
 	fi
 }
 
+driver_rtl8812EU_rtl8822EU() {
+
+	# Wireless drivers for Realtek 8812EU and 8822EU chipsets
+	# disabled from 6.19 and on.
+	if linux-version compare "${version}" ge 3.14 && linux-version compare "${version}" lt 6.19; then
+
+		# Attach to specific commit (is branch:v5.15.0.1)
+		local rtl8822euver="commit:ccb31f4ee346d5c2dd45475d276171b2f8de8350" # Commit date: 2026-02-17 (please update when updating commit ref)
+
+		display_alert "Adding" "Wireless drivers for Realtek 8812EU and 8822EU chipsets ${rtl8822euver}" "info"
+
+		fetch_from_repo "$GITHUB_SOURCE/libc0607/rtl88x2eu-20230815" "rtl8822eu" "${rtl8822euver}" "yes" # https://github.com/libc0607/rtl88x2eu-20230815
+		cd "$kerneldir" || exit
+
+		mkdir -p "$kerneldir/drivers/net/wireless/rtl8822eu/"
+		cp -R "${SRC}/cache/sources/rtl8822eu/${rtl8822euver#*:}"/{core,hal,include,os_dep,platform,rtl8822e.mk,halmac.mk} \
+			"$kerneldir/drivers/net/wireless/rtl8822eu"
+
+		# Makefile
+		cp "${SRC}/cache/sources/rtl8822eu/${rtl8822euver#*:}/Makefile" \
+			"$kerneldir/drivers/net/wireless/rtl8822eu/Makefile"
+
+		# Kconfig
+		cp "${SRC}/cache/sources/rtl8822eu/${rtl8822euver#*:}/Kconfig" \
+			"$kerneldir/drivers/net/wireless/rtl8822eu/Kconfig"
+
+		# Enable AP mode
+		sed -i "s/^CONFIG_AP_MODE.*/CONFIG_AP_MODE = y/" \
+			"$kerneldir/drivers/net/wireless/rtl8822eu/Makefile"
+
+		# Enable P2P mode
+		sed -i "s/^CONFIG_P2P.*/CONFIG_P2P = y/" \
+			"$kerneldir/drivers/net/wireless/rtl8822eu/Makefile"
+
+		# Fix Kconfig file
+		sed -i 's/^\([[:space:]]*\)---help---/\1help/' \
+			"$kerneldir/drivers/net/wireless/rtl8822eu/Kconfig"
+
+
+		# Add to section Makefile
+		echo "obj-\$(CONFIG_RTL8822EU) += rtl8822eu/" >> "$kerneldir/drivers/net/wireless/Makefile"
+		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8822eu\/Kconfig"' \
+			"$kerneldir/drivers/net/wireless/Kconfig"
+	fi
+}
+
+
 driver_xradio_xr819() {
 
 	# Wireless drivers for Xradio XR819 chipsets


### PR DESCRIPTION
# Description

Integrate the [libc0607/rtl88x2eu-20230815](https://github.com/libc0607/rtl88x2eu-20230815) out-of-tree driver into the build system under EXTRA_WIFI for kernels >= 3.14 and < 6.19.

- Fetch pinned upstream commit [ccb31f4ee346d5c2dd45475d276171b2f8de8350](https://github.com/libc0607/rtl88x2eu-20230815/commit/ccb31f4ee346d5c2dd45475d276171b2f8de8350)
- Install sources under `drivers/net/wireless/rtl8822eu`
- Enable AP and P2P modes in driver Makefile
- Hook into kernel Kconfig and Makefile via CONFIG_RTL8822EU

# How Has This Been Tested?

Tested on `6.12.74-current-sunxi` and `6.6.75-legacy-sunxi`. Compatibility with kernels newer than 6.12 has not been verified, and versions earlier than `5.x` are untested (and likely not relevant for most use cases).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Realtek RTL8812EU and RTL8822EU wireless network drivers on Linux kernels 3.14 through 6.18.
  * Driver includes AP mode and P2P connectivity features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->