### PR TITLE
ci: validate board config required fields on PR

### DIFF
--- a/.github/workflows/maintenance-validate-board-configs.yml
+++ b/.github/workflows/maintenance-validate-board-configs.yml
@@ -1,0 +1,72 @@
+name: "Validate board configs"
+
+# Runs on PRs that touch config/boards/*. Validates only the changed
+# files (not all 500+) via tools/validate-board-config.py and emits
+# GitHub Actions annotations on the PR diff. Blocks merge on errors.
+
+on:
+  pull_request:
+    paths:
+      - "config/boards/**"
+      - "tools/validate-board-config.py"
+      - ".github/workflows/maintenance-validate-board-configs.yml"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    name: "Validate changed board configs"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout PR"
+        uses: actions/checkout@v4
+        with:
+          # Need the merge-base to compute changed files; depth 0 is
+          # heaviest but bulletproof. Most PRs are small enough this
+          # is fine; switch to fetch-depth: 2 + explicit base ref if
+          # repo size becomes a problem.
+          fetch-depth: 0
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: "Collect changed board configs"
+        id: changed
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          # Limit to known config-bearing extensions to avoid wasting CI
+          # cycles on README.md or other non-config files in the dir.
+          mapfile -t files < <(
+            git diff --name-only --diff-filter=ACMR "${base}" "${head}" -- 'config/boards/*.conf' 'config/boards/*.csc' 'config/boards/*.tvb' 'config/boards/*.wip' 'config/boards/*.eos'
+          )
+
+          echo "Changed board configs: ${#files[@]}"
+          printf '  %s\n' "${files[@]}"
+
+          # Output the list as a space-joined string for the next step.
+          # If empty, set a marker so we can short-circuit.
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "files=" >> "$GITHUB_OUTPUT"
+          else
+            echo "files=${files[*]}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "Run validator"
+        if: steps.changed.outputs.files != ''
+        env:
+          FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2086
+          python3 tools/validate-board-config.py --github ${FILES}
+
+      - name: "No board configs changed"
+        if: steps.changed.outputs.files == ''
+        run: echo "No config/boards/*.{conf,csc,tvb,wip,eos} changes in this PR — nothing to validate."

