### PR TITLE
boards: fix ayn child boards dropped from build matrix (inventory can't follow source)

### DIFF
--- a/config/boards/ayn-odin2mini.csc
+++ b/config/boards/ayn-odin2mini.csc
@@ -1,5 +1,7 @@
 # Qualcomm SM8550 octa core 8GB/12GB/16GB RAM SoC eMMC USB-C WiFi/BT
 source "${SRC}/config/boards/ayn-odin2.csc"
+declare -g BOARDFAMILY="sm8550"          # inherited from ayn-odin2.csc; declared so the board inventory sees it
+declare -g KERNEL_TARGET="current,edge"  # inherited from ayn-odin2.csc; declared so the board inventory sees it
 declare -g ARCH="arm64"
 declare -g BOARD_NAME="Ayn Odin2 Mini"
 declare -g BOARD_VENDOR="ayntec"

--- a/config/boards/ayn-odin2portal.csc
+++ b/config/boards/ayn-odin2portal.csc
@@ -1,5 +1,6 @@
 # Qualcomm SM8550 octa core 8GB/12GB/16GB RAM SoC eMMC USB-C WiFi/BT
 source "${SRC}/config/boards/ayn-odin2.csc"
+declare -g BOARDFAMILY="sm8550"          # inherited from ayn-odin2.csc; declared so the board inventory sees it
 declare -g ARCH="arm64"
 declare -g BOARD_NAME="Ayn Odin2 Portal"
 declare -g BOARD_VENDOR="ayntec"

--- a/config/boards/ayn-thor.csc
+++ b/config/boards/ayn-thor.csc
@@ -1,5 +1,7 @@
 # Qualcomm SM8550 octa core 8GB/12GB/16GB RAM SoC eMMC USB-C WiFi/BT
 source "${SRC}/config/boards/ayn-odin2.csc"
+declare -g BOARDFAMILY="sm8550"          # inherited from ayn-odin2.csc; declared so the board inventory sees it
+declare -g KERNEL_TARGET="current,edge"  # inherited from ayn-odin2.csc; declared so the board inventory sees it
 declare -g ARCH="arm64"
 declare -g BOARD_NAME="Ayn Thor"
 declare -g BOARD_VENDOR="ayntec"

--- a/config/boards/numaker-iot-ma35d16f90.csc
+++ b/config/boards/numaker-iot-ma35d16f90.csc
@@ -1,6 +1,7 @@
 # Dual-core Cortex-A35 + Cortex-M4, 512MB DDR
 BOARD_NAME="NuMaker IoT MA35D16F90"
 BOARD_VENDOR="nuvoton"
+BOARD_MAINTAINER=""
 BOARDFAMILY="nuvoton-ma35d1"
 INTRODUCED="2024"
 # SD card boot (sdcard1 = SD1 slot on NuMaker IoT board)

--- a/config/boards/numaker-iot-ma35d16f90.csc
+++ b/config/boards/numaker-iot-ma35d16f90.csc
@@ -1,12 +1,13 @@
 # Dual-core Cortex-A35 + Cortex-M4, 512MB DDR
 BOARD_NAME="NuMaker IoT MA35D16F90"
 BOARD_VENDOR="nuvoton"
-BOARD_MAINTAINER=""
+BOARD_MAINTAINER="TuAFBogey"
 BOARDFAMILY="nuvoton-ma35d1"
 INTRODUCED="2024"
 # SD card boot (sdcard1 = SD1 slot on NuMaker IoT board)
 BOOTCONFIG="ma35d1_sdcard1_defconfig"
 KERNEL_TARGET="vendor"
+KERNEL_TEST_TARGET="vendor"
 FULL_DESKTOP="no"
 BOOT_LOGO="no"
 BOOT_FDT_FILE="nuvoton/ma35d1-iot-512m.dtb"


### PR DESCRIPTION
## Problem

The board inventory logged:
```
KERNEL_TARGET not found in 'config/boards/ayn-thor.csc', syntax error?, missing quotes? stray comma?
BOARDFAMILY not found in 'config/boards/ayn-thor.csc', ...
BOARDFAMILY not found in 'config/boards/ayn-odin2portal.csc', ...
KERNEL_TARGET not found in 'config/boards/ayn-odin2mini.csc', ...
```

`ayn-thor`, `ayn-odin2mini` and `ayn-odin2portal` `source "${SRC}/config/boards/ayn-odin2.csc"` and inherit `BOARDFAMILY="sm8550"` and `KERNEL_TARGET="current,edge"` from it. But the inventory parser ([`lib/tools/common/armbian_utils.py`](lib/tools/common/armbian_utils.py)) does a flat per-line regex scan and **does not follow `source`**, so it sees these vars as missing.

This isn't just noise: with no `KERNEL_TARGET`, `BOARD_POSSIBLE_BRANCHES` is empty for `ayn-thor` and `ayn-odin2mini`, so they're **dropped from the build matrix** entirely.

## Fix

Declare the inherited `BOARDFAMILY`/`KERNEL_TARGET` explicitly on the child boards so they're self-describing for the inventory (`ayn-odin2portal` already declares its own `KERNEL_TARGET`, so it only needed `BOARDFAMILY`).

Purely additive — the `source` already sets the same values at build time, so build behaviour is unchanged; this only makes the static inventory see them. `bash -n` clean.

## Out of scope / notes

- Root-cause alternative would be teaching the inventory parser to follow board-to-board `source` (only 6 boards use it today). Happy to do that as a follow-up if preferred.
- Separately, `numaker-iot-ma35d16f90.csc` warns `BOARD_MAINTAINER not found` — it genuinely has no maintainer line (non-fatal, board still builds). Left out of this PR since it needs a maintainer name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved board inventory detection by explicitly publishing board family and kernel target details for several AYN devices.
  * Added missing maintainer metadata for one board to improve completeness and consistency.
  * Included the board’s kernel test target setting for the affected board.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->