### PR TITLE
maint: rockchip64-current: rewrite kernel patches against 6.18.18

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/board-nanopi-zero2-enable-pcie.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-nanopi-zero2-enable-pcie.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shlomi Marco <s.marco@rubycomm.com>
-Date: Thu, 27 Feb 2026 00:00:00 +0000
+Date: Fri, 27 Feb 2026 00:00:00 +0000
 Subject: arm64: dts: rockchip: Enable PCIe on NanoPi Zero2
 
 Enable the PCIe Gen2x1 controller and combo PHY on the FriendlyElec
@@ -11,17 +11,17 @@ vendor kernel device tree (rk3528-nanopi-rev01.dts).
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts | 11 +++++++++++
+ arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts | 11 ++++++++++
  1 file changed, 11 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts b/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts
-@@ -176,6 +176,17 @@
+@@ -208,6 +208,17 @@ &cpu3 {
  	cpu-supply = <&vdd_arm>;
  };
-
+ 
 +&combphy {
 +	status = "okay";
 +};
@@ -36,6 +36,6 @@ index 111111111111..222222222222 100644
  &gmac1 {
  	clock_in_out = "output";
  	phy-handle = <&rgmii_phy>;
---
+-- 
 Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/board-odroidm2-enable-hdmi-audio.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-odroidm2-enable-hdmi-audio.patch
@@ -1,5 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Milivoje Legenovic <m.legenovic@gmail.com>
+Date: Sat, 28 Feb 2026 22:28:39 +0100
+Subject: [ARCHEOLOGY] Odroid-M2: Enable HDMI audio
+
+> X-Git-Archeology: > recovered message: > Signed-off-by: Milivoje Legenovic <m.legenovic@gmail.com>
+> X-Git-Archeology: - Revision d68d84ae6816085144556779cc92384e731d5f1b: https://github.com/armbian/build/commit/d68d84ae6816085144556779cc92384e731d5f1b
+> X-Git-Archeology:   Date: Sat, 28 Feb 2026 22:28:39 +0100
+> X-Git-Archeology:   From: Milivoje Legenovic <m.legenovic@gmail.com>
+> X-Git-Archeology:   Subject: Odroid-M2: Enable HDMI audio
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
-index a72063c55140..c27a1e3db6fa 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
 @@ -264,6 +264,10 @@ hdmi0_out_con: endpoint {
@@ -24,3 +39,6 @@ index a72063c55140..c27a1e3db6fa 100644
  &mdio1 {
  	rgmii_phy1: ethernet-phy@1 {
  		compatible = "ethernet-phy-id001c.c916";
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.18/board-odroidm2-fix-for-ethernet.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-odroidm2-fix-for-ethernet.patch
@@ -37,7 +37,7 @@ index 111111111111..222222222222 100644
  };
  
  &gpu {
-@@ -400,6 +402,8 @@ &mdio1 {
+@@ -408,6 +410,8 @@ &mdio1 {
  	rgmii_phy1: ethernet-phy@1 {
  		compatible = "ethernet-phy-id001c.c916";
  		reg = <1>;
@@ -46,7 +46,7 @@ index 111111111111..222222222222 100644
  		reset-assert-us = <20000>;
  		reset-deassert-us = <100000>;
  		reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
-@@ -479,6 +483,12 @@ pcf8563_int: pcf8563-int {
+@@ -487,6 +491,12 @@ pcf8563_int: pcf8563-int {
  		};
  	};
  

--- a/patch/kernel/archive/rockchip64-6.18/board-pbp-add-dp-alt-mode.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-pbp-add-dp-alt-mode.patch
@@ -40,7 +40,7 @@ index 111111111111..222222222222 100644
  &edp {
  	force-hpd;
  	pinctrl-names = "default";
-@@ -685,6 +699,7 @@ fusb0: fusb30x@22 {
+@@ -681,6 +695,7 @@ fusb0: fusb30x@22 {
  		pinctrl-names = "default";
  		pinctrl-0 = <&fusb0_int_pin>;
  		vbus-supply = <&vbus_typec>;
@@ -48,7 +48,7 @@ index 111111111111..222222222222 100644
  
  		connector {
  			compatible = "usb-c-connector";
-@@ -693,10 +708,19 @@ connector {
+@@ -689,10 +704,19 @@ connector {
  			op-sink-microwatt = <1000000>;
  			power-role = "dual";
  			sink-pdos =
@@ -70,7 +70,7 @@ index 111111111111..222222222222 100644
  
  			ports {
  				#address-cells = <1>;
-@@ -982,6 +1006,7 @@ spiflash: flash@0 {
+@@ -978,6 +1002,7 @@ spiflash: flash@0 {
  };
  
  &tcphy0 {
@@ -78,7 +78,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-@@ -1015,6 +1040,8 @@ &tsadc {
+@@ -1011,6 +1036,8 @@ &tsadc {
  
  &u2phy0 {
  	status = "okay";
@@ -87,7 +87,7 @@ index 111111111111..222222222222 100644
  
  	u2phy0_otg: otg-port {
  		status = "okay";
-@@ -1091,7 +1118,9 @@ &usbdrd3_0 {
+@@ -1087,7 +1114,9 @@ &usbdrd3_0 {
  };
  
  &usbdrd_dwc3_0 {

--- a/patch/kernel/archive/rockchip64-6.18/board-sakurapi-rk3308b-fix-vop-panel.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-sakurapi-rk3308b-fix-vop-panel.patch
@@ -9,12 +9,10 @@ Signed-off-by: TheSnowfield <thesnowfield@sakurapi.org>
  1 file changed, 44 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts b/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts
-index 755a1164c..6e290d0e3 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts
-@@ -113,10 +113,36 @@ sdio_pwrseq: sdio-pwrseq {
- 		 * - SDIO_RESET_L_WL_REG_ON
- 		 * - PDN (power down when low)
+@@ -115,6 +115,32 @@ sdio_pwrseq: sdio-pwrseq {
  		 */
  		reset-gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_LOW>;
  	};
@@ -47,11 +45,7 @@ index 755a1164c..6e290d0e3 100644
  };
  
  &cpu0 {
- 	cpu-supply = <&vdd_core>;
- };
-@@ -203,10 +229,28 @@ &pwm3 {
- &saradc {
- 	vref-supply = <&vcc_1v8>;
+@@ -183,6 +209,24 @@ &saradc {
  	status = "okay";
  };
  
@@ -76,8 +70,6 @@ index 755a1164c..6e290d0e3 100644
  &sdio {
  	#address-cells = <1>;
  	#size-cells = <0>;
- 	cap-sd-highspeed;
- 	cap-sdio-irq;
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/board-sakurapi-rk3308b-fix-wlan-broken.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-sakurapi-rk3308b-fix-wlan-broken.patch
@@ -9,12 +9,10 @@ Signed-off-by: TheSnowfield <thesnowfield@sakurapi.org>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts b/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts
-index b203b7923..b038af7ec 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts
-@@ -253,14 +253,15 @@ &sdio {
- 	keep-power-in-suspend;
- 	mmc-pwrseq = <&sdio_pwrseq>;
+@@ -237,10 +237,11 @@ &sdio {
  	non-removable;
  	no-mmc;
  	no-sd;
@@ -27,8 +25,6 @@ index b203b7923..b038af7ec 100644
  		reg = <1>;
  		interrupt-parent = <&gpio0>;
  		interrupts = <RK_PA3 GPIO_ACTIVE_HIGH>;
- 		interrupt-names = "host-wake";
- 		pinctrl-names = "default";
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/board-sakurapi-rk3308b-spidev.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-sakurapi-rk3308b-spidev.patch
@@ -9,12 +9,10 @@ Signed-off-by: TheSnowfield <thesnowfield@sakurapi.org>
  1 file changed, 22 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts b/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts
-index 80a59a3c7..bd5f3eee9 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3308-sakurapi-rk3308b.dts
-@@ -156,10 +156,32 @@ &emmc {
- 
- &i2c1 {
+@@ -158,6 +158,28 @@ &i2c1 {
  	status = "okay";
  };
  
@@ -43,8 +41,6 @@ index 80a59a3c7..bd5f3eee9 100644
  &pinctrl {
  	pinctrl-names = "default";
  	pinctrl-0 = <&rtc_32k>;
- 
- 	bluetooth {
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/board-station-m2.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-station-m2.patch
@@ -4,7 +4,7 @@ Date: Tue, 24 Feb 2026 01:59:21 +0800
 Subject: fix rk3566-roc-pc
 
 ---
- arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts | 114 +++++++++++++-----
+ arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts | 114 +++++++---
  1 file changed, 84 insertions(+), 30 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3566-roc-pc.dts

--- a/patch/kernel/archive/rockchip64-6.18/drv-spi-spidev-remove-warnings.patch
+++ b/patch/kernel/archive/rockchip64-6.18/drv-spi-spidev-remove-warnings.patch
@@ -12,7 +12,7 @@ diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
 index 111111111111..222222222222 100644
 --- a/drivers/spi/spidev.c
 +++ b/drivers/spi/spidev.c
-@@ -703,6 +703,7 @@ static const struct class spidev_class = {
+@@ -685,6 +685,7 @@ static const struct class spidev_class = {
   * spidev_dt_ids array below. Both arrays are kept in the same ordering.
   */
  static const struct spi_device_id spidev_spi_ids[] = {
@@ -20,7 +20,7 @@ index 111111111111..222222222222 100644
  	{ .name = /* abb */ "spi-sensor" },
  	{ .name = /* cisco */ "spi-petra" },
  	{ .name = /* dh */ "dhcom-board" },
-@@ -736,6 +737,7 @@ static int spidev_of_check(struct device *dev)
+@@ -718,6 +719,7 @@ static int spidev_of_check(struct device *dev)
  }
  
  static const struct of_device_id spidev_dt_ids[] = {

--- a/patch/kernel/archive/rockchip64-6.18/general-disable-mtu-validation.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-disable-mtu-validation.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/eth
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -5859,27 +5859,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
+@@ -5842,27 +5842,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
  static int stmmac_change_mtu(struct net_device *dev, int new_mtu)
  {
  	struct stmmac_priv *priv = netdev_priv(dev);

--- a/patch/kernel/archive/rockchip64-6.18/general-possibility-of-disabling-rk808-rtc.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-possibility-of-disabling-rk808-rtc.patch
@@ -25,7 +25,7 @@ diff --git a/drivers/mfd/mfd-core.c b/drivers/mfd/mfd-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/mfd/mfd-core.c
 +++ b/drivers/mfd/mfd-core.c
-@@ -209,7 +209,7 @@ static int mfd_add_device(struct device *parent, int id,
+@@ -213,7 +213,7 @@ static int mfd_add_device(struct device *parent, int id,
  
  match:
  		if (!pdev->dev.of_node)

--- a/patch/kernel/archive/rockchip64-6.18/net-phy-realtek-add-rtl8211x-LED-configuration-from-OF.patch
+++ b/patch/kernel/archive/rockchip64-6.18/net-phy-realtek-add-rtl8211x-LED-configuration-from-OF.patch
@@ -1,18 +1,18 @@
-From ccdd6b8919f09b003f0881648ea937743c825fd7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Mon, 20 Oct 2025 21:42:28 +0200
-Subject: [PATCH] net: phy: realtek: add rtl8211x LED configuration from OF
+Subject: net: phy: realtek: add rtl8211x LED configuration from OF
 
 Signed-off-by: retro98boy <retro98boy@qq.com>
 ---
- drivers/net/phy/realtek/realtek_main.c | 11 +++++++++++
+ drivers/net/phy/realtek/realtek_main.c | 11 ++++++++++
  1 file changed, 11 insertions(+)
 
 diff --git a/drivers/net/phy/realtek/realtek_main.c b/drivers/net/phy/realtek/realtek_main.c
-index 6ff038520..c77a0d169 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -248,6 +248,15 @@ static int rtl821x_modify_ext_page(struct phy_device *phydev, u16 ext_page,
+@@ -221,6 +221,15 @@ static int rtl821x_modify_ext_page(struct phy_device *phydev, u16 ext_page,
  	return phy_restore_page(phydev, oldpage, ret);
  }
  
@@ -28,7 +28,7 @@ index 6ff038520..c77a0d169 100644
  static int rtl821x_probe(struct phy_device *phydev)
  {
  	struct device *dev = &phydev->mdio.dev;
-@@ -712,6 +721,8 @@ static int rtl8211f_config_init(struct phy_device *phydev)
+@@ -685,6 +694,8 @@ static int rtl8211f_config_init(struct phy_device *phydev)
  	if (ret)
  		return ret;
  
@@ -38,5 +38,5 @@ index 6ff038520..c77a0d169 100644
  	if (ret) {
  		dev_err(dev, "clkout configuration failed: %pe\n",
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/net-usb-r8152-add-LED-configuration-from-OF.patch
+++ b/patch/kernel/archive/rockchip64-6.18/net-usb-r8152-add-LED-configuration-from-OF.patch
@@ -24,7 +24,7 @@ index 111111111111..222222222222 100644
  #include <linux/crc32.h>
  #include <linux/if_vlan.h>
  #include <linux/uaccess.h>
-@@ -7017,6 +7018,22 @@ static void rtl_tally_reset(struct r8152 *tp)
+@@ -7019,6 +7020,22 @@ static void rtl_tally_reset(struct r8152 *tp)
  	ocp_write_word(tp, MCU_TYPE_PLA, PLA_RSTTALLY, ocp_data);
  }
  
@@ -47,7 +47,7 @@ index 111111111111..222222222222 100644
  static void r8152b_init(struct r8152 *tp)
  {
  	u32 ocp_data;
-@@ -7058,6 +7075,8 @@ static void r8152b_init(struct r8152 *tp)
+@@ -7060,6 +7077,8 @@ static void r8152b_init(struct r8152 *tp)
  	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_USB_CTRL);
  	ocp_data &= ~(RX_AGG_DISABLE | RX_ZERO_EN);
  	ocp_write_word(tp, MCU_TYPE_USB, USB_USB_CTRL, ocp_data);
@@ -56,7 +56,7 @@ index 111111111111..222222222222 100644
  }
  
  static void r8153_init(struct r8152 *tp)
-@@ -7198,6 +7217,8 @@ static void r8153_init(struct r8152 *tp)
+@@ -7200,6 +7219,8 @@ static void r8153_init(struct r8152 *tp)
  		tp->coalesce = COALESCE_SLOW;
  		break;
  	}
@@ -65,7 +65,7 @@ index 111111111111..222222222222 100644
  }
  
  static void r8153b_init(struct r8152 *tp)
-@@ -7280,6 +7301,8 @@ static void r8153b_init(struct r8152 *tp)
+@@ -7282,6 +7303,8 @@ static void r8153b_init(struct r8152 *tp)
  	rtl_tally_reset(tp);
  
  	tp->coalesce = 15000;	/* 15 us */

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-phy-rockchip-naneng-Add-fallback-for-old-DTs.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-phy-rockchip-naneng-Add-fallback-for-old-DTs.patch
@@ -95,7 +95,7 @@ index 111111111111..222222222222 100644
  
  	dwc->lpm_nyet_threshold = lpm_nyet_threshold;
  	dwc->tx_de_emphasis = tx_de_emphasis;
-@@ -2444,6 +2479,7 @@ static int dwc3_suspend_common(struct dwc3 *dwc, pm_message_t msg)
+@@ -2461,6 +2496,7 @@ static int dwc3_suspend_common(struct dwc3 *dwc, pm_message_t msg)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -103,7 +103,7 @@ index 111111111111..222222222222 100644
  		if (pm_runtime_suspended(dwc->dev))
  			break;
  		ret = dwc3_gadget_suspend(dwc);
-@@ -2508,11 +2544,12 @@ static int dwc3_resume_common(struct dwc3 *dwc, pm_message_t msg)
+@@ -2525,11 +2561,12 @@ static int dwc3_resume_common(struct dwc3 *dwc, pm_message_t msg)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -117,7 +117,7 @@ index 111111111111..222222222222 100644
  		dwc3_gadget_resume(dwc);
  		break;
  	case DWC3_GCTL_PRTCAP_HOST:
-@@ -2576,6 +2613,7 @@ static int dwc3_runtime_checks(struct dwc3 *dwc)
+@@ -2593,6 +2630,7 @@ static int dwc3_runtime_checks(struct dwc3 *dwc)
  {
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -125,7 +125,7 @@ index 111111111111..222222222222 100644
  		if (dwc->connected)
  			return -EBUSY;
  		break;
-@@ -2614,6 +2652,7 @@ int dwc3_runtime_resume(struct dwc3 *dwc)
+@@ -2631,6 +2669,7 @@ int dwc3_runtime_resume(struct dwc3 *dwc)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -133,7 +133,7 @@ index 111111111111..222222222222 100644
  		if (dwc->pending_events) {
  			pm_runtime_put(dev);
  			dwc->pending_events = false;
-@@ -2638,6 +2677,7 @@ int dwc3_runtime_idle(struct dwc3 *dwc)
+@@ -2655,6 +2694,7 @@ int dwc3_runtime_idle(struct dwc3 *dwc)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -158,7 +158,7 @@ index 111111111111..222222222222 100644
  
  #define DWC3_GCTL_CORESOFTRESET		BIT(11)
  #define DWC3_GCTL_SOFITPSYNC		BIT(10)
-@@ -1164,6 +1170,10 @@ struct dwc3_glue_ops {
+@@ -1166,6 +1172,10 @@ struct dwc3_glue_ops {
   * @sys_wakeup: set if the device may do system wakeup.
   * @wakeup_configured: set if the device is configured for remote wakeup.
   * @suspended: set to track suspend event due to U3/L2.
@@ -169,7 +169,7 @@ index 111111111111..222222222222 100644
   * @susphy_state: state of DWC3_GUSB2PHYCFG_SUSPHY + DWC3_GUSB3PIPECTL_SUSPHY
   *		  before PM suspend.
   * @imod_interval: set the interrupt moderation interval in 250ns
-@@ -1407,6 +1417,8 @@ struct dwc3 {
+@@ -1411,6 +1421,8 @@ struct dwc3 {
  	unsigned		suspended:1;
  	unsigned		susphy_state:1;
  

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-dwc3-Track-the-power-state-of-usb3_generic_phy.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-dwc3-Track-the-power-state-of-usb3_generic_phy.patch
@@ -43,7 +43,7 @@ diff --git a/drivers/usb/dwc3/core.h b/drivers/usb/dwc3/core.h
 index 111111111111..222222222222 100644
 --- a/drivers/usb/dwc3/core.h
 +++ b/drivers/usb/dwc3/core.h
-@@ -1238,6 +1238,8 @@ struct dwc3 {
+@@ -1240,6 +1240,8 @@ struct dwc3 {
  	u8			num_usb2_ports;
  	u8			num_usb3_ports;
  

--- a/patch/kernel/archive/rockchip64-6.18/rk356x-add-51.2MHz-PLL-rate-for-HDMI.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk356x-add-51.2MHz-PLL-rate-for-HDMI.patch
@@ -22,12 +22,10 @@ Signed-off-by: Serhii Korobkov <skorobkov78@gmail.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/clk/rockchip/clk-rk3568.c b/drivers/clk/rockchip/clk-rk3568.c
-index 97d279399..de350538a 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/rockchip/clk-rk3568.c
 +++ b/drivers/clk/rockchip/clk-rk3568.c
-@@ -88,10 +88,11 @@ static struct rockchip_pll_rate_table rk3568_pll_rates[] = {
- 	RK3036_PLL_RATE(101000000, 1, 101, 6, 4, 1, 0),
- 	RK3036_PLL_RATE(100000000, 1, 150, 6, 6, 1, 0),
+@@ -90,6 +90,7 @@ static struct rockchip_pll_rate_table rk3568_pll_rates[] = {
  	RK3036_PLL_RATE(96000000, 1, 96, 6, 4, 1, 0),
  	RK3036_PLL_RATE(78750000, 4, 315, 6, 4, 1, 0),
  	RK3036_PLL_RATE(74250000, 2, 99, 4, 4, 1, 0),
@@ -35,8 +33,6 @@ index 97d279399..de350538a 100644
  	RK3036_PLL_RATE(33300000, 4, 111, 5, 4, 1, 0),
  	{ /* sentinel */ },
  };
- 
- #define RK3568_DIV_ATCLK_CORE_MASK	0x1f
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/temporary-workaround-dma-reset.patch
+++ b/patch/kernel/archive/rockchip64-6.18/temporary-workaround-dma-reset.patch
@@ -17,7 +17,7 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/eth
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -3058,8 +3058,8 @@ static int stmmac_init_dma_engine(struct stmmac_priv *priv)
+@@ -3059,8 +3059,8 @@ static int stmmac_init_dma_engine(struct stmmac_priv *priv)
  
  	ret = stmmac_reset(priv, priv->ioaddr);
  	if (ret) {


### PR DESCRIPTION
as per title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled PCIe support for NanoPi Zero2
  * Enabled HDMI audio for ODROID-M2
  * Added USB-C DisplayPort Alt Mode for Pinebook Pro
  * Enabled display panel output for Sakura Pi
  * Added SPI device support and expanded hardware peripherals for Station M2
  * Implemented LED configuration support for Realtek PHY and USB Ethernet drivers

* **Bug Fixes**
  * Fixed Ethernet configuration for ODROID-M2
  * Resolved WiFi compatibility and performance issues for Sakura Pi
  * Improved DMA reset error handling and USB3 PHY power state management

* **Chores**
  * Updated HDMI clock rate configuration and driver logging levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->