### PR TITLE
docker: gate --privileged behind DOCKER_PRIVILEGED toggle (default yes)

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -381,7 +381,6 @@ function docker_cli_prepare_launch() {
 	declare -g -a DOCKER_ARGS=(
 		"--rm" # side effect - named volumes are considered not attached to anything and are removed on "docker volume prune", since container was removed.
 
-		"--privileged"         # Yep. Armbian needs /dev/loop access, device access, etc. Don't even bother trying without it.
 		"--cap-add=SYS_ADMIN"  # add only required capabilities instead
 		"--cap-add=MKNOD"      # (though MKNOD should be already present)
 		"--cap-add=SYS_PTRACE" # CAP_SYS_PTRACE is required for systemd-detect-virt in some cases @TODO: rpardini: so lets eliminate it @TODO: rpardini maybe it's dead already?
@@ -430,6 +429,16 @@ function docker_cli_prepare_launch() {
 		"--env" "HTTPS_PROXY=${HTTPS_PROXY}"
 		"--env" "APT_PROXY_ADDR=${APT_PROXY_ADDR}"
 	)
+
+	# DOCKER_PRIVILEGED=no switches to a narrow capability set.
+	if [[ "${DOCKER_PRIVILEGED:-yes}" == "yes" ]]; then
+		DOCKER_ARGS+=("--privileged")
+	else
+		DOCKER_ARGS+=(
+			"--device=/dev/loop-control:/dev/loop-control"
+			"--security-opt=seccomp=unconfined"
+		)
+	fi
 
 	# This env var is used super early (in entrypoint.sh), so set it as an env to current value.
 	if [[ "${DOCKER_ARMBIAN_ENABLE_CALL_TRACING:-no}" == "yes" ]]; then


### PR DESCRIPTION
## Summary

Introduces a `DOCKER_PRIVILEGED` env var (default `yes`) gating the
hardcoded `--privileged` flag on the build container. When set to `no`,
the container launches with a narrow capability set instead.

This is intentionally a **conservative first step**: default behaviour
is unchanged. A follow-up PR can flip the default to `no` after
broader board coverage is confirmed.

## Motivation

`--privileged` has been hardcoded in `lib/functions/host/docker.sh:384`
since 2022 (commit `d24d3327a8`). The original comment cited two
reasons:

> Running this container in privileged mode is a simple way to solve
> loop device access issues, required for USB FEL or when writing
> image directly to the block device, when CARD_DEVICE is defined

Both reasons are stale today:

- **USB FEL** support was removed in `ca6bf9046b` (2023-02-09).
- **`CARD_DEVICE`** is passed explicitly via
  `DOCKER_ARGS+=("--device=${CARD_DEVICE}")` at `docker.sh:471`.

The surrounding code already has a near-complete narrow-capability
setup:

```
--cap-add=SYS_ADMIN, MKNOD, SYS_PTRACE
--security-opt=apparmor:unconfined
--device-cgroup-rule='b 7:* rmw'      # loop majors
--device-cgroup-rule='b 259:* rmw'    # loop partitions
-v /dev:/tmp/dev:ro                   # CONTAINER_COMPAT trick
--device=${loop_device_host}          # specific loops
```

This PR adds the two missing pieces to make a non-privileged container
usable for armbian builds:

- `--device=/dev/loop-control:/dev/loop-control` — `losetup -f` needs
  `/dev/loop-control`, not exposed without `--privileged`.
- `--security-opt=seccomp=unconfined` — default seccomp profile may
  block `mount`, `pivot_root`, `unshare` even with `CAP_SYS_ADMIN`,
  which breaks debootstrap and chroot setup.

## Tested

- Host: aarch64 (Armbian 26.2.1 noble), kernel 7.0.1, Docker 29.4.1.
- Builds (all with `ARTIFACT_IGNORE_CACHE=yes DOCKER_PRIVILEGED=no
  RELEASE=noble`, full image build: debootstrap, loop, parted, mkfs,
  chroot, zstd, rsync):

  | Board    | Family     | Arch  | Profile | Kernel  | Runtime |
  |----------|------------|-------|---------|---------|---------|
  | odroidm1 | rockchip64 | arm64 | minimal | 7.0.2   | 49 min  |
  | helios4  | mvebu      | armhf | server  | 6.18.25 | 134 min |
  | helios64 | rockchip64 | arm64 | server  | 7.0.2   | 47 min  |

  All three: `🐳 successful`, image written, no `Operation not
  permitted` / seccomp / loop_control errors in the log.
- DOCKER_PRIVILEGED unset (default `yes`) verified separately to keep
  current behaviour.

## Out of scope

- The losetup helper at `docker.sh:619` (`docker run --rm --privileged
  --cap-add=MKNOD ...`) is unchanged. It is gated by `/dev/loop0`
  missing on the host, which is rare on Linux. A follow-up could mirror
  the toggle there.
- The `@TODO rpardini: maybe it's dead already?` on `--cap-add=SYS_PTRACE`
  is left as-is — orthogonal to this change.

## Follow-up

After this lands and gets exercise on more boards, a one-line PR can
flip the default to `no`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker container execution now supports configurable privileged mode settings, allowing users to control container security behavior. When privileged mode is enabled, containers run with full privileges. When disabled, the system adjusts device access and security constraints automatically. This provides flexibility for different deployment scenarios while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->