### PR TITLE
Update radxa-cubie-a5e.csc with current kernel for build

### DIFF
--- a/config/boards/radxa-cubie-a5e.csc
+++ b/config/boards/radxa-cubie-a5e.csc
@@ -8,6 +8,7 @@ BOOTCONFIG="radxa-cubie-a5e_defconfig"
 OVERLAY_PREFIX="sun55i-a527"
 #BOOT_LOGO="desktop"
 KERNEL_TARGET="current,edge"
+KERNEL_TEST_TARGET="current,edge"
 BOOT_FDT_FILE="sun55i-a527-cubie-a5e.dtb"
 HAS_VIDEO_OUTPUT=no
 

--- a/config/boards/radxa-cubie-a5e.csc
+++ b/config/boards/radxa-cubie-a5e.csc
@@ -7,7 +7,7 @@ INTRODUCED="2025"
 BOOTCONFIG="radxa-cubie-a5e_defconfig"
 OVERLAY_PREFIX="sun55i-a527"
 #BOOT_LOGO="desktop"
-KERNEL_TARGET="edge"
+KERNEL_TARGET="current,edge"
 BOOT_FDT_FILE="sun55i-a527-cubie-a5e.dtb"
 HAS_VIDEO_OUTPUT=no
 


### PR DESCRIPTION
# Description
( description generated by Copilot and also the "Title")
This pull request updates the kernel target configuration for the `radxa-cubie-a5e` board to support both the `current` and `edge` kernel targets instead of just `edge`.

- Configuration update:
  * Modified the `KERNEL_TARGET` in `config/boards/radxa-cubie-a5e.csc` to include both `current` and `edge` kernels, allowing the board to be built with either kernel version.Add "current" kernel (for build?)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated kernel build target for the Radxa Cubie A5E to include both "current" and "edge", offering greater flexibility in available kernel versions.
  * Added a kernel test target set to "current,edge" to enable running test builds across those kernel streams for validation and QA.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->