### PR TITLE
bump mainline to 7.1-rc7

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0           # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "7.1" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v7.1-rc6"
+		declare -g KERNELBRANCH="tag:v7.1-rc7"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }
@@ -26,11 +26,11 @@ function mainline_kernel_decide_version__upstream_release_candidate_number() {
 
  # Example: 6.7-rc7 was released by Linus, but kernel.org git and google git mirrors took a while to catch up; change the source to pull directly from Linus.
  # This was necessary for a few days in late December 2023, but no longer; tag was pushed on 28/Dec/2023.
- function mainline_kernel_decide_version__750_use_torvalds_for_7.1-rc6() {
- 	if [[ "${KERNELBRANCH}" == 'tag:v7.1-rc6' ]]; then
- 		display_alert "Using Linus kernel repo for 7.1-rc6" "${KERNELBRANCH}" "warn"
+ function mainline_kernel_decide_version__750_use_torvalds_for_7.1-rc7() {
+ 	if [[ "${KERNELBRANCH}" == 'tag:v7.1-rc7' ]]; then
+ 		display_alert "Using Linus kernel repo for 7.1-rc7" "${KERNELBRANCH}" "warn"
  		declare -g KERNELSOURCE="https://github.com/torvalds/linux.git"
- 		display_alert "mainline-kernel: missing torvalds tag on 7.1-rc6" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
+ 		display_alert "mainline-kernel: missing torvalds tag on 7.1-rc7" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
  	fi
  }
 

--- a/patch/kernel/archive/rockchip64-7.1/regulator-add-fan53200-driver.patch
+++ b/patch/kernel/archive/rockchip64-7.1/regulator-add-fan53200-driver.patch
@@ -24,7 +24,7 @@ diff --git a/arch/arm64/configs/defconfig b/arch/arm64/configs/defconfig
 index 111111111111..222222222222 100644
 --- a/arch/arm64/configs/defconfig
 +++ b/arch/arm64/configs/defconfig
-@@ -866,6 +866,7 @@ CONFIG_REGULATOR_BD9571MWV=y
+@@ -867,6 +867,7 @@ CONFIG_REGULATOR_BD9571MWV=y
  CONFIG_REGULATOR_CROS_EC=y
  CONFIG_REGULATOR_DA9211=m
  CONFIG_REGULATOR_FAN53555=y

--- a/patch/kernel/archive/rockchip64-7.1/rk3588-1220-arm64-dts-rockchip-describe-pcie-ethernets-on-many-boards.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3588-1220-arm64-dts-rockchip-describe-pcie-ethernets-on-many-boards.patch
@@ -1,7 +1,7 @@
-From 66e234b8a759e479507e9298655af27254f3daf0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Mon, 1 Jun 2026 21:57:04 +0200
-Subject: [PATCH 1/7] dt-bindings: net: add Realtek r8169 family PCIe Ethernet
+Subject: dt-bindings: net: add Realtek r8169 family PCIe Ethernet
 
 Add a binding for fixed/soldered Realtek PCIe Ethernet controllers
 driven by the r8169 driver (RTL8125/8126/8127/8168 and variants).
@@ -16,14 +16,12 @@ these PCI function nodes can be validated.
 Suggested-by: Sebastian Reichel <sebastian.reichel@collabora.com>
 Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- .../bindings/net/realtek,r8169.yaml           | 54 +++++++++++++++++++
- MAINTAINERS                                   |  1 +
- 2 files changed, 55 insertions(+)
- create mode 100644 Documentation/devicetree/bindings/net/realtek,r8169.yaml
+ Documentation/devicetree/bindings/net/realtek,r8169.yaml | 54 ++++++++++
+ 1 file changed, 54 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/net/realtek,r8169.yaml b/Documentation/devicetree/bindings/net/realtek,r8169.yaml
 new file mode 100644
-index 0000000000000..6923211ff4c93
+index 000000000000..111111111111
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/net/realtek,r8169.yaml
 @@ -0,0 +1,54 @@
@@ -81,27 +79,13 @@ index 0000000000000..6923211ff4c93
 +            local-mac-address = [00 00 00 00 00 00];
 +        };
 +    };
-diff --git a/MAINTAINERS b/MAINTAINERS
-index b539be153f6a4..6341de4fadb6c 100644
---- a/MAINTAINERS
-+++ b/MAINTAINERS
-@@ -134,6 +134,7 @@ M:	Heiner Kallweit <hkallweit1@gmail.com>
- M:	nic_swsd@realtek.com
- L:	netdev@vger.kernel.org
- S:	Maintained
-+F:	Documentation/devicetree/bindings/net/realtek,r8169.yaml
- F:	drivers/net/ethernet/realtek/r8169*
- 
- 8250/16?50 (AND CLONE UARTS) SERIAL DRIVER
 -- 
