### PR TITLE
i915: fix Dell XPS 13 7390 device ID in quirk patches

### DIFF
--- a/patch/kernel/archive/uefi-x86-6.18/2008-i915-4-lane-quirk-for-mbp15-1.patch
+++ b/patch/kernel/archive/uefi-x86-6.18/2008-i915-4-lane-quirk-for-mbp15-1.patch
@@ -52,7 +52,7 @@ index 111111111111..222222222222 100644
 @@ -240,6 +252,9 @@ static struct intel_quirk intel_quirks[] = {
  
  	/* Dell XPS 13 7390 2-in-1 */
- 	{ 0x8a12, 0x1028, 0x08b0, quirk_edp_limit_rate_hbr2 },
+ 	{ 0x8a52, 0x1028, 0x08b0, quirk_edp_limit_rate_hbr2 },
 +
 +	/* Apple MacBookPro15,1 */
 +	{ 0x3e9b, 0x106b, 0x0176, quirk_ddi_a_force_4_lanes },

--- a/patch/kernel/archive/uefi-x86-6.19/2008-i915-4-lane-quirk-for-mbp15-1.patch
+++ b/patch/kernel/archive/uefi-x86-6.19/2008-i915-4-lane-quirk-for-mbp15-1.patch
@@ -52,7 +52,7 @@ index 111111111111..222222222222 100644
 @@ -240,6 +252,9 @@ static struct intel_quirk intel_quirks[] = {
  
  	/* Dell XPS 13 7390 2-in-1 */
- 	{ 0x8a12, 0x1028, 0x08b0, quirk_edp_limit_rate_hbr2 },
+ 	{ 0x8a52, 0x1028, 0x08b0, quirk_edp_limit_rate_hbr2 },
 +
 +	/* Apple MacBookPro15,1 */
 +	{ 0x3e9b, 0x106b, 0x0176, quirk_ddi_a_force_4_lanes },


### PR DESCRIPTION
## Summary
- Corrects Dell XPS 13 7390 2-in-1 device ID from `0x8a12` to `0x8a52`
- Fixes the i915 DRM quirk in both 6.18 and 6.19 kernel patches
- Fixes kernel compilation on x86 CURRENT and EDGE

## Test plan
- [x] Verify kernel builds with updated patches
- [ ] Test on Dell XPS 13 7390 2-in-1 hardware
- [ ] Confirm display output works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved graphics display support for Apple MacBook Pro 15-inch (2019) by forcing correct display port lane configuration.
  * Updated graphics driver configuration for Dell XPS 13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->