### PR TITLE
armbian-firstrun: use atomic write for armbianEnv.txt MAC randomization

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -60,12 +60,20 @@ case "$1" in
 	# get rid of purple background color in newt apps whiptail, partimage, debconf ... Reverting to Debian look.
 	[[ -f /etc/newt/palette ]] && sed -e 's/magenta/blue/g' -i /etc/newt/palette
 
-	# randomize mac in armbianEnv.txt
+	# randomize mac in armbianEnv.txt (atomic write to survive power loss)
 	if [[ -f /boot/armbianEnv.txt ]]; then
-		generate_random_mac
-		sed  -i "s/^ethaddr=.*/ethaddr=$MACADDR/" /boot/armbianEnv.txt
-		generate_random_mac
-		sed  -i "s/^eth1addr=.*/eth1addr=$MACADDR/" /boot/armbianEnv.txt
+		generate_random_mac; mac0="$MACADDR"
+		generate_random_mac; mac1="$MACADDR"
+		if sed -e "s/^ethaddr=.*/ethaddr=${mac0}/" \
+		       -e "s/^eth1addr=.*/eth1addr=${mac1}/" \
+		       /boot/armbianEnv.txt > /boot/armbianEnv.txt.tmp \
+		   && chmod --reference=/boot/armbianEnv.txt /boot/armbianEnv.txt.tmp \
+		   && sync /boot/armbianEnv.txt.tmp \
+		   && mv /boot/armbianEnv.txt.tmp /boot/armbianEnv.txt; then
+			:
+		else
+			rm -f /boot/armbianEnv.txt.tmp
+		fi
 	fi
 
 	# hardware workarounds per family


### PR DESCRIPTION
## Summary

- Replace non-atomic `sed -i` with atomic write pattern (`sed` to temp file → `sync` → `mv`) when randomizing MAC addresses in `armbianEnv.txt` during first boot
- Generate both MAC addresses before any I/O to avoid partial state
- Add error handling: if `sed` fails, clean up temp file instead of overwriting

## Background

`sed -i` works by truncating the original file and writing new content. If power is lost during this process, `armbianEnv.txt` can end up with correct file size but all-zero content (observed in production: 186 bytes of `0x00`).

The atomic pattern ensures the original file is either untouched or fully replaced — no intermediate corrupted state is possible.

## Test plan

- [ ] Flash image to device, verify first boot completes and MAC addresses are written correctly
- [ ] Verify `armbianEnv.txt` content is valid after reboot
- [ ] (Optional) Simulate power loss during firstrun and confirm original file is preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable MAC randomization at first run: generates distinct MACs for interfaces and updates the boot configuration using an atomic write. Permissions are preserved, data is synced to storage, and temporary files are cleaned up on failure to avoid partial configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->