### PR TITLE
bootscript: rk35xx: simplify armbianEnv.txt corruption detection

### DIFF
--- a/config/bootscripts/boot-seeed-rk35xx.cmd
+++ b/config/bootscripts/boot-seeed-rk35xx.cmd
@@ -22,22 +22,24 @@ test -n "${distro_bootpart}" || distro_bootpart=1
 echo "Boot script loaded from ${devtype} ${devnum}:${distro_bootpart}"
 
 # Load armbianEnv.txt with corruption detection and .bak fallback.
-# Power loss can fill the file with 0xFF (eMMC erased block) which passes
-# "env import -t" without error but imports zero variables. Clear rootdev
-# before import; if it remains empty, the file was corrupt.
+# Power loss can fill the file with 0xFF (eMMC erased block) or ^@ (NUL,
+# on other storage media) which passes "env import -t" without error but
+# imports zero variables. Clear rootdev before import; if it remains
+# empty, the file was corrupt.
 setenv rootdev
 if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt; then
 	env import -t ${load_addr} ${filesize}
 fi
 if test -z "${rootdev}"; then
 	if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt.bak; then
-		echo "Loading armbianEnv.txt.bak as fallback"
+		echo "WARNING: armbianEnv.txt corrupt, loading .bak fallback"
 		setenv rootdev
 		env import -t ${load_addr} ${filesize}
 	fi
 fi
 # Final safety: derive rootdev from boot source if still unset
 if test -z "${rootdev}"; then
+	echo "WARNING: rootdev not set, deriving from boot source ${devnum}:${distro_bootpart}"
 	setenv rootdev "/dev/mmcblk${devnum}p${distro_bootpart}"
 fi
 

--- a/config/bootscripts/boot-seeed-rk35xx.cmd
+++ b/config/bootscripts/boot-seeed-rk35xx.cmd
@@ -21,7 +21,7 @@ test -n "${distro_bootpart}" || distro_bootpart=1
 
 echo "Boot script loaded from ${devtype} ${devnum}:${distro_bootpart}"
 
-# Load armbianEnv.txt with corruption detection and .bak fallback.
+# Load armbianEnv.txt with corruption detection and .dist fallback.
 # Power loss can fill the file with 0xFF (eMMC erased block) or ^@ (NUL,
 # on other storage media) which passes "env import -t" without error but
 # imports zero variables. Clear rootdev before import; if it remains
@@ -31,8 +31,8 @@ if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv
 	env import -t ${load_addr} ${filesize}
 fi
 if test -z "${rootdev}"; then
-	if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt.bak; then
-		echo "WARNING: armbianEnv.txt corrupt, loading .bak fallback"
+	if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt.dist; then
+		echo "WARNING: armbianEnv.txt corrupt, loading .dist fallback"
 		setenv rootdev
 		env import -t ${load_addr} ${filesize}
 	fi

--- a/config/bootscripts/boot-seeed-rk35xx.cmd
+++ b/config/bootscripts/boot-seeed-rk35xx.cmd
@@ -22,30 +22,23 @@ test -n "${distro_bootpart}" || distro_bootpart=1
 echo "Boot script loaded from ${devtype} ${devnum}:${distro_bootpart}"
 
 # Load armbianEnv.txt with corruption detection and .bak fallback.
-# sed -i + power loss can zero or truncate the file.
-setenv armbian_env_loaded "no"
+# Power loss can fill the file with 0xFF (eMMC erased block) which passes
+# "env import -t" without error but imports zero variables. Clear rootdev
+# before import; if it remains empty, the file was corrupt.
+setenv rootdev
 if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt; then
-	if env import -t ${load_addr} ${filesize}; then
-		setenv armbian_env_loaded "yes"
-	else
-		echo "WARNING: armbianEnv.txt format error"
-	fi
+	env import -t ${load_addr} ${filesize}
 fi
-if test "${armbian_env_loaded}" = "no"; then
+if test -z "${rootdev}"; then
 	if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt.bak; then
 		echo "Loading armbianEnv.txt.bak as fallback"
-		if env import -t ${load_addr} ${filesize}; then
-			setenv armbian_env_loaded "yes"
-		else
-			echo "ERROR: armbianEnv.txt.bak format error"
-		fi
-	else
-		echo "WARNING: no armbianEnv.txt.bak found"
+		setenv rootdev
+		env import -t ${load_addr} ${filesize}
 	fi
 fi
-# Final safety: restore default rootdev if all sources failed
+# Final safety: derive rootdev from boot source if still unset
 if test -z "${rootdev}"; then
-	setenv rootdev "/dev/mmcblk0p1"
+	setenv rootdev "/dev/mmcblk${devnum}p${distro_bootpart}"
 fi
 
 # fdtfile is set by armbianEnv.txt (per-board BOOT_FDT_FILE).

--- a/config/sources/vendors/seeed-studio/recomputer-rk35xx-common.inc
+++ b/config/sources/vendors/seeed-studio/recomputer-rk35xx-common.inc
@@ -511,16 +511,16 @@ function post_family_tweaks__recomputer_rk35xx_disable_armbian_hardware_optimize
 	rm -f "${SDCARD}"/lib/systemd/system/armbian-hardware-optimize.service
 }
 
-# Create armbianEnv.txt.bak at build time.
+# Create armbianEnv.txt.dist at build time.
 # Protects against sed -i + power loss corruption.
 function pre_umount_final_image__recomputer_armbianenv_backup() {
-	display_alert "$BOARD" "Creating armbianEnv.txt backup" "info"
+	display_alert "$BOARD" "Creating armbianEnv.txt.dist fallback" "info"
 
 	local env_file="${MOUNT}/boot/armbianEnv.txt"
-	local bak_file="${MOUNT}/boot/armbianEnv.txt.bak"
+	local dist_file="${MOUNT}/boot/armbianEnv.txt.dist"
 
 	if [[ -f "${env_file}" ]]; then
-		cp -a "${env_file}" "${bak_file}"
-		display_alert "$BOARD" "armbianEnv.txt.bak created"
+		cp -a "${env_file}" "${dist_file}"
+		display_alert "$BOARD" "armbianEnv.txt.dist created"
 	fi
 }


### PR DESCRIPTION
## Summary
- Replace `armbian_env_loaded` flag approach with a simpler `rootdev` check to detect armbianEnv.txt corruption
- Use `part exists mmc` to probe the correct mmc device in the final fallback instead of hardcoding `mmcblk0`

## Details
Power loss can fill armbianEnv.txt with 0xFF (eMMC erased block) which passes `env import -t` without error but imports zero variables. The new approach clears `rootdev` before import and verifies it was actually set afterward. If not, falls back to `.bak`, and finally uses `part exists` to detect which mmc device is present.

## Test plan
- [ ] Boot RK3576 DevKit with valid armbianEnv.txt — verify normal boot
- [ ] Corrupt armbianEnv.txt (fill with 0xFF) — verify `.bak` fallback works
- [ ] Remove both armbianEnv.txt and `.bak` — verify `part exists` fallback boots correctly
- [ ] Test on both SD card (mmcblk1) and eMMC (mmcblk0) boot scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot resilience: detects and recovers from corrupted environment imports after power loss.
  * Automatically falls back to a backup environment when the primary import doesn't populate required boot settings.
  * Derives the fallback root device from detected boot hardware instead of using a fixed device path, increasing recovery reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->