### PR TITLE
u-boot: v2026.01: fix BTRFS zstd decompression failure (error 70)

### DIFF
--- a/patch/u-boot/v2025.10/board_helios4/general-fix-btrfs-zstd-decompression.patch
+++ b/patch/u-boot/v2025.10/board_helios4/general-fix-btrfs-zstd-decompression.patch
@@ -1,0 +1,119 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Velkov <iav-armbian@draconpern.com>
+Date: Thu, 10 Apr 2026 00:00:00 +0000
+Subject: [PATCH] fs: btrfs: fix zstd decompression for BTRFS extents
+
+The generic zstd_decompress() wrapper in lib/zstd/zstd.c works for FIT
+images but fails for BTRFS filesystem extents due to two issues:
+
+1. Sector-aligned compressed size: BTRFS stores compressed extents
+   padded to sector boundaries (4096 bytes).  The on-disk size
+   (disk_num_bytes) may be larger than the actual zstd frame.
+   zstd_decompress_dctx() rejects trailing data after the frame,
+   causing decompression failures for regular (non-inline) extents.
+
+2. Sector-aligned decompressed size: BTRFS compresses in sector-sized
+   blocks, so the zstd frame content size may exceed the actual data
+   size (ram_bytes) stored in extent metadata.  For example, a 3906
+   byte file is compressed as a 4096 byte block.  When the output
+   buffer is sized to ram_bytes, zstd_decompress_dctx() fails with
+   ZSTD_error_dstSize_tooSmall (error 70) for inline extents.
+
+Both issues manifest as boot failures on zstd-compressed BTRFS:
+
+  zstd_decompress: failed to decompress: 70
+  BTRFS: An error occurred while reading file /boot/boot.scr
+
+Fix by calling zstd_decompress_dctx() directly with two adjustments:
+- Use zstd_find_frame_compressed_size() to strip sector padding from
+  the input, giving zstd the exact frame size.
+- Use ZSTD_getFrameContentSize() to detect when the frame decompresses
+  to more than dlen bytes, and allocate a temporary buffer for the
+  full decompressed frame when needed.
+
+This is consistent with decompress_lzo() and decompress_zlib() which
+also call their library functions directly without generic wrappers.
+
+Signed-off-by: Igor Velkov <iav-armbian@draconpern.com>
+---
+ fs/btrfs/compression.c | 66 +++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 62 insertions(+), 4 deletions(-)
+
+diff --git a/fs/btrfs/compression.c b/fs/btrfs/compression.c
+--- a/fs/btrfs/compression.c
++++ b/fs/btrfs/compression.c
+@@ -137,12 +137,70 @@
+
+ static u32 decompress_zstd(const u8 *cbuf, u32 clen, u8 *dbuf, u32 dlen)
+ {
+-	struct abuf in, out;
++	zstd_dctx *ctx;
++	size_t wsize, ret, frame_csize, out_len;
++	void *workspace;
++	unsigned long long fcs;
++	u8 *tmp = NULL;
++	u8 *out_buf = dbuf;
++
++	out_len = dlen;
+
+-	abuf_init_set(&in, (u8 *)cbuf, clen);
+-	abuf_init_set(&out, dbuf, dlen);
++	/*
++	 * Find the actual compressed frame size. BTRFS stores compressed
++	 * extents padded to sector boundaries, but zstd_decompress_dctx()
++	 * requires the exact frame size without trailing padding.
++	 */
++	frame_csize = zstd_find_frame_compressed_size(cbuf, clen);
++	if (!zstd_is_error(frame_csize))
++		clen = frame_csize;
+
+-	return zstd_decompress(&in, &out);
++	/*
++	 * BTRFS compresses in sector-sized blocks, so the zstd frame may
++	 * decompress to a full sector (e.g. 4096) even when the actual
++	 * data (ram_bytes) is smaller. Allocate a larger buffer when needed
++	 * to avoid ZSTD_error_dstSize_tooSmall.
++	 */
++	fcs = ZSTD_getFrameContentSize(cbuf, clen);
++	if (fcs != ZSTD_CONTENTSIZE_ERROR &&
++	    fcs != ZSTD_CONTENTSIZE_UNKNOWN && fcs > dlen) {
++		if (fcs > SIZE_MAX)
++			return -1;
++		tmp = malloc(fcs);
++		if (!tmp)
++			return -1;
++		out_buf = tmp;
++		out_len = fcs;
++	}
++
++	wsize = zstd_dctx_workspace_bound();
++	workspace = malloc(wsize);
++	if (!workspace) {
++		free(tmp);
++		return -1;
++	}
++
++	ctx = zstd_init_dctx(workspace, wsize);
++	if (!ctx) {
++		free(workspace);
++		free(tmp);
++		return -1;
++	}
++
++	ret = zstd_decompress_dctx(ctx, out_buf, out_len, cbuf, clen);
++	free(workspace);
++
++	if (zstd_is_error(ret)) {
++		free(tmp);
++		return -1;
++	}
++
++	if (tmp) {
++		memcpy(dbuf, tmp, dlen);
++		free(tmp);
++	}
++
++	return dlen;
+ }
+
+ u32 btrfs_decompress(u8 type, const char *c, u32 clen, char *d, u32 dlen)

