### PR TITLE
rock-5-itx: link upstream kernel commit in pcie3 refclk u-boot patch

### DIFF
--- a/patch/u-boot/v2026.04/board_rock-5-itx/0001-arm-dts-rockchip-rock-5-itx-drop-pcie-refclk-from-u-boot-dtsi.patch
+++ b/patch/u-boot/v2026.04/board_rock-5-itx/0001-arm-dts-rockchip-rock-5-itx-drop-pcie-refclk-from-u-boot-dtsi.patch
@@ -21,6 +21,10 @@ PI6C oscillator stays powered and the "ref" input ticks regardless of
 U-Boot's clock setup. The kernel keeps the full clocks list from its
 own DTB and is unaffected.
 
+See Linux mainline commit e684f02492f9 ("arm64: dts: rockchip: fix the
+pcie refclock oscillator on Rock 5 ITX") for the kernel-side rationale.
+
+Link: https://lore.kernel.org/r/20240906082511.2963890-6-heiko@sntech.de
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
  arch/arm/dts/rk3588-rock-5-itx-u-boot.dtsi | 20 ++++++++++


### PR DESCRIPTION
## Summary

Follow-up to #9848. Adds a reference to Heiko Stuebner's Linux mainline commit `e684f02492f9` ("arm64: dts: rockchip: fix the pcie refclock oscillator on Rock 5 ITX") in the commit message of the u-boot dtsi override, so reviewers can see the kernel-side rationale for the `pcie30_port{0,1}_refclk` gated-fixed-clock node we work around in U-Boot.

Suggested by @rpardini in https://github.com/armbian/build/pull/9848#discussion_r3261394871.

No code change, message-only.

## Test plan

- [x] `patch --dry-run` still applies cleanly against U-Boot v2026.04
- [x] Rebuild + flash on Rock 5 ITX, NVMe boot still works (unchanged from #9848)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reference documentation to bootloader configuration patch linking to corresponding upstream commits and maintenance resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->