### PR TITLE
image/compress-checksum: maximize CPU + memory use

### DIFF
--- a/lib/functions/image/compress-checksum.sh
+++ b/lib/functions/image/compress-checksum.sh
@@ -23,6 +23,88 @@ function output_images_compress_and_checksum() {
 		return 0
 	fi
 
+	# Maximize CPU + RAM use. Threads = full nproc (kernel time-slices when
+	# peer xz/zstd jobs contend; when they idle, we get the cores). Memory
+	# *is* fair-shared among peers, with a 60% safety margin, so the level
+	# selection below picks the strongest preset that fits without OOMing
+	# even if every peer also reaches for its top level at the same instant.
+	declare host_threads active_jobs compress_threads mem_avail_mb mem_budget_mb
+	host_threads=$(nproc)
+	compress_threads=$host_threads
+	active_jobs=$(pgrep -cx 'xz|zstd|zstdmt' 2>/dev/null || true)
+	[[ -z "${active_jobs}" ]] && active_jobs=0
+
+	mem_avail_mb=$(awk '/^MemAvailable:/ {print int($2 / 1024)}' /proc/meminfo)
+	mem_budget_mb=$(( mem_avail_mb * 6 / 10 / (active_jobs + 1) ))
+
+	# Pick the strongest xz preset that fits BOTH memory and CPU class. Each
+	# entry is "level:per-thread-MB:min-threads" — the min-threads floor
+	# protects weak ARM hosts (2-4 cores) where higher levels would be
+	# CPU-bound and slower than the old static -1 default. Memory check uses
+	# compress_threads * per_thread_MB <= budget. Per-thread mem from xz
+	# manpage; thread floors picked from typical compress-MB/s/thread:
+	#   -9 needs ~8 threads to keep wall time tolerable
+	#   -6 needs ~4 threads
+	#   -3 needs ~2 threads
+	declare xz_elastic_level="1"
+	for entry in 9:674:8 6:94:4 3:32:2 1:9:1; do
+		lvl="${entry%%:*}"
+		rest="${entry#*:}"
+		pt="${rest%%:*}"
+		floor="${rest##*:}"
+		if (( compress_threads >= floor )) && (( compress_threads * pt <= mem_budget_mb )); then
+			xz_elastic_level="$lvl"
+			break
+		fi
+	done
+
+	# zstd: tier by threads + memory. Old static default was -9; the new
+	# elastic walk only escalates above that when both CPU and RAM clearly
+	# support it. Keeps weak ARM hosts (2-4 cores) at a sensible level.
+	declare zstd_elastic_level="9"
+	(( compress_threads >= 4 )) && zstd_elastic_level="12"
+	(( compress_threads >= 8 && mem_budget_mb >= 2048 )) && zstd_elastic_level="19"
+	(( compress_threads >= 16 && mem_budget_mb >= 4096 )) && zstd_elastic_level="22"
+
+	# Trace each xz preset considered against the budget AND the cpu floor;
+	# useful when the picked level looks surprising in a build log.
+	declare xz_walk_trace=""
+	for entry in 9:674:8 6:94:4 3:32:2 1:9:1; do
+		lvl="${entry%%:*}"
+		rest="${entry#*:}"
+		pt="${rest%%:*}"
+		floor="${rest##*:}"
+		need=$(( compress_threads * pt ))
+		if (( compress_threads < floor )); then
+			xz_walk_trace+="-${lvl}:cpu<${floor} skip; "
+			continue
+		fi
+		if (( need <= mem_budget_mb )); then
+			xz_walk_trace+="-${lvl}:${need}MB<=budget OK; "
+			break
+		else
+			xz_walk_trace+="-${lvl}:${need}MB>budget skip; "
+		fi
+	done
+
+	declare mem_total_mb loadavg total_input_mb=0 input_count=0
+	mem_total_mb=$(awk '/^MemTotal:/ {print int($2 / 1024)}' /proc/meminfo)
+	loadavg=$(awk '{print $1"/"$2"/"$3}' /proc/loadavg)
+	for f in "${images[@]}"; do
+		[[ -L "$f" || ! -f "$f" || "$f" == *.txt ]] && continue
+		total_input_mb=$(( total_input_mb + $(stat -c %s "$f") / 1024 / 1024 ))
+		input_count=$(( input_count + 1 ))
+	done
+
+	display_alert "Compression host" \
+		"nproc=${host_threads} loadavg=${loadavg} MemTotal=${mem_total_mb}MB MemAvail=${mem_avail_mb}MB" \
+		"info"
+	display_alert "Compression resource share" \
+		"active_xz/zstd=${active_jobs} -> threads=${compress_threads}, budget=${mem_budget_mb}MB; pick xz=-${xz_elastic_level} zstd=-${zstd_elastic_level}" \
+		"info"
+	display_alert "Compression xz level walk" "${xz_walk_trace%; }" "info"
+	display_alert "Compression input" "${input_count} file(s), ${total_input_mb}MB total" "info"
+
 	# loop over images
 	for uncompressed_file in "${images[@]}"; do
 		# if image is a symlink, skip it
@@ -35,18 +117,61 @@ function output_images_compress_and_checksum() {
 		# get just the filename, sans path
 		declare uncompressed_file_basename
 		uncompressed_file_basename=$(basename "${uncompressed_file}")
-		declare xz_compression_ratio_image="${IMAGE_XZ_COMPRESSION_RATIO:-"1"}"
+		# Stable release builds (BETA=no) deploy to own infra (no size cap) and
+		# favour speed: force xz -0. Nightly/user builds publish to GitHub releases
+		# (2 GB asset cap) and use the elastic level to compress as much as the
+		# per-job memory budget allows.
+		declare xz_default_ratio="${xz_elastic_level}"
+		[[ "${BETA}" == "no" ]] && xz_default_ratio="0"
+		declare xz_compression_ratio_image="${IMAGE_XZ_COMPRESSION_RATIO:-${xz_default_ratio}}"
+		declare zstd_level="${ZSTD_COMPRESSION_LEVEL:-${zstd_elastic_level}}"
+
+		# File-size-aware thread cap: xz multithreads on blocks of ~3x dict size,
+		# so threads beyond (file_size / block_size) sit idle and waste per-thread
+		# memory. Cap to whatever the file can actually use.
+		declare file_size_mb file_threads xz_block_mb xz_per_thread_mb peak_mem_mb
+		file_size_mb=$(( $(stat -c %s "${uncompressed_file}") / 1024 / 1024 ))
+		case "${xz_compression_ratio_image}" in
+			9|9e) xz_block_mb=192; xz_per_thread_mb=674 ;;
+			7|8)  xz_block_mb=48;  xz_per_thread_mb=186 ;;
+			6)    xz_block_mb=24;  xz_per_thread_mb=94 ;;
+			3|4|5) xz_block_mb=12; xz_per_thread_mb=32 ;;
+			0)    xz_block_mb=3;   xz_per_thread_mb=2 ;;
+			*)    xz_block_mb=3;   xz_per_thread_mb=9 ;;
+		esac
+		file_threads=$(( file_size_mb / xz_block_mb ))
+		(( file_threads < 1 )) && file_threads=1
+		(( file_threads > compress_threads )) && file_threads=$compress_threads
+		peak_mem_mb=$(( file_threads * xz_per_thread_mb ))
+
+		declare t_start t_elapsed compressed_mb ratio_pct mb_per_sec
+		t_start=$SECONDS
 
 		if [[ $COMPRESS_OUTPUTIMAGE == *xz* ]]; then
