### PR TITLE
ti: configs: boards: Add TMDS64EVM (AM64x SoC) board support

### DIFF
--- a/config/boards/tmds64evm.conf
+++ b/config/boards/tmds64evm.conf
@@ -1,0 +1,23 @@
+# Texas Instruments AM64 dual core 2GB 3xGBE CPSW PRU PCIe OSPI
+
+BOARD_NAME="TMDS64EVM"
+BOARD_VENDOR="ti"
+BOARDFAMILY="k3"
+BOARD_MAINTAINER="jonaswood01"
+INTRODUCED="2022"
+BOOT_SOC="am64"
+BOOTCONFIG="am64x_evm_a53_defconfig"
+BOOTFS_TYPE="fat"
+BOOT_FDT_FILE="ti/k3-am642-evm.dts"
+TIBOOT3_BOOTCONFIG="am64x_evm_r5_defconfig"
+TIBOOT3_FILE="tiboot3-am64x_sr2-hs-fs-evm.bin"
+DEFAULT_CONSOLE="serial"
+HAS_VIDEO_OUTPUT="no"
+KERNEL_TARGET="vendor,vendor-rt,vendor-edge,edge"
+KERNEL_TEST_TARGET="vendor"
+SERIALCON="ttyS2"
+ATF_PLAT="k3"
+ATF_BOARD="lite"
+OPTEE_ARGS=""
+OPTEE_PLATFORM="k3-am64x"
+TI_PACKAGES+=("firmware-ti-prueth-am64" "firmware-ti-pruhsr-am64" "firmware-ti-pruprp-am64" "firmware-ti-prusw-am64")

--- a/config/sources/families/include/k3_common.inc
+++ b/config/sources/families/include/k3_common.inc
@@ -14,7 +14,7 @@ declare -g CLEAN_LEVEL="make-atf,make-uboot"
 
 declare -g INSTALL_HEADERS="yes"
 
-declare -g TI_PACKAGES=()
+[[ -v "TI_PACKAGES" ]] || declare -g TI_PACKAGES=()
 if [[ "${CC33XX_SUPPORT}" == "yes" ]] ; then
 	if [[ "${RELEASE}" == "trixie" || "${RELEASE}" == "noble" ]] ; then
 		TI_PACKAGES+=("cc33xx-fw" "cc33xx-target-scripts" "cc33conf" "cc33calibrator")


### PR DESCRIPTION
# Description

Add board support for [TMDS64EVM](https://www.ti.com/tool/TMDS64EVM) board using [AM64x SoC](https://www.ti.com/product/AM6442)

`tmds64evm.conf` is very similar to `sk-am64b.conf` with minor differences:

- Separate kernel device tree
- Installs PRU ETH/HSR/PRP/SW firmware packages hosted in [ti-debpkgs](https://github.com/TexasInstruments/ti-debpkgs)

# Documentation summary for feature / change

Will need [new board](https://armbian.com/boards?vendor=ti) in Armbian.com

# How Has This Been Tested?

- [x] `tmds64evm`: [build log](https://paste.armbian.com/ohalevokul), [boot log](https://paste.armbian.com/hugogoruhe.yaml) ✅

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the TMDS64EVM board, including complete boot firmware configuration, kernel target mappings, and platform-specific firmware packages.

* **Bug Fixes**
  * Fixed package initialization logic to preserve existing configurations instead of overwriting them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->