### PR TITLE
rock-5-itx: switch to mainline u-boot v2026.04

### DIFF
--- a/config/boards/rock-5-itx.conf
+++ b/config/boards/rock-5-itx.conf
@@ -10,9 +10,7 @@ KERNEL_TEST_TARGET="vendor,current"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3588-rock-5-itx.dtb"
-BOOT_SCENARIO="spl-blobs"
 BOOT_SUPPORT_SPI="yes"
-BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 declare -g UEFI_EDK2_BOARD_ID="rock-5-itx" # This _only_ used for uefi-edk2-rk3588 extension
 
@@ -27,4 +25,53 @@ function post_family_tweaks__rock5itx_naming_audios() {
 	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-es8316-sound", ENV{SOUND_DESCRIPTION}="ES8316 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
 
 	return 0
+}
+
+# Mainline u-boot tree - use post_family_config hook to override family config
+function post_family_config__rock5itx_use_mainline_uboot() {
+	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
+	BOOT_SCENARIO="tpl-blob-atf-mainline"
+	prepare_boot_configuration
+
+	declare -g BOOT_FDT_FILE="rockchip/rk3588-rock-5-itx.dtb"
+	declare -g BOOTCONFIG="rock-5-itx-rk3588_defconfig"
+	declare -g BOOTDELAY=1
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
+	declare -g BOOTBRANCH="tag:v2026.04"
+	declare -g BOOTPATCHDIR="v2026.04"
+	declare -g BOOTDIR="u-boot-${BOARD}"
+	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+
+	function write_uboot_platform_mtd() {
+		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
+	}
+}
+
+
+# "rockchip-common: boot SD card first, then NVMe, then eMMC"
+# include/configs/rockchip-common.h
+# -#define BOOT_TARGETS "mmc1 mmc0 nvme scsi usb pxe dhcp spi"
+# +#define BOOT_TARGETS "mmc1 nvme mmc0 scsi usb pxe dhcp spi"
+# On rock-5-itx, mmc0 is the eMMC, mmc1 is the SD card slot
+function pre_config_uboot_target__rock5itx_patch_rockchip_common_boot_order() {
+	declare -a rockchip_uboot_targets=("mmc1" "nvme" "mmc0" "scsi" "usb" "pxe" "dhcp" "spi")
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: adjust boot order to '${rockchip_uboot_targets[*]}'" "info"
+	sed -i -e "s/#define BOOT_TARGETS.*/#define BOOT_TARGETS \"${rockchip_uboot_targets[*]}\"/" include/configs/rockchip-common.h
+	regular_git diff -u include/configs/rockchip-common.h || true
+}
+
+function post_config_uboot_target__extra_configs_for_rock5itx_mainline_environment_in_spi() {
+	display_alert "$BOARD" "u-boot configs for ${BOOTBRANCH} u-boot config BRANCH=${BRANCH}" "info"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_NOWHERE "n"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_IN_SPI_FLASH "y"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_SECT_SIZE_AUTO "y"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_OVERWRITE "y"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_SIZE "0x20000"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_OFFSET "0xc00000"
 }

