### PR TITLE
Enable 1 GHz frequency for Panthor

### DIFF
--- a/patch/kernel/archive/rockchip64-7.1/rk35xx-panthor-1GHz.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk35xx-panthor-1GHz.patch
@@ -1,0 +1,1010 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 27 Apr 2025 20:38:05 +0000
+Subject: arm64: dts: rockchip: rk356x: use gpu 200mhz opp as opp-suspend
+
+CLK_GPU is the main clock for the GPU on RK356x, it's typical source
+pll can be one of mpll, gpll, cpll or npll. For higher clock rates it
+is also possible to use the gpu pvtpll as pll source.
+
+The logic to switch between a normal pll and the pvtpll depending on
+rate is handled in TF-A firmware, and exposed to Linux as a scmi clock.
+In the device tree this is modeled in the gpu node by using the scmi gpu
+clk as the core gpu clk and the normal CLK_GPU as a bus clk.
+
+TF-A will typically change to use normal pll for rates up to 400 MHz and
+use pvtpll for 600 MHz or more.
+
+Add opp-suspend to the 200 MHz opp to ensure a normal pll is used when
+the gpu device is in PM runtime suspended state.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ arch/arm64/boot/dts/rockchip/rk3566.dtsi  | 1 +
+ arch/arm64/boot/dts/rockchip/rk3566t.dtsi | 1 +
+ arch/arm64/boot/dts/rockchip/rk3568.dtsi  | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566.dtsi b/arch/arm64/boot/dts/rockchip/rk3566.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566.dtsi
+@@ -57,6 +57,7 @@ gpu_opp_table: opp-table-1 {
+ 		opp-200000000 {
+ 			opp-hz = /bits/ 64 <200000000>;
+ 			opp-microvolt = <850000 850000 1000000>;
++			opp-suspend;
+ 		};
+ 
+ 		opp-300000000 {
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566t.dtsi b/arch/arm64/boot/dts/rockchip/rk3566t.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566t.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566t.dtsi
+@@ -45,6 +45,7 @@ gpu_opp_table: opp-table-1 {
+ 		opp-200000000 {
+ 			opp-hz = /bits/ 64 <200000000>;
+ 			opp-microvolt = <850000 850000 1000000>;
++			opp-suspend;
+ 		};
+ 
+ 		opp-300000000 {
+diff --git a/arch/arm64/boot/dts/rockchip/rk3568.dtsi b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3568.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
+@@ -68,6 +68,7 @@ gpu_opp_table: opp-table-1 {
+ 		opp-200000000 {
+ 			opp-hz = /bits/ 64 <200000000>;
+ 			opp-microvolt = <850000 850000 1000000>;
++			opp-suspend;
+ 		};
+ 
+ 		opp-300000000 {
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 4 May 2025 09:58:29 +0000
+Subject: arm64: dts: rockchip: rk3576: Fix gpu opp table
+
+The Rockchip RK3576 datasheet v1.5 Recommended Operating Conditions
+table list Max GPU frequency as 900 MHz.
+
+The recommended Voltage for GPU is listed as min 0.675 and max 0.918,
+with a typical voltage of 0.75.
+
+Update the GPU OPP table to remove 950 MHz and adjust the voltages to
+match the highest voltages used by vendor kernel to ensure stability.
+
+Fixes: 57b1ce903966 ("arm64: dts: rockchip: Add rk3576 SoC base DT")
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ arch/arm64/boot/dts/rockchip/rk3576.dtsi | 19 ++++------
+ 1 file changed, 7 insertions(+), 12 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3576.dtsi b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+@@ -349,42 +349,37 @@ gpu_opp_table: opp-table-gpu {
+ 
+ 		opp-300000000 {
+ 			opp-hz = /bits/ 64 <300000000>;
+-			opp-microvolt = <700000 700000 850000>;
++			opp-microvolt = <712500 712500 875000>;
+ 		};
+ 
+ 		opp-400000000 {
+ 			opp-hz = /bits/ 64 <400000000>;
+-			opp-microvolt = <700000 700000 850000>;
++			opp-microvolt = <712500 712500 875000>;
+ 		};
+ 
+ 		opp-500000000 {
+ 			opp-hz = /bits/ 64 <500000000>;
+-			opp-microvolt = <700000 700000 850000>;
++			opp-microvolt = <712500 712500 875000>;
+ 		};
+ 
+ 		opp-600000000 {
+ 			opp-hz = /bits/ 64 <600000000>;
+-			opp-microvolt = <700000 700000 850000>;
++			opp-microvolt = <712500 712500 875000>;
+ 		};
+ 
+ 		opp-700000000 {
+ 			opp-hz = /bits/ 64 <700000000>;
+-			opp-microvolt = <725000 725000 850000>;
++			opp-microvolt = <750000 750000 875000>;
+ 		};
+ 
+ 		opp-800000000 {
+ 			opp-hz = /bits/ 64 <800000000>;
+-			opp-microvolt = <775000 775000 850000>;
++			opp-microvolt = <812500 812500 875000>;
+ 		};
+ 
+ 		opp-900000000 {
+ 			opp-hz = /bits/ 64 <900000000>;
+-			opp-microvolt = <825000 825000 850000>;
+-		};
+-
+-		opp-950000000 {
+-			opp-hz = /bits/ 64 <950000000>;
+-			opp-microvolt = <850000 850000 850000>;
++			opp-microvolt = <875000 875000 875000>;
+ 		};
+ 	};
+ 
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 4 May 2025 09:56:19 +0000
+Subject: clk: rockchip: rk3576: Mark pclk_gpu_root as critical
+
+The pclk_gpu_root is required when PVTPLL is used for the GPU.
+
+Mark it with CLK_IS_CRITICAL to ensure it is not disabled.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+Another options is to remove the clk, something that would match RK3588.
+---
+ drivers/clk/rockchip/clk-rk3576.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/clk/rockchip/clk-rk3576.c b/drivers/clk/rockchip/clk-rk3576.c
+index 111111111111..222222222222 100644
+--- a/drivers/clk/rockchip/clk-rk3576.c
++++ b/drivers/clk/rockchip/clk-rk3576.c
+@@ -912,7 +912,7 @@ static struct rockchip_clk_branch rk3576_clk_branches[] __initdata = {
+ 			RK3576_CLKGATE_CON(69), 1, GFLAGS),
+ 	GATE(CLK_GPU, "clk_gpu", "clk_gpu_src_pre", 0,
+ 			RK3576_CLKGATE_CON(69), 3, GFLAGS),
+-	COMPOSITE_NODIV(PCLK_GPU_ROOT, "pclk_gpu_root", mux_100m_50m_24m_p, 0,
++	COMPOSITE_NODIV(PCLK_GPU_ROOT, "pclk_gpu_root", mux_100m_50m_24m_p, CLK_IS_CRITICAL,
+ 			RK3576_CLKSEL_CON(166), 10, 2, MFLAGS,
+ 			RK3576_CLKGATE_CON(69), 8, GFLAGS),
+ 
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 27 Apr 2025 20:38:47 +0000
+Subject: arm64: dts: rockchip: rk3576: Use scmi gpu clk as main GPU clock
+
+CLK_GPU is the main clock for the GPU on RK3576, it's typical source
+pll can be one of gpll, cpll, aupll, spll or lpll. For higher clock
+rates it is also possible to use the gpu pvtpll as pll source.
+
+The logic to switch between a normal pll and the pvtpll depending on
+rate is handled in TF-A firmware, and exposed to Linux as a scmi clock.
+TF-A will typically change to use normal pll for rates up to 200 MHz and
+use pvtpll for 300 MHz or more.
+
+Change to use the SCMI_CLK_GPU as the main GPU clock and the normal
+CLK_GPU as a bus clk to model this in a similar way as on RK356x.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ arch/arm64/boot/dts/rockchip/rk3576.dtsi | 14 +++++++---
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3576.dtsi b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+@@ -347,6 +347,12 @@ opp-2208000000 {
+ 	gpu_opp_table: opp-table-gpu {
+ 		compatible = "operating-points-v2";
+ 
++		opp-200000000 {
++			opp-hz = /bits/ 64 <200000000>;
++			opp-microvolt = <712500 712500 875000>;
++			opp-suspend;
++		};
++
+ 		opp-300000000 {
+ 			opp-hz = /bits/ 64 <300000000>;
+ 			opp-microvolt = <712500 712500 875000>;
+@@ -1259,10 +1265,10 @@ power-domain@RK3576_PD_VO1 {
+ 		gpu: gpu@27800000 {
+ 			compatible = "rockchip,rk3576-mali", "arm,mali-bifrost";
+ 			reg = <0x0 0x27800000 0x0 0x20000>;
+-			assigned-clocks = <&scmi_clk SCMI_CLK_GPU>;
+-			assigned-clock-rates = <198000000>;
+-			clocks = <&cru CLK_GPU>;
+-			clock-names = "core";
++			assigned-clocks = <&cru CLK_GPU>, <&scmi_clk SCMI_CLK_GPU>;
++			assigned-clock-rates = <198000000>, <200000000>;
++			clocks = <&scmi_clk SCMI_CLK_GPU>, <&cru CLK_GPU>;
++			clock-names = "gpu", "bus";
+ 			dynamic-power-coefficient = <1625>;
+ 			interrupts = <GIC_SPI 347 IRQ_TYPE_LEVEL_HIGH>,
+ 				     <GIC_SPI 348 IRQ_TYPE_LEVEL_HIGH>,
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 27 Apr 2025 20:39:15 +0000
+Subject: dt-bindings: gpu: mali-bifrost: fix rockchip,rk3576-mali binding
+
+A scmi clk is used as the main GPU clock for RK3576, similar to RK356x.
+
+Update the RK3576 binding to match the RK356x binding.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ Documentation/devicetree/bindings/gpu/arm,mali-bifrost.yaml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Documentation/devicetree/bindings/gpu/arm,mali-bifrost.yaml b/Documentation/devicetree/bindings/gpu/arm,mali-bifrost.yaml
+index 111111111111..222222222222 100644
+--- a/Documentation/devicetree/bindings/gpu/arm,mali-bifrost.yaml
++++ b/Documentation/devicetree/bindings/gpu/arm,mali-bifrost.yaml
+@@ -267,6 +267,7 @@ allOf:
+         compatible:
+           contains:
+             const: rockchip,rk3568-mali
++            const: rockchip,rk3576-mali
+     then:
+       properties:
+         clocks:
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sat, 10 May 2025 23:59:20 +0000
+Subject: RFC: drm/lima: Do not set clk rate when device is suspended
+
+On Rockchip RK3528 trying to change the SCMI_CLK_GPU rate when the GPU
+device is PM runtime suspended may cause a freeze or kernel panic:
+
+  $ echo performance > /sys/class/devfreq/ff700000.gpu/governor
+
+  SError Interrupt on CPU1, code 0x00000000bf000000 -- SError
+  CPU: 1 UID: 0 PID: 190 Comm: sh Not tainted 6.15.0-rc6 #1 VOLUNTARY
+  Hardware name: Radxa E20C (DT)
+  pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+  pc : smc_send_message+0x140/0x148
+  lr : smc_send_message+0xd8/0x148
+  sp : ffff800082ebb880
+  x29: ffff800082ebb880 x28: ffff0000015a6000 x27: 0000000000000000
+  x26: 0000000000000000 x25: 00000000ffffffff x24: ffff800082ebbae8
+  x23: ffff000004adcc10 x22: ffff0000007d04a0 x21: ffff000004b93680
+  x20: ffff000000e51380 x19: ffff0000007d0480 x18: 0000000000000000
+  x17: 0000000000000000 x16: 0000000000000000 x15: 0000000000000008
+  x14: ffff0000015a6080 x13: 0000000000000000 x12: 0000000000000018
+  x11: 0000000000000040 x10: ffff000004ae2138 x9 : ffff000004ae2130
+  x8 : ffff000001fe1b88 x7 : 0000000000000000 x6 : 0000000000000000
+  x5 : 0000000000000000 x4 : 0000000000000000 x3 : 0000000000000000
+  x2 : 0000000000000000 x1 : 0000000000000000 x0 : 0000000000000000
+  Kernel panic - not syncing: Asynchronous SError Interrupt
+  CPU: 1 UID: 0 PID: 190 Comm: sh Not tainted 6.15.0-rc6 #1 VOLUNTARY
+  Hardware name: Radxa E20C (DT)
+  Call trace:
+   show_stack+0x28/0x78 (C)
+   dump_stack_lvl+0x58/0x74
+   dump_stack+0x14/0x1c
+   panic+0x14c/0x328
+   add_taint+0x0/0xc0
+   arm64_serror_panic+0x60/0x6c
+   do_serror+0x24/0x60
+   el1h_64_error_handler+0x2c/0x40
+   el1h_64_error+0x6c/0x70
+   smc_send_message+0x140/0x148 (P)
+   do_xfer+0xb0/0x200
+   scmi_clock_rate_set+0xc0/0x220
+   scmi_clk_set_rate+0x24/0x38
+   clk_change_rate+0x164/0x288
+   clk_core_set_rate_nolock+0x1dc/0x314
+   clk_set_rate+0x34/0x144
+   _opp_config_clk_single+0x2c/0x90
+   _set_opp+0x104/0x564
+   dev_pm_oppset_rate+0x110/0x260
+   lima_devfreq_target+0x30/0x40
+   devfre_set_target+0x84/0x180
+   devfreq_update_target+0xb4/0xcc
+   update_devfreq+0x10/0x18
+   devfreq_performance_handler+0x40/0x70
+   governor_store+0xe4/0x260
+   dev_attr_store+0x14/0x24
+   sysfs_kf_write+0x54/0x60
+   kernfs_fop_write_iter+0x118/0x1e0
+   vfs_write+0x224/0x390
+   ksys_write+0x68/0x100
+   __arm64_sys_write+0x18/0x20
+   invoke_syscall+0x44/0x100
+   el0_svc_common.constprop.0+0x3c/0xe0
+   do_el0_svc+0x18/0x20
+   el0_svc+0x2c/0xc0
+   el0t_64_sync_handler+0x104/0x130
+   el0t_64_sync+0x170/0x174
+  SMP: stopping secondary CPUs
+  Kernel Offset: disabled
+  CPU fetures: 0x0000,00001000,00000400,0200400b
+  Memory Limit: none
+  ---[ end Kernel panic - not syncing: Asynchronous SError Interrupt ]---
+
+This typically happen when CLK_GPU is disabled or when PD_GPU is down.
+
+Add a config_clks ops that will not set core clk rate when the device is
+PM runtime suspended.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ drivers/gpu/drm/lima/lima_devfreq.c | 43 +++++++++-
+ 1 file changed, 42 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/lima/lima_devfreq.c b/drivers/gpu/drm/lima/lima_devfreq.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/lima/lima_devfreq.c
++++ b/drivers/gpu/drm/lima/lima_devfreq.c
+@@ -11,6 +11,7 @@
+ #include <linux/device.h>
+ #include <linux/platform_device.h>
+ #include <linux/pm_opp.h>
++#include <linux/pm_runtime.h>
+ #include <linux/property.h>
+ 
+ #include "lima_device.h"
+@@ -87,6 +88,41 @@ static struct devfreq_dev_profile lima_devfreq_profile = {
+ 	.get_dev_status = lima_devfreq_get_dev_status,
+ };
+ 
++static int lima_devfreq_config_clks(struct device *dev,
++				    struct opp_table *opp_table,
++				    struct dev_pm_opp *opp,
++				    void *data, bool scaling_down)
++{
++	struct lima_device *ldev = dev_get_drvdata(dev);
++	struct devfreq *devfreq = ldev->devfreq.devfreq;
++	unsigned long *target = data;
++	unsigned long freq;
++	int ret = 0;
++
++	/* One of target and opp must be available */
++	if (target) {
++		freq = *target;
++	} else if (opp) {
++		freq = dev_pm_opp_get_freq(opp);
++	} else {
++		WARN_ON(1);
++		return -EINVAL;
++	}
++
++	pm_runtime_get_noresume(dev);
++
++	if (!pm_runtime_suspended(dev) || !devfreq || !devfreq->suspend_freq) {
++		ret = clk_set_rate(ldev->clk_gpu, freq);
++		if (ret)
++			dev_err(dev, "failed to set clock rate %lu: %d\n",
++				freq, ret);
++	}
++
++	pm_runtime_put_noidle(dev);
++
++	return ret;
++}
++
+ void lima_devfreq_fini(struct lima_device *ldev)
+ {
+ 	struct lima_devfreq *devfreq = &ldev->devfreq;
+@@ -112,6 +148,11 @@ int lima_devfreq_init(struct lima_device *ldev)
+ 	unsigned long cur_freq;
+ 	int ret;
+ 	const char *regulator_names[] = { "mali", NULL };
++	const char *clk_names[] = { "core", NULL };
++	struct dev_pm_opp_config config = {
++		.clk_names = clk_names,
++		.config_clks = lima_devfreq_config_clks,
++	};
+ 
+ 	if (!device_property_present(dev, "operating-points-v2"))
+ 		/* Optional, continue without devfreq */
+@@ -123,7 +164,7 @@ int lima_devfreq_init(struct lima_device *ldev)
+ 	 * clkname is set separately so it is not affected by the optional
+ 	 * regulator setting which may return error.
+ 	 */
+-	ret = devm_pm_opp_set_clkname(dev, "core");
++	ret = devm_pm_opp_set_config(dev, &config);
+ 	if (ret)
+ 		return ret;
+ 
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 4 May 2025 10:00:16 +0000
+Subject: RFC: drm/panfrost: Do not set clk rate when device is suspended
+
+On Rockchip RK3576 trying to change the SCMI_CLK_GPU rate when the GPU
+device is PM runtime suspended may cause a kernel panic:
+
+  $ echo 900000000 > /sys/class/devfreq/27800000.gpu/min_freq
+
+  SError Interrupt on CPU2, code 0x00000000bf000000 -- SError
+  CPU: 2 UID: 0 PID: 236 Comm: sh Not tainted 6.15.0-rc3 #1 VOLUNTARY
+  Hardware name: ArmSoM Sige5 (DT)
+  pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+  pc : smc_send_message+0x140/0x148
+  lr : smc_send_message+0xd8/0x148
+  sp : ffff8000823eb7a0
+  x29: ffff8000823eb7a0 x28: ffff0000c5283000 x27: 0000000000000000
+  x26: 0000000000000000 x25: 00000000ffffffff x24: ffff8000823eba08
+  x23: ffff0000c1dda810 x22: ffff0000c093a9a0 x21: ffff0000c0921280
+  x20: ffff0000c22af8c0 x19: ffff0000c093a980 x18: 0000000000000001
+  x17: 0000000000000001 x16: ffffffffffffffff x15: 0000000000000000
+  x14: ffff0000c5283080 x13: 0000000000000000 x12: 071c71c71c71c71c
+  x11: 0000000000000040 x10: ffff0000c091e138 x9 : ffff0000c091e130
+  x8 : ffff0000c07d8b90 x7 : 0000000000000000 x6 : 0000000000000000
+  x5 : 0000000000000000 x4 : 0000000000000000 x3 : 0000000000000000
+  x2 : 0000000000000000 x1 : 0000000000000000 x0 : 0000000000000000
+  Kernel panic - not syncing: Asynchronous SError Interrupt
+  CPU: 2 UID: 0 PID: 236 Comm: sh Not tainted 6.15.0-rc3 #1 VOLUNTARY
+  Hardware name: ArmSoM Sige5 (DT)
+  Call trace:
+   show_stack+0x28/0x78 (C)
+   dump_stack_lvl+0x58/0x74
+   dump_stack+0x14/0x1c
+   panic+0x14c/0x328
+   add_taint+0x0/0xc0
+   arm64_serror_panic+0x60/0x6c
+   do_serror+0x24/0x60
+   el1h_64_error_handler+0x2c/0x40
+   el1h_64_error+0x6c/0x70
+   smc_send_message+0x140/0x148 (P)
+   do_xfer+0xb0/0x1f8
+   scmi_clock_rate_set+0xc0/0x220
+   scmi_clk_set_rate+0x24/0x38
+   clk_change_rate+0x164/0x288
+   clk_core_set_rate_nolock+0x1dc/0x314
+   clk_set_rate+0x34/0x144
+   _opp_config_clk_single+0x2c/0x90
+   _set_opp+0x104/0x564
+   dev_pm_opp_set_rate+0x110/0x260
+   panfrost_devfreq_target+0x38/0x60
+   devfreq_set_target+0x84/0x180
+   devfreq_update_target+0xb4/0xcc
+   qos_min_notifier_call+0x2c/0x68
+   blocking_notifier_call_chain+0x68/0xa0
+   pm_qos_update_target+0xd8/0x150
+   freq_qos_apply+0x5c/0x64
+   apply_constraint+0x80/0x130
+   __dev_pm_qos_update_request+0x78/0xc4
+   dev_pm_qos_update_request+0x34/0x54
+   min_freq_store+0x74/0xbc
+   dev_attr_store+0x14/0x24
+   sysfs_kf_write+0x54/0x60
+   kernfs_fop_write_iter+0x118/0x1e0
+   vfs_write+0x224/0x390
+   ksys_write+0x68/0x100
+   __arm64_sys_write+0x18/0x20
+   invoke_syscall+0x44/0x100
+   el0_svc_common.constprop.0+0x3c/0xe0
+   do_el0_svc+0x18/0x20
+   el0_svc+0x2c/0xc0
+   el0t_64_sync_handler+0x104/0x130
+   el0t_64_sync+0x170/0x174
+  SMP: stopping secondary CPUs
+  Kernel Offset: disabled
+  CPU features: 0x0400,00041040,01000400,0200400b
+  Memory Limit: 3838 MB
+  ---[ end Kernel panic - not syncing: Asynchronous SError Interrupt ]---
+
+This typically happen when CLK_GPU is disabled or when PD_GPU is down.
+
+Add a config_clks ops that will not set core clk rate when the device is
+PM runtime suspended.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ drivers/gpu/drm/panfrost/panfrost_devfreq.c | 47 ++++++++++
+ drivers/gpu/drm/panfrost/panfrost_device.h  |  4 +
+ drivers/gpu/drm/panfrost/panfrost_drv.c     | 13 +++
+ 3 files changed, 64 insertions(+)
+
+diff --git a/drivers/gpu/drm/panfrost/panfrost_devfreq.c b/drivers/gpu/drm/panfrost/panfrost_devfreq.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/panfrost/panfrost_devfreq.c
++++ b/drivers/gpu/drm/panfrost/panfrost_devfreq.c
+@@ -7,6 +7,7 @@
+ #include <linux/nvmem-consumer.h>
+ #include <linux/platform_device.h>
+ #include <linux/pm_opp.h>
++#include <linux/pm_runtime.h>
+ 
+ #include <drm/drm_print.h>
+ 
+@@ -91,6 +92,41 @@ static struct devfreq_dev_profile panfrost_devfreq_profile = {
+ 	.get_dev_status = panfrost_devfreq_get_dev_status,
+ };
+ 
++static int panfrost_devfreq_config_clks(struct device *dev,
++					struct opp_table *opp_table,
++					struct dev_pm_opp *opp,
++					void *data, bool scaling_down)
++{
++	struct panfrost_device *pfdev = dev_get_drvdata(dev);
++	struct devfreq *devfreq = pfdev->pfdevfreq.devfreq;
++	unsigned long *target = data;
++	unsigned long freq;
++	int ret = 0;
++
++	/* One of target and opp must be available */
++	if (target) {
++		freq = *target;
++	} else if (opp) {
++		freq = dev_pm_opp_get_freq(opp);
++	} else {
++		WARN_ON(1);
++		return -EINVAL;
++	}
++
++	pm_runtime_get_noresume(dev);
++
++	if (!pm_runtime_suspended(dev) || !devfreq || !devfreq->suspend_freq) {
++		ret = clk_set_rate(pfdev->clock, freq);
++		if (ret)
++			dev_err(dev, "failed to set clock rate %lu: %d\n",
++				freq, ret);
++	}
++
++	pm_runtime_put_noidle(dev);
++
++	return ret;
++}
++
+ static int panfrost_read_speedbin(struct device *dev)
+ {
+ 	u32 val;
+@@ -140,6 +176,17 @@ int panfrost_devfreq_init(struct panfrost_device *pfdev)
+ 	if (ret)
+ 		return ret;
+ 
++	if (pfdev->comp->opp_clk_names) {
++		struct dev_pm_opp_config config = {
++			.clk_names = pfdev->comp->opp_clk_names,
++			.config_clks = panfrost_devfreq_config_clks,
++		};
++
++		ret = devm_pm_opp_set_config(dev, &config);
++		if (ret)
++			return ret;
++	}
++
+ 	ret = devm_pm_opp_set_regulators(dev, pfdev->comp->supply_names);
+ 	if (ret) {
+ 		/* Continue if the optional regulator is missing */
+diff --git a/drivers/gpu/drm/panfrost/panfrost_device.h b/drivers/gpu/drm/panfrost/panfrost_device.h
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/panfrost/panfrost_device.h
++++ b/drivers/gpu/drm/panfrost/panfrost_device.h
+@@ -107,6 +107,10 @@ struct panfrost_compatible {
+ 	/* Only required if num_pm_domains > 1. */
+ 	const char * const *pm_domain_names;
+ 
++	/* OPP clock count and names. */
++	int num_opp_clocks;
++	const char * const *opp_clk_names;
++
+ 	/* Vendor implementation quirks callback */
+ 	void (*vendor_quirk)(struct panfrost_device *pfdev);
+ 
+diff --git a/drivers/gpu/drm/panfrost/panfrost_drv.c b/drivers/gpu/drm/panfrost/panfrost_drv.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/panfrost/panfrost_drv.c
++++ b/drivers/gpu/drm/panfrost/panfrost_drv.c
+@@ -1152,6 +1152,17 @@ static const struct panfrost_compatible mediatek_mt8370_data = {
+ 	.gpu_quirks = BIT(GPU_QUIRK_FORCE_AARCH64_PGTABLE),
+ };
+ 
++static const char * const rockchip_opp_clks[] = { "gpu", NULL };
++static const struct panfrost_compatible rockchip_data = {
++	.num_supplies = ARRAY_SIZE(default_supplies) - 1,
++	.supply_names = default_supplies,
++	.num_pm_domains = 1,
++	.pm_domain_names = NULL,
++	.num_opp_clocks = ARRAY_SIZE(rockchip_opp_clks) - 1,
++	.opp_clk_names = rockchip_opp_clks,
++	.pm_features = BIT(GPU_PM_CLK_DIS) | BIT(GPU_PM_VREG_OFF),
++};
++
+ static const struct of_device_id dt_match[] = {
+ 	/* Set first to probe before the generic compatibles */
+ 	{ .compatible = "amlogic,meson-gxm-mali",
+@@ -1177,6 +1188,8 @@ static const struct of_device_id dt_match[] = {
+ 	{ .compatible = "mediatek,mt8192-mali", .data = &mediatek_mt8192_data },
+ 	{ .compatible = "mediatek,mt8370-mali", .data = &mediatek_mt8370_data },
+ 	{ .compatible = "allwinner,sun50i-h616-mali", .data = &default_pm_rt_data },
++	{ .compatible = "rockchip,rk3568-mali", .data = &rockchip_data },
++	{ .compatible = "rockchip,rk3576-mali", .data = &rockchip_data },
+ 	{}
+ };
+ MODULE_DEVICE_TABLE(of, dt_match);
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 27 Apr 2025 20:34:01 +0000
+Subject: RFC: dt-bindings: gpu: mali-valhall-csf: Add bus clock for RK3588
+
+Add support for a bus clock for rockchip,rk3588-mali compatible.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ Documentation/devicetree/bindings/gpu/arm,mali-valhall-csf.yaml | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Documentation/devicetree/bindings/gpu/arm,mali-valhall-csf.yaml b/Documentation/devicetree/bindings/gpu/arm,mali-valhall-csf.yaml
+index 111111111111..222222222222 100644
+--- a/Documentation/devicetree/bindings/gpu/arm,mali-valhall-csf.yaml
++++ b/Documentation/devicetree/bindings/gpu/arm,mali-valhall-csf.yaml
+@@ -40,7 +40,7 @@ properties:
+ 
+   clocks:
+     minItems: 1
+-    maxItems: 3
++    maxItems: 4
+ 
+   clock-names:
+     minItems: 1
+@@ -50,6 +50,7 @@ properties:
+           - coregroup
+           - stacks
+       - const: stacks
++      - const: bus
+ 
+   nvmem-cells:
+     items:
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 27 Apr 2025 20:34:24 +0000
+Subject: RFC: drm/panthor: Add support for a bus clk
+
+On RK3588 the GPU clk is exposed using a normal CLK_GPU and also as
+SCMI_CLK_GPU. The main clock for the GPU is the SCMI_CLK_GPU, however,
+the normal CLK_GPU also need to be enabled independently.
+
+Add support for a bus clk to handle these two different clocks, similar
+to panfrost.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ drivers/gpu/drm/panthor/panthor_device.c | 16 +++++++++-
+ drivers/gpu/drm/panthor/panthor_device.h |  3 ++
+ 2 files changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/panthor/panthor_device.c b/drivers/gpu/drm/panthor/panthor_device.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/panthor/panthor_device.c
++++ b/drivers/gpu/drm/panthor/panthor_device.c
+@@ -72,6 +72,12 @@ static int panthor_clk_init(struct panthor_device *ptdev)
+ 				     PTR_ERR(ptdev->clks.coregroup),
+ 				     "get 'coregroup' clock failed");
+ 
++	ptdev->clks.bus = devm_clk_get_optional(ptdev->base.dev, "bus");
++	if (IS_ERR(ptdev->clks.bus))
++		return dev_err_probe(ptdev->base.dev,
++				     PTR_ERR(ptdev->clks.bus),
++				     "get 'bus' clock failed");
++
+ 	drm_info(&ptdev->base, "clock rate = %lu\n", clk_get_rate(ptdev->clks.core));
+ 	return 0;
+ }
+@@ -509,10 +515,14 @@ int panthor_device_resume(struct device *dev)
+ 
+ 	atomic_set(&ptdev->pm.state, PANTHOR_DEVICE_PM_STATE_RESUMING);
+ 
+-	ret = clk_prepare_enable(ptdev->clks.core);
++	ret = clk_prepare_enable(ptdev->clks.bus);
+ 	if (ret)
+ 		goto err_set_suspended;
+ 
++	ret = clk_prepare_enable(ptdev->clks.core);
++	if (ret)
++		goto err_disable_bus_clk;
++
+ 	ret = clk_prepare_enable(ptdev->clks.stacks);
+ 	if (ret)
+ 		goto err_disable_core_clk;
+@@ -571,6 +581,9 @@ int panthor_device_resume(struct device *dev)
+ err_disable_core_clk:
+ 	clk_disable_unprepare(ptdev->clks.core);
+ 
++err_disable_bus_clk:
++	clk_disable_unprepare(ptdev->clks.bus);
++
+ err_set_suspended:
+ 	atomic_set(&ptdev->pm.state, PANTHOR_DEVICE_PM_STATE_SUSPENDED);
+ 	atomic_set(&ptdev->pm.recovery_needed, 1);
+@@ -618,6 +631,7 @@ int panthor_device_suspend(struct device *dev)
+ 	clk_disable_unprepare(ptdev->clks.coregroup);
+ 	clk_disable_unprepare(ptdev->clks.stacks);
+ 	clk_disable_unprepare(ptdev->clks.core);
++	clk_disable_unprepare(ptdev->clks.bus);
+ 	atomic_set(&ptdev->pm.state, PANTHOR_DEVICE_PM_STATE_SUSPENDED);
+ 	return 0;
+ }
+diff --git a/drivers/gpu/drm/panthor/panthor_device.h b/drivers/gpu/drm/panthor/panthor_device.h
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/panthor/panthor_device.h
++++ b/drivers/gpu/drm/panthor/panthor_device.h
+@@ -138,6 +138,9 @@ struct panthor_device {
+ 
+ 	/** @clks: GPU clocks. */
+ 	struct {
++		/** @bus: Bus clock. This clock is optional. */
++		struct clk *bus;
++
+ 		/** @core: Core clock. */
+ 		struct clk *core;
+ 
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 27 Apr 2025 20:34:55 +0000
+Subject: RFC: arm64: dts: rockchip: rk3588: Use scmi gpu clk as main GPU clock
+
+CLK_GPU is the main clock for the GPU on RK3588, it's typical source
+pll can be one of gpll, cpll, aupll, npll or spll. For higher clock
+rates it is also possible to use the gpu pvtpll as pll source.
+
+The logic to switch between a normal pll and the pvtpll depending on
+rate is handled in TF-A firmware, and exposed to Linux as a scmi clock.
+TF-A will typically change to use normal pll for rates up to 200 MHz and
+use pvtpll for 300 MHz or more.
+
+Change to use the SCMI_CLK_GPU as the main GPU clock and add the normal
+CLK_GPU as a bus clk to model this in a similar way as on RK356x.
+
+Prior to this change the GPU clk rate was max 850 MHz:
+
+  $ glmark2-es2-gbm -b terrain
+  [...]
+    GL_VENDOR:      Mesa
+    GL_RENDERER:    Mali-G610 (Panfrost)
+    GL_VERSION:     OpenGL ES 3.1 Mesa 25.0.4
+    Surface Config: buf=32 r=8 g=8 b=8 a=8 depth=24 stencil=0 samples=0
+    Surface Size:   800x600 fullscreen
+  [...]
+  [terrain] <default>: FPS: 139 FrameTime: 7.231 ms
+
+After this the GPU clk rate can use the 1 GHz rate with PVTPLL:
+
+  [terrain] <default>: FPS: 152 FrameTime: 6.579 ms
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-base.dtsi | 10 +++++-----
+ arch/arm64/boot/dts/rockchip/rk3588-opp.dtsi  |  5 +++++
+ arch/arm64/boot/dts/rockchip/rk3588j.dtsi     |  5 +++++
+ 3 files changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -450,11 +450,11 @@ gpu: gpu@fb000000 {
+ 		compatible = "rockchip,rk3588-mali", "arm,mali-valhall-csf";
+ 		reg = <0x0 0xfb000000 0x0 0x200000>;
+ 		#cooling-cells = <2>;
+-		assigned-clocks = <&scmi_clk SCMI_CLK_GPU>;
+-		assigned-clock-rates = <200000000>;
+-		clocks = <&cru CLK_GPU>, <&cru CLK_GPU_COREGROUP>,
+-			 <&cru CLK_GPU_STACKS>;
+-		clock-names = "core", "coregroup", "stacks";
++		assigned-clocks = <&cru CLK_GPU>, <&scmi_clk SCMI_CLK_GPU>;
++		assigned-clock-rates = <198000000>, <200000000>;
++		clocks = <&scmi_clk SCMI_CLK_GPU>, <&cru CLK_GPU_COREGROUP>,
++			 <&cru CLK_GPU_STACKS>, <&cru CLK_GPU>;
++		clock-names = "core", "coregroup", "stacks", "bus";
+ 		dynamic-power-coefficient = <2982>;
+ 		interrupts = <GIC_SPI 92 IRQ_TYPE_LEVEL_HIGH 0>,
+ 			     <GIC_SPI 93 IRQ_TYPE_LEVEL_HIGH 0>,
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-opp.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-opp.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-opp.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-opp.dtsi
+@@ -176,6 +176,11 @@ opp-2400000000 {
+ 	gpu_opp_table: opp-table-gpu {
+ 		compatible = "operating-points-v2";
+ 
++		opp-200000000 {
++			opp-hz = /bits/ 64 <200000000>;
++			opp-microvolt = <675000 675000 850000>;
++			opp-suspend;
++		};
+ 		opp-300000000 {
+ 			opp-hz = /bits/ 64 <300000000>;
+ 			opp-microvolt = <675000 675000 850000>;
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588j.dtsi b/arch/arm64/boot/dts/rockchip/rk3588j.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588j.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588j.dtsi
+@@ -69,6 +69,11 @@ opp-1608000000 {
+ 	gpu_opp_table: opp-table-gpu {
+ 		compatible = "operating-points-v2";
+ 
++		opp-200000000 {
++			opp-hz = /bits/ 64 <200000000>;
++			opp-microvolt = <750000 750000 850000>;
++			opp-suspend;
++		};
+ 		opp-300000000 {
+ 			opp-hz = /bits/ 64 <300000000>;
+ 			opp-microvolt = <750000 750000 850000>;
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 27 Apr 2025 21:20:00 +0000
+Subject: RFC: drm/panthor: Do not set clk rate when device is suspended
+
+On Rockchip RK3588 trying to change the SCMI_CLK_GPU rate when the GPU
+device is PM runtime suspended may cause a kernel panic:
+
+  $ echo 1000000000 > /sys/class/devfreq/fb000000.gpu/min_freq
+
+  SError Interrupt on CPU4, code 0x00000000be000411 -- SError
+  CPU: 4 UID: 0 PID: 241 Comm: sh Not tainted 6.15.0-rc3 #1 VOLUNTARY
+  Hardware name: Radxa ROCK 5B (DT)
+  pstate: 60400009 (nZCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+  pc : smc_send_message+0x140/0x148
+  lr : smc_send_message+0xd8/0x148
+  sp : ffff8000827138c0
+  x29: ffff8000827138c0 x28: ffff000008764000 x27: 0000000000000000
+  x26: 0000000000000000 x25: 00000000ffffffff x24: ffff800082713b28
+  x23: ffff00000696b010 x22: ffff000003db4da0 x21: ffff000003fdae80
+  x20: ffff0000053f22c0 x19: ffff000003db4d80 x18: 0000000000000000
+  x17: 0000000000000000 x16: 0000000000000000 x15: 00000000245df550
+  x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+  x11: 0000000000000040 x10: ffff000003fde138 x9 : ffff000003fde130
+  x8 : ffff000005e5c948 x7 : 0000000000000000 x6 : 0000000000000000
+  x5 : 0000000000000000 x4 : 0000000000000000 x3 : 0000000000000000
+  x2 : 0000000000000000 x1 : 0000000000000000 x0 : 0000000000000000
+  Kernel panic - not syncing: Asynchronous SError Interrupt
+  CPU: 4 UID: 0 PID: 241 Comm: sh Not tainted 6.15.0-rc3 #1 VOLUNTARY
+  Hardware name: Radxa ROCK 5B (DT)
+  Call trace:
+   show_stack+0x28/0x78 (C)
+   dump_stack_lvl+0x58/0x74
+   dump_stack+0x14/0x1c
+   panic+0x14c/0x328
+   add_taint+0x0/0xc0
+   arm64_serror_panic+0x60/0x6c
+   do_serror+0x24/0x60
+   el1h_64_error_handler+0x2c/0x40
+   el1h_64_error+0x6c/0x70
+   smc_send_message+0x140/0x148 (P)
+   do_xfer+0xb0/0x1f8
+   scmi_clock_rate_set+0xc0/0x220
+   scmi_clk_set_rate+0x24/0x38
+   clk_change_rate+0x164/0x288
+   clk_core_set_rate_nolock+0x1dc/0x314
+   clk_set_rate+0x34/0x144
+   _opp_config_clk_single+0x2c/0x90
+   _set_opp+0x104/0x564
+   dev_pm_opp_set_rate+0x110/0x260
+   panthor_devfreq_target+0x38/0x60 [panthor]
+   devfreq_set_target+0x84/0x180
+   devfreq_update_target+0xb4/0xcc
+   update_devfreq+0x10/0x18
+   set_freq_store+0x6c/0xb4
+   dev_attr_store+0x14/0x24
+   sysfs_kf_write+0x54/0x60
+   kernfs_fop_write_iter+0x118/0x1e0
+   vfs_write+0x224/0x390
+   ksys_write+0x68/0x100
+   __arm64_sys_write+0x18/0x20
+   invoke_syscall+0x44/0x100
+   el0_svc_common.constprop.0+0x3c/0xe0
+   do_el0_svc+0x18/0x20
+   el0_svc+0x2c/0xc0
+   el0t_64_sync_handler+0x104/0x130
+   el0t_64_sync+0x170/0x174
+  SMP: stopping secondary CPUs
+  Kernel Offset: disabled
+  CPU features: 0x0e00,000000e0,01202650,8201700b
+  Memory Limit: 3838 MB
+  ---[ end Kernel panic - not syncing: Asynchronous SError Interrupt ]---
+
+This typically happen when CLK_GPU is disabled or when PD_GPU is down.
+
+Add a config_clks ops that will not set core clk rate when the device is
+PM runtime suspended.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+This could possible be limited to the rockchip,rk3588-mali compaible.
+---
+ drivers/gpu/drm/panthor/panthor_devfreq.c | 44 ++++++++++
+ 1 file changed, 44 insertions(+)
+
+diff --git a/drivers/gpu/drm/panthor/panthor_devfreq.c b/drivers/gpu/drm/panthor/panthor_devfreq.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/panthor/panthor_devfreq.c
++++ b/drivers/gpu/drm/panthor/panthor_devfreq.c
+@@ -130,6 +130,41 @@ static struct devfreq_dev_profile panthor_devfreq_profile = {
+ 	.get_cur_freq = panthor_devfreq_get_cur_freq,
+ };
+ 
++static int panthor_devfreq_config_clks(struct device *dev,
++				       struct opp_table *opp_table,
++				       struct dev_pm_opp *opp,
++				       void *data, bool scaling_down)
++{
++	struct panthor_device *ptdev = dev_get_drvdata(dev);
++	struct devfreq *devfreq = ptdev->devfreq->devfreq;
++	unsigned long *target = data;
++	unsigned long freq;
++	int ret = 0;
++
++	/* One of target and opp must be available */
++	if (target) {
++		freq = *target;
++	} else if (opp) {
++		freq = dev_pm_opp_get_freq(opp);
++	} else {
++		WARN_ON(1);
++		return -EINVAL;
++	}
++
++	pm_runtime_get_noresume(dev);
++
++	if (!pm_runtime_suspended(dev) || !devfreq || !devfreq->suspend_freq) {
++		ret = clk_set_rate(ptdev->clks.core, freq);
++		if (ret)
++			dev_err(dev, "failed to set clock rate %lu: %d\n",
++				freq, ret);
++	}
++
++	pm_runtime_put_noidle(dev);
++
++	return ret;
++}
++
+ int panthor_devfreq_init(struct panthor_device *ptdev)
+ {
+ 	/* There's actually 2 regulators (mali and sram), but the OPP core only
+@@ -139,6 +174,11 @@ int panthor_devfreq_init(struct panthor_device *ptdev)
+ 	 * the coupling logic deal with voltage updates.
+ 	 */
+ 	static const char * const reg_names[] = { "mali", NULL };
++	static const char * const clk_names[] = { "core", NULL };
++	struct dev_pm_opp_config config = {
++		.clk_names = clk_names,
++		.config_clks = panthor_devfreq_config_clks,
++	};
+ 	struct thermal_cooling_device *cooling;
+ 	struct device *dev = ptdev->base.dev;
+ 	struct panthor_devfreq *pdevfreq;
+@@ -164,6 +204,10 @@ int panthor_devfreq_init(struct panthor_device *ptdev)
+ 	 */
+ 	table = dev_pm_opp_get_opp_table(dev);
+ 	if (IS_ERR_OR_NULL(table)) {
++		ret = devm_pm_opp_set_config(dev, &config);
++		if (ret)
++			return ret;
++
+ 		ret = devm_pm_opp_set_regulators(dev, reg_names);
+ 		if (ret && ret != -ENODEV) {
+ 			if (ret != -EPROBE_DEFER)
+-- 
+Armbian
+


### PR DESCRIPTION
Sorry for the last time, I relied on CodeRabbit a bit too much, shouldn't have applied that suggestion without testing.

# Description

Just what it says on the tin: enabling 1GHz for Panthor on mainline.

# How Has This Been Tested?

Patched, built, booted, benchmarked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GPU power management and operating point handling on select Rockchip devices, including more accurate frequency selection.
  * Added support for additional GPU clock sources for relevant GPU families.

* **Bug Fixes**
  * Refined suspend/resume behavior by coordinating GPU clock enable/disable sequencing.
  * Updated GPU OPP tables (including low-power OPP with suspend hints) and refreshed device compatibility to better match hardware capabilities.

* **Documentation**
  * Updated device-tree/binding validation to recognize new GPU clock and compatibility options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->