### PR TITLE
apt: make the apt-cacher-ng proxy non-fatal (pipelining off + reachability fallback)

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -478,7 +478,24 @@ function do_extra_configuration() {
 		APT_PROXY_ADDR="$(echo "${http_proxy:-${https_proxy:-${HTTP_PROXY:-${HTTPS_PROXY:-}}}}" | sed -E 's|https?://([^/]+).*|\1|')"
 		display_alert "Derived APT proxy address from proxy env vars" "${APT_PROXY_ADDR##*@}" "info"
 	fi
-	[[ -n "${APT_PROXY_ADDR}" ]] && display_alert "Using custom apt proxy address" "APT_PROXY_ADDR=${APT_PROXY_ADDR##*@}" "info"
+	# Validate the proxy is actually reachable before adopting it. A derived or
+	# inherited APT_PROXY_ADDR — http_proxy injected into the job by a self-hosted
+	# runner, or a stale NetBox apt_proxy — can point at a cache this host cannot
+	# reach, which otherwise hard-fails every apt operation in the build. Probe
+	# host:port with a short timeout; if it doesn't connect, drop it and go direct.
+	if [[ -n "${APT_PROXY_ADDR}" ]]; then
+		declare _apt_proxy_hostport="${APT_PROXY_ADDR##*@}" # drop optional user@
+		declare _apt_proxy_host="${_apt_proxy_hostport%:*}"
+		declare _apt_proxy_port="${_apt_proxy_hostport##*:}"
+		[[ "${_apt_proxy_port}" == "${_apt_proxy_hostport}" ]] && _apt_proxy_port="3142" # no :port -> acng default
+		if timeout 2 bash -c "exec 3<>/dev/tcp/${_apt_proxy_host}/${_apt_proxy_port}" 2> /dev/null; then
+			display_alert "Using custom apt proxy address" "APT_PROXY_ADDR=${_apt_proxy_hostport} (reachable)" "info"
+		else
+			display_alert "Apt proxy unreachable - building direct" "${_apt_proxy_hostport} not connectable in 2s; ignoring APT_PROXY_ADDR" "wrn"
+			APT_PROXY_ADDR=""
+		fi
+		unset _apt_proxy_hostport _apt_proxy_host _apt_proxy_port
+	fi
 
 	# @TODO: allow to run aggregation, for CONFIG_DEFS_ONLY? rootfs_aggregate_packages
 

--- a/lib/functions/logging/runners.sh
+++ b/lib/functions/logging/runners.sh
@@ -68,6 +68,14 @@ function chroot_sdcard_apt_get() {
 		display_alert "Not using apt-cacher-ng, nor proxy" "no proxy/acng" "debug"
 	fi
 
+	# Going through a caching proxy (apt-cacher-ng): disable HTTP pipelining.
+	# Pipelined responses can get mismatched against fast-changing repo indexes
+	# (e.g. beta.armbian.com), producing "File has unexpected size" / hash-sum
+	# mismatch errors. Serial requests cost a little throughput but are reliable.
+	if [[ "${MANAGE_ACNG}" == "yes" || -n "${APT_PROXY_ADDR}" ]]; then
+		apt_params+=(-o "Acquire::http::Pipeline-Depth=0")
+	fi
+
 	apt_params+=(-o "Dpkg::Use-Pty=0") # Please be quiet
 
 	# Prevent dpkg from prompting about modified conffiles in non-interactive chroot builds.

--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -129,6 +129,9 @@ function create_new_rootfs_cache_via_debootstrap() {
 	if [[ -n "${APT_PROXY_ADDR}" && ("${MANAGE_ACNG}" == "no" || -z "${MANAGE_ACNG}") ]]; then
 		display_alert "Routing mmdebstrap through apt proxy" "http://${APT_PROXY_ADDR##*@}" "info"
 		debootstrap_arguments+=("'--aptopt=Acquire::http::Proxy \"http://${APT_PROXY_ADDR}\"'")
+		# Disable HTTP pipelining through the proxy (see chroot_sdcard_apt_get in
+		# runners.sh) — avoids "File has unexpected size" against volatile indexes.
+		debootstrap_arguments+=("'--aptopt=Acquire::http::Pipeline-Depth \"0\"'")
 	fi
 
 	debootstrap_arguments+=("${RELEASE}" "${SDCARD}/" "${debootstrap_apt_mirror}") # release, path and mirror; always last, positional arguments.


### PR DESCRIPTION
Robustness for builds that route apt through an apt-cacher-ng proxy. Split out of `fix/docker-unique-image-tag`.

- **disable HTTP pipelining through the proxy** — apt-cacher-ng mishandles pipelined requests, causing intermittent hash/size mismatches.
- **probe proxy reachability, fall back to direct** — if the configured proxy isn't reachable, fetch directly instead of failing the whole build.

Touches `main-config.sh`, `runners.sh`, `rootfs-create.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for the configured APT proxy address, clearing it automatically when the proxy is unreachable to ensure apt operations continue normally.
  * Improved reliability when using proxy configurations by disabling HTTP pipelining to avoid connectivity/throughput issues.
  * Applied the same HTTP pipelining disabling behavior to root filesystem builds when downloads are routed through the external APT proxy (without ACNG).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->