### PR TITLE
action: emit assets manifest JSON alongside release uploads

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,11 @@ inputs:
     required: false
     default: ""
 
+  armbian_release_prerelease:
+    description: "Publish the GitHub release as a pre-release. Useful for matrix builds: leave as 'true' while images are still being uploaded, then promote to a regular release with `gh release edit <tag> --prerelease=false --latest` once all assets land."
+    required: false
+    default: "false"
+
   armbian_download_base_url:
     description: "Base URL where the published images live (used to construct file_url / redi_url in the assets manifest)"
     required: false
@@ -525,6 +530,7 @@ runs:
         removeArtifacts: false
         replacesArtifacts: true
         makeLatest: true
+        prerelease: ${{ inputs.armbian_release_prerelease }}
         artifactErrorsFailBuild: true
         token: "${{ inputs.armbian_token }}"
         body: |

--- a/action.yml
+++ b/action.yml
@@ -525,6 +525,7 @@ runs:
         removeArtifacts: false
         replacesArtifacts: true
         makeLatest: true
+        artifactErrorsFailBuild: true
         token: "${{ inputs.armbian_token }}"
         body: |
           ${{ inputs.armbian_release_body }}

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,21 @@ inputs:
     required: false
     default: ""
 
+  armbian_download_base_url:
+    description: "Base URL where the published images live (used to construct file_url / redi_url in the assets manifest)"
+    required: false
+    default: "https://dl.armbian.com"
+
+  armbian_download_repository:
+    description: "Repository segment under <download_base>/<board>/<repo>/ (e.g. 'archive', 'nightly'). Set to empty string for a flat URL shape <download_base>/<filename> — useful when images are published directly to a GitHub release. In flat mode redi_url* mirror file_url* (no separate redirector exists)."
+    required: false
+    default: "archive"
+
+  armbian_index_url:
+    description: "URL of the canonical armbian-images.json used to enrich each entry's company_name / company_website / company_logo by board_slug. Set to empty string to skip enrichment."
+    required: false
+    default: "https://github.armbian.com/armbian-images.json"
+
 runs:
   using: "composite"
 
