### PR TITLE
OrangePi-RV2: Fix wireless access point mode by using the correct FW

### DIFF
--- a/config/boards/orangepirv2.wip
+++ b/config/boards/orangepirv2.wip
@@ -36,6 +36,8 @@ function post_family_tweaks_bsp__orangepirv2_wifi() {
 	display_alert "$BOARD" "Force load bmcdhd wireless" "info"
 	run_host_command_logged mkdir -pv "${destination}"/etc/modules-load.d
 	run_host_command_logged echo "bcmdhd" > "${destination}"/etc/modules-load.d/${BOARD}.conf
+	run_host_command_logged mkdir -pv "${destination}"/etc/modprobe.d
+	run_host_command_logged echo "options bcmdhd firmware_path=brcm/ nvram_path=brcm/" > "${destination}"/etc/modprobe.d/${BOARD}.conf
 }
 
 function post_family_tweaks_bsp__orangepirv2_bluetooth() {


### PR DESCRIPTION
# Description

Commit simply adds a file /etc/modprobe.d/orangepirv2.conf via board config which in turn adds brcm/ to the firmware and nvram pathes for the bcmdhd wifi module. This works, b/c we have two different firmwares for AP6256 under /lib/firmware

# Tests

Tested with Spacemit legacy and current kernels on OrangePi RV2 using a very simple hostapd.conf file

> interface=wlan0
> driver=nl80211
> ssid=test
> channel=1

Because hostapd does not terminate after init (which is does with wrong FW), the access point "test" is visible.

# Commit comment

Notes: the bcmdhd.ko module loads firmware not on init, but delayed on ifup wlan0. This is also true for AP mode, e.g. when starting hostapd. Default FW file names are determined during runtime (with HW query).

We have different fw_bcm43456c5_ag.bin files under /lib/firmware, where /lib/fw/ works but no AP mode and /lib/fw/brcm/ also works now *with* AP mode. Additionally, there are different nvram_ap6256.txt files, but at least with OrangePi RV2 AP6256 hardware, both work.

The fw_bcm43456c5_ag.bin and nvram_ap6256.txt files are the same as in /lib/fw/rkwifi/, the rkwifi/ dir seems unused throughout Armbian cfgs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced wifi configuration for Orange Pi RV2 to improve device compatibility and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->