### PR TITLE
Family Meson S4T7: Opt-out of BTF `KERNEL_BTF=no`

### DIFF
--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -21,6 +21,7 @@ case $BRANCH in
 		declare -g KERNELPATCHDIR="archive/meson-s4t7-5.15"
 		declare -g COMMON_DRIVERS_SOURCE="${GITHUB_SOURCE}/khadas/common_drivers"
 		declare -g EXTRAWIFI=no
+		declare -g KERNEL_BTF=no
 		;;
 
 esac


### PR DESCRIPTION
Khadas VIM4 hangs and panics when booting Resolute.

```
Begin: Running /scripts/local-bottom ... done.
Begin: Running /scripts/init-bottom ... Timed out while waiting for udev queue to empty. done.
[  183.971953][5 T1     d.] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
[  183.972566][5 T1     d.] CPU: 5 PID: 1 Comm: init Not tainted 5.15.137-legacy-meson-s4t7 #1
[  183.973606][5 T1     d.] Hardware name: Khadas VIM4 (DT)
[  183.973611][5 T1     d.] Call trace:
[  183.973614][5 T1     d.]  dump_backtrace+0x0/0x1d0
[  183.973628][5 T1     d.]  show_stack+0x20/0x30
[  183.973635][5 T1     d.]  dump_stack_lvl+0x64/0x80
[  183.976453][5 T1     d.]  dump_stack+0x18/0x34
[  183.976463][5 T1     d.]  panic+0x1a0/0x364
[  183.976471][5 T1     d.]  do_exit+0xad8/0xb7c
[  183.976480][5 T1     d.]  do_group_exit+0x40/0xa0
[  183.976487][5 T1     d.]  __wake_up_parent+0x0/0x40
[  183.976495][5 T1     d.]  invoke_syscall+0x50/0x120
[  183.976504][5 T1     d.]  el0_svc_common.constprop.0+0x4c/0xf4
[  183.976512][5 T1     d.]  do_el0_svc+0x2c/0xa0
[  183.976520][5 T1     d.]  el0_svc+0x20/0x80
[  183.976529][5 T1     d.]  el0t_64_sync_handler+0x108/0x114
[  183.976537][5 T1     d.]  el0t_64_sync+0x1b0/0x1b4
[  183.976545][5 T1     d.] SMP: stopping secondary CPUs
[  183.976705][5 T1     d.] Kernel Offset: 0x369500000000 from 0xffff800008000000
[  183.976709][5 T1     d.] PHYS_OFFSET: 0xfffffe6a40000000
[  183.976712][5 T1     d.] CPU features: 0x0,0000c9a3,00000846
[  183.976717][5 T1     d.] Memory Limit: none
[  184.004309][5 T1     d.] Rebooting in 5 seconds..
[  189.035460][5 T1     d.] [pm]: Reset SDCARD power.
[  1T7:BL:b9e760;ID:1099107E4460030C;FEAT:30F:1FFF0000:B002F:1;POC:CF;RCY:0;OVD:0;DFU:0;SD:0;RD-0:0;CHK:0;SCS:0;
```
Declaring `KERNEL_BTF=no` resolves the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kernel build configuration settings for legacy kernel selection paths to ensure consistent module compilation behavior across supported platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->