### PR TITLE
nanopi-m5: pin DRD0 dwc3 to host mode to expose the second USB3 port

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/board-nanopi-m5-add-wifi-bt-ufs-and-misc.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-nanopi-m5-add-wifi-bt-ufs-and-misc.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
-Date: Fri, 8 May 2026 09:00:00 +0200
+Date: Sat, 16 May 2026 19:00:00 +0200
 Subject: arm64: dts: rockchip: Complete NanoPi M5 board description (6.18)
 
 The mainline rk3576-nanopi-m5.dts in 6.18 is a minimal first-cut that
@@ -44,10 +44,20 @@ schematics. Fill in the gaps:
     header (uart3m0_xfer / uart8m1_xfer pinmuxes) for users wiring up
     sensors, GPS, etc.
 
+  - USB DRD0: force usb_drd0_dwc3 to dr_mode = "host" and drop the
+    extcon link to u2phy0. Both physical USB3 ports on the M5 are
+    Type-A; DRD0 is wired to the second one and was declared as OTG
+    by mainline, but dwc3-rockchip on 6.18 / 7.0 / 7.1 does not
+    consume the rockchip-usb2phy OTG extcon to switch role at probe,
+    so the controller stays stuck in peripheral and the SuperSpeed
+    lane on that port never enumerates. Pinning it to host exposes
+    the second 5 Gbps Type-A port; OTG gadget usage on this port
+    was never functional anyway.
+
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 109 ++++++++++
- 1 file changed, 109 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 112 +++++++++-
+ 1 file changed, 110 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts b/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts
 index 111111111111..222222222222 100644
