### PR TITLE
DTS: Sync CAINIAO CNIoT-CORE from 6.18 to 6.12

### DIFF
--- a/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
+++ b/patch/kernel/archive/meson64-6.12/dt/meson-g12b-a311d-cainiao-cniot-core.dts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
  * Copyright (c) 2019 BayLibre, SAS
- * Author: Neil Armstrong <narmstrong@baylibre.com>
+ * Copyright (c) 2019 Neil Armstrong <narmstrong@baylibre.com>
  * Copyright (c) 2019 Christian Hewitt <christianshewitt@gmail.com>
  * Copyright (c) 2025 retro98boy <retro98boy@qq.com>
  */
@@ -21,7 +21,7 @@
 	aliases {
 		serial0 = &uart_AO;
 		ethernet0 = &ethmac;
-		rtc99 = &vrtc;
+		rtc1 = &vrtc;
 	};
 
 	chosen {
@@ -38,7 +38,7 @@
 		#cooling-cells = <2>;
 		cooling-levels = <0 120 170 220>;
 		pwms = <&pwm_cd 1 40000 1>;
-		tach-gpio = <&gpio GPIOA_4 GPIO_ACTIVE_HIGH>;
+		tach-gpio = <&gpio GPIOA_3 GPIO_ACTIVE_HIGH>;
 	};
 
 	gpio-keys-polled {
@@ -82,12 +82,11 @@
 		};
 	};
 
-	ht6872: ht6872 {
+	ht6872: speaker-amplifier {
 		compatible = "simple-audio-amplifier";
 		enable-gpios = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
 		VCC-supply = <&vdd_amp>;
-		sound-name-prefix = "HT6872";
-		status = "okay";
+		sound-name-prefix = "Speaker Amplifier";
 	};
 
 	sdio_pwrseq: sdio-pwrseq {
@@ -205,7 +204,7 @@
 
 	sound {
 		compatible = "amlogic,axg-sound-card";
-		model = "cainiao-cniot-core";
+		model = "cniot-core";
 		audio-widgets = "Speaker", "Internal Speaker";
 		audio-aux-devs = <&tdmout_a>, <&tdmout_b>, <&ht6872>;
 		audio-routing = "TDMOUT_A IN 0", "FRDDR_A OUT 0",
@@ -216,10 +215,10 @@
 				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
 				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
 				"TDM_B Playback", "TDMOUT_B OUT",
-				"HT6872 INL", "ACODEC LOLP",
-				"HT6872 INR", "ACODEC LORP",
-				"Internal Speaker", "HT6872 OUTL",
-				"Internal Speaker", "HT6872 OUTR";
+				"Speaker Amplifier INL", "ACODEC LOLP",
+				"Speaker Amplifier INR", "ACODEC LORP",
+				"Internal Speaker", "Speaker Amplifier OUTL",
+				"Internal Speaker", "Speaker Amplifier OUTR";
 
 		clocks = <&clkc CLKID_MPLL2>,
 			 <&clkc CLKID_MPLL0>,
@@ -368,7 +367,7 @@
 &cpu_thermal {
 	trips {
 		cpu_active: cpu-active {
-			temperature = <60000>; /* millicelsius */
+			temperature = <55000>; /* millicelsius */
 			hysteresis = <5000>; /* millicelsius */
 			type = "active";
 		};
@@ -392,7 +391,7 @@
 };
 
 &ext_mdio {
-	rtl8211f: rtl8211f@0 {
+	rtl8211f: ethernet-phy@0 {
 		reg = <0>;
 		max-speed = <1000>;
 
@@ -517,7 +516,8 @@
 
 /*
  * GPIOH_4 is connected to 6 WS2812 LEDs.
- * Reusing GPIOH_4 as SPI MOSI to control the WS2812 offers superior performance compared to the GPIO method.
+ * Reusing GPIOH_4 as SPI MOSI to control the WS2812
+ * offers superior performance compared to the GPIO method.
  */
 &spicc1_pins {
 	mux {


### PR DESCRIPTION
# Description

Corrected an oversight where 6.12 was omitted in the last optimization [PR](https://github.com/armbian/build/pull/9526#event-23573913281).

# How Has This Been Tested?

Verified that the 6.18 DTS compiles against the 6.12.y kernel source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated device configuration identifiers and naming for RTC, Ethernet PHY, and audio components.
  * Refined audio amplifier settings and sound card model naming.
  * Adjusted CPU thermal throttling threshold from 60°C to 55°C for improved thermal management.
  * Remapped fan control GPIO configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->