### PR TITLE
stmmac: Refactor Phytium ethernet patches into modular components

### DIFF
--- a/patch/kernel/archive/uefi-arm64-6.12/1000-net-stmicro-stmmac-Phytium-onboard-ethernet-drivers-and-ACPI-glue-for-6.x.patch
+++ b/patch/kernel/archive/uefi-arm64-6.12/1000-net-stmicro-stmmac-Phytium-onboard-ethernet-drivers-and-ACPI-glue-for-6.x.patch
@@ -17,6 +17,7 @@ rpardini hammered:
 - fix stmmac acpi glue for Feiteng on 6.6.y
 - drop the (now-qcom) phy hibernate stuff as it landed by 6.12.y
 - rework stmmac_probe_config_acpi addition for 6.12.y
+- rework for 6.13; remove_new is just remove again
 
 Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
@@ -33,7 +34,7 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-@@ -121,6 +121,16 @@ config DWMAC_MESON
+@@ -132,6 +132,16 @@ config DWMAC_MESON
  	  the stmmac device driver. This driver is used for Meson6,
  	  Meson8, Meson8b and GXBB SoCs.
  
@@ -54,14 +55,14 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Makefile
 +++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
-@@ -19,6 +19,7 @@ obj-$(CONFIG_DWMAC_IPQ806X)	+= dwmac-ipq806x.o
+@@ -20,6 +20,7 @@ obj-$(CONFIG_DWMAC_IPQ806X)	+= dwmac-ipq806x.o
  obj-$(CONFIG_DWMAC_LPC18XX)	+= dwmac-lpc18xx.o
  obj-$(CONFIG_DWMAC_MEDIATEK)	+= dwmac-mediatek.o
  obj-$(CONFIG_DWMAC_MESON)	+= dwmac-meson.o dwmac-meson8b.o
 +obj-$(CONFIG_DWMAC_PHYTIUM)	+= dwmac-phytium.o
  obj-$(CONFIG_DWMAC_QCOM_ETHQOS)	+= dwmac-qcom-ethqos.o
+ obj-$(CONFIG_DWMAC_RENESAS_GBETH) += dwmac-renesas-gbeth.o
  obj-$(CONFIG_DWMAC_ROCKCHIP)	+= dwmac-rk.o
