### PR TITLE
qrb2210: switch edge kernel to mainline linux v7.0

### DIFF
--- a/config/sources/families/qrb2210.conf
+++ b/config/sources/families/qrb2210.conf
@@ -59,9 +59,9 @@ function uboot_custom_postprocess() {
 case "${BRANCH}" in
 
 	edge)
-		KERNELSOURCE='https://github.com/arduino/linux-qcom.git'
-		KERNELBRANCH="branch:qcom-v7.0.0-unoq"
 		declare -g KERNEL_MAJOR_MINOR="7.0"
+		declare -g KERNELBRANCH='tag:v7.0'
+		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		KERNELPATCHDIR="${LINUXFAMILY}-${BRANCH}"
 		LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
 

--- a/patch/kernel/qrb2210-edge/0001-dt-bindings-drm-bridge-anx7625-describe-Type-C-conne.patch
+++ b/patch/kernel/qrb2210-edge/0001-dt-bindings-drm-bridge-anx7625-describe-Type-C-conne.patch
@@ -1,0 +1,145 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Wed, 21 Jan 2026 12:15:45 +0200
+Subject: [PATCH 01/48] dt-bindings: drm/bridge: anx7625: describe Type-C
+ connector
+
+ANX7625 can be used to mux converted video stream with the USB signals
+on a Type-C connector. Describe the optional connector subnode, make it
+exclusive with the AUX bus and port@1 as it is impossible to have both
+eDP panel and USB-C connector.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Reviewed-by: Rob Herring (Arm) <robh@kernel.org>
+Link: https://lore.kernel.org/r/20260121-anx7625-typec-v2-1-d14f31256a17@oss.qualcomm.com
+---
+ .../display/bridge/analogix,anx7625.yaml      | 98 ++++++++++++++++++-
+ 1 file changed, 97 insertions(+), 1 deletion(-)
+
+diff --git a/Documentation/devicetree/bindings/display/bridge/analogix,anx7625.yaml b/Documentation/devicetree/bindings/display/bridge/analogix,anx7625.yaml
+index a1ed1004651b..6ad466952c02 100644
+--- a/Documentation/devicetree/bindings/display/bridge/analogix,anx7625.yaml
++++ b/Documentation/devicetree/bindings/display/bridge/analogix,anx7625.yaml
+@@ -85,6 +85,11 @@ properties:
+   aux-bus:
+     $ref: /schemas/display/dp-aux-bus.yaml#
+ 
++  connector:
++    type: object
++    $ref: /schemas/connector/usb-connector.yaml#
++    unevaluatedProperties: false
++
+   ports:
+     $ref: /schemas/graph.yaml#/properties/ports
+ 
+@@ -117,7 +122,6 @@ properties:
+ 
+     required:
+       - port@0
+-      - port@1
+ 
+ required:
+   - compatible
+@@ -127,6 +131,28 @@ required:
+   - vdd33-supply
+   - ports
+ 
++allOf:
++  - if:
++      required:
++        - aux-bus
++        - connector
++    then:
++      false
++
++  - if:
++      required:
++        - connector
++    then:
++      properties:
++        ports:
++          properties:
++            port@1: false
++    else:
++      properties:
++        ports:
++          required:
++            - port@1
++
+ additionalProperties: false
+ 
+ examples:
+@@ -185,3 +211,73 @@ examples:
+             };
+         };
+     };
++  - |
++    #include <dt-bindings/gpio/gpio.h>
++
++    i2c {
++        #address-cells = <1>;
++        #size-cells = <0>;
++
++        encoder@58 {
++            compatible = "analogix,anx7625";
++            reg = <0x58>;
++            enable-gpios = <&pio 45 GPIO_ACTIVE_HIGH>;
++            reset-gpios = <&pio 73 GPIO_ACTIVE_HIGH>;
++            vdd10-supply = <&pp1000_mipibrdg>;
++            vdd18-supply = <&pp1800_mipibrdg>;
++            vdd33-supply = <&pp3300_mipibrdg>;
++            analogix,audio-enable;
++            analogix,lane0-swing = /bits/ 8 <0x14 0x54 0x64 0x74>;
++            analogix,lane1-swing = /bits/ 8 <0x14 0x54 0x64 0x74>;
++
++            connector {
++                compatible = "usb-c-connector";
++                power-role = "dual";
++                data-role = "dual";
++                vbus-supply = <&vbus_reg>;
++
++                ports {
++                    #address-cells = <1>;
++                    #size-cells = <0>;
++
++                    port@0 {
++                        reg = <0>;
++
++                        endpoint {
++                            remote-endpoint = <&usb_hs>;
++                        };
++                    };
++
++                    port@1 {
++                        reg = <1>;
++
++                        endpoint {
++                            remote-endpoint = <&usb_ss>;
++                        };
++                    };
++
++                    port@2 {
++                        reg = <2>;
++
++                        endpoint {
++                            remote-endpoint = <&usb_sbu>;
++                        };
++                    };
++                };
++            };
++
++            ports {
++                #address-cells = <1>;
++                #size-cells = <0>;
++
++                port@0 {
++                    reg = <0>;
++                    endpoint {
++                        remote-endpoint = <&mipi_dsi>;
++                        bus-type = <7>;
++                        data-lanes = <0 1 2 3>;
++                    };
++                };
++            };
++        };
++    };

