### PR TITLE
Replacing rk35xx-montjoie-crypto-v2-rk35xx.patch with rk35xx-crypto-v3.patch

### DIFF
--- a/patch/kernel/archive/rockchip64-7.0/rk35xx-crypto-v3.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk35xx-crypto-v3.patch
@@ -1,19 +1,68 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe@baylibre.com>
-Date: Tue, 7 Nov 2023 15:55:27 +0000
-Subject: dt-bindings: crypto: add support for rockchip,crypto-rk3588
+From: Dawid Olesinski <dawidro@gmail.com>
+Date: Sun, 10 May 2026 00:00:00 +0100
+Subject: [PATCH] Updated RK3588 crypto patch
 
-Add device tree binding documentation for the Rockchip cryptographic
-offloader V2.
+Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
+Clock names corrected. Original had "a" and "h" as clock-names items. v3 corrects them to "core", "aclk", "hclk" matching the actual clock signal names in the hardware and passing make dt_binding_check.
+YAML example reg size fixed. Original example said 0x4000 (16KB). v3 corrects to 0x2000 (8KB) to match both DTS nodes and the actual hardware register map.
 
-Signed-off-by: Corentin Labbe <clabbe@baylibre.com>
----
- Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml | 65 ++++++++++
- 1 file changed, 65 insertions(+)
+drivers/crypto/Makefile
+Root Makefile hook added. v3 adds obj-$(CONFIG_CRYPTO_DEV_ROCKCHIP2) += rockchip/ to the root crypto Makefile. Without this, if CONFIG_CRYPTO_DEV_ROCKCHIP (the V1 driver) is disabled, the build system never descends into drivers/crypto/rockchip/ and the V2 driver silently doesn't build regardless of Kconfig selection.
+
+rk2_crypto.h
+dbgfs_info field added to struct rockchip_ip. Original was missing it, causing register_debugfs to overwrite dbgfs_stats with the info file pointer. v3 adds struct dentry *dbgfs_info as the third debugfs member.
+#include <linux/reset.h> added. Moved from rk2_crypto.c so that rk2_crypto_ahash.c and rk2_crypto_skcipher.c can call reset_control_assert/deassert directly in their DMA error recovery paths.
+fallback_req ordering documented. Added // keep at the end comment on struct skcipher_request fallback_req in rk2_cipher_rctx. Same ordering maintained in rk2_ahash_rctx with struct ahash_request fallback_req as last member — required for the flexible array __ctx placement to work correctly.
+
+Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
+Clock names corrected. Original had "a" and "h" as clock-names items. v3 corrects them to "core", "aclk", "hclk" matching the actual clock signal names in the hardware and passing make dt_binding_check.
+YAML example reg size fixed. Original example said 0x4000 (16KB). v3 corrects to 0x2000 (8KB) to match both DTS nodes and the actual hardware register map.
+
+drivers/crypto/Makefile
+Root Makefile hook added. v3 adds obj-$(CONFIG_CRYPTO_DEV_ROCKCHIP2) += rockchip/ to the root crypto Makefile. Without this, if CONFIG_CRYPTO_DEV_ROCKCHIP (the V1 driver) is disabled, the build system never descends into drivers/crypto/rockchip/ and the V2 driver silently doesn't build regardless of Kconfig selection.
+
+rk2_crypto.h
+dbgfs_info field added to struct rockchip_ip. Original was missing it, causing register_debugfs to overwrite dbgfs_stats with the info file pointer. v3 adds struct dentry *dbgfs_info as the third debugfs member.
+#include <linux/reset.h> added. Moved from rk2_crypto.c so that rk2_crypto_ahash.c and rk2_crypto_skcipher.c can call reset_control_assert/deassert directly in their DMA error recovery paths.
+fallback_req ordering documented. Added // keep at the end comment on struct skcipher_request fallback_req in rk2_cipher_rctx. Same ordering maintained in rk2_ahash_rctx with struct ahash_request fallback_req as last member — required for the flexible array __ctx placement to work correctly.
+
+rk2_crypto_ahash.c
+Multi-SG hardware fallback. Added if (sg_nents(areq->src) > 1) check at the top of rk2_ahash_need_fallback. The RK3568/3588 hardware padding engine (HW_PAD) loses block-count state across LLI descriptor boundaries, producing wrong digests for any multi-SG request. Single-SG requests continue to use hardware; multi-SG routes to software fallback and increments stat_fb_sgdiff.
+Explicit payload length for hardware padding. Added writel(areq->nbytes, rkc->reg + RK2_CRYPTO_CH0_PC_LEN_0) before starting DMA. The HW_PAD bit requires the total message length to be programmed in advance so the hardware knows where to apply the Merkle–Damgård padding. Without this, single-SG hardware hashes would also produce wrong results.
+INT_EN write-enable mask fixed. Original wrote RK2_CRYPTO_DMA_INT_LISTDONE | 0x7F with no upper bits, which is silently discarded by the HIWORD_UPDATE register pattern. v3 first clears stale pending interrupts (writel(0x7F, DMA_INT_ST)), then writes 0x007F007F so enable bits and their write-enable mask are both set.
+LIST_INT added to last LLI descriptor. LISTDONE (BIT(0)) is only set in DMA_INT_ST when the last LLI entry has RK2_LLI_DMA_CTRL_LIST_INT (BIT(8)) set in dma_ctrl. Without it, DMA completes silently, no interrupt fires, 2-second timeout every request. v3 adds RK2_LLI_DMA_CTRL_LIST_INT | RK2_LLI_DMA_CTRL_SRC_INT to the last descriptor.
+Uninterruptible completion wait. Changed from wait_for_completion_interruptible_timeout to wait_for_completion_timeout. The interruptible variant can return early on SIGTERM/SIGKILL while DMA is still writing to memory, causing data corruption or use-after-free.
+timeout return value captured and checked. Original discarded the return value, making timeout undetectable. v3 stores the return in unsigned long timeout and checks !timeout for ETIMEDOUT, then separately checks !rkc->status for EIO.
+rctx->nrsgs = 0 initialised before dma_map_sg. Ensures rk2_hash_unprepare never calls dma_unmap_sg on an uninitialised count.
+Safe dma_unmap_sg in unprepare. Added if (rctx->nrsgs) guard before dma_unmap_sg, preventing a kernel panic if dma_map_sg failed in the prepare step.
+MAX_LLI overflow check. Added if (ddi >= MAX_LLI) at the top of the LLI build loop with dev_err and -EINVAL. Prevents overflowing the DMA-coherent LLI table with a scatter-list longer than 20 entries.
+readl_poll_timeout_atomic return value checked. Original discarded the return, allowing wrong digest output if HASH_VALID never set. v3 assigns to err and jumps to theend on timeout.
+be32_to_cpu in digest readback. Hardware outputs all digest words (SHA1, SHA256, SHA384, SHA512, SM3, MD5) in big-endian register format. readl() on LE ARM64 gives a byte-swapped value; be32_to_cpu corrects it before put_unaligned_le32.
+pm_runtime_mark_last_busy before put_autosuspend. Refreshes the autosuspend timer on each request completion so the device doesn't suspend between back-to-back requests.
+DMA error hardware reset. On !rkc->status (DMA error interrupt), v3 performs reset_control_assert/udelay(10)/reset_control_deassert to recover the DMA engine from a stuck state before returning -EIO.
+crypto_ahash_set_statesize promotion in rk2_hash_init_tfm. After allocating the fallback, v3 queries its statesize and promotes the template's statesize if the fallback needs more space. Fixes -EOVERFLOW on export()/import() when ARM Crypto Extensions drivers (sha1-ce, sha256-ce) advertise a larger statesize than the raw hash state.
+
+rk2_crypto_skcipher.c
+rk2_print gated with #ifdef CONFIG_CRYPTO_DEV_ROCKCHIP2_DEBUG. Register dumps on every DMA error flood production logs. v3 wraps the entire function and its callsite with the debug config guard.
+OTP KEY VALID bit corrected. Original checked BIT(2) for both HASH BUSY and OTP KEY VALID (copy-paste error). v3 uses BIT(3) for OTP KEY VALID.
+Multi-bit switch statements corrected. All field switches now use (v >> N) & mask before comparing case values, fixing cases that could never match after masking.
+dd->dma_ctrl =  assignment not |=. The LLI table persists across requests. Using |= accumulates stale flag bits from previous requests. v3 uses = for the initial value.
+RK2_CRYPTO_DMA_CTL_START << 16 not literal 1 << 16. Ensures the write-enable mask is always correct regardless of the constant value.
+get_rk2_crypto() with null check for cipher. Original used algt->dev (always first device) for all cipher requests, bypassing load balancing. v3 uses get_rk2_crypto() matching the hash path, with if (!rkc) return -ENODEV.
+DMA unmap moved before timeout/error checks. Original goto theend on timeout bypassed dma_unmap_sg, permanently leaking the mapping. v3 unmaps unconditionally before checking results.
+wait_for_completion_timeout (uninterruptible). Same fix as hash — prevents signal interruption while DMA is active.
+Separate timeout/error errnos. ETIMEDOUT for timeout, EIO for DMA error with rk2_print debug dump.
+INT_EN write-enable mask + stale clear. Same fix as hash path: writel(0x7F, DMA_INT_ST) then writel(0x007F007F, DMA_INT_EN).
+LIST_INT added to cipher descriptor. RK2_LLI_DMA_CTRL_LIST_INT added to dd->dma_ctrl so LISTDONE fires in DMA_INT_ST.
+pm_runtime_mark_last_busy before put_autosuspend.
+DMA error hardware reset. Same reset_control_assert/deassert recovery as hash.
+Fallback log changed to dev_dbg. Original dev_info in rk2_cipher_tfm_init flooded logs during PM stress testing (hundreds of TFM allocations per second). v3 uses dev_dbg.
+
+Stricter XTS fallback check. Changed sg_nents(areq->src) > 1 to != 1 for the XTS-specific SG check. XTS requires exactly one contiguous buffer — more than one SG is wrong but so is zero.
 
 diff --git a/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..e9c08df7603e
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
 @@ -0,0 +1,65 @@
@@ -46,8 +95,8 @@ index 000000000000..111111111111
 +  clock-names:
 +    items:
 +      - const: core
-+      - const: a
-+      - const: h
++      - const: aclk
++      - const: hclk
 +
 +  resets:
 +    minItems: 1
