### PR TITLE
rockchip64: opt-in helios64 CPU stability overlay (current + edge)

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/Makefile
@@ -37,6 +37,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3399-dwc3-0-host.dtbo \
 	rockchip-rk3399-i2c7.dtbo \
 	rockchip-rk3399-i2c8.dtbo \
+	rockchip-rk3399-helios64-cpu-stability.dtbo \
 	rockchip-rk3399-opp-2ghz.dtbo \
 	rockchip-rk3399-pcie-gen2.dtbo \
 	rockchip-rk3399-spi-jedec-nor.dtbo \

--- a/patch/kernel/archive/rockchip64-6.18/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/README.rockchip-overlays
@@ -9,6 +9,7 @@ rockchip (Rockchip)
 ### Provided overlays:
 
 - i2c7, i2c8, pcie-gen2, spi-spidev, uart4, w1-gpio
+- rk3399-helios64-cpu-stability (Helios64 only)
 
 for RK3308:
 - b@1,3ghz, bs, bs-1.3ghz, otg-host, uart1, uart2, uart3, s0-ext-antenna
@@ -70,6 +71,19 @@ WARNING! Not officially supported by Rockchip!!!
 
 Adds the 1.5GHz opp for overclocking
 WARNING! Not officially supported by Rockchip!!!
+
+### rk3399-helios64-cpu-stability
+
+Opt-in workaround for reported instability of the Helios64 NAS (Kobol)
+under sustained CPU load. Raises the A72 big-cluster vcore by +75 mV on
+opp00..opp06 (408 MHz .. 1608 MHz): 0.900 / 0.900 / 0.900 / 0.950 /
+1.025 / 1.100 / 1.175 V respectively (mainline rk3399-op1-opp.dtsi:
+0.825 / 0.825 / 0.825 / 0.875 / 0.950 / 1.025 / 1.100 V). The 1.8 GHz
+top step is left at the mainline 1.20 V. Not enabled by default.
+
+Origin: empirical workaround from the Armbian forum (topics 30074 and
+58597, by prahal and ebin-dev); no upstream patch exists. Apply only if
+you observe random crashes or hangs on a Helios64.
 
 ### rk3399-opp-2ghz
 

--- a/patch/kernel/archive/rockchip64-6.18/overlay/rockchip-rk3399-helios64-cpu-stability.dtso
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/rockchip-rk3399-helios64-cpu-stability.dtso
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "kobol,helios64";
+
+    fragment@0 {
+        target-path = "/opp-table-1";
+        __overlay__ {
+            /* opp-microvolt raised by +75 mV vs mainline (op1-opp.dtsi). */
+            /*  408 MHz: 0.825 V -> 0.900 V */
+            opp00 { opp-microvolt = < 900000  900000 1250000>; };
+            /*  600 MHz: 0.825 V -> 0.900 V */
+            opp01 { opp-microvolt = < 900000  900000 1250000>; };
+            /*  816 MHz: 0.825 V -> 0.900 V */
+            opp02 { opp-microvolt = < 900000  900000 1250000>; };
+            /* 1008 MHz: 0.875 V -> 0.950 V */
+            opp03 { opp-microvolt = < 950000  950000 1250000>; };
+            /* 1200 MHz: 0.950 V -> 1.025 V */
+            opp04 { opp-microvolt = <1025000 1025000 1250000>; };
+            /* 1416 MHz: 1.025 V -> 1.100 V */
+            opp05 { opp-microvolt = <1100000 1100000 1250000>; };
+            /* 1608 MHz: 1.100 V -> 1.175 V */
+            opp06 { opp-microvolt = <1175000 1175000 1250000>; };
+            /* 1800 MHz: 1.200 V — unchanged from mainline */
+        };
+    };
+};

--- a/patch/kernel/archive/rockchip64-7.0/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-7.0/overlay/Makefile
@@ -37,6 +37,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3399-dwc3-0-host.dtbo \
 	rockchip-rk3399-i2c7.dtbo \
 	rockchip-rk3399-i2c8.dtbo \
+	rockchip-rk3399-helios64-cpu-stability.dtbo \
 	rockchip-rk3399-opp-2ghz.dtbo \
 	rockchip-rk3399-pcie-gen2.dtbo \
 	rockchip-rk3399-spi-jedec-nor.dtbo \

