### PR TITLE
NORCO EMB-3531: Add LPDDR4X variants support

### DIFF
--- a/config/boards/norco-emb-3531.csc
+++ b/config/boards/norco-emb-3531.csc
@@ -1,4 +1,4 @@
-# Rockchip RK3399 2GB DDR3 16GB eMMC GBE USB3 RTL8188ETV WiFi PCIe x4 slot
+# Rockchip RK3399 DDR3/LPDDR4X eMMC GBE USB3 USB-WiFi PCIe x4 slot
 BOARD_NAME="NORCO EMB-3531"
 BOARD_VENDOR="norco"
 BOARDFAMILY="rockchip64"
@@ -14,11 +14,17 @@ BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3399-emb-3531.dtb"
 BOOTBRANCH_BOARD="tag:v2026.01"
 BOOTPATCHDIR="v2026.01"
-BOOT_SCENARIO="binman"
 SRC_EXTLINUX="yes"
 SRC_CMDLINE="console=ttyS2,1500000 console=tty0 rk3399_pcie_ignore_serror"
 
 PACKAGE_LIST_BOARD="alsa-ucm-conf" # Contain ALSA UCM top-level configuration file
+
+function post_family_config__norco-emb-3531() {
+	declare -g BOOT_SCENARIO="spl-blobs"
+	declare -g DDR_BLOB="rk33/rk3399_ddr_800MHz_v1.27.bin"
+	declare -g BL31_BLOB="rk33/rk3399_bl31_v1.36.elf"
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
+}
 
 function post_family_tweaks_bsp__norco-emb-3531() {
 	display_alert "${BOARD}" "Installing ALSA UCM configuration files" "info"

--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3399-emb-3531.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3399-emb-3531.dts
@@ -123,13 +123,19 @@
 		vin-supply = <&vcc_sys>;
 	};
 
-	vcc5v0_host: regulator-vcc5v0-host {
+	/*
+	 * Only the LPDDR4X version of the device requires this GPIO to enable the USB3 Hub.
+	 * However, pulling this GPIO high on the DDR3 version will not cause any issues.
+	 */
+	usb3_hub_en: regulator-usb3-hub-en {
 		compatible = "regulator-fixed";
-		regulator-name = "vcc5v0_host";
+		enable-active-high;
+		gpio = <&gpio4 RK_PD2 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&usb3_hub_pin>;
+		regulator-name = "usb3_hub_en";
 		regulator-always-on;
 		regulator-boot-on;
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
 	};
 
 	/* Micro USB */
@@ -144,7 +150,6 @@
 		regulator-boot-on;
 	};
 
-	/* RTL8188ETV */
 	regulator-wifi-en {
 		compatible = "regulator-fixed";
 		enable-active-high;
@@ -601,6 +606,10 @@
 	};
 
 	usb {
+		usb3_hub_pin: usb3-hub-pin {
+			rockchip,pins = <4 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
 		otg_vbus_en: otg-vbus-en {
 			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
@@ -684,7 +693,7 @@
 	};
 
 	u2phy0_host: host-port {
-		phy-supply = <&vcc5v0_host>;
+		phy-supply = <&usb3_hub_en>;
 		status = "okay";
 	};
 };
@@ -697,7 +706,7 @@
 	};
 
 	u2phy1_host: host-port {
-		phy-supply = <&vcc5v0_host>;
+		phy-supply = <&usb3_hub_en>;
 		status = "okay";
 	};
 };

--- a/patch/kernel/archive/rockchip64-7.0/dt/rk3399-emb-3531.dts
+++ b/patch/kernel/archive/rockchip64-7.0/dt/rk3399-emb-3531.dts
@@ -123,13 +123,19 @@
 		vin-supply = <&vcc_sys>;
 	};
 
