### PR TITLE
Feature Proposal - armbian-firstlogin add support for web setup fallback

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -763,6 +763,14 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	# Try to get the local IP address (script halts until IP was found or x retries were done)
 	get_local_ip_addr
 
+	if systemctl is-active --quiet armbian-web-config.service; then
+		WEB_SSID="$(cat /etc/hostname)-armbiansetup"
+		echo -e "\n\e[1m\e[96mWeb Configuration Available!\x1B[0m"
+		echo -e "Connect to Wi-Fi SSID: \e[1m\e[92m${WEB_SSID}\x1B[0m"
+		echo -e "Then open \e[1mhttp://10.42.0.1\x1B[0m in your browser"
+		echo -e "Or continue with CLI setup below...\n"
+	fi
+
 	[[ -z "$PRESET_ROOT_PASSWORD" ]] && echo "" # empty line
 
 	trap '' 2


### PR DESCRIPTION
# Description

This includes a hook in armbian-firstlogin to eventually support web based user onboarding (if the service is enabled) 

For what I'm prototyping/planning see -> https://github.com/Grippy98/armbian-web-config 

This comes out of a need to have an easy setup page for some devices that have Wifi/Ethernet but maybe no display or easy way to connect to Serial. 

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * First login now displays Wi-Fi network details and provides a web configuration URL when the web configuration service is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->