### PR TITLE
fix(extensions/lvm): Fix support for non-ext filesystems

### DIFF
--- a/extensions/lvm.sh
+++ b/extensions/lvm.sh
@@ -67,18 +67,31 @@ function prepare_root_device__create_volume_group() {
 	display_alert "LVM created volume group - root device ${rootdevice}" "${EXTENSION}" "info"
 }
 
-function format_partitions__format_lvm() {
+function label_partition() {
 	if [ "$ROOTFS_TYPE" == "ext4" ]; then
-		# Label the root volume
 		e2label "/dev/mapper/${LVM_VG_NAME}-root" armbi_root
-		blkid | grep "${LVM_VG_NAME}" >> "${DEST}/${LOG_SUBPATH}/lvm.log" 2>&1
-		display_alert "LVM labeled partitions" "${EXTENSION}" "info"
 	elif [ "$ROOTFS_TYPE" == "btrfs" ]; then
-		btrfs filesystem label $( mount | grep "/dev/mapper/${LVM_VG_NAME}-root" | awk '{print $3}' ) armbi_root
-		blkid | grep "${LVM_VG_NAME}" >> "${DEST}/${LOG_SUBPATH}/lvm.log" 2>&1
-		display_alert "LVM labeled partitions" "${EXTENSION}" "info"
-	else
+		btrfs filesystem label "$(mount | grep "/dev/mapper/${LVM_VG_NAME}-root" | awk '{print $3}')" armbi_root
+	elif [ "$ROOTFS_TYPE" == "nilfs" ]; then
+		nilfs-tune -L armbi_root "/dev/mapper/${LVM_VG_NAME}-root"
+	elif [ "$ROOTFS_TYPE" == "xfs" ]; then
+		xfs_io -c "label -s armbi_root" "$(mount | grep "/dev/mapper/${LVM_VG_NAME}-root" | awk '{print $3}')"
+	fi
+}
+
+function format_partitions__format_lvm() {
+	# Skip unknown/unsupported filesystems. nfs does not support labels and f2fs labels cannot be changed online
+	if echo "ext4 btrfs nilfs xfs" | grep -v -w -q "$ROOTFS_TYPE"; then
 		display_alert "LVM partition labels skipped" "${EXTENSION}" "info"
+		return
+	fi
+
+	# Label the root volume
+	if label_partition; then
+		blkid | grep "${LVM_VG_NAME}" >> "${DEST}/${LOG_SUBPATH}/lvm.log" 2>&1
+		display_alert "LVM labeled $ROOTFS_TYPE partitions" "${EXTENSION}" "info"
+	else
+		display_alert "LVM failed to label $ROOTFS_TYPE partition. Ignoring." "${EXTENSION}" "info"
 	fi
 }
 

--- a/extensions/lvm.sh
+++ b/extensions/lvm.sh
@@ -68,10 +68,18 @@ function prepare_root_device__create_volume_group() {
 }
 
 function format_partitions__format_lvm() {
-	# Label the root volume
-	e2label "/dev/mapper/${LVM_VG_NAME}-root" armbi_root
-	blkid | grep "${LVM_VG_NAME}" >> "${DEST}/${LOG_SUBPATH}/lvm.log" 2>&1
-	display_alert "LVM labeled partitions" "${EXTENSION}" "info"
+	if [ "$ROOTFS_TYPE" == "ext4" ]; then
+		# Label the root volume
+		e2label "/dev/mapper/${LVM_VG_NAME}-root" armbi_root
+		blkid | grep "${LVM_VG_NAME}" >> "${DEST}/${LOG_SUBPATH}/lvm.log" 2>&1
+		display_alert "LVM labeled partitions" "${EXTENSION}" "info"
+	elif [ "$ROOTFS_TYPE" == "btrfs" ]; then
+		btrfs filesystem label $( mount | grep "/dev/mapper/${LVM_VG_NAME}-root" | awk '{print $3}' ) armbi_root
+		blkid | grep "${LVM_VG_NAME}" >> "${DEST}/${LOG_SUBPATH}/lvm.log" 2>&1
+		display_alert "LVM labeled partitions" "${EXTENSION}" "info"
+	else
+		display_alert "LVM partition labels skipped" "${EXTENSION}" "info"
+	fi
 }
 
 function post_umount_final_image__cleanup_lvm(){

--- a/extensions/lvm.sh
+++ b/extensions/lvm.sh
@@ -69,19 +69,19 @@ function prepare_root_device__create_volume_group() {
 
 function label_partition() {
 	if [ "$ROOTFS_TYPE" == "ext4" ]; then
-		e2label "/dev/mapper/${LVM_VG_NAME}-root" armbi_root
+		e2label "/dev/mapper/${LVM_VG_NAME}-root" "${ROOT_FS_LABEL}"
 	elif [ "$ROOTFS_TYPE" == "btrfs" ]; then
-		btrfs filesystem label "$(mount | grep "/dev/mapper/${LVM_VG_NAME}-root" | awk '{print $3}')" armbi_root
-	elif [ "$ROOTFS_TYPE" == "nilfs" ]; then
-		nilfs-tune -L armbi_root "/dev/mapper/${LVM_VG_NAME}-root"
+		btrfs filesystem label "$(mount | grep "/dev/mapper/${LVM_VG_NAME}-root" | awk '{print $3}')" "${ROOT_FS_LABEL}"
+	elif [ "$ROOTFS_TYPE" == "nilfs2" ]; then
+		nilfs-tune -L "${ROOT_FS_LABEL}" "/dev/mapper/${LVM_VG_NAME}-root"
 	elif [ "$ROOTFS_TYPE" == "xfs" ]; then
-		xfs_io -c "label -s armbi_root" "$(mount | grep "/dev/mapper/${LVM_VG_NAME}-root" | awk '{print $3}')"
+		xfs_io -c "label -s \"${ROOT_FS_LABEL}\"" "$(mount | grep "/dev/mapper/${LVM_VG_NAME}-root" | awk '{print $3}')"
 	fi
 }
 
 function format_partitions__format_lvm() {
-	# Skip unknown/unsupported filesystems. nfs does not support labels and f2fs labels cannot be changed online
-	if echo "ext4 btrfs nilfs xfs" | grep -v -w -q "$ROOTFS_TYPE"; then
+	# Skip unknown filesystems
+	if echo "ext4 btrfs nilfs2 xfs" | grep -v -w -q "$ROOTFS_TYPE"; then
 		display_alert "LVM partition labels skipped" "${EXTENSION}" "info"
 		return
 	fi

--- a/extensions/lvm.sh
+++ b/extensions/lvm.sh
@@ -68,34 +68,49 @@ function prepare_root_device__create_volume_group() {
 }
 
 function label_partition() {
-	if [ "$ROOTFS_TYPE" == "ext4" ]; then
-		e2label "/dev/mapper/${LVM_VG_NAME}-root" "${ROOT_FS_LABEL}"
-	elif [ "$ROOTFS_TYPE" == "btrfs" ]; then
-		btrfs filesystem label "$(mount | grep "/dev/mapper/${LVM_VG_NAME}-root" | awk '{print $3}')" "${ROOT_FS_LABEL}"
-	elif [ "$ROOTFS_TYPE" == "nilfs2" ]; then
-		nilfs-tune -L "${ROOT_FS_LABEL}" "/dev/mapper/${LVM_VG_NAME}-root"
-	elif [ "$ROOTFS_TYPE" == "xfs" ]; then
-		xfs_io -c "label -s \"${ROOT_FS_LABEL}\"" "$(mount | grep "/dev/mapper/${LVM_VG_NAME}-root" | awk '{print $3}')"
-	fi
+	local rootdevice="/dev/mapper/${LVM_VG_NAME}-root"
+	# btrfs and xfs relabel via the mount point; resolve it structurally
+	# (findmnt is a single util-linux call, robust to spaces and to multiple
+	# mounts of the same device) instead of parsing mount(8) output.
+	local mountpoint
+	mountpoint="$(findmnt --noheadings --first-only --output TARGET --source "${rootdevice}")"
+
+	case "${ROOTFS_TYPE}" in
+		ext4 | ext2)
+			e2label "${rootdevice}" "${ROOT_FS_LABEL}"
+			;;
+		btrfs)
+			btrfs filesystem label "${mountpoint}" "${ROOT_FS_LABEL}"
+			;;
+		nilfs2)
+			nilfs-tune -L "${ROOT_FS_LABEL}" "${rootdevice}"
+			;;
+		xfs)
+			xfs_io -c "label -s ${ROOT_FS_LABEL}" "${mountpoint}"
+			;;
+	esac
 }
 
 function format_partitions__format_lvm() {
-	# Skip unknown filesystems
-	if echo "ext4 btrfs nilfs2 xfs" | grep -v -w -q "$ROOTFS_TYPE"; then
-		display_alert "LVM partition labels skipped" "${EXTENSION}" "info"
-		return
-	fi
+	# Only these filesystems support relabeling the mounted root here; skip the rest.
+	case "${ROOTFS_TYPE}" in
+		ext4 | ext2 | btrfs | nilfs2 | xfs) ;;
+		*)
+			display_alert "LVM partition labels skipped" "${EXTENSION} - unsupported ${ROOTFS_TYPE}" "info"
+			return
+			;;
+	esac
 
 	# Label the root volume
 	if label_partition; then
 		blkid | grep "${LVM_VG_NAME}" >> "${DEST}/${LOG_SUBPATH}/lvm.log" 2>&1
