### PR TITLE
rootfs: strip mmdebstrap's apt proxy so it doesn't ship in the image

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -158,6 +158,10 @@ function create_new_rootfs_cache_via_debootstrap() {
 	display_alert "Cleaning up after mmdebstrap" "mmdebstrap cleanup" "info"
 	run_host_command_logged rm -rf "${SDCARD}/var/cache/apt" "${SDCARD}/var/lib/apt/lists"
 	rm -f "${SDCARD}/etc/apt/apt.conf.d/99-armbian-sandbox" # build-time only; don't ship in the image
+	# mmdebstrap persists the bootstrap --aptopt (our APT_PROXY_ADDR proxy) as
+	# 99mmdebstrap inside the rootfs. That build-host proxy is meaningless — and
+	# usually unreachable — on the user's machine, breaking their apt. Strip it.
+	rm -f "${SDCARD}/etc/apt/apt.conf.d/99mmdebstrap"
 
 	local_apt_deb_cache_prepare "after mmdebstrap cleanup" # just for size reference in logs
 


### PR DESCRIPTION
**Bug:** built images carry a bogus apt proxy. A published rootfs artifact (`rootfs-armhf-resolute-xfce-desktop-minimal`) ships:

```
# /etc/apt/apt.conf.d/99mmdebstrap
Acquire::http::Proxy "http://10.0.40.2:3142";
```

That's a build-host LAN apt-cacher — unreachable on the user's machine, so their `apt update` hangs/fails.

**Cause:** when a CI runner sets `APT_PROXY_ADDR`, [rootfs-create.sh](https://github.com/armbian/build/blob/main/lib/functions/rootfs/rootfs-create.sh) routes mmdebstrap's bootstrap through it via `--aptopt=Acquire::http::Proxy …`. mmdebstrap **persists** that aptopt as `/etc/apt/apt.conf.d/99mmdebstrap` in the target rootfs, and nothing removed it before packaging — so it ships.

**Fix:** `rm -f ${SDCARD}/etc/apt/apt.conf.d/99mmdebstrap` in the existing post-mmdebstrap cleanup, right next to the `99-armbian-sandbox` removal (also build-time only).

Note: this is the root, image-side fix — it leaks even from runners that *legitimately* use a proxy. (The os-ci-test workflow guards that reduce *when* `APT_PROXY_ADDR` is set are complementary, not a substitute.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented build-time apt proxy settings from being carried into packaged root filesystem caches.
  * Cleaned up leftover package manager configuration so cached rootfs images are more portable and less likely to use unintended network settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->