-	vcc5v0_host: regulator-vcc5v0-host {
+	/*
+	 * Only the LPDDR4X version of the device requires this GPIO to enable the USB3 Hub.
+	 * However, pulling this GPIO high on the DDR3 version will not cause any issues.
+	 */
+	usb3_hub_en: regulator-usb3-hub-en {
 		compatible = "regulator-fixed";
-		regulator-name = "vcc5v0_host";
+		enable-active-high;
+		gpio = <&gpio4 RK_PD2 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&usb3_hub_pin>;
+		regulator-name = "usb3_hub_en";
 		regulator-always-on;
 		regulator-boot-on;
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
 	};
 
 	/* Micro USB */
@@ -144,7 +150,6 @@
 		regulator-boot-on;
 	};
 
-	/* RTL8188ETV */
 	regulator-wifi-en {
 		compatible = "regulator-fixed";
 		enable-active-high;
@@ -601,6 +606,10 @@
 	};
 
 	usb {
+		usb3_hub_pin: usb3-hub-pin {
+			rockchip,pins = <4 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
 		otg_vbus_en: otg-vbus-en {
 			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
@@ -684,7 +693,7 @@
 	};
 
 	u2phy0_host: host-port {
-		phy-supply = <&vcc5v0_host>;
+		phy-supply = <&usb3_hub_en>;
 		status = "okay";
 	};
 };
@@ -697,7 +706,7 @@
 	};
 
 	u2phy1_host: host-port {
-		phy-supply = <&vcc5v0_host>;
+		phy-supply = <&usb3_hub_en>;
 		status = "okay";
 	};
 };

--- a/patch/kernel/archive/rockchip64-7.1/dt/rk3399-emb-3531.dts
+++ b/patch/kernel/archive/rockchip64-7.1/dt/rk3399-emb-3531.dts
@@ -123,13 +123,19 @@
 		vin-supply = <&vcc_sys>;
 	};
 
-	vcc5v0_host: regulator-vcc5v0-host {
+	/*
+	 * Only the LPDDR4X version of the device requires this GPIO to enable the USB3 Hub.
+	 * However, pulling this GPIO high on the DDR3 version will not cause any issues.
+	 */
+	usb3_hub_en: regulator-usb3-hub-en {
 		compatible = "regulator-fixed";
-		regulator-name = "vcc5v0_host";
+		enable-active-high;
+		gpio = <&gpio4 RK_PD2 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&usb3_hub_pin>;
+		regulator-name = "usb3_hub_en";
 		regulator-always-on;
 		regulator-boot-on;
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
 	};
 
 	/* Micro USB */
@@ -144,7 +150,6 @@
 		regulator-boot-on;
 	};
 
-	/* RTL8188ETV */
 	regulator-wifi-en {
 		compatible = "regulator-fixed";
 		enable-active-high;
@@ -601,6 +606,10 @@
 	};
 
 	usb {
+		usb3_hub_pin: usb3-hub-pin {
+			rockchip,pins = <4 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
 		otg_vbus_en: otg-vbus-en {
 			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
@@ -684,7 +693,7 @@
 	};
 
 	u2phy0_host: host-port {
-		phy-supply = <&vcc5v0_host>;
+		phy-supply = <&usb3_hub_en>;
 		status = "okay";
 	};
 };
@@ -697,7 +706,7 @@
 	};
 
 	u2phy1_host: host-port {
-		phy-supply = <&vcc5v0_host>;
+		phy-supply = <&usb3_hub_en>;
 		status = "okay";
 	};
 };

--- a/patch/u-boot/v2026.01/board_norco-emb-3531/add-board-norco-emb-3531.patch
+++ b/patch/u-boot/v2026.01/board_norco-emb-3531/add-board-norco-emb-3531.patch
@@ -92,10 +92,10 @@ index 00000000..ab892564
 +CONFIG_ERRNO_STR=y
 diff --git a/dts/upstream/src/arm64/rockchip/rk3399-emb-3531.dts b/dts/upstream/src/arm64/rockchip/rk3399-emb-3531.dts
 new file mode 100644
-index 00000000..8f4cb348
+index 00000000..86eb46c7
 --- /dev/null
 +++ b/dts/upstream/src/arm64/rockchip/rk3399-emb-3531.dts
