### PR TITLE
feat(boards/helios4): enable watchdog extension by default

### DIFF
--- a/config/boards/helios4.conf
+++ b/config/boards/helios4.conf
@@ -13,6 +13,7 @@ FORCE_BOOTSCRIPT_UPDATE="yes"
 KERNEL_TARGET="current,edge"
 KERNEL_TEST_TARGET="current"
 
+enable_extension "watchdog"
 # Enable btrfs support in u-boot
 enable_extension "uboot-btrfs"
 


### PR DESCRIPTION
The Helios4 board ships with the Marvell Armada 388 hardware watchdog (orion_wdt) but no userspace kicker is configured in the default image. After a kernel oops the machine stays hung instead of being reset.

Enable the existing 'watchdog' extension (already used by helios64, odroidm1, odroidn2): adds the 'watchdog' Debian package to the rootfs and uncomments watchdog-device in /etc/watchdog.conf, so the watchdog daemon (or wd_keepalive fallback) opens /dev/watchdog and keeps the hardware timer alive. A wedged kernel will then trigger a hardware reset within ~60s instead of requiring a manual power-cycle.

Tested on Helios4 with kernel 6.18.26-edge-mvebu: kill -9 of the watchdog daemon plus 'echo c > /proc/sysrq-trigger' produced the expected automatic reboot.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled watchdog functionality for the Helios4 board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->