### PR TITLE
orangepi5: rewrite uboot patches against v2026.04-rc3

### DIFF
--- a/patch/u-boot/v2026.04/1001-fdt_fixup_ethernet-add-logs.patch
+++ b/patch/u-boot/v2026.04/1001-fdt_fixup_ethernet-add-logs.patch
@@ -135,7 +135,7 @@ index 111111111111..222222222222 100644
  // SPDX-License-Identifier: GPL-2.0+
  /*
   * Copyright (c) 2013, Google Inc.
-@@ -578,13 +579,31 @@ __weak int ft_verify_fdt(void *fdt)
+@@ -584,13 +585,31 @@ __weak int ft_verify_fdt(void *fdt)
  	return 1;
  }
  
@@ -167,7 +167,7 @@ index 111111111111..222222222222 100644
  	ulong *initrd_start = &images->initrd_start;
  	ulong *initrd_end = &images->initrd_end;
  	bool skip_board_fixup = false;
-@@ -632,6 +651,8 @@ int image_setup_libfdt(struct bootm_headers *images, void *blob, bool lmb)
+@@ -638,6 +657,8 @@ int image_setup_libfdt(struct bootm_headers *images, void *blob, bool lmb)
  					strlen(images->fit_uname_cfg) + 1, 1);
  
  	/* Update ethernet nodes */
@@ -176,7 +176,7 @@ index 111111111111..222222222222 100644
  	fdt_fixup_ethernet(blob);
  #if IS_ENABLED(CONFIG_CMD_PSTORE)
  	/* Append PStore configuration */