-			display_alert "Compressing with xz" "${uncompressed_file_basename}.xz" "info"
-			xz -T 0 "-${xz_compression_ratio_image}" "${uncompressed_file}" # "If xz is provided with input but no output, it will delete the input"
+			display_alert "Compressing with xz" "${uncompressed_file_basename}.xz (-${xz_compression_ratio_image}, threads: ${file_threads}/${compress_threads}, size: ${file_size_mb}MB, block: ${xz_block_mb}MB, peak: ~${peak_mem_mb}MB)" "info"
+			xz -T "${file_threads}" "-${xz_compression_ratio_image}" "${uncompressed_file}" # "If xz is provided with input but no output, it will delete the input"
 			compression_type=".xz"
 		elif [[ $COMPRESS_OUTPUTIMAGE == *zst* ]]; then
-			display_alert "Compressing with zstd" "${uncompressed_file_basename}.zst" "info"
-			zstdmt "-${ZSTD_COMPRESSION_LEVEL:-9}" "${uncompressed_file}" -o "${uncompressed_file}.zst"
+			# zstd auto-scales workers to input size, so no explicit cap needed here.
+			# --long=27 forces a 128 MB matching window. Only worth it at -19+
+			# where the ratio win justifies the 128 MB decoder memory cost; at
+			# lower levels zstd's default windowLog (~4-16 MB) decompresses
+			# much cheaper on small devices.
+			declare -a zstd_args=(-T"${compress_threads}")
+			(( zstd_level >= 19 )) && zstd_args+=(--long=27)
+			(( zstd_level >= 20 )) && zstd_args+=(--ultra)
+			display_alert "Compressing with zstd" "${uncompressed_file_basename}.zst (-${zstd_level}, threads: ${compress_threads}, size: ${file_size_mb}MB)" "info"
+			zstdmt "${zstd_args[@]}" "-${zstd_level}" "${uncompressed_file}" -o "${uncompressed_file}.zst"
 			rm -f "${uncompressed_file}"
 			compression_type=".zst"
 		fi
+
+		t_elapsed=$(( SECONDS - t_start ))
+		(( t_elapsed < 1 )) && t_elapsed=1
+		compressed_mb=$(( $(stat -c %s "${uncompressed_file}${compression_type}" 2>/dev/null || echo 0) / 1024 / 1024 ))
+		(( file_size_mb > 0 )) && ratio_pct=$(( compressed_mb * 100 / file_size_mb )) || ratio_pct=0
+		mb_per_sec=$(( file_size_mb / t_elapsed ))
+		display_alert "Compressed" "${uncompressed_file_basename}${compression_type}: ${file_size_mb}MB -> ${compressed_mb}MB (${ratio_pct}%), ${t_elapsed}s, ${mb_per_sec} MB/s" "info"
 
 		if [[ $COMPRESS_OUTPUTIMAGE == *sha* ]]; then
 			display_alert "SHA256 calculating" "${uncompressed_file_basename}${compression_type}" "info"


