### PR TITLE
radxa-dragon-q6a: fix audio UCM bump, Chromium zink gate, libbpf build

### DIFF
--- a/config/boards/radxa-dragon-q6a.conf
+++ b/config/boards/radxa-dragon-q6a.conf
@@ -32,22 +32,12 @@ function post_family_tweaks_bsp__radxa-dragon-q6a_bsp_firmware_in_initrd() {
 }
 
 function post_family_tweaks__radxa-dragon-q6a_install_alsa_ucm_conf() {
-	# Only install for kernel 6.18.x
-	if [[ "${KERNEL_MAJOR_MINOR}" == "6.18" ]]; then
-		display_alert "Installing alsa-ucm-conf" "${BOARD}: Radxa ALSA UCM configuration" "info"
-
-		declare alsa_ucm_url="https://github.com/radxa-pkg/alsa-ucm-conf/releases/download/1.2.14-1radxa2/alsa-ucm-conf_1.2.14-1radxa2_all.deb"
-		declare alsa_ucm_deb="/tmp/alsa-ucm-conf_1.2.14-1radxa2_all.deb"
-
-		# Download the package
-		run_host_command_logged wget -O "${SDCARD}${alsa_ucm_deb}" "${alsa_ucm_url}"
-
-		# Install in chroot
-		chroot_sdcard dpkg -i "${alsa_ucm_deb}"
-
-		# Clean up
-		run_host_command_logged rm -f "${SDCARD}${alsa_ucm_deb}"
-	else
-		display_alert "Skipping alsa-ucm-conf installation" "Kernel version ${KERNEL_MAJOR_MINOR} != 6.18" "info"
-	fi
+	# Radxa backport bundles the Q6A device UCM plus the DMI matcher (fork only, not upstream).
+	declare alsa_ucm_ver="1.2.15.3-radxa-1"
+	display_alert "Installing alsa-ucm-conf" "${BOARD}: Radxa ALSA UCM backport ${alsa_ucm_ver}" "info"
+	declare alsa_ucm_url="https://github.com/radxa-pkg/alsa-ucm-conf/releases/download/${alsa_ucm_ver}/alsa-ucm-conf_${alsa_ucm_ver}_all.deb"
+	declare alsa_ucm_deb="/tmp/alsa-ucm-conf_${alsa_ucm_ver}_all.deb"
+	run_host_command_logged wget -O "${SDCARD}${alsa_ucm_deb}" "${alsa_ucm_url}"
+	chroot_sdcard dpkg -i "${alsa_ucm_deb}"
+	run_host_command_logged rm -f "${SDCARD}${alsa_ucm_deb}"
 }

--- a/config/optional/boards/radxa-dragon-q6a/_packages/bsp-cli/etc/chromium.d/zzz-armbian-angle-gles
+++ b/config/optional/boards/radxa-dragon-q6a/_packages/bsp-cli/etc/chromium.d/zzz-armbian-angle-gles
@@ -1,0 +1,5 @@
+# ANGLE-GLES on freedreno (FD643) + venus VPU HW decode; zink only on Mesa >= 26 (older glitches, breaks V4L2).
+__mesa="$(dpkg-query -W -f='${Version}' libgl1-mesa-dri 2>/dev/null)"
+if [ -n "$__mesa" ] && dpkg --compare-versions "$__mesa" ge 26; then export MESA_LOADER_DRIVER_OVERRIDE=zink; fi
+unset __mesa
+export CHROMIUM_FLAGS="$CHROMIUM_FLAGS --ozone-platform-hint=auto --use-gl=angle --use-angle=gles --enable-features=AcceleratedVideoDecoder,AcceleratedVideoDecodeLinuxGL --ignore-gpu-blocklist"

