### PR TITLE
extension: fix importlib_resources detection for U-Boot v2024.x-v2025.04

### DIFF
--- a/extensions/uboot-binman-fix-pkg-resources.sh
+++ b/extensions/uboot-binman-fix-pkg-resources.sh
@@ -34,11 +34,15 @@ with open(control_py, "r") as f:
 content = re.sub(r'^import pkg_resources\b[^\n]*\n', '', content, flags=re.MULTILINE)
 
 # 2. Ensure importlib_resources alias is available
-has_importlib_alias = 'importlib_resources' in content
+#    Use regex to detect a real alias import, not just the name appearing in an except clause
+has_importlib_alias = bool(re.search(
+    r'^import importlib\.resources\s+as\s+importlib_resources\b',
+    content, flags=re.MULTILINE
+))
 has_importlib_dotted = re.search(r'^import importlib\.resources\s*$', content, flags=re.MULTILINE)
 
 if not has_importlib_alias and has_importlib_dotted:
-    # New U-Boot (v2024.01+): has "import importlib.resources" without alias
+    # "import importlib.resources" exists at top level but without alias — add alias
     content = re.sub(
         r'^import importlib\.resources\s*$',
         'import importlib.resources as importlib_resources',
@@ -47,7 +51,8 @@ if not has_importlib_alias and has_importlib_dotted:
     # Update existing dotted usage to use the alias
     content = re.sub(r'\bimportlib\.resources\.', 'importlib_resources.', content)
 elif not has_importlib_alias:
-    # Old U-Boot (<=v2023.x): no importlib.resources at all
+    # No top-level importlib.resources import (absent or only inside a try/except block)
+    # — add our own alias block
     import_block = (
         'try:\n'
         '    import importlib.resources as importlib_resources\n'


### PR DESCRIPTION
## Problem

After merging #9407, three CI jobs failed with:
```
binman: name 'importlib_resources' is not defined
make: *** [Makefile:1135: .binman_stamp] Error 1
```
Affected boards: `tinkerboard-2`, `h96-tvbox-3566`, `coolpi-genbook` — all using U-Boot `v2025.04`.

## Root Cause

U-Boot v2024.x–v2025.04 has this pattern in `tools/binman/control.py`:

```python
try:
    import importlib.resources
except ImportError:  # pragma: no cover
    # for Python 3.6
    import importlib_resources
import pkg_resources
```

The previous check `'importlib_resources' in content` matched the string inside the `except` clause and incorrectly concluded the alias already existed — skipping the import. After removing `import pkg_resources`, calls to `importlib_resources.files(...)` were left without a valid import.

## Fix

Replace the string check with a regex anchored to the start of line:

```python
# before:
has_importlib_alias = 'importlib_resources' in content

# after:
has_importlib_alias = bool(re.search(
    r'^import importlib\.resources\s+as\s+importlib_resources\b',
    content, flags=re.MULTILINE
))
```

U-Boot v2024.x–v2025.04 now falls through to the "no top-level import" branch and receives a proper `try/except` alias block.

## Testing

| Board | U-Boot | Result |
|-------|--------|--------|
| tinkerboard-2 (edge) | v2025.04 | ✅ fixed |
| h96-tvbox-3566 (current) | v2025.04 | ✅ fixed |
| coolpi-genbook (edge) | v2025.04 | ✅ fixed |
| odroidc4 (current) | v2022.07 | ✅ regression ok |
| tritium-h5 (current) | v2024.01 | ✅ regression ok |
| odroidn2 (current) | v2026.04 | ✅ no-op ok |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the accuracy of import detection in the build system, refining how package dependencies are handled during the extension build process to prevent unnecessary duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->