### PR TITLE
uefi-common: install firmware-sof-signed on every UEFI build

### DIFF
--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -12,6 +12,14 @@ declare -g BOARD_FIRMWARE_INSTALL="-full"            # Install full firmware for
 declare -g DISTRO_GENERIC_KERNEL=no
 declare -g POWER_MANAGEMENT_FEATURES=yes             # Suspend and resume might work well in UEFI, elsewhere is disabled by default
 
+# Intel SOF (Sound Open Firmware) DSP blobs for Meteor / Lunar / Panther
+# Lake and friends. Most UEFI x86 laptops route audio through SOF — without
+# the firmware the kernel SOF driver probes, fails to load sof-*.ri, and the
+# analog/speaker path stays silent (HDMI still works). Architecture: all
+# package, so adding it for arm64 UEFI is cheap (~7 MB of unused blobs) and
+# avoids a per-family branch here.
+add_packages_to_image firmware-sof-signed
+
 case "${BRANCH}" in
 
 	ddk)


### PR DESCRIPTION
UEFI boards are predominantly x86 laptops where audio routes through SOF. Without the firmware blobs the kernel SOF driver probes, fails to load \`/lib/firmware/intel/sof-ipc4/<plat>/sof-<plat>.ri\`, and the internal speakers / analog path stays silent (HDMI still works — many users don't notice until they unplug).

Move \`firmware-sof-signed\` from the per-release CLI baseline to the UEFI family include — that's the right home for a desktop-/laptop-leaning firmware package.

## Pairs with

- #9855 — drops \`firmware-sof-signed\` from \`config/optional/architectures/amd64/_config/cli/{trixie,sid}/main/packages\`. After both merge, the package is shipped on UEFI builds (covers most of the population that needs it) but no longer pulled into non-UEFI / SBC CLI/amd64 images.

## Why unconditional (not gated on \`LINUXFAMILY=x86\`)

\`firmware-sof-signed\` is \`Architecture: all\` — same .deb on every arch, ~7 MB of blobs. Adding it for arm64 UEFI as well is cheap and keeps the file simpler.

## Test plan

- [ ] Build a UEFI x86 image — \`dpkg -l firmware-sof-signed\` shows installed; \`ls /lib/firmware/intel/sof-ipc4/lnl/\` is non-empty
- [ ] Boot on a Lunar Lake / Meteor Lake laptop — \`dmesg \| grep -i sof\` no longer reports "Direct firmware load … failed"; \`aplay -l\` lists the SOF card
- [ ] Build a UEFI arm64 image — no apt error (package is arch-all and resolves cleanly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated UEFI firmware configuration to ensure the signed Intel Sound Open Firmware (SOF) DSP package is included in all builds, improving system compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->