### PR TITLE
Fix rk3528 nanopi zero2 snps reset gpio property

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/rk3528-14-arm64-dts-rockchip-nanopi-zero2-fix-ethernet-phy-reset.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3528-14-arm64-dts-rockchip-nanopi-zero2-fix-ethernet-phy-reset.patch
@@ -4,7 +4,7 @@ Date: Thu, 26 Mar 2026 00:00:00 +0000
 Subject: arm64: dts: rockchip: nanopi-zero2: fix ethernet PHY reset
 
 Move the Ethernet PHY reset control from the MDIO bus PHY node to the
-GMAC controller node using the SNPS reset properties (snps,reset-gpios
+GMAC controller node using the SNPS reset properties (snps,reset-gpio
 and snps,reset-delays-us). This ensures the PHY is properly reset by
 the GMAC driver during initialization, which is required for reliable
 link establishment on the NanoPi Zero2.
@@ -26,7 +26,7 @@ index 111111111111..222222222222 100644
  	pinctrl-0 = <&rgmii_miim>, <&rgmii_tx_bus2>, <&rgmii_rx_bus2>,
  		    <&rgmii_rgmii_clk>, <&rgmii_rgmii_bus>;
  	status = "okay";
-+	snps,reset-gpios = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,reset-gpio = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
 +	snps,reset-delays-us = <0 20000 100000>;
  };
  

--- a/patch/kernel/archive/rockchip64-7.0/rk3528-14-arm64-dts-rockchip-nanopi-zero2-fix-ethernet-phy-reset.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3528-14-arm64-dts-rockchip-nanopi-zero2-fix-ethernet-phy-reset.patch
@@ -4,7 +4,7 @@ Date: Thu, 26 Mar 2026 00:00:00 +0000
 Subject: arm64: dts: rockchip: nanopi-zero2: fix ethernet PHY reset
 
 Move the Ethernet PHY reset control from the MDIO bus PHY node to the
-GMAC controller node using the SNPS reset properties (snps,reset-gpios
+GMAC controller node using the SNPS reset properties (snps,reset-gpio
 and snps,reset-delays-us). This ensures the PHY is properly reset by
 the GMAC driver during initialization, which is required for reliable
 link establishment on the NanoPi Zero2.
@@ -26,7 +26,7 @@ index 111111111111..222222222222 100644
  	pinctrl-0 = <&rgmii_miim>, <&rgmii_tx_bus2>, <&rgmii_rx_bus2>,
  		    <&rgmii_rgmii_clk>, <&rgmii_rgmii_bus>;
  	status = "okay";
-+	snps,reset-gpios = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,reset-gpio = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
 +	snps,reset-delays-us = <0 20000 100000>;
  };
  

--- a/patch/kernel/archive/rockchip64-7.1/rk3528-14-arm64-dts-rockchip-nanopi-zero2-fix-ethernet-phy-reset.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3528-14-arm64-dts-rockchip-nanopi-zero2-fix-ethernet-phy-reset.patch
@@ -4,7 +4,7 @@ Date: Thu, 26 Mar 2026 00:00:00 +0000
 Subject: arm64: dts: rockchip: nanopi-zero2: fix ethernet PHY reset
 
 Move the Ethernet PHY reset control from the MDIO bus PHY node to the
-GMAC controller node using the SNPS reset properties (snps,reset-gpios
+GMAC controller node using the SNPS reset properties (snps,reset-gpio
 and snps,reset-delays-us). This ensures the PHY is properly reset by
 the GMAC driver during initialization, which is required for reliable
 link establishment on the NanoPi Zero2.
@@ -26,7 +26,7 @@ index 111111111111..222222222222 100644
  	pinctrl-0 = <&rgmii_miim>, <&rgmii_tx_bus2>, <&rgmii_rx_bus2>,
  		    <&rgmii_rgmii_clk>, <&rgmii_rgmii_bus>;
  	status = "okay";
-+	snps,reset-gpios = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,reset-gpio = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
 +	snps,reset-delays-us = <0 20000 100000>;
  };
  


### PR DESCRIPTION
- fixes #9619
- addresses all currently active kernel branches for rockchip64
According to snps,dwmac DT binding documentation (https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Documentation/devicetree/bindings/net/snps,dwmac.yaml?h=v7.0.3#n440)

# Description

See issue report linked above

# How Has This Been Tested?

- [x] build nanopi-zero2 kernel on current

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ethernet PHY reset handling on NanoPi Zero2 devices across kernel versions 6.18, 7.0, and 7.1. This improves the reliability of network link establishment during system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->