### PR TITLE
rpi4b: bump edge to 7.0

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -36,8 +36,8 @@ case "${BRANCH}" in
 
 	edge)
 		declare -g KERNELSOURCE='https://github.com/raspberrypi/linux'
-		declare -g KERNEL_MAJOR_MINOR="6.19" # Major and minor versions of this kernel. For mainline caching.
-		declare -g KERNELBRANCH="branch:rpi-6.19.y"
+		declare -g KERNEL_MAJOR_MINOR="7.0" # Major and minor versions of this kernel. For mainline caching.
+		declare -g KERNELBRANCH="branch:rpi-7.0.y"
 		;;
 esac
 


### PR DESCRIPTION
# Description

bump rpi4b edge to 7.0

# How Has This Been Tested?

- [x] build
- [x] boot rpi5b https://paste.armbian.com/efanahawur

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Edge branch kernel updated from version 6.19 to 7.0
  * Kernel source repository branch updated to align with the new kernel version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->