### PR TITLE
ch13726a: Remove MIPI_DSI_MODE_VIDEO_BURST

### DIFF
--- a/patch/kernel/archive/sm8250-6.19/0065-drm-panel-Add-DDIC-CH13726A-panel-Signed-off-by-Tegu.patch
+++ b/patch/kernel/archive/sm8250-6.19/0065-drm-panel-Add-DDIC-CH13726A-panel-Signed-off-by-Tegu.patch
@@ -49,7 +49,7 @@ new file mode 100644
 index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/gpu/drm/panel/panel-ddic-ch13726a.c
-@@ -0,0 +1,342 @@
+@@ -0,0 +1,341 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * DDIC CH13726A MIPI-DSI panel driver
@@ -337,8 +337,7 @@ index 000000000000..111111111111
 +	dsi->lanes = 4;
 +	dsi->format = MIPI_DSI_FMT_RGB888;
 +	dsi->mode_flags = MIPI_DSI_MODE_VIDEO |
-+					MIPI_DSI_MODE_VIDEO_BURST |
-+					MIPI_DSI_CLOCK_NON_CONTINUOUS;
++			  MIPI_DSI_CLOCK_NON_CONTINUOUS;
 +
 +	drm_panel_init(&ctx->panel, dev, &ch13726a_panel_funcs,
 +		       DRM_MODE_CONNECTOR_DSI);
@@ -394,4 +393,3 @@ index 000000000000..111111111111
 +MODULE_LICENSE("GPL");
 -- 
 Armbian
-


### PR DESCRIPTION
# Description

Remove MIPI_DSI_MODE_VIDEO_BURST, like [the eventually to be upstream driver](https://lore.kernel.org/all/20260426-ch13726a-v7-2-554247c569e5@gmail.com/).

With the flag, severe screen tearing often occurs.

# How Has This Been Tested?

This was tested on my own Retroid Pocket 5

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DDIC CH13726A display panel with brightness control and configurable display modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->