### PR TITLE
maint: rewrite various patchsets

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
@@ -13,7 +13,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3119,7 +3119,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3146,7 +3146,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  {
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
@@ -22,7 +22,7 @@ index 111111111111..222222222222 100644
  
  	if (!port->partner_pd)
  		port->partner_pd = usb_power_delivery_register(NULL, &desc);
-@@ -3129,11 +3129,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3156,11 +3156,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	memcpy(caps.pdo, port->source_caps, sizeof(u32) * port->nr_source_caps);
  	caps.role = TYPEC_SOURCE;
  

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-typec-altmodes-displayport-Respect-DP_CAP_RECEPT.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-typec-altmodes-displayport-Respect-DP_CAP_RECEPT.patch
@@ -51,7 +51,7 @@ index 111111111111..222222222222 100644
  	/* Determining the initial pin assignment. */
  	if (!DP_CONF_GET_PIN_ASSIGN(dp->data.conf)) {
  		/* Is USB together with DP preferred */
-@@ -819,14 +837,36 @@ int dp_altmode_probe(struct typec_altmode *alt)
+@@ -821,14 +839,36 @@ int dp_altmode_probe(struct typec_altmode *alt)
  	struct typec_altmode *plug = typec_altmode_get_plug(alt, TYPEC_PLUG_SOP_P);
  	struct fwnode_handle *fwnode;
  	struct dp_altmode *dp;

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3120,15 +3120,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3147,15 +3147,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -45,7 +45,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -3143,15 +3150,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
+@@ -3170,15 +3177,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -72,7 +72,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -7218,10 +7232,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
+@@ -7245,10 +7259,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
  		port->pds[i] = usb_power_delivery_register(port->dev, &desc);
  		if (IS_ERR(port->pds[i])) {
  			ret = PTR_ERR(port->pds[i]);

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
@@ -37,7 +37,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -1868,6 +1868,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
+@@ -1870,6 +1870,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
  		return;
  
  	for (i = 0; i < modep->altmodes; i++) {

--- a/patch/kernel/archive/rockchip64-6.18/rk3576-0002-mmc-dw_mmc-rockchip-add-v2-tuning-support.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3576-0002-mmc-dw_mmc-rockchip-add-v2-tuning-support.patch
@@ -98,7 +98,7 @@ index 111111111111..222222222222 100644
  	ranges = kmalloc_array(priv->num_phases / 2 + 1,
  			       sizeof(*ranges), GFP_KERNEL);
  	if (!ranges)
-@@ -460,6 +522,7 @@ static int dw_mci_rk3288_parse_dt(struct dw_mci *host)
+@@ -476,6 +538,7 @@ static int dw_mci_rk3288_parse_dt(struct dw_mci *host)
  
  static int dw_mci_rk3576_parse_dt(struct dw_mci *host)
  {
@@ -106,7 +106,7 @@ index 111111111111..222222222222 100644
  	struct dw_mci_rockchip_priv_data *priv;
  	int err = dw_mci_common_parse_dt(host);
  	if (err)
-@@ -467,6 +530,9 @@ static int dw_mci_rk3576_parse_dt(struct dw_mci *host)
+@@ -483,6 +546,9 @@ static int dw_mci_rk3576_parse_dt(struct dw_mci *host)
  
  	priv = host->priv;
  

--- a/patch/kernel/archive/rockchip64-7.1/board-rgds-01-asoc-aw87391.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-rgds-01-asoc-aw87391.patch
@@ -1,20 +1,19 @@
-From ef3aaf886966348c7f5955f0e76517158dd667e9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Noxwell <beebono@yahoo.com>
 Date: Sat, 10 Jan 2026 14:47:43 +0000
-Subject: [PATCH] ASoC: codecs: Add aw87391 amplifier driver
+Subject: ASoC: codecs: Add aw87391 amplifier driver
 
 ---
- sound/soc/codecs/Kconfig   |  12 ++
+ sound/soc/codecs/Kconfig   |  12 +
  sound/soc/codecs/Makefile  |   2 +
- sound/soc/codecs/aw87391.c | 271 +++++++++++++++++++++++++++++++++++++
+ sound/soc/codecs/aw87391.c | 271 ++++++++++
  3 files changed, 285 insertions(+)
- create mode 100644 sound/soc/codecs/aw87391.c
 
 diff --git a/sound/soc/codecs/Kconfig b/sound/soc/codecs/Kconfig
-index 061791e61907..75f727854057 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/Kconfig
 +++ b/sound/soc/codecs/Kconfig
-@@ -56,6 +56,7 @@ config SND_SOC_ALL_CODECS
+@@ -55,6 +55,7 @@ config SND_SOC_ALL_CODECS
  	imply SND_SOC_AUDIO_IIO_AUX
  	imply SND_SOC_AW8738
  	imply SND_SOC_AW87390
@@ -22,7 +21,7 @@ index 061791e61907..75f727854057 100644
  	imply SND_SOC_AW88395
  	imply SND_SOC_AW88081
  	imply SND_SOC_AW88166
-@@ -737,6 +738,17 @@ config SND_SOC_AW87390
+@@ -722,6 +723,17 @@ config SND_SOC_AW87390
  	  sound quality, which is a new high efficiency, low
  	  noise, constant large volume, 6th Smart K audio amplifier.
  
@@ -41,10 +40,10 @@ index 061791e61907..75f727854057 100644
  	tristate "Soc Audio for awinic aw88399"
  	depends on I2C
 diff --git a/sound/soc/codecs/Makefile b/sound/soc/codecs/Makefile
-index d687d4f74363..0d6a66408ddf 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/Makefile
 +++ b/sound/soc/codecs/Makefile
-@@ -49,6 +49,7 @@ snd-soc-arizona-y := arizona.o arizona-jack.o
+@@ -48,6 +48,7 @@ snd-soc-arizona-y := arizona.o arizona-jack.o
  snd-soc-audio-iio-aux-y := audio-iio-aux.o
  snd-soc-aw8738-y := aw8738.o
  snd-soc-aw87390-y := aw87390.o
@@ -52,7 +51,7 @@ index d687d4f74363..0d6a66408ddf 100644
  snd-soc-aw88081-y := aw88081.o
  snd-soc-aw88395-lib-y := aw88395/aw88395_lib.o \
  			aw88395/aw88395_device.o
-@@ -483,6 +484,7 @@ obj-$(CONFIG_SND_SOC_ARIZONA)	+= snd-soc-arizona.o
+@@ -486,6 +487,7 @@ obj-$(CONFIG_SND_SOC_ARIZONA)	+= snd-soc-arizona.o
  obj-$(CONFIG_SND_SOC_AUDIO_IIO_AUX)	+= snd-soc-audio-iio-aux.o
  obj-$(CONFIG_SND_SOC_AW8738)	+= snd-soc-aw8738.o
  obj-$(CONFIG_SND_SOC_AW87390)	+= snd-soc-aw87390.o
@@ -62,7 +61,7 @@ index d687d4f74363..0d6a66408ddf 100644
  obj-$(CONFIG_SND_SOC_AW88395)	+=snd-soc-aw88395.o
 diff --git a/sound/soc/codecs/aw87391.c b/sound/soc/codecs/aw87391.c
 new file mode 100644
-index 000000000000..896db15a2c36
+index 000000000000..111111111111
 --- /dev/null
 +++ b/sound/soc/codecs/aw87391.c
 @@ -0,0 +1,271 @@
@@ -338,5 +337,5 @@ index 000000000000..896db15a2c36
 +MODULE_DESCRIPTION("ASoC AW87391 PA Driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.1/board-rgds-03-goodix-no-cfg-from-disk.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-rgds-03-goodix-no-cfg-from-disk.patch
@@ -1,24 +1,63 @@
-From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] input: touchscreen: goodix: add goodix,no-cfg-from-disk DT opt-out (RG DS dual gt911)
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "J.H." <129548912+crackerjacques@users.noreply.github.com>
+Date: Thu, 11 Jun 2026 11:45:33 +0200
+Subject: [ARCHEOLOGY] board: add Anbernic RG DS (RK3568 dual 4" 640x480
+ handheld) as CSC (#9934)
 
-The Anbernic RG DS has two gt911 touchscreens (same ID 911, same i2c addr on
-separate buses). With load_cfg_from_disk=true the driver requests
-goodix_911_cfg.bin asynchronously and sets up the IRQ in the firmware callback;
-with two identical chips requesting the same (missing) firmware this leaves one
-panel without a working touch IRQ (and incurs a ~60s firmware timeout).
+> X-Git-Archeology: > recovered message: > * board: add Anbernic RG DS (RK3568 dual 4" handheld) as CSC
+> X-Git-Archeology: > recovered message: > RK3568 clamshell handheld, dual 4" 640x480 MIPI-DSI. Supported by mainline
+> X-Git-Archeology: > recovered message: > drivers on edge (7.0) and bleedingedge (7.1): jadard panels, adc-joystick,
+> X-Git-Archeology: > recovered message: > goodix touch, rk817 audio, rtw88 wifi, usb. The kernel options for these are
+> X-Git-Archeology: > recovered message: > set in the shared rockchip64 edge/bleedingedge configs (not the board file).
+> X-Git-Archeology: > recovered message: > Carries the out-of-tree aw87391 speaker-amp driver (plus its DTS wiring on 7.0;
+> X-Git-Archeology: > recovered message: > 7.1 already has the amp nodes in the mainline DTS) and a goodix dual-gt911
+> X-Git-Archeology: > recovered message: > cfg-from-disk fix. Builds mainline U-Boot v2026.01 (vendor 2017.09 does not
+> X-Git-Archeology: > recovered message: > boot this board).
+> X-Git-Archeology: > recovered message: > Needs rk3568 DDR v1.23 / BL31 v1.45 from armbian/rkbin (separate PR).
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > * anbernic-rg-ds: drop redundant board name from header comment
+> X-Git-Archeology: > recovered message: > BOARD_NAME already carries 'Anbernic RG DS'; keep only the hardware
+> X-Git-Archeology: > recovered message: > description on the first-line interactive comment (review: @EvilOlaf).
+> X-Git-Archeology: > recovered message: > Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+> X-Git-Archeology: > recovered message: > ---------
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Co-authored-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Co-authored-by: jackheinlein <crackerjaxx@yandex.com>
+> X-Git-Archeology: - Revision fbfc3ea659f651281d97cfdbf001ca4aa88abeeb: https://github.com/armbian/build/commit/fbfc3ea659f651281d97cfdbf001ca4aa88abeeb
+> X-Git-Archeology:   Date: Thu, 11 Jun 2026 11:45:33 +0200
+> X-Git-Archeology:   From: J.H. <129548912+crackerjacques@users.noreply.github.com>
+> X-Git-Archeology:   Subject: board: add Anbernic RG DS (RK3568 dual 4" 640x480 handheld) as CSC (#9934)
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts | 2 ++
+ drivers/input/touchscreen/goodix.c                     | 9 +++++++++
+ 2 files changed, 11 insertions(+)
 
-Rather than changing the default for every goodix device, add a
-"goodix,no-cfg-from-disk" device-tree property. When present the driver keeps
-load_cfg_from_disk off and sets the IRQ up synchronously in probe using the
-chip's built-in config. Only the RG DS opts in (both gt911 nodes); all other
-boards keep the upstream default. Mirrors ROCKNIX's goodix usability fix.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-
+diff --git a/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts b/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts
+@@ -883,6 +883,7 @@ &i2c3 {
+ 	touch1: touchscreen@14 {
+ 		compatible = "goodix,gt911";
+ 		reg = <0x14>;
++		goodix,no-cfg-from-disk;
+ 		AVDD28-supply = <&vcc2v8_dvp>;
+ 		interrupt-parent = <&gpio0>;
+ 		interrupts = <RK_PC0 IRQ_TYPE_LEVEL_LOW>;
+@@ -908,6 +909,7 @@ &i2c5 {
+ 	touch0: touchscreen@14 {
+ 		compatible = "goodix,gt911";
+ 		reg = <0x14>;
++		goodix,no-cfg-from-disk;
+ 		AVDD28-supply = <&vcc2v8_dvp>;
+ 		interrupt-parent = <&gpio0>;
+ 		interrupts = <RK_PB6 IRQ_TYPE_LEVEL_LOW>;
+diff --git a/drivers/input/touchscreen/goodix.c b/drivers/input/touchscreen/goodix.c
+index 111111111111..222222222222 100644
 --- a/drivers/input/touchscreen/goodix.c
 +++ b/drivers/input/touchscreen/goodix.c
-@@ -1021,7 +1021,16 @@
- 	default:
+@@ -1022,6 +1022,15 @@ static int goodix_get_gpio_config(struct goodix_ts_data *ts)
  		if (ts->gpiod_int && ts->gpiod_rst) {
  			ts->reset_controller_at_probe = true;
  			ts->load_cfg_from_disk = true;
@@ -34,21 +73,6 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
  			ts->irq_pin_access_method = IRQ_PIN_ACCESS_GPIO;
  		}
  	}
---- a/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts
-@@ -920,6 +920,7 @@
- 	touch1: touchscreen@14 {
- 		compatible = "goodix,gt911";
- 		reg = <0x14>;
-+		goodix,no-cfg-from-disk;
- 		AVDD28-supply = <&vcc2v8_dvp>;
- 		interrupt-parent = <&gpio0>;
- 		interrupts = <RK_PC0 IRQ_TYPE_LEVEL_LOW>;
-@@ -944,6 +945,7 @@
- 	touch0: touchscreen@14 {
- 		compatible = "goodix,gt911";
- 		reg = <0x14>;
-+		goodix,no-cfg-from-disk;
- 		AVDD28-supply = <&vcc2v8_dvp>;
- 		interrupt-parent = <&gpio0>;
- 		interrupts = <RK_PB6 IRQ_TYPE_LEVEL_LOW>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/0202-drv-net-phy-ac200-ephy-add.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/0202-drv-net-phy-ac200-ephy-add.patch
@@ -16,8 +16,8 @@ Signed-off-by: Andre Przywara <andre.przywara@arm.com>
 ---
  drivers/net/phy/Kconfig     |  7 +
  drivers/net/phy/Makefile    |  1 +
- drivers/net/phy/ac200-phy.c | 82 ++++++++++
- 3 files changed, 90 insertions(+)
+ drivers/net/phy/ac200-phy.c | 94 ++++++++++
+ 3 files changed, 102 insertions(+)
 
 diff --git a/drivers/net/phy/Kconfig b/drivers/net/phy/Kconfig
 index 111111111111..222222222222 100644

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/0302-arm64-dts-sun50i-h618-orangepi-zero2w-add-emac-sound.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/0302-arm64-dts-sun50i-h618-orangepi-zero2w-add-emac-sound.patch
@@ -6,8 +6,8 @@ Subject: arm64: dts: sun50i-h618-orangepi-zero2w: Add missing nodes
 Signed-off-by: The-going <48602507+The-going@users.noreply.github.com>
 Signed-off-by: Exodus <zjemcikolege@protonmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts | 188 ++++++++++
- 1 file changed, 188 insertions(+)
+ arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts | 190 ++++++++++
+ 1 file changed, 190 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
 index 111111111111..222222222222 100644

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/0701-arm64-dts-sun50i-h616-orangepi-zero-enable-sound.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/0701-arm64-dts-sun50i-h616-orangepi-zero-enable-sound.patch
@@ -79,7 +79,7 @@ index 111111111111..222222222222 100644
  			reg = <0x030f0000 0x10000>;
  			interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL_HIGH>;
  			clocks = <&ccu CLK_BUS_IOMMU>;
-@@ -834,6 +835,63 @@ codec: codec@5096000 {
+@@ -825,6 +826,63 @@ codec: codec@5096000 {
  			status = "disabled";
  		};
  

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
@@ -31,7 +31,7 @@ diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dt
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -841,8 +841,8 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+@@ -832,8 +832,8 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
  			compatible = "allwinner,sunxi-snd-plat-ahub_dam";
  			reg        = <0x05097000 0x1000>;
  			resets     = <&ccu RST_BUS_AUDIO_HUB>;
@@ -42,7 +42,7 @@ index 111111111111..222222222222 100644
  				     <&ccu CLK_AUDIO_HUB>,
  				     <&ccu CLK_BUS_AUDIO_HUB>;
                          clock-names =   "clk_pll_audio",
-@@ -852,6 +852,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+@@ -843,6 +843,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
  			status = "disabled";
  		};
  
@@ -60,7 +60,7 @@ index 111111111111..222222222222 100644
  		ahub1_plat:ahub1_plat {
  			#sound-dai-cells = <0>;
  			compatible      = "allwinner,sunxi-snd-plat-ahub";
-@@ -1055,6 +1066,7 @@ ohci3: usb@5311400 {
+@@ -1046,6 +1057,7 @@ ohci3: usb@5311400 {
  		hdmi: hdmi@6000000 {
  			compatible = "allwinner,sun50i-h616-dw-hdmi",
  				     "allwinner,sun50i-h6-dw-hdmi";

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h6-h616-add-sunxi-info-nodes.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h6-h616-add-sunxi-info-nodes.patch
@@ -42,7 +42,7 @@ diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dt
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -1628,6 +1628,25 @@ r_rsb: rsb@7083000 {
+@@ -1619,6 +1619,25 @@ r_rsb: rsb@7083000 {
  			#address-cells = <1>;
  			#size-cells = <0>;
  		};

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-add-vpu-node.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-add-vpu-node.patch
@@ -29,7 +29,7 @@ index 111111111111..222222222222 100644
 +
  		syscon: syscon@3000000 {
  			compatible = "allwinner,sun50i-h616-system-control";
- 			reg = <0x03000000 0x30>,<0x03000038 0x0fc8>;
+ 			reg = <0x03000000 0x1000>;
 @@ -281,6 +292,19 @@ de3_sram: sram-section@0 {
  					reg = <0x0000 0x1e000>;
  				};

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-net-phy-ac300-phy-add.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-net-phy-ac300-phy-add.patch
@@ -1,8 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alastair D'Silva <deece@users.noreply.github.com>
+Date: Wed, 17 Jun 2026 14:24:40 +0100
+Subject: [ARCHEOLOGY] Feature/sunxi mainline stmmac ac300 (#9952)
+
+> X-Git-Archeology: > recovered message: > * sunxi: H618: drop unused legacy vendor sunxi-gmac driver and align Orange Pi Zero 2W
+> X-Git-Archeology: > recovered message: > Remove the unused legacy vendor GMAC driver from patches. Revert syscon register range changes in the Orange Pi Zero 2W patch to align it with standard mainline stmmac bindings.
+> X-Git-Archeology: > recovered message: > The vendor GMAC was only referenced in the Orange Pi Zero 2W (where it was broken) and the Banana Pi M4 Berry board (where it was disabled), making it completely safe to remove.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: EPHY: add dedicated modular AC300 EPHY driver
+> X-Git-Archeology: > recovered message: > Introduce a dedicated, mainline-quality Clause 22 PHY driver for the Allwinner AC300 Ethernet PHY. This driver matches the AC300 EPHY via a custom compatible string and communicates directly over MDIO.
+> X-Git-Archeology: > recovered message: > We compile the driver directly into the kernel (CONFIG_AC300_PHY=y) instead of building a module (CONFIG_AC300_PHY=m) for the following reasons:
+> X-Git-Archeology: > recovered message: > - The integrated AC300 EPHY starts in a powered-down state.
+> X-Git-Archeology: > recovered message: > - The MAC controller driver (dwmac-sun8i) is compiled in (y). If the AC300 PHY driver is built as a module (m), early MAC driver probing during boot will default to binding the generic C22 PHY driver because the AC300 module cannot be loaded yet.
+> X-Git-Archeology: > recovered message: > - Without the custom AC300 PHY driver's early SYSCON configuration, clock gating setup, and Bandgap calibration programming, the EPHY will fail to negotiate a stable link or establish packet transmission on boot.
+> X-Git-Archeology: > recovered message: > - Compiling the driver directly in ensures that it is immediately available to bind when the MAC probes, allowing out-of-the-box DHCP and network access.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: EPHY: Support internal PHYs for H616 in the stmmac driver
+> X-Git-Archeology: > recovered message: > Introduce support for the co-packaged internal Ethernet Physical Layer (EPHY)
+> X-Git-Archeology: > recovered message: > on Allwinner H616/H618 SoCs in the mainline dwmac-sun8i driver.
+> X-Git-Archeology: > recovered message: > This adds internal PHY handling changes:
+> X-Git-Archeology: > recovered message: > - Define emac_variant_h616_internal with internal PHY, MII, RMII, and RGMII support.
+> X-Git-Archeology: > recovered message: > - Delay the MAC software reset until sun8i_dwmac_init phase. For internal PHYs,
+> X-Git-Archeology: > recovered message: > doing a MAC software reset during early probe/mux-switching fails with an EMAC
+> X-Git-Archeology: > recovered message: > reset timeout because the internal PHY's clocks are not yet active.
+> X-Git-Archeology: > recovered message: > - Skip setting H3_EPHY_SELECT for the H616 syscon MDIO mux configuration, as
+> X-Git-Archeology: > recovered message: > this bit is not applicable to H616/H618.
+> X-Git-Archeology: > recovered message: > - Add stable locally-administered MAC address generation derived from the SoC chip ID
+> X-Git-Archeology: > recovered message: > when a valid hardware address is not present.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: orangepi-zero2w: Enable AC300 EPHY in device tree patches
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > ---------
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: - Revision 21fb43ef2c1deb4a3643f9f9921823f94fd87f26: https://github.com/armbian/build/commit/21fb43ef2c1deb4a3643f9f9921823f94fd87f26
+> X-Git-Archeology:   Date: Wed, 17 Jun 2026 14:24:40 +0100
+> X-Git-Archeology:   From: Alastair D'Silva <deece@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Feature/sunxi mainline stmmac ac300 (#9952)
+> X-Git-Archeology:
+---
+ drivers/net/phy/Kconfig     |   7 +
+ drivers/net/phy/Makefile    |   1 +
+ drivers/net/phy/ac300-phy.c | 353 ++++++++++
+ 3 files changed, 361 insertions(+)
+
 diff --git a/drivers/net/phy/Kconfig b/drivers/net/phy/Kconfig
-index 70b0f0f..e38696e 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -109,6 +109,13 @@ config AC200_PHY
+@@ -108,6 +108,13 @@ config AC200_PHY
  	help
  	  Fast ethernet PHY as found in X-Powers AC200 multi-function device.
  
@@ -17,7 +66,7 @@ index 70b0f0f..e38696e 100644
  	tristate "AMD and Altima PHYs"
  	help
 diff --git a/drivers/net/phy/Makefile b/drivers/net/phy/Makefile
-index 769fe6a..2319869 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/phy/Makefile
 +++ b/drivers/net/phy/Makefile
 @@ -28,6 +28,7 @@ sfp-obj-$(CONFIG_SFP)		+= sfp-bus.o
@@ -30,7 +79,7 @@ index 769fe6a..2319869 100644
  obj-$(CONFIG_AIR_EN8811H_PHY)   += air_en8811h.o
 diff --git a/drivers/net/phy/ac300-phy.c b/drivers/net/phy/ac300-phy.c
 new file mode 100644
-index 0000000..7f98ffe
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/net/phy/ac300-phy.c
 @@ -0,0 +1,353 @@
@@ -387,3 +436,6 @@ index 0000000..7f98ffe
 +	{ }
 +};
 +MODULE_DEVICE_TABLE(mdio, ac300_phy_tbl);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-net-stmmac-dwmac-sun8i-add-h616-internal-phy.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-net-stmmac-dwmac-sun8i-add-h616-internal-phy.patch
@@ -1,5 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alastair D'Silva <deece@users.noreply.github.com>
+Date: Wed, 17 Jun 2026 14:24:40 +0100
+Subject: [ARCHEOLOGY] Feature/sunxi mainline stmmac ac300 (#9952)
+
+> X-Git-Archeology: > recovered message: > * sunxi: H618: drop unused legacy vendor sunxi-gmac driver and align Orange Pi Zero 2W
+> X-Git-Archeology: > recovered message: > Remove the unused legacy vendor GMAC driver from patches. Revert syscon register range changes in the Orange Pi Zero 2W patch to align it with standard mainline stmmac bindings.
+> X-Git-Archeology: > recovered message: > The vendor GMAC was only referenced in the Orange Pi Zero 2W (where it was broken) and the Banana Pi M4 Berry board (where it was disabled), making it completely safe to remove.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: EPHY: add dedicated modular AC300 EPHY driver
+> X-Git-Archeology: > recovered message: > Introduce a dedicated, mainline-quality Clause 22 PHY driver for the Allwinner AC300 Ethernet PHY. This driver matches the AC300 EPHY via a custom compatible string and communicates directly over MDIO.
+> X-Git-Archeology: > recovered message: > We compile the driver directly into the kernel (CONFIG_AC300_PHY=y) instead of building a module (CONFIG_AC300_PHY=m) for the following reasons:
+> X-Git-Archeology: > recovered message: > - The integrated AC300 EPHY starts in a powered-down state.
+> X-Git-Archeology: > recovered message: > - The MAC controller driver (dwmac-sun8i) is compiled in (y). If the AC300 PHY driver is built as a module (m), early MAC driver probing during boot will default to binding the generic C22 PHY driver because the AC300 module cannot be loaded yet.
+> X-Git-Archeology: > recovered message: > - Without the custom AC300 PHY driver's early SYSCON configuration, clock gating setup, and Bandgap calibration programming, the EPHY will fail to negotiate a stable link or establish packet transmission on boot.
+> X-Git-Archeology: > recovered message: > - Compiling the driver directly in ensures that it is immediately available to bind when the MAC probes, allowing out-of-the-box DHCP and network access.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: EPHY: Support internal PHYs for H616 in the stmmac driver
+> X-Git-Archeology: > recovered message: > Introduce support for the co-packaged internal Ethernet Physical Layer (EPHY)
+> X-Git-Archeology: > recovered message: > on Allwinner H616/H618 SoCs in the mainline dwmac-sun8i driver.
+> X-Git-Archeology: > recovered message: > This adds internal PHY handling changes:
+> X-Git-Archeology: > recovered message: > - Define emac_variant_h616_internal with internal PHY, MII, RMII, and RGMII support.
+> X-Git-Archeology: > recovered message: > - Delay the MAC software reset until sun8i_dwmac_init phase. For internal PHYs,
+> X-Git-Archeology: > recovered message: > doing a MAC software reset during early probe/mux-switching fails with an EMAC
+> X-Git-Archeology: > recovered message: > reset timeout because the internal PHY's clocks are not yet active.
+> X-Git-Archeology: > recovered message: > - Skip setting H3_EPHY_SELECT for the H616 syscon MDIO mux configuration, as
+> X-Git-Archeology: > recovered message: > this bit is not applicable to H616/H618.
+> X-Git-Archeology: > recovered message: > - Add stable locally-administered MAC address generation derived from the SoC chip ID
+> X-Git-Archeology: > recovered message: > when a valid hardware address is not present.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: orangepi-zero2w: Enable AC300 EPHY in device tree patches
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > ---------
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: - Revision 21fb43ef2c1deb4a3643f9f9921823f94fd87f26: https://github.com/armbian/build/commit/21fb43ef2c1deb4a3643f9f9921823f94fd87f26
+> X-Git-Archeology:   Date: Wed, 17 Jun 2026 14:24:40 +0100
+> X-Git-Archeology:   From: Alastair D'Silva <deece@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Feature/sunxi mainline stmmac ac300 (#9952)
+> X-Git-Archeology:
+---
+ drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c | 75 ++++++++--
+ 1 file changed, 64 insertions(+), 11 deletions(-)
+
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
-index b36bed544..75e9e7100 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
 @@ -6,7 +6,10 @@
@@ -38,7 +85,7 @@ index b36bed544..75e9e7100 100644
  
  static int sun8i_dwmac_init(struct platform_device *pdev, void *priv)
  {
-@@ -595,6 +609,10 @@ static int sun8i_dwmac_init(struct platform_device *pdev, void *priv)
+@@ -596,6 +610,10 @@ static int sun8i_dwmac_init(struct platform_device *pdev, void *priv)
  		ret = sun8i_dwmac_power_internal_phy(netdev_priv(ndev));
  		if (ret)
  			goto err_disable_regulator;
@@ -49,7 +96,7 @@ index b36bed544..75e9e7100 100644
  	}
  
  	return 0;
-@@ -792,16 +811,24 @@ static int get_ephy_nodes(struct stmmac_priv *priv)
+@@ -792,16 +810,24 @@ static int get_ephy_nodes(struct stmmac_priv *priv)
  	/* Seek for internal PHY */
  	for_each_child_of_node_scoped(mdio_internal, iphynode) {
  		gmac->ephy_clk = of_clk_get(iphynode, 0);
@@ -77,7 +124,8 @@ index b36bed544..75e9e7100 100644
  		}
  		dev_info(priv->device, "Found internal PHY node\n");
  		of_node_put(mdio_internal);
-@@ -880,4 +880,6 @@ static int mdio_mux_syscon_switch_fn(int current_child, int desired_child,
+@@ -879,7 +905,9 @@ static int mdio_mux_syscon_switch_fn(int current_child, int desired_child,
+ 		switch (desired_child) {
  		case DWMAC_SUN8I_MDIO_MUX_INTERNAL_ID:
  			dev_info(priv->device, "Switch mux to internal PHY");
 -			val = (reg & ~H3_EPHY_MUX_MASK) | H3_EPHY_SELECT;
@@ -85,7 +133,9 @@ index b36bed544..75e9e7100 100644
 +			if (gmac->variant != &emac_variant_h616_internal)
 +				val |= H3_EPHY_SELECT;
  			gmac->use_internal_phy = true;
-@@ -900,10 +903,14 @@ static int mdio_mux_syscon_switch_fn(int current_child, int desired_child,
+ 			break;
+ 		case DWMAC_SUN8I_MDIO_MUX_EXTERNAL_ID:
+@@ -900,10 +928,14 @@ static int mdio_mux_syscon_switch_fn(int current_child, int desired_child,
  		} else {
  			sun8i_dwmac_unpower_internal_phy(gmac);
  		}
@@ -104,7 +154,8 @@ index b36bed544..75e9e7100 100644
  	}
  	return ret;
  }
-@@ -1039,6 +1039,10 @@ static void sun8i_dwmac_unset_syscon(struct sunxi_priv_data *gmac)
+@@ -1008,9 +1040,13 @@ static int sun8i_dwmac_set_syscon(struct device *dev,
+ 
  static void sun8i_dwmac_unset_syscon(struct sunxi_priv_data *gmac)
  {
 -	if (gmac->variant->soc_has_internal_phy)
@@ -118,7 +169,9 @@ index b36bed544..75e9e7100 100644
 +		regmap_field_write(gmac->regmap_field, val);
 +	}
  }
-@@ -1192,6 +1223,21 @@ static int sun8i_dwmac_probe(struct platform_device *pdev)
+ 
+ static void sun8i_dwmac_exit(struct platform_device *pdev, void *priv)
+@@ -1197,6 +1233,21 @@ static int sun8i_dwmac_probe(struct platform_device *pdev)
  	}
  
  	plat_dat = devm_stmmac_probe_config_dt(pdev, stmmac_res.mac);
@@ -140,7 +193,7 @@ index b36bed544..75e9e7100 100644
  	if (IS_ERR(plat_dat))
  		return PTR_ERR(plat_dat);
  
-@@ -1300,6 +1346,8 @@ static const struct of_device_id sun8i_dwmac_match[] = {
+@@ -1305,6 +1356,8 @@ static const struct of_device_id sun8i_dwmac_match[] = {
  		.data = &emac_variant_h6 },
  	{ .compatible = "allwinner,sun50i-h616-emac",
  		.data = &emac_variant_h6 },
@@ -149,3 +202,6 @@ index b36bed544..75e9e7100 100644
  	{ }
  };
  MODULE_DEVICE_TABLE(of, sun8i_dwmac_match);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/a711-6.18/0003-mmc-add-delay-after-power-class-selection.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/a711-6.18/0003-mmc-add-delay-after-power-class-selection.patch
@@ -15,7 +15,7 @@ diff --git a/drivers/mmc/core/mmc.c b/drivers/mmc/core/mmc.c
 index 111111111111..222222222222 100644
 --- a/drivers/mmc/core/mmc.c
 +++ b/drivers/mmc/core/mmc.c
-@@ -1863,6 +1863,8 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
+@@ -1865,6 +1865,8 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
  	 */
  	mmc_select_powerclass(card);
  
@@ -24,7 +24,7 @@ index 111111111111..222222222222 100644
  	/*
  	 * Enable HPI feature (if supported)
  	 */
-@@ -1881,6 +1883,8 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
+@@ -1883,6 +1885,8 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
  		}
  	}
  

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/fixes-6.18/0011-mmc-dw-mmc-rockchip-fix-sdmmc-after-soft-reboot.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/fixes-6.18/0011-mmc-dw-mmc-rockchip-fix-sdmmc-after-soft-reboot.patch
@@ -26,7 +26,7 @@ index 111111111111..222222222222 100644
  #include <linux/slab.h>
  
  #include "dw_mmc.h"
-@@ -615,9 +616,20 @@ static const struct dev_pm_ops dw_mci_rockchip_dev_pm_ops = {
+@@ -632,9 +633,20 @@ static const struct dev_pm_ops dw_mci_rockchip_dev_pm_ops = {
  	RUNTIME_PM_OPS(dw_mci_rockchip_runtime_suspend, dw_mci_rockchip_runtime_resume, NULL)
  };
  

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/fixes-6.18/0019-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/fixes-6.18/0019-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
@@ -20,7 +20,7 @@ diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
-@@ -2560,6 +2560,7 @@ static struct usb_serial_driver option_1port_device = {
+@@ -2563,6 +2563,7 @@ static struct usb_serial_driver option_1port_device = {
  #ifdef CONFIG_PM
  	.suspend           = usb_wwan_suspend,
  	.resume            = usb_wwan_resume,

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/0202-drv-net-phy-ac200-ephy-add.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/0202-drv-net-phy-ac200-ephy-add.patch
@@ -16,8 +16,8 @@ Signed-off-by: Andre Przywara <andre.przywara@arm.com>
 ---
  drivers/net/phy/Kconfig     |  7 +
  drivers/net/phy/Makefile    |  1 +
- drivers/net/phy/ac200-phy.c | 82 ++++++++++
- 3 files changed, 90 insertions(+)
+ drivers/net/phy/ac200-phy.c | 94 ++++++++++
+ 3 files changed, 102 insertions(+)
 
 diff --git a/drivers/net/phy/Kconfig b/drivers/net/phy/Kconfig
 index 111111111111..222222222222 100644
@@ -149,6 +149,6 @@ index 000000000000..111111111111
 +	{ }
 +};
 +MODULE_DEVICE_TABLE(mdio, ac200_ephy_phy_tbl);
-+-- 
-+Armbian
+-- 
+Armbian
 

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/0302-arm64-dts-sun50i-h618-orangepi-zero2w-add-emac-sound.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/0302-arm64-dts-sun50i-h618-orangepi-zero2w-add-emac-sound.patch
@@ -6,8 +6,8 @@ Subject: arm64: dts: sun50i-h618-orangepi-zero2w: Add missing nodes
 Signed-off-by: The-going <48602507+The-going@users.noreply.github.com>
 Signed-off-by: Exodus <zjemcikolege@protonmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts | 188 ++++++++++
- 1 file changed, 188 insertions(+)
+ arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts | 190 ++++++++++
+ 1 file changed, 190 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
 index 111111111111..222222222222 100644

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/0701-arm64-dts-sun50i-h616-orangepi-zero-enable-sound.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/0701-arm64-dts-sun50i-h616-orangepi-zero-enable-sound.patch
@@ -79,7 +79,7 @@ index 111111111111..222222222222 100644
  			reg = <0x030f0000 0x10000>;
  			interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL_HIGH>;
  			clocks = <&ccu CLK_BUS_IOMMU>;
-@@ -886,6 +887,63 @@ codec: codec@5096000 {
+@@ -877,6 +878,63 @@ codec: codec@5096000 {
  			status = "disabled";
  		};
  

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
@@ -31,7 +31,7 @@ diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dt
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -893,8 +893,8 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+@@ -884,8 +884,8 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
  			compatible = "allwinner,sunxi-snd-plat-ahub_dam";
  			reg        = <0x05097000 0x1000>;
  			resets     = <&ccu RST_BUS_AUDIO_HUB>;
@@ -42,7 +42,7 @@ index 111111111111..222222222222 100644
  				     <&ccu CLK_AUDIO_HUB>,
  				     <&ccu CLK_BUS_AUDIO_HUB>;
                          clock-names =   "clk_pll_audio",
-@@ -904,6 +904,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
+@@ -895,6 +895,17 @@ ahub_dam_plat:ahub_dam_plat@5097000 {
  			status = "disabled";
  		};
  
@@ -60,7 +60,7 @@ index 111111111111..222222222222 100644
  		ahub1_plat:ahub1_plat {
  			#sound-dai-cells = <0>;
  			compatible      = "allwinner,sunxi-snd-plat-ahub";
-@@ -1107,6 +1118,7 @@ ohci3: usb@5311400 {
+@@ -1098,6 +1109,7 @@ ohci3: usb@5311400 {
  		hdmi: hdmi@6000000 {
  			compatible = "allwinner,sun50i-h616-dw-hdmi",
  				     "allwinner,sun50i-h6-dw-hdmi";

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h6-h616-add-sunxi-info-nodes.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h6-h616-add-sunxi-info-nodes.patch
@@ -42,7 +42,7 @@ diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dt
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
-@@ -1667,6 +1667,25 @@ r_rsb: rsb@7083000 {
+@@ -1658,6 +1658,25 @@ r_rsb: rsb@7083000 {
  			#address-cells = <1>;
  			#size-cells = <0>;
  		};

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-add-vpu-node.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-add-vpu-node.patch
@@ -29,8 +29,8 @@ index 111111111111..222222222222 100644
 +
  		syscon: syscon@3000000 {
  			compatible = "allwinner,sun50i-h616-system-control";
- 			reg = <0x03000000 0x30>,<0x03000038 0x0fc8>;
-@@ -1670,6 +1681,19 @@ cpu_critical: cpu-trip-2 {
+ 			reg = <0x03000000 0x1000>;
+@@ -1661,6 +1672,19 @@ cpu_critical: cpu-trip-2 {
  					hysteresis = <0>;
  				};
  			};

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/drv-net-phy-ac300-phy-add.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/drv-net-phy-ac300-phy-add.patch
@@ -1,5 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alastair D'Silva <deece@users.noreply.github.com>
+Date: Wed, 17 Jun 2026 14:24:40 +0100
+Subject: [ARCHEOLOGY] Feature/sunxi mainline stmmac ac300 (#9952)
+
+> X-Git-Archeology: > recovered message: > * sunxi: H618: drop unused legacy vendor sunxi-gmac driver and align Orange Pi Zero 2W
+> X-Git-Archeology: > recovered message: > Remove the unused legacy vendor GMAC driver from patches. Revert syscon register range changes in the Orange Pi Zero 2W patch to align it with standard mainline stmmac bindings.
+> X-Git-Archeology: > recovered message: > The vendor GMAC was only referenced in the Orange Pi Zero 2W (where it was broken) and the Banana Pi M4 Berry board (where it was disabled), making it completely safe to remove.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: EPHY: add dedicated modular AC300 EPHY driver
+> X-Git-Archeology: > recovered message: > Introduce a dedicated, mainline-quality Clause 22 PHY driver for the Allwinner AC300 Ethernet PHY. This driver matches the AC300 EPHY via a custom compatible string and communicates directly over MDIO.
+> X-Git-Archeology: > recovered message: > We compile the driver directly into the kernel (CONFIG_AC300_PHY=y) instead of building a module (CONFIG_AC300_PHY=m) for the following reasons:
+> X-Git-Archeology: > recovered message: > - The integrated AC300 EPHY starts in a powered-down state.
+> X-Git-Archeology: > recovered message: > - The MAC controller driver (dwmac-sun8i) is compiled in (y). If the AC300 PHY driver is built as a module (m), early MAC driver probing during boot will default to binding the generic C22 PHY driver because the AC300 module cannot be loaded yet.
+> X-Git-Archeology: > recovered message: > - Without the custom AC300 PHY driver's early SYSCON configuration, clock gating setup, and Bandgap calibration programming, the EPHY will fail to negotiate a stable link or establish packet transmission on boot.
+> X-Git-Archeology: > recovered message: > - Compiling the driver directly in ensures that it is immediately available to bind when the MAC probes, allowing out-of-the-box DHCP and network access.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: EPHY: Support internal PHYs for H616 in the stmmac driver
+> X-Git-Archeology: > recovered message: > Introduce support for the co-packaged internal Ethernet Physical Layer (EPHY)
+> X-Git-Archeology: > recovered message: > on Allwinner H616/H618 SoCs in the mainline dwmac-sun8i driver.
+> X-Git-Archeology: > recovered message: > This adds internal PHY handling changes:
+> X-Git-Archeology: > recovered message: > - Define emac_variant_h616_internal with internal PHY, MII, RMII, and RGMII support.
+> X-Git-Archeology: > recovered message: > - Delay the MAC software reset until sun8i_dwmac_init phase. For internal PHYs,
+> X-Git-Archeology: > recovered message: > doing a MAC software reset during early probe/mux-switching fails with an EMAC
+> X-Git-Archeology: > recovered message: > reset timeout because the internal PHY's clocks are not yet active.
+> X-Git-Archeology: > recovered message: > - Skip setting H3_EPHY_SELECT for the H616 syscon MDIO mux configuration, as
+> X-Git-Archeology: > recovered message: > this bit is not applicable to H616/H618.
+> X-Git-Archeology: > recovered message: > - Add stable locally-administered MAC address generation derived from the SoC chip ID
+> X-Git-Archeology: > recovered message: > when a valid hardware address is not present.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: orangepi-zero2w: Enable AC300 EPHY in device tree patches
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > ---------
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: - Revision 21fb43ef2c1deb4a3643f9f9921823f94fd87f26: https://github.com/armbian/build/commit/21fb43ef2c1deb4a3643f9f9921823f94fd87f26
+> X-Git-Archeology:   Date: Wed, 17 Jun 2026 14:24:40 +0100
+> X-Git-Archeology:   From: Alastair D'Silva <deece@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Feature/sunxi mainline stmmac ac300 (#9952)
+> X-Git-Archeology:
+---
+ drivers/net/phy/Kconfig     |   7 +
+ drivers/net/phy/Makefile    |   1 +
+ drivers/net/phy/ac300-phy.c | 353 ++++++++++
+ 3 files changed, 361 insertions(+)
+
 diff --git a/drivers/net/phy/Kconfig b/drivers/net/phy/Kconfig
-index 70b0f0f..e38696e 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
 @@ -109,6 +109,13 @@ config AC200_PHY
@@ -17,7 +66,7 @@ index 70b0f0f..e38696e 100644
  	tristate "AMD and Altima PHYs"
  	help
 diff --git a/drivers/net/phy/Makefile b/drivers/net/phy/Makefile
-index 769fe6a..2319869 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/phy/Makefile
 +++ b/drivers/net/phy/Makefile
 @@ -28,6 +28,7 @@ sfp-obj-$(CONFIG_SFP)		+= sfp-bus.o
@@ -30,7 +79,7 @@ index 769fe6a..2319869 100644
  obj-$(CONFIG_AIR_EN8811H_PHY)   += air_en8811h.o
 diff --git a/drivers/net/phy/ac300-phy.c b/drivers/net/phy/ac300-phy.c
 new file mode 100644
-index 0000000..7f98ffe
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/net/phy/ac300-phy.c
 @@ -0,0 +1,353 @@
@@ -387,3 +436,6 @@ index 0000000..7f98ffe
 +	{ }
 +};
 +MODULE_DEVICE_TABLE(mdio, ac300_phy_tbl);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/drv-net-stmmac-dwmac-sun8i-add-h616-internal-phy.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/drv-net-stmmac-dwmac-sun8i-add-h616-internal-phy.patch
@@ -1,5 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alastair D'Silva <deece@users.noreply.github.com>
+Date: Wed, 17 Jun 2026 14:24:40 +0100
+Subject: [ARCHEOLOGY] Feature/sunxi mainline stmmac ac300 (#9952)
+
+> X-Git-Archeology: > recovered message: > * sunxi: H618: drop unused legacy vendor sunxi-gmac driver and align Orange Pi Zero 2W
+> X-Git-Archeology: > recovered message: > Remove the unused legacy vendor GMAC driver from patches. Revert syscon register range changes in the Orange Pi Zero 2W patch to align it with standard mainline stmmac bindings.
+> X-Git-Archeology: > recovered message: > The vendor GMAC was only referenced in the Orange Pi Zero 2W (where it was broken) and the Banana Pi M4 Berry board (where it was disabled), making it completely safe to remove.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: EPHY: add dedicated modular AC300 EPHY driver
+> X-Git-Archeology: > recovered message: > Introduce a dedicated, mainline-quality Clause 22 PHY driver for the Allwinner AC300 Ethernet PHY. This driver matches the AC300 EPHY via a custom compatible string and communicates directly over MDIO.
+> X-Git-Archeology: > recovered message: > We compile the driver directly into the kernel (CONFIG_AC300_PHY=y) instead of building a module (CONFIG_AC300_PHY=m) for the following reasons:
+> X-Git-Archeology: > recovered message: > - The integrated AC300 EPHY starts in a powered-down state.
+> X-Git-Archeology: > recovered message: > - The MAC controller driver (dwmac-sun8i) is compiled in (y). If the AC300 PHY driver is built as a module (m), early MAC driver probing during boot will default to binding the generic C22 PHY driver because the AC300 module cannot be loaded yet.
+> X-Git-Archeology: > recovered message: > - Without the custom AC300 PHY driver's early SYSCON configuration, clock gating setup, and Bandgap calibration programming, the EPHY will fail to negotiate a stable link or establish packet transmission on boot.
+> X-Git-Archeology: > recovered message: > - Compiling the driver directly in ensures that it is immediately available to bind when the MAC probes, allowing out-of-the-box DHCP and network access.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: EPHY: Support internal PHYs for H616 in the stmmac driver
+> X-Git-Archeology: > recovered message: > Introduce support for the co-packaged internal Ethernet Physical Layer (EPHY)
+> X-Git-Archeology: > recovered message: > on Allwinner H616/H618 SoCs in the mainline dwmac-sun8i driver.
+> X-Git-Archeology: > recovered message: > This adds internal PHY handling changes:
+> X-Git-Archeology: > recovered message: > - Define emac_variant_h616_internal with internal PHY, MII, RMII, and RGMII support.
+> X-Git-Archeology: > recovered message: > - Delay the MAC software reset until sun8i_dwmac_init phase. For internal PHYs,
+> X-Git-Archeology: > recovered message: > doing a MAC software reset during early probe/mux-switching fails with an EMAC
+> X-Git-Archeology: > recovered message: > reset timeout because the internal PHY's clocks are not yet active.
+> X-Git-Archeology: > recovered message: > - Skip setting H3_EPHY_SELECT for the H616 syscon MDIO mux configuration, as
+> X-Git-Archeology: > recovered message: > this bit is not applicable to H616/H618.
+> X-Git-Archeology: > recovered message: > - Add stable locally-administered MAC address generation derived from the SoC chip ID
+> X-Git-Archeology: > recovered message: > when a valid hardware address is not present.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > * sunxi: orangepi-zero2w: Enable AC300 EPHY in device tree patches
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: > recovered message: > Assisted-by: Antigravity <antigravity@google.com>
+> X-Git-Archeology: > recovered message: > ---------
+> X-Git-Archeology: > recovered message: > Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+> X-Git-Archeology: - Revision 21fb43ef2c1deb4a3643f9f9921823f94fd87f26: https://github.com/armbian/build/commit/21fb43ef2c1deb4a3643f9f9921823f94fd87f26
+> X-Git-Archeology:   Date: Wed, 17 Jun 2026 14:24:40 +0100
+> X-Git-Archeology:   From: Alastair D'Silva <deece@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Feature/sunxi mainline stmmac ac300 (#9952)
+> X-Git-Archeology:
+---
+ drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c | 76 ++++++++--
+ 1 file changed, 65 insertions(+), 11 deletions(-)
+
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
-index b36bed544..75e9e7100 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
 @@ -6,7 +6,10 @@
@@ -78,7 +125,8 @@ index b36bed544..75e9e7100 100644
  		}
  		dev_info(priv->device, "Found internal PHY node\n");
  		of_node_put(mdio_internal);
-@@ -880,4 +880,6 @@ static int mdio_mux_syscon_switch_fn(int current_child, int desired_child,
+@@ -879,7 +906,9 @@ static int mdio_mux_syscon_switch_fn(int current_child, int desired_child,
+ 		switch (desired_child) {
  		case DWMAC_SUN8I_MDIO_MUX_INTERNAL_ID:
  			dev_info(priv->device, "Switch mux to internal PHY");
 -			val = (reg & ~H3_EPHY_MUX_MASK) | H3_EPHY_SELECT;
@@ -86,7 +134,9 @@ index b36bed544..75e9e7100 100644
 +			if (gmac->variant != &emac_variant_h616_internal)
 +				val |= H3_EPHY_SELECT;
  			gmac->use_internal_phy = true;
-@@ -900,10 +903,14 @@ static int mdio_mux_syscon_switch_fn(int current_child, int desired_child,
+ 			break;
+ 		case DWMAC_SUN8I_MDIO_MUX_EXTERNAL_ID:
+@@ -900,10 +929,14 @@ static int mdio_mux_syscon_switch_fn(int current_child, int desired_child,
  		} else {
  			sun8i_dwmac_unpower_internal_phy(gmac);
  		}
@@ -105,7 +155,8 @@ index b36bed544..75e9e7100 100644
  	}
  	return ret;
  }
-@@ -1038,6 +1038,10 @@ static void sun8i_dwmac_unset_syscon(struct sunxi_priv_data *gmac)
+@@ -1008,9 +1041,13 @@ static int sun8i_dwmac_set_syscon(struct device *dev,
+ 
  static void sun8i_dwmac_unset_syscon(struct sunxi_priv_data *gmac)
  {
 -	if (gmac->variant->soc_has_internal_phy)
@@ -119,7 +170,9 @@ index b36bed544..75e9e7100 100644
 +		regmap_field_write(gmac->regmap_field, val);
 +	}
  }
-@@ -1192,6 +1223,21 @@ static int sun8i_dwmac_probe(struct platform_device *pdev)
+ 
+ static void sun8i_dwmac_exit(struct device *dev, void *priv)
+@@ -1192,6 +1229,21 @@ static int sun8i_dwmac_probe(struct platform_device *pdev)
  	}
  
  	plat_dat = devm_stmmac_probe_config_dt(pdev, stmmac_res.mac);
@@ -141,7 +194,7 @@ index b36bed544..75e9e7100 100644
  	if (IS_ERR(plat_dat))
  		return PTR_ERR(plat_dat);
  
-@@ -1300,6 +1346,8 @@ static const struct of_device_id sun8i_dwmac_match[] = {
+@@ -1300,6 +1352,8 @@ static const struct of_device_id sun8i_dwmac_match[] = {
  		.data = &emac_variant_h6 },
  	{ .compatible = "allwinner,sun50i-h616-emac",
  		.data = &emac_variant_h6 },
@@ -150,3 +203,6 @@ index b36bed544..75e9e7100 100644
  	{ }
  };
  MODULE_DEVICE_TABLE(of, sun8i_dwmac_match);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/a711-7.0/0003-mmc-add-delay-after-power-class-selection.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/a711-7.0/0003-mmc-add-delay-after-power-class-selection.patch
@@ -15,7 +15,7 @@ diff --git a/drivers/mmc/core/mmc.c b/drivers/mmc/core/mmc.c
 index 111111111111..222222222222 100644
 --- a/drivers/mmc/core/mmc.c
 +++ b/drivers/mmc/core/mmc.c
-@@ -1863,6 +1863,8 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
+@@ -1865,6 +1865,8 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
  	 */
  	mmc_select_powerclass(card);
  
@@ -24,7 +24,7 @@ index 111111111111..222222222222 100644
  	/*
  	 * Enable HPI feature (if supported)
  	 */
-@@ -1881,6 +1883,8 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
+@@ -1883,6 +1885,8 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
  		}
  	}
  

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/fixes-7.0/0010-mmc-dw-mmc-rockchip-fix-sdmmc-after-soft-reboot.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/fixes-7.0/0010-mmc-dw-mmc-rockchip-fix-sdmmc-after-soft-reboot.patch
@@ -26,7 +26,7 @@ index 111111111111..222222222222 100644
  #include <linux/slab.h>
  
  #include "dw_mmc.h"
-@@ -614,9 +615,20 @@ static const struct dev_pm_ops dw_mci_rockchip_dev_pm_ops = {
+@@ -631,9 +632,20 @@ static const struct dev_pm_ops dw_mci_rockchip_dev_pm_ops = {
  	RUNTIME_PM_OPS(dw_mci_rockchip_runtime_suspend, dw_mci_rockchip_runtime_resume, NULL)
  };
  

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/fixes-7.0/0018-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/fixes-7.0/0018-usb-serial-option-add-reset_resume-callback-for-WWAN.patch
@@ -20,7 +20,7 @@ diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
-@@ -2560,6 +2560,7 @@ static struct usb_serial_driver option_1port_device = {
+@@ -2563,6 +2563,7 @@ static struct usb_serial_driver option_1port_device = {
  #ifdef CONFIG_PM
  	.suspend           = usb_wwan_suspend,
  	.resume            = usb_wwan_resume,

--- a/patch/kernel/archive/sunxi-7.0/patches.megous/pb-7.0/0019-regulator-tp65185x-Add-tp65185x-eInk-panel-regulator.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.megous/pb-7.0/0019-regulator-tp65185x-Add-tp65185x-eInk-panel-regulator.patch
@@ -23,7 +23,7 @@ diff --git a/drivers/regulator/Kconfig b/drivers/regulator/Kconfig
 index 111111111111..222222222222 100644
 --- a/drivers/regulator/Kconfig
 +++ b/drivers/regulator/Kconfig
-@@ -1897,4 +1897,12 @@ config REGULATOR_QCOM_LABIBB
+@@ -1898,4 +1898,12 @@ config REGULATOR_QCOM_LABIBB
  	  boost regulator and IBB can be used as a negative boost regulator
  	  for LCD display panel.
  


### PR DESCRIPTION
# Description

sunxi-6.18
sunxi-7.0
rockchip64-6.18
rockchip64-7.1

# How Has This Been Tested?

- [ ] hasn't

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ASoC audio support for H616/H618 using AHUB/DAM components and an HDMI sound-card binding.
  * Added AW87391 amplifier codec driver.
  * Added Ethernet PHY drivers for AC300 and AC200.
  * Added eInk panel regulator support for tp65185x.
  * Added MMC DW Rockchip “v2 tuning” support.

* **Bug Fixes**
  * Improved USB Type-C/TCPC sysfs capability handling and partner altmode re-registration.
  * Fixed DisplayPort altmode pin-compatibility checks and negotiation logging.
  * Corrected HDMI/AHUB clocking to avoid silent audio.
  * Improved Ethernet bring-up for H616 internal PHY (including stable MAC generation).
  * Updated Goodix touchscreen config loading and WWAN USB serial power-management resume.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->