### PR TITLE
add Vulkan support and expand 3D package descriptions

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -46,9 +46,17 @@ function post_install_kernel_debs__3d() {
 	declare -a pkgs=("libgl1-mesa-dri")
 
 	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then
-		pkgs+=("libglx-mesa0") # x11 stuff all the way
-		pkgs+=("mesa-utils" "mesa-utils-extra")
-		pkgs+=("glmark2" "glmark2-wayland" "glmark2-es2-wayland" "glmark2-es2" "glmark2-x11" "glmark2-es2-x11")
+		pkgs+=("libglx-mesa0") # Mesa OpenGL extension library for X11
+		pkgs+=("mesa-utils") # Mesa utilities for OpenGL information and testing
+		pkgs+=("mesa-utils-extra") # Additional Mesa demonstration programs
+		pkgs+=("glmark2") # OpenGL 2.0/3.0 benchmark suite
+		pkgs+=("glmark2-wayland") # Glmark2 Wayland backend for benchmarking
+		pkgs+=("glmark2-es2-wayland") # Glmark2 OpenGL ES 2.0 Wayland backend
+		pkgs+=("glmark2-es2") # Glmark2 OpenGL ES 2.0 benchmark support
+		pkgs+=("glmark2-x11") # Glmark2 X11 backend for benchmarking
+		pkgs+=("glmark2-es2-x11") # Glmark2 OpenGL ES 2.0 X11 backend
+		pkgs+=("vulkan-tools") # Vulkan utilities for testing and debugging (vulkaninfo, etc.)
+		pkgs+=("mesa-vulkan-drivers") # Vulkan drivers for Mesa GPUs (Panfrost, Lima, Radeon, Intel, etc.)
 	fi
 
 	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then # if desktop, add amazingfated's multimedia PPAs and rockchip-multimedia-config utility, chromium, gstreamer, etc


### PR DESCRIPTION
## Summary
- Add Vulkan support packages to mesa-vpu extension
- Expand package definitions with individual inline comments for better documentation

Ref: https://github.com/armbian/build/pull/9423

## Changes
- **vulkan-tools**: Vulkan utilities (vulkaninfo) for testing and debugging
- **mesa-vulkan-drivers**: Vulkan drivers for Mesa GPUs (Panfrost, Lima, Radeon, Intel)
- Expanded all package definitions with descriptive inline comments:
  - libglx-mesa0: Mesa OpenGL extension library for X11
  - mesa-utils: Mesa utilities for OpenGL information and testing
  - mesa-utils-extra: Additional Mesa demonstration programs
  - glmark2 variants: OpenGL 2.0/3.0 and ES 2.0 benchmark suite with Wayland/X11 backends

## Benefits
- Enables Vulkan development and testing on supported hardware
- Improves code documentation and makes package purposes clear for maintainers

## Test plan
- [ ] Build desktop image with mesa-vpu extension
- [ ] Verify Vulkan tools are installed (`vulkaninfo` command available)
- [ ] Test Vulkan driver loading on supported hardware (Panfrost/Radeon)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced graphics package set for desktop installations, now including additional 3D rendering tools, graphics benchmarking utilities, and Vulkan support packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->