### PR TITLE
docker: retry transient ghcr base-image pulls; guard the auto-pull cronjob

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -368,7 +368,12 @@ function docker_cli_build_dockerfile() {
 	if [[ "${do_force_pull:-yes}" == "yes" ]]; then
 		display_alert "Pulling" "${DOCKER_ARMBIAN_BASE_IMAGE}" "info"
 		local pull_failed="yes"
-		run_host_command_logged docker pull "${DOCKER_ARMBIAN_BASE_IMAGE}" && pull_failed="no"
+		# Retry the pull: ghcr.io intermittently returns "error from registry:
+		# denied" under load or on a transient token hiccup even for a
+		# published, accessible image. A single failure would otherwise drop us
+		# into a needless (and much slower) from-scratch build. Retry a few
+		# times before giving up; only then fall back to scratch.
+		sleep_seconds=10 do_with_retries 3 run_host_command_logged docker pull "${DOCKER_ARMBIAN_BASE_IMAGE}" && pull_failed="no"
 
 		if [[ "${pull_failed}" == "no" ]]; then
 			local_image_sha="$(docker images --no-trunc --quiet "${DOCKER_ARMBIAN_BASE_IMAGE}")"

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -889,10 +889,18 @@ function docker_setup_auto_pull_cronjob() {
 		fi
 		sudo chmod +x "${wrapper_script}" || true
 
-		# Create/update cron file
+		# Create/update cron file. Guard the write like the wrapper script above:
+		# if the tee fails (sudo refused, /etc read-only, cron not really
+		# present, ...) we must NOT go on to chmod a file that was never
+		# created — that is what printed the confusing
+		# "chmod: cannot access '${cron_file}': No such file or directory".
+		# Treat it as best-effort and bail gracefully, same as the wrapper path.
 		display_alert "Creating/updating Docker auto-pull cronjob" "${cron_file}" "info"
-		echo "${cron_content}" | sudo tee "${cron_file}" > /dev/null
-		sudo chmod 600 "${cron_file}"
+		if ! echo "${cron_content}" | sudo tee "${cron_file}" > /dev/null 2>&1; then
+			display_alert "Docker auto-pull" "failed to create cronjob ${cron_file} (sudo/permissions?)" "warn"
+			return 0
+		fi
+		sudo chmod 600 "${cron_file}" || true
 
 		# Store hash for next time
 		sudo mkdir -p "$(dirname "${hash_file}")"


### PR DESCRIPTION
Two small Docker robustness fixes, split out of `fix/docker-unique-image-tag`.

- **retry base-image pull on transient ghcr 'denied'** — ghcr occasionally returns a spurious `denied` on an anonymous pull; retry instead of failing the build.
- **guard the auto-pull cronjob write** — don't `chmod` a file that wasn't created.

Touches `docker.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker builds now include automatic retry logic for base image retrieval to mitigate transient network failures.
  * Docker auto-pull installation is more robust with improved error handling during cron configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->