### PR TITLE
fix: armbian-resize-filesystem diskdevname fallback for /dev/sda* devices

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
+++ b/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
@@ -25,7 +25,7 @@ do_expand_partition()
 
 	local diskdevname=$(lsblk -n -d -o PKNAME $partdev) # i.e. mmcblk0 or sda
 	# due to the bug in util-linux 2.34 which fails to show device, let's use this failover:
-	[[ -z $diskdevname ]] && diskdevname=$(echo $partdev | sed -e "s/^\/dev\///" | sed "s/p.*//")
+	[[ -z $diskdevname ]] && diskdevname=$(echo $partdev | sed -e "s/^\/dev\///" | sed -E 's/p?[0-9]+$//')
 	local diskdev="/dev/$diskdevname" # i.e. /dev/mmcblk0, /dev/sda
 	echo "diskdevname: $diskdevname"
 	echo "diskdev: $diskdev"


### PR DESCRIPTION
## Summary

Fixes the sed fallback regex in `armbian-resize-filesystem` that incorrectly handles `/dev/sda*` style device names.

Fixes #9593

## Problem

The fallback path on line 28 uses `sed "s/p.*//"` to strip the partition suffix from device names. This works for devices using a "p" separator (`mmcblk0p2` -> `mmcblk0`, `nvme0n1p1` -> `nvme0n1`) but fails for SCSI/SATA/virtio devices (`sda2` stays `sda2` because there is no "p").

## Fix

Replace with `sed -E 's/p?[0-9]+$//'` which strips an optional "p" followed by trailing digits:

| Input | Old result | New result |
|-------|-----------|------------|
| `mmcblk0p2` | `mmcblk0` | `mmcblk0` |
| `nvme0n1p1` | `nvme0n1` | `nvme0n1` |
| `sda2` | `sda2` (wrong) | `sda` |
| `vda3` | `vda3` (wrong) | `vda` |

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem resize fallback logic to more accurately detect block devices, increasing reliability when standard detection methods are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->