### PR TITLE
Update radxa-e54c.conf - fix netplan ethenet wan port.

### DIFF
--- a/config/boards/radxa-e54c.conf
+++ b/config/boards/radxa-e54c.conf
@@ -79,5 +79,5 @@ function post_post_debootstrap_tweaks__radxa_e54c_wan_fix() {
 
     # Boards ethernet interfaces are lan1, lan2, lan3 and wan
     # wan is not detected by pattern "wan[0-9]*" so replace with "wan" if it exists (only in netplan builds)
-    sed -i 's/wan\[0-9\]\*/wan/g' ${SDCARD}/etc/netplan/10-dhcp-all-interfaces.yaml
+    sed -i 's/wan\[0-9\]\*/wan/g' "${SDCARD}/etc/netplan/10-dhcp-all-interfaces.yaml"
 }

--- a/config/boards/radxa-e54c.conf
+++ b/config/boards/radxa-e54c.conf
@@ -61,7 +61,7 @@ function post_family_tweaks_bsp__radxa_e54c_enable_leds() {
 		invert=0
 	EOF
 	
-        # Internal Ethernet interface can't get an IP address and shouldn't be managed by NetworkManager so make it unmanaged.
+    # Internal Ethernet interface can't get an IP address and shouldn't be managed by NetworkManager so make it unmanaged.
 	display_alert "$BOARD" "Creating Board Support Internal Switch Config" "info"
 	cat <<- EOF > "${destination}"/etc/NetworkManager/conf.d/99-unmanaged-devices.conf
 	[main]
@@ -71,4 +71,13 @@ function post_family_tweaks_bsp__radxa_e54c_enable_leds() {
 
 	EOF
 	
+}
+
+function post_post_debootstrap_tweaks__radxa_e54c_wan_fix() {
+    # Only apply to images with 10-dhcp-all-interfaces.yaml present
+	[[ -e "${SDCARD}/etc/netplan/10-dhcp-all-interfaces.yaml" ]] || return 0
+
+    # Boards ethernet interfaces are lan1, lan2, lan3 and wan
+    # wan is not detected by pattern "wan[0-9]*" so replace with "wan" if it exists (only in netplan builds)
+    sed -i 's/wan\[0-9\]\*/wan/g' ${SDCARD}/etc/netplan/10-dhcp-all-interfaces.yaml
 }


### PR DESCRIPTION
# Description
The Radxa E54C exposes interfaces lan1, lan2, lan3 and wan.   The Armbian netplan config uses a match pattern "wan[0-9]*" which does not match the bare interface name "wan" so replace with "wan" if the 10-dhcp-all-interfaces.yaml file exists (only in netplan builds).

# How Has This Been Tested?

- [x] Tested on Radxa E54C minimal (Netplan)
- [x] Tested on Radxa E54C Gnome (NetworkManager)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WAN interface naming on Radxa E54C boards so network configuration now normalizes WAN identifiers, improving connectivity stability and preventing interface naming issues.

* **Chores**
  * Minor formatting tweaks to board configuration files for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->