@@ -74,32 +123,39 @@ index 000000000000..111111111111
 +    #include <dt-bindings/reset/rockchip,rk3588-cru.h>
 +    crypto@fe370000 {
 +      compatible = "rockchip,rk3588-crypto";
-+      reg = <0xfe370000 0x4000>;
++      reg = <0xfe370000 0x2000>;
 +      interrupts = <GIC_SPI 209 IRQ_TYPE_LEVEL_HIGH 0>;
 +      clocks = <&scmi_clk SCMI_CRYPTO_CORE>, <&scmi_clk SCMI_ACLK_SECURE_NS>,
 +               <&scmi_clk SCMI_HCLK_SECURE_NS>;
-+      clock-names = "core", "a", "h";
-+      resets = <&scmi_reset SRST_CRYPTO_CORE>;
++      clock-names = "core", "aclk", "hclk";
++      resets = <&scmi_reset SCMI_SRST_CRYPTO_CORE>;
 +      reset-names = "core";
 +    };
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe@baylibre.com>
-Date: Tue, 7 Nov 2023 15:55:29 +0000
-Subject: ARM64: dts: rk3588: add crypto node
-
-The rk3588 has a crypto IP handled by the rk3588 crypto driver so adds a
-node for it.
-
-Signed-off-by: Corentin Labbe <clabbe@baylibre.com>
----
- arch/arm64/boot/dts/rockchip/rk3588-base.dtsi | 12 ++++++++++
- 1 file changed, 12 insertions(+)
-
+diff --git a/arch/arm64/boot/dts/rockchip/rk356x-base.dtsi b/arch/arm64/boot/dts/rockchip/rk356x-base.dtsi
+index 441f638e7367..079dba03d64b 100644
+--- a/arch/arm64/boot/dts/rockchip/rk356x-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk356x-base.dtsi
+@@ -1137,6 +1137,18 @@ rng: rng@fe388000 {
+ 		status = "disabled";
+ 	};
+ 
++	crypto: crypto@fe380000 {
++		compatible = "rockchip,rk3568-crypto";
++		reg = <0x0 0xfe380000 0x0 0x2000>;
++		interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
++		clocks = <&cru CLK_CRYPTO_NS_CORE>, <&cru ACLK_CRYPTO_NS>,
++			 <&cru HCLK_CRYPTO_NS>;
++		clock-names = "core", "aclk", "hclk";
++		resets = <&cru SRST_CRYPTO_NS_CORE>;
++		reset-names = "core";
++		status = "okay";
++	};
++
+ 	i2s0_8ch: i2s@fe400000 {
+ 		compatible = "rockchip,rk3568-i2s-tdm";
+ 		reg = <0x0 0xfe400000 0x0 0x1000>;
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-index 111111111111..222222222222 100644
+index 199f10fbd0bb..17dff56722ef 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 @@ -2268,6 +2268,18 @@ rng@fe378000 {
@@ -113,7 +169,7 @@ index 111111111111..222222222222 100644
 +		clocks = <&scmi_clk SCMI_CRYPTO_CORE>, <&scmi_clk SCMI_ACLK_SECURE_NS>,
 +			 <&scmi_clk SCMI_HCLK_SECURE_NS>;
 +		clock-names = "core", "aclk", "hclk";
-+		resets = <&scmi_reset SRST_CRYPTO_CORE>;
++		resets = <&scmi_reset SCMI_SRST_CRYPTO_CORE>;
 +		reset-names = "core";
 +		status = "okay";
 +	};
@@ -121,68 +177,8 @@ index 111111111111..222222222222 100644
  	i2s0_8ch: i2s@fe470000 {
  		compatible = "rockchip,rk3588-i2s-tdm";
  		reg = <0x0 0xfe470000 0x0 0x1000>;
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe@baylibre.com>
-Date: Tue, 7 Nov 2023 15:55:30 +0000
-Subject: ARM64: dts: rk356x: add crypto node
-
-Both RK3566 and RK3568 have a crypto IP handled by the rk3588 crypto driver so adds a
-node for it.
-
-Tested-by: Ricardo Pardini <ricardo@pardini.net>
-Signed-off-by: Corentin Labbe <clabbe@baylibre.com>
----
- arch/arm64/boot/dts/rockchip/rk356x-base.dtsi | 12 ++++++++++
- 1 file changed, 12 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk356x-base.dtsi b/arch/arm64/boot/dts/rockchip/rk356x-base.dtsi
-index 111111111111..222222222222 100644
---- a/arch/arm64/boot/dts/rockchip/rk356x-base.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk356x-base.dtsi
-@@ -1137,6 +1137,18 @@ rng: rng@fe388000 {
- 		status = "disabled";
- 	};
- 
-+	crypto: crypto@fe380000 {
-+		compatible = "rockchip,rk3568-crypto";
-+		reg = <0x0 0xfe380000 0x0 0x2000>;
-+		interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
-+		clocks = <&cru ACLK_CRYPTO_NS>, <&cru HCLK_CRYPTO_NS>,
-+			 <&cru CLK_CRYPTO_NS_CORE>;
-+		clock-names = "aclk", "hclk", "core";
-+		resets = <&cru SRST_CRYPTO_NS_CORE>;
-+		reset-names = "core";
-+		status = "okay";
-+	};
-+
- 	i2s0_8ch: i2s@fe400000 {
- 		compatible = "rockchip,rk3568-i2s-tdm";
- 		reg = <0x0 0xfe400000 0x0 0x1000>;
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe@baylibre.com>
-Date: Tue, 7 Nov 2023 15:55:31 +0000
-Subject: reset: rockchip: secure reset must be used by SCMI
-
-While working on the rk3588 crypto driver, I loose lot of time
-understanding why resetting the IP failed.
-This is due to RK3588_SECURECRU_RESET_OFFSET being in the secure world,
-so impossible to operate on it from the kernel.
-All resets in this block must be handled via SCMI call.
-
-Signed-off-by: Corentin Labbe <clabbe@baylibre.com>
----
- drivers/clk/rockchip/rst-rk3588.c               | 42 ------
- include/dt-bindings/reset/rockchip,rk3588-cru.h | 68 +++++-----
- 2 files changed, 34 insertions(+), 76 deletions(-)
-
 diff --git a/drivers/clk/rockchip/rst-rk3588.c b/drivers/clk/rockchip/rst-rk3588.c
-index 111111111111..222222222222 100644
+index c4ebc01f1c9c..7a856de64d9e 100644
 --- a/drivers/clk/rockchip/rst-rk3588.c
 +++ b/drivers/clk/rockchip/rst-rk3588.c
 @@ -16,9 +16,6 @@
@@ -241,108 +237,8 @@ index 111111111111..222222222222 100644
  };
  
  void rk3588_rst_init(struct device_node *np, void __iomem *reg_base)
-diff --git a/include/dt-bindings/reset/rockchip,rk3588-cru.h b/include/dt-bindings/reset/rockchip,rk3588-cru.h
-index 111111111111..222222222222 100644
---- a/include/dt-bindings/reset/rockchip,rk3588-cru.h
-+++ b/include/dt-bindings/reset/rockchip,rk3588-cru.h
-@@ -716,40 +716,40 @@
- #define SRST_P_GPIO0			627
- #define SRST_GPIO0			628
- 
--#define SRST_A_SECURE_NS_BIU		629
--#define SRST_H_SECURE_NS_BIU		630
--#define SRST_A_SECURE_S_BIU		631
--#define SRST_H_SECURE_S_BIU		632
--#define SRST_P_SECURE_S_BIU		633
--#define SRST_CRYPTO_CORE		634
--
--#define SRST_CRYPTO_PKA			635
--#define SRST_CRYPTO_RNG			636
--#define SRST_A_CRYPTO			637
--#define SRST_H_CRYPTO			638
--#define SRST_KEYLADDER_CORE		639
--#define SRST_KEYLADDER_RNG		640
--#define SRST_A_KEYLADDER		641
--#define SRST_H_KEYLADDER		642
--#define SRST_P_OTPC_S			643
--#define SRST_OTPC_S			644
--#define SRST_WDT_S			645
--
--#define SRST_T_WDT_S			646
--#define SRST_H_BOOTROM			647
--#define SRST_A_DCF			648
--#define SRST_P_DCF			649
--#define SRST_H_BOOTROM_NS		650
--#define SRST_P_KEYLADDER		651
--#define SRST_H_TRNG_S			652
--
--#define SRST_H_TRNG_NS			653
--#define SRST_D_SDMMC_BUFFER		654
--#define SRST_H_SDMMC			655
--#define SRST_H_SDMMC_BUFFER		656
--#define SRST_SDMMC			657
--#define SRST_P_TRNG_CHK			658
--#define SRST_TRNG_S			659
-+#define SRST_A_SECURE_NS_BIU		10
-+#define SRST_H_SECURE_NS_BIU		11
-+#define SRST_A_SECURE_S_BIU		12
-+#define SRST_H_SECURE_S_BIU		13
-+#define SRST_P_SECURE_S_BIU		14
-+#define SRST_CRYPTO_CORE		15
-+
-+#define SRST_CRYPTO_PKA			16
-+#define SRST_CRYPTO_RNG			17
-+#define SRST_A_CRYPTO			18
-+#define SRST_H_CRYPTO			19
-+#define SRST_KEYLADDER_CORE		25
-+#define SRST_KEYLADDER_RNG		26
-+#define SRST_A_KEYLADDER		27
-+#define SRST_H_KEYLADDER		28
-+#define SRST_P_OTPC_S			29
-+#define SRST_OTPC_S			30
-+#define SRST_WDT_S			31
-+
-+#define SRST_T_WDT_S			32
-+#define SRST_H_BOOTROM			33
-+#define SRST_A_DCF			34
-+#define SRST_P_DCF			35
-+#define SRST_H_BOOTROM_NS		37
-+#define SRST_P_KEYLADDER		46
-+#define SRST_H_TRNG_S			47
-+
-+#define SRST_H_TRNG_NS			48
-+#define SRST_D_SDMMC_BUFFER		49
-+#define SRST_H_SDMMC			50
-+#define SRST_H_SDMMC_BUFFER		51
-+#define SRST_SDMMC			52
-+#define SRST_P_TRNG_CHK			53
-+#define SRST_TRNG_S			54
- 
- #define SRST_A_HDMIRX_BIU		660
- 
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe@baylibre.com>
-Date: Tue, 7 Nov 2023 15:55:32 +0000
-Subject: crypto: rockchip: add rk3588 driver
-
-RK3588 have a new crypto IP, this patch adds basic support for it.
-Only hashes and cipher are handled for the moment.
-
-Signed-off-by: Corentin Labbe <clabbe@baylibre.com>
----
- drivers/crypto/Kconfig                        |  29 +
- drivers/crypto/rockchip/Makefile              |   5 +
- drivers/crypto/rockchip/rk2_crypto.c          | 739 ++++++++++
- drivers/crypto/rockchip/rk2_crypto.h          | 246 +++
- drivers/crypto/rockchip/rk2_crypto_ahash.c    | 344 +++++
- drivers/crypto/rockchip/rk2_crypto_skcipher.c | 576 ++++++++
- 6 files changed, 1939 insertions(+)
-
 diff --git a/drivers/crypto/Kconfig b/drivers/crypto/Kconfig
-index 111111111111..222222222222 100644
+index 880717de0851..eef5a03f97de 100644
 --- a/drivers/crypto/Kconfig
 +++ b/drivers/crypto/Kconfig
 @@ -746,6 +746,35 @@ config CRYPTO_DEV_XILINX_TRNG
@@ -375,14 +271,26 @@ index 111111111111..222222222222 100644
 +	depends on DEBUG_FS
 +	help
 +	  Say y to enable Rockchip crypto debug stats.
-+	  This will create /sys/kernel/debug/rk3588_crypto/stats for displaying
++	  This will create /sys/kernel/debug/rk2_crypto/stats for displaying
 +	  the number of requests per algorithm and other internal stats.
 +
  config CRYPTO_DEV_ZYNQMP_AES
  	tristate "Support for Xilinx ZynqMP AES hw accelerator"
  	depends on ZYNQMP_FIRMWARE || COMPILE_TEST
+diff --git a/drivers/crypto/Makefile b/drivers/crypto/Makefile
+index 322ae8854e3e..769c37592120 100644
+--- a/drivers/crypto/Makefile
++++ b/drivers/crypto/Makefile
+@@ -30,6 +30,7 @@ obj-$(CONFIG_CRYPTO_DEV_PPC4XX) += amcc/
+ obj-$(CONFIG_CRYPTO_DEV_QCE) += qce/
+ obj-$(CONFIG_CRYPTO_DEV_QCOM_RNG) += qcom-rng.o
+ obj-$(CONFIG_CRYPTO_DEV_ROCKCHIP) += rockchip/
++obj-$(CONFIG_CRYPTO_DEV_ROCKCHIP2) += rockchip/
+ obj-$(CONFIG_CRYPTO_DEV_S5P) += s5p-sss.o
+ obj-$(CONFIG_CRYPTO_DEV_SA2UL) += sa2ul.o
+ obj-$(CONFIG_CRYPTO_DEV_SAHARA) += sahara.o
 diff --git a/drivers/crypto/rockchip/Makefile b/drivers/crypto/rockchip/Makefile
-index 111111111111..222222222222 100644
+index 11910f0e6a62..abc720245a2e 100644
 --- a/drivers/crypto/rockchip/Makefile
 +++ b/drivers/crypto/rockchip/Makefile
 @@ -4,3 +4,8 @@ rk_crypto-objs := rk3288_crypto.o \
@@ -396,10 +304,10 @@ index 111111111111..222222222222 100644
 +		  rk2_crypto_ahash.o
 diff --git a/drivers/crypto/rockchip/rk2_crypto.c b/drivers/crypto/rockchip/rk2_crypto.c
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..eb63b30040cd
 --- /dev/null
 +++ b/drivers/crypto/rockchip/rk2_crypto.c
-@@ -0,0 +1,739 @@
+@@ -0,0 +1,816 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * hardware cryptographic offloader for RK3568/RK3588 SoC
@@ -415,7 +323,6 @@ index 000000000000..111111111111
 +#include <linux/platform_device.h>
 +#include <linux/of.h>
 +#include <linux/of_device.h>
-+#include <linux/reset.h>
 +
 +static struct rockchip_ip rocklist = {
 +	.dev_list = LIST_HEAD_INIT(rocklist.dev_list),
@@ -426,11 +333,11 @@ index 000000000000..111111111111
 +{
 +	struct rk2_crypto_dev *first;
 +
-+	spin_lock(&rocklist.lock);
++	spin_lock_bh(&rocklist.lock);
 +	first = list_first_entry_or_null(&rocklist.dev_list,
 +					 struct rk2_crypto_dev, list);
 +	list_rotate_left(&rocklist.dev_list);
-+	spin_unlock(&rocklist.lock);
++	spin_unlock_bh(&rocklist.lock);
 +	return first;
 +}
 +
@@ -459,18 +366,23 @@ index 000000000000..111111111111
 +		for (j = 0; j < ARRAY_SIZE(dev->variant->rkclks); j++) {
 +			if (dev->variant->rkclks[j].max == 0)
 +				continue;
-+			if (strcmp(dev->variant->rkclks[j].name, dev->clks[i].id))
++			if (strcmp
++			    (dev->variant->rkclks[j].name, dev->clks[i].id))
 +				continue;
 +			if (cr > dev->variant->rkclks[j].max) {
 +				err = clk_set_rate(dev->clks[i].clk,
 +						   dev->variant->rkclks[j].max);
 +				if (err)
-+					dev_err(dev->dev, "Fail downclocking %s from %lu to %lu\n",
-+						dev->variant->rkclks[j].name, cr,
++					dev_err(dev->dev,
++						"Fail downclocking %s from %lu to %lu\n",
++						dev->variant->rkclks[j].name,
++						cr,
 +						dev->variant->rkclks[j].max);
 +				else
-+					dev_info(dev->dev, "Downclocking %s from %lu to %lu\n",
-+						 dev->variant->rkclks[j].name, cr,
++					dev_info(dev->dev,
++						 "Downclocking %s from %lu to %lu\n",
++						 dev->variant->rkclks[j].name,
++						 cr,
 +						 dev->variant->rkclks[j].max);
 +			}
 +		}
@@ -517,7 +429,10 @@ index 000000000000..111111111111
 +	if (ret)
 +		return ret;
 +
++	reset_control_assert(rkdev->rst);
++	udelay(10);
 +	reset_control_deassert(rkdev->rst);
++
 +	return 0;
 +}
 +
@@ -536,7 +451,7 @@ index 000000000000..111111111111
 +	if (err)
 +		return err;
 +	pm_runtime_enable(rkdev->dev);
-+	return err;
++	return 0;
 +}
 +
 +static void rk2_crypto_pm_exit(struct rk2_crypto_dev *rkdev)
@@ -546,294 +461,320 @@ index 000000000000..111111111111
 +
 +static irqreturn_t rk2_crypto_irq_handle(int irq, void *dev_id)
 +{
-+	struct rk2_crypto_dev *rkc  = platform_get_drvdata(dev_id);
++	struct rk2_crypto_dev *rkc = platform_get_drvdata(dev_id);
 +	u32 v;
 +
 +	v = readl(rkc->reg + RK2_CRYPTO_DMA_INT_ST);
++	if (!v)
++		return IRQ_NONE;
++
 +	writel(v, rkc->reg + RK2_CRYPTO_DMA_INT_ST);
 +
-+	rkc->status = 1;
-+	if (v & 0xF8) {
++	/*
++	 * Only signal completion on list-done or hard DMA error.
++	 * Intermediate SRC_INT (BIT(1)/BIT(2)) fire for every LLI
++	 * entry that has RK2_LLI_DMA_CTRL_SRC_INT set. Completing
++	 * early on those causes the driver to read hash registers
++	 * before all data has been processed, producing wrong results.
++	 */
++	if (v & RK2_CRYPTO_DMA_INT_LISTDONE) {
++		rkc->status = 1;
++		complete(&rkc->complete);
++	} else if (v & 0xF8) {
 +		dev_warn(rkc->dev, "DMA Error\n");
 +		rkc->status = 0;
++		complete(&rkc->complete);
 +	}
-+	complete(&rkc->complete);
++	/* Intermediate SRC_INT/DST_INT: clear and return without completing */
 +
 +	return IRQ_HANDLED;
 +}
 +
 +static struct rk2_crypto_template rk2_crypto_algs[] = {
 +	{
-+		.type = CRYPTO_ALG_TYPE_SKCIPHER,
-+		.rk2_mode = RK2_CRYPTO_AES_ECB,
-+		.alg.skcipher.base = {
-+			.base.cra_name		= "ecb(aes)",
-+			.base.cra_driver_name	= "ecb-aes-rk2",
-+			.base.cra_priority	= 300,
-+			.base.cra_flags		= CRYPTO_ALG_ASYNC | CRYPTO_ALG_NEED_FALLBACK,
-+			.base.cra_blocksize	= AES_BLOCK_SIZE,
-+			.base.cra_ctxsize	= sizeof(struct rk2_cipher_ctx),
-+			.base.cra_alignmask	= 0x0f,
-+			.base.cra_module	= THIS_MODULE,
++	 .type = CRYPTO_ALG_TYPE_SKCIPHER,
++	 .rk2_mode = RK2_CRYPTO_AES_ECB,
++	 .alg.skcipher.base = {
++			       .base.cra_name = "ecb(aes)",
++			       .base.cra_driver_name = "ecb-aes-rk2",
++			       .base.cra_priority = 300,
++			       .base.cra_flags =
++			       CRYPTO_ALG_ASYNC | CRYPTO_ALG_NEED_FALLBACK,
++			       .base.cra_blocksize = AES_BLOCK_SIZE,
++			       .base.cra_ctxsize =
++			       sizeof(struct rk2_cipher_ctx),
++			       .base.cra_alignmask = 0x0f,
++			       .base.cra_module = THIS_MODULE,
 +
-+			.init			= rk2_cipher_tfm_init,
-+			.exit			= rk2_cipher_tfm_exit,
-+			.min_keysize		= AES_MIN_KEY_SIZE,
-+			.max_keysize		= AES_MAX_KEY_SIZE,
-+			.setkey			= rk2_aes_setkey,
-+			.encrypt		= rk2_skcipher_encrypt,
-+			.decrypt		= rk2_skcipher_decrypt,
-+		},
-+		.alg.skcipher.op = {
-+			.do_one_request = rk2_cipher_run,
-+		},
-+	},
++			       .init = rk2_cipher_tfm_init,
++			       .exit = rk2_cipher_tfm_exit,
++			       .min_keysize = AES_MIN_KEY_SIZE,
++			       .max_keysize = AES_MAX_KEY_SIZE,
++			       .setkey = rk2_aes_setkey,
++			       .encrypt = rk2_skcipher_encrypt,
++			       .decrypt = rk2_skcipher_decrypt,
++			       },
++	 .alg.skcipher.op = {
++			     .do_one_request = rk2_cipher_run,
++			     },
++	 },
 +	{
-+		.type = CRYPTO_ALG_TYPE_SKCIPHER,
-+		.rk2_mode = RK2_CRYPTO_AES_CBC,
-+		.alg.skcipher.base = {
-+			.base.cra_name		= "cbc(aes)",
-+			.base.cra_driver_name	= "cbc-aes-rk2",
-+			.base.cra_priority	= 300,
-+			.base.cra_flags		= CRYPTO_ALG_ASYNC | CRYPTO_ALG_NEED_FALLBACK,
-+			.base.cra_blocksize	= AES_BLOCK_SIZE,
-+			.base.cra_ctxsize	= sizeof(struct rk2_cipher_ctx),
-+			.base.cra_alignmask	= 0x0f,
-+			.base.cra_module	= THIS_MODULE,
++	 .type = CRYPTO_ALG_TYPE_SKCIPHER,
++	 .rk2_mode = RK2_CRYPTO_AES_CBC,
++	 .alg.skcipher.base = {
++			       .base.cra_name = "cbc(aes)",
++			       .base.cra_driver_name = "cbc-aes-rk2",
++			       .base.cra_priority = 300,
++			       .base.cra_flags =
++			       CRYPTO_ALG_ASYNC | CRYPTO_ALG_NEED_FALLBACK,
++			       .base.cra_blocksize = AES_BLOCK_SIZE,
++			       .base.cra_ctxsize =
++			       sizeof(struct rk2_cipher_ctx),
++			       .base.cra_alignmask = 0x0f,
++			       .base.cra_module = THIS_MODULE,
 +
-+			.init			= rk2_cipher_tfm_init,
-+			.exit			= rk2_cipher_tfm_exit,
-+			.min_keysize		= AES_MIN_KEY_SIZE,
-+			.max_keysize		= AES_MAX_KEY_SIZE,
-+			.ivsize			= AES_BLOCK_SIZE,
-+			.setkey			= rk2_aes_setkey,
-+			.encrypt		= rk2_skcipher_encrypt,
-+			.decrypt		= rk2_skcipher_decrypt,
-+		},
-+		.alg.skcipher.op = {
-+			.do_one_request = rk2_cipher_run,
-+		},
-+	},
++			       .init = rk2_cipher_tfm_init,
++			       .exit = rk2_cipher_tfm_exit,
++			       .min_keysize = AES_MIN_KEY_SIZE,
++			       .max_keysize = AES_MAX_KEY_SIZE,
++			       .ivsize = AES_BLOCK_SIZE,
++			       .setkey = rk2_aes_setkey,
++			       .encrypt = rk2_skcipher_encrypt,
++			       .decrypt = rk2_skcipher_decrypt,
++			       },
++	 .alg.skcipher.op = {
++			     .do_one_request = rk2_cipher_run,
++			     },
++	 },
 +	{
-+		.type = CRYPTO_ALG_TYPE_SKCIPHER,
-+		.rk2_mode = RK2_CRYPTO_AES_XTS,
-+		.is_xts = true,
-+		.alg.skcipher.base = {
-+			.base.cra_name		= "xts(aes)",
-+			.base.cra_driver_name	= "xts-aes-rk2",
-+			.base.cra_priority	= 300,
-+			.base.cra_flags		= CRYPTO_ALG_ASYNC | CRYPTO_ALG_NEED_FALLBACK,
-+			.base.cra_blocksize	= AES_BLOCK_SIZE,
-+			.base.cra_ctxsize	= sizeof(struct rk2_cipher_ctx),
-+			.base.cra_alignmask	= 0x0f,
-+			.base.cra_module	= THIS_MODULE,
++	 .type = CRYPTO_ALG_TYPE_SKCIPHER,
++	 .rk2_mode = RK2_CRYPTO_AES_XTS,
++	 .is_xts = true,
++	 .alg.skcipher.base = {
++			       .base.cra_name = "xts(aes)",
++			       .base.cra_driver_name = "xts-aes-rk2",
++			       .base.cra_priority = 300,
++			       .base.cra_flags =
++			       CRYPTO_ALG_ASYNC | CRYPTO_ALG_NEED_FALLBACK,
++			       .base.cra_blocksize = AES_BLOCK_SIZE,
++			       .base.cra_ctxsize =
++			       sizeof(struct rk2_cipher_ctx),
++			       .base.cra_alignmask = 0x0f,
++			       .base.cra_module = THIS_MODULE,
 +
-+			.init			= rk2_cipher_tfm_init,
-+			.exit			= rk2_cipher_tfm_exit,
-+			.min_keysize		= AES_MIN_KEY_SIZE * 2,
-+			.max_keysize		= AES_MAX_KEY_SIZE * 2,
-+			.ivsize			= AES_BLOCK_SIZE,
-+			.setkey			= rk2_aes_xts_setkey,
-+			.encrypt		= rk2_skcipher_encrypt,
-+			.decrypt		= rk2_skcipher_decrypt,
-+		},
-+		.alg.skcipher.op = {
-+			.do_one_request = rk2_cipher_run,
-+		},
-+	},
++			       .init = rk2_cipher_tfm_init,
++			       .exit = rk2_cipher_tfm_exit,
++			       .min_keysize = AES_MIN_KEY_SIZE * 2,
++			       .max_keysize = AES_MAX_KEY_SIZE * 2,
++			       .ivsize = AES_BLOCK_SIZE,
++			       .setkey = rk2_aes_xts_setkey,
++			       .encrypt = rk2_skcipher_encrypt,
++			       .decrypt = rk2_skcipher_decrypt,
++			       },
++	 .alg.skcipher.op = {
++			     .do_one_request = rk2_cipher_run,
++			     },
++	 },
 +	{
-+		.type = CRYPTO_ALG_TYPE_AHASH,
-+		.rk2_mode = RK2_CRYPTO_MD5,
-+		.alg.hash.base = {
-+			.init = rk2_ahash_init,
-+			.update = rk2_ahash_update,
-+			.final = rk2_ahash_final,
-+			.finup = rk2_ahash_finup,
-+			.export = rk2_ahash_export,
-+			.import = rk2_ahash_import,
-+			.digest = rk2_ahash_digest,
-+			.init_tfm = rk2_hash_init_tfm,
-+			.exit_tfm = rk2_hash_exit_tfm,
-+			.halg = {
-+				.digestsize = MD5_DIGEST_SIZE,
-+				.statesize = sizeof(struct md5_state),
-+				.base = {
-+					.cra_name = "md5",
-+					.cra_driver_name = "rk2-md5",
-+					.cra_priority = 300,
-+					.cra_flags = CRYPTO_ALG_ASYNC |
-+						CRYPTO_ALG_NEED_FALLBACK,
-+					.cra_blocksize = MD5_HMAC_BLOCK_SIZE,
-+					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_module = THIS_MODULE,
-+				}
-+			}
-+		},
-+		.alg.hash.op = {
-+			.do_one_request = rk2_hash_run,
-+		},
++	 .type = CRYPTO_ALG_TYPE_AHASH,
++	 .rk2_mode = RK2_CRYPTO_MD5,
++	 .alg.hash.base = {
++			   .init = rk2_ahash_init,
++			   .update = rk2_ahash_update,
++			   .final = rk2_ahash_final,
++			   .finup = rk2_ahash_finup,
++			   .export = rk2_ahash_export,
++			   .import = rk2_ahash_import,
++			   .digest = rk2_ahash_digest,
++			   .init_tfm = rk2_hash_init_tfm,
++			   .exit_tfm = rk2_hash_exit_tfm,
++			   .halg = {
++				    .digestsize = MD5_DIGEST_SIZE,
++				    .statesize = sizeof(struct md5_state),
++				    .base = {
++					     .cra_name = "md5",
++					     .cra_driver_name = "rk2-md5",
++					     .cra_priority = 300,
++					     .cra_flags = CRYPTO_ALG_ASYNC |
++					     CRYPTO_ALG_NEED_FALLBACK,
++					     .cra_blocksize =
++					     MD5_HMAC_BLOCK_SIZE,
++					     .cra_ctxsize =
++					     sizeof(struct rk2_ahash_ctx),
++					     .cra_module = THIS_MODULE,
++					     }
++				    }
++			   },
++	 .alg.hash.op = {
++			 .do_one_request = rk2_hash_run,
++			 },
 +
-+	},
++	 },
 +	{
-+		.type = CRYPTO_ALG_TYPE_AHASH,
-+		.rk2_mode = RK2_CRYPTO_SHA1,
-+		.alg.hash.base = {
-+			.init = rk2_ahash_init,
-+			.update = rk2_ahash_update,
-+			.final = rk2_ahash_final,
-+			.finup = rk2_ahash_finup,
-+			.export = rk2_ahash_export,
-+			.import = rk2_ahash_import,
-+			.digest = rk2_ahash_digest,
-+			.init_tfm = rk2_hash_init_tfm,
-+			.exit_tfm = rk2_hash_exit_tfm,
-+			.halg = {
-+				.digestsize = SHA1_DIGEST_SIZE,
-+				.statesize = sizeof(struct sha1_state),
-+				.base = {
-+					.cra_name = "sha1",
-+					.cra_driver_name = "rk2-sha1",
-+					.cra_priority = 300,
-+					.cra_flags = CRYPTO_ALG_ASYNC |
-+						CRYPTO_ALG_NEED_FALLBACK,
-+					.cra_blocksize = SHA1_BLOCK_SIZE,
-+					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_module = THIS_MODULE,
-+				}
-+			}
-+		},
-+		.alg.hash.op = {
-+			.do_one_request = rk2_hash_run,
-+		},
-+	},
++	 .type = CRYPTO_ALG_TYPE_AHASH,
++	 .rk2_mode = RK2_CRYPTO_SHA1,
++	 .alg.hash.base = {
++			   .init = rk2_ahash_init,
++			   .update = rk2_ahash_update,
++			   .final = rk2_ahash_final,
++			   .finup = rk2_ahash_finup,
++			   .export = rk2_ahash_export,
++			   .import = rk2_ahash_import,
++			   .digest = rk2_ahash_digest,
++			   .init_tfm = rk2_hash_init_tfm,
++			   .exit_tfm = rk2_hash_exit_tfm,
++			   .halg = {
++				    .digestsize = SHA1_DIGEST_SIZE,
++				    .statesize = sizeof(struct sha1_state),
++				    .base = {
++					     .cra_name = "sha1",
++					     .cra_driver_name = "rk2-sha1",
++					     .cra_priority = 300,
++					     .cra_flags = CRYPTO_ALG_ASYNC |
++					     CRYPTO_ALG_NEED_FALLBACK,
++					     .cra_blocksize = SHA1_BLOCK_SIZE,
++					     .cra_ctxsize =
++					     sizeof(struct rk2_ahash_ctx),
++					     .cra_module = THIS_MODULE,
++					     }
++				    }
++			   },
++	 .alg.hash.op = {
++			 .do_one_request = rk2_hash_run,
++			 },
++	 },
 +	{
-+		.type = CRYPTO_ALG_TYPE_AHASH,
-+		.rk2_mode = RK2_CRYPTO_SHA256,
-+		.alg.hash.base = {
-+			.init = rk2_ahash_init,
-+			.update = rk2_ahash_update,
-+			.final = rk2_ahash_final,
-+			.finup = rk2_ahash_finup,
-+			.export = rk2_ahash_export,
-+			.import = rk2_ahash_import,
-+			.digest = rk2_ahash_digest,
-+			.init_tfm = rk2_hash_init_tfm,
-+			.exit_tfm = rk2_hash_exit_tfm,
-+			.halg = {
-+				.digestsize = SHA256_DIGEST_SIZE,
-+				.statesize = sizeof(struct sha256_state),
-+				.base = {
-+					.cra_name = "sha256",
-+					.cra_driver_name = "rk2-sha256",
-+					.cra_priority = 300,
-+					.cra_flags = CRYPTO_ALG_ASYNC |
-+						CRYPTO_ALG_NEED_FALLBACK,
-+					.cra_blocksize = SHA256_BLOCK_SIZE,
-+					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_module = THIS_MODULE,
-+				}
-+			}
-+		},
-+		.alg.hash.op = {
-+			.do_one_request = rk2_hash_run,
-+		},
-+	},
++	 .type = CRYPTO_ALG_TYPE_AHASH,
++	 .rk2_mode = RK2_CRYPTO_SHA256,
++	 .alg.hash.base = {
++			   .init = rk2_ahash_init,
++			   .update = rk2_ahash_update,
++			   .final = rk2_ahash_final,
++			   .finup = rk2_ahash_finup,
++			   .export = rk2_ahash_export,
++			   .import = rk2_ahash_import,
++			   .digest = rk2_ahash_digest,
++			   .init_tfm = rk2_hash_init_tfm,
++			   .exit_tfm = rk2_hash_exit_tfm,
++			   .halg = {
++				    .digestsize = SHA256_DIGEST_SIZE,
++				    .statesize = sizeof(struct sha256_state),
++				    .base = {
++					     .cra_name = "sha256",
++					     .cra_driver_name = "rk2-sha256",
++					     .cra_priority = 300,
++					     .cra_flags = CRYPTO_ALG_ASYNC |
++					     CRYPTO_ALG_NEED_FALLBACK,
++					     .cra_blocksize = SHA256_BLOCK_SIZE,
++					     .cra_ctxsize =
++					     sizeof(struct rk2_ahash_ctx),
++					     .cra_module = THIS_MODULE,
++					     }
++				    }
++			   },
++	 .alg.hash.op = {
++			 .do_one_request = rk2_hash_run,
++			 },
++	 },
 +	{
-+		.type = CRYPTO_ALG_TYPE_AHASH,
-+		.rk2_mode = RK2_CRYPTO_SHA384,
-+		.alg.hash.base = {
-+			.init = rk2_ahash_init,
-+			.update = rk2_ahash_update,
-+			.final = rk2_ahash_final,
-+			.finup = rk2_ahash_finup,
-+			.export = rk2_ahash_export,
-+			.import = rk2_ahash_import,
-+			.digest = rk2_ahash_digest,
-+			.init_tfm = rk2_hash_init_tfm,
-+			.exit_tfm = rk2_hash_exit_tfm,
-+			.halg = {
-+				.digestsize = SHA384_DIGEST_SIZE,
-+				.statesize = sizeof(struct sha512_state),
-+				.base = {
-+					.cra_name = "sha384",
-+					.cra_driver_name = "rk2-sha384",
-+					.cra_priority = 300,
-+					.cra_flags = CRYPTO_ALG_ASYNC |
-+						CRYPTO_ALG_NEED_FALLBACK,
-+					.cra_blocksize = SHA384_BLOCK_SIZE,
-+					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_module = THIS_MODULE,
-+				}
-+			}
-+		},
-+		.alg.hash.op = {
-+			.do_one_request = rk2_hash_run,
-+		},
-+	},
++	 .type = CRYPTO_ALG_TYPE_AHASH,
++	 .rk2_mode = RK2_CRYPTO_SHA384,
++	 .alg.hash.base = {
++			   .init = rk2_ahash_init,
++			   .update = rk2_ahash_update,
++			   .final = rk2_ahash_final,
++			   .finup = rk2_ahash_finup,
++			   .export = rk2_ahash_export,
++			   .import = rk2_ahash_import,
++			   .digest = rk2_ahash_digest,
++			   .init_tfm = rk2_hash_init_tfm,
++			   .exit_tfm = rk2_hash_exit_tfm,
++			   .halg = {
++				    .digestsize = SHA384_DIGEST_SIZE,
++				    .statesize = sizeof(struct sha512_state),
++				    .base = {
++					     .cra_name = "sha384",
++					     .cra_driver_name = "rk2-sha384",
++					     .cra_priority = 300,
++					     .cra_flags = CRYPTO_ALG_ASYNC |
++					     CRYPTO_ALG_NEED_FALLBACK,
++					     .cra_blocksize = SHA384_BLOCK_SIZE,
++					     .cra_ctxsize =
++					     sizeof(struct rk2_ahash_ctx),
++					     .cra_module = THIS_MODULE,
++					     }
++				    }
++			   },
++	 .alg.hash.op = {
++			 .do_one_request = rk2_hash_run,
++			 },
++	 },
 +	{
-+		.type = CRYPTO_ALG_TYPE_AHASH,
-+		.rk2_mode = RK2_CRYPTO_SHA512,
-+		.alg.hash.base = {
-+			.init = rk2_ahash_init,
-+			.update = rk2_ahash_update,
-+			.final = rk2_ahash_final,
-+			.finup = rk2_ahash_finup,
-+			.export = rk2_ahash_export,
-+			.import = rk2_ahash_import,
-+			.digest = rk2_ahash_digest,
-+			.init_tfm = rk2_hash_init_tfm,
-+			.exit_tfm = rk2_hash_exit_tfm,
-+			.halg = {
-+				.digestsize = SHA512_DIGEST_SIZE,
-+				.statesize = sizeof(struct sha512_state),
-+				.base = {
-+					.cra_name = "sha512",
-+					.cra_driver_name = "rk2-sha512",
-+					.cra_priority = 300,
-+					.cra_flags = CRYPTO_ALG_ASYNC |
-+						CRYPTO_ALG_NEED_FALLBACK,
-+					.cra_blocksize = SHA512_BLOCK_SIZE,
-+					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_module = THIS_MODULE,
-+				}
-+			}
-+		},
-+		.alg.hash.op = {
-+			.do_one_request = rk2_hash_run,
-+		},
-+	},
++	 .type = CRYPTO_ALG_TYPE_AHASH,
++	 .rk2_mode = RK2_CRYPTO_SHA512,
++	 .alg.hash.base = {
++			   .init = rk2_ahash_init,
++			   .update = rk2_ahash_update,
++			   .final = rk2_ahash_final,
++			   .finup = rk2_ahash_finup,
++			   .export = rk2_ahash_export,
++			   .import = rk2_ahash_import,
++			   .digest = rk2_ahash_digest,
++			   .init_tfm = rk2_hash_init_tfm,
++			   .exit_tfm = rk2_hash_exit_tfm,
++			   .halg = {
++				    .digestsize = SHA512_DIGEST_SIZE,
++				    .statesize = sizeof(struct sha512_state),
++				    .base = {
++					     .cra_name = "sha512",
++					     .cra_driver_name = "rk2-sha512",
++					     .cra_priority = 300,
++					     .cra_flags = CRYPTO_ALG_ASYNC |
++					     CRYPTO_ALG_NEED_FALLBACK,
++					     .cra_blocksize = SHA512_BLOCK_SIZE,
++					     .cra_ctxsize =
++					     sizeof(struct rk2_ahash_ctx),
++					     .cra_module = THIS_MODULE,
++					     }
++				    }
++			   },
++	 .alg.hash.op = {
++			 .do_one_request = rk2_hash_run,
++			 },
++	 },
 +	{
-+		.type = CRYPTO_ALG_TYPE_AHASH,
-+		.rk2_mode = RK2_CRYPTO_SM3,
-+		.alg.hash.base = {
-+			.init = rk2_ahash_init,
-+			.update = rk2_ahash_update,
-+			.final = rk2_ahash_final,
-+			.finup = rk2_ahash_finup,
-+			.export = rk2_ahash_export,
-+			.import = rk2_ahash_import,
-+			.digest = rk2_ahash_digest,
-+			.init_tfm = rk2_hash_init_tfm,
-+			.exit_tfm = rk2_hash_exit_tfm,
-+			.halg = {
-+				.digestsize = SM3_DIGEST_SIZE,
-+				.statesize = sizeof(struct sm3_state),
-+				.base = {
-+					.cra_name = "sm3",
-+					.cra_driver_name = "rk2-sm3",
-+					.cra_priority = 300,
-+					.cra_flags = CRYPTO_ALG_ASYNC |
-+						CRYPTO_ALG_NEED_FALLBACK,
-+					.cra_blocksize = SM3_BLOCK_SIZE,
-+					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_module = THIS_MODULE,
-+				}
-+			}
-+		},
-+		.alg.hash.op = {
-+			.do_one_request = rk2_hash_run,
-+		},
-+	},
++	 .type = CRYPTO_ALG_TYPE_AHASH,
++	 .rk2_mode = RK2_CRYPTO_SM3,
++	 .alg.hash.base = {
++			   .init = rk2_ahash_init,
++			   .update = rk2_ahash_update,
++			   .final = rk2_ahash_final,
++			   .finup = rk2_ahash_finup,
++			   .export = rk2_ahash_export,
++			   .import = rk2_ahash_import,
++			   .digest = rk2_ahash_digest,
++			   .init_tfm = rk2_hash_init_tfm,
++			   .exit_tfm = rk2_hash_exit_tfm,
++			   .halg = {
++				    .digestsize = SM3_DIGEST_SIZE,
++				    .statesize = sizeof(struct sm3_state),
++				    .base = {
++					     .cra_name = "sm3",
++					     .cra_driver_name = "rk2-sm3",
++					     .cra_priority = 300,
++					     .cra_flags = CRYPTO_ALG_ASYNC |
++					     CRYPTO_ALG_NEED_FALLBACK,
++					     .cra_blocksize = SM3_BLOCK_SIZE,
++					     .cra_ctxsize =
++					     sizeof(struct rk2_ahash_ctx),
++					     .cra_module = THIS_MODULE,
++					     }
++				    }
++			   },
++	 .alg.hash.op = {
++			 .do_one_request = rk2_hash_run,
++			 },
++	 },
 +};
 +
 +#ifdef CONFIG_CRYPTO_DEV_ROCKCHIP2_DEBUG
