### PR TITLE
Add Ayn Odin2 kernel 6.19 support

### DIFF
--- a/config/sources/families/sm8550.conf
+++ b/config/sources/families/sm8550.conf
@@ -22,8 +22,8 @@ case $BRANCH in
 		;;
 
 	edge)
-		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH='branch:linux-6.18.y'
+		declare -g KERNEL_MAJOR_MINOR="6.19" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH='branch:linux-6.19.y'
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		;;
 

--- a/patch/kernel/archive/sm8550-6.19/0001-arm64-dts-qcom-sm8550-add-UART15.patch
+++ b/patch/kernel/archive/sm8550-6.19/0001-arm64-dts-qcom-sm8550-add-UART15.patch
@@ -1,0 +1,53 @@
+From 0bb546348037195d1c67e5785cf39d5ea05b0ef6 Mon Sep 17 00:00:00 2001
+From: Teguh Sobirin <teguh@sobir.in>
+Date: Wed, 12 Feb 2025 17:53:48 +0800
+Subject: [PATCH 01/15] arm64: dts: qcom: sm8550: add UART15
+
+Signed-off-by: Teguh Sobirin <teguh@sobir.in>
+---
+ arch/arm64/boot/dts/qcom/sm8550.dtsi | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sm8550.dtsi b/arch/arm64/boot/dts/qcom/sm8550.dtsi
+index e3f93f4f412d..9b5db1ba451c 100644
+--- a/arch/arm64/boot/dts/qcom/sm8550.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8550.dtsi
+@@ -1251,6 +1251,20 @@ &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ACTIVE_ONLY>,
+ 				#size-cells = <0>;
+ 				status = "disabled";
+ 			};
++
++			uart15: serial@89c000 {
++				compatible = "qcom,geni-uart";
++				reg = <0 0x89c000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S7_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_uart15_default>;
++				interrupts = <GIC_SPI 462 IRQ_TYPE_LEVEL_HIGH 0>;
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 0 &clk_virt SLAVE_QUP_CORE_2 0>,
++						<&gem_noc MASTER_APPSS_PROC 0 &config_noc SLAVE_QUP_2 0>;
++				interconnect-names = "qup-core", "qup-config";
++				status = "disabled";
++			};
+ 		};
+ 
+ 		i2c_master_hub_0: geniqup@9c0000 {
+@@ -5095,6 +5109,14 @@ qup_uart14_cts_rts: qup-uart14-cts-rts-state {
+ 				bias-pull-down;
+ 			};
+ 
++			qup_uart15_default: qup-uart15-default-state {
++				/* TX, RX */
++				pins = "gpio74", "gpio75";
++				function = "qup2_se7";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
+ 			sdc2_sleep: sdc2-sleep-state {
+ 				clk-pins {
+ 					pins = "sdc2_clk";
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0002-input-Add-driver-for-RSInput-Gamepad.patch
+++ b/patch/kernel/archive/sm8550-6.19/0002-input-Add-driver-for-RSInput-Gamepad.patch
@@ -1,0 +1,472 @@
+From 8461053a3b7351028b98910cb4ec0e2c7f53e85b Mon Sep 17 00:00:00 2001
+From: Teguh Sobirin <teguh@sobir.in>
+Date: Thu, 20 Feb 2025 14:50:30 +0800
+Subject: [PATCH 02/15] input: Add driver for RSInput Gamepad
+
+Signed-off-by: Teguh Sobirin <teguh@sobir.in>
+---
+ drivers/input/joystick/Kconfig   |   4 +
+ drivers/input/joystick/Makefile  |   1 +
+ drivers/input/joystick/rsinput.c | 423 +++++++++++++++++++++++++++++++
+ 3 files changed, 428 insertions(+)
+ create mode 100644 drivers/input/joystick/rsinput.c
+
+diff --git a/drivers/input/joystick/Kconfig b/drivers/input/joystick/Kconfig
+index 7755e5b454d2..0da3c0f44ecf 100644
+--- a/drivers/input/joystick/Kconfig
++++ b/drivers/input/joystick/Kconfig
+@@ -383,6 +383,10 @@ config JOYSTICK_QWIIC
+ 	  To compile this driver as a module, choose M here: the
+ 	  module will be called qwiic-joystick.
+ 
++config JOYSTICK_RSINPUT
++	tristate "UART Based gamepad driver that found in AYN and Retroid Pocket products"
++	depends on SERIAL_DEV_BUS
++
+ config JOYSTICK_FSIA6B
+ 	tristate "FlySky FS-iA6B RC Receiver"
+ 	select SERIO
+diff --git a/drivers/input/joystick/Makefile b/drivers/input/joystick/Makefile
+index 9976f596a920..3de503e29489 100644
+--- a/drivers/input/joystick/Makefile
++++ b/drivers/input/joystick/Makefile
+@@ -28,6 +28,7 @@ obj-$(CONFIG_JOYSTICK_N64)		+= n64joy.o
+ obj-$(CONFIG_JOYSTICK_PSXPAD_SPI)	+= psxpad-spi.o
+ obj-$(CONFIG_JOYSTICK_PXRC)		+= pxrc.o
+ obj-$(CONFIG_JOYSTICK_QWIIC)		+= qwiic-joystick.o
++obj-$(CONFIG_JOYSTICK_RSINPUT)		+= rsinput.o
+ obj-$(CONFIG_JOYSTICK_SEESAW)		+= adafruit-seesaw.o
+ obj-$(CONFIG_JOYSTICK_SENSEHAT)	+= sensehat-joystick.o
+ obj-$(CONFIG_JOYSTICK_SIDEWINDER)	+= sidewinder.o
+diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
+new file mode 100644
+index 000000000000..8fc0c6ac3745
+--- /dev/null
++++ b/drivers/input/joystick/rsinput.c
+@@ -0,0 +1,423 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * RSInput Gamepad Driver
++ *
++ * Copyright (C) 2024 Teguh Sobirin <teguh@sobir.in>
++ *
++ */
++#define DEBUG
++
++#include <linux/errno.h>
++#include <linux/gpio/consumer.h>
++#include <linux/init.h>
++#include <linux/input.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/serdev.h>
++#include <linux/slab.h>
++#include <uapi/linux/sched/types.h>
++
++#define FRAME_HEAD_1              0xA5
++#define FRAME_HEAD_2              0xD3
++#define FRAME_HEAD_3              0x5A
++#define FRAME_HEAD_4              0x3D
++
++#define CMD_COMMOD                0x01
++#define CMD_STATUS                0x02
++
++#define DATA_COMMOD_VERSION       0x02
++#define DATA_COMMOD_SET_PAR       0x05
++
++#define FRAME_POS_SEQ             4
++#define FRAME_POS_CMD             5
++#define FRAME_POS_LEN_L           6
++#define FRAME_POS_LEN_H           7
++#define FRAME_POS_DATA_1          8
++#define FRAME_POS_DATA_2          9
++#define FRAME_POS_DATA_3          10
++#define FRAME_POS_DATA_4          11
++#define FRAME_POS_DATA_5          12
++#define FRAME_POS_DATA_6          13
++#define FRAME_POS_DATA_7          14
++#define FRAME_POS_DATA_8          15
++#define FRAME_POS_DATA_9          16
++#define FRAME_POS_DATA_10         17
++#define FRAME_POS_DATA_11         18
++#define FRAME_POS_DATA_12         19
++#define FRAME_POS_DATA_13         20
++#define FRAME_POS_DATA_14         21
++
++#define MCU_PKT_SIZE_MIN          9
++
++#define MCU_VERSION_MAX_LEN       64
++
++struct rsinput_driver {
++    struct serdev_device *serdev;
++    struct input_dev *input;
++    struct gpio_desc *boot_gpio;
++    struct gpio_desc *enable_gpio;
++    struct gpio_desc *reset_gpio;
++    uint8_t rx_buf[256];
++    uint8_t sequence_number;
++};
++
++static const unsigned int keymap[] = {
++    BTN_DPAD_UP, BTN_DPAD_DOWN, BTN_DPAD_LEFT, BTN_DPAD_RIGHT,
++    BTN_NORTH,   BTN_WEST,	    BTN_EAST,	   BTN_SOUTH,
++    BTN_TL,	     BTN_TR,	    BTN_SELECT,	   BTN_START,
++    BTN_THUMBL,  BTN_THUMBR,    BTN_MODE,	   BTN_BACK
++};
++
++static uint8_t compute_checksum(const uint8_t *data, size_t len) {
++    uint8_t checksum = 0;
++
++    for (size_t i = FRAME_POS_SEQ; i < len - 1; i++) {
++        checksum ^= data[i];
++    }
++
++    return checksum;
++}
++
++static int rsinput_send_command(struct rsinput_driver *drv, uint8_t cmd, const uint8_t *data, size_t len) {
++    uint8_t frame[256];
++    uint8_t checksum = 0;
++    size_t frame_len = 0;
++
++    frame[frame_len++] = FRAME_HEAD_1;
++    frame[frame_len++] = FRAME_HEAD_2;
++    frame[frame_len++] = FRAME_HEAD_3;
++    frame[frame_len++] = FRAME_HEAD_4;
++
++    frame[frame_len++] = drv->sequence_number;
++    drv->sequence_number++;
++
++    frame[frame_len++] = cmd;
++
++    frame[frame_len++] = len & 0xFF;
++    frame[frame_len++] = (len >> 8) & 0xFF;
++
++    if (data && len) {
++        memcpy(&frame[frame_len], data, len);
++        frame_len += len;
++    }
++
++    checksum = compute_checksum(frame, frame_len + 1);
++    frame[frame_len++] = checksum;
++
++    return serdev_device_write_buf(drv->serdev, frame, frame_len);
++}
++
++static int rsinput_init_commands(struct rsinput_driver *drv) {
++    int error;
++
++    msleep(100);
++    uint8_t version_request[] = {DATA_COMMOD_VERSION};
++    error = rsinput_send_command(drv, CMD_COMMOD, version_request, sizeof(version_request));
++    if (error < 0) {
++        dev_err(&drv->serdev->dev, "Failed to request MCU version: %d\n", error);
++        return error;
++    }
++
++    msleep(100);
++    uint8_t mcu_params[] = {
++        DATA_COMMOD_SET_PAR, 
++        0x01,
++        0x00, 0x00, 0x00, 0x28,
++        0x00, 0x00, 0x00, 0x07
++    };
++    error = rsinput_send_command(drv, CMD_COMMOD, mcu_params, sizeof(mcu_params));
++    if (error < 0) {
++        dev_err(&drv->serdev->dev, "Failed to set MCU parameters: %d\n", error);
++        return error;
++    }
++
++    return 0;
++}
++
++static void handle_cmd_commod(struct rsinput_driver *drv, const uint8_t *data, size_t payload_length) {
++    switch (data[FRAME_POS_DATA_1]) {
++        case DATA_COMMOD_VERSION:
++            if (payload_length >= 1) {
++                char mcu_version[MCU_VERSION_MAX_LEN] = {0};
++                size_t version_length = payload_length;
++                if (version_length > MCU_VERSION_MAX_LEN - 1) {
++                    version_length = MCU_VERSION_MAX_LEN - 1;
++                }
++                memcpy(mcu_version, &data[FRAME_POS_DATA_1], version_length);
++                mcu_version[version_length] = '\0';
++                dev_info(&drv->serdev->dev, "MCU Version: %s\n", mcu_version);
++            } else {
++                dev_err(&drv->serdev->dev, "Invalid MCU version response length\n");
++            }
++            break;
++        case DATA_COMMOD_SET_PAR:
++            dev_info(&drv->serdev->dev, "MCU parameters set successfully\n");
++            break;
++        default:
++            dev_warn(&drv->serdev->dev, "Unhandled CMD_COMMOD sub-command: 0x%02x\n", data[FRAME_POS_DATA_1]);
++            break;
++    }
++}
++
++static void handle_cmd_status(struct rsinput_driver *drv, const uint8_t *data, size_t payload_length) {
++    if (payload_length >= 6) {
++    static unsigned long prev_states;
++    unsigned long keys = data[FRAME_POS_DATA_1] | (data[FRAME_POS_DATA_2] << 8);
++    unsigned long current_states = keys, changes;
++    int i;
++
++    bitmap_xor(&changes, &current_states, &prev_states, ARRAY_SIZE(keymap));
++
++    for_each_set_bit(i, &changes, ARRAY_SIZE(keymap)) {
++        input_report_key(drv->input, keymap[i], (current_states & BIT(i)));
++    }
++
++    input_report_abs(drv->input, ABS_HAT2X,
++             0x650 - (data[FRAME_POS_DATA_3] | (data[FRAME_POS_DATA_4] << 8)));
++    input_report_abs(drv->input, ABS_HAT2Y,
++             0x650 - (data[FRAME_POS_DATA_5] | (data[FRAME_POS_DATA_6] << 8)));
++    input_report_abs(drv->input, ABS_X,
++             -(int16_t)(data[FRAME_POS_DATA_7] | (data[FRAME_POS_DATA_8] << 8)));
++    input_report_abs(drv->input, ABS_Y,
++             -(int16_t)(data[FRAME_POS_DATA_9] | (data[FRAME_POS_DATA_10] << 8)));
++    input_report_abs(drv->input, ABS_RX,
++             -(int16_t)(data[FRAME_POS_DATA_11] | (data[FRAME_POS_DATA_12] << 8)));
++    input_report_abs(drv->input, ABS_RY,
++             -(int16_t)(data[FRAME_POS_DATA_13] | (data[FRAME_POS_DATA_14] << 8)));
++
++    input_sync(drv->input);
++    prev_states = keys;
++
++    } else {
++        dev_warn(&drv->serdev->dev, "Invalid CMD_STATUS response length\n");
++    }
++}
++
++static void rsinput_process_data(struct rsinput_driver *drv, const uint8_t *data, size_t len) {
++    while (len >= MCU_PKT_SIZE_MIN) {
++        uint16_t payload_length = data[FRAME_POS_LEN_L] | (data[FRAME_POS_LEN_H] << 8);
++        size_t frame_length = MCU_PKT_SIZE_MIN + payload_length;
++
++        if (len < frame_length) {
++            return;
++        }
++
++        uint8_t received_checksum = data[frame_length - 1];
++        uint8_t computed_checksum = compute_checksum(data, frame_length);
++        if (computed_checksum != received_checksum) {
++            data += frame_length;
++            len -= frame_length;
++            continue;
++        }
++
++        switch (data[FRAME_POS_CMD]) {
++            case CMD_COMMOD:
++                handle_cmd_commod(drv, data, payload_length);
++                break;
++            case CMD_STATUS:
++                handle_cmd_status(drv, data, payload_length);
++                break;
++            default:
++                dev_warn(&drv->serdev->dev, "Unhandled command: 0x%02X\n", data[FRAME_POS_CMD]);
++                break;
++        }
++
++        data += frame_length;
++        len -= frame_length;
++    }
++
++    if (len > 0) {
++        dev_warn(&drv->serdev->dev, "Trailing bytes after processing: %zu\n", len);
++    }
++}
++
++static size_t rsinput_rx(struct serdev_device *serdev, const u8 *data, size_t count) {
++    struct rsinput_driver *drv = serdev_device_get_drvdata(serdev);
++    uint8_t received_checksum, computed_checksum;
++
++    if (!drv || !data || count == 0) {
++        dev_warn_ratelimited(&serdev->dev, "Invalid RX data\n");
++        goto error;
++    }
++
++    if (count > sizeof(drv->rx_buf)) {
++        dev_warn_ratelimited(&serdev->dev, "RX buffer overflow\n");
++        goto error;
++    }
++
++    memcpy(drv->rx_buf, data, count);
++
++    if (count < MCU_PKT_SIZE_MIN) {
++        dev_warn_ratelimited(&serdev->dev, "Frame too short for checksum validation\n");
++        goto error;
++    }
++
++    received_checksum = drv->rx_buf[count - 1];
++
++    computed_checksum = compute_checksum(drv->rx_buf, count);
++
++    if (computed_checksum != received_checksum) {
++        rsinput_init_commands(drv);
++        goto error;
++    }
++
++    rsinput_process_data(drv, drv->rx_buf, count);
++
++error:
++    return count;
++}
++
++static const struct serdev_device_ops rsinput_rx_ops = {
++    .receive_buf = rsinput_rx,
++};
++
++static int rsinput_probe(struct serdev_device *serdev) {
++    struct rsinput_driver *drv;
++    u32 gamepad_bus = 0;
++    u32 gamepad_vid = 0;
++    u32 gamepad_pid = 0;
++    u32 gamepad_rev = 0;
++    int error;
++
++    drv = devm_kzalloc(&serdev->dev, sizeof(*drv), GFP_KERNEL);
++    if (!drv)
++    return -ENOMEM;
++
++    drv->boot_gpio =
++        devm_gpiod_get_optional(&serdev->dev, "boot", GPIOD_OUT_HIGH);
++    if (IS_ERR(drv->boot_gpio)) {
++        error = PTR_ERR(drv->boot_gpio);
++        dev_warn(&serdev->dev, "Unable to get boot gpio: %d\n", error);
++    }
++
++    drv->enable_gpio =
++        devm_gpiod_get_optional(&serdev->dev, "enable", GPIOD_OUT_HIGH);
++    if (IS_ERR(drv->enable_gpio)) {
++        error = PTR_ERR(drv->enable_gpio);
++        dev_warn(&serdev->dev, "Unable to get enable gpio: %d\n", error);
++    }
++
++    drv->reset_gpio =
++        devm_gpiod_get_optional(&serdev->dev, "reset", GPIOD_OUT_HIGH);
++    if (IS_ERR(drv->reset_gpio)) {
++        error = PTR_ERR(drv->reset_gpio);
++        dev_warn(&serdev->dev, "Unable to get reset gpio: %d\n", error);
++    }
++
++    if (drv->boot_gpio)
++        gpiod_set_value_cansleep(drv->boot_gpio, 0);
++
++    if (drv->reset_gpio)
++        gpiod_set_value_cansleep(drv->reset_gpio, 0);
++
++    msleep(100);
++
++    if (drv->enable_gpio)
++        gpiod_set_value_cansleep(drv->enable_gpio, 1);
++
++    if (drv->reset_gpio)
++        gpiod_set_value_cansleep(drv->reset_gpio, 1);
++
++    msleep(100);
++
++    serdev_device_set_client_ops(serdev, &rsinput_rx_ops);
++    error = serdev_device_open(serdev);
++    if (error)
++        return dev_err_probe(&serdev->dev, error, "Unable to open UART device\n");
++
++    drv->serdev = serdev;
++    drv->sequence_number = 0;
++    
++    serdev_device_set_drvdata(serdev, drv);
++
++    error = serdev_device_set_baudrate(serdev, 115200);
++    if (error < 0)
++        goto err_close;
++
++    serdev_device_set_flow_control(serdev, false);
++
++    drv->input = devm_input_allocate_device(&serdev->dev);
++    if (!drv->input) {
++        error = -ENOMEM;
++        goto err_close;
++    }
++
++    drv->input->phys = "rsinput-gamepad/input0";
++    
++    error = device_property_read_string(&serdev->dev, "gamepad-name", &drv->input->name);
++    if (error) {
++        drv->input->name = "RSInput Gamepad";
++    }
++
++    device_property_read_u32(&serdev->dev, "gamepad-bus", &gamepad_bus);
++    device_property_read_u32(&serdev->dev, "gamepad-vid", &gamepad_vid);
++    device_property_read_u32(&serdev->dev, "gamepad-pid", &gamepad_pid);
++    device_property_read_u32(&serdev->dev, "gamepad-rev", &gamepad_rev);
++
++    drv->input->id.bustype = (u16)gamepad_bus;
++    drv->input->id.vendor  = (u16)gamepad_vid;
++    drv->input->id.product = (u16)gamepad_pid;
++    drv->input->id.version = (u16)gamepad_rev;
++
++    __set_bit(EV_KEY, drv->input->evbit);
++    for (int i = 0; i < ARRAY_SIZE(keymap); i++)
++        input_set_capability(drv->input, EV_KEY, keymap[i]);
++
++    __set_bit(EV_ABS, drv->input->evbit);
++    for (int i = ABS_X; i <= ABS_RZ; i++)
++        input_set_abs_params(drv->input, i, -0x580, 0x580,
++                     0, 0);
++
++    input_set_abs_params(drv->input, ABS_HAT2X, 0, 1830, 0, 30);
++    input_set_abs_params(drv->input, ABS_HAT2Y, 0, 1830, 0, 30);
++
++    error = input_register_device(drv->input);
++    if (error) {
++        goto err_close;
++    }
++
++    error = rsinput_init_commands(drv);
++    if (error < 0) {
++        goto err_close;
++    }
++
++    return 0;
++
++err_close:
++    serdev_device_close(serdev);
++    return error;
++}
++
++static void rsinput_remove(struct serdev_device *serdev) {
++    struct rsinput_driver *drv = serdev_device_get_drvdata(serdev);
++
++    serdev_device_close(serdev);
++    input_unregister_device(drv->input);
++    if (drv->enable_gpio)
++        gpiod_set_value_cansleep(drv->enable_gpio, 0);
++
++    if (drv->reset_gpio)
++        gpiod_set_value_cansleep(drv->reset_gpio, 0);
++}
++
++static const struct of_device_id rsinput_of_match[] = {
++    { .compatible = "gamepad,rsinput" },
++    { /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, rsinput_of_match);
++
++static struct serdev_device_driver rsinput_driver = {
++    .probe = rsinput_probe,
++    .remove = rsinput_remove,
++    .driver = {
++        .name = "rsinput",
++        .of_match_table = rsinput_of_match,
++    },
++};
++
++module_serdev_device_driver(rsinput_driver);
++
++MODULE_LICENSE("GPL");
++MODULE_DESCRIPTION("RSInput Gamepad Driver");
++MODULE_AUTHOR("Teguh Sobirin <teguh@sobir.in>");
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0003-drm-panel-Add-panel-driver-for-Chipone-ICNA3512-base.patch
+++ b/patch/kernel/archive/sm8550-6.19/0003-drm-panel-Add-panel-driver-for-Chipone-ICNA3512-base.patch
@@ -1,0 +1,565 @@
+From 273b6c9c953b71fe019792c5385ed720f7fa794b Mon Sep 17 00:00:00 2001
+From: Teguh Sobirin <teguh@sobir.in>
+Date: Thu, 13 Feb 2025 18:25:19 +0800
+Subject: [PATCH 03/15] drm/panel: Add panel driver for Chipone ICNA3512 based
+ panels
+
+Signed-off-by: Teguh Sobirin <teguh@sobir.in>
+---
+ drivers/gpu/drm/panel/Kconfig                 |  11 +
+ drivers/gpu/drm/panel/Makefile                |   1 +
+ .../gpu/drm/panel/panel-chipone-icna3512.c    | 473 ++++++++++++++++++
+ include/drm/drm_mipi_dsi.h                    |  22 +
+ 4 files changed, 507 insertions(+)
+ create mode 100644 drivers/gpu/drm/panel/panel-chipone-icna3512.c
+
+diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
+index 7a83804fedca..3c0d92cf48e2 100644
+--- a/drivers/gpu/drm/panel/Kconfig
++++ b/drivers/gpu/drm/panel/Kconfig
+@@ -105,6 +105,17 @@ config DRM_PANEL_BOE_TV101WUM_LL2
+ 	  Say Y here if you want to support for BOE TV101WUM-LL2
+ 	  WUXGA PANEL DSI Video Mode panel
+ 
++config DRM_PANEL_CHIPONE_ICNA3512
++	tristate "Chipone ICNA3512 panel driver"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_DISPLAY_HELPER
++	help
++	  Say Y here if you want to enable support for the panels built
++	  around the Chipone ICNA3512 display controller, such as some
++	  Tianma panels used in AYN Odin2 Portal.
++
+ config DRM_PANEL_EBBG_FT8719
+ 	tristate "EBBG FT8719 panel driver"
+ 	depends on OF
+diff --git a/drivers/gpu/drm/panel/Makefile b/drivers/gpu/drm/panel/Makefile
+index b9562a6fdcb3..7f3ca67bae75 100644
+--- a/drivers/gpu/drm/panel/Makefile
++++ b/drivers/gpu/drm/panel/Makefile
+@@ -9,6 +9,7 @@ obj-$(CONFIG_DRM_PANEL_BOE_TD4320) += panel-boe-td4320.o
+ obj-$(CONFIG_DRM_PANEL_BOE_TH101MB31UIG002_28A) += panel-boe-th101mb31ig002-28a.o
+ obj-$(CONFIG_DRM_PANEL_BOE_TV101WUM_LL2) += panel-boe-tv101wum-ll2.o
+ obj-$(CONFIG_DRM_PANEL_BOE_TV101WUM_NL6) += panel-boe-tv101wum-nl6.o
++obj-$(CONFIG_DRM_PANEL_CHIPONE_ICNA3512) += panel-chipone-icna3512.o
+ obj-$(CONFIG_DRM_PANEL_DSI_CM) += panel-dsi-cm.o
+ obj-$(CONFIG_DRM_PANEL_LVDS) += panel-lvds.o
+ obj-$(CONFIG_DRM_PANEL_SIMPLE) += panel-simple.o
+diff --git a/drivers/gpu/drm/panel/panel-chipone-icna3512.c b/drivers/gpu/drm/panel/panel-chipone-icna3512.c
+new file mode 100644
+index 000000000000..cbda976df1db
+--- /dev/null
++++ b/drivers/gpu/drm/panel/panel-chipone-icna3512.c
+@@ -0,0 +1,473 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Chipone ICNA3512 Driver IC panels driver
++ *
++ * Copyright (c) 2025 Teguh Sobirin <teguh@sobir.in>
++ */
++
++#include <linux/backlight.h>
++#include <linux/delay.h>
++#include <linux/gpio/consumer.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_graph.h>
++#include <linux/regulator/consumer.h>
++
++#include <video/mipi_display.h>
++
++#include <drm/display/drm_dsc.h>
++#include <drm/display/drm_dsc_helper.h>
++#include <drm/drm_connector.h>
++#include <drm/drm_crtc.h>
++#include <drm/drm_mipi_dsi.h>
++#include <drm/drm_modes.h>
++#include <drm/drm_panel.h>
++
++struct panel_info {
++	struct drm_panel panel;
++	struct drm_connector *connector;
++	struct mipi_dsi_device *dsi;
++	struct panel_desc *desc;
++	enum drm_panel_orientation orientation;
++
++	struct gpio_desc *reset_gpio;
++	struct regulator_bulk_data supplies[3];
++};
++
++struct panel_desc {
++	unsigned int width_mm;
++	unsigned int height_mm;
++
++	unsigned int bpc;
++	unsigned int lanes;
++	unsigned long mode_flags;
++	enum mipi_dsi_pixel_format format;
++
++	const struct drm_display_mode *modes;
++	unsigned int num_modes;
++	int (*init_sequence)(struct panel_info *pinfo);
++
++	struct drm_dsc_config dsc;
++};
++
++static inline struct panel_info *to_panel_info(struct drm_panel *panel)
++{
++	return container_of(panel, struct panel_info, panel);
++}
++
++static int icna3512_get_current_mode(struct panel_info *pinfo)
++{
++	struct drm_connector *connector = pinfo->connector;
++	struct drm_crtc_state *crtc_state;
++	int i;
++
++	/* Return the default (first) mode if no info available yet */
++	if (!connector->state || !connector->state->crtc)
++		return 0;
++
++	crtc_state = connector->state->crtc->state;
++
++	for (i = 0; i < pinfo->desc->num_modes; i++) {
++		if (drm_mode_match(&crtc_state->mode,
++				   &pinfo->desc->modes[i],
++				   DRM_MODE_MATCH_TIMINGS | DRM_MODE_MATCH_CLOCK))
++			return i;
++	}
++
++	return 0;
++}
++
++static int icna3512_init_sequence(struct panel_info *pinfo)
++{
++	struct mipi_dsi_device *dsi = pinfo->dsi;
++	struct device *dev = &dsi->dev;
++	int ret;
++
++	int cur_mode = icna3512_get_current_mode(pinfo);
++	int cur_vrefresh = drm_mode_vrefresh(&pinfo->desc->modes[cur_mode]);
++
++	mipi_dsi_dcs_write_seq(dsi, 0x9F, 0x01);
++	if (cur_vrefresh == 120) {
++
++		mipi_dsi_dcs_write_seq(dsi, 0xB3, 
++                   0x00, 0xE0, 0xA0, 0x10, 0xC8, 0x00, 0x02, 0x83, 
++                   0x00, 0x10, 0x14, 0x00, 0x00, 0xC3, 0x00, 0x10, 
++                   0x14, 0x00, 0x00, 0xE0, 0x10, 0x10, 0x9C, 0x00, 
++                   0x00, 0xE0, 0xA0, 0x10, 0xC8, 0x22, 0x18, 0x18, 
++                   0x18, 0x18, 0x18);
++        mipi_dsi_dcs_write_seq(dsi, 0x9F, 0x07);
++		mipi_dsi_dcs_write_seq(dsi, 0xB5, 
++                   0x04, 0x0C, 0x08, 0x0C, 0x04, 0x00, 0xC4);
++        mipi_dsi_dcs_write_seq(dsi, 0xD9, 
++                   0x88, 0x40, 0x40, 0x88, 0x40, 0x40, 0x00, 0xEB, 
++                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
++        mipi_dsi_dcs_write_seq(dsi, 0xCE, 
++                   0x01, 0x01, 0x01, 0x01, 0x04, 0x09, 0x2C);
++        mipi_dsi_dcs_write_seq(dsi, 0x48, 0x00);
++        mipi_dsi_dcs_write_seq(dsi, 0x48, 0x30);
++	}
++	else {
++        mipi_dsi_dcs_write_seq(dsi, 0xB3, 
++                   0x00, 0xE0, 0xA0, 0x10, 0xC8, 0x00);
++        mipi_dsi_dcs_write_seq(dsi, 0x9F, 0x07);
++        mipi_dsi_dcs_write_seq(dsi, 0xB2, 
++                   0x04, 0x18, 0x08, 0x0C, 0x02, 0x00, 0xC4);
++        mipi_dsi_dcs_write_seq(dsi, 0xD3, 
++                   0x88, 0x4A, 0x4A, 0x88, 0x4A, 0x4A, 0x00, 0xEB, 
++                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
++        mipi_dsi_dcs_write_seq(dsi, 0xCB, 
++                   0x01, 0x01, 0x01, 0x01, 0x04, 0x09, 0x2C);
++        mipi_dsi_dcs_write_seq(dsi, 0x48, 0x30);
++        mipi_dsi_dcs_write_seq(dsi, 0x48, 0x00);
++	}
++
++    mipi_dsi_dcs_write_seq(dsi, 0x9C, 0xA5, 0xA5);
++    mipi_dsi_dcs_write_seq(dsi, 0xFD, 0x5A, 0x5A);
++    mipi_dsi_dcs_write_seq(dsi, 0x48, 0x00);
++    mipi_dsi_dcs_write_seq(dsi, 0x53, 0xE0);
++    mipi_dsi_dcs_write_seq(dsi, 0x35, 0x00);
++
++	ret = mipi_dsi_dcs_exit_sleep_mode(dsi);
++	if (ret < 0) {
++		dev_err(dev, "failed to exit sleep mode: %d\n", ret);
++		return ret;
++	}
++
++    mipi_dsi_dcs_write_seq(dsi, 0x51, 0x0D, 0xBB);
++    mipi_dsi_dcs_write_seq(dsi, 0x9F, 0x0F);
++    mipi_dsi_dcs_write_seq(dsi, 0xCE, 0x22);
++
++	msleep(120);
++
++	ret = mipi_dsi_dcs_set_display_on(dsi);
++	if (ret < 0) {
++		dev_err(dev, "failed to set display on: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static const struct drm_display_mode icna3512_modes[] = {
++	{
++		/* 120Hz */
++		.clock = (1080 + 156 + 1 + 23) * (1920 + 412 + 1 + 15) * 120 / 1000,
++		.hdisplay = 1080,
++		.hsync_start = 1080 + 156,
++		.hsync_end = 1080 + 156 + 1,
++		.htotal = 1080 + 156 + 1 + 23,
++		.vdisplay = 1920,
++		.vsync_start = 1920 + 412,
++		.vsync_end = 1920 + 412 + 1,
++		.vtotal = 1920 + 412 + 1 + 15,
++	},
++	{
++		/* 60Hz */
++		.clock = (1080 + 156 + 1 + 23) * (1920 + 2760 + 1 + 15) * 60 / 1000,
++		.hdisplay = 1080,
++		.hsync_start = 1080 + 156,
++		.hsync_end = 1080 + 156 + 1,
++		.htotal = 1080 + 156 + 1 + 23,
++		.vdisplay = 1920,
++		.vsync_start = 1920 + 2760,
++		.vsync_end = 1920 + 2760 + 1,
++		.vtotal = 1920 + 2760 + 1 + 15,
++	}
++};
++
++static struct panel_desc icna3512_desc = {
++	.modes = icna3512_modes,
++	.num_modes = ARRAY_SIZE(icna3512_modes),
++	.width_mm = 160,
++	.height_mm = 89,
++	.bpc = 8,
++	.lanes = 4,
++	.format = MIPI_DSI_FMT_RGB888,
++	.mode_flags = MIPI_DSI_CLOCK_NON_CONTINUOUS | MIPI_DSI_MODE_LPM,
++	.init_sequence = icna3512_init_sequence,
++	.dsc = {
++		.dsc_version_major = 0x1,
++		.dsc_version_minor = 0x1,
++		.slice_height = 20,
++		.slice_width = 540,
++		.slice_count = 2,
++		.bits_per_component = 8,
++		.bits_per_pixel = 8 << 4,
++		.block_pred_enable = true,
++	},
++};
++
++static void icna3512_reset(struct panel_info *pinfo)
++{
++	gpiod_set_value_cansleep(pinfo->reset_gpio, 0);
++	usleep_range(10000, 11000);
++	gpiod_set_value_cansleep(pinfo->reset_gpio, 1);
++	usleep_range(10000, 11000);
++	gpiod_set_value_cansleep(pinfo->reset_gpio, 0);
++	usleep_range(10000, 11000);
++}
++
++static int icna3512_prepare(struct drm_panel *panel)
++{
++	struct panel_info *pinfo = to_panel_info(panel);
++	struct drm_dsc_picture_parameter_set pps;
++	int ret;
++
++    ret = regulator_bulk_enable(ARRAY_SIZE(pinfo->supplies), pinfo->supplies);
++	if (ret < 0) {
++		dev_err(panel->dev, "failed to enable regulators: %d\n", ret);
++		return ret;
++	}
++
++	icna3512_reset(pinfo);
++
++	ret = pinfo->desc->init_sequence(pinfo);
++	if (ret < 0) {
++        regulator_bulk_disable(ARRAY_SIZE(pinfo->supplies), pinfo->supplies);
++		dev_err(panel->dev, "failed to initialize panel: %d\n", ret);
++		return ret;
++	}
++
++	drm_dsc_pps_payload_pack(&pps, &pinfo->desc->dsc);
++
++	ret = mipi_dsi_picture_parameter_set(pinfo->dsi, &pps);
++	if (ret < 0) {
++		dev_err(panel->dev, "failed to transmit PPS: %d\n", ret);
++		return ret;
++	}
++
++	/* Not required, ICNA3512 has DSC always enabled. */
++	ret = mipi_dsi_compression_mode(pinfo->dsi, true);
++	if (ret < 0) {
++		dev_err(panel->dev, "failed to enable compression mode: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static int icna3512_disable(struct drm_panel *panel)
++{
++	struct panel_info *pinfo = to_panel_info(panel);
++	int ret;
++
++	ret = mipi_dsi_dcs_set_display_off(pinfo->dsi);
++	if (ret < 0)
++		dev_err(&pinfo->dsi->dev, "failed to set display off: %d\n", ret);
++
++	msleep(50);
++
++	ret = mipi_dsi_dcs_enter_sleep_mode(pinfo->dsi);
++	if (ret < 0)
++		dev_err(&pinfo->dsi->dev, "failed to enter sleep mode: %d\n", ret);
++
++	msleep(120);
++
++	return 0;
++}
++
++static int icna3512_unprepare(struct drm_panel *panel)
++{
++	struct panel_info *pinfo = to_panel_info(panel);
++
++	gpiod_set_value_cansleep(pinfo->reset_gpio, 1);
++    regulator_bulk_disable(ARRAY_SIZE(pinfo->supplies), pinfo->supplies);
++
++	return 0;
++}
++
++static void icna3512_remove(struct mipi_dsi_device *dsi)
++{
++	struct panel_info *pinfo = mipi_dsi_get_drvdata(dsi);
++	int ret;
++
++	ret = mipi_dsi_detach(pinfo->dsi);
++	if (ret < 0)
++		dev_err(&dsi->dev, "failed to detach from DSI host: %d\n", ret);
++
++	drm_panel_remove(&pinfo->panel);
++}
++
++static int icna3512_get_modes(struct drm_panel *panel,
++			       struct drm_connector *connector)
++{
++	struct panel_info *pinfo = to_panel_info(panel);
++	int i;
++
++	for (i = 0; i < pinfo->desc->num_modes; i++) {
++		const struct drm_display_mode *m = &pinfo->desc->modes[i];
++		struct drm_display_mode *mode;
++
++		mode = drm_mode_duplicate(connector->dev, m);
++		if (!mode) {
++			dev_err(panel->dev, "failed to add mode %ux%u@%u\n",
++				m->hdisplay, m->vdisplay, drm_mode_vrefresh(m));
++			return -ENOMEM;
++		}
++
++		mode->type = DRM_MODE_TYPE_DRIVER;
++		if (i == 0)
++			mode->type |= DRM_MODE_TYPE_PREFERRED;
++
++		drm_mode_set_name(mode);
++		drm_mode_probed_add(connector, mode);
++	}
++
++	connector->display_info.width_mm = pinfo->desc->width_mm;
++	connector->display_info.height_mm = pinfo->desc->height_mm;
++	connector->display_info.bpc = pinfo->desc->bpc;
++	pinfo->connector = connector;
++
++	return pinfo->desc->num_modes;
++}
++
++static enum drm_panel_orientation icna3512_get_orientation(struct drm_panel *panel)
++{
++	struct panel_info *pinfo = to_panel_info(panel);
++
++	return pinfo->orientation;
++}
++
++static const struct drm_panel_funcs icna3512_panel_funcs = {
++	.disable = icna3512_disable,
++	.prepare = icna3512_prepare,
++	.unprepare = icna3512_unprepare,
++	.get_modes = icna3512_get_modes,
++	.get_orientation = icna3512_get_orientation,
++};
++
++static int icna3512_bl_update_status(struct backlight_device *bl)
++{
++	struct mipi_dsi_device *dsi = bl_get_data(bl);
++	u16 brightness = backlight_get_brightness(bl);
++	int ret;
++
++	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
++
++	ret = mipi_dsi_dcs_set_display_brightness_large(dsi, brightness);
++	if (ret < 0)
++		return ret;
++
++	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
++
++	return 0;
++}
++
++static int icna3512_bl_get_brightness(struct backlight_device *bl)
++{
++	struct mipi_dsi_device *dsi = bl_get_data(bl);
++	u16 brightness;
++	int ret;
++
++	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
++
++	ret = mipi_dsi_dcs_get_display_brightness_large(dsi, &brightness);
++	if (ret < 0)
++		return ret;
++
++	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
++
++	return brightness;
++}
++
++static const struct backlight_ops icna3512_bl_ops = {
++	.update_status = icna3512_bl_update_status,
++	.get_brightness = icna3512_bl_get_brightness,
++};
++
++static struct backlight_device *icna3512_create_backlight(struct mipi_dsi_device *dsi)
++{
++	struct device *dev = &dsi->dev;
++	const struct backlight_properties props = {
++		.type = BACKLIGHT_RAW,
++		.brightness = 4096,
++		.max_brightness = 4096,
++	};
++
++	return devm_backlight_device_register(dev, dev_name(dev), dev, dsi,
++					      &icna3512_bl_ops, &props);
++}
++
++static int icna3512_probe(struct mipi_dsi_device *dsi)
++{
++	struct device *dev = &dsi->dev;
++	struct panel_info *pinfo;
++	int ret;
++
++	pinfo = devm_kzalloc(dev, sizeof(*pinfo), GFP_KERNEL);
++	if (!pinfo)
++		return -ENOMEM;
++
++	pinfo->supplies[0].supply = "blvdd";
++	pinfo->supplies[1].supply = "iovdd";
++	pinfo->supplies[2].supply = "vdd";
++
++	ret = devm_regulator_bulk_get(dev, ARRAY_SIZE(pinfo->supplies),
++				      pinfo->supplies);
++	if (ret < 0)
++		return dev_err_probe(dev, ret, "failed to get regulators\n");
++
++	pinfo->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_LOW);
++	if (IS_ERR(pinfo->reset_gpio))
++		return dev_err_probe(dev, PTR_ERR(pinfo->reset_gpio), "failed to get reset gpio\n");
++
++	pinfo->desc = (struct panel_desc *)of_device_get_match_data(dev);
++	if (!pinfo->desc)
++		return -ENODEV;
++
++	pinfo->dsi = dsi;
++	mipi_dsi_set_drvdata(dsi, pinfo);
++	drm_panel_init(&pinfo->panel, dev, &icna3512_panel_funcs, DRM_MODE_CONNECTOR_DSI);
++
++	ret = of_drm_get_panel_orientation(dev->of_node, &pinfo->orientation);
++	if (ret < 0) {
++		dev_err(dev, "%pOF: failed to get orientation %d\n", dev->of_node, ret);
++		return ret;
++	}
++
++	pinfo->panel.prepare_prev_first = true;
++
++    pinfo->panel.backlight = icna3512_create_backlight(dsi);
++	if (IS_ERR(pinfo->panel.backlight))
++		return dev_err_probe(dev, PTR_ERR(pinfo->panel.backlight),
++				     "Failed to create backlight\n");
++
++	drm_panel_add(&pinfo->panel);
++
++    pinfo->dsi->lanes = pinfo->desc->lanes;
++    pinfo->dsi->format = pinfo->desc->format;
++    pinfo->dsi->mode_flags = pinfo->desc->mode_flags;
++    pinfo->dsi->dsc = &pinfo->desc->dsc;
++
++    ret = mipi_dsi_attach(pinfo->dsi);
++    if (ret < 0){
++		dev_err_probe(dev, ret, "Failed to attach to DSI host\n");
++		drm_panel_remove(&pinfo->panel);
++        return ret;
++    }
++
++	return 0;
++}
++
++static const struct of_device_id icna3512_of_match[] = {
++	{
++		.compatible = "chipone,icna3512",
++		.data = &icna3512_desc,
++	},
++	{},
++};
++MODULE_DEVICE_TABLE(of, icna3512_of_match);
++
++static struct mipi_dsi_driver icna3512_driver = {
++	.probe = icna3512_probe,
++	.remove = icna3512_remove,
++	.driver = {
++		.name = "panel-chipone-icna3512",
++		.of_match_table = icna3512_of_match,
++	},
++};
++module_mipi_dsi_driver(icna3512_driver);
++
++MODULE_AUTHOR("Teguh Sobirin <teguh@sobir.in>");
++MODULE_DESCRIPTION("DRM driver for Chipone ICNA3512 based MIPI DSI panels");
++MODULE_LICENSE("GPL");
+\ No newline at end of file
+diff --git a/include/drm/drm_mipi_dsi.h b/include/drm/drm_mipi_dsi.h
+index 3aba7b380c8d..979bd874a9f6 100644
+--- a/include/drm/drm_mipi_dsi.h
++++ b/include/drm/drm_mipi_dsi.h
+@@ -421,6 +421,28 @@ void mipi_dsi_dcs_set_tear_off_multi(struct mipi_dsi_multi_context *ctx);
+ 		mipi_dsi_generic_write_multi(ctx, d, ARRAY_SIZE(d)); \
+ 	} while (0)
+ 
++/**
++ * mipi_dsi_dcs_write_seq - transmit a DCS command with payload
++ *
++ * This macro will print errors for you and will RETURN FROM THE CALLING
++ * FUNCTION (yes this is non-intuitive) upon error.
++ *
++ * Because of the non-intuitive return behavior, THIS MACRO IS DEPRECATED.
++ * Please replace calls of it with mipi_dsi_dcs_write_seq_multi().
++ *
++ * @dsi: DSI peripheral device
++ * @cmd: Command
++ * @seq: buffer containing data to be transmitted
++ */
++#define mipi_dsi_dcs_write_seq(dsi, cmd, seq...)                               \
++	do {                                                                   \
++		static const u8 d[] = { cmd, seq };                            \
++		int ret;                                                       \
++		ret = mipi_dsi_dcs_write_buffer_chatty(dsi, d, ARRAY_SIZE(d)); \
++		if (ret < 0)                                                   \
++			return ret;                                            \
++	} while (0)
++
+ /**
+  * mipi_dsi_dcs_write_seq_multi - transmit a DCS command with payload
+  *
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0004-leds-Add-driver-for-HEROIC-HTR3212.patch
+++ b/patch/kernel/archive/sm8550-6.19/0004-leds-Add-driver-for-HEROIC-HTR3212.patch
@@ -1,0 +1,359 @@
+From 25a2370f26467777de6d6aca3a4ab5b7365428bc Mon Sep 17 00:00:00 2001
+From: Teguh Sobirin <teguh@sobir.in>
+Date: Wed, 12 Feb 2025 15:29:16 +0800
+Subject: [PATCH 04/15] leds: Add driver for HEROIC HTR3212
+
+Signed-off-by: Teguh Sobirin <teguh@sobir.in>
+---
+ drivers/leds/Kconfig        |  10 ++
+ drivers/leds/Makefile       |   1 +
+ drivers/leds/leds-htr3212.c | 304 ++++++++++++++++++++++++++++++++++++
+ 3 files changed, 315 insertions(+)
+ create mode 100644 drivers/leds/leds-htr3212.c
+
+diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
+index 11e7282dc297..40fd48fc247d 100644
+--- a/drivers/leds/Kconfig
++++ b/drivers/leds/Kconfig
+@@ -214,6 +214,16 @@ config LEDS_EL15203000
+ 	  To compile this driver as a module, choose M here: the module
+ 	  will be called leds-el15203000.
+ 
++config LEDS_HTR3212
++	tristate "HEROIC HTR3212 LED driver"
++	depends on LEDS_CLASS && I2C
++	select REGMAP_I2C
++	help
++	  Driver for HEROIC HTR3212 LED controller.
++
++	  To compile this driver as a module, choose M here: the module
++	  will be called leds-htr3212.
++
+ config LEDS_TURRIS_OMNIA
+ 	tristate "LED support for CZ.NIC's Turris Omnia"
+ 	depends on LEDS_CLASS_MULTICOLOR
+diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
+index 9a0333ec1a86..36815a7526e9 100644
+--- a/drivers/leds/Makefile
++++ b/drivers/leds/Makefile
+@@ -33,6 +33,7 @@ obj-$(CONFIG_LEDS_DA9052)		+= leds-da9052.o
+ obj-$(CONFIG_LEDS_GPIO)			+= leds-gpio.o
+ obj-$(CONFIG_LEDS_GPIO_REGISTER)	+= leds-gpio-register.o
+ obj-$(CONFIG_LEDS_HP6XX)		+= leds-hp6xx.o
++obj-$(CONFIG_LEDS_HTR3212)		+= leds-htr3212.o
+ obj-$(CONFIG_LEDS_INTEL_SS4200)		+= leds-ss4200.o
+ obj-$(CONFIG_LEDS_IP30)			+= leds-ip30.o
+ obj-$(CONFIG_LEDS_IPAQ_MICRO)		+= leds-ipaq-micro.o
+diff --git a/drivers/leds/leds-htr3212.c b/drivers/leds/leds-htr3212.c
+new file mode 100644
+index 000000000000..0d1b45649a9c
+--- /dev/null
++++ b/drivers/leds/leds-htr3212.c
+@@ -0,0 +1,304 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Driver for HEROIC HTR3212 12-channel 8-bit PWM LED controller
++ *
++ * Copyright (c) 2024 Teguh Sobirin <teguh@sobir.in>
++ *
++ */
++
++#include <linux/delay.h>
++#include <linux/device.h>
++#include <linux/gpio/consumer.h>
++#include <linux/i2c.h>
++#include <linux/kernel.h>
++#include <linux/leds.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/regulator/consumer.h>
++
++#define HTR3212_CHANNELS 12
++#define HTR3212_ENABLE_BIT 1
++#define HTR3212_SHUTDOWN 0x00
++#define HTR3212_PWM_REGISTER_BASE 0x0d
++#define HTR3212_PWM_UPDATE 0x25
++#define HTR3212_LED_CONTROL_BASE 0x32
++#define HTR3212_GLOBAL_CONTROL 0x4a
++#define HTR3212_OUTPUT_FREQ 0x4b
++#define HTR3212_RESET 0x4f
++
++struct htr3212_priv;
++
++struct htr3212_led_data {
++	struct led_classdev cdev;
++	struct htr3212_priv *priv;
++	u8 channel;
++};
++
++struct htr3212_priv {
++	struct i2c_client *client;
++	unsigned int num_leds;
++	struct gpio_desc *sdb;
++	struct regulator *vdd;
++	struct htr3212_led_data leds[];
++};
++
++static int htr3212_write(struct htr3212_priv *priv, u8 reg, u8 val)
++{
++	int ret;
++
++	dev_dbg(&priv->client->dev, "writing register 0x%02X=0x%02X", reg, val);
++
++	ret =  i2c_smbus_write_byte_data(priv->client, reg, val);
++	if (ret) {
++		dev_err(&priv->client->dev,
++			"register write to 0x%02X failed (error %d)",
++			reg, ret);
++	}
++	return ret;
++}
++
++static int htr3212_brightness_set(struct led_classdev *led_cdev,
++				     enum led_brightness brightness)
++{
++	const struct htr3212_led_data *led_data =
++		container_of(led_cdev, struct htr3212_led_data, cdev);
++	u8 pwm_register_offset;
++	int ret;
++
++	dev_dbg(led_cdev->dev, "%s: %d\n", __func__, brightness);
++
++	pwm_register_offset = led_data->channel - 1;
++
++	ret = htr3212_write(led_data->priv,
++			       HTR3212_PWM_REGISTER_BASE + pwm_register_offset,
++			       brightness);
++	if (ret)
++		return ret;
++
++	return htr3212_write(led_data->priv, HTR3212_PWM_UPDATE, 0x00);
++}
++
++static int htr3212_reset_regs(struct htr3212_priv *priv)
++{
++	int ret;
++
++	ret = htr3212_write(priv, HTR3212_RESET, 0x00);
++	if (ret)
++		return ret;
++
++	return 0;
++}
++
++static int htr3212_init_regs(struct htr3212_priv *priv)
++{
++	int ret;
++
++	ret = htr3212_reset_regs(priv);
++	if (ret)
++		return ret;
++
++	u8 value = GENMASK(HTR3212_ENABLE_BIT, 0);
++	u8 num_regs = HTR3212_CHANNELS / HTR3212_ENABLE_BIT;
++
++	int i;
++
++	for (i = 0; i < num_regs; i++) {
++		ret = htr3212_write(priv,
++				HTR3212_LED_CONTROL_BASE + i, value);
++		if (ret)
++			return ret;
++	}
++
++	ret = htr3212_write(priv, HTR3212_SHUTDOWN, 0x01);
++	if (ret)
++		return ret;
++
++	ret = htr3212_write(priv, HTR3212_OUTPUT_FREQ, 0x01);
++	if (ret)
++		return ret;
++
++	ret = htr3212_write(priv, HTR3212_GLOBAL_CONTROL, 0x00);
++	if (ret)
++		return ret;
++
++	return 0;
++}
++
++static int htr3212_parse_child_dt(const struct device *dev,
++				     const struct device_node *child,
++				     struct htr3212_led_data *led_data)
++{
++	struct led_classdev *cdev = &led_data->cdev;
++	int ret = 0;
++	u32 reg;
++
++	ret = of_property_read_u32(child, "reg", &reg);
++	if (ret || reg < 1 || reg > HTR3212_CHANNELS) {
++		dev_err(dev,
++			"Child node %pOF does not have a valid reg property\n",
++			child);
++		return -EINVAL;
++	}
++	led_data->channel = reg;
++
++	cdev->brightness_set_blocking = htr3212_brightness_set;
++
++	if (!device_property_read_bool(dev, "always-on"))
++		cdev->flags |= LED_CORE_SUSPENDRESUME;
++
++	return 0;
++}
++
++static struct htr3212_led_data *htr3212_find_led_data(
++					struct htr3212_priv *priv,
++					u8 channel)
++{
++	size_t i;
++
++	for (i = 0; i < priv->num_leds; i++) {
++		if (priv->leds[i].channel == channel)
++			return &priv->leds[i];
++	}
++
++	return NULL;
++}
++
++static int htr3212_parse_dt(struct device *dev,
++			       struct htr3212_priv *priv)
++{
++	int ret = 0;
++
++	for_each_available_child_of_node_scoped(dev_of_node(dev), child) {
++		struct led_init_data init_data = {};
++		struct htr3212_led_data *led_data =
++			&priv->leds[priv->num_leds];
++		const struct htr3212_led_data *other_led_data;
++
++		led_data->priv = priv;
++
++		ret = htr3212_parse_child_dt(dev, child, led_data);
++		if (ret)
++			return ret;
++
++		other_led_data = htr3212_find_led_data(priv,
++							  led_data->channel);
++		if (other_led_data) {
++			dev_err(dev,
++				"Node %pOF 'reg' conflicts with another LED\n",
++				child);
++			return -EINVAL;
++		}
++
++		init_data.fwnode = of_fwnode_handle(child);
++
++		ret = devm_led_classdev_register_ext(dev, &led_data->cdev,
++						     &init_data);
++		if (ret) {
++			dev_err(dev, "Failed to register LED for %pOF: %d\n",
++				child, ret);
++			return ret;
++		}
++
++		priv->num_leds++;
++	}
++
++	return 0;
++}
++
++static const struct of_device_id of_htr3212_match[] = {
++	{ .compatible = "heroic,htr3212", },
++	{ /* sentinel */ }
++};
++
++MODULE_DEVICE_TABLE(of, of_htr3212_match);
++
++static int htr3212_probe(struct i2c_client *client)
++{
++	struct device *dev = &client->dev;
++	struct htr3212_priv *priv;
++	int count;
++	int ret = 0;
++
++	count = of_get_available_child_count(dev_of_node(dev));
++	if (!count)
++		return -EINVAL;
++
++	priv = devm_kzalloc(dev, struct_size(priv, leds, count),
++			    GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->sdb = devm_gpiod_get(dev, "sdb", GPIOD_OUT_HIGH);
++	if (IS_ERR(priv->sdb))
++		return PTR_ERR(priv->sdb);
++
++	priv->vdd = devm_regulator_get(dev, "vdd");
++	if (IS_ERR(priv->vdd)) {
++		ret = PTR_ERR(priv->vdd);
++		return ret;
++	}
++
++	ret = regulator_enable(priv->vdd);
++	if (ret < 0) {
++		return ret;
++	}
++
++	gpiod_set_value_cansleep(priv->sdb, 1);
++	usleep_range(10000, 11000);
++
++	priv->client = client;
++	i2c_set_clientdata(client, priv);
++
++	ret = htr3212_init_regs(priv);
++	if (ret)
++		goto err_disable_power;
++
++	ret = htr3212_parse_dt(dev, priv);
++	if (ret)
++		goto err_disable_power;
++
++	return 0;
++
++err_disable_power:
++	gpiod_set_value_cansleep(priv->sdb, 0);
++	regulator_disable(priv->vdd);
++	return ret;
++}
++
++static void htr3212_remove(struct i2c_client *client)
++{
++	struct htr3212_priv *priv = i2c_get_clientdata(client);
++	int ret;
++
++	ret = htr3212_reset_regs(priv);
++	if (ret)
++		dev_err(&client->dev, "Failed to reset registers on removal (%pe)\n",
++			ERR_PTR(ret));
++
++	gpiod_set_value_cansleep(priv->sdb, 0);
++
++	regulator_disable(priv->vdd);
++}
++
++static const struct i2c_device_id htr3212_id[] = {
++	{ "htr3212" },
++	{},
++};
++
++MODULE_DEVICE_TABLE(i2c, htr3212_id);
++
++static struct i2c_driver htr3212_driver = {
++	.driver = {
++		.name	= "htr3212",
++		.of_match_table = of_htr3212_match,
++	},
++	.probe		= htr3212_probe,
++	.remove		= htr3212_remove,
++	.id_table	= htr3212_id,
++};
++
++module_i2c_driver(htr3212_driver);
++
++MODULE_AUTHOR("Teguh Sobirin <teguh@sobir.in");
++MODULE_DESCRIPTION("HEROIC HTR3212 LED Driver");
++MODULE_LICENSE("GPL v2");
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0005-ASoC-qcom-sc8280xp-Add-support-for-Primary-I2S.patch
+++ b/patch/kernel/archive/sm8550-6.19/0005-ASoC-qcom-sc8280xp-Add-support-for-Primary-I2S.patch
@@ -1,0 +1,102 @@
+From 26ba9a00c745666d3b44fed99b9659909cd2cecd Mon Sep 17 00:00:00 2001
+From: Teguh Sobirin <teguh@sobir.in>
+Date: Fri, 23 Jan 2026 09:15:25 +0800
+Subject: [PATCH 05/15] ASoC: qcom: sc8280xp Add support for Primary I2S
+
+---
+ sound/soc/qcom/sc8280xp.c | 51 +++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 49 insertions(+), 2 deletions(-)
+
+diff --git a/sound/soc/qcom/sc8280xp.c b/sound/soc/qcom/sc8280xp.c
+index 7925aa3f63ba..2d24d8246604 100644
+--- a/sound/soc/qcom/sc8280xp.c
++++ b/sound/soc/qcom/sc8280xp.c
+@@ -2,6 +2,7 @@
+ // Copyright (c) 2022, Linaro Limited
+ 
+ #include <dt-bindings/sound/qcom,q6afe.h>
++#include <linux/clk.h>
+ #include <linux/module.h>
+ #include <linux/platform_device.h>
+ #include <sound/soc.h>
+@@ -20,6 +21,7 @@ struct sc8280xp_snd_data {
+ 	struct snd_soc_card *card;
+ 	struct snd_soc_jack jack;
+ 	struct snd_soc_jack dp_jack[8];
++	struct clk *i2s_clk;
+ 	bool jack_setup;
+ };
+ 
+@@ -67,6 +69,47 @@ static int sc8280xp_snd_init(struct snd_soc_pcm_runtime *rtd)
+ 	return qcom_snd_wcd_jack_setup(rtd, &data->jack, &data->jack_setup);
+ }
+ 
++static int sc8280xp_snd_startup(struct snd_pcm_substream *substream)
++{
++	unsigned int fmt = SND_SOC_DAIFMT_BP_FP;
++	unsigned int codec_dai_fmt = SND_SOC_DAIFMT_BC_FC | SND_SOC_DAIFMT_NB_NF | SND_SOC_DAIFMT_I2S;
++	struct snd_soc_pcm_runtime *rtd = substream->private_data;
++	struct sc8280xp_snd_data *pdata = snd_soc_card_get_drvdata(rtd->card);
++	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
++	struct snd_soc_dai *codec_dai = snd_soc_rtd_to_codec(rtd, 0);
++
++	switch (cpu_dai->id) {
++	case PRIMARY_MI2S_RX:
++		if (pdata->i2s_clk)
++			clk_prepare_enable(pdata->i2s_clk);
++		snd_soc_dai_set_fmt(cpu_dai, fmt);
++		snd_soc_dai_set_fmt(codec_dai, codec_dai_fmt);
++		break;
++	default:
++		break;
++	}
++
++	return qcom_snd_sdw_startup(substream);
++}
++
++static void sc8280xp_snd_shutdown(struct snd_pcm_substream *substream)
++{
++	struct snd_soc_pcm_runtime *rtd = snd_soc_substream_to_rtd(substream);
++	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
++	struct sc8280xp_snd_data *pdata = snd_soc_card_get_drvdata(rtd->card);
++
++	switch (cpu_dai->id) {
++	case PRIMARY_MI2S_RX:
++		if (pdata->i2s_clk)
++			clk_disable_unprepare(pdata->i2s_clk);
++		break;
++	default:
++		break;
++	}
++
++	qcom_snd_sdw_shutdown(substream);
++}
++
+ static int sc8280xp_be_hw_params_fixup(struct snd_soc_pcm_runtime *rtd,
+ 				     struct snd_pcm_hw_params *params)
+ {
+@@ -115,8 +158,8 @@ static int sc8280xp_snd_hw_free(struct snd_pcm_substream *substream)
+ }
+ 
+ static const struct snd_soc_ops sc8280xp_be_ops = {
+-	.startup = qcom_snd_sdw_startup,
+-	.shutdown = qcom_snd_sdw_shutdown,
++	.startup = sc8280xp_snd_startup,
++	.shutdown = sc8280xp_snd_shutdown,
+ 	.hw_free = sc8280xp_snd_hw_free,
+ 	.prepare = sc8280xp_snd_prepare,
+ };
+@@ -158,6 +201,10 @@ static int sc8280xp_platform_probe(struct platform_device *pdev)
+ 	if (ret)
+ 		return ret;
+ 
++	data->i2s_clk = devm_clk_get_optional(dev, "i2s_clk");
++	if (IS_ERR(data->i2s_clk))
++		return dev_err_probe(dev, PTR_ERR(data->i2s_clk), "unable to get i2s clock\n");
++
+ 	card->driver_name = of_device_get_match_data(dev);
+ 	sc8280xp_add_be_ops(card);
+ 	return devm_snd_soc_register_card(dev, card);
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0006-dt-bindings-mmc-qcom-Document-level-shifter-flag-for.patch
+++ b/patch/kernel/archive/sm8550-6.19/0006-dt-bindings-mmc-qcom-Document-level-shifter-flag-for.patch
@@ -1,0 +1,39 @@
+From 3c06fbe76574a02fd4c92ddf2501d9aba46636de Mon Sep 17 00:00:00 2001
+From: Sarthak Garg <quic_sartgarg@quicinc.com>
+Date: Thu, 7 Nov 2024 13:35:03 +0530
+Subject: [PATCH 06/15] dt-bindings: mmc: qcom: Document level shifter flag for
+ SD card
+
+Introduce a flag to indicate if the Qualcomm platform has a level
+shifter for SD cards. With level shifter addition some extra delay is
+seen on RX data path leading to CRC errors. To compensate these delays
+and avoid CRC errors below things needs to be done:
+
+1) Enable tuning for SDR50 mode
+2) Limit HS mode frequency to 37.5MHz from 50MHz
+
+Add this flag for all targets with a level shifter to handle these
+issues for SD card.
+
+Signed-off-by: Sarthak Garg <quic_sartgarg@quicinc.com>
+---
+ Documentation/devicetree/bindings/mmc/sdhci-msm.yaml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/mmc/sdhci-msm.yaml b/Documentation/devicetree/bindings/mmc/sdhci-msm.yaml
+index 938be8228d66..fd2eb4302210 100644
+--- a/Documentation/devicetree/bindings/mmc/sdhci-msm.yaml
++++ b/Documentation/devicetree/bindings/mmc/sdhci-msm.yaml
+@@ -140,6 +140,9 @@ properties:
+     $ref: /schemas/types.yaml#/definitions/uint32
+     description: platform specific settings for DLL_CONFIG reg.
+ 
++  qcom,use-level-shifter:
++    description: Flag to indicate if platform has level shifter for SD card.
++
+   iommus:
+     minItems: 1
+     maxItems: 8
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0007-clk-qcom-gcc-sm8550-Keep-UFS-PHY-GDSCs-ALWAYS_ON.patch
+++ b/patch/kernel/archive/sm8550-6.19/0007-clk-qcom-gcc-sm8550-Keep-UFS-PHY-GDSCs-ALWAYS_ON.patch
@@ -1,0 +1,53 @@
+From 73f4b970bdb85ffa5c5c2f6fa74aab02664c8ff7 Mon Sep 17 00:00:00 2001
+From: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+Date: Thu, 7 Nov 2024 11:58:09 +0000
+Subject: [PATCH 07/15] clk: qcom: gcc-sm8550: Keep UFS PHY GDSCs ALWAYS_ON
+
+Starting from SM8550, UFS PHY GDSCs doesn't support hardware retention. So
+using RETAIN_FF_ENABLE is wrong. Moreover, without ALWAYS_ON flag, GDSCs
+will get powered down during suspend, causing the UFS PHY to loose its
+state. And this will lead to below UFS error during resume as observed on
+SM8550-QRD:
+
+ufshcd-qcom 1d84000.ufs: ufshcd_uic_hibern8_exit: hibern8 exit failed. ret = 5
+ufshcd-qcom 1d84000.ufs: __ufshcd_wl_resume: hibern8 exit failed 5
+ufs_device_wlun 0:0:0:49488: ufshcd_wl_resume failed: 5
+ufs_device_wlun 0:0:0:49488: PM: dpm_run_callback(): scsi_bus_resume+0x0/0x84 returns 5
+ufs_device_wlun 0:0:0:49488: PM: failed to resume async: error 5
+
+Cc: stable@vger.kernel.org # 6.8
+Fixes: 1fe8273c8d40 ("clk: qcom: gcc-sm8550: Add the missing RETAIN_FF_ENABLE GDSC flag")
+Reported-by: Neil Armstrong <neil.armstrong@linaro.org>
+Suggested-by: Nitin Rawat <quic_nitirawa@quicinc.com>
+Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+Tested-by: Neil Armstrong <neil.armstrong@linaro.org> # on SM8550-QRD
+Tested-by: Neil Armstrong <neil.armstrong@linaro.org> # on SM8550-HDK
+---
+ drivers/clk/qcom/gcc-sm8550.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/clk/qcom/gcc-sm8550.c b/drivers/clk/qcom/gcc-sm8550.c
+index 36a5b7de5b55..245e4de93396 100644
+--- a/drivers/clk/qcom/gcc-sm8550.c
++++ b/drivers/clk/qcom/gcc-sm8550.c
+@@ -3046,7 +3046,7 @@ static struct gdsc ufs_phy_gdsc = {
+ 		.name = "ufs_phy_gdsc",
+ 	},
+ 	.pwrsts = PWRSTS_OFF_ON,
+-	.flags = POLL_CFG_GDSCR | RETAIN_FF_ENABLE,
++	.flags = POLL_CFG_GDSCR | ALWAYS_ON,
+ };
+ 
+ static struct gdsc ufs_mem_phy_gdsc = {
+@@ -3055,7 +3055,7 @@ static struct gdsc ufs_mem_phy_gdsc = {
+ 		.name = "ufs_mem_phy_gdsc",
+ 	},
+ 	.pwrsts = PWRSTS_OFF_ON,
+-	.flags = POLL_CFG_GDSCR | RETAIN_FF_ENABLE,
++	.flags = POLL_CFG_GDSCR | ALWAYS_ON,
+ };
+ 
+ static struct gdsc usb30_prim_gdsc = {
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0008-drm-panel-Add-WIP-panel-driver-for-AYN-Odin-2.patch
+++ b/patch/kernel/archive/sm8550-6.19/0008-drm-panel-Add-WIP-panel-driver-for-AYN-Odin-2.patch
@@ -1,0 +1,307 @@
+From b3fb30965e8b3ed99f6dae82f2e33dd96ed369be Mon Sep 17 00:00:00 2001
+From: Xilin Wu <wuxilin123@gmail.com>
+Date: Wed, 11 Feb 2026 20:04:08 +0800
+Subject: [PATCH 08/15] drm/panel: Add WIP panel driver for AYN Odin 2
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ drivers/gpu/drm/panel/Kconfig                 |  11 +
+ drivers/gpu/drm/panel/Makefile                |   1 +
+ .../gpu/drm/panel/panel-synaptics-td4328.c    | 246 ++++++++++++++++++
+ 3 files changed, 258 insertions(+)
+ create mode 100644 drivers/gpu/drm/panel/panel-synaptics-td4328.c
+
+diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
+index 3c0d92cf48e2..1a658c6179a2 100644
+--- a/drivers/gpu/drm/panel/Kconfig
++++ b/drivers/gpu/drm/panel/Kconfig
+@@ -1109,6 +1109,16 @@ config DRM_PANEL_SYNAPTICS_TDDI
+ 	  namesake, with varying resolutions and data lanes. They also have a
+ 	  built-in LED backlight and a touch controller.
+ 
++config DRM_PANEL_SYNAPTICS_TD4328
++	tristate "Synaptics TD4328-based panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_KMS_HELPER
++	help
++	  Say Y if you want to enable support for panels based on the
++	  Synaptics TD4328 controller.
++
+ config DRM_PANEL_TDO_TL070WSH30
+ 	tristate "TDO TL070WSH30 DSI panel"
+ 	depends on OF
+@@ -1221,4 +1231,5 @@ config DRM_PANEL_XINPENG_XPP055C272
+ 	  Say Y here if you want to enable support for the Xinpeng
+ 	  XPP055C272 controller for 720x1280 LCD panels with MIPI/RGB/SPI
+ 	  system interfaces.
++
+ endmenu
+diff --git a/drivers/gpu/drm/panel/Makefile b/drivers/gpu/drm/panel/Makefile
+index 7f3ca67bae75..f8b4ac030e52 100644
+--- a/drivers/gpu/drm/panel/Makefile
++++ b/drivers/gpu/drm/panel/Makefile
+@@ -104,6 +104,7 @@ obj-$(CONFIG_DRM_PANEL_SITRONIX_ST7703) += panel-sitronix-st7703.o
+ obj-$(CONFIG_DRM_PANEL_SITRONIX_ST7789V) += panel-sitronix-st7789v.o
+ obj-$(CONFIG_DRM_PANEL_SUMMIT) += panel-summit.o
+ obj-$(CONFIG_DRM_PANEL_SYNAPTICS_R63353) += panel-synaptics-r63353.o
++obj-$(CONFIG_DRM_PANEL_SYNAPTICS_TD4328) += panel-synaptics-td4328.o
+ obj-$(CONFIG_DRM_PANEL_SYNAPTICS_TDDI) += panel-synaptics-tddi.o
+ obj-$(CONFIG_DRM_PANEL_SONY_ACX565AKM) += panel-sony-acx565akm.o
+ obj-$(CONFIG_DRM_PANEL_SONY_TD4353_JDI) += panel-sony-td4353-jdi.o
+diff --git a/drivers/gpu/drm/panel/panel-synaptics-td4328.c b/drivers/gpu/drm/panel/panel-synaptics-td4328.c
+new file mode 100644
+index 000000000000..3e1d085fbfcf
+--- /dev/null
++++ b/drivers/gpu/drm/panel/panel-synaptics-td4328.c
+@@ -0,0 +1,246 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree.
++ * Copyright (c) 2024 Xilin Wu <wuxilin123@gmail.com>
++ * Copyright (c) 2024 Junhao Xie <bigfoot@classfun.cn>
++ */
++
++#include <linux/delay.h>
++#include <linux/gpio/consumer.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/regulator/consumer.h>
++
++#include <drm/drm_mipi_dsi.h>
++#include <drm/drm_modes.h>
++#include <drm/drm_panel.h>
++#include <drm/drm_probe_helper.h>
++
++struct td4328 {
++	struct drm_panel panel;
++	struct mipi_dsi_device *dsi;
++	struct regulator_bulk_data supplies[2];
++	struct gpio_desc *reset_gpio;
++};
++
++static inline struct td4328 *to_td4328(struct drm_panel *panel)
++{
++	return container_of(panel, struct td4328, panel);
++}
++
++static void td4328_reset(struct td4328 *ctx)
++{
++	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
++	usleep_range(10000, 11000);
++	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
++	usleep_range(10000, 11000);
++	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
++	usleep_range(10000, 11000);
++}
++
++static int td4328_on(struct td4328 *ctx)
++{
++	struct mipi_dsi_device *dsi = ctx->dsi;
++	struct device *dev = &dsi->dev;
++	int ret;
++
++	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
++
++	mipi_dsi_dcs_write_seq(dsi, 0xb0, 0x00);
++	mipi_dsi_dcs_write_seq(dsi, 0xb3, 0x31);
++	mipi_dsi_dcs_write_seq(dsi, 0xd6, 0x00);
++
++	ret = mipi_dsi_dcs_exit_sleep_mode(dsi);
++	if (ret < 0) {
++		dev_err(dev, "Failed to exit sleep mode: %d\n", ret);
++		return ret;
++	}
++	msleep(70);
++
++	ret = mipi_dsi_dcs_set_display_on(dsi);
++	if (ret < 0) {
++		dev_err(dev, "Failed to set display on: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static int td4328_off(struct td4328 *ctx)
++{
++	struct mipi_dsi_device *dsi = ctx->dsi;
++	struct device *dev = &dsi->dev;
++	int ret;
++
++	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
++
++	ret = mipi_dsi_dcs_set_display_off(dsi);
++	if (ret < 0) {
++		dev_err(dev, "Failed to set display off: %d\n", ret);
++		return ret;
++	}
++	msleep(50);
++
++	ret = mipi_dsi_dcs_enter_sleep_mode(dsi);
++	if (ret < 0) {
++		dev_err(dev, "Failed to enter sleep mode: %d\n", ret);
++		return ret;
++	}
++	msleep(120);
++
++	return 0;
++}
++
++static int td4328_prepare(struct drm_panel *panel)
++{
++	struct td4328 *ctx = to_td4328(panel);
++	struct device *dev = &ctx->dsi->dev;
++	int ret;
++
++	ret = regulator_bulk_enable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
++	if (ret < 0) {
++		dev_err(dev, "Failed to enable regulators: %d\n", ret);
++		return ret;
++	}
++
++	td4328_reset(ctx);
++
++	ret = td4328_on(ctx);
++	if (ret < 0) {
++		dev_err(dev, "Failed to initialize panel: %d\n", ret);
++		gpiod_set_value_cansleep(ctx->reset_gpio, 1);
++		regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
++		return ret;
++	}
++
++	return 0;
++}
++
++static int td4328_unprepare(struct drm_panel *panel)
++{
++	struct td4328 *ctx = to_td4328(panel);
++	struct device *dev = &ctx->dsi->dev;
++	int ret;
++
++	ret = td4328_off(ctx);
++	if (ret < 0)
++		dev_err(dev, "Failed to un-initialize panel: %d\n", ret);
++
++	regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
++
++	return 0;
++}
++
++static const struct drm_display_mode td4328_mode = {
++	.clock = (1080 + 93 + 1 + 47) * (1920 + 40 + 2 + 60) * 60 / 1000,
++	.hdisplay = 1080,
++	.hsync_start = 1080 + 93,
++	.hsync_end = 1080 + 93 + 1,
++	.htotal = 1080 + 93 + 1 + 47,
++	.vdisplay = 1920,
++	.vsync_start = 1920 + 40,
++	.vsync_end = 1920 + 40 + 2,
++	.vtotal = 1920 + 40 + 2 + 60,
++	.width_mm = 75,
++	.height_mm = 133,
++	.type = DRM_MODE_TYPE_DRIVER,
++};
++
++static int td4328_get_modes(struct drm_panel *panel,
++			 struct drm_connector *connector)
++{
++	return drm_connector_helper_get_modes_fixed(connector, &td4328_mode);
++}
++
++static enum drm_panel_orientation td4328_get_orientation(struct drm_panel *panel)
++{
++	return DRM_MODE_PANEL_ORIENTATION_RIGHT_UP;
++}
++
++static const struct drm_panel_funcs td4328_panel_funcs = {
++	.prepare = td4328_prepare,
++	.unprepare = td4328_unprepare,
++	.get_modes = td4328_get_modes,
++	.get_orientation = td4328_get_orientation,
++};
++
++static int td4328_probe(struct mipi_dsi_device *dsi)
++{
++	struct device *dev = &dsi->dev;
++	struct td4328 *ctx;
++	int ret;
++
++	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
++	if (!ctx)
++		return -ENOMEM;
++
++	ctx->supplies[0].supply = "vddio";
++	ctx->supplies[1].supply = "vdd";
++	ret = devm_regulator_bulk_get(dev, ARRAY_SIZE(ctx->supplies),
++				      ctx->supplies);
++	if (ret < 0)
++		return dev_err_probe(dev, ret, "Failed to get regulators\n");
++
++	ctx->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_LOW);
++	if (IS_ERR(ctx->reset_gpio))
++		return dev_err_probe(dev, PTR_ERR(ctx->reset_gpio),
++				     "Failed to get reset-gpios\n");
++
++	ctx->dsi = dsi;
++	mipi_dsi_set_drvdata(dsi, ctx);
++
++	dsi->lanes = 4;
++	dsi->format = MIPI_DSI_FMT_RGB888;
++	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
++			  MIPI_DSI_CLOCK_NON_CONTINUOUS;
++
++	drm_panel_init(&ctx->panel, dev, &td4328_panel_funcs,
++		       DRM_MODE_CONNECTOR_DSI);
++	ctx->panel.prepare_prev_first = true;
++
++	ret = drm_panel_of_backlight(&ctx->panel);
++	if (ret)
++		return dev_err_probe(dev, ret, "Failed to get backlight\n");
++
++	drm_panel_add(&ctx->panel);
++
++	ret = mipi_dsi_attach(dsi);
++	if (ret < 0) {
++		dev_err_probe(dev, ret, "Failed to attach to DSI host\n");
++		drm_panel_remove(&ctx->panel);
++		return ret;
++	}
++
++	return 0;
++}
++
++static void td4328_remove(struct mipi_dsi_device *dsi)
++{
++	struct td4328 *ctx = mipi_dsi_get_drvdata(dsi);
++	int ret;
++
++	ret = mipi_dsi_detach(dsi);
++	if (ret < 0)
++		dev_err(&dsi->dev, "Failed to detach from DSI host: %d\n", ret);
++
++	drm_panel_remove(&ctx->panel);
++}
++
++static const struct of_device_id td4328_of_match[] = {
++	{ .compatible = "syna,td4328" },
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, td4328_of_match);
++
++static struct mipi_dsi_driver td4328_driver = {
++	.probe = td4328_probe,
++	.remove = td4328_remove,
++	.driver = {
++		.name = "panel-td4328",
++		.of_match_table = td4328_of_match,
++	},
++};
++module_mipi_dsi_driver(td4328_driver);
++
++MODULE_DESCRIPTION("DRM driver for td4328-equipped DSI panels");
++MODULE_LICENSE("GPL");
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0009-arm64-dts-qcom-Added-pmk8550-pwm-support.patch
+++ b/patch/kernel/archive/sm8550-6.19/0009-arm64-dts-qcom-Added-pmk8550-pwm-support.patch
@@ -1,0 +1,33 @@
+From 8d061810a0cbed2a1a68f48f2e3c8151250e345c Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Fri, 23 Jan 2026 09:24:14 +0800
+Subject: [PATCH 09/15] arm64: dts: qcom: Added pmk8550 pwm support
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ arch/arm64/boot/dts/qcom/pmk8550.dtsi | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/pmk8550.dtsi b/arch/arm64/boot/dts/qcom/pmk8550.dtsi
+index 583f61fc16ad..3049eb6b46d7 100644
+--- a/arch/arm64/boot/dts/qcom/pmk8550.dtsi
++++ b/arch/arm64/boot/dts/qcom/pmk8550.dtsi
+@@ -73,5 +73,15 @@ pmk8550_gpios: gpio@b800 {
+ 			interrupt-controller;
+ 			#interrupt-cells = <2>;
+ 		};
++
++		pmk8550_pwm: pwm {
++			compatible = "qcom,pmk8550-pwm";
++
++			#address-cells = <1>;
++			#size-cells = <0>;
++			#pwm-cells = <2>;
++
++			status = "disabled";
++		};
+ 	};
+ };
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0010-drivers-power-Fix-name-for-sc8280xp-battery.patch
+++ b/patch/kernel/archive/sm8550-6.19/0010-drivers-power-Fix-name-for-sc8280xp-battery.patch
@@ -1,0 +1,35 @@
+From 59cc95913fc1917736eeb52b823eb20d86d37911 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Fri, 23 Jan 2026 09:31:36 +0800
+Subject: [PATCH 10/15] drivers: power: Fix name for sc8280xp battery
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ drivers/power/supply/qcom_battmgr.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/power/supply/qcom_battmgr.c b/drivers/power/supply/qcom_battmgr.c
+index 80572ee945b4..644b0f5b192e 100644
+--- a/drivers/power/supply/qcom_battmgr.c
++++ b/drivers/power/supply/qcom_battmgr.c
+@@ -818,7 +818,7 @@ static const enum power_supply_property sc8280xp_bat_props[] = {
+ };
+ 
+ static const struct power_supply_desc sc8280xp_bat_psy_desc = {
+-	.name = "qcom-battmgr-bat",
++	.name = "battery",
+ 	.type = POWER_SUPPLY_TYPE_BATTERY,
+ 	.properties = sc8280xp_bat_props,
+ 	.num_properties = ARRAY_SIZE(sc8280xp_bat_props),
+@@ -887,7 +887,7 @@ static const enum power_supply_property sm8350_bat_props[] = {
+ };
+ 
+ static const struct power_supply_desc sm8350_bat_psy_desc = {
+-	.name = "qcom-battmgr-bat",
++	.name = "battery",
+ 	.type = POWER_SUPPLY_TYPE_BATTERY,
+ 	.properties = sm8350_bat_props,
+ 	.num_properties = ARRAY_SIZE(sm8350_bat_props),
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0011-HACK-fix-usb-boot-hang.patch
+++ b/patch/kernel/archive/sm8550-6.19/0011-HACK-fix-usb-boot-hang.patch
@@ -1,0 +1,37 @@
+From c01af8a09fe7d53ba665cea0020f881ba5fbd114 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Fri, 23 Jan 2026 09:32:30 +0800
+Subject: [PATCH 11/15] HACK: fix usb boot hang
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ drivers/usb/host/pci-quirks.c | 13 -------------
+ 1 file changed, 13 deletions(-)
+
+diff --git a/drivers/usb/host/pci-quirks.c b/drivers/usb/host/pci-quirks.c
+index 0404489c2f6a..12e1167e2d25 100644
+--- a/drivers/usb/host/pci-quirks.c
++++ b/drivers/usb/host/pci-quirks.c
+@@ -1226,19 +1226,6 @@ static void quirk_usb_handoff_xhci(struct pci_dev *pdev)
+ 
+ 	op_reg_base = base + XHCI_HC_LENGTH(readl(base));
+ 
+-	/* Wait for the host controller to be ready before writing any
+-	 * operational or runtime registers.  Wait 5 seconds and no more.
+-	 */
+-	timeout = handshake(op_reg_base + XHCI_STS_OFFSET, XHCI_STS_CNR, 0,
+-			5000000, 10);
+-	/* Assume a buggy HC and start HC initialization anyway */
+-	if (timeout) {
+-		val = readl(op_reg_base + XHCI_STS_OFFSET);
+-		dev_warn(&pdev->dev,
+-			 "xHCI HW not ready after 5 sec (HC bug?) status = 0x%x\n",
+-			 val);
+-	}
+-
+ 	/* Send the halt and disable interrupts command */
+ 	val = readl(op_reg_base + XHCI_CMD_OFFSET);
+ 	val &= ~(XHCI_CMD_RUN | XHCI_IRQS);
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0012-drivers-use-soc-serial-for-wifi-and-bluetooth.patch
+++ b/patch/kernel/archive/sm8550-6.19/0012-drivers-use-soc-serial-for-wifi-and-bluetooth.patch
@@ -1,0 +1,303 @@
+From d17dd18d2b8ea1a7340673b54a7c7a926ae0ee83 Mon Sep 17 00:00:00 2001
+From: spycat88 <spycat88@users.noreply.github.com>
+Date: Thu, 23 Jan 2025 15:18:25 +0000
+Subject: [PATCH 12/15] drivers: use soc serial for wifi and bluetooth
+
+---
+ drivers/bluetooth/btqca.c             | 96 ++++++++++++++++++++++++--
+ drivers/net/wireless/ath/ath12k/mac.c | 99 ++++++++++++++++++++++++++-
+ drivers/soc/qcom/socinfo.c            | 10 +++
+ 3 files changed, 198 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/bluetooth/btqca.c b/drivers/bluetooth/btqca.c
+index 7c958d6065be..848d4e43866a 100644
+--- a/drivers/bluetooth/btqca.c
++++ b/drivers/bluetooth/btqca.c
+@@ -12,6 +12,74 @@
+ #include <net/bluetooth/hci_core.h>
+ 
+ #include "btqca.h"
++#include <linux/ctype.h>
++
++extern const char *qcom_serial_number;
++
++/**
++ * generate_bdaddr_from_serial - Generates a BD_ADDR using the serial number
++ * @bdaddr: Pointer to bdaddr_t structure to populate
++ *
++ * This function sets the first 3 bytes to 00:03:7F and the last 3 bytes
++ * are derived from the last 6 characters of qcom_serial_number in reversed order.
++ *
++ * Returns 0 on success, negative error code on failure.
++ */
++static int generate_bdaddr_from_serial(struct hci_dev *hdev, bdaddr_t *bdaddr)
++{
++	size_t serial_len;
++	const char *serial = qcom_serial_number;
++	char last6[7] = {0}; // 6 characters + null terminator
++	int i;
++	int ret;
++
++	if (!serial) {
++		bt_dev_err(hdev, "qcom_serial_number is NULL");
++		return -EINVAL;
++	}
++
++	serial_len = strlen(serial);
++	if (serial_len < 6) {
++		bt_dev_err(hdev, "qcom_serial_number is too short: %zu characters", serial_len);
++		return -EINVAL;
++	}
++
++	// Extract the last 6 characters
++	strncpy(last6, serial + serial_len - 6, 6);
++
++	// Initialize the first 3 bytes
++	bdaddr->b[5] = 0x00;
++	bdaddr->b[4] = 0x03;
++	bdaddr->b[3] = 0x7F;
++
++	// Convert the last 6 characters into 3 bytes in reversed order
++	for (i = 0; i < 3; i++) {
++		char byte_str[3] = {0};
++		u8 byte_val;
++
++		byte_str[0] = last6[i * 2];
++		byte_str[1] = last6[i * 2 + 1];
++
++		if (!isxdigit(byte_str[0]) || !isxdigit(byte_str[1])) {
++			bt_dev_err(hdev, "Invalid hex characters in serial number: %c%c",
++					   byte_str[0], byte_str[1]);
++			return -EINVAL;
++		}
++
++		ret = kstrtou8(byte_str, 16, &byte_val);
++		if (ret < 0) {
++			bt_dev_err(hdev, "Failed to convert hex string to u8: %c%c",
++					   byte_str[0], byte_str[1]);
++			return ret;
++		}
++
++		bdaddr->b[i] = byte_val; // Assign to bytes 0,1,2 (reversed order)
++	}
++
++	bt_dev_info(hdev, "Generated BD_ADDR: %pMR", bdaddr);
++
++	return 0;
++}
+ 
+ int qca_read_soc_version(struct hci_dev *hdev, struct qca_btsoc_version *ver,
+ 			 enum qca_btsoc_type soc_type)
+@@ -714,7 +782,7 @@ int qca_set_bdaddr_rome(struct hci_dev *hdev, const bdaddr_t *bdaddr)
+ }
+ EXPORT_SYMBOL_GPL(qca_set_bdaddr_rome);
+ 
+-static int qca_check_bdaddr(struct hci_dev *hdev, const struct qca_fw_config *config)
++static int __maybe_unused qca_check_bdaddr(struct hci_dev *hdev, const struct qca_fw_config *config)
+ {
+ 	struct hci_rp_read_bd_addr *bda;
+ 	struct sk_buff *skb;
+@@ -790,6 +858,7 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
+ 	u8 rom_ver = 0;
+ 	u32 soc_ver;
+ 	u16 boardid = 0;
++	bdaddr_t generated_bdaddr;
+ 
+ 	bt_dev_dbg(hdev, "QCA setup on UART");
+ 
+@@ -993,9 +1062,28 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
+ 		break;
+ 	}
+ 
+-	err = qca_check_bdaddr(hdev, &config);
+-	if (err)
+-		return err;
++	/* Generate BD_ADDR from qcom_serial_number */
++	err = generate_bdaddr_from_serial(hdev, &generated_bdaddr);
++	if (err) {
++		bt_dev_warn(hdev, "Failed to generate BD_ADDR from serial number, falling back to NVM");
++		err = qca_check_bdaddr(hdev, &config);
++		if (err)
++			return err;
++	} else {
++		/* Set the generated BD_ADDR */
++		err = qca_set_bdaddr(hdev, &generated_bdaddr);
++		if (err) {
++			bt_dev_warn(hdev, "Failed to set generated BD_ADDR, falling back to NVM");
++			err = qca_check_bdaddr(hdev, &config);
++			if (err)
++				return err;
++		} else {
++			/* Update hdev->public_addr and hdev->bdaddr */
++			bacpy(&hdev->public_addr, &generated_bdaddr);
++			bacpy(&hdev->bdaddr, &generated_bdaddr);
++			bt_dev_info(hdev, "BD_ADDR set to %pMR", &hdev->public_addr);
++		}
++	}
+ 
+ 	bt_dev_info(hdev, "QCA setup on UART is completed");
+ 
+diff --git a/drivers/net/wireless/ath/ath12k/mac.c b/drivers/net/wireless/ath/ath12k/mac.c
+index 63684ff9332d..903a6b0efc8f 100644
+--- a/drivers/net/wireless/ath/ath12k/mac.c
++++ b/drivers/net/wireless/ath/ath12k/mac.c
+@@ -162,6 +162,91 @@ static const struct ieee80211_channel ath12k_6ghz_channels[] = {
+ 	CHAN6G(233, 7115, 0),
+ };
+ 
++extern const char *qcom_serial_number;
++
++/* Define a small struct for storing a 6-byte MAC address array */
++struct macaddr_t {
++	u8 b[ETH_ALEN];
++};
++
++/* Define a static, predefined MAC_ADDR structure */
++static const struct macaddr_t static_macaddr = {
++	.b = { 0x00, 0x03, 0x7F, 0x11, 0x22, 0x33 }
++};
++
++/**
++ * generate_macaddr_from_serial - Generates a MAC_ADDR using the serial number
++ * @macaddr: Pointer to macaddr_t structure to populate
++ *
++ * This function sets the first 3 bytes to 00:03:7F and the last 3 bytes
++ * are derived from the last 6 characters of qcom_serial_number.
++ *
++ * Returns 0 on success, negative error code on failure.
++ */
++static int generate_macaddr_from_serial(struct ath12k *ar, struct macaddr_t *macaddr)
++{
++	size_t serial_len;
++	const char *serial = qcom_serial_number;
++	char last6[7] = {0}; // 6 characters + null terminator
++	int i;
++	int ret;
++
++	if (!serial) {
++		ath12k_err(ar->ab, "qcom_serial_number is NULL");
++		return -EINVAL;
++	}
++
++	serial_len = strlen(serial);
++	if (serial_len < 6) {
++		ath12k_err(ar->ab, "qcom_serial_number is too short: %zu characters", serial_len);
++		return -EINVAL;
++	}
++
++	// Extract the last 6 characters
++	strncpy(last6, serial + serial_len - 6, 6);
++
++	// Initialize the first 3 bytes
++	macaddr->b[5] = 0x00;
++	macaddr->b[4] = 0x03;
++	macaddr->b[3] = 0x7F;
++
++	// Convert the last 6 characters into 3 bytes
++	for (i = 0; i < 3; i++) {
++		char byte_str[3] = {0};
++		u8 byte_val;
++
++		byte_str[0] = last6[i * 2];
++		byte_str[1] = last6[i * 2 + 1];
++
++		if (!isxdigit(byte_str[0]) || !isxdigit(byte_str[1])) {
++			ath12k_err(ar->ab, "Invalid hex characters in serial number: %c%c",
++					   byte_str[0], byte_str[1]);
++			return -EINVAL;
++		}
++
++		ret = kstrtou8(byte_str, 16, &byte_val);
++		if (ret < 0) {
++			ath12k_err(ar->ab, "Failed to convert hex string to u8: %c%c",
++					   byte_str[0], byte_str[1]);
++			return ret;
++		}
++
++		macaddr->b[2 - i] = byte_val; // Assign to bytes 2,1,0
++	}
++
++	ath12k_info(ar->ab, "Generated MAC_ADDR: %pMR", macaddr);
++
++	return 0;
++}
++
++static void ath12k_reverse_mac(u8 *dst, const u8 *src)
++{
++	int i;
++
++	for (i = 0; i < ETH_ALEN; i++)
++		dst[i] = src[ETH_ALEN - 1 - i];
++}
++
+ static struct ieee80211_rate ath12k_legacy_rates[] = {
+ 	{ .bitrate = 10,
+ 	  .hw_value = ATH12K_HW_RATE_CCK_LP_1M },
+@@ -14240,6 +14325,7 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
+ 	struct ath12k_base *ab = ar->ab;
+ 	struct ath12k_pdev *pdev;
+ 	struct ath12k_pdev_cap *cap;
++	struct macaddr_t generated_macaddr;
+ 	static const u32 cipher_suites[] = {
+ 		WLAN_CIPHER_SUITE_TKIP,
+ 		WLAN_CIPHER_SUITE_CCMP,
+@@ -14263,11 +14349,18 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
+ 		u32 ht_cap_info = 0;
+ 
+ 		pdev = ar->pdev;
+-		if (ar->ab->pdevs_macaddr_valid) {
+-			ether_addr_copy(ar->mac_addr, pdev->mac_addr);
++		ret = generate_macaddr_from_serial(ar, &generated_macaddr);
++		if (ret) {
++			if (ar->ab->pdevs_macaddr_valid) {
++				ether_addr_copy(ar->mac_addr, pdev->mac_addr);
++			} else {
++				ether_addr_copy(ar->mac_addr, ar->ab->mac_addr);
++				ar->mac_addr[4] += ar->pdev_idx;
++			}
+ 		} else {
+-			ether_addr_copy(ar->mac_addr, ar->ab->mac_addr);
++			ath12k_reverse_mac(ar->mac_addr, generated_macaddr.b);
+ 			ar->mac_addr[4] += ar->pdev_idx;
++			ath12k_info(ab, "MAC_ADDR set to %pMR", generated_macaddr.b);
+ 		}
+ 
+ 		ret = ath12k_mac_setup_register(ar, &ht_cap_info, hw->wiphy->bands);
+diff --git a/drivers/soc/qcom/socinfo.c b/drivers/soc/qcom/socinfo.c
+index 003a2304d535..5bfe2cc2ba9a 100644
+--- a/drivers/soc/qcom/socinfo.c
++++ b/drivers/soc/qcom/socinfo.c
+@@ -224,6 +224,10 @@ struct smem_image_version {
+ };
+ #endif /* CONFIG_DEBUG_FS */
+ 
++/* Global variable to hold the serial number */
++const char *qcom_serial_number;
++EXPORT_SYMBOL(qcom_serial_number);
++
+ struct qcom_socinfo {
+ 	struct soc_device *soc_dev;
+ 	struct soc_device_attribute attr;
+@@ -891,6 +895,9 @@ static int qcom_socinfo_probe(struct platform_device *pdev)
+ 							le32_to_cpu(info->serial_num));
+ 		if (!qs->attr.serial_number)
+ 			return -ENOMEM;
++
++		/* Assign the serial number to the global variable */
++		qcom_serial_number = qs->attr.serial_number;
+ 	}
+ 
+ 	qs->soc_dev = soc_device_register(&qs->attr);
+@@ -914,6 +921,9 @@ static void qcom_socinfo_remove(struct platform_device *pdev)
+ 	soc_device_unregister(qs->soc_dev);
+ 
+ 	socinfo_debugfs_exit(qs);
++
++	/* Clear the global serial number */
++	qcom_serial_number = NULL;
+ }
+ 
+ static struct platform_driver qcom_socinfo_driver = {
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0013-HACK-Revert-back-to-6.12-aw88166-driver.patch
+++ b/patch/kernel/archive/sm8550-6.19/0013-HACK-Revert-back-to-6.12-aw88166-driver.patch
@@ -1,0 +1,711 @@
+From 316c62d8757409a30a4de22d3410e014fcca695e Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sun, 18 Jan 2026 20:37:39 +0800
+Subject: [PATCH 13/15] HACK: Revert back to 6.12 aw88166 driver
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ sound/soc/codecs/aw88166.c | 509 ++++++++++++++++---------------------
+ sound/soc/codecs/aw88166.h |   7 +-
+ 2 files changed, 232 insertions(+), 284 deletions(-)
+
+diff --git a/sound/soc/codecs/aw88166.c b/sound/soc/codecs/aw88166.c
+index daee4de9e3b0..1a289f60a07d 100644
+--- a/sound/soc/codecs/aw88166.c
++++ b/sound/soc/codecs/aw88166.c
+@@ -11,8 +11,8 @@
+ #include <linux/firmware.h>
+ #include <linux/gpio/consumer.h>
+ #include <linux/i2c.h>
+-#include <linux/minmax.h>
+ #include <linux/regmap.h>
++#include <sound/pcm_params.h>
+ #include <sound/soc.h>
+ #include "aw88166.h"
+ #include "aw88395/aw88395_device.h"
+@@ -41,6 +41,111 @@ static const struct regmap_config aw88166_remap_config = {
+ 	.val_format_endian = REGMAP_ENDIAN_BIG,
+ };
+ 
++static int aw_dev_dsp_write_16bit(struct aw_device *aw_dev,
++		unsigned short dsp_addr, unsigned int dsp_data)
++{
++	int ret;
++
++	ret = regmap_write(aw_dev->regmap, AW88166_DSPMADD_REG, dsp_addr);
++	if (ret) {
++		dev_err(aw_dev->dev, "%s write addr error, ret=%d", __func__, ret);
++		return ret;
++	}
++
++	ret = regmap_write(aw_dev->regmap, AW88166_DSPMDAT_REG, (u16)dsp_data);
++	if (ret) {
++		dev_err(aw_dev->dev, "%s write data error, ret=%d", __func__, ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static int aw_dev_dsp_read_16bit(struct aw_device *aw_dev,
++		unsigned short dsp_addr, unsigned int *dsp_data)
++{
++	unsigned int temp_data;
++	int ret;
++
++	ret = regmap_write(aw_dev->regmap, AW88166_DSPMADD_REG, dsp_addr);
++	if (ret) {
++		dev_err(aw_dev->dev, "%s write error, ret=%d", __func__, ret);
++		return ret;
++	}
++
++	ret = regmap_read(aw_dev->regmap, AW88166_DSPMDAT_REG, &temp_data);
++	if (ret) {
++		dev_err(aw_dev->dev, "%s read error, ret=%d", __func__, ret);
++		return ret;
++	}
++	*dsp_data = temp_data;
++
++	return 0;
++}
++
++static int aw_dev_dsp_read_32bit(struct aw_device *aw_dev,
++		unsigned short dsp_addr, unsigned int *dsp_data)
++{
++	unsigned int temp_data;
++	int ret;
++
++	ret = regmap_write(aw_dev->regmap, AW88166_DSPMADD_REG, dsp_addr);
++	if (ret) {
++		dev_err(aw_dev->dev, "%s write error, ret=%d", __func__, ret);
++		return ret;
++	}
++
++	ret = regmap_read(aw_dev->regmap, AW88166_DSPMDAT_REG, &temp_data);
++	if (ret) {
++		dev_err(aw_dev->dev, "%s read error, ret=%d", __func__, ret);
++		return ret;
++	}
++	*dsp_data = temp_data;
++
++	ret = regmap_read(aw_dev->regmap, AW88166_DSPMDAT_REG, &temp_data);
++	if (ret) {
++		dev_err(aw_dev->dev, "%s read error, ret=%d", __func__, ret);
++		return ret;
++	}
++	*dsp_data |= (temp_data << 16);
++
++	return 0;
++}
++
++static int __aw_dev_dsp_read(struct aw_device *aw_dev,
++		unsigned short dsp_addr, unsigned int *dsp_data, unsigned char data_type)
++{
++	u32 reg_value;
++	int ret;
++
++	mutex_lock(&aw_dev->dsp_lock);
++	switch (data_type) {
++	case AW88166_DSP_16_DATA:
++		ret = aw_dev_dsp_read_16bit(aw_dev, dsp_addr, dsp_data);
++		if (ret)
++			dev_err(aw_dev->dev, "read dsp_addr[0x%x] 16-bit dsp_data[0x%x] failed",
++					(u32)dsp_addr, *dsp_data);
++		break;
++	case AW88166_DSP_32_DATA:
++		ret = aw_dev_dsp_read_32bit(aw_dev, dsp_addr, dsp_data);
++		if (ret)
++			dev_err(aw_dev->dev, "read dsp_addr[0x%x] 32r-bit dsp_data[0x%x] failed",
++					(u32)dsp_addr, *dsp_data);
++		break;
++	default:
++		dev_err(aw_dev->dev, "data type[%d] unsupported", data_type);
++		ret = -EINVAL;
++		break;
++	}
++
++	/* clear dsp chip select state */
++	if (regmap_read(aw_dev->regmap, AW88166_ID_REG, &reg_value))
++		dev_err(aw_dev->dev, "%s fail to clear chip state. ret=%d\n", __func__, ret);
++	mutex_unlock(&aw_dev->dsp_lock);
++
++	return ret;
++}
++
+ static void aw_dev_pwd(struct aw_device *aw_dev, bool pwd)
+ {
+ 	int ret;
+@@ -798,22 +903,51 @@ static int aw88166_dev_start(struct aw88166 *aw88166)
+ static int aw_dev_dsp_update_container(struct aw_device *aw_dev,
+ 			unsigned char *data, unsigned int len, unsigned short base)
+ {
+-	u32 tmp_len;
+ 	int i, ret;
+ 
++#ifdef AW88166_DSP_I2C_WRITES
++	u32 tmp_len;
++
++	mutex_lock(&aw_dev->dsp_lock);
+ 	ret = regmap_write(aw_dev->regmap, AW88166_DSPMADD_REG, base);
+ 	if (ret)
+-		return ret;
++		goto error_operation;
+ 
+ 	for (i = 0; i < len; i += AW88166_MAX_RAM_WRITE_BYTE_SIZE) {
+-		tmp_len = min(len - i, AW88166_MAX_RAM_WRITE_BYTE_SIZE);
++		if ((len - i) < AW88166_MAX_RAM_WRITE_BYTE_SIZE)
++			tmp_len = len - i;
++		else
++			tmp_len = AW88166_MAX_RAM_WRITE_BYTE_SIZE;
++
+ 		ret = regmap_raw_write(aw_dev->regmap, AW88166_DSPMDAT_REG,
+ 					&data[i], tmp_len);
+ 		if (ret)
+-			return ret;
++			goto error_operation;
+ 	}
++	mutex_unlock(&aw_dev->dsp_lock);
++#else
++	__be16 reg_val;
++
++	mutex_lock(&aw_dev->dsp_lock);
++	/* i2c write */
++	ret = regmap_write(aw_dev->regmap, AW88166_DSPMADD_REG, base);
++	if (ret)
++		goto error_operation;
++	for (i = 0; i < len; i += 2) {
++		reg_val = cpu_to_be16p((u16 *)(data + i));
++		ret = regmap_write(aw_dev->regmap, AW88166_DSPMDAT_REG,
++					(u16)reg_val);
++		if (ret)
++			goto error_operation;
++	}
++	mutex_unlock(&aw_dev->dsp_lock);
++#endif
+ 
+ 	return 0;
++
++error_operation:
++	mutex_unlock(&aw_dev->dsp_lock);
++	return ret;
+ }
+ 
+ static int aw_dev_get_ra(struct aw_cali_desc *cali_desc)
+@@ -823,8 +957,8 @@ static int aw_dev_get_ra(struct aw_cali_desc *cali_desc)
+ 	u32 dsp_ra;
+ 	int ret;
+ 
+-	ret = aw_dev_dsp_read(aw_dev, AW88166_DSP_REG_CFG_ADPZ_RA,
+-				&dsp_ra, AW_DSP_32_DATA);
++	ret = __aw_dev_dsp_read(aw_dev, AW88166_DSP_REG_CFG_ADPZ_RA,
++				&dsp_ra, AW88166_DSP_32_DATA);
+ 	if (ret) {
+ 		dev_err(aw_dev->dev, "read ra error\n");
+ 		return ret;
+@@ -881,25 +1015,29 @@ static int aw_dev_check_sram(struct aw_device *aw_dev)
+ {
+ 	unsigned int reg_val;
+ 
++	mutex_lock(&aw_dev->dsp_lock);
+ 	/* read dsp_rom_check_reg */
+-	aw_dev_dsp_read(aw_dev, AW88166_DSP_ROM_CHECK_ADDR, &reg_val, AW_DSP_16_DATA);
++	aw_dev_dsp_read_16bit(aw_dev, AW88166_DSP_ROM_CHECK_ADDR, &reg_val);
+ 	if (reg_val != AW88166_DSP_ROM_CHECK_DATA) {
+ 		dev_err(aw_dev->dev, "check dsp rom failed, read[0x%x] != check[0x%x]\n",
+ 						reg_val, AW88166_DSP_ROM_CHECK_DATA);
+-		return -EPERM;
++		goto error;
+ 	}
+ 
+ 	/* check dsp_cfg_base_addr */
+-	aw_dev_dsp_write(aw_dev, AW88166_DSP_CFG_ADDR,
+-				AW88166_DSP_ODD_NUM_BIT_TEST, AW_DSP_16_DATA);
+-	aw_dev_dsp_read(aw_dev, AW88166_DSP_CFG_ADDR, &reg_val, AW_DSP_16_DATA);
++	aw_dev_dsp_write_16bit(aw_dev, AW88166_DSP_CFG_ADDR, AW88166_DSP_ODD_NUM_BIT_TEST);
++	aw_dev_dsp_read_16bit(aw_dev, AW88166_DSP_CFG_ADDR, &reg_val);
+ 	if (reg_val != AW88166_DSP_ODD_NUM_BIT_TEST) {
+ 		dev_err(aw_dev->dev, "check dsp cfg failed, read[0x%x] != write[0x%x]\n",
+ 						reg_val, AW88166_DSP_ODD_NUM_BIT_TEST);
+-		return -EPERM;
++		goto error;
+ 	}
++	mutex_unlock(&aw_dev->dsp_lock);
+ 
+ 	return 0;
++error:
++	mutex_unlock(&aw_dev->dsp_lock);
++	return -EPERM;
+ }
+ 
+ static void aw_dev_select_memclk(struct aw_device *aw_dev, unsigned char flag)
+@@ -1197,7 +1335,7 @@ static void aw88166_start(struct aw88166 *aw88166, bool sync_start)
+ 	if (sync_start == AW88166_SYNC_START)
+ 		aw88166_start_pa(aw88166);
+ 	else
+-		queue_delayed_work(system_dfl_wq,
++		queue_delayed_work(system_wq,
+ 			&aw88166->start_work,
+ 			AW88166_START_WORK_DELAY_MS);
+ }
+@@ -1208,7 +1346,7 @@ static int aw_dev_check_sysint(struct aw_device *aw_dev)
+ 
+ 	aw_dev_get_int_status(aw_dev, &reg_val);
+ 	if (reg_val & AW88166_BIT_SYSINT_CHECK) {
+-		dev_err(aw_dev->dev, "pa stop check fail:0x%04x\n", reg_val);
++		dev_dbg(aw_dev->dev, "pa stop check fail:0x%04x\n", reg_val);
+ 		return -EINVAL;
+ 	}
+ 
+@@ -1254,284 +1392,97 @@ static int aw88166_stop(struct aw_device *aw_dev)
+ 	return 0;
+ }
+ 
+-static struct snd_soc_dai_driver aw88166_dai[] = {
+-	{
+-		.name = "aw88166-aif",
+-		.id = 1,
+-		.playback = {
+-			.stream_name = "Speaker_Playback",
+-			.channels_min = 1,
+-			.channels_max = 2,
+-			.rates = AW88166_RATES,
+-			.formats = AW88166_FORMATS,
+-		},
+-		.capture = {
+-			.stream_name = "Speaker_Capture",
+-			.channels_min = 1,
+-			.channels_max = 2,
+-			.rates = AW88166_RATES,
+-			.formats = AW88166_FORMATS,
+-		},
+-	},
+-};
+-
+-static int aw88166_get_fade_in_time(struct snd_kcontrol *kcontrol,
+-	struct snd_ctl_elem_value *ucontrol)
+-{
+-	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(component);
+-	struct aw_device *aw_dev = aw88166->aw_pa;
+-
+-	ucontrol->value.integer.value[0] = aw_dev->fade_in_time;
+-
+-	return 0;
+-}
+-
+-static int aw88166_set_fade_in_time(struct snd_kcontrol *kcontrol,
+-	struct snd_ctl_elem_value *ucontrol)
+-{
+-	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(component);
+-	struct soc_mixer_control *mc =
+-		(struct soc_mixer_control *)kcontrol->private_value;
+-	struct aw_device *aw_dev = aw88166->aw_pa;
+-	int time;
+-
+-	time = ucontrol->value.integer.value[0];
+-
+-	if (time < mc->min || time > mc->max)
+-		return -EINVAL;
+-
+-	if (time != aw_dev->fade_in_time) {
+-		aw_dev->fade_in_time = time;
+-		return 1;
+-	}
+-
+-	return 0;
+-}
+-
+-static int aw88166_get_fade_out_time(struct snd_kcontrol *kcontrol,
+-	struct snd_ctl_elem_value *ucontrol)
++static int aw88166_startup(struct snd_pcm_substream *substream,
++			struct snd_soc_dai *dai)
+ {
+-	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(component);
+-	struct aw_device *aw_dev = aw88166->aw_pa;
+-
+-	ucontrol->value.integer.value[0] = aw_dev->fade_out_time;
+-
+-	return 0;
+-}
+-
+-static int aw88166_set_fade_out_time(struct snd_kcontrol *kcontrol,
+-	struct snd_ctl_elem_value *ucontrol)
+-{
+-	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(component);
+-	struct soc_mixer_control *mc =
+-		(struct soc_mixer_control *)kcontrol->private_value;
+-	struct aw_device *aw_dev = aw88166->aw_pa;
+-	int time;
+-
+-	time = ucontrol->value.integer.value[0];
+-	if (time < mc->min || time > mc->max)
+-		return -EINVAL;
+-
+-	if (time != aw_dev->fade_out_time) {
+-		aw_dev->fade_out_time = time;
+-		return 1;
++	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK) {
++		dev_dbg(dai->dev, "STREAM_PLAYBACK start");
++	} else {
++		dev_dbg(dai->dev, "STREAM_CAPTURE start");
+ 	}
+-
+ 	return 0;
+ }
+ 
+-static int aw88166_dev_set_profile_index(struct aw_device *aw_dev, int index)
++static int aw88166_set_fmt(struct snd_soc_dai *dai, unsigned int fmt)
+ {
+-	/* check the index whether is valid */
+-	if ((index >= aw_dev->prof_info.count) || (index < 0))
+-		return -EINVAL;
+-	/* check the index whether change */
+-	if (aw_dev->prof_index == index)
+-		return -EINVAL;
+-
+-	aw_dev->prof_index = index;
+-	dev_dbg(aw_dev->dev, "set prof[%s]",
+-		aw_dev->prof_info.prof_name_list[aw_dev->prof_info.prof_desc[index].id]);
++	dev_dbg(dai->dev, "fmt=0x%x", fmt);
+ 
+ 	return 0;
+ }
+ 
+-static int aw88166_profile_info(struct snd_kcontrol *kcontrol,
+-			 struct snd_ctl_elem_info *uinfo)
++static int aw88166_set_dai_sysclk(struct snd_soc_dai *dai,
++				int clk_id, unsigned int freq, int dir)
+ {
+-	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
+-	char *prof_name;
+-	int count, ret;
+-
+-	uinfo->type = SNDRV_CTL_ELEM_TYPE_ENUMERATED;
+-	uinfo->count = 1;
+-
+-	count = aw88166->aw_pa->prof_info.count;
+-	if (count <= 0) {
+-		uinfo->value.enumerated.items = 0;
+-		return 0;
+-	}
+-
+-	uinfo->value.enumerated.items = count;
+-
+-	if (uinfo->value.enumerated.item >= count)
+-		uinfo->value.enumerated.item = count - 1;
+-
+-	count = uinfo->value.enumerated.item;
+-
+-	ret = aw88166_dev_get_prof_name(aw88166->aw_pa, count, &prof_name);
+-	if (ret) {
+-		strscpy(uinfo->value.enumerated.name, "null");
+-		return 0;
+-	}
+-
+-	strscpy(uinfo->value.enumerated.name, prof_name);
+-
++	dev_dbg(dai->dev, "freq=%d", freq);
+ 	return 0;
+ }
+ 
+-static int aw88166_profile_get(struct snd_kcontrol *kcontrol,
+-			struct snd_ctl_elem_value *ucontrol)
++static int aw88166_hw_params(struct snd_pcm_substream *substream,
++				struct snd_pcm_hw_params *params,
++				struct snd_soc_dai *dai)
+ {
+-	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
+-
+-	ucontrol->value.integer.value[0] = aw88166->aw_pa->prof_index;
+-
+-	return 0;
+-}
+-
+-static int aw88166_profile_set(struct snd_kcontrol *kcontrol,
+-		struct snd_ctl_elem_value *ucontrol)
+-{
+-	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
+-	int ret;
+-
+-	mutex_lock(&aw88166->lock);
+-	ret = aw88166_dev_set_profile_index(aw88166->aw_pa, ucontrol->value.integer.value[0]);
+-	if (ret) {
+-		dev_dbg(codec->dev, "profile index does not change");
+-		mutex_unlock(&aw88166->lock);
+-		return 0;
++	if (substream->stream == SNDRV_PCM_STREAM_CAPTURE) {
++		dev_dbg(dai->dev,
++			"STREAM_CAPTURE requested rate: %d, width = %d",
++			params_rate(params), params_width(params));
+ 	}
+ 
+-	if (aw88166->aw_pa->status) {
+-		aw88166_stop(aw88166->aw_pa);
+-		aw88166_start(aw88166, AW88166_SYNC_START);
++	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK) {
++		dev_dbg(dai->dev,
++			"STREAM_PLAYBACK requested rate: %d, width = %d",
++			params_rate(params), params_width(params));
+ 	}
+ 
+-	mutex_unlock(&aw88166->lock);
+-
+-	return 1;
+-}
+-
+-static int aw88166_volume_get(struct snd_kcontrol *kcontrol,
+-				struct snd_ctl_elem_value *ucontrol)
+-{
+-	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
+-	struct aw_volume_desc *vol_desc = &aw88166->aw_pa->volume_desc;
+-
+-	ucontrol->value.integer.value[0] = vol_desc->ctl_volume;
+-
+ 	return 0;
+ }
+ 
+-static int aw88166_volume_set(struct snd_kcontrol *kcontrol,
+-				struct snd_ctl_elem_value *ucontrol)
++static int aw88166_mute(struct snd_soc_dai *dai, int mute, int stream)
+ {
+-	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
+-	struct aw_volume_desc *vol_desc = &aw88166->aw_pa->volume_desc;
+-	struct soc_mixer_control *mc =
+-		(struct soc_mixer_control *)kcontrol->private_value;
+-	int value;
+-
+-	value = ucontrol->value.integer.value[0];
+-	if (value < mc->min || value > mc->max)
+-		return -EINVAL;
+-
+-	if (vol_desc->ctl_volume != value) {
+-		vol_desc->ctl_volume = value;
+-		aw_dev_set_volume(aw88166->aw_pa, vol_desc->ctl_volume);
+-
+-		return 1;
+-	}
+-
+-	return 0;
+-}
+-
+-static int aw88166_get_fade_step(struct snd_kcontrol *kcontrol,
+-				struct snd_ctl_elem_value *ucontrol)
+-{
+-	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
+-
+-	ucontrol->value.integer.value[0] = aw88166->aw_pa->fade_step;
++	dev_dbg(dai->dev, "mute state=%d", mute);
+ 
+ 	return 0;
+ }
+ 
+-static int aw88166_set_fade_step(struct snd_kcontrol *kcontrol,
+-				struct snd_ctl_elem_value *ucontrol)
++static void aw88166_shutdown(struct snd_pcm_substream *substream,
++				struct snd_soc_dai *dai)
+ {
+-	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
+-	struct soc_mixer_control *mc =
+-		(struct soc_mixer_control *)kcontrol->private_value;
+-	int value;
+-
+-	value = ucontrol->value.integer.value[0];
+-	if (value < mc->min || value > mc->max)
+-		return -EINVAL;
+-
+-	if (aw88166->aw_pa->fade_step != value) {
+-		aw88166->aw_pa->fade_step = value;
+-		return 1;
++	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK){
++		dev_dbg(dai->dev, "STREAM_PLAYBACK stop");
++	} else {
++		dev_dbg(dai->dev, "STREAM_CAPTURE stop");
+ 	}
+-
+-	return 0;
+ }
+ 
+-static int aw88166_re_get(struct snd_kcontrol *kcontrol,
+-				struct snd_ctl_elem_value *ucontrol)
+-{
+-	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
+-	struct aw_device *aw_dev = aw88166->aw_pa;
+-
+-	ucontrol->value.integer.value[0] = aw_dev->cali_desc.cali_re;
+-
+-	return 0;
+-}
+-
+-static int aw88166_re_set(struct snd_kcontrol *kcontrol,
+-				struct snd_ctl_elem_value *ucontrol)
+-{
+-	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
+-	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
+-	struct soc_mixer_control *mc =
+-		(struct soc_mixer_control *)kcontrol->private_value;
+-	struct aw_device *aw_dev = aw88166->aw_pa;
+-	int value;
+-
+-	value = ucontrol->value.integer.value[0];
+-	if (value < mc->min || value > mc->max)
+-		return -EINVAL;
+-
+-	if (aw_dev->cali_desc.cali_re != value) {
+-		aw_dev->cali_desc.cali_re = value;
+-		return 1;
+-	}
++static const struct snd_soc_dai_ops aw88166_dai_ops = {
++	.startup = aw88166_startup,
++	.set_fmt = aw88166_set_fmt,
++	.set_sysclk = aw88166_set_dai_sysclk,
++	.hw_params = aw88166_hw_params,
++	.mute_stream = aw88166_mute,
++	.shutdown = aw88166_shutdown,
++};
+ 
+-	return 0;
+-}
++static struct snd_soc_dai_driver aw88166_dai[] = {
++	{
++		.name = "aw88166-aif",
++		.id = 1,
++		.playback = {
++			.stream_name = "Speaker_Playback",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = AW88166_RATES,
++			.formats = AW88166_FORMATS,
++		},
++		.capture = {
++			.stream_name = "Speaker_Capture",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = AW88166_RATES,
++			.formats = AW88166_FORMATS,
++		},
++		.ops = &aw88166_dai_ops,
++	},
++};
+ 
+ static int aw88166_dev_init(struct aw88166 *aw88166, struct aw_container *aw_cfg)
+ {
+@@ -1573,19 +1524,27 @@ static int aw88166_dev_init(struct aw88166 *aw88166, struct aw_container *aw_cfg
+ 
+ static int aw88166_request_firmware_file(struct aw88166 *aw88166)
+ {
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	struct device_node *np = aw_dev->dev->of_node;
+ 	const struct firmware *cont = NULL;
++	const char *fw_name;
+ 	int ret;
+ 
+ 	aw88166->aw_pa->fw_status = AW88166_DEV_FW_FAILED;
+ 
+-	ret = request_firmware(&cont, AW88166_ACF_FILE, aw88166->aw_pa->dev);
++	ret = of_property_read_string(np, "firmware-name", &fw_name);
++	if (ret < 0) {
++		fw_name = AW88166_ACF_FILE;
++	}
++
++	ret = request_firmware(&cont, fw_name, aw88166->aw_pa->dev);
+ 	if (ret) {
+-		dev_err(aw88166->aw_pa->dev, "request [%s] failed!\n", AW88166_ACF_FILE);
++		dev_err(aw88166->aw_pa->dev, "request [%s] failed!\n", fw_name);
+ 		return ret;
+ 	}
+ 
+ 	dev_dbg(aw88166->aw_pa->dev, "loaded %s - size: %zu\n",
+-			AW88166_ACF_FILE, cont ? cont->size : 0);
++			fw_name, cont ? cont->size : 0);
+ 
+ 	aw88166->aw_cfg = devm_kzalloc(aw88166->aw_pa->dev,
+ 			struct_size(aw88166->aw_cfg, data, cont->size), GFP_KERNEL);
+@@ -1599,7 +1558,7 @@ static int aw88166_request_firmware_file(struct aw88166 *aw88166)
+ 
+ 	ret = aw88395_dev_load_acf_check(aw88166->aw_pa, aw88166->aw_cfg);
+ 	if (ret) {
+-		dev_err(aw88166->aw_pa->dev, "load [%s] failed!\n", AW88166_ACF_FILE);
++		dev_err(aw88166->aw_pa->dev, "load [%s] failed!\n", fw_name);
+ 		return ret;
+ 	}
+ 
+@@ -1613,22 +1572,6 @@ static int aw88166_request_firmware_file(struct aw88166 *aw88166)
+ 	return ret;
+ }
+ 
+-static const struct snd_kcontrol_new aw88166_controls[] = {
+-	SOC_SINGLE_EXT("PCM Playback Volume", AW88166_SYSCTRL2_REG,
+-		6, AW88166_MUTE_VOL, 0, aw88166_volume_get,
+-		aw88166_volume_set),
+-	SOC_SINGLE_EXT("Fade Step", 0, 0, AW88166_MUTE_VOL, 0,
+-		aw88166_get_fade_step, aw88166_set_fade_step),
+-	SOC_SINGLE_EXT("Volume Ramp Up Step", 0, 0, FADE_TIME_MAX, FADE_TIME_MIN,
+-		aw88166_get_fade_in_time, aw88166_set_fade_in_time),
+-	SOC_SINGLE_EXT("Volume Ramp Down Step", 0, 0, FADE_TIME_MAX, FADE_TIME_MIN,
+-		aw88166_get_fade_out_time, aw88166_set_fade_out_time),
+-	SOC_SINGLE_EXT("Calib", 0, 0, AW88166_CALI_RE_MAX, 0,
+-		aw88166_re_get, aw88166_re_set),
+-	AW88166_PROFILE_EXT("AW88166 Profile Set", aw88166_profile_info,
+-		aw88166_profile_get, aw88166_profile_set),
+-};
+-
+ static int aw88166_playback_event(struct snd_soc_dapm_widget *w,
+ 				struct snd_kcontrol *k, int event)
+ {
+@@ -1696,8 +1639,6 @@ static const struct snd_soc_component_driver soc_codec_dev_aw88166 = {
+ 	.num_dapm_widgets = ARRAY_SIZE(aw88166_dapm_widgets),
+ 	.dapm_routes = aw88166_audio_map,
+ 	.num_dapm_routes = ARRAY_SIZE(aw88166_audio_map),
+-	.controls = aw88166_controls,
+-	.num_controls = ARRAY_SIZE(aw88166_controls),
+ };
+ 
+ static void aw88166_hw_reset(struct aw88166 *aw88166)
+@@ -1707,6 +1648,8 @@ static void aw88166_hw_reset(struct aw88166 *aw88166)
+ 		usleep_range(AW88166_1000_US, AW88166_1000_US + 10);
+ 		gpiod_set_value_cansleep(aw88166->reset_gpio, 0);
+ 		usleep_range(AW88166_1000_US, AW88166_1000_US + 10);
++		gpiod_set_value_cansleep(aw88166->reset_gpio, 1);
++		usleep_range(AW88166_1000_US, AW88166_1000_US + 10);
+ 	}
+ }
+ 
+diff --git a/sound/soc/codecs/aw88166.h b/sound/soc/codecs/aw88166.h
+index 9f3f47a7003e..8b5c83a48d6e 100644
+--- a/sound/soc/codecs/aw88166.h
++++ b/sound/soc/codecs/aw88166.h
+@@ -387,7 +387,7 @@
+ 
+ #define AW88166_NOISE_GATE_EN_START_BIT	(13)
+ #define AW88166_NOISE_GATE_EN_BITS_LEN		(1)
+-#define AW88166_NOISE_GATE_EN_MASK		\
++#define AW88166_NOISE_GATE_EN_MASK	\
+ 	(~(((1<<AW88166_NOISE_GATE_EN_BITS_LEN)-1) << AW88166_NOISE_GATE_EN_START_BIT))
+ 
+ #define AW88166_WDT_CNT_START_BIT		(0)
+@@ -516,6 +516,11 @@ enum AW88166_DEV_DSP_CFG {
+ 	AW88166_DEV_DSP_BYPASS = 1,
+ };
+ 
++enum {
++	AW88166_DSP_16_DATA = 0,
++	AW88166_DSP_32_DATA = 1,
++};
++
+ enum {
+ 	AW88166_SYNC_START = 0,
+ 	AW88166_ASYNC_START,
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0014-pwm-Add-SI-EN-SN3112-PWM-support.patch
+++ b/patch/kernel/archive/sm8550-6.19/0014-pwm-Add-SI-EN-SN3112-PWM-support.patch
@@ -1,0 +1,406 @@
+From 3ac7ffaef0bf479d3e5c1f10f825abb92f8eef31 Mon Sep 17 00:00:00 2001
+From: BigfootACA <bigfoot@classfun.cn>
+Date: Sat, 24 Jan 2026 19:45:33 +0800
+Subject: [PATCH 14/15] pwm: Add SI-EN SN3112 PWM support
+
+Add a new driver for the SI-EN SN3112 12-channel 8-bit PWM LED controller.
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ drivers/pwm/Kconfig      |  10 ++
+ drivers/pwm/Makefile     |   1 +
+ drivers/pwm/pwm-sn3112.c | 349 +++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 360 insertions(+)
+ create mode 100644 drivers/pwm/pwm-sn3112.c
+
+diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
+index 6f3147518376..ab296d279ab4 100644
+--- a/drivers/pwm/Kconfig
++++ b/drivers/pwm/Kconfig
+@@ -668,6 +668,16 @@ config PWM_SOPHGO_SG2042
+ 	  To compile this driver as a module, choose M here: the module
+ 	  will be called pwm_sophgo_sg2042.
+ 
++config PWM_SN3112
++	tristate "SI-EN SN3112 PWM driver"
++	depends on I2C
++	select REGMAP_I2C
++	help
++	  Generic PWM framework driver for SI-EN SN3112 LED controller.
++
++	  To compile this driver as a module, choose M here: the module
++	  will be called pwm-sn3112.
++
+ config PWM_SPEAR
+ 	tristate "STMicroelectronics SPEAr PWM support"
+ 	depends on PLAT_SPEAR || COMPILE_TEST
+diff --git a/drivers/pwm/Makefile b/drivers/pwm/Makefile
+index 0dc0d2b69025..633bad3e1785 100644
+--- a/drivers/pwm/Makefile
++++ b/drivers/pwm/Makefile
+@@ -59,6 +59,7 @@ obj-$(CONFIG_PWM_ROCKCHIP)	+= pwm-rockchip.o
+ obj-$(CONFIG_PWM_SAMSUNG)	+= pwm-samsung.o
+ obj-$(CONFIG_PWM_SIFIVE)	+= pwm-sifive.o
+ obj-$(CONFIG_PWM_SL28CPLD)	+= pwm-sl28cpld.o
++obj-$(CONFIG_PWM_SN3112)	+= pwm-sn3112.o
+ obj-$(CONFIG_PWM_SOPHGO_SG2042)	+= pwm-sophgo-sg2042.o
+ obj-$(CONFIG_PWM_SPEAR)		+= pwm-spear.o
+ obj-$(CONFIG_PWM_SPRD)		+= pwm-sprd.o
+diff --git a/drivers/pwm/pwm-sn3112.c b/drivers/pwm/pwm-sn3112.c
+new file mode 100644
+index 000000000000..4c1429407d87
+--- /dev/null
++++ b/drivers/pwm/pwm-sn3112.c
+@@ -0,0 +1,349 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Driver for SN3112 12-channel 8-bit PWM LED controller
++ *
++ * Copyright (c) 2024 Junhao Xie <bigfoot@classfun.cn>
++ *
++ */
++
++#include <linux/i2c.h>
++#include <linux/module.h>
++#include <linux/mutex.h>
++#include <linux/platform_device.h>
++#include <linux/pwm.h>
++#include <linux/regmap.h>
++#include <linux/delay.h>
++#include <linux/gpio/consumer.h>
++#include <linux/regulator/consumer.h>
++
++#define SN3112_CHANNELS 12
++#define SN3112_REG_ENABLE 0x00
++#define SN3112_REG_PWM_VAL 0x04
++#define SN3112_REG_PWM_EN 0x13
++#define SN3112_REG_APPLY 0x16
++#define SN3112_REG_RESET 0x17
++
++struct sn3112 {
++	struct device *pdev;
++	struct regmap *regmap;
++	struct mutex lock;
++	struct regulator *vdd;
++	uint8_t pwm_val[SN3112_CHANNELS];
++	uint8_t pwm_en_reg[3];
++	bool pwm_en[SN3112_CHANNELS];
++#if IS_ENABLED(CONFIG_GPIOLIB)
++	struct gpio_desc *sdb;
++#endif
++};
++
++static int sn3112_write_reg(struct sn3112 *priv, unsigned int reg,
++			    unsigned int val)
++{
++	int err;
++
++	dev_dbg(priv->pdev, "request regmap_write 0x%x 0x%x\n", reg, val);
++	err = regmap_write(priv->regmap, reg, val);
++	if (err)
++		dev_warn_ratelimited(
++			priv->pdev,
++			"regmap_write to register 0x%x failed: %pe\n", reg,
++			ERR_PTR(err));
++
++	return err;
++}
++
++static int sn3112_set_en_reg(struct sn3112 *priv, unsigned int channel,
++			     bool enabled, bool write)
++{
++	unsigned int reg, bit;
++
++	if (channel >= SN3112_CHANNELS)
++		return -EINVAL;
++
++	/* LED_EN1: BIT5:BIT3 = OUT3:OUT1 */
++	if (channel >= 0 && channel <= 2)
++		reg = 0, bit = channel + 3;
++	/* LED_EN2: BIT5:BIT0 = OUT9:OUT4 */
++	else if (channel >= 3 && channel <= 8)
++		reg = 1, bit = channel - 3;
++	/* LED_EN3: BIT2:BIT0 = OUT12:OUT10 */
++	else if (channel >= 9 && channel <= 11)
++		reg = 2, bit = channel - 9;
++	else
++		return -EINVAL;
++
++	dev_dbg(priv->pdev, "channel %u enabled %u\n", channel, enabled);
++	dev_dbg(priv->pdev, "reg %u bit %u\n", reg, bit);
++	if (enabled)
++		priv->pwm_en_reg[reg] |= BIT(bit);
++	else
++		priv->pwm_en_reg[reg] &= ~BIT(bit);
++	dev_dbg(priv->pdev, "set enable reg %u to %u\n", reg,
++		priv->pwm_en_reg[reg]);
++
++	if (!write)
++		return 0;
++	return sn3112_write_reg(priv, SN3112_REG_PWM_EN + reg,
++				priv->pwm_en_reg[reg]);
++}
++
++static int sn3112_set_val_reg(struct sn3112 *priv, unsigned int channel,
++			      uint8_t val, bool write)
++{
++	if (channel >= SN3112_CHANNELS)
++		return -EINVAL;
++	priv->pwm_val[channel] = val;
++	dev_dbg(priv->pdev, "set value reg %u to %u\n", channel,
++		priv->pwm_val[channel]);
++
++	if (!write)
++		return 0;
++	return sn3112_write_reg(priv, SN3112_REG_PWM_VAL + channel,
++				priv->pwm_val[channel]);
++}
++
++static int sn3112_write_all(struct sn3112 *priv)
++{
++	int i, ret;
++
++	/* regenerate enable register values */
++	for (i = 0; i < SN3112_CHANNELS; i++) {
++		ret = sn3112_set_en_reg(priv, i, priv->pwm_en[i], false);
++		if (ret != 0)
++			return ret;
++	}
++
++	/* use random value to clear all registers */
++	ret = sn3112_write_reg(priv, SN3112_REG_RESET, 0x66);
++	if (ret != 0)
++		return ret;
++
++	/* set software enable register */
++	ret = sn3112_write_reg(priv, SN3112_REG_ENABLE, 1);
++	if (ret != 0)
++		return ret;
++
++	/* rewrite pwm value register */
++	for (i = 0; i < SN3112_CHANNELS; i++) {
++		ret = sn3112_write_reg(priv, SN3112_REG_PWM_VAL + i,
++				       priv->pwm_val[i]);
++		if (ret != 0)
++			return ret;
++	}
++
++	/* rewrite pwm enable register */
++	for (i = 0; i < 3; i++) {
++		ret = sn3112_write_reg(priv, SN3112_REG_PWM_EN + i,
++				       priv->pwm_en_reg[i]);
++		if (ret != 0)
++			return ret;
++	}
++
++	/* use random value to apply changes */
++	ret = sn3112_write_reg(priv, SN3112_REG_APPLY, 0x66);
++	if (ret != 0)
++		return ret;
++
++	dev_dbg(priv->pdev, "reinitialized\n");
++	return 0;
++}
++
++static int sn3112_pwm_request(struct pwm_chip *chip, struct pwm_device *pwm)
++{
++	struct sn3112 *priv = pwmchip_get_drvdata(chip);
++
++	if (pwm->hwpwm >= SN3112_CHANNELS)
++		return -EINVAL;
++
++	dev_dbg(priv->pdev, "sn3112 request channel %u\n", pwm->hwpwm);
++	pwm->args.period = 1000000;
++	return 0;
++}
++
++static int sn3112_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
++			    const struct pwm_state *state)
++{
++	int ret;
++	u64 val = 0;
++	struct sn3112 *priv = pwmchip_get_drvdata(chip);
++
++	if (pwm->hwpwm >= SN3112_CHANNELS)
++		return -EINVAL;
++
++	if (state->polarity != PWM_POLARITY_NORMAL)
++		return -EINVAL;
++
++	if (state->period <= 0)
++		return -EINVAL;
++
++	val = mul_u64_u64_div_u64(state->duty_cycle, 0xff, state->period);
++	dev_dbg(priv->pdev, "duty_cycle %llu period %llu\n", state->duty_cycle,
++		state->period);
++	dev_dbg(priv->pdev, "set channel %u value to %llu\n", pwm->hwpwm, val);
++	dev_dbg(priv->pdev, "set channel %u enabled to %u\n", pwm->hwpwm,
++		state->enabled);
++
++	mutex_lock(&priv->lock);
++	ret = sn3112_set_en_reg(priv, pwm->hwpwm, state->enabled, true);
++	if (ret)
++		goto out;
++	ret = sn3112_set_val_reg(priv, pwm->hwpwm, val, true);
++	if (ret)
++		goto out;
++	ret = sn3112_write_reg(priv, SN3112_REG_APPLY, 0x66);
++	if (ret)
++		goto out;
++out:
++	mutex_unlock(&priv->lock);
++	return ret;
++}
++
++static const struct pwm_ops sn3112_pwm_ops = {
++	.apply = sn3112_pwm_apply,
++	.request = sn3112_pwm_request,
++};
++
++static const struct regmap_config sn3112_regmap_i2c_config = {
++	.reg_bits = 8,
++	.val_bits = 8,
++	.max_register = 24,
++	.cache_type = REGCACHE_NONE,
++};
++
++static int sn3112_pwm_probe(struct i2c_client *client)
++{
++	struct pwm_chip *chip;
++	struct sn3112 *priv;
++	int ret, i;
++
++	dev_dbg(&client->dev, "probing\n");
++	chip = devm_pwmchip_alloc(&client->dev, SN3112_CHANNELS, sizeof(*priv));
++	if (IS_ERR(chip))
++		return PTR_ERR(chip);
++	priv = pwmchip_get_drvdata(chip);
++	priv->pdev = &client->dev;
++
++	/* initialize sn3112 (chip does not support read command) */
++	for (i = 0; i < SN3112_CHANNELS; i++)
++		priv->pwm_en[i] = false;
++	for (i = 0; i < SN3112_CHANNELS; i++)
++		priv->pwm_val[i] = 0;
++	for (i = 0; i < 3; i++)
++		priv->pwm_en_reg[i] = 0;
++
++	/* enable sn5112 power vdd */
++	priv->vdd = devm_regulator_get(priv->pdev, "vdd");
++	if (IS_ERR(priv->vdd)) {
++		ret = PTR_ERR(priv->vdd);
++		dev_err(priv->pdev, "Unable to get vdd regulator: %d\n", ret);
++		return ret;
++	}
++
++#if IS_ENABLED(CONFIG_GPIOLIB)
++	/* sn5112 hardware shutdown pin */
++	priv->sdb = devm_gpiod_get_optional(priv->pdev, "sdb", GPIOD_OUT_LOW);
++	if (IS_ERR(priv->sdb))
++		return dev_err_probe(priv->pdev, PTR_ERR(priv->sdb),
++				"Unable to get sdb gpio\n");;
++#endif
++
++	/* enable sn5112 power vdd */
++	ret = regulator_enable(priv->vdd);
++	if (ret < 0) {
++		dev_err(priv->pdev, "Unable to enable regulator: %d\n", ret);
++		return ret;
++	}
++
++	priv->regmap = devm_regmap_init_i2c(client, &sn3112_regmap_i2c_config);
++	if (IS_ERR(priv->regmap)) {
++		ret = PTR_ERR(priv->regmap);
++		dev_err(priv->pdev, "Failed to initialize register map: %d\n",
++			ret);
++		goto err_disable_vdd;
++	}
++
++	i2c_set_clientdata(client, chip);
++	mutex_init(&priv->lock);
++
++	chip->ops = &sn3112_pwm_ops;
++	ret = pwmchip_add(chip);
++	if (ret < 0)
++		goto err_disable_vdd;
++
++#if IS_ENABLED(CONFIG_GPIOLIB)
++	/* disable hardware shutdown pin */
++	if (priv->sdb)
++		gpiod_set_value(priv->sdb, 0);
++#endif
++
++	/* initialize registers */
++	ret = sn3112_write_all(priv);
++	if (ret != 0) {
++		dev_err(priv->pdev, "Failed to initialize sn3112: %d\n", ret);
++		goto err_remove_chip;
++	}
++
++	dev_info(&client->dev,
++		 "Found SI-EN SN3112 12-channel 8-bit PWM LED controller\n");
++	return 0;
++
++err_remove_chip:
++	pwmchip_remove(chip);
++err_disable_vdd:
++	regulator_disable(priv->vdd);
++	return ret;
++}
++
++static void sn3112_pwm_remove(struct i2c_client *client)
++{
++	struct pwm_chip *chip = i2c_get_clientdata(client);
++	struct sn3112 *priv = pwmchip_get_drvdata(chip);
++
++	dev_dbg(priv->pdev, "remove\n");
++	pwmchip_remove(chip);
++
++	/* set software enable register */
++	sn3112_write_reg(priv, SN3112_REG_ENABLE, 0);
++
++	/* use random value to apply changes */
++	sn3112_write_reg(priv, SN3112_REG_APPLY, 0x66);
++
++#if IS_ENABLED(CONFIG_GPIOLIB)
++	/* enable hardware shutdown pin */
++	if (priv->sdb)
++		gpiod_set_value(priv->sdb, 1);
++#endif
++
++	/* power-off sn5112 power vdd */
++	regulator_disable(priv->vdd);
++}
++
++static const struct i2c_device_id sn3112_id[] = {
++	{ "sn3112", 0 },
++	{ /* sentinel */ },
++};
++MODULE_DEVICE_TABLE(i2c, sn3112_id);
++
++#ifdef CONFIG_OF
++static const struct of_device_id sn3112_dt_ids[] = {
++	{ .compatible = "si-en,sn3112-pwm", },
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, sn3112_dt_ids);
++#endif
++
++static struct i2c_driver sn3112_i2c_driver = {
++	.driver = {
++		.name = "sn3112-pwm",
++		.of_match_table = of_match_ptr(sn3112_dt_ids),
++	},
++	.probe = sn3112_pwm_probe,
++	.remove = sn3112_pwm_remove,
++	.id_table = sn3112_id,
++};
++
++module_i2c_driver(sn3112_i2c_driver);
++
++MODULE_AUTHOR("BigfootACA <bigfoot@classfun.cn>");
++MODULE_DESCRIPTION("PWM driver for SI-EN SN3112");
++MODULE_LICENSE("GPL");
+-- 
+2.43.0
+

--- a/patch/kernel/archive/sm8550-6.19/0015-dts-arm64-qcom-Added-Ayn-Odin2-device-support.patch
+++ b/patch/kernel/archive/sm8550-6.19/0015-dts-arm64-qcom-Added-Ayn-Odin2-device-support.patch
@@ -1,0 +1,1972 @@
+From 1701b3c07d0e77a84edd33392a14776680e1f8ba Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sat, 17 Jan 2026 18:06:57 +0800
+Subject: [PATCH 15/15] dts: arm64: qcom: Added Ayn Odin2 device support
+
+Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
+---
+ arch/arm64/boot/dts/qcom/Makefile             |    2 +
+ .../boot/dts/qcom/qcs8550-ayn-common.dtsi     | 1399 +++++++++++++++++
+ .../arm64/boot/dts/qcom/qcs8550-ayn-odin2.dts |  270 ++++
+ .../boot/dts/qcom/qcs8550-ayn-odin2portal.dts |  253 +++
+ 4 files changed, 1924 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/qcom/qcs8550-ayn-common.dtsi
+ create mode 100644 arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2.dts
+ create mode 100644 arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2portal.dts
+
+diff --git a/arch/arm64/boot/dts/qcom/Makefile b/arch/arm64/boot/dts/qcom/Makefile
+index 6f34d5ed331c..8a029264ad66 100644
+--- a/arch/arm64/boot/dts/qcom/Makefile
++++ b/arch/arm64/boot/dts/qcom/Makefile
+@@ -140,6 +140,8 @@ dtb-$(CONFIG_ARCH_QCOM)	+= qcs6490-rb3gen2-industrial-mezzanine.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs6490-rb3gen2-vision-mezzanine.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs8300-ride.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs8550-aim300-aiot.dtb
++dtb-$(CONFIG_ARCH_QCOM)	+= qcs8550-ayn-odin2.dtb
++dtb-$(CONFIG_ARCH_QCOM)	+= qcs8550-ayn-odin2portal.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs9100-ride.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs9100-ride-r3.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qdu1000-idp.dtb
+diff --git a/arch/arm64/boot/dts/qcom/qcs8550-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/qcs8550-ayn-common.dtsi
+new file mode 100644
+index 000000000000..2b6da737a0c3
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qcs8550-ayn-common.dtsi
+@@ -0,0 +1,1399 @@
++// SPDX-License-Identifier: BSD-3-Clause
++/*
++ * Copyright (c) 2025, Teguh Sobirin.
++ */
++
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/regulator/qcom,rpmh-regulator.h>
++#include "qcs8550.dtsi"
++#include "pm8550.dtsi"
++#include "pm8550b.dtsi"
++#define PMK8550VE_SID 5
++#include "pm8550ve.dtsi"
++#include "pm8550vs.dtsi"
++#include "pmk8550.dtsi"
++
++/delete-node/ &aop_config_mem;
++/delete-node/ &camera_mem;
++/delete-node/ &ipa_fw_mem;
++/delete-node/ &ipa_gsi_mem;
++/delete-node/ &mpss_dsm_mem;
++/delete-node/ &mpss_mem;
++/delete-node/ &q6_mpss_dtb_mem;
++
++/delete-node/ &cci0;
++/delete-node/ &cci1;
++/delete-node/ &cci2;
++/delete-node/ &camcc;
++/delete-node/ &camss;
++/delete-node/ &remoteproc_mpss;
++
++/ {
++	chassis-type = "handset";
++
++	aliases {
++		serial0 = &uart7;
++		serial1 = &uart14;
++		serial2 = &uart15;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		pinctrl-0 = <&volume_up_n>;
++		pinctrl-names = "default";
++
++		key-volume-up {
++			label = "Volume Up";
++			debounce-interval = <15>;
++			gpios = <&pm8550_gpios 6 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_VOLUMEUP>;
++			linux,can-disable;
++			wakeup-source;
++		};
++	};
++
++	pmic-glink {
++		compatible = "qcom,sm8550-pmic-glink", "qcom,pmic-glink";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		orientation-gpios = <&tlmm 11 GPIO_ACTIVE_HIGH>;
++
++		connector@0 {
++			compatible = "usb-c-connector";
++			reg = <0>;
++			power-role = "dual";
++			data-role = "dual";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					pmic_glink_hs_in: endpoint {
++						remote-endpoint = <&usb_1_dwc3_hs>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					pmic_glink_ss_in: endpoint {
++						remote-endpoint = <&usb_dp_qmpphy_out>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					pmic_glink_sbu: endpoint {
++						remote-endpoint = <&usb0_sbu_mux>;
++					};
++				};
++			};
++		};
++	};
++
++	pwm_fan: pwm-fan {
++		// 40 -> 1550 RPM
++		// 65 -> 2450 RPM
++		// 75 -> 2750 RPM
++		// 90 -> 3250 RPM
++		// 100 -> 3550 RPM
++		// 130 -> 4400 RPM
++		// 150 -> 4850 RPM
++		// 180 -> 5500 RPM
++		// 255 -> 6000 RPM
++		compatible = "pwm-fan";
++		/* level (0, 1, 2, 3, 4, 5, 6, 7) */
++		cooling-levels = <0 40 65 75 90 100 130 150>;
++		#cooling-cells = <2>;
++		fan-supply = <&vdd_fan_5v0>;
++		pwms = <&pm8550_pwm 3 100000>;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&fan_pwm_active &fan_int>;
++
++		pulses-per-revolution = <4>;
++		interrupt-parent = <&tlmm>;
++		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
++	};
++
++reserved-memory {
++		hyp_mem: hyp-region@80000000 {
++			reg = <0 0x80000000 0 0xa00000>;
++			no-map;
++		};
++
++		cpusys_vm_mem: cpusys-vm-region@80a00000 {
++			reg = <0 0x80a00000 0 0x400000>;
++			no-map;
++		};
++
++		hyp_tags_mem: hyp-tags-region@80e00000 {
++			reg = <0 0x80e00000 0 0x3d0000>;
++			no-map;
++		};
++
++		xbl_sc_mem: xbl-sc-region@d8100000 {
++			reg = <0 0xd8100000 0 0x40000>;
++			no-map;
++		};
++
++		hyp_tags_reserved_mem: hyp-tags-reserved-region@811d0000 {
++			reg = <0 0x811d0000 0 0x30000>;
++			no-map;
++		};
++
++		xbl_dt_log_merged_mem: xbl-dt-log-merged-region@81a00000 {
++			reg = <0 0x81a00000 0 0x260000>;
++			no-map;
++		};
++
++		aop_config_merged_mem: aop-config-merged-region@81c80000 {
++			reg = <0 0x81c80000 0 0x74000>;
++			no-map;
++		};
++
++		chipinfo_mem: chipinfo-region@81cf4000 {
++			reg = <0 0x81cf4000 0 0x1000>;
++			no-map;
++		};
++
++		global_sync_mem: global-sync-region@82600000 {
++			reg = <0 0x82600000 0 0x100000>;
++			no-map;
++		};
++
++		tz_stat_mem: tz-stat-region@82700000 {
++			reg = <0 0x82700000 0 0x100000>;
++			no-map;
++		};
++
++		cpucp_fw_mem: cpucp-fw-region@d8140000 {
++			reg = <0 0xd8140000 0 0x1c0000>;
++			no-map;
++		};
++
++		qtee_mem: qtee-region@d8300000 {
++			reg = <0 0xd8300000 0 0x500000>;
++			no-map;
++		};
++
++		hwfence_shbuf: hwfence-shbuf-region@e6440000 {
++			reg = <0 0xe6440000 0 0x2dd000>;
++			no-map;
++		};
++
++		hyp_ext_reserved_mem: hyp-ext-reserved-region@ff700000 {
++			reg = <0 0xff700000 0 0x100000>;
++			no-map;
++		};
++
++		llcc_lpi_mem: llcc_lpi_region@ff800000 {
++			reg = <0 0xff800000 0 0x600000>;
++			no-map;
++		};
++
++		hyp_ext_tags_mem: hyp-ext-tags-region@fce00000 {
++			reg = <0 0xfce00000 0 0x2900000>;
++			no-map;
++		};
++	};
++
++	thermal-zones {
++		cpuss2-thermal {
++			trips {
++				// cpu7_middle_alert0: trip-point0 {
++				// 	temperature = <90000>;
++				// 	hysteresis = <2000>;
++				// 	type = "passive";
++				// };
++
++				// cpu7_middle_alert1: trip-point1 {
++				// 	temperature = <95000>;
++				// 	hysteresis = <2000>;
++				// 	type = "passive";
++				// };
++
++				// cpu7_middle_crit: cpu-critical {
++				// 	temperature = <110000>;
++				// 	hysteresis = <1000>;
++				// 	type = "critical";
++				// };
++
++				cpu7_middle_fan0: trip-point2 {
++					temperature = <50000>;
++					hysteresis = <2000>;
++					type = "active";
++				};
++
++				cpu7_middle_fan1: trip-point3 {
++					temperature = <55000>;
++					hysteresis = <2000>;
++					type = "active";
++				};
++
++				cpu7_middle_fan2: trip-point4 {
++					temperature = <60000>;
++					hysteresis = <2000>;
++					type = "active";
++				};
++
++				cpu7_middle_fan3: trip-point5 {
++					temperature = <65000>;
++					hysteresis = <2000>;
++					type = "active";
++				};
++
++				cpu7_middle_fan4: trip-point6 {
++					temperature = <70000>;
++					hysteresis = <2000>;
++					type = "active";
++				};
++
++				cpu7_middle_fan5: trip-point7 {
++					temperature = <75000>;
++					hysteresis = <2000>;
++					type = "active";
++				};
++
++				cpu7_middle_fan6: trip-point8 {
++					temperature = <80000>;
++					hysteresis = <2000>;
++					type = "active";
++				};
++
++				// cpu7_middle_fan7: trip-point9 {
++				// 	temperature = <75000>;
++				// 	hysteresis = <2000>;
++				// 	type = "active";
++				// };
++
++				// cpu7_middle_fan8: trip-point10 {
++				// 	temperature = <80000>;
++				// 	hysteresis = <2000>;
++				// 	type = "active";
++				// };
++			};
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu7_middle_fan0>;
++					cooling-device = <&pwm_fan 0 1>;
++				};
++				map1 {
++					trip = <&cpu7_middle_fan1>;
++					cooling-device = <&pwm_fan 1 2>;
++				};
++				map2 {
++					trip = <&cpu7_middle_fan2>;
++					cooling-device = <&pwm_fan 2 3>;
++				};
++				map3 {
++					trip = <&cpu7_middle_fan3>;
++					cooling-device = <&pwm_fan 3 4>;
++				};
++				map4 {
++					trip = <&cpu7_middle_fan4>;
++					cooling-device = <&pwm_fan 4 5>;
++				};
++				map5 {
++					trip = <&cpu7_middle_fan5>;
++					cooling-device = <&pwm_fan 5 6>;
++				};
++				map6 {
++					trip = <&cpu7_middle_fan6>;
++					cooling-device = <&pwm_fan 6 7>;
++				};
++				// map7 {
++				// 	trip = <&cpu7_middle_fan7>;
++				// 	cooling-device = <&pwm_fan 7 8>;
++				// };
++				// map8 {
++				// 	trip = <&cpu7_middle_fan8>;
++				// 	cooling-device = <&pwm_fan 8 9>;
++				// };
++			};
++		};
++	};
++
++	sound {
++		compatible = "qcom,sm8550-sndcard", "qcom,sm8450-sndcard";
++		pinctrl-0 = <&lpi_i2s3_active>;
++		pinctrl-names = "default";
++
++		clocks = <&q6prmcc LPASS_CLK_ID_SEN_MI2S_IBIT LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++		clock-names = "i2s_clk";
++
++		assigned-clocks = <&q6prmcc LPASS_CLK_ID_SEN_MI2S_IBIT LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++		assigned-clock-rates = <1536000>;
++
++		model = "AYN-Odin2";
++		audio-routing =
++				"IN1_HPHL", "HPHL_OUT",
++				"IN2_HPHR", "HPHR_OUT",
++				"AMIC2", "MIC BIAS2",
++				"TX SWR_INPUT1", "ADC2_OUTPUT";
++
++		speaker-i2s-dai-link {
++			link-name = "Primary MI2S Playback";
++
++			cpu {
++				sound-dai = <&q6apmbedai PRIMARY_MI2S_RX>;
++			};
++
++			codec {
++				sound-dai = <&spk_amp_l 0>, <&spk_amp_r 0>;
++			};
++
++			platform {
++				sound-dai = <&q6apm>;
++			};
++		};
++
++		wcd-playback-dai-link {
++			link-name = "WCD Playback";
++
++			cpu {
++				sound-dai = <&q6apmbedai RX_CODEC_DMA_RX_0>;
++			};
++
++			codec {
++				sound-dai = <&wcd938x 0>, <&swr1 0>, <&lpass_rxmacro 0>;
++			};
++
++			platform {
++				sound-dai = <&q6apm>;
++			};
++		};
++
++		wcd-capture-dai-link {
++			link-name = "WCD Capture";
++
++			cpu {
++				sound-dai = <&q6apmbedai TX_CODEC_DMA_TX_3>;
++			};
++
++			codec {
++				sound-dai = <&wcd938x 1>, <&swr2 0>, <&lpass_txmacro 0>;
++			};
++
++			platform {
++				sound-dai = <&q6apm>;
++			};
++		};
++
++		dp0-dai-link {
++			link-name = "DP0 Playback";
++			cpu {
++				sound-dai = <&q6apmbedai DISPLAY_PORT_RX_0>;
++			};
++
++			platform {
++				sound-dai = <&q6apm>;
++			};
++
++			codec {
++				sound-dai = <&mdss_dp0>;
++			};
++		};
++	};
++
++	usb0-sbu-mux {
++		compatible = "gpio-sbu-mux";
++
++		enable-gpios = <&tlmm 140 GPIO_ACTIVE_LOW>;
++		select-gpios = <&tlmm 141 GPIO_ACTIVE_HIGH>;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb0_sbu_default>;
++
++		mode-switch;
++		orientation-switch;
++
++		port {
++			usb0_sbu_mux: endpoint {
++				remote-endpoint = <&pmic_glink_sbu>;
++			};
++		};
++	};
++
++	vdd_fan_5v0: vdd-fan-5v0-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_fan_5v0";
++
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++
++		gpio = <&tlmm 109 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&fan_pwr_active>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_mcu_3v3: vdd-mcu-3v3-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_mcu_3v3";
++
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++
++		gpio = <&tlmm 99 GPIO_ACTIVE_HIGH>;
++		regulator-always-on;
++		regulator-boot-on;
++		enable-active-high;
++	};
++
++	vph_pwr: regulator-vph-pwr {
++		compatible = "regulator-fixed";
++		regulator-name = "vph_pwr";
++		regulator-min-microvolt = <3700000>;
++		regulator-max-microvolt = <3700000>;
++
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	wcd938x: audio-codec {
++		compatible = "qcom,wcd9385-codec";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&wcd_default>;
++
++		qcom,micbias1-microvolt = <1800000>;
++		qcom,micbias2-microvolt = <1800000>;
++		qcom,micbias3-microvolt = <1800000>;
++		qcom,micbias4-microvolt = <1800000>;
++		qcom,mbhc-buttons-vthreshold-microvolt = <75000 150000 237000 500000 500000 500000 500000 500000>;
++		qcom,mbhc-headset-vthreshold-microvolt = <1700000>;
++		qcom,mbhc-headphone-vthreshold-microvolt = <50000>;
++		qcom,rx-device = <&wcd_rx>;
++		qcom,tx-device = <&wcd_tx>;
++
++		reset-gpios = <&tlmm 108 GPIO_ACTIVE_LOW>;
++
++		vdd-buck-supply = <&vreg_l15b_1p8>;
++		vdd-rxtx-supply = <&vreg_l15b_1p8>;
++		vdd-io-supply = <&vreg_l15b_1p8>;
++		vdd-mic-bias-supply = <&vreg_bob1>;
++
++		#sound-dai-cells = <1>;
++	};
++
++	wcn7850-pmu {
++		compatible = "qcom,wcn7850-pmu";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&wlan_en>, <&bt_default>, <&pmk8550_sleep_clk>;
++
++		wlan-enable-gpios = <&tlmm 80 GPIO_ACTIVE_HIGH>;
++		bt-enable-gpios = <&tlmm 81 GPIO_ACTIVE_HIGH>;
++
++		vdd-supply = <&vreg_s5g_0p85>;
++		vddio-supply = <&vreg_l15b_1p8>;
++		vddaon-supply = <&vreg_s2g_0p85>;
++		vdddig-supply = <&vreg_s4e_0p95>;
++		vddrfa1p2-supply = <&vreg_s4g_1p25>;
++		vddrfa1p8-supply = <&vreg_s6g_1p86>;
++
++		regulators {
++			vreg_pmu_rfa_cmn: ldo0 {
++				regulator-name = "vreg_pmu_rfa_cmn";
++			};
++
++			vreg_pmu_aon_0p59: ldo1 {
++				regulator-name = "vreg_pmu_aon_0p59";
++			};
++
++			vreg_pmu_wlcx_0p8: ldo2 {
++				regulator-name = "vreg_pmu_wlcx_0p8";
++			};
++
++			vreg_pmu_wlmx_0p85: ldo3 {
++				regulator-name = "vreg_pmu_wlmx_0p85";
++			};
++
++			vreg_pmu_btcmx_0p85: ldo4 {
++				regulator-name = "vreg_pmu_btcmx_0p85";
++			};
++
++			vreg_pmu_rfa_0p8: ldo5 {
++				regulator-name = "vreg_pmu_rfa_0p8";
++			};
++
++			vreg_pmu_rfa_1p2: ldo6 {
++				regulator-name = "vreg_pmu_rfa_1p2";
++			};
++
++			vreg_pmu_rfa_1p8: ldo7 {
++				regulator-name = "vreg_pmu_rfa_1p8";
++			};
++
++			vreg_pmu_pcie_0p9: ldo8 {
++				regulator-name = "vreg_pmu_pcie_0p9";
++			};
++
++			vreg_pmu_pcie_1p8: ldo9 {
++				regulator-name = "vreg_pmu_pcie_1p8";
++			};
++		};
++	};
++};
++
++&apps_rsc {
++	regulators-0 {
++		compatible = "qcom,pm8550-rpmh-regulators";
++		qcom,pmic-id = "b";
++
++		vdd-bob1-supply = <&vph_pwr>;
++		vdd-bob2-supply = <&vph_pwr>;
++		vdd-l1-l4-l10-supply = <&vreg_s6g_1p86>;
++		vdd-l2-l13-l14-supply = <&vreg_bob1>;
++		vdd-l3-supply = <&vreg_s4g_1p25>;
++		vdd-l5-l16-supply = <&vreg_bob1>;
++		vdd-l6-l7-supply = <&vreg_bob1>;
++		vdd-l8-l9-supply = <&vreg_bob1>;
++		vdd-l11-supply = <&vreg_s4g_1p25>;
++		vdd-l12-supply = <&vreg_s6g_1p86>;
++		vdd-l15-supply = <&vreg_s6g_1p86>;
++		vdd-l17-supply = <&vreg_bob2>;
++
++		vreg_bob1: bob1 {
++			regulator-name = "vreg_bob1";
++			regulator-min-microvolt = <3296000>;
++			regulator-max-microvolt = <3960000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_bob2: bob2 {
++			regulator-name = "vreg_bob2";
++			regulator-min-microvolt = <2720000>;
++			regulator-max-microvolt = <3960000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l1b_1p8: ldo1 {
++			regulator-name = "vreg_l1b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l2b_3p0: ldo2 {
++			regulator-name = "vreg_l2b_3p0";
++			regulator-min-microvolt = <3008000>;
++			regulator-max-microvolt = <3008000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l5b_3p1: ldo5 {
++			regulator-name = "vreg_l5b_3p1";
++			regulator-min-microvolt = <3104000>;
++			regulator-max-microvolt = <3104000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l6b_1p8: ldo6 {
++			regulator-name = "vreg_l6b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <3008000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l7b_1p8: ldo7 {
++			regulator-name = "vreg_l7b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <3008000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l8b_1p8: ldo8 {
++			regulator-name = "vreg_l8b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <3008000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l9b_2p9: ldo9 {
++			regulator-name = "vreg_l9b_2p9";
++			regulator-min-microvolt = <2960000>;
++			regulator-max-microvolt = <3008000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l11b_1p2: ldo11 {
++			regulator-name = "vreg_l11b_1p2";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1504000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l12b_1p8: ldo12 {
++			regulator-name = "vreg_l12b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l13b_3p0: ldo13 {
++			regulator-name = "vreg_l13b_3p0";
++			regulator-min-microvolt = <3000000>;
++			regulator-max-microvolt = <3000000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l14b_3p2: ldo14 {
++			regulator-name = "vreg_l14b_3p2";
++			regulator-min-microvolt = <3200000>;
++			regulator-max-microvolt = <3200000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l15b_1p8: ldo15 {
++			regulator-name = "vreg_l15b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l16b_2p8: ldo16 {
++			regulator-name = "vreg_l16b_2p8";
++			regulator-min-microvolt = <2800000>;
++			regulator-max-microvolt = <2800000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l17b_2p5: ldo17 {
++			regulator-name = "vreg_l17b_2p5";
++			regulator-min-microvolt = <2504000>;
++			regulator-max-microvolt = <2504000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++
++	regulators-1 {
++		compatible = "qcom,pm8550vs-rpmh-regulators";
++		qcom,pmic-id = "c";
++
++		vdd-l1-supply = <&vreg_s4g_1p25>;
++		vdd-l2-supply = <&vreg_s4e_0p95>;
++		vdd-l3-supply = <&vreg_s4e_0p95>;
++
++		vreg_l3c_0p9: ldo3 {
++			regulator-name = "vreg_l3c_0p9";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <912000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++
++	regulators-2 {
++		compatible = "qcom,pm8550vs-rpmh-regulators";
++		qcom,pmic-id = "d";
++
++		vdd-l1-supply = <&vreg_s4e_0p95>;
++		vdd-l2-supply = <&vreg_s4e_0p95>;
++		vdd-l3-supply = <&vreg_s4e_0p95>;
++
++		vreg_l1d_0p88: ldo1 {
++			regulator-name = "vreg_l1d_0p88";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <920000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++
++	regulators-3 {
++		compatible = "qcom,pm8550vs-rpmh-regulators";
++		qcom,pmic-id = "e";
++
++		vdd-l1-supply = <&vreg_s4e_0p95>;
++		vdd-l2-supply = <&vreg_s4e_0p95>;
++		vdd-l3-supply = <&vreg_s4g_1p25>;
++		vdd-s4-supply = <&vph_pwr>;
++		vdd-s5-supply = <&vph_pwr>;
++
++		vreg_s4e_0p95: smps4 {
++			regulator-name = "vreg_s4e_0p95";
++			regulator-min-microvolt = <904000>;
++			regulator-max-microvolt = <984000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s5e_1p08: smps5 {
++			regulator-name = "vreg_s5e_1p08";
++			regulator-min-microvolt = <1010000>;
++			regulator-max-microvolt = <1120000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l1e_0p88: ldo1 {
++			regulator-name = "vreg_l1e_0p88";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <912000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l2e_0p9: ldo2 {
++			regulator-name = "vreg_l2e_0p9";
++			regulator-min-microvolt = <870000>;
++			regulator-max-microvolt = <970000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l3e_1p2: ldo3 {
++			regulator-name = "vreg_l3e_1p2";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1200000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++
++	regulators-4 {
++		compatible = "qcom,pm8550ve-rpmh-regulators";
++		qcom,pmic-id = "f";
++
++		vdd-l1-supply = <&vreg_s4e_0p95>;
++		vdd-l2-supply = <&vreg_s4e_0p95>;
++		vdd-l3-supply = <&vreg_s4e_0p95>;
++		vdd-s4-supply = <&vph_pwr>;
++
++		vreg_s4f_0p5: smps4 {
++			regulator-name = "vreg_s4f_0p5";
++			regulator-min-microvolt = <300000>;
++			regulator-max-microvolt = <700000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l1f_0p9: ldo1 {
++			regulator-name = "vreg_l1f_0p9";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <912000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l2f_0p88: ldo2 {
++			regulator-name = "vreg_l2f_0p88";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <912000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l3f_0p88: ldo3 {
++			regulator-name = "vreg_l3f_0p88";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <912000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++
++	regulators-5 {
++		compatible = "qcom,pm8550vs-rpmh-regulators";
++		qcom,pmic-id = "g";
++		vdd-l1-supply = <&vreg_s4g_1p25>;
++		vdd-l2-supply = <&vreg_s4g_1p25>;
++		vdd-l3-supply = <&vreg_s4g_1p25>;
++		vdd-s1-supply = <&vph_pwr>;
++		vdd-s2-supply = <&vph_pwr>;
++		vdd-s3-supply = <&vph_pwr>;
++		vdd-s4-supply = <&vph_pwr>;
++		vdd-s5-supply = <&vph_pwr>;
++		vdd-s6-supply = <&vph_pwr>;
++
++		vreg_s1g_1p25: smps1 {
++			regulator-name = "vreg_s1g_1p25";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1300000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s2g_0p85: smps2 {
++			regulator-name = "vreg_s2g_0p85";
++			regulator-min-microvolt = <500000>;
++			regulator-max-microvolt = <1036000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s3g_0p8: smps3 {
++			regulator-name = "vreg_s3g_0p8";
++			regulator-min-microvolt = <300000>;
++			regulator-max-microvolt = <1004000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s4g_1p25: smps4 {
++			regulator-name = "vreg_s4g_1p25";
++			regulator-min-microvolt = <1256000>;
++			regulator-max-microvolt = <1408000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s5g_0p85: smps5 {
++			regulator-name = "vreg_s5g_0p85";
++			regulator-min-microvolt = <500000>;
++			regulator-max-microvolt = <1004000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s6g_1p86: smps6 {
++			regulator-name = "vreg_s6g_1p86";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <2000000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l1g_1p2: ldo1 {
++			regulator-name = "vreg_l1g_1p2";
++			regulator-min-microvolt = <1128000>;
++			regulator-max-microvolt = <1272000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l2g_1p2: ldo2 {
++			regulator-name = "vreg_l2g_1p2";
++			regulator-min-microvolt = <1100000>;
++			regulator-max-microvolt = <1200000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l3g_1p2: ldo3 {
++			regulator-name = "vreg_l3g_1p2";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1200000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++};
++
++&gpi_dma1 {
++	status = "okay";
++};
++
++&gpi_dma2 {
++	status = "okay";
++};
++
++&gpu {
++	status = "okay";
++};
++
++&i2c0 {
++	clock-frequency = <400000>;
++	status = "okay";
++};
++
++&i2c4 {
++	clock-frequency = <400000>;
++	status = "okay";
++};
++
++&i2c12 {
++	clock-frequency = <400000>;
++	status = "okay";
++};
++
++&i2c_master_hub_0 {
++	status = "okay";
++};
++
++&i2c_hub_2 {
++	clock-frequency = <400000>;
++	status = "okay";
++
++	spk_amp_l: spk_amp_l@34 {
++		compatible = "awinic,aw88166";
++		reg = <0x34>;
++		#sound-dai-cells = <1>;
++		reset-gpios = <&tlmm 103 GPIO_ACTIVE_HIGH>;
++		awinic,audio-channel = <0>;
++		awinic,sync-flag;
++		sound-name-prefix = "SPK_L";
++	};
++
++	spk_amp_r: spk_amp_r@35 {
++		compatible = "awinic,aw88166";
++		reg = <0x35>;
++		#sound-dai-cells = <1>;
++		reset-gpios = <&tlmm 100 GPIO_ACTIVE_HIGH>;
++		awinic,audio-channel = <1>;
++		awinic,sync-flag;
++		sound-name-prefix = "SPK_R";
++	};
++};
++
++&iris {
++        status = "okay";
++};
++
++&lpass_vamacro {
++	qcom,dmic-sample-rate = <4800000>;
++};
++
++&lpass_wsamacro {
++	status = "disabled";
++};
++
++&lpass_tlmm {
++	lpi_i2s3_active: lpi_i2s3-active-state {
++		sck-pins {
++			pins = "gpio12";
++			function = "i2s3_clk";
++			drive-strength = <8>;
++			bias-disable;
++			output-high;
++		};
++
++		ws-pins {
++			pins = "gpio13";
++			function = "i2s3_ws";
++			drive-strength = <8>;
++			bias-disable;
++			output-high;
++		};
++
++		data0-pins {
++			pins = "gpio17";
++			function = "i2s3_data";
++			drive-strength = <8>;
++			bias-disable;
++			output-high;
++		};
++
++		data1-pins {
++			pins = "gpio18";
++			function = "i2s3_data";
++			drive-strength = <8>;
++			bias-disable;
++			output-high;
++		};
++	};
++};
++
++&mdss {
++	status = "okay";
++};
++
++&mdss_dp0 {
++	status = "okay";
++	sound-name-prefix = "Display Port0";
++};
++
++&mdss_dp0_out {
++	data-lanes = <0 1 2 3>;
++	link-frequencies = /bits/ 64 <1620000000 2700000000 5400000000 8100000000>;
++};
++
++&mdss_dsi1 {
++	vdda-supply = <&vreg_l3e_1p2>;
++	status = "okay";
++
++	display_panel: panel@0 {
++		reg = <0>;
++
++		pinctrl-0 = <&sde_dsi_active>, <&sde_te_active>;
++		pinctrl-1 = <&sde_dsi_suspend>, <&sde_te_suspend>;
++		pinctrl-names = "default", "sleep";
++
++		port {
++			panel0_in: endpoint {
++				remote-endpoint = <&mdss_dsi1_out>;
++			};
++		};
++	};
++};
++
++&mdss_dsi1_out {
++	remote-endpoint = <&panel0_in>;
++	data-lanes = <0 1 2 3>;
++};
++
++&mdss_dsi1_phy {
++	vdds-supply = <&vreg_l1e_0p88>;
++	status = "okay";
++};
++
++&pcie0 {
++	perst-gpios = <&tlmm 94 GPIO_ACTIVE_LOW>;
++	wake-gpios = <&tlmm 96 GPIO_ACTIVE_HIGH>;
++	max-link-speed = <2>;
++
++	pinctrl-0 = <&pcie0_default_state>;
++	pinctrl-names = "default";
++
++	status = "okay";
++};
++
++&pcieport0 {
++	wifi@0 {
++		compatible = "pci17cb,1107";
++		reg = <0x10000 0x0 0x0 0x0 0x0>;
++
++		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
++		vddaon-supply = <&vreg_pmu_aon_0p59>;
++		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
++		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
++		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
++		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
++		vddrfa1p8-supply = <&vreg_pmu_rfa_1p8>;
++		vddpcie0p9-supply = <&vreg_pmu_pcie_0p9>;
++		vddpcie1p8-supply = <&vreg_pmu_pcie_1p8>;
++	};
++};
++
++&pcie0_phy {
++	vdda-phy-supply = <&vreg_l1e_0p88>;
++	vdda-pll-supply = <&vreg_l3e_1p2>;
++
++	status = "okay";
++};
++
++&pm8550_gpios {
++	fan_pwm_active: fan-pwm-active-state {
++		pins = "gpio8";
++		function = "func1";
++		input-disable;
++		output-enable;
++		output-low;
++		bias-disable;
++		power-source = <1>;
++	};
++
++	sdc2_card_det_n: sdc2-card-det-n-state {
++		pins = "gpio12";
++		function = "normal";
++		input-enable;
++		output-disable;
++		bias-pull-up;
++		power-source = <1>;
++	};
++
++	volume_up_n: volume-up-n-state {
++		pins = "gpio6";
++		function = "normal";
++		power-source = <1>;
++		bias-pull-up;
++		input-enable;
++	};
++};
++
++&pm8550_pwm {
++	status = "okay";
++};
++
++&pm8550b_eusb2_repeater {
++	qcom,tune-usb2-disc-thres = /bits/ 8 <0x6>;
++	qcom,tune-usb2-amplitude = /bits/ 8 <0xb>;
++	qcom,tune-usb2-preem = /bits/ 8 <0x3>;
++	vdd18-supply = <&vreg_l15b_1p8>;
++	vdd3-supply = <&vreg_l5b_3p1>;
++};
++
++&pmk8550_gpios {
++	pmk8550_sleep_clk: sleep-clk-state {
++		pins = "gpio3";
++		function = "func1";
++		input-disable;
++		output-enable;
++		bias-disable;
++		power-source = <0>;
++	};
++};
++
++&pmk8550_rtc {
++	nvmem-cells = <&rtc_offset>;
++	nvmem-cell-names = "offset";
++};
++
++&pmk8550_sdam_2 {
++	rtc_offset: rtc-offset@bc {
++		reg = <0xbc 0x4>;
++	};
++};
++
++&pon_pwrkey {
++	status = "okay";
++};
++
++&pon_resin {
++	linux,code = <KEY_VOLUMEDOWN>;
++
++	status = "okay";
++};
++
++&qupv3_id_0 {
++	status = "okay";
++};
++
++&qupv3_id_1 {
++	status = "okay";
++};
++
++&sdhc_2 {
++	cd-gpios = <&pm8550_gpios 12 GPIO_ACTIVE_LOW>;
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&sdc2_default &sdc2_card_det_n>;
++	pinctrl-1 = <&sdc2_sleep &sdc2_card_det_n>;
++	vmmc-supply = <&vreg_l9b_2p9>;
++	vqmmc-supply = <&vreg_l8b_1p8>;
++	max-sd-hs-hz = <37500000>;
++	no-sdio;
++	no-mmc;
++
++	qcom,dll-config = <0x0007442c>;
++
++	status = "okay";
++};
++
++&sleep_clk {
++	clock-frequency = <32764>;
++};
++
++&swr1 {
++	status = "okay";
++	wcd_rx: codec@0,4 {
++		compatible = "sdw20217010d00";
++		reg = <0 4>;
++		qcom,rx-port-mapping = <1 2 3 4 5>;
++	};
++};
++
++&swr2 {
++	status = "okay";
++	wcd_tx: codec@0,3 {
++		compatible = "sdw20217010d00";
++		reg = <0 3>;
++		qcom,tx-port-mapping = <2 2 3 4>;
++	};
++};
++
++&tlmm {
++	gpio-reserved-ranges = <32 8>;
++
++	bt_default: bt-default-state {
++		bt-en-pins {
++			pins = "gpio81";
++			function = "gpio";
++			drive-strength = <16>;
++			bias-disable;
++		};
++
++		sw-ctrl-pins {
++			pins = "gpio82";
++			function = "gpio";
++			bias-pull-down;
++		};
++	};
++
++	fan_pwr_active: fan-pwr-active-state {
++		pins = "gpio109";
++		function = "gpio";
++		drive-strength = <2>;
++		bias-disable;
++		output-low;
++	};
++
++	fan_int: fan-int-state {
++		pins = "gpio13";
++		function = "gpio";
++		drive-strength = <2>;
++		bias-disable;
++	};
++
++	mcu_en_active: mcu-en-active-state {
++		pins = "gpio12";
++		function = "gpio";
++		bias-pull-down;
++	};
++
++	sde_dsi_active: sde-dsi-active-state {
++		pins = "gpio133";
++		function = "gpio";
++		drive-strength = <8>;
++		bias-disable;
++	};
++
++	sde_dsi_suspend: sde-dsi-suspend-state {
++		pins = "gpio133";
++		function = "gpio";
++		drive-strength = <2>;
++		bias-pull-down;
++	};
++
++	sde_te_active: sde-te-active-state {
++		pins = "gpio86";
++		function = "mdp_vsync";
++		drive-strength = <2>;
++		bias-pull-down;
++	};
++
++	sde_te_suspend: sde-te-suspend-state {
++		pins = "gpio86";
++		function = "mdp_vsync";
++		drive-strength = <2>;
++		bias-pull-down;
++	};
++
++	ts_rst_default: ts-rst-default-state {
++		pins = "gpio24";
++		function = "gpio";
++		bias-pull-up;
++		drive-strength = <8>;
++	};
++
++	ts_rst_sleep: ts-rst-sleep-state {
++		pins = "gpio24";
++		function = "gpio";
++		bias-pull-down;
++		drive-strength = <2>;
++	};
++
++	ts_int_default: ts-int-default-state {
++		pins = "gpio25";
++		function = "gpio";
++		bias-pull-up;
++		drive-strength = <8>;
++	};
++
++	ts_int_sleep: ts-int-sleep-state {
++		pins = "gpio25";
++		function = "gpio";
++		bias-pull-down;
++		drive-strength = <2>;
++	};
++
++	usb0_sbu_default: usb0-sbu-state {
++		oe-n-pins {
++			pins = "gpio140";
++			function = "gpio";
++			bias-disable;
++			drive-strength = <16>;
++			output-high;
++		};
++
++		sel-pins {
++			pins = "gpio141";
++			function = "gpio";
++			bias-disable;
++			drive-strength = <16>;
++		};
++	};
++
++	wcd_default: wcd-reset-n-active-state {
++		pins = "gpio108";
++		function = "gpio";
++		drive-strength = <16>;
++		bias-disable;
++		output-low;
++	};
++
++	wlan_en: wlan-en-state {
++		pins = "gpio80";
++		function = "gpio";
++		drive-strength = <8>;
++		bias-pull-down;
++	};
++};
++
++&uart7 {
++	status = "okay";
++};
++
++&uart14 {
++	status = "okay";
++
++	bluetooth {
++		compatible = "qcom,wcn7850-bt";
++
++		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
++		vddaon-supply = <&vreg_pmu_aon_0p59>;
++		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
++		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
++		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
++		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
++		vddrfa1p8-supply = <&vreg_pmu_rfa_1p8>;
++
++		max-speed = <3200000>;
++	};
++};
++
++&uart15 {
++	status = "okay";
++
++	gamepad {
++		compatible = "gamepad,rsinput";
++
++		gamepad-name = "AYN Odin2 Gamepad";
++		gamepad-bus = <0x0003>;
++		gamepad-vid = <0x2020>;
++		gamepad-pid = <0x3001>;
++		gamepad-rev = <0x0001>;
++
++		enable-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>;
++		pinctrl-0 = <&mcu_en_active>;
++		pinctrl-names = "default";
++	};
++};
++
++&ufs_mem_hc {
++	reset-gpios = <&tlmm 210 GPIO_ACTIVE_LOW>;
++	vcc-supply = <&vreg_l17b_2p5>;
++	vcc-max-microamp = <1300000>;
++	vccq-supply = <&vreg_l1g_1p2>;
++	vccq-max-microamp = <1200000>;
++	vdd-hba-supply = <&vreg_l3g_1p2>;
++
++	status = "okay";
++};
++
++&ufs_mem_phy {
++	vdda-phy-supply = <&vreg_l1d_0p88>;
++	vdda-pll-supply = <&vreg_l3e_1p2>;
++
++	status = "okay";
++};
++
++&usb_1 {
++	status = "okay";
++};
++
++&usb_1_dwc3_hs {
++	remote-endpoint = <&pmic_glink_hs_in>;
++};
++
++&usb_1_hsphy {
++	phys = <&pm8550b_eusb2_repeater>;
++
++	vdd-supply = <&vreg_l1e_0p88>;
++	vdda12-supply = <&vreg_l3e_1p2>;
++
++	status = "okay";
++};
++
++&usb_dp_qmpphy {
++	vdda-phy-supply = <&vreg_l3e_1p2>;
++	vdda-pll-supply = <&vreg_l3f_0p88>;
++
++	mode-switch;
++
++	status = "okay";
++};
++
++&usb_dp_qmpphy_out {
++	remote-endpoint = <&pmic_glink_ss_in>;
++};
++
++&xo_board {
++	clock-frequency = <76800000>;
++};
+diff --git a/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2.dts b/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2.dts
+new file mode 100644
+index 000000000000..9773a77676ea
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2.dts
+@@ -0,0 +1,270 @@
++// SPDX-License-Identifier: BSD-3-Clause
++/*
++ * Copyright (c) 2025, Teguh Sobirin.
++ * Copyright (c) 2025, ROCKNIX (https://github.com/ROCKNIX)
++ */
++
++/dts-v1/;
++
++#include "qcs8550-ayn-common.dtsi"
++
++/ {
++	model = "AYN Odin 2";
++	compatible = "ayn,odin2", "qcom,qcs8550", "qcom,sm8550";
++	qcom,msm-id = <603 0x20000>;
++	qcom,board-id = <0x1001f 0>;
++
++	backlight: backlight {
++		compatible = "pwm-backlight";
++		pwms = <&pmk8550_pwm 0 860000>;
++		brightness-levels = <1023 0>;
++		num-interpolated-steps = <1023>;
++		default-brightness-level = <600>;
++		power-supply = <&vph_pwr>;
++		enable-gpios = <&pmk8550_gpios 5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pwm_backlight_default>;
++		status = "okay";
++	};
++
++	vdd_disp_2v8: vdd-disp-2v8-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_disp_2v8";
++
++		regulator-min-microvolt = <2800000>;
++		regulator-max-microvolt = <2800000>;
++
++		gpio = <&tlmm 142 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	led_left_side: led-controller-1 {
++		compatible = "pwm-leds-multicolor";
++
++		multi-led {
++			label = "left-side";
++			color = <LED_COLOR_ID_RGB>;
++			max-brightness = <255>;
++
++			led-red {
++				color = <LED_COLOR_ID_RED>;
++				pwms = <&pwm_rgb_left 0>;
++			};
++
++			led-green {
++				color = <LED_COLOR_ID_GREEN>;
++				pwms = <&pwm_rgb_left 1>;
++			};
++
++			led-blue {
++				color = <LED_COLOR_ID_BLUE>;
++				pwms = <&pwm_rgb_left 2>;
++			};
++		};
++	};
++
++	led_left_joystick: led-controller-2 {
++		compatible = "pwm-leds-multicolor";
++
++		multi-led {
++			label = "left-joystick";
++			color = <LED_COLOR_ID_RGB>;
++			max-brightness = <255>;
++
++			led-red {
++				color = <LED_COLOR_ID_RED>;
++				pwms = <&pwm_rgb_left 6>;
++			};
++
++			led-green {
++				color = <LED_COLOR_ID_GREEN>;
++				pwms = <&pwm_rgb_left 7>;
++			};
++
++			led-blue {
++				color = <LED_COLOR_ID_BLUE>;
++				pwms = <&pwm_rgb_left 8>;
++			};
++		};
++	};
++
++	led_right_side: led-controller-3 {
++		compatible = "pwm-leds-multicolor";
++
++		multi-led {
++			label = "right-side";
++			color = <LED_COLOR_ID_RGB>;
++			max-brightness = <255>;
++
++			led-red {
++				color = <LED_COLOR_ID_RED>;
++				pwms = <&pwm_rgb_right 0>;
++			};
++
++			led-green {
++				color = <LED_COLOR_ID_GREEN>;
++				pwms = <&pwm_rgb_right 1>;
++			};
++
++			led-blue {
++				color = <LED_COLOR_ID_BLUE>;
++				pwms = <&pwm_rgb_right 2>;
++			};
++		};
++	};
++
++	led_right_joystick: led-controller-4 {
++		compatible = "pwm-leds-multicolor";
++
++		multi-led {
++			label = "right-joystick";
++			color = <LED_COLOR_ID_RGB>;
++			max-brightness = <255>;
++
++			led-red {
++				color = <LED_COLOR_ID_RED>;
++				pwms = <&pwm_rgb_right 6>;
++			};
++
++			led-green {
++				color = <LED_COLOR_ID_GREEN>;
++				pwms = <&pwm_rgb_right 7>;
++			};
++
++			led-blue {
++				color = <LED_COLOR_ID_BLUE>;
++				pwms = <&pwm_rgb_right 8>;
++			};
++		};
++	};
++};
++
++&display_panel {
++	compatible = "syna,td4328";
++
++	vddio-supply = <&vreg_l12b_1p8>;
++	vdd-supply = <&vdd_disp_2v8>;
++
++        backlight = <&backlight>;
++	reset-gpios = <&tlmm 133 GPIO_ACTIVE_LOW>;
++
++	rotation = <90>;
++};
++
++&gpu {
++	zap-shader {
++		firmware-name = "qcom/sm8550/ayn/odin2portal/a740_zap.mbn";
++	};
++};
++
++&pmk8550_gpios {
++	pwm_backlight_default: pwm-backlight-default-state {
++		pins = "gpio5";
++		function = "func3";
++		input-disable;
++		output-low;
++		output-enable;
++		bias-disable;
++		power-source = <0>;
++		qcom,drive-strength = <2>;
++	};
++};
++
++&pmk8550_pwm {
++	status = "okay";
++};
++
++&i2c0 {
++	clock-frequency = <400000>;
++	status = "okay";
++
++	pwm_rgb_left: sn3112@54 {
++		compatible = "si-en,sn3112-pwm";
++		reg = <0x54>;
++		sdb-gpios = <&tlmm 55 GPIO_ACTIVE_LOW>;
++		vdd-supply = <&vdd_mcu_3v3>;
++		#pwm-cells = <1>;
++	};
++};
++
++&i2c4 {
++	clock-frequency = <400000>;
++	status = "okay";
++
++	touchscreen@20 {
++		compatible = "syna,rmi4-i2c";
++		reg = <0x20>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++		interrupts-extended = <&tlmm 25 0x2008>;
++
++		pinctrl-names = "default", "sleep";
++		pinctrl-0 = <&ts_int_default>;
++		pinctrl-1 = <&ts_int_sleep>;
++
++		vio-supply = <&vreg_l12b_1p8>;
++		
++		syna,startup-delay-ms = <200>;
++		syna,reset-delay-ms = <200>;
++
++		rmi4-f01@1 {
++			syna,nosleep-mode = <0x1>;
++			reg = <0x1>;
++		};
++
++		rmi4-f12@12 {
++			reg = <0x12>;
++			syna,rezero-wait-ms = <20>;
++			syna,clip-x-low = <0>;
++			syna,clip-y-low = <0>;
++			syna,clip-x-high = <1080>;
++			syna,clip-y-high = <1920>;
++			syna,sensor-type = <1>;
++			touchscreen-inverted-x;
++		};
++	};
++};
++
++&i2c12 {
++	clock-frequency = <400000>;
++	status = "okay";
++
++	pwm_rgb_right: sn3112@54 {
++		compatible = "si-en,sn3112-pwm";
++		reg = <0x54>;
++		sdb-gpios = <&tlmm 56 GPIO_ACTIVE_LOW>;
++		vdd-supply = <&vdd_mcu_3v3>;
++		#pwm-cells = <1>;
++	};
++};
++
++&remoteproc_adsp {
++	firmware-name = "qcom/sm8550/ayn/odin2portal/adsp.mbn",
++			"qcom/sm8550/ayn/odin2portal/adsp_dtb.mbn";
++	status = "okay";
++};
++
++&remoteproc_cdsp {
++	firmware-name = "qcom/sm8550/ayn/odin2portal/cdsp.mbn",
++			"qcom/sm8550/ayn/odin2portal/cdsp_dtb.mbn";
++	status = "okay";
++};
++
++&spk_amp_l {
++	firmware-name = "qcom/sm8550/ayn/odin2portal/aw883xx_acf.bin";
++};
++
++&spk_amp_r {
++	firmware-name = "qcom/sm8550/ayn/odin2portal/aw883xx_acf.bin";
++};
++
++&soc {
++    qcom_tzlog: qcom_tzlog {
++        status = "disabled";
++    };
++
++    arch_timer: arch_timer {
++        status = "disabled";
++    };
++};
++
+diff --git a/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2portal.dts b/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2portal.dts
+new file mode 100644
+index 000000000000..918880abb8f1
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2portal.dts
+@@ -0,0 +1,253 @@
++// SPDX-License-Identifier: BSD-3-Clause
++/*
++ * Copyright (c) 2025, Teguh Sobirin.
++ */
++
++/dts-v1/;
++
++#include "qcs8550-ayn-common.dtsi"
++
++/ {
++	model = "AYN Odin 2 Portal";
++	compatible = "ayn,odin2portal", "qcom,qcs8550", "qcom,sm8550";
++	qcom,msm-id = <603 0x20000>;
++	qcom,board-id = <0x1001f 0>;
++
++	vdd_bl_5v0: vdd-bl-5v0-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_bl_5v0";
++
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++
++		gpio = <&tlmm 52 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	vdd_disp_2v8: vdd-disp-2v8-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_disp_2v8";
++
++		regulator-min-microvolt = <2800000>;
++		regulator-max-microvolt = <2800000>;
++
++		gpio = <&tlmm 142 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++};
++
++&display_panel {
++	compatible = "chipone,icna3512";
++
++	blvdd-supply = <&vdd_bl_5v0>;
++	iovdd-supply = <&vreg_l12b_1p8>;
++	vdd-supply = <&vdd_disp_2v8>;
++
++	reset-gpios = <&tlmm 133 GPIO_ACTIVE_LOW>;
++
++	rotation = <270>;
++};
++
++&gpu {
++	zap-shader {
++		firmware-name = "qcom/sm8550/ayn/odin2portal/a740_zap.mbn";
++	};
++};
++
++&i2c0 {
++	htr3212l: led-controller@3c {
++		compatible = "heroic,htr3212";
++		reg = <0x3c>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++		sdb-gpios = <&tlmm 55 GPIO_ACTIVE_HIGH>;
++		vdd-supply = <&vdd_mcu_3v3>;
++
++		ledl_b1: led@1 {
++			reg = <1>;
++			label = "l:r1";
++			color = <LED_COLOR_ID_RED>;
++		};
++		ledl_g1: led@2 {
++			reg = <2>;
++			label = "l:g1";
++			color = <LED_COLOR_ID_GREEN>;
++		};
++		ledl_r1: led@3 {
++			reg = <3>;
++			label = "l:b1";
++			color = <LED_COLOR_ID_BLUE>;
++		};
++		ledl_b2: led@4 {
++			reg = <4>;
++			label = "l:r2";
++			color = <LED_COLOR_ID_RED>;
++		};
++		ledl_g2: led@5 {
++			reg = <5>;
++			label = "l:g2";
++			color = <LED_COLOR_ID_GREEN>;
++		};
++		ledl_r2: led@6 {
++			reg = <6>;
++			label = "l:b2";
++			color = <LED_COLOR_ID_BLUE>;
++		};
++		ledl_b3: led@7 {
++			reg = <7>;
++			label = "l:r3";
++			color = <LED_COLOR_ID_RED>;
++		};
++		ledl_g3: led@8 {
++			reg = <8>;
++			label = "l:g3";
++			color = <LED_COLOR_ID_GREEN>;
++		};
++		ledl_r3: led@9 {
++			reg = <9>;
++			label = "l:b3";
++			color = <LED_COLOR_ID_BLUE>;
++		};
++		ledl_b4: led@10 {
++			reg = <10>;
++			label = "l:r4";
++			color = <LED_COLOR_ID_RED>;
++		};
++		ledl_g4: led@11 {
++			reg = <11>;
++			label = "l:g4";
++			color = <LED_COLOR_ID_GREEN>;
++		};
++		ledl_r4: led@12 {
++			reg = <12>;
++			label = "l:b4";
++			color = <LED_COLOR_ID_BLUE>;
++		};
++	};
++};
++
++&i2c4 {
++	touchscreen: touchscreen@38 {
++		compatible = "focaltech,ft5426";
++		reg = <0x38>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		interrupt-parent = <&tlmm>;
++		interrupts = <25 IRQ_TYPE_EDGE_FALLING>;
++
++		reset-gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
++
++		vcc-supply = <&vreg_l14b_3p2>;
++		iovcc-supply = <&vreg_l12b_1p8>;
++
++		pinctrl-0 = <&ts_int_default &ts_rst_default>;
++		pinctrl-1 = <&ts_int_sleep &ts_rst_sleep>;
++		pinctrl-names = "default", "sleep";
++
++		touchscreen-size-x = <1080>;
++		touchscreen-size-y = <1920>;
++	};
++};
++
++&i2c12 {
++	htr3212r: led-controller@3c {
++		compatible = "heroic,htr3212";
++		reg = <0x3c>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++		sdb-gpios = <&tlmm 56 GPIO_ACTIVE_HIGH>;
++		vdd-supply = <&vdd_mcu_3v3>;
++
++		ledr_b1: led@1 {
++			reg = <1>;
++			label = "r:r1";
++			color = <LED_COLOR_ID_RED>;
++		};
++		ledr_g1: led@2 {
++			reg = <2>;
++			label = "r:g1";
++			color = <LED_COLOR_ID_GREEN>;
++		};
++		ledr_r1: led@3 {
++			reg = <3>;
++			label = "r:b1";
++			color = <LED_COLOR_ID_BLUE>;
++		};
++		ledr_b2: led@4 {
++			reg = <4>;
++			label = "r:r2";
++			color = <LED_COLOR_ID_RED>;
++		};
++		ledr_g2: led@5 {
++			reg = <5>;
++			label = "r:g2";
++			color = <LED_COLOR_ID_GREEN>;
++		};
++		ledr_r2: led@6 {
++			reg = <6>;
++			label = "r:b2";
++			color = <LED_COLOR_ID_BLUE>;
++		};
++		ledr_b3: led@7 {
++			reg = <7>;
++			label = "r:r3";
++			color = <LED_COLOR_ID_RED>;
++		};
++		ledr_g3: led@8 {
++			reg = <8>;
++			label = "r:g3";
++			color = <LED_COLOR_ID_GREEN>;
++		};
++		ledr_r3: led@9 {
++			reg = <9>;
++			label = "r:b3";
++			color = <LED_COLOR_ID_BLUE>;
++		};
++		ledr_b4: led@10 {
++			reg = <10>;
++			label = "r:r4";
++			color = <LED_COLOR_ID_RED>;
++		};
++		ledr_g4: led@11 {
++			reg = <11>;
++			label = "r:g4";
++			color = <LED_COLOR_ID_GREEN>;
++		};
++		ledr_r4: led@12 {
++			reg = <12>;
++			label = "r:b4";
++			color = <LED_COLOR_ID_BLUE>;
++		};
++	};
++};
++
++&remoteproc_adsp {
++	firmware-name = "qcom/sm8550/ayn/odin2portal/adsp.mbn",
++			"qcom/sm8550/ayn/odin2portal/adsp_dtb.mbn";
++	status = "okay";
++};
++
++&remoteproc_cdsp {
++	firmware-name = "qcom/sm8550/ayn/odin2portal/cdsp.mbn",
++			"qcom/sm8550/ayn/odin2portal/cdsp_dtb.mbn";
++	status = "okay";
++};
++
++&spk_amp_l {
++	firmware-name = "qcom/sm8550/ayn/odin2portal/aw883xx_acf.bin";
++};
++
++&spk_amp_r {
++	firmware-name = "qcom/sm8550/ayn/odin2portal/aw883xx_acf.bin";
++};
++
++&soc {
++	qcom_tzlog: qcom_tzlog {
++		status = "disabled";
++	};
++
++	arch_timer: arch_timer {
++		status = "disabled";
++	};
++};
+-- 
+2.43.0
+


### PR DESCRIPTION
# Description

This PR adds kernel 6.19 support for Ayn Odin2 device. I dropped the downstream MMC host controller driver to switch to upstream one. The rest of patches are copied from 6.18.

# How Has This Been Tested?

Verified following functions are working:

    Boot
    TF card
    Built-in display & touchscreen
    Built-in speaker
    Built-in game pad
    USB Type-C port (USB host functionality and display output)
    Charging
    CPU Fan
    WiFi
    Bluetooth
    RTC clock
    LEDs
    Hardware video decoding (using ffmpeg)

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kernel upgraded to 6.19
  * Added support for new input devices and gamepad controllers
  * Expanded LED and PWM controller drivers for device peripherals
  * Enhanced audio subsystem with Primary I2S support
  * Added display panel drivers for improved screen compatibility
  * Extended platform support for mobile devices

* **Bug Fixes**
  * Resolved USB initialization hang issue
  * Corrected battery device naming
  * Improved device serial number handling for Bluetooth and network identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->