### PR TITLE
Milk-V Jupiter disable EEPROM node

### DIFF
--- a/patch/kernel/archive/spacemit-7.1/050-Update-Milk-V-Jupiter-DTS.patch
+++ b/patch/kernel/archive/spacemit-7.1/050-Update-Milk-V-Jupiter-DTS.patch
@@ -126,3 +126,32 @@ index afaad59e6bce..856c6fc250ba 100644
 -- 
 2.53.0
 
+From a6ffdfdae9d98bb71cf6f64f5c0b22e5fa36f6a5 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@gmail.com>
+Date: Sat, 6 Jun 2026 21:02:21 -0400
+Subject: [PATCH] Milk-V Jupiter disable EEPROM node
+
+Causes one core to run at 100%. Which in turn makes the unit hang
+at boot.
+
+Tested-by: Rouge @Discord
+Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
+---
+ arch/riscv/boot/dts/spacemit/k1-milkv-jupiter.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/riscv/boot/dts/spacemit/k1-milkv-jupiter.dts b/arch/riscv/boot/dts/spacemit/k1-milkv-jupiter.dts
+index 856c6fc250ba..004e0904c983 100644
+--- a/arch/riscv/boot/dts/spacemit/k1-milkv-jupiter.dts
++++ b/arch/riscv/boot/dts/spacemit/k1-milkv-jupiter.dts
+@@ -204,6 +204,7 @@ eeprom@50 {
+ 		pagesize = <16>;
+ 		read-only;
+ 		size = <512>;
++		status = "disabled";
+ 
+ 		nvmem-layout {
+ 			compatible = "onie,tlv-layout";
+-- 
+2.53.0
+


### PR DESCRIPTION
* Causes one core to run at 100%. Which in turn makes the unit hang at boot.

Tested-by: Rouge `@Discord`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated device tree configuration for Milk-V Jupiter to disable EEPROM node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->