### PR TITLE
gateway-dk-ask: pin ASK with libxml2 2.12+ compat fix for fmc

### DIFF
--- a/extensions/gateway-dk-ask.sh
+++ b/extensions/gateway-dk-ask.sh
@@ -15,7 +15,7 @@
 # Source repos and refs (pinned to match Yocto)
 # For local testing: set ASK_REPO="file:///path/to/ASK" — the Docker mount hook below handles it
 declare -g ASK_REPO="https://github.com/we-are-mono/ASK.git"
-declare -g ASK_BRANCH="commit:9f5a37ea90bb99e0fadd8d85944f4a9ff40037fd"
+declare -g ASK_BRANCH="commit:a211ea865379362058c6656b9c448e4a7050e93c"
 declare -g FMLIB_REPO="https://github.com/nxp-qoriq/fmlib.git"
 declare -g FMLIB_COMMIT="7a58ecaf0d90d71d6b78d3ac7998282a472c4394"
 declare -g FMC_REPO="https://github.com/nxp-qoriq/fmc.git"

--- a/extensions/gateway-dk-ask.sh
+++ b/extensions/gateway-dk-ask.sh
@@ -15,7 +15,7 @@
 # Source repos and refs (pinned to match Yocto)
 # For local testing: set ASK_REPO="file:///path/to/ASK" — the Docker mount hook below handles it
 declare -g ASK_REPO="https://github.com/we-are-mono/ASK.git"
-declare -g ASK_BRANCH="commit:252b6db5a274383917c7a7688c931d61409978c2"
+declare -g ASK_BRANCH="commit:9ea9bda759de70f75fc994fdc8bfa83a54f66f67"
 declare -g FMLIB_REPO="https://github.com/nxp-qoriq/fmlib.git"
 declare -g FMLIB_COMMIT="7a58ecaf0d90d71d6b78d3ac7998282a472c4394"
 declare -g FMC_REPO="https://github.com/nxp-qoriq/fmc.git"

--- a/extensions/gateway-dk-ask.sh
+++ b/extensions/gateway-dk-ask.sh
@@ -15,7 +15,7 @@
 # Source repos and refs (pinned to match Yocto)
 # For local testing: set ASK_REPO="file:///path/to/ASK" — the Docker mount hook below handles it
 declare -g ASK_REPO="https://github.com/we-are-mono/ASK.git"
-declare -g ASK_BRANCH="commit:9ea9bda759de70f75fc994fdc8bfa83a54f66f67"
+declare -g ASK_BRANCH="commit:9f5a37ea90bb99e0fadd8d85944f4a9ff40037fd"
 declare -g FMLIB_REPO="https://github.com/nxp-qoriq/fmlib.git"
 declare -g FMLIB_COMMIT="7a58ecaf0d90d71d6b78d3ac7998282a472c4394"
 declare -g FMC_REPO="https://github.com/nxp-qoriq/fmc.git"
