### PR TITLE
mixtile-edge2: u-boot: main: bump (generic) u-boot to v2026.07-rc5

### DIFF
--- a/config/boards/mixtile-edge2.csc
+++ b/config/boards/mixtile-edge2.csc
@@ -24,8 +24,8 @@ function post_family_config__h96_max_use_mainline_uboot() {
 
 	declare -g BOOTCONFIG="generic-rk3568_defconfig"
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-	declare -g BOOTBRANCH="tag:v2024.07"
-	declare -g BOOTPATCHDIR="v2024.07/board_${BOARD}"
+	declare -g BOOTBRANCH="tag:v2026.07-rc5"
+	declare -g BOOTPATCHDIR="v2026.07/board_${BOARD}"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"


### PR DESCRIPTION
- 🐸 this `generic-rk3568_defconfig` so should be save to just bump, no patches etc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the board configuration to use a newer U-Boot release for supported builds.
  * Aligned the related patch path to match the updated U-Boot version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->