@@ -842,13 +783,13 @@ index 000000000000..111111111111
 +	struct rk2_crypto_dev *rkc;
 +	unsigned int i;
 +
-+	spin_lock(&rocklist.lock);
++	spin_lock_bh(&rocklist.lock);
 +	list_for_each_entry(rkc, &rocklist.dev_list, list) {
 +		seq_printf(seq, "%s %s requests: %lu\n",
 +			   dev_driver_string(rkc->dev), dev_name(rkc->dev),
 +			   rkc->nreq);
 +	}
-+	spin_unlock(&rocklist.lock);
++	spin_unlock_bh(&rocklist.lock);
 +
 +	for (i = 0; i < ARRAY_SIZE(rk2_crypto_algs); i++) {
 +		if (!rk2_crypto_algs[i].dev)
@@ -856,9 +797,11 @@ index 000000000000..111111111111
 +		switch (rk2_crypto_algs[i].type) {
 +		case CRYPTO_ALG_TYPE_SKCIPHER:
 +			seq_printf(seq, "%s %s reqs=%lu fallback=%lu\n",
-+				   rk2_crypto_algs[i].alg.skcipher.base.base.cra_driver_name,
-+				   rk2_crypto_algs[i].alg.skcipher.base.base.cra_name,
-+				   rk2_crypto_algs[i].stat_req, rk2_crypto_algs[i].stat_fb);
++				   rk2_crypto_algs[i].alg.skcipher.base.base.
++				   cra_driver_name,
++				   rk2_crypto_algs[i].alg.skcipher.base.base.
++				   cra_name, rk2_crypto_algs[i].stat_req,
++				   rk2_crypto_algs[i].stat_fb);
 +			seq_printf(seq, "\tfallback due to length: %lu\n",
 +				   rk2_crypto_algs[i].stat_fb_len);
 +			seq_printf(seq, "\tfallback due to alignment: %lu\n",
@@ -868,9 +811,11 @@ index 000000000000..111111111111
 +			break;
 +		case CRYPTO_ALG_TYPE_AHASH:
 +			seq_printf(seq, "%s %s reqs=%lu fallback=%lu\n",
-+				   rk2_crypto_algs[i].alg.hash.base.halg.base.cra_driver_name,
-+				   rk2_crypto_algs[i].alg.hash.base.halg.base.cra_name,
-+				   rk2_crypto_algs[i].stat_req, rk2_crypto_algs[i].stat_fb);
++				   rk2_crypto_algs[i].alg.hash.base.halg.base.
++				   cra_driver_name,
++				   rk2_crypto_algs[i].alg.hash.base.halg.base.
++				   cra_name, rk2_crypto_algs[i].stat_req,
++				   rk2_crypto_algs[i].stat_fb);
 +			break;
 +		}
 +	}