-@@ -0,0 +1,773 @@
+@@ -0,0 +1,782 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -221,13 +221,19 @@ index 00000000..8f4cb348
 +		vin-supply = <&vcc_sys>;
 +	};
 +
-+	vcc5v0_host: regulator-vcc5v0-host {
++	/*
++	 * Only the LPDDR4X version of the device requires this GPIO to enable the USB3 Hub.
++	 * However, pulling this GPIO high on the DDR3 version will not cause any issues.
++	 */
++	usb3_hub_en: regulator-usb3-hub-en {
 +		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_host";
++		enable-active-high;
++		gpio = <&gpio4 RK_PD2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb3_hub_pin>;
++		regulator-name = "usb3_hub_en";
 +		regulator-always-on;
 +		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
 +	};
 +
 +	/* Micro USB */
@@ -242,7 +248,6 @@ index 00000000..8f4cb348
 +		regulator-boot-on;
 +	};
 +
-+	/* RTL8188ETV */
 +	regulator-wifi-en {
 +		compatible = "regulator-fixed";
 +		enable-active-high;
@@ -699,6 +704,10 @@ index 00000000..8f4cb348
 +	};
 +
 +	usb {
++		usb3_hub_pin: usb3-hub-pin {
++			rockchip,pins = <4 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
 +		otg_vbus_en: otg-vbus-en {
 +			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
@@ -782,7 +791,7 @@ index 00000000..8f4cb348
 +	};
 +
 +	u2phy0_host: host-port {
-+		phy-supply = <&vcc5v0_host>;
++		phy-supply = <&usb3_hub_en>;
 +		status = "okay";
 +	};
 +};
@@ -795,7 +804,7 @@ index 00000000..8f4cb348
 +	};
 +
 +	u2phy1_host: host-port {
-+		phy-supply = <&vcc5v0_host>;
++		phy-supply = <&usb3_hub_en>;
 +		status = "okay";
 +	};
 +};

--- a/patch/u-boot/v2026.01/board_norco-emb-3531/add-board-norco-emb-3531.patch
+++ b/patch/u-boot/v2026.01/board_norco-emb-3531/add-board-norco-emb-3531.patch
@@ -1,26 +1,25 @@
 diff --git a/arch/arm/dts/rk3399-emb-3531-u-boot.dtsi b/arch/arm/dts/rk3399-emb-3531-u-boot.dtsi
 new file mode 100644
-index 00000000..1f5fda1d
+index 00000000..50b0ca0d
 --- /dev/null
 +++ b/arch/arm/dts/rk3399-emb-3531-u-boot.dtsi
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Copyright (C) 2019 Jagan Teki <jagan@amarulasolutions.com>
 + */
 +
 +#include "rk3399-u-boot.dtsi"
-+#include "rk3399-sdram-ddr3-1600.dtsi"
 +
 +&vdd_log {
 +	regulator-init-microvolt = <950000>;
 +};
 diff --git a/configs/emb-3531-rk3399_defconfig b/configs/emb-3531-rk3399_defconfig
 new file mode 100644
-index 00000000..ab892564
+index 00000000..6c6fe382
 --- /dev/null
 +++ b/configs/emb-3531-rk3399_defconfig
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,70 @@
 +# Reference from firefly-rk3399_defconfig
 +CONFIG_ARM=y
 +CONFIG_SKIP_LOWLEVEL_INIT=y
@@ -32,6 +31,7 @@ index 00000000..ab892564
 +CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3399-emb-3531"
 +CONFIG_DM_RESET=y
 +CONFIG_ROCKCHIP_RK3399=y
++CONFIG_ROCKCHIP_EXTERNAL_TPL=y
 +CONFIG_TARGET_EVB_RK3399=y
 +CONFIG_SYS_LOAD_ADDR=0x800800
 +CONFIG_DEBUG_UART_BASE=0xFF1A0000


### PR DESCRIPTION
# Description

The NORCO EMB-3531 has a variant equipped with LPDDR4X memory operating at 1600MHz, alongside the existing DDR3 version at 1600MHz. To achieve a unified image build, the DDR driver has been migrated from the U-Boot TPL to the rkbin DDR blob.