-@@ -645,6 +666,8 @@ int image_setup_libfdt(struct bootm_headers *images, void *blob, bool lmb)
+@@ -651,6 +672,8 @@ int image_setup_libfdt(struct bootm_headers *images, void *blob, bool lmb)
  	}
  
  	if (IS_ENABLED(CONFIG_OF_BOARD_SETUP) && !skip_board_fixup) {
@@ -185,7 +185,7 @@ index 111111111111..222222222222 100644
  		fdt_ret = ft_board_setup(blob, gd->bd);
  		if (fdt_ret) {
  			printf("ERROR: board-specific fdt fixup failed: %s\n",
-@@ -652,7 +675,9 @@ int image_setup_libfdt(struct bootm_headers *images, void *blob, bool lmb)
+@@ -658,7 +681,9 @@ int image_setup_libfdt(struct bootm_headers *images, void *blob, bool lmb)
  			goto err;
  		}
  	}

--- a/patch/u-boot/v2026.04/cmd-fileenv-read-string-from-file-into-env.patch
+++ b/patch/u-boot/v2026.04/cmd-fileenv-read-string-from-file-into-env.patch
@@ -18,7 +18,7 @@ diff --git a/cmd/Kconfig b/cmd/Kconfig
 index 111111111111..222222222222 100644
 --- a/cmd/Kconfig
 +++ b/cmd/Kconfig
-@@ -1898,6 +1898,11 @@ config CMD_XXD
+@@ -1927,6 +1927,11 @@ config CMD_XXD
  	help
  	  Print file as hexdump to standard output
  
@@ -34,14 +34,14 @@ diff --git a/cmd/Makefile b/cmd/Makefile
 index 111111111111..222222222222 100644
 --- a/cmd/Makefile
 +++ b/cmd/Makefile
-@@ -175,6 +175,7 @@ obj-$(CONFIG_CMD_SHA1SUM) += sha1sum.o
+@@ -176,6 +176,7 @@ obj-$(CONFIG_CMD_SHA1SUM) += sha1sum.o
  obj-$(CONFIG_CMD_SEAMA) += seama.o
  obj-$(CONFIG_CMD_SETEXPR) += setexpr.o
  obj-$(CONFIG_CMD_SETEXPR_FMT) += printf.o
 +obj-$(CONFIG_CMD_FILEENV) += fileenv.o
  obj-$(CONFIG_CMD_SPI) += spi.o
  obj-$(CONFIG_CMD_STRINGS) += strings.o
- obj-$(CONFIG_CMD_SMBIOS) += smbios.o
+ obj-$(CONFIG_CMD_SM3SUM) += sm3sum.o
 diff --git a/cmd/fileenv.c b/cmd/fileenv.c
 new file mode 100644
 index 000000000000..111111111111

--- a/patch/u-boot/v2026.04/v5-1-4-spl-Make-UFS-available-for-SPL-builds.patch
+++ b/patch/u-boot/v2026.04/v5-1-4-spl-Make-UFS-available-for-SPL-builds.patch
@@ -1,8 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mecid <mecid@mecomediagroup.de>
+Date: Fri, 20 Feb 2026 21:55:32 +0100
+Subject: [ARCHEOLOGY] Rock-4D: Add Edge + RK3576 Mainline U-Boot (with UFS
+ support) (#9421)
+
+> X-Git-Archeology: > recovered message: > * Rock-4D: Edge (u-boot and kernel)
+> X-Git-Archeology: > recovered message: > * RK3576: Mainline u-boot ufs boot enablement patches
+> X-Git-Archeology: > recovered message: > * Rock-4D: Use Mainline u-boot 2026.04-rc2
+> X-Git-Archeology: > recovered message: > * Rock-4D: Update KERNEL_TEST_TARGET to edge
+> X-Git-Archeology: > recovered message: > * Rock-4D: Use Mainline u-boot on vendor and edge
+> X-Git-Archeology: > recovered message: > * Remove vendor branch check for mainline uboot
+> X-Git-Archeology: - Revision 77f919f6cd5db012127fdbdd9dd506c5e4346a8f: https://github.com/armbian/build/commit/77f919f6cd5db012127fdbdd9dd506c5e4346a8f
+> X-Git-Archeology:   Date: Fri, 20 Feb 2026 21:55:32 +0100
+> X-Git-Archeology:   From: Mecid <mecid@mecomediagroup.de>
+> X-Git-Archeology:   Subject: Rock-4D: Add Edge + RK3576 Mainline U-Boot (with UFS support) (#9421)
+> X-Git-Archeology:
+---
+ MAINTAINERS                |  1 +
+ arch/arm/include/asm/spl.h |  1 +
+ common/spl/Kconfig         | 30 ++++++
+ common/spl/Makefile        |  1 +
+ common/spl/spl_ufs.c       | 49 ++++++++++
+ drivers/Makefile           |  1 +
+ drivers/scsi/Makefile      |  3 +
+ lib/Makefile               |  1 +
+ 8 files changed, 87 insertions(+)
+
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 27ce73d83f48..ca31e57f018a 100644
+index 111111111111..222222222222 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -1861,6 +1861,7 @@ M:	Neil Armstrong <neil.armstrong@linaro.org>
+@@ -1890,6 +1890,7 @@ M:	Neil Armstrong <neil.armstrong@linaro.org>
  M:	Bhupesh Sharma <bhupesh.linux@gmail.com>
  M:	Neha Malcom Francis <n-francis@ti.com>
  S:	Maintained
@@ -11,7 +39,7 @@ index 27ce73d83f48..ca31e57f018a 100644
  
  UPL
 diff --git a/arch/arm/include/asm/spl.h b/arch/arm/include/asm/spl.h
-index ee79a19c05c9..dd462ea6ad82 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/include/asm/spl.h
 +++ b/arch/arm/include/asm/spl.h
 @@ -30,6 +30,7 @@ enum {
@@ -23,10 +51,10 @@ index ee79a19c05c9..dd462ea6ad82 100644
  };
  #endif
 diff --git a/common/spl/Kconfig b/common/spl/Kconfig
-index 4f4119f5806c..68f475717663 100644
+index 111111111111..222222222222 100644
 --- a/common/spl/Kconfig
 +++ b/common/spl/Kconfig
-@@ -1612,6 +1612,36 @@ config SPL_THERMAL
+@@ -1613,6 +1613,36 @@ config SPL_THERMAL
  	  automatic power-off when the temperature gets too high or low. Other
  	  devices may be discrete but connected on a suitable bus.
  
@@ -64,7 +92,7 @@ index 4f4119f5806c..68f475717663 100644
  	bool "Support watchdog drivers"
  	imply SPL_WDT if !HW_WATCHDOG
 diff --git a/common/spl/Makefile b/common/spl/Makefile
-index 4c9482bd3096..e18f3cf09484 100644
+index 111111111111..222222222222 100644
 --- a/common/spl/Makefile
 +++ b/common/spl/Makefile
 @@ -37,6 +37,7 @@ obj-$(CONFIG_$(PHASE_)DFU) += spl_dfu.o
@@ -77,7 +105,7 @@ index 4c9482bd3096..e18f3cf09484 100644
  obj-$(CONFIG_$(PHASE_)UPL) += spl_upl.o
 diff --git a/common/spl/spl_ufs.c b/common/spl/spl_ufs.c
 new file mode 100644
-index 000000000000..cef1843f40f3
+index 000000000000..111111111111
 --- /dev/null
 +++ b/common/spl/spl_ufs.c
 @@ -0,0 +1,49 @@
@@ -131,7 +159,7 @@ index 000000000000..cef1843f40f3
 +
 +SPL_LOAD_IMAGE_METHOD("UFS", 0, BOOT_DEVICE_UFS, spl_ufs_load_image);
 diff --git a/drivers/Makefile b/drivers/Makefile
-index de993ae42ac7..43d0ba332818 100644
+index 111111111111..222222222222 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
 @@ -73,6 +73,7 @@ obj-$(CONFIG_SPL_USB_HOST) += usb/host/
@@ -143,7 +171,7 @@ index de993ae42ac7..43d0ba332818 100644
  endif
  endif
 diff --git a/drivers/scsi/Makefile b/drivers/scsi/Makefile
-index b76de1b22a8b..c9af60d5d03c 100644
+index 111111111111..222222222222 100644
 --- a/drivers/scsi/Makefile
 +++ b/drivers/scsi/Makefile
 @@ -16,4 +16,7 @@ ifdef CONFIG_XPL_BUILD
@@ -155,7 +183,7 @@ index b76de1b22a8b..c9af60d5d03c 100644
 +endif
  endif
 diff --git a/lib/Makefile b/lib/Makefile
-index 70667f3728c2..d0ffabc2b476 100644
+index 111111111111..222222222222 100644
 --- a/lib/Makefile
 +++ b/lib/Makefile
 @@ -147,6 +147,7 @@ else
@@ -166,3 +194,6 @@ index 70667f3728c2..d0ffabc2b476 100644
  else
  # Main U-Boot always uses the full printf support
  obj-y += vsprintf.o strto.o
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.04/v5-2-4-reset-rockchip-make-device-resets-available-in-SPL.patch
+++ b/patch/u-boot/v2026.04/v5-2-4-reset-rockchip-make-device-resets-available-in-SPL.patch
@@ -1,8 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mecid <mecid@mecomediagroup.de>
+Date: Fri, 20 Feb 2026 21:55:32 +0100
+Subject: [ARCHEOLOGY] Rock-4D: Add Edge + RK3576 Mainline U-Boot (with UFS
+ support) (#9421)
+
+> X-Git-Archeology: > recovered message: > * Rock-4D: Edge (u-boot and kernel)
+> X-Git-Archeology: > recovered message: > * RK3576: Mainline u-boot ufs boot enablement patches
+> X-Git-Archeology: > recovered message: > * Rock-4D: Use Mainline u-boot 2026.04-rc2
+> X-Git-Archeology: > recovered message: > * Rock-4D: Update KERNEL_TEST_TARGET to edge
+> X-Git-Archeology: > recovered message: > * Rock-4D: Use Mainline u-boot on vendor and edge
+> X-Git-Archeology: > recovered message: > * Remove vendor branch check for mainline uboot
+> X-Git-Archeology: - Revision 77f919f6cd5db012127fdbdd9dd506c5e4346a8f: https://github.com/armbian/build/commit/77f919f6cd5db012127fdbdd9dd506c5e4346a8f
+> X-Git-Archeology:   Date: Fri, 20 Feb 2026 21:55:32 +0100
+> X-Git-Archeology:   From: Mecid <mecid@mecomediagroup.de>
+> X-Git-Archeology:   Subject: Rock-4D: Add Edge + RK3576 Mainline U-Boot (with UFS support) (#9421)
+> X-Git-Archeology:
+---
+ drivers/reset/Kconfig  | 9 +++++++++
+ drivers/reset/Makefile | 2 +-
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
 diff --git a/drivers/reset/Kconfig b/drivers/reset/Kconfig
-index 74c267dfc4e5..d35f3904e404 100644
+index 111111111111..222222222222 100644
 --- a/drivers/reset/Kconfig
 +++ b/drivers/reset/Kconfig
-@@ -99,6 +99,15 @@ config RESET_ROCKCHIP
+@@ -100,6 +100,15 @@ config RESET_ROCKCHIP
  	  though is that some reset signals, like I2C or MISC reset multiple
  	  devices.
  
@@ -19,7 +41,7 @@ index 74c267dfc4e5..d35f3904e404 100644
  	bool "Synopsys HSDK Reset Driver"
  	depends on DM_RESET && TARGET_HSDK
 diff --git a/drivers/reset/Makefile b/drivers/reset/Makefile
-index ee5b009d1341..dc7d3b610e6e 100644
+index 111111111111..222222222222 100644
 --- a/drivers/reset/Makefile
 +++ b/drivers/reset/Makefile
 @@ -16,7 +16,7 @@ obj-$(CONFIG_RESET_BCM6345) += reset-bcm6345.o
@@ -31,3 +53,6 @@ index ee5b009d1341..dc7d3b610e6e 100644
  obj-$(CONFIG_RESET_MESON) += reset-meson.o
  obj-$(CONFIG_RESET_SOCFPGA) += reset-socfpga.o
  obj-$(CONFIG_RESET_MEDIATEK) += reset-mediatek.o
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.04/v5-3-4-ufs-rockchip-Add-device-reset-support.patch
+++ b/patch/u-boot/v2026.04/v5-3-4-ufs-rockchip-Add-device-reset-support.patch
@@ -1,5 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mecid <mecid@mecomediagroup.de>
+Date: Fri, 20 Feb 2026 21:55:32 +0100
+Subject: [ARCHEOLOGY] Rock-4D: Add Edge + RK3576 Mainline U-Boot (with UFS
+ support) (#9421)
+
+> X-Git-Archeology: > recovered message: > * Rock-4D: Edge (u-boot and kernel)
+> X-Git-Archeology: > recovered message: > * RK3576: Mainline u-boot ufs boot enablement patches
+> X-Git-Archeology: > recovered message: > * Rock-4D: Use Mainline u-boot 2026.04-rc2
+> X-Git-Archeology: > recovered message: > * Rock-4D: Update KERNEL_TEST_TARGET to edge
+> X-Git-Archeology: > recovered message: > * Rock-4D: Use Mainline u-boot on vendor and edge
+> X-Git-Archeology: > recovered message: > * Remove vendor branch check for mainline uboot
+> X-Git-Archeology: - Revision 77f919f6cd5db012127fdbdd9dd506c5e4346a8f: https://github.com/armbian/build/commit/77f919f6cd5db012127fdbdd9dd506c5e4346a8f
+> X-Git-Archeology:   Date: Fri, 20 Feb 2026 21:55:32 +0100
+> X-Git-Archeology:   From: Mecid <mecid@mecomediagroup.de>
+> X-Git-Archeology:   Subject: Rock-4D: Add Edge + RK3576 Mainline U-Boot (with UFS support) (#9421)
+> X-Git-Archeology:
+---
+ drivers/ufs/Kconfig        |  4 ++
+ drivers/ufs/ufs-rockchip.c | 22 ++++++++++
+ drivers/ufs/ufs-rockchip.h |  1 +
+ 3 files changed, 27 insertions(+)
+
 diff --git a/drivers/ufs/Kconfig b/drivers/ufs/Kconfig
-index 6c75bb2a0790..49472933de36 100644
+index 111111111111..222222222222 100644
 --- a/drivers/ufs/Kconfig
 +++ b/drivers/ufs/Kconfig
 @@ -76,6 +76,10 @@ config UFS_RENESAS_GEN5
@@ -14,7 +37,7 @@ index 6c75bb2a0790..49472933de36 100644
  	  This selects the Rockchip specific additions to UFSHCD platform driver.
  
 diff --git a/drivers/ufs/ufs-rockchip.c b/drivers/ufs/ufs-rockchip.c
-index 0384244387da..3576f6e7a2b6 100644
+index 111111111111..222222222222 100644
 --- a/drivers/ufs/ufs-rockchip.c
 +++ b/drivers/ufs/ufs-rockchip.c
 @@ -5,6 +5,7 @@
@@ -66,7 +89,7 @@ index 0384244387da..3576f6e7a2b6 100644
  
  static const struct udevice_id ufs_rockchip_of_match[] = {
 diff --git a/drivers/ufs/ufs-rockchip.h b/drivers/ufs/ufs-rockchip.h
-index 3dcb80f57020..50c2539da78a 100644
+index 111111111111..222222222222 100644
 --- a/drivers/ufs/ufs-rockchip.h
 +++ b/drivers/ufs/ufs-rockchip.h
 @@ -72,6 +72,7 @@ struct ufs_rockchip_host {
@@ -77,3 +100,6 @@ index 3dcb80f57020..50c2539da78a 100644
  	struct clk ref_out_clk;
  	uint64_t caps;
  	uint32_t phy_config_mode;
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.04/v5-4-4-rockchip-spl-Add-support-for-booting-from-UFS.patch
+++ b/patch/u-boot/v2026.04/v5-4-4-rockchip-spl-Add-support-for-booting-from-UFS.patch
@@ -1,5 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mecid <mecid@mecomediagroup.de>
+Date: Fri, 20 Feb 2026 21:55:32 +0100
+Subject: [ARCHEOLOGY] Rock-4D: Add Edge + RK3576 Mainline U-Boot (with UFS
+ support) (#9421)
+
+> X-Git-Archeology: > recovered message: > * Rock-4D: Edge (u-boot and kernel)
+> X-Git-Archeology: > recovered message: > * RK3576: Mainline u-boot ufs boot enablement patches
+> X-Git-Archeology: > recovered message: > * Rock-4D: Use Mainline u-boot 2026.04-rc2
+> X-Git-Archeology: > recovered message: > * Rock-4D: Update KERNEL_TEST_TARGET to edge
+> X-Git-Archeology: > recovered message: > * Rock-4D: Use Mainline u-boot on vendor and edge
+> X-Git-Archeology: > recovered message: > * Remove vendor branch check for mainline uboot
+> X-Git-Archeology: - Revision 77f919f6cd5db012127fdbdd9dd506c5e4346a8f: https://github.com/armbian/build/commit/77f919f6cd5db012127fdbdd9dd506c5e4346a8f
+> X-Git-Archeology:   Date: Fri, 20 Feb 2026 21:55:32 +0100
+> X-Git-Archeology:   From: Mecid <mecid@mecomediagroup.de>
+> X-Git-Archeology:   Subject: Rock-4D: Add Edge + RK3576 Mainline U-Boot (with UFS support) (#9421)
+> X-Git-Archeology:
+---
+ arch/arm/dts/rk3576-u-boot.dtsi              | 16 +++++++++-
+ arch/arm/include/asm/arch-rockchip/bootrom.h |  1 +
+ arch/arm/mach-rockchip/rk3576/rk3576.c       |  1 +
+ arch/arm/mach-rockchip/spl-boot-order.c      | 14 ++++++++
+ 4 files changed, 31 insertions(+), 1 deletion(-)
+
 diff --git a/arch/arm/dts/rk3576-u-boot.dtsi b/arch/arm/dts/rk3576-u-boot.dtsi
-index dc3771b556a3..e442e94f7132 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/rk3576-u-boot.dtsi
 +++ b/arch/arm/dts/rk3576-u-boot.dtsi
 @@ -12,7 +12,7 @@
@@ -40,7 +64,7 @@ index dc3771b556a3..e442e94f7132 100644
  	bootph-all;
  };
 diff --git a/arch/arm/include/asm/arch-rockchip/bootrom.h b/arch/arm/include/asm/arch-rockchip/bootrom.h
-index b15938c021d6..f9ecb6858f04 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/include/asm/arch-rockchip/bootrom.h
 +++ b/arch/arm/include/asm/arch-rockchip/bootrom.h
 @@ -51,6 +51,7 @@ enum {
@@ -52,7 +76,7 @@ index b15938c021d6..f9ecb6858f04 100644
  	BROM_BOOTSOURCE_SPI = 9,
  	BROM_BOOTSOURCE_USB = 10,
 diff --git a/arch/arm/mach-rockchip/rk3576/rk3576.c b/arch/arm/mach-rockchip/rk3576/rk3576.c
-index a1e8a7572fa4..46cf60dc77c7 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-rockchip/rk3576/rk3576.c
 +++ b/arch/arm/mach-rockchip/rk3576/rk3576.c
 @@ -46,6 +46,7 @@ const char * const boot_devices[BROM_LAST_BOOTSOURCE + 1] = {
@@ -64,7 +88,7 @@ index a1e8a7572fa4..46cf60dc77c7 100644
  
  static struct mm_region rk3576_mem_map[] = {
 diff --git a/arch/arm/mach-rockchip/spl-boot-order.c b/arch/arm/mach-rockchip/spl-boot-order.c
-index 6572dde29f65..d2dd5e10935f 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-rockchip/spl-boot-order.c
 +++ b/arch/arm/mach-rockchip/spl-boot-order.c
 @@ -76,6 +76,9 @@ static int spl_node_to_boot_device(int node)
@@ -95,3 +119,6 @@ index 6572dde29f65..d2dd5e10935f 100644
  #if CONFIG_IS_ENABLED(BLK)
  	dev_num = (boot_device == BOOT_DEVICE_MMC1) ? 0 : 1;
  
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

as per title

# How Has This Been Tested?

- [x] build

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fileenv command to load files into environment variables from storage
  * Enabled UFS storage as a boot source for Rockchip devices
  * Implemented device reset support for UFS storage devices

* **Improvements**
  * Enhanced MAC address configuration diagnostics with improved logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->