### PR TITLE
stubble: add host dependencies

### DIFF
--- a/lib/functions/compilation/stubble.sh
+++ b/lib/functions/compilation/stubble.sh
@@ -7,6 +7,12 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
+function add_host_dependencies__stubble_dependencies() {
+	EXTRA_BUILD_DEPS+=("python3-pyelftools")
+	EXTRA_BUILD_DEPS+=("python3-libfdt")
+	EXTRA_BUILD_DEPS+=("systemd-ukify")
+}
+
 function compile_stubble() {
 	if [[ "${KERNEL_DO_STUBBLE}" != "yes" ]]; then
 		return 0


### PR DESCRIPTION
# Description

Add host dependencies for building stubble and building stuble kernel.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=uefi-arm64-dt BRANCH=edge KERNEL_CONFIGURE=no DEB_COMPRESS=xz KERNEL_BTF=yes KERNEL_GIT=shallow KERNEL_DO_STUBBLE=yes`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include additional required host dependencies for proper compilation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->