### PR TITLE
framework artifact-rootfs - remove the last vestige of LEGACY_DEBOOTSTRAP

### DIFF
--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -15,7 +15,6 @@ function artifact_rootfs_config_dump() {
 	artifact_input_variables[DESKTOP_ENVIRONMENT]="${DESKTOP_ENVIRONMENT:-"no_DESKTOP_ENVIRONMENT_set"}"
 	artifact_input_variables[DESKTOP_ENVIRONMENT_CONFIG_NAME]="${DESKTOP_ENVIRONMENT_CONFIG_NAME:-"no_DESKTOP_ENVIRONMENT_CONFIG_NAME_set"}"
 	artifact_input_variables[DESKTOP_APPGROUPS_SELECTED]="${DESKTOP_APPGROUPS_SELECTED:-"no_DESKTOP_APPGROUPS_SELECTED_set"}"
-	artifact_input_variables[LEGACY_DEBOOTSTRAP]="${LEGACY_DEBOOTSTRAP:-"no"}"
 	# Hash of the packages added/removed by extensions
 	declare pkgs_hash="undetermined"
 	pkgs_hash="$(echo "${REMOVE_PACKAGES[*]} ${EXTRA_PACKAGES_ROOTFS[*]} ${PACKAGE_LIST_BOARD_REMOVE} ${PACKAGE_LIST_FAMILY_REMOVE}" | sha256sum | cut -d' ' -f1)"


### PR DESCRIPTION
# Description

This removes a small piece leftover from #9512 
This shouldn't have any interesting effects, but *possibly* it will break/fix the rootfs caching?

```
19:48:10 <+DC-IRC> [Discord] <igorpec> tabris: i have a feeling that rootfs caching doesn't work.
19:50:56 <+DC-IRC> [Discord] <igorpec> https://github.com/armbian/os/actions/runs/23569530304/job/68630175655 example. recreating locally will go into rebuild
19:52:22 <+DC-IRC> [Discord] <igorpec> still investigating ...
```
# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ ] Test A
- [ ] Test B

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed legacy configuration variable handling from the artifact generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->