### PR TITLE
image/compress-checksum: cap compression threads (default 32)

### DIFF
--- a/lib/functions/image/compress-checksum.sh
+++ b/lib/functions/image/compress-checksum.sh
@@ -28,9 +28,16 @@ function output_images_compress_and_checksum() {
 	# *is* fair-shared among peers, with a 60% safety margin, so the level
 	# selection below picks the strongest preset that fits without OOMing
 	# even if every peer also reaches for its top level at the same instant.
-	declare host_threads active_jobs compress_threads mem_avail_mb mem_budget_mb
+	declare host_threads active_jobs compress_threads mem_avail_mb mem_budget_mb max_threads
 	host_threads=$(nproc)
+	# Cap threads: xz speedup is sublinear and its ratio slightly worsens past
+	# ~16-32 threads (more independent blocks), while peak memory grows linearly
+	# (~674MB/thread at -9). On a 128-core box an image would otherwise grab ~91
+	# threads and reserve ~61GB for marginal wall-time gain. Override per-build
+	# with COMPRESS_MAX_THREADS (set it >= nproc to disable the cap).
+	max_threads="${COMPRESS_MAX_THREADS:-32}"
 	compress_threads=$host_threads
+	(( compress_threads > max_threads )) && compress_threads=$max_threads
 	active_jobs=$(pgrep -cx 'xz|zstd|zstdmt' 2>/dev/null || true)
 	[[ -z "${active_jobs}" ]] && active_jobs=0
 
@@ -97,7 +104,7 @@ function output_images_compress_and_checksum() {
 	done
 
 	display_alert "Compression host" \
-		"nproc=${host_threads} loadavg=${loadavg} MemTotal=${mem_total_mb}MB MemAvail=${mem_avail_mb}MB" \
+		"nproc=${host_threads} (cap=${max_threads}) loadavg=${loadavg} MemTotal=${mem_total_mb}MB MemAvail=${mem_avail_mb}MB" \
 		"info"
 	display_alert "Compression resource share" \
 		"active_xz/zstd=${active_jobs} -> threads=${compress_threads}, budget=${mem_budget_mb}MB; pick xz=-${xz_elastic_level} zstd=-${zstd_elastic_level}" \

--- a/lib/functions/image/compress-checksum.sh
+++ b/lib/functions/image/compress-checksum.sh
@@ -36,6 +36,10 @@ function output_images_compress_and_checksum() {
 	# threads and reserve ~61GB for marginal wall-time gain. Override per-build
 	# with COMPRESS_MAX_THREADS (set it >= nproc to disable the cap).
 	max_threads="${COMPRESS_MAX_THREADS:-32}"
+	# Guard against a non-numeric or zero override: bash arithmetic reads
+	# either as 0, which would set compress_threads=0 (xz/zstd -T0 = "use all
+	# cores") and silently collapse the cap. Fall back to the default 32.
+	[[ "${max_threads}" =~ ^[0-9]+$ ]] && (( max_threads >= 1 )) || max_threads=32
 	compress_threads=$host_threads
 	(( compress_threads > max_threads )) && compress_threads=$max_threads
 	active_jobs=$(pgrep -cx 'xz|zstd|zstdmt' 2>/dev/null || true)


### PR DESCRIPTION
## Problem

Since #9758, compression threads are set to full `nproc`. On a 128-core Ampere host a single large xz job grabs ~91 threads (`file_size / block_size` at `-9`). That's wasteful:

- **xz scaling is sublinear past ~16–32 threads**, and the ratio slightly *worsens* with more threads (each thread compresses an independent block → smaller effective dictionary scope).
- **Peak memory is linear in threads** — at `-9` that's ~674 MB/thread, so ~91 threads reserves ~61 GB for marginal wall-time gain.

## Change

Cap `compress_threads` to `min(nproc, 32)`. Because everything downstream keys off `compress_threads`, the cap propagates with no other edits:

- xz per-file thread clamp (`file_threads`)
- xz level-walk memory feasibility check (`compress_threads * per_thread_MB <= budget`)
- zstd `-T` and its tiering thresholds

Peak at `-9` drops from ~61 GB (91 threads) to ~21 GB (32 threads).

### Knobs
- **`COMPRESS_MAX_THREADS`** env override — set `>= nproc` to disable the cap, or lower for tighter RAM.
- The cap is shown in the diagnostic line:
  `[ Compression host ] [ nproc=128 (cap=32) loadavg=... MemTotal=... MemAvail=... ]`

## Testing

`bash -n` clean. Cap value (32) chosen as a fleet-wide default that keeps wall-time gains while bounding RAM; large boxes can raise it per-build.

Signed-off-by: Igor Pecovnik <igor@armbian.com>

Implemented by Igor Pecovnik

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Introduced a configurable compression thread limit (default: 32) to better control CPU usage during image compression and avoid overcommitment.
  * Enhanced compression status alerts to display both detected CPU cores and the applied thread cap for clearer operational feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->