### PR TITLE
rockchip64-6.18: rewrite kernel patches against 6.18.20

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/HACK-Ignore-SError-to-enable-rk3399-PCIe-bus-enumera.patch
+++ b/patch/kernel/archive/rockchip64-6.18/HACK-Ignore-SError-to-enable-rk3399-PCIe-bus-enumera.patch
@@ -1,15 +1,15 @@
-From 2ad2c11dad315482917ac0e27863f12d5c44bfee Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: retro98boy <retro98boy@qq.com>
 Date: Wed, 25 Feb 2026 05:18:04 +0800
-Subject: [PATCH] HACK: Ignore SError to enable rk3399 PCIe bus enumeration
+Subject: HACK: Ignore SError to enable rk3399 PCIe bus enumeration
 
 ---
- arch/arm64/kernel/traps.c                   | 19 ++++++++
- drivers/pci/controller/pcie-rockchip-host.c | 50 +++++++++++++++++++++
+ arch/arm64/kernel/traps.c                   | 19 ++++
+ drivers/pci/controller/pcie-rockchip-host.c | 50 ++++++++++
  2 files changed, 69 insertions(+)
 
 diff --git a/arch/arm64/kernel/traps.c b/arch/arm64/kernel/traps.c
-index 681939ef5..a48ec5dac 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/kernel/traps.c
 +++ b/arch/arm64/kernel/traps.c
 @@ -976,8 +976,27 @@ bool arm64_is_fatal_ras_serror(struct pt_regs *regs, unsigned long esr)
@@ -41,7 +41,7 @@ index 681939ef5..a48ec5dac 100644
  	if (!arm64_is_ras_serror(esr) || arm64_is_fatal_ras_serror(regs, esr))
  		arm64_serror_panic(regs, esr);
 diff --git a/drivers/pci/controller/pcie-rockchip-host.c b/drivers/pci/controller/pcie-rockchip-host.c
-index ee1822ca0..0944aa9a2 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pci/controller/pcie-rockchip-host.c
 +++ b/drivers/pci/controller/pcie-rockchip-host.c
 @@ -923,8 +923,58 @@ static int rockchip_pcie_resume_noirq(struct device *dev)
@@ -104,5 +104,5 @@ index ee1822ca0..0944aa9a2 100644
  	struct device *dev = &pdev->dev;
  	struct pci_host_bridge *bridge;
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/general-rk3588-i2s-mclk-output-gate-1-bindings.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-rk3588-i2s-mclk-output-gate-1-bindings.patch
@@ -1,8 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
 Date: Thu, 19 Mar 2026 08:26:57 +0100
-Subject: dt-bindings: clock: rockchip,rk3588-cru: add I2S MCLK
- output to IO clock IDs
+Subject: dt-bindings: clock: rockchip,rk3588-cru: add I2S MCLK output to IO
+ clock IDs
 
 Add clock identifiers for the four I2S MCLK output to IO gate clocks
 on RK3588, needed by board DTS files where the codec requires MCLK
@@ -16,7 +16,7 @@ Signed-off-by: SuperKali <hello@superkali.me>
  1 file changed, 4 insertions(+)
 
 diff --git a/include/dt-bindings/clock/rockchip,rk3588-cru.h b/include/dt-bindings/clock/rockchip,rk3588-cru.h
-index 0c7d3ca2d5bc..7528034cff56 100644
+index 111111111111..222222222222 100644
 --- a/include/dt-bindings/clock/rockchip,rk3588-cru.h
 +++ b/include/dt-bindings/clock/rockchip,rk3588-cru.h
 @@ -734,6 +734,10 @@

