### PR TITLE
sm8550: Restore kernel 6.18.y for current and edge branch

### DIFF
--- a/config/sources/families/sm8550.conf
+++ b/config/sources/families/sm8550.conf
@@ -16,13 +16,13 @@ enable_extension "image-output-abl"
 case $BRANCH in
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH='tag:v6.18.18'
+		declare -g KERNELBRANCH='branch:linux-6.18.y'
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH='tag:v6.18.18'
+		declare -g KERNELBRANCH='branch:linux-6.18.y'
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		;;
 


### PR DESCRIPTION
This reverts commit 9ce5fd3f1acca09d483abf290604af5b996daa0c.

Now the problem https://forum.armbian.com/topic/58748-cannot-complete-first-boot-wizard/ seems to be fixed. We can restore using 6.18.y branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kernel version tracking to automatically follow the stable branch, ensuring builds include the latest kernel patches for improved security and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->