### PR TITLE
OrangePi 3 LTS: Update $board.conf file

### DIFF
--- a/config/boards/orangepi3-lts.conf
+++ b/config/boards/orangepi3-lts.conf
@@ -1,5 +1,5 @@
 # Allwinner H6 quad core 2GB RAM SoC GBE USB3
-BOARD_NAME="Orange Pi 3 LTS"
+BOARD_NAME="OrangePi 3 LTS"
 BOARD_VENDOR="xunlong"
 BOARDFAMILY="sun50iw6"
 BOARD_MAINTAINER="pyavitz"
@@ -7,11 +7,9 @@ BOOT_FDT_FILE="allwinner/sun50i-h6-orangepi-3-lts.dtb"
 BOOTCONFIG="orangepi_3_lts_defconfig"
 BOOT_LOGO="desktop"
 CRUSTCONFIG="pine_h64_defconfig"
-KERNEL_TARGET="current,edge"
+KERNEL_TARGET="legacy,current,edge"
 KERNEL_TEST_TARGET="current"
 PACKAGE_LIST_BOARD="rfkill bluetooth bluez bluez-tools"
-SRC_EXTLINUX="yes"
-SRC_CMDLINE="console=tty1 console=ttyS0,115200n8 loglevel=1"
 
 function post_family_config__use_orangepi3lts_uboot() {
 	case $BRANCH in
@@ -20,6 +18,10 @@ function post_family_config__use_orangepi3lts_uboot() {
 			declare -g BOOTPATCHDIR="v2026.01"
 			declare -g BOOTBRANCH_BOARD="tag:${BOOTPATCHDIR}"
 			declare -g BOOTBRANCH="${BOOTBRANCH_BOARD}"
+
+			write_uboot_platform() {
+				dd if=$1/u-boot-sunxi-with-spl.bin of=$2 conv=fsync bs=1024 seek=8
+			}
 			;;
 	esac
 }


### PR DESCRIPTION
Add legacy to KERNEL_TARGET var
Switch back to boot.scr
Add write_uboot_platform function
Fixup BOARD_NAME var

Merge after: https://github.com/armbian/build/pull/9381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Extended Orange Pi 3 LTS kernel version support to include legacy releases alongside current and edge variants.
  * Enhanced board-level configuration and firmware handling for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->