### PR TITLE
rockchip64: fix RK3528 USB2 PHY regmap split for high-speed NCM

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
@@ -21,8 +21,8 @@ next-20250910-rk3528 branch.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 160 ++++++++--
- 1 file changed, 127 insertions(+), 33 deletions(-)
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 162 ++++++++--
+ 1 file changed, 129 insertions(+), 33 deletions(-)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 index 111111111111..222222222222 100644
@@ -141,7 +141,7 @@ index 111111111111..222222222222 100644
  }
  
  static unsigned long
-@@ -1360,27 +1381,18 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1360,27 +1381,20 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  	if (!rphy)
  		return -ENOMEM;
  
@@ -156,7 +156,7 @@ index 111111111111..222222222222 100644
 +		rphy->phy_base = device_node_to_regmap(np);
 +		if (IS_ERR(rphy->phy_base))
 +			return PTR_ERR(rphy->phy_base);
-+		rphy->grf = rphy->phy_base;
++		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
  	} else {
  		rphy->grf = syscon_node_to_regmap(dev->parent->of_node);
 -		if (IS_ERR(rphy->grf))
@@ -173,12 +173,14 @@ index 111111111111..222222222222 100644
 -		rphy->usbgrf = NULL;
 +		rphy->phy_base = rphy->grf;
  	}
-+	if (IS_ERR(rphy->grf))
++	if (IS_ERR(rphy->grf)) {
++		dev_err(dev, "failed to locate usbgrf\n");
 +		return PTR_ERR(rphy->grf);
++	}
  
  	if (of_property_read_u32_index(np, "reg", 0, &reg)) {
  		dev_err(dev, "the reg property is not assigned in %pOFn node\n", np);
-@@ -1521,6 +1533,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
+@@ -1521,6 +1535,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  				BIT(2) << BIT_WRITEABLE_SHIFT | 0);
  }
  
@@ -215,7 +217,7 @@ index 111111111111..222222222222 100644
  static int rk3576_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  {
  	int ret;
-@@ -1934,6 +1976,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
+@@ -1934,6 +1978,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
  	{ /* sentinel */ }
  };
  
@@ -273,7 +275,7 @@ index 111111111111..222222222222 100644
  static const struct rockchip_usb2phy_cfg rk3562_phy_cfgs[] = {
  	{
  		.reg = 0xff740000,
-@@ -2301,6 +2394,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
+@@ -2301,6 +2396,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
  	{ .compatible = "rockchip,rk3328-usb2phy", .data = &rk3328_phy_cfgs },
  	{ .compatible = "rockchip,rk3366-usb2phy", .data = &rk3366_phy_cfgs },
  	{ .compatible = "rockchip,rk3399-usb2phy", .data = &rk3399_phy_cfgs },
@@ -283,4 +285,3 @@ index 111111111111..222222222222 100644
  	{ .compatible = "rockchip,rk3576-usb2phy", .data = &rk3576_phy_cfgs },
 -- 
 Armbian
-

--- a/patch/kernel/archive/rockchip64-6.18/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
@@ -21,8 +21,8 @@ next-20250910-rk3528 branch.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 162 ++++++++--
- 1 file changed, 129 insertions(+), 33 deletions(-)
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 164 ++++++++--
+ 1 file changed, 131 insertions(+), 33 deletions(-)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 index 111111111111..222222222222 100644
@@ -141,7 +141,7 @@ index 111111111111..222222222222 100644
  }
  
  static unsigned long
-@@ -1360,27 +1381,20 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1360,27 +1381,22 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  	if (!rphy)
  		return -ENOMEM;
  
@@ -157,6 +157,10 @@ index 111111111111..222222222222 100644
 +		if (IS_ERR(rphy->phy_base))
 +			return PTR_ERR(rphy->phy_base);
 +		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
++		if (IS_ERR(rphy->grf)) {
++			dev_err(dev, "failed to locate usbgrf\n");
++			return PTR_ERR(rphy->grf);
++		}
  	} else {
  		rphy->grf = syscon_node_to_regmap(dev->parent->of_node);
 -		if (IS_ERR(rphy->grf))
@@ -171,16 +175,14 @@ index 111111111111..222222222222 100644
 -			return PTR_ERR(rphy->usbgrf);
 -	} else {
 -		rphy->usbgrf = NULL;
++		if (IS_ERR(rphy->grf))
++			return PTR_ERR(rphy->grf);
 +		rphy->phy_base = rphy->grf;
  	}
