### PR TITLE
mksklipad50: fix devicetree opp voltage settings

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3328-mksklipad50.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3328-mksklipad50.dts
@@ -284,6 +284,21 @@
 	mali-supply = <&vdd_logic>;
 };
 
+&gpu_opp_table {
+	opp-200000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-300000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-400000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-500000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+};
+
 &hdmi {
 	interrupts = <GIC_SPI 35 IRQ_TYPE_LEVEL_HIGH>,
 		     <GIC_SPI 71 IRQ_TYPE_LEVEL_HIGH>;
@@ -347,7 +362,7 @@
 
 			vdd_arm: DCDC_REG2 {
 				regulator-name = "vdd_arm";
-				regulator-min-microvolt = <1400000>;
+				regulator-min-microvolt = <950000>;
 				regulator-max-microvolt = <1450000>;
 				regulator-ramp-delay    = <12500>;
 				regulator-always-on;

--- a/patch/kernel/archive/rockchip64-7.0/dt/rk3328-mksklipad50.dts
+++ b/patch/kernel/archive/rockchip64-7.0/dt/rk3328-mksklipad50.dts
@@ -284,6 +284,21 @@
 	mali-supply = <&vdd_logic>;
 };
 
+&gpu_opp_table {
+	opp-200000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-300000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-400000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-500000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+};
+
 &hdmi {
 	interrupts = <GIC_SPI 35 IRQ_TYPE_LEVEL_HIGH>,
 		     <GIC_SPI 71 IRQ_TYPE_LEVEL_HIGH>;
@@ -347,7 +362,7 @@
 
 			vdd_arm: DCDC_REG2 {
 				regulator-name = "vdd_arm";
-				regulator-min-microvolt = <1400000>;
+				regulator-min-microvolt = <950000>;
 				regulator-max-microvolt = <1450000>;
 				regulator-ramp-delay    = <12500>;
 				regulator-always-on;

--- a/patch/u-boot/v2025.01/board_mksklipad50/02-rk3328-mksklipad50-add-uboot-dts.patch
+++ b/patch/u-boot/v2025.01/board_mksklipad50/02-rk3328-mksklipad50-add-uboot-dts.patch
@@ -1,12 +1,19 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thorsten Maerz <info@netztorte.de>
-Date: Thu, 06 Mar 2025 18:25:31 +0100
+Date: Fri, 20 Mar 2026 13:57:03 +0000
 Subject: feat: Add u-boot dts for MKSKLIPAD50 board
+ dts/upstream/src/arm64/rockchip/rk3328-mksklipad50.dts
+
+Signed-off-by: Thorsten Maerz <info@netztorte.de>
 ---
+ dts/upstream/src/arm64/rockchip/rk3328-mksklipad50.dts | 571 ++++++++++
+ 1 file changed, 571 insertions(+)
 
 diff --git a/dts/upstream/src/arm64/rockchip/rk3328-mksklipad50.dts b/dts/upstream/src/arm64/rockchip/rk3328-mksklipad50.dts
---- a/dts/upstream/src/arm64/rockchip/rk3328-mksklipad50.dts	1970-01-01 01:00:00.000000000 +0100
-+++ b/dts/upstream/src/arm64/rockchip/rk3328-mksklipad50.dts	2025-03-06 18:25:31.937819640 +0100
+new file mode 100644
+index 00000000000..2fd51e35387
+--- /dev/null
++++ b/dts/upstream/src/arm64/rockchip/rk3328-mksklipad50.dts
 @@ -0,0 +1,571 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
@@ -319,7 +326,7 @@ diff --git a/dts/upstream/src/arm64/rockchip/rk3328-mksklipad50.dts b/dts/upstre
 +
 +			vdd_arm: DCDC_REG2 {
 +				regulator-name = "vdd_arm";
-+				regulator-min-microvolt = <1400000>;
++				regulator-min-microvolt = <950000>;
 +				regulator-max-microvolt = <1450000>;
 +				regulator-ramp-delay    = <12500>;
 +				regulator-always-on;
@@ -579,3 +586,6 @@ diff --git a/dts/upstream/src/arm64/rockchip/rk3328-mksklipad50.dts b/dts/upstre
 +	status = "disabled";
 +};
 +
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

Voltages for "gpu_opp_table" and "vdd_arm" were wrongly using default values instead of the customized values from the vendor image, leading to dmesg errors like
[   19.709834] core: _opp_supported_by_regulators: OPP minuV: 1075000 maxuV: 1075000, not supported by regulator
[   19.710075] lima ff300000.gpu: _opp_add: OPP not supported by regulators (200000000)	0xBEBC200

Thanks to Shadowrom2020 for noticing.
https://github.com/armbian/build/pull/9557

# How Has This Been Tested?

- [X] Built and booted trixie image, checked dmesg output: No more "opp" errors, "lima" driver gets loaded.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GPU operating point voltage configurations across kernel versions.
  * Adjusted ARM processor power regulator minimum voltage settings.
  * Added device tree support for MKS KLIPAD50 board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->