### PR TITLE
build: misc cleanup — DEBUG-gated mmdebstrap verbosity, DOCKER_PRUNE opt-in

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -155,8 +155,27 @@ function docker_cli_prepare() {
 	fi
 
 	#############################################################################################################
-	# Cleanup old Docker images to free disk space
-	docker_cleanup_old_images
+	# Optionally clean up old Docker images to free disk space. Off by
+	# default — set DOCKER_PRUNE=yes to opt in.
+	#
+	# The cleanup enumerates `docker images` and calls `docker rmi` on
+	# "old" ones. On hosts where several build invocations share one
+	# dockerd (the usual setup when multiple self-hosted GH Actions
+	# runners live on the same machine) two concurrent invocations
+	# race: runner A's cleanup can rmi an image runner B just
+	# committed between `Successfully built <sha>` and the daemon
+	# writing the imagedb digest file, surfacing as:
+	#   failed to get digest sha256:…: open …/imagedb/content/sha256/…:
+	#   no such file or directory
+	# which aborts runner B's build. Default-off keeps shared-daemon
+	# setups safe; single-host users who want automatic reclaim set
+	# DOCKER_PRUNE=yes and either accept the race risk or run builds
+	# serially.
+	if [[ "${DOCKER_PRUNE:-no}" == "yes" ]]; then
+		docker_cleanup_old_images
+	else
+		display_alert "Skipping Docker image cleanup" "set DOCKER_PRUNE=yes to enable" "debug"
+	fi
 
 	#############################################################################################################
 	# Detect some docker info; use cached.

--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -100,6 +100,13 @@ function create_new_rootfs_cache_via_debootstrap() {
 		"'--components=${AGGREGATED_DEBOOTSTRAP_COMPONENTS_COMMA}'" # from aggregation.py
 		"'--skip=check/empty'"                                      # skips check if the rootfs dir is empty at start
 	)
+
+	# Show mmdebstrap's per-package download/install progress when
+	# DEBUG=yes. Default (no flag) keeps the terse log; DEBUG builds
+	# get the solver + fetch lines that are usually needed to
+	# diagnose a bootstrap failure.
+	[[ "${DEBUG}" == "yes" ]] && debootstrap_arguments+=("--verbose")
+
 	fetch_distro_keyring "$RELEASE"
 
 	# This is necessary to debootstrap from a non-official repo


### PR DESCRIPTION
## Summary

Two small, independent build-framework fixes that were originally riding on top of the larger **desktops → armbian-config module_desktops** migration (#9683) but have nothing to do with desktop. Split out here for cleaner review and to let them land on their own schedule.

## Commits

1. **`rootfs-create: add --verbose to mmdebstrap when DEBUG=yes`**
   mmdebstrap setup failures land in build logs as a one-line `E: setup failed` with no context about which dep resolution actually blew up (recent example: sid/loong64 `gnupg2 >= 2.4.9-4` vs `dirmngr 2.4.8-4` port-sync skew). Pass `--verbose` to mmdebstrap when the user has already opted into `DEBUG=yes`, so the solver + per-package download lines become visible in the build log. Default builds (DEBUG unset) keep the terse log — no behaviour change for anyone who hasn't asked for it.

2. **`docker: gate image cleanup behind DOCKER_PRUNE=yes (default off)`**
   `docker_cli_prepare()` called `docker_cleanup_old_images` unconditionally, which enumerates `docker images` and `rmi`'s old armbian tags. Broken on hosts where several build framework invocations share one dockerd — the usual setup when multiple self-hosted GH Actions runners live on the same machine. Two concurrent invocations race: runner A's cleanup fires `docker rmi <id>` on a tag runner B just committed between `Successfully built <sha>` and dockerd writing the imagedb digest file. B aborts with `failed to get digest sha256:…: no such file or directory`. Default-off makes shared-daemon setups safe out of the box; users flip `DOCKER_PRUNE=yes` for the old behaviour.

## Relationship to other PRs

- #9683 was originally 10 commits spanning the desktop migration plus a few miscellaneous fixes. This PR keeps two of those splits; #9683 stays focused on the single storyline of replacing `config/desktop/` with armbian-config's `module_desktops`.
- The drm/xe `.NEED_FIX` rename that was previously the third commit here has been moved to its own PR (#9745) so it can land on a separate schedule. None of the splits is a prerequisite for the others.

## Test plan

- [x] Default build (`./compile.sh …`) has no mmdebstrap output change vs main — terse log as before.
- [x] `DEBUG=yes ./compile.sh …` shows mmdebstrap's per-package solver + download progress (visible failure context for bootstrap issues).
- [x] On a multi-runner self-hosted host running parallel `./compile.sh` jobs with the default `DOCKER_PRUNE` unset: no `failed to get digest` errors.
- [x] `DOCKER_PRUNE=yes ./compile.sh` behaves as before (cleanup runs).