--- a/patch/kernel/qrb2210-edge/0002-drm-bridge-anx7625-implement-minimal-Type-C-support.patch
+++ b/patch/kernel/qrb2210-edge/0002-drm-bridge-anx7625-implement-minimal-Type-C-support.patch
@@ -1,0 +1,334 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Wed, 21 Jan 2026 12:15:46 +0200
+Subject: [PATCH 02/48] drm: bridge: anx7625: implement minimal Type-C support
+
+ANX7625 can be used as a USB-C controller, handling USB and DP data
+streams. Provide minimal Type-C support necessary for ANX7625 to
+register the Type-C port device and properly respond to data / power
+role events from the Type-C partner.
+
+While ANX7625 provides TCPCI interface, using it would circumvent the
+on-chip running firmware. Analogix recommended using the higher-level
+interface instead of TCPCI.
+
+Reviewed-by: Xin Ji <xji@analogixsemi.com>
+Reviewed-by: Heikki Krogerus <heikki.krogerus@linux.intel.com>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20260121-anx7625-typec-v2-2-d14f31256a17@oss.qualcomm.com
+---
+ drivers/gpu/drm/bridge/analogix/Kconfig   |   1 +
+ drivers/gpu/drm/bridge/analogix/anx7625.c | 155 ++++++++++++++++++++--
+ drivers/gpu/drm/bridge/analogix/anx7625.h |  22 ++-
+ 3 files changed, 168 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/gpu/drm/bridge/analogix/Kconfig b/drivers/gpu/drm/bridge/analogix/Kconfig
+index 4846b2e9be7c..f3448b0631fe 100644
+--- a/drivers/gpu/drm/bridge/analogix/Kconfig
++++ b/drivers/gpu/drm/bridge/analogix/Kconfig
+@@ -34,6 +34,7 @@ config DRM_ANALOGIX_ANX7625
+ 	tristate "Analogix Anx7625 MIPI to DP interface support"
+ 	depends on DRM
+ 	depends on OF
++	depends on TYPEC || !TYPEC
+ 	select DRM_DISPLAY_DP_HELPER
+ 	select DRM_DISPLAY_HDCP_HELPER
+ 	select DRM_DISPLAY_HELPER
+diff --git a/drivers/gpu/drm/bridge/analogix/anx7625.c b/drivers/gpu/drm/bridge/analogix/anx7625.c
+index 4e49e4f28d55..8dc6e3b16968 100644
+--- a/drivers/gpu/drm/bridge/analogix/anx7625.c
++++ b/drivers/gpu/drm/bridge/analogix/anx7625.c
+@@ -3,6 +3,7 @@
+  * Copyright(c) 2020, Analogix Semiconductor. All rights reserved.
+  *
+  */
++#include <linux/cleanup.h>
+ #include <linux/gcd.h>
+ #include <linux/gpio/consumer.h>
+ #include <linux/i2c.h>
+@@ -15,6 +16,9 @@
+ #include <linux/regulator/consumer.h>
+ #include <linux/slab.h>
+ #include <linux/types.h>
++#include <linux/usb.h>
++#include <linux/usb/pd.h>
++#include <linux/usb/role.h>
+ #include <linux/workqueue.h>
+ 
+ #include <linux/of_graph.h>
+@@ -1325,7 +1329,7 @@ static int anx7625_read_hpd_gpio_config_status(struct anx7625_data *ctx)
+ static void anx7625_disable_pd_protocol(struct anx7625_data *ctx)
+ {
+ 	struct device *dev = ctx->dev;
+-	int ret, val;
++	int ret;
+ 
+ 	/* Reset main ocm */
+ 	ret = anx7625_reg_write(ctx, ctx->i2c.rx_p0_client, 0x88, 0x40);
+@@ -1339,6 +1343,11 @@ static void anx7625_disable_pd_protocol(struct anx7625_data *ctx)
+ 		DRM_DEV_DEBUG_DRIVER(dev, "disable PD feature fail.\n");
+ 	else
+ 		DRM_DEV_DEBUG_DRIVER(dev, "disable PD feature succeeded.\n");
++}
++
++static void anx7625_configure_hpd(struct anx7625_data *ctx)
++{
++	int val;
+ 
+ 	/*
+ 	 * Make sure the HPD GPIO already be configured after OCM release before
+@@ -1369,7 +1378,9 @@ static int anx7625_ocm_loading_check(struct anx7625_data *ctx)
+ 	if ((ret & FLASH_LOAD_STA_CHK) != FLASH_LOAD_STA_CHK)
+ 		return -ENODEV;
+ 
+-	anx7625_disable_pd_protocol(ctx);
++	if (!ctx->typec_port)
++		anx7625_disable_pd_protocol(ctx);
++	anx7625_configure_hpd(ctx);
+ 
+ 	DRM_DEV_DEBUG_DRIVER(dev, "Firmware ver %02x%02x,",
+ 			     anx7625_reg_read(ctx,
+@@ -1472,6 +1483,107 @@ static void anx7625_start_dp_work(struct anx7625_data *ctx)
+ 	DRM_DEV_DEBUG_DRIVER(dev, "Secure OCM version=%02x\n", ret);
+ }
+ 
++#if IS_REACHABLE(CONFIG_TYPEC)
++static void anx7625_typec_set_orientation(struct anx7625_data *ctx)
++{
++	u32 val = anx7625_reg_read(ctx, ctx->i2c.rx_p0_client, SYSTEM_STSTUS);
++
++	if (val & (CC1_RP | CC1_RD))
++		typec_set_orientation(ctx->typec_port, TYPEC_ORIENTATION_NORMAL);
++	else if (val & (CC2_RP | CC2_RD))
++		typec_set_orientation(ctx->typec_port, TYPEC_ORIENTATION_REVERSE);
++	else
++		typec_set_orientation(ctx->typec_port, TYPEC_ORIENTATION_NONE);
++}
++
++static void anx7625_typec_set_status(struct anx7625_data *ctx,
++				     unsigned int intr_status,
++				     unsigned int intr_vector)
++{
++	if (intr_vector & CC_STATUS)
++		anx7625_typec_set_orientation(ctx);
++	if (intr_vector & DATA_ROLE_STATUS) {
++		enum typec_data_role data_role = (intr_status & DATA_ROLE_STATUS) ?
++			TYPEC_HOST : TYPEC_DEVICE;
++		usb_role_switch_set_role(ctx->role_sw,
++					 (intr_status & DATA_ROLE_STATUS) ?
++					 USB_ROLE_HOST : USB_ROLE_DEVICE);
++		typec_set_data_role(ctx->typec_port, data_role);
++		ctx->typec_data_role = data_role;
++	}
++	if (intr_vector & VBUS_STATUS)
++		typec_set_pwr_role(ctx->typec_port,
++				   (intr_status & VBUS_STATUS) ?
++				   TYPEC_SOURCE : TYPEC_SINK);
++	if (intr_vector & VCONN_STATUS)
++		typec_set_vconn_role(ctx->typec_port,
++				     (intr_status & VCONN_STATUS) ?
++				     TYPEC_SOURCE : TYPEC_SINK);
++}
++
++static int anx7625_typec_register(struct anx7625_data *ctx)
++{
++	struct typec_capability typec_cap = { };
++	struct fwnode_handle *fwnode __free(fwnode_handle) =
++		device_get_named_child_node(ctx->dev, "connector");
++	u32 val;
++	int ret;
++
++	if (!fwnode)
++		return 0;
++
++	ret = typec_get_fw_cap(&typec_cap, fwnode);
++	if (ret < 0)
++		return ret;
++
++	typec_cap.revision = 0x0120;
++	typec_cap.pd_revision = 0x0300;
++	typec_cap.usb_capability = USB_CAPABILITY_USB2 | USB_CAPABILITY_USB3;
++	typec_cap.orientation_aware = true;
++
++	typec_cap.driver_data = ctx;
++
++	ctx->typec_port = typec_register_port(ctx->dev, &typec_cap);
++	if (IS_ERR(ctx->typec_port))
++		return PTR_ERR(ctx->typec_port);
++
++	ctx->role_sw = fwnode_usb_role_switch_get(fwnode);
++	if (IS_ERR(ctx->role_sw)) {
++		typec_unregister_port(ctx->typec_port);
++		return PTR_ERR(ctx->role_sw);
++	}
++
++	val = anx7625_reg_read(ctx, ctx->i2c.rx_p0_client, SYSTEM_STSTUS);
++
++	anx7625_typec_set_status(ctx, val,
++				 CC_STATUS | DATA_ROLE_STATUS |
++				 VBUS_STATUS | VCONN_STATUS);
++
++	return 0;
++}
++
++static void anx7625_typec_unregister(struct anx7625_data *ctx)
++{
++	usb_role_switch_put(ctx->role_sw);
++	typec_unregister_port(ctx->typec_port);
++}
++#else
++static void anx7625_typec_set_status(struct anx7625_data *ctx,
++				     unsigned int intr_status,
++				     unsigned int intr_vector)
++{
++}
++
++static int anx7625_typec_register(struct anx7625_data *ctx)
++{
++	return 0;
++}
++
++static void anx7625_typec_unregister(struct anx7625_data *ctx)
++{
++}
++#endif
++
+ static int anx7625_read_hpd_status_p0(struct anx7625_data *ctx)
+ {
+ 	return anx7625_reg_read(ctx, ctx->i2c.rx_p0_client, SYSTEM_STSTUS);
+@@ -1566,7 +1678,7 @@ static void dp_hpd_change_handler(struct anx7625_data *ctx, bool on)
+ 	}
+ }
+ 
+-static int anx7625_hpd_change_detect(struct anx7625_data *ctx)
++static int anx7625_intr_status(struct anx7625_data *ctx)
+ {
+ 	int intr_vector, status;
+ 	struct device *dev = ctx->dev;
+@@ -1593,9 +1705,6 @@ static int anx7625_hpd_change_detect(struct anx7625_data *ctx)
+ 		return status;
+ 	}
+ 
+-	if (!(intr_vector & HPD_STATUS_CHANGE))
+-		return -ENOENT;
+-
+ 	status = anx7625_reg_read(ctx, ctx->i2c.rx_p0_client,
+ 				  SYSTEM_STSTUS);
+ 	if (status < 0) {
+@@ -1604,6 +1713,12 @@ static int anx7625_hpd_change_detect(struct anx7625_data *ctx)
+ 	}
+ 
+ 	DRM_DEV_DEBUG_DRIVER(dev, "0x7e:0x45=%x\n", status);
++
++	anx7625_typec_set_status(ctx, status, intr_vector);
++
++	if (!(intr_vector & HPD_STATUS))
++		return -ENOENT;
++
+ 	dp_hpd_change_handler(ctx, status & HPD_STATUS);
+ 
+ 	return 0;
+@@ -1622,7 +1737,7 @@ static void anx7625_work_func(struct work_struct *work)
+ 		return;
+ 	}
+ 
+-	event = anx7625_hpd_change_detect(ctx);
++	event = anx7625_intr_status(ctx);
+ 
+ 	mutex_unlock(&ctx->lock);
+ 
+@@ -2741,11 +2856,29 @@ static int anx7625_i2c_probe(struct i2c_client *client)
+ 	}
+ 
+ 	if (!platform->pdata.low_power_mode) {
+-		anx7625_disable_pd_protocol(platform);
++		struct fwnode_handle *fwnode;
++
++		fwnode = device_get_named_child_node(dev, "connector");
++		if (fwnode)
++			fwnode_handle_put(fwnode);
++		else
++			anx7625_disable_pd_protocol(platform);
++
++		anx7625_configure_hpd(platform);
++
+ 		pm_runtime_get_sync(dev);
+ 		_anx7625_hpd_polling(platform, 5000 * 100);
+ 	}
+ 
++	if (platform->pdata.intp_irq)
++		anx7625_reg_write(platform, platform->i2c.rx_p0_client,
++				  INTERFACE_CHANGE_INT_MASK, 0);
++
++	/* After getting runtime handle */
++	ret = anx7625_typec_register(platform);
++	if (ret)
++		goto pm_suspend;
++
+ 	/* Add work function */
+ 	if (platform->pdata.intp_irq) {
+ 		enable_irq(platform->pdata.intp_irq);
+@@ -2759,6 +2892,10 @@ static int anx7625_i2c_probe(struct i2c_client *client)
+ 
+ 	return 0;
+ 
++pm_suspend:
++	if (!platform->pdata.low_power_mode)
++		pm_runtime_put_sync_suspend(&client->dev);
++
+ free_wq:
+ 	if (platform->workqueue)
+ 		destroy_workqueue(platform->workqueue);
+@@ -2774,6 +2911,8 @@ static void anx7625_i2c_remove(struct i2c_client *client)
+ {
+ 	struct anx7625_data *platform = i2c_get_clientdata(client);
+ 
++	anx7625_typec_unregister(platform);
++
+ 	drm_bridge_remove(&platform->bridge);
+ 
+ 	if (platform->pdata.intp_irq)
+diff --git a/drivers/gpu/drm/bridge/analogix/anx7625.h b/drivers/gpu/drm/bridge/analogix/anx7625.h
+index eb5580f1ab2f..a18561c213af 100644
+--- a/drivers/gpu/drm/bridge/analogix/anx7625.h
++++ b/drivers/gpu/drm/bridge/analogix/anx7625.h
+@@ -51,9 +51,21 @@
+ #define INTR_RECEIVED_MSG BIT(5)
+ 
+ #define SYSTEM_STSTUS 0x45
++#define INTERFACE_CHANGE_INT_MASK 0x43
+ #define INTERFACE_CHANGE_INT 0x44
+-#define HPD_STATUS_CHANGE 0x80
+-#define HPD_STATUS 0x80
++#define VCONN_STATUS	BIT(2)
++#define VBUS_STATUS	BIT(3)
++#define CC_STATUS	BIT(4)
++#define DATA_ROLE_STATUS	BIT(5)
++#define HPD_STATUS	BIT(7)
++
++#define NEW_CC_STATUS 0x46
++#define CC1_RD                  BIT(0)
++#define CC1_RA                  BIT(1)
++#define CC1_RP			(BIT(2) | BIT(3))
++#define CC2_RD                  BIT(4)
++#define CC2_RA                  BIT(5)
++#define CC2_RP			(BIT(6) | BIT(7))
+ 
+ /******** END of I2C Address 0x58 ********/
+ 
+@@ -447,9 +459,15 @@ struct anx7625_i2c_client {
+ 	struct i2c_client *tcpc_client;
+ };
+ 
++struct typec_port;
++struct usb_role_switch;
++
+ struct anx7625_data {
+ 	struct anx7625_platform_data pdata;
+ 	struct platform_device *audio_pdev;
++	struct typec_port *typec_port;
++	struct usb_role_switch *role_sw;
++	int typec_data_role;
+ 	int hpd_status;
+ 	int hpd_high_cnt;
+ 	int dp_en;

--- a/patch/kernel/qrb2210-edge/0003-drm-bridge-anx7625-implement-message-sending.patch
+++ b/patch/kernel/qrb2210-edge/0003-drm-bridge-anx7625-implement-message-sending.patch
@@ -1,0 +1,140 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Wed, 21 Jan 2026 12:15:47 +0200
+Subject: [PATCH 03/48] drm: bridge: anx7625: implement message sending
+
+Swapping the data role requires sending the message to the other USB-C
+side. Implement sending these messages through the OCM. The code is
+largely based on the anx7411.c USB-C driver.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Reviewed-by: Xin Ji <xji@analogixsemi.com>
+Link: https://lore.kernel.org/r/20260121-anx7625-typec-v2-3-d14f31256a17@oss.qualcomm.com
+---
+ drivers/gpu/drm/bridge/analogix/anx7625.c | 68 +++++++++++++++++++++++
+ drivers/gpu/drm/bridge/analogix/anx7625.h | 12 ++++
+ 2 files changed, 80 insertions(+)
+
+diff --git a/drivers/gpu/drm/bridge/analogix/anx7625.c b/drivers/gpu/drm/bridge/analogix/anx7625.c
+index 8dc6e3b16968..c43519097a45 100644
+--- a/drivers/gpu/drm/bridge/analogix/anx7625.c
++++ b/drivers/gpu/drm/bridge/analogix/anx7625.c
+@@ -1484,6 +1484,73 @@ static void anx7625_start_dp_work(struct anx7625_data *ctx)
+ }
+ 
+ #if IS_REACHABLE(CONFIG_TYPEC)
++static u8 anx7625_checksum(u8 *buf, u8 len)
++{
++	u8 ret = 0;
++	u8 i;
++
++	for (i = 0; i < len; i++)
++		ret += buf[i];
++
++	return ret;
++}
++
++static int anx7625_read_msg_ctrl_status(struct anx7625_data *ctx)
++{
++	return anx7625_reg_read(ctx, ctx->i2c.rx_p0_client, CMD_SEND_BUF);
++}
++
++static int anx7625_wait_msg_empty(struct anx7625_data *ctx)
++{
++	int val;
++
++	return readx_poll_timeout(anx7625_read_msg_ctrl_status, ctx,
++				  val, (val < 0) || (val == 0),
++				  2000, 2000 * 150);
++}
++
++static int anx7625_send_msg(struct anx7625_data *ctx, u8 type, u8 *buf, u8 size)
++{
++	struct fw_msg *msg = &ctx->send_msg;
++	u8 crc;
++	int ret;
++
++	size = min_t(u8, size, (u8)MAX_BUF_LEN);
++	memcpy(msg->buf, buf, size);
++	msg->msg_type = type;
++
++	/* msg len equals buffer length + msg_type */
++	msg->msg_len = size + 1;
++
++	crc = anx7625_checksum((u8 *)msg, size + HEADER_LEN);
++	msg->buf[size] = 0 - crc;
++
++	ret = anx7625_wait_msg_empty(ctx);
++	if (ret)
++		return ret;
++
++	ret = anx7625_reg_block_write(ctx, ctx->i2c.rx_p0_client,
++				      CMD_SEND_BUF + 1, size + HEADER_LEN,
++				      &msg->msg_type);
++	ret |= anx7625_reg_write(ctx, ctx->i2c.rx_p0_client, CMD_SEND_BUF,
++				 msg->msg_len);
++	return ret;
++}
++
++static int anx7625_typec_dr_set(struct typec_port *port, enum typec_data_role role)
++{
++	struct anx7625_data *ctx = typec_get_drvdata(port);
++
++	if (role == ctx->typec_data_role)
++		return 0;
++
++	return anx7625_send_msg(ctx, 0x11, NULL, 0);
++}
++
++static const struct typec_operations anx7625_typec_ops = {
++	.dr_set = anx7625_typec_dr_set,
++};
++
+ static void anx7625_typec_set_orientation(struct anx7625_data *ctx)
+ {
+ 	u32 val = anx7625_reg_read(ctx, ctx->i2c.rx_p0_client, SYSTEM_STSTUS);
+@@ -1542,6 +1609,7 @@ static int anx7625_typec_register(struct anx7625_data *ctx)
+ 	typec_cap.orientation_aware = true;
+ 
+ 	typec_cap.driver_data = ctx;
++	typec_cap.ops = &anx7625_typec_ops;
+ 
+ 	ctx->typec_port = typec_register_port(ctx->dev, &typec_cap);
+ 	if (IS_ERR(ctx->typec_port))
+diff --git a/drivers/gpu/drm/bridge/analogix/anx7625.h b/drivers/gpu/drm/bridge/analogix/anx7625.h
+index a18561c213af..957d234ec07c 100644
+--- a/drivers/gpu/drm/bridge/analogix/anx7625.h
++++ b/drivers/gpu/drm/bridge/analogix/anx7625.h
+@@ -67,6 +67,9 @@
+ #define CC2_RA                  BIT(5)
+ #define CC2_RP			(BIT(6) | BIT(7))
+ 
++#define CMD_SEND_BUF		0xC0
++#define CMD_RECV_BUF		0xE0
++
+ /******** END of I2C Address 0x58 ********/
+ 
+ /***************************************************************/
+@@ -462,6 +465,14 @@ struct anx7625_i2c_client {
+ struct typec_port;
+ struct usb_role_switch;
+ 
++#define MAX_BUF_LEN	30
++struct fw_msg {
++	u8 msg_len;
++	u8 msg_type;
++	u8 buf[MAX_BUF_LEN];
++} __packed;
++#define HEADER_LEN		2
++
+ struct anx7625_data {
+ 	struct anx7625_platform_data pdata;
+ 	struct platform_device *audio_pdev;
+@@ -497,6 +508,7 @@ struct anx7625_data {
+ 	struct drm_connector *connector;
+ 	struct mipi_dsi_device *dsi;
+ 	struct drm_dp_aux aux;
++	struct fw_msg send_msg;
+ };
+ 
+ #endif  /* __ANX7625_H__ */

--- a/patch/kernel/qrb2210-edge/0004-drm-bridge-anx7625-correctly-detect-if-PD-can-be-dis.patch
+++ b/patch/kernel/qrb2210-edge/0004-drm-bridge-anx7625-correctly-detect-if-PD-can-be-dis.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Wed, 11 Feb 2026 11:17:27 +0200
+Subject: [PATCH 04/48] drm: bridge: anx7625: correctly detect if PD can be
+ disabled
+
+During initial checks the ANX7625 bridge can be powered on before
+setting up the Type-C port. At this point, when
+anx7625_ocm_loading_check() checks if it can disable PD or not, it will
+notice that typec_port is not set and disable PD, breaking orientation
+and HPD handling. Unify the check between anx7625_ocm_loading_check()
+anx7625_i2c_probe() and anx7625_typec_register() and check for the
+presence of the "connector" node.
+
+Fixes: 8ad0f7d2e6fd ("drm: bridge: anx7625: implement message sending")
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20260211-anx7625-fix-pd-v1-1-1dd31451b06f@oss.qualcomm.com
+---
+ drivers/gpu/drm/bridge/analogix/anx7625.c | 21 ++++++++++++++-------
+ 1 file changed, 14 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/bridge/analogix/anx7625.c b/drivers/gpu/drm/bridge/analogix/anx7625.c
+index c43519097a45..1157a58cf1b1 100644
+--- a/drivers/gpu/drm/bridge/analogix/anx7625.c
++++ b/drivers/gpu/drm/bridge/analogix/anx7625.c
+@@ -1363,6 +1363,18 @@ static void anx7625_configure_hpd(struct anx7625_data *ctx)
+ 	anx7625_hpd_timer_config(ctx);
+ }
+ 
++static bool anx7625_need_pd(struct anx7625_data *ctx)
++{
++	struct fwnode_handle *fwnode;
++
++	fwnode = device_get_named_child_node(ctx->dev, "connector");
++	if (!fwnode)
++		return false;
++
++	fwnode_handle_put(fwnode);
++	return true;
++}
++
+ static int anx7625_ocm_loading_check(struct anx7625_data *ctx)
+ {
+ 	int ret;
+@@ -1378,7 +1390,7 @@ static int anx7625_ocm_loading_check(struct anx7625_data *ctx)
+ 	if ((ret & FLASH_LOAD_STA_CHK) != FLASH_LOAD_STA_CHK)
+ 		return -ENODEV;
+ 
+-	if (!ctx->typec_port)
++	if (!anx7625_need_pd(ctx))
+ 		anx7625_disable_pd_protocol(ctx);
+ 	anx7625_configure_hpd(ctx);
+ 
+@@ -2924,12 +2936,7 @@ static int anx7625_i2c_probe(struct i2c_client *client)
+ 	}
+ 
+ 	if (!platform->pdata.low_power_mode) {
+-		struct fwnode_handle *fwnode;
+-
+-		fwnode = device_get_named_child_node(dev, "connector");
+-		if (fwnode)
+-			fwnode_handle_put(fwnode);
+-		else
++		if (!anx7625_need_pd(platform))
+ 			anx7625_disable_pd_protocol(platform);
+ 
+ 		anx7625_configure_hpd(platform);

--- a/patch/kernel/qrb2210-edge/0005-dt-bindings-mfd-qcom-spmi-pmic-add-compatibles-for-p.patch
+++ b/patch/kernel/qrb2210-edge/0005-dt-bindings-mfd-qcom-spmi-pmic-add-compatibles-for-p.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexey Klimov <alexey.klimov@linaro.org>
+Date: Mon, 9 Feb 2026 14:24:25 +0000
+Subject: [PATCH 05/48] dt-bindings: mfd: qcom,spmi-pmic: add compatibles for
+ pm4124-codec
+
+Qualcomm Agatti SoC has PM4125 PMIC, which includes audio codec.
+Audio codec has TX and RX soundwire slave devices to connect to on-chip
+soundwire master.
+
+Add missing qcom,pm4125-codec compatible to pattern of audio-codec node
+properties in mfd qcom,spmi-pmic schema to complete the audio codec support.
+
+Signed-off-by: Alexey Klimov <alexey.klimov@linaro.org>
+[Srini: reworked the patch]
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20260209142428.214428-2-srinivas.kandagatla@oss.qualcomm.com
+---
+ Documentation/devicetree/bindings/mfd/qcom,spmi-pmic.yaml | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/Documentation/devicetree/bindings/mfd/qcom,spmi-pmic.yaml b/Documentation/devicetree/bindings/mfd/qcom,spmi-pmic.yaml
+index e5931d18d998..f58a85562c26 100644
+--- a/Documentation/devicetree/bindings/mfd/qcom,spmi-pmic.yaml
++++ b/Documentation/devicetree/bindings/mfd/qcom,spmi-pmic.yaml
+@@ -145,7 +145,11 @@ patternProperties:
+ 
+   "^audio-codec@[0-9a-f]+$":
+     type: object
+-    $ref: /schemas/sound/qcom,pm8916-wcd-analog-codec.yaml#
++    oneOf:
++      - $ref: /schemas/sound/qcom,pm8916-wcd-analog-codec.yaml#
++      - properties:
++          compatible:
++            const: qcom,pm4125-codec
+ 
+   "^battery@[0-9a-f]+$":
+     type: object

--- a/patch/kernel/qrb2210-edge/0006-arm64-dts-qcom-agatti-add-LPASS-devices.patch
+++ b/patch/kernel/qrb2210-edge/0006-arm64-dts-qcom-agatti-add-LPASS-devices.patch
@@ -1,0 +1,223 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexey Klimov <alexey.klimov@linaro.org>
+Date: Mon, 9 Feb 2026 14:24:26 +0000
+Subject: [PATCH 06/48] arm64: dts: qcom: agatti: add LPASS devices
+
+The rxmacro, txmacro, vamacro, soundwire nodes, lpass clock
+controllers are required to support audio playback and
+audio capture on sm6115 and its derivatives.
+
+Signed-off-by: Alexey Klimov <alexey.klimov@linaro.org>
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20260209142428.214428-3-srinivas.kandagatla@oss.qualcomm.com
+---
+ arch/arm64/boot/dts/qcom/agatti.dtsi | 189 +++++++++++++++++++++++++++
+ 1 file changed, 189 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/agatti.dtsi b/arch/arm64/boot/dts/qcom/agatti.dtsi
+index 893cb0689013..00e961482a99 100644
+--- a/arch/arm64/boot/dts/qcom/agatti.dtsi
++++ b/arch/arm64/boot/dts/qcom/agatti.dtsi
+@@ -758,6 +758,42 @@
+ 					drive-strength = <8>;
+ 				};
+ 			};
++
++			lpass_tx_swr_active: lpass-tx-swr-active-state {
++				clk-pins {
++					pins = "gpio0";
++					function = "swr_tx_clk";
++					drive-strength = <10>;
++					slew-rate = <3>;
++					bias-disable;
++				};
++
++				data-pins {
++					pins = "gpio1", "gpio2";
++					function = "swr_tx_data";
++					drive-strength = <10>;
++					slew-rate = <3>;
++					bias-bus-hold;
++				};
++			};
++
++			lpass_rx_swr_active: lpass-rx-swr-active-state {
++				clk-pins {
++					pins = "gpio3";
++					function = "swr_rx_clk";
++					drive-strength = <10>;
++					slew-rate = <3>;
++					bias-disable;
++				};
++
++				data-pins {
++					pins = "gpio4", "gpio5";
++					function = "swr_rx_data";
++					drive-strength = <10>;
++					slew-rate = <3>;
++					bias-bus-hold;
++				};
++			};
+ 		};
+ 
+ 		gcc: clock-controller@1400000 {
+@@ -2186,6 +2222,159 @@
+ 			};
+ 		};
+ 
++		rxmacro: codec@a600000 {
++			compatible = "qcom,sm6115-lpass-rx-macro";
++			reg = <0x0 0xa600000 0x0 0x1000>;
++
++			clocks = <&q6afecc LPASS_CLK_ID_RX_CORE_MCLK
++				LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6afecc LPASS_CLK_ID_RX_CORE_NPL_MCLK
++				 LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6afecc LPASS_HW_DCODEC_VOTE
++				 LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&vamacro>;
++			clock-names = "mclk",
++				      "npl",
++				      "dcodec",
++				      "fsgen";
++			assigned-clocks = <&q6afecc LPASS_CLK_ID_RX_CORE_MCLK
++					  LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++					  <&q6afecc LPASS_CLK_ID_RX_CORE_NPL_MCLK
++					  LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++			assigned-clock-rates = <22579200>,
++					       <22579200>;
++			#clock-cells = <0>;
++			clock-output-names = "mclk";
++			#sound-dai-cells = <1>;
++		};
++
++		swr1: soundwire@a610000 {
++			compatible = "qcom,soundwire-v1.6.0";
++			reg = <0x0 0x0a610000 0x0 0x2000>;
++			interrupts = <GIC_SPI 297 IRQ_TYPE_LEVEL_HIGH>;
++
++			clocks = <&rxmacro>;
++			clock-names = "iface";
++
++			resets = <&lpass_audiocc 0>;
++			reset-names = "swr_audio_cgcr";
++
++			label = "RX";
++			qcom,din-ports = <0>;
++			qcom,dout-ports = <5>;
++
++			qcom,ports-sinterval-low =	/bits/ 8 <0x03 0x1f 0x1f 0x07 0x00>;
++			qcom,ports-offset1 =		/bits/ 8 <0x00 0x00 0x0b 0x01 0x00>;
++			qcom,ports-offset2 =		/bits/ 8 <0x00 0x00 0x0b 0x00 0x00>;
++			qcom,ports-hstart =		/bits/ 8 <0xff 0x03 0xff 0xff 0xff>;
++			qcom,ports-hstop =		/bits/ 8 <0xff 0x06 0xff 0xff 0xff>;
++			qcom,ports-word-length =	/bits/ 8 <0x01 0x07 0x04 0xff 0xff>;
++			qcom,ports-block-pack-mode =	/bits/ 8 <0xff 0x00 0x01 0xff 0xff>;
++			qcom,ports-block-group-count =	/bits/ 8 <0xff 0xff 0xff 0xff 0x00>;
++			qcom,ports-lane-control =	/bits/ 8 <0x01 0x00 0x00 0x00 0x00>;
++
++			status = "disabled";
++
++			#sound-dai-cells = <1>;
++			#address-cells = <2>;
++			#size-cells = <0>;
++		};
++
++
++		txmacro: codec@a620000 {
++			compatible = "qcom,sm6115-lpass-tx-macro";
++			reg = <0x0 0x0a620000 0x0 0x1000>;
++
++			clocks = <&q6afecc LPASS_CLK_ID_TX_CORE_MCLK
++				 LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6afecc LPASS_CLK_ID_TX_CORE_NPL_MCLK
++				 LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6afecc LPASS_HW_DCODEC_VOTE
++				 LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&vamacro>;
++			clock-names = "mclk",
++				      "npl",
++				      "dcodec",
++				      "fsgen";
++			assigned-clocks = <&q6afecc LPASS_CLK_ID_TX_CORE_MCLK
++					  LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++					  <&q6afecc LPASS_CLK_ID_TX_CORE_NPL_MCLK
++					  LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++			assigned-clock-rates = <19200000>,
++					       <19200000>;
++			#clock-cells = <0>;
++			clock-output-names = "mclk";
++			#sound-dai-cells = <1>;
++		};
++
++		lpass_audiocc: clock-controller@a6a9000 {
++			compatible = "qcom,sm6115-lpassaudiocc";
++			reg = <0x0 0x0a6a9000 0x0 0x1000>;
++			#reset-cells = <1>;
++		};
++
++		vamacro: codec@a730000 {
++			compatible = "qcom,sm6115-lpass-va-macro";
++			reg = <0x0 0x0a730000 0x0 0x1000>;
++
++			clocks = <&q6afecc LPASS_CLK_ID_TX_CORE_MCLK
++				 LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6afecc LPASS_HW_DCODEC_VOTE
++				 LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6afecc LPASS_CLK_ID_TX_CORE_NPL_MCLK
++				 LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++			clock-names = "mclk",
++				      "dcodec",
++				      "npl";
++			assigned-clocks = <&q6afecc LPASS_CLK_ID_TX_CORE_MCLK
++					  LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++					  <&q6afecc LPASS_CLK_ID_TX_CORE_NPL_MCLK
++					  LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++			assigned-clock-rates = <19200000>,
++					       <19200000>;
++			#clock-cells = <0>;
++			clock-output-names = "fsgen";
++			#sound-dai-cells = <1>;
++		};
++
++		swr0: soundwire@a740000 {
++			compatible = "qcom,soundwire-v1.6.0";
++			reg = <0x0 0x0a740000 0x0 0x2000>;
++			interrupts = <GIC_SPI 296 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 79 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&txmacro>;
++			clock-names = "iface";
++
++			resets = <&lpasscc 0>;
++			reset-names = "swr_audio_cgcr";
++
++			label = "VA_TX";
++			qcom,din-ports = <3>;
++			qcom,dout-ports = <0>;
++
++			qcom,ports-sinterval-low =	/bits/ 8 <0x03 0x03 0x03>;
++			qcom,ports-offset1 =		/bits/ 8 <0x01 0x02 0x01>;
++			qcom,ports-offset2 =		/bits/ 8 <0x00 0x00 0x00>;
++			qcom,ports-hstart =		/bits/ 8 <0xff 0xff 0xff>;
++			qcom,ports-hstop =		/bits/ 8 <0xff 0xff 0xff>;
++			qcom,ports-word-length =	/bits/ 8 <0xff 0xff 0xff>;
++			qcom,ports-block-pack-mode =	/bits/ 8 <0xff 0xff 0xff>;
++			qcom,ports-block-group-count =	/bits/ 8 <0xff 0xff 0xff>;
++			qcom,ports-lane-control =	/bits/ 8 <0x00 0x00 0x00>;
++
++			status = "disabled";
++
++			#sound-dai-cells = <1>;
++			#address-cells = <2>;
++			#size-cells = <0>;
++		};
++
++		lpasscc: clock-controller@a7ec000 {
++			compatible = "qcom,sm6115-lpasscc";
++			reg = <0x0 0x0a7ec000 0x0 0x1000>;
++			#reset-cells = <1>;
++		};
++
+ 		remoteproc_adsp: remoteproc@ab00000 {
+ 			compatible = "qcom,qcm2290-adsp-pas", "qcom,sm6115-adsp-pas";
+ 			reg = <0x0 0x0ab00000 0x0 0x100>;

--- a/patch/kernel/qrb2210-edge/0007-arm64-dts-arduino-imola-add-support-for-sound.patch
+++ b/patch/kernel/qrb2210-edge/0007-arm64-dts-arduino-imola-add-support-for-sound.patch
@@ -1,0 +1,170 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Date: Mon, 9 Feb 2026 14:24:27 +0000
+Subject: [PATCH 07/48] arm64: dts: arduino-imola: add support for sound
+
+Add support for sound on Arduino UNO Q board, which includes
+- Headset playback and record.
+- Lineout
+
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20260209142428.214428-4-srinivas.kandagatla@oss.qualcomm.com
+---
+ .../boot/dts/qcom/qrb2210-arduino-imola.dts   | 137 ++++++++++++++++++
+ 1 file changed, 137 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts
+index 197ab6eb1666..f36f7ff96252 100644
+--- a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts
+@@ -109,6 +109,98 @@
+ 		leds = <&ledr>, <&ledg>, <&ledb>;
+ 	};
+ 
++	sound {
++		compatible = "qcom,qrb2210-sndcard";
++		model = "Arduino-Imola-HPH-LOUT";
++		audio-routing =	"IN1_HPHL", "HPHL_OUT",
++				"IN2_HPHR", "HPHR_OUT",
++				"AMIC2", "MIC BIAS2";
++
++		mm1-dai-link {
++			link-name = "MultiMedia1";
++
++			cpu {
++				sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA1>;
++			};
++		};
++
++		mm2-dai-link {
++			link-name = "MultiMedia2";
++
++			cpu {
++				sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA2>;
++			};
++		};
++
++		mm3-dai-link {
++			link-name = "MultiMedia3";
++
++			cpu {
++				sound-dai = <&q6asmdai  MSM_FRONTEND_DAI_MULTIMEDIA3>;
++			};
++		};
++
++		hph-playback-dai-link {
++			link-name = "HPH Playback";
++			cpu {
++				sound-dai = <&q6afedai RX_CODEC_DMA_RX_0>;
++			};
++
++			platform {
++				sound-dai = <&q6routing>;
++			};
++
++			codec {
++				sound-dai = <&pmic4125_codec 0>, <&swr1 0>, <&rxmacro 0>;
++			};
++		};
++
++		lo-playback-dai-link {
++			link-name = "LO Playback";
++			cpu {
++				sound-dai = <&q6afedai RX_CODEC_DMA_RX_0>;
++			};
++
++			platform {
++				sound-dai = <&q6routing>;
++			};
++
++			codec {
++				sound-dai = <&pmic4125_codec 0>, <&swr1 0>, <&rxmacro 0>;
++			};
++		};
++
++		ear-playback-dai-link {
++			link-name = "Ear Playback";
++			cpu {
++				sound-dai = <&q6afedai RX_CODEC_DMA_RX_0>;
++			};
++
++			platform {
++				sound-dai = <&q6routing>;
++			};
++
++			codec {
++				sound-dai = <&pmic4125_codec 0>, <&swr1 0>, <&rxmacro 0>;
++			};
++		};
++
++		hph-capture-dai-link {
++			link-name = "HP Capture";
++			cpu {
++				sound-dai = <&q6afedai TX_CODEC_DMA_TX_3>;
++			};
++
++			platform {
++				sound-dai = <&q6routing>;
++			};
++
++			codec {
++				sound-dai = <&pmic4125_codec 1>, <&swr0 0>, <&txmacro 0>;
++			};
++		};
++	};
++
+ 	/* PM4125 charger out, supplied by VBAT */
+ 	vph_pwr: regulator-vph-pwr {
+ 		compatible = "regulator-fixed";
+@@ -333,6 +425,51 @@
+ 	};
+ };
+ 
++&spmi_bus {
++	pmic@0 {
++		pmic4125_codec: audio-codec@f000{
++			compatible = "qcom,pm4125-codec";
++			reg =<0xf000>;
++			vdd-io-supply = <&pm4125_l15>;
++			vdd-cp-supply = <&pm4125_s4>;
++			vdd-pa-vpos-supply = <&pm4125_s4>;
++
++			vdd-mic-bias-supply = <&pm4125_l22>;
++			qcom,micbias1-microvolt = <1800000>;
++			qcom,micbias2-microvolt = <1800000>;
++			qcom,micbias3-microvolt = <1800000>;
++
++			qcom,rx-device = <&pm4125_rx>;
++			qcom,tx-device = <&pm4125_tx>;
++			#sound-dai-cells = <1>;
++		};
++	};
++};
++
++&swr0 {
++	pinctrl-0 = <&lpass_tx_swr_active>;
++	pinctrl-names = "default";
++	status = "okay";
++
++	pm4125_tx: codec@0,3 {
++		compatible = "sdw20217010c00";
++		reg = <0 3>;
++		qcom,tx-port-mapping = <1 1 2 3>;
++	};
++};
++
++&swr1 {
++	pinctrl-0 = <&lpass_rx_swr_active>;
++	pinctrl-names = "default";
++	status = "okay";
++
++	pm4125_rx: codec@0,4 {
++		compatible = "sdw20217010c00";
++		reg = <0 4>;
++		qcom,rx-port-mapping = <1 2 3 4 5>;
++	};
++};
++
+ &tlmm {
+ 	spidev_cs: spidev-cs-state {
+ 		pins = "gpio17";

--- a/patch/kernel/qrb2210-edge/0008-arm64-defconfig-Enable-Agatti-audio-drivers.patch
+++ b/patch/kernel/qrb2210-edge/0008-arm64-defconfig-Enable-Agatti-audio-drivers.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Date: Mon, 9 Feb 2026 14:24:28 +0000
+Subject: [PATCH 08/48] arm64: defconfig: Enable Agatti audio drivers
+
+Enable reset controller and pm4125 audio codec driver that are required
+to enable audio support on Qualcomm Agatti SoC based platforms.
+
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20260209142428.214428-5-srinivas.kandagatla@oss.qualcomm.com
+---
+ arch/arm64/configs/defconfig | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm64/configs/defconfig b/arch/arm64/configs/defconfig
+index b67d5b1fc45b..6db35c1605a0 100644
+--- a/arch/arm64/configs/defconfig
++++ b/arch/arm64/configs/defconfig
+@@ -1146,6 +1146,7 @@ CONFIG_SND_SOC_ES8328_I2C=m
+ CONFIG_SND_SOC_GTM601=m
+ CONFIG_SND_SOC_MSM8916_WCD_ANALOG=m
+ CONFIG_SND_SOC_MSM8916_WCD_DIGITAL=m
++CONFIG_SND_SOC_PM4125_SDW=m
+ CONFIG_SND_SOC_PCM3168A_I2C=m
+ CONFIG_SND_SOC_RK3308=m
+ CONFIG_SND_SOC_RK817=m
+@@ -1550,6 +1551,7 @@ CONFIG_SM_GPUCC_8350=m
+ CONFIG_SM_GPUCC_8450=m
+ CONFIG_SM_GPUCC_8550=m
+ CONFIG_SM_GPUCC_8650=m
++CONFIG_SM_LPASSCC_6115=m
+ CONFIG_SM_TCSRCC_8550=y
+ CONFIG_SM_TCSRCC_8650=y
+ CONFIG_SM_TCSRCC_8750=m

--- a/patch/kernel/qrb2210-edge/0009-arm64-dts-qcom-qrb2210-arduino-imola-describe-DSI-DP.patch
+++ b/patch/kernel/qrb2210-edge/0009-arm64-dts-qcom-qrb2210-arduino-imola-describe-DSI-DP.patch
@@ -1,0 +1,177 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Wed, 11 Feb 2026 11:28:06 +0200
+Subject: [PATCH 09/48] arm64: dts: qcom: qrb2210-arduino-imola: describe DSI /
+ DP bridge
+
+Aruino Uno-Q uses Analogix ANX7625 DSI-to-DP bridge to convert DSI
+signals to the connected USB-C DisplayPort dongles. Decribe the chip,
+USB-C connector and routing of USB and display signals.
+
+Co-developed-by: Martino Facchin <m.facchin@arduino.cc>
+Signed-off-by: Martino Facchin <m.facchin@arduino.cc>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Tested-by: Loic Poulain <loic.poulain@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20260211-uno-q-anx7625-v1-1-677bbcf63668@oss.qualcomm.com
+---
+ .../boot/dts/qcom/qrb2210-arduino-imola.dts   | 112 ++++++++++++++++++
+ 1 file changed, 112 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts
+index f36f7ff96252..9cdfc86c92d7 100644
+--- a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts
+@@ -6,6 +6,7 @@
+ /dts-v1/;
+ 
+ #include <dt-bindings/leds/common.h>
++#include <dt-bindings/usb/pd.h>
+ #include "agatti.dtsi"
+ #include "pm4125.dtsi"
+ 
+@@ -201,6 +202,16 @@
+ 		};
+ 	};
+ 
++	vreg_anx_30: regulator-anx-30 {
++		/* ANX7625 VDD3 */
++		compatible = "regulator-fixed";
++		regulator-name = "anx30";
++		regulator-min-microvolt = <3000000>;
++		regulator-max-microvolt = <3000000>;
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
+ 	/* PM4125 charger out, supplied by VBAT */
+ 	vph_pwr: regulator-vph-pwr {
+ 		compatible = "regulator-fixed";
+@@ -234,6 +245,83 @@
+ 	clock-frequency = <100000>;
+ 
+ 	status = "okay";
++
++	anx7625: encoder@58 {
++		compatible = "analogix,anx7625";
++		reg = <0x58>;
++		interrupts-extended = <&tlmm 81 IRQ_TYPE_EDGE_FALLING>;
++		vdd10-supply = <&pm4125_l11>;
++		vdd18-supply = <&pm4125_l15>;
++		vdd33-supply = <&vreg_anx_30>;
++		analogix,audio-enable;
++		analogix,lane0-swing = /bits/ 8 <0x14 0x54 0x64 0x74>;
++		analogix,lane1-swing = /bits/ 8 <0x14 0x54 0x64 0x74>;
++
++		pinctrl-0 = <&anx7625_int_pin>, <&anx7625_cable_det_pin>;
++
++		connector {
++			compatible = "usb-c-connector";
++			power-role = "sink";
++			data-role = "dual";
++			try-power-role = "sink";
++
++			pd-revision = /bits/ 8 <0x03 0x00 0x00 0x00>;
++			op-sink-microwatt = <15000000>;
++			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++				     PDO_VAR(5000, 20000, 3000)>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++					anx_hs_in: endpoint {
++						remote-endpoint = <&usb_dwc3_hs>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++					anx_ss_in: endpoint {
++						remote-endpoint = <&usb_qmpphy_out>;
++					};
++				};
++			};
++		};
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++				anx_dsi0_in: endpoint {
++					remote-endpoint = <&mdss_dsi0_out>;
++					data-lanes = <0 1 2 3>;
++				};
++			};
++		};
++	};
++};
++
++&mdss {
++	status = "okay";
++};
++
++&mdss_dsi0 {
++	vdda-supply = <&pm4125_l5>;
++
++	status = "okay";
++};
++
++&mdss_dsi0_out {
++	remote-endpoint = <&anx_dsi0_in>;
++	data-lanes = <0 1 2 3>;
++};
++
++&mdss_dsi0_phy {
++	status = "okay";
+ };
+ 
+ &pm4125_vbus {
+@@ -498,6 +586,22 @@
+ 		output-disable;
+ 	};
+ 
++	anx7625_cable_det_pin: anx7625-cable-det-pins-state {
++		pins = "gpio46";
++		function = "gpio";
++		drive-strength = <16>;
++		output-disable;
++		bias-pull-up;
++	};
++
++	anx7625_int_pin: anx7625-int-pins-state {
++		pins = "gpio81";
++		function = "gpio";
++		drive-strength = <16>;
++		output-disable;
++		bias-pull-up;
++	};
++
+ 	key_volp_n: key-volp-n-state {
+ 		pins = "gpio96";
+ 		function = "gpio";
+@@ -565,6 +669,10 @@
+ 	status = "okay";
+ };
+ 
++&usb_dwc3_hs {
++	remote-endpoint = <&anx_hs_in>;
++};
++
+ &usb_hsphy {
+ 	vdd-supply = <&pm4125_l12>;
+ 	vdda-pll-supply = <&pm4125_l13>;
+@@ -580,6 +688,10 @@
+ 	status = "okay";
+ };
+ 
++&usb_qmpphy_out {
++	remote-endpoint = <&anx_ss_in>;
++};
++
+ &wifi {
+ 	vdd-0.8-cx-mx-supply = <&pm4125_l7>;
+ 	vdd-1.8-xo-supply = <&pm4125_l13>;

--- a/patch/kernel/qrb2210-edge/0010-drm-bridge-anx7625-don-t-crash-if-Type-C-port-is-not.patch
+++ b/patch/kernel/qrb2210-edge/0010-drm-bridge-anx7625-don-t-crash-if-Type-C-port-is-not.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Loic Poulain <loic.poulain@oss.qualcomm.com>
+Date: Sun, 15 Feb 2026 03:30:02 +0200
+Subject: [PATCH 10/48] drm: bridge: anx7625: don't crash if Type-C port is not
+ used
+
+The typec_set_*() functions do not tolerate being passed the NULL
+typec_port instance. However, if CONFIG_TYPEC is enabled, but anx7625
+DT node doesn't have the usb-c connector fwnode, then typec_port remains
+NULL, crashing the kernel. Prevent calling typec_set_foo() functions by
+checking that ctx->typec_port is not NULL in anx7625_typec_set_status().
+
+ Call trace:
+  typec_set_orientation+0x18/0x68 (P)
+  anx7625_typec_set_status+0x108/0x13c
+  anx7625_work_func+0x124/0x438
+  process_one_work+0x214/0x648
+  worker_thread+0x1b4/0x358
+  kthread+0x14c/0x214
+  ret_from_fork+0x10/0x20
+ Code: 910003fd a90153f3 aa0003f3 2a0103f4 (f9431400)
+
+Fixes: f81455b2d332 ("drm: bridge: anx7625: implement minimal Type-C support")
+Reported-by: Salendarsingh Gaud <sgaud@qti.qualcomm.com>
+Signed-off-by: Loic Poulain <loic.poulain@oss.qualcomm.com>
+[db: dropped chunk anx7625_typec_unregister(), wrote commit message]
+Cc: Amit Kucheria <akucheri@qti.qualcomm.com>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20260215-anx-fix-no-typec-v1-1-75172a5ca88b@oss.qualcomm.com
+---
+ drivers/gpu/drm/bridge/analogix/anx7625.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/gpu/drm/bridge/analogix/anx7625.c b/drivers/gpu/drm/bridge/analogix/anx7625.c
+index 1157a58cf1b1..763519ef0d38 100644
+--- a/drivers/gpu/drm/bridge/analogix/anx7625.c
++++ b/drivers/gpu/drm/bridge/analogix/anx7625.c
+@@ -1579,6 +1579,9 @@ static void anx7625_typec_set_status(struct anx7625_data *ctx,
+ 				     unsigned int intr_status,
+ 				     unsigned int intr_vector)
+ {
++	if (!ctx->typec_port)
++		return;
++
+ 	if (intr_vector & CC_STATUS)
+ 		anx7625_typec_set_orientation(ctx);
+ 	if (intr_vector & DATA_ROLE_STATUS) {

--- a/patch/kernel/qrb2210-edge/0011-arm64-dts-qcom-arduino-imola-fix-faulty-spidev-node.patch
+++ b/patch/kernel/qrb2210-edge/0011-arm64-dts-qcom-arduino-imola-fix-faulty-spidev-node.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riccardo Mereu <r.mereu@arduino.cc>
+Date: Fri, 13 Feb 2026 11:10:02 +0100
+Subject: [PATCH 11/48] arm64: dts: qcom: arduino-imola: fix faulty spidev node
+
+CS pin added on pinctrl0 property is causing spidev to return -ENODEV
+since that GPIO is already part of spi5 pinmuxing.
+
+Fixes: 3f745bc0f11f ("arm64: dts: qcom: qrb2210: add dts for Arduino unoq")
+Signed-off-by: Riccardo Mereu <r.mereu@arduino.cc>
+Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20260213101002.105238-1-r.mereu.kernel@arduino.cc
+---
+ arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts | 12 ++----------
+ 1 file changed, 2 insertions(+), 10 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts
+index 9cdfc86c92d7..f9233d2c55ba 100644
+--- a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts
+@@ -505,11 +505,9 @@
+ &spi5 {
+ 	status = "okay";
+ 
+-	spidev@0 {
+-		reg = <0>;
++	mcu@0 {
+ 		compatible = "arduino,unoq-mcu";
+-		pinctrl-0 = <&spidev_cs>;
+-		pinctrl-names = "default";
++		reg = <0>;
+ 	};
+ };
+ 
+@@ -559,12 +557,6 @@
+ };
+ 
+ &tlmm {
+-	spidev_cs: spidev-cs-state {
+-		pins = "gpio17";
+-		function = "gpio";
+-		drive-strength = <16>;
+-	};
+-
+ 	jmisc_gpio18: jmisc-gpio18-state {
+ 		pins = "gpio18";
+ 		function = "gpio";

--- a/patch/kernel/qrb2210-edge/0012-drm-msm-add-missing-MODULE_DEVICE_ID-definitions.patch
+++ b/patch/kernel/qrb2210-edge/0012-drm-msm-add-missing-MODULE_DEVICE_ID-definitions.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Thu, 19 Feb 2026 14:19:14 +0200
+Subject: [PATCH 12/48] drm/msm: add missing MODULE_DEVICE_ID definitions
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The drm/msm module bundles several drivers, each of them having a
+separate OF match table, however only MDSS (subsystem) and KMS devices
+had corresponding MODULE_DEVICE_ID tables. Thus, if the platform has
+enabled only the GPU device (without enabling display counterparts), the
+module will not be picked up and loaded by userspace.
+
+Add MODULE_DEVICE_ID to the GPU driver and to all other drivers in this
+module.
+
+Fixes: 55459968176f ("drm/msm: add a330/apq8x74")
+Reported-by: Loïc Minier <loic.minier@oss.qualcomm.com>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Link: https://lore.kernel.org/r/20260219-msm-device-id-v1-1-9e7315a6fd20@oss.qualcomm.com
+---
+ drivers/gpu/drm/msm/dp/dp_display.c   | 1 +
+ drivers/gpu/drm/msm/dsi/dsi.c         | 1 +
+ drivers/gpu/drm/msm/dsi/phy/dsi_phy.c | 1 +
+ drivers/gpu/drm/msm/hdmi/hdmi.c       | 1 +
+ drivers/gpu/drm/msm/hdmi/hdmi_phy.c   | 1 +
+ 5 files changed, 5 insertions(+)
+
+diff --git a/drivers/gpu/drm/msm/dp/dp_display.c b/drivers/gpu/drm/msm/dp/dp_display.c
+index 476848bf8cd1..d2124d625485 100644
+--- a/drivers/gpu/drm/msm/dp/dp_display.c
++++ b/drivers/gpu/drm/msm/dp/dp_display.c
+@@ -210,6 +210,7 @@ static const struct of_device_id msm_dp_dt_match[] = {
+ 	{ .compatible = "qcom,x1e80100-dp", .data = &msm_dp_desc_x1e80100 },
+ 	{}
+ };
++MODULE_DEVICE_TABLE(of, msm_dp_dt_match);
+ 
+ static struct msm_dp_display_private *dev_get_dp_display_private(struct device *dev)
+ {
+diff --git a/drivers/gpu/drm/msm/dsi/dsi.c b/drivers/gpu/drm/msm/dsi/dsi.c
+index d8bb40ef820e..3c9f01ed6271 100644
+--- a/drivers/gpu/drm/msm/dsi/dsi.c
++++ b/drivers/gpu/drm/msm/dsi/dsi.c
+@@ -198,6 +198,7 @@ static const struct of_device_id dt_match[] = {
+ 	{ .compatible = "qcom,dsi-ctrl-6g-qcm2290" },
+ 	{}
+ };
++MODULE_DEVICE_TABLE(of, dt_match);
+ 
+ static const struct dev_pm_ops dsi_pm_ops = {
+ 	SET_RUNTIME_PM_OPS(msm_dsi_runtime_suspend, msm_dsi_runtime_resume, NULL)
+diff --git a/drivers/gpu/drm/msm/dsi/phy/dsi_phy.c b/drivers/gpu/drm/msm/dsi/phy/dsi_phy.c
+index 7937266de1d2..c59375aaae19 100644
+--- a/drivers/gpu/drm/msm/dsi/phy/dsi_phy.c
++++ b/drivers/gpu/drm/msm/dsi/phy/dsi_phy.c
+@@ -582,6 +582,7 @@ static const struct of_device_id dsi_phy_dt_match[] = {
+ #endif
+ 	{}
+ };
++MODULE_DEVICE_TABLE(of, dsi_phy_dt_match);
+ 
+ /*
+  * Currently, we only support one SoC for each PHY type. When we have multiple
+diff --git a/drivers/gpu/drm/msm/hdmi/hdmi.c b/drivers/gpu/drm/msm/hdmi/hdmi.c
+index 5afac09c0d33..d5ef5089c9e9 100644
+--- a/drivers/gpu/drm/msm/hdmi/hdmi.c
++++ b/drivers/gpu/drm/msm/hdmi/hdmi.c
+@@ -441,6 +441,7 @@ static const struct of_device_id msm_hdmi_dt_match[] = {
+ 	{ .compatible = "qcom,hdmi-tx-8660", .data = &hdmi_tx_8960_config },
+ 	{}
+ };
++MODULE_DEVICE_TABLE(of, msm_hdmi_dt_match);
+ 
+ static struct platform_driver msm_hdmi_driver = {
+ 	.probe = msm_hdmi_dev_probe,
+diff --git a/drivers/gpu/drm/msm/hdmi/hdmi_phy.c b/drivers/gpu/drm/msm/hdmi/hdmi_phy.c
+index 667573f1db7c..f726555bb681 100644
+--- a/drivers/gpu/drm/msm/hdmi/hdmi_phy.c
++++ b/drivers/gpu/drm/msm/hdmi/hdmi_phy.c
+@@ -204,6 +204,7 @@ static const struct of_device_id msm_hdmi_phy_dt_match[] = {
+ 	  .data = &msm_hdmi_phy_8998_cfg },
+ 	{}
+ };
++MODULE_DEVICE_TABLE(of, msm_hdmi_phy_dt_match);
+ 
+ static struct platform_driver msm_hdmi_phy_platform_driver = {
+ 	.probe      = msm_hdmi_phy_probe,

--- a/patch/kernel/qrb2210-edge/0013-ASoC-codecs-pm4125-fix-array-out-of-bounds.patch
+++ b/patch/kernel/qrb2210-edge/0013-ASoC-codecs-pm4125-fix-array-out-of-bounds.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Date: Thu, 19 Mar 2026 10:10:45 +0000
+Subject: [PATCH 13/48] ASoC: codecs: pm4125: fix array-out-of-bounds
+
+Soundwire Ports are not fully defined in soundwire driver, which means
+that drivers trying to use those ports would get port index of zero,
+lets check this before accessing any arrays.
+This should fix below UBSAN error too.
+
+[  159.628324] UBSAN: array-index-out-of-bounds in sound/soc/codecs/pm4125.c:845:62
+[  159.635835] index -1 is out of range for type 'sdw_port_config [2]'
+[  159.642264] CPU: 3 UID: 1000 PID: 1091 Comm: amixer Tainted: G    B               6.19.0srini+ #61 PREEMPT
+[  159.642295] Tainted: [B]=BAD_PAGE
+[  159.642302] Hardware name: Arduino Imola/Imola, BIOS 2025.07-rc1-g21292a3cdcb4 07/01/2025
+[  159.642311] Call trace:
+[  159.642318]  show_stack+0x18/0x24 (C)
+[  159.642348]  dump_stack_lvl+0x7c/0xb0
+[  159.642367]  dump_stack+0x1c/0x28
+[  159.642383]  ubsan_epilogue+0x10/0x44
+[  159.642399]  __ubsan_handle_out_of_bounds+0xa0/0xc4
+[  159.642422]  pm4125_connect_port.isra.0+0x3f8/0x400 [snd_soc_pm4125]
+[  159.642461]  pm4125_set_compander+0x1e0/0x3a0 [snd_soc_pm4125]
+[  159.642484]  snd_ctl_elem_write+0x2d4/0x408 [snd]
+[  159.642565]  snd_ctl_ioctl+0xb30/0x1320 [snd]
+[  159.642626]  __arm64_sys_ioctl+0x124/0x1a4
+[  159.642646]  invoke_syscall+0x70/0x260
+[  159.642664]  el0_svc_common.constprop.0+0xac/0x230
+
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+---
+ sound/soc/codecs/pm4125.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/sound/soc/codecs/pm4125.c b/sound/soc/codecs/pm4125.c
+index 1f0a3f5389f1..52594a9608f3 100644
+--- a/sound/soc/codecs/pm4125.c
++++ b/sound/soc/codecs/pm4125.c
+@@ -842,13 +842,18 @@ static int pm4125_codec_enable_micbias_pullup(struct snd_soc_dapm_widget *w,
+ 
+ static int pm4125_connect_port(struct pm4125_sdw_priv *sdw_priv, u8 port_idx, u8 ch_id, bool enable)
+ {
+-	struct sdw_port_config *port_config = &sdw_priv->port_config[port_idx - 1];
++	struct sdw_port_config *port_config;
+ 	const struct wcd_sdw_ch_info *ch_info = &sdw_priv->ch_info[ch_id];
+ 	struct sdw_slave *sdev = sdw_priv->sdev;
+ 	u8 port_num = ch_info->port_num;
+ 	u8 ch_mask = ch_info->ch_mask;
+ 	u8 mstr_port_num, mstr_ch_mask;
+ 
++	if (!port_idx) /* Invalid port index */
++		return -EINVAL;
++
++	port_config = &sdw_priv->port_config[port_idx - 1];
++
+ 	port_config->num = port_num;
+ 
+ 	mstr_port_num = sdev->m_port_map[port_num];
+@@ -905,6 +910,8 @@ static int pm4125_set_compander(struct snd_kcontrol *kcontrol, struct snd_ctl_el
+ 	}
+ 
+ 	portidx = sdw_priv->ch_info[mc->reg].port_num;
++	if (!portidx)
++		return 0;
+ 
+ 	pm4125_connect_port(sdw_priv, portidx, mc->reg, value ? true : false);
+ 
+@@ -943,6 +950,8 @@ static int pm4125_set_swr_port(struct snd_kcontrol *kcontrol, struct snd_ctl_ele
+ 	sdw_priv = pm4125->sdw_priv[dai_id];
+ 
+ 	portidx = sdw_priv->ch_info[ch_idx].port_num;
++	if (!portidx) /* Invalid port index */
++		return 0;
+ 
+ 	enable = ucontrol->value.integer.value[0];
+ 

--- a/patch/kernel/qrb2210-edge/0014-ASoC-qcom-common-setup-fe-dais-before-be-dais.patch
+++ b/patch/kernel/qrb2210-edge/0014-ASoC-qcom-common-setup-fe-dais-before-be-dais.patch
@@ -1,0 +1,270 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Date: Mon, 16 Mar 2026 13:55:53 +0000
+Subject: [PATCH 14/48] ASoC: qcom: common: setup fe dais before be dais
+
+On Elite DSP architecuture q6routing setup depends on some of the pcm
+dais to be probed to setup the routing. For some reason if the
+devicetree entires are incorrectly ordered, specially in overlays,
+this could result in
+
+failures like below
+
+q6routing ab00000.remoteproc:glink-edge:apr:service@8:routing: ASoC: Failed to add route MM_DL1(*) -> [MultiMedia1] -> HDMI Mixer
+q6routing ab00000.remoteproc:glink-edge:apr:service@8:routing: ASoC: Failed to add route MM_DL2(*) -> [MultiMedia2] -> HDMI Mixer
+q6routing ab00000.remoteproc:glink-edge:apr:service@8:routing: ASoC: Failed to add route MM_DL3(*) -> [MultiMedia3] -> HDMI Mixer
+q6routing ab00000.remoteproc:glink-edge:apr:service@8:routing: ASoC: Failed to add route MM_DL4(*) -> [MultiMedia4] -> HDMI Mixer
+q6routing ab00000.remoteproc:glink-edge:apr:service@8:routing: ASoC: Failed to add route MM_DL5(*) -> [MultiMedia5] -> HDMI Mixer
+q6routing ab00000.remoteproc:glink-edge:apr:service@8:routing: ASoC: Failed to add route MM_DL6(*) -> [MultiMedia6] -> HDMI Mixer
+q6routing ab00000.remoteproc:glink-edge:apr:service@8:routing: ASoC: Failed to add route MM_DL7(*) -> [MultiMedia7] -> HDMI Mixer
+q6routing ab00000.remoteproc:glink-edge:apr:service@8:routing: ASoC: Failed to add route MM_DL8(*) -> [MultiMedia8] -> HDMI Mixer
+
+Fix this by setting up the pcm dais first and then the backend dais
+after.
+
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+---
+ sound/soc/qcom/common.c | 193 +++++++++++++++++++++++-----------------
+ 1 file changed, 112 insertions(+), 81 deletions(-)
+
+diff --git a/sound/soc/qcom/common.c b/sound/soc/qcom/common.c
+index 7ee60a58a336..88e5cc3c9b49 100644
+--- a/sound/soc/qcom/common.c
++++ b/sound/soc/qcom/common.c
+@@ -1,3 +1,4 @@
++
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (c) 2018, Linaro Limited.
+ // Copyright (c) 2018, The Linux Foundation. All rights reserved.
+@@ -23,16 +24,106 @@ static const struct snd_soc_dapm_widget qcom_jack_snd_widgets[] = {
+ 	SND_SOC_DAPM_SPK("DP7 Jack", NULL),
+ };
+ 
+-int qcom_snd_parse_of(struct snd_soc_card *card)
++static int qcom_snd_setup_dai_links(struct snd_soc_card *card, struct snd_soc_dai_link *link,
++				    struct device_node *np)
+ {
+-	struct device_node *np;
+ 	struct device_node *codec = NULL;
+ 	struct device_node *platform = NULL;
+ 	struct device_node *cpu = NULL;
+ 	struct device *dev = card->dev;
+-	struct snd_soc_dai_link *link;
+ 	struct of_phandle_args args;
+ 	struct snd_soc_dai_link_component *dlc;
++	int ret;
++
++	dlc = devm_kcalloc(dev, 2, sizeof(*dlc), GFP_KERNEL);
++	if (!dlc)
++		return -ENOMEM;
++	link->cpus	= &dlc[0];
++	link->platforms	= &dlc[1];
++
++	link->num_cpus		= 1;
++	link->num_platforms	= 1;
++
++	ret = of_property_read_string(np, "link-name", &link->name);
++	if (ret) {
++		dev_err(card->dev, "error getting codec dai_link name\n");
++		return ret;
++	}
++
++	cpu = of_get_child_by_name(np, "cpu");
++	platform = of_get_child_by_name(np, "platform");
++	codec = of_get_child_by_name(np, "codec");
++
++	if (!cpu) {
++		dev_err(dev, "%s: Can't find cpu DT node\n", link->name);
++		ret = -EINVAL;
++		goto err;
++	}
++
++	ret = snd_soc_of_get_dlc(cpu, &args, link->cpus, 0);
++	if (ret) {
++		dev_err_probe(card->dev, ret,
++			      "%s: error getting cpu dai name\n", link->name);
++		goto err;
++	}
++
++	link->id = args.args[0];
++
++	if (platform) {
++		link->platforms->of_node = of_parse_phandle(platform,
++				"sound-dai",
++				0);
++		if (!link->platforms->of_node) {
++			dev_err(card->dev, "%s: platform dai not found\n", link->name);
++			ret = -EINVAL;
++			goto err;
++		}
++	} else {
++		link->platforms->of_node = link->cpus->of_node;
++	}
++
++	if (codec) {
++		ret = snd_soc_of_get_dai_link_codecs(dev, codec, link);
++		if (ret < 0) {
++			dev_err_probe(card->dev, ret,
++				      "%s: codec dai not found\n", link->name);
++			goto err;
++		}
++
++		if (platform) {
++			/* DPCM backend */
++			link->no_pcm = 1;
++			link->ignore_pmdown_time = 1;
++		}
++	} else {
++		/* DPCM frontend */
++		link->codecs	 = &snd_soc_dummy_dlc;
++		link->num_codecs = 1;
++		link->dynamic = 1;
++	}
++
++	if (platform || !codec) {
++		/* DPCM */
++		link->ignore_suspend = 1;
++		link->nonatomic = 1;
++	}
++	link->stream_name = link->name;
++
++	ret = 0;
++err:
++	of_node_put(cpu);
++	of_node_put(codec);
++	of_node_put(platform);
++
++	return ret;
++}
++
++int qcom_snd_parse_of(struct snd_soc_card *card)
++{
++	struct device_node *np;
++	struct device_node *codec = NULL;
++	struct device *dev = card->dev;
++	struct snd_soc_dai_link *link;
+ 	int ret, num_links;
+ 
+ 	ret = snd_soc_of_parse_card_name(card, "model");
+@@ -82,89 +173,36 @@ int qcom_snd_parse_of(struct snd_soc_card *card)
+ 	card->num_links = num_links;
+ 	link = card->dai_link;
+ 
++	/* setup pcm dais first */
+ 	for_each_available_child_of_node(dev->of_node, np) {
+-		dlc = devm_kcalloc(dev, 2, sizeof(*dlc), GFP_KERNEL);
+-		if (!dlc) {
+-			ret = -ENOMEM;
+-			goto err_put_np;
+-		}
+-
+-		link->cpus	= &dlc[0];
+-		link->platforms	= &dlc[1];
+-
+-		link->num_cpus		= 1;
+-		link->num_platforms	= 1;
+-
+-		ret = of_property_read_string(np, "link-name", &link->name);
+-		if (ret) {
+-			dev_err(card->dev, "error getting codec dai_link name\n");
+-			goto err_put_np;
+-		}
+-
+-		cpu = of_get_child_by_name(np, "cpu");
+-		platform = of_get_child_by_name(np, "platform");
+ 		codec = of_get_child_by_name(np, "codec");
+-
+-		if (!cpu) {
+-			dev_err(dev, "%s: Can't find cpu DT node\n", link->name);
+-			ret = -EINVAL;
+-			goto err;
++		if (codec) {
++			of_node_put(codec);
++			continue;
+ 		}
+ 
+-		ret = snd_soc_of_get_dlc(cpu, &args, link->cpus, 0);
++		ret = qcom_snd_setup_dai_links(card, link, np);
+ 		if (ret) {
+-			dev_err_probe(card->dev, ret,
+-				      "%s: error getting cpu dai name\n", link->name);
+-			goto err;
+-		}
+-
+-		link->id = args.args[0];
+-
+-		if (platform) {
+-			link->platforms->of_node = of_parse_phandle(platform,
+-					"sound-dai",
+-					0);
+-			if (!link->platforms->of_node) {
+-				dev_err(card->dev, "%s: platform dai not found\n", link->name);
+-				ret = -EINVAL;
+-				goto err;
+-			}
+-		} else {
+-			link->platforms->of_node = link->cpus->of_node;
++			of_node_put(np);
++			return ret;
+ 		}
+ 
+-		if (codec) {
+-			ret = snd_soc_of_get_dai_link_codecs(dev, codec, link);
+-			if (ret < 0) {
+-				dev_err_probe(card->dev, ret,
+-					      "%s: codec dai not found\n", link->name);
+-				goto err;
+-			}
++		link++;
++	}
+ 
+-			if (platform) {
+-				/* DPCM backend */
+-				link->no_pcm = 1;
+-				link->ignore_pmdown_time = 1;
+-			}
+-		} else {
+-			/* DPCM frontend */
+-			link->codecs	 = &snd_soc_dummy_dlc;
+-			link->num_codecs = 1;
+-			link->dynamic = 1;
+-		}
++	/* setup backend dais */
++	for_each_available_child_of_node(dev->of_node, np) {
++		codec = of_get_child_by_name(np, "codec");
++		if (!codec)
++			continue;
+ 
+-		if (platform || !codec) {
+-			/* DPCM */
+-			link->ignore_suspend = 1;
+-			link->nonatomic = 1;
++		ret = qcom_snd_setup_dai_links(card, link, np);
++		if (ret) {
++			of_node_put(np);
++			return ret;
+ 		}
+ 
+-		link->stream_name = link->name;
+ 		link++;
+-
+-		of_node_put(cpu);
+-		of_node_put(codec);
+-		of_node_put(platform);
+ 	}
+ 
+ 	if (!card->dapm_widgets) {
+@@ -172,13 +210,6 @@ int qcom_snd_parse_of(struct snd_soc_card *card)
+ 		card->num_dapm_widgets = ARRAY_SIZE(qcom_jack_snd_widgets);
+ 	}
+ 
+-	return 0;
+-err:
+-	of_node_put(cpu);
+-	of_node_put(codec);
+-	of_node_put(platform);
+-err_put_np:
+-	of_node_put(np);
+ 	return ret;
+ }
+ EXPORT_SYMBOL_GPL(qcom_snd_parse_of);

--- a/patch/kernel/qrb2210-edge/0015-arm64-dts-qcom-imola-add-support-for-media-carrier-b.patch
+++ b/patch/kernel/qrb2210-edge/0015-arm64-dts-qcom-imola-add-support-for-media-carrier-b.patch
@@ -1,0 +1,695 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riccardo Mereu <r.mereu@arduino.cc>
+Date: Wed, 18 Mar 2026 17:52:38 +0100
+Subject: [PATCH 15/48] arm64: dts: qcom: imola: add support for media carrier
+ board
+
+Media Carrier is an expansion board for Arduino UnoQ.
+It adds two CSI connector, one DSI connector, 3 jack connector for
+headphones, earphone and lineout and 4 RGB LEDs.
+
+Current devicetree overlays support imx219 based cameras bot with 4lanes
+and 2lanes and whaveshare 8in touch A display.
+
+As you can notice dtbos are splitted since carrier configuration is
+handled in user-space helping user to configure the board.
+---
+ arch/arm64/boot/dts/qcom/Makefile             |  16 +++
+ arch/arm64/boot/dts/qcom/agatti.dtsi          |   4 +
+ ...ola.dts => qrb2210-arduino-imola-base.dts} |  29 ++--
+ ...rrier-media-camera-imx219-csi0-2lanes.dtso |  49 +++++++
+ ...rrier-media-camera-imx219-csi0-4lanes.dtso |  49 +++++++
+ ...rrier-media-camera-imx219-csi1-2lanes.dtso |  49 +++++++
+ ...rrier-media-camera-imx219-csi1-4lanes.dtso |  49 +++++++
+ ...10-arduino-imola-carrier-media-common.dtsi |  45 ++++++
+ ...a-carrier-media-panel-8in_touch_a-dsi.dtso |  58 ++++++++
+ .../qrb2210-arduino-imola-carrier-media.dtso  | 131 ++++++++++++++++++
+ ...rb2210-arduino-imola-video_sound-usbc.dtso |  61 ++++++++
+ 11 files changed, 521 insertions(+), 19 deletions(-)
+ rename arch/arm64/boot/dts/qcom/{qrb2210-arduino-imola.dts => qrb2210-arduino-imola-base.dts} (97%)
+ create mode 100644 arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-2lanes.dtso
+ create mode 100644 arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-4lanes.dtso
+ create mode 100644 arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-2lanes.dtso
+ create mode 100644 arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-4lanes.dtso
+ create mode 100644 arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-common.dtsi
+ create mode 100644 arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-panel-8in_touch_a-dsi.dtso
+ create mode 100644 arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media.dtso
+ create mode 100644 arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-video_sound-usbc.dtso
+
+diff --git a/arch/arm64/boot/dts/qcom/Makefile b/arch/arm64/boot/dts/qcom/Makefile
+index f80b5d9cf1e8..d92cbc887a8f 100644
+--- a/arch/arm64/boot/dts/qcom/Makefile
++++ b/arch/arm64/boot/dts/qcom/Makefile
+@@ -157,7 +157,23 @@ qcs9100-ride-r3-el2-dtbs := qcs9100-ride-r3.dtb lemans-el2.dtbo
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs9100-ride-el2.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs9100-ride-r3-el2.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qdu1000-idp.dtb
++dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-arduino-imola-base.dtb
++
++dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-arduino-imola-carrier-media.dtbo
++dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-2lanes.dtbo
++dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-4lanes.dtbo
++dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-2lanes.dtbo
++dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-4lanes.dtbo
++dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-arduino-imola-carrier-media-panel-8in_touch_a-dsi.dtbo
++dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-arduino-imola-video_sound-usbc.dtbo
++
++qrb2210-arduino-imola-dtbs := qrb2210-arduino-imola-base.dtb qrb2210-arduino-imola-video_sound-usbc.dtbo
+ dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-arduino-imola.dtb
++qrb2210-arduino-imola-carrier-media-full-4lanes-dtbs := qrb2210-arduino-imola-base.dtb qrb2210-arduino-imola-carrier-media.dtbo qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-4lanes.dtbo qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-4lanes.dtbo qrb2210-arduino-imola-carrier-media-panel-8in_touch_a-dsi.dtbo
++dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-arduino-imola-carrier-media-full-4lanes.dtb
++qrb2210-arduino-imola-carrier-media-full-2lanes-dtbs := qrb2210-arduino-imola-base.dtb qrb2210-arduino-imola-carrier-media.dtbo qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-2lanes.dtbo qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-2lanes.dtbo qrb2210-arduino-imola-carrier-media-panel-8in_touch_a-dsi.dtbo
++dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-arduino-imola-carrier-media-full-2lanes.dtb
++
+ dtb-$(CONFIG_ARCH_QCOM)	+= qrb2210-rb1.dtb
+ 
+ qrb2210-rb1-vision-mezzanine-dtbs	:= qrb2210-rb1.dtb qrb2210-rb1-vision-mezzanine.dtbo
+diff --git a/arch/arm64/boot/dts/qcom/agatti.dtsi b/arch/arm64/boot/dts/qcom/agatti.dtsi
+index 00e961482a99..ebeb2ff6b526 100644
+--- a/arch/arm64/boot/dts/qcom/agatti.dtsi
++++ b/arch/arm64/boot/dts/qcom/agatti.dtsi
+@@ -2464,6 +2464,10 @@
+ 							dai@2 {
+ 								reg = <MSM_FRONTEND_DAI_MULTIMEDIA3>;
+ 							};
++
++							dai@3 {
++								reg = <MSM_FRONTEND_DAI_MULTIMEDIA4>;
++							};
+ 						};
+ 					};
+ 
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-base.dts
+similarity index 97%
+rename from arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts
+rename to arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-base.dts
+index f9233d2c55ba..590d8a6951a0 100644
+--- a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-base.dts
+@@ -110,7 +110,7 @@
+ 		leds = <&ledr>, <&ledg>, <&ledb>;
+ 	};
+ 
+-	sound {
++	sound: sound {
+ 		compatible = "qcom,qrb2210-sndcard";
+ 		model = "Arduino-Imola-HPH-LOUT";
+ 		audio-routing =	"IN1_HPHL", "HPHL_OUT",
+@@ -141,6 +141,14 @@
+ 			};
+ 		};
+ 
++		mm4-dai-link {
++			link-name = "MultiMedia4";
++
++			cpu {
++				sound-dai = <&q6asmdai  MSM_FRONTEND_DAI_MULTIMEDIA4>;
++			};
++		};
++
+ 		hph-playback-dai-link {
+ 			link-name = "HPH Playback";
+ 			cpu {
+@@ -258,6 +266,7 @@
+ 		analogix,lane1-swing = /bits/ 8 <0x14 0x54 0x64 0x74>;
+ 
+ 		pinctrl-0 = <&anx7625_int_pin>, <&anx7625_cable_det_pin>;
++		#sound-dai-cells = <1>;
+ 
+ 		connector {
+ 			compatible = "usb-c-connector";
+@@ -289,19 +298,6 @@
+ 				};
+ 			};
+ 		};
+-
+-		ports {
+-			#address-cells = <1>;
+-			#size-cells = <0>;
+-
+-			port@0 {
+-				reg = <0>;
+-				anx_dsi0_in: endpoint {
+-					remote-endpoint = <&mdss_dsi0_out>;
+-					data-lanes = <0 1 2 3>;
+-				};
+-			};
+-		};
+ 	};
+ };
+ 
+@@ -315,11 +311,6 @@
+ 	status = "okay";
+ };
+ 
+-&mdss_dsi0_out {
+-	remote-endpoint = <&anx_dsi0_in>;
+-	data-lanes = <0 1 2 3>;
+-};
+-
+ &mdss_dsi0_phy {
+ 	status = "okay";
+ };
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-2lanes.dtso b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-2lanes.dtso
+new file mode 100644
+index 000000000000..572b73cc323c
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-2lanes.dtso
+@@ -0,0 +1,49 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
++/*
++ * Copyright (c) 2025, Arduino SA
++ */
++
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include "qrb2210-arduino-imola-carrier-media-common.dtsi"
++
++&camss {
++	ports {
++		port@0 {
++			csiphy0_ep: endpoint {
++				data-lanes = <0 1>;
++				remote-endpoint = <&imx219_0_ep>;
++			};
++		};
++	};
++};
++
++&cci_i2c0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	sensor@10 {
++		compatible = "sony,imx219";
++		reg = <0x10>;
++		clocks = <&cam24m>;
++		status = "okay";
++
++		VDIG-supply = <&cam_pwr_csi0>;
++		VANA-supply = <&cam_pwr_csi0>;
++		VDDL-supply = <&cam_pwr_csi0>;
++
++		reset-gpios = <&pca9555 0 GPIO_ACTIVE_HIGH>;
++
++		port {
++			/* MIPI CSI-2 bus endpoint */
++			imx219_0_ep: endpoint {
++				remote-endpoint = <&csiphy0_ep>;
++				clock-lanes = <0>;
++				data-lanes = <1 2>;
++				link-frequencies = /bits/ 64 <456000000>;
++			};
++		};
++	};
++};
+\ No newline at end of file
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-4lanes.dtso b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-4lanes.dtso
+new file mode 100644
+index 000000000000..075294a8524a
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi0-4lanes.dtso
+@@ -0,0 +1,49 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
++/*
++ * Copyright (c) 2025, Arduino SA
++ */
++
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include "qrb2210-arduino-imola-carrier-media-common.dtsi"
++
++&camss {
++	ports {
++		port@0 {
++			csiphy0_ep: endpoint {
++				data-lanes = <0 1 2 3>;
++				remote-endpoint = <&imx219_0_ep>;
++			};
++		};
++	};
++};
++
++&cci_i2c0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	sensor@10 {
++		compatible = "sony,imx219";
++		reg = <0x10>;
++		clocks = <&cam24m>;
++		status = "okay";
++
++		VDIG-supply = <&cam_pwr_csi0>;
++		VANA-supply = <&cam_pwr_csi0>;
++		VDDL-supply = <&cam_pwr_csi0>;
++
++		reset-gpios = <&pca9555 0 GPIO_ACTIVE_HIGH>;
++
++		port {
++			/* MIPI CSI-2 bus endpoint */
++			imx219_0_ep: endpoint {
++				remote-endpoint = <&csiphy0_ep>;
++				clock-lanes = <0>;
++				data-lanes = <1 2 3 4>;
++				link-frequencies = /bits/ 64 <364000000>;
++			};
++		};
++	};
++};
+\ No newline at end of file
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-2lanes.dtso b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-2lanes.dtso
+new file mode 100644
+index 000000000000..51f164b4acd4
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-2lanes.dtso
+@@ -0,0 +1,49 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
++/*
++ * Copyright (c) 2025, Arduino SA
++ */
++
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include "qrb2210-arduino-imola-carrier-media-common.dtsi"
++
++&camss {
++	ports {
++		port@1 {
++			csiphy1_ep: endpoint {
++				data-lanes = <0 1>;
++				remote-endpoint = <&imx219_1_ep>;
++			};
++		};
++	};
++};
++
++&cci_i2c1 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	sensor@10 {
++		compatible = "sony,imx219";
++		reg = <0x10>;
++		clocks = <&cam24m>;
++		status = "okay";
++
++		VDIG-supply = <&cam_pwr_csi1>;
++		VANA-supply = <&cam_pwr_csi1>;
++		VDDL-supply = <&cam_pwr_csi1>;
++
++		reset-gpios = <&pca9555 2 GPIO_ACTIVE_HIGH>;
++
++	   port {
++			/* MIPI CSI-2 bus endpoint */
++			imx219_1_ep: endpoint {
++				remote-endpoint = <&csiphy1_ep>;
++				clock-lanes = <0>;
++				data-lanes = <1 2>;
++				link-frequencies = /bits/ 64 <456000000>;
++			};
++		};
++	};
++};
+\ No newline at end of file
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-4lanes.dtso b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-4lanes.dtso
+new file mode 100644
+index 000000000000..775966196656
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-camera-imx219-csi1-4lanes.dtso
+@@ -0,0 +1,49 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
++/*
++ * Copyright (c) 2025, Arduino SA
++ */
++
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include "qrb2210-arduino-imola-carrier-media-common.dtsi"
++
++&camss {
++	ports {
++		port@1 {
++			csiphy1_ep: endpoint {
++				data-lanes = <0 1 2 3>;
++				remote-endpoint = <&imx219_1_ep>;
++			};
++		};
++	};
++};
++
++&cci_i2c1 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	sensor@10 {
++		compatible = "sony,imx219";
++		reg = <0x10>;
++		clocks = <&cam24m>;
++		status = "okay";
++
++		VDIG-supply = <&cam_pwr_csi1>;
++		VANA-supply = <&cam_pwr_csi1>;
++		VDDL-supply = <&cam_pwr_csi1>;
++
++		reset-gpios = <&pca9555 2 GPIO_ACTIVE_HIGH>;
++
++		port {
++			/* MIPI CSI-2 bus endpoint */
++			imx219_1_ep: endpoint {
++				remote-endpoint = <&csiphy1_ep>;
++				clock-lanes = <0>;
++				data-lanes = <1 2 3 4>;
++				link-frequencies = /bits/ 64 <364000000>;
++			};
++		};
++	};
++};
+\ No newline at end of file
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-common.dtsi b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-common.dtsi
+new file mode 100644
+index 000000000000..dd3ad97d4633
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-common.dtsi
+@@ -0,0 +1,45 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
++/*
++ */
++
++#include <dt-bindings/gpio/gpio.h>
++
++&{/} {
++	cam_pwr_csi0: cam-pwr-csi0 {
++		compatible = "regulator-fixed";
++		regulator-name = "cam-pwr";
++		startup-delay-us = <100000>;
++		gpio = <&pca9555 1 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	cam_pwr_csi1: cam-pwr-csi1 {
++		compatible = "regulator-fixed";
++		regulator-name = "cam-pwr";
++		startup-delay-us = <100000>;
++		gpio = <&pca9555 3 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	clocks {
++		cam24m: cam-clk {
++			compatible = "fixed-clock";
++			#clock-cells = <0>;
++			clock-frequency = <24000000>;
++			clock-output-names = "cam24m";
++		};
++	};
++};
++
++&cci_i2c0 {
++	clock-frequency = <100000>;
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	pca9555: gpio@26 {
++		compatible = "nxp,pca9555";
++		reg = <0x26>;
++		gpio-controller;
++		#gpio-cells = <2>;
++	};
++};
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-panel-8in_touch_a-dsi.dtso b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-panel-8in_touch_a-dsi.dtso
+new file mode 100644
+index 000000000000..ce07422373dd
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-panel-8in_touch_a-dsi.dtso
+@@ -0,0 +1,58 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
++/*
++ * Copyright (c) 2025, Arduino SA
++ */
++
++ /dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include "qrb2210-arduino-imola-carrier-media-common.dtsi"
++
++&cci_i2c0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	display_mcu: display_mcu@45 {
++		compatible = "waveshare,touchscreen-panel-regulator";
++		reg = <0x45>;
++		gpio-controller;
++		#gpio-cells = <2>;
++		enable-gpio = <&display_mcu 2 GPIO_ACTIVE_HIGH>;
++	};
++
++	touch: goodix@5d {
++		compatible = "goodix,gt9271";
++		reg = <0x5d>;
++		reset-gpio = <&display_mcu 9 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&mdss_dsi0 {
++	vdda-supply = <&pm4125_l5>;
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	status = "okay";
++
++	dsi_panel: dsi_panel@0 {
++		reg = <0>;
++		compatible = "waveshare,8.0-dsi-touch-a-4lane";
++		reset-gpio = <&display_mcu 1 GPIO_ACTIVE_HIGH>;
++		iovcc-gpio = <&display_mcu 4 GPIO_ACTIVE_HIGH>;
++		avdd-gpio = <&display_mcu 0 GPIO_ACTIVE_HIGH>;
++		backlight = <&display_mcu>;
++
++		port {
++			panel_in: endpoint {
++				remote-endpoint = <&mdss_dsi0_out>;
++			};
++		};
++	};
++
++};
++
++&mdss_dsi0_out {
++	remote-endpoint = <&panel_in>;
++	data-lanes = <0 1 2 3>;
++};
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media.dtso b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media.dtso
+new file mode 100644
+index 000000000000..4f894e2c11f9
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media.dtso
+@@ -0,0 +1,131 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
++/*
++ * Copyright (c) 2025, Arduino SA
++ */
++
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include "qrb2210-arduino-imola-carrier-media-common.dtsi"
++
++&camss {
++	status = "okay";
++
++	vdda-csiphy-1p2-supply = <&pm4125_l5>;
++	vdda-pll-1p8-supply = <&pm4125_l13>;
++};
++
++&cci {
++	status= "okay";
++};
++
++&leds {
++	led1-blue {
++		label = "media-carrier:blue1";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_BLUE>;
++		gpios = <&pca9555 14 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++
++	led1-green {
++		label = "media-carrier:green1";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_GREEN>;
++		gpios = <&pca9555 15 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++
++	led1-red {
++		label = "media-carrier:red1";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_RED>;
++		gpios = <&pca9555 13 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++	led2-blue {
++		label = "media-carrier:blue2";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_BLUE>;
++		gpios = <&pca9555 11 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++
++	led2-green {
++		label = "media-carrier:green2";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_GREEN>;
++		gpios = <&pca9555 12 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++
++	led2-red {
++		label = "media-carrier:red2";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_RED>;
++		gpios = <&pca9555 10 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++
++	led3-blue {
++		label = "media-carrier:blue3";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_BLUE>;
++		gpios = <&pca9555 8 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++
++	led3-green {
++		label = "media-carrier:green3";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_GREEN>;
++		gpios = <&pca9555 9 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++
++	led3-red {
++		label = "media-carrier:red3";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_RED>;
++		gpios = <&pca9555 7 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++
++	led4-blue {
++		label = "media-carrier:blue4";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_BLUE>;
++		gpios = <&pca9555 5 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++
++	led4-green {
++		label = "media-carrier:green4";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_GREEN>;
++		gpios = <&pca9555 6 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++
++	led4-red {
++		label = "media-carrier:red4";
++		function = LED_FUNCTION_INDICATOR;
++		color = <LED_COLOR_ID_RED>;
++		gpios = <&pca9555 4 GPIO_ACTIVE_LOW>;
++		linux,default-trigger = "none";
++		default-state = "off";
++	};
++};
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-video_sound-usbc.dtso b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-video_sound-usbc.dtso
+new file mode 100644
+index 000000000000..6fb256498cd1
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-video_sound-usbc.dtso
+@@ -0,0 +1,61 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
++/*
++ * Copyright (c) 2025, Arduino SA
++ */
++
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/sound/qcom,q6asm.h>
++#include <dt-bindings/sound/qcom,q6dsp-lpass-ports.h>
++
++&anx7625 {
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@0 {
++			reg = <0>;
++			anx_dsi0_in: endpoint {
++				remote-endpoint = <&mdss_dsi0_out>;
++				data-lanes = <0 1 2 3>;
++			};
++		};
++	};
++};
++
++&mdss_dsi0_out {
++	remote-endpoint = <&anx_dsi0_in>;
++	data-lanes = <0 1 2 3>;
++};
++
++&q6afedai {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	#sound-dai-cells = <1>;
++	dai@18 {
++		reg = <SECONDARY_MI2S_RX>;
++		qcom,sd-lines = <0>;
++	};
++};
++
++&sound {
++	pinctrl-0 = <&lpi_i2s2_active>;
++	pinctrl-names = "default";
++
++	hdmi-i2s-dai-link {
++		link-name = "HDMI/I2S Playback";
++
++		cpu {
++			sound-dai = <&q6afedai SECONDARY_MI2S_RX>;
++		};
++
++		platform {
++			sound-dai = <&q6routing>;
++		};
++
++		codec {
++			sound-dai = <&anx7625 0>;
++		};
++	};
++};

--- a/patch/kernel/qrb2210-edge/0016-remoteproc-qcom_q6v5_pas-explicitly-list-firmware-fo.patch
+++ b/patch/kernel/qrb2210-edge/0016-remoteproc-qcom_q6v5_pas-explicitly-list-firmware-fo.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martino Facchin <m.facchin@arduino.cc>
+Date: Wed, 30 Jul 2025 16:17:59 +0200
+Subject: [PATCH 16/48] remoteproc: qcom_q6v5_pas: explicitly list firmware for
+ automatic inclusion in initramfs
+
+---
+ drivers/remoteproc/qcom_q6v5_pas.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/remoteproc/qcom_q6v5_pas.c b/drivers/remoteproc/qcom_q6v5_pas.c
+index 46204da046fa..e414131f5211 100644
+--- a/drivers/remoteproc/qcom_q6v5_pas.c
++++ b/drivers/remoteproc/qcom_q6v5_pas.c
+@@ -1619,3 +1619,5 @@ static struct platform_driver qcom_pas_driver = {
+ module_platform_driver(qcom_pas_driver);
+ MODULE_DESCRIPTION("Qualcomm Peripheral Authentication Service remoteproc driver");
+ MODULE_LICENSE("GPL v2");
++
++MODULE_FIRMWARE("qcom/qcm2290/adsp.mbn");

--- a/patch/kernel/qrb2210-edge/0017-gpu-drm-msm-add-explicit-firmware-for-a702.patch
+++ b/patch/kernel/qrb2210-edge/0017-gpu-drm-msm-add-explicit-firmware-for-a702.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martino Facchin <m.facchin@arduino.cc>
+Date: Thu, 24 Jul 2025 11:52:58 +0200
+Subject: [PATCH 17/48] gpu: drm: msm: add explicit firmware for a702
+
+update-initramfs uses this information to add the correct firmware to initramfs.
+Needed for early kms and plymouth to work properly
+---
+ drivers/gpu/drm/msm/adreno/a6xx_catalog.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/gpu/drm/msm/adreno/a6xx_catalog.c b/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
+index 38561f26837e..865e04344607 100644
+--- a/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
++++ b/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
+@@ -1967,3 +1967,6 @@ static inline __always_unused void __build_asserts(void)
+ 	BUILD_BUG_ON(a690_protect.count > a690_protect.count_max);
+ 	BUILD_BUG_ON(a730_protect.count > a730_protect.count_max);
+ }
++
++MODULE_FIRMWARE("qcom/a702_sqe.fw");
++MODULE_FIRMWARE("qcom/qcm2290/a702_zap.mbn");

--- a/patch/kernel/qrb2210-edge/0018-ASoC-qcom-sm8250-set-capture-channels-correctly.patch
+++ b/patch/kernel/qrb2210-edge/0018-ASoC-qcom-sm8250-set-capture-channels-correctly.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Date: Mon, 25 Aug 2025 23:08:33 +0100
+Subject: [PATCH 18/48] ASoC: qcom: sm8250: set capture channels correctly
+
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+---
+ sound/soc/qcom/sm8250.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/sound/soc/qcom/sm8250.c b/sound/soc/qcom/sm8250.c
+index f193d0ba63d0..385759496311 100644
+--- a/sound/soc/qcom/sm8250.c
++++ b/sound/soc/qcom/sm8250.c
+@@ -58,6 +58,7 @@ static void sm8250_snd_exit(struct snd_soc_pcm_runtime *rtd)
+ static int sm8250_be_hw_params_fixup(struct snd_soc_pcm_runtime *rtd,
+ 				     struct snd_pcm_hw_params *params)
+ {
++	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
+ 	struct snd_interval *rate = hw_param_interval(params,
+ 					SNDRV_PCM_HW_PARAM_RATE);
+ 	struct snd_interval *channels = hw_param_interval(params,
+@@ -68,6 +69,18 @@ static int sm8250_be_hw_params_fixup(struct snd_soc_pcm_runtime *rtd,
+ 	channels->min = channels->max = 2;
+ 	snd_mask_set_format(fmt, SNDRV_PCM_FORMAT_S16_LE);
+ 
++	switch (cpu_dai->id) {
++	case TX_CODEC_DMA_TX_0:
++	case TX_CODEC_DMA_TX_1:
++	case TX_CODEC_DMA_TX_2:
++	case TX_CODEC_DMA_TX_3:
++		channels->min = 1;
++		channels->min = channels->max = 1;
++		break;
++	default:
++		break;
++	}
++
+ 	return 0;
+ }
+ 

--- a/patch/kernel/qrb2210-edge/0019-ASoC-qcom-sm8250-set-i2s-format-needs.patch
+++ b/patch/kernel/qrb2210-edge/0019-ASoC-qcom-sm8250-set-i2s-format-needs.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Date: Fri, 12 Sep 2025 18:18:31 +0100
+Subject: [PATCH 19/48] ASoC: qcom: sm8250: set i2s format needs
+
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+---
+ sound/soc/qcom/sm8250.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/sound/soc/qcom/sm8250.c b/sound/soc/qcom/sm8250.c
+index 385759496311..8f6e1b03ad00 100644
+--- a/sound/soc/qcom/sm8250.c
++++ b/sound/soc/qcom/sm8250.c
+@@ -16,7 +16,7 @@
+ #include "usb_offload_utils.h"
+ #include "sdw.h"
+ 
+-#define MI2S_BCLK_RATE		1536000
++#define MI2S_BCLK_RATE		3072000
+ 
+ struct sm8250_snd_data {
+ 	bool stream_prepared[AFE_PORT_MAX];
+@@ -77,6 +77,14 @@ static int sm8250_be_hw_params_fixup(struct snd_soc_pcm_runtime *rtd,
+ 		channels->min = 1;
+ 		channels->min = channels->max = 1;
+ 		break;
++	case PRIMARY_MI2S_RX:
++	case SECONDARY_MI2S_RX:
++	case TERTIARY_MI2S_RX:
++		/* clean any param mask before setting new param */
++		snd_mask_reset_range(hw_param_mask(params, SNDRV_PCM_HW_PARAM_FORMAT),
++			     0, (__force unsigned int)SNDRV_PCM_FORMAT_LAST);
++		params_set_format(params, SNDRV_PCM_FORMAT_S32_LE);
++	break;
+ 	default:
+ 		break;
+ 	}

--- a/patch/kernel/qrb2210-edge/0020-ASoC-qcom-q6dsp-add-32-bit-support-for-i2s-backend-d.patch
+++ b/patch/kernel/qrb2210-edge/0020-ASoC-qcom-q6dsp-add-32-bit-support-for-i2s-backend-d.patch
@@ -1,0 +1,79 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Date: Fri, 12 Sep 2025 18:19:05 +0100
+Subject: [PATCH 20/48] ASoC: qcom: q6dsp: add 32 bit support for i2s backend
+ dais
+
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+---
+ sound/soc/qcom/qdsp6/q6dsp-lpass-ports.c | 14 +++++++++-----
+ sound/soc/qcom/qdsp6/q6routing.c         |  3 +++
+ 2 files changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/sound/soc/qcom/qdsp6/q6dsp-lpass-ports.c b/sound/soc/qcom/qdsp6/q6dsp-lpass-ports.c
+index 4eed54b071a5..b509bd8f6752 100644
+--- a/sound/soc/qcom/qdsp6/q6dsp-lpass-ports.c
++++ b/sound/soc/qcom/qdsp6/q6dsp-lpass-ports.c
+@@ -353,7 +353,7 @@ static struct snd_soc_dai_driver q6dsp_audio_fe_dais[] = {
+ 			.rates = SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_8000 |
+ 				 SNDRV_PCM_RATE_16000,
+ 			.formats = SNDRV_PCM_FMTBIT_S16_LE |
+-				   SNDRV_PCM_FMTBIT_S24_LE,
++				   SNDRV_PCM_FMTBIT_S24_LE | SNDRV_PCM_FMTBIT_S32_LE,
+ 			.channels_min = 1,
+ 			.channels_max = 8,
+ 			.rate_min =     8000,
+@@ -380,7 +380,8 @@ static struct snd_soc_dai_driver q6dsp_audio_fe_dais[] = {
+ 			.stream_name = "Secondary MI2S Playback",
+ 			.rates = SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_8000 |
+ 				 SNDRV_PCM_RATE_16000,
+-			.formats = SNDRV_PCM_FMTBIT_S16_LE,
++			.formats = SNDRV_PCM_FMTBIT_S16_LE |
++				   SNDRV_PCM_FMTBIT_S24_LE | SNDRV_PCM_FMTBIT_S32_LE,
+ 			.channels_min = 1,
+ 			.channels_max = 8,
+ 			.rate_min =     8000,
+@@ -407,7 +408,8 @@ static struct snd_soc_dai_driver q6dsp_audio_fe_dais[] = {
+ 			.stream_name = "Tertiary MI2S Playback",
+ 			.rates = SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_8000 |
+ 				 SNDRV_PCM_RATE_16000,
+-			.formats = SNDRV_PCM_FMTBIT_S16_LE,
++			.formats = SNDRV_PCM_FMTBIT_S16_LE |
++				   SNDRV_PCM_FMTBIT_S24_LE | SNDRV_PCM_FMTBIT_S32_LE,
+ 			.channels_min = 1,
+ 			.channels_max = 8,
+ 			.rate_min =     8000,
+@@ -434,7 +436,8 @@ static struct snd_soc_dai_driver q6dsp_audio_fe_dais[] = {
+ 			.stream_name = "Quaternary MI2S Playback",
+ 			.rates = SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_8000 |
+ 				 SNDRV_PCM_RATE_16000,
+-			.formats = SNDRV_PCM_FMTBIT_S16_LE,
++			.formats = SNDRV_PCM_FMTBIT_S16_LE |
++				   SNDRV_PCM_FMTBIT_S24_LE | SNDRV_PCM_FMTBIT_S32_LE,
+ 			.channels_min = 1,
+ 			.channels_max = 8,
+ 			.rate_min =     8000,
+@@ -462,7 +465,8 @@ static struct snd_soc_dai_driver q6dsp_audio_fe_dais[] = {
+ 			.rates = SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_8000 |
+ 			SNDRV_PCM_RATE_16000 | SNDRV_PCM_RATE_96000 |
+ 			SNDRV_PCM_RATE_192000,
+-			.formats = SNDRV_PCM_FMTBIT_S16_LE,
++			.formats = SNDRV_PCM_FMTBIT_S16_LE |
++				   SNDRV_PCM_FMTBIT_S24_LE | SNDRV_PCM_FMTBIT_S32_LE,
+ 			.channels_min = 1,
+ 			.channels_max = 8,
+ 			.rate_min =     8000,
+diff --git a/sound/soc/qcom/qdsp6/q6routing.c b/sound/soc/qcom/qdsp6/q6routing.c
+index 7386226046fa..bbaa47303456 100644
+--- a/sound/soc/qcom/qdsp6/q6routing.c
++++ b/sound/soc/qcom/qdsp6/q6routing.c
+@@ -1083,6 +1083,9 @@ static int routing_hw_params(struct snd_soc_component *component,
+ 	case SNDRV_PCM_FORMAT_S24_LE:
+ 			session->bits_per_sample = 24;
+ 		break;
++	case SNDRV_PCM_FORMAT_S32_LE:
++			session->bits_per_sample = 32;
++		break;
+ 	default:
+ 		break;
+ 	}

--- a/patch/kernel/qrb2210-edge/0021-anx7625-allow-32-bit-format.patch
+++ b/patch/kernel/qrb2210-edge/0021-anx7625-allow-32-bit-format.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+Date: Fri, 12 Sep 2025 18:20:20 +0100
+Subject: [PATCH 21/48] anx7625: allow 32 bit format
+
+The chip requires 32 bit frame, with 16-24 bits of valid data left aligned
+TODO: check that the output format is correct
+
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@oss.qualcomm.com>
+---
+ drivers/gpu/drm/bridge/analogix/anx7625.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/bridge/analogix/anx7625.c b/drivers/gpu/drm/bridge/analogix/anx7625.c
+index 763519ef0d38..0d4102250ec6 100644
+--- a/drivers/gpu/drm/bridge/analogix/anx7625.c
++++ b/drivers/gpu/drm/bridge/analogix/anx7625.c
+@@ -2061,6 +2061,7 @@ static int anx7625_audio_hw_params(struct device *dev, void *data,
+ 		wl = AUDIO_W_LEN_20_20MAX;
+ 		break;
+ 	case 24:
++	case 32:
+ 		wl = AUDIO_W_LEN_24_24MAX;
+ 		break;
+ 	default:

--- a/patch/kernel/qrb2210-edge/0022-drm-anx7625-set-I2S-input-stream-as-right-justified.patch
+++ b/patch/kernel/qrb2210-edge/0022-drm-anx7625-set-I2S-input-stream-as-right-justified.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martino Facchin <m.facchin@arduino.cc>
+Date: Tue, 14 Apr 2026 18:19:54 +0200
+Subject: [PATCH 22/48] drm: anx7625: set I2S input stream as right justified
+
+Limitiations of Qualcomm DSP make it very hard to left justify (chip's default)
+---
+ drivers/gpu/drm/bridge/analogix/anx7625.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/gpu/drm/bridge/analogix/anx7625.c b/drivers/gpu/drm/bridge/analogix/anx7625.c
+index 0d4102250ec6..9bff228917fc 100644
+--- a/drivers/gpu/drm/bridge/analogix/anx7625.c
++++ b/drivers/gpu/drm/bridge/analogix/anx7625.c
+@@ -2101,6 +2101,11 @@ static int anx7625_audio_hw_params(struct device *dev, void *data,
+ 		ret |= anx7625_write_and(ctx, ctx->i2c.tx_p2_client,
+ 				AUDIO_CHANNEL_STATUS_6, ~AUDIO_LAYOUT);
+ 
++
++	/* Right justified for Qualcomm DSP limitations */
++	ret |= anx7625_write_or(ctx, ctx->i2c.tx_p2_client,
++				AUDIO_CONTROL_REGISTER,	1);
++
+ 	/* FS */
+ 	switch (params->sample_rate) {
+ 	case 32000:

--- a/patch/kernel/qrb2210-edge/0023-ASoC-qcom-qdsp6-fix-microphone-stream-re-enable.patch
+++ b/patch/kernel/qrb2210-edge/0023-ASoC-qcom-qdsp6-fix-microphone-stream-re-enable.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martino Facchin <m.facchin@arduino.cc>
+Date: Thu, 16 Apr 2026 14:53:29 +0200
+Subject: [PATCH 23/48] ASoC: qcom: qdsp6: fix microphone stream re-enable
+
+---
+ sound/soc/qcom/qdsp6/q6asm-dai.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/sound/soc/qcom/qdsp6/q6asm-dai.c b/sound/soc/qcom/qdsp6/q6asm-dai.c
+index 9e3d176f50c2..bd7ab7c9a5c7 100644
+--- a/sound/soc/qcom/qdsp6/q6asm-dai.c
++++ b/sound/soc/qcom/qdsp6/q6asm-dai.c
+@@ -224,15 +224,19 @@ static int q6asm_dai_prepare(struct snd_soc_component *component,
+ 	}
+ 
+ 	prtd->pcm_count = snd_pcm_lib_period_bytes(substream);
+-	/* rate and channels are sent to audio driver */
+-	if (prtd->state == Q6ASM_STREAM_RUNNING) {
++	/*
++	 * Re-prepare can be called after STOP without closing the previous
++	 * stream session. Ensure any non-idle session is torn down before
++	 * issuing a new OPEN command.
++	 */
++	if (prtd->state != Q6ASM_STREAM_IDLE) {
+ 		/* clear the previous setup if any  */
+ 		q6asm_cmd(prtd->audio_client, prtd->stream_id, CMD_CLOSE);
+ 		q6asm_unmap_memory_regions(substream->stream,
+ 					   prtd->audio_client);
+ 		q6routing_stream_close(soc_prtd->dai_link->id,
+ 					 substream->stream);
+-		prtd->state = Q6ASM_STREAM_STOPPED;
++		prtd->state = Q6ASM_STREAM_IDLE;
+ 	}
+ 
+ 	ret = q6asm_map_memory_regions(substream->stream, prtd->audio_client,
+@@ -257,7 +261,7 @@ static int q6asm_dai_prepare(struct snd_soc_component *component,
+ 	}
+ 
+ 	if (ret < 0) {
+-		dev_err(dev, "%s: q6asm_open_write failed\n", __func__);
++		dev_err(dev, "%s: q6asm_open failed\n", __func__);
+ 		goto open_err;
+ 	}
+ 

--- a/patch/kernel/qrb2210-edge/0024-ASoC-codecs-pm4125-harden-swr-discovery-path.patch
+++ b/patch/kernel/qrb2210-edge/0024-ASoC-codecs-pm4125-harden-swr-discovery-path.patch
@@ -1,0 +1,131 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martino Facchin <m.facchin@arduino.cc>
+Date: Wed, 1 Apr 2026 09:49:15 +0200
+Subject: [PATCH 24/48] ASoC: codecs: pm4125: harden swr discovery path
+
+Completes ASoC: codecs: pm4125: fix array-out-of-bounds
+by adding extra checks. This avoids a race condition crash on
+dapm_power_widgets(), where for_each_card_dapms(card, d)
+returns a corrupted pointer
+
+Signed-off-by: Martino Facchin <m.facchin@arduino.cc>
+---
+ sound/soc/codecs/pm4125.c | 61 +++++++++++++++++++++++++++++++++++----
+ 1 file changed, 56 insertions(+), 5 deletions(-)
+
+diff --git a/sound/soc/codecs/pm4125.c b/sound/soc/codecs/pm4125.c
+index 52594a9608f3..1ce7c87eb37b 100644
+--- a/sound/soc/codecs/pm4125.c
++++ b/sound/soc/codecs/pm4125.c
+@@ -843,15 +843,29 @@ static int pm4125_codec_enable_micbias_pullup(struct snd_soc_dapm_widget *w,
+ static int pm4125_connect_port(struct pm4125_sdw_priv *sdw_priv, u8 port_idx, u8 ch_id, bool enable)
+ {
+ 	struct sdw_port_config *port_config;
+-	const struct wcd_sdw_ch_info *ch_info = &sdw_priv->ch_info[ch_id];
++	const struct wcd_sdw_ch_info *ch_info;
+ 	struct sdw_slave *sdev = sdw_priv->sdev;
+-	u8 port_num = ch_info->port_num;
+-	u8 ch_mask = ch_info->ch_mask;
++	u8 port_num, ch_mask;
+ 	u8 mstr_port_num, mstr_ch_mask;
+ 
+ 	if (!port_idx) /* Invalid port index */
+ 		return -EINVAL;
+ 
++	if (sdw_priv->is_tx) {
++		if (ch_id > PM4125_ADC2)
++			return -EINVAL;
++	} else {
++		if (ch_id > PM4125_COMP_R)
++			return -EINVAL;
++	}
++
++	ch_info = &sdw_priv->ch_info[ch_id];
++	port_num = ch_info->port_num;
++	ch_mask = ch_info->ch_mask;
++
++	if (!port_num || port_num > PM4125_MAX_SWR_PORTS)
++		return -EINVAL;
++
+ 	port_config = &sdw_priv->port_config[port_idx - 1];
+ 
+ 	port_config->num = port_num;
+@@ -893,10 +907,18 @@ static int pm4125_set_compander(struct snd_kcontrol *kcontrol, struct snd_ctl_el
+ 	struct soc_mixer_control *mc;
+ 	int portidx;
+ 	bool hphr;
++	int ch_idx;
+ 
+ 	mc = (struct soc_mixer_control *)(kcontrol->private_value);
++	ch_idx = mc->reg;
+ 	hphr = mc->shift;
+ 
++	if (!sdw_priv)
++		return -EINVAL;
++
++	if (ch_idx < 0 || ch_idx > PM4125_COMP_R)
++		return -EINVAL;
++
+ 	if (hphr) {
+ 		if (value == pm4125->comp2_enable)
+ 			return 0;
+@@ -909,11 +931,11 @@ static int pm4125_set_compander(struct snd_kcontrol *kcontrol, struct snd_ctl_el
+ 		pm4125->comp1_enable = value;
+ 	}
+ 
+-	portidx = sdw_priv->ch_info[mc->reg].port_num;
++	portidx = sdw_priv->ch_info[ch_idx].port_num;
+ 	if (!portidx)
+ 		return 0;
+ 
+-	pm4125_connect_port(sdw_priv, portidx, mc->reg, value ? true : false);
++	pm4125_connect_port(sdw_priv, portidx, ch_idx, value ? true : false);
+ 
+ 	return 1;
+ }
+@@ -928,8 +950,24 @@ static int pm4125_get_swr_port(struct snd_kcontrol *kcontrol, struct snd_ctl_ele
+ 	int ch_idx = mixer->reg;
+ 	int portidx;
+ 
++	if (dai_id < 0 || dai_id >= NUM_CODEC_DAIS)
++		return -EINVAL;
++
+ 	sdw_priv = pm4125->sdw_priv[dai_id];
++	if (!sdw_priv)
++		return -EINVAL;
++
++	if (sdw_priv->is_tx) {
++		if (ch_idx < 0 || ch_idx > PM4125_ADC2)
++			return -EINVAL;
++	} else {
++		if (ch_idx < 0 || ch_idx > PM4125_HPH_R)
++			return -EINVAL;
++	}
++
+ 	portidx = sdw_priv->ch_info[ch_idx].port_num;
++	if (!portidx) /* Invalid port index */
++		return 0;
+ 
+ 	ucontrol->value.integer.value[0] = sdw_priv->port_enable[portidx];
+ 
+@@ -947,7 +985,20 @@ static int pm4125_set_swr_port(struct snd_kcontrol *kcontrol, struct snd_ctl_ele
+ 	int portidx;
+ 	bool enable;
+ 
++	if (dai_id < 0 || dai_id >= NUM_CODEC_DAIS)
++		return -EINVAL;
++
+ 	sdw_priv = pm4125->sdw_priv[dai_id];
++	if (!sdw_priv)
++		return -EINVAL;
++
++	if (sdw_priv->is_tx) {
++		if (ch_idx < 0 || ch_idx > PM4125_ADC2)
++			return -EINVAL;
++	} else {
++		if (ch_idx < 0 || ch_idx > PM4125_HPH_R)
++			return -EINVAL;
++	}
+ 
+ 	portidx = sdw_priv->ch_info[ch_idx].port_num;
+ 	if (!portidx) /* Invalid port index */

--- a/patch/kernel/qrb2210-edge/0025-dt-bindings-display-panel-himax-hx83102-describe-Wav.patch
+++ b/patch/kernel/qrb2210-edge/0025-dt-bindings-display-panel-himax-hx83102-describe-Wav.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:24 +0300
+Subject: [PATCH 25/48] dt-bindings: display/panel: himax,hx83102: describe
+ Waveshare panel
+
+Describe Waveshare 12.3-DSI-TOUCH-A panel which allegedly uses HX83102
+as a panel controller.
+
+Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ .../devicetree/bindings/display/panel/himax,hx83102.yaml        | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/display/panel/himax,hx83102.yaml b/Documentation/devicetree/bindings/display/panel/himax,hx83102.yaml
+index e4c1aa5deab9..5fb05119c5f9 100644
+--- a/Documentation/devicetree/bindings/display/panel/himax,hx83102.yaml
++++ b/Documentation/devicetree/bindings/display/panel/himax,hx83102.yaml
+@@ -28,6 +28,8 @@ properties:
+           - starry,2082109qfh040022-50e
+           # STARRY himax83102-j02 10.51" WUXGA TFT LCD panel
+           - starry,himax83102-j02
++          # Waveshare 12.3-DSI-TOUCH-A panel
++          - waveshare,12.3-dsi-touch-a
+       - const: himax,hx83102
+ 
+   reg:

--- a/patch/kernel/qrb2210-edge/0026-dt-bindings-display-panel-himax-hx8394-describe-Wave.patch
+++ b/patch/kernel/qrb2210-edge/0026-dt-bindings-display-panel-himax-hx8394-describe-Wave.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:25 +0300
+Subject: [PATCH 26/48] dt-bindings: display/panel: himax,hx8394: describe
+ Waveshare panel
+
+Describe Waveshare 5" and 5" DSI panels which use HX9365-E as a panel
+controller.
+
+Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ .../devicetree/bindings/display/panel/himax,hx8394.yaml         | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/display/panel/himax,hx8394.yaml b/Documentation/devicetree/bindings/display/panel/himax,hx8394.yaml
+index 5725a587e35c..629a395b51d3 100644
+--- a/Documentation/devicetree/bindings/display/panel/himax,hx8394.yaml
++++ b/Documentation/devicetree/bindings/display/panel/himax,hx8394.yaml
+@@ -23,6 +23,8 @@ properties:
+               - hannstar,hsd060bhw4
+               - microchip,ac40t08a-mipi-panel
+               - powkiddy,x55-panel
++              - waveshare,5.0-dsi-touch-a
++              - waveshare,5.5-dsi-touch-a
+           - const: himax,hx8394
+       - items:
+           - enum:

--- a/patch/kernel/qrb2210-edge/0027-dt-bindings-display-panel-jadard-jd9365da-h3-describ.patch
+++ b/patch/kernel/qrb2210-edge/0027-dt-bindings-display-panel-jadard-jd9365da-h3-describ.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:26 +0300
+Subject: [PATCH 27/48] dt-bindings: display/panel: jadard,jd9365da-h3:
+ describe Waveshare panel
+
+Describe Waveshare DSI panels which use JD9365 as a panel controller.
+
+Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ .../bindings/display/panel/jadard,jd9365da-h3.yaml         | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/display/panel/jadard,jd9365da-h3.yaml b/Documentation/devicetree/bindings/display/panel/jadard,jd9365da-h3.yaml
+index 5802fb3c9ffe..def7405b9034 100644
+--- a/Documentation/devicetree/bindings/display/panel/jadard,jd9365da-h3.yaml
++++ b/Documentation/devicetree/bindings/display/panel/jadard,jd9365da-h3.yaml
+@@ -23,6 +23,13 @@ properties:
+           - melfas,lmfbx101117480
+           - radxa,display-10hd-ad001
+           - radxa,display-8hd-ad002
++          - waveshare,3.4-dsi-touch-c
++          - waveshare,4.0-dsi-touch-c
++          - waveshare,8.0-dsi-touch-a
++          - waveshare,9.0-dsi-touch-b
++          - waveshare,10.1-dsi-touch-a
++          - waveshare,10.1-dsi-touch-b
++
+       - const: jadard,jd9365da-h3
+ 
+   reg:

--- a/patch/kernel/qrb2210-edge/0028-dt-bindings-display-panel-ilitek-ili9881c-describe-W.patch
+++ b/patch/kernel/qrb2210-edge/0028-dt-bindings-display-panel-ilitek-ili9881c-describe-W.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:27 +0300
+Subject: [PATCH 28/48] dt-bindings: display/panel: ilitek,ili9881c: describe
+ Waveshare panel
+
+Describe Waveshare 7" DSI panel which uses ILI9881 as a panel
+controller. This panel requires two voltags supplies, so add separate
+iovcc supply.
+
+Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ .../devicetree/bindings/display/panel/ilitek,ili9881c.yaml      | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/display/panel/ilitek,ili9881c.yaml b/Documentation/devicetree/bindings/display/panel/ilitek,ili9881c.yaml
+index d979701a00a8..42e35986fbf6 100644
+--- a/Documentation/devicetree/bindings/display/panel/ilitek,ili9881c.yaml
++++ b/Documentation/devicetree/bindings/display/panel/ilitek,ili9881c.yaml
+@@ -24,6 +24,7 @@ properties:
+           - raspberrypi,dsi-7inch
+           - startek,kd050hdfia020
+           - tdo,tl050hdv35
++          - waveshare,7.0-dsi-touch-a
+           - wanchanglong,w552946aaa
+           - wanchanglong,w552946aba
+       - const: ilitek,ili9881c
+@@ -34,6 +35,7 @@ properties:
+   backlight: true
+   port: true
+   power-supply: true
++  iovcc-supply: true
+   reset-gpios: true
+   rotation: true
+ 

--- a/patch/kernel/qrb2210-edge/0029-dt-bindings-dipslay-panel-describe-panels-using-Foca.patch
+++ b/patch/kernel/qrb2210-edge/0029-dt-bindings-dipslay-panel-describe-panels-using-Foca.patch
@@ -1,0 +1,92 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:28 +0300
+Subject: [PATCH 29/48] dt-bindings: dipslay/panel: describe panels using
+ Focaltech OTA7290B
+
+Add schema for the panels using Focaltech OTA7290B controller. For now
+there is only one such panel, from the Waveshare 8.8 DSI TOUCH-A kit.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
+---
+ .../display/panel/focaltech,ota7290b.yaml     | 70 +++++++++++++++++++
+ 1 file changed, 70 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/display/panel/focaltech,ota7290b.yaml
+
+diff --git a/Documentation/devicetree/bindings/display/panel/focaltech,ota7290b.yaml b/Documentation/devicetree/bindings/display/panel/focaltech,ota7290b.yaml
+new file mode 100644
+index 000000000000..db6775f4d75c
+--- /dev/null
++++ b/Documentation/devicetree/bindings/display/panel/focaltech,ota7290b.yaml
+@@ -0,0 +1,70 @@
++# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/display/panel/focaltech,ota7290b.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: Focaltech OTA7290B DSI panels
++
++maintainers:
++  - Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
++
++allOf:
++  - $ref: panel-common.yaml#
++
++properties:
++  compatible:
++    const: waveshare,8.8-dsi-touch-a
++
++  reg:
++    maxItems: 1
++
++  vdd-supply:
++    description: supply regulator for VDD, usually 3.3V
++
++  vdda-supply:
++    description: supply regulator for VDDA, 7-10V
++
++  vcc-supply:
++    description: supply regulator for VCCIO, usually 1.5V
++
++  reset-gpios: true
++  backlight: true
++  rotation: true
++  port: true
++
++required:
++  - compatible
++  - reg
++  - vdd-supply
++  - vcc-supply
++  - reset-gpios
++
++additionalProperties: false
++
++examples:
++  - |
++    #include <dt-bindings/gpio/gpio.h>
++
++    dsi {
++        #address-cells = <1>;
++        #size-cells = <0>;
++
++        panel@0 {
++            compatible = "waveshare,8.8-dsi-touch-a";
++            reg = <0>;
++            vdd-supply = <&vdd>;
++            vcc-supply = <&vccio>;
++            reset-gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
++            backlight = <&backlight>;
++
++            port {
++                endpoint {
++                    remote-endpoint = <&mipi_out_panel>;
++                };
++            };
++        };
++    };
++
++...
++

--- a/patch/kernel/qrb2210-edge/0030-drm-of-add-helper-to-count-data-lanes-on-a-remote-en.patch
+++ b/patch/kernel/qrb2210-edge/0030-drm-of-add-helper-to-count-data-lanes-on-a-remote-en.patch
@@ -1,0 +1,95 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:29 +0300
+Subject: [PATCH 30/48] drm/of: add helper to count data-lanes on a remote
+ endpoint
+
+If the DSI panel supports versatile lanes configuration, its driver
+might require determining the number of DSI data lanes, which is usually
+specified on the DSI host side of the OF graph. Add new helper as a
+pair to drm_of_get_data_lanes_count_ep() that lets callers determine
+number of data-lanes on the remote side of the OF graph.
+
+Reviewed-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ drivers/gpu/drm/drm_of.c | 34 ++++++++++++++++++++++++++++++++++
+ include/drm/drm_of.h     | 13 +++++++++++++
+ 2 files changed, 47 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_of.c b/drivers/gpu/drm/drm_of.c
+index 4f65ce729a47..ef6b09316963 100644
+--- a/drivers/gpu/drm/drm_of.c
++++ b/drivers/gpu/drm/drm_of.c
+@@ -558,6 +558,40 @@ int drm_of_get_data_lanes_count_ep(const struct device_node *port,
+ }
+ EXPORT_SYMBOL_GPL(drm_of_get_data_lanes_count_ep);
+ 
++/**
++ * drm_of_get_data_lanes_count_remote - Get DSI/(e)DP data lane count by endpoint
++ * @port: DT port node of the DSI/(e)DP source or sink
++ * @port_reg: identifier (value of reg property) of the parent port node
++ * @reg: identifier (value of reg property) of the endpoint node
++ * @min: minimum supported number of data lanes
++ * @max: maximum supported number of data lanes
++ *
++ * Count DT "data-lanes" property elements in the remote endpoint and check for
++ * validity.  This variant uses endpoint specifier.
++ *
++ * Return:
++ * * min..max - positive integer count of "data-lanes" elements
++ * * -EINVAL - the "data-lanes" property is unsupported
++ * * -ENODEV - the "data-lanes" property is missing
++ */
++int drm_of_get_data_lanes_count_remote(const struct device_node *port,
++				       int port_reg, int reg,
++				       const unsigned int min,
++				       const unsigned int max)
++{
++	struct device_node *endpoint, *remote;
++	int ret;
++
++	endpoint = of_graph_get_endpoint_by_regs(port, port_reg, reg);
++	remote = of_graph_get_remote_endpoint(endpoint);
++	of_node_put(endpoint);
++	ret = drm_of_get_data_lanes_count(remote, min, max);
++	of_node_put(remote);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(drm_of_get_data_lanes_count_remote);
++
+ #if IS_ENABLED(CONFIG_DRM_MIPI_DSI)
+ 
+ /**
+diff --git a/include/drm/drm_of.h b/include/drm/drm_of.h
+index f2f2bf82eff9..7bcc0ccfe0f4 100644
+--- a/include/drm/drm_of.h
++++ b/include/drm/drm_of.h
+@@ -62,6 +62,10 @@ int drm_of_get_data_lanes_count_ep(const struct device_node *port,
+ 				   int port_reg, int reg,
+ 				   const unsigned int min,
+ 				   const unsigned int max);
++int drm_of_get_data_lanes_count_remote(const struct device_node *port,
++				       int port_reg, int reg,
++				       const unsigned int min,
++				       const unsigned int max);
+ #else
+ static inline uint32_t drm_of_crtc_port_mask(struct drm_device *dev,
+ 					  struct device_node *port)
+@@ -140,6 +144,15 @@ drm_of_get_data_lanes_count_ep(const struct device_node *port,
+ {
+ 	return -EINVAL;
+ }
++
++static inline int
++drm_of_get_data_lanes_count_remote(const struct device_node *port,
++				   int port_reg, int reg,
++				   const unsigned int min,
++				   const unsigned int max)
++{
++	return -EINVAL;
++}
+ #endif
+ 
+ #if IS_ENABLED(CONFIG_OF) && IS_ENABLED(CONFIG_DRM_MIPI_DSI)

--- a/patch/kernel/qrb2210-edge/0031-drm-panel-himax-hx83102-support-Waveshare-12.3-DSI-p.patch
+++ b/patch/kernel/qrb2210-edge/0031-drm-panel-himax-hx83102-support-Waveshare-12.3-DSI-p.patch
@@ -1,0 +1,213 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:30 +0300
+Subject: [PATCH 31/48] drm/panel: himax-hx83102: support Waveshare 12.3" DSI
+ panel
+
+Add support for the Waveshare 12.3" DSI TOUCH-A panel. According to the
+vendor driver, it uses different mode_flags, so let the panel
+descriptions override driver-wide defaults.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Reviewed-by: Neil Armstrong <neil.armstrong@linaro.org>
+---
+ drivers/gpu/drm/panel/panel-himax-hx83102.c | 146 +++++++++++++++++++-
+ 1 file changed, 144 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/panel/panel-himax-hx83102.c b/drivers/gpu/drm/panel/panel-himax-hx83102.c
+index 1d3bb5dca559..320663ec6b4f 100644
+--- a/drivers/gpu/drm/panel/panel-himax-hx83102.c
++++ b/drivers/gpu/drm/panel/panel-himax-hx83102.c
+@@ -28,11 +28,14 @@
+ #define HX83102_UNKNOWN_B8	0xb8
+ #define HX83102_SETEXTC		0xb9
+ #define HX83102_SETMIPI		0xba
++#define HX83102_UNKNOWN_BB	0xbb
+ #define HX83102_SETVDC		0xbc
+ #define HX83102_SETBANK		0xbd
+ #define HX83102_UNKNOWN_BE	0xbe
+ #define HX83102_SETPTBA		0xbf
+ #define HX83102_SETSTBA		0xc0
++#define HX83102_UNKNOWN_C2	0xc2
++#define HX83102_UNKNOWN_C6	0xc6
+ #define HX83102_SETTCON		0xc7
+ #define HX83102_SETRAMDMY	0xc8
+ #define HX83102_SETPWM		0xc9
+@@ -76,6 +79,9 @@ struct hx83102_panel_desc {
+ 		unsigned int height_mm;
+ 	} size;
+ 
++	bool has_backlight;
++	unsigned long mode_flags;
++
+ 	int (*init)(struct hx83102 *ctx);
+ };
+ 
+@@ -701,6 +707,111 @@ static int starry_2082109qfh040022_50e_init(struct hx83102 *ctx)
+ 	return dsi_ctx.accum_err;
+ }
+ 
++/* This is HX83102-E, assuming commands are the same as the normal HX83102 */
++static int waveshare_12_3_a_init(struct hx83102 *ctx)
++{
++	struct mipi_dsi_multi_context dsi_ctx = { .dsi = ctx->dsi };
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETEXTC, 0x83, 0x10, 0x2e);
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETSPCCMD, 0xcd);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_UNKNOWN_BB, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETSPCCMD, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETPCTRL, 0x67, 0x2c, 0xff, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_UNKNOWN_BE, 0x11, 0x96, 0x89);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_UNKNOWN_D9, 0x04, 0x03, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETPOWER,
++	                             0x10, 0xfa, 0xaf, 0xaf, 0x33, 0x33, 0xb1, 0x4d, 0x2f, 0x36,
++	                             0x36, 0x36, 0x36, 0x22, 0x21, 0x15, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETDISP,
++	                             0x00, 0xd0, 0x27, 0x80, 0x00, 0x14, 0x40, 0x2c, 0x32, 0x02,
++	                             0x00, 0x00, 0x15, 0x20, 0xd7, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETCYC,
++	                             0x98, 0xa0, 0x01, 0x01, 0x98, 0xa0, 0x68, 0x50, 0x01, 0xc7,
++	                             0x01, 0x58, 0x00, 0xff, 0x00, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_UNKNOWN_B6, 0x4d, 0x4d, 0xe3);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETPTBA, 0xfc, 0x85, 0x80);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_UNKNOWN_D2, 0x33, 0x33);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETGIP0,
++	                             0x00, 0x00, 0x00, 0x00, 0x64, 0x04, 0x00, 0x08, 0x08, 0x27,
++	                             0x27, 0x22, 0x2f, 0x15, 0x15, 0x04, 0x04, 0x32, 0x10, 0x13,
++	                             0x00, 0x13, 0x32, 0x10, 0x1f, 0x00,
++	                             0x02, 0x32, 0x17, 0xfd, 0x00, 0x10, 0x00, 0x00, 0x20,
++	                             0x30, 0x01, 0x55, 0x21, 0x38, 0x01, 0x55, 0x0f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETGMA,
++	                             0x00, 0x0c, 0x1a, 0x23, 0x2b, 0x4f, 0x64, 0x69, 0x6c, 0x64,
++	                             0x77, 0x77, 0x76, 0x80, 0x79, 0x7e, 0x85, 0x9a, 0x97, 0x4d,
++	                             0x56, 0x64, 0x70, 0x00, 0x0c, 0x1a, 0x23, 0x2b, 0x4f, 0x64,
++	                             0x69, 0x6c, 0x64, 0x77, 0x77, 0x76, 0x80, 0x79, 0x7e, 0x85,
++	                             0x9a, 0x97, 0x4d, 0x56, 0x64, 0x76);
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETBANK, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETPOWER, 0x01, 0x9b, 0x01, 0x31);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETCLOCK,
++	                             0x80, 0x36, 0x12, 0x16, 0xc0, 0x28, 0x40, 0x84, 0x22);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETGIP0,
++	                             0x01, 0x00, 0xfc, 0x00, 0x00, 0x11, 0x10, 0x00, 0x0e, 0x00,
++	                             0x01);
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETBANK, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETCYC, 0x4e, 0x00, 0x33, 0x11, 0x33, 0x88);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETPTBA, 0xf2, 0x00, 0x02);
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETBANK, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETSTBA,
++	                             0x23, 0x23, 0x22, 0x11, 0xa2, 0x17, 0x00, 0x80, 0x00, 0x00,
++	                             0x08, 0x00, 0x63, 0x63);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_UNKNOWN_C6, 0xf9);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETTCON, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETRAMDMY,
++	                             0x00, 0x04, 0x04, 0x00, 0x00, 0x82, 0x13, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETCASCADE, 0x07, 0x04, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETGIP1,
++	                             0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x21, 0x20, 0x21, 0x20,
++	                             0x01, 0x00, 0x03, 0x02, 0x05, 0x04, 0x07, 0x06, 0x1a, 0x1a,
++	                             0x1a, 0x1a, 0x9a, 0x9a, 0x9a, 0x9a, 0x18, 0x18, 0x18, 0x18,
++	                             0x21, 0x20, 0x21, 0x20, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
++	                             0x18, 0x18, 0x18, 0x18);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETGIP2,
++	                             0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x20, 0x21, 0x20, 0x21,
++	                             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x1a, 0x1a,
++	                             0x1a, 0x1a, 0x1a, 0x1a, 0x1a, 0x1a, 0x18, 0x18, 0x18, 0x18,
++	                             0x20, 0x21, 0x20, 0x21, 0x98, 0x98, 0x98, 0x98, 0x98, 0x98,
++	                             0x98, 0x98, 0x98, 0x98);
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETBANK, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETTP1,
++	                             0x00, 0x34, 0x01, 0x88, 0x0e, 0xbe, 0x0f);
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETBANK, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_UNKNOWN_C2, 0x43, 0xff, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETPANEL, 0x02);
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETBANK, 0x03);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETDISP, 0x80);
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETBANK, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETGIP3,
++	                             0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
++	                             0xaa, 0xaa, 0xaa, 0x80, 0x2a, 0xaa, 0xaa, 0xaa, 0xaa, 0x80,
++	                             0x2a, 0xaa, 0xaa, 0xaa);
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETBANK, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETGIP3,
++	                             0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
++	                             0xaa, 0xaa);
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETBANK, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETGIP3,
++	                             0xff, 0xff, 0xff, 0xff,
++	                             0xff, 0xf0, 0xff, 0xff,
++	                             0xff, 0xff, 0xff, 0xf0);
++
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, HX83102_SETBANK, 0x00);
++
++	return dsi_ctx.accum_err;
++};
++
+ static const struct drm_display_mode starry_mode = {
+ 	.clock = 162680,
+ 	.hdisplay = 1200,
+@@ -833,6 +944,30 @@ static const struct hx83102_panel_desc starry_2082109qfh040022_50e_desc = {
+ 	.init = starry_2082109qfh040022_50e_init,
+ };
+ 
++static const struct drm_display_mode waveshare_12_3_a_mode = {
++	.clock = 95000,
++	.hdisplay = 720,
++	.hsync_start = 720 + 10,
++	.hsync_end = 720 + 10 + 10,
++	.htotal = 720 + 10 + 10 + 12,
++	.vdisplay = 1920,
++	.vsync_start = 1920 + 64,
++	.vsync_end = 1920 + 64 + 18,
++	.vtotal = 1920 + 64 + 18 + 4,
++	.type = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED,
++};
++
++static const struct hx83102_panel_desc waveshare_12_3_inch_a_desc = {
++	.modes = &waveshare_12_3_a_mode,
++	.size = {
++		.width_mm = 109,
++		.height_mm = 292,
++	},
++	.mode_flags = MIPI_DSI_MODE_VIDEO_HSE | MIPI_DSI_MODE_VIDEO |
++	              MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
++	.init = waveshare_12_3_a_init,
++};
++
+ static int hx83102_enable(struct drm_panel *panel)
+ {
+ 	msleep(130);
+@@ -1020,8 +1155,12 @@ static int hx83102_probe(struct mipi_dsi_device *dsi)
+ 	desc = of_device_get_match_data(&dsi->dev);
+ 	dsi->lanes = 4;
+ 	dsi->format = MIPI_DSI_FMT_RGB888;
+-	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_SYNC_PULSE |
+-					  MIPI_DSI_MODE_LPM;
++	if (desc->mode_flags)
++		dsi->mode_flags = desc->mode_flags;
++	else
++		dsi->mode_flags = MIPI_DSI_MODE_VIDEO |
++		                  MIPI_DSI_MODE_VIDEO_SYNC_PULSE |
++		                  MIPI_DSI_MODE_LPM;
+ 	ctx->desc = desc;
+ 	ctx->dsi = dsi;
+ 	ret = hx83102_panel_add(ctx);
+@@ -1069,6 +1208,9 @@ static const struct of_device_id hx83102_of_match[] = {
+ 	{ .compatible = "starry,himax83102-j02",
+ 	  .data = &starry_desc
+ 	},
++	{ .compatible = "waveshare,12.3-dsi-touch-a",
++	  .data = &waveshare_12_3_inch_a_desc
++	},
+ 	{ /* sentinel */ }
+ };
+ MODULE_DEVICE_TABLE(of, hx83102_of_match);

--- a/patch/kernel/qrb2210-edge/0032-drm-panel-himax-hx8394-set-prepare_prev_first.patch
+++ b/patch/kernel/qrb2210-edge/0032-drm-panel-himax-hx8394-set-prepare_prev_first.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:31 +0300
+Subject: [PATCH 32/48] drm/panel: himax-hx8394: set prepare_prev_first
+
+Sending DSI commands from the prepare() callback requires DSI link to be
+up at that point. For DSI hosts is guaranteed only if the panel driver
+sets the .prepare_prev_first flag. Set it to let these panels work with
+the DSI hosts which don't power on the link in their .mode_set callback.
+
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ drivers/gpu/drm/panel/panel-himax-hx8394.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/drm/panel/panel-himax-hx8394.c b/drivers/gpu/drm/panel/panel-himax-hx8394.c
+index c4d3e09a228d..d64f3521eb15 100644
+--- a/drivers/gpu/drm/panel/panel-himax-hx8394.c
++++ b/drivers/gpu/drm/panel/panel-himax-hx8394.c
+@@ -792,6 +792,8 @@ static int hx8394_probe(struct mipi_dsi_device *dsi)
+ 	if (ret)
+ 		return ret;
+ 
++	ctx->panel.prepare_prev_first = true;
++
+ 	drm_panel_add(&ctx->panel);
+ 
+ 	ret = mipi_dsi_attach(dsi);

--- a/patch/kernel/qrb2210-edge/0033-drm-panel-himax-hx8394-simplify-hx8394_enable.patch
+++ b/patch/kernel/qrb2210-edge/0033-drm-panel-himax-hx8394-simplify-hx8394_enable.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:32 +0300
+Subject: [PATCH 33/48] drm/panel: himax-hx8394: simplify hx8394_enable()
+
+Simplify hx8394_enable() function by using hx8394_disable() instead of
+open-coding it and mipi_dsi_msleep() instead of manual checks.
+
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ drivers/gpu/drm/panel/panel-himax-hx8394.c | 41 ++++++++--------------
+ 1 file changed, 14 insertions(+), 27 deletions(-)
+
+diff --git a/drivers/gpu/drm/panel/panel-himax-hx8394.c b/drivers/gpu/drm/panel/panel-himax-hx8394.c
+index d64f3521eb15..1f23c50b6661 100644
+--- a/drivers/gpu/drm/panel/panel-himax-hx8394.c
++++ b/drivers/gpu/drm/panel/panel-himax-hx8394.c
+@@ -618,47 +618,34 @@ static const struct hx8394_panel_desc hl055fhav028c_desc = {
+ 	.init_sequence = hl055fhav028c_init_sequence,
+ };
+ 
+-static int hx8394_enable(struct drm_panel *panel)
++static int hx8394_disable(struct drm_panel *panel)
+ {
+ 	struct hx8394 *ctx = panel_to_hx8394(panel);
+ 	struct mipi_dsi_device *dsi = to_mipi_dsi_device(ctx->dev);
+ 	struct mipi_dsi_multi_context dsi_ctx = { .dsi = dsi };
+-	int ret;
+-
+-	ctx->desc->init_sequence(&dsi_ctx);
+-
+-	mipi_dsi_dcs_exit_sleep_mode_multi(&dsi_ctx);
+-
+-	if (dsi_ctx.accum_err)
+-		return dsi_ctx.accum_err;
+-	/* Panel is operational 120 msec after reset */
+-	msleep(120);
+-
+-	mipi_dsi_dcs_set_display_on_multi(&dsi_ctx);
+-	if (dsi_ctx.accum_err)
+-		goto sleep_in;
+-
+-	return 0;
+-
+-sleep_in:
+-	ret = dsi_ctx.accum_err;
+-	dsi_ctx.accum_err = 0;
+ 
+-	/* This will probably fail, but let's try orderly power off anyway. */
+ 	mipi_dsi_dcs_enter_sleep_mode_multi(&dsi_ctx);
+-	mipi_dsi_msleep(&dsi_ctx, 50);
++	mipi_dsi_msleep(&dsi_ctx, 50); /* about 3 frames */
+ 
+-	return ret;
++	return dsi_ctx.accum_err;
+ }
+ 
+-static int hx8394_disable(struct drm_panel *panel)
++static int hx8394_enable(struct drm_panel *panel)
+ {
+ 	struct hx8394 *ctx = panel_to_hx8394(panel);
+ 	struct mipi_dsi_device *dsi = to_mipi_dsi_device(ctx->dev);
+ 	struct mipi_dsi_multi_context dsi_ctx = { .dsi = dsi };
+ 
+-	mipi_dsi_dcs_enter_sleep_mode_multi(&dsi_ctx);
+-	mipi_dsi_msleep(&dsi_ctx, 50); /* about 3 frames */
++	ctx->desc->init_sequence(&dsi_ctx);
++
++	mipi_dsi_dcs_exit_sleep_mode_multi(&dsi_ctx);
++
++	/* Panel is operational 120 msec after reset */
++	mipi_dsi_msleep(&dsi_ctx, 120);
++
++	mipi_dsi_dcs_set_display_on_multi(&dsi_ctx);
++	if (dsi_ctx.accum_err)
++		hx8394_disable(panel);
+ 
+ 	return dsi_ctx.accum_err;
+ }

--- a/patch/kernel/qrb2210-edge/0034-drm-panel-himax-hx8394-support-Waveshare-DSI-panels.patch
+++ b/patch/kernel/qrb2210-edge/0034-drm-panel-himax-hx8394-support-Waveshare-DSI-panels.patch
@@ -1,0 +1,283 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:33 +0300
+Subject: [PATCH 34/48] drm/panel: himax-hx8394: support Waveshare DSI panels
+
+Enable support for Waveshare 5.0" and 5.5" DSI TOUCH-A panels.
+
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ drivers/gpu/drm/panel/panel-himax-hx8394.c | 244 +++++++++++++++++++++
+ 1 file changed, 244 insertions(+)
+
+diff --git a/drivers/gpu/drm/panel/panel-himax-hx8394.c b/drivers/gpu/drm/panel/panel-himax-hx8394.c
+index 1f23c50b6661..bf80354567df 100644
+--- a/drivers/gpu/drm/panel/panel-himax-hx8394.c
++++ b/drivers/gpu/drm/panel/panel-himax-hx8394.c
+@@ -44,6 +44,7 @@
+ #define HX8394_CMD_SETID	  0xc3
+ #define HX8394_CMD_SETDDB	  0xc4
+ #define HX8394_CMD_UNKNOWN2	  0xc6
++#define HX8394_CMD_UNKNOWN6	  0xc7
+ #define HX8394_CMD_SETCABC	  0xc9
+ #define HX8394_CMD_SETCABCGAIN	  0xca
+ #define HX8394_CMD_SETPANEL	  0xcc
+@@ -618,6 +619,247 @@ static const struct hx8394_panel_desc hl055fhav028c_desc = {
+ 	.init_sequence = hl055fhav028c_init_sequence,
+ };
+ 
++static void waveshare_5_0_inch_a_init_sequence(struct mipi_dsi_multi_context *dsi_ctx)
++{
++	/* 5.19.8 SETEXTC: Set extension command (B9h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETEXTC,
++				     0xff, 0x83, 0x94);
++
++	/* 5.19.2 SETPOWER: Set power (B1h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETPOWER,
++				     0x48, 0x0a, 0x6a, 0x09, 0x33, 0x54, 0x71, 0x71, 0x2e, 0x45);
++
++	/* 5.19.9 SETMIPI: Set MIPI control (BAh) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETMIPI,
++				     0x61, 0x03, 0x68, 0x6b, 0xb2, 0xc0);
++
++	/* 5.19.3 SETDISP: Set display related register (B2h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETDISP,
++				     0x00, 0x80, 0x64, 0x0c, 0x06, 0x2f);
++
++	/* 5.19.4 SETCYC: Set display waveform cycles (B4h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETCYC,
++				     0x1c, 0x78, 0x1c, 0x78, 0x1c, 0x78, 0x01, 0x0c, 0x86, 0x75,
++				     0x00, 0x3f, 0x1c, 0x78, 0x1c, 0x78, 0x1c, 0x78, 0x01, 0x0c,
++				     0x86);
++
++	/* 5.19.19 SETGIP0: Set GIP Option0 (D3h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETGIP0,
++				     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x08, 0x32, 0x10,
++				     0x05, 0x00, 0x05, 0x32, 0x13, 0xc1, 0x00, 0x01, 0x32, 0x10,
++				     0x08, 0x00, 0x00, 0x37, 0x03, 0x07, 0x07, 0x37, 0x05, 0x05,
++				     0x37, 0x0c, 0x40);
++
++	/* 5.19.20 Set GIP Option1 (D5h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETGIP1,
++				     0x18, 0x18, 0x18, 0x18, 0x22, 0x23, 0x20, 0x21, 0x04, 0x05,
++				     0x06, 0x07, 0x00, 0x01, 0x02, 0x03, 0x18, 0x18, 0x18, 0x18,
++				     0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
++				     0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
++				     0x19, 0x19, 0x19, 0x19);
++
++	/* 5.19.21 Set GIP Option2 (D6h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETGIP2,
++				     0x18, 0x18, 0x19, 0x19, 0x21, 0x20, 0x23, 0x22, 0x03, 0x02,
++				     0x01, 0x00, 0x07, 0x06, 0x05, 0x04, 0x18, 0x18, 0x18, 0x18,
++				     0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
++				     0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
++				     0x19, 0x19, 0x18, 0x18);
++
++	/* 5.19.25 SETGAMMA: Set gamma curve related setting (E0h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETGAMMA,
++				     0x07, 0x08, 0x09, 0x0d, 0x10, 0x14, 0x16, 0x13, 0x24, 0x36,
++				     0x48, 0x4a, 0x58, 0x6f, 0x76, 0x80, 0x97, 0xa5, 0xa8, 0xb5,
++				     0xc6, 0x62, 0x63, 0x68, 0x6f, 0x72, 0x78, 0x7f, 0x7f, 0x00,
++				     0x02, 0x08, 0x0d, 0x0c, 0x0e, 0x0f, 0x10, 0x24, 0x36, 0x48,
++				     0x4a, 0x58, 0x6f, 0x78, 0x82, 0x99, 0xa4, 0xa0, 0xb1, 0xc0,
++				     0x5e, 0x5e, 0x64, 0x6b, 0x6c, 0x73, 0x7f, 0x7f);
++
++	/* 5.19.17 SETPANEL (CCh) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETPANEL,
++				     0x0b);
++
++	/* Unknown command, not listed in the HX8394-F datasheet */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_UNKNOWN1,
++				     0x1f, 0x73);
++
++	/* 5.19.5 SETVCOM: Set VCOM voltage (B6h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETVCOM,
++				     0x6b, 0x6b);
++
++	/* Unknown command, not listed in the HX8394-F datasheet */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_UNKNOWN3,
++				     0x02);
++
++	/* 5.19.11 Set register bank (BDh) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETREGBANK,
++				     0x01);
++
++	/* 5.19.2 SETPOWER: Set power (B1h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETPOWER,
++				     0x00);
++
++	/* 5.19.11 Set register bank (BDh) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETREGBANK,
++				     0x00);
++
++	/* Unknown command, not listed in the HX8394-F datasheet */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_UNKNOWN5,
++				     0x40, 0x81, 0x50, 0x00, 0x1a, 0xfc, 0x01);
++};
++
++static const struct drm_display_mode waveshare_5_0_inch_a_mode = {
++	.clock = 70000,
++	.hdisplay = 720,
++	.hsync_start = 720 + 40,
++	.hsync_end = 720 + 40 + 20,
++	.htotal = 720 + 40 + 20 + 20,
++	.vdisplay = 1280,
++	.vsync_start = 1280 + 30,
++	.vsync_end = 1280 + 30 + 10,
++	.vtotal = 1280 + 30 + 10 + 4,
++	.width_mm = 62,
++	.height_mm = 110,
++};
++
++static const struct hx8394_panel_desc waveshare_5_0_inch_a_desc = {
++	.mode = &waveshare_5_0_inch_a_mode,
++	.lanes = 2,
++	.mode_flags = MIPI_DSI_MODE_VIDEO_HSE | MIPI_DSI_MODE_VIDEO |
++		      MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
++	.format = MIPI_DSI_FMT_RGB888,
++	.init_sequence = waveshare_5_0_inch_a_init_sequence,
++};
++
++static const struct drm_display_mode waveshare_5_5_inch_a_mode = {
++	.clock = 65000,
++	.hdisplay = 720,
++	.hsync_start = 720 + 50,
++	.hsync_end = 720 + 50 + 50,
++	.htotal = 720 + 50 + 50 + 10,
++	.vdisplay = 1280,
++	.vsync_start = 1280 + 15,
++	.vsync_end = 1280 + 15 + 12,
++	.vtotal = 1280 + 15 + 12 + 4,
++	.width_mm = 62,
++	.height_mm = 110,
++};
++
++static void waveshare_5_5_inch_a_init_sequence(struct mipi_dsi_multi_context *dsi_ctx)
++{
++	/* 5.19.8 SETEXTC: Set extension command (B9h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETEXTC,
++				     0xff, 0x83, 0x94);
++
++	/* 5.19.9 SETMIPI: Set MIPI control (BAh) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETMIPI,
++				     0x61, 0x03, 0x68, 0x6b, 0xb2, 0xc0);
++
++	/* 5.19.2 SETPOWER: Set power (B1h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETPOWER,
++				     0x48, 0x12, 0x72, 0x09, 0x32, 0x54, 0x71, 0x71, 0x57, 0x47);
++
++	/* 5.19.3 SETDISP: Set display related register (B2h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETDISP,
++				     0x00, 0x80, 0x64, 0x0c, 0x0d, 0x2f);
++
++	/* 5.19.4 SETCYC: Set display waveform cycles (B4h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETCYC,
++				     0x73, 0x74, 0x73, 0x74, 0x73, 0x74, 0x01, 0x0c, 0x86, 0x75,
++				     0x00, 0x3f, 0x73, 0x74, 0x73, 0x74, 0x73, 0x74, 0x01, 0x0c,
++				     0x86);
++
++	/* 5.19.5 SETVCOM: Set VCOM voltage (B6h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETVCOM,
++				     0x86, 0x86);
++
++	/* 5.19.19 SETGIP0: Set GIP Option0 (D3h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETGIP0,
++				     0x00, 0x00, 0x07, 0x07, 0x40, 0x07, 0x0c, 0x00, 0x08, 0x10,
++				     0x08, 0x00, 0x08, 0x54, 0x15, 0x0a, 0x05, 0x0a, 0x02, 0x15,
++				     0x06, 0x05, 0x06, 0x47, 0x44, 0x0a, 0x0a, 0x4b, 0x10, 0x07,
++				     0x07, 0x0c, 0x40);
++
++	/* 5.19.20 Set GIP Option1 (D5h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETGIP1,
++				     0x1c, 0x1c, 0x1d, 0x1d, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
++				     0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x24, 0x25, 0x18, 0x18,
++				     0x26, 0x27, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
++				     0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x20, 0x21,
++				     0x18, 0x18, 0x18, 0x18);
++
++	/* 5.19.21 Set GIP Option2 (D6h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETGIP2,
++				     0x1c, 0x1c, 0x1d, 0x1d, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02,
++				     0x01, 0x00, 0x0b, 0x0a, 0x09, 0x08, 0x21, 0x20, 0x18, 0x18,
++				     0x27, 0x26, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
++				     0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x25, 0x24,
++				     0x18, 0x18, 0x18, 0x18);
++
++	/* 5.19.25 SETGAMMA: Set gamma curve related setting (E0h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETGAMMA,
++				     0x00, 0x13, 0x21, 0x28, 0x2b, 0x2e, 0x32, 0x2f, 0x61, 0x6e,
++				     0x7e, 0x7b, 0x80, 0x8f, 0x91, 0x93, 0x9d, 0x9d, 0x97, 0xa4,
++				     0xb1, 0x57, 0x55, 0x58, 0x5d, 0x60, 0x67, 0x74, 0x7f, 0x00,
++				     0x13, 0x21, 0x28, 0x2b, 0x2e, 0x32, 0x2f, 0x61, 0x6e, 0x7d,
++				     0x7b, 0x7f, 0x8e, 0x90, 0x93, 0x9c, 0x9d, 0x98, 0xa4, 0xb1,
++				     0x58, 0x55, 0x59, 0x5e, 0x61, 0x68, 0x76, 0x7f);
++
++	/* Unknown command, not listed in the HX8394-F datasheet */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_UNKNOWN1,
++				     0x1f, 0x31);
++
++	/* 5.19.17 SETPANEL (CCh) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETPANEL,
++				     0x07);
++
++	/* Unknown command, not listed in the HX8394-F datasheet */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_UNKNOWN3,
++				     0x02);
++
++	/* 5.19.11 Set register bank (BDh) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETREGBANK,
++				     0x02);
++
++	/* Unknown command, not listed in the HX8394-F datasheet */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_UNKNOWN4,
++				     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
++				     0xff, 0xff);
++
++	/* 5.19.11 Set register bank (BDh) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETREGBANK,
++				     0x00);
++
++	/* 5.19.11 Set register bank (BDh) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETREGBANK,
++				     0x01);
++
++	/* 5.19.2 SETPOWER: Set power (B1h) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETPOWER,
++				     0x00);
++
++	/* 5.19.11 Set register bank (BDh) */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_SETREGBANK,
++				     0x00);
++
++	/* Unknown command, not listed in the HX8394-F datasheet */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_UNKNOWN2,
++				     0xed);
++
++	/* Unknown command, not listed in the HX8394-F datasheet */
++	mipi_dsi_dcs_write_seq_multi(dsi_ctx, HX8394_CMD_UNKNOWN6,
++				     0x00, 0xc0);
++};
++
++static const struct hx8394_panel_desc waveshare_5_5_inch_a_desc = {
++	.mode = &waveshare_5_5_inch_a_mode,
++	.lanes = 2,
++	.mode_flags = MIPI_DSI_MODE_VIDEO_HSE | MIPI_DSI_MODE_VIDEO |
++		      MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
++	.format = MIPI_DSI_FMT_RGB888,
++	.init_sequence = waveshare_5_5_inch_a_init_sequence,
++};
++
+ static int hx8394_disable(struct drm_panel *panel)
+ {
+ 	struct hx8394 *ctx = panel_to_hx8394(panel);
+@@ -815,6 +1057,8 @@ static const struct of_device_id hx8394_of_match[] = {
+ 	{ .compatible = "huiling,hl055fhav028c", .data = &hl055fhav028c_desc },
+ 	{ .compatible = "powkiddy,x55-panel", .data = &powkiddy_x55_desc },
+ 	{ .compatible = "microchip,ac40t08a-mipi-panel", .data = &mchp_ac40t08a_desc },
++	{ .compatible = "waveshare,5.0-dsi-touch-a", .data = &waveshare_5_0_inch_a_desc },
++	{ .compatible = "waveshare,5.5-dsi-touch-a", .data = &waveshare_5_5_inch_a_desc },
+ 	{ /* sentinel */ }
+ };
+ MODULE_DEVICE_TABLE(of, hx8394_of_match);

--- a/patch/kernel/qrb2210-edge/0035-drm-panel-jadard-jd9365da-h3-use-drm_connector_helpe.patch
+++ b/patch/kernel/qrb2210-edge/0035-drm-panel-jadard-jd9365da-h3-use-drm_connector_helpe.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:34 +0300
+Subject: [PATCH 35/48] drm/panel: jadard-jd9365da-h3: use
+ drm_connector_helper_get_modes_fixed
+
+Use existing helper instead of manually coding it.
+
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ drivers/gpu/drm/panel/Kconfig                 |  1 +
+ .../gpu/drm/panel/panel-jadard-jd9365da-h3.c  | 19 ++-----------------
+ 2 files changed, 3 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
+index 307152ad7759..4495fc097ffa 100644
+--- a/drivers/gpu/drm/panel/Kconfig
++++ b/drivers/gpu/drm/panel/Kconfig
+@@ -309,6 +309,7 @@ config DRM_PANEL_JADARD_JD9365DA_H3
+ 	depends on OF
+ 	depends on DRM_MIPI_DSI
+ 	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_KMS_HELPER
+ 	help
+ 	  Say Y here if you want to enable support for Jadard JD9365DA-H3
+ 	  WXGA MIPI DSI panel. The panel support TFT dot matrix LCD with
+diff --git a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+index 5386a06fcd08..51ef99e8ecea 100644
+--- a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
++++ b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+@@ -12,6 +12,7 @@
+ #include <drm/drm_modes.h>
+ #include <drm/drm_panel.h>
+ #include <drm/drm_print.h>
++#include <drm/drm_probe_helper.h>
+ 
+ #include <linux/gpio/consumer.h>
+ #include <linux/delay.h>
+@@ -149,24 +150,8 @@ static int jadard_get_modes(struct drm_panel *panel,
+ 			    struct drm_connector *connector)
+ {
+ 	struct jadard *jadard = panel_to_jadard(panel);
+-	const struct drm_display_mode *desc_mode = &jadard->desc->mode;
+-	struct drm_display_mode *mode;
+-
+-	mode = drm_mode_duplicate(connector->dev, desc_mode);
+-	if (!mode) {
+-		DRM_DEV_ERROR(&jadard->dsi->dev, "failed to add mode %ux%ux@%u\n",
+-			      desc_mode->hdisplay, desc_mode->vdisplay,
+-			      drm_mode_vrefresh(desc_mode));
+-		return -ENOMEM;
+-	}
+-
+-	drm_mode_set_name(mode);
+-	drm_mode_probed_add(connector, mode);
+-
+-	connector->display_info.width_mm = mode->width_mm;
+-	connector->display_info.height_mm = mode->height_mm;
+ 
+-	return 1;
++	return drm_connector_helper_get_modes_fixed(connector, &jadard->desc->mode);
+ }
+ 
+ static enum drm_panel_orientation jadard_panel_get_orientation(struct drm_panel *panel)

--- a/patch/kernel/qrb2210-edge/0036-drm-panel-jadard-jd9365da-h3-support-variable-DSI-co.patch
+++ b/patch/kernel/qrb2210-edge/0036-drm-panel-jadard-jd9365da-h3-support-variable-DSI-co.patch
@@ -1,0 +1,138 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:35 +0300
+Subject: [PATCH 36/48] drm/panel: jadard-jd9365da-h3: support variable DSI
+ configuration
+
+Several panels support attachment either using 4 DSI lanes or just 2. In
+some cases, this requires a different panel mode to fulfill clock
+requirements. Extend the driver to handle such cases by letting the
+panel description to omit lanes specification and parsing number of
+lanes from the DT.
+
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Tested-by: Riccardo Mereu <r.mereu@arduino.cc>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ .../gpu/drm/panel/panel-jadard-jd9365da-h3.c  | 45 +++++++++++++++----
+ 1 file changed, 36 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+index 51ef99e8ecea..a2d80bb3805c 100644
+--- a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
++++ b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+@@ -10,6 +10,7 @@
+ 
+ #include <drm/drm_mipi_dsi.h>
+ #include <drm/drm_modes.h>
++#include <drm/drm_of.h>
+ #include <drm/drm_panel.h>
+ #include <drm/drm_print.h>
+ #include <drm/drm_probe_helper.h>
+@@ -23,7 +24,8 @@
+ struct jadard;
+ 
+ struct jadard_panel_desc {
+-	const struct drm_display_mode mode;
++	const struct drm_display_mode *mode_4ln;
++	const struct drm_display_mode *mode_2ln;
+ 	unsigned int lanes;
+ 	enum mipi_dsi_pixel_format format;
+ 	int (*init)(struct jadard *jadard);
+@@ -57,7 +59,10 @@ static void jadard_enable_standard_cmds(struct mipi_dsi_multi_context *dsi_ctx)
+ 	mipi_dsi_dcs_write_seq_multi(dsi_ctx, 0xe1, 0x93);
+ 	mipi_dsi_dcs_write_seq_multi(dsi_ctx, 0xe2, 0x65);
+ 	mipi_dsi_dcs_write_seq_multi(dsi_ctx, 0xe3, 0xf8);
+-	mipi_dsi_dcs_write_seq_multi(dsi_ctx, 0x80, 0x03);
++	if (dsi_ctx->dsi->lanes == 2)
++		mipi_dsi_dcs_write_seq_multi(dsi_ctx, 0x80, 0x01);
++	else
++		mipi_dsi_dcs_write_seq_multi(dsi_ctx, 0x80, 0x03);
+ }
+ 
+ static inline struct jadard *panel_to_jadard(struct drm_panel *panel)
+@@ -151,7 +156,10 @@ static int jadard_get_modes(struct drm_panel *panel,
+ {
+ 	struct jadard *jadard = panel_to_jadard(panel);
+ 
+-	return drm_connector_helper_get_modes_fixed(connector, &jadard->desc->mode);
++	if (jadard->dsi->lanes == 2)
++		return drm_connector_helper_get_modes_fixed(connector, jadard->desc->mode_2ln);
++	else
++		return drm_connector_helper_get_modes_fixed(connector, jadard->desc->mode_4ln);
+ }
+ 
+ static enum drm_panel_orientation jadard_panel_get_orientation(struct drm_panel *panel)
+@@ -354,7 +362,7 @@ static int radxa_display_8hd_ad002_init_cmds(struct jadard *jadard)
+ };
+ 
+ static const struct jadard_panel_desc radxa_display_8hd_ad002_desc = {
+-	.mode = {
++	.mode_4ln = &(const struct drm_display_mode) {
+ 		.clock		= 70000,
+ 
+ 		.hdisplay	= 800,
+@@ -586,7 +594,7 @@ static int cz101b4001_init_cmds(struct jadard *jadard)
+ };
+ 
+ static const struct jadard_panel_desc cz101b4001_desc = {
+-	.mode = {
++	.mode_4ln = &(const struct drm_display_mode) {
+ 		.clock		= 70000,
+ 
+ 		.hdisplay	= 800,
+@@ -819,7 +827,7 @@ static int kingdisplay_kd101ne3_init_cmds(struct jadard *jadard)
+ };
+ 
+ static const struct jadard_panel_desc kingdisplay_kd101ne3_40ti_desc = {
+-	.mode = {
++	.mode_4ln = &(const struct drm_display_mode) {
+ 		.clock		= (800 + 24 + 24 + 24) * (1280 + 30 + 4 + 8) * 60 / 1000,
+ 
+ 		.hdisplay	= 800,
+@@ -1070,7 +1078,7 @@ static int melfas_lmfbx101117480_init_cmds(struct jadard *jadard)
+ };
+ 
+ static const struct jadard_panel_desc melfas_lmfbx101117480_desc = {
+-	.mode = {
++	.mode_4ln = &(const struct drm_display_mode) {
+ 		.clock		= (800 + 24 + 24 + 24) * (1280 + 30 + 4 + 8) * 60 / 1000,
+ 
+ 		.hdisplay	= 800,
+@@ -1326,7 +1334,7 @@ static int anbernic_rgds_init_cmds(struct jadard *jadard)
+ };
+ 
+ static const struct jadard_panel_desc anbernic_rgds_display_desc = {
+-	.mode = {
++	.mode_4ln = &(const struct drm_display_mode) {
+ 		.clock		= (640 + 260 + 220 + 260) * (480 + 10 + 2 + 16) * 60 / 1000,
+ 
+ 		.hdisplay	= 640,
+@@ -1374,7 +1382,26 @@ static int jadard_dsi_probe(struct mipi_dsi_device *dsi)
+ 
+ 	dsi->format = desc->format;
+ 	dsi->lanes = desc->lanes;
+-
++	if (!dsi->lanes) {
++		dsi->lanes = drm_of_get_data_lanes_count_remote(dsi->dev.of_node, 0, -1, 2, 4);
++		if (dsi->lanes < 0)
++			return dsi->lanes;
++		if (dsi->lanes == 4) {
++			if (!desc->mode_4ln) {
++				dev_err(&dsi->dev, "4-lane config is not supported\n");
++				return -EINVAL;
++			}
++		} else if (dsi->lanes == 2) {
++			if (!desc->mode_2ln) {
++				dev_err(&dsi->dev, "2-lane config is not supported\n");
++				return -EINVAL;
++			}
++		} else {
++			dev_err(&dsi->dev, "Unsupported number of lanes, %d\n", dsi->lanes);
++			return -ENODEV;
++		}
++	}
++	dev_dbg(&dsi->dev, "lanes: %d\n", dsi->lanes);
+ 	jadard->reset = devm_gpiod_get(dev, "reset", GPIOD_OUT_HIGH);
+ 	if (IS_ERR(jadard->reset))
+ 		return dev_err_probe(&dsi->dev, PTR_ERR(jadard->reset),

--- a/patch/kernel/qrb2210-edge/0037-drm-panel-jadard-jd9365da-h3-set-prepare_prev_first.patch
+++ b/patch/kernel/qrb2210-edge/0037-drm-panel-jadard-jd9365da-h3-set-prepare_prev_first.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:36 +0300
+Subject: [PATCH 37/48] drm/panel: jadard-jd9365da-h3: set prepare_prev_first
+
+Sending DSI commands from the prepare() callback requires DSI link to be
+up at that point. For DSI hosts is guaranteed only if the panel driver
+sets the .prepare_prev_first flag. Set it to let these panels work with
+the DSI hosts which don't power on the link in their .mode_set callback.
+
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Tested-by: Riccardo Mereu <r.mereu@arduino.cc>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+index a2d80bb3805c..6618980ffc50 100644
+--- a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
++++ b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+@@ -1425,6 +1425,8 @@ static int jadard_dsi_probe(struct mipi_dsi_device *dsi)
+ 	if (ret)
+ 		return ret;
+ 
++	jadard->panel.prepare_prev_first = true;
++
+ 	drm_panel_add(&jadard->panel);
+ 
+ 	mipi_dsi_set_drvdata(dsi, jadard);

--- a/patch/kernel/qrb2210-edge/0038-drm-panel-jadard-jd9365da-h3-support-Waveshare-round.patch
+++ b/patch/kernel/qrb2210-edge/0038-drm-panel-jadard-jd9365da-h3-support-Waveshare-round.patch
@@ -1,0 +1,510 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:37 +0300
+Subject: [PATCH 38/48] drm/panel: jadard-jd9365da-h3: support Waveshare round
+ DSI panels
+
+Add configuration for Waveshare 3.4" and 4.0" round DSI panels using
+JD9365 controller.
+
+Tested-by: Riccardo Mereu <r.mereu@arduino.cc>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Reviewed-by: Neil Armstrong <neil.armstrong@linaro.org>
+---
+ .../gpu/drm/panel/panel-jadard-jd9365da-h3.c  | 476 ++++++++++++++++++
+ 1 file changed, 476 insertions(+)
+
+diff --git a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+index 6618980ffc50..f0f5f58df579 100644
+--- a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
++++ b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+@@ -1359,6 +1359,474 @@ static const struct jadard_panel_desc anbernic_rgds_display_desc = {
+ 		      MIPI_DSI_CLOCK_NON_CONTINUOUS | MIPI_DSI_MODE_LPM,
+ };
+ 
++static int waveshare_3_4_c_init(struct jadard *jadard)
++{
++	struct mipi_dsi_multi_context dsi_ctx = { .dsi = jadard->dsi };
++
++	jd9365da_switch_page(&dsi_ctx, 0x00);
++	jadard_enable_standard_cmds(&dsi_ctx);
++
++	jd9365da_switch_page(&dsi_ctx, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x41);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x03, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x04, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x17, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x18, 0xd0);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x19, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1a, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1b, 0xd0);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1c, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x24, 0xfe);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x35, 0x26);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x38, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x39, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3a, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3c, 0x78);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3d, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3e, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3f, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x40, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x41, 0x64);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x42, 0xc7);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x43, 0x18);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x44, 0x0b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x45, 0x14);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x55, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x57, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x59, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5a, 0x1b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5b, 0x19);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5d, 0x7f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5e, 0x56);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5f, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x60, 0x37);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x61, 0x33);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x62, 0x25);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x63, 0x2a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x64, 0x16);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x65, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x66, 0x2f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x67, 0x32);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x53);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x69, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6a, 0x4c);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6b, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6c, 0x3d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6d, 0x31);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6e, 0x20);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6f, 0x0f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x70, 0x7f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x71, 0x56);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x72, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x73, 0x37);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x74, 0x33);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x75, 0x25);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x76, 0x2a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x77, 0x16);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x78, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x79, 0x2f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7a, 0x32);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7b, 0x53);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7c, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7d, 0x4c);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7e, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7f, 0x3d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x80, 0x31);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x81, 0x20);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x82, 0x0f);
++
++	jd9365da_switch_page(&dsi_ctx, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x02, 0x5e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x03, 0x5e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x04, 0x50);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x05, 0x48);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x06, 0x48);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x07, 0x4a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x08, 0x4a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x09, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0a, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0b, 0x46);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0c, 0x46);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0d, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0e, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0f, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x10, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x11, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x12, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x13, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x14, 0x42);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x15, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x16, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x17, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x18, 0x5e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x19, 0x5e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1a, 0x50);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1b, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1c, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1d, 0x4b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1e, 0x4b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1f, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x20, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x21, 0x47);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x22, 0x47);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x23, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x24, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x25, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x26, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x27, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x28, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x29, 0x41);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2a, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2b, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2c, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2d, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2e, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2f, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x30, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x31, 0x07);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x32, 0x07);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x33, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x34, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x35, 0x0b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x36, 0x0b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x38, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x39, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3a, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3b, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3c, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3d, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3e, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3f, 0x03);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x40, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x41, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x42, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x43, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x44, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x45, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x46, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x47, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x48, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x49, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4a, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4b, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4c, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4d, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4e, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4f, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x50, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x51, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x52, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x53, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x54, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x55, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x56, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x57, 0x1f);
++
++	jd9365da_switch_page(&dsi_ctx, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x58, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x59, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5a, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5b, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5c, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5d, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5e, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5f, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x60, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x61, 0x03);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x62, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x63, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x64, 0xa6);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x65, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x66, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x67, 0x73);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x69, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6a, 0x7f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6b, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6c, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6d, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6e, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6f, 0x88);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x75, 0xd9);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x76, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x77, 0x33);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x78, 0x43);
++
++	jd9365da_switch_page(&dsi_ctx, 0x00);
++
++	mipi_dsi_dcs_exit_sleep_mode_multi(&dsi_ctx);
++	msleep(120);
++	mipi_dsi_dcs_set_display_on_multi(&dsi_ctx);
++	msleep(5);
++	mipi_dsi_dcs_set_tear_on_multi(&dsi_ctx, MIPI_DSI_DCS_TEAR_MODE_VBLANK);
++
++	return dsi_ctx.accum_err;
++}
++
++static const struct jadard_panel_desc waveshare_3_4_inch_c_desc = {
++	.mode_2ln = &(const struct drm_display_mode) {
++		.clock          = (800 + 40 + 20 + 20) * (800 + 24 + 4 + 12) * 60 / 1000,
++
++		.hdisplay       = 800,
++		.hsync_start    = 800 + 40,
++		.hsync_end      = 800 + 40 + 20,
++		.htotal         = 800 + 40 + 20 + 20,
++
++		.vdisplay       = 800,
++		.vsync_start    = 800 + 24,
++		.vsync_end      = 800 + 24 + 4,
++		.vtotal         = 800 + 24 + 4 + 12,
++
++		.width_mm       = 88,
++		.height_mm      = 88,
++		.type           = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED,
++	},
++	.lanes = 2,
++	.format = MIPI_DSI_FMT_RGB888,
++	.init = waveshare_3_4_c_init,
++	.mode_flags = MIPI_DSI_MODE_VIDEO_HSE | MIPI_DSI_MODE_VIDEO |
++	              MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
++};
++
++static int waveshare_4_0_c_init(struct jadard *jadard)
++{
++	struct mipi_dsi_multi_context dsi_ctx = { .dsi = jadard->dsi };
++
++	jd9365da_switch_page(&dsi_ctx, 0x00);
++	jadard_enable_standard_cmds(&dsi_ctx);
++
++	jd9365da_switch_page(&dsi_ctx, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x41);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x03, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x04, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x17, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x18, 0xd0);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x19, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1a, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1b, 0xd0);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1c, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x24, 0xfe);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x35, 0x26);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x38, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x39, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3a, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3c, 0x78);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3d, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3e, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3f, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x40, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x41, 0x64);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x42, 0xc7);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x43, 0x18);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x44, 0x0b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x45, 0x14);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x55, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x57, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x59, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5a, 0x1b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5b, 0x19);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5d, 0x7f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5e, 0x56);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5f, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x60, 0x37);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x61, 0x33);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x62, 0x25);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x63, 0x2a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x64, 0x16);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x65, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x66, 0x2f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x67, 0x32);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x53);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x69, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6a, 0x4c);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6b, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6c, 0x3d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6d, 0x31);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6e, 0x20);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6f, 0x0f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x70, 0x7f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x71, 0x56);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x72, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x73, 0x37);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x74, 0x33);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x75, 0x25);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x76, 0x2a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x77, 0x16);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x78, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x79, 0x2f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7a, 0x32);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7b, 0x53);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7c, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7d, 0x4c);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7e, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7f, 0x3d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x80, 0x31);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x81, 0x20);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x82, 0x0f);
++
++	jd9365da_switch_page(&dsi_ctx, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x02, 0x5e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x03, 0x5e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x04, 0x50);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x05, 0x48);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x06, 0x48);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x07, 0x4a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x08, 0x4a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x09, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0a, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0b, 0x46);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0c, 0x46);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0d, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0e, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0f, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x10, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x11, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x12, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x13, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x14, 0x42);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x15, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x16, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x17, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x18, 0x5e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x19, 0x5e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1a, 0x50);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1b, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1c, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1d, 0x4b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1e, 0x4b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1f, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x20, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x21, 0x47);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x22, 0x47);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x23, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x24, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x25, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x26, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x27, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x28, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x29, 0x41);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2a, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2b, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2c, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2d, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2e, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2f, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x30, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x31, 0x07);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x32, 0x07);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x33, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x34, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x35, 0x0b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x36, 0x0b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x38, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x39, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3a, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3b, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3c, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3d, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3e, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3f, 0x03);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x40, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x41, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x42, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x43, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x44, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x45, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x46, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x47, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x48, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x49, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4a, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4b, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4c, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4d, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4e, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4f, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x50, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x51, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x52, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x53, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x54, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x55, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x56, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x57, 0x1f);
++
++	jd9365da_switch_page(&dsi_ctx, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x58, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x59, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5a, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5b, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5c, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5d, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5e, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5f, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x60, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x61, 0x03);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x62, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x63, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x64, 0xa6);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x65, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x66, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x67, 0x73);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x69, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6a, 0x7f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6b, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6c, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6d, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6e, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6f, 0x88);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x75, 0xd9);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x76, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x77, 0x33);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x78, 0x43);
++
++	jd9365da_switch_page(&dsi_ctx, 0x00);
++
++	mipi_dsi_dcs_exit_sleep_mode_multi(&dsi_ctx);
++	msleep(120);
++	mipi_dsi_dcs_set_display_on_multi(&dsi_ctx);
++	msleep(5);
++	mipi_dsi_dcs_set_tear_on_multi(&dsi_ctx, MIPI_DSI_DCS_TEAR_MODE_VBLANK);
++
++	return dsi_ctx.accum_err;
++}
++
++static const struct jadard_panel_desc waveshare_4_0_inch_c_desc = {
++	.mode_2ln = &(const struct drm_display_mode) {
++		.clock          = (720 + 40 + 20 + 20) * (720 + 24 + 4 + 12) * 60 / 1000,
++
++		.hdisplay       = 720,
++		.hsync_start    = 720 + 40,
++		.hsync_end      = 720 + 40 + 20,
++		.htotal         = 720 + 40 + 20 + 20,
++
++		.vdisplay       = 720,
++		.vsync_start    = 720 + 24,
++		.vsync_end      = 720 + 24 + 4,
++		.vtotal         = 720 + 24 + 4 + 12,
++
++		.width_mm       = 88,
++		.height_mm      = 88,
++		.type           = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED,
++	},
++	.lanes = 2,
++	.format = MIPI_DSI_FMT_RGB888,
++	.init = waveshare_4_0_c_init,
++	.mode_flags = MIPI_DSI_MODE_VIDEO_HSE | MIPI_DSI_MODE_VIDEO |
++		      MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
++};
++
+ static int jadard_dsi_probe(struct mipi_dsi_device *dsi)
+ {
+ 	struct device *dev = &dsi->dev;
+@@ -1477,6 +1945,14 @@ static const struct of_device_id jadard_of_match[] = {
+ 		.compatible = "radxa,display-8hd-ad002",
+ 		.data = &radxa_display_8hd_ad002_desc
+ 	},
++	{
++		.compatible = "waveshare,3.4-dsi-touch-c",
++		.data = &waveshare_3_4_inch_c_desc
++	},
++	{
++		.compatible = "waveshare,4.0-dsi-touch-c",
++		.data = &waveshare_4_0_inch_c_desc
++	},
+ 	{ /* sentinel */ }
+ };
+ MODULE_DEVICE_TABLE(of, jadard_of_match);

