### PR TITLE
sunxi: patch maint

### DIFF
--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
@@ -20,18 +20,18 @@ SUNXI_AHUB_I2S_CLKD(1) to 0x90.
 
 Signed-off-by: joakimtoe <joakimtoe@gmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 16 ++++++++++++++--
- drivers/clk/sunxi-ng/ccu-sun50i-h616.c         |  4 +---
- include/dt-bindings/clock/sun50i-h616-ccu.h    |  2 ++
- sound/soc/sunxi_v2/snd_sunxi_ahub.c            |  4 ++--
- sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c        | 28 +++++++++++++------------
- 5 files changed, 34 insertions(+), 20 deletions(-)
+ arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 16 ++++-
+ drivers/clk/sunxi-ng/ccu-sun50i-h616.c         |  4 +-
+ include/dt-bindings/clock/sun50i-h616-ccu.h    |  2 +
+ sound/soc/sunxi_v2/snd_sunxi_ahub.c            |  4 +-
+ sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c        | 35 +++++-----
+ 5 files changed, 35 insertions(+), 26 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -1085,8 +1085,8 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+@@ -841,8 +841,8 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
  			compatible = "allwinner,sunxi-snd-plat-ahub_dam";
  			reg        = <0x05097000 0x1000>;
  			resets     = <&ccu RST_BUS_AUDIO_HUB>;
@@ -42,7 +42,7 @@ index 111111111111..222222222222 100644
  				     <&ccu CLK_AUDIO_HUB>,
  				     <&ccu CLK_BUS_AUDIO_HUB>;
                          clock-names =   "clk_pll_audio",
-@@ -1096,6 +1096,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+@@ -852,6 +852,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
  			status = "disabled";
  		};
  
