### PR TITLE
rockchip: RK3506: Increase DMA coherent pool

### DIFF
--- a/config/bootenv/rk3506.txt
+++ b/config/bootenv/rk3506.txt
@@ -1,3 +1,3 @@
 verbosity=1
-extraargs=coherent_pool=4M
+extraargs=coherent_pool=8M
 bootlogo=false


### PR DESCRIPTION
# Description

Increases DMA coherent_pool from 4M to 8M on RK3506.

Fixes issues with ethernet / USB / SPI init on RK3506 boards.

# How Has This Been Tested?

- [x] `ebyte-ecb41-pge` tested change in /boot/armbianEnv.txt -- ethernet works and USB inits (both broken before)
- [x] `luckfox-lyra-plus` tested change in /boot/armbianEnv.txt -- fixes enabling SPI when Ethernet is in use (currently broken)

# Checklist:

- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated memory pool allocation configuration in boot environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->