### PR TITLE
style(interactive): remove duplicated shebang line

### DIFF
--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -7,8 +7,6 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
-#!/usr/bin/env bash
-
 function interactive_config_prepare_terminal() {
 	if [[ -z $ROOT_FS_CREATE_ONLY ]]; then
 		if [[ -t 0 ]]; then # "-t fd return True if file descriptor fd is open and refers to a terminal". 0 = stdin, 1 = stdout, 2 = stderr, 3+ custom


### PR DESCRIPTION
## Summary

`lib/functions/configuration/interactive.sh` has a stray second `#!/usr/bin/env bash` on line 10 (right after the SPDX/copyright header), introduced accidentally by commit \`b7b8eb7b\` (\"Add / modify (c) in bash scripts\", #4922) where the (c) header was inserted above the existing shebang and the original shebang line below was left in place.

bash treats it as a comment so behaviour is unchanged, but it is cosmetic noise and stands out when the file is opened. One line removed, no other changes.

\`\`\`diff
 # https://github.com/armbian/build/

-#!/usr/bin/env bash
-
 function interactive_config_prepare_terminal() {
\`\`\`

## Test plan

- [x] `shellcheck` clean (only the same 6 pre-existing SC2034 nameref false-positives, none new)
- Bash semantics unchanged — second `#!` was a comment, not an interpreter directive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed redundant script header element to streamline internal code structure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9802)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->