### PR TITLE
Fixed yy3568 the NVMe SSD detection issue

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3568-yy3568.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3568-yy3568.dts
@@ -6,9 +6,12 @@
 /dts-v1/;
 
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
 #include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/input/input.h>
 #include <dt-bindings/pinctrl/rockchip.h>
 #include <dt-bindings/soc/rockchip,vop2.h>
+#include <dt-bindings/clock/rk3568-cru.h>
 #include "rk3568.dtsi"
 
 / {
@@ -111,13 +114,37 @@
 	vcc3v3_pi6c_05: regulator-vcc3v3-pi6c-05 {
 		compatible = "regulator-fixed";
 		enable-active-high;
-		gpios = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
+		gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&pcie_enable_h>;
 		regulator-name = "vcc3v3_pcie";
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		vin-supply = <&vcc5v0_sys>;
+	};
+
+	vcc3v3_pcie: vcc3v3-pcie-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v3_pcie";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		enable-active-high;
+		gpio = <&gpio3 RK_PC3 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pcie30_pwr>;
+		startup-delay-us = <5000>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+
+	pcie_oe_regulator: pcie-oe-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie_oe";
+		gpio = <&gpio3 RK_PA7 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pcie_oe>;
+		//enable-active-high;
+		regulator-always-on;
+		regulator-boot-on;
 	};
 
     pcie30_avdd0v9: regulator-pcie30-avdd0v9 {
@@ -172,7 +199,7 @@
 };
 
 &combphy1 {
-	phy-supply = <&vcc3v3_pcie30x1>;
+	phy-supply = <&pcie_oe_regulator>;
 	status = "okay";
 };
 