-		display_alert "LVM labeled $ROOTFS_TYPE partitions" "${EXTENSION}" "info"
+		display_alert "LVM labeled ${ROOTFS_TYPE} partitions" "${EXTENSION}" "info"
 	else
-		display_alert "LVM failed to label $ROOTFS_TYPE partition. Ignoring." "${EXTENSION}" "info"
+		display_alert "LVM failed to label ${ROOTFS_TYPE} partition. Ignoring." "${EXTENSION}" "info"
 	fi
 }
 
-function post_umount_final_image__cleanup_lvm(){
+function post_umount_final_image__cleanup_lvm() {
 	execute_and_remove_cleanup_handler cleanup_lvm
 }
 


### PR DESCRIPTION
# Description

Compiling an image with ROOTFS_TYPE=btrfs and ENABLE_EXTENSIONS=lvm fails, because the lvm extensions tries to add a label to the filesystem using a ext4 specific command. 
This PR differentiates between the different filesystems and uses the appropriate command for each to add the label.

nfs and f2fs are not labled, as they do not support labels, or labels cannot be added while the filesystem is mounted.
If the label cannot be successfully added, a message is printed, but ignored.

# How Has This Been Tested?

- [x] Built all relevant ROOTFS_TYPEs with no more build errors
- [x] Flashed and tested btrfs on rock-5-itx

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Root volume labeling now respects filesystem type and supports ext4, btrfs, nilfs2 and xfs.
  * For supported filesystems, the installer reports per-filesystem success/failure and appends block ID info to the LVM log.
  * Labeling is skipped for other filesystem types with an informational log entry to improve clarity and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->