### PR TITLE
kernel: add dependency of initramfs-tools for linux-image package

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -265,6 +265,7 @@ function kernel_package_callback_linux_image() {
 		Maintainer: ${MAINTAINER} <${MAINTAINERMAIL}>
 		Section: kernel
 		Priority: optional
+		Depends: initramfs-tools
 		Provides: linux-image, linux-image-armbian, armbian-$BRANCH, wireguard-modules
 		Description: Armbian Linux $BRANCH kernel image $kernel_version_family
 		 This package contains the Linux kernel, modules and corresponding other files.


### PR DESCRIPTION
# Description

I'm trying to build an iso with armbian's kernel by live-build script: https://salsa.debian.org/live-team/live-build/-/blob/master/test/rebuild.sh?ref_type=heads, while the script is installing kernel and initramfs in a single apt command, and it would fall if kernel doesn't depend on initramfs. initramfs has to be configured before kernel image package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kernel package now declares explicit dependency on boot utilities, ensuring required components are properly installed alongside the kernel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->