### PR TITLE
extension: ccache-remote: fix Docker host-gateway for hostnames resolving to loopback

### DIFF
--- a/extensions/ccache-remote/ccache-remote.sh
+++ b/extensions/ccache-remote/ccache-remote.sh
@@ -396,8 +396,14 @@ function host_pre_docker_launch__setup_remote_ccache() {
 					[[ -z "${_resolved_ip}" ]] && _resolved_ip=$(getent hosts "${_host}" 2>/dev/null | awk '{print $1; exit}' || true)
 				fi
 				if [[ -n "${_resolved_ip}" ]]; then
-					DOCKER_EXTRA_ARGS+=("--add-host=${_host}:${_resolved_ip}")
-					display_alert "Docker --add-host" "${_host}:${_resolved_ip}" "info"
+					# Hostname resolves to loopback on host — service runs locally, use host-gateway for Docker
+					if [[ "${_resolved_ip}" == "127."* || "${_resolved_ip}" == "::1" ]]; then
+						DOCKER_EXTRA_ARGS+=("--add-host=${_host}:host-gateway")
+						display_alert "Docker --add-host (loopback→host-gateway)" "${_host}:${_resolved_ip} → host-gateway" "debug"
+					else
+						DOCKER_EXTRA_ARGS+=("--add-host=${_host}:${_resolved_ip}")
+						display_alert "Docker --add-host" "${_host}:${_resolved_ip}" "debug"
+					fi
 				else
 					display_alert "Cannot resolve hostname for Docker" "${_host}" "wrn"
 				fi


### PR DESCRIPTION
## Summary
- When avahi-browse discovers a ccache service on the local machine, it returns 127.0.0.1 as the address. The code used this IP directly in `--add-host`, making the hostname resolve to the container's own loopback inside Docker instead of the host machine, causing all remote cache lookups to fail (`err=N` in ccache stats).
- Fix: after resolving the hostname, check if the resulting IP is a loopback address and use `host-gateway` instead, consistent with the existing handling for literal `localhost`/`127.0.0.1` in the storage URL.

## Test plan
- [x] Build with ccache-remote extension when avahi discovers local ccache service
- [x] Verify Docker container resolves the hostname to host machine, not container loopback
- [x] Verify remote ccache hits work (no `err=N` in ccache stats)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docker host resolution: loopback addresses (127.* / ::1) are now handled via host-gateway to avoid connectivity issues.
  * Clearer debug logging for loopback cases to aid diagnostics.
  * Non-loopback and unresolved host behaviors remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->