### PR TITLE
Rockchip: youyeetoo yy3568: enable pci-e ssd

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3568-yy3568.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3568-yy3568.dts
@@ -6,9 +6,12 @@
 /dts-v1/;
 
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
 #include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/input/input.h>
 #include <dt-bindings/pinctrl/rockchip.h>
 #include <dt-bindings/soc/rockchip,vop2.h>
+#include <dt-bindings/clock/rk3568-cru.h>
 #include "rk3568.dtsi"
 
 / {
@@ -111,13 +114,37 @@
 	vcc3v3_pi6c_05: regulator-vcc3v3-pi6c-05 {
 		compatible = "regulator-fixed";
 		enable-active-high;
-		gpios = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
+		gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&pcie_enable_h>;
 		regulator-name = "vcc3v3_pcie";
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		vin-supply = <&vcc5v0_sys>;
+	};
+
+	vcc3v3_pcie: vcc3v3-pcie-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v3_pcie";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		enable-active-high;
+		gpio = <&gpio3 RK_PC3 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pcie30_pwr>;
+		startup-delay-us = <5000>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+
+	pcie_oe_regulator: pcie-oe-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie_oe";
+		gpio = <&gpio3 RK_PA7 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pcie_oe>;
+		//enable-active-high;
+		regulator-always-on;
+		regulator-boot-on;
 	};
 
     pcie30_avdd0v9: regulator-pcie30-avdd0v9 {
@@ -172,7 +199,7 @@
 };
 
 &combphy1 {
-	phy-supply = <&vcc3v3_pcie30x1>;
+	phy-supply = <&pcie_oe_regulator>;
 	status = "okay";
 };
 
