### PR TITLE
rockchip64: rewrite patches of current and edge

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/general-add-miniDP-virtual-extcon.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-add-miniDP-virtual-extcon.patch
@@ -1,7 +1,7 @@
-From f0d2b53fcfd0151999f8f7041c3f4a19ac77b191 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tony <tonymckahan@gmail.com>
 Date: Wed, 3 Mar 2021 07:59:25 +0100
-Subject: [PATCH] RK3399 Typec DP (#2676)
+Subject: RK3399 Typec DP (#2676)
 
 > X-Git-Archeology: > recovered message: > * RK3399 NanoPC-T4 Add Type-C alt mode DP
 > X-Git-Archeology: > recovered message: > * rk3399 rockpi 4C add mini-DP (WIP)
@@ -55,12 +55,11 @@ Subject: [PATCH] RK3399 Typec DP (#2676)
 ---
  drivers/extcon/Kconfig                  |  10 +
  drivers/extcon/Makefile                 |   1 +
- drivers/extcon/extcon-usbc-virtual-pd.c | 285 ++++++++++++++++++++++++
+ drivers/extcon/extcon-usbc-virtual-pd.c | 285 ++++++++++
  3 files changed, 296 insertions(+)
- create mode 100644 drivers/extcon/extcon-usbc-virtual-pd.c
 
 diff --git a/drivers/extcon/Kconfig b/drivers/extcon/Kconfig
-index aec46bf03..dd755b952 100644
+index 111111111111..222222222222 100644
 --- a/drivers/extcon/Kconfig
 +++ b/drivers/extcon/Kconfig
 @@ -227,4 +227,14 @@ config EXTCON_RTK_TYPE_C
@@ -79,7 +78,7 @@ index aec46bf03..dd755b952 100644
 +
  endif
 diff --git a/drivers/extcon/Makefile b/drivers/extcon/Makefile
-index 6482f2bfd..979770183 100644
+index 111111111111..222222222222 100644
 --- a/drivers/extcon/Makefile
 +++ b/drivers/extcon/Makefile
 @@ -28,3 +28,4 @@ obj-$(CONFIG_EXTCON_USB_GPIO)	+= extcon-usb-gpio.o
@@ -89,7 +88,7 @@ index 6482f2bfd..979770183 100644
 +obj-$(CONFIG_EXTCON_USBC_VIRTUAL_PD) += extcon-usbc-virtual-pd.o
 diff --git a/drivers/extcon/extcon-usbc-virtual-pd.c b/drivers/extcon/extcon-usbc-virtual-pd.c
 new file mode 100644
-index 000000000..1040c98db
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/extcon/extcon-usbc-virtual-pd.c
 @@ -0,0 +1,285 @@
@@ -379,5 +378,5 @@ index 000000000..1040c98db
 +MODULE_DESCRIPTION("Type-C Virtual PD extcon driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.54.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/general-disable-mtu-validation.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-disable-mtu-validation.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/eth
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -5842,27 +5842,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
+@@ -5851,27 +5851,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
  static int stmmac_change_mtu(struct net_device *dev, int new_mtu)
  {
  	struct stmmac_priv *priv = netdev_priv(dev);

--- a/patch/kernel/archive/rockchip64-6.18/general-possibility-of-disabling-rk808-rtc.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-possibility-of-disabling-rk808-rtc.patch
@@ -25,7 +25,7 @@ diff --git a/drivers/mfd/mfd-core.c b/drivers/mfd/mfd-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/mfd/mfd-core.c
 +++ b/drivers/mfd/mfd-core.c
-@@ -213,7 +213,7 @@ static int mfd_add_device(struct device *parent, int id,
+@@ -223,7 +223,7 @@ static int mfd_add_device(struct device *parent, int id,
  
  match:
  		if (!pdev->dev.of_node)

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
@@ -13,7 +13,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3114,7 +3114,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3119,7 +3119,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  {
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
@@ -22,7 +22,7 @@ index 111111111111..222222222222 100644
  
  	if (!port->partner_pd)
  		port->partner_pd = usb_power_delivery_register(NULL, &desc);
-@@ -3124,11 +3124,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3129,11 +3129,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	memcpy(caps.pdo, port->source_caps, sizeof(u32) * port->nr_source_caps);
  	caps.role = TYPEC_SOURCE;
  

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3115,15 +3115,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3120,15 +3120,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -45,7 +45,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -3138,15 +3145,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
+@@ -3143,15 +3150,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -72,7 +72,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -7209,10 +7223,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
+@@ -7216,10 +7230,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
  		port->pds[i] = usb_power_delivery_register(port->dev, &desc);
  		if (IS_ERR(port->pds[i])) {
  			ret = PTR_ERR(port->pds[i]);

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
@@ -37,7 +37,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -1863,6 +1863,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
+@@ -1868,6 +1868,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
  		return;
  
  	for (i = 0; i < modep->altmodes; i++) {

--- a/patch/kernel/archive/rockchip64-6.18/temporary-workaround-dma-reset.patch
+++ b/patch/kernel/archive/rockchip64-6.18/temporary-workaround-dma-reset.patch
@@ -17,7 +17,7 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/eth
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -3059,8 +3059,8 @@ static int stmmac_init_dma_engine(struct stmmac_priv *priv)
+@@ -3063,8 +3063,8 @@ static int stmmac_init_dma_engine(struct stmmac_priv *priv)
  
  	ret = stmmac_reset(priv, priv->ioaddr);
  	if (ret) {

--- a/patch/kernel/archive/rockchip64-7.0/general-add-miniDP-virtual-extcon.patch
+++ b/patch/kernel/archive/rockchip64-7.0/general-add-miniDP-virtual-extcon.patch
@@ -1,7 +1,7 @@
-From f0d2b53fcfd0151999f8f7041c3f4a19ac77b191 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tony <tonymckahan@gmail.com>
 Date: Wed, 3 Mar 2021 07:59:25 +0100
-Subject: [PATCH] RK3399 Typec DP (#2676)
+Subject: RK3399 Typec DP (#2676)
 
 > X-Git-Archeology: > recovered message: > * RK3399 NanoPC-T4 Add Type-C alt mode DP
 > X-Git-Archeology: > recovered message: > * rk3399 rockpi 4C add mini-DP (WIP)
@@ -55,12 +55,11 @@ Subject: [PATCH] RK3399 Typec DP (#2676)
 ---
  drivers/extcon/Kconfig                  |  10 +
  drivers/extcon/Makefile                 |   1 +
- drivers/extcon/extcon-usbc-virtual-pd.c | 285 ++++++++++++++++++++++++
+ drivers/extcon/extcon-usbc-virtual-pd.c | 285 ++++++++++
  3 files changed, 296 insertions(+)
- create mode 100644 drivers/extcon/extcon-usbc-virtual-pd.c
 
 diff --git a/drivers/extcon/Kconfig b/drivers/extcon/Kconfig
-index aec46bf03..dd755b952 100644
+index 111111111111..222222222222 100644
 --- a/drivers/extcon/Kconfig
 +++ b/drivers/extcon/Kconfig
 @@ -227,4 +227,14 @@ config EXTCON_RTK_TYPE_C
@@ -79,7 +78,7 @@ index aec46bf03..dd755b952 100644
 +
  endif
 diff --git a/drivers/extcon/Makefile b/drivers/extcon/Makefile
-index 6482f2bfd..979770183 100644
+index 111111111111..222222222222 100644
 --- a/drivers/extcon/Makefile
 +++ b/drivers/extcon/Makefile
 @@ -28,3 +28,4 @@ obj-$(CONFIG_EXTCON_USB_GPIO)	+= extcon-usb-gpio.o
@@ -89,7 +88,7 @@ index 6482f2bfd..979770183 100644
 +obj-$(CONFIG_EXTCON_USBC_VIRTUAL_PD) += extcon-usbc-virtual-pd.o
 diff --git a/drivers/extcon/extcon-usbc-virtual-pd.c b/drivers/extcon/extcon-usbc-virtual-pd.c
 new file mode 100644
-index 000000000..1040c98db
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/extcon/extcon-usbc-virtual-pd.c
 @@ -0,0 +1,285 @@
@@ -379,5 +378,5 @@ index 000000000..1040c98db
 +MODULE_DESCRIPTION("Type-C Virtual PD extcon driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.54.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.0/general-disable-mtu-validation.patch
+++ b/patch/kernel/archive/rockchip64-7.0/general-disable-mtu-validation.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/eth
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -6033,27 +6033,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
+@@ -6038,27 +6038,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
  static int stmmac_change_mtu(struct net_device *dev, int new_mtu)
  {
  	struct stmmac_priv *priv = netdev_priv(dev);

--- a/patch/kernel/archive/rockchip64-7.0/general-possibility-of-disabling-rk808-rtc.patch
+++ b/patch/kernel/archive/rockchip64-7.0/general-possibility-of-disabling-rk808-rtc.patch
@@ -25,7 +25,7 @@ diff --git a/drivers/mfd/mfd-core.c b/drivers/mfd/mfd-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/mfd/mfd-core.c
 +++ b/drivers/mfd/mfd-core.c
-@@ -208,7 +208,7 @@ static int mfd_add_device(struct device *parent, int id,
+@@ -218,7 +218,7 @@ static int mfd_add_device(struct device *parent, int id,
  
  match:
  		if (!pdev->dev.of_node)

--- a/patch/kernel/archive/rockchip64-7.0/general-serial-8250-fix-sysrq-break-dw-apb.patch
+++ b/patch/kernel/archive/rockchip64-7.0/general-serial-8250-fix-sysrq-break-dw-apb.patch
@@ -1,7 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Velkov <325961+iav@users.noreply.github.com>
-Date: Sat, 03 May 2026 00:00:00 +0000
-Subject: serial: 8250: fix SysRq-via-BREAK regression for dw-apb-uart (8250_dw)
+Date: Sun, 3 May 2026 00:00:00 +0000
+Subject: serial: 8250: fix SysRq-via-BREAK regression for dw-apb-uart
+ (8250_dw)
 
 Sending a serial BREAK followed by a SysRq command character stopped
 working on dw-apb-uart (e.g. RK3399 / helios64) in Linux 7.0.
@@ -10,12 +11,12 @@ The refactoring introduced by:
 
   commit 8324a54f604d ("serial: 8250: Add serial8250_handle_irq_locked()")
   Link: https://patch.msgid.link/20260203171049.4353-4-ilpo.jarvinen@linux.intel.com
-  (Ilpo Järvinen, [PATCH v2 4/7], 2026-02-03; merged for linux 7.0,
+  (Ilpo Jarvinen, [PATCH v2 4/7], 2026-02-03; merged for linux 7.0,
    Cc: stable -> backported to v6.19.10)
 
   commit 883c5a2bc934 ("serial: 8250_dw: Rework dw8250_handle_irq() locking and IIR handling")
   Link: https://patch.msgid.link/20260203171049.4353-5-ilpo.jarvinen@linux.intel.com
-  (Ilpo Järvinen, [PATCH v2 5/7], 2026-02-03)
+  (Ilpo Jarvinen, [PATCH v2 5/7], 2026-02-03)
 
 replaced the explicit uart_unlock_and_check_sysrq_irqrestore() call in
 serial8250_handle_irq() with a guard(uart_port_lock_irqsave) scope.
@@ -45,14 +46,14 @@ The change to serial8250_handle_irq() is kept as a defence-in-depth fix
 for any other caller that goes through that path.
 
 Fixes: 8324a54f604d ("serial: 8250: Add serial8250_handle_irq_locked()")
-Cc: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Cc: Ilpo Jarvinen <ilpo.jarvinen@linux.intel.com>
 ---
- drivers/tty/serial/8250/8250_dw.c   | 11 +++++++++--
- drivers/tty/serial/8250/8250_port.c |  5 +++--
- 2 files changed, 12 insertions(+), 4 deletions(-)
+ drivers/tty/serial/8250/8250_dw.c   | 10 ++++++++--
+ drivers/tty/serial/8250/8250_port.c |  5 ++++-
+ 2 files changed, 12 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/tty/serial/8250/8250_dw.c b/drivers/tty/serial/8250/8250_dw.c
-index 94beadb4024d..bd8f14dc248c 100644
+index 111111111111..222222222222 100644
 --- a/drivers/tty/serial/8250/8250_dw.c
 +++ b/drivers/tty/serial/8250/8250_dw.c
 @@ -426,19 +426,23 @@ static int dw8250_handle_irq(struct uart_port *p)
@@ -60,10 +61,10 @@ index 94beadb4024d..bd8f14dc248c 100644
  	unsigned int quirks = d->pdata->quirks;
  	unsigned int status;
 +	unsigned long flags;
-
+ 
 -	guard(uart_port_lock_irqsave)(p);
 +	uart_port_lock_irqsave(p, &flags);
-
+ 
  	switch (FIELD_GET(DW_UART_IIR_IID, iir)) {
  	case UART_IIR_NO_INT:
 -		if (d->uart_16550_compatible || up->dma)
@@ -71,34 +72,34 @@ index 94beadb4024d..bd8f14dc248c 100644
 +			uart_port_unlock_irqrestore(p, flags);
  			return 0;
 +		}
-
+ 
  		if (quirks & DW_UART_QUIRK_IER_KICK &&
  		    d->no_int_count == (DW_UART_QUIRK_IER_KICK_THRES - 1))
  			dw8250_quirk_ier_kick(p);
  		d->no_int_count = (d->no_int_count + 1) % DW_UART_QUIRK_IER_KICK_THRES;
-
+ 
 +		uart_port_unlock_irqrestore(p, flags);
  		return 0;
-
+ 
  	case UART_IIR_BUSY:
 @@ -447,6 +451,7 @@ static int dw8250_handle_irq(struct uart_port *p)
-
+ 
  		d->no_int_count = 0;
-
+ 
 +		uart_port_unlock_irqrestore(p, flags);
  		return 1;
  	}
-
+ 
 @@ -480,6 +485,7 @@ static int dw8250_handle_irq(struct uart_port *p)
  	}
-
+ 
  	serial8250_handle_irq_locked(p, iir);
 +	uart_unlock_and_check_sysrq_irqrestore(p, flags);
-
+ 
  	return 1;
  }
 diff --git a/drivers/tty/serial/8250/8250_port.c b/drivers/tty/serial/8250/8250_port.c
-index 328711b5df1a..a815e9075648 100644
+index 111111111111..222222222222 100644
 --- a/drivers/tty/serial/8250/8250_port.c
 +++ b/drivers/tty/serial/8250/8250_port.c
 @@ -1834,11 +1834,14 @@ EXPORT_SYMBOL_NS_GPL(serial8250_handle_irq_locked, "SERIAL_8250");
@@ -109,11 +110,14 @@ index 328711b5df1a..a815e9075648 100644
 +
  	if (iir & UART_IIR_NO_INT)
  		return 0;
-
+ 
 -	guard(uart_port_lock_irqsave)(port);
 +	uart_port_lock_irqsave(port, &flags);
  	serial8250_handle_irq_locked(port, iir);
 +	uart_unlock_and_check_sysrq_irqrestore(port, flags);
-
+ 
  	return 1;
  }
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.0/rk3399-usbc-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3399-usbc-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
@@ -13,7 +13,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3127,7 +3127,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3132,7 +3132,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  {
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
@@ -22,7 +22,7 @@ index 111111111111..222222222222 100644
  
  	if (!port->partner_pd)
  		port->partner_pd = usb_power_delivery_register(NULL, &desc);
-@@ -3137,11 +3137,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3142,11 +3142,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	memcpy(caps.pdo, port->source_caps, sizeof(u32) * port->nr_source_caps);
  	caps.role = TYPEC_SOURCE;
  

--- a/patch/kernel/archive/rockchip64-7.0/rk3399-usbc-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3399-usbc-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3128,15 +3128,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3133,15 +3133,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -45,7 +45,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -3151,15 +3158,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
+@@ -3156,15 +3163,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -72,7 +72,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -7222,10 +7236,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
+@@ -7229,10 +7243,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
  		port->pds[i] = usb_power_delivery_register(port->dev, &desc);
  		if (IS_ERR(port->pds[i])) {
  			ret = PTR_ERR(port->pds[i]);

--- a/patch/kernel/archive/rockchip64-7.0/rk3399-usbc-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
+++ b/patch/kernel/archive/rockchip64-7.0/rk3399-usbc-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
@@ -37,7 +37,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -1876,6 +1876,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
+@@ -1881,6 +1881,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
  		return;
  
  	for (i = 0; i < modep->altmodes; i++) {


### PR DESCRIPTION
as per title
rewrite for latest upstream patch version
no further tests, rewrite only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added virtual Type-C Power Delivery extcon driver support
  * RK808 RTC device can now be disabled via device tree configuration

* **Bug Fixes**
  * Fixed USB Type-C PD capability registration to prevent duplicate entries and allow recovery from failures
  * Corrected serial SYSRQ break command handling for UART controllers
  * Made DMA reset errors non-fatal to allow device initialization with reduced throughput

* **Revert**
  * Reverted automatic unregistration of USB Type-C PD source capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9829)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->