### PR TITLE
ci: scope GITHUB_TOKEN writes to job-level in maintenance-lint-scripts-post

### DIFF
--- a/.github/workflows/maintenance-lint-scripts-post.yml
+++ b/.github/workflows/maintenance-lint-scripts-post.yml
@@ -30,15 +30,17 @@ on:
 
 permissions:
   contents: read
-  actions: read    # required by actions/download-artifact@v4 when downloading from another workflow run via `run-id`
-  pull-requests: write
-  checks: write
-  issues: write    # documented requirement of reviewdog for PR-comment APIs
 
 jobs:
   Post:
     name: Post ShellCheck and shfmt diagnostics
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read    # required by actions/download-artifact@v4 when downloading from another workflow run via `run-id`
+      pull-requests: write
+      checks: write
+      issues: write    # documented requirement of reviewdog for PR-comment APIs
     # Run even on red-cross lint conclusions (`failure`) — the
     # artifact is uploaded via `if: always()` in the lint workflow,
     # and we want to surface diagnostics in the PR even when the


### PR DESCRIPTION
> *"A woman with no troubles went and bought herself a piglet."* — Russian proverb about inviting work into your life. Now that we've put a mechanical security-best-practices checker on the team, we get to keep feeding it small patches like this one.

Closes the Scorecard *Token-Permissions* finding at https://github.com/armbian/build/security/code-scanning/593 (severity High, score 0 — `topLevel 'checks' permission set to 'write'`).

The workflow declared `pull-requests / checks / issues: write` at the top level. There's only one job (`Post`), so the practical blast radius is identical today — but Scorecard wants writes scoped per-job so any future job added here doesn't silently inherit them. Moved the writes to the job block; top-level keeps `contents: read`.

No functional change. After this lands on `main`, the next Scorecard run (via `maintenance-security-scan.yml`) auto-closes the alert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security configuration of CI/CD workflows by refining permission scoping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->