### PR TITLE
rootfs: route mmdebstrap through APT_PROXY_ADDR when set

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -119,6 +119,18 @@ function create_new_rootfs_cache_via_debootstrap() {
 		debootstrap_arguments+=("--customize-hook='sync-out /var/cache/apt/archives/ ${LOCAL_APT_CACHE_INFO[HOST_DEBOOTSTRAP_CACHE_DIR]}'")
 	fi
 
+	# If no managed acng is configured but an apt proxy address is set
+	# (e.g. APT_PROXY_ADDR exported by a CI runner), route mmdebstrap's
+	# downloads through it as a real proxy — the idiomatic --aptopt way the
+	# MANAGE_ACNG case above hints at, and the same proxy the later chroot
+	# apt-get phase uses (runners.sh). Without this the base-system bootstrap
+	# goes direct to the mirror, bypassing the cache. MANAGE_ACNG=yes / a URL
+	# already route through acng's URL-prefix, so this only covers no/unset.
+	if [[ -n "${APT_PROXY_ADDR}" && ( "${MANAGE_ACNG}" == "no" || -z "${MANAGE_ACNG}" ) ]]; then
+		display_alert "Routing mmdebstrap through apt proxy" "http://${APT_PROXY_ADDR##*@}" "info"
+		debootstrap_arguments+=("'--aptopt=Acquire::http::Proxy \"http://${APT_PROXY_ADDR}\"'")
+	fi
+
 	debootstrap_arguments+=("${RELEASE}" "${SDCARD}/" "${debootstrap_apt_mirror}") # release, path and mirror; always last, positional arguments.
 
 	mkdir -p "${SDCARD}/usr/bin"


### PR DESCRIPTION
## Summary

mmdebstrap only used the apt cache via apt-cacher-ng's **URL-prefix** mechanism, driven solely by `MANAGE_ACNG` — it ignored `APT_PROXY_ADDR` entirely. So on CI runners that export only `APT_PROXY_ADDR` (without `MANAGE_ACNG`), the **base-system bootstrap downloaded direct from the mirror, uncached**, while the later chroot apt-get phase (`runners.sh`) correctly routed through the proxy.

This closes that gap: when `APT_PROXY_ADDR` is set and `MANAGE_ACNG` is `no`/unset, mmdebstrap is given `--aptopt='Acquire::http::Proxy "http://<addr>"'`.

## Why this approach

- **Real proxy, not URL-prefix** — consistent with `runners.sh`, and works whether `APT_PROXY_ADDR` points at apt-cacher-ng or any HTTP proxy (the URL-prefix style only works for acng).
- Resolves the existing `--aptopt` FIXME in this function.
- **Zero risk to existing paths** — `MANAGE_ACNG=yes` / URL still use acng's URL-prefix, untouched; this only fills the `no`/unset gap.

## Net effect

The `APT_PROXY_ADDR` exported by the CI runner-info step now caches **both** phases (base bootstrap + package install), not just the second.

## Verification

Quoting was checked to survive `run_host_command_logged`'s `bash -c "$*"` re-parse and reach mmdebstrap as a single correct argv token:
\`--aptopt=Acquire::http::Proxy "http://10.0.40.2:3142"\`

In build logs, look for:
\`Routing mmdebstrap through apt proxy   http://<addr>\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional apt proxy support for package downloads when configured and automatic package management is disabled.
  * System displays an informational alert when proxy routing is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->