### PR TITLE
artifact-uboot: add UBOOT_GIT_CACHE_TTL (fixes #7710)

### DIFF
--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -40,8 +40,14 @@ function artifact_uboot_prepare_version() {
 
 	declare short_hash_size=4
 
+	declare -i uboot_git_cache_ttl_seconds=3600 # by default
+	if [[ "${UBOOT_GIT_CACHE_TTL}" != "" ]]; then
+		uboot_git_cache_ttl_seconds="${UBOOT_GIT_CACHE_TTL}"
+		display_alert "Setting u-boot git cache TTL to" "${uboot_git_cache_ttl_seconds}" "info"
+	fi
+
 	declare -A GIT_INFO_UBOOT=([GIT_SOURCE]="${BOOTSOURCE}" [GIT_REF]="${BOOTBRANCH}")
-	run_memoized GIT_INFO_UBOOT "git2info" memoized_git_ref_to_info "include_makefile_body"
+	memoize_cache_ttl=$uboot_git_cache_ttl_seconds run_memoized GIT_INFO_UBOOT "git2info" memoized_git_ref_to_info "include_makefile_body"
 	debug_dict GIT_INFO_UBOOT
 
 	# Sanity check, the SHA1 gotta be sane.


### PR DESCRIPTION
## Summary

Fix #7710 by introducing `UBOOT_GIT_CACHE_TTL`, mirroring the existing
`KERNEL_GIT_CACHE_TTL` for kernel.

The upstream u-boot git ref SHA1 is memoized for 3600 seconds by default,
so commits pushed to a tracked `BOOTBRANCH` (`branch:*` refspec) are not
picked up until that TTL expires. There was no user-visible knob to
shorten the window — only `ARTIFACT_IGNORE_CACHE=yes` as a blunt workaround.

As suggested by @rpardini in #7710:
> A Pull request implementing `UBOOT_GIT_CACHE_TTL` (via `memoize_cache_ttl` var
> to `run_memoized()` just like is done in `obtain_kernel_git_info_and_makefile()`
> would be welcome.

## What changes

`lib/functions/artifacts/artifact-uboot.sh`: read `UBOOT_GIT_CACHE_TTL`,
emit `display_alert` when set, pass it as `memoize_cache_ttl` to `run_memoized`.
Default behaviour unchanged (3600s).

## Test plan

- [x] `./compile.sh uboot BOARD=helios4 BRANCH=edge UBOOT_GIT_CACHE_TTL=1`
      → `Setting u-boot git cache TTL to [ 1 ]` + `Producing new & caching [ GIT_INFO_UBOOT ]`, exit 0
- [x] `./compile.sh uboot BOARD=helios4 BRANCH=edge` (no override)
      → no TTL alert, `Using cached [ GIT_INFO_UBOOT ]`, exit 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable cache timeout for git operations via environment variable (default: 1 hour).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->