@@ -265,10 +292,11 @@
 &pcie3x2 {
 	num-lanes = <1>;
 	pinctrl-names = "default";
-	pinctrl-0 = <&pcie30x2_reset_h>;
+	pinctrl-0 = <&pcie30x2m1_pins>;
 	reset-gpios = <&gpio2 RK_PD6 GPIO_ACTIVE_HIGH>;
-	vpcie3v3-supply = <&vcc3v3_pi6c_05>;
+	vpcie3v3-supply = <&vcc3v3_pcie>;
 	status = "okay";
+	phys = <&pcie30phy>;
 };
 
 &i2c0 {
@@ -299,6 +327,7 @@
 		#clock-cells = <1>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&pmic_int>;
+		#sound-dai-cells = <0>;
 		system-power-controller;
 		wakeup-source;
 
@@ -534,6 +563,14 @@
 		pcie_enable_h: pcie-enable-h {
 			rockchip,pins = <0 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
+
+		pcie30_pwr: pcie30-pwr {
+			rockchip,pins = <3 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		pcie_oe: pcie-oe {
+			rockchip,pins = <3 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
 	};
 
 	usb {
@@ -545,6 +582,10 @@
 			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
+};
+
+&i2s0_8ch {
+	status = "okay";
 };
 
 &i2s1_8ch {

--- a/patch/u-boot/legacy/u-boot-radxa-rk35xx/dt/rk3568-yy3568.dts
+++ b/patch/u-boot/legacy/u-boot-radxa-rk35xx/dt/rk3568-yy3568.dts
@@ -3,16 +3,31 @@
  * Copyright (c) 2020 Rockchip Electronics Co., Ltd.
  * Copyright (c) 2024 Radxa Limited
  */
-
 /dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/pinctrl/rockchip.h>
 #include "rk3568.dtsi"
 #include "rk3568-u-boot.dtsi"
-#include <dt-bindings/input/input.h>
-
 / {
 	model = "Youyeetoo YY3568";
 	compatible = "youyeetoo,yy3568", "rockchip,rk3568";
-
+	aliases {
+		ethernet0 = &gmac0;
+		ethernet1 = &gmac1;
+		mmc0 = &sdhci;
+		mmc1 = &sdmmc0;
+		mmc2 = &sdmmc2;
+	};
+	vcc12v_input: vcc12v-input {
+		u-boot,dm-pre-reloc;
+		compatible = "regulator-fixed";
+		regulator-name = "vcc12v_input";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+	};
 	vcc5v0_sys: vcc5v0-sys {
 		u-boot,dm-pre-reloc;
 		compatible = "regulator-fixed";
@@ -21,8 +36,8 @@
 		regulator-boot-on;
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
+		vin-supply = <&vcc12v_input>;
 	};
-
 	vcc3v3_sys: vcc3v3-sys {
 		u-boot,dm-pre-reloc;
 		compatible = "regulator-fixed";
@@ -31,31 +46,55 @@
 		regulator-boot-on;
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
+		vin-supply = <&vcc12v_input>;
+	};
+	vcc3v3_pi6c_05: vcc3v3-pi6c-05 {
+		u-boot,dm-pre-reloc;
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pcie_enable_h>;
+		regulator-name = "vcc3v3_pi6c_05";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
 		vin-supply = <&vcc5v0_sys>;
 	};
-
-	led_sys: led-sys {
+	vcc3v3_pcie: vcc3v3-pcie {
 		u-boot,dm-pre-reloc;
 		compatible = "regulator-fixed";
-		regulator-name = "led_sys";
+		regulator-name = "vcc3v3_pcie";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
 		enable-active-high;
-		gpio = <&gpio0 RK_PC1 GPIO_ACTIVE_HIGH>;
-		regulator-boot-on;
-		regulator-always-on;
-		vin-supply = <&vcc3v3_sys>;
+		gpio = <&gpio3 RK_PC3 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pcie30_pwr>;
+		startup-delay-us = <5000>;
+		vin-supply = <&vcc5v0_sys>;
 	};
-
-	led_sys: led-sys {
+	pcie30_avdd0v9: pcie30-avdd0v9 {
 		u-boot,dm-pre-reloc;
 		compatible = "regulator-fixed";
-		regulator-name = "led_sys";
-		enable-active-high;
-		gpio = <&gpio0 RK_PC1 GPIO_ACTIVE_HIGH>;
-		regulator-boot-on;
+		regulator-name = "pcie30_avdd0v9";
 		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <900000>;
+		regulator-max-microvolt = <900000>;
 		vin-supply = <&vcc3v3_sys>;
 	};
-
+	pcie30_avdd1v8: pcie30-avdd1v8 {
+		u-boot,dm-pre-reloc;
+		compatible = "regulator-fixed";
+		regulator-name = "pcie30_avdd1v8";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		vin-supply = <&vcc3v3_sys>;
+	};
 	adc-keys {
 		compatible = "adc-keys";
 		io-channels = <&saradc 0>;
@@ -63,7 +102,6 @@
 		keyup-threshold-microvolt = <1800000>;
 		u-boot,dm-spl;
 		status = "okay";
-
 		volumeup-key {
 			u-boot,dm-spl;
 			linux,code = <KEY_VOLUMEUP>;
@@ -71,12 +109,10 @@
 			press-threshold-microvolt = <9>;
 		};
 	};
-
 	leds {
 		u-boot,dm-pre-reloc;
 		compatible = "gpio-leds";
 		status = "okay";
-
 		blue-led {
 			u-boot,dm-pre-reloc;
 			label = "blue";
@@ -84,75 +120,73 @@
 		};
 	};
 };
-
+&crypto {
+	status = "okay";
+};
+&gmac0 {
+	u-boot,dm-pre-reloc;
+	phy-mode = "rgmii";
+	clock_in_out = "output";
+	snps,reset-gpio = <&gpio2 RK_PD3 GPIO_ACTIVE_LOW>;
+	snps,reset-active-low;
+	snps,reset-delays-us = <0 20000 100000>;
+	assigned-clocks = <&cru SCLK_GMAC0_RX_TX>, <&cru SCLK_GMAC0>;
+	assigned-clock-parents = <&cru SCLK_GMAC0_RGMII_SPEED>;
+	assigned-clock-rates = <0>, <125000000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&gmac0_miim
+		     &gmac0_tx_bus2
+		     &gmac0_rx_bus2
+		     &gmac0_rgmii_clk
+		     &gmac0_rgmii_bus>;
+	phy-handle = <&rgmii_phy0>;
+	status = "okay";
+};
 &gmac1 {
 	u-boot,dm-pre-reloc;
 	phy-mode = "rgmii";
 	clock_in_out = "output";
-
 	snps,reset-gpio = <&gpio2 RK_PD1 GPIO_ACTIVE_LOW>;
 	snps,reset-active-low;
 	/* Reset time is 20ms, 100ms for rtl8211f */
 	snps,reset-delays-us = <0 20000 100000>;
-
 	assigned-clocks = <&cru SCLK_GMAC1_RX_TX>, <&cru SCLK_GMAC1>;
 	assigned-clock-parents = <&cru SCLK_GMAC1_RGMII_SPEED>;
 	assigned-clock-rates = <0>, <125000000>;
-
 	pinctrl-names = "default";
 	pinctrl-0 = <&gmac1m1_miim
 		     &gmac1m1_tx_bus2
 		     &gmac1m1_rx_bus2
 		     &gmac1m1_rgmii_clk
 		     &gmac1m1_rgmii_bus>;
-
 	tx_delay = <0x44>;
 	rx_delay = <0x26>;
-
 	phy-handle = <&rgmii_phy1>;
-	status = "disabled";
-};
-
-&mdio1 {
-	rgmii_phy1: phy@0 {
-		compatible = "ethernet-phy-ieee802.3-c22";
-		reg = <0x0>;
-	};
-};
-
-&crypto {
 	status = "okay";
 };
-
-&uart2 {
-	status = "okay";
-};
-
-&pmu_io_domains {
-	status = "okay";
-	pmuio2-supply = <&vcc_3v3>;
-	vccio1-supply = <&vccio_acodec>;
-	vccio3-supply = <&vccio_sd>;
-	vccio4-supply = <&vcc_1v8>;
-	vccio5-supply = <&vcc_3v3>;
-	vccio6-supply = <&vcc_1v8>;
-	vccio7-supply = <&vcc_3v3>;
+&grf {
 	u-boot,dm-pre-reloc;
+	status = "okay";
 };
-
 &gpio0 {
 	u-boot,dm-pre-reloc;
 };
-
+&gpio1 {
+	u-boot,dm-pre-reloc;
+};
+&gpio2 {
+	u-boot,dm-pre-reloc;
+};
+&gpio3 {
+	u-boot,dm-pre-reloc;
+};
 &gpio4 {
 	u-boot,dm-pre-reloc;
 };
-
 &i2c0 {
 	status = "okay";
 	u-boot,dm-pre-reloc;
 	clock-frequency = <100000>;
-
 	vdd_cpu: tcs4525@1c {
 		u-boot,dm-pre-reloc;
 		compatible = "tcs,tcs452x";
@@ -172,7 +206,6 @@
 			regulator-off-in-suspend;
 		};
 	};
-
 	rk809: pmic@20 {
 		u-boot,dm-pre-reloc;
 		status = "okay";
@@ -180,24 +213,20 @@
 		reg = <0x20>;
 		interrupt-parent = <&gpio0>;
 		interrupts = <3 IRQ_TYPE_LEVEL_LOW>;
-
 		pinctrl-names = "default", "pmic-sleep",
 				"pmic-power-off", "pmic-reset";
 		pinctrl-0 = <&pmic_int>;
 		pinctrl-1 = <&soc_slppin_slp>, <&rk817_slppin_slp>;
 		pinctrl-2 = <&soc_slppin_gpio>, <&rk817_slppin_pwrdn>;
 		pinctrl-3 = <&soc_slppin_gpio>, <&rk817_slppin_rst>;
-
 		rockchip,system-power-controller;
 		wakeup-source;
 		#clock-cells = <1>;
 		clock-output-names = "rk808-clkout1", "rk808-clkout2";
-		//fb-inner-reg-idxs = <2>;
 		/* 1: rst regs (default in codes), 0: rst the pmic */
 		pmic-reset-func = <0>;
 		/* not save the PMIC_POWER_EN register in uboot */
 		not-save-power-en = <1>;
-
 		vcc1-supply = <&vcc3v3_sys>;
 		vcc2-supply = <&vcc3v3_sys>;
 		vcc3-supply = <&vcc3v3_sys>;
@@ -207,42 +236,35 @@
 		vcc7-supply = <&vcc3v3_sys>;
 		vcc8-supply = <&vcc3v3_sys>;
 		vcc9-supply = <&vcc3v3_sys>;
-
 		pwrkey {
 			status = "okay";
 			u-boot,dm-pre-reloc;
 		};
-
 		pinctrl_rk8xx: pinctrl_rk8xx {
 			u-boot,dm-pre-reloc;
 			gpio-controller;
 			#gpio-cells = <2>;
-
 			rk817_slppin_null: rk817_slppin_null {
 				pins = "gpio_slp";
 				function = "pin_fun0";
 				u-boot,dm-pre-reloc;
 			};
-
 			rk817_slppin_slp: rk817_slppin_slp {
 				pins = "gpio_slp";
 				function = "pin_fun1";
 				u-boot,dm-pre-reloc;
 			};
-
 			rk817_slppin_pwrdn: rk817_slppin_pwrdn {
 				pins = "gpio_slp";
 				function = "pin_fun2";
 				u-boot,dm-pre-reloc;
 			};
-
 			rk817_slppin_rst: rk817_slppin_rst {
 				pins = "gpio_slp";
 				function = "pin_fun3";
 				u-boot,dm-pre-reloc;
 			};
 		};
-
 		regulators {
 			u-boot,dm-pre-reloc;
 			vdd_logic: DCDC_REG1 {
@@ -260,7 +282,6 @@
 					regulator-on-in-suspend;
 				};
 			};
-
 			vdd_gpu: DCDC_REG2 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -276,7 +297,6 @@
 					regulator-on-in-suspend;
 				};
 			};
-
 			vcc_ddr: DCDC_REG3 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -288,7 +308,6 @@
 					regulator-on-in-suspend;
 				};
 			};
-
 			vdd_npu: DCDC_REG4 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -304,7 +323,6 @@
 					regulator-on-in-suspend;
 				};
 			};
-
 			vdda0v9_image: LDO_REG1 {
 				u-boot,dm-pre-reloc;
 				regulator-boot-on;
@@ -317,7 +335,6 @@
 					regulator-off-in-suspend;
 				};
 			};
-
 			vdda_0v9: LDO_REG2 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -330,7 +347,6 @@
 					regulator-off-in-suspend;
 				};
 			};
