### PR TITLE
ci: track pinned CLI tool versions with Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,101 @@
+{
+	$schema: "https://docs.renovatebot.com/renovate-schema.json",
+	extends: ["config:recommended"],
+
+	// Run ONLY our custom regex manager. We deliberately do NOT enable the
+	// github-actions / pip managers — those are owned by Dependabot
+	// (.github/dependabot.yml); no point duplicating it.
+	enabledManagers: ["custom.regex"],
+
+	dependencyDashboard: true,
+	labels: ["dependencies"],
+	timezone: "Europe/Zagreb",
+	schedule: ["* 1 * * 6"], // Saturday, 01:00–01:59 Zagreb time
+
+	customManagers: [
+		{
+			customType: "regex",
+			managerFilePatterns: ["/^lib/.*\\.sh$/"],
+
+			// ════════════════════════════════════════════════════════════════
+			//  HOW TO MAKE A PINNED TOOL VERSION TRACKED BY RENOVATE
+			//  (read THIS, not the regex — humans are bad at reading regexes)
+			// ════════════════════════════════════════════════════════════════
+			//
+			//  Several build scripts pin a CLI tool to a version that is then
+			//  downloaded from GitHub Releases. Renovate keeps that pin fresh
+			//  by opening a PR when a newer release appears. For Renovate to
+			//  see a line, the line must look EXACTLY like this (leading tabs
+			//  / indentation are fine):
+			//
+			//      SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-0.11.0} # https://github.com/koalaman/shellcheck/releases
+			//      └──────┬─────────┘ └────────┬─────────┘└──┬──┘   └──────────────────────┬────────────────────────┘
+			//        NAME_VERSION       ${ … :- VERSION }   bare      single "#"  +  https://github.com/OWNER/REPO/releases
+			//        (allow-listed)      default-value form  brace
+			//
+			//  From that line Renovate takes:
+			//      • the version  ("0.11.0")            → currentValue
+			//      • OWNER/REPO from the URL            → depName
+			//  datasource is forced to github-releases; a leading "v" on the
+			//  upstream tag (v0.11.0) is stripped automatically.
+			//
+			//  Note: depName comes from the github.com URL that the upstream
+			//  scripts already write — so NO extra "# renovate:" annotation is
+			//  added to those files. That keeps them byte-identical to upstream
+			//  and conflict-free when iav-main is synced.
+			//
+			//  ─── STRICT RULES ───────────────────────────────────────────────
+			//  Break ANY of these and the line is SILENTLY dropped: Renovate
+			//  just stops tracking it, the version quietly rots, and the only
+			//  visible sign is that the tool disappears from the Dependency
+			//  Dashboard issue. So:
+			//
+			//   1. NAME must be in the allow-list inside `matchStrings` below
+			//      (currently SHELLFMT | SHELLCHECK | ORAS | BATCAT). A brand
+			//      new tool is NOT tracked until you add its NAME there. This
+			//      is intentional — it stops Renovate from grabbing pins that
+			//      must stay fixed (e.g. a RUST_VERSION held back on purpose).
+			//
+			//   2. The version after ":-" must be BARE digits and dots — no
+			//      quotes, no leading "v":
+			//          OK    ${ORAS_VERSION:-1.3.2}
+			//          BAD   ${ORAS_VERSION:-"1.3.2"}   ← quotes kill the match
+			//          BAD   ${ORAS_VERSION:-v1.3.2}    ← leading v kills it
+			//
+			//   3. Use the default-value form  ${NAME:-VERSION}  — with the
+			//      "${", the ":-", and the closing "}". A plain  NAME=1.3.2
+			//      (no braces) is NOT matched.
+			//
+			//   4. The version and its github.com URL comment MUST be on the
+			//      same physical line. No line-continuation "\", no wrapping.
+			//
+			//   5. Between the closing "}" and the comment there may only be
+			//      spaces/tabs. Code BEFORE the assignment is fine (indent, an
+			//      `if`, a leading `&&`), but nothing may come AFTER the "}"
+			//      except the comment:
+			//          OK    [[ -n $x ]] && ORAS_VERSION=${ORAS_VERSION:-1.3.2} # https://github.com/oras-project/oras/releases
+			//          BAD   ORAS_VERSION=${ORAS_VERSION:-1.3.2} && do_thing    # …  ← trailing code kills the match
+			//      Keep the "# https://…/releases" comment LAST on the line.
+			//
+			//   6. The comment must be a single "#" then the canonical URL
+			//      https://github.com/OWNER/REPO/releases :
+			//          OK    # https://github.com/sharkdp/bat/releases
+			//          BAD   ## https://…                ← double hash kills it
+			//          BAD   # http://github.com/…       ← must be https
+			//          BAD   # see github.com/x/y         ← must start https://github.com/ and end /releases
+			//
+			//   7. To track a NEW tool: (a) write its line in the shape above,
+			//      and (b) add its NAME to the alternation in `matchStrings`.
+			// ════════════════════════════════════════════════════════════════
+			matchStrings: [
+				// separator is [[:blank:]] (space/tab only, NOT \s) so the version
+				// and its release-URL comment must sit on ONE physical line —
+				// \s would also cross newlines and could grab an unrelated URL.
+				"\\b(?:SHELLFMT|SHELLCHECK|ORAS|BATCAT)_VERSION=\\$\\{[A-Z_]+:-(?<currentValue>[0-9][0-9.]*)\\}[[:blank:]]*#[[:blank:]]*https://github\\.com/(?<depName>[^/]+/[^/\\s]+)/releases",
+			],
+			datasourceTemplate: "github-releases",
+			extractVersionTemplate: "^v?(?<version>.+)$",
+			versioningTemplate: "semver",
+		},
+	],
+}


