### PR TITLE
sunxi: uwe5622: fix compile warnings -Wmissing-prototypes

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -590,6 +590,7 @@ driver_uwe5622() {
 
 		process_patch_file "${SRC}/patch/misc/wireless-uwe5622/wireless-uwe5622-Fix-compilation-with-6.7-kernel.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-uwe5622/wireless-uwe5622-reduce-system-load.patch" "applying"
+		process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-missing-prototypes.patch" "applying"
 
 		if linux-version compare "${version}" ge 6.9; then
 			process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-v6.9.patch" "applying"

--- a/patch/misc/wireless-uwe5622/uwe5622-missing-prototypes.patch
+++ b/patch/misc/wireless-uwe5622/uwe5622-missing-prototypes.patch
@@ -1,0 +1,13 @@
+From b758478655da935b50a973b0aa2ddbc20893b789 Mon Sep 17 00:00:00 2001
+From: Alastair D'Silva <alastair@d-silva.org>
+Date: Wed, 25 Mar 2026 18:40:00 +1100
+Subject: [PATCH] uwe5622: add missing prototypes to fix -Wmissing-prototypes
+
+Add unisoc_wifi_init and unisoc_wifi_exit prototypes to unisocwifi/main.c.
+
+--- a/drivers/net/wireless/uwe5622/unisocwifi/main.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/main.c
+@@ -1,0 +1,3 @@
++int unisoc_wifi_init(void);
++void unisoc_wifi_exit(void);
++


### PR DESCRIPTION
Add function prototypes to resolve compiler warnings and ensure correct linkage.

# Description

Add missing function prototypes for `unisoc_wifi_init(void)` and `unisoc_wifi_exit(void)` in the Unisoc UWE5622 wireless driver's main initialization file (`unisocwifi/main.c`). This resolves compiler warnings triggered by `-Wmissing-prototypes` during Armbian kernel builds, ensuring correct linkage and avoiding warning-induced compilation failures on modern toolchains.

# How Has This Been Tested?

- [x] Verified that compiling the `mellowflyc5` and `orangepizero3` kernels (which bundle the `uwe5622` driver) completes successfully without warning-induced compilation breaks.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved wireless driver code compilation by resolving build warnings to enhance overall code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->