### PR TITLE
firmware-sof-signed: move from cli/amd64 baseline to UEFI common

### DIFF
--- a/config/optional/architectures/amd64/_config/cli/sid/main/packages
+++ b/config/optional/architectures/amd64/_config/cli/sid/main/packages
@@ -1,4 +1,3 @@
 gpiod
 bolt
 thunderbolt-tools
-firmware-sof-signed

--- a/config/optional/architectures/amd64/_config/cli/trixie/main/packages
+++ b/config/optional/architectures/amd64/_config/cli/trixie/main/packages
@@ -1,4 +1,3 @@
 gpiod
 bolt
 thunderbolt-tools
-firmware-sof-signed

--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -12,6 +12,14 @@ declare -g BOARD_FIRMWARE_INSTALL="-full"            # Install full firmware for
 declare -g DISTRO_GENERIC_KERNEL=no
 declare -g POWER_MANAGEMENT_FEATURES=yes             # Suspend and resume might work well in UEFI, elsewhere is disabled by default
 
+# Intel SOF (Sound Open Firmware) DSP blobs for Meteor / Lunar / Panther
+# Lake and friends. Most UEFI x86 laptops route audio through SOF — without
+# the firmware the kernel SOF driver probes, fails to load sof-*.ri, and the
+# analog/speaker path stays silent (HDMI still works). Architecture: all
+# package, so adding it for arm64 UEFI is cheap (~7 MB of unused blobs) and
+# avoids a per-family branch here.
+add_packages_to_image firmware-sof-signed
+
 case "${BRANCH}" in
 
 	ddk)


### PR DESCRIPTION
Supersedes #9855 + #9856 (both closed; collapsed into one PR per review feedback).

## The bug

UEFI boards — predominantly x86 laptops — route audio through SOF. Without the firmware the kernel SOF driver probes, fails to load \`/lib/firmware/intel/sof-ipc4/<plat>/sof-<plat>.ri\`, and the analog / speaker path stays silent (HDMI still works, which is why many users don't notice until they unplug).

The per-release CLI baseline was the wrong home for it:

- \`trixie\` + \`sid\` had it; \`bookworm\` / \`bullseye\` / \`jammy\` / \`noble\` / \`oracular\` never did. CLI/amd64 was inconsistent across releases.
- SBC / headless CLI images don't need it and were eating ~7 MB of unused blobs.

## The move

| File | Change |
|---|---|
| \`config/optional/architectures/amd64/_config/cli/trixie/main/packages\` | drop \`firmware-sof-signed\` |
| \`config/optional/architectures/amd64/_config/cli/sid/main/packages\` | drop \`firmware-sof-signed\` |
| \`config/sources/families/include/uefi_common.inc\` | \`add_packages_to_image firmware-sof-signed\` (+ comment) |

\`firmware-sof-signed\` is \`Architecture: all\` — adding it unconditionally for arm64 UEFI is cheap (~7 MB of dead blobs on hosts without an SOF DSP) and avoids gating the line by \`LINUXFAMILY\`.

## Net effect

- Every UEFI build (x86 + arm64, all releases) ships SOF firmware
- Non-UEFI CLI/amd64 images no longer pull in the 7 MB
- CLI/amd64 baseline is now consistent across all 7 supported releases

## Test plan

- [ ] \`grep -r firmware-sof config/optional/architectures/amd64/\` returns nothing
- [ ] Build a UEFI x86 image — \`dpkg -l firmware-sof-signed\` shows installed; \`ls /lib/firmware/intel/sof-ipc4/lnl/\` is non-empty
- [ ] Boot on a Lunar Lake laptop — \`dmesg \| grep -i sof\` no longer reports "Direct firmware load … failed"; \`aplay -l\` lists the SOF card
- [ ] Build a non-UEFI CLI/amd64 image — \`dpkg -l\` no longer shows \`firmware-sof-signed\`
- [ ] Build a UEFI arm64 image — no apt error (package is arch-all)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed `firmware-sof-signed` from CLI package configurations (amd64 architecture for sid and trixie)
  * Added `firmware-sof-signed` to UEFI images for enhanced hardware compatibility on x86 laptop systems

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->