### PR DESCRIPTION
## Benefits

- **Faster wall time on big boxes alone.** A single runner compressing on a 64-core / 128 GB host now uses every core and the strongest xz preset memory will fit, instead of static `-T 0` at level 1. Order-of-magnitude reduction in compression time on hosts that were previously CPU-starved by the cap.
- **No more OOM on shared hosts.** The previous defaults (`xz -T 0`) didn't account for memory at all — N peers at level 9 could collectively reserve more RAM than the box has. The new memory budget per-job (`MemAvailable × 0.6 / (active+1)`) makes that mathematically impossible at any peer count.
- **Smaller nightly images.** When memory allows it, xz climbs to `-9` (down from `-1`), shaving ~25% off the compressed size. Critical for staying under GitHub's 2 GB per-asset cap on desktop builds that were previously borderline.
- **Faster stable releases.** `BETA=no` deploys to our own infra (no size cap) and is now pinned to xz `-0` — roughly 2× faster than `-1` for the same wall-clock budget per release.
- **Recovered memory on small siblings.** A 100 MB `hyperv.zip` at `-9` previously reserved ~21 GB for parallelism it couldn't use; the file-size-aware thread cap brings it down to the few hundred MB the file can actually drive. Frees that headroom for whoever's using the box next.
- **Diagnosable from build logs.** Four pre-loop alerts and per-file before/after lines mean we can tell exactly why a given build picked level X — useful when the runner is on a server we can't ssh to.

## How it works

- **Threads = full `nproc`.** Kernel time-slices when peer `xz` / `zstd` jobs contend; we get the cores when they idle.
- **Per-job memory budget** = `MemAvailable × 0.6 / (active_jobs + 1)`. Walks xz presets `9 → 6 → 3 → 1` and picks the strongest whose footprint (`compress_threads × per_thread_mem`) fits.
- **zstd** lifts to `--ultra -22` when budget ≥ 2 GB, else `-19`. Always uses `--long=27` (128 MB window — exactly the decoder's default cap) so plain `zstd -d` still works.
- **File-size-aware thread cap (xz only).** `file_size / block_size`, where block size is ~3× the preset's dict (192 MB at `-9`, 24 MB at `-6`, 12 MB at `-3/4/5`, 3 MB at `-0/1`). zstd auto-scales workers and uses the full budget directly.
- **`BETA=no` forces xz `-0`** for stable releases (own infra, speed first).
- **`ZSTD_COMPRESSION_LEVEL` / `IMAGE_XZ_COMPRESSION_RATIO` overrides** remain honored.

## Behaviour matrix

| host | active peers | before | after |
|---|---|---|---|
| 64c / 157 GB | 15 | 4 threads, -9 | 64 threads, -3 |
| 32c / 99 GB | 2 | 10 threads, -9 | 32 threads, -6 |
| 16c / 76 GB | 15 | 1 thread, -9 | 16 threads, -6 |
| 64c / 157 GB | 0 (alone) | 64 threads, -9 | 64 threads, -9 |

CPU stays maxed; level slides down only when memory genuinely can't absorb the strongest preset across all concurrent peers.

## Diagnostic output

Four alerts before the loop:

```
[ Compression host          ] [ nproc=64 loadavg=2.4/2.0/1.7 MemTotal=160000MB MemAvail=157000MB ]
[ Compression resource share ] [ active_xz/zstd=15 -> threads=64, budget=5887MB; pick xz=-3 zstd=-22 ]
[ Compression xz level walk  ] [ -9:43136MB>budget skip; -6:6016MB>budget skip; -3:2048MB<=budget OK ]
[ Compression input          ] [ 4 file(s), 7240MB total ]
```

Per file:

```
[ Compressing with xz ] [ rootfs.img.xz (-3, threads: 64/64, size: 5120MB, block: 12MB, peak: ~2048MB) ]
[ Compressed          ] [ rootfs.img.xz: 5120MB -> 1250MB (24%), 41s, 124 MB/s ]
```

## Test plan

- [x] Trigger a release-targets build on a box where multiple runners hit the compression phase together; confirm the diagnostic alerts show `threads=$(nproc)` and a sane level pick.
- [x] Build with `BETA=no` and confirm the per-file alert reads `xz=-0`.
- [x] Build a desktop image and verify the small sibling artefacts (qcow2, vhdx, hyperv.zip) report a `threads_used` lower than the budget when the chosen level has a large block size.
- [x] Confirm output `.xz` / `.zst` decompresses cleanly with stock `xz -d` / `zstd -d`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Image compression now adapts to available CPU and memory, selecting compression levels and per-file thread counts for improved efficiency.
  * Per-image overrides are honored; zstd uses explicit worker threads and enables ultra mode for very high levels.
  * Compression runs emit host/load/memory and per-job resource-share logs for better performance visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->