-+	if (IS_ERR(rphy->grf)) {
-+		dev_err(dev, "failed to locate usbgrf\n");
-+		return PTR_ERR(rphy->grf);
-+	}
  
  	if (of_property_read_u32_index(np, "reg", 0, &reg)) {
  		dev_err(dev, "the reg property is not assigned in %pOFn node\n", np);
-@@ -1521,6 +1535,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
+@@ -1521,6 +1537,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  				BIT(2) << BIT_WRITEABLE_SHIFT | 0);
  }
  
@@ -217,7 +219,7 @@ index 111111111111..222222222222 100644
  static int rk3576_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  {
  	int ret;
-@@ -1934,6 +1978,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
+@@ -1934,6 +1980,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
  	{ /* sentinel */ }
  };
  
@@ -275,7 +277,7 @@ index 111111111111..222222222222 100644
  static const struct rockchip_usb2phy_cfg rk3562_phy_cfgs[] = {
  	{
  		.reg = 0xff740000,
-@@ -2301,6 +2396,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
+@@ -2301,6 +2398,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
  	{ .compatible = "rockchip,rk3328-usb2phy", .data = &rk3328_phy_cfgs },
  	{ .compatible = "rockchip,rk3366-usb2phy", .data = &rk3366_phy_cfgs },
  	{ .compatible = "rockchip,rk3399-usb2phy", .data = &rk3399_phy_cfgs },

--- a/patch/kernel/archive/rockchip64-7.0/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
@@ -21,8 +21,8 @@ next-20250910-rk3528 branch.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 160 ++++++++--
- 1 file changed, 127 insertions(+), 33 deletions(-)
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 162 ++++++++--
+ 1 file changed, 129 insertions(+), 33 deletions(-)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 index 111111111111..222222222222 100644
@@ -141,7 +141,7 @@ index 111111111111..222222222222 100644
  }
  
  static unsigned long
-@@ -1360,27 +1381,18 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1360,27 +1381,20 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  	if (!rphy)
  		return -ENOMEM;
  
@@ -156,7 +156,7 @@ index 111111111111..222222222222 100644
 +		rphy->phy_base = device_node_to_regmap(np);
 +		if (IS_ERR(rphy->phy_base))
 +			return PTR_ERR(rphy->phy_base);
-+		rphy->grf = rphy->phy_base;
++		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
  	} else {
  		rphy->grf = syscon_node_to_regmap(dev->parent->of_node);
 -		if (IS_ERR(rphy->grf))
@@ -173,12 +173,14 @@ index 111111111111..222222222222 100644
 -		rphy->usbgrf = NULL;
 +		rphy->phy_base = rphy->grf;
  	}
-+	if (IS_ERR(rphy->grf))
++	if (IS_ERR(rphy->grf)) {
++		dev_err(dev, "failed to locate usbgrf\n");
 +		return PTR_ERR(rphy->grf);
++	}
  
  	if (of_property_read_u32_index(np, "reg", 0, &reg)) {
  		dev_err(dev, "the reg property is not assigned in %pOFn node\n", np);
-@@ -1521,6 +1533,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
+@@ -1521,6 +1535,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  				BIT(2) << BIT_WRITEABLE_SHIFT | 0);
  }
  
@@ -215,7 +217,7 @@ index 111111111111..222222222222 100644
  static int rk3576_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  {
  	int ret;
-@@ -1934,6 +1976,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
+@@ -1934,6 +1978,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
  	{ /* sentinel */ }
  };
  
