### PR TITLE
mkspi: fix devicetree opp voltage settings

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3328-mkspi.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3328-mkspi.dts
@@ -290,6 +290,21 @@
 	mali-supply = <&vdd_logic>;
 };
 
+&gpu_opp_table {
+	opp-200000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-300000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-400000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-500000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+};
+
 &hdmi {
 	interrupts = <GIC_SPI 35 IRQ_TYPE_LEVEL_HIGH>,
 		     <GIC_SPI 71 IRQ_TYPE_LEVEL_HIGH>;

--- a/patch/kernel/archive/rockchip64-7.0/dt/rk3328-mkspi.dts
+++ b/patch/kernel/archive/rockchip64-7.0/dt/rk3328-mkspi.dts
@@ -290,6 +290,21 @@
 	mali-supply = <&vdd_logic>;
 };
 
+&gpu_opp_table {
+	opp-200000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-300000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-400000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+	opp-500000000 {
+		opp-microvolt = <1050000 950000 1200000>;
+	};
+};
+
 &hdmi {
 	interrupts = <GIC_SPI 35 IRQ_TYPE_LEVEL_HIGH>,
 		     <GIC_SPI 71 IRQ_TYPE_LEVEL_HIGH>;


### PR DESCRIPTION
# Description

Fix for `vdd_logic: Failed to set regulator voltages: -22` bug (starting from 6.18 kernel)

With reference to:
- https://github.com/armbian/build/pull/9569
- https://github.com/redrathnure/armbian-mkspi/issues/66


[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]


# How Has This Been Tested?

Run `sudo dmesg | grep lima` and ensure no errors.

- [x] mkspi + TS35 screen + 6.18 Noble image
- [x] mkspi + TS35 screen + 7.0 Noble image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GPU operating-point voltage entries for Rockchip RK3328 devices to refine voltages across multiple frequency levels, improving power efficiency, thermal behavior, and stability during graphics-heavy workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->