### PR TITLE
genio: u-boot: mt8195 (nio-12l): update addr's map patch for large kernels/initrds

### DIFF
--- a/patch/u-boot/u-boot-genio/3306-GENIO-mt8195-fdt_addr_r-kernel_addr_r-ramdisk_addr_r-for-large-kernels-initrds.patch
+++ b/patch/u-boot/u-boot-genio/3306-GENIO-mt8195-fdt_addr_r-kernel_addr_r-ramdisk_addr_r-for-large-kernels-initrds.patch
@@ -4,46 +4,64 @@ Date: Mon, 5 Jan 2026 16:32:45 +0100
 Subject: GENIO: mt8195: fdt_addr_r/kernel_addr_r/ramdisk_addr_r for large
  kernels/initrds
 
-General purpose OS's like Armbian have some huge initrds and kernels, make space.
-- include pxefile_addr_r == scriptaddr at 0x40000000 so PXE works OOB
+Adapt the EXTRA_ENV load addresses (both SPI and non-SPI variants) to
+match the Armbian bootscript memory layout and keep every buffer in a
+distinct, collision-free region.
+Resulting layout (all 2 MB aligned, no overlaps, reserved holes avoided):
 
+  0x43000000  scriptaddr / pxefile_addr_r   (below 0x43200000 hole)
+  0x43200000  -- reserved -- 0x43DFFFFF
+  0x44000000  kernel_addr_r   -> up to 0x54600000   (262 MB)
+  0x54600000  -- reserved -- 0x547FFFFF
+  0x56000000  fdt_addr_r       (small DTB)
+  0x58000000  fdtoverlay_addr_r (32 MB above fdt, 128 MB below reserved)
+  0x60000000  -- reserved -- 0x61FFFFFF
+  0x64000000  ramdisk_addr_r  -> up to 0x83800000   (500 MB)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
 Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- include/configs/mt8195.h | 14 ++++++----
- 1 file changed, 8 insertions(+), 6 deletions(-)
+ include/configs/mt8195.h | 22 +++++-----
+ 1 file changed, 12 insertions(+), 10 deletions(-)
 
 diff --git a/include/configs/mt8195.h b/include/configs/mt8195.h
 index 111111111111..222222222222 100644
 --- a/include/configs/mt8195.h
 +++ b/include/configs/mt8195.h
-@@ -133,11 +133,12 @@
+@@ -132,12 +132,13 @@
+ #if !defined(CONFIG_EXTRA_ENV_SETTINGS)
  #if !IS_ENABLED(CONFIG_SPI_FLASH)
  #define CONFIG_EXTRA_ENV_SETTINGS \
- 	"scriptaddr=0x40000000\0" \
+-	"scriptaddr=0x40000000\0" \
 -	"fdt_addr_r=0x44000000\0" \
-+	"pxefile_addr_r=0x40000000\0" \
+-	"fdtoverlay_addr_r=0x44c00000\0" \
++	"scriptaddr=0x43000000\0" \
++	"pxefile_addr_r=0x43000000\0" \
 +	"fdt_addr_r=0x56000000\0" \
- 	"fdtoverlay_addr_r=0x44c00000\0" \
++	"fdtoverlay_addr_r=0x58000000\0" \
  	"fdt_resize=0x3000\0" \
 -	"kernel_addr_r=0x45000000\0" \
 -	"ramdisk_addr_r=0x49000000\0" \
-+	"kernel_addr_r=0x40000000\0" \
++	"kernel_addr_r=0x44000000\0" \
 +	"ramdisk_addr_r=0x64000000\0" \
  	"fdtfile=" CONFIG_DEFAULT_FDT_FILE ".dtb\0" \
  	"splashimage=" __stringify(CONFIG_SYS_LOAD_ADDR) "\0" \
  	"splashsource=mmc_fs\0" \
-@@ -148,11 +149,12 @@
+@@ -147,12 +148,13 @@
+ 	BOOTENV
  #else
  #define CONFIG_EXTRA_ENV_SETTINGS \
- 	"scriptaddr=0x40000000\0" \
+-	"scriptaddr=0x40000000\0" \
 -	"fdt_addr_r=0x44000000\0" \
-+	"pxefile_addr_r=0x40000000\0" \
+-	"fdtoverlay_addr_r=0x44c00000\0" \
++	"scriptaddr=0x43000000\0" \
++	"pxefile_addr_r=0x43000000\0" \
 +	"fdt_addr_r=0x56000000\0" \
- 	"fdtoverlay_addr_r=0x44c00000\0" \
++	"fdtoverlay_addr_r=0x58000000\0" \
  	"fdt_resize=0x3000\0" \
 -	"kernel_addr_r=0x45000000\0" \
 -	"ramdisk_addr_r=0x49000000\0" \
-+	"kernel_addr_r=0x40000000\0" \
++	"kernel_addr_r=0x44000000\0" \
 +	"ramdisk_addr_r=0x64000000\0" \
  	"fdtfile=" CONFIG_DEFAULT_FDT_FILE ".dtb\0" \
  	"splashimage=" __stringify(CONFIG_SYS_LOAD_ADDR) "\0" \


### PR DESCRIPTION
- 🌱 for extlinux/pxelinux scenarios (matching recently-updated bootscript boot.scr for genio)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted boot memory addresses for GENIO mt8195 to better support larger kernels and initrds.
  * Reduced the risk of boot-time memory overlap by moving key load locations to non-conflicting areas.
  * Updated boot settings so script, kernel, device tree, overlay, and ramdisk loading are aligned with the newer layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->