### PR TITLE
uefi-common: install alsa-ucm-conf so PipeWire can route SOF cards

### DIFF
--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -20,6 +20,16 @@ declare -g POWER_MANAGEMENT_FEATURES=yes             # Suspend and resume might 
 # avoids a per-family branch here.
 add_packages_to_image firmware-sof-signed
 
+# ALSA Use Case Manager profiles. Without this package, PipeWire /
+# wireplumber see the SOF card and its PCM devices but have no per-machine
+# recipe for which device is the speaker output / which controls to unmute /
+# how to route on jack-insert, so they fall back to "auto_null". Effect on a
+# ThinkPad X9-15 (LNL, CS42L43 jack + CS35L56 SPI amps): kernel-level audio
+# is fully alive (aplay -l shows Speaker pcm; `speaker-test -D plughw:0,2`
+# plays), but userspace shows "Dummy Output" and the speakers stay silent.
+# Architecture: all package; harmless on non-UCM machines.
+add_packages_to_image alsa-ucm-conf
+
 case "${BRANCH}" in
 
 	ddk)


### PR DESCRIPTION
## The bug

ThinkPad X9-15 (LNL, CS42L43 jack + CS35L56 SPI amps) booted Armbian with kernel-level audio fully alive — \`aplay -l\` enumerated the Speaker PCM, \`speaker-test -D plughw:0,2\` made sound. But PipeWire / wireplumber only ever saw "auto_null" — no real sink — because the SOF card has six PCM devices (Jack Out, Speaker, three HDMI, Deepbuffer Jack Out) and userspace has no recipe for which one is the speaker output, which controls to unmute, or how to route on jack insert.

\`alsa-ucm-conf\` ships those per-card UCM profiles. Without it: "Dummy Output" only. With it: Speaker sink appears, audio works.

## The fix

One line in \`config/sources/families/include/uefi_common.inc\`:

\`\`\`bash
add_packages_to_image alsa-ucm-conf
\`\`\`

Architecture: all package, inert on machines without UCM profiles. Lives next to the existing \`firmware-sof-signed\` line above — same scope, same rationale.

## Verified on

Lenovo ThinkPad X9-15 Gen 1 (DMI \`21Q6001MGE\`, LNL), Armbian edge x86 7.0.9. Same kernel + same SOF firmware + same Cirrus blobs + same topology as a working Ubuntu OEM 6.17 boot of the same machine — the only difference between "silent" and "working" was this package.

## Test plan

- [ ] Build UEFI x86 desktop on noble / resolute; confirm \`dpkg -l alsa-ucm-conf\` shows installed
- [ ] Boot on any SOF-equipped UEFI laptop (Meteor/Lunar/Panther Lake, recent ThinkPad / Latitude / EliteBook); confirm GNOME Sound shows a Speaker sink instead of Dummy Output
- [ ] Confirm no regression on UEFI builds without SOF hardware (cloud VMs, generic UEFI x86 servers) — package is inert there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio output issue on UEFI x86 laptops where speakers remained silent due to missing per-machine audio routing configuration for SOF audio components.

* **Documentation**
  * Added documentation explaining audio component detection behavior and fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->