### PR TITLE
fix: rockchip family_tweaks fails on forky — addgroup → groupadd

### DIFF
--- a/config/sources/families/rockchip-rv1106.conf
+++ b/config/sources/families/rockchip-rv1106.conf
@@ -126,9 +126,13 @@ write_uboot_platform() {
 family_tweaks() {
 
 	# Create gpio and i2c groups on the build rootfs; they are matched against
-	# udev rules to allow non-root user access to these resources
-	chroot_sdcard addgroup --system --quiet --gid 900 gpio
-	chroot_sdcard addgroup --system --quiet --gid 901 i2c
+	# udev rules to allow non-root user access to these resources.
+	# `groupadd` (from passwd, Essential) instead of `addgroup` (from
+	# adduser): forky no longer pulls adduser into a minimal rootfs.
+	# `getent group … ||` guard keeps the call idempotent — `groupadd`
+	# exits 9 (vs `addgroup`'s 0) if the group already exists.
+	chroot_sdcard getent group gpio >/dev/null || chroot_sdcard groupadd --system --gid 900 gpio
+	chroot_sdcard getent group i2c  >/dev/null || chroot_sdcard groupadd --system --gid 901 i2c
 
 	return 0
 

--- a/config/sources/families/rockchip.conf
+++ b/config/sources/families/rockchip.conf
@@ -236,9 +236,11 @@ fi
 family_tweaks() {
 
 	# Create gpio and i2c groups on the build rootfs; they are matched against
-	# udev rules to allow non-root user access to these resources
-	chroot_sdcard getent group gpio >/dev/null || chroot_sdcard addgroup --system --quiet --gid 900 gpio
-	chroot_sdcard getent group i2c  >/dev/null || chroot_sdcard addgroup --system --quiet --gid 901 i2c
+	# udev rules to allow non-root user access to these resources.
+	# `groupadd` (from passwd, Essential) instead of `addgroup` (from
+	# adduser): forky no longer pulls adduser into a minimal rootfs.
+	chroot_sdcard getent group gpio >/dev/null || chroot_sdcard groupadd --system --gid 900 gpio
+	chroot_sdcard getent group i2c  >/dev/null || chroot_sdcard groupadd --system --gid 901 i2c
 
 	return 0
 


### PR DESCRIPTION
## Symptom

forky armhf rockchip build (e.g. `tinkerboard-current`) fails in `family_tweaks`:

```
COMMAND: addgroup --system --quiet --gid 900 gpio
bash: line 1: addgroup: command not found
ERROR: Error 127 occurred in main shell
```

Log: https://paste.armbian.com/iyasuwenum

## Cause

`addgroup` ships in `adduser`. Debian forky no longer pulls `adduser` into a minimal rootfs (it's been deprioritised in favour of `passwd`'s `groupadd`/`useradd`, which stay Essential). `family_tweaks` calls `addgroup` directly via `chroot_sdcard`, so it 127s the moment the rootfs lacks `adduser`.

## Fix

Switch the four call sites in `config/sources/families/rockchip.conf` and `config/sources/families/rockchip-rv1106.conf` from `addgroup --system --quiet` to `groupadd --system`. `groupadd` is in `passwd` and is present in every Debian/Ubuntu rootfs.

## addgroup vs groupadd — relevant differences

|  | `addgroup --system --quiet --gid N name` | `groupadd --system --gid N name` |
|---|---|---|
| Package | `adduser` (deprecated as essential in forky+) | `passwd` (Essential, all Linux) |
| `--system` / GID | identical behaviour | identical |
| `--quiet` | suppresses success/warn output | not needed — silent on success |
| **Group already exists** | exit `0` | exit `9` |

The exit-9-on-existing difference is gated by a `getent group … ||` guard. `rockchip.conf` already had that guard; added the same guard to `rockchip-rv1106.conf` (its addgroup calls were unguarded), so re-running `family_tweaks` stays idempotent.

## Test plan

- [ ] Re-run the failing nightly (`tinkerboard-current` on forky armhf) — `family_tweaks` should pass and the build progress past the post-cache rootfs stage.
- [ ] Spot-check one rk3588 board (`orangepi5`, `nanopct6`) to confirm rockchip.conf path still works on bookworm/trixie/noble where `adduser` is present.
- [ ] Re-run any rv1106 board (`luckfox-pico-pro`) twice in a row to confirm the new `getent` guard keeps `groupadd` from erroring with exit 9 on the second run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of system group creation during device image builds for Rockchip platforms, ensuring more reliable build outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->