--- a/patch/kernel/qrb2210-edge/0039-drm-panel-jadard-jd9365da-h3-support-Waveshare-WXGA-.patch
+++ b/patch/kernel/qrb2210-edge/0039-drm-panel-jadard-jd9365da-h3-support-Waveshare-WXGA-.patch
@@ -1,0 +1,602 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:38 +0300
+Subject: [PATCH 39/48] drm/panel: jadard-jd9365da-h3: support Waveshare WXGA
+ DSI panels
+
+Add configuration for several Waveshare 8.0" and 10.1" WXGA DSI panels
+using JD9365 controller
+
+Tested-by: Riccardo Mereu <r.mereu@arduino.cc>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Reviewed-by: Neil Armstrong <neil.armstrong@linaro.org>
+---
+ .../gpu/drm/panel/panel-jadard-jd9365da-h3.c  | 568 ++++++++++++++++++
+ 1 file changed, 568 insertions(+)
+
+diff --git a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+index f0f5f58df579..a750758b330c 100644
+--- a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
++++ b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+@@ -1827,6 +1827,566 @@ static const struct jadard_panel_desc waveshare_4_0_inch_c_desc = {
+ 		      MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
+ };
+ 
++static int waveshare_8_0_a_init(struct jadard *jadard)
++{
++	struct mipi_dsi_multi_context dsi_ctx = { .dsi = jadard->dsi };
++
++	jd9365da_switch_page(&dsi_ctx, 0x00);
++	jadard_enable_standard_cmds(&dsi_ctx);
++
++	jd9365da_switch_page(&dsi_ctx, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x00);
++	if (jadard->dsi->lanes == 4)
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x7e);
++	else
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x4e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x03, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x04, 0x65);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0c, 0x74);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x17, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x18, 0xb7);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x19, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1a, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1b, 0xb7);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1c, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x24, 0xfe);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x19);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x38, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x39, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3a, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3b, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3c, 0x70);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3d, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3e, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3f, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x40, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x41, 0xa0);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x43, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x44, 0x0f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x45, 0x28);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4b, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x55, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x56, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x57, 0xa9);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x58, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x59, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5a, 0x37);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5b, 0x19);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5d, 0x78);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5e, 0x63);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5f, 0x54);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x60, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x61, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x62, 0x38);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x63, 0x3d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x64, 0x28);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x65, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x66, 0x41);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x67, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x62);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x69, 0x50);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6a, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6b, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6c, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6d, 0x37);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6e, 0x23);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6f, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x70, 0x78);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x71, 0x63);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x72, 0x54);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x73, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x74, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x75, 0x38);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x76, 0x3d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x77, 0x28);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x78, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x79, 0x41);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7a, 0x43);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7b, 0x62);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7c, 0x50);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7d, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7e, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7f, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x80, 0x37);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x81, 0x23);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x82, 0x10);
++
++	jd9365da_switch_page(&dsi_ctx, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x47);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x47);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x02, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x03, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x04, 0x4b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x05, 0x4b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x06, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x07, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x08, 0x41);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x09, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0a, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0b, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0c, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0d, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0e, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0f, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x10, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x11, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x12, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x13, 0x35);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x14, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x15, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x16, 0x46);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x17, 0x46);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x18, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x19, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1a, 0x4a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1b, 0x4a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1c, 0x48);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1d, 0x48);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1e, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1f, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x20, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x21, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x22, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x23, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x24, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x25, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x26, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x27, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x28, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x29, 0x35);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2a, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2b, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x58, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x59, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5a, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5b, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5c, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5d, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5e, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5f, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x60, 0x30);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x61, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x62, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x63, 0x03);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x64, 0x6b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x65, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x66, 0x0c);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x67, 0x73);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x69, 0x03);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6a, 0x56);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6b, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6c, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6d, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6e, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6f, 0x88);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x70, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x71, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x72, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x73, 0x7b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x74, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x75, 0xf8);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x76, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x77, 0xd5);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x78, 0x2e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x79, 0x12);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7a, 0x03);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7b, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7c, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7d, 0x03);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7e, 0x7b);
++
++	jd9365da_switch_page(&dsi_ctx, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x0e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x02, 0xb3);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x09, 0x60);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0e, 0x2a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x36, 0x59);
++	if (jadard->dsi->lanes != 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x58);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2b, 0x0f);
++	}
++
++	jd9365da_switch_page(&dsi_ctx, 0x00);
++	mipi_dsi_dcs_exit_sleep_mode_multi(&dsi_ctx);
++	msleep(120);
++	mipi_dsi_dcs_set_display_on_multi(&dsi_ctx);
++	msleep(60);
++
++	return 0;
++}
++
++static const struct drm_display_mode waveshare_8_0_a_mode = {
++	.clock		= (800 + 40 + 20 + 20) * (1280 + 30 + 12 + 4) * 60 / 1000,
++
++	.hdisplay	= 800,
++	.hsync_start	= 800 + 40,
++	.hsync_end	= 800 + 40 + 20,
++	.htotal		= 800 + 40 + 20 + 20,
++
++	.vdisplay	= 1280,
++	.vsync_start	= 1280 + 30,
++	.vsync_end	= 1280 + 30 + 12,
++	.vtotal		= 1280 + 30 + 12 + 4,
++
++	.width_mm	= 107,
++	.height_mm	= 172,
++	.type		= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED,
++};
++
++static const struct jadard_panel_desc waveshare_8_0_inch_a_desc = {
++	.mode_4ln = &waveshare_8_0_a_mode,
++	.mode_2ln = &waveshare_8_0_a_mode,
++	.format = MIPI_DSI_FMT_RGB888,
++	.init = waveshare_8_0_a_init,
++	.mode_flags = MIPI_DSI_MODE_VIDEO_HSE | MIPI_DSI_MODE_VIDEO |
++		      MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
++};
++
++static const struct drm_display_mode waveshare_10_1_a_mode = {
++	.clock		= (800 + 40 + 20 + 20) * (1280 + 20 + 20 + 4) * 60 / 1000,
++
++	.hdisplay	= 800,
++	.hsync_start	= 800 + 40,
++	.hsync_end	= 800 + 40 + 20,
++	.htotal		= 800 + 40 + 20 + 20,
++
++	.vdisplay	= 1280,
++	.vsync_start	= 1280 + 20,
++	.vsync_end	= 1280 + 20 + 20,
++	.vtotal		= 1280 + 20 + 20 + 4,
++
++	.width_mm	= 135,
++	.height_mm	= 216,
++	.type		= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED,
++};
++
++static int waveshare_10_1_a_init(struct jadard *jadard)
++{
++	struct mipi_dsi_multi_context dsi_ctx = { .dsi = jadard->dsi };
++
++	jd9365da_switch_page(&dsi_ctx, 0x00);
++	jadard_enable_standard_cmds(&dsi_ctx);
++
++	jd9365da_switch_page(&dsi_ctx, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x00);
++	if (jadard->dsi->lanes == 4)
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x3b);
++	else {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x38);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x03, 0x10);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x04, 0x38);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0c, 0x74);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x17, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x18, 0xaf);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x19, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1a, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1b, 0xaf);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1c, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x35, 0x26);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x38, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x39, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3a, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3c, 0x78);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3d, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3e, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3f, 0x7f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x40, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x41, 0xa0);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x42, 0x81);
++	if (jadard->dsi->lanes == 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x43, 0x14);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x44, 0x23);
++	} else {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x43, 0x1e);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x44, 0x0d);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x45, 0x28);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x55, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x57, 0x69);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x59, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5a, 0x2a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5b, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5d, 0x7f);
++	if (jadard->dsi->lanes == 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5e, 0x6b);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5f, 0x5c);
++	} else  {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5e, 0x6a);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5f, 0x5b);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x60, 0x4f);
++	if (jadard->dsi->lanes == 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x61, 0x4d);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x62, 0x3f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x63, 0x42);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x64, 0x2b);
++	} else {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x61, 0x4a);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x62, 0x3d);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x63, 0x41);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x64, 0x2a);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x65, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x66, 0x43);
++	if (jadard->dsi->lanes == 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x67, 0x43);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x63);
++	} else {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x67, 0x44);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x62);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x69, 0x52);
++	if (jadard->dsi->lanes == 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6a, 0x5a);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6b, 0x4f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6c, 0x4e);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6d, 0x20);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6e, 0x0f);
++	} else {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6a, 0x59);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6b, 0x4c);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6c, 0x48);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6d, 0x3a);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6e, 0x26);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6f, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x70, 0x7f);
++	if (jadard->dsi->lanes == 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x71, 0x6b);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x72, 0x5c);
++	} else {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x71, 0x6a);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x72, 0x5b);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x73, 0x4f);
++	if (jadard->dsi->lanes == 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x74, 0x4d);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x75, 0x3f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x76, 0x42);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x77, 0x2b);
++	} else {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x74, 0x4a);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x75, 0x3d);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x76, 0x41);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x77, 0x2a);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x78, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x79, 0x43);
++	if (jadard->dsi->lanes == 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7a, 0x43);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7b, 0x63);
++	} else {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7a, 0x44);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7b, 0x62);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7c, 0x52);
++	if (jadard->dsi->lanes == 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7d, 0x5a);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7e, 0x4f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7f, 0x4e);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x80, 0x20);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x81, 0x0f);
++	} else {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7d, 0x59);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7e, 0x4c);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7f, 0x48);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x80, 0x3a);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x81, 0x26);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x82, 0x00);
++
++	jd9365da_switch_page(&dsi_ctx, 0x02);
++	if (jadard->dsi->lanes == 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x02);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x02);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x02, 0x00);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x03, 0x00);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x04, 0x1e);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x05, 0x1e);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x06, 0x1f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x07, 0x1f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x08, 0x1f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x09, 0x17);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0a, 0x17);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0b, 0x37);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0c, 0x37);
++	} else {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x42);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x42);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x02, 0x40);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x03, 0x40);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x04, 0x5e);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x05, 0x5e);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x06, 0x5f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x07, 0x5f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x08, 0x5f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x09, 0x57);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0a, 0x57);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0b, 0x77);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0c, 0x77);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0d, 0x47);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0e, 0x47);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0f, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x10, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x11, 0x4b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x12, 0x4b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x13, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x14, 0x49);
++	if (jadard->dsi->lanes == 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x15, 0x1f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x16, 0x01);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x17, 0x01);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x18, 0x00);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x19, 0x00);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1a, 0x1e);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1b, 0x1e);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1c, 0x1f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1d, 0x1f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1e, 0x1f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1f, 0x17);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x20, 0x17);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x21, 0x37);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x22, 0x37);
++	} else {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x15, 0x5f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x16, 0x41);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x17, 0x41);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x18, 0x40);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x19, 0x40);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1a, 0x5e);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1b, 0x5e);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1c, 0x5f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1d, 0x5f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1e, 0x5f);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1f, 0x57);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x20, 0x57);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x21, 0x77);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x22, 0x77);
++	}
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x23, 0x46);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x24, 0x46);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x25, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x26, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x27, 0x4a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x28, 0x4a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x29, 0x48);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2a, 0x48);
++	if (jadard->dsi->lanes == 4)
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2b, 0x1f);
++	else
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2b, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2c, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2d, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2e, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2f, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x30, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x31, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x32, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x33, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x34, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x35, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x36, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x37);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x38, 0x37);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x39, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3a, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3b, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3c, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3d, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3e, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3f, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x40, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x41, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x42, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x43, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x44, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x45, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x46, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x47, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x48, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x49, 0x1e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4a, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4b, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4c, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4d, 0x37);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4e, 0x37);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4f, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x50, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x51, 0x0b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x52, 0x0b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x53, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x54, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x55, 0x07);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x56, 0x07);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x57, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x58, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5b, 0x30);
++	if (jadard->dsi->lanes == 4)
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5c, 0x16);
++	else
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5c, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5d, 0x34);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5e, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5f, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x63, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x64, 0x6a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x67, 0x73);
++	if (jadard->dsi->lanes == 4)
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x1d);
++	else
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x07);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x69, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6a, 0x6a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6b, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6c, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6d, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6e, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6f, 0x88);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x75, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x77, 0xdd);
++	if (jadard->dsi->lanes == 4)
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x78, 0x3f);
++	else
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x78, 0x2c);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x79, 0x15);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7a, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7d, 0x14);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7e, 0x82);
++
++	jd9365da_switch_page(&dsi_ctx, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x0e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x02, 0xb3);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x09, 0x61);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0e, 0x48);
++	if (jadard->dsi->lanes != 4) {
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x58);
++		mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2b, 0x0f);
++	}
++
++	jd9365da_switch_page(&dsi_ctx, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0xe6, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0xe7, 0x0c);
++	mipi_dsi_dcs_exit_sleep_mode_multi(&dsi_ctx);
++	msleep(120);
++	mipi_dsi_dcs_set_display_on_multi(&dsi_ctx);
++	msleep(60);
++
++	return dsi_ctx.accum_err;
++}
++
++static const struct jadard_panel_desc waveshare_10_1_inch_a_desc = {
++	.mode_4ln = &waveshare_10_1_a_mode,
++	.mode_2ln = &waveshare_10_1_a_mode,
++	.format = MIPI_DSI_FMT_RGB888,
++	.init = waveshare_10_1_a_init,
++	.mode_flags = MIPI_DSI_MODE_VIDEO_HSE | MIPI_DSI_MODE_VIDEO |
++		MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
++};
++
+ static int jadard_dsi_probe(struct mipi_dsi_device *dsi)
+ {
+ 	struct device *dev = &dsi->dev;
+@@ -1953,6 +2513,14 @@ static const struct of_device_id jadard_of_match[] = {
+ 		.compatible = "waveshare,4.0-dsi-touch-c",
+ 		.data = &waveshare_4_0_inch_c_desc
+ 	},
++	{
++		.compatible = "waveshare,8.0-dsi-touch-a",
++		.data = &waveshare_8_0_inch_a_desc
++	},
++	{
++		.compatible = "waveshare,10.1-dsi-touch-a",
++		.data = &waveshare_10_1_inch_a_desc
++	},
+ 	{ /* sentinel */ }
+ };
+ MODULE_DEVICE_TABLE(of, jadard_of_match);

