### PR TITLE
git-ref2info: support gitproxy (git_cdn) source for Makefile version fetch

### DIFF
--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -173,7 +173,20 @@ function memoized_git_ref_to_info() {
 					;;
 
 				*)
-					exit_with_error "Unknown git source '${git_source}'"
+					# git_cdn / gitproxy mirror: GITHUB_SOURCE is the proxy base
+					# (GITPROXY_ADDRESS) and the proxy serves github repos at
+					# /org/repo, so git_source is http://host:port/org/repo. The
+					# Makefile version is the upstream one, so fetch it from github's
+					# raw endpoint directly (the proxy is for git clones, not raw HTTP).
+					if [[ "${GITHUB_MIRROR}" == "gitproxy" && -n "${GITPROXY_ADDRESS:-}" && "${git_source}" == "${GITPROXY_ADDRESS%/}/"* ]]; then
+						declare org_and_repo=""
+						IFS=/ read -r _ _ _ _gr_org _gr_repo _ <<< "${git_source}"
+						org_and_repo="${_gr_org}/${_gr_repo}"
+						org_and_repo="${org_and_repo%.git}" # remove .git if present
+						url="https://raw.githubusercontent.com/${org_and_repo}/${sha1}/Makefile"
+					else
+						exit_with_error "Unknown git source '${git_source}'"
+					fi
 					;;
 			esac
 


### PR DESCRIPTION
## Problem

Artifact builds fail on runners that advertise a git_cdn proxy (e.g. `rack-ryzen`, `geekom` — `git_proxy: http://10.0.40.2:8000`):

```
##[error] error! Unknown git source 'http://10.0.40.2:8000/u-boot/u-boot'
Exiting with error 43 at lib/functions/logging/traps.sh:1
```

When `GITPROXY_ADDRESS` is set, `main-config` selects `GITHUB_MIRROR=gitproxy` and `GITHUB_SOURCE` becomes the proxy base, so kernel/u-boot sources look like `http://host:port/org/repo`. `obtain_makefile_body_from_git` ([git-ref2info.sh](lib/functions/general/git-ref2info.sh)) has cases for github.com / gitlab / gitee / kernel.org / … but **none for the gitproxy URL**, so it hits the `*)` default and aborts.

## Fix

Add a gitproxy case: the git_cdn proxies *git clones*, not raw HTTP, and the Makefile version is the upstream one regardless of mirror — so fetch the Makefile from github's raw endpoint, parsing `org/repo` from the proxy URL (same `scheme://host/org/repo` shape as github.com). Truly unknown sources still error.

`bash -n` clean. Guarded on `GITHUB_MIRROR == gitproxy` + the URL actually being under `GITPROXY_ADDRESS`, so non-gitproxy builds are unaffected.

## Context

Surfaced while moving the os pipeline to its own repo; pre-existing — any build using the git_cdn mirror hits it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for fetching Makefiles from an additional Git mirror/CDN-style source when the mirror is configured appropriately.
  * Improved handling of proxied GitHub-style repository paths so Makefile retrieval can resolve more sources successfully.
* **Bug Fixes**
  * Continued to return an error for unsupported Git sources, preserving existing fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->