@@ -60,16 +60,19 @@ index 111111111111..222222222222 100644
  		ahub1_plat:ahub1_plat {
  			#sound-dai-cells = <0>;
  			compatible      = "allwinner,sunxi-snd-plat-ahub";
-@@ -1301,0 +1312,1 @@ hdmi: hdmi@6000000 {
+@@ -1055,6 +1066,7 @@ ohci3: usb@5311400 {
+ 		hdmi: hdmi@6000000 {
+ 			compatible = "allwinner,sun50i-h616-dw-hdmi",
+ 				     "allwinner,sun50i-h6-dw-hdmi";
 +			#sound-dai-cells = <0>;
+ 			reg = <0x06000000 0x10000>;
+ 			reg-io-width = <1>;
+ 			interrupts = <GIC_SPI 63 IRQ_TYPE_LEVEL_HIGH>;
 diff --git a/drivers/clk/sunxi-ng/ccu-sun50i-h616.c b/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
 index 111111111111..222222222222 100644
 --- a/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
 +++ b/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
-@@ -232,14 +232,12 @@ static struct ccu_nm pll_audio_hs_clk = {
- 	.enable		= BIT(31),
- 	.lock		= BIT(28),
- 	.n		= _SUNXI_CCU_MULT_MIN(8, 8, 12),
+@@ -235,10 +235,8 @@ static struct ccu_nm pll_audio_hs_clk = {
  	.m		= _SUNXI_CCU_DIV(16, 6),
  	.sdm		= _SUNXI_CCU_SDM(pll_audio_sdm_table,
  					 BIT(24), 0x178, BIT(31)),
@@ -81,7 +84,6 @@ index 111111111111..222222222222 100644
  		.reg		= 0x078,
  		.hw.init	= CLK_HW_INIT("pll-audio-hs", "osc24M",
  					      &ccu_nm_ops,
- 					      CLK_SET_RATE_UNGATE),
 diff --git a/include/dt-bindings/clock/sun50i-h616-ccu.h b/include/dt-bindings/clock/sun50i-h616-ccu.h
 index 111111111111..222222222222 100644
 --- a/include/dt-bindings/clock/sun50i-h616-ccu.h
@@ -99,7 +101,7 @@ diff --git a/sound/soc/sunxi_v2/snd_sunxi_ahub.c b/sound/soc/sunxi_v2/snd_sunxi_
 index 111111111111..222222222222 100644
 --- a/sound/soc/sunxi_v2/snd_sunxi_ahub.c
 +++ b/sound/soc/sunxi_v2/snd_sunxi_ahub.c
-@@ -100,7 +100,7 @@ static int sunxi_ahub_dai_set_pll(struct snd_soc_dai *dai,
+@@ -114,7 +114,7 @@ static int sunxi_ahub_dai_set_pll(struct snd_soc_dai *dai,
                         return -EINVAL;
                 }
         }
@@ -108,7 +110,7 @@ index 111111111111..222222222222 100644
                 SND_LOG_ERR(HLOG, "freq : %u module clk unsupport\n", freq_out);
                 return -EINVAL;
         }
-@@ -275,7 +275,7 @@ static int sunxi_ahub_dai_set_bclk_ratio(struct snd_soc_dai *dai, unsigned int
+@@ -286,7 +286,7 @@ static int sunxi_ahub_dai_set_bclk_ratio(struct snd_soc_dai *dai, unsigned int r
  
         regmap_update_bits(regmap, SUNXI_AHUB_I2S_CLKD(tdm_num),
                            0xf << I2S_CLKD_BCLKDIV,
@@ -152,7 +154,7 @@ index 111111111111..222222222222 100644
  
  	/* enable clk of ahub */
  	if (clk_prepare_enable(clk_info->clk_pll)) {
-@@ -400,13 +400,11 @@ static int snd_soc_sunxi_ahub_clk_init(struct platform_device *pdev,
+@@ -404,14 +404,12 @@ static int snd_soc_sunxi_ahub_clk_init(struct platform_device *pdev,
  	return 0;
  
  err_module_clk_enable:
@@ -170,7 +172,8 @@ index 111111111111..222222222222 100644
 +	clk_put(clk_info->clk_pll);
  err_pll_clk:
  	clk_put(clk_info->clk_module);
-@@ -481,8 +479,7 @@ static int sunxi_ahub_dam_dev_remove(struct platform_device *pdev)
+ err_module_clk:
+@@ -481,8 +479,7 @@ static void sunxi_ahub_dam_dev_remove(struct platform_device *pdev)
  	clk_put(clk_info->clk_module);
  	clk_disable_unprepare(clk_info->clk_pll);
  	clk_put(clk_info->clk_pll);
@@ -182,3 +185,4 @@ index 111111111111..222222222222 100644
  	reset_control_assert(clk_info->clk_rst);
 -- 
 Armbian
+

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h6-h616-add-sunxi-info-nodes.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h6-h616-add-sunxi-info-nodes.patch
@@ -42,7 +42,7 @@ diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dt
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -1627,6 +1627,25 @@ r_rsb: rsb@7083000 {
+@@ -1628,6 +1628,25 @@ r_rsb: rsb@7083000 {
  			#address-cells = <1>;
  			#size-cells = <0>;
  		};

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-usb-gadget-composite-rename-serial-manufacturer.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-usb-gadget-composite-rename-serial-manufacturer.patch
@@ -13,7 +13,7 @@ diff --git a/drivers/usb/gadget/composite.c b/drivers/usb/gadget/composite.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/gadget/composite.c
 +++ b/drivers/usb/gadget/composite.c
-@@ -2756,7 +2756,7 @@ EXPORT_SYMBOL_GPL(usb_composite_setup_continue);
+@@ -2759,7 +2759,7 @@ EXPORT_SYMBOL_GPL(usb_composite_setup_continue);
  
  static char *composite_default_mfr(struct usb_gadget *gadget)
  {

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/fixes-6.18/0019-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/fixes-6.18/0019-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
@@ -20,7 +20,7 @@ diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
-@@ -2553,6 +2553,7 @@ static struct usb_serial_driver option_1port_device = {
+@@ -2560,6 +2560,7 @@ static struct usb_serial_driver option_1port_device = {
  #ifdef CONFIG_PM
  	.suspend           = usb_wwan_suspend,
  	.resume            = usb_wwan_resume,

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/speed-6.18/0003-Mark-some-slow-drivers-for-async-probe-with-PROBE_PR.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/speed-6.18/0003-Mark-some-slow-drivers-for-async-probe-with-PROBE_PR.patch
@@ -27,7 +27,7 @@ diff --git a/drivers/nfc/nxp-nci/i2c.c b/drivers/nfc/nxp-nci/i2c.c
 index 111111111111..222222222222 100644
 --- a/drivers/nfc/nxp-nci/i2c.c
 +++ b/drivers/nfc/nxp-nci/i2c.c
-@@ -348,6 +348,7 @@ static struct i2c_driver nxp_nci_i2c_driver = {
+@@ -367,6 +367,7 @@ static struct i2c_driver nxp_nci_i2c_driver = {
  		   .name = NXP_NCI_I2C_DRIVER_NAME,
  		   .acpi_match_table = ACPI_PTR(acpi_id),
  		   .of_match_table = of_nxp_nci_i2c_match,

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/tcpm-6.18/0001-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/tcpm-6.18/0001-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
@@ -13,7 +13,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3119,7 +3119,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3146,7 +3146,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  {
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
@@ -22,7 +22,7 @@ index 111111111111..222222222222 100644
  
  	if (!port->partner_pd)
  		port->partner_pd = usb_power_delivery_register(NULL, &desc);
-@@ -3129,11 +3129,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3156,11 +3156,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	memcpy(caps.pdo, port->source_caps, sizeof(u32) * port->nr_source_caps);
  	caps.role = TYPEC_SOURCE;
  

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/tcpm-6.18/0002-usb-typec-altmodes-displayport-Respect-DP_CAP_RECEPT.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/tcpm-6.18/0002-usb-typec-altmodes-displayport-Respect-DP_CAP_RECEPT.patch
@@ -21,7 +21,7 @@ diff --git a/drivers/usb/typec/altmodes/displayport.c b/drivers/usb/typec/altmod
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/altmodes/displayport.c
 +++ b/drivers/usb/typec/altmodes/displayport.c
-@@ -762,14 +762,36 @@ int dp_altmode_probe(struct typec_altmode *alt)
+@@ -764,14 +764,36 @@ int dp_altmode_probe(struct typec_altmode *alt)
  	struct typec_altmode *plug = typec_altmode_get_plug(alt, TYPEC_PLUG_SOP_P);
  	struct fwnode_handle *fwnode;
  	struct dp_altmode *dp;

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/tcpm-6.18/0003-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/tcpm-6.18/0003-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
@@ -37,7 +37,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -1868,6 +1868,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
+@@ -1870,6 +1870,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
  		return;
  
  	for (i = 0; i < modep->altmodes; i++) {

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/tcpm-6.18/0004-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/tcpm-6.18/0004-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3123,15 +3123,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3150,15 +3150,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -45,7 +45,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -3146,15 +3153,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
+@@ -3173,15 +3180,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -72,7 +72,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -7221,10 +7235,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
+@@ -7248,10 +7262,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
  		port->pds[i] = usb_power_delivery_register(port->dev, &desc);
  		if (IS_ERR(port->pds[i])) {
  			ret = PTR_ERR(port->pds[i]);

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/tcpm-6.18/0005-usb-typec-tcpm-Improve-logs.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/tcpm-6.18/0005-usb-typec-tcpm-Improve-logs.patch
@@ -30,7 +30,7 @@ index 111111111111..222222222222 100644
  
  	reinit_completion(&port->tx_complete);
  	ret = port->tcpc->pd_transmit(port->tcpc, tx_sop_type, msg, negotiated_rev);
-@@ -3806,6 +3809,10 @@ void tcpm_pd_receive(struct tcpm_port *port, const struct pd_message *msg,
+@@ -3833,6 +3836,10 @@ void tcpm_pd_receive(struct tcpm_port *port, const struct pd_message *msg,
  		     enum tcpm_transmit_type rx_sop_type)
  {
  	struct pd_rx_event *event;
@@ -41,7 +41,7 @@ index 111111111111..222222222222 100644
  
  	event = kzalloc(sizeof(*event), GFP_ATOMIC);
  	if (!event)
-@@ -6166,7 +6173,7 @@ static void _tcpm_cc_change(struct tcpm_port *port, enum typec_cc_status cc1,
+@@ -6193,7 +6200,7 @@ static void _tcpm_cc_change(struct tcpm_port *port, enum typec_cc_status cc1,
  
  static void _tcpm_pd_vbus_on(struct tcpm_port *port)
  {
@@ -50,7 +50,7 @@ index 111111111111..222222222222 100644
  	port->vbus_present = true;
  	/*
  	 * When vbus_present is true i.e. Voltage at VBUS is greater than VSAFE5V implicitly
-@@ -6256,7 +6263,7 @@ static void _tcpm_pd_vbus_on(struct tcpm_port *port)
+@@ -6283,7 +6290,7 @@ static void _tcpm_pd_vbus_on(struct tcpm_port *port)
  
  static void _tcpm_pd_vbus_off(struct tcpm_port *port)
  {

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
@@ -20,18 +20,18 @@ SUNXI_AHUB_I2S_CLKD(1) to 0x90.
 
 Signed-off-by: joakimtoe <joakimtoe@gmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 16 ++++++++++++++--
- drivers/clk/sunxi-ng/ccu-sun50i-h616.c         |  4 +---
- include/dt-bindings/clock/sun50i-h616-ccu.h    |  2 ++
- sound/soc/sunxi_v2/snd_sunxi_ahub.c            |  4 ++--
- sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c        | 28 +++++++++++++------------
- 5 files changed, 34 insertions(+), 20 deletions(-)
+ arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 16 ++++-
+ drivers/clk/sunxi-ng/ccu-sun50i-h616.c         |  4 +-
+ include/dt-bindings/clock/sun50i-h616-ccu.h    |  2 +
+ sound/soc/sunxi_v2/snd_sunxi_ahub.c            |  4 +-
+ sound/soc/sunxi_v2/snd_sunxi_ahub_dam.c        | 35 +++++-----
+ 5 files changed, 35 insertions(+), 26 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -1085,8 +1085,8 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+@@ -893,8 +893,8 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
  			compatible = "allwinner,sunxi-snd-plat-ahub_dam";
  			reg        = <0x05097000 0x1000>;
  			resets     = <&ccu RST_BUS_AUDIO_HUB>;
@@ -42,7 +42,7 @@ index 111111111111..222222222222 100644
  				     <&ccu CLK_AUDIO_HUB>,
  				     <&ccu CLK_BUS_AUDIO_HUB>;
                          clock-names =   "clk_pll_audio",
-@@ -1096,6 +1096,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+@@ -904,6 +904,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
  			status = "disabled";
  		};
  
@@ -60,16 +60,19 @@ index 111111111111..222222222222 100644
  		ahub1_plat:ahub1_plat {
  			#sound-dai-cells = <0>;
  			compatible      = "allwinner,sunxi-snd-plat-ahub";
-@@ -1301,0 +1312,1 @@ hdmi: hdmi@6000000 {
+@@ -1107,6 +1118,7 @@ ohci3: usb@5311400 {
+ 		hdmi: hdmi@6000000 {
+ 			compatible = "allwinner,sun50i-h616-dw-hdmi",
+ 				     "allwinner,sun50i-h6-dw-hdmi";
 +			#sound-dai-cells = <0>;
+ 			reg = <0x06000000 0x10000>;
+ 			reg-io-width = <1>;
+ 			interrupts = <GIC_SPI 63 IRQ_TYPE_LEVEL_HIGH>;
 diff --git a/drivers/clk/sunxi-ng/ccu-sun50i-h616.c b/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
 index 111111111111..222222222222 100644
 --- a/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
 +++ b/drivers/clk/sunxi-ng/ccu-sun50i-h616.c
-@@ -232,14 +232,12 @@ static struct ccu_nm pll_audio_hs_clk = {
- 	.enable		= BIT(31),
- 	.lock		= BIT(28),
- 	.n		= _SUNXI_CCU_MULT_MIN(8, 8, 12),
+@@ -235,10 +235,8 @@ static struct ccu_nm pll_audio_hs_clk = {
  	.m		= _SUNXI_CCU_DIV(16, 6),
  	.sdm		= _SUNXI_CCU_SDM(pll_audio_sdm_table,
  					 BIT(24), 0x178, BIT(31)),
@@ -81,7 +84,6 @@ index 111111111111..222222222222 100644
  		.reg		= 0x078,
  		.hw.init	= CLK_HW_INIT("pll-audio-hs", "osc24M",
  					      &ccu_nm_ops,
- 					      CLK_SET_RATE_UNGATE),
 diff --git a/include/dt-bindings/clock/sun50i-h616-ccu.h b/include/dt-bindings/clock/sun50i-h616-ccu.h
 index 111111111111..222222222222 100644
 --- a/include/dt-bindings/clock/sun50i-h616-ccu.h
@@ -99,7 +101,7 @@ diff --git a/sound/soc/sunxi_v2/snd_sunxi_ahub.c b/sound/soc/sunxi_v2/snd_sunxi_
 index 111111111111..222222222222 100644
 --- a/sound/soc/sunxi_v2/snd_sunxi_ahub.c
 +++ b/sound/soc/sunxi_v2/snd_sunxi_ahub.c
-@@ -100,7 +100,7 @@ static int sunxi_ahub_dai_set_pll(struct snd_soc_dai *dai,
+@@ -114,7 +114,7 @@ static int sunxi_ahub_dai_set_pll(struct snd_soc_dai *dai,
                         return -EINVAL;
                 }
         }
@@ -108,7 +110,7 @@ index 111111111111..222222222222 100644
                 SND_LOG_ERR(HLOG, "freq : %u module clk unsupport\n", freq_out);
                 return -EINVAL;
         }
-@@ -275,7 +275,7 @@ static int sunxi_ahub_dai_set_bclk_ratio(struct snd_soc_dai *dai, unsigned int
+@@ -286,7 +286,7 @@ static int sunxi_ahub_dai_set_bclk_ratio(struct snd_soc_dai *dai, unsigned int r
  
         regmap_update_bits(regmap, SUNXI_AHUB_I2S_CLKD(tdm_num),
                            0xf << I2S_CLKD_BCLKDIV,
@@ -152,7 +154,7 @@ index 111111111111..222222222222 100644
  
  	/* enable clk of ahub */
  	if (clk_prepare_enable(clk_info->clk_pll)) {
-@@ -400,13 +400,11 @@ static int snd_soc_sunxi_ahub_clk_init(struct platform_device *pdev,
+@@ -404,14 +404,12 @@ static int snd_soc_sunxi_ahub_clk_init(struct platform_device *pdev,
  	return 0;
  
  err_module_clk_enable:
@@ -170,7 +172,8 @@ index 111111111111..222222222222 100644
 +	clk_put(clk_info->clk_pll);
  err_pll_clk:
  	clk_put(clk_info->clk_module);
-@@ -481,8 +479,7 @@ static int sunxi_ahub_dam_dev_remove(struct platform_device *pdev)
+ err_module_clk:
+@@ -481,8 +479,7 @@ static void sunxi_ahub_dam_dev_remove(struct platform_device *pdev)
  	clk_put(clk_info->clk_module);
  	clk_disable_unprepare(clk_info->clk_pll);
  	clk_put(clk_info->clk_pll);
@@ -182,3 +185,4 @@ index 111111111111..222222222222 100644
  	reset_control_assert(clk_info->clk_rst);
 -- 
 Armbian
+

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h6-h616-add-sunxi-info-nodes.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h6-h616-add-sunxi-info-nodes.patch
@@ -42,7 +42,7 @@ diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dt
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -1666,6 +1666,25 @@ r_rsb: rsb@7083000 {
+@@ -1667,6 +1667,25 @@ r_rsb: rsb@7083000 {
  			#address-cells = <1>;
  			#size-cells = <0>;
  		};

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-add-vpu-node.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-add-vpu-node.patch
@@ -30,7 +30,7 @@ index 111111111111..222222222222 100644
  		syscon: syscon@3000000 {
  			compatible = "allwinner,sun50i-h616-system-control";
  			reg = <0x03000000 0x30>,<0x03000038 0x0fc8>;
-@@ -1669,6 +1680,19 @@ cpu_critical: cpu-trip-2 {
+@@ -1670,6 +1681,19 @@ cpu_critical: cpu-trip-2 {
  					hysteresis = <0>;
  				};
  			};

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/drv-usb-gadget-composite-rename-serial-manufacturer.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/drv-usb-gadget-composite-rename-serial-manufacturer.patch
@@ -13,7 +13,7 @@ diff --git a/drivers/usb/gadget/composite.c b/drivers/usb/gadget/composite.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/gadget/composite.c
 +++ b/drivers/usb/gadget/composite.c
-@@ -2756,7 +2756,7 @@ EXPORT_SYMBOL_GPL(usb_composite_setup_continue);
+@@ -2759,7 +2759,7 @@ EXPORT_SYMBOL_GPL(usb_composite_setup_continue);
  
  static char *composite_default_mfr(struct usb_gadget *gadget)
  {

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/fixes-7.0/0018-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/fixes-7.0/0018-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
@@ -20,7 +20,7 @@ diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
-@@ -2553,6 +2553,7 @@ static struct usb_serial_driver option_1port_device = {
+@@ -2560,6 +2560,7 @@ static struct usb_serial_driver option_1port_device = {
  #ifdef CONFIG_PM
  	.suspend           = usb_wwan_suspend,
  	.resume            = usb_wwan_resume,

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/speed-7.0/0003-Mark-some-slow-drivers-for-async-probe-with-PROBE_PR.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/speed-7.0/0003-Mark-some-slow-drivers-for-async-probe-with-PROBE_PR.patch
@@ -27,7 +27,7 @@ diff --git a/drivers/nfc/nxp-nci/i2c.c b/drivers/nfc/nxp-nci/i2c.c
 index 111111111111..222222222222 100644
 --- a/drivers/nfc/nxp-nci/i2c.c
 +++ b/drivers/nfc/nxp-nci/i2c.c
-@@ -348,6 +348,7 @@ static struct i2c_driver nxp_nci_i2c_driver = {
+@@ -367,6 +367,7 @@ static struct i2c_driver nxp_nci_i2c_driver = {
  		   .name = NXP_NCI_I2C_DRIVER_NAME,
  		   .acpi_match_table = ACPI_PTR(acpi_id),
  		   .of_match_table = of_nxp_nci_i2c_match,

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/tcpm-7.0/0001-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/tcpm-7.0/0001-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
@@ -13,7 +13,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3132,7 +3132,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3159,7 +3159,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  {
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
@@ -22,7 +22,7 @@ index 111111111111..222222222222 100644
  
  	if (!port->partner_pd)
  		port->partner_pd = usb_power_delivery_register(NULL, &desc);
-@@ -3142,11 +3142,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3169,11 +3169,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	memcpy(caps.pdo, port->source_caps, sizeof(u32) * port->nr_source_caps);
  	caps.role = TYPEC_SOURCE;
  

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/tcpm-7.0/0002-usb-typec-altmodes-displayport-Respect-DP_CAP_RECEPT.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/tcpm-7.0/0002-usb-typec-altmodes-displayport-Respect-DP_CAP_RECEPT.patch
@@ -51,7 +51,7 @@ index 111111111111..222222222222 100644
  	/* Determining the initial pin assignment. */
  	if (!DP_CONF_GET_PIN_ASSIGN(dp->data.conf)) {
  		/* Is USB together with DP preferred */
-@@ -762,16 +780,40 @@ int dp_altmode_probe(struct typec_altmode *alt)
+@@ -764,16 +782,40 @@ int dp_altmode_probe(struct typec_altmode *alt)
  	struct typec_altmode *plug = typec_altmode_get_plug(alt, TYPEC_PLUG_SOP_P);
  	struct fwnode_handle *fwnode;
  	struct dp_altmode *dp;

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/tcpm-7.0/0003-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/tcpm-7.0/0003-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
@@ -37,7 +37,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -1881,6 +1881,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
+@@ -1883,6 +1883,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
  		return;
  
  	for (i = 0; i < modep->altmodes; i++) {

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/tcpm-7.0/0004-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/tcpm-7.0/0004-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3136,15 +3136,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3163,15 +3163,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -45,7 +45,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -3159,15 +3166,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
+@@ -3186,15 +3193,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -72,7 +72,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -7234,10 +7248,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
+@@ -7261,10 +7275,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
  		port->pds[i] = usb_power_delivery_register(port->dev, &desc);
  		if (IS_ERR(port->pds[i])) {
  			ret = PTR_ERR(port->pds[i]);

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/tcpm-7.0/0005-usb-typec-tcpm-Improve-logs.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/tcpm-7.0/0005-usb-typec-tcpm-Improve-logs.patch
@@ -30,7 +30,7 @@ index 111111111111..222222222222 100644
  
  	reinit_completion(&port->tx_complete);
  	ret = port->tcpc->pd_transmit(port->tcpc, tx_sop_type, msg, negotiated_rev);
-@@ -3819,6 +3822,10 @@ void tcpm_pd_receive(struct tcpm_port *port, const struct pd_message *msg,
+@@ -3846,6 +3849,10 @@ void tcpm_pd_receive(struct tcpm_port *port, const struct pd_message *msg,
  		     enum tcpm_transmit_type rx_sop_type)
  {
  	struct pd_rx_event *event;
@@ -41,7 +41,7 @@ index 111111111111..222222222222 100644
  
  	event = kzalloc_obj(*event, GFP_ATOMIC);
  	if (!event)
-@@ -6179,7 +6186,7 @@ static void _tcpm_cc_change(struct tcpm_port *port, enum typec_cc_status cc1,
+@@ -6206,7 +6213,7 @@ static void _tcpm_cc_change(struct tcpm_port *port, enum typec_cc_status cc1,
  
  static void _tcpm_pd_vbus_on(struct tcpm_port *port)
  {
@@ -50,7 +50,7 @@ index 111111111111..222222222222 100644
  	port->vbus_present = true;
  	/*
  	 * When vbus_present is true i.e. Voltage at VBUS is greater than VSAFE5V implicitly
-@@ -6269,7 +6276,7 @@ static void _tcpm_pd_vbus_on(struct tcpm_port *port)
+@@ -6296,7 +6303,7 @@ static void _tcpm_pd_vbus_on(struct tcpm_port *port)
  
  static void _tcpm_pd_vbus_off(struct tcpm_port *port)
  {


### PR DESCRIPTION
- rewrite patches for 6.18
- rewrite patches for 7.0
- no further tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HDMI/HD-AHUB audio clocking on H616 so HDMI audio uses correct PLL paths
  * Prevented duplicate USB Power Delivery entries and improved alt-mode pin compatibility checks
  * Improved USB WWAN resume/reset handling
  * Corrected AHUB audio clock/divider behavior

* **New Features**
  * Added system-info nodes for H6/H616
  * Added VPU (video codec) node for H616

* **Improvements**
  * Prefer async probe for some I2C drivers
  * USB gadget manufacturer string set to "Armbian Linux"
  * Enhanced TCPM logging for USB PD
<!-- end of auto-generated comment: release notes by coderabbit.ai -->