### PR TITLE
rockchip-rk3588: add Rock 5 ITX PWM fan control overlay

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/Makefile
@@ -56,6 +56,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3568-hk-uart1.dtbo \
 	rockchip-rk3568-rock-3a-disable-uart2.dtbo \
 	rockchip-rk3588-fanctrl.dtbo \
+	rockchip-rk3588-rock-5-itx-pwm-fan.dtbo \
 	rockchip-rk3588-sata0.dtbo \
 	rockchip-rk3588-sata1.dtbo \
 	rockchip-rk3588-sata2.dtbo \

--- a/patch/kernel/archive/rockchip64-6.12/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/README.rockchip-overlays
@@ -292,3 +292,15 @@ Some NanoPC-T6 boards use a A3A444 eMMC chip. Under heavy I/O load when running
 in HS400 mode, this will often result in I/O errors.
 Reducing the eMMC frequency from the default 200000000 Hz to 150000000 Hz improves
 stability and eliminates the I/O errors.
+
+**********************************
+Details for Rock 5 ITX overlays:
+
+### rockchip-rk3588-rock-5-itx-pwm-fan
+
+The Rock 5 ITX DTB defines the fan as a /pwm-fan node without a labelled phandle,
+so the generic rockchip-rk3588-fanctrl overlay (which targets &fan) does not apply.
+This overlay patches the /pwm-fan node directly, fixing the default cooling-levels
+which start at 0 — causing the fan to receive no PWM signal at idle and default to
+full speed. The corrected curve starts at 1 (near-silent) and ramps through four
+steps tied to temperature trip points (45°C / 50°C / 55°C / 65°C).

--- a/patch/kernel/archive/rockchip64-6.12/overlay/rockchip-rk3588-rock-5-itx-pwm-fan.dtso
+++ b/patch/kernel/archive/rockchip64-6.12/overlay/rockchip-rk3588-rock-5-itx-pwm-fan.dtso
@@ -1,0 +1,12 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target-path = "/pwm-fan";
+		__overlay__ {
+			cooling-levels = <1 64 128 192 255>;
+			rockchip,temp-trips = <45000 1 50000 2 55000 3 65000 4>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip64-6.18/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/Makefile
@@ -67,6 +67,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3568-hk-uart1.dtbo \
 	rockchip-rk3568-rock-3a-disable-uart2.dtbo \
 	rockchip-rk3588-fanctrl.dtbo \
+	rockchip-rk3588-rock-5-itx-pwm-fan.dtbo \
 	rockchip-rk3588-sata0.dtbo \
 	rockchip-rk3588-sata1.dtbo \
 	rockchip-rk3588-sata2.dtbo \

--- a/patch/kernel/archive/rockchip64-6.18/overlay/rockchip-rk3588-rock-5-itx-pwm-fan.dtso
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/rockchip-rk3588-rock-5-itx-pwm-fan.dtso
@@ -1,0 +1,12 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target-path = "/pwm-fan";
+		__overlay__ {
+			cooling-levels = <1 64 128 192 255>;
+			rockchip,temp-trips = <45000 1 50000 2 55000 3 65000 4>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip64-7.0/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-7.0/overlay/Makefile
@@ -67,6 +67,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3568-hk-uart1.dtbo \
 	rockchip-rk3568-rock-3a-disable-uart2.dtbo \
 	rockchip-rk3588-fanctrl.dtbo \
+	rockchip-rk3588-rock-5-itx-pwm-fan.dtbo \
 	rockchip-rk3588-sata0.dtbo \
 	rockchip-rk3588-sata1.dtbo \
 	rockchip-rk3588-sata2.dtbo \

--- a/patch/kernel/archive/rockchip64-7.0/overlay/rockchip-rk3588-rock-5-itx-pwm-fan.dtso
+++ b/patch/kernel/archive/rockchip64-7.0/overlay/rockchip-rk3588-rock-5-itx-pwm-fan.dtso
@@ -1,0 +1,12 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target-path = "/pwm-fan";
+		__overlay__ {
+			cooling-levels = <1 64 128 192 255>;
+			rockchip,temp-trips = <45000 1 50000 2 55000 3 65000 4>;
+		};
+	};
+};


### PR DESCRIPTION
## Summary

The Rock 5 ITX DTB defines the PWM fan as `/pwm-fan` without a labelled phandle. The existing `rockchip-rk3588-fanctrl` overlay targets `&fan` which does not exist on this board, so it has no effect.

The default `cooling-levels` in the Rock 5 ITX DTB start at `0`, meaning the fan receives no PWM signal at idle and falls back to full speed regardless of temperature.

This PR adds a new board-specific overlay `rockchip-rk3588-rock-5-itx-pwm-fan` that:

- Patches `/pwm-fan` directly using `target-path` (required since no `&fan` label exists)
- Replaces `cooling-levels` with a curve starting at `1` (near-silent at idle) instead of `0`
- Adds `rockchip,temp-trips` to ramp the fan gradually at 45°C / 50°C / 55°C / 65°C

## Test plan

- [ ] Tested on Rock 5 ITX running Armbian with `linux-vendor-rk35xx 6.1.115`
- [ ] Fan spins down to near-silent at idle (~34–40°C)
- [ ] Fan ramps up correctly under CPU load
- [ ] Overlay loads cleanly via `user_overlays=rockchip-rk3588-rock-5-itx-pwm-fan` in `armbianEnv.txt`
- [ ] Verified via `/sys/devices/platform/pwm-fan/hwmon/hwmon*/pwm1` and running device tree dump

## Related

- Radxa community thread: https://forum.radxa.com/t/cpu-fan-pwm-control-issue/22405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PWM fan control overlay for Rock 5 ITX boards with configurable cooling levels and temperature-based thresholds to optimize fan performance.

* **Documentation**
  * Added documentation for Rock 5 ITX PWM fan overlay configuration and behavior.

* **Chores**
  * Updated build configuration across kernel versions to include new overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->