### PR TITLE
action: fix typos, update defaults, and harden GPG signing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: ""
 
   armbian_artifacts:
-    descriptions: "Upload PATH"
+    description: "Upload PATH"
     required: false
     default: "build/output/images/"
 
@@ -35,7 +35,7 @@ inputs:
   armbian_release:
     description: "Choose userspace release"
     required: false
-    default: "jammy"
+    default: "noble"
 
   armbian_version:
     description: "Set different version"
@@ -50,7 +50,7 @@ inputs:
   armbian_ui:
     description: "Armbian user interface"
     required: false
-    default: "server"
+    default: "minimal"
 
   armbian_compress:
     description: "Armbian compress method"
@@ -59,11 +59,6 @@ inputs:
 
   armbian_extensions:
     description: "Armbian lists of extensions"
-    required: false
-    default: ""
-
-  armbian_userpatches:
-    description: "Armbian userpatches path"
     required: false
     default: ""
 
@@ -77,7 +72,7 @@ inputs:
     required: false
     default: ""
 
-  armbian_release_tittle:
+  armbian_release_title:
     description: "Armbian image"
     required: false
     default: "Armbian image"
@@ -90,6 +85,7 @@ inputs:
   armbian_release_tag:
     description: "Armbian release tag"
     required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -118,7 +114,7 @@ runs:
       uses: actions/checkout@v6
       with:
         repository: armbian/os
-        fetch-depth: 0
+        fetch-depth: 1
         clean: false
         path: os
 
@@ -221,14 +217,14 @@ runs:
       shell: bash
       if: ${{ inputs.armbian_pgp_password != '' }}
       run: |
-        echo ${{ inputs.armbian_pgp_password }} | \
+        printf '%s' "${{ inputs.armbian_pgp_password }}" | \
         gpg --passphrase-fd 0 --armor --detach-sign --pinentry-mode loopback --batch --yes \
         build/output/images/*.img*.xz
 
     - uses: ncipollo/release-action@v1
       with:
         tag: ${{ inputs.armbian_release_tag != '' && inputs.armbian_release_tag || env.ARMBIAN_VERSION }}
-        name: "${{ inputs.armbian_release_tittle }}"
+        name: "${{ inputs.armbian_release_title }}"
         artifacts: "${{ inputs.armbian_artifacts }}*"
         allowUpdates: true
         removeArtifacts: false


### PR DESCRIPTION
## Summary
- Fix `descriptions` typo → `description` for `armbian_artifacts` input
- Fix `armbian_release_tittle` typo → `armbian_release_title` (breaking change for consumers using the old spelling)
- Update default release from `jammy` to `noble`
- Update default UI from `server` to `minimal`
- Remove unused `armbian_userpatches` input
- Add missing `default: ""` for `armbian_release_tag`
- Use `printf` instead of `echo` for GPG passphrase to avoid process list leak
- Reduce `fetch-depth` to 1 for armbian/os checkout (only `stable.json` is read)

## Breaking changes
- `armbian_release_tittle` renamed to `armbian_release_title` — workflows using the old name must update

## Test plan
- [x] Verify existing workflows that reference `armbian_release_tittle` are updated
- [x] Run a test build with default inputs to confirm `noble` + `minimal` works
- [x] Confirm GPG signing still works with `printf` change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a typo in the release title input parameter name.
  * Improved GPG signing passphrase handling to prevent formatting issues.

* **Chores**
  * Updated default configuration values for release and UI settings.
  * Removed deprecated input parameter.
  * Optimized repository checkout performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->