### PR TITLE
u-boot: 2026.04: drop #warnings in fdt_fixup_ethernet logging patch

### DIFF
--- a/patch/u-boot/v2026.04/1001-fdt_fixup_ethernet-add-logs.patch
+++ b/patch/u-boot/v2026.04/1001-fdt_fixup_ethernet-add-logs.patch
@@ -128,7 +128,7 @@ index 111111111111..222222222222 100644
 --- a/boot/image-fdt.c
 +++ b/boot/image-fdt.c
 @@ -1,3 +1,4 @@
-+#warning "Building image-fdt.c: fdt fixup call chain instrumented for MAC debugging."
++
  // SPDX-License-Identifier: GPL-2.0+
  /*
   * Copyright (c) 2013, Google Inc.


### PR DESCRIPTION
- 🌿 those were added to ensure that code was actually being compiled
- 🌴 we're pretty sure now, so avoid spurious warnings during compilation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging throughout the Ethernet boot device tree setup process, including operation counts and detailed reasons for skipped operations.
  * Replaced compile-time warnings with runtime logging for improved visibility and troubleshooting during the boot sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->