### PR TITLE
qcs6490: Fix sound card cannot be detected

### DIFF
--- a/config/boards/radxa-dragon-q6a.conf
+++ b/config/boards/radxa-dragon-q6a.conf
@@ -28,6 +28,12 @@ function post_family_tweaks_bsp__radxa-dragon-q6a_bsp_firmware_in_initrd() {
 		add_firmware "qcom/qcs6490/QCS6490-Radxa-Dragon-Q6A-tplg.bin" # extra one for sound
 	FIRMWARE_HOOK
 	run_host_command_logged chmod -v +x "${file_added_to_bsp_destination}"
+
+	# Fix audio driver loading
+	mkdir -p "${destination}"/etc/modules-load.d
+	cat > "${destination}"/etc/modules-load.d/wcd938x.conf <<- EOT
+	snd-soc-wcd938x
+	EOT
 }
 
 function post_family_tweaks__radxa-dragon-q6a_install_alsa_ucm_conf() {
@@ -35,7 +41,7 @@ function post_family_tweaks__radxa-dragon-q6a_install_alsa_ucm_conf() {
 	if [[ "${KERNEL_MAJOR_MINOR}" == "6.18" ]]; then
 		display_alert "Installing alsa-ucm-conf" "${BOARD}: Radxa ALSA UCM configuration" "info"
 
-		declare alsa_ucm_url="https://github.com/radxa-pkg/alsa-ucm-conf/releases/download/1.2.14-1radxa2/alsa-ucm-conf_1.2.14-1radxa2_all.deb"
+		declare alsa_ucm_url="${GITHUB_SOURCE}/radxa-pkg/alsa-ucm-conf/releases/download/1.2.14-1radxa2/alsa-ucm-conf_1.2.14-1radxa2_all.deb"
 		declare alsa_ucm_deb="/tmp/alsa-ucm-conf_1.2.14-1radxa2_all.deb"
 
 		# Download the package


### PR DESCRIPTION
It seems wcd938x driver module is not loaded automatically by default. Also use GITHUB_SOURCE to respect proxy settings for building.

You can refer to https://forum.armbian.com/topic/57121-latest-armbian-build-hdmi-audio-support-fix/ for more issue details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced audio support initialization for Radxa Dragon Q6a devices
  * Improved build configuration management with more maintainable dependency resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->