### PR TITLE
u-boot/legacy/u-boot-radxa-rk35xx: change a file here to force all rk vendor u-boots to rebuild

### DIFF
--- a/patch/u-boot/legacy/u-boot-radxa-rk35xx/0000.patching_config.yaml
+++ b/patch/u-boot/legacy/u-boot-radxa-rk35xx/0000.patching_config.yaml
@@ -1,5 +1,5 @@
 config:
-
+  # any changes here cause all rk-vendor uboots to be rebuilt in CI
   overlay-directories:
     - { source: "defconfig", target: "configs" } # copies all files in defconfig dir to the configs/ dir in the u-boot source tree
     - { source: "dt", target: "arch/arm/dts" } # copies all files in dt dir to the arch/arm/dts dir in the u-boot source tree


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal configuration comment to clarify that changes in this area will trigger rebuilding all related U-Boot images in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->