### PR TITLE
rockchip64_common: collapse line-continued expansion exec to single line

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -389,12 +389,7 @@ write_uboot_platform_mtd() {
 	[[ -f /etc/armbian-release ]] && source /etc/armbian-release
 	backtitle="Armbian for $BOARD_NAME install script, https://www.armbian.com"
 
-	CHOICE=$(dialog --no-collapse \
-		--title "armbian-install" \
-		--backtitle "$backtitle" \
-		--radiolist "Choose SPI image:" 0 56 4 \
-		"${MENU_ITEMS[@]}" \
-		3>&1 1>&2 2>&3)
+	CHOICE=$(dialog --no-collapse --title "armbian-install" --backtitle "$backtitle" --radiolist "Choose SPI image:" 0 56 4 "${MENU_ITEMS[@]}" 3>&1 1>&2 2>&3)
 
 	if [ $? -eq 0 ]; then
 		idx=$((CHOICE-1))


### PR DESCRIPTION
- 🍀 reason is very sad, see #10055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SPI image selection prompt formatting for consistency, with no change to the available options or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->