<img width="1536" height="2048" alt="Compress_20260514_195006_6247" src="https://github.com/user-attachments/assets/db6cdd71-4e29-4f54-90d9-e1b320b8ec27" />

<img width="1536" height="2048" alt="Compress_20260514_195006_6387" src="https://github.com/user-attachments/assets/4e00d8d3-828a-47d0-bad3-918689fa2802" />

# How Has This Been Tested?

Build unified image then boot with both DDR3 and LPDDR4X variants

## DDR3

```
❯ sudo busybox microcom -s 1500000 /dev/ttyUSB0
DDR Version 1.27 20211018
In
DDR Version 1.27 20211018
In
Channel 0: DDR3, 800MHz
Bus Width=32 Col=10 Bank=8 Row=15 CS=1 Die Bus-Width=16 Size=1024MB
Channel 1: DDR3, 800MHz
Bus Width=32 Col=10 Bank=8 Row=15 CS=1 Die Bus-Width=16 Size=1024MB
256B stride
ch 0 ddrconfig = 0x101, ddrsize = 0x20
ch 1 ddrconfig = 0x101, ddrsize = 0x20
pmugrf_os_reg[2] = 0x32817281, stride = 0x9
OUT

U-Boot SPL 2026.01_armbian-2026.01-S127a-Pc53d-H5653-V2b79-Bd0d2-R448a (May 13 2026 - 13:42:32 +0000)
Trying to boot from MMC1
## Checking hash(es) for config config-1 ... OK
## Checking hash(es) for Image atf-1 ... sha256+ OK
## Checking hash(es) for Image u-boot ... sha256+ OK
## Checking hash(es) for Image fdt-1 ... sha256+ OK
## Checking hash(es) for Image atf-2 ... sha256+ OK
## Checking hash(es) for Image atf-3 ... sha256+ OK
NOTICE:  BL31: v1.3(release):8f40012ab
NOTICE:  BL31: Built : 14:20:53, Feb 16 2023
NOTICE:  BL31: Rockchip release version: v1.1
INFO:    GICv3 with legacy support detected. ARM GICV3 driver initialized in EL3
INFO:    Using opteed sec cpu_context!
INFO:    boot cpu mask: 0
INFO:    plat_rockchip_pmu_init(1203): pd status 3e
INFO:    BL31: Initializing runtime services
WARNING: No OPTEE provided by BL2 boot loader, Booting device without OPTEE initialization. SMC`s destined for OPTEE will return SMC_UNK
ERROR:   Error initializing runtime service opteed_fast
INFO:    BL31: Preparing for EL3 exit to normal world
INFO:    Entry point address = 0x800000
INFO:    SPSR = 0x3c9


U-Boot 2026.01_armbian-2026.01-S127a-Pc53d-H5653-V2b79-Bd0d2-R448a (May 13 2026 - 13:42:32 +0000)

SoC: Rockchip rk3399
Reset cause: POR
Model: NORCO EMB-3531
DRAM:  2 GiB
PMIC:  RK808 
Core:  294 devices, 30 uclasses, devicetree: separate
MMC:   mmc@fe320000: 1, mmc@fe330000: 0
Loading Environment from MMC... Reading from MMC(0)... *** Warning - bad CRC, using default environment