--- a/patch/u-boot/v2025.10/general-fix-btrfs-zstd-decompression.patch
+++ b/patch/u-boot/v2025.10/general-fix-btrfs-zstd-decompression.patch
@@ -1,0 +1,119 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Velkov <iav-armbian@draconpern.com>
+Date: Thu, 10 Apr 2026 00:00:00 +0000
+Subject: [PATCH] fs: btrfs: fix zstd decompression for BTRFS extents
+
+The generic zstd_decompress() wrapper in lib/zstd/zstd.c works for FIT
+images but fails for BTRFS filesystem extents due to two issues:
+
+1. Sector-aligned compressed size: BTRFS stores compressed extents
+   padded to sector boundaries (4096 bytes).  The on-disk size
+   (disk_num_bytes) may be larger than the actual zstd frame.
+   zstd_decompress_dctx() rejects trailing data after the frame,
+   causing decompression failures for regular (non-inline) extents.
+
+2. Sector-aligned decompressed size: BTRFS compresses in sector-sized
+   blocks, so the zstd frame content size may exceed the actual data
+   size (ram_bytes) stored in extent metadata.  For example, a 3906
+   byte file is compressed as a 4096 byte block.  When the output
+   buffer is sized to ram_bytes, zstd_decompress_dctx() fails with
+   ZSTD_error_dstSize_tooSmall (error 70) for inline extents.
+
+Both issues manifest as boot failures on zstd-compressed BTRFS:
+
+  zstd_decompress: failed to decompress: 70
+  BTRFS: An error occurred while reading file /boot/boot.scr
+
+Fix by calling zstd_decompress_dctx() directly with two adjustments:
+- Use zstd_find_frame_compressed_size() to strip sector padding from
+  the input, giving zstd the exact frame size.
+- Use ZSTD_getFrameContentSize() to detect when the frame decompresses
+  to more than dlen bytes, and allocate a temporary buffer for the
+  full decompressed frame when needed.
+
+This is consistent with decompress_lzo() and decompress_zlib() which
+also call their library functions directly without generic wrappers.
+
+Signed-off-by: Igor Velkov <iav-armbian@draconpern.com>
+---
+ fs/btrfs/compression.c | 66 +++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 62 insertions(+), 4 deletions(-)
+
+diff --git a/fs/btrfs/compression.c b/fs/btrfs/compression.c
+--- a/fs/btrfs/compression.c
++++ b/fs/btrfs/compression.c
+@@ -137,12 +137,70 @@
+
+ static u32 decompress_zstd(const u8 *cbuf, u32 clen, u8 *dbuf, u32 dlen)
+ {
+-	struct abuf in, out;
++	zstd_dctx *ctx;
++	size_t wsize, ret, frame_csize, out_len;
++	void *workspace;
++	unsigned long long fcs;
++	u8 *tmp = NULL;
++	u8 *out_buf = dbuf;
++
++	out_len = dlen;
+
+-	abuf_init_set(&in, (u8 *)cbuf, clen);
+-	abuf_init_set(&out, dbuf, dlen);
++	/*
++	 * Find the actual compressed frame size. BTRFS stores compressed
++	 * extents padded to sector boundaries, but zstd_decompress_dctx()
++	 * requires the exact frame size without trailing padding.
++	 */
++	frame_csize = zstd_find_frame_compressed_size(cbuf, clen);
++	if (!zstd_is_error(frame_csize))
++		clen = frame_csize;
+
+-	return zstd_decompress(&in, &out);
++	/*
++	 * BTRFS compresses in sector-sized blocks, so the zstd frame may
++	 * decompress to a full sector (e.g. 4096) even when the actual
++	 * data (ram_bytes) is smaller. Allocate a larger buffer when needed
++	 * to avoid ZSTD_error_dstSize_tooSmall.
++	 */
++	fcs = ZSTD_getFrameContentSize(cbuf, clen);
++	if (fcs != ZSTD_CONTENTSIZE_ERROR &&
++	    fcs != ZSTD_CONTENTSIZE_UNKNOWN && fcs > dlen) {
++		if (fcs > SIZE_MAX)
++			return -1;
++		tmp = malloc(fcs);
++		if (!tmp)
++			return -1;
++		out_buf = tmp;
++		out_len = fcs;
++	}
++
++	wsize = zstd_dctx_workspace_bound();
++	workspace = malloc(wsize);
++	if (!workspace) {
++		free(tmp);
++		return -1;
++	}
++
++	ctx = zstd_init_dctx(workspace, wsize);
++	if (!ctx) {
++		free(workspace);
++		free(tmp);
++		return -1;
++	}
++
++	ret = zstd_decompress_dctx(ctx, out_buf, out_len, cbuf, clen);
++	free(workspace);
++
++	if (zstd_is_error(ret)) {
++		free(tmp);
++		return -1;
++	}
++
++	if (tmp) {
++		memcpy(dbuf, tmp, dlen);
++		free(tmp);
++	}
++
++	return dlen;
+ }
+
+ u32 btrfs_decompress(u8 type, const char *c, u32 clen, char *d, u32 dlen)

