### PR TITLE
Add jellyfin-ffmpeg release constraints and ip-wrapper for easepi-r2

### DIFF
--- a/config/boards/easepi-a2.conf
+++ b/config/boards/easepi-a2.conf
@@ -181,7 +181,7 @@ function post_family_tweaks_bsp__easepi_a2_install_eth_files() {
 }
 
 function custom_apt_repo__add_jellyfin-ffmpeg-repo() {
-	[[ "${CUSTOM_REPO_WHEN}" = "image-early" && "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${CUSTOM_REPO_WHEN}" = "image-early" && "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Preparing jellyfin ffmpeg repository..." "EasePi-A2" "info"
 
 	local keyring_url repo_url
@@ -199,7 +199,7 @@ function custom_apt_repo__add_jellyfin-ffmpeg-repo() {
 }
 
 function extension_prepare_config__prepare_jellyfin-ffmpeg_config() {
-	[[ "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Preparing jellyfin ffmpeg packages..." "EasePi-A2" "info"
 
 	local FFMPEG_PACKAGE=jellyfin-ffmpeg7
@@ -208,7 +208,7 @@ function extension_prepare_config__prepare_jellyfin-ffmpeg_config() {
 }
 
 function pre_customize_image__jellyfin_ffmpeg_link() {
-	[[ "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Create link to jellyfin-ffmpeg binaries..." "EasePi-A2" "info"
 
 	local p

--- a/config/boards/easepi-r2.conf
+++ b/config/boards/easepi-r2.conf
@@ -119,6 +119,25 @@ function post_family_tweaks_bsp__easepi_r2_install_eth_files() {
 		"${destination}/etc/eth_order"
 	install -D -m 0644 "${SRC}/packages/bsp/easepi/easepi-r2/71-net.rules" \
 		"${destination}/etc/udev/rules.d/71-net.rules"
+
+	# Install ip-wrapper for sorted interface display
+	display_alert "EasePi-R2" "Installing ip-wrapper for sorted interface display" "info"
+	# Install ip-easy wrapper script
+	install -D -m 0755 /dev/null "${destination}/usr/local/bin/ip-easy"
+	cat <<- 'EOF' > "${destination}/usr/local/bin/ip-easy"
+	#!/bin/bash
+	if [[ "$1" == "addr" || "$1" == "link" ]]; then
+		interfaces=$(ip -o link show | awk -F': ' '{print $2}' | sort)
+		for iface in $interfaces; do ip "$@" show dev "$iface"; done
+	else
+		/sbin/ip "$@"
+	fi
+	EOF
+	# Install profile.d alias
+	install -D -m 0644 /dev/null "${destination}/etc/profile.d/ip-sorted.sh"
+	cat <<- 'EOF' > "${destination}/etc/profile.d/ip-sorted.sh"
+	alias ip="ip-easy"
+	EOF
 }
 
 function post_customize_image__enable_easepi_r2_eth_service() {
@@ -127,7 +146,7 @@ function post_customize_image__enable_easepi_r2_eth_service() {
 
 # ==================== Jellyfin-FFmpeg Module ====================
 function custom_apt_repo__add_jellyfin-ffmpeg-repo() {
-	[[ "${CUSTOM_REPO_WHEN}" = "image-early" && "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${CUSTOM_REPO_WHEN}" = "image-early" && "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Preparing jellyfin ffmpeg repository..." "EasePi-R2" "info"
 
 	local keyring_url repo_url
@@ -145,7 +164,7 @@ function custom_apt_repo__add_jellyfin-ffmpeg-repo() {
 }
 
 function extension_prepare_config__prepare_jellyfin-ffmpeg_config() {
-	[[ "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Preparing jellyfin ffmpeg packages..." "EasePi-R2" "info"
 
 	local FFMPEG_PACKAGE=jellyfin-ffmpeg7
@@ -154,7 +173,7 @@ function extension_prepare_config__prepare_jellyfin-ffmpeg_config() {
 }
 
 function pre_customize_image__jellyfin_ffmpeg_link() {
-	[[ "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Create link to jellyfin-ffmpeg binaries..." "EasePi-R2" "info"
 
 	local p

--- a/config/boards/easepi-r2.conf
+++ b/config/boards/easepi-r2.conf
@@ -126,7 +126,7 @@ function post_family_tweaks_bsp__easepi_r2_install_eth_files() {
 	install -D -m 0755 /dev/null "${destination}/usr/local/bin/ip-easy"
 	cat <<- 'EOF' > "${destination}/usr/local/bin/ip-easy"
 	#!/bin/bash
-	if [[ "$1" == "addr" || "$1" == "link" ]]; then
+	if [[ "$#" -eq 1 && ( "$1" == "addr" || "$1" == "link" ) ]]; then
 		interfaces=$(ip -o link show | awk -F': ' '{print $2}' | sort)
 		for iface in $interfaces; do ip "$@" show dev "$iface"; done
 	else


### PR DESCRIPTION
**restrict jellyfin-ffmpeg to supported releases**

- Check that RELEASE is in supported list (bookworm|trixie|jammy|noble)
- Skip unsupported releases like sid/oracular to avoid build failures
- Update all 3 jellyfin functions in both board config files

Supported releases verified via curl check:
- bookworm (Debian stable): 200 OK
- trixie (Debian testing): 200 OK
- jammy (Ubuntu 22.04): 200 OK
- noble (Ubuntu 24.04): 200 OK
- sid/oracular: 404 Not Found

**IP-Easy Wrapper Enhancement (EasePi-R2)**

- Added `ip-easy` wrapper script to improve network interface visibility
- Provides sorted interface display for `ip addr` and `ip link` commands
- Installation details:
  - Creates `/usr/local/bin/ip-easy` script with executable permissions
  - Script automatically sorts interfaces alphabetically when running `ip addr` or `ip link` commands
  - Falls back to standard `/sbin/ip` for other commands
  - Installs shell alias in `/etc/profile.d/ip-sorted.sh` to make `ip` command automatically use the wrapper
- Benefit: Clearer and more predictable network interface output during troubleshooting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Jellyfin ffmpeg integration is now limited to vendor builds targeting supported Debian/Ubuntu releases: bookworm, trixie, jammy, noble (EasePi-A2 and EasePi-R2).

* **New Features**
  * EasePi-R2 adds an ip-easy wrapper and login alias that sorts network interface names before showing per-interface details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->