--- a/patch/kernel/archive/rockchip64-7.0/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-7.0/overlay/README.rockchip-overlays
@@ -9,6 +9,7 @@ rockchip (Rockchip)
 ### Provided overlays:
 
 - i2c7, i2c8, pcie-gen2, spi-spidev, uart4, w1-gpio
+- rk3399-helios64-cpu-stability (Helios64 only)
 
 for RK3308:
 - b@1,3ghz, bs, bs-1.3ghz, otg-host, uart1, uart2, uart3, s0-ext-antenna
@@ -70,6 +71,19 @@ WARNING! Not officially supported by Rockchip!!!
 
 Adds the 1.5GHz opp for overclocking
 WARNING! Not officially supported by Rockchip!!!
+
+### rk3399-helios64-cpu-stability
+
+Opt-in workaround for reported instability of the Helios64 NAS (Kobol)
+under sustained CPU load. Raises the A72 big-cluster vcore by +75 mV on
+opp00..opp06 (408 MHz .. 1608 MHz): 0.900 / 0.900 / 0.900 / 0.950 /
+1.025 / 1.100 / 1.175 V respectively (mainline rk3399-op1-opp.dtsi:
+0.825 / 0.825 / 0.825 / 0.875 / 0.950 / 1.025 / 1.100 V). The 1.8 GHz
+top step is left at the mainline 1.20 V. Not enabled by default.
+
+Origin: empirical workaround from the Armbian forum (topics 30074 and
+58597, by prahal and ebin-dev); no upstream patch exists. Apply only if
+you observe random crashes or hangs on a Helios64.
 
 ### rk3399-opp-2ghz
 

--- a/patch/kernel/archive/rockchip64-7.0/overlay/rockchip-rk3399-helios64-cpu-stability.dtso
+++ b/patch/kernel/archive/rockchip64-7.0/overlay/rockchip-rk3399-helios64-cpu-stability.dtso
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "kobol,helios64";
+
+    fragment@0 {
+        target-path = "/opp-table-1";
+        __overlay__ {
+            /* opp-microvolt raised by +75 mV vs mainline (op1-opp.dtsi). */
+            /*  408 MHz: 0.825 V -> 0.900 V */
+            opp00 { opp-microvolt = < 900000  900000 1250000>; };
+            /*  600 MHz: 0.825 V -> 0.900 V */
+            opp01 { opp-microvolt = < 900000  900000 1250000>; };
+            /*  816 MHz: 0.825 V -> 0.900 V */
+            opp02 { opp-microvolt = < 900000  900000 1250000>; };
+            /* 1008 MHz: 0.875 V -> 0.950 V */
+            opp03 { opp-microvolt = < 950000  950000 1250000>; };
+            /* 1200 MHz: 0.950 V -> 1.025 V */
+            opp04 { opp-microvolt = <1025000 1025000 1250000>; };
+            /* 1416 MHz: 1.025 V -> 1.100 V */
+            opp05 { opp-microvolt = <1100000 1100000 1250000>; };
+            /* 1608 MHz: 1.100 V -> 1.175 V */
+            opp06 { opp-microvolt = <1175000 1175000 1250000>; };
+            /* 1800 MHz: 1.200 V — unchanged from mainline */
+        };
+    };
+};


### PR DESCRIPTION
# Description

Adds an opt-in DT overlay for the Helios64 NAS (Kobol) that raises the A72
big-cluster vcore by **+75 mV** on opp00..opp06; opp07 (1.8 GHz / 1.20 V)
is unchanged. Disabled by default — enable via
`overlays=rk3399-helios64-cpu-stability` in `/boot/armbianEnv.txt` (the
`rockchip-` prefix is implicit because `overlay_prefix=rockchip` is
already set for this board) or through `armbian-config` → System →
Kernel → Manage device tree overlays.

Voltage mapping (mainline rk3399-op1-opp.dtsi → this overlay):

| OPP   | freq     | mainline | overlay     |
|-------|---------:|---------:|------------:|
| opp00 |  408 MHz |  0.825 V | 0.900 V     |
| opp01 |  600 MHz |  0.825 V | 0.900 V     |
| opp02 |  816 MHz |  0.825 V | 0.900 V     |
| opp03 | 1008 MHz |  0.875 V | 0.950 V     |
| opp04 | 1200 MHz |  0.950 V | 1.025 V     |
| opp05 | 1416 MHz |  1.025 V | 1.100 V     |
| opp06 | 1608 MHz |  1.100 V | 1.175 V     |
| opp07 | 1800 MHz |  1.200 V | (unchanged) |

