### PR TITLE
Rockchip-rv1106 family: add to group only if group doesn't exist yet

### DIFF
--- a/config/sources/families/rockchip-rv1106.conf
+++ b/config/sources/families/rockchip-rv1106.conf
@@ -127,8 +127,8 @@ family_tweaks() {
 
 	# Create gpio and i2c groups on the build rootfs; they are matched against
 	# udev rules to allow non-root user access to these resources
-	chroot_sdcard addgroup --system --quiet --gid 900 gpio
-	chroot_sdcard addgroup --system --quiet --gid 901 i2c
+	chroot_sdcard getent group gpio >/dev/null || chroot_sdcard addgroup --system --quiet --gid 900 gpio
+	chroot_sdcard getent group i2c  >/dev/null || chroot_sdcard addgroup --system --quiet --gid 901 i2c
 
 	return 0
 


### PR DESCRIPTION
# Description
This is identical to PR #8479 but applied to the `rockchip-rv1106` family. (Please merge that one too! :pray:)

Some other packages may add the `i2c`/`gpio` groups before the family_tweaks are run, causing build failures when they are included.

```bash
# Example
function extension_prepare_config__add_i2c_tools() {
	add_packages_to_image i2c-tools
}
```
>   [🐳|🌿] Applying family [  tweaks: luckfox-pico-max :: rockchip-rv1106 ]
  [🐳|🔨]   err: The group `i2c' already exists, but has a different GID. Exiting.

We should only create them when they do not already exist. This PR does exactly that.

# How Has This Been Tested?

- [x] Build test
- [x] The example above (`i2c-tools` via Extension) now works as expected.

# Checklist:

- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced installation robustness by implementing safer system group creation that avoids errors from duplicate operations during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->