### PR TITLE
rk35xx/rockchip-rk3588: add check for 0-byte-dtb u-boot.itb for Radxa u-boot (vendor)

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -45,13 +45,30 @@ esac
 
 prepare_boot_configuration
 
-pre_config_uboot_target__warn_modern_hosts() {
+function pre_config_uboot_target__warn_modern_hosts() {
 	# Check if building Radxa U-Boot on a host other than Ubuntu Jammy
 	if [[ "${BOOTSOURCE}" == "https://github.com/radxa/u-boot.git" ]]; then
 		if [[ "${HOSTRELEASE}" != "jammy" ]]; then
 			display_alert "Building Rockchip BSP U-Boot from Radxa repository" "on Ubuntu ${HOSTRELEASE} (newer than Jammy) can lead to unintended bugs" "wrn"
 		fi
 	fi
+}
+
+function check_uboot_produced_binary_file__check_vendor_uboot_for_0_byte_dtb() {
+	# this hook is called with those two variables
+	: "${base_binfile:?base_binfile is not set}"
+	: "${binfile:?binfile is not set}"
+
+	[[ "${BOOTSOURCE}" != "https://github.com/radxa/u-boot.git" ]] && return 0 # Check if building Radxa U-Boot
+	[[ "${base_binfile}" != "u-boot.itb" ]] && return 0                        # Only check 'u-boot.itb' file
+	display_alert "u-boot for ${BOARD}::${BRANCH} built on ${HOSTRELEASE}" "Checking for 0-byte DTB: ${base_binfile}" "info"
+
+	# Run dumpimage -l, grep it for string 'Data Size:    0 Bytes', if found, exit_with_error
+	if dumpimage -l "${binfile}" | grep -q "Data Size:    0 Bytes"; then
+		exit_with_error "u-boot for ${BOARD}::${BRANCH}::${base_binfile}: Error: The produced u-boot.itb file contains a 0-byte DTB; built on ${HOSTRELEASE}"
+	fi
+
+	return 0
 }
 
 family_tweaks_bsp() {

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -43,13 +43,30 @@ esac
 
 prepare_boot_configuration
 
-pre_config_uboot_target__warn_modern_hosts() {
+function pre_config_uboot_target__warn_modern_hosts() {
 	# Check if building Radxa U-Boot on a host other than Ubuntu Jammy
 	if [[ "${BOOTSOURCE}" == "https://github.com/radxa/u-boot.git" ]]; then
 		if [[ "${HOSTRELEASE}" != "jammy" ]]; then
 			display_alert "Building Rockchip BSP U-Boot from Radxa repository" "on Ubuntu ${HOSTRELEASE} (newer than Jammy) can lead to unintended bugs" "wrn"
 		fi
 	fi
+}
+
+function check_uboot_produced_binary_file__check_vendor_uboot_for_0_byte_dtb() {
+	# this hook is called with those two variables
+	: "${base_binfile:?base_binfile is not set}"
+	: "${binfile:?binfile is not set}"
+
+	[[ "${BOOTSOURCE}" != "https://github.com/radxa/u-boot.git" ]] && return 0 # Check if building Radxa U-Boot
+	[[ "${base_binfile}" != "u-boot.itb" ]] && return 0                        # Only check 'u-boot.itb' file
+	display_alert "u-boot for ${BOARD}::${BRANCH} built on ${HOSTRELEASE}" "Checking for 0-byte DTB: ${base_binfile}" "info"
+
+	# Run dumpimage -l, grep it for string 'Data Size:    0 Bytes', if found, exit_with_error
+	if dumpimage -l "${binfile}" | grep -q "Data Size:    0 Bytes"; then
+		exit_with_error "u-boot for ${BOARD}::${BRANCH}::${base_binfile}: Error: The produced u-boot.itb file contains a 0-byte DTB; built on ${HOSTRELEASE}"
+	fi
+
+	return 0
 }
 
 family_tweaks_bsp() {

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -81,6 +81,7 @@ function artifact_uboot_prepare_version() {
 	declare -a extension_hooks_to_hash=(
 		"post_uboot_custom_postprocess" "fetch_custom_uboot" "build_custom_uboot"
 		"pre_config_uboot_target" "post_config_uboot_target" "pre_package_uboot_image"
+		"check_uboot_produced_binary_file"
 	)
 	declare -a extension_hooks_hashed=("$(dump_extension_method_sources_functions "${extension_hooks_to_hash[@]}")")
 	declare hash_hooks="undetermined"

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -490,6 +490,15 @@ function compile_uboot() {
 			declare target="${SRC}/output/uboot-bin-${uboot_name}-${base_binfile}-host-${HOSTRELEASE}.bin"
 			run_host_command_logged cp -v "${binfile}" "${target}"
 		fi
+
+		# Delegate to a hook for any extra analysis of the u-boot binary file
+		call_extension_method "check_uboot_produced_binary_file" <<- 'CHECK_UBOOT_PRODUCED_BINARY_FILE'
+			*check one produced u-boot binary*
+			This is called once for *each* produced u-boot binary file, before packaging them into the .deb package.
+			You can use this to analyze the produced binary for correctness, or to extract some information from it.
+			You can use the variable binfile to access the full path to the binary file, and base_binfile to access just the filename.
+		CHECK_UBOOT_PRODUCED_BINARY_FILE
+
 	done
 
 	artifact_package_hook_helper_board_side_functions "postinst" uboot_postinst_base "${postinst_functions[@]}"


### PR DESCRIPTION
#### rk35xx/rockchip-rk3588: add check for 0-byte-dtb u-boot.itb for Radxa u-boot (vendor)

- 🌴 u-boot: introduce hook `check_uboot_produced_binary_file`
  - this is called for each produced binary during u-boot build, before they're actually packaged
  - each call passes binfile and base_binfile to indicate the binary
  - add new hook to hashed hooks for u-boot artifact
- 🌳 rk35xx/rockchip-rk3588: add check for 0-byte-dtb u-boot.itb for Radxa u-boot (vendor)
  - uses the new hook `check_uboot_produced_binary_file`
  - runs dumpimage and greps for magic string `Data Size:    0 Bytes`
  - if found, exits with error
  - this is to clearly catch build-host related issue in #8227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new validation step for U-Boot builds that checks produced binaries for invalid 0-byte device tree blobs and stops the build with a clear error if found.
  * U-Boot artifact versions now account for this validation logic, helping keep versioning aligned with build checks.

* **Bug Fixes**
  * Improved build-time safeguards for Radxa/Rockchip U-Boot outputs to catch broken images earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->