### PR TITLE
armbian-upgrade: use apt-get to silence apt CLI-warning noise

### DIFF
--- a/packages/bsp/common/usr/bin/armbian-upgrade
+++ b/packages/bsp/common/usr/bin/armbian-upgrade
@@ -1,8 +1,10 @@
 #!/bin/bash
 trap "exit" INT TERM
 [[ $EUID != 0 ]] && exec sudo "$0" "$@"
-apt update
-apt -y upgrade
-apt clean
-apt -y autoremove
+# use apt-get, the stable scripting interface: plain `apt` prints
+# "WARNING: apt does not have a stable CLI interface" on every non-interactive call
+apt-get update
+apt-get -y upgrade
+apt-get clean
+apt-get -y autoremove
 exit 0


### PR DESCRIPTION
## What

`/usr/bin/armbian-upgrade` calls plain `apt`, which prints

```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

on every non-interactive invocation — so each upgrade run emits it twice (once for `apt update`, once for `apt -y upgrade`), cluttering build logs and user output.

Switch to `apt-get`, the stable scripting interface, which behaves identically for `update` / `upgrade` / `clean` / `autoremove` but prints no such warning.

## Not addressed here

The separate `[ ! ] repository switch returned non-zero` line is emitted at runtime (armbian-config repo handling), not by this script — out of scope for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system upgrade process reliability and stability by enhancing the underlying upgrade mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->