-
 			vdda0v9_pmu: LDO_REG3 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -344,7 +360,6 @@
 					regulator-suspend-microvolt = <900000>;
 				};
 			};
-
 			vccio_acodec: LDO_REG4 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -357,7 +372,6 @@
 					regulator-off-in-suspend;
 				};
 			};
-
 			vccio_sd: LDO_REG5 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -370,7 +384,6 @@
 					regulator-off-in-suspend;
 				};
 			};
-
 			vcc3v3_pmu: LDO_REG6 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -384,7 +397,6 @@
 					regulator-suspend-microvolt = <3300000>;
 				};
 			};
-
 			vcca_1v8: LDO_REG7 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -397,7 +409,6 @@
 					regulator-off-in-suspend;
 				};
 			};
-
 			vcca1v8_pmu: LDO_REG8 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -411,7 +422,6 @@
 					regulator-suspend-microvolt = <1800000>;
 				};
 			};
-
 			vcca1v8_image: LDO_REG9 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -424,7 +434,6 @@
 					regulator-off-in-suspend;
 				};
 			};
-
 			vcc_1v8: DCDC_REG5 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -437,7 +446,6 @@
 					regulator-off-in-suspend;
 				};
 			};
-
 			vcc_3v3: SWITCH_REG1 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -448,7 +456,6 @@
 					regulator-off-in-suspend;
 				};
 			};
