### PR TITLE
fix(config): skip host filesystem compatibility check for ROOTFS_TYPE=nfs

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -163,8 +163,11 @@ function do_main_configuration() {
 			;;
 	esac
 
-	# Check if the filesystem type is supported by the build host
-	if [[ $CONFIG_DEFS_ONLY != yes ]]; then # don't waste time if only gathering config defs
+	# Check if the filesystem type is supported by the build host.
+	# Skipped for nfs / nfs-root: these rootfs types produce a tarball on the
+	# host (rootfs-to-image.sh `tar | gzip`) and never mount NFS locally — the
+	# target's kernel mounts it at boot time, so host FS support is irrelevant.
+	if [[ $CONFIG_DEFS_ONLY != yes && $ROOTFS_TYPE != nfs && $ROOTFS_TYPE != nfs-root ]]; then # don't waste time if only gathering config defs
 		check_filesystem_compatibility_on_host
 	fi
 


### PR DESCRIPTION
## Summary
- \`do_main_configuration()\` calls \`check_filesystem_compatibility_on_host\` for any \`\$ROOTFS_TYPE\`, including \`nfs\`/\`nfs-root\`. The check greps \`/proc/filesystems\` and modprobes \`nfs\`, aborting if neither succeeds.
- For \`ROOTFS_TYPE=nfs\` (and the \`nfs-root\` variant added by the netboot extension) this is a false positive: \`rootfs-to-image.sh\` produces a tarball via \`tar | gzip\` and never mounts NFS on the host. The target's kernel mounts NFS at boot time — host FS support is irrelevant.
- Aggravated under docker-launcher: \`/lib/modules\` is not forwarded into the container, so even when the host kernel ships \`nfs.ko\` the in-container \`modprobe nfs\` fails. Skipping for nfs is the right fix regardless.
- Skip is encoded at the call site (knows \`ROOTFS_TYPE\` semantics), not inside the function (which stays narrowly responsible).

Same one-line gate already lives on the netboot extension PR (#9656). This patch lifts it to \`main\` as a standalone core armbian fix.

## Test plan
- [ ] Build with \`ROOTFS_TYPE=nfs\` on a host whose kernel/container has no \`nfs.ko\` — should now proceed (previously aborted).
- [ ] Build with \`ROOTFS_TYPE=ext4\` (default) — \`check_filesystem_compatibility_on_host\` runs as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced NFS rootfs handling by skipping unnecessary filesystem compatibility checks when NFS or NFS-root configurations are selected, improving configuration accuracy and build process efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->