### PR TITLE
rockchip64-6.18: rebase rk3399 dwc3 phy-reset-quirk patch for 6.18.32

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-phy-rockchip-naneng-Add-fallback-for-old-DTs.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-phy-rockchip-naneng-Add-fallback-for-old-DTs.patch
@@ -22,7 +22,7 @@ index 111111111111..222222222222 100644
  	reg &= ~(DWC3_GCTL_PRTCAPDIR(DWC3_GCTL_PRTCAP_OTG));
 -	reg |= DWC3_GCTL_PRTCAPDIR(mode);
 +	reg |= DWC3_GCTL_PRTCAPDIR(mode & DWC3_GCTL_PRTCAP_OTG);
- 	dwc3_writel(dwc->regs, DWC3_GCTL, reg);
+ 	dwc3_writel(dwc, DWC3_GCTL, reg);
  
  	dwc->current_dr_role = mode;
 @@ -193,6 +193,7 @@ static void __dwc3_set_mode(struct work_struct *work)
@@ -63,9 +63,9 @@ index 111111111111..222222222222 100644
 +			for (int j = 0; j < dwc->num_usb3_ports; j++)
 +				phy_power_off(dwc->usb3_generic_phy[j]);
 +
- 		reg = dwc3_readl(dwc->regs, DWC3_GCTL);
+ 		reg = dwc3_readl(dwc, DWC3_GCTL);
  		reg |= DWC3_GCTL_CORESOFTRESET;
- 		dwc3_writel(dwc->regs, DWC3_GCTL, reg);
+ 		dwc3_writel(dwc, DWC3_GCTL, reg);
  
 +		if (dwc->usb3_phy_reset_quirk) {
 +			for (int j = 0; j < dwc->num_usb3_ports; j++) {
@@ -158,7 +158,7 @@ index 111111111111..222222222222 100644
  
  #define DWC3_GCTL_CORESOFTRESET		BIT(11)
  #define DWC3_GCTL_SOFITPSYNC		BIT(10)
-@@ -1166,6 +1172,10 @@ struct dwc3_glue_ops {
+@@ -1164,6 +1170,10 @@ struct dwc3_glue_ops {
   * @sys_wakeup: set if the device may do system wakeup.
   * @wakeup_configured: set if the device is configured for remote wakeup.
   * @suspended: set to track suspend event due to U3/L2.
@@ -169,7 +169,7 @@ index 111111111111..222222222222 100644
   * @susphy_state: state of DWC3_GUSB2PHYCFG_SUSPHY + DWC3_GUSB3PIPECTL_SUSPHY
   *		  before PM suspend.
   * @imod_interval: set the interrupt moderation interval in 250ns
-@@ -1411,6 +1421,8 @@ struct dwc3 {
+@@ -1409,6 +1419,8 @@ struct dwc3 {
  	unsigned		suspended:1;
  	unsigned		susphy_state:1;
  


### PR DESCRIPTION
# Description

The `rk3399-usbc-phy-rockchip-naneng-Add-fallback-for-old-DTs.patch` in `patch/kernel/archive/rockchip64-6.18/` was last rewritten against 6.18.18 (commit 2dc5b23a5). Mainline 6.18 stable progressed past that point and refactored `dwc3_readl()` / `dwc3_writel()` to take the `struct dwc3 *` directly instead of `dwc->regs`. The patch context still references the old form, so hunks 1 (`drivers/usb/dwc3/core.c` line 153) and 3 (line 213) fail to match when building against 6.18.32.

This commit updates only the patch context (no change to the `+` / `-` payload) so the same logic applies cleanly on 6.18.32 while remaining compatible with the prior baseline.

The copies of the same patch in `rockchip64-7.0` (rebased by Paolo Sabatino on 2026-03-08, commit `37142830b`) and `rockchip64-7.1` (copy from 7.0 on 2026-04-28, `9d967eccf`) already use the new `dwc3_writel(dwc, ...)` form and do not need a similar update.

# How Has This Been Tested?

Before, on a build pulling 6.18.32 sources (`./compile.sh BOARD=youyeetoo-r1-v3 BRANCH=current`):

```
patching file "drivers/usb/dwc3/core.c"
Hunk #1 FAILED at 153.
Hunk #3 FAILED at 213.
2 out of 10 hunks FAILED -- saving rejects to file "/tmp/tmpnd4dvnbx"
```

After rebase, the patch applies cleanly on kernel 6.18.32, all 16 hunks across the 3 files (`core.c`, `core.h`, `drd.c`), no offset, no rejects.

- [x] dry-run against 6.18.32

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced USB3 PHY power management for RK3399 TypeC devices during USB mode transitions
  * Improved USB controller behavior during role changes and power state transitions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->