In:    serial@ff1a0000
Out:   serial@ff1a0000
Err:   serial@ff1a0000
Model: NORCO EMB-3531
Net:   eth0: ethernet@fe300000
Hit any key to stop autoboot:  0
```

## LPDDR4X

```
❯ sudo busybox microcom -s 1500000 /dev/ttyUSB0
��������������������������������DDR Version 1.27 20211018
In
channel 0
CS = 0
MR0=0xB8
MR4=0x1
MR5=0xFF
MR8=0x8
MR12=0x72
MR14=0x72
MR18=0x0
MR19=0x0
MR24=0x8
MR25=0x0
channel 1
CS = 0
MR0=0xB8
MR4=0x1
MR5=0xFF
MR8=0x8
MR12=0x72
MR14=0x72
MR18=0x0
MR19=0x0
MR24=0x8
MR25=0x0
channel 0 training pass!
channel 1 training pass!
change freq to 416MHz 0,1
Channel 0: LPDDR4,416MHz
Bus Width=32 Col=10 Bank=8 Row=15 CS=1 Die Bus-Width=16 Size=1024MB
Channel 1: LPDDR4,416MHz
Bus Width=32 Col=10 Bank=8 Row=15 CS=1 Die Bus-Width=16 Size=1024MB
256B stride
channel 0
CS = 0
MR0=0xB8
MR4=0x1
MR5=0xFF
MR8=0x8
MR12=0x72
MR14=0x72
MR18=0x0
MR19=0x0
MR24=0x8
MR25=0x0
channel 1
CS = 0
MR0=0xB8
MR4=0x1
MR5=0xFF
MR8=0x8
MR12=0x72
MR14=0x72
MR18=0x0
MR19=0x0
MR24=0x8
MR25=0x0
channel 0 training pass!
channel 1 training pass!
channel 0, cs 0, advanced training done
channel 1, cs 0, advanced training done
change freq to 856MHz 1,0
ch 0 ddrconfig = 0x101, ddrsize = 0x20
ch 1 ddrconfig = 0x101, ddrsize = 0x20
pmugrf_os_reg[2] = 0x3281F281, stride = 0x9
ddr_set_rate to 328MHZ
ddr_set_rate to 666MHZ
ddr_set_rate to 416MHZ, ctl_index 0
ddr_set_rate to 856MHZ, ctl_index 1
support 416 856 328 666 MHz, current 856MHz
OUT

U-Boot SPL 2026.01_armbian-2026.01-S127a-Pc53d-H5653-V2b79-Bd0d2-R448a (May 13 2026 - 13:42:32 +0000)
Trying to boot from MMC1
## Checking hash(es) for config config-1 ... OK
## Checking hash(es) for Image atf-1 ... sha256+ OK
## Checking hash(es) for Image u-boot ... sha256+ OK
## Checking hash(es) for Image fdt-1 ... sha256+ OK
## Checking hash(es) for Image atf-2 ... sha256+ OK
## Checking hash(es) for Image atf-3 ... sha256+ OK
NOTICE:  BL31: v1.3(release):8f40012ab
NOTICE:  BL31: Built : 14:20:53, Feb 16 2023
NOTICE:  BL31: Rockchip release version: v1.1
INFO:    GICv3 with legacy support detected. ARM GICV3 driver initialized in EL3
INFO:    Using opteed sec cpu_context!
INFO:    boot cpu mask: 0
INFO:    plat_rockchip_pmu_init(1203): pd status 3e
INFO:    BL31: Initializing runtime services
WARNING: No OPTEE provided by BL2 boot loader, Booting device without OPTEE initialization. SMC`s destined for OPTEE will return SMC_UNK
ERROR:   Error initializing runtime service opteed_fast
INFO:    BL31: Preparing for EL3 exit to normal world
INFO:    Entry point address = 0x800000
INFO:    SPSR = 0x3c9


U-Boot 2026.01_armbian-2026.01-S127a-Pc53d-H5653-V2b79-Bd0d2-R448a (May 13 2026 - 13:42:32 +0000)

SoC: Rockchip rk3399
Reset cause: POR
Model: NORCO EMB-3531
DRAM:  2 GiB
PMIC:  RK808 
Core:  294 devices, 30 uclasses, devicetree: separate
MMC:   mmc@fe320000: 1, mmc@fe330000: 0
Loading Environment from MMC... Reading from MMC(0)... *** Warning - bad CRC, using default environment

In:    serial@ff1a0000
Out:   serial@ff1a0000
Err:   serial@ff1a0000
Model: NORCO EMB-3531
Net:   eth0: ethernet@fe300000
Hit any key to stop autoboot:  0
```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPIO-controlled USB3 hub power management for the RK3399 EMB-3531 board variant
  * Introduced full board support for the EMB-3531 system configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9823)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->