### PR TITLE
u-boot: debug produced binaries with `dumpimage -l` as well as `binwalk`

### DIFF
--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -482,6 +482,9 @@ function compile_uboot() {
 		display_alert "Analyzing u-boot binary with binwalk" "'${base_binfile}' built on ${HOSTRELEASE}" "info"
 		run_host_command_logged file --brief "${binfile}" "||" true ";" binwalk --run-as=root "${binfile}" "||" true # do not fail, ever
 
+		display_alert "Analyzing u-boot binary with dumpimage" "'${base_binfile}' built on ${HOSTRELEASE}" "info"
+		run_host_command_logged dumpimage -l "${binfile}" "||" true # do not fail, ever
+
 		if [[ "${UBOOT_BINS_TO_OUTPUT}" == "yes" ]]; then
 			display_alert "Copying u-boot binary to output for later binwalk inspection" "'${base_binfile}' built on ${HOSTRELEASE}" "warn"
 			declare target="${SRC}/output/uboot-bin-${uboot_name}-${base_binfile}-host-${HOSTRELEASE}.bin"


### PR DESCRIPTION
- 🍀 still chasing why rk vendor u-boot alledgedly produces nonworking bins when built on non-Jammy hosts
- 🐸 see #9897 and #10055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded packaging checks for bootloader artifacts with an additional binary inspection step.
  * Packaging continues even if the new inspection tool is unavailable or returns an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->