### PR TITLE
Potential fix for code scanning alert no. 2: Code injection

### DIFF
--- a/.github/workflows/maintenance-label-on-approval.yml
+++ b/.github/workflows/maintenance-label-on-approval.yml
@@ -42,10 +42,16 @@ jobs:
       - name: Remove review-related labels
         if: ${{ success() }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
             const { owner, repo } = context.repo;
-            const issue_number = ${{ steps.pr.outputs.number }};
+            const issue_number = Number.parseInt(process.env.PR_NUMBER || "", 10);
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              core.setFailed("Invalid PR number in PR_NUMBER");
+              return;
+            }
             const labelsToRemove = ["Needs review", "Work in progress", "Backlog", "Can be closed?", "Help needed", "Needs Documentation"];
 
             for (const name of labelsToRemove) {


### PR DESCRIPTION
Potential fix for [https://github.com/iav/armbian/security/code-scanning/2](https://github.com/iav/armbian/security/code-scanning/2)

Use the untrusted value via an intermediate environment variable and read it from `process.env` inside the script, instead of embedding `${{ ... }}` directly into JavaScript code.

Best fix in this file:
- In the `Remove review-related labels` step, add:
  - `env:`
  - `PR_NUMBER: ${{ steps.pr.outputs.number }}`
- In the script, replace:
  - `const issue_number = ${{ steps.pr.outputs.number }};`
  with:
  - `const issue_number = Number.parseInt(process.env.PR_NUMBER || "", 10);`
  - plus a validation guard to ensure it is a positive integer before calling the API.

This preserves functionality (using the same PR number) while preventing code injection through expression interpolation in script source.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow for PR label handling: the workflow now validates the PR number and more reliably removes review-related labels.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9799)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->