### PR TITLE
mvebu: edge → 6.18 LTS family-wide + restore 4 patches lost in #6135

### DIFF
--- a/config/sources/families/mvebu.conf
+++ b/config/sources/families/mvebu.conf
@@ -31,11 +31,7 @@ case $BRANCH in
 
 	edge)
 
-		if [[ $BOARD == helios4 ]]; then
-			declare -g KERNEL_MAJOR_MINOR="6.18" # helios4: 6.18 LTS, restore orphaned mvebu patches
-		else
-			declare -g KERNEL_MAJOR_MINOR="6.15" # Major and minor versions of this kernel.
-		fi
+		declare -g KERNEL_MAJOR_MINOR="6.18" # 6.18 LTS, restore orphaned mvebu patches
 		;;
 
 esac

--- a/patch/kernel/archive/mvebu-6.18/0001-cpuidle-mvebu-indicate-failure-to-enter-deeper-sleep.patch
+++ b/patch/kernel/archive/mvebu-6.18/0001-cpuidle-mvebu-indicate-failure-to-enter-deeper-sleep.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Fri, 8 Jan 2016 17:03:44 +0100
+Subject: [ARCHEOLOGY] Patches for Marvell Armada, kernel 4.3 and 4.4
+
+> X-Git-Archeology: > recovered message: > Credits: Russell King http://www.home.arm.linux.org.uk/~rmk/clearfog/
+> X-Git-Archeology: - Revision 06fe0ffe8e197c58ca9d2d919b050311e6a05411: https://github.com/armbian/build/commit/06fe0ffe8e197c58ca9d2d919b050311e6a05411
+> X-Git-Archeology:   Date: Fri, 08 Jan 2016 17:03:44 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Patches for Marvell Armada, kernel 4.3 and 4.4
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 68a6849497488aa8b9f1486c4f13ce4353c8cd53: https://github.com/armbian/build/commit/68a6849497488aa8b9f1486c4f13ce4353c8cd53
+> X-Git-Archeology:   Date: Wed, 03 Feb 2016 20:54:28 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Marvel patches move from one dir to another, small fixes
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision baab6587a50fbc75c7b593110db50796166d9648: https://github.com/armbian/build/commit/baab6587a50fbc75c7b593110db50796166d9648
+> X-Git-Archeology:   Date: Fri, 09 Dec 2016 21:09:22 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Refactor Marvell kernel sources
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e31425190fa09431c96067ab7371d72a9852e282: https://github.com/armbian/build/commit/e31425190fa09431c96067ab7371d72a9852e282
+> X-Git-Archeology:   Date: Fri, 17 Aug 2018 09:17:19 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Move MVEBU, Clearfog & Helios4, DEVelopment branch to 4.18.y ... removed only obviously unneded patches, while the rest needs some/a lot of rework to meet current NEXT levels. http://ix.io/1kpE Tested also without our patchset - severe problems on network stack.
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e261c6f82835bd9b12e07ba837b55fbf1aaa4327: https://github.com/armbian/build/commit/e261c6f82835bd9b12e07ba837b55fbf1aaa4327
+> X-Git-Archeology:   Date: Wed, 31 Jul 2019 12:51:00 +0200
+> X-Git-Archeology:   From: Aditya Prayoga <aprayoga@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move mvebu DEFAULT, NEXT and DEV branch to next kernel (LTS) and U-boot #1426 (#1487)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 150ac0c2afa147d9e3b036c8ecd8238fe5648cf3: https://github.com/armbian/build/commit/150ac0c2afa147d9e3b036c8ecd8238fe5648cf3
+> X-Git-Archeology:   Date: Tue, 19 Nov 2019 23:25:39 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Remove K<4, change branches, new features (#1586)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision aa3d60f57e84d02887c63cae176bdec96b560e38: https://github.com/armbian/build/commit/aa3d60f57e84d02887c63cae176bdec96b560e38
+> X-Git-Archeology:   Date: Thu, 10 Dec 2020 11:47:33 +0100
+> X-Git-Archeology:   From: Rosen Penev <rosenp@gmail.com>
+> X-Git-Archeology:   Subject: refreshed mvebu with quilt (#2419)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5b1c1c2897a570c173c40204e98257b2dd7a74c9: https://github.com/armbian/build/commit/5b1c1c2897a570c173c40204e98257b2dd7a74c9
+> X-Git-Archeology:   Date: Thu, 04 Jan 2024 00:06:37 +0530
+> X-Git-Archeology:   From: Lane Jennison <lane@lane-fu.com>
+> X-Git-Archeology:   Subject: mvebu-edge: move to 6.6.y
+> X-Git-Archeology:
+---
+ drivers/cpuidle/cpuidle-mvebu-v7.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/cpuidle/cpuidle-mvebu-v7.c b/drivers/cpuidle/cpuidle-mvebu-v7.c
+index 111111111111..222222222222 100644
+--- a/drivers/cpuidle/cpuidle-mvebu-v7.c
++++ b/drivers/cpuidle/cpuidle-mvebu-v7.c
+@@ -42,8 +42,12 @@ static __cpuidle int mvebu_v7_enter_idle(struct cpuidle_device *dev,
+ 
+ 	cpu_pm_exit();
+ 
++	/*
++	 * If we failed to enter the desired state, indicate that we
++	 * slept lightly.
++	 */
+ 	if (ret)
+-		return ret;
++		return 0;
+ 
+ 	return index;
+ }
+-- 
+Armbian
+

--- a/patch/kernel/archive/mvebu-6.18/10-mvebu-clearfog-pcie-updates.patch
+++ b/patch/kernel/archive/mvebu-6.18/10-mvebu-clearfog-pcie-updates.patch
@@ -1,0 +1,196 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Russell King <rmk+kernel@arm.linux.org.uk>
+Date: Tue, 29 Nov 2016 10:13:46 +0000
+Subject: mvebu/clearfog pcie updates
+
+Signed-off-by: Russell King <rmk+kernel@arm.linux.org.uk>
+---
+ drivers/pci/controller/pci-mvebu.c | 76 ++++++++++
+ drivers/pci/pci-bridge-emul.c      |  2 +
+ drivers/pci/pcie/aspm.c            |  6 +
+ drivers/pci/pcie/portdrv.c         |  2 +
+ 4 files changed, 86 insertions(+)
+
+diff --git a/drivers/pci/controller/pci-mvebu.c b/drivers/pci/controller/pci-mvebu.c
+index 111111111111..222222222222 100644
+--- a/drivers/pci/controller/pci-mvebu.c
++++ b/drivers/pci/controller/pci-mvebu.c
+@@ -60,6 +60,12 @@
+ #define  PCIE_INT_INTX(i)		BIT(24+i)
+ #define  PCIE_INT_PM_PME		BIT(28)
+ #define  PCIE_INT_ALL_MASK		GENMASK(31, 0)
++#define  PCIE_MASK_ERR_COR		BIT(18)
++#define  PCIE_MASK_ERR_NONFATAL		BIT(17)
++#define  PCIE_MASK_ERR_FATAL		BIT(16)
++#define  PCIE_MASK_FERR_DET		BIT(10)
++#define  PCIE_MASK_NFERR_DET		BIT(9)
++#define  PCIE_MASK_CORERR_DET		BIT(8)
+ #define PCIE_CTRL_OFF		0x1a00
+ #define  PCIE_CTRL_X1_MODE		0x0001
+ #define  PCIE_CTRL_RC_MODE		BIT(1)
+@@ -618,6 +624,54 @@ mvebu_pci_bridge_emul_base_conf_read(struct pci_bridge_emul *bridge,
+ 	return PCI_BRIDGE_EMUL_HANDLED;
+ }
+ 
++static void mvebu_pcie_handle_irq_change(struct mvebu_pcie_port *port)
++{
++	u32 reg, old;
++	u16 devctl, rtctl;
++
++	/*
++	 * Errors from downstream devices:
++	 *  bridge control register SERR: enables reception of errors
++	 * Errors from this device, or received errors:
++	 *  command SERR: enables ERR_NONFATAL and ERR_FATAL messages
++	 *   => when enabled, these conditions also flag SERR in status register
++	 *  devctl CERE: enables ERR_CORR messages
++	 *  devctl NFERE: enables ERR_NONFATAL messages
++	 *  devctl FERE: enables ERR_FATAL messages
++	 * Enabled messages then have three paths:
++	 *  1. rtctl: enables system error indication
++	 *  2. root error status register updated
++	 *  3. root error command register: forwarding via MSI
++	 */
++	old = mvebu_readl(port, PCIE_INT_UNMASK_OFF);
++	reg = old & ~(PCIE_INT_PM_PME | PCIE_MASK_FERR_DET |
++		      PCIE_MASK_NFERR_DET | PCIE_MASK_CORERR_DET |
++		      PCIE_MASK_ERR_COR | PCIE_MASK_ERR_NONFATAL |
++		      PCIE_MASK_ERR_FATAL);
++
++	devctl = port->bridge.pcie_conf.devctl;
++	if (devctl & PCI_EXP_DEVCTL_FERE)
++		reg |= PCIE_MASK_FERR_DET | PCIE_MASK_ERR_FATAL;
++	if (devctl & PCI_EXP_DEVCTL_NFERE)
++		reg |= PCIE_MASK_NFERR_DET | PCIE_MASK_ERR_NONFATAL;
++	if (devctl & PCI_EXP_DEVCTL_CERE)
++		reg |= PCIE_MASK_CORERR_DET | PCIE_MASK_ERR_COR;
++	if (port->bridge.conf.command & PCI_COMMAND_SERR)
++		reg |= PCIE_MASK_FERR_DET | PCIE_MASK_NFERR_DET |
++		       PCIE_MASK_ERR_FATAL | PCIE_MASK_ERR_NONFATAL;
++
++	if (!(port->bridge.conf.bridgectrl & PCI_BRIDGE_CTL_SERR))
++		reg &= ~(PCIE_MASK_ERR_COR | PCIE_MASK_ERR_NONFATAL |
++			 PCIE_MASK_ERR_FATAL);
++
++	rtctl = port->bridge.pcie_conf.rootctl;
++	if (rtctl & PCI_EXP_RTCTL_PMEIE)
++		reg |= PCIE_INT_PM_PME;
++
++	if (old != reg)
++		mvebu_writel(port, reg, PCIE_INT_UNMASK_OFF);
++}
++
+ static pci_bridge_emul_read_status_t
+ mvebu_pci_bridge_emul_pcie_conf_read(struct pci_bridge_emul *bridge,
+ 				     int reg, u32 *value)
+@@ -734,6 +788,9 @@ mvebu_pci_bridge_emul_base_conf_write(struct pci_bridge_emul *bridge,
+ 	switch (reg) {
+ 	case PCI_COMMAND:
+ 		mvebu_writel(port, new, PCIE_CMD_OFF);
++
++		if ((old ^ new) & PCI_COMMAND_SERR)
++			mvebu_pcie_handle_irq_change(port);
+ 		break;
+ 
+ 	case PCI_IO_BASE:
+@@ -775,6 +832,8 @@ mvebu_pci_bridge_emul_base_conf_write(struct pci_bridge_emul *bridge,
+ 		break;
+ 
+ 	case PCI_INTERRUPT_LINE:
++		if (((old ^ new) >> 16) & PCI_BRIDGE_CTL_SERR)
++			mvebu_pcie_handle_irq_change(port);
+ 		if (mask & (PCI_BRIDGE_CTL_BUS_RESET << 16)) {
+ 			u32 ctrl = mvebu_readl(port, PCIE_CTRL_OFF);
+ 			if (new & (PCI_BRIDGE_CTL_BUS_RESET << 16))
+@@ -798,7 +857,18 @@ mvebu_pci_bridge_emul_pcie_conf_write(struct pci_bridge_emul *bridge,
+ 
+ 	switch (reg) {
+ 	case PCI_EXP_DEVCTL:
++		/*
++		 * Armada370 data says these bits must always
++		 * be zero when in root complex mode.
++		 */
++		new &= ~(PCI_EXP_DEVCTL_URRE | PCI_EXP_DEVCTL_FERE |
++			 PCI_EXP_DEVCTL_NFERE | PCI_EXP_DEVCTL_CERE);
++
+ 		mvebu_writel(port, new, PCIE_CAP_PCIEXP + PCI_EXP_DEVCTL);
++
++		if ((new ^ old) & (PCI_EXP_DEVCTL_FERE | PCI_EXP_DEVCTL_NFERE |
++				   PCI_EXP_DEVCTL_CERE | PCI_EXP_DEVCTL_URRE))
++			mvebu_pcie_handle_irq_change(port);
+ 		break;
+ 
+ 	case PCI_EXP_LNKCTL:
+@@ -849,6 +919,12 @@ mvebu_pci_bridge_emul_pcie_conf_write(struct pci_bridge_emul *bridge,
+ 
+ 	default:
+ 		break;
++
++	case PCI_EXP_RTCTL:
++		if ((new ^ old) & (PCI_EXP_RTCTL_SECEE | PCI_EXP_RTCTL_SENFEE |
++				   PCI_EXP_RTCTL_SEFEE | PCI_EXP_RTCTL_PMEIE))
++			mvebu_pcie_handle_irq_change(port);
++		break;
+ 	}
+ }
+ 
+diff --git a/drivers/pci/pci-bridge-emul.c b/drivers/pci/pci-bridge-emul.c
+index 111111111111..222222222222 100644
+--- a/drivers/pci/pci-bridge-emul.c
++++ b/drivers/pci/pci-bridge-emul.c
+@@ -157,6 +157,7 @@ struct pci_bridge_reg_behavior pci_regs_behavior[PCI_STD_HEADER_SIZEOF / 4] = {
+ 		.rw = (GENMASK(7, 0) |
+ 		       ((PCI_BRIDGE_CTL_PARITY |
+ 			 PCI_BRIDGE_CTL_SERR |
++			 /* NOTE: PCIe does not allow ISA, VGA, MASTER_ABORT */
+ 			 PCI_BRIDGE_CTL_ISA |
+ 			 PCI_BRIDGE_CTL_VGA |
+ 			 PCI_BRIDGE_CTL_MASTER_ABORT |
+@@ -355,6 +356,7 @@ int pci_bridge_emul_init(struct pci_bridge_emul *bridge,
+ 	bridge->conf.header_type = PCI_HEADER_TYPE_BRIDGE;
+ 	bridge->conf.cache_line_size = 0x10;
+ 	bridge->conf.status = cpu_to_le16(PCI_STATUS_CAP_LIST);
++	bridge->conf.bridgectrl = cpu_to_le16(PCI_BRIDGE_CTL_SERR);
+ 	bridge->pci_regs_behavior = kmemdup(pci_regs_behavior,
+ 					    sizeof(pci_regs_behavior),
+ 					    GFP_KERNEL);
+diff --git a/drivers/pci/pcie/aspm.c b/drivers/pci/pcie/aspm.c
+index 111111111111..222222222222 100644
+--- a/drivers/pci/pcie/aspm.c
++++ b/drivers/pci/pcie/aspm.c
+@@ -617,6 +617,12 @@ static void pcie_aspm_cap_init(struct pcie_link_state *link, int blacklist)
+ 	pcie_capability_read_dword(child, PCI_EXP_LNKCAP, &child_lnkcap);
+ 	pcie_capability_read_word(parent, PCI_EXP_LNKCTL, &parent_lnkctl);
+ 	pcie_capability_read_word(child, PCI_EXP_LNKCTL, &child_lnkctl);
++dev_info(&parent->dev, "up support %x enabled %x\n",
++	 (parent_lnkcap & PCI_EXP_LNKCAP_ASPMS) >> 10,
++	 !!(parent_lnkctl & PCI_EXP_LNKCTL_ASPMC));
++dev_info(&parent->dev, "dn support %x enabled %x\n",
++	 (child_lnkcap & PCI_EXP_LNKCAP_ASPMS) >> 10,
++	 !!(child_lnkctl & PCI_EXP_LNKCTL_ASPMC));
+ 
+ 	/*
+ 	 * Setup L0s state
+diff --git a/drivers/pci/pcie/portdrv.c b/drivers/pci/pcie/portdrv.c
+index 111111111111..222222222222 100644
+--- a/drivers/pci/pcie/portdrv.c
++++ b/drivers/pci/pcie/portdrv.c
+@@ -335,6 +335,7 @@ static int pcie_port_device_register(struct pci_dev *dev)
+ 
+ 	/* Get and check PCI Express port services */
+ 	capabilities = get_port_device_capability(dev);
++dev_info(&dev->dev, "PCIe capabilities: 0x%x\n", capabilities);
+ 	if (!capabilities)
+ 		return 0;
+ 
+@@ -347,6 +348,7 @@ static int pcie_port_device_register(struct pci_dev *dev)
+ 	 * if that is to be used.
+ 	 */
+ 	status = pcie_init_service_irqs(dev, irqs, capabilities);
++dev_info(&dev->dev, "init_service_irqs: %d\n", status);
+ 	if (status) {
+ 		capabilities &= PCIE_PORT_SERVICE_HP;
+ 		if (!capabilities)
+-- 
+Armbian
+

--- a/patch/kernel/archive/mvebu-6.18/10-mvebu-clearfog-pcie-updates.patch
+++ b/patch/kernel/archive/mvebu-6.18/10-mvebu-clearfog-pcie-updates.patch
@@ -7,9 +7,7 @@ Signed-off-by: Russell King <rmk+kernel@arm.linux.org.uk>
 ---
  drivers/pci/controller/pci-mvebu.c | 76 ++++++++++
  drivers/pci/pci-bridge-emul.c      |  2 +
- drivers/pci/pcie/aspm.c            |  6 +
- drivers/pci/pcie/portdrv.c         |  2 +
- 4 files changed, 86 insertions(+)
+ 2 files changed, 78 insertions(+)
 
 diff --git a/drivers/pci/controller/pci-mvebu.c b/drivers/pci/controller/pci-mvebu.c
 index 111111111111..222222222222 100644
@@ -154,43 +152,6 @@ index 111111111111..222222222222 100644
  	bridge->pci_regs_behavior = kmemdup(pci_regs_behavior,
  					    sizeof(pci_regs_behavior),
  					    GFP_KERNEL);
-diff --git a/drivers/pci/pcie/aspm.c b/drivers/pci/pcie/aspm.c
-index 111111111111..222222222222 100644
---- a/drivers/pci/pcie/aspm.c
-+++ b/drivers/pci/pcie/aspm.c
-@@ -617,6 +617,12 @@ static void pcie_aspm_cap_init(struct pcie_link_state *link, int blacklist)
- 	pcie_capability_read_dword(child, PCI_EXP_LNKCAP, &child_lnkcap);
- 	pcie_capability_read_word(parent, PCI_EXP_LNKCTL, &parent_lnkctl);
- 	pcie_capability_read_word(child, PCI_EXP_LNKCTL, &child_lnkctl);
-+dev_info(&parent->dev, "up support %x enabled %x\n",
-+	 (parent_lnkcap & PCI_EXP_LNKCAP_ASPMS) >> 10,
-+	 !!(parent_lnkctl & PCI_EXP_LNKCTL_ASPMC));
-+dev_info(&parent->dev, "dn support %x enabled %x\n",
-+	 (child_lnkcap & PCI_EXP_LNKCAP_ASPMS) >> 10,
-+	 !!(child_lnkctl & PCI_EXP_LNKCTL_ASPMC));
- 
- 	/*
- 	 * Setup L0s state
-diff --git a/drivers/pci/pcie/portdrv.c b/drivers/pci/pcie/portdrv.c
-index 111111111111..222222222222 100644
---- a/drivers/pci/pcie/portdrv.c
-+++ b/drivers/pci/pcie/portdrv.c
-@@ -335,6 +335,7 @@ static int pcie_port_device_register(struct pci_dev *dev)
- 
- 	/* Get and check PCI Express port services */
- 	capabilities = get_port_device_capability(dev);
-+dev_info(&dev->dev, "PCIe capabilities: 0x%x\n", capabilities);
- 	if (!capabilities)
- 		return 0;
- 
-@@ -347,6 +348,7 @@ static int pcie_port_device_register(struct pci_dev *dev)
- 	 * if that is to be used.
- 	 */
- 	status = pcie_init_service_irqs(dev, irqs, capabilities);
-+dev_info(&dev->dev, "init_service_irqs: %d\n", status);
- 	if (status) {
- 		capabilities &= PCIE_PORT_SERVICE_HP;
- 		if (!capabilities)
 -- 
 Armbian
 

--- a/patch/kernel/archive/mvebu-6.18/11-implement-slot-capabilities-SSPL.patch
+++ b/patch/kernel/archive/mvebu-6.18/11-implement-slot-capabilities-SSPL.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Russell King <rmk+kernel@arm.linux.org.uk>
+Date: Tue, 29 Nov 2016 10:13:48 +0000
+Subject: implement slot capabilities (SSPL)
+
+---
+ drivers/pci/controller/pci-mvebu.c | 20 ++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/drivers/pci/controller/pci-mvebu.c b/drivers/pci/controller/pci-mvebu.c
+index 111111111111..222222222222 100644
+--- a/drivers/pci/controller/pci-mvebu.c
++++ b/drivers/pci/controller/pci-mvebu.c
+@@ -79,6 +79,7 @@
+ #define  PCIE_SSPL_VALUE_MASK		GENMASK(7, 0)
+ #define  PCIE_SSPL_SCALE_SHIFT		8
+ #define  PCIE_SSPL_SCALE_MASK		GENMASK(9, 8)
++#define  PCIE_SSPL_MSGEN		BIT(14)
+ #define  PCIE_SSPL_ENABLE		BIT(16)
+ #define PCIE_RC_RTSTA		0x1a14
+ #define PCIE_DEBUG_CTRL         0x1a60
+@@ -705,6 +706,14 @@ mvebu_pci_bridge_emul_pcie_conf_read(struct pci_bridge_emul *bridge,
+ 			  (PCI_EXP_LNKSTA_DLLLA << 16) : 0);
+ 		break;
+ 
++	case PCI_EXP_SLTCAP:
++	{
++		u32 tmp = mvebu_readl(port, PCIE_SSPL_OFF);
++		*value = FIELD_GET(PCIE_SSPL_SCALE_MASK, tmp) << 15 |
++			 FIELD_GET(PCIE_SSPL_VALUE_MASK, tmp) << 7;
++		break;
++	}
++
+ 	case PCI_EXP_SLTCTL: {
+ 		u16 slotctl = le16_to_cpu(bridge->pcie_conf.slotctl);
+ 		u16 slotsta = le16_to_cpu(bridge->pcie_conf.slotsta);
+@@ -882,6 +891,17 @@ mvebu_pci_bridge_emul_pcie_conf_write(struct pci_bridge_emul *bridge,
+ 		mvebu_writel(port, new, PCIE_CAP_PCIEXP + PCI_EXP_LNKCTL);
+ 		break;
+ 
++	case PCI_EXP_SLTCAP:
++	{
++		u32 sspl = FIELD_PREP(PCIE_SSPL_VALUE_MASK,
++				      FIELD_GET(PCI_EXP_SLTCAP_SPLV, new)) |
++			   FIELD_PREP(PCIE_SSPL_SCALE_MASK,
++				      FIELD_GET(PCI_EXP_SLTCAP_SPLS, new)) |
++			   PCIE_SSPL_MSGEN;
++		mvebu_writel(port, sspl, PCIE_SSPL_OFF);
++		break;
++	}
++
+ 	case PCI_EXP_SLTCTL:
+ 		/*
+ 		 * Allow to change PCIE_SSPL_ENABLE bit only when slot power
+-- 
+Armbian
+

--- a/patch/kernel/archive/mvebu-6.18/11-mvebu-pcie-aer-fixes.patch
+++ b/patch/kernel/archive/mvebu-6.18/11-mvebu-pcie-aer-fixes.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Velkov <325961+iav@users.noreply.github.com>
+Date: Tue, 22 Apr 2026 00:00:00 +0000
+Subject: mvebu/pcie: fix DEVCTL change detection and trim RTCTL handling
+
+Compute the relevant PCI_EXP_DEVCTL change mask before clearing the
+RC-mode forbidden bits from the local write value. Otherwise a change in
+DEVCTL.{CERE,NFERE,FERE} may be missed and the corresponding IRQ mask
+update deferred until some later config-space write.
+
+Also restrict the PCI_EXP_RTCTL-triggered IRQ mask update to PMEIE.
+mvebu_pcie_handle_irq_change() only uses rootctl.PMEIE, so reacting to
+SECEE/SENFEE/SEFEE changes only reruns the helper without affecting the
+hardware interrupt mask.
+
+---
+ drivers/pci/controller/pci-mvebu.c | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-mvebu.c b/drivers/pci/controller/pci-mvebu.c
+--- a/drivers/pci/controller/pci-mvebu.c
++++ b/drivers/pci/controller/pci-mvebu.c
+@@ -865,7 +865,11 @@
+ 	struct mvebu_pcie_port *port = bridge->data;
+
+ 	switch (reg) {
+-	case PCI_EXP_DEVCTL:
++	case PCI_EXP_DEVCTL: {
++		bool aer_changed = (new ^ old) &
++			(PCI_EXP_DEVCTL_FERE | PCI_EXP_DEVCTL_NFERE |
++			 PCI_EXP_DEVCTL_CERE | PCI_EXP_DEVCTL_URRE);
++
+ 		/*
+ 		 * Armada370 data says these bits must always
+ 		 * be zero when in root complex mode.
+@@ -875,10 +879,10 @@
+
+ 		mvebu_writel(port, new, PCIE_CAP_PCIEXP + PCI_EXP_DEVCTL);
+
+-		if ((new ^ old) & (PCI_EXP_DEVCTL_FERE | PCI_EXP_DEVCTL_NFERE |
+-				   PCI_EXP_DEVCTL_CERE | PCI_EXP_DEVCTL_URRE))
++		if (aer_changed)
+ 			mvebu_pcie_handle_irq_change(port);
+ 		break;
++	}
+
+ 	case PCI_EXP_LNKCTL:
+ 		/*
+@@ -941,8 +945,7 @@
+ 		break;
+
+ 	case PCI_EXP_RTCTL:
+-		if ((new ^ old) & (PCI_EXP_RTCTL_SECEE | PCI_EXP_RTCTL_SENFEE |
+-				   PCI_EXP_RTCTL_SEFEE | PCI_EXP_RTCTL_PMEIE))
++		if ((new ^ old) & PCI_EXP_RTCTL_PMEIE)
+ 			mvebu_pcie_handle_irq_change(port);
+ 		break;
+ 	}
+--
+Armbian
+

--- a/patch/kernel/archive/mvebu-6.18/20-pcie-bridge-emul.patch
+++ b/patch/kernel/archive/mvebu-6.18/20-pcie-bridge-emul.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Russell King <rmk+kernel@armlinux.org.uk>
+Date: Tue, 2 Feb 2021 13:45:28 +0000
+Subject: PCI: pci-bridge-emul: re-arrange register tests
+
+Re-arrange the tests for which sets of registers are being accessed
+so that it is easier to add further regions later. No functional
+change.
+
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+---
+ drivers/pci/pci-bridge-emul.c | 15 ++++++----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/pci/pci-bridge-emul.c b/drivers/pci/pci-bridge-emul.c
+index 111111111111..222222222222 100644
+--- a/drivers/pci/pci-bridge-emul.c
++++ b/drivers/pci/pci-bridge-emul.c
+@@ -479,8 +479,11 @@ int pci_bridge_emul_conf_read(struct pci_bridge_emul *bridge, int where,
+ 		read_op = pci_bridge_emul_read_ssid;
+ 		cfgspace = NULL;
+ 		behavior = NULL;
+-	} else if (reg >= bridge->pcie_start && reg < bridge->pcie_start + PCI_CAP_PCIE_SIZEOF &&
+-		   bridge->has_pcie) {
++	} else if (!bridge->has_pcie) {
++		/* PCIe space is not implemented, and no PCI capabilities */
++		*value = 0;
++		return PCIBIOS_SUCCESSFUL;
++	} else if (reg >= bridge->pcie_start && reg < bridge->pcie_start + PCI_CAP_PCIE_SIZEOF) {
+ 		/* Our emulated PCIe capability */
+ 		reg -= bridge->pcie_start;
+ 		read_op = bridge->ops->read_pcie;
+@@ -553,14 +556,16 @@ int pci_bridge_emul_conf_write(struct pci_bridge_emul *bridge, int where,
+ 		write_op = bridge->ops->write_base;
+ 		cfgspace = (__le32 *) &bridge->conf;
+ 		behavior = bridge->pci_regs_behavior;
+-	} else if (reg >= bridge->pcie_start && reg < bridge->pcie_start + PCI_CAP_PCIE_SIZEOF &&
+-		   bridge->has_pcie) {
++	} else if (!bridge->has_pcie) {
++		/* PCIe space is not implemented, and no PCI capabilities */
++		return PCIBIOS_SUCCESSFUL;
++	} else if (reg >= bridge->pcie_start && reg < bridge->pcie_start + PCI_CAP_PCIE_SIZEOF) {
+ 		/* Our emulated PCIe capability */
+ 		reg -= bridge->pcie_start;
+ 		write_op = bridge->ops->write_pcie;
+ 		cfgspace = (__le32 *) &bridge->pcie_conf;
+ 		behavior = bridge->pcie_cap_regs_behavior;
+-	} else if (reg >= PCI_CFG_SPACE_SIZE && bridge->has_pcie) {
++	} else if (reg >= PCI_CFG_SPACE_SIZE) {
+ 		/* PCIe extended capability space */
+ 		reg -= PCI_CFG_SPACE_SIZE;
+ 		write_op = bridge->ops->write_ext;
+-- 
+Armbian
+


### PR DESCRIPTION
Followup to #9694.

This PR bumps the entire mvebu edge branch to 6.18 LTS family-wide.

### Restored patches

When bumping the version (commit 1), I checked that the patches in `mvebu-6.18/` matched what was previously in `mvebu-6.6/`. It turned out that in commit [`f852beca0`](https://github.com/armbian/build/commit/f852beca0) (PR #6135, "move to archive & cleanup", January 2024), when the `mvebu-6.6/` directory was created, **4 clearfog-family patches were silently dropped**:

| File | What it does | Origin |
|---|---|---|
| `0001-cpuidle-mvebu-indicate-failure-to-enter-deeper-sleep.patch` | cpuidle return code fix | mvebu-5.10 → … → mvebu-6.5 |
| `10-mvebu-clearfog-pcie-updates.patch` | AER/PME plumbing for the Marvell PCIe controller | same |
| `11-implement-slot-capabilities-SSPL.patch` | PCIe Slot Capabilities + SSPL emulation | same |
| `20-pcie-bridge-emul.patch` | extensions for `pci_bridge_emul` | same |

Neither the commit message, nor the PR #6135 description, nor any of its comments (issue + review) mention dropping these patches — they appear to have fallen out by oversight during a manual cleanup. Restoring them.

### Edit applied to one of the patches (commit 2)

`10-mvebu-clearfog-pcie-updates.patch` by Russell King (Nov 2016) bundled together two distinct kinds of changes:

1. **Functional part** (kept): `mvebu_pcie_handle_irq_change()` syncs the hardware `PCIE_INT_UNMASK_OFF` mask of the mvebu PCIe controller with the emulated PCI bridge config (AER bits + PME wake) on writes to `PCI_COMMAND.SERR`, `BRIDGE_CTL.SERR`, `DEVCTL.{CERE,NFERE,FERE,URRE}`, `RTCTL.{SECEE,SENFEE,SEFEE,PMEIE}`. Plus the Armada 370 erratum (clamping DEVCTL bits in RC mode) and a default `bridge->conf.bridgectrl = PCI_BRIDGE_CTL_SERR` in `pci-bridge-emul.c`.
2. **Debug part** (removed): 8 lines of `dev_info(...)` calls in `drivers/pci/pcie/aspm.c` and `drivers/pci/pcie/portdrv.c` — bring-up traces from 2016 that just spam dmesg on every boot. The `aspm.c` hunk also no longer applies cleanly to 6.18 (function moved from line 617 to 814) — not worth fixing the offset just to keep that spam.

Without `10-mvebu-clearfog-pcie-updates.patch`, on the mainline 6.18 `pci-mvebu` driver the hardware PCIe error/PME interrupt masks remain disabled — corrected/uncorrected PCIe errors and PME wake events on clearfog boards do not work. This is particularly important for NAS use cases (NVMe/SATA cards in the mPCIe slot). Mainline still hasn't closed this gap (Marek Behún's 2021 rewrite around `pci-bridge-emul` did not restore this functionality).

### Affected boards
`clearfogpro`, `helios4`, `clearfogbase` (csc).

### Verification

| Configuration | Result |
|---|---|
| `./compile.sh kernel ARTIFACT_IGNORE_CACHE=yes BOARD=clearfogpro BRANCH=edge KERNEL_BTF=yes SHARE_LOG=yes USE_CCACHE=yes` | OK — 10:44 min, 6.18.23-mvebu |
| `./compile.sh build BOARD=clearfogpro BRANCH=edge RELEASE=trixie BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no KERNEL_BTF=yes USE_CCACHE=yes` | OK — 18:18 min, image built |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PCIe slot capabilities exposed on mvebu boards for improved device compatibility.

* **Bug Fixes**
  * More robust CPU idle handling to avoid incorrect deeper-sleep behavior.
  * PCIe interrupt masking/forwarding behavior refined to update only when relevant controls change.

* **Chores**
  * Edge branch kernel default set to 6.18 for all mvebu boards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->