### PR TITLE
meson: freeze current kernel at 6.12.28 and fix HDMI PHY frequency limit

### DIFF
--- a/config/sources/families/include/meson_common.inc
+++ b/config/sources/families/include/meson_common.inc
@@ -25,6 +25,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.12"
+		declare -g KERNELBRANCH="tag:v6.12.28" # frozen on this version
 		;;
 esac
 

--- a/patch/kernel/archive/meson-6.12/0052-drm-meson-Describe-the-HDMI-PHY-frequency-limits-of-.patch
+++ b/patch/kernel/archive/meson-6.12/0052-drm-meson-Describe-the-HDMI-PHY-frequency-limits-of-.patch
@@ -43,7 +43,7 @@ index 111111111111..222222222222 100644
 +	 */
  	{
  		.limits = {
- 			.max_hdmi_phy_freq = 1650000000,
+ 			.max_hdmi_phy_freq = 1650000,
  		},
  		.attrs = (const struct soc_device_attribute []) {
  			{ .soc_id = "GXL (S805*)", },


### PR DESCRIPTION
## Summary
- Freezes `KERNELBRANCH` at `v6.12.28` for meson current kernel branch
- Fixes `max_hdmi_phy_freq` value from `1650000000` to `1650000` Hz (removes extra zeros)

## Test plan
- [x] Verify meson boards build with frozen kernel version
- [x] Test HDMI output on affected hardware
- [x] Confirm no regressions with HDMI frequency limits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * System kernel updated to version 6.12.28
  * HDMI specifications optimized for Meson8, Meson8m2, and Meson8b platforms
  * Enhanced display output compatibility for improved visual experience on supported devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->