### PR TITLE
Change default label from 'Needs review' to 'Work in progress'

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,7 +10,7 @@
 #
 # Please keep the labels sorted and deduplicated.
 
-"Needs review":
+"Work in progress":
 - changed-files:
   - any-glob-to-any-file: '**'
 


### PR DESCRIPTION
## Summary
- Renamed the default label from "Needs review" to "Work in progress" in the labeler configuration
- Better reflects the status of changes that haven't been reviewed yet
- Regular user have ability of changing labels and can change to "Needs review" to signalize job is done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated issue and pull request labeling configuration to streamline workflow organization and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->