@@ -882,7 +827,7 @@ index 000000000000..111111111111
 +	struct rk2_crypto_dev *rkc;
 +	u32 v;
 +
-+	spin_lock(&rocklist.lock);
++	spin_lock_bh(&rocklist.lock);
 +	list_for_each_entry(rkc, &rocklist.dev_list, list) {
 +		v = readl(rkc->reg + RK2_CRYPTO_CLK_CTL);
 +		seq_printf(seq, "CRYPTO_CLK_CTL %x\n", v);
@@ -902,14 +847,14 @@ index 000000000000..111111111111
 +		seq_printf(seq, "CRYPTO_HASH_VERSION %x\n", v);
 +		v = readl(rkc->reg + CRYPTO_HMAC_VERSION);
 +		seq_printf(seq, "CRYPTO_HMAC_VERSION %x\n", v);
-+	v = readl(rkc->reg + CRYPTO_RNG_VERSION);
-+	seq_printf(seq, "CRYPTO_RNG_VERSION %x\n", v);
-+	v = readl(rkc->reg + CRYPTO_PKA_VERSION);
-+	seq_printf(seq, "CRYPTO_PKA_VERSION %x\n", v);
-+	v = readl(rkc->reg + CRYPTO_CRYPTO_VERSION);
-+	seq_printf(seq, "CRYPTO_CRYPTO_VERSION %x\n", v);
++		v = readl(rkc->reg + CRYPTO_RNG_VERSION);
++		seq_printf(seq, "CRYPTO_RNG_VERSION %x\n", v);
++		v = readl(rkc->reg + CRYPTO_PKA_VERSION);
++		seq_printf(seq, "CRYPTO_PKA_VERSION %x\n", v);
++		v = readl(rkc->reg + CRYPTO_CRYPTO_VERSION);
++		seq_printf(seq, "CRYPTO_CRYPTO_VERSION %x\n", v);
 +	}
-+	spin_unlock(&rocklist.lock);
++	spin_unlock_bh(&rocklist.lock);
 +
 +	return 0;
 +}
@@ -928,10 +873,11 @@ index 000000000000..111111111111
 +						   rocklist.dbgfs_dir,
 +						   &rocklist,
 +						   &rk2_crypto_debugfs_stats_fops);
-+	rocklist.dbgfs_stats = debugfs_create_file("info", 0440,
-+						   rocklist.dbgfs_dir,
-+						   &rocklist,
-+						   &rk2_crypto_debugfs_info_fops);
++	/* Pointer overwrite fix */
++	rocklist.dbgfs_info = debugfs_create_file("info", 0440,
++						  rocklist.dbgfs_dir,
++						  &rocklist,
++						  &rk2_crypto_debugfs_info_fops);
 +#endif
 +}
 +
@@ -945,15 +891,23 @@ index 000000000000..111111111111
 +		switch (rk2_crypto_algs[i].type) {
 +		case CRYPTO_ALG_TYPE_SKCIPHER:
 +			dev_info(rkc->dev, "Register %s as %s\n",
-+				 rk2_crypto_algs[i].alg.skcipher.base.base.cra_name,
-+				 rk2_crypto_algs[i].alg.skcipher.base.base.cra_driver_name);
-+			err = crypto_engine_register_skcipher(&rk2_crypto_algs[i].alg.skcipher);
++				 rk2_crypto_algs[i].alg.skcipher.base.base.
++				 cra_name,
++				 rk2_crypto_algs[i].alg.skcipher.base.base.
++				 cra_driver_name);
++			err =
++			    crypto_engine_register_skcipher(&rk2_crypto_algs[i].
++							    alg.skcipher);
 +			break;
 +		case CRYPTO_ALG_TYPE_AHASH:
 +			dev_info(rkc->dev, "Register %s as %s %d\n",
-+				 rk2_crypto_algs[i].alg.hash.base.halg.base.cra_name,
-+				 rk2_crypto_algs[i].alg.hash.base.halg.base.cra_driver_name, i);
-+			err = crypto_engine_register_ahash(&rk2_crypto_algs[i].alg.hash);
++				 rk2_crypto_algs[i].alg.hash.base.halg.base.
++				 cra_name,
++				 rk2_crypto_algs[i].alg.hash.base.halg.base.
++				 cra_driver_name, i);
++			err =
++			    crypto_engine_register_ahash(&rk2_crypto_algs[i].
++							 alg.hash);
 +			break;
 +		default:
 +			dev_err(rkc->dev, "unknown algorithm\n");
@@ -963,12 +917,14 @@ index 000000000000..111111111111
 +	}
 +	return 0;
 +
-+err_cipher_algs:
++ err_cipher_algs:
 +	for (k = 0; k < i; k++) {
 +		if (rk2_crypto_algs[k].type == CRYPTO_ALG_TYPE_SKCIPHER)
-+			crypto_engine_unregister_skcipher(&rk2_crypto_algs[k].alg.skcipher);
++			crypto_engine_unregister_skcipher(&rk2_crypto_algs
++							  [k].alg.skcipher);
 +		else
-+			crypto_engine_unregister_ahash(&rk2_crypto_algs[k].alg.hash);
++			crypto_engine_unregister_ahash(&rk2_crypto_algs[k].alg.
++						       hash);
 +	}
 +	return err;
 +}
@@ -979,21 +935,24 @@ index 000000000000..111111111111
 +
 +	for (i = 0; i < ARRAY_SIZE(rk2_crypto_algs); i++) {
 +		if (rk2_crypto_algs[i].type == CRYPTO_ALG_TYPE_SKCIPHER)
-+			crypto_engine_unregister_skcipher(&rk2_crypto_algs[i].alg.skcipher);
++			crypto_engine_unregister_skcipher(&rk2_crypto_algs
++							  [i].alg.skcipher);
 +		else
-+			crypto_engine_unregister_ahash(&rk2_crypto_algs[i].alg.hash);
++			crypto_engine_unregister_ahash(&rk2_crypto_algs[i].alg.
++						       hash);
 +	}
 +}
 +
 +static const struct of_device_id crypto_of_id_table[] = {
-+	{ .compatible = "rockchip,rk3568-crypto",
-+	  .data = &rk3568_variant,
-+	},
-+	{ .compatible = "rockchip,rk3588-crypto",
-+	  .data = &rk3588_variant,
-+	},
++	{.compatible = "rockchip,rk3568-crypto",
++	 .data = &rk3568_variant,
++	 },
++	{.compatible = "rockchip,rk3588-crypto",
++	 .data = &rk3588_variant,
++	 },
 +	{}
 +};
++
 +MODULE_DEVICE_TABLE(of, crypto_of_id_table);
 +
 +static int rk2_crypto_probe(struct platform_device *pdev)
@@ -1002,102 +961,113 @@ index 000000000000..111111111111
 +	struct rk2_crypto_dev *rkc, *first;
 +	int err = 0;
 +
-+	rkc = devm_kzalloc(&pdev->dev, sizeof(*rkc), GFP_KERNEL);
-+	if (!rkc) {
-+		err = -ENOMEM;
-+		goto err_crypto;
-+	}
++	rkc = devm_kzalloc(dev, sizeof(*rkc), GFP_KERNEL);
++	if (!rkc)
++		return -ENOMEM;
 +
-+	rkc->dev = &pdev->dev;
++	rkc->dev = dev;
 +	platform_set_drvdata(pdev, rkc);
 +
-+	rkc->variant = of_device_get_match_data(&pdev->dev);
++	rkc->variant = of_device_get_match_data(dev);
 +	if (!rkc->variant) {
-+		dev_err(&pdev->dev, "Missing variant\n");
++		dev_err(dev, "Missing variant\n");
 +		return -EINVAL;
 +	}
 +
 +	rkc->rst = devm_reset_control_array_get_exclusive(dev);
 +	if (IS_ERR(rkc->rst)) {
 +		err = PTR_ERR(rkc->rst);
-+		dev_err(&pdev->dev, "Fail to get resets err=%d\n", err);
-+		goto err_crypto;
++		dev_err(dev, "Fail to get resets err=%d\n", err);
++		return err;
 +	}
 +
++	/* Manual DMA allocation requires manual cleanup in error paths */
 +	rkc->tl = dma_alloc_coherent(rkc->dev,
 +				     sizeof(struct rk2_crypto_lli) * MAX_LLI,
 +				     &rkc->t_phy, GFP_KERNEL);
 +	if (!rkc->tl) {
 +		dev_err(rkc->dev, "Cannot get DMA memory for task\n");
-+		err = -ENOMEM;
-+		goto err_crypto;
++		return -ENOMEM;
 +	}
