### PR TITLE
prepare-host: support Ubuntu resolute's qemu-user packaging changes

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -175,7 +175,7 @@ function adaptative_prepare_host_dependencies() {
 		ncurses-base ncurses-term # for `make menuconfig`
 		ntpsec-ntpdate #this is a more secure ntpdate
 		patchutils pkg-config pv
-		"qemu-user-static" "arch-test"
+		"arch-test"
 		rsync
 		swig # swig is needed for some u-boot's. example: "bananapi.conf"
 		u-boot-tools
@@ -212,6 +212,19 @@ function adaptative_prepare_host_dependencies() {
 		display_alert "Adding package to 'host_dependencies'" "python3-setuptools" "info"
 		host_dependencies+=("python3-setuptools")
 	fi
+
+	# qemu binfmt + chrooted user emulation.
+	# Up to and including Ubuntu noble / Debian trixie this is the
+	# `qemu-user-static` package (real package shipping the static
+	# /usr/libexec/qemu-binfmt/<arch>-static binaries). Ubuntu resolute
+	# (26.04) splits that into `qemu-user-binfmt` + `qemu-user-binfmt-hwe`
+	# and turns `qemu-user-static` into a virtual package — apt then
+	# refuses to auto-pick a provider, so install the non-HWE concrete
+	# name explicitly there.
+	case "${host_release}" in
+		resolute) host_dependencies+=("qemu-user-binfmt") ;;
+		*)        host_dependencies+=("qemu-user-static") ;;
+	esac
 
 	### Python2 -- required for some older u-boot builds
 	# Debian newer than 'bookworm' and Ubuntu newer than 'lunar'/'mantic' does not carry python2 anymore; in this case some u-boot's might fail to build.

