### PR TITLE
patching: fix #9028 timestamp when multiple patches touch same file

### DIFF
--- a/lib/tools/common/patching_utils.py
+++ b/lib/tools/common/patching_utils.py
@@ -760,10 +760,13 @@ class PatchInPatchFile:
 			files_to_touch = [f for f in files_to_touch if f not in self.deleted_file_names]
 
 		for file_name in files_to_touch:
-			# log.debug(f"Setting mtime of '{file_name}' to '{final_mtime}'.")
 			file_path = os.path.join(working_dir, file_name)
 			try:
-				os.utime(file_path, (final_mtime, final_mtime))
+				# Only bump mtime; never lower it. Multiple patches may touch the same file,
+				# and a later patch with an older timestamp must not override the timestamp
+				# set by an earlier patch with a newer one (#9028).
+				if final_mtime > os.path.getmtime(file_path):
+					os.utime(file_path, (final_mtime, final_mtime))
 			except FileNotFoundError:
 				log.warning(f"File '{file_path}' not found in patch {self}, can't set mtime.")
 


### PR DESCRIPTION
## Summary

Fixes #9028: when patches A and B both modify the same file, and B sorts
after A but has an older mtime, `apply_patch_date_to_files()` would
overwrite A's timestamp with a lower value. The kernel Makefile then
sees the file as older than expected and skips recompilation.

Fix: only call `os.utime()` when `final_mtime` is strictly greater than
the file's current mtime, so a file always retains the timestamp of the
newest patch that touched it.

## Changes

- `lib/tools/common/patching_utils.py`: add `os.path.getmtime()` guard
  before `os.utime()` in `apply_patch_date_to_files()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where patch dates were being incorrectly downgraded when applying multiple patches. Modification timestamps now only update when the new timestamp exceeds the current one, ensuring correct date management across consecutive patch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->