### PR TITLE
Odroid-M2: Support for weather board zero

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/Makefile
@@ -111,7 +111,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-rkvenc-overlay.dtbo \
 	rockchip-rk3588-nanopi-m6-spi-nor-flash.dtbo \
 	rockchip-rk3588-nanopi-m6-display-dsi1-yx35.dtbo \
-	rockchip-rk3588-nanopc-t6-mmc-frequency.dtbo
+	rockchip-rk3588-nanopc-t6-mmc-frequency.dtbo \
+	rockchip-rk3588-odroidm2-weather-board-zero.dtbo
 
 scr-$(CONFIG_ARCH_ROCKCHIP) += \
        rockchip-fixup.scr

--- a/patch/kernel/archive/rockchip64-6.18/overlay/rockchip-rk3588-odroidm2-weather-board-zero.dtso
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/rockchip-rk3588-odroidm2-weather-board-zero.dtso
@@ -1,0 +1,24 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "hardkernel,odroid-m2", "rockchip,rk3588s";
+
+	fragment@0 {
+		target = <&i2c5>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&i2c5m2_xfer>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			weather_sensor: shtc1@70 {
+				status = "okay";
+				label = "weather_board_zero";
+				compatible = "sensirion,shtc1";
+				reg = <0x70>;
+			};
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip64-7.0/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-7.0/overlay/Makefile
@@ -111,7 +111,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-rkvenc-overlay.dtbo \
 	rockchip-rk3588-nanopi-m6-spi-nor-flash.dtbo \
 	rockchip-rk3588-nanopi-m6-display-dsi1-yx35.dtbo \
-	rockchip-rk3588-nanopc-t6-mmc-frequency.dtbo
+	rockchip-rk3588-nanopc-t6-mmc-frequency.dtbo \
+	rockchip-rk3588-odroidm2-weather-board-zero.dtbo
 
 scr-$(CONFIG_ARCH_ROCKCHIP) += \
        rockchip-fixup.scr
@@ -122,4 +123,3 @@ dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \
 dtb-y += $(dtbo-y) $(scr-y) $(dtbotxt-y)
 
 clean-files    := *.dtbo *.scr
-

--- a/patch/kernel/archive/rockchip64-7.0/overlay/rockchip-rk3588-odroidm2-weather-board-zero.dtso
+++ b/patch/kernel/archive/rockchip64-7.0/overlay/rockchip-rk3588-odroidm2-weather-board-zero.dtso
@@ -1,0 +1,24 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "hardkernel,odroid-m2", "rockchip,rk3588s";
+
+	fragment@0 {
+		target = <&i2c5>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&i2c5m2_xfer>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			weather_sensor: shtc1@70 {
+				status = "okay";
+				label = "weather_board_zero";
+				compatible = "sensirion,shtc1";
+				reg = <0x70>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
# Description

Activates the [WEATHER-BOARD Zero](https://wiki.odroid.com/accessory/sensor/weather_board_zero) on the 40-pin header.

# Documentation summary for feature / change

This makes weather board zero usable on Odroid-M2 board with mainline kernel. To activate it

- use `armbian-config` tool to enable overlay `odroidm2-weather-board-zero`
- or add it directly in `/boot/armbianEnv.txt` (e.g. `overlays=odroidm2-weather-board-zero`)

After reboot, verify with `sudo i2cdetect -y 5` that the sensor has been detected. Then you can read values with `sensors` command (`lm-sensors` package), or by using directly HWMON subsystem (`cat /sys/class/hwmon/hwmonX/{temp1_input,humidity1_input}`).

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device tree overlay support for Odroid M2 weather sensor board (RK3588/RK3588S) across kernel versions 6.18 and 7.0, enabling integration with the SHTC1 weather sensor via i2c5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->