### PR TITLE
qrb2210: fix U-Boot load addresses and root partition for 2GB variant

### DIFF
--- a/config/bootscripts/boot-qrb2210.cmd
+++ b/config/bootscripts/boot-qrb2210.cmd
@@ -3,12 +3,14 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-# Set load addresses for Qualcomm QRB2210
-# These must be set explicitly because ABL overwrites defaults at runtime
-setenv kernel_addr_r "0xc0000000"
-setenv fdt_addr_r "0xc3000000"
-setenv ramdisk_addr_r "0xc4000000"
-setenv load_addr "0xd4000000"
+# Set load addresses for Qualcomm QRB2210 / Imola (2 GiB RAM @ 0x40000000–0x7eb00000, 0x80000000–0xc0000000).
+# ABL overwrites U-Boot defaults at runtime; these must be set in the script.
+# 0xc0000000+ is past the end of RAM — U-Boot 2026.01 LMB rejects loads there (see boot log far=0xc3000000).
+setenv kernel_addr_r "0x42000000"
+setenv fdt_addr_r "0x48000000"
+setenv ramdisk_addr_r "0x82000000"
+# Aux loads (env, dtbos). Keep below 0x8a800000 where boot.scr is sourced from.
+setenv load_addr "0x90000000"
 setenv overlay_error "false"
 
 # Qualcomm eMMC device and boot partition (0x43 = GPT partition 67 "efi")
@@ -17,7 +19,7 @@ setenv devnum "0"
 test -n "${distro_bootpart}" || setenv distro_bootpart "43"
 
 # default values
-setenv rootdev "/dev/mmcblk0p1"
+setenv rootdev "/dev/mmcblk0p68"
 setenv verbosity "1"
 setenv console "serial"
 setenv bootlogo "false"

--- a/config/bootscripts/boot-qrb2210.cmd
+++ b/config/bootscripts/boot-qrb2210.cmd
@@ -9,7 +9,7 @@
 setenv kernel_addr_r "0x42000000"
 setenv fdt_addr_r "0x48000000"
 setenv ramdisk_addr_r "0x82000000"
-# Aux loads (env, dtbos). Keep below 0x8a800000 where boot.scr is sourced from.
+# Aux loads (env, dtbos). Keep above 0x8a800000 where boot.scr is sourced from.
 setenv load_addr "0x90000000"
 setenv overlay_error "false"
 


### PR DESCRIPTION


# Description

On Arduino UNO Q, 2 GiB RAM ends at 0xc0000000. kernel/fdt/ramdisk addresses at 0xc0..0xc4 cause U-Boot LMB "overwrite reserved memory" and abort (e.g. far 0xc3000000). 


[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: https://github.com/armbian/community/issues/49
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change
Use addresses within 0x40000000–0x7eb00000 and 0x80000000–0xc0000000.

# How Has This Been Tested?
Successful boot.
root@arduino-uno-q:~# cat /etc/os-release 
PRETTY_NAME="Armbian-unofficial 26.05.0-trunk trixie"
NAME="Debian GNU/Linux"
VERSION_ID="13"
VERSION="13 (trixie)"
VERSION_CODENAME=trixie
DEBIAN_VERSION_FULL=13.5
ID=debian
HOME_URL="https://www.armbian.com"
SUPPORT_URL="https://forum.armbian.com"
BUG_REPORT_URL="https://www.armbian.com/bugs"
ARMBIAN_PRETTY_NAME="Armbian-unofficial 26.05.0-trunk trixie"

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._


# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated boot configuration for the Qualcomm QRB2210 platform: refined memory load locations and clarified boot comments to avoid invalid memory targets.
  * Changed the default root filesystem partition device.
  * These updates reduce boot failures and improve startup reliability on affected hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->