### PR TITLE
chore: update Dependabot schedule to daily updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,20 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "04:00"
+      timezone: "Europe/Ljubljana"
+    open-pull-requests-limit: 3
     labels:
       - "GitHub Actions"
       - "Dependencies"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "05:00"
+      timezone: "Europe/Ljubljana"
+    open-pull-requests-limit: 3
     labels:
       - "GitHub Actions"
       - "Dependencies"


### PR DESCRIPTION
## Summary

This PR updates the Dependabot configuration to check for dependency updates daily instead of weekly.

## Changes

- **GitHub Actions updates**: Changed from weekly to daily (04:00 Europe/Ljubljana)
- **pip updates**: Changed from weekly to daily (05:00 Europe/Ljubljana) 
- Added `open-pull-requests-limit: 3` to prevent excessive open PRs
- Added specific timezone (Europe/Ljubljana) for consistent update timing

## Benefits

- Faster detection of security vulnerabilities in dependencies
- More timely updates for GitHub Actions and Python packages
- Better control over the number of open PRs with the limit setting
- Consistent update timing with timezone specification

## Test plan

- [x] Dependabot configuration is valid
- [x] No breaking changes to existing workflow
- [x] Changes will take effect on next scheduled check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update automation configuration with more frequent checks and optimized scheduling for improved development workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->