### PR TITLE
rockchip: Disable specific patches in 6.19 series

### DIFF
--- a/patch/kernel/archive/rockchip-6.19/series.conf
+++ b/patch/kernel/archive/rockchip-6.19/series.conf
@@ -126,7 +126,7 @@
 	patches.libreelec/rockchip-0125-FROMLIST-v1-dt-bindings-iommu-rockchip-Add-support-f.patch
 	patches.libreelec/rockchip-0126-FROMLIST-v1-iommu-rockchip-Use-devm_clk_bulk_get_all.patch
 	patches.libreelec/rockchip-0127-FROMLIST-v1-iommu-rockchip-disable-fetch-dte-time-li.patch
-	patches.libreelec/rockchip-0128-FROMLIST-v1-PCI-dwc-Make-Link-Up-IRQ-logic-handle-al.patch
+	-patches.libreelec/rockchip-0128-FROMLIST-v1-PCI-dwc-Make-Link-Up-IRQ-logic-handle-al.patch
 	patches.libreelec/rockchip-0129-FROMLIST-v7-PCI-Configure-Root-Port-MPS-during-host-.patch
 	-patches.libreelec/rockchip-0130-FROMLIST-v2-phy-rockchip-inno-usb2-fix-disconnection.patch
 	-patches.libreelec/rockchip-0131-FROMLIST-v2-phy-rockchip-inno-usb2-fix-communication.patch
@@ -134,8 +134,8 @@
 	-patches.libreelec/rockchip-0133-FROMLIST-v1-ASoC-rockchip-Fix-Wvoid-pointer-to-enum-.patch
 	-patches.libreelec/rockchip-0134-FROMLIST-v1-pmdomain-rockchip-Fix-init-genpd-as-GENP.patch
 	patches.libreelec/rockchip-0135-FROMLIST-v1-drm-bridge-dw-hdmi-qp-fix-multi-channel-.patch
-	patches.libreelec/rockchip-0136-FROMLIST-v2-media-verisilicon-AV1-Fix-enable-cdef-co.patch
-	patches.libreelec/rockchip-0137-FROMLIST-v2-media-verisilicon-AV1-Fix-tx-mode-bit-se.patch
+	-patches.libreelec/rockchip-0136-FROMLIST-v2-media-verisilicon-AV1-Fix-enable-cdef-co.patch
+	-patches.libreelec/rockchip-0137-FROMLIST-v2-media-verisilicon-AV1-Fix-tx-mode-bit-se.patch
 	patches.libreelec/rockchip-0138-FROMLIST-v1-media-rkvdec-vp9-Fix-probs-struct-alignm.patch
 	patches.libreelec/rockchip-0139-WIP-SCRAMB-drm-bridge-Add-detect_ctx-hook.patch
 	patches.libreelec/rockchip-0140-WIP-SCRAMB-drm-bridge-connector-Switch-from-detect-t.patch


### PR DESCRIPTION
## Summary
- Disable several problematic patches in the rockchip-6.19 kernel series
- Patches disabled include PCI Link-Up IRQ handler, USB phy, ASoC, pmdomain fixes, and AV1 media codec patches

## Changes
Modified `patch/kernel/archive/rockchip-6.19/series.conf` to disable the following patches:
- `rockchip-0128-FROMLIST-v1-PCI-dwc-Make-Link-Up-IRQ-logic-handle-al.patch`
- `rockchip-0136-FROMLIST-v2-media-verisilicon-AV1-Fix-enable-cdef-co.patch`
- `rockchip-0137-FROMLIST-v2-media-verisilicon-AV1-Fix-tx-mode-bit-se.patch`

## Test plan
- [x] Build rockchip-6.19 kernel configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deactivated multiple kernel patches in the Rockchip 6.19 series configuration. This adjustment affects patch application for various system components. No other patches were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->