@@ -171,7 +181,7 @@ index 111111111111..222222222222 100644
  &sdmmc {
  	bus-width = <4>;
  	cap-mmc-highspeed;
-@@ -910,6 +986,39 @@ &uart0 {
+@@ -910,13 +986,45 @@ &uart0 {
  	status = "okay";
  };
  
@@ -211,6 +221,14 @@ index 111111111111..222222222222 100644
  &usbdp_phy {
  	status = "okay";
  };
+ 
+ &usb_drd0_dwc3 {
+-	dr_mode = "otg";
+-	extcon = <&u2phy0>;
++	dr_mode = "host";
+ 	status = "okay";
+ };
+ 
 -- 
 Armbian
 

--- a/patch/kernel/archive/rockchip64-7.0/board-nanopi-m5-add-wifi-bt-and-misc.patch
+++ b/patch/kernel/archive/rockchip64-7.0/board-nanopi-m5-add-wifi-bt-and-misc.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
-Date: Fri, 8 May 2026 09:00:00 +0200
+Date: Sat, 16 May 2026 19:00:00 +0200
 Subject: arm64: dts: rockchip: Complete NanoPi M5 board description
 
 The mainline rk3576-nanopi-m5.dts is a minimal first-cut that omits
@@ -37,10 +37,20 @@ Fill in the gaps:
     header (uart3m0_xfer / uart8m1_xfer pinmuxes) for users wiring up
     sensors, GPS, etc.
 
+  - USB DRD0: force usb_drd0_dwc3 to dr_mode = "host" and drop the
+    extcon link to u2phy0. Both physical USB3 ports on the M5 are
+    Type-A; DRD0 is wired to the second one and was declared as OTG
+    by mainline, but dwc3-rockchip on 6.18 / 7.0 / 7.1 does not
+    consume the rockchip-usb2phy OTG extcon to switch role at probe,
+    so the controller stays stuck in peripheral and the SuperSpeed
+    lane on that port never enumerates. Pinning it to host exposes
+    the second 5 Gbps Type-A port; OTG gadget usage on this port
+    was never functional anyway.
+
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 85 ++++++++++
- 1 file changed, 85 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 88 +++++++++-
+ 1 file changed, 86 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts b/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts
 index 111111111111..222222222222 100644
@@ -173,6 +183,16 @@ index 111111111111..222222222222 100644
  &ufshc {
  	vcc-supply = <&vcc_3v3_s3>;
  	vccq-supply = <&vcc1v2_ufs_vccq>;
+@@ -947,8 +1032,7 @@ &usbdp_phy {
+ };
+ 
+ &usb_drd0_dwc3 {
+-	dr_mode = "otg";
+-	extcon = <&u2phy0>;
++	dr_mode = "host";
+ 	status = "okay";
+ };
+ 
 -- 
 Armbian
 

--- a/patch/kernel/archive/rockchip64-7.1/board-nanopi-m5-add-wifi-bt-and-misc.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-nanopi-m5-add-wifi-bt-and-misc.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
-Date: Fri, 8 May 2026 09:00:00 +0200
+Date: Sat, 16 May 2026 19:00:00 +0200
 Subject: arm64: dts: rockchip: Complete NanoPi M5 board description
 
 The mainline rk3576-nanopi-m5.dts is a minimal first-cut that omits
@@ -37,10 +37,20 @@ Fill in the gaps:
     header (uart3m0_xfer / uart8m1_xfer pinmuxes) for users wiring up
     sensors, GPS, etc.
 
+  - USB DRD0: force usb_drd0_dwc3 to dr_mode = "host" and drop the
+    extcon link to u2phy0. Both physical USB3 ports on the M5 are
+    Type-A; DRD0 is wired to the second one and was declared as OTG
+    by mainline, but dwc3-rockchip on 6.18 / 7.0 / 7.1 does not
+    consume the rockchip-usb2phy OTG extcon to switch role at probe,
+    so the controller stays stuck in peripheral and the SuperSpeed
+    lane on that port never enumerates. Pinning it to host exposes
+    the second 5 Gbps Type-A port; OTG gadget usage on this port
+    was never functional anyway.
+
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 85 ++++++++++
- 1 file changed, 85 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 88 +++++++++-
+ 1 file changed, 86 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts b/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts
 index 111111111111..222222222222 100644
@@ -173,6 +183,16 @@ index 111111111111..222222222222 100644
  &ufshc {
  	vcc-supply = <&vcc_3v3_s3>;
  	vccq-supply = <&vcc1v2_ufs_vccq>;
+@@ -947,8 +1032,7 @@ &usbdp_phy {
+ };
+ 
+ &usb_drd0_dwc3 {
+-	dr_mode = "otg";
+-	extcon = <&u2phy0>;
++	dr_mode = "host";
+ 	status = "okay";
+ };
+ 
 -- 
 Armbian
 


### PR DESCRIPTION
# Description

Both physical USB3 ports on the NanoPi M5 are Type-A, but `lsusb -t` only shows one of them. The controller for the second port (`usb_drd0_dwc3` @ `0x23000000`) is declared `dr_mode = "otg"` with extcon hooked to `u2phy0`, and `dwc3-rockchip` on 6.18/7.0/7.1 does not act on the OTG extcon to switch role at probe. The controller stays in peripheral and the SuperSpeed lane never enumerates.

Pin DRD0 to `dr_mode = "host"` and drop the dead extcon link. This unlocks the second USB3 root hub. OTG gadget usage on this port was never functional with the upstream `dwc3-rockchip` on this SoC anyway.

The override is added to the board patch on all three rockchip64 branches that consume the upstream M5 DT: `current` (6.18), `edge` (7.0), `bleedingedge` (7.1).

# How Has This Been Tested?

NanoPi M5, kernel `7.0.8-edge-rockchip64` built from this branch. Before, only one DWC3 enumerates:

```
/:  Bus 001.Port 001: Dev 001, Class=root_hub, Driver=xhci-hcd/1p, 480M
/:  Bus 002.Port 001: Dev 001, Class=root_hub, Driver=xhci-hcd/1p, 5000M
```

After, with a SABRENT USB3 enclosure on the first Type-A port:

```
/:  Bus 001.Port 001: Dev 001, Class=root_hub, Driver=xhci-hcd/1p, 480M
/:  Bus 002.Port 001: Dev 001, Class=root_hub, Driver=xhci-hcd/1p, 5000M
    |__ Port 001: Dev 002, If 0, Class=Mass Storage, Driver=uas, 5000M
/:  Bus 003.Port 001: Dev 001, Class=root_hub, Driver=xhci-hcd/1p, 480M
/:  Bus 004.Port 001: Dev 001, Class=root_hub, Driver=xhci-hcd/1p, 5000M
```

Same enclosure moved to the second Type-A port, enumerates on bus 004 at SuperSpeed:

```
/:  Bus 001.Port 001: Dev 001, Class=root_hub, Driver=xhci-hcd/1p, 480M
/:  Bus 002.Port 001: Dev 001, Class=root_hub, Driver=xhci-hcd/1p, 5000M
/:  Bus 003.Port 001: Dev 001, Class=root_hub, Driver=xhci-hcd/1p, 480M
/:  Bus 004.Port 001: Dev 001, Class=root_hub, Driver=xhci-hcd/1p, 5000M
    |__ Port 001: Dev 002, If 0, Class=Mass Storage, Driver=uas, 5000M
```

- [x] build rockchip64 `edge` (7.0)
- [x] test on hw: NanoPi M5

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Wi‑Fi and Bluetooth support on the NanoPi M5
  * Added UFS storage support
  * Enabled BACK key via ADC (hardware button)
  * Added SDIO power/reset handling for more reliable Wi‑Fi
  * Improved Ethernet timing/configuration for better network performance
  * Set USB Type‑C controller to operate in dedicated host mode

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->