### PR TITLE
Fix led trigger for nanopi 5s led-lan2

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/overlay/rockchip-rk3568-nanopi-r5s-leds.dtso
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/rockchip-rk3568-nanopi-r5s-leds.dtso
@@ -11,5 +11,5 @@
 };
 
 &{/gpio-leds/led-lan2} {
-        linux,default-trigger = "r8169-1-100:00:link";
+        linux,default-trigger = "r8169-1-1100:00:link";
 };

--- a/patch/kernel/archive/rockchip64-7.1/overlay/rockchip-rk3568-nanopi-r5s-leds.dtso
+++ b/patch/kernel/archive/rockchip64-7.1/overlay/rockchip-rk3568-nanopi-r5s-leds.dtso
@@ -11,5 +11,5 @@
 };
 
 &{/gpio-leds/led-lan2} {
-        linux,default-trigger = "r8169-1-100:00:link";
+        linux,default-trigger = "r8169-1-1100:00:link";
 };


### PR DESCRIPTION
# Description

Essentially the pcie path is wrong. 
Another part where the fix was necessary was already done in commit 8424dcf5b91d05c44e244bd81383c56ac276f735

I am only changing it for 6.18 kernel, its the only one I tested. Not sure if this should be different for older kernels, or if we also need to fix it there.

# How Has This Been Tested?

Tested by deactivating the shipped overlay and adding the fixed one as a user overlay.

Tested on 6.18 and 7.1 edge kernels, so I guess its safe to do for 6.18, 7.0 and 7.1

# Checklist:

_Please delete options that are not relevant._

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the default behavior of the LAN2 LED on supported devices so it now tracks the correct network link status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->