### PR TITLE
orangepi5-ultra: enable Bluetooth on edge kernel via hci_bcm

### DIFF
--- a/config/boards/orangepi5-ultra.csc
+++ b/config/boards/orangepi5-ultra.csc
@@ -44,7 +44,23 @@ function post_family_tweaks_bsp__orangepi5ultra_bluetooth() {
 }
 
 function post_family_tweaks__orangepi5ultra_enable_bluetooth_service() {
+	# On the edge kernel, the mainline hci_bcm SerDev driver handles BT natively
+	# via the DT bluetooth node. The user-space patchram service would conflict
+	# with SerDev (both try to claim /dev/ttyS7), so we skip enabling it.
+	[[ "$BRANCH" == "edge" ]] && return 0
+
 	display_alert "$BOARD" "Enabling ap6611s-bluetooth.service" "info"
 	chroot_sdcard systemctl enable ap6611s-bluetooth.service
+	return 0
+}
+
+# On the edge kernel, hci_bcm constructs the firmware filename from the board
+# compatible string (BCM.<board>.hcd), not from the chip name. Create a symlink
+# so the driver finds the SYN43711A0 patchram firmware.
+function post_family_tweaks__orangepi5ultra_bt_firmware_symlink() {
+	[[ "$BRANCH" != "edge" ]] && return 0
+	display_alert "$BOARD" "Creating BT firmware symlink for edge kernel" "info"
+	mkdir -p "$SDCARD/lib/firmware/brcm"
+	ln -sf SYN43711A0.hcd "$SDCARD/lib/firmware/brcm/BCM.xunlong,orangepi-5-ultra.hcd"
 	return 0
 }


### PR DESCRIPTION
# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [ ] short description (copy / paste of PR title)
- [Y ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ ] Test A
- [ ] Test B

# Checklist:

_Please delete options that are not relevant._

- [Y] My code follows the style guidelines of this project
- [Y] I have performed a self-review of my own code
- [Y] I have commented my code, particularly in hard-to-understand areas
- [Y] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized Orange Pi 5 Ultra Bluetooth configuration for edge kernel branch, enhancing firmware handling and service initialization to improve hardware compatibility and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->