### PR TITLE
kernel/rockchip64: fix RK3588 I2S MCLK clk_disable_unused regression

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/general-rk3588-i2s-mclk-output-gate-5-ignore-unused.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-rk3588-i2s-mclk-output-gate-5-ignore-unused.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 27 Jun 2026 12:00:00 +0200
+Subject: clk: rockchip: rk3588: don't disable unused I2S MCLK output gates
+
+No in-tree board references these gates yet. Boards drive the codec
+MCLK through the parent I2S*_8CH_MCLKOUT, and now that the gates are
+managed clocks, clk_disable_unused() turns them off at boot. On a board
+that relied on firmware leaving the output enabled, that cuts the MCLK
+and analog audio stops working.
+
+Mark the four gates CLK_IGNORE_UNUSED so an unreferenced gate keeps the
+state firmware left. A board that wants the kernel to own the gate can
+reference I2S*_8CH_MCLKOUT_TO_IO from DT instead.
+
+Upstream: https://lore.kernel.org/linux-rockchip/20260624123914.1767374-1-hello@superkali.me/
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ drivers/clk/rockchip/clk-rk3588.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/clk/rockchip/clk-rk3588.c b/drivers/clk/rockchip/clk-rk3588.c
+index 2cc85fb..169ed47 100644
+--- a/drivers/clk/rockchip/clk-rk3588.c
++++ b/drivers/clk/rockchip/clk-rk3588.c
+@@ -896,7 +896,7 @@ static struct rockchip_clk_branch rk3588_early_clk_branches[] __initdata = {
+ 	MUX(I2S2_2CH_MCLKOUT, "i2s2_2ch_mclkout", i2s2_2ch_mclkout_p, CLK_SET_RATE_PARENT,
+ 			RK3588_CLKSEL_CON(30), 2, 1, MFLAGS),
+ 	GATE_GRF(I2S2_2CH_MCLKOUT_TO_IO, "i2s2_2ch_mclkout_to_io", "i2s2_2ch_mclkout",
+-			0, RK3588_SYSGRF_SOC_CON6, 2, GFLAGS, grf_type_sys),
++			CLK_IGNORE_UNUSED, RK3588_SYSGRF_SOC_CON6, 2, GFLAGS, grf_type_sys),
+ 
+ 	COMPOSITE(CLK_I2S3_2CH_SRC, "clk_i2s3_2ch_src", gpll_aupll_p, 0,
+ 			RK3588_CLKSEL_CON(30), 8, 1, MFLAGS, 3, 5, DFLAGS,
+@@ -913,7 +913,7 @@ static struct rockchip_clk_branch rk3588_early_clk_branches[] __initdata = {
+ 	MUX(I2S3_2CH_MCLKOUT, "i2s3_2ch_mclkout", i2s3_2ch_mclkout_p, CLK_SET_RATE_PARENT,
+ 			RK3588_CLKSEL_CON(32), 2, 1, MFLAGS),
+ 	GATE_GRF(I2S3_2CH_MCLKOUT_TO_IO, "i2s3_2ch_mclkout_to_io", "i2s3_2ch_mclkout",
+-			0, RK3588_SYSGRF_SOC_CON6, 7, GFLAGS, grf_type_sys),
++			CLK_IGNORE_UNUSED, RK3588_SYSGRF_SOC_CON6, 7, GFLAGS, grf_type_sys),
+ 	GATE(PCLK_ACDCDIG, "pclk_acdcdig", "pclk_audio_root", 0,
+ 			RK3588_CLKGATE_CON(7), 11, GFLAGS),
+ 	GATE(HCLK_I2S0_8CH, "hclk_i2s0_8ch", "hclk_audio_root", 0,
+@@ -943,7 +943,7 @@ static struct rockchip_clk_branch rk3588_early_clk_branches[] __initdata = {
+ 	MUX(I2S0_8CH_MCLKOUT, "i2s0_8ch_mclkout", i2s0_8ch_mclkout_p, CLK_SET_RATE_PARENT,
+ 			RK3588_CLKSEL_CON(28), 2, 2, MFLAGS),
+ 	GATE_GRF(I2S0_8CH_MCLKOUT_TO_IO, "i2s0_8ch_mclkout_to_io", "i2s0_8ch_mclkout",
+-			0, RK3588_SYSGRF_SOC_CON6, 0, GFLAGS, grf_type_sys),
++			CLK_IGNORE_UNUSED, RK3588_SYSGRF_SOC_CON6, 0, GFLAGS, grf_type_sys),
+ 
+ 	GATE(HCLK_PDM1, "hclk_pdm1", "hclk_audio_root", 0,
+ 			RK3588_CLKGATE_CON(9), 6, GFLAGS),
+@@ -2230,7 +2230,7 @@ static struct rockchip_clk_branch rk3588_early_clk_branches[] __initdata = {
+ 	MUX(I2S1_8CH_MCLKOUT, "i2s1_8ch_mclkout", i2s1_8ch_mclkout_p, CLK_SET_RATE_PARENT,
+ 			RK3588_PMU_CLKSEL_CON(9), 2, 2, MFLAGS),
+ 	GATE_GRF(I2S1_8CH_MCLKOUT_TO_IO, "i2s1_8ch_mclkout_to_io", "i2s1_8ch_mclkout",
+-			0, RK3588_SYSGRF_SOC_CON6, 1, GFLAGS, grf_type_sys),
++			CLK_IGNORE_UNUSED, RK3588_SYSGRF_SOC_CON6, 1, GFLAGS, grf_type_sys),
+ 	GATE(PCLK_PMU1, "pclk_pmu1", "pclk_pmu0_root", CLK_IS_CRITICAL,
+ 			RK3588_PMU_CLKGATE_CON(1), 0, GFLAGS),
+ 	GATE(CLK_DDR_FAIL_SAFE, "clk_ddr_fail_safe", "clk_pmu0", CLK_IGNORE_UNUSED,
+-- 
+Armbian

--- a/patch/kernel/archive/rockchip64-7.1/general-rk3588-i2s-mclk-output-gate-5-ignore-unused.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-rk3588-i2s-mclk-output-gate-5-ignore-unused.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 27 Jun 2026 12:00:00 +0200
+Subject: clk: rockchip: rk3588: don't disable unused I2S MCLK output gates
+
+No in-tree board references these gates yet. Boards drive the codec
+MCLK through the parent I2S*_8CH_MCLKOUT, and now that the gates are
+managed clocks, clk_disable_unused() turns them off at boot. On a board
+that relied on firmware leaving the output enabled, that cuts the MCLK
+and analog audio stops working.
+
+Mark the four gates CLK_IGNORE_UNUSED so an unreferenced gate keeps the
+state firmware left. A board that wants the kernel to own the gate can
+reference I2S*_8CH_MCLKOUT_TO_IO from DT instead.
+
+Upstream: https://lore.kernel.org/linux-rockchip/20260624123914.1767374-1-hello@superkali.me/
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ drivers/clk/rockchip/clk-rk3588.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/clk/rockchip/clk-rk3588.c b/drivers/clk/rockchip/clk-rk3588.c
+index 2cc85fb..169ed47 100644
+--- a/drivers/clk/rockchip/clk-rk3588.c
++++ b/drivers/clk/rockchip/clk-rk3588.c
+@@ -896,7 +896,7 @@ static struct rockchip_clk_branch rk3588_early_clk_branches[] __initdata = {
+ 	MUX(I2S2_2CH_MCLKOUT, "i2s2_2ch_mclkout", i2s2_2ch_mclkout_p, CLK_SET_RATE_PARENT,
+ 			RK3588_CLKSEL_CON(30), 2, 1, MFLAGS),
+ 	GATE_GRF(I2S2_2CH_MCLKOUT_TO_IO, "i2s2_2ch_mclkout_to_io", "i2s2_2ch_mclkout",
+-			0, RK3588_SYSGRF_SOC_CON6, 2, GFLAGS, grf_type_sys),
++			CLK_IGNORE_UNUSED, RK3588_SYSGRF_SOC_CON6, 2, GFLAGS, grf_type_sys),
+ 
+ 	COMPOSITE(CLK_I2S3_2CH_SRC, "clk_i2s3_2ch_src", gpll_aupll_p, 0,
+ 			RK3588_CLKSEL_CON(30), 8, 1, MFLAGS, 3, 5, DFLAGS,
+@@ -913,7 +913,7 @@ static struct rockchip_clk_branch rk3588_early_clk_branches[] __initdata = {
+ 	MUX(I2S3_2CH_MCLKOUT, "i2s3_2ch_mclkout", i2s3_2ch_mclkout_p, CLK_SET_RATE_PARENT,
+ 			RK3588_CLKSEL_CON(32), 2, 1, MFLAGS),
+ 	GATE_GRF(I2S3_2CH_MCLKOUT_TO_IO, "i2s3_2ch_mclkout_to_io", "i2s3_2ch_mclkout",
+-			0, RK3588_SYSGRF_SOC_CON6, 7, GFLAGS, grf_type_sys),
++			CLK_IGNORE_UNUSED, RK3588_SYSGRF_SOC_CON6, 7, GFLAGS, grf_type_sys),
+ 	GATE(PCLK_ACDCDIG, "pclk_acdcdig", "pclk_audio_root", 0,
+ 			RK3588_CLKGATE_CON(7), 11, GFLAGS),
+ 	GATE(HCLK_I2S0_8CH, "hclk_i2s0_8ch", "hclk_audio_root", 0,
+@@ -943,7 +943,7 @@ static struct rockchip_clk_branch rk3588_early_clk_branches[] __initdata = {
+ 	MUX(I2S0_8CH_MCLKOUT, "i2s0_8ch_mclkout", i2s0_8ch_mclkout_p, CLK_SET_RATE_PARENT,
+ 			RK3588_CLKSEL_CON(28), 2, 2, MFLAGS),
+ 	GATE_GRF(I2S0_8CH_MCLKOUT_TO_IO, "i2s0_8ch_mclkout_to_io", "i2s0_8ch_mclkout",
+-			0, RK3588_SYSGRF_SOC_CON6, 0, GFLAGS, grf_type_sys),
++			CLK_IGNORE_UNUSED, RK3588_SYSGRF_SOC_CON6, 0, GFLAGS, grf_type_sys),
+ 
+ 	GATE(HCLK_PDM1, "hclk_pdm1", "hclk_audio_root", 0,
+ 			RK3588_CLKGATE_CON(9), 6, GFLAGS),
+@@ -2230,7 +2230,7 @@ static struct rockchip_clk_branch rk3588_early_clk_branches[] __initdata = {
+ 	MUX(I2S1_8CH_MCLKOUT, "i2s1_8ch_mclkout", i2s1_8ch_mclkout_p, CLK_SET_RATE_PARENT,
+ 			RK3588_PMU_CLKSEL_CON(9), 2, 2, MFLAGS),
+ 	GATE_GRF(I2S1_8CH_MCLKOUT_TO_IO, "i2s1_8ch_mclkout_to_io", "i2s1_8ch_mclkout",
+-			0, RK3588_SYSGRF_SOC_CON6, 1, GFLAGS, grf_type_sys),
++			CLK_IGNORE_UNUSED, RK3588_SYSGRF_SOC_CON6, 1, GFLAGS, grf_type_sys),
+ 	GATE(PCLK_PMU1, "pclk_pmu1", "pclk_pmu0_root", CLK_IS_CRITICAL,
+ 			RK3588_PMU_CLKGATE_CON(1), 0, GFLAGS),
+ 	GATE(CLK_DDR_FAIL_SAFE, "clk_ddr_fail_safe", "clk_pmu0", CLK_IGNORE_UNUSED,
+-- 
+Armbian


### PR DESCRIPTION
# Description

The clk backport in `current`/`edge` registers the four RK3588 I2S MCLK output gates (`i2s{0,1,2,3}_*_mclkout_to_io`, SYS_GRF SOC_CON6) as managed clocks with flag `0`. No in-tree board references them, so `clk_disable_unused()` switches them off at boot. On a board whose firmware leaves the gate at its reset-default open state, that cuts MCLK to the codec and audio goes silent.

Marking the four gates `CLK_IGNORE_UNUSED` leaves an unreferenced gate in the state firmware set instead of switching it off. The same change is upstream under review: https://lore.kernel.org/linux-rockchip/20260624123914.1767374-1-hello@superkali.me/

Added as `general-rk3588-i2s-mclk-output-gate-5-ignore-unused.patch` on rockchip64-6.18 and rockchip64-7.1, the two branches that carry the gate series.

Closes https://github.com/armbian/build/issues/10047

# How Has This Been Tested?

- [x] `git apply --check` on the real post-series `clk-rk3588.c` for the linux-6.18.y and 7.0.y bases: applies clean.
- [x] Upstream the same change carries Tested-by Diederik de Haas and Ricardo Pardini (NanoPC-T6-LTS regression reproduced and fixed, R58X-Pro still good), Reviewed-by Sebastian Reichel.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved firmware-set I2S MCLK output gate states on RK3588 boards during boot, preventing these clocks from being turned off unexpectedly.
  * Improved audio-related clock handling for affected RK3588 systems, helping avoid boot-time changes to MCLK output behavior.
  * Boards that need kernel-managed control can still enable the clocks through standard hardware configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->