### PR TITLE
Fix swapfile creation

### DIFF
--- a/packages/bsp/common/usr/bin/armbian-install
+++ b/packages/bsp/common/usr/bin/armbian-install
@@ -490,16 +490,6 @@ create_armbian()
 
 	if [[ $2 == ${DISK_ROOT_PART} && -z $1 && $DEVICE_TYPE = uefi ]]; then
 
-		# create swap file size of your memory so we can use it for S4
-		MEM_TOTAL=$(cat /proc/meminfo | awk '/MemTotal/ {print $2}')
-
-		# but no more then 16Gb
-		[[ ${MEM_TOTAL} -gt 16107868 ]] && MEM_TOTAL=16107868
-		dd if=/dev/zero of="${TempDir}"/rootfs/swapfile bs=${MEM_TOTAL} count=1024 conv=notrunc >> $logfile
-
-		mkswap "${TempDir}"/rootfs/swapfile >> $logfile
-		chmod 0600 "${TempDir}"/rootfs/swapfile
-		sed -i "/^GRUB_CMDLINE_LINUX_DEFAULT=/ s/\"$/ resume=UUID=$(findmnt -no UUID -T "${TempDir}"/rootfs/swapfile) resume_offset=$(filefrag -v "${TempDir}"/rootfs/swapfile |grep " 0:"| awk '{print $4}' | cut -d"." -f1)\"/" "${TempDir}"/rootfs/etc/default/grub.d/98-armbian.cfg
 
 		echo "GRUB_DISABLE_OS_PROBER=false" >> "${TempDir}"/rootfs/etc/default/grub.d/98-armbian.cfg
 
@@ -517,7 +507,6 @@ create_armbian()
 			exit 20
 		fi
 		echo "UUID=$target_efi_uuid				/boot/efi		vfat	 defaults 0 2" >> "${TempDir}"/rootfs/etc/fstab
-		echo "/swapfile none swap sw 0 0" >> "${TempDir}"/rootfs/etc/fstab
 
 		cat <<-hibernatemenu >"${TempDir}"/rootfs/etc/polkit-1/localauthority/50-local.d/com.ubuntu.enable-hibernate.pkla
 		[Re-enable hibernate by default in upower]


### PR DESCRIPTION
# Description

With the old armbian-install and smaller emmc storage, the swapfile was too big to fit onto the root file system.
This would cause the installation onto the emmc to fail. The swapsize is now limited (to 1/4th) in case the free root space is less than the memory size.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: #10064 

# How Has This Been Tested?

I've tested this on a couple of Raxda Q6A boards, it works with the smaller swapfile.

- [x] Test A

   - Install armbian on a SDcard
   - Run armbian-install to install on the emmc
   - Once the system is installed on the emmc, reboot and verified that the system boots from the emmc.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated UEFI-only installation behavior to no longer create or configure a swapfile.
  * Removed the corresponding bootloader resume settings and the swapfile entry from the generated filesystem configuration in this installation path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->