-
 			vcc3v3_sd: SWITCH_REG2 {
 				u-boot,dm-pre-reloc;
 				regulator-always-on;
@@ -462,9 +469,70 @@
 		};
 	};
 };
+&i2c0_xfer {
+	u-boot,dm-pre-reloc;
+	status = "okay";
+};
+&rgmii_phy0 {
+	compatible = "ethernet-phy-id001c.c916",
+		     "ethernet-phy-ieee802.3-c22";
+	reset-assert-us = <20000>;
+	reset-deassert-us = <100000>;
+	reset-gpios = <&gpio2 RK_PD3 GPIO_ACTIVE_LOW>;
+};
 
+&rgmii_phy1 {
+	compatible = "ethernet-phy-id001c.c916",
+		     "ethernet-phy-ieee802.3-c22";
+	reset-assert-us = <20000>;
+	reset-deassert-us = <100000>;
+	reset-gpios = <&gpio2 RK_PD1 GPIO_ACTIVE_LOW>;
+};
+&pcfg_pull_none_smt {
+	u-boot,dm-pre-reloc;
+	status = "okay";
+};
+&pcie2x1 {
+	u-boot,dm-pre-reloc;
+	reset-gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_HIGH>;
+	vpcie3v3-supply = <&vcc3v3_pi6c_05>;
+	status = "okay";
+};
+&pcie30_phy_grf {
+	u-boot,dm-pre-reloc;
+};
+&pcie30phy {
+	u-boot,dm-pre-reloc;
+	data-lanes = <1 2>;
+	status = "okay";
+};
+&pcie3x2 {
+	u-boot,dm-pre-reloc;
+	num-lanes = <1>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie30x2_reset_h>;
+	reset-gpios = <&gpio2 RK_PD6 GPIO_ACTIVE_HIGH>;
+	vpcie3v3-supply = <&vcc3v3_pcie>;
+	phys = <&pcie30phy>;
+	status = "okay";
+};
 &pinctrl {
 	u-boot,dm-spl;
+	pcie {
+		u-boot,dm-pre-reloc;
+		pcie30x2_reset_h: pcie30x2-reset-h {
+			u-boot,dm-pre-reloc;
+			rockchip,pins = <2 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+		pcie_enable_h: pcie-enable-h {
+			u-boot,dm-pre-reloc;
+			rockchip,pins = <0 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+		pcie30_pwr: pcie30-pwr {
+			u-boot,dm-pre-reloc;
+			rockchip,pins = <3 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
 	pmic {
 		u-boot,dm-pre-reloc;
 		pmic_int: pmic_int {
@@ -472,23 +540,80 @@
 			rockchip,pins =
 				<0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
-
 		soc_slppin_gpio: soc_slppin_gpio {
 			u-boot,dm-pre-reloc;
 			rockchip,pins =
 				<0 RK_PA2 RK_FUNC_GPIO &pcfg_output_low_pull_down>;
 		};
-
 		soc_slppin_slp: soc_slppin_slp {
 			u-boot,dm-pre-reloc;
 			rockchip,pins =
 				<0 RK_PA2 RK_FUNC_1 &pcfg_pull_up>;
 		};
-
 		soc_slppin_rst: soc_slppin_rst {
 			u-boot,dm-pre-reloc;
 			rockchip,pins =
 				<0 RK_PA2 RK_FUNC_2 &pcfg_pull_none>;
 		};
 	};
+};
+&pmu_io_domains {
+	u-boot,dm-pre-reloc;
+	status = "okay";
+	pmuio1-supply = <&vcc3v3_pmu>;
+	pmuio2-supply = <&vcc3v3_pmu>;
+	vccio1-supply = <&vccio_acodec>;
+	vccio2-supply = <&vcc_1v8>;
+	vccio3-supply = <&vccio_sd>;
+	vccio4-supply = <&vcc_1v8>;
+	vccio5-supply = <&vcc_3v3>;
+	vccio6-supply = <&vcc_1v8>;
+	vccio7-supply = <&vcc_3v3>;
+};
+&pmucru {
+	u-boot,dm-pre-reloc;
+	status = "okay";
+};
+&pmugrf {
+	u-boot,dm-pre-reloc;
+	status = "okay";
+};
+&saradc {
+	vref-supply = <&vcca_1v8>;
+	status = "okay";
+};
+&sdhci {
+	bus-width = <8>;
+	max-frequency = <200000000>;
+	non-removable;
+	pinctrl-names = "default";
+	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_datastrobe>;
+	vmmc-supply = <&vcc_3v3>;
+	vqmmc-supply = <&vcc_1v8>;
+	status = "okay";
+};
+&sdmmc0 {
+	bus-width = <4>;
+	cap-sd-highspeed;
+	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+	disable-wp;
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd>;
+	sd-uhs-sdr104;
+	vmmc-supply = <&vcc3v3_sd>;
+	vqmmc-supply = <&vccio_sd>;
+	status = "okay";
+};
+&sdmmc2 {
+	bus-width = <4>;
+	cap-sd-highspeed;
+	cd-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_LOW>;
+	disable-wp;
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdmmc2m0_bus4 &sdmmc2m0_clk &sdmmc2m0_cmd>;
+	sd-uhs-sdr104;
+	status = "okay";
+};
+&uart2 {
+	status = "okay";
 };


### PR DESCRIPTION
# Description

enable PCI-e SSD on Machine model: Youyeetoo YY3568

# How Has This Been Tested?

6.18.32-current-rockchip64 (build@armbian) 
[Forum Post](https://forum.armbian.com/topic/49775-board-bring-up-youyeetoo-yy3568-rockchip-rk3568/)

https://paste.armbian.com/ekupotacut

# Checklist:

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] My changes generate no new warnings
- [ X] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced hardware support for PCIe controller configuration and power management
  * Improved Ethernet connectivity setup with RGMII PHY configuration
  * Enabled audio subsystem support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->