### PR TITLE
 mainline: bump to 7.1-rc6

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0           # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "7.1" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v7.1-rc3"
+		declare -g KERNELBRANCH="tag:v7.1-rc6"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }
@@ -26,11 +26,11 @@ function mainline_kernel_decide_version__upstream_release_candidate_number() {
 
  # Example: 6.7-rc7 was released by Linus, but kernel.org git and google git mirrors took a while to catch up; change the source to pull directly from Linus.
  # This was necessary for a few days in late December 2023, but no longer; tag was pushed on 28/Dec/2023.
- function mainline_kernel_decide_version__750_use_torvalds_for_7.1-rc3() {
- 	if [[ "${KERNELBRANCH}" == 'tag:v7.1-rc3' ]]; then
- 		display_alert "Using Linus kernel repo for 7.1-rc3" "${KERNELBRANCH}" "warn"
+ function mainline_kernel_decide_version__750_use_torvalds_for_7.1-rc6() {
+ 	if [[ "${KERNELBRANCH}" == 'tag:v7.1-rc6' ]]; then
+ 		display_alert "Using Linus kernel repo for 7.1-rc6" "${KERNELBRANCH}" "warn"
  		declare -g KERNELSOURCE="https://github.com/torvalds/linux.git"
- 		display_alert "mainline-kernel: missing torvalds tag on 7.1-rc3" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
+ 		display_alert "mainline-kernel: missing torvalds tag on 7.1-rc6" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
  	fi
  }
 

--- a/patch/kernel/archive/rockchip64-7.1/board-nanopi-m4v2-dts-add-sound-card.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-nanopi-m4v2-dts-add-sound-card.patch
@@ -169,7 +169,7 @@ diff --git a/sound/soc/codecs/Kconfig b/sound/soc/codecs/Kconfig
 index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/Kconfig
 +++ b/sound/soc/codecs/Kconfig
-@@ -1846,7 +1846,7 @@ config SND_SOC_RT5645
+@@ -1843,7 +1843,7 @@ config SND_SOC_RT5645
  	depends on I2C
  
  config SND_SOC_RT5651

--- a/patch/kernel/archive/rockchip64-7.1/rk3399-rp64-pcie-Reimplement-rockchip-PCIe-bus-scan-delay.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3399-rp64-pcie-Reimplement-rockchip-PCIe-bus-scan-delay.patch
@@ -20,7 +20,7 @@ diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/adm
 index 111111111111..222222222222 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
-@@ -5331,6 +5331,14 @@ Kernel parameters
+@@ -5313,6 +5313,14 @@ Kernel parameters
  		nomsi	Do not use MSI for native PCIe PME signaling (this makes
  			all PCIe root ports use INTx for all services).
  

--- a/patch/kernel/archive/rockchip64-7.1/rk3399-usbc-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3399-usbc-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
@@ -13,7 +13,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3279,7 +3279,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3306,7 +3306,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  {
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
@@ -22,7 +22,7 @@ index 111111111111..222222222222 100644
  
  	if (!port->partner_pd)
  		port->partner_pd = usb_power_delivery_register(NULL, &desc);
-@@ -3289,11 +3289,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3316,11 +3316,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	memcpy(caps.pdo, port->source_caps, sizeof(u32) * port->nr_source_caps);
  	caps.role = TYPEC_SOURCE;
  

--- a/patch/kernel/archive/rockchip64-7.1/rk3399-usbc-usb-typec-altmodes-displayport-Respect-DP_CAP_RECEPT.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3399-usbc-usb-typec-altmodes-displayport-Respect-DP_CAP_RECEPT.patch
@@ -51,7 +51,7 @@ index 111111111111..222222222222 100644
  	/* Determining the initial pin assignment. */
  	if (!DP_CONF_GET_PIN_ASSIGN(dp->data.conf)) {
  		/* Is USB together with DP preferred */
-@@ -819,16 +837,38 @@ int dp_altmode_probe(struct typec_altmode *alt)
+@@ -821,16 +839,38 @@ int dp_altmode_probe(struct typec_altmode *alt)
  	struct typec_altmode *plug = typec_altmode_get_plug(alt, TYPEC_PLUG_SOP_P);
  	struct fwnode_handle *fwnode;
  	struct dp_altmode *dp;

--- a/patch/kernel/archive/rockchip64-7.1/rk3399-usbc-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3399-usbc-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3280,15 +3280,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3307,15 +3307,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -45,7 +45,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -3303,15 +3310,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
+@@ -3330,15 +3337,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -72,7 +72,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -7716,10 +7730,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
+@@ -7743,10 +7757,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
  		port->pds[i] = usb_power_delivery_register(port->dev, &desc);
  		if (IS_ERR(port->pds[i])) {
  			ret = PTR_ERR(port->pds[i]);

--- a/patch/kernel/archive/rockchip64-7.1/rk3399-usbc-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3399-usbc-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
@@ -37,7 +37,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -2028,6 +2028,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
+@@ -2030,6 +2030,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
  		return;
  
  	for (i = 0; i < modep->altmodes; i++) {

--- a/patch/kernel/archive/rockchip64-7.1/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3528-10-phy-rockchip-inno-usb2-Add-support-for-RK3528.patch
@@ -21,8 +21,8 @@ next-20250910-rk3528 branch.
 
 Signed-off-by: Shlomi Marco <s.marco@rubycomm.com>
 ---
- drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 164 ++++++++--
- 1 file changed, 131 insertions(+), 33 deletions(-)
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 150 ++++++++--
+ 1 file changed, 124 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 index 111111111111..222222222222 100644
@@ -141,30 +141,23 @@ index 111111111111..222222222222 100644
  }
  
  static unsigned long
-@@ -1360,27 +1381,22 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1360,7 +1381,11 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  	if (!rphy)
  		return -ENOMEM;
  
 -	if (!dev->parent || !dev->parent->of_node) {
--		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
--		if (IS_ERR(rphy->grf)) {
--			dev_err(dev, "failed to locate usbgrf\n");
--			return PTR_ERR(rphy->grf);
--		}
 +	if (!dev->parent || !dev->parent->of_node ||
 +	    of_property_present(np, "rockchip,usbgrf")) {
 +		rphy->phy_base = device_node_to_regmap(np);
 +		if (IS_ERR(rphy->phy_base))
 +			return PTR_ERR(rphy->phy_base);
-+		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
-+		if (IS_ERR(rphy->grf)) {
-+			dev_err(dev, "failed to locate usbgrf\n");
-+			return PTR_ERR(rphy->grf);
-+		}
- 	} else {
+ 		rphy->grf = syscon_regmap_lookup_by_phandle(np, "rockchip,usbgrf");
+ 		if (IS_ERR(rphy->grf)) {
+ 			dev_err(dev, "failed to locate usbgrf\n");
+@@ -1370,16 +1395,7 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  		rphy->grf = syscon_node_to_regmap(dev->parent->of_node);
--		if (IS_ERR(rphy->grf))
--			return PTR_ERR(rphy->grf);
+ 		if (IS_ERR(rphy->grf))
+ 			return PTR_ERR(rphy->grf);
 -	}
 -
 -	if (of_device_is_compatible(np, "rockchip,rv1108-usb2phy")) {
@@ -175,13 +168,10 @@ index 111111111111..222222222222 100644
 -			return PTR_ERR(rphy->usbgrf);
 -	} else {
 -		rphy->usbgrf = NULL;
-+		if (IS_ERR(rphy->grf))
-+			return PTR_ERR(rphy->grf);
 +		rphy->phy_base = rphy->grf;
  	}
  
  	if (of_property_read_u32_index(np, "reg", 0, &reg)) {
- 		dev_err(dev, "the reg property is not assigned in %pOFn node\n", np);
 @@ -1521,6 +1537,36 @@ static int rk3128_usb2phy_tuning(struct rockchip_usb2phy *rphy)
  				BIT(2) << BIT_WRITEABLE_SHIFT | 0);
  }
@@ -287,3 +277,4 @@ index 111111111111..222222222222 100644
  	{ .compatible = "rockchip,rk3576-usb2phy", .data = &rk3576_phy_cfgs },
 -- 
 Armbian
+

--- a/patch/kernel/archive/rockchip64-7.1/rk3528-13-phy-rockchip-inno-usb2-fix-otg-timer-cleanup.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3528-13-phy-rockchip-inno-usb2-fix-otg-timer-cleanup.patch
@@ -42,7 +42,7 @@ index 111111111111..222222222222 100644
  static int rockchip_usb2phy_probe(struct platform_device *pdev)
  {
  	struct device *dev = &pdev->dev;
-@@ -1495,6 +1510,13 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1499,6 +1514,13 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
  			if (ret)
  				goto put_child;
  		}


### PR DESCRIPTION
# Description

- as per title
- A dts introduced with https://github.com/armbian/build/pull/9880 broke compilation and was removed during build tests. I assume https://github.com/armbian/build/pull/9907 fixes this.
- rewrite rockchip64-7.1 patchset to remove fuzz
- meson64-7.1 is fine

# How Has This Been Tested?

- [x] build rockchip64
- [x] build meson64

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio support for NanoPi M4V2 with RT5651 codec integration.
  * Added configurable Rockchip PCIe bus-scan delay via kernel parameter.
  * Added USB2 PHY support for RK3528 SoC.

* **Bug Fixes**
  * Fixed USB Type-C power delivery capabilities registration handling.
  * Fixed RK3528 USB2 PHY delayed-work cleanup to prevent resource leaks.

* **Chores**
  * Updated mainline kernel version to 7.1-rc6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->