### PR TITLE
armbian-zram-config: refine check for existing /tmp mount

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-zram-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-zram-config
@@ -140,7 +140,7 @@ activate_ramlog_partition() {
 
 activate_compressed_tmp() {
 	# create /tmp not as tmpfs but zram compressed if no fstab entry exists
-	grep -qE '^[^#]+[[:space:]]+/tmp[[:space:]]' /etc/mtab && return
+	grep -qE '^[^#[:space:]][^[:space:]]*[[:space:]]+/tmp[[:space:]]' /etc/mtab && return
 	tmp_device=$(zramctl -f |sed 's/\/dev\///')
 	[[ ! ${tmp_device} =~ ^zram ]] && printf "\n### No more available zram devices (%s)\n" "${tmp_device}" >> ${Log} && exit 1;
 


### PR DESCRIPTION
# Description

`activate_compressed_tmp` has a guard clause preventing zram tmpfs creation when a "`tmpfs /tmp`" entry exists.
This PR extends this behavior to include *any* `/tmp` mount in /etc/fstab, preventing duplicate /tmp entries.

# How Has This Been Tested?

- [x] Created /etc/fstab entry `/opt/tmp /tmp none bind 0 0` -- guard-code succesfully triggers
- [x] Created /etc/fstab entry `tmpfs /tmp tmpfs defaults,nosuid 0 0` (Default) -- guard-code successfully triggers as before
- [x] Manually ensured guard-code does not trigger when `/tmp` is not present (when `activate_compressed_tmp` should run)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of compressed temporary file configuration by enhancing mount detection logic to properly identify existing temporary file mounts, preventing conflicts during system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->