### PR TITLE
uwe5622: fix -Wmissing-prototypes warnings (155 -> 2)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -636,6 +636,8 @@ driver_uwe5622() {
 		if linux-version compare "${version}" ge 7.1; then
 			process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-v7.1.patch" "applying"
 		fi
+
+		process_patch_file "${SRC}/patch/misc/wireless-uwe5622/wireless-uwe5622-Fix-missing-prototypes.patch" "applying"
 	fi
 }
 

--- a/patch/misc/wireless-uwe5622/wireless-uwe5622-Fix-missing-prototypes.patch
+++ b/patch/misc/wireless-uwe5622/wireless-uwe5622-Fix-missing-prototypes.patch
@@ -1,0 +1,1306 @@
+From: Igor Velkov <325961+iav@users.noreply.github.com>
+Subject: [PATCH] uwe5622: fix -Wmissing-prototypes warnings (155 -> 2)
+
+Add 'static' to file-private functions and cross-file forward
+declarations to type-aware area headers. No functional change.
+
+diff --git a/drivers/net/wireless/uwe5622/tty-sdio/alignment/sitm.c b/drivers/net/wireless/uwe5622/tty-sdio/alignment/sitm.c
+index 3506fb0..e89d1ee 100644
+--- a/drivers/net/wireless/uwe5622/tty-sdio/alignment/sitm.c
++++ b/drivers/net/wireless/uwe5622/tty-sdio/alignment/sitm.c
+@@ -53,7 +53,7 @@ static int data_ready(uint8_t *buf, uint32_t count)
+ 	return ret;
+ }
+ 
+-void parse_frame(data_ready_cb data_ready, frame_complete_cb frame_complete)
++static void parse_frame(data_ready_cb data_ready, frame_complete_cb frame_complete)
+ {
+ 	uint8_t byte;
+ 	size_t buffer_size, bytes_read;
+diff --git a/drivers/net/wireless/uwe5622/tty-sdio/lpm.c b/drivers/net/wireless/uwe5622/tty-sdio/lpm.c
+index 70909e9..6f775ca 100644
+--- a/drivers/net/wireless/uwe5622/tty-sdio/lpm.c
++++ b/drivers/net/wireless/uwe5622/tty-sdio/lpm.c
+@@ -13,6 +13,7 @@
+ #include <linux/export.h>
+ #include <linux/device.h>
+ #include <marlin_platform.h>
++#include "lpm.h"
+ 
+ #define VERSION         "marlin2 V0.1"
+ #define PROC_DIR        "bluetooth/sleep"
+@@ -28,7 +29,7 @@ struct proc_dir_entry *bluetooth_dir, *sleep_dir;
+ struct wakeup_source *tx_ws;
+ struct wakeup_source *rx_ws;
+ 
+-void host_wakeup_bt(void)
++static void host_wakeup_bt(void)
+ {
+ 	__pm_stay_awake(tx_ws);
+ 	marlin_set_sleep(MARLIN_BLUETOOTH, FALSE);
+diff --git a/drivers/net/wireless/uwe5622/tty-sdio/rfkill.c b/drivers/net/wireless/uwe5622/tty-sdio/rfkill.c
+index 66ce926..b7426f7 100644
+--- a/drivers/net/wireless/uwe5622/tty-sdio/rfkill.c
++++ b/drivers/net/wireless/uwe5622/tty-sdio/rfkill.c
+@@ -23,6 +23,7 @@
+ #include <linux/of_gpio.h>
+ #include <linux/version.h>
+ #include <marlin_platform.h>
++#include "rfkill.h"
+ 
+ 
+ static struct rfkill *bt_rfk;
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/include/bus_common.h b/drivers/net/wireless/uwe5622/unisocwcn/include/bus_common.h
+index 4ca7be2..3eba017 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/include/bus_common.h
++++ b/drivers/net/wireless/uwe5622/unisocwcn/include/bus_common.h
+@@ -13,4 +13,7 @@ int buf_list_is_full(int chn);
+ struct mchn_ops_t *chn_ops(int channel);
+ int module_ops_register(struct sprdwcn_bus_ops *ops);
+ void module_ops_unregister(void);
++/* -Wmissing-prototypes: cross-file declarations */
++int buf_list_is_empty(int chn);
++
+ #endif
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/include/marlin_platform.h b/drivers/net/wireless/uwe5622/unisocwcn/include/marlin_platform.h
+index ae8daac..b9e23cc 100755
+--- a/drivers/net/wireless/uwe5622/unisocwcn/include/marlin_platform.h
++++ b/drivers/net/wireless/uwe5622/unisocwcn/include/marlin_platform.h
+@@ -122,4 +122,8 @@ void mdbg_assert_interface(char *str);
+ int marlin_reset_callback_register(u32 subsys, struct notifier_block *nb);
+ void marlin_reset_callback_unregister(u32 subsys, struct notifier_block *nb);
+ int marlin_reset_notify_call(enum marlin_cp2_status sts);
++
++/* -Wmissing-prototypes: cross-file declarations */
++int chip_power_on(int subsys);
++
+ #endif
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/loopcheck.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/loopcheck.c
+index 65b6847..a47a66e 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/platform/loopcheck.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/loopcheck.c
+@@ -22,7 +22,7 @@ static struct wcn_loopcheck loopcheck;
+ static struct completion atcmd_completion;
+ static struct mutex atcmd_lock;
+ 
+-int at_cmd_send(char *buf, unsigned int len)
++static int at_cmd_send(char *buf, unsigned int len)
+ {
+ 	unsigned char *send_buf = NULL;
+ 	struct mbuf_t *head, *tail;
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/mem_pd_mgr.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/mem_pd_mgr.c
+index f013b9d..0c98a53 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/platform/mem_pd_mgr.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/mem_pd_mgr.c
+@@ -68,7 +68,7 @@ unsigned int mem_pd_wifi_state(void)
+ 	return ret;
+ }
+ 
+-unsigned int mem_pd_spinlock_lock(int id)
++static unsigned int mem_pd_spinlock_lock(int id)
+ {
+ 	int ret = 0;
+ 	int i = 0;
+@@ -92,7 +92,7 @@ unsigned int mem_pd_spinlock_lock(int id)
+ 	return 0;
+ }
+ 
+-unsigned int mem_pd_spinlock_unlock(int id)
++static unsigned int mem_pd_spinlock_unlock(int id)
+ {
+ 	int ret = 0;
+ 	unsigned int reg_val = UNLOCK_TOKEN;
+@@ -584,7 +584,7 @@ static int ap_int_cp_wifi_bin_done(int subsys)
+ 	return 0;
+ }
+ 
+-int test_mem_clrear(int subsys)
++static int test_mem_clrear(int subsys)
+ {
+ 	int err;
+ 
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_boot.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_boot.c
+index c96071a..886d8d1 100755
+--- a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_boot.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_boot.c
+@@ -670,7 +670,7 @@ const char *strno(int subsys)
+ }
+ 
+ /* tsx/dac init */
+-int marlin_tsx_cali_data_read(struct tsx_data *p_tsx_data)
++static int marlin_tsx_cali_data_read(struct tsx_data *p_tsx_data)
+ {
+ 	u32 size = 0;
+ 	u32 read_len = 0;
+@@ -1881,7 +1881,7 @@ void marlin_hold_cpu(void)
+ 	}
+ }
+ 
+-void marlin_read_cali_data(void)
++static void marlin_read_cali_data(void)
+ {
+ 	int err;
+ 
+@@ -2681,7 +2681,7 @@ void marlin_chip_en(bool enable, bool reset)
+ }
+ EXPORT_SYMBOL_GPL(marlin_chip_en);
+ 
+-int set_cp_mem_status(int subsys, int val)
++static int set_cp_mem_status(int subsys, int val)
+ {
+ 	int ret;
+ 	unsigned int temp_val;
+@@ -2719,7 +2719,7 @@ int set_cp_mem_status(int subsys, int val)
+ 	return ret;
+ }
+ 
+-int enable_spur_remove(void)
++static int enable_spur_remove(void)
+ {
+ 	int ret;
+ 	unsigned int temp_val;
+@@ -2734,7 +2734,7 @@ int enable_spur_remove(void)
+ 	return 0;
+ }
+ 
+-int disable_spur_remove(void)
++static int disable_spur_remove(void)
+ {
+ 	int ret;
+ 	unsigned int temp_val;
+@@ -2749,7 +2749,7 @@ int disable_spur_remove(void)
+ 	return 0;
+ }
+ 
+-void set_fm_supe_freq(int subsys, int val, unsigned long sub_state)
++static void set_fm_supe_freq(int subsys, int val, unsigned long sub_state)
+ {
+ 	switch (subsys) {
+ 	case MARLIN_FM:
+@@ -2815,7 +2815,7 @@ static void marlin_scan_finish(void)
+ 	complete(&marlin_dev->carddetect_done);
+ }
+ 
+-int find_firmware_path(void)
++static int find_firmware_path(void)
+ {
+ 	int ret;
+ 	int pre_len;
+@@ -3002,7 +3002,7 @@ static void pre_btwifi_download_sdio(struct work_struct *work)
+ }
+ 
+ /* for example: wifipa bound XTLEN3 */
+-int pmic_bound_xtl_assert(unsigned int enable)
++static int pmic_bound_xtl_assert(unsigned int enable)
+ {
+ #if defined(CONFIG_WCN_PMIC) && !defined(CONFIG_WCN_PCIE)
+ 	unsigned int val;
+@@ -3019,7 +3019,7 @@ int pmic_bound_xtl_assert(unsigned int enable)
+ 	return 0;
+ }
+ 
+-void wifipa_enable(int enable)
++static void wifipa_enable(int enable)
+ {
+ 	int ret = -1;
+ 
+@@ -3049,7 +3049,7 @@ void wifipa_enable(int enable)
+ }
+ 
+ 
+-void set_wifipa_status(int subsys, int val)
++static void set_wifipa_status(int subsys, int val)
+ {
+ 	return;
+ 
+@@ -3123,7 +3123,7 @@ int chip_power_on(int subsys)
+ 	return 0;
+ }
+ 
+-int chip_power_off(int subsys)
++static int chip_power_off(int subsys)
+ {
+ 	WCN_INFO("%s\n", __func__);
+ 
+@@ -3151,7 +3151,7 @@ int chip_power_off(int subsys)
+ 	return 0;
+ }
+ 
+-int gnss_powerdomain_open(void)
++static int gnss_powerdomain_open(void)
+ {
+ 	/* add by this. */
+ 	int ret = 0, retry_cnt = 0;
+@@ -3208,7 +3208,7 @@ int gnss_powerdomain_open(void)
+ 	return 0;
+ }
+ 
+-int gnss_powerdomain_close(void)
++static int gnss_powerdomain_close(void)
+ {
+ 	/* add by this. */
+ 	int ret = 0;
+@@ -3647,7 +3647,7 @@ EXPORT_SYMBOL_GPL(marlin_set_sleep);
+ /* Temporary modification for UWE5623:
+  * cmd52 read/write timeout -110 issue.
+  */
+-void marlin_read_test_after_reset(void)
++static void marlin_read_test_after_reset(void)
+ {
+ 	int ret;
+ 	unsigned int reg_addr = AON_APB_TEST_READ_REG, reg_val;
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_dump.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_dump.c
+index 5c432c7..ab7b3d4 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_dump.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_dump.c
+@@ -19,6 +19,7 @@
+ #include "wcn_log.h"
+ #include "wcn_misc.h"
+ #include "wcn_glb_reg.h"
++#include "wcn_dump.h"
+ #ifdef CONFIG_WCN_USB
+ #include "./usb_boot.h"
+ #endif
+@@ -226,7 +227,7 @@ out:
+ 	return count;
+ }
+ 
+-void mdbg_clear_log(void)
++static void mdbg_clear_log(void)
+ {
+ 	if (mdbg_dev->ring_dev->ring->rp
+ 		!= mdbg_dev->ring_dev->ring->wp) {
+@@ -530,7 +531,7 @@ static void wcn_dump_cp_register(struct wcn_dump_mem_reg *mem)
+ /* IF CONFIG_UWE5623 IS NOT DEFINE, THIS FUNCTION WILL NOT BE USED!
+  * THIS IS A ERROR BY COMPLIE. SO IT NOT BE STATIC
+  */
+-void wcn_dump_cp_data(struct wcn_dump_mem_reg *mem, int start, int end)
++static void wcn_dump_cp_data(struct wcn_dump_mem_reg *mem, int start, int end)
+ {
+ 	int i;
+ 
+@@ -605,7 +606,7 @@ static int cp_dcache_clean_invalid_all(void)
+ 
+ /* select aon_apb_dap DAP(Debug Access Port) */
+ #if defined CONFIG_UWE5622 || defined CONFIG_CHECK_DRIVER_BY_CHIPID
+-void dap_sel_btwf_lite(void)
++static void dap_sel_btwf_lite(void)
+ {
+ 	int ret;
+ 	unsigned int reg_val;
+@@ -644,7 +645,7 @@ void dap_sel_btwf_lite(void)
+ }
+ 
+ /* select aon_apb_dap DAP(Debug Access Port) */
+-void dap_sel_default_lite(void)
++static void dap_sel_default_lite(void)
+ {
+ 	int ret;
+ 	unsigned int reg_val;
+@@ -658,7 +659,7 @@ void dap_sel_default_lite(void)
+ }
+ 
+ /* enable aon_apb_dap_en */
+-void apb_eb_lite(void)
++static void apb_eb_lite(void)
+ {
+ 	int ret;
+ 	unsigned int reg_val;
+@@ -688,7 +689,7 @@ void apb_eb_lite(void)
+ #endif
+ 
+ /* select aon_apb_dap DAP(Debug Access Port) */
+-void dap_sel_btwf(void)
++static void dap_sel_btwf(void)
+ {
+ 	int ret;
+ 	unsigned int reg_val;
+@@ -727,7 +728,7 @@ void dap_sel_btwf(void)
+ }
+ 
+ /* select aon_apb_dap DAP(Debug Access Port) */
+-void dap_sel_default(void)
++static void dap_sel_default(void)
+ {
+ 	int ret;
+ 	unsigned int reg_val;
+@@ -741,7 +742,7 @@ void dap_sel_default(void)
+ }
+ 
+ /* disable aon_apb_dap_rst */
+-void apb_rst(void)
++static void apb_rst(void)
+ {
+ 	int ret;
+ 	unsigned int reg_val;
+@@ -770,7 +771,7 @@ void apb_rst(void)
+ }
+ 
+ /* enable aon_apb_dap_en */
+-void apb_eb(void)
++static void apb_eb(void)
+ {
+ 	int ret;
+ 	unsigned int reg_val;
+@@ -798,7 +799,7 @@ void apb_eb(void)
+ 	WCN_INFO("%s 2:APB_EB:0x%x\n", __func__, reg_val);
+ }
+ 
+-void check_dap_is_ok(void)
++static void check_dap_is_ok(void)
+ {
+ 	int ret;
+ 	unsigned int reg_val;
+@@ -841,7 +842,7 @@ void hold_btwf_core(void)
+  * Debug Halting Control status Register
+  * (0xe000edf0) = 0xa05f0003
+  */
+-void release_btwf_core(void)
++static void release_btwf_core(void)
+ {
+ 	int ret, i;
+ 	unsigned int reg_val;
+@@ -884,7 +885,7 @@ void set_debug_mode(void)
+  * Debug core Register Selector Register
+  * The index R0 is 0, R1 is 1
+  */
+-void set_core_reg(unsigned int index)
++static void set_core_reg(unsigned int index)
+ {
+ 	int ret, i;
+ 	unsigned int reg_val;
+@@ -908,7 +909,7 @@ void set_core_reg(unsigned int index)
+  * Example: write PC(R15)=0x12345678
+  * reg_index = 15, value = 0x12345678
+  */
+-void write_core_reg_value(unsigned int reg_index, unsigned int value)
++static void write_core_reg_value(unsigned int reg_index, unsigned int value)
+ {
+ 	int ret, i;
+ 	unsigned int reg_val;
+@@ -989,7 +990,7 @@ void sprdwcn_bus_armreg_write(unsigned int reg_index, unsigned int value)
+ }
+ 
+ /* Debug Core register Data Register */
+-void read_core_reg(unsigned int value, unsigned int *p)
++static void read_core_reg(unsigned int value, unsigned int *p)
+ {
+ 	int ret, i;
+ 	unsigned int reg_val;
+@@ -1213,7 +1214,7 @@ static int check_wifi_power_domain_ison(void)
+ 	return 0;
+ }
+ 
+-void dump_dummy_read(void)
++static void dump_dummy_read(void)
+ {
+ 	int ret;
+ 	unsigned int reg_val;
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_op.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_op.c
+index bd7b1a1..c6ad2ee 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_op.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_op.c
+@@ -17,6 +17,7 @@
+ #include <marlin_platform.h>
+ #include <wcn_bus.h>
+ #include "mdbg_type.h"
++#include "wcn_op.h"
+ 
+ #define WCN_OP_NAME	"wcn_op"
+ 
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_procfs.h b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_procfs.h
+index 0e42a67..b069fb9 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_procfs.h
++++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_procfs.h
+@@ -16,4 +16,9 @@ void wakeup_loopcheck_int(void);
+ void loopcheck_first_boot_clear(void);
+ void loopcheck_first_boot_set(void);
+ int prepare_free_buf(int chn, int size, int num);
++/* -Wmissing-prototypes: cross-file declarations */
++int mdbg_assert_read(int channel, struct mbuf_t *head, struct mbuf_t *tail, int num);
++int mdbg_at_cmd_read(int channel, struct mbuf_t *head, struct mbuf_t *tail, int num);
++int mdbg_loopcheck_read(int channel, struct mbuf_t *head, struct mbuf_t *tail, int num);
++
+ #endif
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_swd_dp.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_swd_dp.c
+index 3cb6caf..2ae2c25 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_swd_dp.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_swd_dp.c
+@@ -179,7 +179,7 @@ static void swd_insert_cycles(u32 n)
+ 		swd_clk_cycle();
+ }
+ 
+-u32 swd_transfer(u8 cmd, u32 *data)
++static u32 swd_transfer(u8 cmd, u32 *data)
+ {
+ 	u32 ack = 0;
+ 	u32 bit;
+@@ -523,7 +523,7 @@ static void swd_read_apidr(void)
+ }
+ 
+ 
+-u32 swd_sel_target(u8 cmd, u32 *data)
++static u32 swd_sel_target(u8 cmd, u32 *data)
+ {
+ 	u32 bit, parity;
+ 	u32 n, val;
+@@ -618,7 +618,7 @@ static void swd_device_en(void)
+ 
+ /* Debug Exception and Monitor Control Register */
+ /* (0xe000edfC) = 0x010007f1 */
+-void swd_set_debug_mode(void)
++static void swd_set_debug_mode(void)
+ {
+ 	int ret;
+ 	int addr;
+@@ -645,7 +645,7 @@ void swd_set_debug_mode(void)
+  * Debug Halting Control status Register
+  * (0xe000edf0) = 0xa05f0003
+  */
+-void swd_hold_btwf_core(void)
++static void swd_hold_btwf_core(void)
+ {
+ 	int ret;
+ 	int addr;
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdio_v3.c b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdio_v3.c
+index eec80de..b035fd1 100755
+--- a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdio_v3.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdio_v3.c
+@@ -8,12 +8,12 @@ static int sdio_get_hif_type(void)
+ 	return HW_TYPE_SDIO;
+ }
+ 
+-int sdiohal_driver_register(void)
++static int sdiohal_driver_register(void)
+ {
+ 	return 0;
+ }
+ 
+-void sdiohal_driver_unregister(void)
++static void sdiohal_driver_unregister(void)
+ {
+ 
+ }
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_common.c b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_common.c
+index cf38d8d..ef4c00f 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_common.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_common.c
+@@ -182,7 +182,7 @@ void sdiohal_rx_up(void)
+ 	complete(&p_data->rx_completed);
+ }
+ 
+-void sdiohal_completion_init(void)
++static void sdiohal_completion_init(void)
+ {
+ 	struct sdiohal_data_t *p_data = sdiohal_get_data();
+ 
+@@ -251,7 +251,7 @@ void sdiohal_unlock_scan_ws(void)
+ 	__pm_relax(p_data->scan_ws);
+ }
+ 
+-void sdiohal_wakelock_init(void)
++static void sdiohal_wakelock_init(void)
+ {
+ 	struct sdiohal_data_t *p_data = sdiohal_get_data();
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+@@ -265,7 +265,7 @@ void sdiohal_wakelock_init(void)
+ #endif
+ }
+ 
+-void sdiohal_wakelock_deinit(void)
++static void sdiohal_wakelock_deinit(void)
+ {
+ 	struct sdiohal_data_t *p_data = sdiohal_get_data();
+ 	/*wakeup_source pointer*/
+@@ -290,7 +290,7 @@ void sdiohal_callback_unlock(struct mutex *callback_mutex)
+ 	mutex_unlock(callback_mutex);
+ }
+ 
+-void sdiohal_callback_lock_init(void)
++static void sdiohal_callback_lock_init(void)
+ {
+ 	struct sdiohal_data_t *p_data = sdiohal_get_data();
+ 	struct mutex *chn_callback = p_data->callback_lock;
+@@ -300,7 +300,7 @@ void sdiohal_callback_lock_init(void)
+ 		mutex_init(&chn_callback[channel]);
+ }
+ 
+-void sdiohal_callback_lock_deinit(void)
++static void sdiohal_callback_lock_deinit(void)
+ {
+ 	struct sdiohal_data_t *p_data = sdiohal_get_data();
+ 	struct mutex *chn_callback = p_data->callback_lock;
+@@ -310,7 +310,7 @@ void sdiohal_callback_lock_deinit(void)
+ 		mutex_destroy(&chn_callback[channel]);
+ }
+ 
+-void sdiohal_spinlock_init(void)
++static void sdiohal_spinlock_init(void)
+ {
+ 	struct sdiohal_data_t *p_data = sdiohal_get_data();
+ 
+@@ -430,7 +430,7 @@ void sdiohal_sdma_leave(void)
+ 	mutex_unlock(&p_data->xmit_sdma);
+ }
+ 
+-void sdiohal_mutex_init(void)
++static void sdiohal_mutex_init(void)
+ {
+ 	struct sdiohal_data_t *p_data = sdiohal_get_data();
+ 
+@@ -438,7 +438,7 @@ void sdiohal_mutex_init(void)
+ 	mutex_init(&p_data->xmit_sdma);
+ }
+ 
+-void sdiohal_mutex_deinit(void)
++static void sdiohal_mutex_deinit(void)
+ {
+ 	struct sdiohal_data_t *p_data = sdiohal_get_data();
+ 
+@@ -446,7 +446,7 @@ void sdiohal_mutex_deinit(void)
+ 	mutex_destroy(&p_data->xmit_sdma);
+ }
+ 
+-void sdiohal_sleep_flag_init(void)
++static void sdiohal_sleep_flag_init(void)
+ {
+ 	struct sdiohal_data_t *p_data = sdiohal_get_data();
+ 
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_ctl.c b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_ctl.c
+index 8000bfe..14c3347 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_ctl.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_ctl.c
+@@ -407,7 +407,7 @@ static void sdiohal_tx_send(int chn)
+ 
+ }
+ 
+-int sdiohal_tx_muti_channel_pop(int channel, struct mbuf_t *head,
++static int sdiohal_tx_muti_channel_pop(int channel, struct mbuf_t *head,
+ 		   struct mbuf_t *tail, int num)
+ {
+ 	struct mbuf_t *mbuf_node;
+@@ -470,7 +470,7 @@ static void sdiohal_tx_test_init(void)
+ 	}
+ }
+ 
+-int sdiohal_rx_muti_channel_pop(int channel, struct mbuf_t *head,
++static int sdiohal_rx_muti_channel_pop(int channel, struct mbuf_t *head,
+ 		   struct mbuf_t *tail, int num)
+ {
+ 	int i;
+@@ -512,7 +512,7 @@ static void sdiohal_rx_test_init(void)
+ 	}
+ }
+ 
+-int at_list_tx_pop(int channel, struct mbuf_t *head,
++static int at_list_tx_pop(int channel, struct mbuf_t *head,
+ 		   struct mbuf_t *tail, int num)
+ {
+ 	struct mbuf_t *mbuf_node;
+@@ -541,7 +541,7 @@ int at_list_tx_pop(int channel, struct mbuf_t *head,
+ }
+ 
+ int tp_rx_cnt;
+-int at_list_rx_pop(int channel, struct mbuf_t *head,
++static int at_list_rx_pop(int channel, struct mbuf_t *head,
+ 		   struct mbuf_t *tail, int num)
+ {
+ 	ktime_t times_count;
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_main.c b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_main.c
+index 974c1f8..5eb5702 100755
+--- a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_main.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_main.c
+@@ -653,7 +653,7 @@ static void sdiohal_dump_sys_signal(int index, struct debug_bus_t *config)
+ 				   data_buf, config[index].size * 4, false);
+ }
+ 
+-void sdiohal_dump_debug_bus(void)
++static void sdiohal_dump_debug_bus(void)
+ {
+ 	unsigned char index;
+ 	struct debug_bus_t *config = bus_config;
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.c b/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.c
+index 6b65e1b..318dbf0 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.c
+@@ -70,7 +70,7 @@ void sdio_wait_pub_int_done(void)
+ }
+ EXPORT_SYMBOL(sdio_wait_pub_int_done);
+ 
+-int pub_int_handle_thread(void *data)
++static int pub_int_handle_thread(void *data)
+ {
+ 	union PUB_INT_STS0_REG pub_int_sts0 = {0};
+ 	int bit_num, ret;
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sleep/slp_mgr.h b/drivers/net/wireless/uwe5622/unisocwcn/sleep/slp_mgr.h
+index d32054b..d520a6d 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/sleep/slp_mgr.h
++++ b/drivers/net/wireless/uwe5622/unisocwcn/sleep/slp_mgr.h
+@@ -54,4 +54,8 @@ void slp_mgr_drv_sleep(enum slp_subsys subsys, bool enable);
+ int slp_mgr_wakeup(enum slp_subsys subsys);
+ void slp_mgr_reset(void);
+ 
++
++/* -Wmissing-prototypes: unconditional (def in slp_test.c is unguarded) */
++int slp_test_init(void);
++
+ #endif
+diff --git a/drivers/net/wireless/uwe5622/unisocwcn/wcn_bus.c b/drivers/net/wireless/uwe5622/unisocwcn/wcn_bus.c
+index 231718d..50d6089 100644
+--- a/drivers/net/wireless/uwe5622/unisocwcn/wcn_bus.c
++++ b/drivers/net/wireless/uwe5622/unisocwcn/wcn_bus.c
+@@ -18,6 +18,7 @@
+ #include <linux/slab.h>
+ #include <linux/spinlock.h>
+ #include <wcn_bus.h>
++#include "bus_common.h"
+ 
+ struct buffer_pool_t {
+ 	int size;
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
+index 2e5715e..e061310 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
+@@ -503,7 +503,7 @@ static inline int sprdwl_is_valid_iftype(struct wiphy *wiphy,
+ 	return wiphy->interface_modes & BIT(type);
+ }
+ 
+-int sprdwl_check_p2p_coex(struct sprdwl_priv *priv)
++static int sprdwl_check_p2p_coex(struct sprdwl_priv *priv)
+ {
+ 	if (mode_to_vif(priv, SPRDWL_MODE_P2P_CLIENT) ||
+ 		mode_to_vif(priv, SPRDWL_MODE_P2P_GO))
+@@ -1742,7 +1742,7 @@ static int sprdwl_cfg80211_sched_scan_stop(struct wiphy *wiphy,
+ }
+ 
+ #ifdef SYNC_DISCONNECT
+-void sprdwl_disconnect_handle(struct sprdwl_vif *vif)
++static void sprdwl_disconnect_handle(struct sprdwl_vif *vif)
+ {
+ 	vif->sm_state = SPRDWL_DISCONNECTED;
+ 
+@@ -2139,7 +2139,7 @@ void sprdwl_report_fake_probe(struct wiphy *wiphy, u8 *ie, size_t ielen)
+ 	}
+ }
+ 
+-void signal_level_enhance(struct sprdwl_vif *vif,
++static void signal_level_enhance(struct sprdwl_vif *vif,
+ 			  struct ieee80211_mgmt *mgmt, s32 *signal)
+ {
+ 	struct scan_result *scan_node;
+@@ -3051,7 +3051,7 @@ void sprdwl_report_tdls(struct sprdwl_vif *vif, const u8 *peer,
+ }
+ 
+ /* Roaming related stuff */
+-int sprdwl_cfg80211_set_cqm_rssi_config(struct wiphy *wiphy,
++static int sprdwl_cfg80211_set_cqm_rssi_config(struct wiphy *wiphy,
+ 					struct net_device *ndev,
+ 					s32 rssi_thold, u32 rssi_hyst)
+ {
+@@ -3074,7 +3074,7 @@ void sprdwl_report_cqm(struct sprdwl_vif *vif, u8 rssi_event)
+ #endif
+ }
+ 
+-int sprdwl_cfg80211_update_ft_ies(struct wiphy *wiphy, struct net_device *ndev,
++static int sprdwl_cfg80211_update_ft_ies(struct wiphy *wiphy, struct net_device *ndev,
+ 				  struct cfg80211_update_ft_ies_params *ftie)
+ {
+ 	struct sprdwl_vif *vif = netdev_priv(ndev);
+@@ -3171,7 +3171,7 @@ static int sprdwl_cfg80211_set_mac_acl(struct wiphy *wiphy,
+ 						SPRDWL_SUBCMD_ADD, num, mac_addr);
+ }
+ 
+-int sprdwl_cfg80211_set_power_mgmt(struct wiphy *wiphy, struct net_device *ndev,
++static int sprdwl_cfg80211_set_power_mgmt(struct wiphy *wiphy, struct net_device *ndev,
+ 				   bool enabled, int timeout)
+ {
+ 	struct sprdwl_vif *vif = netdev_priv(ndev);
+@@ -3342,7 +3342,7 @@ static struct cfg80211_ops sprdwl_cfg80211_ops = {
+ #endif
+ };
+ 
+-void sprdwl_save_ch_info(struct sprdwl_priv *priv, u32 band, u32 flags, int center_freq)
++static void sprdwl_save_ch_info(struct sprdwl_priv *priv, u32 band, u32 flags, int center_freq)
+ {
+ 	int index = 0;
+ 	/* Workaround for bug873327, report freq list instead of channel list */
+@@ -3500,7 +3500,7 @@ static void sprdwl_reg_notify(struct wiphy *wiphy,
+ 	}
+ }
+ #else
+-void sprdwl_reg_notify(struct wiphy *wiphy,
++static void sprdwl_reg_notify(struct wiphy *wiphy,
+ 				  struct regulatory_request *request)
+ {
+ 	struct sprdwl_priv *priv = wiphy_priv(wiphy);
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c
+index 093878c..54392ab 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c
+@@ -182,7 +182,7 @@ static const char *assert_reason_to_str(u8 reason)
+ 
+ #undef AR2S
+ 
+-uint16_t CRC16(uint8_t *buf, uint16_t len)
++static uint16_t CRC16(uint8_t *buf, uint16_t len)
+ {
+ 	uint16_t CRC = 0xFFFF;
+ 	uint16_t i;
+@@ -648,7 +648,7 @@ out:
+  * rlen: input the length of rbuf
+  *       output the length of the msg,if *rlen == 0, rbuf get nothing
+  */
+-int sprdwl_cmd_send_recv_no_wait(struct sprdwl_priv *priv,
++static int sprdwl_cmd_send_recv_no_wait(struct sprdwl_priv *priv,
+ 			 struct sprdwl_msg_buf *msg)
+ {
+ 	u8 cmd_id;
+@@ -2204,7 +2204,7 @@ int sprdwl_set_max_clients_allowed(struct sprdwl_priv *priv,
+ 	return sprdwl_cmd_send_recv(priv, msg, CMD_WAIT_TIMEOUT, NULL, NULL);
+ }
+ 
+-void sprdwl_add_hang_cmd(struct sprdwl_vif *vif)
++static void sprdwl_add_hang_cmd(struct sprdwl_vif *vif)
+ {
+ 	struct sprdwl_work *misc_work;
+ 	struct sprdwl_cmd *cmd = &g_sprdwl_cmd;
+@@ -2227,7 +2227,7 @@ void sprdwl_add_hang_cmd(struct sprdwl_vif *vif)
+ 	sprdwl_queue_work(vif->priv, misc_work);
+ }
+ 
+-void sprdwl_add_close_cmd(struct sprdwl_vif *vif, enum sprdwl_mode mode)
++static void sprdwl_add_close_cmd(struct sprdwl_vif *vif, enum sprdwl_mode mode)
+ {
+ 	struct sprdwl_work *misc_work;
+ 
+@@ -2514,7 +2514,7 @@ int sprdwl_cmd_host_wakeup_fw(struct sprdwl_priv *priv, u8 ctx_id)
+ 	return ret;
+ }
+ 
+-int sprdwl_cmd_req_lte_concur(struct sprdwl_priv *priv, u8 ctx_id, u8 user_channel)
++static int sprdwl_cmd_req_lte_concur(struct sprdwl_priv *priv, u8 ctx_id, u8 user_channel)
+ {
+ 	struct sprdwl_msg_buf *msg;
+ 
+@@ -2625,7 +2625,7 @@ unsigned short sprdwl_rx_rsp_process(struct sprdwl_priv *priv, u8 *msg)
+ }
+ 
+ /* Events */
+-void sprdwl_event_station(struct sprdwl_vif *vif, u8 *data, u16 len)
++static void sprdwl_event_station(struct sprdwl_vif *vif, u8 *data, u16 len)
+ {
+ 	struct sprdwl_event_new_station *sta =
+ 		(struct sprdwl_event_new_station *)data;
+@@ -2671,7 +2671,7 @@ void sprdwl_event_scan_done(struct sprdwl_vif *vif, u8 *data, u16 len)
+ 	bss_count = 0;
+ }
+ 
+-void sprdwl_event_connect(struct sprdwl_vif *vif, u8 *data, u16 len)
++static void sprdwl_event_connect(struct sprdwl_vif *vif, u8 *data, u16 len)
+ {
+ 	u8 *pos = data;
+ 	u8 status_code = 0;
+@@ -2793,13 +2793,13 @@ void sprdwl_event_mic_failure(struct sprdwl_vif *vif, u8 *data, u16 len)
+ 				  mic_failure->key_id);
+ }
+ 
+-void sprdwl_event_remain_on_channel_expired(struct sprdwl_vif *vif,
++static void sprdwl_event_remain_on_channel_expired(struct sprdwl_vif *vif,
+ 						u8 *data, u16 len)
+ {
+ 	sprdwl_report_remain_on_channel_expired(vif);
+ }
+ 
+-void sprdwl_event_mlme_tx_status(struct sprdwl_vif *vif, u8 *data, u16 len)
++static void sprdwl_event_mlme_tx_status(struct sprdwl_vif *vif, u8 *data, u16 len)
+ {
+ 	struct sprdwl_event_mgmt_tx_status *tx_status =
+ 		(struct sprdwl_event_mgmt_tx_status *)data;
+@@ -2855,7 +2855,7 @@ void sprdwl_event_frame(struct sprdwl_vif *vif, u8 *data, u16 len, int flag)
+ 	}
+ }
+ 
+-void sprdwl_event_epno_results(struct sprdwl_vif *vif, u8 *data, u16 data_len)
++static void sprdwl_event_epno_results(struct sprdwl_vif *vif, u8 *data, u16 data_len)
+ {
+ 	int i;
+ 	u64 msecs, now;
+@@ -2945,7 +2945,7 @@ failed:
+ 	wl_err("%s report epno event failed\n", __func__);
+ }
+ 
+-void sprdwl_event_gscan_frame(struct sprdwl_vif *vif, u8 *data, u16 len)
++static void sprdwl_event_gscan_frame(struct sprdwl_vif *vif, u8 *data, u16 len)
+ {
+ 	u32 report_event;
+ 	u8 *pos = data;
+@@ -3109,7 +3109,7 @@ void sprdwl_event_suspend_resume(struct sprdwl_vif *vif, u8 *data, u16 len)
+ 	}
+ }
+ 
+-void sprdwl_event_hang_recovery(struct sprdwl_vif *vif, u8 *data, u16 len)
++static void sprdwl_event_hang_recovery(struct sprdwl_vif *vif, u8 *data, u16 len)
+ {
+ 	struct event_hang_recovery *hang =
+ 		(struct event_hang_recovery *)data;
+@@ -3127,7 +3127,7 @@ void sprdwl_event_hang_recovery(struct sprdwl_vif *vif, u8 *data, u16 len)
+ 		tx_up(tx_msg);
+ }
+ 
+-void sprdwl_event_thermal_warn(struct sprdwl_vif *vif, u8 *data, u16 len)
++static void sprdwl_event_thermal_warn(struct sprdwl_vif *vif, u8 *data, u16 len)
+ {
+ 	struct event_thermal_warn *thermal =
+ 		(struct event_thermal_warn *)data;
+@@ -3169,7 +3169,7 @@ void sprdwl_event_thermal_warn(struct sprdwl_vif *vif, u8 *data, u16 len)
+ #define WIFI_EVENT_WFD_RATE 0x30
+ extern int wfd_notifier_call_chain(unsigned long val, void *v);
+ 
+-void sprdwl_wfd_mib_cnt(struct sprdwl_vif *vif, u8 *data, u16 len)
++static void sprdwl_wfd_mib_cnt(struct sprdwl_vif *vif, u8 *data, u16 len)
+ {
+ 	struct event_wfd_mib_cnt *wfd =
+ 		(struct event_wfd_mib_cnt *)data;
+@@ -3262,7 +3262,7 @@ err:
+ 	return -1;
+ }
+ 
+-void sprdwl_event_fw_power_down(struct sprdwl_vif *vif, u8 *data, u16 len)
++static void sprdwl_event_fw_power_down(struct sprdwl_vif *vif, u8 *data, u16 len)
+ {
+ 	struct sprdwl_work *misc_work;
+ 
+@@ -3277,7 +3277,7 @@ void sprdwl_event_fw_power_down(struct sprdwl_vif *vif, u8 *data, u16 len)
+ 	sprdwl_queue_work(vif->priv, misc_work);
+ }
+ 
+-void sprdwl_event_chan_changed(struct sprdwl_vif *vif, u8 *data, u16 len)
++static void sprdwl_event_chan_changed(struct sprdwl_vif *vif, u8 *data, u16 len)
+ {
+ 	struct sprdwl_chan_changed_info *p = (struct sprdwl_chan_changed_info *)data;
+ 	u8 channel;
+@@ -3311,7 +3311,7 @@ void sprdwl_event_chan_changed(struct sprdwl_vif *vif, u8 *data, u16 len)
+ 	}
+ }
+ 
+-void sprdwl_event_coex_bt_on_off(u8 *data, u16 len)
++static void sprdwl_event_coex_bt_on_off(u8 *data, u16 len)
+ {
+ 	struct event_coex_mode_changed *coex_bt_on_off =
+ 		(struct event_coex_mode_changed *)data;
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h
+index 9f7a61f..0355b18 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h
++++ b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h
+@@ -1129,4 +1129,14 @@ int sprdwl_set_wowlan(struct sprdwl_priv *priv, int subcmd, void *pad, int pad_l
+ int sprdwl_sync_disconnect_event(struct sprdwl_vif *vif, unsigned int timeout);
+ #endif
+ int sprdwl_set_if_down(struct net_device *ndev);
++/* -Wmissing-prototypes: cross-file declarations */
++void sprdwl_cancel_scan(struct sprdwl_vif *vif);
++void sprdwl_cancel_sched_scan(struct sprdwl_vif *vif);
++void sprdwl_event_cqm(struct sprdwl_vif *vif, u8 *data, u16 len);
++void sprdwl_event_disconnect(struct sprdwl_vif *vif, u8 *data, u16 len);
++void sprdwl_event_mic_failure(struct sprdwl_vif *vif, u8 *data, u16 len);
++void sprdwl_event_scan_done(struct sprdwl_vif *vif, u8 *data, u16 len);
++void sprdwl_event_suspend_resume(struct sprdwl_vif *vif, u8 *data, u16 len);
++void sprdwl_event_tdls(struct sprdwl_vif *vif, u8 *data, u16 len);
++
+ #endif
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/intf_ops.h b/drivers/net/wireless/uwe5622/unisocwifi/intf_ops.h
+index c580b30..0b67160 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/intf_ops.h
++++ b/drivers/net/wireless/uwe5622/unisocwifi/intf_ops.h
+@@ -94,4 +94,8 @@ static inline int sprdwl_get_ini_status(struct sprdwl_priv *priv)
+ 	return 0;
+ }
+ 
++
++/* -Wmissing-prototypes: cross-file declarations */
++int if_tx_one(struct sprdwl_intf *intf, unsigned char *data, int len, int chn);
++
+ #endif
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/mm.c b/drivers/net/wireless/uwe5622/unisocwifi/mm.c
+index f33d871..88d8f26 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/mm.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/mm.c
+@@ -29,7 +29,7 @@
+ #define SKB_SHARED_INFO_OFFSET \
+ 	SKB_DATA_ALIGN(SPRDWL_MAX_DATA_RXLEN + NET_SKB_PAD)
+ 
+-void check_mh_buffer(struct device *dev, void *buffer, dma_addr_t pa,
++static void check_mh_buffer(struct device *dev, void *buffer, dma_addr_t pa,
+ 			 size_t size, enum dma_data_direction direction)
+ {
+ #define MAX_RETRY_NUM 8
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/qos.c b/drivers/net/wireless/uwe5622/unisocwifi/qos.c
+index 426810c..6273d0c 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/qos.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/qos.c
+@@ -585,7 +585,7 @@ void reset_wmmac_ts_info(void)
+ 		remove_wmmac_ts_info(tsid);
+ }
+ 
+-unsigned int priority_map_to_qos_index(int priority)
++static unsigned int priority_map_to_qos_index(int priority)
+ {
+ 	qos_head_type_t qos_index = SPRDWL_AC_BE;
+ 
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/rtt.c b/drivers/net/wireless/uwe5622/unisocwifi/rtt.c
+index 15410fb..c2fc64d 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/rtt.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/rtt.c
+@@ -614,7 +614,7 @@ out:
+ 	mutex_unlock(&priv->ftm.lock);
+ }
+ 
+-void sprdwl_ftm_event_per_dest_res(struct sprdwl_priv *priv,
++static void sprdwl_ftm_event_per_dest_res(struct sprdwl_priv *priv,
+ 				   struct ftm_per_dest_res *res)
+ {
+ 	u32 i, index;
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/rx_msg.c b/drivers/net/wireless/uwe5622/unisocwifi/rx_msg.c
+index d80267a..86d7f63 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/rx_msg.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/rx_msg.c
+@@ -28,14 +28,14 @@
+ #include "tcp_ack.h"
+ 
+ #ifdef RX_HW_CSUM
+-bool mh_ipv6_ext_hdr(unsigned char nexthdr)
++static bool mh_ipv6_ext_hdr(unsigned char nexthdr)
+ {
+ 	return (nexthdr == NEXTHDR_HOP) ||
+ 		   (nexthdr == NEXTHDR_ROUTING) ||
+ 		   (nexthdr == NEXTHDR_DEST);
+ }
+ 
+-int ipv6_csum(void *data, __wsum csum)
++static int ipv6_csum(void *data, __wsum csum)
+ {
+ 	int ret = 0;
+ 	struct rx_msdu_desc *msdu_desc = (struct rx_msdu_desc *)data;
+@@ -189,7 +189,7 @@ sprdwl_rx_mh_addr_process(struct sprdwl_rx_if *rx_if, void *data,
+ }
+ 
+ #ifdef SPLIT_STACK
+-void sprdwl_rx_net_work_queue(struct work_struct *work)
++static void sprdwl_rx_net_work_queue(struct work_struct *work)
+ {
+ 	struct sprdwl_rx_if *rx_if;
+ 	struct sprdwl_priv *priv;
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c b/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c
+index a8e824e..fa82f9a 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c
+@@ -322,7 +322,7 @@ static int sprdwl_tcp_ack_alloc_index(struct sprdwl_tcp_ack_manage *ack_m)
+ }
+ 
+ /* return val: 0 for not handle tx, 1 for handle tx */
+-int sprdwl_tcp_ack_handle(struct sprdwl_msg_buf *new_msgbuf,
++static int sprdwl_tcp_ack_handle(struct sprdwl_msg_buf *new_msgbuf,
+ 			  struct sprdwl_tcp_ack_manage *ack_m,
+ 			  struct sprdwl_tcp_ack_info *ack_info,
+ 			  struct sprdwl_tcp_ack_msg *ack_msg,
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/tx_msg.c b/drivers/net/wireless/uwe5622/unisocwifi/tx_msg.c
+index adbab27..c1f5de8 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/tx_msg.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/tx_msg.c
+@@ -315,7 +315,7 @@ void sprdwl_dequeue_data_list(struct mbuf_t *head, int num)
+ }
+ 
+ /* seam for tx_thread */
+-void tx_down(struct sprdwl_tx_msg *tx_msg)
++static void tx_down(struct sprdwl_tx_msg *tx_msg)
+ {
+ 	int ret;
+ 	do {
+@@ -381,7 +381,7 @@ void handle_tx_status_after_close(struct sprdwl_vif *vif)
+ 	}
+ }
+ 
+-void sprdwl_init_xmit_list(struct sprdwl_tx_msg *tx_msg)
++static void sprdwl_init_xmit_list(struct sprdwl_tx_msg *tx_msg)
+ {
+ 	INIT_LIST_HEAD(&tx_msg->xmit_msg_list.to_send_list);
+ 	INIT_LIST_HEAD(&tx_msg->xmit_msg_list.to_free_list);
+@@ -423,7 +423,7 @@ add_xmit_list_tail(struct sprdwl_tx_msg *tx_msg,
+ 		 get_list_num(&tx_msg->xmit_msg_list.to_send_list));
+ }
+ 
+-unsigned int queue_is_empty(struct sprdwl_tx_msg *tx_msg, enum sprdwl_mode mode)
++static unsigned int queue_is_empty(struct sprdwl_tx_msg *tx_msg, enum sprdwl_mode mode)
+ {
+ 	int i, j;
+ 	struct tx_t *tx_t_list = tx_msg->tx_list[mode];
+@@ -542,7 +542,7 @@ void sprdwl_fc_add_share_credit(struct sprdwl_vif *vif)
+ 	}
+ }
+ 
+-int sprdwl_fc_find_color_per_mode(struct sprdwl_tx_msg *tx_msg,
++static int sprdwl_fc_find_color_per_mode(struct sprdwl_tx_msg *tx_msg,
+ 				enum sprdwl_mode mode,
+ 				u8 *index)
+ {
+@@ -583,7 +583,7 @@ int sprdwl_fc_find_color_per_mode(struct sprdwl_tx_msg *tx_msg,
+ 	return found;
+ }
+ 
+-int sprdwl_fc_get_shared_num(struct sprdwl_tx_msg *tx_msg, u8 num)
++static int sprdwl_fc_get_shared_num(struct sprdwl_tx_msg *tx_msg, u8 num)
+ {
+ 	u8 i;
+ 	int shared_flow_num = 0;
+@@ -608,7 +608,7 @@ int sprdwl_fc_get_shared_num(struct sprdwl_tx_msg *tx_msg, u8 num)
+ 	return shared_flow_num;
+ }
+ 
+-int sprdwl_fc_get_send_num(struct sprdwl_tx_msg *tx_msg,
++static int sprdwl_fc_get_send_num(struct sprdwl_tx_msg *tx_msg,
+ 				 enum sprdwl_mode mode,
+ 				 int data_num)
+ {
+@@ -672,7 +672,7 @@ int sprdwl_fc_get_send_num(struct sprdwl_tx_msg *tx_msg,
+ }
+ 
+ /*to see there is shared flow or not*/
+-int sprdwl_fc_test_shared_num(struct sprdwl_tx_msg *tx_msg)
++static int sprdwl_fc_test_shared_num(struct sprdwl_tx_msg *tx_msg)
+ {
+ 	u8 i;
+ 	int shared_flow_num = 0;
+@@ -688,7 +688,7 @@ int sprdwl_fc_test_shared_num(struct sprdwl_tx_msg *tx_msg)
+ 	return shared_flow_num;
+ }
+ /*to check flow number, no flow number, no send*/
+-int sprdwl_fc_test_send_num(struct sprdwl_tx_msg *tx_msg,
++static int sprdwl_fc_test_send_num(struct sprdwl_tx_msg *tx_msg,
+ 				 enum sprdwl_mode mode,
+ 				 int data_num)
+ {
+@@ -752,7 +752,7 @@ u8 sprdwl_fc_set_clor_bit(struct sprdwl_tx_msg *tx_msg, int num)
+ 	return i;
+ }
+ 
+-void sprdwl_handle_tx_return(struct sprdwl_tx_msg *tx_msg,
++static void sprdwl_handle_tx_return(struct sprdwl_tx_msg *tx_msg,
+ 				  struct sprdwl_msg_list *list,
+ 				  int send_num, int ret)
+ {
+@@ -784,7 +784,7 @@ void sprdwl_handle_tx_return(struct sprdwl_tx_msg *tx_msg,
+ 	}
+ }
+ 
+-int handle_tx_timeout(struct sprdwl_tx_msg *tx_msg,
++static int handle_tx_timeout(struct sprdwl_tx_msg *tx_msg,
+ 			  struct sprdwl_msg_list *msg_list,
+ 			  struct peer_list *p_list, int ac_index)
+ {
+@@ -1061,7 +1061,7 @@ static int sprdwl_tx_eachmode_data(struct sprdwl_intf *intf,
+ 	return ret;
+ }
+ 
+-void sprdwl_flush_all_txlist(struct sprdwl_tx_msg *sprdwl_tx_dev)
++static void sprdwl_flush_all_txlist(struct sprdwl_tx_msg *sprdwl_tx_dev)
+ {
+ 	sprdwl_sdio_flush_txlist(&sprdwl_tx_dev->tx_list_cmd);
+ 	sprdwl_flush_data_txlist(sprdwl_tx_dev);
+@@ -1187,7 +1187,7 @@ exit:
+ 	return ret;
+ }
+ 
+-void prepare_addba(struct sprdwl_intf *intf, unsigned char lut_index,
++static void prepare_addba(struct sprdwl_intf *intf, unsigned char lut_index,
+ 		   struct sk_buff *skb, struct sprdwl_peer_entry *peer_entry,
+ 		   unsigned char tid)
+ {
+@@ -1649,7 +1649,7 @@ static int sprdwl_mc_pkt_checksum(struct sk_buff *skb, struct net_device *ndev)
+ 	return 1;
+ }
+ 
+-int sprdwl_tx_mc_pkt(struct sk_buff *skb, struct net_device *ndev)
++static int sprdwl_tx_mc_pkt(struct sk_buff *skb, struct net_device *ndev)
+ {
+ 	struct sprdwl_vif *vif;
+ 	struct sprdwl_intf *intf;
+@@ -1725,7 +1725,7 @@ bool is_vowifi_pkt(struct sk_buff *skb, bool *b_cmd_path)
+ 	return ret;
+ }
+ 
+-int sprdwl_tx_filter_ip_pkt(struct sk_buff *skb, struct net_device *ndev)
++static int sprdwl_tx_filter_ip_pkt(struct sk_buff *skb, struct net_device *ndev)
+ {
+ 	bool is_data2cmd;
+ 	bool is_ipv4_dhcp, is_ipv6_dhcp;
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/vendor.c b/drivers/net/wireless/uwe5622/unisocwifi/vendor.c
+index 85b12b7..60f6af3 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/vendor.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/vendor.c
+@@ -398,7 +398,7 @@ out_put_fail:
+ 	return -EMSGSIZE;
+ }
+ 
+-void calc_radio_dif(struct sprdwl_llstat_radio *dif_radio,
++static void calc_radio_dif(struct sprdwl_llstat_radio *dif_radio,
+ 			struct sprdwl_llstat_data *llst,
+ 			struct sprdwl_llstat_radio *pre_radio)
+ {
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/wl_core.c b/drivers/net/wireless/uwe5622/unisocwifi/wl_core.c
+index b14a51a..d5e734a 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/wl_core.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/wl_core.c
+@@ -39,7 +39,7 @@ int sprdwl_debug_level = L_NONE;
+ #endif
+ 
+ struct device *sprdwl_dev;
+-void adjust_debug_level(char *buf, unsigned char offset)
++static void adjust_debug_level(char *buf, unsigned char offset)
+ {
+ 	int level = buf[offset] - '0';
+ 
+@@ -69,7 +69,7 @@ extern unsigned int vi_ratio;
+ extern unsigned int be_ratio;
+ extern unsigned int wmmac_ratio;
+ 
+-void adjust_qos_ratio(char *buf, unsigned char offset)
++static void adjust_qos_ratio(char *buf, unsigned char offset)
+ {
+ 	unsigned int qos_ratio =
+ 		(buf[offset + 3] - '0')*10 + (buf[offset + 4] - '0');
+@@ -90,7 +90,7 @@ void adjust_qos_ratio(char *buf, unsigned char offset)
+ }
+ #endif
+ unsigned int new_threshold;
+-void adjust_tdls_threshold(char *buf, unsigned char offset)
++static void adjust_tdls_threshold(char *buf, unsigned char offset)
+ {
+ 	unsigned int value = 0;
+ 	unsigned int i = 0;
+@@ -436,7 +436,7 @@ static const struct file_operations txrx_debug_fops = {
+ 	.release = single_release,
+ };
+ 
+-void sprdwl_debugfs(void *spdev, struct dentry *dir)
++static void sprdwl_debugfs(void *spdev, struct dentry *dir)
+ {
+ 	struct sprdwl_intf *intf;
+ 
+@@ -447,7 +447,7 @@ void sprdwl_debugfs(void *spdev, struct dentry *dir)
+ 
+ static struct dentry *sprdwl_debug_root;
+ 
+-void sprdwl_debugfs_init(struct sprdwl_intf *intf)
++static void sprdwl_debugfs_init(struct sprdwl_intf *intf)
+ {
+ 	/* create debugfs */
+ 	sprdwl_debug_root = debugfs_create_dir("sprdwl_debug", NULL);
+@@ -468,7 +468,7 @@ void sprdwl_debugfs_init(struct sprdwl_intf *intf)
+ 		debug_ctrl_init();
+ }
+ 
+-void sprdwl_debugfs_deinit(void)
++static void sprdwl_debugfs_deinit(void)
+ {
+ 	/* remove debugfs */
+ 	debugfs_remove_recursive(sprdwl_debug_root);
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.c b/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.c
+index bb8d376..082903e 100755
+--- a/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.c
+@@ -257,7 +257,7 @@ static inline struct pcie_addr_buffer
+ 	return addr_buffer;
+ }
+ 
+-void sprdwl_add_tx_list_head(struct list_head *tx_fail_list,
++static void sprdwl_add_tx_list_head(struct list_head *tx_fail_list,
+ 				 struct list_head *tx_list,
+ 				 int ac_index,
+ 				 int tx_count)
+@@ -356,7 +356,7 @@ int sprdwl_add_topop_list(int chn, struct mbuf_t *head,
+ 	return 0;
+ }
+ 
+-void sprdwl_count_tx_tp(struct sprdwl_tx_msg *tx_msg, int num)
++static void sprdwl_count_tx_tp(struct sprdwl_tx_msg *tx_msg, int num)
+ {
+ 	long long timeus = 0;
+ 	struct sprdwl_intf *intf = get_intf();
+@@ -928,7 +928,7 @@ int sprdwl_intf_fill_msdu_dscr_test(struct sprdwl_priv *priv,
+ }
+ #endif
+ 
+-int sprdwl_rx_fill_mbuf(struct mbuf_t *head, struct mbuf_t *tail, int num, int len)
++static int sprdwl_rx_fill_mbuf(struct mbuf_t *head, struct mbuf_t *tail, int num, int len)
+ {
+ 	struct sprdwl_intf *intf = get_intf();
+ 	int ret = 0, count = 0;
+@@ -957,7 +957,7 @@ int sprdwl_rx_fill_mbuf(struct mbuf_t *head, struct mbuf_t *tail, int num, int l
+ 	return ret;
+ }
+ 
+-int sprdwl_rx_common_push(int chn, struct mbuf_t **head, struct mbuf_t **tail,
++static int sprdwl_rx_common_push(int chn, struct mbuf_t **head, struct mbuf_t **tail,
+ 			  int *num, int len)
+ {
+ 	int ret = 0;
+@@ -1027,7 +1027,7 @@ inline void sprdwl_free_rx_data(struct sprdwl_intf *intf,
+ 		sprdwcn_bus_push_list(chn, (struct mbuf_t *)head, (struct mbuf_t *)tail, num);
+ }
+ 
+-void sprdwl_count_rx_tp(struct sprdwl_rx_if *rx_if, int num)
++static void sprdwl_count_rx_tp(struct sprdwl_rx_if *rx_if, int num)
+ {
+ 	long long timeus = 0;
+ 	struct sprdwl_intf *intf = get_intf();
+@@ -1168,7 +1168,7 @@ void sprdwl_handle_pop_list(void *data)
+ }
+ 
+ /*call back func for HIF pop_link*/
+-int sprdwl_tx_data_pop_list(int channel, struct mbuf_t *head, struct mbuf_t *tail, int num)
++static int sprdwl_tx_data_pop_list(int channel, struct mbuf_t *head, struct mbuf_t *tail, int num)
+ {
+ 	struct mbuf_t *mbuf_pos = NULL;
+ #if defined(MORE_DEBUG)
+@@ -1263,7 +1263,7 @@ int sprdwl_tx_free_pcie_data(struct sprdwl_intf *dev, unsigned char *data,
+ 	return 0;
+ }
+ 
+-int sprdwl_tx_cmd_pop_list(int channel, struct mbuf_t *head, struct mbuf_t *tail, int num)
++static int sprdwl_tx_cmd_pop_list(int channel, struct mbuf_t *head, struct mbuf_t *tail, int num)
+ {
+ 	int count = 0;
+ 	struct mbuf_t *pos = NULL;
+@@ -1311,13 +1311,13 @@ int sprdwl_tx_cmd_pop_list(int channel, struct mbuf_t *head, struct mbuf_t *tail
+ 	return 0;
+ }
+ 
+-int sprdwl_rx_cmd_push(int chn, struct mbuf_t **head, struct mbuf_t **tail, int *num)
++static int sprdwl_rx_cmd_push(int chn, struct mbuf_t **head, struct mbuf_t **tail, int *num)
+ {
+ 	return sprdwl_rx_common_push(chn, head, tail,
+ 					 num, SPRDWL_MAX_CMD_RXLEN);
+ }
+ 
+-int sprdwl_rx_data_push(int chn, struct mbuf_t **head, struct mbuf_t **tail, int *num)
++static int sprdwl_rx_data_push(int chn, struct mbuf_t **head, struct mbuf_t **tail, int *num)
+ {
+ 	return sprdwl_rx_common_push(chn, head, tail,
+ 					 num, SPRDWL_MAX_DATA_RXLEN);
+@@ -1328,7 +1328,7 @@ int sprdwl_rx_data_push(int chn, struct mbuf_t **head, struct mbuf_t **tail, int
+  * 0 - suspend
+  * 1 - resume
+  */
+-int sprdwl_suspend_resume_handle(int chn, int mode)
++static int sprdwl_suspend_resume_handle(int chn, int mode)
+ {
+ 	struct sprdwl_intf *intf = get_intf();
+ 	struct sprdwl_priv *priv = intf->priv;
+@@ -1588,7 +1588,7 @@ void sprdwl_event_sta_lut(struct sprdwl_vif *vif, u8 *data, u16 len)
+ 	}
+ }
+ 
+-void sprdwl_tx_ba_mgmt(struct sprdwl_priv *priv, void *data, int len,
++static void sprdwl_tx_ba_mgmt(struct sprdwl_priv *priv, void *data, int len,
+ 			   unsigned char cmd_id, unsigned char ctx_id)
+ {
+ 	struct sprdwl_msg_buf *msg;


### PR DESCRIPTION
## What

Adds `static` to file-private functions and cross-file forward
declarations to type-aware area headers in the vendored Unisoc uwe5622
driver, cutting -Wmissing-prototypes warnings from 155 to 2. No
functional change — only linkage and declarations.

A new patch `patch/misc/wireless-uwe5622/wireless-uwe5622-Fix-missing-prototypes.patch`
is applied at the end of `driver_uwe5622()`.

## Remaining 2 warnings (left on purpose)

- do_gettimeofday (unisocwcn/.../dump.c) — the driver redefines the
  kernel-removed API; wcn_wrapper.h #defines the name to
  ktime_get_real_ts64 elsewhere, so a real prototype would fight the macro.
- sleep_test_thread (unisocwcn/sleep/slp_test.c) — a kthread with an
  intentional infinite loop; marking it static trips -Werror=return-type
  ("no return statement in function returning non-void").

## Verified

Builds cleanly into kernel 6.18 on a rockchip64 target: 0 errors,
warnings 155 -> 2.

Reproduce:

    ./compile.sh kernel BOARD=odroidm1 BRANCH=current
    grep -c "uwe5622/.*no previous prototype" output/logs/log-kernel-*.log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Unisoc UWE5622 wireless driver: cleaned up function visibility and declarations, added missing prototypes, and consolidated header usage to remove compilation warnings and improve code organization. No functional behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->