### PR TITLE
extensions: skip git fetches during config-dump-json

### DIFF
--- a/extensions/gateway-dk-ask.sh
+++ b/extensions/gateway-dk-ask.sh
@@ -51,6 +51,8 @@ function post_family_config__000_ask_override_family() {
 # Fetch ASK repo (sets ASK_CACHE_DIR for all later build phases)
 # Uses post_family_config because the kernel patch staging hook needs it before fetch_sources_tools runs
 function post_family_config__ask_fetch_repo() {
+	# Skip during config-dump-json: no $HOME is set, fetch_from_repo would fail in git_ensure_safe_directory
+	[[ "${CONFIG_DEFS_ONLY}" == "yes" ]] && { declare -g ASK_CACHE_DIR="${SRC}/cache/sources/ask-repo"; return 0; }
 	# For local file:// repos in Docker, safe.directory is needed (container runs as root)
 	# Use env vars instead of git config --global to avoid persistent side effects
 	if [[ "${ASK_REPO}" == file://* ]]; then
@@ -81,6 +83,7 @@ function extension_finish_config__ask_enable_headers() {
 # framework merges them with patches from patch/kernel/ at build time. The directory is
 # gitignored and ephemeral; it does not persist across clean builds.
 function post_family_config__ask_kernel_patch() {
+	[[ "${CONFIG_DEFS_ONLY}" == "yes" ]] && return 0 # cache wasn't populated during config-dump-json
 	local patch_src="${ASK_CACHE_DIR}/patches/kernel/002-mono-gateway-ask-kernel_linux_6_12.patch"
 	[[ -f "${patch_src}" ]] || exit_with_error "ASK kernel patch not found" "${patch_src}"
 	local patch_dst="${SRC}/userpatches/kernel/${KERNELPATCHDIR}"

--- a/extensions/image-output-arduino.sh
+++ b/extensions/image-output-arduino.sh
@@ -2,6 +2,7 @@
 
 # Fetch Qualcomm flash binaries early in the build
 function post_family_config__fetch_qcombin() {
+	[[ "${CONFIG_DEFS_ONLY}" == "yes" ]] && return 0 # skip fetch during config-dump-json (no $HOME, no network needed)
 	display_alert "Fetching qcombin" "${BOARD}" "info"
 	fetch_from_repo "https://github.com/armbian/qcombin" "qcombin" "branch:main"
 }


### PR DESCRIPTION
## Summary

- `arduino-uno-q` and `gateway-dk` were erroring out during `config-dump-json` with `fatal: $HOME not set` from a `git config --global --add safe.directory ...` call.
- Root cause: both boards enable extensions (`image-output-arduino`, `gateway-dk-ask`) that call `fetch_from_repo` from `post_family_config__*` hooks. Those hooks run during config dump, where `$HOME` is unset, so `git_ensure_safe_directory` ([lib/functions/general/git.sh](lib/functions/general/git.sh#L60)) fails on the `--global` git config write.
- Fix: guard the affected hooks with `CONFIG_DEFS_ONLY`, matching the existing pattern in `extensions/ufs.sh`. The fetch (and the kernel-patch staging that depends on its output) is skipped when only collecting config defs. `ASK_CACHE_DIR` is still set so it appears in the JSON dump.

## Test plan

- [x] `CONFIG_DEFS_ONLY=yes ./compile.sh config-dump-json BOARD=arduino-uno-q BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=yes RELEASE=sid` — produces valid JSON, no error
- [x] `CONFIG_DEFS_ONLY=yes ./compile.sh config-dump-json BOARD=gateway-dk BRANCH=current BUILD_DESKTOP=no BUILD_MINIMAL=yes RELEASE=sid` — produces valid JSON, no error
- [x] Full image build for `arduino-uno-q` still fetches qcombin (hook only no-ops when `CONFIG_DEFS_ONLY=yes`)
- [x] Full image build for `gateway-dk` still fetches the ASK repo and stages the kernel patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized configuration operations to skip unnecessary repository downloads when only configuration definitions are required, improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->