--- a/patch/u-boot/v2026.01/board_helios64/general-fix-btrfs-zstd-decompression.patch
+++ b/patch/u-boot/v2026.01/board_helios64/general-fix-btrfs-zstd-decompression.patch
@@ -1,0 +1,119 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Velkov <iav-armbian@draconpern.com>
+Date: Thu, 10 Apr 2026 00:00:00 +0000
+Subject: [PATCH] fs: btrfs: fix zstd decompression for BTRFS extents
+
+The generic zstd_decompress() wrapper in lib/zstd/zstd.c works for FIT
+images but fails for BTRFS filesystem extents due to two issues:
+
+1. Sector-aligned compressed size: BTRFS stores compressed extents
+   padded to sector boundaries (4096 bytes).  The on-disk size
+   (disk_num_bytes) may be larger than the actual zstd frame.
+   zstd_decompress_dctx() rejects trailing data after the frame,
+   causing decompression failures for regular (non-inline) extents.
+
+2. Sector-aligned decompressed size: BTRFS compresses in sector-sized
+   blocks, so the zstd frame content size may exceed the actual data
+   size (ram_bytes) stored in extent metadata.  For example, a 3906
+   byte file is compressed as a 4096 byte block.  When the output
+   buffer is sized to ram_bytes, zstd_decompress_dctx() fails with
+   ZSTD_error_dstSize_tooSmall (error 70) for inline extents.
+
+Both issues manifest as boot failures on zstd-compressed BTRFS:
+
+  zstd_decompress: failed to decompress: 70
+  BTRFS: An error occurred while reading file /boot/boot.scr
+
+Fix by calling zstd_decompress_dctx() directly with two adjustments:
+- Use zstd_find_frame_compressed_size() to strip sector padding from
+  the input, giving zstd the exact frame size.
+- Use ZSTD_getFrameContentSize() to detect when the frame decompresses
+  to more than dlen bytes, and allocate a temporary buffer for the
+  full decompressed frame when needed.
+
+This is consistent with decompress_lzo() and decompress_zlib() which
+also call their library functions directly without generic wrappers.
+
+Signed-off-by: Igor Velkov <iav-armbian@draconpern.com>
+---
+ fs/btrfs/compression.c | 66 +++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 62 insertions(+), 4 deletions(-)
+
+diff --git a/fs/btrfs/compression.c b/fs/btrfs/compression.c
+--- a/fs/btrfs/compression.c
++++ b/fs/btrfs/compression.c
+@@ -137,12 +137,70 @@
+
+ static u32 decompress_zstd(const u8 *cbuf, u32 clen, u8 *dbuf, u32 dlen)
+ {
+-	struct abuf in, out;
++	zstd_dctx *ctx;
++	size_t wsize, ret, frame_csize, out_len;
++	void *workspace;
++	unsigned long long fcs;
++	u8 *tmp = NULL;
++	u8 *out_buf = dbuf;
++
++	out_len = dlen;
+
+-	abuf_init_set(&in, (u8 *)cbuf, clen);
+-	abuf_init_set(&out, dbuf, dlen);
++	/*
++	 * Find the actual compressed frame size. BTRFS stores compressed
++	 * extents padded to sector boundaries, but zstd_decompress_dctx()
++	 * requires the exact frame size without trailing padding.
++	 */
++	frame_csize = zstd_find_frame_compressed_size(cbuf, clen);
++	if (!zstd_is_error(frame_csize))
++		clen = frame_csize;
+
+-	return zstd_decompress(&in, &out);
++	/*
++	 * BTRFS compresses in sector-sized blocks, so the zstd frame may
++	 * decompress to a full sector (e.g. 4096) even when the actual
++	 * data (ram_bytes) is smaller. Allocate a larger buffer when needed
++	 * to avoid ZSTD_error_dstSize_tooSmall.
++	 */
++	fcs = ZSTD_getFrameContentSize(cbuf, clen);
++	if (fcs != ZSTD_CONTENTSIZE_ERROR &&
++	    fcs != ZSTD_CONTENTSIZE_UNKNOWN && fcs > dlen) {
++		if (fcs > SIZE_MAX)
++			return -1;
++		tmp = malloc(fcs);
++		if (!tmp)
++			return -1;
++		out_buf = tmp;
++		out_len = fcs;
++	}
++
++	wsize = zstd_dctx_workspace_bound();
++	workspace = malloc(wsize);
++	if (!workspace) {
++		free(tmp);
++		return -1;
++	}
++
++	ctx = zstd_init_dctx(workspace, wsize);
++	if (!ctx) {
++		free(workspace);
++		free(tmp);
++		return -1;
++	}
++
++	ret = zstd_decompress_dctx(ctx, out_buf, out_len, cbuf, clen);
++	free(workspace);
++
++	if (zstd_is_error(ret)) {
++		free(tmp);
++		return -1;
++	}
++
++	if (tmp) {
++		memcpy(dbuf, tmp, dlen);
++		free(tmp);
++	}
++
++	return dlen;
+ }
+
+ u32 btrfs_decompress(u8 type, const char *c, u32 clen, char *d, u32 dlen)


