### PR TITLE
cix-acpi: enable HDMI/DP audio on Radxa Orion O6

### DIFF
--- a/config/optional/boards/cix-acpi/_packages/bsp-cli/etc/wireplumber/wireplumber.conf.d/51-cix-hdmi-audio.conf
+++ b/config/optional/boards/cix-acpi/_packages/bsp-cli/etc/wireplumber/wireplumber.conf.d/51-cix-hdmi-audio.conf
@@ -1,0 +1,12 @@
+monitor.alsa.rules = [
+  {
+    matches = [ { node.name = "~alsa_output.platform-CIXH6070.*" } ]
+    actions = {
+      update-props = {
+        api.alsa.headroom               = 4096
+        session.suspend-timeout-seconds = 0
+        api.alsa.period-size            = 1024
+      }
+    }
+  }
+]

--- a/config/optional/boards/cix-acpi/_packages/bsp-cli/usr/share/alsa/ucm2/conf.d/cix_sky1/HiFi.conf
+++ b/config/optional/boards/cix-acpi/_packages/bsp-cli/usr/share/alsa/ucm2/conf.d/cix_sky1/HiFi.conf
@@ -1,0 +1,38 @@
+SectionVerb {
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."HDMI1" {
+	Comment "HDMI/DP 1"
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackChannels "2"
+		JackControl "HDMI/DP,pcm=0 Jack"
+	}
+}
+SectionDevice."HDMI2" {
+	Comment "HDMI/DP 2"
+	Value {
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackChannels "2"
+		JackControl "HDMI/DP,pcm=1 Jack"
+	}
+}
+SectionDevice."HDMI3" {
+	Comment "HDMI/DP 3"
+	Value {
+		PlaybackPCM "hw:${CardId},2"
+		PlaybackChannels "2"
+		JackControl "HDMI/DP,pcm=2 Jack"
+	}
+}
+SectionDevice."HDMI4" {
+	Comment "HDMI/DP 4"
+	Value {
+		PlaybackPCM "hw:${CardId},3"
+		PlaybackChannels "2"
+		JackControl "HDMI/DP,pcm=3 Jack"
+	}
+}

--- a/config/optional/boards/cix-acpi/_packages/bsp-cli/usr/share/alsa/ucm2/conf.d/cix_sky1/cix_sky1.conf
+++ b/config/optional/boards/cix-acpi/_packages/bsp-cli/usr/share/alsa/ucm2/conf.d/cix_sky1/cix_sky1.conf
@@ -1,0 +1,6 @@
+Syntax 6
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Radxa Orion O6 HDMI/DP"
+}

--- a/patch/kernel/archive/cix-7.0/2010-drm-cix-dptx-acpi-hdmi-codec-id-from-uid.patch
+++ b/patch/kernel/archive/cix-7.0/2010-drm-cix-dptx-acpi-hdmi-codec-id-from-uid.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Mon, 22 Jun 2026 22:41:32 +0200
+Subject: drm/cix/dptx: derive ACPI audio codec id from the DP _UID
+
+The HDMI codec was registered with PLATFORM_DEVID_AUTO, so its instance id
+followed probe order and did not match the DP it belongs to. The sky1 ASoC
+machine card maps each I2S link to a fixed hdmi-audio-codec.N, so a shifting
+id leaves links pointing at the wrong or a missing codec.
+
+On ACPI, use the DP _UID as the codec id (bounded to int) so the codec is
+always hdmi-audio-codec.<DP UID>; DT keeps PLATFORM_DEVID_AUTO.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ drivers/gpu/drm/cix/dptx/trilin_dptx.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/cix/dptx/trilin_dptx.c b/drivers/gpu/drm/cix/dptx/trilin_dptx.c
+index f659c07..32ceeeb 100644
+--- a/drivers/gpu/drm/cix/dptx/trilin_dptx.c
++++ b/drivers/gpu/drm/cix/dptx/trilin_dptx.c
+@@ -3375,9 +3375,17 @@ static int dptx_register_audio_device(struct trilin_dp *dp)
+ 		.max_i2s_channels = 8,
+ 		.data = dp,
+ 	};
++	struct acpi_device *adev = ACPI_COMPANION(dp->dev);
++	int devid = PLATFORM_DEVID_AUTO;
++	u64 uid;
++
++	/* ACPI: stable codec id from the DP _UID maps hdmi-audio-codec.N to DP N */
++	if (adev && !acpi_dev_uid_to_integer(adev, &uid) && uid <= INT_MAX)
++		devid = uid;
++
+ 	dptx_aud->running = false;
+ 	dptx_aud->pdev = platform_device_register_data(
+-		dp->dev, HDMI_CODEC_DRV_NAME, PLATFORM_DEVID_AUTO, &codec_data,
++		dp->dev, HDMI_CODEC_DRV_NAME, devid, &codec_data,
+ 		sizeof(codec_data));
+ 
+ 	return PTR_ERR_OR_ZERO(dptx_aud->pdev);
+-- 
+Armbian
+

