### PR TITLE
meson64: fix GPIO can_sleep regression that breaks w1-gpio (1-Wire)

### DIFF
--- a/patch/kernel/archive/meson64-6.12/general-pinctrl-meson-restore-non-sleeping-gpio.patch
+++ b/patch/kernel/archive/meson64-6.12/general-pinctrl-meson-restore-non-sleeping-gpio.patch
@@ -1,0 +1,55 @@
+From 2206401cdf41891fb830893c79413c3a66b0d550 Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <v@baodeep.com>
+Date: Wed, 10 Jun 2026 13:39:38 +0300
+Subject: [PATCH] pinctrl: meson: restore non-sleeping GPIO access
+
+Commit 28f240683871 ("pinctrl: meson: mark the GPIO controller as
+sleeping") set gpio_chip.can_sleep = true to work around
+gpio-shared-proxy holding a spinlock across a sleeping pinctrl config
+path. It was backported to 6.12.y as commit fee56df34234 ("pinctrl:
+meson: mark the GPIO controller as sleeping"), but the shared-GPIO
+proxy code does not exist in 6.12 at all, so on this kernel the
+workaround fixes nothing and only causes a regression.
+
+meson_gpio_get/set/direction_* access MMIO through regmap. The
+regmap_mmio bus uses fast I/O (spinlock) locking, so these value
+callbacks do not contain sleeping operations. Since gpio_chip.can_sleep
+describes the get/set value path, restore can_sleep = false.
+
+Marking the controller sleeping broke atomic value consumers such as
+w1-gpio (1-Wire bitbang): w1_io.c runs its read time slot under
+local_irq_save() and uses the non-cansleep gpiod_set_value() /
+gpiod_get_value(), which with can_sleep=true trigger WARN_ON(can_sleep)
+in gpiolib on every transferred bit (from w1_gpio_write_bit() /
+w1_gpio_read_bit() via w1_reset_bus() and w1_search()). The printk and
+stack dump inside the IRQs-off, microsecond-scale time slot destroy the
+bit timing, so reset/presence detection and ROM search fail: the bus
+master registers but w1_master_slave_count stays at 0 and no devices
+are found. Verified on an Amlogic A113X board (DS18B20 on GPIOA_14):
+with can_sleep restored to false the warnings are gone and the sensor
+is detected and read again.
+
+Fixes: fee56df34234 ("pinctrl: meson: mark the GPIO controller as sleeping")
+Link: https://lore.kernel.org/all/20260105150509.56537-1-bartosz.golaszewski@oss.qualcomm.com/
+Assisted-by: Claude:claude-opus-4-8
+Signed-off-by: Viacheslav Bocharov <v@baodeep.com>
+---
+ drivers/pinctrl/meson/pinctrl-meson.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/pinctrl/meson/pinctrl-meson.c b/drivers/pinctrl/meson/pinctrl-meson.c
+index b4b4638df0f2..e5a32a0532ee 100644
+--- a/drivers/pinctrl/meson/pinctrl-meson.c
++++ b/drivers/pinctrl/meson/pinctrl-meson.c
+@@ -619,7 +619,7 @@ static int meson_gpiolib_register(struct meson_pinctrl *pc)
+ 	pc->chip.set = meson_gpio_set;
+ 	pc->chip.base = -1;
+ 	pc->chip.ngpio = pc->data->num_pins;
+-	pc->chip.can_sleep = true;
++	pc->chip.can_sleep = false;
+ 
+ 	ret = gpiochip_add_data(&pc->chip, pc);
+ 	if (ret) {
+-- 
+2.54.0
+

--- a/patch/kernel/archive/meson64-6.18/general-pinctrl-meson-restore-non-sleeping-gpio.patch
+++ b/patch/kernel/archive/meson64-6.18/general-pinctrl-meson-restore-non-sleeping-gpio.patch
@@ -1,0 +1,55 @@
+From 878274b02d1b1f9610a696ceac66bdb2b89279ee Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <v@baodeep.com>
+Date: Wed, 10 Jun 2026 12:38:37 +0300
+Subject: [PATCH] pinctrl: meson: restore non-sleeping GPIO access
+
+Commit 28f240683871 ("pinctrl: meson: mark the GPIO controller as
+sleeping") set gpio_chip.can_sleep = true to work around
+gpio-shared-proxy holding a spinlock across a sleeping pinctrl config
+path. It was backported to 6.18.y as commit e81d1bc4ea79 ("pinctrl:
+meson: mark the GPIO controller as sleeping"), but the shared-GPIO
+proxy code does not exist in 6.18 at all, so on this kernel the
+workaround fixes nothing and only causes a regression.
+
+meson_gpio_get/set/direction_* access MMIO through regmap. The
+regmap_mmio bus uses fast I/O (spinlock) locking, so these value
+callbacks do not contain sleeping operations. Since gpio_chip.can_sleep
+describes the get/set value path, restore can_sleep = false.
+
+Marking the controller sleeping broke atomic value consumers such as
+w1-gpio (1-Wire bitbang): w1_io.c runs its read time slot under
+local_irq_save() and uses the non-cansleep gpiod_set_value() /
+gpiod_get_value(), which with can_sleep=true trigger WARN_ON(can_sleep)
+in gpiolib on every transferred bit (from w1_gpio_write_bit() /
+w1_gpio_read_bit() via w1_reset_bus() and w1_search()). The printk and
+stack dump inside the IRQs-off, microsecond-scale time slot destroy the
+bit timing, so reset/presence detection and ROM search fail: the bus
+master registers but w1_master_slave_count stays at 0 and no devices
+are found. Verified on an Amlogic A113X board (DS18B20 on GPIOA_14):
+with can_sleep restored to false the warnings are gone and the sensor
+is detected and read again.
+
+Fixes: e81d1bc4ea79 ("pinctrl: meson: mark the GPIO controller as sleeping")
+Link: https://lore.kernel.org/all/20260105150509.56537-1-bartosz.golaszewski@oss.qualcomm.com/
+Assisted-by: Claude:claude-opus-4-8
+Signed-off-by: Viacheslav Bocharov <v@baodeep.com>
+---
+ drivers/pinctrl/meson/pinctrl-meson.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/pinctrl/meson/pinctrl-meson.c b/drivers/pinctrl/meson/pinctrl-meson.c
+index 4507dc8b5563..18295b15ecd9 100644
+--- a/drivers/pinctrl/meson/pinctrl-meson.c
++++ b/drivers/pinctrl/meson/pinctrl-meson.c
+@@ -619,7 +619,7 @@ static int meson_gpiolib_register(struct meson_pinctrl *pc)
+ 	pc->chip.set = meson_gpio_set;
+ 	pc->chip.base = -1;
+ 	pc->chip.ngpio = pc->data->num_pins;
+-	pc->chip.can_sleep = true;
++	pc->chip.can_sleep = false;
+ 
+ 	ret = gpiochip_add_data(&pc->chip, pc);
+ 	if (ret) {
+-- 
+2.54.0
+

--- a/patch/kernel/archive/meson64-7.0/general-gpio-shared-proxy-always-mutex.patch
+++ b/patch/kernel/archive/meson64-7.0/general-gpio-shared-proxy-always-mutex.patch
@@ -1,0 +1,247 @@
+From af83d0da735efc7115ab8300346b9cd76649b1c2 Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <v@baodeep.com>
+Date: Tue, 9 Jun 2026 16:37:20 +0300
+Subject: [PATCH] gpio: shared-proxy: always serialize with a sleeping mutex
+
+The shared GPIO descriptor used either a mutex or a spinlock, chosen at
+runtime from the underlying chip's can_sleep:
+
+	shared_desc->can_sleep = gpiod_cansleep(shared_desc->desc);
+	... if (can_sleep) mutex_lock(); else spin_lock_irqsave();
+
+can_sleep describes only the value path (->get/->set). Under the same
+lock, however, the proxy may call gpiod_set_config() and
+gpiod_direction_*(), which can reach pinctrl paths that take a mutex
+(e.g. gpiod_set_config() -> gpiochip_generic_config() ->
+pinctrl_gpio_set_config()), independent of can_sleep. On a controller
+with non-sleeping MMIO value ops the descriptor lock was a spinlock, so
+that sleeping pinctrl call ran from atomic context. The trace below was
+reproduced on an Amlogic A113X board with the workaround from commit
+28f240683871 ("pinctrl: meson: mark the GPIO controller as sleeping")
+reverted; the original Khadas VIM3 report hit the same path:
+
+	BUG: sleeping function called from invalid context
+	  __mutex_lock
+	  pinctrl_get_device_gpio_range
+	  pinctrl_gpio_set_config
+	  gpiochip_generic_config
+	  gpiod_set_config
+	  gpio_shared_proxy_set_config   <- voting spinlock held
+	  ...
+	  mmc_pwrseq_simple_probe
+
+The spinlock existed to take the value vote from atomic context, but the
+vote and the (possibly sleeping) control operations share the same state
+and lock, so the proxy cannot serialize config under a mutex and also
+offer atomic value access with this scheme.
+
+Always serialize the shared descriptor with a mutex and mark the proxy a
+sleeping gpiochip, driving the underlying GPIO through the cansleep value
+accessors. Those are valid for both sleeping and non-sleeping underlying
+chips, so value access keeps working on fast controllers; the cost is
+that a proxied GPIO no longer offers atomic value access.
+
+This is observable: consumers that gate on gpiod_cansleep() take their
+sleeping branch on a proxied GPIO -- e.g. mmc-pwrseq-emmc skips its
+emergency-restart eMMC reset handler (its normal reset path is
+unaffected), and consumers that reject sleeping GPIOs (pwm-gpio,
+ps2-gpio, ...) would fail to probe. In practice such atomic/fast-bitbang
+users do not share a pin through the proxy, whose purpose is voting on
+shared reset/enable lines. The same narrowing already applies on Amlogic
+after commit 28f240683871 ("pinctrl: meson: mark the GPIO controller as
+sleeping"), and rockchip addressed the identical splat per-driver in
+commit 7ca497be0016 ("gpio: rockchip: Stop calling pinctrl for
+set_direction"); fixing the proxy addresses the shared locking error
+once, for every controller.
+
+The lock type was added by commit a060b8c511ab ("gpiolib: implement
+low-level, shared GPIO support"); the sleeping call under it arrived with
+the proxy driver.
+
+Fixes: e992d54c6f97 ("gpio: shared-proxy: implement the shared GPIO proxy driver")
+Reported-by: Marek Szyprowski <m.szyprowski@samsung.com>
+Closes: https://lore.kernel.org/all/00107523-7737-4b92-a785-14ce4e93b8cb@samsung.com/
+Assisted-by: Claude:claude-opus-4-8
+Signed-off-by: Viacheslav Bocharov <v@baodeep.com>
+---
+ drivers/gpio/gpio-shared-proxy.c | 43 +++++++-------------------------
+ drivers/gpio/gpiolib-shared.c    |  9 ++-----
+ drivers/gpio/gpiolib-shared.h    | 31 +++++++++--------------
+ 3 files changed, 23 insertions(+), 60 deletions(-)
+
+diff --git a/drivers/gpio/gpio-shared-proxy.c b/drivers/gpio/gpio-shared-proxy.c
+index 6941e4be6cf1..856e5b9d6163 100644
+--- a/drivers/gpio/gpio-shared-proxy.c
++++ b/drivers/gpio/gpio-shared-proxy.c
+@@ -109,7 +109,7 @@ static void gpio_shared_proxy_free(struct gpio_chip *gc, unsigned int offset)
+ 
+ 	if (proxy->voted_high) {
+ 		ret = gpio_shared_proxy_set_unlocked(proxy,
+-			shared_desc->can_sleep ? gpiod_set_value_cansleep : gpiod_set_value, 0);
++			gpiod_set_value_cansleep, 0);
+ 		if (ret)
+ 			dev_err(proxy->dev,
+ 				"Failed to unset the shared GPIO value on release: %d\n", ret);
+@@ -222,13 +222,6 @@ static int gpio_shared_proxy_direction_output(struct gpio_chip *gc,
+ 	return gpio_shared_proxy_set_unlocked(proxy, gpiod_direction_output, value);
+ }
+ 
+-static int gpio_shared_proxy_get(struct gpio_chip *gc, unsigned int offset)
+-{
+-	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
+-
+-	return gpiod_get_value(proxy->shared_desc->desc);
+-}
+-
+ static int gpio_shared_proxy_get_cansleep(struct gpio_chip *gc,
+ 					  unsigned int offset)
+ {
+@@ -237,29 +230,15 @@ static int gpio_shared_proxy_get_cansleep(struct gpio_chip *gc,
+ 	return gpiod_get_value_cansleep(proxy->shared_desc->desc);
+ }
+ 
+-static int gpio_shared_proxy_do_set(struct gpio_shared_proxy_data *proxy,
+-				    int (*set_func)(struct gpio_desc *desc, int value),
+-				    int value)
+-{
+-	guard(gpio_shared_desc_lock)(proxy->shared_desc);
+-
+-	return gpio_shared_proxy_set_unlocked(proxy, set_func, value);
+-}
+-
+-static int gpio_shared_proxy_set(struct gpio_chip *gc, unsigned int offset,
+-				 int value)
+-{
+-	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
+-
+-	return gpio_shared_proxy_do_set(proxy, gpiod_set_value, value);
+-}
+-
+ static int gpio_shared_proxy_set_cansleep(struct gpio_chip *gc,
+ 					  unsigned int offset, int value)
+ {
+ 	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
+ 
+-	return gpio_shared_proxy_do_set(proxy, gpiod_set_value_cansleep, value);
++	guard(gpio_shared_desc_lock)(proxy->shared_desc);
++
++	return gpio_shared_proxy_set_unlocked(proxy, gpiod_set_value_cansleep,
++					      value);
+ }
+ 
+ static int gpio_shared_proxy_get_direction(struct gpio_chip *gc,
+@@ -302,20 +281,16 @@ static int gpio_shared_proxy_probe(struct auxiliary_device *adev,
+ 	gc->label = dev_name(dev);
+ 	gc->parent = dev;
+ 	gc->owner = THIS_MODULE;
+-	gc->can_sleep = shared_desc->can_sleep;
++	/* Always a sleeping gpiochip: see the lock comment in gpiolib-shared.h. */
++	gc->can_sleep = true;
+ 
+ 	gc->request = gpio_shared_proxy_request;
+ 	gc->free = gpio_shared_proxy_free;
+ 	gc->set_config = gpio_shared_proxy_set_config;
+ 	gc->direction_input = gpio_shared_proxy_direction_input;
+ 	gc->direction_output = gpio_shared_proxy_direction_output;
+-	if (gc->can_sleep) {
+-		gc->set = gpio_shared_proxy_set_cansleep;
+-		gc->get = gpio_shared_proxy_get_cansleep;
+-	} else {
+-		gc->set = gpio_shared_proxy_set;
+-		gc->get = gpio_shared_proxy_get;
+-	}
++	gc->set = gpio_shared_proxy_set_cansleep;
++	gc->get = gpio_shared_proxy_get_cansleep;
+ 	gc->get_direction = gpio_shared_proxy_get_direction;
+ 	gc->to_irq = gpio_shared_proxy_to_irq;
+ 
+diff --git a/drivers/gpio/gpiolib-shared.c b/drivers/gpio/gpiolib-shared.c
+index de72776fb154..495bd3d0ddf0 100644
+--- a/drivers/gpio/gpiolib-shared.c
++++ b/drivers/gpio/gpiolib-shared.c
+@@ -627,8 +627,7 @@ static void gpio_shared_release(struct kref *kref)
+ 
+ 	shared_desc = entry->shared_desc;
+ 	gpio_device_put(shared_desc->desc->gdev);
+-	if (shared_desc->can_sleep)
+-		mutex_destroy(&shared_desc->mutex);
++	mutex_destroy(&shared_desc->mutex);
+ 	kfree(shared_desc);
+ 	entry->shared_desc = NULL;
+ }
+@@ -659,11 +658,7 @@ gpiod_shared_desc_create(struct gpio_shared_entry *entry)
+ 	}
+ 
+ 	shared_desc->desc = &gdev->descs[entry->offset];
+-	shared_desc->can_sleep = gpiod_cansleep(shared_desc->desc);
+-	if (shared_desc->can_sleep)
+-		mutex_init(&shared_desc->mutex);
+-	else
+-		spin_lock_init(&shared_desc->spinlock);
++	mutex_init(&shared_desc->mutex);
+ 
+ 	return shared_desc;
+ }
+diff --git a/drivers/gpio/gpiolib-shared.h b/drivers/gpio/gpiolib-shared.h
+index 15e72a8dcdb1..5c725118b1af 100644
+--- a/drivers/gpio/gpiolib-shared.h
++++ b/drivers/gpio/gpiolib-shared.h
+@@ -6,7 +6,6 @@
+ #include <linux/cleanup.h>
+ #include <linux/lockdep.h>
+ #include <linux/mutex.h>
+-#include <linux/spinlock.h>
+ 
+ struct gpio_device;
+ struct gpio_desc;
+@@ -42,35 +41,29 @@ static inline int gpio_shared_add_proxy_lookup(struct device *consumer,
+ 
+ struct gpio_shared_desc {
+ 	struct gpio_desc *desc;
+-	bool can_sleep;
+ 	unsigned long cfg;
+ 	unsigned int usecnt;
+ 	unsigned int highcnt;
+-	union {
+-		struct mutex mutex;
+-		spinlock_t spinlock;
+-	};
++	struct mutex mutex; /* serializes all proxy operations on this descriptor */
+ };
+ 
+ struct gpio_shared_desc *devm_gpiod_shared_get(struct device *dev);
+ 
++/*
++ * Under this lock the proxy may call gpiod_set_config()/gpiod_direction_*(),
++ * which can reach pinctrl paths that take a mutex (e.g. gpiod_set_config() ->
++ * gpiochip_generic_config() -> pinctrl_gpio_set_config()), independent of the
++ * underlying chip's can_sleep. A spinlock would run that sleeping call from
++ * atomic context, so the descriptor lock must be a mutex and the proxy
++ * gpiochip is therefore sleeping (can_sleep=true).
++ */
+ DEFINE_LOCK_GUARD_1(gpio_shared_desc_lock, struct gpio_shared_desc,
+-	if (_T->lock->can_sleep)
+-		mutex_lock(&_T->lock->mutex);
+-	else
+-		spin_lock_irqsave(&_T->lock->spinlock, _T->flags),
+-	if (_T->lock->can_sleep)
+-		mutex_unlock(&_T->lock->mutex);
+-	else
+-		spin_unlock_irqrestore(&_T->lock->spinlock, _T->flags),
+-	unsigned long flags)
++	mutex_lock(&_T->lock->mutex),
++	mutex_unlock(&_T->lock->mutex))
+ 
+ static inline void gpio_shared_lockdep_assert(struct gpio_shared_desc *shared_desc)
+ {
+-	if (shared_desc->can_sleep)
+-		lockdep_assert_held(&shared_desc->mutex);
+-	else
+-		lockdep_assert_held(&shared_desc->spinlock);
++	lockdep_assert_held(&shared_desc->mutex);
+ }
+ 
+ #endif /* __LINUX_GPIO_SHARED_H */
+-- 
+2.54.0
+

--- a/patch/kernel/archive/meson64-7.0/general-pinctrl-meson-restore-non-sleeping-gpio.patch
+++ b/patch/kernel/archive/meson64-7.0/general-pinctrl-meson-restore-non-sleeping-gpio.patch
@@ -1,0 +1,59 @@
+From ea87849519886d26d4be91c9404b3e37f2ebce9d Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <v@baodeep.com>
+Date: Tue, 9 Jun 2026 16:37:20 +0300
+Subject: [PATCH] pinctrl: meson: restore non-sleeping GPIO access
+
+Commit 28f240683871 ("pinctrl: meson: mark the GPIO controller as
+sleeping") set gpio_chip.can_sleep = true to work around
+gpio-shared-proxy holding a spinlock across a sleeping pinctrl config
+path. That locking bug is now fixed in the shared-proxy itself ("gpio:
+shared-proxy: always serialize with a sleeping mutex"), so the
+controller-wide workaround is no longer needed; the meson GPIO
+controller does not sleep.
+
+meson_gpio_get/set/direction_* access MMIO through regmap. The
+regmap_mmio bus uses fast I/O (spinlock) locking, so these value
+callbacks do not contain sleeping operations. Since gpio_chip.can_sleep
+describes the get/set value path, restore can_sleep = false.
+
+Marking the controller sleeping also broke atomic value consumers such
+as w1-gpio (1-Wire bitbang): w1_io.c runs its read time slot under
+local_irq_save() and uses the non-cansleep gpiod_set_value() /
+gpiod_get_value(), which with can_sleep=true trigger WARN_ON(can_sleep)
+in gpiolib on every transferred bit (from w1_gpio_write_bit() /
+w1_gpio_read_bit() via w1_reset_bus() and w1_search()). The printk and
+stack dump inside the IRQs-off, microsecond-scale time slot destroy the
+bit timing, so reset/presence detection and ROM search fail: the bus
+master registers but w1_master_slave_count stays at 0 and no devices
+are found. Verified on an Amlogic A113X board (DS18B20 on GPIOA_14):
+with can_sleep restored to false the warnings are gone and the sensor
+is detected and read again.
+
+This must not be applied or backported without the shared-proxy locking
+fix above; otherwise the original Khadas VIM3 splat returns on boards
+that genuinely share a meson GPIO.
+
+Fixes: 28f240683871 ("pinctrl: meson: mark the GPIO controller as sleeping")
+Link: https://lore.kernel.org/all/20260105150509.56537-1-bartosz.golaszewski@oss.qualcomm.com/
+Assisted-by: Claude:claude-opus-4-8
+Signed-off-by: Viacheslav Bocharov <v@baodeep.com>
+---
+ drivers/pinctrl/meson/pinctrl-meson.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/pinctrl/meson/pinctrl-meson.c b/drivers/pinctrl/meson/pinctrl-meson.c
+index 4507dc8b5563..18295b15ecd9 100644
+--- a/drivers/pinctrl/meson/pinctrl-meson.c
++++ b/drivers/pinctrl/meson/pinctrl-meson.c
+@@ -619,7 +619,7 @@ static int meson_gpiolib_register(struct meson_pinctrl *pc)
+ 	pc->chip.set = meson_gpio_set;
+ 	pc->chip.base = -1;
+ 	pc->chip.ngpio = pc->data->num_pins;
+-	pc->chip.can_sleep = true;
++	pc->chip.can_sleep = false;
+ 
+ 	ret = gpiochip_add_data(&pc->chip, pc);
+ 	if (ret) {
+-- 
+2.54.0
+

--- a/patch/kernel/archive/meson64-7.1/general-gpio-shared-proxy-always-mutex.patch
+++ b/patch/kernel/archive/meson64-7.1/general-gpio-shared-proxy-always-mutex.patch
@@ -1,0 +1,242 @@
+From e6d479eeaa03b9073304c0475dd72d781911b196 Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <v@baodeep.com>
+Date: Tue, 9 Jun 2026 16:37:20 +0300
+Subject: [PATCH] gpio: shared-proxy: always serialize with a sleeping mutex
+
+The shared GPIO descriptor used either a mutex or a spinlock, chosen at
+runtime from the underlying chip's can_sleep:
+
+	shared_desc->can_sleep = gpiod_cansleep(shared_desc->desc);
+	... if (can_sleep) mutex_lock(); else spin_lock_irqsave();
+
+can_sleep describes only the value path (->get/->set). Under the same
+lock, however, the proxy may call gpiod_set_config() and
+gpiod_direction_*(), which can reach pinctrl paths that take a mutex
+(e.g. gpiod_set_config() -> gpiochip_generic_config() ->
+pinctrl_gpio_set_config()), independent of can_sleep. On a controller
+with non-sleeping MMIO value ops the descriptor lock was a spinlock, so
+the sleeping pinctrl call ran from atomic context. Reproduced on an
+Amlogic A113X board with the workaround from commit 28f240683871
+("pinctrl: meson: mark the GPIO controller as sleeping") reverted; the
+original Khadas VIM3 report hit the same path:
+
+	BUG: sleeping function called from invalid context
+	  __mutex_lock
+	  pinctrl_get_device_gpio_range
+	  pinctrl_gpio_set_config
+	  gpiochip_generic_config
+	  gpiod_set_config
+	  gpio_shared_proxy_set_config   <- voting spinlock held
+	  ...
+	  mmc_pwrseq_simple_probe
+
+The spinlock existed to take the value vote from atomic context, but the
+vote and the (possibly sleeping) control operations share the same state
+and lock, so this scheme cannot serialize config under a mutex and still
+offer atomic value access. Always serialize the shared descriptor with a
+mutex instead and mark the proxy a sleeping gpiochip, driving the
+underlying GPIO through the cansleep value accessors: those are valid
+for both sleeping and non-sleeping chips, so value access keeps working
+on fast controllers, at the cost of no longer being atomic.
+
+This is observable: consumers gating on gpiod_cansleep() take their
+sleeping branch on a proxied GPIO (mmc-pwrseq-emmc skips its
+emergency-restart reset handler; its normal reset is unaffected), and
+consumers that reject sleeping GPIOs (pwm-gpio, ps2-gpio, ...) would
+fail to probe. Such atomic users do not share a pin through the proxy,
+whose purpose is voting on shared reset/enable lines. The same narrowing
+already applies on Amlogic since that workaround, and rockchip
+addressed the identical splat per-driver in commit 7ca497be0016 ("gpio:
+rockchip: Stop calling pinctrl for set_direction"); fixing the proxy
+addresses the locking error once, for every controller.
+
+The lock type was added by commit a060b8c511ab ("gpiolib: implement
+low-level, shared GPIO support"); the sleeping call under it arrived with
+the proxy driver.
+
+Fixes: e992d54c6f97 ("gpio: shared-proxy: implement the shared GPIO proxy driver")
+Reported-by: Marek Szyprowski <m.szyprowski@samsung.com>
+Closes: https://lore.kernel.org/all/00107523-7737-4b92-a785-14ce4e93b8cb@samsung.com/
+Signed-off-by: Viacheslav Bocharov <v@baodeep.com>
+---
+ drivers/gpio/gpio-shared-proxy.c | 43 +++++++-------------------------
+ drivers/gpio/gpiolib-shared.c    |  9 ++-----
+ drivers/gpio/gpiolib-shared.h    | 31 +++++++++--------------
+ 3 files changed, 23 insertions(+), 60 deletions(-)
+
+diff --git a/drivers/gpio/gpio-shared-proxy.c b/drivers/gpio/gpio-shared-proxy.c
+index 6941e4be6cf1..856e5b9d6163 100644
+--- a/drivers/gpio/gpio-shared-proxy.c
++++ b/drivers/gpio/gpio-shared-proxy.c
+@@ -109,7 +109,7 @@ static void gpio_shared_proxy_free(struct gpio_chip *gc, unsigned int offset)
+ 
+ 	if (proxy->voted_high) {
+ 		ret = gpio_shared_proxy_set_unlocked(proxy,
+-			shared_desc->can_sleep ? gpiod_set_value_cansleep : gpiod_set_value, 0);
++			gpiod_set_value_cansleep, 0);
+ 		if (ret)
+ 			dev_err(proxy->dev,
+ 				"Failed to unset the shared GPIO value on release: %d\n", ret);
+@@ -222,13 +222,6 @@ static int gpio_shared_proxy_direction_output(struct gpio_chip *gc,
+ 	return gpio_shared_proxy_set_unlocked(proxy, gpiod_direction_output, value);
+ }
+ 
+-static int gpio_shared_proxy_get(struct gpio_chip *gc, unsigned int offset)
+-{
+-	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
+-
+-	return gpiod_get_value(proxy->shared_desc->desc);
+-}
+-
+ static int gpio_shared_proxy_get_cansleep(struct gpio_chip *gc,
+ 					  unsigned int offset)
+ {
+@@ -237,29 +230,15 @@ static int gpio_shared_proxy_get_cansleep(struct gpio_chip *gc,
+ 	return gpiod_get_value_cansleep(proxy->shared_desc->desc);
+ }
+ 
+-static int gpio_shared_proxy_do_set(struct gpio_shared_proxy_data *proxy,
+-				    int (*set_func)(struct gpio_desc *desc, int value),
+-				    int value)
+-{
+-	guard(gpio_shared_desc_lock)(proxy->shared_desc);
+-
+-	return gpio_shared_proxy_set_unlocked(proxy, set_func, value);
+-}
+-
+-static int gpio_shared_proxy_set(struct gpio_chip *gc, unsigned int offset,
+-				 int value)
+-{
+-	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
+-
+-	return gpio_shared_proxy_do_set(proxy, gpiod_set_value, value);
+-}
+-
+ static int gpio_shared_proxy_set_cansleep(struct gpio_chip *gc,
+ 					  unsigned int offset, int value)
+ {
+ 	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
+ 
+-	return gpio_shared_proxy_do_set(proxy, gpiod_set_value_cansleep, value);
++	guard(gpio_shared_desc_lock)(proxy->shared_desc);
++
++	return gpio_shared_proxy_set_unlocked(proxy, gpiod_set_value_cansleep,
++					      value);
+ }
+ 
+ static int gpio_shared_proxy_get_direction(struct gpio_chip *gc,
+@@ -302,20 +281,16 @@ static int gpio_shared_proxy_probe(struct auxiliary_device *adev,
+ 	gc->label = dev_name(dev);
+ 	gc->parent = dev;
+ 	gc->owner = THIS_MODULE;
+-	gc->can_sleep = shared_desc->can_sleep;
++	/* Always a sleeping gpiochip: see the lock comment in gpiolib-shared.h. */
++	gc->can_sleep = true;
+ 
+ 	gc->request = gpio_shared_proxy_request;
+ 	gc->free = gpio_shared_proxy_free;
+ 	gc->set_config = gpio_shared_proxy_set_config;
+ 	gc->direction_input = gpio_shared_proxy_direction_input;
+ 	gc->direction_output = gpio_shared_proxy_direction_output;
+-	if (gc->can_sleep) {
+-		gc->set = gpio_shared_proxy_set_cansleep;
+-		gc->get = gpio_shared_proxy_get_cansleep;
+-	} else {
+-		gc->set = gpio_shared_proxy_set;
+-		gc->get = gpio_shared_proxy_get;
+-	}
++	gc->set = gpio_shared_proxy_set_cansleep;
++	gc->get = gpio_shared_proxy_get_cansleep;
+ 	gc->get_direction = gpio_shared_proxy_get_direction;
+ 	gc->to_irq = gpio_shared_proxy_to_irq;
+ 
+diff --git a/drivers/gpio/gpiolib-shared.c b/drivers/gpio/gpiolib-shared.c
+index de72776fb154..495bd3d0ddf0 100644
+--- a/drivers/gpio/gpiolib-shared.c
++++ b/drivers/gpio/gpiolib-shared.c
+@@ -627,8 +627,7 @@ static void gpio_shared_release(struct kref *kref)
+ 
+ 	shared_desc = entry->shared_desc;
+ 	gpio_device_put(shared_desc->desc->gdev);
+-	if (shared_desc->can_sleep)
+-		mutex_destroy(&shared_desc->mutex);
++	mutex_destroy(&shared_desc->mutex);
+ 	kfree(shared_desc);
+ 	entry->shared_desc = NULL;
+ }
+@@ -659,11 +658,7 @@ gpiod_shared_desc_create(struct gpio_shared_entry *entry)
+ 	}
+ 
+ 	shared_desc->desc = &gdev->descs[entry->offset];
+-	shared_desc->can_sleep = gpiod_cansleep(shared_desc->desc);
+-	if (shared_desc->can_sleep)
+-		mutex_init(&shared_desc->mutex);
+-	else
+-		spin_lock_init(&shared_desc->spinlock);
++	mutex_init(&shared_desc->mutex);
+ 
+ 	return shared_desc;
+ }
+diff --git a/drivers/gpio/gpiolib-shared.h b/drivers/gpio/gpiolib-shared.h
+index 15e72a8dcdb1..5c725118b1af 100644
+--- a/drivers/gpio/gpiolib-shared.h
++++ b/drivers/gpio/gpiolib-shared.h
+@@ -6,7 +6,6 @@
+ #include <linux/cleanup.h>
+ #include <linux/lockdep.h>
+ #include <linux/mutex.h>
+-#include <linux/spinlock.h>
+ 
+ struct gpio_device;
+ struct gpio_desc;
+@@ -42,35 +41,29 @@ static inline int gpio_shared_add_proxy_lookup(struct device *consumer,
+ 
+ struct gpio_shared_desc {
+ 	struct gpio_desc *desc;
+-	bool can_sleep;
+ 	unsigned long cfg;
+ 	unsigned int usecnt;
+ 	unsigned int highcnt;
+-	union {
+-		struct mutex mutex;
+-		spinlock_t spinlock;
+-	};
++	struct mutex mutex; /* serializes all proxy operations on this descriptor */
+ };
+ 
+ struct gpio_shared_desc *devm_gpiod_shared_get(struct device *dev);
+ 
++/*
++ * Under this lock the proxy may call gpiod_set_config()/gpiod_direction_*(),
++ * which can reach pinctrl paths that take a mutex (e.g. gpiod_set_config() ->
++ * gpiochip_generic_config() -> pinctrl_gpio_set_config()), independent of the
++ * underlying chip's can_sleep. A spinlock would run that sleeping call from
++ * atomic context, so the descriptor lock must be a mutex and the proxy
++ * gpiochip is therefore sleeping (can_sleep=true).
++ */
+ DEFINE_LOCK_GUARD_1(gpio_shared_desc_lock, struct gpio_shared_desc,
+-	if (_T->lock->can_sleep)
+-		mutex_lock(&_T->lock->mutex);
+-	else
+-		spin_lock_irqsave(&_T->lock->spinlock, _T->flags),
+-	if (_T->lock->can_sleep)
+-		mutex_unlock(&_T->lock->mutex);
+-	else
+-		spin_unlock_irqrestore(&_T->lock->spinlock, _T->flags),
+-	unsigned long flags)
++	mutex_lock(&_T->lock->mutex),
++	mutex_unlock(&_T->lock->mutex))
+ 
+ static inline void gpio_shared_lockdep_assert(struct gpio_shared_desc *shared_desc)
+ {
+-	if (shared_desc->can_sleep)
+-		lockdep_assert_held(&shared_desc->mutex);
+-	else
+-		lockdep_assert_held(&shared_desc->spinlock);
++	lockdep_assert_held(&shared_desc->mutex);
+ }
+ 
+ #endif /* __LINUX_GPIO_SHARED_H */
+-- 
+2.54.0
+

--- a/patch/kernel/archive/meson64-7.1/general-pinctrl-meson-restore-non-sleeping-gpio.patch
+++ b/patch/kernel/archive/meson64-7.1/general-pinctrl-meson-restore-non-sleeping-gpio.patch
@@ -1,0 +1,58 @@
+From cd3a7b205c14a4a1ea44de10105e783b7a0baaa1 Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <v@baodeep.com>
+Date: Tue, 9 Jun 2026 16:37:20 +0300
+Subject: [PATCH] pinctrl: meson: restore non-sleeping GPIO access
+
+Commit 28f240683871 ("pinctrl: meson: mark the GPIO controller as
+sleeping") set gpio_chip.can_sleep = true to work around
+gpio-shared-proxy holding a spinlock across a sleeping pinctrl config
+path. That locking bug is now fixed in the shared-proxy itself ("gpio:
+shared-proxy: always serialize with a sleeping mutex"), so the
+controller-wide workaround is no longer needed; the meson GPIO
+controller does not sleep.
+
+meson_gpio_get/set/direction_* access MMIO through regmap. The
+regmap_mmio bus uses fast I/O (spinlock) locking, so these value
+callbacks do not contain sleeping operations. Since gpio_chip.can_sleep
+describes the get/set value path, restore can_sleep = false.
+
+Marking the controller sleeping also broke atomic value consumers such
+as w1-gpio (1-Wire bitbang): w1_io.c runs its read time slot under
+local_irq_save() and uses the non-cansleep gpiod_set_value() /
+gpiod_get_value(), which with can_sleep=true trigger WARN_ON(can_sleep)
+in gpiolib on every transferred bit (from w1_gpio_write_bit() /
+w1_gpio_read_bit() via w1_reset_bus() and w1_search()). The printk and
+stack dump inside the IRQs-off, microsecond-scale time slot destroy the
+bit timing, so reset/presence detection and ROM search fail: the bus
+master registers but w1_master_slave_count stays at 0 and no devices
+are found. Verified on an Amlogic A113X board (DS18B20 on GPIOA_14):
+with can_sleep restored to false the warnings are gone and the sensor
+is detected and read again.
+
+This must not be applied or backported without the shared-proxy locking
+fix above; otherwise the original Khadas VIM3 splat returns on boards
+that genuinely share a meson GPIO.
+
+Fixes: 28f240683871 ("pinctrl: meson: mark the GPIO controller as sleeping")
+Link: https://lore.kernel.org/all/20260105150509.56537-1-bartosz.golaszewski@oss.qualcomm.com/
+Signed-off-by: Viacheslav Bocharov <v@baodeep.com>
+---
+ drivers/pinctrl/meson/pinctrl-meson.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/pinctrl/meson/pinctrl-meson.c b/drivers/pinctrl/meson/pinctrl-meson.c
+index 4507dc8b5563..18295b15ecd9 100644
+--- a/drivers/pinctrl/meson/pinctrl-meson.c
++++ b/drivers/pinctrl/meson/pinctrl-meson.c
+@@ -619,7 +619,7 @@ static int meson_gpiolib_register(struct meson_pinctrl *pc)
+ 	pc->chip.set = meson_gpio_set;
+ 	pc->chip.base = -1;
+ 	pc->chip.ngpio = pc->data->num_pins;
+-	pc->chip.can_sleep = true;
++	pc->chip.can_sleep = false;
+ 
+ 	ret = gpiochip_add_data(&pc->chip, pc);
+ 	if (ret) {
+-- 
+2.54.0
+


### PR DESCRIPTION
# Description

Mainline commit `28f240683871` ("pinctrl: meson: mark the GPIO controller as sleeping", first released in v7.0, backported to 6.18.y as `e81d1bc4ea79` and to 6.12.y as `fee56df34234`) marks the whole meson GPIO controller as *sleeping* to work around a locking bug in the new gpio-shared-proxy layer.

The flag breaks atomic value-path GPIO consumers on **all Amlogic meson64 boards**: w1-gpio (1-Wire bitbang) hits `WARN_ON(can_sleep)` in gpiolib on every transferred bit inside its IRQs-off time slot; the printk + stack dump destroy the microsecond-scale bit timing, so 1-Wire devices are no longer detected (`w1_master_slave_count` stays 0). Any board using 1-Wire sensors (DS18B20 etc.) over a meson GPIO is affected.

Note: the gpio-shared-proxy code (the thing the mainline commit works around) only exists in >= 6.19/7.0 and is only enabled on arm64 Qualcomm (`HAVE_SHARED_GPIOS`). In 6.12 and 6.18 the backport therefore fixes nothing at all — it only introduces the w1 regression.

## What this PR adds

**meson64-7.0 (edge):**

- `general-gpio-shared-proxy-always-mutex.patch` — fixes the root cause in the shared-GPIO proxy: the descriptor lock is always a sleeping mutex instead of being chosen (mutex vs spinlock) from the underlying chip's `can_sleep`, which let a sleeping pinctrl call run under a spinlock (`BUG: sleeping function called from invalid context`, originally reported on Khadas VIM3).
- `general-pinctrl-meson-restore-non-sleeping-gpio.patch` — restores `can_sleep = false` for meson (the value path is non-sleeping MMIO regmap). Must be applied together with the proxy fix.

**meson64-6.18 (current) and meson64-6.12 (oldlts):**

- `general-pinctrl-meson-restore-non-sleeping-gpio.patch` — the shared-GPIO proxy code does not exist in these kernels, so the backported workaround fixes nothing there and only causes the w1 regression; the `can_sleep = false` restore alone is needed and safe.

## Upstream status

The same two patches are being submitted to LKML (gpio + pinctrl maintainers, `Fixes:` tags in place), with stable backports to be requested afterwards. Once they land upstream/stable these patches can be dropped here. Keeping this PR as **draft** until the LKML submission is out.

# How Has This Been Tested?

- [x] Kernel builds for `BOARD=jethubj100` with the patches applied cleanly (no fuzz/rejects):
  - edge: 7.0.12 (`P341d-C0c30`)
  - current: 6.18.35 (`Pd1b1-Cb96f`)
- [x] On-device verification of these exact builds on JetHub D1 (Amlogic A113X, DS18B20 on GPIOA_14):
  - current 6.18.35: boots, 1-Wire sensor detected and read (`w1_master_slave_count=1`, temperature OK), dmesg has **zero** WARNING/BUG entries.
  - edge 7.0.12: boots, same result — sensor detected and read, zero WARNING/BUG.
- [x] Earlier A/B verification on the same hardware (with shared-GPIO repro instrumentation) confirmed the proxy fix removes the `BUG: sleeping function called from invalid context` splat while the proxy is active, and that without the proxy fix the splat reproduces.
- [ ] 6.12 (oldlts) is build-tested against 6.12.93 sources (patch applies cleanly); J100 does not target oldlts, so no on-device run for it.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored Meson GPIO controllers to non-sleeping mode across kernel versions, preventing WARNs in atomic/IRQ contexts and preserving timing-sensitive GPIO behavior.
  * Unified shared GPIO proxy locking to always use a sleeping mutex, ensuring consistent serialization of shared descriptor operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->