### PR TITLE
docker/riscv64: fix cross-compiler availability for generate-dockerfile

### DIFF
--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -16,6 +16,12 @@ enable_extension "c-plus-plus-compiler"
 # The BLx stuff requires 32-bit compiler, add it using an inline hook.
 # This is only used for non-Docker, since the Docker image already has it, since it includes compilers for all architectures.
 function add_host_dependencies__mvebu64_add_32_bit_c_compiler() {
+	# Skip cross-compilers that don't exist on non-standard host architectures (e.g., riscv64)
+	if [[ "${host_arch}" == "riscv64" ]]; then
+		display_alert "Skipping mvebu64 32-bit compiler" "gcc-arm-linux-gnueabi not available on ${host_arch}" "warn"
+		return 0
+	fi
+
 	display_alert "Adding armhf C compiler to host dependencies" "for mvebu64 BLx compile" "debug"
 	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} gcc-arm-linux-gnueabi" # @TODO: convert to array later
 }

--- a/extensions/arm64-compat-vdso.sh
+++ b/extensions/arm64-compat-vdso.sh
@@ -23,6 +23,12 @@ function extension_prepare_config__arm64_compat_vdso() {
 }
 
 function add_host_dependencies__arm64_compat_vdso() {
+	# Skip cross-compilers that don't exist on non-standard host architectures (e.g., riscv64)
+	if [[ "${host_arch}" == "riscv64" ]]; then
+		display_alert "Skipping arm64-compat-vdso extension" "gcc-arm-linux-gnueabi not available on ${host_arch}" "warn"
+		return 0
+	fi
+
 	if [[ "${KERNEL_COMPILER}" == "clang" ]]; then
 		EXTRA_BUILD_DEPS+=("clang::clang")
 	else

--- a/extensions/c-plus-plus-compiler.sh
+++ b/extensions/c-plus-plus-compiler.sh
@@ -12,3 +12,14 @@ function add_host_dependencies__add_arm64_c_plus_plus_compiler() {
 	# Always add the native g++ compiler
 	EXTRA_BUILD_DEPS+=("native-toolchain::g++")
 }
+
+function host_dependencies_ready__add_arm64_c_plus_plus_compiler() {
+	# The arm64 c++ cross-compiler is only declared on hosts where it exists (see above),
+	# so only assert its presence there. Fail fast if it was requested but not installed.
+	if [[ "${host_arch}" != "riscv64" ]]; then
+		# The g++-aarch64-linux-gnu package installs the binary as aarch64-linux-gnu-g++.
+		if ! command -v aarch64-linux-gnu-g++ > /dev/null 2>&1 && ! command -v g++-aarch64-linux-gnu > /dev/null 2>&1; then
+			exit_with_error "Missing arm64 c++ cross-compiler 'aarch64-linux-gnu-g++'; install g++-aarch64-linux-gnu"
+		fi
+	fi
+}

--- a/extensions/c-plus-plus-compiler.sh
+++ b/extensions/c-plus-plus-compiler.sh
@@ -3,5 +3,12 @@
 
 function add_host_dependencies__add_arm64_c_plus_plus_compiler() {
 	display_alert "Extension: ${EXTENSION}: Adding arm64 c++ compiler to host dependencies" "g++" "debug"
-	EXTRA_BUILD_DEPS+=("cross-arm64::g++-aarch64-linux-gnu" "native-toolchain::g++")
+
+	# Skip cross-compilers that don't exist on non-standard host architectures (e.g. riscv64)
+	if [[ "${host_arch}" != "riscv64" ]]; then
+		EXTRA_BUILD_DEPS+=("cross-arm64::g++-aarch64-linux-gnu")
+	fi
+
+	# Always add the native g++ compiler
+	EXTRA_BUILD_DEPS+=("native-toolchain::g++")
 }

--- a/extensions/sunxi-tools.sh
+++ b/extensions/sunxi-tools.sh
@@ -3,6 +3,12 @@
 # Most sunxi stuff, even if 64-bit, requires 32-bit compiler, add it.
 # This is only used for non-Docker, since the Docker image already has it, since it includes compilers for all architectures.
 function add_host_dependencies__sunxi_add_32_bit_c_compiler() {
+	# Skip cross-compilers that don't exist on non-standard host architectures (e.g., riscv64)
+	if [[ "${host_arch}" == "riscv64" ]]; then
+		display_alert "Skipping sunxi 32-bit compiler" "gcc-arm-linux-gnueabi not available on ${host_arch}" "warn"
+		return 0
+	fi
+
 	display_alert "Adding armhf C compiler to host dependencies" "for sunxi bootloader compile" "debug"
 	EXTRA_BUILD_DEPS+=("cross-armhf::gcc-arm-linux-gnueabi")
 }

--- a/lib/functions/compilation/kernel-make.sh
+++ b/lib/functions/compilation/kernel-make.sh
@@ -131,6 +131,16 @@ function kernel_determine_toolchain() {
 	else
 		kernel_compiler_full="${KERNEL_COMPILER}gcc"
 	fi
+
+	# Fail fast with a readable message if the (cross-)compiler is missing, instead of
+	# letting the '-dumpversion' invocation below die with a cryptic
+	# "env: '${kernel_compiler_full}': No such file or directory" (Error 127). The common
+	# case is cross-building a target whose toolchain is unavailable on this host - e.g. an
+	# arm64 target on a riscv64 host, where gcc-aarch64-linux-gnu is not in the repositories.
+	if ! eval command -v "${kernel_compiler_full}" > /dev/null 2>&1; then
+		exit_with_error "Kernel compiler '${kernel_compiler_full}' not found for target ${ARCH} on host $(dpkg --print-architecture); its cross-toolchain is likely unavailable for this host architecture. Build on a supported host, use a Docker build, or install the toolchain."
+	fi
+
 	kernel_compiler_version="$(eval env "${kernel_compiler_full}" -dumpfullversion -dumpversion)"
 	display_alert "Compiler version" "${kernel_compiler_full} ${kernel_compiler_version}" "info"
 }

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -349,8 +349,11 @@ function docker_cli_prepare_dockerfile() {
 	fi
 	declare -a -g host_dependencies=()
 
-	host_release="${DOCKER_WANTED_RELEASE}" early_prepare_host_dependencies # hooks: add_host_dependencies // host_dependencies_known
-	display_alert "Pre-game host dependencies for host_release '${DOCKER_WANTED_RELEASE}'" "${host_dependencies[*]}" "debug"
+	# Get the actual host architecture for proper cross-compiler selection
+	declare host_arch
+	host_arch="$(dpkg --print-architecture)"
+	host_release="${DOCKER_WANTED_RELEASE}" host_arch="${host_arch}" early_prepare_host_dependencies # hooks: add_host_dependencies // host_dependencies_known
+	display_alert "Pre-game host dependencies for host_release '${DOCKER_WANTED_RELEASE}' host_arch '${host_arch}'" "${host_dependencies[*]}" "debug"
 
 	# This includes apt install equivalent to install_host_dependencies()
 	display_alert "Creating" "Dockerfile; FROM ${DOCKER_ARMBIAN_BASE_IMAGE}" "info"

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -250,19 +250,23 @@ function adaptative_prepare_host_dependencies() {
 	declare wanted_arch="${target_arch:-"all"}"
 
 	# Cross-toolchains are split per target family so each lands in a similarly-sized layer.
-	if [[ "${wanted_arch}" == "amd64" || "${wanted_arch}" == "all" ]]; then
-		host_dependencies+=("cross-amd64::gcc-x86-64-linux-gnu") # from crossbuild-essential-amd64
-	fi
+	# Skip cross-compilers that don't exist on non-standard host architectures (e.g. riscv64),
+	# where only riscv64 cross-compilers are available in the repositories.
+	if [[ "${host_arch}" != "riscv64" ]]; then
+		if [[ "${wanted_arch}" == "amd64" || "${wanted_arch}" == "all" ]]; then
+			host_dependencies+=("cross-amd64::gcc-x86-64-linux-gnu") # from crossbuild-essential-amd64
+		fi
 
-	if [[ "${wanted_arch}" == "arm64" || "${wanted_arch}" == "all" ]]; then
-		# gcc-aarch64-linux-gnu: from crossbuild-essential-arm64 (64-bit arm)
-		host_dependencies+=("cross-arm64::gcc-aarch64-linux-gnu")
-		# gcc-arm-linux-gnueabi: necessary for rockchip64 (and maybe other too) ATF compilation (32-bit arm)
-		host_dependencies+=("cross-armhf::gcc-arm-linux-gnueabi")
-	fi
+		if [[ "${wanted_arch}" == "arm64" || "${wanted_arch}" == "all" ]]; then
+			# gcc-aarch64-linux-gnu: from crossbuild-essential-arm64 (64-bit arm)
+			host_dependencies+=("cross-arm64::gcc-aarch64-linux-gnu")
+			# gcc-arm-linux-gnueabi: necessary for rockchip64 (and maybe other too) ATF compilation (32-bit arm)
+			host_dependencies+=("cross-armhf::gcc-arm-linux-gnueabi")
+		fi
 
-	if [[ "${wanted_arch}" == "armhf" || "${wanted_arch}" == "all" ]]; then
-		host_dependencies+=("cross-armhf::gcc-arm-linux-gnueabihf") # from crossbuild-essential-armhf crossbuild-essential-armel
+		if [[ "${wanted_arch}" == "armhf" || "${wanted_arch}" == "all" ]]; then
+			host_dependencies+=("cross-armhf::gcc-arm-linux-gnueabihf") # from crossbuild-essential-armhf crossbuild-essential-armel
+		fi
 	fi
 
 	if [[ "${wanted_arch}" == "riscv64" || "${wanted_arch}" == "all" ]]; then
@@ -275,7 +279,8 @@ function adaptative_prepare_host_dependencies() {
 		host_dependencies+=("cross-other::debian-ports-archive-keyring")
 	fi
 
-	if [[ "${wanted_arch}" != "amd64" ]]; then
+	# libc6-amd64-cross is not available on riscv64 hosts
+	if [[ "${wanted_arch}" != "amd64" ]] && [[ "${host_arch}" != "riscv64" ]]; then
 		host_dependencies+=("cross-amd64::libc6-amd64-cross") # Support for running x86 binaries (under qemu on other arches)
 	fi
 


### PR DESCRIPTION
## Summary
Fix `./compile.sh generate-dockerfile` failures on native RISC-V hosts by properly detecting host architecture and skipping cross-compiler packages that don't exist in RISC-V package repositories.

## Bugs

Loop devices problem (has been reported upstream):
https://github.com/armbian/os/actions/runs/23560017249/job/68609709451

## Referremce

https://github.com/armbian/docker-armbian-build/pull/13

## Problem
When running `generate-dockerfile` on RISC-V hosts, the build fails with errors like:
```
E: Package 'gcc-x86-64-linux-gnu' has no installation candidate
E: Package 'gcc-aarch64-linux-gnu' has no installation candidate
E: Package 'gcc-arm-linux-gnueabi' has no installation candidate
```

This occurs because:
1. Cross-compiler packages for x86-64, ARM64, and ARMHF don't exist in Debian/Ubuntu RISC-V repositories
2. The host architecture wasn't being detected or passed to dependency resolution
3. Extensions were unconditionally adding cross-compilers without checking host architecture

## Solution
- **docker.sh**: Detect host architecture using `dpkg --print-architecture` and pass it to dependency resolution functions
- **prepare-host.sh**: Check `host_arch` and skip cross-compilers unavailable on RISC-V (x86-64, ARM64, ARMHF)
- **Extensions** (c-plus-plus-compiler, arm64-compat-vdso, sunxi-tools): Check `host_arch` and skip unavailable cross-compilers on RISC-V

## Why This Matters
This fix enables Armbian to build properly on RISC-V hardware, which is important for:

1. **RISE RISC-V Runners** - Free GitHub Actions runner service providing bare-metal RISC-V CI (Scaleway EM-RV1)
   - Org: https://lnkd.in/eKhqR4Bn
   - Personal: https://lnkd.in/eNSeKfZX
   - Usage: `runs-on: ubuntu-24.04-riscv`

2. **Native RISC-V Development** - Developers can now build Armbian images natively on RISC-V workstations

3. **Multi-Arch CI/CD** - Enables testing on real RISC-V hardware instead of QEMU emulation

## Test plan
- [x] Run `./compile.sh generate-dockerfile` on native RISC-V host
- [x] Verify Dockerfile builds without cross-compiler errors
- [x] Test with RISE RISC-V Runners (ubuntu-24.04-riscv)
- [ ] Verify Armbian builds succeed on RISC-V hardware

## Files changed
- `lib/functions/host/docker.sh` - Detect and pass host architecture
- `lib/functions/host/prepare-host.sh` - Skip unavailable cross-compilers
- `extensions/c-plus-plus-compiler.sh` - Architecture-aware dependency addition
- `extensions/arm64-compat-vdso.sh` - Architecture-aware dependency addition
- `extensions/sunxi-tools.sh` - Architecture-aware dependency addition


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for RISC-V 64-bit host systems with improved architecture detection.

* **Chores**
  * Optimized build dependencies to conditionally exclude unnecessary cross-compiler packages on RISC-V hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->