### PR TITLE
armbian-firstlogin: power-loss recovery and atomic writes

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-common
+++ b/packages/bsp/common/usr/lib/armbian/armbian-common
@@ -41,7 +41,7 @@ atomic_write() {
 		chmod --reference="${dest}" "${src}"
 	fi
 	mv -f "${src}" "${dest}"
-	sync -f "${dest}" 2>/dev/null || sync "${dest}" 2>/dev/null
+	sync -f "${dest}" 2>/dev/null || sync
 }
 
 # Generate a random MAC address

--- a/packages/bsp/common/usr/lib/armbian/armbian-common
+++ b/packages/bsp/common/usr/lib/armbian/armbian-common
@@ -36,11 +36,11 @@ chmod +x /etc/update-motd.d/90-warning
 atomic_write() {
 	local src="$1" dest="$2" mode="${3:-}"
 	if [[ -n "${mode}" ]]; then
-		chmod "${mode}" "${src}"
+		chmod "${mode}" "${src}" || return
 	elif [[ -e "${dest}" ]]; then
-		chmod --reference="${dest}" "${src}"
+		chmod --reference="${dest}" "${src}" || return
 	fi
-	mv -f "${src}" "${dest}"
+	mv -f "${src}" "${dest}" || return
 	sync -f "${dest}" 2>/dev/null || sync
 }
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-common
+++ b/packages/bsp/common/usr/lib/armbian/armbian-common
@@ -27,21 +27,26 @@ chmod +x /etc/update-motd.d/90-warning
 } # show_motd_warning
 
 # Atomically replace dest with src via rename + sync, surviving power loss
-# at any point. Usage: atomic_write <src> <dest> [mode]
+# at any point. Usage: atomic_write <src> <dest> [mode] [owner]
 #   src  — temporary file with the new content (consumed/removed by this call)
 #   dest — target file to replace atomically
 #   mode — optional permission mode (e.g. 600); if omitted, preserves dest's mode
+#   owner — optional owner for the replacement, applied before rename
 # Uses mv (rename syscall) for atomicity — do NOT replace with `install`,
 # which copies data in-place and breaks crash safety on power loss.
 atomic_write() {
-	local src="$1" dest="$2" mode="${3:-}"
+	local src="$1" dest="$2" mode="${3:-}" owner="${4:-}"
 	if [[ -n "${mode}" ]]; then
 		chmod "${mode}" "${src}" || return
 	elif [[ -e "${dest}" ]]; then
 		chmod --reference="${dest}" "${src}" || return
 	fi
+	[[ -z "${owner}" ]] || chown "${owner}" "${src}" || return
 	mv -f "${src}" "${dest}" || return
-	sync -f "${dest}" 2>/dev/null || sync
+	# fsync the file contents and then its parent directory: the latter makes the
+	# rename itself durable across power loss.
+	sync -f "${dest}" 2>/dev/null || sync || return
+	sync -f "$(dirname "${dest}")" 2>/dev/null || sync
 }
 
 # Generate a random MAC address

--- a/packages/bsp/common/usr/lib/armbian/armbian-common
+++ b/packages/bsp/common/usr/lib/armbian/armbian-common
@@ -8,6 +8,7 @@
 
 # Functions:
 #
+# atomic_write
 # show_motd_warning
 # generate_random_mac
 # set_fixed_mac
@@ -24,6 +25,24 @@ rm "\$0"
 EOT
 chmod +x /etc/update-motd.d/90-warning
 } # show_motd_warning
+
+# Atomically replace dest with src via rename + sync, surviving power loss
+# at any point. Usage: atomic_write <src> <dest> [mode]
+#   src  — temporary file with the new content (consumed/removed by this call)
+#   dest — target file to replace atomically
+#   mode — optional permission mode (e.g. 600); if omitted, preserves dest's mode
+# Uses mv (rename syscall) for atomicity — do NOT replace with `install`,
+# which copies data in-place and breaks crash safety on power loss.
+atomic_write() {
+	local src="$1" dest="$2" mode="${3:-}"
+	if [[ -n "${mode}" ]]; then
+		chmod "${mode}" "${src}"
+	elif [[ -e "${dest}" ]]; then
+		chmod --reference="${dest}" "${src}"
+	fi
+	mv -f "${src}" "${dest}"
+	sync -f "${dest}" 2>/dev/null || sync "${dest}" 2>/dev/null
+}
 
 # Generate a random MAC address
 generate_random_mac ()

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -120,9 +120,10 @@ do_firstrun_automated_network_configuration()
 						DEVTYPE=wifis
 						local _f="/etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml"
 						if echo -e "$(createYAML)" > "${_f}.tmp"; then
-							atomic_write "${_f}.tmp" "${_f}" 600
+							atomic_write "${_f}.tmp" "${_f}" 600 || return 1
 						else
 							rm -f "${_f}.tmp"
+							return 1
 						fi
 						PRESET_NET_ETHERNET_ENABLED=0
 						netplan apply > /dev/null 2>&1
@@ -137,9 +138,10 @@ do_firstrun_automated_network_configuration()
 						DEVTYPE=ethernets
 						local _f="/etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml"
 						if echo -e "$(createYAML)" > "${_f}.tmp"; then
-							atomic_write "${_f}.tmp" "${_f}" 600
+							atomic_write "${_f}.tmp" "${_f}" 600 || return 1
 						else
 							rm -f "${_f}.tmp"
+							return 1
 						fi
 						PRESET_NET_WIFI_ENABLED=0
 						netplan apply > /dev/null 2>&1