--- a/lib/functions/rootfs/qemu-static.sh
+++ b/lib/functions/rootfs/qemu-static.sh
@@ -17,9 +17,27 @@ function deploy_qemu_binary_to_chroot() {
 		return 0
 	fi
 
-	declare src_host="/usr/bin/${QEMU_BINARY}"
+	# Source: try the historical name first (qemu-<arch>-static), fall back
+	# to the bare name shipped by Ubuntu resolute's qemu-user-binfmt package
+	# (e.g. /usr/bin/qemu-aarch64).
+	declare qemu_no_suffix="${QEMU_BINARY%-static}"
+	declare src_host=""
+	if [[ -f "/usr/bin/${QEMU_BINARY}" ]]; then
+		src_host="/usr/bin/${QEMU_BINARY}"
+	elif [[ -f "/usr/bin/${qemu_no_suffix}" ]]; then
+		src_host="/usr/bin/${qemu_no_suffix}"
+	else
+		exit_with_error "Missing qemu binary on host: tried /usr/bin/${QEMU_BINARY} and /usr/bin/${qemu_no_suffix}"
+	fi
+
+	# Destination: deploy under both names so the chroot resolves whichever
+	# path the host's binfmt registration points at — the older qemu-user-
+	# static package registers /usr/bin/qemu-<arch>-static, while resolute's
+	# qemu-user-binfmt registers /usr/bin/qemu-<arch>.
 	declare dst_target="${chroot_target}/usr/bin/${QEMU_BINARY}"
+	declare dst_target_alt="${chroot_target}/usr/bin/${qemu_no_suffix}"
 	declare dst_target_bkp="${dst_target}.armbian.orig"
+	declare dst_target_alt_bkp="${dst_target_alt}.armbian.orig"
 
 	# Assume we're getting a clean base to work with. Namely, we count on the rootfs cache to _not_ have left a dangling binary.
 	# If the dst_target already exists, it means the target actually has the qemu-static package installed.
@@ -28,9 +46,16 @@ function deploy_qemu_binary_to_chroot() {
 		display_alert "Preserving existing qemu binary" "${QEMU_BINARY} during ${caller}" "info"
 		run_host_command_logged mv -v "${dst_target}" "${dst_target_bkp}"
 	fi
+	if [[ "${dst_target}" != "${dst_target_alt}" && -f "${dst_target_alt}" ]]; then
+		display_alert "Preserving existing qemu binary" "${qemu_no_suffix} during ${caller}" "info"
+		run_host_command_logged mv -v "${dst_target_alt}" "${dst_target_alt_bkp}"
+	fi
 
-	display_alert "Deploying qemu-user-static binary to chroot" "${QEMU_BINARY} during ${caller}" "info"
+	display_alert "Deploying qemu-user-static binary to chroot" "${QEMU_BINARY} during ${caller} (from ${src_host})" "info"
 	run_host_command_logged cp -pv "${src_host}" "${dst_target}"
+	if [[ "${dst_target}" != "${dst_target_alt}" ]]; then
+		run_host_command_logged cp -pv "${src_host}" "${dst_target_alt}"
+	fi
 
 	return 0
 }
@@ -45,8 +70,11 @@ function undeploy_qemu_binary_from_chroot() {
 		return 0
 	fi
 
+	declare qemu_no_suffix="${QEMU_BINARY%-static}"
 	declare dst_target="${chroot_target}/usr/bin/${QEMU_BINARY}"
+	declare dst_target_alt="${chroot_target}/usr/bin/${qemu_no_suffix}"
 	declare dst_target_bkp="${dst_target}.armbian.orig"
+	declare dst_target_alt_bkp="${dst_target_alt}.armbian.orig"
 
 	# Check the binary we deployed is there. If not, panic, as we've lost control.
 	if [[ ! -f "${dst_target}" ]]; then
@@ -56,10 +84,17 @@ function undeploy_qemu_binary_from_chroot() {
 	# Remove the binary we deployed, and restore the original if we had to preserve it.
 	display_alert "Removing qemu-user-static binary from chroot" "${QEMU_BINARY} during ${caller}" "info"
 	run_host_command_logged rm -fv "${dst_target}"
+	if [[ "${dst_target}" != "${dst_target_alt}" && -f "${dst_target_alt}" ]]; then
+		run_host_command_logged rm -fv "${dst_target_alt}"
+	fi
 
 	if [[ -f "${dst_target_bkp}" ]]; then
 		display_alert "Restoring original qemu binary" "${QEMU_BINARY} during ${caller}" "info"
 		run_host_command_logged mv -v "${dst_target_bkp}" "${dst_target}"
+	fi
+	if [[ "${dst_target}" != "${dst_target_alt}" && -f "${dst_target_alt_bkp}" ]]; then
+		display_alert "Restoring original qemu binary" "${qemu_no_suffix} during ${caller}" "info"
+		run_host_command_logged mv -v "${dst_target_alt_bkp}" "${dst_target_alt}"
 	fi
 
 	return 0


### PR DESCRIPTION
## Summary

Two changes, both required for `armbian/build` to run on Ubuntu 26.04 (resolute) hosts and for the daily framework Docker image to build there:

1. **Package name** — `qemu-user-static` is virtual on resolute (split into `qemu-user-binfmt` + `qemu-user-binfmt-hwe`). apt refuses to auto-pick a provider, so `apt-get install` errors out:

   ```
   E: Package 'qemu-user-static' has no installation candidate
   ```

   Match the existing python2 release-conditional pattern in [`prepare-host.sh`](lib/functions/host/prepare-host.sh) and pick `qemu-user-binfmt` on resolute. Older releases keep `qemu-user-static`.

2. **Binary name** (raised by @pyavitz) — `qemu-user-binfmt` ships the binaries **without** the `-static` suffix: `/usr/bin/qemu-aarch64` instead of `/usr/bin/qemu-aarch64-static`. The chroot-deploy code in [`qemu-static.sh`](lib/functions/rootfs/qemu-static.sh) hardcoded the historical name and would fail on resolute hosts even with the apt fix in (1).

   - `deploy_qemu_binary_to_chroot`: resolve the source path by trying `/usr/bin/${QEMU_BINARY}` first, fall back to the bare name. Copy the binary to **both** names inside the chroot, so whichever path the host's binfmt registration points at resolves at chroot time. The old `qemu-user-static` package registered the `-static` name; the new `qemu-user-binfmt` registers the bare name.
   - `undeploy_qemu_binary_from_chroot`: remove and restore both names symmetrically.

   `runners.sh` already had a fallback for executing host-side x86 binaries; this PR brings the chroot-side code into parity.

`QEMU_BINARY` itself stays as `qemu-<arch>-static` in the per-arch configs — the host-side resolution and the chroot-side dual-deploy mean the rest of the build framework can keep using the historical name.

## How to verify

Reproducer that hit (1) in CI:

- [armbian/docker-armbian-build run #25553428098 / job 75006555424](https://github.com/armbian/docker-armbian-build/actions/runs/25553428098/job/75006555424) — `armbian-ubuntu-resolute-amd64-latest` failing in `apt-get install`.
- Triggered by [armbian/docker-armbian-build#26](https://github.com/armbian/docker-armbian-build/pull/26) which adds resolute to the daily framework-image matrix.

Once this PR lands and the docker-armbian-build daily run picks it up, both `armbian-ubuntu-resolute-amd64-latest` and `armbian-ubuntu-resolute-arm64-latest` should build cleanly.

## Test plan

- [x] `./compile.sh requirements` on a resolute host completes without the `no installation candidate` error.
- [ ] On a resolute host, an actual cross-arch image build (e.g. `BOARD=uefi-arm64`) successfully copies the qemu binary into the chroot under both `qemu-aarch64` and `qemu-aarch64-static`, and chrooted commands run.
- [ ] On jammy / noble / bookworm / trixie hosts, the installed package set and chroot deploy paths are unchanged.
- [ ] After merge, the next daily run of `docker-armbian-build`'s `update_docker.yml` produces `armbian-ubuntu-resolute-{amd64,arm64}-latest` and joins them into `armbian-ubuntu-resolute-latest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed QEMU emulation dependency selection to use the appropriate package variant based on host distribution, improving compatibility.
  * Improved deployment and removal of QEMU binaries inside chroots to preserve alternate binary names and restore original backups, reducing emulation breakage during install/uninstall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->