### PR TITLE
Add Calamares installer extension

### DIFF
--- a/extensions/calamares-installer/calamares.sh
+++ b/extensions/calamares-installer/calamares.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Armbian Generic Calamares Installer Extension
+
+function post_repo_customize_image__install_calamares() {
+	display_alert "Adding calamares package to the image."
+	do_with_retries 3 chroot_sdcard_apt_get_update
+	do_with_retries 3 chroot_sdcard_apt_get_install "calamares qtwayland5"
+	display_alert "Configuring Calamares for any Desktop Environment..."
+	run_host_command_logged "cp -vr \"${SRC}/extensions/calamares-installer/config/\"* \"$SDCARD/\""
+
+	# --- Create the Armbian Branding Directory ---
+	# Calamares needs a branding directory with a 'branding.desc' file.
+	# We copy the default theme as a base.
+	echo "Setting up Calamares branding..."
+	mkdir -p "${SDCARD}/etc/calamares/branding"
+	run_host_command_logged "cp -r \"${SDCARD}/usr/share/calamares/branding/default\" \"${SDCARD}/etc/calamares/branding/armbian\""
+
+	# --- Fix the Branding Component Name ---
+	# The copied branding.desc file still contains 'componentName: default'.
+	# We must change it to 'armbian' to match our directory name and settings.conf.
+	echo "Updating branding component name to 'armbian'..."
+	sed -i 's/componentName: default/componentName: armbian/g' "${DEST}/etc/calamares/branding/armbian/branding.desc"
+
+	# --- Copy the QML Files ---
+	# The default branding theme is often incomplete and missing the 'qml' folder.
+	# We must get the QML files from the global Calamares installation directory.
+	QML_SOURCE_DIR="${SDCARD}/usr/share/calamares/qml"
+	QML_BRANDING_DIR="${SDCARD}/etc/calamares/branding/armbian/qml"
+
+	if [ -d "$QML_SOURCE_DIR" ]; then
+		echo "Copying QML files from global directory to branding directory..."
+		mkdir -p "$QML_BRANDING_DIR"
+		run_host_command_logged "cp -r \"$QML_SOURCE_DIR\"/* \"$QML_BRANDING_DIR/\""
+	else
+		echo "ERROR: Global QML directory not found at $QML_SOURCE_DIR"
+		echo "The 'calamares' package may be incomplete or broken."
+		exit 1
+	fi
+	chroot_sdcard "chmod +x /usr/libexec/armbian-finalize.sh"
+	display_alert "Calamares configuration complete."
+}

