### PR TITLE
SpacemiT: Fixup OpenSBI, U-Boot and BPI-F3 DTS

### DIFF
--- a/patch/atf/atf-spacemit/001-Fix-bool-definition.patch
+++ b/patch/atf/atf-spacemit/001-Fix-bool-definition.patch
@@ -1,0 +1,61 @@
+From 6058c8ba1cc525b2d9e5caa48928f9226810dfe7 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@gmail.com>
+Date: Fri, 15 May 2026 08:11:09 -0400
+Subject: [PATCH] Fix bool definition
+
+Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
+---
+ include/sbi/sbi_types.h | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/include/sbi/sbi_types.h b/include/sbi/sbi_types.h
+index def88bb..3691289 100644
+--- a/include/sbi/sbi_types.h
++++ b/include/sbi/sbi_types.h
+@@ -1,5 +1,4 @@
+-/*
+- * SPDX-License-Identifier: BSD-2-Clause
++/* SPDX-License-Identifier: BSD-2-Clause
+  *
+  * Copyright (c) 2019 Western Digital Corporation or its affiliates.
+  *
+@@ -14,6 +13,8 @@
+ 
+ /* clang-format off */
+ 
++#include <stdbool.h>
++
+ typedef char			s8;
+ typedef unsigned char		u8;
+ typedef unsigned char		uint8_t;
+@@ -44,7 +45,6 @@ typedef unsigned long long	uint64_t;
+ #error "Unexpected __riscv_xlen"
+ #endif
+ 
+-typedef int			bool;
+ typedef unsigned long		ulong;
+ typedef unsigned long		uintptr_t;
+ typedef unsigned long		size_t;
+@@ -88,8 +88,8 @@ typedef uint64_t		be64_t;
+ #endif
+ 
+ #define container_of(ptr, type, member) ({			\
+-	const typeof(((type *)0)->member) * __mptr = (ptr);	\
+-	(type *)((char *)__mptr - offsetof(type, member)); })
++    const typeof(((type *)0)->member) * __mptr = (ptr);	\
++    (type *)((char *)__mptr - offsetof(type, member)); })
+ 
+ #define array_size(x) 	(sizeof(x) / sizeof((x)[0]))
+ 
+@@ -111,7 +111,7 @@ typedef uint64_t		be64_t;
+  * external definitions of data types and common macros.
+  * OPENSBI_EXTERNAL_SBI_TYPES is the file name to external header file,
+  * the external build system should address the additional include
+- * directory ccordingly.
++ * directory accordingly.
+  */
+ 
+ #define XSTR(x) #x
+-- 
+2.53.0
+

