### PR TITLE
Extension: "rk-loader-bin". Capture Rockchip idbloader binary.

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -7,6 +7,7 @@
 # https://github.com/armbian/build/
 #
 enable_extension "rkbin-tools"
+enable_extension "rk-loader-bin"
 ARCH=arm64
 OFFSET=16
 BOOTSCRIPT='boot-rockchip64.cmd:boot.cmd'
@@ -174,6 +175,7 @@ prepare_boot_configuration() {
 	display_alert "Preparing boot configuration" "rockchip64_common::prepare_boot_configuration()" "info"
 	ATFSOURCE=''
 	ATF_COMPILE='no'
+	RK_LOADER_BIN="idbloader.img"
 	case "$BOOT_SCENARIO" in
 		blobless | tpl-blob-atf-mainline | binman-atf-mainline)
 			UBOOT_TARGET_MAP="BL31=bl31.elf idbloader.img u-boot.itb;;idbloader.img u-boot.itb"
@@ -212,6 +214,7 @@ prepare_boot_configuration() {
 			;;
 		only-blobs)
 			UBOOT_TARGET_MAP="u-boot-dtb.bin;;idbloader.bin uboot.img trust.bin"
+			RK_LOADER_BIN="idbloader.bin"
 			;;
 		binman)
 			UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB ROCKCHIP_TPL=$RKBIN_DIR/$DDR_BLOB;;u-boot-rockchip.bin"

--- a/config/sources/families/rockchip-rv1106.conf
+++ b/config/sources/families/rockchip-rv1106.conf
@@ -12,6 +12,7 @@
 # This family is optimized for low-memory (64-256MB).
 #
 enable_extension "rkbin-tools"
+enable_extension "rk-loader-bin"
 
 # BOOT_SOC has to be set in the board configuration file; if not set
 # we resort to rv1106
@@ -27,6 +28,7 @@ OVERLAY_PREFIX="rv1106"
 OFFSET=16
 SPL_FIT_GENERATOR="arch/arm/mach-rockchip/make_fit_optee.sh"
 UBOOT_TARGET_MAP="spl/u-boot-spl.bin u-boot.dtb u-boot-nodtb.bin;;download.bin idblock.img u-boot.itb"
+RK_LOADER_BIN="download.bin"
 BOOTSOURCE="https://github.com/radxa/u-boot.git"
 BOOTBRANCH="branch:next-dev-buildroot"
 BOOTPATCHDIR="legacy/u-boot-rockchip-buildroot"

--- a/config/sources/families/rockchip.conf
+++ b/config/sources/families/rockchip.conf
@@ -7,6 +7,7 @@
 # https://github.com/armbian/build/
 #
 enable_extension "rkbin-tools"
+enable_extension "rk-loader-bin"
 
 # BOOT_SOC has to be set in the board configuration file; if not set
 # we resort to rk3288
@@ -16,6 +17,7 @@ ARCH=armhf
 BOOTDELAY=1
 SERIALCON=${SERIALCON:="ttyS2"}
 RKBIN_DIR="$SRC/cache/sources/rkbin-tools"
+RK_LOADER_BIN="idbloader.img"
 if [[ "$BOOT_SOC" == "rk3288" ]]; then
 
 	BOOTSCRIPT="boot-rockchip.cmd:boot.cmd"

--- a/extensions/rk-loader-bin.sh
+++ b/extensions/rk-loader-bin.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2013-2026 Igor Pecovnik, igor@armbian.com
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+#
+
+# Copy the Rockchip loader binary (e.g. idbloader.img) to output/loader/
+# when RK_LOADER_BIN is set in the family or board configuration.
+
+# This binary is required for Rockchip boards to boot from MASKROM mode into LOADER mode.
+# Once in LOADER mode, rkdeveloptool can be used to erase / flash the NAND / eMMC storage onboard.
+
+function post_uboot_custom_postprocess__copy_rk_loader_bin() {
+	[[ -z "${RK_LOADER_BIN}" ]] && return 0
+
+	if [[ ! -f "${RK_LOADER_BIN}" ]]; then
+		exit_with_error "RK_LOADER_BIN file not found in u-boot build directory" "${RK_LOADER_BIN}"
+	fi
+
+	display_alert "Copying Rockchip loader binary" "${RK_LOADER_BIN} -> output/loader/${BOARD}-${RK_LOADER_BIN}" "info"
+	mkdir -p "${DEST}/loader"
+	run_host_command_logged cp -v "${RK_LOADER_BIN}" "${DEST}/loader/${BOARD}-${RK_LOADER_BIN}"
+}


### PR DESCRIPTION
# Description

`idbloader.img` binaries are required for entering LOADER mode (from MASKROM mode).

These binaries are already being built as part of the uboot builds, but the name can differ. (`idbloader.img`, `idbloader.bin`, `download.bin`). Binman-powered builds will implicitly use `idbloader.img`.
This binary name is set with the new "RK_LOADER_BIN" variable.

Loader binaries are copied to `output/loader`. The intent with this addition is for these binaries to be distributed for download (github releases?) so that they can be consumed by tools like https://asadmemon.com/rkdeveloptool/ or future Armbian Imager integrations.

# Documentation summary for feature / change

Some documentation for getting into LOADER mode should be added to the `Rockchip` section, once these loader binaries are available for download somewhere.
https://docs.armbian.com/User-Guide_Getting-Started/#rockchip

# How Has This Been Tested?

- [x] `luckfox-lyra-zero-w` (RK3506) -- binman // modern uboot
- [x] `luckfox-pico-max` (RV1106) -- proprietary rockchip uboot
- Loader binaries compiled // copied successfully.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Rockchip loader binary extension across supported device families.
  * Configured automatic loader binary deployment during the build process for Rockchip-based devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->