### PR TITLE
feat(extensions): sysrq-serial-trigger + kernel-debug-tiers (on-device kernel debugging via serial console)

### DIFF
--- a/extensions/kernel-debug-tiers.sh
+++ b/extensions/kernel-debug-tiers.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2026 Igor Velkov
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+#
+# Enable cumulative kernel debug-information tiers for headless boards that
+# need to be debugged through their serial console. On its own this extension
+# does nothing visible at runtime — it just bakes enough information into the
+# kernel that the operator-console facilities (Magic SysRq, KGDB, pstore) and
+# any tracebacks they print are actually useful rather than streams of hex
+# addresses.
+#
+# Pair with the `sysrq-serial-trigger` extension (kconfig + sysctl + u-boot
+# autoboot delay) to actually have an operator-controllable surface; that
+# extension turns the facilities ON, this one makes them MEANINGFUL.
+#
+# Tiers are cumulative: KERNEL_DEBUG_TIER=N enables every tier ≤ N.
+#
+#   0  no-op (extension stays loaded, kernel side disabled — keeps the
+#      extension declarable in a shared config without forcing the cost on
+#      every board, e.g. when one board needs BTF=no for RAM reasons)
+#   1  printk timestamps + lockup/hung-task detection + stack guards
+#      Cost: a handful of bytes per printk, a few cycles per scheduler tick.
+#      No board prerequisites. Default tier.
+#   2  + pstore/ramoops (persistent dmesg through reboot)
+#      Cost: same as tier 1 plus a reserved memory region. Without a DT
+#      `/reserved-memory/ramoops` node or `ramoops.mem_address=…` bootargs,
+#      the modules load but have nowhere to write — silent no-op.
+#   3  + KGDB / KDB over serial
+#      Cost: same as tier 2 plus larger kernel image. Needs `kgdboc=<port>,<baud>`
+#      in bootargs; without it the dispatcher is in-kernel but unreachable.
+#
+# BTF requirement: from tier 1 onwards this extension needs DEBUG_INFO_BTF=y
+# (Armbian's default unless KERNEL_BTF=no). Without BTF, hung-task tracebacks
+# and KGDB symbol output collapse to address-only — the whole point of the
+# extension is then defeated. So an explicit `KERNEL_BTF=no` (in board/family
+# conf or on the build CLI) combined with KERNEL_DEBUG_TIER>=1 is treated as
+# a hard error: pick one, not both.
+#
+# Usage — add to your userpatches config (e.g. `userpatches/config-my.conf`):
+#
+#     enable_extension "kernel-debug-tiers"
+#     KERNEL_DEBUG_TIER=2                          # default 1 if unset
+#
+# Or pass on the build CLI for a one-off run:
+#
+#     ./compile.sh build BOARD=helios64 BRANCH=edge \
+#         ENABLE_EXTENSIONS=kernel-debug-tiers KERNEL_DEBUG_TIER=3
+
+function extension_prepare_config__kernel_debug_tiers() {
+	declare tier="${KERNEL_DEBUG_TIER:-1}"
+	case "${tier}" in
+		0 | 1 | 2 | 3) ;;
+		*) exit_with_error "${EXTENSION}: KERNEL_DEBUG_TIER must be 0, 1, 2 or 3" "got '${tier}'" ;;
+	esac
+
+	# Tier 0 is a deliberate no-op — extension declared but kernel side off.
+	# Skip the BTF check so a shared config can switch BTF on/off per board.
+	if [[ "${tier}" == "0" ]]; then
+		display_alert "${EXTENSION}: KERNEL_DEBUG_TIER=0" "extension loaded but kernel-side debug disabled" "info"
+		return 0
+	fi
+
+	# Hard-fail on conflicting BTF preference. Armbian disables BTF (and all
+	# DEBUG_INFO) when KERNEL_BTF=no — that strips the very symbols this
+	# extension's tracebacks rely on.
+	if [[ "${KERNEL_BTF}" == "no" ]]; then
+		exit_with_error \
+			"${EXTENSION}: KERNEL_BTF=no conflicts with KERNEL_DEBUG_TIER=${tier}" \
+			"BTF is required for hung-task tracebacks and KGDB symbol resolution; either set KERNEL_BTF=yes (or leave it unset for Armbian's default) or set KERNEL_DEBUG_TIER=0 to disable this extension's kernel side"
+	fi
+
+	# Make BTF explicit so Armbian's default-BTF-on path is unambiguous in logs
+	# even when the user didn't set KERNEL_BTF themselves.
+	declare -g KERNEL_BTF="${KERNEL_BTF:-yes}"
+	display_alert "${EXTENSION}: KERNEL_DEBUG_TIER=${tier}" "BTF=${KERNEL_BTF}" "info"
+}
+
+# Tier 1: low-cost diagnostics. printk timestamps and PRINTK_CALLER add a few
+# bytes per line; stack-end check and lockup detectors cost a few cycles per
+# scheduler tick. Cheap enough to ship on a headless server with serial debug.
+function custom_kernel_config__kernel_debug_tier1() {
+	if [[ "${KERNEL_DEBUG_TIER:-1}" -lt 1 ]]; then
+		return 0
+	fi
+	display_alert "${EXTENSION}: tier 1" "printk timestamps + lockup/hung-task detection" "info"
+	opts_y+=(
+		"PRINTK_TIME"
+		"PRINTK_CALLER"
+		"DETECT_HUNG_TASK"
+		"SOFTLOCKUP_DETECTOR"
+		"SCHED_STACK_END_CHECK"
+	)
+	# Default is 120s upstream; explicit so the value shows up in .config.
+	opts_val["DEFAULT_HUNG_TASK_TIMEOUT"]="120"
+}
+
+# Tier 2: pstore/ramoops — kernel writes its last printk before crash to a
+# reserved memory region; userspace reads /sys/fs/pstore/dmesg-ramoops-0
+# after the reboot. Catch: needs a memory region reserved either via
+# `/reserved-memory/ramoops { ... }` in the device tree, or via bootargs
+# `ramoops.mem_address=<phys> ramoops.mem_size=0x100000 ramoops.console_size=0x40000`.
+# Without that the modules load but have nowhere to write — silent no-op.
+function custom_kernel_config__kernel_debug_tier2_pstore() {
+	if [[ "${KERNEL_DEBUG_TIER:-1}" -lt 2 ]]; then
+		return 0
+	fi
+	display_alert "${EXTENSION}: tier 2 (pstore/ramoops)" "needs DT or bootarg reservation, otherwise no-op" "info"
+	opts_y+=("PSTORE" "PSTORE_CONSOLE" "PSTORE_RAM" "PSTORE_DEFLATE_COMPRESS")
+}
+
+# Tier 3: KGDB/KDB over the serial console. SysRq+g drops into the KDB shell
+# on the same line as the kernel printk — `bt`, `dmesg`, `lsmod`, `dis`,
+# watchpoints. Needs `kgdboc=<console>,<baud>` in bootargs (e.g.
+# `kgdboc=ttyS2,1500000` on Helios64) for the dispatcher to attach to the
+# port; without that the kconfig is enabled but unreachable.
+function custom_kernel_config__kernel_debug_tier3_kgdb() {
+	if [[ "${KERNEL_DEBUG_TIER:-1}" -lt 3 ]]; then
+		return 0
+	fi
+	display_alert "${EXTENSION}: tier 3 (KGDB)" "remember kgdboc=<port>,<baud> in bootargs" "info"
+	opts_y+=(
+		"KGDB"
+		"KGDB_SERIAL_CONSOLE"
+		"KGDB_KDB"
+		"KGDB_LOW_LEVEL_TRAP"
+	)
+	# 0xFF = enable every KDB command (memory peek, register inspect, single
+	# step, etc.). On a locked-down production box this can be masked down —
+	# bits are documented in Documentation/dev-tools/kgdb.rst.
+	# shellcheck disable=SC2034 # opts_val is read by armbian_kernel_config_apply_opts_from_arrays
+	opts_val["KDB_DEFAULT_ENABLE"]="0xFF"
+}

