### PR TITLE
drivers_network: bump rtl8852bs commit ref to 35d3e266 (May 17)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -428,7 +428,7 @@ driver_rtl8852bs() {
 	if linux-version compare "${version}" ge 6.1 && [[ "${LINUXFAMILY}" == spacemit || "${LINUXFAMILY}" == rk35xx || "${LINUXFAMILY}" == rockchip64 ]]; then
 
 		# Attach to specific commit
-		local rtl8852bs_ver='commit:e1f97d72dfc692e86269e836516162b793395289' # Commit date: May 15, 2026 (please update when updating commit ref)
+		local rtl8852bs_ver='commit:35d3e2660fd912c36777cc50dd43b3fbc805d56a' # Commit date: May 17, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8852BS SDIO chipset ${rtl8852bs_ver}" "info"
 


### PR DESCRIPTION
## Summary
One-line bump of the upstream commit pin for the RTL8852BS SDIO driver in [\`lib/functions/compilation/patch/drivers_network.sh\`](lib/functions/compilation/patch/drivers_network.sh):

\`\`\`diff
-	local rtl8852bs_ver='commit:e1f97d72dfc692e86269e836516162b793395289' # Commit date: May 15, 2026 (please update when updating commit ref)
+	local rtl8852bs_ver='commit:35d3e2660fd912c36777cc50dd43b3fbc805d56a' # Commit date: May 17, 2026 (please update when updating commit ref)
\`\`\`

Affects kernel ≥ 6.1 on \`spacemit\`, \`rk35xx\`, \`rockchip64\`.

## Test plan
- [x] Build a kernel image for one of the affected LINUXFAMILYs and confirm the driver fetches the new commit and compiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RTL8852BS wireless driver to a newer upstream version for supported platforms running kernel 6.1 and later.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->