-+
-+	reset_control_assert(rkc->rst);
-+	usleep_range(10, 20);
-+	reset_control_deassert(rkc->rst);
 +
 +	rkc->reg = devm_platform_ioremap_resource(pdev, 0);
 +	if (IS_ERR(rkc->reg)) {
 +		err = PTR_ERR(rkc->reg);
-+		dev_err(&pdev->dev, "Fail to get resources\n");
-+		goto err_crypto;
++		dev_err(dev, "Fail to get resources\n");
++		goto err_dma;
 +	}
 +
 +	err = rk2_crypto_get_clks(rkc);
 +	if (err)
-+		goto err_crypto;
++		goto err_dma;
 +
 +	rkc->irq = platform_get_irq(pdev, 0);
 +	if (rkc->irq < 0) {
-+		dev_err(&pdev->dev, "control Interrupt is not available.\n");
++		dev_err(dev, "control Interrupt is not available.\n");
 +		err = rkc->irq;
-+		goto err_crypto;
++		goto err_dma;
 +	}
 +
-+	err = devm_request_irq(&pdev->dev, rkc->irq,
++	err = devm_request_irq(dev, rkc->irq,
 +			       rk2_crypto_irq_handle, IRQF_SHARED,
 +			       "rk-crypto", pdev);
 +
 +	if (err) {
-+		dev_err(&pdev->dev, "irq request failed.\n");
-+		goto err_crypto;
++		dev_err(dev, "irq request failed.\n");
++		goto err_dma;
 +	}
 +
-+	rkc->engine = crypto_engine_alloc_init(&pdev->dev, true);
++	rkc->engine = crypto_engine_alloc_init(dev, true);
++	if (!rkc->engine) {
++		err = -ENOMEM;
++		goto err_dma;
++	}
++
 +	crypto_engine_start(rkc->engine);
 +	init_completion(&rkc->complete);
 +
 +	err = rk2_crypto_pm_init(rkc);
 +	if (err)
++		goto err_engine;
++
++	err = pm_runtime_resume_and_get(dev);
++	if (err)
 +		goto err_pm;
 +
-+	err = pm_runtime_resume_and_get(&pdev->dev);
-+
-+	spin_lock(&rocklist.lock);
++	spin_lock_bh(&rocklist.lock);
 +	first = list_first_entry_or_null(&rocklist.dev_list,
 +					 struct rk2_crypto_dev, list);
 +	list_add_tail(&rkc->list, &rocklist.dev_list);
-+	spin_unlock(&rocklist.lock);
++	spin_unlock_bh(&rocklist.lock);
 +
 +	if (!first) {
-+		dev_info(dev, "Registers crypto algos\n");
++		dev_info(dev, "Registering crypto algos\n");
 +		err = rk2_crypto_register(rkc);
 +		if (err) {
-+			dev_err(dev, "Fail to register crypto algorithms");
++			dev_err(dev, "Fail to register crypto algorithms\n");
 +			goto err_register_alg;
 +		}
 +
 +		register_debugfs(rkc);
 +	}
 +
++	pm_runtime_mark_last_busy(dev);
++	pm_runtime_put_autosuspend(dev);
++
 +	return 0;
 +
-+err_register_alg:
++ err_register_alg:
++	spin_lock_bh(&rocklist.lock);
++	list_del(&rkc->list);
++	spin_unlock_bh(&rocklist.lock);
++	pm_runtime_put_sync(dev);
++ err_pm:
 +	rk2_crypto_pm_exit(rkc);
-+err_pm:
++ err_engine:
 +	crypto_engine_exit(rkc->engine);
-+err_crypto:
++ err_dma:
++	dma_free_coherent(rkc->dev, sizeof(struct rk2_crypto_lli) * MAX_LLI,
++			  rkc->tl, rkc->t_phy);
 +	dev_err(dev, "Crypto Accelerator not successfully registered\n");
 +	return err;
 +}
