### PR TITLE
gha: fix announce on push

### DIFF
--- a/.github/workflows/maintenance-announce-merge.yml
+++ b/.github/workflows/maintenance-announce-merge.yml
@@ -19,7 +19,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Send push to Discord
         run: |
+          COMMIT_MSG="$(git show -s --format=%s)"
+          # Escape quotes and backslashes for JSON
+          COMMIT_MSG_ESCAPED=$(echo "$COMMIT_MSG" | sed 's/\\/\\\\/g; s/"/\\"/g')
           curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X POST --data \
           "{\"username\": \"Github\", \"avatar_url\": \"${{ secrets.AVATARURL }}\", \"content\": \"\
           :white_check_mark: **Merged** into [$GITHUB_REPOSITORY](<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY>) by [$GITHUB_ACTOR](<$GITHUB_SERVER_URL/$GITHUB_ACTOR>) - \
-          [Link](<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA>): *$(git show -s --format=%s)*\"}" ${{ secrets.WEBHOOKURL }}
+          [Link](<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA>): *$COMMIT_MSG_ESCAPED*\"}" "${{ secrets.WEBHOOKURL }}"


### PR DESCRIPTION
Commit messages containing quotes breaking json, causing the announce to silently fail.
Only dry-run tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the formatting of Discord merge notifications to safely handle special characters in commit messages.
  * Reduced the risk of malformed notification payloads when merge titles include quotes or backslashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->