--- a/patch/kernel/qrb2210-edge/0040-drm-panel-jadard-jd9365da-h3-support-Waveshare-720p-.patch
+++ b/patch/kernel/qrb2210-edge/0040-drm-panel-jadard-jd9365da-h3-support-Waveshare-720p-.patch
@@ -1,0 +1,364 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:39 +0300
+Subject: [PATCH 40/48] drm/panel: jadard-jd9365da-h3: support Waveshare 720p
+ DSI panels
+
+Add configuration for Waveshare 9.0" and 10.1" 720p DSI panels using
+JD9365 controller.
+
+Tested-by: Riccardo Mereu <r.mereu@arduino.cc>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Reviewed-by: Neil Armstrong <neil.armstrong@linaro.org>
+---
+ .../gpu/drm/panel/panel-jadard-jd9365da-h3.c  | 312 ++++++++++++++++++
+ 1 file changed, 312 insertions(+)
+
+diff --git a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+index a750758b330c..f61c70a9a9ff 100644
+--- a/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
++++ b/drivers/gpu/drm/panel/panel-jadard-jd9365da-h3.c
+@@ -21,6 +21,8 @@
+ #include <linux/of.h>
+ #include <linux/regulator/consumer.h>
+ 
++#include <video/mipi_display.h>
++
+ struct jadard;
+ 
+ struct jadard_panel_desc {
+@@ -2043,6 +2045,49 @@ static const struct jadard_panel_desc waveshare_8_0_inch_a_desc = {
+ 		      MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
+ };
+ 
++static int waveshare_10_1_b_init(struct jadard *jadard);
++
++static const struct jadard_panel_desc waveshare_9_0_inch_b_desc = {
++	.mode_4ln = &(const struct drm_display_mode) {
++		.clock		= (720 + 60 + 60 + 4) * (1280 + 16 + 12 + 4) * 60 / 1000,
++
++		.hdisplay	= 720,
++		.hsync_start	= 720 + 60,
++		.hsync_end	= 720 + 60 + 60,
++		.htotal		= 720 + 60 + 60 + 4,
++
++		.vdisplay	= 1280,
++		.vsync_start	= 1280 + 16,
++		.vsync_end	= 1280 + 16 + 12,
++		.vtotal		= 1280 + 16 + 12 + 4,
++
++		.width_mm	= 114,
++		.height_mm	= 196,
++		.type		= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED,
++	},
++	.mode_2ln = &(const struct drm_display_mode) {
++		.clock		= (720 + 50 + 50 + 50) * (1280 + 26 + 12 + 4) * 60 / 1000,
++
++		.hdisplay	= 720,
++		.hsync_start	= 720 + 50,
++		.hsync_end	= 720 + 50 + 50,
++		.htotal		= 720 + 50 + 50 + 50,
++
++		.vdisplay	= 1280,
++		.vsync_start	= 1280 + 26,
++		.vsync_end	= 1280 + 26 + 12,
++		.vtotal		= 1280 + 26 + 12 + 4,
++
++		.width_mm	= 114,
++		.height_mm	= 196,
++		.type		= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED,
++	},
++	.format = MIPI_DSI_FMT_RGB888,
++	.init = waveshare_10_1_b_init,
++	.mode_flags = MIPI_DSI_MODE_VIDEO_HSE | MIPI_DSI_MODE_VIDEO |
++		MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
++};
++
+ static const struct drm_display_mode waveshare_10_1_a_mode = {
+ 	.clock		= (800 + 40 + 20 + 20) * (1280 + 20 + 20 + 4) * 60 / 1000,
+ 
+@@ -2387,6 +2432,265 @@ static const struct jadard_panel_desc waveshare_10_1_inch_a_desc = {
+ 		MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
+ };
+ 
++static int waveshare_10_1_b_init(struct jadard *jadard)
++{
++	struct mipi_dsi_multi_context dsi_ctx = { .dsi = jadard->dsi };
++
++	jd9365da_switch_page(&dsi_ctx, 0x00);
++	jadard_enable_standard_cmds(&dsi_ctx);
++
++	jd9365da_switch_page(&dsi_ctx, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x3d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x03, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x04, 0x3f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x17, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x18, 0xbf);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x19, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1a, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1b, 0xbf);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1c, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x24, 0xfe);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x19);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x38, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x39, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3a, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3c, 0x74);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3d, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3e, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3f, 0xff);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x40, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x41, 0xa0);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x42, 0x7e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x43, 0x1a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x44, 0x0f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x45, 0x24);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x55, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x57, 0xa9);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x59, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5a, 0x38);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5b, 0x1a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5d, 0x7f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5e, 0x65);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5f, 0x52);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x60, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x61, 0x3d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x62, 0x2d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x63, 0x2d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x64, 0x14);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x65, 0x28);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x66, 0x25);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x67, 0x23);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x3f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x69, 0x2d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6a, 0x34);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6b, 0x27);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6c, 0x24);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6d, 0x18);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6e, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6f, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x70, 0x7f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x71, 0x65);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x72, 0x52);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x73, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x74, 0x3d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x75, 0x2d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x76, 0x2d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x77, 0x14);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x78, 0x28);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x79, 0x25);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7a, 0x23);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7b, 0x3f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7c, 0x2d);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7d, 0x34);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7e, 0x27);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7f, 0x24);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x80, 0x18);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x81, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x82, 0x00);
++
++	jd9365da_switch_page(&dsi_ctx, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x51);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x01, 0x55);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x02, 0x50);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x03, 0x51);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x04, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x05, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x06, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x07, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x08, 0x47);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x09, 0x46);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0a, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0b, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0c, 0x4b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0d, 0x4a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0e, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0f, 0x48);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x10, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x11, 0x41);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x12, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x13, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x14, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x15, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x16, 0x51);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x17, 0x55);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x18, 0x50);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x19, 0x51);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1a, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1b, 0x77);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1c, 0x57);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1d, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1e, 0x47);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x1f, 0x46);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x20, 0x45);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x21, 0x44);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x22, 0x4b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x23, 0x4a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x24, 0x49);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x25, 0x48);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x26, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x27, 0x41);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x28, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x29, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2a, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2b, 0x5f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2c, 0x11);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2d, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2e, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2f, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x30, 0x15);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x31, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x32, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x33, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x34, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x35, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x36, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x0b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x38, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x39, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3a, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3b, 0x07);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3c, 0x11);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3d, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3e, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x3f, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x40, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x41, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x42, 0x11);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x43, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x44, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x45, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x46, 0x15);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x47, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x48, 0x17);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x49, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4a, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4b, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4c, 0x0a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4d, 0x0b);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4e, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x4f, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x50, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x51, 0x07);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x52, 0x11);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x53, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x54, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x55, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x56, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x57, 0x1f);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x58, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5b, 0x10);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5c, 0x07);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5d, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5e, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x5f, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x60, 0x40);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x61, 0x01);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x62, 0x02);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x63, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x64, 0x66);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x65, 0x55);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x66, 0x13);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x67, 0x73);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x68, 0x09);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x69, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6a, 0x66);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6b, 0x08);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6c, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6d, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6e, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x6f, 0x88);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x75, 0xe3);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x76, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x77, 0xd5);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x78, 0x2a);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x79, 0x21);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7a, 0x00);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7d, 0x06);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x7e, 0x66);
++
++	jd9365da_switch_page(&dsi_ctx, 0x04);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x00, 0x0e);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x02, 0xb3);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x09, 0x60);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x0e, 0x48);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x37, 0x58);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x2b, 0x0f);
++
++	jd9365da_switch_page(&dsi_ctx, 0x05);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, 0x15, 0x1d);
++
++	jd9365da_switch_page(&dsi_ctx, 0x00);
++	mipi_dsi_dcs_exit_sleep_mode_multi(&dsi_ctx);
++	msleep(120);
++	mipi_dsi_dcs_set_display_on_multi(&dsi_ctx);
++	msleep(5);
++	mipi_dsi_dcs_write_seq_multi(&dsi_ctx, MIPI_DCS_SET_TEAR_ON);
++
++	return 0;
++}
++
++static const struct jadard_panel_desc waveshare_10_1_inch_b_desc = {
++	.mode_4ln = &(const struct drm_display_mode) {
++		.clock		= (720 + 60 + 60 + 4) * (1280 + 16 + 12 + 4) * 60 / 1000,
++
++		.hdisplay	= 720,
++		.hsync_start	= 720 + 60,
++		.hsync_end	= 720 + 60 + 60,
++		.htotal		= 720 + 60 + 60 + 4,
++
++		.vdisplay	= 1280,
++		.vsync_start	= 1280 + 16,
++		.vsync_end	= 1280 + 16 + 12,
++		.vtotal		= 1280 + 16 + 12 + 4,
++
++		.width_mm	= 125,
++		.height_mm	= 222,
++		.type		= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED,
++	},
++	.mode_2ln = &(const struct drm_display_mode) {
++		.clock		= (720 + 50 + 50 + 50) * (1280 + 26 + 12 + 4) * 60 / 1000,
++
++		.hdisplay	= 720,
++		.hsync_start	= 720 + 50,
++		.hsync_end	= 720 + 50 + 50,
++		.htotal		= 720 + 50 + 50 + 50,
++
++		.vdisplay	= 1280,
++		.vsync_start	= 1280 + 26,
++		.vsync_end	= 1280 + 26 + 12,
++		.vtotal		= 1280 + 26 + 12 + 4,
++
++		.width_mm	= 125,
++		.height_mm	= 222,
++		.type		= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED,
++	},
++	.format = MIPI_DSI_FMT_RGB888,
++	.init = waveshare_10_1_b_init,
++	.mode_flags = MIPI_DSI_MODE_VIDEO_HSE | MIPI_DSI_MODE_VIDEO |
++		MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
++};
++
+ static int jadard_dsi_probe(struct mipi_dsi_device *dsi)
+ {
+ 	struct device *dev = &dsi->dev;
+@@ -2517,10 +2821,18 @@ static const struct of_device_id jadard_of_match[] = {
+ 		.compatible = "waveshare,8.0-dsi-touch-a",
+ 		.data = &waveshare_8_0_inch_a_desc
+ 	},
++	{
++		.compatible = "waveshare,9.0-dsi-touch-b",
++		.data = &waveshare_9_0_inch_b_desc
++	},
+ 	{
+ 		.compatible = "waveshare,10.1-dsi-touch-a",
+ 		.data = &waveshare_10_1_inch_a_desc
+ 	},
++	{
++		.compatible = "waveshare,10.1-dsi-touch-b",
++		.data = &waveshare_10_1_inch_b_desc
++	},
+ 	{ /* sentinel */ }
+ };
+ MODULE_DEVICE_TABLE(of, jadard_of_match);

