### PR TITLE
arm64: dts: rockchip: nanopi-m5: fix GMAC rgmii-id causing broken gig…

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/board-nanopi-m5-add-wifi-bt-ufs-and-misc.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-nanopi-m5-add-wifi-bt-ufs-and-misc.patch
@@ -119,8 +119,8 @@ index 111111111111..222222222222 100644
  		    <&eth0m0_rx_bus2>,
  		    <&eth0m0_rgmii_clk>,
  		    <&eth0m0_rgmii_bus>;
++	phy-mode = "rgmii-rxid";
 +	tx_delay = <0x21>;
-+	rx_delay = <0x3f>;
  	status = "okay";
  };
  
@@ -128,8 +128,8 @@ index 111111111111..222222222222 100644
  		    <&eth1m0_rx_bus2>,
  		    <&eth1m0_rgmii_clk>,
  		    <&eth1m0_rgmii_bus>;
++	phy-mode = "rgmii-rxid";
 +	tx_delay = <0x20>;
-+	rx_delay = <0x3f>;
  	status = "okay";
  };
  

--- a/patch/kernel/archive/rockchip64-6.18/board-nanopi-m5-add-wifi-bt-ufs-and-misc.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-nanopi-m5-add-wifi-bt-ufs-and-misc.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
-Date: Sat, 16 May 2026 19:00:00 +0200
+Date: Thu, 28 May 2026 11:00:00 +0200
 Subject: arm64: dts: rockchip: Complete NanoPi M5 board description (6.18)
 
 The mainline rk3576-nanopi-m5.dts in 6.18 is a minimal first-cut that
@@ -25,17 +25,10 @@ schematics. Fill in the gaps:
   - Pinctrl: add the matching wireless-bluetooth and wireless-wlan
     groups for uart5_gpios / wifi_host_wake_irq / wifi_poweren_gpio.
 
-  - GMAC: set RGMII tx_delay / rx_delay to the values used by the
-    FriendlyElec vendor kernel (0x21/0x3f on gmac0, 0x20/0x3f on
-    gmac1). Without these the rockchip dwmac glue logs:
-
-      rk_gmac-dwmac 2a230000.ethernet: Can not read property: tx_delay.
-      rk_gmac-dwmac 2a230000.ethernet: set tx_delay to 0x30
-      rk_gmac-dwmac 2a230000.ethernet: Can not read property: rx_delay.
-      rk_gmac-dwmac 2a230000.ethernet: set rx_delay to 0x10
-
-    and falls back to defaults that do not match the trace lengths to
-    the on-board RTL8211F PHYs.
+  - GMAC: set RGMII tx_delay (0x21 on gmac0, 0x20 on gmac1) to match
+    the FriendlyElec vendor kernel. Leave rx_delay unset: the on-board
+    RTL8211F PHYs use rgmii-id and apply the RX delay internally, so an
+    extra SoC-side rx_delay double-delays RX and breaks gigabit.
 
   - ADC keys: add the saradc back button on saradc channel 0
     (~17 mV press threshold) so the BACK key on the carrier works.
@@ -56,8 +49,8 @@ schematics. Fill in the gaps:
 
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 112 +++++++++-
- 1 file changed, 110 insertions(+), 2 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 110 +++++++++-
+ 1 file changed, 108 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts b/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts
 index 111111111111..222222222222 100644
