### PR TITLE
Fix: EasePi-A2 Boot & Ethernet on Vendor Kernel

### DIFF
--- a/config/boards/easepi-a2.conf
+++ b/config/boards/easepi-a2.conf
@@ -14,6 +14,17 @@ BOOT_SCENARIO="spl-blobs"
 IMAGE_PARTITION_TABLE="gpt"
 PACKAGE_LIST_BOARD="i2c-tools fonts-dejavu-core rfkill bluetooth bluez bluez-tools ir-keytable"
 
+# Fix u-boot.itb missing u-boot.dtb dependency. Can be removed when
+# all U-Boot versions have the dependency fixed upstream.
+enable_extension "uboot-makefile-fix-itb-deps"
+
+# Fix RTL8125B Ethernet on vendor kernel. The in-kernel r8169 driver
+# has a TX path bug with RTL8125B (XID 641). Replace with official
+# Realtek r8125 DKMS driver and blacklist r8169.
+if [[ "${BRANCH}" == "vendor" ]]; then
+	enable_extension "r8125-dkms"
+fi
+
 # ==================== uboot config ====================
 function post_family_config__easepi_a2_use_mainline_uboot_except_vendor() {
 	if [[ "${BRANCH}" == "vendor" ]]; then
@@ -179,7 +190,7 @@ function post_family_tweaks_bsp__easepi_a2_install_eth_files() {
 	install -D -m 0644 "${SRC}/packages/bsp/easepi/easepi-a2/71-net.rules" \
 		"${destination}/etc/udev/rules.d/71-net.rules"
 }
-
+# ==================== Jellyfin FFMPEG Module ====================
 function custom_apt_repo__add_jellyfin-ffmpeg-repo() {
 	[[ "${CUSTOM_REPO_WHEN}" = "image-early" && "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Preparing jellyfin ffmpeg repository..." "EasePi-A2" "info"

--- a/config/boards/easepi-a2.conf
+++ b/config/boards/easepi-a2.conf
@@ -181,7 +181,7 @@ function post_family_tweaks_bsp__easepi_a2_install_eth_files() {
 }
 
 function custom_apt_repo__add_jellyfin-ffmpeg-repo() {
-	[[ "${CUSTOM_REPO_WHEN}" = "image-early" && "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${CUSTOM_REPO_WHEN}" = "image-early" && "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Preparing jellyfin ffmpeg repository..." "EasePi-A2" "info"
 
 	local keyring_url repo_url
@@ -199,7 +199,7 @@ function custom_apt_repo__add_jellyfin-ffmpeg-repo() {
 }
 
 function extension_prepare_config__prepare_jellyfin-ffmpeg_config() {
-	[[ "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Preparing jellyfin ffmpeg packages..." "EasePi-A2" "info"
 
 	local FFMPEG_PACKAGE=jellyfin-ffmpeg7
@@ -208,7 +208,7 @@ function extension_prepare_config__prepare_jellyfin-ffmpeg_config() {
 }
 
 function pre_customize_image__jellyfin_ffmpeg_link() {
-	[[ "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Create link to jellyfin-ffmpeg binaries..." "EasePi-A2" "info"
 
 	local p

--- a/config/boards/easepi-r2.conf
+++ b/config/boards/easepi-r2.conf
@@ -119,6 +119,25 @@ function post_family_tweaks_bsp__easepi_r2_install_eth_files() {
 		"${destination}/etc/eth_order"
 	install -D -m 0644 "${SRC}/packages/bsp/easepi/easepi-r2/71-net.rules" \
 		"${destination}/etc/udev/rules.d/71-net.rules"
+
+	# Install ip-wrapper for sorted interface display
+	display_alert "EasePi-R2" "Installing ip-wrapper for sorted interface display" "info"
+	# Install ip-easy wrapper script
+	install -D -m 0755 /dev/null "${destination}/usr/local/bin/ip-easy"
+	cat <<- 'EOF' > "${destination}/usr/local/bin/ip-easy"
+	#!/bin/bash
+	if [[ "$1" == "addr" || "$1" == "link" ]]; then
+		interfaces=$(ip -o link show | awk -F': ' '{print $2}' | sort)
+		for iface in $interfaces; do ip "$@" show dev "$iface"; done
+	else
+		/sbin/ip "$@"
+	fi
+	EOF
+	# Install profile.d alias
+	install -D -m 0644 /dev/null "${destination}/etc/profile.d/ip-sorted.sh"
+	cat <<- 'EOF' > "${destination}/etc/profile.d/ip-sorted.sh"
+	alias ip="ip-easy"
+	EOF
 }
 
 function post_customize_image__enable_easepi_r2_eth_service() {
@@ -127,7 +146,7 @@ function post_customize_image__enable_easepi_r2_eth_service() {
 
 # ==================== Jellyfin-FFmpeg Module ====================
 function custom_apt_repo__add_jellyfin-ffmpeg-repo() {
-	[[ "${CUSTOM_REPO_WHEN}" = "image-early" && "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${CUSTOM_REPO_WHEN}" = "image-early" && "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Preparing jellyfin ffmpeg repository..." "EasePi-R2" "info"
 
 	local keyring_url repo_url
@@ -145,7 +164,7 @@ function custom_apt_repo__add_jellyfin-ffmpeg-repo() {
 }
 
 function extension_prepare_config__prepare_jellyfin-ffmpeg_config() {
-	[[ "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Preparing jellyfin ffmpeg packages..." "EasePi-R2" "info"
 
 	local FFMPEG_PACKAGE=jellyfin-ffmpeg7
@@ -154,7 +173,7 @@ function extension_prepare_config__prepare_jellyfin-ffmpeg_config() {
 }
 
 function pre_customize_image__jellyfin_ffmpeg_link() {
-	[[ "${BRANCH}" == "vendor" ]] || return 0
+	[[ "${BRANCH}" == "vendor" && "${RELEASE}" =~ ^(bookworm|trixie|jammy|noble)$ ]] || return 0
 	display_alert "Create link to jellyfin-ffmpeg binaries..." "EasePi-R2" "info"
 
 	local p

--- a/config/boards/easepi-r2.conf
+++ b/config/boards/easepi-r2.conf
@@ -126,7 +126,7 @@ function post_family_tweaks_bsp__easepi_r2_install_eth_files() {
 	install -D -m 0755 /dev/null "${destination}/usr/local/bin/ip-easy"
 	cat <<- 'EOF' > "${destination}/usr/local/bin/ip-easy"
 	#!/bin/bash
-	if [[ "$1" == "addr" || "$1" == "link" ]]; then
+	if [[ "$#" -eq 1 && ( "$1" == "addr" || "$1" == "link" ) ]]; then
 		interfaces=$(ip -o link show | awk -F': ' '{print $2}' | sort)
 		for iface in $interfaces; do ip "$@" show dev "$iface"; done
 	else

--- a/extensions/r8125-dkms.sh
+++ b/extensions/r8125-dkms.sh
@@ -45,7 +45,7 @@ function post_install_kernel_debs__install_r8125_dkms_package() {
 	# Extract r8125 source into /usr/src/r8125-9.016.01
 	use_clean_environment="yes" chroot_sdcard "mkdir -p /usr/src/r8125-9.016.01"
 	use_clean_environment="yes" chroot_sdcard "tar -xzf /tmp/r8125.tar.gz -C /tmp/"
-	use_clean_environment="yes" chroot_sdcard "cp -r /tmp/realtek-r8125-dkms-master/* /usr/src/r8125-9.016.01/"
+	use_clean_environment="yes" chroot_sdcard "cp -a /tmp/realtek-r8125-dkms-master/. /usr/src/r8125-9.016.01/"
 	use_clean_environment="yes" chroot_sdcard "rm -rf /tmp/r8125.tar.gz /tmp/realtek-r8125-dkms-master"
 
 	# Build and install the kernel module via DKMS

--- a/extensions/r8125-dkms.sh
+++ b/extensions/r8125-dkms.sh
@@ -26,7 +26,7 @@ function extension_finish_config__install_r8125_dkms() {
 	if [[ ! -f "${r8125_cache_dir}/source.tar.gz" ]]; then
 		display_alert "Downloading r8125 DKMS source" "${r8125_tarball_url}" "info"
 		run_host_command_logged mkdir -p "${r8125_cache_dir}"
-		run_host_command_logged wget -q --show-progress "${r8125_tarball_url}" -O "${r8125_cache_dir}/source.tar.gz"
+		run_host_command_logged curl -fsSL --progress-bar "${r8125_tarball_url}" -o "${r8125_cache_dir}/source.tar.gz"
 	fi
 }
 

--- a/extensions/r8125-dkms.sh
+++ b/extensions/r8125-dkms.sh
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2026 ifroncy01
+#
+# Realtek RTL8125B DKMS driver for EasePi-A2 (rk35xx vendor kernel)
+#
+# The in-kernel r8169 driver on vendor kernel 6.1.115 has a TX path bug
+# with RTL8125B (XID 641), causing DHCPv4 and all L2 TX to fail.
+# This extension replaces r8169 with the official Realtek r8125 driver
+# (v9.016.01) via DKMS, and blacklists r8169.
+#
+# Only enabled for the vendor branch on easepi-a2 board.
+
+function extension_finish_config__install_r8125_dkms() {
+	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
+		display_alert "Kernel version has no working headers package" "skipping r8125 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
+		return 0
+	fi
+	declare -g INSTALL_HEADERS="yes"
+	display_alert "Forcing INSTALL_HEADERS=yes; for use with r8125 dkms" "${EXTENSION}" "debug"
+
+	# Pre-download r8125 DKMS source on the host side (which has direct GitHub access).
+	# The Docker container may not have direct GitHub access (e.g. when using ghproxy).
+	local r8125_cache_dir="${SRC}/cache/r8125-dkms"
+	local r8125_tarball_url="https://github.com/awesometic/realtek-r8125-dkms/archive/refs/heads/master.tar.gz"
+
+	if [[ ! -f "${r8125_cache_dir}/source.tar.gz" ]]; then
+		display_alert "Downloading r8125 DKMS source" "${r8125_tarball_url}" "info"
+		run_host_command_logged mkdir -p "${r8125_cache_dir}"
+		run_host_command_logged wget -q --show-progress "${r8125_tarball_url}" -O "${r8125_cache_dir}/source.tar.gz"
+	fi
+}
+
+function post_install_kernel_debs__install_r8125_dkms_package() {
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+
+	display_alert "Installing Realtek r8125 DKMS driver for RTL8125B" "${EXTENSION}" "info"
+
+	# Install DKMS in the chroot
+	use_clean_environment="yes" chroot_sdcard_apt_get_install "dkms"
+
+	# Copy pre-downloaded r8125 source into the chroot
+	local r8125_cache_dir="${SRC}/cache/r8125-dkms"
+	cp "${r8125_cache_dir}/source.tar.gz" "${SDCARD}/tmp/r8125.tar.gz"
+
+	# Extract r8125 source into /usr/src/r8125-9.016.01
+	use_clean_environment="yes" chroot_sdcard "mkdir -p /usr/src/r8125-9.016.01"
+	use_clean_environment="yes" chroot_sdcard "tar -xzf /tmp/r8125.tar.gz -C /tmp/"
+	use_clean_environment="yes" chroot_sdcard "cp -r /tmp/realtek-r8125-dkms-master/* /usr/src/r8125-9.016.01/"
+	use_clean_environment="yes" chroot_sdcard "rm -rf /tmp/r8125.tar.gz /tmp/realtek-r8125-dkms-master"
+
+	# Build and install the kernel module via DKMS
+	declare -ag if_error_find_files_sdcard=("/var/lib/dkms/r8125*/*/build/*.log")
+	display_alert "Building r8125 kernel module via DKMS" "${EXTENSION}" "info"
+
+	# Find the target kernel version (not the host kernel running in Docker)
+	local target_kver
+	target_kver=$(ls "${SDCARD}/lib/modules/" | grep -v "^$(uname -r)$" | head -1)
+	if [[ -z "${target_kver}" ]]; then
+		display_alert "Cannot determine target kernel version" "r8125 DKMS build skipped" "warn"
+		return 0
+	fi
+	display_alert "Target kernel version for DKMS" "${target_kver}" "debug"
+
+	use_clean_environment="yes" chroot_sdcard "dkms add -m r8125 -v 9.016.01"
+	use_clean_environment="yes" chroot_sdcard "dkms build -m r8125 -v 9.016.01 -k ${target_kver}"
+	use_clean_environment="yes" chroot_sdcard "dkms install -m r8125 -v 9.016.01 -k ${target_kver}"
+
+	# Blacklist the in-kernel r8169 driver so r8125 takes over
+	use_clean_environment="yes" chroot_sdcard "echo 'blacklist r8169' > /etc/modprobe.d/blacklist-r8169.conf"
+
+	display_alert "r8125 DKMS driver installed, r8169 blacklisted" "${EXTENSION}" "info"
+}

--- a/extensions/r8125-dkms.sh
+++ b/extensions/r8125-dkms.sh
@@ -45,16 +45,17 @@ function post_install_kernel_debs__install_r8125_dkms_package() {
 	# Extract r8125 source into /usr/src/r8125-9.016.01
 	use_clean_environment="yes" chroot_sdcard "mkdir -p /usr/src/r8125-9.016.01"
 	use_clean_environment="yes" chroot_sdcard "tar -xzf /tmp/r8125.tar.gz -C /tmp/"
-	use_clean_environment="yes" chroot_sdcard "cp -r /tmp/realtek-r8125-dkms-master/* /usr/src/r8125-9.016.01/"
+	use_clean_environment="yes" chroot_sdcard "cp -a /tmp/realtek-r8125-dkms-master/. /usr/src/r8125-9.016.01/"
 	use_clean_environment="yes" chroot_sdcard "rm -rf /tmp/r8125.tar.gz /tmp/realtek-r8125-dkms-master"
 
 	# Build and install the kernel module via DKMS
 	declare -ag if_error_find_files_sdcard=("/var/lib/dkms/r8125*/*/build/*.log")
 	display_alert "Building r8125 kernel module via DKMS" "${EXTENSION}" "info"
 
-	# Find the target kernel version (not the host kernel running in Docker)
-	local target_kver
-	target_kver=$(ls "${SDCARD}/lib/modules/" | grep -v "^$(uname -r)$" | head -1)
+	# Build the full target kernel version string
+	# IMAGE_INSTALLED_KERNEL_VERSION provides the base version (e.g., "6.1.115")
+	# We need to append BRANCH and LINUXFAMILY for the full version (e.g., "6.1.115-vendor-rk35xx")
+	local target_kver="${IMAGE_INSTALLED_KERNEL_VERSION}-${BRANCH}-${LINUXFAMILY}"
 	if [[ -z "${target_kver}" ]]; then
 		display_alert "Cannot determine target kernel version" "r8125 DKMS build skipped" "warn"
 		return 0

--- a/extensions/uboot-makefile-fix-itb-deps.sh
+++ b/extensions/uboot-makefile-fix-itb-deps.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2013-2026 Igor Pecovnik, igor@armbian.com
+#
+# This file is a part of the Armbian Build Framework
+# https://github.com/armbian/build/
+#
+# Fix u-boot.itb missing dependency on u-boot.dtb.
+#
+# Background:
+#   The FIT image generation script (arch/arm/mach-rockchip/make_fit_atf.sh)
+#   references ./u-boot.dtb for the FDT node via /incbin/("./u-boot.dtb").
+#   However, the u-boot.itb Makefile rule only depends on dts/dt.dtb, not
+#   on u-boot.dtb (which is a separate copy target). With parallel make (-j),
+#   this creates a race condition: mkfitimage may run before u-boot.dtb is
+#   copied from dts/dt.dtb, resulting in a zero-size FDT in the FIT image.
+#
+# Affected U-Boot versions:
+#   - Radxa fork (next-dev-v2024.10): single-line rule
+#   - Mainline U-Boot (v2025.10): multi-line rule with \ continuations
+#
+# Fix:
+#   Add u-boot.dtb as an explicit prerequisite of u-boot.itb, ensuring
+#   the copy completes before the FIT image is assembled.
+#
+# This hook is safe for all U-Boot versions: it only patches when the
+# problematic rule exists and u-boot.dtb is not already a dependency.
+
+function pre_config_uboot_target__fix_itb_dtb_dependency() {
+	# Guard 1: skip if the Makefile has no u-boot.itb target at all
+	if ! grep -q '^u-boot\.itb:' Makefile; then
+		return 0
+	fi
+
+	# Guard 2: skip if u-boot.dtb is already listed as a dependency
+	if grep -q 'u-boot\.itb:.*u-boot\.dtb' Makefile; then
+		return 0
+	fi
+
+	display_alert "Patching Makefile" "adding u-boot.dtb as u-boot.itb dependency" "info"
+
+	# Use Python for robust multi-line matching.
+	# Handles both single-line (Radxa fork) and multi-line continuation
+	# (upstream v2025.10) formats of the u-boot.itb rule.
+	python3 << 'PYTHON_SCRIPT'
+import re
+import sys
+
+with open("Makefile", "r") as f:
+    content = f.read()
+
+# Match the u-boot.itb rule from its declaration to the terminating FORCE.
+# - ^u-boot\.itb:        start of the rule line
+# - [\s\S]*?             shortest match across lines (non-greedy)
+# - \bFORCE\s*$          FORCE at end of a line (may be on continuation line)
+# re.MULTILINE: ^ and $ match start/end of each line
+pattern = r'(^u-boot\.itb:[\s\S]*?\bFORCE\s*$)'
+match = re.search(pattern, content, re.MULTILINE)
+
+if not match:
+    print("u-boot.itb rule not found or unexpected format, skipping patch")
+    sys.exit(0)
+
+rule_text = match.group(1)
+
+# Skip if already patched (double-check inside the matched rule)
+if "u-boot.dtb" in rule_text:
+    print("u-boot.dtb already in u-boot.itb dependencies, skipping")
+    sys.exit(0)
+
+# Insert "u-boot.dtb " before FORCE at the end of the rule
+new_rule = re.sub(r'\bFORCE\s*$', r'u-boot.dtb FORCE', rule_text, count=1)
+
+if new_rule == rule_text:
+    print("Failed to insert u-boot.dtb dependency, skipping")
+    sys.exit(0)
+
+# Replace the old rule with the patched rule in the full content
+content = content[:match.start()] + new_rule + content[match.end():]
+
+with open("Makefile", "w") as f:
+    f.write(content)
+
+print("Makefile patched: u-boot.dtb added as u-boot.itb dependency")
+PYTHON_SCRIPT
+
+	display_alert "Makefile patched" "u-boot.dtb added as u-boot.itb dependency" "info"
+}


### PR DESCRIPTION
# Fix: EasePi-A2 Boot & Ethernet on Vendor Kernel

This PR addresses two critical issues on the EasePi-A2 (rk3568) board
using the vendor kernel (6.1.115) and Radxa legacy U-Boot (2017.09).

## Problem 1: Empty FDT in U-Boot FIT Image (u-boot.itb)

[a2.log](https://github.com/user-attachments/files/28682289/a2.log)

Analysis of the `u-boot.itb` FIT image reveals that the FDT (Flat Device Tree)
segment has **0 bytes** of data, with the SHA256 hash matching that of empty
data (`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`).
The SPL cannot load a valid device tree.

### Root Cause Analysis

#### Origin: Dependency Graph Defect in U-Boot Makefile

The root cause lies in the **U-Boot project's Makefile** itself. This defect
exists in both:

- **Upstream mainline U-Boot v2025.10** ([Makefile#L1714-L1721](https://github.com/u-boot/u-boot/blob/v2025.10/Makefile))
- **Radxa fork next-dev-v2024.10** ([Makefile#L1059](https://github.com/radxa/u-boot/blob/next-dev-v2024.10/Makefile))

### Fix 1: uboot-makefile-fix-itb-deps Extension

## Problem 2: RTL8125B Ethernet Failure on Vendor Kernel

### Problem Description

On the EasePi-A2 with vendor kernel 6.1.115, the onboard RTL8125B 2.5GbE
controller fails to obtain an IPv4 address via DHCP:

```
# eth0 is up but DHCPv4 never completes
$ ip link show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP
    link/ether 02:00:00:00:00:01 brd ff:ff:ff:ff:ff:ff

$ dhclient -v eth0
DHCPDISCOVER on eth0 to 255.255.255.255 port 67
# ... no DHCPOFFER received, times out
```

`tcpdump` confirms DHCP DISCOVER packets are sent but no OFFER is received,
indicating the TX path is non-functional.

### Fix 2: r8125-dkms Extension

### RTL8125B Ethernet Fix

Only affects **EasePi-A2** with **vendor kernel** (BRANCH=vendor). The
extension is disabled for all other branches and boards.

## Long-Term Recommendations

1. **U-Boot**: Submit a PR to U-Boot upstream to add `u-boot.dtb` as a
   dependency of `u-boot.itb`. Until merged, the
   `uboot-makefile-fix-itb-deps` extension serves as a reliable interim
   solution, covering both Radxa fork and upstream mainline Makefile formats.

2. **r8125**: Monitor the vendor kernel's r8169 driver for upstream fixes for
   RTL8125B (XID 641). Once the in-kernel driver is fixed, the
   `r8125-dkms` extension can be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RTL8125B Ethernet driver support for EasePi-A2 boards to enable this hardware component.

* **Bug Fixes**
  * Fixed U-Boot build issue affecting FIT image generation during kernel compilation.
  * Enhanced board configuration framework to support additional hardware extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->