--- a/patch/kernel/qrb2210-edge/0041-drm-panel-ilitek-ili9881c-support-Waveshare-7.0-DSI-.patch
+++ b/patch/kernel/qrb2210-edge/0041-drm-panel-ilitek-ili9881c-support-Waveshare-7.0-DSI-.patch
@@ -1,0 +1,333 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:40 +0300
+Subject: [PATCH 41/48] drm/panel: ilitek-ili9881c: support Waveshare 7.0" DSI
+ panel
+
+Enable support for Waveshare 7.0" DSI TOUCH-A panel. It requires
+additional voltage regulator, iovcc.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ drivers/gpu/drm/panel/panel-ilitek-ili9881c.c | 251 +++++++++++++++++-
+ 1 file changed, 249 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c b/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c
+index 947b47841b01..0652cdb57d11 100644
+--- a/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c
++++ b/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c
+@@ -52,6 +52,7 @@ struct ili9881c {
+ 	const struct ili9881c_desc	*desc;
+ 
+ 	struct regulator	*power;
++	struct regulator	*iovcc;
+ 	struct gpio_desc	*reset;
+ 
+ 	enum drm_panel_orientation	orientation;
+@@ -1997,6 +1998,205 @@ static const struct ili9881c_instr bsd1218_a101kl68_init[] = {
+ 	ILI9881C_COMMAND_INSTR(0xd3, 0x3f),
+ };
+ 
++static const struct ili9881c_instr waveshare_7inch_a_init[] = {
++	ILI9881C_SWITCH_PAGE_INSTR(3),
++	ILI9881C_COMMAND_INSTR(0x01, 0x00),
++	ILI9881C_COMMAND_INSTR(0x02, 0x00),
++	ILI9881C_COMMAND_INSTR(0x03, 0x73),
++	ILI9881C_COMMAND_INSTR(0x04, 0x00),
++	ILI9881C_COMMAND_INSTR(0x05, 0x00),
++	ILI9881C_COMMAND_INSTR(0x06, 0x0a),
++	ILI9881C_COMMAND_INSTR(0x07, 0x00),
++	ILI9881C_COMMAND_INSTR(0x08, 0x00),
++	ILI9881C_COMMAND_INSTR(0x09, 0x61),
++	ILI9881C_COMMAND_INSTR(0x0a, 0x00),
++	ILI9881C_COMMAND_INSTR(0x0b, 0x00),
++	ILI9881C_COMMAND_INSTR(0x0c, 0x01),
++	ILI9881C_COMMAND_INSTR(0x0d, 0x00),
++	ILI9881C_COMMAND_INSTR(0x0e, 0x00),
++	ILI9881C_COMMAND_INSTR(0x0f, 0x61),
++	ILI9881C_COMMAND_INSTR(0x10, 0x61),
++	ILI9881C_COMMAND_INSTR(0x11, 0x00),
++	ILI9881C_COMMAND_INSTR(0x12, 0x00),
++	ILI9881C_COMMAND_INSTR(0x13, 0x00),
++	ILI9881C_COMMAND_INSTR(0x14, 0x00),
++	ILI9881C_COMMAND_INSTR(0x15, 0x00),
++	ILI9881C_COMMAND_INSTR(0x16, 0x00),
++	ILI9881C_COMMAND_INSTR(0x17, 0x00),
++	ILI9881C_COMMAND_INSTR(0x18, 0x00),
++	ILI9881C_COMMAND_INSTR(0x19, 0x00),
++	ILI9881C_COMMAND_INSTR(0x1a, 0x00),
++	ILI9881C_COMMAND_INSTR(0x1b, 0x00),
++	ILI9881C_COMMAND_INSTR(0x1c, 0x00),
++	ILI9881C_COMMAND_INSTR(0x1d, 0x00),
++	ILI9881C_COMMAND_INSTR(0x1e, 0x40),
++	ILI9881C_COMMAND_INSTR(0x1f, 0x80),
++	ILI9881C_COMMAND_INSTR(0x20, 0x06),
++	ILI9881C_COMMAND_INSTR(0x21, 0x01),
++	ILI9881C_COMMAND_INSTR(0x22, 0x00),
++	ILI9881C_COMMAND_INSTR(0x23, 0x00),
++	ILI9881C_COMMAND_INSTR(0x24, 0x00),
++	ILI9881C_COMMAND_INSTR(0x25, 0x00),
++	ILI9881C_COMMAND_INSTR(0x26, 0x00),
++	ILI9881C_COMMAND_INSTR(0x27, 0x00),
++	ILI9881C_COMMAND_INSTR(0x28, 0x33),
++	ILI9881C_COMMAND_INSTR(0x29, 0x03),
++	ILI9881C_COMMAND_INSTR(0x2a, 0x00),
++	ILI9881C_COMMAND_INSTR(0x2b, 0x00),
++	ILI9881C_COMMAND_INSTR(0x2c, 0x00),
++	ILI9881C_COMMAND_INSTR(0x2d, 0x00),
++	ILI9881C_COMMAND_INSTR(0x2e, 0x00),
++	ILI9881C_COMMAND_INSTR(0x2f, 0x00),
++	ILI9881C_COMMAND_INSTR(0x30, 0x00),
++	ILI9881C_COMMAND_INSTR(0x31, 0x00),
++	ILI9881C_COMMAND_INSTR(0x32, 0x00),
++	ILI9881C_COMMAND_INSTR(0x33, 0x00),
++	ILI9881C_COMMAND_INSTR(0x34, 0x04),
++	ILI9881C_COMMAND_INSTR(0x35, 0x00),
++	ILI9881C_COMMAND_INSTR(0x36, 0x00),
++	ILI9881C_COMMAND_INSTR(0x37, 0x00),
++	ILI9881C_COMMAND_INSTR(0x38, 0x3c),
++	ILI9881C_COMMAND_INSTR(0x39, 0x00),
++	ILI9881C_COMMAND_INSTR(0x3a, 0x00),
++	ILI9881C_COMMAND_INSTR(0x3b, 0x00),
++	ILI9881C_COMMAND_INSTR(0x3c, 0x00),
++	ILI9881C_COMMAND_INSTR(0x3d, 0x00),
++	ILI9881C_COMMAND_INSTR(0x3e, 0x00),
++	ILI9881C_COMMAND_INSTR(0x3f, 0x00),
++	ILI9881C_COMMAND_INSTR(0x40, 0x00),
++	ILI9881C_COMMAND_INSTR(0x41, 0x00),
++	ILI9881C_COMMAND_INSTR(0x42, 0x00),
++	ILI9881C_COMMAND_INSTR(0x43, 0x00),
++	ILI9881C_COMMAND_INSTR(0x44, 0x00),
++	ILI9881C_COMMAND_INSTR(0x50, 0x10),
++	ILI9881C_COMMAND_INSTR(0x51, 0x32),
++	ILI9881C_COMMAND_INSTR(0x52, 0x54),
++	ILI9881C_COMMAND_INSTR(0x53, 0x76),
++	ILI9881C_COMMAND_INSTR(0x54, 0x98),
++	ILI9881C_COMMAND_INSTR(0x55, 0xba),
++	ILI9881C_COMMAND_INSTR(0x56, 0x10),
++	ILI9881C_COMMAND_INSTR(0x57, 0x32),
++	ILI9881C_COMMAND_INSTR(0x58, 0x54),
++	ILI9881C_COMMAND_INSTR(0x59, 0x76),
++	ILI9881C_COMMAND_INSTR(0x5a, 0x98),
++	ILI9881C_COMMAND_INSTR(0x5b, 0xba),
++	ILI9881C_COMMAND_INSTR(0x5c, 0xdc),
++	ILI9881C_COMMAND_INSTR(0x5d, 0xfe),
++	ILI9881C_COMMAND_INSTR(0x5e, 0x00),
++	ILI9881C_COMMAND_INSTR(0x5f, 0x0e),
++	ILI9881C_COMMAND_INSTR(0x60, 0x0f),
++	ILI9881C_COMMAND_INSTR(0x61, 0x0c),
++	ILI9881C_COMMAND_INSTR(0x62, 0x0d),
++	ILI9881C_COMMAND_INSTR(0x63, 0x06),
++	ILI9881C_COMMAND_INSTR(0x64, 0x07),
++	ILI9881C_COMMAND_INSTR(0x65, 0x02),
++	ILI9881C_COMMAND_INSTR(0x66, 0x02),
++	ILI9881C_COMMAND_INSTR(0x67, 0x02),
++	ILI9881C_COMMAND_INSTR(0x68, 0x02),
++	ILI9881C_COMMAND_INSTR(0x69, 0x01),
++	ILI9881C_COMMAND_INSTR(0x6a, 0x00),
++	ILI9881C_COMMAND_INSTR(0x6b, 0x02),
++	ILI9881C_COMMAND_INSTR(0x6c, 0x15),
++	ILI9881C_COMMAND_INSTR(0x6d, 0x14),
++	ILI9881C_COMMAND_INSTR(0x6e, 0x02),
++	ILI9881C_COMMAND_INSTR(0x6f, 0x02),
++	ILI9881C_COMMAND_INSTR(0x70, 0x02),
++	ILI9881C_COMMAND_INSTR(0x71, 0x02),
++	ILI9881C_COMMAND_INSTR(0x72, 0x02),
++	ILI9881C_COMMAND_INSTR(0x73, 0x02),
++	ILI9881C_COMMAND_INSTR(0x74, 0x02),
++	ILI9881C_COMMAND_INSTR(0x75, 0x0e),
++	ILI9881C_COMMAND_INSTR(0x76, 0x0f),
++	ILI9881C_COMMAND_INSTR(0x77, 0x0c),
++	ILI9881C_COMMAND_INSTR(0x78, 0x0d),
++	ILI9881C_COMMAND_INSTR(0x79, 0x06),
++	ILI9881C_COMMAND_INSTR(0x7a, 0x07),
++	ILI9881C_COMMAND_INSTR(0x7b, 0x02),
++	ILI9881C_COMMAND_INSTR(0x7c, 0x02),
++	ILI9881C_COMMAND_INSTR(0x7d, 0x02),
++	ILI9881C_COMMAND_INSTR(0x7e, 0x02),
++	ILI9881C_COMMAND_INSTR(0x7f, 0x01),
++	ILI9881C_COMMAND_INSTR(0x80, 0x00),
++	ILI9881C_COMMAND_INSTR(0x81, 0x02),
++	ILI9881C_COMMAND_INSTR(0x82, 0x14),
++	ILI9881C_COMMAND_INSTR(0x83, 0x15),
++	ILI9881C_COMMAND_INSTR(0x84, 0x02),
++	ILI9881C_COMMAND_INSTR(0x85, 0x02),
++	ILI9881C_COMMAND_INSTR(0x86, 0x02),
++	ILI9881C_COMMAND_INSTR(0x87, 0x02),
++	ILI9881C_COMMAND_INSTR(0x88, 0x02),
++	ILI9881C_COMMAND_INSTR(0x89, 0x02),
++	ILI9881C_COMMAND_INSTR(0x8a, 0x02),
++
++	ILI9881C_SWITCH_PAGE_INSTR(4),
++	ILI9881C_COMMAND_INSTR(0x38, 0x01),
++	ILI9881C_COMMAND_INSTR(0x39, 0x00),
++	ILI9881C_COMMAND_INSTR(0x6c, 0x15),
++	ILI9881C_COMMAND_INSTR(0x6e, 0x2a),
++	ILI9881C_COMMAND_INSTR(0x6f, 0x33),
++	ILI9881C_COMMAND_INSTR(0x3a, 0x94),
++	ILI9881C_COMMAND_INSTR(0x8d, 0x14),
++	ILI9881C_COMMAND_INSTR(0x87, 0xba),
++	ILI9881C_COMMAND_INSTR(0x26, 0x76),
++	ILI9881C_COMMAND_INSTR(0xb2, 0xd1),
++	ILI9881C_COMMAND_INSTR(0xb5, 0x06),
++	ILI9881C_COMMAND_INSTR(0x3b, 0x98),
++
++	ILI9881C_SWITCH_PAGE_INSTR(1),
++	ILI9881C_COMMAND_INSTR(0x22, 0x0a),
++	ILI9881C_COMMAND_INSTR(0x31, 0x00),
++	ILI9881C_COMMAND_INSTR(0x53, 0x71),
++	ILI9881C_COMMAND_INSTR(0x55, 0x8f),
++	ILI9881C_COMMAND_INSTR(0x40, 0x33),
++	ILI9881C_COMMAND_INSTR(0x50, 0x96),
++	ILI9881C_COMMAND_INSTR(0x51, 0x96),
++	ILI9881C_COMMAND_INSTR(0x60, 0x23),
++	ILI9881C_COMMAND_INSTR(0xa0, 0x08),
++	ILI9881C_COMMAND_INSTR(0xa1, 0x1d),
++	ILI9881C_COMMAND_INSTR(0xa2, 0x2a),
++	ILI9881C_COMMAND_INSTR(0xa3, 0x10),
++	ILI9881C_COMMAND_INSTR(0xa4, 0x15),
++	ILI9881C_COMMAND_INSTR(0xa5, 0x28),
++	ILI9881C_COMMAND_INSTR(0xa6, 0x1c),
++	ILI9881C_COMMAND_INSTR(0xa7, 0x1d),
++	ILI9881C_COMMAND_INSTR(0xa8, 0x7e),
++	ILI9881C_COMMAND_INSTR(0xa9, 0x1d),
++	ILI9881C_COMMAND_INSTR(0xaa, 0x29),
++	ILI9881C_COMMAND_INSTR(0xab, 0x6b),
++	ILI9881C_COMMAND_INSTR(0xac, 0x1a),
++	ILI9881C_COMMAND_INSTR(0xad, 0x18),
++	ILI9881C_COMMAND_INSTR(0xae, 0x4b),
++	ILI9881C_COMMAND_INSTR(0xaf, 0x20),
++	ILI9881C_COMMAND_INSTR(0xb0, 0x27),
++	ILI9881C_COMMAND_INSTR(0xb1, 0x50),
++	ILI9881C_COMMAND_INSTR(0xb2, 0x64),
++	ILI9881C_COMMAND_INSTR(0xb3, 0x39),
++	ILI9881C_COMMAND_INSTR(0xc0, 0x08),
++	ILI9881C_COMMAND_INSTR(0xc1, 0x1d),
++	ILI9881C_COMMAND_INSTR(0xc2, 0x2a),
++	ILI9881C_COMMAND_INSTR(0xc3, 0x10),
++	ILI9881C_COMMAND_INSTR(0xc4, 0x15),
++	ILI9881C_COMMAND_INSTR(0xc5, 0x28),
++	ILI9881C_COMMAND_INSTR(0xc6, 0x1c),
++	ILI9881C_COMMAND_INSTR(0xc7, 0x1d),
++	ILI9881C_COMMAND_INSTR(0xc8, 0x7e),
++	ILI9881C_COMMAND_INSTR(0xc9, 0x1d),
++	ILI9881C_COMMAND_INSTR(0xca, 0x29),
++	ILI9881C_COMMAND_INSTR(0xcb, 0x6b),
++	ILI9881C_COMMAND_INSTR(0xcc, 0x1a),
++	ILI9881C_COMMAND_INSTR(0xcd, 0x18),
++	ILI9881C_COMMAND_INSTR(0xce, 0x4b),
++	ILI9881C_COMMAND_INSTR(0xcf, 0x20),
++	ILI9881C_COMMAND_INSTR(0xd0, 0x27),
++	ILI9881C_COMMAND_INSTR(0xd1, 0x50),
++	ILI9881C_COMMAND_INSTR(0xd2, 0x64),
++	ILI9881C_COMMAND_INSTR(0xd3, 0x39),
++
++	ILI9881C_SWITCH_PAGE_INSTR(0),
++	ILI9881C_COMMAND_INSTR(0x3a, 0x77),
++	ILI9881C_COMMAND_INSTR(0x36, 0x00),
++};
++
+ static inline struct ili9881c *panel_to_ili9881c(struct drm_panel *panel)
+ {
+ 	return container_of(panel, struct ili9881c, panel);
+@@ -2035,9 +2235,19 @@ static int ili9881c_prepare(struct drm_panel *panel)
+ 	int ret;
+ 
+ 	/* Power the panel */
++	if (ctx->iovcc) {
++		ret = regulator_enable(ctx->iovcc);
++		if (ret)
++			return ret;
++	}
++
++	msleep(5);
+ 	ret = regulator_enable(ctx->power);
+-	if (ret)
+-		return ret;
++	if (ret) {
++		mctx.accum_err = ret;
++		goto disable_iovcc;
++	}
++
+ 	msleep(5);
+ 
+ 	/* And reset it */
+@@ -2074,6 +2284,9 @@ static int ili9881c_prepare(struct drm_panel *panel)
+ 
+ disable_power:
+ 	regulator_disable(ctx->power);
++disable_iovcc:
++	if (ctx->iovcc)
++		regulator_disable(ctx->iovcc);
+ 	return mctx.accum_err;
+ }
+ 
+@@ -2085,6 +2298,8 @@ static int ili9881c_unprepare(struct drm_panel *panel)
+ 	mipi_dsi_dcs_set_display_off_multi(&mctx);
+ 	mipi_dsi_dcs_enter_sleep_mode_multi(&mctx);
+ 	regulator_disable(ctx->power);
++	if (ctx->iovcc)
++		regulator_disable(ctx->iovcc);
+ 	gpiod_set_value_cansleep(ctx->reset, 1);
+ 
+ 	return 0;
+@@ -2260,6 +2475,23 @@ static const struct drm_display_mode bsd1218_a101kl68_default_mode = {
+ 	.height_mm	= 170,
+ };
+ 
++static const struct drm_display_mode waveshare_7inch_a_mode = {
++	.clock		= 83333,
++
++	.hdisplay	= 720,
++	.hsync_start	= 720 + 120,
++	.hsync_end	= 720 + 120 + 100,
++	.htotal		= 720 + 120 + 100 + 100,
++
++	.vdisplay	= 1280,
++	.vsync_start	= 1280 + 10,
++	.vsync_end	= 1280 + 10 + 10,
++	.vtotal		= 1280 + 10 + 10 + 10,
++
++	.width_mm	= 85,
++	.height_mm	= 154,
++};
++
+ static int ili9881c_get_modes(struct drm_panel *panel,
+ 			      struct drm_connector *connector)
+ {
+@@ -2329,6 +2561,11 @@ static int ili9881c_dsi_probe(struct mipi_dsi_device *dsi)
+ 		return dev_err_probe(&dsi->dev, PTR_ERR(ctx->power),
+ 				     "Couldn't get our power regulator\n");
+ 
++	ctx->iovcc = devm_regulator_get_optional(&dsi->dev, "iovcc");
++	if (IS_ERR(ctx->iovcc))
++		return dev_err_probe(&dsi->dev, PTR_ERR(ctx->iovcc),
++				     "Couldn't get our iovcc regulator\n");
++
+ 	ctx->reset = devm_gpiod_get_optional(&dsi->dev, "reset", GPIOD_OUT_LOW);
+ 	if (IS_ERR(ctx->reset))
+ 		return dev_err_probe(&dsi->dev, PTR_ERR(ctx->reset),
+@@ -2454,6 +2691,15 @@ static const struct ili9881c_desc bsd1218_a101kl68_desc = {
+ 	.lanes = 4,
+ };
+ 
++static const struct ili9881c_desc waveshare_7inch_a_desc = {
++	.init = waveshare_7inch_a_init,
++	.init_length = ARRAY_SIZE(waveshare_7inch_a_init),
++	.mode = &waveshare_7inch_a_mode,
++	.mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_HSE |
++		      MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
++	.lanes = 2,
++};
++
+ static const struct of_device_id ili9881c_of_match[] = {
+ 	{ .compatible = "bananapi,lhr050h41", .data = &lhr050h41_desc },
+ 	{ .compatible = "bestar,bsd1218-a101kl68", .data = &bsd1218_a101kl68_desc },
+@@ -2462,6 +2708,7 @@ static const struct of_device_id ili9881c_of_match[] = {
+ 	{ .compatible = "tdo,tl050hdv35", .data = &tl050hdv35_desc },
+ 	{ .compatible = "wanchanglong,w552946aaa", .data = &w552946aaa_desc },
+ 	{ .compatible = "wanchanglong,w552946aba", .data = &w552946aba_desc },
++	{ .compatible = "waveshare,7.0-dsi-touch-a", .data = &waveshare_7inch_a_desc },
+ 	{ .compatible = "ampire,am8001280g", .data = &am8001280g_desc },
+ 	{ .compatible = "raspberrypi,dsi-5inch", &rpi_5inch_desc },
+ 	{ .compatible = "raspberrypi,dsi-7inch", &rpi_7inch_desc },

--- a/patch/kernel/qrb2210-edge/0042-drm-panel-add-devm_drm_panel_add-helper.patch
+++ b/patch/kernel/qrb2210-edge/0042-drm-panel-add-devm_drm_panel_add-helper.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:41 +0300
+Subject: [PATCH 42/48] drm/panel: add devm_drm_panel_add() helper
+
+Add devm_drm_panel_add(), devres-managed version of drm_panel_add().
+It's not uncommon for the panel drivers to use devres functions for most
+of the resources. Provide corresponding replacement for drm_panel_add().
+
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ drivers/gpu/drm/drm_panel.c | 23 +++++++++++++++++++++++
+ include/drm/drm_panel.h     |  1 +
+ 2 files changed, 24 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel.c b/drivers/gpu/drm/drm_panel.c
+index d1e6598ea3bc..a6029b699b73 100644
+--- a/drivers/gpu/drm/drm_panel.c
++++ b/drivers/gpu/drm/drm_panel.c
+@@ -101,6 +101,29 @@ void drm_panel_remove(struct drm_panel *panel)
+ }
+ EXPORT_SYMBOL(drm_panel_remove);
+ 
++static void drm_panel_add_release(void *data)
++{
++	drm_panel_remove(data);
++}
++
++/**
++ * devm_drm_panel_add - add a panel to the global registry using devres
++ * @panel: panel to add
++ *
++ * Add a panel to the global registry so that it can be looked
++ * up by display drivers. The panel to be added must have been
++ * allocated by devm_drm_panel_alloc(). Unlike drm_panel_add() with this
++ * function there is no need to call drm_panel_remove(), it will be called
++ * automatically.
++ */
++int devm_drm_panel_add(struct device *dev, struct drm_panel *panel)
++{
++	drm_panel_add(panel);
++
++	return devm_add_action_or_reset(dev, drm_panel_add_release, panel);
++}
++EXPORT_SYMBOL(devm_drm_panel_add);
++
+ /**
+  * drm_panel_prepare - power on a panel
+  * @panel: DRM panel
+diff --git a/include/drm/drm_panel.h b/include/drm/drm_panel.h
+index 2407bfa60236..1fb9148dd095 100644
+--- a/include/drm/drm_panel.h
++++ b/include/drm/drm_panel.h
+@@ -329,6 +329,7 @@ void drm_panel_put(struct drm_panel *panel);
+ 
+ void drm_panel_add(struct drm_panel *panel);
+ void drm_panel_remove(struct drm_panel *panel);
++int devm_drm_panel_add(struct device *dev, struct drm_panel *panel);
+ 
+ void drm_panel_prepare(struct drm_panel *panel);
+ void drm_panel_unprepare(struct drm_panel *panel);

--- a/patch/kernel/qrb2210-edge/0043-drm-panel-add-driver-for-Waveshare-8.8-DSI-TOUCH-A-p.patch
+++ b/patch/kernel/qrb2210-edge/0043-drm-panel-add-driver-for-Waveshare-8.8-DSI-TOUCH-A-p.patch
@@ -1,0 +1,285 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:42 +0300
+Subject: [PATCH 43/48] drm/panel: add driver for Waveshare 8.8" DSI TOUCH-A
+ panel
+
+Add driver for the panel found on Waveshare 8.8" DSI TOUCH-A kit. It
+uses ota7290b IC as a controller.
+
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ drivers/gpu/drm/panel/Kconfig                 |  12 +
+ drivers/gpu/drm/panel/Makefile                |   1 +
+ .../gpu/drm/panel/panel-focaltech-ota7290b.c  | 226 ++++++++++++++++++
+ 3 files changed, 239 insertions(+)
+ create mode 100644 drivers/gpu/drm/panel/panel-focaltech-ota7290b.c
+
+diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
+index 4495fc097ffa..394dd8e64289 100644
+--- a/drivers/gpu/drm/panel/Kconfig
++++ b/drivers/gpu/drm/panel/Kconfig
+@@ -144,6 +144,18 @@ config DRM_PANEL_FEIYANG_FY07024DI26A30D
+ 	  Say Y if you want to enable support for panels based on the
+ 	  Feiyang FY07024DI26A30-D MIPI-DSI interface.
+ 
++config DRM_PANEL_FOCALTECH_OTA7290B
++	tristate "Focaltech OTA7290B"
++	depends on DRM_MIPI_DSI
++	depends on I2C
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_KMS_HELPER
++	help
++	  Enable support for panels using OTA7290B as a controller (for
++	  example, Waveshare 12.3" DSI TOUCH-A panel). Say Y here if you want
++	  to enable support for this panel. To compile this driver as a module,
++	  choose M here.
++
+ config DRM_PANEL_DSI_CM
+ 	tristate "Generic DSI command mode panels"
+ 	depends on OF
+diff --git a/drivers/gpu/drm/panel/Makefile b/drivers/gpu/drm/panel/Makefile
+index aeffaa95666d..46f359b5035b 100644
+--- a/drivers/gpu/drm/panel/Makefile
++++ b/drivers/gpu/drm/panel/Makefile
+@@ -17,6 +17,7 @@ obj-$(CONFIG_DRM_PANEL_EBBG_FT8719) += panel-ebbg-ft8719.o
+ obj-$(CONFIG_DRM_PANEL_ELIDA_KD35T133) += panel-elida-kd35t133.o
+ obj-$(CONFIG_DRM_PANEL_FEIXIN_K101_IM2BA02) += panel-feixin-k101-im2ba02.o
+ obj-$(CONFIG_DRM_PANEL_FEIYANG_FY07024DI26A30D) += panel-feiyang-fy07024di26a30d.o
++obj-$(CONFIG_DRM_PANEL_FOCALTECH_OTA7290B) += panel-focaltech-ota7290b.o
+ obj-$(CONFIG_DRM_PANEL_HIMAX_HX8279) += panel-himax-hx8279.o
+ obj-$(CONFIG_DRM_PANEL_HIMAX_HX83102) += panel-himax-hx83102.o
+ obj-$(CONFIG_DRM_PANEL_HIMAX_HX83112A) += panel-himax-hx83112a.o
+diff --git a/drivers/gpu/drm/panel/panel-focaltech-ota7290b.c b/drivers/gpu/drm/panel/panel-focaltech-ota7290b.c
+new file mode 100644
+index 000000000000..8c135697a0fd
+--- /dev/null
++++ b/drivers/gpu/drm/panel/panel-focaltech-ota7290b.c
+@@ -0,0 +1,226 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2024 Waveshare International Limited
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
++
++#include <linux/delay.h>
++#include <linux/device.h>
++#include <linux/err.h>
++#include <linux/errno.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/of.h>
++
++#include <linux/gpio/consumer.h>
++#include <linux/regulator/consumer.h>
++
++#include <drm/drm_mipi_dsi.h>
++#include <drm/drm_modes.h>
++#include <drm/drm_panel.h>
++#include <drm/drm_probe_helper.h>
++
++struct ota7290b {
++	struct drm_panel panel;
++	struct mipi_dsi_device *dsi;
++
++	struct regulator *power;
++	struct gpio_desc *reset;
++	struct regulator *avdd;
++	struct regulator *vdd;
++	struct regulator *vcc;
++
++	enum drm_panel_orientation orientation;
++};
++
++static inline struct ota7290b *panel_to_ota(struct drm_panel *panel)
++{
++	return container_of(panel, struct ota7290b, panel);
++}
++
++static int ota7290b_prepare(struct drm_panel *panel)
++{
++	struct ota7290b *ctx = panel_to_ota(panel);
++	struct mipi_dsi_multi_context dsi_ctx = { .dsi = ctx->dsi };
++	int ret;
++
++	if (ctx->vcc) {
++		ret = regulator_enable(ctx->vcc);
++		if (ret)
++			dev_err(panel->dev, "failed to enable VCC regulator: %d\n", ret);
++	}
++
++	if (ctx->reset) {
++		gpiod_set_value_cansleep(ctx->reset, 0);
++		msleep(60);
++		gpiod_set_value_cansleep(ctx->reset, 1);
++		msleep(60);
++	}
++
++	if (ctx->vdd) {
++		ret = regulator_enable(ctx->vdd);
++		if (ret)
++			dev_err(panel->dev, "failed to enable VDD regulator: %d\n", ret);
++	}
++
++	if (ctx->reset) {
++		gpiod_set_value_cansleep(ctx->reset, 0);
++		msleep(60);
++	}
++
++	if (ctx->avdd) {
++		ret = regulator_enable(ctx->avdd);
++		if (ret)
++			dev_err(panel->dev, "failed to enable AVDD regulator: %d\n", ret);
++	}
++
++	mipi_dsi_dcs_exit_sleep_mode_multi(&dsi_ctx);
++	mipi_dsi_msleep(&dsi_ctx, 120);
++	mipi_dsi_dcs_set_display_on_multi(&dsi_ctx);
++	mipi_dsi_msleep(&dsi_ctx, 50);
++
++	if (dsi_ctx.accum_err < 0)
++		dev_err(panel->dev, "failed to init panel: %d\n", dsi_ctx.accum_err);
++
++	return dsi_ctx.accum_err;
++}
++
++static int ota7290b_unprepare(struct drm_panel *panel)
++{
++	struct ota7290b *ctx = panel_to_ota(panel);
++	struct mipi_dsi_multi_context dsi_ctx = { .dsi = ctx->dsi };
++
++	mipi_dsi_dcs_set_display_off_multi(&dsi_ctx);
++	mipi_dsi_dcs_enter_sleep_mode_multi(&dsi_ctx);
++
++	if (ctx->avdd)
++		regulator_disable(ctx->avdd);
++
++	if (ctx->reset) {
++		gpiod_set_value_cansleep(ctx->reset, 1);
++		msleep(5);
++	}
++
++	if (ctx->vdd)
++		regulator_disable(ctx->vdd);
++
++	if (ctx->vcc)
++		regulator_disable(ctx->vcc);
++
++	return 0;
++}
++
++static const struct drm_display_mode waveshare_dsi_touch_8_8_a_mode = {
++	.clock = 75000,
++
++	.hdisplay = 480,
++	.hsync_start = 480 + 50,
++	.hsync_end = 480 + 50 + 50,
++	.htotal = 480 + 50 + 50 + 50,
++
++	.vdisplay = 1920,
++	.vsync_start = 1920 + 20,
++	.vsync_end = 1920 + 20 + 20,
++	.vtotal = 1920 + 20 + 20 + 20,
++
++	.width_mm = 68,
++	.height_mm = 219,
++	.type = DRM_MODE_TYPE_DRIVER,
++};
++
++static int ota7290b_get_modes(struct drm_panel *panel,
++			      struct drm_connector *connector)
++{
++	return drm_connector_helper_get_modes_fixed(connector, &waveshare_dsi_touch_8_8_a_mode);
++}
++
++static enum drm_panel_orientation ota7290b_get_orientation(struct drm_panel *panel)
++{
++	struct ota7290b *ctx = panel_to_ota(panel);
++
++	return ctx->orientation;
++}
++
++static const struct drm_panel_funcs ota7290b_funcs = {
++	.prepare = ota7290b_prepare,
++	.unprepare = ota7290b_unprepare,
++	.get_modes = ota7290b_get_modes,
++	.get_orientation = ota7290b_get_orientation,
++};
++
++static int ota7290b_probe(struct mipi_dsi_device *dsi)
++{
++	struct ota7290b *ctx;
++	int ret;
++
++	ctx = devm_drm_panel_alloc(&dsi->dev, struct ota7290b, panel,
++				   &ota7290b_funcs,
++				   DRM_MODE_CONNECTOR_DSI);
++	if (!ctx)
++		return -ENOMEM;
++	mipi_dsi_set_drvdata(dsi, ctx);
++	ctx->dsi = dsi;
++
++	ctx->reset = devm_gpiod_get_optional(&dsi->dev, "reset", GPIOD_OUT_HIGH);
++	if (IS_ERR(ctx->reset))
++		return dev_err_probe(&dsi->dev, PTR_ERR(ctx->reset),
++				     "Couldn't get our reset GPIO\n");
++
++	ctx->vcc = devm_regulator_get_optional(&dsi->dev, "vcc");
++	if (IS_ERR(ctx->vcc))
++		return dev_err_probe(&dsi->dev, PTR_ERR(ctx->vcc),
++					"Couldn't get our VCC supply\n");
++
++	ctx->avdd = devm_regulator_get_optional(&dsi->dev, "avdd");
++	if (IS_ERR(ctx->avdd))
++		return dev_err_probe(&dsi->dev, PTR_ERR(ctx->avdd),
++					"Couldn't get our AVDD supply\n");
++
++	ctx->vdd = devm_regulator_get_optional(&dsi->dev, "vdd");
++	if (IS_ERR(ctx->vdd))
++		return dev_err_probe(&dsi->dev, PTR_ERR(ctx->vdd),
++					"Couldn't get our VDD supply\n");
++
++	ret = of_drm_get_panel_orientation(
++			dsi->dev.of_node, &ctx->orientation);
++	if (ret) {
++		dev_err(&dsi->dev, "%pOF: failed to get orientation: %d\n",
++			dsi->dev.of_node, ret);
++		return ret;
++	}
++
++	ret = drm_panel_of_backlight(&ctx->panel);
++	if (ret)
++		return ret;
++
++	ctx->panel.prepare_prev_first = true;
++
++	ret = devm_drm_panel_add(&dsi->dev, &ctx->panel);
++	if (ret)
++		return ret;
++
++	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_HSE |
++		MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS,
++	dsi->format = MIPI_DSI_FMT_RGB888,
++	dsi->lanes = 2;
++
++	return devm_mipi_dsi_attach(&dsi->dev, dsi);
++}
++
++static const struct of_device_id ota7290b_of_match[] = {
++	{ .compatible = "waveshare,8.8-dsi-touch-a", },
++	{}
++};
++MODULE_DEVICE_TABLE(of, ota7290b_of_match);
++
++static struct mipi_dsi_driver ota7290b_driver = {
++	.probe		= ota7290b_probe,
++	.driver = {
++		.name		= "focaltech-ota7290b",
++		.of_match_table	= ota7290b_of_match,
++	},
++};
++module_mipi_dsi_driver(ota7290b_driver);
++
++MODULE_DESCRIPTION("Panel driver for Focaltech OTA7290B panels");
++MODULE_LICENSE("GPL");

--- a/patch/kernel/qrb2210-edge/0044-dt-bindings-gpio-describe-Waveshare-GPIO-controller.patch
+++ b/patch/kernel/qrb2210-edge/0044-dt-bindings-gpio-describe-Waveshare-GPIO-controller.patch
@@ -1,0 +1,128 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:43 +0300
+Subject: [PATCH 44/48] dt-bindings: gpio: describe Waveshare GPIO controller
+
+The Waveshare DSI TOUCH family of panels has separate on-board GPIO
+controller, which controls power supplies to the panel and the touch
+screen and provides reset pins for both the panel and the touchscreen.
+Also it provides a simple PWM controller for panel backlight.
+
+Add bindings for these GPIO controllers. As overall integration might be
+not very obvious (and it differs significantly from the bindings used by
+the original drivers), provide complete example with the on-board
+regulators and the DSI panel.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Acked-by: Conor Dooley <conor.dooley@microchip.com>
+---
+ .../gpio/waveshare,dsi-touch-gpio.yaml        | 100 ++++++++++++++++++
+ 1 file changed, 100 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/gpio/waveshare,dsi-touch-gpio.yaml
+
+diff --git a/Documentation/devicetree/bindings/gpio/waveshare,dsi-touch-gpio.yaml b/Documentation/devicetree/bindings/gpio/waveshare,dsi-touch-gpio.yaml
+new file mode 100644
+index 000000000000..410348fcda25
+--- /dev/null
++++ b/Documentation/devicetree/bindings/gpio/waveshare,dsi-touch-gpio.yaml
+@@ -0,0 +1,100 @@
++# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/gpio/waveshare,dsi-touch-gpio.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: Waveshare GPIO controller on DSI TOUCH panels
++
++maintainers:
++  - Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
++
++description:
++  Waveshare DSI TOUCH panel kits contain separate GPIO controller for toggling
++  power supplies and panel / touchscreen resets.
++
++properties:
++  compatible:
++    const: waveshare,dsi-touch-gpio
++
++  reg:
++    maxItems: 1
++
++  gpio-controller: true
++
++  '#gpio-cells':
++    const: 2
++
++required:
++  - compatible
++  - reg
++  - gpio-controller
++  - "#gpio-cells"
++
++additionalProperties: false
++
++examples:
++  - |
++    #include <dt-bindings/gpio/gpio.h>
++
++    i2c {
++        #address-cells = <1>;
++        #size-cells = <0>;
++
++        wsgpio: gpio@45 {
++            compatible = "waveshare,dsi-touch-gpio";
++            reg = <0x45>;
++            gpio-controller;
++            #gpio-cells = <2>;
++        };
++    };
++
++    panel_avdd: regulator-panel-avdd {
++        compatible = "regulator-fixed";
++        regulator-name = "panel-avdd";
++        gpios = <&wsgpio 0 GPIO_ACTIVE_HIGH>;
++        enable-active-high;
++    };
++
++    panel_iovcc: regulator-panel-iovcc {
++        compatible = "regulator-fixed";
++        regulator-name = "panel-iovcc";
++        gpios = <&wsgpio 4 GPIO_ACTIVE_HIGH>;
++        enable-active-high;
++    };
++
++    panel_vcc: regulator-panel-vcc {
++        compatible = "regulator-fixed";
++        regulator-name = "panel-vcc";
++        gpios = <&wsgpio 8 GPIO_ACTIVE_HIGH>;
++        enable-active-high;
++        regulator-always-on;
++    };
++
++    dsi {
++        #address-cells = <1>;
++        #size-cells = <0>;
++
++        panel@0 {
++            reg = <0>;
++            compatible = "waveshare,8.0-dsi-touch-a", "jadard,jd9365da-h3";
++            reset-gpios = <&wsgpio 1 GPIO_ACTIVE_LOW>;
++            vdd-supply = <&panel_avdd>;
++            vccio-supply = <&panel_iovcc>;
++            backlight = <&wsgpio>;
++
++            port {
++                  panel_in: endpoint {
++                      remote-endpoint = <&dsi_out>;
++                  };
++            };
++        };
++
++        port {
++            dsi_out: endpoint {
++                data-lanes = <0 1 2 3>;
++                remote-endpoint = <&panel_in>;
++            };
++        };
++    };
++...

--- a/patch/kernel/qrb2210-edge/0045-gpio-add-GPIO-controller-found-on-Waveshare-DSI-TOUC.patch
+++ b/patch/kernel/qrb2210-edge/0045-gpio-add-GPIO-controller-found-on-Waveshare-DSI-TOUC.patch
@@ -1,0 +1,268 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 13 Apr 2026 17:05:44 +0300
+Subject: [PATCH 45/48] gpio: add GPIO controller found on Waveshare DSI TOUCH
+ panels
+
+The Waveshare DSI TOUCH family of panels has separate on-board GPIO
+controller, which controls power supplies to the panel and the touch
+screen and provides reset pins for both the panel and the touchscreen.
+Also it provides a simple PWM controller for panel backlight. Add
+support for this GPIO controller.
+
+Tested-by: Riccardo Mereu <r.mereu@arduino.cc>
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+---
+ drivers/gpio/Kconfig              |  10 ++
+ drivers/gpio/Makefile             |   1 +
+ drivers/gpio/gpio-waveshare-dsi.c | 208 ++++++++++++++++++++++++++++++
+ 3 files changed, 219 insertions(+)
+ create mode 100644 drivers/gpio/gpio-waveshare-dsi.c
+
+diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
+index b45fb799e36c..e24ad7e32034 100644
+--- a/drivers/gpio/Kconfig
++++ b/drivers/gpio/Kconfig
+@@ -804,6 +804,16 @@ config GPIO_VISCONTI
+ 	help
+ 	  Say yes here to support GPIO on Tohisba Visconti.
+ 
++config GPIO_WAVESHARE_DSI_TOUCH
++	tristate "Waveshare GPIO controller for DSI panels"
++	depends on BACKLIGHT_CLASS_DEVICE
++	depends on I2C
++	select REGMAP_I2C
++	help
++	  Enable support for the GPIO and PWM controller found on Waveshare DSI
++	  TOUCH panel kits. It provides GPIOs (used for regulator control and
++          resets) and backlight support.
++
+ config GPIO_WCD934X
+ 	tristate "Qualcomm Technologies Inc WCD9340/WCD9341 GPIO controller driver"
+ 	depends on MFD_WCD934X && OF_GPIO
+diff --git a/drivers/gpio/Makefile b/drivers/gpio/Makefile
+index c05f7d795c43..94f16f0f28d9 100644
+--- a/drivers/gpio/Makefile
++++ b/drivers/gpio/Makefile
+@@ -206,6 +206,7 @@ obj-$(CONFIG_GPIO_VIRTUSER)		+= gpio-virtuser.o
+ obj-$(CONFIG_GPIO_VIRTIO)		+= gpio-virtio.o
+ obj-$(CONFIG_GPIO_VISCONTI)		+= gpio-visconti.o
+ obj-$(CONFIG_GPIO_VX855)		+= gpio-vx855.o
++obj-$(CONFIG_GPIO_WAVESHARE_DSI_TOUCH)	+= gpio-waveshare-dsi.o
+ obj-$(CONFIG_GPIO_WCD934X)		+= gpio-wcd934x.o
+ obj-$(CONFIG_GPIO_WHISKEY_COVE)		+= gpio-wcove.o
+ obj-$(CONFIG_GPIO_WINBOND)		+= gpio-winbond.o
+diff --git a/drivers/gpio/gpio-waveshare-dsi.c b/drivers/gpio/gpio-waveshare-dsi.c
+new file mode 100644
+index 000000000000..38f52351bb58
+--- /dev/null
++++ b/drivers/gpio/gpio-waveshare-dsi.c
+@@ -0,0 +1,208 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2024 Waveshare International Limited
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
++
++#include <linux/backlight.h>
++#include <linux/err.h>
++#include <linux/fb.h>
++#include <linux/gpio/driver.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/regmap.h>
++
++/* I2C registers of the microcontroller. */
++#define REG_TP		0x94
++#define REG_LCD		0x95
++#define REG_PWM		0x96
++#define REG_SIZE	0x97
++#define REG_ID		0x98
++#define REG_VERSION	0x99
++
++enum {
++	GPIO_AVDD = 0,
++	GPIO_PANEL_RESET = 1,
++	GPIO_BL_ENABLE = 2,
++	GPIO_IOVCC = 4,
++	GPIO_VCC = 8,
++	GPIO_TS_RESET = 9,
++};
++
++#define NUM_GPIO 16
++
++struct waveshare_gpio {
++	struct mutex dir_lock;
++	struct mutex pwr_lock;
++	struct regmap *regmap;
++	u16 poweron_state;
++
++	struct gpio_chip gc;
++};
++
++static const struct regmap_config waveshare_gpio_regmap_config = {
++	.reg_bits = 8,
++	.val_bits = 8,
++	.max_register = REG_VERSION,
++};
++
++static int waveshare_gpio_get(struct waveshare_gpio *state, unsigned int offset)
++{
++	u16 pwr_state;
++
++	guard(mutex)(&state->pwr_lock);
++	pwr_state = state->poweron_state & BIT(offset);
++
++	return !!pwr_state;
++}
++
++static int waveshare_gpio_set(struct waveshare_gpio *state, unsigned int offset, int value)
++{
++	u16 last_val;
++	int err;
++
++	guard(mutex)(&state->pwr_lock);
++
++	last_val = state->poweron_state;
++	if (value)
++		last_val |= BIT(offset);
++	else
++		last_val &= ~BIT(offset);
++
++	state->poweron_state = last_val;
++
++	err = regmap_write(state->regmap, REG_TP, last_val >> 8);
++	if (!err)
++		err = regmap_write(state->regmap, REG_LCD, last_val & 0xff);
++
++	return err;
++}
++
++static int waveshare_gpio_gpio_get_direction(struct gpio_chip *gc, unsigned int offset)
++{
++	return GPIO_LINE_DIRECTION_OUT;
++}
++
++static int waveshare_gpio_gpio_get(struct gpio_chip *gc, unsigned int offset)
++{
++	struct waveshare_gpio *state = gpiochip_get_data(gc);
++
++	return waveshare_gpio_get(state, offset);
++}
++
++static int waveshare_gpio_gpio_set(struct gpio_chip *gc, unsigned int offset, int value)
++{
++	struct waveshare_gpio *state = gpiochip_get_data(gc);
++
++	return waveshare_gpio_set(state, offset, value);
++}
++
++static int waveshare_gpio_update_status(struct backlight_device *bl)
++{
++	struct waveshare_gpio *state = bl_get_data(bl);
++	int brightness = backlight_get_brightness(bl);
++
++	waveshare_gpio_set(state, GPIO_BL_ENABLE, brightness);
++
++	return regmap_write(state->regmap, REG_PWM, brightness);
++}
++
++static const struct backlight_ops waveshare_gpio_bl = {
++	.update_status = waveshare_gpio_update_status,
++};
++
++static int waveshare_gpio_probe(struct i2c_client *i2c)
++{
++	struct backlight_properties props = {};
++	struct waveshare_gpio *state;
++	struct device *dev = &i2c->dev;
++	struct backlight_device *bl;
++	struct regmap *regmap;
++	unsigned int data;
++	int ret;
++
++	state = devm_kzalloc(dev, sizeof(*state), GFP_KERNEL);
++	if (!state)
++		return -ENOMEM;
++
++	ret = devm_mutex_init(dev, &state->dir_lock);
++	if (ret)
++		return ret;
++
++	ret = devm_mutex_init(dev, &state->pwr_lock);
++	if (ret)
++		return ret;
++
++	regmap = devm_regmap_init_i2c(i2c, &waveshare_gpio_regmap_config);
++	if (IS_ERR(regmap))
++		return dev_err_probe(dev, PTR_ERR(regmap), "Failed to allocate register map\n");
++
++	state->regmap = regmap;
++	i2c_set_clientdata(i2c, state);
++
++	ret = regmap_read(regmap, REG_ID, &data);
++	if (ret < 0)
++		return dev_err_probe(dev, ret, "Failed to read register\n");
++
++	dev_dbg(dev, "waveshare panel hw id = 0x%x\n", data);
++
++	ret = regmap_read(regmap, REG_SIZE, &data);
++	if (ret < 0)
++		return dev_err_probe(dev, ret, "Failed to read register\n");
++
++	dev_dbg(dev, "waveshare panel size = %d\n", data);
++
++	ret = regmap_read(regmap, REG_VERSION, &data);
++	if (ret < 0)
++		return dev_err_probe(dev, ret, "Failed to read register\n");
++
++	dev_dbg(dev, "waveshare panel mcu version = 0x%x\n", data);
++
++	ret = waveshare_gpio_set(state, GPIO_TS_RESET, 1);
++	if (ret)
++		return dev_err_probe(dev, ret, "Failed to program GPIOs\n");
++
++	msleep(20);
++
++	state->gc.parent = dev;
++	state->gc.label = i2c->name;
++	state->gc.owner = THIS_MODULE;
++	state->gc.base = -1;
++	state->gc.ngpio = NUM_GPIO;
++
++	/* it is output only */
++	state->gc.get = waveshare_gpio_gpio_get;
++	state->gc.set = waveshare_gpio_gpio_set;
++	state->gc.get_direction = waveshare_gpio_gpio_get_direction;
++	state->gc.can_sleep = true;
++
++	ret = devm_gpiochip_add_data(dev, &state->gc, state);
++	if (ret)
++		return dev_err_probe(dev, ret, "Failed to create gpiochip\n");
++
++	props.type = BACKLIGHT_RAW;
++	props.max_brightness = 255;
++	props.brightness = 255;
++	bl = devm_backlight_device_register(dev, dev_name(dev), dev, state,
++					    &waveshare_gpio_bl, &props);
++	return PTR_ERR_OR_ZERO(bl);
++}
++
++static const struct of_device_id waveshare_gpio_dt_ids[] = {
++	{ .compatible = "waveshare,dsi-touch-gpio" },
++	{},
++};
++MODULE_DEVICE_TABLE(of, waveshare_gpio_dt_ids);
++
++static struct i2c_driver waveshare_gpio_regulator_driver = {
++	.driver = {
++		.name = "waveshare-regulator",
++		.of_match_table = of_match_ptr(waveshare_gpio_dt_ids),
++	},
++	.probe = waveshare_gpio_probe,
++};
++
++module_i2c_driver(waveshare_gpio_regulator_driver);
++
++MODULE_DESCRIPTION("GPIO controller driver for Waveshare DSI touch panels");
++MODULE_LICENSE("GPL");

--- a/patch/kernel/qrb2210-edge/0046-dt-bindings-display-waveshare-dsp2dpi-describe-DSI2L.patch
+++ b/patch/kernel/qrb2210-edge/0046-dt-bindings-display-waveshare-dsp2dpi-describe-DSI2L.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Sun, 12 Apr 2026 20:32:24 +0300
+Subject: [PATCH 46/48] dt-bindings: display: waveshare,dsp2dpi: describe
+ DSI2LVDS setup
+
+Several the Waveshare DSI LCD panel kits use DSI2LVDS ICN6202 bridge
+together with the LVDS panels. Define new compatible for the on-kit
+bridge setup (it is not itmized and it uses Waveshare prefix since the
+rest of the integration details are not known).
+
+Note: the ICN6202 / ICN6211 bridges are completely handled by the board
+itself, they should not be programmed by the host (which otherwise might
+override correct params), etc. As such, it doesn't make sense to use
+those in the compat strings. I consider those to be an internal detail
+of the setup.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
+---
+ .../bindings/display/bridge/waveshare,dsi2dpi.yaml       | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/Documentation/devicetree/bindings/display/bridge/waveshare,dsi2dpi.yaml b/Documentation/devicetree/bindings/display/bridge/waveshare,dsi2dpi.yaml
+index 5e8498c8303d..604b8697110d 100644
+--- a/Documentation/devicetree/bindings/display/bridge/waveshare,dsi2dpi.yaml
++++ b/Documentation/devicetree/bindings/display/bridge/waveshare,dsi2dpi.yaml
+@@ -10,11 +10,14 @@ maintainers:
+   - Joseph Guo <qijian.guo@nxp.com>
+ 
+ description:
+-  Waveshare bridge board is part of Waveshare panel which converts DSI to DPI.
++  Waveshare bridge board is part of Waveshare panel which converts DSI to DPI
++  or LVDS.
+ 
+ properties:
+   compatible:
+-    const: waveshare,dsi2dpi
++    enum:
++      - waveshare,dsi2dpi
++      - waveshare,dsi2lvds
+ 
+   reg:
+     maxItems: 1
+@@ -50,7 +53,7 @@ properties:
+       port@1:
+         $ref: /schemas/graph.yaml#/properties/port
+         description:
+-          Video port for MIPI DPI output panel.
++          Video port for MIPI DPI or LVDS output to the panel.
+ 
+     required:
+       - port@0

--- a/patch/kernel/qrb2210-edge/0047-drm-bridge-waveshare-dsi-support-DSI-LCD-kits-with-L.patch
+++ b/patch/kernel/qrb2210-edge/0047-drm-bridge-waveshare-dsi-support-DSI-LCD-kits-with-L.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Sun, 12 Apr 2026 20:32:25 +0300
+Subject: [PATCH 47/48] drm/bridge: waveshare-dsi: support DSI LCD kits with
+ LVDS panels
+
+Several Waveshare DSI LCD kits use LVDS panels and the ICN6202 DSI2LVDS
+bridge. Support that setup by handling waveshare,dsi2lvds compatible.
+The only difference with the existing waveshare,dsi2dpi is the bridge's
+output type (LVDS vs DPI).
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Reviewed-by: Neil Armstrong <neil.armstrong@linaro.org>
+---
+ drivers/gpu/drm/bridge/waveshare-dsi.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/bridge/waveshare-dsi.c b/drivers/gpu/drm/bridge/waveshare-dsi.c
+index 43f4e7412d72..9df286175399 100644
+--- a/drivers/gpu/drm/bridge/waveshare-dsi.c
++++ b/drivers/gpu/drm/bridge/waveshare-dsi.c
+@@ -175,7 +175,7 @@ static int ws_bridge_probe(struct i2c_client *i2c)
+ 	regmap_write(ws->reg_map, 0xc2, 0x01);
+ 	regmap_write(ws->reg_map, 0xac, 0x01);
+ 
+-	ws->bridge.type = DRM_MODE_CONNECTOR_DPI;
++	ws->bridge.type = (uintptr_t)i2c_get_match_data(i2c);
+ 	ws->bridge.of_node = dev->of_node;
+ 	devm_drm_bridge_add(dev, &ws->bridge);
+ 
+@@ -183,7 +183,8 @@ static int ws_bridge_probe(struct i2c_client *i2c)
+ }
+ 
+ static const struct of_device_id ws_bridge_of_ids[] = {
+-	{.compatible = "waveshare,dsi2dpi",},
++	{.compatible = "waveshare,dsi2dpi", .data = (void *)DRM_MODE_CONNECTOR_DPI, },
++	{.compatible = "waveshare,dsi2lvds", .data = (void *)DRM_MODE_CONNECTOR_LVDS, },
+ 	{ }
+ };
+ 

--- a/patch/kernel/qrb2210-edge/0048-arch-arm64-qcom-imola-Align-panel-DTBO.patch
+++ b/patch/kernel/qrb2210-edge/0048-arch-arm64-qcom-imola-Align-panel-DTBO.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riccardo Mereu <r.mereu@arduino.cc>
+Date: Thu, 16 Apr 2026 16:46:17 +0200
+Subject: [PATCH 48/48] arch: arm64: qcom: imola: Align panel DTBO
+
+Moving to downstream matching DTBO to the upstream one.
+
+Signed-off-by: Riccardo Mereu <r.mereu@arduino.cc>
+---
+ ...a-carrier-media-panel-8in_touch_a-dsi.dtso | 42 ++++++++++++++-----
+ 1 file changed, 32 insertions(+), 10 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-panel-8in_touch_a-dsi.dtso b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-panel-8in_touch_a-dsi.dtso
+index ce07422373dd..bab2bbd4535c 100644
+--- a/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-panel-8in_touch_a-dsi.dtso
++++ b/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola-carrier-media-panel-8in_touch_a-dsi.dtso
+@@ -9,22 +9,45 @@
+ #include <dt-bindings/gpio/gpio.h>
+ #include "qrb2210-arduino-imola-carrier-media-common.dtsi"
+ 
++&{/} {
++	panel_avdd: regulator-panel-avdd {
++		compatible = "regulator-fixed";
++		regulator-name = "panel-avdd";
++		gpios = <&wsgpio 0 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	panel_iovcc: regulator-panel-iovcc {
++		compatible = "regulator-fixed";
++		regulator-name = "panel-iovcc";
++		gpios = <&wsgpio 4 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	panel_vcc: regulator-panel-vcc {
++		compatible = "regulator-fixed";
++		regulator-name = "panel-vcc";
++		gpios = <&wsgpio 8 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-always-on;
++	};
++};
++
+ &cci_i2c0 {
+ 	#address-cells = <1>;
+ 	#size-cells = <0>;
+ 
+-	display_mcu: display_mcu@45 {
+-		compatible = "waveshare,touchscreen-panel-regulator";
++	wsgpio: gpio@45 {
++		compatible = "waveshare,dsi-touch-gpio";
+ 		reg = <0x45>;
+ 		gpio-controller;
+ 		#gpio-cells = <2>;
+-		enable-gpio = <&display_mcu 2 GPIO_ACTIVE_HIGH>;
+ 	};
+ 
+ 	touch: goodix@5d {
+ 		compatible = "goodix,gt9271";
+ 		reg = <0x5d>;
+-		reset-gpio = <&display_mcu 9 GPIO_ACTIVE_HIGH>;
++		reset-gpio = <&wsgpio 9 GPIO_ACTIVE_HIGH>;
+ 	};
+ };
+ 
+@@ -37,11 +60,11 @@
+ 
+ 	dsi_panel: dsi_panel@0 {
+ 		reg = <0>;
+-		compatible = "waveshare,8.0-dsi-touch-a-4lane";
+-		reset-gpio = <&display_mcu 1 GPIO_ACTIVE_HIGH>;
+-		iovcc-gpio = <&display_mcu 4 GPIO_ACTIVE_HIGH>;
+-		avdd-gpio = <&display_mcu 0 GPIO_ACTIVE_HIGH>;
+-		backlight = <&display_mcu>;
++		compatible = "waveshare,8.0-dsi-touch-a", "jadard,jd9365da-h3";
++		reset-gpio = <&wsgpio 1 GPIO_ACTIVE_LOW>;
++		vccio-supply = <&panel_iovcc>;
++		vdd-supply = <&panel_avdd>;
++		backlight = <&wsgpio>;
+ 
+ 		port {
+ 			panel_in: endpoint {
+@@ -49,7 +72,6 @@
+ 			};
+ 		};
+ 	};
+-
+ };
+ 
+ &mdss_dsi0_out {


### PR DESCRIPTION
## Summary

Switches the `edge` kernel for the `qrb2210` family (Arduino UNO Q) from the Arduino fork `arduino/linux-qcom@qcom-v7.0.0-unoq` to the mainline `linux-stable` tree pinned at `tag:v7.0`.

## Why

The Arduino UNO Q *"Imola"* device tree was upstreamed in Linux 7.0:

| Commit | Subject |
|---|---|
| `3f745bc0f11f` | `arm64: dts: qcom: qrb2210: add dts for Arduino unoq` |
| `1a040df09fab` | `arm64: dts: qcom: arduino-imola: fix faulty spidev node` |
| `d5574bb935e3` | `arm64: dts: qcom: qrb2210-arduino-imola: describe DSI / DP bridge` |

`arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts` is present in `torvalds/linux` from `v7.0-rc1` onward; first final release containing it is **Linux 7.0** (2026-04-12). With the DT now upstream, the `edge` branch can drop the fork.

## Changes

Only `config/sources/families/qrb2210.conf`:

- Remove hardcoded `KERNELSOURCE` → falls back to `MAINLINE_KERNEL_SOURCE` (respects regional mirrors).
- `KERNELBRANCH='tag:v7.0'` pinned to latest stable tag.
- `KERNEL_GIT_CACHE_TTL=120` for the high-traffic stable repo.
- `declare -g` on the mainline variables, consistent with other mainline-only Qualcomm families.

No changes to: `config/boards/arduino-uno-q.csc`, `config/kernel/linux-qrb2210-edge.config` (identical after `make olddefconfig` against mainline v7.0), U-Boot, bootscripts, extensions.

## What the fork carried that mainline doesn't (yet)

The fork `qcom-v7.0.0-unoq` has 48 extra commits over `v7.0`, covering features that were **not enabled** in the committed `linux-qrb2210-edge.config` anyway:

- Audio codec `pm4125`, LPASS Agatti, qdsp6/sm8250 fixes.
- Type-C DP support in `anx7625`, Waveshare DSI panels, touch GPIO controllers.
- Imola media carrier board, A702 firmware auto-included in initramfs.

Base boot path (serial console, eMMC, USB gadget RNDIS/ADB, Wi-Fi ath10k, Bluetooth, rootfs resize) is fully covered by mainline v7.0.

## Verification

Clean Trixie minimal build completed successfully: https://paste.armbian.com/pikuwasazi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * USB-C (Type‑C) support for the ANX7625 bridge (orientation, roles, PD/HPD handling and data‑role swapping).
  * Added Waveshare panel support (multiple Waveshare DSI panels) and a new Focaltech-based 8.8" panel driver.
  * Waveshare on‑board GPIO controller and backlight support; SoundWire/LPASS audio nodes for Arduino Imola.

* **Bug Fixes**
  * Prevented crashes when Type‑C port is absent; hardened audio/codec port handling and index bounds.

* **Chores**
  * Updated kernel ref to a tag and added shorter kernel git cache TTL for build optimization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->