--- a/extensions/sysrq-serial-trigger.sh
+++ b/extensions/sysrq-serial-trigger.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2026 Igor Velkov
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+#
+# Enable Magic SysRq through the serial console for headless boards. Without
+# this, kernel hangs (NFS deadlocks, ATA error-handler corner cases on Helios64,
+# etc.) leave you with no way out except the hardware-watchdog timeout or a
+# physical reset. With it, an operator on the serial console can sync,
+# remount-RO and reboot from any kernel state where interrupts still flow.
+#
+# This extension only enables the operator-console *surface*. To make the
+# tracebacks and KGDB sessions reachable through that surface actually
+# informative (rather than streams of hex addresses), pair with the
+# `kernel-debug-tiers` extension which adds BTF, hung-task detection,
+# pstore/ramoops, and KGDB symbol resolution.
+#
+# Mainline kernels ship CONFIG_MAGIC_SYSRQ_SERIAL_SEQUENCE empty by default,
+# which disables BREAK-triggered SysRq entirely. From lib/Kconfig.debug:
+# "If unsure, leave an empty string and the option will not be enabled."
+# (https://elixir.bootlin.com/linux/latest/source/lib/Kconfig.debug#L698)
+# The serial driver requires a non-empty sequence after BREAK so that random
+# line noise cannot trigger a reboot. This extension fills that in with a
+# deliberate sequence that is vanishingly unlikely in normal serial traffic.
+#
+# Usage — add to your userpatches config (e.g. `userpatches/config-my.conf`):
+#
+#     enable_extension "sysrq-serial-trigger"
+#
+# Or pass on the build CLI for a one-off run:
+#
+#     ./compile.sh build BOARD=helios64 BRANCH=edge \
+#         ENABLE_EXTENSIONS=sysrq-serial-trigger
+#
+# Operator workflow (picocom default escape Ctrl-A):
+#     Ctrl-A \      (send BREAK)
+#     sysrq         (the magic sequence, default value of SYSRQ_SERIAL_SEQUENCE)
+#     b             (or any other SysRq command — see Documentation/admin-guide/sysrq.rst)
+#
+# To experiment with a different sequence, override SYSRQ_SERIAL_SEQUENCE
+# from the build CLI; pick something that does not occur in normal output of
+# anything you care about (logging, dialog, etc.).
+
+function custom_kernel_config__sysrq_serial_trigger() {
+	# Default "sysrq": printable, easy to type, and passes through Bash/sed without
+	# escaping. Kernel matches bytes verbatim against serial input after BREAK.
+	declare seq="${SYSRQ_SERIAL_SEQUENCE:-sysrq}"
+	display_alert "${EXTENSION}: enabling SysRq over serial" "sequence='${seq}' after BREAK" "info"
+	opts_y+=("MAGIC_SYSRQ" "MAGIC_SYSRQ_SERIAL")
+	# 1 = SYSRQ_ENABLE_ALL (kernel special-case, not bit 1); enables all SysRq
+	# commands regardless of the runtime kernel.sysrq sysctl value at boot.
+	# shellcheck disable=SC2034 # opts_val is read by armbian_kernel_config_apply_opts_from_arrays
+	opts_val["MAGIC_SYSRQ_DEFAULT_ENABLE"]="1"
+	# Armbian has no opts_str[] equivalent for string kconfig options — opts_val[]
+	# dispatches via --set-val which truncates strings to "" (it is designed for
+	# numeric/hex values only). Use kernel_config_set_string directly; it calls
+	# --set-str and registers the value in kernel_config_modifying_hashes.
+	# Two-phase guard: kernel_config_set_string requires an unpacked source tree;
+	# in the hash-only phase (.config absent) add to hashes manually instead.
+	if [[ -f .config ]]; then
+		kernel_config_set_string "MAGIC_SYSRQ_SERIAL_SEQUENCE" "${seq}"
+	else
+		kernel_config_modifying_hashes+=("MAGIC_SYSRQ_SERIAL_SEQUENCE=\"${seq}\"")
+	fi
+}
+
+# U-Boot autoboot timing — give the operator a real chance to interrupt.
+# Default Armbian u-boot prints "Hit any key to stop autoboot: 0" — i.e.
+# a 1-second window that's effectively unusable. BOOTDELAY=5 gives a 5-second
+# countdown; AUTOBOOT_NEVER_TIMEOUT means a single keypress freezes the
+# countdown entirely so the operator can take their time after that. The
+# trade-off is +5s on every cold boot — acceptable for headless servers,
+# probably annoying for kiosks. Comment out this whole function to revert.
+function post_config_uboot_target__sysrq_serial_uboot_autoboot() {
+	display_alert "${EXTENSION}: u-boot BOOTDELAY=5 + AUTOBOOT_NEVER_TIMEOUT" "give the operator 5s to grab the prompt; pause forever after first keypress" "info"
+	# `scripts/config` is u-boot's own kbuild helper (same script as Linux uses).
+	# It handles "is not set" → enabled and value-overrides correctly without
+	# depending on which form the line currently takes.
+	run_host_command_logged ./scripts/config --set-val CONFIG_BOOTDELAY 5
+	run_host_command_logged ./scripts/config --enable CONFIG_AUTOBOOT_NEVER_TIMEOUT
+}
+
+# Distro defaults (Debian/Ubuntu /usr/lib/sysctl.d/55-magic-sysrq.conf) cap
+# kernel.sysrq at 176 — enough for `s`/`u`/`b` but not `t`/`m`/`f`/`w` which
+# are the actually useful debug commands when a kernel is misbehaving. A
+# headless box with serial-console SysRq is exactly the case where the full
+# set should be available, so override to 1 (all functions). The 60- prefix
+# beats the 55- distro file in sysctl.d lexical order.
+function post_customize_image__sysrq_serial_trigger_userland() {
+	declare conf="${SDCARD}/etc/sysctl.d/60-armbian-sysrq.conf"
+	display_alert "${EXTENSION}: enabling full kernel.sysrq" "${conf##*/} (kernel.sysrq=1)" "info"
+	cat > "${conf}" <<- 'SYSCTL_CONF'
+		# Installed by the Armbian sysrq-serial-trigger extension.
+		# Overrides /usr/lib/sysctl.d/55-magic-sysrq.conf (default 176)
+		# to enable the full SysRq command set — needed for serial-console
+		# debugging (process dumps, blocked-task list, OOM kill, etc.).
+		kernel.sysrq = 1
+	SYSCTL_CONF
+}


