### PR TITLE
rockchip64_common: add board_uboot postprocess hooks

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -313,9 +313,6 @@ uboot_custom_postprocess() {
 			run_host_command_logged /sbin/parted -s rkspi_loader.img unit s mkpart uboot 16384 32734
 			run_host_command_logged dd if=idbloader.img of=rkspi_loader.img seek=64 conv=notrunc
 			run_host_command_logged dd if=u-boot.itb of=rkspi_loader.img seek=16384 conv=notrunc
-			# Hook: allow board/extension to copy out the SPI image (e.g. for Maskrom recovery)
-			declare -F board_uboot_spi_image_postprocess >/dev/null && \
-				board_uboot_spi_image_postprocess
 		else
 			display_alert "uboot_custom_postprocess (mkimage) for BOOT_SUPPORT_SPI:${BOOT_SUPPORT_SPI:-"no"} and BOOT_SPI_RKSPI_LOADER=${BOOT_SPI_RKSPI_LOADER:-"no"}" "SPI rkspi_loader.img" "info"
 			run_host_command_logged tools/mkimage -n "${BOOT_SOC_MKIMAGE}" -T rkspi -d tpl/u-boot-tpl.bin:spl/u-boot-spl.bin rkspi_tpl_spl.img
@@ -323,6 +320,12 @@ uboot_custom_postprocess() {
 			run_host_command_logged dd if=rkspi_tpl_spl.img of=rkspi_loader.img conv=notrunc status=none
 			run_host_command_logged dd if=u-boot.itb of=rkspi_loader.img seek=768 conv=notrunc status=none
 		fi
+		# Hook: allow board/extension to copy out the finished SPI image
+		# (e.g. for Maskrom recovery). Invoked after both rkspi_loader.img
+		# build paths so the hook contract is consistent regardless of
+		# BOOT_SPI_RKSPI_LOADER.
+		declare -F board_uboot_spi_image_postprocess >/dev/null && \
+			board_uboot_spi_image_postprocess
 	fi
 }
 

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -324,8 +324,8 @@ uboot_custom_postprocess() {
 		# (e.g. for Maskrom recovery). Invoked after both rkspi_loader.img
 		# build paths so the hook contract is consistent regardless of
 		# BOOT_SPI_RKSPI_LOADER.
-		declare -F board_uboot_spi_image_postprocess >/dev/null && \
-			board_uboot_spi_image_postprocess
+		declare -F board_uboot_spi_image_after_build >/dev/null && \
+			board_uboot_spi_image_after_build
 	fi
 }
 

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -262,7 +262,12 @@ uboot_custom_postprocess() {
 				display_alert "boot_merger for '${BOOT_SOC}'" "using vendor SPL ${VENDOR_SPL_PATH##*/}" "info"
 			fi
 
-			if [[ "$BOOT_SOC" == "rk3576" ]]; then
+			if declare -F board_uboot_spl_blobs_postprocess >/dev/null; then
+				# Board/extension hook: take over SPL loader generation for this BOOT_SOC
+				# (e.g. boot_merger with custom usbplug, idbloader via mkimage, maskrom
+				# spl_loader save). Falls through to the upstream branches below otherwise.
+				board_uboot_spl_blobs_postprocess "$BOOT_SOC" "$SPL_BIN_PATH" "$FLASH_BOOT_BIN"
+			elif [[ "$BOOT_SOC" == "rk3576" ]]; then
 				display_alert "boot_merger for '${BOOT_SOC}' for scenario ${BOOT_SCENARIO}" "SPL_BIN_PATH: ${SPL_BIN_PATH}" "debug"
 				RKBOOT_INI_FILE=rk3576.ini
 				cp $RKBIN_DIR/rk35/RK3576MINIALL.ini $RKBOOT_INI_FILE
@@ -308,6 +313,9 @@ uboot_custom_postprocess() {
 			run_host_command_logged /sbin/parted -s rkspi_loader.img unit s mkpart uboot 16384 32734
 			run_host_command_logged dd if=idbloader.img of=rkspi_loader.img seek=64 conv=notrunc
 			run_host_command_logged dd if=u-boot.itb of=rkspi_loader.img seek=16384 conv=notrunc
+			# Hook: allow board/extension to copy out the SPI image (e.g. for Maskrom recovery)
+			declare -F board_uboot_spi_image_postprocess >/dev/null && \
+				board_uboot_spi_image_postprocess
 		else
 			display_alert "uboot_custom_postprocess (mkimage) for BOOT_SUPPORT_SPI:${BOOT_SUPPORT_SPI:-"no"} and BOOT_SPI_RKSPI_LOADER=${BOOT_SPI_RKSPI_LOADER:-"no"}" "SPI rkspi_loader.img" "info"
 			run_host_command_logged tools/mkimage -n "${BOOT_SOC_MKIMAGE}" -T rkspi -d tpl/u-boot-tpl.bin:spl/u-boot-spl.bin rkspi_tpl_spl.img


### PR DESCRIPTION
## Summary

Introduce two opt-in board/extension hooks in `rockchip64_common.inc`'s `uboot_custom_postprocess()` so boards can take over SPL loader generation and post-process the finished SPI image without duplicating the family function.

Split out of #10030 per @rpardini's review — board-level changes stay there, this PR focuses on the `rockchip64_common.inc` change that affects the whole family and needs broader consensus.

### Hooks

- `board_uboot_spl_blobs_postprocess(BOOT_SOC, SPL_BIN_PATH, FLASH_BOOT_BIN)` — checked before the existing `BOOT_SOC` branches in the `spl-blobs` scenario. If defined, takes over SPL loader generation entirely (e.g. custom `boot_merger` invocation with usbplug, custom idbloader layout). Falls through to the existing `rk3576` / `rk3588` branches when undefined.
- `board_uboot_spi_image_postprocess()` — invoked after `rkspi_loader.img` is finalized, regardless of which build path produced it (`BOOT_SPI_RKSPI_LOADER=yes` GPT/parted path or the `mkimage` fallback). Lets boards copy out the SPI image (e.g. for Maskrom recovery flashing).

Both hooks follow the existing `declare -F <hook>` dispatch pattern already used throughout the file (e.g. `uboot_custom_postprocess` itself is a board hook of the same shape). The `spl_blobs` hook is guarded by `declare -F` and only fires on the `BOOT_SCENARIO=spl-blobs` path; the `spi_image` hook is guarded and only fires when `BOOT_SUPPORT_SPI=yes`.

### Why hooks instead of extensions

Open question — happy to convert to the extension framework if that's the preferred direction. Notes:

- The surrounding `rockchip64_common.inc` logic is already `declare -F` dispatch (e.g. `boot_environment_u-boot_mainline__rockchip64_config`, family hooks). The new hooks are the same shape — one-line additions, no new infrastructure.
- The hooks are narrow build-time injection points (two callsites, both already in the same family function). An extension would require a full extension file, `enable_extension`, and family-level integration plumbing.
- Extensions are heavier weight; this is a small, opt-in capability that boards can ignore.

### Hook contract / documentation

- **Args**: `board_uboot_spl_blobs_postprocess` receives `BOOT_SOC`, `SPL_BIN_PATH`, `FLASH_BOOT_BIN` (same vars available at the callsite). `board_uboot_spi_image_postprocess` receives no args; the produced image is `rkspi_loader.img` in the current cwd.
- **Dispatch**: both use `declare -F <name> >/dev/null && <name>` so absence is a no-op.
- **Scope**: `spl_blobs` only fires under `BOOT_SCENARIO=spl-blobs`; `spi_image` only fires under `BOOT_SUPPORT_SPI=yes`.
- **Side effects**: hooks are responsible for their own outputs. The Seeed consumer (`rk-uboot-postprocess` extension) compiles a Maskrom-capable usbplug via `boot_merger` and copies `rkspi_loader.img` to `output/images/` for Maskrom recovery.

## Motivating consumer

The Seeed reComputer RK3576/RK3588 DevKit extension needs these to:

1. Run `boot_merger` v1.35 with a custom usbplug binary (new SPI flash support) — currently the family function only knows about the SDK-provided usbplug.
2. Save `rkspi_loader.img` and `<soc>_spl_loader_maskrom.bin` for Maskrom-mode USB flashing (rkdevtool) on boards with the new SPI flash.

Consumer code lives in the Seeed extension (`rk-uboot-postprocess/`), not in this PR — this PR only adds the dispatch points in the family function.

## Test plan

- [ ] `BOOT_SCENARIO=spl-blobs` build on a board that defines `board_uboot_spl_blobs_postprocess` — hook fires, custom SPL loader is produced
- [ ] Same build on a board that does NOT define the hook — falls through to the existing `rk3576`/`rk3588` branches, behavior unchanged
- [ ] `BOOT_SUPPORT_SPI=yes BOOT_SPI_RKSPI_LOADER=yes` — `board_uboot_spi_image_postprocess` fires after the parted/GPT path
- [ ] `BOOT_SUPPORT_SPI=yes BOOT_SPI_RKSPI_LOADER=no` — `board_uboot_spi_image_postprocess` fires after the mkimage path
- [ ] `BOOT_SUPPORT_SPI=no` — neither SPI hook fires

## Related

- #10030 (board-level U-Boot/bootscript changes for reComputer RK3576/RK3588 DevKit — consumer of these hooks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional board/extension post-build hooks for SPL-based boot scenarios, enabling customization after boot images are generated.
  * Added an optional post-build hook for SPI boot images to allow boards to extract, patch, or otherwise finalize the finished SPI image.

* **Bug Fixes**
  * Improved flexibility of the boot-image build flow so custom hooks can take over the relevant processing steps when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->