### PR TITLE
fix: rename imx8m bare hook so binman pkg_resources patch can run

### DIFF
--- a/config/sources/families/imx8m.conf
+++ b/config/sources/families/imx8m.conf
@@ -28,8 +28,11 @@ case $BOARD in
 		;;
 esac
 
-# bootloader releated
-pre_config_uboot_target() {
+# bootloader related.
+# Use `<hook>__<purpose>` so the framework registers this alongside
+# other extensions' hooks at the same stage; a bare
+# `pre_config_uboot_target()` would suppress every other registration.
+pre_config_uboot_target__imx8m_firmware() {
 	# get the firmware
 	rm -rf ${IMX_FIRMWARE}*
 	curl -fL "https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/${IMX_FIRMWARE}.bin" -o "${IMX_FIRMWARE}.bin" || {


### PR DESCRIPTION
## Symptom

`uboot-mba8mpxl-ras314-current` nightly fails at `BINMAN flash.bin` with `ModuleNotFoundError: No module named 'pkg_resources'`. [Run 25262303737](https://github.com/armbian/os/actions/runs/25262303737/job/74075460203).

## Cause

`config/sources/families/imx8m.conf:32` defines `pre_config_uboot_target()` (bare). The framework treats a bare hook as the full implementation and silently drops any `<hook>__<purpose>` companions:

```
WARNING: Extension conflict [ function pre_config_uboot_target already defined!
                              ignoring functions:
                              pre_config_uboot_target__fix_binman_pkg_resources ]
```

So [#9407](https://github.com/armbian/build/pull/9407)'s binman-fix extension never patches `tools/binman/control.py` on i.MX 8M boards. Combined with setuptools >= 82 dropping `pkg_resources`, the u-boot v2024.04 binman blows up the moment `make flash.bin` runs.

## Fix

Rename to `pre_config_uboot_target__imx8m_firmware()`. Body unchanged — same NXP firmware fetch + per-board copy. Both hooks now coexist and run; order doesn't matter (firmware blob copy vs. Python source rewrite are independent).

## Test plan

- [x] Re-run the failing nightly — `Patching binman` info line should appear and `make flash.bin` complete.
- [x] Spot-check one other i.MX 8M board (`mba8mpxl`, `imx8mp-tqma8mpql-mba8mpxl`) builds clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized bootloader hook naming to improve configuration clarity and maintainability.
  * Improved firmware handling during bootloader setup so required HDMI/DP and DDR artifacts are fetched and applied automatically.

* **Documentation**
  * Added comments explaining hook naming conventions and parallel-hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->