### PR TITLE
Odroid-M2: Enable HDMI audio

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/board-odroidm2-enable-hdmi-audio.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-odroidm2-enable-hdmi-audio.patch
@@ -1,0 +1,26 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
+index a72063c55140..c27a1e3db6fa 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
+@@ -264,6 +264,10 @@ hdmi0_out_con: endpoint {
+ 	};
+ };
+ 
++&hdmi0_sound {
++	status = "okay";
++};
++
+ &hdptxphy0 {
+ 	status = "okay";
+ };
+@@ -396,6 +400,10 @@ pcf8563: rtc@51 {
+ 	};
+ };
+ 
++&i2s5_8ch {
++	status = "okay";
++};
++
+ &mdio1 {
+ 	rgmii_phy1: ethernet-phy@1 {
+ 		compatible = "ethernet-phy-id001c.c916";

--- a/patch/kernel/archive/rockchip64-6.19/board-odroidm2-enable-hdmi-audio.patch
+++ b/patch/kernel/archive/rockchip64-6.19/board-odroidm2-enable-hdmi-audio.patch
@@ -1,0 +1,26 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
+index a72063c55140..c27a1e3db6fa 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
+@@ -264,6 +264,10 @@ hdmi0_out_con: endpoint {
+ 	};
+ };
+ 
++&hdmi0_sound {
++	status = "okay";
++};
++
+ &hdptxphy0 {
+ 	status = "okay";
+ };
+@@ -396,6 +400,10 @@ pcf8563: rtc@51 {
+ 	};
+ };
+ 
++&i2s5_8ch {
++	status = "okay";
++};
++
+ &mdio1 {
+ 	rgmii_phy1: ethernet-phy@1 {
+ 		compatible = "ethernet-phy-id001c.c916";


### PR DESCRIPTION
# Description

This patch enables HDMI audio in odroid-m2 device tree.

# How Has This Been Tested?

Tested on 2 different monitors.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled HDMI audio output support for multimedia devices
  * Activated multi-channel I2S audio functionality
  * Enabled additional Ethernet network connectivity options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->