@@ -1105,33 +1075,48 @@ index 000000000000..111111111111
 +static void rk2_crypto_remove(struct platform_device *pdev)
 +{
 +	struct rk2_crypto_dev *rkc = platform_get_drvdata(pdev);
-+	struct rk2_crypto_dev *first;
++	struct rk2_crypto_dev *new_dev;
++	unsigned int i;
++
++	/*
++	 * Stop the engine before touching the device list.
++	 * This drains any in-flight request so nothing can
++	 * call into algt->dev after we change it.
++	 */
++	crypto_engine_exit(rkc->engine);
 +
 +	spin_lock_bh(&rocklist.lock);
 +	list_del(&rkc->list);
-+	first = list_first_entry_or_null(&rocklist.dev_list,
-+					 struct rk2_crypto_dev, list);
++	new_dev = list_first_entry_or_null(&rocklist.dev_list,
++					   struct rk2_crypto_dev, list);
 +	spin_unlock_bh(&rocklist.lock);
 +
-+	if (!first) {
++	if (!new_dev) {
 +#ifdef CONFIG_CRYPTO_DEV_ROCKCHIP2_DEBUG
 +		debugfs_remove_recursive(rocklist.dbgfs_dir);
 +#endif
 +		rk2_crypto_unregister();
++	} else {
++		/* Hand algorithm ownership to a surviving device so
++		 * tfm_init/exit logging doesn't use a freed pointer.
++		 */
++		for (i = 0; i < ARRAY_SIZE(rk2_crypto_algs); i++)
++			rk2_crypto_algs[i].dev = new_dev;
 +	}
 +	rk2_crypto_pm_exit(rkc);
-+	crypto_engine_exit(rkc->engine);
-+	return;
++	dma_free_coherent(rkc->dev,
++			  sizeof(struct rk2_crypto_lli) * MAX_LLI,
++			  rkc->tl, rkc->t_phy);
 +}
 +
 +static struct platform_driver crypto_driver = {
-+	.probe		= rk2_crypto_probe,
-+	.remove		= rk2_crypto_remove,
-+	.driver		= {
-+		.name	= "rk2-crypto",
-+		.pm		= &rk2_crypto_pm_ops,
-+		.of_match_table	= crypto_of_id_table,
-+	},
++	.probe = rk2_crypto_probe,
++	.remove = rk2_crypto_remove,
++	.driver = {
++		   .name = "rk2-crypto",
++		   .pm = &rk2_crypto_pm_ops,
++		   .of_match_table = crypto_of_id_table,
++		   },
 +};
 +
 +module_platform_driver(crypto_driver);
@@ -1141,10 +1126,10 @@ index 000000000000..111111111111
 +MODULE_AUTHOR("Corentin Labbe <clabbe@baylibre.com>");
 diff --git a/drivers/crypto/rockchip/rk2_crypto.h b/drivers/crypto/rockchip/rk2_crypto.h
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..ebd662a31ba1
 --- /dev/null
 +++ b/drivers/crypto/rockchip/rk2_crypto.h
-@@ -0,0 +1,246 @@
+@@ -0,0 +1,249 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +
 +#include <crypto/aes.h>
@@ -1165,6 +1150,7 @@ index 000000000000..111111111111
 +#include <linux/pm_runtime.h>
 +#include <linux/scatterlist.h>
 +#include <linux/hw_random.h>
++#include <linux/reset.h>
 +
 +#define RK2_CRYPTO_CLK_CTL	0x0000
 +#define RK2_CRYPTO_RST_CTL	0x0004
@@ -1283,13 +1269,15 @@ index 000000000000..111111111111
 + * @dev_list:		Used for doing a list of rk2_crypto_dev
 + * @lock:		Control access to dev_list
 + * @dbgfs_dir:		Debugfs dentry for statistic directory
-+ * @dbgfs_stats:	Debugfs dentry for statistic counters
++ * @dbgfs_stats:	Debugfs dentry for stats file
++ * @dbgfs_info:	Debugfs dentry for info file
 + */
 +struct rockchip_ip {
-+	struct list_head	dev_list;
-+	spinlock_t		lock; /* Control access to dev_list */
-+	struct dentry		*dbgfs_dir;
-+	struct dentry		*dbgfs_stats;
++	struct list_head dev_list;
++	spinlock_t lock;	/* Control access to dev_list */
++	struct dentry *dbgfs_dir;
++	struct dentry *dbgfs_stats;
++	struct dentry *dbgfs_info;
 +};
 +
 +struct rk2_clks {
@@ -1303,13 +1291,13 @@ index 000000000000..111111111111
 +};
 +
 +struct rk2_crypto_dev {
-+	struct list_head		list;
-+	struct device			*dev;
-+	struct clk_bulk_data		*clks;
-+	int				num_clks;
-+	struct reset_control		*rst;
-+	void __iomem			*reg;
-+	int				irq;
++	struct list_head list;
++	struct device *dev;
++	struct clk_bulk_data *clks;
++	int num_clks;
++	struct reset_control *rst;
++	void __iomem *reg;
++	int irq;
 +	const struct rk2_variant *variant;
 +	unsigned long nreq;
 +	struct crypto_engine *engine;
@@ -1322,40 +1310,40 @@ index 000000000000..111111111111
 +/* the private variable of hash */
 +struct rk2_ahash_ctx {
 +	/* for fallback */
-+	struct crypto_ahash		*fallback_tfm;
++	struct crypto_ahash *fallback_tfm;
 +};
 +
 +/* the private variable of hash for fallback */
 +struct rk2_ahash_rctx {
-+	struct rk2_crypto_dev		*dev;
-+	struct ahash_request		fallback_req;
-+	u32				mode;
++	struct rk2_crypto_dev *dev;
++	u32 mode;
 +	int nrsgs;
++	struct ahash_request fallback_req;
 +};
 +
 +/* the private variable of cipher */
 +struct rk2_cipher_ctx {
-+	unsigned int			keylen;
-+	u8				key[AES_MAX_KEY_SIZE * 2];
-+	u8				iv[AES_BLOCK_SIZE];
++	unsigned int keylen;
++	u8 key[AES_MAX_KEY_SIZE * 2];
++	u8 iv[AES_BLOCK_SIZE];
 +	struct crypto_skcipher *fallback_tfm;
 +};
 +
 +struct rk2_cipher_rctx {
-+	struct rk2_crypto_dev		*dev;
++	struct rk2_crypto_dev *dev;
 +	u8 backup_iv[AES_BLOCK_SIZE];
-+	u32				mode;
-+	struct skcipher_request fallback_req;   // keep at the end
++	u32 mode;
++	struct skcipher_request fallback_req;	/* must be last, see __ctx placement */
 +};
 +
 +struct rk2_crypto_template {
 +	u32 type;
 +	u32 rk2_mode;
 +	bool is_xts;
-+	struct rk2_crypto_dev           *dev;
++	struct rk2_crypto_dev *dev;
 +	union {
-+		struct skcipher_engine_alg	skcipher;
-+		struct ahash_engine_alg	hash;
++		struct skcipher_engine_alg skcipher;
++		struct ahash_engine_alg hash;
 +	} alg;
 +	unsigned long stat_req;
 +	unsigned long stat_fb;
@@ -1371,9 +1359,9 @@ index 000000000000..111111111111
 +
 +int rk2_cipher_tfm_init(struct crypto_skcipher *tfm);
 +void rk2_cipher_tfm_exit(struct crypto_skcipher *tfm);
-+int rk2_aes_setkey(struct crypto_skcipher *cipher, const u8 *key,
++int rk2_aes_setkey(struct crypto_skcipher *cipher, const u8 * key,
 +		   unsigned int keylen);
-+int rk2_aes_xts_setkey(struct crypto_skcipher *cipher, const u8 *key,
++int rk2_aes_xts_setkey(struct crypto_skcipher *cipher, const u8 * key,
 +		       unsigned int keylen);
 +int rk2_skcipher_encrypt(struct skcipher_request *req);
 +int rk2_skcipher_decrypt(struct skcipher_request *req);
@@ -1393,10 +1381,10 @@ index 000000000000..111111111111
 +void rk2_hash_exit_tfm(struct crypto_ahash *tfm);
 diff --git a/drivers/crypto/rockchip/rk2_crypto_ahash.c b/drivers/crypto/rockchip/rk2_crypto_ahash.c
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..71605385b68f
 --- /dev/null
 +++ b/drivers/crypto/rockchip/rk2_crypto_ahash.c
-@@ -0,0 +1,344 @@
+@@ -0,0 +1,414 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * Crypto offloader support for Rockchip RK3568/RK3588
@@ -1411,8 +1399,20 @@ index 000000000000..111111111111
 +{
 +	struct crypto_ahash *tfm = crypto_ahash_reqtfm(areq);
 +	struct ahash_alg *alg = crypto_ahash_alg(tfm);
-+	struct rk2_crypto_template *algt = container_of(alg, struct rk2_crypto_template, alg.hash.base);
++	struct rk2_crypto_template *algt =
++	    container_of(alg, struct rk2_crypto_template, alg.hash.base);
 +	struct scatterlist *sg;
++
++	/*
++	 * The hardware padding engine (HW_PAD) cannot correctly track
++	 * block boundaries across chained LLI descriptors. A multi-SG
++	 * request would be split into multiple LLI entries causing wrong
++	 * digests. Force software fallback for any multi-SG request.
++	 */
++	if (sg_nents(areq->src) > 1) {
++		algt->stat_fb_sgdiff++;
++		return true;
++	}
 +
 +	sg = areq->src;
 +	while (sg) {
@@ -1435,13 +1435,14 @@ index 000000000000..111111111111
 +	struct crypto_ahash *tfm = crypto_ahash_reqtfm(areq);
 +	struct rk2_ahash_ctx *tfmctx = crypto_ahash_ctx(tfm);
 +	struct ahash_alg *alg = crypto_ahash_alg(tfm);
-+	struct rk2_crypto_template *algt = container_of(alg, struct rk2_crypto_template, alg.hash.base);
++	struct rk2_crypto_template *algt =
++	    container_of(alg, struct rk2_crypto_template, alg.hash.base);
 +
 +	algt->stat_fb++;
 +
 +	ahash_request_set_tfm(&rctx->fallback_req, tfmctx->fallback_tfm);
 +	rctx->fallback_req.base.flags = areq->base.flags &
-+					CRYPTO_TFM_REQ_MAY_SLEEP;
++	    CRYPTO_TFM_REQ_MAY_SLEEP;
 +
 +	rctx->fallback_req.nbytes = areq->nbytes;
 +	rctx->fallback_req.src = areq->src;
@@ -1454,7 +1455,8 @@ index 000000000000..111111111111
 +{
 +	struct crypto_ahash *tfm = crypto_ahash_reqtfm(req);
 +	struct ahash_alg *alg = crypto_ahash_alg(tfm);
-+	struct rk2_crypto_template *algt = container_of(alg, struct rk2_crypto_template, alg.hash.base);
++	struct rk2_crypto_template *algt =
++	    container_of(alg, struct rk2_crypto_template, alg.hash.base);
 +	int digestsize = crypto_ahash_digestsize(tfm);
 +
 +	switch (algt->rk2_mode) {
@@ -1491,7 +1493,7 @@ index 000000000000..111111111111
 +
 +	ahash_request_set_tfm(&rctx->fallback_req, ctx->fallback_tfm);
 +	rctx->fallback_req.base.flags = req->base.flags &
-+					CRYPTO_TFM_REQ_MAY_SLEEP;
++	    CRYPTO_TFM_REQ_MAY_SLEEP;
 +
 +	return crypto_ahash_init(&rctx->fallback_req);
 +}
@@ -1504,7 +1506,7 @@ index 000000000000..111111111111
 +
 +	ahash_request_set_tfm(&rctx->fallback_req, ctx->fallback_tfm);
 +	rctx->fallback_req.base.flags = req->base.flags &
-+					CRYPTO_TFM_REQ_MAY_SLEEP;
++	    CRYPTO_TFM_REQ_MAY_SLEEP;
 +	rctx->fallback_req.nbytes = req->nbytes;
 +	rctx->fallback_req.src = req->src;
 +
@@ -1519,7 +1521,7 @@ index 000000000000..111111111111
 +
 +	ahash_request_set_tfm(&rctx->fallback_req, ctx->fallback_tfm);
 +	rctx->fallback_req.base.flags = req->base.flags &
-+					CRYPTO_TFM_REQ_MAY_SLEEP;
++	    CRYPTO_TFM_REQ_MAY_SLEEP;
 +	rctx->fallback_req.result = req->result;
 +
 +	return crypto_ahash_final(&rctx->fallback_req);
@@ -1533,7 +1535,7 @@ index 000000000000..111111111111
 +
 +	ahash_request_set_tfm(&rctx->fallback_req, ctx->fallback_tfm);
 +	rctx->fallback_req.base.flags = req->base.flags &
-+					CRYPTO_TFM_REQ_MAY_SLEEP;
++	    CRYPTO_TFM_REQ_MAY_SLEEP;
 +
 +	rctx->fallback_req.nbytes = req->nbytes;
 +	rctx->fallback_req.src = req->src;
@@ -1550,7 +1552,7 @@ index 000000000000..111111111111
 +
 +	ahash_request_set_tfm(&rctx->fallback_req, ctx->fallback_tfm);
 +	rctx->fallback_req.base.flags = req->base.flags &
-+					CRYPTO_TFM_REQ_MAY_SLEEP;
++	    CRYPTO_TFM_REQ_MAY_SLEEP;
 +
 +	return crypto_ahash_import(&rctx->fallback_req, in);
 +}
@@ -1563,7 +1565,7 @@ index 000000000000..111111111111
 +
 +	ahash_request_set_tfm(&rctx->fallback_req, ctx->fallback_tfm);
 +	rctx->fallback_req.base.flags = req->base.flags &
-+					CRYPTO_TFM_REQ_MAY_SLEEP;
++	    CRYPTO_TFM_REQ_MAY_SLEEP;
 +
 +	return crypto_ahash_export(&rctx->fallback_req, out);
 +}
@@ -1590,12 +1592,16 @@ index 000000000000..111111111111
 +
 +static int rk2_hash_prepare(struct crypto_engine *engine, void *breq)
 +{
-+	struct ahash_request *areq = container_of(breq, struct ahash_request, base);
++	struct ahash_request *areq =
++	    container_of(breq, struct ahash_request, base);
 +	struct rk2_ahash_rctx *rctx = ahash_request_ctx(areq);
 +	struct rk2_crypto_dev *rkc = rctx->dev;
 +	int ret;
 +
-+	ret = dma_map_sg(rkc->dev, areq->src, sg_nents(areq->src), DMA_TO_DEVICE);
++	rctx->nrsgs = 0;
++
++	ret =
++	    dma_map_sg(rkc->dev, areq->src, sg_nents(areq->src), DMA_TO_DEVICE);
 +	if (ret <= 0)
 +		return -EINVAL;
 +
@@ -1606,20 +1612,24 @@ index 000000000000..111111111111
 +
 +static void rk2_hash_unprepare(struct crypto_engine *engine, void *breq)
 +{
-+	struct ahash_request *areq = container_of(breq, struct ahash_request, base);
++	struct ahash_request *areq =
++	    container_of(breq, struct ahash_request, base);
 +	struct rk2_ahash_rctx *rctx = ahash_request_ctx(areq);
 +	struct rk2_crypto_dev *rkc = rctx->dev;
 +
-+	dma_unmap_sg(rkc->dev, areq->src, rctx->nrsgs, DMA_TO_DEVICE);
++	if (rctx->nrsgs)
++		dma_unmap_sg(rkc->dev, areq->src, rctx->nrsgs, DMA_TO_DEVICE);
 +}
 +
 +int rk2_hash_run(struct crypto_engine *engine, void *breq)
 +{
-+	struct ahash_request *areq = container_of(breq, struct ahash_request, base);
++	struct ahash_request *areq =
++	    container_of(breq, struct ahash_request, base);
 +	struct crypto_ahash *tfm = crypto_ahash_reqtfm(areq);
 +	struct rk2_ahash_rctx *rctx = ahash_request_ctx(areq);
 +	struct ahash_alg *alg = crypto_ahash_alg(tfm);
-+	struct rk2_crypto_template *algt = container_of(alg, struct rk2_crypto_template, alg.hash.base);
++	struct rk2_crypto_template *algt =
++	    container_of(alg, struct rk2_crypto_template, alg.hash.base);
 +	struct scatterlist *sgs = areq->src;
 +	struct rk2_crypto_dev *rkc = rctx->dev;
 +	struct rk2_crypto_lli *dd = &rkc->tl[0];
@@ -1627,14 +1637,17 @@ index 000000000000..111111111111
 +	int err = 0;
 +	unsigned int len = areq->nbytes;
 +	unsigned int todo;
++	unsigned long timeout;
 +	u32 v;
 +	int i;
 +
 +	err = rk2_hash_prepare(engine, breq);
++	if (err)
++		goto theend_unmap;
 +
 +	err = pm_runtime_resume_and_get(rkc->dev);
 +	if (err)
-+		return err;
++		goto theend_unmap;
 +
 +	dev_dbg(rkc->dev, "%s %s len=%d\n", __func__,
 +		crypto_tfm_alg_name(areq->base.tfm), areq->nbytes);
@@ -1648,6 +1661,13 @@ index 000000000000..111111111111
 +	writel(rctx->mode, rkc->reg + RK2_CRYPTO_HASH_CTL);
 +
 +	while (sgs && len > 0) {
++		if (ddi >= MAX_LLI) {
++			dev_err(rkc->dev,
++				"Too many SG entries (current: %d, max: %d)\n",
++				ddi, MAX_LLI);
++			err = -EINVAL;
++			goto theend;
++		}
 +		dd = &rkc->tl[ddi];
 +
 +		todo = min(sg_dma_len(sgs), len);
@@ -1657,7 +1677,8 @@ index 000000000000..111111111111
 +		dd->dst_len = 0;
 +		dd->dma_ctrl = ddi << 24;
 +		dd->iv = 0;
-+		dd->next = rkc->t_phy + sizeof(struct rk2_crypto_lli) * (ddi + 1);
++		dd->next =
++		    rkc->t_phy + sizeof(struct rk2_crypto_lli) * (ddi + 1);
 +
 +		if (ddi == 0)
 +			dd->user = RK2_LLI_CIPHER_START | RK2_LLI_STRING_FIRST;
@@ -1665,46 +1686,77 @@ index 000000000000..111111111111
 +			dd->user = 0;
 +
 +		len -= todo;
-+		dd->dma_ctrl |= RK2_LLI_DMA_CTRL_SRC_INT;
 +		if (len == 0) {
 +			dd->user |= RK2_LLI_STRING_LAST;
-+			dd->dma_ctrl |= RK2_LLI_DMA_CTRL_LAST;
++			dd->dma_ctrl |= RK2_LLI_DMA_CTRL_LAST |
++							RK2_LLI_DMA_CTRL_SRC_INT |
++							RK2_LLI_DMA_CTRL_LIST_INT;
 +		}
-+		dev_dbg(rkc->dev, "HASH SG %d sglen=%d user=%x dma=%x mode=%x len=%d todo=%d phy=%llx\n",
-+			ddi, sgs->length, dd->user, dd->dma_ctrl, rctx->mode, len, todo, rkc->t_phy);
++		dev_dbg(rkc->dev,
++			"HASH SG %d sglen=%d user=%x dma=%x mode=%x len=%d todo=%d phy=%llx\n",
++			ddi, sgs->length, dd->user, dd->dma_ctrl, rctx->mode,
++			len, todo, rkc->t_phy);
 +
 +		sgs = sg_next(sgs);
 +		ddi++;
 +	}
 +	dd->next = 1;
-+	writel(RK2_CRYPTO_DMA_INT_LISTDONE | 0x7F, rkc->reg + RK2_CRYPTO_DMA_INT_EN);
++
++	/* Program total payload length for hardware padding */
++	writel(areq->nbytes, rkc->reg + RK2_CRYPTO_CH0_PC_LEN_0);
++
++	/* Clear stale interrupts, then enable with proper write-mask */
++	writel(0x7F, rkc->reg + RK2_CRYPTO_DMA_INT_ST);
++	writel(0x007F007F, rkc->reg + RK2_CRYPTO_DMA_INT_EN);
 +
 +	writel(rkc->t_phy, rkc->reg + RK2_CRYPTO_DMA_LLI_ADDR);
 +
 +	reinit_completion(&rkc->complete);
 +	rkc->status = 0;
 +
-+	writel(RK2_CRYPTO_DMA_CTL_START | RK2_CRYPTO_DMA_CTL_START << 16, rkc->reg + RK2_CRYPTO_DMA_CTL);
++	writel(RK2_CRYPTO_DMA_CTL_START | (RK2_CRYPTO_DMA_CTL_START << 16),
++	       rkc->reg + RK2_CRYPTO_DMA_CTL);
 +
-+	wait_for_completion_interruptible_timeout(&rkc->complete,
-+						  msecs_to_jiffies(2000));
-+	if (!rkc->status) {
++	timeout = wait_for_completion_timeout(&rkc->complete,
++					      msecs_to_jiffies(2000));
++	if (!timeout) {
 +		dev_err(rkc->dev, "DMA timeout\n");
-+		err = -EFAULT;
++		err = -ETIMEDOUT;
++		goto theend;
++	}
++	if (!rkc->status) {
++		dev_err(rkc->dev, "DMA error\n");
++		err = -EIO;
++		reset_control_assert(rkc->rst);
++		udelay(10);
++		reset_control_deassert(rkc->rst);
 +		goto theend;
 +	}
 +
-+	readl_poll_timeout_atomic(rkc->reg + RK2_CRYPTO_HASH_VALID, v, v == 1,
-+				  10, 1000);
++	err =
++	    readl_poll_timeout_atomic(rkc->reg + RK2_CRYPTO_HASH_VALID, v,
++				      v == 1, 10, 1000);
++	if (err) {
++		dev_err(rkc->dev, "Hash result not valid\n");
++		goto theend;
++	}
 +
++	/* Hardware outputs digest words in big-endian register format.
++	 * be32_to_cpu() corrects for little-endian ARM64 readl().
++	 */
 +	for (i = 0; i < crypto_ahash_digestsize(tfm) / 4; i++) {
 +		v = readl(rkc->reg + RK2_CRYPTO_HASH_DOUT_0 + i * 4);
 +		put_unaligned_le32(be32_to_cpu(v), areq->result + i * 4);
 +	}
 +
-+theend:
++ theend:
++	if (err)
++		writel(0xffff0000, rkc->reg + RK2_CRYPTO_HASH_CTL);
++
++	pm_runtime_mark_last_busy(rkc->dev);
 +	pm_runtime_put_autosuspend(rkc->dev);
 +
++ theend_unmap:
 +	rk2_hash_unprepare(engine, breq);
 +
 +	local_bh_disable();
@@ -1719,15 +1771,21 @@ index 000000000000..111111111111
 +	struct rk2_ahash_ctx *tctx = crypto_ahash_ctx(tfm);
 +	const char *alg_name = crypto_ahash_alg_name(tfm);
 +	struct ahash_alg *alg = crypto_ahash_alg(tfm);
-+	struct rk2_crypto_template *algt = container_of(alg, struct rk2_crypto_template, alg.hash.base);
++	struct rk2_crypto_template *algt =
++	    container_of(alg, struct rk2_crypto_template, alg.hash.base);
++	unsigned int fallback_statesize;
 +
-+	/* for fallback */
 +	tctx->fallback_tfm = crypto_alloc_ahash(alg_name, 0,
 +						CRYPTO_ALG_NEED_FALLBACK);
 +	if (IS_ERR(tctx->fallback_tfm)) {
 +		dev_err(algt->dev->dev, "Could not load fallback driver.\n");
 +		return PTR_ERR(tctx->fallback_tfm);
 +	}
++
++	/* Promote statesize if fallback needs more space for export/import */
++	fallback_statesize = crypto_ahash_statesize(tctx->fallback_tfm);
++	if (fallback_statesize > crypto_ahash_statesize(tfm))
++		crypto_ahash_set_statesize(tfm, fallback_statesize);
 +
 +	crypto_ahash_set_reqsize(tfm,
 +				 sizeof(struct rk2_ahash_rctx) +
@@ -1743,10 +1801,10 @@ index 000000000000..111111111111
 +}
 diff --git a/drivers/crypto/rockchip/rk2_crypto_skcipher.c b/drivers/crypto/rockchip/rk2_crypto_skcipher.c
 new file mode 100644
-index 000000000000..111111111111
+index 000000000000..d89a28ea3370
 --- /dev/null
 +++ b/drivers/crypto/rockchip/rk2_crypto_skcipher.c
-@@ -0,0 +1,576 @@
+@@ -0,0 +1,631 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * hardware cryptographic offloader for RK3568/RK3588 SoC
@@ -1756,6 +1814,7 @@ index 000000000000..111111111111
 +#include <crypto/scatterwalk.h>
 +#include "rk2_crypto.h"
 +
++#ifdef CONFIG_CRYPTO_DEV_ROCKCHIP2_DEBUG
 +static void rk2_print(struct rk2_crypto_dev *rkc)
 +{
 +	u32 v;
@@ -1790,7 +1849,7 @@ index 000000000000..111111111111
 +		dev_err(rkc->dev, "DMA DST invalid\n");
 +		break;
 +	}
-+	switch (v & 0xC) {
++	switch ((v >> 2) & 0x3) {
 +	case 0:
 +		dev_info(rkc->dev, "DMA_STATE: DMA SRC IDLE\n");
 +		break;
@@ -1804,7 +1863,7 @@ index 000000000000..111111111111
 +		dev_err(rkc->dev, "DMA_STATE: DMA SRC invalid\n");
 +		break;
 +	}
-+	switch (v & 0x30) {
++	switch ((v >> 4) & 0x3) {
 +	case 0:
 +		dev_info(rkc->dev, "DMA_STATE: DMA LLI IDLE\n");
 +		break;
@@ -1838,7 +1897,7 @@ index 000000000000..111111111111
 +		dev_info(rkc->dev, "CIPHER_ST: HASH BUSY\n");
 +	else
 +		dev_info(rkc->dev, "CIPHER_ST: HASH IDLE\n");
-+	if (v & BIT(2))
++	if (v & BIT(3))
 +		dev_info(rkc->dev, "CIPHER_ST: OTP KEY VALID\n");
 +	else
 +		dev_info(rkc->dev, "CIPHER_ST: OTP KEY INVALID\n");
@@ -1859,7 +1918,7 @@ index 000000000000..111111111111
 +		dev_info(rkc->dev, "serial: reserved state\n");
 +		break;
 +	}
-+	switch (v & 0xC) {
++	switch ((v >> 2) & 0x3) {
 +	case 0:
 +		dev_info(rkc->dev, "mac_state: IDLE state\n");
 +		break;
@@ -1873,7 +1932,7 @@ index 000000000000..111111111111
 +		dev_info(rkc->dev, "mac_state: reserved state\n");
 +		break;
 +	}
-+	switch (v & 0x30) {
++	switch ((v >> 4) & 0x3) {
 +	case 0:
 +		dev_info(rkc->dev, "parallel_state: IDLE state\n");
 +		break;
@@ -1887,7 +1946,7 @@ index 000000000000..111111111111
 +		dev_info(rkc->dev, "parallel_state: reserved state\n");
 +		break;
 +	}
-+	switch (v & 0xC0) {
++	switch ((v >> 6) & 0x3) {
 +	case 0:
 +		dev_info(rkc->dev, "ccm_state: IDLE state\n");
 +		break;
@@ -1901,7 +1960,7 @@ index 000000000000..111111111111
 +		dev_info(rkc->dev, "ccm_state: reserved state\n");
 +		break;
 +	}
-+	switch (v & 0xF00) {
++	switch ((v >> 8) & 0xF) {
 +	case 0:
 +		dev_info(rkc->dev, "gcm_state: IDLE state\n");
 +		break;
@@ -1915,7 +1974,7 @@ index 000000000000..111111111111
 +		dev_info(rkc->dev, "gcm_state: PC state\n");
 +		break;
 +	}
-+	switch (v & 0xC00) {
++	switch ((v >> 10) & 0x1F) {
 +	case 0x1:
 +		dev_info(rkc->dev, "hash_state: IDLE state\n");
 +		break;
@@ -1939,12 +1998,14 @@ index 000000000000..111111111111
 +	v = readl(rkc->reg + RK2_CRYPTO_DMA_INT_ST);
 +	dev_info(rkc->dev, "RK2_CRYPTO_DMA_INT_ST %x\n", v);
 +}
++#endif
 +
 +static int rk2_cipher_need_fallback(struct skcipher_request *req)
 +{
 +	struct crypto_skcipher *tfm = crypto_skcipher_reqtfm(req);
 +	struct skcipher_alg *alg = crypto_skcipher_alg(tfm);
-+	struct rk2_crypto_template *algt = container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
++	struct rk2_crypto_template *algt =
++	    container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
 +	struct scatterlist *sgs, *sgd;
 +	unsigned int stodo, dtodo, len;
 +	unsigned int bs = crypto_skcipher_blocksize(tfm);
@@ -1952,17 +2013,21 @@ index 000000000000..111111111111
 +	if (!req->cryptlen)
 +		return true;
 +
++	/* XTS hardware implementations often require linear buffers 
++	 * to handle tweak updates correctly.
++	 */
 +	if (algt->is_xts) {
-+		if (sg_nents_for_len(req->src, req->cryptlen) > 1)
++		if (sg_nents_for_len(req->src, req->cryptlen) != 1)
 +			return true;
-+		if (sg_nents_for_len(req->dst, req->cryptlen) > 1)
++		if (sg_nents_for_len(req->dst, req->cryptlen) != 1)
 +			return true;
 +	}
 +
 +	len = req->cryptlen;
 +	sgs = req->src;
 +	sgd = req->dst;
-+	while (sgs && sgd) {
++
++	while (len > 0 && sgs && sgd) {
 +		if (!IS_ALIGNED(sgs->offset, sizeof(u32))) {
 +			algt->stat_fb_align++;
 +			return true;
@@ -1971,25 +2036,32 @@ index 000000000000..111111111111
 +			algt->stat_fb_align++;
 +			return true;
 +		}
++
 +		stodo = min(len, sgs->length);
 +		if (stodo % bs) {
 +			algt->stat_fb_len++;
 +			return true;
 +		}
++
 +		dtodo = min(len, sgd->length);
 +		if (dtodo % bs) {
 +			algt->stat_fb_len++;
 +			return true;
 +		}
++
++		/* DMA engines usually require symmetrical source/destination chunks */
 +		if (stodo != dtodo) {
 +			algt->stat_fb_sgdiff++;
 +			return true;
 +		}
++
 +		len -= stodo;
 +		sgs = sg_next(sgs);
 +		sgd = sg_next(sgd);
 +	}
-+	return false;
++
++	/* If len > 0, the scatterlist was too short for the request */
++	return len > 0;
 +}
 +
 +static int rk2_cipher_fallback(struct skcipher_request *areq)
@@ -1998,7 +2070,8 @@ index 000000000000..111111111111
 +	struct rk2_cipher_ctx *op = crypto_skcipher_ctx(tfm);
 +	struct rk2_cipher_rctx *rctx = skcipher_request_ctx(areq);
 +	struct skcipher_alg *alg = crypto_skcipher_alg(tfm);
-+	struct rk2_crypto_template *algt = container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
++	struct rk2_crypto_template *algt =
++	    container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
 +	int err;
 +
 +	algt->stat_fb++;
@@ -2008,6 +2081,7 @@ index 000000000000..111111111111
 +				      areq->base.complete, areq->base.data);
 +	skcipher_request_set_crypt(&rctx->fallback_req, areq->src, areq->dst,
 +				   areq->cryptlen, areq->iv);
++
 +	if (rctx->mode & RK2_CRYPTO_DEC)
 +		err = crypto_skcipher_decrypt(&rctx->fallback_req);
 +	else
@@ -2030,6 +2104,8 @@ index 000000000000..111111111111
 +		return rk2_cipher_fallback(req);
 +
 +	rkc = get_rk2_crypto();
++	if (!rkc)
++		return -ENODEV;
 +
 +	engine = rkc->engine;
 +	rctx->dev = rkc;
@@ -2074,7 +2150,8 @@ index 000000000000..111111111111
 +	struct rk2_cipher_rctx *rctx = skcipher_request_ctx(req);
 +	struct crypto_skcipher *tfm = crypto_skcipher_reqtfm(req);
 +	struct skcipher_alg *alg = crypto_skcipher_alg(tfm);
-+	struct rk2_crypto_template *algt = container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
++	struct rk2_crypto_template *algt =
++	    container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
 +
 +	rctx->mode = algt->rk2_mode;
 +	return rk2_cipher_handle_req(req);
@@ -2085,7 +2162,8 @@ index 000000000000..111111111111
 +	struct rk2_cipher_rctx *rctx = skcipher_request_ctx(req);
 +	struct crypto_skcipher *tfm = crypto_skcipher_reqtfm(req);
 +	struct skcipher_alg *alg = crypto_skcipher_alg(tfm);
-+	struct rk2_crypto_template *algt = container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
++	struct rk2_crypto_template *algt =
++	    container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
 +
 +	rctx->mode = algt->rk2_mode | RK2_CRYPTO_DEC;
 +	return rk2_cipher_handle_req(req);
@@ -2093,7 +2171,8 @@ index 000000000000..111111111111
 +
 +int rk2_cipher_run(struct crypto_engine *engine, void *async_req)
 +{
-+	struct skcipher_request *areq = container_of(async_req, struct skcipher_request, base);
++	struct skcipher_request *areq =
++	    container_of(async_req, struct skcipher_request, base);
 +	struct crypto_skcipher *tfm = crypto_skcipher_reqtfm(areq);
 +	struct rk2_cipher_rctx *rctx = skcipher_request_ctx(areq);
 +	struct rk2_cipher_ctx *ctx = crypto_skcipher_ctx(tfm);
@@ -2103,14 +2182,16 @@ index 000000000000..111111111111
 +	unsigned int len = areq->cryptlen;
 +	unsigned int todo;
 +	struct skcipher_alg *alg = crypto_skcipher_alg(tfm);
-+	struct rk2_crypto_template *algt = container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
++	struct rk2_crypto_template *algt =
++	    container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
 +	struct rk2_crypto_dev *rkc = rctx->dev;
 +	struct rk2_crypto_lli *dd = &rkc->tl[0];
 +	u32 m, v;
-+	u32 *rkey = (u32 *)ctx->key;
-+	u32 *riv = (u32 *)areq->iv;
++	u32 *rkey = (u32 *) ctx->key;
++	u32 *riv = (u32 *) areq->iv;
 +	int i;
 +	unsigned int offset;
++	unsigned long timeout;
 +
 +	algt->stat_req++;
 +	rkc->nreq++;
@@ -2125,7 +2206,8 @@ index 000000000000..111111111111
 +			m |= RK2_CRYPTO_AES_256BIT_key;
 +			break;
 +		default:
-+			dev_err(rkc->dev, "Invalid key length %u\n", ctx->keylen);
++			dev_err(rkc->dev, "Invalid key length %u\n",
++				ctx->keylen);
 +			return -EINVAL;
 +		}
 +	} else {
@@ -2140,7 +2222,8 @@ index 000000000000..111111111111
 +			m |= RK2_CRYPTO_AES_256BIT_key;
 +			break;
 +		default:
-+			dev_err(rkc->dev, "Invalid key length %u\n", ctx->keylen);
++			dev_err(rkc->dev, "Invalid key length %u\n",
++				ctx->keylen);
 +			return -EINVAL;
 +		}
 +	}
@@ -2161,7 +2244,6 @@ index 000000000000..111111111111
 +	sgd = areq->dst;
 +
 +	while (sgs && sgd && len) {
-+		ivsize = crypto_skcipher_ivsize(tfm);
 +		if (areq->iv && crypto_skcipher_ivsize(tfm) > 0) {
 +			if (rctx->mode & RK2_CRYPTO_DEC) {
 +				offset = sgs->length - ivsize;
@@ -2170,25 +2252,29 @@ index 000000000000..111111111111
 +			}
 +		}
 +
-+		dev_dbg(rkc->dev, "SG len=%u mode=%x ivsize=%u\n", sgs->length, m, ivsize);
++		dev_dbg(rkc->dev, "SG len=%u mode=%x ivsize=%u\n", sgs->length,
++			m, ivsize);
 +
 +		if (sgs == sgd) {
 +			err = dma_map_sg(rkc->dev, sgs, 1, DMA_BIDIRECTIONAL);
 +			if (err != 1) {
-+				dev_err(rkc->dev, "Invalid sg number %d\n", err);
++				dev_err(rkc->dev, "Invalid sg number %d\n",
++					err);
 +				err = -EINVAL;
 +				goto theend;
 +			}
 +		} else {
 +			err = dma_map_sg(rkc->dev, sgs, 1, DMA_TO_DEVICE);
 +			if (err != 1) {
-+				dev_err(rkc->dev, "Invalid sg number %d\n", err);
++				dev_err(rkc->dev, "Invalid sg number %d\n",
++					err);
 +				err = -EINVAL;
 +				goto theend;
 +			}
 +			err = dma_map_sg(rkc->dev, sgd, 1, DMA_FROM_DEVICE);
 +			if (err != 1) {
-+				dev_err(rkc->dev, "Invalid sg number %d\n", err);
++				dev_err(rkc->dev, "Invalid sg number %d\n",
++					err);
 +				err = -EINVAL;
 +				dma_unmap_sg(rkc->dev, sgs, 1, DMA_TO_DEVICE);
 +				goto theend;
@@ -2204,7 +2290,8 @@ index 000000000000..111111111111
 +			}
 +			for (i = 0; i < (ctx->keylen / 8); i++) {
 +				v = cpu_to_be32(rkey[i + ctx->keylen / 8]);
-+				writel(v, rkc->reg + RK2_CRYPTO_CH4_KEY0 + i * 4);
++				writel(v,
++				       rkc->reg + RK2_CRYPTO_CH4_KEY0 + i * 4);
 +			}
 +		} else {
 +			for (i = 0; i < ctx->keylen / 4; i++) {
@@ -2225,13 +2312,13 @@ index 000000000000..111111111111
 +			continue;
 +		}
 +
-+		/* The hw support multiple descriptor, so why this driver use
-+		 * only one descriptor ?
-+		 * Using one descriptor per SG seems the way to do and it works
-+		 * but only when doing encryption.
-+		 * With decryption it always fail on second descriptor.
-+		 * Probably the HW dont know how to use IV.
-+		 */
++		/*
++		 * Process one SG entry per DMA operation. The cipher engine requires
++		 * the IV to be updated between SG entries for CBC and XTS modes;
++		 * the backup_iv mechanism handles this correctly for decryption.
++		 * Building a full multi-descriptor chain is possible but adds
++		 * complexity for no measurable throughput gain on typical workloads.
++ 		*/
 +		todo = min(sg_dma_len(sgs), len);
 +		len -= todo;
 +		dd->src_addr = sg_dma_address(sgs);
@@ -2241,21 +2328,27 @@ index 000000000000..111111111111
 +		dd->iv = 0;
 +		dd->next = 1;
 +
-+		dd->user = RK2_LLI_CIPHER_START | RK2_LLI_STRING_FIRST | RK2_LLI_STRING_LAST;
-+		dd->dma_ctrl |= RK2_LLI_DMA_CTRL_DST_INT | RK2_LLI_DMA_CTRL_LAST;
++		dd->user = RK2_LLI_CIPHER_START | 
++				RK2_LLI_STRING_FIRST |
++				RK2_LLI_STRING_LAST;
++		dd->dma_ctrl = RK2_LLI_DMA_CTRL_DST_INT |
++					RK2_LLI_DMA_CTRL_LAST |
++					RK2_LLI_DMA_CTRL_LIST_INT;
 +
-+		writel(RK2_CRYPTO_DMA_INT_LISTDONE | 0x7F, rkc->reg + RK2_CRYPTO_DMA_INT_EN);
++		writel(0x7F, rkc->reg + RK2_CRYPTO_DMA_INT_ST);
++		writel(0x007F007F, rkc->reg + RK2_CRYPTO_DMA_INT_EN);
 +
-+		/*writel(0x00030000, rkc->reg + RK2_CRYPTO_FIFO_CTL);*/
 +		writel(rkc->t_phy, rkc->reg + RK2_CRYPTO_DMA_LLI_ADDR);
 +
 +		reinit_completion(&rkc->complete);
 +		rkc->status = 0;
 +
-+		writel(RK2_CRYPTO_DMA_CTL_START | 1 << 16, rkc->reg + RK2_CRYPTO_DMA_CTL);
++		writel(RK2_CRYPTO_DMA_CTL_START |
++		       (RK2_CRYPTO_DMA_CTL_START << 16),
++		       rkc->reg + RK2_CRYPTO_DMA_CTL);
 +
-+		wait_for_completion_interruptible_timeout(&rkc->complete,
-+							  msecs_to_jiffies(10000));
++		timeout = wait_for_completion_timeout(&rkc->complete,
++						      msecs_to_jiffies(2000));
 +		if (sgs == sgd) {
 +			dma_unmap_sg(rkc->dev, sgs, 1, DMA_BIDIRECTIONAL);
 +		} else {
@@ -2263,12 +2356,27 @@ index 000000000000..111111111111
 +			dma_unmap_sg(rkc->dev, sgd, 1, DMA_FROM_DEVICE);
 +		}
 +
-+		if (!rkc->status) {
++		if (!timeout) {
 +			dev_err(rkc->dev, "DMA timeout\n");
-+			rk2_print(rkc);
-+			err = -EFAULT;
++			err = -ETIMEDOUT;
 +			goto theend;
 +		}
++
++		if (!rkc->status) {
++			dev_err(rkc->dev, "DMA error\n");
++#ifdef CONFIG_CRYPTO_DEV_ROCKCHIP2_DEBUG
++			rk2_print(rkc);
++#endif
++			err = -EIO;
++
++			/* Reset the entire crypto block to recover from stuck DMA. */
++			reset_control_assert(rkc->rst);
++			udelay(10);
++			reset_control_deassert(rkc->rst);
++
++			goto theend;
++		}
++
 +		if (areq->iv && ivsize > 0) {
 +			offset = sgd->length - ivsize;
 +			if (rctx->mode & RK2_CRYPTO_DEC) {
@@ -2282,8 +2390,9 @@ index 000000000000..111111111111
 +		sgs = sg_next(sgs);
 +		sgd = sg_next(sgd);
 +	}
-+theend:
++ theend:
 +	writel(0xffff0000, rkc->reg + RK2_CRYPTO_BC_CTL);
++	pm_runtime_mark_last_busy(rkc->dev);
 +	pm_runtime_put_autosuspend(rkc->dev);
 +
 +	local_bh_disable();
@@ -2297,21 +2406,25 @@ index 000000000000..111111111111
 +	struct rk2_cipher_ctx *ctx = crypto_skcipher_ctx(tfm);
 +	const char *name = crypto_tfm_alg_name(&tfm->base);
 +	struct skcipher_alg *alg = crypto_skcipher_alg(tfm);
-+	struct rk2_crypto_template *algt = container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
++	struct rk2_crypto_template *algt =
++	    container_of(alg, struct rk2_crypto_template, alg.skcipher.base);
 +
-+	ctx->fallback_tfm = crypto_alloc_skcipher(name, 0, CRYPTO_ALG_NEED_FALLBACK);
++	ctx->fallback_tfm =
++	    crypto_alloc_skcipher(name, 0, CRYPTO_ALG_NEED_FALLBACK);
 +	if (IS_ERR(ctx->fallback_tfm)) {
-+		dev_err(algt->dev->dev, "ERROR: Cannot allocate fallback for %s %ld\n",
-+			name, PTR_ERR(ctx->fallback_tfm));
++		dev_err(algt->dev->dev,
++			"ERROR: Cannot allocate fallback for %s %ld\n", name,
++			PTR_ERR(ctx->fallback_tfm));
 +		return PTR_ERR(ctx->fallback_tfm);
 +	}
 +
-+	dev_info(algt->dev->dev, "Fallback for %s is %s\n",
++	dev_dbg(algt->dev->dev, "Fallback for %s is %s\n",
 +		 crypto_tfm_alg_driver_name(&tfm->base),
-+		 crypto_tfm_alg_driver_name(crypto_skcipher_tfm(ctx->fallback_tfm)));
++		 crypto_tfm_alg_driver_name(crypto_skcipher_tfm
++					    (ctx->fallback_tfm)));
 +
 +	tfm->reqsize = sizeof(struct rk2_cipher_rctx) +
-+		crypto_skcipher_reqsize(ctx->fallback_tfm);
++	    crypto_skcipher_reqsize(ctx->fallback_tfm);
 +
 +	return 0;
 +}
@@ -2323,6 +2436,3 @@ index 000000000000..111111111111
 +	memzero_explicit(ctx->key, ctx->keylen);
 +	crypto_free_skcipher(ctx->fallback_tfm);
 +}
--- 
-Armbian
-


### PR DESCRIPTION
# Description
Fixes and updates to

This issue for instance:
[Bug]: rk3588 crypto unaccelerated #7703

# Documentation summary for feature / change

1. Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml

    Clock names corrected. Original had "a" and "h" as clock-names items. v3 corrects them to "core", "aclk", "hclk" matching the actual clock signal names in the hardware and passing make dt_binding_check.
    YAML example reg size fixed. Original example said 0x4000 (16KB). v3 corrects to 0x2000 (8KB) to match both DTS nodes and the actual hardware register map.

2. drivers/crypto/Makefile

    Root Makefile hook added. v3 adds obj-$(CONFIG_CRYPTO_DEV_ROCKCHIP2) += rockchip/ to the root crypto Makefile. Without this, if CONFIG_CRYPTO_DEV_ROCKCHIP (the V1 driver) is disabled, the build system never descends into drivers/crypto/rockchip/ and the V2 driver silently doesn't build regardless of Kconfig selection.

3. rk2_crypto.h

    dbgfs_info field added to struct rockchip_ip. Original was missing it, causing register_debugfs to overwrite dbgfs_stats with the info file pointer. v3 adds struct dentry *dbgfs_info as the third debugfs member.
    #include <linux/reset.h> added. Moved from rk2_crypto.c so that rk2_crypto_ahash.c and rk2_crypto_skcipher.c can call reset_control_assert/deassert directly in their DMA error recovery paths.
    fallback_req ordering documented. Added // keep at the end comment on struct skcipher_request fallback_req in rk2_cipher_rctx. Same ordering maintained in rk2_ahash_rctx with struct ahash_request fallback_req as last member — required for the flexible array __ctx placement to work correctly.

4. rk2_crypto.c

    pm_init return value fixed. Original returned err at the end, which after pm_runtime_enable would always be 0 but was misleading. v3 explicitly return 0.
    IRQ handler fires complete() only on LISTDONE or hard error. Original called complete() on any non-zero DMA_INT_ST. Intermediate SRC_INT per-LLI-entry interrupts would prematurely wake the hash path before all data was processed, producing wrong digests. v3 only signals completion for RK2_CRYPTO_DMA_INT_LISTDONE (BIT(0)) or error bits (0xF8).
    Consistent spin_lock_bh throughout. get_rk2_crypto(), probe, and remove all use spin_lock_bh/spin_unlock_bh. Original used plain spin_lock in get_rk2_crypto() and probe, risking deadlock if a crypto engine callback ran on the same CPU.
    Debugfs overwrite bug fixed. Original register_debugfs wrote to rocklist.dbgfs_stats twice — the second write (info file) overwrote the stats file pointer. v3 correctly uses rocklist.dbgfs_info for the second file.
    pm_runtime_resume_and_get return value checked in probe. Original ignored this return value. v3 checks it and jumps to err_pm on failure.
    PM reference count balanced on probe success. Original left usage count at 1 after successful registration, pinning the device ON forever. v3 calls pm_runtime_mark_last_busy + pm_runtime_put_autosuspend after successful registration.
    Separate err_register_alg label with list_del + pm_runtime_put_sync. Original jumped to err_pm on registration failure, which skipped both the list cleanup and the PM put. v3 has a dedicated label that removes the device from the list and decrements the PM count before falling through to rk2_crypto_pm_exit.
    crypto_engine_exit called before rk2_crypto_pm_exit in remove. Original order was reversed — clocks disabled before engine drained. v3 exits the engine first to flush all in-flight requests, then disables PM.
    algt->dev handoff on multi-device remove. When the registering device is removed while a second device survives, v3 iterates all algorithm templates and updates algt->dev to the surviving device, preventing use-after-free in tfm_init/tfm_exit logging.
    dma_free_coherent added to rk2_crypto_remove. The LLI table is a non-managed allocation. Original never freed it on normal remove, leaking it on every rmmod. v3 frees it at the end of remove.
    pm_resume does full assert/udelay/deassert cycle. Ensures hardware is cleanly initialised with clocks running on every PM wakeup, not just deassert.

5. rk2_crypto_ahash.c

    Multi-SG hardware fallback. Added if (sg_nents(areq->src) > 1) check at the top of rk2_ahash_need_fallback. The RK3568/3588 hardware padding engine (HW_PAD) loses block-count state across LLI descriptor boundaries, producing wrong digests for any multi-SG request. Single-SG requests continue to use hardware; multi-SG routes to software fallback and increments stat_fb_sgdiff.
    Explicit payload length for hardware padding. Added writel(areq->nbytes, rkc->reg + RK2_CRYPTO_CH0_PC_LEN_0) before starting DMA. The HW_PAD bit requires the total message length to be programmed in advance so the hardware knows where to apply the Merkle–Damgård padding. Without this, single-SG hardware hashes would also produce wrong results.
    INT_EN write-enable mask fixed. Original wrote RK2_CRYPTO_DMA_INT_LISTDONE | 0x7F with no upper bits, which is silently discarded by the HIWORD_UPDATE register pattern. v3 first clears stale pending interrupts (writel(0x7F, DMA_INT_ST)), then writes 0x007F007F so enable bits and their write-enable mask are both set.
    LIST_INT added to last LLI descriptor. LISTDONE (BIT(0)) is only set in DMA_INT_ST when the last LLI entry has RK2_LLI_DMA_CTRL_LIST_INT (BIT(8)) set in dma_ctrl. Without it, DMA completes silently, no interrupt fires, 2-second timeout every request. v3 adds RK2_LLI_DMA_CTRL_LIST_INT | RK2_LLI_DMA_CTRL_SRC_INT to the last descriptor.
    Uninterruptible completion wait. Changed from wait_for_completion_interruptible_timeout to wait_for_completion_timeout. The interruptible variant can return early on SIGTERM/SIGKILL while DMA is still writing to memory, causing data corruption or use-after-free.
    timeout return value captured and checked. Original discarded the return value, making timeout undetectable. v3 stores the return in unsigned long timeout and checks !timeout for ETIMEDOUT, then separately checks !rkc->status for EIO.
    rctx->nrsgs = 0 initialised before dma_map_sg. Ensures rk2_hash_unprepare never calls dma_unmap_sg on an uninitialised count.
    Safe dma_unmap_sg in unprepare. Added if (rctx->nrsgs) guard before dma_unmap_sg, preventing a kernel panic if dma_map_sg failed in the prepare step.
    MAX_LLI overflow check. Added if (ddi >= MAX_LLI) at the top of the LLI build loop with dev_err and -EINVAL. Prevents overflowing the DMA-coherent LLI table with a scatter-list longer than 20 entries.
    readl_poll_timeout_atomic return value checked. Original discarded the return, allowing wrong digest output if HASH_VALID never set. v3 assigns to err and jumps to theend on timeout.
    be32_to_cpu in digest readback. Hardware outputs all digest words (SHA1, SHA256, SHA384, SHA512, SM3, MD5) in big-endian register format. readl() on LE ARM64 gives a byte-swapped value; be32_to_cpu corrects it before put_unaligned_le32.
    pm_runtime_mark_last_busy before put_autosuspend. Refreshes the autosuspend timer on each request completion so the device doesn't suspend between back-to-back requests.
    DMA error hardware reset. On !rkc->status (DMA error interrupt), v3 performs reset_control_assert/udelay(10)/reset_control_deassert to recover the DMA engine from a stuck state before returning -EIO.
    crypto_ahash_set_statesize promotion in rk2_hash_init_tfm. After allocating the fallback, v3 queries its statesize and promotes the template's statesize if the fallback needs more space. Fixes -EOVERFLOW on export()/import() when ARM Crypto Extensions drivers (sha1-ce, sha256-ce) advertise a larger statesize than the raw hash state.

6. rk2_crypto_skcipher.c

    rk2_print gated with #ifdef CONFIG_CRYPTO_DEV_ROCKCHIP2_DEBUG. Register dumps on every DMA error flood production logs. v3 wraps the entire function and its callsite with the debug config guard.
    OTP KEY VALID bit corrected. Original checked BIT(2) for both HASH BUSY and OTP KEY VALID (copy-paste error). v3 uses BIT(3) for OTP KEY VALID.
    Multi-bit switch statements corrected. All field switches now use (v >> N) & mask before comparing case values, fixing cases that could never match after masking.
    dd->dma_ctrl =  assignment not |=. The LLI table persists across requests. Using |= accumulates stale flag bits from previous requests. v3 uses = for the initial value.
    RK2_CRYPTO_DMA_CTL_START << 16 not literal 1 << 16. Ensures the write-enable mask is always correct regardless of the constant value.
    get_rk2_crypto() with null check for cipher. Original used algt->dev (always first device) for all cipher requests, bypassing load balancing. v3 uses get_rk2_crypto() matching the hash path, with if (!rkc) return -ENODEV.
    DMA unmap moved before timeout/error checks. Original goto theend on timeout bypassed dma_unmap_sg, permanently leaking the mapping. v3 unmaps unconditionally before checking results.
    wait_for_completion_timeout (uninterruptible). Same fix as hash — prevents signal interruption while DMA is active.
    Separate timeout/error errnos. ETIMEDOUT for timeout, EIO for DMA error with rk2_print debug dump.
    INT_EN write-enable mask + stale clear. Same fix as hash path: writel(0x7F, DMA_INT_ST) then writel(0x007F007F, DMA_INT_EN).
    LIST_INT added to cipher descriptor. RK2_LLI_DMA_CTRL_LIST_INT added to dd->dma_ctrl so LISTDONE fires in DMA_INT_ST.
    pm_runtime_mark_last_busy before put_autosuspend.
    DMA error hardware reset. Same reset_control_assert/deassert recovery as hash.
    Fallback log changed to dev_dbg. Original dev_info in rk2_cipher_tfm_init flooded logs during PM stress testing (hundreds of TFM allocations per second). v3 uses dev_dbg.
    Stricter XTS fallback check. Changed sg_nents(areq->src) > 1 to != 1 for the XTS-specific SG check. XTS requires exactly one contiguous buffer — more than one SG is wrong but so is zero.

7. include/dt-bindings/reset/rockchip,rk3588-cru.h

    Patch correctly uses mainline SCMI for RK3588. mainline Linux kernel Commit 849d9db form Feb 22, 2025 "dt-bindings: reset: Add SCMI reset IDs for RK3588" so there is no reason to modify this file as entries exist already. Please note the patch still removes the entire RK3588_SECURECRU_RESET_OFFSET macro and all its entries as keeping them in rst-rk3588.c alongside SCMI would be redundant and potentially dangerous.
# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._
CONFIG_CRYPTO_SELFTESTS=y
CONFIG_CRYPTO_SELFTESTS_FULL=y

modprobe tcrypt mode=38   # AES-ECB
modprobe tcrypt mode=39   # AES-CBC
modprobe tcrypt mode=400  # SHA-256
modprobe tcrypt mode=404  # SHA-512
modprobe tcrypt mode=405  # MD5
dmesg | grep -E "tcrypt|testing|passed|failed"

cat /proc/crypto | grep -A5 "rk2"
driver       : rk2-sm3
module       : rk_crypto2
priority     : 300
refcnt       : 1
selftest     : passed
internal     : no
--
driver       : rk2-sha512
module       : rk_crypto2
priority     : 300
refcnt       : 1
selftest     : passed
internal     : no
--
driver       : rk2-sha384
module       : rk_crypto2
priority     : 300
refcnt       : 1
selftest     : passed
internal     : no
--
driver       : rk2-sha256
module       : rk_crypto2
priority     : 300
refcnt       : 1
selftest     : passed
internal     : no
--
driver       : rk2-sha1
module       : rk_crypto2
priority     : 300
refcnt       : 1
selftest     : passed
internal     : no
--
driver       : rk2-md5
module       : rk_crypto2
priority     : 300
refcnt       : 1
selftest     : passed
internal     : no
--
driver       : xts-aes-rk2
module       : rk_crypto2
priority     : 300
refcnt       : 1
selftest     : passed
internal     : no
--
driver       : cbc-aes-rk2
module       : rk_crypto2
priority     : 300
refcnt       : 1
selftest     : passed
internal     : no
--
driver       : ecb-aes-rk2
module       : rk_crypto2
priority     : 300
refcnt       : 1
selftest     : passed
internal     : no

cat /sys/kernel/debug/rk2_crypto/stats
rk2-crypto fe370000.crypto requests: 738
ecb-aes-rk2 ecb(aes) reqs=144 fallback=1960
	fallback due to length: 303
	fallback due to alignment: 1651
	fallback due to SGs: 0
cbc-aes-rk2 cbc(aes) reqs=183 fallback=2109
	fallback due to length: 308
	fallback due to alignment: 1790
	fallback due to SGs: 7
xts-aes-rk2 xts(aes) reqs=174 fallback=2170
	fallback due to length: 74
	fallback due to alignment: 763
	fallback due to SGs: 0
rk2-md5 md5 reqs=34 fallback=718
rk2-sha1 sha1 reqs=46 fallback=654
rk2-sha256 sha256 reqs=34 fallback=609
rk2-sha384 sha384 reqs=41 fallback=666
rk2-sha512 sha512 reqs=42 fallback=654
rk2-sm3 sm3 reqs=40 fallback=690

cat /sys/kernel/debug/rk2_crypto/info
CRYPTO_CLK_CTL 1
CRYPTO_RST_CTL 0
CRYPTO_AES_VERSION 707ff
AES 192
CRYPTO_DES_VERSION 30033
CRYPTO_SM4_VERSION 7ff
CRYPTO_HASH_VERSION 1ff
CRYPTO_HMAC_VERSION 1f
CRYPTO_RNG_VERSION 1000000
CRYPTO_PKA_VERSION 1000000
CRYPTO_CRYPTO_VERSION 2000001

cryptsetup benchmark --cipher aes-cbc --key-size 256
# Tests are approximate using memory only (no storage IO).
# Algorithm |       Key |      Encryption |      Decryption
    aes-cbc        256b       106.4 MiB/s        68.0 MiB/s

 # rapid suspend/resume
for i in $(seq 1 1000); do
    echo -n "test$i" | sha256sum
    sleep 0.003
done

for i in $(seq 1 20); do
    modprobe rk_crypto2
    sleep 1
    rmmod rk_crypto2
    sleep 0.5
done


# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hardware-accelerated cryptographic support for RK3588 and RK3568 devices.

* **Bug Fixes**
  * Improved error handling and timeout recovery in cryptographic operations.
  * Corrected device configuration settings for better hardware compatibility.
  * Enhanced resource management and initialization stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9795)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->