### PR TITLE
armbian-resize-filesystem: fix typo $rootdev → $diskdev in do_expand_partition

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
+++ b/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
@@ -161,7 +161,7 @@ do_expand_partition()
 	echo -e "\nExecuting partprobe:"
 	# Workaround for Kernel bug in 5.8.y and up. Ignore partprobe returning error and inticating that fs is not expended while it is
 	KERNELID=$(uname -r |  awk -F'.' '{print ($1 * 100) + $2}')
-	if ! partprobe $rootdev && [[ ${KERNELID} -le 507 ]]; then
+	if ! partprobe $diskdev && [[ ${KERNELID} -le 507 ]]; then
 		echo -e "\n### [resize2fs] Automated reboot needed to finish the resize procedure"
 		touch /var/run/resize2fs-reboot
 	fi


### PR DESCRIPTION
Typo fix: `$rootdev` is undefined in `do_expand_partition` — should be `$diskdev`.

Fixes #9594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of automatic reboot scheduling during filesystem resize operations on specific kernel versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->