### PR TITLE
nanopi-r76s: fix slow WiFi by enabling SDIO SDR104

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3576-nanopi-r76s.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3576-nanopi-r76s.dts
@@ -753,6 +753,7 @@
 &sdio {
 	max-frequency = <200000000>;
 	bus-width = <4>;
+	cap-sd-highspeed;
 	cap-sdio-irq;
 	disable-wp;
 	keep-power-in-suspend;

--- a/patch/kernel/archive/rockchip64-6.18/mmc-sdio-skip-cmd11-voltage-switch-when-already-1v8.patch
+++ b/patch/kernel/archive/rockchip64-6.18/mmc-sdio-skip-cmd11-voltage-switch-when-already-1v8.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Wed, 3 Jun 2026 17:28:00 +0000
+Subject: mmc: sdio: skip the 1.8V switch when the host already signals at 1.8V
+
+A UHS-capable SDIO card can report S18A=1 even when the host signalling
+is already pinned to 1.8V. The core then issues CMD11 anyway, and with no
+real 3.3V to 1.8V transition the controller can stall on the voltage-switch
+clock update and fall back to high speed.
+
+Skip the switch when ios.signal_voltage is already 1.8V, the same guard
+mmc_sd_init_card() uses on the SD path. This lets an RTL8822CS on a
+fixed-1.8V rail come up at SDR104.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ drivers/mmc/core/sdio.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/core/sdio.c b/drivers/mmc/core/sdio.c
+index 111111111111..222222222222 100644
+--- a/drivers/mmc/core/sdio.c
++++ b/drivers/mmc/core/sdio.c
+@@ -738,8 +738,14 @@ static int mmc_sdio_init_card(struct mmc_host *host, u32 ocr,
+ 	 * fails to check rocr & R4_18V_PRESENT,  but we still need to
+ 	 * try to init uhs card. sdio_read_cccr will take over this task
+ 	 * to make sure which speed mode should work.
++	 *
++	 * If the host already signals at 1.8V there is nothing to switch.
++	 * Some cards still report S18A=1, so guard CMD11 explicitly to avoid
++	 * a redundant voltage switch that can stall the controller. Mirrors
++	 * mmc_sd_init_card().
+ 	 */
+-	if (rocr & ocr & R4_18V_PRESENT) {
++	if ((rocr & ocr & R4_18V_PRESENT) &&
++	    host->ios.signal_voltage != MMC_SIGNAL_VOLTAGE_180) {
+ 		err = mmc_set_uhs_voltage(host, ocr_card);
+ 		if (err == -EAGAIN) {
+ 			mmc_sdio_pre_init(host, ocr_card, card);
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.0/dt/rk3576-nanopi-r76s.dts
+++ b/patch/kernel/archive/rockchip64-7.0/dt/rk3576-nanopi-r76s.dts
@@ -753,6 +753,7 @@
 &sdio {
 	max-frequency = <200000000>;
 	bus-width = <4>;
+	cap-sd-highspeed;
 	cap-sdio-irq;
 	disable-wp;
 	keep-power-in-suspend;

--- a/patch/kernel/archive/rockchip64-7.0/mmc-sdio-skip-cmd11-voltage-switch-when-already-1v8.patch
+++ b/patch/kernel/archive/rockchip64-7.0/mmc-sdio-skip-cmd11-voltage-switch-when-already-1v8.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Wed, 3 Jun 2026 17:28:00 +0000
+Subject: mmc: sdio: skip the 1.8V switch when the host already signals at 1.8V
+
+A UHS-capable SDIO card can report S18A=1 even when the host signalling
+is already pinned to 1.8V. The core then issues CMD11 anyway, and with no
+real 3.3V to 1.8V transition the controller can stall on the voltage-switch
+clock update and fall back to high speed.
+
+Skip the switch when ios.signal_voltage is already 1.8V, the same guard
+mmc_sd_init_card() uses on the SD path. This lets an RTL8822CS on a
+fixed-1.8V rail come up at SDR104.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ drivers/mmc/core/sdio.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/core/sdio.c b/drivers/mmc/core/sdio.c
+index 111111111111..222222222222 100644
+--- a/drivers/mmc/core/sdio.c
++++ b/drivers/mmc/core/sdio.c
+@@ -738,8 +738,14 @@ static int mmc_sdio_init_card(struct mmc_host *host, u32 ocr,
+ 	 * fails to check rocr & R4_18V_PRESENT,  but we still need to
+ 	 * try to init uhs card. sdio_read_cccr will take over this task
+ 	 * to make sure which speed mode should work.
++	 *
++	 * If the host already signals at 1.8V there is nothing to switch.
++	 * Some cards still report S18A=1, so guard CMD11 explicitly to avoid
++	 * a redundant voltage switch that can stall the controller. Mirrors
++	 * mmc_sd_init_card().
+ 	 */
+-	if (rocr & ocr & R4_18V_PRESENT) {
++	if ((rocr & ocr & R4_18V_PRESENT) &&
++	    host->ios.signal_voltage != MMC_SIGNAL_VOLTAGE_180) {
+ 		err = mmc_set_uhs_voltage(host, ocr_card);
+ 		if (err == -EAGAIN) {
+ 			mmc_sdio_pre_init(host, ocr_card, card);
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.1/dt/rk3576-nanopi-r76s.dts
+++ b/patch/kernel/archive/rockchip64-7.1/dt/rk3576-nanopi-r76s.dts
@@ -753,6 +753,7 @@
 &sdio {
 	max-frequency = <200000000>;
 	bus-width = <4>;
+	cap-sd-highspeed;
 	cap-sdio-irq;
 	disable-wp;
 	keep-power-in-suspend;

--- a/patch/kernel/archive/rockchip64-7.1/mmc-sdio-skip-cmd11-voltage-switch-when-already-1v8.patch
+++ b/patch/kernel/archive/rockchip64-7.1/mmc-sdio-skip-cmd11-voltage-switch-when-already-1v8.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Wed, 3 Jun 2026 17:28:00 +0000
+Subject: mmc: sdio: skip the 1.8V switch when the host already signals at 1.8V
+
+A UHS-capable SDIO card can report S18A=1 even when the host signalling
+is already pinned to 1.8V. The core then issues CMD11 anyway, and with no
+real 3.3V to 1.8V transition the controller can stall on the voltage-switch
+clock update and fall back to high speed.
+
+Skip the switch when ios.signal_voltage is already 1.8V, the same guard
+mmc_sd_init_card() uses on the SD path. This lets an RTL8822CS on a
+fixed-1.8V rail come up at SDR104.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ drivers/mmc/core/sdio.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/core/sdio.c b/drivers/mmc/core/sdio.c
+index 111111111111..222222222222 100644
+--- a/drivers/mmc/core/sdio.c
++++ b/drivers/mmc/core/sdio.c
+@@ -738,8 +738,14 @@ static int mmc_sdio_init_card(struct mmc_host *host, u32 ocr,
+ 	 * fails to check rocr & R4_18V_PRESENT,  but we still need to
+ 	 * try to init uhs card. sdio_read_cccr will take over this task
+ 	 * to make sure which speed mode should work.
++	 *
++	 * If the host already signals at 1.8V there is nothing to switch.
++	 * Some cards still report S18A=1, so guard CMD11 explicitly to avoid
++	 * a redundant voltage switch that can stall the controller. Mirrors
++	 * mmc_sd_init_card().
+ 	 */
+-	if (rocr & ocr & R4_18V_PRESENT) {
++	if ((rocr & ocr & R4_18V_PRESENT) &&
++	    host->ios.signal_voltage != MMC_SIGNAL_VOLTAGE_180) {
+ 		err = mmc_set_uhs_voltage(host, ocr_card);
+ 		if (err == -EAGAIN) {
+ 			mmc_sdio_pre_init(host, ocr_card, card);
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

The R76S WiFi (RTL8822CS on M.2 SDIO) never came up in UHS. The card runs on a fixed-1.8V rail yet still sets S18A=1, so the core sent CMD11. There is no real voltage transition to make, the dw_mmc clock update times out, and the bus drops to high speed.

The fix skips that switch when the host already signals 1.8V, matching the guard in mmc_sd_init_card(). It lands in current, edge and bleedingedge. cap-sd-highspeed on the node keeps a 50MHz path if SDR104 tuning ever fails.

# How Has This Been Tested?

Built edge (7.0.11), flashed on an R76S, iperf3 over WiFi to the gateway.

- [x] Before: `high speed SDIO card` at 50MHz, ~51 down / ~23 up Mbit/s
- [x] After: `UHS-I speed SDR104 SDIO card` at 198MHz, ~210 down / ~52 up Mbit/s

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SD high-speed mode support for SDIO controllers across multiple kernel versions.

* **Bug Fixes**
  * Fixed redundant voltage-switch sequences that could cause controller stalls when initializing certain SDIO cards already configured at 1.8V.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->