@@ -273,7 +275,7 @@ index 111111111111..222222222222 100644
  static const struct rockchip_usb2phy_cfg rk3562_phy_cfgs[] = {
  	{
  		.reg = 0xff740000,
-@@ -2301,6 +2394,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
+@@ -2301,6 +2396,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
  	{ .compatible = "rockchip,rk3328-usb2phy", .data = &rk3328_phy_cfgs },
  	{ .compatible = "rockchip,rk3366-usb2phy", .data = &rk3366_phy_cfgs },
  	{ .compatible = "rockchip,rk3399-usb2phy", .data = &rk3399_phy_cfgs },
@@ -283,4 +285,3 @@ index 111111111111..222222222222 100644
  	{ .compatible = "rockchip,rk3576-usb2phy", .data = &rk3576_phy_cfgs },
 -- 
 Armbian
-

--- a/patch/kernel/archive/rockchip64-7.0/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
@@ -21,8 +21,8 @@ next-20250910-rk3528 branch.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 162 ++++++++--
- 1 file changed, 129 insertions(+), 33 deletions(-)
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 164 ++++++++--
+ 1 file changed, 131 insertions(+), 33 deletions(-)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 index 111111111111..222222222222 100644
@@ -141,7 +141,7 @@ index 111111111111..222222222222 100644
  }
  
  static unsigned long
-@@ -1360,27 +1381,20 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1360,27 +1381,22 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  	if (!rphy)
  		return -ENOMEM;
  
@@ -157,6 +157,10 @@ index 111111111111..222222222222 100644
 +		if (IS_ERR(rphy->phy_base))
 +			return PTR_ERR(rphy->phy_base);
 +		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
++		if (IS_ERR(rphy->grf)) {
++			dev_err(dev, "failed to locate usbgrf\n");
++			return PTR_ERR(rphy->grf);
++		}
  	} else {
  		rphy->grf = syscon_node_to_regmap(dev->parent->of_node);
 -		if (IS_ERR(rphy->grf))
@@ -171,16 +175,14 @@ index 111111111111..222222222222 100644
 -			return PTR_ERR(rphy->usbgrf);
 -	} else {
 -		rphy->usbgrf = NULL;
++		if (IS_ERR(rphy->grf))
++			return PTR_ERR(rphy->grf);
 +		rphy->phy_base = rphy->grf;
  	}
-+	if (IS_ERR(rphy->grf)) {
-+		dev_err(dev, "failed to locate usbgrf\n");
-+		return PTR_ERR(rphy->grf);
-+	}
  
  	if (of_property_read_u32_index(np, "reg", 0, &reg)) {
  		dev_err(dev, "the reg property is not assigned in %pOFn node\n", np);
-@@ -1521,6 +1535,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
+@@ -1521,6 +1537,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  				BIT(2) << BIT_WRITEABLE_SHIFT | 0);
  }
  
@@ -217,7 +219,7 @@ index 111111111111..222222222222 100644
  static int rk3576_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  {
  	int ret;
-@@ -1934,6 +1978,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
+@@ -1934,6 +1980,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
  	{ /* sentinel */ }
  };
  
@@ -275,7 +277,7 @@ index 111111111111..222222222222 100644
  static const struct rockchip_usb2phy_cfg rk3562_phy_cfgs[] = {
  	{
  		.reg = 0xff740000,
-@@ -2301,6 +2396,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
+@@ -2301,6 +2398,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
  	{ .compatible = "rockchip,rk3328-usb2phy", .data = &rk3328_phy_cfgs },
  	{ .compatible = "rockchip,rk3366-usb2phy", .data = &rk3366_phy_cfgs },
  	{ .compatible = "rockchip,rk3399-usb2phy", .data = &rk3399_phy_cfgs },

--- a/patch/kernel/archive/rockchip64-7.1/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
@@ -21,8 +21,8 @@ next-20250910-rk3528 branch.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 160 ++++++++--
- 1 file changed, 127 insertions(+), 33 deletions(-)
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 162 ++++++++--
+ 1 file changed, 129 insertions(+), 33 deletions(-)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 index 111111111111..222222222222 100644
@@ -141,7 +141,7 @@ index 111111111111..222222222222 100644
  }
  
  static unsigned long
-@@ -1360,27 +1381,18 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1360,27 +1381,20 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  	if (!rphy)
  		return -ENOMEM;
  
@@ -156,7 +156,7 @@ index 111111111111..222222222222 100644
 +		rphy->phy_base = device_node_to_regmap(np);
 +		if (IS_ERR(rphy->phy_base))
 +			return PTR_ERR(rphy->phy_base);
-+		rphy->grf = rphy->phy_base;
++		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
  	} else {
  		rphy->grf = syscon_node_to_regmap(dev->parent->of_node);
 -		if (IS_ERR(rphy->grf))
@@ -173,12 +173,14 @@ index 111111111111..222222222222 100644
 -		rphy->usbgrf = NULL;
 +		rphy->phy_base = rphy->grf;
  	}
