### PR TITLE
validate-board-config: follow source ${SRC}/config/boards inheritance

### DIFF
--- a/tools/validate-board-config.py
+++ b/tools/validate-board-config.py
@@ -42,6 +42,16 @@ _ASSIGN_RE = re.compile(
     re.MULTILINE,
 )
 
+# Top-level `source ${SRC}/config/boards/<foo>.csc` (or .conf/.tvb/.wip).
+# Anchored to start-of-line so a `source` call inside a function body
+# (which is always indented) doesn't get followed. Captures the relative
+# path under config/boards/ so the validator can resolve it next to the
+# child file being validated.
+_SOURCE_RE = re.compile(
+    r'^source\s+["\']?\$\{?SRC\}?/config/boards/([^"\'\s]+\.(?:conf|csc|tvb|wip))["\']?',
+    re.MULTILINE,
+)
+
 
 
 @dataclass
@@ -83,6 +93,56 @@ def parse_assignments(text: str) -> dict[str, str]:
     return out
 
 
+def collect_inherited_assignments(path: Path, _visited: set[Path] | None = None) -> dict[str, str]:
+    """Resolve fields a board inherits via `source ${SRC}/config/boards/<foo>`.
+
+    Some boards (e.g. ayn-odin2{mini,portal}.csc, ayn-thor.csc) consist
+    of one `source` line pointing at a base .csc plus a handful of
+    overrides for the fields they actually change. Fields the child
+    doesn't redeclare — BOARDFAMILY, KERNEL_TARGET, KERNEL_TEST_TARGET
+    in the typical case — live in the sourced parent.
+
+    Returns a flat dict of effective fields the parent chain provides,
+    in the same shape parse_assignments() returns. Caller merges this
+    behind the child's own dict so the child's explicit values still
+    win.
+
+    Cycles (a sources b sources a) are guarded by the _visited set;
+    missing or unresolvable source targets are silently skipped — the
+    main validator will still flag any field that ends up unset.
+    """
+    if _visited is None:
+        _visited = set()
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return {}
+    if resolved in _visited:
+        return {}
+    _visited.add(resolved)
+
+    text = path.read_text(errors="replace")
+    inherited: dict[str, str] = {}
+    for m in _SOURCE_RE.finditer(text):
+        sourced = path.parent / m.group(1)
+        if not sourced.is_file():
+            continue
+        # Recurse first so transitive parents are merged behind the
+        # immediate parent's fields. Within a single chain, nearest
+        # parent's value should win over a more distant ancestor's,
+        # which falls out naturally from setdefault's "skip if set".
+        ancestors = collect_inherited_assignments(sourced, _visited)
+        parent_fields = parse_assignments(sourced.read_text(errors="replace"))
+        # Parent's own assignments win over its ancestors; merge in
+        # that order, then those become the inheritance pool the
+        # caller will lay behind the child.
+        for k, v in parent_fields.items():
+            inherited.setdefault(k, v)
+        for k, v in ancestors.items():
+            inherited.setdefault(k, v)
+    return inherited
+
+
 def validate(path: Path) -> list[Finding]:
     ext = path.suffix.lstrip(".")
     if ext == "eos":
@@ -90,6 +150,10 @@ def validate(path: Path) -> list[Finding]:
 
     text = path.read_text(errors="replace")
     fields = parse_assignments(text)
+    # Layer fields the child inherits via `source ${SRC}/config/boards/<...>`
+    # behind its own — child's explicit value wins, parent fills the gaps.
+    for k, v in collect_inherited_assignments(path).items():
+        fields.setdefault(k, v)
 
     findings: list[Finding] = []
     fname = str(path)


### PR DESCRIPTION
## Summary

Extend `tools/validate-board-config.py` to recognise the `source "${SRC}/config/boards/<parent>.csc"` pattern that derivative boards use, and treat fields the parent declares as inherited by the child. Today three Ayn-Odin2 derivative boards (`ayn-odin2mini.csc`, `ayn-odin2portal.csc`, `ayn-thor.csc`) use this pattern: each is one `source` line plus a handful of overrides, with `BOARDFAMILY` / `KERNEL_TARGET` / `KERNEL_TEST_TARGET` defined exclusively in the parent `ayn-odin2.csc`. The validator's regex-only parser couldn't see them and would emit:

```
ERROR: config/boards/ayn-odin2mini.csc: BOARDFAMILY: required, ...
ERROR: config/boards/ayn-odin2mini.csc: KERNEL_TARGET: required, ...
(same pair on ayn-odin2portal.csc and ayn-thor.csc)
```

This is a pre-existing latent bug — it would fire on any future change to those files. PR #9747 (which adds explicit `ARCH=arm64` to those boards among others) is what surfaced it.

## Why not just source the bash file

The validator's own header explains:

> The validator does NOT source the bash file (boards have side-effecty function bodies). It extracts top-level `KEY=value` assignments via regex.

So the fix has to stay regex-only. Adding a parallel regex for the `source` pattern keeps that constraint.

## Implementation

New `collect_inherited_assignments(path)`:

- Scans for `^source\s+["']?\$\{?SRC\}?/config/boards/(<file>)["']?` (anchored to start-of-line so `source` calls inside function bodies — which are always indented — aren't followed).
- Loads the sourced file's top-level assignments and lays them behind the child's own via `dict.setdefault`. Child's explicit values still win.
- Recursion-guarded by a visited set keyed on resolved paths — self-source or parent↔child cycle terminates instead of looping.
- Missing or unresolvable source targets are silently skipped — the main required-field checks will still flag any field that ends up unset, so a typo'd source path doesn't mask a real gap.

## Verified

```
$ python3 tools/validate-board-config.py config/boards/ayn-odin2mini.csc config/boards/ayn-odin2portal.csc config/boards/ayn-thor.csc
0 error(s), 0 warning(s) across 3 file(s)
```

Pre-fix: 6 errors, 3 `KERNEL_TEST_TARGET` warnings (`KERNEL_TEST_TARGET="current"` is set on the parent — now correctly inherited).

Self-contained boards (`musepipro.conf`, `bananapif3.conf`, `musebook.conf`, `orangepi5.conf`, …) produce byte-identical validator output to before this change — they have no `source` directive so the inheritance walk is a no-op.

Cycle protection verified with a synthetic fixture (a file sourcing itself → terminates cleanly, no infinite loop).

## Companion PR

[#9747](https://github.com/armbian/build/pull/9747) declares `ARCH=arm64` explicitly on five inheriting boards. Its `Validate changed board configs` job is currently failing on the same three `.csc` derivatives this PR fixes; #9747 needs this PR (or its content) on `main` before the boards PR can pass CI.

## Test plan

- [x] Five PR-changed files in #9747 validate cleanly with this fix in place.
- [x] Non-inheriting boards produce identical validator output pre-/post-change.
- [x] Cyclic source case terminates instead of looping.
- [x] Missing-source case (typo'd path) doesn't crash the validator and still surfaces the real missing field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Board configuration validation now resolves inherited configuration fields from source statements, with child configuration values taking precedence.
  * Added cycle detection to prevent infinite inheritance loops.
  * Missing or unresolvable sources are gracefully skipped without validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->