### PR TITLE
rockchip64-7.0: mekotronics-r58x-pro: analog sound: use SuperKali's new clock

### DIFF
--- a/patch/kernel/archive/rockchip64-7.0/dt/rk3588-mekotronics-r58x-pro.dts
+++ b/patch/kernel/archive/rockchip64-7.0/dt/rk3588-mekotronics-r58x-pro.dts
@@ -420,7 +420,7 @@
 	es8388: audio-codec@10 {
 		compatible = "everest,es8388", "everest,es8328";
 		reg = <0x10>;
-		clocks = <&cru I2S0_8CH_MCLKOUT>;
+		clocks = <&cru I2S0_8CH_MCLKOUT_TO_IO>;
 		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
 		assigned-clock-rates = <12288000>;
 		AVDD-supply = <&avcc_1v8_s0>;


### PR DESCRIPTION
#### rockchip64-7.0: mekotronics-r58x-pro: analog sound: use SuperKali's new clock

- 🌱 rockchip64-7.0: mekotronics-r58x-pro: convert analog audio to simple-audio-card
  - `audio-graph-card` actually never worked, I messed up
  - Daniele has the real fix up in https://lore.kernel.org/linux-rockchip/20260316-rk3588-mclk-gate-grf-v1-0-66fb9a246718@superkali.me/
  - convert to `simple-audio-card` before actually adding it, so playing field is even
- 🌴 rockchip64-7.0: mekotronics-r58x-pro: analog sound: use SuperKali's new clock
  > This series fixes ES8388 audio on the Mekotronics R58X-Pro (RK3588). >
  > Without these patches, the i2s0_8ch_mclkout_to_io gate remains closed
  > (enable_count=0 in the clk_summary), and the codec receives no master
  > clock. DAPM reports all widgets as powered on and playback streams run
  > without errors, but the hardware produces no sound — a rather
  > frustrating failure mode to debug. >
  > With the series applied and the board DTS updated to reference
  > I2S0_8CH_MCLKOUT_TO_IO from the codec node: >
  >     es8388: audio-codec@10 {
  >         compatible = "everest,es8388", "everest,es8328";
  >         reg = <0x10>;
  >         clocks = <&cru I2S0_8CH_MCLKOUT_TO_IO>;
  >         assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
  >         assigned-clock-rates = <12288000>;
  >         ...
  >     }; >
  > audio playback works correctly, tested via headphones output. >
  > Tested-by: Ricardo Pardini <ricardo@pardini.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated audio hardware configuration for improved compatibility and stability on the Mekotronics R58x Pro board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->