@@ -161,11 +161,13 @@ function post_install_kernel_debs__ask_module_autoload() {
 
 # Copy patches into chroot before patched library builds (runs before build_ask_userspace)
 function pre_customize_image__000_prepare_ask_patches() {
-	mkdir -p "${SDCARD}/tmp/ask-patches"
+	# Stage per-package trees (version subdirs preserved) so rebuild_patched_deb
+	# can pick the patch matching the upstream source version.
 	local patch_dirs=("libnetfilter-conntrack" "libnfnetlink")
 	for pdir in "${patch_dirs[@]}"; do
 		[[ -d "${ASK_CACHE_DIR}/patches/${pdir}" ]] || exit_with_error "ASK patch directory missing" "${ASK_CACHE_DIR}/patches/${pdir}"
-		cp "${ASK_CACHE_DIR}/patches/${pdir}/"*.patch "${SDCARD}/tmp/ask-patches/"
+		mkdir -p "${SDCARD}/tmp/ask-patches/${pdir}"
+		cp -a "${ASK_CACHE_DIR}/patches/${pdir}/." "${SDCARD}/tmp/ask-patches/${pdir}/"
 	done
 
 	# Enable deb-src for apt-get source (handles both Debian and Ubuntu)
@@ -409,8 +411,8 @@ Version: ${ask_version}
 Architecture: arm64
 Section: net
 Priority: optional
-Maintainer: Mono Technologies <support@mono.si>
-Depends: linux-image-${BRANCH}-${LINUXFAMILY} (>= ${kernel_ver}), libxml2, libpcap0.8, iptables
+Maintainer: Tomaz Zaman <tomaz@mono.si>
+Depends: linux-image-${BRANCH}-${LINUXFAMILY} (>= ${kernel_ver}), libxml2 | libxml2-16, libpcap0.8, iptables
 Description: NXP ASK hardware offloading userspace for Mono Gateway DK
  Userspace tools (fmlib, fmc, libfci, libcli, dpa-app, cmm) and configuration
  for NXP ASK data-plane acceleration on the LS1046A Gateway DK.
@@ -452,6 +454,9 @@ EOF
 /etc/cdx_pcd.xml
 /etc/cdx_sp.xml
 /etc/config/fastforward
+/etc/fmc/config/cfgdata.xsd
+/etc/fmc/config/hxs_pdl_v3.xml
+/etc/fmc/config/netpcd.xsd
 /etc/sysctl.d/99-ls1046a-conntrack.conf
 CONFFILES
 
@@ -461,7 +466,8 @@ CONFFILES
 	run_host_command_logged dpkg-deb -b "${pkgdir}" "${SRC}/output/debs/${debfile}" \
 		|| exit_with_error "dpkg-deb failed for ${debfile}"
 	cp "${SRC}/output/debs/${debfile}" "${SDCARD}/root/"
-	chroot_sdcard "dpkg -i /root/${debfile}" || exit_with_error "dpkg -i failed for ${debfile}"
+	chroot_sdcard "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends /root/${debfile}" \
+		|| exit_with_error "apt install failed for ${debfile}"
 	rm -f "${SDCARD}/root/${debfile}"
 
 	rm -rf "${pkgdir}"
@@ -495,8 +501,12 @@ function build_ask_patched_libraries() {
 	rm -rf "${SDCARD}/tmp/ask-patched-debs"
 }
 
-# Helper: rebuild a Debian package with an ASK patch in an isolated chroot directory
+# Helper: rebuild a Debian package with an ASK patch in an isolated chroot directory.
 # Usage: rebuild_patched_deb <pkg_name> <patch_file> <deb_globs>
+# The patch is resolved under /tmp/ask-patches/<pkg>/<upstream_version>/<patch_file>,
+# where <upstream_version> is parsed from the source tree's debian/changelog after
+# apt-get source. This lets a single ASK repo cover multiple target distros whose
+# upstream library versions differ (e.g. Trixie/Noble 1.1.0 vs Resolute 1.1.1).
 function rebuild_patched_deb() {
 	local pkg="$1" patch="$2" debs="$3"
 	local workdir="/tmp/ask-rebuild-${pkg}"
@@ -507,7 +517,14 @@ function rebuild_patched_deb() {
 		rm -rf '${workdir}' && mkdir -p '${workdir}' && cd '${workdir}' && \
 		apt-get source '${pkg}' && \
 		cd \$(ls -d ${pkg}-*/ | head -1) && \
-		patch -p1 < '/tmp/ask-patches/${patch}' && \
+		upstream_ver=\$(dpkg-parsechangelog -l debian/changelog -S Version \
+			| sed -E 's/^[0-9]+://; s/-[^-]+\$//; s/^([0-9]+\\.[0-9]+\\.[0-9]+).*/\\1/') && \
+		patch_path=\"/tmp/ask-patches/${pkg}/\${upstream_ver}/${patch}\" && \
+		if [ ! -f \"\${patch_path}\" ]; then \
+			echo \"ERROR: no ASK patch for ${pkg} upstream \${upstream_ver} (looked for \${patch_path})\" >&2; \
+			exit 1; \
+		fi && \
+		patch -p1 < \"\${patch_path}\" && \
 		DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -b -uc -us && \
 		cd '${workdir}' && dpkg -i ${debs} && \
 		cp ${debs} /tmp/ask-patched-debs/ && \

--- a/packages/bsp/gateway-dk/leds-lp5812.c
+++ b/packages/bsp/gateway-dk/leds-lp5812.c
@@ -609,7 +609,6 @@ static int lp5812_probe(struct i2c_client *client)
 
 err_out:
 	lp5812_deinit_device(chip);
-	mutex_destroy(&chip->lock);
 	return ret;
 }
 
@@ -618,7 +617,6 @@ static void lp5812_remove(struct i2c_client *client)
 	struct lp5812_led *led = i2c_get_clientdata(client);
 
 	lp5812_deinit_device(led->chip);
-	mutex_destroy(&led->chip->lock);
 }
 
 /* Chip specific configurations */

--- a/packages/bsp/gateway-dk/leds-lp5812.c
+++ b/packages/bsp/gateway-dk/leds-lp5812.c
@@ -609,6 +609,7 @@ static int lp5812_probe(struct i2c_client *client)
 
 err_out:
 	lp5812_deinit_device(chip);
+	mutex_destroy(&chip->lock);
 	return ret;
 }
 
@@ -617,6 +618,7 @@ static void lp5812_remove(struct i2c_client *client)
 	struct lp5812_led *led = i2c_get_clientdata(client);
 
 	lp5812_deinit_device(led->chip);
+	mutex_destroy(&led->chip->lock);
 }
 
 /* Chip specific configurations */

