### PR TITLE
boards: declare ARCH=arm64 explicitly on five inheriting boards

### DIFF
--- a/config/boards/aml-t95z-plus.tvb
+++ b/config/boards/aml-t95z-plus.tvb
@@ -2,7 +2,8 @@
 BOARD_NAME="T95Z Plus"                          #  (a q201 Chinese clone with internal amlogic ethernet 1gbit, complete with a chunk of metal inside to delay thermal throttling)
 BOARD_VENDOR="amlogic"
 BOOT_FDT_FILE="amlogic/meson-gxm-t95z-plus.dtb" # From chewitt's patches
-BOARDFAMILY="meson-gxl"                         # s912's are actually meson-gxm, no harm done.
+BOARDFAMILY="meson-gxl"                         # s912s are actually meson-gxm, no harm done.
+ARCH="arm64"
 BOARD_VENDOR="generic"
 BOOTCONFIG="meson-gxm-t95z-plus_defconfig"      # patched-in
 BOARD_MAINTAINER=""

--- a/config/boards/ayn-odin2mini.csc
+++ b/config/boards/ayn-odin2mini.csc
@@ -1,5 +1,6 @@
 # Qualcomm SM8550 octa core 8GB/12GB/16GB RAM SoC eMMC USB-C WiFi/BT
 source "${SRC}/config/boards/ayn-odin2.csc"
+declare -g ARCH="arm64"
 declare -g BOARD_NAME="Ayn Odin2 Mini"
 declare -g BOARD_VENDOR="ayntec"
 declare -g BOARD_MAINTAINER="Squishy123"

--- a/config/boards/ayn-odin2portal.csc
+++ b/config/boards/ayn-odin2portal.csc
@@ -1,5 +1,6 @@
 # Qualcomm SM8550 octa core 8GB/12GB/16GB RAM SoC eMMC USB-C WiFi/BT
 source "${SRC}/config/boards/ayn-odin2.csc"
+declare -g ARCH="arm64"
 declare -g BOARD_NAME="Ayn Odin2 Portal"
 declare -g BOARD_VENDOR="ayntec"
 declare -g BOARD_MAINTAINER="Squishy123"

--- a/config/boards/ayn-thor.csc
+++ b/config/boards/ayn-thor.csc
@@ -1,5 +1,6 @@
 # Qualcomm SM8550 octa core 8GB/12GB/16GB RAM SoC eMMC USB-C WiFi/BT
 source "${SRC}/config/boards/ayn-odin2.csc"
+declare -g ARCH="arm64"
 declare -g BOARD_NAME="Ayn Thor"
 declare -g BOARD_VENDOR="ayntec"
 declare -g BOARD_MAINTAINER="Squishy123"

--- a/config/boards/gateway-dk.conf
+++ b/config/boards/gateway-dk.conf
@@ -2,6 +2,7 @@
 BOARD_NAME="Mono Gateway Development Kit"
 BOARD_VENDOR="mono"
 BOARDFAMILY="ls1046a"
+ARCH="arm64"
 BOARD_MAINTAINER="tomazzaman"
 BOOTCONFIG="mono_gateway_dk_defconfig"
 KERNEL_TARGET="current"


### PR DESCRIPTION
## Summary

Five board configs were inheriting their architecture either implicitly (via `BOARDFAMILY` → kernel-config selection) or by sourcing another board's `.csc` without overriding. Declare `ARCH` explicitly so arch-aware tooling can match them by a direct field read.

| Board | Why it was implicit | Now |
|---|---|---|
| `aml-t95z-plus.tvb` | `BOARDFAMILY=meson-gxl` (resolves arm64) | `ARCH=arm64` declared |
| `ayn-odin2mini.csc` | sources `ayn-odin2.csc` | `declare -g ARCH=arm64` |
| `ayn-odin2portal.csc` | sources `ayn-odin2.csc` | `declare -g ARCH=arm64` |
| `ayn-thor.csc` | sources `ayn-odin2.csc` | `declare -g ARCH=arm64` |
| `gateway-dk.conf` | `BOARDFAMILY=ls1046a` | `ARCH=arm64` declared |

## Why

Build-matrix tooling that filters by `ARCH` at config-load time was missing these boards. Their resolved arch was always arm64 via inheritance, but the filter doesn't traverse the `BOARDFAMILY` → kernel-config → `ARCH` chain — it reads the field directly. Declaring `ARCH` here is the cheapest way to make them visible without changing the filter.

## No build behaviour change

The boards already built as arm64 via the inheritance chain. This commit just surfaces the field at the board-config level.

## Out of scope

Originally folded into [#9683](https://github.com/armbian/build/pull/9683) as a side-trip ("Also fold a few per-board ARCH overrides..."). Splitting it out so the desktop migration PR stays focused and these board declarations can land independently.

## Depends on #9748

The `Validate changed board configs` job currently fails on the three `ayn-odin2*` derivative boards because the validator doesn't follow `source ${SRC}/config/boards/<parent>.csc` inheritance — it sees the children as missing `BOARDFAMILY` and `KERNEL_TARGET`. Those errors are pre-existing and unrelated to the `ARCH` change here; the fix lives in [#9748](https://github.com/armbian/build/pull/9748). Once #9748 lands on `main`, this PR can rebase and CI will pass.

## Test plan

- [x] After #9748 merges, rebase this branch and re-run CI: `Validate changed board configs` passes on all five files.
- [x] `./compile.sh BOARD=ayn-odin2mini BRANCH=current build` — succeeds with arm64 toolchain (no behaviour change vs main).
- [x] `./compile.sh BOARD=gateway-dk BRANCH=current build` — same.
- [x] `./compile.sh BOARD=aml-t95z-plus BRANCH=legacy build` — same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated board configuration files to properly declare ARM64 architecture support across multiple device models.
  * Configuration updates applied to five board variants with corrected metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->