### PR TITLE
action: leave torrent URLs empty in per-image asset manifests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -399,12 +399,16 @@ runs:
 
         # ── URL composition ──────────────────────────────────────────────────
         def signature_urls(base):
-            """Return (base, base.asc, base.sha, base.torrent)."""
-            return base, f"{base}.asc", f"{base}.sha", f"{base}.torrent"
+            """Return (base, base.asc, base.sha, ""). The build never
+            produces a .torrent for the assets it ships, so the torrent
+            slot is always empty — the field is kept for schema parity
+            with the canonical armbian-images.json index.
+            """
+            return base, f"{base}.asc", f"{base}.sha", ""
 
         def build_urls(parsed, image_format, img_name):
-            """Compose file_url + redi_url (each with its .asc/.sha/.torrent
-            siblings).
+            """Compose file_url + redi_url (each with its .asc/.sha
+            siblings; torrent slot is always empty — see signature_urls).
 
             Two URL shapes, selected by DOWNLOAD_REPO:
               non-empty -> {base}/{board}/{repo}/{filename}    dl.armbian.com style


### PR DESCRIPTION
## Summary

The composite action publishes images plus their `.asc` and `.sha` siblings, but it **never produces a `.torrent`** for any artefact it ships. Despite that, the per-image `<image>.assets.json` manifest emitted by the manifest step always wrote constructed URLs into `file_url_torrent` and `redi_url_torrent` by appending `.torrent` to the file URL — so consumers of the manifest were greeted with URLs that 404.

This PR makes those two fields empty strings in manifests produced by this action, while keeping the field names present so the schema still matches the canonical `armbian-images.json` index that `armbian.github.io` publishes.

Ref: https://github.com/armbian/website/issues/21

## Change

[`action.yml`](action.yml) → `signature_urls()` returns `(base, base.asc, base.sha, "")` instead of `(base, base.asc, base.sha, base.torrent)`. Both `file_url_torrent` and `redi_url_torrent` flow from this single helper, so they both become `""`. Docstrings updated to spell out the convention.

If/when torrents ever start being produced by the action, only this helper needs to change.

## Test plan

- [x] Re-run a producer workflow (e.g. [armbian/sdk](https://github.com/armbian/sdk)) on its `armbian/build@main` pin.
- [x] Inspect any `<image>.assets.json` from the resulting release: `file_url_torrent` and `redi_url_torrent` are `""` (still present).
- [x] `file_url_asc`, `file_url_sha`, `redi_url_asc`, `redi_url_sha` are unchanged in shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Torrent URLs are no longer included in release asset manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->