### PR TITLE
feat(tools/shellfmt): accept positional file args for scoped format

### DIFF
--- a/lib/tools/shellfmt.sh
+++ b/lib/tools/shellfmt.sh
@@ -83,7 +83,7 @@ cd "${SRC}"
 
 # Allowed file extensions for both full-tree and scoped modes; keep
 # in sync with the find globs below.
-ALLOWED_EXT_RE='\.(sh|conf|inc|csc|tvb)$'
+ALLOWED_EXT_RE='\.(sh|conf|inc|csc|tvb|eos|wip)$'
 
 declare -a ALL_BASH_FILES=()
 
@@ -109,7 +109,7 @@ if ((${#SCOPED_ARGS[@]} > 0)); then
 	fi
 else
 	# Full-tree mode: aggregate every file the framework cares about.
-	board_config_files=$(find config/boards -type f \( -name "*.conf" -o -name "*.csc" -o -name "*.tvb" \))  # All board config files
+	board_config_files=$(find config/boards -type f \( -name "*.conf" -o -name "*.csc" -o -name "*.tvb" -o -name "*.eos" -o -name "*.wip" \))  # All board config files
 	family_config_files=$(find config/sources -type f \( -name "*.conf" -o -name "*.inc" -o -name "*.sh" \)) # All family config files
 	lib_files=$(find lib -type f -name "*.sh")                                                               # All build framework shell files
 	extensions_files=$(find extensions -type f -name "*.sh")                                                 # All extension shell files

--- a/lib/tools/shellfmt.sh
+++ b/lib/tools/shellfmt.sh
@@ -58,6 +58,22 @@ fi
 ACTUAL_VERSION="$("${SHELLFMT_BIN}" -version)"
 echo "Running shellfmt ${ACTUAL_VERSION}"
 
+# Resolve positional args to absolute paths BEFORE chdir, so callers
+# from sub-directories can pass relative paths and have them keep
+# meaning. Avoid `realpath -m` — its `-m` flag is GNU-only and breaks
+# on the macOS realpath(1) the script's darwin branch otherwise
+# supports. Plain `$PWD/path` prefix is enough; shfmt doesn't care
+# about symlink canonicalisation or `..` normalisation, and the
+# missing-file branch below still triggers on dangling paths.
+declare -a SCOPED_ARGS=()
+for _f in "$@"; do
+	if [[ "${_f}" == /* ]]; then
+		SCOPED_ARGS+=("${_f}")
+	else
+		SCOPED_ARGS+=("${PWD}/${_f}")
+	fi
+done
+
 cd "${SRC}"
 #"${SHELLFMT_BIN}" --help
 #"${SHELLFMT_BIN}" -f "${SRC}"
@@ -65,13 +81,41 @@ cd "${SRC}"
 
 # Should match the .editorconfig
 
-# Aggregate all files that should be formatted
-board_config_files=$(find config/boards -type f \( -name "*.conf" -o -name "*.csc" -o -name "*.tvb" \))  # All board config files
-family_config_files=$(find config/sources -type f \( -name "*.conf" -o -name "*.inc" -o -name "*.sh" \)) # All family config files
-lib_files=$(find lib -type f -name "*.sh")                                                               # All build framework shell files
-extensions_files=$(find extensions -type f -name "*.sh")                                                 # All extension shell files
+# Allowed file extensions for both full-tree and scoped modes; keep
+# in sync with the find globs below.
+ALLOWED_EXT_RE='\.(sh|conf|inc|csc|tvb)$'
 
-declare -a ALL_BASH_FILES=(compile.sh ${board_config_files} ${family_config_files} ${lib_files} ${extensions_files})
+declare -a ALL_BASH_FILES=()
+
+if ((${#SCOPED_ARGS[@]} > 0)); then
+	# Scoped mode: only format the files passed on the command line.
+	# Skip anything that doesn't match the allowed extensions so a
+	# stray Python/Markdown/YAML argument doesn't sneak through.
+	echo -e "\nScoped mode: formatting only the files passed on argv"
+	for f in "${SCOPED_ARGS[@]}"; do
+		if [[ ! -e "${f}" ]]; then
+			echo "  skip (missing): ${f}"
+			continue
+		fi
+		if [[ ! "${f}" =~ ${ALLOWED_EXT_RE} ]]; then
+			echo "  skip (unsupported extension): ${f}"
+			continue
+		fi
+		ALL_BASH_FILES+=("${f}")
+	done
+	if ((${#ALL_BASH_FILES[@]} == 0)); then
+		echo "No eligible files after filtering — nothing to do."
+		exit 0
+	fi
+else
+	# Full-tree mode: aggregate every file the framework cares about.
+	board_config_files=$(find config/boards -type f \( -name "*.conf" -o -name "*.csc" -o -name "*.tvb" \))  # All board config files
+	family_config_files=$(find config/sources -type f \( -name "*.conf" -o -name "*.inc" -o -name "*.sh" \)) # All family config files
+	lib_files=$(find lib -type f -name "*.sh")                                                               # All build framework shell files
+	extensions_files=$(find extensions -type f -name "*.sh")                                                 # All extension shell files
+
+	ALL_BASH_FILES=(compile.sh ${board_config_files} ${family_config_files} ${lib_files} ${extensions_files})
+fi
 
 echo -e "\nAll files:" "${ALL_BASH_FILES[@]}"
 


### PR DESCRIPTION
## Summary
- `lib/tools/shellfmt.sh` now accepts positional file arguments. When passed,
  only those files are formatted; without args the wrapper behaves as before
  (full-tree CI-style mass-format).
- Positional args are resolved to absolute paths **before** the script
  `cd`s to the project root, so callers can pass relative paths from
  a sub-directory.
- Arguments are filtered against the same extension allowlist
  (`.sh/.conf/.inc/.csc/.tvb/.eos/.wip`), so a stray `.py/.md/.yml` doesn't
  sneak through.
- `.editorconfig` continues to drive the actual rules — shfmt picks it up
  regardless of mode.

## Drive-by fix
The original full-tree find glob covered `.conf/.csc/.tvb` board configs
but skipped `.eos` (32 files) and `.wip` (2 files), even though
`config/boards/*.{conf,wip,csc,tvb,eos}` are documented as a single
status-flavoured family of board configs. Found no reason for them to
be exempt from formatting — looks like they were simply forgotten.
The second commit in this PR aligns both modes (scoped + full-tree) on
the same five-extension allowlist.

## Why scoped mode
Editor-driven workflows (post-edit hooks, agent helpers) need to format
only the file that was just touched. Previously the wrapper silently
ignored file arguments and reformatted everything, dragging ~100
unrelated files into the next commit.

## Test plan
- [x] `bash lib/tools/shellfmt.sh` — full-tree run unchanged
- [x] `bash lib/tools/shellfmt.sh extensions/apa.sh` — only `apa.sh` formatted
- [x] `bash lib/tools/shellfmt.sh foo.py extensions/apa.sh` — `.py` skipped
      (unsupported extension), `apa.sh` formatted
- [x] from sub-directory: `cd extensions && bash .../shellfmt.sh ./apa.sh`
      resolves the relative path correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Shell script formatter now supports both scoped operation on provided paths and a full-tree mode when no paths are given.
  * Expanded recognized configuration extensions to include .eos and .wip, so additional board/config files are included in formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->