### PR TITLE
fix(kernel-config): append missing newline to .config before edits

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -125,7 +125,7 @@ function artifact_kernel_prepare_version() {
 
 	# run the extensions. they _must_ behave, and not try to modify the .config, instead just fill kernel_config_modifying_hashes
 	declare kernel_config_modifying_hashes_hash="undetermined"
-	declare -a kernel_config_modifying_hashes=()
+	declare -ga kernel_config_modifying_hashes=()
 	call_extensions_kernel_config
 	# Reduce to last assignment per key to keep hashing stable and ignore overridden options.
 	# tac reverses order so last becomes first, then sort -uk keeps first occurrence of each key.

--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -616,6 +616,7 @@ function kernel_config_set_m() {
 	declare module="$1"
 	display_alert "Enabling kernel module" "${module}=m" "debug"
 	run_host_command_logged ./scripts/config --module "${module}"
+	kernel_config_modifying_hashes+=("${module}=m")
 }
 
 # Sets a kernel configuration option to be built-in (=y).
@@ -627,6 +628,7 @@ function kernel_config_set_y() {
 	declare config="$1"
 	display_alert "Enabling kernel config/built-in" "${config}=y" "debug"
 	run_host_command_logged ./scripts/config --enable "${config}"
+	kernel_config_modifying_hashes+=("${config}=y")
 }
 
 # Disables a kernel configuration option (=n).
@@ -637,6 +639,7 @@ function kernel_config_set_n() {
 	declare config="$1"
 	display_alert "Disabling kernel config/module" "${config}=n" "debug"
 	run_host_command_logged ./scripts/config --disable "${config}"
+	kernel_config_modifying_hashes+=("${config}=n")
 }
 
 # Sets a kernel configuration option to a string value.
@@ -649,6 +652,7 @@ function kernel_config_set_string() {
 	declare value="${2}"
 	display_alert "Setting kernel config/module string" "${config}=${value}" "debug"
 	run_host_command_logged ./scripts/config --set-str "${config}" "${value}"
+	kernel_config_modifying_hashes+=("${config}=\"${value}\"")
 }
 
 # Sets a kernel configuration option to a numeric or hexadecimal value.
@@ -661,6 +665,7 @@ function kernel_config_set_val() {
 	declare value="${2}"
 	display_alert "Setting kernel config/module value" "${config}=${value}" "debug"
 	run_host_command_logged ./scripts/config --set-val "${config}" "${value}"
+	kernel_config_modifying_hashes+=("${config}=${value}")
 }
 
 # Applies kernel configuration options from arrays to hashes and the .config file.

--- a/lib/functions/compilation/kernel-config.sh
+++ b/lib/functions/compilation/kernel-config.sh
@@ -69,6 +69,10 @@ function kernel_config_initialize() {
 		run_host_command_logged cp -pv "${kernel_config_source_filename}" "${kernel_work_dir}/.config"
 	fi
 
+	# Ensure .config ends with a newline; ./scripts/config appends via `echo >>` and
+	# silently concatenates the first added option with the last line otherwise.
+	sed -i -e '$a\' "${kernel_work_dir}/.config"
+
 	# Call the extensions. This is _also_ done during the kernel artifact's prepare_version, for consistent caching.
 	cd "${kernel_work_dir}" || exit_with_error "kernel_work_dir does not exist before call_extensions_kernel_config: ${kernel_work_dir}"
 	call_extensions_kernel_config

--- a/lib/functions/compilation/kernel-config.sh
+++ b/lib/functions/compilation/kernel-config.sh
@@ -97,6 +97,13 @@ function call_extensions_kernel_config() {
 	# shellcheck disable=SC2034
 	declare -a opts_y=() opts_n=() opts_m=()
 
+	# kernel_config_set_* append to this array; ensure it exists globally so their
+	# changes survive for artifact versioning even when no caller pre-declared it.
+	if ! declare -p kernel_config_modifying_hashes >/dev/null 2>&1; then
+		# shellcheck disable=SC2034
+		declare -ga kernel_config_modifying_hashes=()
+	fi
+
 	# Run the core-armbian config modifications here, built-in extensions:
 	call_extension_method "armbian_kernel_config" <<- 'ARMBIAN_KERNEL_CONFIG'
 		*Armbian-core default hook point for pre-olddefconfig Kernel config modifications*


### PR DESCRIPTION
## Summary

Issue #9680 report: `kernel_config_set_*` calls from `custom_kernel_config` hooks silently lost, "fixed" by adding a blank line to the defconfig. Two independent bugs combine into this behaviour:

1. **Text-level (commit 1)**: `./scripts/config --enable X` appends new options via `echo >>`. A defconfig shipped without a trailing newline ends up with the first new option glued onto the last line (`# CONFIG_OLDOPT is not setCONFIG_NEWOPT=y`), which `make olddefconfig` then discards. 93 files in `config/kernel/*.config` currently lack a trailing newline. Normalise `.config` once after copying.

2. **Cache-level (commit 2)**: `kernel_config_modifying_hashes` was `declare -a` local to `artifact_kernel_prepare_version()`, and the `kernel_config_set_{y,n,m,string,val}` helpers never appended to it. Hook-driven config changes never reached the cache fingerprint, so a cached artifact built without the hook got reused even after the hook was added. Declare the array globally, push from every setter, and initialise it defensively in `call_extensions_kernel_config`. Co-authored with EvilOlaf, who identified the cache path in the issue thread.

Fixes #9680

## Test plan

- [x] Reproduced bug 1 locally (`scripts/config --enable NEW` on a no-trailing-newline input produces `# CONFIG_OLDOPT is not setCONFIG_NEWOPT=y`).
- [x] Built kernel artifact for `BOARD=nanopi-r6s BRANCH=vendor` (uses `linux-rk35xx-vendor.config`, the exact defconfig from the issue report) with `ARTIFACT_IGNORE_CACHE=yes`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed kernel configuration handling to prevent configuration options from being incorrectly concatenated
  * Enhanced initialization of configuration tracking to ensure proper build artifact versioning
  * Improved configuration change recording for consistent build results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->