### PR TITLE
rockchip64: fix USB gadget NULL pointer crash in eth_get_drvinfo (6.18 + 7.0)

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/general-usb-gadget-fix-dangling-pointer-in-netdev-private-data.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-usb-gadget-fix-dangling-pointer-in-netdev-private-data.patch
@@ -1,0 +1,269 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megi@xff.cz>
+Date: Thu, 7 Sep 2023 14:07:26 +0200
+Subject: usb: gadget: Fix dangling pointer in netdev private data
+
+Some USB drivers destroy and re-create the gadget regularly. This
+leads to stale gadget pointer in gether_* using USB gadget functions
+(ecm, eem, rndis, etc.).
+
+Don't parent the netdev to the gadget device, and set gadget to
+NULL in function unbind callback, to avoid potential use-after-free
+issues.
+
+Note: f_ncm.c is excluded because mainline already handles gadget
+lifecycle via gether_attach_gadget()/gether_detach_gadget().
+
+Signed-off-by: Ondrej Jirman <megi@xff.cz>
+---
+ drivers/usb/gadget/function/f_ecm.c    | 12 ++---
+ drivers/usb/gadget/function/f_eem.c    | 28 +++++------
+ drivers/usb/gadget/function/f_rndis.c  | 26 ++++------
+ drivers/usb/gadget/function/f_subset.c | 18 ++++---
+ drivers/usb/gadget/function/u_ether.c  | 10 ++--
+ 5 files changed, 47 insertions(+), 47 deletions(-)
+
+diff --git a/drivers/usb/gadget/function/f_ecm.c b/drivers/usb/gadget/function/f_ecm.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/gadget/function/f_ecm.c
++++ b/drivers/usb/gadget/function/f_ecm.c
+@@ -689,14 +689,12 @@ ecm_bind(struct usb_configuration *c, struct usb_function *f)
+ 	ecm_opts = container_of(f->fi, struct f_ecm_opts, func_inst);
+
+ 	mutex_lock(&ecm_opts->lock);
+-
+ 	gether_set_gadget(ecm_opts->net, cdev->gadget);
+-
+ 	if (!ecm_opts->bound) {
+ 		status = gether_register_netdev(ecm_opts->net);
+-		ecm_opts->bound = true;
++		if (!status)
++			ecm_opts->bound = true;
+ 	}
+-
+ 	mutex_unlock(&ecm_opts->lock);
+ 	if (status)
+ 		return status;
+@@ -905,7 +903,9 @@ static void ecm_free(struct usb_function *f)
+
+ static void ecm_unbind(struct usb_configuration *c, struct usb_function *f)
+ {
+-	struct f_ecm		*ecm = func_to_ecm(f);
++	struct f_ecm *ecm = func_to_ecm(f);
++	struct f_ecm_opts *opts = container_of(f->fi, struct f_ecm_opts,
++					       func_inst);
+
+ 	DBG(c->cdev, "ecm unbind\n");
+
+@@ -918,6 +918,8 @@ static void ecm_unbind(struct usb_configuration *c, struct usb_function *f)
+
+ 	kfree(ecm->notify_req->buf);
+ 	usb_ep_free_request(ecm->notify, ecm->notify_req);
++
++	gether_set_gadget(opts->net, NULL);
+ }
+
+ static struct usb_function *ecm_alloc(struct usb_function_instance *fi)
+diff --git a/drivers/usb/gadget/function/f_eem.c b/drivers/usb/gadget/function/f_eem.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/gadget/function/f_eem.c
++++ b/drivers/usb/gadget/function/f_eem.c
+@@ -247,28 +247,23 @@ static int eem_bind(struct usb_configuration *c, struct usb_function *f)
+ 	struct usb_composite_dev *cdev = c->cdev;
+ 	struct f_eem		*eem = func_to_eem(f);
+ 	struct usb_string	*us;
+-	int			status;
++	int			status = 0;
+ 	struct usb_ep		*ep;
+
+ 	struct f_eem_opts	*eem_opts;
+
+ 	eem_opts = container_of(f->fi, struct f_eem_opts, func_inst);
+-	/*
+-	 * in drivers/usb/gadget/configfs.c:configfs_composite_bind()
+-	 * configurations are bound in sequence with list_for_each_entry,
+-	 * in each configuration its functions are bound in sequence
+-	 * with list_for_each_entry, so we assume no race condition
+-	 * with regard to eem_opts->bound access
+-	 */
++
++	mutex_lock(&eem_opts->lock);
++	gether_set_gadget(eem_opts->net, cdev->gadget);
+ 	if (!eem_opts->bound) {
+-		mutex_lock(&eem_opts->lock);
+-		gether_set_gadget(eem_opts->net, cdev->gadget);
+ 		status = gether_register_netdev(eem_opts->net);
+-		mutex_unlock(&eem_opts->lock);
+-		if (status)
+-			return status;
+-		eem_opts->bound = true;
++		if (!status)
++			eem_opts->bound = true;
+ 	}
++	mutex_unlock(&eem_opts->lock);
++	if (status)
++		return status;
+
+ 	us = usb_gstrings_attach(cdev, eem_strings,
+ 				 ARRAY_SIZE(eem_string_defs));
+@@ -640,9 +635,14 @@ static void eem_free(struct usb_function *f)
+
+ static void eem_unbind(struct usb_configuration *c, struct usb_function *f)
+ {
++	struct f_eem_opts *opts = container_of(f->fi, struct f_eem_opts,
++					       func_inst);
++
+ 	DBG(c->cdev, "eem unbind\n");
+
+ 	usb_free_all_descriptors(f);
++
++	gether_set_gadget(opts->net, NULL);
+ }
+
+ static struct usb_function *eem_alloc(struct usb_function_instance *fi)
+diff --git a/drivers/usb/gadget/function/f_rndis.c b/drivers/usb/gadget/function/f_rndis.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/gadget/function/f_rndis.c
++++ b/drivers/usb/gadget/function/f_rndis.c
+@@ -660,7 +660,7 @@ rndis_bind(struct usb_configuration *c, struct usb_function *f)
+ 	struct usb_composite_dev *cdev = c->cdev;
+ 	struct f_rndis		*rndis = func_to_rndis(f);
+ 	struct usb_string	*us;
+-	int			status;
++	int			status = 0;
+ 	struct usb_ep		*ep;
+
+ 	struct f_rndis_opts *rndis_opts;
+@@ -682,20 +682,16 @@ rndis_bind(struct usb_configuration *c, struct usb_function *f)
+ 	rndis_iad_descriptor.bFunctionSubClass = rndis_opts->subclass;
+ 	rndis_iad_descriptor.bFunctionProtocol = rndis_opts->protocol;
+
+-	/*
+-	 * in drivers/usb/gadget/configfs.c:configfs_composite_bind()
+-	 * configurations are bound in sequence with list_for_each_entry,
+-	 * in each configuration its functions are bound in sequence
+-	 * with list_for_each_entry, so we assume no race condition
+-	 * with regard to rndis_opts->bound access
+-	 */
++	mutex_lock(&rndis_opts->lock);
++	gether_set_gadget(rndis_opts->net, cdev->gadget);
+ 	if (!rndis_opts->bound) {
+-		gether_set_gadget(rndis_opts->net, cdev->gadget);
+ 		status = gether_register_netdev(rndis_opts->net);
+-		if (status)
+-			return status;
+-		rndis_opts->bound = true;
++		if (!status)
++			rndis_opts->bound = true;
+ 	}
++	mutex_unlock(&rndis_opts->lock);
++	if (status)
++		return status;
+
+ 	us = usb_gstrings_attach(cdev, rndis_strings,
+ 				 ARRAY_SIZE(rndis_string_defs));
+@@ -939,7 +935,9 @@ static void rndis_free(struct usb_function *f)
+
+ static void rndis_unbind(struct usb_configuration *c, struct usb_function *f)
+ {
+-	struct f_rndis		*rndis = func_to_rndis(f);
++	struct f_rndis *rndis = func_to_rndis(f);
++	struct f_rndis_opts *opts = container_of(f->fi, struct f_rndis_opts,
++						 func_inst);
+
+ 	kfree(f->os_desc_table);
+ 	f->os_desc_n = 0;
+@@ -947,6 +945,8 @@ static void rndis_unbind(struct usb_configuration *c, struct usb_function *f)
+
+ 	kfree(rndis->notify_req->buf);
+ 	usb_ep_free_request(rndis->notify, rndis->notify_req);
++
++	gether_set_gadget(opts->net, NULL);
+ }
+
+ static struct usb_function *rndis_alloc(struct usb_function_instance *fi)
+diff --git a/drivers/usb/gadget/function/f_subset.c b/drivers/usb/gadget/function/f_subset.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/gadget/function/f_subset.c
++++ b/drivers/usb/gadget/function/f_subset.c
+@@ -308,15 +308,16 @@ geth_bind(struct usb_configuration *c, struct usb_function *f)
+ 	 * with list_for_each_entry, so we assume no race condition
+ 	 * with regard to gether_opts->bound access
+ 	 */
++	mutex_lock(&gether_opts->lock);
++	gether_set_gadget(gether_opts->net, cdev->gadget);
+ 	if (!gether_opts->bound) {
+-		mutex_lock(&gether_opts->lock);
+-		gether_set_gadget(gether_opts->net, cdev->gadget);
+ 		status = gether_register_netdev(gether_opts->net);
+-		mutex_unlock(&gether_opts->lock);
+-		if (status)
+-			return status;
+-		gether_opts->bound = true;
++		if (!status)
++			gether_opts->bound = true;
+ 	}
++	mutex_unlock(&gether_opts->lock);
++	if (status)
++		return status;
+
+ 	us = usb_gstrings_attach(cdev, geth_strings,
+ 				 ARRAY_SIZE(geth_string_defs));
+@@ -456,8 +457,13 @@ static void geth_free(struct usb_function *f)
+
+ static void geth_unbind(struct usb_configuration *c, struct usb_function *f)
+ {
++	struct f_gether_opts *opts = container_of(f->fi, struct f_gether_opts,
++						  func_inst);
++
+ 	geth_string_defs[0].id = 0;
+ 	usb_free_all_descriptors(f);
++
++	gether_set_gadget(opts->net, NULL);
+ }
+
+ static struct usb_function *geth_alloc(struct usb_function_instance *fi)
+diff --git a/drivers/usb/gadget/function/u_ether.c b/drivers/usb/gadget/function/u_ether.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/gadget/function/u_ether.c
++++ b/drivers/usb/gadget/function/u_ether.c
+@@ -112,8 +112,10 @@ static void eth_get_drvinfo(struct net_device *net, struct ethtool_drvinfo *p)
+
+ 	strscpy(p->driver, "g_ether", sizeof(p->driver));
+ 	strscpy(p->version, UETH__VERSION, sizeof(p->version));
+-	strscpy(p->fw_version, dev->gadget->name, sizeof(p->fw_version));
+-	strscpy(p->bus_info, dev_name(&dev->gadget->dev), sizeof(p->bus_info));
++	if (dev->gadget) {
++		strscpy(p->fw_version, dev->gadget->name, sizeof(p->fw_version));
++		strscpy(p->bus_info, dev_name(&dev->gadget->dev), sizeof(p->bus_info));
++	}
+ }
+
+ /* REVISIT can also support:
+@@ -787,7 +789,6 @@ struct eth_dev *gether_setup_name(struct usb_gadget *g,
+ 	net->max_mtu = GETHER_MAX_MTU_SIZE;
+
+ 	dev->gadget = g;
+-	SET_NETDEV_DEV(net, &g->dev);
+ 	SET_NETDEV_DEVTYPE(net, &gadget_type);
+
+ 	status = register_netdev(net);
+@@ -860,8 +861,6 @@ int gether_register_netdev(struct net_device *net)
+ 	struct usb_gadget *g;
+ 	int status;
+
+-	if (!net->dev.parent)
+-		return -EINVAL;
+ 	dev = netdev_priv(net);
+ 	g = dev->gadget;
+
+@@ -892,7 +891,6 @@ void gether_set_gadget(struct net_device *net, struct usb_gadget *g)
+
+ 	dev = netdev_priv(net);
+ 	dev->gadget = g;
+-	SET_NETDEV_DEV(net, &g->dev);
+ }
+ EXPORT_SYMBOL_GPL(gether_set_gadget);
+
+--
+Armbian

--- a/patch/kernel/archive/rockchip64-7.0/general-usb-gadget-fix-dangling-pointer-in-netdev-private-data.patch
+++ b/patch/kernel/archive/rockchip64-7.0/general-usb-gadget-fix-dangling-pointer-in-netdev-private-data.patch
@@ -1,0 +1,269 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megi@xff.cz>
+Date: Thu, 7 Sep 2023 14:07:26 +0200
+Subject: usb: gadget: Fix dangling pointer in netdev private data
+
+Some USB drivers destroy and re-create the gadget regularly. This
+leads to stale gadget pointer in gether_* using USB gadget functions
+(ecm, eem, rndis, etc.).
+
+Don't parent the netdev to the gadget device, and set gadget to
+NULL in function unbind callback, to avoid potential use-after-free
+issues.
+
+Note: f_ncm.c is excluded because mainline already handles gadget
+lifecycle via gether_attach_gadget()/gether_detach_gadget().
+
+Signed-off-by: Ondrej Jirman <megi@xff.cz>
+---
+ drivers/usb/gadget/function/f_ecm.c    | 12 ++---
+ drivers/usb/gadget/function/f_eem.c    | 28 +++++------
+ drivers/usb/gadget/function/f_rndis.c  | 26 ++++------
+ drivers/usb/gadget/function/f_subset.c | 18 ++++---
+ drivers/usb/gadget/function/u_ether.c  | 10 ++--
+ 5 files changed, 47 insertions(+), 47 deletions(-)
+
+diff --git a/drivers/usb/gadget/function/f_ecm.c b/drivers/usb/gadget/function/f_ecm.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/gadget/function/f_ecm.c
++++ b/drivers/usb/gadget/function/f_ecm.c
+@@ -689,14 +689,12 @@ ecm_bind(struct usb_configuration *c, struct usb_function *f)
+ 	ecm_opts = container_of(f->fi, struct f_ecm_opts, func_inst);
+
+ 	mutex_lock(&ecm_opts->lock);
+-
+ 	gether_set_gadget(ecm_opts->net, cdev->gadget);
+-
+ 	if (!ecm_opts->bound) {
+ 		status = gether_register_netdev(ecm_opts->net);
+-		ecm_opts->bound = true;
++		if (!status)
++			ecm_opts->bound = true;
+ 	}
+-
+ 	mutex_unlock(&ecm_opts->lock);
+ 	if (status)
+ 		return status;
+@@ -905,7 +903,9 @@ static void ecm_free(struct usb_function *f)
+
+ static void ecm_unbind(struct usb_configuration *c, struct usb_function *f)
+ {
+-	struct f_ecm		*ecm = func_to_ecm(f);
++	struct f_ecm *ecm = func_to_ecm(f);
++	struct f_ecm_opts *opts = container_of(f->fi, struct f_ecm_opts,
++					       func_inst);
+
+ 	DBG(c->cdev, "ecm unbind\n");
+
+@@ -918,6 +918,8 @@ static void ecm_unbind(struct usb_configuration *c, struct usb_function *f)
+
+ 	kfree(ecm->notify_req->buf);
+ 	usb_ep_free_request(ecm->notify, ecm->notify_req);
++
++	gether_set_gadget(opts->net, NULL);
+ }
+
+ static struct usb_function *ecm_alloc(struct usb_function_instance *fi)
+diff --git a/drivers/usb/gadget/function/f_eem.c b/drivers/usb/gadget/function/f_eem.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/gadget/function/f_eem.c
++++ b/drivers/usb/gadget/function/f_eem.c
+@@ -247,28 +247,23 @@ static int eem_bind(struct usb_configuration *c, struct usb_function *f)
+ 	struct usb_composite_dev *cdev = c->cdev;
+ 	struct f_eem		*eem = func_to_eem(f);
+ 	struct usb_string	*us;
+-	int			status;
++	int			status = 0;
+ 	struct usb_ep		*ep;
+
+ 	struct f_eem_opts	*eem_opts;
+
+ 	eem_opts = container_of(f->fi, struct f_eem_opts, func_inst);
+-	/*
+-	 * in drivers/usb/gadget/configfs.c:configfs_composite_bind()
+-	 * configurations are bound in sequence with list_for_each_entry,
+-	 * in each configuration its functions are bound in sequence
+-	 * with list_for_each_entry, so we assume no race condition
+-	 * with regard to eem_opts->bound access
+-	 */
++
++	mutex_lock(&eem_opts->lock);
++	gether_set_gadget(eem_opts->net, cdev->gadget);
+ 	if (!eem_opts->bound) {
+-		mutex_lock(&eem_opts->lock);
+-		gether_set_gadget(eem_opts->net, cdev->gadget);
+ 		status = gether_register_netdev(eem_opts->net);
+-		mutex_unlock(&eem_opts->lock);
+-		if (status)
+-			return status;
+-		eem_opts->bound = true;
++		if (!status)
++			eem_opts->bound = true;
+ 	}
++	mutex_unlock(&eem_opts->lock);
++	if (status)
++		return status;
+
+ 	us = usb_gstrings_attach(cdev, eem_strings,
+ 				 ARRAY_SIZE(eem_string_defs));
+@@ -640,9 +635,14 @@ static void eem_free(struct usb_function *f)
+
+ static void eem_unbind(struct usb_configuration *c, struct usb_function *f)
+ {
++	struct f_eem_opts *opts = container_of(f->fi, struct f_eem_opts,
++					       func_inst);
++
+ 	DBG(c->cdev, "eem unbind\n");
+
+ 	usb_free_all_descriptors(f);
++
++	gether_set_gadget(opts->net, NULL);
+ }
+
+ static struct usb_function *eem_alloc(struct usb_function_instance *fi)
+diff --git a/drivers/usb/gadget/function/f_rndis.c b/drivers/usb/gadget/function/f_rndis.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/gadget/function/f_rndis.c
++++ b/drivers/usb/gadget/function/f_rndis.c
+@@ -660,7 +660,7 @@ rndis_bind(struct usb_configuration *c, struct usb_function *f)
+ 	struct usb_composite_dev *cdev = c->cdev;
+ 	struct f_rndis		*rndis = func_to_rndis(f);
+ 	struct usb_string	*us;
+-	int			status;
++	int			status = 0;
+ 	struct usb_ep		*ep;
+
+ 	struct f_rndis_opts *rndis_opts;
+@@ -682,20 +682,16 @@ rndis_bind(struct usb_configuration *c, struct usb_function *f)
+ 	rndis_iad_descriptor.bFunctionSubClass = rndis_opts->subclass;
+ 	rndis_iad_descriptor.bFunctionProtocol = rndis_opts->protocol;
+
+-	/*
+-	 * in drivers/usb/gadget/configfs.c:configfs_composite_bind()
+-	 * configurations are bound in sequence with list_for_each_entry,
+-	 * in each configuration its functions are bound in sequence
+-	 * with list_for_each_entry, so we assume no race condition
+-	 * with regard to rndis_opts->bound access
+-	 */
++	mutex_lock(&rndis_opts->lock);
++	gether_set_gadget(rndis_opts->net, cdev->gadget);
+ 	if (!rndis_opts->bound) {
+-		gether_set_gadget(rndis_opts->net, cdev->gadget);
+ 		status = gether_register_netdev(rndis_opts->net);
+-		if (status)
+-			return status;
+-		rndis_opts->bound = true;
++		if (!status)
++			rndis_opts->bound = true;
+ 	}
++	mutex_unlock(&rndis_opts->lock);
++	if (status)
++		return status;
+
+ 	us = usb_gstrings_attach(cdev, rndis_strings,
+ 				 ARRAY_SIZE(rndis_string_defs));
+@@ -939,7 +935,9 @@ static void rndis_free(struct usb_function *f)
+
+ static void rndis_unbind(struct usb_configuration *c, struct usb_function *f)
+ {
+-	struct f_rndis		*rndis = func_to_rndis(f);
++	struct f_rndis *rndis = func_to_rndis(f);
++	struct f_rndis_opts *opts = container_of(f->fi, struct f_rndis_opts,
++						 func_inst);
+
+ 	kfree(f->os_desc_table);
+ 	f->os_desc_n = 0;
+@@ -947,6 +945,8 @@ static void rndis_unbind(struct usb_configuration *c, struct usb_function *f)
+
+ 	kfree(rndis->notify_req->buf);
+ 	usb_ep_free_request(rndis->notify, rndis->notify_req);
++
++	gether_set_gadget(opts->net, NULL);
+ }
+
+ static struct usb_function *rndis_alloc(struct usb_function_instance *fi)
+diff --git a/drivers/usb/gadget/function/f_subset.c b/drivers/usb/gadget/function/f_subset.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/gadget/function/f_subset.c
++++ b/drivers/usb/gadget/function/f_subset.c
+@@ -308,15 +308,16 @@ geth_bind(struct usb_configuration *c, struct usb_function *f)
+ 	 * with list_for_each_entry, so we assume no race condition
+ 	 * with regard to gether_opts->bound access
+ 	 */
++	mutex_lock(&gether_opts->lock);
++	gether_set_gadget(gether_opts->net, cdev->gadget);
+ 	if (!gether_opts->bound) {
+-		mutex_lock(&gether_opts->lock);
+-		gether_set_gadget(gether_opts->net, cdev->gadget);
+ 		status = gether_register_netdev(gether_opts->net);
+-		mutex_unlock(&gether_opts->lock);
+-		if (status)
+-			return status;
+-		gether_opts->bound = true;
++		if (!status)
++			gether_opts->bound = true;
+ 	}
++	mutex_unlock(&gether_opts->lock);
++	if (status)
++		return status;
+
+ 	us = usb_gstrings_attach(cdev, geth_strings,
+ 				 ARRAY_SIZE(geth_string_defs));
+@@ -456,8 +457,13 @@ static void geth_free(struct usb_function *f)
+
+ static void geth_unbind(struct usb_configuration *c, struct usb_function *f)
+ {
++	struct f_gether_opts *opts = container_of(f->fi, struct f_gether_opts,
++						  func_inst);
++
+ 	geth_string_defs[0].id = 0;
+ 	usb_free_all_descriptors(f);
++
++	gether_set_gadget(opts->net, NULL);
+ }
+
+ static struct usb_function *geth_alloc(struct usb_function_instance *fi)
+diff --git a/drivers/usb/gadget/function/u_ether.c b/drivers/usb/gadget/function/u_ether.c
+index 111111111111..222222222222 100644
+--- a/drivers/usb/gadget/function/u_ether.c
++++ b/drivers/usb/gadget/function/u_ether.c
+@@ -112,8 +112,10 @@ static void eth_get_drvinfo(struct net_device *net, struct ethtool_drvinfo *p)
+
+ 	strscpy(p->driver, "g_ether", sizeof(p->driver));
+ 	strscpy(p->version, UETH__VERSION, sizeof(p->version));
+-	strscpy(p->fw_version, dev->gadget->name, sizeof(p->fw_version));
+-	strscpy(p->bus_info, dev_name(&dev->gadget->dev), sizeof(p->bus_info));
++	if (dev->gadget) {
++		strscpy(p->fw_version, dev->gadget->name, sizeof(p->fw_version));
++		strscpy(p->bus_info, dev_name(&dev->gadget->dev), sizeof(p->bus_info));
++	}
+ }
+
+ /* REVISIT can also support:
+@@ -787,7 +789,6 @@ struct eth_dev *gether_setup_name(struct usb_gadget *g,
+ 	net->max_mtu = GETHER_MAX_MTU_SIZE;
+
+ 	dev->gadget = g;
+-	SET_NETDEV_DEV(net, &g->dev);
+ 	SET_NETDEV_DEVTYPE(net, &gadget_type);
+
+ 	status = register_netdev(net);
+@@ -860,8 +861,6 @@ int gether_register_netdev(struct net_device *net)
+ 	struct usb_gadget *g;
+ 	int status;
+
+-	if (!net->dev.parent)
+-		return -EINVAL;
+ 	dev = netdev_priv(net);
+ 	g = dev->gadget;
+
+@@ -892,7 +891,6 @@ void gether_set_gadget(struct net_device *net, struct usb_gadget *g)
+
+ 	dev = netdev_priv(net);
+ 	dev->gadget = g;
+-	SET_NETDEV_DEV(net, &g->dev);
+ }
+ EXPORT_SYMBOL_GPL(gether_set_gadget);
+
+--
+Armbian


### PR DESCRIPTION
## Summary

- Port Ondrej Jirman's (megi) USB gadget dangling pointer fix from sunxi to rockchip64
- Prevents intermittent kernel panic in `eth_get_drvinfo()` when udev queries ethtool on a USB gadget ethernet interface during DWC3 bind/unbind cycles
- Applies to both `current` (6.18) and `edge` (7.0) kernel branches

## Problem

When USB gadget ethernet (NCM/ECM/RNDIS) is configured, the DWC3 controller may destroy and re-create the gadget during role switching. If udev probes the network interface via ethtool during this window, `eth_get_drvinfo()` dereferences a NULL `dev->gadget` pointer, causing a kernel panic:

```
[   16.697591] Unable to handle kernel NULL pointer dereference at virtual address 0000000000000068
[   16.707044] pc : eth_get_drvinfo+0x58/0x118 [u_ether]

```
This crash is intermittent — it depends on timing between udev and the gadget bind/unbind cycle.

## Fix

The patch (originally by Ondrej Jirman / megi, already applied in sunxi):
- Adds NULL check for `dev->gadget` in `eth_get_drvinfo()`
- Sets gadget pointer to NULL in unbind callbacks for ECM, EEM, RNDIS, and subset functions
- Removes `SET_NETDEV_DEV()` parenting that creates stale references after gadget destruction
- Adds proper mutex locking around bind sequences

**Note:** The `f_ncm.c` hunks from the original patch are excluded because mainline already handles NCM gadget lifecycle via `gether_attach_gadget()`/`gether_detach_gadget()`.

## Test plan

- [x] Patch applies cleanly to both 6.18 and 7.0 kernel source trees (`git apply --check`)
- [x] Kernel builds successfully with patch applied
- [x] USB gadget NCM interface loads and `ethtool -i usb0` returns without crash
- [x] 8 consecutive reboot cycles with zero panics, zero warnings
- [x] Tested on NanoPi Zero2 (RK3528) with `6.18.20-current-rockchip64`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed USB gadget network device issues occurring during repeated device creation and destruction cycles that could cause system instability
  * Improved gadget pointer state management for enhanced reliability
  * Strengthened NULL pointer safety checks in gadget operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->