### PR TITLE
Fix H616/H618 HDMI audio clocking

### DIFF
--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
@@ -1,17 +1,48 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: The-going <48602507+The-going@users.noreply.github.com>
-Date: Mon, 26 May 2025 17:04:56 +0300
-Subject: sun50i-h616: Add the missing digital audio node
+From: joakimtoe <joakimtoe@gmail.com>
+Date: Sun, 31 May 2026 15:50:00 +0200
+Subject: sun50i-h616: Add digital audio node and fix HDMI audio clocking
 
+Add the missing AHUB DAM machine node and fix the H616/H618 HDMI audio
+clock path so the AHUB uses the real audio PLL family. HDMI audio can
+otherwise reach ALSA RUNNING state while staying silent because the AHUB
+is clocked from the audio-codec path and because the I2S BCLK divider is
+programmed two steps below the vendor divider value.
+
+Expose the real audio PLL clock IDs, allow pll-audio-hs to use the exact
+sigma-delta rates, parent the audio-hub module clock to pll-audio-4x, set
+the module clock to the full requested rate, and write the raw AHUB BCLK
+divider map value.
+
+On Orange Pi Zero 2W / H618 this makes 48 kHz stereo HDMI playback use
+pll-audio-hs/pll-audio-4x/audio-hub at 98.304 MHz and programs
+SUNXI_AHUB_I2S_CLKD(1) to 0x90.
+
+Signed-off-by: joakimtoe <joakimtoe@gmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 11 ++++++++++
- 1 file changed, 11 insertions(+)
+ arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 16 ++++++++++++++--
+ drivers/clk/sunxi-ng/ccu-sun50i-h616.c         |  4 +---
+ include/dt-bindings/clock/sun50i-h616-ccu.h    |  2 ++
+ sound/soc/sunxi_v2/snd_sunxi_ahub.c            |  4 ++--
+ sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c        | 28 +++++++++++++------------
+ 5 files changed, 34 insertions(+), 20 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -852,6 +852,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+@@ -1085,8 +1085,8 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+ 			compatible = "allwinner,sunxi-snd-plat-ahub_dam";
+ 			reg        = <0x05097000 0x1000>;
+ 			resets     = <&ccu RST_BUS_AUDIO_HUB>;
+-			clocks     = <&ccu CLK_AUDIO_CODEC_1X>,
+-				     <&ccu CLK_AUDIO_CODEC_4X>,
++			clocks     = <&ccu CLK_PLL_AUDIO_HS>,
++				     <&ccu CLK_PLL_AUDIO_4X>,
+ 				     <&ccu CLK_AUDIO_HUB>,
+ 				     <&ccu CLK_BUS_AUDIO_HUB>;
+                         clock-names =   "clk_pll_audio",
+@@ -1096,6 +1096,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
  			status = "disabled";
  		};
  
