### PR TITLE
radxa-aic8800: Use gcc-14 for Noble release

### DIFF
--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -48,6 +48,11 @@ function post_install_kernel_debs__install_aic8800_dkms_package() {
 	esac
 	use_clean_environment="yes" chroot_sdcard "wget ${aic8800_firmware_url} -P /tmp"
 	display_alert "Install aic8800 packages, will build kernel module in chroot" "${EXTENSION}" "info"
+	if [[ "${RELEASE}" == "noble" ]]; then
+		display_alert "Installing gcc-14 for DKMS build" "${EXTENSION}" "info"
+		use_clean_environment="yes" chroot_sdcard_apt_get_install "gcc-14"
+		use_clean_environment="yes" chroot_sdcard "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100"
+	fi
 	declare -ag if_error_find_files_sdcard=("/var/lib/dkms/aic8800*/*/build/*.log")
 	use_clean_environment="yes" chroot_sdcard_apt_get_install "/tmp/${aic8800_dkms_file_name} /tmp/aic8800-firmware_${latest_version}_all.deb"
 	use_clean_environment="yes" chroot_sdcard "rm -f /tmp/aic8800*.deb"


### PR DESCRIPTION
# Description

Fixes: `gcc: error: unrecognized command-line option '-fmin-function-alignment=8';`

Solves: #9519

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AIC8800 driver installation and build compatibility issues specific to Noble releases.
  * Improved the pre-installation setup by properly configuring the build environment to better support driver compilation.
  * Enhanced overall compatibility with newer Ubuntu releases to ensure successful installation for all affected users on modern systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->