### PR TITLE
fix(offline): honor OFFLINE_WORK in git-ref2info and memoize TTL

### DIFF
--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -7,6 +7,20 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
+# Returns the pinned sha1 for a given git source+branch from
+# config/sources/git_sources.json, or nothing if the file or entry is absent.
+# Uses jq --arg so source/branch values can't break or inject into the jq program.
+# Intentionally file-scope (not nested in memoized_git_ref_to_info) so fetch_from_repo
+# in git.sh can reuse it. Consequence: its body is NOT part of the memoize cache hash
+# (only the memoized function's own body is), so edits here won't invalidate cached
+# entries. Keep it trivial and stable — an exact-match JSON read — so that's safe.
+function _git_sources_pinned_sha1() {
+	declare json="${SRC}/config/sources/git_sources.json"
+	[[ -f "${json}" ]] || return 0
+	jq --raw-output --arg s "${1}" --arg b "${2}" \
+		'[.[] | select(.source == $s and .branch == $b) | .sha1] | first // empty' "${json}"
+}
+
 # This works under memoize-cached.sh::run_memoized() -- which is full of tricks.
 # Nested functions are used because the source of the momoized function is used as part of the cache hash.
 function memoized_git_ref_to_info() {
@@ -30,6 +44,21 @@ function memoized_git_ref_to_info() {
 
 	# Get the SHA1 of the commit
 	declare sha1
+
+	# OFFLINE_WORK guard: do not perform 'git ls-remote' when offline (#6439).
+	# Honored sources, in order: ref_type=commit (sha1 from ref itself); pinned in
+	# config/sources/git_sources.json (branch refs only). If neither yields a sha1 we
+	# fail with a clear message instead of letting the network call surface as a
+	# misleading 502/timeout.
+	if [[ "${OFFLINE_WORK}" == "yes" && "${ref_type}" != "commit" ]]; then
+		sha1="$(_git_sources_pinned_sha1 "${MEMO_DICT[GIT_SOURCE]}" "${ref_name}")"
+		if [[ "${sha1}" =~ ^[0-9a-f]{40}$ ]]; then
+			display_alert "OFFLINE_WORK: using pinned SHA1 from git_sources.json" "${ref_name} -> ${sha1}" "info"
+			refs_to_try=() # skip ls-remote loop below
+		else
+			exit_with_error "OFFLINE_WORK=yes but no SHA1 available for '${MEMO_DICT[GIT_SOURCE]}' '${ref_type}' '${ref_name}' - run online once to populate cache, or pin sha1 in config/sources/git_sources.json"
+		fi
+	fi
 
 	# Enter loop. The first that resolves to a valid sha1 wins.
 	declare to_try
@@ -93,10 +122,15 @@ function memoized_git_ref_to_info() {
 		} 5<> "${SRC}"/output/info/git_sources.json 6<> "${SRC}"/output/info/git_sources.json.new
 	fi
 
-	if [[ -f "${SRC}"/config/sources/git_sources.json && ${ref_type} == "branch" ]]; then
-		cached_revision=$(jq --raw-output '.[] | select(.source == "'${MEMO_DICT[GIT_SOURCE]}'" and .branch == "'$ref_name'") |.sha1' "${SRC}"/config/sources/git_sources.json)
-		display_alert "Found cached git version" "${cached_revision}" "info"
-		[[ -z "${cached_revision}" ]] || sha1=${cached_revision}
+	if [[ "${ref_type}" == "branch" ]]; then
+		declare cached_revision
+		cached_revision="$(_git_sources_pinned_sha1 "${MEMO_DICT[GIT_SOURCE]}" "${ref_name}")"
+		if [[ "${cached_revision}" =~ ^[0-9a-f]{40}$ ]]; then
+			display_alert "Found cached git version" "${cached_revision}" "info"
+			sha1="${cached_revision}"
+		elif [[ -n "${cached_revision}" ]]; then
+			exit_with_error "Invalid pinned SHA1 '${cached_revision}' for '${MEMO_DICT[GIT_SOURCE]}' '${ref_name}' in config/sources/git_sources.json"
+		fi
 	fi
 
 	MEMO_DICT+=(["SHA1"]="${sha1}")
@@ -243,6 +277,14 @@ function memoized_git_ref_to_info() {
 
 			return 0
 		}
+
+		# OFFLINE_WORK guard: Makefile body is fetched via curl to git host(s) — no
+		# network when offline. We have no local fallback here (no bare-clone path in
+		# scope), so fail with a clear message instead of letting curl surface as a
+		# misleading 'undetermined' kernel version downstream (#6439).
+		if [[ "${OFFLINE_WORK}" == "yes" ]]; then
+			exit_with_error "OFFLINE_WORK=yes but Makefile body for '${MEMO_DICT[GIT_SOURCE]}' '${ref_name}' (sha1 ${sha1}) not in cache - run online once to populate ${SRC}/cache/memoize/"
+		fi
 
 		display_alert "Fetching Makefile body" "${ref_name}" "debug"
 		declare makefile_body makefile_url

--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -254,9 +254,14 @@ function fetch_from_repo() {
 		esac
 	fi
 
-	if [[ -f "${SRC}"/config/sources/git_sources.json && $ref_type == "branch" ]]; then
-		cached_revision=$(jq --raw-output '.[] | select(.source == "'$url'" and .branch == "'$ref_name'") |.sha1' "${SRC}"/config/sources/git_sources.json)
-		[[ -z "${cached_revision}" ]] || fetched_revision=${cached_revision}
+	if [[ "${ref_type}" == "branch" ]]; then
+		declare cached_revision
+		cached_revision="$(_git_sources_pinned_sha1 "${url}" "${ref_name}")"
+		if [[ "${cached_revision}" =~ ^[0-9a-f]{40}$ ]]; then
+			fetched_revision="${cached_revision}"
+		elif [[ -n "${cached_revision}" ]]; then
+			exit_with_error "Invalid pinned SHA1 '${cached_revision}' for '${url}' '${ref_name}' in config/sources/git_sources.json"
+		fi
 	fi
 
 	if [[ "${do_checkout:-"yes"}" == "yes" ]]; then

--- a/lib/functions/general/memoize-cached.sh
+++ b/lib/functions/general/memoize-cached.sh
@@ -79,8 +79,17 @@ function run_memoized() {
 	if [[ -f "${disk_cache_file}" ]]; then
 		declare disk_cache_file_mtime_seconds
 		disk_cache_file_mtime_seconds="$(stat -c %Y "${disk_cache_file}")"
-		# if disk_cache_file is older than the ttl, delete it and continue.
+		declare cache_is_stale="no"
 		if [[ "${disk_cache_file_mtime_seconds}" -lt "$(($(date +%s) - memoize_cache_ttl))" ]]; then
+			cache_is_stale="yes"
+		fi
+		# OFFLINE_WORK: serve any cached entry regardless of TTL — the alternative is
+		# a network call that will fail (#6439). Surface that we're using a stale entry.
+		if [[ "${cache_is_stale}" == "yes" && "${OFFLINE_WORK}" == "yes" ]]; then
+			display_alert "OFFLINE_WORK: using stale cache" "${var_n}" "info"
+			cache_is_stale="no"
+		fi
+		if [[ "${cache_is_stale}" == "yes" ]]; then
 			display_alert "Deleting stale cache file" "${disk_cache_file}" "debug"
 			rm -f "${disk_cache_file}"
 		else

--- a/lib/functions/general/memoize-cached.sh
+++ b/lib/functions/general/memoize-cached.sh
@@ -97,6 +97,7 @@ function run_memoized() {
 			display_alert "Using cached" "${var_n}" "info"
 			# shellcheck disable=SC1090 # yep, I'm sourcing the cache here. produced below.
 			source "${disk_cache_file}"
+			flock -u "${lock_fd}"
 			return 0
 		fi
 	fi


### PR DESCRIPTION
## Summary

Fixes #6439.

`memoized_git_ref_to_info()` unconditionally ran `git ls-remote` against the
upstream source even with `OFFLINE_WORK=yes`; when the remote was unreachable
(e.g. `git.kernel.org` 502) the build aborted with a misleading network error
instead of honoring the offline flag.

Two coordinated guards:

- **`memoize-cached.sh`**: when `OFFLINE_WORK=yes`, serve the cache file
  regardless of TTL (the alternative is a network call that will fail). The
  "stale cache served" event is logged via `display_alert`.
- **`git-ref2info.sh`**: early offline guard before the `ls-remote` loop. For
  `ref_type=commit` the SHA1 is taken from the ref itself (no network); for
  branch/tag we look up a pinned SHA1 in `config/sources/git_sources.json`. If
  neither is available, `exit_with_error` with a clear message instead of letting
  `curl`/`ls-remote` surface as a 502.

  The same guard is applied to the `include_makefile_body` block (curl to git
  host) since there is no local-bare fallback in scope here.

Behaviour matrix unchanged for `OFFLINE_WORK=no` (default).

| `OFFLINE_WORK` | memoize cache | pinned in `git_sources.json` | result |
|---|---|---|---|
| no | hit (fresh) | * | use cache (unchanged) |
| no | hit (stale) | * | regen via `ls-remote` (unchanged) |
| no | miss | yes | `ls-remote` then pinned override (unchanged) |
| no | miss | no | `ls-remote` (unchanged) |
| **yes** | hit (any age) | * | use cache (NEW: ignore TTL) |
| **yes** | miss | yes | use pinned, no network (NEW) |
| **yes** | miss | no | fail with clear message (NEW: previously misleading 502) |
| **yes** | _Makefile body needed_ + miss | * | fail with clear message (NEW) |

## Refactor: shared pinned-SHA helper

The pinned-SHA lookup from `config/sources/git_sources.json` was duplicated across
three call sites, two of which built the `jq` filter by concatenating `source`/
`branch` directly into the program text (breaks or mis-parses on values
containing quotes). Extracted into a single `_git_sources_pinned_sha1` helper that
passes values through `jq --arg`, now shared by:

- the offline guard,
- the existing branch-resolution override in `git-ref2info.sh`,
- `fetch_from_repo()` in `git.sh`.

Each call site validates the pinned SHA (40-hex) before use, failing loudly on a
malformed pin instead of silently overriding an already-resolved revision.

## Test plan

Verified via standalone scaffold against an isolated `${SRC}/cache/memoize/`
sandbox:

- [x] `OFFLINE_WORK=yes` build with prior populated cache -> uses cache, no network calls
- [x] `OFFLINE_WORK=yes` build with empty cache + no pinned SHA1 -> fails with clear "OFFLINE_WORK=yes but no SHA1 available ... run online once or pin sha1" message
- [x] `OFFLINE_WORK=yes` build with empty cache + pinned in `config/sources/git_sources.json` -> uses pinned SHA1, no network calls
- [x] `OFFLINE_WORK=no` (default) build -> behaviour unchanged (online `ls-remote` returned real SHA1)
- [x] `OFFLINE_WORK=yes` kernel-config (needs Makefile body) without cache -> fails with clear "Makefile body ... not in cache" message


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved offline mode by resolving pinned git branch/ref references from configured SHA1s to reduce network lookups.
* **Improvements**
  * Added strict validation for pinned SHA1 format and clearer guidance when pinned values are invalid or missing.
  * Refined memoized cache behavior to explicitly detect staleness and control offline usage of cached entries.
* **Bug Fixes**
  * Prevented offline runs from proceeding when Makefile body data isn’t available from the cache, avoiding incorrect downstream kernel/version parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->