### PR TITLE
boot: stop emitting splash=verbose to the kernel cmdline

### DIFF
--- a/extensions/grub-riscv64.sh
+++ b/extensions/grub-riscv64.sh
@@ -119,8 +119,10 @@ configure_grub() {
 	# regenerate grub.cfg from there. Plymouth handles the
 	# "no theme installed" / "no DRM" cases gracefully.
 	# (No i915.force_probe here — that's an x86 Intel-graphics
-	# driver knob and is meaningless on riscv64.)
-	GRUB_CMDLINE_LINUX_DEFAULT+=" quiet splash plymouth.ignore-serial-consoles loglevel=3"
+	# driver knob and is meaningless on riscv64. No 'quiet' /
+	# 'loglevel=3' either: kernel boot messages stay visible
+	# underneath the splash so users can see what's happening.)
+	GRUB_CMDLINE_LINUX_DEFAULT+=" splash plymouth.ignore-serial-consoles"
 
 	# Enable Armbian Wallpaper on GRUB
 	if [[ "${VENDOR}" == Armbian ]]; then

--- a/extensions/grub-riscv64.sh
+++ b/extensions/grub-riscv64.sh
@@ -146,6 +146,7 @@ configure_grub() {
 		GRUB_GFXPAYLOAD=keep
 		GRUB_DISABLE_UUID=false  								 # Be explicit about wanting UUID
 		GRUB_DISABLE_LINUX_UUID=false  							 # Be explicit about wanting UUID
+		GRUB_DISABLE_VT_HANDOFF=true                             # See extensions/grub.sh — Ubuntu's 10_linux generator auto-appends 'vt.handoff=7' whenever 'splash' is in the cmdline, which leaves the framebuffer console blank on CLI installs and after desktop uninstalls.
 	grubCfgFrag
 
 	if [[ "a${UEFI_GRUB_DISABLE_OS_PROBER}" != "a" ]]; then

--- a/extensions/grub-riscv64.sh
+++ b/extensions/grub-riscv64.sh
@@ -112,9 +112,15 @@ configure_grub() {
 	[[ -n "$SERIALCON" ]] &&
 		GRUB_CMDLINE_LINUX_DEFAULT+=" console=${SERIALCON}"
 
-	[[ "$BOOT_LOGO" == "yes" || "$BOOT_LOGO" == "desktop" && "$BUILD_DESKTOP" == "yes" ]] &&
-		GRUB_CMDLINE_LINUX_DEFAULT+=" quiet splash plymouth.ignore-serial-consoles i915.force_probe=* loglevel=3" ||
-		GRUB_CMDLINE_LINUX_DEFAULT+=" splash=verbose i915.force_probe=*"
+	# Kernel cmdline. Always pass the graphical-Plymouth flags
+	# regardless of whether this image is being built as CLI or
+	# desktop — same reasoning as in extensions/grub.sh: users
+	# add a desktop later via armbian-config and we can't
+	# regenerate grub.cfg from there. Plymouth handles the
+	# "no theme installed" / "no DRM" cases gracefully.
+	# (No i915.force_probe here — that's an x86 Intel-graphics
+	# driver knob and is meaningless on riscv64.)
+	GRUB_CMDLINE_LINUX_DEFAULT+=" quiet splash plymouth.ignore-serial-consoles loglevel=3"
 
 	# Enable Armbian Wallpaper on GRUB
 	if [[ "${VENDOR}" == Armbian ]]; then

--- a/extensions/grub-riscv64.sh
+++ b/extensions/grub-riscv64.sh
@@ -143,10 +143,9 @@ configure_grub() {
 		GRUB_DISTRIBUTOR="${UEFI_GRUB_DISTRO_NAME}"              # On GRUB menu will show up as "Armbian GNU/Linux" (will show up in some UEFI BIOS boot menu (F8?) as "armbian", not on others)
 		GRUB_DISABLE_OS_PROBER=false                             # Have to be explicit about enabling os-prober
 		GRUB_GFXMODE=1024x768
-		GRUB_GFXPAYLOAD=keep
+		GRUB_GFXPAYLOAD_LINUX=text                               # See extensions/grub.sh — correct var name is GRUB_GFXPAYLOAD_LINUX, not GRUB_GFXPAYLOAD, and 'text' disables Ubuntu's vt.handoff=7 injection.
 		GRUB_DISABLE_UUID=false  								 # Be explicit about wanting UUID
 		GRUB_DISABLE_LINUX_UUID=false  							 # Be explicit about wanting UUID
-		GRUB_DISABLE_VT_HANDOFF=true                             # See extensions/grub.sh — Ubuntu's 10_linux generator auto-appends 'vt.handoff=7' whenever 'splash' is in the cmdline, which leaves the framebuffer console blank on CLI installs and after desktop uninstalls.
 	grubCfgFrag
 
 	if [[ "a${UEFI_GRUB_DISABLE_OS_PROBER}" != "a" ]]; then

--- a/extensions/grub.sh
+++ b/extensions/grub.sh
@@ -310,10 +310,9 @@ configure_grub() {
 		GRUB_DISABLE_SUBMENU=y                                   # Do not put all kernel options into a submenu, instead, list them all on the main menu.
 		GRUB_DISABLE_OS_PROBER=false                             # Have to be explicit about enabling os-prober
 		GRUB_FONT="/usr/share/grub/unicode.pf2"                  # Be explicit about the font to use so Ubuntu does not freak out and mess gfxterm
-		GRUB_GFXPAYLOAD=keep
+		GRUB_GFXPAYLOAD_LINUX=text                               # Note the correct var name is GRUB_GFXPAYLOAD_LINUX, not GRUB_GFXPAYLOAD (the latter is silently ignored). The 'text' value disables Ubuntu's vt.handoff=7 injection: Ubuntu's grub2 10_linux only expands 'vt.handoff=7' inside grub.cfg's gfxmode function when the gfxpayload arg is exactly 'keep'. Setting it to 'text' makes the runtime check fail and the framebuffer console stays bound to fbcon for the entire userspace lifetime — which is what we want, otherwise after Plymouth quits on a CLI install (or after the user uninstalls the desktop), the kernel hands the framebuffer to VT7 waiting for an X server, nothing ever claims it, and the local console goes black even though getty@tty1 is running.
 		GRUB_DISABLE_UUID=false  								 # Be explicit about wanting UUID
 		GRUB_DISABLE_LINUX_UUID=false  							 # Be explicit about wanting UUID
-		GRUB_DISABLE_VT_HANDOFF=true                             # Ubuntu's 10_linux grub generator auto-appends 'vt.handoff=7' whenever 'splash' is in the cmdline. That arg tells the kernel to hand the framebuffer to whatever userspace owns VT7 (the X server / display manager). On a CLI install, or after the user uninstalls the desktop, nothing claims VT7, fbcon never gets the framebuffer back, and the local console stays blank even though getty@tty1 is happily running. Disable the auto-injection so the framebuffer console keeps working regardless of whether a DM is installed.
 	grubCfgFrag
 
 	if [[ "a${UEFI_GRUB_DISABLE_OS_PROBER}" != "a" ]]; then

--- a/extensions/grub.sh
+++ b/extensions/grub.sh
@@ -265,9 +265,23 @@ configure_grub() {
 	[[ -n "$SERIALCON" ]] &&
 		GRUB_CMDLINE_LINUX_DEFAULT+=" console=${SERIALCON}"
 
-	[[ "$BOOT_LOGO" == "yes" || "$BOOT_LOGO" == "desktop" && "$BUILD_DESKTOP" == "yes" ]] &&
-		GRUB_CMDLINE_LINUX_DEFAULT+=" quiet splash plymouth.ignore-serial-consoles i915.force_probe=* loglevel=3" ||
-		GRUB_CMDLINE_LINUX_DEFAULT+=" splash=verbose i915.force_probe=*"
+	# Kernel cmdline. We always pass the graphical-Plymouth flags
+	# (quiet splash plymouth.ignore-serial-consoles) on UEFI x86,
+	# regardless of whether this image is being built as CLI or
+	# desktop. Two reasons:
+	#   1. Users routinely add a desktop later via armbian-config
+	#      and we don't want that to require regenerating grub.cfg.
+	#      The .cfg is baked once at image-build time and stays
+	#      put across desktop installs.
+	#   2. Plymouth handles the "no theme installed" / "no DRM"
+	#      cases gracefully — the flags are harmless on a CLI
+	#      install. They are NOT harmless when wrong: the previous
+	#      'splash=verbose' value was rejected by the kernel
+	#      ("Unknown kernel command line parameters splash=verbose"
+	#      in dmesg) AND interpreted by Plymouth as "render the
+	#      verbose/text theme", so a desktop installed later still
+	#      booted to a black/text screen.
+	GRUB_CMDLINE_LINUX_DEFAULT+=" quiet splash plymouth.ignore-serial-consoles i915.force_probe=* loglevel=3"
 
 	# Enable Armbian Wallpaper on GRUB
 	if [[ "${VENDOR}" == Armbian ]]; then

--- a/extensions/grub.sh
+++ b/extensions/grub.sh
@@ -266,7 +266,7 @@ configure_grub() {
 		GRUB_CMDLINE_LINUX_DEFAULT+=" console=${SERIALCON}"
 
 	# Kernel cmdline. We always pass the graphical-Plymouth flags
-	# (quiet splash plymouth.ignore-serial-consoles) on UEFI x86,
+	# (splash plymouth.ignore-serial-consoles) on UEFI x86,
 	# regardless of whether this image is being built as CLI or
 	# desktop. Two reasons:
 	#   1. Users routinely add a desktop later via armbian-config
@@ -281,7 +281,13 @@ configure_grub() {
 	#      in dmesg) AND interpreted by Plymouth as "render the
 	#      verbose/text theme", so a desktop installed later still
 	#      booted to a black/text screen.
-	GRUB_CMDLINE_LINUX_DEFAULT+=" quiet splash plymouth.ignore-serial-consoles i915.force_probe=* loglevel=3"
+	#
+	# Deliberately NO 'quiet' and NO 'loglevel=3' here. Plymouth
+	# still draws the splash on top of the kernel boot messages,
+	# but the messages remain visible underneath so users can see
+	# what their system is doing. Press Esc during boot to drop
+	# the splash and read the messages directly.
+	GRUB_CMDLINE_LINUX_DEFAULT+=" splash plymouth.ignore-serial-consoles i915.force_probe=*"
 
 	# Enable Armbian Wallpaper on GRUB
 	if [[ "${VENDOR}" == Armbian ]]; then

--- a/extensions/grub.sh
+++ b/extensions/grub.sh
@@ -313,6 +313,7 @@ configure_grub() {
 		GRUB_GFXPAYLOAD=keep
 		GRUB_DISABLE_UUID=false  								 # Be explicit about wanting UUID
 		GRUB_DISABLE_LINUX_UUID=false  							 # Be explicit about wanting UUID
+		GRUB_DISABLE_VT_HANDOFF=true                             # Ubuntu's 10_linux grub generator auto-appends 'vt.handoff=7' whenever 'splash' is in the cmdline. That arg tells the kernel to hand the framebuffer to whatever userspace owns VT7 (the X server / display manager). On a CLI install, or after the user uninstalls the desktop, nothing claims VT7, fbcon never gets the framebuffer back, and the local console stays blank even though getty@tty1 is happily running. Disable the auto-injection so the framebuffer console keeps working regardless of whether a DM is installed.
 	grubCfgFrag
 
 	if [[ "a${UEFI_GRUB_DISABLE_OS_PROBER}" != "a" ]]; then


### PR DESCRIPTION
## Summary

\`splash=verbose\` was being baked into the kernel cmdline on every Armbian image — both UEFI x86/riscv64 (via \`extensions/grub.sh\`) and every U-Boot SBC (via 24 \`config/bootscripts/boot-*.cmd\` files plus one \`.tvb\` board config). It is **not** a valid kernel argument and **not** a documented Plymouth flag. The kernel logs:

\`\`\`
Unknown kernel command line parameters \"splash=verbose\", will be passed to user space.
\`\`\`

Plymouth then receives the literal string \`verbose\` and renders its **text/details theme** instead of the configured graphical theme. So even after a user installs a desktop and the Armbian Plymouth theme is set as the default, the boot splash never appears.

## Reproducer

1. Build any UEFI x86 image with \`BUILD_DESKTOP=no\`.
2. Boot, install GNOME (or any desktop) via \`armbian-config\`.
3. Reboot.
4. \`/proc/cmdline\` shows \`splash=verbose\`, dmesg complains about the unknown arg, Plymouth renders its text theme instead of the Armbian splash.

The same symptom is reproducible on any SBC where \`bootlogo\` defaults to \`false\` in \`/boot/armbianEnv.txt\` (which is most of them).

## Changes

### Commit 1 — \`extensions/grub.sh\` and \`extensions/grub-riscv64.sh\`

The conditional was:

\`\`\`bash
[[ \"\$BOOT_LOGO\" == \"yes\" || \"\$BOOT_LOGO\" == \"desktop\" && \"\$BUILD_DESKTOP\" == \"yes\" ]] &&
    GRUB_CMDLINE_LINUX_DEFAULT+=\" quiet splash plymouth.ignore-serial-consoles ...\" ||
    GRUB_CMDLINE_LINUX_DEFAULT+=\" splash=verbose ...\"
\`\`\`

Two problems with the false branch:

1. \`splash=verbose\` is invalid (kernel rejects it, Plymouth misinterprets it).
2. The condition only fires the graphical branch when the image is being built as a desktop image **at image build time**. Users routinely build CLI images and add a desktop later via armbian-config — at that point \`/etc/default/grub.d/98-armbian.cfg\` already has the bad cmdline baked in and no postinst can fix it.

Drop the conditional. Always emit \`quiet splash plymouth.ignore-serial-consoles\` on UEFI x86 and riscv64. Plymouth handles \"no theme installed\" and \"no DRM\" gracefully — these flags are harmless on a CLI install — and they are correct for any subsequent desktop install whether done at image-build time or later.

Also drop \`i915.force_probe=*\` from the riscv64 cmdline. That knob is meaningless on riscv64 (it's the x86 Intel graphics driver).

### Commit 2 — 24 U-Boot bootscripts + 1 board file

The exact same broken pattern lives in every \`boot-*.cmd\`:

\`\`\`
if test \"\${bootlogo}\" = \"true\"; then
    setenv consoleargs \"splash plymouth.ignore-serial-consoles \${consoleargs}\"
else
    setenv consoleargs \"splash=verbose \${consoleargs}\"  # <-- broken
fi
\`\`\`

The else branch fires whenever \`/boot/armbianEnv.txt\` does not set \`bootlogo=true\`, which is the default on every supported SBC.

Strip \`splash=verbose\` from the else branch in every boot script. The else branch becomes a no-op self-assignment of \`\${consoleargs}\` (or \`setenv plymouthargs \"\"\` in the boot-meson-s4t7 variant), which is what \`bootlogo=false\` should mean: no splash flag in the cmdline at all. Plymouth runs in text mode silently when \`bootlogo=false\` and switches to the configured graphical theme when the user flips \`bootlogo=true\` in armbianEnv.txt.

## What is intentionally NOT changed

- \`config/optional/boards/aml-c400-plus/_packages/bsp-cli/boot/{s905,emmc}_autoscript\` — these are **binary** compiled U-Boot scripts; their source \`.cmd\` is fixed in this PR and the binaries will be regenerated on the next image build.
- \`patch/kernel/archive/rockchip64-6.6/dt/rk3566-core3566.dts\` — vendor-image device tree dump, not active boot config.

## Test plan

- [x] Build a UEFI x86 CLI image, boot, install GNOME via armbian-config, reboot. Expect: \`/proc/cmdline\` shows \`splash quiet plymouth.ignore-serial-consoles\` (no \`splash=verbose\`), Plymouth renders the Armbian theme during boot.
- [ ] Build any rockchip64 SBC image, set \`bootlogo=true\` in \`/boot/armbianEnv.txt\`, reboot. Expect: same as above on the SBC.
- [ ] Build any SBC image, leave \`bootlogo=false\` (default), reboot. Expect: no splash visible (correct), no \`Unknown kernel command line parameters\` warning in dmesg.
- [ ] Build a riscv64 image. Expect: cmdline contains the graphical Plymouth flags, no \`i915.force_probe=*\`.

## Recovery for existing installs

UEFI x86/riscv64:
\`\`\`
sudo sed -i -E 's/\\bsplash=verbose\\b/splash plymouth.ignore-serial-consoles/' /etc/default/grub.d/98-armbian.cfg
sudo update-grub
sudo reboot
\`\`\`

SBC with U-Boot:
\`\`\`
echo 'bootlogo=true' | sudo tee -a /boot/armbianEnv.txt
sudo reboot
\`\`\`

(No image rebuild required for either; the boot scripts read \`armbianEnv.txt\` at boot time.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic verbose splash kernel parameter for boots without a graphical logo, reducing console noise across many platforms.
  * Restored console clearing on the primary virtual terminal so the login banner is shown after wiping prior output.

* **Chores**
  * Standardized GRUB kernel/boot behavior to always enable the graphical splash and related plymouth settings and adjusted GRUB payload handling for consistent boot transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->