### PR TITLE
ayn-thor: fix fused kernel args in LinuxLoader.cfg cmdline, add rw rootwait

### DIFF
--- a/packages/bsp/ayn-thor/LinuxLoader.cfg
+++ b/packages/bsp/ayn-thor/LinuxLoader.cfg
@@ -54,5 +54,5 @@ DisableDisplayHW = true
 Image = "Image"
 initrd = "initrd.img-INITRD_PLACEHOLDER"
 devicetree = "dtb/qcom/qcs8550-ayn-thor.dtb"
-cmdline = "clk_ignore_unused pd_ignore_unused arm64.nopauthfbcon=rotate:3 console=ttyMSM0,115200n8 root=UUID=UUID_PLACEHOLDER"
+cmdline = "clk_ignore_unused pd_ignore_unused arm64.nopauth fbcon=rotate:3 console=ttyMSM0,115200n8 rw rootwait root=UUID=UUID_PLACEHOLDER"
 


### PR DESCRIPTION
## Description

The `cmdline` in `packages/bsp/ayn-thor/LinuxLoader.cfg` contains `arm64.nopauthfbcon=rotate:3` — two kernel parameters fused by a missing space. As written, neither `arm64.nopauth` nor `fbcon=rotate:3` takes effect on the LinuxLoader direct-`Linux`-target boot path.

This PR:
- splits the fused token into `arm64.nopauth fbcon=rotate:3`
- adds `rw rootwait`, matching the `ayn-odin2` `LinuxLoader.cfg` and the family's `BOOTIMG_CMDLINE_EXTRA` (`clk_ignore_unused pd_ignore_unused rw quiet rootwait`). Without `rootwait`, the direct-Image boot path can race storage enumeration and intermittently panic with "VFS: unable to mount root fs".

For reference, the board config's GRUB path already has these as separate parameters (`GRUB_CMDLINE_LINUX_DEFAULT="clk_ignore_unused pd_ignore_unused arm64.nopauth efi=noruntime fbcon=rotate:1 console=ttyMSM0,115200n8"`), confirming the intent.

## How to test

Build an ayn-thor image (`BOARD=ayn-thor BRANCH=edge`), boot via the Renegade custom ABL with `Target = "Linux"`, and confirm the kernel cmdline in `/proc/cmdline` shows the parameters applied separately.

## Checklist
- [x] Single-line config fix, no build-flow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with Linux kernel boot parameters where arguments were being concatenated improperly, preventing correct configuration interpretation during system startup. The correction ensures proper spacing between boot-time configuration directives, allowing the system to parse and apply all kernel parameters correctly during initialization and enables proper device behavior and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->