--- a/patch/kernel/archive/ls1046a-6.12/004-libbpf-const-correctness-for-newer-glibc.patch
+++ b/patch/kernel/archive/ls1046a-6.12/004-libbpf-const-correctness-for-newer-glibc.patch
@@ -1,0 +1,48 @@
+From: Tomaz Zaman <tomaz@mono.si>
+Date: Tue, 14 Apr 2026 12:00:00 +0000
+Subject: [PATCH] libbpf: const-correctness for strstr/strchr return values
+
+In glibc 2.42+ (Ubuntu Resolute and later), the strstr() and strchr()
+declarations in <string.h> are const-aware: when the input pointer is
+const char*, the return type is const char* as well. Assigning that
+result to a non-const char* triggers -Wdiscarded-qualifiers, which is
+fatal under -Werror.
+
+This breaks the linux-headers .deb postinst (which compiles
+tools/bpf/resolve_btfids on the build host) when the host runs a
+distribution with newer glibc.
+
+Fix by declaring the receiving variables as const char*. The values
+are only used for pointer arithmetic and NULL checks — no const-
+casting elsewhere is needed.
+
+This matches the upstream Linux 6.13+ fix; backported here for the
+NXP lf-6.12.y SDK kernel.
+
+Signed-off-by: Tomaz Zaman <tomaz@mono.si>
+---
+ tools/lib/bpf/libbpf.c | 4 ++--
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/lib/bpf/libbpf.c b/tools/lib/bpf/libbpf.c
+index e33cf3caf8b6..c574034fdab7 100644
+--- a/tools/lib/bpf/libbpf.c
++++ b/tools/lib/bpf/libbpf.c
+@@ -8166,7 +8166,7 @@ static int kallsyms_cb(unsigned long long sym_addr, char sym_type,
+ 	struct bpf_object *obj = ctx;
+ 	const struct btf_type *t;
+ 	struct extern_desc *ext;
+-	char *res;
++	const char *res;
+
+ 	res = strstr(sym_name, ".llvm.");
+ 	if (sym_type == 'd' && res)
+@@ -11951,7 +11951,7 @@ static int resolve_full_path(const char *file, char *result, size_t result_sz)
+ 		if (!search_paths[i])
+ 			continue;
+ 		for (s = search_paths[i]; s != NULL; s = strchr(s, ':')) {
+-			char *next_path;
++			const char *next_path;
+ 			int seg_len;
+
+ 			if (s[0] == ':')


### PR DESCRIPTION
# Description

Update the ASK repo pin to a commit that adds a libxml2 compatibility patch for `fmc`.

Newer libxml2 (2.12.0+, released Oct 2023) changed the `xmlStructuredErrorFunc` callback signature to take a `const xmlError *` instead of `xmlError *`. Without the patch, fmc fails to compile against libxml2 2.12+ headers, breaking builds against newer distributions.

The patch in the ASK repo uses a `LIBXML_VERSION` preprocessor check to select the correct callback signature for both old and new libxml2.

### Distribution coverage

| Distribution | libxml2 | Status |
|---|---|---|
| Debian Trixie | 2.9.14 (despite version string) | OK |
| Ubuntu Noble (24.04 LTS) | 2.9.14 | OK |
| Ubuntu Resolute (26.04 dev) | 2.12+ | Was broken, now fixed |

# How Has This Been Tested?

- [x] Built locally with \`RELEASE=trixie\` (passes)
- [x] Built locally with \`RELEASE=noble\` (passes)
- [x] Built locally with \`RELEASE= resolute\` (passes)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved const-correctness compatibility issues in kernel library for newer glibc environments.

* **Chores**
  * Updated build infrastructure with improved patch staging and dependency management.
  * Enhanced installation process for more reliable package deployment.
  * Refreshed component metadata and configuration file management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->