--- a/patch/kernel/archive/spacemit-7.1/053-Update-BPI-F3-DTS.patch
+++ b/patch/kernel/archive/spacemit-7.1/053-Update-BPI-F3-DTS.patch
@@ -1,0 +1,90 @@
+From f0651580567b1d99e20dd1a6e72155372cf79033 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@gmail.com>
+Date: Sat, 16 May 2026 07:54:15 -0400
+Subject: [PATCH] Update BPI-F3 DTS
+
+Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
+---
+ .../boot/dts/spacemit/k1-bananapi-f3.dts      | 48 ++++++++++---------
+ 1 file changed, 25 insertions(+), 23 deletions(-)
+
+diff --git a/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts b/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts
+index e9fe8189e704..6bcb0bd0b0a0 100644
+--- a/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts
++++ b/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts
+@@ -8,16 +8,18 @@
+ #include "k1-opp.dtsi"
+ 
+ / {
+-	model = "Banana Pi BPI-F3";
++	model = "BananaPi BPI-F3";
+ 	compatible = "bananapi,bpi-f3", "spacemit,k1";
+ 
+ 	aliases {
+ 		ethernet0 = &eth0;
+ 		ethernet1 = &eth1;
+-		serial0 = &uart0;
+-		spi3 = &spi3;
+ 		i2c2 = &i2c2;
+ 		i2c8 = &i2c8;
++		mmc0 = &sdhci0;
++		mmc2 = &emmc;
++		serial0 = &uart0;
++		spi3 = &spi3;
+ 	};
+ 
+ 	chosen {
+@@ -383,6 +385,26 @@ &pcie2 {
+ 	status = "okay";
+ };
+ 
++&sdhci0 {
++	pinctrl-names = "default", "uhs";
++	pinctrl-0 = <&mmc1_cfg>;
++	pinctrl-1 = <&mmc1_uhs_cfg>;
++	bus-width = <4>;
++	cd-gpios = <&gpio K1_GPIO(80) GPIO_ACTIVE_HIGH>;
++	cd-inverted;
++	broken-cd;
++	no-mmc;
++	no-sdio;
++	disable-wp;
++	cap-sd-highspeed;
++	vmmc-supply = <&buck4>;
++	vqmmc-supply = <&aldo1>;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	status = "okay";
++};
++
+ &spi3 {
+ 	pinctrl-0 = <&ssp3_0_cfg>;
+ 	pinctrl-names = "default";
+@@ -422,23 +444,3 @@ hub_3_0: hub@2 {
+ 		reset-gpios = <&gpio K1_GPIO(124) GPIO_ACTIVE_LOW>;
+ 	};
+ };
+-
+-&sdhci0 {
+-	pinctrl-names = "default", "uhs";
+-	pinctrl-0 = <&mmc1_cfg>;
+-	pinctrl-1 = <&mmc1_uhs_cfg>;
+-	bus-width = <4>;
+-	cd-gpios = <&gpio K1_GPIO(80) GPIO_ACTIVE_HIGH>;
+-	cd-inverted;
+-	broken-cd;
+-	no-mmc;
+-	no-sdio;
+-	disable-wp;
+-	cap-sd-highspeed;
+-	vmmc-supply = <&buck4>;
+-	vqmmc-supply = <&aldo1>;
+-	sd-uhs-sdr25;
+-	sd-uhs-sdr50;
+-	sd-uhs-sdr104;
+-	status = "okay";
+-};
+-- 
+2.53.0
+

--- a/patch/u-boot/legacy/u-boot-spacemit-k1/009-Fixup-circular-deps.patch
+++ b/patch/u-boot/legacy/u-boot-spacemit-k1/009-Fixup-circular-deps.patch
@@ -1,0 +1,35 @@
+From 89900082cc79f487d16099dc929534a395418119 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@gmail.com>
+Date: Fri, 15 May 2026 15:48:51 -0400
+Subject: [PATCH] Fixup circular deps
+
+Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
+---
+ tools/Makefile | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/tools/Makefile b/tools/Makefile
+index 36269196..d55d8698 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -267,7 +267,16 @@ HOSTCFLAGS_sha512.o := -pedantic -DCONFIG_SHA512 -DCONFIG_SHA384
+ quiet_cmd_wrap = WRAP    $@
+ cmd_wrap = echo "\#include <../$(patsubst $(obj)/%,%,$@)>" >$@
+ 
+-$(obj)/boot/%.c $(obj)/common/%.c $(obj)/env/%.c $(obj)/lib/%.c:
++$(obj)/boot/%.c: tools/boot/%.c
++	$(call cmd,wrap)
++
++$(obj)/common/%.c: tools/common/%.c
++	$(call cmd,wrap)
++
++$(obj)/env/%.c: tools/env/%.c
++	$(call cmd,wrap)
++
++$(obj)/lib/%.c: tools/lib/%.c
+ 	$(call cmd,wrap)
+ 
+ clean-dirs := lib common
+-- 
+2.53.0
+


### PR DESCRIPTION
OpenSBI
* GCC-15 Support

U-Boot
* Avoid pattern recipe did not update peer target "warning".

Linux
* Move &sdhci0 node and add mmc to aliases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed circular build dependencies affecting compilation.
  * Corrected boolean type definition to use C standard library.
  * Updated device tree configuration for Banana Pi BPI-F3.

* **Improvements**
  * Enhanced device tree with new MMC device aliases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->