### PR TITLE
fixing output to /etc/armbian-image-release

### DIFF
--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -557,12 +557,12 @@ function install_distribution_agnostic() {
 	cp "${SDCARD}"/etc/armbian-release "${SDCARD}"/etc/armbian-image-release
 
 	# save list of enabled extensions for this image
-	EXTENSIONS=${ENABLE_EXTENSIONS} >> "${SDCARD}"/etc/armbian-image-release
+	echo "EXTENSIONS='${ENABLE_EXTENSIONS}'" >> "${SDCARD}"/etc/armbian-image-release
 
 	# store vendor pretty name to image only. We don't need to save this in BSP upgrade
 	# files. Vendor should be only defined at build image stage.
 	[[ -z $VENDORPRETTYNAME ]] && VENDORPRETTYNAME="${VENDOR}"
-	VENDORPRETTYNAME="$VENDORPRETTYNAME" >> "${SDCARD}"/etc/armbian-image-release
+	echo "VENDORPRETTYNAME='$VENDORPRETTYNAME'" >> "${SDCARD}"/etc/armbian-image-release
 
 	# DNS fix. package resolvconf is not available everywhere
 	if [[ -d "${SDCARD}/etc/resolvconf/resolv.conf.d" && -n "$NAMESERVER" ]]; then


### PR DESCRIPTION
# Description

Previously EXTENSIONS and VENDORPRETTYNAME were not successfully output to `/etc/armbian-image-release`.

# Documentation summary for feature / change

N/A

# How Has This Been Tested?

I've tested this change with a local build, resulting in a successful output in the final `/etc/armbian-image-release`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the formatting and storage of system release information to ensure proper persistence of extension and vendor metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->