### PR TITLE
gha-matrix: add short hash-free `name` to matrix items for job labels

### DIFF
--- a/lib/tools/info/output-gha-matrix.py
+++ b/lib/tools/info/output-gha-matrix.py
@@ -87,6 +87,8 @@ def generate_matrix_images(info) -> list[dict]:
 			continue
 
 		desc = f"{image['image_file_id']} {image_id}"
+		# Short, hash-free label for the GHA job name (desc keeps the full id for logs).
+		name = image['image_file_id']
 
 		inputs = image['in']
 
@@ -96,7 +98,7 @@ def generate_matrix_images(info) -> list[dict]:
 		cmds = (armbian_utils.map_to_armbian_params(inputs["vars"], True) + inputs["configs"])  # image build is "build" command, omitted here
 		invocation = " ".join(cmds)
 
-		item = {"desc": desc, "runs_on": runs_on, "invocation": invocation}
+		item = {"desc": desc, "name": name, "runs_on": runs_on, "invocation": invocation}
 		matrix.append(item)
 	return matrix
 
@@ -113,6 +115,8 @@ def generate_matrix_artifacts(info):
 		artifact_name = artifact['in']['artifact_name']
 
 		desc = f"{artifact['out']['artifact_name']}={artifact['out']['artifact_version']}"
+		# Short, hash-free label for the GHA job name (desc keeps name=version+hashes).
+		name = artifact['out']['artifact_name']
 
 		inputs = artifact['in']['original_inputs']
 
@@ -127,7 +131,7 @@ def generate_matrix_artifacts(info):
 		cmds = (["artifact"] + armbian_utils.map_to_armbian_params(inputs["vars"], True) + inputs["configs"])
 		invocation = " ".join(cmds)
 
-		item = {"desc": desc, "runs_on": runs_on, "invocation": invocation}
+		item = {"desc": desc, "name": name, "runs_on": runs_on, "invocation": invocation}
 		matrix.append(item)
 	return matrix
 
@@ -187,7 +191,7 @@ for i, chunk in enumerate(chunks):
 	if len(chunk) == 0:
 		log.warning(f"Chunk '{i + 1}' for '{type_gen}' is empty, adding fake invocation.")
 		chunks[i] = [
-			{"desc": "Fake matrix element so matrix is not empty", "runs_on": "ubuntu-latest", "invocation": "none", "really": "no",
+			{"desc": "Fake matrix element so matrix is not empty", "name": "Empty chunk", "runs_on": "ubuntu-latest", "invocation": "none", "really": "no",
 			 "shost": "no", "fdepth": "1"}
 		]
 	else:


### PR DESCRIPTION
## What

Adds a short, hash-free `name` field to every `gha-matrix` item so workflows can label jobs readably.

Today the GHA job name is `matrix.desc`, which for artifacts is `name=version` where `version` carries the source/patch/config/revision content hashes:

```
uboot-bananapim7-vendor=2017.09-S39cd-P1ff0-H40c4-V34e5-B8ca9-R448a
```

Those hashes are the OCI cache identity (needed for the build), but in the Actions UI they're just noise and wrap across lines.

## Change

[`lib/tools/info/output-gha-matrix.py`](lib/tools/info/output-gha-matrix.py) — add `name` to each matrix item:
- artifacts → `artifact['out']['artifact_name']` (e.g. `uboot-bananapim7-vendor`)
- images → `image['image_file_id']`
- fake/empty-chunk filler → `"Empty chunk"`

Workflows can then use `${{ matrix.name }}` for the job label while `desc`/`invocation` keep the full hashed identity for logs and the build.

## Backward compatibility

Purely additive. `desc`, `runs_on`, `invocation`, `fdepth`, etc. are unchanged, so existing consumers (incl. production `armbian/os`) are unaffected. Chunks are `{"include": [...]}`, so adding a key adds a property without creating any new matrix combinations — job count is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub Actions matrix entries now include a short, human-friendly label for each item.
  * Image and artifact entries will display clearer names in generated matrices, including placeholder entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->