### PR TITLE
cm3588-nas: u-boot: bump to v2026.07-rc3

### DIFF
--- a/config/boards/cm3588-nas.csc
+++ b/config/boards/cm3588-nas.csc
@@ -43,7 +43,18 @@ function post_family_tweaks__cm3588_nas_udev_naming_network_interfaces() {
 
 # Mainline U-Boot
 function post_family_config__cm3588_nas_use_mainline_uboot() {
-	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"
+	display_alert "${BOARD}/${BRANCH}" "Using mainline U-Boot for ${BOARD}/${BRANCH}" "info"
+
+	# If BRANCH==vendor, use rkbin BL31 ${RKBIN_DIR}/${BL31_BLOB}, otherwise, bl31.elf from mainline ATF/TF-A
+	declare bl31_blob="undetermined"
+	if [[ "${BRANCH}" == "vendor" ]]; then
+		display_alert "${BOARD}/${BRANCH}" "Using Rockchip rkbin BL31 blob : ${RKBIN_DIR}/${BL31_BLOB}" "info"
+		bl31_blob="${RKBIN_DIR}/${BL31_BLOB}"
+		declare -g ATF_COMPILE="no" # no need to build mainline it either
+	else
+		display_alert "${BOARD}/${BRANCH}" "Using mainline BL31: bl31.elf from mainline ATF/TF-A" "info"
+		bl31_blob="bl31.elf"
+	fi
 
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"

--- a/config/boards/cm3588-nas.csc
+++ b/config/boards/cm3588-nas.csc
@@ -14,6 +14,7 @@ BOOT_FDT_FILE="rockchip/rk3588-friendlyelec-cm3588-nas.dtb"
 BOOT_SCENARIO="tpl-blob-atf-mainline"
 UEFI_EDK2_BOARD_ID="nanopc-cm3588-nas" # This _only_ used for uefi-edk2-rk3588 extension; cm3588-nas was introduced in v0.12 of edk2-porting/edk2-rk3588
 
+# @TODO: revisit this as it's probably just for vendor kernel
 function post_family_tweaks__cm3588_nas_udev_naming_audios() {
 	display_alert "$BOARD" "Renaming CM3588 audio interfaces to human-readable form" "info"
 
@@ -30,6 +31,7 @@ function post_family_tweaks__cm3588_nas_udev_naming_audios() {
 
 # Output from CM3588 syslog with edge kernel 6.8: r8169 0004:41:00.0 enP4p65s0: renamed from eth0
 # Note: legacy kernel 5.10 uses driver r8125, edge kernel uses r8169 as of 6.8
+# TODO: only needed on BRANCH==vendor since mainline kernel patch for u-boot driven MAC stability also brings eth0/end0
 function post_family_tweaks__cm3588_nas_udev_naming_network_interfaces() {
 	display_alert "$BOARD" "Renaming CM3588 LAN interface to eth0" "info"
 
@@ -45,10 +47,10 @@ function post_family_config__cm3588_nas_use_mainline_uboot() {
 
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-	declare -g BOOTBRANCH="tag:v2026.04"
-	declare -g BOOTPATCHDIR="v2026.04"
+	declare -g BOOTBRANCH="tag:v2026.07-rc4"
+	declare -g BOOTPATCHDIR="v2026.07"
 	declare -g BOOTDIR="u-boot-${BOARD}"
-	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
+	declare -g UBOOT_TARGET_MAP="BL31=${bl31_blob} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # Disable stuff from rockchip64_common; we're using binman here which does all the work
 
 	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
@@ -82,7 +84,7 @@ function pre_config_uboot_target__cm3588_patch_rockchip_common_boot_order() {
 function post_config_uboot_target__extra_configs_for_cm3588-nas_uboot() {
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable preboot & flash user LED in preboot" "info"
 	run_host_command_logged scripts/config --enable CONFIG_USE_PREBOOT
-	run_host_command_logged scripts/config --set-str CONFIG_PREBOOT "'led green on; sleep 0.1; led green off'" # double quotes required due to run_host_command_logged's quirks
+	run_host_command_logged scripts/config --set-str CONFIG_PREBOOT "'led green:indicator on; sleep 0.1; led amber:heartbeat on; sleep 0.1; led green:indicator off; led amber:heartbeat off'" # double quotes required due to run_host_command_logged's quirks
 
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable EFI debugging commands" "info"
 	run_host_command_logged scripts/config --enable CMD_EFIDEBUG
@@ -113,7 +115,7 @@ function post_config_uboot_target__extra_configs_for_cm3588-nas_uboot() {
 
 	# UMS, RockUSB, gadget stuff
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable UMS/RockUSB gadget" "info"
-	declare -a enable_configs=("CONFIG_CMD_USB_MASS_STORAGE" "CONFIG_USB_GADGET" "USB_GADGET_DOWNLOAD" "CONFIG_USB_FUNCTION_ROCKUSB" "CONFIG_USB_FUNCTION_ACM" "CONFIG_CMD_ROCKUSB" "CONFIG_CMD_USB_MASS_STORAGE")
+	declare -a enable_configs=("CONFIG_CMD_USB_MASS_STORAGE" "CONFIG_USB_GADGET" "USB_GADGET_DOWNLOAD" "CONFIG_USB_FUNCTION_ROCKUSB" "CONFIG_USB_FUNCTION_ACM" "CONFIG_CMD_ROCKUSB")
 	for config in "${enable_configs[@]}"; do
 		run_host_command_logged scripts/config --enable "${config}"
 	done

--- a/patch/u-boot/v2026.07/0000.patching_config.yaml
+++ b/patch/u-boot/v2026.07/0000.patching_config.yaml
@@ -1,0 +1,5 @@
+config:
+  overlay-directories:
+    - { source: "defconfig", target: "configs" } # copies all files in defconfig dir to the configs/ dir in the u-boot source tree
+    - { source: "dt_upstream_rockchip", target: "dts/upstream/src/arm64/rockchip" } # copies all files in dt_upstream_rockchip dir to the dts/upstream/src/arm64/rockchip dir in the u-boot source tree
+    - { source: "dt_uboot", target: "arch/arm/dts" } # copies all files in dt_uboot dir to the arch/arm/dts dir in the u-boot source tree

--- a/patch/u-boot/v2026.07/1001-fdt_fixup_ethernet-add-logs.patch
+++ b/patch/u-boot/v2026.07/1001-fdt_fixup_ethernet-add-logs.patch
@@ -1,0 +1,187 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 12 Jan 2026 18:26:25 +0100
+Subject: fdt_fixup_ethernet: add logs
+
+---
+ boot/fdt_support.c | 56 +++++++---
+ boot/image-fdt.c   | 18 +++
+ 2 files changed, 59 insertions(+), 15 deletions(-)
+
+diff --git a/boot/fdt_support.c b/boot/fdt_support.c
+index 111111111111..222222222222 100644
+--- a/boot/fdt_support.c
++++ b/boot/fdt_support.c
+@@ -632,27 +632,31 @@ int fdt_fixup_memory(void *blob, u64 start, u64 size)
+ 
+ void fdt_fixup_ethernet(void *fdt)
+ {
++	log_info("[fdt_fixup_ethernet] called\n");
+ 	int i = 0, j, prop;
+ 	char *tmp, *end;
+ 	char mac[16];
+ 	const char *path;
+ 	unsigned char mac_addr[ARP_HLEN];
+ 	int offset;
++	int total_aliases = 0, total_attempted = 0, total_skipped = 0, total_patched = 0;
+ #ifdef FDT_SEQ_MACADDR_FROM_ENV
+ 	int nodeoff;
+ 	const struct fdt_property *fdt_prop;
+ #endif
+ 
+-	if (fdt_path_offset(fdt, "/aliases") < 0)
++	int aliases_off = fdt_path_offset(fdt, "/aliases");
++	if (aliases_off < 0) {
++		log_info("[fdt_fixup_ethernet] /aliases node not found\n");
+ 		return;
++	}
+ 
+ 	/* Cycle through all aliases */
+ 	for (prop = 0; ; prop++) {
+ 		const char *name;
+ 
+ 		/* FDT might have been edited, recompute the offset */
+-		offset = fdt_first_property_offset(fdt,
+-			fdt_path_offset(fdt, "/aliases"));
++		offset = fdt_first_property_offset(fdt, aliases_off);
+ 		/* Select property number 'prop' */
+ 		for (j = 0; j < prop; j++)
+ 			offset = fdt_next_property_offset(fdt, offset);
+@@ -660,7 +664,10 @@ void fdt_fixup_ethernet(void *fdt)
+ 		if (offset < 0)
+ 			break;
+ 
++		total_aliases++;
+ 		path = fdt_getprop_by_offset(fdt, offset, &name, NULL);
++		log_info("[fdt_fixup_ethernet] alias #%d: name='%s', path='%s'\n", prop, name, path ? path : "<null>");
++
+ 		if (!strncmp(name, "ethernet", 8)) {
+ 			/* Treat plain "ethernet" same as "ethernet0". */
+ 			if (!strcmp(name, "ethernet")
+@@ -679,33 +686,52 @@ void fdt_fixup_ethernet(void *fdt)
+ 				else
+ 					sprintf(mac, "eth%daddr", i);
+ 			} else {
++				log_info("[fdt_fixup_ethernet] Skipping alias '%s' (invalid index)\n", name);
++				total_skipped++;
+ 				continue;
+ 			}
+ #ifdef FDT_SEQ_MACADDR_FROM_ENV
+ 			nodeoff = fdt_path_offset(fdt, path);
+-			fdt_prop = fdt_get_property(fdt, nodeoff, "status",
+-						    NULL);
+-			if (fdt_prop && !strcmp(fdt_prop->data, "disabled"))
++			fdt_prop = fdt_get_property(fdt, nodeoff, "status", NULL);
++			if (fdt_prop && !strcmp(fdt_prop->data, "disabled")) {
++				log_info("[fdt_fixup_ethernet] Node '%s' is disabled, skipping\n", path);
++				total_skipped++;
+ 				continue;
++			}
+ 			i++;
+ #endif
++			total_attempted++;
+ 			tmp = env_get(mac);
+-			if (!tmp)
++			log_info("[fdt_fixup_ethernet] env var for alias '%s' is '%s', value='%s'\n", name, mac, tmp ? tmp : "<not set>");
++			if (!tmp) {
++				log_info("[fdt_fixup_ethernet] env var '%s' not set, skipping\n", mac);
++				total_skipped++;
+ 				continue;
+-
++			}
++			int nodeoff = fdt_path_offset(fdt, path);
++			if (nodeoff < 0) {
++				log_info("[fdt_fixup_ethernet] Node path '%s' not found, skipping\n", path);
++				total_skipped++;
++				continue;
++			}
++			const struct fdt_property *status_prop = fdt_get_property(fdt, nodeoff, "status", NULL);
++			if (status_prop && strcmp((const char *)status_prop->data, "okay")) {
++				log_info("[fdt_fixup_ethernet] Node '%s' status is '%s', skipping\n", path, (const char *)status_prop->data);
++				total_skipped++;
++				continue;
++			}
+ 			for (j = 0; j < 6; j++) {
+-				mac_addr[j] = tmp ?
+-					      hextoul(tmp, &end) : 0;
++				mac_addr[j] = tmp ? hextoul(tmp, &end) : 0;
+ 				if (tmp)
+ 					tmp = (*end) ? end + 1 : end;
+ 			}
+-
+-			do_fixup_by_path(fdt, path, "mac-address",
+-					 &mac_addr, 6, 0);
+-			do_fixup_by_path(fdt, path, "local-mac-address",
+-					 &mac_addr, 6, 1);
++			log_info("[fdt_fixup_ethernet] Patching node '%s' (offset %d) with MAC %02x:%02x:%02x:%02x:%02x:%02x\n", path, nodeoff, mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
++			do_fixup_by_path(fdt, path, "mac-address", &mac_addr, 6, 0);
++			do_fixup_by_path(fdt, path, "local-mac-address", &mac_addr, 6, 1);
++			total_patched++;
+ 		}
+ 	}
++	log_info("[fdt_fixup_ethernet] SUMMARY: aliases found=%d, attempted=%d, skipped=%d, patched=%d\n", total_aliases, total_attempted, total_skipped, total_patched);
+ }
+ 
+ int fdt_record_loadable(void *blob, u32 index, const char *name,
+diff --git a/boot/image-fdt.c b/boot/image-fdt.c
+index 111111111111..222222222222 100644
+--- a/boot/image-fdt.c
++++ b/boot/image-fdt.c
+@@ -1,3 +1,4 @@
++
+ // SPDX-License-Identifier: GPL-2.0+
+ /*
+  * Copyright (c) 2013, Google Inc.
+@@ -586,11 +587,25 @@ __weak int ft_verify_fdt(void *fdt)
+ 
+ __weak int arch_fixup_fdt(void *blob)
+ {
++	log_info("[arch_fixup_fdt] called (weak stub)\n");
++	return 0;
++}
++
++__weak int ft_board_setup(void *blob, struct bd_info *bd)
++{
++	log_info("[ft_board_setup] called (weak stub)\n");
++	return 0;
++}
++
++__weak int ft_system_setup(void *blob, struct bd_info *bd)
++{
++	log_info("[ft_system_setup] called (weak stub)\n");
+ 	return 0;
+ }
+ 
+ int image_setup_libfdt(struct bootm_headers *images, void *blob, bool lmb)
+ {
++	log_info("[image_setup_libfdt] called\n");
+ 	ulong *initrd_start = &images->initrd_start;
+ 	ulong *initrd_end = &images->initrd_end;
+ 	bool skip_board_fixup = false;
+@@ -638,6 +653,7 @@ int image_setup_libfdt(struct bootm_headers *images, void *blob, bool lmb)
+ 					strlen(images->fit_uname_cfg) + 1, 1);
+ 
+ 	/* Update ethernet nodes */
++	log_info("[image_setup_libfdt] calling fdt_fixup_ethernet\n");
+ 	fdt_fixup_ethernet(blob);
+ #if IS_ENABLED(CONFIG_CMD_PSTORE)
+ 	/* Append PStore configuration */
+@@ -651,6 +667,7 @@ int image_setup_libfdt(struct bootm_headers *images, void *blob, bool lmb)
+ 	}
+ 
+ 	if (IS_ENABLED(CONFIG_OF_BOARD_SETUP) && !skip_board_fixup) {
++		log_info("[image_setup_libfdt] calling ft_board_setup\n");
+ 		fdt_ret = ft_board_setup(blob, gd->bd);
+ 		if (fdt_ret) {
+ 			printf("ERROR: board-specific fdt fixup failed: %s\n",
+@@ -659,6 +676,7 @@ int image_setup_libfdt(struct bootm_headers *images, void *blob, bool lmb)
+ 		}
+ 	}
+ 	if (IS_ENABLED(CONFIG_OF_SYSTEM_SETUP)) {
++		log_info("[image_setup_libfdt] calling ft_system_setup\n");
+ 		fdt_ret = ft_system_setup(blob, gd->bd);
+ 		if (fdt_ret) {
+ 			printf("ERROR: system-specific fdt fixup failed: %s\n",
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.07/cmd-fileenv-read-string-from-file-into-env.patch
+++ b/patch/u-boot/v2026.07/cmd-fileenv-read-string-from-file-into-env.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Fri, 31 Jan 2025 15:52:03 +0100
+Subject: cmd: fileenv: read string from file into env
+
+- rpardini: adapted from vendor/legacy patch from 2018
+
+Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ cmd/Kconfig   |  5 +
+ cmd/Makefile  |  1 +
+ cmd/fileenv.c | 46 ++++++++++
+ 3 files changed, 52 insertions(+)
+
+diff --git a/cmd/Kconfig b/cmd/Kconfig
+index 111111111111..222222222222 100644
+--- a/cmd/Kconfig
++++ b/cmd/Kconfig
+@@ -1952,6 +1952,11 @@ config CMD_XXD
+ 	help
+ 	  Print file as hexdump to standard output
+ 
++config CMD_FILEENV
++	bool "fileenv"
++	help
++	   Read a file into memory and store it to env.
++
+ endmenu
+ 
+ if NET
+diff --git a/cmd/Makefile b/cmd/Makefile
+index 111111111111..222222222222 100644
+--- a/cmd/Makefile
++++ b/cmd/Makefile
+@@ -175,6 +175,7 @@ obj-$(CONFIG_CMD_SHA1SUM) += sha1sum.o
+ obj-$(CONFIG_CMD_SEAMA) += seama.o
+ obj-$(CONFIG_CMD_SETEXPR) += setexpr.o
+ obj-$(CONFIG_CMD_SETEXPR_FMT) += printf.o
++obj-$(CONFIG_CMD_FILEENV) += fileenv.o
+ obj-$(CONFIG_CMD_SPI) += spi.o
+ obj-$(CONFIG_CMD_STRINGS) += strings.o
+ obj-$(CONFIG_CMD_SM3SUM) += sm3sum.o
+diff --git a/cmd/fileenv.c b/cmd/fileenv.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/cmd/fileenv.c
+@@ -0,0 +1,46 @@
++#include <config.h>
++#include <command.h>
++#include <fs.h>
++#include <linux/ctype.h>
++#include <vsprintf.h>
++#include "env.h"
++static char *fs_argv[5];
++
++int do_fileenv(struct cmd_tbl *cmdtp, int flag, int argc, char * const argv[])
++{
++	if (argc < 6)
++		return CMD_RET_USAGE;
++
++	fs_argv[0] = "fatload";
++	fs_argv[1] = argv[1];
++	fs_argv[2] = argv[2];
++	fs_argv[3] = argv[3];
++	fs_argv[4] = argv[4];
++
++	if (do_fat_fsload(cmdtp, 0, 5, fs_argv) != 0)
++		return 1;
++
++	char *addr = (char *)simple_strtoul(argv[3], NULL, 16);
++	size_t size = env_get_hex("filesize", 0);
++
++	// Prepare string
++	addr[size] = 0x00;
++	char *s = addr;
++	while(*s != 0x00) {
++		if (isprint(*s)) {
++			s++;
++		}
++		else {
++			*s = 0x00;
++		}
++	}
++
++	return env_set(argv[5], addr);
++}
++
++U_BOOT_CMD(
++	fileenv, 6, 0, do_fileenv,
++	"Read file and store it into env.",
++	"<interface> <dev:part> <addr> <filename> <envname>\n"
++	"    - Read file from fat32 and store it as env."
++);
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.07/general-rk3588-add-i2s-mclk-output-to-io-clock-ids.patch
+++ b/patch/u-boot/v2026.07/general-rk3588-add-i2s-mclk-output-to-io-clock-ids.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Fri, 20 Mar 2026 13:46:31 +0100
+Subject: dt-bindings: clock: rockchip,rk3588-cru: add I2S MCLK output to IO
+ clock IDs
+
+Add clock identifiers for the four I2S MCLK output to IO gate clocks
+on RK3588, needed by board DTS files where the codec requires MCLK
+from the SoC on an external IO pin.
+
+Upstream kernel: https://lore.kernel.org/linux-rockchip/20260316-rk3588-mclk-gate-grf-v1-1-66fb9a246718@superkali.me/
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ dts/upstream/include/dt-bindings/clock/rockchip,rk3588-cru.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/dts/upstream/include/dt-bindings/clock/rockchip,rk3588-cru.h b/dts/upstream/include/dt-bindings/clock/rockchip,rk3588-cru.h
+index 111111111111..222222222222 100644
+--- a/dts/upstream/include/dt-bindings/clock/rockchip,rk3588-cru.h
++++ b/dts/upstream/include/dt-bindings/clock/rockchip,rk3588-cru.h
+@@ -734,6 +734,10 @@
+ #define PCLK_AV1_PRE			719
+ #define HCLK_SDIO_PRE			720
+ #define PCLK_VO1GRF			721
++#define I2S0_8CH_MCLKOUT_TO_IO		722
++#define I2S1_8CH_MCLKOUT_TO_IO		723
++#define I2S2_2CH_MCLKOUT_TO_IO		724
++#define I2S3_2CH_MCLKOUT_TO_IO		725
+ 
+ /* scmi-clocks indices */
+ 
+-- 
+Armbian
+


### PR DESCRIPTION
#### cm3588-nas: u-boot: bump to v2026.07-rc3

- 🍀 u-boot: v2026.07: prepare patching folder for v2026.07
- 🌱 cm3588-nas: u-boot: bump to v2026.07-rc3
  - incl LED name change fix
- 🌿 cm3588-nas: use Rockchip BL31 blob for BRANCH==vendor; still mainline u-boot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `fileenv` command to read files from FAT filesystem into environment variables.

* **Chores**
  * Updated CM3588 NAS board configuration with U-Boot version changes and LED pattern updates.
  * Added I2S MCLK output clock definitions for RK3588.
  * Enhanced bootloader logging for ethernet and device tree operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->