### PR TITLE
Update odroidxu4-current to 6.6.129

### DIFF
--- a/patch/kernel/archive/odroidxu4-6.6/patch-6.6.128-129.patch
+++ b/patch/kernel/archive/odroidxu4-6.6/patch-6.6.128-129.patch
@@ -1,0 +1,33 @@
+diff --git a/Makefile b/Makefile
+index f7157576539da7..022aed9031737f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 6
+ PATCHLEVEL = 6
+-SUBLEVEL = 128
++SUBLEVEL = 129
+ EXTRAVERSION =
+ NAME = Pinguïn Aangedreven
+ 
+diff --git a/arch/x86/kernel/setup.c b/arch/x86/kernel/setup.c
+index df74f865c9f121..eb129277dcdd64 100644
+--- a/arch/x86/kernel/setup.c
++++ b/arch/x86/kernel/setup.c
+@@ -372,15 +372,9 @@ int __init ima_free_kexec_buffer(void)
+ 
+ int __init ima_get_kexec_buffer(void **addr, size_t *size)
+ {
+-	int ret;
+-
+ 	if (!ima_kexec_buffer_size)
+ 		return -ENOENT;
+ 
+-	ret = ima_validate_range(ima_kexec_buffer_phys, ima_kexec_buffer_size);
+-	if (ret)
+-		return ret;
+-
+ 	*addr = __va(ima_kexec_buffer_phys);
+ 	*size = ima_kexec_buffer_size;
+ 


### PR DESCRIPTION
# Description

Update odroidxu4-current kernel to 6.6.128.

# How Has This Been Tested?

- [x] Cold reboot of my Odroid HC1
- [ ] :exclamation: Warm reboot exhibits issues mentioned in https://forum.armbian.com/topic/58592-partitions-not-visible-after-update-to-2621, but this appears unrelated to the kernel.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux kernel to version 6.6.129 with internal optimizations to memory buffer handling procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->