@@ -220,6 +235,286 @@ runs:
         printf '%s' "${{ inputs.armbian_pgp_password }}" | \
         gpg --passphrase-fd 0 --armor --detach-sign --pinentry-mode loopback --batch --yes \
         build/output/images/*.img*.xz
+
+    - name: "Generate release assets manifest"
+      shell: bash
+      env:
+        ARMBIAN_VERSION: ${{ env.ARMBIAN_VERSION }}
+        ARMBIAN_BOARD: ${{ inputs.armbian_board }}
+        ARMBIAN_RELEASE: ${{ inputs.armbian_release }}
+        ARMBIAN_KERNEL_BRANCH: ${{ inputs.armbian_kernel_branch }}
+        ARMBIAN_UI: ${{ inputs.armbian_ui }}
+        ARMBIAN_DOWNLOAD_BASE_URL: ${{ inputs.armbian_download_base_url }}
+        ARMBIAN_DOWNLOAD_REPOSITORY: ${{ inputs.armbian_download_repository }}
+        ARMBIAN_INDEX_URL: ${{ inputs.armbian_index_url }}
+      run: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import json, os, re, sys, urllib.request
+        from datetime import datetime, timezone
+        from pathlib import Path
+
+        # ── Configuration ────────────────────────────────────────────────────
+        IMAGES_DIR = Path("build/output/images")
+        INFO_JSON  = Path("build/output/info/image-info.json")
+
+        DOWNLOAD_BASE = os.environ.get("ARMBIAN_DOWNLOAD_BASE_URL", "https://dl.armbian.com").rstrip("/")
+        # strip("/") so "archive/", "/archive/", or "/" all behave correctly:
+        # avoids double-slashes in composed URLs and lets a slash-only value
+        # collapse to "" (which selects the flat-URL shape below).
+        DOWNLOAD_REPO = os.environ.get("ARMBIAN_DOWNLOAD_REPOSITORY", "archive").strip("/")
+        INDEX_URL     = os.environ.get("ARMBIAN_INDEX_URL", "https://github.armbian.com/armbian-images.json")
+        VERSION_ENV   = os.environ.get("ARMBIAN_VERSION", "")
+
+        # Image format extensions: (full_ext, image_format) pairs. full_ext
+        # lands in the `file_extension` JSON field (e.g. "img.qcow2.xz");
+        # image_format groups variants of the same product (raw vs qcow2 vs
+        # hyperv) for de-dup. Same (stem, image_format) collapses to one
+        # entry preferring xz > zst > raw uncompressed (EXTS is ordered that
+        # way so first-seen wins); different image_format coexist as
+        # separate entries.
+        EXTS = (
+            ("img.qcow2.xz",   "img.qcow2"),
+            ("img.qcow2.zst",  "img.qcow2"),
+            ("img.qcow2",      "img.qcow2"),
+            ("img.vhdx.xz",    "img.vhdx"),
+            ("img.vhdx.zst",   "img.vhdx"),
+            ("img.vhdx",       "img.vhdx"),
+            ("hyperv.zip.xz",  "hyperv.zip"),
+            ("hyperv.zip.zst", "hyperv.zip"),
+            ("hyperv.zip",     "hyperv.zip"),
+            ("img.xz",         "img"),
+            ("img.zst",        "img"),
+            ("img",            "img"),
+        )
+
+        # image_format -> redi_url variant suffix (canonical generator
+        # appends "-qcow2" / "-hyperv" to the friendly redirect path so a
+        # board can serve multiple formats at distinct URLs).
+        FORMAT_SUFFIX = {"img.qcow2": "qcow2", "img.vhdx": "vhdx", "hyperv.zip": "hyperv"}
+
+        # Filename: Armbian[-unofficial]_{version}_{Board}_{distro}_{branch}_{kernel}[_{variant[.app]}]
+        # Variant token is optional (some legacy / hand-crafted builds omit it).
+        FNAME_RE = re.compile(
+            r"^(?P<prefix>Armbian(?:-\w+)?)_(?P<version>[^_]+)_(?P<board>[^_]+)_"
+            r"(?P<distro>[^_]+)_(?P<branch>[^_]+)_(?P<kernel>[^_]+)"
+            r"(?:_(?P<variant>[^.]+(?:\.[^.]+)?))?$"
+        )
+
+        # Fields copied verbatim from the canonical published index when the
+        # slug is present there. Local image-info.json wins per-field for the
+        # board_* fields; company_* and platinum_* are only sourced here.
+        ENRICHMENT_FIELDS = (
+            "board_name", "board_vendor", "board_support", "board_introduced",
+            "company_name", "company_website", "company_logo",
+            "platinum", "platinum_expired", "platinum_until",
+        )
+
+        # ── Loaders ──────────────────────────────────────────────────────────
+        def load_enrichment(url):
+            """Fetch the canonical index and build slug -> enrichment-fields
+            map. Best-effort: silently skips on any failure."""
+            if not url:
+                return {}
+            try:
+                req = urllib.request.Request(url, headers={"User-Agent": "armbian-build-action"})
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    data = json.load(resp)
+            except Exception as e:
+                print(f"::warning title=Assets manifest::Could not fetch enrichment index {url}: {e}")
+                return {}
+            out = {}
+            for asset in data.get("assets", []):
+                slug = (asset.get("board_slug") or "").lower()
+                if slug and slug not in out:
+                    out[slug] = {k: asset.get(k) or "" for k in ENRICHMENT_FIELDS}
+            print(f"Enrichment loaded from {url}: {len(out)} board entries")
+            return out
+
+        def load_board_meta(path):
+            """Read BOARD_TOP_LEVEL_VARS slug -> board_* fields from the
+            build framework's image-info.json (written before this step runs)."""
+            if not path.is_file():
+                return {}
+            try:
+                data = json.loads(path.read_text())
+            except Exception as e:
+                print(f"::warning::Could not parse {path}: {e}")
+                return {}
+            out = {}
+            for entry in data:
+                inv = (entry.get("in", {}) or {}).get("inventory", {}) or {}
+                tlv = inv.get("BOARD_TOP_LEVEL_VARS", {}) or {}
+                slug = (inv.get("BOARD") or "").lower()
+                if not slug:
+                    continue
+                out[slug] = {
+                    "board_name":       tlv.get("BOARD_NAME", ""),
+                    "board_vendor":     tlv.get("BOARD_VENDOR", ""),
+                    "board_support":    tlv.get("BOARD_SUPPORT_LEVEL", ""),
+                    "board_introduced": tlv.get("INTRODUCED", ""),
+                }
+            return out
+
+        # ── Filename parser ──────────────────────────────────────────────────
+        def parse_name(stem):
+            """Extract version/board_slug/distro/branch/kernel/variant/app
+            from a filename stem (no extension). Returns None if no match.
+
+            Variant token can carry .application (e.g. "minimal.hyperv").
+            Kernel field can carry a -suffix: "6.18.26-sdk", "6.6.0-rc1-sdk".
+            Strip only the LAST dash-segment so multi-dash kernels preserve
+            any intermediate tag (e.g. rc1) in kernel_version. Treat the
+            stripped suffix as file_application iff every char is a letter
+            (sdk, omv, kali, …); pre-release tags like "rc5" carry digits
+            and stay attached.
+            """
+            m = FNAME_RE.match(stem)
+            if not m:
+                return None
+            variant = m.group("variant") or ""
+            file_application = ""
+            if "." in variant:
+                variant, file_application = variant.split(".", 1)
+            kernel = m.group("kernel")
+            if "-" in kernel:
+                last_token = kernel.rsplit("-", 1)[1]
+                kernel = kernel.rsplit("-", 1)[0]
+                if last_token.isalpha() and not file_application:
+                    file_application = last_token
+            return {
+                "version":          m.group("version"),
+                "board_slug":       m.group("board").lower(),
+                "distro":           m.group("distro"),
+                "branch":           m.group("branch"),
+                "kernel_version":   kernel,
+                "variant":          variant,
+                "file_application": file_application,
+            }
+
+        # ── URL composition ──────────────────────────────────────────────────
+        def signature_urls(base):
+            """Return (base, base.asc, base.sha, base.torrent)."""
+            return base, f"{base}.asc", f"{base}.sha", f"{base}.torrent"
+
+        def build_urls(parsed, image_format, img_name):
+            """Compose file_url + redi_url (each with its .asc/.sha/.torrent
+            siblings).
+
+            Two URL shapes, selected by DOWNLOAD_REPO:
+              non-empty -> {base}/{board}/{repo}/{filename}    dl.armbian.com style
+              empty     -> {base}/{filename}                   flat (e.g. GitHub releases)
+            Flat mode mirrors redi_url* onto file_url* since there is no
+            separate redirector.
+            """
+            slug = parsed["board_slug"]
+            if DOWNLOAD_REPO:
+                file_urls = signature_urls(f"{DOWNLOAD_BASE}/{slug}/{DOWNLOAD_REPO}/{img_name}")
+                # redi_variant: variant[-{format|app}]. Format suffix wins
+                # over app when both apply (canonical convention).
+                redi_variant = parsed["variant"]
+                tail = FORMAT_SUFFIX.get(image_format) or parsed["file_application"]
+                if tail:
+                    redi_variant = f"{redi_variant}-{tail}" if redi_variant else tail
+                redi_name = f"{parsed['distro'].capitalize()}_{parsed['branch']}"
+                if redi_variant:
+                    redi_name = f"{redi_name}_{redi_variant}"
+                redi_urls = signature_urls(f"{DOWNLOAD_BASE}/{slug}/{redi_name}")
+                return file_urls, redi_urls
+            file_urls = signature_urls(f"{DOWNLOAD_BASE}/{img_name}")
+            return file_urls, file_urls
+
+        # ── Walk image dir, build manifest ───────────────────────────────────
+        def collect_candidates():
+            """Walk IMAGES_DIR, group files by (stem, image_format). Within
+            each group keep the most-compressed form (EXTS is ordered xz >
+            zst > raw, first-seen wins)."""
+            out = {}
+            for ext, image_format in EXTS:
+                for f in IMAGES_DIR.glob(f"*.{ext}"):
+                    stem = f.name[: -(len(ext) + 1)]
+                    key = (stem, image_format)
+                    if key not in out:
+                        out[key] = ext
+            return out
+
+        def build_asset(parsed, image_format, ext, img, board_meta, enrichment):
+            slug = parsed["board_slug"]
+            meta = board_meta.get(slug, {})
+            enrich = enrichment.get(slug, {})
+            stat = img.stat()
+            file_date = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc) \
+                                .strftime("%Y-%m-%dT%H:%M:%SZ")
+            (file_url, file_asc, file_sha, file_tor), \
+                (redi_url, redi_asc, redi_sha, redi_tor) = \
+                build_urls(parsed, image_format, img.name)
+            return {
+                "board_slug":          slug,
+                # local image-info.json wins per-field; published index fills the rest.
+                "board_name":          meta.get("board_name")       or enrich.get("board_name", ""),
+                "board_vendor":        meta.get("board_vendor")     or enrich.get("board_vendor", ""),
+                "board_support":       meta.get("board_support")    or enrich.get("board_support", ""),
+                "board_introduced":    meta.get("board_introduced") or enrich.get("board_introduced", ""),
+                "company_name":        enrich.get("company_name", ""),
+                "company_website":     enrich.get("company_website", ""),
+                "company_logo":        enrich.get("company_logo", ""),
+                "armbian_version":     parsed["version"] or VERSION_ENV,
+                "file_url":            file_url,
+                "file_url_asc":        file_asc,
+                "file_url_sha":        file_sha,
+                "file_url_torrent":    file_tor,
+                "redi_url":            redi_url,
+                "redi_url_asc":        redi_asc,
+                "redi_url_sha":        redi_sha,
+                "redi_url_torrent":    redi_tor,
+                "file_size":           str(stat.st_size),
+                "file_date":           file_date,
+                "distro":              parsed["distro"],
+                "branch":              parsed["branch"],
+                "variant":             parsed["variant"],
+                "file_application":    parsed["file_application"],
+                "promoted":            "false",
+                "download_repository": DOWNLOAD_REPO,
+                "file_extension":      ext,
+                "kernel_version":      parsed["kernel_version"],
+                "platinum":            enrich.get("platinum") or "false",
+                "platinum_expired":    enrich.get("platinum_expired") or "false",
+                "platinum_until":      enrich.get("platinum_until", ""),
+            }
+
+        def write_manifest(asset):
+            """One manifest per image, '<image_filename>.assets.json'.
+            Image filenames are guaranteed unique across this build call
+            and across parallel matrix cells, so the manifest filename is
+            too. Schema {"assets": [...]} so consumers expecting the array
+            (e.g. `jq -s 'map(.assets) | flatten'`) keep working."""
+            img_name = Path(asset["file_url"]).name
+            out = IMAGES_DIR / f"{img_name}.assets.json"
+            out.write_text(json.dumps({"assets": [asset]}, indent=2) + "\n")
+            print(f"Wrote {out}")
+
+        # ── Main ─────────────────────────────────────────────────────────────
+        enrichment = load_enrichment(INDEX_URL)
+        board_meta = load_board_meta(INFO_JSON)
+        candidates = collect_candidates()
+
+        assets = []
+        for (stem, image_format), ext in sorted(candidates.items()):
+            img = IMAGES_DIR / f"{stem}.{ext}"
+            parsed = parse_name(stem)
+            if not parsed:
+                print(f"::warning::Unrecognised filename {img.name}, skipping")
+                continue
+            assets.append(build_asset(parsed, image_format, ext, img, board_meta, enrichment))
+
+        if not assets:
+            print("::warning title=Assets manifest::No images found for assets manifest")
+            sys.exit(0)
+
+        for asset in assets:
+            write_manifest(asset)
+        print(f"Total: {len(assets)} per-image assets manifest{'s' if len(assets) != 1 else ''}")
+        PY
 
     - uses: ncipollo/release-action@v1
       with:


### PR DESCRIPTION
## Summary

Expands the composite action so each build run emits a small JSON manifest describing every image it produced, written next to the image artefacts and uploaded to the GitHub release alongside them. The schema mirrors the canonical `https://github.armbian.com/armbian-images.json` 1:1, so a downstream aggregator can flatten per-build fragments into the central index with `jq -s 'map(.assets) | flatten'` and no bespoke parsing.

Use case: armbian/sdk and any other consumer of `armbian/build@main` ends up with a per-image manifest in its release. Easy to consume.

## What the action does

After the build (and `Sign`) step, before `ncipollo/release-action`:

1. **Walk** `build/output/images` for each known image format — `img`, `img.qcow2`, `img.vhdx`, `hyperv.zip` — in their `xz` / `zst` / raw forms.
2. **Group** by `(stem, image_format)`. Within each group keep the most-compressed form. Different formats coexist as separate manifest entries — the raw image and the qcow2 build of the same logical image are distinct products.
3. **Parse** each filename via a tolerant regex that accepts `Armbian_…` and `Armbian-unofficial_…` prefixes and treats the trailing `_variant[.app]` segment as optional.
4. **Read** board metadata (`BOARD_NAME`, `BOARD_VENDOR`, `BOARD_SUPPORT_LEVEL`, `INTRODUCED`) from the build framework's existing `build/output/info/image-info.json`.
5. **Enrich** by fetching the canonical published index. Populates `company_name` / `company_website` / `company_logo` (Bigin-resolved by armbian.github.io's pipeline) and `platinum` / `platinum_expired` / `platinum_until`, plus a fallback for board_* fields when `image-info.json` doesn't have them.
6. **Compose** `file_url` and `redi_url` (and their `.asc` / `.sha` / `.torrent` siblings) from a configurable base URL + repository segment.
7. **Write** `<image_filename>.assets.json` next to each image. The existing `ncipollo/release-action` glob (`${{ inputs.armbian_artifacts }}*`) picks them up automatically — no caller change needed.

Per-image filenames are unique by construction across both multiple formats in one build call AND parallel matrix cells with different extension lists, so per-cell-named manifests don't collide on the release.

## New optional inputs

| Input | Default | Purpose |
|---|---|---|
| `armbian_download_base_url` | `https://dl.armbian.com` | Base URL where published images live (used to construct `file_url` / `redi_url`). |
| `armbian_download_repository` | `archive` | Repository segment under `<base>/<board>/<repo>/`. **Set to empty string for the flat URL shape** `<base>/<filename>` — useful when images publish directly to a GitHub release. Leading/trailing slashes are stripped. |
| `armbian_index_url` | `https://github.armbian.com/armbian-images.json` | Canonical index used for `company_*` / `platinum_*` enrichment. Empty disables. |

## URL shapes

`armbian_download_repository` selects between two URL conventions:

- **`set` (default `archive`)** — `{base}/{board}/{repo}/{filename}`. `redi_url*` uses the friendly `{Distro}_{branch}_{variant}[-format|app]` redirect path. Format suffix wins over app suffix (canonical convention: `minimal-qcow2`, `minimal-hyperv`).
- **empty** — `{base}/{filename}` (flat). `redi_url*` mirror `file_url*` since GitHub releases have no friendly-redirect convention.

## Schema

```jsonc
{
  "assets": [
    {
      "board_slug":          "uefi-arm64",
      "board_name":          "UEFI arm64",
      "board_vendor":        "generic",
      "board_support":       "conf",
      "board_introduced":    "2022",
      "company_name":        "Generic",
      "company_website":     "",
      "company_logo":        "https://cache.armbian.com/images/vendors/150/generic.png",
      "armbian_version":     "26.05.0-trunk",
      "file_url":            "https://dl.armbian.com/uefi-arm64/archive/Armbian_…_minimal.img.xz",
      "file_url_asc":        "…/…img.xz.asc",
      "file_url_sha":        "…/…img.xz.sha",
      "file_url_torrent":    "…/…img.xz.torrent",
      "redi_url":            "https://dl.armbian.com/uefi-arm64/Noble_current_minimal",
      "redi_url_asc":        "…",
      "redi_url_sha":        "…",
      "redi_url_torrent":    "…",
      "file_size":           "299047896",
      "file_date":           "2026-05-06T08:11:42Z",
      "distro":              "noble",
      "branch":              "current",
      "variant":             "minimal",
      "file_application":    "",
      "promoted":            "false",
      "download_repository": "archive",
      "file_extension":      "img.xz",
      "kernel_version":      "6.18.21",
      "platinum":            "false",
      "platinum_expired":    "false",
      "platinum_until":      ""
    }
  ]
}
```

## Filename parsing

Mirrors [`generate-armbian-images-json.sh`](https://github.com/armbian/armbian.github.io/blob/main/scripts/generate-armbian-images-json.sh):

- **Variant token**: `_variant[.app]` (e.g. `minimal.hyperv`). The `.app` part is optional.
- **Kernel suffix**: rsplit at the LAST `-`. The trailing token becomes `file_application` iff it's all letters (so `sdk`, `omv`, `kali`, `homeassistant`, `openhab`, `ufs` → app; `rc5`, `beta1`, `alpha2`, `pre3` stay attached to `kernel_version`). This way `6.6.0-rc1-sdk` parses as `kernel_version=6.6.0-rc1`, `file_application=sdk`.
- **Variant-side app wins** when both the variant suffix and the kernel suffix carry an app.

## Test results

Dry-run against an 18-image `build/output/images/` tree on a developer host:

- **18/18** filenames parse (regex tolerates the variant-less form, the `Armbian-unofficial` prefix, etc.).
- `board_name` / `board_vendor` / `board_support` / `board_introduced` populate from `image-info.json` for boards listed there; fall back to the canonical index for others.
- `company_*` and `platinum_*` populate from the live published index (340 boards loaded; `uefi-arm64` resolves to `company_name="Generic"` / `company_logo=…/generic.png`; `inovato-quadra` resolves to `platinum="true"` / `platinum_until="2026-06-15"`).
- Synthetic SDK-style filenames (`6.18.26-sdk`) strip cleanly to `kernel_version="6.18.26"` / `file_application="sdk"`. Multi-dash cases (`6.6.0-rc1-sdk`) preserve the rc tag. Edge cases (rc5/beta1/alpha2/pre3 without app, hyperv variant suffixes) all behave correctly.
- All `::warning::` workflow commands go to stdout so GitHub Actions parses them into proper annotations.

## Test plan

- [ ] Trigger an `armbian/sdk` workflow (which uses this action). Confirm the resulting GitHub release contains an `<image_filename>.assets.json` per `.img*` artefact.
- [ ] `jq '.assets | length' *.assets.json` returns `1` for each.
- [ ] Spot-check one entry: `file_url` resolves to a downloadable file, `redi_url` matches the existing `dl.armbian.com` redirect convention (or mirrors `file_url` in flat mode), and `company_*` / `platinum_*` are populated for boards listed in the canonical index.
- [ ] Build a board producing both raw `.img.xz` and `.img.qcow2.xz` and confirm two distinct manifest entries with different `file_extension` and `redi_url`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new action inputs for customizable download base URL, repository, and index URL configuration
  * Introduced automated release asset manifest generation with per-branch asset inventories, metadata enrichment, and missing asset safeguards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->