### PR TITLE
motd/20-ip-info: align (LAN)/(WAN) labels across IPv4 + IPv6 rows

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/20-ip-info
+++ b/packages/bsp/common/etc/update-motd.d/20-ip-info
@@ -80,21 +80,32 @@ print_ip_lines() {
     ipv6s="$(printf '%s\n' $ipv6s | awk -v w="$wan6" '$0!=w' | paste -sd' ' -)"
   fi
 
+  # Both lines use the SAME prefix width and BOTH (LAN) and (WAN)
+  # appendices start with a single leading space — that way the
+  # labels always sit at the same column regardless of whether
+  # one or both are present, and the v6 line stays aligned under
+  # the v4 line. Previously the v6 prefix was 1 space wider and
+  # v6 had no (LAN) label at all, so removing one half (the
+  # common case is LAN deduped against WAN by the block above)
+  # produced misaligned (WAN) labels across the two rows.
+  local prefix4=" IPv4:       "
+  local prefix6=" IPv6:       "
+
   # IPv4 line
   if [[ -n "$ipv4s" || -n "$wan4" ]]; then
     _motd_mark_after_header
-    local line=" IPv4:        "
-    [[ -n "$ipv4s" ]] && line+=" \x1B[93m(LAN)\x1B[0m \x1B[92m${ipv4s// /, }\x1B[0m "
-    [[ -n "$wan4"  ]] && line+="\x1B[93m(WAN)\x1B[0m \x1B[95m${wan4}\x1B[0m "
+    local line="$prefix4"
+    [[ -n "$ipv4s" ]] && line+=" \x1B[93m(LAN)\x1B[0m \x1B[92m${ipv4s// /, }\x1B[0m"
+    [[ -n "$wan4"  ]] && line+=" \x1B[93m(WAN)\x1B[0m \x1B[95m${wan4}\x1B[0m"
     printf '%b\n' "$line"
   fi
 
   # IPv6 line
   if [[ -n "$ipv6s" || -n "$wan6" ]]; then
-    _motd_mark_after_header    
-    local line=" IPv6:         "
-    [[ -n "$ipv6s" ]] && line+="\x1B[96m${ipv6s// /, }\x1B[0m "
-    [[ -n "$wan6"  ]] && line+="\x1B[93m(WAN)\x1B[0m \x1B[95m${wan6}\x1B[0m "
+    _motd_mark_after_header
+    local line="$prefix6"
+    [[ -n "$ipv6s" ]] && line+=" \x1B[93m(LAN)\x1B[0m \x1B[96m${ipv6s// /, }\x1B[0m"
+    [[ -n "$wan6"  ]] && line+=" \x1B[93m(WAN)\x1B[0m \x1B[95m${wan6}\x1B[0m"
     printf '%b\n' "$line"
   fi
 }


### PR DESCRIPTION
## Summary

WAN-only motd rows (the common case on a server with only a public address, where the LAN entry gets deduplicated against WAN by lines 76-81) misalign the `(WAN)` label across the IPv4 and IPv6 rows by one column (addresses below are RFC 5737 / RFC 3849 documentation examples):

```
 IPv4:        (WAN) 192.0.2.42
 IPv6:         (WAN) 2001:db8::42
              ^^^ shifted right by one column
```

Two underlying causes:
1. The IPv4 prefix is 14 chars (\` IPv4:\` + 8 trailing spaces); the IPv6 prefix is 15 (\` IPv6:\` + 9 trailing spaces).
2. The IPv6 LAN appendix had no `(LAN)` label at all — just the bare address — so the extra space was an attempt to align v6's address column with v4's address-with-`(LAN)`-label column. Worked when both rows had a LAN portion; broke as soon as LAN got dropped.

## Change

- Use the same 13-char prefix for both rows (\` IPv4:\` / \` IPv6:\` + 7 padding, no trailing space).
- Both `(LAN)` and `(WAN)` appendices start with a single leading space — the label sits at the same column regardless of which (or both) are present.
- Add a `(LAN)` label to the IPv6 row too; the asymmetry was what forced the per-row spacing offset, and mirroring the v4 structure removes the underlying cause.

## Test plan

Verified across all four cases by stubbing the helpers and exercising `print_ip_lines` directly:

```
--- LAN+WAN (both):
 IPv4:        (LAN) 192.0.2.10, 192.0.2.11 (WAN) 198.51.100.7
 IPv6:        (LAN) fe80::1 (WAN) 2001:db8::42
--- LAN only:
 IPv4:        (LAN) 192.0.2.10
 IPv6:        (LAN) fe80::1
--- WAN only (the reported bug):
 IPv4:        (WAN) 198.51.100.7
 IPv6:        (WAN) 2001:db8::42
--- nothing:
(no output)
```

`(LAN)` and `(WAN)` align column-for-column on both rows in every case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 addresses at login are now correctly labeled "(LAN)" when present, matching IPv4 labeling.
  * LAN/WAN labels for IP rows no longer misalign across address families.

* **Style**
  * Improved column alignment and consistent left-padding for IPv4 and IPv6 lines in the terminal greeting.
  * Unified spacing so label/value columns line up across IPv4 and IPv6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->