### PR TITLE
Update odroidxu4-current to 6.6.135

### DIFF
--- a/patch/kernel/archive/odroidxu4-6.6/patch-6.6.129-130.patch
+++ b/patch/kernel/archive/odroidxu4-6.6/patch-6.6.129-130.patch
@@ -1,0 +1,24546 @@
+diff --git a/Documentation/hwmon/aht10.rst b/Documentation/hwmon/aht10.rst
+index 213644b4ecba6e..7903b6434326d0 100644
+--- a/Documentation/hwmon/aht10.rst
++++ b/Documentation/hwmon/aht10.rst
+@@ -20,6 +20,14 @@ Supported chips:
+ 
+       English: http://www.aosong.com/userfiles/files/media/Data%20Sheet%20AHT20.pdf
+ 
++  * Aosong DHT20
++
++    Prefix: 'dht20'
++
++    Addresses scanned: None
++
++    Datasheet: https://www.digikey.co.nz/en/htmldatasheets/production/9184855/0/0/1/101020932
++
+ Author: Johannes Cornelis Draaijer <jcdra1@gmail.com>
+ 
+ 
+@@ -33,7 +41,7 @@ The address of this i2c device may only be 0x38
+ Special Features
+ ----------------
+ 
+-AHT20 has additional CRC8 support which is sent as the last byte of the sensor
++AHT20, DHT20 has additional CRC8 support which is sent as the last byte of the sensor
+ values.
+ 
+ Usage Notes
+diff --git a/Makefile b/Makefile
+index 022aed9031737f..ec2fb5c10957b5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 6
+ PATCHLEVEL = 6
+-SUBLEVEL = 129
++SUBLEVEL = 130
+ EXTRAVERSION =
+ NAME = Pinguïn Aangedreven
+ 
+@@ -1356,13 +1356,13 @@ ifneq ($(wildcard $(resolve_btfids_O)),)
+ 	$(Q)$(MAKE) -sC $(srctree)/tools/bpf/resolve_btfids O=$(resolve_btfids_O) clean
+ endif
+ 
+-PHONY += objtool_clean
++PHONY += objtool_clean objtool_mrproper
+ 
+ objtool_O = $(abspath $(objtree))/tools/objtool
+ 
+-objtool_clean:
++objtool_clean objtool_mrproper:
+ ifneq ($(wildcard $(objtool_O)),)
+-	$(Q)$(MAKE) -sC $(abs_srctree)/tools/objtool O=$(objtool_O) srctree=$(abs_srctree) clean
++	$(Q)$(MAKE) -sC $(abs_srctree)/tools/objtool O=$(objtool_O) srctree=$(abs_srctree) $(patsubst objtool_%,%,$@)
+ endif
+ 
+ tools/: FORCE
+@@ -1529,7 +1529,7 @@ PHONY += $(mrproper-dirs) mrproper
+ $(mrproper-dirs):
+ 	$(Q)$(MAKE) $(clean)=$(patsubst _mrproper_%,%,$@)
+ 
+-mrproper: clean $(mrproper-dirs)
++mrproper: clean objtool_mrproper $(mrproper-dirs)
+ 	$(call cmd,rmfiles)
+ 	@find . $(RCS_FIND_IGNORE) \
+ 		\( -name '*.rmeta' \) \
+diff --git a/arch/arm/include/asm/string.h b/arch/arm/include/asm/string.h
+index c35250c4991bc7..96fc6cf460ecbe 100644
+--- a/arch/arm/include/asm/string.h
++++ b/arch/arm/include/asm/string.h
+@@ -39,13 +39,17 @@ static inline void *memset32(uint32_t *p, uint32_t v, __kernel_size_t n)
+ }
+ 
+ #define __HAVE_ARCH_MEMSET64
+-extern void *__memset64(uint64_t *, uint32_t low, __kernel_size_t, uint32_t hi);
++extern void *__memset64(uint64_t *, uint32_t first, __kernel_size_t, uint32_t second);
+ static inline void *memset64(uint64_t *p, uint64_t v, __kernel_size_t n)
+ {
+-	if (IS_ENABLED(CONFIG_CPU_LITTLE_ENDIAN))
+-		return __memset64(p, v, n * 8, v >> 32);
+-	else
+-		return __memset64(p, v >> 32, n * 8, v);
++	union {
++		uint64_t val;
++		struct {
++			uint32_t first, second;
++		};
++	} word = { .val = v };
++
++	return __memset64(p, word.first, n * 8, word.second);
+ }
+ 
+ /*
+diff --git a/arch/arm64/boot/dts/qcom/sdm845-oneplus-common.dtsi b/arch/arm64/boot/dts/qcom/sdm845-oneplus-common.dtsi
+index e028b58a30f314..c50d335e0761ff 100644
+--- a/arch/arm64/boot/dts/qcom/sdm845-oneplus-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/sdm845-oneplus-common.dtsi
+@@ -245,7 +245,6 @@
+ 			regulator-min-microvolt = <1800000>;
+ 			regulator-max-microvolt = <1800000>;
+ 			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+-			regulator-boot-on;
+ 		};
+ 
+ 		vreg_l14a_1p88: ldo14 {
+diff --git a/arch/arm64/boot/dts/rockchip/rk3568.dtsi b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
+index f1be76a54ceb0c..4305fd20b5c326 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3568.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
+@@ -97,7 +97,7 @@
+ 		      <0x0 0xf2000000 0x0 0x00100000>;
+ 		ranges = <0x01000000 0x0 0xf2100000 0x0 0xf2100000 0x0 0x00100000>,
+ 			 <0x02000000 0x0 0xf2200000 0x0 0xf2200000 0x0 0x01e00000>,
+-			 <0x03000000 0x0 0x40000000 0x3 0x40000000 0x0 0x40000000>;
++			 <0x03000000 0x3 0x40000000 0x3 0x40000000 0x0 0x40000000>;
+ 		reg-names = "dbi", "apb", "config";
+ 		resets = <&cru SRST_PCIE30X1_POWERUP>;
+ 		reset-names = "pipe";
+@@ -150,7 +150,7 @@
+ 		      <0x0 0xf0000000 0x0 0x00100000>;
+ 		ranges = <0x01000000 0x0 0xf0100000 0x0 0xf0100000 0x0 0x00100000>,
+ 			 <0x02000000 0x0 0xf0200000 0x0 0xf0200000 0x0 0x01e00000>,
+-			 <0x03000000 0x0 0x40000000 0x3 0x80000000 0x0 0x40000000>;
++			 <0x03000000 0x3 0x80000000 0x3 0x80000000 0x0 0x40000000>;
+ 		reg-names = "dbi", "apb", "config";
+ 		resets = <&cru SRST_PCIE30X2_POWERUP>;
+ 		reset-names = "pipe";
+diff --git a/arch/arm64/boot/dts/rockchip/rk356x.dtsi b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
+index 2f885bc3665b5c..6377f2a0b40171 100644
+--- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
+@@ -997,7 +997,7 @@
+ 		power-domains = <&power RK3568_PD_PIPE>;
+ 		ranges = <0x01000000 0x0 0xf4100000 0x0 0xf4100000 0x0 0x00100000>,
+ 			 <0x02000000 0x0 0xf4200000 0x0 0xf4200000 0x0 0x01e00000>,
+-			 <0x03000000 0x0 0x40000000 0x3 0x00000000 0x0 0x40000000>;
++			 <0x03000000 0x3 0x00000000 0x3 0x00000000 0x0 0x40000000>;
+ 		resets = <&cru SRST_PCIE20_POWERUP>;
+ 		reset-names = "pipe";
+ 		#address-cells = <3>;
+diff --git a/arch/arm64/include/asm/pgtable-prot.h b/arch/arm64/include/asm/pgtable-prot.h
+index eed814b00a3897..0236940eccaf29 100644
+--- a/arch/arm64/include/asm/pgtable-prot.h
++++ b/arch/arm64/include/asm/pgtable-prot.h
+@@ -45,11 +45,11 @@
+ 
+ #define _PAGE_DEFAULT		(_PROT_DEFAULT | PTE_ATTRINDX(MT_NORMAL))
+ 
+-#define _PAGE_KERNEL		(PROT_NORMAL)
+-#define _PAGE_KERNEL_RO		((PROT_NORMAL & ~PTE_WRITE) | PTE_RDONLY)
+-#define _PAGE_KERNEL_ROX	((PROT_NORMAL & ~(PTE_WRITE | PTE_PXN)) | PTE_RDONLY)
+-#define _PAGE_KERNEL_EXEC	(PROT_NORMAL & ~PTE_PXN)
+-#define _PAGE_KERNEL_EXEC_CONT	((PROT_NORMAL & ~PTE_PXN) | PTE_CONT)
++#define _PAGE_KERNEL		(PROT_NORMAL | PTE_DIRTY)
++#define _PAGE_KERNEL_RO		((PROT_NORMAL & ~PTE_WRITE) | PTE_RDONLY | PTE_DIRTY)
++#define _PAGE_KERNEL_ROX	((PROT_NORMAL & ~(PTE_WRITE | PTE_PXN)) | PTE_RDONLY | PTE_DIRTY)
++#define _PAGE_KERNEL_EXEC	((PROT_NORMAL & ~PTE_PXN) | PTE_DIRTY)
++#define _PAGE_KERNEL_EXEC_CONT	((PROT_NORMAL & ~PTE_PXN) | PTE_CONT | PTE_DIRTY)
+ 
+ #define _PAGE_SHARED		(_PAGE_DEFAULT | PTE_USER | PTE_RDONLY | PTE_NG | PTE_PXN | PTE_UXN | PTE_WRITE)
+ #define _PAGE_SHARED_EXEC	(_PAGE_DEFAULT | PTE_USER | PTE_RDONLY | PTE_NG | PTE_PXN | PTE_WRITE)
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index 92e43b3a10df9b..7350243a6a28d1 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -262,9 +262,14 @@ static inline pte_t pte_mkdevmap(pte_t pte)
+ 	return set_pte_bit(pte, __pgprot(PTE_DEVMAP | PTE_SPECIAL));
+ }
+ 
+-static inline void set_pte(pte_t *ptep, pte_t pte)
++static inline void set_pte_nosync(pte_t *ptep, pte_t pte)
+ {
+ 	WRITE_ONCE(*ptep, pte);
++}
++
++static inline void set_pte(pte_t *ptep, pte_t pte)
++{
++	set_pte_nosync(ptep, pte);
+ 
+ 	/*
+ 	 * Only if the new pte is valid and kernel, otherwise TLB maintenance
+diff --git a/arch/arm64/mm/mmu.c b/arch/arm64/mm/mmu.c
+index c8e83fe1cd5a73..d6411f7f0b72cc 100644
+--- a/arch/arm64/mm/mmu.c
++++ b/arch/arm64/mm/mmu.c
+@@ -106,28 +106,12 @@ EXPORT_SYMBOL(phys_mem_access_prot);
+ static phys_addr_t __init early_pgtable_alloc(int shift)
+ {
+ 	phys_addr_t phys;
+-	void *ptr;
+ 
+ 	phys = memblock_phys_alloc_range(PAGE_SIZE, PAGE_SIZE, 0,
+ 					 MEMBLOCK_ALLOC_NOLEAKTRACE);
+ 	if (!phys)
+ 		panic("Failed to allocate page table page\n");
+ 
+-	/*
+-	 * The FIX_{PGD,PUD,PMD} slots may be in active use, but the FIX_PTE
+-	 * slot will be free, so we can (ab)use the FIX_PTE slot to initialise
+-	 * any level of table.
+-	 */
+-	ptr = pte_set_fixmap(phys);
+-
+-	memset(ptr, 0, PAGE_SIZE);
+-
+-	/*
+-	 * Implicit barriers also ensure the zeroed page is visible to the page
+-	 * table walker
+-	 */
+-	pte_clear_fixmap();
+-
+ 	return phys;
+ }
+ 
+@@ -169,16 +153,25 @@ bool pgattr_change_is_safe(u64 old, u64 new)
+ 	return ((old ^ new) & ~mask) == 0;
+ }
+ 
+-static void init_pte(pmd_t *pmdp, unsigned long addr, unsigned long end,
+-		     phys_addr_t phys, pgprot_t prot)
++static void init_clear_pgtable(void *table)
+ {
+-	pte_t *ptep;
++	clear_page(table);
+ 
+-	ptep = pte_set_fixmap_offset(pmdp, addr);
++	/* Ensure the zeroing is observed by page table walks. */
++	dsb(ishst);
++}
++
++static void init_pte(pte_t *ptep, unsigned long addr, unsigned long end,
++		     phys_addr_t phys, pgprot_t prot)
++{
+ 	do {
+ 		pte_t old_pte = READ_ONCE(*ptep);
+ 
+-		set_pte(ptep, pfn_pte(__phys_to_pfn(phys), prot));
++		/*
++		 * Required barriers to make this visible to the table walker
++		 * are deferred to the end of alloc_init_cont_pte().
++		 */
++		set_pte_nosync(ptep, pfn_pte(__phys_to_pfn(phys), prot));
+ 
+ 		/*
+ 		 * After the PTE entry has been populated once, we
+@@ -189,8 +182,6 @@ static void init_pte(pmd_t *pmdp, unsigned long addr, unsigned long end,
+ 
+ 		phys += PAGE_SIZE;
+ 	} while (ptep++, addr += PAGE_SIZE, addr != end);
+-
+-	pte_clear_fixmap();
+ }
+ 
+ static void alloc_init_cont_pte(pmd_t *pmdp, unsigned long addr,
+@@ -201,6 +192,7 @@ static void alloc_init_cont_pte(pmd_t *pmdp, unsigned long addr,
+ {
+ 	unsigned long next;
+ 	pmd_t pmd = READ_ONCE(*pmdp);
++	pte_t *ptep;
+ 
+ 	BUG_ON(pmd_sect(pmd));
+ 	if (pmd_none(pmd)) {
+@@ -211,10 +203,14 @@ static void alloc_init_cont_pte(pmd_t *pmdp, unsigned long addr,
+ 			pmdval |= PMD_TABLE_PXN;
+ 		BUG_ON(!pgtable_alloc);
+ 		pte_phys = pgtable_alloc(PAGE_SHIFT);
++		ptep = pte_set_fixmap(pte_phys);
++		init_clear_pgtable(ptep);
++		ptep += pte_index(addr);
+ 		__pmd_populate(pmdp, pte_phys, pmdval);
+-		pmd = READ_ONCE(*pmdp);
++	} else {
++		BUG_ON(pmd_bad(pmd));
++		ptep = pte_set_fixmap_offset(pmdp, addr);
+ 	}
+-	BUG_ON(pmd_bad(pmd));
+ 
+ 	do {
+ 		pgprot_t __prot = prot;
+@@ -226,20 +222,26 @@ static void alloc_init_cont_pte(pmd_t *pmdp, unsigned long addr,
+ 		    (flags & NO_CONT_MAPPINGS) == 0)
+ 			__prot = __pgprot(pgprot_val(prot) | PTE_CONT);
+ 
+-		init_pte(pmdp, addr, next, phys, __prot);
++		init_pte(ptep, addr, next, phys, __prot);
+ 
++		ptep += pte_index(next) - pte_index(addr);
+ 		phys += next - addr;
+ 	} while (addr = next, addr != end);
++
++	/*
++	 * Note: barriers and maintenance necessary to clear the fixmap slot
++	 * ensure that all previous pgtable writes are visible to the table
++	 * walker.
++	 */
++	pte_clear_fixmap();
+ }
+ 
+-static void init_pmd(pud_t *pudp, unsigned long addr, unsigned long end,
++static void init_pmd(pmd_t *pmdp, unsigned long addr, unsigned long end,
+ 		     phys_addr_t phys, pgprot_t prot,
+ 		     phys_addr_t (*pgtable_alloc)(int), int flags)
+ {
+ 	unsigned long next;
+-	pmd_t *pmdp;
+ 
+-	pmdp = pmd_set_fixmap_offset(pudp, addr);
+ 	do {
+ 		pmd_t old_pmd = READ_ONCE(*pmdp);
+ 
+@@ -265,8 +267,6 @@ static void init_pmd(pud_t *pudp, unsigned long addr, unsigned long end,
+ 		}
+ 		phys += next - addr;
+ 	} while (pmdp++, addr = next, addr != end);
+-
+-	pmd_clear_fixmap();
+ }
+ 
+ static void alloc_init_cont_pmd(pud_t *pudp, unsigned long addr,
+@@ -276,6 +276,7 @@ static void alloc_init_cont_pmd(pud_t *pudp, unsigned long addr,
+ {
+ 	unsigned long next;
+ 	pud_t pud = READ_ONCE(*pudp);
++	pmd_t *pmdp;
+ 
+ 	/*
+ 	 * Check for initial section mappings in the pgd/pud.
+@@ -289,10 +290,14 @@ static void alloc_init_cont_pmd(pud_t *pudp, unsigned long addr,
+ 			pudval |= PUD_TABLE_PXN;
+ 		BUG_ON(!pgtable_alloc);
+ 		pmd_phys = pgtable_alloc(PMD_SHIFT);
++		pmdp = pmd_set_fixmap(pmd_phys);
++		init_clear_pgtable(pmdp);
++		pmdp += pmd_index(addr);
+ 		__pud_populate(pudp, pmd_phys, pudval);
+-		pud = READ_ONCE(*pudp);
++	} else {
++		BUG_ON(pud_bad(pud));
++		pmdp = pmd_set_fixmap_offset(pudp, addr);
+ 	}
+-	BUG_ON(pud_bad(pud));
+ 
+ 	do {
+ 		pgprot_t __prot = prot;
+@@ -304,10 +309,13 @@ static void alloc_init_cont_pmd(pud_t *pudp, unsigned long addr,
+ 		    (flags & NO_CONT_MAPPINGS) == 0)
+ 			__prot = __pgprot(pgprot_val(prot) | PTE_CONT);
+ 
+-		init_pmd(pudp, addr, next, phys, __prot, pgtable_alloc, flags);
++		init_pmd(pmdp, addr, next, phys, __prot, pgtable_alloc, flags);
+ 
++		pmdp += pmd_index(next) - pmd_index(addr);
+ 		phys += next - addr;
+ 	} while (addr = next, addr != end);
++
++	pmd_clear_fixmap();
+ }
+ 
+ static void alloc_init_pud(pgd_t *pgdp, unsigned long addr, unsigned long end,
+@@ -328,12 +336,15 @@ static void alloc_init_pud(pgd_t *pgdp, unsigned long addr, unsigned long end,
+ 			p4dval |= P4D_TABLE_PXN;
+ 		BUG_ON(!pgtable_alloc);
+ 		pud_phys = pgtable_alloc(PUD_SHIFT);
++		pudp = pud_set_fixmap(pud_phys);
++		init_clear_pgtable(pudp);
++		pudp += pud_index(addr);
+ 		__p4d_populate(p4dp, pud_phys, p4dval);
+-		p4d = READ_ONCE(*p4dp);
++	} else {
++		BUG_ON(p4d_bad(p4d));
++		pudp = pud_set_fixmap_offset(p4dp, addr);
+ 	}
+-	BUG_ON(p4d_bad(p4d));
+ 
+-	pudp = pud_set_fixmap_offset(p4dp, addr);
+ 	do {
+ 		pud_t old_pud = READ_ONCE(*pudp);
+ 
+@@ -415,11 +426,10 @@ void create_kpti_ng_temp_pgd(pgd_t *pgdir, phys_addr_t phys, unsigned long virt,
+ 
+ static phys_addr_t __pgd_pgtable_alloc(int shift)
+ {
+-	void *ptr = (void *)__get_free_page(GFP_PGTABLE_KERNEL);
+-	BUG_ON(!ptr);
++	/* Page is zeroed by init_clear_pgtable() so don't duplicate effort. */
++	void *ptr = (void *)__get_free_page(GFP_PGTABLE_KERNEL & ~__GFP_ZERO);
+ 
+-	/* Ensure the zeroed page is visible to the page table walker */
+-	dsb(ishst);
++	BUG_ON(!ptr);
+ 	return __pa(ptr);
+ }
+ 
+diff --git a/arch/loongarch/include/asm/uaccess.h b/arch/loongarch/include/asm/uaccess.h
+index 0d22991ae430d4..a9b40d23134361 100644
+--- a/arch/loongarch/include/asm/uaccess.h
++++ b/arch/loongarch/include/asm/uaccess.h
+@@ -196,8 +196,13 @@ do {									\
+ 									\
+ 	__get_kernel_common(*((type *)(dst)), sizeof(type),		\
+ 			    (__force type *)(src));			\
+-	if (unlikely(__gu_err))						\
++	if (unlikely(__gu_err))	{					\
++		pr_info("%s: memory access failed, ecode 0x%x\n",	\
++			__func__, read_csr_excode());			\
++		pr_info("%s: the caller is %pS\n",			\
++			__func__, __builtin_return_address(0));		\
+ 		goto err_label;						\
++	}								\
+ } while (0)
+ 
+ #define __put_kernel_nofault(dst, src, type, err_label)			\
+@@ -207,8 +212,13 @@ do {									\
+ 									\
+ 	__pu_val = *(__force type *)(src);				\
+ 	__put_kernel_common(((type *)(dst)), sizeof(type));		\
+-	if (unlikely(__pu_err))						\
++	if (unlikely(__pu_err))	{					\
++		pr_info("%s: memory access failed, ecode 0x%x\n",	\
++			__func__, read_csr_excode());			\
++		pr_info("%s: the caller is %pS\n",			\
++			__func__, __builtin_return_address(0));		\
+ 		goto err_label;						\
++	}								\
+ } while (0)
+ 
+ extern unsigned long __copy_user(void *to, const void *from, __kernel_size_t n);
+diff --git a/arch/parisc/include/asm/pgtable.h b/arch/parisc/include/asm/pgtable.h
+index 3446a5e2520b22..93772c82c62f51 100644
+--- a/arch/parisc/include/asm/pgtable.h
++++ b/arch/parisc/include/asm/pgtable.h
+@@ -85,7 +85,7 @@ extern void __update_cache(pte_t pte);
+ 	printk("%s:%d: bad pgd %08lx.\n", __FILE__, __LINE__, (unsigned long)pgd_val(e))
+ 
+ /* This is the size of the initially mapped kernel memory */
+-#if defined(CONFIG_64BIT)
++#if defined(CONFIG_64BIT) || defined(CONFIG_KALLSYMS)
+ #define KERNEL_INITIAL_ORDER	26	/* 1<<26 = 64MB */
+ #else
+ #define KERNEL_INITIAL_ORDER	25	/* 1<<25 = 32MB */
+diff --git a/arch/parisc/kernel/cache.c b/arch/parisc/kernel/cache.c
+index 1898956a70f25c..5b19572b3e1d33 100644
+--- a/arch/parisc/kernel/cache.c
++++ b/arch/parisc/kernel/cache.c
+@@ -953,7 +953,7 @@ SYSCALL_DEFINE3(cacheflush, unsigned long, addr, unsigned long, bytes,
+ #else
+ 			"1: cmpb,<<,n	%0,%2,1b\n"
+ #endif
+-			"   fic,m	%3(%4,%0)\n"
++			"   fdc,m	%3(%4,%0)\n"
+ 			"2: sync\n"
+ 			ASM_EXCEPTIONTABLE_ENTRY_EFAULT(1b, 2b, "%1")
+ 			: "+r" (start), "+r" (error)
+@@ -968,7 +968,7 @@ SYSCALL_DEFINE3(cacheflush, unsigned long, addr, unsigned long, bytes,
+ #else
+ 			"1: cmpb,<<,n	%0,%2,1b\n"
+ #endif
+-			"   fdc,m	%3(%4,%0)\n"
++			"   fic,m	%3(%4,%0)\n"
+ 			"2: sync\n"
+ 			ASM_EXCEPTIONTABLE_ENTRY_EFAULT(1b, 2b, "%1")
+ 			: "+r" (start), "+r" (error)
+diff --git a/arch/parisc/kernel/head.S b/arch/parisc/kernel/head.S
+index 96e0264ac96163..9188c8d8743704 100644
+--- a/arch/parisc/kernel/head.S
++++ b/arch/parisc/kernel/head.S
+@@ -56,6 +56,7 @@ ENTRY(parisc_kernel_start)
+ 
+ 	.import __bss_start,data
+ 	.import __bss_stop,data
++	.import __end,data
+ 
+ 	load32		PA(__bss_start),%r3
+ 	load32		PA(__bss_stop),%r4
+@@ -149,7 +150,11 @@ $cpu_ok:
+ 	 * everything ... it will get remapped correctly later */
+ 	ldo		0+_PAGE_KERNEL_RWX(%r0),%r3 /* Hardwired 0 phys addr start */
+ 	load32		(1<<(KERNEL_INITIAL_ORDER-PAGE_SHIFT)),%r11 /* PFN count */
+-	load32		PA(pg0),%r1
++	load32		PA(_end),%r1
++	SHRREG		%r1,PAGE_SHIFT,%r1  /* %r1 is PFN count for _end symbol */
++	cmpb,<<,n	%r11,%r1,1f
++	copy		%r1,%r11	/* %r1 PFN count smaller than %r11 */
++1:	load32		PA(pg0),%r1
+ 
+ $pgt_fill_loop:
+ 	STREGM          %r3,ASM_PTE_ENTRY_SIZE(%r1)
+diff --git a/arch/parisc/kernel/setup.c b/arch/parisc/kernel/setup.c
+index 2f434f2da18514..e392dfa3009d20 100644
+--- a/arch/parisc/kernel/setup.c
++++ b/arch/parisc/kernel/setup.c
+@@ -123,14 +123,6 @@ void __init setup_arch(char **cmdline_p)
+ #endif
+ 	printk(KERN_CONT ".\n");
+ 
+-	/*
+-	 * Check if initial kernel page mappings are sufficient.
+-	 * panic early if not, else we may access kernel functions
+-	 * and variables which can't be reached.
+-	 */
+-	if (__pa((unsigned long) &_end) >= KERNEL_INITIAL_SIZE)
+-		panic("KERNEL_INITIAL_ORDER too small!");
+-
+ #ifdef CONFIG_64BIT
+ 	if(parisc_narrow_firmware) {
+ 		printk(KERN_INFO "Kernel is using PDC in 32-bit mode.\n");
+@@ -282,6 +274,18 @@ void __init start_parisc(void)
+ 	int ret, cpunum;
+ 	struct pdc_coproc_cfg coproc_cfg;
+ 
++	/*
++	 * Check if initial kernel page mapping is sufficient.
++	 * Print warning if not, because we may access kernel functions and
++	 * variables which can't be reached yet through the initial mappings.
++	 * Note that the panic() and printk() functions are not functional
++	 * yet, so we need to use direct iodc() firmware calls instead.
++	 */
++	const char warn1[] = "CRITICAL: Kernel may crash because "
++			     "KERNEL_INITIAL_ORDER is too small.\n";
++	if (__pa((unsigned long) &_end) >= KERNEL_INITIAL_SIZE)
++		pdc_iodc_print(warn1, sizeof(warn1) - 1);
++
+ 	/* check QEMU/SeaBIOS marker in PAGE0 */
+ 	running_on_qemu = (memcmp(&PAGE0->pad0, "SeaBIOS", 8) == 0);
+ 
+diff --git a/arch/powerpc/include/asm/uaccess.h b/arch/powerpc/include/asm/uaccess.h
+index ec7f001d03d017..fa6d8410bc07de 100644
+--- a/arch/powerpc/include/asm/uaccess.h
++++ b/arch/powerpc/include/asm/uaccess.h
+@@ -242,7 +242,7 @@ __gus_failed:								\
+ 		".section .fixup,\"ax\"\n"		\
+ 		"4:	li %0,%3\n"			\
+ 		"	li %1,0\n"			\
+-		"	li %1+1,0\n"			\
++		"	li %L1,0\n"			\
+ 		"	b 3b\n"				\
+ 		".previous\n"				\
+ 		EX_TABLE(1b, 4b)			\
+diff --git a/arch/powerpc/platforms/83xx/km83xx.c b/arch/powerpc/platforms/83xx/km83xx.c
+index 2b5d187d9b62d5..9ef8fb39dd1b18 100644
+--- a/arch/powerpc/platforms/83xx/km83xx.c
++++ b/arch/powerpc/platforms/83xx/km83xx.c
+@@ -155,8 +155,8 @@ machine_device_initcall(mpc83xx_km, mpc83xx_declare_of_platform_devices);
+ 
+ /* list of the supported boards */
+ static char *board[] __initdata = {
+-	"Keymile,KMETER1",
+-	"Keymile,kmpbec8321",
++	"keymile,KMETER1",
++	"keymile,kmpbec8321",
+ 	NULL
+ };
+ 
+diff --git a/arch/riscv/kernel/traps.c b/arch/riscv/kernel/traps.c
+index 53c7de4878c227..314c4d7671ca0b 100644
+--- a/arch/riscv/kernel/traps.c
++++ b/arch/riscv/kernel/traps.c
+@@ -20,6 +20,7 @@
+ #include <linux/irq.h>
+ #include <linux/kexec.h>
+ #include <linux/entry-common.h>
++#include <linux/nospec.h>
+ 
+ #include <asm/asm-prototypes.h>
+ #include <asm/bug.h>
+@@ -317,8 +318,10 @@ asmlinkage __visible __trap_section void do_trap_ecall_u(struct pt_regs *regs)
+ 
+ 		syscall = syscall_enter_from_user_mode(regs, syscall);
+ 
+-		if (syscall >= 0 && syscall < NR_syscalls)
++		if (syscall >= 0 && syscall < NR_syscalls) {
++			syscall = array_index_nospec(syscall, NR_syscalls);
+ 			syscall_handler(regs, syscall);
++		}
+ 
+ 		syscall_exit_to_user_mode(regs);
+ 	} else {
+diff --git a/arch/s390/include/asm/processor.h b/arch/s390/include/asm/processor.h
+index 2f373e8cfed33e..e0db966e185b9b 100644
+--- a/arch/s390/include/asm/processor.h
++++ b/arch/s390/include/asm/processor.h
+@@ -146,7 +146,7 @@ static __always_inline void __stackleak_poison(unsigned long erase_low,
+ 		"	j	4f\n"
+ 		"3:	mvc	8(1,%[addr]),0(%[addr])\n"
+ 		"4:\n"
+-		: [addr] "+&a" (erase_low), [count] "+&d" (count), [tmp] "=&a" (tmp)
++		: [addr] "+&a" (erase_low), [count] "+&a" (count), [tmp] "=&a" (tmp)
+ 		: [poison] "d" (poison)
+ 		: "memory", "cc"
+ 		);
+diff --git a/arch/s390/lib/xor.c b/arch/s390/lib/xor.c
+index fb924a8041dc77..76d7ca64d23107 100644
+--- a/arch/s390/lib/xor.c
++++ b/arch/s390/lib/xor.c
+@@ -29,8 +29,8 @@ static void xor_xc_2(unsigned long bytes, unsigned long * __restrict p1,
+ 		"	j	3f\n"
+ 		"2:	xc	0(1,%1),0(%2)\n"
+ 		"3:\n"
+-		: : "d" (bytes), "a" (p1), "a" (p2)
+-		: "0", "1", "cc", "memory");
++		: "+d" (bytes), "+a" (p1), "+a" (p2)
++		: : "0", "1", "cc", "memory");
+ }
+ 
+ static void xor_xc_3(unsigned long bytes, unsigned long * __restrict p1,
+diff --git a/arch/x86/boot/compressed/sev.c b/arch/x86/boot/compressed/sev.c
+index 92c9f8b79f0dc4..2c17fa01859e4b 100644
+--- a/arch/x86/boot/compressed/sev.c
++++ b/arch/x86/boot/compressed/sev.c
+@@ -277,6 +277,10 @@ void do_boot_stage2_vc(struct pt_regs *regs, unsigned long exit_code)
+ 	if (result != ES_OK)
+ 		goto finish;
+ 
++	result = vc_check_opcode_bytes(&ctxt, exit_code);
++	if (result != ES_OK)
++		goto finish;
++
+ 	switch (exit_code) {
+ 	case SVM_EXIT_RDTSC:
+ 	case SVM_EXIT_RDTSCP:
+@@ -341,6 +345,7 @@ static void enforce_vmpl0(void)
+ 				 MSR_AMD64_SNP_VMSA_REG_PROTECTION |	\
+ 				 MSR_AMD64_SNP_RESERVED_BIT13 |		\
+ 				 MSR_AMD64_SNP_RESERVED_BIT15 |		\
++				 MSR_AMD64_SNP_RESERVED_BITS18_22 |	\
+ 				 MSR_AMD64_SNP_RESERVED_MASK)
+ 
+ /*
+diff --git a/arch/x86/include/asm/efi.h b/arch/x86/include/asm/efi.h
+index a050d329e34bfd..aaf1e71b067aae 100644
+--- a/arch/x86/include/asm/efi.h
++++ b/arch/x86/include/asm/efi.h
+@@ -138,7 +138,7 @@ extern void __init efi_apply_memmap_quirks(void);
+ extern int __init efi_reuse_config(u64 tables, int nr_tables);
+ extern void efi_delete_dummy_variable(void);
+ extern void efi_crash_gracefully_on_page_fault(unsigned long phys_addr);
+-extern void efi_free_boot_services(void);
++extern void efi_unmap_boot_services(void);
+ 
+ void arch_efi_call_virt_setup(void);
+ void arch_efi_call_virt_teardown(void);
+diff --git a/arch/x86/include/asm/msr-index.h b/arch/x86/include/asm/msr-index.h
+index 425980eacaa841..e58204e7714e42 100644
+--- a/arch/x86/include/asm/msr-index.h
++++ b/arch/x86/include/asm/msr-index.h
+@@ -632,11 +632,14 @@
+ #define MSR_AMD64_SNP_IBS_VIRT			BIT_ULL(14)
+ #define MSR_AMD64_SNP_VMSA_REG_PROTECTION	BIT_ULL(16)
+ #define MSR_AMD64_SNP_SMT_PROTECTION		BIT_ULL(17)
++#define MSR_AMD64_SNP_IBPB_ON_ENTRY_BIT	23
++#define MSR_AMD64_SNP_IBPB_ON_ENTRY		BIT_ULL(MSR_AMD64_SNP_IBPB_ON_ENTRY_BIT)
+ 
+ /* SNP feature bits reserved for future use. */
+ #define MSR_AMD64_SNP_RESERVED_BIT13		BIT_ULL(13)
+ #define MSR_AMD64_SNP_RESERVED_BIT15		BIT_ULL(15)
+-#define MSR_AMD64_SNP_RESERVED_MASK		GENMASK_ULL(63, 18)
++#define MSR_AMD64_SNP_RESERVED_BITS18_22	GENMASK_ULL(22, 18)
++#define MSR_AMD64_SNP_RESERVED_MASK		GENMASK_ULL(63, 24)
+ 
+ #define MSR_AMD64_VIRT_SPEC_CTRL	0xc001011f
+ 
+diff --git a/arch/x86/kernel/apic/apic.c b/arch/x86/kernel/apic/apic.c
+index 00ca9c3c1d8bf8..e714449ae79b4c 100644
+--- a/arch/x86/kernel/apic/apic.c
++++ b/arch/x86/kernel/apic/apic.c
+@@ -1931,6 +1931,7 @@ void __init check_x2apic(void)
+ 
+ static inline void try_to_enable_x2apic(int remap_mode) { }
+ static inline void __x2apic_enable(void) { }
++static inline void __x2apic_disable(void) { }
+ #endif /* !CONFIG_X86_X2APIC */
+ 
+ void __init enable_IR_x2apic(void)
+@@ -2652,6 +2653,11 @@ static void lapic_resume(void)
+ 	if (x2apic_mode) {
+ 		__x2apic_enable();
+ 	} else {
++		if (x2apic_enabled()) {
++			pr_warn_once("x2apic: re-enabled by firmware during resume. Disabling\n");
++			__x2apic_disable();
++		}
++
+ 		/*
+ 		 * Make sure the APICBASE points to the right address
+ 		 *
+diff --git a/arch/x86/kernel/apic/x2apic_uv_x.c b/arch/x86/kernel/apic/x2apic_uv_x.c
+index 205cee5676298f..ad65da69ad5685 100644
+--- a/arch/x86/kernel/apic/x2apic_uv_x.c
++++ b/arch/x86/kernel/apic/x2apic_uv_x.c
+@@ -1760,8 +1760,22 @@ static void __init uv_system_init_hub(void)
+ 		struct uv_hub_info_s *new_hub;
+ 
+ 		/* Allocate & fill new per hub info list */
+-		new_hub = (bid == 0) ?  &uv_hub_info_node0
+-			: kzalloc_node(bytes, GFP_KERNEL, uv_blade_to_node(bid));
++		if (bid == 0) {
++			new_hub = &uv_hub_info_node0;
++		} else {
++			int nid;
++
++			/*
++			 * Deconfigured sockets are mapped to SOCK_EMPTY. Use
++			 * NUMA_NO_NODE to allocate on a valid node.
++			 */
++			nid = uv_blade_to_node(bid);
++			if (nid == SOCK_EMPTY)
++				nid = NUMA_NO_NODE;
++
++			new_hub = kzalloc_node(bytes, GFP_KERNEL, nid);
++		}
++
+ 		if (WARN_ON_ONCE(!new_hub)) {
+ 			/* do not kfree() bid 0, which is statically allocated */
+ 			while (--bid > 0)
+diff --git a/arch/x86/kernel/sev-shared.c b/arch/x86/kernel/sev-shared.c
+index b90dfa46ec5b57..caa3de2dcd0a7e 100644
+--- a/arch/x86/kernel/sev-shared.c
++++ b/arch/x86/kernel/sev-shared.c
+@@ -10,11 +10,15 @@
+  */
+ 
+ #ifndef __BOOT_COMPRESSED
+-#define error(v)	pr_err(v)
+-#define has_cpuflag(f)	boot_cpu_has(f)
++#define error(v)			pr_err(v)
++#define has_cpuflag(f)			boot_cpu_has(f)
++#define sev_printk(fmt, ...)		printk(fmt, ##__VA_ARGS__)
++#define sev_printk_rtl(fmt, ...)	printk_ratelimited(fmt, ##__VA_ARGS__)
+ #else
+ #undef WARN
+ #define WARN(condition, format...) (!!(condition))
++#define sev_printk(fmt, ...)
++#define sev_printk_rtl(fmt, ...)
+ #endif
+ 
+ /* I/O parameters for CPUID-related helpers */
+@@ -570,6 +574,7 @@ void __head do_vc_no_ghcb(struct pt_regs *regs, unsigned long exit_code)
+ {
+ 	unsigned int subfn = lower_bits(regs->cx, 32);
+ 	unsigned int fn = lower_bits(regs->ax, 32);
++	u16 opcode = *(unsigned short *)regs->ip;
+ 	struct cpuid_leaf leaf;
+ 	int ret;
+ 
+@@ -577,6 +582,10 @@ void __head do_vc_no_ghcb(struct pt_regs *regs, unsigned long exit_code)
+ 	if (exit_code != SVM_EXIT_CPUID)
+ 		goto fail;
+ 
++	/* Is it really a CPUID insn? */
++	if (opcode != 0xa20f)
++		goto fail;
++
+ 	leaf.fn = fn;
+ 	leaf.subfn = subfn;
+ 
+@@ -1203,3 +1212,94 @@ static int vmgexit_psc(struct ghcb *ghcb, struct snp_psc_desc *desc)
+ out:
+ 	return ret;
+ }
++
++static enum es_result vc_check_opcode_bytes(struct es_em_ctxt *ctxt,
++					    unsigned long exit_code)
++{
++	unsigned int opcode = (unsigned int)ctxt->insn.opcode.value;
++	u8 modrm = ctxt->insn.modrm.value;
++
++	switch (exit_code) {
++
++	case SVM_EXIT_IOIO:
++	case SVM_EXIT_NPF:
++		/* handled separately */
++		return ES_OK;
++
++	case SVM_EXIT_CPUID:
++		if (opcode == 0xa20f)
++			return ES_OK;
++		break;
++
++	case SVM_EXIT_INVD:
++		if (opcode == 0x080f)
++			return ES_OK;
++		break;
++
++	case SVM_EXIT_MONITOR:
++		/* MONITOR and MONITORX instructions generate the same error code */
++		if (opcode == 0x010f && (modrm == 0xc8 || modrm == 0xfa))
++			return ES_OK;
++		break;
++
++	case SVM_EXIT_MWAIT:
++		/* MWAIT and MWAITX instructions generate the same error code */
++		if (opcode == 0x010f && (modrm == 0xc9 || modrm == 0xfb))
++			return ES_OK;
++		break;
++
++	case SVM_EXIT_MSR:
++		/* RDMSR */
++		if (opcode == 0x320f ||
++		/* WRMSR */
++		    opcode == 0x300f)
++			return ES_OK;
++		break;
++
++	case SVM_EXIT_RDPMC:
++		if (opcode == 0x330f)
++			return ES_OK;
++		break;
++
++	case SVM_EXIT_RDTSC:
++		if (opcode == 0x310f)
++			return ES_OK;
++		break;
++
++	case SVM_EXIT_RDTSCP:
++		if (opcode == 0x010f && modrm == 0xf9)
++			return ES_OK;
++		break;
++
++	case SVM_EXIT_READ_DR7:
++		if (opcode == 0x210f &&
++		    X86_MODRM_REG(ctxt->insn.modrm.value) == 7)
++			return ES_OK;
++		break;
++
++	case SVM_EXIT_VMMCALL:
++		if (opcode == 0x010f && modrm == 0xd9)
++			return ES_OK;
++
++		break;
++
++	case SVM_EXIT_WRITE_DR7:
++		if (opcode == 0x230f &&
++		    X86_MODRM_REG(ctxt->insn.modrm.value) == 7)
++			return ES_OK;
++		break;
++
++	case SVM_EXIT_WBINVD:
++		if (opcode == 0x90f)
++			return ES_OK;
++		break;
++
++	default:
++		break;
++	}
++
++	sev_printk(KERN_ERR "Wrong/unhandled opcode bytes: 0x%x, exit_code: 0x%lx, rIP: 0x%lx\n",
++		   opcode, exit_code, ctxt->regs->ip);
++
++	return ES_UNSUPPORTED;
++}
+diff --git a/arch/x86/kernel/sev.c b/arch/x86/kernel/sev.c
+index c6a9a9d3ff2f37..ad2b3ea24dd46d 100644
+--- a/arch/x86/kernel/sev.c
++++ b/arch/x86/kernel/sev.c
+@@ -1749,7 +1749,10 @@ static enum es_result vc_handle_exitcode(struct es_em_ctxt *ctxt,
+ 					 struct ghcb *ghcb,
+ 					 unsigned long exit_code)
+ {
+-	enum es_result result;
++	enum es_result result = vc_check_opcode_bytes(ctxt, exit_code);
++
++	if (result != ES_OK)
++		return result;
+ 
+ 	switch (exit_code) {
+ 	case SVM_EXIT_READ_DR7:
+diff --git a/arch/x86/kernel/uprobes.c b/arch/x86/kernel/uprobes.c
+index 6402fb3089d262..aac2a2c5c6c558 100644
+--- a/arch/x86/kernel/uprobes.c
++++ b/arch/x86/kernel/uprobes.c
+@@ -1102,3 +1102,27 @@ bool arch_uretprobe_is_alive(struct return_instance *ret, enum rp_check ctx,
+ 	else
+ 		return regs->sp <= ret->stack;
+ }
++
++#ifdef CONFIG_IA32_EMULATION
++unsigned long arch_uprobe_get_xol_area(void)
++{
++	struct thread_info *ti = current_thread_info();
++	unsigned long vaddr;
++
++	/*
++	 * HACK: we are not in a syscall, but x86 get_unmapped_area() paths
++	 * ignore TIF_ADDR32 and rely on in_32bit_syscall() to calculate
++	 * vm_unmapped_area_info.high_limit.
++	 *
++	 * The #ifdef above doesn't cover the CONFIG_X86_X32_ABI=y case,
++	 * but in this case in_32bit_syscall() -> in_x32_syscall() always
++	 * (falsely) returns true because ->orig_ax == -1.
++	 */
++	if (test_thread_flag(TIF_ADDR32))
++		ti->status |= TS_COMPAT;
++	vaddr = get_unmapped_area(NULL, TASK_SIZE - PAGE_SIZE, PAGE_SIZE, 0, 0);
++	ti->status &= ~TS_COMPAT;
++
++	return vaddr;
++}
++#endif
+diff --git a/arch/x86/kvm/svm/avic.c b/arch/x86/kvm/svm/avic.c
+index 6970b11a6b4c62..e0edce5d1ca917 100644
+--- a/arch/x86/kvm/svm/avic.c
++++ b/arch/x86/kvm/svm/avic.c
+@@ -82,15 +82,34 @@ struct amd_svm_iommu_ir {
+ 	void *data;		/* Storing pointer to struct amd_ir_data */
+ };
+ 
++static u32 avic_get_max_physical_id(struct kvm_vcpu *vcpu)
++{
++	u32 arch_max;
++
++	if (x2avic_enabled && apic_x2apic_mode(vcpu->arch.apic))
++		arch_max = X2AVIC_MAX_PHYSICAL_ID;
++	else
++		arch_max = AVIC_MAX_PHYSICAL_ID;
++
++	/*
++	 * Despite its name, KVM_CAP_MAX_VCPU_ID represents the maximum APIC ID
++	 * plus one, so the max possible APIC ID is one less than that.
++	 */
++	return min(vcpu->kvm->arch.max_vcpu_ids - 1, arch_max);
++}
++
+ static void avic_activate_vmcb(struct vcpu_svm *svm)
+ {
+ 	struct vmcb *vmcb = svm->vmcb01.ptr;
++	struct kvm_vcpu *vcpu = &svm->vcpu;
+ 
+ 	vmcb->control.int_ctl &= ~(AVIC_ENABLE_MASK | X2APIC_MODE_MASK);
+ 	vmcb->control.avic_physical_id &= ~AVIC_PHYSICAL_MAX_INDEX_MASK;
+-
++	vmcb->control.avic_physical_id |= avic_get_max_physical_id(vcpu);
+ 	vmcb->control.int_ctl |= AVIC_ENABLE_MASK;
+ 
++	svm_clr_intercept(svm, INTERCEPT_CR8_WRITE);
++
+ 	/*
+ 	 * Note: KVM supports hybrid-AVIC mode, where KVM emulates x2APIC MSR
+ 	 * accesses, while interrupt injection to a running vCPU can be
+@@ -100,7 +119,7 @@ static void avic_activate_vmcb(struct vcpu_svm *svm)
+ 	 */
+ 	if (x2avic_enabled && apic_x2apic_mode(svm->vcpu.arch.apic)) {
+ 		vmcb->control.int_ctl |= X2APIC_MODE_MASK;
+-		vmcb->control.avic_physical_id |= X2AVIC_MAX_PHYSICAL_ID;
++
+ 		/* Disabling MSR intercept for x2APIC registers */
+ 		svm_set_x2apic_msr_interception(svm, false);
+ 	} else {
+@@ -110,8 +129,6 @@ static void avic_activate_vmcb(struct vcpu_svm *svm)
+ 		 */
+ 		kvm_make_request(KVM_REQ_TLB_FLUSH_CURRENT, &svm->vcpu);
+ 
+-		/* For xAVIC and hybrid-xAVIC modes */
+-		vmcb->control.avic_physical_id |= AVIC_MAX_PHYSICAL_ID;
+ 		/* Enabling MSR intercept for x2APIC registers */
+ 		svm_set_x2apic_msr_interception(svm, true);
+ 	}
+@@ -124,6 +141,9 @@ static void avic_deactivate_vmcb(struct vcpu_svm *svm)
+ 	vmcb->control.int_ctl &= ~(AVIC_ENABLE_MASK | X2APIC_MODE_MASK);
+ 	vmcb->control.avic_physical_id &= ~AVIC_PHYSICAL_MAX_INDEX_MASK;
+ 
++	if (!sev_es_guest(svm->vcpu.kvm))
++		svm_set_intercept(svm, INTERCEPT_CR8_WRITE);
++
+ 	/*
+ 	 * If running nested and the guest uses its own MSR bitmap, there
+ 	 * is no need to update L0's msr bitmap
+@@ -253,7 +273,7 @@ void avic_init_vmcb(struct vcpu_svm *svm, struct vmcb *vmcb)
+ 	vmcb->control.avic_physical_id = ppa & AVIC_HPA_MASK;
+ 	vmcb->control.avic_vapic_bar = APIC_DEFAULT_PHYS_BASE & VMCB_AVIC_APIC_BAR_MASK;
+ 
+-	if (kvm_apicv_activated(svm->vcpu.kvm))
++	if (kvm_vcpu_apicv_active(&svm->vcpu))
+ 		avic_activate_vmcb(svm);
+ 	else
+ 		avic_deactivate_vmcb(svm);
+diff --git a/arch/x86/kvm/svm/svm.c b/arch/x86/kvm/svm/svm.c
+index 9ddd1ee5f31234..ff65fe73873329 100644
+--- a/arch/x86/kvm/svm/svm.c
++++ b/arch/x86/kvm/svm/svm.c
+@@ -1261,8 +1261,7 @@ static void init_vmcb(struct kvm_vcpu *vcpu)
+ 	svm_set_intercept(svm, INTERCEPT_CR0_WRITE);
+ 	svm_set_intercept(svm, INTERCEPT_CR3_WRITE);
+ 	svm_set_intercept(svm, INTERCEPT_CR4_WRITE);
+-	if (!kvm_vcpu_apicv_active(vcpu))
+-		svm_set_intercept(svm, INTERCEPT_CR8_WRITE);
++	svm_set_intercept(svm, INTERCEPT_CR8_WRITE);
+ 
+ 	set_dr_intercepts(svm);
+ 
+@@ -1375,7 +1374,7 @@ static void init_vmcb(struct kvm_vcpu *vcpu)
+ 	if (boot_cpu_has(X86_FEATURE_V_SPEC_CTRL))
+ 		set_msr_interception(vcpu, svm->msrpm, MSR_IA32_SPEC_CTRL, 1, 1);
+ 
+-	if (kvm_vcpu_apicv_active(vcpu))
++	if (enable_apicv && irqchip_in_kernel(vcpu->kvm))
+ 		avic_init_vmcb(svm, vmcb);
+ 
+ 	if (vnmi)
+@@ -2806,9 +2805,11 @@ static int dr_interception(struct kvm_vcpu *vcpu)
+ 
+ static int cr8_write_interception(struct kvm_vcpu *vcpu)
+ {
++	u8 cr8_prev = kvm_get_cr8(vcpu);
+ 	int r;
+ 
+-	u8 cr8_prev = kvm_get_cr8(vcpu);
++	WARN_ON_ONCE(kvm_vcpu_apicv_active(vcpu));
++
+ 	/* instruction emulation calls kvm_set_cr8() */
+ 	r = cr_interception(vcpu);
+ 	if (lapic_in_kernel(vcpu))
+@@ -2848,7 +2849,7 @@ static int svm_get_msr_feature(struct kvm_msr_entry *msr)
+ 			msr->data |= MSR_AMD64_DE_CFG_LFENCE_SERIALIZE;
+ 		break;
+ 	default:
+-		return KVM_MSR_RET_INVALID;
++		return KVM_MSR_RET_UNSUPPORTED;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/x86/kvm/vmx/vmx.c b/arch/x86/kvm/vmx/vmx.c
+index 4dd3f64a1a8c71..b68fb5329a13eb 100644
+--- a/arch/x86/kvm/vmx/vmx.c
++++ b/arch/x86/kvm/vmx/vmx.c
+@@ -1981,7 +1981,7 @@ static int vmx_get_msr_feature(struct kvm_msr_entry *msr)
+ 			return 1;
+ 		return vmx_get_vmx_msr(&vmcs_config.nested, msr->index, &msr->data);
+ 	default:
+-		return KVM_MSR_RET_INVALID;
++		return KVM_MSR_RET_UNSUPPORTED;
+ 	}
+ }
+ 
+diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
+index 00bbee40dbec2a..ac0b458582c38f 100644
+--- a/arch/x86/kvm/x86.c
++++ b/arch/x86/kvm/x86.c
+@@ -1719,22 +1719,17 @@ static int do_get_msr_feature(struct kvm_vcpu *vcpu, unsigned index, u64 *data)
+ 	struct kvm_msr_entry msr;
+ 	int r;
+ 
++	/* Unconditionally clear the output for simplicity */
++	msr.data = 0;
+ 	msr.index = index;
+ 	r = kvm_get_msr_feature(&msr);
+ 
+-	if (r == KVM_MSR_RET_INVALID) {
+-		/* Unconditionally clear the output for simplicity */
+-		*data = 0;
+-		if (kvm_msr_ignored_check(index, 0, false))
+-			r = 0;
+-	}
+-
+-	if (r)
+-		return r;
++	if (r == KVM_MSR_RET_UNSUPPORTED && kvm_msr_ignored_check(index, 0, false))
++		r = 0;
+ 
+ 	*data = msr.data;
+ 
+-	return 0;
++	return r;
+ }
+ 
+ static bool __kvm_valid_efer(struct kvm_vcpu *vcpu, u64 efer)
+@@ -1922,7 +1917,7 @@ static int kvm_set_msr_ignored_check(struct kvm_vcpu *vcpu,
+ {
+ 	int ret = __kvm_set_msr(vcpu, index, data, host_initiated);
+ 
+-	if (ret == KVM_MSR_RET_INVALID)
++	if (ret == KVM_MSR_RET_UNSUPPORTED)
+ 		if (kvm_msr_ignored_check(index, data, true))
+ 			ret = 0;
+ 
+@@ -1967,7 +1962,7 @@ static int kvm_get_msr_ignored_check(struct kvm_vcpu *vcpu,
+ {
+ 	int ret = __kvm_get_msr(vcpu, index, data, host_initiated);
+ 
+-	if (ret == KVM_MSR_RET_INVALID) {
++	if (ret == KVM_MSR_RET_UNSUPPORTED) {
+ 		/* Unconditionally clear *data for simplicity */
+ 		*data = 0;
+ 		if (kvm_msr_ignored_check(index, 0, false))
+@@ -2036,7 +2031,7 @@ static int complete_fast_rdmsr(struct kvm_vcpu *vcpu)
+ static u64 kvm_msr_reason(int r)
+ {
+ 	switch (r) {
+-	case KVM_MSR_RET_INVALID:
++	case KVM_MSR_RET_UNSUPPORTED:
+ 		return KVM_MSR_EXIT_REASON_UNKNOWN;
+ 	case KVM_MSR_RET_FILTERED:
+ 		return KVM_MSR_EXIT_REASON_FILTER;
+@@ -3817,47 +3812,47 @@ int kvm_set_msr_common(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
+ 		break;
+ 	case MSR_KVM_WALL_CLOCK_NEW:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_CLOCKSOURCE2))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		vcpu->kvm->arch.wall_clock = data;
+ 		kvm_write_wall_clock(vcpu->kvm, data, 0);
+ 		break;
+ 	case MSR_KVM_WALL_CLOCK:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_CLOCKSOURCE))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		vcpu->kvm->arch.wall_clock = data;
+ 		kvm_write_wall_clock(vcpu->kvm, data, 0);
+ 		break;
+ 	case MSR_KVM_SYSTEM_TIME_NEW:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_CLOCKSOURCE2))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		kvm_write_system_time(vcpu, data, false, msr_info->host_initiated);
+ 		break;
+ 	case MSR_KVM_SYSTEM_TIME:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_CLOCKSOURCE))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		kvm_write_system_time(vcpu, data, true,  msr_info->host_initiated);
+ 		break;
+ 	case MSR_KVM_ASYNC_PF_EN:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_ASYNC_PF))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		if (kvm_pv_enable_async_pf(vcpu, data))
+ 			return 1;
+ 		break;
+ 	case MSR_KVM_ASYNC_PF_INT:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_ASYNC_PF_INT))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		if (kvm_pv_enable_async_pf_int(vcpu, data))
+ 			return 1;
+ 		break;
+ 	case MSR_KVM_ASYNC_PF_ACK:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_ASYNC_PF_INT))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 		if (data & 0x1) {
+ 			vcpu->arch.apf.pageready_pending = false;
+ 			kvm_check_async_pf_completion(vcpu);
+@@ -3865,7 +3860,7 @@ int kvm_set_msr_common(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
+ 		break;
+ 	case MSR_KVM_STEAL_TIME:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_STEAL_TIME))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		if (unlikely(!sched_info_on()))
+ 			return 1;
+@@ -3883,7 +3878,7 @@ int kvm_set_msr_common(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
+ 		break;
+ 	case MSR_KVM_PV_EOI_EN:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_PV_EOI))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		if (kvm_lapic_set_pv_eoi(vcpu, data, sizeof(u8)))
+ 			return 1;
+@@ -3891,7 +3886,7 @@ int kvm_set_msr_common(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
+ 
+ 	case MSR_KVM_POLL_CONTROL:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_POLL_CONTROL))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		/* only enable bit supported */
+ 		if (data & (-1ULL << 1))
+@@ -4002,7 +3997,7 @@ int kvm_set_msr_common(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
+ 		    kvm_is_msr_to_save(msr))
+ 			break;
+ 
+-		return KVM_MSR_RET_INVALID;
++		return KVM_MSR_RET_UNSUPPORTED;
+ 	}
+ 	return 0;
+ }
+@@ -4198,61 +4193,61 @@ int kvm_get_msr_common(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
+ 		break;
+ 	case MSR_KVM_WALL_CLOCK:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_CLOCKSOURCE))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		msr_info->data = vcpu->kvm->arch.wall_clock;
+ 		break;
+ 	case MSR_KVM_WALL_CLOCK_NEW:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_CLOCKSOURCE2))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		msr_info->data = vcpu->kvm->arch.wall_clock;
+ 		break;
+ 	case MSR_KVM_SYSTEM_TIME:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_CLOCKSOURCE))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		msr_info->data = vcpu->arch.time;
+ 		break;
+ 	case MSR_KVM_SYSTEM_TIME_NEW:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_CLOCKSOURCE2))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		msr_info->data = vcpu->arch.time;
+ 		break;
+ 	case MSR_KVM_ASYNC_PF_EN:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_ASYNC_PF))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		msr_info->data = vcpu->arch.apf.msr_en_val;
+ 		break;
+ 	case MSR_KVM_ASYNC_PF_INT:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_ASYNC_PF_INT))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		msr_info->data = vcpu->arch.apf.msr_int_val;
+ 		break;
+ 	case MSR_KVM_ASYNC_PF_ACK:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_ASYNC_PF_INT))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		msr_info->data = 0;
+ 		break;
+ 	case MSR_KVM_STEAL_TIME:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_STEAL_TIME))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		msr_info->data = vcpu->arch.st.msr_val;
+ 		break;
+ 	case MSR_KVM_PV_EOI_EN:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_PV_EOI))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		msr_info->data = vcpu->arch.pv_eoi.msr_val;
+ 		break;
+ 	case MSR_KVM_POLL_CONTROL:
+ 		if (!guest_pv_has(vcpu, KVM_FEATURE_POLL_CONTROL))
+-			return 1;
++			return KVM_MSR_RET_UNSUPPORTED;
+ 
+ 		msr_info->data = vcpu->arch.msr_kvm_poll_control;
+ 		break;
+@@ -4361,7 +4356,7 @@ int kvm_get_msr_common(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
+ 			break;
+ 		}
+ 
+-		return KVM_MSR_RET_INVALID;
++		return KVM_MSR_RET_UNSUPPORTED;
+ 	}
+ 	return 0;
+ }
+@@ -11008,7 +11003,9 @@ static inline int vcpu_block(struct kvm_vcpu *vcpu)
+ 	 * causes a spurious wakeup from HLT).
+ 	 */
+ 	if (is_guest_mode(vcpu)) {
+-		if (kvm_check_nested_events(vcpu) < 0)
++		int r = kvm_check_nested_events(vcpu);
++
++		if (r < 0 && r != -EBUSY)
+ 			return 0;
+ 	}
+ 
+diff --git a/arch/x86/kvm/x86.h b/arch/x86/kvm/x86.h
+index 1e7be1f6ab299d..1222e5b3d55801 100644
+--- a/arch/x86/kvm/x86.h
++++ b/arch/x86/kvm/x86.h
+@@ -501,11 +501,18 @@ bool kvm_msr_allowed(struct kvm_vcpu *vcpu, u32 index, u32 type);
+ 
+ /*
+  * Internal error codes that are used to indicate that MSR emulation encountered
+- * an error that should result in #GP in the guest, unless userspace
+- * handles it.
++ * an error that should result in #GP in the guest, unless userspace handles it.
++ * Note, '1', '0', and negative numbers are off limits, as they are used by KVM
++ * as part of KVM's lightly documented internal KVM_RUN return codes.
++ *
++ * UNSUPPORTED	- The MSR isn't supported, either because it is completely
++ *		  unknown to KVM, or because the MSR should not exist according
++ *		  to the vCPU model.
++ *
++ * FILTERED	- Access to the MSR is denied by a userspace MSR filter.
+  */
+-#define  KVM_MSR_RET_INVALID	2	/* in-kernel MSR emulation #GP condition */
+-#define  KVM_MSR_RET_FILTERED	3	/* #GP due to userspace MSR filter */
++#define  KVM_MSR_RET_UNSUPPORTED	2
++#define  KVM_MSR_RET_FILTERED		3
+ 
+ #define __cr4_reserved_bits(__cpu_has, __c)             \
+ ({                                                      \
+diff --git a/arch/x86/platform/efi/efi.c b/arch/x86/platform/efi/efi.c
+index e9f99c56f3ce62..55a61aaa3303ed 100644
+--- a/arch/x86/platform/efi/efi.c
++++ b/arch/x86/platform/efi/efi.c
+@@ -860,7 +860,7 @@ static void __init __efi_enter_virtual_mode(void)
+ 	}
+ 
+ 	efi_check_for_embedded_firmwares();
+-	efi_free_boot_services();
++	efi_unmap_boot_services();
+ 
+ 	if (!efi_is_mixed())
+ 		efi_native_runtime_setup();
+diff --git a/arch/x86/platform/efi/quirks.c b/arch/x86/platform/efi/quirks.c
+index f0cc00032751d0..df3b45ef1420ce 100644
+--- a/arch/x86/platform/efi/quirks.c
++++ b/arch/x86/platform/efi/quirks.c
+@@ -341,7 +341,7 @@ void __init efi_reserve_boot_services(void)
+ 
+ 		/*
+ 		 * Because the following memblock_reserve() is paired
+-		 * with memblock_free_late() for this region in
++		 * with free_reserved_area() for this region in
+ 		 * efi_free_boot_services(), we must be extremely
+ 		 * careful not to reserve, and subsequently free,
+ 		 * critical regions of memory (like the kernel image) or
+@@ -404,17 +404,33 @@ static void __init efi_unmap_pages(efi_memory_desc_t *md)
+ 		pr_err("Failed to unmap VA mapping for 0x%llx\n", va);
+ }
+ 
+-void __init efi_free_boot_services(void)
++struct efi_freeable_range {
++	u64 start;
++	u64 end;
++};
++
++static struct efi_freeable_range *ranges_to_free;
++
++void __init efi_unmap_boot_services(void)
+ {
+ 	struct efi_memory_map_data data = { 0 };
+ 	efi_memory_desc_t *md;
+ 	int num_entries = 0;
++	int idx = 0;
++	size_t sz;
+ 	void *new, *new_md;
+ 
+ 	/* Keep all regions for /sys/kernel/debug/efi */
+ 	if (efi_enabled(EFI_DBG))
+ 		return;
+ 
++	sz = sizeof(*ranges_to_free) * efi.memmap.nr_map + 1;
++	ranges_to_free = kzalloc(sz, GFP_KERNEL);
++	if (!ranges_to_free) {
++		pr_err("Failed to allocate storage for freeable EFI regions\n");
++		return;
++	}
++
+ 	for_each_efi_memory_desc(md) {
+ 		unsigned long long start = md->phys_addr;
+ 		unsigned long long size = md->num_pages << EFI_PAGE_SHIFT;
+@@ -471,7 +487,15 @@ void __init efi_free_boot_services(void)
+ 			start = SZ_1M;
+ 		}
+ 
+-		memblock_free_late(start, size);
++		/*
++		 * With CONFIG_DEFERRED_STRUCT_PAGE_INIT parts of the memory
++		 * map are still not initialized and we can't reliably free
++		 * memory here.
++		 * Queue the ranges to free at a later point.
++		 */
++		ranges_to_free[idx].start = start;
++		ranges_to_free[idx].end = start + size;
++		idx++;
+ 	}
+ 
+ 	if (!num_entries)
+@@ -512,6 +536,31 @@ void __init efi_free_boot_services(void)
+ 	}
+ }
+ 
++static int __init efi_free_boot_services(void)
++{
++	struct efi_freeable_range *range = ranges_to_free;
++	unsigned long freed = 0;
++
++	if (!ranges_to_free)
++		return 0;
++
++	while (range->start) {
++		void *start = phys_to_virt(range->start);
++		void *end = phys_to_virt(range->end);
++
++		free_reserved_area(start, end, -1, NULL);
++		freed += (end - start);
++		range++;
++	}
++	kfree(ranges_to_free);
++
++	if (freed)
++		pr_info("Freeing EFI boot services memory: %ldK\n", freed / SZ_1K);
++
++	return 0;
++}
++arch_initcall(efi_free_boot_services);
++
+ /*
+  * A number of config table entries get remapped to virtual addresses
+  * after entering EFI virtual mode. However, the kexec kernel requires
+diff --git a/drivers/acpi/acpi_processor.c b/drivers/acpi/acpi_processor.c
+index 5e409f86f07098..55f0ea35350556 100644
+--- a/drivers/acpi/acpi_processor.c
++++ b/drivers/acpi/acpi_processor.c
+@@ -102,6 +102,10 @@ static int acpi_processor_errata_piix4(struct pci_dev *dev)
+ 				     PCI_ANY_ID, PCI_ANY_ID, NULL);
+ 		if (ide_dev) {
+ 			errata.piix4.bmisx = pci_resource_start(ide_dev, 4);
++			if (errata.piix4.bmisx)
++				dev_dbg(&ide_dev->dev,
++					"Bus master activity detection (BM-IDE) erratum enabled\n");
++
+ 			pci_dev_put(ide_dev);
+ 		}
+ 
+@@ -120,20 +124,17 @@ static int acpi_processor_errata_piix4(struct pci_dev *dev)
+ 		if (isa_dev) {
+ 			pci_read_config_byte(isa_dev, 0x76, &value1);
+ 			pci_read_config_byte(isa_dev, 0x77, &value2);
+-			if ((value1 & 0x80) || (value2 & 0x80))
++			if ((value1 & 0x80) || (value2 & 0x80)) {
+ 				errata.piix4.fdma = 1;
++				dev_dbg(&isa_dev->dev,
++					"Type-F DMA livelock erratum (C3 disabled)\n");
++			}
+ 			pci_dev_put(isa_dev);
+ 		}
+ 
+ 		break;
+ 	}
+ 
+-	if (ide_dev)
+-		dev_dbg(&ide_dev->dev, "Bus master activity detection (BM-IDE) erratum enabled\n");
+-
+-	if (isa_dev)
+-		dev_dbg(&isa_dev->dev, "Type-F DMA livelock erratum (C3 disabled)\n");
+-
+ 	return 0;
+ }
+ 
+diff --git a/drivers/acpi/osi.c b/drivers/acpi/osi.c
+index ae9620757865b1..600af8814038a3 100644
+--- a/drivers/acpi/osi.c
++++ b/drivers/acpi/osi.c
+@@ -389,6 +389,19 @@ static const struct dmi_system_id acpi_osi_dmi_table[] __initconst = {
+ 		},
+ 	},
+ 
++	/*
++	 * The screen backlight turns off during udev device creation
++	 * when returning true for _OSI("Windows 2009")
++	 */
++	{
++	.callback = dmi_disable_osi_win7,
++	.ident = "Acer Aspire One D255",
++	.matches = {
++		     DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
++		     DMI_MATCH(DMI_PRODUCT_NAME, "AOD255"),
++		},
++	},
++
+ 	/*
+ 	 * The wireless hotkey does not work on those machines when
+ 	 * returning true for _OSI("Windows 2012")
+diff --git a/drivers/acpi/osl.c b/drivers/acpi/osl.c
+index f725813d0cce6a..28527d246fc366 100644
+--- a/drivers/acpi/osl.c
++++ b/drivers/acpi/osl.c
+@@ -1656,7 +1656,7 @@ acpi_status __init acpi_os_initialize(void)
+ 		 * Use acpi_os_map_generic_address to pre-map the reset
+ 		 * register if it's in system memory.
+ 		 */
+-		void *rv;
++		void __iomem *rv;
+ 
+ 		rv = acpi_os_map_generic_address(&acpi_gbl_FADT.reset_register);
+ 		pr_debug("%s: Reset register mapping %s\n", __func__,
+diff --git a/drivers/acpi/sleep.c b/drivers/acpi/sleep.c
+index 728acfeb774d83..2fd51b18d13c49 100644
+--- a/drivers/acpi/sleep.c
++++ b/drivers/acpi/sleep.c
+@@ -372,6 +372,14 @@ static const struct dmi_system_id acpisleep_dmi_table[] __initconst = {
+ 		DMI_MATCH(DMI_PRODUCT_NAME, "80E1"),
+ 		},
+ 	},
++	{
++	.callback = init_nvs_save_s3,
++	.ident = "Lenovo G70-35",
++	.matches = {
++		DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
++		DMI_MATCH(DMI_PRODUCT_NAME, "80Q5"),
++		},
++	},
+ 	/*
+ 	 * ThinkPad X1 Tablet(2016) cannot do suspend-to-idle using
+ 	 * the Low Power S0 Idle firmware interface (see
+diff --git a/drivers/base/power/runtime.c b/drivers/base/power/runtime.c
+index b28fb11cd6db8f..2766bdc9158ab6 100644
+--- a/drivers/base/power/runtime.c
++++ b/drivers/base/power/runtime.c
+@@ -1854,6 +1854,7 @@ void pm_runtime_reinit(struct device *dev)
+ void pm_runtime_remove(struct device *dev)
+ {
+ 	__pm_runtime_disable(dev, false);
++	flush_work(&dev->power.work);
+ 	pm_runtime_reinit(dev);
+ }
+ 
+diff --git a/drivers/base/property.c b/drivers/base/property.c
+index 8c40abed785247..ea93fc8ba59273 100644
+--- a/drivers/base/property.c
++++ b/drivers/base/property.c
+@@ -750,7 +750,18 @@ struct fwnode_handle *
+ fwnode_get_next_child_node(const struct fwnode_handle *fwnode,
+ 			   struct fwnode_handle *child)
+ {
+-	return fwnode_call_ptr_op(fwnode, get_next_child_node, child);
++	struct fwnode_handle *next;
++
++	if (IS_ERR_OR_NULL(fwnode))
++		return NULL;
++
++	/* Try to find a child in primary fwnode */
++	next = fwnode_call_ptr_op(fwnode, get_next_child_node, child);
++	if (next)
++		return next;
++
++	/* When no more children in primary, continue with secondary */
++	return fwnode_call_ptr_op(fwnode->secondary, get_next_child_node, child);
+ }
+ EXPORT_SYMBOL_GPL(fwnode_get_next_child_node);
+ 
+@@ -794,19 +805,7 @@ EXPORT_SYMBOL_GPL(fwnode_get_next_available_child_node);
+ struct fwnode_handle *device_get_next_child_node(const struct device *dev,
+ 						 struct fwnode_handle *child)
+ {
+-	const struct fwnode_handle *fwnode = dev_fwnode(dev);
+-	struct fwnode_handle *next;
+-
+-	if (IS_ERR_OR_NULL(fwnode))
+-		return NULL;
+-
+-	/* Try to find a child in primary fwnode */
+-	next = fwnode_get_next_child_node(fwnode, child);
+-	if (next)
+-		return next;
+-
+-	/* When no more children in primary, continue with secondary */
+-	return fwnode_get_next_child_node(fwnode->secondary, child);
++	return fwnode_get_next_child_node(dev_fwnode(dev), child);
+ }
+ EXPORT_SYMBOL_GPL(device_get_next_child_node);
+ 
+diff --git a/drivers/block/drbd/drbd_actlog.c b/drivers/block/drbd/drbd_actlog.c
+index 64b3a1c76f03d7..10c06c63eb53a7 100644
+--- a/drivers/block/drbd/drbd_actlog.c
++++ b/drivers/block/drbd/drbd_actlog.c
+@@ -483,38 +483,20 @@ void drbd_al_begin_io(struct drbd_device *device, struct drbd_interval *i)
+ 
+ int drbd_al_begin_io_nonblock(struct drbd_device *device, struct drbd_interval *i)
+ {
+-	struct lru_cache *al = device->act_log;
+ 	/* for bios crossing activity log extent boundaries,
+ 	 * we may need to activate two extents in one go */
+ 	unsigned first = i->sector >> (AL_EXTENT_SHIFT-9);
+ 	unsigned last = i->size == 0 ? first : (i->sector + (i->size >> 9) - 1) >> (AL_EXTENT_SHIFT-9);
+-	unsigned nr_al_extents;
+-	unsigned available_update_slots;
+ 	unsigned enr;
+ 
+-	D_ASSERT(device, first <= last);
+-
+-	nr_al_extents = 1 + last - first; /* worst case: all touched extends are cold. */
+-	available_update_slots = min(al->nr_elements - al->used,
+-				al->max_pending_changes - al->pending_changes);
+-
+-	/* We want all necessary updates for a given request within the same transaction
+-	 * We could first check how many updates are *actually* needed,
+-	 * and use that instead of the worst-case nr_al_extents */
+-	if (available_update_slots < nr_al_extents) {
+-		/* Too many activity log extents are currently "hot".
+-		 *
+-		 * If we have accumulated pending changes already,
+-		 * we made progress.
+-		 *
+-		 * If we cannot get even a single pending change through,
+-		 * stop the fast path until we made some progress,
+-		 * or requests to "cold" extents could be starved. */
+-		if (!al->pending_changes)
+-			__set_bit(__LC_STARVING, &device->act_log->flags);
+-		return -ENOBUFS;
++	if (i->partially_in_al_next_enr) {
++		D_ASSERT(device, first < i->partially_in_al_next_enr);
++		D_ASSERT(device, last >= i->partially_in_al_next_enr);
++		first = i->partially_in_al_next_enr;
+ 	}
+ 
++	D_ASSERT(device, first <= last);
++
+ 	/* Is resync active in this area? */
+ 	for (enr = first; enr <= last; enr++) {
+ 		struct lc_element *tmp;
+@@ -529,14 +511,21 @@ int drbd_al_begin_io_nonblock(struct drbd_device *device, struct drbd_interval *
+ 		}
+ 	}
+ 
+-	/* Checkout the refcounts.
+-	 * Given that we checked for available elements and update slots above,
+-	 * this has to be successful. */
++	/* Try to checkout the refcounts. */
+ 	for (enr = first; enr <= last; enr++) {
+ 		struct lc_element *al_ext;
+ 		al_ext = lc_get_cumulative(device->act_log, enr);
+-		if (!al_ext)
+-			drbd_info(device, "LOGIC BUG for enr=%u\n", enr);
++
++		if (!al_ext) {
++			/* Did not work. We may have exhausted the possible
++			 * changes per transaction. Or raced with someone
++			 * "locking" it against changes.
++			 * Remember where to continue from.
++			 */
++			if (enr > first)
++				i->partially_in_al_next_enr = enr;
++			return -ENOBUFS;
++		}
+ 	}
+ 	return 0;
+ }
+@@ -556,7 +545,11 @@ void drbd_al_complete_io(struct drbd_device *device, struct drbd_interval *i)
+ 
+ 	for (enr = first; enr <= last; enr++) {
+ 		extent = lc_find(device->act_log, enr);
+-		if (!extent) {
++		/* Yes, this masks a bug elsewhere.  However, during normal
++		 * operation this is harmless, so no need to crash the kernel
++		 * by the BUG_ON(refcount == 0) in lc_put().
++		 */
++		if (!extent || extent->refcnt == 0) {
+ 			drbd_err(device, "al_complete_io() called on inactive extent %u\n", enr);
+ 			continue;
+ 		}
+diff --git a/drivers/block/drbd/drbd_interval.h b/drivers/block/drbd/drbd_interval.h
+index 366489b72fe971..5d3213b81eede7 100644
+--- a/drivers/block/drbd/drbd_interval.h
++++ b/drivers/block/drbd/drbd_interval.h
+@@ -8,12 +8,15 @@
+ struct drbd_interval {
+ 	struct rb_node rb;
+ 	sector_t sector;		/* start sector of the interval */
+-	unsigned int size;		/* size in bytes */
+ 	sector_t end;			/* highest interval end in subtree */
++	unsigned int size;		/* size in bytes */
+ 	unsigned int local:1		/* local or remote request? */;
+ 	unsigned int waiting:1;		/* someone is waiting for completion */
+ 	unsigned int completed:1;	/* this has been completed already;
+ 					 * ignore for conflict detection */
++
++	/* to resume a partially successful drbd_al_begin_io_nonblock(); */
++	unsigned int partially_in_al_next_enr;
+ };
+ 
+ static inline void drbd_clear_interval(struct drbd_interval *i)
+diff --git a/drivers/block/drbd/drbd_req.c b/drivers/block/drbd/drbd_req.c
+index 380e6584a4ee76..fce2060579eb2d 100644
+--- a/drivers/block/drbd/drbd_req.c
++++ b/drivers/block/drbd/drbd_req.c
+@@ -621,7 +621,8 @@ int __req_mod(struct drbd_request *req, enum drbd_req_event what,
+ 		break;
+ 
+ 	case READ_COMPLETED_WITH_ERROR:
+-		drbd_set_out_of_sync(peer_device, req->i.sector, req->i.size);
++		drbd_set_out_of_sync(first_peer_device(device),
++				req->i.sector, req->i.size);
+ 		drbd_report_io_error(device, req);
+ 		__drbd_chk_io_error(device, DRBD_READ_ERROR);
+ 		fallthrough;
+diff --git a/drivers/bluetooth/btqca.c b/drivers/bluetooth/btqca.c
+index 5651f40db1736e..5b34da23adce7c 100644
+--- a/drivers/bluetooth/btqca.c
++++ b/drivers/bluetooth/btqca.c
+@@ -826,6 +826,8 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
+ 	 */
+ 	if (soc_type == QCA_WCN3988)
+ 		rom_ver = ((soc_ver & 0x00000f00) >> 0x05) | (soc_ver & 0x0000000f);
++	else if (soc_type == QCA_WCN3998)
++		rom_ver = ((soc_ver & 0x0000f000) >> 0x07) | (soc_ver & 0x0000000f);
+ 	else
+ 		rom_ver = ((soc_ver & 0x00000f00) >> 0x04) | (soc_ver & 0x0000000f);
+ 
+diff --git a/drivers/bus/omap-ocp2scp.c b/drivers/bus/omap-ocp2scp.c
+index e02d0656242b8c..87e290a3dc8175 100644
+--- a/drivers/bus/omap-ocp2scp.c
++++ b/drivers/bus/omap-ocp2scp.c
+@@ -17,15 +17,6 @@
+ #define OCP2SCP_TIMING 0x18
+ #define SYNC2_MASK 0xf
+ 
+-static int ocp2scp_remove_devices(struct device *dev, void *c)
+-{
+-	struct platform_device *pdev = to_platform_device(dev);
+-
+-	platform_device_unregister(pdev);
+-
+-	return 0;
+-}
+-
+ static int omap_ocp2scp_probe(struct platform_device *pdev)
+ {
+ 	int ret;
+@@ -79,17 +70,15 @@ err1:
+ 	pm_runtime_disable(&pdev->dev);
+ 
+ err0:
+-	device_for_each_child(&pdev->dev, NULL, ocp2scp_remove_devices);
++	of_platform_depopulate(&pdev->dev);
+ 
+ 	return ret;
+ }
+ 
+-static int omap_ocp2scp_remove(struct platform_device *pdev)
++static void omap_ocp2scp_remove(struct platform_device *pdev)
+ {
+ 	pm_runtime_disable(&pdev->dev);
+-	device_for_each_child(&pdev->dev, NULL, ocp2scp_remove_devices);
+-
+-	return 0;
++	of_platform_depopulate(&pdev->dev);
+ }
+ 
+ #ifdef CONFIG_OF
+@@ -103,7 +92,7 @@ MODULE_DEVICE_TABLE(of, omap_ocp2scp_id_table);
+ 
+ static struct platform_driver omap_ocp2scp_driver = {
+ 	.probe		= omap_ocp2scp_probe,
+-	.remove		= omap_ocp2scp_remove,
++	.remove_new	= omap_ocp2scp_remove,
+ 	.driver		= {
+ 		.name	= "omap-ocp2scp",
+ 		.of_match_table = of_match_ptr(omap_ocp2scp_id_table),
+diff --git a/drivers/cache/ax45mp_cache.c b/drivers/cache/ax45mp_cache.c
+index 1d7dd3d2c101cd..934c5087ec2bda 100644
+--- a/drivers/cache/ax45mp_cache.c
++++ b/drivers/cache/ax45mp_cache.c
+@@ -178,11 +178,11 @@ static const struct of_device_id ax45mp_cache_ids[] = {
+ 
+ static int __init ax45mp_cache_init(void)
+ {
+-	struct device_node *np;
+ 	struct resource res;
+ 	int ret;
+ 
+-	np = of_find_matching_node(NULL, ax45mp_cache_ids);
++	struct device_node *np __free(device_node) =
++		of_find_matching_node(NULL, ax45mp_cache_ids);
+ 	if (!of_device_is_available(np))
+ 		return -ENODEV;
+ 
+diff --git a/drivers/clk/tegra/clk-tegra124-emc.c b/drivers/clk/tegra/clk-tegra124-emc.c
+index 0f6fb776b2298d..5f1af6dfe71546 100644
+--- a/drivers/clk/tegra/clk-tegra124-emc.c
++++ b/drivers/clk/tegra/clk-tegra124-emc.c
+@@ -197,8 +197,8 @@ static struct tegra_emc *emc_ensure_emc_driver(struct tegra_clk_emc *tegra)
+ 	tegra->emc_node = NULL;
+ 
+ 	tegra->emc = platform_get_drvdata(pdev);
++	put_device(&pdev->dev);
+ 	if (!tegra->emc) {
+-		put_device(&pdev->dev);
+ 		pr_err("%s: cannot find EMC driver\n", __func__);
+ 		return NULL;
+ 	}
+diff --git a/drivers/cpuidle/cpuidle.c b/drivers/cpuidle/cpuidle.c
+index aa117f2967fdfc..6704d610573ad6 100644
+--- a/drivers/cpuidle/cpuidle.c
++++ b/drivers/cpuidle/cpuidle.c
+@@ -356,16 +356,6 @@ noinstr int cpuidle_enter_state(struct cpuidle_device *dev,
+ int cpuidle_select(struct cpuidle_driver *drv, struct cpuidle_device *dev,
+ 		   bool *stop_tick)
+ {
+-	/*
+-	 * If there is only a single idle state (or none), there is nothing
+-	 * meaningful for the governor to choose. Skip the governor and
+-	 * always use state 0 with the tick running.
+-	 */
+-	if (drv->state_count <= 1) {
+-		*stop_tick = false;
+-		return 0;
+-	}
+-
+ 	return cpuidle_curr_governor->select(drv, dev, stop_tick);
+ }
+ 
+diff --git a/drivers/crypto/atmel-sha204a.c b/drivers/crypto/atmel-sha204a.c
+index 5bc809146ffea0..67fd084a2b9718 100644
+--- a/drivers/crypto/atmel-sha204a.c
++++ b/drivers/crypto/atmel-sha204a.c
+@@ -52,9 +52,10 @@ static int atmel_sha204a_rng_read_nonblocking(struct hwrng *rng, void *data,
+ 		rng->priv = 0;
+ 	} else {
+ 		work_data = kmalloc(sizeof(*work_data), GFP_ATOMIC);
+-		if (!work_data)
++		if (!work_data) {
++			atomic_dec(&i2c_priv->tfm_count);
+ 			return -ENOMEM;
+-
++		}
+ 		work_data->ctx = i2c_priv;
+ 		work_data->client = i2c_priv->client;
+ 
+diff --git a/drivers/dma/mmp_pdma.c b/drivers/dma/mmp_pdma.c
+index ebdfdcbb4f7ae8..046358e328eba4 100644
+--- a/drivers/dma/mmp_pdma.c
++++ b/drivers/dma/mmp_pdma.c
+@@ -764,6 +764,7 @@ static unsigned int mmp_pdma_residue(struct mmp_pdma_chan *chan,
+ {
+ 	struct mmp_pdma_desc_sw *sw;
+ 	u32 curr, residue = 0;
++	unsigned long flags;
+ 	bool passed = false;
+ 	bool cyclic = chan->cyclic_first != NULL;
+ 
+@@ -779,6 +780,8 @@ static unsigned int mmp_pdma_residue(struct mmp_pdma_chan *chan,
+ 	else
+ 		curr = readl(chan->phy->base + DSADR(chan->phy->idx));
+ 
++	spin_lock_irqsave(&chan->desc_lock, flags);
++
+ 	list_for_each_entry(sw, &chan->chain_running, node) {
+ 		u32 start, end, len;
+ 
+@@ -822,6 +825,7 @@ static unsigned int mmp_pdma_residue(struct mmp_pdma_chan *chan,
+ 			continue;
+ 
+ 		if (sw->async_tx.cookie == cookie) {
++			spin_unlock_irqrestore(&chan->desc_lock, flags);
+ 			return residue;
+ 		} else {
+ 			residue = 0;
+@@ -829,6 +833,8 @@ static unsigned int mmp_pdma_residue(struct mmp_pdma_chan *chan,
+ 		}
+ 	}
+ 
++	spin_unlock_irqrestore(&chan->desc_lock, flags);
++
+ 	/* We should only get here in case of cyclic transactions */
+ 	return residue;
+ }
+diff --git a/drivers/firmware/arm_scpi.c b/drivers/firmware/arm_scpi.c
+index 3de25e9d18ef84..2d85e783ae2675 100644
+--- a/drivers/firmware/arm_scpi.c
++++ b/drivers/firmware/arm_scpi.c
+@@ -18,6 +18,7 @@
+ 
+ #include <linux/bitmap.h>
+ #include <linux/bitfield.h>
++#include <linux/cleanup.h>
+ #include <linux/device.h>
+ #include <linux/err.h>
+ #include <linux/export.h>
+@@ -945,13 +946,13 @@ static int scpi_probe(struct platform_device *pdev)
+ 		int idx = scpi_drvinfo->num_chans;
+ 		struct scpi_chan *pchan = scpi_drvinfo->channels + idx;
+ 		struct mbox_client *cl = &pchan->cl;
+-		struct device_node *shmem = of_parse_phandle(np, "shmem", idx);
++		struct device_node *shmem __free(device_node) =
++			of_parse_phandle(np, "shmem", idx);
+ 
+ 		if (!of_match_node(shmem_of_match, shmem))
+ 			return -ENXIO;
+ 
+ 		ret = of_address_to_resource(shmem, 0, &res);
+-		of_node_put(shmem);
+ 		if (ret) {
+ 			dev_err(dev, "failed to get SCPI payload mem resource\n");
+ 			return ret;
+diff --git a/drivers/firmware/efi/mokvar-table.c b/drivers/firmware/efi/mokvar-table.c
+index 4eb0dff4dfaf8b..bd84a22805b56e 100644
+--- a/drivers/firmware/efi/mokvar-table.c
++++ b/drivers/firmware/efi/mokvar-table.c
+@@ -85,7 +85,7 @@ static struct kobject *mokvar_kobj;
+  * as an alternative to ordinary EFI variables, due to platform-dependent
+  * limitations. The memory occupied by this table is marked as reserved.
+  *
+- * This routine must be called before efi_free_boot_services() in order
++ * This routine must be called before efi_unmap_boot_services() in order
+  * to guarantee that it can mark the table as reserved.
+  *
+  * Implicit inputs:
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gpuvm.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gpuvm.c
+index c94e1cc7e3a73a..b2d86ffc626cb7 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gpuvm.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gpuvm.c
+@@ -1351,7 +1351,10 @@ static int init_kfd_vm(struct amdgpu_vm *vm, void **process_info,
+ 		*ef = dma_fence_get(&info->eviction_fence->base);
+ 	}
+ 
+-	vm->process_info = *process_info;
++	if (cmpxchg(&vm->process_info, NULL, *process_info) != NULL) {
++		ret = -EINVAL;
++		goto already_acquired;
++	}
+ 
+ 	/* Validate page directory and attach eviction fence */
+ 	ret = amdgpu_bo_reserve(vm->root.bo, true);
+@@ -1389,6 +1392,7 @@ validate_pd_fail:
+ 	amdgpu_bo_unreserve(vm->root.bo);
+ reserve_pd_fail:
+ 	vm->process_info = NULL;
++already_acquired:
+ 	if (info) {
+ 		/* Two fence references: one in info and one in *ef */
+ 		dma_fence_put(&info->eviction_fence->base);
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+index 9481d450809b56..ad2723206a1856 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+@@ -2096,8 +2096,10 @@ static int amdgpu_device_ip_early_init(struct amdgpu_device *adev)
+ 		break;
+ 	default:
+ 		r = amdgpu_discovery_set_ip_blocks(adev);
+-		if (r)
++		if (r) {
++			adev->num_ip_blocks = 0;
+ 			return r;
++		}
+ 		break;
+ 	}
+ 
+@@ -4034,7 +4036,7 @@ void amdgpu_device_fini_hw(struct amdgpu_device *adev)
+ 	 * before ip_fini_early to prevent kfd locking refcount issues by calling
+ 	 * amdgpu_amdkfd_suspend()
+ 	 */
+-	if (drm_dev_is_unplugged(adev_to_drm(adev)))
++	if (pci_dev_is_disconnected(adev->pdev))
+ 		amdgpu_amdkfd_device_fini_sw(adev);
+ 
+ 	amdgpu_device_ip_fini_early(adev);
+@@ -4046,7 +4048,7 @@ void amdgpu_device_fini_hw(struct amdgpu_device *adev)
+ 
+ 	amdgpu_gart_dummy_page_fini(adev);
+ 
+-	if (drm_dev_is_unplugged(adev_to_drm(adev)))
++	if (pci_dev_is_disconnected(adev->pdev))
+ 		amdgpu_device_unmap_mmio(adev);
+ 
+ }
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_gmc.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_gmc.c
+index 3c24637f3d6e97..8cb192636368f4 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_gmc.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_gmc.c
+@@ -728,11 +728,15 @@ void amdgpu_gmc_get_vbios_allocations(struct amdgpu_device *adev)
+ 	case CHIP_RENOIR:
+ 		adev->mman.keep_stolen_vga_memory = true;
+ 		break;
+-	case CHIP_YELLOW_CARP:
+-		if (amdgpu_discovery == 0) {
+-			adev->mman.stolen_reserved_offset = 0x1ffb0000;
+-			adev->mman.stolen_reserved_size = 64 * PAGE_SIZE;
+-		}
++	case CHIP_POLARIS10:
++	case CHIP_POLARIS11:
++	case CHIP_POLARIS12:
++		/* MacBookPros with switchable graphics put VRAM at 0 when
++		 * the iGPU is enabled which results in cursor issues if
++		 * the cursor ends up at 0.  Reserve vram at 0 in that case.
++		 */
++		if (adev->gmc.vram_start == 0)
++			adev->mman.keep_stolen_vga_memory = true;
+ 		break;
+ 	default:
+ 		adev->mman.keep_stolen_vga_memory = false;
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_kms.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_kms.c
+index 1f0de6e717112e..10730f256ae0fd 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_kms.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_kms.c
+@@ -82,7 +82,7 @@ void amdgpu_driver_unload_kms(struct drm_device *dev)
+ {
+ 	struct amdgpu_device *adev = drm_to_adev(dev);
+ 
+-	if (adev == NULL)
++	if (adev == NULL || !adev->num_ip_blocks)
+ 		return;
+ 
+ 	amdgpu_unregister_gpu_instance(adev);
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_ras_eeprom.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_ras_eeprom.c
+index 9d82701d365bbe..4cfe26fb9b22ee 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_ras_eeprom.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_ras_eeprom.c
+@@ -1338,15 +1338,31 @@ int amdgpu_ras_eeprom_init(struct amdgpu_ras_eeprom_control *control,
+ 
+ 	__decode_table_header_from_buf(hdr, buf);
+ 
+-	if (hdr->version == RAS_TABLE_VER_V2_1) {
++	switch (hdr->version) {
++	case RAS_TABLE_VER_V2_1:
+ 		control->ras_num_recs = RAS_NUM_RECS_V2_1(hdr);
+ 		control->ras_record_offset = RAS_RECORD_START_V2_1;
+ 		control->ras_max_record_count = RAS_MAX_RECORD_COUNT_V2_1;
+-	} else {
++		break;
++	case RAS_TABLE_VER_V1:
+ 		control->ras_num_recs = RAS_NUM_RECS(hdr);
+ 		control->ras_record_offset = RAS_RECORD_START;
+ 		control->ras_max_record_count = RAS_MAX_RECORD_COUNT;
++		break;
++	default:
++		dev_err(adev->dev,
++			"RAS header invalid, unsupported version: %u",
++			hdr->version);
++		return -EINVAL;
+ 	}
++
++	if (control->ras_num_recs > control->ras_max_record_count) {
++		dev_err(adev->dev,
++			"RAS header invalid, records in header: %u max allowed :%u",
++			control->ras_num_recs, control->ras_max_record_count);
++		return -EINVAL;
++	}
++
+ 	control->ras_fri = RAS_OFFSET_TO_INDEX(control, hdr->first_rec_offset);
+ 
+ 	if (hdr->header == RAS_TABLE_HDR_VAL) {
+diff --git a/drivers/gpu/drm/amd/amdgpu/gmc_v9_0.c b/drivers/gpu/drm/amd/amdgpu/gmc_v9_0.c
+index 6d2b9d260d92c5..fdd36e3b2f144e 100644
+--- a/drivers/gpu/drm/amd/amdgpu/gmc_v9_0.c
++++ b/drivers/gpu/drm/amd/amdgpu/gmc_v9_0.c
+@@ -672,28 +672,35 @@ static int gmc_v9_0_process_interrupt(struct amdgpu_device *adev,
+ 	} else {
+ 		switch (adev->ip_versions[MMHUB_HWIP][0]) {
+ 		case IP_VERSION(9, 0, 0):
+-			mmhub_cid = mmhub_client_ids_vega10[cid][rw];
++			mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_vega10) ?
++				mmhub_client_ids_vega10[cid][rw] : NULL;
+ 			break;
+ 		case IP_VERSION(9, 3, 0):
+-			mmhub_cid = mmhub_client_ids_vega12[cid][rw];
++			mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_vega12) ?
++				mmhub_client_ids_vega12[cid][rw] : NULL;
+ 			break;
+ 		case IP_VERSION(9, 4, 0):
+-			mmhub_cid = mmhub_client_ids_vega20[cid][rw];
++			mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_vega20) ?
++				mmhub_client_ids_vega20[cid][rw] : NULL;
+ 			break;
+ 		case IP_VERSION(9, 4, 1):
+-			mmhub_cid = mmhub_client_ids_arcturus[cid][rw];
++			mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_arcturus) ?
++				mmhub_client_ids_arcturus[cid][rw] : NULL;
+ 			break;
+ 		case IP_VERSION(9, 1, 0):
+ 		case IP_VERSION(9, 2, 0):
+-			mmhub_cid = mmhub_client_ids_raven[cid][rw];
++			mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_raven) ?
++				mmhub_client_ids_raven[cid][rw] : NULL;
+ 			break;
+ 		case IP_VERSION(1, 5, 0):
+ 		case IP_VERSION(2, 4, 0):
+-			mmhub_cid = mmhub_client_ids_renoir[cid][rw];
++			mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_renoir) ?
++				mmhub_client_ids_renoir[cid][rw] : NULL;
+ 			break;
+ 		case IP_VERSION(1, 8, 0):
+ 		case IP_VERSION(9, 4, 2):
+-			mmhub_cid = mmhub_client_ids_aldebaran[cid][rw];
++			mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_aldebaran) ?
++				mmhub_client_ids_aldebaran[cid][rw] : NULL;
+ 			break;
+ 		default:
+ 			mmhub_cid = NULL;
+diff --git a/drivers/gpu/drm/amd/amdgpu/mmhub_v2_0.c b/drivers/gpu/drm/amd/amdgpu/mmhub_v2_0.c
+index 8f76c6ecf50a86..fc241d184e4b10 100644
+--- a/drivers/gpu/drm/amd/amdgpu/mmhub_v2_0.c
++++ b/drivers/gpu/drm/amd/amdgpu/mmhub_v2_0.c
+@@ -154,14 +154,17 @@ mmhub_v2_0_print_l2_protection_fault_status(struct amdgpu_device *adev,
+ 	switch (adev->ip_versions[MMHUB_HWIP][0]) {
+ 	case IP_VERSION(2, 0, 0):
+ 	case IP_VERSION(2, 0, 2):
+-		mmhub_cid = mmhub_client_ids_navi1x[cid][rw];
++		mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_navi1x) ?
++			mmhub_client_ids_navi1x[cid][rw] : NULL;
+ 		break;
+ 	case IP_VERSION(2, 1, 0):
+ 	case IP_VERSION(2, 1, 1):
+-		mmhub_cid = mmhub_client_ids_sienna_cichlid[cid][rw];
++		mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_sienna_cichlid) ?
++			mmhub_client_ids_sienna_cichlid[cid][rw] : NULL;
+ 		break;
+ 	case IP_VERSION(2, 1, 2):
+-		mmhub_cid = mmhub_client_ids_beige_goby[cid][rw];
++		mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_beige_goby) ?
++			mmhub_client_ids_beige_goby[cid][rw] : NULL;
+ 		break;
+ 	default:
+ 		mmhub_cid = NULL;
+diff --git a/drivers/gpu/drm/amd/amdgpu/mmhub_v2_3.c b/drivers/gpu/drm/amd/amdgpu/mmhub_v2_3.c
+index 1dce053a4c4d72..83e8fabb970fa3 100644
+--- a/drivers/gpu/drm/amd/amdgpu/mmhub_v2_3.c
++++ b/drivers/gpu/drm/amd/amdgpu/mmhub_v2_3.c
+@@ -94,7 +94,8 @@ mmhub_v2_3_print_l2_protection_fault_status(struct amdgpu_device *adev,
+ 	case IP_VERSION(2, 3, 0):
+ 	case IP_VERSION(2, 4, 0):
+ 	case IP_VERSION(2, 4, 1):
+-		mmhub_cid = mmhub_client_ids_vangogh[cid][rw];
++		mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_vangogh) ?
++			mmhub_client_ids_vangogh[cid][rw] : NULL;
+ 		break;
+ 	default:
+ 		mmhub_cid = NULL;
+diff --git a/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0.c b/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0.c
+index 441379e91cfa8e..16d9712674a11c 100644
+--- a/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0.c
++++ b/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0.c
+@@ -110,7 +110,8 @@ mmhub_v3_0_print_l2_protection_fault_status(struct amdgpu_device *adev,
+ 	switch (adev->ip_versions[MMHUB_HWIP][0]) {
+ 	case IP_VERSION(3, 0, 0):
+ 	case IP_VERSION(3, 0, 1):
+-		mmhub_cid = mmhub_client_ids_v3_0_0[cid][rw];
++		mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_v3_0_0) ?
++			mmhub_client_ids_v3_0_0[cid][rw] : NULL;
+ 		break;
+ 	default:
+ 		mmhub_cid = NULL;
+diff --git a/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0_1.c b/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0_1.c
+index b0c003da52fc1b..e0287b8e798e1b 100644
+--- a/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0_1.c
++++ b/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0_1.c
+@@ -117,7 +117,8 @@ mmhub_v3_0_1_print_l2_protection_fault_status(struct amdgpu_device *adev,
+ 
+ 	switch (adev->ip_versions[MMHUB_HWIP][0]) {
+ 	case IP_VERSION(3, 0, 1):
+-		mmhub_cid = mmhub_client_ids_v3_0_1[cid][rw];
++		mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_v3_0_1) ?
++			mmhub_client_ids_v3_0_1[cid][rw] : NULL;
+ 		break;
+ 	default:
+ 		mmhub_cid = NULL;
+diff --git a/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0_2.c b/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0_2.c
+index 5dadc85abf7ef3..087a7221496e4b 100644
+--- a/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0_2.c
++++ b/drivers/gpu/drm/amd/amdgpu/mmhub_v3_0_2.c
+@@ -108,7 +108,8 @@ mmhub_v3_0_2_print_l2_protection_fault_status(struct amdgpu_device *adev,
+ 		"MMVM_L2_PROTECTION_FAULT_STATUS:0x%08X\n",
+ 		status);
+ 
+-	mmhub_cid = mmhub_client_ids_v3_0_2[cid][rw];
++	mmhub_cid = cid < ARRAY_SIZE(mmhub_client_ids_v3_0_2) ?
++		mmhub_client_ids_v3_0_2[cid][rw] : NULL;
+ 	dev_err(adev->dev, "\t Faulty UTCL2 client ID: %s (0x%x)\n",
+ 		mmhub_cid ? mmhub_cid : "unknown", cid);
+ 	dev_err(adev->dev, "\t MORE_FAULTS: 0x%lx\n",
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+index 26047109726eb4..f51c3921cbc266 100644
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+@@ -10695,7 +10695,7 @@ static void parse_edid_displayid_vrr(struct drm_connector *connector,
+ 	u16 min_vfreq;
+ 	u16 max_vfreq;
+ 
+-	if (edid == NULL || edid->extensions == 0)
++	if (!edid || !edid->extensions)
+ 		return;
+ 
+ 	/* Find DisplayID extension */
+@@ -10705,7 +10705,7 @@ static void parse_edid_displayid_vrr(struct drm_connector *connector,
+ 			break;
+ 	}
+ 
+-	if (edid_ext == NULL)
++	if (i == edid->extensions)
+ 		return;
+ 
+ 	while (j < EDID_LENGTH) {
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_pp_smu.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_pp_smu.c
+index 848c5b4bb301a5..016230896d0e18 100644
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_pp_smu.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_pp_smu.c
+@@ -97,6 +97,7 @@ bool dm_pp_apply_display_requirements(
+ 			const struct dm_pp_single_disp_config *dc_cfg =
+ 						&pp_display_cfg->disp_configs[i];
+ 			adev->pm.pm_display_cfg.displays[i].controller_id = dc_cfg->pipe_idx + 1;
++			adev->pm.pm_display_cfg.displays[i].pixel_clock = dc_cfg->pixel_clock;
+ 		}
+ 
+ 		amdgpu_dpm_display_configuration_change(adev, &adev->pm.pm_display_cfg);
+diff --git a/drivers/gpu/drm/amd/display/dc/clk_mgr/dce110/dce110_clk_mgr.c b/drivers/gpu/drm/amd/display/dc/clk_mgr/dce110/dce110_clk_mgr.c
+index fb2f154f4fda16..bce53ab36f3e5f 100644
+--- a/drivers/gpu/drm/amd/display/dc/clk_mgr/dce110/dce110_clk_mgr.c
++++ b/drivers/gpu/drm/amd/display/dc/clk_mgr/dce110/dce110_clk_mgr.c
+@@ -164,7 +164,7 @@ void dce110_fill_display_configs(
+ 			stream->link->cur_link_settings.link_rate;
+ 		cfg->link_settings.link_spread =
+ 			stream->link->cur_link_settings.link_spread;
+-		cfg->sym_clock = stream->phy_pix_clk;
++		cfg->pixel_clock = stream->phy_pix_clk;
+ 		/* Round v_refresh*/
+ 		cfg->v_refresh = stream->timing.pix_clk_100hz * 100;
+ 		cfg->v_refresh /= stream->timing.h_total;
+diff --git a/drivers/gpu/drm/amd/display/dc/core/dc_stream.c b/drivers/gpu/drm/amd/display/dc/core/dc_stream.c
+index 0e210407131e78..41da88d355886d 100644
+--- a/drivers/gpu/drm/amd/display/dc/core/dc_stream.c
++++ b/drivers/gpu/drm/amd/display/dc/core/dc_stream.c
+@@ -164,7 +164,7 @@ struct dc_stream_state *dc_create_stream_for_sink(
+ 	if (sink == NULL)
+ 		return NULL;
+ 
+-	stream = kzalloc(sizeof(struct dc_stream_state), GFP_KERNEL);
++	stream = kzalloc(sizeof(struct dc_stream_state), GFP_ATOMIC);
+ 	if (stream == NULL)
+ 		goto alloc_fail;
+ 
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn32/dcn32_resource.c b/drivers/gpu/drm/amd/display/dc/dcn32/dcn32_resource.c
+index f98f35ac68c01a..ddc0a444a05458 100644
+--- a/drivers/gpu/drm/amd/display/dc/dcn32/dcn32_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn32/dcn32_resource.c
+@@ -1872,7 +1872,9 @@ bool dcn32_validate_bandwidth(struct dc *dc,
+ 
+ 	dc->res_pool->funcs->calculate_wm_and_dlg(dc, context, pipes, pipe_cnt, vlevel);
+ 
++	DC_FP_START();
+ 	dcn32_override_min_req_memclk(dc, context);
++	DC_FP_END();
+ 
+ 	BW_VAL_TRACE_END_WATERMARKS();
+ 
+diff --git a/drivers/gpu/drm/amd/display/dc/dm_services_types.h b/drivers/gpu/drm/amd/display/dc/dm_services_types.h
+index facf269c4326dc..b4eefe3ce7c7e3 100644
+--- a/drivers/gpu/drm/amd/display/dc/dm_services_types.h
++++ b/drivers/gpu/drm/amd/display/dc/dm_services_types.h
+@@ -127,7 +127,7 @@ struct dm_pp_single_disp_config {
+ 	uint32_t src_height;
+ 	uint32_t src_width;
+ 	uint32_t v_refresh;
+-	uint32_t sym_clock; /* HDMI only */
++	uint32_t pixel_clock; /* Pixel clock in KHz (for HDMI only: normalized) */
+ 	struct dc_link_settings link_settings; /* DP only */
+ };
+ 
+diff --git a/drivers/gpu/drm/amd/include/dm_pp_interface.h b/drivers/gpu/drm/amd/include/dm_pp_interface.h
+index 1d93a0c574c9e9..ee4212cc93d19f 100644
+--- a/drivers/gpu/drm/amd/include/dm_pp_interface.h
++++ b/drivers/gpu/drm/amd/include/dm_pp_interface.h
+@@ -66,6 +66,7 @@ struct single_display_configuration
+ 	uint32_t view_resolution_cy;
+ 	enum amd_pp_display_config_type displayconfigtype;
+ 	uint32_t vertical_refresh; /* for active display */
++	uint32_t pixel_clock; /* Pixel clock in KHz (for HDMI only: normalized) */
+ };
+ 
+ #define MAX_NUM_DISPLAY 32
+diff --git a/drivers/gpu/drm/amd/pm/amdgpu_dpm_internal.c b/drivers/gpu/drm/amd/pm/amdgpu_dpm_internal.c
+index 2d2d2d5e676341..9ef965e4a92ed1 100644
+--- a/drivers/gpu/drm/amd/pm/amdgpu_dpm_internal.c
++++ b/drivers/gpu/drm/amd/pm/amdgpu_dpm_internal.c
+@@ -100,3 +100,70 @@ u32 amdgpu_dpm_get_vrefresh(struct amdgpu_device *adev)
+ 
+ 	return vrefresh;
+ }
++
++void amdgpu_dpm_get_display_cfg(struct amdgpu_device *adev)
++{
++	struct drm_device *ddev = adev_to_drm(adev);
++	struct amd_pp_display_configuration *cfg = &adev->pm.pm_display_cfg;
++	struct single_display_configuration *display_cfg;
++	struct drm_crtc *crtc;
++	struct amdgpu_crtc *amdgpu_crtc;
++	struct amdgpu_connector *conn;
++	int num_crtcs = 0;
++	int vrefresh;
++	u32 vblank_in_pixels, vblank_time_us;
++
++	cfg->min_vblank_time = 0xffffffff; /* if the displays are off, vblank time is max */
++
++	if (adev->mode_info.num_crtc && adev->mode_info.mode_config_initialized) {
++		list_for_each_entry(crtc, &ddev->mode_config.crtc_list, head) {
++			amdgpu_crtc = to_amdgpu_crtc(crtc);
++
++			/* The array should only contain active displays. */
++			if (!amdgpu_crtc->enabled)
++				continue;
++
++			conn = to_amdgpu_connector(amdgpu_crtc->connector);
++			display_cfg = &adev->pm.pm_display_cfg.displays[num_crtcs++];
++
++			if (amdgpu_crtc->hw_mode.clock) {
++				vrefresh = drm_mode_vrefresh(&amdgpu_crtc->hw_mode);
++
++				vblank_in_pixels =
++					amdgpu_crtc->hw_mode.crtc_htotal *
++					(amdgpu_crtc->hw_mode.crtc_vblank_end -
++					amdgpu_crtc->hw_mode.crtc_vdisplay +
++					(amdgpu_crtc->v_border * 2));
++
++				vblank_time_us =
++					vblank_in_pixels * 1000 / amdgpu_crtc->hw_mode.clock;
++
++				/* The legacy (non-DC) code has issues with mclk switching
++				 * with refresh rates over 120 Hz. Disable mclk switching.
++				 */
++				if (vrefresh > 120)
++					vblank_time_us = 0;
++
++				/* Find minimum vblank time. */
++				if (vblank_time_us < cfg->min_vblank_time)
++					cfg->min_vblank_time = vblank_time_us;
++
++				/* Find vertical refresh rate of first active display. */
++				if (!cfg->vrefresh)
++					cfg->vrefresh = vrefresh;
++			}
++
++			if (amdgpu_crtc->crtc_id < cfg->crtc_index) {
++				/* Find first active CRTC and its line time. */
++				cfg->crtc_index = amdgpu_crtc->crtc_id;
++				cfg->line_time_in_us = amdgpu_crtc->line_time;
++			}
++
++			display_cfg->controller_id = amdgpu_crtc->crtc_id;
++			display_cfg->pixel_clock = conn->pixelclock_for_modeset;
++		}
++	}
++
++	cfg->display_clk = adev->clock.default_dispclk;
++	cfg->num_display = num_crtcs;
++}
+diff --git a/drivers/gpu/drm/amd/pm/inc/amdgpu_dpm_internal.h b/drivers/gpu/drm/amd/pm/inc/amdgpu_dpm_internal.h
+index 5c2a89f0d5d5d3..8be11510cd9236 100644
+--- a/drivers/gpu/drm/amd/pm/inc/amdgpu_dpm_internal.h
++++ b/drivers/gpu/drm/amd/pm/inc/amdgpu_dpm_internal.h
+@@ -29,4 +29,6 @@ u32 amdgpu_dpm_get_vblank_time(struct amdgpu_device *adev);
+ 
+ u32 amdgpu_dpm_get_vrefresh(struct amdgpu_device *adev);
+ 
++void amdgpu_dpm_get_display_cfg(struct amdgpu_device *adev);
++
+ #endif
+diff --git a/drivers/gpu/drm/amd/pm/legacy-dpm/kv_dpm.c b/drivers/gpu/drm/amd/pm/legacy-dpm/kv_dpm.c
+index 4d193313a6d6e3..63d2fb79ba7f8c 100644
+--- a/drivers/gpu/drm/amd/pm/legacy-dpm/kv_dpm.c
++++ b/drivers/gpu/drm/amd/pm/legacy-dpm/kv_dpm.c
+@@ -2299,7 +2299,7 @@ static void kv_apply_state_adjust_rules(struct amdgpu_device *adev,
+ 
+ 		if (pi->sys_info.nb_dpm_enable) {
+ 			force_high = (mclk >= pi->sys_info.nbp_memory_clock[3]) ||
+-				pi->video_start || (adev->pm.dpm.new_active_crtc_count >= 3) ||
++				pi->video_start || (adev->pm.pm_display_cfg.num_display >= 3) ||
+ 				pi->disable_nb_ps3_in_battery;
+ 			ps->dpm0_pg_nb_ps_lo = force_high ? 0x2 : 0x3;
+ 			ps->dpm0_pg_nb_ps_hi = 0x2;
+@@ -2358,7 +2358,7 @@ static int kv_calculate_nbps_level_settings(struct amdgpu_device *adev)
+ 			return 0;
+ 
+ 		force_high = ((mclk >= pi->sys_info.nbp_memory_clock[3]) ||
+-			      (adev->pm.dpm.new_active_crtc_count >= 3) || pi->video_start);
++			      (adev->pm.pm_display_cfg.num_display >= 3) || pi->video_start);
+ 
+ 		if (force_high) {
+ 			for (i = pi->lowest_valid; i <= pi->highest_valid; i++)
+diff --git a/drivers/gpu/drm/amd/pm/legacy-dpm/legacy_dpm.c b/drivers/gpu/drm/amd/pm/legacy-dpm/legacy_dpm.c
+index 48ad413d72afe7..a4f7ef7ac849ef 100644
+--- a/drivers/gpu/drm/amd/pm/legacy-dpm/legacy_dpm.c
++++ b/drivers/gpu/drm/amd/pm/legacy-dpm/legacy_dpm.c
+@@ -797,8 +797,7 @@ static struct amdgpu_ps *amdgpu_dpm_pick_power_state(struct amdgpu_device *adev,
+ 	int i;
+ 	struct amdgpu_ps *ps;
+ 	u32 ui_class;
+-	bool single_display = (adev->pm.dpm.new_active_crtc_count < 2) ?
+-		true : false;
++	bool single_display = adev->pm.pm_display_cfg.num_display < 2;
+ 
+ 	/* check if the vblank period is too short to adjust the mclk */
+ 	if (single_display && adev->powerplay.pp_funcs->vblank_too_short) {
+@@ -1003,7 +1002,8 @@ void amdgpu_legacy_dpm_compute_clocks(void *handle)
+ {
+ 	struct amdgpu_device *adev = (struct amdgpu_device *)handle;
+ 
+-	amdgpu_dpm_get_active_displays(adev);
++	if (!adev->dc_enabled)
++		amdgpu_dpm_get_display_cfg(adev);
+ 
+ 	amdgpu_dpm_change_power_state_locked(adev);
+ }
+diff --git a/drivers/gpu/drm/amd/pm/legacy-dpm/si_dpm.c b/drivers/gpu/drm/amd/pm/legacy-dpm/si_dpm.c
+index e759004046938c..2ade81fc80a0da 100644
+--- a/drivers/gpu/drm/amd/pm/legacy-dpm/si_dpm.c
++++ b/drivers/gpu/drm/amd/pm/legacy-dpm/si_dpm.c
+@@ -3058,7 +3058,7 @@ static int si_get_vce_clock_voltage(struct amdgpu_device *adev,
+ static bool si_dpm_vblank_too_short(void *handle)
+ {
+ 	struct amdgpu_device *adev = (struct amdgpu_device *)handle;
+-	u32 vblank_time = amdgpu_dpm_get_vblank_time(adev);
++	u32 vblank_time = adev->pm.pm_display_cfg.min_vblank_time;
+ 	/* we never hit the non-gddr5 limit so disable it */
+ 	u32 switch_limit = adev->gmc.vram_type == AMDGPU_VRAM_TYPE_GDDR5 ? 450 : 0;
+ 
+@@ -3424,9 +3424,10 @@ static void rv770_get_engine_memory_ss(struct amdgpu_device *adev)
+ static void si_apply_state_adjust_rules(struct amdgpu_device *adev,
+ 					struct amdgpu_ps *rps)
+ {
++	const struct amd_pp_display_configuration *display_cfg =
++		&adev->pm.pm_display_cfg;
+ 	struct  si_ps *ps = si_get_ps(rps);
+ 	struct amdgpu_clock_and_voltage_limits *max_limits;
+-	struct amdgpu_connector *conn;
+ 	bool disable_mclk_switching = false;
+ 	bool disable_sclk_switching = false;
+ 	u32 mclk, sclk;
+@@ -3439,9 +3440,11 @@ static void si_apply_state_adjust_rules(struct amdgpu_device *adev,
+ 	if (adev->asic_type == CHIP_HAINAN) {
+ 		if ((adev->pdev->revision == 0x81) ||
+ 		    (adev->pdev->revision == 0xC3) ||
++		    (adev->pdev->device == 0x6660) ||
+ 		    (adev->pdev->device == 0x6664) ||
+ 		    (adev->pdev->device == 0x6665) ||
+-		    (adev->pdev->device == 0x6667)) {
++		    (adev->pdev->device == 0x6667) ||
++		    (adev->pdev->device == 0x666F)) {
+ 			max_sclk = 75000;
+ 		}
+ 		if ((adev->pdev->revision == 0xC3) ||
+@@ -3475,14 +3478,9 @@ static void si_apply_state_adjust_rules(struct amdgpu_device *adev,
+ 	 * For example, 4K 60Hz and 1080p 144Hz fall into this category.
+ 	 * Find number of such displays connected.
+ 	 */
+-	for (i = 0; i < adev->mode_info.num_crtc; i++) {
+-		if (!(adev->pm.dpm.new_active_crtcs & (1 << i)) ||
+-			!adev->mode_info.crtcs[i]->enabled)
+-			continue;
+-
+-		conn = to_amdgpu_connector(adev->mode_info.crtcs[i]->connector);
+-
+-		if (conn->pixelclock_for_modeset > 297000)
++	for (i = 0; i < display_cfg->num_display; i++) {
++		/* The array only contains active displays. */
++		if (display_cfg->displays[i].pixel_clock > 297000)
+ 			high_pixelclock_count++;
+ 	}
+ 
+@@ -3515,7 +3513,7 @@ static void si_apply_state_adjust_rules(struct amdgpu_device *adev,
+ 		rps->ecclk = 0;
+ 	}
+ 
+-	if ((adev->pm.dpm.new_active_crtc_count > 1) ||
++	if ((adev->pm.pm_display_cfg.num_display > 1) ||
+ 	    si_dpm_vblank_too_short(adev))
+ 		disable_mclk_switching = true;
+ 
+@@ -3663,7 +3661,7 @@ static void si_apply_state_adjust_rules(struct amdgpu_device *adev,
+ 						   ps->performance_levels[i].mclk,
+ 						   max_limits->vddc,  &ps->performance_levels[i].vddc);
+ 		btc_apply_voltage_dependency_rules(&adev->pm.dpm.dyn_state.vddc_dependency_on_dispclk,
+-						   adev->clock.current_dispclk,
++						   display_cfg->display_clk,
+ 						   max_limits->vddc,  &ps->performance_levels[i].vddc);
+ 	}
+ 
+@@ -4188,16 +4186,16 @@ static void si_program_ds_registers(struct amdgpu_device *adev)
+ 
+ static void si_program_display_gap(struct amdgpu_device *adev)
+ {
++	const struct amd_pp_display_configuration *cfg = &adev->pm.pm_display_cfg;
+ 	u32 tmp, pipe;
+-	int i;
+ 
+ 	tmp = RREG32(CG_DISPLAY_GAP_CNTL) & ~(DISP1_GAP_MASK | DISP2_GAP_MASK);
+-	if (adev->pm.dpm.new_active_crtc_count > 0)
++	if (cfg->num_display > 0)
+ 		tmp |= DISP1_GAP(R600_PM_DISPLAY_GAP_VBLANK_OR_WM);
+ 	else
+ 		tmp |= DISP1_GAP(R600_PM_DISPLAY_GAP_IGNORE);
+ 
+-	if (adev->pm.dpm.new_active_crtc_count > 1)
++	if (cfg->num_display > 1)
+ 		tmp |= DISP2_GAP(R600_PM_DISPLAY_GAP_VBLANK_OR_WM);
+ 	else
+ 		tmp |= DISP2_GAP(R600_PM_DISPLAY_GAP_IGNORE);
+@@ -4207,17 +4205,8 @@ static void si_program_display_gap(struct amdgpu_device *adev)
+ 	tmp = RREG32(DCCG_DISP_SLOW_SELECT_REG);
+ 	pipe = (tmp & DCCG_DISP1_SLOW_SELECT_MASK) >> DCCG_DISP1_SLOW_SELECT_SHIFT;
+ 
+-	if ((adev->pm.dpm.new_active_crtc_count > 0) &&
+-	    (!(adev->pm.dpm.new_active_crtcs & (1 << pipe)))) {
+-		/* find the first active crtc */
+-		for (i = 0; i < adev->mode_info.num_crtc; i++) {
+-			if (adev->pm.dpm.new_active_crtcs & (1 << i))
+-				break;
+-		}
+-		if (i == adev->mode_info.num_crtc)
+-			pipe = 0;
+-		else
+-			pipe = i;
++	if (cfg->num_display > 0 && pipe != cfg->crtc_index) {
++		pipe = cfg->crtc_index;
+ 
+ 		tmp &= ~DCCG_DISP1_SLOW_SELECT_MASK;
+ 		tmp |= DCCG_DISP1_SLOW_SELECT(pipe);
+@@ -4228,7 +4217,7 @@ static void si_program_display_gap(struct amdgpu_device *adev)
+ 	 * This can be a problem on PowerXpress systems or if you want to use the card
+ 	 * for offscreen rendering or compute if there are no crtcs enabled.
+ 	 */
+-	si_notify_smc_display_change(adev, adev->pm.dpm.new_active_crtc_count > 0);
++	si_notify_smc_display_change(adev, cfg->num_display > 0);
+ }
+ 
+ static void si_enable_spread_spectrum(struct amdgpu_device *adev, bool enable)
+@@ -5533,7 +5522,7 @@ static int si_convert_power_level_to_smc(struct amdgpu_device *adev,
+ 	    (pl->mclk <= pi->mclk_stutter_mode_threshold) &&
+ 	    !eg_pi->uvd_enabled &&
+ 	    (RREG32(DPG_PIPE_STUTTER_CONTROL) & STUTTER_ENABLE) &&
+-	    (adev->pm.dpm.new_active_crtc_count <= 2)) {
++	    (adev->pm.pm_display_cfg.num_display <= 2)) {
+ 		level->mcFlags |= SISLANDS_SMC_MC_STUTTER_EN;
+ 
+ 		if (gmc_pg)
+@@ -5685,7 +5674,7 @@ static bool si_is_state_ulv_compatible(struct amdgpu_device *adev,
+ 	/* XXX validate against display requirements! */
+ 
+ 	for (i = 0; i < adev->pm.dpm.dyn_state.vddc_dependency_on_dispclk.count; i++) {
+-		if (adev->clock.current_dispclk <=
++		if (adev->pm.pm_display_cfg.display_clk <=
+ 		    adev->pm.dpm.dyn_state.vddc_dependency_on_dispclk.entries[i].clk) {
+ 			if (ulv->pl.vddc <
+ 			    adev->pm.dpm.dyn_state.vddc_dependency_on_dispclk.entries[i].v)
+@@ -5839,30 +5828,22 @@ static int si_upload_ulv_state(struct amdgpu_device *adev)
+ 
+ static int si_upload_smc_data(struct amdgpu_device *adev)
+ {
+-	struct amdgpu_crtc *amdgpu_crtc = NULL;
+-	int i;
++	const struct amd_pp_display_configuration *cfg = &adev->pm.pm_display_cfg;
+ 	u32 crtc_index = 0;
+ 	u32 mclk_change_block_cp_min = 0;
+ 	u32 mclk_change_block_cp_max = 0;
+ 
+-	for (i = 0; i < adev->mode_info.num_crtc; i++) {
+-		if (adev->pm.dpm.new_active_crtcs & (1 << i)) {
+-			amdgpu_crtc = adev->mode_info.crtcs[i];
+-			break;
+-		}
+-	}
+-
+ 	/* When a display is plugged in, program these so that the SMC
+ 	 * performs MCLK switching when it doesn't cause flickering.
+ 	 * When no display is plugged in, there is no need to restrict
+ 	 * MCLK switching, so program them to zero.
+ 	 */
+-	if (adev->pm.dpm.new_active_crtc_count && amdgpu_crtc) {
+-		crtc_index = amdgpu_crtc->crtc_id;
++	if (cfg->num_display) {
++		crtc_index = cfg->crtc_index;
+ 
+-		if (amdgpu_crtc->line_time) {
+-			mclk_change_block_cp_min = 200 / amdgpu_crtc->line_time;
+-			mclk_change_block_cp_max = 100 / amdgpu_crtc->line_time;
++		if (cfg->line_time_in_us) {
++			mclk_change_block_cp_min = 200 / cfg->line_time_in_us;
++			mclk_change_block_cp_max = 100 / cfg->line_time_in_us;
+ 		}
+ 	}
+ 
+diff --git a/drivers/gpu/drm/amd/pm/powerplay/amd_powerplay.c b/drivers/gpu/drm/amd/pm/powerplay/amd_powerplay.c
+index bef6578ac4bfef..3a454aab62ce8b 100644
+--- a/drivers/gpu/drm/amd/pm/powerplay/amd_powerplay.c
++++ b/drivers/gpu/drm/amd/pm/powerplay/amd_powerplay.c
+@@ -1567,16 +1567,7 @@ static void pp_pm_compute_clocks(void *handle)
+ 	struct amdgpu_device *adev = hwmgr->adev;
+ 
+ 	if (!adev->dc_enabled) {
+-		amdgpu_dpm_get_active_displays(adev);
+-		adev->pm.pm_display_cfg.num_display = adev->pm.dpm.new_active_crtc_count;
+-		adev->pm.pm_display_cfg.vrefresh = amdgpu_dpm_get_vrefresh(adev);
+-		adev->pm.pm_display_cfg.min_vblank_time = amdgpu_dpm_get_vblank_time(adev);
+-		/* we have issues with mclk switching with
+-		 * refresh rates over 120 hz on the non-DC code.
+-		 */
+-		if (adev->pm.pm_display_cfg.vrefresh > 120)
+-			adev->pm.pm_display_cfg.min_vblank_time = 0;
+-
++		amdgpu_dpm_get_display_cfg(adev);
+ 		pp_display_configuration_change(handle,
+ 						&adev->pm.pm_display_cfg);
+ 	}
+diff --git a/drivers/gpu/drm/bridge/samsung-dsim.c b/drivers/gpu/drm/bridge/samsung-dsim.c
+index f24666b4819384..b763a6d17e687a 100644
+--- a/drivers/gpu/drm/bridge/samsung-dsim.c
++++ b/drivers/gpu/drm/bridge/samsung-dsim.c
+@@ -1642,6 +1642,14 @@ static int samsung_dsim_register_te_irq(struct samsung_dsim *dsi, struct device
+ 	return 0;
+ }
+ 
++static void samsung_dsim_unregister_te_irq(struct samsung_dsim *dsi)
++{
++	if (dsi->te_gpio) {
++		free_irq(gpiod_to_irq(dsi->te_gpio), dsi);
++		gpiod_put(dsi->te_gpio);
++	}
++}
++
+ static int samsung_dsim_host_attach(struct mipi_dsi_host *host,
+ 				    struct mipi_dsi_device *device)
+ {
+@@ -1713,13 +1721,13 @@ of_find_panel_or_bridge:
+ 	if (!(device->mode_flags & MIPI_DSI_MODE_VIDEO)) {
+ 		ret = samsung_dsim_register_te_irq(dsi, &device->dev);
+ 		if (ret)
+-			return ret;
++			goto err_remove_bridge;
+ 	}
+ 
+ 	if (pdata->host_ops && pdata->host_ops->attach) {
+ 		ret = pdata->host_ops->attach(dsi, device);
+ 		if (ret)
+-			return ret;
++			goto err_unregister_te_irq;
+ 	}
+ 
+ 	dsi->lanes = device->lanes;
+@@ -1727,14 +1735,13 @@ of_find_panel_or_bridge:
+ 	dsi->mode_flags = device->mode_flags;
+ 
+ 	return 0;
+-}
+ 
+-static void samsung_dsim_unregister_te_irq(struct samsung_dsim *dsi)
+-{
+-	if (dsi->te_gpio) {
+-		free_irq(gpiod_to_irq(dsi->te_gpio), dsi);
+-		gpiod_put(dsi->te_gpio);
+-	}
++err_unregister_te_irq:
++	if (!(device->mode_flags & MIPI_DSI_MODE_VIDEO))
++		samsung_dsim_unregister_te_irq(dsi);
++err_remove_bridge:
++	drm_bridge_remove(&dsi->bridge);
++	return ret;
+ }
+ 
+ static int samsung_dsim_host_detach(struct mipi_dsi_host *host,
+diff --git a/drivers/gpu/drm/bridge/ti-sn65dsi83.c b/drivers/gpu/drm/bridge/ti-sn65dsi83.c
+index 8a23116346a8a5..181b1f8d7736a1 100644
+--- a/drivers/gpu/drm/bridge/ti-sn65dsi83.c
++++ b/drivers/gpu/drm/bridge/ti-sn65dsi83.c
+@@ -303,9 +303,9 @@ static u8 sn65dsi83_get_dsi_range(struct sn65dsi83 *ctx,
+ 	 *  DSI_CLK = mode clock * bpp / dsi_data_lanes / 2
+ 	 * the 2 is there because the bus is DDR.
+ 	 */
+-	return DIV_ROUND_UP(clamp((unsigned int)mode->clock *
+-			    mipi_dsi_pixel_format_to_bpp(ctx->dsi->format) /
+-			    ctx->dsi->lanes / 2, 40000U, 500000U), 5000U);
++	return clamp((unsigned int)mode->clock *
++		     mipi_dsi_pixel_format_to_bpp(ctx->dsi->format) /
++		     ctx->dsi->lanes / 2, 40000U, 500000U) / 5000U;
+ }
+ 
+ static u8 sn65dsi83_get_dsi_div(struct sn65dsi83 *ctx)
+@@ -325,6 +325,7 @@ static void sn65dsi83_atomic_pre_enable(struct drm_bridge *bridge,
+ 					struct drm_bridge_state *old_bridge_state)
+ {
+ 	struct sn65dsi83 *ctx = bridge_to_sn65dsi83(bridge);
++	const unsigned int dual_factor = ctx->lvds_dual_link ? 2 : 1;
+ 	struct drm_atomic_state *state = old_bridge_state->base.state;
+ 	const struct drm_bridge_state *bridge_state;
+ 	const struct drm_crtc_state *crtc_state;
+@@ -452,18 +453,18 @@ static void sn65dsi83_atomic_pre_enable(struct drm_bridge *bridge,
+ 	/* 32 + 1 pixel clock to ensure proper operation */
+ 	le16val = cpu_to_le16(32 + 1);
+ 	regmap_bulk_write(ctx->regmap, REG_VID_CHA_SYNC_DELAY_LOW, &le16val, 2);
+-	le16val = cpu_to_le16(mode->hsync_end - mode->hsync_start);
++	le16val = cpu_to_le16((mode->hsync_end - mode->hsync_start) / dual_factor);
+ 	regmap_bulk_write(ctx->regmap, REG_VID_CHA_HSYNC_PULSE_WIDTH_LOW,
+ 			  &le16val, 2);
+ 	le16val = cpu_to_le16(mode->vsync_end - mode->vsync_start);
+ 	regmap_bulk_write(ctx->regmap, REG_VID_CHA_VSYNC_PULSE_WIDTH_LOW,
+ 			  &le16val, 2);
+ 	regmap_write(ctx->regmap, REG_VID_CHA_HORIZONTAL_BACK_PORCH,
+-		     mode->htotal - mode->hsync_end);
++		     (mode->htotal - mode->hsync_end) / dual_factor);
+ 	regmap_write(ctx->regmap, REG_VID_CHA_VERTICAL_BACK_PORCH,
+ 		     mode->vtotal - mode->vsync_end);
+ 	regmap_write(ctx->regmap, REG_VID_CHA_HORIZONTAL_FRONT_PORCH,
+-		     mode->hsync_start - mode->hdisplay);
++		     (mode->hsync_start - mode->hdisplay) / dual_factor);
+ 	regmap_write(ctx->regmap, REG_VID_CHA_VERTICAL_FRONT_PORCH,
+ 		     mode->vsync_start - mode->vdisplay);
+ 	regmap_write(ctx->regmap, REG_VID_CHA_TEST_PATTERN, 0x00);
+diff --git a/drivers/gpu/drm/bridge/ti-sn65dsi86.c b/drivers/gpu/drm/bridge/ti-sn65dsi86.c
+index 560935f2e8cbe1..c90925cf047aa7 100644
+--- a/drivers/gpu/drm/bridge/ti-sn65dsi86.c
++++ b/drivers/gpu/drm/bridge/ti-sn65dsi86.c
+@@ -106,10 +106,21 @@
+ #define SN_PWM_EN_INV_REG			0xA5
+ #define  SN_PWM_INV_MASK			BIT(0)
+ #define  SN_PWM_EN_MASK				BIT(1)
++
++#define SN_IRQ_EN_REG				0xE0
++#define  IRQ_EN					BIT(0)
++
++#define SN_IRQ_EVENTS_EN_REG			0xE6
++#define  HPD_INSERTION_EN			BIT(1)
++#define  HPD_REMOVAL_EN				BIT(2)
++
+ #define SN_AUX_CMD_STATUS_REG			0xF4
+ #define  AUX_IRQ_STATUS_AUX_RPLY_TOUT		BIT(3)
+ #define  AUX_IRQ_STATUS_AUX_SHORT		BIT(5)
+ #define  AUX_IRQ_STATUS_NAT_I2C_FAIL		BIT(6)
++#define SN_IRQ_STATUS_REG			0xF5
++#define  HPD_REMOVAL_STATUS			BIT(2)
++#define  HPD_INSERTION_STATUS			BIT(1)
+ 
+ #define MIN_DSI_CLK_FREQ_MHZ	40
+ 
+@@ -152,7 +163,9 @@
+  * @ln_assign:    Value to program to the LN_ASSIGN register.
+  * @ln_polrs:     Value for the 4-bit LN_POLRS field of SN_ENH_FRAME_REG.
+  * @comms_enabled: If true then communication over the aux channel is enabled.
++ * @hpd_enabled:   If true then HPD events are enabled.
+  * @comms_mutex:   Protects modification of comms_enabled.
++ * @hpd_mutex:     Protects modification of hpd_enabled.
+  *
+  * @gchip:        If we expose our GPIOs, this is used.
+  * @gchip_output: A cache of whether we've set GPIOs to output.  This
+@@ -190,7 +203,9 @@ struct ti_sn65dsi86 {
+ 	u8				ln_assign;
+ 	u8				ln_polrs;
+ 	bool				comms_enabled;
++	bool				hpd_enabled;
+ 	struct mutex			comms_mutex;
++	struct mutex			hpd_mutex;
+ 
+ #if defined(CONFIG_OF_GPIO)
+ 	struct gpio_chip		gchip;
+@@ -221,6 +236,23 @@ static const struct regmap_config ti_sn65dsi86_regmap_config = {
+ 	.max_register = 0xFF,
+ };
+ 
++static int ti_sn65dsi86_read_u8(struct ti_sn65dsi86 *pdata, unsigned int reg,
++				u8 *val)
++{
++	int ret;
++	unsigned int reg_val;
++
++	ret = regmap_read(pdata->regmap, reg, &reg_val);
++	if (ret) {
++		dev_err(pdata->dev, "fail to read raw reg %#x: %d\n",
++			reg, ret);
++		return ret;
++	}
++	*val = (u8)reg_val;
++
++	return 0;
++}
++
+ static int __maybe_unused ti_sn65dsi86_read_u16(struct ti_sn65dsi86 *pdata,
+ 						unsigned int reg, u16 *val)
+ {
+@@ -362,6 +394,7 @@ static void ti_sn65dsi86_disable_comms(struct ti_sn65dsi86 *pdata)
+ static int __maybe_unused ti_sn65dsi86_resume(struct device *dev)
+ {
+ 	struct ti_sn65dsi86 *pdata = dev_get_drvdata(dev);
++	const struct i2c_client *client = to_i2c_client(pdata->dev);
+ 	int ret;
+ 
+ 	ret = regulator_bulk_enable(SN_REGULATOR_SUPPLY_NUM, pdata->supplies);
+@@ -396,6 +429,13 @@ static int __maybe_unused ti_sn65dsi86_resume(struct device *dev)
+ 	if (pdata->refclk)
+ 		ti_sn65dsi86_enable_comms(pdata);
+ 
++	if (client->irq) {
++		ret = regmap_update_bits(pdata->regmap, SN_IRQ_EN_REG, IRQ_EN,
++					 IRQ_EN);
++		if (ret)
++			dev_err(pdata->dev, "Failed to enable IRQ events: %d\n", ret);
++	}
++
+ 	return ret;
+ }
+ 
+@@ -1223,6 +1263,8 @@ static void ti_sn65dsi86_debugfs_init(struct drm_bridge *bridge, struct dentry *
+ static void ti_sn_bridge_hpd_enable(struct drm_bridge *bridge)
+ {
+ 	struct ti_sn65dsi86 *pdata = bridge_to_ti_sn65dsi86(bridge);
++	const struct i2c_client *client = to_i2c_client(pdata->dev);
++	int ret;
+ 
+ 	/*
+ 	 * Device needs to be powered on before reading the HPD state
+@@ -1231,11 +1273,35 @@ static void ti_sn_bridge_hpd_enable(struct drm_bridge *bridge)
+ 	 */
+ 
+ 	pm_runtime_get_sync(pdata->dev);
++
++	mutex_lock(&pdata->hpd_mutex);
++	pdata->hpd_enabled = true;
++	mutex_unlock(&pdata->hpd_mutex);
++
++	if (client->irq) {
++		ret = regmap_set_bits(pdata->regmap, SN_IRQ_EVENTS_EN_REG,
++				      HPD_REMOVAL_EN | HPD_INSERTION_EN);
++		if (ret)
++			dev_err(pdata->dev, "Failed to enable HPD events: %d\n", ret);
++	}
+ }
+ 
+ static void ti_sn_bridge_hpd_disable(struct drm_bridge *bridge)
+ {
+ 	struct ti_sn65dsi86 *pdata = bridge_to_ti_sn65dsi86(bridge);
++	const struct i2c_client *client = to_i2c_client(pdata->dev);
++	int ret;
++
++	if (client->irq) {
++		ret = regmap_clear_bits(pdata->regmap, SN_IRQ_EVENTS_EN_REG,
++					HPD_REMOVAL_EN | HPD_INSERTION_EN);
++		if (ret)
++			dev_err(pdata->dev, "Failed to disable HPD events: %d\n", ret);
++	}
++
++	mutex_lock(&pdata->hpd_mutex);
++	pdata->hpd_enabled = false;
++	mutex_unlock(&pdata->hpd_mutex);
+ 
+ 	pm_runtime_put_autosuspend(pdata->dev);
+ }
+@@ -1321,11 +1387,47 @@ static int ti_sn_bridge_parse_dsi_host(struct ti_sn65dsi86 *pdata)
+ 	return 0;
+ }
+ 
++static irqreturn_t ti_sn_bridge_interrupt(int irq, void *private)
++{
++	struct ti_sn65dsi86 *pdata = private;
++	struct drm_device *dev = pdata->bridge.dev;
++	u8 status;
++	int ret;
++	bool hpd_event;
++
++	ret = ti_sn65dsi86_read_u8(pdata, SN_IRQ_STATUS_REG, &status);
++	if (ret) {
++		dev_err(pdata->dev, "Failed to read IRQ status: %d\n", ret);
++		return IRQ_NONE;
++	}
++
++	hpd_event = status & (HPD_REMOVAL_STATUS | HPD_INSERTION_STATUS);
++
++	dev_dbg(pdata->dev, "(SN_IRQ_STATUS_REG = %#x)\n", status);
++	if (!status)
++		return IRQ_NONE;
++
++	ret = regmap_write(pdata->regmap, SN_IRQ_STATUS_REG, status);
++	if (ret) {
++		dev_err(pdata->dev, "Failed to clear IRQ status: %d\n", ret);
++		return IRQ_NONE;
++	}
++
++	/* Only send the HPD event if we are bound with a device. */
++	mutex_lock(&pdata->hpd_mutex);
++	if (pdata->hpd_enabled && hpd_event)
++		drm_kms_helper_hotplug_event(dev);
++	mutex_unlock(&pdata->hpd_mutex);
++
++	return IRQ_HANDLED;
++}
++
+ static int ti_sn_bridge_probe(struct auxiliary_device *adev,
+ 			      const struct auxiliary_device_id *id)
+ {
+ 	struct ti_sn65dsi86 *pdata = dev_get_drvdata(adev->dev.parent);
+ 	struct device_node *np = pdata->dev->of_node;
++	const struct i2c_client *client = to_i2c_client(pdata->dev);
+ 	int ret;
+ 
+ 	pdata->next_bridge = devm_drm_of_get_bridge(&adev->dev, np, 1, 0);
+@@ -1345,8 +1447,9 @@ static int ti_sn_bridge_probe(struct auxiliary_device *adev,
+ 			   ? DRM_MODE_CONNECTOR_DisplayPort : DRM_MODE_CONNECTOR_eDP;
+ 
+ 	if (pdata->bridge.type == DRM_MODE_CONNECTOR_DisplayPort) {
+-		pdata->bridge.ops = DRM_BRIDGE_OP_EDID | DRM_BRIDGE_OP_DETECT |
+-				    DRM_BRIDGE_OP_HPD;
++		pdata->bridge.ops = DRM_BRIDGE_OP_EDID | DRM_BRIDGE_OP_DETECT;
++		if (client->irq)
++			pdata->bridge.ops |= DRM_BRIDGE_OP_HPD;
+ 		/*
+ 		 * If comms were already enabled they would have been enabled
+ 		 * with the wrong value of HPD_DISABLE. Update it now. Comms
+@@ -1949,6 +2052,7 @@ static int ti_sn65dsi86_probe(struct i2c_client *client)
+ 	dev_set_drvdata(dev, pdata);
+ 	pdata->dev = dev;
+ 
++	mutex_init(&pdata->hpd_mutex);
+ 	mutex_init(&pdata->comms_mutex);
+ 
+ 	pdata->regmap = devm_regmap_init_i2c(client,
+@@ -1979,6 +2083,16 @@ static int ti_sn65dsi86_probe(struct i2c_client *client)
+ 	if (ret)
+ 		return ret;
+ 
++	if (client->irq) {
++		ret = devm_request_threaded_irq(pdata->dev, client->irq, NULL,
++						ti_sn_bridge_interrupt,
++						IRQF_ONESHOT,
++						dev_name(pdata->dev), pdata);
++
++		if (ret)
++			return dev_err_probe(dev, ret, "failed to request interrupt\n");
++	}
++
+ 	/*
+ 	 * Break ourselves up into a collection of aux devices. The only real
+ 	 * motiviation here is to solve the chicken-and-egg problem of probe
+diff --git a/drivers/gpu/drm/drm_file.c b/drivers/gpu/drm/drm_file.c
+index b943221b238f87..b5a5cede4d3d8b 100644
+--- a/drivers/gpu/drm/drm_file.c
++++ b/drivers/gpu/drm/drm_file.c
+@@ -243,6 +243,7 @@ static void drm_events_release(struct drm_file *file_priv)
+ void drm_file_free(struct drm_file *file)
+ {
+ 	struct drm_device *dev;
++	int idx;
+ 
+ 	if (!file)
+ 		return;
+@@ -268,9 +269,11 @@ void drm_file_free(struct drm_file *file)
+ 
+ 	drm_events_release(file);
+ 
+-	if (drm_core_check_feature(dev, DRIVER_MODESET)) {
++	if (drm_core_check_feature(dev, DRIVER_MODESET) &&
++	    drm_dev_enter(dev, &idx)) {
+ 		drm_fb_release(file);
+ 		drm_property_destroy_user_blobs(dev, file);
++		drm_dev_exit(idx);
+ 	}
+ 
+ 	if (drm_core_check_feature(dev, DRIVER_SYNCOBJ))
+diff --git a/drivers/gpu/drm/drm_mode_config.c b/drivers/gpu/drm/drm_mode_config.c
+index 87eb591fe9b5b8..f09137046c2bdf 100644
+--- a/drivers/gpu/drm/drm_mode_config.c
++++ b/drivers/gpu/drm/drm_mode_config.c
+@@ -546,10 +546,13 @@ void drm_mode_config_cleanup(struct drm_device *dev)
+ 	 */
+ 	WARN_ON(!list_empty(&dev->mode_config.fb_list));
+ 	list_for_each_entry_safe(fb, fbt, &dev->mode_config.fb_list, head) {
+-		struct drm_printer p = drm_debug_printer("[leaked fb]");
++		if (list_empty(&fb->filp_head) || drm_framebuffer_read_refcount(fb) > 1) {
++			struct drm_printer p = drm_debug_printer("[leaked fb]");
+ 
+-		drm_printf(&p, "framebuffer[%u]:\n", fb->base.id);
+-		drm_framebuffer_print_info(&p, 1, fb);
++			drm_printf(&p, "framebuffer[%u]:\n", fb->base.id);
++			drm_framebuffer_print_info(&p, 1, fb);
++		}
++		list_del_init(&fb->filp_head);
+ 		drm_framebuffer_free(&fb->base.refcount);
+ 	}
+ 
+diff --git a/drivers/gpu/drm/exynos/exynos_drm_drv.h b/drivers/gpu/drm/exynos/exynos_drm_drv.h
+index 81d501efd01330..5e4788db07b947 100644
+--- a/drivers/gpu/drm/exynos/exynos_drm_drv.h
++++ b/drivers/gpu/drm/exynos/exynos_drm_drv.h
+@@ -199,6 +199,7 @@ struct drm_exynos_file_private {
+ struct exynos_drm_private {
+ 	struct device *g2d_dev;
+ 	struct device *dma_dev;
++	struct device *vidi_dev;
+ 	void *mapping;
+ 
+ 	/* for atomic commit */
+diff --git a/drivers/gpu/drm/exynos/exynos_drm_vidi.c b/drivers/gpu/drm/exynos/exynos_drm_vidi.c
+index e17f9c5c9c90e6..b7eae2469b318a 100644
+--- a/drivers/gpu/drm/exynos/exynos_drm_vidi.c
++++ b/drivers/gpu/drm/exynos/exynos_drm_vidi.c
+@@ -186,15 +186,17 @@ static ssize_t vidi_store_connection(struct device *dev,
+ 				const char *buf, size_t len)
+ {
+ 	struct vidi_context *ctx = dev_get_drvdata(dev);
+-	int ret;
++	int ret, new_connected;
+ 
+-	ret = kstrtoint(buf, 0, &ctx->connected);
++	ret = kstrtoint(buf, 0, &new_connected);
+ 	if (ret)
+ 		return ret;
+ 
+-	if (ctx->connected > 1)
++	if (new_connected > 1)
+ 		return -EINVAL;
+ 
++	mutex_lock(&ctx->lock);
++
+ 	/* use fake edid data for test. */
+ 	if (!ctx->raw_edid)
+ 		ctx->raw_edid = (struct edid *)fake_edid_info;
+@@ -202,14 +204,21 @@ static ssize_t vidi_store_connection(struct device *dev,
+ 	/* if raw_edid isn't same as fake data then it can't be tested. */
+ 	if (ctx->raw_edid != (struct edid *)fake_edid_info) {
+ 		DRM_DEV_DEBUG_KMS(dev, "edid data is not fake data.\n");
+-		return -EINVAL;
++		ret = -EINVAL;
++		goto fail;
+ 	}
+ 
++	ctx->connected = new_connected;
++	mutex_unlock(&ctx->lock);
++
+ 	DRM_DEV_DEBUG_KMS(dev, "requested connection.\n");
+ 
+ 	drm_helper_hpd_irq_event(ctx->drm_dev);
+ 
+ 	return len;
++fail:
++	mutex_unlock(&ctx->lock);
++	return ret;
+ }
+ 
+ static DEVICE_ATTR(connection, 0644, vidi_show_connection,
+@@ -224,9 +233,14 @@ ATTRIBUTE_GROUPS(vidi);
+ int vidi_connection_ioctl(struct drm_device *drm_dev, void *data,
+ 				struct drm_file *file_priv)
+ {
+-	struct vidi_context *ctx = dev_get_drvdata(drm_dev->dev);
++	struct exynos_drm_private *priv = drm_dev->dev_private;
++	struct device *dev = priv ? priv->vidi_dev : NULL;
++	struct vidi_context *ctx = dev ? dev_get_drvdata(dev) : NULL;
+ 	struct drm_exynos_vidi_connection *vidi = data;
+ 
++	if (!ctx)
++		return -ENODEV;
++
+ 	if (!vidi) {
+ 		DRM_DEV_DEBUG_KMS(ctx->dev,
+ 				  "user data for vidi is null.\n");
+@@ -239,40 +253,57 @@ int vidi_connection_ioctl(struct drm_device *drm_dev, void *data,
+ 		return -EINVAL;
+ 	}
+ 
++	mutex_lock(&ctx->lock);
+ 	if (ctx->connected == vidi->connection) {
++		mutex_unlock(&ctx->lock);
+ 		DRM_DEV_DEBUG_KMS(ctx->dev,
+ 				  "same connection request.\n");
+ 		return -EINVAL;
+ 	}
++	mutex_unlock(&ctx->lock);
+ 
+ 	if (vidi->connection) {
+ 		struct edid *raw_edid;
++		struct edid edid_buf;
++		void *edid_userptr = u64_to_user_ptr(vidi->edid);
++
++		if (copy_from_user(&edid_buf, edid_userptr, sizeof(struct edid)))
++			return -EFAULT;
+ 
+-		raw_edid = (struct edid *)(unsigned long)vidi->edid;
+-		if (!drm_edid_is_valid(raw_edid)) {
++		if (!drm_edid_is_valid(&edid_buf)) {
+ 			DRM_DEV_DEBUG_KMS(ctx->dev,
+ 					  "edid data is invalid.\n");
+ 			return -EINVAL;
+ 		}
+-		ctx->raw_edid = drm_edid_duplicate(raw_edid);
+-		if (!ctx->raw_edid) {
++
++		raw_edid = drm_edid_duplicate(&edid_buf);
++
++		if (!raw_edid) {
+ 			DRM_DEV_DEBUG_KMS(ctx->dev,
+ 					  "failed to allocate raw_edid.\n");
+ 			return -ENOMEM;
+ 		}
++		mutex_lock(&ctx->lock);
++		ctx->raw_edid = raw_edid;
++		mutex_unlock(&ctx->lock);
+ 	} else {
+ 		/*
+ 		 * with connection = 0, free raw_edid
+ 		 * only if raw edid data isn't same as fake data.
+ 		 */
++		mutex_lock(&ctx->lock);
+ 		if (ctx->raw_edid && ctx->raw_edid !=
+ 				(struct edid *)fake_edid_info) {
+ 			kfree(ctx->raw_edid);
+ 			ctx->raw_edid = NULL;
+ 		}
++		mutex_unlock(&ctx->lock);
+ 	}
+ 
++	mutex_lock(&ctx->lock);
+ 	ctx->connected = vidi->connection;
++	mutex_unlock(&ctx->lock);
++
+ 	drm_helper_hpd_irq_event(ctx->drm_dev);
+ 
+ 	return 0;
+@@ -287,7 +318,7 @@ static enum drm_connector_status vidi_detect(struct drm_connector *connector,
+ 	 * connection request would come from user side
+ 	 * to do hotplug through specific ioctl.
+ 	 */
+-	return ctx->connected ? connector_status_connected :
++	return READ_ONCE(ctx->connected) ? connector_status_connected :
+ 			connector_status_disconnected;
+ }
+ 
+@@ -309,22 +340,24 @@ static int vidi_get_modes(struct drm_connector *connector)
+ 	struct vidi_context *ctx = ctx_from_connector(connector);
+ 	struct edid *edid;
+ 	int edid_len;
+-	int count;
++	int count = 0;
+ 
+ 	/*
+ 	 * the edid data comes from user side and it would be set
+ 	 * to ctx->raw_edid through specific ioctl.
+ 	 */
++
++	mutex_lock(&ctx->lock);
+ 	if (!ctx->raw_edid) {
+ 		DRM_DEV_DEBUG_KMS(ctx->dev, "raw_edid is null.\n");
+-		return 0;
++		goto fail;
+ 	}
+ 
+ 	edid_len = (1 + ctx->raw_edid->extensions) * EDID_LENGTH;
+ 	edid = kmemdup(ctx->raw_edid, edid_len, GFP_KERNEL);
+ 	if (!edid) {
+ 		DRM_DEV_DEBUG_KMS(ctx->dev, "failed to allocate edid\n");
+-		return 0;
++		goto fail;
+ 	}
+ 
+ 	drm_connector_update_edid_property(connector, edid);
+@@ -333,6 +366,8 @@ static int vidi_get_modes(struct drm_connector *connector)
+ 
+ 	kfree(edid);
+ 
++fail:
++	mutex_unlock(&ctx->lock);
+ 	return count;
+ }
+ 
+@@ -386,6 +421,7 @@ static int vidi_bind(struct device *dev, struct device *master, void *data)
+ {
+ 	struct vidi_context *ctx = dev_get_drvdata(dev);
+ 	struct drm_device *drm_dev = data;
++	struct exynos_drm_private *priv = drm_dev->dev_private;
+ 	struct drm_encoder *encoder = &ctx->encoder;
+ 	struct exynos_drm_plane *exynos_plane;
+ 	struct exynos_drm_plane_config plane_config = { 0 };
+@@ -393,6 +429,8 @@ static int vidi_bind(struct device *dev, struct device *master, void *data)
+ 	int ret;
+ 
+ 	ctx->drm_dev = drm_dev;
++	if (priv)
++		priv->vidi_dev = dev;
+ 
+ 	plane_config.pixel_formats = formats;
+ 	plane_config.num_pixel_formats = ARRAY_SIZE(formats);
+@@ -438,8 +476,12 @@ static int vidi_bind(struct device *dev, struct device *master, void *data)
+ static void vidi_unbind(struct device *dev, struct device *master, void *data)
+ {
+ 	struct vidi_context *ctx = dev_get_drvdata(dev);
++	struct drm_device *drm_dev = data;
++	struct exynos_drm_private *priv = drm_dev->dev_private;
+ 
+ 	del_timer_sync(&ctx->timer);
++	if (priv)
++		priv->vidi_dev = NULL;
+ }
+ 
+ static const struct component_ops vidi_component_ops = {
+@@ -471,11 +513,15 @@ static int vidi_remove(struct platform_device *pdev)
+ {
+ 	struct vidi_context *ctx = platform_get_drvdata(pdev);
+ 
++	mutex_lock(&ctx->lock);
++
+ 	if (ctx->raw_edid != (struct edid *)fake_edid_info) {
+ 		kfree(ctx->raw_edid);
+ 		ctx->raw_edid = NULL;
+ 	}
+ 
++	mutex_unlock(&ctx->lock);
++
+ 	component_del(&pdev->dev, &vidi_component_ops);
+ 
+ 	return 0;
+diff --git a/drivers/gpu/drm/i915/gem/i915_gem_shmem.c b/drivers/gpu/drm/i915/gem/i915_gem_shmem.c
+index ba0e45fe432854..9c9a2f244da72d 100644
+--- a/drivers/gpu/drm/i915/gem/i915_gem_shmem.c
++++ b/drivers/gpu/drm/i915/gem/i915_gem_shmem.c
+@@ -151,8 +151,12 @@ int shmem_sg_alloc_table(struct drm_i915_private *i915, struct sg_table *st,
+ 			}
+ 		} while (1);
+ 
+-		nr_pages = min_t(unsigned long,
+-				folio_nr_pages(folio), page_count - i);
++		nr_pages = min_array(((unsigned long[]) {
++					folio_nr_pages(folio),
++					page_count - i,
++					max_segment / PAGE_SIZE,
++				      }), 3);
++
+ 		if (!i ||
+ 		    sg->length >= max_segment ||
+ 		    folio_pfn(folio) != next_pfn) {
+@@ -162,7 +166,9 @@ int shmem_sg_alloc_table(struct drm_i915_private *i915, struct sg_table *st,
+ 			st->nents++;
+ 			sg_set_folio(sg, folio, nr_pages * PAGE_SIZE, 0);
+ 		} else {
+-			/* XXX: could overflow? */
++			nr_pages = min_t(unsigned long, nr_pages,
++					 (max_segment - sg->length) / PAGE_SIZE);
++
+ 			sg->length += nr_pages * PAGE_SIZE;
+ 		}
+ 		next_pfn = folio_pfn(folio) + nr_pages;
+diff --git a/drivers/gpu/drm/i915/gt/intel_engine_cs.c b/drivers/gpu/drm/i915/gt/intel_engine_cs.c
+index 0729ab5955171e..6ea2c14f781602 100644
+--- a/drivers/gpu/drm/i915/gt/intel_engine_cs.c
++++ b/drivers/gpu/drm/i915/gt/intel_engine_cs.c
+@@ -1973,7 +1973,8 @@ void intel_engines_reset_default_submission(struct intel_gt *gt)
+ 		if (engine->sanitize)
+ 			engine->sanitize(engine);
+ 
+-		engine->set_default_submission(engine);
++		if (engine->set_default_submission)
++			engine->set_default_submission(engine);
+ 	}
+ }
+ 
+diff --git a/drivers/gpu/drm/logicvc/logicvc_drm.c b/drivers/gpu/drm/logicvc/logicvc_drm.c
+index 749debd3d6a577..df74572e6d2eac 100644
+--- a/drivers/gpu/drm/logicvc/logicvc_drm.c
++++ b/drivers/gpu/drm/logicvc/logicvc_drm.c
+@@ -90,7 +90,6 @@ static int logicvc_drm_config_parse(struct logicvc_drm *logicvc)
+ 	struct device *dev = drm_dev->dev;
+ 	struct device_node *of_node = dev->of_node;
+ 	struct logicvc_drm_config *config = &logicvc->config;
+-	struct device_node *layers_node;
+ 	int ret;
+ 
+ 	logicvc_of_property_parse_bool(of_node, LOGICVC_OF_PROPERTY_DITHERING,
+@@ -126,7 +125,8 @@ static int logicvc_drm_config_parse(struct logicvc_drm *logicvc)
+ 	if (ret)
+ 		return ret;
+ 
+-	layers_node = of_get_child_by_name(of_node, "layers");
++	struct device_node *layers_node __free(device_node) =
++		of_get_child_by_name(of_node, "layers");
+ 	if (!layers_node) {
+ 		drm_err(drm_dev, "Missing non-optional layers node\n");
+ 		return -EINVAL;
+diff --git a/drivers/gpu/drm/msm/dsi/dsi_host.c b/drivers/gpu/drm/msm/dsi/dsi_host.c
+index f90ccdfbb2fc7c..6077331deba974 100644
+--- a/drivers/gpu/drm/msm/dsi/dsi_host.c
++++ b/drivers/gpu/drm/msm/dsi/dsi_host.c
+@@ -529,13 +529,49 @@ void dsi_link_clk_disable_v2(struct msm_dsi_host *msm_host)
+ 	clk_disable_unprepare(msm_host->byte_clk);
+ }
+ 
+-static unsigned long dsi_adjust_pclk_for_compression(const struct drm_display_mode *mode,
+-		const struct drm_dsc_config *dsc)
++/**
++ * dsi_adjust_pclk_for_compression() - Adjust the pclk rate for compression case
++ * @mode: The selected mode for the DSI output
++ * @dsc: DRM DSC configuration for this DSI output
++ *
++ * Adjust the pclk rate by calculating a new hdisplay proportional to
++ * the compression ratio such that:
++ *     new_hdisplay = old_hdisplay * compressed_bpp / uncompressed_bpp
++ *
++ * Porches do not need to be adjusted:
++ * - For VIDEO mode they are not compressed by DSC and are passed as is.
++ * - For CMD mode there are no actual porches. Instead these fields
++ *   currently represent the overhead to the image data transfer. As such, they
++ *   are calculated for the final mode parameters (after the compression) and
++ *   are not to be adjusted too.
++ *
++ *  FIXME: Reconsider this if/when CMD mode handling is rewritten to use
++ *  transfer time and data overhead as a starting point of the calculations.
++ */
++static unsigned long
++dsi_adjust_pclk_for_compression(const struct drm_display_mode *mode,
++				const struct drm_dsc_config *dsc,
++				bool is_bonded_dsi)
+ {
+-	int new_hdisplay = DIV_ROUND_UP(mode->hdisplay * drm_dsc_get_bpp_int(dsc),
+-			dsc->bits_per_component * 3);
++	int hdisplay, new_hdisplay, new_htotal;
+ 
+-	int new_htotal = mode->htotal - mode->hdisplay + new_hdisplay;
++	/*
++	 * For bonded DSI, split hdisplay across two links and round up each
++	 * half separately, passing the full hdisplay would only round up once.
++	 * This also aligns with the hdisplay we program later in
++	 * dsi_timing_setup()
++	 */
++	hdisplay = mode->hdisplay;
++	if (is_bonded_dsi)
++		hdisplay /= 2;
++
++	new_hdisplay = DIV_ROUND_UP(hdisplay * drm_dsc_get_bpp_int(dsc),
++				    dsc->bits_per_component * 3);
++
++	if (is_bonded_dsi)
++		new_hdisplay *= 2;
++
++	new_htotal = mode->htotal - mode->hdisplay + new_hdisplay;
+ 
+ 	return mult_frac(mode->clock * 1000u, new_htotal, mode->htotal);
+ }
+@@ -548,7 +584,7 @@ static unsigned long dsi_get_pclk_rate(const struct drm_display_mode *mode,
+ 	pclk_rate = mode->clock * 1000u;
+ 
+ 	if (dsc)
+-		pclk_rate = dsi_adjust_pclk_for_compression(mode, dsc);
++		pclk_rate = dsi_adjust_pclk_for_compression(mode, dsc, is_bonded_dsi);
+ 
+ 	/*
+ 	 * For bonded DSI mode, the current DRM mode has the complete width of the
+@@ -937,8 +973,18 @@ static void dsi_timing_setup(struct msm_dsi_host *msm_host, bool is_bonded_dsi)
+ 		if (ret)
+ 			return;
+ 
+-		/* Divide the display by 3 but keep back/font porch and
+-		 * pulse width same
++		/*
++		 * DPU sends 3 bytes per pclk cycle to DSI. If widebus is
++		 * enabled, bus width is extended to 6 bytes.
++		 *
++		 * Calculate the number of pclks needed to transmit one line of
++		 * the compressed data.
++
++		 * The back/font porch and pulse width are kept intact. For
++		 * VIDEO mode they represent timing parameters rather than
++		 * actual data transfer, see the documentation for
++		 * dsi_adjust_pclk_for_compression(). For CMD mode they are
++		 * unused anyway.
+ 		 */
+ 		h_total -= hdisplay;
+ 		hdisplay = DIV_ROUND_UP(msm_dsc_get_bytes_per_line(msm_host->dsc), 3);
+diff --git a/drivers/gpu/drm/msm/msm_gpummu.c b/drivers/gpu/drm/msm/msm_gpummu.c
+index f7d1945e0c9f52..ab26b7f2e03591 100644
+--- a/drivers/gpu/drm/msm/msm_gpummu.c
++++ b/drivers/gpu/drm/msm/msm_gpummu.c
+@@ -76,7 +76,7 @@ static void msm_gpummu_destroy(struct msm_mmu *mmu)
+ {
+ 	struct msm_gpummu *gpummu = to_msm_gpummu(mmu);
+ 
+-	dma_free_attrs(mmu->dev, TABLE_SIZE, gpummu->table, gpummu->pt_base,
++	dma_free_attrs(mmu->dev, TABLE_SIZE + 32, gpummu->table, gpummu->pt_base,
+ 		DMA_ATTR_FORCE_CONTIGUOUS);
+ 
+ 	kfree(gpummu);
+diff --git a/drivers/gpu/drm/nouveau/nouveau_connector.c b/drivers/gpu/drm/nouveau/nouveau_connector.c
+index c1985448d9b382..5661dcbe6f7577 100644
+--- a/drivers/gpu/drm/nouveau/nouveau_connector.c
++++ b/drivers/gpu/drm/nouveau/nouveau_connector.c
+@@ -1212,6 +1212,9 @@ nouveau_connector_aux_xfer(struct drm_dp_aux *obj, struct drm_dp_aux_msg *msg)
+ 	u8 size = msg->size;
+ 	int ret;
+ 
++	if (pm_runtime_suspended(nv_connector->base.dev->dev))
++		return -EBUSY;
++
+ 	nv_encoder = find_encoder(&nv_connector->base, DCB_OUTPUT_DP);
+ 	if (!nv_encoder || !(aux = nv_encoder->aux))
+ 		return -ENODEV;
+diff --git a/drivers/gpu/drm/radeon/si_dpm.c b/drivers/gpu/drm/radeon/si_dpm.c
+index c688b4d914819c..94e2b2c69aa3bf 100644
+--- a/drivers/gpu/drm/radeon/si_dpm.c
++++ b/drivers/gpu/drm/radeon/si_dpm.c
+@@ -2959,9 +2959,11 @@ static void si_apply_state_adjust_rules(struct radeon_device *rdev,
+ 	if (rdev->family == CHIP_HAINAN) {
+ 		if ((rdev->pdev->revision == 0x81) ||
+ 		    (rdev->pdev->revision == 0xC3) ||
++		    (rdev->pdev->device == 0x6660) ||
+ 		    (rdev->pdev->device == 0x6664) ||
+ 		    (rdev->pdev->device == 0x6665) ||
+-		    (rdev->pdev->device == 0x6667)) {
++		    (rdev->pdev->device == 0x6667) ||
++		    (rdev->pdev->device == 0x666F)) {
+ 			max_sclk = 75000;
+ 		}
+ 		if ((rdev->pdev->revision == 0xC3) ||
+diff --git a/drivers/gpu/drm/scheduler/sched_main.c b/drivers/gpu/drm/scheduler/sched_main.c
+index 4faa2108c0a73b..50716bc5eef63e 100644
+--- a/drivers/gpu/drm/scheduler/sched_main.c
++++ b/drivers/gpu/drm/scheduler/sched_main.c
+@@ -259,6 +259,7 @@ drm_sched_rq_select_entity_fifo(struct drm_sched_rq *rq)
+ /**
+  * drm_sched_job_done - complete a job
+  * @s_job: pointer to the job which is done
++ * @result: 0 on success, -ERRNO on error
+  *
+  * Finish the job's fence and wake up the worker thread.
+  */
+diff --git a/drivers/gpu/drm/solomon/ssd130x.c b/drivers/gpu/drm/solomon/ssd130x.c
+index deec6acdcf6462..0d6a2664cfbeb8 100644
+--- a/drivers/gpu/drm/solomon/ssd130x.c
++++ b/drivers/gpu/drm/solomon/ssd130x.c
+@@ -42,6 +42,8 @@
+ #define DRIVER_MAJOR	1
+ #define DRIVER_MINOR	0
+ 
++#define SSD130X_PAGE_HEIGHT 8
++
+ #define SSD130X_PAGE_COL_START_LOW		0x00
+ #define SSD130X_PAGE_COL_START_HIGH		0x10
+ #define SSD130X_SET_ADDRESS_MODE		0x20
+@@ -102,7 +104,6 @@ const struct ssd130x_deviceinfo ssd130x_variants[] = {
+ 		.default_width = 132,
+ 		.default_height = 64,
+ 		.page_mode_only = 1,
+-		.page_height = 8,
+ 	},
+ 	[SSD1305_ID] = {
+ 		.default_vcomh = 0x34,
+@@ -110,7 +111,6 @@ const struct ssd130x_deviceinfo ssd130x_variants[] = {
+ 		.default_dclk_frq = 7,
+ 		.default_width = 132,
+ 		.default_height = 64,
+-		.page_height = 8,
+ 	},
+ 	[SSD1306_ID] = {
+ 		.default_vcomh = 0x20,
+@@ -119,7 +119,6 @@ const struct ssd130x_deviceinfo ssd130x_variants[] = {
+ 		.need_chargepump = 1,
+ 		.default_width = 128,
+ 		.default_height = 64,
+-		.page_height = 8,
+ 	},
+ 	[SSD1307_ID] = {
+ 		.default_vcomh = 0x20,
+@@ -128,7 +127,6 @@ const struct ssd130x_deviceinfo ssd130x_variants[] = {
+ 		.need_pwm = 1,
+ 		.default_width = 128,
+ 		.default_height = 39,
+-		.page_height = 8,
+ 	},
+ 	[SSD1309_ID] = {
+ 		.default_vcomh = 0x34,
+@@ -136,19 +134,27 @@ const struct ssd130x_deviceinfo ssd130x_variants[] = {
+ 		.default_dclk_frq = 10,
+ 		.default_width = 128,
+ 		.default_height = 64,
+-		.page_height = 8,
+ 	}
+ };
+ EXPORT_SYMBOL_NS_GPL(ssd130x_variants, DRM_SSD130X);
+ 
++struct ssd130x_crtc_state {
++	struct drm_crtc_state base;
++	/* Buffer to store pixels in HW format and written to the panel */
++	u8 *data_array;
++};
++
+ struct ssd130x_plane_state {
+ 	struct drm_shadow_plane_state base;
+ 	/* Intermediate buffer to convert pixels from XRGB8888 to HW format */
+ 	u8 *buffer;
+-	/* Buffer to store pixels in HW format and written to the panel */
+-	u8 *data_array;
+ };
+ 
++static inline struct ssd130x_crtc_state *to_ssd130x_crtc_state(struct drm_crtc_state *state)
++{
++	return container_of(state, struct ssd130x_crtc_state, base);
++}
++
+ static inline struct ssd130x_plane_state *to_ssd130x_plane_state(struct drm_plane_state *state)
+ {
+ 	return container_of(state, struct ssd130x_plane_state, base.base);
+@@ -448,23 +454,22 @@ static int ssd130x_init(struct ssd130x_device *ssd130x)
+ }
+ 
+ static int ssd130x_update_rect(struct ssd130x_device *ssd130x,
+-			       struct ssd130x_plane_state *ssd130x_state,
+-			       struct drm_rect *rect)
++			       struct drm_rect *rect, u8 *buf,
++			       u8 *data_array)
+ {
+ 	unsigned int x = rect->x1;
+ 	unsigned int y = rect->y1;
+-	u8 *buf = ssd130x_state->buffer;
+-	u8 *data_array = ssd130x_state->data_array;
+ 	unsigned int width = drm_rect_width(rect);
+ 	unsigned int height = drm_rect_height(rect);
+ 	unsigned int line_length = DIV_ROUND_UP(width, 8);
+-	unsigned int page_height = ssd130x->device_info->page_height;
++	unsigned int page_height = SSD130X_PAGE_HEIGHT;
++	u8 page_start = ssd130x->page_offset + y / page_height;
+ 	unsigned int pages = DIV_ROUND_UP(height, page_height);
+ 	struct drm_device *drm = &ssd130x->drm;
+ 	u32 array_idx = 0;
+ 	int ret, i, j, k;
+ 
+-	drm_WARN_ONCE(drm, y % 8 != 0, "y must be aligned to screen page\n");
++	drm_WARN_ONCE(drm, y % page_height != 0, "y must be aligned to screen page\n");
+ 
+ 	/*
+ 	 * The screen is divided in pages, each having a height of 8
+@@ -501,22 +506,24 @@ static int ssd130x_update_rect(struct ssd130x_device *ssd130x,
+ 		if (ret < 0)
+ 			return ret;
+ 
+-		ret = ssd130x_set_page_range(ssd130x, ssd130x->page_offset + y / 8, pages);
++		ret = ssd130x_set_page_range(ssd130x, page_start, pages);
+ 		if (ret < 0)
+ 			return ret;
+ 	}
+ 
+ 	for (i = 0; i < pages; i++) {
+-		int m = 8;
++		int m = page_height;
+ 
+ 		/* Last page may be partial */
+-		if (8 * (y / 8 + i + 1) > ssd130x->height)
+-			m = ssd130x->height % 8;
++		if (page_height * (y / page_height + i + 1) > ssd130x->height)
++			m = ssd130x->height % page_height;
++
+ 		for (j = 0; j < width; j++) {
+ 			u8 data = 0;
+ 
+ 			for (k = 0; k < m; k++) {
+-				u8 byte = buf[(8 * i + k) * line_length + j / 8];
++				u32 idx = (page_height * i + k) * line_length + j / 8;
++				u8 byte = buf[idx];
+ 				u8 bit = (byte >> (j % 8)) & 1;
+ 
+ 				data |= bit << k;
+@@ -530,7 +537,7 @@ static int ssd130x_update_rect(struct ssd130x_device *ssd130x,
+ 		 */
+ 		if (ssd130x->page_address_mode) {
+ 			ret = ssd130x_set_page_pos(ssd130x,
+-						   ssd130x->page_offset + i,
++						   page_start + i,
+ 						   ssd130x->col_offset + x);
+ 			if (ret < 0)
+ 				return ret;
+@@ -550,12 +557,9 @@ static int ssd130x_update_rect(struct ssd130x_device *ssd130x,
+ 	return ret;
+ }
+ 
+-static void ssd130x_clear_screen(struct ssd130x_device *ssd130x,
+-				 struct ssd130x_plane_state *ssd130x_state)
++static void ssd130x_clear_screen(struct ssd130x_device *ssd130x, u8 *data_array)
+ {
+-	unsigned int page_height = ssd130x->device_info->page_height;
+-	unsigned int pages = DIV_ROUND_UP(ssd130x->height, page_height);
+-	u8 *data_array = ssd130x_state->data_array;
++	unsigned int pages = DIV_ROUND_UP(ssd130x->height, SSD130X_PAGE_HEIGHT);
+ 	unsigned int width = ssd130x->width;
+ 	int ret, i;
+ 
+@@ -594,22 +598,19 @@ static void ssd130x_clear_screen(struct ssd130x_device *ssd130x,
+ 	}
+ }
+ 
+-static int ssd130x_fb_blit_rect(struct drm_plane_state *state,
++static int ssd130x_fb_blit_rect(struct drm_framebuffer *fb,
+ 				const struct iosys_map *vmap,
+-				struct drm_rect *rect)
++				struct drm_rect *rect,
++				u8 *buf, u8 *data_array)
+ {
+-	struct drm_framebuffer *fb = state->fb;
+ 	struct ssd130x_device *ssd130x = drm_to_ssd130x(fb->dev);
+-	unsigned int page_height = ssd130x->device_info->page_height;
+-	struct ssd130x_plane_state *ssd130x_state = to_ssd130x_plane_state(state);
+-	u8 *buf = ssd130x_state->buffer;
+ 	struct iosys_map dst;
+ 	unsigned int dst_pitch;
+ 	int ret = 0;
+ 
+ 	/* Align y to display page boundaries */
+-	rect->y1 = round_down(rect->y1, page_height);
+-	rect->y2 = min_t(unsigned int, round_up(rect->y2, page_height), ssd130x->height);
++	rect->y1 = round_down(rect->y1, SSD130X_PAGE_HEIGHT);
++	rect->y2 = min_t(unsigned int, round_up(rect->y2, SSD130X_PAGE_HEIGHT), ssd130x->height);
+ 
+ 	dst_pitch = DIV_ROUND_UP(drm_rect_width(rect), 8);
+ 
+@@ -622,7 +623,7 @@ static int ssd130x_fb_blit_rect(struct drm_plane_state *state,
+ 
+ 	drm_gem_fb_end_cpu_access(fb, DMA_FROM_DEVICE);
+ 
+-	ssd130x_update_rect(ssd130x, ssd130x_state, rect);
++	ssd130x_update_rect(ssd130x, rect, buf, data_array);
+ 
+ 	return ret;
+ }
+@@ -634,12 +635,19 @@ static int ssd130x_primary_plane_helper_atomic_check(struct drm_plane *plane,
+ 	struct ssd130x_device *ssd130x = drm_to_ssd130x(drm);
+ 	struct drm_plane_state *plane_state = drm_atomic_get_new_plane_state(state, plane);
+ 	struct ssd130x_plane_state *ssd130x_state = to_ssd130x_plane_state(plane_state);
+-	unsigned int page_height = ssd130x->device_info->page_height;
+-	unsigned int pages = DIV_ROUND_UP(ssd130x->height, page_height);
++	struct drm_crtc *crtc = plane_state->crtc;
++	struct drm_crtc_state *crtc_state;
+ 	const struct drm_format_info *fi;
+ 	unsigned int pitch;
+ 	int ret;
+ 
++	if (!crtc)
++		return -EINVAL;
++
++	crtc_state = drm_atomic_get_crtc_state(state, crtc);
++	if (IS_ERR(crtc_state))
++		return PTR_ERR(crtc_state);
++
+ 	ret = drm_plane_helper_atomic_check(plane, state);
+ 	if (ret)
+ 		return ret;
+@@ -654,14 +662,6 @@ static int ssd130x_primary_plane_helper_atomic_check(struct drm_plane *plane,
+ 	if (!ssd130x_state->buffer)
+ 		return -ENOMEM;
+ 
+-	ssd130x_state->data_array = kcalloc(ssd130x->width, pages, GFP_KERNEL);
+-	if (!ssd130x_state->data_array) {
+-		kfree(ssd130x_state->buffer);
+-		/* Set to prevent a double free in .atomic_destroy_state() */
+-		ssd130x_state->buffer = NULL;
+-		return -ENOMEM;
+-	}
+-
+ 	return 0;
+ }
+ 
+@@ -671,6 +671,10 @@ static void ssd130x_primary_plane_helper_atomic_update(struct drm_plane *plane,
+ 	struct drm_plane_state *plane_state = drm_atomic_get_new_plane_state(state, plane);
+ 	struct drm_plane_state *old_plane_state = drm_atomic_get_old_plane_state(state, plane);
+ 	struct drm_shadow_plane_state *shadow_plane_state = to_drm_shadow_plane_state(plane_state);
++	struct drm_crtc_state *crtc_state = drm_atomic_get_new_crtc_state(state, plane_state->crtc);
++	struct ssd130x_crtc_state *ssd130x_crtc_state =  to_ssd130x_crtc_state(crtc_state);
++	struct ssd130x_plane_state *ssd130x_plane_state = to_ssd130x_plane_state(plane_state);
++	struct drm_framebuffer *fb = plane_state->fb;
+ 	struct drm_atomic_helper_damage_iter iter;
+ 	struct drm_device *drm = plane->dev;
+ 	struct drm_rect dst_clip;
+@@ -687,7 +691,9 @@ static void ssd130x_primary_plane_helper_atomic_update(struct drm_plane *plane,
+ 		if (!drm_rect_intersect(&dst_clip, &damage))
+ 			continue;
+ 
+-		ssd130x_fb_blit_rect(plane_state, &shadow_plane_state->data[0], &dst_clip);
++		ssd130x_fb_blit_rect(fb, &shadow_plane_state->data[0], &dst_clip,
++				     ssd130x_plane_state->buffer,
++				     ssd130x_crtc_state->data_array);
+ 	}
+ 
+ 	drm_dev_exit(idx);
+@@ -698,13 +704,21 @@ static void ssd130x_primary_plane_helper_atomic_disable(struct drm_plane *plane,
+ {
+ 	struct drm_device *drm = plane->dev;
+ 	struct ssd130x_device *ssd130x = drm_to_ssd130x(drm);
+-	struct ssd130x_plane_state *ssd130x_state = to_ssd130x_plane_state(plane->state);
++	struct drm_plane_state *plane_state = drm_atomic_get_new_plane_state(state, plane);
++	struct drm_crtc_state *crtc_state;
++	struct ssd130x_crtc_state *ssd130x_crtc_state;
+ 	int idx;
+ 
++	if (!plane_state->crtc)
++		return;
++
++	crtc_state = drm_atomic_get_new_crtc_state(state, plane_state->crtc);
++	ssd130x_crtc_state = to_ssd130x_crtc_state(crtc_state);
++
+ 	if (!drm_dev_enter(drm, &idx))
+ 		return;
+ 
+-	ssd130x_clear_screen(ssd130x, ssd130x_state);
++	ssd130x_clear_screen(ssd130x, ssd130x_crtc_state->data_array);
+ 
+ 	drm_dev_exit(idx);
+ }
+@@ -737,9 +751,8 @@ static struct drm_plane_state *ssd130x_primary_plane_duplicate_state(struct drm_
+ 	if (!ssd130x_state)
+ 		return NULL;
+ 
+-	/* The buffers are not duplicated and are allocated in .atomic_check */
++	/* The buffer is not duplicated and is allocated in .atomic_check */
+ 	ssd130x_state->buffer = NULL;
+-	ssd130x_state->data_array = NULL;
+ 
+ 	new_shadow_plane_state = &ssd130x_state->base;
+ 
+@@ -753,7 +766,6 @@ static void ssd130x_primary_plane_destroy_state(struct drm_plane *plane,
+ {
+ 	struct ssd130x_plane_state *ssd130x_state = to_ssd130x_plane_state(state);
+ 
+-	kfree(ssd130x_state->data_array);
+ 	kfree(ssd130x_state->buffer);
+ 
+ 	__drm_gem_destroy_shadow_plane_state(&ssd130x_state->base);
+@@ -793,6 +805,74 @@ static enum drm_mode_status ssd130x_crtc_helper_mode_valid(struct drm_crtc *crtc
+ 	return MODE_OK;
+ }
+ 
++static int ssd130x_crtc_helper_atomic_check(struct drm_crtc *crtc,
++					    struct drm_atomic_state *state)
++{
++	struct drm_device *drm = crtc->dev;
++	struct ssd130x_device *ssd130x = drm_to_ssd130x(drm);
++	struct drm_crtc_state *crtc_state = drm_atomic_get_new_crtc_state(state, crtc);
++	struct ssd130x_crtc_state *ssd130x_state = to_ssd130x_crtc_state(crtc_state);
++	unsigned int pages = DIV_ROUND_UP(ssd130x->height, SSD130X_PAGE_HEIGHT);
++	int ret;
++
++	ret = drm_crtc_helper_atomic_check(crtc, state);
++	if (ret)
++		return ret;
++
++	ssd130x_state->data_array = kmalloc(ssd130x->width * pages, GFP_KERNEL);
++	if (!ssd130x_state->data_array)
++		return -ENOMEM;
++
++	return 0;
++}
++
++/* Called during init to allocate the CRTC's atomic state. */
++static void ssd130x_crtc_reset(struct drm_crtc *crtc)
++{
++	struct ssd130x_crtc_state *ssd130x_state;
++
++	WARN_ON(crtc->state);
++
++	ssd130x_state = kzalloc(sizeof(*ssd130x_state), GFP_KERNEL);
++	if (!ssd130x_state)
++		return;
++
++	__drm_atomic_helper_crtc_reset(crtc, &ssd130x_state->base);
++}
++
++static struct drm_crtc_state *ssd130x_crtc_duplicate_state(struct drm_crtc *crtc)
++{
++	struct ssd130x_crtc_state *old_ssd130x_state;
++	struct ssd130x_crtc_state *ssd130x_state;
++
++	if (WARN_ON(!crtc->state))
++		return NULL;
++
++	old_ssd130x_state = to_ssd130x_crtc_state(crtc->state);
++	ssd130x_state = kmemdup(old_ssd130x_state, sizeof(*ssd130x_state), GFP_KERNEL);
++	if (!ssd130x_state)
++		return NULL;
++
++	/* The buffer is not duplicated and is allocated in .atomic_check */
++	ssd130x_state->data_array = NULL;
++
++	__drm_atomic_helper_crtc_duplicate_state(crtc, &ssd130x_state->base);
++
++	return &ssd130x_state->base;
++}
++
++static void ssd130x_crtc_destroy_state(struct drm_crtc *crtc,
++				       struct drm_crtc_state *state)
++{
++	struct ssd130x_crtc_state *ssd130x_state = to_ssd130x_crtc_state(state);
++
++	kfree(ssd130x_state->data_array);
++
++	__drm_atomic_helper_crtc_destroy_state(state);
++
++	kfree(ssd130x_state);
++}
++
+ /*
+  * The CRTC is always enabled. Screen updates are performed by
+  * the primary plane's atomic_update function. Disabling clears
+@@ -800,16 +880,16 @@ static enum drm_mode_status ssd130x_crtc_helper_mode_valid(struct drm_crtc *crtc
+  */
+ static const struct drm_crtc_helper_funcs ssd130x_crtc_helper_funcs = {
+ 	.mode_valid = ssd130x_crtc_helper_mode_valid,
+-	.atomic_check = drm_crtc_helper_atomic_check,
++	.atomic_check = ssd130x_crtc_helper_atomic_check,
+ };
+ 
+ static const struct drm_crtc_funcs ssd130x_crtc_funcs = {
+-	.reset = drm_atomic_helper_crtc_reset,
++	.reset = ssd130x_crtc_reset,
+ 	.destroy = drm_crtc_cleanup,
+ 	.set_config = drm_atomic_helper_set_config,
+ 	.page_flip = drm_atomic_helper_page_flip,
+-	.atomic_duplicate_state = drm_atomic_helper_crtc_duplicate_state,
+-	.atomic_destroy_state = drm_atomic_helper_crtc_destroy_state,
++	.atomic_duplicate_state = ssd130x_crtc_duplicate_state,
++	.atomic_destroy_state = ssd130x_crtc_destroy_state,
+ };
+ 
+ static void ssd130x_encoder_helper_atomic_enable(struct drm_encoder *encoder,
+diff --git a/drivers/gpu/drm/solomon/ssd130x.h b/drivers/gpu/drm/solomon/ssd130x.h
+index 87968b3e7fb827..bbe374453605bb 100644
+--- a/drivers/gpu/drm/solomon/ssd130x.h
++++ b/drivers/gpu/drm/solomon/ssd130x.h
+@@ -39,9 +39,8 @@ struct ssd130x_deviceinfo {
+ 	u32 default_dclk_frq;
+ 	u32 default_width;
+ 	u32 default_height;
+-	u32 page_height;
+-	int need_pwm;
+-	int need_chargepump;
++	bool need_pwm;
++	bool need_chargepump;
+ 	bool page_mode_only;
+ };
+ 
+diff --git a/drivers/gpu/drm/tegra/dsi.c b/drivers/gpu/drm/tegra/dsi.c
+index 49fc4690c63af7..e98eb8d0c4d77c 100644
+--- a/drivers/gpu/drm/tegra/dsi.c
++++ b/drivers/gpu/drm/tegra/dsi.c
+@@ -1539,11 +1539,9 @@ static int tegra_dsi_ganged_probe(struct tegra_dsi *dsi)
+ 			return -EPROBE_DEFER;
+ 
+ 		dsi->slave = platform_get_drvdata(gangster);
+-
+-		if (!dsi->slave) {
+-			put_device(&gangster->dev);
++		put_device(&gangster->dev);
++		if (!dsi->slave)
+ 			return -EPROBE_DEFER;
+-		}
+ 
+ 		dsi->slave->master = dsi;
+ 	}
+diff --git a/drivers/gpu/drm/vmwgfx/vmwgfx_execbuf.c b/drivers/gpu/drm/vmwgfx/vmwgfx_execbuf.c
+index 92b3e44d022fea..073791d6962953 100644
+--- a/drivers/gpu/drm/vmwgfx/vmwgfx_execbuf.c
++++ b/drivers/gpu/drm/vmwgfx/vmwgfx_execbuf.c
+@@ -1160,7 +1160,7 @@ static int vmw_translate_mob_ptr(struct vmw_private *dev_priv,
+ 	ret = vmw_user_bo_lookup(sw_context->filp, handle, &vmw_bo);
+ 	if (ret != 0) {
+ 		drm_dbg(&dev_priv->drm, "Could not find or use MOB buffer.\n");
+-		return PTR_ERR(vmw_bo);
++		return ret;
+ 	}
+ 	vmw_bo_placement_set(vmw_bo, VMW_BO_DOMAIN_MOB, VMW_BO_DOMAIN_MOB);
+ 	ret = vmw_validation_add_bo(sw_context->ctx, vmw_bo);
+@@ -1216,7 +1216,7 @@ static int vmw_translate_guest_ptr(struct vmw_private *dev_priv,
+ 	ret = vmw_user_bo_lookup(sw_context->filp, handle, &vmw_bo);
+ 	if (ret != 0) {
+ 		drm_dbg(&dev_priv->drm, "Could not find or use GMR region.\n");
+-		return PTR_ERR(vmw_bo);
++		return ret;
+ 	}
+ 	vmw_bo_placement_set(vmw_bo, VMW_BO_DOMAIN_GMR | VMW_BO_DOMAIN_VRAM,
+ 			     VMW_BO_DOMAIN_GMR | VMW_BO_DOMAIN_VRAM);
+diff --git a/drivers/gpu/drm/vmwgfx/vmwgfx_page_dirty.c b/drivers/gpu/drm/vmwgfx/vmwgfx_page_dirty.c
+index de2498749e276b..5bb710824d72fb 100644
+--- a/drivers/gpu/drm/vmwgfx/vmwgfx_page_dirty.c
++++ b/drivers/gpu/drm/vmwgfx/vmwgfx_page_dirty.c
+@@ -274,6 +274,13 @@ out_no_dirty:
+ 	return ret;
+ }
+ 
++static void vmw_bo_dirty_free(struct kref *kref)
++{
++	struct vmw_bo_dirty *dirty = container_of(kref, struct vmw_bo_dirty, ref_count);
++
++	kvfree(dirty);
++}
++
+ /**
+  * vmw_bo_dirty_release - Release a dirty-tracking user from a buffer object
+  * @vbo: The buffer object
+@@ -288,7 +295,7 @@ void vmw_bo_dirty_release(struct vmw_bo *vbo)
+ {
+ 	struct vmw_bo_dirty *dirty = vbo->dirty;
+ 
+-	if (dirty && kref_put(&dirty->ref_count, (void *)kvfree))
++	if (dirty && kref_put(&dirty->ref_count, vmw_bo_dirty_free))
+ 		vbo->dirty = NULL;
+ }
+ 
+diff --git a/drivers/hid/hid-cmedia.c b/drivers/hid/hid-cmedia.c
+index cab42047bc99be..77607f2c6d519f 100644
+--- a/drivers/hid/hid-cmedia.c
++++ b/drivers/hid/hid-cmedia.c
+@@ -99,7 +99,7 @@ static int cmhid_raw_event(struct hid_device *hid, struct hid_report *report,
+ {
+ 	struct cmhid *cm = hid_get_drvdata(hid);
+ 
+-	if (len != CM6533_JD_RAWEV_LEN)
++	if (len != CM6533_JD_RAWEV_LEN || !(hid->claimed & HID_CLAIMED_INPUT))
+ 		goto out;
+ 	if (memcmp(data+CM6533_JD_SFX_OFFSET, ji_sfx, sizeof(ji_sfx)))
+ 		goto out;
+diff --git a/drivers/hid/hid-creative-sb0540.c b/drivers/hid/hid-creative-sb0540.c
+index b4c8e7a5d3e025..dfd6add353d19a 100644
+--- a/drivers/hid/hid-creative-sb0540.c
++++ b/drivers/hid/hid-creative-sb0540.c
+@@ -153,7 +153,7 @@ static int creative_sb0540_raw_event(struct hid_device *hid,
+ 	u64 code, main_code;
+ 	int key;
+ 
+-	if (len != 6)
++	if (len != 6 || !(hid->claimed & HID_CLAIMED_INPUT))
+ 		return 0;
+ 
+ 	/* From daemons/hw_hiddev.c sb0540_rec() in lirc */
+diff --git a/drivers/hid/hid-zydacron.c b/drivers/hid/hid-zydacron.c
+index 0d003caee113e3..dda1131eab773e 100644
+--- a/drivers/hid/hid-zydacron.c
++++ b/drivers/hid/hid-zydacron.c
+@@ -114,7 +114,7 @@ static int zc_raw_event(struct hid_device *hdev, struct hid_report *report,
+ 	unsigned key;
+ 	unsigned short index;
+ 
+-	if (report->id == data[0]) {
++	if (report->id == data[0] && (hdev->claimed & HID_CLAIMED_INPUT)) {
+ 
+ 		/* break keys */
+ 		for (index = 0; index < 4; index++) {
+diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
+index a4c361b6619c16..2b090dbd836c51 100644
+--- a/drivers/hwmon/Kconfig
++++ b/drivers/hwmon/Kconfig
+@@ -257,12 +257,12 @@ config SENSORS_ADT7475
+ 	  will be called adt7475.
+ 
+ config SENSORS_AHT10
+-	tristate "Aosong AHT10, AHT20"
++	tristate "Aosong AHT10, AHT20, DHT20"
+ 	depends on I2C
+ 	select CRC8
+ 	help
+-	  If you say yes here, you get support for the Aosong AHT10 and AHT20
+-	  temperature and humidity sensors
++	  If you say yes here, you get support for the Aosong AHT10, AHT20 and
++	  DHT20 temperature and humidity sensors
+ 
+ 	  This driver can also be built as a module. If so, the module
+ 	  will be called aht10.
+diff --git a/drivers/hwmon/aht10.c b/drivers/hwmon/aht10.c
+index f136bf3ff40adf..aa116957d9c962 100644
+--- a/drivers/hwmon/aht10.c
++++ b/drivers/hwmon/aht10.c
+@@ -37,6 +37,10 @@
+ #define AHT10_CMD_MEAS	0b10101100
+ #define AHT10_CMD_RST	0b10111010
+ 
++#define AHT20_CMD_INIT	0b10111110
++
++#define DHT20_CMD_INIT	0b01110001
++
+ /*
+  * Flags in the answer byte/command
+  */
+@@ -48,11 +52,12 @@
+ 
+ #define AHT10_MAX_POLL_INTERVAL_LEN	30
+ 
+-enum aht10_variant { aht10, aht20 };
++enum aht10_variant { aht10, aht20, dht20};
+ 
+ static const struct i2c_device_id aht10_id[] = {
+ 	{ "aht10", aht10 },
+ 	{ "aht20", aht20 },
++	{ "dht20", dht20 },
+ 	{ },
+ };
+ MODULE_DEVICE_TABLE(i2c, aht10_id);
+@@ -77,6 +82,7 @@ MODULE_DEVICE_TABLE(i2c, aht10_id);
+  *              AHT10/AHT20
+  *   @crc8: crc8 support flag
+  *   @meas_size: measurements data size
++ *   @init_cmd: Initialization command
+  */
+ 
+ struct aht10_data {
+@@ -92,6 +98,7 @@ struct aht10_data {
+ 	int humidity;
+ 	bool crc8;
+ 	unsigned int meas_size;
++	u8 init_cmd;
+ };
+ 
+ /**
+@@ -101,13 +108,13 @@ struct aht10_data {
+  */
+ static int aht10_init(struct aht10_data *data)
+ {
+-	const u8 cmd_init[] = {AHT10_CMD_INIT, AHT10_CAL_ENABLED | AHT10_MODE_CYC,
++	const u8 cmd_init[] = {data->init_cmd, AHT10_CAL_ENABLED | AHT10_MODE_CYC,
+ 			       0x00};
+ 	int res;
+ 	u8 status;
+ 	struct i2c_client *client = data->client;
+ 
+-	res = i2c_master_send(client, cmd_init, 3);
++	res = i2c_master_send(client, cmd_init, sizeof(cmd_init));
+ 	if (res < 0)
+ 		return res;
+ 
+@@ -353,9 +360,17 @@ static int aht10_probe(struct i2c_client *client)
+ 		data->meas_size = AHT20_MEAS_SIZE;
+ 		data->crc8 = true;
+ 		crc8_populate_msb(crc8_table, AHT20_CRC8_POLY);
++		data->init_cmd = AHT20_CMD_INIT;
++		break;
++	case dht20:
++		data->meas_size = AHT20_MEAS_SIZE;
++		data->crc8 = true;
++		crc8_populate_msb(crc8_table, AHT20_CRC8_POLY);
++		data->init_cmd = DHT20_CMD_INIT;
+ 		break;
+ 	default:
+ 		data->meas_size = AHT10_MEAS_SIZE;
++		data->init_cmd = AHT10_CMD_INIT;
+ 		break;
+ 	}
+ 
+diff --git a/drivers/hwmon/it87.c b/drivers/hwmon/it87.c
+index fbe86cec605538..51882f7386cc81 100644
+--- a/drivers/hwmon/it87.c
++++ b/drivers/hwmon/it87.c
+@@ -3547,10 +3547,13 @@ static int it87_resume(struct device *dev)
+ {
+ 	struct platform_device *pdev = to_platform_device(dev);
+ 	struct it87_data *data = dev_get_drvdata(dev);
++	int err;
+ 
+ 	it87_resume_sio(pdev);
+ 
+-	it87_lock(data);
++	err = it87_lock(data);
++	if (err)
++		return err;
+ 
+ 	it87_check_pwm(dev);
+ 	it87_check_limit_regs(data);
+diff --git a/drivers/hwmon/max16065.c b/drivers/hwmon/max16065.c
+index 4c9e7892a73c1b..43fbb9b26b102b 100644
+--- a/drivers/hwmon/max16065.c
++++ b/drivers/hwmon/max16065.c
+@@ -151,27 +151,27 @@ static struct max16065_data *max16065_update_device(struct device *dev)
+ 		int i;
+ 
+ 		for (i = 0; i < data->num_adc; i++)
+-			data->adc[i]
+-			  = max16065_read_adc(client, MAX16065_ADC(i));
++			WRITE_ONCE(data->adc[i],
++				   max16065_read_adc(client, MAX16065_ADC(i)));
+ 
+ 		if (data->have_current) {
+-			data->adc[MAX16065_NUM_ADC]
+-			  = max16065_read_adc(client, MAX16065_CSP_ADC);
+-			data->curr_sense
+-			  = i2c_smbus_read_byte_data(client,
+-						     MAX16065_CURR_SENSE);
++			WRITE_ONCE(data->adc[MAX16065_NUM_ADC],
++				   max16065_read_adc(client, MAX16065_CSP_ADC));
++			WRITE_ONCE(data->curr_sense,
++				   i2c_smbus_read_byte_data(client, MAX16065_CURR_SENSE));
+ 		}
+ 
+ 		for (i = 0; i < 2; i++)
+-			data->fault[i]
+-			  = i2c_smbus_read_byte_data(client, MAX16065_FAULT(i));
++			WRITE_ONCE(data->fault[i],
++				   i2c_smbus_read_byte_data(client, MAX16065_FAULT(i)));
+ 
+ 		/*
+ 		 * MAX16067 and MAX16068 have separate undervoltage and
+ 		 * overvoltage alarm bits. Squash them together.
+ 		 */
+ 		if (data->chip == max16067 || data->chip == max16068)
+-			data->fault[0] |= data->fault[1];
++			WRITE_ONCE(data->fault[0],
++				   data->fault[0] | data->fault[1]);
+ 
+ 		data->last_updated = jiffies;
+ 		data->valid = true;
+@@ -185,7 +185,7 @@ static ssize_t max16065_alarm_show(struct device *dev,
+ {
+ 	struct sensor_device_attribute_2 *attr2 = to_sensor_dev_attr_2(da);
+ 	struct max16065_data *data = max16065_update_device(dev);
+-	int val = data->fault[attr2->nr];
++	int val = READ_ONCE(data->fault[attr2->nr]);
+ 
+ 	if (val < 0)
+ 		return val;
+@@ -203,7 +203,7 @@ static ssize_t max16065_input_show(struct device *dev,
+ {
+ 	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+ 	struct max16065_data *data = max16065_update_device(dev);
+-	int adc = data->adc[attr->index];
++	int adc = READ_ONCE(data->adc[attr->index]);
+ 
+ 	if (unlikely(adc < 0))
+ 		return adc;
+@@ -216,7 +216,7 @@ static ssize_t max16065_current_show(struct device *dev,
+ 				     struct device_attribute *da, char *buf)
+ {
+ 	struct max16065_data *data = max16065_update_device(dev);
+-	int curr_sense = data->curr_sense;
++	int curr_sense = READ_ONCE(data->curr_sense);
+ 
+ 	if (unlikely(curr_sense < 0))
+ 		return curr_sense;
+diff --git a/drivers/hwmon/pmbus/isl68137.c b/drivers/hwmon/pmbus/isl68137.c
+index 7e53fb1d5ea303..f1cf3c9666df30 100644
+--- a/drivers/hwmon/pmbus/isl68137.c
++++ b/drivers/hwmon/pmbus/isl68137.c
+@@ -80,8 +80,11 @@ static ssize_t isl68137_avs_enable_show_page(struct i2c_client *client,
+ {
+ 	int val = pmbus_read_byte_data(client, page, PMBUS_OPERATION);
+ 
+-	return sprintf(buf, "%d\n",
+-		       (val & ISL68137_VOUT_AVS) == ISL68137_VOUT_AVS ? 1 : 0);
++	if (val < 0)
++		return val;
++
++	return sysfs_emit(buf, "%d\n",
++			   (val & ISL68137_VOUT_AVS) == ISL68137_VOUT_AVS);
+ }
+ 
+ static ssize_t isl68137_avs_enable_store_page(struct i2c_client *client,
+diff --git a/drivers/hwmon/pmbus/mp2975.c b/drivers/hwmon/pmbus/mp2975.c
+index b9bb469e2d8feb..c8e5b150da55a4 100644
+--- a/drivers/hwmon/pmbus/mp2975.c
++++ b/drivers/hwmon/pmbus/mp2975.c
+@@ -300,6 +300,8 @@ static int mp2973_read_word_data(struct i2c_client *client, int page,
+ 	case PMBUS_STATUS_WORD:
+ 		/* MP2973 & MP2971 return PGOOD instead of PB_STATUS_POWER_GOOD_N. */
+ 		ret = pmbus_read_word_data(client, page, phase, reg);
++		if (ret < 0)
++			return ret;
+ 		ret ^= PB_STATUS_POWER_GOOD_N;
+ 		break;
+ 	case PMBUS_OT_FAULT_LIMIT:
+diff --git a/drivers/hwmon/pmbus/q54sj108a2.c b/drivers/hwmon/pmbus/q54sj108a2.c
+index a235c1cdf4fec5..d9fd1095ae7ee0 100644
+--- a/drivers/hwmon/pmbus/q54sj108a2.c
++++ b/drivers/hwmon/pmbus/q54sj108a2.c
+@@ -78,7 +78,8 @@ static ssize_t q54sj108a2_debugfs_read(struct file *file, char __user *buf,
+ 	int idx = *idxp;
+ 	struct q54sj108a2_data *psu = to_psu(idxp, idx);
+ 	char data[I2C_SMBUS_BLOCK_MAX + 2] = { 0 };
+-	char data_char[I2C_SMBUS_BLOCK_MAX + 2] = { 0 };
++	char data_char[I2C_SMBUS_BLOCK_MAX * 2 + 2] = { 0 };
++	char *out = data;
+ 	char *res;
+ 
+ 	switch (idx) {
+@@ -149,27 +150,27 @@ static ssize_t q54sj108a2_debugfs_read(struct file *file, char __user *buf,
+ 		if (rc < 0)
+ 			return rc;
+ 
+-		res = bin2hex(data, data_char, 32);
+-		rc = res - data;
+-
++		res = bin2hex(data_char, data, rc);
++		rc = res - data_char;
++		out = data_char;
+ 		break;
+ 	case Q54SJ108A2_DEBUGFS_FLASH_KEY:
+ 		rc = i2c_smbus_read_block_data(psu->client, PMBUS_FLASH_KEY_WRITE, data);
+ 		if (rc < 0)
+ 			return rc;
+ 
+-		res = bin2hex(data, data_char, 4);
+-		rc = res - data;
+-
++		res = bin2hex(data_char, data, rc);
++		rc = res - data_char;
++		out = data_char;
+ 		break;
+ 	default:
+ 		return -EINVAL;
+ 	}
+ 
+-	data[rc] = '\n';
++	out[rc] = '\n';
+ 	rc += 2;
+ 
+-	return simple_read_from_buffer(buf, count, ppos, data, rc);
++	return simple_read_from_buffer(buf, count, ppos, out, rc);
+ }
+ 
+ static ssize_t q54sj108a2_debugfs_write(struct file *file, const char __user *buf,
+diff --git a/drivers/i2c/busses/i2c-cp2615.c b/drivers/i2c/busses/i2c-cp2615.c
+index 3ded28632e4c1d..8e17f32d38c06a 100644
+--- a/drivers/i2c/busses/i2c-cp2615.c
++++ b/drivers/i2c/busses/i2c-cp2615.c
+@@ -298,7 +298,10 @@ cp2615_i2c_probe(struct usb_interface *usbif, const struct usb_device_id *id)
+ 	if (!adap)
+ 		return -ENOMEM;
+ 
+-	strncpy(adap->name, usbdev->serial, sizeof(adap->name) - 1);
++	if (!usbdev->serial)
++		return -EINVAL;
++
++	strscpy(adap->name, usbdev->serial, sizeof(adap->name));
+ 	adap->owner = THIS_MODULE;
+ 	adap->dev.parent = &usbif->dev;
+ 	adap->dev.of_node = usbif->dev.of_node;
+diff --git a/drivers/i2c/busses/i2c-fsi.c b/drivers/i2c/busses/i2c-fsi.c
+index 10332693edf0d9..70bf03af377789 100644
+--- a/drivers/i2c/busses/i2c-fsi.c
++++ b/drivers/i2c/busses/i2c-fsi.c
+@@ -728,6 +728,7 @@ static int fsi_i2c_probe(struct device *dev)
+ 		rc = i2c_add_adapter(&port->adapter);
+ 		if (rc < 0) {
+ 			dev_err(dev, "Failed to register adapter: %d\n", rc);
++			of_node_put(np);
+ 			kfree(port);
+ 			continue;
+ 		}
+diff --git a/drivers/i2c/busses/i2c-pxa.c b/drivers/i2c/busses/i2c-pxa.c
+index affdd94f06aaf0..0a63e5d5eefe01 100644
+--- a/drivers/i2c/busses/i2c-pxa.c
++++ b/drivers/i2c/busses/i2c-pxa.c
+@@ -267,6 +267,7 @@ struct pxa_i2c {
+ 	struct pinctrl		*pinctrl;
+ 	struct pinctrl_state	*pinctrl_default;
+ 	struct pinctrl_state	*pinctrl_recovery;
++	bool			reset_before_xfer;
+ };
+ 
+ #define _IBMR(i2c)	((i2c)->reg_ibmr)
+@@ -1143,6 +1144,11 @@ static int i2c_pxa_xfer(struct i2c_adapter *adap,
+ {
+ 	struct pxa_i2c *i2c = adap->algo_data;
+ 
++	if (i2c->reset_before_xfer) {
++		i2c_pxa_reset(i2c);
++		i2c->reset_before_xfer = false;
++	}
++
+ 	return i2c_pxa_internal_xfer(i2c, msgs, num, i2c_pxa_do_xfer);
+ }
+ 
+@@ -1522,7 +1528,16 @@ static int i2c_pxa_probe(struct platform_device *dev)
+ 		}
+ 	}
+ 
+-	i2c_pxa_reset(i2c);
++	/*
++	 * Skip reset on Armada 3700 when recovery is used to avoid
++	 * controller hang due to the pinctrl state changes done by
++	 * the generic recovery initialization code. The reset will
++	 * be performed later, prior to the first transfer.
++	 */
++	if (i2c_type == REGS_A3700 && i2c->adap.bus_recovery_info)
++		i2c->reset_before_xfer = true;
++	else
++		i2c_pxa_reset(i2c);
+ 
+ 	ret = i2c_add_numbered_adapter(&i2c->adap);
+ 	if (ret < 0)
+diff --git a/drivers/i3c/master/dw-i3c-master.c b/drivers/i3c/master/dw-i3c-master.c
+index cee2805fccd0f8..ccb521bcb73e33 100644
+--- a/drivers/i3c/master/dw-i3c-master.c
++++ b/drivers/i3c/master/dw-i3c-master.c
+@@ -941,7 +941,7 @@ static int dw_i3c_master_reattach_i3c_dev(struct i3c_dev_desc *dev,
+ 		master->free_pos &= ~BIT(pos);
+ 	}
+ 
+-	writel(DEV_ADDR_TABLE_DYNAMIC_ADDR(dev->info.dyn_addr),
++	writel(DEV_ADDR_TABLE_DYNAMIC_ADDR(dev->info.dyn_addr) | DEV_ADDR_TABLE_SIR_REJECT,
+ 	       master->regs +
+ 	       DEV_ADDR_TABLE_LOC(master->datstartaddr, data->index));
+ 
+@@ -970,7 +970,7 @@ static int dw_i3c_master_attach_i3c_dev(struct i3c_dev_desc *dev)
+ 	master->free_pos &= ~BIT(pos);
+ 	i3c_dev_set_master_data(dev, data);
+ 
+-	writel(DEV_ADDR_TABLE_DYNAMIC_ADDR(master->devs[pos].addr),
++	writel(DEV_ADDR_TABLE_DYNAMIC_ADDR(master->devs[pos].addr) | DEV_ADDR_TABLE_SIR_REJECT,
+ 	       master->regs +
+ 	       DEV_ADDR_TABLE_LOC(master->datstartaddr, data->index));
+ 
+diff --git a/drivers/i3c/master/mipi-i3c-hci/cmd.h b/drivers/i3c/master/mipi-i3c-hci/cmd.h
+index 1d6dd2c5d01a53..b1bf87daa65166 100644
+--- a/drivers/i3c/master/mipi-i3c-hci/cmd.h
++++ b/drivers/i3c/master/mipi-i3c-hci/cmd.h
+@@ -17,6 +17,7 @@
+ #define CMD_0_TOC			W0_BIT_(31)
+ #define CMD_0_ROC			W0_BIT_(30)
+ #define CMD_0_ATTR			W0_MASK(2, 0)
++#define CMD_0_TID			W0_MASK(6, 3)
+ 
+ /*
+  * Response Descriptor Structure
+diff --git a/drivers/i3c/master/mipi-i3c-hci/cmd_v1.c b/drivers/i3c/master/mipi-i3c-hci/cmd_v1.c
+index 6a781f89b0e406..b5a5e7202e57a6 100644
+--- a/drivers/i3c/master/mipi-i3c-hci/cmd_v1.c
++++ b/drivers/i3c/master/mipi-i3c-hci/cmd_v1.c
+@@ -335,7 +335,7 @@ static int hci_cmd_v1_daa(struct i3c_hci *hci)
+ 		hci->io->queue_xfer(hci, xfer, 1);
+ 		if (!wait_for_completion_timeout(&done, HZ) &&
+ 		    hci->io->dequeue_xfer(hci, xfer, 1)) {
+-			ret = -ETIME;
++			ret = -ETIMEDOUT;
+ 			break;
+ 		}
+ 		if (RESP_STATUS(xfer[0].response) == RESP_ERR_NACK &&
+diff --git a/drivers/i3c/master/mipi-i3c-hci/cmd_v2.c b/drivers/i3c/master/mipi-i3c-hci/cmd_v2.c
+index 4493b2b067cbce..3d33bfe937a6ac 100644
+--- a/drivers/i3c/master/mipi-i3c-hci/cmd_v2.c
++++ b/drivers/i3c/master/mipi-i3c-hci/cmd_v2.c
+@@ -277,7 +277,7 @@ static int hci_cmd_v2_daa(struct i3c_hci *hci)
+ 		hci->io->queue_xfer(hci, xfer, 2);
+ 		if (!wait_for_completion_timeout(&done, HZ) &&
+ 		    hci->io->dequeue_xfer(hci, xfer, 2)) {
+-			ret = -ETIME;
++			ret = -ETIMEDOUT;
+ 			break;
+ 		}
+ 		if (RESP_STATUS(xfer[0].response) != RESP_SUCCESS) {
+diff --git a/drivers/i3c/master/mipi-i3c-hci/core.c b/drivers/i3c/master/mipi-i3c-hci/core.c
+index 837af83c85f4ed..8bceced3c305e9 100644
+--- a/drivers/i3c/master/mipi-i3c-hci/core.c
++++ b/drivers/i3c/master/mipi-i3c-hci/core.c
+@@ -237,7 +237,7 @@ static int i3c_hci_send_ccc_cmd(struct i3c_master_controller *m,
+ 		goto out;
+ 	if (!wait_for_completion_timeout(&done, HZ) &&
+ 	    hci->io->dequeue_xfer(hci, xfer, nxfers)) {
+-		ret = -ETIME;
++		ret = -ETIMEDOUT;
+ 		goto out;
+ 	}
+ 	for (i = prefixed; i < nxfers; i++) {
+@@ -311,7 +311,7 @@ static int i3c_hci_priv_xfers(struct i3c_dev_desc *dev,
+ 		goto out;
+ 	if (!wait_for_completion_timeout(&done, HZ) &&
+ 	    hci->io->dequeue_xfer(hci, xfer, nxfers)) {
+-		ret = -ETIME;
++		ret = -ETIMEDOUT;
+ 		goto out;
+ 	}
+ 	for (i = 0; i < nxfers; i++) {
+@@ -359,7 +359,7 @@ static int i3c_hci_i2c_xfers(struct i2c_dev_desc *dev,
+ 		goto out;
+ 	if (!wait_for_completion_timeout(&done, HZ) &&
+ 	    hci->io->dequeue_xfer(hci, xfer, nxfers)) {
+-		ret = -ETIME;
++		ret = -ETIMEDOUT;
+ 		goto out;
+ 	}
+ 	for (i = 0; i < nxfers; i++) {
+diff --git a/drivers/i3c/master/mipi-i3c-hci/dma.c b/drivers/i3c/master/mipi-i3c-hci/dma.c
+index bcc0c7d4131f26..e270fcd0f7c387 100644
+--- a/drivers/i3c/master/mipi-i3c-hci/dma.c
++++ b/drivers/i3c/master/mipi-i3c-hci/dma.c
+@@ -473,7 +473,7 @@ static bool hci_dma_dequeue_xfer(struct i3c_hci *hci,
+ 			u32 *ring_data = rh->xfer + rh->xfer_struct_sz * idx;
+ 
+ 			/* store no-op cmd descriptor */
+-			*ring_data++ = FIELD_PREP(CMD_0_ATTR, 0x7);
++			*ring_data++ = FIELD_PREP(CMD_0_ATTR, 0x7) | FIELD_PREP(CMD_0_TID, xfer->cmd_tid);
+ 			*ring_data++ = 0;
+ 			if (hci->cmd == &mipi_i3c_hci_cmd_v2) {
+ 				*ring_data++ = 0;
+@@ -491,7 +491,9 @@ static bool hci_dma_dequeue_xfer(struct i3c_hci *hci,
+ 	}
+ 
+ 	/* restart the ring */
++	mipi_i3c_hci_resume(hci);
+ 	rh_reg_write(RING_CONTROL, RING_CTRL_ENABLE);
++	rh_reg_write(RING_CONTROL, RING_CTRL_ENABLE | RING_CTRL_RUN_STOP);
+ 
+ 	return did_unqueue;
+ }
+diff --git a/drivers/iio/chemical/bme680_core.c b/drivers/iio/chemical/bme680_core.c
+index a6bf689833dad7..4f61ae934ef517 100644
+--- a/drivers/iio/chemical/bme680_core.c
++++ b/drivers/iio/chemical/bme680_core.c
+@@ -550,7 +550,7 @@ static int bme680_wait_for_eoc(struct bme680_data *data)
+ 	 * + heater duration
+ 	 */
+ 	int wait_eoc_us = ((data->oversampling_temp + data->oversampling_press +
+-			   data->oversampling_humid) * 1936) + (477 * 4) +
++			   data->oversampling_humid) * 1963) + (477 * 4) +
+ 			   (477 * 5) + 1000 + (data->heater_dur * 1000);
+ 
+ 	usleep_range(wait_eoc_us, wait_eoc_us + 100);
+diff --git a/drivers/iio/chemical/sps30_i2c.c b/drivers/iio/chemical/sps30_i2c.c
+index 5c31299813ecf9..bd5be88c5771ec 100644
+--- a/drivers/iio/chemical/sps30_i2c.c
++++ b/drivers/iio/chemical/sps30_i2c.c
+@@ -171,7 +171,7 @@ static int sps30_i2c_read_meas(struct sps30_state *state, __be32 *meas, size_t n
+ 	if (!sps30_i2c_meas_ready(state))
+ 		return -ETIMEDOUT;
+ 
+-	return sps30_i2c_command(state, SPS30_I2C_READ_MEAS, NULL, 0, meas, sizeof(num) * num);
++	return sps30_i2c_command(state, SPS30_I2C_READ_MEAS, NULL, 0, meas, sizeof(*meas) * num);
+ }
+ 
+ static int sps30_i2c_clean_fan(struct sps30_state *state)
+diff --git a/drivers/iio/chemical/sps30_serial.c b/drivers/iio/chemical/sps30_serial.c
+index 164f4b3e025c94..59674a4247633b 100644
+--- a/drivers/iio/chemical/sps30_serial.c
++++ b/drivers/iio/chemical/sps30_serial.c
+@@ -303,7 +303,7 @@ static int sps30_serial_read_meas(struct sps30_state *state, __be32 *meas, size_
+ 	if (msleep_interruptible(1000))
+ 		return -EINTR;
+ 
+-	ret = sps30_serial_command(state, SPS30_SERIAL_READ_MEAS, NULL, 0, meas, num * sizeof(num));
++	ret = sps30_serial_command(state, SPS30_SERIAL_READ_MEAS, NULL, 0, meas, num * sizeof(*meas));
+ 	if (ret < 0)
+ 		return ret;
+ 	/* if measurements aren't ready sensor returns empty frame */
+diff --git a/drivers/iio/dac/ds4424.c b/drivers/iio/dac/ds4424.c
+index e89e4c0546531f..de47407c5f447e 100644
+--- a/drivers/iio/dac/ds4424.c
++++ b/drivers/iio/dac/ds4424.c
+@@ -141,7 +141,7 @@ static int ds4424_write_raw(struct iio_dev *indio_dev,
+ 
+ 	switch (mask) {
+ 	case IIO_CHAN_INFO_RAW:
+-		if (val < S8_MIN || val > S8_MAX)
++		if (val <= S8_MIN || val > S8_MAX)
+ 			return -EINVAL;
+ 
+ 		if (val > 0) {
+diff --git a/drivers/iio/frequency/adf4377.c b/drivers/iio/frequency/adf4377.c
+index 26abecbd51e066..15759735a8493d 100644
+--- a/drivers/iio/frequency/adf4377.c
++++ b/drivers/iio/frequency/adf4377.c
+@@ -495,7 +495,7 @@ static int adf4377_soft_reset(struct adf4377_state *st)
+ 		return ret;
+ 
+ 	return regmap_read_poll_timeout(st->regmap, 0x0, read_val,
+-					!(read_val & (ADF4377_0000_SOFT_RESET_R_MSK |
++					!(read_val & (ADF4377_0000_SOFT_RESET_MSK |
+ 					ADF4377_0000_SOFT_RESET_R_MSK)), 200, 200 * 100);
+ }
+ 
+diff --git a/drivers/iio/gyro/mpu3050-core.c b/drivers/iio/gyro/mpu3050-core.c
+index de126561f197d8..b50c62412d2050 100644
+--- a/drivers/iio/gyro/mpu3050-core.c
++++ b/drivers/iio/gyro/mpu3050-core.c
+@@ -322,7 +322,9 @@ static int mpu3050_read_raw(struct iio_dev *indio_dev,
+ 		}
+ 	case IIO_CHAN_INFO_RAW:
+ 		/* Resume device */
+-		pm_runtime_get_sync(mpu3050->dev);
++		ret = pm_runtime_resume_and_get(mpu3050->dev);
++		if (ret)
++			return ret;
+ 		mutex_lock(&mpu3050->lock);
+ 
+ 		ret = mpu3050_set_8khz_samplerate(mpu3050);
+@@ -651,14 +653,20 @@ out_trigger_unlock:
+ static int mpu3050_buffer_preenable(struct iio_dev *indio_dev)
+ {
+ 	struct mpu3050 *mpu3050 = iio_priv(indio_dev);
++	int ret;
+ 
+-	pm_runtime_get_sync(mpu3050->dev);
++	ret = pm_runtime_resume_and_get(mpu3050->dev);
++	if (ret)
++		return ret;
+ 
+ 	/* Unless we have OUR trigger active, run at full speed */
+-	if (!mpu3050->hw_irq_trigger)
+-		return mpu3050_set_8khz_samplerate(mpu3050);
++	if (!mpu3050->hw_irq_trigger) {
++		ret = mpu3050_set_8khz_samplerate(mpu3050);
++		if (ret)
++			pm_runtime_put_autosuspend(mpu3050->dev);
++	}
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ static int mpu3050_buffer_postdisable(struct iio_dev *indio_dev)
+diff --git a/drivers/iio/gyro/mpu3050-i2c.c b/drivers/iio/gyro/mpu3050-i2c.c
+index 52b6feed26379a..49a8b83956a948 100644
+--- a/drivers/iio/gyro/mpu3050-i2c.c
++++ b/drivers/iio/gyro/mpu3050-i2c.c
+@@ -19,8 +19,7 @@ static int mpu3050_i2c_bypass_select(struct i2c_mux_core *mux, u32 chan_id)
+ 	struct mpu3050 *mpu3050 = i2c_mux_priv(mux);
+ 
+ 	/* Just power up the device, that is all that is needed */
+-	pm_runtime_get_sync(mpu3050->dev);
+-	return 0;
++	return pm_runtime_resume_and_get(mpu3050->dev);
+ }
+ 
+ static int mpu3050_i2c_bypass_deselect(struct i2c_mux_core *mux, u32 chan_id)
+diff --git a/drivers/iio/imu/inv_icm42600/inv_icm42600_accel.c b/drivers/iio/imu/inv_icm42600/inv_icm42600_accel.c
+index a4155939e9567b..f8c5d87f92c5f4 100644
+--- a/drivers/iio/imu/inv_icm42600/inv_icm42600_accel.c
++++ b/drivers/iio/imu/inv_icm42600/inv_icm42600_accel.c
+@@ -321,6 +321,8 @@ static int inv_icm42600_accel_write_odr(struct iio_dev *indio_dev,
+ 		return -EINVAL;
+ 
+ 	conf.odr = inv_icm42600_accel_odr_conv[idx / 2];
++	if (conf.odr == st->conf.accel.odr)
++		return 0;
+ 
+ 	pm_runtime_get_sync(dev);
+ 	mutex_lock(&st->lock);
+diff --git a/drivers/iio/imu/inv_icm42600/inv_icm42600_gyro.c b/drivers/iio/imu/inv_icm42600/inv_icm42600_gyro.c
+index 9ee26478b666be..4af1fc9395b801 100644
+--- a/drivers/iio/imu/inv_icm42600/inv_icm42600_gyro.c
++++ b/drivers/iio/imu/inv_icm42600/inv_icm42600_gyro.c
+@@ -333,6 +333,8 @@ static int inv_icm42600_gyro_write_odr(struct iio_dev *indio_dev,
+ 		return -EINVAL;
+ 
+ 	conf.odr = inv_icm42600_gyro_odr_conv[idx / 2];
++	if (conf.odr == st->conf.gyro.odr)
++		return 0;
+ 
+ 	pm_runtime_get_sync(dev);
+ 	mutex_lock(&st->lock);
+diff --git a/drivers/iio/industrialio-buffer.c b/drivers/iio/industrialio-buffer.c
+index 176d31d9f9d807..fc04c55da6c789 100644
+--- a/drivers/iio/industrialio-buffer.c
++++ b/drivers/iio/industrialio-buffer.c
+@@ -194,8 +194,10 @@ static ssize_t iio_buffer_write(struct file *filp, const char __user *buf,
+ 	written = 0;
+ 	add_wait_queue(&rb->pollq, &wait);
+ 	do {
+-		if (!indio_dev->info)
+-			return -ENODEV;
++		if (!indio_dev->info) {
++			ret = -ENODEV;
++			break;
++		}
+ 
+ 		if (!iio_buffer_space_available(rb)) {
+ 			if (signal_pending(current)) {
+diff --git a/drivers/iio/light/bh1780.c b/drivers/iio/light/bh1780.c
+index b84166c5fa06ee..f6b0b2fc4ecfcb 100644
+--- a/drivers/iio/light/bh1780.c
++++ b/drivers/iio/light/bh1780.c
+@@ -109,10 +109,10 @@ static int bh1780_read_raw(struct iio_dev *indio_dev,
+ 		case IIO_LIGHT:
+ 			pm_runtime_get_sync(&bh1780->client->dev);
+ 			value = bh1780_read_word(bh1780, BH1780_REG_DLOW);
+-			if (value < 0)
+-				return value;
+ 			pm_runtime_mark_last_busy(&bh1780->client->dev);
+ 			pm_runtime_put_autosuspend(&bh1780->client->dev);
++			if (value < 0)
++				return value;
+ 			*val = value;
+ 
+ 			return IIO_VAL_INT;
+diff --git a/drivers/iio/potentiometer/mcp4131.c b/drivers/iio/potentiometer/mcp4131.c
+index 7890c0993ec48e..0204b7629d20a0 100644
+--- a/drivers/iio/potentiometer/mcp4131.c
++++ b/drivers/iio/potentiometer/mcp4131.c
+@@ -222,7 +222,7 @@ static int mcp4131_write_raw(struct iio_dev *indio_dev,
+ 
+ 	mutex_lock(&data->lock);
+ 
+-	data->buf[0] = address << MCP4131_WIPER_SHIFT;
++	data->buf[0] = address;
+ 	data->buf[0] |= MCP4131_WRITE | (val >> 8);
+ 	data->buf[1] = val & 0xFF; /* 8 bits here */
+ 
+diff --git a/drivers/infiniband/hw/irdma/verbs.c b/drivers/infiniband/hw/irdma/verbs.c
+index b52e0716d23fc3..3b0050e594fdf4 100644
+--- a/drivers/infiniband/hw/irdma/verbs.c
++++ b/drivers/infiniband/hw/irdma/verbs.c
+@@ -4588,7 +4588,7 @@ static int irdma_create_user_ah(struct ib_ah *ibah,
+ #define IRDMA_CREATE_AH_MIN_RESP_LEN offsetofend(struct irdma_create_ah_resp, rsvd)
+ 	struct irdma_ah *ah = container_of(ibah, struct irdma_ah, ibah);
+ 	struct irdma_device *iwdev = to_iwdev(ibah->pd->device);
+-	struct irdma_create_ah_resp uresp;
++	struct irdma_create_ah_resp uresp = {};
+ 	struct irdma_ah *parent_ah;
+ 	int err;
+ 
+diff --git a/drivers/infiniband/hw/mthca/mthca_provider.c b/drivers/infiniband/hw/mthca/mthca_provider.c
+index e1325f2927d6e3..714253b5bbe620 100644
+--- a/drivers/infiniband/hw/mthca/mthca_provider.c
++++ b/drivers/infiniband/hw/mthca/mthca_provider.c
+@@ -428,6 +428,8 @@ static int mthca_create_srq(struct ib_srq *ibsrq,
+ 
+ 	if (context && ib_copy_to_udata(udata, &srq->srqn, sizeof(__u32))) {
+ 		mthca_free_srq(to_mdev(ibsrq->device), srq);
++		mthca_unmap_user_db(to_mdev(ibsrq->device), &context->uar,
++				    context->db_tab, ucmd.db_index);
+ 		return -EFAULT;
+ 	}
+ 
+@@ -436,6 +438,7 @@ static int mthca_create_srq(struct ib_srq *ibsrq,
+ 
+ static int mthca_destroy_srq(struct ib_srq *srq, struct ib_udata *udata)
+ {
++	mthca_free_srq(to_mdev(srq->device), to_msrq(srq));
+ 	if (udata) {
+ 		struct mthca_ucontext *context =
+ 			rdma_udata_to_drv_context(
+@@ -446,8 +449,6 @@ static int mthca_destroy_srq(struct ib_srq *srq, struct ib_udata *udata)
+ 		mthca_unmap_user_db(to_mdev(srq->device), &context->uar,
+ 				    context->db_tab, to_msrq(srq)->db_index);
+ 	}
+-
+-	mthca_free_srq(to_mdev(srq->device), to_msrq(srq));
+ 	return 0;
+ }
+ 
+diff --git a/drivers/iommu/intel/dmar.c b/drivers/iommu/intel/dmar.c
+index 7a38e18b18196b..8358869e03d682 100644
+--- a/drivers/iommu/intel/dmar.c
++++ b/drivers/iommu/intel/dmar.c
+@@ -1309,7 +1309,6 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
+ 	if (fault & DMA_FSTS_ITE) {
+ 		head = readl(iommu->reg + DMAR_IQH_REG);
+ 		head = ((head >> shift) - 1 + QI_LENGTH) % QI_LENGTH;
+-		head |= 1;
+ 		tail = readl(iommu->reg + DMAR_IQT_REG);
+ 		tail = ((tail >> shift) - 1 + QI_LENGTH) % QI_LENGTH;
+ 
+@@ -1319,7 +1318,7 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
+ 		do {
+ 			if (qi->desc_status[head] == QI_IN_USE)
+ 				qi->desc_status[head] = QI_ABORT;
+-			head = (head - 2 + QI_LENGTH) % QI_LENGTH;
++			head = (head - 1 + QI_LENGTH) % QI_LENGTH;
+ 		} while (head != tail);
+ 
+ 		if (qi->desc_status[wait_index] == QI_ABORT)
+diff --git a/drivers/irqchip/irq-gic-v3-its.c b/drivers/irqchip/irq-gic-v3-its.c
+index 91a2bcec1156a2..840108727b1311 100644
+--- a/drivers/irqchip/irq-gic-v3-its.c
++++ b/drivers/irqchip/irq-gic-v3-its.c
+@@ -3402,6 +3402,7 @@ static struct its_device *its_create_device(struct its_node *its, u32 dev_id,
+ 	int lpi_base;
+ 	int nr_lpis;
+ 	int nr_ites;
++	int id_bits;
+ 	int sz;
+ 
+ 	if (!its_alloc_device_table(its, dev_id))
+@@ -3414,7 +3415,10 @@ static struct its_device *its_create_device(struct its_node *its, u32 dev_id,
+ 	/*
+ 	 * Even if the device wants a single LPI, the ITT must be
+ 	 * sized as a power of two (and you need at least one bit...).
++	 * Also honor the ITS's own EID limit.
+ 	 */
++	id_bits = FIELD_GET(GITS_TYPER_IDBITS, its->typer) + 1;
++	nvecs = min_t(unsigned int, nvecs, BIT(id_bits));
+ 	nr_ites = max(2, nvecs);
+ 	sz = nr_ites * (FIELD_GET(GITS_TYPER_ITT_ENTRY_SIZE, its->typer) + 1);
+ 	sz = max(sz, ITS_ITT_ALIGN) + ITS_ITT_ALIGN - 1;
+diff --git a/drivers/irqchip/irq-sifive-plic.c b/drivers/irqchip/irq-sifive-plic.c
+index a8f5cfad16f7de..794bdb6d4d1e3f 100644
+--- a/drivers/irqchip/irq-sifive-plic.c
++++ b/drivers/irqchip/irq-sifive-plic.c
+@@ -148,8 +148,13 @@ static void plic_irq_disable(struct irq_data *d)
+ static void plic_irq_eoi(struct irq_data *d)
+ {
+ 	struct plic_handler *handler = this_cpu_ptr(&plic_handlers);
++	u32 __iomem *reg;
++	bool enabled;
++
++	reg = handler->enable_base + (d->hwirq / 32) * sizeof(u32);
++	enabled = readl(reg) & BIT(d->hwirq % 32);
+ 
+-	if (unlikely(irqd_irq_disabled(d))) {
++	if (unlikely(!enabled)) {
+ 		plic_toggle(handler, d->hwirq, 1);
+ 		writel(d->hwirq, handler->hart_base + CONTEXT_CLAIM);
+ 		plic_toggle(handler, d->hwirq, 0);
+diff --git a/drivers/mailbox/mailbox.c b/drivers/mailbox/mailbox.c
+index cb59b4dbad6269..b4d52b814055b7 100644
+--- a/drivers/mailbox/mailbox.c
++++ b/drivers/mailbox/mailbox.c
+@@ -6,18 +6,17 @@
+  * Author: Jassi Brar <jassisinghbrar@gmail.com>
+  */
+ 
+-#include <linux/interrupt.h>
+-#include <linux/spinlock.h>
+-#include <linux/mutex.h>
++#include <linux/cleanup.h>
+ #include <linux/delay.h>
+-#include <linux/slab.h>
+-#include <linux/err.h>
+-#include <linux/module.h>
+ #include <linux/device.h>
+-#include <linux/bitops.h>
++#include <linux/err.h>
+ #include <linux/mailbox_client.h>
+ #include <linux/mailbox_controller.h>
++#include <linux/module.h>
++#include <linux/mutex.h>
+ #include <linux/of.h>
++#include <linux/property.h>
++#include <linux/spinlock.h>
+ 
+ #include "mailbox.h"
+ 
+@@ -325,7 +324,7 @@ static int __mbox_bind_client(struct mbox_chan *chan, struct mbox_client *cl)
+ 	int ret;
+ 
+ 	if (chan->cl || !try_module_get(chan->mbox->dev->driver->owner)) {
+-		dev_dbg(dev, "%s: mailbox not free\n", __func__);
++		dev_err(dev, "%s: mailbox not free\n", __func__);
+ 		return -EBUSY;
+ 	}
+ 
+@@ -373,13 +372,9 @@ static int __mbox_bind_client(struct mbox_chan *chan, struct mbox_client *cl)
+  */
+ int mbox_bind_client(struct mbox_chan *chan, struct mbox_client *cl)
+ {
+-	int ret;
+-
+-	mutex_lock(&con_mutex);
+-	ret = __mbox_bind_client(chan, cl);
+-	mutex_unlock(&con_mutex);
++	guard(mutex)(&con_mutex);
+ 
+-	return ret;
++	return __mbox_bind_client(chan, cl);
+ }
+ EXPORT_SYMBOL_GPL(mbox_bind_client);
+ 
+@@ -402,47 +397,65 @@ EXPORT_SYMBOL_GPL(mbox_bind_client);
+  */
+ struct mbox_chan *mbox_request_channel(struct mbox_client *cl, int index)
+ {
+-	struct device *dev = cl->dev;
++	struct fwnode_reference_args fwspec;
++	struct fwnode_handle *fwnode;
+ 	struct mbox_controller *mbox;
+ 	struct of_phandle_args spec;
+ 	struct mbox_chan *chan;
++	struct device *dev;
++	unsigned int i;
+ 	int ret;
+ 
+-	if (!dev || !dev->of_node) {
+-		pr_debug("%s: No owner device node\n", __func__);
++	dev = cl->dev;
++	if (!dev) {
++		pr_debug("No owner device\n");
+ 		return ERR_PTR(-ENODEV);
+ 	}
+ 
+-	mutex_lock(&con_mutex);
++	fwnode = dev_fwnode(dev);
++	if (!fwnode) {
++		dev_dbg(dev, "No owner fwnode\n");
++		return ERR_PTR(-ENODEV);
++	}
+ 
+-	ret = of_parse_phandle_with_args(dev->of_node, "mboxes", "#mbox-cells",
+-					 index, &spec);
++	ret = fwnode_property_get_reference_args(fwnode, "mboxes", "#mbox-cells",
++						 0, index, &fwspec);
+ 	if (ret) {
+-		dev_dbg(dev, "%s: can't parse \"mboxes\" property\n", __func__);
+-		mutex_unlock(&con_mutex);
++		dev_err(dev, "%s: can't parse \"%s\" property\n", __func__, "mboxes");
+ 		return ERR_PTR(ret);
+ 	}
+ 
+-	chan = ERR_PTR(-EPROBE_DEFER);
+-	list_for_each_entry(mbox, &mbox_cons, node)
+-		if (mbox->dev->of_node == spec.np) {
+-			chan = mbox->of_xlate(mbox, &spec);
+-			if (!IS_ERR(chan))
+-				break;
++	spec.np = to_of_node(fwspec.fwnode);
++	spec.args_count = fwspec.nargs;
++	for (i = 0; i < spec.args_count; i++)
++		spec.args[i] = fwspec.args[i];
++
++	scoped_guard(mutex, &con_mutex) {
++		chan = ERR_PTR(-EPROBE_DEFER);
++		list_for_each_entry(mbox, &mbox_cons, node) {
++			if (device_match_fwnode(mbox->dev, fwspec.fwnode)) {
++				if (mbox->fw_xlate) {
++					chan = mbox->fw_xlate(mbox, &fwspec);
++					if (!IS_ERR(chan))
++						break;
++				} else if (mbox->of_xlate) {
++					chan = mbox->of_xlate(mbox, &spec);
++					if (!IS_ERR(chan))
++						break;
++				}
++			}
+ 		}
+ 
+-	of_node_put(spec.np);
++		fwnode_handle_put(fwspec.fwnode);
+ 
+-	if (IS_ERR(chan)) {
+-		mutex_unlock(&con_mutex);
+-		return chan;
+-	}
++		if (IS_ERR(chan))
++			return chan;
+ 
+-	ret = __mbox_bind_client(chan, cl);
+-	if (ret)
+-		chan = ERR_PTR(ret);
++		ret = __mbox_bind_client(chan, cl);
++		if (ret)
++			chan = ERR_PTR(ret);
++	}
+ 
+-	mutex_unlock(&con_mutex);
+ 	return chan;
+ }
+ EXPORT_SYMBOL_GPL(mbox_request_channel);
+@@ -450,31 +463,14 @@ EXPORT_SYMBOL_GPL(mbox_request_channel);
+ struct mbox_chan *mbox_request_channel_byname(struct mbox_client *cl,
+ 					      const char *name)
+ {
+-	struct device_node *np = cl->dev->of_node;
+-	struct property *prop;
+-	const char *mbox_name;
+-	int index = 0;
++	int index = device_property_match_string(cl->dev, "mbox-names", name);
+ 
+-	if (!np) {
+-		dev_err(cl->dev, "%s() currently only supports DT\n", __func__);
++	if (index < 0) {
++		dev_err(cl->dev, "%s() could not locate channel named \"%s\"\n",
++			__func__, name);
+ 		return ERR_PTR(-EINVAL);
+ 	}
+-
+-	if (!of_get_property(np, "mbox-names", NULL)) {
+-		dev_err(cl->dev,
+-			"%s() requires an \"mbox-names\" property\n", __func__);
+-		return ERR_PTR(-EINVAL);
+-	}
+-
+-	of_property_for_each_string(np, "mbox-names", prop, mbox_name) {
+-		if (!strncmp(name, mbox_name, strlen(name)))
+-			return mbox_request_channel(cl, index);
+-		index++;
+-	}
+-
+-	dev_err(cl->dev, "%s() could not locate channel named \"%s\"\n",
+-		__func__, name);
+-	return ERR_PTR(-EINVAL);
++	return mbox_request_channel(cl, index);
+ }
+ EXPORT_SYMBOL_GPL(mbox_request_channel_byname);
+ 
+@@ -505,16 +501,13 @@ void mbox_free_channel(struct mbox_chan *chan)
+ }
+ EXPORT_SYMBOL_GPL(mbox_free_channel);
+ 
+-static struct mbox_chan *
+-of_mbox_index_xlate(struct mbox_controller *mbox,
+-		    const struct of_phandle_args *sp)
++static struct mbox_chan *fw_mbox_index_xlate(struct mbox_controller *mbox,
++					     const struct fwnode_reference_args *sp)
+ {
+-	int ind = sp->args[0];
+-
+-	if (ind >= mbox->num_chans)
++	if (sp->nargs < 1 || sp->args[0] >= mbox->num_chans)
+ 		return ERR_PTR(-EINVAL);
+ 
+-	return &mbox->chans[ind];
++	return &mbox->chans[sp->args[0]];
+ }
+ 
+ /**
+@@ -560,12 +553,11 @@ int mbox_controller_register(struct mbox_controller *mbox)
+ 		spin_lock_init(&chan->lock);
+ 	}
+ 
+-	if (!mbox->of_xlate)
+-		mbox->of_xlate = of_mbox_index_xlate;
++	if (!mbox->fw_xlate && !mbox->of_xlate)
++		mbox->fw_xlate = fw_mbox_index_xlate;
+ 
+-	mutex_lock(&con_mutex);
+-	list_add_tail(&mbox->node, &mbox_cons);
+-	mutex_unlock(&con_mutex);
++	scoped_guard(mutex, &con_mutex)
++		list_add_tail(&mbox->node, &mbox_cons);
+ 
+ 	return 0;
+ }
+@@ -582,17 +574,15 @@ void mbox_controller_unregister(struct mbox_controller *mbox)
+ 	if (!mbox)
+ 		return;
+ 
+-	mutex_lock(&con_mutex);
++	scoped_guard(mutex, &con_mutex) {
++		list_del(&mbox->node);
+ 
+-	list_del(&mbox->node);
++		for (i = 0; i < mbox->num_chans; i++)
++			mbox_free_channel(&mbox->chans[i]);
+ 
+-	for (i = 0; i < mbox->num_chans; i++)
+-		mbox_free_channel(&mbox->chans[i]);
+-
+-	if (mbox->txdone_poll)
+-		hrtimer_cancel(&mbox->poll_hrt);
+-
+-	mutex_unlock(&con_mutex);
++		if (mbox->txdone_poll)
++			hrtimer_cancel(&mbox->poll_hrt);
++	}
+ }
+ EXPORT_SYMBOL_GPL(mbox_controller_unregister);
+ 
+diff --git a/drivers/md/dm-verity-fec.c b/drivers/md/dm-verity-fec.c
+index 9275053b387b0d..c9a5bbb6202fbf 100644
+--- a/drivers/md/dm-verity-fec.c
++++ b/drivers/md/dm-verity-fec.c
+@@ -439,10 +439,8 @@ int verity_fec_decode(struct dm_verity *v, struct dm_verity_io *io,
+ 	if (!verity_fec_is_enabled(v))
+ 		return -EOPNOTSUPP;
+ 
+-	if (fio->level >= DM_VERITY_FEC_MAX_RECURSION) {
+-		DMWARN_LIMIT("%s: FEC: recursion too deep", v->data_dev->name);
++	if (fio->level)
+ 		return -EIO;
+-	}
+ 
+ 	fio->level++;
+ 
+diff --git a/drivers/md/dm-verity-fec.h b/drivers/md/dm-verity-fec.h
+index 8454070d28242d..7a73866f727da4 100644
+--- a/drivers/md/dm-verity-fec.h
++++ b/drivers/md/dm-verity-fec.h
+@@ -23,9 +23,6 @@
+ #define DM_VERITY_FEC_BUF_MAX \
+ 	(1 << (PAGE_SHIFT - DM_VERITY_FEC_BUF_RS_BITS))
+ 
+-/* maximum recursion level for verity_fec_decode */
+-#define DM_VERITY_FEC_MAX_RECURSION	4
+-
+ #define DM_VERITY_OPT_FEC_DEV		"use_fec_from_device"
+ #define DM_VERITY_OPT_FEC_BLOCKS	"fec_blocks"
+ #define DM_VERITY_OPT_FEC_START		"fec_start"
+diff --git a/drivers/media/dvb-core/dmxdev.c b/drivers/media/dvb-core/dmxdev.c
+index 804fb339f73551..a67cce02d1577b 100644
+--- a/drivers/media/dvb-core/dmxdev.c
++++ b/drivers/media/dvb-core/dmxdev.c
+@@ -168,7 +168,9 @@ static int dvb_dvr_open(struct inode *inode, struct file *file)
+ 			mutex_unlock(&dmxdev->mutex);
+ 			return -ENOMEM;
+ 		}
+-		dvb_ringbuffer_init(&dmxdev->dvr_buffer, mem, DVR_BUFFER_SIZE);
++		dmxdev->dvr_buffer.data = mem;
++		dmxdev->dvr_buffer.size = DVR_BUFFER_SIZE;
++		dvb_ringbuffer_reset(&dmxdev->dvr_buffer);
+ 		if (dmxdev->may_do_mmap)
+ 			dvb_vb2_init(&dmxdev->dvr_vb2_ctx, "dvr",
+ 				     file->f_flags & O_NONBLOCK);
+diff --git a/drivers/media/dvb-core/dvb_net.c b/drivers/media/dvb-core/dvb_net.c
+index 8bb8dd34c223e9..a2159b2bc17664 100644
+--- a/drivers/media/dvb-core/dvb_net.c
++++ b/drivers/media/dvb-core/dvb_net.c
+@@ -228,6 +228,9 @@ static int handle_one_ule_extension( struct dvb_net_priv *p )
+ 	unsigned char hlen = (p->ule_sndu_type & 0x0700) >> 8;
+ 	unsigned char htype = p->ule_sndu_type & 0x00FF;
+ 
++	if (htype >= ARRAY_SIZE(ule_mandatory_ext_handlers))
++		return -1;
++
+ 	/* Discriminate mandatory and optional extension headers. */
+ 	if (hlen == 0) {
+ 		/* Mandatory extension header */
+diff --git a/drivers/memory/mtk-smi.c b/drivers/memory/mtk-smi.c
+index 6523cb51051827..5ca197e15eb28c 100644
+--- a/drivers/memory/mtk-smi.c
++++ b/drivers/memory/mtk-smi.c
+@@ -563,17 +563,18 @@ static int mtk_smi_larb_probe(struct platform_device *pdev)
+ err_pm_disable:
+ 	pm_runtime_disable(dev);
+ 	device_link_remove(dev, larb->smi_common_dev);
++	put_device(larb->smi_common_dev);
+ 	return ret;
+ }
+ 
+-static int mtk_smi_larb_remove(struct platform_device *pdev)
++static void mtk_smi_larb_remove(struct platform_device *pdev)
+ {
+ 	struct mtk_smi_larb *larb = platform_get_drvdata(pdev);
+ 
+ 	device_link_remove(&pdev->dev, larb->smi_common_dev);
+ 	pm_runtime_disable(&pdev->dev);
+ 	component_del(&pdev->dev, &mtk_smi_larb_component_ops);
+-	return 0;
++	put_device(larb->smi_common_dev);
+ }
+ 
+ static int __maybe_unused mtk_smi_larb_resume(struct device *dev)
+@@ -616,7 +617,7 @@ static const struct dev_pm_ops smi_larb_pm_ops = {
+ 
+ static struct platform_driver mtk_smi_larb_driver = {
+ 	.probe	= mtk_smi_larb_probe,
+-	.remove	= mtk_smi_larb_remove,
++	.remove_new = mtk_smi_larb_remove,
+ 	.driver	= {
+ 		.name = "mtk-smi-larb",
+ 		.of_match_table = mtk_smi_larb_of_ids,
+@@ -795,14 +796,14 @@ static int mtk_smi_common_probe(struct platform_device *pdev)
+ 	return 0;
+ }
+ 
+-static int mtk_smi_common_remove(struct platform_device *pdev)
++static void mtk_smi_common_remove(struct platform_device *pdev)
+ {
+ 	struct mtk_smi *common = dev_get_drvdata(&pdev->dev);
+ 
+ 	if (common->plat->type == MTK_SMI_GEN2_SUB_COMM)
+ 		device_link_remove(&pdev->dev, common->smi_common_dev);
+ 	pm_runtime_disable(&pdev->dev);
+-	return 0;
++	put_device(common->smi_common_dev);
+ }
+ 
+ static int __maybe_unused mtk_smi_common_resume(struct device *dev)
+@@ -842,7 +843,7 @@ static const struct dev_pm_ops smi_common_pm_ops = {
+ 
+ static struct platform_driver mtk_smi_common_driver = {
+ 	.probe	= mtk_smi_common_probe,
+-	.remove = mtk_smi_common_remove,
++	.remove_new = mtk_smi_common_remove,
+ 	.driver	= {
+ 		.name = "mtk-smi-common",
+ 		.of_match_table = mtk_smi_common_of_ids,
+diff --git a/drivers/mfd/omap-usb-host.c b/drivers/mfd/omap-usb-host.c
+index 78f1bb55dbc0fa..e3aae10295a155 100644
+--- a/drivers/mfd/omap-usb-host.c
++++ b/drivers/mfd/omap-usb-host.c
+@@ -816,13 +816,14 @@ static int usbhs_omap_remove_child(struct device *dev, void *data)
+  *
+  * Reverses the effect of usbhs_omap_probe().
+  */
+-static int usbhs_omap_remove(struct platform_device *pdev)
++static void usbhs_omap_remove(struct platform_device *pdev)
+ {
+ 	pm_runtime_disable(&pdev->dev);
+ 
+-	/* remove children */
+-	device_for_each_child(&pdev->dev, NULL, usbhs_omap_remove_child);
+-	return 0;
++	if (pdev->dev.of_node)
++		of_platform_depopulate(&pdev->dev);
++	else
++		device_for_each_child(&pdev->dev, NULL, usbhs_omap_remove_child);
+ }
+ 
+ static const struct dev_pm_ops usbhsomap_dev_pm_ops = {
+@@ -845,7 +846,7 @@ static struct platform_driver usbhs_omap_driver = {
+ 		.of_match_table = usbhs_omap_dt_ids,
+ 	},
+ 	.probe		= usbhs_omap_probe,
+-	.remove		= usbhs_omap_remove,
++	.remove_new	= usbhs_omap_remove,
+ };
+ 
+ MODULE_AUTHOR("Keshava Munegowda <keshava_mgowda@ti.com>");
+diff --git a/drivers/mfd/qcom-pm8xxx.c b/drivers/mfd/qcom-pm8xxx.c
+index 07c531bd1236e5..0e490591177a2d 100644
+--- a/drivers/mfd/qcom-pm8xxx.c
++++ b/drivers/mfd/qcom-pm8xxx.c
+@@ -579,25 +579,17 @@ static int pm8xxx_probe(struct platform_device *pdev)
+ 	return rc;
+ }
+ 
+-static int pm8xxx_remove_child(struct device *dev, void *unused)
+-{
+-	platform_device_unregister(to_platform_device(dev));
+-	return 0;
+-}
+-
+-static int pm8xxx_remove(struct platform_device *pdev)
++static void pm8xxx_remove(struct platform_device *pdev)
+ {
+ 	struct pm_irq_chip *chip = platform_get_drvdata(pdev);
+ 
+-	device_for_each_child(&pdev->dev, NULL, pm8xxx_remove_child);
++	of_platform_depopulate(&pdev->dev);
+ 	irq_domain_remove(chip->irqdomain);
+-
+-	return 0;
+ }
+ 
+ static struct platform_driver pm8xxx_driver = {
+ 	.probe		= pm8xxx_probe,
+-	.remove		= pm8xxx_remove,
++	.remove_new	= pm8xxx_remove,
+ 	.driver		= {
+ 		.name	= "pm8xxx-core",
+ 		.of_match_table = pm8xxx_id_table,
+diff --git a/drivers/mmc/host/mmci_qcom_dml.c b/drivers/mmc/host/mmci_qcom_dml.c
+index 3da6112fbe39db..67371389cc3311 100644
+--- a/drivers/mmc/host/mmci_qcom_dml.c
++++ b/drivers/mmc/host/mmci_qcom_dml.c
+@@ -109,6 +109,7 @@ static int of_get_dml_pipe_index(struct device_node *np, const char *name)
+ 				       &dma_spec))
+ 		return -ENODEV;
+ 
++	of_node_put(dma_spec.np);
+ 	if (dma_spec.args_count)
+ 		return dma_spec.args[0];
+ 
+diff --git a/drivers/mmc/host/sdhci-pci-gli.c b/drivers/mmc/host/sdhci-pci-gli.c
+index 1dc1b9274b68cc..d078e5b2a01299 100644
+--- a/drivers/mmc/host/sdhci-pci-gli.c
++++ b/drivers/mmc/host/sdhci-pci-gli.c
+@@ -70,6 +70,9 @@
+ #define   GLI_9750_MISC_TX1_DLY_VALUE    0x5
+ #define   SDHCI_GLI_9750_MISC_SSC_OFF    BIT(26)
+ 
++#define SDHCI_GLI_9750_GM_BURST_SIZE		  0x510
++#define   SDHCI_GLI_9750_GM_BURST_SIZE_R_OSRC_LMT  GENMASK(17, 16)
++
+ #define SDHCI_GLI_9750_TUNING_CONTROL	          0x540
+ #define   SDHCI_GLI_9750_TUNING_CONTROL_EN          BIT(4)
+ #define   GLI_9750_TUNING_CONTROL_EN_ON             0x1
+@@ -277,10 +280,16 @@ static void gli_set_9750(struct sdhci_host *host)
+ 	u32 misc_value;
+ 	u32 parameter_value;
+ 	u32 control_value;
++	u32 burst_value;
+ 	u16 ctrl2;
+ 
+ 	gl9750_wt_on(host);
+ 
++	/* clear R_OSRC_Lmt to avoid DMA write corruption */
++	burst_value = sdhci_readl(host, SDHCI_GLI_9750_GM_BURST_SIZE);
++	burst_value &= ~SDHCI_GLI_9750_GM_BURST_SIZE_R_OSRC_LMT;
++	sdhci_writel(host, burst_value, SDHCI_GLI_9750_GM_BURST_SIZE);
++
+ 	driving_value = sdhci_readl(host, SDHCI_GLI_9750_DRIVING);
+ 	pll_value = sdhci_readl(host, SDHCI_GLI_9750_PLL);
+ 	sw_ctrl_value = sdhci_readl(host, SDHCI_GLI_9750_SW_CTRL);
+diff --git a/drivers/mmc/host/sdhci.c b/drivers/mmc/host/sdhci.c
+index 9796a3cb3ca62c..d25d1a461e7da6 100644
+--- a/drivers/mmc/host/sdhci.c
++++ b/drivers/mmc/host/sdhci.c
+@@ -4497,8 +4497,15 @@ int sdhci_setup_host(struct sdhci_host *host)
+ 	 * their platform code before calling sdhci_add_host(), and we
+ 	 * won't assume 8-bit width for hosts without that CAP.
+ 	 */
+-	if (!(host->quirks & SDHCI_QUIRK_FORCE_1_BIT_DATA))
++	if (host->quirks & SDHCI_QUIRK_FORCE_1_BIT_DATA) {
++		host->caps1 &= ~(SDHCI_SUPPORT_SDR104 | SDHCI_SUPPORT_SDR50 | SDHCI_SUPPORT_DDR50);
++		if (host->quirks2 & SDHCI_QUIRK2_CAPS_BIT63_FOR_HS400)
++			host->caps1 &= ~SDHCI_SUPPORT_HS400;
++		mmc->caps2 &= ~(MMC_CAP2_HS200 | MMC_CAP2_HS400 | MMC_CAP2_HS400_ES);
++		mmc->caps &= ~(MMC_CAP_DDR | MMC_CAP_UHS);
++	} else {
+ 		mmc->caps |= MMC_CAP_4_BIT_DATA;
++	}
+ 
+ 	if (host->quirks2 & SDHCI_QUIRK2_HOST_NO_CMD23)
+ 		mmc->caps &= ~MMC_CAP_CMD23;
+diff --git a/drivers/mtd/nand/raw/brcmnand/brcmnand.c b/drivers/mtd/nand/raw/brcmnand/brcmnand.c
+index 03d7e26d495375..ece399705bd734 100644
+--- a/drivers/mtd/nand/raw/brcmnand/brcmnand.c
++++ b/drivers/mtd/nand/raw/brcmnand/brcmnand.c
+@@ -2411,14 +2411,12 @@ static int brcmnand_write(struct mtd_info *mtd, struct nand_chip *chip,
+ 	for (i = 0; i < ctrl->max_oob; i += 4)
+ 		oob_reg_write(ctrl, i, 0xffffffff);
+ 
+-	if (mtd->oops_panic_write)
++	if (mtd->oops_panic_write) {
+ 		/* switch to interrupt polling and PIO mode */
+ 		disable_ctrl_irqs(ctrl);
+-
+-	if (use_dma(ctrl) && (has_edu(ctrl) || !oob) && flash_dma_buf_ok(buf)) {
++	} else if (use_dma(ctrl) && (has_edu(ctrl) || !oob) && flash_dma_buf_ok(buf)) {
+ 		if (ctrl->dma_trans(host, addr, (u32 *)buf, oob, mtd->writesize,
+ 				    CMD_PROGRAM_PAGE))
+-
+ 			ret = -EIO;
+ 
+ 		goto out;
+diff --git a/drivers/mtd/nand/raw/cadence-nand-controller.c b/drivers/mtd/nand/raw/cadence-nand-controller.c
+index 0831feb58e13db..06edf52c26c724 100644
+--- a/drivers/mtd/nand/raw/cadence-nand-controller.c
++++ b/drivers/mtd/nand/raw/cadence-nand-controller.c
+@@ -2883,7 +2883,7 @@ static int cadence_nand_init(struct cdns_nand_ctrl *cdns_ctrl)
+ 						  sizeof(*cdns_ctrl->cdma_desc),
+ 						  &cdns_ctrl->dma_cdma_desc,
+ 						  GFP_KERNEL);
+-	if (!cdns_ctrl->dma_cdma_desc)
++	if (!cdns_ctrl->cdma_desc)
+ 		return -ENOMEM;
+ 
+ 	cdns_ctrl->buf_size = SZ_16K;
+diff --git a/drivers/mtd/nand/raw/nand_base.c b/drivers/mtd/nand/raw/nand_base.c
+index fe0b298f8425e8..896a7d819e3c72 100644
+--- a/drivers/mtd/nand/raw/nand_base.c
++++ b/drivers/mtd/nand/raw/nand_base.c
+@@ -4849,11 +4849,16 @@ static void nand_shutdown(struct mtd_info *mtd)
+ static int nand_lock(struct mtd_info *mtd, loff_t ofs, uint64_t len)
+ {
+ 	struct nand_chip *chip = mtd_to_nand(mtd);
++	int ret;
+ 
+ 	if (!chip->ops.lock_area)
+ 		return -ENOTSUPP;
+ 
+-	return chip->ops.lock_area(chip, ofs, len);
++	nand_get_device(chip);
++	ret = chip->ops.lock_area(chip, ofs, len);
++	nand_release_device(chip);
++
++	return ret;
+ }
+ 
+ /**
+@@ -4865,11 +4870,16 @@ static int nand_lock(struct mtd_info *mtd, loff_t ofs, uint64_t len)
+ static int nand_unlock(struct mtd_info *mtd, loff_t ofs, uint64_t len)
+ {
+ 	struct nand_chip *chip = mtd_to_nand(mtd);
++	int ret;
+ 
+ 	if (!chip->ops.unlock_area)
+ 		return -ENOTSUPP;
+ 
+-	return chip->ops.unlock_area(chip, ofs, len);
++	nand_get_device(chip);
++	ret = chip->ops.unlock_area(chip, ofs, len);
++	nand_release_device(chip);
++
++	return ret;
+ }
+ 
+ /* Set default functions */
+diff --git a/drivers/mtd/nand/raw/pl35x-nand-controller.c b/drivers/mtd/nand/raw/pl35x-nand-controller.c
+index eaaaf3319bf863..88a2d7a639d008 100644
+--- a/drivers/mtd/nand/raw/pl35x-nand-controller.c
++++ b/drivers/mtd/nand/raw/pl35x-nand-controller.c
+@@ -862,6 +862,9 @@ static int pl35x_nfc_setup_interface(struct nand_chip *chip, int cs,
+ 			  PL35X_SMC_NAND_TAR_CYCLES(tmgs.t_ar) |
+ 			  PL35X_SMC_NAND_TRR_CYCLES(tmgs.t_rr);
+ 
++	writel(plnand->timings, nfc->conf_regs + PL35X_SMC_CYCLES);
++	pl35x_smc_update_regs(nfc);
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/mtd/parsers/redboot.c b/drivers/mtd/parsers/redboot.c
+index 3b55b676ca6b9c..c06ba7a2a34b4e 100644
+--- a/drivers/mtd/parsers/redboot.c
++++ b/drivers/mtd/parsers/redboot.c
+@@ -270,9 +270,9 @@ nogood:
+ 
+ 		strcpy(names, fl->img->name);
+ #ifdef CONFIG_MTD_REDBOOT_PARTS_READONLY
+-		if (!memcmp(names, "RedBoot", 8) ||
+-		    !memcmp(names, "RedBoot config", 15) ||
+-		    !memcmp(names, "FIS directory", 14)) {
++		if (!strcmp(names, "RedBoot") ||
++		    !strcmp(names, "RedBoot config") ||
++		    !strcmp(names, "FIS directory")) {
+ 			parts[i].mask_flags = MTD_WRITEABLE;
+ 		}
+ #endif
+diff --git a/drivers/net/arcnet/com20020-pci.c b/drivers/net/arcnet/com20020-pci.c
+index e7db6a4e4dc9da..e9ee32b091a418 100644
+--- a/drivers/net/arcnet/com20020-pci.c
++++ b/drivers/net/arcnet/com20020-pci.c
+@@ -114,6 +114,8 @@ static const struct attribute_group com20020_state_group = {
+ 	.attrs = com20020_state_attrs,
+ };
+ 
++static struct com20020_pci_card_info card_info_2p5mbit;
++
+ static void com20020pci_remove(struct pci_dev *pdev);
+ 
+ static int com20020pci_probe(struct pci_dev *pdev,
+@@ -139,7 +141,7 @@ static int com20020pci_probe(struct pci_dev *pdev,
+ 
+ 	ci = (struct com20020_pci_card_info *)id->driver_data;
+ 	if (!ci)
+-		return -EINVAL;
++		ci = &card_info_2p5mbit;
+ 
+ 	priv->ci = ci;
+ 	mm = &ci->misc_map;
+@@ -346,6 +348,18 @@ static struct com20020_pci_card_info card_info_5mbit = {
+ 	.flags = ARC_IS_5MBIT,
+ };
+ 
++static struct com20020_pci_card_info card_info_2p5mbit = {
++	.name = "ARC-PCI",
++	.devcount = 1,
++	.chan_map_tbl = {
++		{
++			.bar = 2,
++			.offset = 0x00,
++			.size = 0x08,
++		},
++	},
++};
++
+ static struct com20020_pci_card_info card_info_sohard = {
+ 	.name = "SOHARD SH ARC-PCI",
+ 	.devcount = 1,
+diff --git a/drivers/net/bonding/bond_debugfs.c b/drivers/net/bonding/bond_debugfs.c
+index b19492a7f6ad13..3c1945c3e850a3 100644
+--- a/drivers/net/bonding/bond_debugfs.c
++++ b/drivers/net/bonding/bond_debugfs.c
+@@ -34,11 +34,17 @@ static int bond_debug_rlb_hash_show(struct seq_file *m, void *v)
+ 	for (; hash_index != RLB_NULL_INDEX;
+ 	     hash_index = client_info->used_next) {
+ 		client_info = &(bond_info->rx_hashtbl[hash_index]);
+-		seq_printf(m, "%-15pI4 %-15pI4 %-17pM %s\n",
+-			&client_info->ip_src,
+-			&client_info->ip_dst,
+-			&client_info->mac_dst,
+-			client_info->slave->dev->name);
++		if (client_info->slave)
++			seq_printf(m, "%-15pI4 %-15pI4 %-17pM %s\n",
++				   &client_info->ip_src,
++				   &client_info->ip_dst,
++				   &client_info->mac_dst,
++				   client_info->slave->dev->name);
++		else
++			seq_printf(m, "%-15pI4 %-15pI4 %-17pM (none)\n",
++				   &client_info->ip_src,
++				   &client_info->ip_dst,
++				   &client_info->mac_dst);
+ 	}
+ 
+ 	spin_unlock_bh(&bond->mode_lock);
+diff --git a/drivers/net/bonding/bond_main.c b/drivers/net/bonding/bond_main.c
+index 836d7fcac71a1d..114ebaa284daa3 100644
+--- a/drivers/net/bonding/bond_main.c
++++ b/drivers/net/bonding/bond_main.c
+@@ -322,7 +322,7 @@ static bool bond_sk_check(struct bonding *bond)
+ 	}
+ }
+ 
+-bool bond_xdp_check(struct bonding *bond, int mode)
++bool __bond_xdp_check(int mode, int xmit_policy)
+ {
+ 	switch (mode) {
+ 	case BOND_MODE_ROUNDROBIN:
+@@ -333,7 +333,7 @@ bool bond_xdp_check(struct bonding *bond, int mode)
+ 		/* vlan+srcmac is not supported with XDP as in most cases the 802.1q
+ 		 * payload is not in the packet due to hardware offload.
+ 		 */
+-		if (bond->params.xmit_policy != BOND_XMIT_POLICY_VLAN_SRCMAC)
++		if (xmit_policy != BOND_XMIT_POLICY_VLAN_SRCMAC)
+ 			return true;
+ 		fallthrough;
+ 	default:
+@@ -341,6 +341,11 @@ bool bond_xdp_check(struct bonding *bond, int mode)
+ 	}
+ }
+ 
++bool bond_xdp_check(struct bonding *bond, int mode)
++{
++	return __bond_xdp_check(mode, bond->params.xmit_policy);
++}
++
+ /*---------------------------------- VLAN -----------------------------------*/
+ 
+ /* In the following 2 functions, bond_vlan_rx_add_vid and bond_vlan_rx_kill_vid,
+@@ -2854,8 +2859,14 @@ static void bond_miimon_commit(struct bonding *bond)
+ 
+ 			continue;
+ 
++		case BOND_LINK_FAIL:
++		case BOND_LINK_BACK:
++			slave_dbg(bond->dev, slave->dev, "link_new_state %d on slave\n",
++				  slave->link_new_state);
++			continue;
++
+ 		default:
+-			slave_err(bond->dev, slave->dev, "invalid new link %d on slave\n",
++			slave_err(bond->dev, slave->dev, "invalid link_new_state %d on slave\n",
+ 				  slave->link_new_state);
+ 			bond_propose_link_state(slave, BOND_LINK_NOCHANGE);
+ 
+@@ -3436,7 +3447,7 @@ int bond_rcv_validate(const struct sk_buff *skb, struct bonding *bond,
+ 	} else if (is_arp) {
+ 		return bond_arp_rcv(skb, bond, slave);
+ #if IS_ENABLED(CONFIG_IPV6)
+-	} else if (is_ipv6) {
++	} else if (is_ipv6 && likely(ipv6_mod_enabled())) {
+ 		return bond_na_rcv(skb, bond, slave);
+ #endif
+ 	} else {
+diff --git a/drivers/net/bonding/bond_options.c b/drivers/net/bonding/bond_options.c
+index 5a2a935945c4cf..b823425ad7f69c 100644
+--- a/drivers/net/bonding/bond_options.c
++++ b/drivers/net/bonding/bond_options.c
+@@ -1546,6 +1546,8 @@ static int bond_option_fail_over_mac_set(struct bonding *bond,
+ static int bond_option_xmit_hash_policy_set(struct bonding *bond,
+ 					    const struct bond_opt_value *newval)
+ {
++	if (bond->xdp_prog && !__bond_xdp_check(BOND_MODE(bond), newval->value))
++		return -EOPNOTSUPP;
+ 	netdev_dbg(bond->dev, "Setting xmit hash policy to %s (%llu)\n",
+ 		   newval->string, newval->value);
+ 	bond->params.xmit_policy = newval->value;
+diff --git a/drivers/net/caif/caif_serial.c b/drivers/net/caif/caif_serial.c
+index 699ed0ff461e89..6799dbf80f484b 100644
+--- a/drivers/net/caif/caif_serial.c
++++ b/drivers/net/caif/caif_serial.c
+@@ -311,6 +311,7 @@ static void ser_release(struct work_struct *work)
+ 			dev_close(ser->dev);
+ 			unregister_netdevice(ser->dev);
+ 			debugfs_deinit(ser);
++			tty_kref_put(tty->link);
+ 			tty_kref_put(tty);
+ 		}
+ 		rtnl_unlock();
+@@ -345,6 +346,7 @@ static int ldisc_open(struct tty_struct *tty)
+ 
+ 	ser = netdev_priv(dev);
+ 	ser->tty = tty_kref_get(tty);
++	tty_kref_get(tty->link);
+ 	ser->dev = dev;
+ 	debugfs_init(ser, tty);
+ 	tty->receive_room = N_TTY_BUF_SIZE;
+@@ -353,6 +355,7 @@ static int ldisc_open(struct tty_struct *tty)
+ 	rtnl_lock();
+ 	result = register_netdevice(dev);
+ 	if (result) {
++		tty_kref_put(tty->link);
+ 		tty_kref_put(tty);
+ 		rtnl_unlock();
+ 		free_netdev(dev);
+diff --git a/drivers/net/can/spi/hi311x.c b/drivers/net/can/spi/hi311x.c
+index 1acd4fc7adc8bf..2038b864832c93 100644
+--- a/drivers/net/can/spi/hi311x.c
++++ b/drivers/net/can/spi/hi311x.c
+@@ -756,7 +756,9 @@ static int hi3110_open(struct net_device *net)
+ 		return ret;
+ 
+ 	mutex_lock(&priv->hi3110_lock);
+-	hi3110_power_enable(priv->transceiver, 1);
++	ret = hi3110_power_enable(priv->transceiver, 1);
++	if (ret)
++		goto out_close_candev;
+ 
+ 	priv->force_quit = 0;
+ 	priv->tx_skb = NULL;
+@@ -791,6 +793,7 @@ static int hi3110_open(struct net_device *net)
+ 	hi3110_hw_sleep(spi);
+  out_close:
+ 	hi3110_power_enable(priv->transceiver, 0);
++ out_close_candev:
+ 	close_candev(net);
+ 	mutex_unlock(&priv->hi3110_lock);
+ 	return ret;
+diff --git a/drivers/net/can/spi/mcp251x.c b/drivers/net/can/spi/mcp251x.c
+index 8c56f85e87c1af..72ae17b2313ecd 100644
+--- a/drivers/net/can/spi/mcp251x.c
++++ b/drivers/net/can/spi/mcp251x.c
+@@ -1202,6 +1202,7 @@ static int mcp251x_open(struct net_device *net)
+ {
+ 	struct mcp251x_priv *priv = netdev_priv(net);
+ 	struct spi_device *spi = priv->spi;
++	bool release_irq = false;
+ 	unsigned long flags = 0;
+ 	int ret;
+ 
+@@ -1245,12 +1246,24 @@ static int mcp251x_open(struct net_device *net)
+ 	return 0;
+ 
+ out_free_irq:
+-	free_irq(spi->irq, priv);
++	/* The IRQ handler might be running, and if so it will be waiting
++	 * for the lock. But free_irq() must wait for the handler to finish
++	 * so calling it here would deadlock.
++	 *
++	 * Setting priv->force_quit will let the handler exit right away
++	 * without any access to the hardware. This make it safe to call
++	 * free_irq() after the lock is released.
++	 */
++	priv->force_quit = 1;
++	release_irq = true;
++
+ 	mcp251x_hw_sleep(spi);
+ out_close:
+ 	mcp251x_power_enable(priv->transceiver, 0);
+ 	close_candev(net);
+ 	mutex_unlock(&priv->mcp_lock);
++	if (release_irq)
++		free_irq(spi->irq, priv);
+ 	return ret;
+ }
+ 
+diff --git a/drivers/net/can/usb/ems_usb.c b/drivers/net/can/usb/ems_usb.c
+index fac8ac79df59f7..d8c881130e9008 100644
+--- a/drivers/net/can/usb/ems_usb.c
++++ b/drivers/net/can/usb/ems_usb.c
+@@ -445,6 +445,11 @@ static void ems_usb_read_bulk_callback(struct urb *urb)
+ 		start = CPC_HEADER_SIZE;
+ 
+ 		while (msg_count) {
++			if (start + CPC_MSG_HEADER_LEN > urb->actual_length) {
++				netdev_err(netdev, "format error\n");
++				break;
++			}
++
+ 			msg = (struct ems_cpc_msg *)&ibuf[start];
+ 
+ 			switch (msg->type) {
+@@ -474,7 +479,7 @@ static void ems_usb_read_bulk_callback(struct urb *urb)
+ 			start += CPC_MSG_HEADER_LEN + msg->length;
+ 			msg_count--;
+ 
+-			if (start > urb->transfer_buffer_length) {
++			if (start > urb->actual_length) {
+ 				netdev_err(netdev, "format error\n");
+ 				break;
+ 			}
+diff --git a/drivers/net/can/usb/etas_es58x/es58x_core.c b/drivers/net/can/usb/etas_es58x/es58x_core.c
+index 77f193861bcccb..e7955c1450d97b 100644
+--- a/drivers/net/can/usb/etas_es58x/es58x_core.c
++++ b/drivers/net/can/usb/etas_es58x/es58x_core.c
+@@ -1461,12 +1461,18 @@ static void es58x_read_bulk_callback(struct urb *urb)
+ 	}
+ 
+  resubmit_urb:
++	usb_anchor_urb(urb, &es58x_dev->rx_urbs);
+ 	ret = usb_submit_urb(urb, GFP_ATOMIC);
++	if (!ret)
++		return;
++
++	usb_unanchor_urb(urb);
++
+ 	if (ret == -ENODEV) {
+ 		for (i = 0; i < es58x_dev->num_can_ch; i++)
+ 			if (es58x_dev->netdev[i])
+ 				netif_device_detach(es58x_dev->netdev[i]);
+-	} else if (ret)
++	} else
+ 		dev_err_ratelimited(dev,
+ 				    "Failed resubmitting read bulk urb: %pe\n",
+ 				    ERR_PTR(ret));
+diff --git a/drivers/net/can/usb/f81604.c b/drivers/net/can/usb/f81604.c
+index fb9fb16507f0bd..36b4bb1c84b271 100644
+--- a/drivers/net/can/usb/f81604.c
++++ b/drivers/net/can/usb/f81604.c
+@@ -413,6 +413,7 @@ static void f81604_read_bulk_callback(struct urb *urb)
+ {
+ 	struct f81604_can_frame *frame = urb->transfer_buffer;
+ 	struct net_device *netdev = urb->context;
++	struct f81604_port_priv *priv = netdev_priv(netdev);
+ 	int ret;
+ 
+ 	if (!netif_device_present(netdev))
+@@ -445,10 +446,15 @@ static void f81604_read_bulk_callback(struct urb *urb)
+ 	f81604_process_rx_packet(netdev, frame);
+ 
+ resubmit_urb:
++	usb_anchor_urb(urb, &priv->urbs_anchor);
+ 	ret = usb_submit_urb(urb, GFP_ATOMIC);
++	if (!ret)
++		return;
++	usb_unanchor_urb(urb);
++
+ 	if (ret == -ENODEV)
+ 		netif_device_detach(netdev);
+-	else if (ret)
++	else
+ 		netdev_err(netdev,
+ 			   "%s: failed to resubmit read bulk urb: %pe\n",
+ 			   __func__, ERR_PTR(ret));
+@@ -620,6 +626,12 @@ static void f81604_read_int_callback(struct urb *urb)
+ 		netdev_info(netdev, "%s: Int URB aborted: %pe\n", __func__,
+ 			    ERR_PTR(urb->status));
+ 
++	if (urb->actual_length < sizeof(*data)) {
++		netdev_warn(netdev, "%s: short int URB: %u < %zu\n",
++			    __func__, urb->actual_length, sizeof(*data));
++		goto resubmit_urb;
++	}
++
+ 	switch (urb->status) {
+ 	case 0: /* success */
+ 		break;
+@@ -646,10 +658,15 @@ static void f81604_read_int_callback(struct urb *urb)
+ 		f81604_handle_tx(priv, data);
+ 
+ resubmit_urb:
++	usb_anchor_urb(urb, &priv->urbs_anchor);
+ 	ret = usb_submit_urb(urb, GFP_ATOMIC);
++	if (!ret)
++		return;
++	usb_unanchor_urb(urb);
++
+ 	if (ret == -ENODEV)
+ 		netif_device_detach(netdev);
+-	else if (ret)
++	else
+ 		netdev_err(netdev, "%s: failed to resubmit int urb: %pe\n",
+ 			   __func__, ERR_PTR(ret));
+ }
+@@ -874,9 +891,27 @@ static void f81604_write_bulk_callback(struct urb *urb)
+ 	if (!netif_device_present(netdev))
+ 		return;
+ 
+-	if (urb->status)
+-		netdev_info(netdev, "%s: Tx URB error: %pe\n", __func__,
+-			    ERR_PTR(urb->status));
++	if (!urb->status)
++		return;
++
++	switch (urb->status) {
++	case -ENOENT:
++	case -ECONNRESET:
++	case -ESHUTDOWN:
++		return;
++	default:
++		break;
++	}
++
++	if (net_ratelimit())
++		netdev_err(netdev, "%s: Tx URB error: %pe\n", __func__,
++			   ERR_PTR(urb->status));
++
++	can_free_echo_skb(netdev, 0, NULL);
++	netdev->stats.tx_dropped++;
++	netdev->stats.tx_errors++;
++
++	netif_wake_queue(netdev);
+ }
+ 
+ static void f81604_clear_reg_work(struct work_struct *work)
+diff --git a/drivers/net/can/usb/gs_usb.c b/drivers/net/can/usb/gs_usb.c
+index 7a3c6493a35360..bde945d99edd1b 100644
+--- a/drivers/net/can/usb/gs_usb.c
++++ b/drivers/net/can/usb/gs_usb.c
+@@ -769,9 +769,8 @@ device_detach:
+ 	}
+ }
+ 
+-static int gs_usb_set_bittiming(struct net_device *netdev)
++static int gs_usb_set_bittiming(struct gs_can *dev)
+ {
+-	struct gs_can *dev = netdev_priv(netdev);
+ 	struct can_bittiming *bt = &dev->can.bittiming;
+ 	struct gs_device_bittiming dbt = {
+ 		.prop_seg = cpu_to_le32(bt->prop_seg),
+@@ -788,9 +787,8 @@ static int gs_usb_set_bittiming(struct net_device *netdev)
+ 				    GFP_KERNEL);
+ }
+ 
+-static int gs_usb_set_data_bittiming(struct net_device *netdev)
++static int gs_usb_set_data_bittiming(struct gs_can *dev)
+ {
+-	struct gs_can *dev = netdev_priv(netdev);
+ 	struct can_bittiming *bt = &dev->can.data_bittiming;
+ 	struct gs_device_bittiming dbt = {
+ 		.prop_seg = cpu_to_le32(bt->prop_seg),
+@@ -1054,6 +1052,20 @@ static int gs_can_open(struct net_device *netdev)
+ 	if (dev->feature & GS_CAN_FEATURE_HW_TIMESTAMP)
+ 		flags |= GS_CAN_MODE_HW_TIMESTAMP;
+ 
++	rc = gs_usb_set_bittiming(dev);
++	if (rc) {
++		netdev_err(netdev, "failed to set bittiming: %pe\n", ERR_PTR(rc));
++		goto out_usb_kill_anchored_urbs;
++	}
++
++	if (ctrlmode & CAN_CTRLMODE_FD) {
++		rc = gs_usb_set_data_bittiming(dev);
++		if (rc) {
++			netdev_err(netdev, "failed to set data bittiming: %pe\n", ERR_PTR(rc));
++			goto out_usb_kill_anchored_urbs;
++		}
++	}
++
+ 	/* finally start device */
+ 	dev->can.state = CAN_STATE_ERROR_ACTIVE;
+ 	dm.flags = cpu_to_le32(flags);
+@@ -1354,7 +1366,6 @@ static struct gs_can *gs_make_candev(unsigned int channel,
+ 	dev->can.state = CAN_STATE_STOPPED;
+ 	dev->can.clock.freq = le32_to_cpu(bt_const.fclk_can);
+ 	dev->can.bittiming_const = &dev->bt_const;
+-	dev->can.do_set_bittiming = gs_usb_set_bittiming;
+ 
+ 	dev->can.ctrlmode_supported = CAN_CTRLMODE_CC_LEN8_DLC;
+ 
+@@ -1378,7 +1389,6 @@ static struct gs_can *gs_make_candev(unsigned int channel,
+ 		 * GS_CAN_FEATURE_BT_CONST_EXT is set.
+ 		 */
+ 		dev->can.data_bittiming_const = &dev->bt_const;
+-		dev->can.do_set_data_bittiming = gs_usb_set_data_bittiming;
+ 	}
+ 
+ 	if (feature & GS_CAN_FEATURE_TERMINATION) {
+diff --git a/drivers/net/can/usb/ucan.c b/drivers/net/can/usb/ucan.c
+index 07406daf7c88ed..6c90b4a7d955a2 100644
+--- a/drivers/net/can/usb/ucan.c
++++ b/drivers/net/can/usb/ucan.c
+@@ -749,7 +749,7 @@ static void ucan_read_bulk_callback(struct urb *urb)
+ 		len = le16_to_cpu(m->len);
+ 
+ 		/* check sanity (length of content) */
+-		if (urb->actual_length - pos < len) {
++		if ((len == 0) || (urb->actual_length - pos < len)) {
+ 			netdev_warn(up->netdev,
+ 				    "invalid message (short; no data; l:%d)\n",
+ 				    urb->actual_length);
+diff --git a/drivers/net/dsa/bcm_sf2.c b/drivers/net/dsa/bcm_sf2.c
+index 257df167687506..7defcfd1c213f0 100644
+--- a/drivers/net/dsa/bcm_sf2.c
++++ b/drivers/net/dsa/bcm_sf2.c
+@@ -971,15 +971,19 @@ static int bcm_sf2_sw_resume(struct dsa_switch *ds)
+ 	ret = bcm_sf2_sw_rst(priv);
+ 	if (ret) {
+ 		pr_err("%s: failed to software reset switch\n", __func__);
++		if (!priv->wol_ports_mask)
++			clk_disable_unprepare(priv->clk);
+ 		return ret;
+ 	}
+ 
+ 	bcm_sf2_crossbar_setup(priv);
+ 
+ 	ret = bcm_sf2_cfp_resume(ds);
+-	if (ret)
++	if (ret) {
++		if (!priv->wol_ports_mask)
++			clk_disable_unprepare(priv->clk);
+ 		return ret;
+-
++	}
+ 	if (priv->hw_params.num_gphy == 1)
+ 		bcm_sf2_gphy_enable_set(ds, true);
+ 
+diff --git a/drivers/net/dsa/microchip/ksz_ptp.c b/drivers/net/dsa/microchip/ksz_ptp.c
+index 3783d20d673b98..533224bcfe4dba 100644
+--- a/drivers/net/dsa/microchip/ksz_ptp.c
++++ b/drivers/net/dsa/microchip/ksz_ptp.c
+@@ -1101,6 +1101,7 @@ static int ksz_ptp_msg_irq_setup(struct ksz_port *port, u8 n)
+ 	const struct ksz_dev_ops *ops = port->ksz_dev->dev_ops;
+ 	struct ksz_irq *ptpirq = &port->ptpirq;
+ 	struct ksz_ptp_irq *ptpmsg_irq;
++	int ret;
+ 
+ 	ptpmsg_irq = &port->ptpmsg_irq[n];
+ 	ptpmsg_irq->num = irq_create_mapping(ptpirq->domain, n);
+@@ -1112,9 +1113,13 @@ static int ksz_ptp_msg_irq_setup(struct ksz_port *port, u8 n)
+ 
+ 	snprintf(ptpmsg_irq->name, sizeof(ptpmsg_irq->name), name[n]);
+ 
+-	return request_threaded_irq(ptpmsg_irq->num, NULL,
+-				    ksz_ptp_msg_thread_fn, IRQF_ONESHOT,
+-				    ptpmsg_irq->name, ptpmsg_irq);
++	ret = request_threaded_irq(ptpmsg_irq->num, NULL,
++				   ksz_ptp_msg_thread_fn, IRQF_ONESHOT,
++				   ptpmsg_irq->name, ptpmsg_irq);
++	if (ret)
++		irq_dispose_mapping(ptpmsg_irq->num);
++
++	return ret;
+ }
+ 
+ int ksz_ptp_irq_setup(struct dsa_switch *ds, u8 p)
+diff --git a/drivers/net/dsa/realtek/rtl8365mb.c b/drivers/net/dsa/realtek/rtl8365mb.c
+index 41ea3b5a42b145..9d59d938078252 100644
+--- a/drivers/net/dsa/realtek/rtl8365mb.c
++++ b/drivers/net/dsa/realtek/rtl8365mb.c
+@@ -766,7 +766,7 @@ static int rtl8365mb_phy_ocp_write(struct realtek_priv *priv, int phy,
+ out:
+ 	mutex_unlock(&priv->map_lock);
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ static int rtl8365mb_phy_read(struct realtek_priv *priv, int phy, int regnum)
+@@ -1482,8 +1482,7 @@ static void rtl8365mb_stats_update(struct realtek_priv *priv, int port)
+ 
+ 	stats->rx_packets = cnt[RTL8365MB_MIB_ifInUcastPkts] +
+ 			    cnt[RTL8365MB_MIB_ifInMulticastPkts] +
+-			    cnt[RTL8365MB_MIB_ifInBroadcastPkts] -
+-			    cnt[RTL8365MB_MIB_ifOutDiscards];
++			    cnt[RTL8365MB_MIB_ifInBroadcastPkts];
+ 
+ 	stats->tx_packets = cnt[RTL8365MB_MIB_ifOutUcastPkts] +
+ 			    cnt[RTL8365MB_MIB_ifOutMulticastPkts] +
+diff --git a/drivers/net/ethernet/amd/xgbe/xgbe-common.h b/drivers/net/ethernet/amd/xgbe/xgbe-common.h
+index aa25a8a0a106f6..d99d2295eab0f4 100644
+--- a/drivers/net/ethernet/amd/xgbe/xgbe-common.h
++++ b/drivers/net/ethernet/amd/xgbe/xgbe-common.h
+@@ -514,7 +514,7 @@
+ #define MAC_SSIR_SSINC_INDEX		16
+ #define MAC_SSIR_SSINC_WIDTH		8
+ #define MAC_TCR_SS_INDEX		29
+-#define MAC_TCR_SS_WIDTH		2
++#define MAC_TCR_SS_WIDTH		3
+ #define MAC_TCR_TE_INDEX		0
+ #define MAC_TCR_TE_WIDTH		1
+ #define MAC_TCR_VNE_INDEX		24
+diff --git a/drivers/net/ethernet/amd/xgbe/xgbe-drv.c b/drivers/net/ethernet/amd/xgbe/xgbe-drv.c
+index 3d6f8f3a833668..67e1d8eacdaedf 100644
+--- a/drivers/net/ethernet/amd/xgbe/xgbe-drv.c
++++ b/drivers/net/ethernet/amd/xgbe/xgbe-drv.c
+@@ -1181,7 +1181,6 @@ int xgbe_powerdown(struct net_device *netdev, unsigned int caller)
+ {
+ 	struct xgbe_prv_data *pdata = netdev_priv(netdev);
+ 	struct xgbe_hw_if *hw_if = &pdata->hw_if;
+-	unsigned long flags;
+ 
+ 	DBGPR("-->xgbe_powerdown\n");
+ 
+@@ -1192,8 +1191,6 @@ int xgbe_powerdown(struct net_device *netdev, unsigned int caller)
+ 		return -EINVAL;
+ 	}
+ 
+-	spin_lock_irqsave(&pdata->lock, flags);
+-
+ 	if (caller == XGMAC_DRIVER_CONTEXT)
+ 		netif_device_detach(netdev);
+ 
+@@ -1209,8 +1206,6 @@ int xgbe_powerdown(struct net_device *netdev, unsigned int caller)
+ 
+ 	pdata->power_down = 1;
+ 
+-	spin_unlock_irqrestore(&pdata->lock, flags);
+-
+ 	DBGPR("<--xgbe_powerdown\n");
+ 
+ 	return 0;
+@@ -1220,7 +1215,6 @@ int xgbe_powerup(struct net_device *netdev, unsigned int caller)
+ {
+ 	struct xgbe_prv_data *pdata = netdev_priv(netdev);
+ 	struct xgbe_hw_if *hw_if = &pdata->hw_if;
+-	unsigned long flags;
+ 
+ 	DBGPR("-->xgbe_powerup\n");
+ 
+@@ -1231,8 +1225,6 @@ int xgbe_powerup(struct net_device *netdev, unsigned int caller)
+ 		return -EINVAL;
+ 	}
+ 
+-	spin_lock_irqsave(&pdata->lock, flags);
+-
+ 	pdata->power_down = 0;
+ 
+ 	xgbe_napi_enable(pdata, 0);
+@@ -1247,8 +1239,6 @@ int xgbe_powerup(struct net_device *netdev, unsigned int caller)
+ 
+ 	xgbe_start_timers(pdata);
+ 
+-	spin_unlock_irqrestore(&pdata->lock, flags);
+-
+ 	DBGPR("<--xgbe_powerup\n");
+ 
+ 	return 0;
+@@ -1348,6 +1338,10 @@ static int xgbe_start(struct xgbe_prv_data *pdata)
+ 
+ 	hw_if->enable_tx(pdata);
+ 	hw_if->enable_rx(pdata);
++	/* Synchronize flag with hardware state after enabling TX/RX.
++	 * This prevents stale state after device restart cycles.
++	 */
++	pdata->data_path_stopped = false;
+ 
+ 	udp_tunnel_nic_reset_ntf(netdev);
+ 
+diff --git a/drivers/net/ethernet/amd/xgbe/xgbe-main.c b/drivers/net/ethernet/amd/xgbe/xgbe-main.c
+index 0e8698928e4d73..6e8fafb2acbaa4 100644
+--- a/drivers/net/ethernet/amd/xgbe/xgbe-main.c
++++ b/drivers/net/ethernet/amd/xgbe/xgbe-main.c
+@@ -185,7 +185,6 @@ struct xgbe_prv_data *xgbe_alloc_pdata(struct device *dev)
+ 	pdata->netdev = netdev;
+ 	pdata->dev = dev;
+ 
+-	spin_lock_init(&pdata->lock);
+ 	spin_lock_init(&pdata->xpcs_lock);
+ 	mutex_init(&pdata->rss_mutex);
+ 	spin_lock_init(&pdata->tstamp_lock);
+diff --git a/drivers/net/ethernet/amd/xgbe/xgbe-phy-v2.c b/drivers/net/ethernet/amd/xgbe/xgbe-phy-v2.c
+index 6d2c401bb246e1..0a99a21af5815d 100644
+--- a/drivers/net/ethernet/amd/xgbe/xgbe-phy-v2.c
++++ b/drivers/net/ethernet/amd/xgbe/xgbe-phy-v2.c
+@@ -2050,7 +2050,7 @@ static void xgbe_set_rx_adap_mode(struct xgbe_prv_data *pdata,
+ static void xgbe_rx_adaptation(struct xgbe_prv_data *pdata)
+ {
+ 	struct xgbe_phy_data *phy_data = pdata->phy_data;
+-	unsigned int reg;
++	int reg;
+ 
+ 	/* step 2: force PCS to send RX_ADAPT Req to PHY */
+ 	XMDIO_WRITE_BITS(pdata, MDIO_MMD_PMAPMD, MDIO_PMA_RX_EQ_CTRL4,
+@@ -2072,11 +2072,20 @@ static void xgbe_rx_adaptation(struct xgbe_prv_data *pdata)
+ 
+ 	/* Step 4: Check for Block lock */
+ 
+-	/* Link status is latched low, so read once to clear
+-	 * and then read again to get current state
+-	 */
+-	reg = XMDIO_READ(pdata, MDIO_MMD_PCS, MDIO_STAT1);
+ 	reg = XMDIO_READ(pdata, MDIO_MMD_PCS, MDIO_STAT1);
++	if (reg < 0)
++		goto set_mode;
++
++	/* Link status is latched low so that momentary link drops
++	 * can be detected. If link was already down read again
++	 * to get the latest state.
++	 */
++	if (!pdata->phy.link && !(reg & MDIO_STAT1_LSTATUS)) {
++		reg = XMDIO_READ(pdata, MDIO_MMD_PCS, MDIO_STAT1);
++		if (reg < 0)
++			goto set_mode;
++	}
++
+ 	if (reg & MDIO_STAT1_LSTATUS) {
+ 		/* If the block lock is found, update the helpers
+ 		 * and declare the link up
+@@ -2116,6 +2125,48 @@ rx_adapt_reinit:
+ 	xgbe_rx_adaptation(pdata);
+ }
+ 
++/*
++ * xgbe_phy_stop_data_path - Stop TX/RX to prevent packet corruption
++ * @pdata: driver private data
++ *
++ * This function stops the data path (TX and RX) to prevent packet
++ * corruption during critical PHY operations like RX adaptation.
++ * Must be called before initiating RX adaptation when link goes down.
++ */
++static void xgbe_phy_stop_data_path(struct xgbe_prv_data *pdata)
++{
++	if (pdata->data_path_stopped)
++		return;
++
++	/* Stop TX/RX to prevent packet corruption during RX adaptation */
++	pdata->hw_if.disable_tx(pdata);
++	pdata->hw_if.disable_rx(pdata);
++	pdata->data_path_stopped = true;
++
++	netif_dbg(pdata, link, pdata->netdev,
++		  "stopping data path for RX adaptation\n");
++}
++
++/*
++ * xgbe_phy_start_data_path - Re-enable TX/RX after RX adaptation
++ * @pdata: driver private data
++ *
++ * This function re-enables the data path (TX and RX) after RX adaptation
++ * has completed successfully. Only called when link is confirmed up.
++ */
++static void xgbe_phy_start_data_path(struct xgbe_prv_data *pdata)
++{
++	if (!pdata->data_path_stopped)
++		return;
++
++	pdata->hw_if.enable_rx(pdata);
++	pdata->hw_if.enable_tx(pdata);
++	pdata->data_path_stopped = false;
++
++	netif_dbg(pdata, link, pdata->netdev,
++		  "restarting data path after RX adaptation\n");
++}
++
+ static void xgbe_phy_rx_reset(struct xgbe_prv_data *pdata)
+ {
+ 	int reg;
+@@ -2909,13 +2960,27 @@ static int xgbe_phy_link_status(struct xgbe_prv_data *pdata, int *an_restart)
+ 	if (pdata->en_rx_adap) {
+ 		/* if the link is available and adaptation is done,
+ 		 * declare link up
++		 *
++		 * Note: When link is up and adaptation is done, we can
++		 * safely re-enable the data path if it was stopped
++		 * for adaptation.
+ 		 */
+-		if ((reg & MDIO_STAT1_LSTATUS) && pdata->rx_adapt_done)
++		if ((reg & MDIO_STAT1_LSTATUS) && pdata->rx_adapt_done) {
++			xgbe_phy_start_data_path(pdata);
+ 			return 1;
++		}
+ 		/* If either link is not available or adaptation is not done,
+ 		 * retrigger the adaptation logic. (if the mode is not set,
+ 		 * then issue mailbox command first)
+ 		 */
++
++		/* CRITICAL: Stop data path BEFORE triggering RX adaptation
++		 * to prevent CRC errors from packets corrupted during
++		 * the adaptation process. This is especially important
++		 * when AN is OFF in 10G KR mode.
++		 */
++		xgbe_phy_stop_data_path(pdata);
++
+ 		if (pdata->mode_set) {
+ 			xgbe_phy_rx_adaptation(pdata);
+ 		} else {
+@@ -2923,8 +2988,11 @@ static int xgbe_phy_link_status(struct xgbe_prv_data *pdata, int *an_restart)
+ 			xgbe_phy_set_mode(pdata, phy_data->cur_mode);
+ 		}
+ 
+-		if (pdata->rx_adapt_done)
++		if (pdata->rx_adapt_done) {
++			/* Adaptation complete, safe to re-enable data path */
++			xgbe_phy_start_data_path(pdata);
+ 			return 1;
++		}
+ 	} else if (reg & MDIO_STAT1_LSTATUS)
+ 		return 1;
+ 
+diff --git a/drivers/net/ethernet/amd/xgbe/xgbe.h b/drivers/net/ethernet/amd/xgbe/xgbe.h
+index a596cd08124fa4..ac0f728c5c85d5 100644
+--- a/drivers/net/ethernet/amd/xgbe/xgbe.h
++++ b/drivers/net/ethernet/amd/xgbe/xgbe.h
+@@ -1083,9 +1083,6 @@ struct xgbe_prv_data {
+ 	unsigned int pp3;
+ 	unsigned int pp4;
+ 
+-	/* Overall device lock */
+-	spinlock_t lock;
+-
+ 	/* XPCS indirect addressing lock */
+ 	spinlock_t xpcs_lock;
+ 	unsigned int xpcs_window_def_reg;
+@@ -1324,6 +1321,10 @@ struct xgbe_prv_data {
+ 	bool en_rx_adap;
+ 	int rx_adapt_retries;
+ 	bool rx_adapt_done;
++	/* Flag to track if data path (TX/RX) was stopped for RX adaptation.
++	 * This prevents packet corruption during the adaptation window.
++	 */
++	bool data_path_stopped;
+ 	bool mode_set;
+ };
+ 
+diff --git a/drivers/net/ethernet/arc/emac_main.c b/drivers/net/ethernet/arc/emac_main.c
+index 8283aeee35fb6d..dde4046cbf010e 100644
+--- a/drivers/net/ethernet/arc/emac_main.c
++++ b/drivers/net/ethernet/arc/emac_main.c
+@@ -934,6 +934,17 @@ int arc_emac_probe(struct net_device *ndev, int interface)
+ 	/* Set poll rate so that it polls every 1 ms */
+ 	arc_reg_set(priv, R_POLLRATE, clock_frequency / 1000000);
+ 
++	/*
++	 * Put the device into a known quiescent state before requesting
++	 * the IRQ. Clear only EMAC interrupt status bits here; leave the
++	 * MDIO completion bit alone and avoid writing TXPL_MASK, which is
++	 * used to force TX polling rather than acknowledge interrupts.
++	 */
++	arc_reg_set(priv, R_ENABLE, 0);
++	arc_reg_set(priv, R_STATUS, RXINT_MASK | TXINT_MASK | ERR_MASK |
++		    TXCH_MASK | MSER_MASK | RXCR_MASK |
++		    RXFR_MASK | RXFL_MASK);
++
+ 	ndev->irq = irq;
+ 	dev_info(dev, "IRQ is %d\n", ndev->irq);
+ 
+diff --git a/drivers/net/ethernet/broadcom/bnxt/bnxt.c b/drivers/net/ethernet/broadcom/bnxt/bnxt.c
+index e337b6c7ee6f93..32bccea606453e 100644
+--- a/drivers/net/ethernet/broadcom/bnxt/bnxt.c
++++ b/drivers/net/ethernet/broadcom/bnxt/bnxt.c
+@@ -3996,7 +3996,7 @@ void bnxt_set_ring_params(struct bnxt *bp)
+ /* Changing allocation mode of RX rings.
+  * TODO: Update when extending xdp_rxq_info to support allocation modes.
+  */
+-int bnxt_set_rx_skb_mode(struct bnxt *bp, bool page_mode)
++static void __bnxt_set_rx_skb_mode(struct bnxt *bp, bool page_mode)
+ {
+ 	struct net_device *dev = bp->dev;
+ 
+@@ -4017,15 +4017,30 @@ int bnxt_set_rx_skb_mode(struct bnxt *bp, bool page_mode)
+ 			bp->rx_skb_func = bnxt_rx_page_skb;
+ 		}
+ 		bp->rx_dir = DMA_BIDIRECTIONAL;
+-		/* Disable LRO or GRO_HW */
+-		netdev_update_features(dev);
+ 	} else {
+ 		dev->max_mtu = bp->max_mtu;
+ 		bp->flags &= ~BNXT_FLAG_RX_PAGE_MODE;
+ 		bp->rx_dir = DMA_FROM_DEVICE;
+ 		bp->rx_skb_func = bnxt_rx_skb;
+ 	}
+-	return 0;
++}
++
++void bnxt_set_rx_skb_mode(struct bnxt *bp, bool page_mode)
++{
++	__bnxt_set_rx_skb_mode(bp, page_mode);
++
++	if (!page_mode) {
++		int rx, tx;
++
++		bnxt_get_max_rings(bp, &rx, &tx, true);
++		if (rx > 1) {
++			bp->flags &= ~BNXT_FLAG_NO_AGG_RINGS;
++			bp->dev->hw_features |= NETIF_F_LRO;
++		}
++	}
++
++	/* Update LRO and GRO_HW availability */
++	netdev_update_features(bp->dev);
+ }
+ 
+ static void bnxt_free_vnic_attributes(struct bnxt *bp)
+@@ -13773,7 +13788,7 @@ static int bnxt_init_one(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 	if (rc)
+ 		goto init_err_pci_clean;
+ 
+-	bnxt_set_rx_skb_mode(bp, false);
++	__bnxt_set_rx_skb_mode(bp, false);
+ 	bnxt_set_tpa_flags(bp);
+ 	bnxt_set_ring_params(bp);
+ 	rc = bnxt_set_dflt_rings(bp, true);
+diff --git a/drivers/net/ethernet/broadcom/bnxt/bnxt.h b/drivers/net/ethernet/broadcom/bnxt/bnxt.h
+index d96c9aabf97a7a..bc1ff1085da7f6 100644
+--- a/drivers/net/ethernet/broadcom/bnxt/bnxt.h
++++ b/drivers/net/ethernet/broadcom/bnxt/bnxt.h
+@@ -2332,7 +2332,7 @@ void bnxt_reuse_rx_data(struct bnxt_rx_ring_info *rxr, u16 cons, void *data);
+ u32 bnxt_fw_health_readl(struct bnxt *bp, int reg_idx);
+ void bnxt_set_tpa_flags(struct bnxt *bp);
+ void bnxt_set_ring_params(struct bnxt *);
+-int bnxt_set_rx_skb_mode(struct bnxt *bp, bool page_mode);
++void bnxt_set_rx_skb_mode(struct bnxt *bp, bool page_mode);
+ int bnxt_hwrm_func_drv_rgtr(struct bnxt *bp, unsigned long *bmap,
+ 			    int bmap_size, bool async_only);
+ int bnxt_hwrm_func_drv_unrgtr(struct bnxt *bp);
+diff --git a/drivers/net/ethernet/broadcom/bnxt/bnxt_xdp.c b/drivers/net/ethernet/broadcom/bnxt/bnxt_xdp.c
+index 07a458ecb7cc93..b6320b64b8e7f3 100644
+--- a/drivers/net/ethernet/broadcom/bnxt/bnxt_xdp.c
++++ b/drivers/net/ethernet/broadcom/bnxt/bnxt_xdp.c
+@@ -422,15 +422,8 @@ static int bnxt_xdp_set(struct bnxt *bp, struct bpf_prog *prog)
+ 		bnxt_set_rx_skb_mode(bp, true);
+ 		xdp_features_set_redirect_target(dev, true);
+ 	} else {
+-		int rx, tx;
+-
+ 		xdp_features_clear_redirect_target(dev);
+ 		bnxt_set_rx_skb_mode(bp, false);
+-		bnxt_get_max_rings(bp, &rx, &tx, true);
+-		if (rx > 1) {
+-			bp->flags &= ~BNXT_FLAG_NO_AGG_RINGS;
+-			bp->dev->hw_features |= NETIF_F_LRO;
+-		}
+ 	}
+ 	bp->tx_nr_rings_xdp = tx_xdp;
+ 	bp->tx_nr_rings = bp->tx_nr_rings_per_tc * tc + tx_xdp;
+diff --git a/drivers/net/ethernet/broadcom/genet/bcmgenet_wol.c b/drivers/net/ethernet/broadcom/genet/bcmgenet_wol.c
+index 3b082114f2e538..2033fb9d893e02 100644
+--- a/drivers/net/ethernet/broadcom/genet/bcmgenet_wol.c
++++ b/drivers/net/ethernet/broadcom/genet/bcmgenet_wol.c
+@@ -123,7 +123,7 @@ static int bcmgenet_poll_wol_status(struct bcmgenet_priv *priv)
+ 	while (!(bcmgenet_rbuf_readl(priv, RBUF_STATUS)
+ 		& RBUF_STATUS_WOL)) {
+ 		retries++;
+-		if (retries > 5) {
++		if (retries > 50) {
+ 			netdev_crit(dev, "polling wol mode timeout\n");
+ 			return -ETIMEDOUT;
+ 		}
+diff --git a/drivers/net/ethernet/cadence/macb.h b/drivers/net/ethernet/cadence/macb.h
+index 9fb5a18e056d41..e8f013ce166cea 100644
+--- a/drivers/net/ethernet/cadence/macb.h
++++ b/drivers/net/ethernet/cadence/macb.h
+@@ -645,6 +645,10 @@
+ #define GEM_T2OFST_OFFSET			0 /* offset value */
+ #define GEM_T2OFST_SIZE				7
+ 
++/* Bitfields in queue pointer registers */
++#define MACB_QUEUE_DISABLE_OFFSET		0 /* disable queue */
++#define MACB_QUEUE_DISABLE_SIZE			1
++
+ /* Offset for screener type 2 compare values (T2CMPOFST).
+  * Note the offset is applied after the specified point,
+  * e.g. GEM_T2COMPOFST_ETYPE denotes the EtherType field, so an offset
+@@ -733,6 +737,7 @@
+ #define MACB_CAPS_NEEDS_RSTONUBR		0x00000100
+ #define MACB_CAPS_MIIONRGMII			0x00000200
+ #define MACB_CAPS_NEED_TSUCLK			0x00000400
++#define MACB_CAPS_QUEUE_DISABLE			0x00000800
+ #define MACB_CAPS_PCS				0x01000000
+ #define MACB_CAPS_HIGH_SPEED			0x02000000
+ #define MACB_CAPS_CLK_HW_CHG			0x04000000
+@@ -1253,6 +1258,8 @@ struct macb {
+ 	u32	(*macb_reg_readl)(struct macb *bp, int offset);
+ 	void	(*macb_reg_writel)(struct macb *bp, int offset, u32 value);
+ 
++	struct macb_dma_desc	*rx_ring_tieoff;
++	dma_addr_t		rx_ring_tieoff_dma;
+ 	size_t			rx_buffer_size;
+ 
+ 	unsigned int		rx_ring_size;
+diff --git a/drivers/net/ethernet/cadence/macb_main.c b/drivers/net/ethernet/cadence/macb_main.c
+index e1df1546a2d6e2..693688a5800223 100644
+--- a/drivers/net/ethernet/cadence/macb_main.c
++++ b/drivers/net/ethernet/cadence/macb_main.c
+@@ -38,6 +38,7 @@
+ #include <linux/ptp_classify.h>
+ #include <linux/reset.h>
+ #include <linux/firmware/xlnx-zynqmp.h>
++#include <linux/gcd.h>
+ #include "macb.h"
+ 
+ /* This structure is only used for MACB on SiFive FU540 devices */
+@@ -719,6 +720,97 @@ static void macb_mac_link_down(struct phylink_config *config, unsigned int mode,
+ 	netif_tx_stop_all_queues(ndev);
+ }
+ 
++/* Use juggling algorithm to left rotate tx ring and tx skb array */
++static void gem_shuffle_tx_one_ring(struct macb_queue *queue)
++{
++	unsigned int head, tail, count, ring_size, desc_size;
++	struct macb_tx_skb tx_skb, *skb_curr, *skb_next;
++	struct macb_dma_desc *desc_curr, *desc_next;
++	unsigned int i, cycles, shift, curr, next;
++	struct macb *bp = queue->bp;
++	unsigned char desc[24];
++	unsigned long flags;
++
++	desc_size = macb_dma_desc_get_size(bp);
++
++	if (WARN_ON_ONCE(desc_size > ARRAY_SIZE(desc)))
++		return;
++
++	spin_lock_irqsave(&queue->tx_ptr_lock, flags);
++	head = queue->tx_head;
++	tail = queue->tx_tail;
++	ring_size = bp->tx_ring_size;
++	count = CIRC_CNT(head, tail, ring_size);
++
++	if (!(tail % ring_size))
++		goto unlock;
++
++	if (!count) {
++		queue->tx_head = 0;
++		queue->tx_tail = 0;
++		goto unlock;
++	}
++
++	shift = tail % ring_size;
++	cycles = gcd(ring_size, shift);
++
++	for (i = 0; i < cycles; i++) {
++		memcpy(&desc, macb_tx_desc(queue, i), desc_size);
++		memcpy(&tx_skb, macb_tx_skb(queue, i),
++		       sizeof(struct macb_tx_skb));
++
++		curr = i;
++		next = (curr + shift) % ring_size;
++
++		while (next != i) {
++			desc_curr = macb_tx_desc(queue, curr);
++			desc_next = macb_tx_desc(queue, next);
++
++			memcpy(desc_curr, desc_next, desc_size);
++
++			if (next == ring_size - 1)
++				desc_curr->ctrl &= ~MACB_BIT(TX_WRAP);
++			if (curr == ring_size - 1)
++				desc_curr->ctrl |= MACB_BIT(TX_WRAP);
++
++			skb_curr = macb_tx_skb(queue, curr);
++			skb_next = macb_tx_skb(queue, next);
++			memcpy(skb_curr, skb_next, sizeof(struct macb_tx_skb));
++
++			curr = next;
++			next = (curr + shift) % ring_size;
++		}
++
++		desc_curr = macb_tx_desc(queue, curr);
++		memcpy(desc_curr, &desc, desc_size);
++		if (i == ring_size - 1)
++			desc_curr->ctrl &= ~MACB_BIT(TX_WRAP);
++		if (curr == ring_size - 1)
++			desc_curr->ctrl |= MACB_BIT(TX_WRAP);
++		memcpy(macb_tx_skb(queue, curr), &tx_skb,
++		       sizeof(struct macb_tx_skb));
++	}
++
++	queue->tx_head = count;
++	queue->tx_tail = 0;
++
++	/* Make descriptor updates visible to hardware */
++	wmb();
++
++unlock:
++	spin_unlock_irqrestore(&queue->tx_ptr_lock, flags);
++}
++
++/* Rotate the queue so that the tail is at index 0 */
++static void gem_shuffle_tx_rings(struct macb *bp)
++{
++	struct macb_queue *queue;
++	int q;
++
++	for (q = 0, queue = bp->queues; q < bp->num_queues; q++, queue++)
++		gem_shuffle_tx_one_ring(queue);
++}
++
+ static void macb_mac_link_up(struct phylink_config *config,
+ 			     struct phy_device *phy,
+ 			     unsigned int mode, phy_interface_t interface,
+@@ -757,8 +849,6 @@ static void macb_mac_link_up(struct phylink_config *config,
+ 			ctrl |= MACB_BIT(PAE);
+ 
+ 		for (q = 0, queue = bp->queues; q < bp->num_queues; ++q, ++queue) {
+-			queue->tx_head = 0;
+-			queue->tx_tail = 0;
+ 			queue_writel(queue, IER,
+ 				     bp->rx_intr_mask | MACB_TX_INT_FLAGS | MACB_BIT(HRESP));
+ 		}
+@@ -772,8 +862,10 @@ static void macb_mac_link_up(struct phylink_config *config,
+ 
+ 	spin_unlock_irqrestore(&bp->lock, flags);
+ 
+-	if (!(bp->caps & MACB_CAPS_MACB_IS_EMAC))
++	if (!(bp->caps & MACB_CAPS_MACB_IS_EMAC)) {
+ 		macb_set_tx_clk(bp, speed);
++		gem_shuffle_tx_rings(bp);
++	}
+ 
+ 	/* Enable Rx and Tx; Enable PTP unicast */
+ 	ctrl = macb_readl(bp, NCR);
+@@ -2481,6 +2573,12 @@ static void macb_free_consistent(struct macb *bp)
+ 	unsigned int q;
+ 	int size;
+ 
++	if (bp->rx_ring_tieoff) {
++		dma_free_coherent(&bp->pdev->dev, macb_dma_desc_get_size(bp),
++				  bp->rx_ring_tieoff, bp->rx_ring_tieoff_dma);
++		bp->rx_ring_tieoff = NULL;
++	}
++
+ 	bp->macbgem_ops.mog_free_rx_buffers(bp);
+ 
+ 	for (q = 0, queue = bp->queues; q < bp->num_queues; ++q, ++queue) {
+@@ -2572,6 +2670,16 @@ static int macb_alloc_consistent(struct macb *bp)
+ 	if (bp->macbgem_ops.mog_alloc_rx_buffers(bp))
+ 		goto out_err;
+ 
++	/* Required for tie off descriptor for PM cases */
++	if (!(bp->caps & MACB_CAPS_QUEUE_DISABLE)) {
++		bp->rx_ring_tieoff = dma_alloc_coherent(&bp->pdev->dev,
++							macb_dma_desc_get_size(bp),
++							&bp->rx_ring_tieoff_dma,
++							GFP_KERNEL);
++		if (!bp->rx_ring_tieoff)
++			goto out_err;
++	}
++
+ 	return 0;
+ 
+ out_err:
+@@ -2579,6 +2687,27 @@ out_err:
+ 	return -ENOMEM;
+ }
+ 
++static void macb_init_tieoff(struct macb *bp)
++{
++	struct macb_dma_desc *desc = bp->rx_ring_tieoff;
++
++	if (bp->caps & MACB_CAPS_QUEUE_DISABLE)
++		return;
++	/* Setup a wrapping descriptor with no free slots
++	 * (WRAP and USED) to tie off/disable unused RX queues.
++	 */
++	macb_set_addr(bp, desc, MACB_BIT(RX_WRAP) | MACB_BIT(RX_USED));
++	desc->ctrl = 0;
++}
++
++static void gem_init_rx_ring(struct macb_queue *queue)
++{
++	queue->rx_tail = 0;
++	queue->rx_prepared_head = 0;
++
++	gem_rx_refill(queue);
++}
++
+ static void gem_init_rings(struct macb *bp)
+ {
+ 	struct macb_queue *queue;
+@@ -2596,12 +2725,10 @@ static void gem_init_rings(struct macb *bp)
+ 		queue->tx_head = 0;
+ 		queue->tx_tail = 0;
+ 
+-		queue->rx_tail = 0;
+-		queue->rx_prepared_head = 0;
+-
+-		gem_rx_refill(queue);
++		gem_init_rx_ring(queue);
+ 	}
+ 
++	macb_init_tieoff(bp);
+ }
+ 
+ static void macb_init_rings(struct macb *bp)
+@@ -2619,6 +2746,8 @@ static void macb_init_rings(struct macb *bp)
+ 	bp->queues[0].tx_head = 0;
+ 	bp->queues[0].tx_tail = 0;
+ 	desc->ctrl |= MACB_BIT(TX_WRAP);
++
++	macb_init_tieoff(bp);
+ }
+ 
+ static void macb_reset_hw(struct macb *bp)
+@@ -3726,6 +3855,9 @@ static int gem_set_rxnfc(struct net_device *netdev, struct ethtool_rxnfc *cmd)
+ 	struct macb *bp = netdev_priv(netdev);
+ 	int ret;
+ 
++	if (!(netdev->hw_features & NETIF_F_NTUPLE))
++		return -EOPNOTSUPP;
++
+ 	switch (cmd->cmd) {
+ 	case ETHTOOL_SRXCLSRLINS:
+ 		if ((cmd->fs.location >= bp->max_tuples)
+@@ -5210,6 +5342,7 @@ static int __maybe_unused macb_suspend(struct device *dev)
+ 	unsigned long flags;
+ 	unsigned int q;
+ 	int err;
++	u32 tmp;
+ 
+ 	if (!device_may_wakeup(&bp->dev->dev))
+ 		phy_exit(bp->sgmii_phy);
+@@ -5219,17 +5352,38 @@ static int __maybe_unused macb_suspend(struct device *dev)
+ 
+ 	if (bp->wol & MACB_WOL_ENABLED) {
+ 		spin_lock_irqsave(&bp->lock, flags);
+-		/* Flush all status bits */
+-		macb_writel(bp, TSR, -1);
+-		macb_writel(bp, RSR, -1);
++
++		/* Disable Tx and Rx engines before  disabling the queues,
++		 * this is mandatory as per the IP spec sheet
++		 */
++		tmp = macb_readl(bp, NCR);
++		macb_writel(bp, NCR, tmp & ~(MACB_BIT(TE) | MACB_BIT(RE)));
+ 		for (q = 0, queue = bp->queues; q < bp->num_queues;
+ 		     ++q, ++queue) {
++			/* Disable RX queues */
++			if (bp->caps & MACB_CAPS_QUEUE_DISABLE) {
++				queue_writel(queue, RBQP, MACB_BIT(QUEUE_DISABLE));
++			} else {
++				/* Tie off RX queues */
++				queue_writel(queue, RBQP,
++					     lower_32_bits(bp->rx_ring_tieoff_dma));
++#ifdef CONFIG_ARCH_DMA_ADDR_T_64BIT
++				queue_writel(queue, RBQPH,
++					     upper_32_bits(bp->rx_ring_tieoff_dma));
++#endif
++			}
+ 			/* Disable all interrupts */
+ 			queue_writel(queue, IDR, -1);
+ 			queue_readl(queue, ISR);
+ 			if (bp->caps & MACB_CAPS_ISR_CLEAR_ON_WRITE)
+ 				queue_writel(queue, ISR, -1);
+ 		}
++		/* Enable Receive engine */
++		macb_writel(bp, NCR, tmp | MACB_BIT(RE));
++		/* Flush all status bits */
++		macb_writel(bp, TSR, -1);
++		macb_writel(bp, RSR, -1);
++
+ 		/* Change interrupt handler and
+ 		 * Enable WoL IRQ on queue 0
+ 		 */
+@@ -5349,8 +5503,18 @@ static int __maybe_unused macb_resume(struct device *dev)
+ 		rtnl_unlock();
+ 	}
+ 
++	if (!(bp->caps & MACB_CAPS_MACB_IS_EMAC))
++		macb_init_buffers(bp);
++
+ 	for (q = 0, queue = bp->queues; q < bp->num_queues;
+ 	     ++q, ++queue) {
++		if (!(bp->caps & MACB_CAPS_MACB_IS_EMAC)) {
++			if (macb_is_gem(bp))
++				gem_init_rx_ring(queue);
++			else
++				macb_init_rx_ring(queue);
++		}
++
+ 		napi_enable(&queue->napi_rx);
+ 		napi_enable(&queue->napi_tx);
+ 	}
+diff --git a/drivers/net/ethernet/cadence/macb_ptp.c b/drivers/net/ethernet/cadence/macb_ptp.c
+index 51d26fa190d7d1..874d9577fc2907 100644
+--- a/drivers/net/ethernet/cadence/macb_ptp.c
++++ b/drivers/net/ethernet/cadence/macb_ptp.c
+@@ -355,8 +355,10 @@ void gem_ptp_remove(struct net_device *ndev)
+ {
+ 	struct macb *bp = netdev_priv(ndev);
+ 
+-	if (bp->ptp_clock)
++	if (bp->ptp_clock) {
+ 		ptp_clock_unregister(bp->ptp_clock);
++		bp->ptp_clock = NULL;
++	}
+ 
+ 	gem_ptp_clear_timer(bp);
+ 
+diff --git a/drivers/net/ethernet/freescale/dpaa2/dpaa2-switch.c b/drivers/net/ethernet/freescale/dpaa2/dpaa2-switch.c
+index 2631732ab2164a..176f7072338b27 100644
+--- a/drivers/net/ethernet/freescale/dpaa2/dpaa2-switch.c
++++ b/drivers/net/ethernet/freescale/dpaa2/dpaa2-switch.c
+@@ -1518,9 +1518,9 @@ static irqreturn_t dpaa2_switch_irq0_handler_thread(int irq_num, void *arg)
+ 	struct device *dev = (struct device *)arg;
+ 	struct ethsw_core *ethsw = dev_get_drvdata(dev);
+ 	struct ethsw_port_priv *port_priv;
+-	u32 status = ~0;
+ 	int err, if_id;
+ 	bool had_mac;
++	u32 status;
+ 
+ 	err = dpsw_get_irq_status(ethsw->mc_io, 0, ethsw->dpsw_handle,
+ 				  DPSW_IRQ_INDEX_IF, &status);
+@@ -1532,7 +1532,7 @@ static irqreturn_t dpaa2_switch_irq0_handler_thread(int irq_num, void *arg)
+ 	if_id = (status & 0xFFFF0000) >> 16;
+ 	if (if_id >= ethsw->sw_attr.num_ifs) {
+ 		dev_err(dev, "Invalid if_id %d in IRQ status\n", if_id);
+-		goto out;
++		goto out_clear;
+ 	}
+ 	port_priv = ethsw->ports[if_id];
+ 
+@@ -1553,12 +1553,13 @@ static irqreturn_t dpaa2_switch_irq0_handler_thread(int irq_num, void *arg)
+ 			dpaa2_switch_port_connect_mac(port_priv);
+ 	}
+ 
+-out:
++out_clear:
+ 	err = dpsw_clear_irq_status(ethsw->mc_io, 0, ethsw->dpsw_handle,
+ 				    DPSW_IRQ_INDEX_IF, status);
+ 	if (err)
+ 		dev_err(dev, "Can't clear irq status (err %d)\n", err);
+ 
++out:
+ 	return IRQ_HANDLED;
+ }
+ 
+diff --git a/drivers/net/ethernet/google/gve/gve.h b/drivers/net/ethernet/google/gve/gve.h
+index d59e28c8677523..f6e43cf96a4658 100644
+--- a/drivers/net/ethernet/google/gve/gve.h
++++ b/drivers/net/ethernet/google/gve/gve.h
+@@ -585,6 +585,7 @@ struct gve_notify_block {
+ 	struct gve_priv *priv;
+ 	struct gve_tx_ring *tx; /* tx rings on this block */
+ 	struct gve_rx_ring *rx; /* rx rings on this block */
++	u32 irq;
+ };
+ 
+ /* Tracks allowed and current queue settings */
+diff --git a/drivers/net/ethernet/google/gve/gve_main.c b/drivers/net/ethernet/google/gve/gve_main.c
+index b2c648fe387525..08f444ee10c75b 100644
+--- a/drivers/net/ethernet/google/gve/gve_main.c
++++ b/drivers/net/ethernet/google/gve/gve_main.c
+@@ -407,9 +407,10 @@ static int gve_alloc_notify_blocks(struct gve_priv *priv)
+ 		snprintf(block->name, sizeof(block->name), "gve-ntfy-blk%d@pci:%s",
+ 			 i, pci_name(priv->pdev));
+ 		block->priv = priv;
++		block->irq = priv->msix_vectors[msix_idx].vector;
+ 		err = request_irq(priv->msix_vectors[msix_idx].vector,
+ 				  gve_is_gqi(priv) ? gve_intr : gve_intr_dqo,
+-				  0, block->name, block);
++				  IRQF_NO_AUTOEN, block->name, block);
+ 		if (err) {
+ 			dev_err(&priv->pdev->dev,
+ 				"Failed to receive msix vector %d\n", i);
+@@ -575,6 +576,7 @@ static void gve_add_napi(struct gve_priv *priv, int ntfy_idx,
+ 	struct gve_notify_block *block = &priv->ntfy_blocks[ntfy_idx];
+ 
+ 	netif_napi_add(priv->dev, &block->napi, gve_poll);
++	enable_irq(block->irq);
+ }
+ 
+ static void gve_remove_napi(struct gve_priv *priv, int ntfy_idx)
+@@ -582,6 +584,7 @@ static void gve_remove_napi(struct gve_priv *priv, int ntfy_idx)
+ 	struct gve_notify_block *block = &priv->ntfy_blocks[ntfy_idx];
+ 
+ 	netif_napi_del(&block->napi);
++	disable_irq(block->irq);
+ }
+ 
+ static int gve_register_xdp_qpls(struct gve_priv *priv)
+diff --git a/drivers/net/ethernet/google/gve/gve_tx_dqo.c b/drivers/net/ethernet/google/gve/gve_tx_dqo.c
+index 857749fef37cf2..e3c46f791abdc3 100644
+--- a/drivers/net/ethernet/google/gve/gve_tx_dqo.c
++++ b/drivers/net/ethernet/google/gve/gve_tx_dqo.c
+@@ -157,6 +157,24 @@ gve_free_pending_packet(struct gve_tx_ring *tx,
+ 	}
+ }
+ 
++static void gve_unmap_packet(struct device *dev,
++			     struct gve_tx_pending_packet_dqo *pkt)
++{
++	int i;
++
++	if (!pkt->num_bufs)
++		return;
++
++	/* SKB linear portion is guaranteed to be mapped */
++	dma_unmap_single(dev, dma_unmap_addr(pkt, dma[0]),
++			 dma_unmap_len(pkt, len[0]), DMA_TO_DEVICE);
++	for (i = 1; i < pkt->num_bufs; i++) {
++		dma_unmap_page(dev, dma_unmap_addr(pkt, dma[i]),
++			       dma_unmap_len(pkt, len[i]), DMA_TO_DEVICE);
++	}
++	pkt->num_bufs = 0;
++}
++
+ /* gve_tx_free_desc - Cleans up all pending tx requests and buffers.
+  */
+ static void gve_tx_clean_pending_packets(struct gve_tx_ring *tx)
+@@ -166,21 +184,12 @@ static void gve_tx_clean_pending_packets(struct gve_tx_ring *tx)
+ 	for (i = 0; i < tx->dqo.num_pending_packets; i++) {
+ 		struct gve_tx_pending_packet_dqo *cur_state =
+ 			&tx->dqo.pending_packets[i];
+-		int j;
+-
+-		for (j = 0; j < cur_state->num_bufs; j++) {
+-			if (j == 0) {
+-				dma_unmap_single(tx->dev,
+-					dma_unmap_addr(cur_state, dma[j]),
+-					dma_unmap_len(cur_state, len[j]),
+-					DMA_TO_DEVICE);
+-			} else {
+-				dma_unmap_page(tx->dev,
+-					dma_unmap_addr(cur_state, dma[j]),
+-					dma_unmap_len(cur_state, len[j]),
+-					DMA_TO_DEVICE);
+-			}
+-		}
++
++		if (tx->dqo.qpl)
++			gve_free_tx_qpl_bufs(tx, cur_state);
++		else
++			gve_unmap_packet(tx->dev, cur_state);
++
+ 		if (cur_state->skb) {
+ 			dev_consume_skb_any(cur_state->skb);
+ 			cur_state->skb = NULL;
+@@ -992,21 +1001,6 @@ static void remove_from_list(struct gve_tx_ring *tx,
+ 	}
+ }
+ 
+-static void gve_unmap_packet(struct device *dev,
+-			     struct gve_tx_pending_packet_dqo *pkt)
+-{
+-	int i;
+-
+-	/* SKB linear portion is guaranteed to be mapped */
+-	dma_unmap_single(dev, dma_unmap_addr(pkt, dma[0]),
+-			 dma_unmap_len(pkt, len[0]), DMA_TO_DEVICE);
+-	for (i = 1; i < pkt->num_bufs; i++) {
+-		dma_unmap_page(dev, dma_unmap_addr(pkt, dma[i]),
+-			       dma_unmap_len(pkt, len[i]), DMA_TO_DEVICE);
+-	}
+-	pkt->num_bufs = 0;
+-}
+-
+ /* Completion types and expected behavior:
+  * No Miss compl + Packet compl = Packet completed normally.
+  * Miss compl + Re-inject compl = Packet completed normally.
+diff --git a/drivers/net/ethernet/intel/e1000/e1000_main.c b/drivers/net/ethernet/intel/e1000/e1000_main.c
+index d015a0a85f078b..8dcb5d7c5a4b3f 100644
+--- a/drivers/net/ethernet/intel/e1000/e1000_main.c
++++ b/drivers/net/ethernet/intel/e1000/e1000_main.c
+@@ -2951,8 +2951,6 @@ static int e1000_tx_map(struct e1000_adapter *adapter,
+ dma_error:
+ 	dev_err(&pdev->dev, "TX DMA map failed\n");
+ 	buffer_info->dma = 0;
+-	if (count)
+-		count--;
+ 
+ 	while (count--) {
+ 		if (i == 0)
+diff --git a/drivers/net/ethernet/intel/e1000e/defines.h b/drivers/net/ethernet/intel/e1000e/defines.h
+index 955bb116185728..c4db2927c6c428 100644
+--- a/drivers/net/ethernet/intel/e1000e/defines.h
++++ b/drivers/net/ethernet/intel/e1000e/defines.h
+@@ -33,6 +33,7 @@
+ 
+ /* Extended Device Control */
+ #define E1000_CTRL_EXT_LPCD  0x00000004     /* LCD Power Cycle Done */
++#define E1000_CTRL_EXT_DPG_EN	0x00000008 /* Dynamic Power Gating Enable */
+ #define E1000_CTRL_EXT_SDP3_DATA 0x00000080 /* Value of SW Definable Pin 3 */
+ #define E1000_CTRL_EXT_FORCE_SMBUS 0x00000800 /* Force SMBus mode */
+ #define E1000_CTRL_EXT_EE_RST    0x00002000 /* Reinitialize from EEPROM */
+diff --git a/drivers/net/ethernet/intel/e1000e/ich8lan.c b/drivers/net/ethernet/intel/e1000e/ich8lan.c
+index df4e7d781cb1cb..f9328caefe44b1 100644
+--- a/drivers/net/ethernet/intel/e1000e/ich8lan.c
++++ b/drivers/net/ethernet/intel/e1000e/ich8lan.c
+@@ -4925,6 +4925,15 @@ static s32 e1000_reset_hw_ich8lan(struct e1000_hw *hw)
+ 	reg |= E1000_KABGTXD_BGSQLBIAS;
+ 	ew32(KABGTXD, reg);
+ 
++	/* The hardware reset value of the DPG_EN bit is 1.
++	 * Clear DPG_EN to prevent unexpected autonomous power gating.
++	 */
++	if (hw->mac.type >= e1000_pch_ptp) {
++		reg = er32(CTRL_EXT);
++		reg &= ~E1000_CTRL_EXT_DPG_EN;
++		ew32(CTRL_EXT, reg);
++	}
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/net/ethernet/intel/e1000e/netdev.c b/drivers/net/ethernet/intel/e1000e/netdev.c
+index 7e4fea0e186b6e..9e9138ccac421f 100644
+--- a/drivers/net/ethernet/intel/e1000e/netdev.c
++++ b/drivers/net/ethernet/intel/e1000e/netdev.c
+@@ -5633,8 +5633,6 @@ static int e1000_tx_map(struct e1000_ring *tx_ring, struct sk_buff *skb,
+ dma_error:
+ 	dev_err(&pdev->dev, "Tx DMA map failed\n");
+ 	buffer_info->dma = 0;
+-	if (count)
+-		count--;
+ 
+ 	while (count--) {
+ 		if (i == 0)
+diff --git a/drivers/net/ethernet/intel/i40e/i40e_main.c b/drivers/net/ethernet/intel/i40e/i40e_main.c
+index 1f233fac9d4e3f..9bcd32d31da771 100644
+--- a/drivers/net/ethernet/intel/i40e/i40e_main.c
++++ b/drivers/net/ethernet/intel/i40e/i40e_main.c
+@@ -3623,6 +3623,7 @@ static int i40e_configure_rx_ring(struct i40e_ring *ring)
+ 	u16 pf_q = vsi->base_queue + ring->queue_index;
+ 	struct i40e_hw *hw = &vsi->back->hw;
+ 	struct i40e_hmc_obj_rxq rx_ctx;
++	u32 xdp_frame_sz;
+ 	int err = 0;
+ 	bool ok;
+ 
+@@ -3632,49 +3633,47 @@ static int i40e_configure_rx_ring(struct i40e_ring *ring)
+ 	memset(&rx_ctx, 0, sizeof(rx_ctx));
+ 
+ 	ring->rx_buf_len = vsi->rx_buf_len;
++	xdp_frame_sz = i40e_rx_pg_size(ring) / 2;
+ 
+ 	/* XDP RX-queue info only needed for RX rings exposed to XDP */
+ 	if (ring->vsi->type != I40E_VSI_MAIN)
+ 		goto skip;
+ 
+-	if (!xdp_rxq_info_is_reg(&ring->xdp_rxq)) {
+-		err = __xdp_rxq_info_reg(&ring->xdp_rxq, ring->netdev,
+-					 ring->queue_index,
+-					 ring->q_vector->napi.napi_id,
+-					 ring->rx_buf_len);
+-		if (err)
+-			return err;
+-	}
+-
+ 	ring->xsk_pool = i40e_xsk_pool(ring);
+ 	if (ring->xsk_pool) {
+-		xdp_rxq_info_unreg(&ring->xdp_rxq);
++		xdp_frame_sz = xsk_pool_get_rx_frag_step(ring->xsk_pool);
+ 		ring->rx_buf_len = xsk_pool_get_rx_frame_size(ring->xsk_pool);
+ 		err = __xdp_rxq_info_reg(&ring->xdp_rxq, ring->netdev,
+ 					 ring->queue_index,
+ 					 ring->q_vector->napi.napi_id,
+-					 ring->rx_buf_len);
++					 xdp_frame_sz);
+ 		if (err)
+ 			return err;
+ 		err = xdp_rxq_info_reg_mem_model(&ring->xdp_rxq,
+ 						 MEM_TYPE_XSK_BUFF_POOL,
+ 						 NULL);
+ 		if (err)
+-			return err;
++			goto unreg_xdp;
+ 		dev_info(&vsi->back->pdev->dev,
+ 			 "Registered XDP mem model MEM_TYPE_XSK_BUFF_POOL on Rx ring %d\n",
+ 			 ring->queue_index);
+ 
+ 	} else {
++		err = __xdp_rxq_info_reg(&ring->xdp_rxq, ring->netdev,
++					 ring->queue_index,
++					 ring->q_vector->napi.napi_id,
++					 xdp_frame_sz);
++		if (err)
++			return err;
+ 		err = xdp_rxq_info_reg_mem_model(&ring->xdp_rxq,
+ 						 MEM_TYPE_PAGE_SHARED,
+ 						 NULL);
+ 		if (err)
+-			return err;
++			goto unreg_xdp;
+ 	}
+ 
+ skip:
+-	xdp_init_buff(&ring->xdp, i40e_rx_pg_size(ring) / 2, &ring->xdp_rxq);
++	xdp_init_buff(&ring->xdp, xdp_frame_sz, &ring->xdp_rxq);
+ 
+ 	rx_ctx.dbuff = DIV_ROUND_UP(ring->rx_buf_len,
+ 				    BIT_ULL(I40E_RXQ_CTX_DBUFF_SHIFT));
+@@ -3708,7 +3707,8 @@ skip:
+ 		dev_info(&vsi->back->pdev->dev,
+ 			 "Failed to clear LAN Rx queue context on Rx ring %d (pf_q %d), error: %d\n",
+ 			 ring->queue_index, pf_q, err);
+-		return -ENOMEM;
++		err = -ENOMEM;
++		goto unreg_xdp;
+ 	}
+ 
+ 	/* set the context in the HMC */
+@@ -3717,7 +3717,8 @@ skip:
+ 		dev_info(&vsi->back->pdev->dev,
+ 			 "Failed to set LAN Rx queue context on Rx ring %d (pf_q %d), error: %d\n",
+ 			 ring->queue_index, pf_q, err);
+-		return -ENOMEM;
++		err = -ENOMEM;
++		goto unreg_xdp;
+ 	}
+ 
+ 	/* configure Rx buffer alignment */
+@@ -3725,7 +3726,8 @@ skip:
+ 		if (I40E_2K_TOO_SMALL_WITH_PADDING) {
+ 			dev_info(&vsi->back->pdev->dev,
+ 				 "2k Rx buffer is too small to fit standard MTU and skb_shared_info\n");
+-			return -EOPNOTSUPP;
++			err = -EOPNOTSUPP;
++			goto unreg_xdp;
+ 		}
+ 		clear_ring_build_skb_enabled(ring);
+ 	} else {
+@@ -3755,6 +3757,11 @@ skip:
+ 	}
+ 
+ 	return 0;
++unreg_xdp:
++	if (ring->vsi->type == I40E_VSI_MAIN)
++		xdp_rxq_info_unreg(&ring->xdp_rxq);
++
++	return err;
+ }
+ 
+ /**
+diff --git a/drivers/net/ethernet/intel/i40e/i40e_txrx.c b/drivers/net/ethernet/intel/i40e/i40e_txrx.c
+index 99604379c87b6c..873fd080de939d 100644
+--- a/drivers/net/ethernet/intel/i40e/i40e_txrx.c
++++ b/drivers/net/ethernet/intel/i40e/i40e_txrx.c
+@@ -1473,6 +1473,9 @@ void i40e_clean_rx_ring(struct i40e_ring *rx_ring)
+ 	if (!rx_ring->rx_bi)
+ 		return;
+ 
++	if (xdp_rxq_info_is_reg(&rx_ring->xdp_rxq))
++		xdp_rxq_info_unreg(&rx_ring->xdp_rxq);
++
+ 	if (rx_ring->xsk_pool) {
+ 		i40e_xsk_clean_rx_ring(rx_ring);
+ 		goto skip_free;
+@@ -1530,8 +1533,6 @@ skip_free:
+ void i40e_free_rx_resources(struct i40e_ring *rx_ring)
+ {
+ 	i40e_clean_rx_ring(rx_ring);
+-	if (rx_ring->vsi->type == I40E_VSI_MAIN)
+-		xdp_rxq_info_unreg(&rx_ring->xdp_rxq);
+ 	rx_ring->xdp_prog = NULL;
+ 	kfree(rx_ring->rx_bi);
+ 	rx_ring->rx_bi = NULL;
+diff --git a/drivers/net/ethernet/intel/i40e/i40e_virtchnl_pf.c b/drivers/net/ethernet/intel/i40e/i40e_virtchnl_pf.c
+index 7f5538e2c9de5c..a9c492d747b9f5 100644
+--- a/drivers/net/ethernet/intel/i40e/i40e_virtchnl_pf.c
++++ b/drivers/net/ethernet/intel/i40e/i40e_virtchnl_pf.c
+@@ -3825,10 +3825,10 @@ static int i40e_vc_del_cloud_filter(struct i40e_vf *vf, u8 *msg)
+ 		cfilter.n_proto = ETH_P_IP;
+ 		if (mask.dst_ip[0] & tcf.dst_ip[0])
+ 			memcpy(&cfilter.ip.v4.dst_ip, tcf.dst_ip,
+-			       ARRAY_SIZE(tcf.dst_ip));
+-		else if (mask.src_ip[0] & tcf.dst_ip[0])
++			       sizeof(cfilter.ip.v4.dst_ip));
++		else if (mask.src_ip[0] & tcf.src_ip[0])
+ 			memcpy(&cfilter.ip.v4.src_ip, tcf.src_ip,
+-			       ARRAY_SIZE(tcf.dst_ip));
++			       sizeof(cfilter.ip.v4.src_ip));
+ 		break;
+ 	case VIRTCHNL_TCP_V6_FLOW:
+ 		cfilter.n_proto = ETH_P_IPV6;
+@@ -3883,7 +3883,7 @@ static int i40e_vc_del_cloud_filter(struct i40e_vf *vf, u8 *msg)
+ 		/* for ipv6, mask is set for all sixteen bytes (4 words) */
+ 		if (cfilter.n_proto == ETH_P_IPV6 && mask.dst_ip[3])
+ 			if (memcmp(&cfilter.ip.v6.dst_ip6, &cf->ip.v6.dst_ip6,
+-				   sizeof(cfilter.ip.v6.src_ip6)))
++				   sizeof(cfilter.ip.v6.dst_ip6)))
+ 				continue;
+ 		if (mask.vlan_id)
+ 			if (cfilter.vlan_id != cf->vlan_id)
+@@ -3971,10 +3971,10 @@ static int i40e_vc_add_cloud_filter(struct i40e_vf *vf, u8 *msg)
+ 		cfilter->n_proto = ETH_P_IP;
+ 		if (mask.dst_ip[0] & tcf.dst_ip[0])
+ 			memcpy(&cfilter->ip.v4.dst_ip, tcf.dst_ip,
+-			       ARRAY_SIZE(tcf.dst_ip));
+-		else if (mask.src_ip[0] & tcf.dst_ip[0])
++			       sizeof(cfilter->ip.v4.dst_ip));
++		else if (mask.src_ip[0] & tcf.src_ip[0])
+ 			memcpy(&cfilter->ip.v4.src_ip, tcf.src_ip,
+-			       ARRAY_SIZE(tcf.dst_ip));
++			       sizeof(cfilter->ip.v4.src_ip));
+ 		break;
+ 	case VIRTCHNL_TCP_V6_FLOW:
+ 		cfilter->n_proto = ETH_P_IPV6;
+diff --git a/drivers/net/ethernet/intel/iavf/iavf_main.c b/drivers/net/ethernet/intel/iavf/iavf_main.c
+index f6a748ae1c9597..02e07fe6a05284 100644
+--- a/drivers/net/ethernet/intel/iavf/iavf_main.c
++++ b/drivers/net/ethernet/intel/iavf/iavf_main.c
+@@ -802,10 +802,13 @@ iavf_vlan_filter *iavf_add_vlan(struct iavf_adapter *adapter,
+ 		adapter->num_vlan_filters++;
+ 		iavf_schedule_aq_request(adapter, IAVF_FLAG_AQ_ADD_VLAN_FILTER);
+ 	} else if (f->state == IAVF_VLAN_REMOVE) {
+-		/* IAVF_VLAN_REMOVE means that VLAN wasn't yet removed.
+-		 * We can safely only change the state here.
++		/* Re-add the filter since we cannot tell whether the
++		 * pending delete has already been processed by the PF.
++		 * A duplicate add is harmless.
+ 		 */
+-		f->state = IAVF_VLAN_ACTIVE;
++		f->state = IAVF_VLAN_ADD;
++		iavf_schedule_aq_request(adapter,
++					 IAVF_FLAG_AQ_ADD_VLAN_FILTER);
+ 	}
+ 
+ clearout:
+diff --git a/drivers/net/ethernet/intel/ice/ice_common.c b/drivers/net/ethernet/intel/ice/ice_common.c
+index 983332cbace21f..eaf1ed6c9df4a2 100644
+--- a/drivers/net/ethernet/intel/ice/ice_common.c
++++ b/drivers/net/ethernet/intel/ice/ice_common.c
+@@ -1611,6 +1611,7 @@ static bool ice_should_retry_sq_send_cmd(u16 opcode)
+ 	case ice_aqc_opc_lldp_stop:
+ 	case ice_aqc_opc_lldp_start:
+ 	case ice_aqc_opc_lldp_filter_ctrl:
++	case ice_aqc_opc_sff_eeprom:
+ 		return true;
+ 	}
+ 
+@@ -1636,6 +1637,7 @@ ice_sq_send_cmd_retry(struct ice_hw *hw, struct ice_ctl_q_info *cq,
+ {
+ 	struct ice_aq_desc desc_cpy;
+ 	bool is_cmd_for_retry;
++	u8 *buf_cpy = NULL;
+ 	u8 idx = 0;
+ 	u16 opcode;
+ 	int status;
+@@ -1645,8 +1647,11 @@ ice_sq_send_cmd_retry(struct ice_hw *hw, struct ice_ctl_q_info *cq,
+ 	memset(&desc_cpy, 0, sizeof(desc_cpy));
+ 
+ 	if (is_cmd_for_retry) {
+-		/* All retryable cmds are direct, without buf. */
+-		WARN_ON(buf);
++		if (buf) {
++			buf_cpy = kmemdup(buf, buf_size, GFP_KERNEL);
++			if (!buf_cpy)
++				return -ENOMEM;
++		}
+ 
+ 		memcpy(&desc_cpy, desc, sizeof(desc_cpy));
+ 	}
+@@ -1658,12 +1663,14 @@ ice_sq_send_cmd_retry(struct ice_hw *hw, struct ice_ctl_q_info *cq,
+ 		    hw->adminq.sq_last_status != ICE_AQ_RC_EBUSY)
+ 			break;
+ 
++		if (buf_cpy)
++			memcpy(buf, buf_cpy, buf_size);
+ 		memcpy(desc, &desc_cpy, sizeof(desc_cpy));
+-
+ 		msleep(ICE_SQ_SEND_DELAY_TIME_MS);
+ 
+ 	} while (++idx < ICE_SQ_SEND_MAX_EXECUTE);
+ 
++	kfree(buf_cpy);
+ 	return status;
+ }
+ 
+diff --git a/drivers/net/ethernet/intel/ice/ice_ethtool.c b/drivers/net/ethernet/intel/ice/ice_ethtool.c
+index dd58b2372dc0c7..1c91f1ba118894 100644
+--- a/drivers/net/ethernet/intel/ice/ice_ethtool.c
++++ b/drivers/net/ethernet/intel/ice/ice_ethtool.c
+@@ -4045,7 +4045,7 @@ ice_get_module_eeprom(struct net_device *netdev,
+ 	struct ice_pf *pf = vsi->back;
+ 	struct ice_hw *hw = &pf->hw;
+ 	bool is_sfp = false;
+-	unsigned int i, j;
++	unsigned int i;
+ 	u16 offset = 0;
+ 	u8 page = 0;
+ 	int status;
+@@ -4087,26 +4087,19 @@ ice_get_module_eeprom(struct net_device *netdev,
+ 		if (page == 0 || !(data[0x2] & 0x4)) {
+ 			u32 copy_len;
+ 
+-			/* If i2c bus is busy due to slow page change or
+-			 * link management access, call can fail. This is normal.
+-			 * So we retry this a few times.
+-			 */
+-			for (j = 0; j < 4; j++) {
+-				status = ice_aq_sff_eeprom(hw, 0, addr, offset, page,
+-							   !is_sfp, value,
+-							   SFF_READ_BLOCK_SIZE,
+-							   0, NULL);
+-				netdev_dbg(netdev, "SFF %02X %02X %02X %X = %02X%02X%02X%02X.%02X%02X%02X%02X (%X)\n",
+-					   addr, offset, page, is_sfp,
+-					   value[0], value[1], value[2], value[3],
+-					   value[4], value[5], value[6], value[7],
+-					   status);
+-				if (status) {
+-					usleep_range(1500, 2500);
+-					memset(value, 0, SFF_READ_BLOCK_SIZE);
+-					continue;
+-				}
+-				break;
++			status = ice_aq_sff_eeprom(hw, 0, addr, offset, page,
++						   !is_sfp, value,
++						   SFF_READ_BLOCK_SIZE,
++						   0, NULL);
++			netdev_dbg(netdev, "SFF %02X %02X %02X %X = %02X%02X%02X%02X.%02X%02X%02X%02X (%pe)\n",
++				   addr, offset, page, is_sfp,
++				   value[0], value[1], value[2], value[3],
++				   value[4], value[5], value[6], value[7],
++				   ERR_PTR(status));
++			if (status) {
++				netdev_err(netdev, "%s: error reading module EEPROM: status %pe\n",
++					   __func__, ERR_PTR(status));
++				return status;
+ 			}
+ 
+ 			/* Make sure we have enough room for the new block */
+diff --git a/drivers/net/ethernet/intel/igc/igc_main.c b/drivers/net/ethernet/intel/igc/igc_main.c
+index 3e1408e1c1fcfb..13c41facfc9760 100644
+--- a/drivers/net/ethernet/intel/igc/igc_main.c
++++ b/drivers/net/ethernet/intel/igc/igc_main.c
+@@ -1700,11 +1700,8 @@ static netdev_tx_t igc_xmit_frame(struct sk_buff *skb,
+ 	/* The minimum packet size with TCTL.PSP set is 17 so pad the skb
+ 	 * in order to meet this minimum size requirement.
+ 	 */
+-	if (skb->len < 17) {
+-		if (skb_padto(skb, 17))
+-			return NETDEV_TX_OK;
+-		skb->len = 17;
+-	}
++	if (skb_put_padto(skb, 17))
++		return NETDEV_TX_OK;
+ 
+ 	return igc_xmit_frame_ring(skb, igc_tx_queue_mapping(adapter, skb));
+ }
+diff --git a/drivers/net/ethernet/intel/ixgbevf/vf.c b/drivers/net/ethernet/intel/ixgbevf/vf.c
+index 65257107dfc8a4..708d5dd921accf 100644
+--- a/drivers/net/ethernet/intel/ixgbevf/vf.c
++++ b/drivers/net/ethernet/intel/ixgbevf/vf.c
+@@ -852,7 +852,8 @@ static s32 ixgbevf_check_mac_link_vf(struct ixgbe_hw *hw,
+ 	if (!mac->get_link_status)
+ 		goto out;
+ 
+-	if (hw->mac.type == ixgbe_mac_e610_vf) {
++	if (hw->mac.type == ixgbe_mac_e610_vf &&
++	    hw->api_version >= ixgbe_mbox_api_16) {
+ 		ret_val = ixgbevf_get_pf_link_state(hw, speed, link_up);
+ 		if (ret_val)
+ 			goto out;
+diff --git a/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c b/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
+index aabc39f7690f8e..410c9dea4fa2ef 100644
+--- a/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
++++ b/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
+@@ -5012,7 +5012,7 @@ static int mvpp2_bm_switch_buffers(struct mvpp2 *priv, bool percpu)
+ 	if (priv->percpu_pools)
+ 		numbufs = port->nrxqs * 2;
+ 
+-	if (change_percpu)
++	if (change_percpu && priv->global_tx_fc)
+ 		mvpp2_bm_pool_update_priv_fc(priv, false);
+ 
+ 	for (i = 0; i < numbufs; i++)
+@@ -5037,7 +5037,7 @@ static int mvpp2_bm_switch_buffers(struct mvpp2 *priv, bool percpu)
+ 			mvpp2_open(port->dev);
+ 	}
+ 
+-	if (change_percpu)
++	if (change_percpu && priv->global_tx_fc)
+ 		mvpp2_bm_pool_update_priv_fc(priv, true);
+ 
+ 	return 0;
+diff --git a/drivers/net/ethernet/marvell/octeon_ep/octep_main.c b/drivers/net/ethernet/marvell/octeon_ep/octep_main.c
+index db24c290a90796..e4a78d5e734954 100644
+--- a/drivers/net/ethernet/marvell/octeon_ep/octep_main.c
++++ b/drivers/net/ethernet/marvell/octeon_ep/octep_main.c
+@@ -534,28 +534,43 @@ static void octep_clean_irqs(struct octep_device *oct)
+ }
+ 
+ /**
+- * octep_enable_ioq_irq() - Enable MSI-x interrupt of a Tx/Rx queue.
++ * octep_update_pkt() - Update IQ/OQ IN/OUT_CNT registers.
+  *
+  * @iq: Octeon Tx queue data structure.
+  * @oq: Octeon Rx queue data structure.
+  */
+-static void octep_enable_ioq_irq(struct octep_iq *iq, struct octep_oq *oq)
++static void octep_update_pkt(struct octep_iq *iq, struct octep_oq *oq)
+ {
+-	u32 pkts_pend = oq->pkts_pending;
++	u32 pkts_pend = READ_ONCE(oq->pkts_pending);
++	u32 last_pkt_count = READ_ONCE(oq->last_pkt_count);
++	u32 pkts_processed = READ_ONCE(iq->pkts_processed);
++	u32 pkt_in_done = READ_ONCE(iq->pkt_in_done);
+ 
+ 	netdev_dbg(iq->netdev, "enabling intr for Q-%u\n", iq->q_no);
+-	if (iq->pkts_processed) {
+-		writel(iq->pkts_processed, iq->inst_cnt_reg);
+-		iq->pkt_in_done -= iq->pkts_processed;
+-		iq->pkts_processed = 0;
++	if (pkts_processed) {
++		writel(pkts_processed, iq->inst_cnt_reg);
++		readl(iq->inst_cnt_reg);
++		WRITE_ONCE(iq->pkt_in_done, (pkt_in_done - pkts_processed));
++		WRITE_ONCE(iq->pkts_processed, 0);
+ 	}
+-	if (oq->last_pkt_count - pkts_pend) {
+-		writel(oq->last_pkt_count - pkts_pend, oq->pkts_sent_reg);
+-		oq->last_pkt_count = pkts_pend;
++	if (last_pkt_count - pkts_pend) {
++		writel(last_pkt_count - pkts_pend, oq->pkts_sent_reg);
++		readl(oq->pkts_sent_reg);
++		WRITE_ONCE(oq->last_pkt_count, pkts_pend);
+ 	}
+ 
+ 	/* Flush the previous wrties before writing to RESEND bit */
+-	wmb();
++	smp_wmb();
++}
++
++/**
++ * octep_enable_ioq_irq() - Enable MSI-x interrupt of a Tx/Rx queue.
++ *
++ * @iq: Octeon Tx queue data structure.
++ * @oq: Octeon Rx queue data structure.
++ */
++static void octep_enable_ioq_irq(struct octep_iq *iq, struct octep_oq *oq)
++{
+ 	writeq(1UL << OCTEP_OQ_INTR_RESEND_BIT, oq->pkts_sent_reg);
+ 	writeq(1UL << OCTEP_IQ_INTR_RESEND_BIT, iq->inst_cnt_reg);
+ }
+@@ -581,7 +596,8 @@ static int octep_napi_poll(struct napi_struct *napi, int budget)
+ 	if (tx_pending || rx_done >= budget)
+ 		return budget;
+ 
+-	napi_complete(napi);
++	octep_update_pkt(ioq_vector->iq, ioq_vector->oq);
++	napi_complete_done(napi, rx_done);
+ 	octep_enable_ioq_irq(ioq_vector->iq, ioq_vector->oq);
+ 	return rx_done;
+ }
+diff --git a/drivers/net/ethernet/marvell/octeon_ep/octep_rx.c b/drivers/net/ethernet/marvell/octeon_ep/octep_rx.c
+index 60afb6bf2f6792..e0c1e13e48c027 100644
+--- a/drivers/net/ethernet/marvell/octeon_ep/octep_rx.c
++++ b/drivers/net/ethernet/marvell/octeon_ep/octep_rx.c
+@@ -323,10 +323,16 @@ static int octep_oq_check_hw_for_pkts(struct octep_device *oct,
+ 				      struct octep_oq *oq)
+ {
+ 	u32 pkt_count, new_pkts;
++	u32 last_pkt_count, pkts_pending;
+ 
+ 	pkt_count = readl(oq->pkts_sent_reg);
+-	new_pkts = pkt_count - oq->last_pkt_count;
++	last_pkt_count = READ_ONCE(oq->last_pkt_count);
++	new_pkts = pkt_count - last_pkt_count;
+ 
++	if (pkt_count < last_pkt_count) {
++		dev_err(oq->dev, "OQ-%u pkt_count(%u) < oq->last_pkt_count(%u)\n",
++			oq->q_no, pkt_count, last_pkt_count);
++	}
+ 	/* Clear the hardware packets counter register if the rx queue is
+ 	 * being processed continuously with-in a single interrupt and
+ 	 * reached half its max value.
+@@ -337,8 +343,9 @@ static int octep_oq_check_hw_for_pkts(struct octep_device *oct,
+ 		pkt_count = readl(oq->pkts_sent_reg);
+ 		new_pkts += pkt_count;
+ 	}
+-	oq->last_pkt_count = pkt_count;
+-	oq->pkts_pending += new_pkts;
++	WRITE_ONCE(oq->last_pkt_count, pkt_count);
++	pkts_pending = READ_ONCE(oq->pkts_pending);
++	WRITE_ONCE(oq->pkts_pending, (pkts_pending + new_pkts));
+ 	return new_pkts;
+ }
+ 
+@@ -411,7 +418,7 @@ static int __octep_oq_process_rx(struct octep_device *oct,
+ 	u16 data_offset;
+ 	u32 read_idx;
+ 
+-	read_idx = oq->host_read_idx;
++	read_idx = READ_ONCE(oq->host_read_idx);
+ 	rx_bytes = 0;
+ 	desc_used = 0;
+ 	for (pkt = 0; pkt < pkts_to_process; pkt++) {
+@@ -494,7 +501,7 @@ static int __octep_oq_process_rx(struct octep_device *oct,
+ 		napi_gro_receive(oq->napi, skb);
+ 	}
+ 
+-	oq->host_read_idx = read_idx;
++	WRITE_ONCE(oq->host_read_idx, read_idx);
+ 	oq->refill_count += desc_used;
+ 	oq->stats.packets += pkt;
+ 	oq->stats.bytes += rx_bytes;
+@@ -517,22 +524,26 @@ int octep_oq_process_rx(struct octep_oq *oq, int budget)
+ {
+ 	u32 pkts_available, pkts_processed, total_pkts_processed;
+ 	struct octep_device *oct = oq->octep_dev;
++	u32 pkts_pending;
+ 
+ 	pkts_available = 0;
+ 	pkts_processed = 0;
+ 	total_pkts_processed = 0;
+ 	while (total_pkts_processed < budget) {
+ 		 /* update pending count only when current one exhausted */
+-		if (oq->pkts_pending == 0)
++		pkts_pending = READ_ONCE(oq->pkts_pending);
++		if (pkts_pending == 0)
+ 			octep_oq_check_hw_for_pkts(oct, oq);
++		pkts_pending = READ_ONCE(oq->pkts_pending);
+ 		pkts_available = min(budget - total_pkts_processed,
+-				     oq->pkts_pending);
++				     pkts_pending);
+ 		if (!pkts_available)
+ 			break;
+ 
+ 		pkts_processed = __octep_oq_process_rx(oct, oq,
+ 						       pkts_available);
+-		oq->pkts_pending -= pkts_processed;
++		pkts_pending = READ_ONCE(oq->pkts_pending);
++		WRITE_ONCE(oq->pkts_pending, (pkts_pending - pkts_processed));
+ 		total_pkts_processed += pkts_processed;
+ 	}
+ 
+diff --git a/drivers/net/ethernet/marvell/octeontx2/af/rvu_devlink.c b/drivers/net/ethernet/marvell/octeontx2/af/rvu_devlink.c
+index 774d8b034725d6..f524ecb4645a95 100644
+--- a/drivers/net/ethernet/marvell/octeontx2/af/rvu_devlink.c
++++ b/drivers/net/ethernet/marvell/octeontx2/af/rvu_devlink.c
+@@ -14,26 +14,16 @@
+ 
+ #define DRV_NAME "octeontx2-af"
+ 
+-static int rvu_report_pair_start(struct devlink_fmsg *fmsg, const char *name)
++static void rvu_report_pair_start(struct devlink_fmsg *fmsg, const char *name)
+ {
+-	int err;
+-
+-	err = devlink_fmsg_pair_nest_start(fmsg, name);
+-	if (err)
+-		return err;
+-
+-	return  devlink_fmsg_obj_nest_start(fmsg);
++	devlink_fmsg_pair_nest_start(fmsg, name);
++	devlink_fmsg_obj_nest_start(fmsg);
+ }
+ 
+-static int rvu_report_pair_end(struct devlink_fmsg *fmsg)
++static void rvu_report_pair_end(struct devlink_fmsg *fmsg)
+ {
+-	int err;
+-
+-	err = devlink_fmsg_obj_nest_end(fmsg);
+-	if (err)
+-		return err;
+-
+-	return devlink_fmsg_pair_nest_end(fmsg);
++	devlink_fmsg_obj_nest_end(fmsg);
++	devlink_fmsg_pair_nest_end(fmsg);
+ }
+ 
+ static bool rvu_common_request_irq(struct rvu *rvu, int offset,
+@@ -284,175 +274,81 @@ static int rvu_nix_report_show(struct devlink_fmsg *fmsg, void *ctx,
+ {
+ 	struct rvu_nix_event_ctx *nix_event_context;
+ 	u64 intr_val;
+-	int err;
+ 
+ 	nix_event_context = ctx;
+ 	switch (health_reporter) {
+ 	case NIX_AF_RVU_INTR:
+ 		intr_val = nix_event_context->nix_af_rvu_int;
+-		err = rvu_report_pair_start(fmsg, "NIX_AF_RVU");
+-		if (err)
+-			return err;
+-		err = devlink_fmsg_u64_pair_put(fmsg, "\tNIX RVU Interrupt Reg ",
+-						nix_event_context->nix_af_rvu_int);
+-		if (err)
+-			return err;
+-		if (intr_val & BIT_ULL(0)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tUnmap Slot Error");
+-			if (err)
+-				return err;
+-		}
+-		err = rvu_report_pair_end(fmsg);
+-		if (err)
+-			return err;
++		rvu_report_pair_start(fmsg, "NIX_AF_RVU");
++		devlink_fmsg_u64_pair_put(fmsg, "\tNIX RVU Interrupt Reg ",
++					  nix_event_context->nix_af_rvu_int);
++		if (intr_val & BIT_ULL(0))
++			devlink_fmsg_string_put(fmsg, "\n\tUnmap Slot Error");
++		rvu_report_pair_end(fmsg);
+ 		break;
+ 	case NIX_AF_RVU_GEN:
+ 		intr_val = nix_event_context->nix_af_rvu_gen;
+-		err = rvu_report_pair_start(fmsg, "NIX_AF_GENERAL");
+-		if (err)
+-			return err;
+-		err = devlink_fmsg_u64_pair_put(fmsg, "\tNIX General Interrupt Reg ",
+-						nix_event_context->nix_af_rvu_gen);
+-		if (err)
+-			return err;
+-		if (intr_val & BIT_ULL(0)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tRx multicast pkt drop");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(1)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tRx mirror pkt drop");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(4)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tSMQ flush done");
+-			if (err)
+-				return err;
+-		}
+-		err = rvu_report_pair_end(fmsg);
+-		if (err)
+-			return err;
++		rvu_report_pair_start(fmsg, "NIX_AF_GENERAL");
++		devlink_fmsg_u64_pair_put(fmsg, "\tNIX General Interrupt Reg ",
++					  nix_event_context->nix_af_rvu_gen);
++		if (intr_val & BIT_ULL(0))
++			devlink_fmsg_string_put(fmsg, "\n\tRx multicast pkt drop");
++		if (intr_val & BIT_ULL(1))
++			devlink_fmsg_string_put(fmsg, "\n\tRx mirror pkt drop");
++		if (intr_val & BIT_ULL(4))
++			devlink_fmsg_string_put(fmsg, "\n\tSMQ flush done");
++		rvu_report_pair_end(fmsg);
+ 		break;
+ 	case NIX_AF_RVU_ERR:
+ 		intr_val = nix_event_context->nix_af_rvu_err;
+-		err = rvu_report_pair_start(fmsg, "NIX_AF_ERR");
+-		if (err)
+-			return err;
+-		err = devlink_fmsg_u64_pair_put(fmsg, "\tNIX Error Interrupt Reg ",
+-						nix_event_context->nix_af_rvu_err);
+-		if (err)
+-			return err;
+-		if (intr_val & BIT_ULL(14)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFault on NIX_AQ_INST_S read");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(13)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFault on NIX_AQ_RES_S write");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(12)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tAQ Doorbell Error");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(6)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tRx on unmapped PF_FUNC");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(5)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tRx multicast replication error");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(4)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFault on NIX_RX_MCE_S read");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(3)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFault on multicast WQE read");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(2)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFault on mirror WQE read");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(1)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFault on mirror pkt write");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(0)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFault on multicast pkt write");
+-			if (err)
+-				return err;
+-		}
+-		err = rvu_report_pair_end(fmsg);
+-		if (err)
+-			return err;
++		rvu_report_pair_start(fmsg, "NIX_AF_ERR");
++		devlink_fmsg_u64_pair_put(fmsg, "\tNIX Error Interrupt Reg ",
++					  nix_event_context->nix_af_rvu_err);
++		if (intr_val & BIT_ULL(14))
++			devlink_fmsg_string_put(fmsg, "\n\tFault on NIX_AQ_INST_S read");
++		if (intr_val & BIT_ULL(13))
++			devlink_fmsg_string_put(fmsg, "\n\tFault on NIX_AQ_RES_S write");
++		if (intr_val & BIT_ULL(12))
++			devlink_fmsg_string_put(fmsg, "\n\tAQ Doorbell Error");
++		if (intr_val & BIT_ULL(6))
++			devlink_fmsg_string_put(fmsg, "\n\tRx on unmapped PF_FUNC");
++		if (intr_val & BIT_ULL(5))
++			devlink_fmsg_string_put(fmsg, "\n\tRx multicast replication error");
++		if (intr_val & BIT_ULL(4))
++			devlink_fmsg_string_put(fmsg, "\n\tFault on NIX_RX_MCE_S read");
++		if (intr_val & BIT_ULL(3))
++			devlink_fmsg_string_put(fmsg, "\n\tFault on multicast WQE read");
++		if (intr_val & BIT_ULL(2))
++			devlink_fmsg_string_put(fmsg, "\n\tFault on mirror WQE read");
++		if (intr_val & BIT_ULL(1))
++			devlink_fmsg_string_put(fmsg, "\n\tFault on mirror pkt write");
++		if (intr_val & BIT_ULL(0))
++			devlink_fmsg_string_put(fmsg, "\n\tFault on multicast pkt write");
++		rvu_report_pair_end(fmsg);
+ 		break;
+ 	case NIX_AF_RVU_RAS:
+-		intr_val = nix_event_context->nix_af_rvu_err;
+-		err = rvu_report_pair_start(fmsg, "NIX_AF_RAS");
+-		if (err)
+-			return err;
+-		err = devlink_fmsg_u64_pair_put(fmsg, "\tNIX RAS Interrupt Reg ",
+-						nix_event_context->nix_af_rvu_err);
+-		if (err)
+-			return err;
+-		err = devlink_fmsg_string_put(fmsg, "\n\tPoison Data on:");
+-		if (err)
+-			return err;
+-		if (intr_val & BIT_ULL(34)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tNIX_AQ_INST_S");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(33)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tNIX_AQ_RES_S");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(32)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tHW ctx");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(4)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tPacket from mirror buffer");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(3)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tPacket from multicast buffer");
+-
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(2)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tWQE read from mirror buffer");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(1)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tWQE read from multicast buffer");
+-			if (err)
+-				return err;
+-		}
+-		if (intr_val & BIT_ULL(0)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tNIX_RX_MCE_S read");
+-			if (err)
+-				return err;
+-		}
+-		err = rvu_report_pair_end(fmsg);
+-		if (err)
+-			return err;
++		intr_val = nix_event_context->nix_af_rvu_ras;
++		rvu_report_pair_start(fmsg, "NIX_AF_RAS");
++		devlink_fmsg_u64_pair_put(fmsg, "\tNIX RAS Interrupt Reg ",
++					  nix_event_context->nix_af_rvu_ras);
++		devlink_fmsg_string_put(fmsg, "\n\tPoison Data on:");
++		if (intr_val & BIT_ULL(34))
++			devlink_fmsg_string_put(fmsg, "\n\tNIX_AQ_INST_S");
++		if (intr_val & BIT_ULL(33))
++			devlink_fmsg_string_put(fmsg, "\n\tNIX_AQ_RES_S");
++		if (intr_val & BIT_ULL(32))
++			devlink_fmsg_string_put(fmsg, "\n\tHW ctx");
++		if (intr_val & BIT_ULL(4))
++			devlink_fmsg_string_put(fmsg, "\n\tPacket from mirror buffer");
++		if (intr_val & BIT_ULL(3))
++			devlink_fmsg_string_put(fmsg, "\n\tPacket from multicast buffer");
++		if (intr_val & BIT_ULL(2))
++			devlink_fmsg_string_put(fmsg, "\n\tWQE read from mirror buffer");
++		if (intr_val & BIT_ULL(1))
++			devlink_fmsg_string_put(fmsg, "\n\tWQE read from multicast buffer");
++		if (intr_val & BIT_ULL(0))
++			devlink_fmsg_string_put(fmsg, "\n\tNIX_RX_MCE_S read");
++		rvu_report_pair_end(fmsg);
+ 		break;
+ 	default:
+ 		return -EINVAL;
+@@ -579,7 +475,7 @@ static int rvu_hw_nix_ras_recover(struct devlink_health_reporter *reporter,
+ 	if (blkaddr < 0)
+ 		return blkaddr;
+ 
+-	if (nix_event_ctx->nix_af_rvu_int)
++	if (nix_event_ctx->nix_af_rvu_ras)
+ 		rvu_write64(rvu, blkaddr, NIX_AF_RAS_ENA_W1S, ~0ULL);
+ 
+ 	return 0;
+@@ -919,181 +815,87 @@ static int rvu_npa_report_show(struct devlink_fmsg *fmsg, void *ctx,
+ 	struct rvu_npa_event_ctx *npa_event_context;
+ 	unsigned int alloc_dis, free_dis;
+ 	u64 intr_val;
+-	int err;
+ 
+ 	npa_event_context = ctx;
+ 	switch (health_reporter) {
+ 	case NPA_AF_RVU_GEN:
+ 		intr_val = npa_event_context->npa_af_rvu_gen;
+-		err = rvu_report_pair_start(fmsg, "NPA_AF_GENERAL");
+-		if (err)
+-			return err;
+-		err = devlink_fmsg_u64_pair_put(fmsg, "\tNPA General Interrupt Reg ",
+-						npa_event_context->npa_af_rvu_gen);
+-		if (err)
+-			return err;
+-		if (intr_val & BIT_ULL(32)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tUnmap PF Error");
+-			if (err)
+-				return err;
+-		}
++		rvu_report_pair_start(fmsg, "NPA_AF_GENERAL");
++		devlink_fmsg_u64_pair_put(fmsg, "\tNPA General Interrupt Reg ",
++					  npa_event_context->npa_af_rvu_gen);
++		if (intr_val & BIT_ULL(32))
++			devlink_fmsg_string_put(fmsg, "\n\tUnmap PF Error");
+ 
+ 		free_dis = FIELD_GET(GENMASK(15, 0), intr_val);
+-		if (free_dis & BIT(NPA_INPQ_NIX0_RX)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tNIX0: free disabled RX");
+-			if (err)
+-				return err;
+-		}
+-		if (free_dis & BIT(NPA_INPQ_NIX0_TX)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tNIX0:free disabled TX");
+-			if (err)
+-				return err;
+-		}
+-		if (free_dis & BIT(NPA_INPQ_NIX1_RX)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tNIX1: free disabled RX");
+-			if (err)
+-				return err;
+-		}
+-		if (free_dis & BIT(NPA_INPQ_NIX1_TX)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tNIX1:free disabled TX");
+-			if (err)
+-				return err;
+-		}
+-		if (free_dis & BIT(NPA_INPQ_SSO)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFree Disabled for SSO");
+-			if (err)
+-				return err;
+-		}
+-		if (free_dis & BIT(NPA_INPQ_TIM)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFree Disabled for TIM");
+-			if (err)
+-				return err;
+-		}
+-		if (free_dis & BIT(NPA_INPQ_DPI)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFree Disabled for DPI");
+-			if (err)
+-				return err;
+-		}
+-		if (free_dis & BIT(NPA_INPQ_AURA_OP)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFree Disabled for AURA");
+-			if (err)
+-				return err;
+-		}
++		if (free_dis & BIT(NPA_INPQ_NIX0_RX))
++			devlink_fmsg_string_put(fmsg, "\n\tNIX0: free disabled RX");
++		if (free_dis & BIT(NPA_INPQ_NIX0_TX))
++			devlink_fmsg_string_put(fmsg, "\n\tNIX0:free disabled TX");
++		if (free_dis & BIT(NPA_INPQ_NIX1_RX))
++			devlink_fmsg_string_put(fmsg, "\n\tNIX1: free disabled RX");
++		if (free_dis & BIT(NPA_INPQ_NIX1_TX))
++			devlink_fmsg_string_put(fmsg, "\n\tNIX1:free disabled TX");
++		if (free_dis & BIT(NPA_INPQ_SSO))
++			devlink_fmsg_string_put(fmsg, "\n\tFree Disabled for SSO");
++		if (free_dis & BIT(NPA_INPQ_TIM))
++			devlink_fmsg_string_put(fmsg, "\n\tFree Disabled for TIM");
++		if (free_dis & BIT(NPA_INPQ_DPI))
++			devlink_fmsg_string_put(fmsg, "\n\tFree Disabled for DPI");
++		if (free_dis & BIT(NPA_INPQ_AURA_OP))
++			devlink_fmsg_string_put(fmsg, "\n\tFree Disabled for AURA");
+ 
+ 		alloc_dis = FIELD_GET(GENMASK(31, 16), intr_val);
+-		if (alloc_dis & BIT(NPA_INPQ_NIX0_RX)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tNIX0: alloc disabled RX");
+-			if (err)
+-				return err;
+-		}
+-		if (alloc_dis & BIT(NPA_INPQ_NIX0_TX)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tNIX0:alloc disabled TX");
+-			if (err)
+-				return err;
+-		}
+-		if (alloc_dis & BIT(NPA_INPQ_NIX1_RX)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tNIX1: alloc disabled RX");
+-			if (err)
+-				return err;
+-		}
+-		if (alloc_dis & BIT(NPA_INPQ_NIX1_TX)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tNIX1:alloc disabled TX");
+-			if (err)
+-				return err;
+-		}
+-		if (alloc_dis & BIT(NPA_INPQ_SSO)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tAlloc Disabled for SSO");
+-			if (err)
+-				return err;
+-		}
+-		if (alloc_dis & BIT(NPA_INPQ_TIM)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tAlloc Disabled for TIM");
+-			if (err)
+-				return err;
+-		}
+-		if (alloc_dis & BIT(NPA_INPQ_DPI)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tAlloc Disabled for DPI");
+-			if (err)
+-				return err;
+-		}
+-		if (alloc_dis & BIT(NPA_INPQ_AURA_OP)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tAlloc Disabled for AURA");
+-			if (err)
+-				return err;
+-		}
+-		err = rvu_report_pair_end(fmsg);
+-		if (err)
+-			return err;
++		if (alloc_dis & BIT(NPA_INPQ_NIX0_RX))
++			devlink_fmsg_string_put(fmsg, "\n\tNIX0: alloc disabled RX");
++		if (alloc_dis & BIT(NPA_INPQ_NIX0_TX))
++			devlink_fmsg_string_put(fmsg, "\n\tNIX0:alloc disabled TX");
++		if (alloc_dis & BIT(NPA_INPQ_NIX1_RX))
++			devlink_fmsg_string_put(fmsg, "\n\tNIX1: alloc disabled RX");
++		if (alloc_dis & BIT(NPA_INPQ_NIX1_TX))
++			devlink_fmsg_string_put(fmsg, "\n\tNIX1:alloc disabled TX");
++		if (alloc_dis & BIT(NPA_INPQ_SSO))
++			devlink_fmsg_string_put(fmsg, "\n\tAlloc Disabled for SSO");
++		if (alloc_dis & BIT(NPA_INPQ_TIM))
++			devlink_fmsg_string_put(fmsg, "\n\tAlloc Disabled for TIM");
++		if (alloc_dis & BIT(NPA_INPQ_DPI))
++			devlink_fmsg_string_put(fmsg, "\n\tAlloc Disabled for DPI");
++		if (alloc_dis & BIT(NPA_INPQ_AURA_OP))
++			devlink_fmsg_string_put(fmsg, "\n\tAlloc Disabled for AURA");
++
++		rvu_report_pair_end(fmsg);
+ 		break;
+ 	case NPA_AF_RVU_ERR:
+-		err = rvu_report_pair_start(fmsg, "NPA_AF_ERR");
+-		if (err)
+-			return err;
+-		err = devlink_fmsg_u64_pair_put(fmsg, "\tNPA Error Interrupt Reg ",
+-						npa_event_context->npa_af_rvu_err);
+-		if (err)
+-			return err;
+-
+-		if (npa_event_context->npa_af_rvu_err & BIT_ULL(14)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFault on NPA_AQ_INST_S read");
+-			if (err)
+-				return err;
+-		}
+-		if (npa_event_context->npa_af_rvu_err & BIT_ULL(13)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tFault on NPA_AQ_RES_S write");
+-			if (err)
+-				return err;
+-		}
+-		if (npa_event_context->npa_af_rvu_err & BIT_ULL(12)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tAQ Doorbell Error");
+-			if (err)
+-				return err;
+-		}
+-		err = rvu_report_pair_end(fmsg);
+-		if (err)
+-			return err;
++		rvu_report_pair_start(fmsg, "NPA_AF_ERR");
++		devlink_fmsg_u64_pair_put(fmsg, "\tNPA Error Interrupt Reg ",
++					  npa_event_context->npa_af_rvu_err);
++		if (npa_event_context->npa_af_rvu_err & BIT_ULL(14))
++			devlink_fmsg_string_put(fmsg, "\n\tFault on NPA_AQ_INST_S read");
++		if (npa_event_context->npa_af_rvu_err & BIT_ULL(13))
++			devlink_fmsg_string_put(fmsg, "\n\tFault on NPA_AQ_RES_S write");
++		if (npa_event_context->npa_af_rvu_err & BIT_ULL(12))
++			devlink_fmsg_string_put(fmsg, "\n\tAQ Doorbell Error");
++		rvu_report_pair_end(fmsg);
+ 		break;
+ 	case NPA_AF_RVU_RAS:
+-		err = rvu_report_pair_start(fmsg, "NPA_AF_RVU_RAS");
+-		if (err)
+-			return err;
+-		err = devlink_fmsg_u64_pair_put(fmsg, "\tNPA RAS Interrupt Reg ",
+-						npa_event_context->npa_af_rvu_ras);
+-		if (err)
+-			return err;
+-		if (npa_event_context->npa_af_rvu_ras & BIT_ULL(34)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tPoison data on NPA_AQ_INST_S");
+-			if (err)
+-				return err;
+-		}
+-		if (npa_event_context->npa_af_rvu_ras & BIT_ULL(33)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tPoison data on NPA_AQ_RES_S");
+-			if (err)
+-				return err;
+-		}
+-		if (npa_event_context->npa_af_rvu_ras & BIT_ULL(32)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tPoison data on HW context");
+-			if (err)
+-				return err;
+-		}
+-		err = rvu_report_pair_end(fmsg);
+-		if (err)
+-			return err;
++		rvu_report_pair_start(fmsg, "NPA_AF_RVU_RAS");
++		devlink_fmsg_u64_pair_put(fmsg, "\tNPA RAS Interrupt Reg ",
++					  npa_event_context->npa_af_rvu_ras);
++		if (npa_event_context->npa_af_rvu_ras & BIT_ULL(34))
++			devlink_fmsg_string_put(fmsg, "\n\tPoison data on NPA_AQ_INST_S");
++		if (npa_event_context->npa_af_rvu_ras & BIT_ULL(33))
++			devlink_fmsg_string_put(fmsg, "\n\tPoison data on NPA_AQ_RES_S");
++		if (npa_event_context->npa_af_rvu_ras & BIT_ULL(32))
++			devlink_fmsg_string_put(fmsg, "\n\tPoison data on HW context");
++		rvu_report_pair_end(fmsg);
+ 		break;
+ 	case NPA_AF_RVU_INTR:
+-		err = rvu_report_pair_start(fmsg, "NPA_AF_RVU");
+-		if (err)
+-			return err;
+-		err = devlink_fmsg_u64_pair_put(fmsg, "\tNPA RVU Interrupt Reg ",
+-						npa_event_context->npa_af_rvu_int);
+-		if (err)
+-			return err;
+-		if (npa_event_context->npa_af_rvu_int & BIT_ULL(0)) {
+-			err = devlink_fmsg_string_put(fmsg, "\n\tUnmap Slot Error");
+-			if (err)
+-				return err;
+-		}
+-		return rvu_report_pair_end(fmsg);
++		rvu_report_pair_start(fmsg, "NPA_AF_RVU");
++		devlink_fmsg_u64_pair_put(fmsg, "\tNPA RVU Interrupt Reg ",
++					  npa_event_context->npa_af_rvu_int);
++		if (npa_event_context->npa_af_rvu_int & BIT_ULL(0))
++			devlink_fmsg_string_put(fmsg, "\n\tUnmap Slot Error");
++		rvu_report_pair_end(fmsg);
++		break;
+ 	default:
+ 		return -EINVAL;
+ 	}
+diff --git a/drivers/net/ethernet/mediatek/mtk_eth_soc.c b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+index c843e6531449ba..e2d3bda1dc9238 100644
+--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
++++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+@@ -3529,12 +3529,21 @@ static int mtk_xdp_setup(struct net_device *dev, struct bpf_prog *prog,
+ 		mtk_stop(dev);
+ 
+ 	old_prog = rcu_replace_pointer(eth->prog, prog, lockdep_rtnl_is_held());
++
++	if (netif_running(dev) && need_update) {
++		int err;
++
++		err = mtk_open(dev);
++		if (err) {
++			rcu_assign_pointer(eth->prog, old_prog);
++
++			return err;
++		}
++	}
++
+ 	if (old_prog)
+ 		bpf_prog_put(old_prog);
+ 
+-	if (netif_running(dev) && need_update)
+-		return mtk_open(dev);
+-
+ 	return 0;
+ }
+ 
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/en/reporter_tx.c b/drivers/net/ethernet/mellanox/mlx5/core/en/reporter_tx.c
+index 51a23345caa180..1319e9ee20fc07 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/en/reporter_tx.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/en/reporter_tx.c
+@@ -46,7 +46,6 @@ static void mlx5e_reset_txqsq_cc_pc(struct mlx5e_txqsq *sq)
+ 		  "SQ 0x%x: cc (0x%x) != pc (0x%x)\n",
+ 		  sq->sqn, sq->cc, sq->pc);
+ 	sq->cc = 0;
+-	sq->dma_fifo_cc = 0;
+ 	sq->pc = 0;
+ }
+ 
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec.h b/drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec.h
+index 9e7c42c2f77b29..bb8942b1a23d2b 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec.h
++++ b/drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec.h
+@@ -266,6 +266,7 @@ struct mlx5e_ipsec_sa_entry {
+ 	struct mlx5e_ipsec_dwork *dwork;
+ 	struct mlx5e_ipsec_limits limits;
+ 	u32 rx_mapped_id;
++	u8 ctx[MLX5_ST_SZ_BYTES(ipsec_aso)];
+ };
+ 
+ struct mlx5_accel_pol_xfrm_attrs {
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec_offload.c b/drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec_offload.c
+index 940e350058d10e..fd03aa4f47b5a9 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec_offload.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec_offload.c
+@@ -309,10 +309,11 @@ static void mlx5e_ipsec_aso_update(struct mlx5e_ipsec_sa_entry *sa_entry,
+ 	mlx5e_ipsec_aso_query(sa_entry, data);
+ }
+ 
+-static void mlx5e_ipsec_update_esn_state(struct mlx5e_ipsec_sa_entry *sa_entry,
+-					 u32 mode_param)
++static void
++mlx5e_ipsec_update_esn_state(struct mlx5e_ipsec_sa_entry *sa_entry,
++			     u32 mode_param,
++			     struct mlx5_accel_esp_xfrm_attrs *attrs)
+ {
+-	struct mlx5_accel_esp_xfrm_attrs attrs = {};
+ 	struct mlx5_wqe_aso_ctrl_seg data = {};
+ 
+ 	if (mode_param < MLX5E_IPSEC_ESN_SCOPE_MID) {
+@@ -322,18 +323,7 @@ static void mlx5e_ipsec_update_esn_state(struct mlx5e_ipsec_sa_entry *sa_entry,
+ 		sa_entry->esn_state.overlap = 1;
+ 	}
+ 
+-	mlx5e_ipsec_build_accel_xfrm_attrs(sa_entry, &attrs);
+-
+-	/* It is safe to execute the modify below unlocked since the only flows
+-	 * that could affect this HW object, are create, destroy and this work.
+-	 *
+-	 * Creation flow can't co-exist with this modify work, the destruction
+-	 * flow would cancel this work, and this work is a single entity that
+-	 * can't conflict with it self.
+-	 */
+-	spin_unlock_bh(&sa_entry->x->lock);
+-	mlx5_accel_esp_modify_xfrm(sa_entry, &attrs);
+-	spin_lock_bh(&sa_entry->x->lock);
++	mlx5e_ipsec_build_accel_xfrm_attrs(sa_entry, attrs);
+ 
+ 	data.data_offset_condition_operand =
+ 		MLX5_IPSEC_ASO_REMOVE_FLOW_PKT_CNT_OFFSET;
+@@ -369,20 +359,18 @@ static void mlx5e_ipsec_aso_update_soft(struct mlx5e_ipsec_sa_entry *sa_entry,
+ static void mlx5e_ipsec_handle_limits(struct mlx5e_ipsec_sa_entry *sa_entry)
+ {
+ 	struct mlx5_accel_esp_xfrm_attrs *attrs = &sa_entry->attrs;
+-	struct mlx5e_ipsec *ipsec = sa_entry->ipsec;
+-	struct mlx5e_ipsec_aso *aso = ipsec->aso;
+ 	bool soft_arm, hard_arm;
+ 	u64 hard_cnt;
+ 
+ 	lockdep_assert_held(&sa_entry->x->lock);
+ 
+-	soft_arm = !MLX5_GET(ipsec_aso, aso->ctx, soft_lft_arm);
+-	hard_arm = !MLX5_GET(ipsec_aso, aso->ctx, hard_lft_arm);
++	soft_arm = !MLX5_GET(ipsec_aso, sa_entry->ctx, soft_lft_arm);
++	hard_arm = !MLX5_GET(ipsec_aso, sa_entry->ctx, hard_lft_arm);
+ 	if (!soft_arm && !hard_arm)
+ 		/* It is not lifetime event */
+ 		return;
+ 
+-	hard_cnt = MLX5_GET(ipsec_aso, aso->ctx, remove_flow_pkt_cnt);
++	hard_cnt = MLX5_GET(ipsec_aso, sa_entry->ctx, remove_flow_pkt_cnt);
+ 	if (!hard_cnt || hard_arm) {
+ 		/* It is possible to see packet counter equal to zero without
+ 		 * hard limit event armed. Such situation can be if packet
+@@ -452,11 +440,11 @@ static void mlx5e_ipsec_handle_event(struct work_struct *_work)
+ 	struct mlx5e_ipsec_work *work =
+ 		container_of(_work, struct mlx5e_ipsec_work, work);
+ 	struct mlx5e_ipsec_sa_entry *sa_entry = work->data;
++	struct mlx5_accel_esp_xfrm_attrs tmp = {};
+ 	struct mlx5_accel_esp_xfrm_attrs *attrs;
+-	struct mlx5e_ipsec_aso *aso;
++	bool need_modify = false;
+ 	int ret;
+ 
+-	aso = sa_entry->ipsec->aso;
+ 	attrs = &sa_entry->attrs;
+ 
+ 	spin_lock_bh(&sa_entry->x->lock);
+@@ -464,18 +452,22 @@ static void mlx5e_ipsec_handle_event(struct work_struct *_work)
+ 	if (ret)
+ 		goto unlock;
+ 
++	if (attrs->lft.soft_packet_limit != XFRM_INF)
++		mlx5e_ipsec_handle_limits(sa_entry);
++
+ 	if (attrs->replay_esn.trigger &&
+-	    !MLX5_GET(ipsec_aso, aso->ctx, esn_event_arm)) {
+-		u32 mode_param = MLX5_GET(ipsec_aso, aso->ctx, mode_parameter);
++	    !MLX5_GET(ipsec_aso, sa_entry->ctx, esn_event_arm)) {
++		u32 mode_param = MLX5_GET(ipsec_aso, sa_entry->ctx,
++					  mode_parameter);
+ 
+-		mlx5e_ipsec_update_esn_state(sa_entry, mode_param);
++		mlx5e_ipsec_update_esn_state(sa_entry, mode_param, &tmp);
++		need_modify = true;
+ 	}
+ 
+-	if (attrs->lft.soft_packet_limit != XFRM_INF)
+-		mlx5e_ipsec_handle_limits(sa_entry);
+-
+ unlock:
+ 	spin_unlock_bh(&sa_entry->x->lock);
++	if (need_modify)
++		mlx5_accel_esp_modify_xfrm(sa_entry, &tmp);
+ 	kfree(work);
+ }
+ 
+@@ -628,6 +620,8 @@ int mlx5e_ipsec_aso_query(struct mlx5e_ipsec_sa_entry *sa_entry,
+ 			/* We are in atomic context */
+ 			udelay(10);
+ 	} while (ret && time_is_after_jiffies(expires));
++	if (!ret)
++		memcpy(sa_entry->ctx, aso->ctx, MLX5_ST_SZ_BYTES(ipsec_aso));
+ 	spin_unlock_bh(&aso->lock);
+ 	return ret;
+ }
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/esw/qos.c b/drivers/net/ethernet/mellanox/mlx5/core/esw/qos.c
+index 05fbd2098b268a..71df503f40d6d2 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/esw/qos.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/esw/qos.c
+@@ -713,24 +713,24 @@ int mlx5_esw_qos_set_vport_rate(struct mlx5_eswitch *esw, struct mlx5_vport *vpo
+ 	return err;
+ }
+ 
+-static u32 mlx5_esw_qos_lag_link_speed_get_locked(struct mlx5_core_dev *mdev)
++static u32 mlx5_esw_qos_lag_link_speed_get(struct mlx5_core_dev *mdev,
++					   bool take_rtnl)
+ {
+ 	struct ethtool_link_ksettings lksettings;
+ 	struct net_device *slave, *master;
+ 	u32 speed = SPEED_UNKNOWN;
+ 
+-	/* Lock ensures a stable reference to master and slave netdevice
+-	 * while port speed of master is queried.
+-	 */
+-	ASSERT_RTNL();
+-
+ 	slave = mlx5_uplink_netdev_get(mdev);
+ 	if (!slave)
+ 		goto out;
+ 
++	if (take_rtnl)
++		rtnl_lock();
+ 	master = netdev_master_upper_dev_get(slave);
+ 	if (master && !__ethtool_get_link_ksettings(master, &lksettings))
+ 		speed = lksettings.base.speed;
++	if (take_rtnl)
++		rtnl_unlock();
+ 
+ out:
+ 	mlx5_uplink_netdev_put(mdev, slave);
+@@ -738,20 +738,15 @@ out:
+ }
+ 
+ static int mlx5_esw_qos_max_link_speed_get(struct mlx5_core_dev *mdev, u32 *link_speed_max,
+-					   bool hold_rtnl_lock, struct netlink_ext_ack *extack)
++					   bool take_rtnl,
++					   struct netlink_ext_ack *extack)
+ {
+ 	int err;
+ 
+ 	if (!mlx5_lag_is_active(mdev))
+ 		goto skip_lag;
+ 
+-	if (hold_rtnl_lock)
+-		rtnl_lock();
+-
+-	*link_speed_max = mlx5_esw_qos_lag_link_speed_get_locked(mdev);
+-
+-	if (hold_rtnl_lock)
+-		rtnl_unlock();
++	*link_speed_max = mlx5_esw_qos_lag_link_speed_get(mdev, take_rtnl);
+ 
+ 	if (*link_speed_max != (u32)SPEED_UNKNOWN)
+ 		return 0;
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/eswitch.c b/drivers/net/ethernet/mellanox/mlx5/core/eswitch.c
+index 914b380fd3eeb5..2559237da49c52 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/eswitch.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/eswitch.c
+@@ -1038,6 +1038,25 @@ const u32 *mlx5_esw_query_functions(struct mlx5_core_dev *dev)
+ 	return ERR_PTR(err);
+ }
+ 
++static int mlx5_esw_host_functions_enabled_query(struct mlx5_eswitch *esw)
++{
++	const u32 *query_host_out;
++
++	if (!mlx5_core_is_ecpf_esw_manager(esw->dev))
++		return 0;
++
++	query_host_out = mlx5_esw_query_functions(esw->dev);
++	if (IS_ERR(query_host_out))
++		return PTR_ERR(query_host_out);
++
++	esw->esw_funcs.host_funcs_disabled =
++		MLX5_GET(query_esw_functions_out, query_host_out,
++			 host_params_context.host_pf_not_exist);
++
++	kvfree(query_host_out);
++	return 0;
++}
++
+ static void mlx5_eswitch_event_handler_register(struct mlx5_eswitch *esw)
+ {
+ 	if (esw->mode == MLX5_ESWITCH_OFFLOADS && mlx5_eswitch_is_funcs_handler(esw->dev)) {
+@@ -1049,10 +1068,11 @@ static void mlx5_eswitch_event_handler_register(struct mlx5_eswitch *esw)
+ 
+ static void mlx5_eswitch_event_handler_unregister(struct mlx5_eswitch *esw)
+ {
+-	if (esw->mode == MLX5_ESWITCH_OFFLOADS && mlx5_eswitch_is_funcs_handler(esw->dev))
++	if (esw->mode == MLX5_ESWITCH_OFFLOADS &&
++	    mlx5_eswitch_is_funcs_handler(esw->dev)) {
+ 		mlx5_eq_notifier_unregister(esw->dev, &esw->esw_funcs.nb);
+-
+-	flush_workqueue(esw->work_queue);
++		atomic_inc(&esw->esw_funcs.generation);
++	}
+ }
+ 
+ static void mlx5_eswitch_clear_vf_vports_info(struct mlx5_eswitch *esw)
+@@ -1870,6 +1890,10 @@ int mlx5_eswitch_init(struct mlx5_core_dev *dev)
+ 		goto abort;
+ 	}
+ 
++	err = mlx5_esw_host_functions_enabled_query(esw);
++	if (err)
++		goto abort;
++
+ 	err = mlx5_esw_vports_init(esw);
+ 	if (err)
+ 		goto abort;
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/eswitch.h b/drivers/net/ethernet/mellanox/mlx5/core/eswitch.h
+index 3e58e731b5697c..48bebc3b8b12c9 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/eswitch.h
++++ b/drivers/net/ethernet/mellanox/mlx5/core/eswitch.h
+@@ -311,10 +311,13 @@ struct esw_mc_addr { /* SRIOV only */
+ struct mlx5_host_work {
+ 	struct work_struct	work;
+ 	struct mlx5_eswitch	*esw;
++	int			work_gen;
+ };
+ 
+ struct mlx5_esw_functions {
+ 	struct mlx5_nb		nb;
++	atomic_t		generation;
++	bool			host_funcs_disabled;
+ 	u16			num_vfs;
+ 	u16			num_ec_vfs;
+ };
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/eswitch_offloads.c b/drivers/net/ethernet/mellanox/mlx5/core/eswitch_offloads.c
+index c218593dc40f4b..e69e0f2c339641 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/eswitch_offloads.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/eswitch_offloads.c
+@@ -3387,22 +3387,28 @@ static void esw_offloads_steering_cleanup(struct mlx5_eswitch *esw)
+ }
+ 
+ static void
+-esw_vfs_changed_event_handler(struct mlx5_eswitch *esw, const u32 *out)
++esw_vfs_changed_event_handler(struct mlx5_eswitch *esw, int work_gen,
++			      const u32 *out)
+ {
+ 	struct devlink *devlink;
+ 	bool host_pf_disabled;
+ 	u16 new_num_vfs;
+ 
++	devlink = priv_to_devlink(esw->dev);
++	devl_lock(devlink);
++
++	/* Stale work from one or more mode changes ago. Bail out. */
++	if (work_gen != atomic_read(&esw->esw_funcs.generation))
++		goto unlock;
++
+ 	new_num_vfs = MLX5_GET(query_esw_functions_out, out,
+ 			       host_params_context.host_num_of_vfs);
+ 	host_pf_disabled = MLX5_GET(query_esw_functions_out, out,
+ 				    host_params_context.host_pf_disabled);
+ 
+ 	if (new_num_vfs == esw->esw_funcs.num_vfs || host_pf_disabled)
+-		return;
++		goto unlock;
+ 
+-	devlink = priv_to_devlink(esw->dev);
+-	devl_lock(devlink);
+ 	/* Number of VFs can only change from "0 to x" or "x to 0". */
+ 	if (esw->esw_funcs.num_vfs > 0) {
+ 		mlx5_eswitch_unload_vf_vports(esw, esw->esw_funcs.num_vfs);
+@@ -3417,6 +3423,7 @@ esw_vfs_changed_event_handler(struct mlx5_eswitch *esw, const u32 *out)
+ 		}
+ 	}
+ 	esw->esw_funcs.num_vfs = new_num_vfs;
++unlock:
+ 	devl_unlock(devlink);
+ }
+ 
+@@ -3433,7 +3440,7 @@ static void esw_functions_changed_event_handler(struct work_struct *work)
+ 	if (IS_ERR(out))
+ 		goto out;
+ 
+-	esw_vfs_changed_event_handler(esw, out);
++	esw_vfs_changed_event_handler(esw, host_work->work_gen, out);
+ 	kvfree(out);
+ out:
+ 	kfree(host_work);
+@@ -3453,6 +3460,7 @@ int mlx5_esw_funcs_changed_handler(struct notifier_block *nb, unsigned long type
+ 	esw = container_of(esw_funcs, struct mlx5_eswitch, esw_funcs);
+ 
+ 	host_work->esw = esw;
++	host_work->work_gen = atomic_read(&esw_funcs->generation);
+ 
+ 	INIT_WORK(&host_work->work, esw_functions_changed_event_handler);
+ 	queue_work(esw->work_queue, &host_work->work);
+diff --git a/drivers/net/ethernet/microsoft/mana/hw_channel.c b/drivers/net/ethernet/microsoft/mana/hw_channel.c
+index 9d6426d4158e31..148dda6570fc5e 100644
+--- a/drivers/net/ethernet/microsoft/mana/hw_channel.c
++++ b/drivers/net/ethernet/microsoft/mana/hw_channel.c
+@@ -776,9 +776,6 @@ void mana_hwc_destroy_channel(struct gdma_context *gc)
+ 		gc->max_num_cqs = 0;
+ 	}
+ 
+-	kfree(hwc->caller_ctx);
+-	hwc->caller_ctx = NULL;
+-
+ 	if (hwc->txq)
+ 		mana_hwc_destroy_wq(hwc, hwc->txq);
+ 
+@@ -788,6 +785,9 @@ void mana_hwc_destroy_channel(struct gdma_context *gc)
+ 	if (hwc->cq)
+ 		mana_hwc_destroy_cq(hwc->gdma_dev->gdma_context, hwc->cq);
+ 
++	kfree(hwc->caller_ctx);
++	hwc->caller_ctx = NULL;
++
+ 	mana_gd_free_res_map(&hwc->inflight_msg_res);
+ 
+ 	hwc->num_inflight_msg = 0;
+diff --git a/drivers/net/ethernet/microsoft/mana/mana_en.c b/drivers/net/ethernet/microsoft/mana/mana_en.c
+index 89852bbc877c11..926502e5e58242 100644
+--- a/drivers/net/ethernet/microsoft/mana/mana_en.c
++++ b/drivers/net/ethernet/microsoft/mana/mana_en.c
+@@ -1368,8 +1368,14 @@ static void mana_poll_tx_cq(struct mana_cq *cq)
+ 	ndev = txq->ndev;
+ 	apc = netdev_priv(ndev);
+ 
++	/* Limit CQEs polled to 4 wraparounds of the CQ to ensure the
++	 * doorbell can be rung in time for the hardware's requirement
++	 * of at least one doorbell ring every 8 wraparounds.
++	 */
+ 	comp_read = mana_gd_poll_cq(cq->gdma_cq, completions,
+-				    CQE_POLLING_BUFFER);
++				    min((cq->gdma_cq->queue_size /
++					  COMP_ENTRY_SIZE) * 4,
++					 CQE_POLLING_BUFFER));
+ 
+ 	if (comp_read < 1)
+ 		return;
+@@ -1749,7 +1755,14 @@ static void mana_poll_rx_cq(struct mana_cq *cq)
+ 	struct mana_rxq *rxq = cq->rxq;
+ 	int comp_read, i;
+ 
+-	comp_read = mana_gd_poll_cq(cq->gdma_cq, comp, CQE_POLLING_BUFFER);
++	/* Limit CQEs polled to 4 wraparounds of the CQ to ensure the
++	 * doorbell can be rung in time for the hardware's requirement
++	 * of at least one doorbell ring every 8 wraparounds.
++	 */
++	comp_read = mana_gd_poll_cq(cq->gdma_cq, comp,
++				    min((cq->gdma_cq->queue_size /
++					  COMP_ENTRY_SIZE) * 4,
++					 CQE_POLLING_BUFFER));
+ 	WARN_ON_ONCE(comp_read > CQE_POLLING_BUFFER);
+ 
+ 	rxq->xdp_flush = false;
+@@ -1794,11 +1807,11 @@ static int mana_cq_handler(void *context, struct gdma_queue *gdma_queue)
+ 		mana_gd_ring_cq(gdma_queue, SET_ARM_BIT);
+ 		cq->work_done_since_doorbell = 0;
+ 		napi_complete_done(&cq->napi, w);
+-	} else if (cq->work_done_since_doorbell >
+-		   cq->gdma_cq->queue_size / COMP_ENTRY_SIZE * 4) {
++	} else if (cq->work_done_since_doorbell >=
++		   (cq->gdma_cq->queue_size / COMP_ENTRY_SIZE) * 4) {
+ 		/* MANA hardware requires at least one doorbell ring every 8
+ 		 * wraparounds of CQ even if there is no need to arm the CQ.
+-		 * This driver rings the doorbell as soon as we have exceeded
++		 * This driver rings the doorbell as soon as it has processed
+ 		 * 4 wraparounds.
+ 		 */
+ 		mana_gd_ring_cq(gdma_queue, 0);
+diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
+index 4dbc076f72d65a..c74de09181c6ac 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/common.h
++++ b/drivers/net/ethernet/stmicro/stmmac/common.h
+@@ -371,7 +371,6 @@ enum request_irq_err {
+ 	REQ_IRQ_ERR_RX,
+ 	REQ_IRQ_ERR_SFTY_UE,
+ 	REQ_IRQ_ERR_SFTY_CE,
+-	REQ_IRQ_ERR_LPI,
+ 	REQ_IRQ_ERR_WOL,
+ 	REQ_IRQ_ERR_MAC,
+ 	REQ_IRQ_ERR_NO,
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
+index a3a249c6359816..dbe3b12d3f17cd 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
+@@ -612,7 +612,6 @@ static int intel_mgbe_common_data(struct pci_dev *pdev,
+ 
+ 	/* Setup MSI vector offset specific to Intel mGbE controller */
+ 	plat->msi_mac_vec = 29;
+-	plat->msi_lpi_vec = 28;
+ 	plat->msi_sfty_ce_vec = 27;
+ 	plat->msi_sfty_ue_vec = 26;
+ 	plat->msi_rx_base_vec = 0;
+@@ -998,8 +997,6 @@ static int stmmac_config_multi_msi(struct pci_dev *pdev,
+ 		res->irq = pci_irq_vector(pdev, plat->msi_mac_vec);
+ 	if (plat->msi_wol_vec < STMMAC_MSI_VEC_MAX)
+ 		res->wol_irq = pci_irq_vector(pdev, plat->msi_wol_vec);
+-	if (plat->msi_lpi_vec < STMMAC_MSI_VEC_MAX)
+-		res->lpi_irq = pci_irq_vector(pdev, plat->msi_lpi_vec);
+ 	if (plat->msi_sfty_ce_vec < STMMAC_MSI_VEC_MAX)
+ 		res->sfty_ce_irq = pci_irq_vector(pdev, plat->msi_sfty_ce_vec);
+ 	if (plat->msi_sfty_ue_vec < STMMAC_MSI_VEC_MAX)
+@@ -1081,7 +1078,6 @@ static int intel_eth_pci_probe(struct pci_dev *pdev,
+ 	 */
+ 	plat->msi_mac_vec = STMMAC_MSI_VEC_MAX;
+ 	plat->msi_wol_vec = STMMAC_MSI_VEC_MAX;
+-	plat->msi_lpi_vec = STMMAC_MSI_VEC_MAX;
+ 	plat->msi_sfty_ce_vec = STMMAC_MSI_VEC_MAX;
+ 	plat->msi_sfty_ue_vec = STMMAC_MSI_VEC_MAX;
+ 	plat->msi_rx_base_vec = STMMAC_MSI_VEC_MAX;
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
+index bdeec098309abf..40f8122ce12205 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
+@@ -14,7 +14,7 @@
+ static int loongson_default_data(struct plat_stmmacenet_data *plat)
+ 
+ {
+-	plat->clk_csr = 2;	/* clk_csr_i = 20-35MHz & MDC = clk_csr_i/16 */
++	plat->clk_csr = 1;	/* clk_csr_i = 100-150MHz & MDC = clk_csr_i/62 */
+ 	plat->has_gmac = 1;
+ 	plat->force_sf_dma_mode = 1;
+ 
+@@ -138,13 +138,6 @@ static int loongson_dwmac_probe(struct pci_dev *pdev, const struct pci_device_id
+ 		res.wol_irq = res.irq;
+ 	}
+ 
+-	res.lpi_irq = of_irq_get_byname(np, "eth_lpi");
+-	if (res.lpi_irq < 0) {
+-		dev_err(&pdev->dev, "IRQ eth_lpi not found\n");
+-		ret = -ENODEV;
+-		goto err_disable_msi;
+-	}
+-
+ 	ret = stmmac_dvr_probe(&pdev->dev, plat, &res);
+ 	if (ret)
+ 		goto err_disable_msi;
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac.h b/drivers/net/ethernet/stmicro/stmmac/stmmac.h
+index 85a55f459af018..61c8fc97a4212e 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac.h
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac.h
+@@ -29,7 +29,6 @@ struct stmmac_resources {
+ 	void __iomem *addr;
+ 	u8 mac[ETH_ALEN];
+ 	int wol_irq;
+-	int lpi_irq;
+ 	int irq;
+ 	int sfty_ce_irq;
+ 	int sfty_ue_irq;
+@@ -260,7 +259,6 @@ struct stmmac_priv {
+ 	bool wol_irq_disabled;
+ 	int clk_csr;
+ 	struct timer_list eee_ctrl_timer;
+-	int lpi_irq;
+ 	int eee_enabled;
+ 	int eee_active;
+ 	int tx_lpi_timer;
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+index 7a8861d77e047b..4c672e1db52e11 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+@@ -3496,10 +3496,6 @@ static void stmmac_free_irq(struct net_device *dev,
+ 			free_irq(priv->sfty_ce_irq, dev);
+ 		fallthrough;
+ 	case REQ_IRQ_ERR_SFTY_CE:
+-		if (priv->lpi_irq > 0 && priv->lpi_irq != dev->irq)
+-			free_irq(priv->lpi_irq, dev);
+-		fallthrough;
+-	case REQ_IRQ_ERR_LPI:
+ 		if (priv->wol_irq > 0 && priv->wol_irq != dev->irq)
+ 			free_irq(priv->wol_irq, dev);
+ 		fallthrough;
+@@ -3554,24 +3550,6 @@ static int stmmac_request_irq_multi_msi(struct net_device *dev)
+ 		}
+ 	}
+ 
+-	/* Request the LPI IRQ in case of another line
+-	 * is used for LPI
+-	 */
+-	if (priv->lpi_irq > 0 && priv->lpi_irq != dev->irq) {
+-		int_name = priv->int_name_lpi;
+-		sprintf(int_name, "%s:%s", dev->name, "lpi");
+-		ret = request_irq(priv->lpi_irq,
+-				  stmmac_mac_interrupt,
+-				  0, int_name, dev);
+-		if (unlikely(ret < 0)) {
+-			netdev_err(priv->dev,
+-				   "%s: alloc lpi MSI %d (error: %d)\n",
+-				   __func__, priv->lpi_irq, ret);
+-			irq_err = REQ_IRQ_ERR_LPI;
+-			goto irq_error;
+-		}
+-	}
+-
+ 	/* Request the Safety Feature Correctible Error line in
+ 	 * case of another line is used
+ 	 */
+@@ -3695,19 +3673,6 @@ static int stmmac_request_irq_single(struct net_device *dev)
+ 		}
+ 	}
+ 
+-	/* Request the IRQ lines */
+-	if (priv->lpi_irq > 0 && priv->lpi_irq != dev->irq) {
+-		ret = request_irq(priv->lpi_irq, stmmac_interrupt,
+-				  IRQF_SHARED, dev->name, dev);
+-		if (unlikely(ret < 0)) {
+-			netdev_err(priv->dev,
+-				   "%s: ERROR: allocating the LPI IRQ %d (%d)\n",
+-				   __func__, priv->lpi_irq, ret);
+-			irq_err = REQ_IRQ_ERR_LPI;
+-			goto irq_error;
+-		}
+-	}
+-
+ 	return 0;
+ 
+ irq_error:
+@@ -6549,9 +6514,13 @@ static int stmmac_vlan_rx_add_vid(struct net_device *ndev, __be16 proto, u16 vid
+ 
+ 	if (priv->hw->num_vlan) {
+ 		ret = stmmac_add_hw_vlan_rx_fltr(priv, ndev, priv->hw, proto, vid);
+-		if (ret)
++		if (ret) {
++			clear_bit(vid, priv->active_vlans);
++			stmmac_vlan_update(priv, is_double);
+ 			goto err_pm_put;
++		}
+ 	}
++
+ err_pm_put:
+ 	pm_runtime_put(priv->device);
+ 
+@@ -6572,15 +6541,21 @@ static int stmmac_vlan_rx_kill_vid(struct net_device *ndev, __be16 proto, u16 vi
+ 		is_double = true;
+ 
+ 	clear_bit(vid, priv->active_vlans);
++	ret = stmmac_vlan_update(priv, is_double);
++	if (ret) {
++		set_bit(vid, priv->active_vlans);
++		goto del_vlan_error;
++	}
+ 
+ 	if (priv->hw->num_vlan) {
+ 		ret = stmmac_del_hw_vlan_rx_fltr(priv, ndev, priv->hw, proto, vid);
+-		if (ret)
++		if (ret) {
++			set_bit(vid, priv->active_vlans);
++			stmmac_vlan_update(priv, is_double);
+ 			goto del_vlan_error;
++		}
+ 	}
+ 
+-	ret = stmmac_vlan_update(priv, is_double);
+-
+ del_vlan_error:
+ 	pm_runtime_put(priv->device);
+ 
+@@ -7426,7 +7401,6 @@ int stmmac_dvr_probe(struct device *device,
+ 
+ 	priv->dev->irq = res->irq;
+ 	priv->wol_irq = res->wol_irq;
+-	priv->lpi_irq = res->lpi_irq;
+ 	priv->sfty_ce_irq = res->sfty_ce_irq;
+ 	priv->sfty_ue_irq = res->sfty_ue_irq;
+ 	for (i = 0; i < MTL_MAX_RX_QUEUES; i++)
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+index 6c684f6ee84be9..1888a549983c62 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+@@ -762,14 +762,6 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
+ 		stmmac_res->wol_irq = stmmac_res->irq;
+ 	}
+ 
+-	stmmac_res->lpi_irq =
+-		platform_get_irq_byname_optional(pdev, "eth_lpi");
+-	if (stmmac_res->lpi_irq < 0) {
+-		if (stmmac_res->lpi_irq == -EPROBE_DEFER)
+-			return -EPROBE_DEFER;
+-		dev_info(&pdev->dev, "IRQ eth_lpi not found\n");
+-	}
+-
+ 	stmmac_res->addr = devm_platform_ioremap_resource(pdev, 0);
+ 
+ 	return PTR_ERR_OR_ZERO(stmmac_res->addr);
+diff --git a/drivers/net/ethernet/ti/am65-cpsw-nuss.c b/drivers/net/ethernet/ti/am65-cpsw-nuss.c
+index 28cc23736a69bb..93cb4193cf0ac7 100644
+--- a/drivers/net/ethernet/ti/am65-cpsw-nuss.c
++++ b/drivers/net/ethernet/ti/am65-cpsw-nuss.c
+@@ -261,7 +261,7 @@ static void am65_cpsw_nuss_ndo_slave_set_rx_mode(struct net_device *ndev)
+ 	cpsw_ale_set_allmulti(common->ale,
+ 			      ndev->flags & IFF_ALLMULTI, port->port_id);
+ 
+-	port_mask = ALE_PORT_HOST;
++	port_mask = BIT(port->port_id) | ALE_PORT_HOST;
+ 	/* Clear all mcast from ALE */
+ 	cpsw_ale_flush_multicast(common->ale, port_mask, -1);
+ 
+diff --git a/drivers/net/ethernet/ti/cpsw_ale.c b/drivers/net/ethernet/ti/cpsw_ale.c
+index 9eccc7064c2b05..bf0b2950272cff 100644
+--- a/drivers/net/ethernet/ti/cpsw_ale.c
++++ b/drivers/net/ethernet/ti/cpsw_ale.c
+@@ -422,14 +422,13 @@ static void cpsw_ale_flush_mcast(struct cpsw_ale *ale, u32 *ale_entry,
+ 				      ale->port_mask_bits);
+ 	if ((mask & port_mask) == 0)
+ 		return; /* ports dont intersect, not interested */
+-	mask &= ~port_mask;
++	mask &= (~port_mask | ALE_PORT_HOST);
+ 
+-	/* free if only remaining port is host port */
+-	if (mask)
++	if (mask == 0x0 || mask == ALE_PORT_HOST)
++		cpsw_ale_set_entry_type(ale_entry, ALE_TYPE_FREE);
++	else
+ 		cpsw_ale_set_port_mask(ale_entry, mask,
+ 				       ale->port_mask_bits);
+-	else
+-		cpsw_ale_set_entry_type(ale_entry, ALE_TYPE_FREE);
+ }
+ 
+ int cpsw_ale_flush_multicast(struct cpsw_ale *ale, int port_mask, int vid)
+diff --git a/drivers/net/mctp/mctp-i2c.c b/drivers/net/mctp/mctp-i2c.c
+index c8c2c5dc46eb79..1a7e7397ba75c6 100644
+--- a/drivers/net/mctp/mctp-i2c.c
++++ b/drivers/net/mctp/mctp-i2c.c
+@@ -344,6 +344,7 @@ static int mctp_i2c_recv(struct mctp_i2c_dev *midev)
+ 	} else {
+ 		status = NET_RX_DROP;
+ 		spin_unlock_irqrestore(&midev->lock, flags);
++		kfree_skb(skb);
+ 	}
+ 
+ 	if (status == NET_RX_SUCCESS) {
+diff --git a/drivers/net/phy/phy_device.c b/drivers/net/phy/phy_device.c
+index 3dd59376a89e8d..1d073947dd4c26 100644
+--- a/drivers/net/phy/phy_device.c
++++ b/drivers/net/phy/phy_device.c
+@@ -1582,8 +1582,6 @@ int phy_attach_direct(struct net_device *dev, struct phy_device *phydev,
+ 		goto error;
+ 
+ 	phy_resume(phydev);
+-	if (!phydev->is_on_sfp_module)
+-		phy_led_triggers_register(phydev);
+ 
+ 	/**
+ 	 * If the external phy used by current mac interface is managed by
+@@ -1856,9 +1854,6 @@ void phy_detach(struct phy_device *phydev)
+ 	phydev->phy_link_change = NULL;
+ 	phydev->phylink = NULL;
+ 
+-	if (!phydev->is_on_sfp_module)
+-		phy_led_triggers_unregister(phydev);
+-
+ 	if (phydev->mdio.dev.driver)
+ 		module_put(phydev->mdio.dev.driver->owner);
+ 
+@@ -3402,17 +3397,28 @@ static int phy_probe(struct device *dev)
+ 	/* Set the state to READY by default */
+ 	phydev->state = PHY_READY;
+ 
++	/* Register the PHY LED triggers */
++	if (!phydev->is_on_sfp_module)
++		phy_led_triggers_register(phydev);
++
+ 	/* Get the LEDs from the device tree, and instantiate standard
+ 	 * LEDs for them.
+ 	 */
+ 	if (IS_ENABLED(CONFIG_PHYLIB_LEDS) && !phy_driver_is_genphy(phydev) &&
+-	    !phy_driver_is_genphy_10g(phydev))
++	    !phy_driver_is_genphy_10g(phydev)) {
+ 		err = of_phy_leds(phydev);
++		if (err)
++			goto out;
++	}
++
++	return 0;
+ 
+ out:
++	if (!phydev->is_on_sfp_module)
++		phy_led_triggers_unregister(phydev);
++
+ 	/* Re-assert the reset signal on error */
+-	if (err)
+-		phy_device_reset(phydev, 1);
++	phy_device_reset(phydev, 1);
+ 
+ 	return err;
+ }
+@@ -3427,6 +3433,9 @@ static int phy_remove(struct device *dev)
+ 	    !phy_driver_is_genphy_10g(phydev))
+ 		phy_leds_unregister(phydev);
+ 
++	if (!phydev->is_on_sfp_module)
++		phy_led_triggers_unregister(phydev);
++
+ 	phydev->state = PHY_DOWN;
+ 
+ 	sfp_bus_del_upstream(phydev->sfp_bus);
+diff --git a/drivers/net/phy/sfp.c b/drivers/net/phy/sfp.c
+index ff438be4c186e1..00bbe20b0b43ec 100644
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -257,6 +257,7 @@ struct sfp {
+ 	unsigned int state_hw_drive;
+ 	unsigned int state_hw_mask;
+ 	unsigned int state_soft_mask;
++	unsigned int state_ignore_mask;
+ 	unsigned int state;
+ 
+ 	struct delayed_work poll;
+@@ -280,7 +281,6 @@ struct sfp {
+ 	unsigned int rs_state_mask;
+ 
+ 	bool have_a2;
+-	bool tx_fault_ignore;
+ 
+ 	const struct sfp_quirk *quirk;
+ 
+@@ -345,9 +345,35 @@ static void sfp_fixup_long_startup(struct sfp *sfp)
+ 	sfp->module_t_start_up = T_START_UP_BAD_GPON;
+ }
+ 
++static void sfp_fixup_ignore_los(struct sfp *sfp)
++{
++	/* This forces LOS to zero, so we ignore transitions */
++	sfp->state_ignore_mask |= SFP_F_LOS;
++	/* Make sure that LOS options are clear */
++	sfp->id.ext.options &= ~cpu_to_be16(SFP_OPTIONS_LOS_INVERTED |
++					    SFP_OPTIONS_LOS_NORMAL);
++}
++
+ static void sfp_fixup_ignore_tx_fault(struct sfp *sfp)
+ {
+-	sfp->tx_fault_ignore = true;
++	sfp->state_ignore_mask |= SFP_F_TX_FAULT;
++}
++
++static void sfp_fixup_ignore_tx_fault_and_los(struct sfp *sfp)
++{
++	sfp_fixup_ignore_tx_fault(sfp);
++	sfp_fixup_ignore_los(sfp);
++}
++
++static void sfp_fixup_ignore_hw(struct sfp *sfp, unsigned int mask)
++{
++	sfp->state_hw_mask &= ~mask;
++}
++
++static void sfp_fixup_nokia(struct sfp *sfp)
++{
++	sfp_fixup_long_startup(sfp);
++	sfp_fixup_ignore_los(sfp);
+ }
+ 
+ // For 10GBASE-T short-reach modules
+@@ -377,7 +403,19 @@ static void sfp_fixup_halny_gsfp(struct sfp *sfp)
+ 	 * these are possibly used for other purposes on this
+ 	 * module, e.g. a serial port.
+ 	 */
+-	sfp->state_hw_mask &= ~(SFP_F_TX_FAULT | SFP_F_LOS);
++	sfp_fixup_ignore_hw(sfp, SFP_F_TX_FAULT | SFP_F_LOS);
++}
++
++static void sfp_fixup_potron(struct sfp *sfp)
++{
++	/*
++	 * The TX_FAULT and LOS pins on this device are used for serial
++	 * communication, so ignore them. Additionally, provide extra
++	 * time for this device to fully start up.
++	 */
++
++	sfp_fixup_long_startup(sfp);
++	sfp_fixup_ignore_hw(sfp, SFP_F_TX_FAULT | SFP_F_LOS);
+ }
+ 
+ static void sfp_fixup_rollball(struct sfp *sfp)
+@@ -449,7 +487,7 @@ static const struct sfp_quirk sfp_quirks[] = {
+ 	// Alcatel Lucent G-010S-A can operate at 2500base-X, but report 3.2GBd
+ 	// NRZ in their EEPROM
+ 	SFP_QUIRK("ALCATELLUCENT", "3FE46541AA", sfp_quirk_2500basex,
+-		  sfp_fixup_long_startup),
++		  sfp_fixup_nokia),
+ 
+ 	// Fiberstore SFP-10G-T doesn't identify as copper, and uses the
+ 	// Rollball protocol to talk to the PHY.
+@@ -469,7 +507,7 @@ static const struct sfp_quirk sfp_quirks[] = {
+ 	// Huawei MA5671A can operate at 2500base-X, but report 1.2GBd NRZ in
+ 	// their EEPROM
+ 	SFP_QUIRK("HUAWEI", "MA5671A", sfp_quirk_2500basex,
+-		  sfp_fixup_ignore_tx_fault),
++		  sfp_fixup_ignore_tx_fault_and_los),
+ 
+ 	// FS 2.5G Base-T
+ 	SFP_QUIRK_M("FS", "SFP-2.5G-T", sfp_quirk_oem_2_5g),
+@@ -485,6 +523,8 @@ static const struct sfp_quirk sfp_quirks[] = {
+ 	SFP_QUIRK_F("Walsun", "HXSX-ATRC-1", sfp_fixup_fs_10gt),
+ 	SFP_QUIRK_F("Walsun", "HXSX-ATRI-1", sfp_fixup_fs_10gt),
+ 
++	SFP_QUIRK_F("YV", "SFP+ONU-XGSPON", sfp_fixup_potron),
++
+ 	// OEM SFP-GE-T is a 1000Base-T module with broken TX_FAULT indicator
+ 	SFP_QUIRK_F("OEM", "SFP-GE-T", sfp_fixup_ignore_tx_fault),
+ 
+@@ -800,7 +840,8 @@ static void sfp_soft_start_poll(struct sfp *sfp)
+ 
+ 	mutex_lock(&sfp->st_mutex);
+ 	// Poll the soft state for hardware pins we want to ignore
+-	sfp->state_soft_mask = ~sfp->state_hw_mask & mask;
++	sfp->state_soft_mask = ~sfp->state_hw_mask & ~sfp->state_ignore_mask &
++			       mask;
+ 
+ 	if (sfp->state_soft_mask & (SFP_F_LOS | SFP_F_TX_FAULT) &&
+ 	    !sfp->need_poll)
+@@ -2325,7 +2366,7 @@ static int sfp_sm_mod_probe(struct sfp *sfp, bool report)
+ 	sfp->module_t_start_up = T_START_UP;
+ 	sfp->module_t_wait = T_WAIT;
+ 
+-	sfp->tx_fault_ignore = false;
++	sfp->state_ignore_mask = 0;
+ 
+ 	if (sfp->id.base.extended_cc == SFF8024_ECC_10GBASE_T_SFI ||
+ 	    sfp->id.base.extended_cc == SFF8024_ECC_10GBASE_T_SR ||
+@@ -2348,6 +2389,8 @@ static int sfp_sm_mod_probe(struct sfp *sfp, bool report)
+ 
+ 	if (sfp->quirk && sfp->quirk->fixup)
+ 		sfp->quirk->fixup(sfp);
++
++	sfp->state_hw_mask &= ~sfp->state_ignore_mask;
+ 	mutex_unlock(&sfp->st_mutex);
+ 
+ 	return 0;
+@@ -2848,10 +2891,7 @@ static void sfp_check_state(struct sfp *sfp)
+ 	mutex_lock(&sfp->st_mutex);
+ 	state = sfp_get_state(sfp);
+ 	changed = state ^ sfp->state;
+-	if (sfp->tx_fault_ignore)
+-		changed &= SFP_F_PRESENT | SFP_F_LOS;
+-	else
+-		changed &= SFP_F_PRESENT | SFP_F_LOS | SFP_F_TX_FAULT;
++	changed &= SFP_F_PRESENT | SFP_F_LOS | SFP_F_TX_FAULT;
+ 
+ 	for (i = 0; i < GPIO_MAX; i++)
+ 		if (changed & BIT(i))
+diff --git a/drivers/net/usb/aqc111.c b/drivers/net/usb/aqc111.c
+index 3ebb1f84d30255..f1820c0d4830fd 100644
+--- a/drivers/net/usb/aqc111.c
++++ b/drivers/net/usb/aqc111.c
+@@ -1400,14 +1400,14 @@ static int aqc111_suspend(struct usb_interface *intf, pm_message_t message)
+ 		aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC,
+ 					SFR_MEDIUM_STATUS_MODE, 2, &reg16);
+ 
+-		aqc111_write_cmd(dev, AQ_WOL_CFG, 0, 0,
+-				 WOL_CFG_SIZE, &wol_cfg);
+-		aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0,
+-				   &aqc111_data->phy_cfg);
++		aqc111_write_cmd_nopm(dev, AQ_WOL_CFG, 0, 0,
++				      WOL_CFG_SIZE, &wol_cfg);
++		aqc111_write32_cmd_nopm(dev, AQ_PHY_OPS, 0, 0,
++					&aqc111_data->phy_cfg);
+ 	} else {
+ 		aqc111_data->phy_cfg |= AQ_LOW_POWER;
+-		aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0,
+-				   &aqc111_data->phy_cfg);
++		aqc111_write32_cmd_nopm(dev, AQ_PHY_OPS, 0, 0,
++					&aqc111_data->phy_cfg);
+ 
+ 		/* Disable RX path */
+ 		aqc111_read16_cmd_nopm(dev, AQ_ACCESS_MAC,
+diff --git a/drivers/net/usb/cdc_ncm.c b/drivers/net/usb/cdc_ncm.c
+index 22554daaf6ff17..56dfd4cd2aa4f7 100644
+--- a/drivers/net/usb/cdc_ncm.c
++++ b/drivers/net/usb/cdc_ncm.c
+@@ -1656,6 +1656,7 @@ int cdc_ncm_rx_verify_ndp16(struct sk_buff *skb_in, int ndpoffset)
+ 	struct usbnet *dev = netdev_priv(skb_in->dev);
+ 	struct usb_cdc_ncm_ndp16 *ndp16;
+ 	int ret = -EINVAL;
++	size_t ndp_len;
+ 
+ 	if ((ndpoffset + sizeof(struct usb_cdc_ncm_ndp16)) > skb_in->len) {
+ 		netif_dbg(dev, rx_err, dev->net, "invalid NDP offset  <%u>\n",
+@@ -1675,8 +1676,8 @@ int cdc_ncm_rx_verify_ndp16(struct sk_buff *skb_in, int ndpoffset)
+ 					sizeof(struct usb_cdc_ncm_dpe16));
+ 	ret--; /* we process NDP entries except for the last one */
+ 
+-	if ((sizeof(struct usb_cdc_ncm_ndp16) +
+-	     ret * (sizeof(struct usb_cdc_ncm_dpe16))) > skb_in->len) {
++	ndp_len = struct_size_t(struct usb_cdc_ncm_ndp16, dpe16, ret);
++	if (ndpoffset + ndp_len > skb_in->len) {
+ 		netif_dbg(dev, rx_err, dev->net, "Invalid nframes = %d\n", ret);
+ 		ret = -EINVAL;
+ 	}
+@@ -1692,6 +1693,7 @@ int cdc_ncm_rx_verify_ndp32(struct sk_buff *skb_in, int ndpoffset)
+ 	struct usbnet *dev = netdev_priv(skb_in->dev);
+ 	struct usb_cdc_ncm_ndp32 *ndp32;
+ 	int ret = -EINVAL;
++	size_t ndp_len;
+ 
+ 	if ((ndpoffset + sizeof(struct usb_cdc_ncm_ndp32)) > skb_in->len) {
+ 		netif_dbg(dev, rx_err, dev->net, "invalid NDP offset  <%u>\n",
+@@ -1711,8 +1713,8 @@ int cdc_ncm_rx_verify_ndp32(struct sk_buff *skb_in, int ndpoffset)
+ 					sizeof(struct usb_cdc_ncm_dpe32));
+ 	ret--; /* we process NDP entries except for the last one */
+ 
+-	if ((sizeof(struct usb_cdc_ncm_ndp32) +
+-	     ret * (sizeof(struct usb_cdc_ncm_dpe32))) > skb_in->len) {
++	ndp_len = struct_size_t(struct usb_cdc_ncm_ndp32, dpe32, ret);
++	if (ndpoffset + ndp_len > skb_in->len) {
+ 		netif_dbg(dev, rx_err, dev->net, "Invalid nframes = %d\n", ret);
+ 		ret = -EINVAL;
+ 	}
+diff --git a/drivers/net/usb/kalmia.c b/drivers/net/usb/kalmia.c
+index 613fc6910f1481..ee9c48f7f68f95 100644
+--- a/drivers/net/usb/kalmia.c
++++ b/drivers/net/usb/kalmia.c
+@@ -132,11 +132,18 @@ kalmia_bind(struct usbnet *dev, struct usb_interface *intf)
+ {
+ 	int status;
+ 	u8 ethernet_addr[ETH_ALEN];
++	static const u8 ep_addr[] = {
++		1 | USB_DIR_IN,
++		2 | USB_DIR_OUT,
++		0};
+ 
+ 	/* Don't bind to AT command interface */
+ 	if (intf->cur_altsetting->desc.bInterfaceClass != USB_CLASS_VENDOR_SPEC)
+ 		return -EINVAL;
+ 
++	if (!usb_check_bulk_endpoints(intf, ep_addr))
++		return -ENODEV;
++
+ 	dev->in = usb_rcvbulkpipe(dev->udev, 0x81 & USB_ENDPOINT_NUMBER_MASK);
+ 	dev->out = usb_sndbulkpipe(dev->udev, 0x02 & USB_ENDPOINT_NUMBER_MASK);
+ 	dev->status = NULL;
+diff --git a/drivers/net/usb/kaweth.c b/drivers/net/usb/kaweth.c
+index e01d14f6c36677..cb2472b59e1046 100644
+--- a/drivers/net/usb/kaweth.c
++++ b/drivers/net/usb/kaweth.c
+@@ -883,6 +883,13 @@ static int kaweth_probe(
+ 	const eth_addr_t bcast_addr = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+ 	int result = 0;
+ 	int rv = -EIO;
++	static const u8 bulk_ep_addr[] = {
++		1 | USB_DIR_IN,
++		2 | USB_DIR_OUT,
++		0};
++	static const u8 int_ep_addr[] = {
++		3 | USB_DIR_IN,
++		0};
+ 
+ 	dev_dbg(dev,
+ 		"Kawasaki Device Probe (Device number:%d): 0x%4.4x:0x%4.4x:0x%4.4x\n",
+@@ -896,6 +903,12 @@ static int kaweth_probe(
+ 		(int)udev->descriptor.bLength,
+ 		(int)udev->descriptor.bDescriptorType);
+ 
++	if (!usb_check_bulk_endpoints(intf, bulk_ep_addr) ||
++	    !usb_check_int_endpoints(intf, int_ep_addr)) {
++		dev_err(dev, "couldn't find required endpoints\n");
++		return -ENODEV;
++	}
++
+ 	netdev = alloc_etherdev(sizeof(*kaweth));
+ 	if (!netdev)
+ 		return -ENOMEM;
+diff --git a/drivers/net/usb/lan78xx.c b/drivers/net/usb/lan78xx.c
+index 4a6377ac316090..f5bcf150fd9ed3 100644
+--- a/drivers/net/usb/lan78xx.c
++++ b/drivers/net/usb/lan78xx.c
+@@ -2672,6 +2672,10 @@ static void lan78xx_init_ltm(struct lan78xx_net *dev)
+ 	u32 buf;
+ 	u32 regs[6] = { 0 };
+ 
++	/* LAN7850 is USB 2.0 and does not support LTM */
++	if (dev->chipid == ID_REV_CHIP_ID_7850_)
++		return;
++
+ 	ret = lan78xx_read_reg(dev, USB_CFG1, &buf);
+ 	if (buf & USB_CFG1_LTM_ENABLE_) {
+ 		u8 temp[2];
+@@ -3537,6 +3541,7 @@ static void lan78xx_rx_csum_offload(struct lan78xx_net *dev,
+ 	 */
+ 	if (!(dev->net->features & NETIF_F_RXCSUM) ||
+ 	    unlikely(rx_cmd_a & RX_CMD_A_ICSM_) ||
++	    unlikely(rx_cmd_a & RX_CMD_A_CSE_MASK_) ||
+ 	    ((rx_cmd_a & RX_CMD_A_FVTG_) &&
+ 	     !(dev->net->features & NETIF_F_HW_VLAN_CTAG_RX))) {
+ 		skb->ip_summed = CHECKSUM_NONE;
+@@ -3609,7 +3614,8 @@ static int lan78xx_rx(struct lan78xx_net *dev, struct sk_buff *skb,
+ 			return 0;
+ 		}
+ 
+-		if (unlikely(rx_cmd_a & RX_CMD_A_RED_)) {
++		if (unlikely(rx_cmd_a & RX_CMD_A_RED_) &&
++		    (rx_cmd_a & RX_CMD_A_RX_HARD_ERRS_MASK_)) {
+ 			netif_dbg(dev, rx_err, dev->net,
+ 				  "Error rx_cmd_a=0x%08x", rx_cmd_a);
+ 		} else {
+@@ -3884,7 +3890,7 @@ static struct skb_data *lan78xx_tx_buf_fill(struct lan78xx_net *dev,
+ 		}
+ 
+ 		tx_data += len;
+-		entry->length += len;
++		entry->length += max_t(unsigned int, len, ETH_ZLEN);
+ 		entry->num_of_packet += skb_shinfo(skb)->gso_segs ?: 1;
+ 
+ 		dev_kfree_skb_any(skb);
+diff --git a/drivers/net/usb/lan78xx.h b/drivers/net/usb/lan78xx.h
+index 968e5e5faee0a7..17a934acff3d64 100644
+--- a/drivers/net/usb/lan78xx.h
++++ b/drivers/net/usb/lan78xx.h
+@@ -74,6 +74,9 @@
+ #define RX_CMD_A_ICSM_			(0x00004000)
+ #define RX_CMD_A_LEN_MASK_		(0x00003FFF)
+ 
++#define RX_CMD_A_RX_HARD_ERRS_MASK_ \
++	(RX_CMD_A_RX_ERRS_MASK_ & ~RX_CMD_A_CSE_MASK_)
++
+ /* Rx Command B */
+ #define RX_CMD_B_CSUM_SHIFT_		(16)
+ #define RX_CMD_B_CSUM_MASK_		(0xFFFF0000)
+diff --git a/drivers/net/usb/pegasus.c b/drivers/net/usb/pegasus.c
+index 0f16a133c75d13..475b066081c7fe 100644
+--- a/drivers/net/usb/pegasus.c
++++ b/drivers/net/usb/pegasus.c
+@@ -815,8 +815,19 @@ static void unlink_all_urbs(pegasus_t *pegasus)
+ 
+ static int alloc_urbs(pegasus_t *pegasus)
+ {
++	static const u8 bulk_ep_addr[] = {
++		1 | USB_DIR_IN,
++		2 | USB_DIR_OUT,
++		0};
++	static const u8 int_ep_addr[] = {
++		3 | USB_DIR_IN,
++		0};
+ 	int res = -ENOMEM;
+ 
++	if (!usb_check_bulk_endpoints(pegasus->intf, bulk_ep_addr) ||
++	    !usb_check_int_endpoints(pegasus->intf, int_ep_addr))
++		return -ENODEV;
++
+ 	pegasus->rx_urb = usb_alloc_urb(0, GFP_KERNEL);
+ 	if (!pegasus->rx_urb) {
+ 		return res;
+@@ -1171,6 +1182,7 @@ static int pegasus_probe(struct usb_interface *intf,
+ 
+ 	pegasus = netdev_priv(net);
+ 	pegasus->dev_index = dev_index;
++	pegasus->intf = intf;
+ 
+ 	res = alloc_urbs(pegasus);
+ 	if (res < 0) {
+@@ -1182,7 +1194,6 @@ static int pegasus_probe(struct usb_interface *intf,
+ 
+ 	INIT_DELAYED_WORK(&pegasus->carrier_check, check_carrier);
+ 
+-	pegasus->intf = intf;
+ 	pegasus->usb = dev;
+ 	pegasus->net = net;
+ 
+diff --git a/drivers/net/vxlan/vxlan_core.c b/drivers/net/vxlan/vxlan_core.c
+index 1b6b6acd34894b..a862998fb3ba64 100644
+--- a/drivers/net/vxlan/vxlan_core.c
++++ b/drivers/net/vxlan/vxlan_core.c
+@@ -2126,6 +2126,11 @@ static bool route_shortcircuit(struct net_device *dev, struct sk_buff *skb)
+ 	{
+ 		struct ipv6hdr *pip6;
+ 
++		/* check if nd_tbl is not initiliazed due to
++		 * ipv6.disable=1 set during boot
++		 */
++		if (!ipv6_stub->nd_tbl)
++			return false;
+ 		if (!pskb_may_pull(skb, sizeof(struct ipv6hdr)))
+ 			return false;
+ 		pip6 = ipv6_hdr(skb);
+diff --git a/drivers/net/wireless/marvell/libertas/main.c b/drivers/net/wireless/marvell/libertas/main.c
+index 78e8b5aecec0e5..91b9501c6d8cb6 100644
+--- a/drivers/net/wireless/marvell/libertas/main.c
++++ b/drivers/net/wireless/marvell/libertas/main.c
+@@ -881,8 +881,8 @@ static void lbs_free_adapter(struct lbs_private *priv)
+ {
+ 	lbs_free_cmd_buffer(priv);
+ 	kfifo_free(&priv->event_fifo);
+-	del_timer(&priv->command_timer);
+-	del_timer(&priv->tx_lockup_timer);
++	timer_delete_sync(&priv->command_timer);
++	timer_delete_sync(&priv->tx_lockup_timer);
+ 	del_timer(&priv->auto_deepsleep_timer);
+ }
+ 
+diff --git a/drivers/net/wireless/mediatek/mt76/mt76_connac_mac.c b/drivers/net/wireless/mediatek/mt76/mt76_connac_mac.c
+index 87479c6c2b505f..570c9dcbc505ea 100644
+--- a/drivers/net/wireless/mediatek/mt76/mt76_connac_mac.c
++++ b/drivers/net/wireless/mediatek/mt76/mt76_connac_mac.c
+@@ -394,6 +394,7 @@ mt76_connac2_mac_write_txwi_80211(struct mt76_dev *dev, __le32 *txwi,
+ 	u32 val;
+ 
+ 	if (ieee80211_is_action(fc) &&
++	    skb->len >= IEEE80211_MIN_ACTION_SIZE + 1 + 1 + 2 &&
+ 	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
+ 	    mgmt->u.action.u.addba_req.action_code == WLAN_ACTION_ADDBA_REQ) {
+ 		u16 capab = le16_to_cpu(mgmt->u.action.u.addba_req.capab);
+diff --git a/drivers/net/wireless/mediatek/mt76/mt7996/mac.c b/drivers/net/wireless/mediatek/mt76/mt7996/mac.c
+index 8fa16f95e6a7b3..3dd503b363ce00 100644
+--- a/drivers/net/wireless/mediatek/mt76/mt7996/mac.c
++++ b/drivers/net/wireless/mediatek/mt76/mt7996/mac.c
+@@ -784,6 +784,7 @@ mt7996_mac_write_txwi_80211(struct mt7996_dev *dev, __le32 *txwi,
+ 	u32 val;
+ 
+ 	if (ieee80211_is_action(fc) &&
++	    skb->len >= IEEE80211_MIN_ACTION_SIZE + 1 &&
+ 	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
+ 	    mgmt->u.action.u.addba_req.action_code == WLAN_ACTION_ADDBA_REQ)
+ 		tid = MT_TX_ADDBA;
+diff --git a/drivers/net/wireless/st/cw1200/pm.c b/drivers/net/wireless/st/cw1200/pm.c
+index a20ab577a3644e..212b6f2af8de4b 100644
+--- a/drivers/net/wireless/st/cw1200/pm.c
++++ b/drivers/net/wireless/st/cw1200/pm.c
+@@ -264,12 +264,14 @@ int cw1200_wow_suspend(struct ieee80211_hw *hw, struct cfg80211_wowlan *wowlan)
+ 		wiphy_err(priv->hw->wiphy,
+ 			  "PM request failed: %d. WoW is disabled.\n", ret);
+ 		cw1200_wow_resume(hw);
++		mutex_unlock(&priv->conf_mutex);
+ 		return -EBUSY;
+ 	}
+ 
+ 	/* Force resume if event is coming from the device. */
+ 	if (atomic_read(&priv->bh_rx)) {
+ 		cw1200_wow_resume(hw);
++		mutex_unlock(&priv->conf_mutex);
+ 		return -EAGAIN;
+ 	}
+ 
+diff --git a/drivers/net/wireless/ti/wlcore/main.c b/drivers/net/wireless/ti/wlcore/main.c
+index 9706240ddd416b..d818485d7e6afc 100644
+--- a/drivers/net/wireless/ti/wlcore/main.c
++++ b/drivers/net/wireless/ti/wlcore/main.c
+@@ -1800,6 +1800,8 @@ static int __maybe_unused wl1271_op_resume(struct ieee80211_hw *hw)
+ 		     wl->wow_enabled);
+ 	WARN_ON(!wl->wow_enabled);
+ 
++	mutex_lock(&wl->mutex);
++
+ 	ret = pm_runtime_force_resume(wl->dev);
+ 	if (ret < 0) {
+ 		wl1271_error("ELP wakeup failure!");
+@@ -1816,8 +1818,6 @@ static int __maybe_unused wl1271_op_resume(struct ieee80211_hw *hw)
+ 		run_irq_work = true;
+ 	spin_unlock_irqrestore(&wl->wl_lock, flags);
+ 
+-	mutex_lock(&wl->mutex);
+-
+ 	/* test the recovery flag before calling any SDIO functions */
+ 	pending_recovery = test_bit(WL1271_FLAG_RECOVERY_IN_PROGRESS,
+ 				    &wl->flags);
+diff --git a/drivers/net/wireless/ti/wlcore/tx.c b/drivers/net/wireless/ti/wlcore/tx.c
+index 75ad0966765615..1c6373013f66a3 100644
+--- a/drivers/net/wireless/ti/wlcore/tx.c
++++ b/drivers/net/wireless/ti/wlcore/tx.c
+@@ -213,7 +213,7 @@ static int wl1271_tx_allocate(struct wl1271 *wl, struct wl12xx_vif *wlvif,
+ 		if (skb_headroom(skb) < (total_len - skb->len) &&
+ 		    pskb_expand_head(skb, (total_len - skb->len), 0, GFP_ATOMIC)) {
+ 			wl1271_free_tx_id(wl, id);
+-			return -EAGAIN;
++			return -ENOMEM;
+ 		}
+ 		desc = skb_push(skb, total_len - skb->len);
+ 
+diff --git a/drivers/nfc/nxp-nci/i2c.c b/drivers/nfc/nxp-nci/i2c.c
+index edf5514795fd08..5ecbf3366a1de4 100644
+--- a/drivers/nfc/nxp-nci/i2c.c
++++ b/drivers/nfc/nxp-nci/i2c.c
+@@ -47,8 +47,8 @@ static int nxp_nci_i2c_set_mode(void *phy_id,
+ {
+ 	struct nxp_nci_i2c_phy *phy = (struct nxp_nci_i2c_phy *) phy_id;
+ 
+-	gpiod_set_value(phy->gpiod_fw, (mode == NXP_NCI_MODE_FW) ? 1 : 0);
+-	gpiod_set_value(phy->gpiod_en, (mode != NXP_NCI_MODE_COLD) ? 1 : 0);
++	gpiod_set_value_cansleep(phy->gpiod_fw, (mode == NXP_NCI_MODE_FW) ? 1 : 0);
++	gpiod_set_value_cansleep(phy->gpiod_en, (mode != NXP_NCI_MODE_COLD) ? 1 : 0);
+ 	usleep_range(10000, 15000);
+ 
+ 	if (mode == NXP_NCI_MODE_COLD)
+diff --git a/drivers/nfc/pn533/usb.c b/drivers/nfc/pn533/usb.c
+index 9e079be43583e0..0b7e3b118dfd48 100644
+--- a/drivers/nfc/pn533/usb.c
++++ b/drivers/nfc/pn533/usb.c
+@@ -629,6 +629,7 @@ static void pn533_usb_disconnect(struct usb_interface *interface)
+ 	usb_free_urb(phy->out_urb);
+ 	usb_free_urb(phy->ack_urb);
+ 	kfree(phy->ack_buffer);
++	usb_put_dev(phy->udev);
+ 
+ 	nfc_info(&interface->dev, "NXP PN533 NFC device disconnected\n");
+ }
+diff --git a/drivers/nvdimm/bus.c b/drivers/nvdimm/bus.c
+index 5852fe290523b9..7785b66d0b61f2 100644
+--- a/drivers/nvdimm/bus.c
++++ b/drivers/nvdimm/bus.c
+@@ -486,14 +486,15 @@ EXPORT_SYMBOL_GPL(nd_synchronize);
+ static void nd_async_device_register(void *d, async_cookie_t cookie)
+ {
+ 	struct device *dev = d;
++	struct device *parent = dev->parent;
+ 
+ 	if (device_add(dev) != 0) {
+ 		dev_err(dev, "%s: failed\n", __func__);
+ 		put_device(dev);
+ 	}
+ 	put_device(dev);
+-	if (dev->parent)
+-		put_device(dev->parent);
++	if (parent)
++		put_device(parent);
+ }
+ 
+ static void nd_async_device_unregister(void *d, async_cookie_t cookie)
+diff --git a/drivers/nvme/host/pci.c b/drivers/nvme/host/pci.c
+index 8ea38cd6ff30d5..03a2ca3edb9c37 100644
+--- a/drivers/nvme/host/pci.c
++++ b/drivers/nvme/host/pci.c
+@@ -339,7 +339,7 @@ static void nvme_dbbuf_set(struct nvme_dev *dev)
+ 		/* Free memory and continue on */
+ 		nvme_dbbuf_dma_free(dev);
+ 
+-		for (i = 1; i <= dev->online_queues; i++)
++		for (i = 1; i < dev->online_queues; i++)
+ 			nvme_dbbuf_free(&dev->queues[i]);
+ 	}
+ }
+@@ -1103,14 +1103,16 @@ static irqreturn_t nvme_irq_check(int irq, void *data)
+ static void nvme_poll_irqdisable(struct nvme_queue *nvmeq)
+ {
+ 	struct pci_dev *pdev = to_pci_dev(nvmeq->dev->dev);
++	int irq;
+ 
+ 	WARN_ON_ONCE(test_bit(NVMEQ_POLLED, &nvmeq->flags));
+ 
+-	disable_irq(pci_irq_vector(pdev, nvmeq->cq_vector));
++	irq = pci_irq_vector(pdev, nvmeq->cq_vector);
++	disable_irq(irq);
+ 	spin_lock(&nvmeq->cq_poll_lock);
+ 	nvme_poll_cq(nvmeq, NULL);
+ 	spin_unlock(&nvmeq->cq_poll_lock);
+-	enable_irq(pci_irq_vector(pdev, nvmeq->cq_vector));
++	enable_irq(irq);
+ }
+ 
+ static int nvme_poll(struct blk_mq_hw_ctx *hctx, struct io_comp_batch *iob)
+diff --git a/drivers/nvme/host/pr.c b/drivers/nvme/host/pr.c
+index 803efc97fd1ea5..1df7cb31556011 100644
+--- a/drivers/nvme/host/pr.c
++++ b/drivers/nvme/host/pr.c
+@@ -203,7 +203,8 @@ retry:
+ static int nvme_pr_read_keys(struct block_device *bdev,
+ 		struct pr_keys *keys_info)
+ {
+-	u32 rse_len, num_keys = keys_info->num_keys;
++	size_t rse_len;
++	u32 num_keys = keys_info->num_keys;
+ 	struct nvme_reservation_status_ext *rse;
+ 	int ret, i;
+ 	bool eds;
+@@ -213,7 +214,10 @@ static int nvme_pr_read_keys(struct block_device *bdev,
+ 	 * enough to get enough keys to fill the return keys buffer.
+ 	 */
+ 	rse_len = struct_size(rse, regctl_eds, num_keys);
+-	rse = kzalloc(rse_len, GFP_KERNEL);
++	if (rse_len > U32_MAX)
++		return -EINVAL;
++
++	rse = kvzalloc(rse_len, GFP_KERNEL);
+ 	if (!rse)
+ 		return -ENOMEM;
+ 
+@@ -238,7 +242,7 @@ static int nvme_pr_read_keys(struct block_device *bdev,
+ 	}
+ 
+ free_rse:
+-	kfree(rse);
++	kvfree(rse);
+ 	return ret;
+ }
+ 
+diff --git a/drivers/pci/iov.c b/drivers/pci/iov.c
+index b8bce45a599866..d595a345a7d473 100644
+--- a/drivers/pci/iov.c
++++ b/drivers/pci/iov.c
+@@ -749,6 +749,7 @@ static int sriov_init(struct pci_dev *dev, int pos)
+ 	u16 ctrl, total;
+ 	struct pci_sriov *iov;
+ 	struct resource *res;
++	const char *res_name;
+ 	struct pci_dev *pdev;
+ 
+ 	pci_read_config_word(dev, pos + PCI_SRIOV_CTRL, &ctrl);
+@@ -789,6 +790,8 @@ found:
+ 	nres = 0;
+ 	for (i = 0; i < PCI_SRIOV_NUM_BARS; i++) {
+ 		res = &dev->resource[i + PCI_IOV_RESOURCES];
++		res_name = pci_resource_name(dev, i + PCI_IOV_RESOURCES);
++
+ 		/*
+ 		 * If it is already FIXED, don't change it, something
+ 		 * (perhaps EA or header fixups) wants it this way.
+@@ -806,8 +809,8 @@ found:
+ 		}
+ 		iov->barsz[i] = resource_size(res);
+ 		res->end = res->start + resource_size(res) * total - 1;
+-		pci_info(dev, "VF(n) BAR%d space: %pR (contains BAR%d for %d VFs)\n",
+-			 i, res, i, total);
++		pci_info(dev, "%s %pR: contains BAR %d for %d VFs\n",
++			 res_name, res, i, total);
+ 		i += bar64;
+ 		nres++;
+ 	}
+diff --git a/drivers/pci/pci.c b/drivers/pci/pci.c
+index d7d7913eb0ee93..d015df77ddff51 100644
+--- a/drivers/pci/pci.c
++++ b/drivers/pci/pci.c
+@@ -850,6 +850,66 @@ struct resource *pci_find_resource(struct pci_dev *dev, struct resource *res)
+ }
+ EXPORT_SYMBOL(pci_find_resource);
+ 
++/**
++ * pci_resource_name - Return the name of the PCI resource
++ * @dev: PCI device to query
++ * @i: index of the resource
++ *
++ * Return the standard PCI resource (BAR) name according to their index.
++ */
++const char *pci_resource_name(struct pci_dev *dev, unsigned int i)
++{
++	static const char * const bar_name[] = {
++		"BAR 0",
++		"BAR 1",
++		"BAR 2",
++		"BAR 3",
++		"BAR 4",
++		"BAR 5",
++		"ROM",
++#ifdef CONFIG_PCI_IOV
++		"VF BAR 0",
++		"VF BAR 1",
++		"VF BAR 2",
++		"VF BAR 3",
++		"VF BAR 4",
++		"VF BAR 5",
++#endif
++		"bridge window",	/* "io" included in %pR */
++		"bridge window",	/* "mem" included in %pR */
++		"bridge window",	/* "mem pref" included in %pR */
++	};
++	static const char * const cardbus_name[] = {
++		"BAR 1",
++		"unknown",
++		"unknown",
++		"unknown",
++		"unknown",
++		"unknown",
++#ifdef CONFIG_PCI_IOV
++		"unknown",
++		"unknown",
++		"unknown",
++		"unknown",
++		"unknown",
++		"unknown",
++#endif
++		"CardBus bridge window 0",	/* I/O */
++		"CardBus bridge window 1",	/* I/O */
++		"CardBus bridge window 0",	/* mem */
++		"CardBus bridge window 1",	/* mem */
++	};
++
++	if (dev->hdr_type == PCI_HEADER_TYPE_CARDBUS &&
++	    i < ARRAY_SIZE(cardbus_name))
++		return cardbus_name[i];
++
++	if (i < ARRAY_SIZE(bar_name))
++		return bar_name[i];
++
++	return "unknown";
++}
++
+ /**
+  * pci_wait_for_pending - wait for @mask bit(s) to clear in status word @pos
+  * @dev: the PCI device to operate on
+@@ -3359,6 +3419,7 @@ static struct resource *pci_ea_get_resource(struct pci_dev *dev, u8 bei,
+ static int pci_ea_read(struct pci_dev *dev, int offset)
+ {
+ 	struct resource *res;
++	const char *res_name;
+ 	int ent_size, ent_offset = offset;
+ 	resource_size_t start, end;
+ 	unsigned long flags;
+@@ -3388,6 +3449,7 @@ static int pci_ea_read(struct pci_dev *dev, int offset)
+ 		goto out;
+ 
+ 	res = pci_ea_get_resource(dev, bei, prop);
++	res_name = pci_resource_name(dev, bei);
+ 	if (!res) {
+ 		pci_err(dev, "Unsupported EA entry BEI: %u\n", bei);
+ 		goto out;
+@@ -3461,16 +3523,16 @@ static int pci_ea_read(struct pci_dev *dev, int offset)
+ 	res->flags = flags;
+ 
+ 	if (bei <= PCI_EA_BEI_BAR5)
+-		pci_info(dev, "BAR %d: %pR (from Enhanced Allocation, properties %#02x)\n",
+-			   bei, res, prop);
++		pci_info(dev, "%s %pR: from Enhanced Allocation, properties %#02x\n",
++			 res_name, res, prop);
+ 	else if (bei == PCI_EA_BEI_ROM)
+-		pci_info(dev, "ROM: %pR (from Enhanced Allocation, properties %#02x)\n",
+-			   res, prop);
++		pci_info(dev, "%s %pR: from Enhanced Allocation, properties %#02x\n",
++			 res_name, res, prop);
+ 	else if (bei >= PCI_EA_BEI_VF_BAR0 && bei <= PCI_EA_BEI_VF_BAR5)
+-		pci_info(dev, "VF BAR %d: %pR (from Enhanced Allocation, properties %#02x)\n",
+-			   bei - PCI_EA_BEI_VF_BAR0, res, prop);
++		pci_info(dev, "%s %pR: from Enhanced Allocation, properties %#02x\n",
++			 res_name, res, prop);
+ 	else
+-		pci_info(dev, "BEI %d res: %pR (from Enhanced Allocation, properties %#02x)\n",
++		pci_info(dev, "BEI %d %pR: from Enhanced Allocation, properties %#02x\n",
+ 			   bei, res, prop);
+ 
+ out:
+@@ -6780,14 +6842,15 @@ static void pci_request_resource_alignment(struct pci_dev *dev, int bar,
+ 					   resource_size_t align, bool resize)
+ {
+ 	struct resource *r = &dev->resource[bar];
++	const char *r_name = pci_resource_name(dev, bar);
+ 	resource_size_t size;
+ 
+ 	if (!(r->flags & IORESOURCE_MEM))
+ 		return;
+ 
+ 	if (r->flags & IORESOURCE_PCI_FIXED) {
+-		pci_info(dev, "BAR%d %pR: ignoring requested alignment %#llx\n",
+-			 bar, r, (unsigned long long)align);
++		pci_info(dev, "%s %pR: ignoring requested alignment %#llx\n",
++			 r_name, r, (unsigned long long)align);
+ 		return;
+ 	}
+ 
+@@ -6823,8 +6886,8 @@ static void pci_request_resource_alignment(struct pci_dev *dev, int bar,
+ 	 * devices and we use the second.
+ 	 */
+ 
+-	pci_info(dev, "BAR%d %pR: requesting alignment to %#llx\n",
+-		 bar, r, (unsigned long long)align);
++	pci_info(dev, "%s %pR: requesting alignment to %#llx\n",
++		 r_name, r, (unsigned long long)align);
+ 
+ 	if (resize) {
+ 		r->start = 0;
+diff --git a/drivers/pci/pci.h b/drivers/pci/pci.h
+index 485f917641e11c..dae7b98536f7a2 100644
+--- a/drivers/pci/pci.h
++++ b/drivers/pci/pci.h
+@@ -281,6 +281,8 @@ void __pci_bus_assign_resources(const struct pci_bus *bus,
+ 				struct list_head *fail_head);
+ bool pci_bus_clip_resource(struct pci_dev *dev, int idx);
+ 
++const char *pci_resource_name(struct pci_dev *dev, unsigned int i);
++
+ void pci_reassigndev_resource_alignment(struct pci_dev *dev);
+ void pci_disable_bridge_window(struct pci_dev *dev);
+ struct pci_bus *pci_bus_get(struct pci_bus *bus);
+diff --git a/drivers/pci/probe.c b/drivers/pci/probe.c
+index cc56bf47c4a3f3..d90ffbb47f0e24 100644
+--- a/drivers/pci/probe.c
++++ b/drivers/pci/probe.c
+@@ -180,6 +180,7 @@ int __pci_read_base(struct pci_dev *dev, enum pci_bar_type type,
+ 	u64 l64, sz64, mask64;
+ 	u16 orig_cmd;
+ 	struct pci_bus_region region, inverted_region;
++	const char *res_name = pci_resource_name(dev, res - dev->resource);
+ 
+ 	mask = type ? PCI_ROM_ADDRESS_MASK : ~0;
+ 
+@@ -254,8 +255,7 @@ int __pci_read_base(struct pci_dev *dev, enum pci_bar_type type,
+ 
+ 	sz64 = pci_size(l64, sz64, mask64);
+ 	if (!sz64) {
+-		pci_info(dev, FW_BUG "reg 0x%x: invalid BAR (can't size)\n",
+-			 pos);
++		pci_info(dev, FW_BUG "%s: invalid; can't size\n", res_name);
+ 		goto fail;
+ 	}
+ 
+@@ -263,20 +263,18 @@ int __pci_read_base(struct pci_dev *dev, enum pci_bar_type type,
+ 		if ((sizeof(pci_bus_addr_t) < 8 || sizeof(resource_size_t) < 8)
+ 		    && sz64 > 0x100000000ULL) {
+ 			res->flags |= IORESOURCE_UNSET | IORESOURCE_DISABLED;
+-			res->start = 0;
+-			res->end = 0;
+-			pci_err(dev, "reg 0x%x: can't handle BAR larger than 4GB (size %#010llx)\n",
+-				pos, (unsigned long long)sz64);
++			resource_set_range(res, 0, 0);
++			pci_err(dev, "%s: can't handle BAR larger than 4GB (size %#010llx)\n",
++				res_name, (unsigned long long)sz64);
+ 			goto out;
+ 		}
+ 
+ 		if ((sizeof(pci_bus_addr_t) < 8) && l) {
+ 			/* Above 32-bit boundary; try to reallocate */
+ 			res->flags |= IORESOURCE_UNSET;
+-			res->start = 0;
+-			res->end = sz64 - 1;
+-			pci_info(dev, "reg 0x%x: can't handle BAR above 4GB (bus address %#010llx)\n",
+-				 pos, (unsigned long long)l64);
++			resource_set_range(res, 0, sz64);
++			pci_info(dev, "%s: can't handle BAR above 4GB (bus address %#010llx)\n",
++				 res_name, (unsigned long long)l64);
+ 			goto out;
+ 		}
+ 	}
+@@ -302,8 +300,8 @@ int __pci_read_base(struct pci_dev *dev, enum pci_bar_type type,
+ 		res->flags |= IORESOURCE_UNSET;
+ 		res->start = 0;
+ 		res->end = region.end - region.start;
+-		pci_info(dev, "reg 0x%x: initial BAR value %#010llx invalid\n",
+-			 pos, (unsigned long long)region.start);
++		pci_info(dev, "%s: initial BAR value %#010llx invalid\n",
++			 res_name, (unsigned long long)region.start);
+ 	}
+ 
+ 	goto out;
+@@ -313,7 +311,7 @@ fail:
+ 	res->flags = 0;
+ out:
+ 	if (res->flags)
+-		pci_info(dev, "reg 0x%x: %pR\n", pos, res);
++		pci_info(dev, "%s %pR\n", res_name, res);
+ 
+ 	return (res->flags & IORESOURCE_MEM_64) ? 1 : 0;
+ }
+@@ -1968,14 +1966,14 @@ int pci_setup_device(struct pci_dev *dev)
+ 				res = &dev->resource[0];
+ 				res->flags = LEGACY_IO_RESOURCE;
+ 				pcibios_bus_to_resource(dev->bus, res, &region);
+-				pci_info(dev, "legacy IDE quirk: reg 0x10: %pR\n",
++				pci_info(dev, "BAR 0 %pR: legacy IDE quirk\n",
+ 					 res);
+ 				region.start = 0x3F6;
+ 				region.end = 0x3F6;
+ 				res = &dev->resource[1];
+ 				res->flags = LEGACY_IO_RESOURCE;
+ 				pcibios_bus_to_resource(dev->bus, res, &region);
+-				pci_info(dev, "legacy IDE quirk: reg 0x14: %pR\n",
++				pci_info(dev, "BAR 1 %pR: legacy IDE quirk\n",
+ 					 res);
+ 			}
+ 			if ((progif & 4) == 0) {
+@@ -1984,14 +1982,14 @@ int pci_setup_device(struct pci_dev *dev)
+ 				res = &dev->resource[2];
+ 				res->flags = LEGACY_IO_RESOURCE;
+ 				pcibios_bus_to_resource(dev->bus, res, &region);
+-				pci_info(dev, "legacy IDE quirk: reg 0x18: %pR\n",
++				pci_info(dev, "BAR 2 %pR: legacy IDE quirk\n",
+ 					 res);
+ 				region.start = 0x376;
+ 				region.end = 0x376;
+ 				res = &dev->resource[3];
+ 				res->flags = LEGACY_IO_RESOURCE;
+ 				pcibios_bus_to_resource(dev->bus, res, &region);
+-				pci_info(dev, "legacy IDE quirk: reg 0x1c: %pR\n",
++				pci_info(dev, "BAR 3 %pR: legacy IDE quirk\n",
+ 					 res);
+ 			}
+ 		}
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index cab4cdbb31387e..5df3a6ea660187 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -583,13 +583,14 @@ static void quirk_extend_bar_to_page(struct pci_dev *dev)
+ 
+ 	for (i = 0; i < PCI_STD_NUM_BARS; i++) {
+ 		struct resource *r = &dev->resource[i];
++		const char *r_name = pci_resource_name(dev, i);
+ 
+ 		if (r->flags & IORESOURCE_MEM && resource_size(r) < PAGE_SIZE) {
+ 			r->end = PAGE_SIZE - 1;
+ 			r->start = 0;
+ 			r->flags |= IORESOURCE_UNSET;
+-			pci_info(dev, "expanded BAR %d to page size: %pR\n",
+-				 i, r);
++			pci_info(dev, "%s %pR: expanded to page size\n",
++				 r_name, r);
+ 		}
+ 	}
+ }
+@@ -618,6 +619,7 @@ static void quirk_io(struct pci_dev *dev, int pos, unsigned int size,
+ 	u32 region;
+ 	struct pci_bus_region bus_region;
+ 	struct resource *res = dev->resource + pos;
++	const char *res_name = pci_resource_name(dev, pos);
+ 
+ 	pci_read_config_dword(dev, PCI_BASE_ADDRESS_0 + (pos << 2), &region);
+ 
+@@ -635,8 +637,7 @@ static void quirk_io(struct pci_dev *dev, int pos, unsigned int size,
+ 	bus_region.end = region + size - 1;
+ 	pcibios_bus_to_resource(dev->bus, res, &bus_region);
+ 
+-	pci_info(dev, FW_BUG "%s quirk: reg 0x%x: %pR\n",
+-		 name, PCI_BASE_ADDRESS_0 + (pos << 2), res);
++	pci_info(dev, FW_BUG "%s %pR: %s quirk\n", res_name, res, name);
+ }
+ 
+ /*
+@@ -683,6 +684,12 @@ static void quirk_io_region(struct pci_dev *dev, int port,
+ 	bus_region.end = region + size - 1;
+ 	pcibios_bus_to_resource(dev->bus, res, &bus_region);
+ 
++	/*
++	 * "res" is typically a bridge window resource that's not being
++	 * used for a bridge window, so it's just a place to stash this
++	 * non-standard resource.  Printing "nr" or pci_resource_name() of
++	 * it doesn't really make sense.
++	 */
+ 	if (!pci_claim_resource(dev, nr))
+ 		pci_info(dev, "quirk: %pR claimed by %s\n", res, name);
+ }
+diff --git a/drivers/pci/setup-bus.c b/drivers/pci/setup-bus.c
+index 3f40be417856e0..d07c1d9ed0620c 100644
+--- a/drivers/pci/setup-bus.c
++++ b/drivers/pci/setup-bus.c
+@@ -213,6 +213,7 @@ static void reassign_resources_sorted(struct list_head *realloc_head,
+ 				      struct list_head *head)
+ {
+ 	struct resource *res;
++	const char *res_name;
+ 	struct pci_dev_resource *add_res, *tmp;
+ 	struct pci_dev_resource *dev_res;
+ 	resource_size_t add_size, align;
+@@ -222,6 +223,7 @@ static void reassign_resources_sorted(struct list_head *realloc_head,
+ 		bool found_match = false;
+ 
+ 		res = add_res->res;
++
+ 		/* Skip resource that has been reset */
+ 		if (!res->flags)
+ 			goto out;
+@@ -237,6 +239,7 @@ static void reassign_resources_sorted(struct list_head *realloc_head,
+ 			continue;
+ 
+ 		idx = res - &add_res->dev->resource[0];
++		res_name = pci_resource_name(add_res->dev, idx);
+ 		add_size = add_res->add_size;
+ 		align = add_res->min_align;
+ 		if (!resource_size(res)) {
+@@ -249,9 +252,9 @@ static void reassign_resources_sorted(struct list_head *realloc_head,
+ 				 (IORESOURCE_STARTALIGN|IORESOURCE_SIZEALIGN);
+ 			if (pci_reassign_resource(add_res->dev, idx,
+ 						  add_size, align))
+-				pci_info(add_res->dev, "failed to add %llx res[%d]=%pR\n",
+-					 (unsigned long long) add_size, idx,
+-					 res);
++				pci_info(add_res->dev, "%s %pR: failed to add %llx\n",
++					 res_name, res,
++					 (unsigned long long) add_size);
+ 		}
+ out:
+ 		list_del(&add_res->list);
+@@ -571,6 +574,7 @@ EXPORT_SYMBOL(pci_setup_cardbus);
+ static void pci_setup_bridge_io(struct pci_dev *bridge)
+ {
+ 	struct resource *res;
++	const char *res_name;
+ 	struct pci_bus_region region;
+ 	unsigned long io_mask;
+ 	u8 io_base_lo, io_limit_lo;
+@@ -583,6 +587,7 @@ static void pci_setup_bridge_io(struct pci_dev *bridge)
+ 
+ 	/* Set up the top and bottom of the PCI I/O segment for this bus */
+ 	res = &bridge->resource[PCI_BRIDGE_IO_WINDOW];
++	res_name = pci_resource_name(bridge, PCI_BRIDGE_IO_WINDOW);
+ 	pcibios_resource_to_bus(bridge->bus, &region, res);
+ 	if (res->flags & IORESOURCE_IO) {
+ 		pci_read_config_word(bridge, PCI_IO_BASE, &l);
+@@ -591,7 +596,7 @@ static void pci_setup_bridge_io(struct pci_dev *bridge)
+ 		l = ((u16) io_limit_lo << 8) | io_base_lo;
+ 		/* Set up upper 16 bits of I/O base/limit */
+ 		io_upper16 = (region.end & 0xffff0000) | (region.start >> 16);
+-		pci_info(bridge, "  bridge window %pR\n", res);
++		pci_info(bridge, "  %s %pR\n", res_name, res);
+ 	} else {
+ 		/* Clear upper 16 bits of I/O base/limit */
+ 		io_upper16 = 0;
+@@ -608,16 +613,18 @@ static void pci_setup_bridge_io(struct pci_dev *bridge)
+ static void pci_setup_bridge_mmio(struct pci_dev *bridge)
+ {
+ 	struct resource *res;
++	const char *res_name;
+ 	struct pci_bus_region region;
+ 	u32 l;
+ 
+ 	/* Set up the top and bottom of the PCI Memory segment for this bus */
+ 	res = &bridge->resource[PCI_BRIDGE_MEM_WINDOW];
++	res_name = pci_resource_name(bridge, PCI_BRIDGE_MEM_WINDOW);
+ 	pcibios_resource_to_bus(bridge->bus, &region, res);
+ 	if (res->flags & IORESOURCE_MEM) {
+ 		l = (region.start >> 16) & 0xfff0;
+ 		l |= region.end & 0xfff00000;
+-		pci_info(bridge, "  bridge window %pR\n", res);
++		pci_info(bridge, "  %s %pR\n", res_name, res);
+ 	} else {
+ 		l = 0x0000fff0;
+ 	}
+@@ -627,6 +634,7 @@ static void pci_setup_bridge_mmio(struct pci_dev *bridge)
+ static void pci_setup_bridge_mmio_pref(struct pci_dev *bridge)
+ {
+ 	struct resource *res;
++	const char *res_name;
+ 	struct pci_bus_region region;
+ 	u32 l, bu, lu;
+ 
+@@ -640,6 +648,7 @@ static void pci_setup_bridge_mmio_pref(struct pci_dev *bridge)
+ 	/* Set up PREF base/limit */
+ 	bu = lu = 0;
+ 	res = &bridge->resource[PCI_BRIDGE_PREF_MEM_WINDOW];
++	res_name = pci_resource_name(bridge, PCI_BRIDGE_PREF_MEM_WINDOW);
+ 	pcibios_resource_to_bus(bridge->bus, &region, res);
+ 	if (res->flags & IORESOURCE_PREFETCH) {
+ 		l = (region.start >> 16) & 0xfff0;
+@@ -648,7 +657,7 @@ static void pci_setup_bridge_mmio_pref(struct pci_dev *bridge)
+ 			bu = upper_32_bits(region.start);
+ 			lu = upper_32_bits(region.end);
+ 		}
+-		pci_info(bridge, "  bridge window %pR\n", res);
++		pci_info(bridge, "  %s %pR\n", res_name, res);
+ 	} else {
+ 		l = 0x0000fff0;
+ 	}
+@@ -1009,6 +1018,7 @@ static int pbus_size_mem(struct pci_bus *bus, unsigned long mask,
+ 		int i;
+ 
+ 		pci_dev_for_each_resource(dev, r, i) {
++			const char *r_name = pci_resource_name(dev, i);
+ 			resource_size_t r_size;
+ 
+ 			if (r->parent || (r->flags & IORESOURCE_PCI_FIXED) ||
+@@ -1039,8 +1049,8 @@ static int pbus_size_mem(struct pci_bus *bus, unsigned long mask,
+ 			if (order < 0)
+ 				order = 0;
+ 			if (order >= ARRAY_SIZE(aligns)) {
+-				pci_warn(dev, "disabling BAR %d: %pR (bad alignment %#llx)\n",
+-					 i, r, (unsigned long long) align);
++				pci_warn(dev, "%s %pR: disabling; bad alignment %#llx\n",
++					 r_name, r, (unsigned long long) align);
+ 				r->flags = 0;
+ 				continue;
+ 			}
+@@ -2230,6 +2240,7 @@ int pci_reassign_bridge_resources(struct pci_dev *bridge, unsigned long type)
+ 		for (i = PCI_BRIDGE_RESOURCES; i < PCI_BRIDGE_RESOURCE_END;
+ 		     i++) {
+ 			struct resource *res = &bridge->resource[i];
++			const char *res_name = pci_resource_name(bridge, i);
+ 
+ 			if ((res->flags ^ type) & PCI_RES_TYPE_MASK)
+ 				continue;
+@@ -2242,8 +2253,7 @@ int pci_reassign_bridge_resources(struct pci_dev *bridge, unsigned long type)
+ 			if (ret)
+ 				goto cleanup;
+ 
+-			pci_info(bridge, "BAR %d: releasing %pR\n",
+-				 i, res);
++			pci_info(bridge, "%s %pR: releasing\n", res_name, res);
+ 
+ 			if (res->parent)
+ 				release_resource(res);
+diff --git a/drivers/pci/setup-res.c b/drivers/pci/setup-res.c
+index ceaa69491f5efe..c6d933ddfd4649 100644
+--- a/drivers/pci/setup-res.c
++++ b/drivers/pci/setup-res.c
+@@ -30,6 +30,7 @@ static void pci_std_update_resource(struct pci_dev *dev, int resno)
+ 	u32 new, check, mask;
+ 	int reg;
+ 	struct resource *res = dev->resource + resno;
++	const char *res_name = pci_resource_name(dev, resno);
+ 
+ 	/* Per SR-IOV spec 3.4.1.11, VF BARs are RO zero */
+ 	if (dev->is_virtfn)
+@@ -104,8 +105,8 @@ static void pci_std_update_resource(struct pci_dev *dev, int resno)
+ 	pci_read_config_dword(dev, reg, &check);
+ 
+ 	if ((new ^ check) & mask) {
+-		pci_err(dev, "BAR %d: error updating (%#010x != %#010x)\n",
+-			resno, new, check);
++		pci_err(dev, "%s: error updating (%#010x != %#010x)\n",
++			res_name, new, check);
+ 	}
+ 
+ 	if (res->flags & IORESOURCE_MEM_64) {
+@@ -113,8 +114,8 @@ static void pci_std_update_resource(struct pci_dev *dev, int resno)
+ 		pci_write_config_dword(dev, reg + 4, new);
+ 		pci_read_config_dword(dev, reg + 4, &check);
+ 		if (check != new) {
+-			pci_err(dev, "BAR %d: error updating (high %#010x != %#010x)\n",
+-				resno, new, check);
++			pci_err(dev, "%s: error updating (high %#010x != %#010x)\n",
++				res_name, new, check);
+ 		}
+ 	}
+ 
+@@ -135,11 +136,12 @@ void pci_update_resource(struct pci_dev *dev, int resno)
+ int pci_claim_resource(struct pci_dev *dev, int resource)
+ {
+ 	struct resource *res = &dev->resource[resource];
++	const char *res_name = pci_resource_name(dev, resource);
+ 	struct resource *root, *conflict;
+ 
+ 	if (res->flags & IORESOURCE_UNSET) {
+-		pci_info(dev, "can't claim BAR %d %pR: no address assigned\n",
+-			 resource, res);
++		pci_info(dev, "%s %pR: can't claim; no address assigned\n",
++			 res_name, res);
+ 		return -EINVAL;
+ 	}
+ 
+@@ -153,16 +155,16 @@ int pci_claim_resource(struct pci_dev *dev, int resource)
+ 
+ 	root = pci_find_parent_resource(dev, res);
+ 	if (!root) {
+-		pci_info(dev, "can't claim BAR %d %pR: no compatible bridge window\n",
+-			 resource, res);
++		pci_info(dev, "%s %pR: can't claim; no compatible bridge window\n",
++			 res_name, res);
+ 		res->flags |= IORESOURCE_UNSET;
+ 		return -EINVAL;
+ 	}
+ 
+ 	conflict = request_resource_conflict(root, res);
+ 	if (conflict) {
+-		pci_info(dev, "can't claim BAR %d %pR: address conflict with %s %pR\n",
+-			 resource, res, conflict->name, conflict);
++		pci_info(dev, "%s %pR: can't claim; address conflict with %s %pR\n",
++			 res_name, res, conflict->name, conflict);
+ 		res->flags |= IORESOURCE_UNSET;
+ 		return -EBUSY;
+ 	}
+@@ -201,6 +203,7 @@ static int pci_revert_fw_address(struct resource *res, struct pci_dev *dev,
+ {
+ 	struct resource *root, *conflict;
+ 	resource_size_t fw_addr, start, end;
++	const char *res_name = pci_resource_name(dev, resno);
+ 
+ 	fw_addr = pcibios_retrieve_fw_addr(dev, resno);
+ 	if (!fw_addr)
+@@ -231,12 +234,11 @@ static int pci_revert_fw_address(struct resource *res, struct pci_dev *dev,
+ 			root = &iomem_resource;
+ 	}
+ 
+-	pci_info(dev, "BAR %d: trying firmware assignment %pR\n",
+-		 resno, res);
++	pci_info(dev, "%s: trying firmware assignment %pR\n", res_name, res);
+ 	conflict = request_resource_conflict(root, res);
+ 	if (conflict) {
+-		pci_info(dev, "BAR %d: %pR conflicts with %s %pR\n",
+-			 resno, res, conflict->name, conflict);
++		pci_info(dev, "%s %pR: conflicts with %s %pR\n", res_name, res,
++			 conflict->name, conflict);
+ 		res->start = start;
+ 		res->end = end;
+ 		res->flags |= IORESOURCE_UNSET;
+@@ -325,6 +327,7 @@ static int _pci_assign_resource(struct pci_dev *dev, int resno,
+ int pci_assign_resource(struct pci_dev *dev, int resno)
+ {
+ 	struct resource *res = dev->resource + resno;
++	const char *res_name = pci_resource_name(dev, resno);
+ 	resource_size_t align, size;
+ 	int ret;
+ 
+@@ -334,8 +337,8 @@ int pci_assign_resource(struct pci_dev *dev, int resno)
+ 	res->flags |= IORESOURCE_UNSET;
+ 	align = pci_resource_alignment(dev, res);
+ 	if (!align) {
+-		pci_info(dev, "BAR %d: can't assign %pR (bogus alignment)\n",
+-			 resno, res);
++		pci_info(dev, "%s %pR: can't assign; bogus alignment\n",
++			 res_name, res);
+ 		return -EINVAL;
+ 	}
+ 
+@@ -348,18 +351,18 @@ int pci_assign_resource(struct pci_dev *dev, int resno)
+ 	 * working, which is better than just leaving it disabled.
+ 	 */
+ 	if (ret < 0) {
+-		pci_info(dev, "BAR %d: no space for %pR\n", resno, res);
++		pci_info(dev, "%s %pR: can't assign; no space\n", res_name, res);
+ 		ret = pci_revert_fw_address(res, dev, resno, size);
+ 	}
+ 
+ 	if (ret < 0) {
+-		pci_info(dev, "BAR %d: failed to assign %pR\n", resno, res);
++		pci_info(dev, "%s %pR: failed to assign\n", res_name, res);
+ 		return ret;
+ 	}
+ 
+ 	res->flags &= ~IORESOURCE_UNSET;
+ 	res->flags &= ~IORESOURCE_STARTALIGN;
+-	pci_info(dev, "BAR %d: assigned %pR\n", resno, res);
++	pci_info(dev, "%s %pR: assigned\n", res_name, res);
+ 	if (resno < PCI_BRIDGE_RESOURCES)
+ 		pci_update_resource(dev, resno);
+ 
+@@ -367,10 +370,11 @@ int pci_assign_resource(struct pci_dev *dev, int resno)
+ }
+ EXPORT_SYMBOL(pci_assign_resource);
+ 
+-int pci_reassign_resource(struct pci_dev *dev, int resno, resource_size_t addsize,
+-			resource_size_t min_align)
++int pci_reassign_resource(struct pci_dev *dev, int resno,
++			  resource_size_t addsize, resource_size_t min_align)
+ {
+ 	struct resource *res = dev->resource + resno;
++	const char *res_name = pci_resource_name(dev, resno);
+ 	unsigned long flags;
+ 	resource_size_t new_size;
+ 	int ret;
+@@ -381,8 +385,8 @@ int pci_reassign_resource(struct pci_dev *dev, int resno, resource_size_t addsiz
+ 	flags = res->flags;
+ 	res->flags |= IORESOURCE_UNSET;
+ 	if (!res->parent) {
+-		pci_info(dev, "BAR %d: can't reassign an unassigned resource %pR\n",
+-			 resno, res);
++		pci_info(dev, "%s %pR: can't reassign; unassigned resource\n",
++			 res_name, res);
+ 		return -EINVAL;
+ 	}
+ 
+@@ -391,15 +395,15 @@ int pci_reassign_resource(struct pci_dev *dev, int resno, resource_size_t addsiz
+ 	ret = _pci_assign_resource(dev, resno, new_size, min_align);
+ 	if (ret) {
+ 		res->flags = flags;
+-		pci_info(dev, "BAR %d: %pR (failed to expand by %#llx)\n",
+-			 resno, res, (unsigned long long) addsize);
++		pci_info(dev, "%s %pR: failed to expand by %#llx\n",
++			 res_name, res, (unsigned long long) addsize);
+ 		return ret;
+ 	}
+ 
+ 	res->flags &= ~IORESOURCE_UNSET;
+ 	res->flags &= ~IORESOURCE_STARTALIGN;
+-	pci_info(dev, "BAR %d: reassigned %pR (expanded by %#llx)\n",
+-		 resno, res, (unsigned long long) addsize);
++	pci_info(dev, "%s %pR: reassigned; expanded by %#llx\n",
++		 res_name, res, (unsigned long long) addsize);
+ 	if (resno < PCI_BRIDGE_RESOURCES)
+ 		pci_update_resource(dev, resno);
+ 
+@@ -409,8 +413,9 @@ int pci_reassign_resource(struct pci_dev *dev, int resno, resource_size_t addsiz
+ void pci_release_resource(struct pci_dev *dev, int resno)
+ {
+ 	struct resource *res = dev->resource + resno;
++	const char *res_name = pci_resource_name(dev, resno);
+ 
+-	pci_info(dev, "BAR %d: releasing %pR\n", resno, res);
++	pci_info(dev, "%s %pR: releasing\n", res_name, res);
+ 
+ 	if (!res->parent)
+ 		return;
+@@ -480,6 +485,7 @@ int pci_enable_resources(struct pci_dev *dev, int mask)
+ 	u16 cmd, old_cmd;
+ 	int i;
+ 	struct resource *r;
++	const char *r_name;
+ 
+ 	pci_read_config_word(dev, PCI_COMMAND, &cmd);
+ 	old_cmd = cmd;
+@@ -488,6 +494,8 @@ int pci_enable_resources(struct pci_dev *dev, int mask)
+ 		if (!(mask & (1 << i)))
+ 			continue;
+ 
++		r_name = pci_resource_name(dev, i);
++
+ 		if (!(r->flags & (IORESOURCE_IO | IORESOURCE_MEM)))
+ 			continue;
+ 		if ((i == PCI_ROM_RESOURCE) &&
+@@ -495,14 +503,14 @@ int pci_enable_resources(struct pci_dev *dev, int mask)
+ 			continue;
+ 
+ 		if (r->flags & IORESOURCE_UNSET) {
+-			pci_err(dev, "can't enable device: BAR %d %pR not assigned\n",
+-				i, r);
++			pci_err(dev, "%s %pR: not assigned; can't enable device\n",
++				r_name, r);
+ 			return -EINVAL;
+ 		}
+ 
+ 		if (!r->parent) {
+-			pci_err(dev, "can't enable device: BAR %d %pR not claimed\n",
+-				i, r);
++			pci_err(dev, "%s %pR: not claimed; can't enable device\n",
++				r_name, r);
+ 			return -EINVAL;
+ 		}
+ 
+diff --git a/drivers/pinctrl/cirrus/pinctrl-cs42l43.c b/drivers/pinctrl/cirrus/pinctrl-cs42l43.c
+index e1ac89be7c847d..1640c5522f0e8a 100644
+--- a/drivers/pinctrl/cirrus/pinctrl-cs42l43.c
++++ b/drivers/pinctrl/cirrus/pinctrl-cs42l43.c
+@@ -574,10 +574,9 @@ static int cs42l43_pin_probe(struct platform_device *pdev)
+ 		if (child) {
+ 			ret = devm_add_action_or_reset(&pdev->dev,
+ 				cs42l43_fwnode_put, child);
+-			if (ret) {
+-				fwnode_handle_put(child);
++			if (ret)
+ 				return ret;
+-			}
++
+ 			if (!child->dev)
+ 				child->dev = priv->dev;
+ 			fwnode = child;
+diff --git a/drivers/pinctrl/pinctrl-equilibrium.c b/drivers/pinctrl/pinctrl-equilibrium.c
+index d7c89c310b3737..e1d8c656576a86 100644
+--- a/drivers/pinctrl/pinctrl-equilibrium.c
++++ b/drivers/pinctrl/pinctrl-equilibrium.c
+@@ -22,7 +22,7 @@
+ #define PIN_NAME_LEN	10
+ #define PAD_REG_OFF	0x100
+ 
+-static void eqbr_gpio_disable_irq(struct irq_data *d)
++static void eqbr_irq_mask(struct irq_data *d)
+ {
+ 	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+ 	struct eqbr_gpio_ctrl *gctrl = gpiochip_get_data(gc);
+@@ -35,7 +35,7 @@ static void eqbr_gpio_disable_irq(struct irq_data *d)
+ 	gpiochip_disable_irq(gc, offset);
+ }
+ 
+-static void eqbr_gpio_enable_irq(struct irq_data *d)
++static void eqbr_irq_unmask(struct irq_data *d)
+ {
+ 	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+ 	struct eqbr_gpio_ctrl *gctrl = gpiochip_get_data(gc);
+@@ -49,7 +49,7 @@ static void eqbr_gpio_enable_irq(struct irq_data *d)
+ 	raw_spin_unlock_irqrestore(&gctrl->lock, flags);
+ }
+ 
+-static void eqbr_gpio_ack_irq(struct irq_data *d)
++static void eqbr_irq_ack(struct irq_data *d)
+ {
+ 	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+ 	struct eqbr_gpio_ctrl *gctrl = gpiochip_get_data(gc);
+@@ -61,10 +61,17 @@ static void eqbr_gpio_ack_irq(struct irq_data *d)
+ 	raw_spin_unlock_irqrestore(&gctrl->lock, flags);
+ }
+ 
+-static void eqbr_gpio_mask_ack_irq(struct irq_data *d)
++static void eqbr_irq_mask_ack(struct irq_data *d)
+ {
+-	eqbr_gpio_disable_irq(d);
+-	eqbr_gpio_ack_irq(d);
++	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
++	struct eqbr_gpio_ctrl *gctrl = gpiochip_get_data(gc);
++	unsigned int offset = irqd_to_hwirq(d);
++	unsigned long flags;
++
++	raw_spin_lock_irqsave(&gctrl->lock, flags);
++	writel(BIT(offset), gctrl->membase + GPIO_IRNENCLR);
++	writel(BIT(offset), gctrl->membase + GPIO_IRNCR);
++	raw_spin_unlock_irqrestore(&gctrl->lock, flags);
+ }
+ 
+ static inline void eqbr_cfg_bit(void __iomem *addr,
+@@ -91,7 +98,7 @@ static int eqbr_irq_type_cfg(struct gpio_irq_type *type,
+ 	return 0;
+ }
+ 
+-static int eqbr_gpio_set_irq_type(struct irq_data *d, unsigned int type)
++static int eqbr_irq_set_type(struct irq_data *d, unsigned int type)
+ {
+ 	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+ 	struct eqbr_gpio_ctrl *gctrl = gpiochip_get_data(gc);
+@@ -165,11 +172,11 @@ static void eqbr_irq_handler(struct irq_desc *desc)
+ 
+ static const struct irq_chip eqbr_irq_chip = {
+ 	.name = "gpio_irq",
+-	.irq_mask = eqbr_gpio_disable_irq,
+-	.irq_unmask = eqbr_gpio_enable_irq,
+-	.irq_ack = eqbr_gpio_ack_irq,
+-	.irq_mask_ack = eqbr_gpio_mask_ack_irq,
+-	.irq_set_type = eqbr_gpio_set_irq_type,
++	.irq_ack = eqbr_irq_ack,
++	.irq_mask = eqbr_irq_mask,
++	.irq_mask_ack = eqbr_irq_mask_ack,
++	.irq_unmask = eqbr_irq_unmask,
++	.irq_set_type = eqbr_irq_set_type,
+ 	.flags = IRQCHIP_IMMUTABLE,
+ 	GPIOCHIP_IRQ_RESOURCE_HELPERS,
+ };
+diff --git a/drivers/platform/x86/amd/pmc/pmc.c b/drivers/platform/x86/amd/pmc/pmc.c
+index af5cc8aa7988c1..259bac3744d4e6 100644
+--- a/drivers/platform/x86/amd/pmc/pmc.c
++++ b/drivers/platform/x86/amd/pmc/pmc.c
+@@ -294,6 +294,7 @@ static void amd_pmc_get_ip_info(struct amd_pmc_dev *dev)
+ 	switch (dev->cpu_id) {
+ 	case AMD_CPU_ID_PCO:
+ 	case AMD_CPU_ID_RN:
++	case AMD_CPU_ID_VG:
+ 	case AMD_CPU_ID_YC:
+ 	case AMD_CPU_ID_CB:
+ 		dev->num_ips = 12;
+@@ -698,6 +699,7 @@ static int amd_pmc_get_os_hint(struct amd_pmc_dev *dev)
+ 	case AMD_CPU_ID_PCO:
+ 		return MSG_OS_HINT_PCO;
+ 	case AMD_CPU_ID_RN:
++	case AMD_CPU_ID_VG:
+ 	case AMD_CPU_ID_YC:
+ 	case AMD_CPU_ID_CB:
+ 	case AMD_CPU_ID_PS:
+@@ -908,6 +910,7 @@ static const struct pci_device_id pmc_pci_ids[] = {
+ 	{ PCI_DEVICE(PCI_VENDOR_ID_AMD, AMD_CPU_ID_PCO) },
+ 	{ PCI_DEVICE(PCI_VENDOR_ID_AMD, AMD_CPU_ID_RV) },
+ 	{ PCI_DEVICE(PCI_VENDOR_ID_AMD, AMD_CPU_ID_SP) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_AMD, AMD_CPU_ID_VG) },
+ 	{ PCI_DEVICE(PCI_VENDOR_ID_AMD, PCI_DEVICE_ID_AMD_1AH_M20H_ROOT) },
+ 	{ }
+ };
+diff --git a/drivers/platform/x86/amd/pmc/pmc.h b/drivers/platform/x86/amd/pmc/pmc.h
+index b4794f118739f6..88e0232592dc91 100644
+--- a/drivers/platform/x86/amd/pmc/pmc.h
++++ b/drivers/platform/x86/amd/pmc/pmc.h
+@@ -47,6 +47,7 @@ void amd_pmc_quirks_init(struct amd_pmc_dev *dev);
+ #define AMD_CPU_ID_RN			0x1630
+ #define AMD_CPU_ID_PCO			AMD_CPU_ID_RV
+ #define AMD_CPU_ID_CZN			AMD_CPU_ID_RN
++#define AMD_CPU_ID_VG			0x1645
+ #define AMD_CPU_ID_YC			0x14B5
+ #define AMD_CPU_ID_CB			0x14D8
+ #define AMD_CPU_ID_PS			0x14E8
+diff --git a/drivers/platform/x86/dell/dell-wmi-base.c b/drivers/platform/x86/dell/dell-wmi-base.c
+index 841a5414d28a68..01f3ff21c88841 100644
+--- a/drivers/platform/x86/dell/dell-wmi-base.c
++++ b/drivers/platform/x86/dell/dell-wmi-base.c
+@@ -80,6 +80,12 @@ static const struct dmi_system_id dell_wmi_smbios_list[] __initconst = {
+ static const struct key_entry dell_wmi_keymap_type_0000[] = {
+ 	{ KE_IGNORE, 0x003a, { KEY_CAPSLOCK } },
+ 
++	/* Audio mute toggle */
++	{ KE_KEY,    0x0109, { KEY_MUTE } },
++
++	/* Mic mute toggle */
++	{ KE_KEY,    0x0150, { KEY_MICMUTE } },
++
+ 	/* Meta key lock */
+ 	{ KE_IGNORE, 0xe000, { KEY_RIGHTMETA } },
+ 
+diff --git a/drivers/platform/x86/dell/dell-wmi-sysman/passwordattr-interface.c b/drivers/platform/x86/dell/dell-wmi-sysman/passwordattr-interface.c
+index 86ec962aace9b8..e586f7957946bf 100644
+--- a/drivers/platform/x86/dell/dell-wmi-sysman/passwordattr-interface.c
++++ b/drivers/platform/x86/dell/dell-wmi-sysman/passwordattr-interface.c
+@@ -93,7 +93,6 @@ int set_new_password(const char *password_type, const char *new)
+ 	if (ret < 0)
+ 		goto out;
+ 
+-	print_hex_dump_bytes("set new password data: ", DUMP_PREFIX_NONE, buffer, buffer_size);
+ 	ret = call_password_interface(wmi_priv.password_attr_wdev, buffer, buffer_size);
+ 	/* on success copy the new password to current password */
+ 	if (!ret)
+diff --git a/drivers/platform/x86/hp/hp-bioscfg/enum-attributes.c b/drivers/platform/x86/hp/hp-bioscfg/enum-attributes.c
+index 20de4596e3011b..d89d11e8610f57 100644
+--- a/drivers/platform/x86/hp/hp-bioscfg/enum-attributes.c
++++ b/drivers/platform/x86/hp/hp-bioscfg/enum-attributes.c
+@@ -96,8 +96,11 @@ int hp_alloc_enumeration_data(void)
+ 	bioscfg_drv.enumeration_instances_count =
+ 		hp_get_instance_count(HP_WMI_BIOS_ENUMERATION_GUID);
+ 
+-	bioscfg_drv.enumeration_data = kcalloc(bioscfg_drv.enumeration_instances_count,
+-					       sizeof(*bioscfg_drv.enumeration_data), GFP_KERNEL);
++	if (!bioscfg_drv.enumeration_instances_count)
++		return -EINVAL;
++	bioscfg_drv.enumeration_data = kvcalloc(bioscfg_drv.enumeration_instances_count,
++						sizeof(*bioscfg_drv.enumeration_data), GFP_KERNEL);
++
+ 	if (!bioscfg_drv.enumeration_data) {
+ 		bioscfg_drv.enumeration_instances_count = 0;
+ 		return -ENOMEM;
+@@ -452,6 +455,6 @@ void hp_exit_enumeration_attributes(void)
+ 	}
+ 	bioscfg_drv.enumeration_instances_count = 0;
+ 
+-	kfree(bioscfg_drv.enumeration_data);
++	kvfree(bioscfg_drv.enumeration_data);
+ 	bioscfg_drv.enumeration_data = NULL;
+ }
+diff --git a/drivers/platform/x86/thinkpad_acpi.c b/drivers/platform/x86/thinkpad_acpi.c
+index 88364a5502e691..be46479d54afee 100644
+--- a/drivers/platform/x86/thinkpad_acpi.c
++++ b/drivers/platform/x86/thinkpad_acpi.c
+@@ -9441,14 +9441,16 @@ static int tpacpi_battery_get(int what, int battery, int *ret)
+ {
+ 	switch (what) {
+ 	case THRESHOLD_START:
+-		if ACPI_FAILURE(tpacpi_battery_acpi_eval(GET_START, ret, battery))
++		if (!battery_info.batteries[battery].start_support ||
++		    ACPI_FAILURE(tpacpi_battery_acpi_eval(GET_START, ret, battery)))
+ 			return -ENODEV;
+ 
+ 		/* The value is in the low 8 bits of the response */
+ 		*ret = *ret & 0xFF;
+ 		return 0;
+ 	case THRESHOLD_STOP:
+-		if ACPI_FAILURE(tpacpi_battery_acpi_eval(GET_STOP, ret, battery))
++		if (!battery_info.batteries[battery].stop_support ||
++		    ACPI_FAILURE(tpacpi_battery_acpi_eval(GET_STOP, ret, battery)))
+ 			return -ENODEV;
+ 		/* Value is in lower 8 bits */
+ 		*ret = *ret & 0xFF;
+diff --git a/drivers/pmdomain/bcm/bcm2835-power.c b/drivers/pmdomain/bcm/bcm2835-power.c
+index d2f0233cb6206d..20130549a7a537 100644
+--- a/drivers/pmdomain/bcm/bcm2835-power.c
++++ b/drivers/pmdomain/bcm/bcm2835-power.c
+@@ -9,6 +9,7 @@
+ #include <linux/clk.h>
+ #include <linux/delay.h>
+ #include <linux/io.h>
++#include <linux/iopoll.h>
+ #include <linux/mfd/bcm2835-pm.h>
+ #include <linux/module.h>
+ #include <linux/platform_device.h>
+@@ -152,7 +153,6 @@ struct bcm2835_power {
+ static int bcm2835_asb_control(struct bcm2835_power *power, u32 reg, bool enable)
+ {
+ 	void __iomem *base = power->asb;
+-	u64 start;
+ 	u32 val;
+ 
+ 	switch (reg) {
+@@ -165,8 +165,6 @@ static int bcm2835_asb_control(struct bcm2835_power *power, u32 reg, bool enable
+ 		break;
+ 	}
+ 
+-	start = ktime_get_ns();
+-
+ 	/* Enable the module's async AXI bridges. */
+ 	if (enable) {
+ 		val = readl(base + reg) & ~ASB_REQ_STOP;
+@@ -175,11 +173,9 @@ static int bcm2835_asb_control(struct bcm2835_power *power, u32 reg, bool enable
+ 	}
+ 	writel(PM_PASSWORD | val, base + reg);
+ 
+-	while (!!(readl(base + reg) & ASB_ACK) == enable) {
+-		cpu_relax();
+-		if (ktime_get_ns() - start >= 1000)
+-			return -ETIMEDOUT;
+-	}
++	if (readl_poll_timeout_atomic(base + reg, val,
++				      !!(val & ASB_ACK) != enable, 0, 5))
++		return -ETIMEDOUT;
+ 
+ 	return 0;
+ }
+@@ -580,11 +576,11 @@ static int bcm2835_reset_status(struct reset_controller_dev *rcdev,
+ 
+ 	switch (id) {
+ 	case BCM2835_RESET_V3D:
+-		return !PM_READ(PM_GRAFX & PM_V3DRSTN);
++		return !(PM_READ(PM_GRAFX) & PM_V3DRSTN);
+ 	case BCM2835_RESET_H264:
+-		return !PM_READ(PM_IMAGE & PM_H264RSTN);
++		return !(PM_READ(PM_IMAGE) & PM_H264RSTN);
+ 	case BCM2835_RESET_ISP:
+-		return !PM_READ(PM_IMAGE & PM_ISPRSTN);
++		return !(PM_READ(PM_IMAGE) & PM_ISPRSTN);
+ 	default:
+ 		return -EINVAL;
+ 	}
+diff --git a/drivers/regulator/pca9450-regulator.c b/drivers/regulator/pca9450-regulator.c
+index 2ab365d2749f9a..8f09f7f15a1191 100644
+--- a/drivers/regulator/pca9450-regulator.c
++++ b/drivers/regulator/pca9450-regulator.c
+@@ -711,11 +711,6 @@ static int pca9450_i2c_probe(struct i2c_client *i2c)
+ 	unsigned int reset_ctrl;
+ 	int ret;
+ 
+-	if (!i2c->irq) {
+-		dev_err(&i2c->dev, "No IRQ configured?\n");
+-		return -EINVAL;
+-	}
+-
+ 	pca9450 = devm_kzalloc(&i2c->dev, sizeof(struct pca9450), GFP_KERNEL);
+ 	if (!pca9450)
+ 		return -ENOMEM;
+@@ -782,23 +777,25 @@ static int pca9450_i2c_probe(struct i2c_client *i2c)
+ 		}
+ 	}
+ 
+-	ret = devm_request_threaded_irq(pca9450->dev, pca9450->irq, NULL,
+-					pca9450_irq_handler,
+-					(IRQF_TRIGGER_FALLING | IRQF_ONESHOT),
+-					"pca9450-irq", pca9450);
+-	if (ret != 0) {
+-		dev_err(pca9450->dev, "Failed to request IRQ: %d\n",
+-			pca9450->irq);
+-		return ret;
+-	}
+-	/* Unmask all interrupt except PWRON/WDOG/RSVD */
+-	ret = regmap_update_bits(pca9450->regmap, PCA9450_REG_INT1_MSK,
+-				IRQ_VR_FLT1 | IRQ_VR_FLT2 | IRQ_LOWVSYS |
+-				IRQ_THERM_105 | IRQ_THERM_125,
+-				IRQ_PWRON | IRQ_WDOGB | IRQ_RSVD);
+-	if (ret) {
+-		dev_err(&i2c->dev, "Unmask irq error\n");
+-		return ret;
++	if (pca9450->irq) {
++		ret = devm_request_threaded_irq(pca9450->dev, pca9450->irq, NULL,
++						pca9450_irq_handler,
++						(IRQF_TRIGGER_LOW | IRQF_ONESHOT),
++						"pca9450-irq", pca9450);
++		if (ret != 0) {
++			dev_err(pca9450->dev, "Failed to request IRQ: %d\n",
++				pca9450->irq);
++			return ret;
++		}
++		/* Unmask all interrupt except PWRON/WDOG/RSVD */
++		ret = regmap_update_bits(pca9450->regmap, PCA9450_REG_INT1_MSK,
++					IRQ_VR_FLT1 | IRQ_VR_FLT2 | IRQ_LOWVSYS |
++					IRQ_THERM_105 | IRQ_THERM_125,
++					IRQ_PWRON | IRQ_WDOGB | IRQ_RSVD);
++		if (ret) {
++			dev_err(&i2c->dev, "Unmask irq error\n");
++			return ret;
++		}
+ 	}
+ 
+ 	/* Clear PRESET_EN bit in BUCK123_DVS to use DVS registers */
+diff --git a/drivers/remoteproc/mtk_scp.c b/drivers/remoteproc/mtk_scp.c
+index ecbece2b5ce7ca..bf7a4b975e7e1b 100644
+--- a/drivers/remoteproc/mtk_scp.c
++++ b/drivers/remoteproc/mtk_scp.c
+@@ -1024,12 +1024,51 @@ static const struct of_device_id mtk_scp_of_match[] = {
+ };
+ MODULE_DEVICE_TABLE(of, mtk_scp_of_match);
+ 
++static int __maybe_unused scp_suspend(struct device *dev)
++{
++	struct mtk_scp *scp = dev_get_drvdata(dev);
++	struct rproc *rproc = scp->rproc;
++
++	/*
++	 * Only unprepare if the SCP is running and holding the clock.
++	 *
++	 * Note: `scp_ops` doesn't implement .attach() callback, hence
++	 * `rproc->state` can never be RPROC_ATTACHED.  Otherwise, it
++	 * should also be checked here.
++	 */
++	if (rproc->state == RPROC_RUNNING)
++		clk_unprepare(scp->clk);
++	return 0;
++}
++
++static int __maybe_unused scp_resume(struct device *dev)
++{
++	struct mtk_scp *scp = dev_get_drvdata(dev);
++	struct rproc *rproc = scp->rproc;
++
++	/*
++	 * Only prepare if the SCP was running and holding the clock.
++	 *
++	 * Note: `scp_ops` doesn't implement .attach() callback, hence
++	 * `rproc->state` can never be RPROC_ATTACHED.  Otherwise, it
++	 * should also be checked here.
++	 */
++	if (rproc->state == RPROC_RUNNING)
++		return clk_prepare(scp->clk);
++	return 0;
++}
++
++static const struct dev_pm_ops scp_pm_ops = {
++	SET_SYSTEM_SLEEP_PM_OPS(scp_suspend, scp_resume)
++};
++
+ static struct platform_driver mtk_scp_driver = {
+ 	.probe = scp_probe,
+ 	.remove_new = scp_remove,
+ 	.driver = {
+ 		.name = "mtk-scp",
+ 		.of_match_table = mtk_scp_of_match,
++		.pm = &scp_pm_ops,
+ 	},
+ };
+ 
+diff --git a/drivers/remoteproc/qcom_sysmon.c b/drivers/remoteproc/qcom_sysmon.c
+index c24e4a88287381..db33a41051a3ed 100644
+--- a/drivers/remoteproc/qcom_sysmon.c
++++ b/drivers/remoteproc/qcom_sysmon.c
+@@ -203,7 +203,7 @@ static const struct qmi_elem_info ssctl_shutdown_resp_ei[] = {
+ };
+ 
+ struct ssctl_subsys_event_req {
+-	u8 subsys_name_len;
++	u32 subsys_name_len;
+ 	char subsys_name[SSCTL_SUBSYS_NAME_LENGTH];
+ 	u32 event;
+ 	u8 evt_driven_valid;
+diff --git a/drivers/s390/block/dasd_eckd.c b/drivers/s390/block/dasd_eckd.c
+index 59359171141540..2777528f7a55f3 100644
+--- a/drivers/s390/block/dasd_eckd.c
++++ b/drivers/s390/block/dasd_eckd.c
+@@ -6185,6 +6185,7 @@ static void copy_pair_set_active(struct dasd_copy_relation *copy, char *new_busi
+ static int dasd_eckd_copy_pair_swap(struct dasd_device *device, char *prim_busid,
+ 				    char *sec_busid)
+ {
++	struct dasd_eckd_private *prim_priv, *sec_priv;
+ 	struct dasd_device *primary, *secondary;
+ 	struct dasd_copy_relation *copy;
+ 	struct dasd_block *block;
+@@ -6205,6 +6206,9 @@ static int dasd_eckd_copy_pair_swap(struct dasd_device *device, char *prim_busid
+ 	if (!secondary)
+ 		return DASD_COPYPAIRSWAP_SECONDARY;
+ 
++	prim_priv = primary->private;
++	sec_priv = secondary->private;
++
+ 	/*
+ 	 * usually the device should be quiesced for swap
+ 	 * for paranoia stop device and requeue requests again
+@@ -6232,6 +6236,18 @@ static int dasd_eckd_copy_pair_swap(struct dasd_device *device, char *prim_busid
+ 			dev_name(&secondary->cdev->dev), rc);
+ 	}
+ 
++	if (primary->stopped & DASD_STOPPED_QUIESCE) {
++		dasd_device_set_stop_bits(secondary, DASD_STOPPED_QUIESCE);
++		dasd_device_remove_stop_bits(primary, DASD_STOPPED_QUIESCE);
++	}
++
++	/*
++	 * The secondary device never got through format detection, but since it
++	 * is a copy of the primary device, the format is exactly the same;
++	 * therefore, the detected layout can simply be copied.
++	 */
++	sec_priv->uses_cdl = prim_priv->uses_cdl;
++
+ 	/* re-enable device */
+ 	dasd_device_remove_stop_bits(primary, DASD_STOPPED_PPRC);
+ 	dasd_device_remove_stop_bits(secondary, DASD_STOPPED_PPRC);
+diff --git a/drivers/s390/crypto/zcrypt_ccamisc.c b/drivers/s390/crypto/zcrypt_ccamisc.c
+index 263fe182648b84..0c7172880dffe9 100644
+--- a/drivers/s390/crypto/zcrypt_ccamisc.c
++++ b/drivers/s390/crypto/zcrypt_ccamisc.c
+@@ -1687,11 +1687,13 @@ static int fetch_cca_info(u16 cardnr, u16 domain, struct cca_info *ci)
+ 
+ 	memset(ci, 0, sizeof(*ci));
+ 
+-	/* get first info from zcrypt device driver about this apqn */
+-	rc = zcrypt_device_status_ext(cardnr, domain, &devstat);
+-	if (rc)
+-		return rc;
+-	ci->hwtype = devstat.hwtype;
++	/* if specific domain given, fetch status and hw info for this apqn */
++	if (domain != AUTOSEL_DOM) {
++		rc = zcrypt_device_status_ext(cardnr, domain, &devstat);
++		if (rc)
++			return rc;
++		ci->hwtype = devstat.hwtype;
++	}
+ 
+ 	/* prep page for rule array and var array use */
+ 	pg = (u8 *)__get_free_page(GFP_KERNEL);
+diff --git a/drivers/s390/crypto/zcrypt_cex4.c b/drivers/s390/crypto/zcrypt_cex4.c
+index 9cfce9ff2e6549..2bb3fc8f3d2f9c 100644
+--- a/drivers/s390/crypto/zcrypt_cex4.c
++++ b/drivers/s390/crypto/zcrypt_cex4.c
+@@ -85,8 +85,7 @@ static ssize_t cca_serialnr_show(struct device *dev,
+ 
+ 	memset(&ci, 0, sizeof(ci));
+ 
+-	if (ap_domain_index >= 0)
+-		cca_get_info(ac->id, ap_domain_index, &ci, zc->online);
++	cca_get_info(ac->id, AUTOSEL_DOM, &ci, zc->online);
+ 
+ 	return sysfs_emit(buf, "%s\n", ci.serial);
+ }
+diff --git a/drivers/scsi/hisi_sas/hisi_sas.h b/drivers/scsi/hisi_sas/hisi_sas.h
+index 1e4550156b735d..4e905c9bec28ea 100644
+--- a/drivers/scsi/hisi_sas/hisi_sas.h
++++ b/drivers/scsi/hisi_sas/hisi_sas.h
+@@ -47,6 +47,13 @@
+ #define HISI_SAS_IOST_ITCT_CACHE_DW_SZ 10
+ #define HISI_SAS_FIFO_DATA_DW_SIZE 32
+ 
++#define HISI_SAS_REG_MEM_SIZE 4
++#define HISI_SAS_MAX_CDB_LEN 16
++#define HISI_SAS_BLK_QUEUE_DEPTH 64
++
++#define BYTE_TO_DW 4
++#define BYTE_TO_DDW 8
++
+ #define HISI_SAS_STATUS_BUF_SZ (sizeof(struct hisi_sas_status_buffer))
+ #define HISI_SAS_COMMAND_TABLE_SZ (sizeof(union hisi_sas_command_table))
+ 
+@@ -93,6 +100,8 @@
+ 
+ #define HISI_SAS_WAIT_PHYUP_TIMEOUT	(30 * HZ)
+ #define HISI_SAS_CLEAR_ITCT_TIMEOUT	(20 * HZ)
++#define HISI_SAS_DELAY_FOR_PHY_DISABLE 100
++#define NAME_BUF_SIZE 256
+ 
+ struct hisi_hba;
+ 
+@@ -168,6 +177,8 @@ struct hisi_sas_debugfs_fifo {
+ 	u32 rd_data[HISI_SAS_FIFO_DATA_DW_SIZE];
+ };
+ 
++#define FRAME_RCVD_BUF 32
++#define SAS_PHY_RESV_SIZE 2
+ struct hisi_sas_phy {
+ 	struct work_struct	works[HISI_PHYES_NUM];
+ 	struct hisi_hba	*hisi_hba;
+@@ -179,10 +190,10 @@ struct hisi_sas_phy {
+ 	spinlock_t lock;
+ 	u64		port_id; /* from hw */
+ 	u64		frame_rcvd_size;
+-	u8		frame_rcvd[32];
++	u8		frame_rcvd[FRAME_RCVD_BUF];
+ 	u8		phy_attached;
+ 	u8		in_reset;
+-	u8		reserved[2];
++	u8		reserved[SAS_PHY_RESV_SIZE];
+ 	u32		phy_type;
+ 	u32		code_violation_err_count;
+ 	enum sas_linkrate	minimum_linkrate;
+@@ -349,6 +360,7 @@ struct hisi_sas_hw {
+ };
+ 
+ #define HISI_SAS_MAX_DEBUGFS_DUMP (50)
++#define HISI_SAS_DEFAULT_DEBUGFS_DUMP 1
+ 
+ struct hisi_sas_debugfs_cq {
+ 	struct hisi_sas_cq *cq;
+@@ -528,12 +540,13 @@ struct hisi_sas_cmd_hdr {
+ 	__le64 dif_prd_table_addr;
+ };
+ 
++#define ITCT_RESV_DDW 12
+ struct hisi_sas_itct {
+ 	__le64 qw0;
+ 	__le64 sas_addr;
+ 	__le64 qw2;
+ 	__le64 qw3;
+-	__le64 qw4_15[12];
++	__le64 qw4_15[ITCT_RESV_DDW];
+ };
+ 
+ struct hisi_sas_iost {
+@@ -543,22 +556,26 @@ struct hisi_sas_iost {
+ 	__le64 qw3;
+ };
+ 
++#define ERROR_RECORD_BUF_DW 4
+ struct hisi_sas_err_record {
+-	u32	data[4];
++	u32	data[ERROR_RECORD_BUF_DW];
+ };
+ 
++#define FIS_RESV_DW 3
+ struct hisi_sas_initial_fis {
+ 	struct hisi_sas_err_record err_record;
+ 	struct dev_to_host_fis fis;
+-	u32 rsvd[3];
++	u32 rsvd[FIS_RESV_DW];
+ };
+ 
++#define BREAKPOINT_DATA_SIZE 128
+ struct hisi_sas_breakpoint {
+-	u8	data[128];
++	u8	data[BREAKPOINT_DATA_SIZE];
+ };
+ 
++#define BREAKPOINT_TAG_NUM 32
+ struct hisi_sas_sata_breakpoint {
+-	struct hisi_sas_breakpoint tag[32];
++	struct hisi_sas_breakpoint tag[BREAKPOINT_TAG_NUM];
+ };
+ 
+ struct hisi_sas_sge {
+@@ -569,13 +586,15 @@ struct hisi_sas_sge {
+ 	__le32 data_off;
+ };
+ 
++#define SMP_CMD_TABLE_SIZE 44
+ struct hisi_sas_command_table_smp {
+-	u8 bytes[44];
++	u8 bytes[SMP_CMD_TABLE_SIZE];
+ };
+ 
++#define DUMMY_BUF_SIZE 12
+ struct hisi_sas_command_table_stp {
+ 	struct	host_to_dev_fis command_fis;
+-	u8	dummy[12];
++	u8	dummy[DUMMY_BUF_SIZE];
+ 	u8	atapi_cdb[ATAPI_CDB_LEN];
+ };
+ 
+@@ -589,12 +608,13 @@ struct hisi_sas_sge_dif_page {
+ 	struct hisi_sas_sge sge[HISI_SAS_SGE_DIF_PAGE_CNT];
+ }  __aligned(16);
+ 
++#define PROT_BUF_SIZE 7
+ struct hisi_sas_command_table_ssp {
+ 	struct ssp_frame_hdr hdr;
+ 	union {
+ 		struct {
+ 			struct ssp_command_iu task;
+-			u32 prot[7];
++			u32 prot[PROT_BUF_SIZE];
+ 		};
+ 		struct ssp_tmf_iu ssp_task;
+ 		struct xfer_rdy_iu xfer_rdy;
+@@ -608,9 +628,10 @@ union hisi_sas_command_table {
+ 	struct hisi_sas_command_table_stp stp;
+ }  __aligned(16);
+ 
++#define IU_BUF_SIZE 1024
+ struct hisi_sas_status_buffer {
+ 	struct hisi_sas_err_record err;
+-	u8	iu[1024];
++	u8	iu[IU_BUF_SIZE];
+ }  __aligned(16);
+ 
+ struct hisi_sas_slot_buf_table {
+diff --git a/drivers/scsi/hisi_sas/hisi_sas_main.c b/drivers/scsi/hisi_sas/hisi_sas_main.c
+index 3ad58250bf6b21..578f7c6117d3dd 100644
+--- a/drivers/scsi/hisi_sas/hisi_sas_main.c
++++ b/drivers/scsi/hisi_sas/hisi_sas_main.c
+@@ -7,6 +7,16 @@
+ #include "hisi_sas.h"
+ #define DRV_NAME "hisi_sas"
+ 
++#define LINK_RATE_BIT_MASK 2
++#define FIS_BUF_SIZE 20
++#define WAIT_CMD_COMPLETE_DELAY 100
++#define WAIT_CMD_COMPLETE_TMROUT 5000
++#define DELAY_FOR_LINK_READY 2000
++#define BLK_CNT_OPTIMIZE_MARK 64
++#define HZ_TO_MHZ 1000000
++#define DELAY_FOR_SOFTRESET_MAX 1000
++#define DELAY_FOR_SOFTRESET_MIN 900
++
+ #define DEV_IS_GONE(dev) \
+ 	((!dev) || (dev->dev_type == SAS_PHY_UNUSED))
+ 
+@@ -127,7 +137,7 @@ u8 hisi_sas_get_prog_phy_linkrate_mask(enum sas_linkrate max)
+ 
+ 	max -= SAS_LINK_RATE_1_5_GBPS;
+ 	for (i = 0; i <= max; i++)
+-		rate |= 1 << (i * 2);
++		rate |= 1 << (i * LINK_RATE_BIT_MASK);
+ 	return rate;
+ }
+ EXPORT_SYMBOL_GPL(hisi_sas_get_prog_phy_linkrate_mask);
+@@ -876,7 +886,7 @@ int hisi_sas_slave_configure(struct scsi_device *sdev)
+ 	if (ret)
+ 		return ret;
+ 	if (!dev_is_sata(dev))
+-		sas_change_queue_depth(sdev, 64);
++		sas_change_queue_depth(sdev, HISI_SAS_BLK_QUEUE_DEPTH);
+ 
+ 	return 0;
+ }
+@@ -1238,7 +1248,7 @@ static int hisi_sas_phy_set_linkrate(struct hisi_hba *hisi_hba, int phy_no,
+ 	sas_phy->phy->minimum_linkrate = min;
+ 
+ 	hisi_sas_phy_enable(hisi_hba, phy_no, 0);
+-	msleep(100);
++	msleep(HISI_SAS_DELAY_FOR_PHY_DISABLE);
+ 	hisi_hba->hw->phy_set_linkrate(hisi_hba, phy_no, &_r);
+ 	hisi_sas_phy_enable(hisi_hba, phy_no, 1);
+ 
+@@ -1268,7 +1278,7 @@ static int hisi_sas_control_phy(struct asd_sas_phy *sas_phy, enum phy_func func,
+ 
+ 	case PHY_FUNC_LINK_RESET:
+ 		hisi_sas_phy_enable(hisi_hba, phy_no, 0);
+-		msleep(100);
++		msleep(HISI_SAS_DELAY_FOR_PHY_DISABLE);
+ 		hisi_sas_phy_enable(hisi_hba, phy_no, 1);
+ 		break;
+ 
+@@ -1323,7 +1333,7 @@ static void hisi_sas_fill_ata_reset_cmd(struct ata_device *dev,
+ 
+ static int hisi_sas_softreset_ata_disk(struct domain_device *device)
+ {
+-	u8 fis[20] = {0};
++	u8 fis[FIS_BUF_SIZE] = {0};
+ 	struct ata_port *ap = device->sata_dev.ap;
+ 	struct ata_link *link;
+ 	int rc = TMF_RESP_FUNC_FAILED;
+@@ -1340,6 +1350,7 @@ static int hisi_sas_softreset_ata_disk(struct domain_device *device)
+ 	}
+ 
+ 	if (rc == TMF_RESP_FUNC_COMPLETE) {
++		usleep_range(DELAY_FOR_SOFTRESET_MIN, DELAY_FOR_SOFTRESET_MAX);
+ 		ata_for_each_link(link, ap, EDGE) {
+ 			int pmp = sata_srst_pmp(link);
+ 
+@@ -1458,7 +1469,7 @@ static void hisi_sas_send_ata_reset_each_phy(struct hisi_hba *hisi_hba,
+ 	struct device *dev = hisi_hba->dev;
+ 	int rc = TMF_RESP_FUNC_FAILED;
+ 	struct ata_link *link;
+-	u8 fis[20] = {0};
++	u8 fis[FIS_BUF_SIZE] = {0};
+ 	int i;
+ 
+ 	for (i = 0; i < hisi_hba->n_phy; i++) {
+@@ -1525,7 +1536,9 @@ void hisi_sas_controller_reset_prepare(struct hisi_hba *hisi_hba)
+ 	hisi_hba->phy_state = hisi_hba->hw->get_phys_state(hisi_hba);
+ 
+ 	scsi_block_requests(shost);
+-	hisi_hba->hw->wait_cmds_complete_timeout(hisi_hba, 100, 5000);
++	hisi_hba->hw->wait_cmds_complete_timeout(hisi_hba,
++						 WAIT_CMD_COMPLETE_DELAY,
++						 WAIT_CMD_COMPLETE_TMROUT);
+ 
+ 	del_timer_sync(&hisi_hba->timer);
+ 
+@@ -1821,7 +1834,7 @@ static int hisi_sas_debug_I_T_nexus_reset(struct domain_device *device)
+ 		rc = ata_wait_after_reset(link, jiffies + HISI_SAS_WAIT_PHYUP_TIMEOUT,
+ 					  smp_ata_check_ready_type);
+ 	} else {
+-		msleep(2000);
++		msleep(DELAY_FOR_LINK_READY);
+ 	}
+ 
+ 	return rc;
+@@ -2236,12 +2249,14 @@ int hisi_sas_alloc(struct hisi_hba *hisi_hba)
+ 		goto err_out;
+ 
+ 	/* roundup to avoid overly large block size */
+-	max_command_entries_ru = roundup(max_command_entries, 64);
++	max_command_entries_ru = roundup(max_command_entries,
++					 BLK_CNT_OPTIMIZE_MARK);
+ 	if (hisi_hba->prot_mask & HISI_SAS_DIX_PROT_MASK)
+ 		sz_slot_buf_ru = sizeof(struct hisi_sas_slot_dif_buf_table);
+ 	else
+ 		sz_slot_buf_ru = sizeof(struct hisi_sas_slot_buf_table);
+-	sz_slot_buf_ru = roundup(sz_slot_buf_ru, 64);
++
++	sz_slot_buf_ru = roundup(sz_slot_buf_ru, BLK_CNT_OPTIMIZE_MARK);
+ 	s = max(lcm(max_command_entries_ru, sz_slot_buf_ru), PAGE_SIZE);
+ 	blk_cnt = (max_command_entries_ru * sz_slot_buf_ru) / s;
+ 	slots_per_blk = s / sz_slot_buf_ru;
+@@ -2405,7 +2420,8 @@ int hisi_sas_get_fw_info(struct hisi_hba *hisi_hba)
+ 	if (IS_ERR(refclk))
+ 		dev_dbg(dev, "no ref clk property\n");
+ 	else
+-		hisi_hba->refclk_frequency_mhz = clk_get_rate(refclk) / 1000000;
++		hisi_hba->refclk_frequency_mhz = clk_get_rate(refclk) /
++						 HZ_TO_MHZ;
+ 
+ 	if (device_property_read_u32(dev, "phy-count", &hisi_hba->n_phy)) {
+ 		dev_err(dev, "could not get property phy-count\n");
+@@ -2521,8 +2537,8 @@ int hisi_sas_probe(struct platform_device *pdev,
+ 	shost->transportt = hisi_sas_stt;
+ 	shost->max_id = HISI_SAS_MAX_DEVICES;
+ 	shost->max_lun = ~0;
+-	shost->max_channel = 1;
+-	shost->max_cmd_len = 16;
++	shost->max_channel = 0;
++	shost->max_cmd_len = HISI_SAS_MAX_CDB_LEN;
+ 	if (hisi_hba->hw->slot_index_alloc) {
+ 		shost->can_queue = HISI_SAS_MAX_COMMANDS;
+ 		shost->cmd_per_lun = HISI_SAS_MAX_COMMANDS;
+diff --git a/drivers/scsi/hisi_sas/hisi_sas_v3_hw.c b/drivers/scsi/hisi_sas/hisi_sas_v3_hw.c
+index 596b5426d99535..7075dde4584db1 100644
+--- a/drivers/scsi/hisi_sas/hisi_sas_v3_hw.c
++++ b/drivers/scsi/hisi_sas/hisi_sas_v3_hw.c
+@@ -465,6 +465,12 @@
+ #define ITCT_HDR_RTOLT_OFF		48
+ #define ITCT_HDR_RTOLT_MSK		(0xffffULL << ITCT_HDR_RTOLT_OFF)
+ 
++/*debugfs*/
++#define TWO_PARA_PER_LINE 2
++#define FOUR_PARA_PER_LINE 4
++#define	DUMP_BUF_SIZE 8
++#define BIST_BUF_SIZE 16
++
+ struct hisi_sas_protect_iu_v3_hw {
+ 	u32 dw0;
+ 	u32 lbrtcv;
+@@ -535,6 +541,43 @@ struct hisi_sas_err_record_v3 {
+ 
+ #define BASE_VECTORS_V3_HW  16
+ #define MIN_AFFINE_VECTORS_V3_HW  (BASE_VECTORS_V3_HW + 1)
++#define IRQ_PHY_UP_DOWN_INDEX 1
++#define IRQ_CHL_INDEX 2
++#define IRQ_AXI_INDEX 11
++
++#define DELAY_FOR_RESET_HW 100
++#define HDR_SG_MOD 0x2
++#define LUN_SIZE 8
++#define ATTR_PRIO_REGION 9
++#define CDB_REGION 12
++#define PRIO_OFF 3
++#define TMF_REGION 10
++#define TAG_MSB 12
++#define TAG_LSB 13
++#define SMP_FRAME_TYPE 2
++#define SMP_CRC_SIZE 4
++#define HDR_TAG_OFF 3
++#define HOST_NO_OFF 6
++#define PHY_NO_OFF 7
++#define IDENTIFY_REG_READ 6
++#define LINK_RESET_TIMEOUT_OFF 4
++#define DECIMALISM_FLAG 10
++#define WAIT_RETRY 100
++#define WAIT_TMROUT 5000
++
++#define ID_DWORD0_INDEX 0
++#define ID_DWORD1_INDEX 1
++#define ID_DWORD2_INDEX 2
++#define ID_DWORD3_INDEX 3
++#define ID_DWORD4_INDEX 4
++#define ID_DWORD5_INDEX 5
++#define TICKS_BIT_INDEX 24
++#define COUNT_BIT_INDEX 8
++
++#define PORT_REG_LENGTH	    0x100
++#define GLOBAL_REG_LENGTH   0x800
++#define	AXI_REG_LENGTH	    0x61
++#define RAS_REG_LENGTH	    0x10
+ 
+ #define CHNL_INT_STS_MSK	0xeeeeeeee
+ #define CHNL_INT_STS_PHY_MSK	0xe
+@@ -807,17 +850,17 @@ static void config_id_frame_v3_hw(struct hisi_hba *hisi_hba, int phy_no)
+ 	identify_buffer = (u32 *)(&identify_frame);
+ 
+ 	hisi_sas_phy_write32(hisi_hba, phy_no, TX_ID_DWORD0,
+-			__swab32(identify_buffer[0]));
++			__swab32(identify_buffer[ID_DWORD0_INDEX]));
+ 	hisi_sas_phy_write32(hisi_hba, phy_no, TX_ID_DWORD1,
+-			__swab32(identify_buffer[1]));
++			__swab32(identify_buffer[ID_DWORD1_INDEX]));
+ 	hisi_sas_phy_write32(hisi_hba, phy_no, TX_ID_DWORD2,
+-			__swab32(identify_buffer[2]));
++			__swab32(identify_buffer[ID_DWORD2_INDEX]));
+ 	hisi_sas_phy_write32(hisi_hba, phy_no, TX_ID_DWORD3,
+-			__swab32(identify_buffer[3]));
++			__swab32(identify_buffer[ID_DWORD3_INDEX]));
+ 	hisi_sas_phy_write32(hisi_hba, phy_no, TX_ID_DWORD4,
+-			__swab32(identify_buffer[4]));
++			__swab32(identify_buffer[ID_DWORD4_INDEX]));
+ 	hisi_sas_phy_write32(hisi_hba, phy_no, TX_ID_DWORD5,
+-			__swab32(identify_buffer[5]));
++			__swab32(identify_buffer[ID_DWORD5_INDEX]));
+ }
+ 
+ static void setup_itct_v3_hw(struct hisi_hba *hisi_hba,
+@@ -937,7 +980,7 @@ static int reset_hw_v3_hw(struct hisi_hba *hisi_hba)
+ 
+ 	/* Disable all of the PHYs */
+ 	hisi_sas_stop_phys(hisi_hba);
+-	udelay(50);
++	udelay(HISI_SAS_DELAY_FOR_PHY_DISABLE);
+ 
+ 	/* Ensure axi bus idle */
+ 	ret = hisi_sas_read32_poll_timeout(AXI_CFG, val, !val,
+@@ -977,7 +1020,7 @@ static int hw_init_v3_hw(struct hisi_hba *hisi_hba)
+ 		return rc;
+ 	}
+ 
+-	msleep(100);
++	msleep(DELAY_FOR_RESET_HW);
+ 	init_reg_v3_hw(hisi_hba);
+ 
+ 	if (guid_parse("D5918B4B-37AE-4E10-A99F-E5E8A6EF4C1F", &guid)) {
+@@ -1026,7 +1069,7 @@ static void disable_phy_v3_hw(struct hisi_hba *hisi_hba, int phy_no)
+ 	cfg &= ~PHY_CFG_ENA_MSK;
+ 	hisi_sas_phy_write32(hisi_hba, phy_no, PHY_CFG, cfg);
+ 
+-	mdelay(50);
++	mdelay(HISI_SAS_DELAY_FOR_PHY_DISABLE);
+ 
+ 	state = hisi_sas_read32(hisi_hba, PHY_STATE);
+ 	if (state & BIT(phy_no)) {
+@@ -1062,7 +1105,7 @@ static void phy_hard_reset_v3_hw(struct hisi_hba *hisi_hba, int phy_no)
+ 		hisi_sas_phy_write32(hisi_hba, phy_no, TXID_AUTO,
+ 					txid_auto | TX_HARDRST_MSK);
+ 	}
+-	msleep(100);
++	msleep(HISI_SAS_DELAY_FOR_PHY_DISABLE);
+ 	hisi_sas_phy_enable(hisi_hba, phy_no, 1);
+ }
+ 
+@@ -1107,7 +1150,8 @@ static int get_wideport_bitmap_v3_hw(struct hisi_hba *hisi_hba, int port_id)
+ 
+ 	for (i = 0; i < hisi_hba->n_phy; i++)
+ 		if (phy_state & BIT(i))
+-			if (((phy_port_num_ma >> (i * 4)) & 0xf) == port_id)
++			if (((phy_port_num_ma >> (i * HISI_SAS_REG_MEM_SIZE)) & 0xf) ==
++			    port_id)
+ 				bitmap |= BIT(i);
+ 
+ 	return bitmap;
+@@ -1305,9 +1349,9 @@ static void prep_ssp_v3_hw(struct hisi_hba *hisi_hba,
+ 	dw1 |= sas_dev->device_id << CMD_HDR_DEV_ID_OFF;
+ 
+ 	dw2 = (((sizeof(struct ssp_command_iu) + sizeof(struct ssp_frame_hdr)
+-	      + 3) / 4) << CMD_HDR_CFL_OFF) |
+-	      ((HISI_SAS_MAX_SSP_RESP_SZ / 4) << CMD_HDR_MRFL_OFF) |
+-	      (2 << CMD_HDR_SG_MOD_OFF);
++	      + 3) / BYTE_TO_DW) << CMD_HDR_CFL_OFF) |
++	      ((HISI_SAS_MAX_SSP_RESP_SZ / BYTE_TO_DW) << CMD_HDR_MRFL_OFF) |
++	      (HDR_SG_MOD << CMD_HDR_SG_MOD_OFF);
+ 	hdr->dw2 = cpu_to_le32(dw2);
+ 	hdr->transfer_tags = cpu_to_le32(slot->idx);
+ 
+@@ -1327,18 +1371,19 @@ static void prep_ssp_v3_hw(struct hisi_hba *hisi_hba,
+ 	buf_cmd = hisi_sas_cmd_hdr_addr_mem(slot) +
+ 		sizeof(struct ssp_frame_hdr);
+ 
+-	memcpy(buf_cmd, &task->ssp_task.LUN, 8);
++	memcpy(buf_cmd, &task->ssp_task.LUN, LUN_SIZE);
+ 	if (!tmf) {
+-		buf_cmd[9] = ssp_task->task_attr;
+-		memcpy(buf_cmd + 12, scsi_cmnd->cmnd, scsi_cmnd->cmd_len);
++		buf_cmd[ATTR_PRIO_REGION] = ssp_task->task_attr;
++		memcpy(buf_cmd + CDB_REGION, scsi_cmnd->cmnd,
++		       scsi_cmnd->cmd_len);
+ 	} else {
+-		buf_cmd[10] = tmf->tmf;
++		buf_cmd[TMF_REGION] = tmf->tmf;
+ 		switch (tmf->tmf) {
+ 		case TMF_ABORT_TASK:
+ 		case TMF_QUERY_TASK:
+-			buf_cmd[12] =
++			buf_cmd[TAG_MSB] =
+ 				(tmf->tag_of_task_to_be_managed >> 8) & 0xff;
+-			buf_cmd[13] =
++			buf_cmd[TAG_LSB] =
+ 				tmf->tag_of_task_to_be_managed & 0xff;
+ 			break;
+ 		default:
+@@ -1371,7 +1416,8 @@ static void prep_ssp_v3_hw(struct hisi_hba *hisi_hba,
+ 			unsigned int interval = scsi_prot_interval(scsi_cmnd);
+ 			unsigned int ilog2_interval = ilog2(interval);
+ 
+-			len = (task->total_xfer_len >> ilog2_interval) * 8;
++			len = (task->total_xfer_len >> ilog2_interval) *
++			      BYTE_TO_DDW;
+ 		}
+ 	}
+ 
+@@ -1391,6 +1437,7 @@ static void prep_smp_v3_hw(struct hisi_hba *hisi_hba,
+ 	struct hisi_sas_device *sas_dev = device->lldd_dev;
+ 	dma_addr_t req_dma_addr;
+ 	unsigned int req_len;
++	u32 cfl;
+ 
+ 	/* req */
+ 	sg_req = &task->smp_task.smp_req;
+@@ -1401,7 +1448,7 @@ static void prep_smp_v3_hw(struct hisi_hba *hisi_hba,
+ 	/* dw0 */
+ 	hdr->dw0 = cpu_to_le32((port->id << CMD_HDR_PORT_OFF) |
+ 			       (1 << CMD_HDR_PRIORITY_OFF) | /* high pri */
+-			       (2 << CMD_HDR_CMD_OFF)); /* smp */
++			       (SMP_FRAME_TYPE << CMD_HDR_CMD_OFF)); /* smp */
+ 
+ 	/* map itct entry */
+ 	hdr->dw1 = cpu_to_le32((sas_dev->device_id << CMD_HDR_DEV_ID_OFF) |
+@@ -1409,8 +1456,9 @@ static void prep_smp_v3_hw(struct hisi_hba *hisi_hba,
+ 			       (DIR_NO_DATA << CMD_HDR_DIR_OFF));
+ 
+ 	/* dw2 */
+-	hdr->dw2 = cpu_to_le32((((req_len - 4) / 4) << CMD_HDR_CFL_OFF) |
+-			       (HISI_SAS_MAX_SMP_RESP_SZ / 4 <<
++	cfl = (req_len - SMP_CRC_SIZE) / BYTE_TO_DW;
++	hdr->dw2 = cpu_to_le32((cfl << CMD_HDR_CFL_OFF) |
++			       (HISI_SAS_MAX_SMP_RESP_SZ / BYTE_TO_DW <<
+ 			       CMD_HDR_MRFL_OFF));
+ 
+ 	hdr->transfer_tags = cpu_to_le32(slot->idx << CMD_HDR_IPTT_OFF);
+@@ -1477,12 +1525,13 @@ static void prep_ata_v3_hw(struct hisi_hba *hisi_hba,
+ 		struct ata_queued_cmd *qc = task->uldd_task;
+ 
+ 		hdr_tag = qc->tag;
+-		task->ata_task.fis.sector_count |= (u8) (hdr_tag << 3);
++		task->ata_task.fis.sector_count |=
++				(u8)(hdr_tag << HDR_TAG_OFF);
+ 		dw2 |= hdr_tag << CMD_HDR_NCQ_TAG_OFF;
+ 	}
+ 
+-	dw2 |= (HISI_SAS_MAX_STP_RESP_SZ / 4) << CMD_HDR_CFL_OFF |
+-			2 << CMD_HDR_SG_MOD_OFF;
++	dw2 |= (HISI_SAS_MAX_STP_RESP_SZ / BYTE_TO_DW) << CMD_HDR_CFL_OFF |
++		HDR_SG_MOD << CMD_HDR_SG_MOD_OFF;
+ 	hdr->dw2 = cpu_to_le32(dw2);
+ 
+ 	/* dw3 */
+@@ -1542,9 +1591,9 @@ static irqreturn_t phy_up_v3_hw(int phy_no, struct hisi_hba *hisi_hba)
+ 	hisi_sas_phy_write32(hisi_hba, phy_no, PHYCTRL_PHY_ENA_MSK, 1);
+ 
+ 	port_id = hisi_sas_read32(hisi_hba, PHY_PORT_NUM_MA);
+-	port_id = (port_id >> (4 * phy_no)) & 0xf;
++	port_id = (port_id >> (HISI_SAS_REG_MEM_SIZE * phy_no)) & 0xf;
+ 	link_rate = hisi_sas_read32(hisi_hba, PHY_CONN_RATE);
+-	link_rate = (link_rate >> (phy_no * 4)) & 0xf;
++	link_rate = (link_rate >> (phy_no * HISI_SAS_REG_MEM_SIZE)) & 0xf;
+ 
+ 	if (port_id == 0xf) {
+ 		dev_err(dev, "phyup: phy%d invalid portid\n", phy_no);
+@@ -1577,8 +1626,8 @@ static irqreturn_t phy_up_v3_hw(int phy_no, struct hisi_hba *hisi_hba)
+ 
+ 		sas_phy->oob_mode = SATA_OOB_MODE;
+ 		attached_sas_addr[0] = 0x50;
+-		attached_sas_addr[6] = shost->host_no;
+-		attached_sas_addr[7] = phy_no;
++		attached_sas_addr[HOST_NO_OFF] = shost->host_no;
++		attached_sas_addr[PHY_NO_OFF] = phy_no;
+ 		memcpy(sas_phy->attached_sas_addr,
+ 		       attached_sas_addr,
+ 		       SAS_ADDR_SIZE);
+@@ -1594,7 +1643,7 @@ static irqreturn_t phy_up_v3_hw(int phy_no, struct hisi_hba *hisi_hba)
+ 			(struct sas_identify_frame *)frame_rcvd;
+ 
+ 		dev_info(dev, "phyup: phy%d link_rate=%d\n", phy_no, link_rate);
+-		for (i = 0; i < 6; i++) {
++		for (i = 0; i < IDENTIFY_REG_READ; i++) {
+ 			u32 idaf = hisi_sas_phy_read32(hisi_hba, phy_no,
+ 					       RX_IDAF_DWORD0 + (i * 4));
+ 			frame_rcvd[i] = __swab32(idaf);
+@@ -1864,7 +1913,7 @@ static void handle_chl_int2_v3_hw(struct hisi_hba *hisi_hba, int phy_no)
+ 
+ 		dev_warn(dev, "phy%d stp link timeout (0x%x)\n",
+ 			 phy_no, reg_value);
+-		if (reg_value & BIT(4))
++		if (reg_value & BIT(LINK_RESET_TIMEOUT_OFF))
+ 			hisi_sas_notify_phy_event(phy, HISI_PHYE_LINK_RESET);
+ 	}
+ 
+@@ -2581,7 +2630,7 @@ static int interrupt_init_v3_hw(struct hisi_hba *hisi_hba)
+ 	struct pci_dev *pdev = hisi_hba->pci_dev;
+ 	int rc, i;
+ 
+-	rc = devm_request_irq(dev, pci_irq_vector(pdev, 1),
++	rc = devm_request_irq(dev, pci_irq_vector(pdev, IRQ_PHY_UP_DOWN_INDEX),
+ 			      int_phy_up_down_bcast_v3_hw, 0,
+ 			      DRV_NAME " phy", hisi_hba);
+ 	if (rc) {
+@@ -2589,7 +2638,7 @@ static int interrupt_init_v3_hw(struct hisi_hba *hisi_hba)
+ 		return -ENOENT;
+ 	}
+ 
+-	rc = devm_request_irq(dev, pci_irq_vector(pdev, 2),
++	rc = devm_request_irq(dev, pci_irq_vector(pdev, IRQ_CHL_INDEX),
+ 			      int_chnl_int_v3_hw, 0,
+ 			      DRV_NAME " channel", hisi_hba);
+ 	if (rc) {
+@@ -2597,7 +2646,7 @@ static int interrupt_init_v3_hw(struct hisi_hba *hisi_hba)
+ 		return -ENOENT;
+ 	}
+ 
+-	rc = devm_request_irq(dev, pci_irq_vector(pdev, 11),
++	rc = devm_request_irq(dev, pci_irq_vector(pdev, IRQ_AXI_INDEX),
+ 			      fatal_axi_int_v3_hw, 0,
+ 			      DRV_NAME " fatal", hisi_hba);
+ 	if (rc) {
+@@ -2610,7 +2659,8 @@ static int interrupt_init_v3_hw(struct hisi_hba *hisi_hba)
+ 
+ 	for (i = 0; i < hisi_hba->cq_nvecs; i++) {
+ 		struct hisi_sas_cq *cq = &hisi_hba->cq[i];
+-		int nr = hisi_sas_intr_conv ? 16 : 16 + i;
++		int nr = hisi_sas_intr_conv ? BASE_VECTORS_V3_HW :
++					      BASE_VECTORS_V3_HW + i;
+ 		unsigned long irqflags = hisi_sas_intr_conv ? IRQF_SHARED :
+ 							      IRQF_ONESHOT;
+ 
+@@ -2668,14 +2718,14 @@ static void interrupt_disable_v3_hw(struct hisi_hba *hisi_hba)
+ 	struct pci_dev *pdev = hisi_hba->pci_dev;
+ 	int i;
+ 
+-	synchronize_irq(pci_irq_vector(pdev, 1));
+-	synchronize_irq(pci_irq_vector(pdev, 2));
+-	synchronize_irq(pci_irq_vector(pdev, 11));
++	synchronize_irq(pci_irq_vector(pdev, IRQ_PHY_UP_DOWN_INDEX));
++	synchronize_irq(pci_irq_vector(pdev, IRQ_CHL_INDEX));
++	synchronize_irq(pci_irq_vector(pdev, IRQ_AXI_INDEX));
+ 	for (i = 0; i < hisi_hba->queue_count; i++)
+ 		hisi_sas_write32(hisi_hba, OQ0_INT_SRC_MSK + 0x4 * i, 0x1);
+ 
+ 	for (i = 0; i < hisi_hba->cq_nvecs; i++)
+-		synchronize_irq(pci_irq_vector(pdev, i + 16));
++		synchronize_irq(pci_irq_vector(pdev, i + BASE_VECTORS_V3_HW));
+ 
+ 	hisi_sas_write32(hisi_hba, ENT_INT_SRC_MSK1, 0xffffffff);
+ 	hisi_sas_write32(hisi_hba, ENT_INT_SRC_MSK2, 0xffffffff);
+@@ -2707,7 +2757,7 @@ static int disable_host_v3_hw(struct hisi_hba *hisi_hba)
+ 
+ 	hisi_sas_stop_phys(hisi_hba);
+ 
+-	mdelay(10);
++	mdelay(HISI_SAS_DELAY_FOR_PHY_DISABLE);
+ 
+ 	reg_val = hisi_sas_read32(hisi_hba, AXI_MASTER_CFG_BASE +
+ 				  AM_CTRL_GLOBAL);
+@@ -2843,13 +2893,13 @@ static ssize_t intr_coal_ticks_v3_hw_store(struct device *dev,
+ 	u32 intr_coal_ticks;
+ 	int ret;
+ 
+-	ret = kstrtou32(buf, 10, &intr_coal_ticks);
++	ret = kstrtou32(buf, DECIMALISM_FLAG, &intr_coal_ticks);
+ 	if (ret) {
+ 		dev_err(dev, "Input data of interrupt coalesce unmatch\n");
+ 		return -EINVAL;
+ 	}
+ 
+-	if (intr_coal_ticks >= BIT(24)) {
++	if (intr_coal_ticks >= BIT(TICKS_BIT_INDEX)) {
+ 		dev_err(dev, "intr_coal_ticks must be less than 2^24!\n");
+ 		return -EINVAL;
+ 	}
+@@ -2882,13 +2932,13 @@ static ssize_t intr_coal_count_v3_hw_store(struct device *dev,
+ 	u32 intr_coal_count;
+ 	int ret;
+ 
+-	ret = kstrtou32(buf, 10, &intr_coal_count);
++	ret = kstrtou32(buf, DECIMALISM_FLAG, &intr_coal_count);
+ 	if (ret) {
+ 		dev_err(dev, "Input data of interrupt coalesce unmatch\n");
+ 		return -EINVAL;
+ 	}
+ 
+-	if (intr_coal_count >= BIT(8)) {
++	if (intr_coal_count >= BIT(COUNT_BIT_INDEX)) {
+ 		dev_err(dev, "intr_coal_count must be less than 2^8!\n");
+ 		return -EINVAL;
+ 	}
+@@ -3014,7 +3064,7 @@ static const struct hisi_sas_debugfs_reg_lu debugfs_port_reg_lu[] = {
+ 
+ static const struct hisi_sas_debugfs_reg debugfs_port_reg = {
+ 	.lu = debugfs_port_reg_lu,
+-	.count = 0x100,
++	.count = PORT_REG_LENGTH,
+ 	.base_off = PORT_BASE,
+ };
+ 
+@@ -3088,7 +3138,7 @@ static const struct hisi_sas_debugfs_reg_lu debugfs_global_reg_lu[] = {
+ 
+ static const struct hisi_sas_debugfs_reg debugfs_global_reg = {
+ 	.lu = debugfs_global_reg_lu,
+-	.count = 0x800,
++	.count = GLOBAL_REG_LENGTH,
+ };
+ 
+ static const struct hisi_sas_debugfs_reg_lu debugfs_axi_reg_lu[] = {
+@@ -3101,7 +3151,7 @@ static const struct hisi_sas_debugfs_reg_lu debugfs_axi_reg_lu[] = {
+ 
+ static const struct hisi_sas_debugfs_reg debugfs_axi_reg = {
+ 	.lu = debugfs_axi_reg_lu,
+-	.count = 0x61,
++	.count = AXI_REG_LENGTH,
+ 	.base_off = AXI_MASTER_CFG_BASE,
+ };
+ 
+@@ -3118,7 +3168,7 @@ static const struct hisi_sas_debugfs_reg_lu debugfs_ras_reg_lu[] = {
+ 
+ static const struct hisi_sas_debugfs_reg debugfs_ras_reg = {
+ 	.lu = debugfs_ras_reg_lu,
+-	.count = 0x10,
++	.count = RAS_REG_LENGTH,
+ 	.base_off = RAS_BASE,
+ };
+ 
+@@ -3127,7 +3177,7 @@ static void debugfs_snapshot_prepare_v3_hw(struct hisi_hba *hisi_hba)
+ 	struct Scsi_Host *shost = hisi_hba->shost;
+ 
+ 	scsi_block_requests(shost);
+-	wait_cmds_complete_timeout_v3_hw(hisi_hba, 100, 5000);
++	wait_cmds_complete_timeout_v3_hw(hisi_hba, WAIT_RETRY, WAIT_TMROUT);
+ 
+ 	set_bit(HISI_SAS_REJECT_CMD_BIT, &hisi_hba->flags);
+ 	hisi_sas_sync_cqs(hisi_hba);
+@@ -3168,7 +3218,7 @@ static void read_iost_itct_cache_v3_hw(struct hisi_hba *hisi_hba,
+ 		return;
+ 	}
+ 
+-	memset(buf, 0, cache_dw_size * 4);
++	memset(buf, 0, cache_dw_size * BYTE_TO_DW);
+ 	buf[0] = val;
+ 
+ 	for (i = 1; i < cache_dw_size; i++)
+@@ -3215,7 +3265,7 @@ static void hisi_sas_bist_test_restore_v3_hw(struct hisi_hba *hisi_hba)
+ 	reg_val = hisi_sas_phy_read32(hisi_hba, phy_no, PROG_PHY_LINK_RATE);
+ 	/* init OOB link rate as 1.5 Gbits */
+ 	reg_val &= ~CFG_PROG_OOB_PHY_LINK_RATE_MSK;
+-	reg_val |= (0x8 << CFG_PROG_OOB_PHY_LINK_RATE_OFF);
++	reg_val |= (SAS_LINK_RATE_1_5_GBPS << CFG_PROG_OOB_PHY_LINK_RATE_OFF);
+ 	hisi_sas_phy_write32(hisi_hba, phy_no, PROG_PHY_LINK_RATE, reg_val);
+ 
+ 	/* enable PHY */
+@@ -3224,6 +3274,9 @@ static void hisi_sas_bist_test_restore_v3_hw(struct hisi_hba *hisi_hba)
+ 
+ #define SAS_PHY_BIST_CODE_INIT	0x1
+ #define SAS_PHY_BIST_CODE1_INIT	0X80
++#define SAS_PHY_BIST_INIT_DELAY 100
++#define SAS_PHY_BIST_LOOP_TEST_0 1
++#define SAS_PHY_BIST_LOOP_TEST_1 2
+ static int debugfs_set_bist_v3_hw(struct hisi_hba *hisi_hba, bool enable)
+ {
+ 	u32 reg_val, mode_tmp;
+@@ -3242,7 +3295,8 @@ static int debugfs_set_bist_v3_hw(struct hisi_hba *hisi_hba, bool enable)
+ 		 ffe[FFE_SATA_1_5_GBPS], ffe[FFE_SATA_3_0_GBPS],
+ 		 ffe[FFE_SATA_6_0_GBPS], fix_code[FIXED_CODE],
+ 		 fix_code[FIXED_CODE_1]);
+-	mode_tmp = path_mode ? 2 : 1;
++	mode_tmp = path_mode ? SAS_PHY_BIST_LOOP_TEST_1 :
++			       SAS_PHY_BIST_LOOP_TEST_0;
+ 	if (enable) {
+ 		/* some preparations before bist test */
+ 		hisi_sas_bist_test_prep_v3_hw(hisi_hba);
+@@ -3285,13 +3339,13 @@ static int debugfs_set_bist_v3_hw(struct hisi_hba *hisi_hba, bool enable)
+ 					     SAS_PHY_BIST_CODE1_INIT);
+ 		}
+ 
+-		mdelay(100);
++		mdelay(SAS_PHY_BIST_INIT_DELAY);
+ 		reg_val |= (CFG_RX_BIST_EN_MSK | CFG_TX_BIST_EN_MSK);
+ 		hisi_sas_phy_write32(hisi_hba, phy_no, SAS_PHY_BIST_CTRL,
+ 				     reg_val);
+ 
+ 		/* clear error bit */
+-		mdelay(100);
++		mdelay(SAS_PHY_BIST_INIT_DELAY);
+ 		hisi_sas_phy_read32(hisi_hba, phy_no, SAS_BIST_ERR_CNT);
+ 	} else {
+ 		/* disable bist test and recover it */
+@@ -3482,7 +3536,7 @@ static void debugfs_snapshot_port_reg_v3_hw(struct hisi_hba *hisi_hba)
+ 	for (phy_cnt = 0; phy_cnt < hisi_hba->n_phy; phy_cnt++) {
+ 		databuf = hisi_hba->debugfs_port_reg[dump_index][phy_cnt].data;
+ 		for (i = 0; i < port->count; i++, databuf++) {
+-			offset = port->base_off + 4 * i;
++			offset = port->base_off + HISI_SAS_REG_MEM_SIZE * i;
+ 			*databuf = hisi_sas_phy_read32(hisi_hba, phy_cnt,
+ 						       offset);
+ 		}
+@@ -3496,7 +3550,8 @@ static void debugfs_snapshot_global_reg_v3_hw(struct hisi_hba *hisi_hba)
+ 	int i;
+ 
+ 	for (i = 0; i < debugfs_global_reg.count; i++, databuf++)
+-		*databuf = hisi_sas_read32(hisi_hba, 4 * i);
++		*databuf = hisi_sas_read32(hisi_hba,
++					   HISI_SAS_REG_MEM_SIZE * i);
+ }
+ 
+ static void debugfs_snapshot_axi_reg_v3_hw(struct hisi_hba *hisi_hba)
+@@ -3507,7 +3562,9 @@ static void debugfs_snapshot_axi_reg_v3_hw(struct hisi_hba *hisi_hba)
+ 	int i;
+ 
+ 	for (i = 0; i < axi->count; i++, databuf++)
+-		*databuf = hisi_sas_read32(hisi_hba, 4 * i + axi->base_off);
++		*databuf = hisi_sas_read32(hisi_hba,
++					   HISI_SAS_REG_MEM_SIZE * i +
++					   axi->base_off);
+ }
+ 
+ static void debugfs_snapshot_ras_reg_v3_hw(struct hisi_hba *hisi_hba)
+@@ -3518,7 +3575,9 @@ static void debugfs_snapshot_ras_reg_v3_hw(struct hisi_hba *hisi_hba)
+ 	int i;
+ 
+ 	for (i = 0; i < ras->count; i++, databuf++)
+-		*databuf = hisi_sas_read32(hisi_hba, 4 * i + ras->base_off);
++		*databuf = hisi_sas_read32(hisi_hba,
++					   HISI_SAS_REG_MEM_SIZE * i +
++					   ras->base_off);
+ }
+ 
+ static void debugfs_snapshot_itct_reg_v3_hw(struct hisi_hba *hisi_hba)
+@@ -3581,7 +3640,7 @@ static void debugfs_print_reg_v3_hw(u32 *regs_val, struct seq_file *s,
+ 	int i;
+ 
+ 	for (i = 0; i < reg->count; i++) {
+-		int off = i * 4;
++		int off = i * HISI_SAS_REG_MEM_SIZE;
+ 		const char *name;
+ 
+ 		name = debugfs_to_reg_name_v3_hw(off, reg->base_off,
+@@ -3659,9 +3718,9 @@ static void debugfs_show_row_64_v3_hw(struct seq_file *s, int index,
+ 
+ 	/* completion header size not fixed per HW version */
+ 	seq_printf(s, "index %04d:\n\t", index);
+-	for (i = 1; i <= sz / 8; i++, ptr++) {
++	for (i = 1; i <= sz / BYTE_TO_DDW; i++, ptr++) {
+ 		seq_printf(s, " 0x%016llx", le64_to_cpu(*ptr));
+-		if (!(i % 2))
++		if (!(i % TWO_PARA_PER_LINE))
+ 			seq_puts(s, "\n\t");
+ 	}
+ 
+@@ -3675,9 +3734,9 @@ static void debugfs_show_row_32_v3_hw(struct seq_file *s, int index,
+ 
+ 	/* completion header size not fixed per HW version */
+ 	seq_printf(s, "index %04d:\n\t", index);
+-	for (i = 1; i <= sz / 4; i++, ptr++) {
++	for (i = 1; i <= sz / BYTE_TO_DW; i++, ptr++) {
+ 		seq_printf(s, " 0x%08x", le32_to_cpu(*ptr));
+-		if (!(i % 4))
++		if (!(i % FOUR_PARA_PER_LINE))
+ 			seq_puts(s, "\n\t");
+ 	}
+ 	seq_puts(s, "\n");
+@@ -3762,7 +3821,7 @@ static int debugfs_iost_cache_v3_hw_show(struct seq_file *s, void *p)
+ 	struct hisi_sas_debugfs_iost_cache *debugfs_iost_cache = s->private;
+ 	struct hisi_sas_iost_itct_cache *iost_cache =
+ 						debugfs_iost_cache->cache;
+-	u32 cache_size = HISI_SAS_IOST_ITCT_CACHE_DW_SZ * 4;
++	u32 cache_size = HISI_SAS_IOST_ITCT_CACHE_DW_SZ * BYTE_TO_DW;
+ 	int i, tab_idx;
+ 	__le64 *iost;
+ 
+@@ -3810,7 +3869,7 @@ static int debugfs_itct_cache_v3_hw_show(struct seq_file *s, void *p)
+ 	struct hisi_sas_debugfs_itct_cache *debugfs_itct_cache = s->private;
+ 	struct hisi_sas_iost_itct_cache *itct_cache =
+ 						debugfs_itct_cache->cache;
+-	u32 cache_size = HISI_SAS_IOST_ITCT_CACHE_DW_SZ * 4;
++	u32 cache_size = HISI_SAS_IOST_ITCT_CACHE_DW_SZ * BYTE_TO_DW;
+ 	int i, tab_idx;
+ 	__le64 *itct;
+ 
+@@ -3839,12 +3898,12 @@ static void debugfs_create_files_v3_hw(struct hisi_hba *hisi_hba, int index)
+ 	u64 *debugfs_timestamp;
+ 	struct dentry *dump_dentry;
+ 	struct dentry *dentry;
+-	char name[256];
++	char name[NAME_BUF_SIZE];
+ 	int p;
+ 	int c;
+ 	int d;
+ 
+-	snprintf(name, 256, "%d", index);
++	snprintf(name, NAME_BUF_SIZE, "%d", index);
+ 
+ 	dump_dentry = debugfs_create_dir(name, hisi_hba->debugfs_dump_dentry);
+ 
+@@ -3860,7 +3919,7 @@ static void debugfs_create_files_v3_hw(struct hisi_hba *hisi_hba, int index)
+ 	/* Create port dir and files */
+ 	dentry = debugfs_create_dir("port", dump_dentry);
+ 	for (p = 0; p < hisi_hba->n_phy; p++) {
+-		snprintf(name, 256, "%d", p);
++		snprintf(name, NAME_BUF_SIZE, "%d", p);
+ 
+ 		debugfs_create_file(name, 0400, dentry,
+ 				    &hisi_hba->debugfs_port_reg[index][p],
+@@ -3870,7 +3929,7 @@ static void debugfs_create_files_v3_hw(struct hisi_hba *hisi_hba, int index)
+ 	/* Create CQ dir and files */
+ 	dentry = debugfs_create_dir("cq", dump_dentry);
+ 	for (c = 0; c < hisi_hba->queue_count; c++) {
+-		snprintf(name, 256, "%d", c);
++		snprintf(name, NAME_BUF_SIZE, "%d", c);
+ 
+ 		debugfs_create_file(name, 0400, dentry,
+ 				    &hisi_hba->debugfs_cq[index][c],
+@@ -3880,7 +3939,7 @@ static void debugfs_create_files_v3_hw(struct hisi_hba *hisi_hba, int index)
+ 	/* Create DQ dir and files */
+ 	dentry = debugfs_create_dir("dq", dump_dentry);
+ 	for (d = 0; d < hisi_hba->queue_count; d++) {
+-		snprintf(name, 256, "%d", d);
++		snprintf(name, NAME_BUF_SIZE, "%d", d);
+ 
+ 		debugfs_create_file(name, 0400, dentry,
+ 				    &hisi_hba->debugfs_dq[index][d],
+@@ -3917,9 +3976,9 @@ static ssize_t debugfs_trigger_dump_v3_hw_write(struct file *file,
+ 						size_t count, loff_t *ppos)
+ {
+ 	struct hisi_hba *hisi_hba = file->f_inode->i_private;
+-	char buf[8];
++	char buf[DUMP_BUF_SIZE];
+ 
+-	if (count > 8)
++	if (count > DUMP_BUF_SIZE)
+ 		return -EFAULT;
+ 
+ 	if (copy_from_user(buf, user_buf, count))
+@@ -3983,7 +4042,7 @@ static ssize_t debugfs_bist_linkrate_v3_hw_write(struct file *filp,
+ {
+ 	struct seq_file *m = filp->private_data;
+ 	struct hisi_hba *hisi_hba = m->private;
+-	char kbuf[16] = {}, *pkbuf;
++	char kbuf[BIST_BUF_SIZE] = {}, *pkbuf;
+ 	bool found = false;
+ 	int i;
+ 
+@@ -4000,7 +4059,7 @@ static ssize_t debugfs_bist_linkrate_v3_hw_write(struct file *filp,
+ 
+ 	for (i = 0; i < ARRAY_SIZE(debugfs_loop_linkrate_v3_hw); i++) {
+ 		if (!strncmp(debugfs_loop_linkrate_v3_hw[i].name,
+-			     pkbuf, 16)) {
++			     pkbuf, BIST_BUF_SIZE)) {
+ 			hisi_hba->debugfs_bist_linkrate =
+ 				debugfs_loop_linkrate_v3_hw[i].value;
+ 			found = true;
+@@ -4073,7 +4132,7 @@ static ssize_t debugfs_bist_code_mode_v3_hw_write(struct file *filp,
+ {
+ 	struct seq_file *m = filp->private_data;
+ 	struct hisi_hba *hisi_hba = m->private;
+-	char kbuf[16] = {}, *pkbuf;
++	char kbuf[BIST_BUF_SIZE] = {}, *pkbuf;
+ 	bool found = false;
+ 	int i;
+ 
+@@ -4090,7 +4149,7 @@ static ssize_t debugfs_bist_code_mode_v3_hw_write(struct file *filp,
+ 
+ 	for (i = 0; i < ARRAY_SIZE(debugfs_loop_code_mode_v3_hw); i++) {
+ 		if (!strncmp(debugfs_loop_code_mode_v3_hw[i].name,
+-			     pkbuf, 16)) {
++			     pkbuf, BIST_BUF_SIZE)) {
+ 			hisi_hba->debugfs_bist_code_mode =
+ 				debugfs_loop_code_mode_v3_hw[i].value;
+ 			found = true;
+@@ -4250,7 +4309,7 @@ static ssize_t debugfs_bist_mode_v3_hw_write(struct file *filp,
+ {
+ 	struct seq_file *m = filp->private_data;
+ 	struct hisi_hba *hisi_hba = m->private;
+-	char kbuf[16] = {}, *pkbuf;
++	char kbuf[BIST_BUF_SIZE] = {}, *pkbuf;
+ 	bool found = false;
+ 	int i;
+ 
+@@ -4266,7 +4325,8 @@ static ssize_t debugfs_bist_mode_v3_hw_write(struct file *filp,
+ 	pkbuf = strstrip(kbuf);
+ 
+ 	for (i = 0; i < ARRAY_SIZE(debugfs_loop_modes_v3_hw); i++) {
+-		if (!strncmp(debugfs_loop_modes_v3_hw[i].name, pkbuf, 16)) {
++		if (!strncmp(debugfs_loop_modes_v3_hw[i].name, pkbuf,
++			     BIST_BUF_SIZE)) {
+ 			hisi_hba->debugfs_bist_mode =
+ 				debugfs_loop_modes_v3_hw[i].value;
+ 			found = true;
+@@ -4604,8 +4664,9 @@ static int debugfs_fifo_data_v3_hw_show(struct seq_file *s, void *p)
+ 
+ 	debugfs_read_fifo_data_v3_hw(phy);
+ 
+-	debugfs_show_row_32_v3_hw(s, 0, HISI_SAS_FIFO_DATA_DW_SIZE * 4,
+-				  (__le32 *)phy->fifo.rd_data);
++	debugfs_show_row_32_v3_hw(s, 0,
++			HISI_SAS_FIFO_DATA_DW_SIZE * HISI_SAS_REG_MEM_SIZE,
++			phy->fifo.rd_data);
+ 
+ 	return 0;
+ }
+@@ -4737,14 +4798,14 @@ static int debugfs_alloc_v3_hw(struct hisi_hba *hisi_hba, int dump_index)
+ 		struct hisi_sas_debugfs_regs *regs =
+ 				&hisi_hba->debugfs_regs[dump_index][r];
+ 
+-		sz = debugfs_reg_array_v3_hw[r]->count * 4;
++		sz = debugfs_reg_array_v3_hw[r]->count * HISI_SAS_REG_MEM_SIZE;
+ 		regs->data = devm_kmalloc(dev, sz, GFP_KERNEL);
+ 		if (!regs->data)
+ 			goto fail;
+ 		regs->hisi_hba = hisi_hba;
+ 	}
+ 
+-	sz = debugfs_port_reg.count * 4;
++	sz = debugfs_port_reg.count * HISI_SAS_REG_MEM_SIZE;
+ 	for (p = 0; p < hisi_hba->n_phy; p++) {
+ 		struct hisi_sas_debugfs_port *port =
+ 				&hisi_hba->debugfs_port_reg[dump_index][p];
+@@ -4854,11 +4915,11 @@ static void debugfs_phy_down_cnt_init_v3_hw(struct hisi_hba *hisi_hba)
+ {
+ 	struct dentry *dir = debugfs_create_dir("phy_down_cnt",
+ 						hisi_hba->debugfs_dir);
+-	char name[16];
++	char name[NAME_BUF_SIZE];
+ 	int phy_no;
+ 
+ 	for (phy_no = 0; phy_no < hisi_hba->n_phy; phy_no++) {
+-		snprintf(name, 16, "%d", phy_no);
++		snprintf(name, NAME_BUF_SIZE, "%d", phy_no);
+ 		debugfs_create_file(name, 0600, dir,
+ 				    &hisi_hba->phy[phy_no],
+ 				    &debugfs_phy_down_cnt_v3_hw_fops);
+@@ -5026,8 +5087,8 @@ hisi_sas_v3_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 	shost->transportt = hisi_sas_stt;
+ 	shost->max_id = HISI_SAS_MAX_DEVICES;
+ 	shost->max_lun = ~0;
+-	shost->max_channel = 1;
+-	shost->max_cmd_len = 16;
++	shost->max_channel = 0;
++	shost->max_cmd_len = HISI_SAS_MAX_CDB_LEN;
+ 	shost->can_queue = HISI_SAS_UNRESERVED_IPTT;
+ 	shost->cmd_per_lun = HISI_SAS_UNRESERVED_IPTT;
+ 	if (hisi_hba->iopoll_q_cnt)
+@@ -5108,12 +5169,13 @@ hisi_sas_v3_destroy_irqs(struct pci_dev *pdev, struct hisi_hba *hisi_hba)
+ {
+ 	int i;
+ 
+-	devm_free_irq(&pdev->dev, pci_irq_vector(pdev, 1), hisi_hba);
+-	devm_free_irq(&pdev->dev, pci_irq_vector(pdev, 2), hisi_hba);
+-	devm_free_irq(&pdev->dev, pci_irq_vector(pdev, 11), hisi_hba);
++	devm_free_irq(&pdev->dev, pci_irq_vector(pdev, IRQ_PHY_UP_DOWN_INDEX), hisi_hba);
++	devm_free_irq(&pdev->dev, pci_irq_vector(pdev, IRQ_CHL_INDEX), hisi_hba);
++	devm_free_irq(&pdev->dev, pci_irq_vector(pdev, IRQ_AXI_INDEX), hisi_hba);
+ 	for (i = 0; i < hisi_hba->cq_nvecs; i++) {
+ 		struct hisi_sas_cq *cq = &hisi_hba->cq[i];
+-		int nr = hisi_sas_intr_conv ? 16 : 16 + i;
++		int nr = hisi_sas_intr_conv ? BASE_VECTORS_V3_HW :
++					      BASE_VECTORS_V3_HW + i;
+ 
+ 		devm_free_irq(&pdev->dev, pci_irq_vector(pdev, nr), cq);
+ 	}
+diff --git a/drivers/scsi/lpfc/lpfc_init.c b/drivers/scsi/lpfc/lpfc_init.c
+index b0eac09de5ad50..dc18d84c54c3c4 100644
+--- a/drivers/scsi/lpfc/lpfc_init.c
++++ b/drivers/scsi/lpfc/lpfc_init.c
+@@ -12049,6 +12049,8 @@ lpfc_sli4_pci_mem_unset(struct lpfc_hba *phba)
+ 		iounmap(phba->sli4_hba.conf_regs_memmap_p);
+ 		if (phba->sli4_hba.dpp_regs_memmap_p)
+ 			iounmap(phba->sli4_hba.dpp_regs_memmap_p);
++		if (phba->sli4_hba.dpp_regs_memmap_wc_p)
++			iounmap(phba->sli4_hba.dpp_regs_memmap_wc_p);
+ 		break;
+ 	case LPFC_SLI_INTF_IF_TYPE_1:
+ 		break;
+diff --git a/drivers/scsi/lpfc/lpfc_sli.c b/drivers/scsi/lpfc/lpfc_sli.c
+index 4cf935b7223af2..c88e224feed8aa 100644
+--- a/drivers/scsi/lpfc/lpfc_sli.c
++++ b/drivers/scsi/lpfc/lpfc_sli.c
+@@ -15938,6 +15938,32 @@ lpfc_dual_chute_pci_bar_map(struct lpfc_hba *phba, uint16_t pci_barset)
+ 	return NULL;
+ }
+ 
++static __maybe_unused void __iomem *
++lpfc_dpp_wc_map(struct lpfc_hba *phba, uint8_t dpp_barset)
++{
++
++	/* DPP region is supposed to cover 64-bit BAR2 */
++	if (dpp_barset != WQ_PCI_BAR_4_AND_5) {
++		lpfc_log_msg(phba, KERN_WARNING, LOG_INIT,
++			     "3273 dpp_barset x%x != WQ_PCI_BAR_4_AND_5\n",
++			     dpp_barset);
++		return NULL;
++	}
++
++	if (!phba->sli4_hba.dpp_regs_memmap_wc_p) {
++		void __iomem *dpp_map;
++
++		dpp_map = ioremap_wc(phba->pci_bar2_map,
++				     pci_resource_len(phba->pcidev,
++						      PCI_64BIT_BAR4));
++
++		if (dpp_map)
++			phba->sli4_hba.dpp_regs_memmap_wc_p = dpp_map;
++	}
++
++	return phba->sli4_hba.dpp_regs_memmap_wc_p;
++}
++
+ /**
+  * lpfc_modify_hba_eq_delay - Modify Delay Multiplier on EQs
+  * @phba: HBA structure that EQs are on.
+@@ -16901,9 +16927,6 @@ lpfc_wq_create(struct lpfc_hba *phba, struct lpfc_queue *wq,
+ 	uint8_t dpp_barset;
+ 	uint32_t dpp_offset;
+ 	uint8_t wq_create_version;
+-#ifdef CONFIG_X86
+-	unsigned long pg_addr;
+-#endif
+ 
+ 	/* sanity check on queue memory */
+ 	if (!wq || !cq)
+@@ -17089,14 +17112,15 @@ lpfc_wq_create(struct lpfc_hba *phba, struct lpfc_queue *wq,
+ 
+ #ifdef CONFIG_X86
+ 			/* Enable combined writes for DPP aperture */
+-			pg_addr = (unsigned long)(wq->dpp_regaddr) & PAGE_MASK;
+-			rc = set_memory_wc(pg_addr, 1);
+-			if (rc) {
++			bar_memmap_p = lpfc_dpp_wc_map(phba, dpp_barset);
++			if (!bar_memmap_p) {
+ 				lpfc_printf_log(phba, KERN_ERR, LOG_INIT,
+ 					"3272 Cannot setup Combined "
+ 					"Write on WQ[%d] - disable DPP\n",
+ 					wq->queue_id);
+ 				phba->cfg_enable_dpp = 0;
++			} else {
++				wq->dpp_regaddr = bar_memmap_p + dpp_offset;
+ 			}
+ #else
+ 			phba->cfg_enable_dpp = 0;
+diff --git a/drivers/scsi/lpfc/lpfc_sli4.h b/drivers/scsi/lpfc/lpfc_sli4.h
+index 2541a8fba093fa..323d3ed3272b5c 100644
+--- a/drivers/scsi/lpfc/lpfc_sli4.h
++++ b/drivers/scsi/lpfc/lpfc_sli4.h
+@@ -783,6 +783,9 @@ struct lpfc_sli4_hba {
+ 	void __iomem *dpp_regs_memmap_p;  /* Kernel memory mapped address for
+ 					   * dpp registers
+ 					   */
++	void __iomem *dpp_regs_memmap_wc_p;/* Kernel memory mapped address for
++					    * dpp registers with write combining
++					    */
+ 	union {
+ 		struct {
+ 			/* IF Type 0, BAR 0 PCI cfg space reg mem map */
+diff --git a/drivers/scsi/mpi3mr/mpi3mr_fw.c b/drivers/scsi/mpi3mr/mpi3mr_fw.c
+index b6ae7ba6de5233..b742ece3f05076 100644
+--- a/drivers/scsi/mpi3mr/mpi3mr_fw.c
++++ b/drivers/scsi/mpi3mr/mpi3mr_fw.c
+@@ -4262,21 +4262,25 @@ void mpi3mr_memset_buffers(struct mpi3mr_ioc *mrioc)
+ 	}
+ 
+ 	for (i = 0; i < mrioc->num_queues; i++) {
+-		mrioc->op_reply_qinfo[i].qid = 0;
+-		mrioc->op_reply_qinfo[i].ci = 0;
+-		mrioc->op_reply_qinfo[i].num_replies = 0;
+-		mrioc->op_reply_qinfo[i].ephase = 0;
+-		atomic_set(&mrioc->op_reply_qinfo[i].pend_ios, 0);
+-		atomic_set(&mrioc->op_reply_qinfo[i].in_use, 0);
+-		mpi3mr_memset_op_reply_q_buffers(mrioc, i);
+-
+-		mrioc->req_qinfo[i].ci = 0;
+-		mrioc->req_qinfo[i].pi = 0;
+-		mrioc->req_qinfo[i].num_requests = 0;
+-		mrioc->req_qinfo[i].qid = 0;
+-		mrioc->req_qinfo[i].reply_qid = 0;
+-		spin_lock_init(&mrioc->req_qinfo[i].q_lock);
+-		mpi3mr_memset_op_req_q_buffers(mrioc, i);
++		if (mrioc->op_reply_qinfo) {
++			mrioc->op_reply_qinfo[i].qid = 0;
++			mrioc->op_reply_qinfo[i].ci = 0;
++			mrioc->op_reply_qinfo[i].num_replies = 0;
++			mrioc->op_reply_qinfo[i].ephase = 0;
++			atomic_set(&mrioc->op_reply_qinfo[i].pend_ios, 0);
++			atomic_set(&mrioc->op_reply_qinfo[i].in_use, 0);
++			mpi3mr_memset_op_reply_q_buffers(mrioc, i);
++		}
++
++		if (mrioc->req_qinfo) {
++			mrioc->req_qinfo[i].ci = 0;
++			mrioc->req_qinfo[i].pi = 0;
++			mrioc->req_qinfo[i].num_requests = 0;
++			mrioc->req_qinfo[i].qid = 0;
++			mrioc->req_qinfo[i].reply_qid = 0;
++			spin_lock_init(&mrioc->req_qinfo[i].q_lock);
++			mpi3mr_memset_op_req_q_buffers(mrioc, i);
++		}
+ 	}
+ 
+ 	atomic_set(&mrioc->pend_large_data_sz, 0);
+diff --git a/drivers/scsi/pm8001/pm8001_sas.c b/drivers/scsi/pm8001/pm8001_sas.c
+index 4daab8b6d67527..0f911228cb2f13 100644
+--- a/drivers/scsi/pm8001/pm8001_sas.c
++++ b/drivers/scsi/pm8001/pm8001_sas.c
+@@ -476,8 +476,9 @@ int pm8001_queue_command(struct sas_task *task, gfp_t gfp_flags)
+ 		} else {
+ 			task->task_done(task);
+ 		}
+-		rc = -ENODEV;
+-		goto err_out;
++		spin_unlock_irqrestore(&pm8001_ha->lock, flags);
++		pm8001_dbg(pm8001_ha, IO, "pm8001_task_exec device gone\n");
++		return 0;
+ 	}
+ 
+ 	ccb = pm8001_ccb_alloc(pm8001_ha, pm8001_dev, task);
+diff --git a/drivers/scsi/scsi_scan.c b/drivers/scsi/scsi_scan.c
+index 8ee74dddef16e0..083bf3386c6b3b 100644
+--- a/drivers/scsi/scsi_scan.c
++++ b/drivers/scsi/scsi_scan.c
+@@ -353,11 +353,8 @@ static struct scsi_device *scsi_alloc_sdev(struct scsi_target *starget,
+ 	 * default device queue depth to figure out sbitmap shift
+ 	 * since we use this queue depth most of times.
+ 	 */
+-	if (scsi_realloc_sdev_budget_map(sdev, depth)) {
+-		put_device(&starget->dev);
+-		kfree(sdev);
+-		goto out;
+-	}
++	if (scsi_realloc_sdev_budget_map(sdev, depth))
++		goto out_device_destroy;
+ 
+ 	scsi_change_queue_depth(sdev, depth);
+ 
+diff --git a/drivers/scsi/ses.c b/drivers/scsi/ses.c
+index d7d0c35c58b80e..05e462f328e75f 100644
+--- a/drivers/scsi/ses.c
++++ b/drivers/scsi/ses.c
+@@ -503,9 +503,8 @@ struct efd {
+ };
+ 
+ static int ses_enclosure_find_by_addr(struct enclosure_device *edev,
+-				      void *data)
++				      struct efd *efd)
+ {
+-	struct efd *efd = data;
+ 	int i;
+ 	struct ses_component *scomp;
+ 
+@@ -658,7 +657,7 @@ static void ses_match_to_enclosure(struct enclosure_device *edev,
+ 	if (efd.addr) {
+ 		efd.dev = &sdev->sdev_gendev;
+ 
+-		enclosure_for_each_device(ses_enclosure_find_by_addr, &efd);
++		ses_enclosure_find_by_addr(edev, &efd);
+ 	}
+ }
+ 
+diff --git a/drivers/scsi/storvsc_drv.c b/drivers/scsi/storvsc_drv.c
+index 9dcad02ce4895b..106bccaac4276e 100644
+--- a/drivers/scsi/storvsc_drv.c
++++ b/drivers/scsi/storvsc_drv.c
+@@ -1861,8 +1861,9 @@ static int storvsc_queuecommand(struct Scsi_Host *host, struct scsi_cmnd *scmnd)
+ 	cmd_request->payload_sz = payload_sz;
+ 
+ 	/* Invokes the vsc to start an IO */
+-	ret = storvsc_do_io(dev, cmd_request, get_cpu());
+-	put_cpu();
++	migrate_disable();
++	ret = storvsc_do_io(dev, cmd_request, smp_processor_id());
++	migrate_enable();
+ 
+ 	if (ret)
+ 		scsi_dma_unmap(scmnd);
+diff --git a/drivers/soc/fsl/qbman/qman.c b/drivers/soc/fsl/qbman/qman.c
+index 7e9074519ad22d..bcbf6bf2e8f456 100644
+--- a/drivers/soc/fsl/qbman/qman.c
++++ b/drivers/soc/fsl/qbman/qman.c
+@@ -1827,6 +1827,8 @@ EXPORT_SYMBOL(qman_create_fq);
+ 
+ void qman_destroy_fq(struct qman_fq *fq)
+ {
++	int leaked;
++
+ 	/*
+ 	 * We don't need to lock the FQ as it is a pre-condition that the FQ be
+ 	 * quiesced. Instead, run some checks.
+@@ -1834,11 +1836,29 @@ void qman_destroy_fq(struct qman_fq *fq)
+ 	switch (fq->state) {
+ 	case qman_fq_state_parked:
+ 	case qman_fq_state_oos:
+-		if (fq_isset(fq, QMAN_FQ_FLAG_DYNAMIC_FQID))
+-			qman_release_fqid(fq->fqid);
++		/*
++		 * There's a race condition here on releasing the fqid,
++		 * setting the fq_table to NULL, and freeing the fqid.
++		 * To prevent it, this order should be respected:
++		 */
++		if (fq_isset(fq, QMAN_FQ_FLAG_DYNAMIC_FQID)) {
++			leaked = qman_shutdown_fq(fq->fqid);
++			if (leaked)
++				pr_debug("FQID %d leaked\n", fq->fqid);
++		}
+ 
+ 		DPAA_ASSERT(fq_table[fq->idx]);
+ 		fq_table[fq->idx] = NULL;
++
++		if (fq_isset(fq, QMAN_FQ_FLAG_DYNAMIC_FQID) && !leaked) {
++			/*
++			 * fq_table[fq->idx] should be set to null before
++			 * freeing fq->fqid otherwise it could by allocated by
++			 * qman_alloc_fqid() while still being !NULL
++			 */
++			smp_wmb();
++			gen_pool_free(qm_fqalloc, fq->fqid | DPAA_GENALLOC_OFF, 1);
++		}
+ 		return;
+ 	default:
+ 		break;
+diff --git a/drivers/soc/qcom/pmic_glink.c b/drivers/soc/qcom/pmic_glink.c
+index 2222ca4fa6e214..ae8bf1f4116a87 100644
+--- a/drivers/soc/qcom/pmic_glink.c
++++ b/drivers/soc/qcom/pmic_glink.c
+@@ -115,8 +115,16 @@ EXPORT_SYMBOL_GPL(pmic_glink_client_register);
+ int pmic_glink_send(struct pmic_glink_client *client, void *data, size_t len)
+ {
+ 	struct pmic_glink *pg = client->pg;
++	int ret;
++
++	mutex_lock(&pg->state_lock);
++	if (!pg->ept)
++		ret = -ECONNRESET;
++	else
++		ret = rpmsg_send(pg->ept, data, len);
++	mutex_unlock(&pg->state_lock);
+ 
+-	return rpmsg_send(pg->ept, data, len);
++	return ret;
+ }
+ EXPORT_SYMBOL_GPL(pmic_glink_send);
+ 
+diff --git a/drivers/spi/spi.c b/drivers/spi/spi.c
+index 5adba36255a1aa..91da4cae011c83 100644
+--- a/drivers/spi/spi.c
++++ b/drivers/spi/spi.c
+@@ -2777,6 +2777,8 @@ static void spi_controller_release(struct device *dev)
+ 	struct spi_controller *ctlr;
+ 
+ 	ctlr = container_of(dev, struct spi_controller, dev);
++
++	free_percpu(ctlr->pcpu_statistics);
+ 	kfree(ctlr);
+ }
+ 
+@@ -2928,6 +2930,12 @@ struct spi_controller *__spi_alloc_controller(struct device *dev,
+ 	if (!ctlr)
+ 		return NULL;
+ 
++	ctlr->pcpu_statistics = spi_alloc_pcpu_stats(NULL);
++	if (!ctlr->pcpu_statistics) {
++		kfree(ctlr);
++		return NULL;
++	}
++
+ 	device_initialize(&ctlr->dev);
+ 	INIT_LIST_HEAD(&ctlr->queue);
+ 	spin_lock_init(&ctlr->queue_lock);
+@@ -3213,17 +3221,8 @@ int spi_register_controller(struct spi_controller *ctlr)
+ 		dev_info(dev, "controller is unqueued, this is deprecated\n");
+ 	} else if (ctlr->transfer_one || ctlr->transfer_one_message) {
+ 		status = spi_controller_initialize_queue(ctlr);
+-		if (status) {
+-			device_del(&ctlr->dev);
+-			goto free_bus_id;
+-		}
+-	}
+-	/* Add statistics */
+-	ctlr->pcpu_statistics = spi_alloc_pcpu_stats(dev);
+-	if (!ctlr->pcpu_statistics) {
+-		dev_err(dev, "Error allocating per-cpu statistics\n");
+-		status = -ENOMEM;
+-		goto destroy_queue;
++		if (status)
++			goto del_ctrl;
+ 	}
+ 
+ 	mutex_lock(&board_lock);
+@@ -3237,8 +3236,8 @@ int spi_register_controller(struct spi_controller *ctlr)
+ 	acpi_register_spi_devices(ctlr);
+ 	return status;
+ 
+-destroy_queue:
+-	spi_destroy_queue(ctlr);
++del_ctrl:
++	device_del(&ctlr->dev);
+ free_bus_id:
+ 	mutex_lock(&board_lock);
+ 	idr_remove(&spi_master_idr, ctlr->bus_num);
+diff --git a/drivers/staging/media/tegra-video/vi.c b/drivers/staging/media/tegra-video/vi.c
+index 94171e62dee9e4..e8ba23e5bcde0f 100644
+--- a/drivers/staging/media/tegra-video/vi.c
++++ b/drivers/staging/media/tegra-video/vi.c
+@@ -439,7 +439,8 @@ static int __tegra_channel_try_format(struct tegra_vi_channel *chan,
+ 		.which = V4L2_SUBDEV_FORMAT_ACTIVE,
+ 		.target = V4L2_SEL_TGT_CROP_BOUNDS,
+ 	};
+-	int ret;
++	struct v4l2_rect *try_crop;
++	int ret = 0;
+ 
+ 	subdev = tegra_channel_get_remote_source_subdev(chan);
+ 	if (!subdev)
+@@ -473,36 +474,40 @@ static int __tegra_channel_try_format(struct tegra_vi_channel *chan,
+ 	 * Attempt to obtain the format size from subdev.
+ 	 * If not available, try to get crop boundary from subdev.
+ 	 */
++	try_crop = v4l2_subdev_get_pad_crop(subdev, sd_state, 0);
+ 	fse.code = fmtinfo->code;
+ 	ret = v4l2_subdev_call(subdev, pad, enum_frame_size, sd_state, &fse);
+ 	if (ret) {
+ 		if (!v4l2_subdev_has_op(subdev, pad, get_selection)) {
+-			sd_state->pads->try_crop.width = 0;
+-			sd_state->pads->try_crop.height = 0;
++			try_crop->width = 0;
++			try_crop->height = 0;
+ 		} else {
+ 			ret = v4l2_subdev_call(subdev, pad, get_selection,
+ 					       NULL, &sdsel);
+-			if (ret)
+-				return -EINVAL;
++			if (ret) {
++				ret = -EINVAL;
++				goto out_free;
++			}
+ 
+-			sd_state->pads->try_crop.width = sdsel.r.width;
+-			sd_state->pads->try_crop.height = sdsel.r.height;
++			try_crop->width = sdsel.r.width;
++			try_crop->height = sdsel.r.height;
+ 		}
+ 	} else {
+-		sd_state->pads->try_crop.width = fse.max_width;
+-		sd_state->pads->try_crop.height = fse.max_height;
++		try_crop->width = fse.max_width;
++		try_crop->height = fse.max_height;
+ 	}
+ 
+ 	ret = v4l2_subdev_call(subdev, pad, set_fmt, sd_state, &fmt);
+ 	if (ret < 0)
+-		return ret;
++		goto out_free;
+ 
+ 	v4l2_fill_pix_format(pix, &fmt.format);
+ 	chan->vi->ops->vi_fmt_align(pix, fmtinfo->bpp);
+ 
++out_free:
+ 	__v4l2_subdev_state_free(sd_state);
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ static int tegra_channel_try_format(struct file *file, void *fh,
+diff --git a/drivers/staging/rtl8723bs/core/rtw_ieee80211.c b/drivers/staging/rtl8723bs/core/rtw_ieee80211.c
+index 54849235a149ab..7cd44e8c69668e 100644
+--- a/drivers/staging/rtl8723bs/core/rtw_ieee80211.c
++++ b/drivers/staging/rtl8723bs/core/rtw_ieee80211.c
+@@ -186,20 +186,25 @@ u8 *rtw_get_ie_ex(u8 *in_ie, uint in_len, u8 eid, u8 *oui, u8 oui_len, u8 *ie, u
+ 
+ 	cnt = 0;
+ 
+-	while (cnt < in_len) {
++	while (cnt + 2 <= in_len) {
++		u8 ie_len = in_ie[cnt + 1];
++
++		if (cnt + 2 + ie_len > in_len)
++			break;
++
+ 		if (eid == in_ie[cnt]
+-			&& (!oui || !memcmp(&in_ie[cnt+2], oui, oui_len))) {
++			&& (!oui || (ie_len >= oui_len && !memcmp(&in_ie[cnt + 2], oui, oui_len)))) {
+ 			target_ie = &in_ie[cnt];
+ 
+ 			if (ie)
+-				memcpy(ie, &in_ie[cnt], in_ie[cnt+1]+2);
++				memcpy(ie, &in_ie[cnt], ie_len + 2);
+ 
+ 			if (ielen)
+-				*ielen = in_ie[cnt+1]+2;
++				*ielen = ie_len + 2;
+ 
+ 			break;
+ 		}
+-		cnt += in_ie[cnt+1]+2; /* goto next */
++		cnt += ie_len + 2; /* goto next */
+ 	}
+ 
+ 	return target_ie;
+diff --git a/drivers/staging/rtl8723bs/core/rtw_mlme.c b/drivers/staging/rtl8723bs/core/rtw_mlme.c
+index 19b877f50fb627..1d44f6a3db1832 100644
+--- a/drivers/staging/rtl8723bs/core/rtw_mlme.c
++++ b/drivers/staging/rtl8723bs/core/rtw_mlme.c
+@@ -2000,7 +2000,10 @@ int rtw_restruct_wmm_ie(struct adapter *adapter, u8 *in_ie, u8 *out_ie, uint in_
+ 	while (i < in_len) {
+ 		ielength = initial_out_len;
+ 
+-		if (in_ie[i] == 0xDD && in_ie[i+2] == 0x00 && in_ie[i+3] == 0x50  && in_ie[i+4] == 0xF2 && in_ie[i+5] == 0x02 && i+5 < in_len) { /* WMM element ID and OUI */
++		if (i + 5 < in_len &&
++		    in_ie[i] == 0xDD && in_ie[i + 2] == 0x00 &&
++		    in_ie[i + 3] == 0x50 && in_ie[i + 4] == 0xF2 &&
++		    in_ie[i + 5] == 0x02) {
+ 			for (j = i; j < i + 9; j++) {
+ 				out_ie[ielength] = in_ie[j];
+ 				ielength++;
+diff --git a/drivers/target/target_core_configfs.c b/drivers/target/target_core_configfs.c
+index 6ec98dfd1f31ce..a52a4ac735e10a 100644
+--- a/drivers/target/target_core_configfs.c
++++ b/drivers/target/target_core_configfs.c
+@@ -108,8 +108,8 @@ static ssize_t target_core_item_dbroot_store(struct config_item *item,
+ 					const char *page, size_t count)
+ {
+ 	ssize_t read_bytes;
+-	struct file *fp;
+ 	ssize_t r = -EINVAL;
++	struct path path = {};
+ 
+ 	mutex_lock(&target_devices_lock);
+ 	if (target_devices) {
+@@ -131,17 +131,14 @@ static ssize_t target_core_item_dbroot_store(struct config_item *item,
+ 		db_root_stage[read_bytes - 1] = '\0';
+ 
+ 	/* validate new db root before accepting it */
+-	fp = filp_open(db_root_stage, O_RDONLY, 0);
+-	if (IS_ERR(fp)) {
++	r = kern_path(db_root_stage, LOOKUP_FOLLOW | LOOKUP_DIRECTORY, &path);
++	if (r) {
+ 		pr_err("db_root: cannot open: %s\n", db_root_stage);
++		if (r == -ENOTDIR)
++			pr_err("db_root: not a directory: %s\n", db_root_stage);
+ 		goto unlock;
+ 	}
+-	if (!S_ISDIR(file_inode(fp)->i_mode)) {
+-		filp_close(fp, NULL);
+-		pr_err("db_root: not a directory: %s\n", db_root_stage);
+-		goto unlock;
+-	}
+-	filp_close(fp, NULL);
++	path_put(&path);
+ 
+ 	strncpy(db_root, db_root_stage, read_bytes);
+ 	pr_debug("Target_Core_ConfigFS: db_root set to %s\n", db_root);
+diff --git a/drivers/tty/serial/8250/8250_dma.c b/drivers/tty/serial/8250/8250_dma.c
+index 62492cf10bc9d4..745a7399c9597b 100644
+--- a/drivers/tty/serial/8250/8250_dma.c
++++ b/drivers/tty/serial/8250/8250_dma.c
+@@ -152,7 +152,22 @@ void serial8250_tx_dma_flush(struct uart_8250_port *p)
+ 	 */
+ 	dma->tx_size = 0;
+ 
++	/*
++	 * We can't use `dmaengine_terminate_sync` because `uart_flush_buffer` is
++	 * holding the uart port spinlock.
++	 */
+ 	dmaengine_terminate_async(dma->txchan);
++
++	/*
++	 * The callback might or might not run. If it doesn't run, we need to ensure
++	 * that `tx_running` is cleared so that we can schedule new transactions.
++	 * If it does run, then the zombie callback will clear `tx_running` again
++	 * and perform a no-op since `tx_size` was cleared above.
++	 *
++	 * In either case, we ASSUME the DMA transaction will terminate before we
++	 * issue a new `serial8250_tx_dma`.
++	 */
++	dma->tx_running = 0;
+ }
+ 
+ int serial8250_rx_dma(struct uart_8250_port *p)
+diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
+index 623fd4aa849922..657b857951b5f3 100644
+--- a/drivers/tty/serial/8250/8250_pci.c
++++ b/drivers/tty/serial/8250/8250_pci.c
+@@ -59,6 +59,8 @@ struct serial_private {
+ };
+ 
+ #define PCI_DEVICE_ID_HPE_PCI_SERIAL	0x37e
++#define PCIE_VENDOR_ID_ASIX		0x125B
++#define PCIE_DEVICE_ID_AX99100		0x9100
+ 
+ static const struct pci_device_id pci_use_msi[] = {
+ 	{ PCI_DEVICE_SUB(PCI_VENDOR_ID_NETMOS, PCI_DEVICE_ID_NETMOS_9900,
+@@ -71,6 +73,8 @@ static const struct pci_device_id pci_use_msi[] = {
+ 			 0xA000, 0x1000) },
+ 	{ PCI_DEVICE_SUB(PCI_VENDOR_ID_HP_3PAR, PCI_DEVICE_ID_HPE_PCI_SERIAL,
+ 			 PCI_ANY_ID, PCI_ANY_ID) },
++	{ PCI_DEVICE_SUB(PCIE_VENDOR_ID_ASIX, PCIE_DEVICE_ID_AX99100,
++			 0xA000, 0x1000) },
+ 	{ }
+ };
+ 
+@@ -834,6 +838,7 @@ static int pci_netmos_init(struct pci_dev *dev)
+ 	case PCI_DEVICE_ID_NETMOS_9912:
+ 	case PCI_DEVICE_ID_NETMOS_9922:
+ 	case PCI_DEVICE_ID_NETMOS_9900:
++	case PCIE_DEVICE_ID_AX99100:
+ 		num_serial = pci_netmos_9900_numports(dev);
+ 		break;
+ 
+@@ -2396,6 +2401,14 @@ static struct pci_serial_quirk pci_serial_quirks[] = {
+ 		.init		= pci_netmos_init,
+ 		.setup		= pci_netmos_9900_setup,
+ 	},
++	{
++		.vendor		= PCIE_VENDOR_ID_ASIX,
++		.device		= PCI_ANY_ID,
++		.subvendor	= PCI_ANY_ID,
++		.subdevice	= PCI_ANY_ID,
++		.init		= pci_netmos_init,
++		.setup		= pci_netmos_9900_setup,
++	},
+ 	/*
+ 	 * EndRun Technologies
+ 	*/
+@@ -5940,6 +5953,10 @@ static const struct pci_device_id serial_pci_tbl[] = {
+ 		0xA000, 0x3002,
+ 		0, 0, pbn_NETMOS9900_2s_115200 },
+ 
++	{	PCIE_VENDOR_ID_ASIX, PCIE_DEVICE_ID_AX99100,
++		0xA000, 0x1000,
++		0, 0, pbn_b0_1_115200 },
++
+ 	/*
+ 	 * Best Connectivity and Rosewill PCI Multi I/O cards
+ 	 */
+diff --git a/drivers/tty/serial/8250/8250_port.c b/drivers/tty/serial/8250/8250_port.c
+index 23aed9e89e3047..c246503c9f80b1 100644
+--- a/drivers/tty/serial/8250/8250_port.c
++++ b/drivers/tty/serial/8250/8250_port.c
+@@ -2533,6 +2533,12 @@ void serial8250_do_shutdown(struct uart_port *port)
+ 	 * the IRQ chain.
+ 	 */
+ 	serial_port_in(port, UART_RX);
++	/*
++	 * LCR writes on DW UART can trigger late (unmaskable) IRQs.
++	 * Handle them before releasing the handler.
++	 */
++	synchronize_irq(port->irq);
++
+ 	serial8250_rpm_put(up);
+ 
+ 	up->ops->release_irq(up);
+diff --git a/drivers/tty/serial/uartlite.c b/drivers/tty/serial/uartlite.c
+index 9f39bafa7fa968..c5a85db7a8f133 100644
+--- a/drivers/tty/serial/uartlite.c
++++ b/drivers/tty/serial/uartlite.c
+@@ -870,6 +870,7 @@ of_err:
+ 	pm_runtime_use_autosuspend(&pdev->dev);
+ 	pm_runtime_set_autosuspend_delay(&pdev->dev, UART_AUTOSUSPEND_TIMEOUT);
+ 	pm_runtime_set_active(&pdev->dev);
++	pm_runtime_get_noresume(&pdev->dev);
+ 	pm_runtime_enable(&pdev->dev);
+ 
+ 	ret = ulite_assign(&pdev->dev, id, res->start, irq, pdata);
+diff --git a/drivers/ufs/core/ufshcd.c b/drivers/ufs/core/ufshcd.c
+index 808b648e1f3885..2dcb0146c17e3f 100644
+--- a/drivers/ufs/core/ufshcd.c
++++ b/drivers/ufs/core/ufshcd.c
+@@ -461,8 +461,8 @@ static void ufshcd_add_command_trace(struct ufs_hba *hba, unsigned int tag,
+ 
+ 	if (is_mcq_enabled(hba)) {
+ 		struct ufs_hw_queue *hwq = ufshcd_mcq_req_to_hwq(hba, rq);
+-
+-		hwq_id = hwq->id;
++		if (hwq)
++			hwq_id = hwq->id;
+ 	} else {
+ 		doorbell = ufshcd_readl(hba, REG_UTP_TRANSFER_REQ_DOOR_BELL);
+ 	}
+@@ -4289,14 +4289,6 @@ out_unlock:
+ 	spin_unlock_irqrestore(hba->host->host_lock, flags);
+ 	mutex_unlock(&hba->uic_cmd_mutex);
+ 
+-	/*
+-	 * If the h8 exit fails during the runtime resume process, it becomes
+-	 * stuck and cannot be recovered through the error handler.  To fix
+-	 * this, use link recovery instead of the error handler.
+-	 */
+-	if (ret && hba->pm_op_in_progress)
+-		ret = ufshcd_link_recovery(hba);
+-
+ 	return ret;
+ }
+ 
+@@ -6968,7 +6960,7 @@ static irqreturn_t ufshcd_handle_mcq_cq_events(struct ufs_hba *hba)
+ 
+ 	ret = ufshcd_vops_get_outstanding_cqs(hba, &outstanding_cqs);
+ 	if (ret)
+-		outstanding_cqs = (1U << hba->nr_hw_queues) - 1;
++		outstanding_cqs = (1ULL << hba->nr_hw_queues) - 1;
+ 
+ 	/* Exclude the poll queues */
+ 	nr_queues = hba->nr_hw_queues - hba->nr_queues[HCTX_TYPE_POLL];
+@@ -9890,6 +9882,7 @@ static int __ufshcd_wl_suspend(struct ufs_hba *hba, enum ufs_pm_op pm_op)
+ 	}
+ 
+ 	flush_work(&hba->eeh_work);
++	cancel_delayed_work_sync(&hba->ufs_rtc_update_work);
+ 
+ 	ret = ufshcd_vops_suspend(hba, pm_op, PRE_CHANGE);
+ 	if (ret)
+@@ -9944,7 +9937,6 @@ vops_suspend:
+ 	if (ret)
+ 		goto set_link_active;
+ 
+-	cancel_delayed_work_sync(&hba->ufs_rtc_update_work);
+ 	goto out;
+ 
+ set_link_active:
+@@ -10016,7 +10008,15 @@ static int __ufshcd_wl_resume(struct ufs_hba *hba, enum ufs_pm_op pm_op)
+ 		} else {
+ 			dev_err(hba->dev, "%s: hibern8 exit failed %d\n",
+ 					__func__, ret);
+-			goto vendor_suspend;
++			/*
++			 * If the h8 exit fails during the runtime resume
++			 * process, it becomes stuck and cannot be recovered
++			 * through the error handler. To fix this, use link
++			 * recovery instead of the error handler.
++			 */
++			ret = ufshcd_link_recovery(hba);
++			if (ret)
++				goto vendor_suspend;
+ 		}
+ 	} else if (ufshcd_is_link_off(hba)) {
+ 		/*
+diff --git a/drivers/usb/cdns3/core.c b/drivers/usb/cdns3/core.c
+index 465e9267b49c12..f0e32227c0b791 100644
+--- a/drivers/usb/cdns3/core.c
++++ b/drivers/usb/cdns3/core.c
+@@ -524,14 +524,13 @@ EXPORT_SYMBOL_GPL(cdns_suspend);
+ 
+ int cdns_resume(struct cdns *cdns)
+ {
++	bool power_lost = cdns_power_is_lost(cdns);
+ 	enum usb_role real_role;
+ 	bool role_changed = false;
+ 	int ret = 0;
+ 
+-	if (cdns_power_is_lost(cdns)) {
+-		if (cdns->role_sw) {
+-			cdns->role = cdns_role_get(cdns->role_sw);
+-		} else {
++	if (power_lost) {
++		if (!cdns->role_sw) {
+ 			real_role = cdns_hw_role_state_machine(cdns);
+ 			if (real_role != cdns->role) {
+ 				ret = cdns_hw_role_switch(cdns);
+@@ -552,8 +551,8 @@ int cdns_resume(struct cdns *cdns)
+ 		}
+ 	}
+ 
+-	if (cdns->roles[cdns->role]->resume)
+-		cdns->roles[cdns->role]->resume(cdns, cdns_power_is_lost(cdns));
++	if (!role_changed && cdns->roles[cdns->role]->resume)
++		cdns->roles[cdns->role]->resume(cdns, power_lost);
+ 
+ 	return 0;
+ }
+diff --git a/drivers/usb/class/cdc-acm.c b/drivers/usb/class/cdc-acm.c
+index c0c4a9415a760f..e005c506dd0a1b 100644
+--- a/drivers/usb/class/cdc-acm.c
++++ b/drivers/usb/class/cdc-acm.c
+@@ -1379,6 +1379,8 @@ made_compressed_probe:
+ 		acm->ctrl_caps = h.usb_cdc_acm_descriptor->bmCapabilities;
+ 	if (quirks & NO_CAP_LINE)
+ 		acm->ctrl_caps &= ~USB_CDC_CAP_LINE;
++	if (quirks & MISSING_CAP_BRK)
++		acm->ctrl_caps |= USB_CDC_CAP_BRK;
+ 	acm->ctrlsize = ctrlsize;
+ 	acm->readsize = readsize;
+ 	acm->rx_buflimit = num_rx_buf;
+@@ -2002,6 +2004,9 @@ static const struct usb_device_id acm_ids[] = {
+ 	.driver_info = IGNORE_DEVICE,
+ 	},
+ 
++	/* CH343 supports CAP_BRK, but doesn't advertise it */
++	{ USB_DEVICE(0x1a86, 0x55d3), .driver_info = MISSING_CAP_BRK, },
++
+ 	/* control interfaces without any protocol set */
+ 	{ USB_INTERFACE_INFO(USB_CLASS_COMM, USB_CDC_SUBCLASS_ACM,
+ 		USB_CDC_PROTO_NONE) },
+diff --git a/drivers/usb/class/cdc-acm.h b/drivers/usb/class/cdc-acm.h
+index 759ac15631d3e5..76f73853a60b63 100644
+--- a/drivers/usb/class/cdc-acm.h
++++ b/drivers/usb/class/cdc-acm.h
+@@ -113,3 +113,4 @@ struct acm {
+ #define CLEAR_HALT_CONDITIONS		BIT(5)
+ #define SEND_ZERO_PACKET		BIT(6)
+ #define DISABLE_ECHO			BIT(7)
++#define MISSING_CAP_BRK			BIT(8)
+diff --git a/drivers/usb/class/cdc-wdm.c b/drivers/usb/class/cdc-wdm.c
+index 600ad9412c146b..c932e247bba0b5 100644
+--- a/drivers/usb/class/cdc-wdm.c
++++ b/drivers/usb/class/cdc-wdm.c
+@@ -225,7 +225,8 @@ static void wdm_in_callback(struct urb *urb)
+ 		/* we may already be in overflow */
+ 		if (!test_bit(WDM_OVERFLOW, &desc->flags)) {
+ 			memmove(desc->ubuf + desc->length, desc->inbuf, length);
+-			desc->length += length;
++			smp_wmb(); /* against wdm_read() */
++			WRITE_ONCE(desc->length, desc->length + length);
+ 		}
+ 	}
+ skip_error:
+@@ -533,6 +534,7 @@ static ssize_t wdm_read
+ 		return -ERESTARTSYS;
+ 
+ 	cntr = READ_ONCE(desc->length);
++	smp_rmb(); /* against wdm_in_callback() */
+ 	if (cntr == 0) {
+ 		desc->read = 0;
+ retry:
+diff --git a/drivers/usb/class/usbtmc.c b/drivers/usb/class/usbtmc.c
+index ee45f3c74aecb5..8cf341a2483471 100644
+--- a/drivers/usb/class/usbtmc.c
++++ b/drivers/usb/class/usbtmc.c
+@@ -727,7 +727,7 @@ static int usbtmc488_ioctl_trigger(struct usbtmc_file_data *file_data)
+ 	buffer[1] = data->bTag;
+ 	buffer[2] = ~data->bTag;
+ 
+-	retval = usb_bulk_msg(data->usb_dev,
++	retval = usb_bulk_msg_killable(data->usb_dev,
+ 			      usb_sndbulkpipe(data->usb_dev,
+ 					      data->bulk_out),
+ 			      buffer, USBTMC_HEADER_SIZE,
+@@ -1347,7 +1347,7 @@ static int send_request_dev_dep_msg_in(struct usbtmc_file_data *file_data,
+ 	buffer[11] = 0; /* Reserved */
+ 
+ 	/* Send bulk URB */
+-	retval = usb_bulk_msg(data->usb_dev,
++	retval = usb_bulk_msg_killable(data->usb_dev,
+ 			      usb_sndbulkpipe(data->usb_dev,
+ 					      data->bulk_out),
+ 			      buffer, USBTMC_HEADER_SIZE,
+@@ -1419,7 +1419,7 @@ static ssize_t usbtmc_read(struct file *filp, char __user *buf,
+ 	actual = 0;
+ 
+ 	/* Send bulk URB */
+-	retval = usb_bulk_msg(data->usb_dev,
++	retval = usb_bulk_msg_killable(data->usb_dev,
+ 			      usb_rcvbulkpipe(data->usb_dev,
+ 					      data->bulk_in),
+ 			      buffer, bufsize, &actual,
+diff --git a/drivers/usb/core/message.c b/drivers/usb/core/message.c
+index 5a5dfbf995e3a0..119d07c4c62b51 100644
+--- a/drivers/usb/core/message.c
++++ b/drivers/usb/core/message.c
+@@ -42,16 +42,19 @@ static void usb_api_blocking_completion(struct urb *urb)
+ 
+ 
+ /*
+- * Starts urb and waits for completion or timeout. Note that this call
+- * is NOT interruptible. Many device driver i/o requests should be
+- * interruptible and therefore these drivers should implement their
+- * own interruptible routines.
++ * Starts urb and waits for completion or timeout.
++ * Whether or not the wait is killable depends on the flag passed in.
++ * For example, compare usb_bulk_msg() and usb_bulk_msg_killable().
++ *
++ * For non-killable waits, we enforce a maximum limit on the timeout value.
+  */
+-static int usb_start_wait_urb(struct urb *urb, int timeout, int *actual_length)
++static int usb_start_wait_urb(struct urb *urb, int timeout, int *actual_length,
++		bool killable)
+ {
+ 	struct api_context ctx;
+ 	unsigned long expire;
+ 	int retval;
++	long rc;
+ 
+ 	init_completion(&ctx.done);
+ 	urb->context = &ctx;
+@@ -60,13 +63,24 @@ static int usb_start_wait_urb(struct urb *urb, int timeout, int *actual_length)
+ 	if (unlikely(retval))
+ 		goto out;
+ 
+-	expire = timeout ? msecs_to_jiffies(timeout) : MAX_SCHEDULE_TIMEOUT;
+-	if (!wait_for_completion_timeout(&ctx.done, expire)) {
++	if (!killable && (timeout <= 0 || timeout > USB_MAX_SYNCHRONOUS_TIMEOUT))
++		timeout = USB_MAX_SYNCHRONOUS_TIMEOUT;
++	expire = (timeout > 0) ? msecs_to_jiffies(timeout) : MAX_SCHEDULE_TIMEOUT;
++	if (killable)
++		rc = wait_for_completion_killable_timeout(&ctx.done, expire);
++	else
++		rc = wait_for_completion_timeout(&ctx.done, expire);
++	if (rc <= 0) {
+ 		usb_kill_urb(urb);
+-		retval = (ctx.status == -ENOENT ? -ETIMEDOUT : ctx.status);
++		if (ctx.status != -ENOENT)
++			retval = ctx.status;
++		else if (rc == 0)
++			retval = -ETIMEDOUT;
++		else
++			retval = rc;
+ 
+ 		dev_dbg(&urb->dev->dev,
+-			"%s timed out on ep%d%s len=%u/%u\n",
++			"%s timed out or killed on ep%d%s len=%u/%u\n",
+ 			current->comm,
+ 			usb_endpoint_num(&urb->ep->desc),
+ 			usb_urb_dir_in(urb) ? "in" : "out",
+@@ -100,7 +114,7 @@ static int usb_internal_control_msg(struct usb_device *usb_dev,
+ 	usb_fill_control_urb(urb, usb_dev, pipe, (unsigned char *)cmd, data,
+ 			     len, usb_api_blocking_completion, NULL);
+ 
+-	retv = usb_start_wait_urb(urb, timeout, &length);
++	retv = usb_start_wait_urb(urb, timeout, &length, false);
+ 	if (retv < 0)
+ 		return retv;
+ 	else
+@@ -117,8 +131,7 @@ static int usb_internal_control_msg(struct usb_device *usb_dev,
+  * @index: USB message index value
+  * @data: pointer to the data to send
+  * @size: length in bytes of the data to send
+- * @timeout: time in msecs to wait for the message to complete before timing
+- *	out (if 0 the wait is forever)
++ * @timeout: time in msecs to wait for the message to complete before timing out
+  *
+  * Context: task context, might sleep.
+  *
+@@ -173,8 +186,7 @@ EXPORT_SYMBOL_GPL(usb_control_msg);
+  * @index: USB message index value
+  * @driver_data: pointer to the data to send
+  * @size: length in bytes of the data to send
+- * @timeout: time in msecs to wait for the message to complete before timing
+- *	out (if 0 the wait is forever)
++ * @timeout: time in msecs to wait for the message to complete before timing out
+  * @memflags: the flags for memory allocation for buffers
+  *
+  * Context: !in_interrupt ()
+@@ -232,8 +244,7 @@ EXPORT_SYMBOL_GPL(usb_control_msg_send);
+  * @index: USB message index value
+  * @driver_data: pointer to the data to be filled in by the message
+  * @size: length in bytes of the data to be received
+- * @timeout: time in msecs to wait for the message to complete before timing
+- *	out (if 0 the wait is forever)
++ * @timeout: time in msecs to wait for the message to complete before timing out
+  * @memflags: the flags for memory allocation for buffers
+  *
+  * Context: !in_interrupt ()
+@@ -304,8 +315,7 @@ EXPORT_SYMBOL_GPL(usb_control_msg_recv);
+  * @len: length in bytes of the data to send
+  * @actual_length: pointer to a location to put the actual length transferred
+  *	in bytes
+- * @timeout: time in msecs to wait for the message to complete before
+- *	timing out (if 0 the wait is forever)
++ * @timeout: time in msecs to wait for the message to complete before timing out
+  *
+  * Context: task context, might sleep.
+  *
+@@ -337,8 +347,7 @@ EXPORT_SYMBOL_GPL(usb_interrupt_msg);
+  * @len: length in bytes of the data to send
+  * @actual_length: pointer to a location to put the actual length transferred
+  *	in bytes
+- * @timeout: time in msecs to wait for the message to complete before
+- *	timing out (if 0 the wait is forever)
++ * @timeout: time in msecs to wait for the message to complete before timing out
+  *
+  * Context: task context, might sleep.
+  *
+@@ -385,10 +394,59 @@ int usb_bulk_msg(struct usb_device *usb_dev, unsigned int pipe,
+ 		usb_fill_bulk_urb(urb, usb_dev, pipe, data, len,
+ 				usb_api_blocking_completion, NULL);
+ 
+-	return usb_start_wait_urb(urb, timeout, actual_length);
++	return usb_start_wait_urb(urb, timeout, actual_length, false);
+ }
+ EXPORT_SYMBOL_GPL(usb_bulk_msg);
+ 
++/**
++ * usb_bulk_msg_killable - Builds a bulk urb, sends it off and waits for completion in a killable state
++ * @usb_dev: pointer to the usb device to send the message to
++ * @pipe: endpoint "pipe" to send the message to
++ * @data: pointer to the data to send
++ * @len: length in bytes of the data to send
++ * @actual_length: pointer to a location to put the actual length transferred
++ *	in bytes
++ * @timeout: time in msecs to wait for the message to complete before
++ *	timing out (if <= 0, the wait is as long as possible)
++ *
++ * Context: task context, might sleep.
++ *
++ * This function is just like usb_blk_msg(), except that it waits in a
++ * killable state and there is no limit on the timeout length.
++ *
++ * Return:
++ * If successful, 0. Otherwise a negative error number. The number of actual
++ * bytes transferred will be stored in the @actual_length parameter.
++ *
++ */
++int usb_bulk_msg_killable(struct usb_device *usb_dev, unsigned int pipe,
++		 void *data, int len, int *actual_length, int timeout)
++{
++	struct urb *urb;
++	struct usb_host_endpoint *ep;
++
++	ep = usb_pipe_endpoint(usb_dev, pipe);
++	if (!ep || len < 0)
++		return -EINVAL;
++
++	urb = usb_alloc_urb(0, GFP_KERNEL);
++	if (!urb)
++		return -ENOMEM;
++
++	if ((ep->desc.bmAttributes & USB_ENDPOINT_XFERTYPE_MASK) ==
++			USB_ENDPOINT_XFER_INT) {
++		pipe = (pipe & ~(3 << 30)) | (PIPE_INTERRUPT << 30);
++		usb_fill_int_urb(urb, usb_dev, pipe, data, len,
++				usb_api_blocking_completion, NULL,
++				ep->desc.bInterval);
++	} else
++		usb_fill_bulk_urb(urb, usb_dev, pipe, data, len,
++				usb_api_blocking_completion, NULL);
++
++	return usb_start_wait_urb(urb, timeout, actual_length, true);
++}
++EXPORT_SYMBOL_GPL(usb_bulk_msg_killable);
++
+ /*-------------------------------------------------------------------*/
+ 
+ static void sg_clean(struct usb_sg_request *io)
+diff --git a/drivers/usb/core/phy.c b/drivers/usb/core/phy.c
+index fb1588e7c28232..ad09410708491d 100644
+--- a/drivers/usb/core/phy.c
++++ b/drivers/usb/core/phy.c
+@@ -138,16 +138,10 @@ int usb_phy_roothub_set_mode(struct usb_phy_roothub *phy_roothub,
+ 	list_for_each_entry(roothub_entry, head, list) {
+ 		err = phy_set_mode(roothub_entry->phy, mode);
+ 		if (err)
+-			goto err_out;
++			return err;
+ 	}
+ 
+ 	return 0;
+-
+-err_out:
+-	list_for_each_entry_continue_reverse(roothub_entry, head, list)
+-		phy_power_off(roothub_entry->phy);
+-
+-	return err;
+ }
+ EXPORT_SYMBOL_GPL(usb_phy_roothub_set_mode);
+ 
+diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
+index 323a949bbb050d..c12942a533ce2e 100644
+--- a/drivers/usb/core/quirks.c
++++ b/drivers/usb/core/quirks.c
+@@ -208,6 +208,10 @@ static const struct usb_device_id usb_quirk_list[] = {
+ 	/* HP v222w 16GB Mini USB Drive */
+ 	{ USB_DEVICE(0x03f0, 0x3f40), .driver_info = USB_QUIRK_DELAY_INIT },
+ 
++	/* Huawei 4G LTE module ME906S  */
++	{ USB_DEVICE(0x03f0, 0xa31d), .driver_info =
++			USB_QUIRK_DISCONNECT_SUSPEND },
++
+ 	/* Creative SB Audigy 2 NX */
+ 	{ USB_DEVICE(0x041e, 0x3020), .driver_info = USB_QUIRK_RESET_RESUME },
+ 
+@@ -377,6 +381,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+ 	/* SanDisk Extreme 55AE */
+ 	{ USB_DEVICE(0x0781, 0x55ae), .driver_info = USB_QUIRK_NO_LPM },
+ 
++	/* Avermedia Live Gamer Ultra 2.1 (GC553G2) - BOS descriptor fetch hangs at SuperSpeed Plus */
++	{ USB_DEVICE(0x07ca, 0x2553), .driver_info = USB_QUIRK_NO_BOS },
++
+ 	/* Realforce 87U Keyboard */
+ 	{ USB_DEVICE(0x0853, 0x011b), .driver_info = USB_QUIRK_NO_LPM },
+ 
+@@ -434,6 +441,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+ 	{ USB_DEVICE(0x0b05, 0x17e0), .driver_info =
+ 			USB_QUIRK_IGNORE_REMOTE_WAKEUP },
+ 
++	/* ASUS TUF 4K PRO - BOS descriptor fetch hangs at SuperSpeed Plus */
++	{ USB_DEVICE(0x0b05, 0x1ab9), .driver_info = USB_QUIRK_NO_BOS },
++
+ 	/* Realtek Semiconductor Corp. Mass Storage Device (Multicard Reader)*/
+ 	{ USB_DEVICE(0x0bda, 0x0151), .driver_info = USB_QUIRK_CONFIG_INTF_STRINGS },
+ 
+@@ -562,6 +572,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+ 
+ 	{ USB_DEVICE(0x2386, 0x350e), .driver_info = USB_QUIRK_NO_LPM },
+ 
++	/* UGREEN 35871 - BOS descriptor fetch hangs at SuperSpeed Plus */
++	{ USB_DEVICE(0x2b89, 0x5871), .driver_info = USB_QUIRK_NO_BOS },
++
+ 	/* APTIV AUTOMOTIVE HUB */
+ 	{ USB_DEVICE(0x2c48, 0x0132), .driver_info =
+ 			USB_QUIRK_SHORT_SET_ADDRESS_REQ_TIMEOUT },
+@@ -572,6 +585,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+ 	/* Alcor Link AK9563 SC Reader used in 2022 Lenovo ThinkPads */
+ 	{ USB_DEVICE(0x2ce3, 0x9563), .driver_info = USB_QUIRK_NO_LPM },
+ 
++	/* ezcap401 - BOS descriptor fetch hangs at SuperSpeed Plus */
++	{ USB_DEVICE(0x32ed, 0x0401), .driver_info = USB_QUIRK_NO_BOS },
++
+ 	/* DELL USB GEN2 */
+ 	{ USB_DEVICE(0x413c, 0xb062), .driver_info = USB_QUIRK_NO_LPM | USB_QUIRK_RESET_RESUME },
+ 
+diff --git a/drivers/usb/dwc3/dwc3-pci.c b/drivers/usb/dwc3/dwc3-pci.c
+index 8f5faf632a8bfa..6110bd96a60e3c 100644
+--- a/drivers/usb/dwc3/dwc3-pci.c
++++ b/drivers/usb/dwc3/dwc3-pci.c
+@@ -56,6 +56,7 @@
+ #define PCI_DEVICE_ID_INTEL_CNPH		0xa36e
+ #define PCI_DEVICE_ID_INTEL_CNPV		0xa3b0
+ #define PCI_DEVICE_ID_INTEL_RPL			0xa70e
++#define PCI_DEVICE_ID_INTEL_NVLH		0xd37f
+ #define PCI_DEVICE_ID_INTEL_PTLH		0xe332
+ #define PCI_DEVICE_ID_INTEL_PTLH_PCH		0xe37e
+ #define PCI_DEVICE_ID_INTEL_PTLU		0xe432
+@@ -448,6 +449,7 @@ static const struct pci_device_id dwc3_pci_id_table[] = {
+ 	{ PCI_DEVICE_DATA(INTEL, CNPH, &dwc3_pci_intel_swnode) },
+ 	{ PCI_DEVICE_DATA(INTEL, CNPV, &dwc3_pci_intel_swnode) },
+ 	{ PCI_DEVICE_DATA(INTEL, RPL, &dwc3_pci_intel_swnode) },
++	{ PCI_DEVICE_DATA(INTEL, NVLH, &dwc3_pci_intel_swnode) },
+ 	{ PCI_DEVICE_DATA(INTEL, PTLH, &dwc3_pci_intel_swnode) },
+ 	{ PCI_DEVICE_DATA(INTEL, PTLH_PCH, &dwc3_pci_intel_swnode) },
+ 	{ PCI_DEVICE_DATA(INTEL, PTLU, &dwc3_pci_intel_swnode) },
+diff --git a/drivers/usb/gadget/function/f_mass_storage.c b/drivers/usb/gadget/function/f_mass_storage.c
+index c265a1f62fc145..e01d57a5327c6b 100644
+--- a/drivers/usb/gadget/function/f_mass_storage.c
++++ b/drivers/usb/gadget/function/f_mass_storage.c
+@@ -180,6 +180,7 @@
+ #include <linux/kthread.h>
+ #include <linux/sched/signal.h>
+ #include <linux/limits.h>
++#include <linux/overflow.h>
+ #include <linux/pagemap.h>
+ #include <linux/rwsem.h>
+ #include <linux/slab.h>
+@@ -1853,8 +1854,15 @@ static int check_command_size_in_blocks(struct fsg_common *common,
+ 		int cmnd_size, enum data_direction data_dir,
+ 		unsigned int mask, int needs_medium, const char *name)
+ {
+-	if (common->curlun)
+-		common->data_size_from_cmnd <<= common->curlun->blkbits;
++	if (common->curlun) {
++		if (check_shl_overflow(common->data_size_from_cmnd,
++				       common->curlun->blkbits,
++				       &common->data_size_from_cmnd)) {
++			common->phase_error = 1;
++			return -EINVAL;
++		}
++	}
++
+ 	return check_command(common, cmnd_size, data_dir,
+ 			mask, needs_medium, name);
+ }
+diff --git a/drivers/usb/gadget/function/f_tcm.c b/drivers/usb/gadget/function/f_tcm.c
+index 5d0d8949539539..3811b7abaf5892 100644
+--- a/drivers/usb/gadget/function/f_tcm.c
++++ b/drivers/usb/gadget/function/f_tcm.c
+@@ -1032,6 +1032,13 @@ static void usbg_cmd_work(struct work_struct *work)
+ 	se_cmd = &cmd->se_cmd;
+ 	tpg = cmd->fu->tpg;
+ 	tv_nexus = tpg->tpg_nexus;
++	if (!tv_nexus) {
++		struct usb_gadget *gadget = fuas_to_gadget(cmd->fu);
++
++		dev_err(&gadget->dev, "Missing nexus, ignoring command\n");
++		return;
++	}
++
+ 	dir = get_cmd_dir(cmd->cmd_buf);
+ 	if (dir < 0) {
+ 		__target_init_cmd(se_cmd,
+@@ -1160,6 +1167,13 @@ static void bot_cmd_work(struct work_struct *work)
+ 	se_cmd = &cmd->se_cmd;
+ 	tpg = cmd->fu->tpg;
+ 	tv_nexus = tpg->tpg_nexus;
++	if (!tv_nexus) {
++		struct usb_gadget *gadget = fuas_to_gadget(cmd->fu);
++
++		dev_err(&gadget->dev, "Missing nexus, ignoring command\n");
++		return;
++	}
++
+ 	dir = get_cmd_dir(cmd->cmd_buf);
+ 	if (dir < 0) {
+ 		__target_init_cmd(se_cmd,
+diff --git a/drivers/usb/host/xhci-ring.c b/drivers/usb/host/xhci-ring.c
+index cdb819e323b348..7623da3ff78531 100644
+--- a/drivers/usb/host/xhci-ring.c
++++ b/drivers/usb/host/xhci-ring.c
+@@ -3219,6 +3219,7 @@ irqreturn_t xhci_irq(struct usb_hcd *hcd)
+ 
+ 	if (status & STS_HCE) {
+ 		xhci_warn(xhci, "WARNING: Host Controller Error\n");
++		xhci_halt(xhci);
+ 		goto out;
+ 	}
+ 
+diff --git a/drivers/usb/host/xhci.c b/drivers/usb/host/xhci.c
+index 8fd88fedbb30ea..0fdb0780d19cff 100644
+--- a/drivers/usb/host/xhci.c
++++ b/drivers/usb/host/xhci.c
+@@ -3939,7 +3939,7 @@ int xhci_disable_slot(struct xhci_hcd *xhci, u32 slot_id)
+ 	if (state == 0xffffffff || (xhci->xhc_state & XHCI_STATE_DYING) ||
+ 			(xhci->xhc_state & XHCI_STATE_HALTED)) {
+ 		spin_unlock_irqrestore(&xhci->lock, flags);
+-		kfree(command);
++		xhci_free_command(xhci, command);
+ 		return -ENODEV;
+ 	}
+ 
+@@ -3947,7 +3947,7 @@ int xhci_disable_slot(struct xhci_hcd *xhci, u32 slot_id)
+ 				slot_id);
+ 	if (ret) {
+ 		spin_unlock_irqrestore(&xhci->lock, flags);
+-		kfree(command);
++		xhci_free_command(xhci, command);
+ 		return ret;
+ 	}
+ 	xhci_ring_cmd_db(xhci);
+diff --git a/drivers/usb/image/mdc800.c b/drivers/usb/image/mdc800.c
+index 67f098579fb456..4d9583d2120264 100644
+--- a/drivers/usb/image/mdc800.c
++++ b/drivers/usb/image/mdc800.c
+@@ -708,7 +708,7 @@ static ssize_t mdc800_device_read (struct file *file, char __user *buf, size_t l
+ 		if (signal_pending (current)) 
+ 		{
+ 			mutex_unlock(&mdc800->io_lock);
+-			return -EINTR;
++			return len == left ? -EINTR : len-left;
+ 		}
+ 
+ 		sts=left > (mdc800->out_count-mdc800->out_ptr)?mdc800->out_count-mdc800->out_ptr:left;
+@@ -731,9 +731,11 @@ static ssize_t mdc800_device_read (struct file *file, char __user *buf, size_t l
+ 					mutex_unlock(&mdc800->io_lock);
+ 					return len-left;
+ 				}
+-				wait_event_timeout(mdc800->download_wait,
++				retval = wait_event_timeout(mdc800->download_wait,
+ 				     mdc800->downloaded,
+ 				     msecs_to_jiffies(TO_DOWNLOAD_GET_READY));
++				if (!retval)
++					usb_kill_urb(mdc800->download_urb);
+ 				mdc800->downloaded = 0;
+ 				if (mdc800->download_urb->status != 0)
+ 				{
+diff --git a/drivers/usb/misc/uss720.c b/drivers/usb/misc/uss720.c
+index eb5a8e0d9e2d6c..e93852460fed71 100644
+--- a/drivers/usb/misc/uss720.c
++++ b/drivers/usb/misc/uss720.c
+@@ -733,7 +733,7 @@ static int uss720_probe(struct usb_interface *intf,
+ 	ret = get_1284_register(pp, 0, &reg, GFP_KERNEL);
+ 	dev_dbg(&intf->dev, "reg: %7ph\n", priv->reg);
+ 	if (ret < 0)
+-		return ret;
++		goto probe_abort;
+ 
+ 	ret = usb_find_last_int_in_endpoint(interface, &epd);
+ 	if (!ret) {
+diff --git a/drivers/usb/misc/yurex.c b/drivers/usb/misc/yurex.c
+index 0eed614ac12739..22f40e1882abd6 100644
+--- a/drivers/usb/misc/yurex.c
++++ b/drivers/usb/misc/yurex.c
+@@ -272,6 +272,7 @@ static int yurex_probe(struct usb_interface *interface, const struct usb_device_
+ 			 dev->int_buffer, YUREX_BUF_SIZE, yurex_interrupt,
+ 			 dev, 1);
+ 	dev->urb->transfer_flags |= URB_NO_TRANSFER_DMA_MAP;
++	dev->bbu = -1;
+ 	if (usb_submit_urb(dev->urb, GFP_KERNEL)) {
+ 		retval = -EIO;
+ 		dev_err(&interface->dev, "Could not submitting URB\n");
+@@ -280,7 +281,6 @@ static int yurex_probe(struct usb_interface *interface, const struct usb_device_
+ 
+ 	/* save our data pointer in this interface device */
+ 	usb_set_intfdata(interface, dev);
+-	dev->bbu = -1;
+ 
+ 	/* we can register the device now, as it is ready */
+ 	retval = usb_register_dev(interface, &yurex_class);
+diff --git a/drivers/usb/renesas_usbhs/common.c b/drivers/usb/renesas_usbhs/common.c
+index 2978e869ac8fbf..4fdc1d0c245151 100644
+--- a/drivers/usb/renesas_usbhs/common.c
++++ b/drivers/usb/renesas_usbhs/common.c
+@@ -800,6 +800,15 @@ static void usbhs_remove(struct platform_device *pdev)
+ 
+ 	usbhs_platform_call(priv, hardware_exit, pdev);
+ 	reset_control_assert(priv->rsts);
++
++	/*
++	 * Explicitly free the IRQ to ensure the interrupt handler is
++	 * disabled and synchronized before freeing resources.
++	 * devm_free_irq() calls free_irq() which waits for any running
++	 * ISR to complete, preventing UAF.
++	 */
++	devm_free_irq(&pdev->dev, priv->irq, priv);
++
+ 	usbhs_mod_remove(priv);
+ 	usbhs_fifo_remove(priv);
+ 	usbhs_pipe_remove(priv);
+diff --git a/drivers/usb/roles/class.c b/drivers/usb/roles/class.c
+index 8664449ca2ff8a..b1977a99d83d70 100644
+--- a/drivers/usb/roles/class.c
++++ b/drivers/usb/roles/class.c
+@@ -110,9 +110,14 @@ static void *usb_role_switch_match(const struct fwnode_handle *fwnode, const cha
+ static struct usb_role_switch *
+ usb_role_switch_is_parent(struct fwnode_handle *fwnode)
+ {
+-	struct fwnode_handle *parent = fwnode_get_parent(fwnode);
++	struct fwnode_handle *parent;
+ 	struct device *dev;
+ 
++	if (!fwnode_device_is_compatible(fwnode, "usb-b-connector"))
++		return NULL;
++
++	parent = fwnode_get_parent(fwnode);
++
+ 	if (!fwnode_property_present(parent, "usb-role-switch")) {
+ 		fwnode_handle_put(parent);
+ 		return NULL;
+diff --git a/drivers/usb/serial/f81232.c b/drivers/usb/serial/f81232.c
+index 5f7a46bcace65c..f397a68bdb53c6 100644
+--- a/drivers/usb/serial/f81232.c
++++ b/drivers/usb/serial/f81232.c
+@@ -70,7 +70,6 @@ MODULE_DEVICE_TABLE(usb, combined_id_table);
+ #define F81232_REGISTER_REQUEST		0xa0
+ #define F81232_GET_REGISTER		0xc0
+ #define F81232_SET_REGISTER		0x40
+-#define F81534A_ACCESS_REG_RETRY	2
+ 
+ #define SERIAL_BASE_ADDRESS		0x0120
+ #define RECEIVE_BUFFER_REGISTER		(0x00 + SERIAL_BASE_ADDRESS)
+@@ -824,36 +823,31 @@ static void f81232_lsr_worker(struct work_struct *work)
+ static int f81534a_ctrl_set_register(struct usb_interface *intf, u16 reg,
+ 					u16 size, void *val)
+ {
+-	struct usb_device *dev = interface_to_usbdev(intf);
+-	int retry = F81534A_ACCESS_REG_RETRY;
+-	int status;
+-
+-	while (retry--) {
+-		status = usb_control_msg_send(dev,
+-					      0,
+-					      F81232_REGISTER_REQUEST,
+-					      F81232_SET_REGISTER,
+-					      reg,
+-					      0,
+-					      val,
+-					      size,
+-					      USB_CTRL_SET_TIMEOUT,
+-					      GFP_KERNEL);
+-		if (status) {
+-			status = usb_translate_errors(status);
+-			if (status == -EIO)
+-				continue;
+-		}
+-
+-		break;
+-	}
+-
+-	if (status) {
+-		dev_err(&intf->dev, "failed to set register 0x%x: %d\n",
+-				reg, status);
+-	}
++	return usb_control_msg_send(interface_to_usbdev(intf),
++						0,
++						F81232_REGISTER_REQUEST,
++						F81232_SET_REGISTER,
++						reg,
++						0,
++						val,
++						size,
++						USB_CTRL_SET_TIMEOUT,
++						GFP_KERNEL);
++}
+ 
+-	return status;
++static int f81534a_ctrl_get_register(struct usb_interface *intf, u16 reg,
++					u16 size, void *val)
++{
++	return usb_control_msg_recv(interface_to_usbdev(intf),
++						0,
++						F81232_REGISTER_REQUEST,
++						F81232_GET_REGISTER,
++						reg,
++						0,
++						val,
++						size,
++						USB_CTRL_GET_TIMEOUT,
++						GFP_KERNEL);
+ }
+ 
+ static int f81534a_ctrl_enable_all_ports(struct usb_interface *intf, bool en)
+@@ -869,6 +863,29 @@ static int f81534a_ctrl_enable_all_ports(struct usb_interface *intf, bool en)
+ 	 * bit 0~11	: Serial port enable bit.
+ 	 */
+ 	if (en) {
++		/*
++		 * The Fintek F81532A/534A/535/536 family relies on the
++		 * F81534A_CTRL_CMD_ENABLE_PORT (116h) register during
++		 * initialization to both determine serial port status and
++		 * control port creation.
++		 *
++		 * If the driver experiences fast load/unload cycles, the
++		 * device state may becomes unstable, resulting in the
++		 * incomplete generation of serial ports.
++		 *
++		 * Performing a dummy read operation on the register prior
++		 * to the initial write command resolves the issue.
++		 *
++		 * This clears the device's stale internal state. Subsequent
++		 * write operations will correctly generate all serial ports.
++		 */
++		status = f81534a_ctrl_get_register(intf,
++						F81534A_CTRL_CMD_ENABLE_PORT,
++						sizeof(enable),
++						enable);
++		if (status)
++			return status;
++
+ 		enable[0] = 0xff;
+ 		enable[1] = 0x8f;
+ 	}
+diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
+index 5e6d689584099b..2e39686e01c9e0 100644
+--- a/drivers/usb/typec/tcpm/tcpm.c
++++ b/drivers/usb/typec/tcpm/tcpm.c
+@@ -6637,7 +6637,7 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
+ 	port->port_type = port->typec_caps.type;
+ 
+ 	port->role_sw = fwnode_usb_role_switch_get(tcpc->fwnode);
+-	if (IS_ERR_OR_NULL(port->role_sw))
++	if (!port->role_sw)
+ 		port->role_sw = usb_role_switch_get(port->dev);
+ 	if (IS_ERR(port->role_sw)) {
+ 		err = PTR_ERR(port->role_sw);
+diff --git a/drivers/usb/typec/ucsi/ucsi_glink.c b/drivers/usb/typec/ucsi/ucsi_glink.c
+index 82a1081d44f1f0..cddbeae9141986 100644
+--- a/drivers/usb/typec/ucsi/ucsi_glink.c
++++ b/drivers/usb/typec/ucsi/ucsi_glink.c
+@@ -72,6 +72,9 @@ struct pmic_glink_ucsi {
+ 
+ 	struct work_struct notify_work;
+ 	struct work_struct register_work;
++	spinlock_t state_lock;
++	bool ucsi_registered;
++	bool pd_running;
+ 
+ 	u8 read_buf[UCSI_BUF_SIZE];
+ };
+@@ -270,8 +273,20 @@ static void pmic_glink_ucsi_notify(struct work_struct *work)
+ static void pmic_glink_ucsi_register(struct work_struct *work)
+ {
+ 	struct pmic_glink_ucsi *ucsi = container_of(work, struct pmic_glink_ucsi, register_work);
++	unsigned long flags;
++	bool pd_running;
+ 
+-	ucsi_register(ucsi->ucsi);
++	spin_lock_irqsave(&ucsi->state_lock, flags);
++	pd_running = ucsi->pd_running;
++	spin_unlock_irqrestore(&ucsi->state_lock, flags);
++
++	if (!ucsi->ucsi_registered && pd_running) {
++		ucsi_register(ucsi->ucsi);
++		ucsi->ucsi_registered = true;
++	} else if (ucsi->ucsi_registered && !pd_running) {
++		ucsi_unregister(ucsi->ucsi);
++		ucsi->ucsi_registered = false;
++	}
+ }
+ 
+ static void pmic_glink_ucsi_callback(const void *data, size_t len, void *priv)
+@@ -295,11 +310,12 @@ static void pmic_glink_ucsi_callback(const void *data, size_t len, void *priv)
+ static void pmic_glink_ucsi_pdr_notify(void *priv, int state)
+ {
+ 	struct pmic_glink_ucsi *ucsi = priv;
++	unsigned long flags;
+ 
+-	if (state == SERVREG_SERVICE_STATE_UP)
+-		schedule_work(&ucsi->register_work);
+-	else if (state == SERVREG_SERVICE_STATE_DOWN)
+-		ucsi_unregister(ucsi->ucsi);
++	spin_lock_irqsave(&ucsi->state_lock, flags);
++	ucsi->pd_running = (state == SERVREG_SERVICE_STATE_UP);
++	spin_unlock_irqrestore(&ucsi->state_lock, flags);
++	schedule_work(&ucsi->register_work);
+ }
+ 
+ static void pmic_glink_ucsi_destroy(void *data)
+@@ -332,6 +348,7 @@ static int pmic_glink_ucsi_probe(struct auxiliary_device *adev,
+ 	init_completion(&ucsi->read_ack);
+ 	init_completion(&ucsi->write_ack);
+ 	init_completion(&ucsi->sync_ack);
++	spin_lock_init(&ucsi->state_lock);
+ 	mutex_init(&ucsi->lock);
+ 
+ 	ucsi->ucsi = ucsi_create(dev, &pmic_glink_ucsi_ops);
+diff --git a/drivers/xen/privcmd.c b/drivers/xen/privcmd.c
+index 61aaded483e1d3..049b29089b7ecc 100644
+--- a/drivers/xen/privcmd.c
++++ b/drivers/xen/privcmd.c
+@@ -12,6 +12,7 @@
+ #include <linux/eventfd.h>
+ #include <linux/file.h>
+ #include <linux/kernel.h>
++#include <linux/kstrtox.h>
+ #include <linux/module.h>
+ #include <linux/mutex.h>
+ #include <linux/poll.h>
+@@ -30,6 +31,9 @@
+ #include <linux/seq_file.h>
+ #include <linux/miscdevice.h>
+ #include <linux/moduleparam.h>
++#include <linux/notifier.h>
++#include <linux/security.h>
++#include <linux/wait.h>
+ 
+ #include <asm/xen/hypervisor.h>
+ #include <asm/xen/hypercall.h>
+@@ -43,6 +47,7 @@
+ #include <xen/page.h>
+ #include <xen/xen-ops.h>
+ #include <xen/balloon.h>
++#include <xen/xenbus.h>
+ 
+ #include "privcmd.h"
+ 
+@@ -61,10 +66,20 @@ module_param_named(dm_op_buf_max_size, privcmd_dm_op_buf_max_size, uint,
+ MODULE_PARM_DESC(dm_op_buf_max_size,
+ 		 "Maximum size of a dm_op hypercall buffer");
+ 
++static bool unrestricted;
++module_param(unrestricted, bool, 0);
++MODULE_PARM_DESC(unrestricted,
++	"Don't restrict hypercalls to target domain if running in a domU");
++
+ struct privcmd_data {
+ 	domid_t domid;
+ };
+ 
++/* DOMID_INVALID implies no restriction */
++static domid_t target_domain = DOMID_INVALID;
++static bool restrict_wait;
++static DECLARE_WAIT_QUEUE_HEAD(restrict_wait_wq);
++
+ static int privcmd_vma_range_is_mapped(
+                struct vm_area_struct *vma,
+                unsigned long addr,
+@@ -1156,13 +1171,16 @@ static long privcmd_ioctl(struct file *file,
+ 
+ static int privcmd_open(struct inode *ino, struct file *file)
+ {
+-	struct privcmd_data *data = kzalloc(sizeof(*data), GFP_KERNEL);
++	struct privcmd_data *data;
++
++	if (wait_event_interruptible(restrict_wait_wq, !restrict_wait) < 0)
++		return -EINTR;
+ 
++	data = kzalloc(sizeof(*data), GFP_KERNEL);
+ 	if (!data)
+ 		return -ENOMEM;
+ 
+-	/* DOMID_INVALID implies no restriction */
+-	data->domid = DOMID_INVALID;
++	data->domid = target_domain;
+ 
+ 	file->private_data = data;
+ 	return 0;
+@@ -1255,6 +1273,52 @@ static struct miscdevice privcmd_dev = {
+ 	.fops = &xen_privcmd_fops,
+ };
+ 
++static int init_restrict(struct notifier_block *notifier,
++			 unsigned long event,
++			 void *data)
++{
++	char *target;
++	unsigned int domid;
++
++	/* Default to an guaranteed unused domain-id. */
++	target_domain = DOMID_IDLE;
++
++	target = xenbus_read(XBT_NIL, "target", "", NULL);
++	if (IS_ERR(target) || kstrtouint(target, 10, &domid)) {
++		pr_err("No target domain found, blocking all hypercalls\n");
++		goto out;
++	}
++
++	target_domain = domid;
++
++ out:
++	if (!IS_ERR(target))
++		kfree(target);
++
++	restrict_wait = false;
++	wake_up_all(&restrict_wait_wq);
++
++	return NOTIFY_DONE;
++}
++
++static struct notifier_block xenstore_notifier = {
++	.notifier_call = init_restrict,
++};
++
++static void __init restrict_driver(void)
++{
++	if (unrestricted) {
++		if (security_locked_down(LOCKDOWN_XEN_USER_ACTIONS))
++			pr_warn("Kernel is locked down, parameter \"unrestricted\" ignored\n");
++		else
++			return;
++	}
++
++	restrict_wait = true;
++
++	register_xenstore_notifier(&xenstore_notifier);
++}
++
+ static int __init privcmd_init(void)
+ {
+ 	int err;
+@@ -1262,6 +1326,9 @@ static int __init privcmd_init(void)
+ 	if (!xen_domain())
+ 		return -ENODEV;
+ 
++	if (!xen_initial_domain())
++		restrict_driver();
++
+ 	err = misc_register(&privcmd_dev);
+ 	if (err != 0) {
+ 		pr_err("Could not register Xen privcmd device\n");
+diff --git a/drivers/xen/xen-acpi-processor.c b/drivers/xen/xen-acpi-processor.c
+index 29670393984638..520756159d3d35 100644
+--- a/drivers/xen/xen-acpi-processor.c
++++ b/drivers/xen/xen-acpi-processor.c
+@@ -379,11 +379,8 @@ read_acpi_id(acpi_handle handle, u32 lvl, void *context, void **rv)
+ 			 acpi_psd[acpi_id].domain);
+ 	}
+ 
+-	status = acpi_evaluate_object(handle, "_CST", NULL, &buffer);
+-	if (ACPI_FAILURE(status)) {
+-		if (!pblk)
+-			return AE_OK;
+-	}
++	if (!pblk && !acpi_has_method(handle, "_CST"))
++		return AE_OK;
+ 	/* .. and it has a C-state */
+ 	__set_bit(acpi_id, acpi_id_cst_present);
+ 
+diff --git a/fs/binfmt_misc.c b/fs/binfmt_misc.c
+index cf5ed5cd4102df..a45b5ba12a9cb8 100644
+--- a/fs/binfmt_misc.c
++++ b/fs/binfmt_misc.c
+@@ -815,8 +815,10 @@ out:
+ 	inode_unlock(d_inode(root));
+ 
+ 	if (err) {
+-		if (f)
++		if (f) {
++			allow_write_access(f);
+ 			filp_close(f, NULL);
++		}
+ 		kfree(e);
+ 		return err;
+ 	}
+diff --git a/fs/btrfs/Makefile b/fs/btrfs/Makefile
+index 90d53209755bf8..3bb869a84e5417 100644
+--- a/fs/btrfs/Makefile
++++ b/fs/btrfs/Makefile
+@@ -33,7 +33,7 @@ btrfs-y += super.o ctree.o extent-tree.o print-tree.o root-tree.o dir-item.o \
+ 	   uuid-tree.o props.o free-space-tree.o tree-checker.o space-info.o \
+ 	   block-rsv.o delalloc-space.o block-group.o discard.o reflink.o \
+ 	   subpage.o tree-mod-log.o extent-io-tree.o fs.o messages.o bio.o \
+-	   lru_cache.o
++	   lru_cache.o raid-stripe-tree.o
+ 
+ btrfs-$(CONFIG_BTRFS_FS_POSIX_ACL) += acl.o
+ btrfs-$(CONFIG_BTRFS_FS_CHECK_INTEGRITY) += check-integrity.o
+diff --git a/fs/btrfs/accessors.h b/fs/btrfs/accessors.h
+index 8cfc8214109ca9..341c07b4c2272c 100644
+--- a/fs/btrfs/accessors.h
++++ b/fs/btrfs/accessors.h
+@@ -305,6 +305,14 @@ BTRFS_SETGET_FUNCS(timespec_nsec, struct btrfs_timespec, nsec, 32);
+ BTRFS_SETGET_STACK_FUNCS(stack_timespec_sec, struct btrfs_timespec, sec, 64);
+ BTRFS_SETGET_STACK_FUNCS(stack_timespec_nsec, struct btrfs_timespec, nsec, 32);
+ 
++BTRFS_SETGET_FUNCS(stripe_extent_encoding, struct btrfs_stripe_extent, encoding, 8);
++BTRFS_SETGET_FUNCS(raid_stride_devid, struct btrfs_raid_stride, devid, 64);
++BTRFS_SETGET_FUNCS(raid_stride_physical, struct btrfs_raid_stride, physical, 64);
++BTRFS_SETGET_STACK_FUNCS(stack_stripe_extent_encoding,
++			 struct btrfs_stripe_extent, encoding, 8);
++BTRFS_SETGET_STACK_FUNCS(stack_raid_stride_devid, struct btrfs_raid_stride, devid, 64);
++BTRFS_SETGET_STACK_FUNCS(stack_raid_stride_physical, struct btrfs_raid_stride, physical, 64);
++
+ /* struct btrfs_dev_extent */
+ BTRFS_SETGET_FUNCS(dev_extent_chunk_tree, struct btrfs_dev_extent, chunk_tree, 64);
+ BTRFS_SETGET_FUNCS(dev_extent_chunk_objectid, struct btrfs_dev_extent,
+diff --git a/fs/btrfs/bio.c b/fs/btrfs/bio.c
+index 650972895652d8..6fa13be15f301a 100644
+--- a/fs/btrfs/bio.c
++++ b/fs/btrfs/bio.c
+@@ -15,6 +15,7 @@
+ #include "rcu-string.h"
+ #include "zoned.h"
+ #include "file-item.h"
++#include "raid-stripe-tree.h"
+ 
+ static struct bio_set btrfs_bioset;
+ static struct bio_set btrfs_clone_bioset;
+@@ -416,6 +417,9 @@ static void btrfs_orig_write_end_io(struct bio *bio)
+ 	else
+ 		bio->bi_status = BLK_STS_OK;
+ 
++	if (bio_op(bio) == REQ_OP_ZONE_APPEND && !bio->bi_status)
++		stripe->physical = bio->bi_iter.bi_sector << SECTOR_SHIFT;
++
+ 	btrfs_orig_bbio_end_io(bbio);
+ 	btrfs_put_bioc(bioc);
+ }
+@@ -427,6 +431,8 @@ static void btrfs_clone_write_end_io(struct bio *bio)
+ 	if (bio->bi_status) {
+ 		atomic_inc(&stripe->bioc->error);
+ 		btrfs_log_dev_io_error(bio, stripe->dev);
++	} else if (bio_op(bio) == REQ_OP_ZONE_APPEND) {
++		stripe->physical = bio->bi_iter.bi_sector << SECTOR_SHIFT;
+ 	}
+ 
+ 	/* Pass on control to the original bio this one was cloned from */
+@@ -490,6 +496,7 @@ static void btrfs_submit_mirrored_bio(struct btrfs_io_context *bioc, int dev_nr)
+ 	bio->bi_private = &bioc->stripes[dev_nr];
+ 	bio->bi_iter.bi_sector = bioc->stripes[dev_nr].physical >> SECTOR_SHIFT;
+ 	bioc->stripes[dev_nr].bioc = bioc;
++	bioc->size = bio->bi_iter.bi_size;
+ 	btrfs_submit_dev_bio(bioc->stripes[dev_nr].dev, bio);
+ }
+ 
+@@ -499,6 +506,8 @@ static void __btrfs_submit_bio(struct bio *bio, struct btrfs_io_context *bioc,
+ 	if (!bioc) {
+ 		/* Single mirror read/write fast path. */
+ 		btrfs_bio(bio)->mirror_num = mirror_num;
++		if (bio_op(bio) != REQ_OP_READ)
++			btrfs_bio(bio)->orig_physical = smap->physical;
+ 		bio->bi_iter.bi_sector = smap->physical >> SECTOR_SHIFT;
+ 		if (bio_op(bio) != REQ_OP_READ)
+ 			btrfs_bio(bio)->orig_physical = smap->physical;
+@@ -690,6 +699,18 @@ static bool btrfs_submit_chunk(struct btrfs_bio *bbio, int mirror_num)
+ 			bio->bi_opf |= REQ_OP_ZONE_APPEND;
+ 		}
+ 
++		if (is_data_bbio(bbio) && bioc &&
++		    btrfs_need_stripe_tree_update(bioc->fs_info, bioc->map_type)) {
++			/*
++			 * No locking for the list update, as we only add to
++			 * the list in the I/O submission path, and list
++			 * iteration only happens in the completion path, which
++			 * can't happen until after the last submission.
++			 */
++			btrfs_get_bioc(bioc);
++			list_add_tail(&bioc->rst_ordered_entry, &bbio->ordered->bioc_list);
++		}
++
+ 		/*
+ 		 * Csum items for reloc roots have already been cloned at this
+ 		 * point, so they are handled as part of the no-checksum case.
+diff --git a/fs/btrfs/block-rsv.c b/fs/btrfs/block-rsv.c
+index 97084ea3af0cca..07bf07431a7f48 100644
+--- a/fs/btrfs/block-rsv.c
++++ b/fs/btrfs/block-rsv.c
+@@ -354,6 +354,11 @@ void btrfs_update_global_block_rsv(struct btrfs_fs_info *fs_info)
+ 		min_items++;
+ 	}
+ 
++	if (btrfs_fs_incompat(fs_info, RAID_STRIPE_TREE)) {
++		num_bytes += btrfs_root_used(&fs_info->stripe_root->root_item);
++		min_items++;
++	}
++
+ 	/*
+ 	 * But we also want to reserve enough space so we can do the fallback
+ 	 * global reserve for an unlink, which is an additional
+@@ -405,6 +410,7 @@ void btrfs_init_root_block_rsv(struct btrfs_root *root)
+ 	case BTRFS_EXTENT_TREE_OBJECTID:
+ 	case BTRFS_FREE_SPACE_TREE_OBJECTID:
+ 	case BTRFS_BLOCK_GROUP_TREE_OBJECTID:
++	case BTRFS_RAID_STRIPE_TREE_OBJECTID:
+ 		root->block_rsv = &fs_info->delayed_refs_rsv;
+ 		break;
+ 	case BTRFS_ROOT_TREE_OBJECTID:
+diff --git a/fs/btrfs/ctree.h b/fs/btrfs/ctree.h
+index 834af67fac231d..1743aa21fa6e58 100644
+--- a/fs/btrfs/ctree.h
++++ b/fs/btrfs/ctree.h
+@@ -472,30 +472,11 @@ static inline u32 BTRFS_MAX_XATTR_SIZE(const struct btrfs_fs_info *info)
+ #define BTRFS_BYTES_TO_BLKS(fs_info, bytes) \
+ 				((bytes) >> (fs_info)->sectorsize_bits)
+ 
+-static inline u32 btrfs_crc32c(u32 crc, const void *address, unsigned length)
+-{
+-	return crc32c(crc, address, length);
+-}
+-
+-static inline void btrfs_crc32c_final(u32 crc, u8 *result)
+-{
+-	put_unaligned_le32(~crc, result);
+-}
+-
+ static inline u64 btrfs_name_hash(const char *name, int len)
+ {
+        return crc32c((u32)~1, name, len);
+ }
+ 
+-/*
+- * Figure the key offset of an extended inode ref
+- */
+-static inline u64 btrfs_extref_hash(u64 parent_objectid, const char *name,
+-                                   int len)
+-{
+-       return (u64) crc32c(parent_objectid, name, len);
+-}
+-
+ static inline gfp_t btrfs_alloc_write_mask(struct address_space *mapping)
+ {
+ 	return mapping_gfp_constraint(mapping, ~__GFP_FS);
+diff --git a/fs/btrfs/disk-io.c b/fs/btrfs/disk-io.c
+index 3c26e91a8055f2..b4ec844b7d741a 100644
+--- a/fs/btrfs/disk-io.c
++++ b/fs/btrfs/disk-io.c
+@@ -470,28 +470,6 @@ static int btree_migrate_folio(struct address_space *mapping,
+ #define btree_migrate_folio NULL
+ #endif
+ 
+-static int btree_writepages(struct address_space *mapping,
+-			    struct writeback_control *wbc)
+-{
+-	struct btrfs_fs_info *fs_info;
+-	int ret;
+-
+-	if (wbc->sync_mode == WB_SYNC_NONE) {
+-
+-		if (wbc->for_kupdate)
+-			return 0;
+-
+-		fs_info = BTRFS_I(mapping->host)->root->fs_info;
+-		/* this is a bit racy, but that's ok */
+-		ret = __percpu_counter_compare(&fs_info->dirty_metadata_bytes,
+-					     BTRFS_DIRTY_METADATA_THRESH,
+-					     fs_info->dirty_metadata_batch);
+-		if (ret < 0)
+-			return 0;
+-	}
+-	return btree_write_cache_pages(mapping, wbc);
+-}
+-
+ static bool btree_release_folio(struct folio *folio, gfp_t gfp_flags)
+ {
+ 	if (folio_test_writeback(folio) || folio_test_dirty(folio))
+@@ -1179,6 +1157,8 @@ static struct btrfs_root *btrfs_get_global_root(struct btrfs_fs_info *fs_info,
+ 		return btrfs_grab_root(fs_info->block_group_root);
+ 	case BTRFS_FREE_SPACE_TREE_OBJECTID:
+ 		return btrfs_grab_root(btrfs_global_root(fs_info, &key));
++	case BTRFS_RAID_STRIPE_TREE_OBJECTID:
++		return btrfs_grab_root(fs_info->stripe_root);
+ 	default:
+ 		return NULL;
+ 	}
+@@ -1259,6 +1239,7 @@ void btrfs_free_fs_info(struct btrfs_fs_info *fs_info)
+ 	btrfs_put_root(fs_info->fs_root);
+ 	btrfs_put_root(fs_info->data_reloc_root);
+ 	btrfs_put_root(fs_info->block_group_root);
++	btrfs_put_root(fs_info->stripe_root);
+ 	btrfs_check_leaked_roots(fs_info);
+ 	btrfs_extent_buffer_leak_debug_check(fs_info);
+ 	kfree(fs_info->super_copy);
+@@ -1812,6 +1793,7 @@ static void free_root_pointers(struct btrfs_fs_info *info, bool free_chunk_root)
+ 	free_root_extent_buffers(info->fs_root);
+ 	free_root_extent_buffers(info->data_reloc_root);
+ 	free_root_extent_buffers(info->block_group_root);
++	free_root_extent_buffers(info->stripe_root);
+ 	if (free_chunk_root)
+ 		free_root_extent_buffers(info->chunk_root);
+ }
+@@ -2287,6 +2269,20 @@ static int btrfs_read_roots(struct btrfs_fs_info *fs_info)
+ 		fs_info->uuid_root = root;
+ 	}
+ 
++	if (btrfs_fs_incompat(fs_info, RAID_STRIPE_TREE)) {
++		location.objectid = BTRFS_RAID_STRIPE_TREE_OBJECTID;
++		root = btrfs_read_tree_root(tree_root, &location);
++		if (IS_ERR(root)) {
++			if (!btrfs_test_opt(fs_info, IGNOREBADROOTS)) {
++				ret = PTR_ERR(root);
++				goto out;
++			}
++		} else {
++			set_bit(BTRFS_ROOT_TRACK_DIRTY, &root->state);
++			fs_info->stripe_root = root;
++		}
++	}
++
+ 	return 0;
+ out:
+ 	btrfs_warn(fs_info, "failed to read root (objectid=%llu): %d",
+@@ -3076,7 +3072,7 @@ int btrfs_check_features(struct btrfs_fs_info *fs_info, bool is_rw_mount)
+ 	if (incompat & ~BTRFS_FEATURE_INCOMPAT_SUPP) {
+ 		btrfs_err(fs_info,
+ 		"cannot mount because of unknown incompat features (0x%llx)",
+-		    incompat);
++		    incompat & ~BTRFS_FEATURE_INCOMPAT_SUPP);
+ 		return -EINVAL;
+ 	}
+ 
+@@ -3108,7 +3104,7 @@ int btrfs_check_features(struct btrfs_fs_info *fs_info, bool is_rw_mount)
+ 	if (compat_ro_unsupp && is_rw_mount) {
+ 		btrfs_err(fs_info,
+ 	"cannot mount read-write because of unknown compat_ro features (0x%llx)",
+-		       compat_ro);
++		       compat_ro_unsupp);
+ 		return -EINVAL;
+ 	}
+ 
+@@ -3121,7 +3117,7 @@ int btrfs_check_features(struct btrfs_fs_info *fs_info, bool is_rw_mount)
+ 	    !btrfs_test_opt(fs_info, NOLOGREPLAY)) {
+ 		btrfs_err(fs_info,
+ "cannot replay dirty log with unsupported compat_ro features (0x%llx), try rescue=nologreplay",
+-			  compat_ro);
++			  compat_ro_unsupp);
+ 		return -EINVAL;
+ 	}
+ 
+diff --git a/fs/btrfs/extent-tree.c b/fs/btrfs/extent-tree.c
+index 774bdafc822c1d..04ea2b2a9383e4 100644
+--- a/fs/btrfs/extent-tree.c
++++ b/fs/btrfs/extent-tree.c
+@@ -42,6 +42,7 @@
+ #include "file-item.h"
+ #include "orphan.h"
+ #include "tree-checker.h"
++#include "raid-stripe-tree.h"
+ 
+ #undef SCRAMBLE_DELAYED_REFS
+ 
+@@ -414,11 +415,11 @@ u64 hash_extent_data_ref(u64 root_objectid, u64 owner, u64 offset)
+ 	__le64 lenum;
+ 
+ 	lenum = cpu_to_le64(root_objectid);
+-	high_crc = btrfs_crc32c(high_crc, &lenum, sizeof(lenum));
++	high_crc = crc32c(high_crc, &lenum, sizeof(lenum));
+ 	lenum = cpu_to_le64(owner);
+-	low_crc = btrfs_crc32c(low_crc, &lenum, sizeof(lenum));
++	low_crc = crc32c(low_crc, &lenum, sizeof(lenum));
+ 	lenum = cpu_to_le64(offset);
+-	low_crc = btrfs_crc32c(low_crc, &lenum, sizeof(lenum));
++	low_crc = crc32c(low_crc, &lenum, sizeof(lenum));
+ 
+ 	return ((u64)high_crc << 31) ^ (u64)low_crc;
+ }
+diff --git a/fs/btrfs/extent_io.c b/fs/btrfs/extent_io.c
+index fab8ffb3a2f827..536c400e5964fb 100644
+--- a/fs/btrfs/extent_io.c
++++ b/fs/btrfs/extent_io.c
+@@ -1921,8 +1921,7 @@ static int submit_eb_page(struct page *page, struct btrfs_eb_write_context *ctx)
+ 	return 1;
+ }
+ 
+-int btree_write_cache_pages(struct address_space *mapping,
+-				   struct writeback_control *wbc)
++int btree_writepages(struct address_space *mapping, struct writeback_control *wbc)
+ {
+ 	struct btrfs_eb_write_context ctx = { .wbc = wbc };
+ 	struct btrfs_fs_info *fs_info = BTRFS_I(mapping->host)->root->fs_info;
+diff --git a/fs/btrfs/extent_io.h b/fs/btrfs/extent_io.h
+index 68368ba99321e1..ee955527f2985c 100644
+--- a/fs/btrfs/extent_io.h
++++ b/fs/btrfs/extent_io.h
+@@ -189,8 +189,7 @@ void extent_write_locked_range(struct inode *inode, struct page *locked_page,
+ 			       bool pages_dirty);
+ int extent_writepages(struct address_space *mapping,
+ 		      struct writeback_control *wbc);
+-int btree_write_cache_pages(struct address_space *mapping,
+-			    struct writeback_control *wbc);
++int btree_writepages(struct address_space *mapping, struct writeback_control *wbc);
+ void extent_readahead(struct readahead_control *rac);
+ int extent_fiemap(struct btrfs_inode *inode, struct fiemap_extent_info *fieinfo,
+ 		  u64 start, u64 len);
+diff --git a/fs/btrfs/file.c b/fs/btrfs/file.c
+index 9ef543db8aab91..8e7108c14de2ce 100644
+--- a/fs/btrfs/file.c
++++ b/fs/btrfs/file.c
+@@ -1514,6 +1514,22 @@ relock:
+ 		btrfs_inode_unlock(BTRFS_I(inode), ilock_flags);
+ 		goto buffered;
+ 	}
++	/*
++	 * We can't control the folios being passed in, applications can write
++	 * to them while a direct IO write is in progress.  This means the
++	 * content might change after we calculated the data checksum.
++	 * Therefore we can end up storing a checksum that doesn't match the
++	 * persisted data.
++	 *
++	 * To be extra safe and avoid false data checksum mismatch, if the
++	 * inode requires data checksum, just fallback to buffered IO.
++	 * For buffered IO we have full control of page cache and can ensure
++	 * no one is modifying the content during writeback.
++	 */
++	if (!(BTRFS_I(inode)->flags & BTRFS_INODE_NODATASUM)) {
++		btrfs_inode_unlock(BTRFS_I(inode), ilock_flags);
++		goto buffered;
++	}
+ 
+ 	/*
+ 	 * The iov_iter can be mapped to the same file range we are writing to.
+diff --git a/fs/btrfs/free-space-cache.c b/fs/btrfs/free-space-cache.c
+index 9a6ec9344c3e06..c6e3b9a2921ab1 100644
+--- a/fs/btrfs/free-space-cache.c
++++ b/fs/btrfs/free-space-cache.c
+@@ -57,6 +57,11 @@ static void bitmap_clear_bits(struct btrfs_free_space_ctl *ctl,
+ 			      struct btrfs_free_space *info, u64 offset,
+ 			      u64 bytes, bool update_stats);
+ 
++static void btrfs_crc32c_final(u32 crc, u8 *result)
++{
++	put_unaligned_le32(~crc, result);
++}
++
+ static void __btrfs_remove_free_space_cache(struct btrfs_free_space_ctl *ctl)
+ {
+ 	struct btrfs_free_space *info;
+@@ -540,7 +545,7 @@ static void io_ctl_set_crc(struct btrfs_io_ctl *io_ctl, int index)
+ 	if (index == 0)
+ 		offset = sizeof(u32) * io_ctl->num_pages;
+ 
+-	crc = btrfs_crc32c(crc, io_ctl->orig + offset, PAGE_SIZE - offset);
++	crc = crc32c(crc, io_ctl->orig + offset, PAGE_SIZE - offset);
+ 	btrfs_crc32c_final(crc, (u8 *)&crc);
+ 	io_ctl_unmap_page(io_ctl);
+ 	tmp = page_address(io_ctl->pages[0]);
+@@ -562,7 +567,7 @@ static int io_ctl_check_crc(struct btrfs_io_ctl *io_ctl, int index)
+ 	val = *tmp;
+ 
+ 	io_ctl_map_page(io_ctl, 0);
+-	crc = btrfs_crc32c(crc, io_ctl->orig + offset, PAGE_SIZE - offset);
++	crc = crc32c(crc, io_ctl->orig + offset, PAGE_SIZE - offset);
+ 	btrfs_crc32c_final(crc, (u8 *)&crc);
+ 	if (val != crc) {
+ 		btrfs_err_rl(io_ctl->fs_info,
+diff --git a/fs/btrfs/fs.h b/fs/btrfs/fs.h
+index d24d41f7811a61..b8b9ce8921baf5 100644
+--- a/fs/btrfs/fs.h
++++ b/fs/btrfs/fs.h
+@@ -371,6 +371,7 @@ struct btrfs_fs_info {
+ 	struct btrfs_root *uuid_root;
+ 	struct btrfs_root *data_reloc_root;
+ 	struct btrfs_root *block_group_root;
++	struct btrfs_root *stripe_root;
+ 
+ 	/* The log root tree is a directory of all the other log roots */
+ 	struct btrfs_root *log_root_tree;
+diff --git a/fs/btrfs/inode-item.h b/fs/btrfs/inode-item.h
+index d43633d5620f29..0f1730dabce6d8 100644
+--- a/fs/btrfs/inode-item.h
++++ b/fs/btrfs/inode-item.h
+@@ -4,6 +4,7 @@
+ #define BTRFS_INODE_ITEM_H
+ 
+ #include <linux/types.h>
++#include <linux/crc32c.h>
+ 
+ struct btrfs_trans_handle;
+ struct btrfs_root;
+@@ -76,6 +77,12 @@ static inline void btrfs_inode_split_flags(u64 inode_item_flags,
+ 	*ro_flags = (u32)(inode_item_flags >> 32);
+ }
+ 
++/* Figure the key offset of an extended inode ref. */
++static inline u64 btrfs_extref_hash(u64 parent_objectid, const char *name, int len)
++{
++       return (u64)crc32c(parent_objectid, name, len);
++}
++
+ int btrfs_truncate_inode_items(struct btrfs_trans_handle *trans,
+ 			       struct btrfs_root *root,
+ 			       struct btrfs_truncate_control *control);
+diff --git a/fs/btrfs/inode.c b/fs/btrfs/inode.c
+index 96edac307408c6..cf39f52fc0484b 100644
+--- a/fs/btrfs/inode.c
++++ b/fs/btrfs/inode.c
+@@ -71,6 +71,7 @@
+ #include "super.h"
+ #include "orphan.h"
+ #include "backref.h"
++#include "raid-stripe-tree.h"
+ 
+ struct btrfs_iget_args {
+ 	u64 ino;
+@@ -3104,6 +3105,10 @@ int btrfs_finish_one_ordered(struct btrfs_ordered_extent *ordered_extent)
+ 
+ 	trans->block_rsv = &inode->block_rsv;
+ 
++	ret = btrfs_insert_raid_extent(trans, ordered_extent);
++	if (ret)
++		goto out;
++
+ 	if (test_bit(BTRFS_ORDERED_COMPRESSED, &ordered_extent->flags))
+ 		compress_type = ordered_extent->compress_type;
+ 	if (test_bit(BTRFS_ORDERED_PREALLOC, &ordered_extent->flags)) {
+@@ -3252,7 +3257,8 @@ out:
+ int btrfs_finish_ordered_io(struct btrfs_ordered_extent *ordered)
+ {
+ 	if (btrfs_is_zoned(btrfs_sb(ordered->inode->i_sb)) &&
+-	    !test_bit(BTRFS_ORDERED_IOERR, &ordered->flags))
++	    !test_bit(BTRFS_ORDERED_IOERR, &ordered->flags) &&
++	    list_empty(&ordered->bioc_list))
+ 		btrfs_finish_ordered_zoned(ordered);
+ 	return btrfs_finish_one_ordered(ordered);
+ }
+@@ -6221,6 +6227,25 @@ int btrfs_create_new_inode(struct btrfs_trans_handle *trans,
+ 	unsigned long ptr;
+ 	int ret;
+ 
++	if (!args->orphan && !args->subvol) {
++		/*
++		 * Before anything else, check if we can add the name to the
++		 * parent directory. We want to avoid a dir item overflow in
++		 * case we have an existing dir item due to existing name
++		 * hash collisions. We do this check here before we call
++		 * btrfs_add_link() down below so that we can avoid a
++		 * transaction abort (which could be exploited by malicious
++		 * users).
++		 *
++		 * For subvolumes we already do this in btrfs_mksubvol().
++		 */
++		ret = btrfs_check_dir_item_collision(BTRFS_I(dir)->root,
++						     btrfs_ino(BTRFS_I(dir)),
++						     name);
++		if (ret < 0)
++			return ret;
++	}
++
+ 	path = btrfs_alloc_path();
+ 	if (!path)
+ 		return -ENOMEM;
+diff --git a/fs/btrfs/ioctl.c b/fs/btrfs/ioctl.c
+index 71e6715efa14cd..a441b49962a3e0 100644
+--- a/fs/btrfs/ioctl.c
++++ b/fs/btrfs/ioctl.c
+@@ -3999,6 +3999,25 @@ static long _btrfs_ioctl_set_received_subvol(struct file *file,
+ 		goto out;
+ 	}
+ 
++	received_uuid_changed = memcmp(root_item->received_uuid, sa->uuid,
++				       BTRFS_UUID_SIZE);
++
++	/*
++	 * Before we attempt to add the new received uuid, check if we have room
++	 * for it in case there's already an item. If the size of the existing
++	 * item plus this root's ID (u64) exceeds the maximum item size, we can
++	 * return here without the need to abort a transaction. If we don't do
++	 * this check, the btrfs_uuid_tree_add() call below would fail with
++	 * -EOVERFLOW and result in a transaction abort. Malicious users could
++	 * exploit this to turn the fs into RO mode.
++	 */
++	if (received_uuid_changed && !btrfs_is_empty_uuid(sa->uuid)) {
++		ret = btrfs_uuid_tree_check_overflow(fs_info, sa->uuid,
++						     BTRFS_UUID_KEY_RECEIVED_SUBVOL);
++		if (ret < 0)
++			goto out;
++	}
++
+ 	/*
+ 	 * 1 - root item
+ 	 * 2 - uuid items (received uuid + subvol uuid)
+@@ -4014,8 +4033,6 @@ static long _btrfs_ioctl_set_received_subvol(struct file *file,
+ 	sa->rtime.sec = ct.tv_sec;
+ 	sa->rtime.nsec = ct.tv_nsec;
+ 
+-	received_uuid_changed = memcmp(root_item->received_uuid, sa->uuid,
+-				       BTRFS_UUID_SIZE);
+ 	if (received_uuid_changed &&
+ 	    !btrfs_is_empty_uuid(root_item->received_uuid)) {
+ 		ret = btrfs_uuid_tree_remove(trans, root_item->received_uuid,
+@@ -4037,7 +4054,8 @@ static long _btrfs_ioctl_set_received_subvol(struct file *file,
+ 
+ 	ret = btrfs_update_root(trans, fs_info->tree_root,
+ 				&root->root_key, &root->root_item);
+-	if (ret < 0) {
++	if (unlikely(ret < 0)) {
++		btrfs_abort_transaction(trans, ret);
+ 		btrfs_end_transaction(trans);
+ 		goto out;
+ 	}
+diff --git a/fs/btrfs/locking.c b/fs/btrfs/locking.c
+index 7979449a58d6b5..51737e73506699 100644
+--- a/fs/btrfs/locking.c
++++ b/fs/btrfs/locking.c
+@@ -73,6 +73,7 @@ static struct btrfs_lockdep_keyset {
+ 	{ .id = BTRFS_UUID_TREE_OBJECTID,	DEFINE_NAME("uuid")	},
+ 	{ .id = BTRFS_FREE_SPACE_TREE_OBJECTID,	DEFINE_NAME("free-space") },
+ 	{ .id = BTRFS_BLOCK_GROUP_TREE_OBJECTID, DEFINE_NAME("block-group") },
++	{ .id = BTRFS_RAID_STRIPE_TREE_OBJECTID, DEFINE_NAME("raid-stripe") },
+ 	{ .id = 0,				DEFINE_NAME("tree")	},
+ };
+ 
+diff --git a/fs/btrfs/ordered-data.c b/fs/btrfs/ordered-data.c
+index c68e9ecbc438cc..e0a2d0cfd5ebe7 100644
+--- a/fs/btrfs/ordered-data.c
++++ b/fs/btrfs/ordered-data.c
+@@ -198,6 +198,7 @@ static struct btrfs_ordered_extent *alloc_ordered_extent(
+ 	INIT_LIST_HEAD(&entry->log_list);
+ 	INIT_LIST_HEAD(&entry->root_extent_list);
+ 	INIT_LIST_HEAD(&entry->work_list);
++	INIT_LIST_HEAD(&entry->bioc_list);
+ 	init_completion(&entry->completion);
+ 
+ 	/*
+diff --git a/fs/btrfs/ordered-data.h b/fs/btrfs/ordered-data.h
+index 173bd5c5df2624..1c51ac57e5dfde 100644
+--- a/fs/btrfs/ordered-data.h
++++ b/fs/btrfs/ordered-data.h
+@@ -151,6 +151,8 @@ struct btrfs_ordered_extent {
+ 	struct completion completion;
+ 	struct btrfs_work flush_work;
+ 	struct list_head work_list;
++
++	struct list_head bioc_list;
+ };
+ 
+ static inline void
+diff --git a/fs/btrfs/raid-stripe-tree.c b/fs/btrfs/raid-stripe-tree.c
+new file mode 100644
+index 00000000000000..c093e0bbb7be35
+--- /dev/null
++++ b/fs/btrfs/raid-stripe-tree.c
+@@ -0,0 +1,87 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2023 Western Digital Corporation or its affiliates.
++ */
++
++#include <linux/btrfs_tree.h>
++#include "ctree.h"
++#include "fs.h"
++#include "accessors.h"
++#include "transaction.h"
++#include "disk-io.h"
++#include "raid-stripe-tree.h"
++#include "volumes.h"
++#include "misc.h"
++#include "print-tree.h"
++
++static int btrfs_insert_one_raid_extent(struct btrfs_trans_handle *trans,
++					struct btrfs_io_context *bioc)
++{
++	struct btrfs_fs_info *fs_info = trans->fs_info;
++	struct btrfs_key stripe_key;
++	struct btrfs_root *stripe_root = fs_info->stripe_root;
++	const int num_stripes = btrfs_bg_type_to_factor(bioc->map_type);
++	u8 encoding = btrfs_bg_flags_to_raid_index(bioc->map_type);
++	struct btrfs_stripe_extent *stripe_extent;
++	const size_t item_size = struct_size(stripe_extent, strides, num_stripes);
++	int ret;
++
++	stripe_extent = kzalloc(item_size, GFP_NOFS);
++	if (!stripe_extent) {
++		btrfs_abort_transaction(trans, -ENOMEM);
++		btrfs_end_transaction(trans);
++		return -ENOMEM;
++	}
++
++	btrfs_set_stack_stripe_extent_encoding(stripe_extent, encoding);
++	for (int i = 0; i < num_stripes; i++) {
++		u64 devid = bioc->stripes[i].dev->devid;
++		u64 physical = bioc->stripes[i].physical;
++		u64 length = bioc->stripes[i].length;
++		struct btrfs_raid_stride *raid_stride = &stripe_extent->strides[i];
++
++		if (length == 0)
++			length = bioc->size;
++
++		btrfs_set_stack_raid_stride_devid(raid_stride, devid);
++		btrfs_set_stack_raid_stride_physical(raid_stride, physical);
++	}
++
++	stripe_key.objectid = bioc->logical;
++	stripe_key.type = BTRFS_RAID_STRIPE_KEY;
++	stripe_key.offset = bioc->size;
++
++	ret = btrfs_insert_item(trans, stripe_root, &stripe_key, stripe_extent,
++				item_size);
++	if (ret)
++		btrfs_abort_transaction(trans, ret);
++
++	kfree(stripe_extent);
++
++	return ret;
++}
++
++int btrfs_insert_raid_extent(struct btrfs_trans_handle *trans,
++			     struct btrfs_ordered_extent *ordered_extent)
++{
++	struct btrfs_io_context *bioc;
++	int ret;
++
++	if (!btrfs_fs_incompat(trans->fs_info, RAID_STRIPE_TREE))
++		return 0;
++
++	list_for_each_entry(bioc, &ordered_extent->bioc_list, rst_ordered_entry) {
++		ret = btrfs_insert_one_raid_extent(trans, bioc);
++		if (ret)
++			return ret;
++	}
++
++	while (!list_empty(&ordered_extent->bioc_list)) {
++		bioc = list_first_entry(&ordered_extent->bioc_list,
++					typeof(*bioc), rst_ordered_entry);
++		list_del(&bioc->rst_ordered_entry);
++		btrfs_put_bioc(bioc);
++	}
++
++	return ret;
++}
+diff --git a/fs/btrfs/raid-stripe-tree.h b/fs/btrfs/raid-stripe-tree.h
+new file mode 100644
+index 00000000000000..7a169e75ad6df9
+--- /dev/null
++++ b/fs/btrfs/raid-stripe-tree.h
+@@ -0,0 +1,35 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2023 Western Digital Corporation or its affiliates.
++ */
++
++#ifndef BTRFS_RAID_STRIPE_TREE_H
++#define BTRFS_RAID_STRIPE_TREE_H
++
++struct btrfs_io_context;
++struct btrfs_io_stripe;
++struct btrfs_ordered_extent;
++struct btrfs_trans_handle;
++
++int btrfs_insert_raid_extent(struct btrfs_trans_handle *trans,
++			     struct btrfs_ordered_extent *ordered_extent);
++
++static inline bool btrfs_need_stripe_tree_update(struct btrfs_fs_info *fs_info,
++						 u64 map_type)
++{
++	u64 type = map_type & BTRFS_BLOCK_GROUP_TYPE_MASK;
++	u64 profile = map_type & BTRFS_BLOCK_GROUP_PROFILE_MASK;
++
++	if (!btrfs_fs_incompat(fs_info, RAID_STRIPE_TREE))
++		return false;
++
++	if (type != BTRFS_BLOCK_GROUP_DATA)
++		return false;
++
++	if (profile & BTRFS_BLOCK_GROUP_RAID1_MASK)
++		return true;
++
++	return false;
++}
++
++#endif
+diff --git a/fs/btrfs/scrub.c b/fs/btrfs/scrub.c
+index 3338e2e7a9a026..d2d2548eea05a6 100644
+--- a/fs/btrfs/scrub.c
++++ b/fs/btrfs/scrub.c
+@@ -635,7 +635,7 @@ static void scrub_verify_one_metadata(struct scrub_stripe *stripe, int sector_nr
+ 		btrfs_warn_rl(fs_info,
+ 		"tree block %llu mirror %u has bad fsid, has %pU want %pU",
+ 			      logical, stripe->mirror_num,
+-			      header->fsid, fs_info->fs_devices->fsid);
++			      header->fsid, fs_info->fs_devices->metadata_uuid);
+ 		return;
+ 	}
+ 	if (memcmp(header->chunk_tree_uuid, fs_info->chunk_tree_uuid,
+diff --git a/fs/btrfs/send.c b/fs/btrfs/send.c
+index 6768e2231d6101..4fa05ee81d4344 100644
+--- a/fs/btrfs/send.c
++++ b/fs/btrfs/send.c
+@@ -814,7 +814,7 @@ static int send_cmd(struct send_ctx *sctx)
+ 	put_unaligned_le32(sctx->send_size - sizeof(*hdr), &hdr->len);
+ 	put_unaligned_le32(0, &hdr->crc);
+ 
+-	crc = btrfs_crc32c(0, (unsigned char *)sctx->send_buf, sctx->send_size);
++	crc = crc32c(0, (unsigned char *)sctx->send_buf, sctx->send_size);
+ 	put_unaligned_le32(crc, &hdr->crc);
+ 
+ 	ret = write_buf(sctx->send_filp, sctx->send_buf, sctx->send_size,
+@@ -5740,8 +5740,8 @@ static int send_encoded_extent(struct send_ctx *sctx, struct btrfs_path *path,
+ 	hdr = (struct btrfs_cmd_header *)sctx->send_buf;
+ 	hdr->len = cpu_to_le32(sctx->send_size + disk_num_bytes - sizeof(*hdr));
+ 	hdr->crc = 0;
+-	crc = btrfs_crc32c(0, sctx->send_buf, sctx->send_size);
+-	crc = btrfs_crc32c(crc, sctx->send_buf + data_offset, disk_num_bytes);
++	crc = crc32c(0, sctx->send_buf, sctx->send_size);
++	crc = crc32c(crc, sctx->send_buf + data_offset, disk_num_bytes);
+ 	hdr->crc = cpu_to_le32(crc);
+ 
+ 	ret = write_buf(sctx->send_filp, sctx->send_buf, sctx->send_size,
+diff --git a/fs/btrfs/transaction.c b/fs/btrfs/transaction.c
+index 6dbbb03be562f5..8de686b83adbf2 100644
+--- a/fs/btrfs/transaction.c
++++ b/fs/btrfs/transaction.c
+@@ -1877,6 +1877,22 @@ static noinline int create_pending_snapshot(struct btrfs_trans_handle *trans,
+ 		ret = btrfs_uuid_tree_add(trans, new_root_item->received_uuid,
+ 					  BTRFS_UUID_KEY_RECEIVED_SUBVOL,
+ 					  objectid);
++		/*
++		 * We are creating of lot of snapshots of the same root that was
++		 * received (has a received UUID) and reached a leaf's limit for
++		 * an item. We can safely ignore this and avoid a transaction
++		 * abort. A deletion of this snapshot will still work since we
++		 * ignore if an item with a BTRFS_UUID_KEY_RECEIVED_SUBVOL key
++		 * is missing (see btrfs_delete_subvolume()). Send/receive will
++		 * work too since it peeks the first root id from the existing
++		 * item (it could peek any), and in case it's missing it
++		 * falls back to search by BTRFS_UUID_KEY_SUBVOL keys.
++		 * Creation of a snapshot does not require CAP_SYS_ADMIN, so
++		 * we don't want users triggering transaction aborts, either
++		 * intentionally or not.
++		 */
++		if (ret == -EOVERFLOW)
++			ret = 0;
+ 		if (ret && ret != -EEXIST) {
+ 			btrfs_abort_transaction(trans, ret);
+ 			goto fail;
+diff --git a/fs/btrfs/tree-checker.c b/fs/btrfs/tree-checker.c
+index 0d93368c1691ae..d2c36b765c83a1 100644
+--- a/fs/btrfs/tree-checker.c
++++ b/fs/btrfs/tree-checker.c
+@@ -1220,7 +1220,7 @@ static int check_root_item(struct extent_buffer *leaf, struct btrfs_key *key,
+ 	}
+ 	if (unlikely(btrfs_root_drop_level(&ri) >= BTRFS_MAX_LEVEL)) {
+ 		generic_err(leaf, slot,
+-			    "invalid root level, have %u expect [0, %u]",
++			    "invalid root drop_level, have %u expect [0, %u]",
+ 			    btrfs_root_drop_level(&ri), BTRFS_MAX_LEVEL - 1);
+ 		return -EUCLEAN;
+ 	}
+@@ -1673,7 +1673,7 @@ static int check_extent_data_ref(struct extent_buffer *leaf,
+ 			     objectid > BTRFS_LAST_FREE_OBJECTID)) {
+ 			extent_err(leaf, slot,
+ 				   "invalid extent data backref objectid value %llu",
+-				   root);
++				   objectid);
+ 			return -EUCLEAN;
+ 		}
+ 		if (unlikely(!IS_ALIGNED(offset, leaf->fs_info->sectorsize))) {
+@@ -1802,7 +1802,7 @@ static int check_dev_extent_item(const struct extent_buffer *leaf,
+ 		if (unlikely(prev_key->offset + prev_len > key->offset)) {
+ 			generic_err(leaf, slot,
+ 		"dev extent overlap, prev offset %llu len %llu current offset %llu",
+-				    prev_key->objectid, prev_len, key->offset);
++				    prev_key->offset, prev_len, key->offset);
+ 			return -EUCLEAN;
+ 		}
+ 	}
+diff --git a/fs/btrfs/tree-log.c b/fs/btrfs/tree-log.c
+index 882bb3c04c23f0..c77852dc32399e 100644
+--- a/fs/btrfs/tree-log.c
++++ b/fs/btrfs/tree-log.c
+@@ -5856,6 +5856,7 @@ static int log_conflicting_inodes(struct btrfs_trans_handle *trans,
+ 				  struct btrfs_root *root,
+ 				  struct btrfs_log_ctx *ctx)
+ {
++	const bool orig_log_new_dentries = ctx->log_new_dentries;
+ 	int ret = 0;
+ 
+ 	/*
+@@ -5917,7 +5918,11 @@ static int log_conflicting_inodes(struct btrfs_trans_handle *trans,
+ 			 * dir index key range logged for the directory. So we
+ 			 * must make sure the deletion is recorded.
+ 			 */
++			ctx->log_new_dentries = false;
+ 			ret = btrfs_log_inode(trans, inode, LOG_INODE_ALL, ctx);
++			if (!ret && ctx->log_new_dentries)
++				ret = log_new_dir_dentries(trans, inode, ctx);
++
+ 			btrfs_add_delayed_iput(inode);
+ 			if (ret)
+ 				break;
+@@ -5952,6 +5957,7 @@ static int log_conflicting_inodes(struct btrfs_trans_handle *trans,
+ 			break;
+ 	}
+ 
++	ctx->log_new_dentries = orig_log_new_dentries;
+ 	ctx->logging_conflict_inodes = false;
+ 	if (ret)
+ 		free_conflicting_inodes(ctx);
+diff --git a/fs/btrfs/uuid-tree.c b/fs/btrfs/uuid-tree.c
+index 5be74f9e47ebf3..0987fdcaea68c1 100644
+--- a/fs/btrfs/uuid-tree.c
++++ b/fs/btrfs/uuid-tree.c
+@@ -228,6 +228,49 @@ out:
+ 	return ret;
+ }
+ 
++/*
++ * Check if we can add one root ID to a UUID key.
++ * If the key does not yet exists, we can, otherwise only if extended item does
++ * not exceeds the maximum item size permitted by the leaf size.
++ *
++ * Returns 0 on success, negative value on error.
++ */
++int btrfs_uuid_tree_check_overflow(struct btrfs_fs_info *fs_info,
++				   u8 *uuid, u8 type)
++{
++	struct btrfs_path *path;
++	int ret;
++	u32 item_size;
++	struct btrfs_key key;
++
++	if (WARN_ON_ONCE(!fs_info->uuid_root))
++		return -EINVAL;
++
++	path = btrfs_alloc_path();
++	if (!path)
++		return -ENOMEM;
++
++	btrfs_uuid_to_key(uuid, type, &key);
++	ret = btrfs_search_slot(NULL, fs_info->uuid_root, &key, path, 0, 0);
++	if (ret < 0) {
++		btrfs_free_path(path);
++		return ret;
++	}
++	if (ret > 0) {
++		btrfs_free_path(path);
++		return 0;
++	}
++
++	item_size = btrfs_item_size(path->nodes[0], path->slots[0]);
++	btrfs_free_path(path);
++
++	if (sizeof(struct btrfs_item) + item_size + sizeof(u64) >
++	    BTRFS_LEAF_DATA_SIZE(fs_info))
++		return -EOVERFLOW;
++
++	return 0;
++}
++
+ static int btrfs_uuid_iter_rem(struct btrfs_root *uuid_root, u8 *uuid, u8 type,
+ 			       u64 subid)
+ {
+diff --git a/fs/btrfs/uuid-tree.h b/fs/btrfs/uuid-tree.h
+index 5350c87fe2caf3..29e7b76c64621a 100644
+--- a/fs/btrfs/uuid-tree.h
++++ b/fs/btrfs/uuid-tree.h
+@@ -7,6 +7,8 @@ int btrfs_uuid_tree_add(struct btrfs_trans_handle *trans, u8 *uuid, u8 type,
+ 			u64 subid);
+ int btrfs_uuid_tree_remove(struct btrfs_trans_handle *trans, u8 *uuid, u8 type,
+ 			u64 subid);
++int btrfs_uuid_tree_check_overflow(struct btrfs_fs_info *fs_info,
++				   u8 *uuid, u8 type);
+ int btrfs_uuid_tree_iterate(struct btrfs_fs_info *fs_info);
+ 
+ #endif
+diff --git a/fs/btrfs/volumes.c b/fs/btrfs/volumes.c
+index 6ce083a6ed61ff..23756f1464013d 100644
+--- a/fs/btrfs/volumes.c
++++ b/fs/btrfs/volumes.c
+@@ -5943,6 +5943,7 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
+ }
+ 
+ static struct btrfs_io_context *alloc_btrfs_io_context(struct btrfs_fs_info *fs_info,
++						       u64 logical,
+ 						       u16 total_stripes)
+ {
+ 	struct btrfs_io_context *bioc;
+@@ -5962,6 +5963,7 @@ static struct btrfs_io_context *alloc_btrfs_io_context(struct btrfs_fs_info *fs_
+ 	bioc->fs_info = fs_info;
+ 	bioc->replace_stripe_src = -1;
+ 	bioc->full_stripe_logical = (u64)-1;
++	bioc->logical = logical;
+ 
+ 	return bioc;
+ }
+@@ -6498,7 +6500,7 @@ int btrfs_map_block(struct btrfs_fs_info *fs_info, enum btrfs_map_op op,
+ 		goto out;
+ 	}
+ 
+-	bioc = alloc_btrfs_io_context(fs_info, num_alloc_stripes);
++	bioc = alloc_btrfs_io_context(fs_info, logical, num_alloc_stripes);
+ 	if (!bioc) {
+ 		ret = -ENOMEM;
+ 		goto out;
+diff --git a/fs/btrfs/volumes.h b/fs/btrfs/volumes.h
+index 5203095318b027..c6c5253bf50640 100644
+--- a/fs/btrfs/volumes.h
++++ b/fs/btrfs/volumes.h
+@@ -387,12 +387,11 @@ struct btrfs_fs_devices {
+ 
+ struct btrfs_io_stripe {
+ 	struct btrfs_device *dev;
+-	union {
+-		/* Block mapping */
+-		u64 physical;
+-		/* For the endio handler */
+-		struct btrfs_io_context *bioc;
+-	};
++	/* Block mapping. */
++	u64 physical;
++	u64 length;
++	/* For the endio handler. */
++	struct btrfs_io_context *bioc;
+ };
+ 
+ struct btrfs_discard_stripe {
+@@ -425,6 +424,11 @@ struct btrfs_io_context {
+ 	atomic_t error;
+ 	u16 max_errors;
+ 
++	u64 logical;
++	u64 size;
++	/* Raid stripe tree ordered entry. */
++	struct list_head rst_ordered_entry;
++
+ 	/*
+ 	 * The total number of stripes, including the extra duplicated
+ 	 * stripe for replace.
+diff --git a/fs/ceph/dir.c b/fs/ceph/dir.c
+index 529dd07fa459f1..cc448470fd9b9b 100644
+--- a/fs/ceph/dir.c
++++ b/fs/ceph/dir.c
+@@ -1292,6 +1292,7 @@ static int ceph_unlink(struct inode *dir, struct dentry *dentry)
+ 	struct ceph_fs_client *fsc = ceph_sb_to_fs_client(dir->i_sb);
+ 	struct ceph_mds_client *mdsc = fsc->mdsc;
+ 	struct inode *inode = d_inode(dentry);
++	struct ceph_inode_info *ci = ceph_inode(inode);
+ 	struct ceph_mds_request *req;
+ 	bool try_async = ceph_test_mount_opt(fsc, ASYNC_DIROPS);
+ 	int err = -EROFS;
+@@ -1349,7 +1350,19 @@ retry:
+ 			 * We have enough caps, so we assume that the unlink
+ 			 * will succeed. Fix up the target inode and dcache.
+ 			 */
+-			drop_nlink(inode);
++
++			/*
++			 * Protect the i_nlink update with i_ceph_lock
++			 * to precent racing against ceph_fill_inode()
++			 * handling our completion on a worker thread
++			 * and don't decrement if i_nlink has already
++			 * been updated to zero by this completion.
++			 */
++			spin_lock(&ci->i_ceph_lock);
++			if (inode->i_nlink > 0)
++				drop_nlink(inode);
++			spin_unlock(&ci->i_ceph_lock);
++
+ 			d_delete(dentry);
+ 		} else {
+ 			spin_lock(&fsc->async_unlink_conflict_lock);
+diff --git a/fs/ceph/mds_client.c b/fs/ceph/mds_client.c
+index dfa1b3c82b53ac..50d5cb85332bec 100644
+--- a/fs/ceph/mds_client.c
++++ b/fs/ceph/mds_client.c
+@@ -2672,6 +2672,7 @@ retry:
+ 			if (ret < 0) {
+ 				dput(parent);
+ 				dput(cur);
++				__putname(path);
+ 				return ERR_PTR(ret);
+ 			}
+ 
+@@ -2681,6 +2682,7 @@ retry:
+ 				if (len < 0) {
+ 					dput(parent);
+ 					dput(cur);
++					__putname(path);
+ 					return ERR_PTR(len);
+ 				}
+ 			}
+@@ -2717,6 +2719,7 @@ retry:
+ 		 * cannot ever succeed.  Creating paths that long is
+ 		 * possible with Ceph, but Linux cannot use them.
+ 		 */
++		__putname(path);
+ 		return ERR_PTR(-ENAMETOOLONG);
+ 	}
+ 
+diff --git a/fs/eventpoll.c b/fs/eventpoll.c
+index 1e80a9b1d1263f..3c6c646fb3c49c 100644
+--- a/fs/eventpoll.c
++++ b/fs/eventpoll.c
+@@ -1907,7 +1907,8 @@ static int ep_poll(struct eventpoll *ep, struct epoll_event __user *events,
+  * @ep: the &struct eventpoll to be currently checked.
+  * @depth: Current depth of the path being checked.
+  *
+- * Return: depth of the subtree, or INT_MAX if we found a loop or went too deep.
++ * Return: depth of the subtree, or a value bigger than EP_MAX_NESTS if we found
++ * a loop or went too deep.
+  */
+ static int ep_loop_check_proc(struct eventpoll *ep, int depth)
+ {
+@@ -1926,7 +1927,7 @@ static int ep_loop_check_proc(struct eventpoll *ep, int depth)
+ 			struct eventpoll *ep_tovisit;
+ 			ep_tovisit = epi->ffd.file->private_data;
+ 			if (ep_tovisit == inserting_into || depth > EP_MAX_NESTS)
+-				result = INT_MAX;
++				result = EP_MAX_NESTS+1;
+ 			else
+ 				result = max(result, ep_loop_check_proc(ep_tovisit, depth + 1) + 1);
+ 			if (result > EP_MAX_NESTS)
+diff --git a/fs/ext4/ext4.h b/fs/ext4/ext4.h
+index 85ba12a48f26a9..ce8bd312c1b842 100644
+--- a/fs/ext4/ext4.h
++++ b/fs/ext4/ext4.h
+@@ -3708,11 +3708,12 @@ extern int ext4_map_blocks(handle_t *handle, struct inode *inode,
+ extern int ext4_ext_calc_credits_for_single_extent(struct inode *inode,
+ 						   int num,
+ 						   struct ext4_ext_path *path);
+-extern int ext4_ext_insert_extent(handle_t *, struct inode *,
+-				  struct ext4_ext_path **,
+-				  struct ext4_extent *, int);
++extern struct ext4_ext_path *ext4_ext_insert_extent(
++				handle_t *handle, struct inode *inode,
++				struct ext4_ext_path *path,
++				struct ext4_extent *newext, int gb_flags);
+ extern struct ext4_ext_path *ext4_find_extent(struct inode *, ext4_lblk_t,
+-					      struct ext4_ext_path **,
++					      struct ext4_ext_path *,
+ 					      int flags);
+ extern void ext4_free_ext_path(struct ext4_ext_path *);
+ extern int ext4_ext_check_inode(struct inode *inode);
+diff --git a/fs/ext4/extents.c b/fs/ext4/extents.c
+index 8d9cd6574d3265..b7e9cbe832121f 100644
+--- a/fs/ext4/extents.c
++++ b/fs/ext4/extents.c
+@@ -43,8 +43,13 @@
+ #define EXT4_EXT_MARK_UNWRIT1	0x2  /* mark first half unwritten */
+ #define EXT4_EXT_MARK_UNWRIT2	0x4  /* mark second half unwritten */
+ 
+-#define EXT4_EXT_DATA_VALID1	0x8  /* first half contains valid data */
+-#define EXT4_EXT_DATA_VALID2	0x10 /* second half contains valid data */
++/* first half contains valid data */
++#define EXT4_EXT_DATA_ENTIRE_VALID1	0x8   /* has entirely valid data */
++#define EXT4_EXT_DATA_PARTIAL_VALID1	0x10  /* has partially valid data */
++#define EXT4_EXT_DATA_VALID1		(EXT4_EXT_DATA_ENTIRE_VALID1 | \
++					 EXT4_EXT_DATA_PARTIAL_VALID1)
++
++#define EXT4_EXT_DATA_VALID2	0x20 /* second half contains valid data */
+ 
+ static __le32 ext4_extent_block_csum(struct inode *inode,
+ 				     struct ext4_extent_header *eh)
+@@ -84,12 +89,11 @@ static void ext4_extent_block_csum_set(struct inode *inode,
+ 	et->et_checksum = ext4_extent_block_csum(inode, eh);
+ }
+ 
+-static int ext4_split_extent_at(handle_t *handle,
+-			     struct inode *inode,
+-			     struct ext4_ext_path **ppath,
+-			     ext4_lblk_t split,
+-			     int split_flag,
+-			     int flags);
++static struct ext4_ext_path *ext4_split_extent_at(handle_t *handle,
++						  struct inode *inode,
++						  struct ext4_ext_path *path,
++						  ext4_lblk_t split,
++						  int split_flag, int flags);
+ 
+ static int ext4_ext_trunc_restart_fn(struct inode *inode, int *dropped)
+ {
+@@ -335,9 +339,15 @@ ext4_force_split_extent_at(handle_t *handle, struct inode *inode,
+ 	if (nofail)
+ 		flags |= EXT4_GET_BLOCKS_METADATA_NOFAIL | EXT4_EX_NOFAIL;
+ 
+-	return ext4_split_extent_at(handle, inode, ppath, lblk, unwritten ?
++	path = ext4_split_extent_at(handle, inode, path, lblk, unwritten ?
+ 			EXT4_EXT_MARK_UNWRIT1|EXT4_EXT_MARK_UNWRIT2 : 0,
+ 			flags);
++	if (IS_ERR(path)) {
++		*ppath = NULL;
++		return PTR_ERR(path);
++	}
++	*ppath = path;
++	return 0;
+ }
+ 
+ static int
+@@ -689,7 +699,7 @@ static void ext4_ext_show_leaf(struct inode *inode, struct ext4_ext_path *path)
+ 	struct ext4_extent *ex;
+ 	int i;
+ 
+-	if (!path)
++	if (IS_ERR_OR_NULL(path))
+ 		return;
+ 
+ 	eh = path[depth].p_hdr;
+@@ -881,11 +891,10 @@ void ext4_ext_tree_init(handle_t *handle, struct inode *inode)
+ 
+ struct ext4_ext_path *
+ ext4_find_extent(struct inode *inode, ext4_lblk_t block,
+-		 struct ext4_ext_path **orig_path, int flags)
++		 struct ext4_ext_path *path, int flags)
+ {
+ 	struct ext4_extent_header *eh;
+ 	struct buffer_head *bh;
+-	struct ext4_ext_path *path = orig_path ? *orig_path : NULL;
+ 	short int depth, i, ppos = 0;
+ 	int ret;
+ 	gfp_t gfp_flags = GFP_NOFS;
+@@ -906,7 +915,7 @@ ext4_find_extent(struct inode *inode, ext4_lblk_t block,
+ 		ext4_ext_drop_refs(path);
+ 		if (depth > path[0].p_maxdepth) {
+ 			kfree(path);
+-			*orig_path = path = NULL;
++			path = NULL;
+ 		}
+ 	}
+ 	if (!path) {
+@@ -957,14 +966,10 @@ ext4_find_extent(struct inode *inode, ext4_lblk_t block,
+ 
+ 	ext4_ext_show_path(inode, path);
+ 
+-	if (orig_path)
+-		*orig_path = path;
+ 	return path;
+ 
+ err:
+ 	ext4_free_ext_path(path);
+-	if (orig_path)
+-		*orig_path = NULL;
+ 	return ERR_PTR(ret);
+ }
+ 
+@@ -1397,13 +1402,12 @@ out:
+  * finds empty index and adds new leaf.
+  * if no free index is found, then it requests in-depth growing.
+  */
+-static int ext4_ext_create_new_leaf(handle_t *handle, struct inode *inode,
+-				    unsigned int mb_flags,
+-				    unsigned int gb_flags,
+-				    struct ext4_ext_path **ppath,
+-				    struct ext4_extent *newext)
++static struct ext4_ext_path *
++ext4_ext_create_new_leaf(handle_t *handle, struct inode *inode,
++			 unsigned int mb_flags, unsigned int gb_flags,
++			 struct ext4_ext_path *path,
++			 struct ext4_extent *newext)
+ {
+-	struct ext4_ext_path *path = *ppath;
+ 	struct ext4_ext_path *curp;
+ 	int depth, i, err = 0;
+ 
+@@ -1424,28 +1428,25 @@ repeat:
+ 		 * entry: create all needed subtree and add new leaf */
+ 		err = ext4_ext_split(handle, inode, mb_flags, path, newext, i);
+ 		if (err)
+-			goto out;
++			goto errout;
+ 
+ 		/* refill path */
+ 		path = ext4_find_extent(inode,
+ 				    (ext4_lblk_t)le32_to_cpu(newext->ee_block),
+-				    ppath, gb_flags);
+-		if (IS_ERR(path))
+-			err = PTR_ERR(path);
++				    path, gb_flags);
++		return path;
+ 	} else {
+ 		/* tree is full, time to grow in depth */
+ 		err = ext4_ext_grow_indepth(handle, inode, mb_flags);
+ 		if (err)
+-			goto out;
++			goto errout;
+ 
+ 		/* refill path */
+ 		path = ext4_find_extent(inode,
+ 				   (ext4_lblk_t)le32_to_cpu(newext->ee_block),
+-				    ppath, gb_flags);
+-		if (IS_ERR(path)) {
+-			err = PTR_ERR(path);
+-			goto out;
+-		}
++				    path, gb_flags);
++		if (IS_ERR(path))
++			return path;
+ 
+ 		/*
+ 		 * only first (depth 0 -> 1) produces free space;
+@@ -1457,9 +1458,11 @@ repeat:
+ 			goto repeat;
+ 		}
+ 	}
++	return path;
+ 
+-out:
+-	return err;
++errout:
++	ext4_free_ext_path(path);
++	return ERR_PTR(err);
+ }
+ 
+ /*
+@@ -1967,16 +1970,15 @@ out:
+  * inserts requested extent as new one into the tree,
+  * creating new leaf in the no-space case.
+  */
+-int ext4_ext_insert_extent(handle_t *handle, struct inode *inode,
+-				struct ext4_ext_path **ppath,
+-				struct ext4_extent *newext, int gb_flags)
++struct ext4_ext_path *
++ext4_ext_insert_extent(handle_t *handle, struct inode *inode,
++		       struct ext4_ext_path *path,
++		       struct ext4_extent *newext, int gb_flags)
+ {
+-	struct ext4_ext_path *path = *ppath;
+ 	struct ext4_extent_header *eh;
+ 	struct ext4_extent *ex, *fex;
+ 	struct ext4_extent *nearex; /* nearest extent */
+-	struct ext4_ext_path *npath = NULL;
+-	int depth, len, err;
++	int depth, len, err = 0;
+ 	ext4_lblk_t next;
+ 	int mb_flags = 0, unwritten;
+ 
+@@ -1984,14 +1986,16 @@ int ext4_ext_insert_extent(handle_t *handle, struct inode *inode,
+ 		mb_flags |= EXT4_MB_DELALLOC_RESERVED;
+ 	if (unlikely(ext4_ext_get_actual_len(newext) == 0)) {
+ 		EXT4_ERROR_INODE(inode, "ext4_ext_get_actual_len(newext) == 0");
+-		return -EFSCORRUPTED;
++		err = -EFSCORRUPTED;
++		goto errout;
+ 	}
+ 	depth = ext_depth(inode);
+ 	ex = path[depth].p_ext;
+ 	eh = path[depth].p_hdr;
+ 	if (unlikely(path[depth].p_hdr == NULL)) {
+ 		EXT4_ERROR_INODE(inode, "path[%d].p_hdr == NULL", depth);
+-		return -EFSCORRUPTED;
++		err = -EFSCORRUPTED;
++		goto errout;
+ 	}
+ 
+ 	/* try to insert block into found extent and return */
+@@ -2029,7 +2033,7 @@ int ext4_ext_insert_extent(handle_t *handle, struct inode *inode,
+ 			err = ext4_ext_get_access(handle, inode,
+ 						  path + depth);
+ 			if (err)
+-				return err;
++				goto errout;
+ 			unwritten = ext4_ext_is_unwritten(ex);
+ 			ex->ee_len = cpu_to_le16(ext4_ext_get_actual_len(ex)
+ 					+ ext4_ext_get_actual_len(newext));
+@@ -2054,7 +2058,7 @@ prepend:
+ 			err = ext4_ext_get_access(handle, inode,
+ 						  path + depth);
+ 			if (err)
+-				return err;
++				goto errout;
+ 
+ 			unwritten = ext4_ext_is_unwritten(ex);
+ 			ex->ee_block = newext->ee_block;
+@@ -2079,21 +2083,26 @@ prepend:
+ 	if (le32_to_cpu(newext->ee_block) > le32_to_cpu(fex->ee_block))
+ 		next = ext4_ext_next_leaf_block(path);
+ 	if (next != EXT_MAX_BLOCKS) {
++		struct ext4_ext_path *npath;
++
+ 		ext_debug(inode, "next leaf block - %u\n", next);
+-		BUG_ON(npath != NULL);
+ 		npath = ext4_find_extent(inode, next, NULL, gb_flags);
+-		if (IS_ERR(npath))
+-			return PTR_ERR(npath);
++		if (IS_ERR(npath)) {
++			err = PTR_ERR(npath);
++			goto errout;
++		}
+ 		BUG_ON(npath->p_depth != path->p_depth);
+ 		eh = npath[depth].p_hdr;
+ 		if (le16_to_cpu(eh->eh_entries) < le16_to_cpu(eh->eh_max)) {
+ 			ext_debug(inode, "next leaf isn't full(%d)\n",
+ 				  le16_to_cpu(eh->eh_entries));
++			ext4_free_ext_path(path);
+ 			path = npath;
+ 			goto has_space;
+ 		}
+ 		ext_debug(inode, "next leaf has no free space(%d,%d)\n",
+ 			  le16_to_cpu(eh->eh_entries), le16_to_cpu(eh->eh_max));
++		ext4_free_ext_path(npath);
+ 	}
+ 
+ 	/*
+@@ -2102,11 +2111,10 @@ prepend:
+ 	 */
+ 	if (gb_flags & EXT4_GET_BLOCKS_METADATA_NOFAIL)
+ 		mb_flags |= EXT4_MB_USE_RESERVED;
+-	err = ext4_ext_create_new_leaf(handle, inode, mb_flags, gb_flags,
+-				       ppath, newext);
+-	if (err)
+-		goto cleanup;
+-	path = *ppath;
++	path = ext4_ext_create_new_leaf(handle, inode, mb_flags, gb_flags,
++					path, newext);
++	if (IS_ERR(path))
++		return path;
+ 	depth = ext_depth(inode);
+ 	eh = path[depth].p_hdr;
+ 
+@@ -2115,7 +2123,7 @@ has_space:
+ 
+ 	err = ext4_ext_get_access(handle, inode, path + depth);
+ 	if (err)
+-		goto cleanup;
++		goto errout;
+ 
+ 	if (!nearex) {
+ 		/* there is no extent in this leaf, create first one */
+@@ -2173,17 +2181,20 @@ merge:
+ 	if (!(gb_flags & EXT4_GET_BLOCKS_PRE_IO))
+ 		ext4_ext_try_to_merge(handle, inode, path, nearex);
+ 
+-
+ 	/* time to correct all indexes above */
+ 	err = ext4_ext_correct_indexes(handle, inode, path);
+ 	if (err)
+-		goto cleanup;
++		goto errout;
+ 
+ 	err = ext4_ext_dirty(handle, inode, path + path->p_depth);
++	if (err)
++		goto errout;
+ 
+-cleanup:
+-	ext4_free_ext_path(npath);
+-	return err;
++	return path;
++
++errout:
++	ext4_free_ext_path(path);
++	return ERR_PTR(err);
+ }
+ 
+ static int ext4_fill_es_cache_info(struct inode *inode,
+@@ -3152,16 +3163,14 @@ static int ext4_ext_zeroout(struct inode *inode, struct ext4_extent *ex)
+  *  a> the extent are splitted into two extent.
+  *  b> split is not needed, and just mark the extent.
+  *
+- * return 0 on success.
++ * Return an extent path pointer on success, or an error pointer on failure.
+  */
+-static int ext4_split_extent_at(handle_t *handle,
+-			     struct inode *inode,
+-			     struct ext4_ext_path **ppath,
+-			     ext4_lblk_t split,
+-			     int split_flag,
+-			     int flags)
++static struct ext4_ext_path *ext4_split_extent_at(handle_t *handle,
++						  struct inode *inode,
++						  struct ext4_ext_path *path,
++						  ext4_lblk_t split,
++						  int split_flag, int flags)
+ {
+-	struct ext4_ext_path *path = *ppath;
+ 	ext4_fsblk_t newblock;
+ 	ext4_lblk_t ee_block;
+ 	struct ext4_extent *ex, newex, orig_ex, zero_ex;
+@@ -3169,8 +3178,9 @@ static int ext4_split_extent_at(handle_t *handle,
+ 	unsigned int ee_len, depth;
+ 	int err = 0;
+ 
+-	BUG_ON((split_flag & (EXT4_EXT_DATA_VALID1 | EXT4_EXT_DATA_VALID2)) ==
+-	       (EXT4_EXT_DATA_VALID1 | EXT4_EXT_DATA_VALID2));
++	BUG_ON((split_flag & EXT4_EXT_DATA_VALID1) == EXT4_EXT_DATA_VALID1);
++	BUG_ON((split_flag & EXT4_EXT_DATA_VALID1) &&
++	       (split_flag & EXT4_EXT_DATA_VALID2));
+ 
+ 	/* Do not cache extents that are in the process of being modified. */
+ 	flags |= EXT4_EX_NOCACHE;
+@@ -3234,24 +3244,27 @@ static int ext4_split_extent_at(handle_t *handle,
+ 	if (split_flag & EXT4_EXT_MARK_UNWRIT2)
+ 		ext4_ext_mark_unwritten(ex2);
+ 
+-	err = ext4_ext_insert_extent(handle, inode, ppath, &newex, flags);
+-	if (err != -ENOSPC && err != -EDQUOT && err != -ENOMEM)
++	path = ext4_ext_insert_extent(handle, inode, path, &newex, flags);
++	if (!IS_ERR(path))
+ 		goto out;
+ 
++	err = PTR_ERR(path);
++	if (err != -ENOSPC && err != -EDQUOT && err != -ENOMEM)
++		goto out_path;
++
+ 	/*
+-	 * Update path is required because previous ext4_ext_insert_extent()
+-	 * may have freed or reallocated the path. Using EXT4_EX_NOFAIL
+-	 * guarantees that ext4_find_extent() will not return -ENOMEM,
+-	 * otherwise -ENOMEM will cause a retry in do_writepages(), and a
+-	 * WARN_ON may be triggered in ext4_da_update_reserve_space() due to
+-	 * an incorrect ee_len causing the i_reserved_data_blocks exception.
++	 * Get a new path to try to zeroout or fix the extent length.
++	 * Using EXT4_EX_NOFAIL guarantees that ext4_find_extent()
++	 * will not return -ENOMEM, otherwise -ENOMEM will cause a
++	 * retry in do_writepages(), and a WARN_ON may be triggered
++	 * in ext4_da_update_reserve_space() due to an incorrect
++	 * ee_len causing the i_reserved_data_blocks exception.
+ 	 */
+-	path = ext4_find_extent(inode, ee_block, ppath,
+-				flags | EXT4_EX_NOFAIL);
++	path = ext4_find_extent(inode, ee_block, NULL, flags | EXT4_EX_NOFAIL);
+ 	if (IS_ERR(path)) {
+ 		EXT4_ERROR_INODE(inode, "Failed split extent on %u, err %ld",
+ 				 split, PTR_ERR(path));
+-		return PTR_ERR(path);
++		goto out_path;
+ 	}
+ 	depth = ext_depth(inode);
+ 	ex = path[depth].p_ext;
+@@ -3283,6 +3296,23 @@ static int ext4_split_extent_at(handle_t *handle,
+ 		}
+ 
+ 		if (!err) {
++			/*
++			 * The first half contains partially valid data, the
++			 * splitting of this extent has not been completed, fix
++			 * extent length and ext4_split_extent() split will the
++			 * first half again.
++			 */
++			if (split_flag & EXT4_EXT_DATA_PARTIAL_VALID1) {
++				/*
++				 * Drop extent cache to prevent stale unwritten
++				 * extents remaining after zeroing out.
++				 */
++				ext4_es_remove_extent(inode,
++					le32_to_cpu(zero_ex.ee_block),
++					ext4_ext_get_actual_len(&zero_ex));
++				goto fix_extent_len;
++			}
++
+ 			/* update the extent length and mark as initialized */
+ 			ex->ee_len = cpu_to_le16(ee_len);
+ 			ext4_ext_try_to_merge(handle, inode, path, ex);
+@@ -3306,10 +3336,17 @@ fix_extent_len:
+ 	 * and err is a non-zero error code.
+ 	 */
+ 	ext4_ext_dirty(handle, inode, path + path->p_depth);
+-	return err;
+ out:
+-	ext4_ext_show_leaf(inode, *ppath);
+-	return err;
++	if (err) {
++		ext4_free_ext_path(path);
++		path = ERR_PTR(err);
++	}
++out_path:
++	if (IS_ERR(path))
++		/* Remove all remaining potentially stale extents. */
++		ext4_es_remove_extent(inode, ee_block, ee_len);
++	ext4_ext_show_leaf(inode, path);
++	return path;
+ }
+ 
+ /*
+@@ -3323,21 +3360,18 @@ out:
+  *   c> Splits in three extents: Somone is splitting in middle of the extent
+  *
+  */
+-static int ext4_split_extent(handle_t *handle,
+-			      struct inode *inode,
+-			      struct ext4_ext_path **ppath,
+-			      struct ext4_map_blocks *map,
+-			      int split_flag,
+-			      int flags)
++static struct ext4_ext_path *ext4_split_extent(handle_t *handle,
++					       struct inode *inode,
++					       struct ext4_ext_path *path,
++					       struct ext4_map_blocks *map,
++					       int split_flag, int flags,
++					       unsigned int *allocated)
+ {
+-	struct ext4_ext_path *path = *ppath;
+ 	ext4_lblk_t ee_block;
+ 	struct ext4_extent *ex;
+ 	unsigned int ee_len, depth;
+-	int err = 0;
+ 	int unwritten;
+ 	int split_flag1, flags1;
+-	int allocated = map->m_len;
+ 
+ 	depth = ext_depth(inode);
+ 	ex = path[depth].p_ext;
+@@ -3355,29 +3389,30 @@ static int ext4_split_extent(handle_t *handle,
+ 			split_flag1 |= EXT4_EXT_MARK_UNWRIT1 |
+ 				       EXT4_EXT_MARK_UNWRIT2;
+ 		if (split_flag & EXT4_EXT_DATA_VALID2)
+-			split_flag1 |= EXT4_EXT_DATA_VALID1;
+-		err = ext4_split_extent_at(handle, inode, ppath,
++			split_flag1 |= map->m_lblk > ee_block ?
++				       EXT4_EXT_DATA_PARTIAL_VALID1 :
++				       EXT4_EXT_DATA_ENTIRE_VALID1;
++		path = ext4_split_extent_at(handle, inode, path,
+ 				map->m_lblk + map->m_len, split_flag1, flags1);
+-		if (err)
+-			goto out;
+-	} else {
+-		allocated = ee_len - (map->m_lblk - ee_block);
+-	}
+-	/*
+-	 * Update path is required because previous ext4_split_extent_at() may
+-	 * result in split of original leaf or extent zeroout.
+-	 */
+-	path = ext4_find_extent(inode, map->m_lblk, ppath, flags);
+-	if (IS_ERR(path))
+-		return PTR_ERR(path);
+-	depth = ext_depth(inode);
+-	ex = path[depth].p_ext;
+-	if (!ex) {
+-		EXT4_ERROR_INODE(inode, "unexpected hole at %lu",
+-				 (unsigned long) map->m_lblk);
+-		return -EFSCORRUPTED;
++		if (IS_ERR(path))
++			return path;
++		/*
++		 * Update path is required because previous ext4_split_extent_at
++		 * may result in split of original leaf or extent zeroout.
++		 */
++		path = ext4_find_extent(inode, map->m_lblk, path, flags);
++		if (IS_ERR(path))
++			return path;
++		depth = ext_depth(inode);
++		ex = path[depth].p_ext;
++		if (!ex) {
++			EXT4_ERROR_INODE(inode, "unexpected hole at %lu",
++					(unsigned long) map->m_lblk);
++			ext4_free_ext_path(path);
++			return ERR_PTR(-EFSCORRUPTED);
++		}
++		unwritten = ext4_ext_is_unwritten(ex);
+ 	}
+-	unwritten = ext4_ext_is_unwritten(ex);
+ 
+ 	if (map->m_lblk >= ee_block) {
+ 		split_flag1 = split_flag & EXT4_EXT_DATA_VALID2;
+@@ -3386,15 +3421,20 @@ static int ext4_split_extent(handle_t *handle,
+ 			split_flag1 |= split_flag & (EXT4_EXT_MAY_ZEROOUT |
+ 						     EXT4_EXT_MARK_UNWRIT2);
+ 		}
+-		err = ext4_split_extent_at(handle, inode, ppath,
++		path = ext4_split_extent_at(handle, inode, path,
+ 				map->m_lblk, split_flag1, flags);
+-		if (err)
+-			goto out;
++		if (IS_ERR(path))
++			return path;
+ 	}
+ 
+-	ext4_ext_show_leaf(inode, *ppath);
+-out:
+-	return err ? err : allocated;
++	if (allocated) {
++		if (map->m_lblk + map->m_len > ee_block + ee_len)
++			*allocated = ee_len - (map->m_lblk - ee_block);
++		else
++			*allocated = map->m_len;
++	}
++	ext4_ext_show_leaf(inode, path);
++	return path;
+ }
+ 
+ /*
+@@ -3417,13 +3457,11 @@ out:
+  *    that are allocated and initialized.
+  *    It is guaranteed to be >= map->m_len.
+  */
+-static int ext4_ext_convert_to_initialized(handle_t *handle,
+-					   struct inode *inode,
+-					   struct ext4_map_blocks *map,
+-					   struct ext4_ext_path **ppath,
+-					   int flags)
++static struct ext4_ext_path *
++ext4_ext_convert_to_initialized(handle_t *handle, struct inode *inode,
++			struct ext4_map_blocks *map, struct ext4_ext_path *path,
++			int flags, unsigned int *allocated)
+ {
+-	struct ext4_ext_path *path = *ppath;
+ 	struct ext4_sb_info *sbi;
+ 	struct ext4_extent_header *eh;
+ 	struct ext4_map_blocks split_map;
+@@ -3433,7 +3471,6 @@ static int ext4_ext_convert_to_initialized(handle_t *handle,
+ 	unsigned int ee_len, depth, map_len = map->m_len;
+ 	int err = 0;
+ 	int split_flag = EXT4_EXT_DATA_VALID2;
+-	int allocated = 0;
+ 	unsigned int max_zeroout = 0;
+ 
+ 	ext_debug(inode, "logical block %llu, max_blocks %u\n",
+@@ -3474,6 +3511,7 @@ static int ext4_ext_convert_to_initialized(handle_t *handle,
+ 	 *  - L2: we only attempt to merge with an extent stored in the
+ 	 *    same extent tree node.
+ 	 */
++	*allocated = 0;
+ 	if ((map->m_lblk == ee_block) &&
+ 		/* See if we can merge left */
+ 		(map_len < ee_len) &&		/*L1*/
+@@ -3503,7 +3541,7 @@ static int ext4_ext_convert_to_initialized(handle_t *handle,
+ 			(prev_len < (EXT_INIT_MAX_LEN - map_len))) {	/*C4*/
+ 			err = ext4_ext_get_access(handle, inode, path + depth);
+ 			if (err)
+-				goto out;
++				goto errout;
+ 
+ 			trace_ext4_ext_convert_to_initialized_fastpath(inode,
+ 				map, ex, abut_ex);
+@@ -3518,7 +3556,7 @@ static int ext4_ext_convert_to_initialized(handle_t *handle,
+ 			abut_ex->ee_len = cpu_to_le16(prev_len + map_len);
+ 
+ 			/* Result: number of initialized blocks past m_lblk */
+-			allocated = map_len;
++			*allocated = map_len;
+ 		}
+ 	} else if (((map->m_lblk + map_len) == (ee_block + ee_len)) &&
+ 		   (map_len < ee_len) &&	/*L1*/
+@@ -3549,7 +3587,7 @@ static int ext4_ext_convert_to_initialized(handle_t *handle,
+ 		    (next_len < (EXT_INIT_MAX_LEN - map_len))) {	/*C4*/
+ 			err = ext4_ext_get_access(handle, inode, path + depth);
+ 			if (err)
+-				goto out;
++				goto errout;
+ 
+ 			trace_ext4_ext_convert_to_initialized_fastpath(inode,
+ 				map, ex, abut_ex);
+@@ -3564,18 +3602,20 @@ static int ext4_ext_convert_to_initialized(handle_t *handle,
+ 			abut_ex->ee_len = cpu_to_le16(next_len + map_len);
+ 
+ 			/* Result: number of initialized blocks past m_lblk */
+-			allocated = map_len;
++			*allocated = map_len;
+ 		}
+ 	}
+-	if (allocated) {
++	if (*allocated) {
+ 		/* Mark the block containing both extents as dirty */
+ 		err = ext4_ext_dirty(handle, inode, path + depth);
+ 
+ 		/* Update path to point to the right extent */
+ 		path[depth].p_ext = abut_ex;
++		if (err)
++			goto errout;
+ 		goto out;
+ 	} else
+-		allocated = ee_len - (map->m_lblk - ee_block);
++		*allocated = ee_len - (map->m_lblk - ee_block);
+ 
+ 	WARN_ON(map->m_lblk < ee_block);
+ 	/*
+@@ -3602,21 +3642,21 @@ static int ext4_ext_convert_to_initialized(handle_t *handle,
+ 	split_map.m_lblk = map->m_lblk;
+ 	split_map.m_len = map->m_len;
+ 
+-	if (max_zeroout && (allocated > split_map.m_len)) {
+-		if (allocated <= max_zeroout) {
++	if (max_zeroout && (*allocated > split_map.m_len)) {
++		if (*allocated <= max_zeroout) {
+ 			/* case 3 or 5 */
+ 			zero_ex1.ee_block =
+ 				 cpu_to_le32(split_map.m_lblk +
+ 					     split_map.m_len);
+ 			zero_ex1.ee_len =
+-				cpu_to_le16(allocated - split_map.m_len);
++				cpu_to_le16(*allocated - split_map.m_len);
+ 			ext4_ext_store_pblock(&zero_ex1,
+ 				ext4_ext_pblock(ex) + split_map.m_lblk +
+ 				split_map.m_len - ee_block);
+ 			err = ext4_ext_zeroout(inode, &zero_ex1);
+ 			if (err)
+ 				goto fallback;
+-			split_map.m_len = allocated;
++			split_map.m_len = *allocated;
+ 		}
+ 		if (split_map.m_lblk - ee_block + split_map.m_len <
+ 								max_zeroout) {
+@@ -3634,22 +3674,24 @@ static int ext4_ext_convert_to_initialized(handle_t *handle,
+ 
+ 			split_map.m_len += split_map.m_lblk - ee_block;
+ 			split_map.m_lblk = ee_block;
+-			allocated = map->m_len;
++			*allocated = map->m_len;
+ 		}
+ 	}
+ 
+ fallback:
+-	err = ext4_split_extent(handle, inode, ppath, &split_map, split_flag,
+-				flags);
+-	if (err > 0)
+-		err = 0;
++	path = ext4_split_extent(handle, inode, path, &split_map, split_flag,
++				 flags, NULL);
++	if (IS_ERR(path))
++		return path;
+ out:
+ 	/* If we have gotten a failure, don't zero out status tree */
+-	if (!err) {
+-		ext4_zeroout_es(inode, &zero_ex1);
+-		ext4_zeroout_es(inode, &zero_ex2);
+-	}
+-	return err ? err : allocated;
++	ext4_zeroout_es(inode, &zero_ex1);
++	ext4_zeroout_es(inode, &zero_ex2);
++	return path;
++
++errout:
++	ext4_free_ext_path(path);
++	return ERR_PTR(err);
+ }
+ 
+ /*
+@@ -3674,15 +3716,16 @@ out:
+  * being filled will be convert to initialized by the end_io callback function
+  * via ext4_convert_unwritten_extents().
+  *
+- * Returns the size of unwritten extent to be written on success.
++ * The size of unwritten extent to be written is passed to the caller via the
++ * allocated pointer. Return an extent path pointer on success, or an error
++ * pointer on failure.
+  */
+-static int ext4_split_convert_extents(handle_t *handle,
++static struct ext4_ext_path *ext4_split_convert_extents(handle_t *handle,
+ 					struct inode *inode,
+ 					struct ext4_map_blocks *map,
+-					struct ext4_ext_path **ppath,
+-					int flags)
++					struct ext4_ext_path *path,
++					int flags, unsigned int *allocated)
+ {
+-	struct ext4_ext_path *path = *ppath;
+ 	ext4_lblk_t eof_block;
+ 	ext4_lblk_t ee_block;
+ 	struct ext4_extent *ex;
+@@ -3696,10 +3739,6 @@ static int ext4_split_convert_extents(handle_t *handle,
+ 			>> inode->i_sb->s_blocksize_bits;
+ 	if (eof_block < map->m_lblk + map->m_len)
+ 		eof_block = map->m_lblk + map->m_len;
+-	/*
+-	 * It is safe to convert extent to initialized via explicit
+-	 * zeroout only if extent is fully inside i_size or new_size.
+-	 */
+ 	depth = ext_depth(inode);
+ 	ex = path[depth].p_ext;
+ 	ee_block = le32_to_cpu(ex->ee_block);
+@@ -3707,23 +3746,31 @@ static int ext4_split_convert_extents(handle_t *handle,
+ 
+ 	/* Convert to unwritten */
+ 	if (flags & EXT4_GET_BLOCKS_CONVERT_UNWRITTEN) {
+-		split_flag |= EXT4_EXT_DATA_VALID1;
+-	/* Convert to initialized */
+-	} else if (flags & EXT4_GET_BLOCKS_CONVERT) {
++		split_flag |= EXT4_EXT_DATA_ENTIRE_VALID1;
++	/* Split the existing unwritten extent */
++	} else if (flags & (EXT4_GET_BLOCKS_UNWRIT_EXT |
++			    EXT4_GET_BLOCKS_CONVERT)) {
++		/*
++		 * It is safe to convert extent to initialized via explicit
++		 * zeroout only if extent is fully inside i_size or new_size.
++		 */
+ 		split_flag |= ee_block + ee_len <= eof_block ?
+ 			      EXT4_EXT_MAY_ZEROOUT : 0;
+-		split_flag |= (EXT4_EXT_MARK_UNWRIT2 | EXT4_EXT_DATA_VALID2);
++		split_flag |= EXT4_EXT_MARK_UNWRIT2;
++		/* Convert to initialized */
++		if (flags & EXT4_GET_BLOCKS_CONVERT)
++			split_flag |= EXT4_EXT_DATA_VALID2;
+ 	}
+ 	flags |= EXT4_GET_BLOCKS_PRE_IO;
+-	return ext4_split_extent(handle, inode, ppath, map, split_flag, flags);
++	return ext4_split_extent(handle, inode, path, map, split_flag, flags,
++				 allocated);
+ }
+ 
+-static int ext4_convert_unwritten_extents_endio(handle_t *handle,
+-						struct inode *inode,
+-						struct ext4_map_blocks *map,
+-						struct ext4_ext_path **ppath)
++static struct ext4_ext_path *
++ext4_convert_unwritten_extents_endio(handle_t *handle, struct inode *inode,
++				     struct ext4_map_blocks *map,
++				     struct ext4_ext_path *path)
+ {
+-	struct ext4_ext_path *path = *ppath;
+ 	struct ext4_extent *ex;
+ 	ext4_lblk_t ee_block;
+ 	unsigned int ee_len;
+@@ -3751,20 +3798,21 @@ static int ext4_convert_unwritten_extents_endio(handle_t *handle,
+ 			     inode->i_ino, (unsigned long long)ee_block, ee_len,
+ 			     (unsigned long long)map->m_lblk, map->m_len);
+ #endif
+-		err = ext4_split_convert_extents(handle, inode, map, ppath,
+-						 EXT4_GET_BLOCKS_CONVERT);
+-		if (err < 0)
+-			return err;
+-		path = ext4_find_extent(inode, map->m_lblk, ppath, 0);
++		path = ext4_split_convert_extents(handle, inode, map, path,
++						EXT4_GET_BLOCKS_CONVERT, NULL);
+ 		if (IS_ERR(path))
+-			return PTR_ERR(path);
++			return path;
++
++		path = ext4_find_extent(inode, map->m_lblk, path, 0);
++		if (IS_ERR(path))
++			return path;
+ 		depth = ext_depth(inode);
+ 		ex = path[depth].p_ext;
+ 	}
+ 
+ 	err = ext4_ext_get_access(handle, inode, path + depth);
+ 	if (err)
+-		goto out;
++		goto errout;
+ 	/* first mark the extent as initialized */
+ 	ext4_ext_mark_initialized(ex);
+ 
+@@ -3775,9 +3823,15 @@ static int ext4_convert_unwritten_extents_endio(handle_t *handle,
+ 
+ 	/* Mark modified extent as dirty */
+ 	err = ext4_ext_dirty(handle, inode, path + path->p_depth);
+-out:
++	if (err)
++		goto errout;
++
+ 	ext4_ext_show_leaf(inode, path);
+-	return err;
++	return path;
++
++errout:
++	ext4_free_ext_path(path);
++	return ERR_PTR(err);
+ }
+ 
+ static int
+@@ -3809,13 +3863,19 @@ convert_initialized_extent(handle_t *handle, struct inode *inode,
+ 		  (unsigned long long)ee_block, ee_len);
+ 
+ 	if (ee_block != map->m_lblk || ee_len > map->m_len) {
+-		err = ext4_split_convert_extents(handle, inode, map, ppath,
+-				EXT4_GET_BLOCKS_CONVERT_UNWRITTEN);
+-		if (err < 0)
+-			return err;
+-		path = ext4_find_extent(inode, map->m_lblk, ppath, 0);
+-		if (IS_ERR(path))
++		path = ext4_split_convert_extents(handle, inode, map, path,
++				EXT4_GET_BLOCKS_CONVERT_UNWRITTEN, NULL);
++		if (IS_ERR(path)) {
++			*ppath = NULL;
++			return PTR_ERR(path);
++		}
++
++		path = ext4_find_extent(inode, map->m_lblk, path, 0);
++		if (IS_ERR(path)) {
++			*ppath = NULL;
+ 			return PTR_ERR(path);
++		}
++		*ppath = path;
+ 		depth = ext_depth(inode);
+ 		ex = path[depth].p_ext;
+ 		if (!ex) {
+@@ -3851,19 +3911,18 @@ convert_initialized_extent(handle_t *handle, struct inode *inode,
+ 	return 0;
+ }
+ 
+-static int
++static struct ext4_ext_path *
+ ext4_ext_handle_unwritten_extents(handle_t *handle, struct inode *inode,
+ 			struct ext4_map_blocks *map,
+-			struct ext4_ext_path **ppath, int flags,
+-			unsigned int allocated, ext4_fsblk_t newblock)
++			struct ext4_ext_path *path, int flags,
++			unsigned int *allocated, ext4_fsblk_t newblock)
+ {
+-	int ret = 0;
+ 	int err = 0;
+ 
+ 	ext_debug(inode, "logical block %llu, max_blocks %u, flags 0x%x, allocated %u\n",
+ 		  (unsigned long long)map->m_lblk, map->m_len, flags,
+-		  allocated);
+-	ext4_ext_show_leaf(inode, *ppath);
++		  *allocated);
++	ext4_ext_show_leaf(inode, path);
+ 
+ 	/*
+ 	 * When writing into unwritten space, we should not fail to
+@@ -3872,36 +3931,34 @@ ext4_ext_handle_unwritten_extents(handle_t *handle, struct inode *inode,
+ 	flags |= EXT4_GET_BLOCKS_METADATA_NOFAIL;
+ 
+ 	trace_ext4_ext_handle_unwritten_extents(inode, map, flags,
+-						    allocated, newblock);
++						*allocated, newblock);
+ 
+ 	/* get_block() before submitting IO, split the extent */
+ 	if (flags & EXT4_GET_BLOCKS_PRE_IO) {
+-		ret = ext4_split_convert_extents(handle, inode, map, ppath,
+-					 flags | EXT4_GET_BLOCKS_CONVERT);
+-		if (ret < 0) {
+-			err = ret;
+-			goto out2;
+-		}
++		path = ext4_split_convert_extents(handle, inode, map, path,
++						  flags, allocated);
++		if (IS_ERR(path))
++			return path;
+ 		/*
+-		 * shouldn't get a 0 return when splitting an extent unless
++		 * shouldn't get a 0 allocated when splitting an extent unless
+ 		 * m_len is 0 (bug) or extent has been corrupted
+ 		 */
+-		if (unlikely(ret == 0)) {
++		if (unlikely(*allocated == 0)) {
+ 			EXT4_ERROR_INODE(inode,
+-					 "unexpected ret == 0, m_len = %u",
++					 "unexpected allocated == 0, m_len = %u",
+ 					 map->m_len);
+ 			err = -EFSCORRUPTED;
+-			goto out2;
++			goto errout;
+ 		}
+ 		map->m_flags |= EXT4_MAP_UNWRITTEN;
+ 		goto out;
+ 	}
+ 	/* IO end_io complete, convert the filled extent to written */
+ 	if (flags & EXT4_GET_BLOCKS_CONVERT) {
+-		err = ext4_convert_unwritten_extents_endio(handle, inode, map,
+-							   ppath);
+-		if (err < 0)
+-			goto out2;
++		path = ext4_convert_unwritten_extents_endio(handle, inode,
++							    map, path);
++		if (IS_ERR(path))
++			return path;
+ 		ext4_update_inode_fsync_trans(handle, inode, 1);
+ 		goto map_out;
+ 	}
+@@ -3933,36 +3990,37 @@ ext4_ext_handle_unwritten_extents(handle_t *handle, struct inode *inode,
+ 	 * For buffered writes, at writepage time, etc.  Convert a
+ 	 * discovered unwritten extent to written.
+ 	 */
+-	ret = ext4_ext_convert_to_initialized(handle, inode, map, ppath, flags);
+-	if (ret < 0) {
+-		err = ret;
+-		goto out2;
+-	}
++	path = ext4_ext_convert_to_initialized(handle, inode, map, path,
++					       flags, allocated);
++	if (IS_ERR(path))
++		return path;
+ 	ext4_update_inode_fsync_trans(handle, inode, 1);
+ 	/*
+-	 * shouldn't get a 0 return when converting an unwritten extent
++	 * shouldn't get a 0 allocated when converting an unwritten extent
+ 	 * unless m_len is 0 (bug) or extent has been corrupted
+ 	 */
+-	if (unlikely(ret == 0)) {
+-		EXT4_ERROR_INODE(inode, "unexpected ret == 0, m_len = %u",
++	if (unlikely(*allocated == 0)) {
++		EXT4_ERROR_INODE(inode, "unexpected allocated == 0, m_len = %u",
+ 				 map->m_len);
+ 		err = -EFSCORRUPTED;
+-		goto out2;
++		goto errout;
+ 	}
+ 
+ out:
+-	allocated = ret;
+ 	map->m_flags |= EXT4_MAP_NEW;
+ map_out:
+ 	map->m_flags |= EXT4_MAP_MAPPED;
+ out1:
+ 	map->m_pblk = newblock;
+-	if (allocated > map->m_len)
+-		allocated = map->m_len;
+-	map->m_len = allocated;
+-	ext4_ext_show_leaf(inode, *ppath);
+-out2:
+-	return err ? err : allocated;
++	if (*allocated > map->m_len)
++		*allocated = map->m_len;
++	map->m_len = *allocated;
++	ext4_ext_show_leaf(inode, path);
++	return path;
++
++errout:
++	ext4_free_ext_path(path);
++	return ERR_PTR(err);
+ }
+ 
+ /*
+@@ -4156,7 +4214,7 @@ int ext4_ext_map_blocks(handle_t *handle, struct inode *inode,
+ 	struct ext4_extent newex, *ex, ex2;
+ 	struct ext4_sb_info *sbi = EXT4_SB(inode->i_sb);
+ 	ext4_fsblk_t newblock = 0, pblk;
+-	int err = 0, depth, ret;
++	int err = 0, depth;
+ 	unsigned int allocated = 0, offset = 0;
+ 	unsigned int allocated_clusters = 0;
+ 	struct ext4_allocation_request ar;
+@@ -4231,13 +4289,11 @@ int ext4_ext_map_blocks(handle_t *handle, struct inode *inode,
+ 				goto out;
+ 			}
+ 
+-			ret = ext4_ext_handle_unwritten_extents(
+-				handle, inode, map, &path, flags,
+-				allocated, newblock);
+-			if (ret < 0)
+-				err = ret;
+-			else
+-				allocated = ret;
++			path = ext4_ext_handle_unwritten_extents(
++				handle, inode, map, path, flags,
++				&allocated, newblock);
++			if (IS_ERR(path))
++				err = PTR_ERR(path);
+ 			goto out;
+ 		}
+ 	}
+@@ -4289,6 +4345,7 @@ int ext4_ext_map_blocks(handle_t *handle, struct inode *inode,
+ 	    get_implied_cluster_alloc(inode->i_sb, map, &ex2, path)) {
+ 		ar.len = allocated = map->m_len;
+ 		newblock = map->m_pblk;
++		err = 0;
+ 		goto got_allocated_blocks;
+ 	}
+ 
+@@ -4361,8 +4418,9 @@ got_allocated_blocks:
+ 		map->m_flags |= EXT4_MAP_UNWRITTEN;
+ 	}
+ 
+-	err = ext4_ext_insert_extent(handle, inode, &path, &newex, flags);
+-	if (err) {
++	path = ext4_ext_insert_extent(handle, inode, path, &newex, flags);
++	if (IS_ERR(path)) {
++		err = PTR_ERR(path);
+ 		if (allocated_clusters) {
+ 			int fb_flags = 0;
+ 
+@@ -5200,7 +5258,7 @@ ext4_ext_shift_extents(struct inode *inode, handle_t *handle,
+ 	* won't be shifted beyond EXT_MAX_BLOCKS.
+ 	*/
+ 	if (SHIFT == SHIFT_LEFT) {
+-		path = ext4_find_extent(inode, start - 1, &path,
++		path = ext4_find_extent(inode, start - 1, path,
+ 					EXT4_EX_NOCACHE);
+ 		if (IS_ERR(path))
+ 			return PTR_ERR(path);
+@@ -5249,7 +5307,7 @@ again:
+ 	 * becomes NULL to indicate the end of the loop.
+ 	 */
+ 	while (iterator && start <= stop) {
+-		path = ext4_find_extent(inode, *iterator, &path,
++		path = ext4_find_extent(inode, *iterator, path,
+ 					EXT4_EX_NOCACHE);
+ 		if (IS_ERR(path))
+ 			return PTR_ERR(path);
+@@ -5571,22 +5629,21 @@ static int ext4_insert_range(struct file *file, loff_t offset, loff_t len)
+ 			if (ext4_ext_is_unwritten(extent))
+ 				split_flag = EXT4_EXT_MARK_UNWRIT1 |
+ 					EXT4_EXT_MARK_UNWRIT2;
+-			ret = ext4_split_extent_at(handle, inode, &path,
++			path = ext4_split_extent_at(handle, inode, path,
+ 					offset_lblk, split_flag,
+ 					EXT4_EX_NOCACHE |
+ 					EXT4_GET_BLOCKS_PRE_IO |
+ 					EXT4_GET_BLOCKS_METADATA_NOFAIL);
+ 		}
+ 
+-		ext4_free_ext_path(path);
+-		if (ret < 0) {
++		if (IS_ERR(path)) {
+ 			up_write(&EXT4_I(inode)->i_data_sem);
++			ret = PTR_ERR(path);
+ 			goto out_stop;
+ 		}
+-	} else {
+-		ext4_free_ext_path(path);
+ 	}
+ 
++	ext4_free_ext_path(path);
+ 	ext4_es_remove_extent(inode, offset_lblk, EXT_MAX_BLOCKS - offset_lblk);
+ 
+ 	/*
+@@ -5832,11 +5889,8 @@ int ext4_clu_mapped(struct inode *inode, ext4_lblk_t lclu)
+ 
+ 	/* search for the extent closest to the first block in the cluster */
+ 	path = ext4_find_extent(inode, EXT4_C2B(sbi, lclu), NULL, 0);
+-	if (IS_ERR(path)) {
+-		err = PTR_ERR(path);
+-		path = NULL;
+-		goto out;
+-	}
++	if (IS_ERR(path))
++		return PTR_ERR(path);
+ 
+ 	depth = ext_depth(inode);
+ 
+@@ -5920,7 +5974,7 @@ int ext4_ext_replay_update_ex(struct inode *inode, ext4_lblk_t start,
+ 		if (ret)
+ 			goto out;
+ 
+-		path = ext4_find_extent(inode, start, &path, 0);
++		path = ext4_find_extent(inode, start, path, 0);
+ 		if (IS_ERR(path))
+ 			return PTR_ERR(path);
+ 		ex = path[path->p_depth].p_ext;
+@@ -5934,7 +5988,7 @@ int ext4_ext_replay_update_ex(struct inode *inode, ext4_lblk_t start,
+ 			if (ret)
+ 				goto out;
+ 
+-			path = ext4_find_extent(inode, start, &path, 0);
++			path = ext4_find_extent(inode, start, path, 0);
+ 			if (IS_ERR(path))
+ 				return PTR_ERR(path);
+ 			ex = path[path->p_depth].p_ext;
+diff --git a/fs/ext4/fast_commit.c b/fs/ext4/fast_commit.c
+index 62a6960242c5a6..be65b5f51d9e21 100644
+--- a/fs/ext4/fast_commit.c
++++ b/fs/ext4/fast_commit.c
+@@ -1806,12 +1806,12 @@ static int ext4_fc_replay_add_range(struct super_block *sb,
+ 			if (ext4_ext_is_unwritten(ex))
+ 				ext4_ext_mark_unwritten(&newex);
+ 			down_write(&EXT4_I(inode)->i_data_sem);
+-			ret = ext4_ext_insert_extent(
+-				NULL, inode, &path, &newex, 0);
++			path = ext4_ext_insert_extent(NULL, inode,
++						      path, &newex, 0);
+ 			up_write((&EXT4_I(inode)->i_data_sem));
+-			ext4_free_ext_path(path);
+-			if (ret)
++			if (IS_ERR(path))
+ 				goto out;
++			ext4_free_ext_path(path);
+ 			goto next;
+ 		}
+ 
+diff --git a/fs/ext4/mballoc.c b/fs/ext4/mballoc.c
+index d095c4a218a3ac..5c58bfda40b7f9 100644
+--- a/fs/ext4/mballoc.c
++++ b/fs/ext4/mballoc.c
+@@ -883,6 +883,21 @@ mb_update_avg_fragment_size(struct super_block *sb, struct ext4_group_info *grp)
+ 	}
+ }
+ 
++static ext4_group_t ext4_get_allocation_groups_count(
++				struct ext4_allocation_context *ac)
++{
++	ext4_group_t ngroups = ext4_get_groups_count(ac->ac_sb);
++
++	/* non-extent files are limited to low blocks/groups */
++	if (!(ext4_test_inode_flag(ac->ac_inode, EXT4_INODE_EXTENTS)))
++		ngroups = EXT4_SB(ac->ac_sb)->s_blockfile_groups;
++
++	/* Pairs with smp_wmb() in ext4_update_super() */
++	smp_rmb();
++
++	return ngroups;
++}
++
+ /*
+  * Choose next group by traversing largest_free_order lists. Updates *new_cr if
+  * cr level needs an update.
+@@ -1452,7 +1467,7 @@ out:
+  * Lock the buddy and bitmap pages. This make sure other parallel init_group
+  * on the same buddy page doesn't happen whild holding the buddy page lock.
+  * Return locked buddy and bitmap pages on e4b struct. If buddy and bitmap
+- * are on the same page e4b->bd_buddy_page is NULL and return value is 0.
++ * are on the same page e4b->bd_buddy_folio is NULL and return value is 0.
+  */
+ static int ext4_mb_get_buddy_page_lock(struct super_block *sb,
+ 		ext4_group_t group, struct ext4_buddy *e4b, gfp_t gfp)
+@@ -1460,10 +1475,10 @@ static int ext4_mb_get_buddy_page_lock(struct super_block *sb,
+ 	struct inode *inode = EXT4_SB(sb)->s_buddy_cache;
+ 	int block, pnum, poff;
+ 	int blocks_per_page;
+-	struct page *page;
++	struct folio *folio;
+ 
+-	e4b->bd_buddy_page = NULL;
+-	e4b->bd_bitmap_page = NULL;
++	e4b->bd_buddy_folio = NULL;
++	e4b->bd_bitmap_folio = NULL;
+ 
+ 	blocks_per_page = PAGE_SIZE / sb->s_blocksize;
+ 	/*
+@@ -1474,37 +1489,38 @@ static int ext4_mb_get_buddy_page_lock(struct super_block *sb,
+ 	block = group * 2;
+ 	pnum = block / blocks_per_page;
+ 	poff = block % blocks_per_page;
+-	page = find_or_create_page(inode->i_mapping, pnum, gfp);
+-	if (!page)
+-		return -ENOMEM;
+-	BUG_ON(page->mapping != inode->i_mapping);
+-	e4b->bd_bitmap_page = page;
+-	e4b->bd_bitmap = page_address(page) + (poff * sb->s_blocksize);
++	folio = __filemap_get_folio(inode->i_mapping, pnum,
++			FGP_LOCK | FGP_ACCESSED | FGP_CREAT, gfp);
++	if (IS_ERR(folio))
++		return PTR_ERR(folio);
++	BUG_ON(folio->mapping != inode->i_mapping);
++	e4b->bd_bitmap_folio = folio;
++	e4b->bd_bitmap = folio_address(folio) + (poff * sb->s_blocksize);
+ 
+ 	if (blocks_per_page >= 2) {
+ 		/* buddy and bitmap are on the same page */
+ 		return 0;
+ 	}
+ 
+-	block++;
+-	pnum = block / blocks_per_page;
+-	page = find_or_create_page(inode->i_mapping, pnum, gfp);
+-	if (!page)
+-		return -ENOMEM;
+-	BUG_ON(page->mapping != inode->i_mapping);
+-	e4b->bd_buddy_page = page;
++	/* blocks_per_page == 1, hence we need another page for the buddy */
++	folio = __filemap_get_folio(inode->i_mapping, block + 1,
++			FGP_LOCK | FGP_ACCESSED | FGP_CREAT, gfp);
++	if (IS_ERR(folio))
++		return PTR_ERR(folio);
++	BUG_ON(folio->mapping != inode->i_mapping);
++	e4b->bd_buddy_folio = folio;
+ 	return 0;
+ }
+ 
+ static void ext4_mb_put_buddy_page_lock(struct ext4_buddy *e4b)
+ {
+-	if (e4b->bd_bitmap_page) {
+-		unlock_page(e4b->bd_bitmap_page);
+-		put_page(e4b->bd_bitmap_page);
++	if (e4b->bd_bitmap_folio) {
++		folio_unlock(e4b->bd_bitmap_folio);
++		folio_put(e4b->bd_bitmap_folio);
+ 	}
+-	if (e4b->bd_buddy_page) {
+-		unlock_page(e4b->bd_buddy_page);
+-		put_page(e4b->bd_buddy_page);
++	if (e4b->bd_buddy_folio) {
++		folio_unlock(e4b->bd_buddy_folio);
++		folio_put(e4b->bd_buddy_folio);
+ 	}
+ }
+ 
+@@ -1519,7 +1535,7 @@ int ext4_mb_init_group(struct super_block *sb, ext4_group_t group, gfp_t gfp)
+ 
+ 	struct ext4_group_info *this_grp;
+ 	struct ext4_buddy e4b;
+-	struct page *page;
++	struct folio *folio;
+ 	int ret = 0;
+ 
+ 	might_sleep();
+@@ -1546,16 +1562,16 @@ int ext4_mb_init_group(struct super_block *sb, ext4_group_t group, gfp_t gfp)
+ 		goto err;
+ 	}
+ 
+-	page = e4b.bd_bitmap_page;
+-	ret = ext4_mb_init_cache(page, NULL, gfp);
++	folio = e4b.bd_bitmap_folio;
++	ret = ext4_mb_init_cache(&folio->page, NULL, gfp);
+ 	if (ret)
+ 		goto err;
+-	if (!PageUptodate(page)) {
++	if (!folio_test_uptodate(folio)) {
+ 		ret = -EIO;
+ 		goto err;
+ 	}
+ 
+-	if (e4b.bd_buddy_page == NULL) {
++	if (e4b.bd_buddy_folio == NULL) {
+ 		/*
+ 		 * If both the bitmap and buddy are in
+ 		 * the same page we don't need to force
+@@ -1565,11 +1581,11 @@ int ext4_mb_init_group(struct super_block *sb, ext4_group_t group, gfp_t gfp)
+ 		goto err;
+ 	}
+ 	/* init buddy cache */
+-	page = e4b.bd_buddy_page;
+-	ret = ext4_mb_init_cache(page, e4b.bd_bitmap, gfp);
++	folio = e4b.bd_buddy_folio;
++	ret = ext4_mb_init_cache(&folio->page, e4b.bd_bitmap, gfp);
+ 	if (ret)
+ 		goto err;
+-	if (!PageUptodate(page)) {
++	if (!folio_test_uptodate(folio)) {
+ 		ret = -EIO;
+ 		goto err;
+ 	}
+@@ -1591,7 +1607,7 @@ ext4_mb_load_buddy_gfp(struct super_block *sb, ext4_group_t group,
+ 	int block;
+ 	int pnum;
+ 	int poff;
+-	struct page *page;
++	struct folio *folio;
+ 	int ret;
+ 	struct ext4_group_info *grp;
+ 	struct ext4_sb_info *sbi = EXT4_SB(sb);
+@@ -1609,8 +1625,8 @@ ext4_mb_load_buddy_gfp(struct super_block *sb, ext4_group_t group,
+ 	e4b->bd_info = grp;
+ 	e4b->bd_sb = sb;
+ 	e4b->bd_group = group;
+-	e4b->bd_buddy_page = NULL;
+-	e4b->bd_bitmap_page = NULL;
++	e4b->bd_buddy_folio = NULL;
++	e4b->bd_bitmap_folio = NULL;
+ 
+ 	if (unlikely(EXT4_MB_GRP_NEED_INIT(grp))) {
+ 		/*
+@@ -1631,102 +1647,104 @@ ext4_mb_load_buddy_gfp(struct super_block *sb, ext4_group_t group,
+ 	pnum = block / blocks_per_page;
+ 	poff = block % blocks_per_page;
+ 
+-	/* we could use find_or_create_page(), but it locks page
+-	 * what we'd like to avoid in fast path ... */
+-	page = find_get_page_flags(inode->i_mapping, pnum, FGP_ACCESSED);
+-	if (page == NULL || !PageUptodate(page)) {
+-		if (page)
+-			/*
+-			 * drop the page reference and try
+-			 * to get the page with lock. If we
+-			 * are not uptodate that implies
+-			 * somebody just created the page but
+-			 * is yet to initialize the same. So
+-			 * wait for it to initialize.
+-			 */
+-			put_page(page);
+-		page = find_or_create_page(inode->i_mapping, pnum, gfp);
+-		if (page) {
+-			if (WARN_RATELIMIT(page->mapping != inode->i_mapping,
+-	"ext4: bitmap's paging->mapping != inode->i_mapping\n")) {
++	/* Avoid locking the folio in the fast path ... */
++	folio = __filemap_get_folio(inode->i_mapping, pnum, FGP_ACCESSED, 0);
++	if (IS_ERR(folio) || !folio_test_uptodate(folio) || folio_test_locked(folio)) {
++		/*
++		 * folio_test_locked is employed to detect ongoing folio
++		 * migrations, since concurrent migrations can lead to
++		 * bitmap inconsistency. And if we are not uptodate that
++		 * implies somebody just created the folio but is yet to
++		 * initialize it. We can drop the folio reference and
++		 * try to get the folio with lock in both cases to avoid
++		 * concurrency.
++		 */
++		if (!IS_ERR(folio))
++			folio_put(folio);
++		folio = __filemap_get_folio(inode->i_mapping, pnum,
++				FGP_LOCK | FGP_ACCESSED | FGP_CREAT, gfp);
++		if (!IS_ERR(folio)) {
++			if (WARN_RATELIMIT(folio->mapping != inode->i_mapping,
++	"ext4: bitmap's mapping != inode->i_mapping\n")) {
+ 				/* should never happen */
+-				unlock_page(page);
++				folio_unlock(folio);
+ 				ret = -EINVAL;
+ 				goto err;
+ 			}
+-			if (!PageUptodate(page)) {
+-				ret = ext4_mb_init_cache(page, NULL, gfp);
++			if (!folio_test_uptodate(folio)) {
++				ret = ext4_mb_init_cache(&folio->page, NULL, gfp);
+ 				if (ret) {
+-					unlock_page(page);
++					folio_unlock(folio);
+ 					goto err;
+ 				}
+-				mb_cmp_bitmaps(e4b, page_address(page) +
++				mb_cmp_bitmaps(e4b, folio_address(folio) +
+ 					       (poff * sb->s_blocksize));
+ 			}
+-			unlock_page(page);
++			folio_unlock(folio);
+ 		}
+ 	}
+-	if (page == NULL) {
+-		ret = -ENOMEM;
++	if (IS_ERR(folio)) {
++		ret = PTR_ERR(folio);
+ 		goto err;
+ 	}
+-	if (!PageUptodate(page)) {
++	if (!folio_test_uptodate(folio)) {
+ 		ret = -EIO;
+ 		goto err;
+ 	}
+ 
+-	/* Pages marked accessed already */
+-	e4b->bd_bitmap_page = page;
+-	e4b->bd_bitmap = page_address(page) + (poff * sb->s_blocksize);
++	/* Folios marked accessed already */
++	e4b->bd_bitmap_folio = folio;
++	e4b->bd_bitmap = folio_address(folio) + (poff * sb->s_blocksize);
+ 
+ 	block++;
+ 	pnum = block / blocks_per_page;
+ 	poff = block % blocks_per_page;
+ 
+-	page = find_get_page_flags(inode->i_mapping, pnum, FGP_ACCESSED);
+-	if (page == NULL || !PageUptodate(page)) {
+-		if (page)
+-			put_page(page);
+-		page = find_or_create_page(inode->i_mapping, pnum, gfp);
+-		if (page) {
+-			if (WARN_RATELIMIT(page->mapping != inode->i_mapping,
+-	"ext4: buddy bitmap's page->mapping != inode->i_mapping\n")) {
++	folio = __filemap_get_folio(inode->i_mapping, pnum, FGP_ACCESSED, 0);
++	if (IS_ERR(folio) || !folio_test_uptodate(folio) || folio_test_locked(folio)) {
++		if (!IS_ERR(folio))
++			folio_put(folio);
++		folio = __filemap_get_folio(inode->i_mapping, pnum,
++				FGP_LOCK | FGP_ACCESSED | FGP_CREAT, gfp);
++		if (!IS_ERR(folio)) {
++			if (WARN_RATELIMIT(folio->mapping != inode->i_mapping,
++	"ext4: buddy bitmap's mapping != inode->i_mapping\n")) {
+ 				/* should never happen */
+-				unlock_page(page);
++				folio_unlock(folio);
+ 				ret = -EINVAL;
+ 				goto err;
+ 			}
+-			if (!PageUptodate(page)) {
+-				ret = ext4_mb_init_cache(page, e4b->bd_bitmap,
++			if (!folio_test_uptodate(folio)) {
++				ret = ext4_mb_init_cache(&folio->page, e4b->bd_bitmap,
+ 							 gfp);
+ 				if (ret) {
+-					unlock_page(page);
++					folio_unlock(folio);
+ 					goto err;
+ 				}
+ 			}
+-			unlock_page(page);
++			folio_unlock(folio);
+ 		}
+ 	}
+-	if (page == NULL) {
+-		ret = -ENOMEM;
++	if (IS_ERR(folio)) {
++		ret = PTR_ERR(folio);
+ 		goto err;
+ 	}
+-	if (!PageUptodate(page)) {
++	if (!folio_test_uptodate(folio)) {
+ 		ret = -EIO;
+ 		goto err;
+ 	}
+ 
+-	/* Pages marked accessed already */
+-	e4b->bd_buddy_page = page;
+-	e4b->bd_buddy = page_address(page) + (poff * sb->s_blocksize);
++	/* Folios marked accessed already */
++	e4b->bd_buddy_folio = folio;
++	e4b->bd_buddy = folio_address(folio) + (poff * sb->s_blocksize);
+ 
+ 	return 0;
+ 
+ err:
+-	if (page)
+-		put_page(page);
+-	if (e4b->bd_bitmap_page)
+-		put_page(e4b->bd_bitmap_page);
++	if (folio)
++		folio_put(folio);
++	if (e4b->bd_bitmap_folio)
++		folio_put(e4b->bd_bitmap_folio);
+ 
+ 	e4b->bd_buddy = NULL;
+ 	e4b->bd_bitmap = NULL;
+@@ -1741,10 +1759,10 @@ static int ext4_mb_load_buddy(struct super_block *sb, ext4_group_t group,
+ 
+ static void ext4_mb_unload_buddy(struct ext4_buddy *e4b)
+ {
+-	if (e4b->bd_bitmap_page)
+-		put_page(e4b->bd_bitmap_page);
+-	if (e4b->bd_buddy_page)
+-		put_page(e4b->bd_buddy_page);
++	if (e4b->bd_bitmap_folio)
++		folio_put(e4b->bd_bitmap_folio);
++	if (e4b->bd_buddy_folio)
++		folio_put(e4b->bd_buddy_folio);
+ }
+ 
+ 
+@@ -2168,9 +2186,9 @@ static void ext4_mb_use_best_found(struct ext4_allocation_context *ac,
+ 	 * double allocate blocks. The reference is dropped
+ 	 * in ext4_mb_release_context
+ 	 */
+-	ac->ac_bitmap_page = e4b->bd_bitmap_page;
++	ac->ac_bitmap_page = &e4b->bd_bitmap_folio->page;
+ 	get_page(ac->ac_bitmap_page);
+-	ac->ac_buddy_page = e4b->bd_buddy_page;
++	ac->ac_buddy_page = &e4b->bd_buddy_folio->page;
+ 	get_page(ac->ac_buddy_page);
+ 	/* store last allocated for subsequent stream allocation */
+ 	if (ac->ac_flags & EXT4_MB_STREAM_ALLOC) {
+@@ -2814,10 +2832,7 @@ ext4_mb_regular_allocator(struct ext4_allocation_context *ac)
+ 
+ 	sb = ac->ac_sb;
+ 	sbi = EXT4_SB(sb);
+-	ngroups = ext4_get_groups_count(sb);
+-	/* non-extent files are limited to low blocks/groups */
+-	if (!(ext4_test_inode_flag(ac->ac_inode, EXT4_INODE_EXTENTS)))
+-		ngroups = sbi->s_blockfile_groups;
++	ngroups = ext4_get_allocation_groups_count(ac);
+ 
+ 	BUG_ON(ac->ac_status == AC_STATUS_FOUND);
+ 
+@@ -3902,8 +3917,8 @@ static void ext4_free_data_in_buddy(struct super_block *sb,
+ 		/* No more items in the per group rb tree
+ 		 * balance refcounts from ext4_mb_free_metadata()
+ 		 */
+-		put_page(e4b.bd_buddy_page);
+-		put_page(e4b.bd_bitmap_page);
++		folio_put(e4b.bd_buddy_folio);
++		folio_put(e4b.bd_bitmap_folio);
+ 	}
+ 	ext4_unlock_group(sb, entry->efd_group);
+ 	ext4_mb_unload_buddy(&e4b);
+@@ -3996,8 +4011,7 @@ void ext4_exit_mballoc(void)
+  * Returns 0 if success or error code
+  */
+ static noinline_for_stack int
+-ext4_mb_mark_diskspace_used(struct ext4_allocation_context *ac,
+-				handle_t *handle, unsigned int reserv_clstrs)
++ext4_mb_mark_diskspace_used(struct ext4_allocation_context *ac, handle_t *handle)
+ {
+ 	struct buffer_head *bitmap_bh = NULL;
+ 	struct ext4_group_desc *gdp;
+@@ -4083,13 +4097,6 @@ ext4_mb_mark_diskspace_used(struct ext4_allocation_context *ac,
+ 
+ 	ext4_unlock_group(sb, ac->ac_b_ex.fe_group);
+ 	percpu_counter_sub(&sbi->s_freeclusters_counter, ac->ac_b_ex.fe_len);
+-	/*
+-	 * Now reduce the dirty block count also. Should not go negative
+-	 */
+-	if (!(ac->ac_flags & EXT4_MB_DELALLOC_RESERVED))
+-		/* release all the reserved blocks if non delalloc */
+-		percpu_counter_sub(&sbi->s_dirtyclusters_counter,
+-				   reserv_clstrs);
+ 
+ 	if (sbi->s_log_groups_per_flex) {
+ 		ext4_group_t flex_group = ext4_flex_group(sbi,
+@@ -6262,7 +6269,7 @@ repeat:
+ 			ext4_mb_pa_put_free(ac);
+ 	}
+ 	if (likely(ac->ac_status == AC_STATUS_FOUND)) {
+-		*errp = ext4_mb_mark_diskspace_used(ac, handle, reserv_clstrs);
++		*errp = ext4_mb_mark_diskspace_used(ac, handle);
+ 		if (*errp) {
+ 			ext4_discard_allocated_blocks(ac);
+ 			goto errout;
+@@ -6293,12 +6300,9 @@ errout:
+ out:
+ 	if (inquota && ar->len < inquota)
+ 		dquot_free_block(ar->inode, EXT4_C2B(sbi, inquota - ar->len));
+-	if (!ar->len) {
+-		if ((ar->flags & EXT4_MB_DELALLOC_RESERVED) == 0)
+-			/* release all the reserved blocks if non delalloc */
+-			percpu_counter_sub(&sbi->s_dirtyclusters_counter,
+-						reserv_clstrs);
+-	}
++	/* release any reserved blocks */
++	if (reserv_clstrs)
++		percpu_counter_sub(&sbi->s_dirtyclusters_counter, reserv_clstrs);
+ 
+ 	trace_ext4_allocate_blocks(ar, (unsigned long long)block);
+ 
+@@ -6349,8 +6353,8 @@ ext4_mb_free_metadata(handle_t *handle, struct ext4_buddy *e4b,
+ 	struct rb_node *parent = NULL, *new_node;
+ 
+ 	BUG_ON(!ext4_handle_valid(handle));
+-	BUG_ON(e4b->bd_bitmap_page == NULL);
+-	BUG_ON(e4b->bd_buddy_page == NULL);
++	BUG_ON(e4b->bd_bitmap_folio == NULL);
++	BUG_ON(e4b->bd_buddy_folio == NULL);
+ 
+ 	new_node = &new_entry->efd_node;
+ 	cluster = new_entry->efd_start_cluster;
+@@ -6361,8 +6365,8 @@ ext4_mb_free_metadata(handle_t *handle, struct ext4_buddy *e4b,
+ 		 * otherwise we'll refresh it from
+ 		 * on-disk bitmap and lose not-yet-available
+ 		 * blocks */
+-		get_page(e4b->bd_buddy_page);
+-		get_page(e4b->bd_bitmap_page);
++		folio_get(e4b->bd_buddy_folio);
++		folio_get(e4b->bd_bitmap_folio);
+ 	}
+ 	while (*n) {
+ 		parent = *n;
+diff --git a/fs/ext4/mballoc.h b/fs/ext4/mballoc.h
+index dd16050022f524..0dd6bc69ab611b 100644
+--- a/fs/ext4/mballoc.h
++++ b/fs/ext4/mballoc.h
+@@ -216,9 +216,9 @@ struct ext4_allocation_context {
+ #define AC_STATUS_BREAK		3
+ 
+ struct ext4_buddy {
+-	struct page *bd_buddy_page;
++	struct folio *bd_buddy_folio;
+ 	void *bd_buddy;
+-	struct page *bd_bitmap_page;
++	struct folio *bd_bitmap_folio;
+ 	void *bd_bitmap;
+ 	struct ext4_group_info *bd_info;
+ 	struct super_block *bd_sb;
+diff --git a/fs/ext4/migrate.c b/fs/ext4/migrate.c
+index a5e1492bbaaa56..1b0dfd963d3f01 100644
+--- a/fs/ext4/migrate.c
++++ b/fs/ext4/migrate.c
+@@ -37,7 +37,6 @@ static int finish_range(handle_t *handle, struct inode *inode,
+ 	path = ext4_find_extent(inode, lb->first_block, NULL, 0);
+ 	if (IS_ERR(path)) {
+ 		retval = PTR_ERR(path);
+-		path = NULL;
+ 		goto err_out;
+ 	}
+ 
+@@ -53,7 +52,9 @@ static int finish_range(handle_t *handle, struct inode *inode,
+ 	retval = ext4_datasem_ensure_credits(handle, inode, needed, needed, 0);
+ 	if (retval < 0)
+ 		goto err_out;
+-	retval = ext4_ext_insert_extent(handle, inode, &path, &newext, 0);
++	path = ext4_ext_insert_extent(handle, inode, path, &newext, 0);
++	if (IS_ERR(path))
++		retval = PTR_ERR(path);
+ err_out:
+ 	up_write((&EXT4_I(inode)->i_data_sem));
+ 	ext4_free_ext_path(path);
+diff --git a/fs/ext4/move_extent.c b/fs/ext4/move_extent.c
+index a3b0acca02ca53..d5636a2a718a8d 100644
+--- a/fs/ext4/move_extent.c
++++ b/fs/ext4/move_extent.c
+@@ -26,16 +26,17 @@ static inline int
+ get_ext_path(struct inode *inode, ext4_lblk_t lblock,
+ 		struct ext4_ext_path **ppath)
+ {
+-	struct ext4_ext_path *path;
++	struct ext4_ext_path *path = *ppath;
+ 
+-	path = ext4_find_extent(inode, lblock, ppath, EXT4_EX_NOCACHE);
++	*ppath = NULL;
++	path = ext4_find_extent(inode, lblock, path, EXT4_EX_NOCACHE);
+ 	if (IS_ERR(path))
+ 		return PTR_ERR(path);
+ 	if (path[ext_depth(inode)].p_ext == NULL) {
+ 		ext4_free_ext_path(path);
+-		*ppath = NULL;
+ 		return -ENODATA;
+ 	}
++	*ppath = path;
+ 	return 0;
+ }
+ 
+diff --git a/fs/f2fs/gc.c b/fs/f2fs/gc.c
+index 8122135bb1fff0..5654608a119235 100644
+--- a/fs/f2fs/gc.c
++++ b/fs/f2fs/gc.c
+@@ -1742,6 +1742,13 @@ static int do_garbage_collect(struct f2fs_sb_info *sbi,
+ 					GET_SUM_BLOCK(sbi, segno));
+ 		f2fs_put_page(sum_page, 0);
+ 
++		if (IS_CURSEC(sbi, GET_SEC_FROM_SEG(sbi, segno))) {
++			f2fs_err(sbi, "%s: segment %u is used by log",
++							__func__, segno);
++			f2fs_bug_on(sbi, 1);
++			goto skip;
++		}
++
+ 		if (get_valid_blocks(sbi, segno, false) == 0)
+ 			goto freed;
+ 		if (gc_type == BG_GC && __is_large_section(sbi) &&
+@@ -1752,7 +1759,7 @@ static int do_garbage_collect(struct f2fs_sb_info *sbi,
+ 
+ 		sum = page_address(sum_page);
+ 		if (type != GET_SUM_TYPE((&sum->footer))) {
+-			f2fs_err(sbi, "Inconsistent segment (%u) type [%d, %d] in SSA and SIT",
++			f2fs_err(sbi, "Inconsistent segment (%u) type [%d, %d] in SIT and SSA",
+ 				 segno, type, GET_SUM_TYPE((&sum->footer)));
+ 			set_sbi_flag(sbi, SBI_NEED_FSCK);
+ 			f2fs_stop_checkpoint(sbi, false,
+@@ -2005,6 +2012,16 @@ int f2fs_gc_range(struct f2fs_sb_info *sbi,
+ 			.iroot = RADIX_TREE_INIT(gc_list.iroot, GFP_NOFS),
+ 		};
+ 
++		/*
++		 * avoid migrating empty section, as it can be allocated by
++		 * log in parallel.
++		 */
++		if (!get_valid_blocks(sbi, segno, true))
++			continue;
++
++		if (IS_CURSEC(sbi, GET_SEC_FROM_SEG(sbi, segno)))
++			continue;
++
+ 		do_garbage_collect(sbi, segno, &gc_list, FG_GC,
+ 						dry_run_sections == 0);
+ 		put_gc_inode(&gc_list);
+diff --git a/fs/iomap/buffered-io.c b/fs/iomap/buffered-io.c
+index 7e9480150d61e6..c5d439f8e2254e 100644
+--- a/fs/iomap/buffered-io.c
++++ b/fs/iomap/buffered-io.c
+@@ -1838,10 +1838,19 @@ iomap_writepage_map(struct iomap_writepage_ctx *wpc,
+ 		if (error)
+ 			break;
+ 		trace_iomap_writepage_map(inode, &wpc->iomap);
+-		if (WARN_ON_ONCE(wpc->iomap.type == IOMAP_INLINE))
+-			continue;
+-		if (wpc->iomap.type == IOMAP_HOLE)
++		switch (wpc->iomap.type) {
++		case IOMAP_UNWRITTEN:
++		case IOMAP_MAPPED:
++			break;
++		case IOMAP_HOLE:
+ 			continue;
++		default:
++			WARN_ON_ONCE(1);
++			error = -EIO;
++			break;
++		}
++		if (error)
++			break;
+ 		iomap_add_to_ioend(inode, pos, folio, ifs, wpc, wbc,
+ 				 &submit_list);
+ 		count++;
+diff --git a/fs/iomap/direct-io.c b/fs/iomap/direct-io.c
+index ec6b019f087fdc..0a82c69e360fe4 100644
+--- a/fs/iomap/direct-io.c
++++ b/fs/iomap/direct-io.c
+@@ -659,12 +659,12 @@ __iomap_dio_rw(struct kiocb *iocb, struct iov_iter *iter,
+ 			}
+ 			goto out_free_dio;
+ 		}
++	}
+ 
+-		if (!wait_for_completion && !inode->i_sb->s_dio_done_wq) {
+-			ret = sb_init_dio_done_wq(inode->i_sb);
+-			if (ret < 0)
+-				goto out_free_dio;
+-		}
++	if (!wait_for_completion && !inode->i_sb->s_dio_done_wq) {
++		ret = sb_init_dio_done_wq(inode->i_sb);
++		if (ret < 0)
++			goto out_free_dio;
+ 	}
+ 
+ 	inode_dio_begin(inode);
+diff --git a/fs/nfs/file.c b/fs/nfs/file.c
+index 2f4db026f8d678..cf16ee710d42b6 100644
+--- a/fs/nfs/file.c
++++ b/fs/nfs/file.c
+@@ -441,7 +441,7 @@ static void nfs_invalidate_folio(struct folio *folio, size_t offset,
+ 	/* Cancel any unstarted writes on this page */
+ 	nfs_wb_folio_cancel(inode, folio);
+ 	folio_wait_fscache(folio);
+-	trace_nfs_invalidate_folio(inode, folio);
++	trace_nfs_invalidate_folio(inode, folio_pos(folio) + offset, length);
+ }
+ 
+ /*
+@@ -459,7 +459,8 @@ static bool nfs_release_folio(struct folio *folio, gfp_t gfp)
+ 		if ((current_gfp_context(gfp) & GFP_KERNEL) != GFP_KERNEL ||
+ 		    current_is_kswapd() || current_is_kcompactd())
+ 			return false;
+-		if (nfs_wb_folio(folio_file_mapping(folio)->host, folio) < 0)
++		if (nfs_wb_folio_reclaim(folio_file_mapping(folio)->host, folio) < 0 ||
++		    folio_test_private(folio))
+ 			return false;
+ 	}
+ 	return nfs_fscache_release_folio(folio, gfp);
+@@ -509,7 +510,8 @@ static int nfs_launder_folio(struct folio *folio)
+ 
+ 	folio_wait_fscache(folio);
+ 	ret = nfs_wb_folio(inode, folio);
+-	trace_nfs_launder_folio_done(inode, folio, ret);
++	trace_nfs_launder_folio_done(inode, folio_pos(folio),
++			folio_size(folio), ret);
+ 	return ret;
+ }
+ 
+diff --git a/fs/nfs/nfs4proc.c b/fs/nfs/nfs4proc.c
+index fe6986939bc90b..42fa7c915e29b9 100644
+--- a/fs/nfs/nfs4proc.c
++++ b/fs/nfs/nfs4proc.c
+@@ -3792,8 +3792,8 @@ int nfs4_do_close(struct nfs4_state *state, gfp_t gfp_mask, int wait)
+ 	calldata->res.seqid = calldata->arg.seqid;
+ 	calldata->res.server = server;
+ 	calldata->res.lr_ret = -NFS4ERR_NOMATCHING_LAYOUT;
+-	calldata->lr.roc = pnfs_roc(state->inode,
+-			&calldata->lr.arg, &calldata->lr.res, msg.rpc_cred);
++	calldata->lr.roc = pnfs_roc(state->inode, &calldata->lr.arg,
++				    &calldata->lr.res, msg.rpc_cred, wait);
+ 	if (calldata->lr.roc) {
+ 		calldata->arg.lr_args = &calldata->lr.arg;
+ 		calldata->res.lr_res = &calldata->lr.res;
+@@ -6742,7 +6742,7 @@ static int _nfs4_proc_delegreturn(struct inode *inode, const struct cred *cred,
+ 	data->inode = nfs_igrab_and_active(inode);
+ 	if (data->inode || issync) {
+ 		data->lr.roc = pnfs_roc(inode, &data->lr.arg, &data->lr.res,
+-					cred);
++					cred, issync);
+ 		if (data->lr.roc) {
+ 			data->args.lr_args = &data->lr.arg;
+ 			data->res.lr_res = &data->lr.res;
+diff --git a/fs/nfs/nfstrace.h b/fs/nfs/nfstrace.h
+index 4e90ca531176d9..85224e9369e7a6 100644
+--- a/fs/nfs/nfstrace.h
++++ b/fs/nfs/nfstrace.h
+@@ -933,10 +933,11 @@ TRACE_EVENT(nfs_sillyrename_unlink,
+ DECLARE_EVENT_CLASS(nfs_folio_event,
+ 		TP_PROTO(
+ 			const struct inode *inode,
+-			struct folio *folio
++			loff_t offset,
++			size_t count
+ 		),
+ 
+-		TP_ARGS(inode, folio),
++		TP_ARGS(inode, offset, count),
+ 
+ 		TP_STRUCT__entry(
+ 			__field(dev_t, dev)
+@@ -944,7 +945,7 @@ DECLARE_EVENT_CLASS(nfs_folio_event,
+ 			__field(u64, fileid)
+ 			__field(u64, version)
+ 			__field(loff_t, offset)
+-			__field(u32, count)
++			__field(size_t, count)
+ 		),
+ 
+ 		TP_fast_assign(
+@@ -954,13 +955,13 @@ DECLARE_EVENT_CLASS(nfs_folio_event,
+ 			__entry->fileid = nfsi->fileid;
+ 			__entry->fhandle = nfs_fhandle_hash(&nfsi->fh);
+ 			__entry->version = inode_peek_iversion_raw(inode);
+-			__entry->offset = folio_file_pos(folio);
+-			__entry->count = nfs_folio_length(folio);
++			__entry->offset = offset,
++			__entry->count = count;
+ 		),
+ 
+ 		TP_printk(
+ 			"fileid=%02x:%02x:%llu fhandle=0x%08x version=%llu "
+-			"offset=%lld count=%u",
++			"offset=%lld count=%zu",
+ 			MAJOR(__entry->dev), MINOR(__entry->dev),
+ 			(unsigned long long)__entry->fileid,
+ 			__entry->fhandle, __entry->version,
+@@ -972,18 +973,20 @@ DECLARE_EVENT_CLASS(nfs_folio_event,
+ 	DEFINE_EVENT(nfs_folio_event, name, \
+ 			TP_PROTO( \
+ 				const struct inode *inode, \
+-				struct folio *folio \
++				loff_t offset, \
++				size_t count \
+ 			), \
+-			TP_ARGS(inode, folio))
++			TP_ARGS(inode, offset, count))
+ 
+ DECLARE_EVENT_CLASS(nfs_folio_event_done,
+ 		TP_PROTO(
+ 			const struct inode *inode,
+-			struct folio *folio,
++			loff_t offset,
++			size_t count,
+ 			int ret
+ 		),
+ 
+-		TP_ARGS(inode, folio, ret),
++		TP_ARGS(inode, offset, count, ret),
+ 
+ 		TP_STRUCT__entry(
+ 			__field(dev_t, dev)
+@@ -992,7 +995,7 @@ DECLARE_EVENT_CLASS(nfs_folio_event_done,
+ 			__field(u64, fileid)
+ 			__field(u64, version)
+ 			__field(loff_t, offset)
+-			__field(u32, count)
++			__field(size_t, count)
+ 		),
+ 
+ 		TP_fast_assign(
+@@ -1002,14 +1005,14 @@ DECLARE_EVENT_CLASS(nfs_folio_event_done,
+ 			__entry->fileid = nfsi->fileid;
+ 			__entry->fhandle = nfs_fhandle_hash(&nfsi->fh);
+ 			__entry->version = inode_peek_iversion_raw(inode);
+-			__entry->offset = folio_file_pos(folio);
+-			__entry->count = nfs_folio_length(folio);
++			__entry->offset = offset,
++			__entry->count = count,
+ 			__entry->ret = ret;
+ 		),
+ 
+ 		TP_printk(
+ 			"fileid=%02x:%02x:%llu fhandle=0x%08x version=%llu "
+-			"offset=%lld count=%u ret=%d",
++			"offset=%lld count=%zu ret=%d",
+ 			MAJOR(__entry->dev), MINOR(__entry->dev),
+ 			(unsigned long long)__entry->fileid,
+ 			__entry->fhandle, __entry->version,
+@@ -1021,14 +1024,18 @@ DECLARE_EVENT_CLASS(nfs_folio_event_done,
+ 	DEFINE_EVENT(nfs_folio_event_done, name, \
+ 			TP_PROTO( \
+ 				const struct inode *inode, \
+-				struct folio *folio, \
++				loff_t offset, \
++				size_t count, \
+ 				int ret \
+ 			), \
+-			TP_ARGS(inode, folio, ret))
++			TP_ARGS(inode, offset, count, ret))
+ 
+ DEFINE_NFS_FOLIO_EVENT(nfs_aop_readpage);
+ DEFINE_NFS_FOLIO_EVENT_DONE(nfs_aop_readpage_done);
+ 
++DEFINE_NFS_FOLIO_EVENT(nfs_writeback_folio_reclaim);
++DEFINE_NFS_FOLIO_EVENT_DONE(nfs_writeback_folio_reclaim_done);
++
+ DEFINE_NFS_FOLIO_EVENT(nfs_writeback_folio);
+ DEFINE_NFS_FOLIO_EVENT_DONE(nfs_writeback_folio_done);
+ 
+diff --git a/fs/nfs/pnfs.c b/fs/nfs/pnfs.c
+index 7dae2004c65f90..315383941abdc6 100644
+--- a/fs/nfs/pnfs.c
++++ b/fs/nfs/pnfs.c
+@@ -1427,10 +1427,9 @@ pnfs_commit_and_return_layout(struct inode *inode)
+ 	return ret;
+ }
+ 
+-bool pnfs_roc(struct inode *ino,
+-		struct nfs4_layoutreturn_args *args,
+-		struct nfs4_layoutreturn_res *res,
+-		const struct cred *cred)
++bool pnfs_roc(struct inode *ino, struct nfs4_layoutreturn_args *args,
++	      struct nfs4_layoutreturn_res *res, const struct cred *cred,
++	      bool sync)
+ {
+ 	struct nfs_inode *nfsi = NFS_I(ino);
+ 	struct nfs_open_context *ctx;
+@@ -1441,7 +1440,7 @@ bool pnfs_roc(struct inode *ino,
+ 	nfs4_stateid stateid;
+ 	enum pnfs_iomode iomode = 0;
+ 	bool layoutreturn = false, roc = false;
+-	bool skip_read = false;
++	bool skip_read;
+ 
+ 	if (!nfs_have_layout(ino))
+ 		return false;
+@@ -1454,20 +1453,14 @@ retry:
+ 		lo = NULL;
+ 		goto out_noroc;
+ 	}
+-	pnfs_get_layout_hdr(lo);
+-	if (test_bit(NFS_LAYOUT_RETURN_LOCK, &lo->plh_flags)) {
+-		spin_unlock(&ino->i_lock);
+-		rcu_read_unlock();
+-		wait_on_bit(&lo->plh_flags, NFS_LAYOUT_RETURN,
+-				TASK_UNINTERRUPTIBLE);
+-		pnfs_put_layout_hdr(lo);
+-		goto retry;
+-	}
+ 
+ 	/* no roc if we hold a delegation */
++	skip_read = false;
+ 	if (nfs4_check_delegation(ino, FMODE_READ)) {
+-		if (nfs4_check_delegation(ino, FMODE_WRITE))
++		if (nfs4_check_delegation(ino, FMODE_WRITE)) {
++			lo = NULL;
+ 			goto out_noroc;
++		}
+ 		skip_read = true;
+ 	}
+ 
+@@ -1476,12 +1469,43 @@ retry:
+ 		if (state == NULL)
+ 			continue;
+ 		/* Don't return layout if there is open file state */
+-		if (state->state & FMODE_WRITE)
++		if (state->state & FMODE_WRITE) {
++			lo = NULL;
+ 			goto out_noroc;
++		}
+ 		if (state->state & FMODE_READ)
+ 			skip_read = true;
+ 	}
+ 
++	if (skip_read) {
++		bool writes = false;
++
++		list_for_each_entry(lseg, &lo->plh_segs, pls_list) {
++			if (lseg->pls_range.iomode != IOMODE_READ) {
++				writes = true;
++				break;
++			}
++		}
++		if (!writes) {
++			lo = NULL;
++			goto out_noroc;
++		}
++	}
++
++	pnfs_get_layout_hdr(lo);
++	if (test_bit(NFS_LAYOUT_RETURN_LOCK, &lo->plh_flags)) {
++		if (!sync) {
++			pnfs_set_plh_return_info(
++				lo, skip_read ? IOMODE_RW : IOMODE_ANY, 0);
++			goto out_noroc;
++		}
++		spin_unlock(&ino->i_lock);
++		rcu_read_unlock();
++		wait_on_bit(&lo->plh_flags, NFS_LAYOUT_RETURN,
++			    TASK_UNINTERRUPTIBLE);
++		pnfs_put_layout_hdr(lo);
++		goto retry;
++	}
+ 
+ 	list_for_each_entry_safe(lseg, next, &lo->plh_segs, pls_list) {
+ 		if (skip_read && lseg->pls_range.iomode == IOMODE_READ)
+@@ -1521,7 +1545,7 @@ retry:
+ out_noroc:
+ 	spin_unlock(&ino->i_lock);
+ 	rcu_read_unlock();
+-	pnfs_layoutcommit_inode(ino, true);
++	pnfs_layoutcommit_inode(ino, sync);
+ 	if (roc) {
+ 		struct pnfs_layoutdriver_type *ld = NFS_SERVER(ino)->pnfs_curr_ld;
+ 		if (ld->prepare_layoutreturn)
+diff --git a/fs/nfs/pnfs.h b/fs/nfs/pnfs.h
+index 79996d7dad0f76..a613466f6f2205 100644
+--- a/fs/nfs/pnfs.h
++++ b/fs/nfs/pnfs.h
+@@ -295,10 +295,9 @@ int pnfs_mark_matching_lsegs_return(struct pnfs_layout_hdr *lo,
+ 				u32 seq);
+ int pnfs_mark_layout_stateid_invalid(struct pnfs_layout_hdr *lo,
+ 		struct list_head *lseg_list);
+-bool pnfs_roc(struct inode *ino,
+-		struct nfs4_layoutreturn_args *args,
+-		struct nfs4_layoutreturn_res *res,
+-		const struct cred *cred);
++bool pnfs_roc(struct inode *ino, struct nfs4_layoutreturn_args *args,
++	      struct nfs4_layoutreturn_res *res, const struct cred *cred,
++	      bool sync);
+ int pnfs_roc_done(struct rpc_task *task, struct nfs4_layoutreturn_args **argpp,
+ 		  struct nfs4_layoutreturn_res **respp, int *ret);
+ void pnfs_roc_release(struct nfs4_layoutreturn_args *args,
+@@ -769,12 +768,10 @@ pnfs_layoutcommit_outstanding(struct inode *inode)
+ 	return false;
+ }
+ 
+-
+-static inline bool
+-pnfs_roc(struct inode *ino,
+-		struct nfs4_layoutreturn_args *args,
+-		struct nfs4_layoutreturn_res *res,
+-		const struct cred *cred)
++static inline bool pnfs_roc(struct inode *ino,
++			    struct nfs4_layoutreturn_args *args,
++			    struct nfs4_layoutreturn_res *res,
++			    const struct cred *cred, bool sync)
+ {
+ 	return false;
+ }
+diff --git a/fs/nfs/read.c b/fs/nfs/read.c
+index 688a24e9bc8bb8..ed411897e33faf 100644
+--- a/fs/nfs/read.c
++++ b/fs/nfs/read.c
+@@ -333,13 +333,15 @@ out:
+ int nfs_read_folio(struct file *file, struct folio *folio)
+ {
+ 	struct inode *inode = file_inode(file);
++	loff_t pos = folio_pos(folio);
++	size_t len = folio_size(folio);
+ 	struct nfs_pageio_descriptor pgio;
+ 	struct nfs_open_context *ctx;
+ 	int ret;
+ 
+-	trace_nfs_aop_readpage(inode, folio);
++	trace_nfs_aop_readpage(inode, pos, len);
+ 	nfs_inc_stats(inode, NFSIOS_VFSREADPAGE);
+-	task_io_account_read(folio_size(folio));
++	task_io_account_read(len);
+ 
+ 	/*
+ 	 * Try to flush any pending writes to the file..
+@@ -382,7 +384,7 @@ int nfs_read_folio(struct file *file, struct folio *folio)
+ out_put:
+ 	put_nfs_open_context(ctx);
+ out:
+-	trace_nfs_aop_readpage_done(inode, folio, ret);
++	trace_nfs_aop_readpage_done(inode, pos, len, ret);
+ 	return ret;
+ out_unlock:
+ 	folio_unlock(folio);
+diff --git a/fs/nfs/write.c b/fs/nfs/write.c
+index ef69b15aa72e5f..dc57e67cefcd18 100644
+--- a/fs/nfs/write.c
++++ b/fs/nfs/write.c
+@@ -2121,6 +2121,39 @@ int nfs_wb_folio_cancel(struct inode *inode, struct folio *folio)
+ 	return ret;
+ }
+ 
++/**
++ * nfs_wb_folio_reclaim - Write back all requests on one page
++ * @inode: pointer to page
++ * @folio: pointer to folio
++ *
++ * Assumes that the folio has been locked by the caller
++ */
++int nfs_wb_folio_reclaim(struct inode *inode, struct folio *folio)
++{
++	loff_t range_start = folio_pos(folio);
++	size_t len = folio_size(folio);
++	struct writeback_control wbc = {
++		.sync_mode = WB_SYNC_ALL,
++		.nr_to_write = 0,
++		.range_start = range_start,
++		.range_end = range_start + len - 1,
++		.for_sync = 1,
++	};
++	int ret;
++
++	if (folio_test_writeback(folio))
++		return -EBUSY;
++	if (folio_clear_dirty_for_io(folio)) {
++		trace_nfs_writeback_folio_reclaim(inode, range_start, len);
++		ret = nfs_writepage_locked(folio, &wbc);
++		trace_nfs_writeback_folio_reclaim_done(inode, range_start, len,
++						       ret);
++		return ret;
++	}
++	nfs_commit_inode(inode, 0);
++	return 0;
++}
++
+ /**
+  * nfs_wb_folio - Write back all requests on one page
+  * @inode: pointer to page
+@@ -2131,17 +2164,17 @@ int nfs_wb_folio_cancel(struct inode *inode, struct folio *folio)
+  */
+ int nfs_wb_folio(struct inode *inode, struct folio *folio)
+ {
+-	loff_t range_start = folio_file_pos(folio);
+-	loff_t range_end = range_start + (loff_t)folio_size(folio) - 1;
++	loff_t range_start = folio_pos(folio);
++	size_t len = folio_size(folio);
+ 	struct writeback_control wbc = {
+ 		.sync_mode = WB_SYNC_ALL,
+ 		.nr_to_write = 0,
+ 		.range_start = range_start,
+-		.range_end = range_end,
++		.range_end = range_start + len - 1,
+ 	};
+ 	int ret;
+ 
+-	trace_nfs_writeback_folio(inode, folio);
++	trace_nfs_writeback_folio(inode, range_start, len);
+ 
+ 	for (;;) {
+ 		folio_wait_writeback(folio);
+@@ -2159,7 +2192,7 @@ int nfs_wb_folio(struct inode *inode, struct folio *folio)
+ 			goto out_error;
+ 	}
+ out_error:
+-	trace_nfs_writeback_folio_done(inode, folio, ret);
++	trace_nfs_writeback_folio_done(inode, range_start, len, ret);
+ 	return ret;
+ }
+ 
+diff --git a/fs/nfsd/nfs4xdr.c b/fs/nfsd/nfs4xdr.c
+index d84eaae7cd0b62..03a4a8de111402 100644
+--- a/fs/nfsd/nfs4xdr.c
++++ b/fs/nfsd/nfs4xdr.c
+@@ -5425,9 +5425,14 @@ nfsd4_encode_operation(struct nfsd4_compoundres *resp, struct nfsd4_op *op)
+ 		int len = xdr->buf->len - post_err_offset;
+ 
+ 		so->so_replay.rp_status = op->status;
+-		so->so_replay.rp_buflen = len;
+-		read_bytes_from_xdr_buf(xdr->buf, post_err_offset,
++		if (len <= NFSD4_REPLAY_ISIZE) {
++			so->so_replay.rp_buflen = len;
++			read_bytes_from_xdr_buf(xdr->buf,
++						post_err_offset,
+ 						so->so_replay.rp_buf, len);
++		} else {
++			so->so_replay.rp_buflen = 0;
++		}
+ 	}
+ status:
+ 	*p = op->status;
+diff --git a/fs/nfsd/nfsctl.c b/fs/nfsd/nfsctl.c
+index 4703e2a935684b..9b7f3145255111 100644
+--- a/fs/nfsd/nfsctl.c
++++ b/fs/nfsd/nfsctl.c
+@@ -151,9 +151,19 @@ static int exports_net_open(struct net *net, struct file *file)
+ 
+ 	seq = file->private_data;
+ 	seq->private = nn->svc_export_cache;
++	get_net(net);
+ 	return 0;
+ }
+ 
++static int exports_release(struct inode *inode, struct file *file)
++{
++	struct seq_file *seq = file->private_data;
++	struct cache_detail *cd = seq->private;
++
++	put_net(cd->net);
++	return seq_release(inode, file);
++}
++
+ static int exports_nfsd_open(struct inode *inode, struct file *file)
+ {
+ 	return exports_net_open(inode->i_sb->s_fs_info, file);
+@@ -163,7 +173,7 @@ static const struct file_operations exports_nfsd_operations = {
+ 	.open		= exports_nfsd_open,
+ 	.read		= seq_read,
+ 	.llseek		= seq_lseek,
+-	.release	= seq_release,
++	.release	= exports_release,
+ };
+ 
+ static int export_features_show(struct seq_file *m, void *v)
+@@ -1476,7 +1486,7 @@ static const struct proc_ops exports_proc_ops = {
+ 	.proc_open	= exports_proc_open,
+ 	.proc_read	= seq_read,
+ 	.proc_lseek	= seq_lseek,
+-	.proc_release	= seq_release,
++	.proc_release	= exports_release,
+ };
+ 
+ static int create_proc_exports_entry(void)
+diff --git a/fs/nfsd/state.h b/fs/nfsd/state.h
+index 5da7785609b07f..d1450fe7e2b90e 100644
+--- a/fs/nfsd/state.h
++++ b/fs/nfsd/state.h
+@@ -430,11 +430,18 @@ struct nfs4_client_reclaim {
+ 	struct xdr_netobj	cr_princhash;
+ };
+ 
+-/* A reasonable value for REPLAY_ISIZE was estimated as follows:  
+- * The OPEN response, typically the largest, requires 
+- *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +  8(verifier) + 
+- *   4(deleg. type) + 8(deleg. stateid) + 4(deleg. recall flag) + 
+- *   20(deleg. space limit) + ~32(deleg. ace) = 112 bytes 
++/*
++ * REPLAY_ISIZE is sized for an OPEN response with delegation:
++ *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +
++ *   8(verifier) + 4(deleg. type) + 8(deleg. stateid) +
++ *   4(deleg. recall flag) + 20(deleg. space limit) +
++ *   ~32(deleg. ace) = 112 bytes
++ *
++ * Some responses can exceed this. A LOCK denial includes the conflicting
++ * lock owner, which can be up to 1024 bytes (NFS4_OPAQUE_LIMIT). Responses
++ * larger than REPLAY_ISIZE are not cached in rp_ibuf; only rp_status is
++ * saved. Enlarging this constant increases the size of every
++ * nfs4_stateowner.
+  */
+ 
+ #define NFSD4_REPLAY_ISIZE       112 
+diff --git a/fs/smb/client/cifsencrypt.c b/fs/smb/client/cifsencrypt.c
+index da3d003cb43db8..3d6b6632123356 100644
+--- a/fs/smb/client/cifsencrypt.c
++++ b/fs/smb/client/cifsencrypt.c
+@@ -23,6 +23,7 @@
+ #include <linux/fips.h>
+ #include "../common/arc4.h"
+ #include <crypto/aead.h>
++#include <crypto/utils.h>
+ 
+ /*
+  * Hash data from a BVEC-type iterator.
+@@ -371,7 +372,7 @@ int cifs_verify_signature(struct smb_rqst *rqst,
+ /*	cifs_dump_mem("what we think it should be: ",
+ 		      what_we_think_sig_should_be, 16); */
+ 
+-	if (memcmp(server_response_sig, what_we_think_sig_should_be, 8))
++	if (crypto_memneq(server_response_sig, what_we_think_sig_should_be, 8))
+ 		return -EACCES;
+ 	else
+ 		return 0;
+diff --git a/fs/smb/client/cifsfs.c b/fs/smb/client/cifsfs.c
+index 0461f89c4852ed..11712e8c39db03 100644
+--- a/fs/smb/client/cifsfs.c
++++ b/fs/smb/client/cifsfs.c
+@@ -290,10 +290,14 @@ static void cifs_kill_sb(struct super_block *sb)
+ 
+ 	/*
+ 	 * We need to release all dentries for the cached directories
+-	 * before we kill the sb.
++	 * and close all deferred file handles before we kill the sb.
+ 	 */
+ 	if (cifs_sb->root) {
+ 		close_all_cached_dirs(cifs_sb);
++		cifs_close_all_deferred_files_sb(cifs_sb);
++
++		/* Wait for all pending oplock breaks to complete */
++		flush_workqueue(cifsoplockd_wq);
+ 
+ 		/* finally release root dentry */
+ 		dput(cifs_sb->root);
+@@ -768,7 +772,6 @@ static void cifs_umount_begin(struct super_block *sb)
+ 	spin_unlock(&tcon->tc_lock);
+ 	spin_unlock(&cifs_tcp_ses_lock);
+ 
+-	cifs_close_all_deferred_files(tcon);
+ 	/* cancel_brl_requests(tcon); */ /* BB mark all brl mids as exiting */
+ 	/* cancel_notify_requests(tcon); */
+ 	if (tcon->ses && tcon->ses->server) {
+diff --git a/fs/smb/client/cifsglob.h b/fs/smb/client/cifsglob.h
+index 6168c6d62b5e59..8e85332cb7abcc 100644
+--- a/fs/smb/client/cifsglob.h
++++ b/fs/smb/client/cifsglob.h
+@@ -20,6 +20,7 @@
+ #include <linux/utsname.h>
+ #include <linux/sched/mm.h>
+ #include <linux/netfs.h>
++#include <linux/fcntl.h>
+ #include "cifs_fs_sb.h"
+ #include "cifsacl.h"
+ #include <crypto/internal/hash.h>
+@@ -2354,4 +2355,14 @@ static inline bool cifs_ses_exiting(struct cifs_ses *ses)
+ 	return ret;
+ }
+ 
++static inline int cifs_open_create_options(unsigned int oflags, int opts)
++{
++	/* O_SYNC also has bit for O_DSYNC so following check picks up either */
++	if (oflags & O_SYNC)
++		opts |= CREATE_WRITE_THROUGH;
++	if (oflags & O_DIRECT)
++		opts |= CREATE_NO_BUFFER;
++	return opts;
++}
++
+ #endif	/* _CIFS_GLOB_H */
+diff --git a/fs/smb/client/cifsproto.h b/fs/smb/client/cifsproto.h
+index 5ab877e480abcb..1f37bc2923fb89 100644
+--- a/fs/smb/client/cifsproto.h
++++ b/fs/smb/client/cifsproto.h
+@@ -300,6 +300,7 @@ extern void cifs_close_deferred_file(struct cifsInodeInfo *cifs_inode);
+ 
+ extern void cifs_close_all_deferred_files(struct cifs_tcon *cifs_tcon);
+ 
++void cifs_close_all_deferred_files_sb(struct cifs_sb_info *cifs_sb);
+ extern void cifs_close_deferred_file_under_dentry(struct cifs_tcon *cifs_tcon,
+ 				const char *path);
+ 
+diff --git a/fs/smb/client/connect.c b/fs/smb/client/connect.c
+index 59220ebd6eccef..78feea9c262ef0 100644
+--- a/fs/smb/client/connect.c
++++ b/fs/smb/client/connect.c
+@@ -1922,6 +1922,10 @@ static int match_session(struct cifs_ses *ses,
+ 	case Kerberos:
+ 		if (!uid_eq(ctx->cred_uid, ses->cred_uid))
+ 			return 0;
++		if (strncmp(ses->user_name ?: "",
++			    ctx->username ?: "",
++			    CIFS_MAX_USERNAME_LEN))
++			return 0;
+ 		break;
+ 	case NTLMv2:
+ 	case RawNTLMSSP:
+@@ -2214,7 +2218,6 @@ cifs_set_cifscreds(struct smb3_fs_context *ctx, struct cifs_ses *ses)
+ 	/* find first : in payload */
+ 	payload = upayload->data;
+ 	delim = strnchr(payload, upayload->datalen, ':');
+-	cifs_dbg(FYI, "payload=%s\n", payload);
+ 	if (!delim) {
+ 		cifs_dbg(FYI, "Unable to find ':' in payload (datalen=%d)\n",
+ 			 upayload->datalen);
+diff --git a/fs/smb/client/dir.c b/fs/smb/client/dir.c
+index 1822493dd0842e..6bb0e98462a986 100644
+--- a/fs/smb/client/dir.c
++++ b/fs/smb/client/dir.c
+@@ -304,6 +304,7 @@ static int cifs_do_create(struct inode *inode, struct dentry *direntry, unsigned
+ 		goto out;
+ 	}
+ 
++	create_options |= cifs_open_create_options(oflags, create_options);
+ 	/*
+ 	 * if we're not using unix extensions, see if we need to set
+ 	 * ATTR_READONLY on the create call
+diff --git a/fs/smb/client/file.c b/fs/smb/client/file.c
+index 92e43589fd83f1..94c8b173a8d630 100644
+--- a/fs/smb/client/file.c
++++ b/fs/smb/client/file.c
+@@ -459,15 +459,8 @@ static int cifs_nt_open(const char *full_path, struct inode *inode, struct cifs_
+  *********************************************************************/
+ 
+ 	disposition = cifs_get_disposition(f_flags);
+-
+ 	/* BB pass O_SYNC flag through on file attributes .. BB */
+-
+-	/* O_SYNC also has bit for O_DSYNC so following check picks up either */
+-	if (f_flags & O_SYNC)
+-		create_options |= CREATE_WRITE_THROUGH;
+-
+-	if (f_flags & O_DIRECT)
+-		create_options |= CREATE_NO_BUFFER;
++	create_options |= cifs_open_create_options(f_flags, create_options);
+ 
+ retry_open:
+ 	oparms = (struct cifs_open_parms) {
+@@ -586,8 +579,6 @@ struct cifsFileInfo *cifs_new_fileinfo(struct cifs_fid *fid, struct file *file,
+ 	mutex_init(&cfile->fh_mutex);
+ 	spin_lock_init(&cfile->file_info_lock);
+ 
+-	cifs_sb_active(inode->i_sb);
+-
+ 	/*
+ 	 * If the server returned a read oplock and we have mandatory brlocks,
+ 	 * set oplock level to None.
+@@ -642,7 +633,6 @@ static void cifsFileInfo_put_final(struct cifsFileInfo *cifs_file)
+ 	struct inode *inode = d_inode(cifs_file->dentry);
+ 	struct cifsInodeInfo *cifsi = CIFS_I(inode);
+ 	struct cifsLockInfo *li, *tmp;
+-	struct super_block *sb = inode->i_sb;
+ 
+ 	/*
+ 	 * Delete any outstanding lock records. We'll lose them when the file
+@@ -660,7 +650,6 @@ static void cifsFileInfo_put_final(struct cifsFileInfo *cifs_file)
+ 
+ 	cifs_put_tlink(cifs_file->tlink);
+ 	dput(cifs_file->dentry);
+-	cifs_sb_deactive(sb);
+ 	kfree(cifs_file->symlink_target);
+ 	kfree(cifs_file);
+ }
+@@ -1117,13 +1106,8 @@ cifs_reopen_file(struct cifsFileInfo *cfile, bool can_flush)
+ 		rdwr_for_fscache = 1;
+ 
+ 	desired_access = cifs_convert_flags(cfile->f_flags, rdwr_for_fscache);
+-
+-	/* O_SYNC also has bit for O_DSYNC so following check picks up either */
+-	if (cfile->f_flags & O_SYNC)
+-		create_options |= CREATE_WRITE_THROUGH;
+-
+-	if (cfile->f_flags & O_DIRECT)
+-		create_options |= CREATE_NO_BUFFER;
++	create_options |= cifs_open_create_options(cfile->f_flags,
++						   create_options);
+ 
+ 	if (server->ops->get_lease_key)
+ 		server->ops->get_lease_key(inode, &cfile->fid);
+@@ -5166,12 +5150,6 @@ void cifs_oplock_break(struct work_struct *work)
+ 	__u64 persistent_fid, volatile_fid;
+ 	__u16 net_fid;
+ 
+-	/*
+-	 * Hold a reference to the superblock to prevent it and its inodes from
+-	 * being freed while we are accessing cinode. Otherwise, _cifsFileInfo_put()
+-	 * may release the last reference to the sb and trigger inode eviction.
+-	 */
+-	cifs_sb_active(sb);
+ 	wait_on_bit(&cinode->flags, CIFS_INODE_PENDING_WRITERS,
+ 			TASK_UNINTERRUPTIBLE);
+ 
+@@ -5244,7 +5222,6 @@ oplock_break_ack:
+ 	cifs_put_tlink(tlink);
+ out:
+ 	cifs_done_oplock_break(cinode);
+-	cifs_sb_deactive(sb);
+ }
+ 
+ /*
+diff --git a/fs/smb/client/fs_context.c b/fs/smb/client/fs_context.c
+index 37b04c23ee8986..930f9c17a8d6d0 100644
+--- a/fs/smb/client/fs_context.c
++++ b/fs/smb/client/fs_context.c
+@@ -1809,7 +1809,7 @@ int smb3_init_fs_context(struct fs_context *fc)
+ 	ctx->backupuid_specified = false; /* no backup intent for a user */
+ 	ctx->backupgid_specified = false; /* no backup intent for a group */
+ 
+-	ctx->retrans = 1;
++	ctx->retrans = 0;
+ 	ctx->reparse_type = CIFS_REPARSE_TYPE_DEFAULT;
+ 
+ /*
+diff --git a/fs/smb/client/misc.c b/fs/smb/client/misc.c
+index 9b5aeafe220bd9..a31b4e912719cc 100644
+--- a/fs/smb/client/misc.c
++++ b/fs/smb/client/misc.c
+@@ -27,6 +27,11 @@
+ #include "fs_context.h"
+ #include "cached_dir.h"
+ 
++struct tcon_list {
++	struct list_head entry;
++	struct cifs_tcon *tcon;
++};
++
+ /* The xid serves as a useful identifier for each incoming vfs request,
+    in a similar way to the mid which is useful to track each sent smb,
+    and CurrentXid can also provide a running counter (although it
+@@ -831,6 +836,44 @@ cifs_close_all_deferred_files(struct cifs_tcon *tcon)
+ 		kfree(tmp_list);
+ 	}
+ }
++
++void cifs_close_all_deferred_files_sb(struct cifs_sb_info *cifs_sb)
++{
++	struct rb_root *root = &cifs_sb->tlink_tree;
++	struct rb_node *node;
++	struct cifs_tcon *tcon;
++	struct tcon_link *tlink;
++	struct tcon_list *tmp_list, *q;
++	LIST_HEAD(tcon_head);
++
++	spin_lock(&cifs_sb->tlink_tree_lock);
++	for (node = rb_first(root); node; node = rb_next(node)) {
++		tlink = rb_entry(node, struct tcon_link, tl_rbnode);
++		tcon = tlink_tcon(tlink);
++		if (IS_ERR(tcon))
++			continue;
++		tmp_list = kmalloc(sizeof(struct tcon_list), GFP_ATOMIC);
++		if (tmp_list == NULL)
++			break;
++		tmp_list->tcon = tcon;
++		/* Take a reference on tcon to prevent it from being freed */
++		spin_lock(&tcon->tc_lock);
++		++tcon->tc_count;
++		trace_smb3_tcon_ref(tcon->debug_id, tcon->tc_count,
++				    netfs_trace_tcon_ref_get_close_defer_files);
++		spin_unlock(&tcon->tc_lock);
++		list_add_tail(&tmp_list->entry, &tcon_head);
++	}
++	spin_unlock(&cifs_sb->tlink_tree_lock);
++
++	list_for_each_entry_safe(tmp_list, q, &tcon_head, entry) {
++		cifs_close_all_deferred_files(tmp_list->tcon);
++		list_del(&tmp_list->entry);
++		cifs_put_tcon(tmp_list->tcon, netfs_trace_tcon_ref_put_close_defer_files);
++		kfree(tmp_list);
++	}
++}
++
+ void
+ cifs_close_deferred_file_under_dentry(struct cifs_tcon *tcon, const char *path)
+ {
+diff --git a/fs/smb/client/smb2inode.c b/fs/smb/client/smb2inode.c
+index d6086394d0b844..c576d82799acb7 100644
+--- a/fs/smb/client/smb2inode.c
++++ b/fs/smb/client/smb2inode.c
+@@ -315,7 +315,7 @@ replay_again:
+ 							  cfile->fid.volatile_fid,
+ 							  SMB_FIND_FILE_POSIX_INFO,
+ 							  SMB2_O_INFO_FILE, 0,
+-							  sizeof(struct smb311_posix_qinfo *) +
++							  sizeof(struct smb311_posix_qinfo) +
+ 							  (PATH_MAX * 2) +
+ 							  (sizeof(struct smb_sid) * 2), 0, NULL);
+ 			} else {
+@@ -325,7 +325,7 @@ replay_again:
+ 							  COMPOUND_FID,
+ 							  SMB_FIND_FILE_POSIX_INFO,
+ 							  SMB2_O_INFO_FILE, 0,
+-							  sizeof(struct smb311_posix_qinfo *) +
++							  sizeof(struct smb311_posix_qinfo) +
+ 							  (PATH_MAX * 2) +
+ 							  (sizeof(struct smb_sid) * 2), 0, NULL);
+ 			}
+diff --git a/fs/smb/client/smb2ops.c b/fs/smb/client/smb2ops.c
+index 63752bd02aafe3..e3f7a1383e22f6 100644
+--- a/fs/smb/client/smb2ops.c
++++ b/fs/smb/client/smb2ops.c
+@@ -586,6 +586,7 @@ parse_server_interfaces(struct network_interface_info_ioctl_rsp *buf,
+ 	struct iface_info_ipv6 *p6;
+ 	struct cifs_server_iface *info = NULL, *iface = NULL, *niface = NULL;
+ 	struct cifs_server_iface tmp_iface;
++	__be16 port;
+ 	ssize_t bytes_left;
+ 	size_t next = 0;
+ 	int nb_iface = 0;
+@@ -620,6 +621,15 @@ parse_server_interfaces(struct network_interface_info_ioctl_rsp *buf,
+ 		goto out;
+ 	}
+ 
++	spin_lock(&ses->server->srv_lock);
++	if (ses->server->dstaddr.ss_family == AF_INET)
++		port = ((struct sockaddr_in *)&ses->server->dstaddr)->sin_port;
++	else if (ses->server->dstaddr.ss_family == AF_INET6)
++		port = ((struct sockaddr_in6 *)&ses->server->dstaddr)->sin6_port;
++	else
++		port = cpu_to_be16(CIFS_PORT);
++	spin_unlock(&ses->server->srv_lock);
++
+ 	while (bytes_left >= (ssize_t)sizeof(*p)) {
+ 		memset(&tmp_iface, 0, sizeof(tmp_iface));
+ 		/* default to 1Gbps when link speed is unset */
+@@ -640,7 +650,7 @@ parse_server_interfaces(struct network_interface_info_ioctl_rsp *buf,
+ 			memcpy(&addr4->sin_addr, &p4->IPv4Address, 4);
+ 
+ 			/* [MS-SMB2] 2.2.32.5.1.1 Clients MUST ignore these */
+-			addr4->sin_port = cpu_to_be16(CIFS_PORT);
++			addr4->sin_port = port;
+ 
+ 			cifs_dbg(FYI, "%s: ipv4 %pI4\n", __func__,
+ 				 &addr4->sin_addr);
+@@ -654,7 +664,7 @@ parse_server_interfaces(struct network_interface_info_ioctl_rsp *buf,
+ 			/* [MS-SMB2] 2.2.32.5.1.2 Clients MUST ignore these */
+ 			addr6->sin6_flowinfo = 0;
+ 			addr6->sin6_scope_id = 0;
+-			addr6->sin6_port = cpu_to_be16(CIFS_PORT);
++			addr6->sin6_port = port;
+ 
+ 			cifs_dbg(FYI, "%s: ipv6 %pI6\n", __func__,
+ 				 &addr6->sin6_addr);
+diff --git a/fs/smb/client/smb2pdu.c b/fs/smb/client/smb2pdu.c
+index ea73fc5da60309..176ae313f4a62a 100644
+--- a/fs/smb/client/smb2pdu.c
++++ b/fs/smb/client/smb2pdu.c
+@@ -1660,19 +1660,17 @@ SMB2_auth_kerberos(struct SMB2_sess_data *sess_data)
+ 	is_binding = (ses->ses_status == SES_GOOD);
+ 	spin_unlock(&ses->ses_lock);
+ 
+-	/* keep session key if binding */
+-	if (!is_binding) {
+-		kfree_sensitive(ses->auth_key.response);
+-		ses->auth_key.response = kmemdup(msg->data, msg->sesskey_len,
+-						 GFP_KERNEL);
+-		if (!ses->auth_key.response) {
+-			cifs_dbg(VFS, "Kerberos can't allocate (%u bytes) memory\n",
+-				 msg->sesskey_len);
+-			rc = -ENOMEM;
+-			goto out_put_spnego_key;
+-		}
+-		ses->auth_key.len = msg->sesskey_len;
++	kfree_sensitive(ses->auth_key.response);
++	ses->auth_key.response = kmemdup(msg->data,
++					 msg->sesskey_len,
++					 GFP_KERNEL);
++	if (!ses->auth_key.response) {
++		cifs_dbg(VFS, "%s: can't allocate (%u bytes) memory\n",
++			 __func__, msg->sesskey_len);
++		rc = -ENOMEM;
++		goto out_put_spnego_key;
+ 	}
++	ses->auth_key.len = msg->sesskey_len;
+ 
+ 	sess_data->iov[1].iov_base = msg->data + msg->sesskey_len;
+ 	sess_data->iov[1].iov_len = msg->secblob_len;
+@@ -3929,7 +3927,7 @@ int
+ SMB311_posix_query_info(const unsigned int xid, struct cifs_tcon *tcon,
+ 		u64 persistent_fid, u64 volatile_fid, struct smb311_posix_qinfo *data, u32 *plen)
+ {
+-	size_t output_len = sizeof(struct smb311_posix_qinfo *) +
++	size_t output_len = sizeof(struct smb311_posix_qinfo) +
+ 			(sizeof(struct smb_sid) * 2) + (PATH_MAX * 2);
+ 	*plen = 0;
+ 
+@@ -5075,7 +5073,10 @@ replay_again:
+ 
+ 	memset(&rqst, 0, sizeof(struct smb_rqst));
+ 	rqst.rq_iov = iov;
+-	rqst.rq_nvec = n_vec + 1;
++	/* iov[0] is the SMB header; move payload to rq_iter for encryption safety */
++	rqst.rq_nvec = 1;
++	iov_iter_kvec(&rqst.rq_iter, ITER_SOURCE, &iov[1], n_vec,
++		      io_parms->length);
+ 
+ 	if (retries)
+ 		smb2_set_replay(server, &rqst);
+diff --git a/fs/smb/client/smb2transport.c b/fs/smb/client/smb2transport.c
+index 99081e9d6283a2..daf8ba2cd8a100 100644
+--- a/fs/smb/client/smb2transport.c
++++ b/fs/smb/client/smb2transport.c
+@@ -19,6 +19,7 @@
+ #include <linux/mempool.h>
+ #include <linux/highmem.h>
+ #include <crypto/aead.h>
++#include <crypto/utils.h>
+ #include "cifsglob.h"
+ #include "cifsproto.h"
+ #include "smb2proto.h"
+@@ -732,7 +733,8 @@ smb2_verify_signature(struct smb_rqst *rqst, struct TCP_Server_Info *server)
+ 	if (rc)
+ 		return rc;
+ 
+-	if (memcmp(server_response_sig, shdr->Signature, SMB2_SIGNATURE_SIZE)) {
++	if (crypto_memneq(server_response_sig, shdr->Signature,
++			  SMB2_SIGNATURE_SIZE)) {
+ 		cifs_dbg(VFS, "sign fail cmd 0x%x message id 0x%llx\n",
+ 			shdr->Command, shdr->MessageId);
+ 		return -EACCES;
+diff --git a/fs/smb/client/trace.h b/fs/smb/client/trace.h
+index 17e7ce3b14af06..bd6e59b70872e4 100644
+--- a/fs/smb/client/trace.h
++++ b/fs/smb/client/trace.h
+@@ -30,6 +30,7 @@
+ 	EM(netfs_trace_tcon_ref_get_cached_laundromat,	"GET Ch-Lau") \
+ 	EM(netfs_trace_tcon_ref_get_cached_lease_break,	"GET Ch-Lea") \
+ 	EM(netfs_trace_tcon_ref_get_cancelled_close,	"GET Cn-Cls") \
++	EM(netfs_trace_tcon_ref_get_close_defer_files,	"GET Cl-Def") \
+ 	EM(netfs_trace_tcon_ref_get_dfs_refer,		"GET DfsRef") \
+ 	EM(netfs_trace_tcon_ref_get_find,		"GET Find  ") \
+ 	EM(netfs_trace_tcon_ref_get_find_sess_tcon,	"GET FndSes") \
+@@ -41,6 +42,7 @@
+ 	EM(netfs_trace_tcon_ref_put_cancelled_close,	"PUT Cn-Cls") \
+ 	EM(netfs_trace_tcon_ref_put_cancelled_close_fid, "PUT Cn-Fid") \
+ 	EM(netfs_trace_tcon_ref_put_cancelled_mid,	"PUT Cn-Mid") \
++	EM(netfs_trace_tcon_ref_put_close_defer_files,	"PUT Cl-Def") \
+ 	EM(netfs_trace_tcon_ref_put_mnt_ctx,		"PUT MntCtx") \
+ 	EM(netfs_trace_tcon_ref_put_dfs_refer,		"PUT DfsRfr") \
+ 	EM(netfs_trace_tcon_ref_put_reconnect_server,	"PUT Reconn") \
+diff --git a/fs/smb/client/transport.c b/fs/smb/client/transport.c
+index 7fee8e2c723a8d..1eb25603b6e838 100644
+--- a/fs/smb/client/transport.c
++++ b/fs/smb/client/transport.c
+@@ -1022,16 +1022,21 @@ cifs_cancelled_callback(struct mid_q_entry *mid)
+ }
+ 
+ /*
+- * Return a channel (master if none) of @ses that can be used to send
+- * regular requests.
++ * cifs_pick_channel - pick an eligible channel for network operations
+  *
+- * If we are currently binding a new channel (negprot/sess.setup),
+- * return the new incomplete channel.
++ * @ses: session reference
++ *
++ * Select an eligible channel (not terminating and not marked as needing
++ * reconnect), preferring the least loaded one. If no eligible channel is
++ * found, fall back to the primary channel (index 0).
++ *
++ * Return: TCP_Server_Info pointer for the chosen channel, or NULL if @ses is
++ * NULL.
+  */
+ struct TCP_Server_Info *cifs_pick_channel(struct cifs_ses *ses)
+ {
+ 	uint index = 0;
+-	unsigned int min_in_flight = UINT_MAX, max_in_flight = 0;
++	unsigned int min_in_flight = UINT_MAX;
+ 	struct TCP_Server_Info *server = NULL;
+ 	int i, start, cur;
+ 
+@@ -1061,14 +1066,8 @@ struct TCP_Server_Info *cifs_pick_channel(struct cifs_ses *ses)
+ 			min_in_flight = server->in_flight;
+ 			index = cur;
+ 		}
+-		if (server->in_flight > max_in_flight)
+-			max_in_flight = server->in_flight;
+ 	}
+ 
+-	/* if all channels are equally loaded, fall back to round-robin */
+-	if (min_in_flight == max_in_flight)
+-		index = (uint)start % ses->chan_count;
+-
+ 	server = ses->chans[index].server;
+ 	spin_unlock(&ses->chan_lock);
+ 
+diff --git a/fs/smb/server/Kconfig b/fs/smb/server/Kconfig
+index cabe6a843c6a07..da0187e76cf1c5 100644
+--- a/fs/smb/server/Kconfig
++++ b/fs/smb/server/Kconfig
+@@ -11,6 +11,7 @@ config SMB_SERVER
+ 	select CRYPTO_HMAC
+ 	select CRYPTO_ECB
+ 	select CRYPTO_LIB_DES
++	select CRYPTO_LIB_UTILS
+ 	select CRYPTO_SHA256
+ 	select CRYPTO_CMAC
+ 	select CRYPTO_SHA512
+diff --git a/fs/smb/server/auth.c b/fs/smb/server/auth.c
+index f4b20b80af0620..16a57425099dea 100644
+--- a/fs/smb/server/auth.c
++++ b/fs/smb/server/auth.c
+@@ -13,6 +13,7 @@
+ #include <linux/xattr.h>
+ #include <crypto/hash.h>
+ #include <crypto/aead.h>
++#include <crypto/utils.h>
+ #include <linux/random.h>
+ #include <linux/scatterlist.h>
+ 
+@@ -283,7 +284,8 @@ int ksmbd_auth_ntlmv2(struct ksmbd_conn *conn, struct ksmbd_session *sess,
+ 		goto out;
+ 	}
+ 
+-	if (memcmp(ntlmv2->ntlmv2_hash, ntlmv2_rsp, CIFS_HMAC_MD5_HASH_SIZE) != 0)
++	if (crypto_memneq(ntlmv2->ntlmv2_hash, ntlmv2_rsp,
++			  CIFS_HMAC_MD5_HASH_SIZE))
+ 		rc = -EINVAL;
+ out:
+ 	if (ctx)
+@@ -797,12 +799,8 @@ static int generate_smb3signingkey(struct ksmbd_session *sess,
+ 	if (!(conn->dialect >= SMB30_PROT_ID && signing->binding))
+ 		memcpy(chann->smb3signingkey, key, SMB3_SIGN_KEY_SIZE);
+ 
+-	ksmbd_debug(AUTH, "dumping generated AES signing keys\n");
++	ksmbd_debug(AUTH, "generated SMB3 signing key\n");
+ 	ksmbd_debug(AUTH, "Session Id    %llu\n", sess->id);
+-	ksmbd_debug(AUTH, "Session Key   %*ph\n",
+-		    SMB2_NTLMV2_SESSKEY_SIZE, sess->sess_key);
+-	ksmbd_debug(AUTH, "Signing Key   %*ph\n",
+-		    SMB3_SIGN_KEY_SIZE, key);
+ 	return 0;
+ }
+ 
+@@ -866,23 +864,9 @@ static int generate_smb3encryptionkey(struct ksmbd_conn *conn,
+ 	if (rc)
+ 		return rc;
+ 
+-	ksmbd_debug(AUTH, "dumping generated AES encryption keys\n");
++	ksmbd_debug(AUTH, "generated SMB3 encryption/decryption keys\n");
+ 	ksmbd_debug(AUTH, "Cipher type   %d\n", conn->cipher_type);
+ 	ksmbd_debug(AUTH, "Session Id    %llu\n", sess->id);
+-	ksmbd_debug(AUTH, "Session Key   %*ph\n",
+-		    SMB2_NTLMV2_SESSKEY_SIZE, sess->sess_key);
+-	if (conn->cipher_type == SMB2_ENCRYPTION_AES256_CCM ||
+-	    conn->cipher_type == SMB2_ENCRYPTION_AES256_GCM) {
+-		ksmbd_debug(AUTH, "ServerIn Key  %*ph\n",
+-			    SMB3_GCM256_CRYPTKEY_SIZE, sess->smb3encryptionkey);
+-		ksmbd_debug(AUTH, "ServerOut Key %*ph\n",
+-			    SMB3_GCM256_CRYPTKEY_SIZE, sess->smb3decryptionkey);
+-	} else {
+-		ksmbd_debug(AUTH, "ServerIn Key  %*ph\n",
+-			    SMB3_GCM128_CRYPTKEY_SIZE, sess->smb3encryptionkey);
+-		ksmbd_debug(AUTH, "ServerOut Key %*ph\n",
+-			    SMB3_GCM128_CRYPTKEY_SIZE, sess->smb3decryptionkey);
+-	}
+ 	return 0;
+ }
+ 
+diff --git a/fs/smb/server/oplock.c b/fs/smb/server/oplock.c
+index 2a3ef29ac0eb75..f0e1d1151d6213 100644
+--- a/fs/smb/server/oplock.c
++++ b/fs/smb/server/oplock.c
+@@ -120,7 +120,7 @@ static void free_lease(struct oplock_info *opinfo)
+ 	kfree(lease);
+ }
+ 
+-static void free_opinfo(struct oplock_info *opinfo)
++static void __free_opinfo(struct oplock_info *opinfo)
+ {
+ 	if (opinfo->is_lease)
+ 		free_lease(opinfo);
+@@ -129,6 +129,18 @@ static void free_opinfo(struct oplock_info *opinfo)
+ 	kfree(opinfo);
+ }
+ 
++static void free_opinfo_rcu(struct rcu_head *rcu)
++{
++	struct oplock_info *opinfo = container_of(rcu, struct oplock_info, rcu);
++
++	__free_opinfo(opinfo);
++}
++
++static void free_opinfo(struct oplock_info *opinfo)
++{
++	call_rcu(&opinfo->rcu, free_opinfo_rcu);
++}
++
+ struct oplock_info *opinfo_get(struct ksmbd_file *fp)
+ {
+ 	struct oplock_info *opinfo;
+@@ -176,9 +188,9 @@ void opinfo_put(struct oplock_info *opinfo)
+ 	free_opinfo(opinfo);
+ }
+ 
+-static void opinfo_add(struct oplock_info *opinfo)
++static void opinfo_add(struct oplock_info *opinfo, struct ksmbd_file *fp)
+ {
+-	struct ksmbd_inode *ci = opinfo->o_fp->f_ci;
++	struct ksmbd_inode *ci = fp->f_ci;
+ 
+ 	down_write(&ci->m_lock);
+ 	list_add(&opinfo->op_entry, &ci->m_op_list);
+@@ -1123,10 +1135,12 @@ void smb_lazy_parent_lease_break_close(struct ksmbd_file *fp)
+ 
+ 	rcu_read_lock();
+ 	opinfo = rcu_dereference(fp->f_opinfo);
+-	rcu_read_unlock();
+ 
+-	if (!opinfo || !opinfo->is_lease || opinfo->o_lease->version != 2)
++	if (!opinfo || !opinfo->is_lease || opinfo->o_lease->version != 2) {
++		rcu_read_unlock();
+ 		return;
++	}
++	rcu_read_unlock();
+ 
+ 	p_ci = ksmbd_inode_lookup_lock(fp->filp->f_path.dentry->d_parent);
+ 	if (!p_ci)
+@@ -1277,20 +1291,21 @@ set_lev:
+ 	set_oplock_level(opinfo, req_op_level, lctx);
+ 
+ out:
+-	rcu_assign_pointer(fp->f_opinfo, opinfo);
+-	opinfo->o_fp = fp;
+-
+ 	opinfo_count_inc(fp);
+-	opinfo_add(opinfo);
++	opinfo_add(opinfo, fp);
++
+ 	if (opinfo->is_lease) {
+ 		err = add_lease_global_list(opinfo);
+ 		if (err)
+ 			goto err_out;
+ 	}
+ 
++	rcu_assign_pointer(fp->f_opinfo, opinfo);
++	opinfo->o_fp = fp;
++
+ 	return 0;
+ err_out:
+-	free_opinfo(opinfo);
++	__free_opinfo(opinfo);
+ 	return err;
+ }
+ 
+diff --git a/fs/smb/server/oplock.h b/fs/smb/server/oplock.h
+index 0fe931485465ac..f8da0bba766bad 100644
+--- a/fs/smb/server/oplock.h
++++ b/fs/smb/server/oplock.h
+@@ -76,8 +76,9 @@ struct oplock_info {
+ 	struct lease		*o_lease;
+ 	struct list_head        op_entry;
+ 	struct list_head        lease_entry;
+-	wait_queue_head_t oplock_q; /* Other server threads */
+-	wait_queue_head_t oplock_brk; /* oplock breaking wait */
++	wait_queue_head_t	oplock_q; /* Other server threads */
++	wait_queue_head_t	oplock_brk; /* oplock breaking wait */
++	struct rcu_head		rcu;
+ };
+ 
+ struct lease_break_info {
+diff --git a/fs/smb/server/smb2pdu.c b/fs/smb/server/smb2pdu.c
+index da4d914c87ad24..bdd2214c79f983 100644
+--- a/fs/smb/server/smb2pdu.c
++++ b/fs/smb/server/smb2pdu.c
+@@ -4,6 +4,7 @@
+  *   Copyright (C) 2018 Samsung Electronics Co., Ltd.
+  */
+ 
++#include <crypto/utils.h>
+ #include <linux/inetdevice.h>
+ #include <net/addrconf.h>
+ #include <linux/syscalls.h>
+@@ -117,6 +118,8 @@ int smb2_get_ksmbd_tcon(struct ksmbd_work *work)
+ 			pr_err("The first operation in the compound does not have tcon\n");
+ 			return -EINVAL;
+ 		}
++		if (work->tcon->t_state != TREE_CONNECTED)
++			return -ENOENT;
+ 		if (tree_id != UINT_MAX && work->tcon->id != tree_id) {
+ 			pr_err("tree id(%u) is different with id(%u) in first operation\n",
+ 					tree_id, work->tcon->id);
+@@ -1933,6 +1936,7 @@ out_err:
+ 			}
+ 		}
+ 		smb2_set_err_rsp(work);
++		conn->binding = false;
+ 	} else {
+ 		unsigned int iov_len;
+ 
+@@ -2809,7 +2813,11 @@ static int parse_durable_handle_context(struct ksmbd_work *work,
+ 						goto out;
+ 					}
+ 
+-					dh_info->fp->conn = conn;
++					if (dh_info->fp->conn) {
++						ksmbd_put_durable_fd(dh_info->fp);
++						err = -EBADF;
++						goto out;
++					}
+ 					dh_info->reconnected = true;
+ 					goto out;
+ 				}
+@@ -2990,13 +2998,14 @@ int smb2_open(struct ksmbd_work *work)
+ 				goto err_out2;
+ 			}
+ 
++			fp = dh_info.fp;
++
+ 			if (ksmbd_override_fsids(work)) {
+ 				rc = -ENOMEM;
+ 				ksmbd_put_durable_fd(dh_info.fp);
+ 				goto err_out2;
+ 			}
+ 
+-			fp = dh_info.fp;
+ 			file_info = FILE_OPENED;
+ 
+ 			rc = ksmbd_vfs_getattr(&fp->filp->f_path, &stat);
+@@ -3592,10 +3601,8 @@ int smb2_open(struct ksmbd_work *work)
+ 
+ reconnected_fp:
+ 	rsp->StructureSize = cpu_to_le16(89);
+-	rcu_read_lock();
+-	opinfo = rcu_dereference(fp->f_opinfo);
++	opinfo = opinfo_get(fp);
+ 	rsp->OplockLevel = opinfo != NULL ? opinfo->level : 0;
+-	rcu_read_unlock();
+ 	rsp->Flags = 0;
+ 	rsp->CreateAction = cpu_to_le32(file_info);
+ 	rsp->CreationTime = cpu_to_le64(fp->create_time);
+@@ -3636,6 +3643,7 @@ reconnected_fp:
+ 		next_ptr = &lease_ccontext->Next;
+ 		next_off = conn->vals->create_lease_size;
+ 	}
++	opinfo_put(opinfo);
+ 
+ 	if (maximal_access_ctxt) {
+ 		struct create_context *mxac_ccontext;
+@@ -6067,14 +6075,14 @@ static int smb2_create_link(struct ksmbd_work *work,
+ 				rc = -EINVAL;
+ 				ksmbd_debug(SMB, "cannot delete %s\n",
+ 					    link_name);
+-				goto out;
+ 			}
+ 		} else {
+ 			rc = -EEXIST;
+ 			ksmbd_debug(SMB, "link already exists\n");
+-			goto out;
+ 		}
+ 		ksmbd_vfs_kern_path_unlock(&parent_path, &path);
++		if (rc)
++			goto out;
+ 	}
+ 	rc = ksmbd_vfs_link(work, target_name, link_name);
+ 	if (rc)
+@@ -8804,7 +8812,7 @@ int smb2_check_sign_req(struct ksmbd_work *work)
+ 				signature))
+ 		return 0;
+ 
+-	if (memcmp(signature, signature_req, SMB2_SIGNATURE_SIZE)) {
++	if (crypto_memneq(signature, signature_req, SMB2_SIGNATURE_SIZE)) {
+ 		pr_err("bad smb2 signature\n");
+ 		return 0;
+ 	}
+@@ -8892,7 +8900,7 @@ int smb3_check_sign_req(struct ksmbd_work *work)
+ 	if (ksmbd_sign_smb3_pdu(conn, signing_key, iov, 1, signature))
+ 		return 0;
+ 
+-	if (memcmp(signature, signature_req, SMB2_SIGNATURE_SIZE)) {
++	if (crypto_memneq(signature, signature_req, SMB2_SIGNATURE_SIZE)) {
+ 		pr_err("bad smb2 signature\n");
+ 		return 0;
+ 	}
+diff --git a/fs/squashfs/cache.c b/fs/squashfs/cache.c
+index 5062326d0efb71..25bf038b880ab2 100644
+--- a/fs/squashfs/cache.c
++++ b/fs/squashfs/cache.c
+@@ -340,6 +340,9 @@ int squashfs_read_metadata(struct super_block *sb, void *buffer,
+ 	if (unlikely(length < 0))
+ 		return -EIO;
+ 
++	if (unlikely(*offset < 0 || *offset >= SQUASHFS_METADATA_SIZE))
++		return -EIO;
++
+ 	while (length) {
+ 		entry = squashfs_cache_get(sb, msblk->block_cache, *block, 0);
+ 		if (entry->error) {
+diff --git a/fs/xfs/xfs_bmap_item.c b/fs/xfs/xfs_bmap_item.c
+index b6d63b8bdad5a2..969cad575c3029 100644
+--- a/fs/xfs/xfs_bmap_item.c
++++ b/fs/xfs/xfs_bmap_item.c
+@@ -278,7 +278,8 @@ xfs_bmap_update_diff_items(
+ 
+ 	ba = container_of(a, struct xfs_bmap_intent, bi_list);
+ 	bb = container_of(b, struct xfs_bmap_intent, bi_list);
+-	return ba->bi_owner->i_ino - bb->bi_owner->i_ino;
++	return (ba->bi_owner->i_ino > bb->bi_owner->i_ino) -
++		(ba->bi_owner->i_ino < bb->bi_owner->i_ino);
+ }
+ 
+ /* Set the map extent flags for this mapping. */
+diff --git a/fs/xfs/xfs_dquot.c b/fs/xfs/xfs_dquot.c
+index 9b67f05d92a193..ce42208d51bea0 100644
+--- a/fs/xfs/xfs_dquot.c
++++ b/fs/xfs/xfs_dquot.c
+@@ -1297,9 +1297,15 @@ xfs_qm_dqflush(
+ 	return 0;
+ 
+ out_abort:
++	/*
++	 * Shut down the log before removing the dquot item from the AIL.
++	 * Otherwise, the log tail may advance past this item's LSN while
++	 * log writes are still in progress, making these unflushed changes
++	 * unrecoverable on the next mount.
++	 */
++	xfs_force_shutdown(mp, SHUTDOWN_CORRUPT_INCORE);
+ 	dqp->q_flags &= ~XFS_DQFLAG_DIRTY;
+ 	xfs_trans_ail_delete(lip, 0);
+-	xfs_force_shutdown(mp, SHUTDOWN_CORRUPT_INCORE);
+ out_unlock:
+ 	xfs_dqfunlock(dqp);
+ 	return error;
+diff --git a/fs/xfs/xfs_log.c b/fs/xfs/xfs_log.c
+index d03976b8218027..5b6ee1f7948fb3 100644
+--- a/fs/xfs/xfs_log.c
++++ b/fs/xfs/xfs_log.c
+@@ -1552,6 +1552,8 @@ xlog_alloc_log(
+ 
+ 	if (xfs_has_logv2(mp) && mp->m_sb.sb_logsunit > 1)
+ 		log->l_iclog_roundoff = mp->m_sb.sb_logsunit;
++	else if (mp->m_sb.sb_logsectsize > 0)
++		log->l_iclog_roundoff = mp->m_sb.sb_logsectsize;
+ 	else
+ 		log->l_iclog_roundoff = BBSIZE;
+ 
+diff --git a/include/linux/bpf.h b/include/linux/bpf.h
+index 0af6b2a5273adc..1021156886272c 100644
+--- a/include/linux/bpf.h
++++ b/include/linux/bpf.h
+@@ -2231,6 +2231,7 @@ int bpf_link_prime(struct bpf_link *link, struct bpf_link_primer *primer);
+ int bpf_link_settle(struct bpf_link_primer *primer);
+ void bpf_link_cleanup(struct bpf_link_primer *primer);
+ void bpf_link_inc(struct bpf_link *link);
++struct bpf_link *bpf_link_inc_not_zero(struct bpf_link *link);
+ void bpf_link_put(struct bpf_link *link);
+ int bpf_link_new_fd(struct bpf_link *link);
+ struct bpf_link *bpf_link_get_from_fd(u32 ufd);
+@@ -2586,6 +2587,11 @@ static inline void bpf_link_inc(struct bpf_link *link)
+ {
+ }
+ 
++static inline struct bpf_link *bpf_link_inc_not_zero(struct bpf_link *link)
++{
++	return NULL;
++}
++
+ static inline void bpf_link_put(struct bpf_link *link)
+ {
+ }
+diff --git a/include/linux/indirect_call_wrapper.h b/include/linux/indirect_call_wrapper.h
+index c1c76a70a6ce9f..227cee5e2a98b5 100644
+--- a/include/linux/indirect_call_wrapper.h
++++ b/include/linux/indirect_call_wrapper.h
+@@ -16,22 +16,26 @@
+  */
+ #define INDIRECT_CALL_1(f, f1, ...)					\
+ 	({								\
+-		likely(f == f1) ? f1(__VA_ARGS__) : f(__VA_ARGS__);	\
++		typeof(f) __f1 = (f);					\
++		likely(__f1 == f1) ? f1(__VA_ARGS__) : __f1(__VA_ARGS__);	\
+ 	})
+ #define INDIRECT_CALL_2(f, f2, f1, ...)					\
+ 	({								\
+-		likely(f == f2) ? f2(__VA_ARGS__) :			\
+-				  INDIRECT_CALL_1(f, f1, __VA_ARGS__);	\
++		typeof(f) __f2 = (f);					\
++		likely(__f2 == f2) ? f2(__VA_ARGS__) :			\
++				  INDIRECT_CALL_1(__f2, f1, __VA_ARGS__);	\
+ 	})
+ #define INDIRECT_CALL_3(f, f3, f2, f1, ...)					\
+ 	({									\
+-		likely(f == f3) ? f3(__VA_ARGS__) :				\
+-				  INDIRECT_CALL_2(f, f2, f1, __VA_ARGS__);	\
++		typeof(f) __f3 = (f);						\
++		likely(__f3 == f3) ? f3(__VA_ARGS__) :				\
++				  INDIRECT_CALL_2(__f3, f2, f1, __VA_ARGS__);	\
+ 	})
+ #define INDIRECT_CALL_4(f, f4, f3, f2, f1, ...)					\
+ 	({									\
+-		likely(f == f4) ? f4(__VA_ARGS__) :				\
+-				  INDIRECT_CALL_3(f, f3, f2, f1, __VA_ARGS__);	\
++		typeof(f) __f4 = (f);						\
++		likely(__f4 == f4) ? f4(__VA_ARGS__) :				\
++				  INDIRECT_CALL_3(__f4, f3, f2, f1, __VA_ARGS__);	\
+ 	})
+ 
+ #define INDIRECT_CALLABLE_DECLARE(f)	f
+diff --git a/include/linux/ioport.h b/include/linux/ioport.h
+index 25d768d4897017..d10749797f18d3 100644
+--- a/include/linux/ioport.h
++++ b/include/linux/ioport.h
+@@ -216,6 +216,38 @@ struct resource *lookup_resource(struct resource *root, resource_size_t start);
+ int adjust_resource(struct resource *res, resource_size_t start,
+ 		    resource_size_t size);
+ resource_size_t resource_alignment(struct resource *res);
++
++/**
++ * resource_set_size - Calculate resource end address from size and start
++ * @res: Resource descriptor
++ * @size: Size of the resource
++ *
++ * Calculate the end address for @res based on @size.
++ *
++ * Note: The start address of @res must be set when calling this function.
++ * Prefer resource_set_range() if setting both the start address and @size.
++ */
++static inline void resource_set_size(struct resource *res, resource_size_t size)
++{
++	res->end = res->start + size - 1;
++}
++
++/**
++ * resource_set_range - Set resource start and end addresses
++ * @res: Resource descriptor
++ * @start: Start address for the resource
++ * @size: Size of the resource
++ *
++ * Set @res start address and calculate the end address based on @size.
++ */
++static inline void resource_set_range(struct resource *res,
++				      resource_size_t start,
++				      resource_size_t size)
++{
++	res->start = start;
++	resource_set_size(res, size);
++}
++
+ static inline resource_size_t resource_size(const struct resource *res)
+ {
+ 	return res->end - res->start + 1;
+diff --git a/include/linux/irqchip/arm-gic-v3.h b/include/linux/irqchip/arm-gic-v3.h
+index 728691365464c1..977e140b6a9716 100644
+--- a/include/linux/irqchip/arm-gic-v3.h
++++ b/include/linux/irqchip/arm-gic-v3.h
+@@ -394,6 +394,7 @@
+ #define GITS_TYPER_VLPIS		(1UL << 1)
+ #define GITS_TYPER_ITT_ENTRY_SIZE_SHIFT	4
+ #define GITS_TYPER_ITT_ENTRY_SIZE	GENMASK_ULL(7, 4)
++#define GITS_TYPER_IDBITS		GENMASK_ULL(12, 8)
+ #define GITS_TYPER_IDBITS_SHIFT		8
+ #define GITS_TYPER_DEVBITS_SHIFT	13
+ #define GITS_TYPER_DEVBITS		GENMASK_ULL(17, 13)
+diff --git a/include/linux/mailbox_client.h b/include/linux/mailbox_client.h
+index 734694912ef749..c6eea9afb943d5 100644
+--- a/include/linux/mailbox_client.h
++++ b/include/linux/mailbox_client.h
+@@ -7,8 +7,8 @@
+ #ifndef __MAILBOX_CLIENT_H
+ #define __MAILBOX_CLIENT_H
+ 
+-#include <linux/of.h>
+ #include <linux/device.h>
++#include <linux/of.h>
+ 
+ struct mbox_chan;
+ 
+diff --git a/include/linux/mailbox_controller.h b/include/linux/mailbox_controller.h
+index 6fee33cb52f585..b91379922cb332 100644
+--- a/include/linux/mailbox_controller.h
++++ b/include/linux/mailbox_controller.h
+@@ -3,11 +3,11 @@
+ #ifndef __MAILBOX_CONTROLLER_H
+ #define __MAILBOX_CONTROLLER_H
+ 
++#include <linux/completion.h>
++#include <linux/device.h>
++#include <linux/hrtimer.h>
+ #include <linux/of.h>
+ #include <linux/types.h>
+-#include <linux/hrtimer.h>
+-#include <linux/device.h>
+-#include <linux/completion.h>
+ 
+ struct mbox_chan;
+ 
+@@ -66,6 +66,7 @@ struct mbox_chan_ops {
+  *			no interrupt rises. Ignored if 'txdone_irq' is set.
+  * @txpoll_period:	If 'txdone_poll' is in effect, the API polls for
+  *			last TX's status after these many millisecs
++ * @fw_xlate:		Controller driver specific mapping of channel via fwnode
+  * @of_xlate:		Controller driver specific mapping of channel via DT
+  * @poll_hrt:		API private. hrtimer used to poll for TXDONE on all
+  *			channels.
+@@ -79,6 +80,8 @@ struct mbox_controller {
+ 	bool txdone_irq;
+ 	bool txdone_poll;
+ 	unsigned txpoll_period;
++	struct mbox_chan *(*fw_xlate)(struct mbox_controller *mbox,
++				      const struct fwnode_reference_args *sp);
+ 	struct mbox_chan *(*of_xlate)(struct mbox_controller *mbox,
+ 				      const struct of_phandle_args *sp);
+ 	/* Internal to API */
+diff --git a/include/linux/mlx5/mlx5_ifc.h b/include/linux/mlx5/mlx5_ifc.h
+index 4913d364e97747..c59fd31719a13f 100644
+--- a/include/linux/mlx5/mlx5_ifc.h
++++ b/include/linux/mlx5/mlx5_ifc.h
+@@ -11799,7 +11799,9 @@ struct mlx5_ifc_mtrc_ctrl_bits {
+ 
+ struct mlx5_ifc_host_params_context_bits {
+ 	u8         host_number[0x8];
+-	u8         reserved_at_8[0x7];
++	u8         reserved_at_8[0x5];
++	u8         host_pf_not_exist[0x1];
++	u8         reserved_at_14[0x1];
+ 	u8         host_pf_disabled[0x1];
+ 	u8         host_num_of_vfs[0x10];
+ 
+diff --git a/include/linux/mmc/host.h b/include/linux/mmc/host.h
+index 62a6847a3b6f00..93b1978f1ca546 100644
+--- a/include/linux/mmc/host.h
++++ b/include/linux/mmc/host.h
+@@ -446,14 +446,12 @@ struct mmc_host {
+ 
+ 	struct mmc_ios		ios;		/* current io bus settings */
+ 
++	bool			claimed;	/* host exclusively claimed */
++
+ 	/* group bitfields together to minimize padding */
+ 	unsigned int		use_spi_crc:1;
+-	unsigned int		claimed:1;	/* host exclusively claimed */
+ 	unsigned int		doing_init_tune:1; /* initial tuning in progress */
+-	unsigned int		can_retune:1;	/* re-tuning can be used */
+ 	unsigned int		doing_retune:1;	/* re-tuning in progress */
+-	unsigned int		retune_now:1;	/* do re-tuning at next req */
+-	unsigned int		retune_paused:1; /* re-tuning is temporarily disabled */
+ 	unsigned int		retune_crc_disable:1; /* don't trigger retune upon crc */
+ 	unsigned int		can_dma_map_merge:1; /* merging can be used */
+ 	unsigned int		vqmmc_enabled:1; /* vqmmc regulator is enabled */
+@@ -461,6 +459,9 @@ struct mmc_host {
+ 	int			rescan_disable;	/* disable card detection */
+ 	int			rescan_entered;	/* used with nonremovable devices */
+ 
++	bool			can_retune;	/* re-tuning can be used */
++	bool			retune_now;	/* do re-tuning at next req */
++	bool			retune_paused;	/* re-tuning is temporarily disabled */
+ 	int			need_retune;	/* re-tuning is needed */
+ 	int			hold_retune;	/* hold off re-tuning */
+ 	unsigned int		retune_period;	/* re-tuning period in secs */
+diff --git a/include/linux/nfs_fs.h b/include/linux/nfs_fs.h
+index 832b7e354b4e36..86d589070b23b5 100644
+--- a/include/linux/nfs_fs.h
++++ b/include/linux/nfs_fs.h
+@@ -608,6 +608,7 @@ extern int  nfs_update_folio(struct file *file, struct folio *folio,
+ extern int nfs_sync_inode(struct inode *inode);
+ extern int nfs_wb_all(struct inode *inode);
+ extern int nfs_wb_folio(struct inode *inode, struct folio *folio);
++extern int nfs_wb_folio_reclaim(struct inode *inode, struct folio *folio);
+ int nfs_wb_folio_cancel(struct inode *inode, struct folio *folio);
+ extern int  nfs_commit_inode(struct inode *, int);
+ extern struct nfs_commit_data *nfs_commitdata_alloc(void);
+diff --git a/include/linux/security.h b/include/linux/security.h
+index 4bd0f6fc553e7b..937840870d86c3 100644
+--- a/include/linux/security.h
++++ b/include/linux/security.h
+@@ -125,6 +125,7 @@ enum lockdown_reason {
+ 	LOCKDOWN_BPF_WRITE_USER,
+ 	LOCKDOWN_DBG_WRITE_KERNEL,
+ 	LOCKDOWN_RTAS_ERROR_INJECTION,
++	LOCKDOWN_XEN_USER_ACTIONS,
+ 	LOCKDOWN_INTEGRITY_MAX,
+ 	LOCKDOWN_KCORE,
+ 	LOCKDOWN_KPROBES,
+diff --git a/include/linux/stmmac.h b/include/linux/stmmac.h
+index 42ff5a4de8ee76..a0c28b8d6c51a0 100644
+--- a/include/linux/stmmac.h
++++ b/include/linux/stmmac.h
+@@ -306,7 +306,6 @@ struct plat_stmmacenet_data {
+ 	int ext_snapshot_num;
+ 	int msi_mac_vec;
+ 	int msi_wol_vec;
+-	int msi_lpi_vec;
+ 	int msi_sfty_ce_vec;
+ 	int msi_sfty_ue_vec;
+ 	int msi_rx_base_vec;
+diff --git a/include/linux/trace_recursion.h b/include/linux/trace_recursion.h
+index d48cd92d2364af..67e6a9923d568b 100644
+--- a/include/linux/trace_recursion.h
++++ b/include/linux/trace_recursion.h
+@@ -34,6 +34,13 @@ enum {
+ 	TRACE_INTERNAL_SIRQ_BIT,
+ 	TRACE_INTERNAL_TRANSITION_BIT,
+ 
++	/* Internal event use recursion bits */
++	TRACE_INTERNAL_EVENT_BIT,
++	TRACE_INTERNAL_EVENT_NMI_BIT,
++	TRACE_INTERNAL_EVENT_IRQ_BIT,
++	TRACE_INTERNAL_EVENT_SIRQ_BIT,
++	TRACE_INTERNAL_EVENT_TRANSITION_BIT,
++
+ 	TRACE_BRANCH_BIT,
+ /*
+  * Abuse of the trace_recursion.
+@@ -97,6 +104,8 @@ enum {
+ 
+ #define TRACE_LIST_START	TRACE_INTERNAL_BIT
+ 
++#define TRACE_EVENT_START	TRACE_INTERNAL_EVENT_BIT
++
+ #define TRACE_CONTEXT_MASK	((1 << (TRACE_LIST_START + TRACE_CONTEXT_BITS)) - 1)
+ 
+ /*
+diff --git a/include/linux/uprobes.h b/include/linux/uprobes.h
+index d91e32aff5a134..a5ec2b024a226d 100644
+--- a/include/linux/uprobes.h
++++ b/include/linux/uprobes.h
+@@ -140,6 +140,7 @@ extern bool arch_uretprobe_is_alive(struct return_instance *ret, enum rp_check c
+ extern bool arch_uprobe_ignore(struct arch_uprobe *aup, struct pt_regs *regs);
+ extern void arch_uprobe_copy_ixol(struct page *page, unsigned long vaddr,
+ 					 void *src, unsigned long len);
++extern unsigned long arch_uprobe_get_xol_area(void);
+ #else /* !CONFIG_UPROBES */
+ struct uprobes_state {
+ };
+diff --git a/include/linux/usb.h b/include/linux/usb.h
+index a21074861f91fe..6e6e3206714873 100644
+--- a/include/linux/usb.h
++++ b/include/linux/usb.h
+@@ -1843,14 +1843,18 @@ void usb_buffer_unmap_sg(const struct usb_device *dev, int is_in,
+  *                         SYNCHRONOUS CALL SUPPORT                  *
+  *-------------------------------------------------------------------*/
+ 
++/* Maximum value allowed for timeout in synchronous routines below */
++#define USB_MAX_SYNCHRONOUS_TIMEOUT		60000	/* ms */
++
+ extern int usb_control_msg(struct usb_device *dev, unsigned int pipe,
+ 	__u8 request, __u8 requesttype, __u16 value, __u16 index,
+ 	void *data, __u16 size, int timeout);
+ extern int usb_interrupt_msg(struct usb_device *usb_dev, unsigned int pipe,
+ 	void *data, int len, int *actual_length, int timeout);
+ extern int usb_bulk_msg(struct usb_device *usb_dev, unsigned int pipe,
+-	void *data, int len, int *actual_length,
+-	int timeout);
++	void *data, int len, int *actual_length, int timeout);
++extern int usb_bulk_msg_killable(struct usb_device *usb_dev, unsigned int pipe,
++	void *data, int len, int *actual_length, int timeout);
+ 
+ /* wrappers around usb_control_msg() for the most common standard requests */
+ int usb_control_msg_send(struct usb_device *dev, __u8 endpoint, __u8 request,
+diff --git a/include/net/act_api.h b/include/net/act_api.h
+index 4ae0580b63cae6..8db6994c90eec1 100644
+--- a/include/net/act_api.h
++++ b/include/net/act_api.h
+@@ -68,6 +68,7 @@ struct tc_action {
+ #define TCA_ACT_FLAGS_REPLACE	(1U << (TCA_ACT_FLAGS_USER_BITS + 2))
+ #define TCA_ACT_FLAGS_NO_RTNL	(1U << (TCA_ACT_FLAGS_USER_BITS + 3))
+ #define TCA_ACT_FLAGS_AT_INGRESS	(1U << (TCA_ACT_FLAGS_USER_BITS + 4))
++#define TCA_ACT_FLAGS_AT_INGRESS_OR_CLSACT	(1U << (TCA_ACT_FLAGS_USER_BITS + 5))
+ 
+ /* Update lastuse only if needed, to avoid dirtying a cache line.
+  * We use a temp variable to avoid fetching jiffies twice.
+diff --git a/include/net/bonding.h b/include/net/bonding.h
+index 9fb40a59202091..66940d41d48540 100644
+--- a/include/net/bonding.h
++++ b/include/net/bonding.h
+@@ -696,6 +696,7 @@ void bond_debug_register(struct bonding *bond);
+ void bond_debug_unregister(struct bonding *bond);
+ void bond_debug_reregister(struct bonding *bond);
+ const char *bond_mode_name(int mode);
++bool __bond_xdp_check(int mode, int xmit_policy);
+ bool bond_xdp_check(struct bonding *bond, int mode);
+ void bond_setup(struct net_device *bond_dev);
+ unsigned int bond_get_num_tx_queues(void);
+diff --git a/include/net/dsa.h b/include/net/dsa.h
+index 0b9c6aa2704748..0bfe02f93476af 100644
+--- a/include/net/dsa.h
++++ b/include/net/dsa.h
+@@ -297,6 +297,7 @@ struct dsa_port {
+ 	struct devlink_port	devlink_port;
+ 	struct phylink		*pl;
+ 	struct phylink_config	pl_config;
++	netdevice_tracker	master_tracker;
+ 	struct dsa_lag		*lag;
+ 	struct net_device	*hsr_dev;
+ 
+diff --git a/include/net/netfilter/nf_tables.h b/include/net/netfilter/nf_tables.h
+index 02a73037fae019..000ae2900f8c3e 100644
+--- a/include/net/netfilter/nf_tables.h
++++ b/include/net/netfilter/nf_tables.h
+@@ -1770,6 +1770,11 @@ struct nft_trans_gc {
+ 	struct rcu_head		rcu;
+ };
+ 
++static inline int nft_trans_gc_space(const struct nft_trans_gc *trans)
++{
++	return NFT_TRANS_GC_BATCHCOUNT - trans->count;
++}
++
+ struct nft_trans_gc *nft_trans_gc_alloc(struct nft_set *set,
+ 					unsigned int gc_seq, gfp_t gfp);
+ void nft_trans_gc_destroy(struct nft_trans_gc *trans);
+diff --git a/include/net/sch_generic.h b/include/net/sch_generic.h
+index 3287988a6a9878..385af747b0b4e0 100644
+--- a/include/net/sch_generic.h
++++ b/include/net/sch_generic.h
+@@ -694,6 +694,34 @@ void qdisc_destroy(struct Qdisc *qdisc);
+ void qdisc_put(struct Qdisc *qdisc);
+ void qdisc_put_unlocked(struct Qdisc *qdisc);
+ void qdisc_tree_reduce_backlog(struct Qdisc *qdisc, int n, int len);
++
++static inline void dev_reset_queue(struct net_device *dev,
++				   struct netdev_queue *dev_queue,
++				   void *_unused)
++{
++	struct Qdisc *qdisc;
++	bool nolock;
++
++	qdisc = rtnl_dereference(dev_queue->qdisc_sleeping);
++	if (!qdisc)
++		return;
++
++	nolock = qdisc->flags & TCQ_F_NOLOCK;
++
++	if (nolock)
++		spin_lock_bh(&qdisc->seqlock);
++	spin_lock_bh(qdisc_lock(qdisc));
++
++	qdisc_reset(qdisc);
++
++	spin_unlock_bh(qdisc_lock(qdisc));
++	if (nolock) {
++		clear_bit(__QDISC_STATE_MISSED, &qdisc->state);
++		clear_bit(__QDISC_STATE_DRAINING, &qdisc->state);
++		spin_unlock_bh(&qdisc->seqlock);
++	}
++}
++
+ #ifdef CONFIG_NET_SCHED
+ int qdisc_offload_dump_helper(struct Qdisc *q, enum tc_setup_type type,
+ 			      void *type_data);
+@@ -756,13 +784,23 @@ static inline bool skb_skip_tc_classify(struct sk_buff *skb)
+ static inline void qdisc_reset_all_tx_gt(struct net_device *dev, unsigned int i)
+ {
+ 	struct Qdisc *qdisc;
++	bool nolock;
+ 
+ 	for (; i < dev->num_tx_queues; i++) {
+ 		qdisc = rtnl_dereference(netdev_get_tx_queue(dev, i)->qdisc);
+ 		if (qdisc) {
++			nolock = qdisc->flags & TCQ_F_NOLOCK;
++
++			if (nolock)
++				spin_lock_bh(&qdisc->seqlock);
+ 			spin_lock_bh(qdisc_lock(qdisc));
+ 			qdisc_reset(qdisc);
+ 			spin_unlock_bh(qdisc_lock(qdisc));
++			if (nolock) {
++				clear_bit(__QDISC_STATE_MISSED, &qdisc->state);
++				clear_bit(__QDISC_STATE_DRAINING, &qdisc->state);
++				spin_unlock_bh(&qdisc->seqlock);
++			}
+ 		}
+ 	}
+ }
+@@ -1327,6 +1365,11 @@ void mini_qdisc_pair_init(struct mini_Qdisc_pair *miniqp, struct Qdisc *qdisc,
+ void mini_qdisc_pair_block_init(struct mini_Qdisc_pair *miniqp,
+ 				struct tcf_block *block);
+ 
++static inline bool mini_qdisc_pair_inited(struct mini_Qdisc_pair *miniqp)
++{
++	return !!miniqp->p_miniq;
++}
++
+ void mq_change_real_num_tx(struct Qdisc *sch, unsigned int new_real_tx);
+ 
+ int sch_frag_xmit_hook(struct sk_buff *skb, int (*xmit)(struct sk_buff *skb));
+diff --git a/include/net/tc_act/tc_gate.h b/include/net/tc_act/tc_gate.h
+index c8fa11ebb3978e..c7650f7de0ff88 100644
+--- a/include/net/tc_act/tc_gate.h
++++ b/include/net/tc_act/tc_gate.h
+@@ -32,6 +32,7 @@ struct tcf_gate_params {
+ 	s32			tcfg_clockid;
+ 	size_t			num_entries;
+ 	struct list_head	entries;
++	struct rcu_head		rcu;
+ };
+ 
+ #define GATE_ACT_GATE_OPEN	BIT(0)
+@@ -39,7 +40,7 @@ struct tcf_gate_params {
+ 
+ struct tcf_gate {
+ 	struct tc_action	common;
+-	struct tcf_gate_params	param;
++	struct tcf_gate_params __rcu *param;
+ 	u8			current_gate_status;
+ 	ktime_t			current_close_time;
+ 	u32			current_entry_octets;
+@@ -60,47 +61,65 @@ static inline bool is_tcf_gate(const struct tc_action *a)
+ 	return false;
+ }
+ 
++static inline struct tcf_gate_params *tcf_gate_params_locked(const struct tc_action *a)
++{
++	struct tcf_gate *gact = to_gate(a);
++
++	return rcu_dereference_protected(gact->param,
++					 lockdep_is_held(&gact->tcf_lock));
++}
++
+ static inline s32 tcf_gate_prio(const struct tc_action *a)
+ {
++	struct tcf_gate_params *p;
+ 	s32 tcfg_prio;
+ 
+-	tcfg_prio = to_gate(a)->param.tcfg_priority;
++	p = tcf_gate_params_locked(a);
++	tcfg_prio = p->tcfg_priority;
+ 
+ 	return tcfg_prio;
+ }
+ 
+ static inline u64 tcf_gate_basetime(const struct tc_action *a)
+ {
++	struct tcf_gate_params *p;
+ 	u64 tcfg_basetime;
+ 
+-	tcfg_basetime = to_gate(a)->param.tcfg_basetime;
++	p = tcf_gate_params_locked(a);
++	tcfg_basetime = p->tcfg_basetime;
+ 
+ 	return tcfg_basetime;
+ }
+ 
+ static inline u64 tcf_gate_cycletime(const struct tc_action *a)
+ {
++	struct tcf_gate_params *p;
+ 	u64 tcfg_cycletime;
+ 
+-	tcfg_cycletime = to_gate(a)->param.tcfg_cycletime;
++	p = tcf_gate_params_locked(a);
++	tcfg_cycletime = p->tcfg_cycletime;
+ 
+ 	return tcfg_cycletime;
+ }
+ 
+ static inline u64 tcf_gate_cycletimeext(const struct tc_action *a)
+ {
++	struct tcf_gate_params *p;
+ 	u64 tcfg_cycletimeext;
+ 
+-	tcfg_cycletimeext = to_gate(a)->param.tcfg_cycletime_ext;
++	p = tcf_gate_params_locked(a);
++	tcfg_cycletimeext = p->tcfg_cycletime_ext;
+ 
+ 	return tcfg_cycletimeext;
+ }
+ 
+ static inline u32 tcf_gate_num_entries(const struct tc_action *a)
+ {
++	struct tcf_gate_params *p;
+ 	u32 num_entries;
+ 
+-	num_entries = to_gate(a)->param.num_entries;
++	p = tcf_gate_params_locked(a);
++	num_entries = p->num_entries;
+ 
+ 	return num_entries;
+ }
+@@ -114,7 +133,7 @@ static inline struct action_gate_entry
+ 	u32 num_entries;
+ 	int i = 0;
+ 
+-	p = &to_gate(a)->param;
++	p = tcf_gate_params_locked(a);
+ 	num_entries = p->num_entries;
+ 
+ 	list_for_each_entry(entry, &p->entries, list)
+diff --git a/include/net/tc_act/tc_ife.h b/include/net/tc_act/tc_ife.h
+index c7f24a2da1cad4..24d4d5a62b3c23 100644
+--- a/include/net/tc_act/tc_ife.h
++++ b/include/net/tc_act/tc_ife.h
+@@ -13,15 +13,13 @@ struct tcf_ife_params {
+ 	u8 eth_src[ETH_ALEN];
+ 	u16 eth_type;
+ 	u16 flags;
+-
++	struct list_head metalist;
+ 	struct rcu_head rcu;
+ };
+ 
+ struct tcf_ife_info {
+ 	struct tc_action common;
+ 	struct tcf_ife_params __rcu *params;
+-	/* list of metaids allowed */
+-	struct list_head metalist;
+ };
+ #define to_ife(a) ((struct tcf_ife_info *)a)
+ 
+diff --git a/include/net/udp_tunnel.h b/include/net/udp_tunnel.h
+index 29251c3519cf0c..0e6eb40cd7778f 100644
+--- a/include/net/udp_tunnel.h
++++ b/include/net/udp_tunnel.h
+@@ -47,7 +47,7 @@ int udp_sock_create6(struct net *net, struct udp_port_cfg *cfg,
+ static inline int udp_sock_create6(struct net *net, struct udp_port_cfg *cfg,
+ 				   struct socket **sockp)
+ {
+-	return 0;
++	return -EPFNOSUPPORT;
+ }
+ #endif
+ 
+diff --git a/include/net/xdp_sock_drv.h b/include/net/xdp_sock_drv.h
+index 5425f7ad5ebdec..7dc08a46462421 100644
+--- a/include/net/xdp_sock_drv.h
++++ b/include/net/xdp_sock_drv.h
+@@ -41,6 +41,11 @@ static inline u32 xsk_pool_get_rx_frame_size(struct xsk_buff_pool *pool)
+ 	return xsk_pool_get_chunk_size(pool) - xsk_pool_get_headroom(pool);
+ }
+ 
++static inline u32 xsk_pool_get_rx_frag_step(struct xsk_buff_pool *pool)
++{
++	return pool->unaligned ? 0 : xsk_pool_get_chunk_size(pool);
++}
++
+ static inline void xsk_pool_set_rxq_info(struct xsk_buff_pool *pool,
+ 					 struct xdp_rxq_info *rxq)
+ {
+@@ -114,8 +119,8 @@ static inline void xsk_buff_free(struct xdp_buff *xdp)
+ 	if (likely(!xdp_buff_has_frags(xdp)))
+ 		goto out;
+ 
+-	list_for_each_entry_safe(pos, tmp, xskb_list, xskb_list_node) {
+-		list_del(&pos->xskb_list_node);
++	list_for_each_entry_safe(pos, tmp, xskb_list, list_node) {
++		list_del_init(&pos->list_node);
+ 		xp_free(pos);
+ 	}
+ 
+@@ -128,7 +133,7 @@ static inline void xsk_buff_add_frag(struct xdp_buff *xdp)
+ {
+ 	struct xdp_buff_xsk *frag = container_of(xdp, struct xdp_buff_xsk, xdp);
+ 
+-	list_add_tail(&frag->xskb_list_node, &frag->pool->xskb_list);
++	list_add_tail(&frag->list_node, &frag->pool->xskb_list);
+ }
+ 
+ static inline struct xdp_buff *xsk_buff_get_frag(struct xdp_buff *first)
+@@ -138,9 +143,9 @@ static inline struct xdp_buff *xsk_buff_get_frag(struct xdp_buff *first)
+ 	struct xdp_buff_xsk *frag;
+ 
+ 	frag = list_first_entry_or_null(&xskb->pool->xskb_list,
+-					struct xdp_buff_xsk, xskb_list_node);
++					struct xdp_buff_xsk, list_node);
+ 	if (frag) {
+-		list_del(&frag->xskb_list_node);
++		list_del_init(&frag->list_node);
+ 		ret = &frag->xdp;
+ 	}
+ 
+@@ -151,7 +156,7 @@ static inline void xsk_buff_del_tail(struct xdp_buff *tail)
+ {
+ 	struct xdp_buff_xsk *xskb = container_of(tail, struct xdp_buff_xsk, xdp);
+ 
+-	list_del(&xskb->xskb_list_node);
++	list_del_init(&xskb->list_node);
+ }
+ 
+ static inline struct xdp_buff *xsk_buff_get_tail(struct xdp_buff *first)
+@@ -160,7 +165,7 @@ static inline struct xdp_buff *xsk_buff_get_tail(struct xdp_buff *first)
+ 	struct xdp_buff_xsk *frag;
+ 
+ 	frag = list_last_entry(&xskb->pool->xskb_list, struct xdp_buff_xsk,
+-			       xskb_list_node);
++			       list_node);
+ 	return &frag->xdp;
+ }
+ 
+@@ -263,6 +268,11 @@ static inline u32 xsk_pool_get_rx_frame_size(struct xsk_buff_pool *pool)
+ 	return 0;
+ }
+ 
++static inline u32 xsk_pool_get_rx_frag_step(struct xsk_buff_pool *pool)
++{
++	return 0;
++}
++
+ static inline void xsk_pool_set_rxq_info(struct xsk_buff_pool *pool,
+ 					 struct xdp_rxq_info *rxq)
+ {
+diff --git a/include/net/xsk_buff_pool.h b/include/net/xsk_buff_pool.h
+index f0d6ce4bda7a28..97392fd7712c6c 100644
+--- a/include/net/xsk_buff_pool.h
++++ b/include/net/xsk_buff_pool.h
+@@ -28,8 +28,7 @@ struct xdp_buff_xsk {
+ 	dma_addr_t frame_dma;
+ 	struct xsk_buff_pool *pool;
+ 	u64 orig_addr;
+-	struct list_head free_list_node;
+-	struct list_head xskb_list_node;
++	struct list_head list_node;
+ };
+ 
+ #define XSK_CHECK_PRIV_TYPE(t) BUILD_BUG_ON(sizeof(t) > offsetofend(struct xdp_buff_xsk, cb))
+diff --git a/include/trace/events/btrfs.h b/include/trace/events/btrfs.h
+index f759109caeeac6..eb762cc7bec531 100644
+--- a/include/trace/events/btrfs.h
++++ b/include/trace/events/btrfs.h
+@@ -225,8 +225,8 @@ DECLARE_EVENT_CLASS(btrfs__inode,
+ 		__entry->generation = BTRFS_I(inode)->generation;
+ 		__entry->last_trans = BTRFS_I(inode)->last_trans;
+ 		__entry->logged_trans = BTRFS_I(inode)->logged_trans;
+-		__entry->root_objectid =
+-				BTRFS_I(inode)->root->root_key.objectid;
++		__entry->root_objectid = BTRFS_I(inode)->root ?
++					 btrfs_root_id(BTRFS_I(inode)->root) : 0;
+ 	),
+ 
+ 	TP_printk_btrfs("root=%llu(%s) gen=%llu ino=%llu blocks=%llu "
+diff --git a/include/trace/events/kmem.h b/include/trace/events/kmem.h
+index 58688768ef0f03..e10fd4e1c7e4a2 100644
+--- a/include/trace/events/kmem.h
++++ b/include/trace/events/kmem.h
+@@ -359,7 +359,13 @@ TRACE_EVENT(rss_stat,
+ 
+ 	TP_fast_assign(
+ 		__entry->mm_id = mm_ptr_to_hash(mm);
+-		__entry->curr = !!(current->mm == mm);
++		/*
++		 * curr is true if the mm matches the current task's mm_struct.
++		 * Since kthreads (PF_KTHREAD) have no mm_struct of their own
++		 * but can borrow one via kthread_use_mm(), we must filter them
++		 * out to avoid incorrectly attributing the RSS update to them.
++		 */
++		__entry->curr = current->mm == mm && !(current->flags & PF_KTHREAD);
+ 		__entry->member = member;
+ 		__entry->size = (percpu_counter_sum_positive(&mm->rss_stat[member])
+ 							    << PAGE_SHIFT);
+diff --git a/include/trace/events/rxrpc.h b/include/trace/events/rxrpc.h
+index 743f8f1f42a742..ceb09fabfb04cc 100644
+--- a/include/trace/events/rxrpc.h
++++ b/include/trace/events/rxrpc.h
+@@ -270,6 +270,7 @@
+ 	EM(rxrpc_call_put_kernel,		"PUT kernel  ") \
+ 	EM(rxrpc_call_put_poke,			"PUT poke    ") \
+ 	EM(rxrpc_call_put_recvmsg,		"PUT recvmsg ") \
++	EM(rxrpc_call_put_recvmsg_peek_nowait,	"PUT peek-nwt") \
+ 	EM(rxrpc_call_put_release_sock,		"PUT rls-sock") \
+ 	EM(rxrpc_call_put_release_sock_tba,	"PUT rls-sk-a") \
+ 	EM(rxrpc_call_put_sendmsg,		"PUT sendmsg ") \
+@@ -287,6 +288,9 @@
+ 	EM(rxrpc_call_see_distribute_error,	"SEE dist-err") \
+ 	EM(rxrpc_call_see_input,		"SEE input   ") \
+ 	EM(rxrpc_call_see_recvmsg,		"SEE recvmsg ") \
++	EM(rxrpc_call_see_recvmsg_requeue,	"SEE recv-rqu") \
++	EM(rxrpc_call_see_recvmsg_requeue_first, "SEE recv-rqF") \
++	EM(rxrpc_call_see_recvmsg_requeue_move,	"SEE recv-rqM") \
+ 	EM(rxrpc_call_see_release,		"SEE release ") \
+ 	EM(rxrpc_call_see_userid_exists,	"SEE u-exists") \
+ 	EM(rxrpc_call_see_waiting_call,		"SEE q-conn  ") \
+diff --git a/include/uapi/linux/btrfs.h b/include/uapi/linux/btrfs.h
+index 6f776faaa791c1..7b499b90bb779e 100644
+--- a/include/uapi/linux/btrfs.h
++++ b/include/uapi/linux/btrfs.h
+@@ -333,6 +333,7 @@ struct btrfs_ioctl_fs_info_args {
+ #define BTRFS_FEATURE_INCOMPAT_RAID1C34		(1ULL << 11)
+ #define BTRFS_FEATURE_INCOMPAT_ZONED		(1ULL << 12)
+ #define BTRFS_FEATURE_INCOMPAT_EXTENT_TREE_V2	(1ULL << 13)
++#define BTRFS_FEATURE_INCOMPAT_RAID_STRIPE_TREE	(1ULL << 14)
+ 
+ struct btrfs_ioctl_feature_flags {
+ 	__u64 compat_flags;
+diff --git a/include/uapi/linux/btrfs_tree.h b/include/uapi/linux/btrfs_tree.h
+index fc3c32186d7eb1..ca65d7b7a6ca19 100644
+--- a/include/uapi/linux/btrfs_tree.h
++++ b/include/uapi/linux/btrfs_tree.h
+@@ -73,6 +73,9 @@
+ /* Holds the block group items for extent tree v2. */
+ #define BTRFS_BLOCK_GROUP_TREE_OBJECTID 11ULL
+ 
++/* Tracks RAID stripes in block groups. */
++#define BTRFS_RAID_STRIPE_TREE_OBJECTID 12ULL
++
+ /* device stats in the device tree */
+ #define BTRFS_DEV_STATS_OBJECTID 0ULL
+ 
+@@ -261,6 +264,8 @@
+ #define BTRFS_DEV_ITEM_KEY	216
+ #define BTRFS_CHUNK_ITEM_KEY	228
+ 
++#define BTRFS_RAID_STRIPE_KEY	230
++
+ /*
+  * Records the overall state of the qgroups.
+  * There's only one instance of this key present,
+@@ -719,6 +724,30 @@ struct btrfs_free_space_header {
+ 	__le64 num_bitmaps;
+ } __attribute__ ((__packed__));
+ 
++struct btrfs_raid_stride {
++	/* The id of device this raid extent lives on. */
++	__le64 devid;
++	/* The physical location on disk. */
++	__le64 physical;
++} __attribute__ ((__packed__));
++
++/* The stripe_extent::encoding, 1:1 mapping of enum btrfs_raid_types. */
++#define BTRFS_STRIPE_RAID0	1
++#define BTRFS_STRIPE_RAID1	2
++#define BTRFS_STRIPE_DUP	3
++#define BTRFS_STRIPE_RAID10	4
++#define BTRFS_STRIPE_RAID5	5
++#define BTRFS_STRIPE_RAID6	6
++#define BTRFS_STRIPE_RAID1C3	7
++#define BTRFS_STRIPE_RAID1C4	8
++
++struct btrfs_stripe_extent {
++	__u8 encoding;
++	__u8 reserved[7];
++	/* An array of raid strides this stripe is composed of. */
++	struct btrfs_raid_stride strides[];
++} __attribute__ ((__packed__));
++
+ #define BTRFS_HEADER_FLAG_WRITTEN	(1ULL << 0)
+ #define BTRFS_HEADER_FLAG_RELOC		(1ULL << 1)
+ 
+diff --git a/include/uapi/linux/pci_regs.h b/include/uapi/linux/pci_regs.h
+index ade8dabf621085..036991bee1a747 100644
+--- a/include/uapi/linux/pci_regs.h
++++ b/include/uapi/linux/pci_regs.h
+@@ -694,7 +694,7 @@
+ #define  PCI_EXP_LNKCTL2_HASD		0x0020 /* HW Autonomous Speed Disable */
+ #define PCI_EXP_LNKSTA2		0x32	/* Link Status 2 */
+ #define  PCI_EXP_LNKSTA2_FLIT		0x0400 /* Flit Mode Status */
+-#define PCI_CAP_EXP_ENDPOINT_SIZEOF_V2	0x32	/* end of v2 EPs w/ link */
++#define PCI_CAP_EXP_ENDPOINT_SIZEOF_V2	0x34	/* end of v2 EPs w/ link */
+ #define PCI_EXP_SLTCAP2		0x34	/* Slot Capabilities 2 */
+ #define  PCI_EXP_SLTCAP2_IBPD	0x00000001 /* In-band PD Disable Supported */
+ #define PCI_EXP_SLTCTL2		0x38	/* Slot Control 2 */
+diff --git a/io_uring/kbuf.c b/io_uring/kbuf.c
+index b2c381634393d2..ad1e14359662ce 100644
+--- a/io_uring/kbuf.c
++++ b/io_uring/kbuf.c
+@@ -70,9 +70,15 @@ void io_kbuf_recycle_legacy(struct io_kiocb *req, unsigned issue_flags)
+ 
+ 	buf = req->kbuf;
+ 	bl = io_buffer_get_list(ctx, buf->bgid);
+-	list_add(&buf->list, &bl->buf_list);
++	/*
++	 * If the buffer list was upgraded to a ring-based one, or removed,
++	 * while the request was in-flight in io-wq, drop it.
++	 */
++	if (bl && !bl->is_mapped)
++		list_add(&buf->list, &bl->buf_list);
+ 	req->flags &= ~REQ_F_BUFFER_SELECTED;
+ 	req->buf_index = buf->bgid;
++	req->kbuf = NULL;
+ 
+ 	io_ring_submit_unlock(ctx, issue_flags);
+ 	return;
+diff --git a/kernel/bpf/devmap.c b/kernel/bpf/devmap.c
+index 5f2356b47b2ddc..3bdec239be6108 100644
+--- a/kernel/bpf/devmap.c
++++ b/kernel/bpf/devmap.c
+@@ -577,18 +577,22 @@ static inline bool is_ifindex_excluded(int *excluded, int num_excluded, int ifin
+ }
+ 
+ /* Get ifindex of each upper device. 'indexes' must be able to hold at
+- * least MAX_NEST_DEV elements.
+- * Returns the number of ifindexes added.
++ * least 'max' elements.
++ * Returns the number of ifindexes added, or -EOVERFLOW if there are too
++ * many upper devices.
+  */
+-static int get_upper_ifindexes(struct net_device *dev, int *indexes)
++static int get_upper_ifindexes(struct net_device *dev, int *indexes, int max)
+ {
+ 	struct net_device *upper;
+ 	struct list_head *iter;
+ 	int n = 0;
+ 
+ 	netdev_for_each_upper_dev_rcu(dev, upper, iter) {
++		if (n >= max)
++			return -EOVERFLOW;
+ 		indexes[n++] = upper->ifindex;
+ 	}
++
+ 	return n;
+ }
+ 
+@@ -604,7 +608,11 @@ int dev_map_enqueue_multi(struct xdp_frame *xdpf, struct net_device *dev_rx,
+ 	int err;
+ 
+ 	if (exclude_ingress) {
+-		num_excluded = get_upper_ifindexes(dev_rx, excluded_devices);
++		num_excluded = get_upper_ifindexes(dev_rx, excluded_devices,
++						   ARRAY_SIZE(excluded_devices) - 1);
++		if (num_excluded < 0)
++			return num_excluded;
++
+ 		excluded_devices[num_excluded++] = dev_rx->ifindex;
+ 	}
+ 
+@@ -722,7 +730,11 @@ int dev_map_redirect_multi(struct net_device *dev, struct sk_buff *skb,
+ 	int err;
+ 
+ 	if (exclude_ingress) {
+-		num_excluded = get_upper_ifindexes(dev, excluded_devices);
++		num_excluded = get_upper_ifindexes(dev, excluded_devices,
++						   ARRAY_SIZE(excluded_devices) - 1);
++		if (num_excluded < 0)
++			return num_excluded;
++
+ 		excluded_devices[num_excluded++] = dev->ifindex;
+ 	}
+ 
+diff --git a/kernel/bpf/syscall.c b/kernel/bpf/syscall.c
+index 63cf5a221081ba..2207f9e7a56742 100644
+--- a/kernel/bpf/syscall.c
++++ b/kernel/bpf/syscall.c
+@@ -5219,10 +5219,11 @@ static int link_detach(union bpf_attr *attr)
+ 	return ret;
+ }
+ 
+-static struct bpf_link *bpf_link_inc_not_zero(struct bpf_link *link)
++struct bpf_link *bpf_link_inc_not_zero(struct bpf_link *link)
+ {
+ 	return atomic64_fetch_add_unless(&link->refcnt, 1, 0) ? link : ERR_PTR(-ENOENT);
+ }
++EXPORT_SYMBOL(bpf_link_inc_not_zero);
+ 
+ struct bpf_link *bpf_link_by_id(u32 id)
+ {
+diff --git a/kernel/bpf/trampoline.c b/kernel/bpf/trampoline.c
+index e48791442acc5f..6f7968d3704ebd 100644
+--- a/kernel/bpf/trampoline.c
++++ b/kernel/bpf/trampoline.c
+@@ -701,10 +701,8 @@ int bpf_trampoline_link_cgroup_shim(struct bpf_prog *prog,
+ 	mutex_lock(&tr->mutex);
+ 
+ 	shim_link = cgroup_shim_find(tr, bpf_func);
+-	if (shim_link) {
++	if (shim_link && !IS_ERR(bpf_link_inc_not_zero(&shim_link->link.link))) {
+ 		/* Reusing existing shim attached by the other program. */
+-		bpf_link_inc(&shim_link->link.link);
+-
+ 		mutex_unlock(&tr->mutex);
+ 		bpf_trampoline_put(tr); /* bpf_trampoline_get above */
+ 		return 0;
+diff --git a/kernel/bpf/verifier.c b/kernel/bpf/verifier.c
+index 4af7c96f6985da..226f2cd338d67b 100644
+--- a/kernel/bpf/verifier.c
++++ b/kernel/bpf/verifier.c
+@@ -14158,6 +14158,10 @@ static void reg_set_min_max(struct bpf_reg_state *true_reg,
+ 		}
+ 		break;
+ 	case BPF_JSET:
++		/* Forget the ranges before narrowing tnums, to avoid invariant
++		 * violations if we're on a dead branch.
++		 */
++		__mark_reg_unbounded(false_reg);
+ 		if (is_jmp32) {
+ 			false_32off = tnum_and(false_32off, tnum_const(~val32));
+ 			if (is_power_of_2(val32))
+diff --git a/kernel/cgroup/cgroup.c b/kernel/cgroup/cgroup.c
+index 476be99dbcf1bf..e787dc0eacd7d7 100644
+--- a/kernel/cgroup/cgroup.c
++++ b/kernel/cgroup/cgroup.c
+@@ -2457,6 +2457,7 @@ static void cgroup_migrate_add_task(struct task_struct *task,
+ 
+ 	mgctx->tset.nr_tasks++;
+ 
++	css_set_skip_task_iters(cset, task);
+ 	list_move_tail(&task->cg_list, &cset->mg_tasks);
+ 	if (list_empty(&cset->mg_node))
+ 		list_add_tail(&cset->mg_node,
+diff --git a/kernel/events/core.c b/kernel/events/core.c
+index 9a6be06176bb41..652baf91c629e5 100644
+--- a/kernel/events/core.c
++++ b/kernel/events/core.c
+@@ -9729,6 +9729,13 @@ int perf_event_overflow(struct perf_event *event,
+ 			struct perf_sample_data *data,
+ 			struct pt_regs *regs)
+ {
++	/*
++	 * Entry point from hardware PMI, interrupts should be disabled here.
++	 * This serializes us against perf_event_remove_from_context() in
++	 * things like perf_event_release_kernel().
++	 */
++	lockdep_assert_irqs_disabled();
++
+ 	return __perf_event_overflow(event, 1, data, regs);
+ }
+ 
+@@ -9809,6 +9816,19 @@ static void perf_swevent_event(struct perf_event *event, u64 nr,
+ {
+ 	struct hw_perf_event *hwc = &event->hw;
+ 
++	/*
++	 * This is:
++	 *   - software		preempt
++	 *   - tracepoint	preempt
++	 *   -   tp_target_task	irq (ctx->lock)
++	 *   - uprobes		preempt/irq
++	 *   - kprobes		preempt/irq
++	 *   - hw_breakpoint	irq
++	 *
++	 * Any of these are sufficient to hold off RCU and thus ensure @event
++	 * exists.
++	 */
++	lockdep_assert_preemption_disabled();
+ 	local64_add(nr, &event->count);
+ 
+ 	if (!regs)
+@@ -9817,6 +9837,16 @@ static void perf_swevent_event(struct perf_event *event, u64 nr,
+ 	if (!is_sampling_event(event))
+ 		return;
+ 
++	/*
++	 * Serialize against event_function_call() IPIs like normal overflow
++	 * event handling. Specifically, must not allow
++	 * perf_event_release_kernel() -> perf_remove_from_context() to make
++	 * progress and 'release' the event from under us.
++	 */
++	guard(irqsave)();
++	if (event->state != PERF_EVENT_STATE_ACTIVE)
++		return;
++
+ 	if ((event->attr.sample_type & PERF_SAMPLE_PERIOD) && !event->attr.freq) {
+ 		data->period = nr;
+ 		return perf_swevent_overflow(event, 1, data, regs);
+@@ -10320,6 +10350,11 @@ void perf_tp_event(u16 event_type, u64 count, void *record, int entry_size,
+ 	struct perf_sample_data data;
+ 	struct perf_event *event;
+ 
++	/*
++	 * Per being a tracepoint, this runs with preemption disabled.
++	 */
++	lockdep_assert_preemption_disabled();
++
+ 	struct perf_raw_record raw = {
+ 		.frag = {
+ 			.size = entry_size,
+@@ -10733,6 +10768,11 @@ void perf_bp_event(struct perf_event *bp, void *data)
+ 	struct perf_sample_data sample;
+ 	struct pt_regs *regs = data;
+ 
++	/*
++	 * Exception context, will have interrupts disabled.
++	 */
++	lockdep_assert_irqs_disabled();
++
+ 	perf_sample_data_init(&sample, bp->attr.bp_addr, 0);
+ 
+ 	if (!bp->hw.state && !perf_exclude_event(bp, regs))
+@@ -11185,7 +11225,7 @@ static enum hrtimer_restart perf_swevent_hrtimer(struct hrtimer *hrtimer)
+ 
+ 	if (regs && !perf_exclude_event(event, regs)) {
+ 		if (!(event->attr.exclude_idle && is_idle_task(current)))
+-			if (__perf_event_overflow(event, 1, &data, regs))
++			if (perf_event_overflow(event, &data, regs))
+ 				ret = HRTIMER_NORESTART;
+ 	}
+ 
+diff --git a/kernel/events/uprobes.c b/kernel/events/uprobes.c
+index 6304238293ae10..3b96952bd6ec78 100644
+--- a/kernel/events/uprobes.c
++++ b/kernel/events/uprobes.c
+@@ -1449,6 +1449,12 @@ void uprobe_munmap(struct vm_area_struct *vma, unsigned long start, unsigned lon
+ 		set_bit(MMF_RECALC_UPROBES, &vma->vm_mm->flags);
+ }
+ 
++unsigned long __weak arch_uprobe_get_xol_area(void)
++{
++	/* Try to map as high as possible, this is only a hint. */
++	return get_unmapped_area(NULL, TASK_SIZE - PAGE_SIZE, PAGE_SIZE, 0, 0);
++}
++
+ /* Slot allocation for XOL */
+ static int xol_add_vma(struct mm_struct *mm, struct xol_area *area)
+ {
+@@ -1464,9 +1470,7 @@ static int xol_add_vma(struct mm_struct *mm, struct xol_area *area)
+ 	}
+ 
+ 	if (!area->vaddr) {
+-		/* Try to map as high as possible, this is only a hint. */
+-		area->vaddr = get_unmapped_area(NULL, TASK_SIZE - PAGE_SIZE,
+-						PAGE_SIZE, 0, 0);
++		area->vaddr = arch_uprobe_get_xol_area();
+ 		if (IS_ERR_VALUE(area->vaddr)) {
+ 			ret = area->vaddr;
+ 			goto fail;
+diff --git a/kernel/fork.c b/kernel/fork.c
+index 2141ebb2ef92ad..ce6f6e1e39057a 100644
+--- a/kernel/fork.c
++++ b/kernel/fork.c
+@@ -3350,7 +3350,7 @@ static int unshare_fs(unsigned long unshare_flags, struct fs_struct **new_fsp)
+ 		return 0;
+ 
+ 	/* don't need lock here; in the worst case we'll do useless copy */
+-	if (fs->users == 1)
++	if (!(unshare_flags & CLONE_NEWNS) && fs->users == 1)
+ 		return 0;
+ 
+ 	*new_fsp = copy_fs_struct(fs);
+diff --git a/kernel/kprobes.c b/kernel/kprobes.c
+index c10954bd84448b..b687bd4ed932dc 100644
+--- a/kernel/kprobes.c
++++ b/kernel/kprobes.c
+@@ -1078,25 +1078,23 @@ static int __arm_kprobe_ftrace(struct kprobe *p, struct ftrace_ops *ops,
+ 	lockdep_assert_held(&kprobe_mutex);
+ 
+ 	ret = ftrace_set_filter_ip(ops, (unsigned long)p->addr, 0, 0);
+-	if (WARN_ONCE(ret < 0, "Failed to arm kprobe-ftrace at %pS (error %d)\n", p->addr, ret))
++	if (ret < 0)
+ 		return ret;
+ 
+ 	if (*cnt == 0) {
+ 		ret = register_ftrace_function(ops);
+-		if (WARN(ret < 0, "Failed to register kprobe-ftrace (error %d)\n", ret))
+-			goto err_ftrace;
++		if (ret < 0) {
++			/*
++			 * At this point, sinec ops is not registered, we should be sefe from
++			 * registering empty filter.
++			 */
++			ftrace_set_filter_ip(ops, (unsigned long)p->addr, 1, 0);
++			return ret;
++		}
+ 	}
+ 
+ 	(*cnt)++;
+ 	return ret;
+-
+-err_ftrace:
+-	/*
+-	 * At this point, sinec ops is not registered, we should be sefe from
+-	 * registering empty filter.
+-	 */
+-	ftrace_set_filter_ip(ops, (unsigned long)p->addr, 1, 0);
+-	return ret;
+ }
+ 
+ static int arm_kprobe_ftrace(struct kprobe *p)
+@@ -1114,6 +1112,10 @@ static int __disarm_kprobe_ftrace(struct kprobe *p, struct ftrace_ops *ops,
+ 	int ret;
+ 
+ 	lockdep_assert_held(&kprobe_mutex);
++	if (unlikely(kprobe_ftrace_disabled)) {
++		/* Now ftrace is disabled forever, disarm is already done. */
++		return 0;
++	}
+ 
+ 	if (*cnt == 1) {
+ 		ret = unregister_ftrace_function(ops);
+@@ -1453,7 +1455,7 @@ _kprobe_addr(kprobe_opcode_t *addr, const char *symbol_name,
+ 	     unsigned long offset, bool *on_func_entry)
+ {
+ 	if ((symbol_name && addr) || (!symbol_name && !addr))
+-		goto invalid;
++		return ERR_PTR(-EINVAL);
+ 
+ 	if (symbol_name) {
+ 		/*
+@@ -1483,11 +1485,10 @@ _kprobe_addr(kprobe_opcode_t *addr, const char *symbol_name,
+ 	 * at the start of the function.
+ 	 */
+ 	addr = arch_adjust_kprobe_addr((unsigned long)addr, offset, on_func_entry);
+-	if (addr)
+-		return addr;
++	if (!addr)
++		return ERR_PTR(-EINVAL);
+ 
+-invalid:
+-	return ERR_PTR(-EINVAL);
++	return addr;
+ }
+ 
+ static kprobe_opcode_t *kprobe_addr(struct kprobe *p)
+@@ -1510,15 +1511,15 @@ static struct kprobe *__get_valid_kprobe(struct kprobe *p)
+ 	if (unlikely(!ap))
+ 		return NULL;
+ 
+-	if (p != ap) {
+-		list_for_each_entry(list_p, &ap->list, list)
+-			if (list_p == p)
+-			/* kprobe p is a valid probe */
+-				goto valid;
+-		return NULL;
+-	}
+-valid:
+-	return ap;
++	if (p == ap)
++		return ap;
++
++	list_for_each_entry(list_p, &ap->list, list)
++		if (list_p == p)
++		/* kprobe p is a valid probe */
++			return ap;
++
++	return NULL;
+ }
+ 
+ /*
+diff --git a/kernel/rcu/tree_nocb.h b/kernel/rcu/tree_nocb.h
+index 8993b2322be2b0..a3d613f063a8f7 100644
+--- a/kernel/rcu/tree_nocb.h
++++ b/kernel/rcu/tree_nocb.h
+@@ -1221,7 +1221,6 @@ static long rcu_nocb_rdp_offload(void *arg)
+ 	struct rcu_segcblist *cblist = &rdp->cblist;
+ 	unsigned long flags;
+ 	int wake_gp;
+-	struct rcu_data *rdp_gp = rdp->nocb_gp_rdp;
+ 
+ 	WARN_ON_ONCE(rdp->cpu != raw_smp_processor_id());
+ 	/*
+@@ -1231,7 +1230,7 @@ static long rcu_nocb_rdp_offload(void *arg)
+ 	if (!rdp->nocb_gp_rdp)
+ 		return -EINVAL;
+ 
+-	if (WARN_ON_ONCE(!rdp_gp->nocb_gp_kthread))
++	if (WARN_ON_ONCE(!rdp->nocb_gp_kthread))
+ 		return -EINVAL;
+ 
+ 	pr_info("Offloading %d\n", rdp->cpu);
+@@ -1260,7 +1259,7 @@ static long rcu_nocb_rdp_offload(void *arg)
+ 	 */
+ 	wake_gp = rdp_offload_toggle(rdp, true, flags);
+ 	if (wake_gp)
+-		wake_up_process(rdp_gp->nocb_gp_kthread);
++		wake_up_process(rdp->nocb_gp_kthread);
+ 	swait_event_exclusive(rdp->nocb_state_wq,
+ 			      rcu_segcblist_test_flags(cblist, SEGCBLIST_KTHREAD_CB) &&
+ 			      rcu_segcblist_test_flags(cblist, SEGCBLIST_KTHREAD_GP));
+diff --git a/kernel/rseq.c b/kernel/rseq.c
+index 810005f927d7cc..e6ee81dd1e457a 100644
+--- a/kernel/rseq.c
++++ b/kernel/rseq.c
+@@ -432,8 +432,9 @@ SYSCALL_DEFINE4(rseq, struct rseq __user *, rseq, u32, rseq_len,
+ 	 * auxiliary vector AT_RSEQ_ALIGN. If rseq_len is the original rseq
+ 	 * size, the required alignment is the original struct rseq alignment.
+ 	 *
+-	 * In order to be valid, rseq_len is either the original rseq size, or
+-	 * large enough to contain all supported fields, as communicated to
++	 * The rseq_len is required to be greater or equal to the original rseq
++	 * size. In order to be valid, rseq_len is either the original rseq size,
++	 * or large enough to contain all supported fields, as communicated to
+ 	 * user-space through the ELF auxiliary vector AT_RSEQ_FEATURE_SIZE.
+ 	 */
+ 	if (rseq_len < ORIG_RSEQ_SIZE ||
+diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
+index de205ecc147402..cdf49a04fd5820 100644
+--- a/kernel/sched/fair.c
++++ b/kernel/sched/fair.c
+@@ -8557,12 +8557,6 @@ idle:
+ 			goto again;
+ 	}
+ 
+-	/*
+-	 * rq is about to be idle, check if we need to update the
+-	 * lost_idle_time of clock_pelt
+-	 */
+-	update_idle_rq_clock_pelt(rq);
+-
+ 	return NULL;
+ }
+ 
+diff --git a/kernel/sched/idle.c b/kernel/sched/idle.c
+index 565f8374ddbbf7..20a8f0f972e633 100644
+--- a/kernel/sched/idle.c
++++ b/kernel/sched/idle.c
+@@ -134,6 +134,14 @@ static int call_cpuidle(struct cpuidle_driver *drv, struct cpuidle_device *dev,
+ 	return cpuidle_enter(drv, dev, next_state);
+ }
+ 
++static void idle_call_stop_or_retain_tick(bool stop_tick)
++{
++	if (stop_tick || tick_nohz_tick_stopped())
++		tick_nohz_idle_stop_tick();
++	else
++		tick_nohz_idle_retain_tick();
++}
++
+ /**
+  * cpuidle_idle_call - the main idle function
+  *
+@@ -143,7 +151,7 @@ static int call_cpuidle(struct cpuidle_driver *drv, struct cpuidle_device *dev,
+  * set, and it returns with polling set.  If it ever stops polling, it
+  * must clear the polling bit.
+  */
+-static void cpuidle_idle_call(void)
++static void cpuidle_idle_call(bool stop_tick)
+ {
+ 	struct cpuidle_device *dev = cpuidle_get_device();
+ 	struct cpuidle_driver *drv = cpuidle_get_cpu_driver(dev);
+@@ -165,7 +173,7 @@ static void cpuidle_idle_call(void)
+ 	 */
+ 
+ 	if (cpuidle_not_available(drv, dev)) {
+-		tick_nohz_idle_stop_tick();
++		idle_call_stop_or_retain_tick(stop_tick);
+ 
+ 		default_idle_call();
+ 		goto exit_idle;
+@@ -199,24 +207,35 @@ static void cpuidle_idle_call(void)
+ 
+ 		next_state = cpuidle_find_deepest_state(drv, dev, max_latency_ns);
+ 		call_cpuidle(drv, dev, next_state);
+-	} else {
+-		bool stop_tick = true;
++	} else if (drv->state_count > 1) {
++		/*
++		 * stop_tick is expected to be true by default by cpuidle
++		 * governors, which allows them to select idle states with
++		 * target residency above the tick period length.
++		 */
++		stop_tick = true;
+ 
+ 		/*
+ 		 * Ask the cpuidle framework to choose a convenient idle state.
+ 		 */
+ 		next_state = cpuidle_select(drv, dev, &stop_tick);
+ 
+-		if (stop_tick || tick_nohz_tick_stopped())
+-			tick_nohz_idle_stop_tick();
+-		else
+-			tick_nohz_idle_retain_tick();
++		idle_call_stop_or_retain_tick(stop_tick);
+ 
+ 		entered_state = call_cpuidle(drv, dev, next_state);
+ 		/*
+ 		 * Give the governor an opportunity to reflect on the outcome
+ 		 */
+ 		cpuidle_reflect(dev, entered_state);
++	} else {
++		idle_call_stop_or_retain_tick(stop_tick);
++
++		/*
++		 * If there is only a single idle state (or none), there is
++		 * nothing meaningful for the governor to choose.  Skip the
++		 * governor and always use state 0.
++		 */
++		call_cpuidle(drv, dev, 0);
+ 	}
+ 
+ exit_idle:
+@@ -237,6 +256,7 @@ exit_idle:
+ static void do_idle(void)
+ {
+ 	int cpu = smp_processor_id();
++	bool got_tick = false;
+ 
+ 	/*
+ 	 * Check if we need to update blocked load
+@@ -279,8 +299,9 @@ static void do_idle(void)
+ 			tick_nohz_idle_restart_tick();
+ 			cpu_idle_poll();
+ 		} else {
+-			cpuidle_idle_call();
++			cpuidle_idle_call(got_tick);
+ 		}
++		got_tick = tick_nohz_idle_got_tick();
+ 		arch_cpu_idle_exit();
+ 	}
+ 
+@@ -414,6 +435,12 @@ static void set_next_task_idle(struct rq *rq, struct task_struct *next, bool fir
+ {
+ 	update_idle_core(rq);
+ 	schedstat_inc(rq->sched_goidle);
++
++	/*
++	 * rq is about to be idle, check if we need to update the
++	 * lost_idle_time of clock_pelt
++	 */
++	update_idle_rq_clock_pelt(rq);
+ }
+ 
+ #ifdef CONFIG_SMP
+diff --git a/kernel/time/time.c b/kernel/time/time.c
+index 1ad88e97b4ebcf..da7e8a02a0964f 100644
+--- a/kernel/time/time.c
++++ b/kernel/time/time.c
+@@ -702,7 +702,7 @@ EXPORT_SYMBOL(clock_t_to_jiffies);
+  *
+  * Return: jiffies_64 value converted to 64-bit "clock_t" (CLOCKS_PER_SEC)
+  */
+-u64 jiffies_64_to_clock_t(u64 x)
++notrace u64 jiffies_64_to_clock_t(u64 x)
+ {
+ #if (TICK_NSEC % (NSEC_PER_SEC / USER_HZ)) == 0
+ # if HZ < USER_HZ
+diff --git a/kernel/trace/trace.c b/kernel/trace/trace.c
+index 29720531ac8188..6b35666a4e0be6 100644
+--- a/kernel/trace/trace.c
++++ b/kernel/trace/trace.c
+@@ -3105,6 +3105,11 @@ static void __ftrace_trace_stack(struct trace_buffer *buffer,
+ 	struct ftrace_stack *fstack;
+ 	struct stack_entry *entry;
+ 	int stackidx;
++	int bit;
++
++	bit = trace_test_and_set_recursion(_THIS_IP_, _RET_IP_, TRACE_EVENT_START);
++	if (bit < 0)
++		return;
+ 
+ 	/*
+ 	 * Add one, for this function and the call to save_stack_trace()
+@@ -3162,6 +3167,7 @@ static void __ftrace_trace_stack(struct trace_buffer *buffer,
+ 	__this_cpu_dec(ftrace_stack_reserve);
+ 	preempt_enable_notrace();
+ 
++	trace_clear_recursion(bit);
+ }
+ 
+ static inline void ftrace_trace_stack(struct trace_array *tr,
+@@ -9271,7 +9277,7 @@ static void
+ init_tracer_tracefs(struct trace_array *tr, struct dentry *d_tracer);
+ 
+ static int
+-allocate_trace_buffer(struct trace_array *tr, struct array_buffer *buf, int size)
++allocate_trace_buffer(struct trace_array *tr, struct array_buffer *buf, unsigned long size)
+ {
+ 	enum ring_buffer_flags rb_flags;
+ 
+@@ -9307,7 +9313,7 @@ static void free_trace_buffer(struct array_buffer *buf)
+ 	}
+ }
+ 
+-static int allocate_trace_buffers(struct trace_array *tr, int size)
++static int allocate_trace_buffers(struct trace_array *tr, unsigned long size)
+ {
+ 	int ret;
+ 
+@@ -10330,7 +10336,7 @@ __init static void enable_instances(void)
+ 
+ __init static int tracer_alloc_buffers(void)
+ {
+-	int ring_buf_size;
++	unsigned long ring_buf_size;
+ 	int ret = -ENOMEM;
+ 
+ 
+diff --git a/kernel/trace/trace_events.c b/kernel/trace/trace_events.c
+index 106ae22f0464d3..9dc45aa43000c7 100644
+--- a/kernel/trace/trace_events.c
++++ b/kernel/trace/trace_events.c
+@@ -4140,26 +4140,22 @@ static __init int event_trace_memsetup(void)
+ 	return 0;
+ }
+ 
+-__init void
+-early_enable_events(struct trace_array *tr, char *buf, bool disable_first)
++/*
++ * Helper function to enable or disable a comma-separated list of events
++ * from the bootup buffer.
++ */
++static __init void __early_set_events(struct trace_array *tr, char *buf, bool enable)
+ {
+ 	char *token;
+-	int ret;
+-
+-	while (true) {
+-		token = strsep(&buf, ",");
+-
+-		if (!token)
+-			break;
+ 
++	while ((token = strsep(&buf, ","))) {
+ 		if (*token) {
+-			/* Restarting syscalls requires that we stop them first */
+-			if (disable_first)
++			if (enable) {
++				if (ftrace_set_clr_event(tr, token, 1))
++					pr_warn("Failed to enable trace event: %s\n", token);
++			} else {
+ 				ftrace_set_clr_event(tr, token, 0);
+-
+-			ret = ftrace_set_clr_event(tr, token, 1);
+-			if (ret)
+-				pr_warn("Failed to enable trace event: %s\n", token);
++			}
+ 		}
+ 
+ 		/* Put back the comma to allow this to be called again */
+@@ -4168,6 +4164,32 @@ early_enable_events(struct trace_array *tr, char *buf, bool disable_first)
+ 	}
+ }
+ 
++/**
++ * early_enable_events - enable events from the bootup buffer
++ * @tr: The trace array to enable the events in
++ * @buf: The buffer containing the comma separated list of events
++ * @disable_first: If true, disable all events in @buf before enabling them
++ *
++ * This function enables events from the bootup buffer. If @disable_first
++ * is true, it will first disable all events in the buffer before enabling
++ * them.
++ *
++ * For syscall events, which rely on a global refcount to register the
++ * SYSCALL_WORK_SYSCALL_TRACEPOINT flag (especially for pid 1), we must
++ * ensure the refcount hits zero before re-enabling them. A simple
++ * "disable then enable" per-event is not enough if multiple syscalls are
++ * used, as the refcount will stay above zero. Thus, we need a two-phase
++ * approach: disable all, then enable all.
++ */
++__init void
++early_enable_events(struct trace_array *tr, char *buf, bool disable_first)
++{
++	if (disable_first)
++		__early_set_events(tr, buf, false);
++
++	__early_set_events(tr, buf, true);
++}
++
+ static __init int event_trace_enable(void)
+ {
+ 	struct trace_array *tr = top_trace_array();
+diff --git a/kernel/trace/trace_events_trigger.c b/kernel/trace/trace_events_trigger.c
+index fe079ff82ef1bf..3ef1fe15493d3c 100644
+--- a/kernel/trace/trace_events_trigger.c
++++ b/kernel/trace/trace_events_trigger.c
+@@ -19,6 +19,9 @@ static DEFINE_MUTEX(trigger_cmd_mutex);
+ 
+ void trigger_data_free(struct event_trigger_data *data)
+ {
++	if (!data)
++		return;
++
+ 	if (data->cmd_ops->set_filter)
+ 		data->cmd_ops->set_filter(NULL, data, NULL);
+ 
+diff --git a/lib/bootconfig.c b/lib/bootconfig.c
+index 97f8911ea339e6..675f34cf32f0d0 100644
+--- a/lib/bootconfig.c
++++ b/lib/bootconfig.c
+@@ -318,7 +318,7 @@ int __init xbc_node_compose_key_after(struct xbc_node *root,
+ 			       depth ? "." : "");
+ 		if (ret < 0)
+ 			return ret;
+-		if (ret > size) {
++		if (ret >= size) {
+ 			size = 0;
+ 		} else {
+ 			size -= ret;
+@@ -534,9 +534,9 @@ static char *skip_spaces_until_newline(char *p)
+ static int __init __xbc_open_brace(char *p)
+ {
+ 	/* Push the last key as open brace */
+-	open_brace[brace_index++] = xbc_node_index(last_parent);
+ 	if (brace_index >= XBC_DEPTH_MAX)
+ 		return xbc_parse_error("Exceed max depth of braces", p);
++	open_brace[brace_index++] = xbc_node_index(last_parent);
+ 
+ 	return 0;
+ }
+@@ -714,7 +714,8 @@ static int __init xbc_parse_kv(char **k, char *v, int op)
+ 		if (op == ':') {
+ 			unsigned short nidx = child->next;
+ 
+-			xbc_init_node(child, v, XBC_VALUE);
++			if (xbc_init_node(child, v, XBC_VALUE) < 0)
++				return xbc_parse_error("Failed to override value", v);
+ 			child->next = nidx;	/* keep subkeys */
+ 			goto array;
+ 		}
+@@ -793,7 +794,7 @@ static int __init xbc_verify_tree(void)
+ 
+ 	/* Brace closing */
+ 	if (brace_index) {
+-		n = &xbc_nodes[open_brace[brace_index]];
++		n = &xbc_nodes[open_brace[brace_index - 1]];
+ 		return xbc_parse_error("Brace is not closed",
+ 					xbc_node_get_data(n));
+ 	}
+diff --git a/mm/kfence/core.c b/mm/kfence/core.c
+index 16a6ecca95fce3..29214aaf3ae1fe 100644
+--- a/mm/kfence/core.c
++++ b/mm/kfence/core.c
+@@ -13,6 +13,7 @@
+ #include <linux/hash.h>
+ #include <linux/irq_work.h>
+ #include <linux/jhash.h>
++#include <linux/kasan-enabled.h>
+ #include <linux/kcsan-checks.h>
+ #include <linux/kfence.h>
+ #include <linux/kmemleak.h>
+@@ -861,6 +862,20 @@ void __init kfence_alloc_pool_and_metadata(void)
+ 	if (!kfence_sample_interval)
+ 		return;
+ 
++	/*
++	 * If KASAN hardware tags are enabled, disable KFENCE, because it
++	 * does not support MTE yet.
++	 */
++	if (kasan_hw_tags_enabled()) {
++		pr_info("disabled as KASAN HW tags are enabled\n");
++		if (__kfence_pool) {
++			memblock_free(__kfence_pool, KFENCE_POOL_SIZE);
++			__kfence_pool = NULL;
++		}
++		kfence_sample_interval = 0;
++		return;
++	}
++
+ 	/*
+ 	 * If the pool has already been initialized by arch, there is no need to
+ 	 * re-allocate the memory pool.
+@@ -930,14 +945,14 @@ static int kfence_init_late(void)
+ #ifdef CONFIG_CONTIG_ALLOC
+ 	struct page *pages;
+ 
+-	pages = alloc_contig_pages(nr_pages_pool, GFP_KERNEL, first_online_node,
+-				   NULL);
++	pages = alloc_contig_pages(nr_pages_pool, GFP_KERNEL | __GFP_SKIP_KASAN,
++				   first_online_node, NULL);
+ 	if (!pages)
+ 		return -ENOMEM;
+ 
+ 	__kfence_pool = page_to_virt(pages);
+-	pages = alloc_contig_pages(nr_pages_meta, GFP_KERNEL, first_online_node,
+-				   NULL);
++	pages = alloc_contig_pages(nr_pages_meta, GFP_KERNEL | __GFP_SKIP_KASAN,
++				   first_online_node, NULL);
+ 	if (pages)
+ 		kfence_metadata_init = page_to_virt(pages);
+ #else
+@@ -947,11 +962,13 @@ static int kfence_init_late(void)
+ 		return -EINVAL;
+ 	}
+ 
+-	__kfence_pool = alloc_pages_exact(KFENCE_POOL_SIZE, GFP_KERNEL);
++	__kfence_pool = alloc_pages_exact(KFENCE_POOL_SIZE,
++					  GFP_KERNEL | __GFP_SKIP_KASAN);
+ 	if (!__kfence_pool)
+ 		return -ENOMEM;
+ 
+-	kfence_metadata_init = alloc_pages_exact(KFENCE_METADATA_SIZE, GFP_KERNEL);
++	kfence_metadata_init = alloc_pages_exact(KFENCE_METADATA_SIZE,
++						 GFP_KERNEL | __GFP_SKIP_KASAN);
+ #endif
+ 
+ 	if (!kfence_metadata_init)
+diff --git a/mm/mempolicy.c b/mm/mempolicy.c
+index 94c74c594d102a..d8007e1c269052 100644
+--- a/mm/mempolicy.c
++++ b/mm/mempolicy.c
+@@ -1071,10 +1071,8 @@ static long migrate_to_node(struct mm_struct *mm, int source, int dest,
+ 
+ 	VM_BUG_ON(!(flags & (MPOL_MF_MOVE | MPOL_MF_MOVE_ALL)));
+ 	vma = find_vma(mm, 0);
+-	if (unlikely(!vma)) {
+-		mmap_read_unlock(mm);
++	if (unlikely(!vma))
+ 		return 0;
+-	}
+ 
+ 	/*
+ 	 * This does not migrate the range, but isolates all pages that
+diff --git a/net/atm/lec.c b/net/atm/lec.c
+index b7fa48a9b72059..0d4b8e5936dcfb 100644
+--- a/net/atm/lec.c
++++ b/net/atm/lec.c
+@@ -1260,24 +1260,28 @@ static void lec_arp_clear_vccs(struct lec_arp_table *entry)
+ 		struct lec_vcc_priv *vpriv = LEC_VCC_PRIV(vcc);
+ 		struct net_device *dev = (struct net_device *)vcc->proto_data;
+ 
+-		vcc->pop = vpriv->old_pop;
+-		if (vpriv->xoff)
+-			netif_wake_queue(dev);
+-		kfree(vpriv);
+-		vcc->user_back = NULL;
+-		vcc->push = entry->old_push;
+-		vcc_release_async(vcc, -EPIPE);
++		if (vpriv) {
++			vcc->pop = vpriv->old_pop;
++			if (vpriv->xoff)
++				netif_wake_queue(dev);
++			kfree(vpriv);
++			vcc->user_back = NULL;
++			vcc->push = entry->old_push;
++			vcc_release_async(vcc, -EPIPE);
++		}
+ 		entry->vcc = NULL;
+ 	}
+ 	if (entry->recv_vcc) {
+ 		struct atm_vcc *vcc = entry->recv_vcc;
+ 		struct lec_vcc_priv *vpriv = LEC_VCC_PRIV(vcc);
+ 
+-		kfree(vpriv);
+-		vcc->user_back = NULL;
++		if (vpriv) {
++			kfree(vpriv);
++			vcc->user_back = NULL;
+ 
+-		entry->recv_vcc->push = entry->old_recv_push;
+-		vcc_release_async(entry->recv_vcc, -EPIPE);
++			entry->recv_vcc->push = entry->old_recv_push;
++			vcc_release_async(entry->recv_vcc, -EPIPE);
++		}
+ 		entry->recv_vcc = NULL;
+ 	}
+ }
+diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
+index 209180b4c26817..c31edbd7c2abab 100644
+--- a/net/batman-adv/bat_iv_ogm.c
++++ b/net/batman-adv/bat_iv_ogm.c
+@@ -464,6 +464,9 @@ batadv_iv_ogm_can_aggregate(const struct batadv_ogm_packet *new_bat_ogm_packet,
+ 	    !time_after_eq(aggregation_end_time, forw_packet->send_time))
+ 		return false;
+ 
++	if (skb_tailroom(forw_packet->skb) < packet_len)
++		return false;
++
+ 	if (aggregated_bytes > BATADV_MAX_AGGREGATION_BYTES)
+ 		return false;
+ 
+diff --git a/net/batman-adv/bat_v_elp.c b/net/batman-adv/bat_v_elp.c
+index b065578b4436ee..44deb3ac771296 100644
+--- a/net/batman-adv/bat_v_elp.c
++++ b/net/batman-adv/bat_v_elp.c
+@@ -112,7 +112,15 @@ static bool batadv_v_elp_get_throughput(struct batadv_hardif_neigh_node *neigh,
+ 			/* unsupported WiFi driver version */
+ 			goto default_throughput;
+ 
+-		real_netdev = batadv_get_real_netdev(hard_iface->net_dev);
++		/* only use rtnl_trylock because the elp worker will be cancelled while
++		 * the rntl_lock is held. the cancel_delayed_work_sync() would otherwise
++		 * wait forever when the elp work_item was started and it is then also
++		 * trying to rtnl_lock
++		 */
++		if (!rtnl_trylock())
++			return false;
++		real_netdev = __batadv_get_real_netdev(hard_iface->net_dev);
++		rtnl_unlock();
+ 		if (!real_netdev)
+ 			goto default_throughput;
+ 
+diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+index 96a412beab2de9..c142e629e4d728 100644
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -203,7 +203,7 @@ static bool batadv_is_valid_iface(const struct net_device *net_dev)
+ }
+ 
+ /**
+- * batadv_get_real_netdevice() - check if the given netdev struct is a virtual
++ * __batadv_get_real_netdev() - check if the given netdev struct is a virtual
+  *  interface on top of another 'real' interface
+  * @netdev: the device to check
+  *
+@@ -213,7 +213,7 @@ static bool batadv_is_valid_iface(const struct net_device *net_dev)
+  * Return: the 'real' net device or the original net device and NULL in case
+  *  of an error.
+  */
+-static struct net_device *batadv_get_real_netdevice(struct net_device *netdev)
++struct net_device *__batadv_get_real_netdev(struct net_device *netdev)
+ {
+ 	struct batadv_hard_iface *hard_iface = NULL;
+ 	struct net_device *real_netdev = NULL;
+@@ -266,7 +266,7 @@ struct net_device *batadv_get_real_netdev(struct net_device *net_device)
+ 	struct net_device *real_netdev;
+ 
+ 	rtnl_lock();
+-	real_netdev = batadv_get_real_netdevice(net_device);
++	real_netdev = __batadv_get_real_netdev(net_device);
+ 	rtnl_unlock();
+ 
+ 	return real_netdev;
+@@ -335,7 +335,7 @@ static u32 batadv_wifi_flags_evaluate(struct net_device *net_device)
+ 	if (batadv_is_cfg80211_netdev(net_device))
+ 		wifi_flags |= BATADV_HARDIF_WIFI_CFG80211_DIRECT;
+ 
+-	real_netdev = batadv_get_real_netdevice(net_device);
++	real_netdev = __batadv_get_real_netdev(net_device);
+ 	if (!real_netdev)
+ 		return wifi_flags;
+ 
+diff --git a/net/batman-adv/hard-interface.h b/net/batman-adv/hard-interface.h
+index 64f660dbbe542c..c7c2f17e6a4623 100644
+--- a/net/batman-adv/hard-interface.h
++++ b/net/batman-adv/hard-interface.h
+@@ -68,6 +68,7 @@ enum batadv_hard_if_bcast {
+ 
+ extern struct notifier_block batadv_hard_if_notifier;
+ 
++struct net_device *__batadv_get_real_netdev(struct net_device *net_device);
+ struct net_device *batadv_get_real_netdev(struct net_device *net_device);
+ bool batadv_is_cfg80211_hardif(struct batadv_hard_iface *hard_iface);
+ bool batadv_is_wifi_hardif(struct batadv_hard_iface *hard_iface);
+diff --git a/net/bluetooth/hci_conn.c b/net/bluetooth/hci_conn.c
+index 30feeaf7e64248..97e48c1f69aff7 100644
+--- a/net/bluetooth/hci_conn.c
++++ b/net/bluetooth/hci_conn.c
+@@ -1837,6 +1837,8 @@ static bool hci_le_set_cig_params(struct hci_conn *conn, struct bt_iso_qos *qos)
+ 		return false;
+ 
+ done:
++	conn->iso_qos = *qos;
++
+ 	if (hci_cmd_sync_queue(hdev, set_cig_params_sync,
+ 			       UINT_PTR(qos->ucast.cig), NULL) < 0)
+ 		return false;
+@@ -1903,8 +1905,6 @@ struct hci_conn *hci_bind_cis(struct hci_dev *hdev, bdaddr_t *dst,
+ 	}
+ 
+ 	hci_conn_hold(cis);
+-
+-	cis->iso_qos = *qos;
+ 	cis->state = BT_BOUND;
+ 
+ 	return cis;
+diff --git a/net/bluetooth/hci_sync.c b/net/bluetooth/hci_sync.c
+index 6a14f760710774..6192f70e4d3935 100644
+--- a/net/bluetooth/hci_sync.c
++++ b/net/bluetooth/hci_sync.c
+@@ -6555,8 +6555,8 @@ static int hci_le_create_conn_sync(struct hci_dev *hdev, void *data)
+ 	 * state.
+ 	 */
+ 	if (hci_dev_test_flag(hdev, HCI_LE_SCAN)) {
+-		hci_scan_disable_sync(hdev);
+ 		hci_dev_set_flag(hdev, HCI_LE_SCAN_INTERRUPTED);
++		hci_scan_disable_sync(hdev);
+ 	}
+ 
+ 	/* Update random address, but set require_privacy to false so
+diff --git a/net/bluetooth/hidp/core.c b/net/bluetooth/hidp/core.c
+index 707f229f896a1f..40a6f1e20babc8 100644
+--- a/net/bluetooth/hidp/core.c
++++ b/net/bluetooth/hidp/core.c
+@@ -986,7 +986,8 @@ static void session_free(struct kref *ref)
+ 	skb_queue_purge(&session->intr_transmit);
+ 	fput(session->intr_sock->file);
+ 	fput(session->ctrl_sock->file);
+-	l2cap_conn_put(session->conn);
++	if (session->conn)
++		l2cap_conn_put(session->conn);
+ 	kfree(session);
+ }
+ 
+@@ -1164,6 +1165,15 @@ static void hidp_session_remove(struct l2cap_conn *conn,
+ 
+ 	down_write(&hidp_session_sem);
+ 
++	/* Drop L2CAP reference immediately to indicate that
++	 * l2cap_unregister_user() shall not be called as it is already
++	 * considered removed.
++	 */
++	if (session->conn) {
++		l2cap_conn_put(session->conn);
++		session->conn = NULL;
++	}
++
+ 	hidp_session_terminate(session);
+ 
+ 	cancel_work_sync(&session->dev_init);
+@@ -1301,7 +1311,9 @@ static int hidp_session_thread(void *arg)
+ 	 * Instead, this call has the same semantics as if user-space tried to
+ 	 * delete the session.
+ 	 */
+-	l2cap_unregister_user(session->conn, &session->user);
++	if (session->conn)
++		l2cap_unregister_user(session->conn, &session->user);
++
+ 	hidp_session_put(session);
+ 
+ 	module_put_and_kthread_exit(0);
+diff --git a/net/bluetooth/l2cap_core.c b/net/bluetooth/l2cap_core.c
+index 0cbd6c29212385..16cc5c878305b7 100644
+--- a/net/bluetooth/l2cap_core.c
++++ b/net/bluetooth/l2cap_core.c
+@@ -1686,17 +1686,15 @@ static void l2cap_info_timeout(struct work_struct *work)
+ 
+ int l2cap_register_user(struct l2cap_conn *conn, struct l2cap_user *user)
+ {
+-	struct hci_dev *hdev = conn->hcon->hdev;
+ 	int ret;
+ 
+ 	/* We need to check whether l2cap_conn is registered. If it is not, we
+-	 * must not register the l2cap_user. l2cap_conn_del() is unregisters
+-	 * l2cap_conn objects, but doesn't provide its own locking. Instead, it
+-	 * relies on the parent hci_conn object to be locked. This itself relies
+-	 * on the hci_dev object to be locked. So we must lock the hci device
+-	 * here, too. */
++	 * must not register the l2cap_user. l2cap_conn_del() unregisters
++	 * l2cap_conn objects under conn->lock, and we use the same lock here
++	 * to protect access to conn->users and conn->hchan.
++	 */
+ 
+-	hci_dev_lock(hdev);
++	mutex_lock(&conn->lock);
+ 
+ 	if (!list_empty(&user->list)) {
+ 		ret = -EINVAL;
+@@ -1717,16 +1715,14 @@ int l2cap_register_user(struct l2cap_conn *conn, struct l2cap_user *user)
+ 	ret = 0;
+ 
+ out_unlock:
+-	hci_dev_unlock(hdev);
++	mutex_unlock(&conn->lock);
+ 	return ret;
+ }
+ EXPORT_SYMBOL(l2cap_register_user);
+ 
+ void l2cap_unregister_user(struct l2cap_conn *conn, struct l2cap_user *user)
+ {
+-	struct hci_dev *hdev = conn->hcon->hdev;
+-
+-	hci_dev_lock(hdev);
++	mutex_lock(&conn->lock);
+ 
+ 	if (list_empty(&user->list))
+ 		goto out_unlock;
+@@ -1735,7 +1731,7 @@ void l2cap_unregister_user(struct l2cap_conn *conn, struct l2cap_user *user)
+ 	user->remove(conn, user);
+ 
+ out_unlock:
+-	hci_dev_unlock(hdev);
++	mutex_unlock(&conn->lock);
+ }
+ EXPORT_SYMBOL(l2cap_unregister_user);
+ 
+@@ -4585,7 +4581,8 @@ static inline int l2cap_information_rsp(struct l2cap_conn *conn,
+ 
+ 	switch (type) {
+ 	case L2CAP_IT_FEAT_MASK:
+-		conn->feat_mask = get_unaligned_le32(rsp->data);
++		if (cmd_len >= sizeof(*rsp) + sizeof(u32))
++			conn->feat_mask = get_unaligned_le32(rsp->data);
+ 
+ 		if (conn->feat_mask & L2CAP_FEAT_FIXED_CHAN) {
+ 			struct l2cap_info_req req;
+@@ -4604,7 +4601,8 @@ static inline int l2cap_information_rsp(struct l2cap_conn *conn,
+ 		break;
+ 
+ 	case L2CAP_IT_FIXED_CHAN:
+-		conn->remote_fixed_chan = rsp->data[0];
++		if (cmd_len >= sizeof(*rsp) + sizeof(rsp->data[0]))
++			conn->remote_fixed_chan = rsp->data[0];
+ 		conn->info_state |= L2CAP_INFO_FEAT_MASK_REQ_DONE;
+ 		conn->info_ident = 0;
+ 
+@@ -5009,7 +5007,7 @@ static inline int l2cap_ecred_conn_req(struct l2cap_conn *conn,
+ 	u16 mtu, mps;
+ 	__le16 psm;
+ 	u8 result, len = 0;
+-	int i, num_scid;
++	int i, num_scid = 0;
+ 	bool defer = false;
+ 
+ 	if (!enable_ecred)
+@@ -5020,6 +5018,14 @@ static inline int l2cap_ecred_conn_req(struct l2cap_conn *conn,
+ 		goto response;
+ 	}
+ 
++	/* Check if there are no pending channels with the same ident */
++	__l2cap_chan_list_id(conn, cmd->ident, l2cap_ecred_list_defer,
++			     &num_scid);
++	if (num_scid) {
++		result = L2CAP_CR_LE_INVALID_PARAMS;
++		goto response;
++	}
++
+ 	cmd_len -= sizeof(*req);
+ 	num_scid = cmd_len / sizeof(u16);
+ 
+@@ -5372,7 +5378,7 @@ static inline int l2cap_ecred_reconf_rsp(struct l2cap_conn *conn,
+ 					 u8 *data)
+ {
+ 	struct l2cap_chan *chan, *tmp;
+-	struct l2cap_ecred_conn_rsp *rsp = (void *) data;
++	struct l2cap_ecred_reconf_rsp *rsp = (void *)data;
+ 	u16 result;
+ 
+ 	if (cmd_len < sizeof(*rsp))
+@@ -5380,7 +5386,7 @@ static inline int l2cap_ecred_reconf_rsp(struct l2cap_conn *conn,
+ 
+ 	result = __le16_to_cpu(rsp->result);
+ 
+-	BT_DBG("result 0x%4.4x", rsp->result);
++	BT_DBG("result 0x%4.4x", result);
+ 
+ 	if (!result)
+ 		return 0;
+@@ -6608,8 +6614,10 @@ static int l2cap_ecred_data_rcv(struct l2cap_chan *chan, struct sk_buff *skb)
+ 		return -ENOBUFS;
+ 	}
+ 
+-	if (chan->imtu < skb->len) {
+-		BT_ERR("Too big LE L2CAP PDU");
++	if (skb->len > chan->imtu) {
++		BT_ERR("Too big LE L2CAP PDU: len %u > %u", skb->len,
++		       chan->imtu);
++		l2cap_send_disconn_req(chan, ECONNRESET);
+ 		return -ENOBUFS;
+ 	}
+ 
+@@ -6635,7 +6643,9 @@ static int l2cap_ecred_data_rcv(struct l2cap_chan *chan, struct sk_buff *skb)
+ 		       sdu_len, skb->len, chan->imtu);
+ 
+ 		if (sdu_len > chan->imtu) {
+-			BT_ERR("Too big LE L2CAP SDU length received");
++			BT_ERR("Too big LE L2CAP SDU length: len %u > %u",
++			       skb->len, sdu_len);
++			l2cap_send_disconn_req(chan, ECONNRESET);
+ 			err = -EMSGSIZE;
+ 			goto failed;
+ 		}
+@@ -6671,6 +6681,7 @@ static int l2cap_ecred_data_rcv(struct l2cap_chan *chan, struct sk_buff *skb)
+ 
+ 	if (chan->sdu->len + skb->len > chan->sdu_len) {
+ 		BT_ERR("Too much LE L2CAP data received");
++		l2cap_send_disconn_req(chan, ECONNRESET);
+ 		err = -EINVAL;
+ 		goto failed;
+ 	}
+diff --git a/net/bluetooth/smp.c b/net/bluetooth/smp.c
+index e7ee13fe83a74a..62c8eab1b84a5c 100644
+--- a/net/bluetooth/smp.c
++++ b/net/bluetooth/smp.c
+@@ -2744,7 +2744,7 @@ static int smp_cmd_public_key(struct l2cap_conn *conn, struct sk_buff *skb)
+ 	if (!test_bit(SMP_FLAG_DEBUG_KEY, &smp->flags) &&
+ 	    !crypto_memneq(key, smp->local_pk, 64)) {
+ 		bt_dev_err(hdev, "Remote and local public keys are identical");
+-		return SMP_UNSPECIFIED;
++		return SMP_DHKEY_CHECK_FAILED;
+ 	}
+ 
+ 	memcpy(smp->remote_pk, key, 64);
+diff --git a/net/bridge/br_device.c b/net/bridge/br_device.c
+index 42d4c3727bf76d..4af3e4c67038dc 100644
+--- a/net/bridge/br_device.c
++++ b/net/bridge/br_device.c
+@@ -72,7 +72,7 @@ netdev_tx_t br_dev_xmit(struct sk_buff *skb, struct net_device *dev)
+ 	     eth_hdr(skb)->h_proto == htons(ETH_P_RARP)) &&
+ 	    br_opt_get(br, BROPT_NEIGH_SUPPRESS_ENABLED)) {
+ 		br_do_proxy_suppress_arp(skb, br, vid, NULL);
+-	} else if (IS_ENABLED(CONFIG_IPV6) &&
++	} else if (ipv6_mod_enabled() &&
+ 		   skb->protocol == htons(ETH_P_IPV6) &&
+ 		   br_opt_get(br, BROPT_NEIGH_SUPPRESS_ENABLED) &&
+ 		   pskb_may_pull(skb, sizeof(struct ipv6hdr) +
+diff --git a/net/bridge/br_input.c b/net/bridge/br_input.c
+index 847fe03a08ee80..46d2b20afd5ff2 100644
+--- a/net/bridge/br_input.c
++++ b/net/bridge/br_input.c
+@@ -165,7 +165,7 @@ int br_handle_frame_finish(struct net *net, struct sock *sk, struct sk_buff *skb
+ 	    (skb->protocol == htons(ETH_P_ARP) ||
+ 	     skb->protocol == htons(ETH_P_RARP))) {
+ 		br_do_proxy_suppress_arp(skb, br, vid, p);
+-	} else if (IS_ENABLED(CONFIG_IPV6) &&
++	} else if (ipv6_mod_enabled() &&
+ 		   skb->protocol == htons(ETH_P_IPV6) &&
+ 		   br_opt_get(br, BROPT_NEIGH_SUPPRESS_ENABLED) &&
+ 		   pskb_may_pull(skb, sizeof(struct ipv6hdr) +
+diff --git a/net/can/bcm.c b/net/can/bcm.c
+index 75653584f31b94..35039645c4629e 100644
+--- a/net/can/bcm.c
++++ b/net/can/bcm.c
+@@ -1128,6 +1128,7 @@ static int bcm_rx_setup(struct bcm_msg_head *msg_head, struct msghdr *msg,
+ 		if (!op)
+ 			return -ENOMEM;
+ 
++		spin_lock_init(&op->bcm_tx_lock);
+ 		op->can_id = msg_head->can_id;
+ 		op->nframes = msg_head->nframes;
+ 		op->cfsiz = CFSIZ(msg_head->flags);
+diff --git a/net/ceph/auth.c b/net/ceph/auth.c
+index d38c9eadbe2f18..0d75679c6a7ed4 100644
+--- a/net/ceph/auth.c
++++ b/net/ceph/auth.c
+@@ -205,9 +205,9 @@ int ceph_handle_auth_reply(struct ceph_auth_client *ac,
+ 	s32 result;
+ 	u64 global_id;
+ 	void *payload, *payload_end;
+-	int payload_len;
++	u32 payload_len;
+ 	char *result_msg;
+-	int result_msg_len;
++	u32 result_msg_len;
+ 	int ret = -EINVAL;
+ 
+ 	mutex_lock(&ac->mutex);
+@@ -217,10 +217,12 @@ int ceph_handle_auth_reply(struct ceph_auth_client *ac,
+ 	result = ceph_decode_32(&p);
+ 	global_id = ceph_decode_64(&p);
+ 	payload_len = ceph_decode_32(&p);
++	ceph_decode_need(&p, end, payload_len, bad);
+ 	payload = p;
+ 	p += payload_len;
+ 	ceph_decode_need(&p, end, sizeof(u32), bad);
+ 	result_msg_len = ceph_decode_32(&p);
++	ceph_decode_need(&p, end, result_msg_len, bad);
+ 	result_msg = p;
+ 	p += result_msg_len;
+ 	if (p != end)
+diff --git a/net/ceph/messenger_v2.c b/net/ceph/messenger_v2.c
+index f82029bd33db8b..89f2ab4b8e3a8c 100644
+--- a/net/ceph/messenger_v2.c
++++ b/net/ceph/messenger_v2.c
+@@ -392,7 +392,7 @@ static int head_onwire_len(int ctrl_len, bool secure)
+ 	int head_len;
+ 	int rem_len;
+ 
+-	BUG_ON(ctrl_len < 0 || ctrl_len > CEPH_MSG_MAX_CONTROL_LEN);
++	BUG_ON(ctrl_len < 1 || ctrl_len > CEPH_MSG_MAX_CONTROL_LEN);
+ 
+ 	if (secure) {
+ 		head_len = CEPH_PREAMBLE_SECURE_LEN;
+@@ -401,9 +401,7 @@ static int head_onwire_len(int ctrl_len, bool secure)
+ 			head_len += padded_len(rem_len) + CEPH_GCM_TAG_LEN;
+ 		}
+ 	} else {
+-		head_len = CEPH_PREAMBLE_PLAIN_LEN;
+-		if (ctrl_len)
+-			head_len += ctrl_len + CEPH_CRC_LEN;
++		head_len = CEPH_PREAMBLE_PLAIN_LEN + ctrl_len + CEPH_CRC_LEN;
+ 	}
+ 	return head_len;
+ }
+@@ -528,11 +526,16 @@ static int decode_preamble(void *p, struct ceph_frame_desc *desc)
+ 		desc->fd_aligns[i] = ceph_decode_16(&p);
+ 	}
+ 
+-	if (desc->fd_lens[0] < 0 ||
++	/*
++	 * This would fire for FRAME_TAG_WAIT (it has one empty
++	 * segment), but we should never get it as client.
++	 */
++	if (desc->fd_lens[0] < 1 ||
+ 	    desc->fd_lens[0] > CEPH_MSG_MAX_CONTROL_LEN) {
+ 		pr_err("bad control segment length %d\n", desc->fd_lens[0]);
+ 		return -EINVAL;
+ 	}
++
+ 	if (desc->fd_lens[1] < 0 ||
+ 	    desc->fd_lens[1] > CEPH_MSG_MAX_FRONT_LEN) {
+ 		pr_err("bad front segment length %d\n", desc->fd_lens[1]);
+@@ -549,10 +552,6 @@ static int decode_preamble(void *p, struct ceph_frame_desc *desc)
+ 		return -EINVAL;
+ 	}
+ 
+-	/*
+-	 * This would fire for FRAME_TAG_WAIT (it has one empty
+-	 * segment), but we should never get it as client.
+-	 */
+ 	if (!desc->fd_lens[desc->fd_seg_cnt - 1]) {
+ 		pr_err("last segment empty, segment count %d\n",
+ 		       desc->fd_seg_cnt);
+@@ -2869,12 +2868,15 @@ static int process_message_header(struct ceph_connection *con,
+ 				  void *p, void *end)
+ {
+ 	struct ceph_frame_desc *desc = &con->v2.in_desc;
+-	struct ceph_msg_header2 *hdr2 = p;
++	struct ceph_msg_header2 *hdr2;
+ 	struct ceph_msg_header hdr;
+ 	int skip;
+ 	int ret;
+ 	u64 seq;
+ 
++	ceph_decode_need(&p, end, sizeof(*hdr2), bad);
++	hdr2 = p;
++
+ 	/* verify seq# */
+ 	seq = le64_to_cpu(hdr2->seq);
+ 	if ((s64)seq - (s64)con->in_seq < 1) {
+@@ -2905,6 +2907,10 @@ static int process_message_header(struct ceph_connection *con,
+ 	WARN_ON(!con->in_msg);
+ 	WARN_ON(con->in_msg->con != con);
+ 	return 1;
++
++bad:
++	pr_err("failed to decode message header\n");
++	return -EINVAL;
+ }
+ 
+ static int process_message(struct ceph_connection *con)
+@@ -2934,6 +2940,11 @@ static int __handle_control(struct ceph_connection *con, void *p)
+ 	if (con->v2.in_desc.fd_tag != FRAME_TAG_MESSAGE)
+ 		return process_control(con, p, end);
+ 
++	if (con->state != CEPH_CON_S_OPEN) {
++		con->error_msg = "protocol error, unexpected message";
++		return -EINVAL;
++	}
++
+ 	ret = process_message_header(con, p, end);
+ 	if (ret < 0)
+ 		return ret;
+diff --git a/net/ceph/mon_client.c b/net/ceph/mon_client.c
+index 0f8b8335981cfd..290fd7ab125fa7 100644
+--- a/net/ceph/mon_client.c
++++ b/net/ceph/mon_client.c
+@@ -72,8 +72,8 @@ static struct ceph_monmap *ceph_monmap_decode(void **p, void *end, bool msgr2)
+ 	struct ceph_monmap *monmap = NULL;
+ 	struct ceph_fsid fsid;
+ 	u32 struct_len;
+-	int blob_len;
+-	int num_mon;
++	u32 blob_len;
++	u32 num_mon;
+ 	u8 struct_v;
+ 	u32 epoch;
+ 	int ret;
+@@ -112,7 +112,7 @@ static struct ceph_monmap *ceph_monmap_decode(void **p, void *end, bool msgr2)
+ 	}
+ 	ceph_decode_32_safe(p, end, num_mon, e_inval);
+ 
+-	dout("%s fsid %pU epoch %u num_mon %d\n", __func__, &fsid, epoch,
++	dout("%s fsid %pU epoch %u num_mon %u\n", __func__, &fsid, epoch,
+ 	     num_mon);
+ 	if (num_mon > CEPH_MAX_MON)
+ 		goto e_inval;
+diff --git a/net/core/dst.c b/net/core/dst.c
+index 2513665696f693..5ed8cb10748f5a 100644
+--- a/net/core/dst.c
++++ b/net/core/dst.c
+@@ -68,6 +68,7 @@ void dst_init(struct dst_entry *dst, struct dst_ops *ops,
+ 	dst->lwtstate = NULL;
+ 	rcuref_init(&dst->__rcuref, initial_ref);
+ 	INIT_LIST_HEAD(&dst->rt_uncached);
++	dst->rt_uncached_list = NULL;
+ 	dst->__use = 0;
+ 	dst->lastuse = jiffies;
+ 	dst->flags = flags;
+diff --git a/net/core/filter.c b/net/core/filter.c
+index e5dc1f699297b0..2cd58d1d4a7aa7 100644
+--- a/net/core/filter.c
++++ b/net/core/filter.c
+@@ -3340,6 +3340,7 @@ static int bpf_skb_proto_4_to_6(struct sk_buff *skb)
+ 			shinfo->gso_type &= ~SKB_GSO_TCPV4;
+ 			shinfo->gso_type |=  SKB_GSO_TCPV6;
+ 		}
++		shinfo->gso_type |=  SKB_GSO_DODGY;
+ 	}
+ 
+ 	bpf_skb_change_protocol(skb, ETH_P_IPV6);
+@@ -3370,6 +3371,7 @@ static int bpf_skb_proto_6_to_4(struct sk_buff *skb)
+ 			shinfo->gso_type &= ~SKB_GSO_TCPV6;
+ 			shinfo->gso_type |=  SKB_GSO_TCPV4;
+ 		}
++		shinfo->gso_type |=  SKB_GSO_DODGY;
+ 	}
+ 
+ 	bpf_skb_change_protocol(skb, ETH_P_IP);
+@@ -4132,12 +4134,14 @@ static int bpf_xdp_frags_increase_tail(struct xdp_buff *xdp, int offset)
+ 	struct skb_shared_info *sinfo = xdp_get_shared_info_from_buff(xdp);
+ 	skb_frag_t *frag = &sinfo->frags[sinfo->nr_frags - 1];
+ 	struct xdp_rxq_info *rxq = xdp->rxq;
+-	unsigned int tailroom;
++	int tailroom;
+ 
+ 	if (!rxq->frag_size || rxq->frag_size > xdp->frame_sz)
+ 		return -EOPNOTSUPP;
+ 
+-	tailroom = rxq->frag_size - skb_frag_size(frag) - skb_frag_off(frag);
++	tailroom = rxq->frag_size - skb_frag_size(frag) -
++		   skb_frag_off(frag) % rxq->frag_size;
++	WARN_ON_ONCE(tailroom < 0);
+ 	if (unlikely(offset > tailroom))
+ 		return -EINVAL;
+ 
+diff --git a/net/dsa/dsa.c b/net/dsa/dsa.c
+index ea308274093670..395899a2bc21eb 100644
+--- a/net/dsa/dsa.c
++++ b/net/dsa/dsa.c
+@@ -1257,14 +1257,25 @@ static int dsa_port_parse_of(struct dsa_port *dp, struct device_node *dn)
+ 	if (ethernet) {
+ 		struct net_device *master;
+ 		const char *user_protocol;
++		int err;
+ 
++		rtnl_lock();
+ 		master = of_find_net_device_by_node(ethernet);
+ 		of_node_put(ethernet);
+-		if (!master)
++		if (!master) {
++			rtnl_unlock();
+ 			return -EPROBE_DEFER;
++		}
++
++		netdev_hold(master, &dp->master_tracker, GFP_KERNEL);
++		put_device(&master->dev);
++		rtnl_unlock();
+ 
+ 		user_protocol = of_get_property(dn, "dsa-tag-protocol", NULL);
+-		return dsa_port_parse_cpu(dp, master, user_protocol);
++		err = dsa_port_parse_cpu(dp, master, user_protocol);
++		if (err)
++			netdev_put(master, &dp->master_tracker);
++		return err;
+ 	}
+ 
+ 	if (link)
+@@ -1397,37 +1408,30 @@ static struct device *dev_find_class(struct device *parent, char *class)
+ 	return device_find_child(parent, class, dev_is_class);
+ }
+ 
+-static struct net_device *dsa_dev_to_net_device(struct device *dev)
+-{
+-	struct device *d;
+-
+-	d = dev_find_class(dev, "net");
+-	if (d != NULL) {
+-		struct net_device *nd;
+-
+-		nd = to_net_dev(d);
+-		dev_hold(nd);
+-		put_device(d);
+-
+-		return nd;
+-	}
+-
+-	return NULL;
+-}
+-
+ static int dsa_port_parse(struct dsa_port *dp, const char *name,
+ 			  struct device *dev)
+ {
+ 	if (!strcmp(name, "cpu")) {
+ 		struct net_device *master;
++		struct device *d;
++		int err;
+ 
+-		master = dsa_dev_to_net_device(dev);
+-		if (!master)
++		rtnl_lock();
++		d = dev_find_class(dev, "net");
++		if (!d) {
++			rtnl_unlock();
+ 			return -EPROBE_DEFER;
++		}
+ 
+-		dev_put(master);
++		master = to_net_dev(d);
++		netdev_hold(master, &dp->master_tracker, GFP_KERNEL);
++		put_device(d);
++		rtnl_unlock();
+ 
+-		return dsa_port_parse_cpu(dp, master, NULL);
++		err = dsa_port_parse_cpu(dp, master, NULL);
++		if (err)
++			netdev_put(master, &dp->master_tracker);
++		return err;
+ 	}
+ 
+ 	if (!strcmp(name, "dsa"))
+@@ -1495,6 +1499,9 @@ static void dsa_switch_release_ports(struct dsa_switch *ds)
+ 	struct dsa_vlan *v, *n;
+ 
+ 	dsa_switch_for_each_port_safe(dp, next, ds) {
++		if (dsa_port_is_cpu(dp) && dp->master)
++			netdev_put(dp->master, &dp->master_tracker);
++
+ 		/* These are either entries that upper layers lost track of
+ 		 * (probably due to bugs), or installed through interfaces
+ 		 * where one does not necessarily have to remove them, like
+@@ -1639,8 +1646,10 @@ void dsa_switch_shutdown(struct dsa_switch *ds)
+ 	/* Disconnect from further netdevice notifiers on the master,
+ 	 * since netdev_uses_dsa() will now return false.
+ 	 */
+-	dsa_switch_for_each_cpu_port(dp, ds)
++	dsa_switch_for_each_cpu_port(dp, ds) {
+ 		dp->master->dsa_ptr = NULL;
++		netdev_put(dp->master, &dp->master_tracker);
++	}
+ 
+ 	rtnl_unlock();
+ out:
+diff --git a/net/ipv4/icmp.c b/net/ipv4/icmp.c
+index 784591ed5bb7ce..64a0bc633a3eb4 100644
+--- a/net/ipv4/icmp.c
++++ b/net/ipv4/icmp.c
+@@ -870,10 +870,12 @@ out:
+ 
+ static bool icmp_tag_validation(int proto)
+ {
++	const struct net_protocol *ipprot;
+ 	bool ok;
+ 
+ 	rcu_read_lock();
+-	ok = rcu_dereference(inet_protos[proto])->icmp_strict_tag_validation;
++	ipprot = rcu_dereference(inet_protos[proto]);
++	ok = ipprot ? ipprot->icmp_strict_tag_validation : false;
+ 	rcu_read_unlock();
+ 	return ok;
+ }
+diff --git a/net/ipv4/route.c b/net/ipv4/route.c
+index fcabacec89c73e..55ea367f95b3bd 100644
+--- a/net/ipv4/route.c
++++ b/net/ipv4/route.c
+@@ -1546,9 +1546,9 @@ void rt_add_uncached_list(struct rtable *rt)
+ 
+ void rt_del_uncached_list(struct rtable *rt)
+ {
+-	if (!list_empty(&rt->dst.rt_uncached)) {
+-		struct uncached_list *ul = rt->dst.rt_uncached_list;
++	struct uncached_list *ul = rt->dst.rt_uncached_list;
+ 
++	if (ul) {
+ 		spin_lock_bh(&ul->lock);
+ 		list_del_init(&rt->dst.rt_uncached);
+ 		spin_unlock_bh(&ul->lock);
+diff --git a/net/ipv4/tcp.c b/net/ipv4/tcp.c
+index 2bae34d63c3db7..021e1bdbddcb8c 100644
+--- a/net/ipv4/tcp.c
++++ b/net/ipv4/tcp.c
+@@ -244,6 +244,7 @@
+ #define pr_fmt(fmt) "TCP: " fmt
+ 
+ #include <crypto/hash.h>
++#include <crypto/utils.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/types.h>
+@@ -4556,7 +4557,7 @@ tcp_inbound_md5_hash(const struct sock *sk, const struct sk_buff *skb,
+ 							 hash_expected,
+ 							 NULL, skb);
+ 
+-	if (genhash || memcmp(hash_location, newhash, 16) != 0) {
++	if (genhash || crypto_memneq(hash_location, newhash, 16)) {
+ 		NET_INC_STATS(sock_net(sk), LINUX_MIB_TCPMD5FAILURE);
+ 		if (family == AF_INET) {
+ 			net_info_ratelimited("MD5 Hash failed for (%pI4, %d)->(%pI4, %d)%s L3 index %d\n",
+diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
+index f67967c7577146..bec3bbf57a4f1b 100644
+--- a/net/ipv4/tcp_input.c
++++ b/net/ipv4/tcp_input.c
+@@ -6705,17 +6705,21 @@ int tcp_rcv_state_process(struct sock *sk, struct sk_buff *skb)
+ 		return 0;
+ 
+ 	/* step 5: check the ACK field */
+-	acceptable = tcp_ack(sk, skb, FLAG_SLOWPATH |
+-				      FLAG_UPDATE_TS_RECENT |
+-				      FLAG_NO_CHALLENGE_ACK) > 0;
++	reason = tcp_ack(sk, skb, FLAG_SLOWPATH |
++				  FLAG_UPDATE_TS_RECENT |
++				  FLAG_NO_CHALLENGE_ACK);
+ 
+-	if (!acceptable) {
++	if ((int)reason <= 0) {
+ 		if (sk->sk_state == TCP_SYN_RECV)
+ 			return 1;	/* send one RST */
+-		tcp_send_challenge_ack(sk);
+-		SKB_DR_SET(reason, TCP_OLD_ACK);
+-		goto discard;
++		/* accept old ack during closing */
++		if ((int)reason < 0) {
++			tcp_send_challenge_ack(sk);
++			reason = -reason;
++			goto discard;
++		}
+ 	}
++	SKB_DR_SET(reason, NOT_SPECIFIED);
+ 	switch (sk->sk_state) {
+ 	case TCP_SYN_RECV:
+ 		tp->delivered++; /* SYN-ACK delivery isn't tracked in tcp_ack */
+diff --git a/net/ipv4/tcp_ipv4.c b/net/ipv4/tcp_ipv4.c
+index ab4be34e58bb23..c8d35f1c0ece23 100644
+--- a/net/ipv4/tcp_ipv4.c
++++ b/net/ipv4/tcp_ipv4.c
+@@ -80,6 +80,7 @@
+ #include <linux/btf_ids.h>
+ 
+ #include <crypto/hash.h>
++#include <crypto/utils.h>
+ #include <linux/scatterlist.h>
+ 
+ #include <trace/events/tcp.h>
+@@ -776,7 +777,7 @@ static void tcp_v4_send_reset(const struct sock *sk, struct sk_buff *skb)
+ 
+ 
+ 		genhash = tcp_v4_md5_hash_skb(newhash, key, NULL, skb);
+-		if (genhash || memcmp(hash_location, newhash, 16) != 0)
++		if (genhash || crypto_memneq(hash_location, newhash, 16))
+ 			goto out;
+ 
+ 	}
+diff --git a/net/ipv4/tcp_offload.c b/net/ipv4/tcp_offload.c
+index f1f723579a490c..7b09f6d0818b72 100644
+--- a/net/ipv4/tcp_offload.c
++++ b/net/ipv4/tcp_offload.c
+@@ -31,6 +31,70 @@ static void tcp_gso_tstamp(struct sk_buff *skb, struct sk_buff *gso_skb,
+ 	}
+ }
+ 
++static void __tcpv4_gso_segment_csum(struct sk_buff *seg,
++				     __be32 *oldip, __be32 newip,
++				     __be16 *oldport, __be16 newport)
++{
++	struct tcphdr *th;
++	struct iphdr *iph;
++
++	if (*oldip == newip && *oldport == newport)
++		return;
++
++	th = tcp_hdr(seg);
++	iph = ip_hdr(seg);
++
++	inet_proto_csum_replace4(&th->check, seg, *oldip, newip, true);
++	inet_proto_csum_replace2(&th->check, seg, *oldport, newport, false);
++	*oldport = newport;
++
++	csum_replace4(&iph->check, *oldip, newip);
++	*oldip = newip;
++}
++
++static struct sk_buff *__tcpv4_gso_segment_list_csum(struct sk_buff *segs)
++{
++	const struct tcphdr *th;
++	const struct iphdr *iph;
++	struct sk_buff *seg;
++	struct tcphdr *th2;
++	struct iphdr *iph2;
++
++	seg = segs;
++	th = tcp_hdr(seg);
++	iph = ip_hdr(seg);
++	th2 = tcp_hdr(seg->next);
++	iph2 = ip_hdr(seg->next);
++
++	if (!(*(const u32 *)&th->source ^ *(const u32 *)&th2->source) &&
++	    iph->daddr == iph2->daddr && iph->saddr == iph2->saddr)
++		return segs;
++
++	while ((seg = seg->next)) {
++		th2 = tcp_hdr(seg);
++		iph2 = ip_hdr(seg);
++
++		__tcpv4_gso_segment_csum(seg,
++					 &iph2->saddr, iph->saddr,
++					 &th2->source, th->source);
++		__tcpv4_gso_segment_csum(seg,
++					 &iph2->daddr, iph->daddr,
++					 &th2->dest, th->dest);
++	}
++
++	return segs;
++}
++
++static struct sk_buff *__tcp4_gso_segment_list(struct sk_buff *skb,
++					      netdev_features_t features)
++{
++	skb = skb_segment_list(skb, features, skb_mac_header_len(skb));
++	if (IS_ERR(skb))
++		return skb;
++
++	return __tcpv4_gso_segment_list_csum(skb);
++}
++
+ static struct sk_buff *tcp4_gso_segment(struct sk_buff *skb,
+ 					netdev_features_t features)
+ {
+@@ -40,6 +104,16 @@ static struct sk_buff *tcp4_gso_segment(struct sk_buff *skb,
+ 	if (!pskb_may_pull(skb, sizeof(struct tcphdr)))
+ 		return ERR_PTR(-EINVAL);
+ 
++	if (skb_shinfo(skb)->gso_type & SKB_GSO_FRAGLIST) {
++		struct tcphdr *th = tcp_hdr(skb);
++
++		if ((skb_pagelen(skb) - th->doff * 4 == skb_shinfo(skb)->gso_size) &&
++		    !(skb_shinfo(skb)->gso_type & SKB_GSO_DODGY))
++			return __tcp4_gso_segment_list(skb, features);
++
++		skb->ip_summed = CHECKSUM_NONE;
++	}
++
+ 	if (unlikely(skb->ip_summed != CHECKSUM_PARTIAL)) {
+ 		const struct iphdr *iph = ip_hdr(skb);
+ 		struct tcphdr *th = tcp_hdr(skb);
+diff --git a/net/ipv4/udp_offload.c b/net/ipv4/udp_offload.c
+index 9be9df2caf6540..cd860d8d497b4f 100644
+--- a/net/ipv4/udp_offload.c
++++ b/net/ipv4/udp_offload.c
+@@ -352,7 +352,8 @@ struct sk_buff *__udp_gso_segment(struct sk_buff *gso_skb,
+ 
+ 	if (skb_shinfo(gso_skb)->gso_type & SKB_GSO_FRAGLIST) {
+ 		 /* Detect modified geometry and pass those to skb_segment. */
+-		if (skb_pagelen(gso_skb) - sizeof(*uh) == skb_shinfo(gso_skb)->gso_size)
++		if ((skb_pagelen(gso_skb) - sizeof(*uh) == skb_shinfo(gso_skb)->gso_size) &&
++		    !(skb_shinfo(gso_skb)->gso_type & SKB_GSO_DODGY))
+ 			return __udp_gso_segment_list(gso_skb, features, is_ipv6);
+ 
+ 		ret = __skb_linearize(gso_skb);
+diff --git a/net/ipv6/ip6_output.c b/net/ipv6/ip6_output.c
+index c86d5dca29df01..74145d05ddd220 100644
+--- a/net/ipv6/ip6_output.c
++++ b/net/ipv6/ip6_output.c
+@@ -261,35 +261,36 @@ bool ip6_autoflowlabel(struct net *net, const struct ipv6_pinfo *np)
+ int ip6_xmit(const struct sock *sk, struct sk_buff *skb, struct flowi6 *fl6,
+ 	     __u32 mark, struct ipv6_txoptions *opt, int tclass, u32 priority)
+ {
+-	struct net *net = sock_net(sk);
+ 	const struct ipv6_pinfo *np = inet6_sk(sk);
+ 	struct in6_addr *first_hop = &fl6->daddr;
+ 	struct dst_entry *dst = skb_dst(skb);
+-	struct net_device *dev = dst->dev;
+ 	struct inet6_dev *idev = ip6_dst_idev(dst);
+ 	struct hop_jumbo_hdr *hop_jumbo;
+ 	int hoplen = sizeof(*hop_jumbo);
++	struct net *net = sock_net(sk);
+ 	unsigned int head_room;
++	struct net_device *dev;
+ 	struct ipv6hdr *hdr;
+ 	u8  proto = fl6->flowi6_proto;
+ 	int seg_len = skb->len;
+-	int hlimit = -1;
++	int ret, hlimit = -1;
+ 	u32 mtu;
+ 
++	rcu_read_lock();
++
++	dev = dst_dev_rcu(dst);
+ 	head_room = sizeof(struct ipv6hdr) + hoplen + LL_RESERVED_SPACE(dev);
+ 	if (opt)
+ 		head_room += opt->opt_nflen + opt->opt_flen;
+ 
+ 	if (unlikely(head_room > skb_headroom(skb))) {
+-		/* Make sure idev stays alive */
+-		rcu_read_lock();
++		/* idev stays alive while we hold rcu_read_lock(). */
+ 		skb = skb_expand_head(skb, head_room);
+ 		if (!skb) {
+ 			IP6_INC_STATS(net, idev, IPSTATS_MIB_OUTDISCARDS);
+-			rcu_read_unlock();
+-			return -ENOBUFS;
++			ret = -ENOBUFS;
++			goto unlock;
+ 		}
+-		rcu_read_unlock();
+ 	}
+ 
+ 	if (opt) {
+@@ -351,17 +352,21 @@ int ip6_xmit(const struct sock *sk, struct sk_buff *skb, struct flowi6 *fl6,
+ 		 * skb to its handler for processing
+ 		 */
+ 		skb = l3mdev_ip6_out((struct sock *)sk, skb);
+-		if (unlikely(!skb))
+-			return 0;
++		if (unlikely(!skb)) {
++			ret = 0;
++			goto unlock;
++		}
+ 
+ 		/* hooks should never assume socket lock is held.
+ 		 * we promote our socket to non const
+ 		 */
+-		return NF_HOOK(NFPROTO_IPV6, NF_INET_LOCAL_OUT,
+-			       net, (struct sock *)sk, skb, NULL, dev,
+-			       dst_output);
++		ret = NF_HOOK(NFPROTO_IPV6, NF_INET_LOCAL_OUT,
++			      net, (struct sock *)sk, skb, NULL, dev,
++			      dst_output);
++		goto unlock;
+ 	}
+ 
++	ret = -EMSGSIZE;
+ 	skb->dev = dev;
+ 	/* ipv6_local_error() does not require socket lock,
+ 	 * we promote our socket to non const
+@@ -370,7 +375,9 @@ int ip6_xmit(const struct sock *sk, struct sk_buff *skb, struct flowi6 *fl6,
+ 
+ 	IP6_INC_STATS(net, idev, IPSTATS_MIB_FRAGFAILS);
+ 	kfree_skb(skb);
+-	return -EMSGSIZE;
++unlock:
++	rcu_read_unlock();
++	return ret;
+ }
+ EXPORT_SYMBOL(ip6_xmit);
+ 
+diff --git a/net/ipv6/route.c b/net/ipv6/route.c
+index ad452a04d7299e..5a6cc828855dc2 100644
+--- a/net/ipv6/route.c
++++ b/net/ipv6/route.c
+@@ -149,9 +149,9 @@ void rt6_uncached_list_add(struct rt6_info *rt)
+ 
+ void rt6_uncached_list_del(struct rt6_info *rt)
+ {
+-	if (!list_empty(&rt->dst.rt_uncached)) {
+-		struct uncached_list *ul = rt->dst.rt_uncached_list;
++	struct uncached_list *ul = rt->dst.rt_uncached_list;
+ 
++	if (ul) {
+ 		spin_lock_bh(&ul->lock);
+ 		list_del_init(&rt->dst.rt_uncached);
+ 		spin_unlock_bh(&ul->lock);
+@@ -1065,7 +1065,8 @@ static struct net_device *ip6_rt_get_dev_rcu(const struct fib6_result *res)
+ 		 */
+ 		if (netif_is_l3_slave(dev) &&
+ 		    !rt6_need_strict(&res->f6i->fib6_dst.addr))
+-			dev = l3mdev_master_dev_rcu(dev);
++			dev = l3mdev_master_dev_rcu(dev) ? :
++			      dev_net(dev)->loopback_dev;
+ 		else if (!netif_is_l3_master(dev))
+ 			dev = dev_net(dev)->loopback_dev;
+ 		/* last case is netif_is_l3_master(dev) is true in which
+@@ -3566,7 +3567,6 @@ int fib6_nh_init(struct net *net, struct fib6_nh *fib6_nh,
+ 	netdevice_tracker *dev_tracker = &fib6_nh->fib_nh_dev_tracker;
+ 	struct net_device *dev = NULL;
+ 	struct inet6_dev *idev = NULL;
+-	int addr_type;
+ 	int err;
+ 
+ 	fib6_nh->fib_nh_family = AF_INET6;
+@@ -3608,11 +3608,10 @@ int fib6_nh_init(struct net *net, struct fib6_nh *fib6_nh,
+ 
+ 	fib6_nh->fib_nh_weight = 1;
+ 
+-	/* We cannot add true routes via loopback here,
+-	 * they would result in kernel looping; promote them to reject routes
++	/* Reset the nexthop device to the loopback device in case of reject
++	 * routes.
+ 	 */
+-	addr_type = ipv6_addr_type(&cfg->fc_dst);
+-	if (fib6_is_reject(cfg->fc_flags, dev, addr_type)) {
++	if (cfg->fc_flags & RTF_REJECT) {
+ 		/* hold loopback dev/idev if we haven't done so. */
+ 		if (dev != net->loopback_dev) {
+ 			if (dev) {
+diff --git a/net/ipv6/tcp_ipv6.c b/net/ipv6/tcp_ipv6.c
+index 624ab1424eba7d..2c579868fe81f9 100644
+--- a/net/ipv6/tcp_ipv6.c
++++ b/net/ipv6/tcp_ipv6.c
+@@ -64,6 +64,7 @@
+ #include <linux/seq_file.h>
+ 
+ #include <crypto/hash.h>
++#include <crypto/utils.h>
+ #include <linux/scatterlist.h>
+ 
+ #include <trace/events/tcp.h>
+@@ -1035,7 +1036,7 @@ static void tcp_v6_send_reset(const struct sock *sk, struct sk_buff *skb)
+ 			goto out;
+ 
+ 		genhash = tcp_v6_md5_hash_skb(newhash, key, NULL, skb);
+-		if (genhash || memcmp(hash_location, newhash, 16) != 0)
++		if (genhash || crypto_memneq(hash_location, newhash, 16))
+ 			goto out;
+ 	}
+ #endif
+diff --git a/net/ipv6/tcpv6_offload.c b/net/ipv6/tcpv6_offload.c
+index bf0c957e4b5eaa..10025c9e07d355 100644
+--- a/net/ipv6/tcpv6_offload.c
++++ b/net/ipv6/tcpv6_offload.c
+@@ -40,6 +40,61 @@ INDIRECT_CALLABLE_SCOPE int tcp6_gro_complete(struct sk_buff *skb, int thoff)
+ 	return 0;
+ }
+ 
++static void __tcpv6_gso_segment_csum(struct sk_buff *seg,
++				     __be16 *oldport, __be16 newport)
++{
++	struct tcphdr *th;
++
++	if (*oldport == newport)
++		return;
++
++	th = tcp_hdr(seg);
++	inet_proto_csum_replace2(&th->check, seg, *oldport, newport, false);
++	*oldport = newport;
++}
++
++static struct sk_buff *__tcpv6_gso_segment_list_csum(struct sk_buff *segs)
++{
++	const struct tcphdr *th;
++	const struct ipv6hdr *iph;
++	struct sk_buff *seg;
++	struct tcphdr *th2;
++	struct ipv6hdr *iph2;
++
++	seg = segs;
++	th = tcp_hdr(seg);
++	iph = ipv6_hdr(seg);
++	th2 = tcp_hdr(seg->next);
++	iph2 = ipv6_hdr(seg->next);
++
++	if (!(*(const u32 *)&th->source ^ *(const u32 *)&th2->source) &&
++	    ipv6_addr_equal(&iph->saddr, &iph2->saddr) &&
++	    ipv6_addr_equal(&iph->daddr, &iph2->daddr))
++		return segs;
++
++	while ((seg = seg->next)) {
++		th2 = tcp_hdr(seg);
++		iph2 = ipv6_hdr(seg);
++
++		iph2->saddr = iph->saddr;
++		iph2->daddr = iph->daddr;
++		__tcpv6_gso_segment_csum(seg, &th2->source, th->source);
++		__tcpv6_gso_segment_csum(seg, &th2->dest, th->dest);
++	}
++
++	return segs;
++}
++
++static struct sk_buff *__tcp6_gso_segment_list(struct sk_buff *skb,
++					      netdev_features_t features)
++{
++	skb = skb_segment_list(skb, features, skb_mac_header_len(skb));
++	if (IS_ERR(skb))
++		return skb;
++
++	return __tcpv6_gso_segment_list_csum(skb);
++}
++
+ static struct sk_buff *tcp6_gso_segment(struct sk_buff *skb,
+ 					netdev_features_t features)
+ {
+@@ -51,6 +106,16 @@ static struct sk_buff *tcp6_gso_segment(struct sk_buff *skb,
+ 	if (!pskb_may_pull(skb, sizeof(*th)))
+ 		return ERR_PTR(-EINVAL);
+ 
++	if (skb_shinfo(skb)->gso_type & SKB_GSO_FRAGLIST) {
++		struct tcphdr *th = tcp_hdr(skb);
++
++		if ((skb_pagelen(skb) - th->doff * 4 == skb_shinfo(skb)->gso_size) &&
++		    !(skb_shinfo(skb)->gso_type & SKB_GSO_DODGY))
++			return __tcp6_gso_segment_list(skb, features);
++
++		skb->ip_summed = CHECKSUM_NONE;
++	}
++
+ 	if (unlikely(skb->ip_summed != CHECKSUM_PARTIAL)) {
+ 		const struct ipv6hdr *ipv6h = ipv6_hdr(skb);
+ 		struct tcphdr *th = tcp_hdr(skb);
+diff --git a/net/l2tp/l2tp_ppp.c b/net/l2tp/l2tp_ppp.c
+index 6146e4e67bbb54..34d8582c0c072e 100644
+--- a/net/l2tp/l2tp_ppp.c
++++ b/net/l2tp/l2tp_ppp.c
+@@ -130,22 +130,12 @@ static const struct ppp_channel_ops pppol2tp_chan_ops = {
+ 
+ static const struct proto_ops pppol2tp_ops;
+ 
+-/* Retrieves the pppol2tp socket associated to a session.
+- * A reference is held on the returned socket, so this function must be paired
+- * with sock_put().
+- */
++/* Retrieves the pppol2tp socket associated to a session. */
+ static struct sock *pppol2tp_session_get_sock(struct l2tp_session *session)
+ {
+ 	struct pppol2tp_session *ps = l2tp_session_priv(session);
+-	struct sock *sk;
+ 
+-	rcu_read_lock();
+-	sk = rcu_dereference(ps->sk);
+-	if (sk)
+-		sock_hold(sk);
+-	rcu_read_unlock();
+-
+-	return sk;
++	return rcu_dereference(ps->sk);
+ }
+ 
+ /* Helpers to obtain tunnel/session contexts from sockets.
+@@ -211,14 +201,13 @@ end:
+ 
+ static void pppol2tp_recv(struct l2tp_session *session, struct sk_buff *skb, int data_len)
+ {
+-	struct pppol2tp_session *ps = l2tp_session_priv(session);
+-	struct sock *sk = NULL;
++	struct sock *sk;
+ 
+ 	/* If the socket is bound, send it in to PPP's input queue. Otherwise
+ 	 * queue it on the session socket.
+ 	 */
+ 	rcu_read_lock();
+-	sk = rcu_dereference(ps->sk);
++	sk = pppol2tp_session_get_sock(session);
+ 	if (!sk)
+ 		goto no_sock;
+ 
+@@ -528,13 +517,14 @@ static void pppol2tp_show(struct seq_file *m, void *arg)
+ 	struct l2tp_session *session = arg;
+ 	struct sock *sk;
+ 
++	rcu_read_lock();
+ 	sk = pppol2tp_session_get_sock(session);
+ 	if (sk) {
+ 		struct pppox_sock *po = pppox_sk(sk);
+ 
+ 		seq_printf(m, "   interface %s\n", ppp_dev_name(&po->chan));
+-		sock_put(sk);
+ 	}
++	rcu_read_unlock();
+ }
+ 
+ static void pppol2tp_session_init(struct l2tp_session *session)
+@@ -1540,6 +1530,7 @@ static void pppol2tp_seq_session_show(struct seq_file *m, void *v)
+ 		port = ntohs(inet->inet_sport);
+ 	}
+ 
++	rcu_read_lock();
+ 	sk = pppol2tp_session_get_sock(session);
+ 	if (sk) {
+ 		state = sk->sk_state;
+@@ -1575,8 +1566,8 @@ static void pppol2tp_seq_session_show(struct seq_file *m, void *v)
+ 		struct pppox_sock *po = pppox_sk(sk);
+ 
+ 		seq_printf(m, "   interface %s\n", ppp_dev_name(&po->chan));
+-		sock_put(sk);
+ 	}
++	rcu_read_unlock();
+ }
+ 
+ static int pppol2tp_seq_show(struct seq_file *m, void *v)
+diff --git a/net/mac80211/debugfs.c b/net/mac80211/debugfs.c
+index 207f772bd8ce2b..bd7c5dfeaa8c5a 100644
+--- a/net/mac80211/debugfs.c
++++ b/net/mac80211/debugfs.c
+@@ -326,7 +326,6 @@ static ssize_t aql_enable_read(struct file *file, char __user *user_buf,
+ static ssize_t aql_enable_write(struct file *file, const char __user *user_buf,
+ 				size_t count, loff_t *ppos)
+ {
+-	bool aql_disabled = static_key_false(&aql_disable.key);
+ 	char buf[3];
+ 	size_t len;
+ 
+@@ -341,15 +340,12 @@ static ssize_t aql_enable_write(struct file *file, const char __user *user_buf,
+ 	if (len > 0 && buf[len - 1] == '\n')
+ 		buf[len - 1] = 0;
+ 
+-	if (buf[0] == '0' && buf[1] == '\0') {
+-		if (!aql_disabled)
+-			static_branch_inc(&aql_disable);
+-	} else if (buf[0] == '1' && buf[1] == '\0') {
+-		if (aql_disabled)
+-			static_branch_dec(&aql_disable);
+-	} else {
++	if (buf[0] == '0' && buf[1] == '\0')
++		static_branch_enable(&aql_disable);
++	else if (buf[0] == '1' && buf[1] == '\0')
++		static_branch_disable(&aql_disable);
++	else
+ 		return -EINVAL;
+-	}
+ 
+ 	return count;
+ }
+diff --git a/net/mac80211/link.c b/net/mac80211/link.c
+index af4d2b2e9a26f8..2b44f1fe2031a9 100644
+--- a/net/mac80211/link.c
++++ b/net/mac80211/link.c
+@@ -201,6 +201,7 @@ static int ieee80211_vif_update_links(struct ieee80211_sub_if_data *sdata,
+ 	struct ieee80211_bss_conf *old[IEEE80211_MLD_MAX_NUM_LINKS];
+ 	struct ieee80211_link_data *old_data[IEEE80211_MLD_MAX_NUM_LINKS];
+ 	bool use_deflink = old_links == 0; /* set for error case */
++	bool non_sta = sdata->vif.type != NL80211_IFTYPE_STATION;
+ 
+ 	sdata_assert_lock(sdata);
+ 
+@@ -254,6 +255,7 @@ static int ieee80211_vif_update_links(struct ieee80211_sub_if_data *sdata,
+ 		link = links[link_id];
+ 		ieee80211_link_init(sdata, link_id, &link->data, &link->conf);
+ 		ieee80211_link_setup(&link->data);
++		ieee80211_set_wmm_default(&link->data, true, non_sta);
+ 	}
+ 
+ 	if (new_links == 0)
+diff --git a/net/mac80211/mesh.c b/net/mac80211/mesh.c
+index a5e7edd2f2d137..0899443e83cdab 100644
+--- a/net/mac80211/mesh.c
++++ b/net/mac80211/mesh.c
+@@ -76,6 +76,9 @@ bool mesh_matches_local(struct ieee80211_sub_if_data *sdata,
+ 	 *   - MDA enabled
+ 	 * - Power management control on fc
+ 	 */
++	if (!ie->mesh_config)
++		return false;
++
+ 	if (!(ifmsh->mesh_id_len == ie->mesh_id_len &&
+ 	     memcmp(ifmsh->mesh_id, ie->mesh_id, ie->mesh_id_len) == 0 &&
+ 	     (ifmsh->mesh_pp_id == ie->mesh_config->meshconf_psel) &&
+@@ -1640,6 +1643,9 @@ static void mesh_rx_csa_frame(struct ieee80211_sub_if_data *sdata,
+ 	if (!mesh_matches_local(sdata, elems))
+ 		goto free;
+ 
++	if (!elems->mesh_chansw_params_ie)
++		goto free;
++
+ 	ifmsh->chsw_ttl = elems->mesh_chansw_params_ie->mesh_ttl;
+ 	if (!--ifmsh->chsw_ttl)
+ 		fwd_csa = false;
+diff --git a/net/mac80211/mlme.c b/net/mac80211/mlme.c
+index 78b9206f99f469..77da0bd5891efa 100644
+--- a/net/mac80211/mlme.c
++++ b/net/mac80211/mlme.c
+@@ -5854,6 +5854,9 @@ static void ieee80211_ml_reconfiguration(struct ieee80211_sub_if_data *sdata,
+ 		control = le16_to_cpu(prof->control);
+ 		link_id = control & IEEE80211_MLE_STA_RECONF_CONTROL_LINK_ID;
+ 
++		if (link_id >= IEEE80211_MLD_MAX_NUM_LINKS)
++			continue;
++
+ 		removed_links |= BIT(link_id);
+ 
+ 		/* the MAC address should not be included, but handle it */
+diff --git a/net/mctp/route.c b/net/mctp/route.c
+index 009ba5edbd5254..59fbc54d8e66c5 100644
+--- a/net/mctp/route.c
++++ b/net/mctp/route.c
+@@ -267,6 +267,7 @@ static void mctp_flow_prepare_output(struct sk_buff *skb, struct mctp_dev *dev)
+ {
+ 	struct mctp_sk_key *key;
+ 	struct mctp_flow *flow;
++	unsigned long flags;
+ 
+ 	flow = skb_ext_find(skb, SKB_EXT_MCTP);
+ 	if (!flow)
+@@ -274,12 +275,14 @@ static void mctp_flow_prepare_output(struct sk_buff *skb, struct mctp_dev *dev)
+ 
+ 	key = flow->key;
+ 
+-	if (key->dev) {
++	spin_lock_irqsave(&key->lock, flags);
++
++	if (!key->dev)
++		mctp_dev_set_key(dev, key);
++	else
+ 		WARN_ON(key->dev != dev);
+-		return;
+-	}
+ 
+-	mctp_dev_set_key(dev, key);
++	spin_unlock_irqrestore(&key->lock, flags);
+ }
+ #else
+ static void mctp_skb_set_flow(struct sk_buff *skb, struct mctp_sk_key *key) {}
+diff --git a/net/mpls/af_mpls.c b/net/mpls/af_mpls.c
+index 5a4b175b78c8c9..0561a530ecf0d9 100644
+--- a/net/mpls/af_mpls.c
++++ b/net/mpls/af_mpls.c
+@@ -2775,6 +2775,7 @@ out_unregister_rtnl:
+ out_unregister_rtnl_af:
+ 	rtnl_af_unregister(&mpls_af_ops);
+ 	dev_remove_pack(&mpls_packet_type);
++	unregister_netdevice_notifier(&mpls_dev_notifier);
+ out_unregister_pernet:
+ 	unregister_pernet_subsys(&mpls_net_ops);
+ 	goto out;
+diff --git a/net/mptcp/pm.c b/net/mptcp/pm.c
+index ab7bdb6531816d..8778a7211e4c54 100644
+--- a/net/mptcp/pm.c
++++ b/net/mptcp/pm.c
+@@ -57,7 +57,7 @@ int mptcp_pm_remove_addr(struct mptcp_sock *msk, const struct mptcp_rm_list *rm_
+ 	msk->pm.rm_list_tx = *rm_list;
+ 	rm_addr |= BIT(MPTCP_RM_ADDR_SIGNAL);
+ 	WRITE_ONCE(msk->pm.addr_signal, rm_addr);
+-	mptcp_pm_nl_addr_send_ack(msk);
++	mptcp_pm_nl_addr_send_ack_avoid_list(msk, rm_list);
+ 	return 0;
+ }
+ 
+diff --git a/net/mptcp/pm_netlink.c b/net/mptcp/pm_netlink.c
+index 4b805d7f5769f7..91aaf4bd43ea26 100644
+--- a/net/mptcp/pm_netlink.c
++++ b/net/mptcp/pm_netlink.c
+@@ -662,6 +662,15 @@ subflow:
+ 	}
+ 
+ exit:
++	/* If an endpoint has both the signal and subflow flags, but it is not
++	 * possible to create subflows -- the 'while' loop body above never
++	 * executed --  then still mark the endp as used, which is somehow the
++	 * case. This avoids issues later when removing the endpoint and calling
++	 * __mark_subflow_endp_available(), which expects the increment here.
++	 */
++	if (signal_and_subflow && local.addr.id != msk->mpc_endpoint_id)
++		msk->pm.local_addr_used++;
++
+ 	mptcp_pm_nl_check_work_pending(msk);
+ }
+ 
+@@ -849,9 +858,23 @@ bool mptcp_pm_nl_is_init_remote_addr(struct mptcp_sock *msk,
+ 	return mptcp_addresses_equal(&mpc_remote, remote, remote->port);
+ }
+ 
+-void mptcp_pm_nl_addr_send_ack(struct mptcp_sock *msk)
++static bool subflow_in_rm_list(const struct mptcp_subflow_context *subflow,
++			       const struct mptcp_rm_list *rm_list)
+ {
+-	struct mptcp_subflow_context *subflow;
++	u8 i, id = subflow_get_local_id(subflow);
++
++	for (i = 0; i < rm_list->nr; i++) {
++		if (rm_list->ids[i] == id)
++			return true;
++	}
++
++	return false;
++}
++
++void mptcp_pm_nl_addr_send_ack_avoid_list(struct mptcp_sock *msk,
++					  const struct mptcp_rm_list *rm_list)
++{
++	struct mptcp_subflow_context *subflow, *same_id = NULL;
+ 
+ 	msk_owned_by_me(msk);
+ 	lockdep_assert_held(&msk->pm.lock);
+@@ -861,11 +884,30 @@ void mptcp_pm_nl_addr_send_ack(struct mptcp_sock *msk)
+ 		return;
+ 
+ 	mptcp_for_each_subflow(msk, subflow) {
+-		if (__mptcp_subflow_active(subflow)) {
+-			mptcp_pm_send_ack(msk, subflow, false, false);
+-			break;
++		if (!__mptcp_subflow_active(subflow))
++			continue;
++
++		if (unlikely(rm_list &&
++			     subflow_in_rm_list(subflow, rm_list))) {
++			if (!same_id)
++				same_id = subflow;
++		} else {
++			goto send_ack;
+ 		}
+ 	}
++
++	if (same_id)
++		subflow = same_id;
++	else
++		return;
++
++send_ack:
++	mptcp_pm_send_ack(msk, subflow, false, false);
++}
++
++void mptcp_pm_nl_addr_send_ack(struct mptcp_sock *msk)
++{
++	mptcp_pm_nl_addr_send_ack_avoid_list(msk, NULL);
+ }
+ 
+ int mptcp_pm_nl_mp_prio_send_ack(struct mptcp_sock *msk,
+@@ -1605,10 +1647,8 @@ static bool mptcp_pm_remove_anno_addr(struct mptcp_sock *msk,
+ 	ret = remove_anno_list_by_saddr(msk, addr);
+ 	if (ret || force) {
+ 		spin_lock_bh(&msk->pm.lock);
+-		if (ret) {
+-			__set_bit(addr->id, msk->pm.id_avail_bitmap);
++		if (ret)
+ 			msk->pm.add_addr_signaled--;
+-		}
+ 		mptcp_pm_remove_addr(msk, &list);
+ 		spin_unlock_bh(&msk->pm.lock);
+ 	}
+@@ -1646,17 +1686,15 @@ static int mptcp_nl_remove_subflow_and_signal_addr(struct net *net,
+ 					  !(entry->flags & MPTCP_PM_ADDR_FLAG_IMPLICIT));
+ 
+ 		list.ids[0] = mptcp_endp_get_local_id(msk, addr);
+-		if (remove_subflow) {
+-			spin_lock_bh(&msk->pm.lock);
+-			mptcp_pm_nl_rm_subflow_received(msk, &list);
+-			spin_unlock_bh(&msk->pm.lock);
+-		}
+ 
+-		if (entry->flags & MPTCP_PM_ADDR_FLAG_SUBFLOW) {
+-			spin_lock_bh(&msk->pm.lock);
++		spin_lock_bh(&msk->pm.lock);
++		if (remove_subflow)
++			mptcp_pm_nl_rm_subflow_received(msk, &list);
++		if (entry->flags & MPTCP_PM_ADDR_FLAG_SUBFLOW)
+ 			__mark_subflow_endp_available(msk, list.ids[0]);
+-			spin_unlock_bh(&msk->pm.lock);
+-		}
++		else /* mark endp ID as available, e.g. Signal or MPC endp */
++			__set_bit(addr->id, msk->pm.id_avail_bitmap);
++		spin_unlock_bh(&msk->pm.lock);
+ 
+ 		if (msk->mpc_endpoint_id == entry->addr.id)
+ 			msk->mpc_endpoint_id = 0;
+diff --git a/net/mptcp/protocol.h b/net/mptcp/protocol.h
+index 58805fbf1f961c..93be4c0432d1c1 100644
+--- a/net/mptcp/protocol.h
++++ b/net/mptcp/protocol.h
+@@ -932,6 +932,8 @@ void mptcp_pm_add_addr_send_ack(struct mptcp_sock *msk);
+ bool mptcp_pm_nl_is_init_remote_addr(struct mptcp_sock *msk,
+ 				     const struct mptcp_addr_info *remote);
+ void mptcp_pm_nl_addr_send_ack(struct mptcp_sock *msk);
++void mptcp_pm_nl_addr_send_ack_avoid_list(struct mptcp_sock *msk,
++					  const struct mptcp_rm_list *rm_list);
+ void mptcp_pm_rm_addr_received(struct mptcp_sock *msk,
+ 			       const struct mptcp_rm_list *rm_list);
+ void mptcp_pm_mp_prio_received(struct sock *sk, u8 bkup);
+diff --git a/net/ncsi/ncsi-aen.c b/net/ncsi/ncsi-aen.c
+index 62fb1031763d14..040a31557201bc 100644
+--- a/net/ncsi/ncsi-aen.c
++++ b/net/ncsi/ncsi-aen.c
+@@ -224,7 +224,8 @@ int ncsi_aen_handler(struct ncsi_dev_priv *ndp, struct sk_buff *skb)
+ 	if (!nah) {
+ 		netdev_warn(ndp->ndev.dev, "Invalid AEN (0x%x) received\n",
+ 			    h->type);
+-		return -ENOENT;
++		ret = -ENOENT;
++		goto out;
+ 	}
+ 
+ 	ret = ncsi_validate_aen_pkt(h, nah->payload);
+diff --git a/net/ncsi/ncsi-rsp.c b/net/ncsi/ncsi-rsp.c
+index d5ed80731e8928..0be1059371de42 100644
+--- a/net/ncsi/ncsi-rsp.c
++++ b/net/ncsi/ncsi-rsp.c
+@@ -1176,8 +1176,10 @@ int ncsi_rcv_rsp(struct sk_buff *skb, struct net_device *dev,
+ 	/* Find the NCSI device */
+ 	nd = ncsi_find_dev(orig_dev);
+ 	ndp = nd ? TO_NCSI_DEV_PRIV(nd) : NULL;
+-	if (!ndp)
+-		return -ENODEV;
++	if (!ndp) {
++		ret = -ENODEV;
++		goto err_free_skb;
++	}
+ 
+ 	/* Check if it is AEN packet */
+ 	hdr = (struct ncsi_pkt_hdr *)skb_network_header(skb);
+@@ -1199,7 +1201,8 @@ int ncsi_rcv_rsp(struct sk_buff *skb, struct net_device *dev,
+ 	if (!nrh) {
+ 		netdev_err(nd->dev, "Received unrecognized packet (0x%x)\n",
+ 			   hdr->type);
+-		return -ENOENT;
++		ret = -ENOENT;
++		goto err_free_skb;
+ 	}
+ 
+ 	/* Associate with the request */
+@@ -1207,7 +1210,8 @@ int ncsi_rcv_rsp(struct sk_buff *skb, struct net_device *dev,
+ 	nr = &ndp->requests[hdr->id];
+ 	if (!nr->used) {
+ 		spin_unlock_irqrestore(&ndp->lock, flags);
+-		return -ENODEV;
++		ret = -ENODEV;
++		goto err_free_skb;
+ 	}
+ 
+ 	nr->rsp = skb;
+@@ -1261,4 +1265,8 @@ out_netlink:
+ out:
+ 	ncsi_free_request(nr);
+ 	return ret;
++
++err_free_skb:
++	kfree_skb(skb);
++	return ret;
+ }
+diff --git a/net/netfilter/nf_bpf_link.c b/net/netfilter/nf_bpf_link.c
+index 658e401b7937e4..c65502aa125575 100644
+--- a/net/netfilter/nf_bpf_link.c
++++ b/net/netfilter/nf_bpf_link.c
+@@ -170,7 +170,7 @@ static int bpf_nf_link_update(struct bpf_link *link, struct bpf_prog *new_prog,
+ 
+ static const struct bpf_link_ops bpf_nf_link_lops = {
+ 	.release = bpf_nf_link_release,
+-	.dealloc = bpf_nf_link_dealloc,
++	.dealloc_deferred = bpf_nf_link_dealloc,
+ 	.detach = bpf_nf_link_detach,
+ 	.show_fdinfo = bpf_nf_link_show_info,
+ 	.fill_link_info = bpf_nf_link_fill_link_info,
+diff --git a/net/netfilter/nf_conntrack_h323_asn1.c b/net/netfilter/nf_conntrack_h323_asn1.c
+index 62aa22a0787695..7b1497ed97d269 100644
+--- a/net/netfilter/nf_conntrack_h323_asn1.c
++++ b/net/netfilter/nf_conntrack_h323_asn1.c
+@@ -331,6 +331,8 @@ static int decode_int(struct bitstr *bs, const struct field_t *f,
+ 		if (nf_h323_error_boundary(bs, 0, 2))
+ 			return H323_ERROR_BOUND;
+ 		len = get_bits(bs, 2) + 1;
++		if (nf_h323_error_boundary(bs, len, 0))
++			return H323_ERROR_BOUND;
+ 		BYTE_ALIGN(bs);
+ 		if (base && (f->attr & DECODE)) {	/* timeToLive */
+ 			unsigned int v = get_uint(bs, len) + f->lb;
+@@ -922,6 +924,8 @@ int DecodeQ931(unsigned char *buf, size_t sz, Q931 *q931)
+ 				break;
+ 			p++;
+ 			len--;
++			if (len <= 0)
++				break;
+ 			return DecodeH323_UserInformation(buf, p, len,
+ 							  &q931->UUIE);
+ 		}
+diff --git a/net/netfilter/nf_conntrack_netlink.c b/net/netfilter/nf_conntrack_netlink.c
+index 928bd2013289af..b4761a060e7a08 100644
+--- a/net/netfilter/nf_conntrack_netlink.c
++++ b/net/netfilter/nf_conntrack_netlink.c
+@@ -3140,23 +3140,27 @@ errout:
+ 	return 0;
+ }
+ #endif
+-static int ctnetlink_exp_done(struct netlink_callback *cb)
++
++static unsigned long ctnetlink_exp_id(const struct nf_conntrack_expect *exp)
+ {
+-	if (cb->args[1])
+-		nf_ct_expect_put((struct nf_conntrack_expect *)cb->args[1]);
+-	return 0;
++	unsigned long id = (unsigned long)exp;
++
++	id += nf_ct_get_id(exp->master);
++	id += exp->class;
++
++	return id ? id : 1;
+ }
+ 
+ static int
+ ctnetlink_exp_dump_table(struct sk_buff *skb, struct netlink_callback *cb)
+ {
+ 	struct net *net = sock_net(skb->sk);
+-	struct nf_conntrack_expect *exp, *last;
+ 	struct nfgenmsg *nfmsg = nlmsg_data(cb->nlh);
+ 	u_int8_t l3proto = nfmsg->nfgen_family;
++	unsigned long last_id = cb->args[1];
++	struct nf_conntrack_expect *exp;
+ 
+ 	rcu_read_lock();
+-	last = (struct nf_conntrack_expect *)cb->args[1];
+ 	for (; cb->args[0] < nf_ct_expect_hsize; cb->args[0]++) {
+ restart:
+ 		hlist_for_each_entry_rcu(exp, &nf_ct_expect_hash[cb->args[0]],
+@@ -3168,7 +3172,7 @@ restart:
+ 				continue;
+ 
+ 			if (cb->args[1]) {
+-				if (exp != last)
++				if (ctnetlink_exp_id(exp) != last_id)
+ 					continue;
+ 				cb->args[1] = 0;
+ 			}
+@@ -3177,9 +3181,7 @@ restart:
+ 						    cb->nlh->nlmsg_seq,
+ 						    IPCTNL_MSG_EXP_NEW,
+ 						    exp) < 0) {
+-				if (!refcount_inc_not_zero(&exp->use))
+-					continue;
+-				cb->args[1] = (unsigned long)exp;
++				cb->args[1] = ctnetlink_exp_id(exp);
+ 				goto out;
+ 			}
+ 		}
+@@ -3190,32 +3192,34 @@ restart:
+ 	}
+ out:
+ 	rcu_read_unlock();
+-	if (last)
+-		nf_ct_expect_put(last);
+-
+ 	return skb->len;
+ }
+ 
+ static int
+ ctnetlink_exp_ct_dump_table(struct sk_buff *skb, struct netlink_callback *cb)
+ {
+-	struct nf_conntrack_expect *exp, *last;
+ 	struct nfgenmsg *nfmsg = nlmsg_data(cb->nlh);
+ 	struct nf_conn *ct = cb->data;
+-	struct nf_conn_help *help = nfct_help(ct);
++	struct nf_conn_help *help;
+ 	u_int8_t l3proto = nfmsg->nfgen_family;
++	unsigned long last_id = cb->args[1];
++	struct nf_conntrack_expect *exp;
+ 
+ 	if (cb->args[0])
+ 		return 0;
+ 
++	help = nfct_help(ct);
++	if (!help)
++		return 0;
++
+ 	rcu_read_lock();
+-	last = (struct nf_conntrack_expect *)cb->args[1];
++
+ restart:
+ 	hlist_for_each_entry_rcu(exp, &help->expectations, lnode) {
+ 		if (l3proto && exp->tuple.src.l3num != l3proto)
+ 			continue;
+ 		if (cb->args[1]) {
+-			if (exp != last)
++			if (ctnetlink_exp_id(exp) != last_id)
+ 				continue;
+ 			cb->args[1] = 0;
+ 		}
+@@ -3223,9 +3227,7 @@ restart:
+ 					    cb->nlh->nlmsg_seq,
+ 					    IPCTNL_MSG_EXP_NEW,
+ 					    exp) < 0) {
+-			if (!refcount_inc_not_zero(&exp->use))
+-				continue;
+-			cb->args[1] = (unsigned long)exp;
++			cb->args[1] = ctnetlink_exp_id(exp);
+ 			goto out;
+ 		}
+ 	}
+@@ -3236,12 +3238,27 @@ restart:
+ 	cb->args[0] = 1;
+ out:
+ 	rcu_read_unlock();
+-	if (last)
+-		nf_ct_expect_put(last);
+-
+ 	return skb->len;
+ }
+ 
++static int ctnetlink_dump_exp_ct_start(struct netlink_callback *cb)
++{
++	struct nf_conn *ct = cb->data;
++
++	if (!refcount_inc_not_zero(&ct->ct_general.use))
++		return -ENOENT;
++	return 0;
++}
++
++static int ctnetlink_dump_exp_ct_done(struct netlink_callback *cb)
++{
++	struct nf_conn *ct = cb->data;
++
++	if (ct)
++		nf_ct_put(ct);
++	return 0;
++}
++
+ static int ctnetlink_dump_exp_ct(struct net *net, struct sock *ctnl,
+ 				 struct sk_buff *skb,
+ 				 const struct nlmsghdr *nlh,
+@@ -3257,7 +3274,8 @@ static int ctnetlink_dump_exp_ct(struct net *net, struct sock *ctnl,
+ 	struct nf_conntrack_zone zone;
+ 	struct netlink_dump_control c = {
+ 		.dump = ctnetlink_exp_ct_dump_table,
+-		.done = ctnetlink_exp_done,
++		.start = ctnetlink_dump_exp_ct_start,
++		.done = ctnetlink_dump_exp_ct_done,
+ 	};
+ 
+ 	err = ctnetlink_parse_tuple(cda, &tuple, CTA_EXPECT_MASTER,
+@@ -3307,7 +3325,6 @@ static int ctnetlink_get_expect(struct sk_buff *skb,
+ 		else {
+ 			struct netlink_dump_control c = {
+ 				.dump = ctnetlink_exp_dump_table,
+-				.done = ctnetlink_exp_done,
+ 			};
+ 			return netlink_dump_start(info->sk, skb, info->nlh, &c);
+ 		}
+diff --git a/net/netfilter/nf_conntrack_sip.c b/net/netfilter/nf_conntrack_sip.c
+index d0eac27f6ba03c..657839a58782a5 100644
+--- a/net/netfilter/nf_conntrack_sip.c
++++ b/net/netfilter/nf_conntrack_sip.c
+@@ -1534,11 +1534,12 @@ static int sip_help_tcp(struct sk_buff *skb, unsigned int protoff,
+ {
+ 	struct tcphdr *th, _tcph;
+ 	unsigned int dataoff, datalen;
+-	unsigned int matchoff, matchlen, clen;
++	unsigned int matchoff, matchlen;
+ 	unsigned int msglen, origlen;
+ 	const char *dptr, *end;
+ 	s16 diff, tdiff = 0;
+ 	int ret = NF_ACCEPT;
++	unsigned long clen;
+ 	bool term;
+ 
+ 	if (ctinfo != IP_CT_ESTABLISHED &&
+@@ -1573,6 +1574,9 @@ static int sip_help_tcp(struct sk_buff *skb, unsigned int protoff,
+ 		if (dptr + matchoff == end)
+ 			break;
+ 
++		if (clen > datalen)
++			break;
++
+ 		term = false;
+ 		for (; end + strlen("\r\n\r\n") <= dptr + datalen; end++) {
+ 			if (end[0] == '\r' && end[1] == '\n' &&
+diff --git a/net/netfilter/nf_tables_api.c b/net/netfilter/nf_tables_api.c
+index 41614e897ec8fd..b411abe9743b74 100644
+--- a/net/netfilter/nf_tables_api.c
++++ b/net/netfilter/nf_tables_api.c
+@@ -8772,6 +8772,7 @@ static int nf_tables_newflowtable(struct sk_buff *skb,
+ 	return 0;
+ 
+ err_flowtable_hooks:
++	synchronize_rcu();
+ 	nft_trans_destroy(trans);
+ err_flowtable_trans:
+ 	nft_hooks_destroy(&flowtable->hook_list);
+@@ -9944,11 +9945,6 @@ static void nft_trans_gc_queue_work(struct nft_trans_gc *trans)
+ 	schedule_work(&trans_gc_work);
+ }
+ 
+-static int nft_trans_gc_space(struct nft_trans_gc *trans)
+-{
+-	return NFT_TRANS_GC_BATCHCOUNT - trans->count;
+-}
+-
+ struct nft_trans_gc *nft_trans_gc_queue_async(struct nft_trans_gc *gc,
+ 					      unsigned int gc_seq, gfp_t gfp)
+ {
+diff --git a/net/netfilter/nfnetlink_cthelper.c b/net/netfilter/nfnetlink_cthelper.c
+index 97248963a7d3b5..71a248cca746ae 100644
+--- a/net/netfilter/nfnetlink_cthelper.c
++++ b/net/netfilter/nfnetlink_cthelper.c
+@@ -603,10 +603,10 @@ restart:
+ 				goto out;
+ 			}
+ 		}
+-	}
+-	if (cb->args[1]) {
+-		cb->args[1] = 0;
+-		goto restart;
++		if (cb->args[1]) {
++			cb->args[1] = 0;
++			goto restart;
++		}
+ 	}
+ out:
+ 	rcu_read_unlock();
+diff --git a/net/netfilter/nfnetlink_osf.c b/net/netfilter/nfnetlink_osf.c
+index 50723ba0828905..da9d5d6de98f4d 100644
+--- a/net/netfilter/nfnetlink_osf.c
++++ b/net/netfilter/nfnetlink_osf.c
+@@ -302,7 +302,9 @@ static int nfnl_osf_add_callback(struct sk_buff *skb,
+ {
+ 	struct nf_osf_user_finger *f;
+ 	struct nf_osf_finger *kf = NULL, *sf;
++	unsigned int tot_opt_len = 0;
+ 	int err = 0;
++	int i;
+ 
+ 	if (!capable(CAP_NET_ADMIN))
+ 		return -EPERM;
+@@ -318,6 +320,17 @@ static int nfnl_osf_add_callback(struct sk_buff *skb,
+ 	if (f->opt_num > ARRAY_SIZE(f->opt))
+ 		return -EINVAL;
+ 
++	for (i = 0; i < f->opt_num; i++) {
++		if (!f->opt[i].length || f->opt[i].length > MAX_IPOPTLEN)
++			return -EINVAL;
++		if (f->opt[i].kind == OSFOPT_MSS && f->opt[i].length < 4)
++			return -EINVAL;
++
++		tot_opt_len += f->opt[i].length;
++		if (tot_opt_len > MAX_IPOPTLEN)
++			return -EINVAL;
++	}
++
+ 	if (!memchr(f->genre, 0, MAXGENRELEN) ||
+ 	    !memchr(f->subtype, 0, MAXGENRELEN) ||
+ 	    !memchr(f->version, 0, MAXGENRELEN))
+diff --git a/net/netfilter/nfnetlink_queue.c b/net/netfilter/nfnetlink_queue.c
+index 09209b4952ad14..0ac0db71dbc61f 100644
+--- a/net/netfilter/nfnetlink_queue.c
++++ b/net/netfilter/nfnetlink_queue.c
+@@ -1283,8 +1283,10 @@ static int nfqnl_recv_verdict(struct sk_buff *skb, const struct nfnl_info *info,
+ 
+ 	if (entry->state.pf == PF_BRIDGE) {
+ 		err = nfqa_parse_bridge(entry, nfqa);
+-		if (err < 0)
++		if (err < 0) {
++			nfqnl_reinject(entry, NF_DROP);
+ 			return err;
++		}
+ 	}
+ 
+ 	if (nfqa[NFQA_PAYLOAD]) {
+diff --git a/net/netfilter/nft_ct.c b/net/netfilter/nft_ct.c
+index 3ec63852d058f9..128eb0ac37742a 100644
+--- a/net/netfilter/nft_ct.c
++++ b/net/netfilter/nft_ct.c
+@@ -22,6 +22,8 @@
+ #include <net/netfilter/nf_conntrack_timeout.h>
+ #include <net/netfilter/nf_conntrack_l4proto.h>
+ #include <net/netfilter/nf_conntrack_expect.h>
++#include <net/netfilter/nf_conntrack_seqadj.h>
++#include "nf_internals.h"
+ 
+ struct nft_ct_helper_obj  {
+ 	struct nf_conntrack_helper *helper4;
+@@ -526,6 +528,7 @@ static void __nft_ct_set_destroy(const struct nft_ctx *ctx, struct nft_ct *priv)
+ #endif
+ #ifdef CONFIG_NF_CONNTRACK_ZONES
+ 	case NFT_CT_ZONE:
++		nf_queue_nf_hook_drop(ctx->net);
+ 		mutex_lock(&nft_ct_pcpu_mutex);
+ 		if (--nft_ct_pcpu_template_refcnt == 0)
+ 			nft_ct_tmpl_put_pcpu();
+@@ -996,6 +999,7 @@ static void nft_ct_timeout_obj_destroy(const struct nft_ctx *ctx,
+ 	struct nft_ct_timeout_obj *priv = nft_obj_data(obj);
+ 	struct nf_ct_timeout *timeout = priv->timeout;
+ 
++	nf_queue_nf_hook_drop(ctx->net);
+ 	nf_ct_untimeout(ctx->net, timeout);
+ 	nf_ct_netns_put(ctx->net, ctx->family);
+ 	kfree(priv->timeout);
+@@ -1128,6 +1132,7 @@ static void nft_ct_helper_obj_destroy(const struct nft_ctx *ctx,
+ {
+ 	struct nft_ct_helper_obj *priv = nft_obj_data(obj);
+ 
++	nf_queue_nf_hook_drop(ctx->net);
+ 	if (priv->helper4)
+ 		nf_conntrack_helper_put(priv->helper4);
+ 	if (priv->helper6)
+@@ -1173,6 +1178,10 @@ static void nft_ct_helper_obj_eval(struct nft_object *obj,
+ 	if (help) {
+ 		rcu_assign_pointer(help->helper, to_assign);
+ 		set_bit(IPS_HELPER_BIT, &ct->status);
++
++		if ((ct->status & IPS_NAT_MASK) && !nfct_seqadj(ct))
++			if (!nfct_seqadj_ext_add(ct))
++				regs->verdict.code = NF_DROP;
+ 	}
+ }
+ 
+diff --git a/net/netfilter/nft_set_pipapo.c b/net/netfilter/nft_set_pipapo.c
+index c3ada6798d4a3f..00a13c50ec8bf4 100644
+--- a/net/netfilter/nft_set_pipapo.c
++++ b/net/netfilter/nft_set_pipapo.c
+@@ -1570,6 +1570,7 @@ static void pipapo_drop(struct nft_pipapo_match *m,
+ 	int i;
+ 
+ 	nft_pipapo_for_each_field(f, i, m) {
++		bool last = i == m->field_count - 1;
+ 		int g;
+ 
+ 		for (g = 0; g < f->groups; g++) {
+@@ -1589,7 +1590,7 @@ static void pipapo_drop(struct nft_pipapo_match *m,
+ 		}
+ 
+ 		pipapo_unmap(f->mt, f->rules, rulemap[i].to, rulemap[i].n,
+-			     rulemap[i + 1].n, i == m->field_count - 1);
++			     last ? 0 : rulemap[i + 1].n, last);
+ 		if (pipapo_resize(f, f->rules, f->rules - rulemap[i].n)) {
+ 			/* We can ignore this, a failure to shrink tables down
+ 			 * doesn't make tables invalid.
+@@ -1614,11 +1615,11 @@ static void nft_pipapo_gc_deactivate(struct net *net, struct nft_set *set,
+ }
+ 
+ /**
+- * pipapo_gc() - Drop expired entries from set, destroy start and end elements
++ * pipapo_gc_scan() - Drop expired entries from set and link them to gc list
+  * @set:	nftables API set representation
+  * @m:		Matching data
+  */
+-static void pipapo_gc(struct nft_set *set, struct nft_pipapo_match *m)
++static void pipapo_gc_scan(struct nft_set *set, struct nft_pipapo_match *m)
+ {
+ 	struct nft_pipapo *priv = nft_set_priv(set);
+ 	struct net *net = read_pnet(&set->net);
+@@ -1631,6 +1632,8 @@ static void pipapo_gc(struct nft_set *set, struct nft_pipapo_match *m)
+ 	if (!gc)
+ 		return;
+ 
++	list_add(&gc->list, &priv->gc_head);
++
+ 	while ((rules_f0 = pipapo_rules_same_key(m->f, first_rule))) {
+ 		union nft_pipapo_map_bucket rulemap[NFT_PIPAPO_MAX_FIELDS];
+ 		const struct nft_pipapo_field *f;
+@@ -1660,9 +1663,13 @@ static void pipapo_gc(struct nft_set *set, struct nft_pipapo_match *m)
+ 		if (__nft_set_elem_expired(&e->ext, tstamp)) {
+ 			priv->dirty = true;
+ 
+-			gc = nft_trans_gc_queue_sync(gc, GFP_ATOMIC);
+-			if (!gc)
+-				return;
++			if (!nft_trans_gc_space(gc)) {
++				gc = nft_trans_gc_alloc(set, 0, GFP_KERNEL);
++				if (!gc)
++					return;
++
++				list_add(&gc->list, &priv->gc_head);
++			}
+ 
+ 			nft_pipapo_gc_deactivate(net, set, e);
+ 			pipapo_drop(m, rulemap);
+@@ -1676,10 +1683,30 @@ static void pipapo_gc(struct nft_set *set, struct nft_pipapo_match *m)
+ 		}
+ 	}
+ 
+-	gc = nft_trans_gc_catchall_sync(gc);
++	priv->last_gc = jiffies;
++}
++
++/**
++ * pipapo_gc_queue() - Free expired elements
++ * @set:	nftables API set representation
++ */
++static void pipapo_gc_queue(struct nft_set *set)
++{
++	struct nft_pipapo *priv = nft_set_priv(set);
++	struct nft_trans_gc *gc, *next;
++
++	/* always do a catchall cycle: */
++	gc = nft_trans_gc_alloc(set, 0, GFP_KERNEL);
+ 	if (gc) {
++		gc = nft_trans_gc_catchall_sync(gc);
++		if (gc)
++			nft_trans_gc_queue_sync_done(gc);
++	}
++
++	/* always purge queued gc elements. */
++	list_for_each_entry_safe(gc, next, &priv->gc_head, list) {
++		list_del(&gc->list);
+ 		nft_trans_gc_queue_sync_done(gc);
+-		priv->last_gc = jiffies;
+ 	}
+ }
+ 
+@@ -1733,6 +1760,10 @@ static void pipapo_reclaim_match(struct rcu_head *rcu)
+  *
+  * We also need to create a new working copy for subsequent insertions and
+  * deletions.
++ *
++ * After the live copy has been replaced by the clone, we can safely queue
++ * expired elements that have been collected by pipapo_gc_scan() for
++ * memory reclaim.
+  */
+ static void nft_pipapo_commit(struct nft_set *set)
+ {
+@@ -1740,7 +1771,7 @@ static void nft_pipapo_commit(struct nft_set *set)
+ 	struct nft_pipapo_match *new_clone, *old;
+ 
+ 	if (time_after_eq(jiffies, priv->last_gc + nft_set_gc_interval(set)))
+-		pipapo_gc(set, priv->clone);
++		pipapo_gc_scan(set, priv->clone);
+ 
+ 	if (!priv->dirty)
+ 		return;
+@@ -1757,6 +1788,8 @@ static void nft_pipapo_commit(struct nft_set *set)
+ 		call_rcu(&old->rcu, pipapo_reclaim_match);
+ 
+ 	priv->clone = new_clone;
++
++	pipapo_gc_queue(set);
+ }
+ 
+ static bool nft_pipapo_transaction_mutex_held(const struct nft_set *set)
+@@ -2228,6 +2261,7 @@ static int nft_pipapo_init(const struct nft_set *set,
+ 
+ 	priv->dirty = false;
+ 
++	INIT_LIST_HEAD(&priv->gc_head);
+ 	rcu_assign_pointer(priv->match, m);
+ 
+ 	return 0;
+@@ -2280,6 +2314,8 @@ static void nft_pipapo_destroy(const struct nft_ctx *ctx,
+ 	struct nft_pipapo_match *m;
+ 	int cpu;
+ 
++	WARN_ON_ONCE(!list_empty(&priv->gc_head));
++
+ 	m = rcu_dereference_protected(priv->match, true);
+ 	if (m) {
+ 		rcu_barrier();
+diff --git a/net/netfilter/nft_set_pipapo.h b/net/netfilter/nft_set_pipapo.h
+index aad9130cc7635c..743ba7c153ffe4 100644
+--- a/net/netfilter/nft_set_pipapo.h
++++ b/net/netfilter/nft_set_pipapo.h
+@@ -165,6 +165,7 @@ struct nft_pipapo_match {
+  * @width:	Total bytes to be matched for one packet, including padding
+  * @dirty:	Working copy has pending insertions or deletions
+  * @last_gc:	Timestamp of last garbage collection run, jiffies
++ * @gc_head:	list of nft_trans_gc to queue up for mem reclaim
+  */
+ struct nft_pipapo {
+ 	struct nft_pipapo_match __rcu *match;
+@@ -172,6 +173,7 @@ struct nft_pipapo {
+ 	int width;
+ 	bool dirty;
+ 	unsigned long last_gc;
++	struct list_head gc_head;
+ };
+ 
+ struct nft_pipapo_elem;
+diff --git a/net/netfilter/xt_CT.c b/net/netfilter/xt_CT.c
+index 3ba94c34297cf5..498f5871c84a0e 100644
+--- a/net/netfilter/xt_CT.c
++++ b/net/netfilter/xt_CT.c
+@@ -16,6 +16,7 @@
+ #include <net/netfilter/nf_conntrack_ecache.h>
+ #include <net/netfilter/nf_conntrack_timeout.h>
+ #include <net/netfilter/nf_conntrack_zones.h>
++#include "nf_internals.h"
+ 
+ static inline int xt_ct_target(struct sk_buff *skb, struct nf_conn *ct)
+ {
+@@ -283,6 +284,9 @@ static void xt_ct_tg_destroy(const struct xt_tgdtor_param *par,
+ 	struct nf_conn_help *help;
+ 
+ 	if (ct) {
++		if (info->helper[0] || info->timeout[0])
++			nf_queue_nf_hook_drop(par->net);
++
+ 		help = nfct_help(ct);
+ 		xt_ct_put_helper(help);
+ 
+diff --git a/net/netfilter/xt_IDLETIMER.c b/net/netfilter/xt_IDLETIMER.c
+index 9869ef3c2ab378..92a8289b1cb357 100644
+--- a/net/netfilter/xt_IDLETIMER.c
++++ b/net/netfilter/xt_IDLETIMER.c
+@@ -320,6 +320,12 @@ static int idletimer_tg_checkentry(const struct xt_tgchk_param *par)
+ 
+ 	info->timer = __idletimer_tg_find_by_label(info->label);
+ 	if (info->timer) {
++		if (info->timer->timer_type & XT_IDLETIMER_ALARM) {
++			pr_debug("Adding/Replacing rule with same label and different timer type is not allowed\n");
++			mutex_unlock(&list_mutex);
++			return -EINVAL;
++		}
++
+ 		info->timer->refcnt++;
+ 		mod_timer(&info->timer->timer,
+ 			  msecs_to_jiffies(info->timeout * 1000) + jiffies);
+diff --git a/net/netfilter/xt_dccp.c b/net/netfilter/xt_dccp.c
+index e5a13ecbe67a01..037ab93e25d0af 100644
+--- a/net/netfilter/xt_dccp.c
++++ b/net/netfilter/xt_dccp.c
+@@ -62,10 +62,10 @@ dccp_find_option(u_int8_t option,
+ 			return true;
+ 		}
+ 
+-		if (op[i] < 2)
++		if (op[i] < 2 || i == optlen - 1)
+ 			i++;
+ 		else
+-			i += op[i+1]?:1;
++			i += op[i + 1] ? : 1;
+ 	}
+ 
+ 	spin_unlock_bh(&dccp_buflock);
+diff --git a/net/netfilter/xt_tcpudp.c b/net/netfilter/xt_tcpudp.c
+index e8991130a3de0c..f76cf18f1a2445 100644
+--- a/net/netfilter/xt_tcpudp.c
++++ b/net/netfilter/xt_tcpudp.c
+@@ -59,8 +59,10 @@ tcp_find_option(u_int8_t option,
+ 
+ 	for (i = 0; i < optlen; ) {
+ 		if (op[i] == option) return !invert;
+-		if (op[i] < 2) i++;
+-		else i += op[i+1]?:1;
++		if (op[i] < 2 || i == optlen - 1)
++			i++;
++		else
++			i += op[i + 1] ? : 1;
+ 	}
+ 
+ 	return invert;
+diff --git a/net/netfilter/xt_time.c b/net/netfilter/xt_time.c
+index 6aa12d0f54e23c..61de85e02a40fb 100644
+--- a/net/netfilter/xt_time.c
++++ b/net/netfilter/xt_time.c
+@@ -227,13 +227,13 @@ time_mt(const struct sk_buff *skb, struct xt_action_param *par)
+ 
+ 	localtime_2(&current_time, stamp);
+ 
+-	if (!(info->weekdays_match & (1 << current_time.weekday)))
++	if (!(info->weekdays_match & (1U << current_time.weekday)))
+ 		return false;
+ 
+ 	/* Do not spend time computing monthday if all days match anyway */
+ 	if (info->monthdays_match != XT_TIME_ALL_MONTHDAYS) {
+ 		localtime_3(&current_time, stamp);
+-		if (!(info->monthdays_match & (1 << current_time.monthday)))
++		if (!(info->monthdays_match & (1U << current_time.monthday)))
+ 			return false;
+ 	}
+ 
+diff --git a/net/nfc/nci/core.c b/net/nfc/nci/core.c
+index b7d4952a7dcf88..1f33da345bea6d 100644
+--- a/net/nfc/nci/core.c
++++ b/net/nfc/nci/core.c
+@@ -1024,18 +1024,23 @@ static int nci_transceive(struct nfc_dev *nfc_dev, struct nfc_target *target,
+ 	struct nci_conn_info *conn_info;
+ 
+ 	conn_info = ndev->rf_conn_info;
+-	if (!conn_info)
++	if (!conn_info) {
++		kfree_skb(skb);
+ 		return -EPROTO;
++	}
+ 
+ 	pr_debug("target_idx %d, len %d\n", target->idx, skb->len);
+ 
+ 	if (!ndev->target_active_prot) {
+ 		pr_err("unable to exchange data, no active target\n");
++		kfree_skb(skb);
+ 		return -EINVAL;
+ 	}
+ 
+-	if (test_and_set_bit(NCI_DATA_EXCHANGE, &ndev->flags))
++	if (test_and_set_bit(NCI_DATA_EXCHANGE, &ndev->flags)) {
++		kfree_skb(skb);
+ 		return -EBUSY;
++	}
+ 
+ 	/* store cb and context to be used on receiving data */
+ 	conn_info->data_exchange_cb = cb;
+@@ -1471,10 +1476,20 @@ static bool nci_valid_size(struct sk_buff *skb)
+ 	unsigned int hdr_size = NCI_CTRL_HDR_SIZE;
+ 
+ 	if (skb->len < hdr_size ||
+-	    !nci_plen(skb->data) ||
+ 	    skb->len < hdr_size + nci_plen(skb->data)) {
+ 		return false;
+ 	}
++
++	if (!nci_plen(skb->data)) {
++		/* Allow zero length in proprietary notifications (0x20 - 0x3F). */
++		if (nci_opcode_oid(nci_opcode(skb->data)) >= 0x20 &&
++		    nci_mt(skb->data) == NCI_MT_NTF_PKT)
++			return true;
++
++		/* Disallow zero length otherwise. */
++		return false;
++	}
++
+ 	return true;
+ }
+ 
+diff --git a/net/nfc/nci/data.c b/net/nfc/nci/data.c
+index 3d36ea5701f022..7a3fb2a397a1ea 100644
+--- a/net/nfc/nci/data.c
++++ b/net/nfc/nci/data.c
+@@ -33,7 +33,8 @@ void nci_data_exchange_complete(struct nci_dev *ndev, struct sk_buff *skb,
+ 	conn_info = nci_get_conn_info_by_conn_id(ndev, conn_id);
+ 	if (!conn_info) {
+ 		kfree_skb(skb);
+-		goto exit;
++		clear_bit(NCI_DATA_EXCHANGE, &ndev->flags);
++		return;
+ 	}
+ 
+ 	cb = conn_info->data_exchange_cb;
+@@ -45,6 +46,12 @@ void nci_data_exchange_complete(struct nci_dev *ndev, struct sk_buff *skb,
+ 	del_timer_sync(&ndev->data_timer);
+ 	clear_bit(NCI_DATA_EXCHANGE_TO, &ndev->flags);
+ 
++	/* Mark the exchange as done before calling the callback.
++	 * The callback (e.g. rawsock_data_exchange_complete) may
++	 * want to immediately queue another data exchange.
++	 */
++	clear_bit(NCI_DATA_EXCHANGE, &ndev->flags);
++
+ 	if (cb) {
+ 		/* forward skb to nfc core */
+ 		cb(cb_context, skb, err);
+@@ -54,9 +61,6 @@ void nci_data_exchange_complete(struct nci_dev *ndev, struct sk_buff *skb,
+ 		/* no waiting callback, free skb */
+ 		kfree_skb(skb);
+ 	}
+-
+-exit:
+-	clear_bit(NCI_DATA_EXCHANGE, &ndev->flags);
+ }
+ 
+ /* ----------------- NCI TX Data ----------------- */
+diff --git a/net/nfc/rawsock.c b/net/nfc/rawsock.c
+index 5125392bb68ebf..028b4daafaf832 100644
+--- a/net/nfc/rawsock.c
++++ b/net/nfc/rawsock.c
+@@ -67,6 +67,17 @@ static int rawsock_release(struct socket *sock)
+ 	if (sock->type == SOCK_RAW)
+ 		nfc_sock_unlink(&raw_sk_list, sk);
+ 
++	if (sk->sk_state == TCP_ESTABLISHED) {
++		/* Prevent rawsock_tx_work from starting new transmits and
++		 * wait for any in-progress work to finish.  This must happen
++		 * before the socket is orphaned to avoid a race where
++		 * rawsock_tx_work runs after the NCI device has been freed.
++		 */
++		sk->sk_shutdown |= SEND_SHUTDOWN;
++		cancel_work_sync(&nfc_rawsock(sk)->tx_work);
++		rawsock_write_queue_purge(sk);
++	}
++
+ 	sock_orphan(sk);
+ 	sock_put(sk);
+ 
+diff --git a/net/rds/tcp.c b/net/rds/tcp.c
+index 985b05f38b6746..dee18da64a3229 100644
+--- a/net/rds/tcp.c
++++ b/net/rds/tcp.c
+@@ -494,18 +494,24 @@ bool rds_tcp_tune(struct socket *sock)
+ 	struct rds_tcp_net *rtn;
+ 
+ 	tcp_sock_set_nodelay(sock->sk);
+-	lock_sock(sk);
+ 	/* TCP timer functions might access net namespace even after
+ 	 * a process which created this net namespace terminated.
+ 	 */
+ 	if (!sk->sk_net_refcnt) {
+-		if (!maybe_get_net(net)) {
+-			release_sock(sk);
++		if (!maybe_get_net(net))
+ 			return false;
+-		}
++		/*
++		 * sk_net_refcnt_upgrade() must be called before lock_sock()
++		 * because it does a GFP_KERNEL allocation, which can trigger
++		 * fs_reclaim and create a circular lock dependency with the
++		 * socket lock.  The fields it modifies (sk_net_refcnt,
++		 * ns_tracker) are not accessed by any concurrent code path
++		 * at this point.
++		 */
+ 		sk_net_refcnt_upgrade(sk);
+ 		put_net(net);
+ 	}
++	lock_sock(sk);
+ 	rtn = net_generic(net, rds_tcp_netid);
+ 	if (rtn->sndbuf_size > 0) {
+ 		sk->sk_sndbuf = rtn->sndbuf_size;
+diff --git a/net/rose/af_rose.c b/net/rose/af_rose.c
+index 1cc5eaeb1c608e..e80bc7788bec57 100644
+--- a/net/rose/af_rose.c
++++ b/net/rose/af_rose.c
+@@ -810,6 +810,11 @@ static int rose_connect(struct socket *sock, struct sockaddr *uaddr, int addr_le
+ 		goto out_release;
+ 	}
+ 
++	if (sk->sk_state == TCP_SYN_SENT) {
++		err = -EALREADY;
++		goto out_release;
++	}
++
+ 	sk->sk_state   = TCP_CLOSE;
+ 	sock->state = SS_UNCONNECTED;
+ 
+diff --git a/net/rxrpc/ar-internal.h b/net/rxrpc/ar-internal.h
+index 86438c86eb2fd3..f4512761f572d6 100644
+--- a/net/rxrpc/ar-internal.h
++++ b/net/rxrpc/ar-internal.h
+@@ -331,7 +331,7 @@ struct rxrpc_peer {
+ 	struct hlist_head	error_targets;	/* targets for net error distribution */
+ 	struct rb_root		service_conns;	/* Service connections */
+ 	struct list_head	keepalive_link;	/* Link in net->peer_keepalive[] */
+-	time64_t		last_tx_at;	/* Last time packet sent here */
++	unsigned int		last_tx_at;	/* Last time packet sent here (time64_t LSW) */
+ 	seqlock_t		service_conn_lock;
+ 	spinlock_t		lock;		/* access lock */
+ 	unsigned int		if_mtu;		/* interface MTU for this peer */
+@@ -1171,6 +1171,13 @@ void rxrpc_transmit_one(struct rxrpc_call *call, struct rxrpc_txbuf *txb);
+ void rxrpc_input_error(struct rxrpc_local *, struct sk_buff *);
+ void rxrpc_peer_keepalive_worker(struct work_struct *);
+ 
++/* Update the last transmission time on a peer for keepalive purposes. */
++static inline void rxrpc_peer_mark_tx(struct rxrpc_peer *peer)
++{
++	/* To avoid tearing on 32-bit systems, we only keep the LSW. */
++	WRITE_ONCE(peer->last_tx_at, ktime_get_seconds());
++}
++
+ /*
+  * peer_object.c
+  */
+diff --git a/net/rxrpc/conn_event.c b/net/rxrpc/conn_event.c
+index c4eb7986efddf8..c8df12d80c7cea 100644
+--- a/net/rxrpc/conn_event.c
++++ b/net/rxrpc/conn_event.c
+@@ -180,7 +180,7 @@ void rxrpc_conn_retransmit_call(struct rxrpc_connection *conn,
+ 	}
+ 
+ 	ret = kernel_sendmsg(conn->local->socket, &msg, iov, ioc, len);
+-	conn->peer->last_tx_at = ktime_get_seconds();
++	rxrpc_peer_mark_tx(conn->peer);
+ 	if (ret < 0)
+ 		trace_rxrpc_tx_fail(chan->call_debug_id, serial, ret,
+ 				    rxrpc_tx_point_call_final_resend);
+diff --git a/net/rxrpc/output.c b/net/rxrpc/output.c
+index 4bbb27a48bd8ae..02f2de578f30c6 100644
+--- a/net/rxrpc/output.c
++++ b/net/rxrpc/output.c
+@@ -233,7 +233,7 @@ int rxrpc_send_ack_packet(struct rxrpc_call *call, struct rxrpc_txbuf *txb)
+ 
+ 	iov_iter_kvec(&msg.msg_iter, WRITE, iov, 1, len);
+ 	ret = do_udp_sendmsg(conn->local->socket, &msg, len);
+-	call->peer->last_tx_at = ktime_get_seconds();
++	rxrpc_peer_mark_tx(call->peer);
+ 	if (ret < 0) {
+ 		trace_rxrpc_tx_fail(call->debug_id, serial, ret,
+ 				    rxrpc_tx_point_call_ack);
+@@ -307,7 +307,7 @@ int rxrpc_send_abort_packet(struct rxrpc_call *call)
+ 
+ 	iov_iter_kvec(&msg.msg_iter, WRITE, iov, 1, sizeof(pkt));
+ 	ret = do_udp_sendmsg(conn->local->socket, &msg, sizeof(pkt));
+-	conn->peer->last_tx_at = ktime_get_seconds();
++	rxrpc_peer_mark_tx(conn->peer);
+ 	if (ret < 0)
+ 		trace_rxrpc_tx_fail(call->debug_id, serial, ret,
+ 				    rxrpc_tx_point_call_abort);
+@@ -392,6 +392,7 @@ dont_set_request_ack:
+ 					    txb->wire.flags,
+ 					    test_bit(RXRPC_TXBUF_RESENT, &txb->flags),
+ 					    true);
++			rxrpc_peer_mark_tx(conn->peer);
+ 			goto done;
+ 		}
+ 	}
+@@ -425,7 +426,7 @@ dont_set_request_ack:
+ 	 */
+ 	rxrpc_inc_stat(call->rxnet, stat_tx_data_send);
+ 	ret = do_udp_sendmsg(conn->local->socket, &msg, len);
+-	conn->peer->last_tx_at = ktime_get_seconds();
++	rxrpc_peer_mark_tx(conn->peer);
+ 
+ 	if (ret < 0) {
+ 		rxrpc_inc_stat(call->rxnet, stat_tx_data_send_fail);
+@@ -572,7 +573,7 @@ void rxrpc_send_conn_abort(struct rxrpc_connection *conn)
+ 
+ 	trace_rxrpc_tx_packet(conn->debug_id, &whdr, rxrpc_tx_point_conn_abort);
+ 
+-	conn->peer->last_tx_at = ktime_get_seconds();
++	rxrpc_peer_mark_tx(conn->peer);
+ }
+ 
+ /*
+@@ -691,7 +692,7 @@ void rxrpc_send_keepalive(struct rxrpc_peer *peer)
+ 		trace_rxrpc_tx_packet(peer->debug_id, &whdr,
+ 				      rxrpc_tx_point_version_keepalive);
+ 
+-	peer->last_tx_at = ktime_get_seconds();
++	rxrpc_peer_mark_tx(peer);
+ 	_leave("");
+ }
+ 
+diff --git a/net/rxrpc/peer_event.c b/net/rxrpc/peer_event.c
+index 552ba84a255c43..8c7fad55da74d7 100644
+--- a/net/rxrpc/peer_event.c
++++ b/net/rxrpc/peer_event.c
+@@ -224,6 +224,21 @@ static void rxrpc_distribute_error(struct rxrpc_peer *peer, struct sk_buff *skb,
+ 	spin_unlock(&peer->lock);
+ }
+ 
++/*
++ * Reconstruct the last transmission time.  The difference calculated should be
++ * valid provided no more than ~68 years elapsed since the last transmission.
++ */
++static time64_t rxrpc_peer_get_tx_mark(const struct rxrpc_peer *peer, time64_t base)
++{
++	s32 last_tx_at = READ_ONCE(peer->last_tx_at);
++	s32 base_lsw = base;
++	s32 diff = last_tx_at - base_lsw;
++
++	diff = clamp(diff, -RXRPC_KEEPALIVE_TIME, RXRPC_KEEPALIVE_TIME);
++
++	return diff + base;
++}
++
+ /*
+  * Perform keep-alive pings.
+  */
+@@ -252,7 +267,7 @@ static void rxrpc_peer_keepalive_dispatch(struct rxrpc_net *rxnet,
+ 		spin_unlock(&rxnet->peer_hash_lock);
+ 
+ 		if (use) {
+-			keepalive_at = peer->last_tx_at + RXRPC_KEEPALIVE_TIME;
++			keepalive_at = rxrpc_peer_get_tx_mark(peer, base) + RXRPC_KEEPALIVE_TIME;
+ 			slot = keepalive_at - base;
+ 			_debug("%02x peer %u t=%d {%pISp}",
+ 			       cursor, peer->debug_id, slot, &peer->srx.transport);
+diff --git a/net/rxrpc/proc.c b/net/rxrpc/proc.c
+index 208312c244f6b0..55a95f064df087 100644
+--- a/net/rxrpc/proc.c
++++ b/net/rxrpc/proc.c
+@@ -225,13 +225,13 @@ static int rxrpc_peer_seq_show(struct seq_file *seq, void *v)
+ 	now = ktime_get_seconds();
+ 	seq_printf(seq,
+ 		   "UDP   %-47.47s %-47.47s %3u"
+-		   " %3u %5u %6llus %8u %8u\n",
++		   " %3u %5u %6ds %8u %8u\n",
+ 		   lbuff,
+ 		   rbuff,
+ 		   refcount_read(&peer->ref),
+ 		   peer->cong_ssthresh,
+ 		   peer->mtu,
+-		   now - peer->last_tx_at,
++		   (s32)now - (s32)READ_ONCE(peer->last_tx_at),
+ 		   peer->srtt_us >> 3,
+ 		   jiffies_to_usecs(peer->rto_j));
+ 
+diff --git a/net/rxrpc/recvmsg.c b/net/rxrpc/recvmsg.c
+index e24a44bae9a32c..b6e524c065f00b 100644
+--- a/net/rxrpc/recvmsg.c
++++ b/net/rxrpc/recvmsg.c
+@@ -430,7 +430,8 @@ try_again:
+ 	if (rxrpc_call_has_failed(call))
+ 		goto call_failed;
+ 
+-	if (!skb_queue_empty(&call->recvmsg_queue))
++	if (!(flags & MSG_PEEK) &&
++	    !skb_queue_empty(&call->recvmsg_queue))
+ 		rxrpc_notify_socket(call);
+ 	goto not_yet_complete;
+ 
+@@ -461,11 +462,21 @@ error_unlock_call:
+ error_requeue_call:
+ 	if (!(flags & MSG_PEEK)) {
+ 		spin_lock(&rx->recvmsg_lock);
+-		list_add(&call->recvmsg_link, &rx->recvmsg_q);
+-		spin_unlock(&rx->recvmsg_lock);
++		if (list_empty(&call->recvmsg_link)) {
++			list_add(&call->recvmsg_link, &rx->recvmsg_q);
++			rxrpc_see_call(call, rxrpc_call_see_recvmsg_requeue);
++			spin_unlock(&rx->recvmsg_lock);
++		} else if (list_is_first(&call->recvmsg_link, &rx->recvmsg_q)) {
++			spin_unlock(&rx->recvmsg_lock);
++			rxrpc_put_call(call, rxrpc_call_see_recvmsg_requeue_first);
++		} else {
++			list_move(&call->recvmsg_link, &rx->recvmsg_q);
++			spin_unlock(&rx->recvmsg_lock);
++			rxrpc_put_call(call, rxrpc_call_see_recvmsg_requeue_move);
++		}
+ 		trace_rxrpc_recvmsg(call_debug_id, rxrpc_recvmsg_requeue, 0);
+ 	} else {
+-		rxrpc_put_call(call, rxrpc_call_put_recvmsg);
++		rxrpc_put_call(call, rxrpc_call_put_recvmsg_peek_nowait);
+ 	}
+ error_no_call:
+ 	release_sock(&rx->sk);
+diff --git a/net/rxrpc/rxkad.c b/net/rxrpc/rxkad.c
+index ad6c57a9f27c77..e3c99a016f8c4a 100644
+--- a/net/rxrpc/rxkad.c
++++ b/net/rxrpc/rxkad.c
+@@ -674,7 +674,7 @@ static int rxkad_issue_challenge(struct rxrpc_connection *conn)
+ 		return -EAGAIN;
+ 	}
+ 
+-	conn->peer->last_tx_at = ktime_get_seconds();
++	rxrpc_peer_mark_tx(conn->peer);
+ 	trace_rxrpc_tx_packet(conn->debug_id, &whdr,
+ 			      rxrpc_tx_point_rxkad_challenge);
+ 	_leave(" = 0");
+diff --git a/net/sched/act_ct.c b/net/sched/act_ct.c
+index 50d24e240e8fba..a5f4a27c8dd31f 100644
+--- a/net/sched/act_ct.c
++++ b/net/sched/act_ct.c
+@@ -1327,6 +1327,12 @@ static int tcf_ct_init(struct net *net, struct nlattr *nla,
+ 		return -EINVAL;
+ 	}
+ 
++	if (bind && !(flags & TCA_ACT_FLAGS_AT_INGRESS_OR_CLSACT)) {
++		NL_SET_ERR_MSG_MOD(extack,
++				   "Attaching ct to a non ingress/clsact qdisc is unsupported");
++		return -EOPNOTSUPP;
++	}
++
+ 	err = nla_parse_nested(tb, TCA_CT_MAX, nla, ct_policy, extack);
+ 	if (err < 0)
+ 		return err;
+diff --git a/net/sched/act_gate.c b/net/sched/act_gate.c
+index c9a811f4c7eeed..f385a8b647243f 100644
+--- a/net/sched/act_gate.c
++++ b/net/sched/act_gate.c
+@@ -32,9 +32,12 @@ static ktime_t gate_get_time(struct tcf_gate *gact)
+ 	return KTIME_MAX;
+ }
+ 
+-static void gate_get_start_time(struct tcf_gate *gact, ktime_t *start)
++static void tcf_gate_params_free_rcu(struct rcu_head *head);
++
++static void gate_get_start_time(struct tcf_gate *gact,
++				const struct tcf_gate_params *param,
++				ktime_t *start)
+ {
+-	struct tcf_gate_params *param = &gact->param;
+ 	ktime_t now, base, cycle;
+ 	u64 n;
+ 
+@@ -69,12 +72,14 @@ static enum hrtimer_restart gate_timer_func(struct hrtimer *timer)
+ {
+ 	struct tcf_gate *gact = container_of(timer, struct tcf_gate,
+ 					     hitimer);
+-	struct tcf_gate_params *p = &gact->param;
+ 	struct tcfg_gate_entry *next;
++	struct tcf_gate_params *p;
+ 	ktime_t close_time, now;
+ 
+ 	spin_lock(&gact->tcf_lock);
+ 
++	p = rcu_dereference_protected(gact->param,
++				      lockdep_is_held(&gact->tcf_lock));
+ 	next = gact->next_entry;
+ 
+ 	/* cycle start, clear pending bit, clear total octets */
+@@ -230,6 +235,35 @@ static void release_entry_list(struct list_head *entries)
+ 	}
+ }
+ 
++static int tcf_gate_copy_entries(struct tcf_gate_params *dst,
++				 const struct tcf_gate_params *src,
++				 struct netlink_ext_ack *extack)
++{
++	struct tcfg_gate_entry *entry;
++	int i = 0;
++
++	list_for_each_entry(entry, &src->entries, list) {
++		struct tcfg_gate_entry *new;
++
++		new = kzalloc(sizeof(*new), GFP_ATOMIC);
++		if (!new) {
++			NL_SET_ERR_MSG(extack, "Not enough memory for entry");
++			return -ENOMEM;
++		}
++
++		new->index      = entry->index;
++		new->gate_state = entry->gate_state;
++		new->interval   = entry->interval;
++		new->ipv        = entry->ipv;
++		new->maxoctets  = entry->maxoctets;
++		list_add_tail(&new->list, &dst->entries);
++		i++;
++	}
++
++	dst->num_entries = i;
++	return 0;
++}
++
+ static int parse_gate_list(struct nlattr *list_attr,
+ 			   struct tcf_gate_params *sched,
+ 			   struct netlink_ext_ack *extack)
+@@ -275,23 +309,42 @@ release_list:
+ 	return err;
+ }
+ 
+-static void gate_setup_timer(struct tcf_gate *gact, u64 basetime,
+-			     enum tk_offsets tko, s32 clockid,
+-			     bool do_init)
++static bool gate_timer_needs_cancel(u64 basetime, u64 old_basetime,
++				    enum tk_offsets tko,
++				    enum tk_offsets old_tko,
++				    s32 clockid, s32 old_clockid)
+ {
+-	if (!do_init) {
+-		if (basetime == gact->param.tcfg_basetime &&
+-		    tko == gact->tk_offset &&
+-		    clockid == gact->param.tcfg_clockid)
+-			return;
++	return basetime != old_basetime ||
++	       clockid != old_clockid ||
++	       tko != old_tko;
++}
+ 
+-		spin_unlock_bh(&gact->tcf_lock);
+-		hrtimer_cancel(&gact->hitimer);
+-		spin_lock_bh(&gact->tcf_lock);
++static int gate_clock_resolve(s32 clockid, enum tk_offsets *tko,
++			      struct netlink_ext_ack *extack)
++{
++	switch (clockid) {
++	case CLOCK_REALTIME:
++		*tko = TK_OFFS_REAL;
++		return 0;
++	case CLOCK_MONOTONIC:
++		*tko = TK_OFFS_MAX;
++		return 0;
++	case CLOCK_BOOTTIME:
++		*tko = TK_OFFS_BOOT;
++		return 0;
++	case CLOCK_TAI:
++		*tko = TK_OFFS_TAI;
++		return 0;
++	default:
++		NL_SET_ERR_MSG(extack, "Invalid 'clockid'");
++		return -EINVAL;
+ 	}
+-	gact->param.tcfg_basetime = basetime;
+-	gact->param.tcfg_clockid = clockid;
+-	gact->tk_offset = tko;
++}
++
++static void gate_setup_timer(struct tcf_gate *gact, s32 clockid,
++			     enum tk_offsets tko)
++{
++	WRITE_ONCE(gact->tk_offset, tko);
+ 	hrtimer_init(&gact->hitimer, clockid, HRTIMER_MODE_ABS_SOFT);
+ 	gact->hitimer.function = gate_timer_func;
+ }
+@@ -302,15 +355,22 @@ static int tcf_gate_init(struct net *net, struct nlattr *nla,
+ 			 struct netlink_ext_ack *extack)
+ {
+ 	struct tc_action_net *tn = net_generic(net, act_gate_ops.net_id);
+-	enum tk_offsets tk_offset = TK_OFFS_TAI;
++	u64 cycletime = 0, basetime = 0, cycletime_ext = 0;
++	struct tcf_gate_params *p = NULL, *old_p = NULL;
++	enum tk_offsets old_tk_offset = TK_OFFS_TAI;
++	const struct tcf_gate_params *cur_p = NULL;
+ 	bool bind = flags & TCA_ACT_FLAGS_BIND;
+ 	struct nlattr *tb[TCA_GATE_MAX + 1];
++	enum tk_offsets tko = TK_OFFS_TAI;
+ 	struct tcf_chain *goto_ch = NULL;
+-	u64 cycletime = 0, basetime = 0;
+-	struct tcf_gate_params *p;
++	s32 timer_clockid = CLOCK_TAI;
++	bool use_old_entries = false;
++	s32 old_clockid = CLOCK_TAI;
++	bool need_cancel = false;
+ 	s32 clockid = CLOCK_TAI;
+ 	struct tcf_gate *gact;
+ 	struct tc_gate *parm;
++	u64 old_basetime = 0;
+ 	int ret = 0, err;
+ 	u32 gflags = 0;
+ 	s32 prio = -1;
+@@ -327,26 +387,8 @@ static int tcf_gate_init(struct net *net, struct nlattr *nla,
+ 	if (!tb[TCA_GATE_PARMS])
+ 		return -EINVAL;
+ 
+-	if (tb[TCA_GATE_CLOCKID]) {
++	if (tb[TCA_GATE_CLOCKID])
+ 		clockid = nla_get_s32(tb[TCA_GATE_CLOCKID]);
+-		switch (clockid) {
+-		case CLOCK_REALTIME:
+-			tk_offset = TK_OFFS_REAL;
+-			break;
+-		case CLOCK_MONOTONIC:
+-			tk_offset = TK_OFFS_MAX;
+-			break;
+-		case CLOCK_BOOTTIME:
+-			tk_offset = TK_OFFS_BOOT;
+-			break;
+-		case CLOCK_TAI:
+-			tk_offset = TK_OFFS_TAI;
+-			break;
+-		default:
+-			NL_SET_ERR_MSG(extack, "Invalid 'clockid'");
+-			return -EINVAL;
+-		}
+-	}
+ 
+ 	parm = nla_data(tb[TCA_GATE_PARMS]);
+ 	index = parm->index;
+@@ -372,6 +414,60 @@ static int tcf_gate_init(struct net *net, struct nlattr *nla,
+ 		return -EEXIST;
+ 	}
+ 
++	gact = to_gate(*a);
++
++	err = tcf_action_check_ctrlact(parm->action, tp, &goto_ch, extack);
++	if (err < 0)
++		goto release_idr;
++
++	p = kzalloc(sizeof(*p), GFP_KERNEL);
++	if (!p) {
++		err = -ENOMEM;
++		goto chain_put;
++	}
++	INIT_LIST_HEAD(&p->entries);
++
++	use_old_entries = !tb[TCA_GATE_ENTRY_LIST];
++	if (!use_old_entries) {
++		err = parse_gate_list(tb[TCA_GATE_ENTRY_LIST], p, extack);
++		if (err < 0)
++			goto err_free;
++		use_old_entries = !err;
++	}
++
++	if (ret == ACT_P_CREATED && use_old_entries) {
++		NL_SET_ERR_MSG(extack, "The entry list is empty");
++		err = -EINVAL;
++		goto err_free;
++	}
++
++	if (ret != ACT_P_CREATED) {
++		rcu_read_lock();
++		cur_p = rcu_dereference(gact->param);
++
++		old_basetime  = cur_p->tcfg_basetime;
++		old_clockid   = cur_p->tcfg_clockid;
++		old_tk_offset = READ_ONCE(gact->tk_offset);
++
++		basetime      = old_basetime;
++		cycletime_ext = cur_p->tcfg_cycletime_ext;
++		prio          = cur_p->tcfg_priority;
++		gflags        = cur_p->tcfg_flags;
++
++		if (!tb[TCA_GATE_CLOCKID])
++			clockid = old_clockid;
++
++		err = 0;
++		if (use_old_entries) {
++			err = tcf_gate_copy_entries(p, cur_p, extack);
++			if (!err && !tb[TCA_GATE_CYCLE_TIME])
++				cycletime = cur_p->tcfg_cycletime;
++		}
++		rcu_read_unlock();
++		if (err)
++			goto err_free;
++	}
++
+ 	if (tb[TCA_GATE_PRIORITY])
+ 		prio = nla_get_s32(tb[TCA_GATE_PRIORITY]);
+ 
+@@ -381,25 +477,26 @@ static int tcf_gate_init(struct net *net, struct nlattr *nla,
+ 	if (tb[TCA_GATE_FLAGS])
+ 		gflags = nla_get_u32(tb[TCA_GATE_FLAGS]);
+ 
+-	gact = to_gate(*a);
+-	if (ret == ACT_P_CREATED)
+-		INIT_LIST_HEAD(&gact->param.entries);
++	if (tb[TCA_GATE_CYCLE_TIME])
++		cycletime = nla_get_u64(tb[TCA_GATE_CYCLE_TIME]);
+ 
+-	err = tcf_action_check_ctrlact(parm->action, tp, &goto_ch, extack);
+-	if (err < 0)
+-		goto release_idr;
++	if (tb[TCA_GATE_CYCLE_TIME_EXT])
++		cycletime_ext = nla_get_u64(tb[TCA_GATE_CYCLE_TIME_EXT]);
+ 
+-	spin_lock_bh(&gact->tcf_lock);
+-	p = &gact->param;
++	err = gate_clock_resolve(clockid, &tko, extack);
++	if (err)
++		goto err_free;
++	timer_clockid = clockid;
+ 
+-	if (tb[TCA_GATE_CYCLE_TIME])
+-		cycletime = nla_get_u64(tb[TCA_GATE_CYCLE_TIME]);
++	need_cancel = ret != ACT_P_CREATED &&
++		      gate_timer_needs_cancel(basetime, old_basetime,
++					      tko, old_tk_offset,
++					      timer_clockid, old_clockid);
+ 
+-	if (tb[TCA_GATE_ENTRY_LIST]) {
+-		err = parse_gate_list(tb[TCA_GATE_ENTRY_LIST], p, extack);
+-		if (err < 0)
+-			goto chain_put;
+-	}
++	if (need_cancel)
++		hrtimer_cancel(&gact->hitimer);
++
++	spin_lock_bh(&gact->tcf_lock);
+ 
+ 	if (!cycletime) {
+ 		struct tcfg_gate_entry *entry;
+@@ -408,22 +505,20 @@ static int tcf_gate_init(struct net *net, struct nlattr *nla,
+ 		list_for_each_entry(entry, &p->entries, list)
+ 			cycle = ktime_add_ns(cycle, entry->interval);
+ 		cycletime = cycle;
+-		if (!cycletime) {
+-			err = -EINVAL;
+-			goto chain_put;
+-		}
+ 	}
+ 	p->tcfg_cycletime = cycletime;
++	p->tcfg_cycletime_ext = cycletime_ext;
+ 
+-	if (tb[TCA_GATE_CYCLE_TIME_EXT])
+-		p->tcfg_cycletime_ext =
+-			nla_get_u64(tb[TCA_GATE_CYCLE_TIME_EXT]);
+-
+-	gate_setup_timer(gact, basetime, tk_offset, clockid,
+-			 ret == ACT_P_CREATED);
++	if (need_cancel || ret == ACT_P_CREATED)
++		gate_setup_timer(gact, timer_clockid, tko);
+ 	p->tcfg_priority = prio;
+ 	p->tcfg_flags = gflags;
+-	gate_get_start_time(gact, &start);
++	p->tcfg_basetime = basetime;
++	p->tcfg_clockid = timer_clockid;
++	gate_get_start_time(gact, p, &start);
++
++	old_p = rcu_replace_pointer(gact->param, p,
++				    lockdep_is_held(&gact->tcf_lock));
+ 
+ 	gact->current_close_time = start;
+ 	gact->current_gate_status = GATE_ACT_GATE_OPEN | GATE_ACT_PENDING;
+@@ -440,11 +535,15 @@ static int tcf_gate_init(struct net *net, struct nlattr *nla,
+ 	if (goto_ch)
+ 		tcf_chain_put_by_act(goto_ch);
+ 
++	if (old_p)
++		call_rcu(&old_p->rcu, tcf_gate_params_free_rcu);
++
+ 	return ret;
+ 
++err_free:
++	release_entry_list(&p->entries);
++	kfree(p);
+ chain_put:
+-	spin_unlock_bh(&gact->tcf_lock);
+-
+ 	if (goto_ch)
+ 		tcf_chain_put_by_act(goto_ch);
+ release_idr:
+@@ -452,21 +551,29 @@ release_idr:
+ 	 * without taking tcf_lock.
+ 	 */
+ 	if (ret == ACT_P_CREATED)
+-		gate_setup_timer(gact, gact->param.tcfg_basetime,
+-				 gact->tk_offset, gact->param.tcfg_clockid,
+-				 true);
++		gate_setup_timer(gact, timer_clockid, tko);
++
+ 	tcf_idr_release(*a, bind);
+ 	return err;
+ }
+ 
++static void tcf_gate_params_free_rcu(struct rcu_head *head)
++{
++	struct tcf_gate_params *p = container_of(head, struct tcf_gate_params, rcu);
++
++	release_entry_list(&p->entries);
++	kfree(p);
++}
++
+ static void tcf_gate_cleanup(struct tc_action *a)
+ {
+ 	struct tcf_gate *gact = to_gate(a);
+ 	struct tcf_gate_params *p;
+ 
+-	p = &gact->param;
+ 	hrtimer_cancel(&gact->hitimer);
+-	release_entry_list(&p->entries);
++	p = rcu_dereference_protected(gact->param, 1);
++	if (p)
++		call_rcu(&p->rcu, tcf_gate_params_free_rcu);
+ }
+ 
+ static int dumping_entry(struct sk_buff *skb,
+@@ -515,10 +622,9 @@ static int tcf_gate_dump(struct sk_buff *skb, struct tc_action *a,
+ 	struct nlattr *entry_list;
+ 	struct tcf_t t;
+ 
+-	spin_lock_bh(&gact->tcf_lock);
+-	opt.action = gact->tcf_action;
+-
+-	p = &gact->param;
++	rcu_read_lock();
++	opt.action = READ_ONCE(gact->tcf_action);
++	p = rcu_dereference(gact->param);
+ 
+ 	if (nla_put(skb, TCA_GATE_PARMS, sizeof(opt), &opt))
+ 		goto nla_put_failure;
+@@ -558,12 +664,12 @@ static int tcf_gate_dump(struct sk_buff *skb, struct tc_action *a,
+ 	tcf_tm_dump(&t, &gact->tcf_tm);
+ 	if (nla_put_64bit(skb, TCA_GATE_TM, sizeof(t), &t, TCA_GATE_PAD))
+ 		goto nla_put_failure;
+-	spin_unlock_bh(&gact->tcf_lock);
++	rcu_read_unlock();
+ 
+ 	return skb->len;
+ 
+ nla_put_failure:
+-	spin_unlock_bh(&gact->tcf_lock);
++	rcu_read_unlock();
+ 	nlmsg_trim(skb, b);
+ 	return -1;
+ }
+diff --git a/net/sched/act_ife.c b/net/sched/act_ife.c
+index 58c1ab02bd0d2b..bf772401b1f412 100644
+--- a/net/sched/act_ife.c
++++ b/net/sched/act_ife.c
+@@ -293,8 +293,8 @@ static int load_metaops_and_vet(u32 metaid, void *val, int len, bool rtnl_held)
+ /* called when adding new meta information
+ */
+ static int __add_metainfo(const struct tcf_meta_ops *ops,
+-			  struct tcf_ife_info *ife, u32 metaid, void *metaval,
+-			  int len, bool atomic, bool exists)
++			  struct tcf_ife_params *p, u32 metaid, void *metaval,
++			  int len, bool atomic)
+ {
+ 	struct tcf_meta_info *mi = NULL;
+ 	int ret = 0;
+@@ -313,45 +313,40 @@ static int __add_metainfo(const struct tcf_meta_ops *ops,
+ 		}
+ 	}
+ 
+-	if (exists)
+-		spin_lock_bh(&ife->tcf_lock);
+-	list_add_tail(&mi->metalist, &ife->metalist);
+-	if (exists)
+-		spin_unlock_bh(&ife->tcf_lock);
++	list_add_tail(&mi->metalist, &p->metalist);
+ 
+ 	return ret;
+ }
+ 
+ static int add_metainfo_and_get_ops(const struct tcf_meta_ops *ops,
+-				    struct tcf_ife_info *ife, u32 metaid,
+-				    bool exists)
++				    struct tcf_ife_params *p, u32 metaid)
+ {
+ 	int ret;
+ 
+ 	if (!try_module_get(ops->owner))
+ 		return -ENOENT;
+-	ret = __add_metainfo(ops, ife, metaid, NULL, 0, true, exists);
++	ret = __add_metainfo(ops, p, metaid, NULL, 0, true);
+ 	if (ret)
+ 		module_put(ops->owner);
+ 	return ret;
+ }
+ 
+-static int add_metainfo(struct tcf_ife_info *ife, u32 metaid, void *metaval,
+-			int len, bool exists)
++static int add_metainfo(struct tcf_ife_params *p, u32 metaid, void *metaval,
++			int len)
+ {
+ 	const struct tcf_meta_ops *ops = find_ife_oplist(metaid);
+ 	int ret;
+ 
+ 	if (!ops)
+ 		return -ENOENT;
+-	ret = __add_metainfo(ops, ife, metaid, metaval, len, false, exists);
++	ret = __add_metainfo(ops, p, metaid, metaval, len, false);
+ 	if (ret)
+ 		/*put back what find_ife_oplist took */
+ 		module_put(ops->owner);
+ 	return ret;
+ }
+ 
+-static int use_all_metadata(struct tcf_ife_info *ife, bool exists)
++static int use_all_metadata(struct tcf_ife_params *p)
+ {
+ 	struct tcf_meta_ops *o;
+ 	int rc = 0;
+@@ -359,7 +354,7 @@ static int use_all_metadata(struct tcf_ife_info *ife, bool exists)
+ 
+ 	read_lock(&ife_mod_lock);
+ 	list_for_each_entry(o, &ifeoplist, list) {
+-		rc = add_metainfo_and_get_ops(o, ife, o->metaid, exists);
++		rc = add_metainfo_and_get_ops(o, p, o->metaid);
+ 		if (rc == 0)
+ 			installed += 1;
+ 	}
+@@ -371,7 +366,7 @@ static int use_all_metadata(struct tcf_ife_info *ife, bool exists)
+ 		return -EINVAL;
+ }
+ 
+-static int dump_metalist(struct sk_buff *skb, struct tcf_ife_info *ife)
++static int dump_metalist(struct sk_buff *skb, struct tcf_ife_params *p)
+ {
+ 	struct tcf_meta_info *e;
+ 	struct nlattr *nest;
+@@ -379,14 +374,14 @@ static int dump_metalist(struct sk_buff *skb, struct tcf_ife_info *ife)
+ 	int total_encoded = 0;
+ 
+ 	/*can only happen on decode */
+-	if (list_empty(&ife->metalist))
++	if (list_empty(&p->metalist))
+ 		return 0;
+ 
+ 	nest = nla_nest_start_noflag(skb, TCA_IFE_METALST);
+ 	if (!nest)
+ 		goto out_nlmsg_trim;
+ 
+-	list_for_each_entry(e, &ife->metalist, metalist) {
++	list_for_each_entry(e, &p->metalist, metalist) {
+ 		if (!e->ops->get(skb, e))
+ 			total_encoded += 1;
+ 	}
+@@ -403,13 +398,11 @@ out_nlmsg_trim:
+ 	return -1;
+ }
+ 
+-/* under ife->tcf_lock */
+-static void _tcf_ife_cleanup(struct tc_action *a)
++static void __tcf_ife_cleanup(struct tcf_ife_params *p)
+ {
+-	struct tcf_ife_info *ife = to_ife(a);
+ 	struct tcf_meta_info *e, *n;
+ 
+-	list_for_each_entry_safe(e, n, &ife->metalist, metalist) {
++	list_for_each_entry_safe(e, n, &p->metalist, metalist) {
+ 		list_del(&e->metalist);
+ 		if (e->metaval) {
+ 			if (e->ops->release)
+@@ -422,18 +415,23 @@ static void _tcf_ife_cleanup(struct tc_action *a)
+ 	}
+ }
+ 
++static void tcf_ife_cleanup_params(struct rcu_head *head)
++{
++	struct tcf_ife_params *p = container_of(head, struct tcf_ife_params,
++						rcu);
++
++	__tcf_ife_cleanup(p);
++	kfree(p);
++}
++
+ static void tcf_ife_cleanup(struct tc_action *a)
+ {
+ 	struct tcf_ife_info *ife = to_ife(a);
+ 	struct tcf_ife_params *p;
+ 
+-	spin_lock_bh(&ife->tcf_lock);
+-	_tcf_ife_cleanup(a);
+-	spin_unlock_bh(&ife->tcf_lock);
+-
+ 	p = rcu_dereference_protected(ife->params, 1);
+ 	if (p)
+-		kfree_rcu(p, rcu);
++		call_rcu(&p->rcu, tcf_ife_cleanup_params);
+ }
+ 
+ static int load_metalist(struct nlattr **tb, bool rtnl_held)
+@@ -455,8 +453,7 @@ static int load_metalist(struct nlattr **tb, bool rtnl_held)
+ 	return 0;
+ }
+ 
+-static int populate_metalist(struct tcf_ife_info *ife, struct nlattr **tb,
+-			     bool exists, bool rtnl_held)
++static int populate_metalist(struct tcf_ife_params *p, struct nlattr **tb)
+ {
+ 	int len = 0;
+ 	int rc = 0;
+@@ -468,7 +465,7 @@ static int populate_metalist(struct tcf_ife_info *ife, struct nlattr **tb,
+ 			val = nla_data(tb[i]);
+ 			len = nla_len(tb[i]);
+ 
+-			rc = add_metainfo(ife, i, val, len, exists);
++			rc = add_metainfo(p, i, val, len);
+ 			if (rc)
+ 				return rc;
+ 		}
+@@ -523,6 +520,7 @@ static int tcf_ife_init(struct net *net, struct nlattr *nla,
+ 	p = kzalloc(sizeof(*p), GFP_KERNEL);
+ 	if (!p)
+ 		return -ENOMEM;
++	INIT_LIST_HEAD(&p->metalist);
+ 
+ 	if (tb[TCA_IFE_METALST]) {
+ 		err = nla_parse_nested_deprecated(tb2, IFE_META_MAX,
+@@ -567,8 +565,6 @@ static int tcf_ife_init(struct net *net, struct nlattr *nla,
+ 	}
+ 
+ 	ife = to_ife(*a);
+-	if (ret == ACT_P_CREATED)
+-		INIT_LIST_HEAD(&ife->metalist);
+ 
+ 	err = tcf_action_check_ctrlact(parm->action, tp, &goto_ch, extack);
+ 	if (err < 0)
+@@ -600,8 +596,7 @@ static int tcf_ife_init(struct net *net, struct nlattr *nla,
+ 	}
+ 
+ 	if (tb[TCA_IFE_METALST]) {
+-		err = populate_metalist(ife, tb2, exists,
+-					!(flags & TCA_ACT_FLAGS_NO_RTNL));
++		err = populate_metalist(p, tb2);
+ 		if (err)
+ 			goto metadata_parse_err;
+ 	} else {
+@@ -610,7 +605,7 @@ static int tcf_ife_init(struct net *net, struct nlattr *nla,
+ 		 * as we can. You better have at least one else we are
+ 		 * going to bail out
+ 		 */
+-		err = use_all_metadata(ife, exists);
++		err = use_all_metadata(p);
+ 		if (err)
+ 			goto metadata_parse_err;
+ 	}
+@@ -626,13 +621,14 @@ static int tcf_ife_init(struct net *net, struct nlattr *nla,
+ 	if (goto_ch)
+ 		tcf_chain_put_by_act(goto_ch);
+ 	if (p)
+-		kfree_rcu(p, rcu);
++		call_rcu(&p->rcu, tcf_ife_cleanup_params);
+ 
+ 	return ret;
+ metadata_parse_err:
+ 	if (goto_ch)
+ 		tcf_chain_put_by_act(goto_ch);
+ release_idr:
++	__tcf_ife_cleanup(p);
+ 	kfree(p);
+ 	tcf_idr_release(*a, bind);
+ 	return err;
+@@ -679,7 +675,7 @@ static int tcf_ife_dump(struct sk_buff *skb, struct tc_action *a, int bind,
+ 	if (nla_put(skb, TCA_IFE_TYPE, 2, &p->eth_type))
+ 		goto nla_put_failure;
+ 
+-	if (dump_metalist(skb, ife)) {
++	if (dump_metalist(skb, p)) {
+ 		/*ignore failure to dump metalist */
+ 		pr_info("Failed to dump metalist\n");
+ 	}
+@@ -693,13 +689,13 @@ nla_put_failure:
+ 	return -1;
+ }
+ 
+-static int find_decode_metaid(struct sk_buff *skb, struct tcf_ife_info *ife,
++static int find_decode_metaid(struct sk_buff *skb, struct tcf_ife_params *p,
+ 			      u16 metaid, u16 mlen, void *mdata)
+ {
+ 	struct tcf_meta_info *e;
+ 
+ 	/* XXX: use hash to speed up */
+-	list_for_each_entry(e, &ife->metalist, metalist) {
++	list_for_each_entry_rcu(e, &p->metalist, metalist) {
+ 		if (metaid == e->metaid) {
+ 			if (e->ops) {
+ 				/* We check for decode presence already */
+@@ -716,10 +712,13 @@ static int tcf_ife_decode(struct sk_buff *skb, const struct tc_action *a,
+ {
+ 	struct tcf_ife_info *ife = to_ife(a);
+ 	int action = ife->tcf_action;
++	struct tcf_ife_params *p;
+ 	u8 *ifehdr_end;
+ 	u8 *tlv_data;
+ 	u16 metalen;
+ 
++	p = rcu_dereference_bh(ife->params);
++
+ 	bstats_update(this_cpu_ptr(ife->common.cpu_bstats), skb);
+ 	tcf_lastuse_update(&ife->tcf_tm);
+ 
+@@ -745,7 +744,7 @@ static int tcf_ife_decode(struct sk_buff *skb, const struct tc_action *a,
+ 			return TC_ACT_SHOT;
+ 		}
+ 
+-		if (find_decode_metaid(skb, ife, mtype, dlen, curr_data)) {
++		if (find_decode_metaid(skb, p, mtype, dlen, curr_data)) {
+ 			/* abuse overlimits to count when we receive metadata
+ 			 * but dont have an ops for it
+ 			 */
+@@ -769,12 +768,12 @@ static int tcf_ife_decode(struct sk_buff *skb, const struct tc_action *a,
+ /*XXX: check if we can do this at install time instead of current
+  * send data path
+ **/
+-static int ife_get_sz(struct sk_buff *skb, struct tcf_ife_info *ife)
++static int ife_get_sz(struct sk_buff *skb, struct tcf_ife_params *p)
+ {
+-	struct tcf_meta_info *e, *n;
++	struct tcf_meta_info *e;
+ 	int tot_run_sz = 0, run_sz = 0;
+ 
+-	list_for_each_entry_safe(e, n, &ife->metalist, metalist) {
++	list_for_each_entry_rcu(e, &p->metalist, metalist) {
+ 		if (e->ops->check_presence) {
+ 			run_sz = e->ops->check_presence(skb, e);
+ 			tot_run_sz += run_sz;
+@@ -795,7 +794,7 @@ static int tcf_ife_encode(struct sk_buff *skb, const struct tc_action *a,
+ 	   OUTERHDR:TOTMETALEN:{TLVHDR:Metadatum:TLVHDR..}:ORIGDATA
+ 	   where ORIGDATA = original ethernet header ...
+ 	 */
+-	u16 metalen = ife_get_sz(skb, ife);
++	u16 metalen = ife_get_sz(skb, p);
+ 	int hdrm = metalen + skb->dev->hard_header_len + IFE_METAHDRLEN;
+ 	unsigned int skboff = 0;
+ 	int new_len = skb->len + hdrm;
+@@ -833,25 +832,21 @@ drop:
+ 	if (!ife_meta)
+ 		goto drop;
+ 
+-	spin_lock(&ife->tcf_lock);
+-
+ 	/* XXX: we dont have a clever way of telling encode to
+ 	 * not repeat some of the computations that are done by
+ 	 * ops->presence_check...
+ 	 */
+-	list_for_each_entry(e, &ife->metalist, metalist) {
++	list_for_each_entry_rcu(e, &p->metalist, metalist) {
+ 		if (e->ops->encode) {
+ 			err = e->ops->encode(skb, (void *)(ife_meta + skboff),
+ 					     e);
+ 		}
+ 		if (err < 0) {
+ 			/* too corrupt to keep around if overwritten */
+-			spin_unlock(&ife->tcf_lock);
+ 			goto drop;
+ 		}
+ 		skboff += err;
+ 	}
+-	spin_unlock(&ife->tcf_lock);
+ 	oethh = (struct ethhdr *)skb->data;
+ 
+ 	if (!is_zero_ether_addr(p->eth_src))
+diff --git a/net/sched/cls_api.c b/net/sched/cls_api.c
+index 7245f39d1e6529..a90a7b01f3f36d 100644
+--- a/net/sched/cls_api.c
++++ b/net/sched/cls_api.c
+@@ -2151,6 +2151,11 @@ static bool is_qdisc_ingress(__u32 classid)
+ 	return (TC_H_MIN(classid) == TC_H_MIN(TC_H_MIN_INGRESS));
+ }
+ 
++static bool is_ingress_or_clsact(struct tcf_block *block, struct Qdisc *q)
++{
++	return tcf_block_shared(block) || (q && !!(q->flags & TCQ_F_INGRESS));
++}
++
+ static int tc_new_tfilter(struct sk_buff *skb, struct nlmsghdr *n,
+ 			  struct netlink_ext_ack *extack)
+ {
+@@ -2344,6 +2349,8 @@ replay:
+ 		flags |= TCA_ACT_FLAGS_NO_RTNL;
+ 	if (is_qdisc_ingress(parent))
+ 		flags |= TCA_ACT_FLAGS_AT_INGRESS;
++	if (is_ingress_or_clsact(block, q))
++		flags |= TCA_ACT_FLAGS_AT_INGRESS_OR_CLSACT;
+ 	err = tp->ops->change(net, skb, tp, cl, t->tcm_handle, tca, &fh,
+ 			      flags, extack);
+ 	if (err == 0) {
+diff --git a/net/sched/sch_ets.c b/net/sched/sch_ets.c
+index 6ff619277ffd9e..0a5768d98acac5 100644
+--- a/net/sched/sch_ets.c
++++ b/net/sched/sch_ets.c
+@@ -115,12 +115,12 @@ static void ets_offload_change(struct Qdisc *sch)
+ 	struct ets_sched *q = qdisc_priv(sch);
+ 	struct tc_ets_qopt_offload qopt;
+ 	unsigned int w_psum_prev = 0;
+-	unsigned int q_psum = 0;
+-	unsigned int q_sum = 0;
+ 	unsigned int quantum;
+ 	unsigned int w_psum;
+ 	unsigned int weight;
+ 	unsigned int i;
++	u64 q_psum = 0;
++	u64 q_sum = 0;
+ 
+ 	if (!tc_can_offload(dev) || !dev->netdev_ops->ndo_setup_tc)
+ 		return;
+@@ -138,8 +138,12 @@ static void ets_offload_change(struct Qdisc *sch)
+ 
+ 	for (i = 0; i < q->nbands; i++) {
+ 		quantum = q->classes[i].quantum;
+-		q_psum += quantum;
+-		w_psum = quantum ? q_psum * 100 / q_sum : 0;
++		if (quantum) {
++			q_psum += quantum;
++			w_psum = div64_u64(q_psum * 100, q_sum);
++		} else {
++			w_psum = 0;
++		}
+ 		weight = w_psum - w_psum_prev;
+ 		w_psum_prev = w_psum;
+ 
+diff --git a/net/sched/sch_generic.c b/net/sched/sch_generic.c
+index c1c67da2d3fc43..714e51f8d46e94 100644
+--- a/net/sched/sch_generic.c
++++ b/net/sched/sch_generic.c
+@@ -1290,33 +1290,6 @@ static void dev_deactivate_queue(struct net_device *dev,
+ 	}
+ }
+ 
+-static void dev_reset_queue(struct net_device *dev,
+-			    struct netdev_queue *dev_queue,
+-			    void *_unused)
+-{
+-	struct Qdisc *qdisc;
+-	bool nolock;
+-
+-	qdisc = rtnl_dereference(dev_queue->qdisc_sleeping);
+-	if (!qdisc)
+-		return;
+-
+-	nolock = qdisc->flags & TCQ_F_NOLOCK;
+-
+-	if (nolock)
+-		spin_lock_bh(&qdisc->seqlock);
+-	spin_lock_bh(qdisc_lock(qdisc));
+-
+-	qdisc_reset(qdisc);
+-
+-	spin_unlock_bh(qdisc_lock(qdisc));
+-	if (nolock) {
+-		clear_bit(__QDISC_STATE_MISSED, &qdisc->state);
+-		clear_bit(__QDISC_STATE_DRAINING, &qdisc->state);
+-		spin_unlock_bh(&qdisc->seqlock);
+-	}
+-}
+-
+ static bool some_qdisc_is_busy(struct net_device *dev)
+ {
+ 	unsigned int i;
+diff --git a/net/sched/sch_ingress.c b/net/sched/sch_ingress.c
+index 8dde3548dc11cb..70d668cb0db816 100644
+--- a/net/sched/sch_ingress.c
++++ b/net/sched/sch_ingress.c
+@@ -113,14 +113,15 @@ static void ingress_destroy(struct Qdisc *sch)
+ {
+ 	struct ingress_sched_data *q = qdisc_priv(sch);
+ 	struct net_device *dev = qdisc_dev(sch);
+-	struct bpf_mprog_entry *entry = rtnl_dereference(dev->tcx_ingress);
++	struct bpf_mprog_entry *entry;
+ 
+ 	if (sch->parent != TC_H_INGRESS)
+ 		return;
+ 
+ 	tcf_block_put_ext(q->block, sch, &q->block_info);
+ 
+-	if (entry) {
++	if (mini_qdisc_pair_inited(&q->miniqp)) {
++		entry = rtnl_dereference(dev->tcx_ingress);
+ 		tcx_miniq_dec(entry);
+ 		if (!tcx_entry_is_active(entry)) {
+ 			tcx_entry_update(dev, NULL, true);
+@@ -289,10 +290,9 @@ static int clsact_init(struct Qdisc *sch, struct nlattr *opt,
+ 
+ static void clsact_destroy(struct Qdisc *sch)
+ {
++	struct bpf_mprog_entry *ingress_entry, *egress_entry;
+ 	struct clsact_sched_data *q = qdisc_priv(sch);
+ 	struct net_device *dev = qdisc_dev(sch);
+-	struct bpf_mprog_entry *ingress_entry = rtnl_dereference(dev->tcx_ingress);
+-	struct bpf_mprog_entry *egress_entry = rtnl_dereference(dev->tcx_egress);
+ 
+ 	if (sch->parent != TC_H_CLSACT)
+ 		return;
+@@ -300,7 +300,8 @@ static void clsact_destroy(struct Qdisc *sch)
+ 	tcf_block_put_ext(q->ingress_block, sch, &q->ingress_block_info);
+ 	tcf_block_put_ext(q->egress_block, sch, &q->egress_block_info);
+ 
+-	if (ingress_entry) {
++	if (mini_qdisc_pair_inited(&q->miniqp_ingress)) {
++		ingress_entry = rtnl_dereference(dev->tcx_ingress);
+ 		tcx_miniq_dec(ingress_entry);
+ 		if (!tcx_entry_is_active(ingress_entry)) {
+ 			tcx_entry_update(dev, NULL, true);
+@@ -308,7 +309,8 @@ static void clsact_destroy(struct Qdisc *sch)
+ 		}
+ 	}
+ 
+-	if (egress_entry) {
++	if (mini_qdisc_pair_inited(&q->miniqp_egress)) {
++		egress_entry = rtnl_dereference(dev->tcx_egress);
+ 		tcx_miniq_dec(egress_entry);
+ 		if (!tcx_entry_is_active(egress_entry)) {
+ 			tcx_entry_update(dev, NULL, false);
+diff --git a/net/sched/sch_teql.c b/net/sched/sch_teql.c
+index 0a7856e14a975d..efcca269662139 100644
+--- a/net/sched/sch_teql.c
++++ b/net/sched/sch_teql.c
+@@ -146,15 +146,12 @@ teql_destroy(struct Qdisc *sch)
+ 					master->slaves = NEXT_SLAVE(q);
+ 					if (q == master->slaves) {
+ 						struct netdev_queue *txq;
+-						spinlock_t *root_lock;
+ 
+ 						txq = netdev_get_tx_queue(master->dev, 0);
+ 						master->slaves = NULL;
+ 
+-						root_lock = qdisc_root_sleeping_lock(rtnl_dereference(txq->qdisc));
+-						spin_lock_bh(root_lock);
+-						qdisc_reset(rtnl_dereference(txq->qdisc));
+-						spin_unlock_bh(root_lock);
++						dev_reset_queue(master->dev,
++								txq, NULL);
+ 					}
+ 				}
+ 				skb_queue_purge(&dat->q);
+@@ -315,6 +312,7 @@ restart:
+ 			if (__netif_tx_trylock(slave_txq)) {
+ 				unsigned int length = qdisc_pkt_len(skb);
+ 
++				skb->dev = slave;
+ 				if (!netif_xmit_frozen_or_stopped(slave_txq) &&
+ 				    netdev_start_xmit(skb, slave, slave_txq, false) ==
+ 				    NETDEV_TX_OK) {
+diff --git a/net/smc/af_smc.c b/net/smc/af_smc.c
+index b3bfd0f18d4180..0e9a3b8da6a63b 100644
+--- a/net/smc/af_smc.c
++++ b/net/smc/af_smc.c
+@@ -124,7 +124,14 @@ static struct sock *smc_tcp_syn_recv_sock(const struct sock *sk,
+ 	struct smc_sock *smc;
+ 	struct sock *child;
+ 
+-	smc = smc_clcsock_user_data(sk);
++	rcu_read_lock();
++	smc = smc_clcsock_user_data_rcu(sk);
++	if (!smc || !refcount_inc_not_zero(&smc->sk.sk_refcnt)) {
++		rcu_read_unlock();
++		smc = NULL;
++		goto drop;
++	}
++	rcu_read_unlock();
+ 
+ 	if (READ_ONCE(sk->sk_ack_backlog) + atomic_read(&smc->queued_smc_hs) >
+ 				sk->sk_max_ack_backlog)
+@@ -146,11 +153,14 @@ static struct sock *smc_tcp_syn_recv_sock(const struct sock *sk,
+ 		if (inet_csk(child)->icsk_af_ops == inet_csk(sk)->icsk_af_ops)
+ 			inet_csk(child)->icsk_af_ops = smc->ori_af_ops;
+ 	}
++	sock_put(&smc->sk);
+ 	return child;
+ 
+ drop:
+ 	dst_release(dst);
+ 	tcp_listendrop(sk);
++	if (smc)
++		sock_put(&smc->sk);
+ 	return NULL;
+ }
+ 
+@@ -249,7 +259,7 @@ static void smc_fback_restore_callbacks(struct smc_sock *smc)
+ 	struct sock *clcsk = smc->clcsock->sk;
+ 
+ 	write_lock_bh(&clcsk->sk_callback_lock);
+-	clcsk->sk_user_data = NULL;
++	rcu_assign_sk_user_data(clcsk, NULL);
+ 
+ 	smc_clcsock_restore_cb(&clcsk->sk_state_change, &smc->clcsk_state_change);
+ 	smc_clcsock_restore_cb(&clcsk->sk_data_ready, &smc->clcsk_data_ready);
+@@ -882,7 +892,7 @@ static void smc_fback_replace_callbacks(struct smc_sock *smc)
+ 	struct sock *clcsk = smc->clcsock->sk;
+ 
+ 	write_lock_bh(&clcsk->sk_callback_lock);
+-	clcsk->sk_user_data = (void *)((uintptr_t)smc | SK_USER_DATA_NOCOPY);
++	__rcu_assign_sk_user_data_with_flags(clcsk, smc, SK_USER_DATA_NOCOPY);
+ 
+ 	smc_clcsock_replace_cb(&clcsk->sk_state_change, smc_fback_state_change,
+ 			       &smc->clcsk_state_change);
+@@ -2651,8 +2661,8 @@ static int smc_listen(struct socket *sock, int backlog)
+ 	 * smc-specific sk_data_ready function
+ 	 */
+ 	write_lock_bh(&smc->clcsock->sk->sk_callback_lock);
+-	smc->clcsock->sk->sk_user_data =
+-		(void *)((uintptr_t)smc | SK_USER_DATA_NOCOPY);
++	__rcu_assign_sk_user_data_with_flags(smc->clcsock->sk, smc,
++					     SK_USER_DATA_NOCOPY);
+ 	smc_clcsock_replace_cb(&smc->clcsock->sk->sk_data_ready,
+ 			       smc_clcsock_data_ready, &smc->clcsk_data_ready);
+ 	write_unlock_bh(&smc->clcsock->sk->sk_callback_lock);
+@@ -2673,10 +2683,11 @@ static int smc_listen(struct socket *sock, int backlog)
+ 		write_lock_bh(&smc->clcsock->sk->sk_callback_lock);
+ 		smc_clcsock_restore_cb(&smc->clcsock->sk->sk_data_ready,
+ 				       &smc->clcsk_data_ready);
+-		smc->clcsock->sk->sk_user_data = NULL;
++		rcu_assign_sk_user_data(smc->clcsock->sk, NULL);
+ 		write_unlock_bh(&smc->clcsock->sk->sk_callback_lock);
+ 		goto out;
+ 	}
++	sock_set_flag(sk, SOCK_RCU_FREE);
+ 	sk->sk_max_ack_backlog = backlog;
+ 	sk->sk_ack_backlog = 0;
+ 	sk->sk_state = SMC_LISTEN;
+diff --git a/net/smc/smc.h b/net/smc/smc.h
+index 36699ba5518874..49bf6971610dfe 100644
+--- a/net/smc/smc.h
++++ b/net/smc/smc.h
+@@ -304,6 +304,11 @@ static inline struct smc_sock *smc_clcsock_user_data(const struct sock *clcsk)
+ 	       ((uintptr_t)clcsk->sk_user_data & ~SK_USER_DATA_NOCOPY);
+ }
+ 
++static inline struct smc_sock *smc_clcsock_user_data_rcu(const struct sock *clcsk)
++{
++	return (struct smc_sock *)rcu_dereference_sk_user_data(clcsk);
++}
++
+ /* save target_cb in saved_cb, and replace target_cb with new_cb */
+ static inline void smc_clcsock_replace_cb(void (**target_cb)(struct sock *),
+ 					  void (*new_cb)(struct sock *),
+diff --git a/net/smc/smc_close.c b/net/smc/smc_close.c
+index 10219f55aad14d..bb0313ef5f7c1b 100644
+--- a/net/smc/smc_close.c
++++ b/net/smc/smc_close.c
+@@ -218,7 +218,7 @@ again:
+ 			write_lock_bh(&smc->clcsock->sk->sk_callback_lock);
+ 			smc_clcsock_restore_cb(&smc->clcsock->sk->sk_data_ready,
+ 					       &smc->clcsk_data_ready);
+-			smc->clcsock->sk->sk_user_data = NULL;
++			rcu_assign_sk_user_data(smc->clcsock->sk, NULL);
+ 			write_unlock_bh(&smc->clcsock->sk->sk_callback_lock);
+ 			rc = kernel_sock_shutdown(smc->clcsock, SHUT_RDWR);
+ 		}
+diff --git a/net/sunrpc/cache.c b/net/sunrpc/cache.c
+index cb6a6bc9fea77d..447d2a0b75fd05 100644
+--- a/net/sunrpc/cache.c
++++ b/net/sunrpc/cache.c
+@@ -1052,14 +1052,25 @@ static int cache_release(struct inode *inode, struct file *filp,
+ 	struct cache_reader *rp = filp->private_data;
+ 
+ 	if (rp) {
++		struct cache_request *rq = NULL;
++
+ 		spin_lock(&queue_lock);
+ 		if (rp->offset) {
+ 			struct cache_queue *cq;
+-			for (cq= &rp->q; &cq->list != &cd->queue;
+-			     cq = list_entry(cq->list.next, struct cache_queue, list))
++			for (cq = &rp->q; &cq->list != &cd->queue;
++			     cq = list_entry(cq->list.next,
++					     struct cache_queue, list))
+ 				if (!cq->reader) {
+-					container_of(cq, struct cache_request, q)
+-						->readers--;
++					struct cache_request *cr =
++						container_of(cq,
++						struct cache_request, q);
++					cr->readers--;
++					if (cr->readers == 0 &&
++					    !test_bit(CACHE_PENDING,
++						      &cr->item->flags)) {
++						list_del(&cr->q.list);
++						rq = cr;
++					}
+ 					break;
+ 				}
+ 			rp->offset = 0;
+@@ -1067,9 +1078,14 @@ static int cache_release(struct inode *inode, struct file *filp,
+ 		list_del(&rp->q.list);
+ 		spin_unlock(&queue_lock);
+ 
++		if (rq) {
++			cache_put(rq->item, cd);
++			kfree(rq->buf);
++			kfree(rq);
++		}
++
+ 		filp->private_data = NULL;
+ 		kfree(rp);
+-
+ 	}
+ 	if (filp->f_mode & FMODE_WRITE) {
+ 		atomic_dec(&cd->writers);
+diff --git a/net/sunrpc/xprtrdma/verbs.c b/net/sunrpc/xprtrdma/verbs.c
+index cb909329a5039d..4132a505d742ad 100644
+--- a/net/sunrpc/xprtrdma/verbs.c
++++ b/net/sunrpc/xprtrdma/verbs.c
+@@ -1362,7 +1362,7 @@ void rpcrdma_post_recvs(struct rpcrdma_xprt *r_xprt, int needed, bool temp)
+ 		needed += RPCRDMA_MAX_RECV_BATCH;
+ 
+ 	if (atomic_inc_return(&ep->re_receiving) > 1)
+-		goto out;
++		goto out_dec;
+ 
+ 	/* fast path: all needed reps can be found on the free list */
+ 	wr = NULL;
+@@ -1389,7 +1389,7 @@ void rpcrdma_post_recvs(struct rpcrdma_xprt *r_xprt, int needed, bool temp)
+ 		++count;
+ 	}
+ 	if (!wr)
+-		goto out;
++		goto out_dec;
+ 
+ 	rc = ib_post_recv(ep->re_id->qp, wr,
+ 			  (const struct ib_recv_wr **)&bad_wr);
+@@ -1404,9 +1404,10 @@ void rpcrdma_post_recvs(struct rpcrdma_xprt *r_xprt, int needed, bool temp)
+ 			--count;
+ 		}
+ 	}
++
++out_dec:
+ 	if (atomic_dec_return(&ep->re_receiving) > 0)
+ 		complete(&ep->re_done);
+-
+ out:
+ 	trace_xprtrdma_post_recvs(r_xprt, count);
+ 	ep->re_receive_count += count;
+diff --git a/net/tipc/socket.c b/net/tipc/socket.c
+index bb1118d02f9532..e5931e56ef094e 100644
+--- a/net/tipc/socket.c
++++ b/net/tipc/socket.c
+@@ -2238,6 +2238,8 @@ static bool tipc_sk_filter_connect(struct tipc_sock *tsk, struct sk_buff *skb,
+ 		if (skb_queue_empty(&sk->sk_write_queue))
+ 			break;
+ 		get_random_bytes(&delay, 2);
++		if (tsk->conn_timeout < 4)
++			tsk->conn_timeout = 4;
+ 		delay %= (tsk->conn_timeout / 4);
+ 		delay = msecs_to_jiffies(delay + 100);
+ 		sk_reset_timer(sk, &sk->sk_timer, jiffies + delay);
+diff --git a/net/wireless/core.c b/net/wireless/core.c
+index 0baa4c6ab16940..fac19dab23c641 100644
+--- a/net/wireless/core.c
++++ b/net/wireless/core.c
+@@ -1132,6 +1132,7 @@ void wiphy_unregister(struct wiphy *wiphy)
+ 	/* this has nothing to do now but make sure it's gone */
+ 	cancel_work_sync(&rdev->wiphy_work);
+ 
++	cancel_work_sync(&rdev->rfkill_block);
+ 	cancel_work_sync(&rdev->conn_work);
+ 	flush_work(&rdev->event_work);
+ 	cancel_delayed_work_sync(&rdev->dfs_update_channels_wk);
+diff --git a/net/wireless/pmsr.c b/net/wireless/pmsr.c
+index 841a4516793b19..77cb1de9fc13b4 100644
+--- a/net/wireless/pmsr.c
++++ b/net/wireless/pmsr.c
+@@ -641,6 +641,7 @@ void cfg80211_pmsr_wdev_down(struct wireless_dev *wdev)
+ 	}
+ 	spin_unlock_bh(&wdev->pmsr_lock);
+ 
++	cancel_work_sync(&wdev->pmsr_free_wk);
+ 	if (found)
+ 		cfg80211_pmsr_process_abort(wdev);
+ 
+diff --git a/net/wireless/radiotap.c b/net/wireless/radiotap.c
+index ae2e1a8964611e..9ac97d59f88820 100644
+--- a/net/wireless/radiotap.c
++++ b/net/wireless/radiotap.c
+@@ -239,14 +239,14 @@ int ieee80211_radiotap_iterator_next(
+ 		default:
+ 			if (!iterator->current_namespace ||
+ 			    iterator->_arg_index >= iterator->current_namespace->n_bits) {
+-				if (iterator->current_namespace == &radiotap_ns)
+-					return -ENOENT;
+ 				align = 0;
+ 			} else {
+ 				align = iterator->current_namespace->align_size[iterator->_arg_index].align;
+ 				size = iterator->current_namespace->align_size[iterator->_arg_index].size;
+ 			}
+ 			if (!align) {
++				if (iterator->current_namespace == &radiotap_ns)
++					return -ENOENT;
+ 				/* skip all subsequent data */
+ 				iterator->_arg = iterator->_next_ns_data;
+ 				/* give up on this namespace */
+diff --git a/net/xdp/xsk.c b/net/xdp/xsk.c
+index 569d39f19c5695..9e1ac917f97083 100644
+--- a/net/xdp/xsk.c
++++ b/net/xdp/xsk.c
+@@ -160,26 +160,32 @@ static int xsk_rcv_zc(struct xdp_sock *xs, struct xdp_buff *xdp, u32 len)
+ 	struct xdp_buff_xsk *pos, *tmp;
+ 	struct list_head *xskb_list;
+ 	u32 contd = 0;
++	u32 num_desc;
+ 	int err;
+ 
+-	if (frags)
+-		contd = XDP_PKT_CONTD;
++	if (likely(!frags)) {
++		err = __xsk_rcv_zc(xs, xskb, len, contd);
++		if (err)
++			goto err;
++		return 0;
++	}
+ 
+-	err = __xsk_rcv_zc(xs, xskb, len, contd);
+-	if (err)
++	contd = XDP_PKT_CONTD;
++	num_desc = xdp_get_shared_info_from_buff(xdp)->nr_frags + 1;
++	if (xskq_prod_nb_free(xs->rx, num_desc) < num_desc) {
++		xs->rx_queue_full++;
++		err = -ENOBUFS;
+ 		goto err;
+-	if (likely(!frags))
+-		return 0;
++	}
+ 
++	__xsk_rcv_zc(xs, xskb, len, contd);
+ 	xskb_list = &xskb->pool->xskb_list;
+-	list_for_each_entry_safe(pos, tmp, xskb_list, xskb_list_node) {
++	list_for_each_entry_safe(pos, tmp, xskb_list, list_node) {
+ 		if (list_is_singular(xskb_list))
+ 			contd = 0;
+ 		len = pos->xdp.data_end - pos->xdp.data;
+-		err = __xsk_rcv_zc(xs, pos, len, contd);
+-		if (err)
+-			goto err;
+-		list_del(&pos->xskb_list_node);
++		__xsk_rcv_zc(xs, pos, len, contd);
++		list_del_init(&pos->list_node);
+ 	}
+ 
+ 	return 0;
+diff --git a/net/xdp/xsk_buff_pool.c b/net/xdp/xsk_buff_pool.c
+index 380b0b3f3d8d0c..6789d99fd99e01 100644
+--- a/net/xdp/xsk_buff_pool.c
++++ b/net/xdp/xsk_buff_pool.c
+@@ -100,8 +100,7 @@ struct xsk_buff_pool *xp_create_and_assign_umem(struct xdp_sock *xs,
+ 		xskb = &pool->heads[i];
+ 		xskb->pool = pool;
+ 		xskb->xdp.frame_sz = umem->chunk_size - umem->headroom;
+-		INIT_LIST_HEAD(&xskb->free_list_node);
+-		INIT_LIST_HEAD(&xskb->xskb_list_node);
++		INIT_LIST_HEAD(&xskb->list_node);
+ 		if (pool->unaligned)
+ 			pool->free_heads[i] = xskb;
+ 		else
+@@ -535,8 +534,8 @@ struct xdp_buff *xp_alloc(struct xsk_buff_pool *pool)
+ 	} else {
+ 		pool->free_list_cnt--;
+ 		xskb = list_first_entry(&pool->free_list, struct xdp_buff_xsk,
+-					free_list_node);
+-		list_del_init(&xskb->free_list_node);
++					list_node);
++		list_del_init(&xskb->list_node);
+ 	}
+ 
+ 	xskb->xdp.data = xskb->xdp.data_hard_start + XDP_PACKET_HEADROOM;
+@@ -604,8 +603,8 @@ static u32 xp_alloc_reused(struct xsk_buff_pool *pool, struct xdp_buff **xdp, u3
+ 
+ 	i = nb_entries;
+ 	while (i--) {
+-		xskb = list_first_entry(&pool->free_list, struct xdp_buff_xsk, free_list_node);
+-		list_del_init(&xskb->free_list_node);
++		xskb = list_first_entry(&pool->free_list, struct xdp_buff_xsk, list_node);
++		list_del_init(&xskb->list_node);
+ 
+ 		*xdp = &xskb->xdp;
+ 		xdp++;
+@@ -656,11 +655,11 @@ EXPORT_SYMBOL(xp_can_alloc);
+ 
+ void xp_free(struct xdp_buff_xsk *xskb)
+ {
+-	if (!list_empty(&xskb->free_list_node))
++	if (!list_empty(&xskb->list_node))
+ 		return;
+ 
+ 	xskb->pool->free_list_cnt++;
+-	list_add(&xskb->free_list_node, &xskb->pool->free_list);
++	list_add(&xskb->list_node, &xskb->pool->free_list);
+ }
+ EXPORT_SYMBOL(xp_free);
+ 
+diff --git a/rust/kernel/kunit.rs b/rust/kernel/kunit.rs
+index 722655b2d62df7..f33d8f5f1851a6 100644
+--- a/rust/kernel/kunit.rs
++++ b/rust/kernel/kunit.rs
+@@ -13,6 +13,10 @@ use core::{ffi::c_void, fmt};
+ /// Public but hidden since it should only be used from KUnit generated code.
+ #[doc(hidden)]
+ pub fn err(args: fmt::Arguments<'_>) {
++    // `args` is unused if `CONFIG_PRINTK` is not set - this avoids a build-time warning.
++    #[cfg(not(CONFIG_PRINTK))]
++    let _ = args;
++
+     // SAFETY: The format string is null-terminated and the `%pA` specifier matches the argument we
+     // are passing.
+     #[cfg(CONFIG_PRINTK)]
+@@ -29,6 +33,10 @@ pub fn err(args: fmt::Arguments<'_>) {
+ /// Public but hidden since it should only be used from KUnit generated code.
+ #[doc(hidden)]
+ pub fn info(args: fmt::Arguments<'_>) {
++    // `args` is unused if `CONFIG_PRINTK` is not set - this avoids a build-time warning.
++    #[cfg(not(CONFIG_PRINTK))]
++    let _ = args;
++
+     // SAFETY: The format string is null-terminated and the `%pA` specifier matches the argument we
+     // are passing.
+     #[cfg(CONFIG_PRINTK)]
+diff --git a/security/apparmor/apparmorfs.c b/security/apparmor/apparmorfs.c
+index 6885ecd4afddca..157ebdb100c00b 100644
+--- a/security/apparmor/apparmorfs.c
++++ b/security/apparmor/apparmorfs.c
+@@ -32,6 +32,7 @@
+ #include "include/crypto.h"
+ #include "include/ipc.h"
+ #include "include/label.h"
++#include "include/lib.h"
+ #include "include/policy.h"
+ #include "include/policy_ns.h"
+ #include "include/resource.h"
+@@ -62,6 +63,7 @@
+  * securityfs and apparmorfs filesystems.
+  */
+ 
++#define IREF_POISON 101
+ 
+ /*
+  * support fns
+@@ -79,7 +81,7 @@ static void rawdata_f_data_free(struct rawdata_f_data *private)
+ 	if (!private)
+ 		return;
+ 
+-	aa_put_loaddata(private->loaddata);
++	aa_put_i_loaddata(private->loaddata);
+ 	kvfree(private);
+ }
+ 
+@@ -153,6 +155,71 @@ static int aafs_show_path(struct seq_file *seq, struct dentry *dentry)
+ 	return 0;
+ }
+ 
++static struct aa_ns *get_ns_common_ref(struct aa_common_ref *ref)
++{
++	if (ref) {
++		struct aa_label *reflabel = container_of(ref, struct aa_label,
++							 count);
++		return aa_get_ns(labels_ns(reflabel));
++	}
++
++	return NULL;
++}
++
++static struct aa_proxy *get_proxy_common_ref(struct aa_common_ref *ref)
++{
++	if (ref)
++		return aa_get_proxy(container_of(ref, struct aa_proxy, count));
++
++	return NULL;
++}
++
++static struct aa_loaddata *get_loaddata_common_ref(struct aa_common_ref *ref)
++{
++	if (ref)
++		return aa_get_i_loaddata(container_of(ref, struct aa_loaddata,
++						      count));
++	return NULL;
++}
++
++static void aa_put_common_ref(struct aa_common_ref *ref)
++{
++	if (!ref)
++		return;
++
++	switch (ref->reftype) {
++	case REF_RAWDATA:
++		aa_put_i_loaddata(container_of(ref, struct aa_loaddata,
++					       count));
++		break;
++	case REF_PROXY:
++		aa_put_proxy(container_of(ref, struct aa_proxy,
++					  count));
++		break;
++	case REF_NS:
++		/* ns count is held on its unconfined label */
++		aa_put_ns(labels_ns(container_of(ref, struct aa_label, count)));
++		break;
++	default:
++		AA_BUG(true, "unknown refcount type");
++		break;
++	}
++}
++
++static void aa_get_common_ref(struct aa_common_ref *ref)
++{
++	kref_get(&ref->count);
++}
++
++static void aafs_evict(struct inode *inode)
++{
++	struct aa_common_ref *ref = inode->i_private;
++
++	clear_inode(inode);
++	aa_put_common_ref(ref);
++	inode->i_private = (void *) IREF_POISON;
++}
++
+ static void aafs_free_inode(struct inode *inode)
+ {
+ 	if (S_ISLNK(inode->i_mode))
+@@ -162,6 +229,7 @@ static void aafs_free_inode(struct inode *inode)
+ 
+ static const struct super_operations aafs_super_ops = {
+ 	.statfs = simple_statfs,
++	.evict_inode = aafs_evict,
+ 	.free_inode = aafs_free_inode,
+ 	.show_path = aafs_show_path,
+ };
+@@ -262,7 +330,8 @@ static int __aafs_setup_d_inode(struct inode *dir, struct dentry *dentry,
+  * aafs_remove(). Will return ERR_PTR on failure.
+  */
+ static struct dentry *aafs_create(const char *name, umode_t mode,
+-				  struct dentry *parent, void *data, void *link,
++				  struct dentry *parent,
++				  struct aa_common_ref *data, void *link,
+ 				  const struct file_operations *fops,
+ 				  const struct inode_operations *iops)
+ {
+@@ -299,6 +368,9 @@ static struct dentry *aafs_create(const char *name, umode_t mode,
+ 		goto fail_dentry;
+ 	inode_unlock(dir);
+ 
++	if (data)
++		aa_get_common_ref(data);
++
+ 	return dentry;
+ 
+ fail_dentry:
+@@ -323,7 +395,8 @@ fail_lock:
+  * see aafs_create
+  */
+ static struct dentry *aafs_create_file(const char *name, umode_t mode,
+-				       struct dentry *parent, void *data,
++				       struct dentry *parent,
++				       struct aa_common_ref *data,
+ 				       const struct file_operations *fops)
+ {
+ 	return aafs_create(name, mode, parent, data, NULL, fops, NULL);
+@@ -404,7 +477,8 @@ static struct aa_loaddata *aa_simple_write_to_buffer(const char __user *userbuf,
+ 
+ 	data->size = copy_size;
+ 	if (copy_from_user(data->data, userbuf, copy_size)) {
+-		aa_put_loaddata(data);
++		/* trigger free - don't need to put pcount */
++		aa_put_i_loaddata(data);
+ 		return ERR_PTR(-EFAULT);
+ 	}
+ 
+@@ -412,7 +486,8 @@ static struct aa_loaddata *aa_simple_write_to_buffer(const char __user *userbuf,
+ }
+ 
+ static ssize_t policy_update(u32 mask, const char __user *buf, size_t size,
+-			     loff_t *pos, struct aa_ns *ns)
++			     loff_t *pos, struct aa_ns *ns,
++			     const struct cred *ocred)
+ {
+ 	struct aa_loaddata *data;
+ 	struct aa_label *label;
+@@ -423,7 +498,7 @@ static ssize_t policy_update(u32 mask, const char __user *buf, size_t size,
+ 	/* high level check about policy management - fine grained in
+ 	 * below after unpack
+ 	 */
+-	error = aa_may_manage_policy(current_cred(), label, ns, mask);
++	error = aa_may_manage_policy(current_cred(), label, ns, ocred, mask);
+ 	if (error)
+ 		goto end_section;
+ 
+@@ -431,7 +506,10 @@ static ssize_t policy_update(u32 mask, const char __user *buf, size_t size,
+ 	error = PTR_ERR(data);
+ 	if (!IS_ERR(data)) {
+ 		error = aa_replace_profiles(ns, label, mask, data);
+-		aa_put_loaddata(data);
++		/* put pcount, which will put count and free if no
++		 * profiles referencing it.
++		 */
++		aa_put_profile_loaddata(data);
+ 	}
+ end_section:
+ 	end_current_label_crit_section(label);
+@@ -443,8 +521,9 @@ end_section:
+ static ssize_t profile_load(struct file *f, const char __user *buf, size_t size,
+ 			    loff_t *pos)
+ {
+-	struct aa_ns *ns = aa_get_ns(f->f_inode->i_private);
+-	int error = policy_update(AA_MAY_LOAD_POLICY, buf, size, pos, ns);
++	struct aa_ns *ns = get_ns_common_ref(f->f_inode->i_private);
++	int error = policy_update(AA_MAY_LOAD_POLICY, buf, size, pos, ns,
++				  f->f_cred);
+ 
+ 	aa_put_ns(ns);
+ 
+@@ -460,9 +539,9 @@ static const struct file_operations aa_fs_profile_load = {
+ static ssize_t profile_replace(struct file *f, const char __user *buf,
+ 			       size_t size, loff_t *pos)
+ {
+-	struct aa_ns *ns = aa_get_ns(f->f_inode->i_private);
++	struct aa_ns *ns = get_ns_common_ref(f->f_inode->i_private);
+ 	int error = policy_update(AA_MAY_LOAD_POLICY | AA_MAY_REPLACE_POLICY,
+-				  buf, size, pos, ns);
++				  buf, size, pos, ns, f->f_cred);
+ 	aa_put_ns(ns);
+ 
+ 	return error;
+@@ -480,14 +559,14 @@ static ssize_t profile_remove(struct file *f, const char __user *buf,
+ 	struct aa_loaddata *data;
+ 	struct aa_label *label;
+ 	ssize_t error;
+-	struct aa_ns *ns = aa_get_ns(f->f_inode->i_private);
++	struct aa_ns *ns = get_ns_common_ref(f->f_inode->i_private);
+ 
+ 	label = begin_current_label_crit_section();
+ 	/* high level check about policy management - fine grained in
+ 	 * below after unpack
+ 	 */
+ 	error = aa_may_manage_policy(current_cred(), label, ns,
+-				     AA_MAY_REMOVE_POLICY);
++				     f->f_cred, AA_MAY_REMOVE_POLICY);
+ 	if (error)
+ 		goto out;
+ 
+@@ -501,7 +580,7 @@ static ssize_t profile_remove(struct file *f, const char __user *buf,
+ 	if (!IS_ERR(data)) {
+ 		data->data[size] = 0;
+ 		error = aa_remove_profiles(ns, label, data->data, size);
+-		aa_put_loaddata(data);
++		aa_put_profile_loaddata(data);
+ 	}
+  out:
+ 	end_current_label_crit_section(label);
+@@ -570,7 +649,7 @@ static int ns_revision_open(struct inode *inode, struct file *file)
+ 	if (!rev)
+ 		return -ENOMEM;
+ 
+-	rev->ns = aa_get_ns(inode->i_private);
++	rev->ns = get_ns_common_ref(inode->i_private);
+ 	if (!rev->ns)
+ 		rev->ns = aa_get_current_ns();
+ 	file->private_data = rev;
+@@ -1048,7 +1127,7 @@ static const struct file_operations seq_profile_ ##NAME ##_fops = {	      \
+ static int seq_profile_open(struct inode *inode, struct file *file,
+ 			    int (*show)(struct seq_file *, void *))
+ {
+-	struct aa_proxy *proxy = aa_get_proxy(inode->i_private);
++	struct aa_proxy *proxy = get_proxy_common_ref(inode->i_private);
+ 	int error = single_open(file, show, proxy);
+ 
+ 	if (error) {
+@@ -1240,18 +1319,17 @@ static const struct file_operations seq_rawdata_ ##NAME ##_fops = {	      \
+ static int seq_rawdata_open(struct inode *inode, struct file *file,
+ 			    int (*show)(struct seq_file *, void *))
+ {
+-	struct aa_loaddata *data = __aa_get_loaddata(inode->i_private);
++	struct aa_loaddata *data = get_loaddata_common_ref(inode->i_private);
+ 	int error;
+ 
+ 	if (!data)
+-		/* lost race this ent is being reaped */
+ 		return -ENOENT;
+ 
+ 	error = single_open(file, show, data);
+ 	if (error) {
+ 		AA_BUG(file->private_data &&
+ 		       ((struct seq_file *)file->private_data)->private);
+-		aa_put_loaddata(data);
++		aa_put_i_loaddata(data);
+ 	}
+ 
+ 	return error;
+@@ -1262,7 +1340,7 @@ static int seq_rawdata_release(struct inode *inode, struct file *file)
+ 	struct seq_file *seq = (struct seq_file *) file->private_data;
+ 
+ 	if (seq)
+-		aa_put_loaddata(seq->private);
++		aa_put_i_loaddata(seq->private);
+ 
+ 	return single_release(inode, file);
+ }
+@@ -1376,9 +1454,8 @@ static int rawdata_open(struct inode *inode, struct file *file)
+ 	if (!aa_current_policy_view_capable(NULL))
+ 		return -EACCES;
+ 
+-	loaddata = __aa_get_loaddata(inode->i_private);
++	loaddata = get_loaddata_common_ref(inode->i_private);
+ 	if (!loaddata)
+-		/* lost race: this entry is being reaped */
+ 		return -ENOENT;
+ 
+ 	private = rawdata_f_data_alloc(loaddata->size);
+@@ -1403,7 +1480,7 @@ fail_decompress:
+ 	return error;
+ 
+ fail_private_alloc:
+-	aa_put_loaddata(loaddata);
++	aa_put_i_loaddata(loaddata);
+ 	return error;
+ }
+ 
+@@ -1420,7 +1497,6 @@ static void remove_rawdata_dents(struct aa_loaddata *rawdata)
+ 
+ 	for (i = 0; i < AAFS_LOADDATA_NDENTS; i++) {
+ 		if (!IS_ERR_OR_NULL(rawdata->dents[i])) {
+-			/* no refcounts on i_private */
+ 			aafs_remove(rawdata->dents[i]);
+ 			rawdata->dents[i] = NULL;
+ 		}
+@@ -1463,35 +1539,37 @@ int __aa_fs_create_rawdata(struct aa_ns *ns, struct aa_loaddata *rawdata)
+ 		return PTR_ERR(dir);
+ 	rawdata->dents[AAFS_LOADDATA_DIR] = dir;
+ 
+-	dent = aafs_create_file("abi", S_IFREG | 0444, dir, rawdata,
++	dent = aafs_create_file("abi", S_IFREG | 0444, dir, &rawdata->count,
+ 				      &seq_rawdata_abi_fops);
+ 	if (IS_ERR(dent))
+ 		goto fail;
+ 	rawdata->dents[AAFS_LOADDATA_ABI] = dent;
+ 
+-	dent = aafs_create_file("revision", S_IFREG | 0444, dir, rawdata,
+-				      &seq_rawdata_revision_fops);
++	dent = aafs_create_file("revision", S_IFREG | 0444, dir,
++				&rawdata->count,
++				&seq_rawdata_revision_fops);
+ 	if (IS_ERR(dent))
+ 		goto fail;
+ 	rawdata->dents[AAFS_LOADDATA_REVISION] = dent;
+ 
+ 	if (aa_g_hash_policy) {
+ 		dent = aafs_create_file("sha1", S_IFREG | 0444, dir,
+-					      rawdata, &seq_rawdata_hash_fops);
++					&rawdata->count,
++					&seq_rawdata_hash_fops);
+ 		if (IS_ERR(dent))
+ 			goto fail;
+ 		rawdata->dents[AAFS_LOADDATA_HASH] = dent;
+ 	}
+ 
+ 	dent = aafs_create_file("compressed_size", S_IFREG | 0444, dir,
+-				rawdata,
++				&rawdata->count,
+ 				&seq_rawdata_compressed_size_fops);
+ 	if (IS_ERR(dent))
+ 		goto fail;
+ 	rawdata->dents[AAFS_LOADDATA_COMPRESSED_SIZE] = dent;
+ 
+-	dent = aafs_create_file("raw_data", S_IFREG | 0444,
+-				      dir, rawdata, &rawdata_fops);
++	dent = aafs_create_file("raw_data", S_IFREG | 0444, dir,
++				&rawdata->count, &rawdata_fops);
+ 	if (IS_ERR(dent))
+ 		goto fail;
+ 	rawdata->dents[AAFS_LOADDATA_DATA] = dent;
+@@ -1499,13 +1577,11 @@ int __aa_fs_create_rawdata(struct aa_ns *ns, struct aa_loaddata *rawdata)
+ 
+ 	rawdata->ns = aa_get_ns(ns);
+ 	list_add(&rawdata->list, &ns->rawdata_list);
+-	/* no refcount on inode rawdata */
+ 
+ 	return 0;
+ 
+ fail:
+ 	remove_rawdata_dents(rawdata);
+-
+ 	return PTR_ERR(dent);
+ }
+ #endif /* CONFIG_SECURITY_APPARMOR_EXPORT_BINARY */
+@@ -1529,13 +1605,10 @@ void __aafs_profile_rmdir(struct aa_profile *profile)
+ 		__aafs_profile_rmdir(child);
+ 
+ 	for (i = AAFS_PROF_SIZEOF - 1; i >= 0; --i) {
+-		struct aa_proxy *proxy;
+ 		if (!profile->dents[i])
+ 			continue;
+ 
+-		proxy = d_inode(profile->dents[i])->i_private;
+ 		aafs_remove(profile->dents[i]);
+-		aa_put_proxy(proxy);
+ 		profile->dents[i] = NULL;
+ 	}
+ }
+@@ -1568,14 +1641,7 @@ static struct dentry *create_profile_file(struct dentry *dir, const char *name,
+ 					  struct aa_profile *profile,
+ 					  const struct file_operations *fops)
+ {
+-	struct aa_proxy *proxy = aa_get_proxy(profile->label.proxy);
+-	struct dentry *dent;
+-
+-	dent = aafs_create_file(name, S_IFREG | 0444, dir, proxy, fops);
+-	if (IS_ERR(dent))
+-		aa_put_proxy(proxy);
+-
+-	return dent;
++	return aafs_create_file(name, S_IFREG | 0444, dir, &profile->label.proxy->count, fops);
+ }
+ 
+ #ifdef CONFIG_SECURITY_APPARMOR_EXPORT_BINARY
+@@ -1626,7 +1692,8 @@ static const char *rawdata_get_link_base(struct dentry *dentry,
+ 					 struct delayed_call *done,
+ 					 const char *name)
+ {
+-	struct aa_proxy *proxy = inode->i_private;
++	struct aa_common_ref *ref = inode->i_private;
++	struct aa_proxy *proxy = container_of(ref, struct aa_proxy, count);
+ 	struct aa_label *label;
+ 	struct aa_profile *profile;
+ 	char *target;
+@@ -1768,27 +1835,24 @@ int __aafs_profile_mkdir(struct aa_profile *profile, struct dentry *parent)
+ 	if (profile->rawdata) {
+ 		if (aa_g_hash_policy) {
+ 			dent = aafs_create("raw_sha1", S_IFLNK | 0444, dir,
+-					   profile->label.proxy, NULL, NULL,
+-					   &rawdata_link_sha1_iops);
++					   &profile->label.proxy->count, NULL,
++					   NULL, &rawdata_link_sha1_iops);
+ 			if (IS_ERR(dent))
+ 				goto fail;
+-			aa_get_proxy(profile->label.proxy);
+ 			profile->dents[AAFS_PROF_RAW_HASH] = dent;
+ 		}
+ 		dent = aafs_create("raw_abi", S_IFLNK | 0444, dir,
+-				   profile->label.proxy, NULL, NULL,
++				   &profile->label.proxy->count, NULL, NULL,
+ 				   &rawdata_link_abi_iops);
+ 		if (IS_ERR(dent))
+ 			goto fail;
+-		aa_get_proxy(profile->label.proxy);
+ 		profile->dents[AAFS_PROF_RAW_ABI] = dent;
+ 
+ 		dent = aafs_create("raw_data", S_IFLNK | 0444, dir,
+-				   profile->label.proxy, NULL, NULL,
++				   &profile->label.proxy->count, NULL, NULL,
+ 				   &rawdata_link_data_iops);
+ 		if (IS_ERR(dent))
+ 			goto fail;
+-		aa_get_proxy(profile->label.proxy);
+ 		profile->dents[AAFS_PROF_RAW_DATA] = dent;
+ 	}
+ #endif /*CONFIG_SECURITY_APPARMOR_EXPORT_BINARY */
+@@ -1819,13 +1883,13 @@ static int ns_mkdir_op(struct mnt_idmap *idmap, struct inode *dir,
+ 	int error;
+ 
+ 	label = begin_current_label_crit_section();
+-	error = aa_may_manage_policy(current_cred(), label, NULL,
++	error = aa_may_manage_policy(current_cred(), label, NULL, NULL,
+ 				     AA_MAY_LOAD_POLICY);
+ 	end_current_label_crit_section(label);
+ 	if (error)
+ 		return error;
+ 
+-	parent = aa_get_ns(dir->i_private);
++	parent = get_ns_common_ref(dir->i_private);
+ 	AA_BUG(d_inode(ns_subns_dir(parent)) != dir);
+ 
+ 	/* we have to unlock and then relock to get locking order right
+@@ -1869,13 +1933,13 @@ static int ns_rmdir_op(struct inode *dir, struct dentry *dentry)
+ 	int error;
+ 
+ 	label = begin_current_label_crit_section();
+-	error = aa_may_manage_policy(current_cred(), label, NULL,
++	error = aa_may_manage_policy(current_cred(), label, NULL, NULL,
+ 				     AA_MAY_LOAD_POLICY);
+ 	end_current_label_crit_section(label);
+ 	if (error)
+ 		return error;
+ 
+-	parent = aa_get_ns(dir->i_private);
++	parent = get_ns_common_ref(dir->i_private);
+ 	/* rmdir calls the generic securityfs functions to remove files
+ 	 * from the apparmor dir. It is up to the apparmor ns locking
+ 	 * to avoid races.
+@@ -1945,27 +2009,6 @@ void __aafs_ns_rmdir(struct aa_ns *ns)
+ 
+ 	__aa_fs_list_remove_rawdata(ns);
+ 
+-	if (ns_subns_dir(ns)) {
+-		sub = d_inode(ns_subns_dir(ns))->i_private;
+-		aa_put_ns(sub);
+-	}
+-	if (ns_subload(ns)) {
+-		sub = d_inode(ns_subload(ns))->i_private;
+-		aa_put_ns(sub);
+-	}
+-	if (ns_subreplace(ns)) {
+-		sub = d_inode(ns_subreplace(ns))->i_private;
+-		aa_put_ns(sub);
+-	}
+-	if (ns_subremove(ns)) {
+-		sub = d_inode(ns_subremove(ns))->i_private;
+-		aa_put_ns(sub);
+-	}
+-	if (ns_subrevision(ns)) {
+-		sub = d_inode(ns_subrevision(ns))->i_private;
+-		aa_put_ns(sub);
+-	}
+-
+ 	for (i = AAFS_NS_SIZEOF - 1; i >= 0; --i) {
+ 		aafs_remove(ns->dents[i]);
+ 		ns->dents[i] = NULL;
+@@ -1990,40 +2033,40 @@ static int __aafs_ns_mkdir_entries(struct aa_ns *ns, struct dentry *dir)
+ 		return PTR_ERR(dent);
+ 	ns_subdata_dir(ns) = dent;
+ 
+-	dent = aafs_create_file("revision", 0444, dir, ns,
++	dent = aafs_create_file("revision", 0444, dir,
++				&ns->unconfined->label.count,
+ 				&aa_fs_ns_revision_fops);
+ 	if (IS_ERR(dent))
+ 		return PTR_ERR(dent);
+-	aa_get_ns(ns);
+ 	ns_subrevision(ns) = dent;
+ 
+-	dent = aafs_create_file(".load", 0640, dir, ns,
+-				      &aa_fs_profile_load);
++	dent = aafs_create_file(".load", 0640, dir,
++				&ns->unconfined->label.count,
++				&aa_fs_profile_load);
+ 	if (IS_ERR(dent))
+ 		return PTR_ERR(dent);
+-	aa_get_ns(ns);
+ 	ns_subload(ns) = dent;
+ 
+-	dent = aafs_create_file(".replace", 0640, dir, ns,
+-				      &aa_fs_profile_replace);
++	dent = aafs_create_file(".replace", 0640, dir,
++				&ns->unconfined->label.count,
++				&aa_fs_profile_replace);
+ 	if (IS_ERR(dent))
+ 		return PTR_ERR(dent);
+-	aa_get_ns(ns);
+ 	ns_subreplace(ns) = dent;
+ 
+-	dent = aafs_create_file(".remove", 0640, dir, ns,
+-				      &aa_fs_profile_remove);
++	dent = aafs_create_file(".remove", 0640, dir,
++				&ns->unconfined->label.count,
++				&aa_fs_profile_remove);
+ 	if (IS_ERR(dent))
+ 		return PTR_ERR(dent);
+-	aa_get_ns(ns);
+ 	ns_subremove(ns) = dent;
+ 
+ 	  /* use create_dentry so we can supply private data */
+-	dent = aafs_create("namespaces", S_IFDIR | 0755, dir, ns, NULL, NULL,
+-			   &ns_dir_inode_operations);
++	dent = aafs_create("namespaces", S_IFDIR | 0755, dir,
++			   &ns->unconfined->label.count,
++			   NULL, NULL, &ns_dir_inode_operations);
+ 	if (IS_ERR(dent))
+ 		return PTR_ERR(dent);
+-	aa_get_ns(ns);
+ 	ns_subns_dir(ns) = dent;
+ 
+ 	return 0;
+diff --git a/security/apparmor/include/label.h b/security/apparmor/include/label.h
+index 2a72e6b17d68bc..5aca0f612f8fd6 100644
+--- a/security/apparmor/include/label.h
++++ b/security/apparmor/include/label.h
+@@ -101,7 +101,7 @@ enum label_flags {
+ 
+ struct aa_label;
+ struct aa_proxy {
+-	struct kref count;
++	struct aa_common_ref count;
+ 	struct aa_label __rcu *label;
+ };
+ 
+@@ -121,7 +121,7 @@ struct label_it {
+  * @ent: set of profiles for label, actual size determined by @size
+  */
+ struct aa_label {
+-	struct kref count;
++	struct aa_common_ref count;
+ 	struct rb_node node;
+ 	struct rcu_head rcu;
+ 	struct aa_proxy *proxy;
+@@ -373,7 +373,7 @@ int aa_label_match(struct aa_profile *profile, struct aa_ruleset *rules,
+  */
+ static inline struct aa_label *__aa_get_label(struct aa_label *l)
+ {
+-	if (l && kref_get_unless_zero(&l->count))
++	if (l && kref_get_unless_zero(&l->count.count))
+ 		return l;
+ 
+ 	return NULL;
+@@ -382,7 +382,7 @@ static inline struct aa_label *__aa_get_label(struct aa_label *l)
+ static inline struct aa_label *aa_get_label(struct aa_label *l)
+ {
+ 	if (l)
+-		kref_get(&(l->count));
++		kref_get(&(l->count.count));
+ 
+ 	return l;
+ }
+@@ -402,7 +402,7 @@ static inline struct aa_label *aa_get_label_rcu(struct aa_label __rcu **l)
+ 	rcu_read_lock();
+ 	do {
+ 		c = rcu_dereference(*l);
+-	} while (c && !kref_get_unless_zero(&c->count));
++	} while (c && !kref_get_unless_zero(&c->count.count));
+ 	rcu_read_unlock();
+ 
+ 	return c;
+@@ -442,7 +442,7 @@ static inline struct aa_label *aa_get_newest_label(struct aa_label *l)
+ static inline void aa_put_label(struct aa_label *l)
+ {
+ 	if (l)
+-		kref_put(&l->count, aa_label_kref);
++		kref_put(&l->count.count, aa_label_kref);
+ }
+ 
+ 
+@@ -452,7 +452,7 @@ void aa_proxy_kref(struct kref *kref);
+ static inline struct aa_proxy *aa_get_proxy(struct aa_proxy *proxy)
+ {
+ 	if (proxy)
+-		kref_get(&(proxy->count));
++		kref_get(&(proxy->count.count));
+ 
+ 	return proxy;
+ }
+@@ -460,7 +460,7 @@ static inline struct aa_proxy *aa_get_proxy(struct aa_proxy *proxy)
+ static inline void aa_put_proxy(struct aa_proxy *proxy)
+ {
+ 	if (proxy)
+-		kref_put(&proxy->count, aa_proxy_kref);
++		kref_put(&proxy->count.count, aa_proxy_kref);
+ }
+ 
+ void __aa_proxy_redirect(struct aa_label *orig, struct aa_label *new);
+diff --git a/security/apparmor/include/lib.h b/security/apparmor/include/lib.h
+index 1ec00113a056fc..e76470c8b84c2c 100644
+--- a/security/apparmor/include/lib.h
++++ b/security/apparmor/include/lib.h
+@@ -71,6 +71,18 @@ void aa_info_message(const char *str);
+ /* Security blob offsets */
+ extern struct lsm_blob_sizes apparmor_blob_sizes;
+ 
++enum reftype {
++	REF_NS,
++	REF_PROXY,
++	REF_RAWDATA,
++};
++
++/* common reference count used by data the shows up in aafs */
++struct aa_common_ref {
++	struct kref count;
++	enum reftype reftype;
++};
++
+ /**
+  * aa_strneq - compare null terminated @str to a non null terminated substring
+  * @str: a null terminated string
+diff --git a/security/apparmor/include/match.h b/security/apparmor/include/match.h
+index ae31a8a631fc6a..a86f74b59360af 100644
+--- a/security/apparmor/include/match.h
++++ b/security/apparmor/include/match.h
+@@ -181,6 +181,7 @@ static inline void aa_put_dfa(struct aa_dfa *dfa)
+ #define MATCH_FLAG_DIFF_ENCODE 0x80000000
+ #define MARK_DIFF_ENCODE 0x40000000
+ #define MATCH_FLAG_OOB_TRANSITION 0x20000000
++#define MARK_DIFF_ENCODE_VERIFIED 0x10000000
+ #define MATCH_FLAGS_MASK 0xff000000
+ #define MATCH_FLAGS_VALID (MATCH_FLAG_DIFF_ENCODE | MATCH_FLAG_OOB_TRANSITION)
+ #define MATCH_FLAGS_INVALID (MATCH_FLAGS_MASK & ~MATCH_FLAGS_VALID)
+diff --git a/security/apparmor/include/policy.h b/security/apparmor/include/policy.h
+index bb682d51341299..e486238f2d3384 100644
+--- a/security/apparmor/include/policy.h
++++ b/security/apparmor/include/policy.h
+@@ -337,7 +337,7 @@ static inline aa_state_t ANY_RULE_MEDIATES(struct list_head *head,
+ static inline struct aa_profile *aa_get_profile(struct aa_profile *p)
+ {
+ 	if (p)
+-		kref_get(&(p->label.count));
++		kref_get(&(p->label.count.count));
+ 
+ 	return p;
+ }
+@@ -351,7 +351,7 @@ static inline struct aa_profile *aa_get_profile(struct aa_profile *p)
+  */
+ static inline struct aa_profile *aa_get_profile_not0(struct aa_profile *p)
+ {
+-	if (p && kref_get_unless_zero(&p->label.count))
++	if (p && kref_get_unless_zero(&p->label.count.count))
+ 		return p;
+ 
+ 	return NULL;
+@@ -371,7 +371,7 @@ static inline struct aa_profile *aa_get_profile_rcu(struct aa_profile __rcu **p)
+ 	rcu_read_lock();
+ 	do {
+ 		c = rcu_dereference(*p);
+-	} while (c && !kref_get_unless_zero(&c->label.count));
++	} while (c && !kref_get_unless_zero(&c->label.count.count));
+ 	rcu_read_unlock();
+ 
+ 	return c;
+@@ -384,7 +384,7 @@ static inline struct aa_profile *aa_get_profile_rcu(struct aa_profile __rcu **p)
+ static inline void aa_put_profile(struct aa_profile *p)
+ {
+ 	if (p)
+-		kref_put(&p->label.count, aa_label_kref);
++		kref_put(&p->label.count.count, aa_label_kref);
+ }
+ 
+ static inline int AUDIT_MODE(struct aa_profile *profile)
+@@ -401,7 +401,7 @@ bool aa_policy_admin_capable(const struct cred *subj_cred,
+ 			     struct aa_label *label, struct aa_ns *ns);
+ int aa_may_manage_policy(const struct cred *subj_cred,
+ 			 struct aa_label *label, struct aa_ns *ns,
+-			 u32 mask);
++			 const struct cred *ocred, u32 mask);
+ bool aa_current_policy_view_capable(struct aa_ns *ns);
+ bool aa_current_policy_admin_capable(struct aa_ns *ns);
+ 
+diff --git a/security/apparmor/include/policy_ns.h b/security/apparmor/include/policy_ns.h
+index 33d665516fc116..dabb69bc87e00a 100644
+--- a/security/apparmor/include/policy_ns.h
++++ b/security/apparmor/include/policy_ns.h
+@@ -18,6 +18,8 @@
+ #include "label.h"
+ #include "policy.h"
+ 
++/* Match max depth of user namespaces */
++#define MAX_NS_DEPTH 32
+ 
+ /* struct aa_ns_acct - accounting of profiles in namespace
+  * @max_size: maximum space allowed for all profiles in namespace
+diff --git a/security/apparmor/include/policy_unpack.h b/security/apparmor/include/policy_unpack.h
+index a6f4611ee50cf9..e5a95dc4da1f76 100644
+--- a/security/apparmor/include/policy_unpack.h
++++ b/security/apparmor/include/policy_unpack.h
+@@ -87,17 +87,29 @@ struct aa_ext {
+ 	u32 version;
+ };
+ 
+-/*
+- * struct aa_loaddata - buffer of policy raw_data set
++/* struct aa_loaddata - buffer of policy raw_data set
++ * @count: inode/filesystem refcount - use aa_get_i_loaddata()
++ * @pcount: profile refcount - use aa_get_profile_loaddata()
++ * @list: list the loaddata is on
++ * @work: used to do a delayed cleanup
++ * @dents: refs to dents created in aafs
++ * @ns: the namespace this loaddata was loaded into
++ * @name:
++ * @size: the size of the data that was loaded
++ * @compressed_size: the size of the data when it is compressed
++ * @revision: unique revision count that this data was loaded as
++ * @abi: the abi number the loaddata uses
++ * @hash: a hash of the loaddata, used to help dedup data
+  *
+- * there is no loaddata ref for being on ns list, nor a ref from
+- * d_inode(@dentry) when grab a ref from these, @ns->lock must be held
+- * && __aa_get_loaddata() needs to be used, and the return value
+- * checked, if NULL the loaddata is already being reaped and should be
+- * considered dead.
++ * There is no loaddata ref for being on ns->rawdata_list, so
++ * @ns->lock must be held when walking the list. Dentries and
++ * inode opens hold refs on @count; profiles hold refs on @pcount.
++ * When the last @pcount drops, do_ploaddata_rmfs() removes the
++ * fs entries and drops the associated @count ref.
+  */
+ struct aa_loaddata {
+-	struct kref count;
++	struct aa_common_ref count;
++	struct kref pcount;
+ 	struct list_head list;
+ 	struct work_struct work;
+ 	struct dentry *dents[AAFS_LOADDATA_NDENTS];
+@@ -119,50 +131,53 @@ struct aa_loaddata {
+ int aa_unpack(struct aa_loaddata *udata, struct list_head *lh, const char **ns);
+ 
+ /**
+- * __aa_get_loaddata - get a reference count to uncounted data reference
++ * aa_get_loaddata - get a reference count from a counted data reference
+  * @data: reference to get a count on
+  *
+- * Returns: pointer to reference OR NULL if race is lost and reference is
+- *          being repeated.
+- * Requires: @data->ns->lock held, and the return code MUST be checked
+- *
+- * Use only from inode->i_private and @data->list found references
++ * Returns: pointer to reference
++ * Requires: @data to have a valid reference count on it. It is a bug
++ *           if the race to reap can be encountered when it is used.
+  */
+ static inline struct aa_loaddata *
+-__aa_get_loaddata(struct aa_loaddata *data)
++aa_get_i_loaddata(struct aa_loaddata *data)
+ {
+-	if (data && kref_get_unless_zero(&(data->count)))
+-		return data;
+ 
+-	return NULL;
++	if (data)
++		kref_get(&(data->count.count));
++	return data;
+ }
+ 
++
+ /**
+- * aa_get_loaddata - get a reference count from a counted data reference
++ * aa_get_profile_loaddata - get a profile reference count on loaddata
+  * @data: reference to get a count on
+  *
+- * Returns: point to reference
+- * Requires: @data to have a valid reference count on it. It is a bug
+- *           if the race to reap can be encountered when it is used.
++ * Returns: pointer to reference
++ * Requires: @data to have a valid reference count on it.
+  */
+ static inline struct aa_loaddata *
+-aa_get_loaddata(struct aa_loaddata *data)
++aa_get_profile_loaddata(struct aa_loaddata *data)
+ {
+-	struct aa_loaddata *tmp = __aa_get_loaddata(data);
+-
+-	AA_BUG(data && !tmp);
+-
+-	return tmp;
++	if (data)
++		kref_get(&(data->pcount));
++	return data;
+ }
+ 
+ void __aa_loaddata_update(struct aa_loaddata *data, long revision);
+ bool aa_rawdata_eq(struct aa_loaddata *l, struct aa_loaddata *r);
+ void aa_loaddata_kref(struct kref *kref);
++void aa_ploaddata_kref(struct kref *kref);
+ struct aa_loaddata *aa_loaddata_alloc(size_t size);
+-static inline void aa_put_loaddata(struct aa_loaddata *data)
++static inline void aa_put_i_loaddata(struct aa_loaddata *data)
++{
++	if (data)
++		kref_put(&data->count.count, aa_loaddata_kref);
++}
++
++static inline void aa_put_profile_loaddata(struct aa_loaddata *data)
+ {
+ 	if (data)
+-		kref_put(&data->count, aa_loaddata_kref);
++		kref_put(&data->pcount, aa_ploaddata_kref);
+ }
+ 
+ #if IS_ENABLED(CONFIG_KUNIT)
+diff --git a/security/apparmor/label.c b/security/apparmor/label.c
+index d64c838f5d84e6..73428072a754f1 100644
+--- a/security/apparmor/label.c
++++ b/security/apparmor/label.c
+@@ -52,7 +52,8 @@ static void free_proxy(struct aa_proxy *proxy)
+ 
+ void aa_proxy_kref(struct kref *kref)
+ {
+-	struct aa_proxy *proxy = container_of(kref, struct aa_proxy, count);
++	struct aa_proxy *proxy = container_of(kref, struct aa_proxy,
++					      count.count);
+ 
+ 	free_proxy(proxy);
+ }
+@@ -63,7 +64,8 @@ struct aa_proxy *aa_alloc_proxy(struct aa_label *label, gfp_t gfp)
+ 
+ 	new = kzalloc(sizeof(struct aa_proxy), gfp);
+ 	if (new) {
+-		kref_init(&new->count);
++		kref_init(&new->count.count);
++		new->count.reftype = REF_PROXY;
+ 		rcu_assign_pointer(new->label, aa_get_label(label));
+ 	}
+ 	return new;
+@@ -369,7 +371,8 @@ static void label_free_rcu(struct rcu_head *head)
+ 
+ void aa_label_kref(struct kref *kref)
+ {
+-	struct aa_label *label = container_of(kref, struct aa_label, count);
++	struct aa_label *label = container_of(kref, struct aa_label,
++					      count.count);
+ 	struct aa_ns *ns = labels_ns(label);
+ 
+ 	if (!ns) {
+@@ -406,7 +409,8 @@ bool aa_label_init(struct aa_label *label, int size, gfp_t gfp)
+ 
+ 	label->size = size;			/* doesn't include null */
+ 	label->vec[size] = NULL;		/* null terminate */
+-	kref_init(&label->count);
++	kref_init(&label->count.count);
++	label->count.reftype = REF_NS;		/* for aafs purposes */
+ 	RB_CLEAR_NODE(&label->node);
+ 
+ 	return true;
+diff --git a/security/apparmor/match.c b/security/apparmor/match.c
+index 6f6cdb86f32b5d..29e728f6fbcfb8 100644
+--- a/security/apparmor/match.c
++++ b/security/apparmor/match.c
+@@ -160,9 +160,10 @@ static int verify_dfa(struct aa_dfa *dfa)
+ 	if (state_count == 0)
+ 		goto out;
+ 	for (i = 0; i < state_count; i++) {
+-		if (!(BASE_TABLE(dfa)[i] & MATCH_FLAG_DIFF_ENCODE) &&
+-		    (DEFAULT_TABLE(dfa)[i] >= state_count))
++		if (DEFAULT_TABLE(dfa)[i] >= state_count) {
++			pr_err("AppArmor DFA default state out of bounds");
+ 			goto out;
++		}
+ 		if (BASE_TABLE(dfa)[i] & MATCH_FLAGS_INVALID) {
+ 			pr_err("AppArmor DFA state with invalid match flags");
+ 			goto out;
+@@ -201,16 +202,31 @@ static int verify_dfa(struct aa_dfa *dfa)
+ 		size_t j, k;
+ 
+ 		for (j = i;
+-		     (BASE_TABLE(dfa)[j] & MATCH_FLAG_DIFF_ENCODE) &&
+-		     !(BASE_TABLE(dfa)[j] & MARK_DIFF_ENCODE);
++		     ((BASE_TABLE(dfa)[j] & MATCH_FLAG_DIFF_ENCODE) &&
++		      !(BASE_TABLE(dfa)[j] & MARK_DIFF_ENCODE_VERIFIED));
+ 		     j = k) {
++			if (BASE_TABLE(dfa)[j] & MARK_DIFF_ENCODE)
++				/* loop in current chain */
++				goto out;
+ 			k = DEFAULT_TABLE(dfa)[j];
+ 			if (j == k)
++				/* self loop */
+ 				goto out;
+-			if (k < j)
+-				break;		/* already verified */
+ 			BASE_TABLE(dfa)[j] |= MARK_DIFF_ENCODE;
+ 		}
++		/* move mark to verified */
++		for (j = i;
++		     (BASE_TABLE(dfa)[j] & MATCH_FLAG_DIFF_ENCODE);
++		     j = k) {
++			k = DEFAULT_TABLE(dfa)[j];
++			if (j < i)
++				/* jumps to state/chain that has been
++				 * verified
++				 */
++				break;
++			BASE_TABLE(dfa)[j] &= ~MARK_DIFF_ENCODE;
++			BASE_TABLE(dfa)[j] |= MARK_DIFF_ENCODE_VERIFIED;
++		}
+ 	}
+ 	error = 0;
+ 
+@@ -408,13 +424,18 @@ aa_state_t aa_dfa_match_len(struct aa_dfa *dfa, aa_state_t start,
+ 	if (dfa->tables[YYTD_ID_EC]) {
+ 		/* Equivalence class table defined */
+ 		u8 *equiv = EQUIV_TABLE(dfa);
+-		for (; len; len--)
+-			match_char(state, def, base, next, check,
+-				   equiv[(u8) *str++]);
++		for (; len; len--) {
++			u8 c = equiv[(u8) *str];
++
++			match_char(state, def, base, next, check, c);
++			str++;
++		}
+ 	} else {
+ 		/* default is direct to next state */
+-		for (; len; len--)
+-			match_char(state, def, base, next, check, (u8) *str++);
++		for (; len; len--) {
++			match_char(state, def, base, next, check, (u8) *str);
++			str++;
++		}
+ 	}
+ 
+ 	return state;
+@@ -448,13 +469,18 @@ aa_state_t aa_dfa_match(struct aa_dfa *dfa, aa_state_t start, const char *str)
+ 		/* Equivalence class table defined */
+ 		u8 *equiv = EQUIV_TABLE(dfa);
+ 		/* default is direct to next state */
+-		while (*str)
+-			match_char(state, def, base, next, check,
+-				   equiv[(u8) *str++]);
++		while (*str) {
++			u8 c = equiv[(u8) *str];
++
++			match_char(state, def, base, next, check, c);
++			str++;
++		}
+ 	} else {
+ 		/* default is direct to next state */
+-		while (*str)
+-			match_char(state, def, base, next, check, (u8) *str++);
++		while (*str) {
++			match_char(state, def, base, next, check, (u8) *str);
++			str++;
++		}
+ 	}
+ 
+ 	return state;
+diff --git a/security/apparmor/policy.c b/security/apparmor/policy.c
+index 009fa7cfb6688a..2756fee2442b23 100644
+--- a/security/apparmor/policy.c
++++ b/security/apparmor/policy.c
+@@ -182,19 +182,43 @@ static void __list_remove_profile(struct aa_profile *profile)
+ }
+ 
+ /**
+- * __remove_profile - remove old profile, and children
+- * @profile: profile to be replaced  (NOT NULL)
++ * __remove_profile - remove profile, and children
++ * @profile: profile to be removed  (NOT NULL)
+  *
+  * Requires: namespace list lock be held, or list not be shared
+  */
+ static void __remove_profile(struct aa_profile *profile)
+ {
++	struct aa_profile *curr, *to_remove;
++
+ 	AA_BUG(!profile);
+ 	AA_BUG(!profile->ns);
+ 	AA_BUG(!mutex_is_locked(&profile->ns->lock));
+ 
+ 	/* release any children lists first */
+-	__aa_profile_list_release(&profile->base.profiles);
++	if (!list_empty(&profile->base.profiles)) {
++		curr = list_first_entry(&profile->base.profiles, struct aa_profile, base.list);
++
++		while (curr != profile) {
++
++			while (!list_empty(&curr->base.profiles))
++				curr = list_first_entry(&curr->base.profiles,
++							struct aa_profile, base.list);
++
++			to_remove = curr;
++			if (!list_is_last(&to_remove->base.list,
++					  &aa_deref_parent(curr)->base.profiles))
++				curr = list_next_entry(to_remove, base.list);
++			else
++				curr = aa_deref_parent(curr);
++
++			/* released by free_profile */
++			aa_label_remove(&to_remove->label);
++			__aafs_profile_rmdir(to_remove);
++			__list_remove_profile(to_remove);
++		}
++	}
++
+ 	/* released by free_profile */
+ 	aa_label_remove(&profile->label);
+ 	__aafs_profile_rmdir(profile);
+@@ -312,7 +336,7 @@ void aa_free_profile(struct aa_profile *profile)
+ 	}
+ 
+ 	kfree_sensitive(profile->hash);
+-	aa_put_loaddata(profile->rawdata);
++	aa_put_profile_loaddata(profile->rawdata);
+ 	aa_label_destroy(&profile->label);
+ 
+ 	kfree_sensitive(profile);
+@@ -867,17 +891,44 @@ bool aa_current_policy_admin_capable(struct aa_ns *ns)
+ 	return res;
+ }
+ 
++static bool is_subset_of_obj_privilege(const struct cred *cred,
++				       struct aa_label *label,
++				       const struct cred *ocred)
++{
++	if (cred == ocred)
++		return true;
++
++	if (!aa_label_is_subset(label, cred_label(ocred)))
++		return false;
++	/* don't allow crossing userns for now */
++	if (cred->user_ns != ocred->user_ns)
++		return false;
++	if (!cap_issubset(cred->cap_inheritable, ocred->cap_inheritable))
++		return false;
++	if (!cap_issubset(cred->cap_permitted, ocred->cap_permitted))
++		return false;
++	if (!cap_issubset(cred->cap_effective, ocred->cap_effective))
++		return false;
++	if (!cap_issubset(cred->cap_bset, ocred->cap_bset))
++		return false;
++	if (!cap_issubset(cred->cap_ambient, ocred->cap_ambient))
++		return false;
++	return true;
++}
++
++
+ /**
+  * aa_may_manage_policy - can the current task manage policy
+  * @subj_cred; subjects cred
+  * @label: label to check if it can manage policy
+  * @ns: namespace being managed by @label (may be NULL if @label's ns)
++ * @ocred: object cred if request is coming from an open object
+  * @mask: contains the policy manipulation operation being done
+  *
+  * Returns: 0 if the task is allowed to manipulate policy else error
+  */
+ int aa_may_manage_policy(const struct cred *subj_cred, struct aa_label *label,
+-			 struct aa_ns *ns, u32 mask)
++			 struct aa_ns *ns, const struct cred *ocred, u32 mask)
+ {
+ 	const char *op;
+ 
+@@ -893,6 +944,11 @@ int aa_may_manage_policy(const struct cred *subj_cred, struct aa_label *label,
+ 		return audit_policy(label, op, NULL, NULL, "policy_locked",
+ 				    -EACCES);
+ 
++	if (ocred && !is_subset_of_obj_privilege(subj_cred, label, ocred))
++		return audit_policy(label, op, NULL, NULL,
++				    "not privileged for target profile",
++				    -EACCES);
++
+ 	if (!aa_policy_admin_capable(subj_cred, label, ns))
+ 		return audit_policy(label, op, NULL, NULL, "not policy admin",
+ 				    -EACCES);
+@@ -1064,7 +1120,7 @@ ssize_t aa_replace_profiles(struct aa_ns *policy_ns, struct aa_label *label,
+ 	LIST_HEAD(lh);
+ 
+ 	op = mask & AA_MAY_REPLACE_POLICY ? OP_PROF_REPL : OP_PROF_LOAD;
+-	aa_get_loaddata(udata);
++	aa_get_profile_loaddata(udata);
+ 	/* released below */
+ 	error = aa_unpack(udata, &lh, &ns_name);
+ 	if (error)
+@@ -1091,6 +1147,7 @@ ssize_t aa_replace_profiles(struct aa_ns *policy_ns, struct aa_label *label,
+ 				goto fail;
+ 			}
+ 			ns_name = ent->ns_name;
++			ent->ns_name = NULL;
+ 		} else
+ 			count++;
+ 	}
+@@ -1115,10 +1172,10 @@ ssize_t aa_replace_profiles(struct aa_ns *policy_ns, struct aa_label *label,
+ 			if (aa_rawdata_eq(rawdata_ent, udata)) {
+ 				struct aa_loaddata *tmp;
+ 
+-				tmp = __aa_get_loaddata(rawdata_ent);
++				tmp = aa_get_profile_loaddata(rawdata_ent);
+ 				/* check we didn't fail the race */
+ 				if (tmp) {
+-					aa_put_loaddata(udata);
++					aa_put_profile_loaddata(udata);
+ 					udata = tmp;
+ 					break;
+ 				}
+@@ -1131,7 +1188,7 @@ ssize_t aa_replace_profiles(struct aa_ns *policy_ns, struct aa_label *label,
+ 		struct aa_profile *p;
+ 
+ 		if (aa_g_export_binary)
+-			ent->new->rawdata = aa_get_loaddata(udata);
++			ent->new->rawdata = aa_get_profile_loaddata(udata);
+ 		error = __lookup_replace(ns, ent->new->base.hname,
+ 					 !(mask & AA_MAY_REPLACE_POLICY),
+ 					 &ent->old, &info);
+@@ -1264,7 +1321,7 @@ ssize_t aa_replace_profiles(struct aa_ns *policy_ns, struct aa_label *label,
+ 
+ out:
+ 	aa_put_ns(ns);
+-	aa_put_loaddata(udata);
++	aa_put_profile_loaddata(udata);
+ 	kfree(ns_name);
+ 
+ 	if (error)
+diff --git a/security/apparmor/policy_ns.c b/security/apparmor/policy_ns.c
+index fd5b7afbcb4871..c56ef36baef4b6 100644
+--- a/security/apparmor/policy_ns.c
++++ b/security/apparmor/policy_ns.c
+@@ -260,6 +260,8 @@ static struct aa_ns *__aa_create_ns(struct aa_ns *parent, const char *name,
+ 	AA_BUG(!name);
+ 	AA_BUG(!mutex_is_locked(&parent->lock));
+ 
++	if (parent->level > MAX_NS_DEPTH)
++		return ERR_PTR(-ENOSPC);
+ 	ns = alloc_ns(parent->base.hname, name);
+ 	if (!ns)
+ 		return ERR_PTR(-ENOMEM);
+diff --git a/security/apparmor/policy_unpack.c b/security/apparmor/policy_unpack.c
+index 9b25624285e676..bdc784fafbf74d 100644
+--- a/security/apparmor/policy_unpack.c
++++ b/security/apparmor/policy_unpack.c
+@@ -108,34 +108,48 @@ bool aa_rawdata_eq(struct aa_loaddata *l, struct aa_loaddata *r)
+ 	return memcmp(l->data, r->data, r->compressed_size ?: r->size) == 0;
+ }
+ 
++static void do_loaddata_free(struct aa_loaddata *d)
++{
++	kfree_sensitive(d->hash);
++	kfree_sensitive(d->name);
++	kvfree(d->data);
++	kfree_sensitive(d);
++}
++
++void aa_loaddata_kref(struct kref *kref)
++{
++	struct aa_loaddata *d = container_of(kref, struct aa_loaddata,
++					     count.count);
++
++	do_loaddata_free(d);
++}
++
+ /*
+  * need to take the ns mutex lock which is NOT safe most places that
+  * put_loaddata is called, so we have to delay freeing it
+  */
+-static void do_loaddata_free(struct work_struct *work)
++static void do_ploaddata_rmfs(struct work_struct *work)
+ {
+ 	struct aa_loaddata *d = container_of(work, struct aa_loaddata, work);
+ 	struct aa_ns *ns = aa_get_ns(d->ns);
+ 
+ 	if (ns) {
+ 		mutex_lock_nested(&ns->lock, ns->level);
++		/* remove fs ref to loaddata */
+ 		__aa_fs_remove_rawdata(d);
+ 		mutex_unlock(&ns->lock);
+ 		aa_put_ns(ns);
+ 	}
+-
+-	kfree_sensitive(d->hash);
+-	kfree_sensitive(d->name);
+-	kvfree(d->data);
+-	kfree_sensitive(d);
++	/* called by dropping last pcount, so drop its associated icount */
++	aa_put_i_loaddata(d);
+ }
+ 
+-void aa_loaddata_kref(struct kref *kref)
++void aa_ploaddata_kref(struct kref *kref)
+ {
+-	struct aa_loaddata *d = container_of(kref, struct aa_loaddata, count);
++	struct aa_loaddata *d = container_of(kref, struct aa_loaddata, pcount);
+ 
+ 	if (d) {
+-		INIT_WORK(&d->work, do_loaddata_free);
++		INIT_WORK(&d->work, do_ploaddata_rmfs);
+ 		schedule_work(&d->work);
+ 	}
+ }
+@@ -152,7 +166,9 @@ struct aa_loaddata *aa_loaddata_alloc(size_t size)
+ 		kfree(d);
+ 		return ERR_PTR(-ENOMEM);
+ 	}
+-	kref_init(&d->count);
++	kref_init(&d->count.count);
++	d->count.reftype = REF_RAWDATA;
++	kref_init(&d->pcount);
+ 	INIT_LIST_HEAD(&d->list);
+ 
+ 	return d;
+@@ -764,7 +780,17 @@ static int unpack_pdb(struct aa_ext *e, struct aa_policydb **policy,
+ 	if (!aa_unpack_u32(e, &pdb->start[AA_CLASS_FILE], "dfa_start")) {
+ 		/* default start state for xmatch and file dfa */
+ 		pdb->start[AA_CLASS_FILE] = DFA_START;
+-	}	/* setup class index */
++	}
++
++	size_t state_count = pdb->dfa->tables[YYTD_ID_BASE]->td_lolen;
++
++	if (pdb->start[0] >= state_count ||
++	    pdb->start[AA_CLASS_FILE] >= state_count) {
++		*info = "invalid dfa start state";
++		goto fail;
++	}
++
++	/* setup class index */
+ 	for (i = AA_CLASS_FILE + 1; i <= AA_CLASS_LAST; i++) {
+ 		pdb->start[i] = aa_dfa_next(pdb->dfa, pdb->start[0],
+ 					       i);
+@@ -1122,7 +1148,6 @@ static int verify_header(struct aa_ext *e, int required, const char **ns)
+ {
+ 	int error = -EPROTONOSUPPORT;
+ 	const char *name = NULL;
+-	*ns = NULL;
+ 
+ 	/* get the interface version */
+ 	if (!aa_unpack_u32(e, &e->version, "version")) {
+diff --git a/security/security.c b/security/security.c
+index b6144833c7a8ea..1794860fd614ea 100644
+--- a/security/security.c
++++ b/security/security.c
+@@ -61,6 +61,7 @@ const char *const lockdown_reasons[LOCKDOWN_CONFIDENTIALITY_MAX + 1] = {
+ 	[LOCKDOWN_BPF_WRITE_USER] = "use of bpf to write user RAM",
+ 	[LOCKDOWN_DBG_WRITE_KERNEL] = "use of kgdb/kdb to write kernel RAM",
+ 	[LOCKDOWN_RTAS_ERROR_INJECTION] = "RTAS error injection",
++	[LOCKDOWN_XEN_USER_ACTIONS] = "Xen guest user action",
+ 	[LOCKDOWN_INTEGRITY_MAX] = "integrity",
+ 	[LOCKDOWN_KCORE] = "/proc/kcore access",
+ 	[LOCKDOWN_KPROBES] = "use of kprobes",
+diff --git a/sound/core/pcm_native.c b/sound/core/pcm_native.c
+index 23578307f1262d..214210c8747458 100644
+--- a/sound/core/pcm_native.c
++++ b/sound/core/pcm_native.c
+@@ -2148,6 +2148,10 @@ static int snd_pcm_drain(struct snd_pcm_substream *substream,
+ 	for (;;) {
+ 		long tout;
+ 		struct snd_pcm_runtime *to_check;
++		unsigned int drain_rate;
++		snd_pcm_uframes_t drain_bufsz;
++		bool drain_no_period_wakeup;
++
+ 		if (signal_pending(current)) {
+ 			result = -ERESTARTSYS;
+ 			break;
+@@ -2167,16 +2171,25 @@ static int snd_pcm_drain(struct snd_pcm_substream *substream,
+ 		snd_pcm_group_unref(group, substream);
+ 		if (!to_check)
+ 			break; /* all drained */
++		/*
++		 * Cache the runtime fields needed after unlock.
++		 * A concurrent close() on the linked stream may free
++		 * its runtime via snd_pcm_detach_substream() once we
++		 * release the stream lock below.
++		 */
++		drain_no_period_wakeup = to_check->no_period_wakeup;
++		drain_rate = to_check->rate;
++		drain_bufsz = to_check->buffer_size;
+ 		init_waitqueue_entry(&wait, current);
+ 		set_current_state(TASK_INTERRUPTIBLE);
+ 		add_wait_queue(&to_check->sleep, &wait);
+ 		snd_pcm_stream_unlock_irq(substream);
+-		if (runtime->no_period_wakeup)
++		if (drain_no_period_wakeup)
+ 			tout = MAX_SCHEDULE_TIMEOUT;
+ 		else {
+ 			tout = 100;
+-			if (runtime->rate) {
+-				long t = runtime->buffer_size * 1100 / runtime->rate;
++			if (drain_rate) {
++				long t = drain_bufsz * 1100 / drain_rate;
+ 				tout = max(t, tout);
+ 			}
+ 			tout = msecs_to_jiffies(tout);
+diff --git a/sound/pci/hda/cs35l56_hda.c b/sound/pci/hda/cs35l56_hda.c
+index b84f3b3eb1409e..8d86a13b8a9607 100644
+--- a/sound/pci/hda/cs35l56_hda.c
++++ b/sound/pci/hda/cs35l56_hda.c
+@@ -174,7 +174,7 @@ static int cs35l56_hda_mixer_info(struct snd_kcontrol *kcontrol,
+ static int cs35l56_hda_mixer_get(struct snd_kcontrol *kcontrol,
+ 				 struct snd_ctl_elem_value *ucontrol)
+ {
+-	struct cs35l56_hda *cs35l56 = (struct cs35l56_hda *)kcontrol->private_data;
++	struct cs35l56_hda *cs35l56 = snd_kcontrol_chip(kcontrol);
+ 	unsigned int reg_val;
+ 	int i;
+ 
+@@ -194,7 +194,7 @@ static int cs35l56_hda_mixer_get(struct snd_kcontrol *kcontrol,
+ static int cs35l56_hda_mixer_put(struct snd_kcontrol *kcontrol,
+ 				 struct snd_ctl_elem_value *ucontrol)
+ {
+-	struct cs35l56_hda *cs35l56 = (struct cs35l56_hda *)kcontrol->private_data;
++	struct cs35l56_hda *cs35l56 = snd_kcontrol_chip(kcontrol);
+ 	unsigned int item = ucontrol->value.enumerated.item[0];
+ 	bool changed;
+ 
+@@ -221,7 +221,7 @@ static int cs35l56_hda_posture_info(struct snd_kcontrol *kcontrol,
+ static int cs35l56_hda_posture_get(struct snd_kcontrol *kcontrol,
+ 				   struct snd_ctl_elem_value *ucontrol)
+ {
+-	struct cs35l56_hda *cs35l56 = (struct cs35l56_hda *)kcontrol->private_data;
++	struct cs35l56_hda *cs35l56 = snd_kcontrol_chip(kcontrol);
+ 	unsigned int pos;
+ 	int ret;
+ 
+@@ -237,8 +237,8 @@ static int cs35l56_hda_posture_get(struct snd_kcontrol *kcontrol,
+ static int cs35l56_hda_posture_put(struct snd_kcontrol *kcontrol,
+ 				   struct snd_ctl_elem_value *ucontrol)
+ {
+-	struct cs35l56_hda *cs35l56 = (struct cs35l56_hda *)kcontrol->private_data;
+-	unsigned long pos = ucontrol->value.integer.value[0];
++	struct cs35l56_hda *cs35l56 = snd_kcontrol_chip(kcontrol);
++	long pos = ucontrol->value.integer.value[0];
+ 	bool changed;
+ 	int ret;
+ 
+@@ -284,7 +284,7 @@ static int cs35l56_hda_vol_info(struct snd_kcontrol *kcontrol,
+ static int cs35l56_hda_vol_get(struct snd_kcontrol *kcontrol,
+ 			       struct snd_ctl_elem_value *ucontrol)
+ {
+-	struct cs35l56_hda *cs35l56 = (struct cs35l56_hda *)kcontrol->private_data;
++	struct cs35l56_hda *cs35l56 = snd_kcontrol_chip(kcontrol);
+ 	unsigned int raw_vol;
+ 	int vol;
+ 	int ret;
+@@ -308,7 +308,7 @@ static int cs35l56_hda_vol_get(struct snd_kcontrol *kcontrol,
+ static int cs35l56_hda_vol_put(struct snd_kcontrol *kcontrol,
+ 			       struct snd_ctl_elem_value *ucontrol)
+ {
+-	struct cs35l56_hda *cs35l56 = (struct cs35l56_hda *)kcontrol->private_data;
++	struct cs35l56_hda *cs35l56 = snd_kcontrol_chip(kcontrol);
+ 	long vol = ucontrol->value.integer.value[0];
+ 	unsigned int raw_vol;
+ 	bool changed;
+diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
+index fd141185ce2b99..355b26583eb4e7 100644
+--- a/sound/pci/hda/patch_conexant.c
++++ b/sound/pci/hda/patch_conexant.c
+@@ -312,6 +312,7 @@ enum {
+ 	CXT_PINCFG_SWS_JS201D,
+ 	CXT_PINCFG_TOP_SPEAKER,
+ 	CXT_FIXUP_HP_A_U,
++	CXT_FIXUP_ACER_SWIFT_HP,
+ };
+ 
+ /* for hda_fixup_thinkpad_acpi() */
+@@ -1028,6 +1029,14 @@ static const struct hda_fixup cxt_fixups[] = {
+ 		.type = HDA_FIXUP_FUNC,
+ 		.v.func = cxt_fixup_hp_a_u,
+ 	},
++	[CXT_FIXUP_ACER_SWIFT_HP] = {
++		.type = HDA_FIXUP_PINS,
++		.v.pins = (const struct hda_pintbl[]) {
++			{ 0x16, 0x0321403f }, /* Headphone */
++			{ 0x19, 0x40f001f0 }, /* Mic */
++			{ }
++		},
++	},
+ };
+ 
+ static const struct hda_quirk cxt5045_fixups[] = {
+@@ -1077,6 +1086,7 @@ static const struct hda_quirk cxt5066_fixups[] = {
+ 	SND_PCI_QUIRK(0x1025, 0x0543, "Acer Aspire One 522", CXT_FIXUP_STEREO_DMIC),
+ 	SND_PCI_QUIRK(0x1025, 0x054c, "Acer Aspire 3830TG", CXT_FIXUP_ASPIRE_DMIC),
+ 	SND_PCI_QUIRK(0x1025, 0x054f, "Acer Aspire 4830T", CXT_FIXUP_ASPIRE_DMIC),
++	SND_PCI_QUIRK(0x1025, 0x136d, "Acer Swift SF314", CXT_FIXUP_ACER_SWIFT_HP),
+ 	SND_PCI_QUIRK(0x103c, 0x8079, "HP EliteBook 840 G3", CXT_FIXUP_HP_DOCK),
+ 	SND_PCI_QUIRK(0x103c, 0x807C, "HP EliteBook 820 G3", CXT_FIXUP_HP_DOCK),
+ 	SND_PCI_QUIRK(0x103c, 0x80FD, "HP ProBook 640 G2", CXT_FIXUP_HP_DOCK),
+@@ -1085,6 +1095,7 @@ static const struct hda_quirk cxt5066_fixups[] = {
+ 	SND_PCI_QUIRK(0x103c, 0x8174, "HP Spectre x360", CXT_FIXUP_HP_SPECTRE),
+ 	SND_PCI_QUIRK(0x103c, 0x822e, "HP ProBook 440 G4", CXT_FIXUP_MUTE_LED_GPIO),
+ 	SND_PCI_QUIRK(0x103c, 0x8231, "HP ProBook 450 G4", CXT_FIXUP_MUTE_LED_GPIO),
++	SND_PCI_QUIRK(0x103c, 0x826b, "HP ZBook Studio G4", CXT_FIXUP_MUTE_LED_GPIO),
+ 	SND_PCI_QUIRK(0x103c, 0x828c, "HP EliteBook 840 G4", CXT_FIXUP_HP_DOCK),
+ 	SND_PCI_QUIRK(0x103c, 0x8299, "HP 800 G3 SFF", CXT_FIXUP_HP_MIC_NO_PRESENCE),
+ 	SND_PCI_QUIRK(0x103c, 0x829a, "HP 800 G3 DM", CXT_FIXUP_HP_MIC_NO_PRESENCE),
+diff --git a/sound/soc/amd/acp3x-rt5682-max9836.c b/sound/soc/amd/acp3x-rt5682-max9836.c
+index 28ad5f5b9a7660..73575f6de1ee3e 100644
+--- a/sound/soc/amd/acp3x-rt5682-max9836.c
++++ b/sound/soc/amd/acp3x-rt5682-max9836.c
+@@ -94,8 +94,13 @@ static int acp3x_5682_init(struct snd_soc_pcm_runtime *rtd)
+ 		return ret;
+ 	}
+ 
+-	rt5682_dai_wclk = clk_get(component->dev, "rt5682-dai-wclk");
+-	rt5682_dai_bclk = clk_get(component->dev, "rt5682-dai-bclk");
++	rt5682_dai_wclk = devm_clk_get(component->dev, "rt5682-dai-wclk");
++	if (IS_ERR(rt5682_dai_wclk))
++		return PTR_ERR(rt5682_dai_wclk);
++
++	rt5682_dai_bclk = devm_clk_get(component->dev, "rt5682-dai-bclk");
++	if (IS_ERR(rt5682_dai_bclk))
++		return PTR_ERR(rt5682_dai_bclk);
+ 
+ 	ret = snd_soc_card_jack_new_pins(card, "Headset Jack",
+ 					 SND_JACK_HEADSET |
+diff --git a/sound/soc/amd/yc/acp6x-mach.c b/sound/soc/amd/yc/acp6x-mach.c
+index 5aeacbcb1f6ad9..ab75349d1063dd 100644
+--- a/sound/soc/amd/yc/acp6x-mach.c
++++ b/sound/soc/amd/yc/acp6x-mach.c
+@@ -696,6 +696,20 @@ static const struct dmi_system_id yc_acp_quirk_table[] = {
+ 				DMI_MATCH(DMI_PRODUCT_NAME, "Vivobook_ASUSLaptop M6501RR_M6501RR"),
+ 			}
+ 		},
++	{
++		.driver_data = &acp6x_card,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
++			DMI_MATCH(DMI_PRODUCT_NAME, "ASUS EXPERTBOOK BM1503CDA"),
++		}
++	},
++	{
++		.driver_data = &acp6x_card,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
++			DMI_MATCH(DMI_BOARD_NAME, "PM1503CDA"),
++		}
++	},
+ 	{}
+ };
+ 
+diff --git a/sound/soc/codecs/cs42l43-jack.c b/sound/soc/codecs/cs42l43-jack.c
+index f58d55d77693f2..ba60acc4b2f094 100644
+--- a/sound/soc/codecs/cs42l43-jack.c
++++ b/sound/soc/codecs/cs42l43-jack.c
+@@ -699,6 +699,7 @@ static int cs42l43_run_type_detect(struct cs42l43_codec *priv)
+ 	switch (type & CS42L43_HSDET_TYPE_STS_MASK) {
+ 	case 0x0: // CTIA
+ 	case 0x1: // OMTP
++	case 0x4:
+ 		return cs42l43_run_load_detect(priv, true);
+ 	case 0x2: // 3-pole
+ 		return cs42l43_run_load_detect(priv, false);
+diff --git a/sound/soc/generic/simple-card-utils.c b/sound/soc/generic/simple-card-utils.c
+index 598b0000df244d..86ccd044b93c46 100644
+--- a/sound/soc/generic/simple-card-utils.c
++++ b/sound/soc/generic/simple-card-utils.c
+@@ -988,35 +988,31 @@ EXPORT_SYMBOL_GPL(asoc_graph_card_probe);
+ 
+ int asoc_graph_is_ports0(struct device_node *np)
+ {
+-	struct device_node *port, *ports, *ports0, *top;
+-	int ret;
++	struct device_node *parent __free(device_node) = of_get_parent(np);
++	struct device_node *port;
+ 
+ 	/* np is "endpoint" or "port" */
+-	if (of_node_name_eq(np, "endpoint")) {
+-		port = of_get_parent(np);
+-	} else {
++	if (of_node_name_eq(np, "endpoint"))
++		port = parent;
++	else
+ 		port = np;
+-		of_node_get(port);
+-	}
+ 
+-	ports	= of_get_parent(port);
+-	top	= of_get_parent(ports);
+-	ports0	= of_get_child_by_name(top, "ports");
++	struct device_node *ports __free(device_node) = of_get_parent(port);
++	const char *at = strchr(kbasename(ports->full_name), '@');
+ 
+-	ret = ports0 == ports;
+-
+-	of_node_put(port);
+-	of_node_put(ports);
+-	of_node_put(ports0);
+-	of_node_put(top);
+-
+-	return ret;
++	/*
++	 * Since child iteration order may differ
++	 * between a base DT and DT overlays,
++	 * string match "ports" or "ports@0" in the node name instead.
++	 */
++	return !at || !strcmp(at, "@0");
+ }
+ EXPORT_SYMBOL_GPL(asoc_graph_is_ports0);
+ 
+ static int graph_get_dai_id(struct device_node *ep)
+ {
+-	struct device_node *node;
++	struct device_node *node __free(device_node) = of_graph_get_port_parent(ep);
++	struct device_node *port __free(device_node) = of_get_parent(ep);
+ 	struct device_node *endpoint;
+ 	struct of_endpoint info;
+ 	int i, id;
+@@ -1039,13 +1035,10 @@ static int graph_get_dai_id(struct device_node *ep)
+ 		if (of_property_present(ep,   "reg"))
+ 			return info.id;
+ 
+-		node = of_get_parent(ep);
+-		ret = of_property_present(node, "reg");
+-		of_node_put(node);
++		ret = of_property_present(port, "reg");
+ 		if (ret)
+ 			return info.port;
+ 	}
+-	node = of_graph_get_port_parent(ep);
+ 
+ 	/*
+ 	 * Non HDMI sound case, counting port/endpoint on its DT
+@@ -1059,8 +1052,6 @@ static int graph_get_dai_id(struct device_node *ep)
+ 		i++;
+ 	}
+ 
+-	of_node_put(node);
+-
+ 	if (id < 0)
+ 		return -ENODEV;
+ 
+@@ -1070,7 +1061,6 @@ static int graph_get_dai_id(struct device_node *ep)
+ int asoc_graph_parse_dai(struct device *dev, struct device_node *ep,
+ 			 struct snd_soc_dai_link_component *dlc, int *is_single_link)
+ {
+-	struct device_node *node;
+ 	struct of_phandle_args args = {};
+ 	struct snd_soc_dai *dai;
+ 	int ret;
+@@ -1078,7 +1068,7 @@ int asoc_graph_parse_dai(struct device *dev, struct device_node *ep,
+ 	if (!ep)
+ 		return 0;
+ 
+-	node = of_graph_get_port_parent(ep);
++	struct device_node *node __free(device_node) = of_graph_get_port_parent(ep);
+ 
+ 	/*
+ 	 * Try to find from DAI node
+@@ -1120,10 +1110,8 @@ int asoc_graph_parse_dai(struct device *dev, struct device_node *ep,
+ 	 *    if he unbinded CPU or Codec.
+ 	 */
+ 	ret = snd_soc_get_dlc(&args, dlc);
+-	if (ret < 0) {
+-		of_node_put(node);
++	if (ret < 0)
+ 		return ret;
+-	}
+ 
+ parse_dai_end:
+ 	if (is_single_link)
+diff --git a/sound/soc/qcom/qdsp6/q6apm-dai.c b/sound/soc/qcom/qdsp6/q6apm-dai.c
+index ddca7312274bd3..1c2900cccba661 100644
+--- a/sound/soc/qcom/qdsp6/q6apm-dai.c
++++ b/sound/soc/qcom/qdsp6/q6apm-dai.c
+@@ -841,6 +841,7 @@ static const struct snd_soc_component_driver q6apm_fe_dai_component = {
+ 	.ack		= q6apm_dai_ack,
+ 	.compress_ops	= &q6apm_dai_compress_ops,
+ 	.use_dai_pcm_id = true,
++	.remove_order   = SND_SOC_COMP_ORDER_EARLY,
+ };
+ 
+ static int q6apm_dai_probe(struct platform_device *pdev)
+diff --git a/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c b/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c
+index 3813fe5e01819a..9fcf8f59ea280a 100644
+--- a/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c
++++ b/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c
+@@ -272,6 +272,7 @@ static const struct snd_soc_component_driver q6apm_lpass_dai_component = {
+ 	.of_xlate_dai_name = q6dsp_audio_ports_of_xlate_dai_name,
+ 	.be_pcm_base = AUDIOREACH_BE_PCM_BASE,
+ 	.use_dai_pcm_id = true,
++	.remove_order   = SND_SOC_COMP_ORDER_FIRST,
+ };
+ 
+ static int q6apm_lpass_dai_dev_probe(struct platform_device *pdev)
+diff --git a/sound/soc/qcom/qdsp6/q6apm.c b/sound/soc/qcom/qdsp6/q6apm.c
+index ca57413cb7847a..e6258e8dfa2bb7 100644
+--- a/sound/soc/qcom/qdsp6/q6apm.c
++++ b/sound/soc/qcom/qdsp6/q6apm.c
+@@ -732,6 +732,7 @@ static const struct snd_soc_component_driver q6apm_audio_component = {
+ 	.name		= APM_AUDIO_DRV_NAME,
+ 	.probe		= q6apm_audio_probe,
+ 	.remove		= q6apm_audio_remove,
++	.remove_order   = SND_SOC_COMP_ORDER_LAST,
+ };
+ 
+ static int apm_probe(gpr_device_t *gdev)
+diff --git a/sound/soc/soc-core.c b/sound/soc/soc-core.c
+index dc95b6f4155586..696f5501a27bcd 100644
+--- a/sound/soc/soc-core.c
++++ b/sound/soc/soc-core.c
+@@ -456,8 +456,7 @@ static void soc_free_pcm_runtime(struct snd_soc_pcm_runtime *rtd)
+ 
+ 	list_del(&rtd->list);
+ 
+-	if (delayed_work_pending(&rtd->delayed_work))
+-		flush_delayed_work(&rtd->delayed_work);
++	flush_delayed_work(&rtd->delayed_work);
+ 	snd_soc_pcm_component_free(rtd);
+ 
+ 	/*
+@@ -1720,12 +1719,15 @@ static void cleanup_dmi_name(char *name)
+ 
+ /*
+  * Check if a DMI field is valid, i.e. not containing any string
+- * in the black list.
++ * in the black list and not the empty string.
+  */
+ static int is_dmi_valid(const char *field)
+ {
+ 	int i = 0;
+ 
++	if (!field[0])
++		return 0;
++
+ 	while (dmi_blacklist[i]) {
+ 		if (strstr(field, dmi_blacklist[i]))
+ 			return 0;
+@@ -1997,6 +1999,9 @@ static void soc_cleanup_card_resources(struct snd_soc_card *card)
+ 	for_each_card_rtds(card, rtd)
+ 		if (rtd->initialized)
+ 			snd_soc_link_exit(rtd);
++	/* flush delayed work before removing DAIs and DAPM widgets */
++	snd_soc_flush_all_delayed_work(card);
++
+ 	/* remove and free each DAI */
+ 	soc_remove_link_dais(card);
+ 	soc_remove_link_components(card);
+diff --git a/sound/usb/endpoint.c b/sound/usb/endpoint.c
+index 1092b964167e97..f6cef6aaca7731 100644
+--- a/sound/usb/endpoint.c
++++ b/sound/usb/endpoint.c
+@@ -160,8 +160,8 @@ int snd_usb_endpoint_implicit_feedback_sink(struct snd_usb_endpoint *ep)
+  * This won't be used for implicit feedback which takes the packet size
+  * returned from the sync source
+  */
+-static int slave_next_packet_size(struct snd_usb_endpoint *ep,
+-				  unsigned int avail)
++static int synced_next_packet_size(struct snd_usb_endpoint *ep,
++				   unsigned int avail)
+ {
+ 	unsigned long flags;
+ 	unsigned int phase;
+@@ -224,13 +224,14 @@ int snd_usb_endpoint_next_packet_size(struct snd_usb_endpoint *ep,
+ 
+ 	packet = ctx->packet_size[idx];
+ 	if (packet) {
++		packet = min(packet, ep->maxframesize);
+ 		if (avail && packet >= avail)
+ 			return -EAGAIN;
+ 		return packet;
+ 	}
+ 
+ 	if (ep->sync_source)
+-		return slave_next_packet_size(ep, avail);
++		return synced_next_packet_size(ep, avail);
+ 	else
+ 		return next_packet_size(ep, avail);
+ }
+@@ -1396,6 +1397,9 @@ int snd_usb_endpoint_set_params(struct snd_usb_audio *chip,
+ 		goto unlock;
+ 	}
+ 
++	ep->packsize[0] = min(ep->packsize[0], ep->maxframesize);
++	ep->packsize[1] = min(ep->packsize[1], ep->maxframesize);
++
+ 	/* calculate the frequency in 16.16 format */
+ 	ep->freqm = ep->freqn;
+ 	ep->freqshift = INT_MIN;
+diff --git a/sound/usb/mixer_scarlett2.c b/sound/usb/mixer_scarlett2.c
+index 6112c3fb8ba68b..c4b29b3670cd4b 100644
+--- a/sound/usb/mixer_scarlett2.c
++++ b/sound/usb/mixer_scarlett2.c
+@@ -3898,6 +3898,8 @@ static int scarlett2_find_fc_interface(struct usb_device *dev,
+ 
+ 		if (desc->bInterfaceClass != 255)
+ 			continue;
++		if (desc->bNumEndpoints < 1)
++			continue;
+ 
+ 		epd = get_endpoint(intf->altsetting, 0);
+ 		private->bInterfaceNumber = desc->bInterfaceNumber;
+diff --git a/sound/usb/quirks.c b/sound/usb/quirks.c
+index ff2bbe761ee3a8..04896ab01f372d 100644
+--- a/sound/usb/quirks.c
++++ b/sound/usb/quirks.c
+@@ -2251,6 +2251,8 @@ static const struct usb_audio_quirk_flags_table quirk_flags_table[] = {
+ 		   QUIRK_FLAG_SHARE_MEDIA_DEVICE | QUIRK_FLAG_ALIGN_TRANSFER),
+ 	DEVICE_FLG(0x2040, 0x7281, /* Hauppauge HVR-950Q-MXL */
+ 		   QUIRK_FLAG_SHARE_MEDIA_DEVICE | QUIRK_FLAG_ALIGN_TRANSFER),
++	DEVICE_FLG(0x20b1, 0x2009, /* XMOS Ltd DIYINHK USB Audio 2.0 */
++		   QUIRK_FLAG_SKIP_IMPLICIT_FB | QUIRK_FLAG_DSD_RAW),
+ 	DEVICE_FLG(0x2040, 0x8200, /* Hauppauge Woodbury */
+ 		   QUIRK_FLAG_SHARE_MEDIA_DEVICE | QUIRK_FLAG_ALIGN_TRANSFER),
+ 	DEVICE_FLG(0x21b4, 0x0081, /* AudioQuest DragonFly */
+@@ -2308,7 +2310,7 @@ static const struct usb_audio_quirk_flags_table quirk_flags_table[] = {
+ 	VENDOR_FLG(0x07fd, /* MOTU */
+ 		   QUIRK_FLAG_VALIDATE_RATES),
+ 	VENDOR_FLG(0x1235, /* Focusrite Novation */
+-		   QUIRK_FLAG_VALIDATE_RATES),
++		   0),
+ 	VENDOR_FLG(0x1511, /* AURALiC */
+ 		   QUIRK_FLAG_DSD_RAW),
+ 	VENDOR_FLG(0x152a, /* Thesycon devices */
+diff --git a/sound/usb/validate.c b/sound/usb/validate.c
+index 4bb4893f6e74f7..f62b7cc041dc9b 100644
+--- a/sound/usb/validate.c
++++ b/sound/usb/validate.c
+@@ -281,7 +281,7 @@ static const struct usb_desc_validator audio_validators[] = {
+ 	/* UAC_VERSION_2, UAC2_SAMPLE_RATE_CONVERTER: not implemented yet */
+ 
+ 	/* UAC3 */
+-	FIXED(UAC_VERSION_2, UAC_HEADER, struct uac3_ac_header_descriptor),
++	FIXED(UAC_VERSION_3, UAC_HEADER, struct uac3_ac_header_descriptor),
+ 	FIXED(UAC_VERSION_3, UAC_INPUT_TERMINAL,
+ 	      struct uac3_input_terminal_descriptor),
+ 	FIXED(UAC_VERSION_3, UAC_OUTPUT_TERMINAL,
+diff --git a/tools/bootconfig/main.c b/tools/bootconfig/main.c
+index 8a48cc2536f566..32cf48f2da9a1d 100644
+--- a/tools/bootconfig/main.c
++++ b/tools/bootconfig/main.c
+@@ -157,8 +157,11 @@ static int load_xbc_file(const char *path, char **buf)
+ 	if (fd < 0)
+ 		return -errno;
+ 	ret = fstat(fd, &stat);
+-	if (ret < 0)
+-		return -errno;
++	if (ret < 0) {
++		ret = -errno;
++		close(fd);
++		return ret;
++	}
+ 
+ 	ret = load_xbc_fd(fd, buf, stat.st_size);
+ 
+diff --git a/tools/objtool/Makefile b/tools/objtool/Makefile
+index e9a0f89e9c39a9..4efe652637f021 100644
+--- a/tools/objtool/Makefile
++++ b/tools/objtool/Makefile
+@@ -87,10 +87,12 @@ $(LIBSUBCMD)-clean:
+ 	$(Q)$(RM) -r -- $(LIBSUBCMD_OUTPUT)
+ 
+ clean: $(LIBSUBCMD)-clean
+-	$(call QUIET_CLEAN, objtool) $(RM) $(OBJTOOL)
+-	$(Q)find $(OUTPUT) -name '*.o' -delete -o -name '\.*.cmd' -delete -o -name '\.*.d' -delete
++	$(Q)find $(OUTPUT) \( -name '*.o' -o -name '\.*.cmd' -o -name '\.*.d' \) -type f -print | xargs $(RM)
+ 	$(Q)$(RM) $(OUTPUT)arch/x86/lib/inat-tables.c $(OUTPUT)fixdep
+ 
++mrproper: clean
++	$(call QUIET_CLEAN, objtool) $(RM) $(OBJTOOL)
++
+ FORCE:
+ 
+-.PHONY: clean FORCE
++.PHONY: clean mrproper FORCE
+diff --git a/tools/testing/kunit/kunit_kernel.py b/tools/testing/kunit/kunit_kernel.py
+index 0b6488efed47ac..df7622dac0ff10 100644
+--- a/tools/testing/kunit/kunit_kernel.py
++++ b/tools/testing/kunit/kunit_kernel.py
+@@ -331,8 +331,10 @@ class LinuxSourceTree:
+ 		return self.validate_config(build_dir)
+ 
+ 	def run_kernel(self, args: Optional[List[str]]=None, build_dir: str='', filter_glob: str='', filter: str='', filter_action: Optional[str]=None, timeout: Optional[int]=None) -> Iterator[str]:
+-		if not args:
+-			args = []
++		# Copy to avoid mutating the caller-supplied list. exec_tests() reuses
++		# the same args across repeated run_kernel() calls (e.g. --run_isolated),
++		# so appending to the original would accumulate stale flags on each call.
++		args = list(args) if args else []
+ 		if filter_glob:
+ 			args.append('kunit.filter_glob=' + filter_glob)
+ 		if filter:
+diff --git a/tools/testing/kunit/kunit_tool_test.py b/tools/testing/kunit/kunit_tool_test.py
+index b28c1510be2eb9..5254a25ad2d9df 100755
+--- a/tools/testing/kunit/kunit_tool_test.py
++++ b/tools/testing/kunit/kunit_tool_test.py
+@@ -461,6 +461,32 @@ class LinuxSourceTreeTest(unittest.TestCase):
+ 			with open(kunit_kernel.get_outfile_path(build_dir), 'rt') as outfile:
+ 				self.assertEqual(outfile.read(), 'hi\nbye\n', msg='Missing some output')
+ 
++	def test_run_kernel_args_not_mutated(self):
++		"""Verify run_kernel() copies args so callers can reuse them."""
++		start_calls = []
++
++		def fake_start(start_args, unused_build_dir):
++			start_calls.append(list(start_args))
++			return subprocess.Popen(['printf', 'KTAP version 1\n'],
++						text=True, stdout=subprocess.PIPE)
++
++		with tempfile.TemporaryDirectory('') as build_dir:
++			tree = kunit_kernel.LinuxSourceTree(build_dir,
++					kunitconfig_paths=[os.devnull])
++			with mock.patch.object(tree._ops, 'start', side_effect=fake_start), \
++			     mock.patch.object(kunit_kernel.subprocess, 'call'):
++				kernel_args = ['mem=1G']
++				for _ in tree.run_kernel(args=kernel_args, build_dir=build_dir,
++							 filter_glob='suite.test1'):
++					pass
++				for _ in tree.run_kernel(args=kernel_args, build_dir=build_dir,
++							 filter_glob='suite.test2'):
++					pass
++				self.assertEqual(kernel_args, ['mem=1G'],
++					'run_kernel() should not modify caller args')
++				self.assertIn('kunit.filter_glob=suite.test1', start_calls[0])
++				self.assertIn('kunit.filter_glob=suite.test2', start_calls[1])
++
+ 	def test_build_reconfig_no_config(self):
+ 		with tempfile.TemporaryDirectory('') as build_dir:
+ 			with open(kunit_kernel.get_kunitconfig_path(build_dir), 'w') as f:
+diff --git a/tools/testing/selftests/arm64/abi/hwcap.c b/tools/testing/selftests/arm64/abi/hwcap.c
+index e3d262831d919e..311a2a65f7cf23 100644
+--- a/tools/testing/selftests/arm64/abi/hwcap.c
++++ b/tools/testing/selftests/arm64/abi/hwcap.c
+@@ -216,8 +216,8 @@ static void sve2_sigill(void)
+ 
+ static void sve2p1_sigill(void)
+ {
+-	/* BFADD Z0.H, Z0.H, Z0.H */
+-	asm volatile(".inst 0x65000000" : : : "z0");
++	/* LD1Q {Z0.Q}, P0/Z, [Z0.D, X0] */
++	asm volatile(".inst 0xC400A000" : : : "z0");
+ }
+ 
+ static void sveaes_sigill(void)
+diff --git a/tools/testing/selftests/net/mptcp/mptcp_join.sh b/tools/testing/selftests/net/mptcp/mptcp_join.sh
+index c571563a42c596..538973a4684974 100755
+--- a/tools/testing/selftests/net/mptcp/mptcp_join.sh
++++ b/tools/testing/selftests/net/mptcp/mptcp_join.sh
+@@ -81,6 +81,24 @@ CBPF_MPTCP_SUBOPTION_ADD_ADDR="14,
+ 			       6 0 0 65535,
+ 			       6 0 0 0"
+ 
++# IPv4: TCP hdr of 48B, a first suboption of 12B (DACK8), the RM_ADDR suboption
++# generated using "nfbpf_compile '(ip[32] & 0xf0) == 0xc0 && ip[53] == 0x0c &&
++#				  (ip[66] & 0xf0) == 0x40'"
++CBPF_MPTCP_SUBOPTION_RM_ADDR="13,
++			      48 0 0 0,
++			      84 0 0 240,
++			      21 0 9 64,
++			      48 0 0 32,
++			      84 0 0 240,
++			      21 0 6 192,
++			      48 0 0 53,
++			      21 0 4 12,
++			      48 0 0 66,
++			      84 0 0 240,
++			      21 0 1 64,
++			      6 0 0 65535,
++			      6 0 0 0"
++
+ init_partial()
+ {
+ 	capout=$(mktemp)
+@@ -2424,6 +2442,19 @@ remove_tests()
+ 		chk_rst_nr 0 0
+ 	fi
+ 
++	# signal+subflow with limits, remove
++	if reset "remove signal+subflow with limits"; then
++		pm_nl_set_limits $ns1 0 0
++		pm_nl_add_endpoint $ns1 10.0.2.1 flags signal,subflow
++		pm_nl_set_limits $ns2 0 0
++		addr_nr_ns1=-1 speed=slow \
++			run_tests $ns1 $ns2 10.0.1.1
++		chk_join_nr 0 0 0
++		chk_add_nr 1 1
++		chk_rm_nr 1 0 invert
++		chk_rst_nr 0 0
++	fi
++
+ 	# addresses remove
+ 	if reset "remove addresses"; then
+ 		pm_nl_set_limits $ns1 3 3
+@@ -3867,6 +3898,14 @@ endpoint_tests()
+ 		chk_subflow_nr "after no reject" 3
+ 		chk_mptcp_info subflows 2 subflows 2
+ 
++		# To make sure RM_ADDR are sent over a different subflow, but
++		# allow the rest to quickly and cleanly close the subflow
++		local ipt=1
++		ip netns exec "${ns2}" ${iptables} -I OUTPUT -s "10.0.1.2" \
++			-p tcp -m tcp --tcp-option 30 \
++			-m bpf --bytecode \
++			"$CBPF_MPTCP_SUBOPTION_RM_ADDR" \
++			-j DROP || ipt=0
+ 		local i
+ 		for i in $(seq 3); do
+ 			pm_nl_del_endpoint $ns2 1 10.0.1.2
+@@ -3879,6 +3918,7 @@ endpoint_tests()
+ 			chk_subflow_nr "after re-add id 0 ($i)" 3
+ 			chk_mptcp_info subflows 3 subflows 3
+ 		done
++		[ ${ipt} = 1 ] && ip netns exec "${ns2}" ${iptables} -D OUTPUT 1
+ 
+ 		mptcp_lib_kill_group_wait $tests_pid
+ 
+@@ -3921,38 +3961,54 @@ endpoint_tests()
+ 			$ns1 10.0.2.1 id 1 flags signal
+ 		chk_subflow_nr "before delete" 2
+ 		chk_mptcp_info subflows 1 subflows 1
++		chk_mptcp_info add_addr_signal 2 add_addr_accepted 1
+ 
+ 		pm_nl_del_endpoint $ns1 1 10.0.2.1
+ 		pm_nl_del_endpoint $ns1 2 224.0.0.1
+ 		sleep 0.5
+ 		chk_subflow_nr "after delete" 1
+ 		chk_mptcp_info subflows 0 subflows 0
++		chk_mptcp_info add_addr_signal 0 add_addr_accepted 0
+ 
+ 		pm_nl_add_endpoint $ns1 10.0.2.1 id 1 flags signal
+ 		pm_nl_add_endpoint $ns1 10.0.3.1 id 2 flags signal
+ 		wait_mpj $ns2
+ 		chk_subflow_nr "after re-add" 3
+ 		chk_mptcp_info subflows 2 subflows 2
++		chk_mptcp_info add_addr_signal 2 add_addr_accepted 2
+ 
++		# To make sure RM_ADDR are sent over a different subflow, but
++		# allow the rest to quickly and cleanly close the subflow
++		local ipt=1
++		ip netns exec "${ns1}" ${iptables} -I OUTPUT -s "10.0.1.1" \
++			-p tcp -m tcp --tcp-option 30 \
++			-m bpf --bytecode \
++			"$CBPF_MPTCP_SUBOPTION_RM_ADDR" \
++			-j DROP || ipt=0
+ 		pm_nl_del_endpoint $ns1 42 10.0.1.1
+ 		sleep 0.5
+ 		chk_subflow_nr "after delete ID 0" 2
+ 		chk_mptcp_info subflows 2 subflows 2
++		chk_mptcp_info add_addr_signal 2 add_addr_accepted 2
++		[ ${ipt} = 1 ] && ip netns exec "${ns1}" ${iptables} -D OUTPUT 1
+ 
+ 		pm_nl_add_endpoint $ns1 10.0.1.1 id 99 flags signal
+ 		wait_mpj $ns2
+ 		chk_subflow_nr "after re-add ID 0" 3
+ 		chk_mptcp_info subflows 3 subflows 3
++		chk_mptcp_info add_addr_signal 3 add_addr_accepted 2
+ 
+ 		pm_nl_del_endpoint $ns1 99 10.0.1.1
+ 		sleep 0.5
+ 		chk_subflow_nr "after re-delete ID 0" 2
+ 		chk_mptcp_info subflows 2 subflows 2
++		chk_mptcp_info add_addr_signal 2 add_addr_accepted 2
+ 
+ 		pm_nl_add_endpoint $ns1 10.0.1.1 id 88 flags signal
+ 		wait_mpj $ns2
+ 		chk_subflow_nr "after re-re-add ID 0" 3
+ 		chk_mptcp_info subflows 3 subflows 3
++		chk_mptcp_info add_addr_signal 3 add_addr_accepted 2
+ 		mptcp_lib_kill_group_wait $tests_pid
+ 
+ 		kill_events_pids
+diff --git a/tools/testing/selftests/net/mptcp/simult_flows.sh b/tools/testing/selftests/net/mptcp/simult_flows.sh
+index 214a89fce8b803..e7b84e9ec0f8ab 100755
+--- a/tools/testing/selftests/net/mptcp/simult_flows.sh
++++ b/tools/testing/selftests/net/mptcp/simult_flows.sh
+@@ -227,10 +227,13 @@ run_test()
+ 	for dev in ns2eth1 ns2eth2; do
+ 		tc -n $ns2 qdisc del dev $dev root >/dev/null 2>&1
+ 	done
+-	tc -n $ns1 qdisc add dev ns1eth1 root netem rate ${rate1}mbit $delay1
+-	tc -n $ns1 qdisc add dev ns1eth2 root netem rate ${rate2}mbit $delay2
+-	tc -n $ns2 qdisc add dev ns2eth1 root netem rate ${rate1}mbit $delay1
+-	tc -n $ns2 qdisc add dev ns2eth2 root netem rate ${rate2}mbit $delay2
++
++	# keep the queued pkts number low, or the RTT estimator will see
++	# increasing latency over time.
++	tc -n $ns1 qdisc add dev ns1eth1 root netem rate ${rate1}mbit $delay1 limit 50
++	tc -n $ns1 qdisc add dev ns1eth2 root netem rate ${rate2}mbit $delay2 limit 50
++	tc -n $ns2 qdisc add dev ns2eth1 root netem rate ${rate1}mbit $delay1 limit 50
++	tc -n $ns2 qdisc add dev ns2eth2 root netem rate ${rate2}mbit $delay2 limit 50
+ 
+ 	# time is measured in ms, account for transfer size, aggregated link speed
+ 	# and header overhead (10%)

--- a/patch/kernel/archive/odroidxu4-6.6/patch-6.6.130-131.patch
+++ b/patch/kernel/archive/odroidxu4-6.6/patch-6.6.130-131.patch
@@ -1,0 +1,6011 @@
+diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
+index fff3ca50c6c26c..fdbc2749fbb373 100644
+--- a/Documentation/admin-guide/kernel-parameters.txt
++++ b/Documentation/admin-guide/kernel-parameters.txt
+@@ -6901,6 +6901,9 @@
+ 				p = USB_QUIRK_SHORT_SET_ADDRESS_REQ_TIMEOUT
+ 					(Reduce timeout of the SET_ADDRESS
+ 					request from 5000 ms to 500 ms);
++				q = USB_QUIRK_FORCE_ONE_CONFIG (Device
++					claims zero configurations,
++					forcing to 1);
+ 			Example: quirks=0781:5580:bk,0a5c:5834:gij
+ 
+ 	usbhid.mousepoll=
+diff --git a/Documentation/hwmon/adm1177.rst b/Documentation/hwmon/adm1177.rst
+index 1c85a2af92bf74..375f6d6e03a7d3 100644
+--- a/Documentation/hwmon/adm1177.rst
++++ b/Documentation/hwmon/adm1177.rst
+@@ -27,10 +27,10 @@ for details.
+ Sysfs entries
+ -------------
+ 
+-The following attributes are supported. Current maxim attribute
++The following attributes are supported. Current maximum attribute
+ is read-write, all other attributes are read-only.
+ 
+-in0_input		Measured voltage in microvolts.
++in0_input		Measured voltage in millivolts.
+ 
+-curr1_input		Measured current in microamperes.
+-curr1_max_alarm		Overcurrent alarm in microamperes.
++curr1_input		Measured current in milliamperes.
++curr1_max		Overcurrent shutdown threshold in milliamperes.
+diff --git a/Documentation/hwmon/peci-cputemp.rst b/Documentation/hwmon/peci-cputemp.rst
+index fe0422248dc5ea..266b62a46f49c2 100644
+--- a/Documentation/hwmon/peci-cputemp.rst
++++ b/Documentation/hwmon/peci-cputemp.rst
+@@ -51,8 +51,9 @@ temp1_max		Provides thermal control temperature of the CPU package
+ temp1_crit		Provides shutdown temperature of the CPU package which
+ 			is also known as the maximum processor junction
+ 			temperature, Tjmax or Tprochot.
+-temp1_crit_hyst		Provides the hysteresis value from Tcontrol to Tjmax of
+-			the CPU package.
++temp1_crit_hyst		Provides the hysteresis temperature of the CPU
++			package. Returns Tcontrol, the temperature at which
++			the critical condition clears.
+ 
+ temp2_label		"DTS"
+ temp2_input		Provides current temperature of the CPU package scaled
+@@ -62,8 +63,9 @@ temp2_max		Provides thermal control temperature of the CPU package
+ temp2_crit		Provides shutdown temperature of the CPU package which
+ 			is also known as the maximum processor junction
+ 			temperature, Tjmax or Tprochot.
+-temp2_crit_hyst		Provides the hysteresis value from Tcontrol to Tjmax of
+-			the CPU package.
++temp2_crit_hyst		Provides the hysteresis temperature of the CPU
++			package. Returns Tcontrol, the temperature at which
++			the critical condition clears.
+ 
+ temp3_label		"Tcontrol"
+ temp3_input		Provides current Tcontrol temperature of the CPU
+diff --git a/Makefile b/Makefile
+index ec2fb5c10957b5..567fe79e76bf4c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 6
+ PATCHLEVEL = 6
+-SUBLEVEL = 130
++SUBLEVEL = 131
+ EXTRAVERSION =
+ NAME = Pinguïn Aangedreven
+ 
+diff --git a/arch/arm64/boot/dts/freescale/imx8mn-tqma8mqnl-mba8mx.dts b/arch/arm64/boot/dts/freescale/imx8mn-tqma8mqnl-mba8mx.dts
+index 3f1e49bfe38f73..26e9119e8a1dbc 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mn-tqma8mqnl-mba8mx.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mn-tqma8mqnl-mba8mx.dts
+@@ -63,6 +63,10 @@
+ 	};
+ };
+ 
++&reg_usdhc2_vqmmc {
++	status = "okay";
++};
++
+ &sai3 {
+ 	assigned-clocks = <&clk IMX8MN_CLK_SAI3>;
+ 	assigned-clock-parents = <&clk IMX8MN_AUDIO_PLL1_OUT>;
+@@ -207,8 +211,7 @@
+ 			   <MX8MN_IOMUXC_SD2_DATA0_USDHC2_DATA0		0x1d4>,
+ 			   <MX8MN_IOMUXC_SD2_DATA1_USDHC2_DATA1		0x1d4>,
+ 			   <MX8MN_IOMUXC_SD2_DATA2_USDHC2_DATA2		0x1d4>,
+-			   <MX8MN_IOMUXC_SD2_DATA3_USDHC2_DATA3		0x1d4>,
+-			   <MX8MN_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x84>;
++			   <MX8MN_IOMUXC_SD2_DATA3_USDHC2_DATA3		0x1d4>;
+ 	};
+ 
+ 	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
+@@ -217,8 +220,7 @@
+ 			   <MX8MN_IOMUXC_SD2_DATA0_USDHC2_DATA0		0x1d4>,
+ 			   <MX8MN_IOMUXC_SD2_DATA1_USDHC2_DATA1		0x1d4>,
+ 			   <MX8MN_IOMUXC_SD2_DATA2_USDHC2_DATA2		0x1d4>,
+-			   <MX8MN_IOMUXC_SD2_DATA3_USDHC2_DATA3		0x1d4>,
+-			   <MX8MN_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x84>;
++			   <MX8MN_IOMUXC_SD2_DATA3_USDHC2_DATA3		0x1d4>;
+ 	};
+ 
+ 	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
+@@ -227,8 +229,7 @@
+ 			   <MX8MN_IOMUXC_SD2_DATA0_USDHC2_DATA0		0x1d4>,
+ 			   <MX8MN_IOMUXC_SD2_DATA1_USDHC2_DATA1		0x1d4>,
+ 			   <MX8MN_IOMUXC_SD2_DATA2_USDHC2_DATA2		0x1d4>,
+-			   <MX8MN_IOMUXC_SD2_DATA3_USDHC2_DATA3		0x1d4>,
+-			   <MX8MN_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x84>;
++			   <MX8MN_IOMUXC_SD2_DATA3_USDHC2_DATA3		0x1d4>;
+ 	};
+ 
+ 	pinctrl_usdhc2_gpio: usdhc2-gpiogrp {
+diff --git a/arch/arm64/boot/dts/freescale/imx8mn-tqma8mqnl.dtsi b/arch/arm64/boot/dts/freescale/imx8mn-tqma8mqnl.dtsi
+index 391ca5516e4c5d..78aaa04ebbc086 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mn-tqma8mqnl.dtsi
++++ b/arch/arm64/boot/dts/freescale/imx8mn-tqma8mqnl.dtsi
+@@ -30,6 +30,20 @@
+ 		regulator-max-microvolt = <3300000>;
+ 	};
+ 
++	reg_usdhc2_vqmmc: regulator-usdhc2-vqmmc {
++		compatible = "regulator-gpio";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usdhc2_vqmmc>;
++		regulator-name = "V_SD2";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++		gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
++		states = <1800000 0x1>,
++			 <3300000 0x0>;
++		vin-supply = <&ldo5_reg>;
++		status = "disabled";
++	};
++
+ 	reserved-memory {
+ 		#address-cells = <2>;
+ 		#size-cells = <2>;
+@@ -219,6 +233,10 @@
+ 	};
+ };
+ 
++&usdhc2 {
++	vqmmc-supply = <&reg_usdhc2_vqmmc>;
++};
++
+ &usdhc3 {
+ 	pinctrl-names = "default", "state_100mhz", "state_200mhz";
+ 	pinctrl-0 = <&pinctrl_usdhc3>;
+@@ -273,6 +291,10 @@
+ 		fsl,pins = <MX8MN_IOMUXC_SD2_RESET_B_GPIO2_IO19		0x84>;
+ 	};
+ 
++	pinctrl_reg_usdhc2_vqmmc: regusdhc2vqmmcgrp {
++		fsl,pins = <MX8MN_IOMUXC_GPIO1_IO04_GPIO1_IO4		0xc0>;
++	};
++
+ 	pinctrl_usdhc3: usdhc3grp {
+ 		fsl,pins = <MX8MN_IOMUXC_NAND_WE_B_USDHC3_CLK		0x1d4>,
+ 			   <MX8MN_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d2>,
+diff --git a/arch/arm64/kvm/reset.c b/arch/arm64/kvm/reset.c
+index 43a53a403f5102..83fc4f302903f8 100644
+--- a/arch/arm64/kvm/reset.c
++++ b/arch/arm64/kvm/reset.c
+@@ -293,6 +293,20 @@ int kvm_reset_vcpu(struct kvm_vcpu *vcpu)
+ 			kvm_vcpu_set_be(vcpu);
+ 
+ 		*vcpu_pc(vcpu) = target_pc;
++
++		/*
++		 * We may come from a state where either a PC update was
++		 * pending (SMC call resulting in PC being increpented to
++		 * skip the SMC) or a pending exception. Make sure we get
++		 * rid of all that, as this cannot be valid out of reset.
++		 *
++		 * Note that clearing the exception mask also clears PC
++		 * updates, but that's an implementation detail, and we
++		 * really want to make it explicit.
++		 */
++		vcpu_clear_flag(vcpu, PENDING_EXCEPTION);
++		vcpu_clear_flag(vcpu, EXCEPT_MASK);
++		vcpu_clear_flag(vcpu, INCREMENT_PC);
+ 		vcpu_set_reg(vcpu, 0, reset_state.r0);
+ 	}
+ 
+diff --git a/arch/loongarch/pci/pci.c b/arch/loongarch/pci/pci.c
+index ea4dbac0b47b59..70485b167cfab5 100644
+--- a/arch/loongarch/pci/pci.c
++++ b/arch/loongarch/pci/pci.c
+@@ -6,9 +6,11 @@
+ #include <linux/export.h>
+ #include <linux/init.h>
+ #include <linux/acpi.h>
++#include <linux/delay.h>
+ #include <linux/types.h>
+ #include <linux/pci.h>
+ #include <linux/vgaarb.h>
++#include <linux/io-64-nonatomic-lo-hi.h>
+ #include <asm/cacheflush.h>
+ #include <asm/loongson.h>
+ 
+@@ -16,6 +18,9 @@
+ #define PCI_DEVICE_ID_LOONGSON_DC1      0x7a06
+ #define PCI_DEVICE_ID_LOONGSON_DC2      0x7a36
+ #define PCI_DEVICE_ID_LOONGSON_DC3      0x7a46
++#define PCI_DEVICE_ID_LOONGSON_GPU1     0x7a15
++#define PCI_DEVICE_ID_LOONGSON_GPU2     0x7a25
++#define PCI_DEVICE_ID_LOONGSON_GPU3     0x7a35
+ 
+ int raw_pci_read(unsigned int domain, unsigned int bus, unsigned int devfn,
+ 						int reg, int len, u32 *val)
+@@ -100,3 +105,78 @@ static void pci_fixup_vgadev(struct pci_dev *pdev)
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_DC1, pci_fixup_vgadev);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_DC2, pci_fixup_vgadev);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_DC3, pci_fixup_vgadev);
++
++#define CRTC_NUM_MAX		2
++#define CRTC_OUTPUT_ENABLE	0x100
++
++static void loongson_gpu_fixup_dma_hang(struct pci_dev *pdev, bool on)
++{
++	u32 i, val, count, crtc_offset, device;
++	void __iomem *crtc_reg, *base, *regbase;
++	static u32 crtc_status[CRTC_NUM_MAX] = { 0 };
++
++	base = pdev->bus->ops->map_bus(pdev->bus, pdev->devfn + 1, 0);
++	device = readw(base + PCI_DEVICE_ID);
++
++	regbase = ioremap(readq(base + PCI_BASE_ADDRESS_0) & ~0xffull, SZ_64K);
++	if (!regbase) {
++		pci_err(pdev, "Failed to ioremap()\n");
++		return;
++	}
++
++	switch (device) {
++	case PCI_DEVICE_ID_LOONGSON_DC2:
++		crtc_reg = regbase + 0x1240;
++		crtc_offset = 0x10;
++		break;
++	case PCI_DEVICE_ID_LOONGSON_DC3:
++		crtc_reg = regbase;
++		crtc_offset = 0x400;
++		break;
++	}
++
++	for (i = 0; i < CRTC_NUM_MAX; i++, crtc_reg += crtc_offset) {
++		val = readl(crtc_reg);
++
++		if (!on)
++			crtc_status[i] = val;
++
++		/* No need to fixup if the status is off at startup. */
++		if (!(crtc_status[i] & CRTC_OUTPUT_ENABLE))
++			continue;
++
++		if (on)
++			val |= CRTC_OUTPUT_ENABLE;
++		else
++			val &= ~CRTC_OUTPUT_ENABLE;
++
++		mb();
++		writel(val, crtc_reg);
++
++		for (count = 0; count < 40; count++) {
++			val = readl(crtc_reg) & CRTC_OUTPUT_ENABLE;
++			if ((on && val) || (!on && !val))
++				break;
++			udelay(1000);
++		}
++
++		pci_info(pdev, "DMA hang fixup at reg[0x%lx]: 0x%x\n",
++				(unsigned long)crtc_reg & 0xffff, readl(crtc_reg));
++	}
++
++	iounmap(regbase);
++}
++
++static void pci_fixup_dma_hang_early(struct pci_dev *pdev)
++{
++	loongson_gpu_fixup_dma_hang(pdev, false);
++}
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_GPU2, pci_fixup_dma_hang_early);
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_GPU3, pci_fixup_dma_hang_early);
++
++static void pci_fixup_dma_hang_final(struct pci_dev *pdev)
++{
++	loongson_gpu_fixup_dma_hang(pdev, true);
++}
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_GPU2, pci_fixup_dma_hang_final);
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_GPU3, pci_fixup_dma_hang_final);
+diff --git a/arch/powerpc/net/bpf_jit_comp64.c b/arch/powerpc/net/bpf_jit_comp64.c
+index 2239ce5e8501cd..f4b597c40b46e0 100644
+--- a/arch/powerpc/net/bpf_jit_comp64.c
++++ b/arch/powerpc/net/bpf_jit_comp64.c
+@@ -307,27 +307,32 @@ static int bpf_jit_emit_tail_call(u32 *image, struct codegen_context *ctx, u32 o
+ 
+ 	/*
+ 	 * tail_call_cnt++;
++	 * Writeback this updated value only if tailcall succeeds.
+ 	 */
+ 	EMIT(PPC_RAW_ADDI(bpf_to_ppc(TMP_REG_1), bpf_to_ppc(TMP_REG_1), 1));
+-	EMIT(PPC_RAW_STD(bpf_to_ppc(TMP_REG_1), _R1, bpf_jit_stack_tailcallcnt(ctx)));
+ 
+ 	/* prog = array->ptrs[index]; */
+-	EMIT(PPC_RAW_MULI(bpf_to_ppc(TMP_REG_1), b2p_index, 8));
+-	EMIT(PPC_RAW_ADD(bpf_to_ppc(TMP_REG_1), bpf_to_ppc(TMP_REG_1), b2p_bpf_array));
+-	EMIT(PPC_RAW_LD(bpf_to_ppc(TMP_REG_1), bpf_to_ppc(TMP_REG_1), offsetof(struct bpf_array, ptrs)));
++	EMIT(PPC_RAW_MULI(bpf_to_ppc(TMP_REG_2), b2p_index, 8));
++	EMIT(PPC_RAW_ADD(bpf_to_ppc(TMP_REG_2), bpf_to_ppc(TMP_REG_2), b2p_bpf_array));
++	EMIT(PPC_RAW_LD(bpf_to_ppc(TMP_REG_2), bpf_to_ppc(TMP_REG_2),
++			offsetof(struct bpf_array, ptrs)));
+ 
+ 	/*
+ 	 * if (prog == NULL)
+ 	 *   goto out;
+ 	 */
+-	EMIT(PPC_RAW_CMPLDI(bpf_to_ppc(TMP_REG_1), 0));
++	EMIT(PPC_RAW_CMPLDI(bpf_to_ppc(TMP_REG_2), 0));
+ 	PPC_BCC_SHORT(COND_EQ, out);
+ 
+ 	/* goto *(prog->bpf_func + prologue_size); */
+-	EMIT(PPC_RAW_LD(bpf_to_ppc(TMP_REG_1), bpf_to_ppc(TMP_REG_1), offsetof(struct bpf_prog, bpf_func)));
+-	EMIT(PPC_RAW_ADDI(bpf_to_ppc(TMP_REG_1), bpf_to_ppc(TMP_REG_1),
+-			FUNCTION_DESCR_SIZE + bpf_tailcall_prologue_size));
+-	EMIT(PPC_RAW_MTCTR(bpf_to_ppc(TMP_REG_1)));
++	EMIT(PPC_RAW_LD(bpf_to_ppc(TMP_REG_2), bpf_to_ppc(TMP_REG_2),
++			offsetof(struct bpf_prog, bpf_func)));
++	EMIT(PPC_RAW_ADDI(bpf_to_ppc(TMP_REG_2), bpf_to_ppc(TMP_REG_2),
++			  FUNCTION_DESCR_SIZE + bpf_tailcall_prologue_size));
++	EMIT(PPC_RAW_MTCTR(bpf_to_ppc(TMP_REG_2)));
++
++	/* Writeback updated tailcall count */
++	EMIT(PPC_RAW_STD(bpf_to_ppc(TMP_REG_1), _R1, bpf_jit_stack_tailcallcnt(ctx)));
+ 
+ 	/* tear down stack, restore NVRs, ... */
+ 	bpf_jit_emit_common_epilogue(image, ctx);
+diff --git a/arch/s390/include/asm/barrier.h b/arch/s390/include/asm/barrier.h
+index 82de2a7c41605f..94a7a4fea120d3 100644
+--- a/arch/s390/include/asm/barrier.h
++++ b/arch/s390/include/asm/barrier.h
+@@ -60,8 +60,8 @@ do {									\
+  * @size: number of elements in array
+  */
+ #define array_index_mask_nospec array_index_mask_nospec
+-static inline unsigned long array_index_mask_nospec(unsigned long index,
+-						    unsigned long size)
++static __always_inline unsigned long array_index_mask_nospec(unsigned long index,
++							     unsigned long size)
+ {
+ 	unsigned long mask;
+ 
+diff --git a/arch/s390/kernel/entry.S b/arch/s390/kernel/entry.S
+index 0476ce7700dfaa..b8c5c78b0d1457 100644
+--- a/arch/s390/kernel/entry.S
++++ b/arch/s390/kernel/entry.S
+@@ -300,6 +300,7 @@ SYM_CODE_START(system_call)
+ 	xgr	%r9,%r9
+ 	xgr	%r10,%r10
+ 	xgr	%r11,%r11
++	xgr	%r12,%r12
+ 	la	%r2,STACK_FRAME_OVERHEAD(%r15)	# pointer to pt_regs
+ 	mvc	__PT_R8(64,%r2),__LC_SAVE_AREA_SYNC
+ 	MBEAR	%r2
+@@ -378,6 +379,7 @@ SYM_CODE_START(pgm_check_handler)
+ 	xgr	%r5,%r5
+ 	xgr	%r6,%r6
+ 	xgr	%r7,%r7
++	xgr	%r12,%r12
+ 	lgr	%r2,%r11
+ 	brasl	%r14,__do_pgm_check
+ 	tmhh	%r8,0x0001		# returning to user space?
+@@ -439,6 +441,7 @@ SYM_CODE_START(\name)
+ 	xgr	%r6,%r6
+ 	xgr	%r7,%r7
+ 	xgr	%r10,%r10
++	xgr	%r12,%r12
+ 	xc	__PT_FLAGS(8,%r11),__PT_FLAGS(%r11)
+ 	mvc	__PT_R8(64,%r11),__LC_SAVE_AREA_ASYNC
+ 	MBEAR	%r11
+@@ -547,6 +550,7 @@ SYM_CODE_START(mcck_int_handler)
+ 	xgr	%r6,%r6
+ 	xgr	%r7,%r7
+ 	xgr	%r10,%r10
++	xgr	%r12,%r12
+ 	mvc	__PT_R8(64,%r11),0(%r14)
+ 	stmg	%r8,%r9,__PT_PSW(%r11)
+ 	xc	__PT_FLAGS(8,%r11),__PT_FLAGS(%r11)
+diff --git a/arch/s390/kernel/syscall.c b/arch/s390/kernel/syscall.c
+index dc2355c623d6ea..05818f919d27d6 100644
+--- a/arch/s390/kernel/syscall.c
++++ b/arch/s390/kernel/syscall.c
+@@ -13,6 +13,7 @@
+  */
+ 
+ #include <linux/errno.h>
++#include <linux/nospec.h>
+ #include <linux/sched.h>
+ #include <linux/mm.h>
+ #include <linux/fs.h>
+@@ -141,6 +142,7 @@ static void do_syscall(struct pt_regs *regs)
+ 	if (likely(nr >= NR_syscalls))
+ 		goto out;
+ 	do {
++		nr = array_index_nospec(nr, NR_syscalls);
+ 		regs->gprs[2] = current->thread.sys_call_table[nr](regs);
+ 	} while (test_and_clear_pt_regs_flag(regs, PIF_EXECVE_PGSTE_RESTART));
+ out:
+diff --git a/arch/sh/drivers/platform_early.c b/arch/sh/drivers/platform_early.c
+index 143747c45206fe..48ddbc547bd9ac 100644
+--- a/arch/sh/drivers/platform_early.c
++++ b/arch/sh/drivers/platform_early.c
+@@ -26,10 +26,6 @@ static int platform_match(struct device *dev, struct device_driver *drv)
+ 	struct platform_device *pdev = to_platform_device(dev);
+ 	struct platform_driver *pdrv = to_platform_driver(drv);
+ 
+-	/* When driver_override is set, only bind to the matching driver */
+-	if (pdev->driver_override)
+-		return !strcmp(pdev->driver_override, drv->name);
+-
+ 	/* Then try to match against the id table */
+ 	if (pdrv->id_table)
+ 		return platform_match_id(pdrv->id_table, pdev) != NULL;
+diff --git a/arch/x86/kvm/mmu/mmu.c b/arch/x86/kvm/mmu/mmu.c
+index 04b9b919235ecf..0dc804149b0f38 100644
+--- a/arch/x86/kvm/mmu/mmu.c
++++ b/arch/x86/kvm/mmu/mmu.c
+@@ -2914,12 +2914,6 @@ static int mmu_set_spte(struct kvm_vcpu *vcpu, struct kvm_memory_slot *slot,
+ 	bool prefetch = !fault || fault->prefetch;
+ 	bool write_fault = fault && fault->write;
+ 
+-	if (unlikely(is_noslot_pfn(pfn))) {
+-		vcpu->stat.pf_mmio_spte_created++;
+-		mark_mmio_spte(vcpu, sptep, gfn, pte_access);
+-		return RET_PF_EMULATE;
+-	}
+-
+ 	if (is_shadow_present_pte(*sptep)) {
+ 		/*
+ 		 * If we overwrite a PTE page pointer with a 2MB PMD, unlink
+@@ -2939,6 +2933,14 @@ static int mmu_set_spte(struct kvm_vcpu *vcpu, struct kvm_memory_slot *slot,
+ 			was_rmapped = 1;
+ 	}
+ 
++	if (unlikely(is_noslot_pfn(pfn))) {
++		vcpu->stat.pf_mmio_spte_created++;
++		mark_mmio_spte(vcpu, sptep, gfn, pte_access);
++		if (flush)
++			kvm_flush_remote_tlbs_gfn(vcpu->kvm, gfn, level);
++		return RET_PF_EMULATE;
++	}
++
+ 	wrprot = make_spte(vcpu, sp, slot, pte_access, gfn, pfn, *sptep, prefetch,
+ 			   true, host_writable, &spte);
+ 
+diff --git a/arch/x86/platform/efi/quirks.c b/arch/x86/platform/efi/quirks.c
+index df3b45ef1420ce..a29efaf6fe411e 100644
+--- a/arch/x86/platform/efi/quirks.c
++++ b/arch/x86/platform/efi/quirks.c
+@@ -424,7 +424,7 @@ void __init efi_unmap_boot_services(void)
+ 	if (efi_enabled(EFI_DBG))
+ 		return;
+ 
+-	sz = sizeof(*ranges_to_free) * efi.memmap.nr_map + 1;
++	sz = sizeof(*ranges_to_free) * (efi.memmap.nr_map + 1);
+ 	ranges_to_free = kzalloc(sz, GFP_KERNEL);
+ 	if (!ranges_to_free) {
+ 		pr_err("Failed to allocate storage for freeable EFI regions\n");
+diff --git a/drivers/acpi/ec.c b/drivers/acpi/ec.c
+index 8e304efde3429e..f94cddbbb55acd 100644
+--- a/drivers/acpi/ec.c
++++ b/drivers/acpi/ec.c
+@@ -1653,6 +1653,8 @@ static int acpi_ec_setup(struct acpi_ec *ec, struct acpi_device *device, bool ca
+ 
+ 	ret = ec_install_handlers(ec, device, call_reg);
+ 	if (ret) {
++		ec_remove_handlers(ec);
++
+ 		if (ec == first_ec)
+ 			first_ec = NULL;
+ 
+diff --git a/drivers/base/regmap/regmap.c b/drivers/base/regmap/regmap.c
+index 48860beff95c9f..3b84755c2e54dc 100644
+--- a/drivers/base/regmap/regmap.c
++++ b/drivers/base/regmap/regmap.c
+@@ -1541,6 +1541,7 @@ static int _regmap_select_page(struct regmap *map, unsigned int *reg,
+ 			       unsigned int val_num)
+ {
+ 	void *orig_work_buf;
++	unsigned int selector_reg;
+ 	unsigned int win_offset;
+ 	unsigned int win_page;
+ 	bool page_chg;
+@@ -1559,10 +1560,31 @@ static int _regmap_select_page(struct regmap *map, unsigned int *reg,
+ 			return -EINVAL;
+ 	}
+ 
+-	/* It is possible to have selector register inside data window.
+-	   In that case, selector register is located on every page and
+-	   it needs no page switching, when accessed alone. */
++	/*
++	 * Calculate the address of the selector register in the corresponding
++	 * data window if it is located on every page.
++	 */
++	page_chg = in_range(range->selector_reg, range->window_start, range->window_len);
++	if (page_chg)
++		selector_reg = range->range_min + win_page * range->window_len +
++			       range->selector_reg - range->window_start;
++
++	/*
++	 * It is possible to have selector register inside data window.
++	 * In that case, selector register is located on every page and it
++	 * needs no page switching, when accessed alone.
++	 *
++	 * Nevertheless we should synchronize the cache values for it.
++	 * This can't be properly achieved if the selector register is
++	 * the first and the only one to be read inside the data window.
++	 * That's why we update it in that case as well.
++	 *
++	 * However, we specifically avoid updating it for the default page,
++	 * when it's overlapped with the real data window, to prevent from
++	 * infinite looping.
++	 */
+ 	if (val_num > 1 ||
++	    (page_chg && selector_reg != range->selector_reg) ||
+ 	    range->window_start + win_offset != range->selector_reg) {
+ 		/* Use separate work_buf during page switching */
+ 		orig_work_buf = map->work_buf;
+@@ -1571,7 +1593,7 @@ static int _regmap_select_page(struct regmap *map, unsigned int *reg,
+ 		ret = _regmap_update_bits(map, range->selector_reg,
+ 					  range->selector_mask,
+ 					  win_page << range->selector_shift,
+-					  &page_chg, false);
++					  NULL, false);
+ 
+ 		map->work_buf = orig_work_buf;
+ 
+diff --git a/drivers/bluetooth/btintel.c b/drivers/bluetooth/btintel.c
+index 3773cd9d998d55..25fcd00c6a1748 100644
+--- a/drivers/bluetooth/btintel.c
++++ b/drivers/bluetooth/btintel.c
+@@ -242,11 +242,13 @@ static void btintel_hw_error(struct hci_dev *hdev, u8 code)
+ 
+ 	bt_dev_err(hdev, "Hardware error 0x%2.2x", code);
+ 
++	hci_req_sync_lock(hdev);
++
+ 	skb = __hci_cmd_sync(hdev, HCI_OP_RESET, 0, NULL, HCI_INIT_TIMEOUT);
+ 	if (IS_ERR(skb)) {
+ 		bt_dev_err(hdev, "Reset after hardware error failed (%ld)",
+ 			   PTR_ERR(skb));
+-		return;
++		goto unlock;
+ 	}
+ 	kfree_skb(skb);
+ 
+@@ -254,18 +256,21 @@ static void btintel_hw_error(struct hci_dev *hdev, u8 code)
+ 	if (IS_ERR(skb)) {
+ 		bt_dev_err(hdev, "Retrieving Intel exception info failed (%ld)",
+ 			   PTR_ERR(skb));
+-		return;
++		goto unlock;
+ 	}
+ 
+ 	if (skb->len != 13) {
+ 		bt_dev_err(hdev, "Exception info size mismatch");
+ 		kfree_skb(skb);
+-		return;
++		goto unlock;
+ 	}
+ 
+ 	bt_dev_err(hdev, "Exception info %s", (char *)(skb->data + 1));
+ 
+ 	kfree_skb(skb);
++
++unlock:
++	hci_req_sync_unlock(hdev);
+ }
+ 
+ int btintel_version_info(struct hci_dev *hdev, struct intel_version *ver)
+diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
+index 168e46ce59976a..c51523d780e653 100644
+--- a/drivers/bluetooth/btusb.c
++++ b/drivers/bluetooth/btusb.c
+@@ -2314,8 +2314,11 @@ static void btusb_work(struct work_struct *work)
+ 		if (data->air_mode == HCI_NOTIFY_ENABLE_SCO_CVSD) {
+ 			if (hdev->voice_setting & 0x0020) {
+ 				static const int alts[3] = { 2, 4, 5 };
++				unsigned int sco_idx;
+ 
+-				new_alts = alts[data->sco_num - 1];
++				sco_idx = min_t(unsigned int, data->sco_num - 1,
++						ARRAY_SIZE(alts) - 1);
++				new_alts = alts[sco_idx];
+ 			} else {
+ 				new_alts = data->sco_num;
+ 			}
+diff --git a/drivers/bluetooth/hci_ll.c b/drivers/bluetooth/hci_ll.c
+index 4a0b5c3160c2b6..4d987dece2d0ca 100644
+--- a/drivers/bluetooth/hci_ll.c
++++ b/drivers/bluetooth/hci_ll.c
+@@ -541,6 +541,8 @@ static int download_firmware(struct ll_device *lldev)
+ 	if (err || !fw->data || !fw->size) {
+ 		bt_dev_err(lldev->hu.hdev, "request_firmware failed(errno %d) for %s",
+ 			   err, bts_scr_name);
++		if (!err)
++			release_firmware(fw);
+ 		return -EINVAL;
+ 	}
+ 	ptr = (void *)fw->data;
+diff --git a/drivers/cpufreq/cpufreq_conservative.c b/drivers/cpufreq/cpufreq_conservative.c
+index b6bd0ff3532349..efdcc4ab43340a 100644
+--- a/drivers/cpufreq/cpufreq_conservative.c
++++ b/drivers/cpufreq/cpufreq_conservative.c
+@@ -314,6 +314,17 @@ static void cs_start(struct cpufreq_policy *policy)
+ 	dbs_info->requested_freq = policy->cur;
+ }
+ 
++static void cs_limits(struct cpufreq_policy *policy)
++{
++	struct cs_policy_dbs_info *dbs_info = to_dbs_info(policy->governor_data);
++
++	/*
++	 * The limits have changed, so may have the current frequency. Reset
++	 * requested_freq to avoid any unintended outcomes due to the mismatch.
++	 */
++	dbs_info->requested_freq = policy->cur;
++}
++
+ static struct dbs_governor cs_governor = {
+ 	.gov = CPUFREQ_DBS_GOVERNOR_INITIALIZER("conservative"),
+ 	.kobj_type = { .default_groups = cs_groups },
+@@ -323,6 +334,7 @@ static struct dbs_governor cs_governor = {
+ 	.init = cs_init,
+ 	.exit = cs_exit,
+ 	.start = cs_start,
++	.limits = cs_limits,
+ };
+ 
+ #define CPU_FREQ_GOV_CONSERVATIVE	(cs_governor.gov)
+diff --git a/drivers/cpufreq/cpufreq_governor.c b/drivers/cpufreq/cpufreq_governor.c
+index 1a7fcaf39cc9b5..8f5474612b3124 100644
+--- a/drivers/cpufreq/cpufreq_governor.c
++++ b/drivers/cpufreq/cpufreq_governor.c
+@@ -563,6 +563,7 @@ EXPORT_SYMBOL_GPL(cpufreq_dbs_governor_stop);
+ 
+ void cpufreq_dbs_governor_limits(struct cpufreq_policy *policy)
+ {
++	struct dbs_governor *gov = dbs_governor_of(policy);
+ 	struct policy_dbs_info *policy_dbs;
+ 
+ 	/* Protect gov->gdbs_data against cpufreq_dbs_governor_exit() */
+@@ -574,6 +575,8 @@ void cpufreq_dbs_governor_limits(struct cpufreq_policy *policy)
+ 	mutex_lock(&policy_dbs->update_mutex);
+ 	cpufreq_policy_apply_limits(policy);
+ 	gov_update_sample_delay(policy_dbs, 0);
++	if (gov->limits)
++		gov->limits(policy);
+ 	mutex_unlock(&policy_dbs->update_mutex);
+ 
+ out:
+diff --git a/drivers/cpufreq/cpufreq_governor.h b/drivers/cpufreq/cpufreq_governor.h
+index 168c23fd7fcac7..1462d59277bd12 100644
+--- a/drivers/cpufreq/cpufreq_governor.h
++++ b/drivers/cpufreq/cpufreq_governor.h
+@@ -138,6 +138,7 @@ struct dbs_governor {
+ 	int (*init)(struct dbs_data *dbs_data);
+ 	void (*exit)(struct dbs_data *dbs_data);
+ 	void (*start)(struct cpufreq_policy *policy);
++	void (*limits)(struct cpufreq_policy *policy);
+ };
+ 
+ static inline struct dbs_governor *dbs_governor_of(struct cpufreq_policy *policy)
+diff --git a/drivers/cxl/core/hdm.c b/drivers/cxl/core/hdm.c
+index f9738c863df0e1..dc4dff7a2d38da 100644
+--- a/drivers/cxl/core/hdm.c
++++ b/drivers/cxl/core/hdm.c
+@@ -119,7 +119,6 @@ static bool should_emulate_decoders(struct cxl_endpoint_dvsec_info *info)
+ 	struct cxl_hdm *cxlhdm;
+ 	void __iomem *hdm;
+ 	u32 ctrl;
+-	int i;
+ 
+ 	if (!info)
+ 		return false;
+@@ -138,22 +137,16 @@ static bool should_emulate_decoders(struct cxl_endpoint_dvsec_info *info)
+ 		return false;
+ 
+ 	/*
+-	 * If any decoders are committed already, there should not be any
+-	 * emulated DVSEC decoders.
++	 * If HDM decoders are globally enabled, do not fall back to DVSEC
++	 * range emulation. Zeroed decoder registers after region teardown
++	 * do not imply absence of HDM capability.
++	 *
++	 * Falling back to DVSEC here would treat the decoder as AUTO and
++	 * may incorrectly latch default interleave settings.
+ 	 */
+-	for (i = 0; i < cxlhdm->decoder_count; i++) {
+-		ctrl = readl(hdm + CXL_HDM_DECODER0_CTRL_OFFSET(i));
+-		dev_dbg(&info->port->dev,
+-			"decoder%d.%d: committed: %ld base: %#x_%.8x size: %#x_%.8x\n",
+-			info->port->id, i,
+-			FIELD_GET(CXL_HDM_DECODER0_CTRL_COMMITTED, ctrl),
+-			readl(hdm + CXL_HDM_DECODER0_BASE_HIGH_OFFSET(i)),
+-			readl(hdm + CXL_HDM_DECODER0_BASE_LOW_OFFSET(i)),
+-			readl(hdm + CXL_HDM_DECODER0_SIZE_HIGH_OFFSET(i)),
+-			readl(hdm + CXL_HDM_DECODER0_SIZE_LOW_OFFSET(i)));
+-		if (FIELD_GET(CXL_HDM_DECODER0_CTRL_COMMITTED, ctrl))
+-			return false;
+-	}
++	ctrl = readl(hdm + CXL_HDM_DECODER_CTRL_OFFSET);
++	if (ctrl & CXL_HDM_DECODER_ENABLE)
++		return false;
+ 
+ 	return true;
+ }
+diff --git a/drivers/dma/dw-edma/dw-hdma-v0-core.c b/drivers/dma/dw-edma/dw-hdma-v0-core.c
+index e3f8db4fe909a1..ce8f7254bab21b 100644
+--- a/drivers/dma/dw-edma/dw-hdma-v0-core.c
++++ b/drivers/dma/dw-edma/dw-hdma-v0-core.c
+@@ -252,10 +252,10 @@ static void dw_hdma_v0_core_start(struct dw_edma_chunk *chunk, bool first)
+ 			  lower_32_bits(chunk->ll_region.paddr));
+ 		SET_CH_32(dw, chan->dir, chan->id, llp.msb,
+ 			  upper_32_bits(chunk->ll_region.paddr));
++		/* Set consumer cycle */
++		SET_CH_32(dw, chan->dir, chan->id, cycle_sync,
++			HDMA_V0_CONSUMER_CYCLE_STAT | HDMA_V0_CONSUMER_CYCLE_BIT);
+ 	}
+-	/* Set consumer cycle */
+-	SET_CH_32(dw, chan->dir, chan->id, cycle_sync,
+-		  HDMA_V0_CONSUMER_CYCLE_STAT | HDMA_V0_CONSUMER_CYCLE_BIT);
+ 
+ 	dw_hdma_v0_sync_ll_data(chunk);
+ 
+diff --git a/drivers/dma/idxd/cdev.c b/drivers/dma/idxd/cdev.c
+index aa39fcd389a942..5ded4a0887bc84 100644
+--- a/drivers/dma/idxd/cdev.c
++++ b/drivers/dma/idxd/cdev.c
+@@ -161,11 +161,7 @@ static struct device_type idxd_cdev_file_type = {
+ static void idxd_cdev_dev_release(struct device *dev)
+ {
+ 	struct idxd_cdev *idxd_cdev = dev_to_cdev(dev);
+-	struct idxd_cdev_context *cdev_ctx;
+-	struct idxd_wq *wq = idxd_cdev->wq;
+ 
+-	cdev_ctx = &ictx[wq->idxd->data->type];
+-	ida_simple_remove(&cdev_ctx->minor_ida, idxd_cdev->minor);
+ 	kfree(idxd_cdev);
+ }
+ 
+@@ -550,7 +546,7 @@ int idxd_wq_add_cdev(struct idxd_wq *wq)
+ 	cdev = &idxd_cdev->cdev;
+ 	dev = cdev_dev(idxd_cdev);
+ 	cdev_ctx = &ictx[wq->idxd->data->type];
+-	minor = ida_simple_get(&cdev_ctx->minor_ida, 0, MINORMASK, GFP_KERNEL);
++	minor = ida_alloc_max(&cdev_ctx->minor_ida, MINORMASK, GFP_KERNEL);
+ 	if (minor < 0) {
+ 		kfree(idxd_cdev);
+ 		return minor;
+@@ -585,11 +581,15 @@ int idxd_wq_add_cdev(struct idxd_wq *wq)
+ 
+ void idxd_wq_del_cdev(struct idxd_wq *wq)
+ {
++	struct idxd_cdev_context *cdev_ctx;
+ 	struct idxd_cdev *idxd_cdev;
+ 
+ 	idxd_cdev = wq->idxd_cdev;
+ 	wq->idxd_cdev = NULL;
+ 	cdev_device_del(&idxd_cdev->cdev, cdev_dev(idxd_cdev));
++
++	cdev_ctx = &ictx[wq->idxd->data->type];
++	ida_free(&cdev_ctx->minor_ida, idxd_cdev->minor);
+ 	put_device(cdev_dev(idxd_cdev));
+ }
+ 
+diff --git a/drivers/dma/idxd/device.c b/drivers/dma/idxd/device.c
+index 542d340552dd71..44bbeb3acd14ee 100644
+--- a/drivers/dma/idxd/device.c
++++ b/drivers/dma/idxd/device.c
+@@ -173,6 +173,7 @@ void idxd_wq_free_resources(struct idxd_wq *wq)
+ 	free_descs(wq);
+ 	dma_free_coherent(dev, wq->compls_size, wq->compls, wq->compls_addr);
+ 	sbitmap_queue_free(&wq->sbq);
++	wq->type = IDXD_WQT_NONE;
+ }
+ 
+ int idxd_wq_enable(struct idxd_wq *wq)
+@@ -365,7 +366,6 @@ static void idxd_wq_disable_cleanup(struct idxd_wq *wq)
+ 	lockdep_assert_held(&wq->wq_lock);
+ 	wq->state = IDXD_WQ_DISABLED;
+ 	memset(wq->wqcfg, 0, idxd->wqcfg_size);
+-	wq->type = IDXD_WQT_NONE;
+ 	wq->threshold = 0;
+ 	wq->priority = 0;
+ 	wq->enqcmds_retries = IDXD_ENQCMDS_RETRIES;
+@@ -1507,7 +1507,6 @@ void drv_disable_wq(struct idxd_wq *wq)
+ 	idxd_wq_reset(wq);
+ 	idxd_wq_free_resources(wq);
+ 	percpu_ref_exit(&wq->wq_active);
+-	wq->type = IDXD_WQT_NONE;
+ 	wq->client_count = 0;
+ }
+ 
+diff --git a/drivers/dma/idxd/sysfs.c b/drivers/dma/idxd/sysfs.c
+index 3a5ce477a81ad6..7971db45709f84 100644
+--- a/drivers/dma/idxd/sysfs.c
++++ b/drivers/dma/idxd/sysfs.c
+@@ -1810,6 +1810,7 @@ static void idxd_conf_device_release(struct device *dev)
+ {
+ 	struct idxd_device *idxd = confdev_to_idxd(dev);
+ 
++	destroy_workqueue(idxd->wq);
+ 	kfree(idxd->groups);
+ 	bitmap_free(idxd->wq_enable_map);
+ 	kfree(idxd->wqs);
+diff --git a/drivers/dma/sh/rz-dmac.c b/drivers/dma/sh/rz-dmac.c
+index d11be188477466..e5d89bc1bb83e7 100644
+--- a/drivers/dma/sh/rz-dmac.c
++++ b/drivers/dma/sh/rz-dmac.c
+@@ -10,6 +10,7 @@
+  */
+ 
+ #include <linux/bitfield.h>
++#include <linux/cleanup.h>
+ #include <linux/dma-mapping.h>
+ #include <linux/dmaengine.h>
+ #include <linux/interrupt.h>
+@@ -285,13 +286,10 @@ static void rz_dmac_disable_hw(struct rz_dmac_chan *channel)
+ {
+ 	struct dma_chan *chan = &channel->vc.chan;
+ 	struct rz_dmac *dmac = to_rz_dmac(chan->device);
+-	unsigned long flags;
+ 
+ 	dev_dbg(dmac->dev, "%s channel %d\n", __func__, channel->index);
+ 
+-	local_irq_save(flags);
+ 	rz_dmac_ch_writel(channel, CHCTRL_DEFAULT, CHCTRL, 1);
+-	local_irq_restore(flags);
+ }
+ 
+ static void rz_dmac_set_dmars_register(struct rz_dmac *dmac, int nr, u32 dmars)
+@@ -424,6 +422,7 @@ static int rz_dmac_alloc_chan_resources(struct dma_chan *chan)
+ 		if (!desc)
+ 			break;
+ 
++		/* No need to lock. This is called only for the 1st client. */
+ 		list_add_tail(&desc->node, &channel->ld_free);
+ 		channel->descs_allocated++;
+ 	}
+@@ -479,18 +478,21 @@ rz_dmac_prep_dma_memcpy(struct dma_chan *chan, dma_addr_t dest, dma_addr_t src,
+ 	dev_dbg(dmac->dev, "%s channel: %d src=0x%pad dst=0x%pad len=%zu\n",
+ 		__func__, channel->index, &src, &dest, len);
+ 
+-	if (list_empty(&channel->ld_free))
+-		return NULL;
++	scoped_guard(spinlock_irqsave, &channel->vc.lock) {
++		if (list_empty(&channel->ld_free))
++			return NULL;
+ 
+-	desc = list_first_entry(&channel->ld_free, struct rz_dmac_desc, node);
++		desc = list_first_entry(&channel->ld_free, struct rz_dmac_desc, node);
+ 
+-	desc->type = RZ_DMAC_DESC_MEMCPY;
+-	desc->src = src;
+-	desc->dest = dest;
+-	desc->len = len;
+-	desc->direction = DMA_MEM_TO_MEM;
++		desc->type = RZ_DMAC_DESC_MEMCPY;
++		desc->src = src;
++		desc->dest = dest;
++		desc->len = len;
++		desc->direction = DMA_MEM_TO_MEM;
++
++		list_move_tail(channel->ld_free.next, &channel->ld_queue);
++	}
+ 
+-	list_move_tail(channel->ld_free.next, &channel->ld_queue);
+ 	return vchan_tx_prep(&channel->vc, &desc->vd, flags);
+ }
+ 
+@@ -506,27 +508,29 @@ rz_dmac_prep_slave_sg(struct dma_chan *chan, struct scatterlist *sgl,
+ 	int dma_length = 0;
+ 	int i = 0;
+ 
+-	if (list_empty(&channel->ld_free))
+-		return NULL;
++	scoped_guard(spinlock_irqsave, &channel->vc.lock) {
++		if (list_empty(&channel->ld_free))
++			return NULL;
+ 
+-	desc = list_first_entry(&channel->ld_free, struct rz_dmac_desc, node);
++		desc = list_first_entry(&channel->ld_free, struct rz_dmac_desc, node);
+ 
+-	for_each_sg(sgl, sg, sg_len, i) {
+-		dma_length += sg_dma_len(sg);
+-	}
++		for_each_sg(sgl, sg, sg_len, i)
++			dma_length += sg_dma_len(sg);
+ 
+-	desc->type = RZ_DMAC_DESC_SLAVE_SG;
+-	desc->sg = sgl;
+-	desc->sgcount = sg_len;
+-	desc->len = dma_length;
+-	desc->direction = direction;
++		desc->type = RZ_DMAC_DESC_SLAVE_SG;
++		desc->sg = sgl;
++		desc->sgcount = sg_len;
++		desc->len = dma_length;
++		desc->direction = direction;
+ 
+-	if (direction == DMA_DEV_TO_MEM)
+-		desc->src = channel->src_per_address;
+-	else
+-		desc->dest = channel->dst_per_address;
++		if (direction == DMA_DEV_TO_MEM)
++			desc->src = channel->src_per_address;
++		else
++			desc->dest = channel->dst_per_address;
++
++		list_move_tail(channel->ld_free.next, &channel->ld_queue);
++	}
+ 
+-	list_move_tail(channel->ld_free.next, &channel->ld_queue);
+ 	return vchan_tx_prep(&channel->vc, &desc->vd, flags);
+ }
+ 
+@@ -538,8 +542,8 @@ static int rz_dmac_terminate_all(struct dma_chan *chan)
+ 	unsigned int i;
+ 	LIST_HEAD(head);
+ 
+-	rz_dmac_disable_hw(channel);
+ 	spin_lock_irqsave(&channel->vc.lock, flags);
++	rz_dmac_disable_hw(channel);
+ 	for (i = 0; i < DMAC_NR_LMDESC; i++)
+ 		lmdesc[i].header = 0;
+ 
+@@ -667,7 +671,9 @@ static void rz_dmac_irq_handle_channel(struct rz_dmac_chan *channel)
+ 	if (chstat & CHSTAT_ER) {
+ 		dev_err(dmac->dev, "DMAC err CHSTAT_%d = %08X\n",
+ 			channel->index, chstat);
+-		rz_dmac_ch_writel(channel, CHCTRL_DEFAULT, CHCTRL, 1);
++
++		scoped_guard(spinlock_irqsave, &channel->vc.lock)
++			rz_dmac_ch_writel(channel, CHCTRL_DEFAULT, CHCTRL, 1);
+ 		goto done;
+ 	}
+ 
+diff --git a/drivers/dma/xilinx/xdma.c b/drivers/dma/xilinx/xdma.c
+index dbab4c44991435..d806bb1162aef1 100644
+--- a/drivers/dma/xilinx/xdma.c
++++ b/drivers/dma/xilinx/xdma.c
+@@ -901,8 +901,8 @@ static int xdma_probe(struct platform_device *pdev)
+ 
+ 	xdev->rmap = devm_regmap_init_mmio(&pdev->dev, reg_base,
+ 					   &xdma_regmap_config);
+-	if (!xdev->rmap) {
+-		xdma_err(xdev, "config regmap failed: %d", ret);
++	if (IS_ERR(xdev->rmap)) {
++		xdma_err(xdev, "config regmap failed: %pe", xdev->rmap);
+ 		goto failed;
+ 	}
+ 	INIT_LIST_HEAD(&xdev->dma_dev.channels);
+diff --git a/drivers/dma/xilinx/xilinx_dma.c b/drivers/dma/xilinx/xilinx_dma.c
+index 176cac3f37a73a..3d728dd1ecde1d 100644
+--- a/drivers/dma/xilinx/xilinx_dma.c
++++ b/drivers/dma/xilinx/xilinx_dma.c
+@@ -994,16 +994,16 @@ static u32 xilinx_dma_get_residue(struct xilinx_dma_chan *chan,
+ 					      struct xilinx_cdma_tx_segment,
+ 					      node);
+ 			cdma_hw = &cdma_seg->hw;
+-			residue += (cdma_hw->control - cdma_hw->status) &
+-				   chan->xdev->max_buffer_len;
++			residue += (cdma_hw->control & chan->xdev->max_buffer_len) -
++			           (cdma_hw->status & chan->xdev->max_buffer_len);
+ 		} else if (chan->xdev->dma_config->dmatype ==
+ 			   XDMA_TYPE_AXIDMA) {
+ 			axidma_seg = list_entry(entry,
+ 						struct xilinx_axidma_tx_segment,
+ 						node);
+ 			axidma_hw = &axidma_seg->hw;
+-			residue += (axidma_hw->control - axidma_hw->status) &
+-				   chan->xdev->max_buffer_len;
++			residue += (axidma_hw->control & chan->xdev->max_buffer_len) -
++			           (axidma_hw->status & chan->xdev->max_buffer_len);
+ 		} else {
+ 			aximcdma_seg =
+ 				list_entry(entry,
+@@ -1011,8 +1011,8 @@ static u32 xilinx_dma_get_residue(struct xilinx_dma_chan *chan,
+ 					   node);
+ 			aximcdma_hw = &aximcdma_seg->hw;
+ 			residue +=
+-				(aximcdma_hw->control - aximcdma_hw->status) &
+-				chan->xdev->max_buffer_len;
++				(aximcdma_hw->control & chan->xdev->max_buffer_len) -
++				(aximcdma_hw->status & chan->xdev->max_buffer_len);
+ 		}
+ 	}
+ 
+@@ -1214,14 +1214,6 @@ static int xilinx_dma_alloc_chan_resources(struct dma_chan *dchan)
+ 
+ 	dma_cookie_init(dchan);
+ 
+-	if (chan->xdev->dma_config->dmatype == XDMA_TYPE_AXIDMA) {
+-		/* For AXI DMA resetting once channel will reset the
+-		 * other channel as well so enable the interrupts here.
+-		 */
+-		dma_ctrl_set(chan, XILINX_DMA_REG_DMACR,
+-			      XILINX_DMA_DMAXR_ALL_IRQ_MASK);
+-	}
+-
+ 	if ((chan->xdev->dma_config->dmatype == XDMA_TYPE_CDMA) && chan->has_sg)
+ 		dma_ctrl_set(chan, XILINX_DMA_REG_DMACR,
+ 			     XILINX_CDMA_CR_SGMODE);
+@@ -1541,8 +1533,29 @@ static void xilinx_dma_start_transfer(struct xilinx_dma_chan *chan)
+ 	if (chan->err)
+ 		return;
+ 
+-	if (list_empty(&chan->pending_list))
++	if (list_empty(&chan->pending_list)) {
++		if (chan->cyclic) {
++			struct xilinx_dma_tx_descriptor *desc;
++			struct list_head *entry;
++
++			desc = list_last_entry(&chan->done_list,
++					       struct xilinx_dma_tx_descriptor, node);
++			list_for_each(entry, &desc->segments) {
++				struct xilinx_axidma_tx_segment *axidma_seg;
++				struct xilinx_axidma_desc_hw *axidma_hw;
++				axidma_seg = list_entry(entry,
++							struct xilinx_axidma_tx_segment,
++							node);
++				axidma_hw = &axidma_seg->hw;
++				axidma_hw->status = 0;
++			}
++
++			list_splice_tail_init(&chan->done_list, &chan->active_list);
++			chan->desc_pendingcount = 0;
++			chan->idle = false;
++		}
+ 		return;
++	}
+ 
+ 	if (!chan->idle)
+ 		return;
+@@ -1568,6 +1581,7 @@ static void xilinx_dma_start_transfer(struct xilinx_dma_chan *chan)
+ 			     head_desc->async_tx.phys);
+ 	reg  &= ~XILINX_DMA_CR_DELAY_MAX;
+ 	reg  |= chan->irq_delay << XILINX_DMA_CR_DELAY_SHIFT;
++	reg |= XILINX_DMA_DMAXR_ALL_IRQ_MASK;
+ 	dma_ctrl_write(chan, XILINX_DMA_REG_DMACR, reg);
+ 
+ 	xilinx_dma_start(chan);
+@@ -2901,7 +2915,7 @@ static int xilinx_dma_chan_probe(struct xilinx_dma_device *xdev,
+ 		return -EINVAL;
+ 	}
+ 
+-	xdev->common.directions |= chan->direction;
++	xdev->common.directions |= BIT(chan->direction);
+ 
+ 	/* Request the interrupt */
+ 	chan->irq = of_irq_get(node, chan->tdest);
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd.c
+index fbee10927bfb64..946264a87d0e8a 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd.c
+@@ -670,9 +670,9 @@ int amdgpu_amdkfd_submit_ib(struct amdgpu_device *adev,
+ 		goto err_ib_sched;
+ 	}
+ 
+-	/* Drop the initial kref_init count (see drm_sched_main as example) */
+-	dma_fence_put(f);
+ 	ret = dma_fence_wait(f, false);
++	/* Drop the returned fence reference after the wait completes */
++	dma_fence_put(f);
+ 
+ err_ib_sched:
+ 	amdgpu_job_free(job);
+diff --git a/drivers/gpu/drm/i915/display/intel_gmbus.c b/drivers/gpu/drm/i915/display/intel_gmbus.c
+index e95ddb580ef6cc..a01e655c24ff35 100644
+--- a/drivers/gpu/drm/i915/display/intel_gmbus.c
++++ b/drivers/gpu/drm/i915/display/intel_gmbus.c
+@@ -460,8 +460,10 @@ gmbus_xfer_read_chunk(struct drm_i915_private *i915,
+ 
+ 		val = intel_de_read_fw(i915, GMBUS3(i915));
+ 		do {
+-			if (extra_byte_added && len == 1)
++			if (extra_byte_added && len == 1) {
++				len--;
+ 				break;
++			}
+ 
+ 			*buf++ = val & 0xff;
+ 			val >>= 8;
+diff --git a/drivers/hid/hid-apple.c b/drivers/hid/hid-apple.c
+index 9dd5c698fefe05..6fae3427218fc6 100644
+--- a/drivers/hid/hid-apple.c
++++ b/drivers/hid/hid-apple.c
+@@ -645,9 +645,7 @@ static __u8 *apple_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 		hid_info(hdev,
+ 			 "fixing up Magic Keyboard battery report descriptor\n");
+ 		*rsize = *rsize - 1;
+-		rdesc = kmemdup(rdesc + 1, *rsize, GFP_KERNEL);
+-		if (!rdesc)
+-			return NULL;
++		rdesc = rdesc + 1;
+ 
+ 		rdesc[0] = 0x05;
+ 		rdesc[1] = 0x01;
+diff --git a/drivers/hid/hid-asus.c b/drivers/hid/hid-asus.c
+index d971e339b5eac7..544b74eda284ae 100644
+--- a/drivers/hid/hid-asus.c
++++ b/drivers/hid/hid-asus.c
+@@ -1200,14 +1200,21 @@ static __u8 *asus_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 		 */
+ 		if (*rsize == rsize_orig &&
+ 			rdesc[offs] == 0x09 && rdesc[offs + 1] == 0x76) {
+-			*rsize = rsize_orig + 1;
+-			rdesc = kmemdup(rdesc, *rsize, GFP_KERNEL);
+-			if (!rdesc)
+-				return NULL;
++			__u8 *new_rdesc;
++
++			new_rdesc = devm_kzalloc(&hdev->dev, rsize_orig + 1,
++						 GFP_KERNEL);
++			if (!new_rdesc)
++				return rdesc;
+ 
+ 			hid_info(hdev, "Fixing up %s keyb report descriptor\n",
+ 				drvdata->quirks & QUIRK_T100CHI ?
+ 				"T100CHI" : "T90CHI");
++
++			memcpy(new_rdesc, rdesc, rsize_orig);
++			*rsize = rsize_orig + 1;
++			rdesc = new_rdesc;
++
+ 			memmove(rdesc + offs + 4, rdesc + offs + 2, 12);
+ 			rdesc[offs] = 0x19;
+ 			rdesc[offs + 1] = 0x00;
+@@ -1291,6 +1298,9 @@ static const struct hid_device_id asus_devices[] = {
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
+ 	    USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY_X),
+ 	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
++	    USB_DEVICE_ID_ASUSTEK_XGM_2023),
++	},
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
+ 	    USB_DEVICE_ID_ASUSTEK_ROG_CLAYMORE_II_KEYBOARD),
+ 	  QUIRK_ROG_CLAYMORE_II_KEYBOARD },
+diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
+index a1910e12f7e05f..2057546b268231 100644
+--- a/drivers/hid/hid-ids.h
++++ b/drivers/hid/hid-ids.h
+@@ -219,6 +219,7 @@
+ #define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY_X		0x1b4c
+ #define USB_DEVICE_ID_ASUSTEK_ROG_CLAYMORE_II_KEYBOARD	0x196b
+ #define USB_DEVICE_ID_ASUSTEK_FX503VD_KEYBOARD	0x1869
++#define USB_DEVICE_ID_ASUSTEK_XGM_2023	0x1a9a
+ 
+ #define USB_VENDOR_ID_ATEN		0x0557
+ #define USB_DEVICE_ID_ATEN_UC100KM	0x2004
+diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
+index 99d0dbf62af378..d5df2745f3da44 100644
+--- a/drivers/hid/hid-magicmouse.c
++++ b/drivers/hid/hid-magicmouse.c
+@@ -963,13 +963,11 @@ static __u8 *magicmouse_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 	 */
+ 	if ((is_usb_magicmouse2(hdev->vendor, hdev->product) ||
+ 	     is_usb_magictrackpad2(hdev->vendor, hdev->product)) &&
+-	    *rsize == 83 && rdesc[46] == 0x84 && rdesc[58] == 0x85) {
++	    *rsize >= 83 && rdesc[46] == 0x84 && rdesc[58] == 0x85) {
+ 		hid_info(hdev,
+ 			 "fixing up magicmouse battery report descriptor\n");
+ 		*rsize = *rsize - 1;
+-		rdesc = kmemdup(rdesc + 1, *rsize, GFP_KERNEL);
+-		if (!rdesc)
+-			return NULL;
++		rdesc = rdesc + 1;
+ 
+ 		rdesc[0] = 0x05;
+ 		rdesc[1] = 0x01;
+diff --git a/drivers/hid/hid-mcp2221.c b/drivers/hid/hid-mcp2221.c
+index d2d413c829f44a..99af0b541316bf 100644
+--- a/drivers/hid/hid-mcp2221.c
++++ b/drivers/hid/hid-mcp2221.c
+@@ -337,6 +337,8 @@ static int mcp_i2c_smbus_read(struct mcp2221 *mcp,
+ 				usleep_range(90, 100);
+ 				retries++;
+ 			} else {
++				usleep_range(980, 1000);
++				mcp_cancel_last_cmd(mcp);
+ 				return ret;
+ 			}
+ 		} else {
+diff --git a/drivers/hwmon/adm1177.c b/drivers/hwmon/adm1177.c
+index 60a893f271597b..7581fd2456f9b0 100644
+--- a/drivers/hwmon/adm1177.c
++++ b/drivers/hwmon/adm1177.c
+@@ -10,6 +10,8 @@
+ #include <linux/hwmon.h>
+ #include <linux/i2c.h>
+ #include <linux/init.h>
++#include <linux/math64.h>
++#include <linux/minmax.h>
+ #include <linux/module.h>
+ #include <linux/regulator/consumer.h>
+ 
+@@ -33,7 +35,7 @@
+ struct adm1177_state {
+ 	struct i2c_client	*client;
+ 	u32			r_sense_uohm;
+-	u32			alert_threshold_ua;
++	u64			alert_threshold_ua;
+ 	bool			vrange_high;
+ };
+ 
+@@ -48,7 +50,7 @@ static int adm1177_write_cmd(struct adm1177_state *st, u8 cmd)
+ }
+ 
+ static int adm1177_write_alert_thr(struct adm1177_state *st,
+-				   u32 alert_threshold_ua)
++				   u64 alert_threshold_ua)
+ {
+ 	u64 val;
+ 	int ret;
+@@ -91,8 +93,8 @@ static int adm1177_read(struct device *dev, enum hwmon_sensor_types type,
+ 			*val = div_u64((105840000ull * dummy),
+ 				       4096 * st->r_sense_uohm);
+ 			return 0;
+-		case hwmon_curr_max_alarm:
+-			*val = st->alert_threshold_ua;
++		case hwmon_curr_max:
++			*val = div_u64(st->alert_threshold_ua, 1000);
+ 			return 0;
+ 		default:
+ 			return -EOPNOTSUPP;
+@@ -126,9 +128,10 @@ static int adm1177_write(struct device *dev, enum hwmon_sensor_types type,
+ 	switch (type) {
+ 	case hwmon_curr:
+ 		switch (attr) {
+-		case hwmon_curr_max_alarm:
+-			adm1177_write_alert_thr(st, val);
+-			return 0;
++		case hwmon_curr_max:
++			val = clamp_val(val, 0,
++					div_u64(105840000ULL, st->r_sense_uohm));
++			return adm1177_write_alert_thr(st, (u64)val * 1000);
+ 		default:
+ 			return -EOPNOTSUPP;
+ 		}
+@@ -156,7 +159,7 @@ static umode_t adm1177_is_visible(const void *data,
+ 			if (st->r_sense_uohm)
+ 				return 0444;
+ 			return 0;
+-		case hwmon_curr_max_alarm:
++		case hwmon_curr_max:
+ 			if (st->r_sense_uohm)
+ 				return 0644;
+ 			return 0;
+@@ -170,7 +173,7 @@ static umode_t adm1177_is_visible(const void *data,
+ 
+ static const struct hwmon_channel_info * const adm1177_info[] = {
+ 	HWMON_CHANNEL_INFO(curr,
+-			   HWMON_C_INPUT | HWMON_C_MAX_ALARM),
++			   HWMON_C_INPUT | HWMON_C_MAX),
+ 	HWMON_CHANNEL_INFO(in,
+ 			   HWMON_I_INPUT),
+ 	NULL
+@@ -192,7 +195,8 @@ static int adm1177_probe(struct i2c_client *client)
+ 	struct device *dev = &client->dev;
+ 	struct device *hwmon_dev;
+ 	struct adm1177_state *st;
+-	u32 alert_threshold_ua;
++	u64 alert_threshold_ua;
++	u32 prop;
+ 	int ret;
+ 
+ 	st = devm_kzalloc(dev, sizeof(*st), GFP_KERNEL);
+@@ -208,22 +212,26 @@ static int adm1177_probe(struct i2c_client *client)
+ 	if (device_property_read_u32(dev, "shunt-resistor-micro-ohms",
+ 				     &st->r_sense_uohm))
+ 		st->r_sense_uohm = 0;
+-	if (device_property_read_u32(dev, "adi,shutdown-threshold-microamp",
+-				     &alert_threshold_ua)) {
+-		if (st->r_sense_uohm)
+-			/*
+-			 * set maximum default value from datasheet based on
+-			 * shunt-resistor
+-			 */
+-			alert_threshold_ua = div_u64(105840000000,
+-						     st->r_sense_uohm);
+-		else
+-			alert_threshold_ua = 0;
++	if (!device_property_read_u32(dev, "adi,shutdown-threshold-microamp",
++				      &prop)) {
++		alert_threshold_ua = prop;
++	} else if (st->r_sense_uohm) {
++		/*
++		 * set maximum default value from datasheet based on
++		 * shunt-resistor
++		 */
++		alert_threshold_ua = div_u64(105840000000ULL,
++					     st->r_sense_uohm);
++	} else {
++		alert_threshold_ua = 0;
+ 	}
+ 	st->vrange_high = device_property_read_bool(dev,
+ 						    "adi,vrange-high-enable");
+-	if (alert_threshold_ua && st->r_sense_uohm)
+-		adm1177_write_alert_thr(st, alert_threshold_ua);
++	if (alert_threshold_ua && st->r_sense_uohm) {
++		ret = adm1177_write_alert_thr(st, alert_threshold_ua);
++		if (ret)
++			return ret;
++	}
+ 
+ 	ret = adm1177_write_cmd(st, ADM1177_CMD_V_CONT |
+ 				    ADM1177_CMD_I_CONT |
+diff --git a/drivers/hwmon/axi-fan-control.c b/drivers/hwmon/axi-fan-control.c
+index 19b9bf3d75ef94..641cc06c77aff5 100644
+--- a/drivers/hwmon/axi-fan-control.c
++++ b/drivers/hwmon/axi-fan-control.c
+@@ -13,8 +13,9 @@
+ #include <linux/io.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+-#include <linux/of.h>
++#include <linux/mod_devicetable.h>
+ #include <linux/platform_device.h>
++#include <linux/property.h>
+ 
+ /* register map */
+ #define ADI_REG_RSTN		0x0080
+@@ -368,12 +369,12 @@ static irqreturn_t axi_fan_control_irq_handler(int irq, void *data)
+ }
+ 
+ static int axi_fan_control_init(struct axi_fan_control_data *ctl,
+-				const struct device_node *np)
++				const struct device *dev)
+ {
+ 	int ret;
+ 
+ 	/* get fan pulses per revolution */
+-	ret = of_property_read_u32(np, "pulses-per-revolution", &ctl->ppr);
++	ret = device_property_read_u32(dev, "pulses-per-revolution", &ctl->ppr);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -443,25 +444,16 @@ static struct attribute *axi_fan_control_attrs[] = {
+ };
+ ATTRIBUTE_GROUPS(axi_fan_control);
+ 
+-static const u32 version_1_0_0 = ADI_AXI_PCORE_VER(1, 0, 'a');
+-
+-static const struct of_device_id axi_fan_control_of_match[] = {
+-	{ .compatible = "adi,axi-fan-control-1.00.a",
+-		.data = (void *)&version_1_0_0},
+-	{},
+-};
+-MODULE_DEVICE_TABLE(of, axi_fan_control_of_match);
+-
+ static int axi_fan_control_probe(struct platform_device *pdev)
+ {
+ 	struct axi_fan_control_data *ctl;
+ 	struct clk *clk;
+-	const struct of_device_id *id;
++	const unsigned int *id;
+ 	const char *name = "axi_fan_control";
+ 	u32 version;
+ 	int ret;
+ 
+-	id = of_match_node(axi_fan_control_of_match, pdev->dev.of_node);
++	id = device_get_match_data(&pdev->dev);
+ 	if (!id)
+ 		return -EINVAL;
+ 
+@@ -474,10 +466,9 @@ static int axi_fan_control_probe(struct platform_device *pdev)
+ 		return PTR_ERR(ctl->base);
+ 
+ 	clk = devm_clk_get_enabled(&pdev->dev, NULL);
+-	if (IS_ERR(clk)) {
+-		dev_err(&pdev->dev, "clk_get failed with %ld\n", PTR_ERR(clk));
+-		return PTR_ERR(clk);
+-	}
++	if (IS_ERR(clk))
++		return dev_err_probe(&pdev->dev, PTR_ERR(clk),
++				     "clk_get failed\n");
+ 
+ 	ctl->clk_rate = clk_get_rate(clk);
+ 	if (!ctl->clk_rate)
+@@ -485,22 +476,20 @@ static int axi_fan_control_probe(struct platform_device *pdev)
+ 
+ 	version = axi_ioread(ADI_AXI_REG_VERSION, ctl);
+ 	if (ADI_AXI_PCORE_VER_MAJOR(version) !=
+-	    ADI_AXI_PCORE_VER_MAJOR((*(u32 *)id->data))) {
+-		dev_err(&pdev->dev, "Major version mismatch. Expected %d.%.2d.%c, Reported %d.%.2d.%c\n",
+-			ADI_AXI_PCORE_VER_MAJOR((*(u32 *)id->data)),
+-			ADI_AXI_PCORE_VER_MINOR((*(u32 *)id->data)),
+-			ADI_AXI_PCORE_VER_PATCH((*(u32 *)id->data)),
+-			ADI_AXI_PCORE_VER_MAJOR(version),
+-			ADI_AXI_PCORE_VER_MINOR(version),
+-			ADI_AXI_PCORE_VER_PATCH(version));
+-		return -ENODEV;
+-	}
+-
+-	ret = axi_fan_control_init(ctl, pdev->dev.of_node);
+-	if (ret) {
+-		dev_err(&pdev->dev, "Failed to initialize device\n");
+-		return ret;
+-	}
++	    ADI_AXI_PCORE_VER_MAJOR((*id)))
++		return dev_err_probe(&pdev->dev, -ENODEV,
++				     "Major version mismatch. Expected %d.%.2d.%c, Reported %d.%.2d.%c\n",
++				     ADI_AXI_PCORE_VER_MAJOR(*id),
++				     ADI_AXI_PCORE_VER_MINOR(*id),
++				     ADI_AXI_PCORE_VER_PATCH(*id),
++				     ADI_AXI_PCORE_VER_MAJOR(version),
++				     ADI_AXI_PCORE_VER_MINOR(version),
++				     ADI_AXI_PCORE_VER_PATCH(version));
++
++	ret = axi_fan_control_init(ctl, &pdev->dev);
++	if (ret)
++		return dev_err_probe(&pdev->dev, ret,
++				     "Failed to initialize device\n");
+ 
+ 	ctl->hdev = devm_hwmon_device_register_with_info(&pdev->dev,
+ 							 name,
+@@ -518,15 +507,23 @@ static int axi_fan_control_probe(struct platform_device *pdev)
+ 	ret = devm_request_threaded_irq(&pdev->dev, ctl->irq, NULL,
+ 					axi_fan_control_irq_handler,
+ 					IRQF_ONESHOT | IRQF_TRIGGER_HIGH,
+-					pdev->driver_override, ctl);
+-	if (ret) {
+-		dev_err(&pdev->dev, "failed to request an irq, %d", ret);
+-		return ret;
+-	}
++					NULL, ctl);
++	if (ret)
++		return dev_err_probe(&pdev->dev, ret,
++				     "failed to request an irq\n");
+ 
+ 	return 0;
+ }
+ 
++static const u32 version_1_0_0 = ADI_AXI_PCORE_VER(1, 0, 'a');
++
++static const struct of_device_id axi_fan_control_of_match[] = {
++	{ .compatible = "adi,axi-fan-control-1.00.a",
++		.data = (void *)&version_1_0_0},
++	{},
++};
++MODULE_DEVICE_TABLE(of, axi_fan_control_of_match);
++
+ static struct platform_driver axi_fan_control_driver = {
+ 	.driver = {
+ 		.name = "axi_fan_control_driver",
+diff --git a/drivers/hwmon/peci/cputemp.c b/drivers/hwmon/peci/cputemp.c
+index a812c15948d918..2d7b2c88ae8495 100644
+--- a/drivers/hwmon/peci/cputemp.c
++++ b/drivers/hwmon/peci/cputemp.c
+@@ -133,7 +133,7 @@ static int get_temp_target(struct peci_cputemp *priv, enum peci_temp_target_type
+ 		*val = priv->temp.target.tjmax;
+ 		break;
+ 	case crit_hyst_type:
+-		*val = priv->temp.target.tjmax - priv->temp.target.tcontrol;
++		*val = priv->temp.target.tcontrol;
+ 		break;
+ 	default:
+ 		ret = -EOPNOTSUPP;
+@@ -339,7 +339,7 @@ static umode_t cputemp_is_visible(const void *data, enum hwmon_sensor_types type
+ {
+ 	const struct peci_cputemp *priv = data;
+ 
+-	if (channel > CPUTEMP_CHANNEL_NUMS)
++	if (channel >= CPUTEMP_CHANNEL_NUMS)
+ 		return 0;
+ 
+ 	if (channel < channel_core)
+diff --git a/drivers/hwmon/pmbus/isl68137.c b/drivers/hwmon/pmbus/isl68137.c
+index f1cf3c9666df30..c868fcd121829e 100644
+--- a/drivers/hwmon/pmbus/isl68137.c
++++ b/drivers/hwmon/pmbus/isl68137.c
+@@ -78,7 +78,15 @@ static ssize_t isl68137_avs_enable_show_page(struct i2c_client *client,
+ 					     int page,
+ 					     char *buf)
+ {
+-	int val = pmbus_read_byte_data(client, page, PMBUS_OPERATION);
++	int val;
++
++	val = pmbus_lock_interruptible(client);
++	if (val)
++		return val;
++
++	val = pmbus_read_byte_data(client, page, PMBUS_OPERATION);
++
++	pmbus_unlock(client);
+ 
+ 	if (val < 0)
+ 		return val;
+@@ -100,6 +108,10 @@ static ssize_t isl68137_avs_enable_store_page(struct i2c_client *client,
+ 
+ 	op_val = result ? ISL68137_VOUT_AVS : 0;
+ 
++	rc = pmbus_lock_interruptible(client);
++	if (rc)
++		return rc;
++
+ 	/*
+ 	 * Writes to VOUT setpoint over AVSBus will persist after the VRM is
+ 	 * switched to PMBus control. Switching back to AVSBus control
+@@ -111,17 +123,20 @@ static ssize_t isl68137_avs_enable_store_page(struct i2c_client *client,
+ 		rc = pmbus_read_word_data(client, page, 0xff,
+ 					  PMBUS_VOUT_COMMAND);
+ 		if (rc < 0)
+-			return rc;
++			goto unlock;
+ 
+ 		rc = pmbus_write_word_data(client, page, PMBUS_VOUT_COMMAND,
+ 					   rc);
+ 		if (rc < 0)
+-			return rc;
++			goto unlock;
+ 	}
+ 
+ 	rc = pmbus_update_byte_data(client, page, PMBUS_OPERATION,
+ 				    ISL68137_VOUT_AVS, op_val);
+ 
++unlock:
++	pmbus_unlock(client);
++
+ 	return (rc < 0) ? rc : count;
+ }
+ 
+diff --git a/drivers/infiniband/core/rw.c b/drivers/infiniband/core/rw.c
+index 2522ff1cc462c7..49fbfe1cef689c 100644
+--- a/drivers/infiniband/core/rw.c
++++ b/drivers/infiniband/core/rw.c
+@@ -326,14 +326,29 @@ int rdma_rw_ctx_init(struct rdma_rw_ctx *ctx, struct ib_qp *qp, u32 port_num,
+ 	if (rdma_rw_io_needs_mr(qp->device, port_num, dir, sg_cnt)) {
+ 		ret = rdma_rw_init_mr_wrs(ctx, qp, port_num, sg, sg_cnt,
+ 				sg_offset, remote_addr, rkey, dir);
+-	} else if (sg_cnt > 1) {
++		/*
++		 * If MR init succeeded or failed for a reason other
++		 * than pool exhaustion, that result is final.
++		 *
++		 * Pool exhaustion (-EAGAIN) from the max_sgl_rd
++		 * optimization is recoverable: fall back to
++		 * direct SGE posting. iWARP and force_mr require
++		 * MRs unconditionally, so -EAGAIN is terminal.
++		 */
++		if (ret != -EAGAIN ||
++		    rdma_protocol_iwarp(qp->device, port_num) ||
++		    unlikely(rdma_rw_force_mr))
++			goto out;
++	}
++
++	if (sg_cnt > 1)
+ 		ret = rdma_rw_init_map_wrs(ctx, qp, sg, sg_cnt, sg_offset,
+ 				remote_addr, rkey, dir);
+-	} else {
++	else
+ 		ret = rdma_rw_init_single_wr(ctx, qp, sg, sg_offset,
+ 				remote_addr, rkey, dir);
+-	}
+ 
++out:
+ 	if (ret < 0)
+ 		goto out_unmap_sg;
+ 	return ret;
+diff --git a/drivers/infiniband/hw/irdma/cm.c b/drivers/infiniband/hw/irdma/cm.c
+index b3f14816251b4a..122b4cffc8dc70 100644
+--- a/drivers/infiniband/hw/irdma/cm.c
++++ b/drivers/infiniband/hw/irdma/cm.c
+@@ -2239,11 +2239,12 @@ irdma_make_cm_node(struct irdma_cm_core *cm_core, struct irdma_device *iwdev,
+ 	int oldarpindex;
+ 	int arpindex;
+ 	struct net_device *netdev = iwdev->netdev;
++	int ret;
+ 
+ 	/* create an hte and cm_node for this instance */
+ 	cm_node = kzalloc(sizeof(*cm_node), GFP_ATOMIC);
+ 	if (!cm_node)
+-		return NULL;
++		return ERR_PTR(-ENOMEM);
+ 
+ 	/* set our node specific transport info */
+ 	cm_node->ipv4 = cm_info->ipv4;
+@@ -2346,8 +2347,10 @@ irdma_make_cm_node(struct irdma_cm_core *cm_core, struct irdma_device *iwdev,
+ 			arpindex = -EINVAL;
+ 	}
+ 
+-	if (arpindex < 0)
++	if (arpindex < 0) {
++		ret = -EINVAL;
+ 		goto err;
++	}
+ 
+ 	ether_addr_copy(cm_node->rem_mac,
+ 			iwdev->rf->arp_table[arpindex].mac_addr);
+@@ -2358,7 +2361,7 @@ irdma_make_cm_node(struct irdma_cm_core *cm_core, struct irdma_device *iwdev,
+ err:
+ 	kfree(cm_node);
+ 
+-	return NULL;
++	return ERR_PTR(ret);
+ }
+ 
+ static void irdma_destroy_connection(struct irdma_cm_node *cm_node)
+@@ -3019,8 +3022,8 @@ static int irdma_create_cm_node(struct irdma_cm_core *cm_core,
+ 
+ 	/* create a CM connection node */
+ 	cm_node = irdma_make_cm_node(cm_core, iwdev, cm_info, NULL);
+-	if (!cm_node)
+-		return -ENOMEM;
++	if (IS_ERR(cm_node))
++		return PTR_ERR(cm_node);
+ 
+ 	/* set our node side to client (active) side */
+ 	cm_node->tcp_cntxt.client = 1;
+@@ -3217,9 +3220,9 @@ void irdma_receive_ilq(struct irdma_sc_vsi *vsi, struct irdma_puda_buf *rbuf)
+ 		cm_info.cm_id = listener->cm_id;
+ 		cm_node = irdma_make_cm_node(cm_core, iwdev, &cm_info,
+ 					     listener);
+-		if (!cm_node) {
++		if (IS_ERR(cm_node)) {
+ 			ibdev_dbg(&cm_core->iwdev->ibdev,
+-				  "CM: allocate node failed\n");
++				  "CM: allocate node failed ret=%ld\n", PTR_ERR(cm_node));
+ 			refcount_dec(&listener->refcnt);
+ 			return;
+ 		}
+@@ -4237,21 +4240,21 @@ static void irdma_cm_event_handler(struct work_struct *work)
+ 		irdma_cm_event_reset(event);
+ 		break;
+ 	case IRDMA_CM_EVENT_CONNECTED:
+-		if (!event->cm_node->cm_id ||
+-		    event->cm_node->state != IRDMA_CM_STATE_OFFLOADED)
++		if (!cm_node->cm_id ||
++		    cm_node->state != IRDMA_CM_STATE_OFFLOADED)
+ 			break;
+ 		irdma_cm_event_connected(event);
+ 		break;
+ 	case IRDMA_CM_EVENT_MPA_REJECT:
+-		if (!event->cm_node->cm_id ||
++		if (!cm_node->cm_id ||
+ 		    cm_node->state == IRDMA_CM_STATE_OFFLOADED)
+ 			break;
+ 		irdma_send_cm_event(cm_node, cm_node->cm_id,
+ 				    IW_CM_EVENT_CONNECT_REPLY, -ECONNREFUSED);
+ 		break;
+ 	case IRDMA_CM_EVENT_ABORTED:
+-		if (!event->cm_node->cm_id ||
+-		    event->cm_node->state == IRDMA_CM_STATE_OFFLOADED)
++		if (!cm_node->cm_id ||
++		    cm_node->state == IRDMA_CM_STATE_OFFLOADED)
+ 			break;
+ 		irdma_event_connect_error(event);
+ 		break;
+@@ -4261,7 +4264,7 @@ static void irdma_cm_event_handler(struct work_struct *work)
+ 		break;
+ 	}
+ 
+-	irdma_rem_ref_cm_node(event->cm_node);
++	irdma_rem_ref_cm_node(cm_node);
+ 	kfree(event);
+ }
+ 
+diff --git a/drivers/infiniband/hw/irdma/utils.c b/drivers/infiniband/hw/irdma/utils.c
+index 91ed7edcd788b5..0571544e045e8c 100644
+--- a/drivers/infiniband/hw/irdma/utils.c
++++ b/drivers/infiniband/hw/irdma/utils.c
+@@ -2345,8 +2345,6 @@ void irdma_modify_qp_to_err(struct irdma_sc_qp *sc_qp)
+ 	struct irdma_qp *qp = sc_qp->qp_uk.back_qp;
+ 	struct ib_qp_attr attr;
+ 
+-	if (qp->iwdev->rf->reset)
+-		return;
+ 	attr.qp_state = IB_QPS_ERR;
+ 
+ 	if (rdma_protocol_roce(qp->ibqp.device, 1))
+diff --git a/drivers/infiniband/hw/irdma/verbs.c b/drivers/infiniband/hw/irdma/verbs.c
+index 3b0050e594fdf4..532b36b25e9196 100644
+--- a/drivers/infiniband/hw/irdma/verbs.c
++++ b/drivers/infiniband/hw/irdma/verbs.c
+@@ -536,7 +536,8 @@ static int irdma_destroy_qp(struct ib_qp *ibqp, struct ib_udata *udata)
+ 	}
+ 
+ 	irdma_qp_rem_ref(&iwqp->ibqp);
+-	wait_for_completion(&iwqp->free_qp);
++	if (!iwdev->rf->reset)
++		wait_for_completion(&iwqp->free_qp);
+ 	irdma_free_lsmm_rsrc(iwqp);
+ 	irdma_cqp_qp_destroy_cmd(&iwdev->rf->sc_dev, &iwqp->sc_qp);
+ 
+@@ -1008,6 +1009,7 @@ static int irdma_create_qp(struct ib_qp *ibqp,
+ 	spin_lock_init(&iwqp->sc_qp.pfpdu.lock);
+ 	iwqp->sig_all = init_attr->sq_sig_type == IB_SIGNAL_ALL_WR;
+ 	rf->qp_table[qp_num] = iwqp;
++	init_completion(&iwqp->free_qp);
+ 
+ 	if (rdma_protocol_roce(&iwdev->ibdev, 1)) {
+ 		if (dev->ws_add(&iwdev->vsi, 0)) {
+@@ -1042,7 +1044,6 @@ static int irdma_create_qp(struct ib_qp *ibqp,
+ 		}
+ 	}
+ 
+-	init_completion(&iwqp->free_qp);
+ 	return 0;
+ 
+ error:
+@@ -1364,8 +1365,6 @@ int irdma_modify_qp_roce(struct ib_qp *ibqp, struct ib_qp_attr *attr,
+ 			roce_info->rd_en = true;
+ 	}
+ 
+-	wait_event(iwqp->mod_qp_waitq, !atomic_read(&iwqp->hw_mod_qp_pend));
+-
+ 	ibdev_dbg(&iwdev->ibdev,
+ 		  "VERBS: caller: %pS qp_id=%d to_ibqpstate=%d ibqpstate=%d irdma_qpstate=%d attr_mask=0x%x\n",
+ 		  __builtin_return_address(0), ibqp->qp_num, attr->qp_state,
+@@ -1442,6 +1441,7 @@ int irdma_modify_qp_roce(struct ib_qp *ibqp, struct ib_qp_attr *attr,
+ 		case IB_QPS_ERR:
+ 		case IB_QPS_RESET:
+ 			if (iwqp->iwarp_state == IRDMA_QP_STATE_ERROR) {
++				iwqp->ibqp_state = attr->qp_state;
+ 				spin_unlock_irqrestore(&iwqp->lock, flags);
+ 				if (udata && udata->inlen) {
+ 					if (ib_copy_from_udata(&ureq, udata,
+@@ -1647,6 +1647,7 @@ int irdma_modify_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr, int attr_mask,
+ 		case IB_QPS_ERR:
+ 		case IB_QPS_RESET:
+ 			if (iwqp->iwarp_state == IRDMA_QP_STATE_ERROR) {
++				iwqp->ibqp_state = attr->qp_state;
+ 				spin_unlock_irqrestore(&iwqp->lock, flags);
+ 				if (udata && udata->inlen) {
+ 					if (ib_copy_from_udata(&ureq, udata,
+diff --git a/drivers/irqchip/irq-qcom-mpm.c b/drivers/irqchip/irq-qcom-mpm.c
+index 0807e4aca933fb..e598e4898936c8 100644
+--- a/drivers/irqchip/irq-qcom-mpm.c
++++ b/drivers/irqchip/irq-qcom-mpm.c
+@@ -305,6 +305,8 @@ static int mpm_pd_power_off(struct generic_pm_domain *genpd)
+ 	if (ret < 0)
+ 		return ret;
+ 
++	mbox_client_txdone(priv->mbox_chan, 0);
++
+ 	return 0;
+ }
+ 
+@@ -414,6 +416,7 @@ static int qcom_mpm_init(struct device_node *np, struct device_node *parent)
+ 	}
+ 
+ 	priv->mbox_client.dev = dev;
++	priv->mbox_client.knows_txdone = true;
+ 	priv->mbox_chan = mbox_request_channel(&priv->mbox_client, 0);
+ 	if (IS_ERR(priv->mbox_chan)) {
+ 		ret = PTR_ERR(priv->mbox_chan);
+diff --git a/drivers/media/mc/mc-request.c b/drivers/media/mc/mc-request.c
+index addb8f2d8939ef..ebcbe7165e96d6 100644
+--- a/drivers/media/mc/mc-request.c
++++ b/drivers/media/mc/mc-request.c
+@@ -190,6 +190,8 @@ static long media_request_ioctl_reinit(struct media_request *req)
+ 	struct media_device *mdev = req->mdev;
+ 	unsigned long flags;
+ 
++	mutex_lock(&mdev->req_queue_mutex);
++
+ 	spin_lock_irqsave(&req->lock, flags);
+ 	if (req->state != MEDIA_REQUEST_STATE_IDLE &&
+ 	    req->state != MEDIA_REQUEST_STATE_COMPLETE) {
+@@ -197,6 +199,7 @@ static long media_request_ioctl_reinit(struct media_request *req)
+ 			"request: %s not in idle or complete state, cannot reinit\n",
+ 			req->debug_str);
+ 		spin_unlock_irqrestore(&req->lock, flags);
++		mutex_unlock(&mdev->req_queue_mutex);
+ 		return -EBUSY;
+ 	}
+ 	if (req->access_count) {
+@@ -204,6 +207,7 @@ static long media_request_ioctl_reinit(struct media_request *req)
+ 			"request: %s is being accessed, cannot reinit\n",
+ 			req->debug_str);
+ 		spin_unlock_irqrestore(&req->lock, flags);
++		mutex_unlock(&mdev->req_queue_mutex);
+ 		return -EBUSY;
+ 	}
+ 	req->state = MEDIA_REQUEST_STATE_CLEANING;
+@@ -214,6 +218,7 @@ static long media_request_ioctl_reinit(struct media_request *req)
+ 	spin_lock_irqsave(&req->lock, flags);
+ 	req->state = MEDIA_REQUEST_STATE_IDLE;
+ 	spin_unlock_irqrestore(&req->lock, flags);
++	mutex_unlock(&mdev->req_queue_mutex);
+ 
+ 	return 0;
+ }
+diff --git a/drivers/media/v4l2-core/v4l2-ioctl.c b/drivers/media/v4l2-core/v4l2-ioctl.c
+index f4d9d62790940b..1a0b4acdc40dc0 100644
+--- a/drivers/media/v4l2-core/v4l2-ioctl.c
++++ b/drivers/media/v4l2-core/v4l2-ioctl.c
+@@ -2998,13 +2998,14 @@ static long __video_do_ioctl(struct file *file,
+ 		vfh = file->private_data;
+ 
+ 	/*
+-	 * We need to serialize streamon/off with queueing new requests.
++	 * We need to serialize streamon/off/reqbufs with queueing new requests.
+ 	 * These ioctls may trigger the cancellation of a streaming
+ 	 * operation, and that should not be mixed with queueing a new
+ 	 * request at the same time.
+ 	 */
+ 	if (v4l2_device_supports_requests(vfd->v4l2_dev) &&
+-	    (cmd == VIDIOC_STREAMON || cmd == VIDIOC_STREAMOFF)) {
++	    (cmd == VIDIOC_STREAMON || cmd == VIDIOC_STREAMOFF ||
++	     cmd == VIDIOC_REQBUFS)) {
+ 		req_queue_lock = &vfd->v4l2_dev->mdev->req_queue_mutex;
+ 
+ 		if (mutex_lock_interruptible(req_queue_lock))
+diff --git a/drivers/mtd/spi-nor/core.c b/drivers/mtd/spi-nor/core.c
+index 1b0c6770c14e46..6e135581ec62a7 100644
+--- a/drivers/mtd/spi-nor/core.c
++++ b/drivers/mtd/spi-nor/core.c
+@@ -2082,6 +2082,76 @@ static const struct flash_info *spi_nor_detect(struct spi_nor *nor)
+ 	return info;
+ }
+ 
++/*
++ * On Octal DTR capable flashes, reads cannot start or end at an odd
++ * address in Octal DTR mode. Extra bytes need to be read at the start
++ * or end to make sure both the start address and length remain even.
++ */
++static int spi_nor_octal_dtr_read(struct spi_nor *nor, loff_t from, size_t len,
++				  u_char *buf)
++{
++	u_char *tmp_buf;
++	size_t tmp_len;
++	loff_t start, end;
++	int ret, bytes_read;
++
++	if (IS_ALIGNED(from, 2) && IS_ALIGNED(len, 2))
++		return spi_nor_read_data(nor, from, len, buf);
++	else if (IS_ALIGNED(from, 2) && len > PAGE_SIZE)
++		return spi_nor_read_data(nor, from, round_down(len, PAGE_SIZE),
++					 buf);
++
++	tmp_buf = kmalloc(PAGE_SIZE, GFP_KERNEL);
++	if (!tmp_buf)
++		return -ENOMEM;
++
++	start = round_down(from, 2);
++	end = round_up(from + len, 2);
++
++	/*
++	 * Avoid allocating too much memory. The requested read length might be
++	 * quite large. Allocating a buffer just as large (slightly bigger, in
++	 * fact) would put unnecessary memory pressure on the system.
++	 *
++	 * For example if the read is from 3 to 1M, then this will read from 2
++	 * to 4098. The reads from 4098 to 1M will then not need a temporary
++	 * buffer so they can proceed as normal.
++	 */
++	tmp_len = min_t(size_t, end - start, PAGE_SIZE);
++
++	ret = spi_nor_read_data(nor, start, tmp_len, tmp_buf);
++	if (ret == 0) {
++		ret = -EIO;
++		goto out;
++	}
++	if (ret < 0)
++		goto out;
++
++	/*
++	 * More bytes are read than actually requested, but that number can't be
++	 * reported to the calling function or it will confuse its calculations.
++	 * Calculate how many of the _requested_ bytes were read.
++	 */
++	bytes_read = ret;
++
++	if (from != start)
++		ret -= from - start;
++
++	/*
++	 * Only account for extra bytes at the end if they were actually read.
++	 * For example, if the total length was truncated because of temporary
++	 * buffer size limit then the adjustment for the extra bytes at the end
++	 * is not needed.
++	 */
++	if (start + bytes_read == end)
++		ret -= end - (from + len);
++
++	memcpy(buf, tmp_buf + (from - start), ret);
++out:
++	kfree(tmp_buf);
++	return ret;
++}
++
+ static int spi_nor_read(struct mtd_info *mtd, loff_t from, size_t len,
+ 			size_t *retlen, u_char *buf)
+ {
+@@ -2101,7 +2171,11 @@ static int spi_nor_read(struct mtd_info *mtd, loff_t from, size_t len,
+ 
+ 		addr = spi_nor_convert_addr(nor, addr);
+ 
+-		ret = spi_nor_read_data(nor, addr, len, buf);
++		if (nor->read_proto == SNOR_PROTO_8_8_8_DTR)
++			ret = spi_nor_octal_dtr_read(nor, addr, len, buf);
++		else
++			ret = spi_nor_read_data(nor, addr, len, buf);
++
+ 		if (ret == 0) {
+ 			/* We shouldn't see 0-length reads */
+ 			ret = -EIO;
+@@ -2124,6 +2198,68 @@ read_err:
+ 	return ret;
+ }
+ 
++/*
++ * On Octal DTR capable flashes, writes cannot start or end at an odd address
++ * in Octal DTR mode. Extra 0xff bytes need to be appended or prepended to
++ * make sure the start address and end address are even. 0xff is used because
++ * on NOR flashes a program operation can only flip bits from 1 to 0, not the
++ * other way round. 0 to 1 flip needs to happen via erases.
++ */
++static int spi_nor_octal_dtr_write(struct spi_nor *nor, loff_t to, size_t len,
++				   const u8 *buf)
++{
++	u8 *tmp_buf;
++	size_t bytes_written;
++	loff_t start, end;
++	int ret;
++
++	if (IS_ALIGNED(to, 2) && IS_ALIGNED(len, 2))
++		return spi_nor_write_data(nor, to, len, buf);
++
++	tmp_buf = kmalloc(nor->params->page_size, GFP_KERNEL);
++	if (!tmp_buf)
++		return -ENOMEM;
++
++	memset(tmp_buf, 0xff, nor->params->page_size);
++
++	start = round_down(to, 2);
++	end = round_up(to + len, 2);
++
++	memcpy(tmp_buf + (to - start), buf, len);
++
++	ret = spi_nor_write_data(nor, start, end - start, tmp_buf);
++	if (ret == 0) {
++		ret = -EIO;
++		goto out;
++	}
++	if (ret < 0)
++		goto out;
++
++	/*
++	 * More bytes are written than actually requested, but that number can't
++	 * be reported to the calling function or it will confuse its
++	 * calculations. Calculate how many of the _requested_ bytes were
++	 * written.
++	 */
++	bytes_written = ret;
++
++	if (to != start)
++		ret -= to - start;
++
++	/*
++	 * Only account for extra bytes at the end if they were actually
++	 * written. For example, if for some reason the controller could only
++	 * complete a partial write then the adjustment for the extra bytes at
++	 * the end is not needed.
++	 */
++	if (start + bytes_written == end)
++		ret -= end - (to + len);
++
++out:
++	kfree(tmp_buf);
++	return ret;
++}
++
+ /*
+  * Write an address range to the nor chip.  Data must be written in
+  * FLASH_PAGESIZE chunks.  The address range may be any size provided
+@@ -2174,7 +2310,12 @@ static int spi_nor_write(struct mtd_info *mtd, loff_t to, size_t len,
+ 			goto write_err;
+ 		}
+ 
+-		ret = spi_nor_write_data(nor, addr, page_remain, buf + i);
++		if (nor->write_proto == SNOR_PROTO_8_8_8_DTR)
++			ret = spi_nor_octal_dtr_write(nor, addr, page_remain,
++						      buf + i);
++		else
++			ret = spi_nor_write_data(nor, addr, page_remain,
++						 buf + i);
+ 		spi_nor_unlock_device(nor);
+ 		if (ret < 0)
+ 			goto write_err;
+diff --git a/drivers/net/ethernet/cadence/macb_main.c b/drivers/net/ethernet/cadence/macb_main.c
+index 693688a5800223..743dd6e31a62d6 100644
+--- a/drivers/net/ethernet/cadence/macb_main.c
++++ b/drivers/net/ethernet/cadence/macb_main.c
+@@ -1129,7 +1129,7 @@ static void macb_tx_unmap(struct macb *bp, struct macb_tx_skb *tx_skb, int budge
+ 	}
+ 
+ 	if (tx_skb->skb) {
+-		napi_consume_skb(tx_skb->skb, budget);
++		dev_consume_skb_any(tx_skb->skb);
+ 		tx_skb->skb = NULL;
+ 	}
+ }
+@@ -3255,7 +3255,7 @@ static void gem_get_ethtool_stats(struct net_device *dev,
+ 	spin_lock_irq(&bp->stats_lock);
+ 	gem_update_stats(bp);
+ 	memcpy(data, &bp->ethtool_stats, sizeof(u64)
+-			* (GEM_STATS_LEN + QUEUE_STATS_LEN * MACB_MAX_QUEUES));
++			* (GEM_STATS_LEN + QUEUE_STATS_LEN * bp->num_queues));
+ 	spin_unlock_irq(&bp->stats_lock);
+ }
+ 
+diff --git a/drivers/net/ethernet/freescale/enetc/enetc_ethtool.c b/drivers/net/ethernet/freescale/enetc/enetc_ethtool.c
+index 1e3e0073276ecb..f641fb4c599800 100644
+--- a/drivers/net/ethernet/freescale/enetc/enetc_ethtool.c
++++ b/drivers/net/ethernet/freescale/enetc/enetc_ethtool.c
+@@ -747,6 +747,8 @@ static void enetc_get_ringparam(struct net_device *ndev,
+ {
+ 	struct enetc_ndev_priv *priv = netdev_priv(ndev);
+ 
++	ring->rx_max_pending = priv->rx_bd_count;
++	ring->tx_max_pending = priv->tx_bd_count;
+ 	ring->rx_pending = priv->rx_bd_count;
+ 	ring->tx_pending = priv->tx_bd_count;
+ 
+diff --git a/drivers/net/ethernet/intel/ice/ice_ethtool.c b/drivers/net/ethernet/intel/ice/ice_ethtool.c
+index 1c91f1ba118894..448ca855df9019 100644
+--- a/drivers/net/ethernet/intel/ice/ice_ethtool.c
++++ b/drivers/net/ethernet/intel/ice/ice_ethtool.c
+@@ -1528,6 +1528,17 @@ __ice_get_ethtool_stats(struct net_device *netdev,
+ 	int i = 0;
+ 	char *p;
+ 
++	if (ice_is_port_repr_netdev(netdev)) {
++		ice_update_eth_stats(vsi);
++
++		for (j = 0; j < ICE_VSI_STATS_LEN; j++) {
++			p = (char *)vsi + ice_gstrings_vsi_stats[j].stat_offset;
++			data[i++] = (ice_gstrings_vsi_stats[j].sizeof_stat ==
++				     sizeof(u64)) ? *(u64 *)p : *(u32 *)p;
++		}
++		return;
++	}
++
+ 	ice_update_pf_stats(pf);
+ 	ice_update_vsi_stats(vsi);
+ 
+@@ -1537,9 +1548,6 @@ __ice_get_ethtool_stats(struct net_device *netdev,
+ 			     sizeof(u64)) ? *(u64 *)p : *(u32 *)p;
+ 	}
+ 
+-	if (ice_is_port_repr_netdev(netdev))
+-		return;
+-
+ 	/* populate per queue stats */
+ 	rcu_read_lock();
+ 
+diff --git a/drivers/net/ethernet/intel/ice/ice_repr.c b/drivers/net/ethernet/intel/ice/ice_repr.c
+index c686ac0935ebec..23c243d5444626 100644
+--- a/drivers/net/ethernet/intel/ice/ice_repr.c
++++ b/drivers/net/ethernet/intel/ice/ice_repr.c
+@@ -2,6 +2,7 @@
+ /* Copyright (C) 2019-2021, Intel Corporation. */
+ 
+ #include "ice.h"
++#include "ice_lib.h"
+ #include "ice_eswitch.h"
+ #include "ice_devlink.h"
+ #include "ice_sriov.h"
+@@ -57,7 +58,7 @@ ice_repr_get_stats64(struct net_device *netdev, struct rtnl_link_stats64 *stats)
+ 		return;
+ 	vsi = np->repr->src_vsi;
+ 
+-	ice_update_vsi_stats(vsi);
++	ice_update_eth_stats(vsi);
+ 	eth_stats = &vsi->eth_stats;
+ 
+ 	stats->tx_packets = eth_stats->tx_unicast + eth_stats->tx_broadcast +
+diff --git a/drivers/net/ethernet/pensando/ionic/ionic_lif.c b/drivers/net/ethernet/pensando/ionic/ionic_lif.c
+index 1ac7a40fcc43e3..a6a069ba841c8c 100644
+--- a/drivers/net/ethernet/pensando/ionic/ionic_lif.c
++++ b/drivers/net/ethernet/pensando/ionic/ionic_lif.c
+@@ -1728,13 +1728,18 @@ static int ionic_set_mac_address(struct net_device *netdev, void *sa)
+ 	if (ether_addr_equal(netdev->dev_addr, mac))
+ 		return 0;
+ 
+-	err = ionic_program_mac(lif, mac);
+-	if (err < 0)
+-		return err;
++	/* Only program macs for virtual functions to avoid losing the permanent
++	 * Mac across warm reset/reboot.
++	 */
++	if (lif->ionic->pdev->is_virtfn) {
++		err = ionic_program_mac(lif, mac);
++		if (err < 0)
++			return err;
+ 
+-	if (err > 0)
+-		netdev_dbg(netdev, "%s: SET and GET ATTR Mac are not equal-due to old FW running\n",
+-			   __func__);
++		if (err > 0)
++			netdev_dbg(netdev, "%s: SET and GET ATTR Mac are not equal-due to old FW running\n",
++				   __func__);
++	}
+ 
+ 	err = eth_prepare_mac_addr_change(netdev, addr);
+ 	if (err)
+diff --git a/drivers/net/usb/r8152.c b/drivers/net/usb/r8152.c
+index a2e3f9583def78..91cf24fb5531fb 100644
+--- a/drivers/net/usb/r8152.c
++++ b/drivers/net/usb/r8152.c
+@@ -10036,6 +10036,7 @@ static const struct usb_device_id rtl8152_table[] = {
+ 	{ USB_DEVICE(VENDOR_ID_DLINK,   0xb301) },
+ 	{ USB_DEVICE(VENDOR_ID_DELL,    0xb097) },
+ 	{ USB_DEVICE(VENDOR_ID_ASUS,    0x1976) },
++	{ USB_DEVICE(VENDOR_ID_TRENDNET, 0xe02b) },
+ 	{}
+ };
+ 
+diff --git a/drivers/net/virtio_net.c b/drivers/net/virtio_net.c
+index caae11ba2f8bed..b33fc94ebd7720 100644
+--- a/drivers/net/virtio_net.c
++++ b/drivers/net/virtio_net.c
+@@ -2443,6 +2443,7 @@ static netdev_tx_t start_xmit(struct sk_buff *skb, struct net_device *dev)
+ 	/* Don't wait up for transmitted skbs to be freed. */
+ 	if (!use_napi) {
+ 		skb_orphan(skb);
++		skb_dst_drop(skb);
+ 		nf_reset_ct(skb);
+ 	}
+ 
+diff --git a/drivers/nvme/host/core.c b/drivers/nvme/host/core.c
+index f09ebcbe117984..215aa871092d52 100644
+--- a/drivers/nvme/host/core.c
++++ b/drivers/nvme/host/core.c
+@@ -4287,6 +4287,13 @@ int nvme_alloc_admin_tag_set(struct nvme_ctrl *ctrl, struct blk_mq_tag_set *set,
+ 	if (ret)
+ 		return ret;
+ 
++	/*
++	 * If a previous admin queue exists (e.g., from before a reset),
++	 * put it now before allocating a new one to avoid orphaning it.
++	 */
++	if (ctrl->admin_q)
++		blk_put_queue(ctrl->admin_q);
++
+ 	ctrl->admin_q = blk_mq_init_queue(set);
+ 	if (IS_ERR(ctrl->admin_q)) {
+ 		ret = PTR_ERR(ctrl->admin_q);
+diff --git a/drivers/nvme/host/fabrics.c b/drivers/nvme/host/fabrics.c
+index 5963e8b695ffc5..cf6fb2d51886dc 100644
+--- a/drivers/nvme/host/fabrics.c
++++ b/drivers/nvme/host/fabrics.c
+@@ -1179,8 +1179,8 @@ void nvmf_free_options(struct nvmf_ctrl_options *opts)
+ 	kfree(opts->subsysnqn);
+ 	kfree(opts->host_traddr);
+ 	kfree(opts->host_iface);
+-	kfree(opts->dhchap_secret);
+-	kfree(opts->dhchap_ctrl_secret);
++	kfree_sensitive(opts->dhchap_secret);
++	kfree_sensitive(opts->dhchap_ctrl_secret);
+ 	kfree(opts);
+ }
+ EXPORT_SYMBOL_GPL(nvmf_free_options);
+diff --git a/drivers/nvme/host/pci.c b/drivers/nvme/host/pci.c
+index 03a2ca3edb9c37..6f78577fb70daf 100644
+--- a/drivers/nvme/host/pci.c
++++ b/drivers/nvme/host/pci.c
+@@ -1120,7 +1120,8 @@ static int nvme_poll(struct blk_mq_hw_ctx *hctx, struct io_comp_batch *iob)
+ 	struct nvme_queue *nvmeq = hctx->driver_data;
+ 	bool found;
+ 
+-	if (!nvme_cqe_pending(nvmeq))
++	if (!test_bit(NVMEQ_POLLED, &nvmeq->flags) ||
++	    !nvme_cqe_pending(nvmeq))
+ 		return 0;
+ 
+ 	spin_lock(&nvmeq->cq_poll_lock);
+@@ -2355,7 +2356,13 @@ static int nvme_setup_io_queues(struct nvme_dev *dev)
+ 	dev->nr_write_queues = write_queues;
+ 	dev->nr_poll_queues = poll_queues;
+ 
+-	nr_io_queues = dev->nr_allocated_queues - 1;
++	/*
++	 * The initial number of allocated queue slots may be too large if the
++	 * user reduced the special queue parameters. Cap the value to the
++	 * number we need for this round.
++	 */
++	nr_io_queues = min(nvme_max_io_queues(dev),
++			   dev->nr_allocated_queues - 1);
+ 	result = nvme_set_queue_count(&dev->ctrl, &nr_io_queues);
+ 	if (result < 0)
+ 		return result;
+diff --git a/drivers/phy/ti/phy-j721e-wiz.c b/drivers/phy/ti/phy-j721e-wiz.c
+index fc3cd98c60ff42..a28c168b35d922 100644
+--- a/drivers/phy/ti/phy-j721e-wiz.c
++++ b/drivers/phy/ti/phy-j721e-wiz.c
+@@ -1424,6 +1424,7 @@ static int wiz_get_lane_phy_types(struct device *dev, struct wiz *wiz)
+ 			dev_err(dev,
+ 				"%s: Reading \"reg\" from \"%s\" failed: %d\n",
+ 				__func__, subnode->name, ret);
++			of_node_put(serdes);
+ 			return ret;
+ 		}
+ 		of_property_read_u32(subnode, "cdns,num-lanes", &num_lanes);
+@@ -1438,6 +1439,7 @@ static int wiz_get_lane_phy_types(struct device *dev, struct wiz *wiz)
+ 		}
+ 	}
+ 
++	of_node_put(serdes);
+ 	return 0;
+ }
+ 
+diff --git a/drivers/pinctrl/mediatek/pinctrl-mtk-common.c b/drivers/pinctrl/mediatek/pinctrl-mtk-common.c
+index 74b15952b742eb..7066fab7621e93 100644
+--- a/drivers/pinctrl/mediatek/pinctrl-mtk-common.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mtk-common.c
+@@ -1133,9 +1133,12 @@ int mtk_pctrl_init(struct platform_device *pdev,
+ 		goto chip_error;
+ 	}
+ 
+-	ret = mtk_eint_init(pctl, pdev);
+-	if (ret)
+-		goto chip_error;
++	/* Only initialize EINT if we have EINT pins */
++	if (data->eint_hw.ap_num > 0) {
++		ret = mtk_eint_init(pctl, pdev);
++		if (ret)
++			goto chip_error;
++	}
+ 
+ 	return 0;
+ 
+diff --git a/drivers/platform/olpc/olpc-xo175-ec.c b/drivers/platform/olpc/olpc-xo175-ec.c
+index 62ccbcb15c7446..efe4cee5acfff0 100644
+--- a/drivers/platform/olpc/olpc-xo175-ec.c
++++ b/drivers/platform/olpc/olpc-xo175-ec.c
+@@ -482,7 +482,7 @@ static int olpc_xo175_ec_cmd(u8 cmd, u8 *inbuf, size_t inlen, u8 *resp,
+ 	dev_dbg(dev, "CMD %x, %zd bytes expected\n", cmd, resp_len);
+ 
+ 	if (inlen > 5) {
+-		dev_err(dev, "command len %zd too big!\n", resp_len);
++		dev_err(dev, "command len %zd too big!\n", inlen);
+ 		return -EOVERFLOW;
+ 	}
+ 
+diff --git a/drivers/platform/x86/intel/hid.c b/drivers/platform/x86/intel/hid.c
+index ac88119a73b84c..79390e9e888a7e 100644
+--- a/drivers/platform/x86/intel/hid.c
++++ b/drivers/platform/x86/intel/hid.c
+@@ -121,6 +121,13 @@ static const struct dmi_system_id button_array_table[] = {
+ 			DMI_MATCH(DMI_PRODUCT_FAMILY, "ThinkPad X1 Tablet Gen 2"),
+ 		},
+ 	},
++	{
++		.ident = "Lenovo ThinkPad X1 Fold 16 Gen 1",
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
++			DMI_MATCH(DMI_PRODUCT_FAMILY, "ThinkPad X1 Fold 16 Gen 1"),
++		},
++	},
+ 	{
+ 		.ident = "Microsoft Surface Go 3",
+ 		.matches = {
+@@ -175,6 +182,12 @@ static const struct dmi_system_id dmi_vgbs_allow_list[] = {
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "Dell Pro Rugged 12 Tablet RA02260"),
+ 		},
+ 	},
++	{
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
++			DMI_MATCH(DMI_PRODUCT_NAME, "Dell 14 Plus 2-in-1 DB04250"),
++		},
++	},
+ 	{ }
+ };
+ 
+diff --git a/drivers/platform/x86/intel/speed_select_if/isst_tpmi_core.c b/drivers/platform/x86/intel/speed_select_if/isst_tpmi_core.c
+index 63faa2ea8327b2..df0b0118b751ff 100644
+--- a/drivers/platform/x86/intel/speed_select_if/isst_tpmi_core.c
++++ b/drivers/platform/x86/intel/speed_select_if/isst_tpmi_core.c
+@@ -709,7 +709,7 @@ static int isst_if_get_perf_level(void __user *argp)
+ 	_read_pp_info("current_level", perf_level.current_level, SST_PP_STATUS_OFFSET,
+ 		      SST_PP_LEVEL_START, SST_PP_LEVEL_WIDTH, SST_MUL_FACTOR_NONE)
+ 	_read_pp_info("locked", perf_level.locked, SST_PP_STATUS_OFFSET,
+-		      SST_PP_LOCK_START, SST_PP_LEVEL_WIDTH, SST_MUL_FACTOR_NONE)
++		      SST_PP_LOCK_START, SST_PP_LOCK_WIDTH, SST_MUL_FACTOR_NONE)
+ 	_read_pp_info("feature_state", perf_level.feature_state, SST_PP_STATUS_OFFSET,
+ 		      SST_PP_FEATURE_STATE_START, SST_PP_FEATURE_STATE_WIDTH, SST_MUL_FACTOR_NONE)
+ 	perf_level.enabled = !!(power_domain_info->sst_header.cap_mask & BIT(1));
+diff --git a/drivers/platform/x86/touchscreen_dmi.c b/drivers/platform/x86/touchscreen_dmi.c
+index 30c05a9948319d..b8f2cb2f843205 100644
+--- a/drivers/platform/x86/touchscreen_dmi.c
++++ b/drivers/platform/x86/touchscreen_dmi.c
+@@ -430,6 +430,16 @@ static const struct ts_dmi_data gdix1002_00_upside_down_data = {
+ 	.properties	= gdix1001_upside_down_props,
+ };
+ 
++static const struct property_entry gdix1001_y_inverted_props[] = {
++	PROPERTY_ENTRY_BOOL("touchscreen-inverted-y"),
++	{ }
++};
++
++static const struct ts_dmi_data gdix1001_y_inverted_data = {
++	.acpi_name	= "GDIX1001",
++	.properties	= gdix1001_y_inverted_props,
++};
++
+ static const struct property_entry gp_electronic_t701_props[] = {
+ 	PROPERTY_ENTRY_U32("touchscreen-size-x", 960),
+ 	PROPERTY_ENTRY_U32("touchscreen-size-y", 640),
+@@ -1691,6 +1701,14 @@ const struct dmi_system_id touchscreen_dmi_table[] = {
+ 			DMI_MATCH(DMI_PRODUCT_SKU, "PN20170413488"),
+ 		},
+ 	},
++	{
++		/* SUPI S10 */
++		.driver_data = (void *)&gdix1001_y_inverted_data,
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "SUPI"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "S10"),
++		},
++	},
+ 	{
+ 		/* Techbite Arc 11.6 */
+ 		.driver_data = (void *)&techbite_arc_11_6_data,
+diff --git a/drivers/scsi/ibmvscsi/ibmvfc.c b/drivers/scsi/ibmvscsi/ibmvfc.c
+index c98346e464b484..f2780cc9c60ad5 100644
+--- a/drivers/scsi/ibmvscsi/ibmvfc.c
++++ b/drivers/scsi/ibmvscsi/ibmvfc.c
+@@ -4928,7 +4928,8 @@ static void ibmvfc_discover_targets_done(struct ibmvfc_event *evt)
+ 	switch (mad_status) {
+ 	case IBMVFC_MAD_SUCCESS:
+ 		ibmvfc_dbg(vhost, "Discover Targets succeeded\n");
+-		vhost->num_targets = be32_to_cpu(rsp->num_written);
++		vhost->num_targets = min_t(u32, be32_to_cpu(rsp->num_written),
++					   max_targets);
+ 		ibmvfc_set_host_action(vhost, IBMVFC_HOST_ACTION_ALLOC_TGTS);
+ 		break;
+ 	case IBMVFC_MAD_FAILED:
+diff --git a/drivers/scsi/scsi_transport_sas.c b/drivers/scsi/scsi_transport_sas.c
+index 7b4c4752e21609..a9eb548c0de9f5 100644
+--- a/drivers/scsi/scsi_transport_sas.c
++++ b/drivers/scsi/scsi_transport_sas.c
+@@ -1732,7 +1732,7 @@ static int sas_user_scan(struct Scsi_Host *shost, uint channel,
+ 		break;
+ 
+ 	default:
+-		if (channel < shost->max_channel) {
++		if (channel <= shost->max_channel) {
+ 			res = scsi_scan_host_selected(shost, channel, id, lun,
+ 						      SCSI_SCAN_MANUAL);
+ 		} else {
+diff --git a/drivers/scsi/ses.c b/drivers/scsi/ses.c
+index 05e462f328e75f..01ba9f8b836592 100644
+--- a/drivers/scsi/ses.c
++++ b/drivers/scsi/ses.c
+@@ -190,7 +190,7 @@ static unsigned char *ses_get_page2_descriptor(struct enclosure_device *edev,
+ 	unsigned char *type_ptr = ses_dev->page1_types;
+ 	unsigned char *desc_ptr = ses_dev->page2 + 8;
+ 
+-	if (ses_recv_diag(sdev, 2, ses_dev->page2, ses_dev->page2_len) < 0)
++	if (ses_recv_diag(sdev, 2, ses_dev->page2, ses_dev->page2_len))
+ 		return NULL;
+ 
+ 	for (i = 0; i < ses_dev->page1_num_types; i++, type_ptr += 4) {
+diff --git a/drivers/spi/spi-fsl-lpspi.c b/drivers/spi/spi-fsl-lpspi.c
+index 8ef82a11ebb0fa..6b66b0e62db4fb 100644
+--- a/drivers/spi/spi-fsl-lpspi.c
++++ b/drivers/spi/spi-fsl-lpspi.c
+@@ -954,7 +954,7 @@ static int fsl_lpspi_probe(struct platform_device *pdev)
+ 		enable_irq(irq);
+ 	}
+ 
+-	ret = devm_spi_register_controller(&pdev->dev, controller);
++	ret = spi_register_controller(controller);
+ 	if (ret < 0) {
+ 		dev_err_probe(&pdev->dev, ret, "spi_register_controller error\n");
+ 		goto free_dma;
+@@ -981,6 +981,7 @@ static void fsl_lpspi_remove(struct platform_device *pdev)
+ 	struct fsl_lpspi_data *fsl_lpspi =
+ 				spi_controller_get_devdata(controller);
+ 
++	spi_unregister_controller(controller);
+ 	fsl_lpspi_dma_exit(controller);
+ 
+ 	pm_runtime_dont_use_autosuspend(fsl_lpspi->dev);
+diff --git a/drivers/spi/spi-intel-pci.c b/drivers/spi/spi-intel-pci.c
+index 5c0dec90eec1df..43692315ea3058 100644
+--- a/drivers/spi/spi-intel-pci.c
++++ b/drivers/spi/spi-intel-pci.c
+@@ -86,6 +86,7 @@ static const struct pci_device_id intel_spi_pci_ids[] = {
+ 	{ PCI_VDEVICE(INTEL, 0xa324), (unsigned long)&cnl_info },
+ 	{ PCI_VDEVICE(INTEL, 0xa3a4), (unsigned long)&cnl_info },
+ 	{ PCI_VDEVICE(INTEL, 0xa823), (unsigned long)&cnl_info },
++	{ PCI_VDEVICE(INTEL, 0xd323), (unsigned long)&cnl_info },
+ 	{ PCI_VDEVICE(INTEL, 0xe323), (unsigned long)&cnl_info },
+ 	{ PCI_VDEVICE(INTEL, 0xe423), (unsigned long)&cnl_info },
+ 	{ },
+diff --git a/drivers/spi/spi-sn-f-ospi.c b/drivers/spi/spi-sn-f-ospi.c
+index fd8c8eb37d01d6..2d6d50b6f4dc92 100644
+--- a/drivers/spi/spi-sn-f-ospi.c
++++ b/drivers/spi/spi-sn-f-ospi.c
+@@ -609,7 +609,7 @@ static int f_ospi_probe(struct platform_device *pdev)
+ 	u32 num_cs = OSPI_NUM_CS;
+ 	int ret;
+ 
+-	ctlr = spi_alloc_host(dev, sizeof(*ospi));
++	ctlr = devm_spi_alloc_host(dev, sizeof(*ospi));
+ 	if (!ctlr)
+ 		return -ENOMEM;
+ 
+@@ -632,16 +632,12 @@ static int f_ospi_probe(struct platform_device *pdev)
+ 	platform_set_drvdata(pdev, ospi);
+ 
+ 	ospi->base = devm_platform_ioremap_resource(pdev, 0);
+-	if (IS_ERR(ospi->base)) {
+-		ret = PTR_ERR(ospi->base);
+-		goto err_put_ctlr;
+-	}
++	if (IS_ERR(ospi->base))
++		return PTR_ERR(ospi->base);
+ 
+ 	ospi->clk = devm_clk_get_enabled(dev, NULL);
+-	if (IS_ERR(ospi->clk)) {
+-		ret = PTR_ERR(ospi->clk);
+-		goto err_put_ctlr;
+-	}
++	if (IS_ERR(ospi->clk))
++		return PTR_ERR(ospi->clk);
+ 
+ 	mutex_init(&ospi->mlock);
+ 
+@@ -658,9 +654,6 @@ static int f_ospi_probe(struct platform_device *pdev)
+ err_destroy_mutex:
+ 	mutex_destroy(&ospi->mlock);
+ 
+-err_put_ctlr:
+-	spi_controller_put(ctlr);
+-
+ 	return ret;
+ }
+ 
+diff --git a/drivers/usb/core/config.c b/drivers/usb/core/config.c
+index 10a1bc059ea1f7..9cd263b6cdee84 100644
+--- a/drivers/usb/core/config.c
++++ b/drivers/usb/core/config.c
+@@ -891,7 +891,11 @@ int usb_get_configuration(struct usb_device *dev)
+ 		dev->descriptor.bNumConfigurations = ncfg = USB_MAXCONFIG;
+ 	}
+ 
+-	if (ncfg < 1) {
++	if (ncfg < 1 && dev->quirks & USB_QUIRK_FORCE_ONE_CONFIG) {
++		dev_info(ddev, "Device claims zero configurations, forcing to 1\n");
++		dev->descriptor.bNumConfigurations = 1;
++		ncfg = 1;
++	} else if (ncfg < 1) {
+ 		dev_err(ddev, "no configurations\n");
+ 		return -EINVAL;
+ 	}
+diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
+index c12942a533ce2e..53b08d6cf78241 100644
+--- a/drivers/usb/core/quirks.c
++++ b/drivers/usb/core/quirks.c
+@@ -141,6 +141,8 @@ static int quirks_param_set(const char *value, const struct kernel_param *kp)
+ 			case 'p':
+ 				flags |= USB_QUIRK_SHORT_SET_ADDRESS_REQ_TIMEOUT;
+ 				break;
++			case 'q':
++				flags |= USB_QUIRK_FORCE_ONE_CONFIG;
+ 			/* Ignore unrecognized flag characters */
+ 			}
+ 		}
+@@ -594,6 +596,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+ 	/* VCOM device */
+ 	{ USB_DEVICE(0x4296, 0x7570), .driver_info = USB_QUIRK_CONFIG_INTF_STRINGS },
+ 
++	/* Noji-MCS SmartCard Reader */
++	{ USB_DEVICE(0x5131, 0x2007), .driver_info = USB_QUIRK_FORCE_ONE_CONFIG },
++
+ 	/* INTEL VALUE SSD */
+ 	{ USB_DEVICE(0x8086, 0xf1a5), .driver_info = USB_QUIRK_RESET_RESUME },
+ 
+diff --git a/fs/btrfs/block-group.c b/fs/btrfs/block-group.c
+index a08e03a74909a7..3bc6c99ed2e38d 100644
+--- a/fs/btrfs/block-group.c
++++ b/fs/btrfs/block-group.c
+@@ -4386,7 +4386,7 @@ static void check_removing_space_info(struct btrfs_space_info *space_info)
+ 		for (int i = 0; i < BTRFS_SPACE_INFO_SUB_GROUP_MAX; i++) {
+ 			if (space_info->sub_group[i]) {
+ 				check_removing_space_info(space_info->sub_group[i]);
+-				kfree(space_info->sub_group[i]);
++				btrfs_sysfs_remove_space_info(space_info->sub_group[i]);
+ 				space_info->sub_group[i] = NULL;
+ 			}
+ 		}
+diff --git a/fs/btrfs/disk-io.c b/fs/btrfs/disk-io.c
+index b4ec844b7d741a..c7746baa86f8c1 100644
+--- a/fs/btrfs/disk-io.c
++++ b/fs/btrfs/disk-io.c
+@@ -2444,8 +2444,8 @@ int btrfs_validate_super(struct btrfs_fs_info *fs_info,
+ 
+ 	if (mirror_num >= 0 &&
+ 	    btrfs_super_bytenr(sb) != btrfs_sb_offset(mirror_num)) {
+-		btrfs_err(fs_info, "super offset mismatch %llu != %u",
+-			  btrfs_super_bytenr(sb), BTRFS_SUPER_INFO_OFFSET);
++		btrfs_err(fs_info, "super offset mismatch %llu != %llu",
++			  btrfs_super_bytenr(sb), btrfs_sb_offset(mirror_num));
+ 		ret = -EINVAL;
+ 	}
+ 
+diff --git a/fs/btrfs/ioctl.c b/fs/btrfs/ioctl.c
+index a441b49962a3e0..4723013995f5bb 100644
+--- a/fs/btrfs/ioctl.c
++++ b/fs/btrfs/ioctl.c
+@@ -759,6 +759,13 @@ static noinline int create_subvol(struct mnt_idmap *idmap,
+ 		goto out;
+ 	}
+ 
++	/*
++	 * Subvolumes have orphans cleaned on first dentry lookup. A new
++	 * subvolume cannot have any orphans, so we should set the bit before we
++	 * add the subvolume dentry to the dentry cache, so that it is in the
++	 * same state as a subvolume after first lookup.
++	 */
++	set_bit(BTRFS_ROOT_ORPHAN_CLEANUP, &new_root->state);
+ 	d_instantiate_new(dentry, new_inode_args.inode);
+ 	new_inode_args.inode = NULL;
+ 
+diff --git a/fs/btrfs/volumes.c b/fs/btrfs/volumes.c
+index 23756f1464013d..f5e4b8f3dcb7f7 100644
+--- a/fs/btrfs/volumes.c
++++ b/fs/btrfs/volumes.c
+@@ -7641,8 +7641,9 @@ int btrfs_run_dev_stats(struct btrfs_trans_handle *trans)
+ 		smp_rmb();
+ 
+ 		ret = update_dev_stat_item(trans, device);
+-		if (!ret)
+-			atomic_sub(stats_cnt, &device->dev_stats_ccnt);
++		if (ret)
++			break;
++		atomic_sub(stats_cnt, &device->dev_stats_ccnt);
+ 	}
+ 	mutex_unlock(&fs_devices->device_list_mutex);
+ 
+diff --git a/fs/erofs/zdata.c b/fs/erofs/zdata.c
+index c1f802ecc47b2c..5b3eb4a2279346 100644
+--- a/fs/erofs/zdata.c
++++ b/fs/erofs/zdata.c
+@@ -1415,6 +1415,7 @@ static void z_erofs_decompress_kickoff(struct z_erofs_decompressqueue *io,
+ 				       int bios)
+ {
+ 	struct erofs_sb_info *const sbi = EROFS_SB(io->sb);
++	int gfp_flag;
+ 
+ 	/* wake up the caller thread for sync decompression */
+ 	if (io->sync) {
+@@ -1447,7 +1448,9 @@ static void z_erofs_decompress_kickoff(struct z_erofs_decompressqueue *io,
+ 			sbi->opt.sync_decompress = EROFS_SYNC_DECOMPRESS_FORCE_ON;
+ 		return;
+ 	}
++	gfp_flag = memalloc_noio_save();
+ 	z_erofs_decompressqueue_work(&io->u.work);
++	memalloc_noio_restore(gfp_flag);
+ }
+ 
+ static struct page *pickup_page_for_submission(struct z_erofs_pcluster *pcl,
+@@ -1500,6 +1503,7 @@ repeat:
+ 	lock_page(page);
+ 	if (likely(page->mapping == mc)) {
+ 		WRITE_ONCE(pcl->compressed_bvecs[nr].page, page);
++		oldpage = page;
+ 
+ 		/*
+ 		 * The cached folio is still in managed cache but without
+diff --git a/fs/ext4/crypto.c b/fs/ext4/crypto.c
+index 453d4da5de5207..8292494a9b6c82 100644
+--- a/fs/ext4/crypto.c
++++ b/fs/ext4/crypto.c
+@@ -169,10 +169,17 @@ static int ext4_set_context(struct inode *inode, const void *ctx, size_t len,
+ 	 */
+ 
+ 	if (handle) {
++		/*
++		 * Since the inode is new it is ok to pass the
++		 * XATTR_CREATE flag. This is necessary to match the
++		 * remaining journal credits check in the set_handle
++		 * function with the credits allocated for the new
++		 * inode.
++		 */
+ 		res = ext4_xattr_set_handle(handle, inode,
+ 					    EXT4_XATTR_INDEX_ENCRYPTION,
+ 					    EXT4_XATTR_NAME_ENCRYPTION_CONTEXT,
+-					    ctx, len, 0);
++					    ctx, len, XATTR_CREATE);
+ 		if (!res) {
+ 			ext4_set_inode_flag(inode, EXT4_INODE_ENCRYPT);
+ 			ext4_clear_inode_state(inode,
+diff --git a/fs/ext4/ext4.h b/fs/ext4/ext4.h
+index ce8bd312c1b842..317c2c0c015b2f 100644
+--- a/fs/ext4/ext4.h
++++ b/fs/ext4/ext4.h
+@@ -1535,6 +1535,7 @@ struct ext4_sb_info {
+ 	struct proc_dir_entry *s_proc;
+ 	struct kobject s_kobj;
+ 	struct completion s_kobj_unregister;
++	struct mutex s_error_notify_mutex; /* protects sysfs_notify vs kobject_del */
+ 	struct super_block *s_sb;
+ 	struct buffer_head *s_mmp_bh;
+ 
+diff --git a/fs/ext4/extents.c b/fs/ext4/extents.c
+index b7e9cbe832121f..7626cf2b07f1cb 100644
+--- a/fs/ext4/extents.c
++++ b/fs/ext4/extents.c
+@@ -4421,9 +4421,13 @@ got_allocated_blocks:
+ 	path = ext4_ext_insert_extent(handle, inode, path, &newex, flags);
+ 	if (IS_ERR(path)) {
+ 		err = PTR_ERR(path);
+-		if (allocated_clusters) {
++		/*
++		 * Gracefully handle out of space conditions. If the filesystem
++		 * is inconsistent, we'll just leak allocated blocks to avoid
++		 * causing even more damage.
++		 */
++		if (allocated_clusters && (err == -EDQUOT || err == -ENOSPC)) {
+ 			int fb_flags = 0;
+-
+ 			/*
+ 			 * free data blocks we just allocated.
+ 			 * not a good idea to call discard here directly,
+diff --git a/fs/ext4/fast_commit.c b/fs/ext4/fast_commit.c
+index be65b5f51d9e21..60727da9ea11d3 100644
+--- a/fs/ext4/fast_commit.c
++++ b/fs/ext4/fast_commit.c
+@@ -1601,19 +1601,21 @@ static int ext4_fc_replay_inode(struct super_block *sb,
+ 	/* Immediately update the inode on disk. */
+ 	ret = ext4_handle_dirty_metadata(NULL, NULL, iloc.bh);
+ 	if (ret)
+-		goto out;
++		goto out_brelse;
+ 	ret = sync_dirty_buffer(iloc.bh);
+ 	if (ret)
+-		goto out;
++		goto out_brelse;
+ 	ret = ext4_mark_inode_used(sb, ino);
+ 	if (ret)
+-		goto out;
++		goto out_brelse;
+ 
+ 	/* Given that we just wrote the inode on disk, this SHOULD succeed. */
+ 	inode = ext4_iget(sb, ino, EXT4_IGET_NORMAL);
+ 	if (IS_ERR(inode)) {
+ 		ext4_debug("Inode not found.");
+-		return -EFSCORRUPTED;
++		inode = NULL;
++		ret = -EFSCORRUPTED;
++		goto out_brelse;
+ 	}
+ 
+ 	/*
+@@ -1630,13 +1632,14 @@ static int ext4_fc_replay_inode(struct super_block *sb,
+ 	ext4_inode_csum_set(inode, ext4_raw_inode(&iloc), EXT4_I(inode));
+ 	ret = ext4_handle_dirty_metadata(NULL, NULL, iloc.bh);
+ 	sync_dirty_buffer(iloc.bh);
++out_brelse:
+ 	brelse(iloc.bh);
+ out:
+ 	iput(inode);
+ 	if (!ret)
+ 		blkdev_issue_flush(sb->s_bdev);
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ /*
+diff --git a/fs/ext4/fsync.c b/fs/ext4/fsync.c
+index b40d3b29f7e5c5..6e7925cc56512b 100644
+--- a/fs/ext4/fsync.c
++++ b/fs/ext4/fsync.c
+@@ -83,11 +83,23 @@ static int ext4_fsync_nojournal(struct file *file, loff_t start, loff_t end,
+ 				int datasync, bool *needs_barrier)
+ {
+ 	struct inode *inode = file->f_inode;
++	struct writeback_control wbc = {
++		.sync_mode = WB_SYNC_ALL,
++		.nr_to_write = 0,
++	};
+ 	int ret;
+ 
+ 	ret = generic_buffers_fsync_noflush(file, start, end, datasync);
+-	if (!ret)
+-		ret = ext4_sync_parent(inode);
++	if (ret)
++		return ret;
++
++	/* Force writeout of inode table buffer to disk */
++	ret = ext4_write_inode(inode, &wbc);
++	if (ret)
++		return ret;
++
++	ret = ext4_sync_parent(inode);
++
+ 	if (test_opt(inode->i_sb, BARRIER))
+ 		*needs_barrier = true;
+ 
+diff --git a/fs/ext4/ialloc.c b/fs/ext4/ialloc.c
+index 9991f2dd7d9f7a..8daebea58027aa 100644
+--- a/fs/ext4/ialloc.c
++++ b/fs/ext4/ialloc.c
+@@ -688,6 +688,12 @@ static int recently_deleted(struct super_block *sb, ext4_group_t group, int ino)
+ 	if (unlikely(!gdp))
+ 		return 0;
+ 
++	/* Inode was never used in this filesystem? */
++	if (ext4_has_group_desc_csum(sb) &&
++	    (gdp->bg_flags & cpu_to_le16(EXT4_BG_INODE_UNINIT) ||
++	     ino >= EXT4_INODES_PER_GROUP(sb) - ext4_itable_unused_count(sb, gdp)))
++		return 0;
++
+ 	bh = sb_find_get_block(sb, ext4_inode_table(sb, gdp) +
+ 		       (ino / inodes_per_block));
+ 	if (!bh || !buffer_uptodate(bh))
+diff --git a/fs/ext4/inline.c b/fs/ext4/inline.c
+index 0cb175a1abe09e..a4206a20feaa19 100644
+--- a/fs/ext4/inline.c
++++ b/fs/ext4/inline.c
+@@ -517,7 +517,15 @@ static int ext4_read_inline_folio(struct inode *inode, struct folio *folio)
+ 		goto out;
+ 
+ 	len = min_t(size_t, ext4_get_inline_size(inode), i_size_read(inode));
+-	BUG_ON(len > PAGE_SIZE);
++
++	if (len > PAGE_SIZE) {
++		ext4_error_inode(inode, __func__, __LINE__, 0,
++				 "inline size %zu exceeds PAGE_SIZE", len);
++		ret = -EFSCORRUPTED;
++		brelse(iloc.bh);
++		goto out;
++	}
++
+ 	kaddr = kmap_local_folio(folio, 0);
+ 	ret = ext4_read_inline_data(inode, kaddr, len, &iloc);
+ 	flush_dcache_folio(folio);
+diff --git a/fs/ext4/inode.c b/fs/ext4/inode.c
+index 11ca8ba52c3ab3..949377692c4911 100644
+--- a/fs/ext4/inode.c
++++ b/fs/ext4/inode.c
+@@ -5530,6 +5530,18 @@ int ext4_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
+ 		if (attr->ia_size == inode->i_size)
+ 			inc_ivers = false;
+ 
++		/*
++		 * If file has inline data but new size exceeds inline capacity,
++		 * convert to extent-based storage first to prevent inconsistent
++		 * state (inline flag set but size exceeds inline capacity).
++		 */
++		if (ext4_has_inline_data(inode) &&
++		    attr->ia_size > EXT4_I(inode)->i_inline_size) {
++			error = ext4_convert_inline_data(inode);
++			if (error)
++				goto err_out;
++		}
++
+ 		if (shrink) {
+ 			if (ext4_should_order_data(inode)) {
+ 				error = ext4_begin_ordered_truncate(inode,
+diff --git a/fs/ext4/mballoc.c b/fs/ext4/mballoc.c
+index 5c58bfda40b7f9..e9be0c0a8042c4 100644
+--- a/fs/ext4/mballoc.c
++++ b/fs/ext4/mballoc.c
+@@ -2369,8 +2369,12 @@ int ext4_mb_find_by_goal(struct ext4_allocation_context *ac,
+ 		return 0;
+ 
+ 	err = ext4_mb_load_buddy(ac->ac_sb, group, e4b);
+-	if (err)
++	if (err) {
++		if (EXT4_MB_GRP_BBITMAP_CORRUPT(e4b->bd_info) &&
++		    !(ac->ac_flags & EXT4_MB_HINT_GOAL_ONLY))
++			return 0;
+ 		return err;
++	}
+ 
+ 	ext4_lock_group(ac->ac_sb, group);
+ 	if (unlikely(EXT4_MB_GRP_BBITMAP_CORRUPT(e4b->bd_info)))
+@@ -3498,9 +3502,7 @@ err_freebuddy:
+ 	rcu_read_unlock();
+ 	iput(sbi->s_buddy_cache);
+ err_freesgi:
+-	rcu_read_lock();
+-	kvfree(rcu_dereference(sbi->s_group_info));
+-	rcu_read_unlock();
++	kvfree(rcu_access_pointer(sbi->s_group_info));
+ 	return -ENOMEM;
+ }
+ 
+@@ -3791,15 +3793,14 @@ int ext4_mb_release(struct super_block *sb)
+ 	struct kmem_cache *cachep = get_groupinfo_cache(sb->s_blocksize_bits);
+ 	int count;
+ 
+-	if (test_opt(sb, DISCARD)) {
+-		/*
+-		 * wait the discard work to drain all of ext4_free_data
+-		 */
+-		flush_work(&sbi->s_discard_work);
+-		WARN_ON_ONCE(!list_empty(&sbi->s_discard_list));
+-	}
++	/*
++	 * wait the discard work to drain all of ext4_free_data
++	 */
++	flush_work(&sbi->s_discard_work);
++	WARN_ON_ONCE(!list_empty(&sbi->s_discard_list));
+ 
+-	if (sbi->s_group_info) {
++	group_info = rcu_access_pointer(sbi->s_group_info);
++	if (group_info) {
+ 		for (i = 0; i < ngroups; i++) {
+ 			cond_resched();
+ 			grinfo = ext4_get_group_info(sb, i);
+@@ -3817,12 +3818,9 @@ int ext4_mb_release(struct super_block *sb)
+ 		num_meta_group_infos = (ngroups +
+ 				EXT4_DESC_PER_BLOCK(sb) - 1) >>
+ 			EXT4_DESC_PER_BLOCK_BITS(sb);
+-		rcu_read_lock();
+-		group_info = rcu_dereference(sbi->s_group_info);
+ 		for (i = 0; i < num_meta_group_infos; i++)
+ 			kfree(group_info[i]);
+ 		kvfree(group_info);
+-		rcu_read_unlock();
+ 	}
+ 	kfree(sbi->s_mb_avg_fragment_size);
+ 	kfree(sbi->s_mb_avg_fragment_size_locks);
+diff --git a/fs/ext4/page-io.c b/fs/ext4/page-io.c
+index 7287dbfe13f120..fa982f0712c517 100644
+--- a/fs/ext4/page-io.c
++++ b/fs/ext4/page-io.c
+@@ -506,9 +506,15 @@ int ext4_bio_write_folio(struct ext4_io_submit *io, struct folio *folio,
+ 		nr_to_submit++;
+ 	} while ((bh = bh->b_this_page) != head);
+ 
+-	/* Nothing to submit? Just unlock the folio... */
+-	if (!nr_to_submit)
++	if (!nr_to_submit) {
++		/*
++		 * We have nothing to submit. Just cycle the folio through
++		 * writeback state to properly update xarray tags.
++		 */
++		__folio_start_writeback(folio, keep_towrite);
++		folio_end_writeback(folio);
+ 		return 0;
++	}
+ 
+ 	bh = head = folio_buffers(folio);
+ 
+diff --git a/fs/ext4/super.c b/fs/ext4/super.c
+index 561f670768f966..045c1cf3c59639 100644
+--- a/fs/ext4/super.c
++++ b/fs/ext4/super.c
+@@ -1266,12 +1266,10 @@ static void ext4_group_desc_free(struct ext4_sb_info *sbi)
+ 	struct buffer_head **group_desc;
+ 	int i;
+ 
+-	rcu_read_lock();
+-	group_desc = rcu_dereference(sbi->s_group_desc);
++	group_desc = rcu_access_pointer(sbi->s_group_desc);
+ 	for (i = 0; i < sbi->s_gdb_count; i++)
+ 		brelse(group_desc[i]);
+ 	kvfree(group_desc);
+-	rcu_read_unlock();
+ }
+ 
+ static void ext4_flex_groups_free(struct ext4_sb_info *sbi)
+@@ -1279,14 +1277,12 @@ static void ext4_flex_groups_free(struct ext4_sb_info *sbi)
+ 	struct flex_groups **flex_groups;
+ 	int i;
+ 
+-	rcu_read_lock();
+-	flex_groups = rcu_dereference(sbi->s_flex_groups);
++	flex_groups = rcu_access_pointer(sbi->s_flex_groups);
+ 	if (flex_groups) {
+ 		for (i = 0; i < sbi->s_flex_groups_allocated; i++)
+ 			kvfree(flex_groups[i]);
+ 		kvfree(flex_groups);
+ 	}
+-	rcu_read_unlock();
+ }
+ 
+ static void ext4_put_super(struct super_block *sb)
+@@ -3655,6 +3651,13 @@ int ext4_feature_set_ok(struct super_block *sb, int readonly)
+ 			 "extents feature\n");
+ 		return 0;
+ 	}
++	if (ext4_has_feature_bigalloc(sb) &&
++	    le32_to_cpu(EXT4_SB(sb)->s_es->s_first_data_block)) {
++		ext4_msg(sb, KERN_WARNING,
++			 "bad geometry: bigalloc file system with non-zero "
++			 "first_data_block\n");
++		return 0;
++	}
+ 
+ #if !IS_ENABLED(CONFIG_QUOTA) || !IS_ENABLED(CONFIG_QFMT_V2)
+ 	if (!readonly && (ext4_has_feature_quota(sb) ||
+@@ -5337,6 +5340,7 @@ static int __ext4_fill_super(struct fs_context *fc, struct super_block *sb)
+ 
+ 	timer_setup(&sbi->s_err_report, print_daily_error_info, 0);
+ 	spin_lock_init(&sbi->s_error_lock);
++	mutex_init(&sbi->s_error_notify_mutex);
+ 	INIT_WORK(&sbi->s_sb_upd_work, update_super_work);
+ 
+ 	err = ext4_group_desc_init(sb, es, logical_sb_block, &first_not_zeroed);
+diff --git a/fs/ext4/sysfs.c b/fs/ext4/sysfs.c
+index d65dccb44ed592..3238b7961a58d9 100644
+--- a/fs/ext4/sysfs.c
++++ b/fs/ext4/sysfs.c
+@@ -529,7 +529,10 @@ static const struct kobj_type ext4_feat_ktype = {
+ 
+ void ext4_notify_error_sysfs(struct ext4_sb_info *sbi)
+ {
+-	sysfs_notify(&sbi->s_kobj, NULL, "errors_count");
++	mutex_lock(&sbi->s_error_notify_mutex);
++	if (sbi->s_kobj.state_in_sysfs)
++		sysfs_notify(&sbi->s_kobj, NULL, "errors_count");
++	mutex_unlock(&sbi->s_error_notify_mutex);
+ }
+ 
+ static struct kobject *ext4_root;
+@@ -542,8 +545,10 @@ int ext4_register_sysfs(struct super_block *sb)
+ 	int err;
+ 
+ 	init_completion(&sbi->s_kobj_unregister);
++	mutex_lock(&sbi->s_error_notify_mutex);
+ 	err = kobject_init_and_add(&sbi->s_kobj, &ext4_sb_ktype, ext4_root,
+ 				   "%s", sb->s_id);
++	mutex_unlock(&sbi->s_error_notify_mutex);
+ 	if (err) {
+ 		kobject_put(&sbi->s_kobj);
+ 		wait_for_completion(&sbi->s_kobj_unregister);
+@@ -576,7 +581,10 @@ void ext4_unregister_sysfs(struct super_block *sb)
+ 
+ 	if (sbi->s_proc)
+ 		remove_proc_subtree(sb->s_id, ext4_proc_root);
++
++	mutex_lock(&sbi->s_error_notify_mutex);
+ 	kobject_del(&sbi->s_kobj);
++	mutex_unlock(&sbi->s_error_notify_mutex);
+ }
+ 
+ int __init ext4_init_sysfs(void)
+diff --git a/fs/gfs2/lock_dlm.c b/fs/gfs2/lock_dlm.c
+index 07aac73377d8fe..a72ece0970346f 100644
+--- a/fs/gfs2/lock_dlm.c
++++ b/fs/gfs2/lock_dlm.c
+@@ -311,11 +311,6 @@ static void gdlm_put_lock(struct gfs2_glock *gl)
+ 	gfs2_sbstats_inc(gl, GFS2_LKS_DCOUNT);
+ 	gfs2_update_request_times(gl);
+ 
+-	/* don't want to call dlm if we've unmounted the lock protocol */
+-	if (test_bit(DFL_UNMOUNT, &ls->ls_recover_flags)) {
+-		gfs2_glock_free(gl);
+-		return;
+-	}
+ 	/* don't want to skip dlm_unlock writing the lvb when lock has one */
+ 
+ 	if (test_bit(SDF_SKIP_DLM_UNLOCK, &sdp->sd_flags) &&
+@@ -332,6 +327,11 @@ again:
+ 		goto again;
+ 	}
+ 
++	if (error == -ENODEV) {
++		gfs2_glock_free(gl);
++		return;
++	}
++
+ 	if (error) {
+ 		fs_err(sdp, "gdlm_unlock %x,%llx err=%d\n",
+ 		       gl->gl_name.ln_type,
+diff --git a/fs/jbd2/checkpoint.c b/fs/jbd2/checkpoint.c
+index 368ae50d8a59e0..32ed28cfb3a0b4 100644
+--- a/fs/jbd2/checkpoint.c
++++ b/fs/jbd2/checkpoint.c
+@@ -267,7 +267,15 @@ restart:
+ 			 */
+ 			BUFFER_TRACE(bh, "queue");
+ 			get_bh(bh);
+-			J_ASSERT_BH(bh, !buffer_jwrite(bh));
++			if (WARN_ON_ONCE(buffer_jwrite(bh))) {
++				put_bh(bh); /* drop the ref we just took */
++				spin_unlock(&journal->j_list_lock);
++				/* Clean up any previously batched buffers */
++				if (batch_count)
++					__flush_batch(journal, &batch_count);
++				jbd2_journal_abort(journal, -EFSCORRUPTED);
++				return -EFSCORRUPTED;
++			}
+ 			journal->j_chkpt_bhs[batch_count++] = bh;
+ 			transaction->t_chp_stats.cs_written++;
+ 			transaction->t_checkpoint_list = jh->b_cpnext;
+@@ -325,7 +333,10 @@ int jbd2_cleanup_journal_tail(journal_t *journal)
+ 
+ 	if (!jbd2_journal_get_log_tail(journal, &first_tid, &blocknr))
+ 		return 1;
+-	J_ASSERT(blocknr != 0);
++	if (WARN_ON_ONCE(blocknr == 0)) {
++		jbd2_journal_abort(journal, -EFSCORRUPTED);
++		return -EFSCORRUPTED;
++	}
+ 
+ 	/*
+ 	 * We need to make sure that any blocks that were recently written out
+diff --git a/fs/smb/server/oplock.c b/fs/smb/server/oplock.c
+index f0e1d1151d6213..c49a75ff5fbb42 100644
+--- a/fs/smb/server/oplock.c
++++ b/fs/smb/server/oplock.c
+@@ -82,11 +82,19 @@ static void lease_del_list(struct oplock_info *opinfo)
+ 	spin_unlock(&lb->lb_lock);
+ }
+ 
+-static void lb_add(struct lease_table *lb)
++static struct lease_table *alloc_lease_table(struct oplock_info *opinfo)
+ {
+-	write_lock(&lease_list_lock);
+-	list_add(&lb->l_entry, &lease_table_list);
+-	write_unlock(&lease_list_lock);
++	struct lease_table *lb;
++
++	lb = kmalloc(sizeof(struct lease_table), GFP_KERNEL);
++	if (!lb)
++		return NULL;
++
++	memcpy(lb->client_guid, opinfo->conn->ClientGUID,
++	       SMB2_CLIENT_GUID_SIZE);
++	INIT_LIST_HEAD(&lb->lease_list);
++	spin_lock_init(&lb->lb_lock);
++	return lb;
+ }
+ 
+ static int alloc_lease(struct oplock_info *opinfo, struct lease_ctx_info *lctx)
+@@ -1042,34 +1050,27 @@ static void copy_lease(struct oplock_info *op1, struct oplock_info *op2)
+ 	lease2->version = lease1->version;
+ }
+ 
+-static int add_lease_global_list(struct oplock_info *opinfo)
++static void add_lease_global_list(struct oplock_info *opinfo,
++				  struct lease_table *new_lb)
+ {
+ 	struct lease_table *lb;
+ 
+-	read_lock(&lease_list_lock);
++	write_lock(&lease_list_lock);
+ 	list_for_each_entry(lb, &lease_table_list, l_entry) {
+ 		if (!memcmp(lb->client_guid, opinfo->conn->ClientGUID,
+ 			    SMB2_CLIENT_GUID_SIZE)) {
+ 			opinfo->o_lease->l_lb = lb;
+ 			lease_add_list(opinfo);
+-			read_unlock(&lease_list_lock);
+-			return 0;
++			write_unlock(&lease_list_lock);
++			kfree(new_lb);
++			return;
+ 		}
+ 	}
+-	read_unlock(&lease_list_lock);
+ 
+-	lb = kmalloc(sizeof(struct lease_table), GFP_KERNEL);
+-	if (!lb)
+-		return -ENOMEM;
+-
+-	memcpy(lb->client_guid, opinfo->conn->ClientGUID,
+-	       SMB2_CLIENT_GUID_SIZE);
+-	INIT_LIST_HEAD(&lb->lease_list);
+-	spin_lock_init(&lb->lb_lock);
+-	opinfo->o_lease->l_lb = lb;
++	opinfo->o_lease->l_lb = new_lb;
+ 	lease_add_list(opinfo);
+-	lb_add(lb);
+-	return 0;
++	list_add(&new_lb->l_entry, &lease_table_list);
++	write_unlock(&lease_list_lock);
+ }
+ 
+ static void set_oplock_level(struct oplock_info *opinfo, int level,
+@@ -1189,6 +1190,7 @@ int smb_grant_oplock(struct ksmbd_work *work, int req_op_level, u64 pid,
+ 	int err = 0;
+ 	struct oplock_info *opinfo = NULL, *prev_opinfo = NULL;
+ 	struct ksmbd_inode *ci = fp->f_ci;
++	struct lease_table *new_lb = NULL;
+ 	bool prev_op_has_lease;
+ 	__le32 prev_op_state = 0;
+ 
+@@ -1291,21 +1293,37 @@ set_lev:
+ 	set_oplock_level(opinfo, req_op_level, lctx);
+ 
+ out:
+-	opinfo_count_inc(fp);
+-	opinfo_add(opinfo, fp);
+-
++	/*
++	 * Set o_fp before any publication so that concurrent readers
++	 * (e.g. find_same_lease_key() on the lease list) that
++	 * dereference opinfo->o_fp don't hit a NULL pointer.
++	 *
++	 * Keep the original publication order so concurrent opens can
++	 * still observe the in-flight grant via ci->m_op_list, but make
++	 * everything after opinfo_add() no-fail by preallocating any new
++	 * lease_table first.
++	 */
++	opinfo->o_fp = fp;
+ 	if (opinfo->is_lease) {
+-		err = add_lease_global_list(opinfo);
+-		if (err)
++		new_lb = alloc_lease_table(opinfo);
++		if (!new_lb) {
++			err = -ENOMEM;
+ 			goto err_out;
++		}
+ 	}
+ 
++	opinfo_count_inc(fp);
++	opinfo_add(opinfo, fp);
++
++	if (opinfo->is_lease)
++		add_lease_global_list(opinfo, new_lb);
++
+ 	rcu_assign_pointer(fp->f_opinfo, opinfo);
+-	opinfo->o_fp = fp;
+ 
+ 	return 0;
+ err_out:
+-	__free_opinfo(opinfo);
++	kfree(new_lb);
++	opinfo_put(opinfo);
+ 	return err;
+ }
+ 
+diff --git a/fs/smb/server/smb2pdu.c b/fs/smb/server/smb2pdu.c
+index bdd2214c79f983..fa0a22f3db1c6f 100644
+--- a/fs/smb/server/smb2pdu.c
++++ b/fs/smb/server/smb2pdu.c
+@@ -1925,8 +1925,14 @@ out_err:
+ 			if (sess->user && sess->user->flags & KSMBD_USER_FLAG_DELAY_SESSION)
+ 				try_delay = true;
+ 
+-			sess->last_active = jiffies;
+-			sess->state = SMB2_SESSION_EXPIRED;
++			/*
++			 * For binding requests, session belongs to another
++			 * connection. Do not expire it.
++			 */
++			if (!(req->Flags & SMB2_SESSION_REQ_FLAG_BINDING)) {
++				sess->last_active = jiffies;
++				sess->state = SMB2_SESSION_EXPIRED;
++			}
+ 			ksmbd_user_session_put(sess);
+ 			work->sess = NULL;
+ 			if (try_delay) {
+@@ -4436,8 +4442,9 @@ int smb2_query_dir(struct ksmbd_work *work)
+ 	d_info.wptr = (char *)rsp->Buffer;
+ 	d_info.rptr = (char *)rsp->Buffer;
+ 	d_info.out_buf_len =
+-		smb2_calc_max_out_buf_len(work, 8,
+-					  le32_to_cpu(req->OutputBufferLength));
++		smb2_calc_max_out_buf_len(work,
++				offsetof(struct smb2_query_directory_rsp, Buffer),
++				le32_to_cpu(req->OutputBufferLength));
+ 	if (d_info.out_buf_len < 0) {
+ 		rc = -EINVAL;
+ 		goto err_out;
+@@ -4704,8 +4711,9 @@ static int smb2_get_ea(struct ksmbd_work *work, struct ksmbd_file *fp,
+ 	}
+ 
+ 	buf_free_len =
+-		smb2_calc_max_out_buf_len(work, 8,
+-					  le32_to_cpu(req->OutputBufferLength));
++		smb2_calc_max_out_buf_len(work,
++				offsetof(struct smb2_query_info_rsp, Buffer),
++				le32_to_cpu(req->OutputBufferLength));
+ 	if (buf_free_len < 0)
+ 		return -EINVAL;
+ 
+@@ -4917,7 +4925,8 @@ static int get_file_all_info(struct ksmbd_work *work,
+ 	int conv_len;
+ 	char *filename;
+ 	u64 time;
+-	int ret;
++	int ret, buf_free_len, filename_len;
++	struct smb2_query_info_req *req = ksmbd_req_buf_next(work);
+ 
+ 	if (!(fp->daccess & FILE_READ_ATTRIBUTES_LE)) {
+ 		ksmbd_debug(SMB, "no right to read the attributes : 0x%x\n",
+@@ -4929,6 +4938,16 @@ static int get_file_all_info(struct ksmbd_work *work,
+ 	if (IS_ERR(filename))
+ 		return PTR_ERR(filename);
+ 
++	filename_len = strlen(filename);
++	buf_free_len = smb2_calc_max_out_buf_len(work,
++			offsetof(struct smb2_query_info_rsp, Buffer) +
++			offsetof(struct smb2_file_all_info, FileName),
++			le32_to_cpu(req->OutputBufferLength));
++	if (buf_free_len < (filename_len + 1) * 2) {
++		kfree(filename);
++		return -EINVAL;
++	}
++
+ 	ret = vfs_getattr(&fp->filp->f_path, &stat, STATX_BASIC_STATS,
+ 			  AT_STATX_SYNC_AS_STAT);
+ 	if (ret) {
+@@ -4964,7 +4983,8 @@ static int get_file_all_info(struct ksmbd_work *work,
+ 	file_info->Mode = fp->coption;
+ 	file_info->AlignmentRequirement = 0;
+ 	conv_len = smbConvertToUTF16((__le16 *)file_info->FileName, filename,
+-				     PATH_MAX, conn->local_nls, 0);
++				     min(filename_len, PATH_MAX),
++				     conn->local_nls, 0);
+ 	conv_len *= 2;
+ 	file_info->FileNameLength = cpu_to_le32(conv_len);
+ 	rsp->OutputBufferLength =
+@@ -5018,8 +5038,9 @@ static int get_file_stream_info(struct ksmbd_work *work,
+ 	file_info = (struct smb2_file_stream_info *)rsp->Buffer;
+ 
+ 	buf_free_len =
+-		smb2_calc_max_out_buf_len(work, 8,
+-					  le32_to_cpu(req->OutputBufferLength));
++		smb2_calc_max_out_buf_len(work,
++				offsetof(struct smb2_query_info_rsp, Buffer),
++				le32_to_cpu(req->OutputBufferLength));
+ 	if (buf_free_len < 0)
+ 		goto out;
+ 
+@@ -7515,14 +7536,15 @@ retry:
+ 		rc = vfs_lock_file(filp, smb_lock->cmd, flock, NULL);
+ skip:
+ 		if (smb_lock->flags & SMB2_LOCKFLAG_UNLOCK) {
++			locks_free_lock(flock);
++			kfree(smb_lock);
+ 			if (!rc) {
+ 				ksmbd_debug(SMB, "File unlocked\n");
+ 			} else if (rc == -ENOENT) {
+ 				rsp->hdr.Status = STATUS_NOT_LOCKED;
++				err = rc;
+ 				goto out;
+ 			}
+-			locks_free_lock(flock);
+-			kfree(smb_lock);
+ 		} else {
+ 			if (rc == FILE_LOCK_DEFERRED) {
+ 				void **argv;
+@@ -7591,6 +7613,9 @@ skip:
+ 				spin_unlock(&work->conn->llist_lock);
+ 				ksmbd_debug(SMB, "successful in taking lock\n");
+ 			} else {
++				locks_free_lock(flock);
++				kfree(smb_lock);
++				err = rc;
+ 				goto out;
+ 			}
+ 		}
+@@ -7621,13 +7646,17 @@ out:
+ 		struct file_lock *rlock = NULL;
+ 
+ 		rlock = smb_flock_init(filp);
+-		rlock->fl_type = F_UNLCK;
+-		rlock->fl_start = smb_lock->start;
+-		rlock->fl_end = smb_lock->end;
++		if (rlock) {
++			rlock->fl_type = F_UNLCK;
++			rlock->fl_start = smb_lock->start;
++			rlock->fl_end = smb_lock->end;
+ 
+-		rc = vfs_lock_file(filp, F_SETLK, rlock, NULL);
+-		if (rc)
+-			pr_err("rollback unlock fail : %d\n", rc);
++			rc = vfs_lock_file(filp, F_SETLK, rlock, NULL);
++			if (rc)
++				pr_err("rollback unlock fail : %d\n", rc);
++		} else {
++			pr_err("rollback unlock alloc failed\n");
++		}
+ 
+ 		list_del(&smb_lock->llist);
+ 		spin_lock(&work->conn->llist_lock);
+@@ -7637,7 +7666,8 @@ out:
+ 		spin_unlock(&work->conn->llist_lock);
+ 
+ 		locks_free_lock(smb_lock->fl);
+-		locks_free_lock(rlock);
++		if (rlock)
++			locks_free_lock(rlock);
+ 		kfree(smb_lock);
+ 	}
+ out2:
+@@ -8119,8 +8149,9 @@ int smb2_ioctl(struct ksmbd_work *work)
+ 	buffer = (char *)req + le32_to_cpu(req->InputOffset);
+ 
+ 	cnt_code = le32_to_cpu(req->CtlCode);
+-	ret = smb2_calc_max_out_buf_len(work, 48,
+-					le32_to_cpu(req->MaxOutputResponse));
++	ret = smb2_calc_max_out_buf_len(work,
++			offsetof(struct smb2_ioctl_rsp, Buffer),
++			le32_to_cpu(req->MaxOutputResponse));
+ 	if (ret < 0) {
+ 		rsp->hdr.Status = STATUS_INVALID_PARAMETER;
+ 		goto out;
+diff --git a/fs/xattr.c b/fs/xattr.c
+index 7574d24b982ef6..5f2d74332ea636 100644
+--- a/fs/xattr.c
++++ b/fs/xattr.c
+@@ -698,8 +698,6 @@ SYSCALL_DEFINE5(fsetxattr, int, fd, const char __user *, name,
+ 	int error;
+ 
+ 	CLASS(fd, f)(fd);
+-	if (!f.file)
+-		return -EBADF;
+ 
+ 	audit_file(f.file);
+ 	error = setxattr_copy(name, &ctx);
+@@ -810,16 +808,11 @@ SYSCALL_DEFINE4(lgetxattr, const char __user *, pathname,
+ SYSCALL_DEFINE4(fgetxattr, int, fd, const char __user *, name,
+ 		void __user *, value, size_t, size)
+ {
+-	struct fd f = fdget(fd);
+-	ssize_t error = -EBADF;
++	CLASS(fd, f)(fd);
+ 
+-	if (!f.file)
+-		return error;
+ 	audit_file(f.file);
+-	error = getxattr(file_mnt_idmap(f.file), f.file->f_path.dentry,
++	return getxattr(file_mnt_idmap(f.file), f.file->f_path.dentry,
+ 			 name, value, size);
+-	fdput(f);
+-	return error;
+ }
+ 
+ /*
+@@ -886,15 +879,10 @@ SYSCALL_DEFINE3(llistxattr, const char __user *, pathname, char __user *, list,
+ 
+ SYSCALL_DEFINE3(flistxattr, int, fd, char __user *, list, size_t, size)
+ {
+-	struct fd f = fdget(fd);
+-	ssize_t error = -EBADF;
++	CLASS(fd, f)(fd);
+ 
+-	if (!f.file)
+-		return error;
+ 	audit_file(f.file);
+-	error = listxattr(f.file->f_path.dentry, list, size);
+-	fdput(f);
+-	return error;
++	return listxattr(f.file->f_path.dentry, list, size);
+ }
+ 
+ /*
+@@ -951,12 +939,10 @@ SYSCALL_DEFINE2(lremovexattr, const char __user *, pathname,
+ 
+ SYSCALL_DEFINE2(fremovexattr, int, fd, const char __user *, name)
+ {
+-	struct fd f = fdget(fd);
++	CLASS(fd, f)(fd);
+ 	char kname[XATTR_NAME_MAX + 1];
+-	int error = -EBADF;
++	int error;
+ 
+-	if (!f.file)
+-		return error;
+ 	audit_file(f.file);
+ 
+ 	error = strncpy_from_user(kname, name, sizeof(kname));
+@@ -971,7 +957,6 @@ SYSCALL_DEFINE2(fremovexattr, int, fd, const char __user *, name)
+ 				    f.file->f_path.dentry, kname);
+ 		mnt_drop_write_file(f.file);
+ 	}
+-	fdput(f);
+ 	return error;
+ }
+ 
+diff --git a/fs/xfs/xfs_attr_item.c b/fs/xfs/xfs_attr_item.c
+index df86c9c097209e..889fca3f8de1ce 100644
+--- a/fs/xfs/xfs_attr_item.c
++++ b/fs/xfs/xfs_attr_item.c
+@@ -746,8 +746,8 @@ xlog_recover_attri_commit_pass2(
+ 	switch (op) {
+ 	case XFS_ATTRI_OP_FLAGS_SET:
+ 	case XFS_ATTRI_OP_FLAGS_REPLACE:
+-		/* Log item, attr name, attr value */
+-		if (item->ri_total != 3) {
++		/* Log item, attr name, optional attr value */
++		if (item->ri_total != 2 + !!attri_formatp->alfi_value_len) {
+ 			XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+ 					     attri_formatp, len);
+ 			return -EFSCORRUPTED;
+diff --git a/fs/xfs/xfs_dquot_item.c b/fs/xfs/xfs_dquot_item.c
+index 7d19091215b080..74449aec81edce 100644
+--- a/fs/xfs/xfs_dquot_item.c
++++ b/fs/xfs/xfs_dquot_item.c
+@@ -125,6 +125,7 @@ xfs_qm_dquot_logitem_push(
+ {
+ 	struct xfs_dquot	*dqp = DQUOT_ITEM(lip)->qli_dquot;
+ 	struct xfs_buf		*bp = lip->li_buf;
++	struct xfs_ail		*ailp = lip->li_ailp;
+ 	uint			rval = XFS_ITEM_SUCCESS;
+ 	int			error;
+ 
+@@ -153,7 +154,7 @@ xfs_qm_dquot_logitem_push(
+ 		goto out_unlock;
+ 	}
+ 
+-	spin_unlock(&lip->li_ailp->ail_lock);
++	spin_unlock(&ailp->ail_lock);
+ 
+ 	error = xfs_qm_dqflush(dqp, &bp);
+ 	if (!error) {
+@@ -163,7 +164,11 @@ xfs_qm_dquot_logitem_push(
+ 	} else if (error == -EAGAIN)
+ 		rval = XFS_ITEM_LOCKED;
+ 
+-	spin_lock(&lip->li_ailp->ail_lock);
++	/*
++	 * The buffer no longer protects the log item from reclaim, so
++	 * do not reference lip after this point.
++	 */
++	spin_lock(&ailp->ail_lock);
+ out_unlock:
+ 	xfs_dqunlock(dqp);
+ 	return rval;
+diff --git a/fs/xfs/xfs_inode_item.c b/fs/xfs/xfs_inode_item.c
+index b55ad3b7b11394..77cd2f168a2b42 100644
+--- a/fs/xfs/xfs_inode_item.c
++++ b/fs/xfs/xfs_inode_item.c
+@@ -727,6 +727,7 @@ xfs_inode_item_push(
+ 	struct xfs_inode_log_item *iip = INODE_ITEM(lip);
+ 	struct xfs_inode	*ip = iip->ili_inode;
+ 	struct xfs_buf		*bp = lip->li_buf;
++	struct xfs_ail		*ailp = lip->li_ailp;
+ 	uint			rval = XFS_ITEM_SUCCESS;
+ 	int			error;
+ 
+@@ -749,7 +750,7 @@ xfs_inode_item_push(
+ 	if (!xfs_buf_trylock(bp))
+ 		return XFS_ITEM_LOCKED;
+ 
+-	spin_unlock(&lip->li_ailp->ail_lock);
++	spin_unlock(&ailp->ail_lock);
+ 
+ 	/*
+ 	 * We need to hold a reference for flushing the cluster buffer as it may
+@@ -773,7 +774,11 @@ xfs_inode_item_push(
+ 		rval = XFS_ITEM_LOCKED;
+ 	}
+ 
+-	spin_lock(&lip->li_ailp->ail_lock);
++	/*
++	 * The buffer no longer protects the log item from reclaim, so
++	 * do not reference lip after this point.
++	 */
++	spin_lock(&ailp->ail_lock);
+ 	return rval;
+ }
+ 
+diff --git a/fs/xfs/xfs_mount.c b/fs/xfs/xfs_mount.c
+index 747db90731e894..fca50269069049 100644
+--- a/fs/xfs/xfs_mount.c
++++ b/fs/xfs/xfs_mount.c
+@@ -576,8 +576,9 @@ xfs_unmount_check(
+  * have been retrying in the background.  This will prevent never-ending
+  * retries in AIL pushing from hanging the unmount.
+  *
+- * Finally, we can push the AIL to clean all the remaining dirty objects, then
+- * reclaim the remaining inodes that are still in memory at this point in time.
++ * Stop inodegc and background reclaim before pushing the AIL so that they
++ * are not running while the AIL is being flushed. Then push the AIL to
++ * clean all the remaining dirty objects and reclaim the remaining inodes.
+  */
+ static void
+ xfs_unmount_flush_inodes(
+@@ -589,9 +590,9 @@ xfs_unmount_flush_inodes(
+ 
+ 	set_bit(XFS_OPSTATE_UNMOUNTING, &mp->m_opstate);
+ 
+-	xfs_ail_push_all_sync(mp->m_ail);
+ 	xfs_inodegc_stop(mp);
+ 	cancel_delayed_work_sync(&mp->m_reclaim_work);
++	xfs_ail_push_all_sync(mp->m_ail);
+ 	xfs_reclaim_inodes(mp);
+ 	xfs_health_unmount(mp);
+ }
+diff --git a/fs/xfs/xfs_trace.c b/fs/xfs/xfs_trace.c
+index 8a5dc1538aa826..2bf489b445ee10 100644
+--- a/fs/xfs/xfs_trace.c
++++ b/fs/xfs/xfs_trace.c
+@@ -22,6 +22,7 @@
+ #include "xfs_trans.h"
+ #include "xfs_log.h"
+ #include "xfs_log_priv.h"
++#include "xfs_trans_priv.h"
+ #include "xfs_buf_item.h"
+ #include "xfs_quota.h"
+ #include "xfs_dquot_item.h"
+diff --git a/fs/xfs/xfs_trace.h b/fs/xfs/xfs_trace.h
+index d562028281f5c7..5c481d0df85183 100644
+--- a/fs/xfs/xfs_trace.h
++++ b/fs/xfs/xfs_trace.h
+@@ -50,6 +50,7 @@
+ #include <linux/tracepoint.h>
+ 
+ struct xfs_agf;
++struct xfs_ail;
+ struct xfs_alloc_arg;
+ struct xfs_attr_list_context;
+ struct xfs_buf_log_item;
+@@ -1332,14 +1333,41 @@ TRACE_EVENT(xfs_log_force,
+ DEFINE_EVENT(xfs_log_item_class, name, \
+ 	TP_PROTO(struct xfs_log_item *lip), \
+ 	TP_ARGS(lip))
+-DEFINE_LOG_ITEM_EVENT(xfs_ail_push);
+-DEFINE_LOG_ITEM_EVENT(xfs_ail_pinned);
+-DEFINE_LOG_ITEM_EVENT(xfs_ail_locked);
+-DEFINE_LOG_ITEM_EVENT(xfs_ail_flushing);
+ DEFINE_LOG_ITEM_EVENT(xfs_cil_whiteout_mark);
+ DEFINE_LOG_ITEM_EVENT(xfs_cil_whiteout_skip);
+ DEFINE_LOG_ITEM_EVENT(xfs_cil_whiteout_unpin);
+ 
++DECLARE_EVENT_CLASS(xfs_ail_push_class,
++	TP_PROTO(struct xfs_ail *ailp, uint type, unsigned long flags, xfs_lsn_t lsn),
++	TP_ARGS(ailp, type, flags, lsn),
++	TP_STRUCT__entry(
++		__field(dev_t, dev)
++		__field(uint, type)
++		__field(unsigned long, flags)
++		__field(xfs_lsn_t, lsn)
++	),
++	TP_fast_assign(
++		__entry->dev = ailp->ail_log->l_mp->m_super->s_dev;
++		__entry->type = type;
++		__entry->flags = flags;
++		__entry->lsn = lsn;
++	),
++	TP_printk("dev %d:%d lsn %d/%d type %s flags %s",
++		  MAJOR(__entry->dev), MINOR(__entry->dev),
++		  CYCLE_LSN(__entry->lsn), BLOCK_LSN(__entry->lsn),
++		  __print_symbolic(__entry->type, XFS_LI_TYPE_DESC),
++		  __print_flags(__entry->flags, "|", XFS_LI_FLAGS))
++)
++
++#define DEFINE_AIL_PUSH_EVENT(name) \
++DEFINE_EVENT(xfs_ail_push_class, name, \
++	TP_PROTO(struct xfs_ail *ailp, uint type, unsigned long flags, xfs_lsn_t lsn), \
++	TP_ARGS(ailp, type, flags, lsn))
++DEFINE_AIL_PUSH_EVENT(xfs_ail_push);
++DEFINE_AIL_PUSH_EVENT(xfs_ail_pinned);
++DEFINE_AIL_PUSH_EVENT(xfs_ail_locked);
++DEFINE_AIL_PUSH_EVENT(xfs_ail_flushing);
++
+ DECLARE_EVENT_CLASS(xfs_ail_class,
+ 	TP_PROTO(struct xfs_log_item *lip, xfs_lsn_t old_lsn, xfs_lsn_t new_lsn),
+ 	TP_ARGS(lip, old_lsn, new_lsn),
+diff --git a/fs/xfs/xfs_trans_ail.c b/fs/xfs/xfs_trans_ail.c
+index 1098452e7f9534..1bf02eada333a5 100644
+--- a/fs/xfs/xfs_trans_ail.c
++++ b/fs/xfs/xfs_trans_ail.c
+@@ -389,6 +389,12 @@ xfsaild_resubmit_item(
+ 	return XFS_ITEM_SUCCESS;
+ }
+ 
++/*
++ * Push a single log item from the AIL.
++ *
++ * @lip may have been released and freed by the time this function returns,
++ * so callers must not dereference the log item afterwards.
++ */
+ static inline uint
+ xfsaild_push_item(
+ 	struct xfs_ail		*ailp,
+@@ -476,20 +482,26 @@ xfsaild_push(
+ 
+ 	lsn = lip->li_lsn;
+ 	while ((XFS_LSN_CMP(lip->li_lsn, target) <= 0)) {
+-		int	lock_result;
++		int		lock_result;
++		uint		type = lip->li_type;
++		unsigned long	flags = lip->li_flags;
++		xfs_lsn_t	item_lsn = lip->li_lsn;
+ 
+ 		/*
+ 		 * Note that iop_push may unlock and reacquire the AIL lock.  We
+ 		 * rely on the AIL cursor implementation to be able to deal with
+ 		 * the dropped lock.
++		 *
++		 * The log item may have been freed by the push, so it must not
++		 * be accessed or dereferenced below this line.
+ 		 */
+ 		lock_result = xfsaild_push_item(ailp, lip);
+ 		switch (lock_result) {
+ 		case XFS_ITEM_SUCCESS:
+ 			XFS_STATS_INC(mp, xs_push_ail_success);
+-			trace_xfs_ail_push(lip);
++			trace_xfs_ail_push(ailp, type, flags, item_lsn);
+ 
+-			ailp->ail_last_pushed_lsn = lsn;
++			ailp->ail_last_pushed_lsn = item_lsn;
+ 			break;
+ 
+ 		case XFS_ITEM_FLUSHING:
+@@ -505,22 +517,22 @@ xfsaild_push(
+ 			 * AIL is being flushed.
+ 			 */
+ 			XFS_STATS_INC(mp, xs_push_ail_flushing);
+-			trace_xfs_ail_flushing(lip);
++			trace_xfs_ail_flushing(ailp, type, flags, item_lsn);
+ 
+ 			flushing++;
+-			ailp->ail_last_pushed_lsn = lsn;
++			ailp->ail_last_pushed_lsn = item_lsn;
+ 			break;
+ 
+ 		case XFS_ITEM_PINNED:
+ 			XFS_STATS_INC(mp, xs_push_ail_pinned);
+-			trace_xfs_ail_pinned(lip);
++			trace_xfs_ail_pinned(ailp, type, flags, item_lsn);
+ 
+ 			stuck++;
+ 			ailp->ail_log_flush++;
+ 			break;
+ 		case XFS_ITEM_LOCKED:
+ 			XFS_STATS_INC(mp, xs_push_ail_locked);
+-			trace_xfs_ail_locked(lip);
++			trace_xfs_ail_locked(ailp, type, flags, item_lsn);
+ 
+ 			stuck++;
+ 			break;
+diff --git a/include/linux/dma-mapping.h b/include/linux/dma-mapping.h
+index 608e8296ba206a..d5cd7b243b87d4 100644
+--- a/include/linux/dma-mapping.h
++++ b/include/linux/dma-mapping.h
+@@ -219,8 +219,8 @@ static inline void *dma_alloc_attrs(struct device *dev, size_t size,
+ {
+ 	return NULL;
+ }
+-static void dma_free_attrs(struct device *dev, size_t size, void *cpu_addr,
+-		dma_addr_t dma_handle, unsigned long attrs)
++static inline void dma_free_attrs(struct device *dev, size_t size,
++		void *cpu_addr, dma_addr_t dma_handle, unsigned long attrs)
+ {
+ }
+ static inline void *dmam_alloc_attrs(struct device *dev, size_t size,
+diff --git a/include/linux/usb/quirks.h b/include/linux/usb/quirks.h
+index 2f7bd2fdc6164b..b3cc7beab4a3ce 100644
+--- a/include/linux/usb/quirks.h
++++ b/include/linux/usb/quirks.h
+@@ -78,4 +78,7 @@
+ /* skip BOS descriptor request */
+ #define USB_QUIRK_NO_BOS			BIT(17)
+ 
++/* Device claims zero configurations, forcing to 1 */
++#define USB_QUIRK_FORCE_ONE_CONFIG		BIT(18)
++
+ #endif /* __LINUX_USB_QUIRKS_H */
+diff --git a/include/linux/usb/r8152.h b/include/linux/usb/r8152.h
+index 2ca60828f28bb6..1502b2a355f980 100644
+--- a/include/linux/usb/r8152.h
++++ b/include/linux/usb/r8152.h
+@@ -32,6 +32,7 @@
+ #define VENDOR_ID_DLINK			0x2001
+ #define VENDOR_ID_DELL			0x413c
+ #define VENDOR_ID_ASUS			0x0b05
++#define VENDOR_ID_TRENDNET		0x20f4
+ 
+ #if IS_REACHABLE(CONFIG_USB_RTL8152)
+ extern u8 rtl8152_get_version(struct usb_interface *intf);
+diff --git a/include/net/bluetooth/hci_sync.h b/include/net/bluetooth/hci_sync.h
+index e2e588b08fe90a..e155ab5aa9b4f1 100644
+--- a/include/net/bluetooth/hci_sync.h
++++ b/include/net/bluetooth/hci_sync.h
+@@ -8,6 +8,23 @@
+ #define UINT_PTR(_handle)		((void *)((uintptr_t)_handle))
+ #define PTR_UINT(_ptr)			((uintptr_t)((void *)_ptr))
+ 
++#define HCI_REQ_DONE	  0
++#define HCI_REQ_PEND	  1
++#define HCI_REQ_CANCELED  2
++
++#define hci_req_sync_lock(hdev)   mutex_lock(&hdev->req_lock)
++#define hci_req_sync_unlock(hdev) mutex_unlock(&hdev->req_lock)
++
++struct hci_request {
++	struct hci_dev		*hdev;
++	struct sk_buff_head	cmd_q;
++
++	/* If something goes wrong when building the HCI request, the error
++	 * value is stored in this field.
++	 */
++	int			err;
++};
++
+ typedef int (*hci_cmd_sync_work_func_t)(struct hci_dev *hdev, void *data);
+ typedef void (*hci_cmd_sync_work_destroy_t)(struct hci_dev *hdev, void *data,
+ 					    int err);
+diff --git a/include/net/inet_hashtables.h b/include/net/inet_hashtables.h
+index 3ecfeadbfa0694..8eeb3708f20ba1 100644
+--- a/include/net/inet_hashtables.h
++++ b/include/net/inet_hashtables.h
+@@ -278,6 +278,20 @@ inet_bhashfn_portaddr(const struct inet_hashinfo *hinfo, const struct sock *sk,
+ 	return &hinfo->bhash2[hash & (hinfo->bhash_size - 1)];
+ }
+ 
++static inline bool inet_use_hash2_on_bind(const struct sock *sk)
++{
++#if IS_ENABLED(CONFIG_IPV6)
++	if (sk->sk_family == AF_INET6) {
++		if (ipv6_addr_any(&sk->sk_v6_rcv_saddr))
++			return false;
++
++		if (!ipv6_addr_v4mapped(&sk->sk_v6_rcv_saddr))
++			return true;
++	}
++#endif
++	return sk->sk_rcv_saddr != htonl(INADDR_ANY);
++}
++
+ struct inet_bind_hashbucket *
+ inet_bhash2_addr_any_hashbucket(const struct sock *sk, const struct net *net, int port);
+ 
+diff --git a/include/net/ip6_fib.h b/include/net/ip6_fib.h
+index f4c5b705418c03..05489554019b4d 100644
+--- a/include/net/ip6_fib.h
++++ b/include/net/ip6_fib.h
+@@ -512,12 +512,14 @@ void fib6_rt_update(struct net *net, struct fib6_info *rt,
+ void inet6_rt_notify(int event, struct fib6_info *rt, struct nl_info *info,
+ 		     unsigned int flags);
+ 
++void fib6_age_exceptions(struct fib6_info *rt, struct fib6_gc_args *gc_args,
++			 unsigned long now);
+ void fib6_run_gc(unsigned long expires, struct net *net, bool force);
+-
+ void fib6_gc_cleanup(void);
+ 
+ int fib6_init(void);
+ 
++#if IS_ENABLED(CONFIG_IPV6)
+ /* Add the route to the gc list if it is not already there
+  *
+  * The callers should hold f6i->fib6_table->tb6_lock.
+@@ -550,6 +552,23 @@ static inline void fib6_remove_gc_list(struct fib6_info *f6i)
+ 		hlist_del_init(&f6i->gc_link);
+ }
+ 
++static inline void fib6_may_remove_gc_list(struct net *net,
++					   struct fib6_info *f6i)
++{
++	struct fib6_gc_args gc_args;
++
++	if (hlist_unhashed(&f6i->gc_link))
++		return;
++
++	gc_args.timeout = READ_ONCE(net->ipv6.sysctl.ip6_rt_gc_interval);
++	gc_args.more = 0;
++
++	rcu_read_lock();
++	fib6_age_exceptions(f6i, &gc_args, jiffies);
++	rcu_read_unlock();
++}
++#endif
++
+ struct ipv6_route_iter {
+ 	struct seq_net_private p;
+ 	struct fib6_walker w;
+diff --git a/include/uapi/linux/dma-buf.h b/include/uapi/linux/dma-buf.h
+index 5a6fda66d9adf0..e827c9d20c5d35 100644
+--- a/include/uapi/linux/dma-buf.h
++++ b/include/uapi/linux/dma-buf.h
+@@ -20,6 +20,7 @@
+ #ifndef _DMA_BUF_UAPI_H_
+ #define _DMA_BUF_UAPI_H_
+ 
++#include <linux/ioctl.h>
+ #include <linux/types.h>
+ 
+ /**
+diff --git a/include/uapi/linux/netfilter/nf_conntrack_common.h b/include/uapi/linux/netfilter/nf_conntrack_common.h
+index 26071021e986f6..56b6b60a814f5e 100644
+--- a/include/uapi/linux/netfilter/nf_conntrack_common.h
++++ b/include/uapi/linux/netfilter/nf_conntrack_common.h
+@@ -159,5 +159,9 @@ enum ip_conntrack_expect_events {
+ #define NF_CT_EXPECT_INACTIVE		0x2
+ #define NF_CT_EXPECT_USERSPACE		0x4
+ 
++#ifdef __KERNEL__
++#define NF_CT_EXPECT_MASK	(NF_CT_EXPECT_PERMANENT | NF_CT_EXPECT_INACTIVE | \
++				 NF_CT_EXPECT_USERSPACE)
++#endif
+ 
+ #endif /* _UAPI_NF_CONNTRACK_COMMON_H */
+diff --git a/kernel/bpf/btf.c b/kernel/bpf/btf.c
+index 14361b3b9edd00..1ace7faa59cfdf 100644
+--- a/kernel/bpf/btf.c
++++ b/kernel/bpf/btf.c
+@@ -1636,7 +1636,16 @@ static void btf_free_id(struct btf *btf)
+ 	 * of the _bh() version.
+ 	 */
+ 	spin_lock_irqsave(&btf_idr_lock, flags);
+-	idr_remove(&btf_idr, btf->id);
++	if (btf->id) {
++		idr_remove(&btf_idr, btf->id);
++		/*
++		 * Clear the id here to make this function idempotent, since it will get
++		 * called a couple of times for module BTFs: on module unload, and then
++		 * the final btf_put(). btf_alloc_id() starts IDs with 1, so we can use
++		 * 0 as sentinel value.
++		 */
++		WRITE_ONCE(btf->id, 0);
++	}
+ 	spin_unlock_irqrestore(&btf_idr_lock, flags);
+ }
+ 
+@@ -7158,7 +7167,7 @@ static void bpf_btf_show_fdinfo(struct seq_file *m, struct file *filp)
+ {
+ 	const struct btf *btf = filp->private_data;
+ 
+-	seq_printf(m, "btf_id:\t%u\n", btf->id);
++	seq_printf(m, "btf_id:\t%u\n", READ_ONCE(btf->id));
+ }
+ #endif
+ 
+@@ -7250,7 +7259,7 @@ int btf_get_info_by_fd(const struct btf *btf,
+ 	if (copy_from_user(&info, uinfo, info_copy))
+ 		return -EFAULT;
+ 
+-	info.id = btf->id;
++	info.id = READ_ONCE(btf->id);
+ 	ubtf = u64_to_user_ptr(info.btf);
+ 	btf_copy = min_t(u32, btf->data_size, info.btf_size);
+ 	if (copy_to_user(ubtf, btf->data, btf_copy))
+@@ -7313,7 +7322,7 @@ int btf_get_fd_by_id(u32 id)
+ 
+ u32 btf_obj_id(const struct btf *btf)
+ {
+-	return btf->id;
++	return READ_ONCE(btf->id);
+ }
+ 
+ bool btf_is_kernel(const struct btf *btf)
+@@ -7445,6 +7454,13 @@ static int btf_module_notify(struct notifier_block *nb, unsigned long op,
+ 			if (btf_mod->module != module)
+ 				continue;
+ 
++			/*
++			 * For modules, we do the freeing of BTF IDR as soon as
++			 * module goes away to disable BTF discovery, since the
++			 * btf_try_get_module() on such BTFs will fail. This may
++			 * be called again on btf_put(), but it's ok to do so.
++			 */
++			btf_free_id(btf_mod->btf);
+ 			list_del(&btf_mod->list);
+ 			if (btf_mod->sysfs_attr)
+ 				sysfs_remove_bin_file(btf_kobj, btf_mod->sysfs_attr);
+diff --git a/kernel/bpf/core.c b/kernel/bpf/core.c
+index a343248c35ded6..3011add7c4a882 100644
+--- a/kernel/bpf/core.c
++++ b/kernel/bpf/core.c
+@@ -1667,6 +1667,12 @@ bool bpf_opcode_in_insntable(u8 code)
+ }
+ 
+ #ifndef CONFIG_BPF_JIT_ALWAYS_ON
++/* Absolute value of s32 without undefined behavior for S32_MIN */
++static u32 abs_s32(s32 x)
++{
++	return x >= 0 ? (u32)x : -(u32)x;
++}
++
+ /**
+  *	___bpf_prog_run - run eBPF program on a given context
+  *	@regs: is the array of MAX_BPF_EXT_REG eBPF pseudo-registers
+@@ -1831,8 +1837,8 @@ select_insn:
+ 			DST = do_div(AX, (u32) SRC);
+ 			break;
+ 		case 1:
+-			AX = abs((s32)DST);
+-			AX = do_div(AX, abs((s32)SRC));
++			AX = abs_s32((s32)DST);
++			AX = do_div(AX, abs_s32((s32)SRC));
+ 			if ((s32)DST < 0)
+ 				DST = (u32)-AX;
+ 			else
+@@ -1859,8 +1865,8 @@ select_insn:
+ 			DST = do_div(AX, (u32) IMM);
+ 			break;
+ 		case 1:
+-			AX = abs((s32)DST);
+-			AX = do_div(AX, abs((s32)IMM));
++			AX = abs_s32((s32)DST);
++			AX = do_div(AX, abs_s32((s32)IMM));
+ 			if ((s32)DST < 0)
+ 				DST = (u32)-AX;
+ 			else
+@@ -1886,8 +1892,8 @@ select_insn:
+ 			DST = (u32) AX;
+ 			break;
+ 		case 1:
+-			AX = abs((s32)DST);
+-			do_div(AX, abs((s32)SRC));
++			AX = abs_s32((s32)DST);
++			do_div(AX, abs_s32((s32)SRC));
+ 			if (((s32)DST < 0) == ((s32)SRC < 0))
+ 				DST = (u32)AX;
+ 			else
+@@ -1913,8 +1919,8 @@ select_insn:
+ 			DST = (u32) AX;
+ 			break;
+ 		case 1:
+-			AX = abs((s32)DST);
+-			do_div(AX, abs((s32)IMM));
++			AX = abs_s32((s32)DST);
++			do_div(AX, abs_s32((s32)IMM));
+ 			if (((s32)DST < 0) == ((s32)IMM < 0))
+ 				DST = (u32)AX;
+ 			else
+diff --git a/kernel/dma/swiotlb.c b/kernel/dma/swiotlb.c
+index e7c3fbd0737ec0..2959309c4fb821 100644
+--- a/kernel/dma/swiotlb.c
++++ b/kernel/dma/swiotlb.c
+@@ -30,6 +30,7 @@
+ #include <linux/gfp.h>
+ #include <linux/highmem.h>
+ #include <linux/io.h>
++#include <linux/kmsan-checks.h>
+ #include <linux/iommu-helper.h>
+ #include <linux/init.h>
+ #include <linux/memblock.h>
+@@ -906,10 +907,19 @@ static void swiotlb_bounce(struct device *dev, phys_addr_t tlb_addr, size_t size
+ 
+ 			local_irq_save(flags);
+ 			page = pfn_to_page(pfn);
+-			if (dir == DMA_TO_DEVICE)
++			if (dir == DMA_TO_DEVICE) {
++				/*
++				 * Ideally, kmsan_check_highmem_page()
++				 * could be used here to detect infoleaks,
++				 * but callers may map uninitialized buffers
++				 * that will be written by the device,
++				 * causing false positives.
++				 */
+ 				memcpy_from_page(vaddr, page, offset, sz);
+-			else
++			} else {
++				kmsan_unpoison_memory(vaddr, sz);
+ 				memcpy_to_page(page, offset, vaddr, sz);
++			}
+ 			local_irq_restore(flags);
+ 
+ 			size -= sz;
+@@ -918,8 +928,15 @@ static void swiotlb_bounce(struct device *dev, phys_addr_t tlb_addr, size_t size
+ 			offset = 0;
+ 		}
+ 	} else if (dir == DMA_TO_DEVICE) {
++		/*
++		 * Ideally, kmsan_check_memory() could be used here to detect
++		 * infoleaks (uninitialized data being sent to device), but
++		 * callers may map uninitialized buffers that will be written
++		 * by the device, causing false positives.
++		 */
+ 		memcpy(vaddr, phys_to_virt(orig_addr), size);
+ 	} else {
++		kmsan_unpoison_memory(vaddr, size);
+ 		memcpy(phys_to_virt(orig_addr), vaddr, size);
+ 	}
+ }
+diff --git a/kernel/events/core.c b/kernel/events/core.c
+index 652baf91c629e5..eba5eb6fcb8762 100644
+--- a/kernel/events/core.c
++++ b/kernel/events/core.c
+@@ -2349,6 +2349,24 @@ group_sched_out(struct perf_event *group_event, struct perf_event_context *ctx)
+ 		event_sched_out(event, ctx);
+ }
+ 
++static inline void
++ctx_time_update(struct perf_cpu_context *cpuctx, struct perf_event_context *ctx)
++{
++	if (ctx->is_active & EVENT_TIME) {
++		update_context_time(ctx);
++		update_cgrp_time_from_cpuctx(cpuctx, false);
++	}
++}
++
++static inline void
++ctx_time_update_event(struct perf_event_context *ctx, struct perf_event *event)
++{
++	if (ctx->is_active & EVENT_TIME) {
++		update_context_time(ctx);
++		update_cgrp_time_from_event(event);
++	}
++}
++
+ #define DETACH_GROUP	0x01UL
+ #define DETACH_CHILD	0x02UL
+ #define DETACH_DEAD	0x04UL
+@@ -2370,10 +2388,7 @@ __perf_remove_from_context(struct perf_event *event,
+ 	enum perf_event_state state = PERF_EVENT_STATE_OFF;
+ 	unsigned long flags = (unsigned long)info;
+ 
+-	if (ctx->is_active & EVENT_TIME) {
+-		update_context_time(ctx);
+-		update_cgrp_time_from_cpuctx(cpuctx, false);
+-	}
++	ctx_time_update(cpuctx, ctx);
+ 
+ 	/*
+ 	 * Ensure event_sched_out() switches to OFF, at the very least
+@@ -2470,12 +2485,8 @@ static void __perf_event_disable(struct perf_event *event,
+ 	if (event->state < PERF_EVENT_STATE_INACTIVE)
+ 		return;
+ 
+-	if (ctx->is_active & EVENT_TIME) {
+-		update_context_time(ctx);
+-		update_cgrp_time_from_event(event);
+-	}
+-
+ 	perf_pmu_disable(event->pmu_ctx->pmu);
++	ctx_time_update_event(ctx, event);
+ 
+ 	/*
+ 	 * When disabling a group leader, the whole group becomes ineligible
+@@ -4521,7 +4532,7 @@ static void __perf_event_read(void *info)
+ 	struct perf_event *sub, *event = data->event;
+ 	struct perf_event_context *ctx = event->ctx;
+ 	struct perf_cpu_context *cpuctx = this_cpu_ptr(&perf_cpu_context);
+-	struct pmu *pmu = event->pmu;
++	struct pmu *pmu;
+ 
+ 	/*
+ 	 * If this is a task context, we need to check whether it is
+@@ -4533,36 +4544,30 @@ static void __perf_event_read(void *info)
+ 	if (ctx->task && cpuctx->task_ctx != ctx)
+ 		return;
+ 
+-	raw_spin_lock(&ctx->lock);
+-	if (ctx->is_active & EVENT_TIME) {
+-		update_context_time(ctx);
+-		update_cgrp_time_from_event(event);
+-	}
++	guard(raw_spinlock)(&ctx->lock);
++	ctx_time_update_event(ctx, event);
+ 
+ 	perf_event_update_time(event);
+ 	if (data->group)
+ 		perf_event_update_sibling_time(event);
+ 
+ 	if (event->state != PERF_EVENT_STATE_ACTIVE)
+-		goto unlock;
++		return;
+ 
+ 	if (!data->group) {
+-		pmu->read(event);
++		perf_pmu_read(event);
+ 		data->ret = 0;
+-		goto unlock;
++		return;
+ 	}
+ 
++	pmu = event->pmu_ctx->pmu;
+ 	pmu->start_txn(pmu, PERF_PMU_TXN_READ);
+ 
+-	pmu->read(event);
+-
++	perf_pmu_read(event);
+ 	for_each_sibling_event(sub, event)
+ 		perf_pmu_read(sub);
+ 
+ 	data->ret = pmu->commit_txn(pmu);
+-
+-unlock:
+-	raw_spin_unlock(&ctx->lock);
+ }
+ 
+ static inline u64 perf_event_count(struct perf_event *event)
+@@ -4718,10 +4723,7 @@ again:
+ 		 * May read while context is not active (e.g., thread is
+ 		 * blocked), in that case we cannot update context time
+ 		 */
+-		if (ctx->is_active & EVENT_TIME) {
+-			update_context_time(ctx);
+-			update_cgrp_time_from_event(event);
+-		}
++		ctx_time_update_event(ctx, event);
+ 
+ 		perf_event_update_time(event);
+ 		if (group)
+@@ -13536,7 +13538,7 @@ inherit_event(struct perf_event *parent_event,
+ 	get_ctx(child_ctx);
+ 	child_event->ctx = child_ctx;
+ 
+-	pmu_ctx = find_get_pmu_context(child_event->pmu, child_ctx, child_event);
++	pmu_ctx = find_get_pmu_context(parent_event->pmu_ctx->pmu, child_ctx, child_event);
+ 	if (IS_ERR(pmu_ctx)) {
+ 		free_event(child_event);
+ 		return ERR_CAST(pmu_ctx);
+diff --git a/kernel/futex/pi.c b/kernel/futex/pi.c
+index ce2889f123755f..9496084b6dcd84 100644
+--- a/kernel/futex/pi.c
++++ b/kernel/futex/pi.c
+@@ -930,9 +930,9 @@ int fixup_pi_owner(u32 __user *uaddr, struct futex_q *q, int locked)
+ int futex_lock_pi(u32 __user *uaddr, unsigned int flags, ktime_t *time, int trylock)
+ {
+ 	struct hrtimer_sleeper timeout, *to;
+-	struct task_struct *exiting = NULL;
+ 	struct rt_mutex_waiter rt_waiter;
+ 	struct futex_hash_bucket *hb;
++	struct task_struct *exiting;
+ 	struct futex_q q = futex_q_init;
+ 	int res, ret;
+ 
+@@ -945,6 +945,7 @@ int futex_lock_pi(u32 __user *uaddr, unsigned int flags, ktime_t *time, int tryl
+ 	to = futex_setup_timer(time, &timeout, flags, 0);
+ 
+ retry:
++	exiting = NULL;
+ 	ret = get_futex_key(uaddr, flags & FLAGS_SHARED, &q.key, FUTEX_WRITE);
+ 	if (unlikely(ret != 0))
+ 		goto out;
+diff --git a/kernel/module/main.c b/kernel/module/main.c
+index 627680e568fccc..76d90c20de6743 100644
+--- a/kernel/module/main.c
++++ b/kernel/module/main.c
+@@ -1424,6 +1424,13 @@ static int simplify_symbols(struct module *mod, const struct load_info *info)
+ 			break;
+ 
+ 		default:
++			if (sym[i].st_shndx >= info->hdr->e_shnum) {
++				pr_err("%s: Symbol %s has an invalid section index %u (max %u)\n",
++				       mod->name, name, sym[i].st_shndx, info->hdr->e_shnum - 1);
++				ret = -ENOEXEC;
++				break;
++			}
++
+ 			/* Divert to percpu allocation if a percpu var. */
+ 			if (sym[i].st_shndx == info->index.pcpu)
+ 				secbase = (unsigned long)mod_percpu(mod);
+diff --git a/kernel/power/power.h b/kernel/power/power.h
+index 62a7cb452a4be6..3ea663f1ad1e2a 100644
+--- a/kernel/power/power.h
++++ b/kernel/power/power.h
+@@ -152,7 +152,7 @@ extern unsigned int snapshot_additional_pages(struct zone *zone);
+ extern unsigned long snapshot_get_image_size(void);
+ extern int snapshot_read_next(struct snapshot_handle *handle);
+ extern int snapshot_write_next(struct snapshot_handle *handle);
+-extern void snapshot_write_finalize(struct snapshot_handle *handle);
++int snapshot_write_finalize(struct snapshot_handle *handle);
+ extern int snapshot_image_loaded(struct snapshot_handle *handle);
+ 
+ extern bool hibernate_acquire(void);
+diff --git a/kernel/power/snapshot.c b/kernel/power/snapshot.c
+index 50a15408c3fcad..c3ad93fc24e644 100644
+--- a/kernel/power/snapshot.c
++++ b/kernel/power/snapshot.c
+@@ -58,22 +58,24 @@ static inline void hibernate_restore_protection_end(void)
+ 	hibernate_restore_protection_active = false;
+ }
+ 
+-static inline void hibernate_restore_protect_page(void *page_address)
++static inline int __must_check hibernate_restore_protect_page(void *page_address)
+ {
+ 	if (hibernate_restore_protection_active)
+-		set_memory_ro((unsigned long)page_address, 1);
++		return set_memory_ro((unsigned long)page_address, 1);
++	return 0;
+ }
+ 
+-static inline void hibernate_restore_unprotect_page(void *page_address)
++static inline int hibernate_restore_unprotect_page(void *page_address)
+ {
+ 	if (hibernate_restore_protection_active)
+-		set_memory_rw((unsigned long)page_address, 1);
++		return set_memory_rw((unsigned long)page_address, 1);
++	return 0;
+ }
+ #else
+ static inline void hibernate_restore_protection_begin(void) {}
+ static inline void hibernate_restore_protection_end(void) {}
+-static inline void hibernate_restore_protect_page(void *page_address) {}
+-static inline void hibernate_restore_unprotect_page(void *page_address) {}
++static inline int __must_check hibernate_restore_protect_page(void *page_address) {return 0; }
++static inline int hibernate_restore_unprotect_page(void *page_address) {return 0; }
+ #endif /* CONFIG_STRICT_KERNEL_RWX  && CONFIG_ARCH_HAS_SET_MEMORY */
+ 
+ 
+@@ -2832,7 +2834,9 @@ next:
+ 		}
+ 	} else {
+ 		copy_last_highmem_page();
+-		hibernate_restore_protect_page(handle->buffer);
++		error = hibernate_restore_protect_page(handle->buffer);
++		if (error)
++			return error;
+ 		handle->buffer = get_buffer(&orig_bm, &ca);
+ 		if (IS_ERR(handle->buffer))
+ 			return PTR_ERR(handle->buffer);
+@@ -2858,15 +2862,29 @@ next:
+  * stored in highmem.  Additionally, it recycles bitmap memory that's not
+  * necessary any more.
+  */
+-void snapshot_write_finalize(struct snapshot_handle *handle)
++int snapshot_write_finalize(struct snapshot_handle *handle)
+ {
++	int error;
++
++	/*
++	 * Call snapshot_write_next() to drain any trailing zero pages,
++	 * but make sure we're in the data page region first.
++	 * This function can return PAGE_SIZE if the kernel was expecting
++	 * another copy page. Return -ENODATA in that situation.
++	 */
++	if (handle->cur > nr_meta_pages + 1) {
++		error = snapshot_write_next(handle);
++		if (error)
++			return error > 0 ? -ENODATA : error;
++	}
+ 	copy_last_highmem_page();
+-	hibernate_restore_protect_page(handle->buffer);
++	error = hibernate_restore_protect_page(handle->buffer);
+ 	/* Do that only if we have loaded the image entirely */
+ 	if (handle->cur > 1 && handle->cur > nr_meta_pages + nr_copy_pages + nr_zero_pages) {
+ 		memory_bm_recycle(&orig_bm);
+ 		free_highmem_data();
+ 	}
++	return error;
+ }
+ 
+ int snapshot_image_loaded(struct snapshot_handle *handle)
+diff --git a/kernel/power/swap.c b/kernel/power/swap.c
+index d71c590550d282..8c162e18e16452 100644
+--- a/kernel/power/swap.c
++++ b/kernel/power/swap.c
+@@ -1099,8 +1099,8 @@ static int load_image(struct swap_map_handle *handle,
+ 		ret = err2;
+ 	if (!ret) {
+ 		pr_info("Image loading done\n");
+-		snapshot_write_finalize(snapshot);
+-		if (!snapshot_image_loaded(snapshot))
++		ret = snapshot_write_finalize(snapshot);
++		if (!ret && !snapshot_image_loaded(snapshot))
+ 			ret = -ENODATA;
+ 	}
+ 	swsusp_show_speed(start, stop, nr_to_read, "Read");
+@@ -1440,8 +1440,8 @@ out_finish:
+ 	stop = ktime_get();
+ 	if (!ret) {
+ 		pr_info("Image loading done\n");
+-		snapshot_write_finalize(snapshot);
+-		if (!snapshot_image_loaded(snapshot))
++		ret = snapshot_write_finalize(snapshot);
++		if (!ret && !snapshot_image_loaded(snapshot))
+ 			ret = -ENODATA;
+ 		if (!ret) {
+ 			if (swsusp_header->flags & SF_CRC32_MODE) {
+diff --git a/kernel/power/user.c b/kernel/power/user.c
+index 3a4e70366f354c..3aa41ba22129d8 100644
+--- a/kernel/power/user.c
++++ b/kernel/power/user.c
+@@ -317,7 +317,9 @@ static long snapshot_ioctl(struct file *filp, unsigned int cmd,
+ 		break;
+ 
+ 	case SNAPSHOT_ATOMIC_RESTORE:
+-		snapshot_write_finalize(&data->handle);
++		error = snapshot_write_finalize(&data->handle);
++		if (error)
++			break;
+ 		if (data->mode != O_WRONLY || !data->frozen ||
+ 		    !snapshot_image_loaded(&data->handle)) {
+ 			error = -EPERM;
+diff --git a/kernel/sysctl.c b/kernel/sysctl.c
+index 354a2d294f526a..f8f07c04923886 100644
+--- a/kernel/sysctl.c
++++ b/kernel/sysctl.c
+@@ -1374,7 +1374,7 @@ int proc_do_large_bitmap(struct ctl_table *table, int write,
+ 	unsigned long bitmap_len = table->maxlen;
+ 	unsigned long *bitmap = *(unsigned long **) table->data;
+ 	unsigned long *tmp_bitmap = NULL;
+-	char tr_a[] = { '-', ',', '\n' }, tr_b[] = { ',', '\n', 0 }, c;
++	char tr_a[] = { '-', ',', '\n' }, tr_b[] = { ',', '\n', 0 }, c = 0;
+ 
+ 	if (!bitmap || !bitmap_len || !left || (*ppos && !write)) {
+ 		*lenp = 0;
+diff --git a/kernel/time/alarmtimer.c b/kernel/time/alarmtimer.c
+index 8d9f13d847f09f..2816c3a5f39091 100644
+--- a/kernel/time/alarmtimer.c
++++ b/kernel/time/alarmtimer.c
+@@ -608,7 +608,7 @@ static s64 alarm_timer_forward(struct k_itimer *timr, ktime_t now)
+ {
+ 	struct alarm *alarm = &timr->it.alarm.alarmtimer;
+ 
+-	return alarm_forward(alarm, timr->it_interval, now);
++	return alarm_forward(alarm, now, timr->it_interval);
+ }
+ 
+ /**
+diff --git a/kernel/trace/trace_osnoise.c b/kernel/trace/trace_osnoise.c
+index 4d12d02965a4b7..3b039374c993ed 100644
+--- a/kernel/trace/trace_osnoise.c
++++ b/kernel/trace/trace_osnoise.c
+@@ -2099,26 +2099,21 @@ static void osnoise_hotplug_workfn(struct work_struct *dummy)
+ {
+ 	unsigned int cpu = smp_processor_id();
+ 
+-	mutex_lock(&trace_types_lock);
++	guard(mutex)(&trace_types_lock);
+ 
+ 	if (!osnoise_has_registered_instances())
+-		goto out_unlock_trace;
++		return;
+ 
+-	mutex_lock(&interface_lock);
+-	cpus_read_lock();
++	guard(cpus_read_lock)();
++	guard(mutex)(&interface_lock);
+ 
+ 	if (!cpu_online(cpu))
+-		goto out_unlock;
++		return;
++
+ 	if (!cpumask_test_cpu(cpu, &osnoise_cpumask))
+-		goto out_unlock;
++		return;
+ 
+ 	start_kthread(cpu);
+-
+-out_unlock:
+-	cpus_read_unlock();
+-	mutex_unlock(&interface_lock);
+-out_unlock_trace:
+-	mutex_unlock(&trace_types_lock);
+ }
+ 
+ static DECLARE_WORK(osnoise_hotplug_work, osnoise_hotplug_workfn);
+@@ -2273,11 +2268,11 @@ static ssize_t osnoise_options_write(struct file *filp, const char __user *ubuf,
+ 	if (running)
+ 		stop_per_cpu_kthreads();
+ 
+-	mutex_lock(&interface_lock);
+ 	/*
+ 	 * avoid CPU hotplug operations that might read options.
+ 	 */
+ 	cpus_read_lock();
++	mutex_lock(&interface_lock);
+ 
+ 	retval = cnt;
+ 
+@@ -2293,8 +2288,8 @@ static ssize_t osnoise_options_write(struct file *filp, const char __user *ubuf,
+ 			clear_bit(option, &osnoise_options);
+ 	}
+ 
+-	cpus_read_unlock();
+ 	mutex_unlock(&interface_lock);
++	cpus_read_unlock();
+ 
+ 	if (running)
+ 		start_per_cpu_kthreads();
+@@ -2316,31 +2311,22 @@ static ssize_t
+ osnoise_cpus_read(struct file *filp, char __user *ubuf, size_t count,
+ 		  loff_t *ppos)
+ {
+-	char *mask_str;
++	char *mask_str __free(kfree) = NULL;
+ 	int len;
+ 
+-	mutex_lock(&interface_lock);
++	guard(mutex)(&interface_lock);
+ 
+ 	len = snprintf(NULL, 0, "%*pbl\n", cpumask_pr_args(&osnoise_cpumask)) + 1;
+ 	mask_str = kmalloc(len, GFP_KERNEL);
+-	if (!mask_str) {
+-		count = -ENOMEM;
+-		goto out_unlock;
+-	}
++	if (!mask_str)
++		return -ENOMEM;
+ 
+ 	len = snprintf(mask_str, len, "%*pbl\n", cpumask_pr_args(&osnoise_cpumask));
+-	if (len >= count) {
+-		count = -EINVAL;
+-		goto out_free;
+-	}
++	if (len >= count)
++		return -EINVAL;
+ 
+ 	count = simple_read_from_buffer(ubuf, count, ppos, mask_str, len);
+ 
+-out_free:
+-	kfree(mask_str);
+-out_unlock:
+-	mutex_unlock(&interface_lock);
+-
+ 	return count;
+ }
+ 
+@@ -2389,16 +2375,16 @@ osnoise_cpus_write(struct file *filp, const char __user *ubuf, size_t count,
+ 	if (running)
+ 		stop_per_cpu_kthreads();
+ 
+-	mutex_lock(&interface_lock);
+ 	/*
+ 	 * osnoise_cpumask is read by CPU hotplug operations.
+ 	 */
+ 	cpus_read_lock();
++	mutex_lock(&interface_lock);
+ 
+ 	cpumask_copy(&osnoise_cpumask, osnoise_cpumask_new);
+ 
+-	cpus_read_unlock();
+ 	mutex_unlock(&interface_lock);
++	cpus_read_unlock();
+ 
+ 	if (running)
+ 		start_per_cpu_kthreads();
+diff --git a/mm/damon/sysfs.c b/mm/damon/sysfs.c
+index acb6e57cd9cbe8..7a410640a0ef7a 100644
+--- a/mm/damon/sysfs.c
++++ b/mm/damon/sysfs.c
+@@ -1494,6 +1494,9 @@ static int damon_sysfs_handle_cmd(enum damon_sysfs_cmd cmd,
+ {
+ 	bool need_wait = true;
+ 
++	if (cmd != DAMON_SYSFS_CMD_OFF && kdamond->contexts->nr != 1)
++		return -EINVAL;
++
+ 	/* Handle commands that doesn't access DAMON context-internal data */
+ 	switch (cmd) {
+ 	case DAMON_SYSFS_CMD_ON:
+diff --git a/net/bluetooth/hci_request.h b/net/bluetooth/hci_request.h
+index 0be75cf0efed86..b730da4a8b4768 100644
+--- a/net/bluetooth/hci_request.h
++++ b/net/bluetooth/hci_request.h
+@@ -22,27 +22,6 @@
+ 
+ #include <asm/unaligned.h>
+ 
+-#define HCI_REQ_DONE	  0
+-#define HCI_REQ_PEND	  1
+-#define HCI_REQ_CANCELED  2
+-
+-#define hci_req_sync_lock(hdev)   mutex_lock(&hdev->req_lock)
+-#define hci_req_sync_unlock(hdev) mutex_unlock(&hdev->req_lock)
+-
+-#define HCI_REQ_DONE	  0
+-#define HCI_REQ_PEND	  1
+-#define HCI_REQ_CANCELED  2
+-
+-struct hci_request {
+-	struct hci_dev		*hdev;
+-	struct sk_buff_head	cmd_q;
+-
+-	/* If something goes wrong when building the HCI request, the error
+-	 * value is stored in this field.
+-	 */
+-	int			err;
+-};
+-
+ void hci_req_init(struct hci_request *req, struct hci_dev *hdev);
+ void hci_req_purge(struct hci_request *req);
+ bool hci_req_status_pend(struct hci_dev *hdev);
+diff --git a/net/bluetooth/hci_sync.c b/net/bluetooth/hci_sync.c
+index 6192f70e4d3935..c1c9d82faa6588 100644
+--- a/net/bluetooth/hci_sync.c
++++ b/net/bluetooth/hci_sync.c
+@@ -12,7 +12,6 @@
+ #include <net/bluetooth/hci_core.h>
+ #include <net/bluetooth/mgmt.h>
+ 
+-#include "hci_request.h"
+ #include "hci_codec.h"
+ #include "hci_debugfs.h"
+ #include "smp.h"
+@@ -147,6 +146,13 @@ static int hci_req_sync_run(struct hci_request *req)
+ 	return 0;
+ }
+ 
++static void hci_request_init(struct hci_request *req, struct hci_dev *hdev)
++{
++	skb_queue_head_init(&req->cmd_q);
++	req->hdev = hdev;
++	req->err = 0;
++}
++
+ /* This function requires the caller holds hdev->req_lock. */
+ struct sk_buff *__hci_cmd_sync_sk(struct hci_dev *hdev, u16 opcode, u32 plen,
+ 				  const void *param, u8 event, u32 timeout,
+@@ -158,7 +164,7 @@ struct sk_buff *__hci_cmd_sync_sk(struct hci_dev *hdev, u16 opcode, u32 plen,
+ 
+ 	bt_dev_dbg(hdev, "Opcode 0x%4.4x", opcode);
+ 
+-	hci_req_init(&req, hdev);
++	hci_request_init(&req, hdev);
+ 
+ 	hci_cmd_sync_add(&req, opcode, plen, param, event, sk);
+ 
+@@ -5227,7 +5233,9 @@ int hci_dev_close_sync(struct hci_dev *hdev)
+ 	cancel_delayed_work(&hdev->le_scan_disable);
+ 	cancel_delayed_work(&hdev->le_scan_restart);
+ 
+-	hci_request_cancel_all(hdev);
++	hci_cmd_sync_cancel_sync(hdev, ENODEV);
++
++	cancel_interleave_scan(hdev);
+ 
+ 	if (hdev->adv_instance_timeout) {
+ 		cancel_delayed_work_sync(&hdev->adv_instance_expire);
+diff --git a/net/bluetooth/l2cap_core.c b/net/bluetooth/l2cap_core.c
+index 16cc5c878305b7..3da3e9fddd0498 100644
+--- a/net/bluetooth/l2cap_core.c
++++ b/net/bluetooth/l2cap_core.c
+@@ -2383,6 +2383,9 @@ static int l2cap_segment_sdu(struct l2cap_chan *chan,
+ 	/* Remote device may have requested smaller PDUs */
+ 	pdu_len = min_t(size_t, pdu_len, chan->remote_mps);
+ 
++	if (!pdu_len)
++		return -EINVAL;
++
+ 	if (len <= pdu_len) {
+ 		sar = L2CAP_SAR_UNSEGMENTED;
+ 		sdu_len = 0;
+@@ -4281,14 +4284,16 @@ static inline int l2cap_config_req(struct l2cap_conn *conn,
+ 	if (test_bit(CONF_INPUT_DONE, &chan->conf_state)) {
+ 		set_default_fcs(chan);
+ 
+-		if (chan->mode == L2CAP_MODE_ERTM ||
+-		    chan->mode == L2CAP_MODE_STREAMING)
+-			err = l2cap_ertm_init(chan);
++		if (chan->state != BT_CONNECTED) {
++			if (chan->mode == L2CAP_MODE_ERTM ||
++			    chan->mode == L2CAP_MODE_STREAMING)
++				err = l2cap_ertm_init(chan);
+ 
+-		if (err < 0)
+-			l2cap_send_disconn_req(chan, -err);
+-		else
+-			l2cap_chan_ready(chan);
++			if (err < 0)
++				l2cap_send_disconn_req(chan, -err);
++			else
++				l2cap_chan_ready(chan);
++		}
+ 
+ 		goto unlock;
+ 	}
+@@ -6553,6 +6558,10 @@ static void l2cap_chan_le_send_credits(struct l2cap_chan *chan)
+ 	struct l2cap_le_credits pkt;
+ 	u16 return_credits = l2cap_le_rx_credits(chan);
+ 
++	if (chan->mode != L2CAP_MODE_LE_FLOWCTL &&
++	    chan->mode != L2CAP_MODE_EXT_FLOWCTL)
++		return;
++
+ 	if (chan->rx_credits >= return_credits)
+ 		return;
+ 
+@@ -6636,6 +6645,11 @@ static int l2cap_ecred_data_rcv(struct l2cap_chan *chan, struct sk_buff *skb)
+ 	if (!chan->sdu) {
+ 		u16 sdu_len;
+ 
++		if (!pskb_may_pull(skb, L2CAP_SDULEN_SIZE)) {
++			err = -EINVAL;
++			goto failed;
++		}
++
+ 		sdu_len = get_unaligned_le16(skb->data);
+ 		skb_pull(skb, L2CAP_SDULEN_SIZE);
+ 
+diff --git a/net/bluetooth/l2cap_sock.c b/net/bluetooth/l2cap_sock.c
+index 250cc0bc552e01..1960d35b3be0af 100644
+--- a/net/bluetooth/l2cap_sock.c
++++ b/net/bluetooth/l2cap_sock.c
+@@ -1665,6 +1665,9 @@ static void l2cap_sock_ready_cb(struct l2cap_chan *chan)
+ 	struct sock *sk = chan->data;
+ 	struct sock *parent;
+ 
++	if (!sk)
++		return;
++
+ 	lock_sock(sk);
+ 
+ 	parent = bt_sk(sk)->parent;
+diff --git a/net/bluetooth/sco.c b/net/bluetooth/sco.c
+index 6635d155e360be..56a146515df9e9 100644
+--- a/net/bluetooth/sco.c
++++ b/net/bluetooth/sco.c
+@@ -338,7 +338,7 @@ static void sco_recv_frame(struct sco_conn *conn, struct sk_buff *skb)
+ 	struct sock *sk;
+ 
+ 	sco_conn_lock(conn);
+-	sk = conn->sk;
++	sk = sco_sock_hold(conn);
+ 	sco_conn_unlock(conn);
+ 
+ 	if (!sk)
+@@ -347,11 +347,15 @@ static void sco_recv_frame(struct sco_conn *conn, struct sk_buff *skb)
+ 	BT_DBG("sk %p len %u", sk, skb->len);
+ 
+ 	if (sk->sk_state != BT_CONNECTED)
+-		goto drop;
++		goto drop_put;
+ 
+-	if (!sock_queue_rcv_skb(sk, skb))
++	if (!sock_queue_rcv_skb(sk, skb)) {
++		sock_put(sk);
+ 		return;
++	}
+ 
++drop_put:
++	sock_put(sk);
+ drop:
+ 	kfree_skb(skb);
+ }
+diff --git a/net/can/af_can.c b/net/can/af_can.c
+index cdad0be43e8ff1..e0ad55b9af6460 100644
+--- a/net/can/af_can.c
++++ b/net/can/af_can.c
+@@ -467,7 +467,7 @@ int can_rx_register(struct net *net, struct net_device *dev, canid_t can_id,
+ 
+ 	rcv->can_id = can_id;
+ 	rcv->mask = mask;
+-	rcv->matches = 0;
++	atomic_long_set(&rcv->matches, 0);
+ 	rcv->func = func;
+ 	rcv->data = data;
+ 	rcv->ident = ident;
+@@ -571,7 +571,7 @@ EXPORT_SYMBOL(can_rx_unregister);
+ static inline void deliver(struct sk_buff *skb, struct receiver *rcv)
+ {
+ 	rcv->func(skb, rcv->data);
+-	rcv->matches++;
++	atomic_long_inc(&rcv->matches);
+ }
+ 
+ static int can_rcv_filter(struct can_dev_rcv_lists *dev_rcv_lists, struct sk_buff *skb)
+diff --git a/net/can/af_can.h b/net/can/af_can.h
+index 22f3352c77fece..87887014f5628e 100644
+--- a/net/can/af_can.h
++++ b/net/can/af_can.h
+@@ -52,7 +52,7 @@ struct receiver {
+ 	struct hlist_node list;
+ 	canid_t can_id;
+ 	canid_t mask;
+-	unsigned long matches;
++	atomic_long_t matches;
+ 	void (*func)(struct sk_buff *skb, void *data);
+ 	void *data;
+ 	char *ident;
+diff --git a/net/can/gw.c b/net/can/gw.c
+index e65500c52bf5c7..676af9a0b6596a 100644
+--- a/net/can/gw.c
++++ b/net/can/gw.c
+@@ -374,10 +374,10 @@ static void cgw_csum_crc8_rel(struct canfd_frame *cf,
+ 		return;
+ 
+ 	if (from <= to) {
+-		for (i = crc8->from_idx; i <= crc8->to_idx; i++)
++		for (i = from; i <= to; i++)
+ 			crc = crc8->crctab[crc ^ cf->data[i]];
+ 	} else {
+-		for (i = crc8->from_idx; i >= crc8->to_idx; i--)
++		for (i = from; i >= to; i--)
+ 			crc = crc8->crctab[crc ^ cf->data[i]];
+ 	}
+ 
+@@ -396,7 +396,7 @@ static void cgw_csum_crc8_rel(struct canfd_frame *cf,
+ 		break;
+ 	}
+ 
+-	cf->data[crc8->result_idx] = crc ^ crc8->final_xor_val;
++	cf->data[res] = crc ^ crc8->final_xor_val;
+ }
+ 
+ static void cgw_csum_crc8_pos(struct canfd_frame *cf,
+diff --git a/net/can/isotp.c b/net/can/isotp.c
+index d1c6f206f42950..4945e480544286 100644
+--- a/net/can/isotp.c
++++ b/net/can/isotp.c
+@@ -1227,12 +1227,6 @@ static int isotp_release(struct socket *sock)
+ 	so->ifindex = 0;
+ 	so->bound = 0;
+ 
+-	if (so->rx.buf != so->rx.sbuf)
+-		kfree(so->rx.buf);
+-
+-	if (so->tx.buf != so->tx.sbuf)
+-		kfree(so->tx.buf);
+-
+ 	sock_orphan(sk);
+ 	sock->sk = NULL;
+ 
+@@ -1600,6 +1594,21 @@ static int isotp_notifier(struct notifier_block *nb, unsigned long msg,
+ 	return NOTIFY_DONE;
+ }
+ 
++static void isotp_sock_destruct(struct sock *sk)
++{
++	struct isotp_sock *so = isotp_sk(sk);
++
++	/* do the standard CAN sock destruct work */
++	can_sock_destruct(sk);
++
++	/* free potential extended PDU buffers */
++	if (so->rx.buf != so->rx.sbuf)
++		kfree(so->rx.buf);
++
++	if (so->tx.buf != so->tx.sbuf)
++		kfree(so->tx.buf);
++}
++
+ static int isotp_init(struct sock *sk)
+ {
+ 	struct isotp_sock *so = isotp_sk(sk);
+@@ -1646,6 +1655,9 @@ static int isotp_init(struct sock *sk)
+ 	list_add_tail(&so->notifier, &isotp_notifier_list);
+ 	spin_unlock(&isotp_notifier_lock);
+ 
++	/* re-assign default can_sock_destruct() reference */
++	sk->sk_destruct = isotp_sock_destruct;
++
+ 	return 0;
+ }
+ 
+diff --git a/net/can/proc.c b/net/can/proc.c
+index 25fdf060e30d0d..2f78ea8ac30b0a 100644
+--- a/net/can/proc.c
++++ b/net/can/proc.c
+@@ -196,7 +196,8 @@ static void can_print_rcvlist(struct seq_file *m, struct hlist_head *rx_list,
+ 			"   %-5s     %03x    %08x  %pK  %pK  %8ld  %s\n";
+ 
+ 		seq_printf(m, fmt, DNAME(dev), r->can_id, r->mask,
+-				r->func, r->data, r->matches, r->ident);
++			   r->func, r->data, atomic_long_read(&r->matches),
++			   r->ident);
+ 	}
+ }
+ 
+diff --git a/net/core/rtnetlink.c b/net/core/rtnetlink.c
+index 1613563132035b..acb3a8e19743c3 100644
+--- a/net/core/rtnetlink.c
++++ b/net/core/rtnetlink.c
+@@ -571,11 +571,14 @@ static size_t rtnl_link_get_slave_info_data_size(const struct net_device *dev)
+ 		goto out;
+ 
+ 	ops = master_dev->rtnl_link_ops;
+-	if (!ops || !ops->get_slave_size)
++	if (!ops)
++		goto out;
++	size += nla_total_size(strlen(ops->kind) + 1);  /* IFLA_INFO_SLAVE_KIND */
++	if (!ops->get_slave_size)
+ 		goto out;
+ 	/* IFLA_INFO_SLAVE_DATA + nested data */
+-	size = nla_total_size(sizeof(struct nlattr)) +
+-	       ops->get_slave_size(master_dev, dev);
++	size += nla_total_size(sizeof(struct nlattr)) +
++		ops->get_slave_size(master_dev, dev);
+ 
+ out:
+ 	rcu_read_unlock();
+diff --git a/net/ipv4/esp4.c b/net/ipv4/esp4.c
+index 2caf6a2a819b21..4256c7ee59397f 100644
+--- a/net/ipv4/esp4.c
++++ b/net/ipv4/esp4.c
+@@ -233,10 +233,13 @@ static void esp_output_done(void *data, int err)
+ 		xfrm_dev_resume(skb);
+ 	} else {
+ 		if (!err &&
+-		    x->encap && x->encap->encap_type == TCP_ENCAP_ESPINTCP)
+-			esp_output_tail_tcp(x, skb);
+-		else
+-			xfrm_output_resume(skb->sk, skb, err);
++		    x->encap && x->encap->encap_type == TCP_ENCAP_ESPINTCP) {
++			err = esp_output_tail_tcp(x, skb);
++			if (err != -EINPROGRESS)
++				kfree_skb(skb);
++		} else {
++			xfrm_output_resume(skb_to_full_sk(skb), skb, err);
++		}
+ 	}
+ }
+ 
+diff --git a/net/ipv4/inet_connection_sock.c b/net/ipv4/inet_connection_sock.c
+index bd032ac2376ed7..7ac315b93bc605 100644
+--- a/net/ipv4/inet_connection_sock.c
++++ b/net/ipv4/inet_connection_sock.c
+@@ -151,19 +151,6 @@ void inet_sk_get_local_port_range(const struct sock *sk, int *low, int *high)
+ }
+ EXPORT_SYMBOL(inet_sk_get_local_port_range);
+ 
+-static bool inet_use_bhash2_on_bind(const struct sock *sk)
+-{
+-#if IS_ENABLED(CONFIG_IPV6)
+-	if (sk->sk_family == AF_INET6) {
+-		int addr_type = ipv6_addr_type(&sk->sk_v6_rcv_saddr);
+-
+-		return addr_type != IPV6_ADDR_ANY &&
+-			addr_type != IPV6_ADDR_MAPPED;
+-	}
+-#endif
+-	return sk->sk_rcv_saddr != htonl(INADDR_ANY);
+-}
+-
+ static bool inet_bind_conflict(const struct sock *sk, struct sock *sk2,
+ 			       kuid_t sk_uid, bool relax,
+ 			       bool reuseport_cb_ok, bool reuseport_ok)
+@@ -198,8 +185,15 @@ static bool __inet_bhash2_conflict(const struct sock *sk, struct sock *sk2,
+ 				   kuid_t sk_uid, bool relax,
+ 				   bool reuseport_cb_ok, bool reuseport_ok)
+ {
+-	if (sk->sk_family == AF_INET && ipv6_only_sock(sk2))
+-		return false;
++	if (ipv6_only_sock(sk2)) {
++		if (sk->sk_family == AF_INET)
++			return false;
++
++#if IS_ENABLED(CONFIG_IPV6)
++		if (ipv6_addr_v4mapped(&sk->sk_v6_rcv_saddr))
++			return false;
++#endif
++	}
+ 
+ 	return inet_bind_conflict(sk, sk2, sk_uid, relax,
+ 				  reuseport_cb_ok, reuseport_ok);
+@@ -237,9 +231,10 @@ static int inet_csk_bind_conflict(const struct sock *sk,
+ 				  const struct inet_bind2_bucket *tb2, /* may be null */
+ 				  bool relax, bool reuseport_ok)
+ {
+-	bool reuseport_cb_ok;
+-	struct sock_reuseport *reuseport_cb;
+ 	kuid_t uid = sock_i_uid((struct sock *)sk);
++	struct sock_reuseport *reuseport_cb;
++	bool reuseport_cb_ok;
++	struct sock *sk2;
+ 
+ 	rcu_read_lock();
+ 	reuseport_cb = rcu_dereference(sk->sk_reuseport_cb);
+@@ -247,32 +242,29 @@ static int inet_csk_bind_conflict(const struct sock *sk,
+ 	reuseport_cb_ok = !reuseport_cb || READ_ONCE(reuseport_cb->num_closed_socks);
+ 	rcu_read_unlock();
+ 
+-	/*
+-	 * Unlike other sk lookup places we do not check
++	/* Conflicts with an existing IPV6_ADDR_ANY (if ipv6) or INADDR_ANY (if
++	 * ipv4) should have been checked already. We need to do these two
++	 * checks separately because their spinlocks have to be acquired/released
++	 * independently of each other, to prevent possible deadlocks
++	 */
++	if (inet_use_hash2_on_bind(sk))
++		return tb2 && inet_bhash2_conflict(sk, tb2, uid, relax,
++						   reuseport_cb_ok, reuseport_ok);
++
++	/* Unlike other sk lookup places we do not check
+ 	 * for sk_net here, since _all_ the socks listed
+ 	 * in tb->owners and tb2->owners list belong
+ 	 * to the same net - the one this bucket belongs to.
+ 	 */
++	sk_for_each_bound(sk2, &tb->owners) {
++		if (!inet_bind_conflict(sk, sk2, uid, relax, reuseport_cb_ok, reuseport_ok))
++			continue;
+ 
+-	if (!inet_use_bhash2_on_bind(sk)) {
+-		struct sock *sk2;
+-
+-		sk_for_each_bound(sk2, &tb->owners)
+-			if (inet_bind_conflict(sk, sk2, uid, relax,
+-					       reuseport_cb_ok, reuseport_ok) &&
+-			    inet_rcv_saddr_equal(sk, sk2, true))
+-				return true;
+-
+-		return false;
++		if (inet_rcv_saddr_equal(sk, sk2, true))
++			return true;
+ 	}
+ 
+-	/* Conflicts with an existing IPV6_ADDR_ANY (if ipv6) or INADDR_ANY (if
+-	 * ipv4) should have been checked already. We need to do these two
+-	 * checks separately because their spinlocks have to be acquired/released
+-	 * independently of each other, to prevent possible deadlocks
+-	 */
+-	return tb2 && inet_bhash2_conflict(sk, tb2, uid, relax, reuseport_cb_ok,
+-					   reuseport_ok);
++	return false;
+ }
+ 
+ /* Determine if there is a bind conflict with an existing IPV6_ADDR_ANY (if ipv6) or
+@@ -372,7 +364,7 @@ other_parity_scan:
+ 		head = &hinfo->bhash[inet_bhashfn(net, port,
+ 						  hinfo->bhash_size)];
+ 		spin_lock_bh(&head->lock);
+-		if (inet_use_bhash2_on_bind(sk)) {
++		if (inet_use_hash2_on_bind(sk)) {
+ 			if (inet_bhash2_addr_any_conflict(sk, port, l3mdev, relax, false))
+ 				goto next_port;
+ 		}
+@@ -557,7 +549,7 @@ int inet_csk_get_port(struct sock *sk, unsigned short snum)
+ 				check_bind_conflict = false;
+ 		}
+ 
+-		if (check_bind_conflict && inet_use_bhash2_on_bind(sk)) {
++		if (check_bind_conflict && inet_use_hash2_on_bind(sk)) {
+ 			if (inet_bhash2_addr_any_conflict(sk, port, l3mdev, true, true))
+ 				goto fail_unlock;
+ 		}
+diff --git a/net/ipv4/inet_hashtables.c b/net/ipv4/inet_hashtables.c
+index 7292f701762512..ed253aa1f5d3fc 100644
+--- a/net/ipv4/inet_hashtables.c
++++ b/net/ipv4/inet_hashtables.c
+@@ -845,7 +845,8 @@ bool inet_bind2_bucket_match_addr_any(const struct inet_bind2_bucket *tb, const
+ 			return ipv6_addr_any(&tb->v6_rcv_saddr) ||
+ 				ipv6_addr_v4mapped_any(&tb->v6_rcv_saddr);
+ 
+-		return false;
++		return ipv6_addr_v4mapped(&sk->sk_v6_rcv_saddr) &&
++			tb->rcv_saddr == 0;
+ 	}
+ 
+ 	if (sk->sk_family == AF_INET6)
+diff --git a/net/ipv4/udp.c b/net/ipv4/udp.c
+index dc91699ce0328a..f301871fa2b1a6 100644
+--- a/net/ipv4/udp.c
++++ b/net/ipv4/udp.c
+@@ -287,7 +287,7 @@ int udp_lib_get_port(struct sock *sk, unsigned short snum,
+ 	} else {
+ 		hslot = udp_hashslot(udptable, net, snum);
+ 		spin_lock_bh(&hslot->lock);
+-		if (hslot->count > 10) {
++		if (inet_use_hash2_on_bind(sk) && hslot->count > 10) {
+ 			int exist;
+ 			unsigned int slot2 = udp_sk(sk)->udp_portaddr_hash ^ snum;
+ 
+diff --git a/net/ipv6/addrconf.c b/net/ipv6/addrconf.c
+index 4958452cd33204..7fcc68dcf144b0 100644
+--- a/net/ipv6/addrconf.c
++++ b/net/ipv6/addrconf.c
+@@ -2831,7 +2831,7 @@ void addrconf_prefix_rcv(struct net_device *dev, u8 *opt, int len, bool sllao)
+ 					fib6_add_gc_list(rt);
+ 				} else {
+ 					fib6_clean_expires(rt);
+-					fib6_remove_gc_list(rt);
++					fib6_may_remove_gc_list(net, rt);
+ 				}
+ 
+ 				spin_unlock_bh(&table->tb6_lock);
+@@ -4816,7 +4816,7 @@ static int modify_prefix_route(struct net *net, struct inet6_ifaddr *ifp,
+ 
+ 		if (!expires) {
+ 			fib6_clean_expires(f6i);
+-			fib6_remove_gc_list(f6i);
++			fib6_may_remove_gc_list(net, f6i);
+ 		} else {
+ 			fib6_set_expires(f6i, expires);
+ 			fib6_add_gc_list(f6i);
+diff --git a/net/ipv6/esp6.c b/net/ipv6/esp6.c
+index 2caaab61b9967c..f3305154745ece 100644
+--- a/net/ipv6/esp6.c
++++ b/net/ipv6/esp6.c
+@@ -269,10 +269,13 @@ static void esp_output_done(void *data, int err)
+ 		xfrm_dev_resume(skb);
+ 	} else {
+ 		if (!err &&
+-		    x->encap && x->encap->encap_type == TCP_ENCAP_ESPINTCP)
+-			esp_output_tail_tcp(x, skb);
+-		else
+-			xfrm_output_resume(skb->sk, skb, err);
++		    x->encap && x->encap->encap_type == TCP_ENCAP_ESPINTCP) {
++			err = esp_output_tail_tcp(x, skb);
++			if (err != -EINPROGRESS)
++				kfree_skb(skb);
++		} else {
++			xfrm_output_resume(skb_to_full_sk(skb), skb, err);
++		}
+ 	}
+ }
+ 
+diff --git a/net/ipv6/ip6_fib.c b/net/ipv6/ip6_fib.c
+index 6fe867579118ba..7a28807ca44648 100644
+--- a/net/ipv6/ip6_fib.c
++++ b/net/ipv6/ip6_fib.c
+@@ -1131,7 +1131,7 @@ static int fib6_add_rt2node(struct fib6_node *fn, struct fib6_info *rt,
+ 					return -EEXIST;
+ 				if (!(rt->fib6_flags & RTF_EXPIRES)) {
+ 					fib6_clean_expires(iter);
+-					fib6_remove_gc_list(iter);
++					fib6_may_remove_gc_list(info->nl_net, iter);
+ 				} else {
+ 					fib6_set_expires(iter, rt->expires);
+ 					fib6_add_gc_list(iter);
+@@ -2311,6 +2311,17 @@ static void fib6_flush_trees(struct net *net)
+ /*
+  *	Garbage collection
+  */
++void fib6_age_exceptions(struct fib6_info *rt, struct fib6_gc_args *gc_args,
++			 unsigned long now)
++{
++	bool may_expire = rt->fib6_flags & RTF_EXPIRES && rt->expires;
++	int old_more = gc_args->more;
++
++	rt6_age_exceptions(rt, gc_args, now);
++
++	if (!may_expire && old_more == gc_args->more)
++		fib6_remove_gc_list(rt);
++}
+ 
+ static int fib6_age(struct fib6_info *rt, struct fib6_gc_args *gc_args)
+ {
+@@ -2333,7 +2344,7 @@ static int fib6_age(struct fib6_info *rt, struct fib6_gc_args *gc_args)
+ 	 *	Note, that clones are aged out
+ 	 *	only if they are not in use now.
+ 	 */
+-	rt6_age_exceptions(rt, gc_args, now);
++	fib6_age_exceptions(rt, gc_args, now);
+ 
+ 	return 0;
+ }
+diff --git a/net/ipv6/netfilter/ip6t_rt.c b/net/ipv6/netfilter/ip6t_rt.c
+index 4ad8b2032f1f92..5561bd9cea8185 100644
+--- a/net/ipv6/netfilter/ip6t_rt.c
++++ b/net/ipv6/netfilter/ip6t_rt.c
+@@ -157,6 +157,10 @@ static int rt_mt6_check(const struct xt_mtchk_param *par)
+ 		pr_debug("unknown flags %X\n", rtinfo->invflags);
+ 		return -EINVAL;
+ 	}
++	if (rtinfo->addrnr > IP6T_RT_HOPS) {
++		pr_debug("too many addresses specified\n");
++		return -EINVAL;
++	}
+ 	if ((rtinfo->flags & (IP6T_RT_RES | IP6T_RT_FST_MASK)) &&
+ 	    (!(rtinfo->flags & IP6T_RT_TYP) ||
+ 	     (rtinfo->rt_type != 0) ||
+diff --git a/net/ipv6/route.c b/net/ipv6/route.c
+index 5a6cc828855dc2..c5b71baf95e7b3 100644
+--- a/net/ipv6/route.c
++++ b/net/ipv6/route.c
+@@ -1035,7 +1035,7 @@ int rt6_route_rcv(struct net_device *dev, u8 *opt, int len,
+ 
+ 		if (!addrconf_finite_timeout(lifetime)) {
+ 			fib6_clean_expires(rt);
+-			fib6_remove_gc_list(rt);
++			fib6_may_remove_gc_list(net, rt);
+ 		} else {
+ 			fib6_set_expires(rt, jiffies + HZ * lifetime);
+ 			fib6_add_gc_list(rt);
+diff --git a/net/ipv6/xfrm6_output.c b/net/ipv6/xfrm6_output.c
+index ad07904642cad1..ff183bd76c9984 100644
+--- a/net/ipv6/xfrm6_output.c
++++ b/net/ipv6/xfrm6_output.c
+@@ -82,14 +82,14 @@ static int __xfrm6_output(struct net *net, struct sock *sk, struct sk_buff *skb)
+ 
+ 	toobig = skb->len > mtu && !skb_is_gso(skb);
+ 
+-	if (toobig && xfrm6_local_dontfrag(skb->sk)) {
++	if (toobig && xfrm6_local_dontfrag(sk)) {
+ 		xfrm6_local_rxpmtu(skb, mtu);
+ 		kfree_skb(skb);
+ 		return -EMSGSIZE;
+ 	} else if (toobig && xfrm6_noneed_fragment(skb)) {
+ 		skb->ignore_df = 1;
+ 		goto skip_frag;
+-	} else if (!skb->ignore_df && toobig && skb->sk) {
++	} else if (!skb->ignore_df && toobig && sk) {
+ 		xfrm_local_error(skb, mtu);
+ 		kfree_skb(skb);
+ 		return -EMSGSIZE;
+diff --git a/net/key/af_key.c b/net/key/af_key.c
+index 6c4448908afed2..4849407da86d6e 100644
+--- a/net/key/af_key.c
++++ b/net/key/af_key.c
+@@ -3517,7 +3517,7 @@ static int set_sadb_kmaddress(struct sk_buff *skb, const struct xfrm_kmaddress *
+ 
+ static int set_ipsecrequest(struct sk_buff *skb,
+ 			    uint8_t proto, uint8_t mode, int level,
+-			    uint32_t reqid, uint8_t family,
++			    uint32_t reqid, sa_family_t family,
+ 			    const xfrm_address_t *src, const xfrm_address_t *dst)
+ {
+ 	struct sadb_x_ipsecrequest *rq;
+@@ -3582,12 +3582,17 @@ static int pfkey_send_migrate(const struct xfrm_selector *sel, u8 dir, u8 type,
+ 
+ 	/* ipsecrequests */
+ 	for (i = 0, mp = m; i < num_bundles; i++, mp++) {
+-		/* old locator pair */
+-		size_pol += sizeof(struct sadb_x_ipsecrequest) +
+-			    pfkey_sockaddr_pair_size(mp->old_family);
+-		/* new locator pair */
+-		size_pol += sizeof(struct sadb_x_ipsecrequest) +
+-			    pfkey_sockaddr_pair_size(mp->new_family);
++		int pair_size;
++
++		pair_size = pfkey_sockaddr_pair_size(mp->old_family);
++		if (!pair_size)
++			return -EINVAL;
++		size_pol += sizeof(struct sadb_x_ipsecrequest) + pair_size;
++
++		pair_size = pfkey_sockaddr_pair_size(mp->new_family);
++		if (!pair_size)
++			return -EINVAL;
++		size_pol += sizeof(struct sadb_x_ipsecrequest) + pair_size;
+ 	}
+ 
+ 	size += sizeof(struct sadb_msg) + size_pol;
+diff --git a/net/netfilter/nf_conntrack_expect.c b/net/netfilter/nf_conntrack_expect.c
+index 81ca348915c98c..7bc64eb89bac44 100644
+--- a/net/netfilter/nf_conntrack_expect.c
++++ b/net/netfilter/nf_conntrack_expect.c
+@@ -627,11 +627,15 @@ static int exp_seq_show(struct seq_file *s, void *v)
+ {
+ 	struct nf_conntrack_expect *expect;
+ 	struct nf_conntrack_helper *helper;
++	struct net *net = seq_file_net(s);
+ 	struct hlist_node *n = v;
+ 	char *delim = "";
+ 
+ 	expect = hlist_entry(n, struct nf_conntrack_expect, hnode);
+ 
++	if (!net_eq(nf_ct_exp_net(expect), net))
++		return 0;
++
+ 	if (expect->timeout.function)
+ 		seq_printf(s, "%ld ", timer_pending(&expect->timeout)
+ 			   ? (long)(expect->timeout.expires - jiffies)/HZ : 0);
+diff --git a/net/netfilter/nf_conntrack_netlink.c b/net/netfilter/nf_conntrack_netlink.c
+index b4761a060e7a08..718526867ffdcc 100644
+--- a/net/netfilter/nf_conntrack_netlink.c
++++ b/net/netfilter/nf_conntrack_netlink.c
+@@ -883,8 +883,8 @@ struct ctnetlink_filter {
+ };
+ 
+ static const struct nla_policy cta_filter_nla_policy[CTA_FILTER_MAX + 1] = {
+-	[CTA_FILTER_ORIG_FLAGS]		= { .type = NLA_U32 },
+-	[CTA_FILTER_REPLY_FLAGS]	= { .type = NLA_U32 },
++	[CTA_FILTER_ORIG_FLAGS]		= NLA_POLICY_MASK(NLA_U32, CTA_FILTER_F_ALL),
++	[CTA_FILTER_REPLY_FLAGS]	= NLA_POLICY_MASK(NLA_U32, CTA_FILTER_F_ALL),
+ };
+ 
+ static int ctnetlink_parse_filter(const struct nlattr *attr,
+@@ -898,17 +898,11 @@ static int ctnetlink_parse_filter(const struct nlattr *attr,
+ 	if (ret)
+ 		return ret;
+ 
+-	if (tb[CTA_FILTER_ORIG_FLAGS]) {
++	if (tb[CTA_FILTER_ORIG_FLAGS])
+ 		filter->orig_flags = nla_get_u32(tb[CTA_FILTER_ORIG_FLAGS]);
+-		if (filter->orig_flags & ~CTA_FILTER_F_ALL)
+-			return -EOPNOTSUPP;
+-	}
+ 
+-	if (tb[CTA_FILTER_REPLY_FLAGS]) {
++	if (tb[CTA_FILTER_REPLY_FLAGS])
+ 		filter->reply_flags = nla_get_u32(tb[CTA_FILTER_REPLY_FLAGS]);
+-		if (filter->reply_flags & ~CTA_FILTER_F_ALL)
+-			return -EOPNOTSUPP;
+-	}
+ 
+ 	return 0;
+ }
+@@ -2622,7 +2616,7 @@ static const struct nla_policy exp_nla_policy[CTA_EXPECT_MAX+1] = {
+ 	[CTA_EXPECT_HELP_NAME]	= { .type = NLA_NUL_STRING,
+ 				    .len = NF_CT_HELPER_NAME_LEN - 1 },
+ 	[CTA_EXPECT_ZONE]	= { .type = NLA_U16 },
+-	[CTA_EXPECT_FLAGS]	= { .type = NLA_U32 },
++	[CTA_EXPECT_FLAGS]	= NLA_POLICY_MASK(NLA_BE32, NF_CT_EXPECT_MASK),
+ 	[CTA_EXPECT_CLASS]	= { .type = NLA_U32 },
+ 	[CTA_EXPECT_NAT]	= { .type = NLA_NESTED },
+ 	[CTA_EXPECT_FN]		= { .type = NLA_NUL_STRING },
+diff --git a/net/netfilter/nf_conntrack_proto_tcp.c b/net/netfilter/nf_conntrack_proto_tcp.c
+index 53d46ebcb5f769..fd080f05eaf93e 100644
+--- a/net/netfilter/nf_conntrack_proto_tcp.c
++++ b/net/netfilter/nf_conntrack_proto_tcp.c
+@@ -1384,9 +1384,9 @@ nla_put_failure:
+ }
+ 
+ static const struct nla_policy tcp_nla_policy[CTA_PROTOINFO_TCP_MAX+1] = {
+-	[CTA_PROTOINFO_TCP_STATE]	    = { .type = NLA_U8 },
+-	[CTA_PROTOINFO_TCP_WSCALE_ORIGINAL] = { .type = NLA_U8 },
+-	[CTA_PROTOINFO_TCP_WSCALE_REPLY]    = { .type = NLA_U8 },
++	[CTA_PROTOINFO_TCP_STATE]	    = NLA_POLICY_MAX(NLA_U8, TCP_CONNTRACK_SYN_SENT2),
++	[CTA_PROTOINFO_TCP_WSCALE_ORIGINAL] = NLA_POLICY_MAX(NLA_U8, TCP_MAX_WSCALE),
++	[CTA_PROTOINFO_TCP_WSCALE_REPLY]    = NLA_POLICY_MAX(NLA_U8, TCP_MAX_WSCALE),
+ 	[CTA_PROTOINFO_TCP_FLAGS_ORIGINAL]  = { .len = sizeof(struct nf_ct_tcp_flags) },
+ 	[CTA_PROTOINFO_TCP_FLAGS_REPLY]	    = { .len = sizeof(struct nf_ct_tcp_flags) },
+ };
+@@ -1413,10 +1413,6 @@ static int nlattr_to_tcp(struct nlattr *cda[], struct nf_conn *ct)
+ 	if (err < 0)
+ 		return err;
+ 
+-	if (tb[CTA_PROTOINFO_TCP_STATE] &&
+-	    nla_get_u8(tb[CTA_PROTOINFO_TCP_STATE]) >= TCP_CONNTRACK_MAX)
+-		return -EINVAL;
+-
+ 	spin_lock_bh(&ct->lock);
+ 	if (tb[CTA_PROTOINFO_TCP_STATE])
+ 		ct->proto.tcp.state = nla_get_u8(tb[CTA_PROTOINFO_TCP_STATE]);
+diff --git a/net/netfilter/nf_conntrack_sip.c b/net/netfilter/nf_conntrack_sip.c
+index 657839a58782a5..84334537c60673 100644
+--- a/net/netfilter/nf_conntrack_sip.c
++++ b/net/netfilter/nf_conntrack_sip.c
+@@ -1040,6 +1040,7 @@ static int process_sdp(struct sk_buff *skb, unsigned int protoff,
+ 	unsigned int port;
+ 	const struct sdp_media_type *t;
+ 	int ret = NF_ACCEPT;
++	bool have_rtp_addr = false;
+ 
+ 	hooks = rcu_dereference(nf_nat_sip_hooks);
+ 
+@@ -1056,8 +1057,11 @@ static int process_sdp(struct sk_buff *skb, unsigned int protoff,
+ 	caddr_len = 0;
+ 	if (ct_sip_parse_sdp_addr(ct, *dptr, sdpoff, *datalen,
+ 				  SDP_HDR_CONNECTION, SDP_HDR_MEDIA,
+-				  &matchoff, &matchlen, &caddr) > 0)
++				  &matchoff, &matchlen, &caddr) > 0) {
+ 		caddr_len = matchlen;
++		memcpy(&rtp_addr, &caddr, sizeof(rtp_addr));
++		have_rtp_addr = true;
++	}
+ 
+ 	mediaoff = sdpoff;
+ 	for (i = 0; i < ARRAY_SIZE(sdp_media_types); ) {
+@@ -1091,9 +1095,11 @@ static int process_sdp(struct sk_buff *skb, unsigned int protoff,
+ 					  &matchoff, &matchlen, &maddr) > 0) {
+ 			maddr_len = matchlen;
+ 			memcpy(&rtp_addr, &maddr, sizeof(rtp_addr));
+-		} else if (caddr_len)
++			have_rtp_addr = true;
++		} else if (caddr_len) {
+ 			memcpy(&rtp_addr, &caddr, sizeof(rtp_addr));
+-		else {
++			have_rtp_addr = true;
++		} else {
+ 			nf_ct_helper_log(skb, ct, "cannot parse SDP message");
+ 			return NF_DROP;
+ 		}
+@@ -1125,7 +1131,7 @@ static int process_sdp(struct sk_buff *skb, unsigned int protoff,
+ 
+ 	/* Update session connection and owner addresses */
+ 	hooks = rcu_dereference(nf_nat_sip_hooks);
+-	if (hooks && ct->status & IPS_NAT_MASK)
++	if (hooks && ct->status & IPS_NAT_MASK && have_rtp_addr)
+ 		ret = hooks->sdp_session(skb, protoff, dataoff,
+ 					 dptr, datalen, sdpoff,
+ 					 &rtp_addr);
+diff --git a/net/netfilter/nfnetlink_log.c b/net/netfilter/nfnetlink_log.c
+index 134e05d31061e4..aa5fc9bffef0c3 100644
+--- a/net/netfilter/nfnetlink_log.c
++++ b/net/netfilter/nfnetlink_log.c
+@@ -647,15 +647,11 @@ __build_packet_message(struct nfnl_log_net *log,
+ 
+ 	if (data_len) {
+ 		struct nlattr *nla;
+-		int size = nla_attr_size(data_len);
+ 
+-		if (skb_tailroom(inst->skb) < nla_total_size(data_len))
++		nla = nla_reserve(inst->skb, NFULA_PAYLOAD, data_len);
++		if (!nla)
+ 			goto nla_put_failure;
+ 
+-		nla = skb_put(inst->skb, nla_total_size(data_len));
+-		nla->nla_type = NFULA_PAYLOAD;
+-		nla->nla_len = size;
+-
+ 		if (skb_copy_bits(skb, 0, nla_data(nla), data_len))
+ 			BUG();
+ 	}
+diff --git a/net/nfc/nci/core.c b/net/nfc/nci/core.c
+index 1f33da345bea6d..e2ffdb06bf9aa3 100644
+--- a/net/nfc/nci/core.c
++++ b/net/nfc/nci/core.c
+@@ -575,8 +575,7 @@ static int nci_close_device(struct nci_dev *ndev)
+ 	skb_queue_purge(&ndev->rx_q);
+ 	skb_queue_purge(&ndev->tx_q);
+ 
+-	/* Flush RX and TX wq */
+-	flush_workqueue(ndev->rx_wq);
++	/* Flush TX wq, RX wq flush can't be under the lock */
+ 	flush_workqueue(ndev->tx_wq);
+ 
+ 	/* Reset device */
+@@ -588,13 +587,13 @@ static int nci_close_device(struct nci_dev *ndev)
+ 		      msecs_to_jiffies(NCI_RESET_TIMEOUT));
+ 
+ 	/* After this point our queues are empty
+-	 * and no works are scheduled.
++	 * rx work may be running but will see that NCI_UP was cleared
+ 	 */
+ 	ndev->ops->close(ndev);
+ 
+ 	clear_bit(NCI_INIT, &ndev->flags);
+ 
+-	/* Flush cmd wq */
++	/* Flush cmd and tx wq */
+ 	flush_workqueue(ndev->cmd_wq);
+ 
+ 	del_timer_sync(&ndev->cmd_timer);
+@@ -604,6 +603,9 @@ static int nci_close_device(struct nci_dev *ndev)
+ 
+ 	mutex_unlock(&ndev->req_lock);
+ 
++	/* rx_work may take req_lock via nci_deactivate_target */
++	flush_workqueue(ndev->rx_wq);
++
+ 	return 0;
+ }
+ 
+diff --git a/net/openvswitch/flow_netlink.c b/net/openvswitch/flow_netlink.c
+index 1d9a44d6216af2..b31abd5508f551 100644
+--- a/net/openvswitch/flow_netlink.c
++++ b/net/openvswitch/flow_netlink.c
+@@ -2939,6 +2939,8 @@ static int validate_set(const struct nlattr *a,
+ 	case OVS_KEY_ATTR_MPLS:
+ 		if (!eth_p_mpls(eth_type))
+ 			return -EINVAL;
++		if (key_len != sizeof(struct ovs_key_mpls))
++			return -EINVAL;
+ 		break;
+ 
+ 	case OVS_KEY_ATTR_SCTP:
+diff --git a/net/openvswitch/vport-netdev.c b/net/openvswitch/vport-netdev.c
+index 3c41d53bb9e99f..68d38c12427c1e 100644
+--- a/net/openvswitch/vport-netdev.c
++++ b/net/openvswitch/vport-netdev.c
+@@ -144,11 +144,15 @@ static void vport_netdev_free(struct rcu_head *rcu)
+ void ovs_netdev_detach_dev(struct vport *vport)
+ {
+ 	ASSERT_RTNL();
+-	vport->dev->priv_flags &= ~IFF_OVS_DATAPATH;
+ 	netdev_rx_handler_unregister(vport->dev);
+ 	netdev_upper_dev_unlink(vport->dev,
+ 				netdev_master_upper_dev_get(vport->dev));
+ 	dev_set_promiscuity(vport->dev, -1);
++
++	/* paired with smp_mb() in netdev_destroy() */
++	smp_wmb();
++
++	vport->dev->priv_flags &= ~IFF_OVS_DATAPATH;
+ }
+ 
+ static void netdev_destroy(struct vport *vport)
+@@ -167,6 +171,9 @@ static void netdev_destroy(struct vport *vport)
+ 		rtnl_unlock();
+ 	}
+ 
++	/* paired with smp_wmb() in ovs_netdev_detach_dev() */
++	smp_mb();
++
+ 	call_rcu(&vport->rcu, vport_netdev_free);
+ }
+ 
+@@ -182,8 +189,6 @@ void ovs_netdev_tunnel_destroy(struct vport *vport)
+ 	 */
+ 	if (vport->dev->reg_state == NETREG_REGISTERED)
+ 		rtnl_delete_link(vport->dev, 0, NULL);
+-	netdev_put(vport->dev, &vport->dev_tracker);
+-	vport->dev = NULL;
+ 	rtnl_unlock();
+ 
+ 	call_rcu(&vport->rcu, vport_netdev_free);
+diff --git a/net/packet/af_packet.c b/net/packet/af_packet.c
+index 9620f160be70bb..4f2727a42cad1e 100644
+--- a/net/packet/af_packet.c
++++ b/net/packet/af_packet.c
+@@ -3196,6 +3196,7 @@ static int packet_release(struct socket *sock)
+ 
+ 	spin_lock(&po->bind_lock);
+ 	unregister_prot_hook(sk, false);
++	WRITE_ONCE(po->num, 0);
+ 	packet_cached_dev_reset(po);
+ 
+ 	if (po->prot_hook.dev) {
+diff --git a/net/smc/smc_rx.c b/net/smc/smc_rx.c
+index acb14e28cad411..a48f8c93f4b63f 100644
+--- a/net/smc/smc_rx.c
++++ b/net/smc/smc_rx.c
+@@ -135,9 +135,16 @@ out:
+ 	sock_put(sk);
+ }
+ 
++static bool smc_rx_pipe_buf_get(struct pipe_inode_info *pipe,
++				struct pipe_buffer *buf)
++{
++	/* smc_spd_priv in buf->private is not shareable; disallow cloning. */
++	return false;
++}
++
+ static const struct pipe_buf_operations smc_pipe_ops = {
+ 	.release = smc_rx_pipe_buf_release,
+-	.get = generic_pipe_buf_get
++	.get	 = smc_rx_pipe_buf_get,
+ };
+ 
+ static void smc_rx_spd_release(struct splice_pipe_desc *spd,
+diff --git a/net/tls/tls_sw.c b/net/tls/tls_sw.c
+index 410e39e4b79fd2..dc57b31a5fe5c0 100644
+--- a/net/tls/tls_sw.c
++++ b/net/tls/tls_sw.c
+@@ -246,6 +246,7 @@ static int tls_decrypt_async_wait(struct tls_sw_context_rx *ctx)
+ 		crypto_wait_req(-EINPROGRESS, &ctx->async_wait);
+ 	atomic_inc(&ctx->decrypt_pending);
+ 
++	__skb_queue_purge(&ctx->async_hold);
+ 	return ctx->async_wait.err;
+ }
+ 
+@@ -2191,7 +2192,6 @@ recv_end:
+ 
+ 		/* Wait for all previously submitted records to be decrypted */
+ 		ret = tls_decrypt_async_wait(ctx);
+-		__skb_queue_purge(&ctx->async_hold);
+ 
+ 		if (ret) {
+ 			if (err >= 0 || err == -EINPROGRESS)
+diff --git a/net/xfrm/xfrm_interface_core.c b/net/xfrm/xfrm_interface_core.c
+index ca6db1e960ce64..44e48c58aa3247 100644
+--- a/net/xfrm/xfrm_interface_core.c
++++ b/net/xfrm/xfrm_interface_core.c
+@@ -507,7 +507,7 @@ xmit:
+ 	skb_dst_set(skb, dst);
+ 	skb->dev = tdev;
+ 
+-	err = dst_output(xi->net, skb->sk, skb);
++	err = dst_output(xi->net, skb_to_full_sk(skb), skb);
+ 	if (net_xmit_eval(err) == 0) {
+ 		dev_sw_netstats_tx_add(dev, 1, length);
+ 	} else {
+diff --git a/net/xfrm/xfrm_output.c b/net/xfrm/xfrm_output.c
+index 9277dd4ed541ab..a5b5d82bd75501 100644
+--- a/net/xfrm/xfrm_output.c
++++ b/net/xfrm/xfrm_output.c
+@@ -841,7 +841,7 @@ static int xfrm4_tunnel_check_size(struct sk_buff *skb)
+ 	     !skb_gso_validate_network_len(skb, ip_skb_dst_mtu(skb->sk, skb)))) {
+ 		skb->protocol = htons(ETH_P_IP);
+ 
+-		if (skb->sk)
++		if (skb->sk && sk_fullsock(skb->sk))
+ 			xfrm_local_error(skb, mtu);
+ 		else
+ 			icmp_send(skb, ICMP_DEST_UNREACH,
+@@ -877,6 +877,7 @@ static int xfrm6_tunnel_check_size(struct sk_buff *skb)
+ {
+ 	int mtu, ret = 0;
+ 	struct dst_entry *dst = skb_dst(skb);
++	struct sock *sk = skb_to_full_sk(skb);
+ 
+ 	if (skb->ignore_df)
+ 		goto out;
+@@ -891,9 +892,9 @@ static int xfrm6_tunnel_check_size(struct sk_buff *skb)
+ 		skb->dev = dst->dev;
+ 		skb->protocol = htons(ETH_P_IPV6);
+ 
+-		if (xfrm6_local_dontfrag(skb->sk))
++		if (xfrm6_local_dontfrag(sk))
+ 			ipv6_stub->xfrm6_local_rxpmtu(skb, mtu);
+-		else if (skb->sk)
++		else if (sk)
+ 			xfrm_local_error(skb, mtu);
+ 		else
+ 			icmpv6_send(skb, ICMPV6_PKT_TOOBIG, 0, mtu);
+diff --git a/net/xfrm/xfrm_policy.c b/net/xfrm/xfrm_policy.c
+index b516dd15113ed6..45851f822ec4ae 100644
+--- a/net/xfrm/xfrm_policy.c
++++ b/net/xfrm/xfrm_policy.c
+@@ -2937,7 +2937,7 @@ static void xfrm_policy_queue_process(struct timer_list *t)
+ 		skb_dst_drop(skb);
+ 		skb_dst_set(skb, dst);
+ 
+-		dst_output(net, skb->sk, skb);
++		dst_output(net, skb_to_full_sk(skb), skb);
+ 	}
+ 
+ out:
+diff --git a/net/xfrm/xfrm_state.c b/net/xfrm/xfrm_state.c
+index 81e01cdc7a7d58..ca42c9b8cecc3e 100644
+--- a/net/xfrm/xfrm_state.c
++++ b/net/xfrm/xfrm_state.c
+@@ -2033,6 +2033,7 @@ out:
+ 
+ 		err = 0;
+ 		x->km.state = XFRM_STATE_DEAD;
++		xfrm_dev_state_delete(x);
+ 		__xfrm_state_put(x);
+ 	}
+ 
+diff --git a/rust/kernel/init/macros.rs b/rust/kernel/init/macros.rs
+index cb769a09e74263..d6f8d5ce61af74 100644
+--- a/rust/kernel/init/macros.rs
++++ b/rust/kernel/init/macros.rs
+@@ -964,35 +964,54 @@ macro_rules! __pin_data {
+         @pinned($($(#[$($p_attr:tt)*])* $pvis:vis $p_field:ident : $p_type:ty),* $(,)?),
+         @not_pinned($($(#[$($attr:tt)*])* $fvis:vis $field:ident : $type:ty),* $(,)?),
+     ) => {
+-        // For every field, we create a projection function according to its projection type. If a
+-        // field is structurally pinned, then it must be initialized via `PinInit`, if it is not
+-        // structurally pinned, then it can be initialized via `Init`.
+-        //
+-        // The functions are `unsafe` to prevent accidentally calling them.
+-        #[allow(dead_code)]
+-        impl<$($impl_generics)*> $pin_data<$($ty_generics)*>
+-        where $($whr)*
+-        {
+-            $(
+-                $(#[$($p_attr)*])*
+-                $pvis unsafe fn $p_field<E>(
+-                    self,
+-                    slot: *mut $p_type,
+-                    init: impl $crate::init::PinInit<$p_type, E>,
+-                ) -> ::core::result::Result<(), E> {
+-                    unsafe { $crate::init::PinInit::__pinned_init(init, slot) }
+-                }
+-            )*
+-            $(
+-                $(#[$($attr)*])*
+-                $fvis unsafe fn $field<E>(
+-                    self,
+-                    slot: *mut $type,
+-                    init: impl $crate::init::Init<$type, E>,
+-                ) -> ::core::result::Result<(), E> {
+-                    unsafe { $crate::init::Init::__init(init, slot) }
+-                }
+-            )*
++        $crate::macros::paste! {
++            // For every field, we create a projection function according to its projection type. If a
++            // field is structurally pinned, then it must be initialized via `PinInit`, if it is not
++            // structurally pinned, then it can be initialized via `Init`.
++            //
++            // The functions are `unsafe` to prevent accidentally calling them.
++            #[allow(dead_code, non_snake_case)]
++            #[expect(clippy::missing_safety_doc)]
++            impl<$($impl_generics)*> $pin_data<$($ty_generics)*>
++            where $($whr)*
++            {
++                $(
++                    $(#[$($p_attr)*])*
++                    $pvis unsafe fn $p_field<E>(
++                        self,
++                        slot: *mut $p_type,
++                        init: impl $crate::init::PinInit<$p_type, E>,
++                    ) -> ::core::result::Result<(), E> {
++                        unsafe { $crate::init::PinInit::__pinned_init(init, slot) }
++                    }
++
++                    $(#[$($p_attr)*])*
++                    $pvis unsafe fn [<__project_ $p_field>]<'__slot>(
++                        self,
++                        slot: &'__slot mut $p_type,
++                    ) -> ::core::pin::Pin<&'__slot mut $p_type> {
++                        unsafe { ::core::pin::Pin::new_unchecked(slot) }
++                    }
++                )*
++                $(
++                    $(#[$($attr)*])*
++                    $fvis unsafe fn $field<E>(
++                        self,
++                        slot: *mut $type,
++                        init: impl $crate::init::Init<$type, E>,
++                    ) -> ::core::result::Result<(), E> {
++                        unsafe { $crate::init::Init::__init(init, slot) }
++                    }
++
++                    $(#[$($attr)*])*
++                    $fvis unsafe fn [<__project_ $field>]<'__slot>(
++                        self,
++                        slot: &'__slot mut $type,
++                    ) -> &'__slot mut $type {
++                        slot
++                    }
++                )*
++            }
+         }
+     };
+ }
+@@ -1186,6 +1205,17 @@ macro_rules! __init_internal {
+         // return when an error/panic occurs.
+         // We also use the `data` to require the correct trait (`Init` or `PinInit`) for `$field`.
+         unsafe { $data.$field(::core::ptr::addr_of_mut!((*$slot).$field), init)? };
++        // NOTE: the field accessor ensures that the initialized field is properly aligned.
++        // Unaligned fields will cause the compiler to emit E0793. We do not support
++        // unaligned fields since `Init::__init` requires an aligned pointer; the call to
++        // `ptr::write` below has the same requirement.
++        // SAFETY:
++        // - the project function does the correct field projection,
++        // - the field has been initialized,
++        // - the reference is only valid until the end of the initializer.
++        #[allow(unused_variables, unused_assignments)]
++        let $field = $crate::macros::paste!(unsafe { $data.[< __project_ $field >](&mut (*$slot).$field) });
++
+         // Create the drop guard:
+         //
+         // We rely on macro hygiene to make it impossible for users to access this local variable.
+@@ -1217,6 +1247,18 @@ macro_rules! __init_internal {
+         // SAFETY: `slot` is valid, because we are inside of an initializer closure, we
+         // return when an error/panic occurs.
+         unsafe { $crate::init::Init::__init(init, ::core::ptr::addr_of_mut!((*$slot).$field))? };
++
++        // NOTE: the field accessor ensures that the initialized field is properly aligned.
++        // Unaligned fields will cause the compiler to emit E0793. We do not support
++        // unaligned fields since `Init::__init` requires an aligned pointer; the call to
++        // `ptr::write` below has the same requirement.
++        // SAFETY:
++        // - the field is not structurally pinned, since the line above must compile,
++        // - the field has been initialized,
++        // - the reference is only valid until the end of the initializer.
++        #[allow(unused_variables, unused_assignments)]
++        let $field = unsafe { &mut (*$slot).$field };
++
+         // Create the drop guard:
+         //
+         // We rely on macro hygiene to make it impossible for users to access this local variable.
+@@ -1235,7 +1277,7 @@ macro_rules! __init_internal {
+             );
+         }
+     };
+-    (init_slot($($use_data:ident)?):
++    (init_slot(): // No `use_data`, so all fields are not structurally pinned
+         @data($data:ident),
+         @slot($slot:ident),
+         @guards($($guards:ident,)*),
+@@ -1249,6 +1291,19 @@ macro_rules! __init_internal {
+             // SAFETY: The memory at `slot` is uninitialized.
+             unsafe { ::core::ptr::write(::core::ptr::addr_of_mut!((*$slot).$field), $field) };
+         }
++
++        // NOTE: the field accessor ensures that the initialized field is properly aligned.
++        // Unaligned fields will cause the compiler to emit E0793. We do not support
++        // unaligned fields since `Init::__init` requires an aligned pointer; the call to
++        // `ptr::write` below has the same requirement.
++        #[allow(unused_variables, unused_assignments)]
++        // SAFETY:
++        // - the field is not structurally pinned, since no `use_data` was required to create this
++        //   initializer,
++        // - the field has been initialized,
++        // - the reference is only valid until the end of the initializer.
++        let $field = unsafe { &mut (*$slot).$field };
++
+         // Create the drop guard:
+         //
+         // We rely on macro hygiene to make it impossible for users to access this local variable.
+@@ -1259,7 +1314,50 @@ macro_rules! __init_internal {
+                 $crate::init::__internal::DropGuard::new(::core::ptr::addr_of_mut!((*$slot).$field))
+             };
+ 
+-            $crate::__init_internal!(init_slot($($use_data)?):
++            $crate::__init_internal!(init_slot():
++                @data($data),
++                @slot($slot),
++                @guards([< __ $field _guard >], $($guards,)*),
++                @munch_fields($($rest)*),
++            );
++        }
++    };
++    (init_slot($use_data:ident):
++        @data($data:ident),
++        @slot($slot:ident),
++        @guards($($guards:ident,)*),
++        // Init by-value.
++        @munch_fields($field:ident $(: $val:expr)?, $($rest:tt)*),
++    ) => {
++        {
++            $(let $field = $val;)?
++            // Initialize the field.
++            //
++            // SAFETY: The memory at `slot` is uninitialized.
++            unsafe { ::core::ptr::write(::core::ptr::addr_of_mut!((*$slot).$field), $field) };
++        }
++        // NOTE: the field accessor ensures that the initialized field is properly aligned.
++        // Unaligned fields will cause the compiler to emit E0793. We do not support
++        // unaligned fields since `Init::__init` requires an aligned pointer; the call to
++        // `ptr::write` below has the same requirement.
++        // SAFETY:
++        // - the project function does the correct field projection,
++        // - the field has been initialized,
++        // - the reference is only valid until the end of the initializer.
++        #[allow(unused_variables, unused_assignments)]
++        let $field = $crate::macros::paste!(unsafe { $data.[< __project_ $field >](&mut (*$slot).$field) });
++
++        // Create the drop guard:
++        //
++        // We rely on macro hygiene to make it impossible for users to access this local variable.
++        // We use `paste!` to create new hygiene for `$field`.
++        $crate::macros::paste! {
++            // SAFETY: We forget the guard later when initialization has succeeded.
++            let [< __ $field _guard >] = unsafe {
++                $crate::init::__internal::DropGuard::new(::core::ptr::addr_of_mut!((*$slot).$field))
++            };
++
++            $crate::__init_internal!(init_slot($use_data):
+                 @data($data),
+                 @slot($slot),
+                 @guards([<$field>], $($guards,)*),
+diff --git a/sound/firewire/amdtp-stream.c b/sound/firewire/amdtp-stream.c
+index 8c6254ff143eb4..cb2424bd22d569 100644
+--- a/sound/firewire/amdtp-stream.c
++++ b/sound/firewire/amdtp-stream.c
+@@ -1156,7 +1156,7 @@ static void process_rx_packets(struct fw_iso_context *context, u32 tstamp, size_
+ 	struct pkt_desc *desc = s->packet_descs_cursor;
+ 	unsigned int pkt_header_length;
+ 	unsigned int packets;
+-	u32 curr_cycle_time;
++	u32 curr_cycle_time = 0;
+ 	bool need_hw_irq;
+ 	int i;
+ 
+diff --git a/sound/pci/hda/patch_realtek.c b/sound/pci/hda/patch_realtek.c
+index 5b836a91135cc8..1a5e2fb0c842b6 100644
+--- a/sound/pci/hda/patch_realtek.c
++++ b/sound/pci/hda/patch_realtek.c
+@@ -10175,6 +10175,7 @@ static const struct hda_quirk alc269_fixup_tbl[] = {
+ 	SND_PCI_QUIRK(0x103c, 0x89ca, "HP", ALC236_FIXUP_HP_MUTE_LED_MICMUTE_VREF),
+ 	SND_PCI_QUIRK(0x103c, 0x89d3, "HP EliteBook 645 G9 (MB 89D2)", ALC236_FIXUP_HP_MUTE_LED_MICMUTE_VREF),
+ 	SND_PCI_QUIRK(0x103c, 0x8a0f, "HP Pavilion 14-ec1xxx", ALC287_FIXUP_HP_GPIO_LED),
++	SND_PCI_QUIRK(0x103c, 0x8a1f, "HP Laptop 14s-dr5xxx", ALC236_FIXUP_HP_MUTE_LED_COEFBIT2),
+ 	SND_PCI_QUIRK(0x103c, 0x8a20, "HP Laptop 15s-fq5xxx", ALC236_FIXUP_HP_MUTE_LED_COEFBIT2),
+ 	SND_PCI_QUIRK(0x103c, 0x8a25, "HP Victus 16-d1xxx (MB 8A25)", ALC245_FIXUP_HP_MUTE_LED_COEFBIT),
+ 	SND_PCI_QUIRK(0x103c, 0x8a78, "HP Dev One", ALC285_FIXUP_HP_LIMIT_INT_MIC_BOOST),
+@@ -10519,6 +10520,7 @@ static const struct hda_quirk alc269_fixup_tbl[] = {
+ 	SND_PCI_QUIRK(0x17aa, 0x224c, "Thinkpad", ALC298_FIXUP_TPT470_DOCK),
+ 	SND_PCI_QUIRK(0x17aa, 0x224d, "Thinkpad", ALC298_FIXUP_TPT470_DOCK),
+ 	SND_PCI_QUIRK(0x17aa, 0x225d, "Thinkpad T480", ALC269_FIXUP_LIMIT_INT_MIC_BOOST),
++	SND_PCI_QUIRK(0x17aa, 0x2288, "Thinkpad X390", ALC285_FIXUP_THINKPAD_NO_BASS_SPK_HEADSET_JACK),
+ 	SND_PCI_QUIRK(0x17aa, 0x2292, "Thinkpad X1 Carbon 7th", ALC285_FIXUP_THINKPAD_HEADSET_JACK),
+ 	SND_PCI_QUIRK(0x17aa, 0x22be, "Thinkpad X1 Carbon 8th", ALC285_FIXUP_THINKPAD_HEADSET_JACK),
+ 	SND_PCI_QUIRK(0x17aa, 0x22c1, "Thinkpad P1 Gen 3", ALC285_FIXUP_THINKPAD_NO_BASS_SPK_HEADSET_JACK),
+diff --git a/sound/soc/codecs/adau1372.c b/sound/soc/codecs/adau1372.c
+index 98380a7ce64d80..25f123110b5be4 100644
+--- a/sound/soc/codecs/adau1372.c
++++ b/sound/soc/codecs/adau1372.c
+@@ -761,7 +761,7 @@ static int adau1372_startup(struct snd_pcm_substream *substream, struct snd_soc_
+ 	return 0;
+ }
+ 
+-static void adau1372_enable_pll(struct adau1372 *adau1372)
++static int adau1372_enable_pll(struct adau1372 *adau1372)
+ {
+ 	unsigned int val, timeout = 0;
+ 	int ret;
+@@ -777,19 +777,26 @@ static void adau1372_enable_pll(struct adau1372 *adau1372)
+ 		timeout++;
+ 	} while (!(val & 1) && timeout < 3);
+ 
+-	if (ret < 0 || !(val & 1))
++	if (ret < 0 || !(val & 1)) {
+ 		dev_err(adau1372->dev, "Failed to lock PLL\n");
++		return ret < 0 ? ret : -ETIMEDOUT;
++	}
++
++	return 0;
+ }
+ 
+-static void adau1372_set_power(struct adau1372 *adau1372, bool enable)
++static int adau1372_set_power(struct adau1372 *adau1372, bool enable)
+ {
+ 	if (adau1372->enabled == enable)
+-		return;
++		return 0;
+ 
+ 	if (enable) {
+ 		unsigned int clk_ctrl = ADAU1372_CLK_CTRL_MCLK_EN;
++		int ret;
+ 
+-		clk_prepare_enable(adau1372->mclk);
++		ret = clk_prepare_enable(adau1372->mclk);
++		if (ret)
++			return ret;
+ 		if (adau1372->pd_gpio)
+ 			gpiod_set_value(adau1372->pd_gpio, 0);
+ 
+@@ -803,7 +810,14 @@ static void adau1372_set_power(struct adau1372 *adau1372, bool enable)
+ 		 * accessed.
+ 		 */
+ 		if (adau1372->use_pll) {
+-			adau1372_enable_pll(adau1372);
++			ret = adau1372_enable_pll(adau1372);
++			if (ret) {
++				regcache_cache_only(adau1372->regmap, true);
++				if (adau1372->pd_gpio)
++					gpiod_set_value(adau1372->pd_gpio, 1);
++				clk_disable_unprepare(adau1372->mclk);
++				return ret;
++			}
+ 			clk_ctrl |= ADAU1372_CLK_CTRL_CLKSRC;
+ 		}
+ 
+@@ -828,6 +842,8 @@ static void adau1372_set_power(struct adau1372 *adau1372, bool enable)
+ 	}
+ 
+ 	adau1372->enabled = enable;
++
++	return 0;
+ }
+ 
+ static int adau1372_set_bias_level(struct snd_soc_component *component,
+@@ -841,11 +857,9 @@ static int adau1372_set_bias_level(struct snd_soc_component *component,
+ 	case SND_SOC_BIAS_PREPARE:
+ 		break;
+ 	case SND_SOC_BIAS_STANDBY:
+-		adau1372_set_power(adau1372, true);
+-		break;
++		return adau1372_set_power(adau1372, true);
+ 	case SND_SOC_BIAS_OFF:
+-		adau1372_set_power(adau1372, false);
+-		break;
++		return adau1372_set_power(adau1372, false);
+ 	}
+ 
+ 	return 0;
+diff --git a/sound/soc/fsl/fsl_easrc.c b/sound/soc/fsl/fsl_easrc.c
+index ec53bda46a467d..13396a167b8ac2 100644
+--- a/sound/soc/fsl/fsl_easrc.c
++++ b/sound/soc/fsl/fsl_easrc.c
+@@ -52,10 +52,13 @@ static int fsl_easrc_iec958_put_bits(struct snd_kcontrol *kcontrol,
+ 	struct soc_mreg_control *mc =
+ 		(struct soc_mreg_control *)kcontrol->private_value;
+ 	unsigned int regval = ucontrol->value.integer.value[0];
++	int ret;
++
++	ret = (easrc_priv->bps_iec958[mc->regbase] != regval);
+ 
+ 	easrc_priv->bps_iec958[mc->regbase] = regval;
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ static int fsl_easrc_iec958_get_bits(struct snd_kcontrol *kcontrol,
+@@ -93,14 +96,17 @@ static int fsl_easrc_set_reg(struct snd_kcontrol *kcontrol,
+ 	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
+ 	struct soc_mreg_control *mc =
+ 		(struct soc_mreg_control *)kcontrol->private_value;
++	struct fsl_asrc *easrc = snd_soc_component_get_drvdata(component);
+ 	unsigned int regval = ucontrol->value.integer.value[0];
++	bool changed;
+ 	int ret;
+ 
+-	ret = snd_soc_component_write(component, mc->regbase, regval);
+-	if (ret < 0)
++	ret = regmap_update_bits_check(easrc->regmap, mc->regbase,
++				       GENMASK(31, 0), regval, &changed);
++	if (ret != 0)
+ 		return ret;
+ 
+-	return 0;
++	return changed;
+ }
+ 
+ #define SOC_SINGLE_REG_RW(xname, xreg) \
+diff --git a/sound/soc/intel/catpt/device.c b/sound/soc/intel/catpt/device.c
+index cac3dffbd0d9f6..6cc8b241f743e4 100644
+--- a/sound/soc/intel/catpt/device.c
++++ b/sound/soc/intel/catpt/device.c
+@@ -271,7 +271,15 @@ static int catpt_acpi_probe(struct platform_device *pdev)
+ 	if (IS_ERR(cdev->pci_ba))
+ 		return PTR_ERR(cdev->pci_ba);
+ 
+-	/* alloc buffer for storing DRAM context during dx transitions */
++	/*
++	 * As per design HOST is responsible for preserving firmware's runtime
++	 * context during D0 -> D3 -> D0 transitions.  Addresses used for DMA
++	 * to/from HOST memory shall be outside the reserved range of 0xFFFxxxxx.
++	 */
++	ret = dma_coerce_mask_and_coherent(cdev->dev, DMA_BIT_MASK(31));
++	if (ret)
++		return ret;
++
+ 	cdev->dxbuf_vaddr = dmam_alloc_coherent(dev, catpt_dram_size(cdev),
+ 						&cdev->dxbuf_paddr, GFP_KERNEL);
+ 	if (!cdev->dxbuf_vaddr)
+diff --git a/sound/soc/intel/catpt/dsp.c b/sound/soc/intel/catpt/dsp.c
+index 346bec00030669..3cde6b7ae92374 100644
+--- a/sound/soc/intel/catpt/dsp.c
++++ b/sound/soc/intel/catpt/dsp.c
+@@ -125,9 +125,6 @@ int catpt_dmac_probe(struct catpt_dev *cdev)
+ 	dmac->dev = cdev->dev;
+ 	dmac->irq = cdev->irq;
+ 
+-	ret = dma_coerce_mask_and_coherent(cdev->dev, DMA_BIT_MASK(31));
+-	if (ret)
+-		return ret;
+ 	/*
+ 	 * Caller is responsible for putting device in D0 to allow
+ 	 * for I/O and memory access before probing DW.
+diff --git a/sound/soc/sof/ipc4-topology.c b/sound/soc/sof/ipc4-topology.c
+index cc17d4e74c82fe..43040d4d724bcb 100644
+--- a/sound/soc/sof/ipc4-topology.c
++++ b/sound/soc/sof/ipc4-topology.c
+@@ -2203,7 +2203,7 @@ static int sof_ipc4_control_load_bytes(struct snd_sof_dev *sdev, struct snd_sof_
+ 		return -EINVAL;
+ 	}
+ 
+-	if (scontrol->priv_size < sizeof(struct sof_abi_hdr)) {
++	if (scontrol->priv_size && scontrol->priv_size < sizeof(struct sof_abi_hdr)) {
+ 		dev_err(sdev->dev,
+ 			"bytes control %s initial data size %zu is insufficient.\n",
+ 			scontrol->name, scontrol->priv_size);
+diff --git a/tools/lib/bpf/libbpf.c b/tools/lib/bpf/libbpf.c
+index 95f2ffefff3ff7..802ae6dbddfa31 100644
+--- a/tools/lib/bpf/libbpf.c
++++ b/tools/lib/bpf/libbpf.c
+@@ -11247,7 +11247,7 @@ static int resolve_full_path(const char *file, char *result, size_t result_sz)
+ 		if (!search_paths[i])
+ 			continue;
+ 		for (s = search_paths[i]; s != NULL; s = strchr(s, ':')) {
+-			char *next_path;
++			const char *next_path;
+ 			int seg_len;
+ 
+ 			if (s[0] == ':')
+diff --git a/tools/objtool/arch/x86/decode.c b/tools/objtool/arch/x86/decode.c
+index c0f25d00181ec2..40a5aa02bd8311 100644
+--- a/tools/objtool/arch/x86/decode.c
++++ b/tools/objtool/arch/x86/decode.c
+@@ -325,52 +325,36 @@ int arch_decode_instruction(struct objtool_file *file, const struct section *sec
+ 		if (!rex_w)
+ 			break;
+ 
+-		if (modrm_reg == CFI_SP) {
+-
+-			if (mod_is_reg()) {
+-				/* mov %rsp, reg */
+-				ADD_OP(op) {
+-					op->src.type = OP_SRC_REG;
+-					op->src.reg = CFI_SP;
+-					op->dest.type = OP_DEST_REG;
+-					op->dest.reg = modrm_rm;
+-				}
+-				break;
+-
+-			} else {
+-				/* skip RIP relative displacement */
+-				if (is_RIP())
+-					break;
+-
+-				/* skip nontrivial SIB */
+-				if (have_SIB()) {
+-					modrm_rm = sib_base;
+-					if (sib_index != CFI_SP)
+-						break;
+-				}
+-
+-				/* mov %rsp, disp(%reg) */
+-				ADD_OP(op) {
+-					op->src.type = OP_SRC_REG;
+-					op->src.reg = CFI_SP;
+-					op->dest.type = OP_DEST_REG_INDIRECT;
+-					op->dest.reg = modrm_rm;
+-					op->dest.offset = ins.displacement.value;
+-				}
+-				break;
++		if (mod_is_reg()) {
++			/* mov reg, reg */
++			ADD_OP(op) {
++				op->src.type = OP_SRC_REG;
++				op->src.reg = modrm_reg;
++				op->dest.type = OP_DEST_REG;
++				op->dest.reg = modrm_rm;
+ 			}
+-
+ 			break;
+ 		}
+ 
+-		if (rm_is_reg(CFI_SP)) {
++		/* skip RIP relative displacement */
++		if (is_RIP())
++			break;
+ 
+-			/* mov reg, %rsp */
++		/* skip nontrivial SIB */
++		if (have_SIB()) {
++			modrm_rm = sib_base;
++			if (sib_index != CFI_SP)
++				break;
++		}
++
++		/* mov %rsp, disp(%reg) */
++		if (modrm_reg == CFI_SP) {
+ 			ADD_OP(op) {
+ 				op->src.type = OP_SRC_REG;
+-				op->src.reg = modrm_reg;
+-				op->dest.type = OP_DEST_REG;
+-				op->dest.reg = CFI_SP;
++				op->src.reg = CFI_SP;
++				op->dest.type = OP_DEST_REG_INDIRECT;
++				op->dest.reg = modrm_rm;
++				op->dest.offset = ins.displacement.value;
+ 			}
+ 			break;
+ 		}
+diff --git a/tools/objtool/check.c b/tools/objtool/check.c
+index c021798ba83729..6497c80fd6f771 100644
+--- a/tools/objtool/check.c
++++ b/tools/objtool/check.c
+@@ -2969,6 +2969,20 @@ static int update_cfi_state(struct instruction *insn,
+ 				cfi->stack_size += 8;
+ 			}
+ 
++			else if (cfi->vals[op->src.reg].base == CFI_CFA) {
++				/*
++				 * Clang RSP musical chairs:
++				 *
++				 *   mov %rsp, %rdx [handled above]
++				 *   ...
++				 *   mov %rdx, %rbx [handled here]
++				 *   ...
++				 *   mov %rbx, %rsp [handled above]
++				 */
++				cfi->vals[op->dest.reg].base = CFI_CFA;
++				cfi->vals[op->dest.reg].offset = cfi->vals[op->src.reg].offset;
++			}
++
+ 
+ 			break;
+ 

--- a/patch/kernel/archive/odroidxu4-6.6/patch-6.6.131-132.patch
+++ b/patch/kernel/archive/odroidxu4-6.6/patch-6.6.131-132.patch
@@ -1,0 +1,219 @@
+diff --git a/Makefile b/Makefile
+index 567fe79e76bf4c..56ff90e4d6036d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 6
+ PATCHLEVEL = 6
+-SUBLEVEL = 131
++SUBLEVEL = 132
+ EXTRAVERSION =
+ NAME = Pinguïn Aangedreven
+ 
+diff --git a/rust/kernel/init/macros.rs b/rust/kernel/init/macros.rs
+index d6f8d5ce61af74..cb769a09e74263 100644
+--- a/rust/kernel/init/macros.rs
++++ b/rust/kernel/init/macros.rs
+@@ -964,54 +964,35 @@ macro_rules! __pin_data {
+         @pinned($($(#[$($p_attr:tt)*])* $pvis:vis $p_field:ident : $p_type:ty),* $(,)?),
+         @not_pinned($($(#[$($attr:tt)*])* $fvis:vis $field:ident : $type:ty),* $(,)?),
+     ) => {
+-        $crate::macros::paste! {
+-            // For every field, we create a projection function according to its projection type. If a
+-            // field is structurally pinned, then it must be initialized via `PinInit`, if it is not
+-            // structurally pinned, then it can be initialized via `Init`.
+-            //
+-            // The functions are `unsafe` to prevent accidentally calling them.
+-            #[allow(dead_code, non_snake_case)]
+-            #[expect(clippy::missing_safety_doc)]
+-            impl<$($impl_generics)*> $pin_data<$($ty_generics)*>
+-            where $($whr)*
+-            {
+-                $(
+-                    $(#[$($p_attr)*])*
+-                    $pvis unsafe fn $p_field<E>(
+-                        self,
+-                        slot: *mut $p_type,
+-                        init: impl $crate::init::PinInit<$p_type, E>,
+-                    ) -> ::core::result::Result<(), E> {
+-                        unsafe { $crate::init::PinInit::__pinned_init(init, slot) }
+-                    }
+-
+-                    $(#[$($p_attr)*])*
+-                    $pvis unsafe fn [<__project_ $p_field>]<'__slot>(
+-                        self,
+-                        slot: &'__slot mut $p_type,
+-                    ) -> ::core::pin::Pin<&'__slot mut $p_type> {
+-                        unsafe { ::core::pin::Pin::new_unchecked(slot) }
+-                    }
+-                )*
+-                $(
+-                    $(#[$($attr)*])*
+-                    $fvis unsafe fn $field<E>(
+-                        self,
+-                        slot: *mut $type,
+-                        init: impl $crate::init::Init<$type, E>,
+-                    ) -> ::core::result::Result<(), E> {
+-                        unsafe { $crate::init::Init::__init(init, slot) }
+-                    }
+-
+-                    $(#[$($attr)*])*
+-                    $fvis unsafe fn [<__project_ $field>]<'__slot>(
+-                        self,
+-                        slot: &'__slot mut $type,
+-                    ) -> &'__slot mut $type {
+-                        slot
+-                    }
+-                )*
+-            }
++        // For every field, we create a projection function according to its projection type. If a
++        // field is structurally pinned, then it must be initialized via `PinInit`, if it is not
++        // structurally pinned, then it can be initialized via `Init`.
++        //
++        // The functions are `unsafe` to prevent accidentally calling them.
++        #[allow(dead_code)]
++        impl<$($impl_generics)*> $pin_data<$($ty_generics)*>
++        where $($whr)*
++        {
++            $(
++                $(#[$($p_attr)*])*
++                $pvis unsafe fn $p_field<E>(
++                    self,
++                    slot: *mut $p_type,
++                    init: impl $crate::init::PinInit<$p_type, E>,
++                ) -> ::core::result::Result<(), E> {
++                    unsafe { $crate::init::PinInit::__pinned_init(init, slot) }
++                }
++            )*
++            $(
++                $(#[$($attr)*])*
++                $fvis unsafe fn $field<E>(
++                    self,
++                    slot: *mut $type,
++                    init: impl $crate::init::Init<$type, E>,
++                ) -> ::core::result::Result<(), E> {
++                    unsafe { $crate::init::Init::__init(init, slot) }
++                }
++            )*
+         }
+     };
+ }
+@@ -1205,17 +1186,6 @@ macro_rules! __init_internal {
+         // return when an error/panic occurs.
+         // We also use the `data` to require the correct trait (`Init` or `PinInit`) for `$field`.
+         unsafe { $data.$field(::core::ptr::addr_of_mut!((*$slot).$field), init)? };
+-        // NOTE: the field accessor ensures that the initialized field is properly aligned.
+-        // Unaligned fields will cause the compiler to emit E0793. We do not support
+-        // unaligned fields since `Init::__init` requires an aligned pointer; the call to
+-        // `ptr::write` below has the same requirement.
+-        // SAFETY:
+-        // - the project function does the correct field projection,
+-        // - the field has been initialized,
+-        // - the reference is only valid until the end of the initializer.
+-        #[allow(unused_variables, unused_assignments)]
+-        let $field = $crate::macros::paste!(unsafe { $data.[< __project_ $field >](&mut (*$slot).$field) });
+-
+         // Create the drop guard:
+         //
+         // We rely on macro hygiene to make it impossible for users to access this local variable.
+@@ -1247,18 +1217,6 @@ macro_rules! __init_internal {
+         // SAFETY: `slot` is valid, because we are inside of an initializer closure, we
+         // return when an error/panic occurs.
+         unsafe { $crate::init::Init::__init(init, ::core::ptr::addr_of_mut!((*$slot).$field))? };
+-
+-        // NOTE: the field accessor ensures that the initialized field is properly aligned.
+-        // Unaligned fields will cause the compiler to emit E0793. We do not support
+-        // unaligned fields since `Init::__init` requires an aligned pointer; the call to
+-        // `ptr::write` below has the same requirement.
+-        // SAFETY:
+-        // - the field is not structurally pinned, since the line above must compile,
+-        // - the field has been initialized,
+-        // - the reference is only valid until the end of the initializer.
+-        #[allow(unused_variables, unused_assignments)]
+-        let $field = unsafe { &mut (*$slot).$field };
+-
+         // Create the drop guard:
+         //
+         // We rely on macro hygiene to make it impossible for users to access this local variable.
+@@ -1277,7 +1235,7 @@ macro_rules! __init_internal {
+             );
+         }
+     };
+-    (init_slot(): // No `use_data`, so all fields are not structurally pinned
++    (init_slot($($use_data:ident)?):
+         @data($data:ident),
+         @slot($slot:ident),
+         @guards($($guards:ident,)*),
+@@ -1291,19 +1249,6 @@ macro_rules! __init_internal {
+             // SAFETY: The memory at `slot` is uninitialized.
+             unsafe { ::core::ptr::write(::core::ptr::addr_of_mut!((*$slot).$field), $field) };
+         }
+-
+-        // NOTE: the field accessor ensures that the initialized field is properly aligned.
+-        // Unaligned fields will cause the compiler to emit E0793. We do not support
+-        // unaligned fields since `Init::__init` requires an aligned pointer; the call to
+-        // `ptr::write` below has the same requirement.
+-        #[allow(unused_variables, unused_assignments)]
+-        // SAFETY:
+-        // - the field is not structurally pinned, since no `use_data` was required to create this
+-        //   initializer,
+-        // - the field has been initialized,
+-        // - the reference is only valid until the end of the initializer.
+-        let $field = unsafe { &mut (*$slot).$field };
+-
+         // Create the drop guard:
+         //
+         // We rely on macro hygiene to make it impossible for users to access this local variable.
+@@ -1314,50 +1259,7 @@ macro_rules! __init_internal {
+                 $crate::init::__internal::DropGuard::new(::core::ptr::addr_of_mut!((*$slot).$field))
+             };
+ 
+-            $crate::__init_internal!(init_slot():
+-                @data($data),
+-                @slot($slot),
+-                @guards([< __ $field _guard >], $($guards,)*),
+-                @munch_fields($($rest)*),
+-            );
+-        }
+-    };
+-    (init_slot($use_data:ident):
+-        @data($data:ident),
+-        @slot($slot:ident),
+-        @guards($($guards:ident,)*),
+-        // Init by-value.
+-        @munch_fields($field:ident $(: $val:expr)?, $($rest:tt)*),
+-    ) => {
+-        {
+-            $(let $field = $val;)?
+-            // Initialize the field.
+-            //
+-            // SAFETY: The memory at `slot` is uninitialized.
+-            unsafe { ::core::ptr::write(::core::ptr::addr_of_mut!((*$slot).$field), $field) };
+-        }
+-        // NOTE: the field accessor ensures that the initialized field is properly aligned.
+-        // Unaligned fields will cause the compiler to emit E0793. We do not support
+-        // unaligned fields since `Init::__init` requires an aligned pointer; the call to
+-        // `ptr::write` below has the same requirement.
+-        // SAFETY:
+-        // - the project function does the correct field projection,
+-        // - the field has been initialized,
+-        // - the reference is only valid until the end of the initializer.
+-        #[allow(unused_variables, unused_assignments)]
+-        let $field = $crate::macros::paste!(unsafe { $data.[< __project_ $field >](&mut (*$slot).$field) });
+-
+-        // Create the drop guard:
+-        //
+-        // We rely on macro hygiene to make it impossible for users to access this local variable.
+-        // We use `paste!` to create new hygiene for `$field`.
+-        $crate::macros::paste! {
+-            // SAFETY: We forget the guard later when initialization has succeeded.
+-            let [< __ $field _guard >] = unsafe {
+-                $crate::init::__internal::DropGuard::new(::core::ptr::addr_of_mut!((*$slot).$field))
+-            };
+-
+-            $crate::__init_internal!(init_slot($use_data):
++            $crate::__init_internal!(init_slot($($use_data)?):
+                 @data($data),
+                 @slot($slot),
+                 @guards([<$field>], $($guards,)*),

--- a/patch/kernel/archive/odroidxu4-6.6/patch-6.6.132-133.patch
+++ b/patch/kernel/archive/odroidxu4-6.6/patch-6.6.132-133.patch
@@ -1,0 +1,56 @@
+diff --git a/Makefile b/Makefile
+index 56ff90e4d6036d..753e98740a5e1e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 6
+ PATCHLEVEL = 6
+-SUBLEVEL = 132
++SUBLEVEL = 133
+ EXTRAVERSION =
+ NAME = Pinguïn Aangedreven
+ 
+diff --git a/fs/xattr.c b/fs/xattr.c
+index 5f2d74332ea636..20a038b06d1275 100644
+--- a/fs/xattr.c
++++ b/fs/xattr.c
+@@ -699,6 +699,8 @@ SYSCALL_DEFINE5(fsetxattr, int, fd, const char __user *, name,
+ 
+ 	CLASS(fd, f)(fd);
+ 
++	if (!f.file)
++		return -EBADF;
+ 	audit_file(f.file);
+ 	error = setxattr_copy(name, &ctx);
+ 	if (error)
+@@ -810,6 +812,8 @@ SYSCALL_DEFINE4(fgetxattr, int, fd, const char __user *, name,
+ {
+ 	CLASS(fd, f)(fd);
+ 
++	if (!f.file)
++		return -EBADF;
+ 	audit_file(f.file);
+ 	return getxattr(file_mnt_idmap(f.file), f.file->f_path.dentry,
+ 			 name, value, size);
+@@ -881,8 +885,10 @@ SYSCALL_DEFINE3(flistxattr, int, fd, char __user *, list, size_t, size)
+ {
+ 	CLASS(fd, f)(fd);
+ 
++	if (!f.file)
++		return -EBADF;
+ 	audit_file(f.file);
+-	return listxattr(f.file->f_path.dentry, list, size);
++	return  listxattr(f.file->f_path.dentry, list, size);
+ }
+ 
+ /*
+@@ -943,6 +949,8 @@ SYSCALL_DEFINE2(fremovexattr, int, fd, const char __user *, name)
+ 	char kname[XATTR_NAME_MAX + 1];
+ 	int error;
+ 
++	if (!f.file)
++		return -EBADF;
+ 	audit_file(f.file);
+ 
+ 	error = strncpy_from_user(kname, name, sizeof(kname));

--- a/patch/kernel/archive/odroidxu4-6.6/patch-6.6.133-134.patch
+++ b/patch/kernel/archive/odroidxu4-6.6/patch-6.6.133-134.patch
@@ -1,0 +1,6472 @@
+diff --git a/Documentation/devicetree/bindings/auxdisplay/holtek,ht16k33.yaml b/Documentation/devicetree/bindings/auxdisplay/holtek,ht16k33.yaml
+index be95f6b97b41a5..0c28292a5bb46c 100644
+--- a/Documentation/devicetree/bindings/auxdisplay/holtek,ht16k33.yaml
++++ b/Documentation/devicetree/bindings/auxdisplay/holtek,ht16k33.yaml
+@@ -66,7 +66,7 @@ then:
+   required:
+     - refresh-rate-hz
+ 
+-additionalProperties: false
++unevaluatedProperties: false
+ 
+ examples:
+   - |
+diff --git a/Documentation/devicetree/bindings/connector/usb-connector.yaml b/Documentation/devicetree/bindings/connector/usb-connector.yaml
+index 7c8a3e8430d306..48a93690bb4392 100644
+--- a/Documentation/devicetree/bindings/connector/usb-connector.yaml
++++ b/Documentation/devicetree/bindings/connector/usb-connector.yaml
+@@ -232,6 +232,7 @@ properties:
+     type: boolean
+ 
+ dependencies:
++  pd-disable: [typec-power-opmode]
+   sink-vdos-v1: [ sink-vdos ]
+   sink-vdos: [ sink-vdos-v1 ]
+ 
+diff --git a/Documentation/devicetree/bindings/gpio/microchip,mpfs-gpio.yaml b/Documentation/devicetree/bindings/gpio/microchip,mpfs-gpio.yaml
+index d481e78958a74a..2c7355e9547a1c 100644
+--- a/Documentation/devicetree/bindings/gpio/microchip,mpfs-gpio.yaml
++++ b/Documentation/devicetree/bindings/gpio/microchip,mpfs-gpio.yaml
+@@ -33,7 +33,7 @@ properties:
+     const: 2
+ 
+   "#interrupt-cells":
+-    const: 1
++    const: 2
+ 
+   ngpios:
+     description:
+@@ -84,7 +84,7 @@ examples:
+         gpio-controller;
+         #gpio-cells = <2>;
+         interrupt-controller;
+-        #interrupt-cells = <1>;
++        #interrupt-cells = <2>;
+         interrupts = <53>, <53>, <53>, <53>,
+                      <53>, <53>, <53>, <53>,
+                      <53>, <53>, <53>, <53>,
+diff --git a/Makefile b/Makefile
+index 753e98740a5e1e..6b1d800ce74b06 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 6
+ PATCHLEVEL = 6
+-SUBLEVEL = 133
++SUBLEVEL = 134
+ EXTRAVERSION =
+ NAME = Pinguïn Aangedreven
+ 
+diff --git a/arch/arm64/kernel/patch-scs.c b/arch/arm64/kernel/patch-scs.c
+index a1fe4b4ff59176..6d656179ea03b9 100644
+--- a/arch/arm64/kernel/patch-scs.c
++++ b/arch/arm64/kernel/patch-scs.c
+@@ -171,6 +171,14 @@ static int noinstr scs_handle_fde_frame(const struct eh_frame *frame,
+ 			size -= 2;
+ 			break;
+ 
++		case DW_CFA_advance_loc4:
++			loc += *opcode++ * code_alignment_factor;
++			loc += (*opcode++ << 8) * code_alignment_factor;
++			loc += (*opcode++ << 16) * code_alignment_factor;
++			loc += (*opcode++ << 24) * code_alignment_factor;
++			size -= 4;
++		break;
++
+ 		case DW_CFA_def_cfa:
+ 		case DW_CFA_offset_extended:
+ 			size = skip_xleb128(&opcode, size);
+diff --git a/arch/loongarch/include/asm/linkage.h b/arch/loongarch/include/asm/linkage.h
+index e2eca1a25b4ef7..a1bd6a3ee03a19 100644
+--- a/arch/loongarch/include/asm/linkage.h
++++ b/arch/loongarch/include/asm/linkage.h
+@@ -41,4 +41,40 @@
+ 	.cfi_endproc;					\
+ 	SYM_END(name, SYM_T_NONE)
+ 
++/*
++ * This is for the signal handler trampoline, which is used as the return
++ * address of the signal handlers in userspace instead of called normally.
++ * The long standing libgcc bug https://gcc.gnu.org/PR124050 requires a
++ * nop between .cfi_startproc and the actual address of the trampoline, so
++ * we cannot simply use SYM_FUNC_START.
++ *
++ * This wrapper also contains all the .cfi_* directives for recovering
++ * the content of the GPRs and the "return address" (where the rt_sigreturn
++ * syscall will jump to), assuming there is a struct rt_sigframe (where
++ * a struct sigcontext containing those information we need to recover) at
++ * $sp.  The "DWARF for the LoongArch(TM) Architecture" manual states
++ * column 0 is for $zero, but it does not make too much sense to
++ * save/restore the hardware zero register.  Repurpose this column here
++ * for the return address (here it's not the content of $ra we cannot use
++ * the default column 3).
++ */
++#define SYM_SIGFUNC_START(name)				\
++	.cfi_startproc;					\
++	.cfi_signal_frame;				\
++	.cfi_def_cfa 3, RT_SIGFRAME_SC;			\
++	.cfi_return_column 0;				\
++	.cfi_offset 0, SC_PC;				\
++							\
++	.irp num, 1,  2,  3,  4,  5,  6,  7,  8, 	\
++		  9,  10, 11, 12, 13, 14, 15, 16,	\
++		  17, 18, 19, 20, 21, 22, 23, 24,	\
++		  25, 26, 27, 28, 29, 30, 31;		\
++	.cfi_offset \num, SC_REGS + \num * SZREG;	\
++	.endr;						\
++							\
++	nop;						\
++	SYM_START(name, SYM_L_GLOBAL, SYM_A_ALIGN)
++
++#define SYM_SIGFUNC_END(name) SYM_FUNC_END(name)
++
+ #endif
+diff --git a/arch/loongarch/include/asm/sigframe.h b/arch/loongarch/include/asm/sigframe.h
+new file mode 100644
+index 00000000000000..109298b8d7e0b0
+--- /dev/null
++++ b/arch/loongarch/include/asm/sigframe.h
+@@ -0,0 +1,9 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++
++#include <asm/siginfo.h>
++#include <asm/ucontext.h>
++
++struct rt_sigframe {
++	struct siginfo rs_info;
++	struct ucontext rs_uctx;
++};
+diff --git a/arch/loongarch/kernel/asm-offsets.c b/arch/loongarch/kernel/asm-offsets.c
+index 110afd3cc8f348..10c66ec95fa19f 100644
+--- a/arch/loongarch/kernel/asm-offsets.c
++++ b/arch/loongarch/kernel/asm-offsets.c
+@@ -15,6 +15,7 @@
+ #include <asm/ptrace.h>
+ #include <asm/processor.h>
+ #include <asm/ftrace.h>
++#include <asm/sigframe.h>
+ 
+ void output_ptreg_defines(void)
+ {
+@@ -218,6 +219,7 @@ void output_sc_defines(void)
+ 	COMMENT("Linux sigcontext offsets.");
+ 	OFFSET(SC_REGS, sigcontext, sc_regs);
+ 	OFFSET(SC_PC, sigcontext, sc_pc);
++	OFFSET(RT_SIGFRAME_SC, rt_sigframe, rs_uctx.uc_mcontext);
+ 	BLANK();
+ }
+ 
+diff --git a/arch/loongarch/kernel/signal.c b/arch/loongarch/kernel/signal.c
+index 0e90cd2df0ea3a..c9a0fd40e8b57d 100644
+--- a/arch/loongarch/kernel/signal.c
++++ b/arch/loongarch/kernel/signal.c
+@@ -34,6 +34,7 @@
+ #include <asm/cpu-features.h>
+ #include <asm/fpu.h>
+ #include <asm/lbt.h>
++#include <asm/sigframe.h>
+ #include <asm/ucontext.h>
+ #include <asm/vdso.h>
+ 
+@@ -71,11 +72,6 @@ extern asmlinkage int _save_ftop_context(void __user *ftop);
+ extern asmlinkage int _restore_ftop_context(void __user *ftop);
+ #endif
+ 
+-struct rt_sigframe {
+-	struct siginfo rs_info;
+-	struct ucontext rs_uctx;
+-};
+-
+ struct _ctx_layout {
+ 	struct sctx_info *addr;
+ 	unsigned int size;
+diff --git a/arch/loongarch/vdso/Makefile b/arch/loongarch/vdso/Makefile
+index 1a0f6ca0247b4c..ebf3b4d5217270 100644
+--- a/arch/loongarch/vdso/Makefile
++++ b/arch/loongarch/vdso/Makefile
+@@ -24,7 +24,7 @@ cflags-vdso := $(ccflags-vdso) \
+ 	$(filter -W%,$(filter-out -Wa$(comma)%,$(KBUILD_CFLAGS))) \
+ 	-std=gnu11 -O2 -g -fno-strict-aliasing -fno-common -fno-builtin \
+ 	-fno-stack-protector -fno-jump-tables -DDISABLE_BRANCH_PROFILING \
+-	$(call cc-option, -fno-asynchronous-unwind-tables) \
++	$(call cc-option, -fasynchronous-unwind-tables) \
+ 	$(call cc-option, -fno-stack-protector)
+ aflags-vdso := $(ccflags-vdso) \
+ 	-D__ASSEMBLY__ -Wa,-gdwarf-2
+@@ -36,7 +36,7 @@ endif
+ # VDSO linker flags.
+ ldflags-y := -Bsymbolic --no-undefined -soname=linux-vdso.so.1 \
+ 	$(filter -E%,$(KBUILD_CFLAGS)) -nostdlib -shared \
+-	--hash-style=sysv --build-id -T
++	--hash-style=sysv --build-id --eh-frame-hdr -T
+ 
+ GCOV_PROFILE := n
+ 
+diff --git a/arch/loongarch/vdso/sigreturn.S b/arch/loongarch/vdso/sigreturn.S
+index 9cb3c58fad03bf..59f940d928de7b 100644
+--- a/arch/loongarch/vdso/sigreturn.S
++++ b/arch/loongarch/vdso/sigreturn.S
+@@ -12,13 +12,13 @@
+ 
+ #include <asm/regdef.h>
+ #include <asm/asm.h>
++#include <asm/asm-offsets.h>
+ 
+ 	.section	.text
+-	.cfi_sections	.debug_frame
+ 
+-SYM_FUNC_START(__vdso_rt_sigreturn)
++SYM_SIGFUNC_START(__vdso_rt_sigreturn)
+ 
+ 	li.w	a7, __NR_rt_sigreturn
+ 	syscall	0
+ 
+-SYM_FUNC_END(__vdso_rt_sigreturn)
++SYM_SIGFUNC_END(__vdso_rt_sigreturn)
+diff --git a/arch/mips/lib/multi3.c b/arch/mips/lib/multi3.c
+index 4c2483f410c26b..92b3778bb56feb 100644
+--- a/arch/mips/lib/multi3.c
++++ b/arch/mips/lib/multi3.c
+@@ -4,12 +4,12 @@
+ #include "libgcc.h"
+ 
+ /*
+- * GCC 7 & older can suboptimally generate __multi3 calls for mips64r6, so for
++ * GCC 9 & older can suboptimally generate __multi3 calls for mips64r6, so for
+  * that specific case only we implement that intrinsic here.
+  *
+  * See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82981
+  */
+-#if defined(CONFIG_64BIT) && defined(CONFIG_CPU_MIPSR6) && (__GNUC__ < 8)
++#if defined(CONFIG_64BIT) && defined(CONFIG_CPU_MIPSR6) && (__GNUC__ < 10)
+ 
+ /* multiply 64-bit values, low 64-bits returned */
+ static inline long long notrace dmulu(long long a, long long b)
+@@ -51,4 +51,4 @@ ti_type notrace __multi3(ti_type a, ti_type b)
+ }
+ EXPORT_SYMBOL(__multi3);
+ 
+-#endif /* 64BIT && CPU_MIPSR6 && GCC7 */
++#endif /* 64BIT && CPU_MIPSR6 && GCC9 */
+diff --git a/arch/mips/mm/tlb-r4k.c b/arch/mips/mm/tlb-r4k.c
+index 06cb140476ea08..4d49ecf2761031 100644
+--- a/arch/mips/mm/tlb-r4k.c
++++ b/arch/mips/mm/tlb-r4k.c
+@@ -536,7 +536,7 @@ static void __ref r4k_tlb_uniquify(void)
+ 
+ 	tlb_vpn_size = tlbsize * sizeof(*tlb_vpns);
+ 	tlb_vpns = (use_slab ?
+-		    kmalloc(tlb_vpn_size, GFP_KERNEL) :
++		    kmalloc(tlb_vpn_size, GFP_ATOMIC) :
+ 		    memblock_alloc_raw(tlb_vpn_size, sizeof(*tlb_vpns)));
+ 	if (WARN_ON(!tlb_vpns))
+ 		return; /* Pray local_flush_tlb_all() is good enough. */
+diff --git a/arch/mips/ralink/clk.c b/arch/mips/ralink/clk.c
+index 9db73fcac522eb..5c1eb46ef5d07e 100644
+--- a/arch/mips/ralink/clk.c
++++ b/arch/mips/ralink/clk.c
+@@ -21,16 +21,16 @@ static const char *clk_cpu(int *idx)
+ {
+ 	switch (ralink_soc) {
+ 	case RT2880_SOC:
+-		*idx = 0;
++		*idx = 1;
+ 		return "ralink,rt2880-sysc";
+ 	case RT3883_SOC:
+-		*idx = 0;
++		*idx = 1;
+ 		return "ralink,rt3883-sysc";
+ 	case RT305X_SOC_RT3050:
+-		*idx = 0;
++		*idx = 1;
+ 		return "ralink,rt3050-sysc";
+ 	case RT305X_SOC_RT3052:
+-		*idx = 0;
++		*idx = 1;
+ 		return "ralink,rt3052-sysc";
+ 	case RT305X_SOC_RT3350:
+ 		*idx = 1;
+diff --git a/arch/riscv/kernel/kgdb.c b/arch/riscv/kernel/kgdb.c
+index 9f3db3503dabd6..edaab2aa16a3ec 100644
+--- a/arch/riscv/kernel/kgdb.c
++++ b/arch/riscv/kernel/kgdb.c
+@@ -175,7 +175,7 @@ struct dbg_reg_def_t dbg_reg_def[DBG_MAX_REG_NUM] = {
+ 	{DBG_REG_T1, GDB_SIZEOF_REG, offsetof(struct pt_regs, t1)},
+ 	{DBG_REG_T2, GDB_SIZEOF_REG, offsetof(struct pt_regs, t2)},
+ 	{DBG_REG_FP, GDB_SIZEOF_REG, offsetof(struct pt_regs, s0)},
+-	{DBG_REG_S1, GDB_SIZEOF_REG, offsetof(struct pt_regs, a1)},
++	{DBG_REG_S1, GDB_SIZEOF_REG, offsetof(struct pt_regs, s1)},
+ 	{DBG_REG_A0, GDB_SIZEOF_REG, offsetof(struct pt_regs, a0)},
+ 	{DBG_REG_A1, GDB_SIZEOF_REG, offsetof(struct pt_regs, a1)},
+ 	{DBG_REG_A2, GDB_SIZEOF_REG, offsetof(struct pt_regs, a2)},
+@@ -244,8 +244,9 @@ sleeping_thread_to_gdb_regs(unsigned long *gdb_regs, struct task_struct *task)
+ 	gdb_regs[DBG_REG_S6_OFF] = task->thread.s[6];
+ 	gdb_regs[DBG_REG_S7_OFF] = task->thread.s[7];
+ 	gdb_regs[DBG_REG_S8_OFF] = task->thread.s[8];
+-	gdb_regs[DBG_REG_S9_OFF] = task->thread.s[10];
+-	gdb_regs[DBG_REG_S10_OFF] = task->thread.s[11];
++	gdb_regs[DBG_REG_S9_OFF] = task->thread.s[9];
++	gdb_regs[DBG_REG_S10_OFF] = task->thread.s[10];
++	gdb_regs[DBG_REG_S11_OFF] = task->thread.s[11];
+ 	gdb_regs[DBG_REG_EPC_OFF] = task->thread.ra;
+ }
+ 
+diff --git a/arch/x86/kernel/cpu/common.c b/arch/x86/kernel/cpu/common.c
+index cf455968f27b69..ef73ce697ec8ad 100644
+--- a/arch/x86/kernel/cpu/common.c
++++ b/arch/x86/kernel/cpu/common.c
+@@ -2012,12 +2012,6 @@ static void identify_cpu(struct cpuinfo_x86 *c)
+ 	setup_smap(c);
+ 	setup_umip(c);
+ 
+-	/* Enable FSGSBASE instructions if available. */
+-	if (cpu_has(c, X86_FEATURE_FSGSBASE)) {
+-		cr4_set_bits(X86_CR4_FSGSBASE);
+-		elf_hwcap2 |= HWCAP2_FSGSBASE;
+-	}
+-
+ 	/*
+ 	 * The vendor-specific functions might have changed features.
+ 	 * Now we do "generic changes."
+@@ -2349,6 +2343,18 @@ void cpu_init_exception_handling(void)
+ 	/* GHCB needs to be setup to handle #VC. */
+ 	setup_ghcb();
+ 
++	/*
++	 * On CPUs with FSGSBASE support, paranoid_entry() uses
++	 * ALTERNATIVE-patched RDGSBASE/WRGSBASE instructions. Secondary CPUs
++	 * boot after alternatives are patched globally, so early exceptions
++	 * execute patched code that depends on FSGSBASE. Enable the feature
++	 * before any exceptions occur.
++	 */
++	if (cpu_feature_enabled(X86_FEATURE_FSGSBASE)) {
++		cr4_set_bits(X86_CR4_FSGSBASE);
++		elf_hwcap2 |= HWCAP2_FSGSBASE;
++	}
++
+ 	/* Finally load the IDT */
+ 	load_current_idt();
+ }
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index 3d0b7542f771ca..24575ceae14bd0 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -622,8 +622,10 @@ static int af_alg_alloc_tsgl(struct sock *sk)
+ 		sg_init_table(sgl->sg, MAX_SGL_ENTS + 1);
+ 		sgl->cur = 0;
+ 
+-		if (sg)
++		if (sg) {
++			sg_unmark_end(sg + MAX_SGL_ENTS - 1);
+ 			sg_chain(sg, MAX_SGL_ENTS + 1, sgl->sg);
++		}
+ 
+ 		list_add_tail(&sgl->list, &ctx->tsgl_list);
+ 	}
+diff --git a/drivers/accel/qaic/qaic_control.c b/drivers/accel/qaic/qaic_control.c
+index 08b78f56785329..de8b17e2b29e18 100644
+--- a/drivers/accel/qaic/qaic_control.c
++++ b/drivers/accel/qaic/qaic_control.c
+@@ -910,7 +910,7 @@ static int decode_deactivate(struct qaic_device *qdev, void *trans, u32 *msg_len
+ 		 */
+ 		return -ENODEV;
+ 
+-	if (status) {
++	if (usr && status) {
+ 		/*
+ 		 * Releasing resources failed on the device side, which puts
+ 		 * us in a bind since they may still be in use, so enable the
+@@ -1104,6 +1104,9 @@ static void *msg_xfer(struct qaic_device *qdev, struct wrapper_list *wrappers, u
+ 	mutex_lock(&qdev->cntl_mutex);
+ 	if (!list_empty(&elem.list))
+ 		list_del(&elem.list);
++	/* resp_worker() processed the response but the wait was interrupted */
++	else if (ret == -ERESTARTSYS)
++		ret = 0;
+ 	if (!ret && !elem.buf)
+ 		ret = -ETIMEDOUT;
+ 	else if (ret > 0 && !elem.buf)
+@@ -1414,9 +1417,49 @@ static void resp_worker(struct work_struct *work)
+ 	}
+ 	mutex_unlock(&qdev->cntl_mutex);
+ 
+-	if (!found)
++	if (!found) {
++		/*
++		 * The user might have gone away at this point without waiting
++		 * for QAIC_TRANS_DEACTIVATE_FROM_DEV transaction coming from
++		 * the device. If this is not handled correctly, the host will
++		 * not know that the DBC[n] has been freed on the device.
++		 * Due to this failure in synchronization between the device and
++		 * the host, if another user requests to activate a network, and
++		 * the device assigns DBC[n] again, save_dbc_buf() will hang,
++		 * waiting for dbc[n]->in_use to be set to false, which will not
++		 * happen unless the qaic_dev_reset_clean_local_state() gets
++		 * called by resetting the device (or re-inserting the module).
++		 *
++		 * As a solution, we look for QAIC_TRANS_DEACTIVATE_FROM_DEV
++		 * transactions in the message before disposing of it, then
++		 * handle releasing the DBC resources.
++		 *
++		 * Since the user has gone away, if the device could not
++		 * deactivate the network (status != 0), there is no way to
++		 * enable and reassign the DBC to the user. We can put trust in
++		 * the device that it will release all the active DBCs in
++		 * response to the QAIC_TRANS_TERMINATE_TO_DEV transaction,
++		 * otherwise, the user can issue an soc_reset to the device.
++		 */
++		u32 msg_count = le32_to_cpu(msg->hdr.count);
++		u32 msg_len = le32_to_cpu(msg->hdr.len);
++		u32 len = 0;
++		int j;
++
++		for (j = 0; j < msg_count && len < msg_len; ++j) {
++			struct wire_trans_hdr *trans_hdr;
++
++			trans_hdr = (struct wire_trans_hdr *)(msg->data + len);
++			if (le32_to_cpu(trans_hdr->type) == QAIC_TRANS_DEACTIVATE_FROM_DEV) {
++				if (decode_deactivate(qdev, trans_hdr, &len, NULL))
++					len += le32_to_cpu(trans_hdr->len);
++			} else {
++				len += le32_to_cpu(trans_hdr->len);
++			}
++		}
+ 		/* request must have timed out, drop packet */
+ 		kfree(msg);
++	}
+ 
+ 	kfree(resp);
+ }
+diff --git a/drivers/comedi/drivers.c b/drivers/comedi/drivers.c
+index ce4cde140518b0..01a406b885b38f 100644
+--- a/drivers/comedi/drivers.c
++++ b/drivers/comedi/drivers.c
+@@ -1000,6 +1000,14 @@ int comedi_device_attach(struct comedi_device *dev, struct comedi_devconfig *it)
+ 		ret = -EIO;
+ 		goto out;
+ 	}
++	if (IS_ENABLED(CONFIG_LOCKDEP)) {
++		/*
++		 * dev->spinlock is for private use by the attached low-level
++		 * driver.  Reinitialize it to stop lock-dependency tracking
++		 * between attachments to different low-level drivers.
++		 */
++		spin_lock_init(&dev->spinlock);
++	}
+ 	dev->driver = driv;
+ 	dev->board_name = dev->board_ptr ? *(const char **)dev->board_ptr
+ 					 : dev->driver->driver_name;
+diff --git a/drivers/comedi/drivers/dt2815.c b/drivers/comedi/drivers/dt2815.c
+index 03ba2fd18a2169..d066dc303520b9 100644
+--- a/drivers/comedi/drivers/dt2815.c
++++ b/drivers/comedi/drivers/dt2815.c
+@@ -175,6 +175,18 @@ static int dt2815_attach(struct comedi_device *dev, struct comedi_devconfig *it)
+ 		    ? current_range_type : voltage_range_type;
+ 	}
+ 
++	/*
++	 * Check if hardware is present before attempting any I/O operations.
++	 * Reading 0xff from status register typically indicates no hardware
++	 * on the bus (floating bus reads as all 1s).
++	 */
++	if (inb(dev->iobase + DT2815_STATUS) == 0xff) {
++		dev_err(dev->class_dev,
++			"No hardware detected at I/O base 0x%lx\n",
++			dev->iobase);
++		return -ENODEV;
++	}
++
+ 	/* Init the 2815 */
+ 	outb(0x00, dev->iobase + DT2815_STATUS);
+ 	for (i = 0; i < 100; i++) {
+diff --git a/drivers/comedi/drivers/me4000.c b/drivers/comedi/drivers/me4000.c
+index 9aea02b86ed912..5fc95e92aff370 100644
+--- a/drivers/comedi/drivers/me4000.c
++++ b/drivers/comedi/drivers/me4000.c
+@@ -315,6 +315,18 @@ static int me4000_xilinx_download(struct comedi_device *dev,
+ 	unsigned int val;
+ 	unsigned int i;
+ 
++	/* Get data stream length from header. */
++	if (size >= 4) {
++		file_length = (((unsigned int)data[0] & 0xff) << 24) +
++			      (((unsigned int)data[1] & 0xff) << 16) +
++			      (((unsigned int)data[2] & 0xff) << 8) +
++			      ((unsigned int)data[3] & 0xff);
++	}
++	if (size < 16 || file_length > size - 16) {
++		dev_err(dev->class_dev, "Firmware length inconsistency\n");
++		return -EINVAL;
++	}
++
+ 	if (!xilinx_iobase)
+ 		return -ENODEV;
+ 
+@@ -346,10 +358,6 @@ static int me4000_xilinx_download(struct comedi_device *dev,
+ 	outl(val, devpriv->plx_regbase + PLX9052_CNTRL);
+ 
+ 	/* Download Xilinx firmware */
+-	file_length = (((unsigned int)data[0] & 0xff) << 24) +
+-		      (((unsigned int)data[1] & 0xff) << 16) +
+-		      (((unsigned int)data[2] & 0xff) << 8) +
+-		      ((unsigned int)data[3] & 0xff);
+ 	usleep_range(10, 1000);
+ 
+ 	for (i = 0; i < file_length; i++) {
+diff --git a/drivers/comedi/drivers/me_daq.c b/drivers/comedi/drivers/me_daq.c
+index 076b15097afd9f..2f2ea029cffc2a 100644
+--- a/drivers/comedi/drivers/me_daq.c
++++ b/drivers/comedi/drivers/me_daq.c
+@@ -344,6 +344,25 @@ static int me2600_xilinx_download(struct comedi_device *dev,
+ 	unsigned int file_length;
+ 	unsigned int i;
+ 
++	/*
++	 * Format of the firmware
++	 * Build longs from the byte-wise coded header
++	 * Byte 1-3:   length of the array
++	 * Byte 4-7:   version
++	 * Byte 8-11:  date
++	 * Byte 12-15: reserved
++	 */
++	if (size >= 4) {
++		file_length = (((unsigned int)data[0] & 0xff) << 24) +
++			      (((unsigned int)data[1] & 0xff) << 16) +
++			      (((unsigned int)data[2] & 0xff) << 8) +
++			      ((unsigned int)data[3] & 0xff);
++	}
++	if (size < 16 || file_length > size - 16) {
++		dev_err(dev->class_dev, "Firmware length inconsistency\n");
++		return -EINVAL;
++	}
++
+ 	/* disable irq's on PLX */
+ 	writel(0x00, devpriv->plx_regbase + PLX9052_INTCSR);
+ 
+@@ -357,22 +376,6 @@ static int me2600_xilinx_download(struct comedi_device *dev,
+ 	writeb(0x00, dev->mmio + 0x0);
+ 	sleep(1);
+ 
+-	/*
+-	 * Format of the firmware
+-	 * Build longs from the byte-wise coded header
+-	 * Byte 1-3:   length of the array
+-	 * Byte 4-7:   version
+-	 * Byte 8-11:  date
+-	 * Byte 12-15: reserved
+-	 */
+-	if (size < 16)
+-		return -EINVAL;
+-
+-	file_length = (((unsigned int)data[0] & 0xff) << 24) +
+-	    (((unsigned int)data[1] & 0xff) << 16) +
+-	    (((unsigned int)data[2] & 0xff) << 8) +
+-	    ((unsigned int)data[3] & 0xff);
+-
+ 	/*
+ 	 * Loop for writing firmware byte by byte to xilinx
+ 	 * Firmware data start at offset 16
+diff --git a/drivers/comedi/drivers/ni_atmio16d.c b/drivers/comedi/drivers/ni_atmio16d.c
+index 9fa902529a8e97..e01ab5311d2351 100644
+--- a/drivers/comedi/drivers/ni_atmio16d.c
++++ b/drivers/comedi/drivers/ni_atmio16d.c
+@@ -698,7 +698,8 @@ static int atmio16d_attach(struct comedi_device *dev,
+ 
+ static void atmio16d_detach(struct comedi_device *dev)
+ {
+-	reset_atmio16d(dev);
++	if (dev->private)
++		reset_atmio16d(dev);
+ 	comedi_legacy_detach(dev);
+ }
+ 
+diff --git a/drivers/counter/rz-mtu3-cnt.c b/drivers/counter/rz-mtu3-cnt.c
+index ee821493b16649..b0de86670907a0 100644
+--- a/drivers/counter/rz-mtu3-cnt.c
++++ b/drivers/counter/rz-mtu3-cnt.c
+@@ -107,9 +107,9 @@ static bool rz_mtu3_is_counter_invalid(struct counter_device *counter, int id)
+ 	struct rz_mtu3_cnt *const priv = counter_priv(counter);
+ 	unsigned long tmdr;
+ 
+-	pm_runtime_get_sync(priv->ch->dev);
++	pm_runtime_get_sync(counter->parent);
+ 	tmdr = rz_mtu3_shared_reg_read(priv->ch, RZ_MTU3_TMDR3);
+-	pm_runtime_put(priv->ch->dev);
++	pm_runtime_put(counter->parent);
+ 
+ 	if (id == RZ_MTU3_32_BIT_CH && test_bit(RZ_MTU3_TMDR3_LWA, &tmdr))
+ 		return false;
+@@ -165,12 +165,12 @@ static int rz_mtu3_count_read(struct counter_device *counter,
+ 	if (ret)
+ 		return ret;
+ 
+-	pm_runtime_get_sync(ch->dev);
++	pm_runtime_get_sync(counter->parent);
+ 	if (count->id == RZ_MTU3_32_BIT_CH)
+ 		*val = rz_mtu3_32bit_ch_read(ch, RZ_MTU3_TCNTLW);
+ 	else
+ 		*val = rz_mtu3_16bit_ch_read(ch, RZ_MTU3_TCNT);
+-	pm_runtime_put(ch->dev);
++	pm_runtime_put(counter->parent);
+ 	mutex_unlock(&priv->lock);
+ 
+ 	return 0;
+@@ -187,26 +187,26 @@ static int rz_mtu3_count_write(struct counter_device *counter,
+ 	if (ret)
+ 		return ret;
+ 
+-	pm_runtime_get_sync(ch->dev);
++	pm_runtime_get_sync(counter->parent);
+ 	if (count->id == RZ_MTU3_32_BIT_CH)
+ 		rz_mtu3_32bit_ch_write(ch, RZ_MTU3_TCNTLW, val);
+ 	else
+ 		rz_mtu3_16bit_ch_write(ch, RZ_MTU3_TCNT, val);
+-	pm_runtime_put(ch->dev);
++	pm_runtime_put(counter->parent);
+ 	mutex_unlock(&priv->lock);
+ 
+ 	return 0;
+ }
+ 
+ static int rz_mtu3_count_function_read_helper(struct rz_mtu3_channel *const ch,
+-					      struct rz_mtu3_cnt *const priv,
++					      struct counter_device *const counter,
+ 					      enum counter_function *function)
+ {
+ 	u8 timer_mode;
+ 
+-	pm_runtime_get_sync(ch->dev);
++	pm_runtime_get_sync(counter->parent);
+ 	timer_mode = rz_mtu3_8bit_ch_read(ch, RZ_MTU3_TMDR1);
+-	pm_runtime_put(ch->dev);
++	pm_runtime_put(counter->parent);
+ 
+ 	switch (timer_mode & RZ_MTU3_TMDR1_PH_CNT_MODE_MASK) {
+ 	case RZ_MTU3_TMDR1_PH_CNT_MODE_1:
+@@ -240,7 +240,7 @@ static int rz_mtu3_count_function_read(struct counter_device *counter,
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = rz_mtu3_count_function_read_helper(ch, priv, function);
++	ret = rz_mtu3_count_function_read_helper(ch, counter, function);
+ 	mutex_unlock(&priv->lock);
+ 
+ 	return ret;
+@@ -279,9 +279,9 @@ static int rz_mtu3_count_function_write(struct counter_device *counter,
+ 		return -EINVAL;
+ 	}
+ 
+-	pm_runtime_get_sync(ch->dev);
++	pm_runtime_get_sync(counter->parent);
+ 	rz_mtu3_8bit_ch_write(ch, RZ_MTU3_TMDR1, timer_mode);
+-	pm_runtime_put(ch->dev);
++	pm_runtime_put(counter->parent);
+ 	mutex_unlock(&priv->lock);
+ 
+ 	return 0;
+@@ -300,9 +300,9 @@ static int rz_mtu3_count_direction_read(struct counter_device *counter,
+ 	if (ret)
+ 		return ret;
+ 
+-	pm_runtime_get_sync(ch->dev);
++	pm_runtime_get_sync(counter->parent);
+ 	tsr = rz_mtu3_8bit_ch_read(ch, RZ_MTU3_TSR);
+-	pm_runtime_put(ch->dev);
++	pm_runtime_put(counter->parent);
+ 
+ 	*direction = (tsr & RZ_MTU3_TSR_TCFD) ?
+ 		COUNTER_COUNT_DIRECTION_FORWARD : COUNTER_COUNT_DIRECTION_BACKWARD;
+@@ -377,14 +377,14 @@ static int rz_mtu3_count_ceiling_write(struct counter_device *counter,
+ 		return -EINVAL;
+ 	}
+ 
+-	pm_runtime_get_sync(ch->dev);
++	pm_runtime_get_sync(counter->parent);
+ 	if (count->id == RZ_MTU3_32_BIT_CH)
+ 		rz_mtu3_32bit_ch_write(ch, RZ_MTU3_TGRALW, ceiling);
+ 	else
+ 		rz_mtu3_16bit_ch_write(ch, RZ_MTU3_TGRA, ceiling);
+ 
+ 	rz_mtu3_8bit_ch_write(ch, RZ_MTU3_TCR, RZ_MTU3_TCR_CCLR_TGRA);
+-	pm_runtime_put(ch->dev);
++	pm_runtime_put(counter->parent);
+ 	mutex_unlock(&priv->lock);
+ 
+ 	return 0;
+@@ -495,25 +495,28 @@ static int rz_mtu3_count_enable_read(struct counter_device *counter,
+ static int rz_mtu3_count_enable_write(struct counter_device *counter,
+ 				      struct counter_count *count, u8 enable)
+ {
+-	struct rz_mtu3_channel *const ch = rz_mtu3_get_ch(counter, count->id);
+ 	struct rz_mtu3_cnt *const priv = counter_priv(counter);
+ 	int ret = 0;
+ 
++	mutex_lock(&priv->lock);
++
++	if (priv->count_is_enabled[count->id] == enable)
++		goto exit;
++
+ 	if (enable) {
+-		mutex_lock(&priv->lock);
+-		pm_runtime_get_sync(ch->dev);
++		pm_runtime_get_sync(counter->parent);
+ 		ret = rz_mtu3_initialize_counter(counter, count->id);
+ 		if (ret == 0)
+ 			priv->count_is_enabled[count->id] = true;
+-		mutex_unlock(&priv->lock);
+ 	} else {
+-		mutex_lock(&priv->lock);
+ 		rz_mtu3_terminate_counter(counter, count->id);
+ 		priv->count_is_enabled[count->id] = false;
+-		pm_runtime_put(ch->dev);
+-		mutex_unlock(&priv->lock);
++		pm_runtime_put(counter->parent);
+ 	}
+ 
++exit:
++	mutex_unlock(&priv->lock);
++
+ 	return ret;
+ }
+ 
+@@ -540,9 +543,9 @@ static int rz_mtu3_cascade_counts_enable_get(struct counter_device *counter,
+ 	if (ret)
+ 		return ret;
+ 
+-	pm_runtime_get_sync(priv->ch->dev);
++	pm_runtime_get_sync(counter->parent);
+ 	tmdr = rz_mtu3_shared_reg_read(priv->ch, RZ_MTU3_TMDR3);
+-	pm_runtime_put(priv->ch->dev);
++	pm_runtime_put(counter->parent);
+ 	*cascade_enable = test_bit(RZ_MTU3_TMDR3_LWA, &tmdr);
+ 	mutex_unlock(&priv->lock);
+ 
+@@ -559,10 +562,10 @@ static int rz_mtu3_cascade_counts_enable_set(struct counter_device *counter,
+ 	if (ret)
+ 		return ret;
+ 
+-	pm_runtime_get_sync(priv->ch->dev);
++	pm_runtime_get_sync(counter->parent);
+ 	rz_mtu3_shared_reg_update_bit(priv->ch, RZ_MTU3_TMDR3,
+ 				      RZ_MTU3_TMDR3_LWA, cascade_enable);
+-	pm_runtime_put(priv->ch->dev);
++	pm_runtime_put(counter->parent);
+ 	mutex_unlock(&priv->lock);
+ 
+ 	return 0;
+@@ -579,9 +582,9 @@ static int rz_mtu3_ext_input_phase_clock_select_get(struct counter_device *count
+ 	if (ret)
+ 		return ret;
+ 
+-	pm_runtime_get_sync(priv->ch->dev);
++	pm_runtime_get_sync(counter->parent);
+ 	tmdr = rz_mtu3_shared_reg_read(priv->ch, RZ_MTU3_TMDR3);
+-	pm_runtime_put(priv->ch->dev);
++	pm_runtime_put(counter->parent);
+ 	*ext_input_phase_clock_select = test_bit(RZ_MTU3_TMDR3_PHCKSEL, &tmdr);
+ 	mutex_unlock(&priv->lock);
+ 
+@@ -598,11 +601,11 @@ static int rz_mtu3_ext_input_phase_clock_select_set(struct counter_device *count
+ 	if (ret)
+ 		return ret;
+ 
+-	pm_runtime_get_sync(priv->ch->dev);
++	pm_runtime_get_sync(counter->parent);
+ 	rz_mtu3_shared_reg_update_bit(priv->ch, RZ_MTU3_TMDR3,
+ 				      RZ_MTU3_TMDR3_PHCKSEL,
+ 				      ext_input_phase_clock_select);
+-	pm_runtime_put(priv->ch->dev);
++	pm_runtime_put(counter->parent);
+ 	mutex_unlock(&priv->lock);
+ 
+ 	return 0;
+@@ -640,7 +643,7 @@ static int rz_mtu3_action_read(struct counter_device *counter,
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = rz_mtu3_count_function_read_helper(ch, priv, &function);
++	ret = rz_mtu3_count_function_read_helper(ch, counter, &function);
+ 	if (ret) {
+ 		mutex_unlock(&priv->lock);
+ 		return ret;
+diff --git a/drivers/cpufreq/cpufreq_governor.c b/drivers/cpufreq/cpufreq_governor.c
+index 8f5474612b3124..00a26fa6292c52 100644
+--- a/drivers/cpufreq/cpufreq_governor.c
++++ b/drivers/cpufreq/cpufreq_governor.c
+@@ -468,13 +468,13 @@ int cpufreq_dbs_governor_init(struct cpufreq_policy *policy)
+ 	/* Failure, so roll back. */
+ 	pr_err("initialization failed (dbs_data kobject init error %d)\n", ret);
+ 
+-	kobject_put(&dbs_data->attr_set.kobj);
+-
+ 	policy->governor_data = NULL;
+ 
+ 	if (!have_governor_per_policy())
+ 		gov->gdbs_data = NULL;
+-	gov->exit(dbs_data);
++
++	kobject_put(&dbs_data->attr_set.kobj);
++	goto free_policy_dbs_info;
+ 
+ free_dbs_data:
+ 	kfree(dbs_data);
+diff --git a/drivers/crypto/caam/caamalg_qi2.c b/drivers/crypto/caam/caamalg_qi2.c
+index a148ff1f0872c4..06e0681fdbe15f 100644
+--- a/drivers/crypto/caam/caamalg_qi2.c
++++ b/drivers/crypto/caam/caamalg_qi2.c
+@@ -3325,9 +3325,10 @@ static int ahash_setkey(struct crypto_ahash *ahash, const u8 *key,
+ 		if (aligned_len < keylen)
+ 			return -EOVERFLOW;
+ 
+-		hashed_key = kmemdup(key, aligned_len, GFP_KERNEL);
++		hashed_key = kmalloc(aligned_len, GFP_KERNEL);
+ 		if (!hashed_key)
+ 			return -ENOMEM;
++		memcpy(hashed_key, key, keylen);
+ 		ret = hash_digest_key(ctx, &keylen, hashed_key, digestsize);
+ 		if (ret)
+ 			goto bad_free_key;
+diff --git a/drivers/crypto/caam/caamhash.c b/drivers/crypto/caam/caamhash.c
+index 65785dc5b73b2b..30cc46c4c33af7 100644
+--- a/drivers/crypto/caam/caamhash.c
++++ b/drivers/crypto/caam/caamhash.c
+@@ -441,9 +441,10 @@ static int ahash_setkey(struct crypto_ahash *ahash,
+ 		if (aligned_len < keylen)
+ 			return -EOVERFLOW;
+ 
+-		hashed_key = kmemdup(key, keylen, GFP_KERNEL);
++		hashed_key = kmalloc(aligned_len, GFP_KERNEL);
+ 		if (!hashed_key)
+ 			return -ENOMEM;
++		memcpy(hashed_key, key, keylen);
+ 		ret = hash_digest_key(ctx, &keylen, hashed_key, digestsize);
+ 		if (ret)
+ 			goto bad_free_key;
+diff --git a/drivers/dma/fsl-edma-main.c b/drivers/dma/fsl-edma-main.c
+index 34b194759d218e..745870d469028f 100644
+--- a/drivers/dma/fsl-edma-main.c
++++ b/drivers/dma/fsl-edma-main.c
+@@ -142,7 +142,7 @@ static struct dma_chan *fsl_edma3_xlate(struct of_phandle_args *dma_spec,
+ 
+ 	b_chmux = !!(fsl_edma->drvdata->flags & FSL_EDMA_DRV_HAS_CHMUX);
+ 
+-	mutex_lock(&fsl_edma->fsl_edma_mutex);
++	guard(mutex)(&fsl_edma->fsl_edma_mutex);
+ 	list_for_each_entry_safe(chan, _chan, &fsl_edma->dma_dev.channels,
+ 					device_node) {
+ 
+@@ -152,10 +152,8 @@ static struct dma_chan *fsl_edma3_xlate(struct of_phandle_args *dma_spec,
+ 		fsl_chan = to_fsl_edma_chan(chan);
+ 		i = fsl_chan - fsl_edma->chans;
+ 
+-		fsl_chan->priority = dma_spec->args[1];
+-		fsl_chan->is_rxchan = dma_spec->args[2] & FSL_EDMA_RX;
+-		fsl_chan->is_remote = dma_spec->args[2] & FSL_EDMA_REMOTE;
+-		fsl_chan->is_multi_fifo = dma_spec->args[2] & FSL_EDMA_MULTI_FIFO;
++		if (!b_chmux && i != dma_spec->args[0])
++			continue;
+ 
+ 		if ((dma_spec->args[2] & FSL_EDMA_EVEN_CH) && (i & 0x1))
+ 			continue;
+@@ -163,21 +161,16 @@ static struct dma_chan *fsl_edma3_xlate(struct of_phandle_args *dma_spec,
+ 		if ((dma_spec->args[2] & FSL_EDMA_ODD_CH) && !(i & 0x1))
+ 			continue;
+ 
+-		if (!b_chmux && i == dma_spec->args[0]) {
+-			chan = dma_get_slave_channel(chan);
+-			chan->device->privatecnt++;
+-			mutex_unlock(&fsl_edma->fsl_edma_mutex);
+-			return chan;
+-		} else if (b_chmux && !fsl_chan->srcid) {
+-			/* if controller support channel mux, choose a free channel */
+-			chan = dma_get_slave_channel(chan);
+-			chan->device->privatecnt++;
+-			fsl_chan->srcid = dma_spec->args[0];
+-			mutex_unlock(&fsl_edma->fsl_edma_mutex);
+-			return chan;
+-		}
++		fsl_chan->srcid = dma_spec->args[0];
++		fsl_chan->priority = dma_spec->args[1];
++		fsl_chan->is_rxchan = dma_spec->args[2] & FSL_EDMA_RX;
++		fsl_chan->is_remote = dma_spec->args[2] & FSL_EDMA_REMOTE;
++		fsl_chan->is_multi_fifo = dma_spec->args[2] & FSL_EDMA_MULTI_FIFO;
++
++		chan = dma_get_slave_channel(chan);
++		chan->device->privatecnt++;
++		return chan;
+ 	}
+-	mutex_unlock(&fsl_edma->fsl_edma_mutex);
+ 	return NULL;
+ }
+ 
+diff --git a/drivers/gpio/gpio-mxc.c b/drivers/gpio/gpio-mxc.c
+index 619b6fb9d833a4..3cdc2b218a86af 100644
+--- a/drivers/gpio/gpio-mxc.c
++++ b/drivers/gpio/gpio-mxc.c
+@@ -576,12 +576,13 @@ static bool mxc_gpio_set_pad_wakeup(struct mxc_gpio_port *port, bool enable)
+ 	unsigned long config;
+ 	bool ret = false;
+ 	int i, type;
++	bool is_imx8qm = of_device_is_compatible(port->dev->of_node, "fsl,imx8qm-gpio");
+ 
+ 	static const u32 pad_type_map[] = {
+ 		IMX_SCU_WAKEUP_OFF,		/* 0 */
+ 		IMX_SCU_WAKEUP_RISE_EDGE,	/* IRQ_TYPE_EDGE_RISING */
+ 		IMX_SCU_WAKEUP_FALL_EDGE,	/* IRQ_TYPE_EDGE_FALLING */
+-		IMX_SCU_WAKEUP_FALL_EDGE,	/* IRQ_TYPE_EDGE_BOTH */
++		IMX_SCU_WAKEUP_RISE_EDGE,	/* IRQ_TYPE_EDGE_BOTH */
+ 		IMX_SCU_WAKEUP_HIGH_LVL,	/* IRQ_TYPE_LEVEL_HIGH */
+ 		IMX_SCU_WAKEUP_OFF,		/* 5 */
+ 		IMX_SCU_WAKEUP_OFF,		/* 6 */
+@@ -596,6 +597,13 @@ static bool mxc_gpio_set_pad_wakeup(struct mxc_gpio_port *port, bool enable)
+ 				config = pad_type_map[type];
+ 			else
+ 				config = IMX_SCU_WAKEUP_OFF;
++
++			if (is_imx8qm && config == IMX_SCU_WAKEUP_FALL_EDGE) {
++				dev_warn_once(port->dev,
++					      "No falling-edge support for wakeup on i.MX8QM\n");
++				config = IMX_SCU_WAKEUP_OFF;
++			}
++
+ 			ret |= mxc_gpio_generic_config(port, i, config);
+ 		}
+ 	}
+diff --git a/drivers/gpu/drm/ast/ast_dp501.c b/drivers/gpu/drm/ast/ast_dp501.c
+index f10d53b0c94f0b..7c0a80f4da2a0e 100644
+--- a/drivers/gpu/drm/ast/ast_dp501.c
++++ b/drivers/gpu/drm/ast/ast_dp501.c
+@@ -439,7 +439,7 @@ static void ast_init_analog(struct drm_device *dev)
+ 	/* Finally, clear bits [17:16] of SCU2c */
+ 	data = ast_read32(ast, 0x1202c);
+ 	data &= 0xfffcffff;
+-	ast_write32(ast, 0, data);
++	ast_write32(ast, 0x1202c, data);
+ 
+ 	/* Disable DVO */
+ 	ast_set_index_reg_mask(ast, AST_IO_CRTC_PORT, 0xa3, 0xcf, 0x00);
+diff --git a/drivers/gpu/drm/drm_ioc32.c b/drivers/gpu/drm/drm_ioc32.c
+index 49a743f62b4a2b..7afa24cf305e0f 100644
+--- a/drivers/gpu/drm/drm_ioc32.c
++++ b/drivers/gpu/drm/drm_ioc32.c
+@@ -28,6 +28,7 @@
+  * IN THE SOFTWARE.
+  */
+ #include <linux/compat.h>
++#include <linux/nospec.h>
+ #include <linux/ratelimit.h>
+ #include <linux/export.h>
+ 
+@@ -983,6 +984,7 @@ long drm_compat_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+ 	if (nr >= ARRAY_SIZE(drm_compat_ioctls))
+ 		return drm_ioctl(filp, cmd, arg);
+ 
++	nr = array_index_nospec(nr, ARRAY_SIZE(drm_compat_ioctls));
+ 	fn = drm_compat_ioctls[nr].fn;
+ 	if (!fn)
+ 		return drm_ioctl(filp, cmd, arg);
+diff --git a/drivers/gpu/drm/i915/display/g4x_dp.c b/drivers/gpu/drm/i915/display/g4x_dp.c
+index e8ee0a08947e8f..f2ccd44ed1a0ed 100644
+--- a/drivers/gpu/drm/i915/display/g4x_dp.c
++++ b/drivers/gpu/drm/i915/display/g4x_dp.c
+@@ -132,7 +132,7 @@ static void intel_dp_prepare(struct intel_encoder *encoder,
+ 			intel_dp->DP |= DP_SYNC_VS_HIGH;
+ 		intel_dp->DP |= DP_LINK_TRAIN_OFF_CPT;
+ 
+-		if (drm_dp_enhanced_frame_cap(intel_dp->dpcd))
++		if (pipe_config->enhanced_framing)
+ 			intel_dp->DP |= DP_ENHANCED_FRAMING;
+ 
+ 		intel_dp->DP |= DP_PIPE_SEL_IVB(crtc->pipe);
+diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
+index b6c2cb7153fde3..0039508943626d 100644
+--- a/drivers/hid/hid-multitouch.c
++++ b/drivers/hid/hid-multitouch.c
+@@ -472,12 +472,19 @@ static void mt_get_feature(struct hid_device *hdev, struct hid_report *report)
+ 		dev_warn(&hdev->dev, "failed to fetch feature %d\n",
+ 			 report->id);
+ 	} else {
++		/* The report ID in the request and the response should match */
++		if (report->id != buf[0]) {
++			hid_err(hdev, "Returned feature report did not match the request\n");
++			goto free;
++		}
++
+ 		ret = hid_report_raw_event(hdev, HID_FEATURE_REPORT, buf,
+ 					   size, 0);
+ 		if (ret)
+ 			dev_warn(&hdev->dev, "failed to report feature\n");
+ 	}
+ 
++free:
+ 	kfree(buf);
+ }
+ 
+diff --git a/drivers/hid/wacom_wac.c b/drivers/hid/wacom_wac.c
+index 42bc8f05e26358..859d0d9c5894ef 100644
+--- a/drivers/hid/wacom_wac.c
++++ b/drivers/hid/wacom_wac.c
+@@ -1256,10 +1256,20 @@ static int wacom_intuos_bt_irq(struct wacom_wac *wacom, size_t len)
+ 
+ 	switch (data[0]) {
+ 	case 0x04:
++		if (len < 32) {
++			dev_warn(wacom->pen_input->dev.parent,
++				 "Report 0x04 too short: %zu bytes\n", len);
++			break;
++		}
+ 		wacom_intuos_bt_process_data(wacom, data + i);
+ 		i += 10;
+ 		fallthrough;
+ 	case 0x03:
++		if (i == 1 && len < 22) {
++			dev_warn(wacom->pen_input->dev.parent,
++				 "Report 0x03 too short: %zu bytes\n", len);
++			break;
++		}
+ 		wacom_intuos_bt_process_data(wacom, data + i);
+ 		i += 10;
+ 		wacom_intuos_bt_process_data(wacom, data + i);
+diff --git a/drivers/hwmon/occ/common.c b/drivers/hwmon/occ/common.c
+index 755926fa0bf7d9..58a103073fbc60 100644
+--- a/drivers/hwmon/occ/common.c
++++ b/drivers/hwmon/occ/common.c
+@@ -420,6 +420,12 @@ static ssize_t occ_show_freq_2(struct device *dev,
+ 	return sysfs_emit(buf, "%u\n", val);
+ }
+ 
++static u64 occ_get_powr_avg(u64 accum, u32 samples)
++{
++	return (samples == 0) ? 0 :
++		mul_u64_u32_div(accum, 1000000UL, samples);
++}
++
+ static ssize_t occ_show_power_1(struct device *dev,
+ 				struct device_attribute *attr, char *buf)
+ {
+@@ -441,9 +447,8 @@ static ssize_t occ_show_power_1(struct device *dev,
+ 		val = get_unaligned_be16(&power->sensor_id);
+ 		break;
+ 	case 1:
+-		val = get_unaligned_be32(&power->accumulator) /
+-			get_unaligned_be32(&power->update_tag);
+-		val *= 1000000ULL;
++		val = occ_get_powr_avg(get_unaligned_be32(&power->accumulator),
++				       get_unaligned_be32(&power->update_tag));
+ 		break;
+ 	case 2:
+ 		val = (u64)get_unaligned_be32(&power->update_tag) *
+@@ -459,12 +464,6 @@ static ssize_t occ_show_power_1(struct device *dev,
+ 	return sysfs_emit(buf, "%llu\n", val);
+ }
+ 
+-static u64 occ_get_powr_avg(u64 accum, u32 samples)
+-{
+-	return (samples == 0) ? 0 :
+-		mul_u64_u32_div(accum, 1000000UL, samples);
+-}
+-
+ static ssize_t occ_show_power_2(struct device *dev,
+ 				struct device_attribute *attr, char *buf)
+ {
+@@ -725,7 +724,7 @@ static ssize_t occ_show_extended(struct device *dev,
+ 	switch (sattr->nr) {
+ 	case 0:
+ 		if (extn->flags & EXTN_FLAG_SENSOR_ID) {
+-			rc = sysfs_emit(buf, "%u",
++			rc = sysfs_emit(buf, "%u\n",
+ 					get_unaligned_be32(&extn->sensor_id));
+ 		} else {
+ 			rc = sysfs_emit(buf, "%4phN\n", extn->name);
+diff --git a/drivers/hwmon/pmbus/pxe1610.c b/drivers/hwmon/pmbus/pxe1610.c
+index e2790a682dc80c..d37e389b50d763 100644
+--- a/drivers/hwmon/pmbus/pxe1610.c
++++ b/drivers/hwmon/pmbus/pxe1610.c
+@@ -104,7 +104,10 @@ static int pxe1610_probe(struct i2c_client *client)
+ 	 * By default this device doesn't boot to page 0, so set page 0
+ 	 * to access all pmbus registers.
+ 	 */
+-	i2c_smbus_write_byte_data(client, PMBUS_PAGE, 0);
++	ret = i2c_smbus_write_byte_data(client, PMBUS_PAGE, 0);
++	if (ret < 0)
++		return dev_err_probe(&client->dev, ret,
++				     "Failed to set page 0\n");
+ 
+ 	/* Read Manufacturer id */
+ 	ret = i2c_smbus_read_block_data(client, PMBUS_MFR_ID, buf);
+diff --git a/drivers/hwmon/pmbus/tps53679.c b/drivers/hwmon/pmbus/tps53679.c
+index 5c9466244d70d1..ecc1be33b3b1b9 100644
+--- a/drivers/hwmon/pmbus/tps53679.c
++++ b/drivers/hwmon/pmbus/tps53679.c
+@@ -156,8 +156,8 @@ static int tps53676_identify(struct i2c_client *client,
+ 	ret = i2c_smbus_read_block_data(client, PMBUS_IC_DEVICE_ID, buf);
+ 	if (ret < 0)
+ 		return ret;
+-	if (strncmp("TI\x53\x67\x60", buf, 5)) {
+-		dev_err(&client->dev, "Unexpected device ID: %s\n", buf);
++	if (ret != 6 || memcmp(buf, "TI\x53\x67\x60\x00", 6)) {
++		dev_err(&client->dev, "Unexpected device ID: %*ph\n", ret, buf);
+ 		return -ENODEV;
+ 	}
+ 
+diff --git a/drivers/i2c/busses/Kconfig b/drivers/i2c/busses/Kconfig
+index 8d4270664ebd11..79ab924a4b2b9f 100644
+--- a/drivers/i2c/busses/Kconfig
++++ b/drivers/i2c/busses/Kconfig
+@@ -1139,6 +1139,8 @@ config I2C_TEGRA
+ 	tristate "NVIDIA Tegra internal I2C controller"
+ 	depends on ARCH_TEGRA || (COMPILE_TEST && (ARC || ARM || ARM64 || M68K || RISCV || SUPERH || SPARC))
+ 	# COMPILE_TEST needs architectures with readsX()/writesX() primitives
++	depends on PINCTRL
++	# ARCH_TEGRA implies PINCTRL, but the COMPILE_TEST side doesn't.
+ 	help
+ 	  If you say yes to this option, support will be included for the
+ 	  I2C controller embedded in NVIDIA Tegra SOCs
+diff --git a/drivers/i2c/busses/i2c-tegra.c b/drivers/i2c/busses/i2c-tegra.c
+index 5766231b13cd17..a882f0f65d82a5 100644
+--- a/drivers/i2c/busses/i2c-tegra.c
++++ b/drivers/i2c/busses/i2c-tegra.c
+@@ -1788,8 +1788,11 @@ static int tegra_i2c_probe(struct platform_device *pdev)
+ 	 *
+ 	 * VI I2C device shouldn't be marked as IRQ-safe because VI I2C won't
+ 	 * be used for atomic transfers. ACPI device is not IRQ safe also.
++	 *
++	 * Devices with pinctrl states cannot be marked IRQ-safe as the pinctrl
++	 * state transitions during runtime PM require mutexes.
+ 	 */
+-	if (!IS_VI(i2c_dev) && !has_acpi_companion(i2c_dev->dev))
++	if (!IS_VI(i2c_dev) && !has_acpi_companion(i2c_dev->dev) && !i2c_dev->dev->pins)
+ 		pm_runtime_irq_safe(i2c_dev->dev);
+ 
+ 	pm_runtime_enable(i2c_dev->dev);
+diff --git a/drivers/iio/accel/adxl355_core.c b/drivers/iio/accel/adxl355_core.c
+index 93b8bd6f929dab..4493c96c576a29 100644
+--- a/drivers/iio/accel/adxl355_core.c
++++ b/drivers/iio/accel/adxl355_core.c
+@@ -745,7 +745,7 @@ static const struct iio_chan_spec adxl355_channels[] = {
+ 				      BIT(IIO_CHAN_INFO_OFFSET),
+ 		.scan_index = 3,
+ 		.scan_type = {
+-			.sign = 's',
++			.sign = 'u',
+ 			.realbits = 12,
+ 			.storagebits = 16,
+ 			.endianness = IIO_BE,
+diff --git a/drivers/iio/adc/ti-adc161s626.c b/drivers/iio/adc/ti-adc161s626.c
+index b789891dcf490e..0b5efbdc573e30 100644
+--- a/drivers/iio/adc/ti-adc161s626.c
++++ b/drivers/iio/adc/ti-adc161s626.c
+@@ -15,6 +15,7 @@
+ #include <linux/init.h>
+ #include <linux/err.h>
+ #include <linux/spi/spi.h>
++#include <asm/unaligned.h>
+ #include <linux/iio/iio.h>
+ #include <linux/iio/trigger.h>
+ #include <linux/iio/buffer.h>
+@@ -70,8 +71,7 @@ struct ti_adc_data {
+ 
+ 	u8 read_size;
+ 	u8 shift;
+-
+-	u8 buffer[16] __aligned(IIO_DMA_MINALIGN);
++	u8 buf[3] __aligned(IIO_DMA_MINALIGN);
+ };
+ 
+ static int ti_adc_read_measurement(struct ti_adc_data *data,
+@@ -80,26 +80,20 @@ static int ti_adc_read_measurement(struct ti_adc_data *data,
+ 	int ret;
+ 
+ 	switch (data->read_size) {
+-	case 2: {
+-		__be16 buf;
+-
+-		ret = spi_read(data->spi, (void *) &buf, 2);
++	case 2:
++		ret = spi_read(data->spi, data->buf, 2);
+ 		if (ret)
+ 			return ret;
+ 
+-		*val = be16_to_cpu(buf);
++		*val = get_unaligned_be16(data->buf);
+ 		break;
+-	}
+-	case 3: {
+-		__be32 buf;
+-
+-		ret = spi_read(data->spi, (void *) &buf, 3);
++	case 3:
++		ret = spi_read(data->spi, data->buf, 3);
+ 		if (ret)
+ 			return ret;
+ 
+-		*val = be32_to_cpu(buf) >> 8;
++		*val = get_unaligned_be24(data->buf);
+ 		break;
+-	}
+ 	default:
+ 		return -EINVAL;
+ 	}
+@@ -114,15 +108,20 @@ static irqreturn_t ti_adc_trigger_handler(int irq, void *private)
+ 	struct iio_poll_func *pf = private;
+ 	struct iio_dev *indio_dev = pf->indio_dev;
+ 	struct ti_adc_data *data = iio_priv(indio_dev);
+-	int ret;
++	struct {
++		s16 data;
++		aligned_s64 timestamp;
++	} scan = { };
++	int ret, val;
++
++	ret = ti_adc_read_measurement(data, &indio_dev->channels[0], &val);
++	if (ret)
++		goto exit_notify_done;
+ 
+-	ret = ti_adc_read_measurement(data, &indio_dev->channels[0],
+-				     (int *) &data->buffer);
+-	if (!ret)
+-		iio_push_to_buffers_with_timestamp(indio_dev,
+-					data->buffer,
+-					iio_get_time_ns(indio_dev));
++	scan.data = val;
++	iio_push_to_buffers_with_timestamp(indio_dev, &scan, iio_get_time_ns(indio_dev));
+ 
++ exit_notify_done:
+ 	iio_trigger_notify_done(indio_dev->trig);
+ 
+ 	return IRQ_HANDLED;
+diff --git a/drivers/iio/dac/ad5770r.c b/drivers/iio/dac/ad5770r.c
+index f66d67402e4365..69b6ba343032a3 100644
+--- a/drivers/iio/dac/ad5770r.c
++++ b/drivers/iio/dac/ad5770r.c
+@@ -323,7 +323,7 @@ static int ad5770r_read_raw(struct iio_dev *indio_dev,
+ 				       chan->address,
+ 				       st->transf_buf, 2);
+ 		if (ret)
+-			return 0;
++			return ret;
+ 
+ 		buf16 = st->transf_buf[0] + (st->transf_buf[1] << 8);
+ 		*val = buf16 >> 2;
+diff --git a/drivers/iio/gyro/mpu3050-core.c b/drivers/iio/gyro/mpu3050-core.c
+index b50c62412d2050..695269359621ad 100644
+--- a/drivers/iio/gyro/mpu3050-core.c
++++ b/drivers/iio/gyro/mpu3050-core.c
+@@ -1139,11 +1139,16 @@ static int mpu3050_trigger_probe(struct iio_dev *indio_dev, int irq)
+ 
+ 	ret = iio_trigger_register(mpu3050->trig);
+ 	if (ret)
+-		return ret;
++		goto err_iio_trigger;
+ 
+ 	indio_dev->trig = iio_trigger_get(mpu3050->trig);
+ 
+ 	return 0;
++
++err_iio_trigger:
++	free_irq(mpu3050->irq, mpu3050->trig);
++
++	return ret;
+ }
+ 
+ int mpu3050_common_probe(struct device *dev,
+@@ -1231,12 +1236,6 @@ int mpu3050_common_probe(struct device *dev,
+ 		goto err_power_down;
+ 	}
+ 
+-	ret = iio_device_register(indio_dev);
+-	if (ret) {
+-		dev_err(dev, "device register failed\n");
+-		goto err_cleanup_buffer;
+-	}
+-
+ 	dev_set_drvdata(dev, indio_dev);
+ 
+ 	/* Check if we have an assigned IRQ to use as trigger */
+@@ -1259,9 +1258,20 @@ int mpu3050_common_probe(struct device *dev,
+ 	pm_runtime_use_autosuspend(dev);
+ 	pm_runtime_put(dev);
+ 
++	ret = iio_device_register(indio_dev);
++	if (ret) {
++		dev_err(dev, "device register failed\n");
++		goto err_iio_device_register;
++	}
++
+ 	return 0;
+ 
+-err_cleanup_buffer:
++err_iio_device_register:
++	pm_runtime_get_sync(dev);
++	pm_runtime_put_noidle(dev);
++	pm_runtime_disable(dev);
++	if (irq)
++		free_irq(mpu3050->irq, mpu3050->trig);
+ 	iio_triggered_buffer_cleanup(indio_dev);
+ err_power_down:
+ 	mpu3050_power_down(mpu3050);
+@@ -1274,13 +1284,13 @@ void mpu3050_common_remove(struct device *dev)
+ 	struct iio_dev *indio_dev = dev_get_drvdata(dev);
+ 	struct mpu3050 *mpu3050 = iio_priv(indio_dev);
+ 
++	iio_device_unregister(indio_dev);
+ 	pm_runtime_get_sync(dev);
+ 	pm_runtime_put_noidle(dev);
+ 	pm_runtime_disable(dev);
+-	iio_triggered_buffer_cleanup(indio_dev);
+ 	if (mpu3050->irq)
+-		free_irq(mpu3050->irq, mpu3050);
+-	iio_device_unregister(indio_dev);
++		free_irq(mpu3050->irq, mpu3050->trig);
++	iio_triggered_buffer_cleanup(indio_dev);
+ 	mpu3050_power_down(mpu3050);
+ }
+ 
+diff --git a/drivers/iio/imu/bmi160/bmi160_core.c b/drivers/iio/imu/bmi160/bmi160_core.c
+index a77f1a8348ffcb..3e98a7110cbe31 100644
+--- a/drivers/iio/imu/bmi160/bmi160_core.c
++++ b/drivers/iio/imu/bmi160/bmi160_core.c
+@@ -568,12 +568,16 @@ static int bmi160_config_pin(struct regmap *regmap, enum bmi160_int_pin pin,
+ 		int_out_ctrl_shift = BMI160_INT1_OUT_CTRL_SHIFT;
+ 		int_latch_mask = BMI160_INT1_LATCH_MASK;
+ 		int_map_mask = BMI160_INT1_MAP_DRDY_EN;
++		pin_name = "INT1";
+ 		break;
+ 	case BMI160_PIN_INT2:
+ 		int_out_ctrl_shift = BMI160_INT2_OUT_CTRL_SHIFT;
+ 		int_latch_mask = BMI160_INT2_LATCH_MASK;
+ 		int_map_mask = BMI160_INT2_MAP_DRDY_EN;
++		pin_name = "INT2";
+ 		break;
++	default:
++		return -EINVAL;
+ 	}
+ 	int_out_ctrl_mask = BMI160_INT_OUT_CTRL_MASK << int_out_ctrl_shift;
+ 
+@@ -607,17 +611,8 @@ static int bmi160_config_pin(struct regmap *regmap, enum bmi160_int_pin pin,
+ 	ret = bmi160_write_conf_reg(regmap, BMI160_REG_INT_MAP,
+ 				    int_map_mask, int_map_mask,
+ 				    write_usleep);
+-	if (ret) {
+-		switch (pin) {
+-		case BMI160_PIN_INT1:
+-			pin_name = "INT1";
+-			break;
+-		case BMI160_PIN_INT2:
+-			pin_name = "INT2";
+-			break;
+-		}
++	if (ret)
+ 		dev_err(dev, "Failed to configure %s IRQ pin", pin_name);
+-	}
+ 
+ 	return ret;
+ }
+diff --git a/drivers/iio/imu/bno055/bno055.c b/drivers/iio/imu/bno055/bno055.c
+index 98f17c29da69bd..7b58b418b8a8ba 100644
+--- a/drivers/iio/imu/bno055/bno055.c
++++ b/drivers/iio/imu/bno055/bno055.c
+@@ -64,7 +64,7 @@
+ #define BNO055_GRAVITY_DATA_X_LSB_REG	0x2E
+ #define BNO055_GRAVITY_DATA_Y_LSB_REG	0x30
+ #define BNO055_GRAVITY_DATA_Z_LSB_REG	0x32
+-#define BNO055_SCAN_CH_COUNT ((BNO055_GRAVITY_DATA_Z_LSB_REG - BNO055_ACC_DATA_X_LSB_REG) / 2)
++#define BNO055_SCAN_CH_COUNT ((BNO055_GRAVITY_DATA_Z_LSB_REG - BNO055_ACC_DATA_X_LSB_REG) / 2 + 1)
+ #define BNO055_TEMP_REG			0x34
+ #define BNO055_CALIB_STAT_REG		0x35
+ #define BNO055_CALIB_STAT_MAGN_SHIFT 0
+diff --git a/drivers/iio/imu/inv_icm42600/inv_icm42600_buffer.c b/drivers/iio/imu/inv_icm42600/inv_icm42600_buffer.c
+index aca6ce75889053..743580ea5845e8 100644
+--- a/drivers/iio/imu/inv_icm42600/inv_icm42600_buffer.c
++++ b/drivers/iio/imu/inv_icm42600/inv_icm42600_buffer.c
+@@ -378,6 +378,7 @@ out_unlock:
+ static int inv_icm42600_buffer_postdisable(struct iio_dev *indio_dev)
+ {
+ 	struct inv_icm42600_state *st = iio_device_get_drvdata(indio_dev);
++	struct inv_sensors_timestamp *ts = iio_priv(indio_dev);
+ 	struct device *dev = regmap_get_device(st->map);
+ 	unsigned int sensor;
+ 	unsigned int *watermark;
+@@ -399,6 +400,8 @@ static int inv_icm42600_buffer_postdisable(struct iio_dev *indio_dev)
+ 
+ 	mutex_lock(&st->lock);
+ 
++	inv_sensors_timestamp_apply_odr(ts, 0, 0, 0);
++
+ 	ret = inv_icm42600_buffer_set_fifo_en(st, st->fifo.en & ~sensor);
+ 	if (ret)
+ 		goto out_unlock;
+diff --git a/drivers/iio/imu/st_lsm6dsx/st_lsm6dsx_buffer.c b/drivers/iio/imu/st_lsm6dsx/st_lsm6dsx_buffer.c
+index b8119fa4768eb8..d00e82b9c3bbea 100644
+--- a/drivers/iio/imu/st_lsm6dsx/st_lsm6dsx_buffer.c
++++ b/drivers/iio/imu/st_lsm6dsx/st_lsm6dsx_buffer.c
+@@ -202,6 +202,10 @@ static int st_lsm6dsx_set_fifo_odr(struct st_lsm6dsx_sensor *sensor,
+ 	const struct st_lsm6dsx_reg *batch_reg;
+ 	u8 data;
+ 
++	/* Only internal sensors have a FIFO ODR configuration register. */
++	if (sensor->id >= ARRAY_SIZE(hw->settings->batch))
++		return 0;
++
+ 	batch_reg = &hw->settings->batch[sensor->id];
+ 	if (batch_reg->addr) {
+ 		int val;
+diff --git a/drivers/iio/light/vcnl4035.c b/drivers/iio/light/vcnl4035.c
+index fe3c4c5db6205d..d4a72c5184ba69 100644
+--- a/drivers/iio/light/vcnl4035.c
++++ b/drivers/iio/light/vcnl4035.c
+@@ -105,17 +105,23 @@ static irqreturn_t vcnl4035_trigger_consumer_handler(int irq, void *p)
+ 	struct iio_dev *indio_dev = pf->indio_dev;
+ 	struct vcnl4035_data *data = iio_priv(indio_dev);
+ 	/* Ensure naturally aligned timestamp */
+-	u8 buffer[ALIGN(sizeof(u16), sizeof(s64)) + sizeof(s64)]  __aligned(8) = { };
++	struct {
++		u16 als_data;
++		aligned_s64 timestamp;
++	} buffer = { };
++	unsigned int val;
+ 	int ret;
+ 
+-	ret = regmap_read(data->regmap, VCNL4035_ALS_DATA, (int *)buffer);
++	ret = regmap_read(data->regmap, VCNL4035_ALS_DATA, &val);
+ 	if (ret < 0) {
+ 		dev_err(&data->client->dev,
+ 			"Trigger consumer can't read from sensor.\n");
+ 		goto fail_read;
+ 	}
+-	iio_push_to_buffers_with_timestamp(indio_dev, buffer,
+-					iio_get_time_ns(indio_dev));
++
++	buffer.als_data = val;
++	iio_push_to_buffers_with_timestamp(indio_dev, &buffer,
++					   iio_get_time_ns(indio_dev));
+ 
+ fail_read:
+ 	iio_trigger_notify_done(indio_dev->trig);
+@@ -378,7 +384,7 @@ static const struct iio_chan_spec vcnl4035_channels[] = {
+ 			.sign = 'u',
+ 			.realbits = 16,
+ 			.storagebits = 16,
+-			.endianness = IIO_LE,
++			.endianness = IIO_CPU,
+ 		},
+ 	},
+ 	{
+@@ -392,7 +398,7 @@ static const struct iio_chan_spec vcnl4035_channels[] = {
+ 			.sign = 'u',
+ 			.realbits = 16,
+ 			.storagebits = 16,
+-			.endianness = IIO_LE,
++			.endianness = IIO_CPU,
+ 		},
+ 	},
+ };
+diff --git a/drivers/input/joystick/xpad.c b/drivers/input/joystick/xpad.c
+index 09fcc14051f285..fc484b35e776a2 100644
+--- a/drivers/input/joystick/xpad.c
++++ b/drivers/input/joystick/xpad.c
+@@ -307,6 +307,8 @@ static const struct xpad_device {
+ 	{ 0x1532, 0x0a00, "Razer Atrox Arcade Stick", MAP_TRIGGERS_TO_BUTTONS, XTYPE_XBOXONE },
+ 	{ 0x1532, 0x0a03, "Razer Wildcat", 0, XTYPE_XBOXONE },
+ 	{ 0x1532, 0x0a29, "Razer Wolverine V2", 0, XTYPE_XBOXONE },
++	{ 0x1532, 0x0a57, "Razer Wolverine V3 Pro (Wired)", 0, XTYPE_XBOX360 },
++	{ 0x1532, 0x0a59, "Razer Wolverine V3 Pro (2.4 GHz Dongle)", 0, XTYPE_XBOX360 },
+ 	{ 0x15e4, 0x3f00, "Power A Mini Pro Elite", 0, XTYPE_XBOX360 },
+ 	{ 0x15e4, 0x3f0a, "Xbox Airflo wired controller", 0, XTYPE_XBOX360 },
+ 	{ 0x15e4, 0x3f10, "Batarang Xbox 360 controller", 0, XTYPE_XBOX360 },
+@@ -354,6 +356,8 @@ static const struct xpad_device {
+ 	{ 0x1bad, 0xfd00, "Razer Onza TE", 0, XTYPE_XBOX360 },
+ 	{ 0x1bad, 0xfd01, "Razer Onza", 0, XTYPE_XBOX360 },
+ 	{ 0x1ee9, 0x1590, "ZOTAC Gaming Zone", 0, XTYPE_XBOX360 },
++	{ 0x20bc, 0x5134, "BETOP BTP-KP50B Xinput Dongle", 0, XTYPE_XBOX360 },
++	{ 0x20bc, 0x514a, "BETOP BTP-KP50C Xinput Dongle", 0, XTYPE_XBOX360 },
+ 	{ 0x20d6, 0x2001, "BDA Xbox Series X Wired Controller", 0, XTYPE_XBOXONE },
+ 	{ 0x20d6, 0x2009, "PowerA Enhanced Wired Controller for Xbox Series X|S", 0, XTYPE_XBOXONE },
+ 	{ 0x20d6, 0x2064, "PowerA Wired Controller for Xbox", MAP_SHARE_BUTTON, XTYPE_XBOXONE },
+@@ -547,6 +551,7 @@ static const struct usb_device_id xpad_table[] = {
+ 	XPAD_XBOX360_VENDOR(0x1a86),		/* Nanjing Qinheng Microelectronics (WCH) */
+ 	XPAD_XBOX360_VENDOR(0x1bad),		/* Harmonix Rock Band guitar and drums */
+ 	XPAD_XBOX360_VENDOR(0x1ee9),		/* ZOTAC Technology Limited */
++	XPAD_XBOX360_VENDOR(0x20bc),		/* BETOP wireless dongles */
+ 	XPAD_XBOX360_VENDOR(0x20d6),		/* PowerA controllers */
+ 	XPAD_XBOXONE_VENDOR(0x20d6),		/* PowerA controllers */
+ 	XPAD_XBOX360_VENDOR(0x24c6),		/* PowerA controllers */
+diff --git a/drivers/input/rmi4/rmi_f54.c b/drivers/input/rmi4/rmi_f54.c
+index 5c3da910b5b2ce..a035b04b43ce59 100644
+--- a/drivers/input/rmi4/rmi_f54.c
++++ b/drivers/input/rmi4/rmi_f54.c
+@@ -540,6 +540,8 @@ static void rmi_f54_work(struct work_struct *work)
+ 	int error;
+ 	int i;
+ 
++	mutex_lock(&f54->data_mutex);
++
+ 	report_size = rmi_f54_get_report_size(f54);
+ 	if (report_size == 0) {
+ 		dev_err(&fn->dev, "Bad report size, report type=%d\n",
+@@ -548,8 +550,6 @@ static void rmi_f54_work(struct work_struct *work)
+ 		goto error;     /* retry won't help */
+ 	}
+ 
+-	mutex_lock(&f54->data_mutex);
+-
+ 	/*
+ 	 * Need to check if command has completed.
+ 	 * If not try again later.
+diff --git a/drivers/input/serio/i8042-acpipnpio.h b/drivers/input/serio/i8042-acpipnpio.h
+index d492aa93a7c3ca..0cf55ec6d0b404 100644
+--- a/drivers/input/serio/i8042-acpipnpio.h
++++ b/drivers/input/serio/i8042-acpipnpio.h
+@@ -1187,6 +1187,13 @@ static const struct dmi_system_id i8042_dmi_quirk_table[] __initconst = {
+ 		.driver_data = (void *)(SERIO_QUIRK_NOMUX | SERIO_QUIRK_RESET_ALWAYS |
+ 					SERIO_QUIRK_NOLOOP | SERIO_QUIRK_NOPNP)
+ 	},
++	{
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "X6KK45xU_X6SP45xU"),
++		},
++		.driver_data = (void *)(SERIO_QUIRK_NOMUX | SERIO_QUIRK_RESET_ALWAYS |
++					SERIO_QUIRK_NOLOOP | SERIO_QUIRK_NOPNP)
++	},
+ 	{
+ 		.matches = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "WUJIE Series-X5SP4NAG"),
+diff --git a/drivers/misc/fastrpc.c b/drivers/misc/fastrpc.c
+index c110fb606dfb8b..30f10e79cc6ee9 100644
+--- a/drivers/misc/fastrpc.c
++++ b/drivers/misc/fastrpc.c
+@@ -1374,6 +1374,7 @@ err_invoke:
+ 	}
+ err_map:
+ 	fastrpc_buf_free(fl->cctx->remote_heap);
++	fl->cctx->remote_heap = NULL;
+ err_name:
+ 	kfree(name);
+ err:
+diff --git a/drivers/net/ethernet/broadcom/tg3.c b/drivers/net/ethernet/broadcom/tg3.c
+index ea4973096aa287..1ffd98a1c74172 100644
+--- a/drivers/net/ethernet/broadcom/tg3.c
++++ b/drivers/net/ethernet/broadcom/tg3.c
+@@ -12212,7 +12212,7 @@ static int tg3_get_link_ksettings(struct net_device *dev,
+ 	ethtool_convert_legacy_u32_to_link_mode(cmd->link_modes.advertising,
+ 						advertising);
+ 
+-	if (netif_running(dev) && tp->link_up) {
++	if (netif_running(dev) && netif_carrier_ok(dev)) {
+ 		cmd->base.speed = tp->link_config.active_speed;
+ 		cmd->base.duplex = tp->link_config.active_duplex;
+ 		ethtool_convert_legacy_u32_to_link_mode(
+@@ -16945,6 +16945,13 @@ static int tg3_get_invariants(struct tg3 *tp, const struct pci_device_id *ent)
+ 	return err;
+ }
+ 
++static int tg3_is_default_mac_address(u8 *addr)
++{
++	static const u8 default_mac_address[ETH_ALEN] = { 0x00, 0x10, 0x18, 0x00, 0x00, 0x00 };
++
++	return ether_addr_equal(default_mac_address, addr);
++}
++
+ static int tg3_get_device_address(struct tg3 *tp, u8 *addr)
+ {
+ 	u32 hi, lo, mac_offset;
+@@ -17016,6 +17023,10 @@ static int tg3_get_device_address(struct tg3 *tp, u8 *addr)
+ 
+ 	if (!is_valid_ether_addr(addr))
+ 		return -EINVAL;
++
++	if (tg3_is_default_mac_address(addr))
++		return device_get_mac_address(&tp->pdev->dev, addr);
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/net/ethernet/cadence/macb_main.c b/drivers/net/ethernet/cadence/macb_main.c
+index 743dd6e31a62d6..aac62db4ee1460 100644
+--- a/drivers/net/ethernet/cadence/macb_main.c
++++ b/drivers/net/ethernet/cadence/macb_main.c
+@@ -5384,6 +5384,8 @@ static int __maybe_unused macb_suspend(struct device *dev)
+ 		macb_writel(bp, TSR, -1);
+ 		macb_writel(bp, RSR, -1);
+ 
++		spin_unlock_irqrestore(&bp->lock, flags);
++
+ 		/* Change interrupt handler and
+ 		 * Enable WoL IRQ on queue 0
+ 		 */
+@@ -5395,11 +5397,12 @@ static int __maybe_unused macb_suspend(struct device *dev)
+ 				dev_err(dev,
+ 					"Unable to request IRQ %d (error %d)\n",
+ 					bp->queues[0].irq, err);
+-				spin_unlock_irqrestore(&bp->lock, flags);
+ 				return err;
+ 			}
++			spin_lock_irqsave(&bp->lock, flags);
+ 			queue_writel(bp->queues, IER, GEM_BIT(WOL));
+ 			gem_writel(bp, WOL, MACB_BIT(MAG));
++			spin_unlock_irqrestore(&bp->lock, flags);
+ 		} else {
+ 			err = devm_request_irq(dev, bp->queues[0].irq, macb_wol_interrupt,
+ 					       IRQF_SHARED, netdev->name, bp->queues);
+@@ -5407,13 +5410,13 @@ static int __maybe_unused macb_suspend(struct device *dev)
+ 				dev_err(dev,
+ 					"Unable to request IRQ %d (error %d)\n",
+ 					bp->queues[0].irq, err);
+-				spin_unlock_irqrestore(&bp->lock, flags);
+ 				return err;
+ 			}
++			spin_lock_irqsave(&bp->lock, flags);
+ 			queue_writel(bp->queues, IER, MACB_BIT(WOL));
+ 			macb_writel(bp, WOL, MACB_BIT(MAG));
++			spin_unlock_irqrestore(&bp->lock, flags);
+ 		}
+-		spin_unlock_irqrestore(&bp->lock, flags);
+ 
+ 		enable_irq_wake(bp->queues[0].irq);
+ 	}
+@@ -5480,6 +5483,8 @@ static int __maybe_unused macb_resume(struct device *dev)
+ 		queue_readl(bp->queues, ISR);
+ 		if (bp->caps & MACB_CAPS_ISR_CLEAR_ON_WRITE)
+ 			queue_writel(bp->queues, ISR, -1);
++		spin_unlock_irqrestore(&bp->lock, flags);
++
+ 		/* Replace interrupt handler on queue 0 */
+ 		devm_free_irq(dev, bp->queues[0].irq, bp->queues);
+ 		err = devm_request_irq(dev, bp->queues[0].irq, macb_interrupt,
+@@ -5488,10 +5493,8 @@ static int __maybe_unused macb_resume(struct device *dev)
+ 			dev_err(dev,
+ 				"Unable to request IRQ %d (error %d)\n",
+ 				bp->queues[0].irq, err);
+-			spin_unlock_irqrestore(&bp->lock, flags);
+ 			return err;
+ 		}
+-		spin_unlock_irqrestore(&bp->lock, flags);
+ 
+ 		disable_irq_wake(bp->queues[0].irq);
+ 
+diff --git a/drivers/net/ethernet/cadence/macb_pci.c b/drivers/net/ethernet/cadence/macb_pci.c
+index f66d22de5168d2..34e249e0e5860b 100644
+--- a/drivers/net/ethernet/cadence/macb_pci.c
++++ b/drivers/net/ethernet/cadence/macb_pci.c
+@@ -97,10 +97,10 @@ static int macb_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 	return 0;
+ 
+ err_plat_dev_register:
+-	clk_unregister(plat_data.hclk);
++	clk_unregister_fixed_rate(plat_data.hclk);
+ 
+ err_hclk_register:
+-	clk_unregister(plat_data.pclk);
++	clk_unregister_fixed_rate(plat_data.pclk);
+ 
+ err_pclk_register:
+ 	return err;
+@@ -110,10 +110,12 @@ static void macb_remove(struct pci_dev *pdev)
+ {
+ 	struct platform_device *plat_dev = pci_get_drvdata(pdev);
+ 	struct macb_platform_data *plat_data = dev_get_platdata(&plat_dev->dev);
++	struct clk *pclk = plat_data->pclk;
++	struct clk *hclk = plat_data->hclk;
+ 
+-	clk_unregister(plat_data->pclk);
+-	clk_unregister(plat_data->hclk);
+ 	platform_device_unregister(plat_dev);
++	clk_unregister_fixed_rate(pclk);
++	clk_unregister_fixed_rate(hclk);
+ }
+ 
+ static const struct pci_device_id dev_id_table[] = {
+diff --git a/drivers/net/ethernet/faraday/ftgmac100.c b/drivers/net/ethernet/faraday/ftgmac100.c
+index 848e41a4b1dbb1..2387762c37ea3e 100644
+--- a/drivers/net/ethernet/faraday/ftgmac100.c
++++ b/drivers/net/ethernet/faraday/ftgmac100.c
+@@ -934,19 +934,19 @@ static int ftgmac100_alloc_rings(struct ftgmac100 *priv)
+ 	priv->tx_skbs = kcalloc(MAX_TX_QUEUE_ENTRIES, sizeof(void *),
+ 				GFP_KERNEL);
+ 	if (!priv->tx_skbs)
+-		return -ENOMEM;
++		goto err_free_rx_skbs;
+ 
+ 	/* Allocate descriptors */
+ 	priv->rxdes = dma_alloc_coherent(priv->dev,
+ 					 MAX_RX_QUEUE_ENTRIES * sizeof(struct ftgmac100_rxdes),
+ 					 &priv->rxdes_dma, GFP_KERNEL);
+ 	if (!priv->rxdes)
+-		return -ENOMEM;
++		goto err_free_tx_skbs;
+ 	priv->txdes = dma_alloc_coherent(priv->dev,
+ 					 MAX_TX_QUEUE_ENTRIES * sizeof(struct ftgmac100_txdes),
+ 					 &priv->txdes_dma, GFP_KERNEL);
+ 	if (!priv->txdes)
+-		return -ENOMEM;
++		goto err_free_rxdes;
+ 
+ 	/* Allocate scratch packet buffer */
+ 	priv->rx_scratch = dma_alloc_coherent(priv->dev,
+@@ -954,9 +954,29 @@ static int ftgmac100_alloc_rings(struct ftgmac100 *priv)
+ 					      &priv->rx_scratch_dma,
+ 					      GFP_KERNEL);
+ 	if (!priv->rx_scratch)
+-		return -ENOMEM;
++		goto err_free_txdes;
+ 
+ 	return 0;
++
++err_free_txdes:
++	dma_free_coherent(priv->dev,
++			  MAX_TX_QUEUE_ENTRIES *
++			  sizeof(struct ftgmac100_txdes),
++			  priv->txdes, priv->txdes_dma);
++	priv->txdes = NULL;
++err_free_rxdes:
++	dma_free_coherent(priv->dev,
++			  MAX_RX_QUEUE_ENTRIES *
++			  sizeof(struct ftgmac100_rxdes),
++			  priv->rxdes, priv->rxdes_dma);
++	priv->rxdes = NULL;
++err_free_tx_skbs:
++	kfree(priv->tx_skbs);
++	priv->tx_skbs = NULL;
++err_free_rx_skbs:
++	kfree(priv->rx_skbs);
++	priv->rx_skbs = NULL;
++	return -ENOMEM;
+ }
+ 
+ static void ftgmac100_init_rings(struct ftgmac100 *priv)
+diff --git a/drivers/net/ethernet/freescale/fec_ptp.c b/drivers/net/ethernet/freescale/fec_ptp.c
+index 4bb894b5afcb99..778713c2fed402 100644
+--- a/drivers/net/ethernet/freescale/fec_ptp.c
++++ b/drivers/net/ethernet/freescale/fec_ptp.c
+@@ -546,9 +546,6 @@ static int fec_ptp_enable(struct ptp_clock_info *ptp,
+ 		if (rq->perout.flags)
+ 			return -EOPNOTSUPP;
+ 
+-		if (rq->perout.index != fep->pps_channel)
+-			return -EOPNOTSUPP;
+-
+ 		period.tv_sec = rq->perout.period.sec;
+ 		period.tv_nsec = rq->perout.period.nsec;
+ 		period_ns = timespec64_to_ns(&period);
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/devlink.c b/drivers/net/ethernet/mellanox/mlx5/core/devlink.c
+index b2532b1c9565a1..8e8c15d825325e 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/devlink.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/devlink.c
+@@ -53,9 +53,7 @@ mlx5_devlink_info_get(struct devlink *devlink, struct devlink_info_req *req,
+ 	if (err)
+ 		return err;
+ 
+-	err = mlx5_fw_version_query(dev, &running_fw, &stored_fw);
+-	if (err)
+-		return err;
++	mlx5_fw_version_query(dev, &running_fw, &stored_fw);
+ 
+ 	snprintf(version_str, sizeof(version_str), "%d.%d.%04d",
+ 		 mlx5_fw_ver_major(running_fw), mlx5_fw_ver_minor(running_fw),
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/fw.c b/drivers/net/ethernet/mellanox/mlx5/core/fw.c
+index 70898f0a9866cd..d5de2df111ab49 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/fw.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/fw.c
+@@ -802,48 +802,63 @@ mlx5_fw_image_pending(struct mlx5_core_dev *dev,
+ 	return 0;
+ }
+ 
+-int mlx5_fw_version_query(struct mlx5_core_dev *dev,
+-			  u32 *running_ver, u32 *pending_ver)
++void mlx5_fw_version_query(struct mlx5_core_dev *dev,
++			   u32 *running_ver, u32 *pending_ver)
+ {
+ 	u32 reg_mcqi_version[MLX5_ST_SZ_DW(mcqi_version)] = {};
+ 	bool pending_version_exists;
+ 	int component_index;
+ 	int err;
+ 
++	*running_ver = 0;
++	*pending_ver = 0;
++
+ 	if (!MLX5_CAP_GEN(dev, mcam_reg) || !MLX5_CAP_MCAM_REG(dev, mcqi) ||
+ 	    !MLX5_CAP_MCAM_REG(dev, mcqs)) {
+ 		mlx5_core_warn(dev, "fw query isn't supported by the FW\n");
+-		return -EOPNOTSUPP;
++		return;
+ 	}
+ 
+ 	component_index = mlx5_get_boot_img_component_index(dev);
+-	if (component_index < 0)
+-		return component_index;
++	if (component_index < 0) {
++		mlx5_core_warn(dev, "fw query failed to find boot img component index, err %d\n",
++			       component_index);
++		return;
++	}
+ 
++	*running_ver = U32_MAX; /* indicate failure */
+ 	err = mlx5_reg_mcqi_version_query(dev, component_index,
+ 					  MCQI_FW_RUNNING_VERSION,
+ 					  reg_mcqi_version);
+-	if (err)
+-		return err;
+-
+-	*running_ver = MLX5_GET(mcqi_version, reg_mcqi_version, version);
+-
++	if (!err)
++		*running_ver = MLX5_GET(mcqi_version, reg_mcqi_version,
++					version);
++	else
++		mlx5_core_warn(dev, "failed to query running version, err %d\n",
++			       err);
++
++	*pending_ver = U32_MAX; /* indicate failure */
+ 	err = mlx5_fw_image_pending(dev, component_index, &pending_version_exists);
+-	if (err)
+-		return err;
++	if (err) {
++		mlx5_core_warn(dev, "failed to query pending image, err %d\n",
++			       err);
++		return;
++	}
+ 
+ 	if (!pending_version_exists) {
+ 		*pending_ver = 0;
+-		return 0;
++		return;
+ 	}
+ 
+ 	err = mlx5_reg_mcqi_version_query(dev, component_index,
+ 					  MCQI_FW_STORED_VERSION,
+ 					  reg_mcqi_version);
+-	if (err)
+-		return err;
+-
+-	*pending_ver = MLX5_GET(mcqi_version, reg_mcqi_version, version);
+-
+-	return 0;
++	if (!err)
++		*pending_ver = MLX5_GET(mcqi_version, reg_mcqi_version,
++					version);
++	else
++		mlx5_core_warn(dev, "failed to query pending version, err %d\n",
++			       err);
++
++	return;
+ }
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/lag/debugfs.c b/drivers/net/ethernet/mellanox/mlx5/core/lag/debugfs.c
+index f4b777d4e10869..41ddca52e95475 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/lag/debugfs.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/lag/debugfs.c
+@@ -163,8 +163,11 @@ DEFINE_SHOW_ATTRIBUTE(members);
+ 
+ void mlx5_ldev_add_debugfs(struct mlx5_core_dev *dev)
+ {
++	struct mlx5_lag *ldev = mlx5_lag_dev(dev);
+ 	struct dentry *dbg;
+ 
++	if (!ldev)
++		return;
+ 	dbg = debugfs_create_dir("lag", mlx5_debugfs_get_dev_root(dev));
+ 	dev->priv.dbg.lag_debugfs = dbg;
+ 
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.h b/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.h
+index 124352459c23d9..562729cd95a873 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.h
++++ b/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.h
+@@ -269,8 +269,8 @@ void mlx5_dm_cleanup(struct mlx5_core_dev *dev);
+ 
+ int mlx5_firmware_flash(struct mlx5_core_dev *dev, const struct firmware *fw,
+ 			struct netlink_ext_ack *extack);
+-int mlx5_fw_version_query(struct mlx5_core_dev *dev,
+-			  u32 *running_ver, u32 *stored_ver);
++void mlx5_fw_version_query(struct mlx5_core_dev *dev, u32 *running_ver,
++			   u32 *stored_ver);
+ 
+ #ifdef CONFIG_MLX5_CORE_EN
+ int mlx5e_init(void);
+diff --git a/drivers/net/ethernet/microsoft/mana/mana_en.c b/drivers/net/ethernet/microsoft/mana/mana_en.c
+index 926502e5e58242..b56a337b1e212f 100644
+--- a/drivers/net/ethernet/microsoft/mana/mana_en.c
++++ b/drivers/net/ethernet/microsoft/mana/mana_en.c
+@@ -2759,6 +2759,7 @@ static int add_adev(struct gdma_dev *gd)
+ 	struct auxiliary_device *adev;
+ 	struct mana_adev *madev;
+ 	int ret;
++	int id;
+ 
+ 	madev = kzalloc(sizeof(*madev), GFP_KERNEL);
+ 	if (!madev)
+@@ -2768,7 +2769,8 @@ static int add_adev(struct gdma_dev *gd)
+ 	ret = mana_adev_idx_alloc();
+ 	if (ret < 0)
+ 		goto idx_fail;
+-	adev->id = ret;
++	id = ret;
++	adev->id = id;
+ 
+ 	adev->name = "rdma";
+ 	adev->dev.parent = gd->gdma_context->dev;
+@@ -2792,7 +2794,7 @@ add_fail:
+ 	auxiliary_device_uninit(adev);
+ 
+ init_fail:
+-	mana_adev_idx_free(adev->id);
++	mana_adev_idx_free(id);
+ 
+ idx_fail:
+ 	kfree(madev);
+diff --git a/drivers/net/ethernet/xilinx/xilinx_axienet.h b/drivers/net/ethernet/xilinx/xilinx_axienet.h
+index 2facbdfbb319e7..e6a1611b7aab2c 100644
+--- a/drivers/net/ethernet/xilinx/xilinx_axienet.h
++++ b/drivers/net/ethernet/xilinx/xilinx_axienet.h
+@@ -103,7 +103,7 @@
+ #define XAXIDMA_BD_HAS_DRE_MASK		0xF00 /* Whether has DRE mask */
+ #define XAXIDMA_BD_WORDLEN_MASK		0xFF /* Whether has DRE mask */
+ 
+-#define XAXIDMA_BD_CTRL_LENGTH_MASK	0x007FFFFF /* Requested len */
++#define XAXIDMA_BD_CTRL_LENGTH_MASK	GENMASK(25, 0) /* Requested len */
+ #define XAXIDMA_BD_CTRL_TXSOF_MASK	0x08000000 /* First tx packet */
+ #define XAXIDMA_BD_CTRL_TXEOF_MASK	0x04000000 /* Last tx packet */
+ #define XAXIDMA_BD_CTRL_ALL_MASK	0x0C000000 /* All control bits */
+@@ -129,7 +129,7 @@
+ #define XAXIDMA_BD_CTRL_TXEOF_MASK	0x04000000 /* Last tx packet */
+ #define XAXIDMA_BD_CTRL_ALL_MASK	0x0C000000 /* All control bits */
+ 
+-#define XAXIDMA_BD_STS_ACTUAL_LEN_MASK	0x007FFFFF /* Actual len */
++#define XAXIDMA_BD_STS_ACTUAL_LEN_MASK	GENMASK(25, 0) /* Actual len */
+ #define XAXIDMA_BD_STS_COMPLETE_MASK	0x80000000 /* Completed */
+ #define XAXIDMA_BD_STS_DEC_ERR_MASK	0x40000000 /* Decode error */
+ #define XAXIDMA_BD_STS_SLV_ERR_MASK	0x20000000 /* Slave error */
+diff --git a/drivers/net/phy/sfp.c b/drivers/net/phy/sfp.c
+index 00bbe20b0b43ec..165c624c985fd5 100644
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -465,10 +465,15 @@ static void sfp_quirk_ubnt_uf_instant(const struct sfp_eeprom_id *id,
+ {
+ 	/* Ubiquiti U-Fiber Instant module claims that support all transceiver
+ 	 * types including 10G Ethernet which is not truth. So clear all claimed
+-	 * modes and set only one mode which module supports: 1000baseX_Full.
++	 * modes and set only one mode which module supports: 1000baseX_Full,
++	 * along with the Autoneg and pause bits.
+ 	 */
+ 	linkmode_zero(modes);
+ 	linkmode_set_bit(ETHTOOL_LINK_MODE_1000baseX_Full_BIT, modes);
++	linkmode_set_bit(ETHTOOL_LINK_MODE_Autoneg_BIT, modes);
++	linkmode_set_bit(ETHTOOL_LINK_MODE_Pause_BIT, modes);
++	linkmode_set_bit(ETHTOOL_LINK_MODE_Asym_Pause_BIT, modes);
++
+ 	phy_interface_zero(interfaces);
+ 	__set_bit(PHY_INTERFACE_MODE_1000BASEX, interfaces);
+ }
+diff --git a/drivers/net/vxlan/vxlan_core.c b/drivers/net/vxlan/vxlan_core.c
+index a862998fb3ba64..1a973dcf256127 100644
+--- a/drivers/net/vxlan/vxlan_core.c
++++ b/drivers/net/vxlan/vxlan_core.c
+@@ -1964,12 +1964,14 @@ static struct sk_buff *vxlan_na_create(struct sk_buff *request,
+ 	ns_olen = request->len - skb_network_offset(request) -
+ 		sizeof(struct ipv6hdr) - sizeof(*ns);
+ 	for (i = 0; i < ns_olen-1; i += (ns->opt[i+1]<<3)) {
+-		if (!ns->opt[i + 1]) {
++		if (!ns->opt[i + 1] || i + (ns->opt[i + 1] << 3) > ns_olen) {
+ 			kfree_skb(reply);
+ 			return NULL;
+ 		}
+ 		if (ns->opt[i] == ND_OPT_SOURCE_LL_ADDR) {
+-			daddr = ns->opt + i + sizeof(struct nd_opt_hdr);
++			if ((ns->opt[i + 1] << 3) >=
++			    sizeof(struct nd_opt_hdr) + ETH_ALEN)
++				daddr = ns->opt + i + sizeof(struct nd_opt_hdr);
+ 			break;
+ 		}
+ 	}
+diff --git a/drivers/net/wireless/ath/ath11k/dp.h b/drivers/net/wireless/ath/ath11k/dp.h
+index 2f6dd69d3be276..0ce26f76bb8153 100644
+--- a/drivers/net/wireless/ath/ath11k/dp.h
++++ b/drivers/net/wireless/ath/ath11k/dp.h
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: BSD-3-Clause-Clear */
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
+- * Copyright (c) 2021-2023 Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) 2021-2023, 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #ifndef ATH11K_DP_H
+@@ -20,7 +20,6 @@ struct ath11k_ext_irq_grp;
+ 
+ struct dp_rx_tid {
+ 	u8 tid;
+-	u32 *vaddr;
+ 	dma_addr_t paddr;
+ 	u32 size;
+ 	u32 ba_win_sz;
+@@ -37,6 +36,9 @@ struct dp_rx_tid {
+ 	/* Timer info related to fragments */
+ 	struct timer_list frag_timer;
+ 	struct ath11k_base *ab;
++	u32 *vaddr_unaligned;
++	dma_addr_t paddr_unaligned;
++	u32 unaligned_size;
+ };
+ 
+ #define DP_REO_DESC_FREE_THRESHOLD  64
+diff --git a/drivers/net/wireless/ath/ath11k/dp_rx.c b/drivers/net/wireless/ath/ath11k/dp_rx.c
+index ed1ea61c814203..d2d994e094809f 100644
+--- a/drivers/net/wireless/ath/ath11k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_rx.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: BSD-3-Clause-Clear
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
+- * Copyright (c) 2021-2023 Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+  */
+ 
+ #include <linux/ieee80211.h>
+@@ -675,11 +675,11 @@ void ath11k_dp_reo_cmd_list_cleanup(struct ath11k_base *ab)
+ 	list_for_each_entry_safe(cmd, tmp, &dp->reo_cmd_list, list) {
+ 		list_del(&cmd->list);
+ 		rx_tid = &cmd->data;
+-		if (rx_tid->vaddr) {
+-			dma_unmap_single(ab->dev, rx_tid->paddr,
+-					 rx_tid->size, DMA_BIDIRECTIONAL);
+-			kfree(rx_tid->vaddr);
+-			rx_tid->vaddr = NULL;
++		if (rx_tid->vaddr_unaligned) {
++			dma_free_noncoherent(ab->dev, rx_tid->unaligned_size,
++					     rx_tid->vaddr_unaligned,
++					     rx_tid->paddr_unaligned, DMA_BIDIRECTIONAL);
++			rx_tid->vaddr_unaligned = NULL;
+ 		}
+ 		kfree(cmd);
+ 	}
+@@ -689,11 +689,11 @@ void ath11k_dp_reo_cmd_list_cleanup(struct ath11k_base *ab)
+ 		list_del(&cmd_cache->list);
+ 		dp->reo_cmd_cache_flush_count--;
+ 		rx_tid = &cmd_cache->data;
+-		if (rx_tid->vaddr) {
+-			dma_unmap_single(ab->dev, rx_tid->paddr,
+-					 rx_tid->size, DMA_BIDIRECTIONAL);
+-			kfree(rx_tid->vaddr);
+-			rx_tid->vaddr = NULL;
++		if (rx_tid->vaddr_unaligned) {
++			dma_free_noncoherent(ab->dev, rx_tid->unaligned_size,
++					     rx_tid->vaddr_unaligned,
++					     rx_tid->paddr_unaligned, DMA_BIDIRECTIONAL);
++			rx_tid->vaddr_unaligned = NULL;
+ 		}
+ 		kfree(cmd_cache);
+ 	}
+@@ -708,11 +708,11 @@ static void ath11k_dp_reo_cmd_free(struct ath11k_dp *dp, void *ctx,
+ 	if (status != HAL_REO_CMD_SUCCESS)
+ 		ath11k_warn(dp->ab, "failed to flush rx tid hw desc, tid %d status %d\n",
+ 			    rx_tid->tid, status);
+-	if (rx_tid->vaddr) {
+-		dma_unmap_single(dp->ab->dev, rx_tid->paddr, rx_tid->size,
+-				 DMA_BIDIRECTIONAL);
+-		kfree(rx_tid->vaddr);
+-		rx_tid->vaddr = NULL;
++	if (rx_tid->vaddr_unaligned) {
++		dma_free_noncoherent(dp->ab->dev, rx_tid->unaligned_size,
++				     rx_tid->vaddr_unaligned,
++				     rx_tid->paddr_unaligned, DMA_BIDIRECTIONAL);
++		rx_tid->vaddr_unaligned = NULL;
+ 	}
+ }
+ 
+@@ -749,10 +749,10 @@ static void ath11k_dp_reo_cache_flush(struct ath11k_base *ab,
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to send HAL_REO_CMD_FLUSH_CACHE cmd, tid %d (%d)\n",
+ 			   rx_tid->tid, ret);
+-		dma_unmap_single(ab->dev, rx_tid->paddr, rx_tid->size,
+-				 DMA_BIDIRECTIONAL);
+-		kfree(rx_tid->vaddr);
+-		rx_tid->vaddr = NULL;
++		dma_free_noncoherent(ab->dev, rx_tid->unaligned_size,
++				     rx_tid->vaddr_unaligned,
++				     rx_tid->paddr_unaligned, DMA_BIDIRECTIONAL);
++		rx_tid->vaddr_unaligned = NULL;
+ 	}
+ }
+ 
+@@ -802,10 +802,10 @@ static void ath11k_dp_rx_tid_del_func(struct ath11k_dp *dp, void *ctx,
+ 
+ 	return;
+ free_desc:
+-	dma_unmap_single(ab->dev, rx_tid->paddr, rx_tid->size,
+-			 DMA_BIDIRECTIONAL);
+-	kfree(rx_tid->vaddr);
+-	rx_tid->vaddr = NULL;
++	dma_free_noncoherent(ab->dev, rx_tid->unaligned_size,
++			     rx_tid->vaddr_unaligned,
++			     rx_tid->paddr_unaligned, DMA_BIDIRECTIONAL);
++	rx_tid->vaddr_unaligned = NULL;
+ }
+ 
+ void ath11k_peer_rx_tid_delete(struct ath11k *ar,
+@@ -831,14 +831,16 @@ void ath11k_peer_rx_tid_delete(struct ath11k *ar,
+ 		if (ret != -ESHUTDOWN)
+ 			ath11k_err(ar->ab, "failed to send HAL_REO_CMD_UPDATE_RX_QUEUE cmd, tid %d (%d)\n",
+ 				   tid, ret);
+-		dma_unmap_single(ar->ab->dev, rx_tid->paddr, rx_tid->size,
+-				 DMA_BIDIRECTIONAL);
+-		kfree(rx_tid->vaddr);
+-		rx_tid->vaddr = NULL;
++		dma_free_noncoherent(ar->ab->dev, rx_tid->unaligned_size,
++				     rx_tid->vaddr_unaligned,
++				     rx_tid->paddr_unaligned, DMA_BIDIRECTIONAL);
++		rx_tid->vaddr_unaligned = NULL;
+ 	}
+ 
+ 	rx_tid->paddr = 0;
++	rx_tid->paddr_unaligned = 0;
+ 	rx_tid->size = 0;
++	rx_tid->unaligned_size = 0;
+ }
+ 
+ static int ath11k_dp_rx_link_desc_return(struct ath11k_base *ab,
+@@ -982,10 +984,9 @@ static void ath11k_dp_rx_tid_mem_free(struct ath11k_base *ab,
+ 	if (!rx_tid->active)
+ 		goto unlock_exit;
+ 
+-	dma_unmap_single(ab->dev, rx_tid->paddr, rx_tid->size,
+-			 DMA_BIDIRECTIONAL);
+-	kfree(rx_tid->vaddr);
+-	rx_tid->vaddr = NULL;
++	dma_free_noncoherent(ab->dev, rx_tid->unaligned_size, rx_tid->vaddr_unaligned,
++			     rx_tid->paddr_unaligned, DMA_BIDIRECTIONAL);
++	rx_tid->vaddr_unaligned = NULL;
+ 
+ 	rx_tid->active = false;
+ 
+@@ -1000,9 +1001,8 @@ int ath11k_peer_rx_tid_setup(struct ath11k *ar, const u8 *peer_mac, int vdev_id,
+ 	struct ath11k_base *ab = ar->ab;
+ 	struct ath11k_peer *peer;
+ 	struct dp_rx_tid *rx_tid;
+-	u32 hw_desc_sz;
+-	u32 *addr_aligned;
+-	void *vaddr;
++	u32 hw_desc_sz, *vaddr;
++	void *vaddr_unaligned;
+ 	dma_addr_t paddr;
+ 	int ret;
+ 
+@@ -1050,49 +1050,40 @@ int ath11k_peer_rx_tid_setup(struct ath11k *ar, const u8 *peer_mac, int vdev_id,
+ 	else
+ 		hw_desc_sz = ath11k_hal_reo_qdesc_size(DP_BA_WIN_SZ_MAX, tid);
+ 
+-	vaddr = kzalloc(hw_desc_sz + HAL_LINK_DESC_ALIGN - 1, GFP_ATOMIC);
+-	if (!vaddr) {
++	rx_tid->unaligned_size = hw_desc_sz + HAL_LINK_DESC_ALIGN - 1;
++	vaddr_unaligned = dma_alloc_noncoherent(ab->dev, rx_tid->unaligned_size, &paddr,
++						DMA_BIDIRECTIONAL, GFP_ATOMIC);
++	if (!vaddr_unaligned) {
+ 		spin_unlock_bh(&ab->base_lock);
+ 		return -ENOMEM;
+ 	}
+ 
+-	addr_aligned = PTR_ALIGN(vaddr, HAL_LINK_DESC_ALIGN);
+-
+-	ath11k_hal_reo_qdesc_setup(addr_aligned, tid, ba_win_sz,
+-				   ssn, pn_type);
+-
+-	paddr = dma_map_single(ab->dev, addr_aligned, hw_desc_sz,
+-			       DMA_BIDIRECTIONAL);
+-
+-	ret = dma_mapping_error(ab->dev, paddr);
+-	if (ret) {
+-		spin_unlock_bh(&ab->base_lock);
+-		ath11k_warn(ab, "failed to setup dma map for peer %pM rx tid %d: %d\n",
+-			    peer_mac, tid, ret);
+-		goto err_mem_free;
+-	}
+-
+-	rx_tid->vaddr = vaddr;
+-	rx_tid->paddr = paddr;
++	rx_tid->vaddr_unaligned = vaddr_unaligned;
++	vaddr = PTR_ALIGN(vaddr_unaligned, HAL_LINK_DESC_ALIGN);
++	rx_tid->paddr_unaligned = paddr;
++	rx_tid->paddr = rx_tid->paddr_unaligned + ((unsigned long)vaddr -
++			(unsigned long)rx_tid->vaddr_unaligned);
++	ath11k_hal_reo_qdesc_setup(vaddr, tid, ba_win_sz, ssn, pn_type);
+ 	rx_tid->size = hw_desc_sz;
+ 	rx_tid->active = true;
+ 
++	/* After dma_alloc_noncoherent, vaddr is being modified for reo qdesc setup.
++	 * Since these changes are not reflected in the device, driver now needs to
++	 * explicitly call dma_sync_single_for_device.
++	 */
++	dma_sync_single_for_device(ab->dev, rx_tid->paddr,
++				   rx_tid->size,
++				   DMA_TO_DEVICE);
+ 	spin_unlock_bh(&ab->base_lock);
+ 
+-	ret = ath11k_wmi_peer_rx_reorder_queue_setup(ar, vdev_id, peer_mac,
+-						     paddr, tid, 1, ba_win_sz);
++	ret = ath11k_wmi_peer_rx_reorder_queue_setup(ar, vdev_id, peer_mac, rx_tid->paddr,
++						     tid, 1, ba_win_sz);
+ 	if (ret) {
+ 		ath11k_warn(ar->ab, "failed to setup rx reorder queue for peer %pM tid %d: %d\n",
+ 			    peer_mac, tid, ret);
+ 		ath11k_dp_rx_tid_mem_free(ab, peer_mac, vdev_id, tid);
+ 	}
+ 
+-	return ret;
+-
+-err_mem_free:
+-	kfree(rx_tid->vaddr);
+-	rx_tid->vaddr = NULL;
+-
+ 	return ret;
+ }
+ 
+@@ -1119,9 +1110,8 @@ int ath11k_dp_rx_ampdu_stop(struct ath11k *ar,
+ 	struct ath11k_base *ab = ar->ab;
+ 	struct ath11k_peer *peer;
+ 	struct ath11k_sta *arsta = ath11k_sta_to_arsta(params->sta);
++	struct dp_rx_tid *rx_tid;
+ 	int vdev_id = arsta->arvif->vdev_id;
+-	dma_addr_t paddr;
+-	bool active;
+ 	int ret;
+ 
+ 	spin_lock_bh(&ab->base_lock);
+@@ -1133,15 +1123,14 @@ int ath11k_dp_rx_ampdu_stop(struct ath11k *ar,
+ 		return -ENOENT;
+ 	}
+ 
+-	paddr = peer->rx_tid[params->tid].paddr;
+-	active = peer->rx_tid[params->tid].active;
++	rx_tid = &peer->rx_tid[params->tid];
+ 
+-	if (!active) {
++	if (!rx_tid->active) {
+ 		spin_unlock_bh(&ab->base_lock);
+ 		return 0;
+ 	}
+ 
+-	ret = ath11k_peer_rx_tid_reo_update(ar, peer, peer->rx_tid, 1, 0, false);
++	ret = ath11k_peer_rx_tid_reo_update(ar, peer, rx_tid, 1, 0, false);
+ 	spin_unlock_bh(&ab->base_lock);
+ 	if (ret) {
+ 		ath11k_warn(ab, "failed to update reo for rx tid %d: %d\n",
+@@ -1150,7 +1139,8 @@ int ath11k_dp_rx_ampdu_stop(struct ath11k *ar,
+ 	}
+ 
+ 	ret = ath11k_wmi_peer_rx_reorder_queue_setup(ar, vdev_id,
+-						     params->sta->addr, paddr,
++						     params->sta->addr,
++						     rx_tid->paddr,
+ 						     params->tid, 1, 1);
+ 	if (ret)
+ 		ath11k_warn(ab, "failed to send wmi to delete rx tid %d\n",
+@@ -2996,11 +2986,52 @@ ath11k_dp_rx_mon_update_status_buf_state(struct ath11k_mon_data *pmon,
+ 	}
+ }
+ 
++static enum dp_mon_status_buf_state
++ath11k_dp_rx_mon_buf_done(struct ath11k_base *ab, struct hal_srng *srng,
++			  struct dp_rxdma_ring *rx_ring)
++{
++	struct ath11k_skb_rxcb *rxcb;
++	struct hal_tlv_hdr *tlv;
++	struct sk_buff *skb;
++	void *status_desc;
++	dma_addr_t paddr;
++	u32 cookie;
++	int buf_id;
++	u8 rbm;
++
++	status_desc = ath11k_hal_srng_src_next_peek(ab, srng);
++	if (!status_desc)
++		return DP_MON_STATUS_NO_DMA;
++
++	ath11k_hal_rx_buf_addr_info_get(status_desc, &paddr, &cookie, &rbm);
++
++	buf_id = FIELD_GET(DP_RXDMA_BUF_COOKIE_BUF_ID, cookie);
++
++	spin_lock_bh(&rx_ring->idr_lock);
++	skb = idr_find(&rx_ring->bufs_idr, buf_id);
++	spin_unlock_bh(&rx_ring->idr_lock);
++
++	if (!skb)
++		return DP_MON_STATUS_NO_DMA;
++
++	rxcb = ATH11K_SKB_RXCB(skb);
++	dma_sync_single_for_cpu(ab->dev, rxcb->paddr,
++				skb->len + skb_tailroom(skb),
++				DMA_FROM_DEVICE);
++
++	tlv = (struct hal_tlv_hdr *)skb->data;
++	if (FIELD_GET(HAL_TLV_HDR_TAG, tlv->tl) != HAL_RX_STATUS_BUFFER_DONE)
++		return DP_MON_STATUS_NO_DMA;
++
++	return DP_MON_STATUS_REPLINISH;
++}
++
+ static int ath11k_dp_rx_reap_mon_status_ring(struct ath11k_base *ab, int mac_id,
+ 					     int *budget, struct sk_buff_head *skb_list)
+ {
+ 	struct ath11k *ar;
+ 	const struct ath11k_hw_hal_params *hal_params;
++	enum dp_mon_status_buf_state reap_status;
+ 	struct ath11k_pdev_dp *dp;
+ 	struct dp_rxdma_ring *rx_ring;
+ 	struct ath11k_mon_data *pmon;
+@@ -3063,15 +3094,38 @@ static int ath11k_dp_rx_reap_mon_status_ring(struct ath11k_base *ab, int mac_id,
+ 				ath11k_warn(ab, "mon status DONE not set %lx, buf_id %d\n",
+ 					    FIELD_GET(HAL_TLV_HDR_TAG,
+ 						      tlv->tl), buf_id);
+-				/* If done status is missing, hold onto status
+-				 * ring until status is done for this status
+-				 * ring buffer.
+-				 * Keep HP in mon_status_ring unchanged,
+-				 * and break from here.
+-				 * Check status for same buffer for next time
++				/* RxDMA status done bit might not be set even
++				 * though tp is moved by HW.
+ 				 */
+-				pmon->buf_state = DP_MON_STATUS_NO_DMA;
+-				break;
++
++				/* If done status is missing:
++				 * 1. As per MAC team's suggestion,
++				 *    when HP + 1 entry is peeked and if DMA
++				 *    is not done and if HP + 2 entry's DMA done
++				 *    is set. skip HP + 1 entry and
++				 *    start processing in next interrupt.
++				 * 2. If HP + 2 entry's DMA done is not set,
++				 *    poll onto HP + 1 entry DMA done to be set.
++				 *    Check status for same buffer for next time
++				 *    dp_rx_mon_status_srng_process
++				 */
++
++				reap_status = ath11k_dp_rx_mon_buf_done(ab, srng,
++									rx_ring);
++				if (reap_status == DP_MON_STATUS_NO_DMA)
++					continue;
++
++				spin_lock_bh(&rx_ring->idr_lock);
++				idr_remove(&rx_ring->bufs_idr, buf_id);
++				spin_unlock_bh(&rx_ring->idr_lock);
++
++				dma_unmap_single(ab->dev, rxcb->paddr,
++						 skb->len + skb_tailroom(skb),
++						 DMA_FROM_DEVICE);
++
++				dev_kfree_skb_any(skb);
++				pmon->buf_state = DP_MON_STATUS_REPLINISH;
++				goto move_next;
+ 			}
+ 
+ 			spin_lock_bh(&rx_ring->idr_lock);
+diff --git a/drivers/net/wireless/ath/ath11k/hal.c b/drivers/net/wireless/ath/ath11k/hal.c
+index 79cf65bc2e1724..b42925f84200c8 100644
+--- a/drivers/net/wireless/ath/ath11k/hal.c
++++ b/drivers/net/wireless/ath/ath11k/hal.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: BSD-3-Clause-Clear
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
+- * Copyright (c) 2021-2023 Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) 2021-2024 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ #include <linux/dma-mapping.h>
+ #include "hal_tx.h"
+@@ -783,6 +783,20 @@ u32 *ath11k_hal_srng_src_get_next_reaped(struct ath11k_base *ab,
+ 	return desc;
+ }
+ 
++u32 *ath11k_hal_srng_src_next_peek(struct ath11k_base *ab, struct hal_srng *srng)
++{
++	u32 next_hp;
++
++	lockdep_assert_held(&srng->lock);
++
++	next_hp = (srng->u.src_ring.hp + srng->entry_size) % srng->ring_size;
++
++	if (next_hp != srng->u.src_ring.cached_tp)
++		return srng->ring_base_vaddr + next_hp;
++
++	return NULL;
++}
++
+ u32 *ath11k_hal_srng_src_peek(struct ath11k_base *ab, struct hal_srng *srng)
+ {
+ 	lockdep_assert_held(&srng->lock);
+diff --git a/drivers/net/wireless/ath/ath11k/hal.h b/drivers/net/wireless/ath/ath11k/hal.h
+index aa21eb1fdce159..494c2b8a128167 100644
+--- a/drivers/net/wireless/ath/ath11k/hal.h
++++ b/drivers/net/wireless/ath/ath11k/hal.h
+@@ -946,6 +946,8 @@ u32 *ath11k_hal_srng_dst_peek(struct ath11k_base *ab, struct hal_srng *srng);
+ int ath11k_hal_srng_dst_num_free(struct ath11k_base *ab, struct hal_srng *srng,
+ 				 bool sync_hw_ptr);
+ u32 *ath11k_hal_srng_src_peek(struct ath11k_base *ab, struct hal_srng *srng);
++u32 *ath11k_hal_srng_src_next_peek(struct ath11k_base *ab,
++				   struct hal_srng *srng);
+ u32 *ath11k_hal_srng_src_get_next_reaped(struct ath11k_base *ab,
+ 					 struct hal_srng *srng);
+ u32 *ath11k_hal_srng_src_reap_next(struct ath11k_base *ab,
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/d3.c b/drivers/net/wireless/intel/iwlwifi/mvm/d3.c
+index 6c108dbbbc5402..ac304e21a36727 100644
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/d3.c
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/d3.c
+@@ -2863,7 +2863,7 @@ static void iwl_mvm_nd_match_info_handler(struct iwl_mvm *mvm,
+ 	if (IS_ERR_OR_NULL(vif))
+ 		return;
+ 
+-	if (len < sizeof(struct iwl_scan_offload_match_info)) {
++	if (len < sizeof(struct iwl_scan_offload_match_info) + matches_len) {
+ 		IWL_ERR(mvm, "Invalid scan match info notification\n");
+ 		return;
+ 	}
+diff --git a/drivers/net/wireless/microchip/wilc1000/hif.c b/drivers/net/wireless/microchip/wilc1000/hif.c
+index 25e881ee727cdb..91122e7be41338 100644
+--- a/drivers/net/wireless/microchip/wilc1000/hif.c
++++ b/drivers/net/wireless/microchip/wilc1000/hif.c
+@@ -162,7 +162,7 @@ int wilc_scan(struct wilc_vif *vif, u8 scan_source, u8 scan_type,
+ 	u32 index = 0;
+ 	u32 i, scan_timeout;
+ 	u8 *buffer;
+-	u8 valuesize = 0;
++	u32 valuesize = 0;
+ 	u8 *search_ssid_vals = NULL;
+ 	struct host_if_drv *hif_drv = vif->hif_drv;
+ 
+diff --git a/drivers/net/wireless/virtual/virt_wifi.c b/drivers/net/wireless/virtual/virt_wifi.c
+index 2977b30c6d593c..55b2d44e4315f1 100644
+--- a/drivers/net/wireless/virtual/virt_wifi.c
++++ b/drivers/net/wireless/virtual/virt_wifi.c
+@@ -555,7 +555,6 @@ static int virt_wifi_newlink(struct net *src_net, struct net_device *dev,
+ 	eth_hw_addr_inherit(dev, priv->lowerdev);
+ 	netif_stacked_transfer_operstate(priv->lowerdev, dev);
+ 
+-	SET_NETDEV_DEV(dev, &priv->lowerdev->dev);
+ 	dev->ieee80211_ptr = kzalloc(sizeof(*dev->ieee80211_ptr), GFP_KERNEL);
+ 
+ 	if (!dev->ieee80211_ptr) {
+diff --git a/drivers/nfc/pn533/uart.c b/drivers/nfc/pn533/uart.c
+index a556acdb947bbe..f4afd1156e062c 100644
+--- a/drivers/nfc/pn533/uart.c
++++ b/drivers/nfc/pn533/uart.c
+@@ -211,6 +211,9 @@ static int pn532_receive_buf(struct serdev_device *serdev,
+ 
+ 	del_timer(&dev->cmd_timeout);
+ 	for (i = 0; i < count; i++) {
++		if (unlikely(!skb_tailroom(dev->recv_skb)))
++			skb_trim(dev->recv_skb, 0);
++
+ 		skb_put_u8(dev->recv_skb, *data++);
+ 		if (!pn532_uart_rx_is_frame(dev->recv_skb))
+ 			continue;
+diff --git a/drivers/nvmem/imx-ocotp-ele.c b/drivers/nvmem/imx-ocotp-ele.c
+index 66e468af0f2fe8..3be93400e818e1 100644
+--- a/drivers/nvmem/imx-ocotp-ele.c
++++ b/drivers/nvmem/imx-ocotp-ele.c
+@@ -127,6 +127,7 @@ static int imx_ocotp_cell_pp(void *context, const char *id, int index,
+ static void imx_ocotp_fixup_dt_cell_info(struct nvmem_device *nvmem,
+ 					 struct nvmem_cell_info *cell)
+ {
++	cell->raw_len = round_up(cell->bytes, 4);
+ 	cell->read_post_process = imx_ocotp_cell_pp;
+ }
+ 
+diff --git a/drivers/nvmem/imx-ocotp.c b/drivers/nvmem/imx-ocotp.c
+index 7bf7656d4f9631..108d78d7f6cba6 100644
+--- a/drivers/nvmem/imx-ocotp.c
++++ b/drivers/nvmem/imx-ocotp.c
+@@ -589,6 +589,7 @@ MODULE_DEVICE_TABLE(of, imx_ocotp_dt_ids);
+ static void imx_ocotp_fixup_dt_cell_info(struct nvmem_device *nvmem,
+ 					 struct nvmem_cell_info *cell)
+ {
++	cell->raw_len = round_up(cell->bytes, 4);
+ 	cell->read_post_process = imx_ocotp_cell_pp;
+ }
+ 
+diff --git a/drivers/spi/spi-geni-qcom.c b/drivers/spi/spi-geni-qcom.c
+index 37a20652fd2e75..ef1a05837cb977 100644
+--- a/drivers/spi/spi-geni-qcom.c
++++ b/drivers/spi/spi-geni-qcom.c
+@@ -948,10 +948,13 @@ static irqreturn_t geni_spi_isr(int irq, void *data)
+ 	struct spi_master *spi = data;
+ 	struct spi_geni_master *mas = spi_master_get_devdata(spi);
+ 	struct geni_se *se = &mas->se;
+-	u32 m_irq;
++	u32 m_irq, dma_tx_status, dma_rx_status;
+ 
+ 	m_irq = readl(se->base + SE_GENI_M_IRQ_STATUS);
+-	if (!m_irq)
++	dma_tx_status = readl_relaxed(se->base + SE_DMA_TX_IRQ_STAT);
++	dma_rx_status = readl_relaxed(se->base + SE_DMA_RX_IRQ_STAT);
++
++	if (!m_irq && !dma_tx_status && !dma_rx_status)
+ 		return IRQ_NONE;
+ 
+ 	if (m_irq & (M_CMD_OVERRUN_EN | M_ILLEGAL_CMD_EN | M_CMD_FAILURE_EN |
+@@ -999,8 +1002,6 @@ static irqreturn_t geni_spi_isr(int irq, void *data)
+ 		}
+ 	} else if (mas->cur_xfer_mode == GENI_SE_DMA) {
+ 		const struct spi_transfer *xfer = mas->cur_xfer;
+-		u32 dma_tx_status = readl_relaxed(se->base + SE_DMA_TX_IRQ_STAT);
+-		u32 dma_rx_status = readl_relaxed(se->base + SE_DMA_RX_IRQ_STAT);
+ 
+ 		if (dma_tx_status)
+ 			writel(dma_tx_status, se->base + SE_DMA_TX_IRQ_CLR);
+diff --git a/drivers/target/loopback/tcm_loop.c b/drivers/target/loopback/tcm_loop.c
+index db13c6a379d875..72d374c94ce2b3 100644
+--- a/drivers/target/loopback/tcm_loop.c
++++ b/drivers/target/loopback/tcm_loop.c
+@@ -26,6 +26,7 @@
+ #include <linux/slab.h>
+ #include <linux/types.h>
+ #include <linux/configfs.h>
++#include <linux/blk-mq.h>
+ #include <scsi/scsi.h>
+ #include <scsi/scsi_tcq.h>
+ #include <scsi/scsi_host.h>
+@@ -267,15 +268,27 @@ static int tcm_loop_device_reset(struct scsi_cmnd *sc)
+ 	return (ret == TMR_FUNCTION_COMPLETE) ? SUCCESS : FAILED;
+ }
+ 
++static bool tcm_loop_flush_work_iter(struct request *rq, void *data)
++{
++	struct scsi_cmnd *sc = blk_mq_rq_to_pdu(rq);
++	struct tcm_loop_cmd *tl_cmd = scsi_cmd_priv(sc);
++	struct se_cmd *se_cmd = &tl_cmd->tl_se_cmd;
++
++	flush_work(&se_cmd->work);
++	return true;
++}
++
+ static int tcm_loop_target_reset(struct scsi_cmnd *sc)
+ {
+ 	struct tcm_loop_hba *tl_hba;
+ 	struct tcm_loop_tpg *tl_tpg;
++	struct Scsi_Host *sh = sc->device->host;
++	int ret;
+ 
+ 	/*
+ 	 * Locate the tcm_loop_hba_t pointer
+ 	 */
+-	tl_hba = *(struct tcm_loop_hba **)shost_priv(sc->device->host);
++	tl_hba = *(struct tcm_loop_hba **)shost_priv(sh);
+ 	if (!tl_hba) {
+ 		pr_err("Unable to perform device reset without active I_T Nexus\n");
+ 		return FAILED;
+@@ -284,11 +297,38 @@ static int tcm_loop_target_reset(struct scsi_cmnd *sc)
+ 	 * Locate the tl_tpg pointer from TargetID in sc->device->id
+ 	 */
+ 	tl_tpg = &tl_hba->tl_hba_tpgs[sc->device->id];
+-	if (tl_tpg) {
+-		tl_tpg->tl_transport_status = TCM_TRANSPORT_ONLINE;
+-		return SUCCESS;
+-	}
+-	return FAILED;
++	if (!tl_tpg)
++		return FAILED;
++
++	/*
++	 * Issue a LUN_RESET to drain all commands that the target core
++	 * knows about.  This handles commands not yet marked CMD_T_COMPLETE.
++	 */
++	ret = tcm_loop_issue_tmr(tl_tpg, sc->device->lun, 0, TMR_LUN_RESET);
++	if (ret != TMR_FUNCTION_COMPLETE)
++		return FAILED;
++
++	/*
++	 * Flush any deferred target core completion work that may still be
++	 * queued.  Commands that already had CMD_T_COMPLETE set before the TMR
++	 * are skipped by the TMR drain, but their async completion work
++	 * (transport_lun_remove_cmd → percpu_ref_put, release_cmd → scsi_done)
++	 * may still be pending in target_completion_wq.
++	 *
++	 * The SCSI EH will reuse in-flight scsi_cmnd structures for recovery
++	 * commands (e.g. TUR) immediately after this handler returns SUCCESS —
++	 * if deferred work is still pending, the memset in queuecommand would
++	 * zero the se_cmd while the work accesses it, leaking the LUN
++	 * percpu_ref and hanging configfs unlink forever.
++	 *
++	 * Use blk_mq_tagset_busy_iter() to find all started requests and
++	 * flush_work() on each — the same pattern used by mpi3mr, scsi_debug,
++	 * and other SCSI drivers to drain outstanding commands during reset.
++	 */
++	blk_mq_tagset_busy_iter(&sh->tag_set, tcm_loop_flush_work_iter, NULL);
++
++	tl_tpg->tl_transport_status = TCM_TRANSPORT_ONLINE;
++	return SUCCESS;
+ }
+ 
+ static const struct scsi_host_template tcm_loop_driver_template = {
+diff --git a/drivers/thermal/thermal_core.c b/drivers/thermal/thermal_core.c
+index dad909547179f8..660a8d6f35673b 100644
+--- a/drivers/thermal/thermal_core.c
++++ b/drivers/thermal/thermal_core.c
+@@ -1394,6 +1394,7 @@ unregister:
+ 	device_del(&tz->device);
+ release_device:
+ 	put_device(&tz->device);
++	wait_for_completion(&tz->removal);
+ remove_id:
+ 	ida_free(&thermal_tz_ida, id);
+ free_tzp:
+diff --git a/drivers/thunderbolt/nhi.c b/drivers/thunderbolt/nhi.c
+index d13063e6957163..3c879a0d92f94a 100644
+--- a/drivers/thunderbolt/nhi.c
++++ b/drivers/thunderbolt/nhi.c
+@@ -1010,7 +1010,7 @@ static bool nhi_wake_supported(struct pci_dev *pdev)
+ 	 * If power rails are sustainable for wakeup from S4 this
+ 	 * property is set by the BIOS.
+ 	 */
+-	if (device_property_read_u8(&pdev->dev, "WAKE_SUPPORTED", &val))
++	if (!device_property_read_u8(&pdev->dev, "WAKE_SUPPORTED", &val))
+ 		return !!val;
+ 
+ 	return true;
+diff --git a/drivers/usb/cdns3/cdns3-gadget.c b/drivers/usb/cdns3/cdns3-gadget.c
+index 05e8414c31df4c..f0447f2231a815 100644
+--- a/drivers/usb/cdns3/cdns3-gadget.c
++++ b/drivers/usb/cdns3/cdns3-gadget.c
+@@ -2588,6 +2588,9 @@ static int __cdns3_gadget_ep_queue(struct usb_ep *ep,
+ 	struct cdns3_request *priv_req;
+ 	int ret = 0;
+ 
++	if (!ep->desc)
++		return -ESHUTDOWN;
++
+ 	request->actual = 0;
+ 	request->status = -EINPROGRESS;
+ 	priv_req = to_cdns3_request(request);
+@@ -3428,6 +3431,7 @@ static int __cdns3_gadget_init(struct cdns *cdns)
+ 	ret = cdns3_gadget_start(cdns);
+ 	if (ret) {
+ 		pm_runtime_put_sync(cdns->dev);
++		cdns_drd_gadget_off(cdns);
+ 		return ret;
+ 	}
+ 
+diff --git a/drivers/usb/class/cdc-acm.c b/drivers/usb/class/cdc-acm.c
+index e005c506dd0a1b..9b9eb4568ad23f 100644
+--- a/drivers/usb/class/cdc-acm.c
++++ b/drivers/usb/class/cdc-acm.c
+@@ -1225,6 +1225,12 @@ static int acm_probe(struct usb_interface *intf,
+ 		if (!data_interface || !control_interface)
+ 			return -ENODEV;
+ 		goto skip_normal_probe;
++	} else if (quirks == NO_UNION_12) {
++		data_interface = usb_ifnum_to_if(usb_dev, 2);
++		control_interface = usb_ifnum_to_if(usb_dev, 1);
++		if (!data_interface || !control_interface)
++			 return -ENODEV;
++		goto skip_normal_probe;
+ 	}
+ 
+ 	/* normal probing*/
+@@ -1748,6 +1754,9 @@ static const struct usb_device_id acm_ids[] = {
+ 	{ USB_DEVICE(0x045b, 0x024D),	/* Renesas R-Car E3 USB Download mode */
+ 	.driver_info = DISABLE_ECHO,	/* Don't echo banner */
+ 	},
++	{ USB_DEVICE(0x04b8, 0x0d12),	/* EPSON HMD Com&Sens */
++	.driver_info = NO_UNION_12,	/* union descriptor is garbage */
++	},
+ 	{ USB_DEVICE(0x0e8d, 0x0003), /* FIREFLY, MediaTek Inc; andrey.arapov@gmail.com */
+ 	.driver_info = NO_UNION_NORMAL, /* has no union descriptor */
+ 	},
+diff --git a/drivers/usb/class/cdc-acm.h b/drivers/usb/class/cdc-acm.h
+index 76f73853a60b63..25fd5329a8781f 100644
+--- a/drivers/usb/class/cdc-acm.h
++++ b/drivers/usb/class/cdc-acm.h
+@@ -114,3 +114,4 @@ struct acm {
+ #define SEND_ZERO_PACKET		BIT(6)
+ #define DISABLE_ECHO			BIT(7)
+ #define MISSING_CAP_BRK			BIT(8)
++#define NO_UNION_12			BIT(9)
+diff --git a/drivers/usb/class/usbtmc.c b/drivers/usb/class/usbtmc.c
+index 8cf341a2483471..bf8690bb654fb6 100644
+--- a/drivers/usb/class/usbtmc.c
++++ b/drivers/usb/class/usbtmc.c
+@@ -254,6 +254,9 @@ static int usbtmc_release(struct inode *inode, struct file *file)
+ 	list_del(&file_data->file_elem);
+ 
+ 	spin_unlock_irq(&file_data->data->dev_lock);
++
++	/* flush anchored URBs */
++	usbtmc_draw_down(file_data);
+ 	mutex_unlock(&file_data->data->io_mutex);
+ 
+ 	kref_put(&file_data->data->kref, usbtmc_delete);
+diff --git a/drivers/usb/common/ulpi.c b/drivers/usb/common/ulpi.c
+index 0886b19d2e1c8f..c9f52cd1cfb2bf 100644
+--- a/drivers/usb/common/ulpi.c
++++ b/drivers/usb/common/ulpi.c
+@@ -331,10 +331,9 @@ struct ulpi *ulpi_register_interface(struct device *dev,
+ 	ulpi->ops = ops;
+ 
+ 	ret = ulpi_register(dev, ulpi);
+-	if (ret) {
+-		kfree(ulpi);
++	if (ret)
+ 		return ERR_PTR(ret);
+-	}
++
+ 
+ 	return ulpi;
+ }
+diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
+index 53b08d6cf78241..7442ac03f5ff77 100644
+--- a/drivers/usb/core/quirks.c
++++ b/drivers/usb/core/quirks.c
+@@ -402,6 +402,7 @@ static const struct usb_device_id usb_quirk_list[] = {
+ 
+ 	/* Silicon Motion Flash Drive */
+ 	{ USB_DEVICE(0x090c, 0x1000), .driver_info = USB_QUIRK_DELAY_INIT },
++	{ USB_DEVICE(0x090c, 0x2000), .driver_info = USB_QUIRK_DELAY_INIT },
+ 
+ 	/* Sound Devices USBPre2 */
+ 	{ USB_DEVICE(0x0926, 0x0202), .driver_info =
+@@ -490,6 +491,8 @@ static const struct usb_device_id usb_quirk_list[] = {
+ 	/* Razer - Razer Blade Keyboard */
+ 	{ USB_DEVICE(0x1532, 0x0116), .driver_info =
+ 			USB_QUIRK_LINEAR_UFRAME_INTR_BINTERVAL },
++	/* Razer - Razer Kiyo Pro Webcam */
++	{ USB_DEVICE(0x1532, 0x0e05), .driver_info = USB_QUIRK_NO_LPM },
+ 
+ 	/* Lenovo ThinkPad OneLink+ Dock twin hub controllers (VIA Labs VL812) */
+ 	{ USB_DEVICE(0x17ef, 0x1018), .driver_info = USB_QUIRK_RESET_RESUME },
+diff --git a/drivers/usb/dwc2/gadget.c b/drivers/usb/dwc2/gadget.c
+index c0db3c52831a2d..c4a06eeb61fe82 100644
+--- a/drivers/usb/dwc2/gadget.c
++++ b/drivers/usb/dwc2/gadget.c
+@@ -4604,7 +4604,9 @@ static int dwc2_hsotg_udc_stop(struct usb_gadget *gadget)
+ 	/* Exit clock gating when driver is stopped. */
+ 	if (hsotg->params.power_down == DWC2_POWER_DOWN_PARAM_NONE &&
+ 	    hsotg->bus_suspended && !hsotg->params.no_clock_gating) {
++		spin_lock_irqsave(&hsotg->lock, flags);
+ 		dwc2_gadget_exit_clock_gating(hsotg, 0);
++		spin_unlock_irqrestore(&hsotg->lock, flags);
+ 	}
+ 
+ 	/* all endpoints should be shutdown */
+diff --git a/drivers/usb/gadget/function/f_rndis.c b/drivers/usb/gadget/function/f_rndis.c
+index ef7e734511ab2e..c1172864427307 100644
+--- a/drivers/usb/gadget/function/f_rndis.c
++++ b/drivers/usb/gadget/function/f_rndis.c
+@@ -11,6 +11,7 @@
+ 
+ /* #define VERBOSE_DEBUG */
+ 
++#include <linux/cleanup.h>
+ #include <linux/slab.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+@@ -678,9 +679,11 @@ rndis_bind(struct usb_configuration *c, struct usb_function *f)
+ 			return -ENOMEM;
+ 	}
+ 
+-	rndis_iad_descriptor.bFunctionClass = rndis_opts->class;
+-	rndis_iad_descriptor.bFunctionSubClass = rndis_opts->subclass;
+-	rndis_iad_descriptor.bFunctionProtocol = rndis_opts->protocol;
++	scoped_guard(mutex, &rndis_opts->lock) {
++		rndis_iad_descriptor.bFunctionClass = rndis_opts->class;
++		rndis_iad_descriptor.bFunctionSubClass = rndis_opts->subclass;
++		rndis_iad_descriptor.bFunctionProtocol = rndis_opts->protocol;
++	}
+ 
+ 	/*
+ 	 * in drivers/usb/gadget/configfs.c:configfs_composite_bind()
+diff --git a/drivers/usb/gadget/function/f_subset.c b/drivers/usb/gadget/function/f_subset.c
+index 8ae9689ef2a081..7d209382c06868 100644
+--- a/drivers/usb/gadget/function/f_subset.c
++++ b/drivers/usb/gadget/function/f_subset.c
+@@ -6,6 +6,7 @@
+  * Copyright (C) 2008 Nokia Corporation
+  */
+ 
++#include <linux/cleanup.h>
+ #include <linux/slab.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+@@ -449,8 +450,13 @@ static struct usb_function_instance *geth_alloc_inst(void)
+ static void geth_free(struct usb_function *f)
+ {
+ 	struct f_gether *eth;
++	struct f_gether_opts *opts;
++
++	opts = container_of(f->fi, struct f_gether_opts, func_inst);
+ 
+ 	eth = func_to_geth(f);
++	scoped_guard(mutex, &opts->lock)
++		opts->refcnt--;
+ 	kfree(eth);
+ }
+ 
+diff --git a/drivers/usb/gadget/function/f_uac1_legacy.c b/drivers/usb/gadget/function/f_uac1_legacy.c
+index e2d7f69128a0e8..f8ed471ab9a811 100644
+--- a/drivers/usb/gadget/function/f_uac1_legacy.c
++++ b/drivers/usb/gadget/function/f_uac1_legacy.c
+@@ -360,19 +360,46 @@ static int f_audio_out_ep_complete(struct usb_ep *ep, struct usb_request *req)
+ static void f_audio_complete(struct usb_ep *ep, struct usb_request *req)
+ {
+ 	struct f_audio *audio = req->context;
+-	int status = req->status;
+-	u32 data = 0;
+ 	struct usb_ep *out_ep = audio->out_ep;
+ 
+-	switch (status) {
+-
+-	case 0:				/* normal completion? */
+-		if (ep == out_ep)
++	switch (req->status) {
++	case 0:
++		if (ep == out_ep) {
+ 			f_audio_out_ep_complete(ep, req);
+-		else if (audio->set_con) {
+-			memcpy(&data, req->buf, req->length);
+-			audio->set_con->set(audio->set_con, audio->set_cmd,
+-					le16_to_cpu(data));
++		} else if (audio->set_con) {
++			struct usb_audio_control *con = audio->set_con;
++			u8 type = con->type;
++			u32 data;
++			bool valid_request = false;
++
++			switch (type) {
++			case UAC_FU_MUTE: {
++				u8 value;
++
++				if (req->actual == sizeof(value)) {
++					memcpy(&value, req->buf, sizeof(value));
++					data = value;
++					valid_request = true;
++				}
++				break;
++			}
++			case UAC_FU_VOLUME: {
++				__le16 value;
++
++				if (req->actual == sizeof(value)) {
++					memcpy(&value, req->buf, sizeof(value));
++					data = le16_to_cpu(value);
++					valid_request = true;
++				}
++				break;
++			}
++			}
++
++			if (valid_request)
++				con->set(con, audio->set_cmd, data);
++			else
++				usb_ep_set_halt(ep);
++
+ 			audio->set_con = NULL;
+ 		}
+ 		break;
+diff --git a/drivers/usb/gadget/function/f_uvc.c b/drivers/usb/gadget/function/f_uvc.c
+index 2e6bafb2a55492..37c33cab208a77 100644
+--- a/drivers/usb/gadget/function/f_uvc.c
++++ b/drivers/usb/gadget/function/f_uvc.c
+@@ -410,6 +410,12 @@ uvc_function_disconnect(struct uvc_device *uvc)
+ {
+ 	int ret;
+ 
++	guard(mutex)(&uvc->lock);
++	if (uvc->func_unbound) {
++		dev_dbg(&uvc->vdev.dev, "skipping function deactivate (unbound)\n");
++		return;
++	}
++
+ 	if ((ret = usb_function_deactivate(&uvc->func)) < 0)
+ 		uvcg_info(&uvc->func, "UVC disconnect failed with %d\n", ret);
+ }
+@@ -428,6 +434,15 @@ static ssize_t function_name_show(struct device *dev,
+ 
+ static DEVICE_ATTR_RO(function_name);
+ 
++static void uvc_vdev_release(struct video_device *vdev)
++{
++	struct uvc_device *uvc = video_get_drvdata(vdev);
++
++	/* Signal uvc_function_unbind() that the video device has been released */
++	if (uvc->vdev_release_done)
++		complete(uvc->vdev_release_done);
++}
++
+ static int
+ uvc_register_video(struct uvc_device *uvc)
+ {
+@@ -440,7 +455,7 @@ uvc_register_video(struct uvc_device *uvc)
+ 	uvc->vdev.v4l2_dev->dev = &cdev->gadget->dev;
+ 	uvc->vdev.fops = &uvc_v4l2_fops;
+ 	uvc->vdev.ioctl_ops = &uvc_v4l2_ioctl_ops;
+-	uvc->vdev.release = video_device_release_empty;
++	uvc->vdev.release = uvc_vdev_release;
+ 	uvc->vdev.vfl_dir = VFL_DIR_TX;
+ 	uvc->vdev.lock = &uvc->video.mutex;
+ 	uvc->vdev.device_caps = V4L2_CAP_VIDEO_OUTPUT | V4L2_CAP_STREAMING;
+@@ -653,6 +668,8 @@ uvc_function_bind(struct usb_configuration *c, struct usb_function *f)
+ 	int ret = -EINVAL;
+ 
+ 	uvcg_info(f, "%s()\n", __func__);
++	scoped_guard(mutex, &uvc->lock)
++		uvc->func_unbound = false;
+ 
+ 	opts = fi_to_f_uvc_opts(f->fi);
+ 	/* Sanity check the streaming endpoint module parameters. */
+@@ -975,12 +992,19 @@ static void uvc_free(struct usb_function *f)
+ static void uvc_function_unbind(struct usb_configuration *c,
+ 				struct usb_function *f)
+ {
++	DECLARE_COMPLETION_ONSTACK(vdev_release_done);
+ 	struct usb_composite_dev *cdev = c->cdev;
+ 	struct uvc_device *uvc = to_uvc(f);
+ 	struct uvc_video *video = &uvc->video;
+ 	long wait_ret = 1;
++	bool connected;
+ 
+ 	uvcg_info(f, "%s()\n", __func__);
++	scoped_guard(mutex, &uvc->lock) {
++		uvc->func_unbound = true;
++		uvc->vdev_release_done = &vdev_release_done;
++		connected = uvc->func_connected;
++	}
+ 
+ 	if (video->async_wq)
+ 		destroy_workqueue(video->async_wq);
+@@ -991,7 +1015,7 @@ static void uvc_function_unbind(struct usb_configuration *c,
+ 	 * though the video device removal uevent. Allow some time for the
+ 	 * application to close out before things get deleted.
+ 	 */
+-	if (uvc->func_connected) {
++	if (connected) {
+ 		uvcg_dbg(f, "waiting for clean disconnect\n");
+ 		wait_ret = wait_event_interruptible_timeout(uvc->func_connected_queue,
+ 				uvc->func_connected == false, msecs_to_jiffies(500));
+@@ -1002,7 +1026,10 @@ static void uvc_function_unbind(struct usb_configuration *c,
+ 	video_unregister_device(&uvc->vdev);
+ 	v4l2_device_unregister(&uvc->v4l2_dev);
+ 
+-	if (uvc->func_connected) {
++	scoped_guard(mutex, &uvc->lock)
++		connected = uvc->func_connected;
++
++	if (connected) {
+ 		/*
+ 		 * Wait for the release to occur to ensure there are no longer any
+ 		 * pending operations that may cause panics when resources are cleaned
+@@ -1014,6 +1041,10 @@ static void uvc_function_unbind(struct usb_configuration *c,
+ 		uvcg_dbg(f, "done waiting for release with ret: %ld\n", wait_ret);
+ 	}
+ 
++	/* Wait for the video device to be released */
++	wait_for_completion(&vdev_release_done);
++	uvc->vdev_release_done = NULL;
++
+ 	usb_ep_free_request(cdev->gadget->ep0, uvc->control_req);
+ 	kfree(uvc->control_buf);
+ 
+@@ -1032,6 +1063,8 @@ static struct usb_function *uvc_alloc(struct usb_function_instance *fi)
+ 		return ERR_PTR(-ENOMEM);
+ 
+ 	mutex_init(&uvc->video.mutex);
++	mutex_init(&uvc->lock);
++	uvc->func_unbound = true;
+ 	uvc->state = UVC_STATE_DISCONNECTED;
+ 	init_waitqueue_head(&uvc->func_connected_queue);
+ 	opts = fi_to_f_uvc_opts(fi);
+diff --git a/drivers/usb/gadget/function/u_ether.c b/drivers/usb/gadget/function/u_ether.c
+index 2da2db5e15a3c8..62e2018d0357c7 100644
+--- a/drivers/usb/gadget/function/u_ether.c
++++ b/drivers/usb/gadget/function/u_ether.c
+@@ -1200,6 +1200,11 @@ void gether_disconnect(struct gether *link)
+ 
+ 	DBG(dev, "%s\n", __func__);
+ 
++	spin_lock(&dev->lock);
++	dev->port_usb = NULL;
++	link->is_suspend = false;
++	spin_unlock(&dev->lock);
++
+ 	netif_stop_queue(dev->net);
+ 	netif_carrier_off(dev->net);
+ 
+@@ -1237,11 +1242,6 @@ void gether_disconnect(struct gether *link)
+ 	dev->header_len = 0;
+ 	dev->unwrap = NULL;
+ 	dev->wrap = NULL;
+-
+-	spin_lock(&dev->lock);
+-	dev->port_usb = NULL;
+-	link->is_suspend = false;
+-	spin_unlock(&dev->lock);
+ }
+ EXPORT_SYMBOL_GPL(gether_disconnect);
+ 
+diff --git a/drivers/usb/gadget/function/uvc.h b/drivers/usb/gadget/function/uvc.h
+index 6751de8b63ad94..595b07c923c1ab 100644
+--- a/drivers/usb/gadget/function/uvc.h
++++ b/drivers/usb/gadget/function/uvc.h
+@@ -131,6 +131,9 @@ struct uvc_device {
+ 	enum uvc_state state;
+ 	struct usb_function func;
+ 	struct uvc_video video;
++	struct completion *vdev_release_done;
++	struct mutex lock;	/* protects func_unbound and func_connected */
++	bool func_unbound;
+ 	bool func_connected;
+ 	wait_queue_head_t func_connected_queue;
+ 
+diff --git a/drivers/usb/gadget/function/uvc_v4l2.c b/drivers/usb/gadget/function/uvc_v4l2.c
+index 0195625bef53ab..eda0cd6ad66e94 100644
+--- a/drivers/usb/gadget/function/uvc_v4l2.c
++++ b/drivers/usb/gadget/function/uvc_v4l2.c
+@@ -491,6 +491,8 @@ uvc_v4l2_subscribe_event(struct v4l2_fh *fh,
+ 	if (sub->type < UVC_EVENT_FIRST || sub->type > UVC_EVENT_LAST)
+ 		return -EINVAL;
+ 
++	guard(mutex)(&uvc->lock);
++
+ 	if (sub->type == UVC_EVENT_SETUP && uvc->func_connected)
+ 		return -EBUSY;
+ 
+@@ -512,7 +514,8 @@ static void uvc_v4l2_disable(struct uvc_device *uvc)
+ 	uvc_function_disconnect(uvc);
+ 	uvcg_video_enable(&uvc->video, 0);
+ 	uvcg_free_buffers(&uvc->video.queue);
+-	uvc->func_connected = false;
++	scoped_guard(mutex, &uvc->lock)
++		uvc->func_connected = false;
+ 	wake_up_interruptible(&uvc->func_connected_queue);
+ }
+ 
+diff --git a/drivers/usb/gadget/udc/dummy_hcd.c b/drivers/usb/gadget/udc/dummy_hcd.c
+index a06f56c08e19d0..543c4977aaa4e1 100644
+--- a/drivers/usb/gadget/udc/dummy_hcd.c
++++ b/drivers/usb/gadget/udc/dummy_hcd.c
+@@ -461,8 +461,13 @@ static void set_link_state(struct dummy_hcd *dum_hcd)
+ 
+ 		/* Report reset and disconnect events to the driver */
+ 		if (dum->ints_enabled && (disconnect || reset)) {
+-			stop_activity(dum);
+ 			++dum->callback_usage;
++			/*
++			 * stop_activity() can drop dum->lock, so it must
++			 * not come between the dum->ints_enabled test
++			 * and the ++dum->callback_usage.
++			 */
++			stop_activity(dum);
+ 			spin_unlock(&dum->lock);
+ 			if (reset)
+ 				usb_gadget_udc_reset(&dum->gadget, dum->driver);
+@@ -907,21 +912,6 @@ static int dummy_pullup(struct usb_gadget *_gadget, int value)
+ 	spin_lock_irqsave(&dum->lock, flags);
+ 	dum->pullup = (value != 0);
+ 	set_link_state(dum_hcd);
+-	if (value == 0) {
+-		/*
+-		 * Emulate synchronize_irq(): wait for callbacks to finish.
+-		 * This seems to be the best place to emulate the call to
+-		 * synchronize_irq() that's in usb_gadget_remove_driver().
+-		 * Doing it in dummy_udc_stop() would be too late since it
+-		 * is called after the unbind callback and unbind shouldn't
+-		 * be invoked until all the other callbacks are finished.
+-		 */
+-		while (dum->callback_usage > 0) {
+-			spin_unlock_irqrestore(&dum->lock, flags);
+-			usleep_range(1000, 2000);
+-			spin_lock_irqsave(&dum->lock, flags);
+-		}
+-	}
+ 	spin_unlock_irqrestore(&dum->lock, flags);
+ 
+ 	usb_hcd_poll_rh_status(dummy_hcd_to_hcd(dum_hcd));
+@@ -944,6 +934,20 @@ static void dummy_udc_async_callbacks(struct usb_gadget *_gadget, bool enable)
+ 
+ 	spin_lock_irq(&dum->lock);
+ 	dum->ints_enabled = enable;
++	if (!enable) {
++		/*
++		 * Emulate synchronize_irq(): wait for callbacks to finish.
++		 * This has to happen after emulated interrupts are disabled
++		 * (dum->ints_enabled is clear) and before the unbind callback,
++		 * just like the call to synchronize_irq() in
++		 * gadget/udc/core:gadget_unbind_driver().
++		 */
++		while (dum->callback_usage > 0) {
++			spin_unlock_irq(&dum->lock);
++			usleep_range(1000, 2000);
++			spin_lock_irq(&dum->lock);
++		}
++	}
+ 	spin_unlock_irq(&dum->lock);
+ }
+ 
+@@ -1533,6 +1537,12 @@ top:
+ 		/* rescan to continue with any other queued i/o */
+ 		if (rescan)
+ 			goto top;
++
++		/* request not fully transferred; stop iterating to
++		 * preserve data ordering across queued requests.
++		 */
++		if (req->req.actual < req->req.length)
++			break;
+ 	}
+ 	return sent;
+ }
+diff --git a/drivers/usb/host/ehci-brcm.c b/drivers/usb/host/ehci-brcm.c
+index 77e42c739c5806..fc0b61bfb0dff7 100644
+--- a/drivers/usb/host/ehci-brcm.c
++++ b/drivers/usb/host/ehci-brcm.c
+@@ -31,8 +31,8 @@ static inline void ehci_brcm_wait_for_sof(struct ehci_hcd *ehci, u32 delay)
+ 	int res;
+ 
+ 	/* Wait for next microframe (every 125 usecs) */
+-	res = readl_relaxed_poll_timeout(&ehci->regs->frame_index, val,
+-					 val != frame_idx, 1, 130);
++	res = readl_relaxed_poll_timeout_atomic(&ehci->regs->frame_index,
++						val, val != frame_idx, 1, 130);
+ 	if (res)
+ 		ehci_err(ehci, "Error waiting for SOF\n");
+ 	udelay(delay);
+diff --git a/drivers/usb/serial/io_edgeport.c b/drivers/usb/serial/io_edgeport.c
+index 477c0927dc1b9d..179c02f5209e40 100644
+--- a/drivers/usb/serial/io_edgeport.c
++++ b/drivers/usb/serial/io_edgeport.c
+@@ -73,6 +73,7 @@ static const struct usb_device_id edgeport_4port_id_table[] = {
+ 	{ USB_DEVICE(USB_VENDOR_ID_ION, ION_DEVICE_ID_EDGEPORT_22I) },
+ 	{ USB_DEVICE(USB_VENDOR_ID_ION, ION_DEVICE_ID_EDGEPORT_412_4) },
+ 	{ USB_DEVICE(USB_VENDOR_ID_ION, ION_DEVICE_ID_EDGEPORT_COMPATIBLE) },
++	{ USB_DEVICE(USB_VENDOR_ID_ION, ION_DEVICE_ID_BLACKBOX_IC135A) },
+ 	{ }
+ };
+ 
+@@ -121,6 +122,7 @@ static const struct usb_device_id id_table_combined[] = {
+ 	{ USB_DEVICE(USB_VENDOR_ID_ION, ION_DEVICE_ID_EDGEPORT_8R) },
+ 	{ USB_DEVICE(USB_VENDOR_ID_ION, ION_DEVICE_ID_EDGEPORT_8RR) },
+ 	{ USB_DEVICE(USB_VENDOR_ID_ION, ION_DEVICE_ID_EDGEPORT_412_8) },
++	{ USB_DEVICE(USB_VENDOR_ID_ION, ION_DEVICE_ID_BLACKBOX_IC135A) },
+ 	{ USB_DEVICE(USB_VENDOR_ID_NCR, NCR_DEVICE_ID_EPIC_0202) },
+ 	{ USB_DEVICE(USB_VENDOR_ID_NCR, NCR_DEVICE_ID_EPIC_0203) },
+ 	{ USB_DEVICE(USB_VENDOR_ID_NCR, NCR_DEVICE_ID_EPIC_0310) },
+@@ -470,6 +472,7 @@ static void get_product_info(struct edgeport_serial *edge_serial)
+ 	case ION_DEVICE_ID_EDGEPORT_2_DIN:
+ 	case ION_DEVICE_ID_EDGEPORT_4_DIN:
+ 	case ION_DEVICE_ID_EDGEPORT_16_DUAL_CPU:
++	case ION_DEVICE_ID_BLACKBOX_IC135A:
+ 		product_info->IsRS232 = 1;
+ 		break;
+ 
+diff --git a/drivers/usb/serial/io_usbvend.h b/drivers/usb/serial/io_usbvend.h
+index 9a6f742ad3abd0..c82a275e8e76ec 100644
+--- a/drivers/usb/serial/io_usbvend.h
++++ b/drivers/usb/serial/io_usbvend.h
+@@ -211,6 +211,7 @@
+ 
+ //
+ // Definitions for other product IDs
++#define ION_DEVICE_ID_BLACKBOX_IC135A		0x0801	// OEM device (rebranded Edgeport/4)
+ #define ION_DEVICE_ID_MT4X56USB			0x1403	// OEM device
+ #define ION_DEVICE_ID_E5805A			0x1A01  // OEM device (rebranded Edgeport/4)
+ 
+diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
+index 58f34c8d2b84ac..2d632e892da489 100644
+--- a/drivers/usb/serial/option.c
++++ b/drivers/usb/serial/option.c
+@@ -2441,6 +2441,9 @@ static const struct usb_device_id option_ids[] = {
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x2dee, 0x4d22, 0xff, 0xff, 0x30) },	/* MeiG Smart SRM815 and SRM825L */
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x2dee, 0x4d22, 0xff, 0xff, 0x40) },	/* MeiG Smart SRM825L */
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x2dee, 0x4d22, 0xff, 0xff, 0x60) },	/* MeiG Smart SRM825L */
++	{ USB_DEVICE_AND_INTERFACE_INFO(0x2dee, 0x4d38, 0xff, 0xff, 0x30) },	/* MeiG Smart SRM825WN (Diag) */
++	{ USB_DEVICE_AND_INTERFACE_INFO(0x2dee, 0x4d38, 0xff, 0xff, 0x40) },	/* MeiG Smart SRM825WN (AT) */
++	{ USB_DEVICE_AND_INTERFACE_INFO(0x2dee, 0x4d38, 0xff, 0xff, 0x60) },	/* MeiG Smart SRM825WN (NMEA) */
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x2df3, 0x9d03, 0xff) },			/* LongSung M5710 */
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x305a, 0x1404, 0xff) },			/* GosunCn GM500 RNDIS */
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x305a, 0x1405, 0xff) },			/* GosunCn GM500 MBIM */
+@@ -2461,6 +2464,7 @@ static const struct usb_device_id option_ids[] = {
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x33f8, 0x0302, 0xff) },			/* Rolling RW101R-GL (laptop MBIM) */
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x33f8, 0x0802, 0xff),			/* Rolling RW350-GL (laptop MBIM) */
+ 	  .driver_info = RSVD(5) },
++	{ USB_DEVICE_INTERFACE_CLASS(0x33f8, 0x1003, 0xff) },			/* Rolling RW135R-GL (laptop MBIM) */
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x3731, 0x0100, 0xff, 0xff, 0x30) },	/* NetPrisma LCUK54-WWD for Global */
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x3731, 0x0100, 0xff, 0x00, 0x40) },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x3731, 0x0100, 0xff, 0xff, 0x40) },
+diff --git a/drivers/vfio/device_cdev.c b/drivers/vfio/device_cdev.c
+index e75da0a70d1f83..bb1817bd4ff319 100644
+--- a/drivers/vfio/device_cdev.c
++++ b/drivers/vfio/device_cdev.c
+@@ -39,6 +39,13 @@ int vfio_device_fops_cdev_open(struct inode *inode, struct file *filep)
+ 
+ 	filep->private_data = df;
+ 
++	/*
++	 * Use the pseudo fs inode on the device to link all mmaps
++	 * to the same address space, allowing us to unmap all vmas
++	 * associated to this device using unmap_mapping_range().
++	 */
++	filep->f_mapping = device->inode->i_mapping;
++
+ 	return 0;
+ 
+ err_put_registration:
+diff --git a/drivers/vfio/group.c b/drivers/vfio/group.c
+index 54c3079031e165..4cd857ff0259b4 100644
+--- a/drivers/vfio/group.c
++++ b/drivers/vfio/group.c
+@@ -285,6 +285,13 @@ static struct file *vfio_device_open_file(struct vfio_device *device)
+ 	 */
+ 	filep->f_mode |= (FMODE_PREAD | FMODE_PWRITE);
+ 
++	/*
++	 * Use the pseudo fs inode on the device to link all mmaps
++	 * to the same address space, allowing us to unmap all vmas
++	 * associated to this device using unmap_mapping_range().
++	 */
++	filep->f_mapping = device->inode->i_mapping;
++
+ 	if (device->group->type == VFIO_NO_IOMMU)
+ 		dev_warn(device->dev, "vfio-noiommu device opened by user "
+ 			 "(%s:%d)\n", current->comm, task_pid_nr(current));
+diff --git a/drivers/vfio/pci/vfio_pci_core.c b/drivers/vfio/pci/vfio_pci_core.c
+index 3f139360752e29..55e28feba475ed 100644
+--- a/drivers/vfio/pci/vfio_pci_core.c
++++ b/drivers/vfio/pci/vfio_pci_core.c
+@@ -1599,100 +1599,20 @@ ssize_t vfio_pci_core_write(struct vfio_device *core_vdev, const char __user *bu
+ }
+ EXPORT_SYMBOL_GPL(vfio_pci_core_write);
+ 
+-/* Return 1 on zap and vma_lock acquired, 0 on contention (only with @try) */
+-static int vfio_pci_zap_and_vma_lock(struct vfio_pci_core_device *vdev, bool try)
++static void vfio_pci_zap_bars(struct vfio_pci_core_device *vdev)
+ {
+-	struct vfio_pci_mmap_vma *mmap_vma, *tmp;
++	struct vfio_device *core_vdev = &vdev->vdev;
++	loff_t start = VFIO_PCI_INDEX_TO_OFFSET(VFIO_PCI_BAR0_REGION_INDEX);
++	loff_t end = VFIO_PCI_INDEX_TO_OFFSET(VFIO_PCI_ROM_REGION_INDEX);
++	loff_t len = end - start;
+ 
+-	/*
+-	 * Lock ordering:
+-	 * vma_lock is nested under mmap_lock for vm_ops callback paths.
+-	 * The memory_lock semaphore is used by both code paths calling
+-	 * into this function to zap vmas and the vm_ops.fault callback
+-	 * to protect the memory enable state of the device.
+-	 *
+-	 * When zapping vmas we need to maintain the mmap_lock => vma_lock
+-	 * ordering, which requires using vma_lock to walk vma_list to
+-	 * acquire an mm, then dropping vma_lock to get the mmap_lock and
+-	 * reacquiring vma_lock.  This logic is derived from similar
+-	 * requirements in uverbs_user_mmap_disassociate().
+-	 *
+-	 * mmap_lock must always be the top-level lock when it is taken.
+-	 * Therefore we can only hold the memory_lock write lock when
+-	 * vma_list is empty, as we'd need to take mmap_lock to clear
+-	 * entries.  vma_list can only be guaranteed empty when holding
+-	 * vma_lock, thus memory_lock is nested under vma_lock.
+-	 *
+-	 * This enables the vm_ops.fault callback to acquire vma_lock,
+-	 * followed by memory_lock read lock, while already holding
+-	 * mmap_lock without risk of deadlock.
+-	 */
+-	while (1) {
+-		struct mm_struct *mm = NULL;
+-
+-		if (try) {
+-			if (!mutex_trylock(&vdev->vma_lock))
+-				return 0;
+-		} else {
+-			mutex_lock(&vdev->vma_lock);
+-		}
+-		while (!list_empty(&vdev->vma_list)) {
+-			mmap_vma = list_first_entry(&vdev->vma_list,
+-						    struct vfio_pci_mmap_vma,
+-						    vma_next);
+-			mm = mmap_vma->vma->vm_mm;
+-			if (mmget_not_zero(mm))
+-				break;
+-
+-			list_del(&mmap_vma->vma_next);
+-			kfree(mmap_vma);
+-			mm = NULL;
+-		}
+-		if (!mm)
+-			return 1;
+-		mutex_unlock(&vdev->vma_lock);
+-
+-		if (try) {
+-			if (!mmap_read_trylock(mm)) {
+-				mmput(mm);
+-				return 0;
+-			}
+-		} else {
+-			mmap_read_lock(mm);
+-		}
+-		if (try) {
+-			if (!mutex_trylock(&vdev->vma_lock)) {
+-				mmap_read_unlock(mm);
+-				mmput(mm);
+-				return 0;
+-			}
+-		} else {
+-			mutex_lock(&vdev->vma_lock);
+-		}
+-		list_for_each_entry_safe(mmap_vma, tmp,
+-					 &vdev->vma_list, vma_next) {
+-			struct vm_area_struct *vma = mmap_vma->vma;
+-
+-			if (vma->vm_mm != mm)
+-				continue;
+-
+-			list_del(&mmap_vma->vma_next);
+-			kfree(mmap_vma);
+-
+-			zap_vma_ptes(vma, vma->vm_start,
+-				     vma->vm_end - vma->vm_start);
+-		}
+-		mutex_unlock(&vdev->vma_lock);
+-		mmap_read_unlock(mm);
+-		mmput(mm);
+-	}
++	unmap_mapping_range(core_vdev->inode->i_mapping, start, len, true);
+ }
+ 
+ void vfio_pci_zap_and_down_write_memory_lock(struct vfio_pci_core_device *vdev)
+ {
+-	vfio_pci_zap_and_vma_lock(vdev, false);
+ 	down_write(&vdev->memory_lock);
+-	mutex_unlock(&vdev->vma_lock);
++	vfio_pci_zap_bars(vdev);
+ }
+ 
+ u16 vfio_pci_memory_lock_and_enable(struct vfio_pci_core_device *vdev)
+@@ -1714,99 +1634,56 @@ void vfio_pci_memory_unlock_and_restore(struct vfio_pci_core_device *vdev, u16 c
+ 	up_write(&vdev->memory_lock);
+ }
+ 
+-/* Caller holds vma_lock */
+-static int __vfio_pci_add_vma(struct vfio_pci_core_device *vdev,
+-			      struct vm_area_struct *vma)
+-{
+-	struct vfio_pci_mmap_vma *mmap_vma;
+-
+-	mmap_vma = kmalloc(sizeof(*mmap_vma), GFP_KERNEL_ACCOUNT);
+-	if (!mmap_vma)
+-		return -ENOMEM;
+-
+-	mmap_vma->vma = vma;
+-	list_add(&mmap_vma->vma_next, &vdev->vma_list);
+-
+-	return 0;
+-}
+-
+-/*
+- * Zap mmaps on open so that we can fault them in on access and therefore
+- * our vma_list only tracks mappings accessed since last zap.
+- */
+-static void vfio_pci_mmap_open(struct vm_area_struct *vma)
+-{
+-	zap_vma_ptes(vma, vma->vm_start, vma->vm_end - vma->vm_start);
+-}
+-
+-static void vfio_pci_mmap_close(struct vm_area_struct *vma)
++static unsigned long vma_to_pfn(struct vm_area_struct *vma)
+ {
+ 	struct vfio_pci_core_device *vdev = vma->vm_private_data;
+-	struct vfio_pci_mmap_vma *mmap_vma;
++	int index = vma->vm_pgoff >> (VFIO_PCI_OFFSET_SHIFT - PAGE_SHIFT);
++	u64 pgoff;
+ 
+-	mutex_lock(&vdev->vma_lock);
+-	list_for_each_entry(mmap_vma, &vdev->vma_list, vma_next) {
+-		if (mmap_vma->vma == vma) {
+-			list_del(&mmap_vma->vma_next);
+-			kfree(mmap_vma);
+-			break;
+-		}
+-	}
+-	mutex_unlock(&vdev->vma_lock);
++	pgoff = vma->vm_pgoff &
++		((1U << (VFIO_PCI_OFFSET_SHIFT - PAGE_SHIFT)) - 1);
++
++	return (pci_resource_start(vdev->pdev, index) >> PAGE_SHIFT) + pgoff;
+ }
+ 
+ static vm_fault_t vfio_pci_mmap_fault(struct vm_fault *vmf)
+ {
+ 	struct vm_area_struct *vma = vmf->vma;
+ 	struct vfio_pci_core_device *vdev = vma->vm_private_data;
+-	struct vfio_pci_mmap_vma *mmap_vma;
+-	vm_fault_t ret = VM_FAULT_NOPAGE;
++	unsigned long pfn, pgoff = vmf->pgoff - vma->vm_pgoff;
++	unsigned long addr = vma->vm_start;
++	vm_fault_t ret = VM_FAULT_SIGBUS;
++
++	pfn = vma_to_pfn(vma);
+ 
+-	mutex_lock(&vdev->vma_lock);
+ 	down_read(&vdev->memory_lock);
+ 
+-	/*
+-	 * Memory region cannot be accessed if the low power feature is engaged
+-	 * or memory access is disabled.
+-	 */
+-	if (vdev->pm_runtime_engaged || !__vfio_pci_memory_enabled(vdev)) {
+-		ret = VM_FAULT_SIGBUS;
+-		goto up_out;
+-	}
++	if (vdev->pm_runtime_engaged || !__vfio_pci_memory_enabled(vdev))
++		goto out_unlock;
++
++	ret = vmf_insert_pfn(vma, vmf->address, pfn + pgoff);
++	if (ret & VM_FAULT_ERROR)
++		goto out_unlock;
+ 
+ 	/*
+-	 * We populate the whole vma on fault, so we need to test whether
+-	 * the vma has already been mapped, such as for concurrent faults
+-	 * to the same vma.  io_remap_pfn_range() will trigger a BUG_ON if
+-	 * we ask it to fill the same range again.
++	 * Pre-fault the remainder of the vma, abort further insertions and
++	 * supress error if fault is encountered during pre-fault.
+ 	 */
+-	list_for_each_entry(mmap_vma, &vdev->vma_list, vma_next) {
+-		if (mmap_vma->vma == vma)
+-			goto up_out;
+-	}
+-
+-	if (io_remap_pfn_range(vma, vma->vm_start, vma->vm_pgoff,
+-			       vma->vm_end - vma->vm_start,
+-			       vma->vm_page_prot)) {
+-		ret = VM_FAULT_SIGBUS;
+-		zap_vma_ptes(vma, vma->vm_start, vma->vm_end - vma->vm_start);
+-		goto up_out;
+-	}
++	for (; addr < vma->vm_end; addr += PAGE_SIZE, pfn++) {
++		if (addr == vmf->address)
++			continue;
+ 
+-	if (__vfio_pci_add_vma(vdev, vma)) {
+-		ret = VM_FAULT_OOM;
+-		zap_vma_ptes(vma, vma->vm_start, vma->vm_end - vma->vm_start);
++		if (vmf_insert_pfn(vma, addr, pfn) & VM_FAULT_ERROR)
++			break;
+ 	}
+ 
+-up_out:
++out_unlock:
+ 	up_read(&vdev->memory_lock);
+-	mutex_unlock(&vdev->vma_lock);
++
+ 	return ret;
+ }
+ 
+ static const struct vm_operations_struct vfio_pci_mmap_ops = {
+-	.open = vfio_pci_mmap_open,
+-	.close = vfio_pci_mmap_close,
+ 	.fault = vfio_pci_mmap_fault,
+ };
+ 
+@@ -1869,11 +1746,12 @@ int vfio_pci_core_mmap(struct vfio_device *core_vdev, struct vm_area_struct *vma
+ 
+ 	vma->vm_private_data = vdev;
+ 	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+-	vma->vm_pgoff = (pci_resource_start(pdev, index) >> PAGE_SHIFT) + pgoff;
++	vma->vm_page_prot = pgprot_decrypted(vma->vm_page_prot);
+ 
+ 	/*
+-	 * See remap_pfn_range(), called from vfio_pci_fault() but we can't
+-	 * change vm_flags within the fault handler.  Set them now.
++	 * Set vm_flags now, they should not be changed in the fault handler.
++	 * We want the same flags and page protection (decrypted above) as
++	 * io_remap_pfn_range() would set.
+ 	 */
+ 	vm_flags_set(vma, VM_IO | VM_PFNMAP | VM_DONTEXPAND | VM_DONTDUMP);
+ 	vma->vm_ops = &vfio_pci_mmap_ops;
+@@ -2173,8 +2051,6 @@ int vfio_pci_core_init_dev(struct vfio_device *core_vdev)
+ 	mutex_init(&vdev->ioeventfds_lock);
+ 	INIT_LIST_HEAD(&vdev->dummy_resources_list);
+ 	INIT_LIST_HEAD(&vdev->ioeventfds_list);
+-	mutex_init(&vdev->vma_lock);
+-	INIT_LIST_HEAD(&vdev->vma_list);
+ 	INIT_LIST_HEAD(&vdev->sriov_pfs_item);
+ 	init_rwsem(&vdev->memory_lock);
+ 	xa_init(&vdev->ctx);
+@@ -2190,7 +2066,6 @@ void vfio_pci_core_release_dev(struct vfio_device *core_vdev)
+ 
+ 	mutex_destroy(&vdev->igate);
+ 	mutex_destroy(&vdev->ioeventfds_lock);
+-	mutex_destroy(&vdev->vma_lock);
+ 	kfree(vdev->region);
+ 	kfree(vdev->pm_save);
+ }
+@@ -2468,26 +2343,15 @@ unwind:
+ 	return ret;
+ }
+ 
+-/*
+- * We need to get memory_lock for each device, but devices can share mmap_lock,
+- * therefore we need to zap and hold the vma_lock for each device, and only then
+- * get each memory_lock.
+- */
+ static int vfio_pci_dev_set_hot_reset(struct vfio_device_set *dev_set,
+ 				      struct vfio_pci_group_info *groups,
+ 				      struct iommufd_ctx *iommufd_ctx)
+ {
+-	struct vfio_pci_core_device *cur_mem;
+-	struct vfio_pci_core_device *cur_vma;
+-	struct vfio_pci_core_device *cur;
++	struct vfio_pci_core_device *vdev;
+ 	struct pci_dev *pdev;
+-	bool is_mem = true;
+ 	int ret;
+ 
+ 	mutex_lock(&dev_set->lock);
+-	cur_mem = list_first_entry(&dev_set->device_list,
+-				   struct vfio_pci_core_device,
+-				   vdev.dev_set_list);
+ 
+ 	pdev = vfio_pci_dev_set_resettable(dev_set);
+ 	if (!pdev) {
+@@ -2504,7 +2368,7 @@ static int vfio_pci_dev_set_hot_reset(struct vfio_device_set *dev_set,
+ 	if (ret)
+ 		goto err_unlock;
+ 
+-	list_for_each_entry(cur_vma, &dev_set->device_list, vdev.dev_set_list) {
++	list_for_each_entry(vdev, &dev_set->device_list, vdev.dev_set_list) {
+ 		bool owned;
+ 
+ 		/*
+@@ -2528,38 +2392,38 @@ static int vfio_pci_dev_set_hot_reset(struct vfio_device_set *dev_set,
+ 		 * Otherwise, reset is not allowed.
+ 		 */
+ 		if (iommufd_ctx) {
+-			int devid = vfio_iommufd_get_dev_id(&cur_vma->vdev,
++			int devid = vfio_iommufd_get_dev_id(&vdev->vdev,
+ 							    iommufd_ctx);
+ 
+ 			owned = (devid > 0 || devid == -ENOENT);
+ 		} else {
+-			owned = vfio_dev_in_groups(&cur_vma->vdev, groups);
++			owned = vfio_dev_in_groups(&vdev->vdev, groups);
+ 		}
+ 
+ 		if (!owned) {
+ 			ret = -EINVAL;
+-			goto err_undo;
++			break;
+ 		}
+ 
+ 		/*
+-		 * Locking multiple devices is prone to deadlock, runaway and
+-		 * unwind if we hit contention.
++		 * Take the memory write lock for each device and zap BAR
++		 * mappings to prevent the user accessing the device while in
++		 * reset.  Locking multiple devices is prone to deadlock,
++		 * runaway and unwind if we hit contention.
+ 		 */
+-		if (!vfio_pci_zap_and_vma_lock(cur_vma, true)) {
++		if (!down_write_trylock(&vdev->memory_lock)) {
+ 			ret = -EBUSY;
+-			goto err_undo;
++			break;
+ 		}
++
++		vfio_pci_zap_bars(vdev);
+ 	}
+-	cur_vma = NULL;
+ 
+-	list_for_each_entry(cur_mem, &dev_set->device_list, vdev.dev_set_list) {
+-		if (!down_write_trylock(&cur_mem->memory_lock)) {
+-			ret = -EBUSY;
+-			goto err_undo;
+-		}
+-		mutex_unlock(&cur_mem->vma_lock);
++	if (!list_entry_is_head(vdev,
++				&dev_set->device_list, vdev.dev_set_list)) {
++		vdev = list_prev_entry(vdev, vdev.dev_set_list);
++		goto err_undo;
+ 	}
+-	cur_mem = NULL;
+ 
+ 	/*
+ 	 * The pci_reset_bus() will reset all the devices in the bus.
+@@ -2570,25 +2434,22 @@ static int vfio_pci_dev_set_hot_reset(struct vfio_device_set *dev_set,
+ 	 * cause the PCI config space reset without restoring the original
+ 	 * state (saved locally in 'vdev->pm_save').
+ 	 */
+-	list_for_each_entry(cur, &dev_set->device_list, vdev.dev_set_list)
+-		vfio_pci_set_power_state(cur, PCI_D0);
++	list_for_each_entry(vdev, &dev_set->device_list, vdev.dev_set_list)
++		vfio_pci_set_power_state(vdev, PCI_D0);
+ 
+ 	ret = pci_reset_bus(pdev);
+ 
++	vdev = list_last_entry(&dev_set->device_list,
++			       struct vfio_pci_core_device, vdev.dev_set_list);
++
+ err_undo:
+-	list_for_each_entry(cur, &dev_set->device_list, vdev.dev_set_list) {
+-		if (cur == cur_mem)
+-			is_mem = false;
+-		if (cur == cur_vma)
+-			break;
+-		if (is_mem)
+-			up_write(&cur->memory_lock);
+-		else
+-			mutex_unlock(&cur->vma_lock);
+-	}
++	list_for_each_entry_from_reverse(vdev, &dev_set->device_list,
++					 vdev.dev_set_list)
++		up_write(&vdev->memory_lock);
++
++	list_for_each_entry(vdev, &dev_set->device_list, vdev.dev_set_list)
++		pm_runtime_put(&vdev->pdev->dev);
+ 
+-	list_for_each_entry(cur, &dev_set->device_list, vdev.dev_set_list)
+-		pm_runtime_put(&cur->pdev->dev);
+ err_unlock:
+ 	mutex_unlock(&dev_set->lock);
+ 	return ret;
+diff --git a/drivers/vfio/vfio_main.c b/drivers/vfio/vfio_main.c
+index 6dfb290c339f99..ec4fbd993bf006 100644
+--- a/drivers/vfio/vfio_main.c
++++ b/drivers/vfio/vfio_main.c
+@@ -22,8 +22,10 @@
+ #include <linux/list.h>
+ #include <linux/miscdevice.h>
+ #include <linux/module.h>
++#include <linux/mount.h>
+ #include <linux/mutex.h>
+ #include <linux/pci.h>
++#include <linux/pseudo_fs.h>
+ #include <linux/rwsem.h>
+ #include <linux/sched.h>
+ #include <linux/slab.h>
+@@ -43,9 +45,13 @@
+ #define DRIVER_AUTHOR	"Alex Williamson <alex.williamson@redhat.com>"
+ #define DRIVER_DESC	"VFIO - User Level meta-driver"
+ 
++#define VFIO_MAGIC 0x5646494f /* "VFIO" */
++
+ static struct vfio {
+ 	struct class			*device_class;
+ 	struct ida			device_ida;
++	struct vfsmount			*vfs_mount;
++	int				fs_count;
+ } vfio;
+ 
+ #ifdef CONFIG_VFIO_NOIOMMU
+@@ -186,6 +192,8 @@ static void vfio_device_release(struct device *dev)
+ 	if (device->ops->release)
+ 		device->ops->release(device);
+ 
++	iput(device->inode);
++	simple_release_fs(&vfio.vfs_mount, &vfio.fs_count);
+ 	kvfree(device);
+ }
+ 
+@@ -228,6 +236,34 @@ out_free:
+ }
+ EXPORT_SYMBOL_GPL(_vfio_alloc_device);
+ 
++static int vfio_fs_init_fs_context(struct fs_context *fc)
++{
++	return init_pseudo(fc, VFIO_MAGIC) ? 0 : -ENOMEM;
++}
++
++static struct file_system_type vfio_fs_type = {
++	.name = "vfio",
++	.owner = THIS_MODULE,
++	.init_fs_context = vfio_fs_init_fs_context,
++	.kill_sb = kill_anon_super,
++};
++
++static struct inode *vfio_fs_inode_new(void)
++{
++	struct inode *inode;
++	int ret;
++
++	ret = simple_pin_fs(&vfio_fs_type, &vfio.vfs_mount, &vfio.fs_count);
++	if (ret)
++		return ERR_PTR(ret);
++
++	inode = alloc_anon_inode(vfio.vfs_mount->mnt_sb);
++	if (IS_ERR(inode))
++		simple_release_fs(&vfio.vfs_mount, &vfio.fs_count);
++
++	return inode;
++}
++
+ /*
+  * Initialize a vfio_device so it can be registered to vfio core.
+  */
+@@ -246,6 +282,11 @@ static int vfio_init_device(struct vfio_device *device, struct device *dev,
+ 	init_completion(&device->comp);
+ 	device->dev = dev;
+ 	device->ops = ops;
++	device->inode = vfio_fs_inode_new();
++	if (IS_ERR(device->inode)) {
++		ret = PTR_ERR(device->inode);
++		goto out_inode;
++	}
+ 
+ 	if (ops->init) {
+ 		ret = ops->init(device);
+@@ -260,6 +301,9 @@ static int vfio_init_device(struct vfio_device *device, struct device *dev,
+ 	return 0;
+ 
+ out_uninit:
++	iput(device->inode);
++	simple_release_fs(&vfio.vfs_mount, &vfio.fs_count);
++out_inode:
+ 	vfio_release_device_set(device);
+ 	ida_free(&vfio.device_ida, device->index);
+ 	return ret;
+diff --git a/fs/btrfs/inode.c b/fs/btrfs/inode.c
+index cf39f52fc0484b..46df425ab7bae8 100644
+--- a/fs/btrfs/inode.c
++++ b/fs/btrfs/inode.c
+@@ -691,8 +691,12 @@ out:
+ 	 * it won't count as data extent, free them directly here.
+ 	 * And at reserve time, it's always aligned to page size, so
+ 	 * just free one page here.
++	 *
++	 * If we fallback to non-inline (ret == 1) due to -ENOSPC, then we need
++	 * to keep the data reservation.
+ 	 */
+-	btrfs_qgroup_free_data(inode, NULL, 0, PAGE_SIZE, NULL);
++	if (ret <= 0)
++		btrfs_qgroup_free_data(inode, NULL, 0, fs_info->sectorsize, NULL);
+ 	btrfs_free_path(path);
+ 	if (trans)
+ 		btrfs_end_transaction(trans);
+diff --git a/fs/btrfs/tree-checker.c b/fs/btrfs/tree-checker.c
+index d2c36b765c83a1..0689bd3832f8c8 100644
+--- a/fs/btrfs/tree-checker.c
++++ b/fs/btrfs/tree-checker.c
+@@ -1224,6 +1224,23 @@ static int check_root_item(struct extent_buffer *leaf, struct btrfs_key *key,
+ 			    btrfs_root_drop_level(&ri), BTRFS_MAX_LEVEL - 1);
+ 		return -EUCLEAN;
+ 	}
++	/*
++	 * If drop_progress.objectid is non-zero, a btrfs_drop_snapshot() was
++	 * interrupted and the resume point was recorded in drop_progress and
++	 * drop_level.  In that case drop_level must be >= 1: level 0 is the
++	 * leaf level and drop_snapshot never saves a checkpoint there (it
++	 * only records checkpoints at internal node levels in DROP_REFERENCE
++	 * stage).  A zero drop_level combined with a non-zero drop_progress
++	 * objectid indicates on-disk corruption and would cause a BUG_ON in
++	 * merge_reloc_root() and btrfs_drop_snapshot() at mount time.
++	 */
++	if (unlikely(btrfs_disk_key_objectid(&ri.drop_progress) != 0 &&
++		     btrfs_root_drop_level(&ri) == 0)) {
++		generic_err(leaf, slot,
++			    "invalid root drop_level 0 with non-zero drop_progress objectid %llu",
++			    btrfs_disk_key_objectid(&ri.drop_progress));
++		return -EUCLEAN;
++	}
+ 
+ 	/* Flags check */
+ 	if (unlikely(btrfs_root_flags(&ri) & ~valid_root_flags)) {
+diff --git a/fs/btrfs/zoned.c b/fs/btrfs/zoned.c
+index 6e8b8c46ba18f6..dabbfc3b7d776b 100644
+--- a/fs/btrfs/zoned.c
++++ b/fs/btrfs/zoned.c
+@@ -342,7 +342,10 @@ int btrfs_get_dev_zone_info_all_devices(struct btrfs_fs_info *fs_info)
+ 	if (!btrfs_fs_incompat(fs_info, ZONED))
+ 		return 0;
+ 
+-	mutex_lock(&fs_devices->device_list_mutex);
++	/*
++	 * No need to take the device_list mutex here, we're still in the mount
++	 * path and devices cannot be added to or removed from the list yet.
++	 */
+ 	list_for_each_entry(device, &fs_devices->devices, dev_list) {
+ 		/* We can skip reading of zone info for missing devices */
+ 		if (!device->bdev)
+@@ -352,7 +355,6 @@ int btrfs_get_dev_zone_info_all_devices(struct btrfs_fs_info *fs_info)
+ 		if (ret)
+ 			break;
+ 	}
+-	mutex_unlock(&fs_devices->device_list_mutex);
+ 
+ 	return ret;
+ }
+diff --git a/fs/ext4/fast_commit.c b/fs/ext4/fast_commit.c
+index 60727da9ea11d3..ca5f1b0d2687b5 100644
+--- a/fs/ext4/fast_commit.c
++++ b/fs/ext4/fast_commit.c
+@@ -997,7 +997,7 @@ static int ext4_fc_submit_inode_data_all(journal_t *journal)
+ 			finish_wait(&ei->i_fc_wait, &wait);
+ 		}
+ 		spin_unlock(&sbi->s_fc_lock);
+-		ret = jbd2_submit_inode_data(journal, ei->jinode);
++		ret = jbd2_submit_inode_data(journal, READ_ONCE(ei->jinode));
+ 		if (ret)
+ 			return ret;
+ 		spin_lock(&sbi->s_fc_lock);
+@@ -1022,7 +1022,7 @@ static int ext4_fc_wait_inode_data_all(journal_t *journal)
+ 			continue;
+ 		spin_unlock(&sbi->s_fc_lock);
+ 
+-		ret = jbd2_wait_inode_data(journal, pos->jinode);
++		ret = jbd2_wait_inode_data(journal, READ_ONCE(pos->jinode));
+ 		if (ret)
+ 			return ret;
+ 		spin_lock(&sbi->s_fc_lock);
+diff --git a/fs/ext4/inode.c b/fs/ext4/inode.c
+index 949377692c4911..d72e7f3263eaf9 100644
+--- a/fs/ext4/inode.c
++++ b/fs/ext4/inode.c
+@@ -123,6 +123,8 @@ void ext4_inode_csum_set(struct inode *inode, struct ext4_inode *raw,
+ static inline int ext4_begin_ordered_truncate(struct inode *inode,
+ 					      loff_t new_size)
+ {
++	struct jbd2_inode *jinode = READ_ONCE(EXT4_I(inode)->jinode);
++
+ 	trace_ext4_begin_ordered_truncate(inode, new_size);
+ 	/*
+ 	 * If jinode is zero, then we never opened the file for
+@@ -130,10 +132,10 @@ static inline int ext4_begin_ordered_truncate(struct inode *inode,
+ 	 * jbd2_journal_begin_ordered_truncate() since there's no
+ 	 * outstanding writes we need to flush.
+ 	 */
+-	if (!EXT4_I(inode)->jinode)
++	if (!jinode)
+ 		return 0;
+ 	return jbd2_journal_begin_ordered_truncate(EXT4_JOURNAL(inode),
+-						   EXT4_I(inode)->jinode,
++						   jinode,
+ 						   new_size);
+ }
+ 
+@@ -4160,8 +4162,13 @@ int ext4_inode_attach_jinode(struct inode *inode)
+ 			spin_unlock(&inode->i_lock);
+ 			return -ENOMEM;
+ 		}
+-		ei->jinode = jinode;
+-		jbd2_journal_init_jbd_inode(ei->jinode, inode);
++		jbd2_journal_init_jbd_inode(jinode, inode);
++		/*
++		 * Publish ->jinode only after it is fully initialized so that
++		 * readers never observe a partially initialized jbd2_inode.
++		 */
++		smp_wmb();
++		WRITE_ONCE(ei->jinode, jinode);
+ 		jinode = NULL;
+ 	}
+ 	spin_unlock(&inode->i_lock);
+diff --git a/fs/ext4/mballoc.c b/fs/ext4/mballoc.c
+index e9be0c0a8042c4..73b27ddafe9154 100644
+--- a/fs/ext4/mballoc.c
++++ b/fs/ext4/mballoc.c
+@@ -2892,6 +2892,8 @@ repeat:
+ 		 * from the goal value specified
+ 		 */
+ 		group = ac->ac_g_ex.fe_group;
++		if (group >= ngroups)
++			group = 0;
+ 		ac->ac_groups_linear_remaining = sbi->s_mb_max_linear_groups;
+ 		prefetch_grp = group;
+ 
+diff --git a/fs/gfs2/dir.c b/fs/gfs2/dir.c
+index 3a2a10d6d43d13..c4e9488483d909 100644
+--- a/fs/gfs2/dir.c
++++ b/fs/gfs2/dir.c
+@@ -60,6 +60,7 @@
+ #include <linux/crc32.h>
+ #include <linux/vmalloc.h>
+ #include <linux/bio.h>
++#include <linux/log2.h>
+ 
+ #include "gfs2.h"
+ #include "incore.h"
+@@ -562,15 +563,18 @@ static struct gfs2_dirent *gfs2_dirent_scan(struct inode *inode, void *buf,
+ 	int ret = 0;
+ 
+ 	ret = gfs2_dirent_offset(GFS2_SB(inode), buf);
+-	if (ret < 0)
+-		goto consist_inode;
+-
++	if (ret < 0) {
++		gfs2_consist_inode(GFS2_I(inode));
++		return ERR_PTR(-EIO);
++	}
+ 	offset = ret;
+ 	prev = NULL;
+ 	dent = buf + offset;
+ 	size = be16_to_cpu(dent->de_rec_len);
+-	if (gfs2_check_dirent(GFS2_SB(inode), dent, offset, size, len, 1))
+-		goto consist_inode;
++	if (gfs2_check_dirent(GFS2_SB(inode), dent, offset, size, len, 1)) {
++		gfs2_consist_inode(GFS2_I(inode));
++		return ERR_PTR(-EIO);
++	}
+ 	do {
+ 		ret = scan(dent, name, opaque);
+ 		if (ret)
+@@ -582,8 +586,10 @@ static struct gfs2_dirent *gfs2_dirent_scan(struct inode *inode, void *buf,
+ 		dent = buf + offset;
+ 		size = be16_to_cpu(dent->de_rec_len);
+ 		if (gfs2_check_dirent(GFS2_SB(inode), dent, offset, size,
+-				      len, 0))
+-			goto consist_inode;
++				      len, 0)) {
++			gfs2_consist_inode(GFS2_I(inode));
++			return ERR_PTR(-EIO);
++		}
+ 	} while(1);
+ 
+ 	switch(ret) {
+@@ -597,10 +603,6 @@ static struct gfs2_dirent *gfs2_dirent_scan(struct inode *inode, void *buf,
+ 		BUG_ON(ret > 0);
+ 		return ERR_PTR(ret);
+ 	}
+-
+-consist_inode:
+-	gfs2_consist_inode(GFS2_I(inode));
+-	return ERR_PTR(-EIO);
+ }
+ 
+ static int dirent_check_reclen(struct gfs2_inode *dip,
+@@ -609,14 +611,16 @@ static int dirent_check_reclen(struct gfs2_inode *dip,
+ 	const void *ptr = d;
+ 	u16 rec_len = be16_to_cpu(d->de_rec_len);
+ 
+-	if (unlikely(rec_len < sizeof(struct gfs2_dirent)))
+-		goto broken;
++	if (unlikely(rec_len < sizeof(struct gfs2_dirent))) {
++		gfs2_consist_inode(dip);
++		return -EIO;
++	}
+ 	ptr += rec_len;
+ 	if (ptr < end_p)
+ 		return rec_len;
+ 	if (ptr == end_p)
+ 		return -ENOENT;
+-broken:
++
+ 	gfs2_consist_inode(dip);
+ 	return -EIO;
+ }
+@@ -909,7 +913,6 @@ static int dir_make_exhash(struct inode *inode)
+ 	struct qstr args;
+ 	struct buffer_head *bh, *dibh;
+ 	struct gfs2_leaf *leaf;
+-	int y;
+ 	u32 x;
+ 	__be64 *lp;
+ 	u64 bn;
+@@ -976,9 +979,7 @@ static int dir_make_exhash(struct inode *inode)
+ 	i_size_write(inode, sdp->sd_sb.sb_bsize / 2);
+ 	gfs2_add_inode_blocks(&dip->i_inode, 1);
+ 	dip->i_diskflags |= GFS2_DIF_EXHASH;
+-
+-	for (x = sdp->sd_hash_ptrs, y = -1; x; x >>= 1, y++) ;
+-	dip->i_depth = y;
++	dip->i_depth = ilog2(sdp->sd_hash_ptrs);
+ 
+ 	gfs2_dinode_out(dip, dibh->b_data);
+ 
+diff --git a/fs/gfs2/glops.c b/fs/gfs2/glops.c
+index 4a169c60bce65d..f575cd8ff47c15 100644
+--- a/fs/gfs2/glops.c
++++ b/fs/gfs2/glops.c
+@@ -11,6 +11,7 @@
+ #include <linux/bio.h>
+ #include <linux/posix_acl.h>
+ #include <linux/security.h>
++#include <linux/log2.h>
+ 
+ #include "gfs2.h"
+ #include "incore.h"
+@@ -412,10 +413,14 @@ static int gfs2_dinode_in(struct gfs2_inode *ip, const void *buf)
+ 	struct inode *inode = &ip->i_inode;
+ 	bool is_new = inode->i_state & I_NEW;
+ 
+-	if (unlikely(ip->i_no_addr != be64_to_cpu(str->di_num.no_addr)))
+-		goto corrupt;
+-	if (unlikely(!is_new && inode_wrong_type(inode, mode)))
+-		goto corrupt;
++	if (unlikely(ip->i_no_addr != be64_to_cpu(str->di_num.no_addr))) {
++		gfs2_consist_inode(ip);
++		return -EIO;
++	}
++	if (unlikely(!is_new && inode_wrong_type(inode, mode))) {
++		gfs2_consist_inode(ip);
++		return -EIO;
++	}
+ 	ip->i_no_formal_ino = be64_to_cpu(str->di_num.no_formal_ino);
+ 	inode->i_mode = mode;
+ 	if (is_new) {
+@@ -451,26 +456,33 @@ static int gfs2_dinode_in(struct gfs2_inode *ip, const void *buf)
+ 	/* i_diskflags and i_eattr must be set before gfs2_set_inode_flags() */
+ 	gfs2_set_inode_flags(inode);
+ 	height = be16_to_cpu(str->di_height);
+-	if (unlikely(height > sdp->sd_max_height))
+-		goto corrupt;
++	if (unlikely(height > sdp->sd_max_height)) {
++		gfs2_consist_inode(ip);
++		return -EIO;
++	}
+ 	ip->i_height = (u8)height;
+ 
+ 	depth = be16_to_cpu(str->di_depth);
+-	if (unlikely(depth > GFS2_DIR_MAX_DEPTH))
+-		goto corrupt;
++	if (unlikely(depth > GFS2_DIR_MAX_DEPTH)) {
++		gfs2_consist_inode(ip);
++		return -EIO;
++	}
++	if ((ip->i_diskflags & GFS2_DIF_EXHASH) &&
++	    depth < ilog2(sdp->sd_hash_ptrs)) {
++		gfs2_consist_inode(ip);
++		return -EIO;
++	}
+ 	ip->i_depth = (u8)depth;
+ 	ip->i_entries = be32_to_cpu(str->di_entries);
+ 
+-	if (gfs2_is_stuffed(ip) && inode->i_size > gfs2_max_stuffed_size(ip))
+-		goto corrupt;
+-
++	if (gfs2_is_stuffed(ip) && inode->i_size > gfs2_max_stuffed_size(ip)) {
++		gfs2_consist_inode(ip);
++		return -EIO;
++	}
+ 	if (S_ISREG(inode->i_mode))
+ 		gfs2_set_aops(inode);
+ 
+ 	return 0;
+-corrupt:
+-	gfs2_consist_inode(ip);
+-	return -EIO;
+ }
+ 
+ /**
+diff --git a/fs/gfs2/xattr.c b/fs/gfs2/xattr.c
+index 2117011c8c5778..27b9dd1179c262 100644
+--- a/fs/gfs2/xattr.c
++++ b/fs/gfs2/xattr.c
+@@ -96,30 +96,34 @@ static int ea_foreach_i(struct gfs2_inode *ip, struct buffer_head *bh,
+ 		return -EIO;
+ 
+ 	for (ea = GFS2_EA_BH2FIRST(bh);; prev = ea, ea = GFS2_EA2NEXT(ea)) {
+-		if (!GFS2_EA_REC_LEN(ea))
+-			goto fail;
++		if (!GFS2_EA_REC_LEN(ea)) {
++			gfs2_consist_inode(ip);
++			return -EIO;
++		}
+ 		if (!(bh->b_data <= (char *)ea && (char *)GFS2_EA2NEXT(ea) <=
+-						  bh->b_data + bh->b_size))
+-			goto fail;
+-		if (!gfs2_eatype_valid(sdp, ea->ea_type))
+-			goto fail;
++						  bh->b_data + bh->b_size)) {
++			gfs2_consist_inode(ip);
++			return -EIO;
++		}
++		if (!gfs2_eatype_valid(sdp, ea->ea_type)) {
++			gfs2_consist_inode(ip);
++			return -EIO;
++		}
+ 		error = ea_call(ip, bh, ea, prev, data);
+ 		if (error)
+ 			return error;
+ 
+ 		if (GFS2_EA_IS_LAST(ea)) {
+ 			if ((char *)GFS2_EA2NEXT(ea) !=
+-			    bh->b_data + bh->b_size)
+-				goto fail;
++			    bh->b_data + bh->b_size) {
++				gfs2_consist_inode(ip);
++				return -EIO;
++			}
+ 			break;
+ 		}
+ 	}
+ 
+ 	return error;
+-
+-fail:
+-	gfs2_consist_inode(ip);
+-	return -EIO;
+ }
+ 
+ static int ea_foreach(struct gfs2_inode *ip, ea_call_t ea_call, void *data)
+diff --git a/include/linux/netfilter/ipset/ip_set.h b/include/linux/netfilter/ipset/ip_set.h
+index e9f4f845d760af..b98331572ad298 100644
+--- a/include/linux/netfilter/ipset/ip_set.h
++++ b/include/linux/netfilter/ipset/ip_set.h
+@@ -309,7 +309,7 @@ enum {
+ 
+ /* register and unregister set references */
+ extern ip_set_id_t ip_set_get_byname(struct net *net,
+-				     const char *name, struct ip_set **set);
++				     const struct nlattr *name, struct ip_set **set);
+ extern void ip_set_put_byindex(struct net *net, ip_set_id_t index);
+ extern void ip_set_name_byindex(struct net *net, ip_set_id_t index, char *name);
+ extern ip_set_id_t ip_set_nfnl_get_byindex(struct net *net, ip_set_id_t index);
+diff --git a/include/linux/swapops.h b/include/linux/swapops.h
+index 925c84653af5e9..7555a4a3d3d49a 100644
+--- a/include/linux/swapops.h
++++ b/include/linux/swapops.h
+@@ -488,11 +488,21 @@ static inline struct page *pfn_swap_entry_to_page(swp_entry_t entry)
+ {
+ 	struct page *p = pfn_to_page(swp_offset_pfn(entry));
+ 
+-	/*
+-	 * Any use of migration entries may only occur while the
+-	 * corresponding page is locked
+-	 */
+-	BUG_ON(is_migration_entry(entry) && !PageLocked(p));
++	if (is_migration_entry(entry)) {
++		/*
++		 * Ensure we do not race with split, which might alter tail
++		 * pages into new folios and thus result in observing an
++		 * unlocked folio.
++		 * This matches the write barrier in __split_folio_to_order().
++		 */
++		smp_rmb();
++
++		/*
++		 * Any use of migration entries may only occur while the
++		 * corresponding page is locked
++		 */
++		BUG_ON(!PageLocked(p));
++	}
+ 
+ 	return p;
+ }
+diff --git a/include/linux/vfio.h b/include/linux/vfio.h
+index 5ac5f182ce0bb6..514a7f9b3ef4b3 100644
+--- a/include/linux/vfio.h
++++ b/include/linux/vfio.h
+@@ -64,6 +64,7 @@ struct vfio_device {
+ 	struct completion comp;
+ 	struct iommufd_access *iommufd_access;
+ 	void (*put_kvm)(struct kvm *kvm);
++	struct inode *inode;
+ #if IS_ENABLED(CONFIG_IOMMUFD)
+ 	struct iommufd_device *iommufd_device;
+ 	u8 iommufd_attached:1;
+diff --git a/include/linux/vfio_pci_core.h b/include/linux/vfio_pci_core.h
+index 562e8754869da6..4f283514a1ed65 100644
+--- a/include/linux/vfio_pci_core.h
++++ b/include/linux/vfio_pci_core.h
+@@ -93,8 +93,6 @@ struct vfio_pci_core_device {
+ 	struct list_head		sriov_pfs_item;
+ 	struct vfio_pci_core_device	*sriov_pf_core_dev;
+ 	struct notifier_block	nb;
+-	struct mutex		vma_lock;
+-	struct list_head	vma_list;
+ 	struct rw_semaphore	memory_lock;
+ };
+ 
+diff --git a/include/net/netfilter/nf_conntrack_expect.h b/include/net/netfilter/nf_conntrack_expect.h
+index 165e7a03b8e9dc..e9a8350e7ccfb0 100644
+--- a/include/net/netfilter/nf_conntrack_expect.h
++++ b/include/net/netfilter/nf_conntrack_expect.h
+@@ -22,10 +22,16 @@ struct nf_conntrack_expect {
+ 	/* Hash member */
+ 	struct hlist_node hnode;
+ 
++	/* Network namespace */
++	possible_net_t net;
++
+ 	/* We expect this tuple, with the following mask */
+ 	struct nf_conntrack_tuple tuple;
+ 	struct nf_conntrack_tuple_mask mask;
+ 
++#ifdef CONFIG_NF_CONNTRACK_ZONES
++	struct nf_conntrack_zone zone;
++#endif
+ 	/* Usage count. */
+ 	refcount_t use;
+ 
+@@ -40,7 +46,7 @@ struct nf_conntrack_expect {
+ 			 struct nf_conntrack_expect *this);
+ 
+ 	/* Helper to assign to new connection */
+-	struct nf_conntrack_helper *helper;
++	struct nf_conntrack_helper __rcu *helper;
+ 
+ 	/* The conntrack of the master connection */
+ 	struct nf_conn *master;
+@@ -62,7 +68,17 @@ struct nf_conntrack_expect {
+ 
+ static inline struct net *nf_ct_exp_net(struct nf_conntrack_expect *exp)
+ {
+-	return nf_ct_net(exp->master);
++	return read_pnet(&exp->net);
++}
++
++static inline bool nf_ct_exp_zone_equal_any(const struct nf_conntrack_expect *a,
++					    const struct nf_conntrack_zone *b)
++{
++#ifdef CONFIG_NF_CONNTRACK_ZONES
++	return a->zone.id == b->id;
++#else
++	return true;
++#endif
+ }
+ 
+ #define NF_CT_EXP_POLICY_NAME_LEN	16
+diff --git a/kernel/bpf/verifier.c b/kernel/bpf/verifier.c
+index 226f2cd338d67b..45eb795c8c0452 100644
+--- a/kernel/bpf/verifier.c
++++ b/kernel/bpf/verifier.c
+@@ -6912,7 +6912,8 @@ static int check_mem_access(struct bpf_verifier_env *env, int insn_idx, u32 regn
+ 	} else if (reg->type == CONST_PTR_TO_MAP) {
+ 		err = check_ptr_to_map_access(env, regs, regno, off, size, t,
+ 					      value_regno);
+-	} else if (base_type(reg->type) == PTR_TO_BUF) {
++	} else if (base_type(reg->type) == PTR_TO_BUF &&
++		   !type_may_be_null(reg->type)) {
+ 		bool rdonly_mem = type_is_rdonly_mem(reg->type);
+ 		u32 *max_access;
+ 
+@@ -16148,8 +16149,13 @@ static bool regsafe(struct bpf_verifier_env *env, struct bpf_reg_state *rold,
+ 		 * since someone could have accessed through (ptr - k), or
+ 		 * even done ptr -= k in a register, to get a safe access.
+ 		 */
+-		if (rold->range > rcur->range)
++		if (rold->range < 0 || rcur->range < 0) {
++			/* special case for [BEYOND|AT]_PKT_END */
++			if (rold->range != rcur->range)
++				return false;
++		} else if (rold->range > rcur->range) {
+ 			return false;
++		}
+ 		/* If the offsets don't match, we can't trust our alignment;
+ 		 * nor can we be sure that we won't fall out of range.
+ 		 */
+diff --git a/kernel/fork.c b/kernel/fork.c
+index ce6f6e1e39057a..5b60692b1a4ea1 100644
+--- a/kernel/fork.c
++++ b/kernel/fork.c
+@@ -733,6 +733,21 @@ static __latent_entropy int dup_mmap(struct mm_struct *mm,
+ 		} else if (anon_vma_fork(tmp, mpnt))
+ 			goto fail_nomem_anon_vma_fork;
+ 		vm_flags_clear(tmp, VM_LOCKED_MASK);
++		/*
++		 * Copy/update hugetlb private vma information.
++		 */
++		if (is_vm_hugetlb_page(tmp))
++			hugetlb_dup_vma_private(tmp);
++
++		/* Link the vma into the MT */
++		if (vma_iter_bulk_store(&vmi, tmp))
++			goto fail_nomem_vmi_store;
++
++		mm->map_count++;
++
++		if (tmp->vm_ops && tmp->vm_ops->open)
++			tmp->vm_ops->open(tmp);
++
+ 		file = tmp->vm_file;
+ 		if (file) {
+ 			struct address_space *mapping = file->f_mapping;
+@@ -749,23 +764,9 @@ static __latent_entropy int dup_mmap(struct mm_struct *mm,
+ 			i_mmap_unlock_write(mapping);
+ 		}
+ 
+-		/*
+-		 * Copy/update hugetlb private vma information.
+-		 */
+-		if (is_vm_hugetlb_page(tmp))
+-			hugetlb_dup_vma_private(tmp);
+-
+-		/* Link the vma into the MT */
+-		if (vma_iter_bulk_store(&vmi, tmp))
+-			goto fail_nomem_vmi_store;
+-
+-		mm->map_count++;
+ 		if (!(tmp->vm_flags & VM_WIPEONFORK))
+ 			retval = copy_page_range(tmp, mpnt);
+ 
+-		if (tmp->vm_ops && tmp->vm_ops->open)
+-			tmp->vm_ops->open(tmp);
+-
+ 		if (retval)
+ 			goto loop_out;
+ 	}
+diff --git a/net/atm/lec.c b/net/atm/lec.c
+index 0d4b8e5936dcfb..d8ab969625790b 100644
+--- a/net/atm/lec.c
++++ b/net/atm/lec.c
+@@ -154,10 +154,19 @@ static void lec_handle_bridge(struct sk_buff *skb, struct net_device *dev)
+ 					/* 0x01 is topology change */
+ 
+ 		priv = netdev_priv(dev);
+-		atm_force_charge(priv->lecd, skb2->truesize);
+-		sk = sk_atm(priv->lecd);
+-		skb_queue_tail(&sk->sk_receive_queue, skb2);
+-		sk->sk_data_ready(sk);
++		struct atm_vcc *vcc;
++
++		rcu_read_lock();
++		vcc = rcu_dereference(priv->lecd);
++		if (vcc) {
++			atm_force_charge(vcc, skb2->truesize);
++			sk = sk_atm(vcc);
++			skb_queue_tail(&sk->sk_receive_queue, skb2);
++			sk->sk_data_ready(sk);
++		} else {
++			dev_kfree_skb(skb2);
++		}
++		rcu_read_unlock();
+ 	}
+ }
+ #endif /* IS_ENABLED(CONFIG_BRIDGE) */
+@@ -216,7 +225,7 @@ static netdev_tx_t lec_start_xmit(struct sk_buff *skb,
+ 	int is_rdesc;
+ 
+ 	pr_debug("called\n");
+-	if (!priv->lecd) {
++	if (!rcu_access_pointer(priv->lecd)) {
+ 		pr_info("%s:No lecd attached\n", dev->name);
+ 		dev->stats.tx_errors++;
+ 		netif_stop_queue(dev);
+@@ -449,10 +458,19 @@ static int lec_atm_send(struct atm_vcc *vcc, struct sk_buff *skb)
+ 				break;
+ 			skb2->len = sizeof(struct atmlec_msg);
+ 			skb_copy_to_linear_data(skb2, mesg, sizeof(*mesg));
+-			atm_force_charge(priv->lecd, skb2->truesize);
+-			sk = sk_atm(priv->lecd);
+-			skb_queue_tail(&sk->sk_receive_queue, skb2);
+-			sk->sk_data_ready(sk);
++			struct atm_vcc *vcc;
++
++			rcu_read_lock();
++			vcc = rcu_dereference(priv->lecd);
++			if (vcc) {
++				atm_force_charge(vcc, skb2->truesize);
++				sk = sk_atm(vcc);
++				skb_queue_tail(&sk->sk_receive_queue, skb2);
++				sk->sk_data_ready(sk);
++			} else {
++				dev_kfree_skb(skb2);
++			}
++			rcu_read_unlock();
+ 		}
+ 	}
+ #endif /* IS_ENABLED(CONFIG_BRIDGE) */
+@@ -468,23 +486,16 @@ static int lec_atm_send(struct atm_vcc *vcc, struct sk_buff *skb)
+ 
+ static void lec_atm_close(struct atm_vcc *vcc)
+ {
+-	struct sk_buff *skb;
+ 	struct net_device *dev = (struct net_device *)vcc->proto_data;
+ 	struct lec_priv *priv = netdev_priv(dev);
+ 
+-	priv->lecd = NULL;
++	rcu_assign_pointer(priv->lecd, NULL);
++	synchronize_rcu();
+ 	/* Do something needful? */
+ 
+ 	netif_stop_queue(dev);
+ 	lec_arp_destroy(priv);
+ 
+-	if (skb_peek(&sk_atm(vcc)->sk_receive_queue))
+-		pr_info("%s closing with messages pending\n", dev->name);
+-	while ((skb = skb_dequeue(&sk_atm(vcc)->sk_receive_queue))) {
+-		atm_return(vcc, skb->truesize);
+-		dev_kfree_skb(skb);
+-	}
+-
+ 	pr_info("%s: Shut down!\n", dev->name);
+ 	module_put(THIS_MODULE);
+ }
+@@ -510,12 +521,14 @@ send_to_lecd(struct lec_priv *priv, atmlec_msg_type type,
+ 	     const unsigned char *mac_addr, const unsigned char *atm_addr,
+ 	     struct sk_buff *data)
+ {
++	struct atm_vcc *vcc;
+ 	struct sock *sk;
+ 	struct sk_buff *skb;
+ 	struct atmlec_msg *mesg;
+ 
+-	if (!priv || !priv->lecd)
++	if (!priv || !rcu_access_pointer(priv->lecd))
+ 		return -1;
++
+ 	skb = alloc_skb(sizeof(struct atmlec_msg), GFP_ATOMIC);
+ 	if (!skb)
+ 		return -1;
+@@ -532,18 +545,27 @@ send_to_lecd(struct lec_priv *priv, atmlec_msg_type type,
+ 	if (atm_addr)
+ 		memcpy(&mesg->content.normal.atm_addr, atm_addr, ATM_ESA_LEN);
+ 
+-	atm_force_charge(priv->lecd, skb->truesize);
+-	sk = sk_atm(priv->lecd);
++	rcu_read_lock();
++	vcc = rcu_dereference(priv->lecd);
++	if (!vcc) {
++		rcu_read_unlock();
++		kfree_skb(skb);
++		return -1;
++	}
++
++	atm_force_charge(vcc, skb->truesize);
++	sk = sk_atm(vcc);
+ 	skb_queue_tail(&sk->sk_receive_queue, skb);
+ 	sk->sk_data_ready(sk);
+ 
+ 	if (data != NULL) {
+ 		pr_debug("about to send %d bytes of data\n", data->len);
+-		atm_force_charge(priv->lecd, data->truesize);
++		atm_force_charge(vcc, data->truesize);
+ 		skb_queue_tail(&sk->sk_receive_queue, data);
+ 		sk->sk_data_ready(sk);
+ 	}
+ 
++	rcu_read_unlock();
+ 	return 0;
+ }
+ 
+@@ -618,7 +640,7 @@ static void lec_push(struct atm_vcc *vcc, struct sk_buff *skb)
+ 
+ 		atm_return(vcc, skb->truesize);
+ 		if (*(__be16 *) skb->data == htons(priv->lecid) ||
+-		    !priv->lecd || !(dev->flags & IFF_UP)) {
++		    !rcu_access_pointer(priv->lecd) || !(dev->flags & IFF_UP)) {
+ 			/*
+ 			 * Probably looping back, or if lecd is missing,
+ 			 * lecd has gone down
+@@ -753,12 +775,12 @@ static int lecd_attach(struct atm_vcc *vcc, int arg)
+ 		priv = netdev_priv(dev_lec[i]);
+ 	} else {
+ 		priv = netdev_priv(dev_lec[i]);
+-		if (priv->lecd)
++		if (rcu_access_pointer(priv->lecd))
+ 			return -EADDRINUSE;
+ 	}
+ 	lec_arp_init(priv);
+ 	priv->itfnum = i;	/* LANE2 addition */
+-	priv->lecd = vcc;
++	rcu_assign_pointer(priv->lecd, vcc);
+ 	vcc->dev = &lecatm_dev;
+ 	vcc_insert_socket(sk_atm(vcc));
+ 
+diff --git a/net/atm/lec.h b/net/atm/lec.h
+index be0e2667bd8c3f..ec85709bf81859 100644
+--- a/net/atm/lec.h
++++ b/net/atm/lec.h
+@@ -91,7 +91,7 @@ struct lec_priv {
+ 						 */
+ 	spinlock_t lec_arp_lock;
+ 	struct atm_vcc *mcast_vcc;		/* Default Multicast Send VCC */
+-	struct atm_vcc *lecd;
++	struct atm_vcc __rcu *lecd;
+ 	struct delayed_work lec_arp_work;	/* C10 */
+ 	unsigned int maximum_unknown_frame_count;
+ 						/*
+diff --git a/net/bluetooth/hci_event.c b/net/bluetooth/hci_event.c
+index 4aa445e7f56bc2..8b184839b013ab 100644
+--- a/net/bluetooth/hci_event.c
++++ b/net/bluetooth/hci_event.c
+@@ -6555,25 +6555,31 @@ static void hci_le_remote_conn_param_req_evt(struct hci_dev *hdev, void *data,
+ 	latency = le16_to_cpu(ev->latency);
+ 	timeout = le16_to_cpu(ev->timeout);
+ 
++	hci_dev_lock(hdev);
++
+ 	hcon = hci_conn_hash_lookup_handle(hdev, handle);
+-	if (!hcon || hcon->state != BT_CONNECTED)
+-		return send_conn_param_neg_reply(hdev, handle,
+-						 HCI_ERROR_UNKNOWN_CONN_ID);
++	if (!hcon || hcon->state != BT_CONNECTED) {
++		send_conn_param_neg_reply(hdev, handle,
++					  HCI_ERROR_UNKNOWN_CONN_ID);
++		goto unlock;
++	}
+ 
+-	if (max > hcon->le_conn_max_interval)
+-		return send_conn_param_neg_reply(hdev, handle,
+-						 HCI_ERROR_INVALID_LL_PARAMS);
++	if (max > hcon->le_conn_max_interval) {
++		send_conn_param_neg_reply(hdev, handle,
++					  HCI_ERROR_INVALID_LL_PARAMS);
++		goto unlock;
++	}
+ 
+-	if (hci_check_conn_params(min, max, latency, timeout))
+-		return send_conn_param_neg_reply(hdev, handle,
+-						 HCI_ERROR_INVALID_LL_PARAMS);
++	if (hci_check_conn_params(min, max, latency, timeout)) {
++		send_conn_param_neg_reply(hdev, handle,
++					  HCI_ERROR_INVALID_LL_PARAMS);
++		goto unlock;
++	}
+ 
+ 	if (hcon->role == HCI_ROLE_MASTER) {
+ 		struct hci_conn_params *params;
+ 		u8 store_hint;
+ 
+-		hci_dev_lock(hdev);
+-
+ 		params = hci_conn_params_lookup(hdev, &hcon->dst,
+ 						hcon->dst_type);
+ 		if (params) {
+@@ -6586,8 +6592,6 @@ static void hci_le_remote_conn_param_req_evt(struct hci_dev *hdev, void *data,
+ 			store_hint = 0x00;
+ 		}
+ 
+-		hci_dev_unlock(hdev);
+-
+ 		mgmt_new_conn_param(hdev, &hcon->dst, hcon->dst_type,
+ 				    store_hint, min, max, latency, timeout);
+ 	}
+@@ -6601,6 +6605,9 @@ static void hci_le_remote_conn_param_req_evt(struct hci_dev *hdev, void *data,
+ 	cp.max_ce_len = 0;
+ 
+ 	hci_send_cmd(hdev, HCI_OP_LE_CONN_PARAM_REQ_REPLY, sizeof(cp), &cp);
++
++unlock:
++	hci_dev_unlock(hdev);
+ }
+ 
+ static void hci_le_direct_adv_report_evt(struct hci_dev *hdev, void *data,
+diff --git a/net/bluetooth/hci_sync.c b/net/bluetooth/hci_sync.c
+index c1c9d82faa6588..a41cfc76e98bf1 100644
+--- a/net/bluetooth/hci_sync.c
++++ b/net/bluetooth/hci_sync.c
+@@ -825,8 +825,15 @@ int hci_cmd_sync_run(struct hci_dev *hdev, hci_cmd_sync_work_func_t func,
+ 		return -ENETDOWN;
+ 
+ 	/* If on cmd_sync_work then run immediately otherwise queue */
+-	if (current_work() == &hdev->cmd_sync_work)
+-		return func(hdev, data);
++	if (current_work() == &hdev->cmd_sync_work) {
++		int err;
++
++		err = func(hdev, data);
++		if (destroy)
++			destroy(hdev, data, err);
++
++		return 0;
++	}
+ 
+ 	return hci_cmd_sync_submit(hdev, func, data, destroy);
+ }
+diff --git a/net/bluetooth/mgmt.c b/net/bluetooth/mgmt.c
+index 7de0a0d752629f..51a6ad6a36c8d7 100644
+--- a/net/bluetooth/mgmt.c
++++ b/net/bluetooth/mgmt.c
+@@ -2388,6 +2388,7 @@ static int mesh_send(struct sock *sk, struct hci_dev *hdev, void *data, u16 len)
+ 	struct mgmt_mesh_tx *mesh_tx;
+ 	struct mgmt_cp_mesh_send *send = data;
+ 	struct mgmt_rp_mesh_read_features rp;
++	u16 expected_len;
+ 	bool sending;
+ 	int err = 0;
+ 
+@@ -2395,12 +2396,19 @@ static int mesh_send(struct sock *sk, struct hci_dev *hdev, void *data, u16 len)
+ 	    !hci_dev_test_flag(hdev, HCI_MESH_EXPERIMENTAL))
+ 		return mgmt_cmd_status(sk, hdev->id, MGMT_OP_MESH_SEND,
+ 				       MGMT_STATUS_NOT_SUPPORTED);
+-	if (!hci_dev_test_flag(hdev, HCI_LE_ENABLED) ||
+-	    len <= MGMT_MESH_SEND_SIZE ||
+-	    len > (MGMT_MESH_SEND_SIZE + 31))
++	if (!hci_dev_test_flag(hdev, HCI_LE_ENABLED))
+ 		return mgmt_cmd_status(sk, hdev->id, MGMT_OP_MESH_SEND,
+ 				       MGMT_STATUS_REJECTED);
+ 
++	if (!send->adv_data_len || send->adv_data_len > 31)
++		return mgmt_cmd_status(sk, hdev->id, MGMT_OP_MESH_SEND,
++				       MGMT_STATUS_REJECTED);
++
++	expected_len = struct_size(send, adv_data, send->adv_data_len);
++	if (expected_len != len)
++		return mgmt_cmd_status(sk, hdev->id, MGMT_OP_MESH_SEND,
++				       MGMT_STATUS_INVALID_PARAMS);
++
+ 	hci_dev_lock(hdev);
+ 
+ 	memset(&rp, 0, sizeof(rp));
+@@ -7145,6 +7153,9 @@ static bool ltk_is_valid(struct mgmt_ltk_info *key)
+ 	if (key->initiator != 0x00 && key->initiator != 0x01)
+ 		return false;
+ 
++	if (key->enc_size > sizeof(key->val))
++		return false;
++
+ 	switch (key->addr.type) {
+ 	case BDADDR_LE_PUBLIC:
+ 		return true;
+diff --git a/net/bluetooth/sco.c b/net/bluetooth/sco.c
+index 56a146515df9e9..1c9c54f35988bd 100644
+--- a/net/bluetooth/sco.c
++++ b/net/bluetooth/sco.c
+@@ -238,7 +238,7 @@ static int sco_chan_add(struct sco_conn *conn, struct sock *sk,
+ 	int err = 0;
+ 
+ 	sco_conn_lock(conn);
+-	if (conn->sk)
++	if (conn->sk || sco_pi(sk)->conn)
+ 		err = -EBUSY;
+ 	else
+ 		__sco_chan_add(conn, sk, parent);
+@@ -292,9 +292,20 @@ static int sco_connect(struct sock *sk)
+ 
+ 	lock_sock(sk);
+ 
++	/* Recheck state after reacquiring the socket lock, as another
++	 * thread may have changed it (e.g., closed the socket).
++	 */
++	if (sk->sk_state != BT_OPEN && sk->sk_state != BT_BOUND) {
++		release_sock(sk);
++		hci_conn_drop(hcon);
++		err = -EBADFD;
++		goto unlock;
++	}
++
+ 	err = sco_chan_add(conn, sk, NULL);
+ 	if (err) {
+ 		release_sock(sk);
++		hci_conn_drop(hcon);
+ 		goto unlock;
+ 	}
+ 
+@@ -601,13 +612,18 @@ static int sco_sock_connect(struct socket *sock, struct sockaddr *addr, int alen
+ 	    addr->sa_family != AF_BLUETOOTH)
+ 		return -EINVAL;
+ 
+-	if (sk->sk_state != BT_OPEN && sk->sk_state != BT_BOUND)
++	lock_sock(sk);
++
++	if (sk->sk_state != BT_OPEN && sk->sk_state != BT_BOUND) {
++		release_sock(sk);
+ 		return -EBADFD;
++	}
+ 
+-	if (sk->sk_type != SOCK_SEQPACKET)
+-		err = -EINVAL;
++	if (sk->sk_type != SOCK_SEQPACKET) {
++		release_sock(sk);
++		return -EINVAL;
++	}
+ 
+-	lock_sock(sk);
+ 	/* Set destination address and psm */
+ 	bacpy(&sco_pi(sk)->dst, &sa->sco_bdaddr);
+ 	release_sock(sk);
+diff --git a/net/bluetooth/smp.c b/net/bluetooth/smp.c
+index 62c8eab1b84a5c..6fabc76aa9d7c6 100644
+--- a/net/bluetooth/smp.c
++++ b/net/bluetooth/smp.c
+@@ -1019,10 +1019,7 @@ static u8 smp_random(struct smp_chan *smp)
+ 
+ 		smp_s1(smp->tk, smp->prnd, smp->rrnd, stk);
+ 
+-		if (hcon->pending_sec_level == BT_SECURITY_HIGH)
+-			auth = 1;
+-		else
+-			auth = 0;
++		auth = test_bit(SMP_FLAG_MITM_AUTH, &smp->flags) ? 1 : 0;
+ 
+ 		/* Even though there's no _RESPONDER suffix this is the
+ 		 * responder STK we're adding for later lookup (the initiator
+@@ -1827,7 +1824,7 @@ static u8 smp_cmd_pairing_req(struct l2cap_conn *conn, struct sk_buff *skb)
+ 	if (sec_level > conn->hcon->pending_sec_level)
+ 		conn->hcon->pending_sec_level = sec_level;
+ 
+-	/* If we need MITM check that it can be achieved */
++	/* If we need MITM check that it can be achieved. */
+ 	if (conn->hcon->pending_sec_level >= BT_SECURITY_HIGH) {
+ 		u8 method;
+ 
+@@ -1835,6 +1832,10 @@ static u8 smp_cmd_pairing_req(struct l2cap_conn *conn, struct sk_buff *skb)
+ 					 req->io_capability);
+ 		if (method == JUST_WORKS || method == JUST_CFM)
+ 			return SMP_AUTH_REQUIREMENTS;
++
++		/* Force MITM bit if it isn't set by the initiator. */
++		auth |= SMP_AUTH_MITM;
++		rsp.auth_req |= SMP_AUTH_MITM;
+ 	}
+ 
+ 	key_size = min(req->max_key_size, rsp.max_key_size);
+diff --git a/net/bridge/br_arp_nd_proxy.c b/net/bridge/br_arp_nd_proxy.c
+index c7869a286df401..f033a516756025 100644
+--- a/net/bridge/br_arp_nd_proxy.c
++++ b/net/bridge/br_arp_nd_proxy.c
+@@ -248,12 +248,12 @@ struct nd_msg *br_is_nd_neigh_msg(struct sk_buff *skb, struct nd_msg *msg)
+ 
+ static void br_nd_send(struct net_bridge *br, struct net_bridge_port *p,
+ 		       struct sk_buff *request, struct neighbour *n,
+-		       __be16 vlan_proto, u16 vlan_tci, struct nd_msg *ns)
++		       __be16 vlan_proto, u16 vlan_tci)
+ {
+ 	struct net_device *dev = request->dev;
+ 	struct net_bridge_vlan_group *vg;
++	struct nd_msg *na, *ns;
+ 	struct sk_buff *reply;
+-	struct nd_msg *na;
+ 	struct ipv6hdr *pip6;
+ 	int na_olen = 8; /* opt hdr + ETH_ALEN for target */
+ 	int ns_olen;
+@@ -261,7 +261,7 @@ static void br_nd_send(struct net_bridge *br, struct net_bridge_port *p,
+ 	u8 *daddr;
+ 	u16 pvid;
+ 
+-	if (!dev)
++	if (!dev || skb_linearize(request))
+ 		return;
+ 
+ 	len = LL_RESERVED_SPACE(dev) + sizeof(struct ipv6hdr) +
+@@ -278,17 +278,21 @@ static void br_nd_send(struct net_bridge *br, struct net_bridge_port *p,
+ 	skb_set_mac_header(reply, 0);
+ 
+ 	daddr = eth_hdr(request)->h_source;
++	ns = (struct nd_msg *)(skb_network_header(request) +
++			       sizeof(struct ipv6hdr));
+ 
+ 	/* Do we need option processing ? */
+ 	ns_olen = request->len - (skb_network_offset(request) +
+ 				  sizeof(struct ipv6hdr)) - sizeof(*ns);
+ 	for (i = 0; i < ns_olen - 1; i += (ns->opt[i + 1] << 3)) {
+-		if (!ns->opt[i + 1]) {
++		if (!ns->opt[i + 1] || i + (ns->opt[i + 1] << 3) > ns_olen) {
+ 			kfree_skb(reply);
+ 			return;
+ 		}
+ 		if (ns->opt[i] == ND_OPT_SOURCE_LL_ADDR) {
+-			daddr = ns->opt + i + sizeof(struct nd_opt_hdr);
++			if ((ns->opt[i + 1] << 3) >=
++			    sizeof(struct nd_opt_hdr) + ETH_ALEN)
++				daddr = ns->opt + i + sizeof(struct nd_opt_hdr);
+ 			break;
+ 		}
+ 	}
+@@ -465,9 +469,9 @@ void br_do_suppress_nd(struct sk_buff *skb, struct net_bridge *br,
+ 				if (vid != 0)
+ 					br_nd_send(br, p, skb, n,
+ 						   skb->vlan_proto,
+-						   skb_vlan_tag_get(skb), msg);
++						   skb_vlan_tag_get(skb));
+ 				else
+-					br_nd_send(br, p, skb, n, 0, 0, msg);
++					br_nd_send(br, p, skb, n, 0, 0);
+ 				replied = true;
+ 			}
+ 
+diff --git a/net/core/dev.c b/net/core/dev.c
+index 56b6797589f561..405b448bd91fef 100644
+--- a/net/core/dev.c
++++ b/net/core/dev.c
+@@ -3535,6 +3535,22 @@ static netdev_features_t dflt_features_check(struct sk_buff *skb,
+ 	return vlan_features_check(skb, features);
+ }
+ 
++static bool skb_gso_has_extension_hdr(const struct sk_buff *skb)
++{
++	if (!skb->encapsulation)
++		return ((skb_shinfo(skb)->gso_type & SKB_GSO_TCPV6 ||
++			 (skb_shinfo(skb)->gso_type & SKB_GSO_UDP_L4 &&
++			  vlan_get_protocol(skb) == htons(ETH_P_IPV6))) &&
++			skb_transport_header_was_set(skb) &&
++			skb_network_header_len(skb) != sizeof(struct ipv6hdr));
++	else
++		return (!skb_inner_network_header_was_set(skb) ||
++			((skb_shinfo(skb)->gso_type & SKB_GSO_TCPV6 ||
++			  (skb_shinfo(skb)->gso_type & SKB_GSO_UDP_L4 &&
++			   inner_ip_hdr(skb)->version == 6)) &&
++			 skb_inner_network_header_len(skb) != sizeof(struct ipv6hdr)));
++}
++
+ static netdev_features_t gso_features_check(const struct sk_buff *skb,
+ 					    struct net_device *dev,
+ 					    netdev_features_t features)
+@@ -3576,11 +3592,7 @@ static netdev_features_t gso_features_check(const struct sk_buff *skb,
+ 	 * so neither does TSO that depends on it.
+ 	 */
+ 	if (features & NETIF_F_IPV6_CSUM &&
+-	    (skb_shinfo(skb)->gso_type & SKB_GSO_TCPV6 ||
+-	     (skb_shinfo(skb)->gso_type & SKB_GSO_UDP_L4 &&
+-	      vlan_get_protocol(skb) == htons(ETH_P_IPV6))) &&
+-	    skb_transport_header_was_set(skb) &&
+-	    skb_network_header_len(skb) != sizeof(struct ipv6hdr) &&
++	    skb_gso_has_extension_hdr(skb) &&
+ 	    !ipv6_has_hopopt_jumbo(skb))
+ 		features &= ~(NETIF_F_IPV6_CSUM | NETIF_F_TSO6 | NETIF_F_GSO_UDP_L4);
+ 
+diff --git a/net/core/skmsg.c b/net/core/skmsg.c
+index 5d557ba9c0cb47..e2bba1e86752e5 100644
+--- a/net/core/skmsg.c
++++ b/net/core/skmsg.c
+@@ -1266,17 +1266,20 @@ out:
+ 
+ static void sk_psock_verdict_data_ready(struct sock *sk)
+ {
+-	struct socket *sock = sk->sk_socket;
+-	const struct proto_ops *ops;
++	const struct proto_ops *ops = NULL;
++	struct socket *sock;
+ 	int copied;
+ 
+ 	trace_sk_data_ready(sk);
+ 
+-	if (unlikely(!sock))
+-		return;
+-	ops = READ_ONCE(sock->ops);
++	rcu_read_lock();
++	sock = READ_ONCE(sk->sk_socket);
++	if (likely(sock))
++		ops = READ_ONCE(sock->ops);
++	rcu_read_unlock();
+ 	if (!ops || !ops->read_skb)
+ 		return;
++
+ 	copied = ops->read_skb(sk, sk_psock_verdict_recv);
+ 	if (copied >= 0) {
+ 		struct sk_psock *psock;
+diff --git a/net/hsr/hsr_device.c b/net/hsr/hsr_device.c
+index 70e958caa956d7..b34a9b680aab34 100644
+--- a/net/hsr/hsr_device.c
++++ b/net/hsr/hsr_device.c
+@@ -473,8 +473,8 @@ static void hsr_change_rx_flags(struct net_device *dev, int change)
+ static int hsr_ndo_vlan_rx_add_vid(struct net_device *dev,
+ 				   __be16 proto, u16 vid)
+ {
+-	bool is_slave_a_added = false;
+-	bool is_slave_b_added = false;
++	struct net_device *slave_a_dev = NULL;
++	struct net_device *slave_b_dev = NULL;
+ 	struct hsr_port *port;
+ 	struct hsr_priv *hsr;
+ 	int ret = 0;
+@@ -490,33 +490,35 @@ static int hsr_ndo_vlan_rx_add_vid(struct net_device *dev,
+ 		switch (port->type) {
+ 		case HSR_PT_SLAVE_A:
+ 			if (ret) {
+-				/* clean up Slave-B */
+ 				netdev_err(dev, "add vid failed for Slave-A\n");
+-				if (is_slave_b_added)
+-					vlan_vid_del(port->dev, proto, vid);
+-				return ret;
++				goto unwind;
+ 			}
+-
+-			is_slave_a_added = true;
++			slave_a_dev = port->dev;
+ 			break;
+-
+ 		case HSR_PT_SLAVE_B:
+ 			if (ret) {
+-				/* clean up Slave-A */
+ 				netdev_err(dev, "add vid failed for Slave-B\n");
+-				if (is_slave_a_added)
+-					vlan_vid_del(port->dev, proto, vid);
+-				return ret;
++				goto unwind;
+ 			}
+-
+-			is_slave_b_added = true;
++			slave_b_dev = port->dev;
+ 			break;
+ 		default:
++			if (ret)
++				goto unwind;
+ 			break;
+ 		}
+ 	}
+ 
+ 	return 0;
++
++unwind:
++	if (slave_a_dev)
++		vlan_vid_del(slave_a_dev, proto, vid);
++
++	if (slave_b_dev)
++		vlan_vid_del(slave_b_dev, proto, vid);
++
++	return ret;
+ }
+ 
+ static int hsr_ndo_vlan_rx_kill_vid(struct net_device *dev,
+diff --git a/net/ipv6/addrconf.c b/net/ipv6/addrconf.c
+index 7fcc68dcf144b0..32fa6236dacdd9 100644
+--- a/net/ipv6/addrconf.c
++++ b/net/ipv6/addrconf.c
+@@ -3611,12 +3611,12 @@ static void addrconf_permanent_addr(struct net *net, struct net_device *dev)
+ 		if ((ifp->flags & IFA_F_PERMANENT) &&
+ 		    fixup_permanent_addr(net, idev, ifp) < 0) {
+ 			write_unlock_bh(&idev->lock);
+-			in6_ifa_hold(ifp);
+-			ipv6_del_addr(ifp);
+-			write_lock_bh(&idev->lock);
+ 
+ 			net_info_ratelimited("%s: Failed to add prefix route for address %pI6c; dropping\n",
+ 					     idev->dev->name, &ifp->addr);
++			in6_ifa_hold(ifp);
++			ipv6_del_addr(ifp);
++			write_lock_bh(&idev->lock);
+ 		}
+ 	}
+ 
+diff --git a/net/ipv6/datagram.c b/net/ipv6/datagram.c
+index 41ebc4e5747344..c1139f05a79427 100644
+--- a/net/ipv6/datagram.c
++++ b/net/ipv6/datagram.c
+@@ -763,6 +763,7 @@ int ip6_datagram_send_ctl(struct net *net, struct sock *sk,
+ {
+ 	struct in6_pktinfo *src_info;
+ 	struct cmsghdr *cmsg;
++	struct ipv6_rt_hdr *orthdr;
+ 	struct ipv6_rt_hdr *rthdr;
+ 	struct ipv6_opt_hdr *hdr;
+ 	struct ipv6_txoptions *opt = ipc6->opt;
+@@ -924,9 +925,13 @@ int ip6_datagram_send_ctl(struct net *net, struct sock *sk,
+ 				goto exit_f;
+ 			}
+ 			if (cmsg->cmsg_type == IPV6_DSTOPTS) {
++				if (opt->dst1opt)
++					opt->opt_flen -= ipv6_optlen(opt->dst1opt);
+ 				opt->opt_flen += len;
+ 				opt->dst1opt = hdr;
+ 			} else {
++				if (opt->dst0opt)
++					opt->opt_nflen -= ipv6_optlen(opt->dst0opt);
+ 				opt->opt_nflen += len;
+ 				opt->dst0opt = hdr;
+ 			}
+@@ -969,12 +974,17 @@ int ip6_datagram_send_ctl(struct net *net, struct sock *sk,
+ 				goto exit_f;
+ 			}
+ 
++			orthdr = opt->srcrt;
++			if (orthdr)
++				opt->opt_nflen -= ((orthdr->hdrlen + 1) << 3);
+ 			opt->opt_nflen += len;
+ 			opt->srcrt = rthdr;
+ 
+ 			if (cmsg->cmsg_type == IPV6_2292RTHDR && opt->dst1opt) {
+ 				int dsthdrlen = ((opt->dst1opt->hdrlen+1)<<3);
+ 
++				if (opt->dst0opt)
++					opt->opt_nflen -= ipv6_optlen(opt->dst0opt);
+ 				opt->opt_nflen += dsthdrlen;
+ 				opt->dst0opt = opt->dst1opt;
+ 				opt->dst1opt = NULL;
+diff --git a/net/ipv6/icmp.c b/net/ipv6/icmp.c
+index 1d1c56e0e24607..0002fe04e04097 100644
+--- a/net/ipv6/icmp.c
++++ b/net/ipv6/icmp.c
+@@ -679,6 +679,9 @@ int ip6_err_gen_icmpv6_unreach(struct sk_buff *skb, int nhs, int type,
+ 	if (!skb2)
+ 		return 1;
+ 
++	/* Remove debris left by IPv4 stack. */
++	memset(IP6CB(skb2), 0, sizeof(*IP6CB(skb2)));
++
+ 	skb_dst_drop(skb2);
+ 	skb_pull(skb2, nhs);
+ 	skb_reset_network_header(skb2);
+diff --git a/net/ipv6/ioam6.c b/net/ipv6/ioam6.c
+index a35b6fdbc93e90..a1953cf6131be2 100644
+--- a/net/ipv6/ioam6.c
++++ b/net/ipv6/ioam6.c
+@@ -648,7 +648,7 @@ static void __ioam6_fill_trace_data(struct sk_buff *skb,
+ 				    struct ioam6_namespace *ns,
+ 				    struct ioam6_trace_hdr *trace,
+ 				    struct ioam6_schema *sc,
+-				    u8 sclen, bool is_input)
++				    unsigned int sclen, bool is_input)
+ {
+ 	struct timespec64 ts;
+ 	ktime_t tstamp;
+@@ -878,7 +878,7 @@ void ioam6_fill_trace_data(struct sk_buff *skb,
+ 			   bool is_input)
+ {
+ 	struct ioam6_schema *sc;
+-	u8 sclen = 0;
++	unsigned int sclen = 0;
+ 
+ 	/* Skip if Overflow flag is set
+ 	 */
+diff --git a/net/ipv6/ip6_flowlabel.c b/net/ipv6/ip6_flowlabel.c
+index b3ca4beb4405aa..bf909fa69a9771 100644
+--- a/net/ipv6/ip6_flowlabel.c
++++ b/net/ipv6/ip6_flowlabel.c
+@@ -133,11 +133,6 @@ static void fl_release(struct ip6_flowlabel *fl)
+ 		if (time_after(ttd, fl->expires))
+ 			fl->expires = ttd;
+ 		ttd = fl->expires;
+-		if (fl->opt && fl->share == IPV6_FL_S_EXCL) {
+-			struct ipv6_txoptions *opt = fl->opt;
+-			fl->opt = NULL;
+-			kfree(opt);
+-		}
+ 		if (!timer_pending(&ip6_fl_gc_timer) ||
+ 		    time_after(ip6_fl_gc_timer.expires, ttd))
+ 			mod_timer(&ip6_fl_gc_timer, ttd);
+diff --git a/net/ipv6/ip6_tunnel.c b/net/ipv6/ip6_tunnel.c
+index 69cace90ece16f..5a2583a82f974f 100644
+--- a/net/ipv6/ip6_tunnel.c
++++ b/net/ipv6/ip6_tunnel.c
+@@ -601,11 +601,16 @@ ip4ip6_err(struct sk_buff *skb, struct inet6_skb_parm *opt,
+ 	if (!skb2)
+ 		return 0;
+ 
++	/* Remove debris left by IPv6 stack. */
++	memset(IPCB(skb2), 0, sizeof(*IPCB(skb2)));
++
+ 	skb_dst_drop(skb2);
+ 
+ 	skb_pull(skb2, offset);
+ 	skb_reset_network_header(skb2);
+ 	eiph = ip_hdr(skb2);
++	if (eiph->version != 4 || eiph->ihl < 5)
++		goto out;
+ 
+ 	/* Try to guess incoming interface */
+ 	rt = ip_route_output_ports(dev_net(skb->dev), &fl4, NULL, eiph->saddr,
+diff --git a/net/ipv6/ndisc.c b/net/ipv6/ndisc.c
+index 80ceb401ecf2dc..652263e2f2d024 100644
+--- a/net/ipv6/ndisc.c
++++ b/net/ipv6/ndisc.c
+@@ -1216,6 +1216,9 @@ static void ndisc_ra_useropt(struct sk_buff *ra, struct nd_opt_hdr *opt)
+ 	ndmsg->nduseropt_icmp_type = icmp6h->icmp6_type;
+ 	ndmsg->nduseropt_icmp_code = icmp6h->icmp6_code;
+ 	ndmsg->nduseropt_opts_len = opt->nd_opt_len << 3;
++	ndmsg->nduseropt_pad1 = 0;
++	ndmsg->nduseropt_pad2 = 0;
++	ndmsg->nduseropt_pad3 = 0;
+ 
+ 	memcpy(ndmsg + 1, opt, opt->nd_opt_len << 3);
+ 
+diff --git a/net/mptcp/pm_netlink.c b/net/mptcp/pm_netlink.c
+index 91aaf4bd43ea26..269e95c8415fac 100644
+--- a/net/mptcp/pm_netlink.c
++++ b/net/mptcp/pm_netlink.c
+@@ -1189,7 +1189,7 @@ static struct lock_class_key mptcp_keys[2];
+ static int mptcp_pm_nl_create_listen_socket(struct sock *sk,
+ 					    struct mptcp_pm_addr_entry *entry)
+ {
+-	bool is_ipv6 = sk->sk_family == AF_INET6;
++	bool is_ipv6 = entry->addr.family == AF_INET6;
+ 	int addrlen = sizeof(struct sockaddr_in);
+ 	struct sockaddr_storage addr;
+ 	struct sock *newsk, *ssk;
+diff --git a/net/netfilter/ipset/ip_set_core.c b/net/netfilter/ipset/ip_set_core.c
+index cc20e6d56807c6..a4e1d7951b2c60 100644
+--- a/net/netfilter/ipset/ip_set_core.c
++++ b/net/netfilter/ipset/ip_set_core.c
+@@ -821,7 +821,7 @@ EXPORT_SYMBOL_GPL(ip_set_del);
+  *
+  */
+ ip_set_id_t
+-ip_set_get_byname(struct net *net, const char *name, struct ip_set **set)
++ip_set_get_byname(struct net *net, const struct nlattr *name, struct ip_set **set)
+ {
+ 	ip_set_id_t i, index = IPSET_INVALID_ID;
+ 	struct ip_set *s;
+@@ -830,7 +830,7 @@ ip_set_get_byname(struct net *net, const char *name, struct ip_set **set)
+ 	rcu_read_lock();
+ 	for (i = 0; i < inst->ip_set_max; i++) {
+ 		s = rcu_dereference(inst->ip_set_list)[i];
+-		if (s && STRNCMP(s->name, name)) {
++		if (s && nla_strcmp(name, s->name) == 0) {
+ 			__ip_set_get(s);
+ 			index = i;
+ 			*set = s;
+diff --git a/net/netfilter/ipset/ip_set_hash_gen.h b/net/netfilter/ipset/ip_set_hash_gen.h
+index 20b223e6e93b9c..9da9420703216b 100644
+--- a/net/netfilter/ipset/ip_set_hash_gen.h
++++ b/net/netfilter/ipset/ip_set_hash_gen.h
+@@ -1098,7 +1098,7 @@ mtype_del(struct ip_set *set, void *value, const struct ip_set_ext *ext,
+ 			if (!test_bit(i, n->used))
+ 				k++;
+ 		}
+-		if (n->pos == 0 && k == 0) {
++		if (k == n->pos) {
+ 			t->hregion[r].ext_size -= ext_size(n->size, dsize);
+ 			rcu_assign_pointer(hbucket(t, key), NULL);
+ 			kfree_rcu(n, rcu);
+diff --git a/net/netfilter/ipset/ip_set_list_set.c b/net/netfilter/ipset/ip_set_list_set.c
+index db794fe1300e69..83e1fdcc752d6a 100644
+--- a/net/netfilter/ipset/ip_set_list_set.c
++++ b/net/netfilter/ipset/ip_set_list_set.c
+@@ -367,7 +367,7 @@ list_set_uadt(struct ip_set *set, struct nlattr *tb[],
+ 	ret = ip_set_get_extensions(set, tb, &ext);
+ 	if (ret)
+ 		return ret;
+-	e.id = ip_set_get_byname(map->net, nla_data(tb[IPSET_ATTR_NAME]), &s);
++	e.id = ip_set_get_byname(map->net, tb[IPSET_ATTR_NAME], &s);
+ 	if (e.id == IPSET_INVALID_ID)
+ 		return -IPSET_ERR_NAME;
+ 	/* "Loop detection" */
+@@ -389,7 +389,7 @@ list_set_uadt(struct ip_set *set, struct nlattr *tb[],
+ 
+ 	if (tb[IPSET_ATTR_NAMEREF]) {
+ 		e.refid = ip_set_get_byname(map->net,
+-					    nla_data(tb[IPSET_ATTR_NAMEREF]),
++					    tb[IPSET_ATTR_NAMEREF],
+ 					    &s);
+ 		if (e.refid == IPSET_INVALID_ID) {
+ 			ret = -IPSET_ERR_NAMEREF;
+diff --git a/net/netfilter/nf_conntrack_broadcast.c b/net/netfilter/nf_conntrack_broadcast.c
+index 9fb9b80312989b..d44d9379a8a084 100644
+--- a/net/netfilter/nf_conntrack_broadcast.c
++++ b/net/netfilter/nf_conntrack_broadcast.c
+@@ -21,6 +21,7 @@ int nf_conntrack_broadcast_help(struct sk_buff *skb,
+ 				unsigned int timeout)
+ {
+ 	const struct nf_conntrack_helper *helper;
++	struct net *net = read_pnet(&ct->ct_net);
+ 	struct nf_conntrack_expect *exp;
+ 	struct iphdr *iph = ip_hdr(skb);
+ 	struct rtable *rt = skb_rtable(skb);
+@@ -70,8 +71,11 @@ int nf_conntrack_broadcast_help(struct sk_buff *skb,
+ 	exp->expectfn             = NULL;
+ 	exp->flags                = NF_CT_EXPECT_PERMANENT;
+ 	exp->class		  = NF_CT_EXPECT_CLASS_DEFAULT;
+-	exp->helper               = NULL;
+-
++	rcu_assign_pointer(exp->helper, helper);
++	write_pnet(&exp->net, net);
++#ifdef CONFIG_NF_CONNTRACK_ZONES
++	exp->zone = ct->zone;
++#endif
+ 	nf_ct_expect_related(exp, 0);
+ 	nf_ct_expect_put(exp);
+ 
+diff --git a/net/netfilter/nf_conntrack_expect.c b/net/netfilter/nf_conntrack_expect.c
+index 7bc64eb89bac44..70bcddfc17ccc2 100644
+--- a/net/netfilter/nf_conntrack_expect.c
++++ b/net/netfilter/nf_conntrack_expect.c
+@@ -112,8 +112,8 @@ nf_ct_exp_equal(const struct nf_conntrack_tuple *tuple,
+ 		const struct net *net)
+ {
+ 	return nf_ct_tuple_mask_cmp(tuple, &i->tuple, &i->mask) &&
+-	       net_eq(net, nf_ct_net(i->master)) &&
+-	       nf_ct_zone_equal_any(i->master, zone);
++	       net_eq(net, read_pnet(&i->net)) &&
++	       nf_ct_exp_zone_equal_any(i, zone);
+ }
+ 
+ bool nf_ct_remove_expect(struct nf_conntrack_expect *exp)
+@@ -309,12 +309,20 @@ struct nf_conntrack_expect *nf_ct_expect_alloc(struct nf_conn *me)
+ }
+ EXPORT_SYMBOL_GPL(nf_ct_expect_alloc);
+ 
++/* This function can only be used from packet path, where accessing
++ * master's helper is safe, because the packet holds a reference on
++ * the conntrack object. Never use it from control plane.
++ */
+ void nf_ct_expect_init(struct nf_conntrack_expect *exp, unsigned int class,
+ 		       u_int8_t family,
+ 		       const union nf_inet_addr *saddr,
+ 		       const union nf_inet_addr *daddr,
+ 		       u_int8_t proto, const __be16 *src, const __be16 *dst)
+ {
++	struct nf_conntrack_helper *helper = NULL;
++	struct nf_conn *ct = exp->master;
++	struct net *net = read_pnet(&ct->ct_net);
++	struct nf_conn_help *help;
+ 	int len;
+ 
+ 	if (family == AF_INET)
+@@ -325,7 +333,16 @@ void nf_ct_expect_init(struct nf_conntrack_expect *exp, unsigned int class,
+ 	exp->flags = 0;
+ 	exp->class = class;
+ 	exp->expectfn = NULL;
+-	exp->helper = NULL;
++
++	help = nfct_help(ct);
++	if (help)
++		helper = rcu_dereference(help->helper);
++
++	rcu_assign_pointer(exp->helper, helper);
++	write_pnet(&exp->net, net);
++#ifdef CONFIG_NF_CONNTRACK_ZONES
++	exp->zone = ct->zone;
++#endif
+ 	exp->tuple.src.l3num = family;
+ 	exp->tuple.dst.protonum = proto;
+ 
+@@ -658,7 +675,7 @@ static int exp_seq_show(struct seq_file *s, void *v)
+ 	if (expect->flags & NF_CT_EXPECT_USERSPACE)
+ 		seq_printf(s, "%sUSERSPACE", delim);
+ 
+-	helper = rcu_dereference(nfct_help(expect->master)->helper);
++	helper = rcu_dereference(expect->helper);
+ 	if (helper) {
+ 		seq_printf(s, "%s%s", expect->flags ? " " : "", helper->name);
+ 		if (helper->expect_policy[expect->class].name[0])
+diff --git a/net/netfilter/nf_conntrack_h323_main.c b/net/netfilter/nf_conntrack_h323_main.c
+index ed983421e2eb2f..791aafe9f39601 100644
+--- a/net/netfilter/nf_conntrack_h323_main.c
++++ b/net/netfilter/nf_conntrack_h323_main.c
+@@ -642,7 +642,7 @@ static int expect_h245(struct sk_buff *skb, struct nf_conn *ct,
+ 			  &ct->tuplehash[!dir].tuple.src.u3,
+ 			  &ct->tuplehash[!dir].tuple.dst.u3,
+ 			  IPPROTO_TCP, NULL, &port);
+-	exp->helper = &nf_conntrack_helper_h245;
++	rcu_assign_pointer(exp->helper, &nf_conntrack_helper_h245);
+ 
+ 	nathook = rcu_dereference(nfct_h323_nat_hook);
+ 	if (memcmp(&ct->tuplehash[dir].tuple.src.u3,
+@@ -766,7 +766,7 @@ static int expect_callforwarding(struct sk_buff *skb,
+ 	nf_ct_expect_init(exp, NF_CT_EXPECT_CLASS_DEFAULT, nf_ct_l3num(ct),
+ 			  &ct->tuplehash[!dir].tuple.src.u3, &addr,
+ 			  IPPROTO_TCP, NULL, &port);
+-	exp->helper = nf_conntrack_helper_q931;
++	rcu_assign_pointer(exp->helper, nf_conntrack_helper_q931);
+ 
+ 	nathook = rcu_dereference(nfct_h323_nat_hook);
+ 	if (memcmp(&ct->tuplehash[dir].tuple.src.u3,
+@@ -1233,7 +1233,7 @@ static int expect_q931(struct sk_buff *skb, struct nf_conn *ct,
+ 				&ct->tuplehash[!dir].tuple.src.u3 : NULL,
+ 			  &ct->tuplehash[!dir].tuple.dst.u3,
+ 			  IPPROTO_TCP, NULL, &port);
+-	exp->helper = nf_conntrack_helper_q931;
++	rcu_assign_pointer(exp->helper, nf_conntrack_helper_q931);
+ 	exp->flags = NF_CT_EXPECT_PERMANENT;	/* Accept multiple calls */
+ 
+ 	nathook = rcu_dereference(nfct_h323_nat_hook);
+@@ -1305,7 +1305,7 @@ static int process_gcf(struct sk_buff *skb, struct nf_conn *ct,
+ 	nf_ct_expect_init(exp, NF_CT_EXPECT_CLASS_DEFAULT, nf_ct_l3num(ct),
+ 			  &ct->tuplehash[!dir].tuple.src.u3, &addr,
+ 			  IPPROTO_UDP, NULL, &port);
+-	exp->helper = nf_conntrack_helper_ras;
++	rcu_assign_pointer(exp->helper, nf_conntrack_helper_ras);
+ 
+ 	if (nf_ct_expect_related(exp, 0) == 0) {
+ 		pr_debug("nf_ct_ras: expect RAS ");
+@@ -1522,7 +1522,7 @@ static int process_acf(struct sk_buff *skb, struct nf_conn *ct,
+ 			  &ct->tuplehash[!dir].tuple.src.u3, &addr,
+ 			  IPPROTO_TCP, NULL, &port);
+ 	exp->flags = NF_CT_EXPECT_PERMANENT;
+-	exp->helper = nf_conntrack_helper_q931;
++	rcu_assign_pointer(exp->helper, nf_conntrack_helper_q931);
+ 
+ 	if (nf_ct_expect_related(exp, 0) == 0) {
+ 		pr_debug("nf_ct_ras: expect Q.931 ");
+@@ -1576,7 +1576,7 @@ static int process_lcf(struct sk_buff *skb, struct nf_conn *ct,
+ 			  &ct->tuplehash[!dir].tuple.src.u3, &addr,
+ 			  IPPROTO_TCP, NULL, &port);
+ 	exp->flags = NF_CT_EXPECT_PERMANENT;
+-	exp->helper = nf_conntrack_helper_q931;
++	rcu_assign_pointer(exp->helper, nf_conntrack_helper_q931);
+ 
+ 	if (nf_ct_expect_related(exp, 0) == 0) {
+ 		pr_debug("nf_ct_ras: expect Q.931 ");
+diff --git a/net/netfilter/nf_conntrack_helper.c b/net/netfilter/nf_conntrack_helper.c
+index 10f72b5b4e1ad7..7d5e4f67f268c6 100644
+--- a/net/netfilter/nf_conntrack_helper.c
++++ b/net/netfilter/nf_conntrack_helper.c
+@@ -400,14 +400,10 @@ EXPORT_SYMBOL_GPL(nf_conntrack_helper_register);
+ 
+ static bool expect_iter_me(struct nf_conntrack_expect *exp, void *data)
+ {
+-	struct nf_conn_help *help = nfct_help(exp->master);
+ 	const struct nf_conntrack_helper *me = data;
+ 	const struct nf_conntrack_helper *this;
+ 
+-	if (exp->helper == me)
+-		return true;
+-
+-	this = rcu_dereference_protected(help->helper,
++	this = rcu_dereference_protected(exp->helper,
+ 					 lockdep_is_held(&nf_conntrack_expect_lock));
+ 	return this == me;
+ }
+@@ -424,8 +420,13 @@ void nf_conntrack_helper_unregister(struct nf_conntrack_helper *me)
+ 	 */
+ 	synchronize_rcu();
+ 
+-	nf_ct_expect_iterate_destroy(expect_iter_me, NULL);
++	nf_ct_expect_iterate_destroy(expect_iter_me, me);
+ 	nf_ct_iterate_destroy(unhelp, me);
++
++	/* nf_ct_iterate_destroy() does an unconditional synchronize_rcu() as
++	 * last step, this ensures rcu readers of exp->helper are done.
++	 * No need for another synchronize_rcu() here.
++	 */
+ }
+ EXPORT_SYMBOL_GPL(nf_conntrack_helper_unregister);
+ 
+diff --git a/net/netfilter/nf_conntrack_netlink.c b/net/netfilter/nf_conntrack_netlink.c
+index 718526867ffdcc..9b089cdfcd352c 100644
+--- a/net/netfilter/nf_conntrack_netlink.c
++++ b/net/netfilter/nf_conntrack_netlink.c
+@@ -2624,7 +2624,6 @@ static const struct nla_policy exp_nla_policy[CTA_EXPECT_MAX+1] = {
+ 
+ static struct nf_conntrack_expect *
+ ctnetlink_alloc_expect(const struct nlattr *const cda[], struct nf_conn *ct,
+-		       struct nf_conntrack_helper *helper,
+ 		       struct nf_conntrack_tuple *tuple,
+ 		       struct nf_conntrack_tuple *mask);
+ 
+@@ -2853,7 +2852,6 @@ ctnetlink_glue_attach_expect(const struct nlattr *attr, struct nf_conn *ct,
+ {
+ 	struct nlattr *cda[CTA_EXPECT_MAX+1];
+ 	struct nf_conntrack_tuple tuple, mask;
+-	struct nf_conntrack_helper *helper = NULL;
+ 	struct nf_conntrack_expect *exp;
+ 	int err;
+ 
+@@ -2867,17 +2865,8 @@ ctnetlink_glue_attach_expect(const struct nlattr *attr, struct nf_conn *ct,
+ 	if (err < 0)
+ 		return err;
+ 
+-	if (cda[CTA_EXPECT_HELP_NAME]) {
+-		const char *helpname = nla_data(cda[CTA_EXPECT_HELP_NAME]);
+-
+-		helper = __nf_conntrack_helper_find(helpname, nf_ct_l3num(ct),
+-						    nf_ct_protonum(ct));
+-		if (helper == NULL)
+-			return -EOPNOTSUPP;
+-	}
+-
+ 	exp = ctnetlink_alloc_expect((const struct nlattr * const *)cda, ct,
+-				     helper, &tuple, &mask);
++				     &tuple, &mask);
+ 	if (IS_ERR(exp))
+ 		return PTR_ERR(exp);
+ 
+@@ -2994,7 +2983,7 @@ ctnetlink_exp_dump_expect(struct sk_buff *skb,
+ {
+ 	struct nf_conn *master = exp->master;
+ 	long timeout = ((long)exp->timeout.expires - (long)jiffies) / HZ;
+-	struct nf_conn_help *help;
++	struct nf_conntrack_helper *helper;
+ #if IS_ENABLED(CONFIG_NF_NAT)
+ 	struct nlattr *nest_parms;
+ 	struct nf_conntrack_tuple nat_tuple = {};
+@@ -3039,15 +3028,12 @@ ctnetlink_exp_dump_expect(struct sk_buff *skb,
+ 	    nla_put_be32(skb, CTA_EXPECT_FLAGS, htonl(exp->flags)) ||
+ 	    nla_put_be32(skb, CTA_EXPECT_CLASS, htonl(exp->class)))
+ 		goto nla_put_failure;
+-	help = nfct_help(master);
+-	if (help) {
+-		struct nf_conntrack_helper *helper;
+ 
+-		helper = rcu_dereference(help->helper);
+-		if (helper &&
+-		    nla_put_string(skb, CTA_EXPECT_HELP_NAME, helper->name))
+-			goto nla_put_failure;
+-	}
++	helper = rcu_dereference(exp->helper);
++	if (helper &&
++	    nla_put_string(skb, CTA_EXPECT_HELP_NAME, helper->name))
++		goto nla_put_failure;
++
+ 	expfn = nf_ct_helper_expectfn_find_by_symbol(exp->expectfn);
+ 	if (expfn != NULL &&
+ 	    nla_put_string(skb, CTA_EXPECT_FN, expfn->name))
+@@ -3376,12 +3362,9 @@ static int ctnetlink_get_expect(struct sk_buff *skb,
+ static bool expect_iter_name(struct nf_conntrack_expect *exp, void *data)
+ {
+ 	struct nf_conntrack_helper *helper;
+-	const struct nf_conn_help *m_help;
+ 	const char *name = data;
+ 
+-	m_help = nfct_help(exp->master);
+-
+-	helper = rcu_dereference(m_help->helper);
++	helper = rcu_dereference(exp->helper);
+ 	if (!helper)
+ 		return false;
+ 
+@@ -3512,20 +3495,25 @@ ctnetlink_parse_expect_nat(const struct nlattr *attr,
+ 
+ static struct nf_conntrack_expect *
+ ctnetlink_alloc_expect(const struct nlattr * const cda[], struct nf_conn *ct,
+-		       struct nf_conntrack_helper *helper,
+ 		       struct nf_conntrack_tuple *tuple,
+ 		       struct nf_conntrack_tuple *mask)
+ {
+-	u_int32_t class = 0;
++	struct net *net = read_pnet(&ct->ct_net);
++	struct nf_conntrack_helper *helper;
+ 	struct nf_conntrack_expect *exp;
+ 	struct nf_conn_help *help;
++	u32 class = 0;
+ 	int err;
+ 
+ 	help = nfct_help(ct);
+ 	if (!help)
+ 		return ERR_PTR(-EOPNOTSUPP);
+ 
+-	if (cda[CTA_EXPECT_CLASS] && helper) {
++	helper = rcu_dereference(help->helper);
++	if (!helper)
++		return ERR_PTR(-EOPNOTSUPP);
++
++	if (cda[CTA_EXPECT_CLASS]) {
+ 		class = ntohl(nla_get_be32(cda[CTA_EXPECT_CLASS]));
+ 		if (class > helper->expect_class_max)
+ 			return ERR_PTR(-EINVAL);
+@@ -3555,7 +3543,11 @@ ctnetlink_alloc_expect(const struct nlattr * const cda[], struct nf_conn *ct,
+ 
+ 	exp->class = class;
+ 	exp->master = ct;
+-	exp->helper = helper;
++	write_pnet(&exp->net, net);
++#ifdef CONFIG_NF_CONNTRACK_ZONES
++	exp->zone = ct->zone;
++#endif
++	rcu_assign_pointer(exp->helper, helper);
+ 	exp->tuple = *tuple;
+ 	exp->mask.src.u3 = mask->src.u3;
+ 	exp->mask.src.u.all = mask->src.u.all;
+@@ -3565,6 +3557,12 @@ ctnetlink_alloc_expect(const struct nlattr * const cda[], struct nf_conn *ct,
+ 						 exp, nf_ct_l3num(ct));
+ 		if (err < 0)
+ 			goto err_out;
++#if IS_ENABLED(CONFIG_NF_NAT)
++	} else {
++		memset(&exp->saved_addr, 0, sizeof(exp->saved_addr));
++		memset(&exp->saved_proto, 0, sizeof(exp->saved_proto));
++		exp->dir = 0;
++#endif
+ 	}
+ 	return exp;
+ err_out:
+@@ -3580,7 +3578,6 @@ ctnetlink_create_expect(struct net *net,
+ {
+ 	struct nf_conntrack_tuple tuple, mask, master_tuple;
+ 	struct nf_conntrack_tuple_hash *h = NULL;
+-	struct nf_conntrack_helper *helper = NULL;
+ 	struct nf_conntrack_expect *exp;
+ 	struct nf_conn *ct;
+ 	int err;
+@@ -3606,33 +3603,7 @@ ctnetlink_create_expect(struct net *net,
+ 	ct = nf_ct_tuplehash_to_ctrack(h);
+ 
+ 	rcu_read_lock();
+-	if (cda[CTA_EXPECT_HELP_NAME]) {
+-		const char *helpname = nla_data(cda[CTA_EXPECT_HELP_NAME]);
+-
+-		helper = __nf_conntrack_helper_find(helpname, u3,
+-						    nf_ct_protonum(ct));
+-		if (helper == NULL) {
+-			rcu_read_unlock();
+-#ifdef CONFIG_MODULES
+-			if (request_module("nfct-helper-%s", helpname) < 0) {
+-				err = -EOPNOTSUPP;
+-				goto err_ct;
+-			}
+-			rcu_read_lock();
+-			helper = __nf_conntrack_helper_find(helpname, u3,
+-							    nf_ct_protonum(ct));
+-			if (helper) {
+-				err = -EAGAIN;
+-				goto err_rcu;
+-			}
+-			rcu_read_unlock();
+-#endif
+-			err = -EOPNOTSUPP;
+-			goto err_ct;
+-		}
+-	}
+-
+-	exp = ctnetlink_alloc_expect(cda, ct, helper, &tuple, &mask);
++	exp = ctnetlink_alloc_expect(cda, ct, &tuple, &mask);
+ 	if (IS_ERR(exp)) {
+ 		err = PTR_ERR(exp);
+ 		goto err_rcu;
+@@ -3642,8 +3613,8 @@ ctnetlink_create_expect(struct net *net,
+ 	nf_ct_expect_put(exp);
+ err_rcu:
+ 	rcu_read_unlock();
+-err_ct:
+ 	nf_ct_put(ct);
++
+ 	return err;
+ }
+ 
+diff --git a/net/netfilter/nf_conntrack_sip.c b/net/netfilter/nf_conntrack_sip.c
+index 84334537c60673..fda6fc1fc4c583 100644
+--- a/net/netfilter/nf_conntrack_sip.c
++++ b/net/netfilter/nf_conntrack_sip.c
+@@ -924,7 +924,7 @@ static int set_expected_rtp_rtcp(struct sk_buff *skb, unsigned int protoff,
+ 		exp = __nf_ct_expect_find(net, nf_ct_zone(ct), &tuple);
+ 
+ 		if (!exp || exp->master == ct ||
+-		    nfct_help(exp->master)->helper != nfct_help(ct)->helper ||
++		    exp->helper != nfct_help(ct)->helper ||
+ 		    exp->class != class)
+ 			break;
+ #if IS_ENABLED(CONFIG_NF_NAT)
+@@ -1303,7 +1303,7 @@ static int process_register_request(struct sk_buff *skb, unsigned int protoff,
+ 	nf_ct_expect_init(exp, SIP_EXPECT_SIGNALLING, nf_ct_l3num(ct),
+ 			  saddr, &daddr, proto, NULL, &port);
+ 	exp->timeout.expires = sip_timeout * HZ;
+-	exp->helper = helper;
++	rcu_assign_pointer(exp->helper, helper);
+ 	exp->flags = NF_CT_EXPECT_PERMANENT | NF_CT_EXPECT_INACTIVE;
+ 
+ 	hooks = rcu_dereference(nf_nat_sip_hooks);
+diff --git a/net/netfilter/nf_flow_table_offload.c b/net/netfilter/nf_flow_table_offload.c
+index 3d46372b538e56..7136eed469862e 100644
+--- a/net/netfilter/nf_flow_table_offload.c
++++ b/net/netfilter/nf_flow_table_offload.c
+@@ -13,6 +13,8 @@
+ #include <net/netfilter/nf_conntrack_core.h>
+ #include <net/netfilter/nf_conntrack_tuple.h>
+ 
++#define NF_FLOW_RULE_ACTION_MAX	24
++
+ static struct workqueue_struct *nf_flow_offload_add_wq;
+ static struct workqueue_struct *nf_flow_offload_del_wq;
+ static struct workqueue_struct *nf_flow_offload_stats_wq;
+@@ -215,7 +217,12 @@ static void flow_offload_mangle(struct flow_action_entry *entry,
+ static inline struct flow_action_entry *
+ flow_action_entry_next(struct nf_flow_rule *flow_rule)
+ {
+-	int i = flow_rule->rule->action.num_entries++;
++	int i;
++
++	if (unlikely(flow_rule->rule->action.num_entries >= NF_FLOW_RULE_ACTION_MAX))
++		return NULL;
++
++	i = flow_rule->rule->action.num_entries++;
+ 
+ 	return &flow_rule->rule->action.entries[i];
+ }
+@@ -233,6 +240,9 @@ static int flow_offload_eth_src(struct net *net,
+ 	u32 mask, val;
+ 	u16 val16;
+ 
++	if (!entry0 || !entry1)
++		return -E2BIG;
++
+ 	this_tuple = &flow->tuplehash[dir].tuple;
+ 
+ 	switch (this_tuple->xmit_type) {
+@@ -283,6 +293,9 @@ static int flow_offload_eth_dst(struct net *net,
+ 	u8 nud_state;
+ 	u16 val16;
+ 
++	if (!entry0 || !entry1)
++		return -E2BIG;
++
+ 	this_tuple = &flow->tuplehash[dir].tuple;
+ 
+ 	switch (this_tuple->xmit_type) {
+@@ -324,16 +337,19 @@ static int flow_offload_eth_dst(struct net *net,
+ 	return 0;
+ }
+ 
+-static void flow_offload_ipv4_snat(struct net *net,
+-				   const struct flow_offload *flow,
+-				   enum flow_offload_tuple_dir dir,
+-				   struct nf_flow_rule *flow_rule)
++static int flow_offload_ipv4_snat(struct net *net,
++				  const struct flow_offload *flow,
++				  enum flow_offload_tuple_dir dir,
++				  struct nf_flow_rule *flow_rule)
+ {
+ 	struct flow_action_entry *entry = flow_action_entry_next(flow_rule);
+ 	u32 mask = ~htonl(0xffffffff);
+ 	__be32 addr;
+ 	u32 offset;
+ 
++	if (!entry)
++		return -E2BIG;
++
+ 	switch (dir) {
+ 	case FLOW_OFFLOAD_DIR_ORIGINAL:
+ 		addr = flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.dst_v4.s_addr;
+@@ -344,23 +360,27 @@ static void flow_offload_ipv4_snat(struct net *net,
+ 		offset = offsetof(struct iphdr, daddr);
+ 		break;
+ 	default:
+-		return;
++		return -EOPNOTSUPP;
+ 	}
+ 
+ 	flow_offload_mangle(entry, FLOW_ACT_MANGLE_HDR_TYPE_IP4, offset,
+ 			    &addr, &mask);
++	return 0;
+ }
+ 
+-static void flow_offload_ipv4_dnat(struct net *net,
+-				   const struct flow_offload *flow,
+-				   enum flow_offload_tuple_dir dir,
+-				   struct nf_flow_rule *flow_rule)
++static int flow_offload_ipv4_dnat(struct net *net,
++				  const struct flow_offload *flow,
++				  enum flow_offload_tuple_dir dir,
++				  struct nf_flow_rule *flow_rule)
+ {
+ 	struct flow_action_entry *entry = flow_action_entry_next(flow_rule);
+ 	u32 mask = ~htonl(0xffffffff);
+ 	__be32 addr;
+ 	u32 offset;
+ 
++	if (!entry)
++		return -E2BIG;
++
+ 	switch (dir) {
+ 	case FLOW_OFFLOAD_DIR_ORIGINAL:
+ 		addr = flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.src_v4.s_addr;
+@@ -371,14 +391,15 @@ static void flow_offload_ipv4_dnat(struct net *net,
+ 		offset = offsetof(struct iphdr, saddr);
+ 		break;
+ 	default:
+-		return;
++		return -EOPNOTSUPP;
+ 	}
+ 
+ 	flow_offload_mangle(entry, FLOW_ACT_MANGLE_HDR_TYPE_IP4, offset,
+ 			    &addr, &mask);
++	return 0;
+ }
+ 
+-static void flow_offload_ipv6_mangle(struct nf_flow_rule *flow_rule,
++static int flow_offload_ipv6_mangle(struct nf_flow_rule *flow_rule,
+ 				     unsigned int offset,
+ 				     const __be32 *addr, const __be32 *mask)
+ {
+@@ -387,15 +408,20 @@ static void flow_offload_ipv6_mangle(struct nf_flow_rule *flow_rule,
+ 
+ 	for (i = 0; i < sizeof(struct in6_addr) / sizeof(u32); i++) {
+ 		entry = flow_action_entry_next(flow_rule);
++		if (!entry)
++			return -E2BIG;
++
+ 		flow_offload_mangle(entry, FLOW_ACT_MANGLE_HDR_TYPE_IP6,
+ 				    offset + i * sizeof(u32), &addr[i], mask);
+ 	}
++
++	return 0;
+ }
+ 
+-static void flow_offload_ipv6_snat(struct net *net,
+-				   const struct flow_offload *flow,
+-				   enum flow_offload_tuple_dir dir,
+-				   struct nf_flow_rule *flow_rule)
++static int flow_offload_ipv6_snat(struct net *net,
++				  const struct flow_offload *flow,
++				  enum flow_offload_tuple_dir dir,
++				  struct nf_flow_rule *flow_rule)
+ {
+ 	u32 mask = ~htonl(0xffffffff);
+ 	const __be32 *addr;
+@@ -411,16 +437,16 @@ static void flow_offload_ipv6_snat(struct net *net,
+ 		offset = offsetof(struct ipv6hdr, daddr);
+ 		break;
+ 	default:
+-		return;
++		return -EOPNOTSUPP;
+ 	}
+ 
+-	flow_offload_ipv6_mangle(flow_rule, offset, addr, &mask);
++	return flow_offload_ipv6_mangle(flow_rule, offset, addr, &mask);
+ }
+ 
+-static void flow_offload_ipv6_dnat(struct net *net,
+-				   const struct flow_offload *flow,
+-				   enum flow_offload_tuple_dir dir,
+-				   struct nf_flow_rule *flow_rule)
++static int flow_offload_ipv6_dnat(struct net *net,
++				  const struct flow_offload *flow,
++				  enum flow_offload_tuple_dir dir,
++				  struct nf_flow_rule *flow_rule)
+ {
+ 	u32 mask = ~htonl(0xffffffff);
+ 	const __be32 *addr;
+@@ -436,10 +462,10 @@ static void flow_offload_ipv6_dnat(struct net *net,
+ 		offset = offsetof(struct ipv6hdr, saddr);
+ 		break;
+ 	default:
+-		return;
++		return -EOPNOTSUPP;
+ 	}
+ 
+-	flow_offload_ipv6_mangle(flow_rule, offset, addr, &mask);
++	return flow_offload_ipv6_mangle(flow_rule, offset, addr, &mask);
+ }
+ 
+ static int flow_offload_l4proto(const struct flow_offload *flow)
+@@ -461,15 +487,18 @@ static int flow_offload_l4proto(const struct flow_offload *flow)
+ 	return type;
+ }
+ 
+-static void flow_offload_port_snat(struct net *net,
+-				   const struct flow_offload *flow,
+-				   enum flow_offload_tuple_dir dir,
+-				   struct nf_flow_rule *flow_rule)
++static int flow_offload_port_snat(struct net *net,
++				  const struct flow_offload *flow,
++				  enum flow_offload_tuple_dir dir,
++				  struct nf_flow_rule *flow_rule)
+ {
+ 	struct flow_action_entry *entry = flow_action_entry_next(flow_rule);
+ 	u32 mask, port;
+ 	u32 offset;
+ 
++	if (!entry)
++		return -E2BIG;
++
+ 	switch (dir) {
+ 	case FLOW_OFFLOAD_DIR_ORIGINAL:
+ 		port = ntohs(flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.dst_port);
+@@ -484,22 +513,26 @@ static void flow_offload_port_snat(struct net *net,
+ 		mask = ~htonl(0xffff);
+ 		break;
+ 	default:
+-		return;
++		return -EOPNOTSUPP;
+ 	}
+ 
+ 	flow_offload_mangle(entry, flow_offload_l4proto(flow), offset,
+ 			    &port, &mask);
++	return 0;
+ }
+ 
+-static void flow_offload_port_dnat(struct net *net,
+-				   const struct flow_offload *flow,
+-				   enum flow_offload_tuple_dir dir,
+-				   struct nf_flow_rule *flow_rule)
++static int flow_offload_port_dnat(struct net *net,
++				  const struct flow_offload *flow,
++				  enum flow_offload_tuple_dir dir,
++				  struct nf_flow_rule *flow_rule)
+ {
+ 	struct flow_action_entry *entry = flow_action_entry_next(flow_rule);
+ 	u32 mask, port;
+ 	u32 offset;
+ 
++	if (!entry)
++		return -E2BIG;
++
+ 	switch (dir) {
+ 	case FLOW_OFFLOAD_DIR_ORIGINAL:
+ 		port = ntohs(flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.src_port);
+@@ -514,20 +547,24 @@ static void flow_offload_port_dnat(struct net *net,
+ 		mask = ~htonl(0xffff0000);
+ 		break;
+ 	default:
+-		return;
++		return -EOPNOTSUPP;
+ 	}
+ 
+ 	flow_offload_mangle(entry, flow_offload_l4proto(flow), offset,
+ 			    &port, &mask);
++	return 0;
+ }
+ 
+-static void flow_offload_ipv4_checksum(struct net *net,
+-				       const struct flow_offload *flow,
+-				       struct nf_flow_rule *flow_rule)
++static int flow_offload_ipv4_checksum(struct net *net,
++				      const struct flow_offload *flow,
++				      struct nf_flow_rule *flow_rule)
+ {
+ 	u8 protonum = flow->tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.l4proto;
+ 	struct flow_action_entry *entry = flow_action_entry_next(flow_rule);
+ 
++	if (!entry)
++		return -E2BIG;
++
+ 	entry->id = FLOW_ACTION_CSUM;
+ 	entry->csum_flags = TCA_CSUM_UPDATE_FLAG_IPV4HDR;
+ 
+@@ -539,12 +576,14 @@ static void flow_offload_ipv4_checksum(struct net *net,
+ 		entry->csum_flags |= TCA_CSUM_UPDATE_FLAG_UDP;
+ 		break;
+ 	}
++
++	return 0;
+ }
+ 
+-static void flow_offload_redirect(struct net *net,
+-				  const struct flow_offload *flow,
+-				  enum flow_offload_tuple_dir dir,
+-				  struct nf_flow_rule *flow_rule)
++static int flow_offload_redirect(struct net *net,
++				 const struct flow_offload *flow,
++				 enum flow_offload_tuple_dir dir,
++				 struct nf_flow_rule *flow_rule)
+ {
+ 	const struct flow_offload_tuple *this_tuple, *other_tuple;
+ 	struct flow_action_entry *entry;
+@@ -562,21 +601,28 @@ static void flow_offload_redirect(struct net *net,
+ 		ifindex = other_tuple->iifidx;
+ 		break;
+ 	default:
+-		return;
++		return -EOPNOTSUPP;
+ 	}
+ 
+ 	dev = dev_get_by_index(net, ifindex);
+ 	if (!dev)
+-		return;
++		return -ENODEV;
+ 
+ 	entry = flow_action_entry_next(flow_rule);
++	if (!entry) {
++		dev_put(dev);
++		return -E2BIG;
++	}
++
+ 	entry->id = FLOW_ACTION_REDIRECT;
+ 	entry->dev = dev;
++
++	return 0;
+ }
+ 
+-static void flow_offload_encap_tunnel(const struct flow_offload *flow,
+-				      enum flow_offload_tuple_dir dir,
+-				      struct nf_flow_rule *flow_rule)
++static int flow_offload_encap_tunnel(const struct flow_offload *flow,
++				     enum flow_offload_tuple_dir dir,
++				     struct nf_flow_rule *flow_rule)
+ {
+ 	const struct flow_offload_tuple *this_tuple;
+ 	struct flow_action_entry *entry;
+@@ -584,7 +630,7 @@ static void flow_offload_encap_tunnel(const struct flow_offload *flow,
+ 
+ 	this_tuple = &flow->tuplehash[dir].tuple;
+ 	if (this_tuple->xmit_type == FLOW_OFFLOAD_XMIT_DIRECT)
+-		return;
++		return 0;
+ 
+ 	dst = this_tuple->dst_cache;
+ 	if (dst && dst->lwtstate) {
+@@ -593,15 +639,19 @@ static void flow_offload_encap_tunnel(const struct flow_offload *flow,
+ 		tun_info = lwt_tun_info(dst->lwtstate);
+ 		if (tun_info && (tun_info->mode & IP_TUNNEL_INFO_TX)) {
+ 			entry = flow_action_entry_next(flow_rule);
++			if (!entry)
++				return -E2BIG;
+ 			entry->id = FLOW_ACTION_TUNNEL_ENCAP;
+ 			entry->tunnel = tun_info;
+ 		}
+ 	}
++
++	return 0;
+ }
+ 
+-static void flow_offload_decap_tunnel(const struct flow_offload *flow,
+-				      enum flow_offload_tuple_dir dir,
+-				      struct nf_flow_rule *flow_rule)
++static int flow_offload_decap_tunnel(const struct flow_offload *flow,
++				     enum flow_offload_tuple_dir dir,
++				     struct nf_flow_rule *flow_rule)
+ {
+ 	const struct flow_offload_tuple *other_tuple;
+ 	struct flow_action_entry *entry;
+@@ -609,7 +659,7 @@ static void flow_offload_decap_tunnel(const struct flow_offload *flow,
+ 
+ 	other_tuple = &flow->tuplehash[!dir].tuple;
+ 	if (other_tuple->xmit_type == FLOW_OFFLOAD_XMIT_DIRECT)
+-		return;
++		return 0;
+ 
+ 	dst = other_tuple->dst_cache;
+ 	if (dst && dst->lwtstate) {
+@@ -618,9 +668,13 @@ static void flow_offload_decap_tunnel(const struct flow_offload *flow,
+ 		tun_info = lwt_tun_info(dst->lwtstate);
+ 		if (tun_info && (tun_info->mode & IP_TUNNEL_INFO_TX)) {
+ 			entry = flow_action_entry_next(flow_rule);
++			if (!entry)
++				return -E2BIG;
+ 			entry->id = FLOW_ACTION_TUNNEL_DECAP;
+ 		}
+ 	}
++
++	return 0;
+ }
+ 
+ static int
+@@ -632,8 +686,9 @@ nf_flow_rule_route_common(struct net *net, const struct flow_offload *flow,
+ 	const struct flow_offload_tuple *tuple;
+ 	int i;
+ 
+-	flow_offload_decap_tunnel(flow, dir, flow_rule);
+-	flow_offload_encap_tunnel(flow, dir, flow_rule);
++	if (flow_offload_decap_tunnel(flow, dir, flow_rule) < 0 ||
++	    flow_offload_encap_tunnel(flow, dir, flow_rule) < 0)
++		return -1;
+ 
+ 	if (flow_offload_eth_src(net, flow, dir, flow_rule) < 0 ||
+ 	    flow_offload_eth_dst(net, flow, dir, flow_rule) < 0)
+@@ -649,6 +704,8 @@ nf_flow_rule_route_common(struct net *net, const struct flow_offload *flow,
+ 
+ 		if (tuple->encap[i].proto == htons(ETH_P_8021Q)) {
+ 			entry = flow_action_entry_next(flow_rule);
++			if (!entry)
++				return -1;
+ 			entry->id = FLOW_ACTION_VLAN_POP;
+ 		}
+ 	}
+@@ -662,6 +719,8 @@ nf_flow_rule_route_common(struct net *net, const struct flow_offload *flow,
+ 			continue;
+ 
+ 		entry = flow_action_entry_next(flow_rule);
++		if (!entry)
++			return -1;
+ 
+ 		switch (other_tuple->encap[i].proto) {
+ 		case htons(ETH_P_PPP_SES):
+@@ -687,18 +746,22 @@ int nf_flow_rule_route_ipv4(struct net *net, struct flow_offload *flow,
+ 		return -1;
+ 
+ 	if (test_bit(NF_FLOW_SNAT, &flow->flags)) {
+-		flow_offload_ipv4_snat(net, flow, dir, flow_rule);
+-		flow_offload_port_snat(net, flow, dir, flow_rule);
++		if (flow_offload_ipv4_snat(net, flow, dir, flow_rule) < 0 ||
++		    flow_offload_port_snat(net, flow, dir, flow_rule) < 0)
++			return -1;
+ 	}
+ 	if (test_bit(NF_FLOW_DNAT, &flow->flags)) {
+-		flow_offload_ipv4_dnat(net, flow, dir, flow_rule);
+-		flow_offload_port_dnat(net, flow, dir, flow_rule);
++		if (flow_offload_ipv4_dnat(net, flow, dir, flow_rule) < 0 ||
++		    flow_offload_port_dnat(net, flow, dir, flow_rule) < 0)
++			return -1;
+ 	}
+ 	if (test_bit(NF_FLOW_SNAT, &flow->flags) ||
+ 	    test_bit(NF_FLOW_DNAT, &flow->flags))
+-		flow_offload_ipv4_checksum(net, flow, flow_rule);
++		if (flow_offload_ipv4_checksum(net, flow, flow_rule) < 0)
++			return -1;
+ 
+-	flow_offload_redirect(net, flow, dir, flow_rule);
++	if (flow_offload_redirect(net, flow, dir, flow_rule) < 0)
++		return -1;
+ 
+ 	return 0;
+ }
+@@ -712,22 +775,23 @@ int nf_flow_rule_route_ipv6(struct net *net, struct flow_offload *flow,
+ 		return -1;
+ 
+ 	if (test_bit(NF_FLOW_SNAT, &flow->flags)) {
+-		flow_offload_ipv6_snat(net, flow, dir, flow_rule);
+-		flow_offload_port_snat(net, flow, dir, flow_rule);
++		if (flow_offload_ipv6_snat(net, flow, dir, flow_rule) < 0 ||
++		    flow_offload_port_snat(net, flow, dir, flow_rule) < 0)
++			return -1;
+ 	}
+ 	if (test_bit(NF_FLOW_DNAT, &flow->flags)) {
+-		flow_offload_ipv6_dnat(net, flow, dir, flow_rule);
+-		flow_offload_port_dnat(net, flow, dir, flow_rule);
++		if (flow_offload_ipv6_dnat(net, flow, dir, flow_rule) < 0 ||
++		    flow_offload_port_dnat(net, flow, dir, flow_rule) < 0)
++			return -1;
+ 	}
+ 
+-	flow_offload_redirect(net, flow, dir, flow_rule);
++	if (flow_offload_redirect(net, flow, dir, flow_rule) < 0)
++		return -1;
+ 
+ 	return 0;
+ }
+ EXPORT_SYMBOL_GPL(nf_flow_rule_route_ipv6);
+ 
+-#define NF_FLOW_RULE_ACTION_MAX	16
+-
+ static struct nf_flow_rule *
+ nf_flow_offload_rule_alloc(struct net *net,
+ 			   const struct flow_offload_work *offload,
+diff --git a/net/netfilter/nf_tables_api.c b/net/netfilter/nf_tables_api.c
+index b411abe9743b74..0aaddc1131c650 100644
+--- a/net/netfilter/nf_tables_api.c
++++ b/net/netfilter/nf_tables_api.c
+@@ -11105,8 +11105,6 @@ static int nft_verdict_init(const struct nft_ctx *ctx, struct nft_data *data,
+ 	switch (data->verdict.code) {
+ 	case NF_ACCEPT:
+ 	case NF_DROP:
+-	case NF_QUEUE:
+-		break;
+ 	case NFT_CONTINUE:
+ 	case NFT_BREAK:
+ 	case NFT_RETURN:
+@@ -11141,6 +11139,11 @@ static int nft_verdict_init(const struct nft_ctx *ctx, struct nft_data *data,
+ 
+ 		data->verdict.chain = chain;
+ 		break;
++	case NF_QUEUE:
++		/* The nft_queue expression is used for this purpose, an
++		 * immediate NF_QUEUE verdict should not ever be seen here.
++		 */
++		fallthrough;
+ 	default:
+ 		return -EINVAL;
+ 	}
+diff --git a/net/netfilter/nfnetlink_log.c b/net/netfilter/nfnetlink_log.c
+index aa5fc9bffef0c3..f96421ad14afb5 100644
+--- a/net/netfilter/nfnetlink_log.c
++++ b/net/netfilter/nfnetlink_log.c
+@@ -726,7 +726,7 @@ nfulnl_log_packet(struct net *net,
+ 		+ nla_total_size(plen)			/* prefix */
+ 		+ nla_total_size(sizeof(struct nfulnl_msg_packet_hw))
+ 		+ nla_total_size(sizeof(struct nfulnl_msg_packet_timestamp))
+-		+ nla_total_size(sizeof(struct nfgenmsg));	/* NLMSG_DONE */
++		+ nlmsg_total_size(sizeof(struct nfgenmsg));	/* NLMSG_DONE */
+ 
+ 	if (in && skb_mac_header_was_set(skb)) {
+ 		size += nla_total_size(skb->dev->hard_header_len)
+diff --git a/net/netfilter/x_tables.c b/net/netfilter/x_tables.c
+index d892afc9a1acca..c1ab85fb8c46d1 100644
+--- a/net/netfilter/x_tables.c
++++ b/net/netfilter/x_tables.c
+@@ -501,6 +501,17 @@ int xt_check_match(struct xt_mtchk_param *par,
+ 				    par->match->table, par->table);
+ 		return -EINVAL;
+ 	}
++
++	/* NFPROTO_UNSPEC implies NF_INET_* hooks which do not overlap with
++	 * NF_ARP_IN,OUT,FORWARD, allow explicit extensions with NFPROTO_ARP
++	 * support.
++	 */
++	if (par->family == NFPROTO_ARP &&
++	    par->match->family != NFPROTO_ARP) {
++		pr_info_ratelimited("%s_tables: %s match: not valid for this family\n",
++				    xt_prefix[par->family], par->match->name);
++		return -EINVAL;
++	}
+ 	if (par->match->hooks && (par->hook_mask & ~par->match->hooks) != 0) {
+ 		char used[64], allow[64];
+ 
+@@ -1016,6 +1027,18 @@ int xt_check_target(struct xt_tgchk_param *par,
+ 				    par->target->table, par->table);
+ 		return -EINVAL;
+ 	}
++
++	/* NFPROTO_UNSPEC implies NF_INET_* hooks which do not overlap with
++	 * NF_ARP_IN,OUT,FORWARD, allow explicit extensions with NFPROTO_ARP
++	 * support.
++	 */
++	if (par->family == NFPROTO_ARP &&
++	    par->target->family != NFPROTO_ARP) {
++		pr_info_ratelimited("%s_tables: %s target: not valid for this family\n",
++				    xt_prefix[par->family], par->target->name);
++		return -EINVAL;
++	}
++
+ 	if (par->target->hooks && (par->hook_mask & ~par->target->hooks) != 0) {
+ 		char used[64], allow[64];
+ 
+diff --git a/net/netfilter/xt_cgroup.c b/net/netfilter/xt_cgroup.c
+index c0f5e9a4f3c651..bfc98719684e29 100644
+--- a/net/netfilter/xt_cgroup.c
++++ b/net/netfilter/xt_cgroup.c
+@@ -53,6 +53,9 @@ static int cgroup_mt_check_v1(const struct xt_mtchk_param *par)
+ 
+ 	info->priv = NULL;
+ 	if (info->has_path) {
++		if (strnlen(info->path, sizeof(info->path)) >= sizeof(info->path))
++			return -ENAMETOOLONG;
++
+ 		cgrp = cgroup_get_from_path(info->path);
+ 		if (IS_ERR(cgrp)) {
+ 			pr_info_ratelimited("invalid path, errno=%ld\n",
+@@ -85,6 +88,9 @@ static int cgroup_mt_check_v2(const struct xt_mtchk_param *par)
+ 
+ 	info->priv = NULL;
+ 	if (info->has_path) {
++		if (strnlen(info->path, sizeof(info->path)) >= sizeof(info->path))
++			return -ENAMETOOLONG;
++
+ 		cgrp = cgroup_get_from_path(info->path);
+ 		if (IS_ERR(cgrp)) {
+ 			pr_info_ratelimited("invalid path, errno=%ld\n",
+diff --git a/net/netfilter/xt_rateest.c b/net/netfilter/xt_rateest.c
+index 72324bd976af8c..b1d736c15fcbe5 100644
+--- a/net/netfilter/xt_rateest.c
++++ b/net/netfilter/xt_rateest.c
+@@ -91,6 +91,11 @@ static int xt_rateest_mt_checkentry(const struct xt_mtchk_param *par)
+ 		goto err1;
+ 	}
+ 
++	if (strnlen(info->name1, sizeof(info->name1)) >= sizeof(info->name1))
++		return -ENAMETOOLONG;
++	if (strnlen(info->name2, sizeof(info->name2)) >= sizeof(info->name2))
++		return -ENAMETOOLONG;
++
+ 	ret  = -ENOENT;
+ 	est1 = xt_rateest_lookup(par->net, info->name1);
+ 	if (!est1)
+diff --git a/net/qrtr/af_qrtr.c b/net/qrtr/af_qrtr.c
+index 00c51cf693f3d0..b703e4c6458532 100644
+--- a/net/qrtr/af_qrtr.c
++++ b/net/qrtr/af_qrtr.c
+@@ -118,7 +118,7 @@ static DEFINE_XARRAY_ALLOC(qrtr_ports);
+  * @ep: endpoint
+  * @ref: reference count for node
+  * @nid: node id
+- * @qrtr_tx_flow: tree of qrtr_tx_flow, keyed by node << 32 | port
++ * @qrtr_tx_flow: xarray of qrtr_tx_flow, keyed by node << 32 | port
+  * @qrtr_tx_lock: lock for qrtr_tx_flow inserts
+  * @rx_queue: receive queue
+  * @item: list item for broadcast list
+@@ -129,7 +129,7 @@ struct qrtr_node {
+ 	struct kref ref;
+ 	unsigned int nid;
+ 
+-	struct radix_tree_root qrtr_tx_flow;
++	struct xarray qrtr_tx_flow;
+ 	struct mutex qrtr_tx_lock; /* for qrtr_tx_flow */
+ 
+ 	struct sk_buff_head rx_queue;
+@@ -172,6 +172,7 @@ static void __qrtr_node_release(struct kref *kref)
+ 	struct qrtr_tx_flow *flow;
+ 	unsigned long flags;
+ 	void __rcu **slot;
++	unsigned long index;
+ 
+ 	spin_lock_irqsave(&qrtr_nodes_lock, flags);
+ 	/* If the node is a bridge for other nodes, there are possibly
+@@ -189,11 +190,9 @@ static void __qrtr_node_release(struct kref *kref)
+ 	skb_queue_purge(&node->rx_queue);
+ 
+ 	/* Free tx flow counters */
+-	radix_tree_for_each_slot(slot, &node->qrtr_tx_flow, &iter, 0) {
+-		flow = *slot;
+-		radix_tree_iter_delete(&node->qrtr_tx_flow, &iter, slot);
++	xa_for_each(&node->qrtr_tx_flow, index, flow)
+ 		kfree(flow);
+-	}
++	xa_destroy(&node->qrtr_tx_flow);
+ 	kfree(node);
+ }
+ 
+@@ -228,9 +227,7 @@ static void qrtr_tx_resume(struct qrtr_node *node, struct sk_buff *skb)
+ 
+ 	key = remote_node << 32 | remote_port;
+ 
+-	rcu_read_lock();
+-	flow = radix_tree_lookup(&node->qrtr_tx_flow, key);
+-	rcu_read_unlock();
++	flow = xa_load(&node->qrtr_tx_flow, key);
+ 	if (flow) {
+ 		spin_lock(&flow->resume_tx.lock);
+ 		flow->pending = 0;
+@@ -269,12 +266,13 @@ static int qrtr_tx_wait(struct qrtr_node *node, int dest_node, int dest_port,
+ 		return 0;
+ 
+ 	mutex_lock(&node->qrtr_tx_lock);
+-	flow = radix_tree_lookup(&node->qrtr_tx_flow, key);
++	flow = xa_load(&node->qrtr_tx_flow, key);
+ 	if (!flow) {
+ 		flow = kzalloc(sizeof(*flow), GFP_KERNEL);
+ 		if (flow) {
+ 			init_waitqueue_head(&flow->resume_tx);
+-			if (radix_tree_insert(&node->qrtr_tx_flow, key, flow)) {
++			if (xa_err(xa_store(&node->qrtr_tx_flow, key, flow,
++					    GFP_KERNEL))) {
+ 				kfree(flow);
+ 				flow = NULL;
+ 			}
+@@ -326,9 +324,7 @@ static void qrtr_tx_flow_failed(struct qrtr_node *node, int dest_node,
+ 	unsigned long key = (u64)dest_node << 32 | dest_port;
+ 	struct qrtr_tx_flow *flow;
+ 
+-	rcu_read_lock();
+-	flow = radix_tree_lookup(&node->qrtr_tx_flow, key);
+-	rcu_read_unlock();
++	flow = xa_load(&node->qrtr_tx_flow, key);
+ 	if (flow) {
+ 		spin_lock_irq(&flow->resume_tx.lock);
+ 		flow->tx_failed = 1;
+@@ -599,7 +595,7 @@ int qrtr_endpoint_register(struct qrtr_endpoint *ep, unsigned int nid)
+ 	node->nid = QRTR_EP_NID_AUTO;
+ 	node->ep = ep;
+ 
+-	INIT_RADIX_TREE(&node->qrtr_tx_flow, GFP_KERNEL);
++	xa_init(&node->qrtr_tx_flow);
+ 	mutex_init(&node->qrtr_tx_lock);
+ 
+ 	qrtr_node_assign(node, nid);
+@@ -627,6 +623,7 @@ void qrtr_endpoint_unregister(struct qrtr_endpoint *ep)
+ 	struct qrtr_tx_flow *flow;
+ 	struct sk_buff *skb;
+ 	unsigned long flags;
++	unsigned long index;
+ 	void __rcu **slot;
+ 
+ 	mutex_lock(&node->ep_lock);
+@@ -649,10 +646,8 @@ void qrtr_endpoint_unregister(struct qrtr_endpoint *ep)
+ 
+ 	/* Wake up any transmitters waiting for resume-tx from the node */
+ 	mutex_lock(&node->qrtr_tx_lock);
+-	radix_tree_for_each_slot(slot, &node->qrtr_tx_flow, &iter, 0) {
+-		flow = *slot;
++	xa_for_each(&node->qrtr_tx_flow, index, flow)
+ 		wake_up_interruptible_all(&flow->resume_tx);
+-	}
+ 	mutex_unlock(&node->qrtr_tx_lock);
+ 
+ 	qrtr_node_release(node);
+diff --git a/net/rds/ib_rdma.c b/net/rds/ib_rdma.c
+index 8f070ee7e74268..30fca2169aa7ab 100644
+--- a/net/rds/ib_rdma.c
++++ b/net/rds/ib_rdma.c
+@@ -608,8 +608,13 @@ void *rds_ib_get_mr(struct scatterlist *sg, unsigned long nents,
+ 		return ibmr;
+ 	}
+ 
+-	if (conn)
++	if (conn) {
+ 		ic = conn->c_transport_data;
++		if (!ic || !ic->i_cm_id || !ic->i_cm_id->qp) {
++			ret = -ENODEV;
++			goto out;
++		}
++	}
+ 
+ 	if (!rds_ibdev->mr_8k_pool || !rds_ibdev->mr_1m_pool) {
+ 		ret = -ENODEV;
+diff --git a/net/sched/cls_api.c b/net/sched/cls_api.c
+index a90a7b01f3f36d..45124fd64d6b48 100644
+--- a/net/sched/cls_api.c
++++ b/net/sched/cls_api.c
+@@ -2886,6 +2886,7 @@ static int tc_chain_fill_node(const struct tcf_proto_ops *tmplt_ops,
+ 	tcm->tcm__pad1 = 0;
+ 	tcm->tcm__pad2 = 0;
+ 	tcm->tcm_handle = 0;
++	tcm->tcm_info = 0;
+ 	if (block->q) {
+ 		tcm->tcm_ifindex = qdisc_dev(block->q)->ifindex;
+ 		tcm->tcm_parent = block->q->handle;
+diff --git a/net/sched/cls_flow.c b/net/sched/cls_flow.c
+index 815216b564f323..d92ffdaf546c39 100644
+--- a/net/sched/cls_flow.c
++++ b/net/sched/cls_flow.c
+@@ -503,8 +503,16 @@ static int flow_change(struct net *net, struct sk_buff *in_skb,
+ 		}
+ 
+ 		if (TC_H_MAJ(baseclass) == 0) {
+-			struct Qdisc *q = tcf_block_q(tp->chain->block);
++			struct tcf_block *block = tp->chain->block;
++			struct Qdisc *q;
+ 
++			if (tcf_block_shared(block)) {
++				NL_SET_ERR_MSG(extack,
++					       "Must specify baseclass when attaching flow filter to block");
++				goto err2;
++			}
++
++			q = tcf_block_q(block);
+ 			baseclass = TC_H_MAKE(q->handle, baseclass);
+ 		}
+ 		if (TC_H_MIN(baseclass) == 0)
+diff --git a/net/sched/cls_fw.c b/net/sched/cls_fw.c
+index c49d6af0e04807..2e5e8df5ca55c4 100644
+--- a/net/sched/cls_fw.c
++++ b/net/sched/cls_fw.c
+@@ -247,8 +247,18 @@ static int fw_change(struct net *net, struct sk_buff *in_skb,
+ 	struct nlattr *tb[TCA_FW_MAX + 1];
+ 	int err;
+ 
+-	if (!opt)
+-		return handle ? -EINVAL : 0; /* Succeed if it is old method. */
++	if (!opt) {
++		if (handle)
++			return -EINVAL;
++
++		if (tcf_block_shared(tp->chain->block)) {
++			NL_SET_ERR_MSG(extack,
++				       "Must specify mark when attaching fw filter to block");
++			return -EINVAL;
++		}
++
++		return 0; /* Succeed if it is old method. */
++	}
+ 
+ 	err = nla_parse_nested_deprecated(tb, TCA_FW_MAX, opt, fw_policy,
+ 					  NULL);
+diff --git a/net/sched/sch_hfsc.c b/net/sched/sch_hfsc.c
+index 751b1e2c35b3f9..1ac51d02499195 100644
+--- a/net/sched/sch_hfsc.c
++++ b/net/sched/sch_hfsc.c
+@@ -555,7 +555,7 @@ static void
+ rtsc_min(struct runtime_sc *rtsc, struct internal_sc *isc, u64 x, u64 y)
+ {
+ 	u64 y1, y2, dx, dy;
+-	u32 dsm;
++	u64 dsm;
+ 
+ 	if (isc->sm1 <= isc->sm2) {
+ 		/* service curve is convex */
+@@ -598,7 +598,7 @@ rtsc_min(struct runtime_sc *rtsc, struct internal_sc *isc, u64 x, u64 y)
+ 	 */
+ 	dx = (y1 - y) << SM_SHIFT;
+ 	dsm = isc->sm1 - isc->sm2;
+-	do_div(dx, dsm);
++	dx = div64_u64(dx, dsm);
+ 	/*
+ 	 * check if (x, y1) belongs to the 1st segment of rtsc.
+ 	 * if so, add the offset.
+diff --git a/net/sched/sch_netem.c b/net/sched/sch_netem.c
+index 0ad231e94e14d3..7361f90c8c1a11 100644
+--- a/net/sched/sch_netem.c
++++ b/net/sched/sch_netem.c
+@@ -517,8 +517,9 @@ static int netem_enqueue(struct sk_buff *skb, struct Qdisc *sch,
+ 			goto finish_segs;
+ 		}
+ 
+-		skb->data[get_random_u32_below(skb_headlen(skb))] ^=
+-			1<<get_random_u32_below(8);
++		if (skb_headlen(skb))
++			skb->data[get_random_u32_below(skb_headlen(skb))] ^=
++				1 << get_random_u32_below(8);
+ 	}
+ 
+ 	if (unlikely(q->t_len >= sch->limit)) {
+diff --git a/net/x25/x25_in.c b/net/x25/x25_in.c
+index b981a4828d08c2..e47ebd8acd21bf 100644
+--- a/net/x25/x25_in.c
++++ b/net/x25/x25_in.c
+@@ -34,6 +34,10 @@ static int x25_queue_rx_frame(struct sock *sk, struct sk_buff *skb, int more)
+ 	struct sk_buff *skbo, *skbn = skb;
+ 	struct x25_sock *x25 = x25_sk(sk);
+ 
++	/* make sure we don't overflow */
++	if (x25->fraglen + skb->len > USHRT_MAX)
++		return 1;
++
+ 	if (more) {
+ 		x25->fraglen += skb->len;
+ 		skb_queue_tail(&x25->fragment_queue, skb);
+@@ -44,10 +48,9 @@ static int x25_queue_rx_frame(struct sock *sk, struct sk_buff *skb, int more)
+ 	if (x25->fraglen > 0) {	/* End of fragment */
+ 		int len = x25->fraglen + skb->len;
+ 
+-		if ((skbn = alloc_skb(len, GFP_ATOMIC)) == NULL){
+-			kfree_skb(skb);
++		skbn = alloc_skb(len, GFP_ATOMIC);
++		if (!skbn)
+ 			return 1;
+-		}
+ 
+ 		skb_queue_tail(&x25->fragment_queue, skb);
+ 
+diff --git a/net/x25/x25_subr.c b/net/x25/x25_subr.c
+index 0285aaa1e93c17..159708d9ad20cb 100644
+--- a/net/x25/x25_subr.c
++++ b/net/x25/x25_subr.c
+@@ -40,6 +40,7 @@ void x25_clear_queues(struct sock *sk)
+ 	skb_queue_purge(&x25->interrupt_in_queue);
+ 	skb_queue_purge(&x25->interrupt_out_queue);
+ 	skb_queue_purge(&x25->fragment_queue);
++	x25->fraglen = 0;
+ }
+ 
+ 
+diff --git a/sound/pci/ctxfi/ctdaio.c b/sound/pci/ctxfi/ctdaio.c
+index 7fc720046ce293..4e4c780bfa9d35 100644
+--- a/sound/pci/ctxfi/ctdaio.c
++++ b/sound/pci/ctxfi/ctdaio.c
+@@ -119,6 +119,7 @@ static unsigned int daio_device_index(enum DAIOTYP type, struct hw *hw)
+ 		switch (type) {
+ 		case SPDIFOO:	return 0;
+ 		case SPDIFIO:	return 0;
++		case SPDIFI1:	return 1;
+ 		case LINEO1:	return 4;
+ 		case LINEO2:	return 7;
+ 		case LINEO3:	return 5;
+diff --git a/sound/soc/cirrus/ep93xx-i2s.c b/sound/soc/cirrus/ep93xx-i2s.c
+index 522de4b8029398..a13fb1243379e9 100644
+--- a/sound/soc/cirrus/ep93xx-i2s.c
++++ b/sound/soc/cirrus/ep93xx-i2s.c
+@@ -105,16 +105,28 @@ static inline unsigned ep93xx_i2s_read_reg(struct ep93xx_i2s_info *info,
+ 	return __raw_readl(info->regs + reg);
+ }
+ 
+-static void ep93xx_i2s_enable(struct ep93xx_i2s_info *info, int stream)
++static int ep93xx_i2s_enable(struct ep93xx_i2s_info *info, int stream)
+ {
+ 	unsigned base_reg;
++	int err;
+ 
+ 	if ((ep93xx_i2s_read_reg(info, EP93XX_I2S_TX0EN) & 0x1) == 0 &&
+ 	    (ep93xx_i2s_read_reg(info, EP93XX_I2S_RX0EN) & 0x1) == 0) {
+ 		/* Enable clocks */
+-		clk_prepare_enable(info->mclk);
+-		clk_prepare_enable(info->sclk);
+-		clk_prepare_enable(info->lrclk);
++		err = clk_prepare_enable(info->mclk);
++		if (err)
++			return err;
++		err = clk_prepare_enable(info->sclk);
++		if (err) {
++			clk_disable_unprepare(info->mclk);
++			return err;
++		}
++		err = clk_prepare_enable(info->lrclk);
++		if (err) {
++			clk_disable_unprepare(info->sclk);
++			clk_disable_unprepare(info->mclk);
++			return err;
++		}
+ 
+ 		/* Enable i2s */
+ 		ep93xx_i2s_write_reg(info, EP93XX_I2S_GLCTRL, 1);
+@@ -133,6 +145,8 @@ static void ep93xx_i2s_enable(struct ep93xx_i2s_info *info, int stream)
+ 		ep93xx_i2s_write_reg(info, EP93XX_I2S_TXCTRL,
+ 				     EP93XX_I2S_TXCTRL_TXEMPTY_LVL |
+ 				     EP93XX_I2S_TXCTRL_TXUFIE);
++
++	return 0;
+ }
+ 
+ static void ep93xx_i2s_disable(struct ep93xx_i2s_info *info, int stream)
+@@ -214,9 +228,7 @@ static int ep93xx_i2s_startup(struct snd_pcm_substream *substream,
+ {
+ 	struct ep93xx_i2s_info *info = snd_soc_dai_get_drvdata(dai);
+ 
+-	ep93xx_i2s_enable(info, substream->stream);
+-
+-	return 0;
++	return ep93xx_i2s_enable(info, substream->stream);
+ }
+ 
+ static void ep93xx_i2s_shutdown(struct snd_pcm_substream *substream,
+@@ -392,14 +404,16 @@ static int ep93xx_i2s_suspend(struct snd_soc_component *component)
+ static int ep93xx_i2s_resume(struct snd_soc_component *component)
+ {
+ 	struct ep93xx_i2s_info *info = snd_soc_component_get_drvdata(component);
++	int err;
+ 
+ 	if (!snd_soc_component_active(component))
+ 		return 0;
+ 
+-	ep93xx_i2s_enable(info, SNDRV_PCM_STREAM_PLAYBACK);
+-	ep93xx_i2s_enable(info, SNDRV_PCM_STREAM_CAPTURE);
++	err = ep93xx_i2s_enable(info, SNDRV_PCM_STREAM_PLAYBACK);
++	if (err)
++		return err;
+ 
+-	return 0;
++	return ep93xx_i2s_enable(info, SNDRV_PCM_STREAM_CAPTURE);
+ }
+ #else
+ #define ep93xx_i2s_suspend	NULL
+diff --git a/sound/usb/caiaq/device.c b/sound/usb/caiaq/device.c
+index dfd820483849eb..3a71bab8a47749 100644
+--- a/sound/usb/caiaq/device.c
++++ b/sound/usb/caiaq/device.c
+@@ -488,7 +488,7 @@ static int init_card(struct snd_usb_caiaqdev *cdev)
+ 		memset(id, 0, sizeof(id));
+ 
+ 		for (c = card->shortname, len = 0;
+-			*c && len < sizeof(card->id); c++)
++			*c && len < sizeof(card->id) - 1; c++)
+ 			if (*c != ' ')
+ 				id[len++] = *c;
+ 
+diff --git a/tools/objtool/check.c b/tools/objtool/check.c
+index 6497c80fd6f771..2c7b09c8415f0b 100644
+--- a/tools/objtool/check.c
++++ b/tools/objtool/check.c
+@@ -2136,12 +2136,11 @@ static void mark_func_jump_tables(struct objtool_file *file,
+ 			last = insn;
+ 
+ 		/*
+-		 * Store back-pointers for unconditional forward jumps such
++		 * Store back-pointers for forward jumps such
+ 		 * that find_jump_table() can back-track using those and
+ 		 * avoid some potentially confusing code.
+ 		 */
+-		if (insn->type == INSN_JUMP_UNCONDITIONAL && insn->jump_dest &&
+-		    insn->offset > last->offset &&
++		if (insn->jump_dest &&
+ 		    insn->jump_dest->offset > insn->offset &&
+ 		    !insn->jump_dest->first_jump_src) {
+ 

--- a/patch/kernel/archive/odroidxu4-6.6/patch-6.6.134-135.patch
+++ b/patch/kernel/archive/odroidxu4-6.6/patch-6.6.134-135.patch
@@ -1,0 +1,2257 @@
+diff --git a/Makefile b/Makefile
+index 6b1d800ce74b06..53144259e49628 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 6
+ PATCHLEVEL = 6
+-SUBLEVEL = 134
++SUBLEVEL = 135
+ EXTRAVERSION =
+ NAME = Pinguïn Aangedreven
+ 
+diff --git a/arch/arm64/boot/dts/freescale/imx8mq-librem5-r3.dts b/arch/arm64/boot/dts/freescale/imx8mq-librem5-r3.dts
+index 077c5cd2586f75..4533a84fb0b95f 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mq-librem5-r3.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mq-librem5-r3.dts
+@@ -7,7 +7,7 @@
+ 
+ &a53_opp_table {
+ 	opp-1000000000 {
+-		opp-microvolt = <950000>;
++		opp-microvolt = <1000000>;
+ 	};
+ };
+ 
+diff --git a/arch/arm64/boot/dts/freescale/imx8mq-librem5.dtsi b/arch/arm64/boot/dts/freescale/imx8mq-librem5.dtsi
+index 138a4d36a7ef0e..84971ba7bcb807 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mq-librem5.dtsi
++++ b/arch/arm64/boot/dts/freescale/imx8mq-librem5.dtsi
+@@ -847,9 +847,9 @@
+ 				regulator-max-microvolt = <1300000>;
+ 				regulator-boot-on;
+ 				regulator-ramp-delay = <1250>;
+-				rohm,dvs-run-voltage = <880000>;
+-				rohm,dvs-idle-voltage = <820000>;
+-				rohm,dvs-suspend-voltage = <810000>;
++				rohm,dvs-run-voltage = <900000>;
++				rohm,dvs-idle-voltage = <850000>;
++				rohm,dvs-suspend-voltage = <850000>;
+ 				regulator-always-on;
+ 			};
+ 
+@@ -859,8 +859,8 @@
+ 				regulator-max-microvolt = <1300000>;
+ 				regulator-boot-on;
+ 				regulator-ramp-delay = <1250>;
+-				rohm,dvs-run-voltage = <950000>;
+-				rohm,dvs-idle-voltage = <850000>;
++				rohm,dvs-run-voltage = <1000000>;
++				rohm,dvs-idle-voltage = <900000>;
+ 				regulator-always-on;
+ 			};
+ 
+@@ -869,14 +869,14 @@
+ 				regulator-min-microvolt = <700000>;
+ 				regulator-max-microvolt = <1300000>;
+ 				regulator-boot-on;
+-				rohm,dvs-run-voltage = <850000>;
++				rohm,dvs-run-voltage = <900000>;
+ 			};
+ 
+ 			buck4_reg: BUCK4 {
+ 				regulator-name = "buck4";
+ 				regulator-min-microvolt = <700000>;
+ 				regulator-max-microvolt = <1300000>;
+-				rohm,dvs-run-voltage = <930000>;
++				rohm,dvs-run-voltage = <1000000>;
+ 			};
+ 
+ 			buck5_reg: BUCK5 {
+@@ -1410,13 +1410,3 @@
+ 	fsl,ext-reset-output;
+ 	status = "okay";
+ };
+-
+-&a53_opp_table {
+-	opp-1000000000 {
+-		opp-microvolt = <850000>;
+-	};
+-
+-	opp-1500000000 {
+-		opp-microvolt = <950000>;
+-	};
+-};
+diff --git a/arch/arm64/boot/dts/hisilicon/hi3798cv200-poplar.dts b/arch/arm64/boot/dts/hisilicon/hi3798cv200-poplar.dts
+index 7d370dac4c8571..579d55daa7d04e 100644
+--- a/arch/arm64/boot/dts/hisilicon/hi3798cv200-poplar.dts
++++ b/arch/arm64/boot/dts/hisilicon/hi3798cv200-poplar.dts
+@@ -179,7 +179,7 @@
+ };
+ 
+ &pcie {
+-	reset-gpios = <&gpio4 4 GPIO_ACTIVE_HIGH>;
++	reset-gpios = <&gpio4 4 GPIO_ACTIVE_LOW>;
+ 	vpcie-supply = <&reg_pcie>;
+ 	status = "okay";
+ };
+diff --git a/arch/arm64/boot/dts/hisilicon/hi3798cv200.dtsi b/arch/arm64/boot/dts/hisilicon/hi3798cv200.dtsi
+index d01023401d7e3f..4ff486d0050d5c 100644
+--- a/arch/arm64/boot/dts/hisilicon/hi3798cv200.dtsi
++++ b/arch/arm64/boot/dts/hisilicon/hi3798cv200.dtsi
+@@ -81,6 +81,7 @@
+ 		#address-cells = <1>;
+ 		#size-cells = <1>;
+ 		ranges = <0x0 0x0 0xf0000000 0x10000000>;
++		dma-ranges = <0x0 0x0 0x0 0x40000000>;
+ 
+ 		crg: clock-reset-controller@8a22000 {
+ 			compatible = "hisilicon,hi3798cv200-crg", "syscon", "simple-mfd";
+diff --git a/arch/mips/include/asm/cpu-features.h b/arch/mips/include/asm/cpu-features.h
+index 404390bb87eaf5..3f11e5218e6c65 100644
+--- a/arch/mips/include/asm/cpu-features.h
++++ b/arch/mips/include/asm/cpu-features.h
+@@ -484,7 +484,6 @@
+ # endif
+ # ifndef cpu_vmbits
+ # define cpu_vmbits cpu_data[0].vmbits
+-# define __NEED_VMBITS_PROBE
+ # endif
+ #endif
+ 
+diff --git a/arch/mips/include/asm/cpu-info.h b/arch/mips/include/asm/cpu-info.h
+index a600670d00e970..1aee44124f1187 100644
+--- a/arch/mips/include/asm/cpu-info.h
++++ b/arch/mips/include/asm/cpu-info.h
+@@ -80,9 +80,7 @@ struct cpuinfo_mips {
+ 	int			srsets; /* Shadow register sets */
+ 	int			package;/* physical package number */
+ 	unsigned int		globalnumber;
+-#ifdef CONFIG_64BIT
+ 	int			vmbits; /* Virtual memory size in bits */
+-#endif
+ 	void			*data;	/* Additional data */
+ 	unsigned int		watch_reg_count;   /* Number that exist */
+ 	unsigned int		watch_reg_use_cnt; /* Usable by ptrace */
+diff --git a/arch/mips/include/asm/mipsregs.h b/arch/mips/include/asm/mipsregs.h
+index e959a6b1a325ca..92ad301395045a 100644
+--- a/arch/mips/include/asm/mipsregs.h
++++ b/arch/mips/include/asm/mipsregs.h
+@@ -1714,6 +1714,8 @@ do {									\
+ 
+ #define read_c0_entryhi()	__read_ulong_c0_register($10, 0)
+ #define write_c0_entryhi(val)	__write_ulong_c0_register($10, 0, val)
++#define read_c0_entryhi_64()	__read_64bit_c0_register($10, 0)
++#define write_c0_entryhi_64(val) __write_64bit_c0_register($10, 0, val)
+ 
+ #define read_c0_guestctl1()	__read_32bit_c0_register($10, 4)
+ #define write_c0_guestctl1(val)	__write_32bit_c0_register($10, 4, val)
+diff --git a/arch/mips/kernel/cpu-probe.c b/arch/mips/kernel/cpu-probe.c
+index c7fee72ea60679..d982bc3288eb7a 100644
+--- a/arch/mips/kernel/cpu-probe.c
++++ b/arch/mips/kernel/cpu-probe.c
+@@ -208,11 +208,14 @@ static inline void set_elf_base_platform(const char *plat)
+ 
+ static inline void cpu_probe_vmbits(struct cpuinfo_mips *c)
+ {
+-#ifdef __NEED_VMBITS_PROBE
+-	write_c0_entryhi(0x3fffffffffffe000ULL);
+-	back_to_back_c0_hazard();
+-	c->vmbits = fls64(read_c0_entryhi() & 0x3fffffffffffe000ULL);
+-#endif
++	int vmbits = 31;
++
++	if (cpu_has_64bits) {
++		write_c0_entryhi_64(0x3fffffffffffe000ULL);
++		back_to_back_c0_hazard();
++		vmbits = fls64(read_c0_entryhi_64() & 0x3fffffffffffe000ULL);
++	}
++	c->vmbits = vmbits;
+ }
+ 
+ static void set_isa(struct cpuinfo_mips *c, unsigned int isa)
+diff --git a/arch/mips/kernel/cpu-r3k-probe.c b/arch/mips/kernel/cpu-r3k-probe.c
+index be93469c0e0eca..2adf95225aa7ee 100644
+--- a/arch/mips/kernel/cpu-r3k-probe.c
++++ b/arch/mips/kernel/cpu-r3k-probe.c
+@@ -138,6 +138,8 @@ void cpu_probe(void)
+ 	else
+ 		cpu_set_nofpu_opts(c);
+ 
++	c->vmbits = 31;
++
+ 	reserve_exception_space(0, 0x400);
+ }
+ 
+diff --git a/arch/mips/mm/tlb-r4k.c b/arch/mips/mm/tlb-r4k.c
+index 4d49ecf2761031..0cb68a5316010e 100644
+--- a/arch/mips/mm/tlb-r4k.c
++++ b/arch/mips/mm/tlb-r4k.c
+@@ -13,6 +13,7 @@
+ #include <linux/sched.h>
+ #include <linux/smp.h>
+ #include <linux/memblock.h>
++#include <linux/minmax.h>
+ #include <linux/mm.h>
+ #include <linux/hugetlb.h>
+ #include <linux/export.h>
+@@ -24,6 +25,7 @@
+ #include <asm/hazards.h>
+ #include <asm/mmu_context.h>
+ #include <asm/tlb.h>
++#include <asm/tlbdebug.h>
+ #include <asm/tlbmisc.h>
+ 
+ extern void build_tlb_refill_handler(void);
+@@ -509,87 +511,259 @@ static int __init set_ntlb(char *str)
+ __setup("ntlb=", set_ntlb);
+ 
+ 
+-/* Comparison function for EntryHi VPN fields.  */
+-static int r4k_vpn_cmp(const void *a, const void *b)
++/* The start bit position of VPN2 and Mask in EntryHi/PageMask registers.  */
++#define VPN2_SHIFT 13
++
++/* Read full EntryHi even with CONFIG_32BIT.  */
++static inline unsigned long long read_c0_entryhi_native(void)
++{
++	return cpu_has_64bits ? read_c0_entryhi_64() : read_c0_entryhi();
++}
++
++/* Write full EntryHi even with CONFIG_32BIT.  */
++static inline void write_c0_entryhi_native(unsigned long long v)
+ {
+-	long v = *(unsigned long *)a - *(unsigned long *)b;
+-	int s = sizeof(long) > sizeof(int) ? sizeof(long) * 8 - 1: 0;
+-	return s ? (v != 0) | v >> s : v;
++	if (cpu_has_64bits)
++		write_c0_entryhi_64(v);
++	else
++		write_c0_entryhi(v);
+ }
+ 
++/* TLB entry state for uniquification.  */
++struct tlbent {
++	unsigned long long wired:1;
++	unsigned long long global:1;
++	unsigned long long asid:10;
++	unsigned long long vpn:51;
++	unsigned long long pagesz:5;
++	unsigned long long index:14;
++};
++
+ /*
+- * Initialise all TLB entries with unique values that do not clash with
+- * what we have been handed over and what we'll be using ourselves.
++ * Comparison function for TLB entry sorting.  Place wired entries first,
++ * then global entries, then order by the increasing VPN/ASID and the
++ * decreasing page size.  This lets us avoid clashes with wired entries
++ * easily and get entries for larger pages out of the way first.
++ *
++ * We could group bits so as to reduce the number of comparisons, but this
++ * is seldom executed and not performance-critical, so prefer legibility.
+  */
+-static void __ref r4k_tlb_uniquify(void)
++static int r4k_entry_cmp(const void *a, const void *b)
+ {
+-	int tlbsize = current_cpu_data.tlbsize;
+-	bool use_slab = slab_is_available();
+-	int start = num_wired_entries();
+-	phys_addr_t tlb_vpn_size;
+-	unsigned long *tlb_vpns;
+-	unsigned long vpn_mask;
+-	int cnt, ent, idx, i;
+-
+-	vpn_mask = GENMASK(cpu_vmbits - 1, 13);
+-	vpn_mask |= IS_ENABLED(CONFIG_64BIT) ? 3ULL << 62 : 1 << 31;
++	struct tlbent ea = *(struct tlbent *)a, eb = *(struct tlbent *)b;
++
++	if (ea.wired > eb.wired)
++		return -1;
++	else if (ea.wired < eb.wired)
++		return 1;
++	else if (ea.global > eb.global)
++		return -1;
++	else if (ea.global < eb.global)
++		return 1;
++	else if (ea.vpn < eb.vpn)
++		return -1;
++	else if (ea.vpn > eb.vpn)
++		return 1;
++	else if (ea.asid < eb.asid)
++		return -1;
++	else if (ea.asid > eb.asid)
++		return 1;
++	else if (ea.pagesz > eb.pagesz)
++		return -1;
++	else if (ea.pagesz < eb.pagesz)
++		return 1;
++	else
++		return 0;
++}
+ 
+-	tlb_vpn_size = tlbsize * sizeof(*tlb_vpns);
+-	tlb_vpns = (use_slab ?
+-		    kmalloc(tlb_vpn_size, GFP_ATOMIC) :
+-		    memblock_alloc_raw(tlb_vpn_size, sizeof(*tlb_vpns)));
+-	if (WARN_ON(!tlb_vpns))
+-		return; /* Pray local_flush_tlb_all() is good enough. */
++/*
++ * Fetch all the TLB entries.  Mask individual VPN values retrieved with
++ * the corresponding page mask and ignoring any 1KiB extension as we'll
++ * be using 4KiB pages for uniquification.
++ */
++static void __ref r4k_tlb_uniquify_read(struct tlbent *tlb_vpns, int tlbsize)
++{
++	int start = num_wired_entries();
++	unsigned long long vpn_mask;
++	bool global;
++	int i;
+ 
+-	htw_stop();
++	vpn_mask = GENMASK(current_cpu_data.vmbits - 1, VPN2_SHIFT);
++	vpn_mask |= cpu_has_64bits ? 3ULL << 62 : 1 << 31;
+ 
+-	for (i = start, cnt = 0; i < tlbsize; i++, cnt++) {
+-		unsigned long vpn;
++	for (i = 0; i < tlbsize; i++) {
++		unsigned long long entryhi, vpn, mask, asid;
++		unsigned int pagesz;
+ 
+ 		write_c0_index(i);
+ 		mtc0_tlbr_hazard();
+ 		tlb_read();
+ 		tlb_read_hazard();
+-		vpn = read_c0_entryhi();
+-		vpn &= vpn_mask & PAGE_MASK;
+-		tlb_vpns[cnt] = vpn;
+ 
+-		/* Prevent any large pages from overlapping regular ones.  */
+-		write_c0_pagemask(read_c0_pagemask() & PM_DEFAULT_MASK);
+-		mtc0_tlbw_hazard();
+-		tlb_write_indexed();
+-		tlbw_use_hazard();
++		global = !!(read_c0_entrylo0() & ENTRYLO_G);
++		entryhi = read_c0_entryhi_native();
++		mask = read_c0_pagemask();
++
++		asid = entryhi & cpu_asid_mask(&current_cpu_data);
++		vpn = (entryhi & vpn_mask & ~mask) >> VPN2_SHIFT;
++		pagesz = ilog2((mask >> VPN2_SHIFT) + 1);
++
++		tlb_vpns[i].global = global;
++		tlb_vpns[i].asid = global ? 0 : asid;
++		tlb_vpns[i].vpn = vpn;
++		tlb_vpns[i].pagesz = pagesz;
++		tlb_vpns[i].wired = i < start;
++		tlb_vpns[i].index = i;
+ 	}
++}
+ 
+-	sort(tlb_vpns, cnt, sizeof(tlb_vpns[0]), r4k_vpn_cmp, NULL);
++/*
++ * Write unique values to all but the wired TLB entries each, using
++ * the 4KiB page size.  This size might not be supported with R6, but
++ * EHINV is mandatory for R6, so we won't ever be called in that case.
++ *
++ * A sorted table is supplied with any wired entries at the beginning,
++ * followed by any global entries, and then finally regular entries.
++ * We start at the VPN and ASID values of zero and only assign user
++ * addresses, therefore guaranteeing no clash with addresses produced
++ * by UNIQUE_ENTRYHI.  We avoid any VPN values used by wired or global
++ * entries, by increasing the VPN value beyond the span of such entry.
++ *
++ * When a VPN/ASID clash is found with a regular entry we increment the
++ * ASID instead until no VPN/ASID clash has been found or the ASID space
++ * has been exhausted, in which case we increase the VPN value beyond
++ * the span of the largest clashing entry.
++ *
++ * We do not need to be concerned about FTLB or MMID configurations as
++ * those are required to implement the EHINV feature.
++ */
++static void __ref r4k_tlb_uniquify_write(struct tlbent *tlb_vpns, int tlbsize)
++{
++	unsigned long long asid, vpn, vpn_size, pagesz;
++	int widx, gidx, idx, sidx, lidx, i;
+ 
+-	write_c0_pagemask(PM_DEFAULT_MASK);
++	vpn_size = 1ULL << (current_cpu_data.vmbits - VPN2_SHIFT);
++	pagesz = ilog2((PM_4K >> VPN2_SHIFT) + 1);
++
++	write_c0_pagemask(PM_4K);
+ 	write_c0_entrylo0(0);
+ 	write_c0_entrylo1(0);
+ 
+-	idx = 0;
+-	ent = tlbsize;
+-	for (i = start; i < tlbsize; i++)
+-		while (1) {
+-			unsigned long entryhi, vpn;
++	asid = 0;
++	vpn = 0;
++	widx = 0;
++	gidx = 0;
++	for (sidx = 0; sidx < tlbsize && tlb_vpns[sidx].wired; sidx++)
++		;
++	for (lidx = sidx; lidx < tlbsize && tlb_vpns[lidx].global; lidx++)
++		;
++	idx = gidx = sidx + 1;
++	for (i = sidx; i < tlbsize; i++) {
++		unsigned long long entryhi, vpn_pagesz = 0;
+ 
+-			entryhi = UNIQUE_ENTRYHI(ent);
+-			vpn = entryhi & vpn_mask & PAGE_MASK;
++		while (1) {
++			if (WARN_ON(vpn >= vpn_size)) {
++				dump_tlb_all();
++				/* Pray local_flush_tlb_all() will cope.  */
++				return;
++			}
+ 
+-			if (idx >= cnt || vpn < tlb_vpns[idx]) {
+-				write_c0_entryhi(entryhi);
+-				write_c0_index(i);
+-				mtc0_tlbw_hazard();
+-				tlb_write_indexed();
+-				ent++;
+-				break;
+-			} else if (vpn == tlb_vpns[idx]) {
+-				ent++;
+-			} else {
++			/* VPN must be below the next wired entry.  */
++			if (widx < sidx && vpn >= tlb_vpns[widx].vpn) {
++				vpn = max(vpn,
++					  (tlb_vpns[widx].vpn +
++					   (1ULL << tlb_vpns[widx].pagesz)));
++				asid = 0;
++				widx++;
++				continue;
++			}
++			/* VPN must be below the next global entry.  */
++			if (gidx < lidx && vpn >= tlb_vpns[gidx].vpn) {
++				vpn = max(vpn,
++					  (tlb_vpns[gidx].vpn +
++					   (1ULL << tlb_vpns[gidx].pagesz)));
++				asid = 0;
++				gidx++;
++				continue;
++			}
++			/* Try to find a free ASID so as to conserve VPNs.  */
++			if (idx < tlbsize && vpn == tlb_vpns[idx].vpn &&
++			    asid == tlb_vpns[idx].asid) {
++				unsigned long long idx_pagesz;
++
++				idx_pagesz = tlb_vpns[idx].pagesz;
++				vpn_pagesz = max(vpn_pagesz, idx_pagesz);
++				do
++					idx++;
++				while (idx < tlbsize &&
++				       vpn == tlb_vpns[idx].vpn &&
++				       asid == tlb_vpns[idx].asid);
++				asid++;
++				if (asid > cpu_asid_mask(&current_cpu_data)) {
++					vpn += vpn_pagesz;
++					asid = 0;
++					vpn_pagesz = 0;
++				}
++				continue;
++			}
++			/* VPN mustn't be above the next regular entry.  */
++			if (idx < tlbsize && vpn > tlb_vpns[idx].vpn) {
++				vpn = max(vpn,
++					  (tlb_vpns[idx].vpn +
++					   (1ULL << tlb_vpns[idx].pagesz)));
++				asid = 0;
+ 				idx++;
++				continue;
+ 			}
++			break;
+ 		}
+ 
++		entryhi = (vpn << VPN2_SHIFT) | asid;
++		write_c0_entryhi_native(entryhi);
++		write_c0_index(tlb_vpns[i].index);
++		mtc0_tlbw_hazard();
++		tlb_write_indexed();
++
++		tlb_vpns[i].asid = asid;
++		tlb_vpns[i].vpn = vpn;
++		tlb_vpns[i].pagesz = pagesz;
++
++		asid++;
++		if (asid > cpu_asid_mask(&current_cpu_data)) {
++			vpn += 1ULL << pagesz;
++			asid = 0;
++		}
++	}
++}
++
++/*
++ * Initialise all TLB entries with unique values that do not clash with
++ * what we have been handed over and what we'll be using ourselves.
++ */
++static void __ref r4k_tlb_uniquify(void)
++{
++	int tlbsize = current_cpu_data.tlbsize;
++	bool use_slab = slab_is_available();
++	phys_addr_t tlb_vpn_size;
++	struct tlbent *tlb_vpns;
++
++	tlb_vpn_size = tlbsize * sizeof(*tlb_vpns);
++	tlb_vpns = (use_slab ?
++		    kmalloc(tlb_vpn_size, GFP_ATOMIC) :
++		    memblock_alloc_raw(tlb_vpn_size, sizeof(*tlb_vpns)));
++	if (WARN_ON(!tlb_vpns))
++		return; /* Pray local_flush_tlb_all() is good enough. */
++
++	htw_stop();
++
++	r4k_tlb_uniquify_read(tlb_vpns, tlbsize);
++
++	sort(tlb_vpns, tlbsize, sizeof(*tlb_vpns), r4k_entry_cmp, NULL);
++
++	r4k_tlb_uniquify_write(tlb_vpns, tlbsize);
++
++	write_c0_pagemask(PM_DEFAULT_MASK);
++
+ 	tlbw_use_hazard();
+ 	htw_start();
+ 	flush_micro_tlb();
+@@ -638,7 +812,8 @@ static void r4k_tlb_configure(void)
+ 	temp_tlb_entry = current_cpu_data.tlbsize - 1;
+ 
+ 	/* From this point on the ARC firmware is dead.	 */
+-	r4k_tlb_uniquify();
++	if (!cpu_has_tlbinv)
++		r4k_tlb_uniquify();
+ 	local_flush_tlb_all();
+ 
+ 	/* Did I tell you that ARC SUCKS?  */
+diff --git a/arch/x86/include/asm/msr-index.h b/arch/x86/include/asm/msr-index.h
+index e58204e7714e42..deb5fe00177630 100644
+--- a/arch/x86/include/asm/msr-index.h
++++ b/arch/x86/include/asm/msr-index.h
+@@ -582,6 +582,9 @@
+ #define MSR_AMD64_DC_CFG		0xc0011022
+ #define MSR_AMD64_TW_CFG		0xc0011023
+ 
++#define MSR_AMD64_FP_CFG		0xc0011028
++#define MSR_AMD64_FP_CFG_ZEN1_DENORM_FIX_BIT	9
++
+ #define MSR_AMD64_DE_CFG		0xc0011029
+ #define MSR_AMD64_DE_CFG_LFENCE_SERIALIZE_BIT	 1
+ #define MSR_AMD64_DE_CFG_LFENCE_SERIALIZE	BIT_ULL(MSR_AMD64_DE_CFG_LFENCE_SERIALIZE_BIT)
+diff --git a/arch/x86/kernel/cpu/amd.c b/arch/x86/kernel/cpu/amd.c
+index 864d62e9461418..211141d37d1555 100644
+--- a/arch/x86/kernel/cpu/amd.c
++++ b/arch/x86/kernel/cpu/amd.c
+@@ -1112,6 +1112,9 @@ static void init_amd_zen1(struct cpuinfo_x86 *c)
+ 		msr_clear_bit(MSR_K7_HWCR, MSR_K7_HWCR_IRPERF_EN_BIT);
+ 		clear_cpu_cap(c, X86_FEATURE_IRPERF);
+ 	}
++
++	pr_notice_once("AMD Zen1 FPDSS bug detected, enabling mitigation.\n");
++	msr_set_bit(MSR_AMD64_FP_CFG, MSR_AMD64_FP_CFG_ZEN1_DENORM_FIX_BIT);
+ }
+ 
+ static bool cpu_has_zenbleed_microcode(void)
+diff --git a/crypto/asymmetric_keys/x509_cert_parser.c b/crypto/asymmetric_keys/x509_cert_parser.c
+index 5201f47e31d8b0..c0ad30de29a572 100644
+--- a/crypto/asymmetric_keys/x509_cert_parser.c
++++ b/crypto/asymmetric_keys/x509_cert_parser.c
+@@ -592,10 +592,10 @@ int x509_process_extension(void *context, size_t hdrlen,
+ 		 *   0x04 is where keyCertSign lands in this bit string
+ 		 *   0x80 is where digitalSignature lands in this bit string
+ 		 */
+-		if (v[0] != ASN1_BTS)
+-			return -EBADMSG;
+ 		if (vlen < 4)
+ 			return -EBADMSG;
++		if (v[0] != ASN1_BTS)
++			return -EBADMSG;
+ 		if (v[2] >= 8)
+ 			return -EBADMSG;
+ 		if (v[3] & 0x80)
+@@ -628,10 +628,10 @@ int x509_process_extension(void *context, size_t hdrlen,
+ 		 *	(Expect 0xFF if the CA is TRUE)
+ 		 * vlen should match the entire extension size
+ 		 */
+-		if (v[0] != (ASN1_CONS_BIT | ASN1_SEQ))
+-			return -EBADMSG;
+ 		if (vlen < 2)
+ 			return -EBADMSG;
++		if (v[0] != (ASN1_CONS_BIT | ASN1_SEQ))
++			return -EBADMSG;
+ 		if (v[1] != vlen - 2)
+ 			return -EBADMSG;
+ 		/* Empty SEQUENCE means CA:FALSE (default value omitted per DER) */
+diff --git a/drivers/edac/edac_mc.c b/drivers/edac/edac_mc.c
+index 6faeb2ab39601b..952ebd94e0ece1 100644
+--- a/drivers/edac/edac_mc.c
++++ b/drivers/edac/edac_mc.c
+@@ -369,13 +369,13 @@ struct mem_ctl_info *edac_mc_alloc(unsigned int mc_num,
+ 	if (!mci->layers)
+ 		goto error;
+ 
++	mci->dev.release = mci_release;
++	device_initialize(&mci->dev);
++
+ 	mci->pvt_info = kzalloc(sz_pvt, GFP_KERNEL);
+ 	if (!mci->pvt_info)
+ 		goto error;
+ 
+-	mci->dev.release = mci_release;
+-	device_initialize(&mci->dev);
+-
+ 	/* setup index and various internal pointers */
+ 	mci->mc_idx = mc_num;
+ 	mci->tot_dimms = tot_dimms;
+diff --git a/drivers/gpu/drm/drm_file.c b/drivers/gpu/drm/drm_file.c
+index b5a5cede4d3d8b..b943221b238f87 100644
+--- a/drivers/gpu/drm/drm_file.c
++++ b/drivers/gpu/drm/drm_file.c
+@@ -243,7 +243,6 @@ static void drm_events_release(struct drm_file *file_priv)
+ void drm_file_free(struct drm_file *file)
+ {
+ 	struct drm_device *dev;
+-	int idx;
+ 
+ 	if (!file)
+ 		return;
+@@ -269,11 +268,9 @@ void drm_file_free(struct drm_file *file)
+ 
+ 	drm_events_release(file);
+ 
+-	if (drm_core_check_feature(dev, DRIVER_MODESET) &&
+-	    drm_dev_enter(dev, &idx)) {
++	if (drm_core_check_feature(dev, DRIVER_MODESET)) {
+ 		drm_fb_release(file);
+ 		drm_property_destroy_user_blobs(dev, file);
+-		drm_dev_exit(idx);
+ 	}
+ 
+ 	if (drm_core_check_feature(dev, DRIVER_SYNCOBJ))
+diff --git a/drivers/gpu/drm/drm_mode_config.c b/drivers/gpu/drm/drm_mode_config.c
+index f09137046c2bdf..87eb591fe9b5b8 100644
+--- a/drivers/gpu/drm/drm_mode_config.c
++++ b/drivers/gpu/drm/drm_mode_config.c
+@@ -546,13 +546,10 @@ void drm_mode_config_cleanup(struct drm_device *dev)
+ 	 */
+ 	WARN_ON(!list_empty(&dev->mode_config.fb_list));
+ 	list_for_each_entry_safe(fb, fbt, &dev->mode_config.fb_list, head) {
+-		if (list_empty(&fb->filp_head) || drm_framebuffer_read_refcount(fb) > 1) {
+-			struct drm_printer p = drm_debug_printer("[leaked fb]");
++		struct drm_printer p = drm_debug_printer("[leaked fb]");
+ 
+-			drm_printf(&p, "framebuffer[%u]:\n", fb->base.id);
+-			drm_framebuffer_print_info(&p, 1, fb);
+-		}
+-		list_del_init(&fb->filp_head);
++		drm_printf(&p, "framebuffer[%u]:\n", fb->base.id);
++		drm_framebuffer_print_info(&p, 1, fb);
+ 		drm_framebuffer_free(&fb->base.refcount);
+ 	}
+ 
+diff --git a/drivers/gpu/drm/i915/gt/intel_engine_heartbeat.c b/drivers/gpu/drm/i915/gt/intel_engine_heartbeat.c
+index 9a527e1f5be655..a3683ac1bb9b1e 100644
+--- a/drivers/gpu/drm/i915/gt/intel_engine_heartbeat.c
++++ b/drivers/gpu/drm/i915/gt/intel_engine_heartbeat.c
+@@ -144,10 +144,12 @@ static void heartbeat(struct work_struct *wrk)
+ 	/* Just in case everything has gone horribly wrong, give it a kick */
+ 	intel_engine_flush_submission(engine);
+ 
+-	rq = engine->heartbeat.systole;
+-	if (rq && i915_request_completed(rq)) {
+-		i915_request_put(rq);
+-		engine->heartbeat.systole = NULL;
++	rq = xchg(&engine->heartbeat.systole, NULL);
++	if (rq) {
++		if (i915_request_completed(rq))
++			i915_request_put(rq);
++		else
++			engine->heartbeat.systole = rq;
+ 	}
+ 
+ 	if (!intel_engine_pm_get_if_awake(engine))
+@@ -228,8 +230,11 @@ static void heartbeat(struct work_struct *wrk)
+ unlock:
+ 	mutex_unlock(&ce->timeline->mutex);
+ out:
+-	if (!engine->i915->params.enable_hangcheck || !next_heartbeat(engine))
+-		i915_request_put(fetch_and_zero(&engine->heartbeat.systole));
++	if (!engine->i915->params.enable_hangcheck || !next_heartbeat(engine)) {
++		rq = xchg(&engine->heartbeat.systole, NULL);
++		if (rq)
++			i915_request_put(rq);
++	}
+ 	intel_engine_pm_put(engine);
+ }
+ 
+@@ -243,8 +248,13 @@ void intel_engine_unpark_heartbeat(struct intel_engine_cs *engine)
+ 
+ void intel_engine_park_heartbeat(struct intel_engine_cs *engine)
+ {
+-	if (cancel_delayed_work(&engine->heartbeat.work))
+-		i915_request_put(fetch_and_zero(&engine->heartbeat.systole));
++	if (cancel_delayed_work(&engine->heartbeat.work)) {
++		struct i915_request *rq;
++
++		rq = xchg(&engine->heartbeat.systole, NULL);
++		if (rq)
++			i915_request_put(rq);
++	}
+ }
+ 
+ void intel_gt_unpark_heartbeats(struct intel_gt *gt)
+diff --git a/drivers/input/misc/uinput.c b/drivers/input/misc/uinput.c
+index edb62a284548b9..a2f1edeffa98f8 100644
+--- a/drivers/input/misc/uinput.c
++++ b/drivers/input/misc/uinput.c
+@@ -25,8 +25,10 @@
+ #include <linux/module.h>
+ #include <linux/init.h>
+ #include <linux/fs.h>
++#include <linux/lockdep.h>
+ #include <linux/miscdevice.h>
+ #include <linux/overflow.h>
++#include <linux/spinlock.h>
+ #include <linux/input/mt.h>
+ #include "../input-compat.h"
+ 
+@@ -57,6 +59,7 @@ struct uinput_device {
+ 	struct input_dev	*dev;
+ 	struct mutex		mutex;
+ 	enum uinput_state	state;
++	spinlock_t		state_lock;
+ 	wait_queue_head_t	waitq;
+ 	unsigned char		ready;
+ 	unsigned char		head;
+@@ -75,6 +78,8 @@ static int uinput_dev_event(struct input_dev *dev,
+ 	struct uinput_device	*udev = input_get_drvdata(dev);
+ 	struct timespec64	ts;
+ 
++	lockdep_assert_held(&dev->event_lock);
++
+ 	ktime_get_ts64(&ts);
+ 
+ 	udev->buff[udev->head] = (struct input_event) {
+@@ -146,27 +151,26 @@ static void uinput_request_release_slot(struct uinput_device *udev,
+ static int uinput_request_send(struct uinput_device *udev,
+ 			       struct uinput_request *request)
+ {
+-	int retval;
++	unsigned long flags;
++	int retval = 0;
+ 
+-	retval = mutex_lock_interruptible(&udev->mutex);
+-	if (retval)
+-		return retval;
++	spin_lock(&udev->state_lock);
+ 
+ 	if (udev->state != UIST_CREATED) {
+ 		retval = -ENODEV;
+ 		goto out;
+ 	}
+ 
+-	init_completion(&request->done);
+-
+ 	/*
+ 	 * Tell our userspace application about this new request
+ 	 * by queueing an input event.
+ 	 */
++	spin_lock_irqsave(&udev->dev->event_lock, flags);
+ 	uinput_dev_event(udev->dev, EV_UINPUT, request->code, request->id);
++	spin_unlock_irqrestore(&udev->dev->event_lock, flags);
+ 
+  out:
+-	mutex_unlock(&udev->mutex);
++	spin_unlock(&udev->state_lock);
+ 	return retval;
+ }
+ 
+@@ -175,6 +179,13 @@ static int uinput_request_submit(struct uinput_device *udev,
+ {
+ 	int retval;
+ 
++	/*
++	 * Initialize completion before allocating the request slot.
++	 * Once the slot is allocated, uinput_flush_requests() may
++	 * complete it at any time, so it must be initialized first.
++	 */
++	init_completion(&request->done);
++
+ 	retval = uinput_request_reserve_slot(udev, request);
+ 	if (retval)
+ 		return retval;
+@@ -289,7 +300,14 @@ static void uinput_destroy_device(struct uinput_device *udev)
+ 	struct input_dev *dev = udev->dev;
+ 	enum uinput_state old_state = udev->state;
+ 
++	/*
++	 * Update state under state_lock so that concurrent
++	 * uinput_request_send() sees the state change before we
++	 * flush pending requests and tear down the device.
++	 */
++	spin_lock(&udev->state_lock);
+ 	udev->state = UIST_NEW_DEVICE;
++	spin_unlock(&udev->state_lock);
+ 
+ 	if (dev) {
+ 		name = dev->name;
+@@ -366,7 +384,9 @@ static int uinput_create_device(struct uinput_device *udev)
+ 	if (error)
+ 		goto fail2;
+ 
++	spin_lock(&udev->state_lock);
+ 	udev->state = UIST_CREATED;
++	spin_unlock(&udev->state_lock);
+ 
+ 	return 0;
+ 
+@@ -384,6 +404,7 @@ static int uinput_open(struct inode *inode, struct file *file)
+ 		return -ENOMEM;
+ 
+ 	mutex_init(&newdev->mutex);
++	spin_lock_init(&newdev->state_lock);
+ 	spin_lock_init(&newdev->requests_lock);
+ 	init_waitqueue_head(&newdev->requests_waitq);
+ 	init_waitqueue_head(&newdev->waitq);
+diff --git a/drivers/mmc/host/vub300.c b/drivers/mmc/host/vub300.c
+index cef0e716ad16fd..4e0a645b45b928 100644
+--- a/drivers/mmc/host/vub300.c
++++ b/drivers/mmc/host/vub300.c
+@@ -2369,8 +2369,8 @@ static void vub300_disconnect(struct usb_interface *interface)
+ 			usb_set_intfdata(interface, NULL);
+ 			/* prevent more I/O from starting */
+ 			vub300->interface = NULL;
+-			kref_put(&vub300->kref, vub300_delete);
+ 			mmc_remove_host(mmc);
++			kref_put(&vub300->kref, vub300_delete);
+ 			pr_info("USB vub300 remote SDIO host controller[%d]"
+ 				" now disconnected", ifnum);
+ 			return;
+diff --git a/drivers/net/ethernet/altera/altera_tse_main.c b/drivers/net/ethernet/altera/altera_tse_main.c
+index 2e15800e53102f..33ce4a6850df6c 100644
+--- a/drivers/net/ethernet/altera/altera_tse_main.c
++++ b/drivers/net/ethernet/altera/altera_tse_main.c
+@@ -574,6 +574,7 @@ static netdev_tx_t tse_start_xmit(struct sk_buff *skb, struct net_device *dev)
+ 				  DMA_TO_DEVICE);
+ 	if (dma_mapping_error(priv->device, dma_addr)) {
+ 		netdev_err(priv->dev, "%s: DMA mapping error\n", __func__);
++		dev_kfree_skb_any(skb);
+ 		ret = NETDEV_TX_OK;
+ 		goto out;
+ 	}
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/main.c b/drivers/net/ethernet/mellanox/mlx5/core/main.c
+index df6eeb0f57bcd5..80f3493fc544c4 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/main.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/main.c
+@@ -2208,6 +2208,7 @@ static const struct pci_device_id mlx5_core_pci_table[] = {
+ 	{ PCI_VDEVICE(MELLANOX, 0x1023) },			/* ConnectX-8 */
+ 	{ PCI_VDEVICE(MELLANOX, 0x1025) },			/* ConnectX-9 */
+ 	{ PCI_VDEVICE(MELLANOX, 0x1027) },			/* ConnectX-10 */
++	{ PCI_VDEVICE(MELLANOX, 0x2101) },			/* ConnectX-10 NVLink-C2C */
+ 	{ PCI_VDEVICE(MELLANOX, 0xa2d2) },			/* BlueField integrated ConnectX-5 network controller */
+ 	{ PCI_VDEVICE(MELLANOX, 0xa2d3), MLX5_PCI_DEV_IS_VF},	/* BlueField integrated ConnectX-5 network controller VF */
+ 	{ PCI_VDEVICE(MELLANOX, 0xa2d6) },			/* BlueField-2 integrated ConnectX-6 Dx network controller */
+diff --git a/drivers/net/ethernet/microchip/lan966x/lan966x_fdma.c b/drivers/net/ethernet/microchip/lan966x/lan966x_fdma.c
+index 3960534ac2ad81..e717d68bf45aac 100644
+--- a/drivers/net/ethernet/microchip/lan966x/lan966x_fdma.c
++++ b/drivers/net/ethernet/microchip/lan966x/lan966x_fdma.c
+@@ -85,6 +85,8 @@ static int lan966x_fdma_rx_alloc_page_pool(struct lan966x_rx *rx)
+ 		pp_params.dma_dir = DMA_BIDIRECTIONAL;
+ 
+ 	rx->page_pool = page_pool_create(&pp_params);
++	if (unlikely(IS_ERR(rx->page_pool)))
++		return PTR_ERR(rx->page_pool);
+ 
+ 	for (int i = 0; i < lan966x->num_phys_ports; ++i) {
+ 		struct lan966x_port *port;
+diff --git a/drivers/net/ethernet/qualcomm/qca_uart.c b/drivers/net/ethernet/qualcomm/qca_uart.c
+index 9adec91f35e947..4526fd9cd81cb1 100644
+--- a/drivers/net/ethernet/qualcomm/qca_uart.c
++++ b/drivers/net/ethernet/qualcomm/qca_uart.c
+@@ -114,7 +114,7 @@ qca_tty_receive(struct serdev_device *serdev, const unsigned char *data,
+ 			if (!qca->rx_skb) {
+ 				netdev_dbg(netdev, "recv: out of RX resources\n");
+ 				n_stats->rx_errors++;
+-				return i;
++				return i + 1;
+ 			}
+ 		}
+ 	}
+diff --git a/drivers/net/ethernet/stmicro/stmmac/chain_mode.c b/drivers/net/ethernet/stmicro/stmmac/chain_mode.c
+index fb55efd52240d0..1c01e3c640ceeb 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/chain_mode.c
++++ b/drivers/net/ethernet/stmicro/stmmac/chain_mode.c
+@@ -20,7 +20,7 @@ static int jumbo_frm(struct stmmac_tx_queue *tx_q, struct sk_buff *skb,
+ 	unsigned int nopaged_len = skb_headlen(skb);
+ 	struct stmmac_priv *priv = tx_q->priv_data;
+ 	unsigned int entry = tx_q->cur_tx;
+-	unsigned int bmax, des2;
++	unsigned int bmax, buf_len, des2;
+ 	unsigned int i = 1, len;
+ 	struct dma_desc *desc;
+ 
+@@ -31,17 +31,18 @@ static int jumbo_frm(struct stmmac_tx_queue *tx_q, struct sk_buff *skb,
+ 	else
+ 		bmax = BUF_SIZE_2KiB;
+ 
+-	len = nopaged_len - bmax;
++	buf_len = min_t(unsigned int, nopaged_len, bmax);
++	len = nopaged_len - buf_len;
+ 
+ 	des2 = dma_map_single(priv->device, skb->data,
+-			      bmax, DMA_TO_DEVICE);
++			      buf_len, DMA_TO_DEVICE);
+ 	desc->des2 = cpu_to_le32(des2);
+ 	if (dma_mapping_error(priv->device, des2))
+ 		return -1;
+ 	tx_q->tx_skbuff_dma[entry].buf = des2;
+-	tx_q->tx_skbuff_dma[entry].len = bmax;
++	tx_q->tx_skbuff_dma[entry].len = buf_len;
+ 	/* do not close the descriptor and do not set own bit */
+-	stmmac_prepare_tx_desc(priv, desc, 1, bmax, csum, STMMAC_CHAIN_MODE,
++	stmmac_prepare_tx_desc(priv, desc, 1, buf_len, csum, STMMAC_CHAIN_MODE,
+ 			0, false, skb->len);
+ 
+ 	while (len != 0) {
+diff --git a/drivers/net/virtio_net.c b/drivers/net/virtio_net.c
+index b33fc94ebd7720..33f61922c13994 100644
+--- a/drivers/net/virtio_net.c
++++ b/drivers/net/virtio_net.c
+@@ -4465,6 +4465,7 @@ static int virtnet_probe(struct virtio_device *vdev)
+ 	struct virtnet_info *vi;
+ 	u16 max_queue_pairs;
+ 	int mtu = 0;
++	u16 key_sz;
+ 
+ 	/* Find if host supports multiqueue/rss virtio_net device */
+ 	max_queue_pairs = 1;
+@@ -4589,14 +4590,13 @@ static int virtnet_probe(struct virtio_device *vdev)
+ 	}
+ 
+ 	if (vi->has_rss || vi->has_rss_hash_report) {
+-		vi->rss_key_size =
+-			virtio_cread8(vdev, offsetof(struct virtio_net_config, rss_max_key_size));
+-		if (vi->rss_key_size > VIRTIO_NET_RSS_MAX_KEY_SIZE) {
+-			dev_err(&vdev->dev, "rss_max_key_size=%u exceeds the limit %u.\n",
+-				vi->rss_key_size, VIRTIO_NET_RSS_MAX_KEY_SIZE);
+-			err = -EINVAL;
+-			goto free;
+-		}
++		key_sz = virtio_cread8(vdev, offsetof(struct virtio_net_config, rss_max_key_size));
++
++		vi->rss_key_size = min_t(u16, key_sz, VIRTIO_NET_RSS_MAX_KEY_SIZE);
++		if (key_sz > vi->rss_key_size)
++			dev_warn(&vdev->dev,
++				 "rss_max_key_size=%u exceeds driver limit %u, clamping\n",
++				 key_sz, vi->rss_key_size);
+ 
+ 		vi->rss_hash_types_supported =
+ 		    virtio_cread32(vdev, offsetof(struct virtio_net_config, supported_hash_types));
+diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmsmac/dma.c b/drivers/net/wireless/broadcom/brcm80211/brcmsmac/dma.c
+index b7df576bb84d9b..2c0ea993d71f91 100644
+--- a/drivers/net/wireless/broadcom/brcm80211/brcmsmac/dma.c
++++ b/drivers/net/wireless/broadcom/brcm80211/brcmsmac/dma.c
+@@ -483,7 +483,7 @@ static void *dma_ringalloc(struct dma_info *di, u32 boundary, uint size,
+ 	if (((desc_strtaddr + size - 1) & boundary) != (desc_strtaddr
+ 							& boundary)) {
+ 		*alignbits = dma_align_sizetobits(size);
+-		dma_free_coherent(di->dmadev, size, va, *descpa);
++		dma_free_coherent(di->dmadev, *alloced, va, *descpa);
+ 		va = dma_alloc_consistent(di, size, *alignbits,
+ 			alloced, descpa);
+ 	}
+diff --git a/drivers/net/wireless/ralink/rt2x00/rt2x00usb.c b/drivers/net/wireless/ralink/rt2x00/rt2x00usb.c
+index 8fd22c69855fa4..9b193e46788638 100644
+--- a/drivers/net/wireless/ralink/rt2x00/rt2x00usb.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2x00usb.c
+@@ -830,7 +830,7 @@ int rt2x00usb_probe(struct usb_interface *usb_intf,
+ 	if (retval)
+ 		goto exit_free_device;
+ 
+-	rt2x00dev->anchor = devm_kmalloc(&usb_dev->dev,
++	rt2x00dev->anchor = devm_kmalloc(&usb_intf->dev,
+ 					sizeof(struct usb_anchor),
+ 					GFP_KERNEL);
+ 	if (!rt2x00dev->anchor) {
+diff --git a/drivers/nfc/pn533/uart.c b/drivers/nfc/pn533/uart.c
+index f4afd1156e062c..055a0bf7d2352e 100644
+--- a/drivers/nfc/pn533/uart.c
++++ b/drivers/nfc/pn533/uart.c
+@@ -211,6 +211,13 @@ static int pn532_receive_buf(struct serdev_device *serdev,
+ 
+ 	del_timer(&dev->cmd_timeout);
+ 	for (i = 0; i < count; i++) {
++		if (!dev->recv_skb) {
++			dev->recv_skb = alloc_skb(PN532_UART_SKB_BUFF_LEN,
++						  GFP_KERNEL);
++			if (!dev->recv_skb)
++				return i;
++		}
++
+ 		if (unlikely(!skb_tailroom(dev->recv_skb)))
+ 			skb_trim(dev->recv_skb, 0);
+ 
+@@ -219,9 +226,7 @@ static int pn532_receive_buf(struct serdev_device *serdev,
+ 			continue;
+ 
+ 		pn533_recv_frame(dev->priv, dev->recv_skb, 0);
+-		dev->recv_skb = alloc_skb(PN532_UART_SKB_BUFF_LEN, GFP_KERNEL);
+-		if (!dev->recv_skb)
+-			return 0;
++		dev->recv_skb = NULL;
+ 	}
+ 
+ 	return i;
+diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
+index b7a6d8a28fe930..8c941d6267a5c5 100644
+--- a/drivers/pci/pci-driver.c
++++ b/drivers/pci/pci-driver.c
+@@ -1668,14 +1668,6 @@ static int pci_dma_configure(struct device *dev)
+ 		ret = acpi_dma_configure(dev, acpi_get_dma_attr(adev));
+ 	}
+ 
+-	/*
+-	 * Attempt to enable ACS regardless of capability because some Root
+-	 * Ports (e.g. those quirked with *_intel_pch_acs_*) do not have
+-	 * the standard ACS capability but still support ACS via those
+-	 * quirks.
+-	 */
+-	pci_enable_acs(to_pci_dev(dev));
+-
+ 	pci_put_host_bridge_device(bridge);
+ 
+ 	if (!ret && !driver->driver_managed_dma) {
+diff --git a/drivers/pci/pci.c b/drivers/pci/pci.c
+index d015df77ddff51..b82927905968ed 100644
+--- a/drivers/pci/pci.c
++++ b/drivers/pci/pci.c
+@@ -1046,7 +1046,7 @@ static void pci_std_enable_acs(struct pci_dev *dev)
+  * pci_enable_acs - enable ACS if hardware support it
+  * @dev: the PCI device
+  */
+-void pci_enable_acs(struct pci_dev *dev)
++static void pci_enable_acs(struct pci_dev *dev)
+ {
+ 	if (!pci_acs_enable)
+ 		goto disable_acs_redir;
+@@ -3823,6 +3823,14 @@ bool pci_acs_path_enabled(struct pci_dev *start,
+ void pci_acs_init(struct pci_dev *dev)
+ {
+ 	dev->acs_cap = pci_find_ext_capability(dev, PCI_EXT_CAP_ID_ACS);
++
++	/*
++	 * Attempt to enable ACS regardless of capability because some Root
++	 * Ports (e.g. those quirked with *_intel_pch_acs_*) do not have
++	 * the standard ACS capability but still support ACS via those
++	 * quirks.
++	 */
++	pci_enable_acs(dev);
+ }
+ 
+ /**
+diff --git a/drivers/pci/pci.h b/drivers/pci/pci.h
+index dae7b98536f7a2..3c35aae7431f62 100644
+--- a/drivers/pci/pci.h
++++ b/drivers/pci/pci.h
+@@ -557,7 +557,6 @@ static inline resource_size_t pci_resource_alignment(struct pci_dev *dev,
+ }
+ 
+ void pci_acs_init(struct pci_dev *dev);
+-void pci_enable_acs(struct pci_dev *dev);
+ #ifdef CONFIG_PCI_QUIRKS
+ int pci_dev_specific_acs_enabled(struct pci_dev *dev, u16 acs_flags);
+ int pci_dev_specific_enable_acs(struct pci_dev *dev);
+diff --git a/drivers/pmdomain/imx/imx8mp-blk-ctrl.c b/drivers/pmdomain/imx/imx8mp-blk-ctrl.c
+index 4c3a225c1e44a7..a53ee38e7d3279 100644
+--- a/drivers/pmdomain/imx/imx8mp-blk-ctrl.c
++++ b/drivers/pmdomain/imx/imx8mp-blk-ctrl.c
+@@ -352,9 +352,6 @@ static void imx8mp_hdmi_blk_ctrl_power_on(struct imx8mp_blk_ctrl *bc,
+ 		regmap_set_bits(bc->regmap, HDMI_RTX_RESET_CTL0, BIT(12));
+ 		regmap_clear_bits(bc->regmap, HDMI_TX_CONTROL0, BIT(3));
+ 		break;
+-	case IMX8MP_HDMIBLK_PD_HDCP:
+-		regmap_set_bits(bc->regmap, HDMI_RTX_CLK_CTL0, BIT(11));
+-		break;
+ 	case IMX8MP_HDMIBLK_PD_HRV:
+ 		regmap_set_bits(bc->regmap, HDMI_RTX_CLK_CTL1, BIT(3) | BIT(4) | BIT(5));
+ 		regmap_set_bits(bc->regmap, HDMI_RTX_RESET_CTL0, BIT(15));
+@@ -408,9 +405,6 @@ static void imx8mp_hdmi_blk_ctrl_power_off(struct imx8mp_blk_ctrl *bc,
+ 		regmap_clear_bits(bc->regmap, HDMI_RTX_CLK_CTL0, BIT(7));
+ 		regmap_clear_bits(bc->regmap, HDMI_RTX_CLK_CTL1, BIT(22) | BIT(24));
+ 		break;
+-	case IMX8MP_HDMIBLK_PD_HDCP:
+-		regmap_clear_bits(bc->regmap, HDMI_RTX_CLK_CTL0, BIT(11));
+-		break;
+ 	case IMX8MP_HDMIBLK_PD_HRV:
+ 		regmap_clear_bits(bc->regmap, HDMI_RTX_RESET_CTL0, BIT(15));
+ 		regmap_clear_bits(bc->regmap, HDMI_RTX_CLK_CTL1, BIT(3) | BIT(4) | BIT(5));
+@@ -439,7 +433,7 @@ static int imx8mp_hdmi_power_notifier(struct notifier_block *nb,
+ 	regmap_write(bc->regmap, HDMI_RTX_CLK_CTL0, 0x0);
+ 	regmap_write(bc->regmap, HDMI_RTX_CLK_CTL1, 0x0);
+ 	regmap_set_bits(bc->regmap, HDMI_RTX_CLK_CTL0,
+-			BIT(0) | BIT(1) | BIT(10));
++			BIT(0) | BIT(1) | BIT(10) | BIT(11));
+ 	regmap_set_bits(bc->regmap, HDMI_RTX_RESET_CTL0, BIT(0));
+ 
+ 	/*
+diff --git a/drivers/ufs/core/ufshcd.c b/drivers/ufs/core/ufshcd.c
+index 2dcb0146c17e3f..f6aada5150f9cd 100644
+--- a/drivers/ufs/core/ufshcd.c
++++ b/drivers/ufs/core/ufshcd.c
+@@ -10475,16 +10475,6 @@ int ufshcd_system_thaw(struct device *dev)
+ EXPORT_SYMBOL_GPL(ufshcd_system_thaw);
+ #endif /* CONFIG_PM_SLEEP  */
+ 
+-/**
+- * ufshcd_dealloc_host - deallocate Host Bus Adapter (HBA)
+- * @hba: pointer to Host Bus Adapter (HBA)
+- */
+-void ufshcd_dealloc_host(struct ufs_hba *hba)
+-{
+-	scsi_host_put(hba->host);
+-}
+-EXPORT_SYMBOL_GPL(ufshcd_dealloc_host);
+-
+ /**
+  * ufshcd_set_dma_mask - Set dma mask based on the controller
+  *			 addressing capability
+@@ -10503,12 +10493,26 @@ static int ufshcd_set_dma_mask(struct ufs_hba *hba)
+ 	return dma_set_mask_and_coherent(hba->dev, DMA_BIT_MASK(32));
+ }
+ 
++/**
++ * ufshcd_devres_release - devres cleanup handler, invoked during release of
++ *			   hba->dev
++ * @host: pointer to SCSI host
++ */
++static void ufshcd_devres_release(void *host)
++{
++	scsi_host_put(host);
++}
++
+ /**
+  * ufshcd_alloc_host - allocate Host Bus Adapter (HBA)
+  * @dev: pointer to device handle
+  * @hba_handle: driver private handle
+  *
+  * Return: 0 on success, non-zero value on failure.
++ *
++ * NOTE: There is no corresponding ufshcd_dealloc_host() because this function
++ * keeps track of its allocations using devres and deallocates everything on
++ * device removal automatically.
+  */
+ int ufshcd_alloc_host(struct device *dev, struct ufs_hba **hba_handle)
+ {
+@@ -10530,6 +10534,13 @@ int ufshcd_alloc_host(struct device *dev, struct ufs_hba **hba_handle)
+ 		err = -ENOMEM;
+ 		goto out_error;
+ 	}
++
++	err = devm_add_action_or_reset(dev, ufshcd_devres_release,
++				       host);
++	if (err)
++		return dev_err_probe(dev, err,
++				     "failed to add ufshcd dealloc action\n");
++
+ 	host->nr_maps = HCTX_TYPE_POLL + 1;
+ 	hba = shost_priv(host);
+ 	hba->host = host;
+diff --git a/drivers/ufs/host/ufshcd-pci.c b/drivers/ufs/host/ufshcd-pci.c
+index 4ecaaf52b3e95e..3ff799497191fa 100644
+--- a/drivers/ufs/host/ufshcd-pci.c
++++ b/drivers/ufs/host/ufshcd-pci.c
+@@ -620,7 +620,6 @@ static void ufshcd_pci_remove(struct pci_dev *pdev)
+ 	pm_runtime_forbid(&pdev->dev);
+ 	pm_runtime_get_noresume(&pdev->dev);
+ 	ufshcd_remove(hba);
+-	ufshcd_dealloc_host(hba);
+ }
+ 
+ /**
+@@ -665,7 +664,6 @@ ufshcd_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 	err = ufshcd_init(hba, mmio_base, pdev->irq);
+ 	if (err) {
+ 		dev_err(&pdev->dev, "Initialization failed\n");
+-		ufshcd_dealloc_host(hba);
+ 		return err;
+ 	}
+ 
+diff --git a/drivers/ufs/host/ufshcd-pltfrm.c b/drivers/ufs/host/ufshcd-pltfrm.c
+index 797a4dfe45d908..0112ecbebe46a8 100644
+--- a/drivers/ufs/host/ufshcd-pltfrm.c
++++ b/drivers/ufs/host/ufshcd-pltfrm.c
+@@ -339,21 +339,17 @@ int ufshcd_pltfrm_init(struct platform_device *pdev,
+ 	struct device *dev = &pdev->dev;
+ 
+ 	mmio_base = devm_platform_ioremap_resource(pdev, 0);
+-	if (IS_ERR(mmio_base)) {
+-		err = PTR_ERR(mmio_base);
+-		goto out;
+-	}
++	if (IS_ERR(mmio_base))
++		return PTR_ERR(mmio_base);
+ 
+ 	irq = platform_get_irq(pdev, 0);
+-	if (irq < 0) {
+-		err = irq;
+-		goto out;
+-	}
++	if (irq < 0)
++		return irq;
+ 
+ 	err = ufshcd_alloc_host(dev, &hba);
+ 	if (err) {
+ 		dev_err(dev, "Allocation failed\n");
+-		goto out;
++		return err;
+ 	}
+ 
+ 	hba->vops = vops;
+@@ -362,13 +358,13 @@ int ufshcd_pltfrm_init(struct platform_device *pdev,
+ 	if (err) {
+ 		dev_err(dev, "%s: clock parse failed %d\n",
+ 				__func__, err);
+-		goto dealloc_host;
++		return err;
+ 	}
+ 	err = ufshcd_parse_regulator_info(hba);
+ 	if (err) {
+ 		dev_err(dev, "%s: regulator init failed %d\n",
+ 				__func__, err);
+-		goto dealloc_host;
++		return err;
+ 	}
+ 
+ 	ufshcd_init_lanes_per_dir(hba);
+@@ -377,18 +373,13 @@ int ufshcd_pltfrm_init(struct platform_device *pdev,
+ 	if (err) {
+ 		dev_err_probe(dev, err, "Initialization failed with error %d\n",
+ 			      err);
+-		goto dealloc_host;
++		return err;
+ 	}
+ 
+ 	pm_runtime_set_active(dev);
+ 	pm_runtime_enable(dev);
+ 
+ 	return 0;
+-
+-dealloc_host:
+-	ufshcd_dealloc_host(hba);
+-out:
+-	return err;
+ }
+ EXPORT_SYMBOL_GPL(ufshcd_pltfrm_init);
+ 
+diff --git a/drivers/usb/gadget/function/f_hid.c b/drivers/usb/gadget/function/f_hid.c
+index d8dafebeabea48..2137513b23a08c 100644
+--- a/drivers/usb/gadget/function/f_hid.c
++++ b/drivers/usb/gadget/function/f_hid.c
+@@ -1000,13 +1000,8 @@ static int hidg_bind(struct usb_configuration *c, struct usb_function *f)
+ 	if (status)
+ 		goto fail;
+ 
+-	spin_lock_init(&hidg->write_spinlock);
+ 	hidg->write_pending = 1;
+ 	hidg->req = NULL;
+-	spin_lock_init(&hidg->read_spinlock);
+-	init_waitqueue_head(&hidg->write_queue);
+-	init_waitqueue_head(&hidg->read_queue);
+-	INIT_LIST_HEAD(&hidg->completed_out_req);
+ 
+ 	/* create char device */
+ 	cdev_init(&hidg->cdev, &f_hidg_fops);
+@@ -1275,6 +1270,12 @@ static struct usb_function *hidg_alloc(struct usb_function_instance *fi)
+ 
+ 	mutex_lock(&opts->lock);
+ 
++	spin_lock_init(&hidg->write_spinlock);
++	spin_lock_init(&hidg->read_spinlock);
++	init_waitqueue_head(&hidg->write_queue);
++	init_waitqueue_head(&hidg->read_queue);
++	INIT_LIST_HEAD(&hidg->completed_out_req);
++
+ 	device_initialize(&hidg->dev);
+ 	hidg->dev.release = hidg_release;
+ 	hidg->dev.class = &hidg_class;
+diff --git a/include/net/netfilter/nf_conntrack_timeout.h b/include/net/netfilter/nf_conntrack_timeout.h
+index 9fdaba911de64d..3a66d4abb6d688 100644
+--- a/include/net/netfilter/nf_conntrack_timeout.h
++++ b/include/net/netfilter/nf_conntrack_timeout.h
+@@ -14,6 +14,7 @@
+ struct nf_ct_timeout {
+ 	__u16			l3num;
+ 	const struct nf_conntrack_l4proto *l4proto;
++	struct rcu_head		rcu;
+ 	char			data[];
+ };
+ 
+diff --git a/include/trace/events/rxrpc.h b/include/trace/events/rxrpc.h
+index ceb09fabfb04cc..6965099dda89fa 100644
+--- a/include/trace/events/rxrpc.h
++++ b/include/trace/events/rxrpc.h
+@@ -294,7 +294,7 @@
+ 	EM(rxrpc_call_see_release,		"SEE release ") \
+ 	EM(rxrpc_call_see_userid_exists,	"SEE u-exists") \
+ 	EM(rxrpc_call_see_waiting_call,		"SEE q-conn  ") \
+-	E_(rxrpc_call_see_zap,			"SEE zap     ")
++	E_(rxrpc_call_see_still_live,		"SEE !still-l")
+ 
+ #define rxrpc_txqueue_traces \
+ 	EM(rxrpc_txqueue_await_reply,		"AWR") \
+diff --git a/include/ufs/ufshcd.h b/include/ufs/ufshcd.h
+index 8d2efb9e5d664b..60942ed0040f1e 100644
+--- a/include/ufs/ufshcd.h
++++ b/include/ufs/ufshcd.h
+@@ -1286,7 +1286,6 @@ static inline void ufshcd_rmwl(struct ufs_hba *hba, u32 mask, u32 val, u32 reg)
+ }
+ 
+ int ufshcd_alloc_host(struct device *, struct ufs_hba **);
+-void ufshcd_dealloc_host(struct ufs_hba *);
+ int ufshcd_hba_enable(struct ufs_hba *hba);
+ int ufshcd_init(struct ufs_hba *, void __iomem *, unsigned int);
+ int ufshcd_link_recovery(struct ufs_hba *hba);
+diff --git a/lib/crypto/chacha.c b/lib/crypto/chacha.c
+index b748fd3d256e41..1bff9f2837778f 100644
+--- a/lib/crypto/chacha.c
++++ b/lib/crypto/chacha.c
+@@ -86,6 +86,8 @@ void chacha_block_generic(u32 *state, u8 *stream, int nrounds)
+ 		put_unaligned_le32(x[i] + state[i], &stream[i * sizeof(u32)]);
+ 
+ 	state[12]++;
++
++	memzero_explicit(x, sizeof(x));
+ }
+ EXPORT_SYMBOL(chacha_block_generic);
+ 
+@@ -110,5 +112,7 @@ void hchacha_block_generic(const u32 *state, u32 *stream, int nrounds)
+ 
+ 	memcpy(&stream[0], &x[0], 16);
+ 	memcpy(&stream[4], &x[12], 16);
++
++	memzero_explicit(x, sizeof(x));
+ }
+ EXPORT_SYMBOL(hchacha_block_generic);
+diff --git a/mm/filemap.c b/mm/filemap.c
+index 1c229b261a62be..7416868d044913 100644
+--- a/mm/filemap.c
++++ b/mm/filemap.c
+@@ -3616,14 +3616,19 @@ vm_fault_t filemap_map_pages(struct vm_fault *vmf,
+ 	unsigned int nr_pages = 0, mmap_miss = 0, mmap_miss_saved;
+ 	bool can_map_large;
+ 
++	/*
++	 * Recalculate end_pgoff based on file_end before calling
++	 * next_uptodate_folio() to avoid races with concurrent
++	 * truncation.
++	 */
++	file_end = DIV_ROUND_UP(i_size_read(mapping->host), PAGE_SIZE) - 1;
++	end_pgoff = min(end_pgoff, file_end);
++
+ 	rcu_read_lock();
+ 	folio = next_uptodate_folio(&xas, mapping, end_pgoff);
+ 	if (!folio)
+ 		goto out;
+ 
+-	file_end = DIV_ROUND_UP(i_size_read(mapping->host), PAGE_SIZE) - 1;
+-	end_pgoff = min(end_pgoff, file_end);
+-
+ 	/*
+ 	 * Do not allow to map with PTEs beyond i_size and with PMD
+ 	 * across i_size to preserve SIGBUS semantics.
+diff --git a/net/batman-adv/bridge_loop_avoidance.c b/net/batman-adv/bridge_loop_avoidance.c
+index 37ce6cfb352097..96b3c1c972cd27 100644
+--- a/net/batman-adv/bridge_loop_avoidance.c
++++ b/net/batman-adv/bridge_loop_avoidance.c
+@@ -2132,6 +2132,7 @@ batadv_bla_claim_dump_entry(struct sk_buff *msg, u32 portid,
+ 			    struct batadv_bla_claim *claim)
+ {
+ 	const u8 *primary_addr = primary_if->net_dev->dev_addr;
++	struct batadv_bla_backbone_gw *backbone_gw;
+ 	u16 backbone_crc;
+ 	bool is_own;
+ 	void *hdr;
+@@ -2147,32 +2148,35 @@ batadv_bla_claim_dump_entry(struct sk_buff *msg, u32 portid,
+ 
+ 	genl_dump_check_consistent(cb, hdr);
+ 
+-	is_own = batadv_compare_eth(claim->backbone_gw->orig,
+-				    primary_addr);
++	backbone_gw = batadv_bla_claim_get_backbone_gw(claim);
++
++	is_own = batadv_compare_eth(backbone_gw->orig, primary_addr);
+ 
+-	spin_lock_bh(&claim->backbone_gw->crc_lock);
+-	backbone_crc = claim->backbone_gw->crc;
+-	spin_unlock_bh(&claim->backbone_gw->crc_lock);
++	spin_lock_bh(&backbone_gw->crc_lock);
++	backbone_crc = backbone_gw->crc;
++	spin_unlock_bh(&backbone_gw->crc_lock);
+ 
+ 	if (is_own)
+ 		if (nla_put_flag(msg, BATADV_ATTR_BLA_OWN)) {
+ 			genlmsg_cancel(msg, hdr);
+-			goto out;
++			goto put_backbone_gw;
+ 		}
+ 
+ 	if (nla_put(msg, BATADV_ATTR_BLA_ADDRESS, ETH_ALEN, claim->addr) ||
+ 	    nla_put_u16(msg, BATADV_ATTR_BLA_VID, claim->vid) ||
+ 	    nla_put(msg, BATADV_ATTR_BLA_BACKBONE, ETH_ALEN,
+-		    claim->backbone_gw->orig) ||
++		    backbone_gw->orig) ||
+ 	    nla_put_u16(msg, BATADV_ATTR_BLA_CRC,
+ 			backbone_crc)) {
+ 		genlmsg_cancel(msg, hdr);
+-		goto out;
++		goto put_backbone_gw;
+ 	}
+ 
+ 	genlmsg_end(msg, hdr);
+ 	ret = 0;
+ 
++put_backbone_gw:
++	batadv_backbone_gw_put(backbone_gw);
+ out:
+ 	return ret;
+ }
+@@ -2468,6 +2472,7 @@ out:
+ bool batadv_bla_check_claim(struct batadv_priv *bat_priv,
+ 			    u8 *addr, unsigned short vid)
+ {
++	struct batadv_bla_backbone_gw *backbone_gw;
+ 	struct batadv_bla_claim search_claim;
+ 	struct batadv_bla_claim *claim = NULL;
+ 	struct batadv_hard_iface *primary_if = NULL;
+@@ -2490,9 +2495,13 @@ bool batadv_bla_check_claim(struct batadv_priv *bat_priv,
+ 	 * return false.
+ 	 */
+ 	if (claim) {
+-		if (!batadv_compare_eth(claim->backbone_gw->orig,
++		backbone_gw = batadv_bla_claim_get_backbone_gw(claim);
++
++		if (!batadv_compare_eth(backbone_gw->orig,
+ 					primary_if->net_dev->dev_addr))
+ 			ret = false;
++
++		batadv_backbone_gw_put(backbone_gw);
+ 		batadv_claim_put(claim);
+ 	}
+ 
+diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+index 53dea8ae96e477..d830ccf016697b 100644
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -844,8 +844,8 @@ batadv_tt_prepare_tvlv_global_data(struct batadv_orig_node *orig_node,
+ {
+ 	u16 num_vlan = 0;
+ 	u16 num_entries = 0;
+-	u16 change_offset;
+-	u16 tvlv_len;
++	u16 tvlv_len = 0;
++	unsigned int change_offset;
+ 	struct batadv_tvlv_tt_vlan_data *tt_vlan;
+ 	struct batadv_orig_node_vlan *vlan;
+ 	u8 *tt_change_ptr;
+@@ -863,6 +863,11 @@ batadv_tt_prepare_tvlv_global_data(struct batadv_orig_node *orig_node,
+ 	if (*tt_len < 0)
+ 		*tt_len = batadv_tt_len(num_entries);
+ 
++	if (change_offset > U16_MAX || *tt_len > U16_MAX - change_offset) {
++		*tt_len = 0;
++		goto out;
++	}
++
+ 	tvlv_len = *tt_len;
+ 	tvlv_len += change_offset;
+ 
+diff --git a/net/ipv6/seg6_iptunnel.c b/net/ipv6/seg6_iptunnel.c
+index c44e4c0824e0d8..50bc05b853291c 100644
+--- a/net/ipv6/seg6_iptunnel.c
++++ b/net/ipv6/seg6_iptunnel.c
+@@ -48,7 +48,8 @@ static size_t seg6_lwt_headroom(struct seg6_iptunnel_encap *tuninfo)
+ }
+ 
+ struct seg6_lwt {
+-	struct dst_cache cache;
++	struct dst_cache cache_input;
++	struct dst_cache cache_output;
+ 	struct seg6_iptunnel_encap tuninfo[];
+ };
+ 
+@@ -486,7 +487,7 @@ static int seg6_input_core(struct net *net, struct sock *sk,
+ 	slwt = seg6_lwt_lwtunnel(lwtst);
+ 
+ 	local_bh_disable();
+-	dst = dst_cache_get(&slwt->cache);
++	dst = dst_cache_get(&slwt->cache_input);
+ 	local_bh_enable();
+ 
+ 	err = seg6_do_srh(skb, dst);
+@@ -500,7 +501,7 @@ static int seg6_input_core(struct net *net, struct sock *sk,
+ 		/* cache only if we don't create a dst reference loop */
+ 		if (!dst->error && lwtst != dst->lwtstate) {
+ 			local_bh_disable();
+-			dst_cache_set_ip6(&slwt->cache, dst,
++			dst_cache_set_ip6(&slwt->cache_input, dst,
+ 					  &ipv6_hdr(skb)->saddr);
+ 			local_bh_enable();
+ 		}
+@@ -560,7 +561,7 @@ static int seg6_output_core(struct net *net, struct sock *sk,
+ 	slwt = seg6_lwt_lwtunnel(orig_dst->lwtstate);
+ 
+ 	local_bh_disable();
+-	dst = dst_cache_get(&slwt->cache);
++	dst = dst_cache_get(&slwt->cache_output);
+ 	local_bh_enable();
+ 
+ 	err = seg6_do_srh(skb, dst);
+@@ -585,9 +586,12 @@ static int seg6_output_core(struct net *net, struct sock *sk,
+ 			goto drop;
+ 		}
+ 
+-		local_bh_disable();
+-		dst_cache_set_ip6(&slwt->cache, dst, &fl6.saddr);
+-		local_bh_enable();
++		/* cache only if we don't create a dst reference loop */
++		if (orig_dst->lwtstate != dst->lwtstate) {
++			local_bh_disable();
++			dst_cache_set_ip6(&slwt->cache_output, dst, &fl6.saddr);
++			local_bh_enable();
++		}
+ 
+ 		err = skb_cow_head(skb, LL_RESERVED_SPACE(dst->dev));
+ 		if (unlikely(err))
+@@ -694,11 +698,13 @@ static int seg6_build_state(struct net *net, struct nlattr *nla,
+ 
+ 	slwt = seg6_lwt_lwtunnel(newts);
+ 
+-	err = dst_cache_init(&slwt->cache, GFP_ATOMIC);
+-	if (err) {
+-		kfree(newts);
+-		return err;
+-	}
++	err = dst_cache_init(&slwt->cache_input, GFP_ATOMIC);
++	if (err)
++		goto err_free_newts;
++
++	err = dst_cache_init(&slwt->cache_output, GFP_ATOMIC);
++	if (err)
++		goto err_destroy_input;
+ 
+ 	memcpy(&slwt->tuninfo, tuninfo, tuninfo_len);
+ 
+@@ -713,11 +719,20 @@ static int seg6_build_state(struct net *net, struct nlattr *nla,
+ 	*ts = newts;
+ 
+ 	return 0;
++
++err_destroy_input:
++	dst_cache_destroy(&slwt->cache_input);
++err_free_newts:
++	kfree(newts);
++	return err;
+ }
+ 
+ static void seg6_destroy_state(struct lwtunnel_state *lwt)
+ {
+-	dst_cache_destroy(&seg6_lwt_lwtunnel(lwt)->cache);
++	struct seg6_lwt *slwt = seg6_lwt_lwtunnel(lwt);
++
++	dst_cache_destroy(&slwt->cache_input);
++	dst_cache_destroy(&slwt->cache_output);
+ }
+ 
+ static int seg6_fill_encap_info(struct sk_buff *skb,
+diff --git a/net/mptcp/pm_netlink.c b/net/mptcp/pm_netlink.c
+index 269e95c8415fac..28f8d7fb7bdf39 100644
+--- a/net/mptcp/pm_netlink.c
++++ b/net/mptcp/pm_netlink.c
+@@ -1079,7 +1079,7 @@ static void __mptcp_pm_release_addr_entry(struct mptcp_pm_addr_entry *entry)
+ 
+ static int mptcp_pm_nl_append_new_local_addr(struct pm_nl_pernet *pernet,
+ 					     struct mptcp_pm_addr_entry *entry,
+-					     bool needs_id, bool replace)
++					     bool replace)
+ {
+ 	struct mptcp_pm_addr_entry *cur, *del_entry = NULL;
+ 	unsigned int addr_max;
+@@ -1138,7 +1138,7 @@ static int mptcp_pm_nl_append_new_local_addr(struct pm_nl_pernet *pernet,
+ 		}
+ 	}
+ 
+-	if (!entry->addr.id && needs_id) {
++	if (!entry->addr.id) {
+ find_next:
+ 		entry->addr.id = find_next_zero_bit(pernet->id_bitmap,
+ 						    MPTCP_PM_MAX_ADDR_ID + 1,
+@@ -1149,7 +1149,7 @@ find_next:
+ 		}
+ 	}
+ 
+-	if (!entry->addr.id && needs_id)
++	if (!entry->addr.id)
+ 		goto out;
+ 
+ 	__set_bit(entry->addr.id, pernet->id_bitmap);
+@@ -1282,7 +1282,7 @@ int mptcp_pm_nl_get_local_id(struct mptcp_sock *msk, struct mptcp_addr_info *skc
+ 	entry->ifindex = 0;
+ 	entry->flags = MPTCP_PM_ADDR_FLAG_IMPLICIT;
+ 	entry->lsk = NULL;
+-	ret = mptcp_pm_nl_append_new_local_addr(pernet, entry, true, false);
++	ret = mptcp_pm_nl_append_new_local_addr(pernet, entry, false);
+ 	if (ret < 0)
+ 		kfree(entry);
+ 
+@@ -1524,18 +1524,6 @@ next:
+ 	return 0;
+ }
+ 
+-static bool mptcp_pm_has_addr_attr_id(const struct nlattr *attr,
+-				      struct genl_info *info)
+-{
+-	struct nlattr *tb[MPTCP_PM_ADDR_ATTR_MAX + 1];
+-
+-	if (!nla_parse_nested_deprecated(tb, MPTCP_PM_ADDR_ATTR_MAX, attr,
+-					 mptcp_pm_addr_policy, info->extack) &&
+-	    tb[MPTCP_PM_ADDR_ATTR_ID])
+-		return true;
+-	return false;
+-}
+-
+ static int mptcp_nl_cmd_add_addr(struct sk_buff *skb, struct genl_info *info)
+ {
+ 	struct nlattr *attr = info->attrs[MPTCP_PM_ATTR_ADDR];
+@@ -1577,9 +1565,7 @@ static int mptcp_nl_cmd_add_addr(struct sk_buff *skb, struct genl_info *info)
+ 			goto out_free;
+ 		}
+ 	}
+-	ret = mptcp_pm_nl_append_new_local_addr(pernet, entry,
+-						!mptcp_pm_has_addr_attr_id(attr, info),
+-						true);
++	ret = mptcp_pm_nl_append_new_local_addr(pernet, entry, true);
+ 	if (ret < 0) {
+ 		GENL_SET_ERR_MSG_FMT(info, "too many addresses or duplicate one: %d", ret);
+ 		goto out_free;
+diff --git a/net/mptcp/protocol.c b/net/mptcp/protocol.c
+index 85ef9042873bef..6bf6bd741cba1c 100644
+--- a/net/mptcp/protocol.c
++++ b/net/mptcp/protocol.c
+@@ -4301,6 +4301,8 @@ int __init mptcp_proto_v6_init(void)
+ {
+ 	int err;
+ 
++	mptcp_subflow_v6_init();
++
+ 	mptcp_v6_prot = mptcp_prot;
+ 	strcpy(mptcp_v6_prot.name, "MPTCPv6");
+ 	mptcp_v6_prot.slab = NULL;
+diff --git a/net/mptcp/protocol.h b/net/mptcp/protocol.h
+index 93be4c0432d1c1..fbb3897c9c2c2b 100644
+--- a/net/mptcp/protocol.h
++++ b/net/mptcp/protocol.h
+@@ -746,6 +746,7 @@ static inline void mptcp_subflow_tcp_fallback(struct sock *sk,
+ void __init mptcp_proto_init(void);
+ #if IS_ENABLED(CONFIG_MPTCP_IPV6)
+ int __init mptcp_proto_v6_init(void);
++void __init mptcp_subflow_v6_init(void);
+ #endif
+ 
+ struct sock *mptcp_sk_clone_init(const struct sock *sk,
+diff --git a/net/mptcp/subflow.c b/net/mptcp/subflow.c
+index c34f9f176587a2..36c6d76f18dfac 100644
+--- a/net/mptcp/subflow.c
++++ b/net/mptcp/subflow.c
+@@ -2092,7 +2092,15 @@ void __init mptcp_subflow_init(void)
+ 	tcp_prot_override.psock_update_sk_prot = NULL;
+ #endif
+ 
++	mptcp_diag_subflow_init(&subflow_ulp_ops);
++
++	if (tcp_register_ulp(&subflow_ulp_ops) != 0)
++		panic("MPTCP: failed to register subflows to ULP\n");
++}
++
+ #if IS_ENABLED(CONFIG_MPTCP_IPV6)
++void __init mptcp_subflow_v6_init(void)
++{
+ 	/* In struct mptcp_subflow_request_sock, we assume the TCP request sock
+ 	 * structures for v4 and v6 have the same size. It should not changed in
+ 	 * the future but better to make sure to be warned if it is no longer
+@@ -2132,10 +2140,5 @@ void __init mptcp_subflow_init(void)
+ 	/* Disable sockmap processing for subflows */
+ 	tcpv6_prot_override.psock_update_sk_prot = NULL;
+ #endif
+-#endif
+-
+-	mptcp_diag_subflow_init(&subflow_ulp_ops);
+-
+-	if (tcp_register_ulp(&subflow_ulp_ops) != 0)
+-		panic("MPTCP: failed to register subflows to ULP\n");
+ }
++#endif
+diff --git a/net/netfilter/nft_ct.c b/net/netfilter/nft_ct.c
+index 128eb0ac37742a..7ed103de9b76fd 100644
+--- a/net/netfilter/nft_ct.c
++++ b/net/netfilter/nft_ct.c
+@@ -1002,7 +1002,7 @@ static void nft_ct_timeout_obj_destroy(const struct nft_ctx *ctx,
+ 	nf_queue_nf_hook_drop(ctx->net);
+ 	nf_ct_untimeout(ctx->net, timeout);
+ 	nf_ct_netns_put(ctx->net, ctx->family);
+-	kfree(priv->timeout);
++	kfree_rcu(priv->timeout, rcu);
+ }
+ 
+ static int nft_ct_timeout_obj_dump(struct sk_buff *skb,
+diff --git a/net/netfilter/nft_set_pipapo.c b/net/netfilter/nft_set_pipapo.c
+index 00a13c50ec8bf4..e55664ca2aadb7 100644
+--- a/net/netfilter/nft_set_pipapo.c
++++ b/net/netfilter/nft_set_pipapo.c
+@@ -525,6 +525,8 @@ static struct nft_pipapo_elem *pipapo_get(const struct net *net,
+ 	int i;
+ 
+ 	m = priv->clone;
++	if (m->bsize_max == 0)
++		return ret;
+ 
+ 	res_map = kmalloc_array(m->bsize_max, sizeof(*res_map), GFP_ATOMIC);
+ 	if (!res_map) {
+@@ -1394,14 +1396,20 @@ static struct nft_pipapo_match *pipapo_clone(struct nft_pipapo_match *old)
+ 		       src->bsize * sizeof(*dst->lt) *
+ 		       src->groups * NFT_PIPAPO_BUCKETS(src->bb));
+ 
+-		if (src->rules > (INT_MAX / sizeof(*src->mt)))
+-			goto out_mt;
++		if (src->rules > 0) {
++			if (src->rules > (INT_MAX / sizeof(*src->mt)))
++				goto out_mt;
++
++			dst->mt = kvmalloc_array(src->rules, sizeof(*src->mt),
++						 GFP_KERNEL);
++			if (!dst->mt)
++				goto out_mt;
+ 
+-		dst->mt = kvmalloc(src->rules * sizeof(*src->mt), GFP_KERNEL_ACCOUNT);
+-		if (!dst->mt)
+-			goto out_mt;
++			memcpy(dst->mt, src->mt, src->rules * sizeof(*src->mt));
++		} else {
++			dst->mt = NULL;
++		}
+ 
+-		memcpy(dst->mt, src->mt, src->rules * sizeof(*src->mt));
+ 		src++;
+ 		dst++;
+ 	}
+diff --git a/net/rfkill/core.c b/net/rfkill/core.c
+index 14cc8fe8584bd1..5552604e83c948 100644
+--- a/net/rfkill/core.c
++++ b/net/rfkill/core.c
+@@ -73,11 +73,14 @@ struct rfkill_int_event {
+ 	struct rfkill_event_ext	ev;
+ };
+ 
++/* Max rfkill events that can be "in-flight" for one data source */
++#define MAX_RFKILL_EVENT	1000
+ struct rfkill_data {
+ 	struct list_head	list;
+ 	struct list_head	events;
+ 	struct mutex		mtx;
+ 	wait_queue_head_t	read_wait;
++	u32			event_count;
+ 	bool			input_handler;
+ 	u8			max_size;
+ };
+@@ -255,10 +258,12 @@ static void rfkill_global_led_trigger_unregister(void)
+ }
+ #endif /* CONFIG_RFKILL_LEDS */
+ 
+-static void rfkill_fill_event(struct rfkill_event_ext *ev,
+-			      struct rfkill *rfkill,
+-			      enum rfkill_operation op)
++static int rfkill_fill_event(struct rfkill_int_event *int_ev,
++			     struct rfkill *rfkill,
++			     struct rfkill_data *data,
++			     enum rfkill_operation op)
+ {
++	struct rfkill_event_ext *ev = &int_ev->ev;
+ 	unsigned long flags;
+ 
+ 	ev->idx = rfkill->idx;
+@@ -271,6 +276,15 @@ static void rfkill_fill_event(struct rfkill_event_ext *ev,
+ 					RFKILL_BLOCK_SW_PREV));
+ 	ev->hard_block_reasons = rfkill->hard_block_reasons;
+ 	spin_unlock_irqrestore(&rfkill->lock, flags);
++
++	scoped_guard(mutex, &data->mtx) {
++		if (data->event_count++ > MAX_RFKILL_EVENT) {
++			data->event_count--;
++			return -ENOSPC;
++		}
++		list_add_tail(&int_ev->list, &data->events);
++	}
++	return 0;
+ }
+ 
+ static void rfkill_send_events(struct rfkill *rfkill, enum rfkill_operation op)
+@@ -282,10 +296,10 @@ static void rfkill_send_events(struct rfkill *rfkill, enum rfkill_operation op)
+ 		ev = kzalloc(sizeof(*ev), GFP_KERNEL);
+ 		if (!ev)
+ 			continue;
+-		rfkill_fill_event(&ev->ev, rfkill, op);
+-		mutex_lock(&data->mtx);
+-		list_add_tail(&ev->list, &data->events);
+-		mutex_unlock(&data->mtx);
++		if (rfkill_fill_event(ev, rfkill, data, op)) {
++			kfree(ev);
++			continue;
++		}
+ 		wake_up_interruptible(&data->read_wait);
+ 	}
+ }
+@@ -1190,10 +1204,8 @@ static int rfkill_fop_open(struct inode *inode, struct file *file)
+ 		if (!ev)
+ 			goto free;
+ 		rfkill_sync(rfkill);
+-		rfkill_fill_event(&ev->ev, rfkill, RFKILL_OP_ADD);
+-		mutex_lock(&data->mtx);
+-		list_add_tail(&ev->list, &data->events);
+-		mutex_unlock(&data->mtx);
++		if (rfkill_fill_event(ev, rfkill, data, RFKILL_OP_ADD))
++			kfree(ev);
+ 	}
+ 	list_add(&data->list, &rfkill_fds);
+ 	mutex_unlock(&rfkill_global_mutex);
+@@ -1263,6 +1275,7 @@ static ssize_t rfkill_fop_read(struct file *file, char __user *buf,
+ 		ret = -EFAULT;
+ 
+ 	list_del(&ev->list);
++	data->event_count--;
+ 	kfree(ev);
+  out:
+ 	mutex_unlock(&data->mtx);
+diff --git a/net/rxrpc/af_rxrpc.c b/net/rxrpc/af_rxrpc.c
+index 205e0d4d048ea2..0547c809876ed1 100644
+--- a/net/rxrpc/af_rxrpc.c
++++ b/net/rxrpc/af_rxrpc.c
+@@ -635,9 +635,6 @@ static int rxrpc_setsockopt(struct socket *sock, int level, int optname,
+ 			goto success;
+ 
+ 		case RXRPC_SECURITY_KEY:
+-			ret = -EINVAL;
+-			if (rx->key)
+-				goto error;
+ 			ret = -EISCONN;
+ 			if (rx->sk.sk_state != RXRPC_UNBOUND)
+ 				goto error;
+@@ -645,9 +642,6 @@ static int rxrpc_setsockopt(struct socket *sock, int level, int optname,
+ 			goto error;
+ 
+ 		case RXRPC_SECURITY_KEYRING:
+-			ret = -EINVAL;
+-			if (rx->key)
+-				goto error;
+ 			ret = -EISCONN;
+ 			if (rx->sk.sk_state != RXRPC_UNBOUND)
+ 				goto error;
+diff --git a/net/rxrpc/call_object.c b/net/rxrpc/call_object.c
+index 4f8e8f884d102c..42d8b0bada4a94 100644
+--- a/net/rxrpc/call_object.c
++++ b/net/rxrpc/call_object.c
+@@ -645,11 +645,9 @@ void rxrpc_put_call(struct rxrpc_call *call, enum rxrpc_call_trace why)
+ 	if (dead) {
+ 		ASSERTCMP(__rxrpc_call_state(call), ==, RXRPC_CALL_COMPLETE);
+ 
+-		if (!list_empty(&call->link)) {
+-			spin_lock(&rxnet->call_lock);
+-			list_del_init(&call->link);
+-			spin_unlock(&rxnet->call_lock);
+-		}
++		spin_lock(&rxnet->call_lock);
++		list_del_rcu(&call->link);
++		spin_unlock(&rxnet->call_lock);
+ 
+ 		rxrpc_cleanup_call(call);
+ 	}
+@@ -697,6 +695,7 @@ static void rxrpc_destroy_call(struct work_struct *work)
+ 	rxrpc_put_bundle(call->bundle, rxrpc_bundle_put_call);
+ 	rxrpc_put_peer(call->peer, rxrpc_peer_put_call);
+ 	rxrpc_put_local(call->local, rxrpc_local_put_call);
++	key_put(call->key);
+ 	call_rcu(&call->rcu, rxrpc_rcu_free_call);
+ }
+ 
+@@ -733,24 +732,20 @@ void rxrpc_destroy_all_calls(struct rxrpc_net *rxnet)
+ 	_enter("");
+ 
+ 	if (!list_empty(&rxnet->calls)) {
+-		spin_lock(&rxnet->call_lock);
++		int shown = 0;
+ 
+-		while (!list_empty(&rxnet->calls)) {
+-			call = list_entry(rxnet->calls.next,
+-					  struct rxrpc_call, link);
+-			_debug("Zapping call %p", call);
++		spin_lock(&rxnet->call_lock);
+ 
+-			rxrpc_see_call(call, rxrpc_call_see_zap);
+-			list_del_init(&call->link);
++		list_for_each_entry(call, &rxnet->calls, link) {
++			rxrpc_see_call(call, rxrpc_call_see_still_live);
+ 
+ 			pr_err("Call %p still in use (%d,%s,%lx,%lx)!\n",
+ 			       call, refcount_read(&call->ref),
+ 			       rxrpc_call_states[__rxrpc_call_state(call)],
+ 			       call->flags, call->events);
+ 
+-			spin_unlock(&rxnet->call_lock);
+-			cond_resched();
+-			spin_lock(&rxnet->call_lock);
++			if (++shown >= 10)
++				break;
+ 		}
+ 
+ 		spin_unlock(&rxnet->call_lock);
+diff --git a/net/rxrpc/io_thread.c b/net/rxrpc/io_thread.c
+index d7e72bae4d2b2c..0491f2bbf61e08 100644
+--- a/net/rxrpc/io_thread.c
++++ b/net/rxrpc/io_thread.c
+@@ -389,7 +389,8 @@ static int rxrpc_input_packet_on_conn(struct rxrpc_connection *conn,
+ 
+ 	if (sp->hdr.callNumber > chan->call_id) {
+ 		if (rxrpc_to_client(sp)) {
+-			rxrpc_put_call(call, rxrpc_call_put_input);
++			if (call)
++				rxrpc_put_call(call, rxrpc_call_put_input);
+ 			return rxrpc_protocol_error(skb,
+ 						    rxrpc_eproto_unexpected_implicit_end);
+ 		}
+diff --git a/net/rxrpc/key.c b/net/rxrpc/key.c
+index 33e8302a79e331..2396eecf13110b 100644
+--- a/net/rxrpc/key.c
++++ b/net/rxrpc/key.c
+@@ -452,7 +452,7 @@ int rxrpc_request_key(struct rxrpc_sock *rx, sockptr_t optval, int optlen)
+ 
+ 	_enter("");
+ 
+-	if (optlen <= 0 || optlen > PAGE_SIZE - 1 || rx->securities)
++	if (optlen <= 0 || optlen > PAGE_SIZE - 1 || rx->key)
+ 		return -EINVAL;
+ 
+ 	description = memdup_sockptr_nul(optval, optlen);
+diff --git a/net/rxrpc/rxkad.c b/net/rxrpc/rxkad.c
+index e3c99a016f8c4a..149939d19b0049 100644
+--- a/net/rxrpc/rxkad.c
++++ b/net/rxrpc/rxkad.c
+@@ -189,6 +189,7 @@ static int rxkad_prime_packet_security(struct rxrpc_connection *conn,
+ 	struct rxrpc_crypt iv;
+ 	__be32 *tmpbuf;
+ 	size_t tmpsize = 4 * sizeof(__be32);
++	int ret;
+ 
+ 	_enter("");
+ 
+@@ -217,13 +218,13 @@ static int rxkad_prime_packet_security(struct rxrpc_connection *conn,
+ 	skcipher_request_set_sync_tfm(req, ci);
+ 	skcipher_request_set_callback(req, 0, NULL, NULL);
+ 	skcipher_request_set_crypt(req, &sg, &sg, tmpsize, iv.x);
+-	crypto_skcipher_encrypt(req);
++	ret = crypto_skcipher_encrypt(req);
+ 	skcipher_request_free(req);
+ 
+ 	memcpy(&conn->rxkad.csum_iv, tmpbuf + 2, sizeof(conn->rxkad.csum_iv));
+ 	kfree(tmpbuf);
+-	_leave(" = 0");
+-	return 0;
++	_leave(" = %d", ret);
++	return ret;
+ }
+ 
+ /*
+@@ -256,6 +257,7 @@ static int rxkad_secure_packet_auth(const struct rxrpc_call *call,
+ 	struct scatterlist sg;
+ 	size_t pad;
+ 	u16 check;
++	int ret;
+ 
+ 	_enter("");
+ 
+@@ -278,11 +280,11 @@ static int rxkad_secure_packet_auth(const struct rxrpc_call *call,
+ 	skcipher_request_set_sync_tfm(req, call->conn->rxkad.cipher);
+ 	skcipher_request_set_callback(req, 0, NULL, NULL);
+ 	skcipher_request_set_crypt(req, &sg, &sg, 8, iv.x);
+-	crypto_skcipher_encrypt(req);
++	ret = crypto_skcipher_encrypt(req);
+ 	skcipher_request_zero(req);
+ 
+-	_leave(" = 0");
+-	return 0;
++	_leave(" = %d", ret);
++	return ret;
+ }
+ 
+ /*
+@@ -340,7 +342,7 @@ static int rxkad_secure_packet(struct rxrpc_call *call, struct rxrpc_txbuf *txb)
+ 	union {
+ 		__be32 buf[2];
+ 	} crypto __aligned(8);
+-	u32 x, y;
++	u32 x, y = 0;
+ 	int ret;
+ 
+ 	_enter("{%d{%x}},{#%u},%u,",
+@@ -371,8 +373,10 @@ static int rxkad_secure_packet(struct rxrpc_call *call, struct rxrpc_txbuf *txb)
+ 	skcipher_request_set_sync_tfm(req, call->conn->rxkad.cipher);
+ 	skcipher_request_set_callback(req, 0, NULL, NULL);
+ 	skcipher_request_set_crypt(req, &sg, &sg, 8, iv.x);
+-	crypto_skcipher_encrypt(req);
++	ret = crypto_skcipher_encrypt(req);
+ 	skcipher_request_zero(req);
++	if (ret < 0)
++		goto out;
+ 
+ 	y = ntohl(crypto.buf[1]);
+ 	y = (y >> 16) & 0xffff;
+@@ -395,6 +399,7 @@ static int rxkad_secure_packet(struct rxrpc_call *call, struct rxrpc_txbuf *txb)
+ 		break;
+ 	}
+ 
++out:
+ 	skcipher_request_free(req);
+ 	_leave(" = %d [set %x]", ret, y);
+ 	return ret;
+@@ -435,8 +440,10 @@ static int rxkad_verify_packet_1(struct rxrpc_call *call, struct sk_buff *skb,
+ 	skcipher_request_set_sync_tfm(req, call->conn->rxkad.cipher);
+ 	skcipher_request_set_callback(req, 0, NULL, NULL);
+ 	skcipher_request_set_crypt(req, sg, sg, 8, iv.x);
+-	crypto_skcipher_decrypt(req);
++	ret = crypto_skcipher_decrypt(req);
+ 	skcipher_request_zero(req);
++	if (ret < 0)
++		return ret;
+ 
+ 	/* Extract the decrypted packet length */
+ 	if (skb_copy_bits(skb, sp->offset, &sechdr, sizeof(sechdr)) < 0)
+@@ -513,10 +520,14 @@ static int rxkad_verify_packet_2(struct rxrpc_call *call, struct sk_buff *skb,
+ 	skcipher_request_set_sync_tfm(req, call->conn->rxkad.cipher);
+ 	skcipher_request_set_callback(req, 0, NULL, NULL);
+ 	skcipher_request_set_crypt(req, sg, sg, sp->len, iv.x);
+-	crypto_skcipher_decrypt(req);
++	ret = crypto_skcipher_decrypt(req);
+ 	skcipher_request_zero(req);
+ 	if (sg != _sg)
+ 		kfree(sg);
++	if (ret < 0) {
++		WARN_ON_ONCE(ret != -ENOMEM);
++		return ret;
++	}
+ 
+ 	/* Extract the decrypted packet length */
+ 	if (skb_copy_bits(skb, sp->offset, &sechdr, sizeof(sechdr)) < 0)
+@@ -584,8 +595,10 @@ static int rxkad_verify_packet(struct rxrpc_call *call, struct sk_buff *skb)
+ 	skcipher_request_set_sync_tfm(req, call->conn->rxkad.cipher);
+ 	skcipher_request_set_callback(req, 0, NULL, NULL);
+ 	skcipher_request_set_crypt(req, &sg, &sg, 8, iv.x);
+-	crypto_skcipher_encrypt(req);
++	ret = crypto_skcipher_encrypt(req);
+ 	skcipher_request_zero(req);
++	if (ret < 0)
++		goto out;
+ 
+ 	y = ntohl(crypto.buf[1]);
+ 	cksum = (y >> 16) & 0xffff;
+@@ -869,6 +882,7 @@ static int rxkad_decrypt_ticket(struct rxrpc_connection *conn,
+ 	struct in_addr addr;
+ 	unsigned int life;
+ 	time64_t issue, now;
++	int ret;
+ 	bool little_endian;
+ 	u8 *p, *q, *name, *end;
+ 
+@@ -888,8 +902,11 @@ static int rxkad_decrypt_ticket(struct rxrpc_connection *conn,
+ 	sg_init_one(&sg[0], ticket, ticket_len);
+ 	skcipher_request_set_callback(req, 0, NULL, NULL);
+ 	skcipher_request_set_crypt(req, sg, sg, ticket_len, iv.x);
+-	crypto_skcipher_decrypt(req);
++	ret = crypto_skcipher_decrypt(req);
+ 	skcipher_request_free(req);
++	if (ret < 0)
++		return rxrpc_abort_conn(conn, skb, RXKADBADTICKET, -EPROTO,
++					rxkad_abort_resp_tkt_short);
+ 
+ 	p = ticket;
+ 	end = p + ticket_len;
+@@ -984,21 +1001,23 @@ static int rxkad_decrypt_ticket(struct rxrpc_connection *conn,
+ /*
+  * decrypt the response packet
+  */
+-static void rxkad_decrypt_response(struct rxrpc_connection *conn,
+-				   struct rxkad_response *resp,
+-				   const struct rxrpc_crypt *session_key)
++static int rxkad_decrypt_response(struct rxrpc_connection *conn,
++				  struct rxkad_response *resp,
++				  const struct rxrpc_crypt *session_key)
+ {
+ 	struct skcipher_request *req = rxkad_ci_req;
+ 	struct scatterlist sg[1];
+ 	struct rxrpc_crypt iv;
++	int ret;
+ 
+ 	_enter(",,%08x%08x",
+ 	       ntohl(session_key->n[0]), ntohl(session_key->n[1]));
+ 
+ 	mutex_lock(&rxkad_ci_mutex);
+-	if (crypto_sync_skcipher_setkey(rxkad_ci, session_key->x,
+-					sizeof(*session_key)) < 0)
+-		BUG();
++	ret = crypto_sync_skcipher_setkey(rxkad_ci, session_key->x,
++					  sizeof(*session_key));
++	if (ret < 0)
++		goto unlock;
+ 
+ 	memcpy(&iv, session_key, sizeof(iv));
+ 
+@@ -1007,12 +1026,14 @@ static void rxkad_decrypt_response(struct rxrpc_connection *conn,
+ 	skcipher_request_set_sync_tfm(req, rxkad_ci);
+ 	skcipher_request_set_callback(req, 0, NULL, NULL);
+ 	skcipher_request_set_crypt(req, sg, sg, sizeof(resp->encrypted), iv.x);
+-	crypto_skcipher_decrypt(req);
++	ret = crypto_skcipher_decrypt(req);
+ 	skcipher_request_zero(req);
+ 
++unlock:
+ 	mutex_unlock(&rxkad_ci_mutex);
+ 
+ 	_leave("");
++	return ret;
+ }
+ 
+ /*
+@@ -1105,7 +1126,9 @@ static int rxkad_verify_response(struct rxrpc_connection *conn,
+ 
+ 	/* use the session key from inside the ticket to decrypt the
+ 	 * response */
+-	rxkad_decrypt_response(conn, response, &session_key);
++	ret = rxkad_decrypt_response(conn, response, &session_key);
++	if (ret < 0)
++		goto temporary_error_free_ticket;
+ 
+ 	if (ntohl(response->encrypted.epoch) != conn->proto.epoch ||
+ 	    ntohl(response->encrypted.cid) != conn->proto.cid ||
+diff --git a/net/rxrpc/server_key.c b/net/rxrpc/server_key.c
+index e51940589ee546..9d95a6055b707b 100644
+--- a/net/rxrpc/server_key.c
++++ b/net/rxrpc/server_key.c
+@@ -125,6 +125,9 @@ int rxrpc_server_keyring(struct rxrpc_sock *rx, sockptr_t optval, int optlen)
+ 
+ 	_enter("");
+ 
++	if (rx->securities)
++		return -EINVAL;
++
+ 	if (optlen <= 0 || optlen > PAGE_SIZE - 1)
+ 		return -EINVAL;
+ 
+diff --git a/net/tipc/group.c b/net/tipc/group.c
+index 3e137d8c9d2ff5..215f2a7d84588a 100644
+--- a/net/tipc/group.c
++++ b/net/tipc/group.c
+@@ -746,6 +746,7 @@ void tipc_group_proto_rcv(struct tipc_group *grp, bool *usr_wakeup,
+ 	u32 port = msg_origport(hdr);
+ 	struct tipc_member *m, *pm;
+ 	u16 remitted, in_flight;
++	u16 acked;
+ 
+ 	if (!grp)
+ 		return;
+@@ -798,7 +799,10 @@ void tipc_group_proto_rcv(struct tipc_group *grp, bool *usr_wakeup,
+ 	case GRP_ACK_MSG:
+ 		if (!m)
+ 			return;
+-		m->bc_acked = msg_grp_bc_acked(hdr);
++		acked = msg_grp_bc_acked(hdr);
++		if (less_eq(acked, m->bc_acked))
++			return;
++		m->bc_acked = acked;
+ 		if (--grp->bc_ackers)
+ 			return;
+ 		list_del_init(&m->small_win);
+diff --git a/net/tls/tls_sw.c b/net/tls/tls_sw.c
+index dc57b31a5fe5c0..d86a487065e925 100644
+--- a/net/tls/tls_sw.c
++++ b/net/tls/tls_sw.c
+@@ -584,6 +584,16 @@ static int tls_do_encryption(struct sock *sk,
+ 	if (rc == -EBUSY) {
+ 		rc = tls_encrypt_async_wait(ctx);
+ 		rc = rc ?: -EINPROGRESS;
++		/*
++		 * The async callback tls_encrypt_done() has already
++		 * decremented encrypt_pending and restored the sge on
++		 * both success and error. Skip the synchronous cleanup
++		 * below on error, just remove the record and return.
++		 */
++		if (rc != -EINPROGRESS) {
++			list_del(&rec->list);
++			return rc;
++		}
+ 	}
+ 	if (!rc || rc != -EINPROGRESS) {
+ 		atomic_dec(&ctx->encrypt_pending);
+diff --git a/net/xfrm/xfrm_user.c b/net/xfrm/xfrm_user.c
+index 5b3ab4532aec29..74bee718573db2 100644
+--- a/net/xfrm/xfrm_user.c
++++ b/net/xfrm/xfrm_user.c
+@@ -3583,6 +3583,8 @@ static int build_polexpire(struct sk_buff *skb, struct xfrm_policy *xp,
+ 		return err;
+ 	}
+ 	upe->hard = !!hard;
++	/* clear the padding bytes */
++	memset_after(upe, 0, hard);
+ 
+ 	nlmsg_end(skb, nlh);
+ 	return 0;
+@@ -3740,6 +3742,7 @@ static int build_report(struct sk_buff *skb, u8 proto,
+ 		return -EMSGSIZE;
+ 
+ 	ur = nlmsg_data(nlh);
++	memset(ur, 0, sizeof(*ur));
+ 	ur->proto = proto;
+ 	memcpy(&ur->sel, sel, sizeof(ur->sel));
+ 
+diff --git a/sound/soc/generic/simple-card-utils.c b/sound/soc/generic/simple-card-utils.c
+index 86ccd044b93c46..a64484fe5a2840 100644
+--- a/sound/soc/generic/simple-card-utils.c
++++ b/sound/soc/generic/simple-card-utils.c
+@@ -1061,6 +1061,7 @@ static int graph_get_dai_id(struct device_node *ep)
+ int asoc_graph_parse_dai(struct device *dev, struct device_node *ep,
+ 			 struct snd_soc_dai_link_component *dlc, int *is_single_link)
+ {
++	struct device_node *node;
+ 	struct of_phandle_args args = {};
+ 	struct snd_soc_dai *dai;
+ 	int ret;
+@@ -1068,7 +1069,7 @@ int asoc_graph_parse_dai(struct device *dev, struct device_node *ep,
+ 	if (!ep)
+ 		return 0;
+ 
+-	struct device_node *node __free(device_node) = of_graph_get_port_parent(ep);
++	node = of_graph_get_port_parent(ep);
+ 
+ 	/*
+ 	 * Try to find from DAI node
+@@ -1110,8 +1111,10 @@ int asoc_graph_parse_dai(struct device *dev, struct device_node *ep,
+ 	 *    if he unbinded CPU or Codec.
+ 	 */
+ 	ret = snd_soc_get_dlc(&args, dlc);
+-	if (ret < 0)
++	if (ret < 0) {
++		of_node_put(node);
+ 		return ret;
++	}
+ 
+ parse_dai_end:
+ 	if (is_single_link)


### PR DESCRIPTION
# Description

Update odroidxu4-current kernel to 6.6.135.

# How Has This Been Tested?

- [x] Warm reboot of my Odroid HC1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system stability across multiple processor architectures
  * Enhanced security validation in file-descriptor operations
  * Fixed resource management issues in device drivers
  * Resolved compatibility issues affecting storage, networking, and graphics subsystems

* **Chores**
  * Updated Linux kernel from v6.6.131 to v6.6.135

<!-- end of auto-generated comment: release notes by coderabbit.ai -->