### PR TITLE
kernel: add linux-initramfs-tool as dep of linux-image package

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -265,7 +265,7 @@ function kernel_package_callback_linux_image() {
 		Maintainer: ${MAINTAINER} <${MAINTAINERMAIL}>
 		Section: kernel
 		Priority: optional
-		Depends: initramfs-tools
+		Depends: initramfs-tools | linux-initramfs-tool
 		Provides: linux-image, linux-image-armbian, armbian-$BRANCH, wireguard-modules
 		Description: Armbian Linux $BRANCH kernel image $kernel_version_family
 		 This package contains the Linux kernel, modules and corresponding other files.


### PR DESCRIPTION
Debian forky has toggled to dracut as its default initrd, and linux-initramfs-tool is a virtual packaged prodided by all alternatives like initramfs-tools/dracut. So add linux-initramfs-tool to dependency would make system with other initrd like dracut happy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to accept alternative initramfs support tools, providing users with greater flexibility in system configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->