### PR TITLE
chore(config/common): remove dead FAST_CREATE_IMAGE variable

### DIFF
--- a/config/sources/common.conf
+++ b/config/sources/common.conf
@@ -14,7 +14,6 @@
 # shellcheck source=/dev/null
 source "${SRC}/config/sources/mainline-kernel.conf.sh"
 
-declare -g FAST_CREATE_IMAGE='yes'
 declare -g MAIN_CMDLINE='rw no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0 splash plymouth.ignore-serial-consoles'
 
 # So the idea is to let the board/family/hooks define these variables.


### PR DESCRIPTION
## Summary
- Remove `declare -g FAST_CREATE_IMAGE='yes'` from `config/sources/common.conf`. The variable has zero readers in the current tree.

## Why this is dead

`FAST_CREATE_IMAGE` was a real switch once — selecting between `dd` (slow, safe) and `truncate` (fast, sparse) for the blank rootfs image. Its life:

| When | Commit / PR | What |
| ---- | ----------- | ---- |
| 2020-11-22 | `3ddd91de7` (#2365) | Introduced as a real switch in `lib/functions/image/partitioning.sh` (`if [[ $FAST_CREATE_IMAGE == yes ]]; then truncate ... else dd ...`). |
| 2022-04-05 | `7b6d9f162` (#3639) | Default flipped to `"yes"` by adding `FAST_CREATE_IMAGE="yes"` to the per-arch configs (`amd64.conf`, `armhf.conf`, ...). |
| 2022-09-25 | `72cf555bc` (armbian-next) | **Consumer removed.** `partitioning.sh` switched to unconditional `truncate`. Commit subject: `bye bye $FAST_CREATE_IMAGE: always use truncate for blank image`. |
| 2022-11-06 | `3e701a857` (#4387, initial RISC-V) | Per-arch declarations dropped during arch-config restructuring, but a fresh `export FAST_CREATE_IMAGE='yes'` was planted in the new `config/sources/common.conf`. By this point the consumer had been gone for ~6 weeks. |
| 2023-03-28 | `62f5fe159` | Mechanical shellfmt pass: `export ...` → `declare -g ...`. No semantic change. |

So the line in `common.conf` is a leftover from a 2022 merge that re-introduced the variable into the new common-config location ~6 weeks after the only code path that read it had been deleted. It has been a no-op ever since.

## Why remove it

- A globally-declared `*=yes` flag with no consumers reads as documentation that the framework supports a "fast image creation" mode users can toggle. It does not — `truncate` is unconditional.
- Setting `FAST_CREATE_IMAGE=no` (the previously meaningful override) silently does nothing today.
- The declaration also leaks into `config-dump-json`/diagnostics output, padding the surface area of "knobs the build supports".

## Test plan

- [x] `bash lib/tools/shellcheck.sh config/sources/common.conf` passes (`Congrats, no error's detected in config/sources.`)
- [x] After the change, `git grep -n FAST_CREATE_IMAGE` returns nothing
- [x] No external consumers in `armbian/build` per GitHub code-search

🤖 Assisted-by: Claude: claude-opus-4-7