### PR TITLE
armbian-kernel: btf: fixes + enable KPROBES

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -136,6 +136,7 @@ function armbian_kernel_config__600_enable_ebpf_and_btf_info() {
 
 		display_alert "Enabling eBPF and BTF info" "for fully BTF & CO-RE enabled kernel" "info"
 		opts_n+=("DEBUG_INFO_NONE")                   # Make sure the "none" option is disabled
+		opts_n+=("DEBUG_INFO_REDUCED")                # DEBUG_INFO_REDUCED=y disables DEBUG_INFO_BTF
 		opts_y+=(
 			"BPF_JIT" "BPF_JIT_DEFAULT_ON" "FTRACE_SYSCALLS" "PROBE_EVENTS_BTF_ARGS" "BPF_KPROBE_OVERRIDE" # eBPF == on
 			"BPF_UNPRIV_DEFAULT_OFF"

--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -155,6 +155,8 @@ function armbian_kernel_config__600_enable_ebpf_and_btf_info() {
 			"DYNAMIC_FTRACE"                         # Dynamic ftrace support
 			"FTRACE"                                 # Ftrace (function tracer) support
 			"FUNCTION_TRACER"                        # Function tracer support
+			"KPROBES"                                # Kprobes support for dynamic kernel instrumentation
+			"KPROBE_EVENTS"                          # Kprobe events support
 			"TRACEFS_AUTOMOUNT_DEPRECATED"           # This is valid until 2030, needed for some eBPF tools
 		)
 	fi


### PR DESCRIPTION
#### armbian-kernel: btf: fixes + enable KPROBES

- 🌵 armbian-kernel: btf: `DEBUG_INFO_REDUCED` blocks `DEBUG_INFO_BTF`
  - only for KERNEL_BTF=yes case
- 🍃 armbian-kernel: btf: `KPROBES` + `KPROBE_EVENTS`
  - only for KERNEL_BTF=yes case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced kernel compilation configuration for eBPF/BTF debug information handling, ensuring proper debug symbol selection and enabling dynamic kernel instrumentation capabilities for improved system tracing and debugging support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->