### PR TITLE
fix(kernel-debs): allow 'dwarves' as alternative for 'pahole' in headers Depends

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -511,6 +511,9 @@ function kernel_package_callback_linux_headers() {
 
 	# Generate a control file
 	# TODO: libssl-dev is only required if we're signing modules, which is a kernel .config option.
+	# Note: 'pahole | dwarves' alternative — older releases (buster/bullseye/focal) ship pahole inside the
+	# 'dwarves' package; standalone 'pahole' exists from bookworm/jammy onward. When support for these
+	# releases is dropped, simplify to 'pahole'.
 	cat <<- CONTROL_FILE > "${package_DEBIAN_dir}/control"
 		Version: ${artifact_version}
 		Maintainer: ${MAINTAINER} <${MAINTAINERMAIL}>
@@ -519,7 +522,7 @@ function kernel_package_callback_linux_headers() {
 		Architecture: ${ARCH}
 		Priority: optional
 		Provides: linux-headers (= ${kernel_version}), linux-headers-armbian, armbian-$BRANCH
-		Depends: make, gcc, libc6-dev, bison, flex, libssl-dev, libelf-dev, pahole
+		Depends: make, gcc, libc6-dev, bison, flex, libssl-dev, libelf-dev, pahole | dwarves
 		Description: Armbian Linux $BRANCH headers ${kernel_version_family}
 		 This package provides kernel header files for ${kernel_version_family}
 		 .

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -378,7 +378,6 @@ function install_distribution_agnostic() {
 
 		if [[ "${KERNEL_HAS_WORKING_HEADERS:-"no"}" == "yes" ]]; then
 			if [[ $INSTALL_HEADERS == yes ]]; then # @TODO remove? might be a good idea to always install headers.
-				chroot_sdcard_apt_get_install "pahole"
 				install_artifact_deb_chroot "linux-headers"
 			fi
 		fi


### PR DESCRIPTION
This fixes the current inability to build `bullseye` (and other older-release) images: apt can't resolve `Depends: pahole` against the bullseye repos — the package doesn't exist there — so kernel-headers install, and therefore the whole rootfs phase, fails.

## Summary

The `linux-headers-*` .deb generated by `kernel_package_callback_linux_headers()` declares `Depends: ..., pahole`. On older releases — Debian buster/bullseye and Ubuntu focal — `pahole` is not a standalone package; the binary lives inside `dwarves`. apt therefore refuses to install the headers .deb on those releases with `E: Unable to correct problems, you have held broken packages.`

Use the alternative dependency `pahole | dwarves` so apt picks `pahole` on bookworm+/jammy+ and falls back to `dwarves` on older releases. On modern releases `dwarves` is itself a transitional package that pulls `pahole`, so the alternative remains satisfiable everywhere.

This also lets us drop the explicit `chroot_sdcard_apt_get_install "pahole"` from `install_distribution_agnostic()`: installing the headers .deb pulls pahole/dwarves via Depends.

Comment in `kernel-debs.sh` notes that when buster/bullseye/focal support is dropped the alternative can be simplified to plain `pahole`.

## Reproduction (before)

```
./compile.sh build BOARD=helios4 BRANCH=edge RELEASE=bullseye KERNEL_BTF=no
```

Two consecutive failures in `install_distribution_agnostic`:

1. `E: Unable to locate package pahole` from the explicit `apt-get install pahole`.
2. After replacing with `dwarves`: `E: Unable to correct problems, you have held broken packages.` on `install_artifact_deb_chroot "linux-headers"` because the headers .deb itself declares `Depends: pahole`.

## Validation

| Target | Result |
|--------|--------|
| `helios4 edge bullseye` | Built to image (validates `dwarves` fallback path) |
| `helios4 edge noble` | Built to image (validates standalone `pahole` path) |

## Scope: why buster/focal aren't end-to-end tested here

`buster` and `focal` (and `oracular`) are still **present** in `config/distributions/`, so this build framework formally accepts them as release names. They currently can't be exercised end-to-end on the project's infrastructure because they're missing from the package-index JSON at `https://github.armbian.com/<pkg>.json` (generated by GHA in `armbian/armbian.github.io@data`, path `data/<pkg>.json`) — sourcing `base-files` fails before kernel install. Restoring those releases to that JSON is a small, reversible change elsewhere; if and when that happens, this patch will already do the right thing because the alternative covers them.

Whether `buster`/`focal`/`oracular` should be removed from `config/distributions/` altogether is a separate question not addressed by this PR. The `pahole | dwarves` alternative carries no cost on releases where `pahole` is available, so keeping the older names covered is a free safety net rather than a commitment to support them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kernel headers build dependencies to support both `pahole` and `dwarves` packages, improving compatibility across different Linux distributions.
  * Simplified the kernel headers installation process by streamlining dependency handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->