### PR TITLE
fix(ci/shellcheck): pass --shell=bash for per-file lint of board configs

### DIFF
--- a/.github/workflows/maintenance-lint-scripts.yml
+++ b/.github/workflows/maintenance-lint-scripts.yml
@@ -108,7 +108,7 @@ jobs:
             [[ -f "$file" ]] || continue
             if [[ ! "$file" =~ lib/|extensions/|\.py$|\.service$|\.rules$|\.network$|\.netdev$ ]]; then
               if grep -qE '^#!/.*bash' "$file" 2>/dev/null; then
-                "$SC" --severity=error --format=gcc "$file" >> shellcheck-findings.txt 2>&1 || true
+                "$SC" --shell=bash --severity=error --format=gcc "$file" >> shellcheck-findings.txt 2>&1 || true
               fi
             fi
           done
@@ -193,7 +193,7 @@ jobs:
             [[ -f "$file" ]] || continue
             if [[ ! "$file" =~ lib/|extensions/|\.py$|\.service$|\.rules$|\.network$|\.netdev$ ]]; then
               if grep -qE '^#!/.*bash' "$file" 2>/dev/null; then
-                shellcheck --severity=error "$file" || ret=$?
+                shellcheck --shell=bash --severity=error "$file" || ret=$?
               fi
             fi
           done


### PR DESCRIPTION
## Summary

The per-file ShellCheck loops in `maintenance-lint-scripts.yml` gate invocation behind `grep -qE '^#!/.*bash' "$file"`, but `grep` scans every line — so any board `.conf` with an embedded `#!/bin/bash` heredoc (e.g. `config/boards/easepi-a2.conf` at lines 267/289/496) passes the gate. The follow-up `shellcheck` call ran without `--shell=bash`, so it looked at line 1 (a `# Rockchip ...` comment), couldn't determine the target shell, and errored:

```
In config/boards/easepi-a2.conf line 1:
^-- SC2148 (error): Tips depend on target shell and yours is unknown.
                    Add a shebang or a 'shell' directive.
```

See: https://github.com/armbian/build/actions/runs/26461652130/job/77910798513 (PR #9880).

## Fix

Add `--shell=bash` to both call sites (findings artifact + red-cross gate). ShellCheck now knows the shell up front, SC2148 no longer fires on line 1, and the embedded heredocs inside the `.conf` still get linted as bash.

## Test plan

- [ ] Re-run PR #9880's `Maintenance: Lint scripts` workflow → SC2148 no longer fires on `config/boards/easepi-a2.conf` / `easepi-r2.conf`
- [ ] Existing bash-shebang scripts in other PRs still get the same red-cross treatment (no regression in coverage)

## Follow-up (not in this PR)

The gate itself is technically buggy: `grep` matches anywhere in the file, so `.conf` files with embedded heredoc shebangs pass even though line 1 is a comment. A stricter gate would be `[[ "$(head -1 "$file")" =~ ^#!/.*bash ]]`. Left alone here because `--shell=bash` makes the looser gate correct in practice (we lint the whole file as bash, heredocs included).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow validation to use explicit bash configuration for improved shell script verification accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->