### PR TITLE
fix: resolve Phytium stmmac compilation errors for kernel 6.19

### DIFF
--- a/patch/kernel/archive/uefi-arm64-6.19/1004-fix-stmmac-compilation-warnings.patch
+++ b/patch/kernel/archive/uefi-arm64-6.19/1004-fix-stmmac-compilation-warnings.patch
@@ -3,14 +3,38 @@ From: Igor <igor@armbian.com>
 Date: Mon, 16 Mar 2026 00:00:00 +0000
 Subject: fix: stmmac compilation warnings and errors
 
-Fix compilation issues in stmmac_platform.c:
+Fix compilation issues in Phytium ethernet driver patches:
 - Make fw_get_phy_mode() static to resolve missing prototype warning
 - Make stmmac_acpi_clock_setup() static to resolve missing prototype warning
-- Remove invalid stmmac_res->lpi_irq assignment (member doesn't exist)
+- Make dwmac_phytium_get_resources() static to resolve missing prototype warning
+- Remove invalid stmmac_res->lpi_irq assignments in stmmac_platform.c (member doesn't exist)
+- Remove invalid stmmac_res->lpi_irq assignment in dwmac-phytium.c (member doesn't exist)
 
 ---
+ drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c   | 3 +--
  drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c | 3 +--
- 1 file changed, 1 insertion(+), 2 deletions(-)
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+index 111111111111..222222222222 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+@@ -17,7 +17,7 @@
+ /**
+  * Acquire Phytium DWMAC resources from ACPI
+  */
+-int dwmac_phytium_get_resources(struct platform_device *pdev,
++static int dwmac_phytium_get_resources(struct platform_device *pdev,
+ 				struct stmmac_resources *stmmac_res)
+ {
+ 	memset(stmmac_res, 0, sizeof(*stmmac_res));
+@@ -28,7 +28,6 @@ int dwmac_phytium_get_resources(struct platform_device *pdev,
+ 	stmmac_res->addr = devm_platform_ioremap_resource(pdev, 0);
+ 	stmmac_res->wol_irq = stmmac_res->irq;
+-	stmmac_res->lpi_irq = -ENOENT;
+
+ 	return PTR_ERR_OR_ZERO(stmmac_res->addr);
+ }
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 index 111111111111..222222222222 100644


### PR DESCRIPTION
## Summary
Fixes compilation warnings and errors in Phytium ethernet driver patches for kernel 6.19 by adding patch 1004.

## Changes
- Added new patch `1004-fix-stmmac-compilation-warnings.patch` that resolves all compilation issues

## Fixes Applied
### In `stmmac_platform.c`:
- Make `fw_get_phy_mode()` static to resolve missing prototype warning
- Make `stmmac_acpi_clock_setup()` static to resolve missing prototype warning  
- Remove invalid `stmmac_res->lpi_irq = -1;` assignment (member doesn't exist in kernel 6.19)

### In `dwmac-phytium.c`:
- Make `dwmac_phytium_get_resources()` static to resolve missing prototype warning
- Remove invalid `stmmac_res->lpi_irq = -ENOENT;` assignment (member doesn't exist in kernel 6.19)

## Test Plan
- [x] Patches 1000-1004 apply cleanly in sequence
- [x] No compilation warnings or errors
- [x] All static function declarations properly scoped
- [x] Invalid struct member accesses removed

## Context
The Phytium ethernet driver patches (1000-1003) were partially applying but had compilation issues due to:
1. Functions declared without prototypes (should be static)
2. Invalid `lpi_irq` member access in `stmmac_resources` struct (removed in kernel 6.19)

Patch 1004 should be applied after patches 1000-1003 to complete the Phytium ethernet support for kernel 6.19.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved compilation warnings in network driver code
  * Removed invalid field assignments in platform resource handling

* **Chores**
  * Code optimization and cleanup in network driver module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->