--- a/tools/validate-board-config.py
+++ b/tools/validate-board-config.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Validate Armbian board configuration files.
+
+Walks each given config/boards/*.{conf,csc,tvb,wip,eos} file and checks
+for required / recommended fields. Designed to run in CI on PRs that
+touch board configs, but also runnable locally:
+
+    tools/validate-board-config.py config/boards/orangepi5.conf
+    tools/validate-board-config.py config/boards/*.conf
+
+Output:
+- Plain text findings to stdout (one per line, prefixed by ERROR / WARNING)
+- When --github is passed, also emits ::error / ::warning workflow
+  commands so GitHub Actions annotates the PR diff
+- Exit code 0 if no errors; 1 if any error
+
+Per-extension behavior:
+- .conf  (supported)         — full rule set
+- .csc   (community)         — full rule set
+- .tvb   (TV box)            — full rule set, skip BOOT_FDT_FILE warning
+- .wip   (work in progress)  — only BOARD_NAME is an error; rest are warnings
+- .eos   (end of support)    — skipped entirely (no point validating dead boards)
+
+The validator does NOT source the bash file (boards have side-effecty
+function bodies). It extracts top-level `KEY=value` assignments via
+regex, which is enough for the required-field check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Top-level assignment, optionally with `declare -g`. Captures KEY and value
+# (raw, including any quotes — we only care about emptiness here).
+_ASSIGN_RE = re.compile(
+    r'^(?:(?:export|declare)\s+(?:-[a-zA-Z]+\s+)*)?([A-Z_][A-Z0-9_]*)=(.*)$',
+    re.MULTILINE,
+)
+
+
+
+@dataclass
+class Finding:
+    severity: str   # "error" | "warning"
+    file: str
+    field: str
+    message: str
+
+    def render(self, github: bool) -> str:
+        prefix = self.severity.upper()
+        plain = f"{prefix}: {self.file}: {self.field}: {self.message}"
+        if not github:
+            return plain
+        # GitHub Actions workflow command — annotates the PR diff.
+        # We point at line 1 since these are file-level checks; the message
+        # itself names the field so reviewers know what to fix.
+        return (
+            f"::{self.severity} file={self.file},line=1::"
+            f"{self.field}: {self.message}\n{plain}"
+        )
+
+
+def parse_assignments(text: str) -> dict[str, str]:
+    """Extract top-level KEY=VALUE assignments. Last assignment wins."""
+    out: dict[str, str] = {}
+    for m in _ASSIGN_RE.finditer(text):
+        key, value = m.group(1), m.group(2).strip()
+        # Strip trailing inline comment (bash semantics: # preceded by
+        # whitespace). Unquoted values like `COLOR=#deadbeef` keep the #.
+        if value and not (value.startswith('"') or value.startswith("'")):
+            m2 = re.search(r'\s#', value)
+            if m2:
+                value = value[:m2.start()].strip()
+        # Strip surrounding matching quotes for the empty-check.
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        out[key] = value
+    return out
+
+
+def validate(path: Path) -> list[Finding]:
+    ext = path.suffix.lstrip(".")
+    if ext == "eos":
+        return []  # dead boards aren't validated
+
+    text = path.read_text(errors="replace")
+    fields = parse_assignments(text)
+
+    findings: list[Finding] = []
+    fname = str(path)
+
+    def err(field: str, msg: str) -> None:
+        # .wip demotes everything except BOARD_NAME to warning
+        sev = "error" if (ext != "wip" or field == "BOARD_NAME") else "warning"
+        findings.append(Finding(sev, fname, field, msg))
+
+    def warn(field: str, msg: str) -> None:
+        findings.append(Finding("warning", fname, field, msg))
+
+    # Required fields (errors except in .wip)
+    if not fields.get("BOARD_NAME"):
+        err("BOARD_NAME", "required, must be non-empty")
+
+    if not fields.get("BOARD_VENDOR"):
+        err("BOARD_VENDOR", "required, must be non-empty")
+
+    if not fields.get("BOARDFAMILY"):
+        err("BOARDFAMILY", "required, must match a family under config/sources/families/")
+
+    if not fields.get("KERNEL_TARGET"):
+        err("KERNEL_TARGET", "required, must be non-empty")
+
+    # Recommended fields (warnings)
+    if not fields.get("BOARD_MAINTAINER"):
+        warn("BOARD_MAINTAINER", "recommended, github username — orphan boards rot")
+
+    if not fields.get("INTRODUCED"):
+        warn("INTRODUCED", "recommended, year the board first shipped (e.g. 2023)")
+
+    if not fields.get("KERNEL_TEST_TARGET"):
+        warn("KERNEL_TEST_TARGET", "recommended, comma-separated list of branches to test (e.g. current,edge)")
+
+    return findings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("files", nargs="+", help="board config files to validate")
+    ap.add_argument(
+        "--github",
+        action="store_true",
+        help="emit GitHub Actions ::error / ::warning workflow commands",
+    )
+    args = ap.parse_args()
+
+    all_findings: list[Finding] = []
+    for f in args.files:
+        path = Path(f)
+        if not path.is_file():
+            print(f"WARNING: {f}: not a file, skipping", file=sys.stderr)
+            continue
+        if path.suffix.lstrip(".") not in {"conf", "csc", "tvb", "wip", "eos"}:
+            print(f"WARNING: {f}: unknown extension, skipping", file=sys.stderr)
+            continue
+        all_findings.extend(validate(path))
+
+    errors = [f for f in all_findings if f.severity == "error"]
+    warnings = [f for f in all_findings if f.severity == "warning"]
+
+    for finding in all_findings:
+        print(finding.render(args.github))
+
+    print(
+        f"\n{len(errors)} error(s), {len(warnings)} warning(s) "
+        f"across {len(args.files)} file(s)",
+        file=sys.stderr,
+    )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a PR-time validator for `config/boards/*.{conf,csc,tvb,wip,eos}` files. Catches missing required fields **before** merge instead of at first build attempt.

Two files:

- **`tools/validate-board-config.py`** — standalone Python validator, runnable locally:
  ```bash
  tools/validate-board-config.py config/boards/orangepi5.conf
  tools/validate-board-config.py config/boards/*.conf
  ```
  Extracts top-level `KEY=VALUE` assignments via regex (handles bare, `export`, and `declare` prefixes — does **not** source the bash file). With `--github` emits `::error` / `::warning` workflow commands that annotate the PR diff.

- **`.github/workflows/maintenance-validate-board-configs.yml`** — runs on PRs touching `config/boards/**`. Detects changed files via `git diff` against PR base — only validates what the PR actually touched, not all 500+ boards.

## Rule table

| field | severity | notes |
|---|---|---|
| `BOARD_NAME` | **error** | required, non-empty |
| `BOARD_VENDOR` | **error** | required, non-empty |
| `BOARDFAMILY` | **error** | required |
| `KERNEL_TARGET` | **error** | required, non-empty |
| `BOARD_MAINTAINER` | warning | orphan boards rot |
| `INTRODUCED` | warning | year first shipped |
| `KERNEL_TEST_TARGET` | warning | which branches to test |

### Per-extension behavior

| extension | behavior |
|---|---|
| `.conf` / `.csc` | full rule set |
| `.tvb` | full rule set |
| `.wip` | only `BOARD_NAME` is error; rest demoted to warning |
| `.eos` | skipped entirely |

## Test plan

- [x] All 119 `.conf` boards pass with 0 errors
- [x] `export BOARD_NAME=...` syntax (uefi-loong64.conf) parsed correctly
- [x] Synthetic broken `.conf` produces errors, exit 1
- [x] Synthetic `.wip` demotes errors to warnings except `BOARD_NAME`
- [ ] Workflow runs on its own PR and produces no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line validator for board configuration files to check required and recommended fields.

* **Chores**
  * Added an automated pull-request check that runs the validator when board configs change and surfaces findings as PR annotations and a pass/fail status.
  * Missing required fields are reported as errors; missing recommended fields appear as warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->