### PR TITLE
SpacemiT: Update K1 boot support

### DIFF
--- a/patch/kernel/archive/spacemit-6.18/dt/k1-musepi-pro.dts
+++ b/patch/kernel/archive/spacemit-6.18/dt/k1-musepi-pro.dts
@@ -950,6 +950,42 @@
 		m25p,fast-read;
 		broken-flash-reset;
 		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@00000 {
+				label = "bootinfo";
+				reg = <0x00000 0x10000>;
+			};
+
+			partition@10000 {
+				label = "private";
+				reg = <0x10000 0x10000>;
+			};
+
+			partition@20000 {
+				label = "fsbl";
+				reg = <0x20000 0x40000>;
+			};
+
+			partition@60000 {
+				label = "env";
+				reg = <0x60000 0x10000>;
+			};
+
+			partition@70000 {
+				label = "opensbi";
+				reg = <0x70000 0x30000>;
+			};
+
+			partition@a0000 {
+				label = "uboot";
+				reg = <0xa0000 0xf60000>;
+			};
+		};
 	};
 };
 

--- a/patch/kernel/archive/spacemit-6.6/dt/k1-musebook.dts
+++ b/patch/kernel/archive/spacemit-6.6/dt/k1-musebook.dts
@@ -796,6 +796,42 @@
 		m25p,fast-read;
 		broken-flash-reset;
 		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@00000 {
+				label = "bootinfo";
+				reg = <0x00000 0x10000>;
+			};
+
+			partition@10000 {
+				label = "private";
+				reg = <0x10000 0x10000>;
+			};
+
+			partition@20000 {
+				label = "fsbl";
+				reg = <0x20000 0x40000>;
+			};
+
+			partition@60000 {
+				label = "env";
+				reg = <0x60000 0x10000>;
+			};
+
+			partition@70000 {
+				label = "opensbi";
+				reg = <0x70000 0x30000>;
+			};
+
+			partition@a0000 {
+				label = "uboot";
+				reg = <0xa0000 0xf60000>;
+			};
+		};
 	};
 };
 

--- a/patch/kernel/archive/spacemit-6.6/dt/k1-musepi-pro.dts
+++ b/patch/kernel/archive/spacemit-6.6/dt/k1-musepi-pro.dts
@@ -950,6 +950,42 @@
 		m25p,fast-read;
 		broken-flash-reset;
 		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@00000 {
+				label = "bootinfo";
+				reg = <0x00000 0x10000>;
+			};
+
+			partition@10000 {
+				label = "private";
+				reg = <0x10000 0x10000>;
+			};
+
+			partition@20000 {
+				label = "fsbl";
+				reg = <0x20000 0x40000>;
+			};
+
+			partition@60000 {
+				label = "env";
+				reg = <0x60000 0x10000>;
+			};
+
+			partition@70000 {
+				label = "opensbi";
+				reg = <0x70000 0x30000>;
+			};
+
+			partition@a0000 {
+				label = "uboot";
+				reg = <0xa0000 0xf60000>;
+			};
+		};
 	};
 };
 

--- a/patch/u-boot/legacy/u-boot-spacemit-k1/004-Update-SpacemiT-K1-U-Boot-Environment.patch
+++ b/patch/u-boot/legacy/u-boot-spacemit-k1/004-Update-SpacemiT-K1-U-Boot-Environment.patch
@@ -1,18 +1,20 @@
-From 767d386dcc7422266d6afc0585b7b742f631bf28 Mon Sep 17 00:00:00 2001
+From 0b26640518abc9f9f443f4a78b00749040015a49 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@gmail.com>
-Date: Sat, 21 Feb 2026 15:56:32 -0500
-Subject: [PATCH] Add syslinux script and uefi support
+Date: Wed, 3 Jun 2026 15:15:18 -0400
+Subject: [PATCH] Update SpacemiT K1 U-Boot Environment
+
+Boot order USB SDCARD NVME MMC
 
 Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
 ---
- board/spacemit/k1-x/k1-x.env | 374 ++++-------------------------------
- 1 file changed, 38 insertions(+), 336 deletions(-)
+ board/spacemit/k1-x/k1-x.env | 376 ++++-------------------------------
+ 1 file changed, 40 insertions(+), 336 deletions(-)
 
 diff --git a/board/spacemit/k1-x/k1-x.env b/board/spacemit/k1-x/k1-x.env
-index 3499aec7..463cbd07 100644
+index 3499aec7..d2f59a92 100644
 --- a/board/spacemit/k1-x/k1-x.env
 +++ b/board/spacemit/k1-x/k1-x.env
-@@ -1,336 +1,38 @@
+@@ -1,336 +1,40 @@
 -// Common parameter
 -earlycon=sbi
 -init=/init
@@ -349,44 +351,46 @@ index 3499aec7..463cbd07 100644
 -bootmenu_7="recovery from usb"=run flash_from_usb
 -bootmenu_8="recovery from mmc"=run flash_from_mmc
 -bootmenu_9="recovery from net"=run flash_from_net
-+// SYSLINUX, SCRIPT and UEFI Support
++// Environment boot order USB SDCARD NVME MMC
 +
