### PR TITLE
kernel-headers: add version to linux-headers virtual package

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -517,7 +517,7 @@ function kernel_package_callback_linux_headers() {
 		Package: ${package_name}
 		Architecture: ${ARCH}
 		Priority: optional
-		Provides: linux-headers, linux-headers-armbian, armbian-$BRANCH
+		Provides: linux-headers (= ${kernel_version}), linux-headers-armbian, armbian-$BRANCH
 		Depends: make, gcc, libc6-dev, bison, flex, libssl-dev, libelf-dev, pahole
 		Description: Armbian Linux $BRANCH headers ${kernel_version_family}
 		 This package provides kernel header files for ${kernel_version_family}


### PR DESCRIPTION
## Problem

The `linux-headers-${BRANCH}-${LINUXFAMILY}` package declares `Provides: linux-headers` without a version. Per Debian Policy §7.5, an unversioned virtual package cannot satisfy a versioned dependency.

DKMS packages depend on `linux-headers (>= X.Y)` as the last fallback alternative, e.g. `bcachefs-kernel-dkms`:

```
Depends: linux-headers-generic (>= 6.16) | linux-headers-arm64 (>= 6.16)
       | linux-headers-cloud-arm64 (>= 6.16) | linux-headers-rt-arm64 (>= 6.16)
       | linux-headers (>= 6.16)
```

Because the Armbian `Provides: linux-headers` had no version, apt skipped this alternative and pulled `linux-headers-generic` from the Ubuntu archive — installing headers for `6.17.0-22-generic` on a box actually running `7.0.0-rc7-edge-rockchip64`. ~477 MB of wrong headers, plus a DKMS module that may silently compile against the wrong tree.

## Fix

Add the upstream kernel version to the virtual package in `lib/functions/compilation/kernel-debs.sh`:

```diff
- Provides: linux-headers, linux-headers-armbian, armbian-$BRANCH
+ Provides: linux-headers (= ${kernel_version}), linux-headers-armbian, armbian-$BRANCH
```

`${kernel_version}` is the upstream kernel version (e.g. `7.0.0-rc7`) — already available in `prepare_kernel_packaging_debs()`. Versioned `Provides` are supported since dpkg 1.17.11 (Debian 8, Ubuntu 15.04).

A versioned `Provides` also satisfies any unversioned `Depends: linux-headers` (verified below), so the existing reverse-deps (`dkms`, `alsa-source`, `lime-forensics-dkms`) keep working.

## Verification

Built `linux-headers-edge-rockchip64` for `odroidm1` / `edge` / `rockchip64`:

```
Before: Provides: linux-headers, linux-headers-armbian, armbian-edge
After:  Provides: linux-headers (= 7.0.0), linux-headers-armbian, armbian-edge
```

Installed on a running `odroidm1` and checked dependency resolution:

```
$ apt-get satisfy --simulate 'linux-headers'           # nothing to install
$ apt-get satisfy --simulate 'linux-headers (>= 6.16)' # nothing to install
```

`apt-get remove --simulate` of the Ubuntu headers stack (`linux-headers-generic`, `linux-headers-6.17.0-{20,22}`, `linux-headers-6.17.0-{20,22}-generic`) proposed removing those five packages **without** touching `bcachefs-kernel-dkms` — confirming the Armbian package now satisfies `linux-headers (>= 6.16)`.

After purging the five orphaned Ubuntu-headers packages, the DKMS module still resolves correctly against the Armbian headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Debian package metadata to use version-qualified identifiers for Linux headers compatibility and dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->