### PR TITLE
fix(sm8250): drop duplicate cpu7_opp21 label on Xiaoxin Pad Pro overclock OPP

### DIFF
--- a/patch/kernel/archive/sm8250-6.18/0020-arm64-dts-qcom-add-device-tree-for-Xiaoxin-Pad-Pro-1.patch
+++ b/patch/kernel/archive/sm8250-6.18/0020-arm64-dts-qcom-add-device-tree-for-Xiaoxin-Pad-Pro-1.patch
@@ -57,7 +57,7 @@ index 000000000000..86a4885d1b57
 +/delete-node/ &cdsp_secure_heap;
 +
 +&cpu7_opp_table {
-+	cpu7_opp21: opp-3187200000 {
++	opp-3187200000 {
 +		opp-hz = /bits/ 64 <3187200000>;
 +		opp-peak-kBps = <8368000 51609600>;
 +	};

--- a/patch/kernel/archive/sm8250-6.19/0020-arm64-dts-qcom-add-device-tree-for-Xiaoxin-Pad-Pro-1.patch
+++ b/patch/kernel/archive/sm8250-6.19/0020-arm64-dts-qcom-add-device-tree-for-Xiaoxin-Pad-Pro-1.patch
@@ -57,7 +57,7 @@ index 000000000000..86a4885d1b57
 +/delete-node/ &cdsp_secure_heap;
 +
 +&cpu7_opp_table {
-+	cpu7_opp21: opp-3187200000 {
++	opp-3187200000 {
 +		opp-hz = /bits/ 64 <3187200000>;
 +		opp-peak-kBps = <8368000 51609600>;
 +	};


### PR DESCRIPTION
## Summary

- Patch `0020-arm64-dts-qcom-add-device-tree-for-Xiaoxin-Pad-Pro-1.patch` adds an overclock OPP at 3.1872 GHz to `&cpu7_opp_table` but labels it `cpu7_opp21`, a label already in use by `opp-3091200000` in upstream `sm8250.dtsi`.
- `dtc` rejects the tree with `duplicate_label`, which breaks `make dtbs` for the entire sm8250 family — any board in that family (e.g. `dg-svr-865-tiny`) fails to build even though it doesn't use the Lenovo DTB.
- Fix: drop the unused label (nothing references it). Applied to both `sm8250-6.18` and `sm8250-6.19`.

## DTC error

```
arch/arm64/boot/dts/qcom/sm8250-lenovo-q706f.dts:27.29-30.4:
  ERROR (duplicate_label): /opp-table-cpu7/opp-3187200000:
  Duplicate label 'cpu7_opp21' on /opp-table-cpu7/opp-3187200000
                            and /opp-table-cpu7/opp-3091200000
ERROR: Input tree has errors, aborting (use -f to force output)
```

## Test plan

- [x] `./compile.sh BOARD=dg-svr-865-tiny BRANCH=current KERNEL_ONLY=yes` completes `make dtbs` successfully on sm8250-6.18
- [x] `./compile.sh BOARD=<lenovo-q706f-board-if-any> BRANCH=current KERNEL_ONLY=yes` still produces a working `sm8250-lenovo-q706f.dtb`
- [x] Same checks repeated against sm8250-6.19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hardware support for Lenovo Xiaoxin Pad Pro 12.6 on Qualcomm SM8250 platform with complete device enablement including display, audio amplifiers, USB-C with DisplayPort alt-mode support, Wi-Fi controller, touchscreen, SD card reader, and storage interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->