--- a/patch/kernel/archive/cix-7.0/2011-asoc-cix-skip-absent-hdmi-codec-acpi.patch
+++ b/patch/kernel/archive/cix-7.0/2011-asoc-cix-skip-absent-hdmi-codec-acpi.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Mon, 22 Jun 2026 22:41:33 +0200
+Subject: ASoC: cix: skip HDMI links whose codec device is absent
+
+cix_card_parse_acpi() built a DAI link for every entry in the HDMI topology.
+If a DP TX is held in deferred probe (for example stuck on a supplier that
+has no driver) it never registers its hdmi-audio-codec, and then
+snd_soc_register_card() would defer the whole card forever, leaving the board
+with no HDMI audio at all.
+
+Look up the codec platform device first and skip the link when it is absent,
+mirroring the existing handling of a missing I2S device. The card comes up
+with the outputs that are actually available. Reuse the codec name for the
+link component instead of formatting it twice.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ sound/soc/cix/card-utils.c | 24 ++++++++++++++++++------
+ 1 file changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/sound/soc/cix/card-utils.c b/sound/soc/cix/card-utils.c
+index 15080dd..ef7c3a2 100644
+--- a/sound/soc/cix/card-utils.c
++++ b/sound/soc/cix/card-utils.c
+@@ -689,9 +689,11 @@ int cix_card_parse_acpi(struct cix_asoc_card *priv)
+ 
+ 	for (i = 0; i < SKY1_HDMI_LINKS; i++) {
+ 		const char *i2s_name = sky1_hdmi_topology[i].i2s_name;
++		int codec_id = sky1_hdmi_topology[i].codec_id;
+ 		struct snd_soc_dai_link_component *cpu, *codec, *plat;
+ 		struct snd_soc_dai_link *link;
+-		struct device *i2s_dev;
++		struct device *i2s_dev, *codec_dev;
++		char *codec_name;
+ 
+ 		/* Skip links whose I2S platform device doesn't exist */
+ 		i2s_dev = bus_find_device_by_name(&platform_bus_type, NULL,
+@@ -703,6 +705,20 @@ int cix_card_parse_acpi(struct cix_asoc_card *priv)
+ 		}
+ 		put_device(i2s_dev);
+ 
++		codec_name = devm_kasprintf(dev, GFP_KERNEL,
++					    "hdmi-audio-codec.%d", codec_id);
++		if (!codec_name)
++			return -ENOMEM;
++
++		/* No codec means the parent DP TX is absent or stuck; skip instead of failing the card */
++		codec_dev = bus_find_device_by_name(&platform_bus_type, NULL,
++						    codec_name);
++		if (!codec_dev) {
++			dev_info(dev, "%s not present, skipping\n", codec_name);
++			continue;
++		}
++		put_device(codec_dev);
++
+ 		cpu = &comps[num_links * 3];
+ 		codec = &comps[num_links * 3 + 1];
+ 		plat = &comps[num_links * 3 + 2];
+@@ -713,11 +729,7 @@ int cix_card_parse_acpi(struct cix_asoc_card *priv)
+ 		cpu->dai_name = "i2s-mc-aif1";
+ 
+ 		/* Codec DAI: hdmi-audio-codec */
+-		codec->name = devm_kasprintf(dev, GFP_KERNEL,
+-					     "hdmi-audio-codec.%d",
+-					     sky1_hdmi_topology[i].codec_id);
+-		if (!codec->name)
+-			return -ENOMEM;
++		codec->name = codec_name;
+ 		codec->dai_name = "i2s-hifi";
+ 
+ 		/* Platform: DMA is co-located with CPU */
+-- 
+Armbian
+

--- a/patch/kernel/archive/cix-7.0/2012-drm-cix-dptx-program-audio-maud-naud.patch
+++ b/patch/kernel/archive/cix-7.0/2012-drm-cix-dptx-program-audio-maud-naud.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Mon, 22 Jun 2026 22:27:15 +0200
+Subject: drm/cix/dptx: program audio Maud/Naud and clock mode for recovery
+
+The DP audio path set channel-status but never wrote Maud/Naud or the audio
+clock mode, so the sink could not recover the audio sample clock: the on-wire
+clock free-ran and strict sinks (HDMI capture/KVM) dropped samples. The only
+Maud/Naud writer, trilin_dp_panel_config_msa(), is dead code, gated on video
+sync-lock and fed by trilin_dp_get_audio_clk_rate() which is a stub returning 0.
+
+Program the values in dptx_audio_setup() where the sample rate is known: select
+the audio sync clock mode (SEC0_AUDIO_CLOCK_MODE bit 0) and write the reduced
+Maud/Naud from 512*fs : link rate, matching the IP vendor values. This also
+covers link retrain since dptx_audio_reconfig_and_enable() re-runs setup.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ drivers/gpu/drm/cix/dptx/trilin_dptx_audio.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/drivers/gpu/drm/cix/dptx/trilin_dptx_audio.c b/drivers/gpu/drm/cix/dptx/trilin_dptx_audio.c
+index ae35f92..d2bc54c 100644
+--- a/drivers/gpu/drm/cix/dptx/trilin_dptx_audio.c
++++ b/drivers/gpu/drm/cix/dptx/trilin_dptx_audio.c
+@@ -2,6 +2,7 @@
+ /* Copyright 2024 Cix Technology Group Co., Ltd. */
+ #include <linux/kernel.h>
+ #include <linux/version.h>
++#include <linux/gcd.h>
+ #include "trilin_dptx_reg.h"
+ #include "trilin_dptx.h"
+ 
+@@ -18,6 +19,8 @@ static void dptx_audio_setup(struct trilin_dp *dp, int source, int freq,
+ 	unsigned int offset;
+ 	unsigned int cs_length_orig_freq;
+ 	unsigned int cs_freq_clock_accuracy;
++	unsigned long maud, naud, g;
++	int link_rate;
+ 
+ 	if (!dp)
+ 		return;
+@@ -78,6 +81,18 @@ static void dptx_audio_setup(struct trilin_dp *dp, int source, int freq,
+ 	trilin_dp_write(dp, TRILIN_DPTX_SEC0_CHANNEL_COUNT + offset,
+ 			channel_count);
+ 	trilin_dp_write(dp, TRILIN_DPTX_SEC0_INPUT_SELECT + offset, source);
++
++	/* Audio clock: sync mode + reduced Maud/Naud (512*fs : link rate) so the sink recovers fs */
++	link_rate = drm_dp_bw_code_to_link_rate(dp->mode.bw_code);
++	if (link_rate > 0) {
++		g = gcd(512UL * freq, 1000UL * link_rate);
++		maud = (512UL * freq) / g;
++		naud = (1000UL * link_rate) / g;
++		trilin_dp_write(dp, TRILIN_DPTX_SEC0_AUDIO_CLOCK_MODE + offset,
++				trilin_dp_read(dp, TRILIN_DPTX_SEC0_AUDIO_CLOCK_MODE + offset) | BIT(0));
++		trilin_dp_write(dp, TRILIN_DPTX_SEC0_MAUD + offset, maud);
++		trilin_dp_write(dp, TRILIN_DPTX_SEC0_NAUD + offset, naud);
++	}
+ }
+ 
+ static int dptx_audio_startup(struct device *dev, void *data)
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

This brings up HDMI/DP audio on the Radxa Orion O6 (cix-acpi). It is three small kernel patches plus a board UCM profile and one wireplumber tweak.

Kernel side:

- Give the HDMI codec a fixed id derived from the DP `_UID`, so the sky1 machine card maps each link to the right `hdmi-audio-codec.N` instead of a probe-order id.
- Skip an HDMI link when its codec never appears. On the O6, DP2 stays in deferred probe forever because its supplier `CIXH5040` has no driver, and without this the whole card defers and the board gets no audio at all.
- Program the DP audio clock. The driver set the channel status but never wrote Maud/Naud or the audio clock mode, so the sink could not recover the sample clock and the on-wire clock free-ran. The values match the IP vendor reference and are confirmed by reading the registers back.

BSP side:

- A UCM for the `cix_sky1` card that exposes the four HDMI/DP outputs as stereo sinks with jack detection, so they show up correctly in GNOME and route to the connected port.
- A small wireplumber rule that adds playback headroom on this card.

About that wireplumber rule, and a question for @amazingfate since you wrote the cix sound card.

The audio DMA (`arm-dma350`) only advances its cyclic position once per period, so PipeWire schedules too tight and underruns without extra headroom, which is audible as a stutter. I went through the kernel side but every option looked wrong: reporting `DMA_RESIDUE_GRANULARITY_DESCRIPTOR` would set the BATCH hint, but it is device wide and would break residue for the non-cyclic UART/SPI users, and making the cyclic residue accurate keeps `BURST` so it never sets BATCH and does not help. That left the per-card headroom rule as the surgical fix.

So I would rather ask than ship a workaround I am not sure about. Do you think there is a cleaner way to handle the headroom here? Without it the audio from my GLKVM (an HDMI KVM) stutters. I have no way to test on a real display with actual speakers, and I have never had audio trouble with this GLKVM on other boards, so I suspect I am missing something rather than the GLKVM being the cause.

# How Has This Been Tested?

Tested on a Radxa Orion O6, HDMI/DP audio out to the connected display through a GL.iNet GLKVM.

- [x] Card comes up as `cix_sky1`, four `HDMI/DP` stereo sinks visible in GNOME, the connected output plays.
- [x] Maud/Naud and the audio clock mode verified by reading the DP registers back (MAUD 512, NAUD 5625, clock mode sync at HBR).
- [x] Playback is smooth with the wireplumber headroom in place.
- [ ] Not tested on a directly attached monitor or AVR with speakers (no hardware on hand).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