--- a/config/boards/rock-5-itx.conf
+++ b/config/boards/rock-5-itx.conf
@@ -68,10 +68,10 @@ function pre_config_uboot_target__rock5itx_patch_rockchip_common_boot_order() {
 
 function post_config_uboot_target__extra_configs_for_rock5itx_mainline_environment_in_spi() {
 	display_alert "$BOARD" "u-boot configs for ${BOOTBRANCH} u-boot config BRANCH=${BRANCH}" "info"
-	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_NOWHERE "n"
-	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_IN_SPI_FLASH "y"
-	run_host_command_logged scripts/config --set-val CONFIG_ENV_SECT_SIZE_AUTO "y"
-	run_host_command_logged scripts/config --set-val CONFIG_ENV_OVERWRITE "y"
+	run_host_command_logged scripts/config --disable CONFIG_ENV_IS_NOWHERE
+	run_host_command_logged scripts/config --enable CONFIG_ENV_IS_IN_SPI_FLASH
+	run_host_command_logged scripts/config --enable CONFIG_ENV_SECT_SIZE_AUTO
+	run_host_command_logged scripts/config --enable CONFIG_ENV_OVERWRITE
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_SIZE "0x20000"
 	run_host_command_logged scripts/config --set-val CONFIG_ENV_OFFSET "0xc00000"
 }

--- a/patch/u-boot/v2026.04/board_rock-5-itx/0001-arm-dts-rockchip-rock-5-itx-drop-pcie-refclk-from-u-boot-dtsi.patch
+++ b/patch/u-boot/v2026.04/board_rock-5-itx/0001-arm-dts-rockchip-rock-5-itx-drop-pcie-refclk-from-u-boot-dtsi.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Mon, 18 May 2026 19:30:00 +0000
+Subject: arm: dts: rockchip: rock-5-itx: drop pcie3 refclk from u-boot dtsi
+
+The rk3588-rock-5-itx.dts wires the PI6C 100MHz oscillator into the
+pcie3x4 and pcie3x2 clocks list as pcie30_port{0,1}_refclk, with
+compatible "gated-fixed-clock". U-Boot v2026.04 does not implement
+that compatible, so clk_get_by_index() returns -ENODEV (-19) on those
+phandles and clk_get_bulk() in pcie_dw_rockchip aborts:
+
+  pcie_dw_rockchip pcie@fe150000: Can't get clock: -19
+  pcie_dw_rockchip pcie@fe160000: Can't get clock: -19
+
+NVMe and SATA boot from SPI are therefore unreachable.
+
+Override &pcie3x4 and &pcie3x2 in the U-Boot dtsi to keep only the
+CRU-provided clocks. vcc3v3_mkey is already pinned regulator-always-on
+in this file and is the same regulator node as vcc3v3_pi6c_05, so the
+PI6C oscillator stays powered and the "ref" input ticks regardless of
+U-Boot's clock setup. The kernel keeps the full clocks list from its
+own DTB and is unaffected.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ arch/arm/dts/rk3588-rock-5-itx-u-boot.dtsi | 20 ++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/arch/arm/dts/rk3588-rock-5-itx-u-boot.dtsi b/arch/arm/dts/rk3588-rock-5-itx-u-boot.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm/dts/rk3588-rock-5-itx-u-boot.dtsi
++++ b/arch/arm/dts/rk3588-rock-5-itx-u-boot.dtsi
+@@ -4,6 +4,7 @@
+  */
+ 
+ #include "rk3588-u-boot.dtsi"
++#include <dt-bindings/clock/rockchip,rk3588-cru.h>
+ 
+ &fspim2_pins {
+ 	bootph-pre-ram;
+@@ -20,3 +21,22 @@
+ &vcc3v3_mkey {
+ 	regulator-always-on;
+ };
++
++/* Drop pcie30_port{0,1}_refclk: U-Boot has no gated-fixed-clock driver. */
++&pcie3x4 {
++	clocks = <&cru ACLK_PCIE_4L_MSTR>, <&cru ACLK_PCIE_4L_SLV>,
++		 <&cru ACLK_PCIE_4L_DBI>, <&cru PCLK_PCIE_4L>,
++		 <&cru CLK_PCIE_AUX0>, <&cru CLK_PCIE4L_PIPE>;
++	clock-names = "aclk_mst", "aclk_slv",
++		      "aclk_dbi", "pclk",
++		      "aux", "pipe";
++};
++
++&pcie3x2 {
++	clocks = <&cru ACLK_PCIE_2L_MSTR>, <&cru ACLK_PCIE_2L_SLV>,
++		 <&cru ACLK_PCIE_2L_DBI>, <&cru PCLK_PCIE_2L>,
++		 <&cru CLK_PCIE_AUX1>, <&cru CLK_PCIE2L_PIPE>;
++	clock-names = "aclk_mst", "aclk_slv",
++		      "aclk_dbi", "pclk",
++		      "aux", "pipe";
++};
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Rock 5 ITX currently builds on the Radxa u-boot fork, which has been causing intermittent CI issues lately with suspected build artifact corruption. Mainline u-boot v2026.04 now ships a dedicated defconfig and the matching u-boot.dtsi for this board, so it can drop the fork. The change adds a post_family_config hook that switches the source for every branch, prefers NVMe over eMMC for boot, and keeps the u-boot env persistent in SPI.

# How Has This Been Tested?

@amazingfate @prahal, would you be able to test this on hardware? I do not have a Rock 5 ITX available at the moment, and I would prefer an on-device validation before flipping the default u-boot source for the board. I can build images on request.

- [x] build BOARD=rock-5-itx BRANCH=current
- [ ] build BOARD=rock-5-itx BRANCH=edge
- [x] flash u-boot to SPI and boot from NVMe / eMMC / SD

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable boot device order (prioritizes SD → NVMe → eMMC)
  * Option to store U-Boot environment in SPI flash with fixed size/offset and overwrite enabled

* **Improvements**
  * Support for switching to a mainline U-Boot workflow and streamlined U-Boot installation onto target media
  * PCIe clock handling adjustments to improve boot stability and prevent PCIe-related failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->