### PR TITLE
fix(orangepi5max): bind UART bluetooth service lifecycle to rfkill

### DIFF
--- a/config/boards/orangepi5-max.csc
+++ b/config/boards/orangepi5-max.csc
@@ -68,9 +68,9 @@ function post_family_tweaks_bsp__orangepi5max_bluetooth() {
 	mkdir -p $destination/etc/udev/rules.d/
 	cat <<-EOF > $destination/etc/udev/rules.d/99-ap6611s-bluetooth.rules
 		# Stop service on rfkill block
-		ACTION=="add|change", SUBSYSTEM=="rfkill", ENV{RFKILL_NAME}=="bt_default", ENV{RFKILL_TYPE}=="bluetooth", ENV{RFKILL_STATE}=="0", RUN+="/usr/bin/systemctl stop ap6611s-bluetooth.service"
+		ACTION=="add|change", SUBSYSTEM=="rfkill", ENV{RFKILL_NAME}=="bt_default", ENV{RFKILL_TYPE}=="bluetooth", ENV{RFKILL_STATE}=="0", RUN+="/usr/bin/systemctl stop --no-block ap6611s-bluetooth.service"
 		# Restart service to reload firmware on rfkill unblock
-		ACTION=="add|change", SUBSYSTEM=="rfkill", ENV{RFKILL_NAME}=="bt_default", ENV{RFKILL_TYPE}=="bluetooth", ENV{RFKILL_STATE}=="1", RUN+="/usr/bin/systemctl restart --no-block ap6611s-bluetooth.service"
+		ACTION=="add|change", SUBSYSTEM=="rfkill", ENV{RFKILL_NAME}=="bt_default", ENV{RFKILL_TYPE}=="bluetooth", ENV{RFKILL_STATE}=="1", RUN+="/bin/sh -c 'sleep 2 && systemctl restart --no-block ap6611s-bluetooth.service'"
 	EOF
 
 	return 0


### PR DESCRIPTION
# Description

This PR fixes the issue where toggling Bluetooth via Desktop Environments (like KDE/GNOME) or `rfkill` causes the UART Bluetooth chip (AP6611S) on the Orange Pi 5 Max to permanently lose its patchram firmware until a manual service restart.

**Motivation and Context:**
Previously, `ap6611s-bluetooth.service` was statically enabled at boot. If a user soft-blocked the Bluetooth radio (e.g., turning it off in KDE settings), the chip would lose power/reset and drop its firmware, rendering it a "dead" adapter when turned back on.
This change removes the static `systemctl enable` and replaces it with `udev` rules. It binds the lifecycle of the firmware-patching service directly to the kernel's `rfkill` subsystem:
1. `ACTION=="add|change" ... RFKILL_STATE=="1"` -> (re)starts the service to reload firmware when Bluetooth is turned ON.
2. `ACTION=="add|change" ... RFKILL_STATE=="0"` -> stops the service when Bluetooth is turned OFF.

# Documentation summary for feature / change

- [x] short description: Bind Orange Pi 5 Max UART Bluetooth service to rfkill.
- [x] summary: UART Bluetooth on Orange Pi 5 Max now fully supports soft-blocking and unblocking (via Desktop UI toggles or CLI) without dropping firmware state or requiring manual daemon restarts.
- [x] example of usage: Toggle the Bluetooth switch in KDE/GNOME, or run `sudo rfkill block bluetooth` / `sudo rfkill unblock bluetooth` in the terminal. The background patchram service will automatically stop/start accordingly.

# How Has This Been Tested?

I have tested this mechanism in both Desktop Environment and Headless (pure terminal) scenarios on Orange Pi 5 Max to ensure no regressions occur.

- [x] **Test A: Desktop Environment (KDE Plasma) UI Toggle**
  Toggled Bluetooth off and on using the desktop applet. Verified that the `ap6611s-bluetooth.service` automatically stops and restarts in the background, and the `hci0` adapter successfully re-appears and connects to devices upon turning on.
- [x] **Test B: Headless / CLI Toggle**
  Executed `sudo rfkill block bluetooth` and verified via `systemctl status` that the service cleanly exits. Executed `sudo rfkill unblock bluetooth` and verified the service restarts, successfully executing `brcm_patchram_plus` to restore the `hci0` interface. Tested surviving a full system reboot.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Bluetooth service lifecycle management for OrangePi 5 Max to respond dynamically to rfkill state changes rather than relying on boot-time activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->