### PR TITLE
(#9400 P1b) Replace unsafe eval with declare -g and nameref

### DIFF
--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -345,7 +345,11 @@ function artifact_dump_json_info() {
 		declaration="$(declare -p "${var}")"
 		# Special handling for arrays. Syntax is not pretty, but works.
 		if [[ "${declaration}" =~ "declare -a" ]]; then
-			eval "declare ${var}_ARRAY=\"\${${var}[*]}\""
+			# nameref alias avoids eval; ${var} is from a hard-coded list so
+			# it's already a valid identifier.
+			local -n _ao_src="${var}"
+			declare "${var}_ARRAY=${_ao_src[*]}"
+			unset -n _ao_src
 			ARTIFACTS_VAR_DICT["${var}_ARRAY"]="$(declare -p "${var}_ARRAY")"
 		else
 			ARTIFACTS_VAR_DICT["${var}"]="${declaration}"

--- a/lib/functions/cli/utils-cli.sh
+++ b/lib/functions/cli/utils-cli.sh
@@ -65,7 +65,7 @@ function apply_cmdline_params_to_env() {
 		if [[ -z "${!param_name+x}" ]] || [[ "${current_env_value}" != "${param_value}" ]]; then
 			display_alert "Applying cmdline param" "'$param_name': '${current_env_value_desc}' --> '${param_value_desc}' ${__my_reason}" "cmdline"
 			# use `declare -g` to make it global, we're in a function.
-			eval "declare -g $param_name=\"$param_value\""
+			declare -g "${param_name}=${param_value}"
 		else
 			# rpardini: strategic amount of spacing in log files show the kinda neuroticism that drives me.
 			display_alert "Skip     cmdline param" "'$param_name': already set to '${param_value_desc}' ${__my_reason}" "info"

--- a/lib/functions/configuration/change-tracking.sh
+++ b/lib/functions/configuration/change-tracking.sh
@@ -18,7 +18,13 @@ function track_config_variables() {
 
 		# if the var is an array...
 		if [[ "${array_values:-"no"}" == "yes" ]]; then
-			eval "var_value=\"\${${var_name}[@]}\"" # sorry
+			# bash nameref (local -n) creates an alias for the variable named in $var_name —
+			# no eval needed, no code-injection risk. Works for arrays and scalars alike.
+			# unset -n removes the alias only (not the referenced array) to avoid
+			# "already a nameref" warnings on the next loop iteration.
+			local -n _ct_arr_ref="${var_name}"
+			var_value="${_ct_arr_ref[*]}"
+			unset -n _ct_arr_ref
 			value_text="${blue_color:-}(${bright_blue_color:-}${var_value}${blue_color:-})"
 		else
 			var_value="${!var_name}"

--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -30,8 +30,8 @@ function interactive_config_prepare_terminal() {
 # $1: variable name
 # $2: variable value
 function set_interactive_config_value() {
-	eval "$1"='$2'
-	eval "ARMBIAN_INTERACTIVE_CONFIGS[${1}]"='$2'
+	declare -g "${1}=${2}"
+	ARMBIAN_INTERACTIVE_CONFIGS["${1}"]="${2}"
 }
 
 function interactive_finish() {


### PR DESCRIPTION
## Summary

Replaces 5 `eval` usages that can be trivially eliminated — part of the bash safety plan in #9400 (P1b).

| File | Old | New |
|---|---|---|
| `lib/functions/cli/utils-cli.sh` | `eval "declare -g $name=\"$value\""` | `declare -g "${name}=${value}"` |
| `lib/functions/configuration/interactive.sh` | `eval "$1"='$2'` | `declare -g "${1}=${2}"` |
| `lib/functions/configuration/interactive.sh` | `eval "ARMBIAN_INTERACTIVE_CONFIGS[${1}]"='$2'` | `ARMBIAN_INTERACTIVE_CONFIGS["${1}"]="${2}"` |
| `lib/functions/configuration/change-tracking.sh` | `eval "var_value=\"\${${var_name}[@]}\""` | `local -n` nameref |
| `lib/functions/artifacts/artifacts-obtain.sh` | `eval "declare ${var}_ARRAY=\"\${${var}[*]}\""` | `local -n` nameref |

## Why eval is risky here

`eval` executes its argument as shell code. If a variable name or value were ever a crafted string (e.g. from user input or a config file), it could inject arbitrary commands. The bash builtins used as replacements do not have this property.

Note: `parse_cmdline_params` already validates parameter names against `^[a-zA-Z_][a-zA-Z0-9_]*$` before inserting into `ARMBIAN_PARSED_CMDLINE_PARAMS`, so names reaching `apply_cmdline_params_to_env` are guaranteed to be valid identifiers — closing the array-index injection vector at the source.

## The nameref case explained

`change-tracking.sh` and `artifacts-obtain.sh` both needed to read an array variable whose name is stored in a scalar at runtime. The original comment in change-tracking said `# sorry`. The fix uses bash 4.3+ **nameref** (`local -n`), which creates an alias to the variable without executing any code:

```bash
# Before — eval reads array by dynamic name, code-injection risk:
eval "var_value=\"\${${var_name}[@]}\"" # sorry

# After — nameref creates a safe alias, no code executed:
local -n _ct_arr_ref="${var_name}"  # alias for the array named in $var_name
var_value="${_ct_arr_ref[*]}"       # read through the alias
unset -n _ct_arr_ref                # remove alias only (not the array!) to avoid
                                    # "already a nameref" warnings next iteration
```

## Out of scope

Other `eval` usages in `lib/` intentionally left alone:
- `cli-configdump.sh:61` — deserializer for `@Q`-quoted serialization (safe by construction, cannot be trivially replaced without reworking serialization).
- Code/hook materialization (`extensions.sh`, `armbian-bsp-desktop-deb.sh`, `traps.sh`, heredocs in `utils-cli.sh`) — legitimate dynamic code generation.
- `eval env "${COMPILER}gcc"` in compilation paths — redundant `eval` but no injection risk; not in P1b scope.

## Test plan
- [x] `shellcheck` passes with no new warnings
- [x] `compile.sh` runs normally (cmdline param application, interactive config, change tracking, artifact config dump all exercised in normal builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
