### PR TITLE
fix(deps): add Pygments to requirements.txt (rich.syntax dep)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,6 @@ PyYAML == 6.0.3        # for parsing/writing YAML
 oras == 0.2.42         # for OCI stuff in mapper-oci-update
 Jinja2 == 3.1.6        # for templating
 rich == 15.0.0         # for rich text formatting
+Pygments == 2.19.1     # syntax highlighting, required by rich.syntax (imported by lib/tools/patching.py)
 dtschema == 2026.4     # for checking dts files and dt bindings
 yamllint == 1.38.0     # for checking dts files and dt bindings


### PR DESCRIPTION
`lib/tools/patching.py:444` imports `from rich.syntax import Syntax`. The `rich` package pinned in `requirements.txt` has `pygments<3.0.0,>=2.13.0` listed in its PyPI `requires_dist`, yet on a fresh host the install resolved to `rich` without pulling Pygments (possibly an interaction with the pinned `pip == 26.1.1` resolver or a cached pip-hash short-circuit). The build fails with:

```
Traceback (most recent call last):
  File "/armbian/lib/tools/patching.py", line 444, in <module>
    from rich.syntax import Syntax
  File ".../rich/syntax.py", line 24, in <module>
    from pygments.lexer import Lexer
ModuleNotFoundError: No module named 'pygments'
```

Reproduced on a fresh Hetzner CAX21 (Ubuntu Noble 6.8) with:

```
./compile.sh build BOARD=helios4 BRANCH=edge BUILD_MINIMAL=yes \
  RELEASE=noble PREFER_DOCKER=yes KERNEL_CONFIGURE=no EXPERT=yes \
  ARTIFACT_IGNORE_CACHE=yes
```

Fail surface is the u-boot patching phase (`uboot_main_patching_python`); any code path that imports `rich.syntax` is affected.

Pinning `Pygments == 2.19.1` explicitly in `requirements.txt` is a defensive fix — dependabot will keep it current alongside `rich`.

Assisted-by: Claude:claude-opus-4.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated syntax highlighting dependency to a pinned version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9819)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->