### PR TITLE
dwc2: explicitly force host mode for USB_DR_MODE_HOST

### DIFF
--- a/patch/kernel/archive/rockchip-6.18/patches.armbian/general-dwc2-fix-wait-time.patch
+++ b/patch/kernel/archive/rockchip-6.18/patches.armbian/general-dwc2-fix-wait-time.patch
@@ -35,6 +35,7 @@ index 111111111111..222222222222 100644
 +
  	switch (hsotg->dr_mode) {
  	case USB_DR_MODE_HOST:
+ 		dwc2_force_mode(hsotg, true);
  		/*
  		 * NOTE: This is required for some rockchip soc based
  		 * platforms on their host-only dwc2.

--- a/patch/kernel/archive/rockchip-6.19/patches.armbian/general-dwc2-fix-wait-time.patch
+++ b/patch/kernel/archive/rockchip-6.19/patches.armbian/general-dwc2-fix-wait-time.patch
@@ -35,6 +35,7 @@ index 111111111111..222222222222 100644
 +
  	switch (hsotg->dr_mode) {
  	case USB_DR_MODE_HOST:
+ 		dwc2_force_mode(hsotg, true);
  		/*
  		 * NOTE: This is required for some rockchip soc based
  		 * platforms on their host-only dwc2.


### PR DESCRIPTION
## Summary

Adjust patch due to changes:
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/drivers/usb/dwc2/core.c?h=v6.18.16&id=9799f977759e427811d1844fa536e23b351e3411
 
## Test plan
- [x] Build kernel patches for 6.18 and 6.19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced USB host mode initialization with adaptive polling mechanism instead of fixed wait times.
  * Improved timeout handling for USB host mode detection to better manage initialization edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->