### PR TITLE
arduino-uno-q: install USB gadget scripts unconditionally in BSP

### DIFF
--- a/config/boards/arduino-uno-q.csc
+++ b/config/boards/arduino-uno-q.csc
@@ -41,7 +41,8 @@ function post_family_tweaks__arduino-uno-q() {
 }
 
 function post_family_tweaks_bsp__arduino-uno-q_usb_gadget() {
-	[[ "${DISTRIBUTION}" != "Ubuntu" ]] && return 0
+	# BSP is built once and cached across distros, so install files unconditionally.
+	# The usbgadget-rndis service is enabled in post_family_tweaks__ only when adbd is unavailable.
 	display_alert "Installing USB gadget network scripts" "${BOARD}" "info"
 	install -Dm755 "$SRC/packages/bsp/usb-gadget-network/setup-usbgadget-network.sh" "$destination/usr/local/bin/setup-usbgadget-network.sh"
 	install -Dm755 "$SRC/packages/bsp/usb-gadget-network/remove-usbgadget-network.sh" "$destination/usr/local/bin/remove-usbgadget-network.sh"


### PR DESCRIPTION
## Summary
Fix Ubuntu builds failing with \`Failed to enable unit, unit usbgadget-rndis.service does not exist\` on CI.

The BSP package is built once per board+branch and cached across all distributions. Conditioning the installation on \`DISTRIBUTION\` inside a \`post_family_tweaks_bsp__\` hook causes the CI to cache a BSP built for Debian (without gadget files), then reuse it for Ubuntu builds where \`systemctl enable usbgadget-rndis.service\` fails because the service file is missing in the cached BSP.

This is why no other board uses \`DISTRIBUTION\` checks in \`post_family_tweaks_bsp__\` — they only use them in \`pre_customize_image__\` which runs per-distro.

## Fix
Install the USB gadget files unconditionally in the BSP (they're harmless if unused) and keep the service enablement conditional in \`post_family_tweaks__\` where \`DISTRIBUTION\` can be reliably checked per-image.

## Test plan
- [x] Log confirms the issue: https://paste.armbian.com/zuzopofuqa
- [ ] CI builds should pass for both Debian Trixie and Ubuntu Noble

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Arduino Uno USB gadget functionality to work more consistently across different Linux distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->