### PR TITLE
station-m2: fix sata

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/board-station-m2.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-station-m2.patch
@@ -1,11 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: chainsx <chainsx@outlook.com>
-Date: Fri, 21 Feb 2025 19:36:41 +0800
+Date: Tue, 24 Feb 2026 01:59:21 +0800
 Subject: fix rk3566-roc-pc
 
 ---
- arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts | 110 +++++++---
- 1 file changed, 80 insertions(+), 30 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts | 114 +++++++++++++-----
+ 1 file changed, 84 insertions(+), 30 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts
 index 111111111111..222222222222 100644
@@ -146,15 +146,15 @@ index 111111111111..222222222222 100644
 -			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
 +		vcc5v0_usb30_host_en_h: vcc5v0-usb30-host-en-h {
 +			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		vcc5v0_usb_otg_en_h: vcc5v0-usb-otg-en-h {
-+			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
-+	};
  
 -		vcc5v0_usb_otg_en_h: vcc5v0-usb-otg-en_h {
 -			rockchip,pins = <0 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		vcc5v0_usb_otg_en_h: vcc5v0-usb-otg-en-h {
++			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
 +	headphone {
 +		hp_det: hp-det {
 +			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_up>;
@@ -173,7 +173,7 @@ index 111111111111..222222222222 100644
  &sdhci {
  	bus-width = <8>;
  	mmc-hs200-1_8v;
-@@ -600,28 +629,36 @@ &sdmmc1 {
+@@ -600,28 +629,40 @@ &sdmmc1 {
  	bus-width = <4>;
  	cap-sd-highspeed;
  	cap-sdio-irq;
@@ -209,6 +209,10 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
++&sata2 {
++	target-supply = <&vcc3v3_pcie>;
++};
++
  &uart1 {
  	pinctrl-names = "default";
 -	pinctrl-0 = <&uart1m0_xfer &uart1m0_ctsn>;
@@ -216,7 +220,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  	uart-has-rtscts;
  
-@@ -653,6 +690,11 @@ &usb2phy0_otg {
+@@ -653,6 +694,11 @@ &usb2phy0_otg {
  	status = "okay";
  };
  
@@ -228,7 +232,7 @@ index 111111111111..222222222222 100644
  &usb2phy1_otg {
  	phy-supply = <&vcc5v0_usb30_host>;
  	status = "okay";
-@@ -682,6 +724,14 @@ &usb_host0_ohci {
+@@ -682,6 +728,14 @@ &usb_host0_ohci {
  	status = "okay";
  };
  

--- a/patch/kernel/archive/rockchip64-6.19/board-station-m2.patch
+++ b/patch/kernel/archive/rockchip64-6.19/board-station-m2.patch
@@ -1,11 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: chainsx <chainsx@outlook.com>
-Date: Fri, 21 Feb 2025 19:36:41 +0800
+Date: Tue, 24 Feb 2026 01:59:21 +0800
 Subject: fix rk3566-roc-pc
 
 ---
- arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts | 110 +++++++---
- 1 file changed, 80 insertions(+), 30 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts | 114 +++++++++++++-----
+ 1 file changed, 84 insertions(+), 30 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts
 index 111111111111..222222222222 100644
@@ -146,15 +146,15 @@ index 111111111111..222222222222 100644
 -			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
 +		vcc5v0_usb30_host_en_h: vcc5v0-usb30-host-en-h {
 +			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		vcc5v0_usb_otg_en_h: vcc5v0-usb-otg-en-h {
-+			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
-+	};
  
 -		vcc5v0_usb_otg_en_h: vcc5v0-usb-otg-en_h {
 -			rockchip,pins = <0 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		vcc5v0_usb_otg_en_h: vcc5v0-usb-otg-en-h {
++			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
 +	headphone {
 +		hp_det: hp-det {
 +			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_up>;
@@ -173,7 +173,7 @@ index 111111111111..222222222222 100644
  &sdhci {
  	bus-width = <8>;
  	mmc-hs200-1_8v;
-@@ -600,28 +629,36 @@ &sdmmc1 {
+@@ -600,28 +629,40 @@ &sdmmc1 {
  	bus-width = <4>;
  	cap-sd-highspeed;
  	cap-sdio-irq;
@@ -209,6 +209,10 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
++&sata2 {
++	target-supply = <&vcc3v3_pcie>;
++};
++
  &uart1 {
  	pinctrl-names = "default";
 -	pinctrl-0 = <&uart1m0_xfer &uart1m0_ctsn>;
@@ -216,7 +220,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  	uart-has-rtscts;
  
-@@ -653,6 +690,11 @@ &usb2phy0_otg {
+@@ -653,6 +694,11 @@ &usb2phy0_otg {
  	status = "okay";
  };
  
@@ -228,7 +232,7 @@ index 111111111111..222222222222 100644
  &usb2phy1_otg {
  	phy-supply = <&vcc5v0_usb30_host>;
  	status = "okay";
-@@ -682,6 +724,14 @@ &usb_host0_ohci {
+@@ -682,6 +728,14 @@ &usb_host0_ohci {
  	status = "okay";
  };
  


### PR DESCRIPTION
# Description

Fix the sata definition to adapt to the use of rockchip-rk3566-sata2.dtso.

Due to issues with patch generation, only the following content was actually added:

```
&sata2 {
	target-supply = <&vcc3v3_pcie>;
};
```

Reference:

https://github.com/armbian/build/pull/9409

# How Has This Been Tested?

- [x] sata

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added headset detection support
  * Enabled thermal monitoring with CPU temperature management
  * Added support for additional USB host controllers
  * Enabled SATA storage interface
  * Added LED indicator support

* **Chores**
  * Updated USB power control pin mappings
  * Modified MMC/SD card interface configuration
  * Extended UART pin configuration
  * Adjusted I2C controller settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->