@@ -29,6 +60,125 @@ index 111111111111..222222222222 100644
  		ahub1_plat:ahub1_plat {
  			#sound-dai-cells = <0>;
  			compatible      = "allwinner,sunxi-snd-plat-ahub";
+@@ -1301,0 +1312,1 @@ hdmi: hdmi@6000000 {
++			#sound-dai-cells = <0>;
+diff --git a/drivers/clk/sunxi-ng/ccu-sun50i-h616.c b/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
+index 111111111111..222222222222 100644
+--- a/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
++++ b/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
+@@ -232,14 +232,12 @@ static struct ccu_nm pll_audio_hs_clk = {
+ 	.enable		= BIT(31),
+ 	.lock		= BIT(28),
+ 	.n		= _SUNXI_CCU_MULT_MIN(8, 8, 12),
+ 	.m		= _SUNXI_CCU_DIV(16, 6),
+ 	.sdm		= _SUNXI_CCU_SDM(pll_audio_sdm_table,
+ 					 BIT(24), 0x178, BIT(31)),
+-	.fixed_post_div = 2,
+ 	.common		= {
+-		.features	= CCU_FEATURE_FIXED_POSTDIV |
+-				  CCU_FEATURE_SIGMA_DELTA_MOD,
++		.features	= CCU_FEATURE_SIGMA_DELTA_MOD,
+ 		.reg		= 0x078,
+ 		.hw.init	= CLK_HW_INIT("pll-audio-hs", "osc24M",
+ 					      &ccu_nm_ops,
+ 					      CLK_SET_RATE_UNGATE),
+diff --git a/include/dt-bindings/clock/sun50i-h616-ccu.h b/include/dt-bindings/clock/sun50i-h616-ccu.h
+index 111111111111..222222222222 100644
+--- a/include/dt-bindings/clock/sun50i-h616-ccu.h
++++ b/include/dt-bindings/clock/sun50i-h616-ccu.h
+@@ -7,6 +7,8 @@
+ #define _DT_BINDINGS_CLK_SUN50I_H616_H_
+ 
+ #define CLK_PLL_PERIPH0		4
++#define CLK_PLL_AUDIO_HS	17
++#define CLK_PLL_AUDIO_4X	20
+ 
+ #define CLK_CPUX		21
+ 
+diff --git a/sound/soc/sunxi_v2/snd_sunxi_ahub.c b/sound/soc/sunxi_v2/snd_sunxi_ahub.c
+index 111111111111..222222222222 100644
+--- a/sound/soc/sunxi_v2/snd_sunxi_ahub.c
++++ b/sound/soc/sunxi_v2/snd_sunxi_ahub.c
+@@ -100,7 +100,7 @@ static int sunxi_ahub_dai_set_pll(struct snd_soc_dai *dai,
+                        return -EINVAL;
+                }
+        }
+-       if (clk_set_rate(clk_info->clk_module, freq_out / 2)) {
++       if (clk_set_rate(clk_info->clk_module, freq_out)) {
+                SND_LOG_ERR(HLOG, "freq : %u module clk unsupport\n", freq_out);
+                return -EINVAL;
+        }
+@@ -275,7 +275,7 @@ static int sunxi_ahub_dai_set_bclk_ratio(struct snd_soc_dai *dai, unsigned int
+ 
+        regmap_update_bits(regmap, SUNXI_AHUB_I2S_CLKD(tdm_num),
+                           0xf << I2S_CLKD_BCLKDIV,
+-                          (bclk_ratio - 2) << I2S_CLKD_BCLKDIV);
++                          bclk_ratio << I2S_CLKD_BCLKDIV);
+ 
+        return 0;
+ }
+diff --git a/sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c b/sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c
+index 111111111111..222222222222 100644
+--- a/sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c
++++ b/sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c
+@@ -370,19 +370,19 @@ static int snd_soc_sunxi_ahub_clk_init(struct platform_device *pdev,
+ 		ret = -EBUSY;
+ 		goto err_pll_clk;
+ 	}
+-	//clk_info->clk_pllx4 = of_clk_get_by_name(np, "clk_pll_audio_4x");
+-	//if (IS_ERR_OR_NULL(clk_info->clk_pllx4)) {
+-	//	SND_LOG_ERR(HLOG, "clk pllx4 get failed\n");
+-	//	ret = -EBUSY;
+-	//	goto err_pllx4_clk;
+-	//}
++	clk_info->clk_pllx4 = of_clk_get_by_name(np, "clk_pll_audio_4x");
++	if (IS_ERR_OR_NULL(clk_info->clk_pllx4)) {
++		SND_LOG_ERR(HLOG, "clk pllx4 get failed\n");
++		ret = -EBUSY;
++		goto err_pllx4_clk;
++	}
+ 
+ 	/* set ahub clk parent */
+-	//if (clk_set_parent(clk_info->clk_module, clk_info->clk_pllx4)) {
+-	//	SND_LOG_ERR(HLOG, "set parent of clk_module to pllx4 failed\n");
+-	//	ret = -EINVAL;
+-	//	goto err_set_parent_clk;
+-	//}
++	if (clk_set_parent(clk_info->clk_module, clk_info->clk_pllx4)) {
++		SND_LOG_ERR(HLOG, "set parent of clk_module to pllx4 failed\n");
++		ret = -EINVAL;
++		goto err_set_parent_clk;
++	}
+ 
+ 	/* enable clk of ahub */
+ 	if (clk_prepare_enable(clk_info->clk_pll)) {
+@@ -400,13 +400,11 @@ static int snd_soc_sunxi_ahub_clk_init(struct platform_device *pdev,
+ 	return 0;
+ 
+ err_module_clk_enable:
+-//	clk_disable_unprepare(clk_info->clk_pllx4);
+-//err_pllx4_clk_enable:
+ 	clk_disable_unprepare(clk_info->clk_pll);
+ err_pll_clk_enable:
+-//err_set_parent_clk:
+-//	clk_put(clk_info->clk_pllx4);
+-//err_pllx4_clk:
+-//	clk_put(clk_info->clk_pll);
++err_set_parent_clk:
++	clk_put(clk_info->clk_pllx4);
++err_pllx4_clk:
++	clk_put(clk_info->clk_pll);
+ err_pll_clk:
+ 	clk_put(clk_info->clk_module);
+@@ -481,8 +479,7 @@ static int sunxi_ahub_dam_dev_remove(struct platform_device *pdev)
+ 	clk_put(clk_info->clk_module);
+ 	clk_disable_unprepare(clk_info->clk_pll);
+ 	clk_put(clk_info->clk_pll);
+-	//clk_disable_unprepare(clk_info->clk_pllx4);
+-	//clk_put(clk_info->clk_pllx4);
++	clk_put(clk_info->clk_pllx4);
+ 	clk_disable_unprepare(clk_info->clk_bus);
+ 	clk_put(clk_info->clk_bus);
+ 	reset_control_assert(clk_info->clk_rst);
 -- 
 Armbian
-

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
@@ -1,17 +1,48 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: The-going <48602507+The-going@users.noreply.github.com>
-Date: Mon, 26 May 2025 17:04:56 +0300
-Subject: sun50i-h616: Add the missing digital audio node
+From: joakimtoe <joakimtoe@gmail.com>
+Date: Sun, 31 May 2026 15:50:00 +0200
+Subject: sun50i-h616: Add digital audio node and fix HDMI audio clocking
 
+Add the missing AHUB DAM machine node and fix the H616/H618 HDMI audio
+clock path so the AHUB uses the real audio PLL family. HDMI audio can
+otherwise reach ALSA RUNNING state while staying silent because the AHUB
+is clocked from the audio-codec path and because the I2S BCLK divider is
+programmed two steps below the vendor divider value.
+
+Expose the real audio PLL clock IDs, allow pll-audio-hs to use the exact
+sigma-delta rates, parent the audio-hub module clock to pll-audio-4x, set
+the module clock to the full requested rate, and write the raw AHUB BCLK
+divider map value.
+
+On Orange Pi Zero 2W / H618 this makes 48 kHz stereo HDMI playback use
+pll-audio-hs/pll-audio-4x/audio-hub at 98.304 MHz and programs
+SUNXI_AHUB_I2S_CLKD(1) to 0x90.
+
+Signed-off-by: joakimtoe <joakimtoe@gmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 11 ++++++++++
- 1 file changed, 11 insertions(+)
+ arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 16 ++++++++++++++--
+ drivers/clk/sunxi-ng/ccu-sun50i-h616.c         |  4 +---
+ include/dt-bindings/clock/sun50i-h616-ccu.h    |  2 ++
+ sound/soc/sunxi_v2/snd_sunxi_ahub.c            |  4 ++--
+ sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c        | 28 +++++++++++++------------
+ 5 files changed, 34 insertions(+), 20 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -904,6 +904,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+@@ -1085,8 +1085,8 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+ 			compatible = "allwinner,sunxi-snd-plat-ahub_dam";
+ 			reg        = <0x05097000 0x1000>;
+ 			resets     = <&ccu RST_BUS_AUDIO_HUB>;
+-			clocks     = <&ccu CLK_AUDIO_CODEC_1X>,
+-				     <&ccu CLK_AUDIO_CODEC_4X>,
++			clocks     = <&ccu CLK_PLL_AUDIO_HS>,
++				     <&ccu CLK_PLL_AUDIO_4X>,
+ 				     <&ccu CLK_AUDIO_HUB>,
+ 				     <&ccu CLK_BUS_AUDIO_HUB>;
+                         clock-names =   "clk_pll_audio",
+@@ -1096,6 +1096,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
  			status = "disabled";
  		};
  
@@ -29,6 +60,125 @@ index 111111111111..222222222222 100644
  		ahub1_plat:ahub1_plat {
  			#sound-dai-cells = <0>;
  			compatible      = "allwinner,sunxi-snd-plat-ahub";
+@@ -1301,0 +1312,1 @@ hdmi: hdmi@6000000 {
++			#sound-dai-cells = <0>;
+diff --git a/drivers/clk/sunxi-ng/ccu-sun50i-h616.c b/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
+index 111111111111..222222222222 100644
+--- a/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
++++ b/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
+@@ -232,14 +232,12 @@ static struct ccu_nm pll_audio_hs_clk = {
+ 	.enable		= BIT(31),
+ 	.lock		= BIT(28),
+ 	.n		= _SUNXI_CCU_MULT_MIN(8, 8, 12),
+ 	.m		= _SUNXI_CCU_DIV(16, 6),
+ 	.sdm		= _SUNXI_CCU_SDM(pll_audio_sdm_table,
+ 					 BIT(24), 0x178, BIT(31)),
+-	.fixed_post_div = 2,
+ 	.common		= {
+-		.features	= CCU_FEATURE_FIXED_POSTDIV |
+-				  CCU_FEATURE_SIGMA_DELTA_MOD,
++		.features	= CCU_FEATURE_SIGMA_DELTA_MOD,
+ 		.reg		= 0x078,
+ 		.hw.init	= CLK_HW_INIT("pll-audio-hs", "osc24M",
+ 					      &ccu_nm_ops,
+ 					      CLK_SET_RATE_UNGATE),
+diff --git a/include/dt-bindings/clock/sun50i-h616-ccu.h b/include/dt-bindings/clock/sun50i-h616-ccu.h
+index 111111111111..222222222222 100644
+--- a/include/dt-bindings/clock/sun50i-h616-ccu.h
++++ b/include/dt-bindings/clock/sun50i-h616-ccu.h
+@@ -7,6 +7,8 @@
+ #define _DT_BINDINGS_CLK_SUN50I_H616_H_
+ 
+ #define CLK_PLL_PERIPH0		4
++#define CLK_PLL_AUDIO_HS	17
++#define CLK_PLL_AUDIO_4X	20
+ 
+ #define CLK_CPUX		21
+ 
+diff --git a/sound/soc/sunxi_v2/snd_sunxi_ahub.c b/sound/soc/sunxi_v2/snd_sunxi_ahub.c
+index 111111111111..222222222222 100644
+--- a/sound/soc/sunxi_v2/snd_sunxi_ahub.c
++++ b/sound/soc/sunxi_v2/snd_sunxi_ahub.c
+@@ -100,7 +100,7 @@ static int sunxi_ahub_dai_set_pll(struct snd_soc_dai *dai,
+                        return -EINVAL;
+                }
+        }
+-       if (clk_set_rate(clk_info->clk_module, freq_out / 2)) {
++       if (clk_set_rate(clk_info->clk_module, freq_out)) {
+                SND_LOG_ERR(HLOG, "freq : %u module clk unsupport\n", freq_out);
+                return -EINVAL;
+        }
+@@ -275,7 +275,7 @@ static int sunxi_ahub_dai_set_bclk_ratio(struct snd_soc_dai *dai, unsigned int
+ 
+        regmap_update_bits(regmap, SUNXI_AHUB_I2S_CLKD(tdm_num),
+                           0xf << I2S_CLKD_BCLKDIV,
+-                          (bclk_ratio - 2) << I2S_CLKD_BCLKDIV);
++                          bclk_ratio << I2S_CLKD_BCLKDIV);
+ 
+        return 0;
+ }
+diff --git a/sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c b/sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c
+index 111111111111..222222222222 100644
+--- a/sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c
++++ b/sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c
+@@ -370,19 +370,19 @@ static int snd_soc_sunxi_ahub_clk_init(struct platform_device *pdev,
+ 		ret = -EBUSY;
+ 		goto err_pll_clk;
+ 	}
+-	//clk_info->clk_pllx4 = of_clk_get_by_name(np, "clk_pll_audio_4x");
+-	//if (IS_ERR_OR_NULL(clk_info->clk_pllx4)) {
+-	//	SND_LOG_ERR(HLOG, "clk pllx4 get failed\n");
+-	//	ret = -EBUSY;
+-	//	goto err_pllx4_clk;
+-	//}
++	clk_info->clk_pllx4 = of_clk_get_by_name(np, "clk_pll_audio_4x");
++	if (IS_ERR_OR_NULL(clk_info->clk_pllx4)) {
++		SND_LOG_ERR(HLOG, "clk pllx4 get failed\n");
++		ret = -EBUSY;
++		goto err_pllx4_clk;
++	}
+ 
+ 	/* set ahub clk parent */
+-	//if (clk_set_parent(clk_info->clk_module, clk_info->clk_pllx4)) {
+-	//	SND_LOG_ERR(HLOG, "set parent of clk_module to pllx4 failed\n");
+-	//	ret = -EINVAL;
+-	//	goto err_set_parent_clk;
+-	//}
++	if (clk_set_parent(clk_info->clk_module, clk_info->clk_pllx4)) {
++		SND_LOG_ERR(HLOG, "set parent of clk_module to pllx4 failed\n");
++		ret = -EINVAL;
++		goto err_set_parent_clk;
++	}
+ 
+ 	/* enable clk of ahub */
+ 	if (clk_prepare_enable(clk_info->clk_pll)) {
+@@ -400,13 +400,11 @@ static int snd_soc_sunxi_ahub_clk_init(struct platform_device *pdev,
+ 	return 0;
+ 
+ err_module_clk_enable:
+-//	clk_disable_unprepare(clk_info->clk_pllx4);
+-//err_pllx4_clk_enable:
+ 	clk_disable_unprepare(clk_info->clk_pll);
+ err_pll_clk_enable:
+-//err_set_parent_clk:
+-//	clk_put(clk_info->clk_pllx4);
+-//err_pllx4_clk:
+-//	clk_put(clk_info->clk_pll);
++err_set_parent_clk:
++	clk_put(clk_info->clk_pllx4);
++err_pllx4_clk:
++	clk_put(clk_info->clk_pll);
+ err_pll_clk:
+ 	clk_put(clk_info->clk_module);
+@@ -481,8 +479,7 @@ static int sunxi_ahub_dam_dev_remove(struct platform_device *pdev)
+ 	clk_put(clk_info->clk_module);
+ 	clk_disable_unprepare(clk_info->clk_pll);
+ 	clk_put(clk_info->clk_pll);
+-	//clk_disable_unprepare(clk_info->clk_pllx4);
+-	//clk_put(clk_info->clk_pllx4);
++	clk_put(clk_info->clk_pllx4);
+ 	clk_disable_unprepare(clk_info->clk_bus);
+ 	clk_put(clk_info->clk_bus);
+ 	reset_control_assert(clk_info->clk_rst);
 -- 
 Armbian
-


### PR DESCRIPTION
  # Description

  Fix HDMI audio on H616/H618 boards using the Armbian sunxi64 current and edge kernel patch stacks.

  On Orange Pi Zero 2W / H618, HDMI video worked and the HDMI ALSA card was created correctly. ELD was valid, ASoC routing was active, DW-HDMI
  I2S setup was reached, and PCM playback entered `RUNNING`, but no audible sound was produced by the TV.

  This PR updates the existing H616 digital audio patch for both `sunxi-6.18` and `sunxi-7.0` to:

  - expose/use the real H616 audio PLL clocks for AHUB: `CLK_PLL_AUDIO_HS` and `CLK_PLL_AUDIO_4X`
  - remove the fixed post divider from `pll-audio-hs` so exact SDM audio rates are used
  - parent the AHUB module clock to `pll-audio-4x`
  - set the AHUB module rate to the full requested output rate instead of `freq_out / 2`
  - program the AHUB BCLK divider field with the raw divider map value instead of `bclk_ratio - 2`
  - make the HDMI controller node a DAI provider with `#sound-dai-cells = <0>`, so a separate local `hdmi-audio-fix` overlay is no longer needed

  GitHub issue reference: none
  Jira reference number: none

  # Documentation summary for feature / change

  No main documentation entry is expected. This is a kernel patch-stack fix for HDMI audio behavior on affected H616/H618 boards.

  # How Has This Been Tested?

  Tested on Orange Pi Zero 2W / H618 with Armbian sunxi64 Linux 6.18.33.

  - [x] Verified original failure mode: HDMI card present, ELD valid, PCM `RUNNING`, no audible sound
  - [x] Verified BCLK-only patch was not sufficient
  - [x] Verified final patch set with HDMI as card 0 while analog codec was disabled
  - [x] Verified final patch set without local `hdmi-audio-fix` overlay:
    - `user_overlays=`
    - HDMI card present as card 1 with analog codec enabled
    - ELD valid
    - `speaker-test -D hw:1,0 -c 2 -r 48000 -F S32_LE -t sine` runs
    - `speaker-test -D hw:1,0 -c 2 -r 48000 -F S16_LE -t sine` runs
    - PCM state `RUNNING`
    - `0x0509730c = 0x00000090`
    - `pll-audio-hs = 98.304 MHz`
    - `pll-audio-4x = 98.304 MHz`
    - `audio-hub = 98.304 MHz`

  Also compared runtime AHUB/I2S/DW-HDMI registers against a working Batocera H616/H618 reference board. The relevant playback clock/register
  state matched after this fix.

  # Checklist:

  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HDMI audio clock configuration on H616/H618 devices to use correct audio PLL sources.
  * Corrected audio module clock programming and I2S divider calculations in the audio driver for proper audio output routing.
  * Restored proper clock parent relationships to improve overall audio functionality stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->