@@ -269,16 +271,18 @@ set_shell() {
 	# /etc/adduser.conf is optional, so guard that edit.
 	local _f="/etc/default/useradd"
 	if sed "s|^SHELL=.*|SHELL=${SHELL_PATH}|" "${_f}" > "${_f}.tmp"; then
-		atomic_write "${_f}.tmp" "${_f}"
+		atomic_write "${_f}.tmp" "${_f}" || return 1
 	else
 		rm -f "${_f}.tmp"
+		return 1
 	fi
 	if [[ -f /etc/adduser.conf ]]; then
 		_f="/etc/adduser.conf"
 		if sed "s|^DSHELL=.*|DSHELL=${SHELL_PATH}|" "${_f}" > "${_f}.tmp"; then
-			atomic_write "${_f}.tmp" "${_f}"
+			atomic_write "${_f}.tmp" "${_f}" || return 1
 		else
 			rm -f "${_f}.tmp"
+			return 1
 		fi
 	fi
 
@@ -373,9 +377,10 @@ set_timezone_and_locales() {
 						         password: "${password}"
 						EOF
 						then
-							atomic_write "${_f}.tmp" "${_f}" 600
+							atomic_write "${_f}.tmp" "${_f}" 600 || return 1
 						else
 							rm -f "${_f}.tmp"
+							return 1
 						fi
 
 						# apply to netplan
@@ -514,13 +519,19 @@ set_timezone_and_locales() {
 		# change default locales (atomic write)
 		local _f="/etc/default/locale"
 		if sed "s/=.*/=$(echo ${LOCALES} | cut -d" " -f1)/g" "${_f}" > "${_f}.tmp"; then
-			atomic_write "${_f}.tmp" "${_f}"
+			atomic_write "${_f}.tmp" "${_f}" || return 1
+		else
+			rm -f "${_f}.tmp"
+			return 1
 		fi
 
 		# generate locales (atomic write for locale.gen)
 		local _f="/etc/locale.gen"
 		if sed 's/# '"${LOCALES}"'/'"${LOCALES}"'/' "${_f}" > "${_f}.tmp"; then
-			atomic_write "${_f}.tmp" "${_f}"
+			atomic_write "${_f}.tmp" "${_f}" || return 1
+		else
+			rm -f "${_f}.tmp"
+			return 1
 		fi
 		echo -e "Generating locales: \x1B[92m${LOCALES}\x1B[0m"
 		locale-gen "${LOCALES}" > /dev/null 2>&1
@@ -535,10 +546,11 @@ set_timezone_and_locales() {
 			fi
 			if ! grep -q "^export LC_ALL=$LOCALES" "$rcfile" 2>/dev/null; then
 				{
+					cat -- "$rcfile"
 					echo "export LC_ALL=$LOCALES"
 					echo "export LANG=$LOCALES"
 					echo "export LANGUAGE=$LOCALES"
-				} >> "$rcfile"
+				} > "${rcfile}.tmp" && atomic_write "${rcfile}.tmp" "$rcfile" "" "$RealUserName:$RealUserName" || return 1
 			fi
 		done
 
@@ -652,19 +664,26 @@ add_user() {
 				# comes from SHELL_PATH (set_shell ran first). Password is disabled here
 				# and set right below, same as adduser --disabled-password.
 				useradd --create-home --home-dir /home/"$RealUserName" --shell "$SHELL_PATH" \
-					--comment "$RealName" --user-group "$RealUserName"
+					--comment "$RealName" --user-group "$RealUserName" || return 1
 			elif [ ! -d "/home/$RealUserName" ]; then
-				mkdir -p /home/"$RealUserName"
-				cp -r /etc/skel/. /home/"$RealUserName"/ 2>/dev/null
-				chown -R "$RealUserName:$RealUserName" /home/"$RealUserName"
+				mkdir -p /home/"$RealUserName" || return 1
+				cp -r /etc/skel/. /home/"$RealUserName"/ 2>/dev/null || return 1
+				chown -R "$RealUserName:$RealUserName" /home/"$RealUserName" || return 1
 				echo -e "Repaired missing home directory for \e[0;92m$RealUserName\x1B[0m."
 			fi
 
 			# download and add SSH key if defined
 			if [[ -n "${PRESET_USER_KEY}" ]]; then
-				mkdir -p /home/"$RealUserName"/.ssh/
-				curl --retry 5 --connect-timeout 3 "${PRESET_USER_KEY}" > /home/"$RealUserName"/.ssh/authorized_keys 2> /dev/null
-				chown -R "$RealUserName":"$RealUserName" /home/"$RealUserName"/.ssh/
+				local _f="/home/$RealUserName/.ssh/authorized_keys"
+				mkdir -p /home/"$RealUserName"/.ssh/ || return 1
+				chown "$RealUserName:$RealUserName" /home/"$RealUserName"/.ssh/ || return 1
+				chmod 700 /home/"$RealUserName"/.ssh/ || return 1
+				if curl --retry 5 --connect-timeout 3 "${PRESET_USER_KEY}" > "${_f}.tmp" 2> /dev/null; then
+					atomic_write "${_f}.tmp" "${_f}" 600 "$RealUserName:$RealUserName" || return 1
+				else
+					rm -f "${_f}.tmp"
+					return 1
+				fi
 			fi
 
 			if [[ -n "$first_input" ]]; then
@@ -706,9 +725,10 @@ add_user() {
 				# need to restore or validate any dist version of /etc/sudoers.
 				local _f="/etc/sudoers.d/armbian-firstlogin-psd"
 				if echo "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" > "${_f}.tmp"; then
-					atomic_write "${_f}.tmp" "${_f}" 440
+					atomic_write "${_f}.tmp" "${_f}" 440 || return 1
 				else
 					rm -f "${_f}.tmp"
+					return 1
 				fi
 				touch /home/"${RealUserName}"/.activate_psd
 				chown "$RealUserName":"$RealUserName" /home/"${RealUserName}"/.activate_psd
@@ -754,10 +774,17 @@ if [[ -f /root/.not_logged_in_yet ]] && tty -s; then
 
 	# override configuration from URL
 	if [[ -n "${PRESET_CONFIGURATION}" ]]; then
-		curl --retry 5 --connect-timeout 3 "${PRESET_CONFIGURATION}" > /root/.not_logged_in_yet 2> /dev/null
+		_f="/root/.not_logged_in_yet"
+		if curl --retry 5 --connect-timeout 3 "${PRESET_CONFIGURATION}" > "${_f}.tmp" 2> /dev/null && bash -n "${_f}.tmp"; then
+			atomic_write "${_f}.tmp" "${_f}" 600 || exit 1
+			. "${_f}"
+		else
+			rm -f "${_f}.tmp"
+			exit 1
+		fi
 	fi
 
-	do_firstrun_automated_network_configuration
+	do_firstrun_automated_network_configuration || exit 1
 
 	# disable autologin (remove both generic and tty-specific paths)
 	rm -f /etc/systemd/system/getty@.service.d/override.conf
@@ -944,7 +971,7 @@ if [[ -f /root/.not_logged_in_yet ]] && tty -s; then
 
 	# ask user to select shell
 	trap '' 2
-	set_shell
+	set_shell || exit 1
 	trap - INT TERM EXIT
 
 	trap check_abort INT
@@ -953,7 +980,7 @@ if [[ -f /root/.not_logged_in_yet ]] && tty -s; then
 		[[ -z "${PRESET_USER_NAME}" ]] && echo -e "\nCreating a new user account. Press <Ctrl-C> to abort"
 		[[ "${desktop_dm}" != "none" ]] && echo -e "\n\e[0;31mDesktop environment will not be enabled if you abort the new user creation\x1B[0m"
 		add_user
-		if [[ -z "${RealUserName:-}" ]]; then
+		if [[ $? -ne 0 || -z "${RealUserName:-}" ]]; then
 			echo -e "\nUser creation failed. Retrying on next login."
 			exit 1
 		fi
@@ -962,7 +989,7 @@ if [[ -f /root/.not_logged_in_yet ]] && tty -s; then
 
 	# ask user to select automated locales or not
 	trap '' 2
-	set_timezone_and_locales
+	set_timezone_and_locales || exit 1
 	trap - INT TERM EXIT
 
 	if [[ ${USER_SHELL} == zsh ]]; then
@@ -972,15 +999,14 @@ if [[ -f /root/.not_logged_in_yet ]] && tty -s; then
 	# re-enable passing locale environment via ssh (atomic write)
 	_f="/etc/ssh/sshd_config"
 	if sed -E '/^[[:blank:]]*#[[:blank:]]*AcceptEnv[[:blank:]]+LANG/ s/^[[:blank:]]*#[[:blank:]]*//' "${_f}" > "${_f}.tmp"; then
-		atomic_write "${_f}.tmp" "${_f}"
+		atomic_write "${_f}.tmp" "${_f}" || exit 1
+	else
+		rm -f "${_f}.tmp"
+		exit 1
 	fi
-	# Delete marker BEFORE restarting sshd.  If the script is running
-	# over an SSH session, `systemctl restart ssh.service` kills the
-	# session and this script with it, so any code after the restart
-	# never executes.
-	rm -f /root/.not_logged_in_yet
-	# restart sshd daemon
-	systemctl restart ssh.service
+	# Reload keeps the active SSH session alive, so the marker can remain until
+	# every remaining firstlogin action completes.
+	systemctl reload ssh.service || exit 1
 
 	# rpardini: hacks per-dm, very much legacy stuff that works by a miracle
 	if [[ "${desktop_dm}" == "lightdm" ]] && [ -n "$RealName" ]; then
@@ -1145,4 +1171,7 @@ fi
 # All configuration complete - safe to remove firstlogin marker now
 # This must be the last operation to ensure power-loss during any
 # step above will cause firstlogin to re-run on next boot.
-tty -s && rm -f /root/.not_logged_in_yet
+if tty -s; then
+	rm -f /root/.not_logged_in_yet
+	sync -f /root 2>/dev/null || sync
+fi

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -14,24 +14,7 @@
 [[ -n "$DISTRIB_CODENAME" && -f /etc/armbian-distribution-status ]] && DISTRIBUTION_STATUS=$(grep "^$DISTRIB_CODENAME" /etc/armbian-distribution-status | cut -d"=" -f2 | cut -d";" -f1)
 
 . /etc/armbian-release
-
-# Atomic write helper: atomically replace dest with src via rename + sync.
-# Usage: atomic_write <src> <dest> [mode]
-#   src  — temporary file with new content (consumed/removed by this call)
-#   dest — target file to replace atomically
-#   mode — optional permission mode (e.g. 600); if omitted, preserves dest's mode
-# Uses mv (rename syscall) for atomicity — do NOT replace with `install`,
-# which copies data in-place and breaks crash safety on power loss.
-atomic_write() {
-	local src="$1" dest="$2" mode="${3:-}"
-	if [[ -n "$mode" ]]; then
-		chmod "$mode" "$src"
-	elif [[ -e "$dest" ]]; then
-		chmod --reference="$dest" "$src"
-	fi
-	mv -f "$src" "$dest"
-	sync -f "$dest" 2>/dev/null || sync "$dest" 2>/dev/null
-}
+. /usr/lib/armbian/armbian-common
 
 check_abort() {
 
@@ -137,7 +120,7 @@ do_firstrun_automated_network_configuration()
 						DEVTYPE=wifis
 						local _f="/etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml"
 						echo -e "$(createYAML)" > "${_f}.tmp"
-						atomic_write "${_f}.tmp" "$_f" 600
+						atomic_write "${_f}.tmp" "${_f}" 600
 						PRESET_NET_ETHERNET_ENABLED=0
 						netplan apply > /dev/null 2>&1
 
@@ -151,7 +134,7 @@ do_firstrun_automated_network_configuration()
 						DEVTYPE=ethernets
 						local _f="/etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml"
 						echo -e "$(createYAML)" > "${_f}.tmp"
-						atomic_write "${_f}.tmp" "$_f" 600
+						atomic_write "${_f}.tmp" "${_f}" 600
 						PRESET_NET_WIFI_ENABLED=0
 						netplan apply > /dev/null 2>&1
 				fi
@@ -276,14 +259,15 @@ set_shell() {
 	SHELL_PATH=$(grep "/$USER_SHELL$" /etc/shells | tail -1)
 	chsh -s "$(grep -iF "/$USER_SHELL" /etc/shells | tail -1)"
 
-	# change shell for future users. useradd (Essential, from passwd) reads
-	# /etc/default/useradd; /etc/adduser.conf only exists when the (now optional
-	# on Debian forky+) adduser package is installed, so guard that edit.
-	sed -i "s|^SHELL=.*|SHELL=${SHELL_PATH}|" /etc/default/useradd
-	sync -f /etc/default/useradd 2>/dev/null
+	# Change shell for future users. useradd reads /etc/default/useradd;
+	# /etc/adduser.conf is optional, so guard that edit.
+	local _f="/etc/default/useradd"
+	sed "s|^SHELL=.*|SHELL=${SHELL_PATH}|" "${_f}" > "${_f}.tmp"
+	atomic_write "${_f}.tmp" "${_f}"
 	if [[ -f /etc/adduser.conf ]]; then
-		sed -i "s|^DSHELL=.*|DSHELL=${SHELL_PATH}|" /etc/adduser.conf
-		sync -f /etc/adduser.conf 2>/dev/null
+		_f="/etc/adduser.conf"
+		sed "s|^DSHELL=.*|DSHELL=${SHELL_PATH}|" "${_f}" > "${_f}.tmp"
+		atomic_write "${_f}.tmp" "${_f}"
 	fi
 
 }
@@ -376,7 +360,7 @@ set_timezone_and_locales() {
 						        "$SSID":
 						         password: "${password}"
 						EOF
-						atomic_write "${_f}.tmp" "$_f" 600
+						atomic_write "${_f}.tmp" "${_f}" 600
 
 						# apply to netplan
 						systemctl daemon-reload
@@ -512,14 +496,15 @@ set_timezone_and_locales() {
 		dpkg-reconfigure --frontend=noninteractive tzdata > /dev/null 2>&1
 
 		# change default locales (atomic write)
-		if sed -i "s/=.*/=$(echo ${LOCALES} | cut -d" " -f1)/g" /etc/default/locale; then
-			sync -f /etc/default/locale 2>/dev/null
+		local _f="/etc/default/locale"
+		if sed "s/=.*/=$(echo ${LOCALES} | cut -d" " -f1)/g" "${_f}" > "${_f}.tmp"; then
+			atomic_write "${_f}.tmp" "${_f}"
 		fi
 
 		# generate locales (atomic write for locale.gen)
 		local _f="/etc/locale.gen"
-		if sed 's/# '"${LOCALES}"'/'"${LOCALES}"'/' "$_f" > "${_f}.tmp"; then
-			atomic_write "${_f}.tmp" "$_f"
+		if sed 's/# '"${LOCALES}"'/'"${LOCALES}"'/' "${_f}" > "${_f}.tmp"; then
+			atomic_write "${_f}.tmp" "${_f}"
 		fi
 		echo -e "Generating locales: \x1B[92m${LOCALES}\x1B[0m"
 		locale-gen "${LOCALES}" > /dev/null 2>&1
@@ -569,9 +554,9 @@ add_user() {
 	# Power-loss re-run: detect existing regular user, skip username prompt
 	local existing_user
 	existing_user=$(awk -F: '$3 >= 1000 && $1 != "nobody" {print $1; exit}' /etc/passwd)
-	if [ -n "$existing_user" ] && [ -d "/home/$existing_user" ]; then
-		RealUserName="$existing_user"
-		username="$existing_user"
+	if [ -n "${existing_user}" ] && [ -d "/home/${existing_user}" ]; then
+		RealUserName="${existing_user}"
+		username="${existing_user}"
 		echo -e "Detected existing user \e[0;92m$RealUserName\x1B[0m from previous setup, reusing."
 	else
 	while [ -f "/root/.not_logged_in_yet" ]; do
@@ -683,6 +668,8 @@ add_user() {
 			if ! grep -q '^root\s\+ALL' /etc/sudoers 2>/dev/null; then
 				# sudoers corrupted (power-loss), restore from dpkg default
 				local _f="/etc/sudoers"
+				# Note: quoted heredoc tag ('SUEOF') disables shell variable expansion;
+				# all content is literal — do not add $VAR references inside without unquoting.
 				cat > "${_f}.tmp" << 'SUEOF'
 Defaults	env_reset
 Defaults	mail_badpass
@@ -693,16 +680,16 @@ root	ALL=(ALL:ALL) ALL
 
 @includedir /etc/sudoers.d
 SUEOF
-				atomic_write "${_f}.tmp" "$_f" 440
+				atomic_write "${_f}.tmp" "${_f}" 440
 			fi
 			# set up profile sync daemon on desktop systems
 			if command -v psd > /dev/null 2>&1; then
 				# Add psd-overlay-helper to sudoers (atomic write, idempotent)
 				if ! grep -q "psd-overlay-helper" /etc/sudoers 2>/dev/null; then
 					local _f="/etc/sudoers"
-					cp -p "$_f" "${_f}.tmp"
+					cp -p "${_f}" "${_f}.tmp"
 					echo "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> "${_f}.tmp"
-					atomic_write "${_f}.tmp" "$_f"
+					atomic_write "${_f}.tmp" "${_f}"
 				fi
 				touch /home/"${RealUserName}"/.activate_psd
 				chown "$RealUserName":"$RealUserName" /home/"${RealUserName}"/.activate_psd
@@ -963,10 +950,10 @@ if [[ -f /root/.not_logged_in_yet && -n "$(tty)" ]]; then
 		printf "\nYou selected \e[0;91mZSH\x1B[0m as your default shell. If you want to use it right away, please logout and login! \n\n"
 	fi
 
-	# re-enable passing locale environment via ssh and allow root password login (atomic write)
+	# re-enable passing locale environment via ssh (atomic write)
 	_f="/etc/ssh/sshd_config"
-	if sed -e '/^#AcceptEnv LANG/ s/^#//' -e 's/^#PermitRootLogin.*/PermitRootLogin yes/' "$_f" > "${_f}.tmp"; then
-		atomic_write "${_f}.tmp" "$_f"
+	if sed -E '/^[[:blank:]]*#[[:blank:]]*AcceptEnv[[:blank:]]+LANG/ s/^[[:blank:]]*#[[:blank:]]*//' "${_f}" > "${_f}.tmp"; then
+		atomic_write "${_f}.tmp" "${_f}"
 	fi
 	# Delete marker BEFORE restarting sshd.  If the script is running
 	# over an SSH session, `systemctl restart ssh.service` kills the

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -511,6 +511,12 @@ set_timezone_and_locales() {
 
 		# setting detected locales only for user (idempotent)
 		for rcfile in /home/"$RealUserName"/.bashrc /home/"$RealUserName"/.xsessionrc; do
+			if [[ ! -e "$rcfile" ]]; then
+				# Create empty file with proper ownership before appending; leave
+				# ownership alone if the file already exists (user may have customized).
+				touch -- "$rcfile"
+				chown -- "$RealUserName":"$RealUserName" "$rcfile"
+			fi
 			if ! grep -q "^export LC_ALL=$LOCALES" "$rcfile" 2>/dev/null; then
 				{
 					echo "export LC_ALL=$LOCALES"

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -119,8 +119,11 @@ do_firstrun_automated_network_configuration()
 						DEVICE_NAME=${wlan_index}
 						DEVTYPE=wifis
 						local _f="/etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml"
-						echo -e "$(createYAML)" > "${_f}.tmp"
-						atomic_write "${_f}.tmp" "${_f}" 600
+						if echo -e "$(createYAML)" > "${_f}.tmp"; then
+							atomic_write "${_f}.tmp" "${_f}" 600
+						else
+							rm -f "${_f}.tmp"
+						fi
 						PRESET_NET_ETHERNET_ENABLED=0
 						netplan apply > /dev/null 2>&1
 
@@ -133,8 +136,11 @@ do_firstrun_automated_network_configuration()
 						DEVICE_NAME=${eth_index}
 						DEVTYPE=ethernets
 						local _f="/etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml"
-						echo -e "$(createYAML)" > "${_f}.tmp"
-						atomic_write "${_f}.tmp" "${_f}" 600
+						if echo -e "$(createYAML)" > "${_f}.tmp"; then
+							atomic_write "${_f}.tmp" "${_f}" 600
+						else
+							rm -f "${_f}.tmp"
+						fi
 						PRESET_NET_WIFI_ENABLED=0
 						netplan apply > /dev/null 2>&1
 				fi
@@ -262,12 +268,18 @@ set_shell() {
 	# Change shell for future users. useradd reads /etc/default/useradd;
 	# /etc/adduser.conf is optional, so guard that edit.
 	local _f="/etc/default/useradd"
-	sed "s|^SHELL=.*|SHELL=${SHELL_PATH}|" "${_f}" > "${_f}.tmp"
-	atomic_write "${_f}.tmp" "${_f}"
+	if sed "s|^SHELL=.*|SHELL=${SHELL_PATH}|" "${_f}" > "${_f}.tmp"; then
+		atomic_write "${_f}.tmp" "${_f}"
+	else
+		rm -f "${_f}.tmp"
+	fi
 	if [[ -f /etc/adduser.conf ]]; then
 		_f="/etc/adduser.conf"
-		sed "s|^DSHELL=.*|DSHELL=${SHELL_PATH}|" "${_f}" > "${_f}.tmp"
-		atomic_write "${_f}.tmp" "${_f}"
+		if sed "s|^DSHELL=.*|DSHELL=${SHELL_PATH}|" "${_f}" > "${_f}.tmp"; then
+			atomic_write "${_f}.tmp" "${_f}"
+		else
+			rm -f "${_f}.tmp"
+		fi
 	fi
 
 }
@@ -349,7 +361,7 @@ set_timezone_and_locales() {
 
 						# generate config
 						local _f="/etc/netplan/30-wifis-dhcp.yaml"
-						cat <<- EOF > "${_f}.tmp"
+						if cat <<- EOF > "${_f}.tmp"
 						# Created by Armbian firstlogin script
 						network:
 						  wifis:
@@ -360,7 +372,11 @@ set_timezone_and_locales() {
 						        "$SSID":
 						         password: "${password}"
 						EOF
-						atomic_write "${_f}.tmp" "${_f}" 600
+						then
+							atomic_write "${_f}.tmp" "${_f}" 600
+						else
+							rm -f "${_f}.tmp"
+						fi
 
 						# apply to netplan
 						systemctl daemon-reload
@@ -689,8 +705,11 @@ add_user() {
 				# recovery is simply "no drop-in" → re-run recreates it, and there is no
 				# need to restore or validate any dist version of /etc/sudoers.
 				local _f="/etc/sudoers.d/armbian-firstlogin-psd"
-				echo "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" > "${_f}.tmp"
-				atomic_write "${_f}.tmp" "${_f}" 440
+				if echo "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" > "${_f}.tmp"; then
+					atomic_write "${_f}.tmp" "${_f}" 440
+				else
+					rm -f "${_f}.tmp"
+				fi
 				touch /home/"${RealUserName}"/.activate_psd
 				chown "$RealUserName":"$RealUserName" /home/"${RealUserName}"/.activate_psd
 			fi

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -711,7 +711,7 @@ set_user_icon() {
 }
 
 
-if [[ -f /root/.not_logged_in_yet && -n "$(tty)" ]]; then
+if [[ -f /root/.not_logged_in_yet ]] && tty -s; then
 
 	. /root/.not_logged_in_yet
 
@@ -1108,4 +1108,4 @@ fi
 # All configuration complete - safe to remove firstlogin marker now
 # This must be the last operation to ensure power-loss during any
 # step above will cause firstlogin to re-run on next boot.
-[[ -n "$(tty)" ]] && rm -f /root/.not_logged_in_yet
+tty -s && rm -f /root/.not_logged_in_yet

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -15,6 +15,19 @@
 
 . /etc/armbian-release
 
+# Atomic write helper: mv tmp to dest with sync
+atomic_write() {
+	local dest="$1" mode="${2:-}"
+	local tmp="${dest}.tmp"
+	if [[ -n "$mode" ]]; then
+		chmod "$mode" "$tmp"
+	elif [[ -e "$dest" ]]; then
+		chmod --reference="$dest" "$tmp"
+	fi
+	mv -f "$tmp" "$dest"
+	sync -f "$dest" 2>/dev/null || sync "$dest" 2>/dev/null
+}
+
 check_abort() {
 
 	echo -e "\nDisabling user account creation procedure\n"
@@ -117,9 +130,8 @@ do_firstrun_automated_network_configuration()
 
 						DEVICE_NAME=${wlan_index}
 						DEVTYPE=wifis
-						echo -e "$(createYAML)" > /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml
-						chmod 600 /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml
-						#Enable Wlan, disable Eth
+						echo -e "$(createYAML)" > /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml.tmp
+						atomic_write /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml 600
 						PRESET_NET_ETHERNET_ENABLED=0
 						netplan apply > /dev/null 2>&1
 
@@ -131,9 +143,8 @@ do_firstrun_automated_network_configuration()
 
 						DEVICE_NAME=${eth_index}
 						DEVTYPE=ethernets
-						echo -e "$(createYAML)" > /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml
-						chmod 600 /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml
-						# Enable Eth, disable Wlan
+						echo -e "$(createYAML)" > /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml.tmp
+						atomic_write /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml 600
 						PRESET_NET_WIFI_ENABLED=0
 						netplan apply > /dev/null 2>&1
 				fi
@@ -262,7 +273,11 @@ set_shell() {
 	# /etc/default/useradd; /etc/adduser.conf only exists when the (now optional
 	# on Debian forky+) adduser package is installed, so guard that edit.
 	sed -i "s|^SHELL=.*|SHELL=${SHELL_PATH}|" /etc/default/useradd
-	[[ -f /etc/adduser.conf ]] && sed -i "s|^DSHELL=.*|DSHELL=${SHELL_PATH}|" /etc/adduser.conf
+	sync -f /etc/default/useradd 2>/dev/null
+	if [[ -f /etc/adduser.conf ]]; then
+		sed -i "s|^DSHELL=.*|DSHELL=${SHELL_PATH}|" /etc/adduser.conf
+		sync -f /etc/adduser.conf 2>/dev/null
+	fi
 
 }
 
@@ -342,7 +357,7 @@ set_timezone_and_locales() {
 						done
 
 						# generate config
-						cat <<- EOF > /etc/netplan/30-wifis-dhcp.yaml
+						cat <<- EOF > /etc/netplan/30-wifis-dhcp.yaml.tmp
 						# Created by Armbian firstlogin script
 						network:
 						  wifis:
@@ -353,7 +368,8 @@ set_timezone_and_locales() {
 						        "$SSID":
 						         password: "${password}"
 						EOF
-						chmod 600 /etc/netplan/30-wifis-dhcp.yaml
+						chmod 600 /etc/netplan/30-wifis-dhcp.yaml.tmp
+						atomic_write /etc/netplan/30-wifis-dhcp.yaml
 
 						# apply to netplan
 						systemctl daemon-reload
@@ -424,6 +440,7 @@ set_timezone_and_locales() {
 			jq '.timezone, .country, .country_code' |
 			while read -r TIMEZONE; do
 				read -r COUNTRY
+				read -r COUNTRYCODE
 				echo "${TIMEZONE},${COUNTRY},${COUNTRYCODE}" | tr --delete '"\n'
 			done
 	)
@@ -487,25 +504,28 @@ set_timezone_and_locales() {
 		timedatectl set-timezone "${TZDATA}"
 		dpkg-reconfigure --frontend=noninteractive tzdata > /dev/null 2>&1
 
-		# change default locales
-		sed -i "s/=.*/=$(echo ${LOCALES} | cut -d" " -f1)/g" /etc/default/locale
+		# change default locales (atomic write)
+		if sed -i "s/=.*/=$(echo ${LOCALES} | cut -d" " -f1)/g" /etc/default/locale; then
+			sync -f /etc/default/locale 2>/dev/null
+		fi
 
-		# generate locales
-		sed -i 's/# '"${LOCALES}"'/'"${LOCALES}"'/' /etc/locale.gen
+		# generate locales (atomic write for locale.gen)
+		if sed 's/# '"${LOCALES}"'/'"${LOCALES}"'/' /etc/locale.gen > /etc/locale.gen.tmp; then
+			atomic_write /etc/locale.gen
+		fi
 		echo -e "Generating locales: \x1B[92m${LOCALES}\x1B[0m"
 		locale-gen "${LOCALES}" > /dev/null 2>&1
 
-		# setting detected locales only for user
-		{
-			echo "export LC_ALL=$LOCALES"
-			echo "export LANG=$LOCALES"
-			echo "export LANGUAGE=$LOCALES"
-		} >> /home/"$RealUserName"/.bashrc
-		{
-			echo "export LC_ALL=$LOCALES"
-			echo "export LANG=$LOCALES"
-			echo "export LANGUAGE=$LOCALES"
-		} >> /home/"$RealUserName"/.xsessionrc
+		# setting detected locales only for user (idempotent)
+		for rcfile in /home/"$RealUserName"/.bashrc /home/"$RealUserName"/.xsessionrc; do
+			if ! grep -q "^export LC_ALL=$LOCALES" "$rcfile" 2>/dev/null; then
+				{
+					echo "export LC_ALL=$LOCALES"
+					echo "export LANG=$LOCALES"
+					echo "export LANGUAGE=$LOCALES"
+				} >> "$rcfile"
+			fi
+		done
 
 	fi
 }
@@ -537,6 +557,15 @@ add_profile_sync_settings() {
 add_user() {
 	read -r -t 0 _
 	REPEATS=3
+
+	# Power-loss re-run: detect existing regular user, skip username prompt
+	local existing_user
+	existing_user=$(awk -F: '$3 >= 1000 && $1 != "nobody" {print $1; exit}' /etc/passwd)
+	if [ -n "$existing_user" ] && [ -d "/home/$existing_user" ]; then
+		RealUserName="$existing_user"
+		username="$existing_user"
+		echo -e "Detected existing user \e[0;92m$RealUserName\x1B[0m from previous setup, reusing."
+	else
 	while [ -f "/root/.not_logged_in_yet" ]; do
 		[[ -z "${PRESET_USER_NAME}" ]] && echo -e "\nPlease provide a username (eg. your first name): \c"
 		if [ -z "$PRESET_USER_NAME" ];then
@@ -551,8 +580,13 @@ add_user() {
 
 		RealUserName="$(echo "$username" | tr '[:upper:]' '[:lower:]' | tr -d -c '[:alnum:]')"
 		[ -z "$RealUserName" ] && return
-		if ! id "$RealUserName" > /dev/null 2>&1; then break; else echo -e "Username \e[0;31m$RealUserName\x1B[0m already exists on the system."; fi
+		if ! id "$RealUserName" > /dev/null 2>&1; then
+			break
+		else
+			echo -e "Username \e[0;31m$RealUserName\x1B[0m already exists on the system."
+		fi
 	done
+	fi
 
 	# Set default user login icon
 	set_user_icon "$RealUserName"
@@ -588,13 +622,16 @@ add_user() {
 				RealName="$PRESET_DEFAULT_REALNAME"
 			fi
 
-			# useradd (Essential, from passwd) instead of adduser (optional on
-			# Debian forky+, absent from minimal images). --user-group mirrors
-			# adduser's per-user group; --create-home copies /etc/skel; login shell
-			# comes from SHELL_PATH (set_shell ran first). Password is disabled here
-			# and set right below, same as adduser --disabled-password.
-			useradd --create-home --home-dir /home/"$RealUserName" --shell "$SHELL_PATH" \
-				--comment "$RealName" --user-group "$RealUserName"
+			# Skip user creation if already exists (power-loss re-run)
+			if ! id "$RealUserName" > /dev/null 2>&1; then
+				# useradd (Essential, from passwd) instead of adduser (optional on
+				# Debian forky+, absent from minimal images). --user-group mirrors
+				# adduser's per-user group; --create-home copies /etc/skel; login shell
+				# comes from SHELL_PATH (set_shell ran first). Password is disabled here
+				# and set right below, same as adduser --disabled-password.
+				useradd --create-home --home-dir /home/"$RealUserName" --shell "$SHELL_PATH" \
+					--comment "$RealName" --user-group "$RealUserName"
+			fi
 
 			# download and add SSH key if defined
 			if [[ -n "${PRESET_USER_KEY}" ]]; then
@@ -631,10 +668,33 @@ add_user() {
 			[ -z "$RealName" ] && RealName="$RealUserName"
 			echo -e "\nDear \e[0;92m${RealName}\x1B[0m, your account \e[0;92m${RealUserName}\x1B[0m has been created and is sudo enabled."
 			echo -e "Please use this account for your daily work from now on.\n"
-			rm -f /root/.not_logged_in_yet
+			# .not_logged_in_yet is NOT deleted here - moved to end of script
+			# to ensure all subsequent configuration (timezone, SSH, desktop)
+			# completes before marking firstlogin as done
+			# Validate sudoers before modifying (detect power-loss corruption)
+			if ! grep -q '^root\s\+ALL' /etc/sudoers 2>/dev/null; then
+				# sudoers corrupted (power-loss), restore from dpkg default
+				cat > /etc/sudoers.tmp << 'SUEOF'
+Defaults	env_reset
+Defaults	mail_badpass
+Defaults	secure_path=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+root	ALL=(ALL:ALL) ALL
+%sudo	ALL=(ALL:ALL) ALL
+
+@includedir /etc/sudoers.d
+SUEOF
+				chmod 440 /etc/sudoers.tmp
+				atomic_write /etc/sudoers
+			fi
 			# set up profile sync daemon on desktop systems
 			if command -v psd > /dev/null 2>&1; then
-				echo -e "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> /etc/sudoers
+				# Add psd-overlay-helper to sudoers (atomic write, idempotent)
+				if ! grep -q "psd-overlay-helper" /etc/sudoers 2>/dev/null; then
+					cp -p /etc/sudoers /etc/sudoers.tmp
+					echo "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> /etc/sudoers.tmp
+					atomic_write /etc/sudoers
+				fi
 				touch /home/"${RealUserName}"/.activate_psd
 				chown "$RealUserName":"$RealUserName" /home/"${RealUserName}"/.activate_psd
 			fi
@@ -643,7 +703,7 @@ add_user() {
 			echo -e "Rejected - \e[0;31mpasswords do not match.\x1B[0m Try again [${REPEATS}]."
 			REPEATS=$((REPEATS - 1))
 		fi
-		[[ "$REPEATS" -eq 0 ]] && logout
+		[[ "$REPEATS" -eq 0 ]] && exit 0
 	done
 
 }
@@ -673,7 +733,7 @@ set_user_icon() {
 }
 
 
-if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
+if [[ -f /root/.not_logged_in_yet && -n "$(tty)" ]]; then
 
 	. /root/.not_logged_in_yet
 
@@ -684,9 +744,11 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 
 	do_firstrun_automated_network_configuration
 
-	# disable autologin
+	# disable autologin (remove both generic and tty-specific paths)
 	rm -f /etc/systemd/system/getty@.service.d/override.conf
+	rm -f /etc/systemd/system/getty@tty1.service.d/override.conf
 	rm -f /etc/systemd/system/serial-getty@.service.d/override.conf
+	rm -f /etc/systemd/system/serial-getty@ttyGS0.service.d/override.conf
 	systemctl daemon-reload
 
 	declare desktop_dm="none"
@@ -872,11 +934,15 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 
 	trap check_abort INT
 
-	while [ -f "/root/.not_logged_in_yet" ]; do
+	if [ -f "/root/.not_logged_in_yet" ]; then
 		[[ -z "${PRESET_USER_NAME}" ]] && echo -e "\nCreating a new user account. Press <Ctrl-C> to abort"
 		[[ "${desktop_dm}" != "none" ]] && echo -e "\n\e[0;31mDesktop environment will not be enabled if you abort the new user creation\x1B[0m"
 		add_user
-	done
+		if [[ -z "${RealUserName:-}" ]]; then
+			echo -e "\nUser creation failed. Retrying on next login."
+			exit 1
+		fi
+	fi
 	trap - INT TERM EXIT
 
 	# ask user to select automated locales or not
@@ -888,8 +954,15 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		printf "\nYou selected \e[0;91mZSH\x1B[0m as your default shell. If you want to use it right away, please logout and login! \n\n"
 	fi
 
-	# re-enable passing locale environment via ssh
-	sed -e '/^#AcceptEnv LANG/ s/^#//' -i /etc/ssh/sshd_config
+	# re-enable passing locale environment via ssh and allow root password login (atomic write)
+	if sed -e '/^#AcceptEnv LANG/ s/^#//' -e 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config > /etc/ssh/sshd_config.tmp; then
+		atomic_write /etc/ssh/sshd_config
+	fi
+	# Delete marker BEFORE restarting sshd.  If the script is running
+	# over an SSH session, `systemctl restart ssh.service` kills the
+	# session and this script with it, so any code after the restart
+	# never executes.
+	rm -f /root/.not_logged_in_yet
 	# restart sshd daemon
 	systemctl restart ssh.service
 
@@ -1052,3 +1125,8 @@ fi
 if [[ -f /root/provisioning.sh ]]; then
 	. /root/provisioning.sh
 fi
+
+# All configuration complete - safe to remove firstlogin marker now
+# This must be the last operation to ensure power-loss during any
+# step above will cause firstlogin to re-run on next boot.
+[[ -n "$(tty)" ]] && rm -f /root/.not_logged_in_yet

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -900,7 +900,13 @@ if [[ -f /root/.not_logged_in_yet ]] && tty -s; then
 			# download SSH key if defined
 			if [[ -n "${PRESET_ROOT_KEY}" ]]; then
 				mkdir -p /root/.ssh/
-				curl --retry 5 --connect-timeout 3 "${PRESET_ROOT_KEY}" > /root/.ssh/authorized_keys 2> /dev/null
+				_f="/root/.ssh/authorized_keys"
+				if curl --retry 5 --connect-timeout 3 "${PRESET_ROOT_KEY}" > "${_f}.tmp" 2> /dev/null; then
+					atomic_write "${_f}.tmp" "${_f}" 600 || exit 1
+				else
+					rm -f "${_f}.tmp"
+					exit 1
+				fi
 			fi
 		fi
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -15,16 +15,21 @@
 
 . /etc/armbian-release
 
-# Atomic write helper: mv tmp to dest with sync
+# Atomic write helper: atomically replace dest with src via rename + sync.
+# Usage: atomic_write <src> <dest> [mode]
+#   src  — temporary file with new content (consumed/removed by this call)
+#   dest — target file to replace atomically
+#   mode — optional permission mode (e.g. 600); if omitted, preserves dest's mode
+# Uses mv (rename syscall) for atomicity — do NOT replace with `install`,
+# which copies data in-place and breaks crash safety on power loss.
 atomic_write() {
-	local dest="$1" mode="${2:-}"
-	local tmp="${dest}.tmp"
+	local src="$1" dest="$2" mode="${3:-}"
 	if [[ -n "$mode" ]]; then
-		chmod "$mode" "$tmp"
+		chmod "$mode" "$src"
 	elif [[ -e "$dest" ]]; then
-		chmod --reference="$dest" "$tmp"
+		chmod --reference="$dest" "$src"
 	fi
-	mv -f "$tmp" "$dest"
+	mv -f "$src" "$dest"
 	sync -f "$dest" 2>/dev/null || sync "$dest" 2>/dev/null
 }
 
@@ -130,8 +135,9 @@ do_firstrun_automated_network_configuration()
 
 						DEVICE_NAME=${wlan_index}
 						DEVTYPE=wifis
-						echo -e "$(createYAML)" > /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml.tmp
-						atomic_write /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml 600
+						local _f="/etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml"
+						echo -e "$(createYAML)" > "${_f}.tmp"
+						atomic_write "${_f}.tmp" "$_f" 600
 						PRESET_NET_ETHERNET_ENABLED=0
 						netplan apply > /dev/null 2>&1
 
@@ -143,8 +149,9 @@ do_firstrun_automated_network_configuration()
 
 						DEVICE_NAME=${eth_index}
 						DEVTYPE=ethernets
-						echo -e "$(createYAML)" > /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml.tmp
-						atomic_write /etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml 600
+						local _f="/etc/netplan/30-${DEVTYPE}${CONFIG_NAME}.yaml"
+						echo -e "$(createYAML)" > "${_f}.tmp"
+						atomic_write "${_f}.tmp" "$_f" 600
 						PRESET_NET_WIFI_ENABLED=0
 						netplan apply > /dev/null 2>&1
 				fi
@@ -357,7 +364,8 @@ set_timezone_and_locales() {
 						done
 
 						# generate config
-						cat <<- EOF > /etc/netplan/30-wifis-dhcp.yaml.tmp
+						local _f="/etc/netplan/30-wifis-dhcp.yaml"
+						cat <<- EOF > "${_f}.tmp"
 						# Created by Armbian firstlogin script
 						network:
 						  wifis:
@@ -368,8 +376,7 @@ set_timezone_and_locales() {
 						        "$SSID":
 						         password: "${password}"
 						EOF
-						chmod 600 /etc/netplan/30-wifis-dhcp.yaml.tmp
-						atomic_write /etc/netplan/30-wifis-dhcp.yaml
+						atomic_write "${_f}.tmp" "$_f" 600
 
 						# apply to netplan
 						systemctl daemon-reload
@@ -510,8 +517,9 @@ set_timezone_and_locales() {
 		fi
 
 		# generate locales (atomic write for locale.gen)
-		if sed 's/# '"${LOCALES}"'/'"${LOCALES}"'/' /etc/locale.gen > /etc/locale.gen.tmp; then
-			atomic_write /etc/locale.gen
+		local _f="/etc/locale.gen"
+		if sed 's/# '"${LOCALES}"'/'"${LOCALES}"'/' "$_f" > "${_f}.tmp"; then
+			atomic_write "${_f}.tmp" "$_f"
 		fi
 		echo -e "Generating locales: \x1B[92m${LOCALES}\x1B[0m"
 		locale-gen "${LOCALES}" > /dev/null 2>&1
@@ -674,7 +682,8 @@ add_user() {
 			# Validate sudoers before modifying (detect power-loss corruption)
 			if ! grep -q '^root\s\+ALL' /etc/sudoers 2>/dev/null; then
 				# sudoers corrupted (power-loss), restore from dpkg default
-				cat > /etc/sudoers.tmp << 'SUEOF'
+				local _f="/etc/sudoers"
+				cat > "${_f}.tmp" << 'SUEOF'
 Defaults	env_reset
 Defaults	mail_badpass
 Defaults	secure_path=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -684,16 +693,16 @@ root	ALL=(ALL:ALL) ALL
 
 @includedir /etc/sudoers.d
 SUEOF
-				chmod 440 /etc/sudoers.tmp
-				atomic_write /etc/sudoers
+				atomic_write "${_f}.tmp" "$_f" 440
 			fi
 			# set up profile sync daemon on desktop systems
 			if command -v psd > /dev/null 2>&1; then
 				# Add psd-overlay-helper to sudoers (atomic write, idempotent)
 				if ! grep -q "psd-overlay-helper" /etc/sudoers 2>/dev/null; then
-					cp -p /etc/sudoers /etc/sudoers.tmp
-					echo "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> /etc/sudoers.tmp
-					atomic_write /etc/sudoers
+					local _f="/etc/sudoers"
+					cp -p "$_f" "${_f}.tmp"
+					echo "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> "${_f}.tmp"
+					atomic_write "${_f}.tmp" "$_f"
 				fi
 				touch /home/"${RealUserName}"/.activate_psd
 				chown "$RealUserName":"$RealUserName" /home/"${RealUserName}"/.activate_psd
@@ -955,8 +964,9 @@ if [[ -f /root/.not_logged_in_yet && -n "$(tty)" ]]; then
 	fi
 
 	# re-enable passing locale environment via ssh and allow root password login (atomic write)
-	if sed -e '/^#AcceptEnv LANG/ s/^#//' -e 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config > /etc/ssh/sshd_config.tmp; then
-		atomic_write /etc/ssh/sshd_config
+	_f="/etc/ssh/sshd_config"
+	if sed -e '/^#AcceptEnv LANG/ s/^#//' -e 's/^#PermitRootLogin.*/PermitRootLogin yes/' "$_f" > "${_f}.tmp"; then
+		atomic_write "${_f}.tmp" "$_f"
 	fi
 	# Delete marker BEFORE restarting sshd.  If the script is running
 	# over an SSH session, `systemctl restart ssh.service` kills the

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -560,7 +560,7 @@ add_user() {
 	# Power-loss re-run: detect existing regular user, skip username prompt
 	local existing_user
 	existing_user=$(awk -F: '$3 >= 1000 && $1 != "nobody" {print $1; exit}' /etc/passwd)
-	if [ -n "${existing_user}" ] && [ -d "/home/${existing_user}" ]; then
+	if [ -n "${existing_user}" ]; then
 		RealUserName="${existing_user}"
 		username="${existing_user}"
 		echo -e "Detected existing user \e[0;92m$RealUserName\x1B[0m from previous setup, reusing."
@@ -580,6 +580,11 @@ add_user() {
 		RealUserName="$(echo "$username" | tr '[:upper:]' '[:lower:]' | tr -d -c '[:alnum:]')"
 		[ -z "$RealUserName" ] && return
 		if ! id "$RealUserName" > /dev/null 2>&1; then
+			break
+		elif [ ! -d "/home/$RealUserName" ]; then
+			# Partially created user from a prior interrupted run: break and let
+			# the home-repair branch below recover it. Without this, PRESET_USER_NAME
+			# would loop forever on "already exists".
 			break
 		else
 			echo -e "Username \e[0;31m$RealUserName\x1B[0m already exists on the system."
@@ -621,7 +626,9 @@ add_user() {
 				RealName="$PRESET_DEFAULT_REALNAME"
 			fi
 
-			# Skip user creation if already exists (power-loss re-run)
+			# Skip user creation if already exists (power-loss re-run). If the user
+			# exists but home is missing (passwd written, home creation interrupted),
+			# rebuild it from /etc/skel with correct ownership so the user can log in.
 			if ! id "$RealUserName" > /dev/null 2>&1; then
 				# useradd (Essential, from passwd) instead of adduser (optional on
 				# Debian forky+, absent from minimal images). --user-group mirrors
@@ -630,6 +637,11 @@ add_user() {
 				# and set right below, same as adduser --disabled-password.
 				useradd --create-home --home-dir /home/"$RealUserName" --shell "$SHELL_PATH" \
 					--comment "$RealName" --user-group "$RealUserName"
+			elif [ ! -d "/home/$RealUserName" ]; then
+				mkdir -p /home/"$RealUserName"
+				cp -r /etc/skel/. /home/"$RealUserName"/ 2>/dev/null
+				chown -R "$RealUserName:$RealUserName" /home/"$RealUserName"
+				echo -e "Repaired missing home directory for \e[0;92m$RealUserName\x1B[0m."
 			fi
 
 			# download and add SSH key if defined

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -664,33 +664,15 @@ add_user() {
 			# .not_logged_in_yet is NOT deleted here - moved to end of script
 			# to ensure all subsequent configuration (timezone, SSH, desktop)
 			# completes before marking firstlogin as done
-			# Validate sudoers before modifying (detect power-loss corruption)
-			if ! grep -q '^root\s\+ALL' /etc/sudoers 2>/dev/null; then
-				# sudoers corrupted (power-loss), restore from dpkg default
-				local _f="/etc/sudoers"
-				# Note: quoted heredoc tag ('SUEOF') disables shell variable expansion;
-				# all content is literal — do not add $VAR references inside without unquoting.
-				cat > "${_f}.tmp" << 'SUEOF'
-Defaults	env_reset
-Defaults	mail_badpass
-Defaults	secure_path=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
-root	ALL=(ALL:ALL) ALL
-%sudo	ALL=(ALL:ALL) ALL
-
-@includedir /etc/sudoers.d
-SUEOF
-				atomic_write "${_f}.tmp" "${_f}" 440
-			fi
 			# set up profile sync daemon on desktop systems
 			if command -v psd > /dev/null 2>&1; then
-				# Add psd-overlay-helper to sudoers (atomic write, idempotent)
-				if ! grep -q "psd-overlay-helper" /etc/sudoers 2>/dev/null; then
-					local _f="/etc/sudoers"
-					cp -p "${_f}" "${_f}.tmp"
-					echo "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> "${_f}.tmp"
-					atomic_write "${_f}.tmp" "${_f}"
-				fi
+				# Grant psd-overlay-helper NOPASSWD via a sudoers drop-in (atomic write).
+				# Using /etc/sudoers.d/ avoids touching /etc/sudoers directly: power-loss
+				# recovery is simply "no drop-in" → re-run recreates it, and there is no
+				# need to restore or validate any dist version of /etc/sudoers.
+				local _f="/etc/sudoers.d/armbian-firstlogin-psd"
+				echo "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" > "${_f}.tmp"
+				atomic_write "${_f}.tmp" "${_f}" 440
 				touch /home/"${RealUserName}"/.activate_psd
 				chown "$RealUserName":"$RealUserName" /home/"${RealUserName}"/.activate_psd
 			fi

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -62,17 +62,15 @@ case "$1" in
 
 	# randomize mac in armbianEnv.txt (atomic write to survive power loss)
 	if [[ -f /boot/armbianEnv.txt ]]; then
-		generate_random_mac; mac0="$MACADDR"
-		generate_random_mac; mac1="$MACADDR"
+		generate_random_mac; mac0="${MACADDR}"
+		generate_random_mac; mac1="${MACADDR}"
+		_f="/boot/armbianEnv.txt"
 		if sed -e "s/^ethaddr=.*/ethaddr=${mac0}/" \
 		       -e "s/^eth1addr=.*/eth1addr=${mac1}/" \
-		       /boot/armbianEnv.txt > /boot/armbianEnv.txt.tmp \
-		   && chmod --reference=/boot/armbianEnv.txt /boot/armbianEnv.txt.tmp \
-		   && sync /boot/armbianEnv.txt.tmp \
-		   && mv /boot/armbianEnv.txt.tmp /boot/armbianEnv.txt; then
-			:
+		       "${_f}" > "${_f}.tmp"; then
+			atomic_write "${_f}.tmp" "${_f}"
 		else
-			rm -f /boot/armbianEnv.txt.tmp
+			rm -f "${_f}.tmp"
 		fi
 	fi
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -68,7 +68,7 @@ case "$1" in
 		if sed -e "s/^ethaddr=.*/ethaddr=${mac0}/" \
 		       -e "s/^eth1addr=.*/eth1addr=${mac1}/" \
 		       "${_f}" > "${_f}.tmp"; then
-			atomic_write "${_f}.tmp" "${_f}"
+			atomic_write "${_f}.tmp" "${_f}" || exit 1
 		else
 			rm -f "${_f}.tmp"
 		fi


### PR DESCRIPTION
## Summary

- Add power-loss recovery: if firstlogin is interrupted (power loss), re-running detects existing user and skips prompts
- Replace non-atomic `sed -i` with atomic write pattern (`sed` to temp file → `sync` → `mv`) for critical config files (sudoers, sshd_config, locale.gen, netplan)
- Add `chmod --reference` to preserve original file permissions in atomic writes (per feedback on #9937)
- Move `.not_logged_in_yet` deletion to end of script so any interrupted step causes re-run
- Add sudoers corruption detection and recovery from power loss
- Make locale exports idempotent (avoid duplicate entries on re-run)
- Fix `logout` → `exit 0` (correct for subshell context)
- Fix unquoted `$(tty)` in test
- Add autologin cleanup for tty-specific override paths

## Background

On embedded devices (e.g. reComputer RK3576), power loss during first boot is a real scenario. The stock `armbian-firstlogin` has several issues:

1. **Non-atomic writes**: `sed -i` truncates and rewrites — power loss during this window leaves zero-filled files
2. **No re-run recovery**: if interrupted after user creation but before completing all config, the marker file is already deleted and firstlogin won't re-run
3. **Non-idempotent**: locale exports are appended unconditionally, causing duplicates on re-run

## Test plan

- [ ] Flash image to device, complete first boot successfully
- [ ] Verify user creation, locale, timezone, SSH config all work
- [ ] Simulate power loss at various points during firstlogin and verify recovery on next boot
- [ ] Verify `armbianEnv.txt`, `sudoers`, `sshd_config` are valid after reboot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More resilient, power-loss-safe updates for network, locale, SSH, and sudoers using atomic, permission-preserving writes.
  * Improved first-boot user-creation flow: re-runs safely, reuses existing home directories when appropriate, avoids duplicates, and retries cleanly on failure.
  * Enhanced locale and geolocation handling (including country code support) and idempotent per-user shell configuration changes.
  * Stricter firstlogin/TTY gating, expanded autologin disable cleanup, safer marker deletion ordering, and improved MAC randomization updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->