### PR TITLE
kernel: run `kernel_copy_extra_sources` hooks after `kernel_maybe_clean`

### DIFF
--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -41,13 +41,13 @@ function compile_kernel() {
 	kernel_base_revision_date="$(LC_ALL=C date -d "@${kernel_base_revision_ts}")"
 	display_alert "Using Kernel git revision" "${kernel_git_revision} at '${kernel_base_revision_date}'"
 
+	# Possibly 'make clean'.
+	LOG_SECTION="kernel_maybe_clean" do_with_logging do_with_hooks kernel_maybe_clean
+
 	# Call extension method to prepare extra sources
 	call_extension_method "kernel_copy_extra_sources" <<- 'ARMBIAN_KERNEL_SOURCES_EXTRA'
 		*Hook to copy extra kernel sources to the kernel under compilation*
 	ARMBIAN_KERNEL_SOURCES_EXTRA
-
-	# Possibly 'make clean'.
-	LOG_SECTION="kernel_maybe_clean" do_with_logging do_with_hooks kernel_maybe_clean
 
 	# Patching.
 	declare hash pre_patch_version


### PR DESCRIPTION
- 🌵 otherwise changes done to kernel dir go away if cleaning is requested, which has been forcing family and board code to use unrelated hooks to workaround it, which in turn requires causes CONFIG_DEFS_ONLY=yes hacks which then causes hashes to differ from actual build runs
- 🐸 with this, now any source-level changes (incl generating patches) can now be done using `kernel_copy_extra_sources`; make sure to include all hashing-related code and references (eg: source SHA1 from external repos) into that hook, so changes there cause a change to the `-HK`
- 🍃 Fixes: c47c9372bf6970d6ca8c32bc5f7ec2a1416ab5bd "Add new hook to allow copying code into kernel"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized kernel compilation build process order for improved consistency in the build workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9830)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->