### PR TITLE
ci(workflow): prevent duplicate comments and hard-fail on missing board assets

### DIFF
--- a/.github/workflows/maintenance-check-board-assets.yml
+++ b/.github/workflows/maintenance-check-board-assets.yml
@@ -143,7 +143,8 @@ jobs:
             echo 'comment<<EOF' >> "$GITHUB_OUTPUT"
             cat "$comment_file" >> "$GITHUB_OUTPUT"
             echo 'EOF' >> "$GITHUB_OUTPUT"
-            echo "::warning ::Missing required assets (see PR comment)."
+            echo "::error::Missing required board assets (see PR comment)."
+            exit 1
           else
             echo "missing=false" >> "$GITHUB_OUTPUT"
           fi
@@ -164,9 +165,30 @@ jobs:
 
             Once the missing files are added (or a PR is opened in **${process.env.WEBSITE_REPO}**), re-run this check.
             `;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body
-            });
+
+            // Check if a comment with the same header already exists to avoid flooding
+            // Use paginate to fetch all comments (listComments only returns first page)
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              });
+
+              const botComment = comments.find(comment =>
+                comment.user.type === 'Bot' &&
+                comment.body.includes('### 🚫 Missing required board assets')
+              );
+
+              if (!botComment) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body
+                });
+              }
+            } catch (error) {
+              // Log error but don't fail the step - the validation already failed with exit 1
+              core.warning(`Failed to post PR comment: ${error.message}`);
+            }


### PR DESCRIPTION
## Summary
- Check for existing bot comment before posting to avoid flooding
- Changed `::warning` to `::error` with `exit 1` to fail the job when assets are missing
- This blocks PR merge until required assets are added to `armbian.github.io`

## Changes
1. **Anti-flood**: Bot now checks if a comment with `### 🚫 Missing required board assets` already exists before posting
2. **Hard failure**: Job now exits with error when assets are missing (was just warning before)

This ensures PRs cannot be merged until the required board images and vendor logos exist in the website repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate bot comments on pull requests by detecting existing validation messages before creating new ones.
  * Failures to post validation comments are now logged as warnings and no longer cause the validation step to fail.

* **Chores**
  * Asset validation now enforces required board assets and reports an error (failing the check) when assets are missing instead of issuing only a warning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->