### PR TITLE
meson64: a311d: Fix Xorg display when etnaviv enabled

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -241,7 +241,8 @@ family_tweaks_bsp() {
 				EndSection
 			EOF
 			;;
-		"jethubj200" | "odroidn2" | "odroidc4" | "khadas-vim2" | "odroidhc4" | "khadas-vim3" | "khadas-vim3l" | "radxa-zero" | "radxa-zero2" | "bananapi-m2s")
+		"jethubj200" | "odroidn2" | "odroidc4" | "khadas-vim2" | "odroidhc4" | "khadas-vim3" | "khadas-vim3l" | \
+		"radxa-zero" | "radxa-zero2" | "bananapi-m2s" | "cainiao-cniot-core")
 			cat <<- EOF > "$destination"/etc/X11/xorg.conf
 				Section "Device"
 				    Identifier  "DRM Graphics Acclerated"
@@ -254,6 +255,13 @@ family_tweaks_bsp() {
 				    Option      "TripleBuffer"   "True"
 				    ## End glamor configuration
 
+				EndSection
+
+				Section "OutputClass"
+				    Identifier "Amlogic"
+				    MatchDriver "meson"
+				    Driver "modesetting"
+				    Option "PrimaryGPU" "true"
 				EndSection
 
 				Section "Screen"


### PR DESCRIPTION
# Description

This PR fix Xorg display when etnaviv driver enabled

# How Has This Been Tested?

Build Ubuntu Noble XFCE4 system image, then tested on CAINIAO CNIoT-CORE (A311D device)

I don't have the equipment to test other devices such as the jethubj200 and odroidn2, but I think it won't break their original Xorg functionality since they all use the meson-drm driver



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended device support to include the cainiao-cniot-core board.

* **Chores**
  * Refined display configuration structure and improved formatting consistency across device settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->