-+nvme_devtype=nvme
-+nvme_devnum=0
-+nvme_bootpart=1
-+
-+autoboot=if test -e ${devtype} ${devnum}:${distro_bootpart} /extlinux/extlinux.conf; then \
-+		sysboot ${devtype} ${devnum}:${distro_bootpart} any 0x2000000 /extlinux/extlinux.conf; \
++bootfunc=if test -e ${devtype} ${devnum}:${distro_bootpart} /extlinux/extlinux.conf; then \
++		echo "Booting from ${devtype} ${devnum}:${distro_bootpart} ..."; \
++		sysboot ${devtype} ${devnum}:${distro_bootpart} any ${kernel_addr_r} /extlinux/extlinux.conf; \
 +	elif test -e ${devtype} ${devnum}:${distro_bootpart} /boot/extlinux/extlinux.conf; then \
-+		sysboot ${devtype} ${devnum}:${distro_bootpart} any 0x2000000 /boot/extlinux/extlinux.conf; \
++		echo "Booting from ${devtype} ${devnum}:${distro_bootpart} ..."; \
++		sysboot ${devtype} ${devnum}:${distro_bootpart} any ${kernel_addr_r} /boot/extlinux/extlinux.conf; \
 +	elif test -e ${devtype} ${devnum}:${distro_bootpart} /boot.scr; then \
-+		load ${devtype} ${devnum}:${distro_bootpart} 0x2000000 /boot.scr; source 0x2000000; \
++		load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} /boot.scr; source ${kernel_addr_r}; \
 +	elif test -e ${devtype} ${devnum}:${distro_bootpart} /boot/boot.scr; then \
-+		load ${devtype} ${devnum}:${distro_bootpart} 0x2000000 /boot/boot.scr; source 0x2000000; \
-+	elif test -e ${devtype} ${devnum}:${distro_bootpart} EFI/BOOT/BOOTRISCV64.EFI; then \
-+		load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} EFI/BOOT/BOOTRISCV64.EFI; bootefi ${kernel_addr_r}; \
-+	fi;
-+	nvme part; \
-+	setenv devtype $nvme_devtype; \
-+	setenv devnum $nvme_devnum; \
-+	setenv distro_bootpart $nvme_bootpart; \
-+	if test -e ${devtype} ${devnum}:${distro_bootpart} /extlinux/extlinux.conf; then \
-+		sysboot ${devtype} ${devnum}:${distro_bootpart} any 0x2000000 /extlinux/extlinux.conf; \
-+	elif test -e ${devtype} ${devnum}:${distro_bootpart} /boot/extlinux/extlinux.conf; then \
-+		sysboot ${devtype} ${devnum}:${distro_bootpart} any 0x2000000 /boot/extlinux/extlinux.conf; \
-+	elif test -e ${devtype} ${devnum}:${distro_bootpart} /boot.scr; then \
-+		load ${devtype} ${devnum}:${distro_bootpart} 0x2000000 /boot.scr; source 0x2000000; \
-+	elif test -e ${devtype} ${devnum}:${distro_bootpart} /boot/boot.scr; then \
-+		load ${devtype} ${devnum}:${distro_bootpart} 0x2000000 /boot/boot.scr; source 0x2000000; \
++		load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} /boot/boot.scr; source ${kernel_addr_r}; \
 +	elif test -e ${devtype} ${devnum}:${distro_bootpart} EFI/BOOT/BOOTRISCV64.EFI; then \
 +		load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} EFI/BOOT/BOOTRISCV64.EFI; bootefi ${kernel_addr_r}; \
 +	fi;
 +
-+bootcmd=echo "Loading K1-X Environment ..."; \
++autoboot=echo "Loading K1 environment"; \
 +	echo ""; \
-+	echo "Running NVMe Scan ..."; \
++	setenv devnum 0; \
++	setenv distro_bootpart 1; \
++	// usb boot
++	setenv devtype usb; \
++	usb start; \
++	run bootfunc; \
++	// sd card boot
++	setenv devtype mmc; \
++	run bootfunc; \
++	// nvme boot
++	setenv devtype nvme; \
 +	nvme scan; \
-+	run autoboot
++	nvme part; \
++	run bootfunc; \
++	// mmc boot
++	setenv devtype mmc; \
++	setenv devnum 1; \
++	run bootfunc; \
++	setenv devnum 2; \
++	run bootfunc;
++
++bootcmd=run autoboot
 -- 
-2.51.0
+2.53.0
 


### PR DESCRIPTION
Boot order USB SDCARD NVME MMC

* Add USB boot support
* Where SPI is available add the ability to update it on a running unit (without fastboot)

Note: I'll update the board confs at later date after more testing, when it comes to the SPI.

This has been boot tested on the BPI-F3 and MusePi Pro

@sven-ola


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated QSPI flash partition configurations across device variants.

* **New Features**
  * Enhanced boot system supporting multiple media types (USB, SD card, NVMe, MMC) and boot methods (Extlinux, U-Boot scripts, UEFI) for improved system flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->