### PR TITLE
sm8550-6.18: Fix SD card not working on 6.18.14 or newer kernel

### DIFF
--- a/patch/kernel/archive/sm8550-6.18/0001-arm64-dts-qcom-sm8550-add-UART15.patch
+++ b/patch/kernel/archive/sm8550-6.18/0001-arm64-dts-qcom-sm8550-add-UART15.patch
@@ -1,7 +1,7 @@
-From df25170e42b1b5a20e5e2d1489bcffe5d6aee336 Mon Sep 17 00:00:00 2001
+From d33b2c8395b34bb7f2fdbe1ae4f7fbe641fff4db Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Wed, 12 Feb 2025 17:53:48 +0800
-Subject: [PATCH 01/18] arm64: dts: qcom: sm8550: add UART15
+Subject: [PATCH 01/19] arm64: dts: qcom: sm8550: add UART15
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  1 file changed, 22 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/qcom/sm8550.dtsi b/arch/arm64/boot/dts/qcom/sm8550.dtsi
-index 7724dba75..ac0698c01 100644
+index e294dc9c68c9..e6e1f55fb0b2 100644
 --- a/arch/arm64/boot/dts/qcom/sm8550.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8550.dtsi
 @@ -1251,6 +1251,20 @@ &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ACTIVE_ONLY>,