### PR DESCRIPTION
## Summary

- Fix zstd decompression in U-Boot when booting from a BTRFS partition with zstd compression
- The generic `zstd_decompress()` wrapper in `lib/zstd/zstd.c` fails for BTRFS extents due to two sector-alignment mismatches
- Call `zstd_decompress_dctx()` directly with `zstd_find_frame_compressed_size()` to strip input padding and `ZSTD_getFrameContentSize()` to handle output buffer size mismatch
- Patch applies to both v2026.01 and v2025.10 (`fs/btrfs/compression.c` is identical)
- The patch may also apply to v26.04, but I haven't tested it on real hardware.

### Root cause

1. **Sector-aligned compressed size**: BTRFS stores compressed extents padded to sector boundaries (4096 bytes). `zstd_decompress_dctx()` rejects trailing data after the zstd frame, breaking regular (non-inline) extents.

2. **Sector-aligned decompressed size**: BTRFS compresses in sector-sized blocks, so the zstd frame content size may exceed `ram_bytes` from extent metadata (e.g. a 3906-byte file is compressed as a 4096-byte block). `zstd_decompress_dctx()` returns `ZSTD_error_dstSize_tooSmall` (error 70) for inline extents.

Symptoms:
```
zstd_decompress: failed to decompress: 70
BTRFS: An error occurred while reading file /boot/boot.scr
```

## Testing done

- [x] Helios64 (RK3399), U-Boot v2026.01, SD card with BTRFS + zstd compression
- [x] Helios4 (Marvell A388), U-Boot v2025.10, BTRFS + zstd — boots successfully
- [x] boot.scr, armbianEnv.txt (inline extents) read successfully
- [x] Image (37MB), DTB (90KB), uInitrd (30MB) (regular compressed extents) read successfully
- [x] Kernel starts, system boots to login prompt

🤖 Assisted by [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed BTRFS zstd decompression handling for properly processing sector-aligned padding and oversized buffers in U-Boot v2025.10 and v2026.01, improving compatibility with compressed BTRFS filesystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->