### PR TITLE
patch maintenance: some rewriting against recent patch versions

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/board-odroidm2-fix-usbc-in-otg-mode.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-odroidm2-fix-usbc-in-otg-mode.patch
@@ -1,7 +1,7 @@
-From 50621b27ec5ad2d190668ff9280b7a6e4401886d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Milivoje Legenovic <m.legenovic@gmail.com>
 Date: Sat, 4 Apr 2026 19:19:47 +0200
-Subject: [PATCH 1/1] Odroid-M2: Make USB-C port working in OTG mode
+Subject: Odroid-M2: Make USB-C port working in OTG mode
 
 Signed-off-by: Milivoje Legenovic <m.legenovic@gmail.com>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Milivoje Legenovic <m.legenovic@gmail.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
-index a72063c55140..8ade418a6228 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
-@@ -346,13 +346,15 @@ usbc0: usb-typec@22 {
+@@ -352,13 +352,15 @@ usbc0: usb-typec@22 {
  
  		connector {
  			compatible = "usb-c-connector";
@@ -30,5 +30,5 @@ index a72063c55140..8ade418a6228 100644
  			ports {
  				#address-cells = <1>;
 -- 
-2.47.3
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/board-odroidm2-support-for-vu8s-panel.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-odroidm2-support-for-vu8s-panel.patch
@@ -138,7 +138,7 @@ index 111111111111..222222222222 100644
  	usbc0: usb-typec@22 {
  		compatible = "fcs,fusb302";
  		reg = <0x22>;
-@@ -454,6 +558,10 @@ lcd {
+@@ -456,6 +560,10 @@ lcd {
  		lcd_pwren: lcd-pwren {
  			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
@@ -149,7 +149,7 @@ index 111111111111..222222222222 100644
  	};
  
  	leds {
-@@ -497,6 +605,16 @@ rtl8211f_rst: rtl8211f-rst {
+@@ -499,6 +607,16 @@ rtl8211f_rst: rtl8211f-rst {
  		};
  	};
  
@@ -166,7 +166,7 @@ index 111111111111..222222222222 100644
  	usb {
  		usb2_host_pwren: usb2-host-pwren {
  			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
-@@ -522,6 +640,11 @@ &pwm0 {
+@@ -524,6 +642,11 @@ &pwm0 {
  	status = "okay";
  };
  
@@ -178,7 +178,7 @@ index 111111111111..222222222222 100644
  &saradc {
  	vref-supply = <&vcca_1v8_s0>;
  	status = "okay";
-@@ -970,3 +1093,15 @@ vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
+@@ -972,3 +1095,15 @@ vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
  		remote-endpoint = <&hdmi0_in_vp0>;
  	};
  };

--- a/patch/kernel/archive/rockchip64-6.18/board-pbp-add-dp-alt-mode.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-pbp-add-dp-alt-mode.patch
@@ -70,7 +70,7 @@ index 111111111111..222222222222 100644
  
  			ports {
  				#address-cells = <1>;
-@@ -978,6 +1002,7 @@ spiflash: flash@0 {
+@@ -960,6 +984,7 @@ spiflash: flash@0 {
  };
  
  &tcphy0 {
@@ -78,7 +78,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-@@ -1011,6 +1036,8 @@ &tsadc {
+@@ -993,6 +1018,8 @@ &tsadc {
  
  &u2phy0 {
  	status = "okay";
@@ -87,7 +87,7 @@ index 111111111111..222222222222 100644
  
  	u2phy0_otg: otg-port {
  		status = "okay";
-@@ -1087,7 +1114,9 @@ &usbdrd3_0 {
+@@ -1069,7 +1096,9 @@ &usbdrd3_0 {
  };
  
  &usbdrd_dwc3_0 {

--- a/patch/kernel/archive/rockchip64-7.0/rk3588-1221-arm64-fix-typec-for-orangepi-5-5b.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3588-1221-arm64-fix-typec-for-orangepi-5-5b.patch
@@ -1,5 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chaitanya Talnikar <ct@talnikar.in>
+Date: Thu, 16 Apr 2026 18:19:34 +0300
+Subject: [ARCHEOLOGY] Fix USB Type-C port for Orangepi 5/5B
+
+> X-Git-Archeology: - Revision e2b90659ec7a10b643281dd7965a05d3a68e2f4f: https://github.com/armbian/build/commit/e2b90659ec7a10b643281dd7965a05d3a68e2f4f
+> X-Git-Archeology:   Date: Thu, 16 Apr 2026 18:19:34 +0300
+> X-Git-Archeology:   From: Chaitanya Talnikar <ct@talnikar.in>
+> X-Git-Archeology:   Subject: Fix USB Type-C port for Orangepi 5/5B
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi | 14 +++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
-index dafad29f9854..8ee9b46f3d5f 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
 @@ -303,7 +303,18 @@ usb_con: connector {
@@ -30,3 +44,6 @@ index dafad29f9854..8ee9b46f3d5f 100644
  	status = "okay";
  };
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/fixes-6.18/0019-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/fixes-6.18/0019-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
@@ -20,7 +20,7 @@ diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
-@@ -2543,6 +2543,7 @@ static struct usb_serial_driver option_1port_device = {
+@@ -2549,6 +2549,7 @@ static struct usb_serial_driver option_1port_device = {
  #ifdef CONFIG_PM
  	.suspend           = usb_wwan_suspend,
  	.resume            = usb_wwan_resume,

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/fixes-7.0/0018-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/fixes-7.0/0018-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
@@ -20,7 +20,7 @@ diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
-@@ -2547,6 +2547,7 @@ static struct usb_serial_driver option_1port_device = {
+@@ -2549,6 +2549,7 @@ static struct usb_serial_driver option_1port_device = {
  #ifdef CONFIG_PM
  	.suspend           = usb_wwan_suspend,
  	.resume            = usb_wwan_resume,

--- a/patch/kernel/archive/uefi-x86-6.18/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-6.18/4001-asahi-trackpad.patch
@@ -22,7 +22,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2316,6 +2316,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2320,6 +2320,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_I2C:
  		bus = "I2C";
  		break;
@@ -36,7 +36,7 @@ diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -93,6 +93,7 @@
+@@ -96,6 +96,7 @@
  
  #define USB_VENDOR_ID_APPLE		0x05ac
  #define BT_VENDOR_ID_APPLE		0x004c
@@ -44,7 +44,7 @@ index 111111111111..222222222222 100644
  #define USB_DEVICE_ID_APPLE_MIGHTYMOUSE	0x0304
  #define USB_DEVICE_ID_APPLE_MAGICMOUSE	0x030d
  #define USB_DEVICE_ID_APPLE_MAGICMOUSE2	0x0269
-@@ -197,6 +198,10 @@
+@@ -200,6 +201,10 @@
  #define USB_DEVICE_ID_APPLE_IRCONTROL5	0x8243
  #define USB_DEVICE_ID_APPLE_TOUCHBAR_BACKLIGHT 0x8102
  #define USB_DEVICE_ID_APPLE_TOUCHBAR_DISPLAY 0x8302
@@ -100,7 +100,7 @@ diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -94,6 +94,7 @@
+@@ -97,6 +97,7 @@
  #define USB_VENDOR_ID_APPLE		0x05ac
  #define BT_VENDOR_ID_APPLE		0x004c
  #define SPI_VENDOR_ID_APPLE		0x05ac
@@ -108,7 +108,7 @@ index 111111111111..222222222222 100644
  #define USB_DEVICE_ID_APPLE_MIGHTYMOUSE	0x0304
  #define USB_DEVICE_ID_APPLE_MAGICMOUSE	0x030d
  #define USB_DEVICE_ID_APPLE_MAGICMOUSE2	0x0269
-@@ -202,6 +203,10 @@
+@@ -205,6 +206,10 @@
  #define SPI_DEVICE_ID_APPLE_MACBOOK_PRO13_2020	0x0341
  #define SPI_DEVICE_ID_APPLE_MACBOOK_PRO14_2021	0x0342
  #define SPI_DEVICE_ID_APPLE_MACBOOK_PRO16_2021	0x0343
@@ -136,7 +136,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2319,6 +2319,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2323,6 +2323,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_SPI:
  		bus = "SPI";
  		break;
@@ -184,7 +184,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -468,7 +468,10 @@ static int hid_parser_global(struct hid_parser *parser, struct hid_item *item)
+@@ -471,7 +471,10 @@ static int hid_parser_global(struct hid_parser *parser, struct hid_item *item)
  
  	case HID_GLOBAL_ITEM_TAG_REPORT_SIZE:
  		parser->global.report_size = item_udata(item);
@@ -236,7 +236,7 @@ diff --git a/drivers/hid/hid-apple.c b/drivers/hid/hid-apple.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-apple.c
 +++ b/drivers/hid/hid-apple.c
-@@ -519,6 +519,15 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
+@@ -522,6 +522,15 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
  				table = macbookair_fn_keys;
  			else if (hid->product < 0x21d || hid->product >= 0x300)
  				table = powerbook_fn_keys;
@@ -252,7 +252,7 @@ index 111111111111..222222222222 100644
  			else
  				table = apple_fn_keys;
  		}
-@@ -939,6 +948,10 @@ static int apple_probe(struct hid_device *hdev,
+@@ -940,6 +949,10 @@ static int apple_probe(struct hid_device *hdev,
  	struct apple_sc *asc;
  	int ret;
  
@@ -263,7 +263,7 @@ index 111111111111..222222222222 100644
  	asc = devm_kzalloc(&hdev->dev, sizeof(*asc), GFP_KERNEL);
  	if (asc == NULL) {
  		hid_err(hdev, "can't alloc apple descriptor\n");
-@@ -1217,6 +1230,8 @@ static const struct hid_device_id apple_devices[] = {
+@@ -1218,6 +1231,8 @@ static const struct hid_device_id apple_devices[] = {
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK | APPLE_RDESC_BATTERY },
  	{ HID_BLUETOOTH_DEVICE(BT_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_MAGIC_KEYBOARD_NUMPAD_2024),
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
@@ -291,7 +291,7 @@ diff --git a/drivers/hid/hid-apple.c b/drivers/hid/hid-apple.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-apple.c
 +++ b/drivers/hid/hid-apple.c
-@@ -519,9 +519,10 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
+@@ -522,9 +522,10 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
  				table = macbookair_fn_keys;
  			else if (hid->product < 0x21d || hid->product >= 0x300)
  				table = powerbook_fn_keys;
@@ -303,7 +303,7 @@ index 111111111111..222222222222 100644
  					table = macbookpro_dedicated_esc_fn_keys;
  					break;
  				default:
-@@ -948,7 +949,7 @@ static int apple_probe(struct hid_device *hdev,
+@@ -949,7 +950,7 @@ static int apple_probe(struct hid_device *hdev,
  	struct apple_sc *asc;
  	int ret;
  
@@ -312,7 +312,7 @@ index 111111111111..222222222222 100644
  	    hdev->type != HID_TYPE_SPI_KEYBOARD)
  		return -ENODEV;
  
-@@ -1232,6 +1233,8 @@ static const struct hid_device_id apple_devices[] = {
+@@ -1233,6 +1234,8 @@ static const struct hid_device_id apple_devices[] = {
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
  	{ HID_SPI_DEVICE(SPI_VENDOR_ID_APPLE, HID_ANY_ID),
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
@@ -886,7 +886,7 @@ index 111111111111..222222222222 100644
  	default: /* USB_DEVICE_ID_APPLE_MAGICTRACKPAD */
  		report = hid_register_report(hdev, HID_INPUT_REPORT,
  			TRACKPAD_REPORT_ID, 0);
-@@ -1060,6 +1318,8 @@ static const struct hid_device_id magic_mice[] = {
+@@ -1058,6 +1316,8 @@ static const struct hid_device_id magic_mice[] = {
  		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
  		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },
@@ -1056,7 +1056,7 @@ index 111111111111..222222222222 100644
  	/*
  	 * Some devices repond with 'invalid report id' when feature
  	 * report switching it into multitouch mode is sent to it.
-@@ -1320,6 +1349,8 @@ static const struct hid_device_id magic_mice[] = {
+@@ -1318,6 +1347,8 @@ static const struct hid_device_id magic_mice[] = {
  		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },
  	{ HID_SPI_DEVICE(SPI_VENDOR_ID_APPLE, HID_ANY_ID),
  	  .driver_data = 0 },
@@ -1084,7 +1084,7 @@ diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-magicmouse.c
 +++ b/drivers/hid/hid-magicmouse.c
-@@ -1355,6 +1355,16 @@ static const struct hid_device_id magic_mice[] = {
+@@ -1353,6 +1353,16 @@ static const struct hid_device_id magic_mice[] = {
  };
  MODULE_DEVICE_TABLE(hid, magic_mice);
  
@@ -1101,7 +1101,7 @@ index 111111111111..222222222222 100644
  static struct hid_driver magicmouse_driver = {
  	.name = "magicmouse",
  	.id_table = magic_mice,
-@@ -1365,6 +1375,10 @@ static struct hid_driver magicmouse_driver = {
+@@ -1363,6 +1373,10 @@ static struct hid_driver magicmouse_driver = {
  	.event = magicmouse_event,
  	.input_mapping = magicmouse_input_mapping,
  	.input_configured = magicmouse_input_configured,

--- a/patch/kernel/archive/uefi-x86-6.18/4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch
+++ b/patch/kernel/archive/uefi-x86-6.18/4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch
@@ -25,7 +25,7 @@ index 111111111111..222222222222 100644
  #define APPLE_HAS_FN		BIT(2)
  /* BIT(3) reserved, was: APPLE_HIDDEV */
  #define APPLE_ISO_TILDE_QUIRK	BIT(4)
-@@ -953,6 +953,9 @@ static int apple_probe(struct hid_device *hdev,
+@@ -954,6 +954,9 @@ static int apple_probe(struct hid_device *hdev,
  	    hdev->type != HID_TYPE_SPI_KEYBOARD)
  		return -ENODEV;
  
@@ -35,7 +35,7 @@ index 111111111111..222222222222 100644
  	asc = devm_kzalloc(&hdev->dev, sizeof(*asc), GFP_KERNEL);
  	if (asc == NULL) {
  		hid_err(hdev, "can't alloc apple descriptor\n");
-@@ -1175,27 +1178,31 @@ static const struct hid_device_id apple_devices[] = {
+@@ -1176,27 +1179,31 @@ static const struct hid_device_id apple_devices[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRING9_JIS),
  		.driver_data = APPLE_HAS_FN | APPLE_RDESC_JIS },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K),

--- a/patch/kernel/archive/uefi-x86-6.18/4004-HID-magicmouse-Add-support-for-trackpads-found-on-T2.patch
+++ b/patch/kernel/archive/uefi-x86-6.18/4004-HID-magicmouse-Add-support-for-trackpads-found-on-T2.patch
@@ -387,7 +387,7 @@ index 111111111111..222222222222 100644
  	case HID_ANY_ID:
  		switch (id->bus) {
  		case BUS_HOST:
-@@ -1469,6 +1705,24 @@ static const struct hid_device_id magic_mice[] = {
+@@ -1467,6 +1703,24 @@ static const struct hid_device_id magic_mice[] = {
  		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
  		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },

--- a/patch/kernel/archive/uefi-x86-7.0/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-7.0/4001-asahi-trackpad.patch
@@ -22,7 +22,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2317,6 +2317,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2320,6 +2320,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_I2C:
  		bus = "I2C";
  		break;
@@ -36,7 +36,7 @@ diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -93,6 +93,7 @@
+@@ -96,6 +96,7 @@
  
  #define USB_VENDOR_ID_APPLE		0x05ac
  #define BT_VENDOR_ID_APPLE		0x004c
@@ -44,7 +44,7 @@ index 111111111111..222222222222 100644
  #define USB_DEVICE_ID_APPLE_MIGHTYMOUSE	0x0304
  #define USB_DEVICE_ID_APPLE_MAGICMOUSE	0x030d
  #define USB_DEVICE_ID_APPLE_MAGICMOUSE2	0x0269
-@@ -197,6 +198,10 @@
+@@ -200,6 +201,10 @@
  #define USB_DEVICE_ID_APPLE_IRCONTROL5	0x8243
  #define USB_DEVICE_ID_APPLE_TOUCHBAR_BACKLIGHT 0x8102
  #define USB_DEVICE_ID_APPLE_TOUCHBAR_DISPLAY 0x8302
@@ -100,7 +100,7 @@ diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -94,6 +94,7 @@
+@@ -97,6 +97,7 @@
  #define USB_VENDOR_ID_APPLE		0x05ac
  #define BT_VENDOR_ID_APPLE		0x004c
  #define SPI_VENDOR_ID_APPLE		0x05ac
@@ -108,7 +108,7 @@ index 111111111111..222222222222 100644
  #define USB_DEVICE_ID_APPLE_MIGHTYMOUSE	0x0304
  #define USB_DEVICE_ID_APPLE_MAGICMOUSE	0x030d
  #define USB_DEVICE_ID_APPLE_MAGICMOUSE2	0x0269
-@@ -202,6 +203,10 @@
+@@ -205,6 +206,10 @@
  #define SPI_DEVICE_ID_APPLE_MACBOOK_PRO13_2020	0x0341
  #define SPI_DEVICE_ID_APPLE_MACBOOK_PRO14_2021	0x0342
  #define SPI_DEVICE_ID_APPLE_MACBOOK_PRO16_2021	0x0343
@@ -136,7 +136,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2320,6 +2320,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2323,6 +2323,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_SPI:
  		bus = "SPI";
  		break;
@@ -184,7 +184,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -468,7 +468,10 @@ static int hid_parser_global(struct hid_parser *parser, struct hid_item *item)
+@@ -471,7 +471,10 @@ static int hid_parser_global(struct hid_parser *parser, struct hid_item *item)
  
  	case HID_GLOBAL_ITEM_TAG_REPORT_SIZE:
  		parser->global.report_size = item_udata(item);


### PR DESCRIPTION
- rewrite various patchsets
- minor changes only
- no build tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple SPI trackpad and keyboard support for compatible devices
  * Added MIPI DSI display panel support for Odroid-M2 Vu8S
  * Added DisplayPort Alt Mode support for Pinebook Pro USB Type-C
  * Enhanced T2 trackpad support with improved input handling

* **Bug Fixes**
  * Fixed USB-C OTG mode configuration for Odroid-M2 and OrangePi 5
  * Improved USB WWAN device power management handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->