@@ -33,7 +33,7 @@ index 7724dba75..ac0698c01 100644
  		};
  
  		i2c_master_hub_0: geniqup@9c0000 {
-@@ -4917,6 +4931,14 @@ qup_uart14_cts_rts: qup-uart14-cts-rts-state {
+@@ -4915,6 +4929,14 @@ qup_uart14_cts_rts: qup-uart14-cts-rts-state {
  				bias-pull-down;
  			};
  

--- a/patch/kernel/archive/sm8550-6.18/0002-input-Add-driver-for-RSInput-Gamepad.patch
+++ b/patch/kernel/archive/sm8550-6.18/0002-input-Add-driver-for-RSInput-Gamepad.patch
@@ -1,7 +1,7 @@
-From 223437dc502f36021f3131bf8ba3a0b2a3dcee0c Mon Sep 17 00:00:00 2001
+From 45e73e32a831ec69b2ac779f4dca1cba90cd8fbc Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Thu, 20 Feb 2025 14:50:30 +0800
-Subject: [PATCH 02/18] input: Add driver for RSInput Gamepad
+Subject: [PATCH 02/19] input: Add driver for RSInput Gamepad
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
@@ -12,7 +12,7 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  create mode 100644 drivers/input/joystick/rsinput.c
 
 diff --git a/drivers/input/joystick/Kconfig b/drivers/input/joystick/Kconfig
-index 7755e5b45..0da3c0f44 100644
+index 7755e5b454d2..0da3c0f44ecf 100644
 --- a/drivers/input/joystick/Kconfig
 +++ b/drivers/input/joystick/Kconfig
 @@ -383,6 +383,10 @@ config JOYSTICK_QWIIC
@@ -27,7 +27,7 @@ index 7755e5b45..0da3c0f44 100644
  	tristate "FlySky FS-iA6B RC Receiver"
  	select SERIO
 diff --git a/drivers/input/joystick/Makefile b/drivers/input/joystick/Makefile
-index 9976f596a..3de503e29 100644
+index 9976f596a920..3de503e29489 100644
 --- a/drivers/input/joystick/Makefile
 +++ b/drivers/input/joystick/Makefile
 @@ -28,6 +28,7 @@ obj-$(CONFIG_JOYSTICK_N64)		+= n64joy.o
@@ -40,7 +40,7 @@ index 9976f596a..3de503e29 100644
  obj-$(CONFIG_JOYSTICK_SIDEWINDER)	+= sidewinder.o
 diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
 new file mode 100644
-index 000000000..8fc0c6ac3
+index 000000000000..8fc0c6ac3745
 --- /dev/null
 +++ b/drivers/input/joystick/rsinput.c
 @@ -0,0 +1,423 @@

--- a/patch/kernel/archive/sm8550-6.18/0003-drm-panel-Add-panel-driver-for-Chipone-ICNA3512-base.patch
+++ b/patch/kernel/archive/sm8550-6.18/0003-drm-panel-Add-panel-driver-for-Chipone-ICNA3512-base.patch
@@ -1,7 +1,7 @@
-From e795cc2b164408cc92c11f96be268a689c7b4c1a Mon Sep 17 00:00:00 2001
+From 8b6871478024c713a8ee8366f71880f3e49c32b3 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Thu, 13 Feb 2025 18:25:19 +0800
-Subject: [PATCH 03/18] drm/panel: Add panel driver for Chipone ICNA3512 based
+Subject: [PATCH 03/19] drm/panel: Add panel driver for Chipone ICNA3512 based
  panels
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
@@ -14,7 +14,7 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  create mode 100644 drivers/gpu/drm/panel/panel-chipone-icna3512.c
 
 diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
-index 407c5f6a2..d8cf15b0b 100644
+index 407c5f6a268b..d8cf15b0b38c 100644
 --- a/drivers/gpu/drm/panel/Kconfig
 +++ b/drivers/gpu/drm/panel/Kconfig
 @@ -105,6 +105,17 @@ config DRM_PANEL_BOE_TV101WUM_LL2
@@ -36,7 +36,7 @@ index 407c5f6a2..d8cf15b0b 100644
  	tristate "EBBG FT8719 panel driver"
  	depends on OF
 diff --git a/drivers/gpu/drm/panel/Makefile b/drivers/gpu/drm/panel/Makefile
-index 3615a761b..171843de9 100644
+index 3615a761b44f..171843de9791 100644
 --- a/drivers/gpu/drm/panel/Makefile
 +++ b/drivers/gpu/drm/panel/Makefile
 @@ -9,6 +9,7 @@ obj-$(CONFIG_DRM_PANEL_BOE_TD4320) += panel-boe-td4320.o
@@ -49,7 +49,7 @@ index 3615a761b..171843de9 100644
  obj-$(CONFIG_DRM_PANEL_SIMPLE) += panel-simple.o
 diff --git a/drivers/gpu/drm/panel/panel-chipone-icna3512.c b/drivers/gpu/drm/panel/panel-chipone-icna3512.c
 new file mode 100644
-index 000000000..cbda976df
+index 000000000000..cbda976df1db
 --- /dev/null
 +++ b/drivers/gpu/drm/panel/panel-chipone-icna3512.c
 @@ -0,0 +1,473 @@
@@ -528,7 +528,7 @@ index 000000000..cbda976df
 +MODULE_LICENSE("GPL");
 \ No newline at end of file
 diff --git a/include/drm/drm_mipi_dsi.h b/include/drm/drm_mipi_dsi.h
-index 3aba7b380..979bd874a 100644
+index 3aba7b380c8d..979bd874a9f6 100644
 --- a/include/drm/drm_mipi_dsi.h
 +++ b/include/drm/drm_mipi_dsi.h
 @@ -421,6 +421,28 @@ void mipi_dsi_dcs_set_tear_off_multi(struct mipi_dsi_multi_context *ctx);

--- a/patch/kernel/archive/sm8550-6.18/0004-leds-Add-driver-for-HEROIC-HTR3212.patch
+++ b/patch/kernel/archive/sm8550-6.18/0004-leds-Add-driver-for-HEROIC-HTR3212.patch
@@ -1,7 +1,7 @@
-From b105642e6a3e41b2853ca688c25682d9c934d056 Mon Sep 17 00:00:00 2001
+From 5a3fd14855dc3eaa6015c939fbc439ccc2ccff28 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Wed, 12 Feb 2025 15:29:16 +0800
-Subject: [PATCH 04/18] leds: Add driver for HEROIC HTR3212
+Subject: [PATCH 04/19] leds: Add driver for HEROIC HTR3212
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
@@ -12,7 +12,7 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  create mode 100644 drivers/leds/leds-htr3212.c
 
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 06e6291be..8e5c6ca7d 100644
+index 06e6291be11b..8e5c6ca7d661 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -218,6 +218,16 @@ config LEDS_EXPRESSWIRE
@@ -33,7 +33,7 @@ index 06e6291be..8e5c6ca7d 100644
  	tristate "LED support for CZ.NIC's Turris Omnia"
  	depends on LEDS_CLASS_MULTICOLOR
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 9a0333ec1..36815a752 100644
+index 9a0333ec1a86..36815a7526e9 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -33,6 +33,7 @@ obj-$(CONFIG_LEDS_DA9052)		+= leds-da9052.o
@@ -46,7 +46,7 @@ index 9a0333ec1..36815a752 100644
  obj-$(CONFIG_LEDS_IPAQ_MICRO)		+= leds-ipaq-micro.o
 diff --git a/drivers/leds/leds-htr3212.c b/drivers/leds/leds-htr3212.c
 new file mode 100644
-index 000000000..bbb4b2fc1
+index 000000000000..bbb4b2fc185f
 --- /dev/null
 +++ b/drivers/leds/leds-htr3212.c
 @@ -0,0 +1,298 @@

--- a/patch/kernel/archive/sm8550-6.18/0005-ASoC-qcom-sc8280xp-Add-support-for-Primary-I2S.patch
+++ b/patch/kernel/archive/sm8550-6.18/0005-ASoC-qcom-sc8280xp-Add-support-for-Primary-I2S.patch
@@ -1,14 +1,14 @@
-From 10d9493e70a541d909494556d7d28451e4c17f0d Mon Sep 17 00:00:00 2001
+From d9fc6ec8f0a4cdadf45275b2e41c0e691342f223 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Fri, 23 Jan 2026 09:15:25 +0800
-Subject: [PATCH 05/18] ASoC: qcom: sc8280xp Add support for Primary I2S
+Subject: [PATCH 05/19] ASoC: qcom: sc8280xp Add support for Primary I2S
 
 ---
  sound/soc/qcom/sc8280xp.c | 40 ++++++++++++++++++++++++++++++++++++++-
  1 file changed, 39 insertions(+), 1 deletion(-)
 
 diff --git a/sound/soc/qcom/sc8280xp.c b/sound/soc/qcom/sc8280xp.c
-index ed8b04c60..01017d05a 100644
+index ed8b04c6022e..01017d05af95 100644
 --- a/sound/soc/qcom/sc8280xp.c
 +++ b/sound/soc/qcom/sc8280xp.c
 @@ -2,6 +2,7 @@

--- a/patch/kernel/archive/sm8550-6.18/0006-dt-bindings-mmc-qcom-Document-level-shifter-flag-for.patch
+++ b/patch/kernel/archive/sm8550-6.18/0006-dt-bindings-mmc-qcom-Document-level-shifter-flag-for.patch
@@ -1,7 +1,7 @@
-From 8127a1d15b63b1f582be9c212472b8d50bcb3b9d Mon Sep 17 00:00:00 2001
+From 552c919a8a6ac4ccc5f2ae22bb63da0a96cfba7c Mon Sep 17 00:00:00 2001
 From: Sarthak Garg <quic_sartgarg@quicinc.com>
 Date: Thu, 7 Nov 2024 13:35:03 +0530
-Subject: [PATCH 06/18] dt-bindings: mmc: qcom: Document level shifter flag for
+Subject: [PATCH 06/19] dt-bindings: mmc: qcom: Document level shifter flag for
  SD card
 
 Introduce a flag to indicate if the Qualcomm platform has a level
@@ -21,7 +21,7 @@ Signed-off-by: Sarthak Garg <quic_sartgarg@quicinc.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/mmc/sdhci-msm.yaml b/Documentation/devicetree/bindings/mmc/sdhci-msm.yaml
-index 594bd174f..14b91538a 100644
+index 594bd174ff21..14b91538aa07 100644
 --- a/Documentation/devicetree/bindings/mmc/sdhci-msm.yaml
 +++ b/Documentation/devicetree/bindings/mmc/sdhci-msm.yaml
 @@ -138,6 +138,9 @@ properties:

--- a/patch/kernel/archive/sm8550-6.18/0007-mmc-sdhci-msm-Limit-HS-mode-frequency-to-37.5MHz.patch
+++ b/patch/kernel/archive/sm8550-6.18/0007-mmc-sdhci-msm-Limit-HS-mode-frequency-to-37.5MHz.patch
@@ -1,7 +1,7 @@
-From 59ca09bcdfb968d7da2ad65fc51127a6aec1183c Mon Sep 17 00:00:00 2001
+From b497610e4c8123afff8f2c0b2482c0801ff27d9f Mon Sep 17 00:00:00 2001
 From: Sarthak Garg <quic_sartgarg@quicinc.com>
 Date: Fri, 23 Jan 2026 09:17:32 +0800
-Subject: [PATCH 07/18] mmc: sdhci-msm: Limit HS mode frequency to 37.5MHz
+Subject: [PATCH 07/19] mmc: sdhci-msm: Limit HS mode frequency to 37.5MHz
 
 For Qualcomm SoCs with level shifter delays are seen on receivers data
 path due to latency added by level shifter.
@@ -16,7 +16,7 @@ Signed-off-by: Sarthak Garg <quic_sartgarg@quicinc.com>
  1 file changed, 10 insertions(+)
 
 diff --git a/drivers/mmc/host/sdhci-msm.c b/drivers/mmc/host/sdhci-msm.c
-index 3b8523313..ea5531a97 100644
+index 3b85233131b3..ea5531a97c49 100644
 --- a/drivers/mmc/host/sdhci-msm.c
 +++ b/drivers/mmc/host/sdhci-msm.c
 @@ -147,6 +147,8 @@

--- a/patch/kernel/archive/sm8550-6.18/0008-mmc-sdhci-msm-Toggle-the-FIFO-write-clock-after-unga.patch
+++ b/patch/kernel/archive/sm8550-6.18/0008-mmc-sdhci-msm-Toggle-the-FIFO-write-clock-after-unga.patch
@@ -1,7 +1,7 @@
-From a55ef657ce7ac5c14a09d6f361d6caa62a2a8bcb Mon Sep 17 00:00:00 2001
+From 1b187aba718a5c59a82de61033364e6794168c4e Mon Sep 17 00:00:00 2001
 From: Ram Prakash Gupta <quic_rampraka@quicinc.com>
 Date: Tue, 22 Oct 2024 16:40:25 +0530
-Subject: [PATCH 08/18] mmc: sdhci-msm: Toggle the FIFO write clock after
+Subject: [PATCH 08/19] mmc: sdhci-msm: Toggle the FIFO write clock after
  ungate
 
 For Qualcomm SoCs with sdcc minor version 6B and more, command path
@@ -16,7 +16,7 @@ Signed-off-by: Ram Prakash Gupta <quic_rampraka@quicinc.com>
  1 file changed, 41 insertions(+)
 
 diff --git a/drivers/mmc/host/sdhci-msm.c b/drivers/mmc/host/sdhci-msm.c
-index ea5531a97..5be69346b 100644
+index ea5531a97c49..5be69346b2af 100644
 --- a/drivers/mmc/host/sdhci-msm.c
 +++ b/drivers/mmc/host/sdhci-msm.c
 @@ -158,6 +158,7 @@

--- a/patch/kernel/archive/sm8550-6.18/0009-clk-qcom-gcc-sm8550-Keep-UFS-PHY-GDSCs-ALWAYS_ON.patch
+++ b/patch/kernel/archive/sm8550-6.18/0009-clk-qcom-gcc-sm8550-Keep-UFS-PHY-GDSCs-ALWAYS_ON.patch
@@ -1,7 +1,7 @@
-From d5271df380a8407f0e0db336f4eba34ce587f135 Mon Sep 17 00:00:00 2001
+From 0bf82eda7a188208a7835b7a2d9301efde003ab7 Mon Sep 17 00:00:00 2001
 From: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
 Date: Thu, 7 Nov 2024 11:58:09 +0000
-Subject: [PATCH 09/18] clk: qcom: gcc-sm8550: Keep UFS PHY GDSCs ALWAYS_ON
+Subject: [PATCH 09/19] clk: qcom: gcc-sm8550: Keep UFS PHY GDSCs ALWAYS_ON
 
 Starting from SM8550, UFS PHY GDSCs doesn't support hardware retention. So
 using RETAIN_FF_ENABLE is wrong. Moreover, without ALWAYS_ON flag, GDSCs
@@ -27,7 +27,7 @@ Tested-by: Neil Armstrong <neil.armstrong@linaro.org> # on SM8550-HDK
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/clk/qcom/gcc-sm8550.c b/drivers/clk/qcom/gcc-sm8550.c
-index 862a9bf73..2803c0855 100644
+index 36a5b7de5b55..245e4de93396 100644
 --- a/drivers/clk/qcom/gcc-sm8550.c
 +++ b/drivers/clk/qcom/gcc-sm8550.c
 @@ -3046,7 +3046,7 @@ static struct gdsc ufs_phy_gdsc = {

--- a/patch/kernel/archive/sm8550-6.18/0010-drm-panel-Add-WIP-panel-driver-for-AYN-Odin-2.patch
+++ b/patch/kernel/archive/sm8550-6.18/0010-drm-panel-Add-WIP-panel-driver-for-AYN-Odin-2.patch
@@ -1,7 +1,7 @@
-From 512a16bf06286e0ce6d7ff03c419464c298e0fe2 Mon Sep 17 00:00:00 2001
+From c7ba4b72c9763b779b9d957db94a05a58e2dbe6f Mon Sep 17 00:00:00 2001
 From: Xilin Wu <wuxilin123@gmail.com>
 Date: Fri, 23 Jan 2026 09:21:13 +0800
-Subject: [PATCH 10/18] drm/panel: Add WIP panel driver for AYN Odin 2
+Subject: [PATCH 10/19] drm/panel: Add WIP panel driver for AYN Odin 2
 
 Signed-off-by: Xilin Wu <wuxilin123@gmail.com>
 ---
@@ -12,7 +12,7 @@ Signed-off-by: Xilin Wu <wuxilin123@gmail.com>
  create mode 100644 drivers/gpu/drm/panel/panel-synaptics-td4328.c
 
 diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
-index d8cf15b0b..d34351f27 100644
+index d8cf15b0b38c..d34351f27eed 100644
 --- a/drivers/gpu/drm/panel/Kconfig
 +++ b/drivers/gpu/drm/panel/Kconfig
 @@ -1056,6 +1056,16 @@ config DRM_PANEL_SYNAPTICS_R63353
@@ -39,7 +39,7 @@ index d8cf15b0b..d34351f27 100644
 +
  endmenu
 diff --git a/drivers/gpu/drm/panel/Makefile b/drivers/gpu/drm/panel/Makefile
-index 171843de9..d8e9d6ac1 100644
+index 171843de9791..d8e9d6ac129e 100644
 --- a/drivers/gpu/drm/panel/Makefile
 +++ b/drivers/gpu/drm/panel/Makefile
 @@ -101,6 +101,7 @@ obj-$(CONFIG_DRM_PANEL_SITRONIX_ST7703) += panel-sitronix-st7703.o
@@ -52,7 +52,7 @@ index 171843de9..d8e9d6ac1 100644
  obj-$(CONFIG_DRM_PANEL_SONY_TULIP_TRULY_NT35521) += panel-sony-tulip-truly-nt35521.o
 diff --git a/drivers/gpu/drm/panel/panel-synaptics-td4328.c b/drivers/gpu/drm/panel/panel-synaptics-td4328.c
 new file mode 100644
-index 000000000..0fb0ddd93
+index 000000000000..0fb0ddd9373d
 --- /dev/null
 +++ b/drivers/gpu/drm/panel/panel-synaptics-td4328.c
 @@ -0,0 +1,246 @@

--- a/patch/kernel/archive/sm8550-6.18/0011-arm64-dts-qcom-Added-pmk8550-pwm-support.patch
+++ b/patch/kernel/archive/sm8550-6.18/0011-arm64-dts-qcom-Added-pmk8550-pwm-support.patch
@@ -1,7 +1,7 @@
-From 9e66f088c6907dfa6fa91be93d035098653b9619 Mon Sep 17 00:00:00 2001
+From 0effe54432dc4549832135b1bed4c8b5f90ada3e Mon Sep 17 00:00:00 2001
 From: Alex Ling <ling_kasim@hotmail.com>
 Date: Fri, 23 Jan 2026 09:24:14 +0800
-Subject: [PATCH 11/18] arm64: dts: qcom: Added pmk8550 pwm support
+Subject: [PATCH 11/19] arm64: dts: qcom: Added pmk8550 pwm support
 
 Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
  1 file changed, 10 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/qcom/pmk8550.dtsi b/arch/arm64/boot/dts/qcom/pmk8550.dtsi
-index 583f61fc1..3049eb6b4 100644
+index 583f61fc16ad..3049eb6b46d7 100644
 --- a/arch/arm64/boot/dts/qcom/pmk8550.dtsi
 +++ b/arch/arm64/boot/dts/qcom/pmk8550.dtsi
 @@ -73,5 +73,15 @@ pmk8550_gpios: gpio@b800 {

--- a/patch/kernel/archive/sm8550-6.18/0012-drivers-mmc-Added-qcom-downstream-sdhci-driver.patch
+++ b/patch/kernel/archive/sm8550-6.18/0012-drivers-mmc-Added-qcom-downstream-sdhci-driver.patch
@@ -1,7 +1,7 @@
-From 84045ef4fbbf9286be8030c487fe22cf02824a23 Mon Sep 17 00:00:00 2001
+From a34e3bc3de9d68a7636ff18bc0b4d5675b892d5e Mon Sep 17 00:00:00 2001
 From: Alex Ling <ling_kasim@hotmail.com>
 Date: Fri, 23 Jan 2026 09:29:36 +0800
-Subject: [PATCH 12/18] drivers: mmc: Added qcom downstream sdhci driver
+Subject: [PATCH 12/19] drivers: mmc: Added qcom downstream sdhci driver
 
 ---
  drivers/mmc/host/Kconfig                |   16 +
@@ -15,7 +15,7 @@ Subject: [PATCH 12/18] drivers: mmc: Added qcom downstream sdhci driver
  create mode 100644 drivers/mmc/host/sdhci-msm.h
 
 diff --git a/drivers/mmc/host/Kconfig b/drivers/mmc/host/Kconfig
-index c94ae4794..df8b351a2 100644
+index c94ae4794545..df8b351a251e 100644
 --- a/drivers/mmc/host/Kconfig
 +++ b/drivers/mmc/host/Kconfig
 @@ -606,6 +606,22 @@ config MMC_SDHCI_MSM
@@ -42,7 +42,7 @@ index c94ae4794..df8b351a2 100644
  	tristate "Freescale i.MX21/27/31 or MPC512x Multimedia Card support"
  	depends on ARCH_MXC || PPC_MPC512x || COMPILE_TEST
 diff --git a/drivers/mmc/host/Makefile b/drivers/mmc/host/Makefile
-index 5057fea8a..90afe9aa2 100644
+index 5057fea8afb6..90afe9aa27dc 100644
 --- a/drivers/mmc/host/Makefile
 +++ b/drivers/mmc/host/Makefile
 @@ -96,6 +96,7 @@ obj-$(CONFIG_MMC_SDHCI_BCM_KONA)	+= sdhci-bcm-kona.o
@@ -54,7 +54,7 @@ index 5057fea8a..90afe9aa2 100644
  obj-$(CONFIG_MMC_SDHCI_MICROCHIP_PIC32)	+= sdhci-pic32.o
  obj-$(CONFIG_MMC_SDHCI_BRCMSTB)		+= sdhci-brcmstb.o
 diff --git a/drivers/mmc/host/cqhci-core.c b/drivers/mmc/host/cqhci-core.c
-index 178277d90..0a83252bb 100644
+index 178277d90c31..0a83252bbb80 100644
 --- a/drivers/mmc/host/cqhci-core.c
 +++ b/drivers/mmc/host/cqhci-core.c
 @@ -792,6 +792,11 @@ static void cqhci_finish_mrq(struct mmc_host *mmc, unsigned int tag)
@@ -85,7 +85,7 @@ index 178277d90..0a83252bb 100644
  }
  
 diff --git a/drivers/mmc/host/cqhci.h b/drivers/mmc/host/cqhci.h
-index ce189a186..e346db32e 100644
+index ce189a1866b9..e346db32e5b2 100644
 --- a/drivers/mmc/host/cqhci.h
 +++ b/drivers/mmc/host/cqhci.h
 @@ -119,6 +119,14 @@
@@ -113,7 +113,7 @@ index ce189a186..e346db32e 100644
  	size_t data_size;
 diff --git a/drivers/mmc/host/sdhci-msm-downstream.c b/drivers/mmc/host/sdhci-msm-downstream.c
 new file mode 100644
-index 000000000..4cc1b2fde
+index 000000000000..4cc1b2fde376
 --- /dev/null
 +++ b/drivers/mmc/host/sdhci-msm-downstream.c
 @@ -0,0 +1,5808 @@
@@ -5927,7 +5927,7 @@ index 000000000..4cc1b2fde
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/mmc/host/sdhci-msm.h b/drivers/mmc/host/sdhci-msm.h
 new file mode 100644
-index 000000000..88aa1d3cd
+index 000000000000..88aa1d3cddaa
 --- /dev/null
 +++ b/drivers/mmc/host/sdhci-msm.h
 @@ -0,0 +1,272 @@

--- a/patch/kernel/archive/sm8550-6.18/0013-drivers-power-Fix-name-for-sc8280xp-battery.patch
+++ b/patch/kernel/archive/sm8550-6.18/0013-drivers-power-Fix-name-for-sc8280xp-battery.patch
@@ -1,7 +1,7 @@
-From ab22f8aadb8e3345416f9e934a48b8a59748173d Mon Sep 17 00:00:00 2001
+From 66e1115869c60ed1b1a5b93199f79094b35501df Mon Sep 17 00:00:00 2001
 From: Alex Ling <ling_kasim@hotmail.com>
 Date: Fri, 23 Jan 2026 09:31:36 +0800
-Subject: [PATCH 13/18] drivers: power: Fix name for sc8280xp battery
+Subject: [PATCH 13/19] drivers: power: Fix name for sc8280xp battery
 
 Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/power/supply/qcom_battmgr.c b/drivers/power/supply/qcom_battmgr.c
-index e6f01e012..21019949e 100644
+index ff77dba29a3e..0c1977bcd660 100644
 --- a/drivers/power/supply/qcom_battmgr.c
 +++ b/drivers/power/supply/qcom_battmgr.c
 @@ -822,7 +822,7 @@ static const enum power_supply_property sc8280xp_bat_props[] = {

--- a/patch/kernel/archive/sm8550-6.18/0014-HACK-fix-usb-boot-hang.patch
+++ b/patch/kernel/archive/sm8550-6.18/0014-HACK-fix-usb-boot-hang.patch
@@ -1,7 +1,7 @@
-From f46b5f9b1c1157a835a1a08252cd891687ac0376 Mon Sep 17 00:00:00 2001
+From c217ba5e752403e857cfd1a5d4034dbc7725c53d Mon Sep 17 00:00:00 2001
 From: Alex Ling <ling_kasim@hotmail.com>
 Date: Fri, 23 Jan 2026 09:32:30 +0800
-Subject: [PATCH 14/18] HACK: fix usb boot hang
+Subject: [PATCH 14/19] HACK: fix usb boot hang
 
 Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
  1 file changed, 13 deletions(-)
 
 diff --git a/drivers/usb/host/pci-quirks.c b/drivers/usb/host/pci-quirks.c
-index 0404489c2..12e1167e2 100644
+index 0404489c2f6a..12e1167e2d25 100644
 --- a/drivers/usb/host/pci-quirks.c
 +++ b/drivers/usb/host/pci-quirks.c
 @@ -1226,19 +1226,6 @@ static void quirk_usb_handoff_xhci(struct pci_dev *pdev)

--- a/patch/kernel/archive/sm8550-6.18/0015-drivers-use-soc-serial-for-wifi-and-bluetooth.patch
+++ b/patch/kernel/archive/sm8550-6.18/0015-drivers-use-soc-serial-for-wifi-and-bluetooth.patch
@@ -1,7 +1,7 @@
-From 59250424d761009af70ce8079169d8e6081acf26 Mon Sep 17 00:00:00 2001
+From 3a7726aa21594d4b0ac7d7464a05f42af0d4f1a5 Mon Sep 17 00:00:00 2001
 From: spycat88 <spycat88@users.noreply.github.com>
 Date: Thu, 23 Jan 2025 15:18:25 +0000
-Subject: [PATCH 15/18] drivers: use soc serial for wifi and bluetooth
+Subject: [PATCH 15/19] drivers: use soc serial for wifi and bluetooth
 
 ---
  drivers/bluetooth/btqca.c             |  94 ++++++++++++++++++++++--
@@ -10,7 +10,7 @@ Subject: [PATCH 15/18] drivers: use soc serial for wifi and bluetooth
  3 files changed, 196 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/bluetooth/btqca.c b/drivers/bluetooth/btqca.c
-index 7c958d606..d71871f94 100644
+index 7c958d6065be..d71871f94b79 100644
 --- a/drivers/bluetooth/btqca.c
 +++ b/drivers/bluetooth/btqca.c
 @@ -12,6 +12,74 @@
@@ -136,7 +136,7 @@ index 7c958d606..d71871f94 100644
  	bt_dev_info(hdev, "QCA setup on UART is completed");
  
 diff --git a/drivers/net/wireless/ath/ath12k/mac.c b/drivers/net/wireless/ath/ath12k/mac.c
-index 095b49a39..45ad5cbd2 100644
+index b97469dca046..ac33f2b87f24 100644
 --- a/drivers/net/wireless/ath/ath12k/mac.c
 +++ b/drivers/net/wireless/ath/ath12k/mac.c
 @@ -162,6 +162,91 @@ static const struct ieee80211_channel ath12k_6ghz_channels[] = {
@@ -231,7 +231,7 @@ index 095b49a39..45ad5cbd2 100644
  static struct ieee80211_rate ath12k_legacy_rates[] = {
  	{ .bitrate = 10,
  	  .hw_value = ATH12K_HW_RATE_CCK_LP_1M },
-@@ -13723,6 +13808,7 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
+@@ -13729,6 +13814,7 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
  	struct ath12k_base *ab = ar->ab;
  	struct ath12k_pdev *pdev;
  	struct ath12k_pdev_cap *cap;
@@ -239,7 +239,7 @@ index 095b49a39..45ad5cbd2 100644
  	static const u32 cipher_suites[] = {
  		WLAN_CIPHER_SUITE_TKIP,
  		WLAN_CIPHER_SUITE_CCMP,
-@@ -13746,11 +13832,17 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
+@@ -13752,11 +13838,17 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
  		u32 ht_cap_info = 0;
  
  		pdev = ar->pdev;
@@ -262,7 +262,7 @@ index 095b49a39..45ad5cbd2 100644
  
  		ret = ath12k_mac_setup_register(ar, &ht_cap_info, hw->wiphy->bands);
 diff --git a/drivers/soc/qcom/socinfo.c b/drivers/soc/qcom/socinfo.c
-index 963772f45..b69c976da 100644
+index 963772f45489..b69c976da4e6 100644
 --- a/drivers/soc/qcom/socinfo.c
 +++ b/drivers/soc/qcom/socinfo.c
 @@ -171,6 +171,10 @@ struct smem_image_version {

--- a/patch/kernel/archive/sm8550-6.18/0016-HACK-Revert-back-to-6.12-aw88166-driver.patch
+++ b/patch/kernel/archive/sm8550-6.18/0016-HACK-Revert-back-to-6.12-aw88166-driver.patch
@@ -1,7 +1,7 @@
-From f3406cb7cea1b173c4e4c3bb1e8f23cda63ba03c Mon Sep 17 00:00:00 2001
+From 091f60d924225f1c1217ec740ef493c010442f49 Mon Sep 17 00:00:00 2001
 From: Alex Ling <ling_kasim@hotmail.com>
 Date: Sun, 18 Jan 2026 20:37:39 +0800
-Subject: [PATCH 16/18] HACK: Revert back to 6.12 aw88166 driver
+Subject: [PATCH 16/19] HACK: Revert back to 6.12 aw88166 driver
 
 Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
  2 files changed, 105 insertions(+), 275 deletions(-)
 
 diff --git a/sound/soc/codecs/aw88166.c b/sound/soc/codecs/aw88166.c
-index 28f62b991..e2636bde6 100644
+index 28f62b991ef2..e2636bde62fc 100644
 --- a/sound/soc/codecs/aw88166.c
 +++ b/sound/soc/codecs/aw88166.c
 @@ -11,8 +11,8 @@
@@ -523,7 +523,7 @@ index 28f62b991..e2636bde6 100644
  }
  
 diff --git a/sound/soc/codecs/aw88166.h b/sound/soc/codecs/aw88166.h
-index 3a53ba0ac..8b5c83a48 100644
+index 3a53ba0ac625..8b5c83a48d6e 100644
 --- a/sound/soc/codecs/aw88166.h
 +++ b/sound/soc/codecs/aw88166.h
 @@ -387,7 +387,7 @@

--- a/patch/kernel/archive/sm8550-6.18/0017-pwm-Add-SI-EN-SN3112-PWM-support.patch
+++ b/patch/kernel/archive/sm8550-6.18/0017-pwm-Add-SI-EN-SN3112-PWM-support.patch
@@ -1,7 +1,7 @@
-From 46a8c2454f5e228718a36f046d0e42156ded57e6 Mon Sep 17 00:00:00 2001
+From 0f0ba6c9853a0bd06bbf8040c3d52bfd40ee55bd Mon Sep 17 00:00:00 2001
 From: BigfootACA <bigfoot@classfun.cn>
 Date: Sat, 24 Jan 2026 19:45:33 +0800
-Subject: [PATCH 17/18] pwm: Add SI-EN SN3112 PWM support
+Subject: [PATCH 17/19] pwm: Add SI-EN SN3112 PWM support
 
 Add a new driver for the SI-EN SN3112 12-channel 8-bit PWM LED controller.
 
@@ -14,7 +14,7 @@ Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
  create mode 100644 drivers/pwm/pwm-sn3112.c
 
 diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
-index c2fd3f4b6..c05ac85c4 100644
+index c2fd3f4b62d9..c05ac85c4b30 100644
 --- a/drivers/pwm/Kconfig
 +++ b/drivers/pwm/Kconfig
 @@ -658,6 +658,16 @@ config PWM_SOPHGO_SG2042
@@ -35,7 +35,7 @@ index c2fd3f4b6..c05ac85c4 100644
  	tristate "STMicroelectronics SPEAr PWM support"
  	depends on PLAT_SPEAR || COMPILE_TEST
 diff --git a/drivers/pwm/Makefile b/drivers/pwm/Makefile
-index dfa8b4966..c507bebf8 100644
+index dfa8b4966ee1..c507bebf8931 100644
 --- a/drivers/pwm/Makefile
 +++ b/drivers/pwm/Makefile
 @@ -58,6 +58,7 @@ obj-$(CONFIG_PWM_ROCKCHIP)	+= pwm-rockchip.o
@@ -48,7 +48,7 @@ index dfa8b4966..c507bebf8 100644
  obj-$(CONFIG_PWM_SPRD)		+= pwm-sprd.o
 diff --git a/drivers/pwm/pwm-sn3112.c b/drivers/pwm/pwm-sn3112.c
 new file mode 100644
-index 000000000..18345b19b
+index 000000000000..18345b19b02f
 --- /dev/null
 +++ b/drivers/pwm/pwm-sn3112.c
 @@ -0,0 +1,350 @@

--- a/patch/kernel/archive/sm8550-6.18/0018-dts-arm64-qcom-Added-Ayn-Odin2-device-support.patch
+++ b/patch/kernel/archive/sm8550-6.18/0018-dts-arm64-qcom-Added-Ayn-Odin2-device-support.patch
@@ -1,7 +1,7 @@
-From 79099aed12688fb0a2b5a33b6df164144f3a2e2d Mon Sep 17 00:00:00 2001
+From 6fdafbab156fb813ad299323f1c39de305f97855 Mon Sep 17 00:00:00 2001
 From: Alex Ling <ling_kasim@hotmail.com>
 Date: Sat, 17 Jan 2026 18:06:57 +0800
-Subject: [PATCH 18/18] dts: arm64: qcom: Added Ayn Odin2 device support
+Subject: [PATCH 18/19] dts: arm64: qcom: Added Ayn Odin2 device support
 
 Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
 ---
@@ -15,7 +15,7 @@ Signed-off-by: Alex Ling <ling_kasim@hotmail.com>
  create mode 100644 arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2portal.dts
 
 diff --git a/arch/arm64/boot/dts/qcom/Makefile b/arch/arm64/boot/dts/qcom/Makefile
-index 296688f7c..8d44febb9 100644
+index 296688f7cb26..8d44febb9b0b 100644
 --- a/arch/arm64/boot/dts/qcom/Makefile
 +++ b/arch/arm64/boot/dts/qcom/Makefile
 @@ -135,6 +135,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= qcs6490-rb3gen2-industrial-mezzanine.dtb
@@ -28,7 +28,7 @@ index 296688f7c..8d44febb9 100644
  dtb-$(CONFIG_ARCH_QCOM)	+= qdu1000-idp.dtb
 diff --git a/arch/arm64/boot/dts/qcom/qcs8550-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/qcs8550-ayn-common.dtsi
 new file mode 100644
-index 000000000..cc8ba1f44
+index 000000000000..cc8ba1f4456c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/qcom/qcs8550-ayn-common.dtsi
 @@ -0,0 +1,1401 @@
@@ -1435,7 +1435,7 @@ index 000000000..cc8ba1f44
 +};
 diff --git a/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2.dts b/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2.dts
 new file mode 100644
-index 000000000..877e869ce
+index 000000000000..877e869ce31a
 --- /dev/null
 +++ b/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2.dts
 @@ -0,0 +1,355 @@
@@ -1796,7 +1796,7 @@ index 000000000..877e869ce
 +};
 diff --git a/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2portal.dts b/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2portal.dts
 new file mode 100644
-index 000000000..6561c4ce6
+index 000000000000..6561c4ce6994
 --- /dev/null
 +++ b/arch/arm64/boot/dts/qcom/qcs8550-ayn-odin2portal.dts
 @@ -0,0 +1,338 @@

--- a/patch/kernel/archive/sm8550-6.18/0019-Revert-clk-qcom-gcc-sm8550-Use-floor-ops-for-SDCC-RC.patch
+++ b/patch/kernel/archive/sm8550-6.18/0019-Revert-clk-qcom-gcc-sm8550-Use-floor-ops-for-SDCC-RC.patch
@@ -1,0 +1,36 @@
+From 2cbbfe9f3feef2679122ca5c148b99375aeaccdc Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Wed, 4 Mar 2026 22:48:48 +0800
+Subject: [PATCH 19/19] Revert "clk: qcom: gcc-sm8550: Use floor ops for SDCC
+ RCGs"
+
+This reverts commit b714c1d0bb437e46b1bb82fea5d0a138bbfe6f98.
+---
+ drivers/clk/qcom/gcc-sm8550.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/clk/qcom/gcc-sm8550.c b/drivers/clk/qcom/gcc-sm8550.c
+index 245e4de93396..2803c085508b 100644
+--- a/drivers/clk/qcom/gcc-sm8550.c
++++ b/drivers/clk/qcom/gcc-sm8550.c
+@@ -1025,7 +1025,7 @@ static struct clk_rcg2 gcc_sdcc2_apps_clk_src = {
+ 		.parent_data = gcc_parent_data_9,
+ 		.num_parents = ARRAY_SIZE(gcc_parent_data_9),
+ 		.flags = CLK_SET_RATE_PARENT,
+-		.ops = &clk_rcg2_shared_floor_ops,
++		.ops = &clk_rcg2_shared_ops,
+ 	},
+ };
+ 
+@@ -1048,7 +1048,7 @@ static struct clk_rcg2 gcc_sdcc4_apps_clk_src = {
+ 		.parent_data = gcc_parent_data_0,
+ 		.num_parents = ARRAY_SIZE(gcc_parent_data_0),
+ 		.flags = CLK_SET_RATE_PARENT,
+-		.ops = &clk_rcg2_shared_floor_ops,
++		.ops = &clk_rcg2_shared_ops,
+ 	},
+ };
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
It appears the upstream commit "clk: qcom: gcc-sm8550: Use floor ops for SDCC
 RCGs" conflicts with the downstream msm sdhc driver. Revert it for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for RSInput gamepad driver, Chipone ICNA3512 and Synaptics TD4328 display panels, HEROIC HTR3212 LED driver, and SI-EN SN3112 PWM driver.
  * Added Primary I2S audio support and AYN Odin 2 device support.
  * Added SD card level-shifter support and serial number sharing for WiFi/Bluetooth connectivity.

* **Bug Fixes**
  * Fixed USB boot hang and battery naming issues.
  * Optimized SD card HS mode frequency limiting and MMC clock handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->