@@ -115,25 +108,23 @@ index 111111111111..222222222222 100644
  	sound {
  		compatible = "simple-audio-card";
  		pinctrl-names = "default";
-@@ -288,6 +326,8 @@ &gmac0 {
+@@ -288,6 +326,7 @@ &gmac0 {
  		    <&eth0m0_rx_bus2>,
  		    <&eth0m0_rgmii_clk>,
  		    <&eth0m0_rgmii_bus>;
-+	phy-mode = "rgmii-rxid";
 +	tx_delay = <0x21>;
  	status = "okay";
  };
  
-@@ -302,6 +342,8 @@ &gmac1 {
+@@ -302,6 +341,7 @@ &gmac1 {
  		    <&eth1m0_rx_bus2>,
  		    <&eth1m0_rgmii_clk>,
  		    <&eth1m0_rgmii_bus>;
-+	phy-mode = "rgmii-rxid";
 +	tx_delay = <0x20>;
  	status = "okay";
  };
  
-@@ -846,6 +888,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
+@@ -846,6 +886,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
  			rockchip,pins = <0 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -156,7 +147,7 @@ index 111111111111..222222222222 100644
  };
  
  &sai2 {
-@@ -857,6 +915,24 @@ &saradc {
+@@ -857,6 +913,24 @@ &saradc {
  	status = "okay";
  };
  
@@ -181,7 +172,7 @@ index 111111111111..222222222222 100644
  &sdmmc {
  	bus-width = <4>;
  	cap-mmc-highspeed;
-@@ -910,13 +986,45 @@ &uart0 {
+@@ -910,13 +984,45 @@ &uart0 {
  	status = "okay";
  };
  

--- a/patch/kernel/archive/rockchip64-7.0/board-nanopi-m5-add-wifi-bt-and-misc.patch
+++ b/patch/kernel/archive/rockchip64-7.0/board-nanopi-m5-add-wifi-bt-and-misc.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
-Date: Sat, 16 May 2026 19:00:00 +0200
+Date: Thu, 28 May 2026 11:00:00 +0200
 Subject: arm64: dts: rockchip: Complete NanoPi M5 board description
 
 The mainline rk3576-nanopi-m5.dts is a minimal first-cut that omits
@@ -18,17 +18,10 @@ Fill in the gaps:
   - Pinctrl: add the matching wireless-bluetooth and wireless-wlan
     groups for uart5_gpios / wifi_host_wake_irq / wifi_poweren_gpio.
 
-  - GMAC: set RGMII tx_delay / rx_delay to the values used by the
-    FriendlyElec vendor kernel (0x21/0x3f on gmac0, 0x20/0x3f on
-    gmac1). Without these the rockchip dwmac glue logs:
-
-      rk_gmac-dwmac 2a230000.ethernet: Can not read property: tx_delay.
-      rk_gmac-dwmac 2a230000.ethernet: set tx_delay to 0x30
-      rk_gmac-dwmac 2a230000.ethernet: Can not read property: rx_delay.
-      rk_gmac-dwmac 2a230000.ethernet: set rx_delay to 0x10
-
-    and falls back to defaults that do not match the trace lengths to
-    the on-board RTL8211F PHYs.
+  - GMAC: set RGMII tx_delay (0x21 on gmac0, 0x20 on gmac1) to match
+    the FriendlyElec vendor kernel. Leave rx_delay unset: the on-board
+    RTL8211F PHYs use rgmii-id and apply the RX delay internally, so an
+    extra SoC-side rx_delay double-delays RX and breaks gigabit.
 
   - ADC keys: add the saradc back button on saradc channel 0
     (~17 mV press threshold) so the BACK key on the carrier works.
@@ -49,8 +42,8 @@ Fill in the gaps:
 
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 88 +++++++++-
- 1 file changed, 86 insertions(+), 2 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 86 +++++++++-
+ 1 file changed, 84 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts b/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts
 index 111111111111..222222222222 100644
@@ -85,25 +78,23 @@ index 111111111111..222222222222 100644
  	sound {
  		compatible = "simple-audio-card";
  		pinctrl-names = "default";
-@@ -304,6 +326,8 @@ &gmac0 {
+@@ -304,6 +326,7 @@ &gmac0 {
  		    <&eth0m0_rx_bus2>,
  		    <&eth0m0_rgmii_clk>,
  		    <&eth0m0_rgmii_bus>;
 +	tx_delay = <0x21>;
-+	rx_delay = <0x3f>;
  	status = "okay";
  };
  
-@@ -318,6 +342,8 @@ &gmac1 {
+@@ -318,6 +341,7 @@ &gmac1 {
  		    <&eth1m0_rx_bus2>,
  		    <&eth1m0_rgmii_clk>,
  		    <&eth1m0_rgmii_bus>;
 +	tx_delay = <0x20>;
-+	rx_delay = <0x3f>;
  	status = "okay";
  };
  
-@@ -866,6 +892,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
+@@ -866,6 +890,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
  			rockchip,pins = <0 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -126,7 +117,7 @@ index 111111111111..222222222222 100644
  };
  
  &sai2 {
-@@ -881,6 +923,24 @@ &saradc {
+@@ -881,6 +921,24 @@ &saradc {
  	status = "okay";
  };
  
@@ -151,7 +142,7 @@ index 111111111111..222222222222 100644
  &sdmmc {
  	bus-width = <4>;
  	cap-mmc-highspeed;
-@@ -934,6 +994,31 @@ &uart0 {
+@@ -934,6 +992,31 @@ &uart0 {
  	status = "okay";
  };
  
@@ -183,7 +174,7 @@ index 111111111111..222222222222 100644
  &ufshc {
  	vcc-supply = <&vcc_3v3_s3>;
  	vccq-supply = <&vcc1v2_ufs_vccq>;
-@@ -947,8 +1032,7 @@ &usbdp_phy {
+@@ -947,8 +1030,7 @@ &usbdp_phy {
  };
  
  &usb_drd0_dwc3 {

--- a/patch/kernel/archive/rockchip64-7.1/board-nanopi-m5-add-wifi-bt-and-misc.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-nanopi-m5-add-wifi-bt-and-misc.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
-Date: Sat, 16 May 2026 19:00:00 +0200
+Date: Thu, 28 May 2026 11:00:00 +0200
 Subject: arm64: dts: rockchip: Complete NanoPi M5 board description
 
 The mainline rk3576-nanopi-m5.dts is a minimal first-cut that omits
@@ -18,17 +18,10 @@ Fill in the gaps:
   - Pinctrl: add the matching wireless-bluetooth and wireless-wlan
     groups for uart5_gpios / wifi_host_wake_irq / wifi_poweren_gpio.
 
-  - GMAC: set RGMII tx_delay / rx_delay to the values used by the
-    FriendlyElec vendor kernel (0x21/0x3f on gmac0, 0x20/0x3f on
-    gmac1). Without these the rockchip dwmac glue logs:
-
-      rk_gmac-dwmac 2a230000.ethernet: Can not read property: tx_delay.
-      rk_gmac-dwmac 2a230000.ethernet: set tx_delay to 0x30
-      rk_gmac-dwmac 2a230000.ethernet: Can not read property: rx_delay.
-      rk_gmac-dwmac 2a230000.ethernet: set rx_delay to 0x10
-
-    and falls back to defaults that do not match the trace lengths to
-    the on-board RTL8211F PHYs.
+  - GMAC: set RGMII tx_delay (0x21 on gmac0, 0x20 on gmac1) to match
+    the FriendlyElec vendor kernel. Leave rx_delay unset: the on-board
+    RTL8211F PHYs use rgmii-id and apply the RX delay internally, so an
+    extra SoC-side rx_delay double-delays RX and breaks gigabit.
 
   - ADC keys: add the saradc back button on saradc channel 0
     (~17 mV press threshold) so the BACK key on the carrier works.
@@ -49,8 +42,8 @@ Fill in the gaps:
 
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 88 +++++++++-
- 1 file changed, 86 insertions(+), 2 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 86 +++++++++-
+ 1 file changed, 84 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts b/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts
 index 111111111111..222222222222 100644
@@ -85,25 +78,23 @@ index 111111111111..222222222222 100644
  	sound {
  		compatible = "simple-audio-card";
  		pinctrl-names = "default";
-@@ -304,6 +326,8 @@ &gmac0 {
+@@ -304,6 +326,7 @@ &gmac0 {
  		    <&eth0m0_rx_bus2>,
  		    <&eth0m0_rgmii_clk>,
  		    <&eth0m0_rgmii_bus>;
 +	tx_delay = <0x21>;
-+	rx_delay = <0x3f>;
  	status = "okay";
  };
  
-@@ -318,6 +342,8 @@ &gmac1 {
+@@ -318,6 +341,7 @@ &gmac1 {
  		    <&eth1m0_rx_bus2>,
  		    <&eth1m0_rgmii_clk>,
  		    <&eth1m0_rgmii_bus>;
 +	tx_delay = <0x20>;
-+	rx_delay = <0x3f>;
  	status = "okay";
  };
  
-@@ -866,6 +892,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
+@@ -866,6 +890,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
  			rockchip,pins = <0 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -126,7 +117,7 @@ index 111111111111..222222222222 100644
  };
  
  &sai2 {
-@@ -881,6 +923,24 @@ &saradc {
+@@ -881,6 +921,24 @@ &saradc {
  	status = "okay";
  };
  
@@ -151,7 +142,7 @@ index 111111111111..222222222222 100644
  &sdmmc {
  	bus-width = <4>;
  	cap-mmc-highspeed;
-@@ -934,6 +994,31 @@ &uart0 {
+@@ -934,6 +992,31 @@ &uart0 {
  	status = "okay";
  };
  
@@ -183,7 +174,7 @@ index 111111111111..222222222222 100644
  &ufshc {
  	vcc-supply = <&vcc_3v3_s3>;
  	vccq-supply = <&vcc1v2_ufs_vccq>;
-@@ -947,8 +1032,7 @@ &usbdp_phy {
+@@ -947,8 +1030,7 @@ &usbdp_phy {
  };
  
  &usb_drd0_dwc3 {


### PR DESCRIPTION
RTL8211F in rgmii-id mode applies its own internal RX delay. Setting rx_delay on top of that causes double delay which breaks gigabit RX entirely (RX counters stuck at zero, DHCP never receives OFFER).

Change phy-mode to rgmii-rxid and drop rx_delay for both gmac0 and gmac1. Tested on NanoPi M5 with kernel 6.18.33-current-rockchip64.

# Description

Without this fix, gigabit RX is completely non-functional on NanoPi M5 with kernel 6.18. The interface comes up at 1000Mb/s, TX works, but no packets are ever received. DHCP never gets an OFFER, ethtool -S shows RX counters stuck at zero.

Root cause: the DTB sets phy-mode = "rgmii-id" which means the RTL8211F PHY applies its own internal RX delay. The driver then also applies an additional hardware rx_delay = <0x3f> on top of it. The double delay breaks gigabit RX entirely.

Workaround that confirmed the root cause: forcing 100Mbps via ethtool -s end0 speed 100 duplex full autoneg off made RX work immediately.

Fix: change phy-mode to rgmii-rxid (PHY handles RX delay internally) and remove rx_delay for both gmac0 and gmac1.

Forum thread: https://forum.armbian.com/topic/59912-nanopi-m5-rk3576-gigabit-rx-broken-due-to-double-rgmii-delay-in-dtb/

# How Has This Been Tested?

- [x] Booted NanoPi M5 with kernel 6.18.33-current-rockchip64 on SD card. Without fix: gigabit RX non-functional, DHCP OFFER never received, RX counters at zero. With fix: both gmac0 and gmac1 work correctly at 1Gbps full duplex.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled UFS storage controller with proper power rails
  * Added Wi‑Fi (SDIO) and Bluetooth (RTL8822CS) support with GPIO power/wake sequencing
  * Restored BACK button via onboard ADC
  * Enabled additional serial ports for peripherals
  * Optimized Ethernet timing for reliable MAC operation
  * Configured the USB port to operate as a host device

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->