### PR TITLE
rockchip64: Fix RTL8211 phy LED dts setting patch

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/net-phy-realtek-add-rtl8211x-LED-configuration-from-OF.patch
+++ b/patch/kernel/archive/rockchip64-6.18/net-phy-realtek-add-rtl8211x-LED-configuration-from-OF.patch
@@ -1,18 +1,18 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From ccdd6b8919f09b003f0881648ea937743c825fd7 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Mon, 20 Oct 2025 21:42:28 +0200
-Subject: net: phy: realtek: add rtl8211x LED configuration from OF
+Subject: [PATCH] net: phy: realtek: add rtl8211x LED configuration from OF
 
 Signed-off-by: retro98boy <retro98boy@qq.com>
 ---
- drivers/net/phy/realtek/realtek_main.c | 11 ++++++++++
+ drivers/net/phy/realtek/realtek_main.c | 11 +++++++++++
  1 file changed, 11 insertions(+)
 
 diff --git a/drivers/net/phy/realtek/realtek_main.c b/drivers/net/phy/realtek/realtek_main.c
-index 111111111111..222222222222 100644
+index 6ff038520..c77a0d169 100644
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -221,6 +221,15 @@ static int rtl821x_modify_ext_page(struct phy_device *phydev, u16 ext_page,
+@@ -248,6 +248,15 @@ static int rtl821x_modify_ext_page(struct phy_device *phydev, u16 ext_page,
  	return phy_restore_page(phydev, oldpage, ret);
  }
  
@@ -28,15 +28,15 @@ index 111111111111..222222222222 100644
  static int rtl821x_probe(struct phy_device *phydev)
  {
  	struct device *dev = &phydev->mdio.dev;
-@@ -254,6 +263,8 @@ static int rtl8211f_probe(struct phy_device *phydev)
- 	if (ret < 0)
+@@ -712,6 +721,8 @@ static int rtl8211f_config_init(struct phy_device *phydev)
+ 	if (ret)
  		return ret;
  
 +	rtl821x_led_of_init(phydev);
 +
- 	/* Disable all PME events */
- 	ret = phy_write_paged(phydev, RTL8211F_WOL_PAGE,
- 			      RTL8211F_WOL_SETTINGS_EVENTS, 0);
+ 	ret = rtl8211f_config_clk_out(phydev);
+ 	if (ret) {
+ 		dev_err(dev, "clkout configuration failed: %pe\n",
 -- 
-Armbian
+2.53.0
 

--- a/patch/kernel/archive/rockchip64-6.19/net-phy-realtek-add-rtl8211x-LED-configuration-from-OF.patch
+++ b/patch/kernel/archive/rockchip64-6.19/net-phy-realtek-add-rtl8211x-LED-configuration-from-OF.patch
@@ -1,15 +1,15 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From ccdd6b8919f09b003f0881648ea937743c825fd7 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Mon, 20 Oct 2025 21:42:28 +0200
-Subject: net: phy: realtek: add rtl8211x LED configuration from OF
+Subject: [PATCH] net: phy: realtek: add rtl8211x LED configuration from OF
 
 Signed-off-by: retro98boy <retro98boy@qq.com>
 ---
- drivers/net/phy/realtek/realtek_main.c | 11 ++++++++++
+ drivers/net/phy/realtek/realtek_main.c | 11 +++++++++++
  1 file changed, 11 insertions(+)
 
 diff --git a/drivers/net/phy/realtek/realtek_main.c b/drivers/net/phy/realtek/realtek_main.c
-index 111111111111..222222222222 100644
+index 6ff038520..c77a0d169 100644
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
 @@ -248,6 +248,15 @@ static int rtl821x_modify_ext_page(struct phy_device *phydev, u16 ext_page,
@@ -28,15 +28,15 @@ index 111111111111..222222222222 100644
  static int rtl821x_probe(struct phy_device *phydev)
  {
  	struct device *dev = &phydev->mdio.dev;
-@@ -281,6 +290,8 @@ static int rtl8211f_probe(struct phy_device *phydev)
- 	if (ret < 0)
+@@ -712,6 +721,8 @@ static int rtl8211f_config_init(struct phy_device *phydev)
+ 	if (ret)
  		return ret;
  
 +	rtl821x_led_of_init(phydev);
 +
- 	/* Disable all PME events */
- 	ret = phy_write_paged(phydev, RTL8211F_WOL_PAGE,
- 			      RTL8211F_WOL_SETTINGS_EVENTS, 0);
+ 	ret = rtl8211f_config_clk_out(phydev);
+ 	if (ret) {
+ 		dev_err(dev, "clkout configuration failed: %pe\n",
 -- 
-Armbian
+2.53.0
 


### PR DESCRIPTION
# Description

On rockchip64 devices running kernel versions 6.18 and 6.19, the method of configuring the RTL8211 PHY using the "realtek-data" property in the dts is currently broken.

The root cause was identified in a recent [PR](https://github.com/armbian/build/pull/8786) where the execution sequence of `rtl821x_led_of_init(phydev);` was relocated. This issue can be resolved by reverting the position of this function call as close as possible to its original location in the initialization flow.

# How Has This Been Tested?

Test on smart-am40 rk3399 device

```
./compile.sh kernel BOARD=smart-am40 BRANCH=current RELEASE=noble

./compile.sh kernel BOARD=smart-am40 BRANCH=edge RELEASE=noble
```

smart-am40 phy dts node:

```
		rtl8211f: rtl8211f@0 {
			reg = <0>;
			reset-assert-us = <10000>;
			reset-deassert-us = <30000>;
			reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
			realtek,led-data = <0x820b>;
		};
```

before fix:

```
root@smart-am40:~# phytool write eth0/0/0x1f 0x0d04
root@smart-am40:~# phytool read eth0/0/0x10
0x6251
root@smart-am40:~# phytool write eth0/0/0x1f 0x0000
```

after fix:

```
root@smart-am40:~# phytool write eth0/0/0x1f 0x0d04
root@smart-am40:~# phytool read eth0/0/0x10
0x820b
root@smart-am40:~# phytool write eth0/0/0x1f 0x0000
```

# Checklist:

- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced LED configuration support for RTL8211x network devices and added error handling for clock configuration initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->