### PR DESCRIPTION
## Description

Two extensions that, together with the kernel patches already merged as PR #9750 (rk3399 8250_dw) and PR #9760 (mvebu-6.18 8250_dw), form a coherent system for **on-device kernel debugging through the serial console** on headless ARM boards (NAS-style: helios4, helios64, similar).

Each piece is necessary, none is sufficient on its own:

- **`kernel-debug-tiers`** turns on the kernel-side information without which there is nothing to debug — BTF for hung-task tracebacks, printk timestamps and PRINTK_CALLER, lockup/hung-task detection, pstore/ramoops for post-reboot dmesg, KGDB symbol resolution. Three cumulative tiers (`KERNEL_DEBUG_TIER=1|2|3`, default 1) so the operator picks the cost they're willing to pay; tier 0 is a deliberate no-op.

- **`sysrq-serial-trigger`** turns on the serial console as a debug surface — `MAGIC_SYSRQ` + `MAGIC_SYSRQ_SERIAL_SEQUENCE` in kconfig, `kernel.sysrq=1` sysctl, and a long enough u-boot `BOOTDELAY` for the operator to actually catch the prompt. Without this, even a kernel full of debug info can only be examined post-mortem; nothing can be done about a live hang.

- **The `8250_dw` driver patches** (PR #9750/#9760, already merged) close the last gap on rk3399 and mvebu: the BREAK condition on a dw-apb-uart goes through `dw8250_handle_irq()`, which used to swallow `LSR.BI` without invoking `uart_handle_break()` → `handle_sysrq_from_serial()`. Before those patches, even a fully configured SysRq-over-serial setup on these SoCs only *appeared* to work; the operator's BREAK never reached the SysRq dispatcher.

Together these three changes make the well-documented "send BREAK, type the magic sequence, then press a SysRq command" workflow actually functional on rk3399 and mvebu boards, with enough kernel debug info behind it that the resulting tracebacks and KGDB sessions are informative rather than just hex addresses.

## Tier guarantees

- **Hard-fail on conflicting BTF preference**: `KERNEL_BTF=no` + `KERNEL_DEBUG_TIER>=1` exits early in `extension_prepare_config` with a helpful message (set `KERNEL_BTF=yes`/leave unset, or `KERNEL_DEBUG_TIER=0`).
- **Tier 0 is a real opt-out** (extension stays loaded, kernel side off) — useful in shared configs where some boards must keep `KERNEL_BTF=no` for RAM reasons.
- **`sysrq-serial-trigger` is independent** of the debug tiers; either can be enabled standalone.

## Tests performed

End-to-end on helios64 (rockchip64-edge, kernel 7.0.3-rockchip64):

| Run | Override | Expected | Result |
|---|---|---|---|
| T1 | `KERNEL_DEBUG_TIER=1` (default) | full kernel build, tier 1 markers + sysrq markers | ✓ build OK, kernel 7.0.3-rockchip64, 40m30s |
| T0 | `KERNEL_DEBUG_TIER=0` | extension loaded, no tier-N kconfig changes | ✓ |
| T2 | `KERNEL_DEBUG_TIER=2` | tier 1 + tier 2 (pstore), no tier 3 | ✓ |
| T3 | `KERNEL_DEBUG_TIER=3` | tier 1 + tier 2 + tier 3 (KGDB) | ✓ |
| BTF guard | `KERNEL_BTF=no` (default tier 1) | hard-fail in `extension_prepare_config` | ✓ rc=43, exact error message |
| BTF=no + T0 | `KERNEL_BTF=no KERNEL_DEBUG_TIER=0` | guard skipped, build proceeds | ✓ |

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules (#9750, #9760 — both merged)

Assisted-by: Claude:claude-opus-4.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kernel debug tier system (levels 0–3) with validated tier selection; progressively enables low-cost diagnostics, persistent pstore/ramoops tracing, and optional remote KGDB/KDB serial debug (attach via kgdboc bootarg).
  * Magic SysRq over serial: enables serial SysRq handling, extends boot console prompt window for operator interaction, and forces sysrq=1 in the final image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->