### PR TITLE
stubble: only add host deps when KERNEL_DO_STUBBLE=yes

### DIFF
--- a/lib/functions/compilation/stubble.sh
+++ b/lib/functions/compilation/stubble.sh
@@ -8,6 +8,11 @@
 # https://github.com/armbian/build/
 
 function add_host_dependencies__stubble_dependencies() {
+	# Only stubble-using configs (KERNEL_DO_STUBBLE=yes, e.g. the uefidt family)
+	# need these. systemd-ukify and python3-libfdt aren't in older hosts' repos
+	# (Ubuntu Jammy ships systemd 249 — no ukify), so adding them unconditionally
+	# breaks host-prep for EVERY other build on such a host. Gate on the flag.
+	[[ "${KERNEL_DO_STUBBLE}" != "yes" ]] && return 0
 	EXTRA_BUILD_DEPS+=("python3-pyelftools")
 	EXTRA_BUILD_DEPS+=("python3-libfdt")
 	EXTRA_BUILD_DEPS+=("systemd-ukify")


### PR DESCRIPTION
### Problem

`add_host_dependencies__stubble_dependencies()` is registered on the global `add_host_dependencies` hook, so it runs for **every** build and unconditionally appends:

```
python3-pyelftools  python3-libfdt  systemd-ukify
```

to `EXTRA_BUILD_DEPS`. But `systemd-ukify` (and `python3-libfdt`) aren't packaged on older hosts — **Ubuntu Jammy ships systemd 249, which predates `ukify`** — so host-prep dies on any Jammy host, even for boards that have nothing to do with stubble:

```
[🐳|🌱] Installing host-side packages [ python3-pyelftools python3-libfdt systemd-ukify ]
  E: Unable to locate package python3-libfdt
  E: Unable to locate package systemd-ukify
```

`KERNEL_DO_STUBBLE=yes` is set only by the `uefidt` family, and `compile_stubble` already early-returns unless it's set — but the host-dep hook didn't.

### Fix

Gate the dependency injection on `KERNEL_DO_STUBBLE=yes`, matching `compile_stubble`. Only stubble-using configs pull these packages; every other build on Jammy is unaffected.

```bash
[[ "${KERNEL_DO_STUBBLE}" != "yes" ]] && return 0
```

The flag is set during configuration, which runs before `prepare-host` calls `add_host_dependencies`, so it's reliably available at hook time.

> Note: building the `uefidt` family itself still requires a host new enough to provide `systemd-ukify` (Mantic/Noble+). This PR only stops non-stubble builds from being collateral damage on older hosts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized build dependency management to conditionally include stubble-related packages only when required, reducing unnecessary overhead for builds that don't use this feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->