### PR TITLE
meson64-6.12: oldlts: update meson-axg mmc phase configuration patch

### DIFF
--- a/patch/kernel/archive/meson64-6.12/general-meson-mmc-2-arm64-amlogic-dts-meson-update-meson-axg-device-tree.patch
+++ b/patch/kernel/archive/meson64-6.12/general-meson-mmc-2-arm64-amlogic-dts-meson-update-meson-axg-device-tree.patch
@@ -23,22 +23,30 @@ index 111111111111..222222222222 100644
  
  / {
  	compatible = "amlogic,meson-axg";
-@@ -1922,6 +1923,7 @@ sd_emmc_b: mmc@5000 {
+@@ -1958,10 +1958,11 @@ sd_emmc_b: mmc@5000 {
+ 				status = "disabled";
+ 				clocks = <&clkc CLKID_SD_EMMC_B>,
  					<&clkc CLKID_SD_EMMC_B_CLK0>,
  					<&clkc CLKID_FCLK_DIV2>;
  				clock-names = "core", "clkin0", "clkin1";
 +				amlogic,mmc-phase = <CLK_PHASE_270 CLK_PHASE_0 CLK_PHASE_0>;
  				resets = <&reset RESET_SD_EMMC_B>;
- 			};
  
-@@ -1935,6 +1937,7 @@ sd_emmc_c: mmc@7000 {
+ 				assigned-clocks = <&clkc CLKID_SD_EMMC_B_CLK0>;
+ 				assigned-clock-rates = <24000000>;
+ 			};
+@@ -1973,10 +1974,11 @@ sd_emmc_c: mmc@7000 {
+ 				status = "disabled";
+ 				clocks = <&clkc CLKID_SD_EMMC_C>,
+ 					<&clkc CLKID_SD_EMMC_C_CLK0>,
  					<&clkc CLKID_FCLK_DIV2>;
  				clock-names = "core", "clkin0", "clkin1";
- 				resets = <&reset RESET_SD_EMMC_C>;
 +				amlogic,mmc-phase = <CLK_PHASE_270 CLK_PHASE_0 CLK_PHASE_0>;
- 			};
+ 				resets = <&reset RESET_SD_EMMC_C>;
  
- 			nfc: nand-controller@7800 {
+ 				assigned-clocks = <&clkc CLKID_SD_EMMC_C_CLK0>;
+ 				assigned-clock-rates = <24000000>;
+ 			};
 -- 
 Armbian
 


### PR DESCRIPTION
- 🌴 picked from #9447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Meson-AXG device tree configuration with optimized MMC/SD controller settings by refining clock phase timing parameters and adjusting base clock rates. These changes improve hardware compatibility, enhance system stability, and extend support for diverse SD and eMMC memory device implementations on Amlogic platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->