### PR TITLE
enh: substring filter for the board picker

### DIFF
--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -180,10 +180,10 @@ function interactive_config_ask_board_list() {
 }
 
 function get_kernel_info_for_branch() {
-    local search_branch="$1"
-    local conf_file="${SRC}/config/sources/families/${BOARDFAMILY}.conf"
+	local search_branch="$1"
+	local conf_file="${SRC}/config/sources/families/${BOARDFAMILY}.conf"
 
-    awk -v branch="$search_branch" '
+	awk -v branch="$search_branch" '
     BEGIN { found=0; major_minor=""; desc="" }
     /^[[:space:]]*[a-zA-Z0-9_-]+\)/ {
         if ($0 ~ "^[[:space:]]*" branch "\\)") {
@@ -210,65 +210,64 @@ function get_kernel_info_for_branch() {
 }
 
 function interactive_config_ask_branch() {
-    if [[ -n $BRANCH ]]; then
-        display_alert "Already set BRANCH, skipping interactive" "${BRANCH}" "debug"
-        return 0
-    fi
+	if [[ -n $BRANCH ]]; then
+		display_alert "Already set BRANCH, skipping interactive" "${BRANCH}" "debug"
+		return 0
+	fi
 
-    declare -a options=()
-    declare one_kernel_target
+	declare -a options=()
+	declare one_kernel_target
 
-    for one_kernel_target in $(echo "${KERNEL_TARGET}" | tr "," "\n"); do
-
+	for one_kernel_target in $(echo "${KERNEL_TARGET}" | tr "," "\n"); do
 
 		local version=""
-        local description=""
+		local description=""
 
-        local info
-        info="$(get_kernel_info_for_branch "$one_kernel_target")"
-        version="${info%%|*}"
-        description="${info#*|}"
+		local info
+		info="$(get_kernel_info_for_branch "$one_kernel_target")"
+		version="${info%%|*}"
+		description="${info#*|}"
 
-        # Fallback if description is empty
-        if [[ -z "$description" ]]; then
-            case "$one_kernel_target" in
-                current)
-                    description="Recommended. Usually an LTS kernel"
-                    ;;
-                legacy)
-                    description="Old stable / Legacy kernel"
-                    ;;
-                edge)
-                    description="Bleeding edge / latest possible"
-                    ;;
-                cloud)
-                    description="Cloud optimized minimal LTS kernel"
-                    ;;
-                vendor)
-                    description="Vendor BSP kernel"
+		# Fallback if description is empty
+		if [[ -z "$description" ]]; then
+			case "$one_kernel_target" in
+				current)
+					description="Recommended. Usually an LTS kernel"
 					;;
-                *)
-                    description="Experimental ${one_kernel_target} kernel / for Developers"
-                    ;;
-            esac
-        fi
+				legacy)
+					description="Old stable / Legacy kernel"
+					;;
+				edge)
+					description="Bleeding edge / latest possible"
+					;;
+				cloud)
+					description="Cloud optimized minimal LTS kernel"
+					;;
+				vendor)
+					description="Vendor BSP kernel"
+					;;
+				*)
+					description="Experimental ${one_kernel_target} kernel / for Developers"
+					;;
+			esac
+		fi
 
-        # Append version if found
-        if [[ -n "$version" ]]; then
-            description="${description} (${version})"
-        fi
+		# Append version if found
+		if [[ -n "$version" ]]; then
+			description="${description} (${version})"
+		fi
 
-        options+=("${one_kernel_target}" "${description}")
-    done
+		options+=("${one_kernel_target}" "${description}")
+	done
 
-    dialog_if_terminal_set_vars --title "Choose a kernel" --backtitle "$backtitle" --colors \
-        --menu "Select the target kernel branch.\nSelected BOARD='${BOARD}'\nExact kernel versions depend on selected board and its family." \
-        $TTY_Y $TTY_X $((TTY_Y - 8)) "${options[@]}"
+	dialog_if_terminal_set_vars --title "Choose a kernel" --backtitle "$backtitle" --colors \
+		--menu "Select the target kernel branch.\nSelected BOARD='${BOARD}'\nExact kernel versions depend on selected board and its family." \
+		$TTY_Y $TTY_X $((TTY_Y - 8)) "${options[@]}"
 
-    set_interactive_config_value BRANCH "${DIALOG_RESULT}"
+	set_interactive_config_value BRANCH "${DIALOG_RESULT}"
 
