### PR TITLE
cli/amd64: drop firmware-sof-signed from trixie + sid

### DIFF
--- a/config/optional/architectures/amd64/_config/cli/sid/main/packages
+++ b/config/optional/architectures/amd64/_config/cli/sid/main/packages
@@ -1,4 +1,3 @@
 gpiod
 bolt
 thunderbolt-tools
-firmware-sof-signed

--- a/config/optional/architectures/amd64/_config/cli/trixie/main/packages
+++ b/config/optional/architectures/amd64/_config/cli/trixie/main/packages
@@ -1,4 +1,3 @@
 gpiod
 bolt
 thunderbolt-tools
-firmware-sof-signed


### PR DESCRIPTION
\`firmware-sof-signed\` was the odd-one-out in the CLI/amd64 release dirs — only \`trixie\` and \`sid\` listed it; \`bookworm\` / \`bullseye\` / \`jammy\` / \`noble\` / \`oracular\` have always shipped CLI without it. SOF firmware on a CLI image is dead weight (~7.4 MB on disk) since no ALSA/PulseAudio/PipeWire stack is installed at the CLI tier.

Drop on both so the CLI/amd64 set is consistent across releases. Desktops still get SOF firmware via the desktop package set / firmware-sof-signed-as-distro-default route.

## Test plan

- [ ] \`grep -r firmware-sof config/optional/architectures/amd64/\` returns nothing
- [ ] CLI builds on trixie + sid succeed and the image is ~7 MB smaller
- [ ] Desktop builds on trixie + sid still get SOF if they need it (verify via \`dpkg -l\` on a built desktop image)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `firmware-sof-signed` package from the AMD64 architecture configurations for both sid and trixie distributions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->