### PR TITLE
sunxi: skip uboot logging level increase

### DIFF
--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -152,8 +152,12 @@ function compile_uboot_target() {
 		# Hack, up the log level to 6: "info" (default is 4: "warning")
 		display_alert "Hacking log level in u-boot config" "LOGLEVEL=${uboot_loglevel} for ${target}" "info"
 		run_host_command_logged scripts/config --enable CONFIG_LOG
-		run_host_command_logged scripts/config --set-val CONFIG_LOGLEVEL ${uboot_loglevel}
-		run_host_command_logged scripts/config --set-val CONFIG_LOG_MAX_LEVEL ${uboot_loglevel}
+
+		# Skip setting log level for sunxi and sunxi64 families
+		if [[ $LINUXFAMILY != "sunxi" && $LINUXFAMILY != "sunxi64" ]]; then
+			run_host_command_logged scripts/config --set-val CONFIG_LOG_MAX_LEVEL ${uboot_loglevel}
+			run_host_command_logged scripts/config --set-val CONFIG_LOGLEVEL ${uboot_loglevel}
+		fi
 
 		# Include Armbian version so UART bootlogs are drastically more useful
 		run_host_command_logged ./scripts/config --disable "LOCALVERSION_AUTO"


### PR DESCRIPTION
Possible fix for H5 related crash and H6 related cpu stalling
https://github.com/armbian/build/issues/9555

Needs testing across various Allwinner devices

If confirmed it needs to be determined if we keep it as it is, remove logging for all families or do something else. I don't know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined u-boot build configuration to properly handle kernel family differences, with specific adjustments for sunxi-based systems to ensure correct logging settings are applied during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->