### PR TITLE
Khadas VIM1S/VIM4 disable wayland and default to X as its fairly unstable

### DIFF
--- a/config/boards/khadas-vim1s.conf
+++ b/config/boards/khadas-vim1s.conf
@@ -11,6 +11,8 @@ SERIALCON="ttyS0" # for vendor kernel
 BOOTCONFIG="kvim1s_defconfig"
 KHADAS_BOARD_ID="kvim1s" # used to compile the fip blobs
 
+enable_extension "wayland-sessions-mask" # wayland is fairly broken on legacy board
+
 declare -g KHADAS_OOWOW_BOARD_ID="VIM1S" # for use with EXT=output-image-oowow
 
 OVERLAY_PREFIX='s4-s905y4'

--- a/config/boards/khadas-vim4.conf
+++ b/config/boards/khadas-vim4.conf
@@ -14,6 +14,8 @@ KHADAS_BOARD_ID="kvim4" # used to compile the fip blobs
 
 declare -g KHADAS_OOWOW_BOARD_ID="VIM4" # for use with EXT=output-image-oowow
 
+enable_extension "wayland-sessions-mask" # wayland is fairly broken on legacy board
+
 OVERLAY_PREFIX='t7-a311d2'
 
 function post_family_tweaks_bsp__enable_fan_service() {


### PR DESCRIPTION
# Description

This makes Gnome desktop usable.

# How Has This Been Tested?

- [x] Generated and booted Gnome desktop on VIM4

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enabled Wayland sessions masking extension for system board configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->