### PR TITLE
ci: skip build-artifacts gating job on forks

### DIFF
--- a/.github/workflows/maintenance-build-artifacts.yml
+++ b/.github/workflows/maintenance-build-artifacts.yml
@@ -9,10 +9,14 @@ on: pull_request_target
 
 jobs:
   Check:
+    # Self-hosted runner labelled `Linux` only exists in the armbian/build
+    # infrastructure; in forks the job would otherwise sit queued forever
+    # and show as a pending check on every PR.
+    if: ${{ github.repository_owner == 'armbian' }}
     permissions:
       pull-requests: read
 
-    name: Check label and authorization  
+    name: Check label and authorization
     runs-on: Linux
     outputs:
       member: ${{ steps.checkUserMember.outputs.isTeamMember }}
@@ -32,7 +36,7 @@ jobs:
     concurrency:
       group: pipeline-pr-${{github.event.pull_request.number}}
       cancel-in-progress: true
-    if: ${{ github.repository_owner == 'Armbian' && needs.Check.outputs.member == 'true' }}
+    if: ${{ github.repository_owner == 'armbian' && needs.Check.outputs.member == 'true' }}
     uses: armbian/os/.github/workflows/complete-artifact-matrix-all.yml@main
     secrets:
       ORG_MEMBERS: ${{ secrets.ORG_MEMBERS }}


### PR DESCRIPTION
# Description

The `Check` job in `.github/workflows/maintenance-build-artifacts.yml` uses `runs-on: Linux`, which targets a self-hosted runner registered only in the armbian/build infrastructure. The workflow is triggered on `pull_request_target`, so it runs on every PR in every fork — but forks have no such runner, so the job sits in `queued` forever and shows up as a permanently pending check on each fork PR (example: https://github.com/iav/armbian/actions/runs/26067897269/job/76642661311).

This adds the same `github.repository_owner == 'armbian'` guard that already protects the downstream `Compile` job, evaluated **before runner allocation** so the job is cleanly skipped in forks instead of hanging.

While here:
- lowercase `'Armbian'` → `'armbian'` for consistency with the canonical owner login (GitHub Actions string comparison is case-insensitive, so this is purely cosmetic);
- trim trailing whitespace from the job `name:`.

No behaviour change in `armbian/build` itself — `github.repository_owner` evaluates to `armbian` there and both jobs proceed exactly as before.

# How Has This Been Tested?

- [x] Diff reviewed; `if:` placed at job-level so it gates runner allocation, not just steps.
- [ ] To confirm in upstream: first PR against `armbian/build` after merge should still trigger the Linux runner and the `Check` job.
- [ ] To confirm in a fork: same workflow file in a fork PR should display the `Check` job as **Skipped** instead of pending-queued.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (added a short comment explaining the runner-label constraint)
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed CI/CD workflow to prevent indefinite job queuing on repository forks by adding repository ownership verification checks.
  * Standardized authorization conditions across build workflow jobs for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->