`max` (third element of the triplet) is kept at 1.25 V on all entries,
matching the forum workaround (post #237456 in topic 58597 by @ebin-dev).

Two commits, one per kernel tree: `rockchip64-current` (6.18) and
`rockchip64-edge` (7.0).

## Motivation

Long-standing instability reports for Helios64 under sustained CPU load
are tracked on the Armbian forum:
- topic 30074 ("Helios64 Armbian 23.08 bookworm issues solved")
- topic 58597 ("Helios64 Armbian Trixie with Linux 6.18 incl. opp-microvolt patch")

Forum users (prahal, ebin-dev) have been distributing pre-built DTBs
with the same opp-microvolt bumps for years. No upstream patch exists
and Kobol is no longer maintaining helios* boards, so this will not
land in mainline.

**Deliberately not a board-default change.** On my own Helios64 the
stock mainline voltages run stable, and I don't want to push a
tree-wide voltage bump onto every user when only some units exhibit
the instability.

**But the affected users currently have to maintain a hand-patched
DTB** — copying `rk3399-kobol-helios64.dtb` into `/boot/dtb/rockchip/`
and redoing it on every kernel package update. That workflow is
fragile and easy to forget. Armbian already has a clean, durable
mechanism for exactly this case — DT overlays selected via
`armbianEnv.txt` / `armbian-config`. This PR brings the forum
workaround into that mechanism.

## How Has This Been Tested?

- [x] `current` (6.18) deb built — `linux-dtb-current-rockchip64`
      ships `rockchip/overlay/rockchip-rk3399-helios64-cpu-stability.dtbo`
      (485 B); `dtc -I dtb` decompiles to the documented values.
- [x] `edge` (7.0) deb built — identical overlay payload, verified
      the same way.
- [x] **Helios64 SD-card boot, current/6.18, Trixie minimal** — overlay
      enabled via `armbian-config`. U-boot log: `Applying kernel
      provided DT overlay rockchip-rk3399-helios64-cpu-stability.dtbo`.
      Live DT after boot:
      ```
      for n in 0 1 2 3 4 5 6 7; do
        od -An -tx4 --endian=big \
           /sys/firmware/devicetree/base/opp-table-1/opp0$n/opp-microvolt
      done

      opp00  000dbba0 000dbba0 001312d0    900000   900000  1250000 µV
      opp01  000dbba0 000dbba0 001312d0
      opp02  000dbba0 000dbba0 001312d0
      opp03  000e7ef0 000e7ef0 001312d0    950000
      opp04  000fa3e8 000fa3e8 001312d0   1025000
      opp05  0010c8e0 0010c8e0 001312d0   1100000
      opp06  0011edd8 0011edd8 001312d0   1175000
      opp07  00124f80 00124f80 001312d0   1200000 (unchanged)
      ```
- [x] Overlay visible in `armbian-config` → System → Kernel →
      Manage device tree overlays (TUI writes
      `rk3399-helios64-cpu-stability` to the `overlays=` line in
      `armbianEnv.txt`).
- [x] **Helios64 SD-card boot, edge/7.0** (kernel 7.0.7-edge-rockchip64,
      Trixie minimal) — overlay enabled via the same TUI path, identical
      end-to-end result:
      ```
      opp00  000dbba0 000dbba0 001312d0    900000   900000  1250000 µV
      opp01  000dbba0 000dbba0 001312d0
      opp02  000dbba0 000dbba0 001312d0
      opp03  000e7ef0 000e7ef0 001312d0    950000
      opp04  000fa3e8 000fa3e8 001312d0   1025000
      opp05  0010c8e0 0010c8e0 001312d0   1100000
      opp06  0011edd8 0011edd8 001312d0   1175000
      opp07  00124f80 00124f80 001312d0   1200000 (unchanged)
      ```

## Changes since the latest review

- Applied CodeRabbit nitpick: per-OPP frequency / voltage transition
  is now documented inline in the `.dtso` (a single-line comment
  above each `opp0N { ... };`), and the README block was tightened
  to replace the imprecise "50-75 mV" phrasing with the actual
  uniform +75 mV value plus the explicit mainline→overlay voltage
  list. No functional change to the overlay payload.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
