### PR TITLE
partitioning: fix #9201 /etc/fstab entry (double comma)

### DIFF
--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -342,7 +342,6 @@ function prepare_partitions() {
 
 		if [[ $ROOTFS_TYPE == btrfs ]]; then
 			btrfs_root_subvolume="${BTRFS_ROOT_SUBVOLUME:-@}"
-			mountopts[$ROOTFS_TYPE]='commit=120'
 			run_host_command_logged btrfs subvolume create $MOUNT/$btrfs_root_subvolume
 			# getting the subvolume id of the newly created volume @ to install it
 			# as the default volume for mounting without explicit reference
@@ -363,27 +362,27 @@ function prepare_partitions() {
 
 			run_host_command_logged umount $rootdevice
 			display_alert "Remounting rootfs" "$rootdevice (UUID=${ROOT_PART_UUID})"
-			run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]} ${fscreateopt} $rootdevice $MOUNT/
+			run_host_command_logged mount -odefaults${mountopts[$ROOTFS_TYPE]} ${fscreateopt} $rootdevice $MOUNT/
 		fi
 		rootfs="UUID=$(blkid -s UUID -o value $rootdevice)"
-		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults,${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab
+		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab
 		if [[ $ROOTFS_TYPE == btrfs ]]; then
 			call_extension_method "btrfs_root_add_subvolumes_fstab" <<- 'BTRFS_ROOT_ADD_SUBVOLUMES_FSTAB'
 				run_host_command_logged mkdir -p $MOUNT/home
-				run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@home $rootdevice $MOUNT/home
-				echo "$rootfs /home btrfs defaults,${mountopts[$ROOTFS_TYPE]},subvol=@home 0 2" >> $SDCARD/etc/fstab
+				run_host_command_logged mount -odefaults${mountopts[$ROOTFS_TYPE]},subvol=@home $rootdevice $MOUNT/home
+				echo "$rootfs /home btrfs defaults${mountopts[$ROOTFS_TYPE]},subvol=@home 0 2" >> $SDCARD/etc/fstab
 				run_host_command_logged mkdir -p $MOUNT/var
-				run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@var $rootdevice $MOUNT/var
-				echo "$rootfs /var btrfs defaults,${mountopts[$ROOTFS_TYPE]},subvol=@var 0 2" >> $SDCARD/etc/fstab
+				run_host_command_logged mount -odefaults${mountopts[$ROOTFS_TYPE]},subvol=@var $rootdevice $MOUNT/var
+				echo "$rootfs /var btrfs defaults${mountopts[$ROOTFS_TYPE]},subvol=@var 0 2" >> $SDCARD/etc/fstab
 				run_host_command_logged mkdir -p $MOUNT/var/log
-				run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@var_log $rootdevice $MOUNT/var/log
-				echo "$rootfs /var/log btrfs defaults,${mountopts[$ROOTFS_TYPE]},subvol=@var_log 0 2" >> $SDCARD/etc/fstab
+				run_host_command_logged mount -odefaults${mountopts[$ROOTFS_TYPE]},subvol=@var_log $rootdevice $MOUNT/var/log
+				echo "$rootfs /var/log btrfs defaults${mountopts[$ROOTFS_TYPE]},subvol=@var_log 0 2" >> $SDCARD/etc/fstab
 				run_host_command_logged mkdir -p $MOUNT/var/cache
-				run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@var_cache $rootdevice $MOUNT/var/cache
-				echo "$rootfs /var/cache btrfs defaults,${mountopts[$ROOTFS_TYPE]},subvol=@var_cache 0 2" >> $SDCARD/etc/fstab
+				run_host_command_logged mount -odefaults${mountopts[$ROOTFS_TYPE]},subvol=@var_cache $rootdevice $MOUNT/var/cache
+				echo "$rootfs /var/cache btrfs defaults${mountopts[$ROOTFS_TYPE]},subvol=@var_cache 0 2" >> $SDCARD/etc/fstab
 				run_host_command_logged mkdir -p  $MOUNT/srv
-				run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@srv $rootdevice $MOUNT/srv
-				echo "$rootfs /srv btrfs defaults,${mountopts[$ROOTFS_TYPE]},subvol=@srv 0 2" >> $SDCARD/etc/fstab
+				run_host_command_logged mount -odefaults${mountopts[$ROOTFS_TYPE]},subvol=@srv $rootdevice $MOUNT/srv
+				echo "$rootfs /srv btrfs defaults${mountopts[$ROOTFS_TYPE]},subvol=@srv 0 2" >> $SDCARD/etc/fstab
 			BTRFS_ROOT_ADD_SUBVOLUMES_FSTAB
 		fi
 


### PR DESCRIPTION
## Summary

Fixes #9201: double-comma bug in generated `/etc/fstab` entries (e.g. `defaults,,commit=120,errors=remount-ro` for ext4).

The root cause: `mountopts[]` values start with a leading comma by convention (see line 26 comment), but all call sites were adding an explicit comma before the expansion, doubling it.

This is the complete fix suggested by @EvilOlaf in #9227 (https://github.com/armbian/build/pull/9227#issuecomment-3734903408) — removing the hardcoded `,` after `defaults` at all call sites, rather than patching only line 369.

## Changes

- Lines 366, 369: root filesystem `mount` and `fstab` entry
- Lines 373–386: btrfs subvolume `mount` and `fstab` entries (not covered by #9227)
- Line 345: btrfs `mountopts` override was missing the leading comma, accidentally compensated by the extra comma at call sites — fixed to follow the convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Normalized how filesystem mount options are concatenated for Btrfs root and subvolume mounts. Formatting-only change; effective options (e.g., commit settings) and user behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->