### PR TITLE
framework run_host_x86_binary_logged - robustness improvements in automatic quoting

### DIFF
--- a/lib/functions/logging/runners.sh
+++ b/lib/functions/logging/runners.sh
@@ -194,7 +194,7 @@ function run_host_x86_binary_logged() {
 	fi
 	local -a actual_invocation=('env' '-u' 'QEMU_CPU' "${qemu_invocation[@]}")
 	# `env -u QEMU_CPU` will unset any possible specified CPUs to emulate, as in config/sources/arm64.conf
-	run_host_command_logged "${actual_invocation[*]Q}" # Exit with this result code
+	run_host_command_logged "${actual_invocation[*]@Q}" # Exit with this result code
 }
 
 # Run simple and exit with it's code. Exactly the same as run_host_command_logged(). Used to have pv pipe, but that causes chaos.


### PR DESCRIPTION
# Description

just what it says on the tin, answer to #9467, minor refactor found around #9466 


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] ran shellcheck, it's :smile:
- [x] `./compile.sh artifact ARTIFACT_IGNORE_CACHE=yes BOARD=odroidhc4 BRANCH=current BUILD_DESKTOP=no BUILD_MINIMAL=yes COMPRESS_OUTPUTIMAGE=xz DEB_COMPRESS=xz EXPERT=yes KERNEL_CONFIGURE=no KERNEL_GIT=full MANAGE_ACNG=http://squid.tabris.net:3142/ RELEASE=trixie WHAT=uboot`
  - https://paste.armbian.com/ukuyavejih

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command invocation in the logging system so logged commands now execute reliably and arguments are preserved and passed safely, preventing mis-execution or formatting issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->