-2.54.0
+Armbian
 
-
-From 8494a3f81766c93a11c0d6c59232f375d8f5e7cb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Mon, 12 Jan 2026 19:25:15 +0100
-Subject: [PATCH 2/7] arm64: dts: rockchip: describe PCIe RTL8125 Ethernets on
- NanoPC-T6
+Subject: arm64: dts: rockchip: describe PCIe RTL8125 Ethernets on NanoPC-T6
 
 The FriendlyElec NanoPC-T6 carries two on-board Realtek RTL8125 NICs
 behind pcie2x1l0 and pcie2x1l2.
@@ -114,11 +98,11 @@ stable MAC across boots that both U-Boot and the kernel agree on.
 
 Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- .../boot/dts/rockchip/rk3588-nanopc-t6.dtsi   | 30 +++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 30 ++++++++++
  1 file changed, 30 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-index 84b6b53f016ab..04c4479f08170 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
 @@ -20,6 +20,8 @@ / {
@@ -130,7 +114,7 @@ index 84b6b53f016ab..04c4479f08170 100644
  		mmc0 = &sdhci;
  		mmc1 = &sdmmc;
  	};
-@@ -635,6 +637,20 @@ &pcie2x1l0 {
+@@ -671,6 +673,20 @@ &pcie2x1l0 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&pcie2_0_rst>;
  	status = "okay";
@@ -151,7 +135,7 @@ index 84b6b53f016ab..04c4479f08170 100644
  };
  
  &pcie2x1l1 {
-@@ -651,6 +667,20 @@ &pcie2x1l2 {
+@@ -687,6 +703,20 @@ &pcie2x1l2 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&pcie2_2_rst>;
  	status = "okay";
@@ -173,14 +157,13 @@ index 84b6b53f016ab..04c4479f08170 100644
  
  &pcie30phy {
 -- 
-2.54.0
+Armbian
 
-
-From 221d265bba63db6da6e03c5560cb47f200b726df Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Mon, 1 Jun 2026 22:20:02 +0200
-Subject: [PATCH 3/7] arm64: dts: rockchip: describe PCIe RTL8125 Ethernet on
- FriendlyElec CM3588-NAS
+Subject: arm64: dts: rockchip: describe PCIe RTL8125 Ethernet on FriendlyElec
+ CM3588-NAS
 
 The FriendlyElec CM3588-NAS carrier carries an on-board Realtek
 RTL8125 NIC behind pcie2x1l2.
@@ -193,11 +176,11 @@ both U-Boot and the kernel agree on.
 
 Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- .../rk3588-friendlyelec-cm3588-nas.dts        | 21 +++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts | 21 ++++++++++
  1 file changed, 21 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts b/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
-index 10a7d3691a26f..ba21ffbaaedf7 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
 @@ -19,6 +19,10 @@ / {
@@ -211,7 +194,7 @@ index 10a7d3691a26f..ba21ffbaaedf7 100644
  	adc_key_recovery: adc-key-recovery {
  		compatible = "adc-keys";
  		io-channels = <&saradc 1>;
-@@ -473,6 +477,23 @@ &pcie2x1l1 {
+@@ -512,6 +516,23 @@ &pcie2x1l1 {
  	status = "okay";
  };
  
@@ -236,14 +219,13 @@ index 10a7d3691a26f..ba21ffbaaedf7 100644
  	/*
  	* Data lane mapping <1 3 2 4> = x1x1 x1x1 (bifurcation of both ports)
 -- 
-2.54.0
+Armbian
 
-
-From be0886fba8e0013cfd5edf4d06c214ebb0e442c5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Mon, 1 Jun 2026 22:42:11 +0200
-Subject: [PATCH 4/7] arm64: dts: rockchip: describe PCIe RTL8125 Ethernet on
- FriendlyElec NanoPi R5S
+Subject: arm64: dts: rockchip: describe PCIe RTL8125 Ethernet on FriendlyElec
+ NanoPi R5S
 
 The FriendlyElec NanoPi R5S (rk3568) carries two on-board Realtek
 RTL8125 NICs behind pcie2x1 and pcie3x1, alongside the existing gmac0
@@ -257,11 +239,11 @@ and the kernel agree on.
 
 Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- .../boot/dts/rockchip/rk3568-nanopi-r5s.dts   | 30 +++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3568-nanopi-r5s.dts | 30 ++++++++++
  1 file changed, 30 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3568-nanopi-r5s.dts b/arch/arm64/boot/dts/rockchip/rk3568-nanopi-r5s.dts
-index 718d1a2da8e56..488b5fb40522b 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3568-nanopi-r5s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-nanopi-r5s.dts
 @@ -15,6 +15,8 @@ / {
@@ -316,14 +298,13 @@ index 718d1a2da8e56..488b5fb40522b 100644
  
  &pcie3x2 {
 -- 
-2.54.0
+Armbian
 
-
-From 318a4577ff828ed37384b9b5e3f7527800ddfcd9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Mon, 1 Jun 2026 22:51:51 +0200
-Subject: [PATCH 5/7] arm64: dts: rockchip: describe PCIe RTL8125 Ethernet on
- FriendlyElec NanoPi R6C
+Subject: arm64: dts: rockchip: describe PCIe RTL8125 Ethernet on FriendlyElec
+ NanoPi R6C
 
 The FriendlyElec NanoPi R6C carries one on-board Realtek RTL8125 NIC
 (the LAN port; WAN uses the on-SoC gmac1 RGMII PHY) behind pcie2x1l1.
@@ -339,11 +320,11 @@ RTL8125-capable lane is empty compared to the R6S.
 
 Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- .../boot/dts/rockchip/rk3588s-nanopi-r6c.dts  | 21 +++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6c.dts | 21 ++++++++++
  1 file changed, 21 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6c.dts b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6c.dts
-index ccc5e46275176..b142df0b0e180 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6c.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6c.dts
 @@ -7,8 +7,29 @@
@@ -377,14 +358,13 @@ index ccc5e46275176..b142df0b0e180 100644
 +	};
 +};
 -- 
-2.54.0
+Armbian
 
-
-From fd0afdbbf82440d49611467535c76bc3af0324b6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Mon, 1 Jun 2026 22:12:31 +0200
-Subject: [PATCH 6/7] arm64: dts: rockchip: describe PCIe RTL8125 Ethernet on
- Radxa ROCK 5 family
+Subject: arm64: dts: rockchip: describe PCIe RTL8125 Ethernet on Radxa ROCK 5
+ family
 
 The Radxa ROCK 5B / 5B+ / 5T all carry on-board Realtek RTL8125 NICs.
 
@@ -398,12 +378,12 @@ additionally describes pcie2x1l1 with its second RTL8125.
 
 Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- .../dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi    | 15 +++++++++++++++
- .../arm64/boot/dts/rockchip/rk3588-rock-5t.dts | 18 ++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi | 15 ++++++++
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts         | 18 ++++++++++
  2 files changed, 33 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
-index bf4a1d2e55ca3..1b48f57638fca 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
 @@ -10,6 +10,7 @@
@@ -436,7 +416,7 @@ index bf4a1d2e55ca3..1b48f57638fca 100644
  
  &pcie30phy {
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
-index 425036146b6d9..116e3512c4413 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
 @@ -8,6 +8,10 @@ / {
@@ -472,14 +452,13 @@ index 425036146b6d9..116e3512c4413 100644
  
  &pcie30phy {
 -- 
-2.54.0
+Armbian
 
-
-From ba497ede96297b428a2723fb93a1dc10c8c98eb6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Wed, 3 Jun 2026 20:51:55 +0200
-Subject: [PATCH 7/7] arm64: dts: rockchip: describe PCIe RTL8125 Ethernet on
- Radxa ROCK 5 ITX
+Subject: arm64: dts: rockchip: describe PCIe RTL8125 Ethernet on Radxa ROCK 5
+ ITX
 
 The Radxa ROCK 5 ITX carries two on-board Realtek RTL8125 NICs behind
 pcie2x1l1 and pcie2x1l2.
@@ -491,11 +470,11 @@ boots that both U-Boot and the kernel agree on.
 
 Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- .../boot/dts/rockchip/rk3588-rock-5-itx.dts   | 30 +++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts | 30 ++++++++++
  1 file changed, 30 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
-index f7dd01d6fa0ab..8c6c29667ea02 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
 @@ -20,6 +20,8 @@ / {
@@ -550,5 +529,5 @@ index f7dd01d6fa0ab..8c6c29667ea02 100644
  
  &pcie30phy {
 -- 
-2.54.0
+Armbian
 


### PR DESCRIPTION
# Description

- bump to 7.1-rc7
- rockchip64-7.1: rewritten
- meson64-7.1: no changes


# How Has This Been Tested?

- [x] build rockchip64-7.1
- [x] build meson64-7.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Kernel Updates**
  * Mainline kernel version updated to v7.1-rc7

* **New Hardware Support**
  * FAN53200 voltage regulator support added for Tinkerboard-2, enabling enhanced power management
  * PCIe Ethernet devices now fully functional on multiple Rockchip-based boards with automatic MAC address detection and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->