### PR TITLE
sunxi: fix `Unhandled Exception in EL3.` and/causing secondary cpus not coming online

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -9,7 +9,7 @@
 enable_extension "sunxi-tools"
 declare -g ARCH=arm64
 declare -g ATF_TARGET_MAP="PLAT=$ATF_PLAT DEBUG=1 bl31;;build/$ATF_PLAT/debug/bl31.bin"
-declare -g ATFBRANCH="tag:lts-v2.12.4"
+declare -g ATFBRANCH="tag:lts-v2.12.9"
 declare -g BOOTDELAY=1
 declare -g BOOTPATCHDIR="${BOOTPATCHDIR:-"u-boot-sunxi"}"
 declare -g BOOTBRANCH="${BOOTBRANCH:-"tag:v2024.01"}"
@@ -46,8 +46,7 @@ family_tweaks() {
 }
 
 write_uboot_platform() {
-	dd if=/dev/zero of=$2 bs=1k count=1023 seek=1 status=noxfer > /dev/null 2>&1
-	dd if=$1/u-boot-sunxi-with-spl.bin of=$2 bs=1024 seek=8 status=noxfer > /dev/null 2>&1
+	dd if=$1/u-boot-sunxi-with-spl.bin of=$2 conv=fsync bs=1024 seek=8
 }
 
 setup_write_uboot_platform() {

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -149,12 +149,6 @@ function compile_uboot_target() {
 			run_host_command_logged scripts/config --set-val CONFIG_BOOTDELAY "${BOOTDELAY}"
 		fi
 
-		# Hack, up the log level to 6: "info" (default is 4: "warning")
-		display_alert "Hacking log level in u-boot config" "LOGLEVEL=${uboot_loglevel} for ${target}" "info"
-		run_host_command_logged scripts/config --enable CONFIG_LOG
-		run_host_command_logged scripts/config --set-val CONFIG_LOGLEVEL ${uboot_loglevel}
-		run_host_command_logged scripts/config --set-val CONFIG_LOG_MAX_LEVEL ${uboot_loglevel}
-
 		# Include Armbian version so UART bootlogs are drastically more useful
 		run_host_command_logged ./scripts/config --disable "LOCALVERSION_AUTO"
 		run_host_command_logged ./scripts/config --set-str "LOCALVERSION" "_armbian-${artifact_version}" # crazy quotes!


### PR DESCRIPTION
# Description

Possible fix for 
https://github.com/armbian/build/issues/9555 and https://github.com/armbian/build/issues/9521

Successor PR of https://github.com/armbian/build/pull/9522

Credits to @AbdulKus for the deep dive and  @pyavitz for the `write_uboot_platform` adjustment

# How Has This Been Tested?

- [x] build from `main` and boot: the mentioned EL3 exception happens and only one core comes online
- [x] build and boot with these changes: no exception and secondary cpus are there.

Tests were conducted with fresh Trixie minimal images on  `current` kernel using Orange Pi One Plus (H6).

**This shall be tested on as many older Allwinner devices as possible** to either verify fixed or still working as expected.
This also includes sunxi32 boards, because `write_uboot_platform` and ATF are also used for those.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


# foot notes:

what I've tried to narrow this down:

- built from main: crash on boot and cpus don't come online
- remove LOGGING from uboot, same
- used 2.12.9 ATF, same
- used 2.12.9 ATF + remove LOGGING from uboot, same
- used 2.12.9 ATF + remove LOGGING from uboot + remove DEBUG=1 from ATF, same
- used uboot 2026.01, no more crash but cpus don't come online
- used uboot 2026.01 + 2.12.9 ATF, no more crash but cpus don't come online
- remove LOGGING from ATF, crash+ cpus don't come online
- change uboot write function  only, crash+ cpus don't come online
- ultimately the combination sent with this PR worked. no crash, all cores online

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ARM Trusted Firmware to the latest LTS version (v2.12.9).
  * Refined bootloader write process with improved data synchronization.
  * Adjusted bootloader logging configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->