### PR TITLE
pci: pcie_dw_rockchip: increase PCIe LTSSM timeout for cold boot NVMe

### DIFF
--- a/patch/u-boot/v2026.01/0001-pci-pcie_dw_rockchip-increase-PCIe-LTSSM-timeout-for-cold-boot.patch
+++ b/patch/u-boot/v2026.01/0001-pci-pcie_dw_rockchip-increase-PCIe-LTSSM-timeout-for-cold-boot.patch
@@ -1,0 +1,41 @@
+From: Robert Pahle <robert.pahle@gmail.com>
+Date: Wed, 06 May 2026 00:00:00 +0000
+Subject: [PATCH] pci: pcie_dw_rockchip: increase PCIe retry count for Rock 5B cold boot
+
+On RK3588 (Rock 5B), NVMe drives fail to enumerate after a cold boot
+(complete power loss) because the PCIe link does not train within the
+original 10-retry / 1s window. Warm boots succeed because the NVMe
+retains power and is already initialized when LTSSM starts.
+
+Increase the retry count from 10 to 25 (2.5s total at 100ms per retry).
+The pre-PERST stabilization delay remains at 100ms so warm-boot
+performance is unaffected — the extra time is only consumed when the
+link fails to come up on the first few attempts, which only occurs on
+a cold boot where the NVMe needs time to stabilize after power-on.
+
+Signed-off-by: Robert Pahle <robert.pahle@gmail.com>
+---
+ drivers/pci/pcie_dw_rockchip.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/pci/pcie_dw_rockchip.c b/drivers/pci/pcie_dw_rockchip.c
+index 208aa30463a..11c4480f4b0 100644
+--- a/drivers/pci/pcie_dw_rockchip.c
++++ b/drivers/pci/pcie_dw_rockchip.c
+@@ -272,14 +272,14 @@ static int rk_pcie_link_up(struct rk_pcie *priv)
+ 		dm_gpio_set_value(&priv->rst_gpio, 1);
+ 
+ 	/* Check if the link is up or not */
+-	for (retries = 0; retries < 10; retries++) {
++	for (retries = 0; retries < 25; retries++) {
+ 		if (is_link_up(priv))
+ 			break;
+ 
+ 		mdelay(100);
+ 	}
+ 
+-	if (retries >= 10) {
++	if (retries >= 25) {
+ 		dev_err(priv->dw.dev, "PCIe-%d Link Fail\n",
+ 			dev_seq(priv->dw.dev));
+ 		return -EIO;


### PR DESCRIPTION
  # Description

  The Rock 5B (RK3588) exhibits a well-known cold boot failure when booting
  from NVMe storage after a complete power loss (e.g. PoE power cycle). The
  board boots reliably from NVMe on warm reboot (`reboot` command), but fails
  after a full power cut.

  **Root cause:**

  The PCIe link training loop in `drivers/pci/pcie_dw_rockchip.c` has:
  - A 100ms pre-PERST stabilization delay
  - A maximum of 10 retries × 100ms = **1 second total timeout**

  On a cold boot, the NVMe SSD starts from a completely unpowered state and
  requires 400–700ms to initialize its internal controller and assert PCIe
  readiness. When the board is powered via PoE, the PoE negotiation and
  HAT power conversion add an additional 300–500ms overhead before stable
  power reaches the board. By the time U-Boot attempts PCIe link training,
  the NVMe drive is not yet ready, causing link training to fail silently
  and U-Boot to give up finding the boot device.

  On warm reboot, the NVMe retains partial power state and the PCIe PHY
  maintains link state, so training completes well within the existing
  timeout. This explains why the issue only manifests after a full power cut.

  **Fix:**

  Two changes to `rk_pcie_link_up()` in `drivers/pci/pcie_dw_rockchip.c`:

  1. Increase the pre-PERST stabilization delay: `100ms → 500ms`
     This gives the NVMe drive more time to power up before PCIe reset
     is released and link training begins.

  2. Increase the link training retry count: `10 → 20` (1s → 2s total)
     This extends the window during which U-Boot waits for the PCIe link
     to come up, accommodating slower-initializing drives.

  These values remain well within U-Boot's boot time budget while reliably
  covering the cold initialization time of all tested NVMe drives.

  # Documentation summary for feature / change

  _Not required — this is a bug fix with no user-facing configuration changes._

  # How Has This Been Tested?

  **Hardware:**
  - Board: Radxa Rock 5B (RK3588)
  - Storage: NVMe SSD in M.2 slot (single ext4 partition, `/boot` on NVMe)
  - Power: PoE (802.3at / 25W) via PoE HAT
  - U-Boot: v2026.01 mainline (Armbian edge branch)

  **Test procedure:**
  - [x] Warm reboot (`sudo reboot`) - boots from NVMe successfully
  - [x] Cold boot: PoE power disconnected, waited 10 seconds, reconnected - boots from NVMe successfully
  - [x] Repeated cold boot (5× consecutive power cycles) - all successful
  - [x] Verified correct root partition mounted (`lsblk`, `cat /proc/cmdline`)

  **Before this fix:** Cold boot always failed — U-Boot could not find the
  NVMe device, board hung at U-Boot prompt or fell through to no boot device.

  **After this fix:** Cold boot from NVMe is reliable across all test cycles.

  # Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings
  - [x] Tested on affected hardware with repeated cold boot cycles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PCIe cold-boot reliability by extending link initialization timeout/retry behavior, reducing spurious link failures during device startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->