--- a/extensions/calamares-installer/calamares.sh
+++ b/extensions/calamares-installer/calamares.sh
@@ -19,7 +19,7 @@ function post_repo_customize_image__install_calamares() {
 	# The copied branding.desc file still contains 'componentName: default'.
 	# We must change it to 'armbian' to match our directory name and settings.conf.
 	echo "Updating branding component name to 'armbian'..."
-	sed -i 's/componentName: default/componentName: armbian/g' "${DEST}/etc/calamares/branding/armbian/branding.desc"
+	sed -i 's/componentName: default/componentName: armbian/g' "${SDCARD}/etc/calamares/branding/armbian/branding.desc"
 
 	# --- Copy the QML Files ---
 	# The default branding theme is often incomplete and missing the 'qml' folder.

--- a/extensions/calamares-installer/config/etc/calamares/modules.conf
+++ b/extensions/calamares-installer/config/etc/calamares/modules.conf
@@ -1,0 +1,28 @@
+# Calamares Modules Configuration
+# This file declares which modules are available for the installer.
+# The module names here must match the names used in settings.conf.
+
+# --- UI Modules (shown in the sidebar) ---
+# These modules provide the user interface for the installation steps.
+
+- name: welcome
+- name: partition
+- name: users
+- name: summary
+- name: finished
+
+# --- Execution Modules (run in the background) ---
+# These modules perform the actual work of installing the system.
+
+- name: partition
+- name: rsync
+- name: machineid
+- name: fstab
+- name: locale
+- name: keyboard
+- name: users
+- name: displaymanager
+- name: packages
+- name: grubcfg
+- name: bootloader
+- name: shellprocess

--- a/extensions/calamares-installer/config/etc/calamares/modules/displaymanager.conf
+++ b/extensions/calamares-installer/config/etc/calamares/modules/displaymanager.conf
@@ -1,0 +1,6 @@
+# Generic Display Manager Configuration for Calamares
+# This file works for XFCE (LightDM), GNOME (GDM3), and KDE (SDDM).
+
+# By leaving the list empty, Calamares will auto-detect the display manager
+# based on the packages installed in the image.
+displaymanagers: []

--- a/extensions/calamares-installer/config/etc/calamares/modules/partition.conf
+++ b/extensions/calamares-installer/config/etc/calamares/modules/partition.conf
@@ -1,0 +1,10 @@
+partitionFileSystemType: "ext4"
+defaultFileSystemType: "ext4"
+# This tells Calamares to create a separate /boot partition
+efiSystemPartition: "/boot"
+userSwapChoices:
+    - none
+    - file
+ensureSuspendToDisk: false
+allowZfs: false
+allowLuksAutomatedPartitioning: false

--- a/extensions/calamares-installer/config/etc/calamares/modules/rsync.conf
+++ b/extensions/calamares-installer/config/etc/calamares/modules/rsync.conf
@@ -1,0 +1,22 @@
+# This module copies the live filesystem to the target partition.
+# It's used when the live system is not a squashfs image.
+
+# The source directory is the root of the live system.
+source: "/"
+
+# The destination is the root of the target partition.
+destination: ""
+
+# Exclude directories that are created by the kernel or are not meant to be copied.
+exclude:
+  - /proc
+  - /sys
+  - /dev
+  - /run
+  - /tmp
+  - /mnt
+  - /media
+  - /etc/calamares # Exclude our installer config from the final system
+
+# Additional rsync options for a reliable copy.
+rsyncOptions: [ "-a", "-X", "-A", "--numeric-ids", "--info=progress2" ]

--- a/extensions/calamares-installer/config/etc/calamares/modules/shellprocess_final.conf
+++ b/extensions/calamares-installer/config/etc/calamares/modules/shellprocess_final.conf
@@ -1,0 +1,4 @@
+dontChroot: false
+timeout: 300
+script:
+    - "/usr/libexec/armbian-finalize.sh"

--- a/extensions/calamares-installer/config/etc/calamares/settings.conf
+++ b/extensions/calamares-installer/config/etc/calamares/settings.conf
@@ -1,0 +1,82 @@
+# Calamares Configuration File for Armbian
+# This file defines the sequence of modules for the installation process.
+
+# Tells Calamares to look for modules in the 'modules/' subdirectory
+# of the configuration directory (/etc/calamares/).
+modules-search: [ local ]
+
+# --- Module Instances ---
+# This section defines explicit instances for modules that need custom configuration.
+# Modules without custom configs can be referenced directly by name in the sequence.
+instances:
+- id: rsync
+  module: rsync
+  config: rsync.conf
+- id: partition
+  module: partition
+  config: partition.conf
+- id: displaymanager
+  module: displaymanager
+  config: displaymanager.conf
+- id: shellprocess_final
+  module: shellprocess
+  config: shellprocess_final.conf
+
+# This is the main installation sequence.
+# It is divided into 'show' steps (displayed in the UI) and 'exec' steps (run in the background).
+# The order is critical.
+sequence:
+  # --- UI Steps ---
+  # These modules will be shown to the user in the graphical wizard.
+  - show:
+      - welcome      # Welcome screen
+      - partition    # Disk partitioning
+      - users        # User creation (username, password, root)
+      - summary      # Pre-installation summary
+
+  # --- Execution Steps ---
+  # These modules perform the actual installation work.
+  # They run in the background after the user clicks "Install".
+  - exec:
+      - partition      # Applies the partitioning choices
+      - rsync          # Copies the live filesystem to the target partition
+      - machineid      # Creates a unique machine ID
+      - fstab          # Generates /etc/fstab
+      - locale         # Sets system locale
+      - keyboard       # Sets keyboard layout
+      - users          # Creates the user accounts
+      - displaymanager # Configures the display manager (if applicable)
+      - packages       # Installs additional packages (if any are defined)
+      - grubcfg        # Prepares GRUB configuration
+      - bootloader     # Installs the bootloader to the MBR/EFI
+      - shellprocess_final # Runs the final post-installation script
+
+  # --- Final UI Step ---
+  # This module is shown after the installation is complete.
+  - show:
+      - finished       # Installation finished screen
+
+# --- Global Settings ---
+
+# The branding component name. This MUST match the directory name
+# in /etc/calamares/branding/ and the 'componentName' in branding.desc.
+branding: armbian
+
+# Prompt the user to continue even if there are non-critical errors.
+# Set to 'true' for debugging, 'false' for production.
+prompt-install: false
+
+# Set to 'true' to prevent Calamares from chrooting into the target system.
+# Most modules require this to be 'false'.
+dont-chroot: false
+
+# Set to 'true' to enable OEM mode (for pre-installing systems).
+oem-setup: false
+
+# UI/UX settings
+disable-cancel: false
+disable-cancel-during-exec: false
+hide-back-and-next-during-exec: false
+
+# Set to 'true' to automatically close Calamares after a successful installation.
+quit-at-end: false

--- a/extensions/calamares-installer/config/usr/libexec/armbian-finalize.sh
+++ b/extensions/calamares-installer/config/usr/libexec/armbian-finalize.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo "--- Running Armbian Finalization Script ---"
+
+if [ -f /usr/lib/armbian/armbian-install ]; then
+    echo "Executing armbian-install to configure the bootloader..."
+    /usr/lib/armbian/armbian-install
+else
+    echo "ERROR: /usr/lib/armbian/armbian-install not found!"
+    exit 1
+fi
+
+echo "--- Armbian Finalization Complete ---"
+exit 0

--- a/extensions/calamares-installer/config/xdg/autostart/calamares.desktop
+++ b/extensions/calamares-installer/config/xdg/autostart/calamares.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Install Armbian
+Comment=Install this system permanently to your disk
+Exec=pkexec /usr/bin/calamares
+Icon=system-software-install
+Terminal=false
+Categories=System;
+StartupNotify=true


### PR DESCRIPTION
## Summary
- Add new Calamares-based installer extension for Armbian live images
- Provides graphical installation experience for desktop environments
- Includes partitioning, filesystem unpacking, display manager, and bootloader configuration
- Auto-detects display manager (LightDM/GDM3/SDDM) based on installed packages

## Files added
- `extensions/calamares-installer/calamares.sh` - Main installer hook
- `extensions/calamares-installer/config/etc/calamares/` - Calamares configuration
  - `settings.conf` - Module instances configuration
  - `modules.conf` - Module sequence
  - `modules/*.conf` - Individual module configurations (partition, unpackfs, displaymanager, shellprocess)
- `extensions/calamares-installer/config/usr/libexec/armbian-finalize.sh` - Finalization script
- `extensions/calamares-installer/config/xdg/autostart/calamares.desktop` - Autostart entry

## Test plan
- [ ] Build live image with Calamares extension enabled
- [ ] Boot live image and verify Calamares launches automatically
- [ ] Test installation process with different partition layouts
- [ ] Verify bootloader installation works on target hardware
- [ ] Test with different desktop environments (XFCE, GNOME, KDE)