-+	if (IS_ERR(rphy->grf))
++	if (IS_ERR(rphy->grf)) {
++		dev_err(dev, "failed to locate usbgrf\n");
 +		return PTR_ERR(rphy->grf);
++	}
  
  	if (of_property_read_u32_index(np, "reg", 0, &reg)) {
  		dev_err(dev, "the reg property is not assigned in %pOFn node\n", np);
-@@ -1521,6 +1533,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
+@@ -1521,6 +1535,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  				BIT(2) << BIT_WRITEABLE_SHIFT | 0);
  }
  
@@ -215,7 +217,7 @@ index 111111111111..222222222222 100644
  static int rk3576_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  {
  	int ret;
-@@ -1934,6 +1976,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
+@@ -1934,6 +1978,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
  	{ /* sentinel */ }
  };
  
@@ -273,7 +275,7 @@ index 111111111111..222222222222 100644
  static const struct rockchip_usb2phy_cfg rk3562_phy_cfgs[] = {
  	{
  		.reg = 0xff740000,
-@@ -2301,6 +2394,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
+@@ -2301,6 +2396,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
  	{ .compatible = "rockchip,rk3328-usb2phy", .data = &rk3328_phy_cfgs },
  	{ .compatible = "rockchip,rk3366-usb2phy", .data = &rk3366_phy_cfgs },
  	{ .compatible = "rockchip,rk3399-usb2phy", .data = &rk3399_phy_cfgs },
@@ -283,4 +285,3 @@ index 111111111111..222222222222 100644
  	{ .compatible = "rockchip,rk3576-usb2phy", .data = &rk3576_phy_cfgs },
 -- 
 Armbian
-

--- a/patch/kernel/archive/rockchip64-7.1/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
@@ -21,8 +21,8 @@ next-20250910-rk3528 branch.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 162 ++++++++--
- 1 file changed, 129 insertions(+), 33 deletions(-)
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 164 ++++++++--
+ 1 file changed, 131 insertions(+), 33 deletions(-)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 index 111111111111..222222222222 100644
@@ -141,7 +141,7 @@ index 111111111111..222222222222 100644
  }
  
  static unsigned long
-@@ -1360,27 +1381,20 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1360,27 +1381,22 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  	if (!rphy)
  		return -ENOMEM;
  
@@ -157,6 +157,10 @@ index 111111111111..222222222222 100644
 +		if (IS_ERR(rphy->phy_base))
 +			return PTR_ERR(rphy->phy_base);
 +		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
++		if (IS_ERR(rphy->grf)) {
++			dev_err(dev, "failed to locate usbgrf\n");
++			return PTR_ERR(rphy->grf);
++		}
  	} else {
  		rphy->grf = syscon_node_to_regmap(dev->parent->of_node);
 -		if (IS_ERR(rphy->grf))
@@ -171,16 +175,14 @@ index 111111111111..222222222222 100644
 -			return PTR_ERR(rphy->usbgrf);
 -	} else {
 -		rphy->usbgrf = NULL;
++		if (IS_ERR(rphy->grf))
++			return PTR_ERR(rphy->grf);
 +		rphy->phy_base = rphy->grf;
  	}