--- a/patch/kernel/archive/qcs6490-6.18/0001-libbpf-const-correctness-for-newer-glibc.patch
+++ b/patch/kernel/archive/qcs6490-6.18/0001-libbpf-const-correctness-for-newer-glibc.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Mon, 22 Jun 2026 12:32:22 +0200
+Subject: libbpf: const-correctness for strstr/strchr return values
+
+glibc 2.42+ (Ubuntu Resolute and later) makes the strstr()/strchr()
+declarations const-aware: a const char* input yields a const char*
+return. Assigning that to a non-const char* triggers
+-Werror=discarded-qualifiers, which is fatal.
+
+This breaks the linux-headers .deb postinst, which compiles
+tools/bpf/resolve_btfids in the target rootfs, when that rootfs runs a
+newer-glibc release. Declare the receiving variables const; they are
+only used for pointer arithmetic and NULL checks.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ tools/lib/bpf/libbpf.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/tools/lib/bpf/libbpf.c b/tools/lib/bpf/libbpf.c
+index dd3b2f5..9c98c6a 100644
+--- a/tools/lib/bpf/libbpf.c
++++ b/tools/lib/bpf/libbpf.c
+@@ -8245,7 +8245,7 @@ static int kallsyms_cb(unsigned long long sym_addr, char sym_type,
+ 	struct bpf_object *obj = ctx;
+ 	const struct btf_type *t;
+ 	struct extern_desc *ext;
+-	char *res;
++	const char *res;
+ 
+ 	res = strstr(sym_name, ".llvm.");
+ 	if (sym_type == 'd' && res)
+@@ -11574,7 +11574,8 @@ static int avail_kallsyms_cb(unsigned long long sym_addr, char sym_type,
+ 		 *
+ 		 *   [0] fb6a421fb615 ("kallsyms: Match symbols exactly with CONFIG_LTO_CLANG")
+ 		 */
+-		char sym_trim[256], *psym_trim = sym_trim, *sym_sfx;
++		char sym_trim[256], *psym_trim = sym_trim;
++		const char *sym_sfx;
+ 
+ 		if (!(sym_sfx = strstr(sym_name, ".llvm.")))
+ 			return 0;
+@@ -12159,7 +12160,7 @@ static int resolve_full_path(const char *file, char *result, size_t result_sz)
+ 		if (!search_paths[i])
+ 			continue;
+ 		for (s = search_paths[i]; s != NULL; s = strchr(s, ':')) {
+-			char *next_path;
++			const char *next_path;
+ 			int seg_len;
+ 
+ 			if (s[0] == ':')
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

This bundles three fixes for the Radxa Dragon Q6A (qcs6490).

Audio did not work, it crashed instead of playing. Two parts. The shipped adsp.mbn and cdsp.mbn were the wrong vendor blobs and wedged the audio DSP; those are already fixed in armbian-firmware with the mainline linux-firmware versions (armbian/firmware#129, merged). On the build side the alsa-ucm-conf the board pulls was old, so this PR bumps it to the latest radxa release and drops the hook check that pinned it to kernel 6.18.

Chromium had no usable GPU video path. The chromium.d drop-in runs the browser on ANGLE-GLES over freedreno with the V4L2 decode flags. zink is the right backend on Mesa 26 but glitches on Mesa 25, so the drop-in switches it on at runtime only when libgl1-mesa-dri is 26 or newer. That keeps Noble on native and gives Resolute zink without picking one at build time.

The Resolute build broke in the linux-headers postinst: glibc 2.42 made strstr and strchr const-aware, so resolve_btfids tripped -Werror=discarded-qualifiers in libbpf. The kernel patch marks the three receiving pointers const, same as the existing ls1046a fix.

# How Has This Been Tested?

Radxa Dragon Q6A, kernel 6.18.2-current-qcs6490, tested on Resolute and Noble.

- [x] Audio: sinks present (HDMI/DP + headphones), paplay clean, no CMD timeout flood
- [x] Chromium: 4k YouTube smooth on Resolute (zink) and Noble (native), A/B confirmed the Mesa gate
- [x] Kernel: patch applies, resolve_btfids compiles on Resolute (glibc 2.42)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved kernel compatibility issues with newer glibc versions.

* **Improvements**
  * Updated ALSA audio configuration for Radxa Dragon Q6A to ensure consistent support.
  * Enhanced Chromium GPU rendering on Radxa Dragon Q6A with improved Mesa driver detection and platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->