-    [[ -z ${BRANCH} ]] && exit_with_error "No kernel branch selected"
-    return 0
+	[[ -z ${BRANCH} ]] && exit_with_error "No kernel branch selected"
+	return 0
 }
 
 function interactive_config_ask_release() {

--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -135,6 +135,9 @@ function interactive_config_ask_board_list() {
 
 	declare WIP_BUTTON='CSC/WIP/EOS/TVB'
 	declare STATE_DESCRIPTION=' - boards with high level of software maturity'
+	declare BOARD_FILTER=''
+	declare FILTER_TAG='[set filter]'
+	declare CLEAR_TAG='[clear filter]'
 	declare temp_rc
 	temp_rc=$(mktemp) # @TODO: this is a _very_ early call to mktemp - no TMPDIR set yet - it needs to be cleaned-up somehow
 
@@ -151,6 +154,41 @@ function interactive_config_ask_board_list() {
 			get_list_of_all_buildable_boards arr_all_board_names arr_all_board_options dict_all_board_types dict_all_board_source_files dict_all_board_descriptions # invoke
 			board_list_needs_refresh=no
 		fi
+
+		# Apply substring filter (case-insensitive, matches name and description) and
+		# prepend a sentinel entry that opens an --inputbox to set/change/clear the filter.
+		# arr_all_board_options is a flat sequence of (tag, item) pairs as dialog expects.
+		declare -a arr_menu_options=()
+		if [[ -n "${BOARD_FILTER}" ]]; then
+			declare lc_filter="${BOARD_FILTER,,}"
+			declare i tag item hay
+			declare -a arr_filter_hits=()
+			for ((i = 0; i < ${#arr_all_board_options[@]}; i += 2)); do
+				tag="${arr_all_board_options[i]}"
+				item="${arr_all_board_options[i + 1]}"
+				# Match against board name + raw description (from dict_all_board_descriptions),
+				# not against arr_all_board_options' item which carries dialog --colors escapes
+				# (\Z1...\Zn) and a leading "(type)" badge - those would cause false positives
+				# for searches like "conf", "wip" or "z1".
+				hay="${tag} ${dict_all_board_descriptions["${tag}"]}"
+				hay="${hay,,}"
+				if [[ "${hay}" == *"${lc_filter}"* ]]; then
+					arr_filter_hits+=("${tag}" "${item}")
+				fi
+			done
+			declare match_count=$((${#arr_filter_hits[@]} / 2))
+			arr_menu_options=(
+				"${FILTER_TAG}" "\Z1change filter (current: ${BOARD_FILTER}, ${match_count}/${#arr_all_board_names[@]} boards)\Zn"
+				"${CLEAR_TAG}" "\Z1clear filter, show all ${#arr_all_board_names[@]} boards\Zn"
+				"${arr_filter_hits[@]}"
+			)
+		else
+			arr_menu_options=(
+				"${FILTER_TAG}" "\Z1filter boards by substring of name or description\Zn"
+				"${arr_all_board_options[@]}"
+			)
+		fi
+
 		echo > "${temp_rc}"                    # zero out the rcfile to start
 		if [[ $WIP_STATE != supported ]]; then # be if wip csc etc included. I personally disagree here.
 			cat <<- 'EOF' > "${temp_rc}"
@@ -166,9 +204,9 @@ function interactive_config_ask_board_list() {
 		DIALOGRC=$temp_rc \
 			dialog_if_terminal_set_vars --title "Choose a board" --backtitle "$backtitle" --scrollbar \
 			--colors --extra-label "Show $WIP_BUTTON" --extra-button \
-			--menu "Select the target board. Displaying:\n$STATE_DESCRIPTION" $TTY_Y $TTY_X $((TTY_Y - 8)) "${arr_all_board_options[@]}"
-		set_interactive_config_value BOARD "${DIALOG_RESULT}"
+			--menu "Select the target board. Displaying:\n$STATE_DESCRIPTION" $TTY_Y $TTY_X $((TTY_Y - 8)) "${arr_menu_options[@]}"
 		declare STATUS=${DIALOG_EXIT_CODE}
+		declare RESULT="${DIALOG_RESULT}"
 
 		if [[ $STATUS == 3 ]]; then
 			if [[ $WIP_STATE == supported ]]; then
@@ -188,6 +226,16 @@ function interactive_config_ask_board_list() {
 			board_list_needs_refresh=yes # WIP_STATE changed - rescan to include/exclude wip/csc/eos/tvb
 			continue
 		elif [[ $STATUS == 0 ]]; then
+			if [[ "${RESULT}" == "${FILTER_TAG}" ]]; then
+				dialog_if_terminal_set_vars --title "Filter boards" --backtitle "$backtitle" \
+					--inputbox "Case-insensitive substring of board name or description. Empty value clears." 8 "${TTY_X}" "${BOARD_FILTER}"
+				[[ ${DIALOG_EXIT_CODE} == 0 ]] && BOARD_FILTER="${DIALOG_RESULT}"
+				continue
+			elif [[ "${RESULT}" == "${CLEAR_TAG}" ]]; then
+				BOARD_FILTER=''
+				continue
+			fi
+			set_interactive_config_value BOARD "${RESULT}"
 			break
 		else
 			exit_with_error "You cancelled interactive config" "Build cancelled, board not chosen"

--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -81,18 +81,24 @@ function get_list_of_all_buildable_boards() {
 		prepare_options=1
 	fi
 
-	local board_file_path board_type full_board_file
+	# Avoid a $(basename ... | cut ...) + $(head | cut ...) subshell pair per board file -
+	# with ~400 boards this is ~800 fork/exec cycles per scan. Bash parameter expansion
+	# plus a single `read` are equivalent and effectively free, which makes a noticeable
+	# difference on every dialog redraw (CSC/WIP toggle, filter changes, etc.).
+	local board_file_path board_type full_board_file board_name board_desc first_line
 	for board_file_path in "${board_file_paths[@]}"; do
 		[[ ! -d "${board_file_path}" ]] && continue
 		for board_type in "${board_types[@]}"; do
 			for full_board_file in "${board_file_path}"/*."${board_type}"; do
 				[[ "${full_board_file}" == *"*"* ]] && continue # ignore non-matches, due to bash's (non-)globbing behaviour
-				local board_name board_desc
-				board_name="$(basename "${full_board_file}" | cut -d'.' -f1)"
+				board_name="${full_board_file##*/}"             # strip directory (basename)
+				board_name="${board_name%.*}"                   # strip extension (cut -d'.' -f1)
 				ref_dict_all_board_types["${board_name}"]="${board_type}"
 				ref_dict_all_board_source_files["${board_name}"]="${ref_dict_all_board_source_files["${board_name}"]} ${full_board_file}" # accumulate, will have extra space
 				if [[ ${prepare_options} -gt 0 ]]; then
-					board_desc="$(head -1 "${full_board_file}" | cut -d'#' -f2)"
+					IFS= read -r first_line < "${full_board_file}" || true
+					board_desc="${first_line#*#}"  # everything after first '#' (cut -d'#' -f2 ...
+					board_desc="${board_desc%%#*}" # ... up to next '#' if any)
 					ref_dict_all_board_descriptions["${board_name}"]="${board_desc}"
 				fi
 			done
@@ -132,12 +138,21 @@ function interactive_config_ask_board_list() {
 	declare temp_rc
 	temp_rc=$(mktemp) # @TODO: this is a _very_ early call to mktemp - no TMPDIR set yet - it needs to be cleaned-up somehow
 
+	# Cache the board scan across dialog redraws. The result only changes when WIP_STATE
+	# changes (Show CSC/WIP/EOS/TVB button toggles the type set), so we re-scan only on
+	# that branch below. Without the cache every redraw would re-glob ~400 board files.
+	declare -a arr_all_board_names=() arr_all_board_options=()                                       # arrays
+	declare -A dict_all_board_types=() dict_all_board_source_files=() dict_all_board_descriptions=() # dictionaries
+	declare board_list_needs_refresh=yes
 	while true; do
-		declare -a arr_all_board_names=() arr_all_board_options=()                                                                                              # arrays
-		declare -A dict_all_board_types=() dict_all_board_source_files=() dict_all_board_descriptions=()                                                        # dictionaries
-		get_list_of_all_buildable_boards arr_all_board_names arr_all_board_options dict_all_board_types dict_all_board_source_files dict_all_board_descriptions # invoke
-		echo > "${temp_rc}"                                                                                                                                     # zero out the rcfile to start
-		if [[ $WIP_STATE != supported ]]; then                                                                                                                  # be if wip csc etc included. I personally disagree here.
+		if [[ "${board_list_needs_refresh}" == "yes" ]]; then
+			arr_all_board_names=() arr_all_board_options=()
+			dict_all_board_types=() dict_all_board_source_files=() dict_all_board_descriptions=()
+			get_list_of_all_buildable_boards arr_all_board_names arr_all_board_options dict_all_board_types dict_all_board_source_files dict_all_board_descriptions # invoke
+			board_list_needs_refresh=no
+		fi
+		echo > "${temp_rc}"                    # zero out the rcfile to start
+		if [[ $WIP_STATE != supported ]]; then # be if wip csc etc included. I personally disagree here.
 			cat <<- 'EOF' > "${temp_rc}"
 				dialog_color = (RED,WHITE,OFF)
 				screen_color = (WHITE,RED,ON)
@@ -170,6 +185,7 @@ function interactive_config_ask_board_list() {
 				WIP_BUTTON='CSC/WIP/EOS'
 				EXPERT=no # @TODO: this overrides an "expert" mode that could be set on by the user. revert to original one?
 			fi
+			board_list_needs_refresh=yes # WIP_STATE changed - rescan to include/exclude wip/csc/eos/tvb
 			continue
 		elif [[ $STATUS == 0 ]]; then
 			break


### PR DESCRIPTION
## Summary

Add a substring filter to the interactive board picker (`./compile.sh` when `BOARD` is not set). With ~400 supported boards the alphabetical list is long; the dialog's built-in first-letter navigation is impractical when many boards share a prefix. The PR introduces a `[set filter]` sentinel at the top of the menu that opens a `dialog --inputbox`; matching is case-insensitive on both the board name and the description line.

Bundled with two related changes that make the picker itself snappier (see commits below) — without them, opening / toggling / filtering the picker each pays a ~800-fork-per-redraw cost.

## Behaviour

- No filter active — the menu looks exactly like before plus a single new top entry `[set filter]`. All boards remain visible, no buttons added, no layout shift.
- Filter active — a second sentinel `[clear filter]` appears, and the first sentinel's description shows `change filter (current: <X>, <N>/<TOTAL> boards)`. Only matching boards are listed beneath.
- Filter state survives the `Show CSC/WIP/EOS/TVB` toggle.
- Cancel / Esc / OK on an empty board selection behave as before.

## Screens

Before — current behaviour with no sentinel, no filter:

<img width="690" height="386" alt="putty_2026-05-17_10-22-19" src="https://github.com/user-attachments/assets/43bb2649-47ef-4ad2-9e81-e1c5042951f4" />

After (no filter) — new sentinel at top:

<img width="690" height="386" alt="putty_2026-05-17_10-13-22" src="https://github.com/user-attachments/assets/76499ef3-c5b9-4b0c-aefc-7dbab959f339" />

<!-- placeholder: after-no-filter.png -->

Filter inputbox:

<img width="690" height="386" alt="putty_2026-05-17_10-11-13" src="https://github.com/user-attachments/assets/c03936b6-cb82-4d29-88be-11318e25491f" />

<!-- placeholder: filter-inputbox.png -->

Filter active — 2/367 boards match `helios`:

<img width="690" height="386" alt="putty_2026-05-17_10-11-37" src="https://github.com/user-attachments/assets/f3bb003c-f2b0-4c2a-990e-10475ba9c2a6" />

<!-- placeholder: filter-active.png -->

## Why a sentinel and not a button

The first attempt added `--help-button --help-label "Filter"` to the existing `--menu`. In a standard 80×24 PuTTY/xterm the four buttons (OK, Show CSC.., Cancel, Filter) plus the menu items don't fit; `dialog` returns 255 ("screen too small") before the user can interact. A sentinel menu entry sidesteps that — no extra button, no layout change.

## Commits

1. `interactive: shfmt whole-file format pass` — formatting-only pass on `lib/functions/configuration/interactive.sh` so the substantive diffs that follow show up clean. No behaviour change.
2. `interactive: cache board list across dialog redraws, drop per-file subshells` — `get_list_of_all_buildable_boards` previously forked `basename | cut` and `head | cut` per board file (~800 forks for ~400 boards) and re-ran on every dialog redraw. Replaces the subshells with bash parameter expansion + a single `read -r`, and hoists the result out of the while loop so it only re-scans when `WIP_STATE` changes (Show CSC/WIP/EOS/TVB toggle).
3. `interactive: substring filter for the board picker` — the actual feature, ~45 lines added in `interactive_config_ask_board_list`.

## Test plan

- [x] Build a board interactively without setting BOARD: `./compile.sh build` → dialog shows `[set filter]` at top alongside all boards
- [x] Select `[set filter]` → type `helios` → menu shows `[set filter]` (with `current: helios, 2/367`), `[clear filter]`, `helios4`, `helios64`
- [x] Select `[clear filter]` → full list returns, only `[set filter]` sentinel remains
- [x] Toggle `Show CSC/WIP/EOS/TVB` while a filter is active → filter persists, re-scan happens once
- [x] Original button row is unchanged (OK / Show.. / Cancel) — no `--help-button` added
- [x] Board descriptions in the menu match the pre-PR cut/head output for a spot-checked sample

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Substring filtering for board selection with "[set filter]" and "[clear filter]" options; filter persists during interactive configuration.
  * Case-insensitive matching across board name and description.

* **Performance**
  * Faster board-list handling via cached scans and more efficient parsing to avoid redundant external calls; cache refreshes when board-type toggles change.

* **Behavior**
  * Improved responsiveness and more reliable selection handling during interactive dialogs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->