### PR TITLE
artifact-uboot: opt-in cache-bust via UBOOT_HASH_EXTRA for prebuilt blobs

### DIFF
--- a/config/sources/families/meson-gxl.conf
+++ b/config/sources/families/meson-gxl.conf
@@ -17,11 +17,17 @@ fi
 if [[ $BOARD = khadas-vim1 ]]; then
 	# temporally workaround - using prebuild u-boot from https://github.com/khadas/khadas-uboot/releases/tag/0.11
 	UBOOT_TARGET_MAP=";;$SRC/packages/blobs/meson/u-boot-vim1-sd.bin:u-boot.bin"
+	# bump on every prebuilt-blob change so the u-boot .deb repackages (keep in sync
+	# with the khadas-uboot release the blob above comes from)
+	UBOOT_HASH_EXTRA="khadas-uboot-0.11"
 fi
 
 if [[ $BOARD = khadas-vim2 ]]; then
 	# temporally workaround - using prebuild u-boot from https://github.com/khadas/khadas-uboot/releases/tag/0.11
 	UBOOT_TARGET_MAP=";;$SRC/packages/blobs/meson/u-boot-vim2-sd.bin:u-boot.bin"
+	# bump on every prebuilt-blob change so the u-boot .deb repackages (keep in sync
+	# with the khadas-uboot release the blob above comes from)
+	UBOOT_HASH_EXTRA="khadas-uboot-0.11"
 fi
 
 family_tweaks() {

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -110,6 +110,10 @@ function artifact_uboot_prepare_version() {
 		"${IMAGE_PARTITION_TABLE}" "${BOOT_FDT_FILE}" "${SERIALCON}"     # image and kernel related, to be used as reference/docs
 		"${SRC_EXTLINUX}" "${SRC_CMDLINE}"                               # image and kernel related, to be used as reference/docs
 	)
+	# Opt-in cache-bust for a board shipping a prebuilt/external u-boot blob: bump
+	# UBOOT_HASH_EXTRA when the blob changes to force a repackage. Appended ONLY when
+	# set, so boards that don't use it keep their exact previous version (no churn).
+	[[ -n "${UBOOT_HASH_EXTRA:-}" ]] && vars_to_hash+=("${UBOOT_HASH_EXTRA}")
 	declare hash_variables="undetermined" # will be set by calculate_hash_for_variables(), which normalizes the input
 	calculate_hash_for_variables "${vars_to_hash[@]}"
 	declare vars_config_hash="${hash_variables}"
@@ -121,7 +125,10 @@ function artifact_uboot_prepare_version() {
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
-	# outer scope
+	# outer scope. UBOOT_HASH_EXTRA (in vars_to_hash above) folds into -V, so a board
+	# that ships a prebuilt or externally-fetched u-boot blob just bumps that string
+	# to force a repackage — no filesystem read here (the blob may not exist yet at
+	# matrix-prep, and may not live in this repo at all).
 	artifact_version="${GIT_INFO_UBOOT[MAKEFILE_VERSION]}-S${short_sha1}-P${uboot_patches_hash_short}-H${hash_hooks_and_functions_short}-V${var_config_hash_short}-B${bash_hash_short}"
 
 	declare -a reasons=(

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -205,6 +205,15 @@ function do_main_configuration() {
 	# Defaults... # @TODO: why?
 	declare -g -r MAINLINE_UBOOT_DIR='u-boot'
 
+	# Opt-in cache-bust string for the u-boot artifact. A board/family that ships a
+	# prebuilt or externally-fetched u-boot blob (e.g. khadas-vim1/vim2) sets this —
+	# typically to the blob's upstream version — and bumps it whenever the blob
+	# changes, so the u-boot .deb repackages instead of reusing the cached artifact.
+	# It can't be a content hash: the blob may live outside this repo and not exist
+	# yet at matrix-prep. Folded into the artifact version by artifact-uboot.sh.
+	# (`:-` so it never clobbers a value a board/family already set.)
+	declare -g UBOOT_HASH_EXTRA="${UBOOT_HASH_EXTRA:-}"
+
 	# pre-calculate mirrors. important: this sets _SOURCE variants that might be used in common.conf to default things to mainline, but using mirror.
 	# @TODO: setting them here allows family/board code (and hooks) to read them and embed them into configuration, which is bad: it might end up without the mirror.
 	[[ $USE_MAINLINE_GOOGLE_MIRROR == yes ]] && MAINLINE_MIRROR=google


### PR DESCRIPTION
## Summary

The u-boot artifact version hashed the `UBOOT_TARGET_MAP` **string** but not the identity of any prebuilt blob it points at. Bumping a blob in place (same path) left the artifact version unchanged, so the build reused the cached `.deb` and the new blob never got packaged.

This adds an **opt-in version string `UBOOT_HASH_EXTRA`** that a board/family sets when it ships a prebuilt or externally-fetched u-boot blob, and bumps whenever the blob changes. It folds into the artifact version's `-V` hash, forcing a repackage.

## Why a string, not a file content-hash

The first cut parsed `UBOOT_TARGET_MAP` for filenames and hashed the bytes. Two problems killed that (per review):

- **Parsing the map is fragile** — it mixes build *inputs* and *outputs* indistinguishably (@rpardini: handle it out-of-band, don't parse it).
- **Content-hashing a file doesn't work in general** — a u-boot blob may be **fetched at build time and not live in this repo**, so it **doesn't exist at matrix-prep** when `prepare_version` runs. Reading it would fail or be non-deterministic across hosts.

A string sidesteps both: no filesystem access at matrix-prep, and it works for any blob regardless of where it lives.

## Behaviour

- **`lib/functions/configuration/main-config.sh`** — `UBOOT_HASH_EXTRA` declared + documented centrally (with the other u-boot defaults); `:-` so it never clobbers a board value.
- **`lib/functions/artifacts/artifact-uboot.sh`** — appended to `vars_to_hash` **only when set**.
- **`config/sources/families/meson-gxl.conf`** — khadas-vim1 / khadas-vim2 opt in.

**No churn:** with `UBOOT_HASH_EXTRA` unset, `-V` is byte-identical to the pre-change baseline, so every other board's u-boot artifact is untouched. Set → distinct hash; bumping `0.11`→`0.17.3` → distinct again → repackage.

## Note for the blob bump (#9994)

This is the manual-but-universal trade-off: the blob-bump PR (#9994) must also **bump `UBOOT_HASH_EXTRA`** (→ `khadas-uboot-0.17.3`) when it swaps the blob, or the cache won't invalidate.

Split out from #9994, which depends on this to actually repackage the new blobs.