### PR TITLE
kernel-dtb: surface missing BOOT_FDT_FILE as err alert (fixes #8083)

### DIFF
--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -183,9 +183,8 @@ function kernel_dtb_only_build() {
 
 	display_alert "Considering further .dts convenience processing" "for board '${BOARD}' branch '${BRANCH}'" "info"
 
-	# If BOOT_FDT_FILE is not set, bail.
 	if [[ -z "${BOOT_FDT_FILE}" ]]; then
-		display_alert "Board '${BOARD}' branch '${BRANCH}'" "No BOOT_FDT_FILE set for board, skipping further processing" "warn"
+		display_alert "Board '${BOARD}' branch '${BRANCH}' has no BOOT_FDT_FILE" "linux-dtb package produced OK; preprocessed DTS copy skipped. Check board config and any post_family_config_* hook that may unset it." "err"
 		return 0
 	fi
 


### PR DESCRIPTION
## Summary
- Fixes #8083: `kernel-dtb` silently produced an empty `output/` preprocessed-DTS copy when `BOOT_FDT_FILE` was unset (typical case: board config relies on a `post_family_config_branch_*` hook that unsets it for some kernel branches — e.g. `orangepi5-max` on `edge`).
- `kernel_dtb_only_build()` now elevates the missing-`BOOT_FDT_FILE` notice from `warn` to `err`, with a diagnostic pointing at both likely sources (board config, post-family hook). The `linux-dtb` `.deb` is still produced — only the preprocessed DTS copy in `output/` is skipped.
- Regular `kernel` artifact is unaffected — it does not go through `kernel_dtb_only_build()`.

## Test plan
- [x] `./compile.sh kernel-dtb BOARD=orangepi5-max BRANCH=edge` — `.deb` produced, red `err`-level alert references `post_family_config_*` hook (this board unsets `BOOT_FDT_FILE` in an edge-specific hook).
- [x] `./compile.sh kernel-dtb BOARD=orangepi5-max BRANCH=current` — `.deb` produced + preprocessed DTS copy in `output/` (FDT stays set on `current`).
- [x] `bash -n lib/functions/compilation/kernel.sh` — OK.
- [x] `shellcheck --severity=error lib/functions/compilation/kernel.sh` — OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Elevated the message for missing kernel device-tree configuration to an error with clearer guidance, making the issue more visible during builds.
  * Prevents silent skipping of device-tree processing when configuration is unset, ensuring misconfigurations are surfaced early and easier to resolve.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