- obj-$(CONFIG_DWMAC_RZN1)	+= dwmac-rzn1.o
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c
@@ -87,7 +88,7 @@ index 111111111111..222222222222 100644
  	} else {
  		plat_dat = dev_get_platdata(&pdev->dev);
  		if (!plat_dat) {
-@@ -65,12 +72,24 @@ static const struct of_device_id dwmac_generic_match[] = {
+@@ -66,12 +73,24 @@ static const struct of_device_id dwmac_generic_match[] = {
  };
  MODULE_DEVICE_TABLE(of, dwmac_generic_match);
  
@@ -175,7 +176,7 @@ index 000000000000..111111111111
 +	np = dev_fwnode(dev);
 +
 +	plat->phy_interface = fwnode_get_phy_mode(np);
-+	plat->mac_interface = plat->phy_interface;
++	
 +
 +	/* Get max speed of operation from properties */
 +	if (fwnode_property_read_u32(np, "max-speed", &plat->max_speed))
@@ -330,7 +331,7 @@ index 000000000000..111111111111
 +
 +static struct platform_driver dwmac_phytium_driver = {
 +	.probe  = dwmac_phytium_probe,
-+	.remove_new = stmmac_pltfr_remove,
++	.remove = stmmac_pltfr_remove,
 +	.driver = {
 +		.name           = "dwmac-phytium",
 +		.pm		= &stmmac_pltfr_pm_ops,
@@ -367,9 +368,9 @@ index 111111111111..222222222222 100644
  #include <linux/platform_device.h>
  #include <linux/pm_runtime.h>
  #include <linux/module.h>
-@@ -707,6 +710,249 @@ devm_stmmac_probe_config_dt(struct platform_device *pdev, u8 *mac)
- #endif /* CONFIG_OF */
- EXPORT_SYMBOL_GPL(devm_stmmac_probe_config_dt);
+@@ -697,6 +700,249 @@ struct clk *stmmac_pltfr_find_clk(struct plat_stmmacenet_data *plat_dat,
+ }
+ EXPORT_SYMBOL_GPL(stmmac_pltfr_find_clk);
  
 +#ifdef CONFIG_ACPI
 +/*
@@ -516,7 +517,7 @@ index 111111111111..222222222222 100644
 +
 +	np = dev_fwnode(&(pdev->dev));
 +
-+	plat->mac_interface = fw_get_phy_mode(np);
++	plat->phy_interface = fw_get_phy_mode(np);
 +
 +	/* Get max speed of operation from device tree */
 +	if (fwnode_property_read_u32(np, "max-speed", &plat->max_speed))
@@ -617,7 +618,7 @@ index 111111111111..222222222222 100644
  int stmmac_get_platform_resources(struct platform_device *pdev,
  				  struct stmmac_resources *stmmac_res)
  {
-@@ -714,8 +960,14 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
+@@ -704,8 +950,14 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
  
  	/* Get IRQ information early to have an ability to ask for deferred
  	 * probe if needed before we went too far with resource allocation.
@@ -633,7 +634,7 @@ index 111111111111..222222222222 100644
  	if (stmmac_res->irq < 0)
  		return stmmac_res->irq;
  
-@@ -733,6 +985,7 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
+@@ -723,6 +975,7 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
  			return -EPROBE_DEFER;
  		dev_info(&pdev->dev, "IRQ eth_wake_irq not found\n");
  		stmmac_res->wol_irq = stmmac_res->irq;
@@ -652,8 +653,8 @@ index 111111111111..222222222222 100644
 +struct plat_stmmacenet_data *
 +stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac);
  
- int stmmac_get_platform_resources(struct platform_device *pdev,
- 				  struct stmmac_resources *stmmac_res);
+ struct clk *stmmac_pltfr_find_clk(struct plat_stmmacenet_data *plat_dat,
+ 				  const char *name);
 -- 
 Armbian
 

--- a/patch/kernel/archive/uefi-arm64-6.12/1001-net-stmicro-stmmac-Phytium-adapt-to-net-stmmac-remove-axi_blen-array.patch
+++ b/patch/kernel/archive/uefi-arm64-6.12/1001-net-stmicro-stmmac-Phytium-adapt-to-net-stmmac-remove-axi_blen-array.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 29 Dec 2025 14:35:40 +0100
+Subject: net: stmicro: stmmac: Phytium: adapt to "net: stmmac: remove axi_blen
+ array"
+
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+index 111111111111..222222222222 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+@@ -724,7 +724,10 @@ static struct stmmac_axi * stmmac_axi_setup_acpi(struct platform_device *pdev)
+ 		axi->axi_wr_osr_lmt = 1;
+ 	if (fwnode_property_read_u32(np, "snps,rd_osr_lmt", &axi->axi_rd_osr_lmt))
+ 		axi->axi_rd_osr_lmt = 1;
+-	fwnode_property_read_u32_array(np, "snps,blen", axi->axi_blen, AXI_BLEN);
++
++	u32 axi_blen[AXI_BLEN]; // adapt to "net: stmmac: remove axi_blen array"
++	fwnode_property_read_u32_array(np, "snps,blen", axi_blen, AXI_BLEN);
++	stmmac_axi_blen_to_mask(&axi->axi_blen_regval, axi_blen, AXI_BLEN);
+ 
+ 	return axi;
+ }
+-- 
+Armbian
+

--- a/patch/kernel/archive/uefi-arm64-6.12/1002-net-stmicro-stmmac-Phytium-adapt-to-net-stmmac-replace-has_xxxx-with-core_type.patch
+++ b/patch/kernel/archive/uefi-arm64-6.12/1002-net-stmicro-stmmac-Phytium-adapt-to-net-stmmac-replace-has_xxxx-with-core_type.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 29 Dec 2025 15:20:32 +0100
+Subject: net: stmicro: stmmac: Phytium: adapt to "net: stmmac: replace
+ has_xxxx with core_type"
+
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c   | 4 ++--
+ drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+index 111111111111..222222222222 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+@@ -55,7 +55,7 @@ dwmac_phytium_parse_config_acpi(struct platform_device *pdev, const char *mac)
+ 	np = dev_fwnode(dev);
+ 
+ 	plat->phy_interface = fwnode_get_phy_mode(np);
+-	
++
+ 
+ 	/* Get max speed of operation from properties */
+ 	if (fwnode_property_read_u32(np, "max-speed", &plat->max_speed))
+@@ -96,7 +96,7 @@ dwmac_phytium_parse_config_acpi(struct platform_device *pdev, const char *mac)
+ 	plat->unicast_filter_entries = 1;
+ 
+ 	fwnode_property_read_u32(np, "max-frame-size", &plat->maxmtu);
+-	plat->has_gmac = 1;
++	plat->core_type = DWMAC_CORE_GMAC; // adapt to "net: stmmac: replace has_xxxx with core_type"
+ 	plat->pmt = 1;
+ 
+ 	dma_cfg = devm_kzalloc(dev, sizeof(*dma_cfg), GFP_KERNEL);
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+index 111111111111..222222222222 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+@@ -903,7 +903,7 @@ stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac)
+ 						&pdev->dev, plat->unicast_filter_entries);
+ 	plat->multicast_filter_bins = dwmac1000_validate_mcast_bins(
+ 						&pdev->dev, plat->multicast_filter_bins);
+-	plat->has_gmac = 1;
++	plat->core_type = DWMAC_CORE_GMAC; // adapt to "net: stmmac: replace has_xxxx with core_type"
+ 	plat->pmt = 1;
+ 
+ 	dma_cfg = devm_kzalloc(&pdev->dev, sizeof(*dma_cfg), GFP_KERNEL);
+-- 
+Armbian
+

--- a/patch/kernel/archive/uefi-arm64-6.12/1003-net-stmicro-stmmac-Phytium-adapt-to-net-stmmac-pass-struct-device-to-init-exit-methods.patch
+++ b/patch/kernel/archive/uefi-arm64-6.12/1003-net-stmicro-stmmac-Phytium-adapt-to-net-stmmac-pass-struct-device-to-init-exit-methods.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 29 Dec 2025 15:41:31 +0100
+Subject: net: stmicro: stmmac: Phytium: adapt to "net: stmmac: pass struct
+ device to init()/exit() methods"
+
+- ref https://github.com/torvalds/linux/commit/85081acc6b1188f2a6e5e605dc644225fcdf327f
+
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+index 111111111111..222222222222 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+@@ -195,7 +195,7 @@ static int dwmac_phytium_probe(struct platform_device *pdev)
+ 
+ err_exit:
+ 	if (plat_dat->exit)
+-		plat_dat->exit(pdev, plat_dat->bsp_priv);
++		plat_dat->exit(&pdev->dev, plat_dat->bsp_priv);
+ 
+ 	return ret;
+ }
+-- 
+Armbian
+

--- a/patch/kernel/archive/uefi-arm64-6.12/1004-fix-stmmac-compilation-warnings.patch
+++ b/patch/kernel/archive/uefi-arm64-6.12/1004-fix-stmmac-compilation-warnings.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor <igor@armbian.com>
+Date: Mon, 16 Mar 2026 00:00:00 +0000
+Subject: fix: stmmac compilation warnings and errors
+
+Fix compilation issues in Phytium ethernet driver patches:
+- Make fw_get_phy_mode() static to resolve missing prototype warning
+- Make stmmac_acpi_clock_setup() static to resolve missing prototype warning
+- Make dwmac_phytium_get_resources() static to resolve missing prototype warning
+- Remove invalid stmmac_res->lpi_irq assignments in stmmac_platform.c (member doesn't exist)
+- Remove invalid stmmac_res->lpi_irq assignment in dwmac-phytium.c (member doesn't exist)
+
+---
+ drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c   | 3 +--
+ drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c | 3 +--
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+index 111111111111..222222222222 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+@@ -17,7 +17,7 @@
+ /**
+  * Acquire Phytium DWMAC resources from ACPI
+  */
+-int dwmac_phytium_get_resources(struct platform_device *pdev,
++static int dwmac_phytium_get_resources(struct platform_device *pdev,
+ 				struct stmmac_resources *stmmac_res)
+ {
+ 	memset(stmmac_res, 0, sizeof(*stmmac_res));
+@@ -28,7 +28,6 @@ int dwmac_phytium_get_resources(struct platform_device *pdev,
+ 	stmmac_res->addr = devm_platform_ioremap_resource(pdev, 0);
+ 	stmmac_res->wol_irq = stmmac_res->irq;
+-	stmmac_res->lpi_irq = -ENOENT;
+
+ 	return PTR_ERR_OR_ZERO(stmmac_res->addr);
+ }
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+index 111111111111..222222222222 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+@@ -769,7 +769,7 @@ static int stmmac_acpi_phy(struct plat_stmmacenet_data *plat,
+ 	return 0;
+ }
+
+-int fw_get_phy_mode(struct fwnode_handle *np)
++static int fw_get_phy_mode(struct fwnode_handle *np)
+ {
+ 	const char *pm;
+ 	int err, i;
+@@ -788,7 +788,7 @@ int fw_get_phy_mode(struct fwnode_handle *np)
+ 	return -ENODEV;
+ }
+
+-int stmmac_acpi_clock_setup(struct plat_stmmacenet_data *plat,
++static int stmmac_acpi_clock_setup(struct plat_stmmacenet_data *plat,
+ 			    struct platform_device *pdev)
+ {
+ 	struct fwnode_handle *np = dev_fwnode(&(pdev->dev));
+@@ -978,7 +978,6 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
+ 			return -EPROBE_DEFER;
+ 		dev_info(&pdev->dev, "IRQ eth_wake_irq not found\n");
+ 		stmmac_res->wol_irq = stmmac_res->irq;
+-		stmmac_res->lpi_irq = -1;
+ 	}
+
+ 	stmmac_res->sfty_irq =
+--
+Armbian


### PR DESCRIPTION
## Summary
- Refactor monolithic Phytium ethernet driver patch into multiple focused patches
- Improve maintainability by separating concerns into individual patches
- Add compilation warning fixes

## Changes
Split the original `net-stmicro-stmmac-Phytium-onboard-ethernet-drivers-and-ACPI-glue-for-6.x.patch` into:

- `1000-net-stmicro-stmmac-Phytium-onboard-ethernet-drivers-and-ACPI-glue-for-6.x.patch` - Original Phytium onboard ethernet drivers and ACPI glue
- `1001-net-stmicro-stmmac-Phytium-adapt-to-net-stmmac-remove-axi_blen-array.patch` - Adapt to stmmac removal of axi_blen array
- `1002-net-stmicro-stmmac-Phytium-adapt-to-net-stmmac-replace-has_xxxx-with-core_type.patch` - Adapt to stmmac replace has_xxxx with core_type
- `1003-net-stmicro-stmmac-Phytium-adapt-to-net-stmmac-pass-struct-device-to-init-exit-methods.patch` - Adapt to stmmac pass struct device to init/exit methods
- `1004-fix-stmmac-compilation-warnings.patch` - Fix stmmac compilation warnings

## Benefits
- Better maintainability with smaller, focused patches
- Easier to review and understand individual changes
- Easier to enable/disable specific adaptations if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compilation warnings and tightened driver linkage for Phytium Ethernet support.

* **Chores**
  * Integrated additional DWMAC drivers and updated platform registration/initialization behavior.
  * Adjusted AXI buffer-length handling to store mask/register values rather than raw entries.
  * Standardized core-type detection for GMAC capability and refined MAC/PHY interface assignment during probe.
  * Changed exported platform API surface to improve clock/resource lookup and platform init/exit argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->