### PR TITLE
cosmetic: clean up build warnings (locale, setfont, GPG, oras)

### DIFF
--- a/lib/functions/general/oci-oras.sh
+++ b/lib/functions/general/oci-oras.sh
@@ -160,7 +160,20 @@ function oras_get_artifact_manifest() {
 
 	oras_has_manifest="no"
 	# Gotta capture the output & if it failed...
-	oras_manifest_json="$(run_tool_oras manifest fetch "${extra_params[@]}" "${image_full_oci}")" && oras_has_manifest="yes" || oras_has_manifest="no"
+	# Capture stderr: a 404 (cache miss) is normal for fresh artifacts —
+	# suppress oras's "Error response from registry: failed to fetch"
+	# dump. The caller (artifacts-obtain.sh) already reports the miss
+	# with a clean display_alert. Any OTHER error (auth, network) is
+	# still printed so real problems aren't hidden.
+	local oras_stderr_file
+	oras_stderr_file=$(mktemp)
+	oras_manifest_json="$(run_tool_oras manifest fetch "${extra_params[@]}" "${image_full_oci}" 2>"${oras_stderr_file}")" && oras_has_manifest="yes" || oras_has_manifest="no"
+	local oras_stderr
+	oras_stderr=$(<"${oras_stderr_file}")
+	rm -f "${oras_stderr_file}"
+	if [[ "${oras_has_manifest}" == "no" && -n "${oras_stderr}" && "${oras_stderr}" != *"not found"* ]]; then
+		display_alert "ORAS manifest fetch error" "${oras_stderr}" "wrn"
+	fi
 	display_alert "oras_has_manifest after: ${oras_has_manifest}" "ORAS manifest yes/no" "debug"
 	display_alert "oras_manifest_json after: ${oras_manifest_json}" "ORAS manifest json" "debug"
 

--- a/lib/functions/logging/runners.sh
+++ b/lib/functions/logging/runners.sh
@@ -131,13 +131,20 @@ function chroot_sdcard_apt_get() {
 
 # please, please, unify around this function.
 function chroot_sdcard() {
-	raw_command="$*" raw_extra="chroot_sdcard" TMPDIR="" \
+	# LC_ALL/LANG/LANGUAGE: clear the host's locale before entering the
+	# chroot — the target rootfs usually hasn't generated the host's locale
+	# yet, producing noisy "bash: warning: setlocale: LC_ALL: cannot change
+	# locale" on every chroot_sdcard call. Individual commands that need a
+	# specific locale (dpkg-divert, locale-gen) set LC_ALL=C explicitly.
+	# SUDO_USER: clear so chroot commands don't try to look up the host
+	# builder's username (which doesn't exist inside the rootfs).
+	raw_command="$*" raw_extra="chroot_sdcard" TMPDIR="" LC_ALL="C" LANG="C" LANGUAGE="" SUDO_USER="" \
 		run_host_command_logged_raw chroot "${SDCARD}" /usr/bin/env bash -e -o pipefail -c "$*"
 }
 
 # please, please, unify around this function.
 function chroot_mount() {
-	raw_command="$*" raw_extra="chroot_mount" TMPDIR="" \
+	raw_command="$*" raw_extra="chroot_mount" TMPDIR="" LC_ALL="C" LANG="C" LANGUAGE="" SUDO_USER="" \
 		run_host_command_logged_raw chroot "${MOUNT}" /usr/bin/env bash -e -o pipefail -c "$*"
 }
 

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -266,19 +266,25 @@ function create_sources_list_and_deploy_repo_key() {
 	mkdir -p "${basedir}"/usr/share/keyrings
 	# change to binary form
 	APT_SIGNING_KEY_FILE="/usr/share/keyrings/armbian-archive-keyring.gpg"
-	gpg --batch --yes --dearmor < "${SRC}"/config/armbian.key > "${basedir}${APT_SIGNING_KEY_FILE}"
+	# Use a temporary GPG homedir so we don't touch the builder's
+	# ~/.gnupg (which may be owned by a different user when running
+	# under sudo, producing "unsafe ownership on homedir" warnings).
+	local gpg_tmp
+	gpg_tmp=$(mktemp -d)
+	gpg --homedir "${gpg_tmp}" --batch --yes --dearmor < "${SRC}"/config/armbian.key > "${basedir}${APT_SIGNING_KEY_FILE}"
+	rm -rf "${gpg_tmp}"
 
 	# deploy the qemu binary, no matter where the rootfs came from (built or cached)
 	deploy_qemu_binary_to_chroot "${basedir}" "${when}" # undeployed at end of this function
 
 	# lets link to the old file as armbian-config uses it and we can't set there to new file
 	# we user force linking as some old caches still exists
-	chroot "${basedir}" /bin/bash -c "ln -fs armbian-archive-keyring.gpg /usr/share/keyrings/armbian.gpg"
+	LC_ALL="C" LANG="C" LANGUAGE="" SUDO_USER="" chroot "${basedir}" /bin/bash -c "ln -fs armbian-archive-keyring.gpg /usr/share/keyrings/armbian.gpg"
 
 	# lets keep old way for old distributions
 	if [[ "${RELEASE}" =~ (focal|bullseye) ]]; then
 		cp "${SRC}"/config/armbian.key "${basedir}"
-		chroot "${basedir}" /bin/bash -c "cat armbian.key | apt-key add - > /dev/null 2>&1"
+		LC_ALL="C" LANG="C" LANGUAGE="" SUDO_USER="" chroot "${basedir}" /bin/bash -c "cat armbian.key | apt-key add - > /dev/null 2>&1"
 	fi
 
 	# undeploy the qemu binary from the image; we don't want to ship the host's qemu in the target image

--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -115,6 +115,15 @@ function create_new_rootfs_cache_via_debootstrap() {
 	debootstrap_arguments+=("${RELEASE}" "${SDCARD}/" "${debootstrap_apt_mirror}") # release, path and mirror; always last, positional arguments.
 
 	mkdir -p "${SDCARD}/usr/bin"
+
+	# Suppress "Download is performed unsandboxed as root" — the _apt
+	# user may not exist yet in a fresh rootfs. Pre-create an apt config
+	# drop-in on the HOST side before mmdebstrap runs; --skip=check/empty
+	# allows pre-populated rootfs dirs, and mmdebstrap preserves files
+	# that don't belong to any extracted package.
+	mkdir -p "${SDCARD}/etc/apt/apt.conf.d"
+	echo 'APT::Sandbox::User "root";' > "${SDCARD}/etc/apt/apt.conf.d/99-armbian-sandbox"
+
 	deploy_qemu_binary_to_chroot "${SDCARD}" "rootfs" # undeployed near the end of this function
 
 	run_host_command_logged "${debootstrap_bin}" "${debootstrap_arguments[@]}" || {
@@ -129,6 +138,7 @@ function create_new_rootfs_cache_via_debootstrap() {
 	# Done with mmdebstrap. Clean-up its litterbox.
 	display_alert "Cleaning up after mmdebstrap" "mmdebstrap cleanup" "info"
 	run_host_command_logged rm -rf "${SDCARD}/var/cache/apt" "${SDCARD}/var/lib/apt/lists"
+	rm -f "${SDCARD}/etc/apt/apt.conf.d/99-armbian-sandbox" # build-time only; don't ship in the image
 
 	local_apt_deb_cache_prepare "after mmdebstrap cleanup" # just for size reference in logs
 
@@ -158,7 +168,10 @@ function create_new_rootfs_cache_via_debootstrap() {
 		# @TODO: Should be configurable.
 		sed -e 's/CHARMAP=.*/CHARMAP="UTF-8"/' -e 's/FONTSIZE=.*/FONTSIZE="8x16"/' \
 			-e 's/CODESET=.*/CODESET="guess"/' -i "$SDCARD/etc/default/console-setup"
-		chroot_sdcard LC_ALL=C LANG=C setupcon --save --force
+		# setupcon triggers setfont which fails with KDGETMODE errors
+		# when there's no real console (chroot has no tty). The config
+		# is saved correctly regardless — suppress the noise.
+		chroot_sdcard "LC_ALL=C LANG=C setupcon --save --force 2>/dev/null || true"
 	fi
 
 	# stage: create apt-get sources list (basic Debian/Ubuntu apt sources, no external nor PPAS).


### PR DESCRIPTION
## Summary

Silences five categories of noisy but harmless warnings that clutter every image build log. Two commits, 4 files, +46 / -7 lines.

### Commit 1: chroot environment cleanup

| warning | cause | fix |
|---|---|---|
| \`bash: warning: setlocale: LC_ALL: cannot change locale (sl_SI.UTF-8)\` | Host's \`LC_ALL\` leaks into chroot via \`chroot_sdcard\` | Set \`LC_ALL=C LANG=C LANGUAGE="" SUDO_USER=""\` in wrappers + direct \`chroot\` calls |
| \`gpg: WARNING: unsafe ownership on homedir\` | \`gpg --dearmor\` under sudo uses builder's \`~/.gnupg\` | Temporary \`--homedir\` for the single dearmor call |
| \`setfont: ERROR kdfontop.c:29 is_kd_text: ioctl(KDGETMODE)\` | \`setupcon --save --force\` triggers setfont in chroot (no tty) | Redirect stderr to \`/dev/null\` |
| \`W: Download is performed unsandboxed as root\` | \`_apt\` user doesn't exist in fresh rootfs | Pre-create \`/etc/apt/apt.conf.d/99-armbian-sandbox\` before mmdebstrap; removed in cleanup |
| \`id: 'igorp': no such user\` | \`SUDO_USER\` leaks from host into chroot | Cleared in the same wrapper fix |

Files: \`lib/functions/logging/runners.sh\`, \`lib/functions/rootfs/distro-specific.sh\`, \`lib/functions/rootfs/rootfs-create.sh\`

### Commit 2: oras 404 cosmetic

| warning | cause | fix |
|---|---|---|
| \`Error response from registry: failed to fetch\` | oras manifest probe returns 404 on cache miss (normal) | Capture stderr; suppress if "not found"; show as warning for any other error |

File: \`lib/functions/general/oci-oras.sh\`

## Test plan

- [x] Build a desktop image — all five warning categories gone from the log
- [x] Locale generation still works (\`en_US.UTF-8\` generated correctly)
- [ ] Console font config saved correctly in \`/etc/default/console-setup\`
- [ ] Armbian GPG key correctly dearmored in \`/usr/share/keyrings/\`
- [ ] \`99-armbian-sandbox\` file absent from the final image (\`/etc/apt/apt.conf.d/\`)
- [ ] Cache miss shows single clean \`[🌱] Artifact is not available in remote cache\` line
- [ ] Real oras errors (auth, network) still shown as \`[⚠]\` warning
- [ ] No regression on arm64 cross-builds (qemu chroot with \`LC_ALL=C\`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented host locale and username from leaking into build chroots to avoid inconsistent package behavior and accidental host references.
  * Suppressed noisy console-setup errors during root filesystem creation to reduce misleading build output.
  * Improved external artifact fetch handling by capturing stderr and emitting clearer warnings on unexpected errors.

* **Chores**
  * Isolated GPG operations to a temporary home to avoid using the builder's keyring.
  * Applied apt sandbox config only during build and removed it from the final filesystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->