### PR TITLE
fix(interactive): parse case alternatives in get_kernel_info_for_branch

### DIFF
--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -247,11 +247,21 @@ function get_kernel_info_for_branch() {
 	local search_branch="$1"
 	local conf_file="${SRC}/config/sources/families/${BOARDFAMILY}.conf"
 
+	# Recognises both `branch)` and `pat1 | pat2 | …)` case labels (#8957).
 	awk -v branch="$search_branch" '
     BEGIN { found=0; major_minor=""; desc="" }
-    /^[[:space:]]*[a-zA-Z0-9_-]+\)/ {
-        if ($0 ~ "^[[:space:]]*" branch "\\)") {
-            found=1
+    /^[[:space:]]*[a-zA-Z0-9_*?-][a-zA-Z0-9_*? |-]*\)/ {
+        label = $0
+        sub(/\).*/, "", label)
+        sub(/^[[:space:]]+/, "", label)
+        sub(/[[:space:]]+$/, "", label)
+        n = split(label, alts, /[[:space:]]*\|[[:space:]]*/)
+        matched = 0
+        for (i = 1; i <= n; i++) {
+            if (alts[i] == branch) { matched = 1; break }
+        }
+        if (matched) {
+            found = 1
             next
         } else if (found) {
             exit


### PR DESCRIPTION
## Summary

Fixes #8957.

The awk parser in `get_kernel_info_for_branch()` searched the family conf for `^[[:space:]]*<branch>\)`, which matches a single-pattern case label like `current)` but **not** a case label with alternation like `vendor | vendor-rt)`. With no match, the function returned an empty description and the menu fell back to a hardcoded label ("Vendor BSP kernel" for the `vendor` branch), so any custom `KERNEL_DESCRIPTION` inside an alternation block was silently lost.

**Fix:** extract the label (everything before the closing paren), split on `|` (with optional surrounding whitespace) and check each alternative against the requested branch.

**Real-world impact:** `families/k3.conf` and `families/k3-beagle.conf` both use `vendor | vendor-rt)` to share kernel/u-boot config between the two branches. Their `KERNEL_DESCRIPTION` was effectively dead code before this fix.

Single-label labels (`vendor-edge)`, `current)` etc.) continue to match — they are just an `n=1` case of the new alternation logic.

## Test plan

Verified via standalone scaffold (`.tmp/test-kernel-info-8957.sh`) against real fixtures in the repo:

- [x] `vendor` in `k3` family (alternation) → returns "Texas Instruments currently supported Processor SDK kernel" (was: empty → fallback "Vendor BSP kernel")
- [x] `vendor-rt` in `k3` family (alternation) → returns same description (was: empty)
- [x] `vendor` in `k3-beagle` family (alternation) → returns "BeagleBoard.org (vendor) kernel" (was: empty)
- [x] `vendor-rt` in `k3-beagle` family (alternation) → returns same (was: empty)
- [x] `vendor-edge` in `k3` family (single label, **regression check**) → returns "Texas Instruments latest pre-released Processor SDK kernel" (unchanged)
- [x] Unknown branch → returns empty (caller's fallback path handles)

## Notes

- Userpatches/board-conf overrides of `KERNEL_DESCRIPTION` are **not** addressed here — that's a separate architectural problem (text awk on a single file vs runtime evaluation of the full config flow). This PR fixes only the `pat | pat)` parser shortfall.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel label parsing so single or multi-alternative branch labels are recognized exactly, producing more accurate kernel version and description info across boards.
  * Interactive kernel selection behavior unchanged; users will see correct descriptions and versions when choosing a kernel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->