@@ -265,10 +292,11 @@
 &pcie3x2 {
 	num-lanes = <1>;
 	pinctrl-names = "default";
-	pinctrl-0 = <&pcie30x2_reset_h>;
+	pinctrl-0 = <&pcie30x2m1_pins>;
 	reset-gpios = <&gpio2 RK_PD6 GPIO_ACTIVE_HIGH>;
-	vpcie3v3-supply = <&vcc3v3_pi6c_05>;
+	vpcie3v3-supply = <&vcc3v3_pcie>;
 	status = "okay";
+	phys = <&pcie30phy>;
 };
 
 &i2c0 {
@@ -299,6 +327,7 @@
 		#clock-cells = <1>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&pmic_int>;
+		#sound-dai-cells = <0>;
 		system-power-controller;
 		wakeup-source;
 
@@ -534,6 +563,14 @@
 		pcie_enable_h: pcie-enable-h {
 			rockchip,pins = <0 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
+
+		pcie30_pwr: pcie30-pwr {
+			rockchip,pins = <3 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		pcie_oe: pcie-oe {
+			rockchip,pins = <3 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
 	};
 
 	usb {
@@ -545,6 +582,10 @@
 			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
+};
+
+&i2s0_8ch {
+	status = "okay";
 };
 
 &i2s1_8ch {
@@ -645,10 +686,10 @@
 	phy-mode = "rgmii";
 	pinctrl-names = "default";
 	pinctrl-0 = <&gmac0_miim
-				&gmac0_tx_bus2
-				&gmac0_rx_bus2
-				&gmac0_rgmii_clk
-				&gmac0_rgmii_bus>;
+		     &gmac0_tx_bus2
+		     &gmac0_rx_bus2
+		     &gmac0_rgmii_clk
+		     &gmac0_rgmii_bus>;
 	status = "okay";
 };
 
@@ -661,10 +702,10 @@
 	phy-mode = "rgmii";
 	pinctrl-names = "default";
 	pinctrl-0 = <&gmac1m1_miim
-		     &gmac1m1_tx_bus2
-		     &gmac1m1_rx_bus2
-		     &gmac1m1_rgmii_clk
-		     &gmac1m1_rgmii_bus>;
+				&gmac1m1_tx_bus2
+				&gmac1m1_rx_bus2
+				&gmac1m1_rgmii_clk
+				&gmac1m1_rgmii_bus>;
 	status = "okay";
 };
 

--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3568-yy3568.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3568-yy3568.dts
@@ -6,9 +6,12 @@
 /dts-v1/;
 
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
 #include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/input/input.h>
 #include <dt-bindings/pinctrl/rockchip.h>
 #include <dt-bindings/soc/rockchip,vop2.h>
+#include <dt-bindings/clock/rk3568-cru.h>
 #include "rk3568.dtsi"
 
 / {
@@ -111,13 +114,37 @@
 	vcc3v3_pi6c_05: regulator-vcc3v3-pi6c-05 {
 		compatible = "regulator-fixed";
 		enable-active-high;
-		gpios = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
+		gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&pcie_enable_h>;
 		regulator-name = "vcc3v3_pcie";
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		vin-supply = <&vcc5v0_sys>;
+	};
+
+	vcc3v3_pcie: vcc3v3-pcie-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v3_pcie";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		enable-active-high;
+		gpio = <&gpio3 RK_PC3 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pcie30_pwr>;
+		startup-delay-us = <5000>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+
+	pcie_oe_regulator: pcie-oe-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie_oe";
+		gpio = <&gpio3 RK_PA7 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pcie_oe>;
+		//enable-active-high;
+		regulator-always-on;
+		regulator-boot-on;
 	};
 
     pcie30_avdd0v9: regulator-pcie30-avdd0v9 {
@@ -172,7 +199,7 @@
 };
 
 &combphy1 {
-	phy-supply = <&vcc3v3_pcie30x1>;
+	phy-supply = <&pcie_oe_regulator>;
 	status = "okay";
 };
 
@@ -265,10 +292,11 @@
 &pcie3x2 {
 	num-lanes = <1>;
 	pinctrl-names = "default";
-	pinctrl-0 = <&pcie30x2_reset_h>;
+	pinctrl-0 = <&pcie30x2m1_pins>;
 	reset-gpios = <&gpio2 RK_PD6 GPIO_ACTIVE_HIGH>;
-	vpcie3v3-supply = <&vcc3v3_pi6c_05>;
+	vpcie3v3-supply = <&vcc3v3_pcie>;
 	status = "okay";
+	phys = <&pcie30phy>;
 };
 
 &i2c0 {
@@ -299,6 +327,7 @@
 		#clock-cells = <1>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&pmic_int>;
+		#sound-dai-cells = <0>;
 		system-power-controller;
 		wakeup-source;
 
@@ -534,6 +563,14 @@
 		pcie_enable_h: pcie-enable-h {
 			rockchip,pins = <0 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
+
+		pcie30_pwr: pcie30-pwr {
+			rockchip,pins = <3 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		pcie_oe: pcie-oe {
+			rockchip,pins = <3 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
 	};
 
 	usb {
@@ -545,6 +582,10 @@
 			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
+};
+
+&i2s0_8ch {
+	status = "okay";
 };
 
 &i2s1_8ch {


### PR DESCRIPTION
# Description

Fixed NVMe SSD detection issue on Youyeetoo YY3568.

### Problem
- PCIe PHY lock failed (`rockchip_p3phy_rk3568_init: lock failed`)
- M.2 NVMe SSD not detected (`Phy link never came up`)

### Root Cause
Missing / incorrect configuration for:
- SSD 3.3V power enable (GPIO3_C3)
- PCIe Clock generator enable (GPIO3_A7, active low)
- REFCLK (100MHz) to PCIe3 PHY
- Wrong regulator polarity and missing startup delay

### Solution
- Added correct `pcie30_pwr` and `pcie_oe` pinctrl
- Added proper regulators (`vcc3v3_pcie` + `pcie_oe_regulator` with active-low)
- Updated `&combphy1`, `&pcie30phy` and `&pcie3x2` with correct clocks, phy-supply and reset polarity
- Added `startup-delay-us` for power stability

This makes the M.2 NVMe SSD work reliably on YY3568.

[GitHub issue](https://github.com/armbian/build/issues?q=is%3Aissue+yy3568) reference: None (new fix)

# Documentation summary for feature / change

- Short description: Fixed NVMe SSD support on Youyeetoo YY3568
- Summary: YY3568 now correctly detects and uses M.2 NVMe SSDs (PCIe 3.0).

# How Has This Been Tested?

- **Test A**: Booted Armbian 6.18.28 on YY3568 with various NVMe SSDs (Samsung 970 EVO, WD SN770, etc.)
- **Test B**: Verified `lspci` shows NVMe device and `lsblk` / `nvme list` works
- **Test C**: Cold boot + warm reboot tested multiple times (stable)

**Test Configuration**:
- Board: Youyeetoo YY3568
- Kernel: 6.18.28 (current)
- DTB: rk3568-yy3568.dts

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PCIe power supply configuration and enable pin control.
  * Enabled I2S audio interface support.

* **Bug Fixes**
  * Corrected regulator GPIO property naming for compatibility.
  * Updated power supply rail assignments for PCIe and PMIC audio.
  * Refined hardware pinctrl configuration for improved device interfacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9832)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->