### PR TITLE
kernel: fix process not exit with kernel build failure

### DIFF
--- a/lib/functions/compilation/kernel-make.sh
+++ b/lib/functions/compilation/kernel-make.sh
@@ -111,8 +111,10 @@ function run_kernel_make_dialog() {
 
 function run_kernel_make_long_running() {
 	local seconds_start=${SECONDS} # Bash has a builtin SECONDS that is seconds since start of script
-	KERNEL_MAKE_UNBUFFER="unbuffer" run_kernel_make_internal "$@"
+	local command_result=0
+	KERNEL_MAKE_UNBUFFER="unbuffer" run_kernel_make_internal "$@" || command_result=$?
 	display_alert "Kernel Make '$*' took" "$((SECONDS - seconds_start)) seconds" "debug"
+	return ${command_result}
 }
 
 function kernel_determine_toolchain() {


### PR DESCRIPTION
# Description

When there are failures when building kernel, the process does not exit because there is a log command at the end of function. We can force the function return the exit code of run_kernel_make_internal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kernel build handling improved: debug alerts about elapsed time are now shown only for successful compilations; when a build fails the actual error code is returned and no misleading success notification is emitted, improving accuracy of build reporting and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->