--- a/patch/kernel/archive/rockchip64-6.18/general-rk3588-i2s-mclk-output-gate-2-allow-grf-type-sys.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-rk3588-i2s-mclk-output-gate-2-allow-grf-type-sys.patch
@@ -24,7 +24,7 @@ Signed-off-by: SuperKali <hello@superkali.me>
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/clk/rockchip/clk.c b/drivers/clk/rockchip/clk.c
-index e8b3b0b9a4f8..911e6b610618 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/rockchip/clk.c
 +++ b/drivers/clk/rockchip/clk.c
 @@ -509,10 +509,9 @@ void rockchip_clk_register_branches(struct rockchip_clk_provider *ctx,

--- a/patch/kernel/archive/rockchip64-6.18/general-rk3588-i2s-mclk-output-gate-3-grf-header.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-rk3588-i2s-mclk-output-gate-3-grf-header.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
 Date: Fri, 20 Mar 2026 11:24:11 +0100
-Subject: soc: rockchip: rk3588: add SYS_GRF SOC_CON6 register
- offset
+Subject: soc: rockchip: rk3588: add SYS_GRF SOC_CON6 register offset
 
 Add the RK3588_SYSGRF_SOC_CON6 register offset to the RK3588 GRF
 header. This register contains the I2S MCLK output to IO gate bits,
@@ -14,7 +13,7 @@ Signed-off-by: SuperKali <hello@superkali.me>
  1 file changed, 2 insertions(+)
 
 diff --git a/include/soc/rockchip/rk3588_grf.h b/include/soc/rockchip/rk3588_grf.h
-index 02a7b2432d99..db0092fc66ad 100644
+index 111111111111..222222222222 100644
 --- a/include/soc/rockchip/rk3588_grf.h
 +++ b/include/soc/rockchip/rk3588_grf.h
 @@ -19,4 +19,6 @@

--- a/patch/kernel/archive/rockchip64-6.18/general-rk3588-i2s-mclk-output-gate-4-gate-grf-clocks.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-rk3588-i2s-mclk-output-gate-4-gate-grf-clocks.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
 Date: Fri, 20 Mar 2026 11:25:50 +0100
-Subject: clk: rockchip: rk3588: add GATE_GRF clocks for I2S MCLK
- output to IO
+Subject: clk: rockchip: rk3588: add GATE_GRF clocks for I2S MCLK output to IO
 
 The I2S MCLK outputs on RK3588 are gated by bits in the SYS_GRF
 register SOC_CON6 (offset 0x318). These gates control whether the
@@ -35,11 +34,11 @@ Upstream: https://lore.kernel.org/linux-rockchip/20260320-rk3588-mclk-gate-grf-v
 
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- drivers/clk/rockchip/clk-rk3588.c | 24 ++++++++++++++++++++++++
+ drivers/clk/rockchip/clk-rk3588.c | 24 ++++++++++
  1 file changed, 24 insertions(+)
 
 diff --git a/drivers/clk/rockchip/clk-rk3588.c b/drivers/clk/rockchip/clk-rk3588.c
-index 1694223f4f84..2cc85fb5b2cc 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/rockchip/clk-rk3588.c
 +++ b/drivers/clk/rockchip/clk-rk3588.c
 @@ -5,11 +5,14 @@

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-rp64-pcie-Reimplement-rockchip-PCIe-bus-scan-delay.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-rp64-pcie-Reimplement-rockchip-PCIe-bus-scan-delay.patch
@@ -54,7 +54,7 @@ index 111111111111..222222222222 100644
  static void rockchip_pcie_enable_bw_int(struct rockchip_pcie *rockchip)
  {
  	u32 status;
-@@ -929,6 +933,7 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
+@@ -979,6 +983,7 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
  	struct device *dev = &pdev->dev;
  	struct pci_host_bridge *bridge;
  	int err;
@@ -62,7 +62,7 @@ index 111111111111..222222222222 100644
  
  	if (!dev->of_node)
  		return -ENODEV;
-@@ -978,6 +983,26 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
+@@ -1028,6 +1033,26 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
  	bridge->sysdata = rockchip;
  	bridge->ops = &rockchip_pcie_ops;
  

--- a/patch/kernel/archive/rockchip64-6.18/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shlomi Marco <s.marco@rubycomm.com>
-Date: Sun, 02 Mar 2026 00:00:00 +0000
+Date: Mon, 2 Mar 2026 00:00:00 +0000
 Subject: phy: rockchip-inno-usb2: Add support for RK3528
 
 Add USB2 PHY support for the Rockchip RK3528 SoC.
@@ -21,12 +21,14 @@ next-20250910-rk3528 branch.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 136 +++++++++++++++---
- 1 file changed, 105 insertions(+), 31 deletions(-)
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 160 ++++++++--
+ 1 file changed, 127 insertions(+), 33 deletions(-)
 
+diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
+index 111111111111..222222222222 100644
 --- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 +++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
-@@ -171,6 +171,7 @@
+@@ -171,6 +171,7 @@ struct rockchip_usb2phy_port_cfg {
   * @num_ports: specify how many ports that the phy has.
   * @phy_tuning: phy default parameters tuning.
   * @clkout_ctl: keep on/turn off output clk of phy.
@@ -34,7 +36,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
   * @port_cfgs: usb-phy port configurations.
   * @chg_det: charger detection registers.
   */
-@@ -179,6 +180,7 @@
+@@ -179,6 +180,7 @@ struct rockchip_usb2phy_cfg {
  	unsigned int	num_ports;
  	int (*phy_tuning)(struct rockchip_usb2phy *rphy);
  	struct usb2phy_reg	clkout_ctl;
@@ -42,7 +44,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  	const struct rockchip_usb2phy_port_cfg	port_cfgs[USB2PHY_NUM_PORTS];
  	const struct rockchip_chg_det_reg	chg_det;
  };
-@@ -228,7 +230,7 @@
+@@ -228,7 +230,7 @@ struct rockchip_usb2phy_port {
   * struct rockchip_usb2phy - usb2.0 phy driver data.
   * @dev: pointer to device.
   * @grf: General Register Files regmap.
@@ -51,7 +53,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
   * @clks: array of phy input clocks.
   * @clk480m: clock struct of phy output clk.
   * @clk480m_hw: clock struct of phy output clk management.
-@@ -246,7 +248,7 @@
+@@ -246,7 +248,7 @@ struct rockchip_usb2phy_port {
  struct rockchip_usb2phy {
  	struct device	*dev;
  	struct regmap	*grf;
@@ -60,7 +62,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  	struct clk_bulk_data	*clks;
  	struct clk	*clk480m;
  	struct clk_hw	clk480m_hw;
-@@ -263,7 +265,7 @@
+@@ -263,7 +265,7 @@ struct rockchip_usb2phy {
  
  static inline struct regmap *get_reg_base(struct rockchip_usb2phy *rphy)
  {
@@ -69,7 +71,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  }
  
  static inline int property_enable(struct regmap *base,
-@@ -319,16 +321,33 @@
+@@ -319,16 +321,33 @@ static void rockchip_usb2phy_clk_bulk_disable(void *data)
  	clk_bulk_disable_unprepare(rphy->num_clks, rphy->clks);
  }
  
@@ -107,7 +109,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  		if (ret)
  			return ret;
  
-@@ -341,21 +360,23 @@
+@@ -341,21 +360,23 @@ static int rockchip_usb2phy_clk480m_prepare(struct clk_hw *hw)
  
  static void rockchip_usb2phy_clk480m_unprepare(struct clk_hw *hw)
  {
@@ -139,22 +141,22 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  }
  
  static unsigned long
-@@ -1360,27 +1381,18 @@
+@@ -1360,27 +1381,18 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  	if (!rphy)
  		return -ENOMEM;
-
+ 
 -	if (!dev->parent || !dev->parent->of_node) {
+-		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
+-		if (IS_ERR(rphy->grf)) {
+-			dev_err(dev, "failed to locate usbgrf\n");
+-			return PTR_ERR(rphy->grf);
+-		}
 +	if (!dev->parent || !dev->parent->of_node ||
 +	    of_property_present(np, "rockchip,usbgrf")) {
 +		rphy->phy_base = device_node_to_regmap(np);
 +		if (IS_ERR(rphy->phy_base))
 +			return PTR_ERR(rphy->phy_base);
--		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
 +		rphy->grf = rphy->phy_base;
--		if (IS_ERR(rphy->grf)) {
--			dev_err(dev, "failed to locate usbgrf\n");
--			return PTR_ERR(rphy->grf);
--		}
  	} else {
  		rphy->grf = syscon_node_to_regmap(dev->parent->of_node);
 -		if (IS_ERR(rphy->grf))
@@ -176,7 +178,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  
  	if (of_property_read_u32_index(np, "reg", 0, &reg)) {
  		dev_err(dev, "the reg property is not assigned in %pOFn node\n", np);
-@@ -1521,6 +1533,36 @@
+@@ -1521,6 +1533,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  				BIT(2) << BIT_WRITEABLE_SHIFT | 0);
  }
  
@@ -213,7 +215,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  static int rk3576_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  {
  	int ret;
-@@ -1934,6 +1968,57 @@
+@@ -1934,6 +1976,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
  	{ /* sentinel */ }
  };
  
@@ -271,7 +273,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  static const struct rockchip_usb2phy_cfg rk3562_phy_cfgs[] = {
  	{
  		.reg = 0xff740000,
-@@ -2301,6 +2386,7 @@
+@@ -2301,6 +2394,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
  	{ .compatible = "rockchip,rk3328-usb2phy", .data = &rk3328_phy_cfgs },
  	{ .compatible = "rockchip,rk3366-usb2phy", .data = &rk3366_phy_cfgs },
  	{ .compatible = "rockchip,rk3399-usb2phy", .data = &rk3399_phy_cfgs },

--- a/patch/kernel/archive/rockchip64-6.18/rk3528-11-arm64-dts-rockchip-rk3528-Add-USB-controller-and-PHY-nodes.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3528-11-arm64-dts-rockchip-rk3528-Add-USB-controller-and-PHY-nodes.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shlomi Marco <s.marco@rubycomm.com>
-Date: Sun, 02 Mar 2026 00:00:00 +0000
+Date: Mon, 2 Mar 2026 00:00:00 +0000
 Subject: arm64: dts: rockchip: rk3528: Add USB controller and PHY nodes
 
 Add the USB controller and PHY device tree nodes for the RK3528 SoC:
@@ -17,17 +17,17 @@ RK3528 USB patches and the U-Boot device tree.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3528.dtsi | 80 ++++++++++++++++++++++++
- 1 file changed, 80 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3528.dtsi | 78 ++++++++++
+ 1 file changed, 78 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3528.dtsi b/arch/arm64/boot/dts/rockchip/rk3528.dtsi
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3528.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3528.dtsi
-@@ -336,6 +336,30 @@
+@@ -336,6 +336,30 @@ pcie_intc: legacy-interrupt-controller {
  			};
  		};
-
+ 
 +		usb_host0_xhci: usb@fe500000 {
 +			compatible = "rockchip,rk3528-dwc3", "snps,dwc3";
 +			reg = <0x0 0xfe500000 0x0 0x400000>;
@@ -55,10 +55,10 @@ index 111111111111..222222222222 100644
  		gic: interrupt-controller@fed01000 {
  			compatible = "arm,gic-400";
  			reg = <0x0 0xfed01000 0 0x1000>,
-@@ -349,6 +373,30 @@
+@@ -349,6 +373,30 @@ gic: interrupt-controller@fed01000 {
  			#interrupt-cells = <3>;
  		};
-
+ 
 +		usb_host0_ehci: usb@ff100000 {
 +			compatible = "generic-ehci";
 +			reg = <0x0 0xff100000 0x0 0x40000>;
@@ -86,7 +86,7 @@ index 111111111111..222222222222 100644
  		qos_crypto_a: qos@ff200000 {
  			compatible = "rockchip,rk3528-qos", "syscon";
  			reg = <0x0 0xff200000 0x0 0x20>;
-@@ -1238,6 +1286,36 @@
+@@ -1238,6 +1286,36 @@ combphy: phy@ffdc0000 {
  			rockchip,pipe-phy-grf = <&pipe_phy_grf>;
  			status = "disabled";
  		};

--- a/patch/kernel/archive/rockchip64-6.18/rk3528-12-arm64-dts-rockchip-nanopi-zero2-Enable-USB.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3528-12-arm64-dts-rockchip-nanopi-zero2-Enable-USB.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shlomi Marco <s.marco@rubycomm.com>
-Date: Sun, 02 Mar 2026 00:00:00 +0000
+Date: Mon, 2 Mar 2026 00:00:00 +0000
 Subject: arm64: dts: rockchip: nanopi-zero2: Enable USB
 
 Enable USB2 PHY, EHCI, OHCI and DWC3 (xHCI) controllers on the
@@ -16,14 +16,14 @@ defined in the board DTS but were previously unused.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts | 27 +++++++++++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts | 27 ++++++++++
  1 file changed, 27 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts b/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts
-@@ -349,3 +349,30 @@
+@@ -349,3 +349,30 @@ &uart0 {
  	pinctrl-0 = <&uart0m0_xfer>;
  	status = "okay";
  };

--- a/patch/kernel/archive/rockchip64-6.18/rk3576-0001-gpio-rockchip-set-input-direction-when-request-irq.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3576-0001-gpio-rockchip-set-input-direction-when-request-irq.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ye Zhang <ye.zhang@rock-chips.com>
 Date: Tue, 12 Nov 2024 09:54:08 +0800
-Subject: [PATCH] gpio: rockchip: set input direction when request irq
+Subject: gpio: rockchip: set input direction when request irq
 
 Set input direction when requesting IRQ to ensure proper GPIO
 configuration for interrupt handling.
@@ -14,10 +14,10 @@ Reviewed-by: Sebastian Reichel <sebastian.reichel@collabora.com>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpio/gpio-rockchip.c b/drivers/gpio/gpio-rockchip.c
-index bcfc323a8315..8c07896fbc0f 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpio/gpio-rockchip.c
 +++ b/drivers/gpio/gpio-rockchip.c
-@@ -478,8 +478,11 @@ static int rockchip_irq_reqres(struct irq_data *d)
+@@ -471,8 +471,11 @@ static int rockchip_irq_reqres(struct irq_data *d)
  {
  	struct irq_chip_generic *gc = irq_data_get_irq_chip_data(d);
  	struct rockchip_pin_bank *bank = gc->private;
@@ -31,5 +31,5 @@ index bcfc323a8315..8c07896fbc0f 100644
  
  static void rockchip_irq_relres(struct irq_data *d)
 -- 
-2.47.3
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/rk3576-0002-mmc-dw_mmc-rockchip-add-v2-tuning-support.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3576-0002-mmc-dw_mmc-rockchip-add-v2-tuning-support.patch
@@ -1,18 +1,18 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shawn Lin <shawn.lin@rock-chips.com>
 Date: Mon, 12 Apr 2021 00:00:00 +0800
-Subject: [PATCH] mmc: dw_mmc-rockchip: add v2 tuning support
+Subject: mmc: dw_mmc-rockchip: add v2 tuning support
 
 Add support for v2 tuning mechanism in Rockchip DW MMC controller
 to improve MMC performance and reliability.
 
 Signed-off-by: Shawn Lin <shawn.lin@rock-chips.com>
 ---
- drivers/mmc/host/dw_mmc-rockchip.c | 64 ++++++++++++++++++++++++++++++
- 1 file changed, 64 insertions(+)
+ drivers/mmc/host/dw_mmc-rockchip.c | 66 ++++++++++
+ 1 file changed, 66 insertions(+)
 
 diff --git a/drivers/mmc/host/dw_mmc-rockchip.c b/drivers/mmc/host/dw_mmc-rockchip.c
-index ff6a52d85e52..a13e46012b16 100644
+index 111111111111..222222222222 100644
 --- a/drivers/mmc/host/dw_mmc-rockchip.c
 +++ b/drivers/mmc/host/dw_mmc-rockchip.c
 @@ -36,6 +36,8 @@ struct dw_mci_rockchip_priv_data {
@@ -117,5 +117,5 @@ index ff6a52d85e52..a13e46012b16 100644
  
  	return 0;
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/rk3576-0003-pmdomain-rockchip-add-always-on-support.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3576-0003-pmdomain-rockchip-add-always-on-support.patch
@@ -1,19 +1,18 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Finley Xiao <finley.xiao@rock-chips.com>
 Date: Wed, 12 Oct 2022 19:25:38 +0800
-Subject: [PATCH] pmdomain: rockchip: Add always on configuration for power
- domain
+Subject: pmdomain: rockchip: Add always on configuration for power domain
 
 This adds support for the always_on flag in the rockchip_domain_info
 structure, allowing certain power domains to be kept always on.
 
 Signed-off-by: Finley Xiao <finley.xiao@rock-chips.com>
 ---
- drivers/pmdomain/rockchip/pm-domains.c | 32 ++++++++++++++++++++++++++
- 1 file changed, 32 insertions(+)
+ drivers/pmdomain/rockchip/pm-domains.c | 26 ++++++++++
+ 1 file changed, 26 insertions(+)
 
 diff --git a/drivers/pmdomain/rockchip/pm-domains.c b/drivers/pmdomain/rockchip/pm-domains.c
-index 1955c6d453e4..f8d587fc3af8 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pmdomain/rockchip/pm-domains.c
 +++ b/drivers/pmdomain/rockchip/pm-domains.c
 @@ -55,6 +55,7 @@ struct rockchip_domain_info {
@@ -24,7 +23,7 @@ index 1955c6d453e4..f8d587fc3af8 100644
  	u32 pwr_offset;
  	u32 mem_offset;
  	u32 req_offset;
-@@ -750,6 +752,26 @@ static void rockchip_pd_detach_dev(struct generic_pm_domain *genpd,
+@@ -750,6 +751,26 @@ static void rockchip_pd_detach_dev(struct generic_pm_domain *genpd,
  	pm_clk_destroy(dev);
  }
  
@@ -51,7 +50,7 @@ index 1955c6d453e4..f8d587fc3af8 100644
  static int rockchip_pm_add_one_domain(struct rockchip_pmu *pmu,
  				      struct device_node *node)
  {
-@@ -868,6 +890,11 @@ static int rockchip_pm_add_one_domain(struct rockchip_pmu *pmu,
+@@ -878,6 +899,11 @@ static int rockchip_pm_add_one_domain(struct rockchip_pmu *pmu,
  	pd->genpd.flags = GENPD_FLAG_PM_CLK | GENPD_FLAG_NO_STAY_ON;
  	if (pd_info->active_wakeup)
  		pd->genpd.flags |= GENPD_FLAG_ACTIVE_WAKEUP;
@@ -64,4 +63,5 @@ index 1955c6d453e4..f8d587fc3af8 100644
  		      !rockchip_pmu_domain_is_on(pd) ||
  		      (pd->info->mem_status_mask && !rockchip_pmu_domain_is_mem_on(pd)));
 -- 
-2.49.0
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.18/rk3576-0004-dt-bindings-pwm-rockchip-rk3576-pwm.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3576-0004-dt-bindings-pwm-rockchip-rk3576-pwm.patch
@@ -1,7 +1,7 @@
-From 4549bc0ee877e2c46324b4d1282fc84bbdb69110 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
 Date: Mon, 27 Oct 2025 18:11:56 +0100
-Subject: [PATCH] dt-bindings: pwm: Add a new binding for rockchip,rk3576-pwm
+Subject: dt-bindings: pwm: Add a new binding for rockchip,rk3576-pwm
 
 The Rockchip RK3576 SoC has a newer PWM controller IP revision than
 previous Rockchip SoCs. This IP, called "PWMv4" by Rockchip, introduces
@@ -21,14 +21,12 @@ Reviewed-by: Conor Dooley <conor.dooley@microchip.com>
 Reviewed-by: Rob Herring (Arm) <robh@kernel.org>
 Signed-off-by: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
 ---
- .../bindings/pwm/rockchip,rk3576-pwm.yaml     | 77 +++++++++++++++++++
- MAINTAINERS                                   |  7 ++
- 2 files changed, 84 insertions(+)
- create mode 100644 Documentation/devicetree/bindings/pwm/rockchip,rk3576-pwm.yaml
+ Documentation/devicetree/bindings/pwm/rockchip,rk3576-pwm.yaml | 77 ++++++++++
+ 1 file changed, 77 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/pwm/rockchip,rk3576-pwm.yaml b/Documentation/devicetree/bindings/pwm/rockchip,rk3576-pwm.yaml
 new file mode 100644
-index 000000000000..48d5055c8b06
+index 000000000000..111111111111
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/pwm/rockchip,rk3576-pwm.yaml
 @@ -0,0 +1,77 @@
@@ -109,24 +107,6 @@ index 000000000000..48d5055c8b06
 +            #pwm-cells = <3>;
 +        };
 +    };
-diff --git a/MAINTAINERS b/MAINTAINERS
-index e8f06145fb54..4ff6848d195f 100644
---- a/MAINTAINERS
-+++ b/MAINTAINERS
-@@ -22272,6 +22272,13 @@ F:	Documentation/userspace-api/media/v4l/metafmt-rkisp1.rst
- F:	drivers/media/platform/rockchip/rkisp1
- F:	include/uapi/linux/rkisp1-config.h
- 
-+ROCKCHIP MFPWM
-+M:	Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
-+L:	linux-rockchip@lists.infradead.org
-+L:	linux-pwm@vger.kernel.org
-+S:	Maintained
-+F:	Documentation/devicetree/bindings/pwm/rockchip,rk3576-pwm.yaml
-+
- ROCKCHIP RK3568 RANDOM NUMBER GENERATOR SUPPORT
- M:	Daniel Golle <daniel@makrotopia.org>
- M:	Aurelien Jarno <aurelien@aurel32.net>
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/rk3576-0005-mfd-rockchip-add-mfpwm-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3576-0005-mfd-rockchip-add-mfpwm-driver.patch
@@ -1,10 +1,7 @@
-From b97f0816ac5d63e3aa353b40def3a897006c8300 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
 Date: Mon, 27 Oct 2025 18:11:57 +0100
-Subject: [PATCH] mfd: Add Rockchip mfpwm driver
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
+Subject: mfd: Add Rockchip mfpwm driver
 
 With the Rockchip RK3576, the PWM IP used by Rockchip has changed
 substantially. Looking at both the downstream pwm-rockchip driver as
@@ -14,7 +11,7 @@ is best supported in a new driver.
 
 This brings us to the question as to what such a new driver should be.
 To me, it soon became clear that it should actually be several new
-drivers, most prominently when Uwe Kleine-König let me know that I
+drivers, most prominently when Uwe Kleine-Konig let me know that I
 should not implement the pwm subsystem's capture callback, but instead
 write a counter driver for this functionality.
 
@@ -33,33 +30,17 @@ drivers don't step on each other's toes.
 
 Signed-off-by: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
 ---
- MAINTAINERS                        |   2 +
  drivers/mfd/Kconfig                |  15 +
  drivers/mfd/Makefile               |   1 +
- drivers/mfd/rockchip-mfpwm.c       | 340 +++++++++++++++++++++
- include/linux/mfd/rockchip-mfpwm.h | 454 +++++++++++++++++++++++++++++
- 5 files changed, 812 insertions(+)
- create mode 100644 drivers/mfd/rockchip-mfpwm.c
- create mode 100644 include/linux/mfd/rockchip-mfpwm.h
+ drivers/mfd/rockchip-mfpwm.c       | 340 +++++++
+ include/linux/mfd/rockchip-mfpwm.h | 454 ++++++++++
+ 4 files changed, 810 insertions(+)
 
-diff --git a/MAINTAINERS b/MAINTAINERS
-index 4ff6848d195f..e9117452179e 100644
---- a/MAINTAINERS
-+++ b/MAINTAINERS
-@@ -22278,6 +22278,8 @@ L:	linux-rockchip@lists.infradead.org
- L:	linux-pwm@vger.kernel.org
- S:	Maintained
- F:	Documentation/devicetree/bindings/pwm/rockchip,rk3576-pwm.yaml
-+F:	drivers/soc/rockchip/mfpwm.c
-+F:	include/soc/rockchip/mfpwm.h
- 
- ROCKCHIP RK3568 RANDOM NUMBER GENERATOR SUPPORT
- M:	Daniel Golle <daniel@makrotopia.org>
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 6cec1858947b..8fdc23adf7a3 100644
+index 111111111111..222222222222 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
-@@ -1350,6 +1350,21 @@ config MFD_RC5T583
+@@ -1361,6 +1361,21 @@ config MFD_RC5T583
  	  Additional drivers must be enabled in order to use the
  	  different functionality of the device.
  
@@ -82,7 +63,7 @@ index 6cec1858947b..8fdc23adf7a3 100644
  	tristate
  	select MFD_CORE
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index 865e9f12faff..af79d24abd5b 100644
+index 111111111111..222222222222 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
 @@ -230,6 +230,7 @@ obj-$(CONFIG_MFD_PALMAS)	+= palmas.o
@@ -95,7 +76,7 @@ index 865e9f12faff..af79d24abd5b 100644
  obj-$(CONFIG_MFD_RK8XX_SPI)	+= rk8xx-spi.o
 diff --git a/drivers/mfd/rockchip-mfpwm.c b/drivers/mfd/rockchip-mfpwm.c
 new file mode 100644
-index 000000000000..08c2d8da41b7
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/mfd/rockchip-mfpwm.c
 @@ -0,0 +1,340 @@
@@ -441,7 +422,7 @@ index 000000000000..08c2d8da41b7
 +MODULE_LICENSE("GPL");
 diff --git a/include/linux/mfd/rockchip-mfpwm.h b/include/linux/mfd/rockchip-mfpwm.h
 new file mode 100644
-index 000000000000..78d9c3396f7e
+index 000000000000..111111111111
 --- /dev/null
 +++ b/include/linux/mfd/rockchip-mfpwm.h
 @@ -0,0 +1,454 @@
@@ -900,5 +881,5 @@ index 000000000000..78d9c3396f7e
 +
 +#endif /* __SOC_ROCKCHIP_MFPWM_H__ */
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/rk3576-0006-pwm-rockchip-pwmv4-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3576-0006-pwm-rockchip-pwmv4-driver.patch
@@ -1,7 +1,7 @@
-From 2d916c20738623f5fca2b9dc1965f63ecf3bf287 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
 Date: Mon, 27 Oct 2025 18:11:58 +0100
-Subject: [PATCH] pwm: Add rockchip PWMv4 driver
+Subject: pwm: Add rockchip PWMv4 driver
 
 The Rockchip RK3576 brings with it a new PWM IP, in downstream code
 referred to as "v4". This new IP is different enough from the previous
@@ -16,27 +16,13 @@ this specific hardware IP do not interfere with each other.
 
 Signed-off-by: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
 ---
- MAINTAINERS                   |   1 +
- drivers/pwm/Kconfig           |  13 ++
+ drivers/pwm/Kconfig           |  13 +
  drivers/pwm/Makefile          |   1 +
- drivers/pwm/pwm-rockchip-v4.c | 353 ++++++++++++++++++++++++++++++++++
- 4 files changed, 368 insertions(+)
- create mode 100644 drivers/pwm/pwm-rockchip-v4.c
+ drivers/pwm/pwm-rockchip-v4.c | 353 ++++++++++
+ 3 files changed, 367 insertions(+)
 
-diff --git a/MAINTAINERS b/MAINTAINERS
-index e9117452179e..e965dcef034e 100644
---- a/MAINTAINERS
-+++ b/MAINTAINERS
-@@ -22278,6 +22278,7 @@ L:	linux-rockchip@lists.infradead.org
- L:	linux-pwm@vger.kernel.org
- S:	Maintained
- F:	Documentation/devicetree/bindings/pwm/rockchip,rk3576-pwm.yaml
-+F:	drivers/pwm/pwm-rockchip-v4.c
- F:	drivers/soc/rockchip/mfpwm.c
- F:	include/soc/rockchip/mfpwm.h
- 
 diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
-index c2fd3f4b62d9..b852a7b2a29d 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pwm/Kconfig
 +++ b/drivers/pwm/Kconfig
 @@ -615,6 +615,19 @@ config PWM_ROCKCHIP
@@ -60,7 +46,7 @@ index c2fd3f4b62d9..b852a7b2a29d 100644
  	tristate "Samsung PWM support"
  	depends on PLAT_SAMSUNG || ARCH_S5PV210 || ARCH_EXYNOS || COMPILE_TEST
 diff --git a/drivers/pwm/Makefile b/drivers/pwm/Makefile
-index dfa8b4966ee1..fe0d16558d99 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pwm/Makefile
 +++ b/drivers/pwm/Makefile
 @@ -55,6 +55,7 @@ obj-$(CONFIG_PWM_RENESAS_RZG2L_GPT)	+= pwm-rzg2l-gpt.o
@@ -73,7 +59,7 @@ index dfa8b4966ee1..fe0d16558d99 100644
  obj-$(CONFIG_PWM_SL28CPLD)	+= pwm-sl28cpld.o
 diff --git a/drivers/pwm/pwm-rockchip-v4.c b/drivers/pwm/pwm-rockchip-v4.c
 new file mode 100644
-index 000000000000..7afa83f12b6a
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/pwm/pwm-rockchip-v4.c
 @@ -0,0 +1,353 @@
@@ -431,5 +417,5 @@ index 000000000000..7afa83f12b6a
 +MODULE_IMPORT_NS("ROCKCHIP_MFPWM");
 +MODULE_ALIAS("platform:pwm-rockchip-v4");
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/rk3576-0007-counter-rockchip-pwm-capture-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3576-0007-counter-rockchip-pwm-capture-driver.patch
@@ -1,7 +1,7 @@
-From 27367df8bebf7641bba3b27e29200357feb49854 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
 Date: Mon, 27 Oct 2025 18:11:59 +0100
-Subject: [PATCH] counter: Add rockchip-pwm-capture driver
+Subject: counter: Add rockchip-pwm-capture driver
 
 Among many other things, Rockchip's new PWMv4 IP in the RK3576 supports
 PWM capture functionality.
@@ -15,27 +15,13 @@ without them interfering with each other.
 
 Signed-off-by: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
 ---
- MAINTAINERS                            |   1 +
- drivers/counter/Kconfig                |  13 ++
+ drivers/counter/Kconfig                |  13 +
  drivers/counter/Makefile               |   1 +
- drivers/counter/rockchip-pwm-capture.c | 306 +++++++++++++++++++++++++
- 4 files changed, 321 insertions(+)
- create mode 100644 drivers/counter/rockchip-pwm-capture.c
+ drivers/counter/rockchip-pwm-capture.c | 306 ++++++++++
+ 3 files changed, 320 insertions(+)
 
-diff --git a/MAINTAINERS b/MAINTAINERS
-index e965dcef034e..16c6434bd37d 100644
---- a/MAINTAINERS
-+++ b/MAINTAINERS
-@@ -22278,6 +22278,7 @@ L:	linux-rockchip@lists.infradead.org
- L:	linux-pwm@vger.kernel.org
- S:	Maintained
- F:	Documentation/devicetree/bindings/pwm/rockchip,rk3576-pwm.yaml
-+F:	drivers/counter/rockchip-pwm-capture.c
- F:	drivers/pwm/pwm-rockchip-v4.c
- F:	drivers/soc/rockchip/mfpwm.c
- F:	include/soc/rockchip/mfpwm.h
 diff --git a/drivers/counter/Kconfig b/drivers/counter/Kconfig
-index d30d22dfe577..12e823dd0ec7 100644
+index 111111111111..222222222222 100644
 --- a/drivers/counter/Kconfig
 +++ b/drivers/counter/Kconfig
 @@ -90,6 +90,19 @@ config MICROCHIP_TCB_CAPTURE
@@ -59,7 +45,7 @@ index d30d22dfe577..12e823dd0ec7 100644
  	tristate "Renesas RZ/G2L MTU3a counter driver"
  	depends on RZ_MTU3
 diff --git a/drivers/counter/Makefile b/drivers/counter/Makefile
-index fa3c1d08f706..2bfcfc2c584b 100644
+index 111111111111..222222222222 100644
 --- a/drivers/counter/Makefile
 +++ b/drivers/counter/Makefile
 @@ -17,3 +17,4 @@ obj-$(CONFIG_FTM_QUADDEC)	+= ftm-quaddec.o
@@ -69,7 +55,7 @@ index fa3c1d08f706..2bfcfc2c584b 100644
 +obj-$(CONFIG_ROCKCHIP_PWM_CAPTURE)	+= rockchip-pwm-capture.o
 diff --git a/drivers/counter/rockchip-pwm-capture.c b/drivers/counter/rockchip-pwm-capture.c
 new file mode 100644
-index 000000000000..63e1286303f9
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/counter/rockchip-pwm-capture.c
 @@ -0,0 +1,306 @@
@@ -380,5 +366,5 @@ index 000000000000..63e1286303f9
 +MODULE_IMPORT_NS("COUNTER");
 +MODULE_ALIAS("platform:rockchip-pwm-capture");
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/rk3576-0008-arm64-dts-rk3576-add-pwm-nodes.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3576-0008-arm64-dts-rk3576-add-pwm-nodes.patch
@@ -1,7 +1,7 @@
-From 859ea127641e14e58688f3699be5d6ba55daf2bb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
 Date: Mon, 27 Oct 2025 18:12:00 +0100
-Subject: [PATCH] arm64: dts: rockchip: add PWM nodes to RK3576 SoC dtsi
+Subject: arm64: dts: rockchip: add PWM nodes to RK3576 SoC dtsi
 
 The RK3576 SoC features three distinct PWM controllers, with variable
 numbers of channels. Add each channel as a separate node to the SoC's
@@ -9,11 +9,11 @@ device tree, as they don't really overlap in register ranges.
 
 Signed-off-by: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3576.dtsi | 208 +++++++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3576.dtsi | 208 ++++++++++
  1 file changed, 208 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576.dtsi b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
-index c72343e7a045..f118be020cbc 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
 @@ -1030,6 +1030,32 @@ uart1: serial@27310000 {
@@ -49,7 +49,7 @@ index c72343e7a045..f118be020cbc 100644
  		pmu: power-management@27380000 {
  			compatible = "rockchip,rk3576-pmu", "syscon", "simple-mfd";
  			reg = <0x0 0x27380000 0x0 0x800>;
-@@ -2480,6 +2506,188 @@ uart9: serial@2adc0000 {
+@@ -2515,6 +2541,188 @@ uart9: serial@2adc0000 {
  			status = "disabled";
  		};
  
@@ -239,5 +239,5 @@ index c72343e7a045..f118be020cbc 100644
  			compatible = "rockchip,rk3576-saradc", "rockchip,rk3588-saradc";
  			reg = <0x0 0x2ae00000 0x0 0x10000>;
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/rk3576-0009-arm64-dts-rk3576-add-dma-coherent-pcie-gmac.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3576-0009-arm64-dts-rk3576-add-dma-coherent-pcie-gmac.patch
@@ -1,8 +1,7 @@
-From 7f1a1145ef39a8dfb196c9b66996408af86b7f55 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shawn Lin <shawn.lin@rock-chips.com>
 Date: Fri, 28 Nov 2025 15:09:22 +0800
-Subject: [PATCH] arm64: dts: rockchip: add dma-coherent for pcie and gmac of
- RK3576
+Subject: arm64: dts: rockchip: add dma-coherent for pcie and gmac of RK3576
 
 The RK3576 SoC employs ARM CCI for maintaining cache coherency
 between the CPU cluster and high-speed peripherals including USB3,
@@ -24,7 +23,7 @@ Signed-off-by: Shawn Lin <shawn.lin@rock-chips.com>
  1 file changed, 4 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576.dtsi b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
-index f118be020cbc..c24a07bb7a19 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
 @@ -709,6 +709,7 @@ pcie0: pcie@22000000 {
@@ -43,7 +42,7 @@ index f118be020cbc..c24a07bb7a19 100644
  			status = "disabled";
  
  			pcie1_intc: legacy-interrupt-controller {
-@@ -1735,6 +1737,7 @@ gmac0: ethernet@2a220000 {
+@@ -1770,6 +1772,7 @@ gmac0: ethernet@2a220000 {
  			snps,mtl-rx-config = <&gmac0_mtl_rx_setup>;
  			snps,mtl-tx-config = <&gmac0_mtl_tx_setup>;
  			snps,tso;
@@ -51,7 +50,7 @@ index f118be020cbc..c24a07bb7a19 100644
  			status = "disabled";
  
  			mdio0: mdio {
-@@ -1782,6 +1785,7 @@ gmac1: ethernet@2a230000 {
+@@ -1817,6 +1820,7 @@ gmac1: ethernet@2a230000 {
  			snps,mtl-rx-config = <&gmac1_mtl_rx_setup>;
  			snps,mtl-tx-config = <&gmac1_mtl_tx_setup>;
  			snps,tso;
@@ -60,5 +59,5 @@ index f118be020cbc..c24a07bb7a19 100644
  
  			mdio1: mdio {
 -- 
-2.53.0
+Armbian
 


### PR DESCRIPTION
as per title
build test pending but will probably be fine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added USB controller and PHY support for RK3528 SoC.
  * Added I2S master clock output support for RK3588 audio interface.
  * Added PWM and PWM capture controller support for RK3576.
  * Added configurable PCIe bus scan delay feature.
  * Added DMA coherency support for PCIe and Ethernet controllers on RK3576.

* **Bug Fixes**
  * Improved SError handling for RK3399 PCIe bus enumeration.
  * Enhanced power domain management with always-on support.
  * Improved MMC tuning algorithm for RK3576.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->