### PR TITLE
mainline: bump `edge` to 7.0-rc6

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0           # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "7.0" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v7.0-rc5"
+		declare -g KERNELBRANCH="tag:v7.0-rc6"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }
@@ -26,11 +26,11 @@ function mainline_kernel_decide_version__upstream_release_candidate_number() {
 
  # Example: 6.7-rc7 was released by Linus, but kernel.org git and google git mirrors took a while to catch up; change the source to pull directly from Linus.
  # This was necessary for a few days in late December 2023, but no longer; tag was pushed on 28/Dec/2023.
- function mainline_kernel_decide_version__750_use_torvalds_for_7.0-rc5() {
- 	if [[ "${KERNELBRANCH}" == 'tag:v7.0-rc5' ]]; then
- 		display_alert "Using Linus kernel repo for 7.0-rc5" "${KERNELBRANCH}" "warn"
+ function mainline_kernel_decide_version__750_use_torvalds_for_7.0-rc6() {
+ 	if [[ "${KERNELBRANCH}" == 'tag:v7.0-rc6' ]]; then
+ 		display_alert "Using Linus kernel repo for 7.0-rc6" "${KERNELBRANCH}" "warn"
  		declare -g KERNELSOURCE="https://github.com/torvalds/linux.git"
- 		display_alert "mainline-kernel: missing torvalds tag on 7.0-rc5" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
+ 		display_alert "mainline-kernel: missing torvalds tag on 7.0-rc6" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
  	fi
  }
 

--- a/patch/kernel/archive/rockchip64-7.0/HACK-Ignore-SError-to-enable-rk3399-PCIe-bus-enumera.patch
+++ b/patch/kernel/archive/rockchip64-7.0/HACK-Ignore-SError-to-enable-rk3399-PCIe-bus-enumera.patch
@@ -1,15 +1,15 @@
-From 2ad2c11dad315482917ac0e27863f12d5c44bfee Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: retro98boy <retro98boy@qq.com>
 Date: Wed, 25 Feb 2026 05:18:04 +0800
-Subject: [PATCH] HACK: Ignore SError to enable rk3399 PCIe bus enumeration
+Subject: HACK: Ignore SError to enable rk3399 PCIe bus enumeration
 
 ---
- arch/arm64/kernel/traps.c                   | 19 ++++++++
- drivers/pci/controller/pcie-rockchip-host.c | 50 +++++++++++++++++++++
+ arch/arm64/kernel/traps.c                   | 19 ++++
+ drivers/pci/controller/pcie-rockchip-host.c | 50 ++++++++++
  2 files changed, 69 insertions(+)
 
 diff --git a/arch/arm64/kernel/traps.c b/arch/arm64/kernel/traps.c
-index 681939ef5..a48ec5dac 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/kernel/traps.c
 +++ b/arch/arm64/kernel/traps.c
 @@ -976,8 +976,27 @@ bool arm64_is_fatal_ras_serror(struct pt_regs *regs, unsigned long esr)
@@ -41,7 +41,7 @@ index 681939ef5..a48ec5dac 100644
  	if (!arm64_is_ras_serror(esr) || arm64_is_fatal_ras_serror(regs, esr))
  		arm64_serror_panic(regs, esr);
 diff --git a/drivers/pci/controller/pcie-rockchip-host.c b/drivers/pci/controller/pcie-rockchip-host.c
-index ee1822ca0..0944aa9a2 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pci/controller/pcie-rockchip-host.c
 +++ b/drivers/pci/controller/pcie-rockchip-host.c
 @@ -923,8 +923,58 @@ static int rockchip_pcie_resume_noirq(struct device *dev)
@@ -104,5 +104,5 @@ index ee1822ca0..0944aa9a2 100644
  	struct device *dev = &pdev->dev;
  	struct pci_host_bridge *bridge;
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.0/general-ASoC-codecs-es8328-allow-sharing-LRCK-for-microphone.patch
+++ b/patch/kernel/archive/rockchip64-7.0/general-ASoC-codecs-es8328-allow-sharing-LRCK-for-microphone.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: c127dev <contact@c127.dev>
 Date: Mon, 23 Mar 2026 17:34:45 +0000
-Subject: [PATCH] ASoC: codecs: es8328: allow sharing LRCK for microphone and
- playback
+Subject: ASoC: codecs: es8328: allow sharing LRCK for microphone and playback
 
 In some board designs, such as the Orange Pi 5 Pro SBC, the ADC LRCK
 pin might not be directly connected. This causes the microphone to fail
@@ -23,7 +22,7 @@ Signed-off-by: c127dev <contact@c127.dev>
  1 file changed, 10 insertions(+)
 
 diff --git a/sound/soc/codecs/es8328.c b/sound/soc/codecs/es8328.c
-index 9838fe42cb6f..d34d6893f5b9 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/es8328.c
 +++ b/sound/soc/codecs/es8328.c
 @@ -906,6 +906,16 @@ int es8328_probe(struct device *dev, struct regmap *regmap)
@@ -44,5 +43,5 @@ index 9838fe42cb6f..d34d6893f5b9 100644
  			&es8328_component_driver, &es8328_dai, 1);
  }
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.0/general-rk3588-i2s-mclk-output-gate-1-bindings.patch
+++ b/patch/kernel/archive/rockchip64-7.0/general-rk3588-i2s-mclk-output-gate-1-bindings.patch
@@ -1,8 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
 Date: Thu, 19 Mar 2026 08:26:57 +0100
-Subject: dt-bindings: clock: rockchip,rk3588-cru: add I2S MCLK
- output to IO clock IDs
+Subject: dt-bindings: clock: rockchip,rk3588-cru: add I2S MCLK output to IO
+ clock IDs
 
 Add clock identifiers for the four I2S MCLK output to IO gate clocks
 on RK3588, needed by board DTS files where the codec requires MCLK
