### PR TITLE
arduino-uno-q: fix CI build by fetching qcombin at image creation time

### DIFF
--- a/config/boards/arduino-uno-q.csc
+++ b/config/boards/arduino-uno-q.csc
@@ -17,16 +17,35 @@ function post_family_tweaks__arduino-uno-q() {
 	do_with_retries 3 chroot_sdcard_apt_get_update
 	do_with_retries 3 chroot_sdcard_apt_get_install \
 		rmtfs qrtr-tools protection-domain-mapper tqftpserv \
-		bluetooth bluez gdisk adbd qbootctl
+		bluetooth bluez gdisk qbootctl
 
-	# ADB branding
-	chroot_sdcard sed -i 's/"Debian"/"Armbian"/' /usr/lib/android-sdk/platform-tools/adbd-usb-gadget
-	chroot_sdcard sed -i 's/"ADB device"/"Arduino UNO Q"/' /usr/lib/android-sdk/platform-tools/adbd-usb-gadget
+	# USB access: adbd on Debian, USB gadget network on Ubuntu (adbd not available)
+	if [[ "${DISTRIBUTION}" == "Debian" ]]; then
+		do_with_retries 3 chroot_sdcard_apt_get_install adbd
+		chroot_sdcard sed -i 's/"Debian"/"Armbian"/' /usr/lib/android-sdk/platform-tools/adbd-usb-gadget
+		chroot_sdcard sed -i 's/"ADB device"/"Arduino UNO Q"/' /usr/lib/android-sdk/platform-tools/adbd-usb-gadget
+		chroot_sdcard systemctl enable adbd.service
+	else
+		# unudhcpd is in the Armbian repo
+		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.sources
+		do_with_retries 3 chroot_sdcard_apt_get_update
+		do_with_retries 3 chroot_sdcard_apt_get_install unudhcpd
+		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled
+		do_with_retries 3 chroot_sdcard_apt_get_update
+		chroot_sdcard systemctl enable usbgadget-rndis.service
+	fi
 
 	# Enable services
-	chroot_sdcard systemctl enable adbd.service
 	chroot_sdcard systemctl enable qbootctl.service
 	chroot_sdcard systemctl enable armbian-resize-filesystem-qcom.service
+}
+
+function post_family_tweaks_bsp__arduino-uno-q_usb_gadget() {
+	[[ "${DISTRIBUTION}" != "Ubuntu" ]] && return 0
+	display_alert "Installing USB gadget network scripts" "${BOARD}" "info"
+	install -Dm755 "$SRC/packages/bsp/usb-gadget-network/setup-usbgadget-network.sh" "$destination/usr/local/bin/setup-usbgadget-network.sh"
+	install -Dm755 "$SRC/packages/bsp/usb-gadget-network/remove-usbgadget-network.sh" "$destination/usr/local/bin/remove-usbgadget-network.sh"
+	install -Dm644 "$SRC/packages/bsp/usb-gadget-network/usbgadget-rndis.service" "$destination/usr/lib/systemd/system/usbgadget-rndis.service"
 }
 
 function post_family_tweaks_bsp__arduino-uno-q_resize_rootfs() {

--- a/config/sources/families/qrb2210.conf
+++ b/config/sources/families/qrb2210.conf
@@ -11,7 +11,6 @@ ARCH="arm64"
 
 LINUXFAMILY="qrb2210"
 enable_extension "image-output-arduino"
-enable_extension "qcombin"
 declare -g IMAGE_PARTITION_TABLE='gpt'
 declare -g ATF_COMPILE="no"
 declare -g QCOMBIN_DIR="$SRC/cache/sources/qcombin"

--- a/extensions/image-output-arduino.sh
+++ b/extensions/image-output-arduino.sh
@@ -1,44 +1,70 @@
+#!/usr/bin/env bash
+
+# Fetch Qualcomm flash binaries early in the build
+function post_family_config__fetch_qcombin() {
+	display_alert "Fetching qcombin" "${BOARD}" "info"
+	fetch_from_repo "https://github.com/armbian/qcombin" "qcombin" "branch:main"
+}
+
+declare -g ARDUINO_ROOTFS_LOOP=""
+declare -g ARDUINO_ROOTFS_MOUNT=""
+
+# Convert standard Armbian image into a QDL-flashable archive for Arduino UNO Q
 function post_build_image__900_convert_to_arduino_img() {
 	[[ -z $version ]] && exit_with_error "version is not set"
 
-	display_alert "Converting image $version" "${EXTENSION}" "info"
-	declare -g BOOTFS_IMAGE_FILE="${DESTIMG}/${version}.bootfs.img"
-	declare -g ROOTFS_IMAGE_FILE="${DESTIMG}/${version}.rootfs.img"
+	display_alert "Creating QDL flash archive" "${version}" "info"
 
-	# Extract partition offsets from the image using fdisk
 	local img="${DESTIMG}/${version}.img"
-	local sector_size=512
+	local bootfs_img="${DESTIMG}/${version}.bootfs.img"
+	local rootfs_img="${DESTIMG}/${version}.rootfs.img"
+	local outdir="${DESTIMG}/arduino-images"
+	ARDUINO_ROOTFS_MOUNT="${DESTIMG}/rootfs_mount"
 
-	local p1_start=$(fdisk -l "${img}" | grep "${img}1" | awk '{print $2}')
-	local p1_sectors=$(fdisk -l "${img}" | grep "${img}1" | awk '{print $4}')
-	local p2_start=$(fdisk -l "${img}" | grep "${img}2" | awk '{print $2}')
-	local p2_sectors=$(fdisk -l "${img}" | grep "${img}2" | awk '{print $4}')
+	# Extract partition offsets using sfdisk JSON output
+	local p1_start p1_size p2_start p2_size
+	p1_start=$(sfdisk -J "${img}" | python3 -c "import sys,json; p=json.load(sys.stdin)['partitiontable']['partitions']; print(p[0]['start'])")
+	p1_size=$(sfdisk -J "${img}" | python3 -c "import sys,json; p=json.load(sys.stdin)['partitiontable']['partitions']; print(p[0]['size'])")
+	p2_start=$(sfdisk -J "${img}" | python3 -c "import sys,json; p=json.load(sys.stdin)['partitiontable']['partitions']; print(p[1]['start'])")
+	p2_size=$(sfdisk -J "${img}" | python3 -c "import sys,json; p=json.load(sys.stdin)['partitiontable']['partitions']; print(p[1]['size'])")
 
-	display_alert "Extracting boot partition" "offset=${p1_start} sectors=${p1_sectors}" "info"
-	dd if="${img}" of="${BOOTFS_IMAGE_FILE}" bs=${sector_size} skip=${p1_start} count=${p1_sectors} status=progress
+	display_alert "Extracting boot partition" "offset=${p1_start} sectors=${p1_size}" "info"
+	run_host_command_logged dd if="${img}" of="${bootfs_img}" bs=512 skip="${p1_start}" count="${p1_size}" status=progress
 
-	display_alert "Extracting rootfs partition" "offset=${p2_start} sectors=${p2_sectors}" "info"
-	dd if="${img}" of="${ROOTFS_IMAGE_FILE}" bs=${sector_size} skip=${p2_start} count=${p2_sectors} status=progress
+	display_alert "Extracting rootfs partition" "offset=${p2_start} sectors=${p2_size}" "info"
+	run_host_command_logged dd if="${img}" of="${rootfs_img}" bs=512 skip="${p2_start}" count="${p2_size}" status=progress
 
-	rm -rf arduino-images
-	mkdir -p arduino-images/flash
-	cp -r "${QCOMBIN_DIR}/Agatti/arduino-uno-q/"* arduino-images/flash/
-	cp "${QCOMBIN_DIR}/Agatti/prog_firehose_ddr.elf" arduino-images/flash/
+	# Assemble flash directory with qcombin binaries
+	rm -rf "${outdir}"
+	mkdir -p "${outdir}/flash"
+	run_host_command_logged cp -r "${QCOMBIN_DIR}/Agatti/arduino-uno-q/"* "${outdir}/flash/"
+	run_host_command_logged cp "${QCOMBIN_DIR}/Agatti/prog_firehose_ddr.elf" "${outdir}/flash/"
 
-	mkdir -p rootfs_mount
-	local rootfs_loop=$(losetup -f --show "${ROOTFS_IMAGE_FILE}")
-	mount ${rootfs_loop} rootfs_mount
-	cp rootfs_mount/usr/lib/linux-u-boot-${BRANCH}-${BOARD}/boot.img arduino-images/flash/
-	umount rootfs_mount
-	losetup -d ${rootfs_loop}
+	# Extract boot.img (U-Boot) from rootfs
+	mkdir -p "${ARDUINO_ROOTFS_MOUNT}"
+	ARDUINO_ROOTFS_LOOP=$(losetup -f --show "${rootfs_img}")
+	add_cleanup_handler "image_output_arduino_cleanup"
+	mount "${ARDUINO_ROOTFS_LOOP}" "${ARDUINO_ROOTFS_MOUNT}"
+	run_host_command_logged cp "${ARDUINO_ROOTFS_MOUNT}/usr/lib/linux-u-boot-${BRANCH}-${BOARD}/boot.img" "${outdir}/flash/"
+	umount "${ARDUINO_ROOTFS_MOUNT}"
+	losetup -d "${ARDUINO_ROOTFS_LOOP}"
+	ARDUINO_ROOTFS_LOOP=""
 
+	# Replace raw image with flash archive
 	rm "${img}"
+	mv "${bootfs_img}" "${outdir}/disk-sdcard.img.esp"
+	mv "${rootfs_img}" "${outdir}/disk-sdcard.img.root"
 
-	mv ${BOOTFS_IMAGE_FILE} arduino-images/disk-sdcard.img.esp
-	mv ${ROOTFS_IMAGE_FILE} arduino-images/disk-sdcard.img.root
-
-	tar -cvf ${DESTIMG}/${version}.tar arduino-images
-	rm -rf arduino-images
+	display_alert "Creating archive" "${version}.tar" "info"
+	tar -cf "${DESTIMG}/${version}.tar" -C "${DESTIMG}" arduino-images
+	rm -rf "${outdir}"
 
 	return 0
+}
+
+function image_output_arduino_cleanup() {
+	if [[ -n "${ARDUINO_ROOTFS_LOOP}" ]]; then
+		umount "${ARDUINO_ROOTFS_MOUNT}" 2>/dev/null
+		losetup -d "${ARDUINO_ROOTFS_LOOP}" 2>/dev/null
+	fi
 }

--- a/extensions/qcombin.sh
+++ b/extensions/qcombin.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-function fetch_sources_tools__qcombin() {
-	fetch_from_repo "${QCOMBIN_GIT_URL:-"https://github.com/armbian/qcombin"}" "qcombin" "branch:${QCOMBIN_GIT_BRANCH:-"main"}"
-}


### PR DESCRIPTION
## Summary
- Fix CI build failure at `image-output-arduino.sh:25` where qcombin flash binaries were not fetched
- The `qcombin.sh` extension used `fetch_sources_tools` hook which only runs during u-boot compilation — when artifacts are cached (CI), the fetch is skipped
- Move qcombin fetch into `image-output-arduino.sh` using `post_family_config` hook which always runs
- Remove the standalone `qcombin.sh` extension
- Improve image-output extension: sfdisk JSON parsing, proper logging, cleanup handler, quoted variables

## Test plan
- [x] Local build completes successfully
- [x] Output archive created with all flash binaries
- [x] No cleanup handler warnings
- [ ] CI build should now pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Arduino image output now produces a QDL-flashable archive with improved partition extraction and robust cleanup on failure.
  * Board USB gadget provisioning updated: Ubuntu receives dedicated gadget setup and service; Debian gets conditional ADB support; other distros use RNDIS gadget service.

* **Refactor**
  * qcombin integration reorganized — no longer auto-enabled during family config; fetch/handling relocated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->