### PR TITLE
board: aml-c400-plus: Fix eMMC boot format and partition layout

### DIFF
--- a/config/optional/boards/aml-c400-plus/_packages/bsp-cli/boot/armbianEnv.txt
+++ b/config/optional/boards/aml-c400-plus/_packages/bsp-cli/boot/armbianEnv.txt
@@ -1,4 +1,4 @@
-extraargs=earlycon rootflags=data=writeback rw no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0
+extraargs=earlycon rw no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0 amlogic.hdmitx=cec:0
 bootlogo=false
 verbosity=7
 console=both

--- a/config/optional/boards/aml-c400-plus/_packages/bsp-cli/root/fstab.template
+++ b/config/optional/boards/aml-c400-plus/_packages/bsp-cli/root/fstab.template
@@ -2,6 +2,6 @@
 #/dev/root	/		auto		noatime,errors=remount-ro	0 1
 #proc		/proc		proc		defaults				0 0
 
-/dev/root	/		ext4		defaults,noatime,errors=remount-ro	0 1
+LABEL=ROOT_EMMC	/		ext4		defaults,noatime,errors=remount-ro	0 1
 tmpfs		/tmp		tmpfs		defaults,nosuid				0 0
 LABEL=BOOT_EMMC	/boot		vfat		defaults				0 2

--- a/config/optional/boards/aml-c400-plus/_packages/bsp-cli/root/install-aml.sh
+++ b/config/optional/boards/aml-c400-plus/_packages/bsp-cli/root/install-aml.sh
@@ -123,8 +123,8 @@ if grep -q $PART_ROOT /proc/mounts ; then
 fi
 
 echo "Formatting ROOT partition..."
-mke2fs -F -q -t ext4 -L ROOT_EMMC -m 0 $PART_ROOT
-e2fsck -n $PART_ROOT
+mkfs.ext4 -F -q -O ^64bit -L ROOT_EMMC -m 0 "$PART_ROOT"
+#e2fsck -n $PART_ROOT
 echo "done."
 
 echo "Copying ROOTFS."


### PR DESCRIPTION
# Description
This PR fixes the eMMC boot failure on the 'aml-c400-plus' (Magicsee C400 Plus) TV Box. This issue is specifically triggered when building modern OS releases bundled with recent Linux Kernels (6.x and 7.x branches), where modern 'e2fsprogs' features break compatibility with legacy U-Boot.

# Changes
- Change default eMMC filesystem format to 32-bit (disable 64bit extension) to match legacy U-Boot capabilities.
- Update fstab template to map root partition via LABEL=ROOT_EMMC instead of deprecated /dev/root.
- Remove 'data=writeback' rootflag from armbianEnv.txt to improve data integrity on internal flash.
- Add 'amlogic.hdmitx=cec:0' boot argument to prevent HDMI-CEC initialization conflicts during startup.

# How Has This Been Tested?

Tested and verified fully working on live hardware booting directly from the eMMC.

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved system boot configuration for the AML C400 Plus board with enhanced filesystem checking
  * Enhanced root filesystem mounting reliability through label-based identification instead of device paths
  * Optimized ROOT partition formatting process during system installation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armbian/build/pull/9911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->