@@ -16,7 +16,7 @@ Signed-off-by: SuperKali <hello@superkali.me>
  1 file changed, 4 insertions(+)
 
 diff --git a/include/dt-bindings/clock/rockchip,rk3588-cru.h b/include/dt-bindings/clock/rockchip,rk3588-cru.h
-index 0c7d3ca2d5bc..7528034cff56 100644
+index 111111111111..222222222222 100644
 --- a/include/dt-bindings/clock/rockchip,rk3588-cru.h
 +++ b/include/dt-bindings/clock/rockchip,rk3588-cru.h
 @@ -734,6 +734,10 @@

--- a/patch/kernel/archive/rockchip64-7.0/general-rk3588-i2s-mclk-output-gate-2-allow-grf-type-sys.patch
+++ b/patch/kernel/archive/rockchip64-7.0/general-rk3588-i2s-mclk-output-gate-2-allow-grf-type-sys.patch
@@ -24,7 +24,7 @@ Signed-off-by: SuperKali <hello@superkali.me>
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/clk/rockchip/clk.c b/drivers/clk/rockchip/clk.c
-index e8b3b0b9a4f8..911e6b610618 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/rockchip/clk.c
 +++ b/drivers/clk/rockchip/clk.c
 @@ -509,10 +509,9 @@ void rockchip_clk_register_branches(struct rockchip_clk_provider *ctx,

--- a/patch/kernel/archive/rockchip64-7.0/general-rk3588-i2s-mclk-output-gate-3-grf-header.patch
+++ b/patch/kernel/archive/rockchip64-7.0/general-rk3588-i2s-mclk-output-gate-3-grf-header.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
 Date: Fri, 20 Mar 2026 11:24:11 +0100
-Subject: soc: rockchip: rk3588: add SYS_GRF SOC_CON6 register
- offset
+Subject: soc: rockchip: rk3588: add SYS_GRF SOC_CON6 register offset
 
 Add the RK3588_SYSGRF_SOC_CON6 register offset to the RK3588 GRF
 header. This register contains the I2S MCLK output to IO gate bits,
@@ -14,7 +13,7 @@ Signed-off-by: SuperKali <hello@superkali.me>
  1 file changed, 2 insertions(+)
 
 diff --git a/include/soc/rockchip/rk3588_grf.h b/include/soc/rockchip/rk3588_grf.h
-index 02a7b2432d99..db0092fc66ad 100644
+index 111111111111..222222222222 100644
 --- a/include/soc/rockchip/rk3588_grf.h
 +++ b/include/soc/rockchip/rk3588_grf.h
 @@ -19,4 +19,6 @@

--- a/patch/kernel/archive/rockchip64-7.0/general-rk3588-i2s-mclk-output-gate-4-gate-grf-clocks.patch
+++ b/patch/kernel/archive/rockchip64-7.0/general-rk3588-i2s-mclk-output-gate-4-gate-grf-clocks.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
 Date: Fri, 20 Mar 2026 11:25:50 +0100
-Subject: clk: rockchip: rk3588: add GATE_GRF clocks for I2S MCLK
- output to IO
+Subject: clk: rockchip: rk3588: add GATE_GRF clocks for I2S MCLK output to IO
 
 The I2S MCLK outputs on RK3588 are gated by bits in the SYS_GRF
 register SOC_CON6 (offset 0x318). These gates control whether the
@@ -35,11 +34,11 @@ Upstream: https://lore.kernel.org/linux-rockchip/20260320-rk3588-mclk-gate-grf-v
 
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- drivers/clk/rockchip/clk-rk3588.c | 24 ++++++++++++++++++++++++
+ drivers/clk/rockchip/clk-rk3588.c | 24 ++++++++++
  1 file changed, 24 insertions(+)
 
 diff --git a/drivers/clk/rockchip/clk-rk3588.c b/drivers/clk/rockchip/clk-rk3588.c
-index 1694223f4f84..2cc85fb5b2cc 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/rockchip/clk-rk3588.c
 +++ b/drivers/clk/rockchip/clk-rk3588.c
 @@ -5,11 +5,14 @@

--- a/patch/kernel/archive/rockchip64-7.0/net-stmmac-dwmac-motorcomm-fix-eFUSE-MAC-Address-Rea.patch
+++ b/patch/kernel/archive/rockchip64-7.0/net-stmmac-dwmac-motorcomm-fix-eFUSE-MAC-Address-Rea.patch
@@ -1,8 +1,7 @@
-From a216e978eb6f4d6316732021e73172f0c49f2930 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: c127dev <contact@c127.dev>
 Date: Sun, 15 Mar 2026 01:06:19 +0000
-Subject: [PATCH] net: stmmac: dwmac-motorcomm: fix eFUSE MAC Address Read
- Failure
+Subject: net: stmmac: dwmac-motorcomm: fix eFUSE MAC Address Read Failure
 
 This patch fixes an issue where reading the MAC address from the eFUSE
 fails due to a race condition.
@@ -19,11 +18,11 @@ eFUSE controller to load its internal data before returning valid reads.
 
 Signed-off-by: c127dev <contact@c127.dev>
 ---
- .../ethernet/stmicro/stmmac/dwmac-motorcomm.c | 23 +++++++++++++++----
+ drivers/net/ethernet/stmicro/stmmac/dwmac-motorcomm.c | 23 ++++++++--
  1 file changed, 18 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-motorcomm.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-motorcomm.c
-index 8b45b9cf7202..61a197cd34ab 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-motorcomm.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-motorcomm.c
 @@ -6,6 +6,7 @@
@@ -78,5 +77,5 @@ index 8b45b9cf7202..61a197cd34ab 100644
  
  	return stmmac_dvr_probe(&pdev->dev, plat, &res);
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.0/rk3399-rp64-pcie-Reimplement-rockchip-PCIe-bus-scan-delay.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3399-rp64-pcie-Reimplement-rockchip-PCIe-bus-scan-delay.patch
@@ -54,7 +54,7 @@ index 111111111111..222222222222 100644
  static void rockchip_pcie_enable_bw_int(struct rockchip_pcie *rockchip)
  {
  	u32 status;
-@@ -929,6 +933,7 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
+@@ -979,6 +983,7 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
  	struct device *dev = &pdev->dev;
  	struct pci_host_bridge *bridge;
  	int err;
@@ -62,7 +62,7 @@ index 111111111111..222222222222 100644
  
  	if (!dev->of_node)
  		return -ENODEV;
-@@ -978,6 +983,26 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
+@@ -1028,6 +1033,26 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
  	bridge->sysdata = rockchip;
  	bridge->ops = &rockchip_pcie_ops;
  

--- a/patch/kernel/archive/rockchip64-7.0/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shlomi Marco <s.marco@rubycomm.com>
-Date: Sun, 02 Mar 2026 00:00:00 +0000
+Date: Mon, 2 Mar 2026 00:00:00 +0000
 Subject: phy: rockchip-inno-usb2: Add support for RK3528
 
 Add USB2 PHY support for the Rockchip RK3528 SoC.
@@ -21,12 +21,14 @@ next-20250910-rk3528 branch.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 136 +++++++++++++++---
- 1 file changed, 105 insertions(+), 31 deletions(-)
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 160 ++++++++--
+ 1 file changed, 127 insertions(+), 33 deletions(-)
 
+diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
+index 111111111111..222222222222 100644
 --- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 +++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
-@@ -171,6 +171,7 @@
+@@ -171,6 +171,7 @@ struct rockchip_usb2phy_port_cfg {
   * @num_ports: specify how many ports that the phy has.
   * @phy_tuning: phy default parameters tuning.
   * @clkout_ctl: keep on/turn off output clk of phy.
@@ -34,7 +36,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
   * @port_cfgs: usb-phy port configurations.
   * @chg_det: charger detection registers.
   */
-@@ -179,6 +180,7 @@
+@@ -179,6 +180,7 @@ struct rockchip_usb2phy_cfg {
  	unsigned int	num_ports;
  	int (*phy_tuning)(struct rockchip_usb2phy *rphy);
  	struct usb2phy_reg	clkout_ctl;
@@ -42,7 +44,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  	const struct rockchip_usb2phy_port_cfg	port_cfgs[USB2PHY_NUM_PORTS];
  	const struct rockchip_chg_det_reg	chg_det;
  };
-@@ -228,7 +230,7 @@
+@@ -228,7 +230,7 @@ struct rockchip_usb2phy_port {
   * struct rockchip_usb2phy - usb2.0 phy driver data.
   * @dev: pointer to device.
   * @grf: General Register Files regmap.
@@ -51,7 +53,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
   * @clks: array of phy input clocks.
   * @clk480m: clock struct of phy output clk.
   * @clk480m_hw: clock struct of phy output clk management.
-@@ -246,7 +248,7 @@
+@@ -246,7 +248,7 @@ struct rockchip_usb2phy_port {
  struct rockchip_usb2phy {
  	struct device	*dev;
  	struct regmap	*grf;
@@ -60,7 +62,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  	struct clk_bulk_data	*clks;
  	struct clk	*clk480m;
  	struct clk_hw	clk480m_hw;
-@@ -263,7 +265,7 @@
+@@ -263,7 +265,7 @@ struct rockchip_usb2phy {
  
  static inline struct regmap *get_reg_base(struct rockchip_usb2phy *rphy)
  {
@@ -69,7 +71,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  }
  
  static inline int property_enable(struct regmap *base,
-@@ -319,16 +321,33 @@
+@@ -319,16 +321,33 @@ static void rockchip_usb2phy_clk_bulk_disable(void *data)
  	clk_bulk_disable_unprepare(rphy->num_clks, rphy->clks);
  }
  
@@ -107,7 +109,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  		if (ret)
  			return ret;
  
-@@ -341,21 +360,23 @@
+@@ -341,21 +360,23 @@ static int rockchip_usb2phy_clk480m_prepare(struct clk_hw *hw)
  
  static void rockchip_usb2phy_clk480m_unprepare(struct clk_hw *hw)
  {
@@ -139,22 +141,22 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  }
  
  static unsigned long
-@@ -1360,27 +1381,18 @@
+@@ -1360,27 +1381,18 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  	if (!rphy)
  		return -ENOMEM;
-
+ 
 -	if (!dev->parent || !dev->parent->of_node) {
+-		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
+-		if (IS_ERR(rphy->grf)) {
+-			dev_err(dev, "failed to locate usbgrf\n");
+-			return PTR_ERR(rphy->grf);
+-		}
 +	if (!dev->parent || !dev->parent->of_node ||
 +	    of_property_present(np, "rockchip,usbgrf")) {
 +		rphy->phy_base = device_node_to_regmap(np);
 +		if (IS_ERR(rphy->phy_base))
 +			return PTR_ERR(rphy->phy_base);
--		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
 +		rphy->grf = rphy->phy_base;
--		if (IS_ERR(rphy->grf)) {
--			dev_err(dev, "failed to locate usbgrf\n");
--			return PTR_ERR(rphy->grf);
--		}
  	} else {
  		rphy->grf = syscon_node_to_regmap(dev->parent->of_node);
 -		if (IS_ERR(rphy->grf))
@@ -176,7 +178,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  
  	if (of_property_read_u32_index(np, "reg", 0, &reg)) {
  		dev_err(dev, "the reg property is not assigned in %pOFn node\n", np);
-@@ -1521,6 +1533,36 @@
+@@ -1521,6 +1533,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  				BIT(2) << BIT_WRITEABLE_SHIFT | 0);
  }
  
@@ -213,7 +215,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  static int rk3576_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  {
  	int ret;
-@@ -1934,6 +1968,57 @@
+@@ -1934,6 +1976,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
  	{ /* sentinel */ }
  };
  
@@ -271,7 +273,7 @@ Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
  static const struct rockchip_usb2phy_cfg rk3562_phy_cfgs[] = {
  	{
  		.reg = 0xff740000,
-@@ -2301,6 +2386,7 @@
+@@ -2301,6 +2394,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
  	{ .compatible = "rockchip,rk3328-usb2phy", .data = &rk3328_phy_cfgs },
  	{ .compatible = "rockchip,rk3366-usb2phy", .data = &rk3366_phy_cfgs },
  	{ .compatible = "rockchip,rk3399-usb2phy", .data = &rk3399_phy_cfgs },

--- a/patch/kernel/archive/rockchip64-7.0/rk3528-11-arm64-dts-rockchip-rk3528-Add-USB-controller-and-PHY-nodes.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3528-11-arm64-dts-rockchip-rk3528-Add-USB-controller-and-PHY-nodes.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shlomi Marco <s.marco@rubycomm.com>
-Date: Sun, 02 Mar 2026 00:00:00 +0000
+Date: Mon, 2 Mar 2026 00:00:00 +0000
 Subject: arm64: dts: rockchip: rk3528: Add USB controller and PHY nodes
 
 Add the USB controller and PHY device tree nodes for the RK3528 SoC:
@@ -17,17 +17,17 @@ RK3528 USB patches and the U-Boot device tree.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3528.dtsi | 80 ++++++++++++++++++++++++
- 1 file changed, 80 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3528.dtsi | 78 ++++++++++
+ 1 file changed, 78 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3528.dtsi b/arch/arm64/boot/dts/rockchip/rk3528.dtsi
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3528.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3528.dtsi
-@@ -336,6 +336,30 @@
+@@ -336,6 +336,30 @@ pcie_intc: legacy-interrupt-controller {
  			};
  		};
-
+ 
 +		usb_host0_xhci: usb@fe500000 {
 +			compatible = "rockchip,rk3528-dwc3", "snps,dwc3";
 +			reg = <0x0 0xfe500000 0x0 0x400000>;
@@ -55,10 +55,10 @@ index 111111111111..222222222222 100644
  		gic: interrupt-controller@fed01000 {
  			compatible = "arm,gic-400";
  			reg = <0x0 0xfed01000 0 0x1000>,
-@@ -349,6 +373,30 @@
+@@ -349,6 +373,30 @@ gic: interrupt-controller@fed01000 {
  			#interrupt-cells = <3>;
  		};
-
+ 
 +		usb_host0_ehci: usb@ff100000 {
 +			compatible = "generic-ehci";
 +			reg = <0x0 0xff100000 0x0 0x40000>;
@@ -86,7 +86,7 @@ index 111111111111..222222222222 100644
  		qos_crypto_a: qos@ff200000 {
  			compatible = "rockchip,rk3528-qos", "syscon";
  			reg = <0x0 0xff200000 0x0 0x20>;
-@@ -1238,6 +1286,36 @@
+@@ -1238,6 +1286,36 @@ combphy: phy@ffdc0000 {
  			rockchip,pipe-phy-grf = <&pipe_phy_grf>;
  			status = "disabled";
  		};

--- a/patch/kernel/archive/rockchip64-7.0/rk3528-12-arm64-dts-rockchip-nanopi-zero2-Enable-USB.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3528-12-arm64-dts-rockchip-nanopi-zero2-Enable-USB.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shlomi Marco <s.marco@rubycomm.com>
-Date: Sun, 02 Mar 2026 00:00:00 +0000
+Date: Mon, 2 Mar 2026 00:00:00 +0000
 Subject: arm64: dts: rockchip: nanopi-zero2: Enable USB
 
 Enable USB2 PHY, EHCI, OHCI and DWC3 (xHCI) controllers on the
@@ -18,14 +18,14 @@ defined in the board DTS but were previously unused.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts | 28 ++++++++++++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts | 28 ++++++++++
  1 file changed, 28 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts b/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts
-@@ -349,3 +349,31 @@
+@@ -349,3 +349,31 @@ &uart0 {
  	pinctrl-0 = <&uart0m0_xfer>;
  	status = "okay";
  };

--- a/patch/kernel/archive/rockchip64-7.0/rk3528-13-phy-rockchip-inno-usb2-fix-otg-timer-cleanup.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3528-13-phy-rockchip-inno-usb2-fix-otg-timer-cleanup.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shlomi Marco <s.marco@rubycomm.com>
-Date: Wed, 26 Mar 2026 00:00:00 +0000
+Date: Thu, 26 Mar 2026 00:00:00 +0000
 Subject: phy: rockchip-inno-usb2: fix OTG timer cleanup on driver removal
 
 The OTG state machine delayed works (otg_sm_work, chg_work, sm_work)
@@ -13,17 +13,17 @@ delayed works when the device is removed or probe unwinds.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 24 +++++++++++++++++++++++-
- 1 file changed, 23 insertions(+), 1 deletion(-)
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 22 ++++++++++
+ 1 file changed, 22 insertions(+)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 index 111111111111..222222222222 100644
 --- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 +++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
-@@ -1359,6 +1359,21 @@ static int rockchip_usb2phy_otg_port_init(struct rockchip_usb2phy *rphy,
+@@ -1366,6 +1366,21 @@ static int rockchip_usb2phy_otg_port_init(struct rockchip_usb2phy *rphy,
  	return ret;
  }
-
+ 
 +static void rockchip_usb2phy_otg_work_cleanup(void *data)
 +{
 +	struct rockchip_usb2phy_port *rport = data;
@@ -42,11 +42,10 @@ index 111111111111..222222222222 100644
  static int rockchip_usb2phy_probe(struct platform_device *pdev)
  {
  	struct device *dev = &pdev->dev;
-@@ -1488,6 +1503,13 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1495,6 +1510,13 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  			if (ret)
  				goto put_child;
  		}
--
 +		ret = devm_add_action_or_reset(dev,
 +			of_node_name_eq(child_np, "host-port") ?
 +				rockchip_usb2phy_host_work_cleanup :
@@ -54,7 +53,7 @@ index 111111111111..222222222222 100644
 +			rport);
 +		if (ret)
 +			goto put_child;
-+
+ 
  next_child:
  		/* to prevent out of boundary */
 -- 

--- a/patch/kernel/archive/rockchip64-7.0/rk3528-14-arm64-dts-rockchip-nanopi-zero2-fix-ethernet-phy-reset.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3528-14-arm64-dts-rockchip-nanopi-zero2-fix-ethernet-phy-reset.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shlomi Marco <s.marco@rubycomm.com>
-Date: Wed, 26 Mar 2026 00:00:00 +0000
+Date: Thu, 26 Mar 2026 00:00:00 +0000
 Subject: arm64: dts: rockchip: nanopi-zero2: fix ethernet PHY reset
 
 Move the Ethernet PHY reset control from the MDIO bus PHY node to the
@@ -22,17 +22,16 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts b/arch/arm64/b
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3528-nanopi-zero2.dts
-@@ -217,6 +217,8 @@
+@@ -228,6 +228,8 @@ &gmac1 {
  	pinctrl-0 = <&rgmii_miim>, <&rgmii_tx_bus2>, <&rgmii_rx_bus2>,
  		    <&rgmii_rgmii_clk>, <&rgmii_rgmii_bus>;
  	status = "okay";
 +	snps,reset-gpios = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
 +	snps,reset-delays-us = <0 20000 100000>;
  };
-
+ 
  &gpu {
-@@ -244,12 +246,7 @@
- &mdio1 {
+@@ -256,11 +258,6 @@ &mdio1 {
  	rgmii_phy: ethernet-phy@1 {
  		compatible = "ethernet-phy-ieee802.3-c22";
  		reg = <0x1>;
@@ -43,6 +42,7 @@ index 111111111111..222222222222 100644
 -		reset-gpios = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
  	};
  };
-
+ 
 -- 
 Armbian
+

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-gem-dma-support-dedicated-dma-device-for-allocation-and-mapping.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-gem-dma-support-dedicated-dma-device-for-allocation-and-mapping.patch
@@ -1,14 +1,30 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: EvilOlaf <werner@armbian.com>
-Date: Fri, 27 Mar 2026 15:19:07 +0100
-Subject: [ARCHEOLOGY] sunxi-7.0: drm/gem-dma: Support dedicated DMA device for
- allocation
+From: Chen-Yu Tsai <wenst@chromium.org>
+Date: Wed, 11 Mar 2026 17:49:26 +0800
+Subject: [PATCH] drm/gem-dma: Support dedicated DMA device for allocation and mapping
 
-> X-Git-Archeology: - Revision d944703ab8a32e52838f921cb67dd2db6d26b5df: https://github.com/armbian/build/commit/d944703ab8a32e52838f921cb67dd2db6d26b5df
-> X-Git-Archeology:   Date: Fri, 27 Mar 2026 15:19:07 +0100
-> X-Git-Archeology:   From: EvilOlaf <werner@armbian.com>
-> X-Git-Archeology:   Subject: sunxi-7.0: drm/gem-dma: Support dedicated DMA device for allocation
-> X-Git-Archeology:
+Support for a dedicated DMA device for prime imports was added in commit
+143ec8d3f939 ("drm/prime: Support dedicated DMA device for dma-buf imports").
+This allowed the DRM driver to provide a dedicated DMA device when its
+own underlying device was not capable of DMA, for example when it is a
+USB device (the original target) or a virtual device. The latter case is
+common on embedded SoCs, on which the display pipeline is composed of
+various fixed function blocks, and the DRM device is simply a made-up
+device, an address space managing the routing between the blocks, or
+whichever block the implementor thought made sense at the time. The
+point is that the chosen device is often not the actual device doing
+the DMA. Various drivers have used workarounds or reimplemented the
+GEM DMA helpers to get the DMA addresses and IOMMUs to work correctly.
+
+Add support for the dedicated DMA device to the GEM DMA helpers.
+
+No existing driver currently uses the GEM DMA helpers and calls
+drm_dev_set_dma_dev() to set a dedicated DMA device, so no existing
+users should be affected.
+
+Reviewed-by: Thomas Zimmermann <tzimmermann@suse.de>
+Signed-off-by: Chen-Yu Tsai <wenst@chromium.org>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
 ---
  drivers/gpu/drm/drm_gem_dma_helper.c | 21 ++++++----
  1 file changed, 12 insertions(+), 9 deletions(-)

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-gem-dma-support-dedicated-dma-device-for-allocation-and-mapping.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-gem-dma-support-dedicated-dma-device-for-allocation-and-mapping.patch
@@ -1,31 +1,20 @@
-From: Chen-Yu Tsai <wenst@chromium.org>
-Date: Wed, 11 Mar 2026 17:49:26 +0800
-Subject: [PATCH] drm/gem-dma: Support dedicated DMA device for allocation and mapping
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: EvilOlaf <werner@armbian.com>
+Date: Fri, 27 Mar 2026 15:19:07 +0100
+Subject: [ARCHEOLOGY] sunxi-7.0: drm/gem-dma: Support dedicated DMA device for
+ allocation
 
-Support for a dedicated DMA device for prime imports was added in commit
-143ec8d3f939 ("drm/prime: Support dedicated DMA device for dma-buf imports").
-This allowed the DRM driver to provide a dedicated DMA device when its
-own underlying device was not capable of DMA, for example when it is a
-USB device (the original target) or a virtual device. The latter case is
-common on embedded SoCs, on which the display pipeline is composed of
-various fixed function blocks, and the DRM device is simply a made-up
-device, an address space managing the routing between the blocks, or
-whichever block the implementor thought made sense at the time. The
-point is that the chosen device is often not the actual device doing
-the DMA. Various drivers have used workarounds or reimplemented the
-GEM DMA helpers to get the DMA addresses and IOMMUs to work correctly.
+> X-Git-Archeology: - Revision d944703ab8a32e52838f921cb67dd2db6d26b5df: https://github.com/armbian/build/commit/d944703ab8a32e52838f921cb67dd2db6d26b5df
+> X-Git-Archeology:   Date: Fri, 27 Mar 2026 15:19:07 +0100
+> X-Git-Archeology:   From: EvilOlaf <werner@armbian.com>
+> X-Git-Archeology:   Subject: sunxi-7.0: drm/gem-dma: Support dedicated DMA device for allocation
+> X-Git-Archeology:
+---
+ drivers/gpu/drm/drm_gem_dma_helper.c | 21 ++++++----
+ 1 file changed, 12 insertions(+), 9 deletions(-)
 
-Add support for the dedicated DMA device to the GEM DMA helpers.
-
-No existing driver currently uses the GEM DMA helpers and calls
-drm_dev_set_dma_dev() to set a dedicated DMA device, so no existing
-users should be affected.
-
-Reviewed-by: Thomas Zimmermann <tzimmermann@suse.de>
-Signed-off-by: Chen-Yu Tsai <wenst@chromium.org>
-Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
 diff --git a/drivers/gpu/drm/drm_gem_dma_helper.c b/drivers/gpu/drm/drm_gem_dma_helper.c
-index ecb9746f4da8..70f83e464476 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/drm_gem_dma_helper.c
 +++ b/drivers/gpu/drm/drm_gem_dma_helper.c
 @@ -146,12 +146,13 @@ struct drm_gem_dma_object *drm_gem_dma_create(struct drm_device *drm,
@@ -88,5 +77,5 @@ index ecb9746f4da8..70f83e464476 100644
  	}
  	if (ret)
 -- 
-2.53.0.473.g4a7958ca14-goog
+Armbian
 

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-prime-limit-scatter-list-size-with-dedicated-dma-device.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-prime-limit-scatter-list-size-with-dedicated-dma-device.patch
@@ -1,22 +1,20 @@
-From: Chen-Yu Tsai <wenst@chromium.org>
-Date: Wed, 11 Mar 2026 17:49:25 +0800
-Subject: [PATCH] drm/prime: Limit scatter list size with dedicated DMA device
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: EvilOlaf <werner@armbian.com>
+Date: Fri, 27 Mar 2026 15:19:07 +0100
+Subject: [ARCHEOLOGY] sunxi-7.0: drm/gem-dma: Support dedicated DMA device for
+ allocation
 
-If a dedicated DMA device is specified for the DRM device, then the
-scatter list size limit should pertain to the DMA device.
+> X-Git-Archeology: - Revision d944703ab8a32e52838f921cb67dd2db6d26b5df: https://github.com/armbian/build/commit/d944703ab8a32e52838f921cb67dd2db6d26b5df
+> X-Git-Archeology:   Date: Fri, 27 Mar 2026 15:19:07 +0100
+> X-Git-Archeology:   From: EvilOlaf <werner@armbian.com>
+> X-Git-Archeology:   Subject: sunxi-7.0: drm/gem-dma: Support dedicated DMA device for allocation
+> X-Git-Archeology:
+---
+ drivers/gpu/drm/drm_prime.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
-Use the dedicated DMA device, if given, to limit the scatter list size.
-This only applies to drivers that have called drm_dev_set_dma_dev() and
-are using drm_prime_pages_to_sg() either directly or through the SHMEM
-helpers. At the time of this writing, the former case only includes the
-Rockchip DRM driver, while the latter case includes the gud, udl, and
-the tiny appletbdrm and gm12u320 drivers.
-
-Reviewed-by: Thomas Zimmermann <tzimmermann@suse.de>
-Signed-off-by: Chen-Yu Tsai <wenst@chromium.org>
-Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
 diff --git a/drivers/gpu/drm/drm_prime.c b/drivers/gpu/drm/drm_prime.c
-index 51fdb06d3e9f..9b44c78cd77f 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/drm_prime.c
 +++ b/drivers/gpu/drm/drm_prime.c
 @@ -859,7 +859,7 @@ struct sg_table *drm_prime_pages_to_sg(struct drm_device *dev,
@@ -29,5 +27,5 @@ index 51fdb06d3e9f..9b44c78cd77f 100644
  		max_segment = UINT_MAX;
  	err = sg_alloc_table_from_pages_segment(sg, pages, nr_pages, 0,
 -- 
-2.53.0.473.g4a7958ca14-goog
+Armbian
 

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-prime-limit-scatter-list-size-with-dedicated-dma-device.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-prime-limit-scatter-list-size-with-dedicated-dma-device.patch
@@ -1,14 +1,21 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: EvilOlaf <werner@armbian.com>
-Date: Fri, 27 Mar 2026 15:19:07 +0100
-Subject: [ARCHEOLOGY] sunxi-7.0: drm/gem-dma: Support dedicated DMA device for
- allocation
+From: Chen-Yu Tsai <wenst@chromium.org>
+Date: Wed, 11 Mar 2026 17:49:25 +0800
+Subject: [PATCH] drm/prime: Limit scatter list size with dedicated DMA device
 
-> X-Git-Archeology: - Revision d944703ab8a32e52838f921cb67dd2db6d26b5df: https://github.com/armbian/build/commit/d944703ab8a32e52838f921cb67dd2db6d26b5df
-> X-Git-Archeology:   Date: Fri, 27 Mar 2026 15:19:07 +0100
-> X-Git-Archeology:   From: EvilOlaf <werner@armbian.com>
-> X-Git-Archeology:   Subject: sunxi-7.0: drm/gem-dma: Support dedicated DMA device for allocation
-> X-Git-Archeology:
+If a dedicated DMA device is specified for the DRM device, then the
+scatter list size limit should pertain to the DMA device.
+
+Use the dedicated DMA device, if given, to limit the scatter list size.
+This only applies to drivers that have called drm_dev_set_dma_dev() and
+are using drm_prime_pages_to_sg() either directly or through the SHMEM
+helpers. At the time of this writing, the former case only includes the
+Rockchip DRM driver, while the latter case includes the gud, udl, and
+the tiny appletbdrm and gm12u320 drivers.
+
+Reviewed-by: Thomas Zimmermann <tzimmermann@suse.de>
+Signed-off-by: Chen-Yu Tsai <wenst@chromium.org>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
 ---
  drivers/gpu/drm/drm_prime.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-sun4i-use-backend-mixer-as-dedicated-dma-device.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-sun4i-use-backend-mixer-as-dedicated-dma-device.patch
@@ -1,33 +1,24 @@
-From: Chen-Yu Tsai <wenst@chromium.org>
-Date: Wed, 11 Mar 2026 17:49:28 +0800
-Subject: [PATCH] drm/sun4i: Use backend/mixer as dedicated DMA device
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: EvilOlaf <werner@armbian.com>
+Date: Fri, 27 Mar 2026 15:19:07 +0100
+Subject: [ARCHEOLOGY] sunxi-7.0: drm/gem-dma: Support dedicated DMA device for
+ allocation
 
-The sun4i DRM driver deals with DMA constraints in a peculiar way.
-Instead of using the actual DMA device in various helpers, it justs
-reconfigures the DMA constraints of the virtual display device using
-the DMA device's device tree node by calling of_dma_configure().
+> X-Git-Archeology: - Revision d944703ab8a32e52838f921cb67dd2db6d26b5df: https://github.com/armbian/build/commit/d944703ab8a32e52838f921cb67dd2db6d26b5df
+> X-Git-Archeology:   Date: Fri, 27 Mar 2026 15:19:07 +0100
+> X-Git-Archeology:   From: EvilOlaf <werner@armbian.com>
+> X-Git-Archeology:   Subject: sunxi-7.0: drm/gem-dma: Support dedicated DMA device for allocation
+> X-Git-Archeology:
+---
+ drivers/gpu/drm/sun4i/sun4i_backend.c | 27 +++++-----
+ drivers/gpu/drm/sun4i/sun8i_mixer.c   | 27 +++++-----
+ 2 files changed, 30 insertions(+), 24 deletions(-)
 
-Turns out of_dma_configure() should only be called from bus code.
-Lately this also triggers a big warning through of_iommu_configure()
-and ultimately __iommu_probe_device():
-
-    late IOMMU probe at driver bind, something fishy here!
-
-Now that the GEM DMA helpers have proper support for allocating
-and mapping buffers with a dedicated DMA device, switch over to
-it as the proper solution.
-
-The mixer change was tested on a Pine H64 model B. The backend change
-was only compile tested. Though I don't expect any issues, help testing
-on an older device would be appreciated.
-
-Signed-off-by: Chen-Yu Tsai <wenst@chromium.org>
-Acked-by: Jernej Skrabec <jernej.skrabec@gmail.com>
 diff --git a/drivers/gpu/drm/sun4i/sun4i_backend.c b/drivers/gpu/drm/sun4i/sun4i_backend.c
-index 6391bdc94a5c..a57fb5151def 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/sun4i/sun4i_backend.c
 +++ b/drivers/gpu/drm/sun4i/sun4i_backend.c
-@@ -798,18 +798,21 @@ static int sun4i_backend_bind(struct device *dev, struct device *master,
+@@ -795,18 +795,21 @@ static int sun4i_backend_bind(struct device *dev, struct device *master,
  	dev_set_drvdata(dev, backend);
  	spin_lock_init(&backend->frontend_lock);
  
@@ -62,11 +53,11 @@ index 6391bdc94a5c..a57fb5151def 100644
  	backend->engine.node = dev->of_node;
  	backend->engine.ops = &sun4i_backend_engine_ops;
 diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.c b/drivers/gpu/drm/sun4i/sun8i_mixer.c
-index 02acc7cbdb97..4071ab38b4ae 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_mixer.c
 +++ b/drivers/gpu/drm/sun4i/sun8i_mixer.c
-@@ -536,18 +536,21 @@ static int sun8i_mixer_bind(struct device *dev, struct device *master,
- 	mixer->engine.ops = &sun8i_engine_ops;
+@@ -531,18 +531,21 @@ static int sun8i_mixer_bind(struct device *dev, struct device *master,
+ 	dev_set_drvdata(dev, mixer);
  	mixer->engine.node = dev->of_node;
  
 -	if (of_property_present(dev->of_node, "iommus")) {
@@ -100,5 +91,5 @@ index 02acc7cbdb97..4071ab38b4ae 100644
  	/*
  	 * While this function can fail, we shouldn't do anything
 -- 
-2.53.0.473.g4a7958ca14-goog
+Armbian
 

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-sun4i-use-backend-mixer-as-dedicated-dma-device.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/drm-sun4i-use-backend-mixer-as-dedicated-dma-device.patch
@@ -1,14 +1,29 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: EvilOlaf <werner@armbian.com>
-Date: Fri, 27 Mar 2026 15:19:07 +0100
-Subject: [ARCHEOLOGY] sunxi-7.0: drm/gem-dma: Support dedicated DMA device for
- allocation
+From: Chen-Yu Tsai <wenst@chromium.org>
+Date: Wed, 11 Mar 2026 17:49:28 +0800
+Subject: [PATCH] drm/sun4i: Use backend/mixer as dedicated DMA device
 
-> X-Git-Archeology: - Revision d944703ab8a32e52838f921cb67dd2db6d26b5df: https://github.com/armbian/build/commit/d944703ab8a32e52838f921cb67dd2db6d26b5df
-> X-Git-Archeology:   Date: Fri, 27 Mar 2026 15:19:07 +0100
-> X-Git-Archeology:   From: EvilOlaf <werner@armbian.com>
-> X-Git-Archeology:   Subject: sunxi-7.0: drm/gem-dma: Support dedicated DMA device for allocation
-> X-Git-Archeology:
+The sun4i DRM driver deals with DMA constraints in a peculiar way.
+Instead of using the actual DMA device in various helpers, it justs
+reconfigures the DMA constraints of the virtual display device using
+the DMA device's device tree node by calling of_dma_configure().
+
+Turns out of_dma_configure() should only be called from bus code.
+Lately this also triggers a big warning through of_iommu_configure()
+and ultimately __iommu_probe_device():
+
+    late IOMMU probe at driver bind, something fishy here!
+
+Now that the GEM DMA helpers have proper support for allocating
+and mapping buffers with a dedicated DMA device, switch over to
+it as the proper solution.
+
+The mixer change was tested on a Pine H64 model B. The backend change
+was only compile tested. Though I don't expect any issues, help testing
+on an older device would be appreciated.
+
+Signed-off-by: Chen-Yu Tsai <wenst@chromium.org>
+Acked-by: Jernej Skrabec <jernej.skrabec@gmail.com>
 ---
  drivers/gpu/drm/sun4i/sun4i_backend.c | 27 +++++-----
  drivers/gpu/drm/sun4i/sun8i_mixer.c   | 27 +++++-----

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/drv-iommu-sunxi-add-iommu-driver.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/drv-iommu-sunxi-add-iommu-driver.patch
@@ -9,10 +9,10 @@ Signed-off-by: Marvin Wewer <mwewer37@proton.me>
  drivers/iommu/Makefile               |    3 +
  drivers/iommu/sun55i-iommu-pgtable.c |  468 +++
  drivers/iommu/sun55i-iommu-pgtable.h |  125 +
- drivers/iommu/sun55i-iommu.c         | 1605 ++++++++++
+ drivers/iommu/sun55i-iommu.c         | 1604 ++++++++++
  drivers/iommu/sun55i-iommu.h         |   57 +
  include/sunxi-iommu.h                |   50 +
- 7 files changed, 2318 insertions(+)
+ 7 files changed, 2317 insertions(+)
 
 diff --git a/drivers/iommu/Kconfig b/drivers/iommu/Kconfig
 index 111111111111..222222222222 100644

--- a/patch/kernel/archive/uefi-x86-7.0/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-7.0/4001-asahi-trackpad.patch
@@ -22,7 +22,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2316,6 +2316,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2317,6 +2317,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_I2C:
  		bus = "I2C";
  		break;
@@ -70,7 +70,7 @@ index 111111111111..222222222222 100644
  };
  
  enum hid_battery_status {
-@@ -786,6 +788,8 @@ struct hid_descriptor {
+@@ -787,6 +789,8 @@ struct hid_descriptor {
  	.bus = BUS_BLUETOOTH, .vendor = (ven), .product = (prod)
  #define HID_I2C_DEVICE(ven, prod)				\
  	.bus = BUS_I2C, .vendor = (ven), .product = (prod)
@@ -136,7 +136,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2319,6 +2319,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2320,6 +2320,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_SPI:
  		bus = "SPI";
  		break;


### PR DESCRIPTION
# Description

- rewrite rockchip64 :heavy_check_mark: 
- rewrite meson64: no changes
- rewrite uefi-arm64: no changes
- rewrite uefi-x86  :heavy_check_mark: 
- rewrite sunxi  :heavy_check_mark: 

@rpardini I have issues with three patches (in sunxi) where `rewrite-kernel-patches` persistently removes the original header and replaces it with some archeology stuff. I already tried earlier to restore them with a dedicated commit (https://github.com/armbian/build/commit/faba3a4eb46053be0dfb16f4befa53c01e06a354) in hope that the mechanism would acknowledge but no dice. How to prevent that in future? 

# How Has This Been Tested?

- [x] build rockchip64
- [x] build meson64
- [x] build uefi-arm64
- [x] build uefi-x86
- [x] build sunxi
- [x] build sunxi64
- [ ] ???
- [ ] Profit!

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added USB2 PHY support for RK3528 boards
  * Added IOMMU support for Allwinner A523 SoCs
  * Added I2S MCLK output clock support for RK3588
  * Added configurable PCIe bus scan delay
  * Added HID support for SPI-connected input devices

* **Bug Fixes**
  * Fixed RK3399 PCIe enumeration with SError interrupt handling
  * Fixed RK3528 Ethernet PHY reset configuration
  * Improved Motorcomm eFUSE MAC address reading reliability
  * Fixed RK3528 USB OTG timer cleanup on probe failure

* **Refactor**
  * Updated DRM graphics memory allocation to use dedicated DMA devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->