### PR TITLE
Improve proxy handling for builds

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -455,12 +455,23 @@ function do_extra_configuration() {
 		APT_MIRROR=$UBUNTU_MIRROR
 	fi
 
-	[[ -n "${APT_PROXY_ADDR}" ]] && display_alert "Using custom apt proxy address" "APT_PROXY_ADDR=${APT_PROXY_ADDR}" "info"
+	# Derive APT_PROXY_ADDR from proxy env vars if unset, which runners.sh uses inside chroot.
+	# Skip if MANAGE_ACNG is active to prevent conflicting behavior.
+	if [[ -z "${APT_PROXY_ADDR}" && -n "${http_proxy:-${https_proxy:-${HTTP_PROXY:-${HTTPS_PROXY:-}}}}" && ( -z "${MANAGE_ACNG}" || "${MANAGE_ACNG}" == "no" ) ]]; then
+		APT_PROXY_ADDR="$(echo "${http_proxy:-${https_proxy:-${HTTP_PROXY:-${HTTPS_PROXY:-}}}}" | sed -E 's|https?://([^/]+).*|\1|')"
+		display_alert "Derived APT proxy address from proxy env vars" "${APT_PROXY_ADDR##*@}" "info"
+	fi
+	[[ -n "${APT_PROXY_ADDR}" ]] && display_alert "Using custom apt proxy address" "APT_PROXY_ADDR=${APT_PROXY_ADDR##*@}" "info"
 
 	# @TODO: allow to run aggregation, for CONFIG_DEFS_ONLY? rootfs_aggregate_packages
 
-	# Give the option to configure DNS server used in the chroot during the build process
-	[[ -z $NAMESERVER ]] && NAMESERVER="1.0.0.1" # default is cloudflare alternate
+	# Derive host DNS server so chroot can resolve hostnames on proxy; else, use cloudflare
+	if [[ -z "${NAMESERVER}" ]]; then
+		declare _dns_resolv_file="/etc/resolv.conf"
+		[[ -f "/run/systemd/resolve/resolv.conf" ]] && _dns_resolv_file="/run/systemd/resolve/resolv.conf"
+		NAMESERVER="$(awk '(/^nameserver/) && ($2 !~ /^127\./) && ($2 != "::1") && ($2 !~ /^fe80:/) {print $2; exit}' "${_dns_resolv_file}" 2>/dev/null)"
+		NAMESERVER="${NAMESERVER:-1.0.0.1}"
+	fi
 
 	# Consolidate the extra image suffix. loop and add.
 	declare EXTRA_IMAGE_SUFFIX=""

--- a/lib/functions/general/oci-oras.sh
+++ b/lib/functions/general/oci-oras.sh
@@ -87,10 +87,21 @@ function run_tool_oras() {
 
 	# Run oras, possibly with retries...
 	declare ORAS_HOME="${HOME:-"${TMPDIR}"}" # oras _requires_ a HOME to work atleast in 1.2+
+	declare -a oras_proxy_env=(
+		"http_proxy=${http_proxy:-${HTTP_PROXY:-}}"
+		"https_proxy=${https_proxy:-${HTTPS_PROXY:-}}"
+		"HTTP_PROXY=${HTTP_PROXY:-${http_proxy:-}}"
+		"HTTPS_PROXY=${HTTPS_PROXY:-${https_proxy:-}}"
+		"ftp_proxy=${ftp_proxy:-${FTP_PROXY:-}}"
+		"FTP_PROXY=${FTP_PROXY:-${ftp_proxy:-}}"
+		"no_proxy=${no_proxy:-${NO_PROXY:-}}"
+		"NO_PROXY=${NO_PROXY:-${no_proxy:-}}"
+		"APT_PROXY_ADDR=${APT_PROXY_ADDR:-}"
+	)
 	display_alert "Running ORAS ${ACTUAL_VERSION}" "HOME='${ORAS_HOME}'; retries='${retries:-1}'; cmdline: $*" "debug"
 	if [[ "${retries:-1}" -gt 1 ]]; then
 		display_alert "Calling ORAS with retries ${retries}" "$*" "debug"
-		sleep_seconds="30" do_with_retries "${retries}" env -i "HOME=${ORAS_HOME}" "HTTPS_PROXY=${HTTPS_PROXY}" "${ORAS_BIN}" "$@"
+		sleep_seconds="30" do_with_retries "${retries}" env -i "HOME=${ORAS_HOME}" "${oras_proxy_env[@]}" "${ORAS_BIN}" "$@"
 	else
 		# If any parameters passed, call ORAS, otherwise exit. We call it this way (sans-parameters) early to prepare ORAS tooling.
 		if [[ $# -eq 0 ]]; then
@@ -99,7 +110,7 @@ function run_tool_oras() {
 		fi
 
 		display_alert "Calling ORAS" "$*" "debug"
-		env -i "HOME=${ORAS_HOME}" "${ORAS_BIN}" "$@"
+		env -i "HOME=${ORAS_HOME}" "${oras_proxy_env[@]}" "${ORAS_BIN}" "$@"
 	fi
 }
 

--- a/lib/functions/general/python-tools.sh
+++ b/lib/functions/general/python-tools.sh
@@ -126,11 +126,22 @@ function prepare_python_and_pip() {
 
 		# Install pip, using get-pip.py; that bootstraps pip using an embedded, temporary, pip contained in get-pip.py
 		display_alert "Installing pip using get-pip.py" "${pip3_version_number}" "info"
-		run_host_command_logged env -i "${PYTHON3_VARS[@]@Q}" "${PYTHON3_INFO[BIN]}" "${PYTHON3_INFO[GET_PIP_BIN]}" "${pip3_extra_args[@]}" "pip==${pip3_version_number}"
+		declare -a python_proxy_env=(
+		"http_proxy=${http_proxy:-${HTTP_PROXY:-}}"
+		"https_proxy=${https_proxy:-${HTTPS_PROXY:-}}"
+		"HTTP_PROXY=${HTTP_PROXY:-${http_proxy:-}}"
+		"HTTPS_PROXY=${HTTPS_PROXY:-${https_proxy:-}}"
+		"ftp_proxy=${ftp_proxy:-${FTP_PROXY:-}}"
+		"FTP_PROXY=${FTP_PROXY:-${ftp_proxy:-}}"
+		"no_proxy=${no_proxy:-${NO_PROXY:-}}"
+		"NO_PROXY=${NO_PROXY:-${no_proxy:-}}"
+		"APT_PROXY_ADDR=${APT_PROXY_ADDR:-}"
+		)
+		run_host_command_logged env -i "${python_proxy_env[@]@Q}" "${PYTHON3_VARS[@]@Q}" "${PYTHON3_INFO[BIN]}" "${PYTHON3_INFO[GET_PIP_BIN]}" "${pip3_extra_args[@]}" "pip==${pip3_version_number}"
 
 		# Install the dependencies
 		display_alert "Installing Python dependencies" "from ${python3_pip_dependencies_path}" "info"
-		run_host_command_logged env -i "${PYTHON3_VARS[@]@Q}" "${PYTHON3_INFO[BIN]}" -m pip install "${pip3_extra_args[@]}" -r "${python3_pip_dependencies_path}"
+		run_host_command_logged env -i "${python_proxy_env[@]@Q}" "${PYTHON3_VARS[@]@Q}" "${PYTHON3_INFO[BIN]}" -m pip install "${pip3_extra_args[@]}" -r "${python3_pip_dependencies_path}"
 
 		# Create the hash file
 		run_host_command_logged touch "${python_hash_file}"

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -442,12 +442,24 @@ function docker_cli_prepare_launch() {
 		"--env" "GITHUB_WORKSPACE=${GITHUB_WORKSPACE}"
 
 		# Pass proxy args
- 		"--env" "http_proxy=${http_proxy:-${HTTP_PROXY}}"
- 		"--env" "https_proxy=${https_proxy:-${HTTPS_PROXY}}"
- 		"--env" "HTTP_PROXY=${HTTP_PROXY}"
-		"--env" "HTTPS_PROXY=${HTTPS_PROXY}"
-		"--env" "APT_PROXY_ADDR=${APT_PROXY_ADDR}"
+		"--env" "http_proxy=${http_proxy:-${HTTP_PROXY:-}}"
+		"--env" "https_proxy=${https_proxy:-${HTTPS_PROXY:-}}"
+		"--env" "HTTP_PROXY=${HTTP_PROXY:-${http_proxy:-}}"
+		"--env" "HTTPS_PROXY=${HTTPS_PROXY:-${https_proxy:-}}"
+		"--env" "ftp_proxy=${ftp_proxy:-${FTP_PROXY:-}}"
+		"--env" "FTP_PROXY=${FTP_PROXY:-${ftp_proxy:-}}"
+		"--env" "no_proxy=${no_proxy:-${NO_PROXY:-}}"
+		"--env" "NO_PROXY=${NO_PROXY:-${no_proxy:-}}"
+		"--env" "APT_PROXY_ADDR=${APT_PROXY_ADDR:-}"
 	)
+
+	# Pass in host DNS server so container can resolve hostnames on proxy
+	declare _dns_resolv_file="/etc/resolv.conf"
+	[[ -f "/run/systemd/resolve/resolv.conf" ]] && _dns_resolv_file="/run/systemd/resolve/resolv.conf"
+	while IFS= read -r _dns_server; do
+		[[ "${_dns_server}" =~ ^127\. || "${_dns_server}" == "::1" || "${_dns_server}" =~ ^fe80: ]] && continue
+		DOCKER_ARGS+=("--dns" "${_dns_server}")
+	done < <(awk '/^nameserver/ {print $2}' "${_dns_resolv_file}" 2>/dev/null)
 
 	# DOCKER_PRIVILEGED=no switches to a narrow capability set.
 	if [[ "${DOCKER_PRIVILEGED:-yes}" == "yes" ]]; then


### PR DESCRIPTION
# Description

Have faced issues when building inside TI proxy for long time now, finally have time to PR to help fix/improve so I don't need proxy hacks any longer. Should also help others inside their own separate proxy, and shoud not affect others outside proxy.

# How Has This Been Tested?

Built using `sk-am62b` on `vendor` on same PC with Ubuntu 22.04

- [x] Build inside TI proxy: [log](https://paste.armbian.com/ixowufasac)
- [x] Build outside proxy: [log](https://paste.armbian.com/dulohopeci)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements
* Automatic proxy configuration detection from standard environment variables
* Improved DNS nameserver selection in containerized environments for enhanced network reliability
* Better proxy variable handling and consistency across tools, installations, and executions
* Enhanced fallback mechanisms for resilient network operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->