### PR TITLE
(#9400 P2a) Replace echo|tr/sed subshells with parameter expansion

### DIFF
--- a/lib/functions/compilation/utils-compilation.sh
+++ b/lib/functions/compilation/utils-compilation.sh
@@ -64,12 +64,16 @@ overlayfs_wrapper() {
 	fi
 	if [[ $operation == cleanup ]]; then
 		if [[ -f /tmp/.overlayfs_wrapper_umount ]]; then
-			for dir in $(< /tmp/.overlayfs_wrapper_umount); do
+			local -a _overlay_umount_dirs
+			mapfile -t _overlay_umount_dirs < /tmp/.overlayfs_wrapper_umount
+			for dir in "${_overlay_umount_dirs[@]}"; do
 				[[ $dir == /tmp/* ]] && umount -l "$dir" > /dev/null 2>&1
 			done
 		fi
 		if [[ -f /tmp/.overlayfs_wrapper_cleanup ]]; then
-			for dir in $(< /tmp/.overlayfs_wrapper_cleanup); do
+			local -a _overlay_cleanup_dirs
+			mapfile -t _overlay_cleanup_dirs < /tmp/.overlayfs_wrapper_cleanup
+			for dir in "${_overlay_cleanup_dirs[@]}"; do
 				[[ $dir == /tmp/* ]] && rm -rf "$dir"
 			done
 		fi

--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -282,7 +282,7 @@ function interactive_config_ask_branch() {
 	declare -a options=()
 	declare one_kernel_target
 
-	for one_kernel_target in $(echo "${KERNEL_TARGET}" | tr "," "\n"); do
+	for one_kernel_target in ${KERNEL_TARGET//,/ }; do
 
 		local version=""
 		local description=""

--- a/lib/functions/general/countdown.sh
+++ b/lib/functions/general/countdown.sh
@@ -24,7 +24,7 @@ function exit_if_countdown_not_aborted() {
 	display_alert "Problem detected" "${reason}" "err"
 	display_alert "Exiting in ${loops} seconds" "Press <Ctrl-C> to abort, <Enter> to ignore and continue" "err"
 	echo -n "Counting down: " >&2
-	for i in $(seq 1 "${loops}"); do
+	for ((i = 1; i <= loops; i++)); do
 		declare stop_waiting=0
 		declare keep_waiting=0
 		timeout --foreground 1 bash -c "read -n1; echo \$REPLY" && stop_waiting=1 || keep_waiting=1
@@ -54,7 +54,7 @@ function countdown_and_continue_if_not_aborted() {
 	fi
 
 	echo -n "Counting down: " >&2
-	for i in $(seq 1 "${loops}"); do
+	for ((i = 1; i <= loops; i++)); do
 		declare stop_waiting=0
 		declare keep_waiting=0
 		timeout --foreground 1 bash -c "read -n1; echo \$REPLY" && stop_waiting=1 || keep_waiting=1

--- a/lib/functions/general/extensions.sh
+++ b/lib/functions/general/extensions.sh
@@ -141,7 +141,8 @@ function initialize_extension_manager() {
 	# before starting, auto-add extensions specified (eg, on the command-line) via the ENABLE_EXTENSIONS or EXT env var. Do it only once.
 	[[ ${initialize_extension_manager_counter} -lt 1 ]] && [[ "${ENABLE_EXTENSIONS:-"${EXT}"}" != "" ]] && {
 		local auto_extension
-		for auto_extension in $(echo "${ENABLE_EXTENSIONS:-"${EXT}"}" | tr "," " "); do
+		local _enable_csv="${ENABLE_EXTENSIONS:-"${EXT}"}"
+		for auto_extension in ${_enable_csv//,/ }; do
 			ENABLE_EXTENSION_TRACE_HINT="ENABLE_EXTENSIONS/EXT -> " enable_extension "${auto_extension}"
 		done
 	}

--- a/lib/functions/main/build-packages.sh
+++ b/lib/functions/main/build-packages.sh
@@ -65,7 +65,7 @@ function main_default_build_packages() {
 	if [[ "${IGNORE_UPDATES}" != "yes" ]]; then
 		LOG_SECTION="clean_deprecated_mountpoints" do_with_logging clean_deprecated_mountpoints
 
-		for cleaning_fragment in $(tr ',' ' ' <<< "${CLEAN_LEVEL}"); do
+		for cleaning_fragment in ${CLEAN_LEVEL//,/ }; do
 			if [[ $cleaning_fragment != sources ]] && [[ $cleaning_fragment != none ]] && [[ $cleaning_fragment != make* ]]; then
 				LOG_SECTION="cleaning_${cleaning_fragment}" do_with_logging general_cleaning "${cleaning_fragment}"
 			fi

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -505,7 +505,8 @@ function install_distribution_agnostic() {
 	# example: SERIALCON="ttyS0:15000000,ttyGS1"
 	#
 	ifs=$IFS
-	for i in $(echo "${SERIALCON:-'ttyS0'}" | sed "s/,/ /g"); do
+	local _serialcon_csv="${SERIALCON:-'ttyS0'}"
+	for i in ${_serialcon_csv//,/ }; do
 		IFS=':' read -r -a array <<< "$i"
 		[[ "${array[0]}" == "tty1" ]] && continue # Don't enable tty1 as serial console.
 		display_alert "Enabling serial console" "${array[0]}" "info"

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -505,7 +505,7 @@ function install_distribution_agnostic() {
 	# example: SERIALCON="ttyS0:15000000,ttyGS1"
 	#
 	ifs=$IFS
-	local _serialcon_csv="${SERIALCON:-'ttyS0'}"
+	local _serialcon_csv="${SERIALCON:-ttyS0}"
 	for i in ${_serialcon_csv//,/ }; do
 		IFS=':' read -r -a array <<< "$i"
 		[[ "${array[0]}" == "tty1" ]] && continue # Don't enable tty1 as serial console.


### PR DESCRIPTION
## Summary

Replaces 6 instances where a `for` loop iterates over a comma-separated string by spawning `echo … | tr/sed` (or `tr <<<`) subshells. All replacements use bash-native parameter expansion `${VAR//,/ }`, plus one switch from `seq(1)` to a C-style arithmetic loop and one switch from word-splitting `$(< file)` to `mapfile`. Part of the bash-safety cleanup tracked in #9400 (P2a).

[GitHub issue](https://github.com/armbian/build/issues/9400) reference: #9400
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2818]

## Changes

| File | Before | After |
|---|---|---|
| `lib/functions/general/extensions.sh` | `for x in $(echo "${ENABLE_EXTENSIONS:-${EXT}}" \| tr "," " ")` | local CSV var + `${_enable_csv//,/ }` |
| `lib/functions/configuration/interactive.sh` | `for x in $(echo "${KERNEL_TARGET}" \| tr "," "\n")` | `for x in ${KERNEL_TARGET//,/ }` |
| `lib/functions/general/countdown.sh` (×2) | `for i in $(seq 1 "${loops}")` | `for ((i = 1; i <= loops; i++))` |
| `lib/functions/main/build-packages.sh` | `for x in $(tr ',' ' ' <<< "${CLEAN_LEVEL}")` | `for x in ${CLEAN_LEVEL//,/ }` |
| `lib/functions/rootfs/distro-agnostic.sh` | `for i in $(echo "${SERIALCON:-'ttyS0'}" \| sed "s/,/ /g")` | local CSV var + `${_serialcon_csv//,/ }`; also drop the literal single quotes from the default (see follow-up commit below) |
| `lib/functions/compilation/utils-compilation.sh` (×2) | `for dir in $(< /tmp/.overlayfs_wrapper_*)` | `mapfile -t arr < file; for dir in "${arr[@]}"` |

## Why this matters

Each `echo "${var}" | tr/sed` form forks a subshell and one or two external processes just to do what bash can do in-place with `${var//pattern/replacement}`. The replacements also reduce one class of word-splitting surprise: in the `mapfile` case, paths with whitespace are now preserved verbatim instead of being broken apart.

## Note on intentional word splitting

The replacements `for x in ${VAR//,/ }` deliberately keep the expansion unquoted — that is the mechanism for the loop to split on whitespace. Inside `[[ ]]` or assignments these expansions would still need to be quoted; outside the loop header, they are not modified.

## Follow-up: SERIALCON default

A separate commit drops the literal single quotes from the `SERIALCON:-'ttyS0'` default. When `SERIALCON` was unset, the value `'ttyS0'` (with the quotes) was retained through the parameter expansion and downstream `array[0]` became the 4-character string `'ttyS0'` — producing a malformed `/etc/securetty` entry and a non-existent `serial-getty@'ttyS0'.service` path.

## Out of scope (deferred)

- `bsp/armbian-bsp-cli-deb.sh:235` (from the original P2a list in #9400): the relevant block has been refactored away since the audit was written; no change needed.

[AR-2818]: https://armbian.atlassian.net/browse/AR-2818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced subprocess-heavy list parsing with in-shell splitting and iteration to reduce overhead and improve reliability.
  * Made cleanup/unmount and extension-loading flows iterate tracked entries more robustly to avoid missed removals.
  * Simplified interactive menus, countdown loops, cleaning-fragment handling, and serial-console parsing while preserving existing behavior and user-facing outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->