### PR DESCRIPTION
## Summary

Adds a Renovate configuration that keeps the CLI tools pinned in the
build scripts (shellcheck, shfmt, oras, bat) up to date — it opens a PR
when a newer GitHub release is published.

- A custom regex manager reads the version and `OWNER/REPO` from the
  `# https://github.com/OWNER/REPO/releases` comment the scripts already
  carry, so the source files need no extra markup.
- An explicit variable-name allow-list (`SHELLFMT | SHELLCHECK | ORAS |
  BATCAT`) limits tracking to these tools; any version pinned on purpose
  elsewhere is left untouched.
- Config is `renovate.json5` so the rule for how a tracked version line
  must be written is documented in plain language right next to it.
- `enabledManagers: ["custom.regex"]` — GitHub Actions and Python stay
  with Dependabot.

## Tracked pins

| tool | version | file |
|---|---|---|
| mvdan/sh (shfmt) | 3.13.1 | lib/tools/shellfmt.sh |
| koalaman/shellcheck | 0.11.0 | lib/tools/shellcheck.sh, lib/functions/general/shellcheck.sh |
| oras-project/oras | 1.3.2 | lib/functions/general/oci-oras.sh |
| sharkdp/bat | 0.26.1 | lib/functions/general/bat-cat.sh |

The manager matches exactly these lines and nothing else under `lib/**/*.sh`.

## Test plan

- [x] \`renovate-config-validator renovate.json5\` — Config validated successfully

## Once merged and the Renovate app is enabled

Renovate is a third-party service (mend.io), **free for open-source
projects**. This config is inert on its own — it takes effect only once
the Renovate GitHub App is installed on the repository; merging the file
alone does nothing.

Once active it behaves much like Dependabot:

- it maintains a single **Dependency Dashboard** issue — a status page
  listing every tracked pin, with checkboxes to trigger a run on demand
  and manage updates;
- it opens a **pull request proposing each new version** as soon as it is
  released upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Renovate to automatically manage and track pinned tool versions in shell scripts. Enables dependency dashboard visibility, implements custom version matching patterns for specific development tools, and applies scheduled updates on Saturdays in the Europe/Zagreb timezone.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->