### PR TITLE
Fix cmdline fsck argument

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -226,6 +226,7 @@ config/boards/youyeetoo-r1-v3.csc		@SuperKali
 config/boards/youyeetoo-yy3588.csc		@SuperKali
 config/boards/yy3568.csc		@hqnicolas
 config/boards/zeropi.csc		@igorpecovnik
+config/bootscripts/boot-jethub.cmd		@adeepn
 config/kernel/linux-arm64-*.config		@PeterChrz @rpardini
 config/kernel/linux-bcm2711-*.config		@PanderMusubi @teknoid
 config/kernel/linux-genio-*.config		@HeyMeco
@@ -259,6 +260,7 @@ config/kernel/linux-uefi-arm64-*.config		@rpardini
 config/kernel/linux-uefi-loong64-*.config		@amazingfate
 config/kernel/linux-uefi-x86-*.config		@rpardini
 config/kernel/linux-xpressreal-t3-*.config		@wei633
+extensions/jethub-burn		@adeepn
 patch/atf/atf-arm64/		@PeterChrz @rpardini
 patch/atf/atf-bcm2711/		@PanderMusubi @teknoid
 patch/atf/atf-imx8/		@schmiedelm
@@ -353,11 +355,11 @@ sources/families/jethub.conf		@adeepn
 sources/families/k3-beagle.conf		@Grippy98
 sources/families/k3.conf		@Grippy98 @glneo @jonaswood01
 sources/families/ls1046a.conf		@tomazzaman
-sources/families/meson-axg.conf		@pyavitz
+sources/families/meson-axg.conf		@pyavitz @adeepn
 sources/families/meson-g12a.conf		@engineer-80
 sources/families/meson-g12b.conf		@NicoD-SBC @Tonymac32 @jeanrhum @pyavitz @retro98boy @rpardini
 sources/families/meson-gxbb.conf		@igorpecovnik @teknoid
-sources/families/meson-gxl.conf		@SteeManMI @Tonymac32 @igorpecovnik @jomadeto @retro98boy
+sources/families/meson-gxl.conf		@SteeManMI @Tonymac32 @igorpecovnik @jomadeto @retro98boy @adeepn
 sources/families/meson-s4t7.conf		@adeepn @leggewie @pyavitz @rpardini
 sources/families/meson-sm1.conf		@Tonymac32 @igorpecovnik @rpardini
 sources/families/meson8b.conf		@baldpope @hzyitc @juanlufont

--- a/config/bootscripts/boot-jethub.cmd
+++ b/config/bootscripts/boot-jethub.cmd
@@ -34,7 +34,7 @@ echo "Current fdtfile after armbianEnv: ${fdtfile}"
 
 if test "${console}" = "serial"; then setenv consoleargs "console=ttyAML0,115200n8"; fi
 
-setenv bootargs "root=${rootdev} rootwait rootflags=data=writeback rootfstype=${rootfstype} ${consoleargs} no_console_suspend consoleblank=0 coherent_pool=2M loglevel=${verbosity} fsck.fix=yes fsck.repair=yes net.ifnames=0 ${extraargs} ${extraboardargs}"
+setenv bootargs "root=${rootdev} rootwait rootflags=data=writeback rootfstype=${rootfstype} ${consoleargs} no_console_suspend consoleblank=0 coherent_pool=2M loglevel=${verbosity} fsck.mode=force fsck.repair=yes net.ifnames=0 ${extraargs} ${extraboardargs}"
 
 if test -n "${board_name}"; then setenv bootargs "${bootargs} board=${board}"; fi
 


### PR DESCRIPTION
# Description

This adds cmdline argument `fsck.mode=force` to fix filesystem corruption issues

# How Has This Been Tested?

Built and booted on JetHub boards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tweaked system boot configuration to change how filesystem checks and automatic repairs are handled during startup, improving reliability of initialization.
  * Updated repository maintainer/ownership mappings to reflect current responsibilities for boards and firmware-related components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->