### PR TITLE
radxa-cubie-a5e: tidy BOARD_NAME to "Cubie A5E"

### DIFF
--- a/config/boards/radxa-cubie-a5e.csc
+++ b/config/boards/radxa-cubie-a5e.csc
@@ -1,5 +1,5 @@
 # Allwinner Cortex-A55 octa core SoC 2/4GB-RAM, 2x GBe, WiFi/BT, M.2 2230/USB3, NPU
-BOARD_NAME="radxa cubie a5e"
+BOARD_NAME="Cubie A5E"
 BOARD_VENDOR="radxa"
 BOARDFAMILY="sun55iw3"
 BOARD_MAINTAINER="juanesf"


### PR DESCRIPTION
Drop the redundant vendor prefix from the board name.

`BOARD_VENDOR` is already `radxa`, so `BOARD_NAME="radxa cubie a5e"` doubled the vendor up. Renamed to `"Cubie A5E"` (matching the product's branding).

```
-BOARD_NAME="radxa cubie a5e"
+BOARD_NAME="Cubie A5E"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated board name formatting for improved consistency and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->