-+	if (IS_ERR(rphy->grf)) {
-+		dev_err(dev, "failed to locate usbgrf\n");
-+		return PTR_ERR(rphy->grf);
-+	}
  
  	if (of_property_read_u32_index(np, "reg", 0, &reg)) {
  		dev_err(dev, "the reg property is not assigned in %pOFn node\n", np);
-@@ -1521,6 +1535,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
+@@ -1521,6 +1537,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  				BIT(2) << BIT_WRITEABLE_SHIFT | 0);
  }
  
@@ -217,7 +219,7 @@ index 111111111111..222222222222 100644
  static int rk3576_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  {
  	int ret;
-@@ -1934,6 +1978,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
+@@ -1934,6 +1980,57 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
  	{ /* sentinel */ }
  };
  
@@ -275,7 +277,7 @@ index 111111111111..222222222222 100644
  static const struct rockchip_usb2phy_cfg rk3562_phy_cfgs[] = {
  	{
  		.reg = 0xff740000,
-@@ -2301,6 +2396,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
+@@ -2301,6 +2398,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
  	{ .compatible = "rockchip,rk3328-usb2phy", .data = &rk3328_phy_cfgs },
  	{ .compatible = "rockchip,rk3366-usb2phy", .data = &rk3366_phy_cfgs },
  	{ .compatible = "rockchip,rk3399-usb2phy", .data = &rk3399_phy_cfgs },


### PR DESCRIPTION
## Problem

Images built since our PR #9500 broke USB-C NCM on NanoPi Zero2:

- UDC `state=default`, `current_speed=full-speed` (12 Mbps)
- `usb0` DOWN / NO-CARRIER
- Windows host: no usable `UsbNcm Host Device`

USB-C NCM is the canonical user-facing USB gadget configuration on the NanoPi Zero2, so this regression effectively breaks the board's USB-Ethernet interface for any downstream that relies on it.

## Root cause

`rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch` (merged in #9500) introduced `phy_base` for RK3528's standalone PHY MMIO window correctly, but also assigned:

```c
rphy->grf = rphy->phy_base;
```

when the DT node carried `rockchip,usbgrf`. That collapsed the GRF/syscon regmap onto the standalone PHY MMIO. Code that logically uses `rphy->grf` for port-control fields then accesses the wrong register window. The patch's own commit message already named the right topology — this just brings the code in line with that description.

## Fix

```diff
-	rphy->grf = rphy->phy_base;
+	rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
```

plus the matching `IS_ERR(rphy->grf)` failure path. Older SoC layouts that don't carry `rockchip,usbgrf` keep the existing parent-syscon fallback.

Applied identically to **`rockchip64-6.18`**, **`rockchip64-7.0`**, and **`rockchip64-7.1`** (the latter inherited the bug from the recent `9d967eccf rockchip64: copy patchset from 7.0 to 7.1`).

## Test results:  NanoPi Zero2

| | Bad images (Apr 5 6.18.21, Apr 7 6.18.20) | This patch |
|---|---|---|
| UDC state | `default` | **`configured`** |
| `current_speed` | `full-speed` | **`high-speed`** |
| `usb0` | DOWN / NO-CARRIER | **UP, `10.10.10.1/24`** |
| Windows | no `UsbNcm Host Device` | **`UsbNcm Host Device #5`, Up, `426.0 Mbps`** |
| Ping board IPv6 link-local | fail | **3/3, 0% loss, ≤1 ms** |

The decisive boundary test was an Apr 7 image built at the same `v6.18.20` kernel tag as the known-good 2026-03-25 image — both reproduced the bug at the same kernel source rev, ruling out kernel-stable / toolchain hypotheses and pinning the regression to this patch's `grf = phy_base` assignment.

Hardware-validated 2026-05-03 with image revision `26.05.0-rk3528grf2`.

## Out of scope

A separate `u_ether` NULL-deref on gadget teardown (`eth_get_drvinfo`) is tracked in #9608; this PR doesn't try to address that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for RK3528 USB2 PHY, enabling proper USB2 device connectivity and initialization on RK3528 systems.
  * Improves USB2 clock-output control to match RK3528 hardware behavior.
  * Introduces RK3528-specific PHY tuning for better suspend behavior and high-speed signal integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->