### PR TITLE
Update nanopi r5s udev rule tweak for persistent net interface names

### DIFF
--- a/config/boards/nanopi-r5s.csc
+++ b/config/boards/nanopi-r5s.csc
@@ -34,7 +34,7 @@ function post_family_tweaks__nanopir5s_udev_network_interfaces() {
 	cat <<- EOF > "${SDCARD}/etc/udev/rules.d/70-persistent-net.rules"
 		SUBSYSTEM=="net", ACTION=="add", KERNELS=="fe2a0000.ethernet", NAME:="wan1"
 		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:01:00.0", NAME:="lan1"
-		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0001:01:00.0", NAME:="lan2"
+        SUBSYSTEM=="net", ACTION=="add", KERNELS=="0001:11:00.0", NAME:="lan2"
 	EOF
 }
 


### PR DESCRIPTION


# Description

It seems that wan1, lan1 were always correct, but the pcie KERNELS match for lan2 is not correct.

Fixed by adding correct pci device path.


# How Has This Been Tested?

On a fresh install on sdcard or emmc all the interfaces are except lan2 were named correctly.
After this patch, on fresh install, lan2 is now also named correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network interface identification for the NanoPi R5S board to ensure proper detection of a secondary network interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9811)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->