### PR TITLE
families: sm8550: Limit kernel version to 6.18.18

### DIFF
--- a/config/sources/families/sm8550.conf
+++ b/config/sources/families/sm8550.conf
@@ -16,13 +16,13 @@ enable_extension "image-output-abl"
 case $BRANCH in
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH='branch:linux-6.18.y'
+		declare -g KERNELBRANCH='tag:v6.18.18'
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH='branch:linux-6.18.y'
+		declare -g KERNELBRANCH='tag:v6.18.18'
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		;;
 


### PR DESCRIPTION
# Description

This is a workaround for issue https://forum.armbian.com/topic/58748-cannot-complete-first-boot-wizard/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Kernel source version updated to 6.18.18 across all branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->