### PR TITLE
Enable 1 GHz frequency for Panthor on mainline

### DIFF
--- a/patch/kernel/archive/rockchip64-7.1/rk35xx-panthor-1GHz.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk35xx-panthor-1GHz.patch
@@ -5,8 +5,10 @@ index 9db9f84ad964..596e8a93380e 100644
 @@ -269,6 +269,7 @@ allOf:
          compatible:
            contains:
-             const: rockchip,rk3568-mali
-+            const: rockchip,rk3576-mali
+-            const: rockchip,rk3568-mali
+            enum:
+              - rockchip,rk3568-mali
+              - rockchip,rk3576-mali
      then:
        properties:
          clocks:

--- a/patch/kernel/archive/rockchip64-7.1/rk35xx-panthor-1GHz.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk35xx-panthor-1GHz.patch
@@ -1,0 +1,539 @@
+diff --git a/Documentation/devicetree/bindings/gpu/arm,mali-bifrost.yaml b/Documentation/devicetree/bindings/gpu/arm,mali-bifrost.yaml
+index 9db9f84ad964..596e8a93380e 100644
+--- a/Documentation/devicetree/bindings/gpu/arm,mali-bifrost.yaml
++++ b/Documentation/devicetree/bindings/gpu/arm,mali-bifrost.yaml
+@@ -269,6 +269,7 @@ allOf:
+         compatible:
+           contains:
+             const: rockchip,rk3568-mali
++            const: rockchip,rk3576-mali
+     then:
+       properties:
+         clocks:
+diff --git a/Documentation/devicetree/bindings/gpu/arm,mali-valhall-csf.yaml b/Documentation/devicetree/bindings/gpu/arm,mali-valhall-csf.yaml
+index 8eccd4338a2b..5713020068ec 100644
+--- a/Documentation/devicetree/bindings/gpu/arm,mali-valhall-csf.yaml
++++ b/Documentation/devicetree/bindings/gpu/arm,mali-valhall-csf.yaml
+@@ -40,7 +40,7 @@ properties:
+ 
+   clocks:
+     minItems: 1
+-    maxItems: 3
++    maxItems: 4
+ 
+   clock-names:
+     minItems: 1
+@@ -50,6 +50,7 @@ properties:
+           - coregroup
+           - stacks
+       - const: stacks
++      - const: bus
+ 
+   nvmem-cells:
+     items:
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566.dtsi b/arch/arm64/boot/dts/rockchip/rk3566.dtsi
+index 3fcca79279f7..d3aa13545845 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566.dtsi
+@@ -57,6 +57,7 @@ gpu_opp_table: opp-table-1 {
+ 		opp-200000000 {
+ 			opp-hz = /bits/ 64 <200000000>;
+ 			opp-microvolt = <850000 850000 1000000>;
++			opp-suspend;
+ 		};
+ 
+ 		opp-300000000 {
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566t.dtsi b/arch/arm64/boot/dts/rockchip/rk3566t.dtsi
+index cd89bd3b125b..2a8c59e6777e 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566t.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566t.dtsi
+@@ -45,6 +45,7 @@ gpu_opp_table: opp-table-1 {
+ 		opp-200000000 {
+ 			opp-hz = /bits/ 64 <200000000>;
+ 			opp-microvolt = <850000 850000 1000000>;
++			opp-suspend;
+ 		};
+ 
+ 		opp-300000000 {
+diff --git a/arch/arm64/boot/dts/rockchip/rk3568.dtsi b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
+index 3bc653f027f1..bc0195021f95 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3568.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
+@@ -68,6 +68,7 @@ gpu_opp_table: opp-table-1 {
+ 		opp-200000000 {
+ 			opp-hz = /bits/ 64 <200000000>;
+ 			opp-microvolt = <850000 850000 1000000>;
++			opp-suspend;
+ 		};
+ 
+ 		opp-300000000 {
+diff --git a/arch/arm64/boot/dts/rockchip/rk3576.dtsi b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+index e12a2a0cfb89..b25c5200fe83 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+@@ -347,44 +347,45 @@ opp-2208000000 {
+ 	gpu_opp_table: opp-table-gpu {
+ 		compatible = "operating-points-v2";
+ 
++		opp-200000000 {
++			opp-hz = /bits/ 64 <200000000>;
++			opp-microvolt = <712500 712500 875000>;
++			opp-suspend;
++		};
++
+ 		opp-300000000 {
+ 			opp-hz = /bits/ 64 <300000000>;
+-			opp-microvolt = <700000 700000 850000>;
++			opp-microvolt = <712500 712500 875000>;
+ 		};
+ 
+ 		opp-400000000 {
+ 			opp-hz = /bits/ 64 <400000000>;
+-			opp-microvolt = <700000 700000 850000>;
++			opp-microvolt = <712500 712500 875000>;
+ 		};
+ 
+ 		opp-500000000 {
+ 			opp-hz = /bits/ 64 <500000000>;
+-			opp-microvolt = <700000 700000 850000>;
++			opp-microvolt = <712500 712500 875000>;
+ 		};
+ 
+ 		opp-600000000 {
+ 			opp-hz = /bits/ 64 <600000000>;
+-			opp-microvolt = <700000 700000 850000>;
++			opp-microvolt = <712500 712500 875000>;
+ 		};
+ 
+ 		opp-700000000 {
+ 			opp-hz = /bits/ 64 <700000000>;
+-			opp-microvolt = <725000 725000 850000>;
++			opp-microvolt = <750000 750000 875000>;
+ 		};
+ 
+ 		opp-800000000 {
+ 			opp-hz = /bits/ 64 <800000000>;
+-			opp-microvolt = <775000 775000 850000>;
++			opp-microvolt = <812500 812500 875000>;
+ 		};
+ 
+ 		opp-900000000 {
+ 			opp-hz = /bits/ 64 <900000000>;
+-			opp-microvolt = <825000 825000 850000>;
+-		};
+-
+-		opp-950000000 {
+-			opp-hz = /bits/ 64 <950000000>;
+-			opp-microvolt = <850000 850000 850000>;
++			opp-microvolt = <875000 875000 875000>;
+ 		};
+ 	};
+ 
+@@ -1264,10 +1265,10 @@ power-domain@RK3576_PD_VO1 {
+ 		gpu: gpu@27800000 {
+ 			compatible = "rockchip,rk3576-mali", "arm,mali-bifrost";
+ 			reg = <0x0 0x27800000 0x0 0x20000>;
+-			assigned-clocks = <&scmi_clk SCMI_CLK_GPU>;
+-			assigned-clock-rates = <198000000>;
+-			clocks = <&cru CLK_GPU>;
+-			clock-names = "core";
++			assigned-clocks = <&cru CLK_GPU>, <&scmi_clk SCMI_CLK_GPU>;
++			assigned-clock-rates = <198000000>, <200000000>;
++			clocks = <&scmi_clk SCMI_CLK_GPU>, <&cru CLK_GPU>;
++			clock-names = "gpu", "bus";
+ 			dynamic-power-coefficient = <1625>;
+ 			interrupts = <GIC_SPI 347 IRQ_TYPE_LEVEL_HIGH>,
+ 				     <GIC_SPI 348 IRQ_TYPE_LEVEL_HIGH>,
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+index fc1fdbfd3162..afa3a52acfd8 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -450,11 +450,11 @@ gpu: gpu@fb000000 {
+ 		compatible = "rockchip,rk3588-mali", "arm,mali-valhall-csf";
+ 		reg = <0x0 0xfb000000 0x0 0x200000>;
+ 		#cooling-cells = <2>;
+-		assigned-clocks = <&scmi_clk SCMI_CLK_GPU>;
+-		assigned-clock-rates = <200000000>;
+-		clocks = <&cru CLK_GPU>, <&cru CLK_GPU_COREGROUP>,
+-			 <&cru CLK_GPU_STACKS>;
+-		clock-names = "core", "coregroup", "stacks";
++		assigned-clocks = <&cru CLK_GPU>, <&scmi_clk SCMI_CLK_GPU>;
++		assigned-clock-rates = <198000000>, <200000000>;
++		clocks = <&scmi_clk SCMI_CLK_GPU>, <&cru CLK_GPU_COREGROUP>,
++			 <&cru CLK_GPU_STACKS>, <&cru CLK_GPU>;
++		clock-names = "core", "coregroup", "stacks", "bus";
+ 		dynamic-power-coefficient = <2982>;
+ 		interrupts = <GIC_SPI 92 IRQ_TYPE_LEVEL_HIGH 0>,
+ 			     <GIC_SPI 93 IRQ_TYPE_LEVEL_HIGH 0>,
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-opp.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-opp.dtsi
+index b5d630d2c879..921b1977223a 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-opp.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-opp.dtsi
+@@ -118,6 +118,11 @@ opp-2400000000 {
+ 	gpu_opp_table: opp-table-gpu {
+ 		compatible = "operating-points-v2";
+ 
++		opp-200000000 {
++			opp-hz = /bits/ 64 <200000000>;
++			opp-microvolt = <675000 675000 850000>;
++			opp-suspend;
++		};
+ 		opp-300000000 {
+ 			opp-hz = /bits/ 64 <300000000>;
+ 			opp-microvolt = <675000 675000 850000>;
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588j.dtsi b/arch/arm64/boot/dts/rockchip/rk3588j.dtsi
+index e1e0e3fc0ca7..1ca74d4fb1cd 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588j.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588j.dtsi
+@@ -69,6 +69,11 @@ opp-1608000000 {
+ 	gpu_opp_table: opp-table-gpu {
+ 		compatible = "operating-points-v2";
+ 
++		opp-200000000 {
++			opp-hz = /bits/ 64 <200000000>;
++			opp-microvolt = <750000 750000 850000>;
++			opp-suspend;
++		};
+ 		opp-300000000 {
+ 			opp-hz = /bits/ 64 <300000000>;
+ 			opp-microvolt = <750000 750000 850000>;
+diff --git a/drivers/clk/rockchip/clk-rk3576.c b/drivers/clk/rockchip/clk-rk3576.c
+index 2557358e0b9d..f903737a1a2b 100644
+--- a/drivers/clk/rockchip/clk-rk3576.c
++++ b/drivers/clk/rockchip/clk-rk3576.c
+@@ -912,7 +912,7 @@ static struct rockchip_clk_branch rk3576_clk_branches[] __initdata = {
+ 			RK3576_CLKGATE_CON(69), 1, GFLAGS),
+ 	GATE(CLK_GPU, "clk_gpu", "clk_gpu_src_pre", 0,
+ 			RK3576_CLKGATE_CON(69), 3, GFLAGS),
+-	COMPOSITE_NODIV(PCLK_GPU_ROOT, "pclk_gpu_root", mux_100m_50m_24m_p, 0,
++	COMPOSITE_NODIV(PCLK_GPU_ROOT, "pclk_gpu_root", mux_100m_50m_24m_p, CLK_IS_CRITICAL,
+ 			RK3576_CLKSEL_CON(166), 10, 2, MFLAGS,
+ 			RK3576_CLKGATE_CON(69), 8, GFLAGS),
+ 
+diff --git a/drivers/gpu/drm/lima/lima_devfreq.c b/drivers/gpu/drm/lima/lima_devfreq.c
+index bc8fb4e38d0a..303da7ed09a8 100644
+--- a/drivers/gpu/drm/lima/lima_devfreq.c
++++ b/drivers/gpu/drm/lima/lima_devfreq.c
+@@ -11,6 +11,7 @@
+ #include <linux/device.h>
+ #include <linux/platform_device.h>
+ #include <linux/pm_opp.h>
++#include <linux/pm_runtime.h>
+ #include <linux/property.h>
+ 
+ #include "lima_device.h"
+@@ -87,6 +88,41 @@ static struct devfreq_dev_profile lima_devfreq_profile = {
+ 	.get_dev_status = lima_devfreq_get_dev_status,
+ };
+ 
++static int lima_devfreq_config_clks(struct device *dev,
++				    struct opp_table *opp_table,
++				    struct dev_pm_opp *opp,
++				    void *data, bool scaling_down)
++{
++	struct lima_device *ldev = dev_get_drvdata(dev);
++	struct devfreq *devfreq = ldev->devfreq.devfreq;
++	unsigned long *target = data;
++	unsigned long freq;
++	int ret = 0;
++
++	/* One of target and opp must be available */
++	if (target) {
++		freq = *target;
++	} else if (opp) {
++		freq = dev_pm_opp_get_freq(opp);
++	} else {
++		WARN_ON(1);
++		return -EINVAL;
++	}
++
++	pm_runtime_get_noresume(dev);
++
++	if (!pm_runtime_suspended(dev) || !devfreq || !devfreq->suspend_freq) {
++		ret = clk_set_rate(ldev->clk_gpu, freq);
++		if (ret)
++			dev_err(dev, "failed to set clock rate %lu: %d\n",
++				freq, ret);
++	}
++
++	pm_runtime_put_noidle(dev);
++
++	return ret;
++}
++
+ void lima_devfreq_fini(struct lima_device *ldev)
+ {
+ 	struct lima_devfreq *devfreq = &ldev->devfreq;
+@@ -112,6 +148,11 @@ int lima_devfreq_init(struct lima_device *ldev)
+ 	unsigned long cur_freq;
+ 	int ret;
+ 	const char *regulator_names[] = { "mali", NULL };
++	const char *clk_names[] = { "core", NULL };
++	struct dev_pm_opp_config config = {
++		.clk_names = clk_names,
++		.config_clks = lima_devfreq_config_clks,
++	};
+ 
+ 	if (!device_property_present(dev, "operating-points-v2"))
+ 		/* Optional, continue without devfreq */
+@@ -123,7 +164,7 @@ int lima_devfreq_init(struct lima_device *ldev)
+ 	 * clkname is set separately so it is not affected by the optional
+ 	 * regulator setting which may return error.
+ 	 */
+-	ret = devm_pm_opp_set_clkname(dev, "core");
++	ret = devm_pm_opp_set_config(dev, &config);
+ 	if (ret)
+ 		return ret;
+ 
+diff --git a/drivers/gpu/drm/panfrost/panfrost_devfreq.c b/drivers/gpu/drm/panfrost/panfrost_devfreq.c
+index b51c30778811..d6b2154fb3c6 100644
+--- a/drivers/gpu/drm/panfrost/panfrost_devfreq.c
++++ b/drivers/gpu/drm/panfrost/panfrost_devfreq.c
+@@ -7,6 +7,7 @@
+ #include <linux/nvmem-consumer.h>
+ #include <linux/platform_device.h>
+ #include <linux/pm_opp.h>
++#include <linux/pm_runtime.h>
+ 
+ #include <drm/drm_print.h>
+ 
+@@ -91,6 +92,41 @@ static struct devfreq_dev_profile panfrost_devfreq_profile = {
+ 	.get_dev_status = panfrost_devfreq_get_dev_status,
+ };
+ 
++static int panfrost_devfreq_config_clks(struct device *dev,
++					struct opp_table *opp_table,
++					struct dev_pm_opp *opp,
++					void *data, bool scaling_down)
++{
++	struct panfrost_device *pfdev = dev_get_drvdata(dev);
++	struct devfreq *devfreq = pfdev->pfdevfreq.devfreq;
++	unsigned long *target = data;
++	unsigned long freq;
++	int ret = 0;
++
++	/* One of target and opp must be available */
++	if (target) {
++		freq = *target;
++	} else if (opp) {
++		freq = dev_pm_opp_get_freq(opp);
++	} else {
++		WARN_ON(1);
++		return -EINVAL;
++	}
++
++	pm_runtime_get_noresume(dev);
++
++	if (!pm_runtime_suspended(dev) || !devfreq || !devfreq->suspend_freq) {
++		ret = clk_set_rate(pfdev->clock, freq);
++		if (ret)
++			dev_err(dev, "failed to set clock rate %lu: %d\n",
++				freq, ret);
++	}
++
++	pm_runtime_put_noidle(dev);
++
++	return ret;
++}
++
+ static int panfrost_read_speedbin(struct device *dev)
+ {
+ 	u32 val;
+@@ -140,6 +176,17 @@ int panfrost_devfreq_init(struct panfrost_device *pfdev)
+ 	if (ret)
+ 		return ret;
+ 
++	if (pfdev->comp->opp_clk_names) {
++		struct dev_pm_opp_config config = {
++			.clk_names = pfdev->comp->opp_clk_names,
++			.config_clks = panfrost_devfreq_config_clks,
++		};
++
++		ret = devm_pm_opp_set_config(dev, &config);
++		if (ret)
++			return ret;
++	}
++
+ 	ret = devm_pm_opp_set_regulators(dev, pfdev->comp->supply_names);
+ 	if (ret) {
+ 		/* Continue if the optional regulator is missing */
+diff --git a/drivers/gpu/drm/panfrost/panfrost_device.h b/drivers/gpu/drm/panfrost/panfrost_device.h
+index ec55c136b1b6..91e4fa2061a7 100644
+--- a/drivers/gpu/drm/panfrost/panfrost_device.h
++++ b/drivers/gpu/drm/panfrost/panfrost_device.h
+@@ -107,6 +107,10 @@ struct panfrost_compatible {
+ 	/* Only required if num_pm_domains > 1. */
+ 	const char * const *pm_domain_names;
+ 
++	/* OPP clock count and names. */
++	int num_opp_clocks;
++	const char * const *opp_clk_names;
++
+ 	/* Vendor implementation quirks callback */
+ 	void (*vendor_quirk)(struct panfrost_device *pfdev);
+ 
+diff --git a/drivers/gpu/drm/panfrost/panfrost_drv.c b/drivers/gpu/drm/panfrost/panfrost_drv.c
+index 784e36d72c2b..8dcd0188b299 100644
+--- a/drivers/gpu/drm/panfrost/panfrost_drv.c
++++ b/drivers/gpu/drm/panfrost/panfrost_drv.c
+@@ -1152,6 +1152,17 @@ static const struct panfrost_compatible mediatek_mt8370_data = {
+ 	.gpu_quirks = BIT(GPU_QUIRK_FORCE_AARCH64_PGTABLE),
+ };
+ 
++static const char * const rockchip_opp_clks[] = { "gpu", NULL };
++static const struct panfrost_compatible rockchip_data = {
++	.num_supplies = ARRAY_SIZE(default_supplies) - 1,
++	.supply_names = default_supplies,
++	.num_pm_domains = 1,
++	.pm_domain_names = NULL,
++	.num_opp_clocks = ARRAY_SIZE(rockchip_opp_clks) - 1,
++	.opp_clk_names = rockchip_opp_clks,
++	.pm_features = BIT(GPU_PM_CLK_DIS) | BIT(GPU_PM_VREG_OFF),
++};
++
+ static const struct of_device_id dt_match[] = {
+ 	/* Set first to probe before the generic compatibles */
+ 	{ .compatible = "amlogic,meson-gxm-mali",
+@@ -1178,6 +1189,8 @@ static const struct of_device_id dt_match[] = {
+ 	{ .compatible = "mediatek,mt8192-mali", .data = &mediatek_mt8192_data },
+ 	{ .compatible = "mediatek,mt8370-mali", .data = &mediatek_mt8370_data },
+ 	{ .compatible = "allwinner,sun50i-h616-mali", .data = &default_pm_rt_data },
++	{ .compatible = "rockchip,rk3568-mali", .data = &rockchip_data },
++	{ .compatible = "rockchip,rk3576-mali", .data = &rockchip_data },
+ 	{}
+ };
+ MODULE_DEVICE_TABLE(of, dt_match);
+diff --git a/drivers/gpu/drm/panthor/panthor_devfreq.c b/drivers/gpu/drm/panthor/panthor_devfreq.c
+index 2249b41ca4af..4529c79e5388 100644
+--- a/drivers/gpu/drm/panthor/panthor_devfreq.c
++++ b/drivers/gpu/drm/panthor/panthor_devfreq.c
+@@ -130,6 +130,41 @@ static struct devfreq_dev_profile panthor_devfreq_profile = {
+ 	.get_cur_freq = panthor_devfreq_get_cur_freq,
+ };
+ 
++static int panthor_devfreq_config_clks(struct device *dev,
++				       struct opp_table *opp_table,
++				       struct dev_pm_opp *opp,
++				       void *data, bool scaling_down)
++{
++	struct panthor_device *ptdev = dev_get_drvdata(dev);
++	struct devfreq *devfreq = ptdev->devfreq->devfreq;
++	unsigned long *target = data;
++	unsigned long freq;
++	int ret = 0;
++
++	/* One of target and opp must be available */
++	if (target) {
++		freq = *target;
++	} else if (opp) {
++		freq = dev_pm_opp_get_freq(opp);
++	} else {
++		WARN_ON(1);
++		return -EINVAL;
++	}
++
++	pm_runtime_get_noresume(dev);
++
++	if (!pm_runtime_suspended(dev) || !devfreq || !devfreq->suspend_freq) {
++		ret = clk_set_rate(ptdev->clks.core, freq);
++		if (ret)
++			dev_err(dev, "failed to set clock rate %lu: %d\n",
++				freq, ret);
++	}
++
++	pm_runtime_put_noidle(dev);
++
++	return ret;
++}
++
+ int panthor_devfreq_init(struct panthor_device *ptdev)
+ {
+ 	/* There's actually 2 regulators (mali and sram), but the OPP core only
+@@ -139,6 +174,11 @@ int panthor_devfreq_init(struct panthor_device *ptdev)
+ 	 * the coupling logic deal with voltage updates.
+ 	 */
+ 	static const char * const reg_names[] = { "mali", NULL };
++	static const char * const clk_names[] = { "core", NULL };
++	struct dev_pm_opp_config config = {
++		.clk_names = clk_names,
++		.config_clks = panthor_devfreq_config_clks,
++	};
+ 	struct thermal_cooling_device *cooling;
+ 	struct device *dev = ptdev->base.dev;
+ 	struct panthor_devfreq *pdevfreq;
+@@ -164,6 +204,10 @@ int panthor_devfreq_init(struct panthor_device *ptdev)
+ 	 */
+ 	table = dev_pm_opp_get_opp_table(dev);
+ 	if (IS_ERR_OR_NULL(table)) {
++		ret = devm_pm_opp_set_config(dev, &config);
++		if (ret)
++			return ret;
++
+ 		ret = devm_pm_opp_set_regulators(dev, reg_names);
+ 		if (ret && ret != -ENODEV) {
+ 			if (ret != -EPROBE_DEFER)
+diff --git a/drivers/gpu/drm/panthor/panthor_device.c b/drivers/gpu/drm/panthor/panthor_device.c
+index bd417d6ae8c0..9a3c50932998 100644
+--- a/drivers/gpu/drm/panthor/panthor_device.c
++++ b/drivers/gpu/drm/panthor/panthor_device.c
+@@ -47,6 +47,12 @@ static int panthor_clk_init(struct panthor_device *ptdev)
+ 				     PTR_ERR(ptdev->clks.coregroup),
+ 				     "get 'coregroup' clock failed");
+ 
++	ptdev->clks.bus = devm_clk_get_optional(ptdev->base.dev, "bus");
++	if (IS_ERR(ptdev->clks.bus))
++		return dev_err_probe(ptdev->base.dev,
++				     PTR_ERR(ptdev->clks.bus),
++				     "get 'bus' clock failed");
++
+ 	drm_info(&ptdev->base, "clock rate = %lu\n", clk_get_rate(ptdev->clks.core));
+ 	return 0;
+ }
+@@ -492,10 +498,14 @@ int panthor_device_resume(struct device *dev)
+ 
+ 	atomic_set(&ptdev->pm.state, PANTHOR_DEVICE_PM_STATE_RESUMING);
+ 
+-	ret = clk_prepare_enable(ptdev->clks.core);
++	ret = clk_prepare_enable(ptdev->clks.bus);
+ 	if (ret)
+ 		goto err_set_suspended;
+ 
++	ret = clk_prepare_enable(ptdev->clks.core);
++	if (ret)
++		goto err_disable_bus_clk;
++
+ 	ret = clk_prepare_enable(ptdev->clks.stacks);
+ 	if (ret)
+ 		goto err_disable_core_clk;
+@@ -554,6 +564,9 @@ int panthor_device_resume(struct device *dev)
+ err_disable_core_clk:
+ 	clk_disable_unprepare(ptdev->clks.core);
+ 
++err_disable_bus_clk:
++	clk_disable_unprepare(ptdev->clks.bus);
++
+ err_set_suspended:
+ 	atomic_set(&ptdev->pm.state, PANTHOR_DEVICE_PM_STATE_SUSPENDED);
+ 	atomic_set(&ptdev->pm.recovery_needed, 1);
+@@ -601,6 +614,7 @@ int panthor_device_suspend(struct device *dev)
+ 	clk_disable_unprepare(ptdev->clks.coregroup);
+ 	clk_disable_unprepare(ptdev->clks.stacks);
+ 	clk_disable_unprepare(ptdev->clks.core);
++	clk_disable_unprepare(ptdev->clks.bus);
+ 	atomic_set(&ptdev->pm.state, PANTHOR_DEVICE_PM_STATE_SUSPENDED);
+ 	return 0;
+ }
+diff --git a/drivers/gpu/drm/panthor/panthor_device.h b/drivers/gpu/drm/panthor/panthor_device.h
+index a412a50eec76..d97a3d292e3a 100644
+--- a/drivers/gpu/drm/panthor/panthor_device.h
++++ b/drivers/gpu/drm/panthor/panthor_device.h
+@@ -142,6 +142,9 @@ struct panthor_device {
+ 
+ 	/** @clks: GPU clocks. */
+ 	struct {
++		/** @bus: Bus clock. This clock is optional. */
++		struct clk *bus;
++
+ 		/** @core: Core clock. */
+ 		struct clk *core;
+ 


### PR DESCRIPTION
This was long time coming, and Collabora isn't going to tackle this anytime soon, so we're just going to adopt @Kwiboo's patches (which were still in RFC state) from here: https://github.com/Kwiboo/linux-rockchip/commits/next-20250428-rk35xx-scmi-gpu-clk/ — but only for rk3588 for now, rebased and checked to compile and work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional Rockchip GPU variants and clock configurations.
  * Added improved GPU power and frequency handling for lower-speed operating states.

* **Bug Fixes**
  * Improved suspend/resume behavior and runtime power management for Rockchip GPUs.
  * Refined GPU voltage and clock settings to help stabilize performance and power use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->