### PR TITLE
nanopi-r76s: fix SD boot and storage stability on eMMC-less units

### DIFF
--- a/config/boards/nanopi-r76s.conf
+++ b/config/boards/nanopi-r76s.conf
@@ -31,15 +31,14 @@ function post_family_config__nanopi_r76s_use_mainline_uboot() {
 	declare -g BOOTPATCHDIR="v2026.04"
 	unset BOOT_FDT_FILE
 
-	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
-	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
+	# boot_merger (uboot_custom_postprocess) injects the rk3576 SD boost; binman's u-boot-rockchip.bin lacks it
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;idbloader.img u-boot.itb"
 
-	# Disable stuff from rockchip64_common; we're using binman here which does all the work already
-	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+	unset write_uboot_platform write_uboot_platform_mtd
 
-	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
 	function write_uboot_platform() {
-		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+		dd "if=$1/idbloader.img" "of=$2" seek=64    conv=notrunc status=none
+		dd "if=$1/u-boot.itb"    "of=$2" seek=16384 conv=notrunc status=none
 	}
 }
 

--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3576-nanopi-r76s.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3576-nanopi-r76s.dts
@@ -793,6 +793,8 @@
 	vmmc-supply = <&vcc_3v3_s3>;
 	vqmmc-supply = <&vccio_sd_s0>;
 	pinctrl-names = "default";
+	/* drop sdmmc0_pwren from SoC default pinctrl: unstable SDR104 re-init */
+	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_det &sdmmc0_bus4>;
 	status = "okay";
 };
 

--- a/patch/kernel/archive/rockchip64-7.0/dt/rk3576-nanopi-r76s.dts
+++ b/patch/kernel/archive/rockchip64-7.0/dt/rk3576-nanopi-r76s.dts
@@ -793,6 +793,8 @@
 	vmmc-supply = <&vcc_3v3_s3>;
 	vqmmc-supply = <&vccio_sd_s0>;
 	pinctrl-names = "default";
+	/* drop sdmmc0_pwren from SoC default pinctrl: unstable SDR104 re-init */
+	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_det &sdmmc0_bus4>;
 	status = "okay";
 };
 

--- a/patch/kernel/archive/rockchip64-7.1/dt/rk3576-nanopi-r76s.dts
+++ b/patch/kernel/archive/rockchip64-7.1/dt/rk3576-nanopi-r76s.dts
@@ -793,6 +793,8 @@
 	vmmc-supply = <&vcc_3v3_s3>;
 	vqmmc-supply = <&vccio_sd_s0>;
 	pinctrl-names = "default";
+	/* drop sdmmc0_pwren from SoC default pinctrl: unstable SDR104 re-init */
+	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_det &sdmmc0_bus4>;
 	status = "okay";
 };
 


### PR DESCRIPTION
# Description

Two fixes that together let the NanoPi R76S boot and run reliably from microSD, which matters for the eMMC-less units that have no other storage. The bootloader is now assembled through boot_merger so the Rockchip SD boost the BootROM needs is included; the previous binman image left it out, which gave these boards no serial output and no boot from SD. On the kernel side the SD node was inheriting the SoC default pinctrl that claims the card power-enable pin, which let the controller power-cycle the card during error recovery and produced an endless SDR104 re-tune loop with I/O errors; dropping that pin restores stable operation, the same change Rockchip made upstream for rk3576. Reported at https://forum.armbian.com/topic/59113-nanopi-r76s-rev2-unbootable/

# How Has This Been Tested?

Built the edge image and booted it from microSD on an R76S. Serial output now appears from the first stage and the card initialises once at SDR104 with no more re-tune loop or cache-flush I/O errors. On-device confirmation from an eMMC-less unit (the configuration in the report) would still be welcome.

- [x] build BOARD=nanopi-r76s BRANCH=edge
- [x] boot and run rootfs from microSD

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings