### PR TITLE
Handle invalid data in COLUMNS env var when determining console width

### DIFF
--- a/lib/functions/compilation/kernel-patching.sh
+++ b/lib/functions/compilation/kernel-patching.sh
@@ -31,7 +31,7 @@ function kernel_main_patching_python() {
 		#"BOARD="                                             # BOARD is needed for the patchset selection logic; mostly for u-boot. empty for kernel.
 		#"TARGET="                                            # TARGET is need for u-boot's SPI/SATA etc selection logic. empty for kernel
 		# For table generation to fit into the screen, or being large when in GHA.
-		"COLUMNS=${COLUMNS}"
+		"COLUMNS=${COLUMNS:-160}"
 		"COLORFGBG=${COLORFGBG}"
 		"GITHUB_ACTIONS=${GITHUB_ACTIONS}"
 		# Needed so git can find the global .gitconfig, and Python can parse the PATH to determine which git to use.

--- a/lib/functions/compilation/uboot-patching.sh
+++ b/lib/functions/compilation/uboot-patching.sh
@@ -26,7 +26,7 @@ function uboot_main_patching_python() {
 		"TARGET=${target_patchdir}"                           # TARGET is need for u-boot's SPI/SATA etc selection logic
 		"USERPATCHES_PATH=${USERPATCHES_PATH}"                # Needed to find the userpatches.
 		# For table generation to fit into the screen, or being large when in GHA.
-		"COLUMNS=${COLUMNS}"
+		"COLUMNS=${COLUMNS:-160}"
 		"COLORFGBG=${COLORFGBG}"
 		"GITHUB_ACTIONS=${GITHUB_ACTIONS}"
 		# Needed so git can find the global .gitconfig, and Python can parse the PATH to determine which git to use.


### PR DESCRIPTION
# Description

Building on the main branch gives me the following error:

```
[👉]    Summary: u-boot patching: 8 total patches; 8 applied; 0 with problems
[👉]    Traceback (most recent call last):
[👉]      File "/opt/broker/firmware/armbian/lib/tools/patching.py", line 447, in <module>
[👉]        console_width = (int(os.environ.get("COLUMNS", 160)) - 12) if os.environ.get("GITHUB_ACTIONS", "") == "" else 160
[👉]                         ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[👉]    ValueError: invalid literal for int() with base 10: ''
[💥]     👆👆👆 Showing logfile above 👆👆👆 [ /opt/broker/firmware/armbian/.tmp/logs-no-uuidgen-yet-28734-9577/023.000.compile_uboot.log ]
[💥] Error 1 occurred in main shell [ at /opt/broker/firmware/armbian/lib/functions/logging/runners.sh:247
    run_host_command_logged_raw() --> lib/functions/logging/runners.sh:247
        run_host_command_logged() --> lib/functions/logging/runners.sh:229
     uboot_main_patching_python() --> lib/functions/compilation/uboot-patching.sh:56
                  do_with_hooks() --> lib/functions/general/extensions.sh:617
             patch_uboot_target() --> lib/functions/compilation/uboot.sh:42
           compile_uboot_target() --> lib/functions/compilation/uboot.sh:69
   loop_over_uboot_targets_and_do() --> lib/functions/compilation/uboot.sh:364
                  compile_uboot() --> lib/functions/compilation/uboot.sh:455
                do_with_logging() --> lib/functions/logging/section-logging.sh:85
   artifact_uboot_build_from_sources() --> lib/functions/artifacts/artifact-uboot.sh:178
    artifact_build_from_sources() --> lib/functions/artifacts/artifacts-obtain.sh:34
       obtain_complete_artifact() --> lib/functions/artifacts/artifacts-obtain.sh:280
       build_artifact_for_image() --> lib/functions/artifacts/artifacts-obtain.sh:392
    main_default_build_packages() --> lib/functions/main/build-packages.sh:102
   full_build_packages_rootfs_and_image() --> lib/functions/main/default-build.sh:31
          do_with_default_build() --> lib/functions/main/default-build.sh:42
         cli_standard_build_run() --> lib/functions/cli/cli-build.sh:25
        armbian_cli_run_command() --> lib/functions/cli/utils-cli.sh:136
                 cli_entrypoint() --> lib/functions/cli/entrypoint.sh:208
                           main() --> ./compile.sh:50
 ]
```

# How Has This Been Tested?

My build now completes, both locally and in CI.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes from malformed console settings by safely parsing width input, falling back to sensible defaults, and enforcing a minimum usable width.
  * Ensures a consistent console width in CI environments and applies the corrected width when initializing the display renderer, improving layout stability and readability.
  * Improved robustness against non-numeric terminal configurations to avoid layout regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->