### PR TITLE
gateway-dk(-ask): fixes for eternal CI rebuilding

### DIFF
--- a/config/sources/families/ls1046a.conf
+++ b/config/sources/families/ls1046a.conf
@@ -146,7 +146,10 @@ function write_uboot_platform() {
 	)
 	for part in "${parts[@]}"; do
 		local file="${part%%:*}" seek="${part##*:}"
-		[[ -f "$1/${file}" ]] || { echo "write_uboot_platform: missing $1/${file}" >&2; return 1; }
+		[[ -f "$1/${file}" ]] || {
+			echo "write_uboot_platform: missing $1/${file}" >&2
+			return 1
+		}
 		dd if="$1/${file}" of="$2" bs=512 seek="${seek}" conv=notrunc status=noxfer > /dev/null 2>&1 || return 1
 	done
 }

--- a/extensions/gateway-dk-ask.sh
+++ b/extensions/gateway-dk-ask.sh
@@ -52,7 +52,7 @@ function post_family_config__000_ask_override_family() {
 # Uses post_family_config because the kernel patch staging hook needs it before fetch_sources_tools runs
 function post_family_config__ask_fetch_repo() {
 	# Skip during config-dump-json: no $HOME is set, fetch_from_repo would fail in git_ensure_safe_directory
-	[[ "${CONFIG_DEFS_ONLY}" == "yes" ]] && {
+	[[ "${CONFIG_DEFS_ONLY}" == "yes" || "${ARMBIAN_COMMAND}" == "download-artifact" ]] && {
 		declare -g ASK_CACHE_DIR="${SRC}/cache/sources/ask-repo"
 		return 0
 	}

--- a/extensions/gateway-dk-ask.sh
+++ b/extensions/gateway-dk-ask.sh
@@ -95,23 +95,23 @@ function custom_kernel_config__ask_modules() {
 
 	# Copy module sources and Kbuild files from ASK cache
 	# (Kbuild files coexist with old Makefiles — kbuild prefers Kbuild when both exist)
-	mkdir -p "${ask_drv}"
-	cp -a "${ASK_CACHE_DIR}/${ASK_CDX_DIR}" "${ask_drv}/cdx"
-	cp -a "${ASK_CACHE_DIR}/${ASK_FCI_DIR}" "${ask_drv}/fci"
-	cp -a "${ASK_CACHE_DIR}/${ASK_AUTOBRIDGE_DIR}" "${ask_drv}/auto_bridge"
+	run_host_command_logged mkdir -pv "${ask_drv}"
+	run_host_command_logged cp -av "${ASK_CACHE_DIR}/${ASK_CDX_DIR}" "${ask_drv}/cdx"
+	run_host_command_logged cp -av "${ASK_CACHE_DIR}/${ASK_FCI_DIR}" "${ask_drv}/fci"
+	run_host_command_logged cp -av "${ASK_CACHE_DIR}/${ASK_AUTOBRIDGE_DIR}" "${ask_drv}/auto_bridge"
 
 	# Parent Kconfig and Makefile from ASK repo
-	cp "${ASK_CACHE_DIR}/Kconfig" "${ask_drv}/Kconfig"
-	cp "${ASK_CACHE_DIR}/Kbuild.mk" "${ask_drv}/Makefile"
+	run_host_command_logged cp -v "${ASK_CACHE_DIR}/Kconfig" "${ask_drv}/Kconfig"
+	run_host_command_logged cp -v "${ASK_CACHE_DIR}/Kbuild.mk" "${ask_drv}/Makefile"
 
 	# Board-specific modules (not part of ASK repo — from Armbian BSP)
 	if [[ "${BOARD}" == "gateway-dk" ]]; then
-		mkdir -p "${ask_drv}/sfp_led" "${ask_drv}/leds_lp5812"
-		cp "${bsp_dir}/sfp-led.c" "${ask_drv}/sfp_led/"
-		cp "${bsp_dir}/sfp-led.Kbuild" "${ask_drv}/sfp_led/Kbuild"
-		cp "${bsp_dir}/leds-lp5812.c" "${ask_drv}/leds_lp5812/"
-		cp "${bsp_dir}/leds-lp5812.h" "${ask_drv}/leds_lp5812/"
-		cp "${bsp_dir}/leds-lp5812.Kbuild" "${ask_drv}/leds_lp5812/Kbuild"
+		run_host_command_logged mkdir -pv "${ask_drv}/sfp_led" "${ask_drv}/leds_lp5812"
+		run_host_command_logged cp -v "${bsp_dir}/sfp-led.c" "${ask_drv}/sfp_led/"
+		run_host_command_logged cp -v "${bsp_dir}/sfp-led.Kbuild" "${ask_drv}/sfp_led/Kbuild"
+		run_host_command_logged cp -v "${bsp_dir}/leds-lp5812.c" "${ask_drv}/leds_lp5812/"
+		run_host_command_logged cp -v "${bsp_dir}/leds-lp5812.h" "${ask_drv}/leds_lp5812/"
+		run_host_command_logged cp -v "${bsp_dir}/leds-lp5812.Kbuild" "${ask_drv}/leds_lp5812/Kbuild"
 
 		# Add board-specific entries to ASK Kconfig and Makefile
 		patch -p1 -d "${ask_drv}" < "${bsp_dir}/ask-kconfig-board-modules.patch"
@@ -121,11 +121,18 @@ function custom_kernel_config__ask_modules() {
 
 	# Wire into parent freescale Kconfig and Makefile
 	local fsl_dir="${kernel_work_dir}/drivers/net/ethernet/freescale"
-	if ! grep -q 'source.*ask/Kconfig' "${fsl_dir}/Kconfig" 2> /dev/null; then
+	if ! grep -q 'source.*ask/Kconfig' "${fsl_dir}/Kconfig"; then
+		display_alert "ASK extension" "adding ASK Kconfig to freescale Kconfig" "info"
 		sed -i '/endif.*NET_VENDOR_FREESCALE/i source "drivers/net/ethernet/freescale/ask/Kconfig"' "${fsl_dir}/Kconfig"
+	else
+		display_alert "ASK extension" "ASK Kconfig already present in freescale Kconfig" "info"
 	fi
-	if ! grep -q 'ask/' "${fsl_dir}/Makefile" 2> /dev/null; then
+
+	if ! grep -q 'ask/' "${fsl_dir}/Makefile"; then
+		display_alert "ASK extension" "adding ASK modules to freescale Makefile" "info"
 		echo 'obj-y += ask/' >> "${fsl_dir}/Makefile"
+	else
+		display_alert "ASK extension" "ASK modules already present in freescale Makefile"
 	fi
 
 	display_alert "ASK extension" "ASK module sources and Kbuild files placed in kernel tree" "info"
@@ -146,13 +153,14 @@ function custom_kernel_config__ask_modules() {
 # framework merges them with patches from patch/kernel/ at build time. The directory is
 # gitignored and ephemeral; it does not persist across clean builds.
 function post_family_config__ask_kernel_patch() {
+	display_alert "ASK extension" "ASK kernel patch being staged in userpatches" "wrn"
 	[[ "${CONFIG_DEFS_ONLY}" == "yes" ]] && return 0 # cache wasn't populated during config-dump-json
 	local patch_src="${ASK_CACHE_DIR}/patches/kernel/002-mono-gateway-ask-kernel_linux_6_12.patch"
 	[[ -f "${patch_src}" ]] || exit_with_error "ASK kernel patch not found" "${patch_src}"
 	local patch_dst="${SRC}/userpatches/kernel/${KERNELPATCHDIR}"
-	mkdir -p "${patch_dst}"
+	run_host_command_logged mkdir -pv "${patch_dst}"
 	# Renamed to 003- to apply after 001-ina234 and 002-device-tree in the Armbian patch dir
-	cp "${patch_src}" "${patch_dst}/003-mono-gateway-ask-kernel_linux_6_12.patch"
+	run_host_command_logged cp -v "${patch_src}" "${patch_dst}/003-mono-gateway-ask-kernel_linux_6_12.patch"
 	display_alert "ASK extension" "ASK kernel patch staged in userpatches" "info"
 }
 
@@ -529,6 +537,5 @@ function rebuild_patched_deb() {
 		DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -b -uc -us && \
 		cd '${workdir}' && dpkg -i ${debs} && \
 		cp ${debs} /tmp/ask-patched-debs/ && \
-		rm -rf '${workdir}'" ||
-		exit_with_error "${pkg} rebuild failed"
+		rm -rf '${workdir}'" || exit_with_error "${pkg} rebuild failed"
 }

--- a/extensions/gateway-dk-ask.sh
+++ b/extensions/gateway-dk-ask.sh
@@ -93,6 +93,12 @@ function custom_kernel_config__ask_modules() {
 	local ask_drv="${kernel_work_dir}/drivers/net/ethernet/freescale/ask"
 	local bsp_dir="${SRC}/packages/bsp/gateway-dk"
 
+	# Cleanup previous tree if it exists (otherwise copying again creates 1-deep duplicates)
+	if [[ -d "${ask_drv}" ]]; then
+		display_alert "ASK extension" "removing previous ASK module tree in kernel" "info"
+		run_host_command_logged rm -rf "${ask_drv}"
+	fi
+
 	# Copy module sources and Kbuild files from ASK cache
 	# (Kbuild files coexist with old Makefiles — kbuild prefers Kbuild when both exist)
 	run_host_command_logged mkdir -pv "${ask_drv}"

--- a/extensions/gateway-dk-ask.sh
+++ b/extensions/gateway-dk-ask.sh
@@ -52,7 +52,10 @@ function post_family_config__000_ask_override_family() {
 # Uses post_family_config because the kernel patch staging hook needs it before fetch_sources_tools runs
 function post_family_config__ask_fetch_repo() {
 	# Skip during config-dump-json: no $HOME is set, fetch_from_repo would fail in git_ensure_safe_directory
-	[[ "${CONFIG_DEFS_ONLY}" == "yes" ]] && { declare -g ASK_CACHE_DIR="${SRC}/cache/sources/ask-repo"; return 0; }
+	[[ "${CONFIG_DEFS_ONLY}" == "yes" ]] && {
+		declare -g ASK_CACHE_DIR="${SRC}/cache/sources/ask-repo"
+		return 0
+	}
 	# For local file:// repos in Docker, safe.directory is needed (container runs as root)
 	# Use env vars instead of git config --global to avoid persistent side effects
 	if [[ "${ASK_REPO}" == file://* ]]; then
@@ -62,7 +65,7 @@ function post_family_config__ask_fetch_repo() {
 		export GIT_CONFIG_KEY_1="safe.directory" GIT_CONFIG_VALUE_1="${local_path}/.git"
 	fi
 	fetch_from_repo "${ASK_REPO}" "ask-repo" "${ASK_BRANCH}"
-	unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0 GIT_CONFIG_KEY_1 GIT_CONFIG_VALUE_1 2>/dev/null
+	unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0 GIT_CONFIG_KEY_1 GIT_CONFIG_VALUE_1 2> /dev/null
 	declare -g ASK_CACHE_DIR="${SRC}/cache/sources/ask-repo"
 }
 
@@ -118,10 +121,10 @@ function custom_kernel_config__ask_modules() {
 
 	# Wire into parent freescale Kconfig and Makefile
 	local fsl_dir="${kernel_work_dir}/drivers/net/ethernet/freescale"
-	if ! grep -q 'source.*ask/Kconfig' "${fsl_dir}/Kconfig" 2>/dev/null; then
+	if ! grep -q 'source.*ask/Kconfig' "${fsl_dir}/Kconfig" 2> /dev/null; then
 		sed -i '/endif.*NET_VENDOR_FREESCALE/i source "drivers/net/ethernet/freescale/ask/Kconfig"' "${fsl_dir}/Kconfig"
 	fi
-	if ! grep -q 'ask/' "${fsl_dir}/Makefile" 2>/dev/null; then
+	if ! grep -q 'ask/' "${fsl_dir}/Makefile" 2> /dev/null; then
 		echo 'obj-y += ask/' >> "${fsl_dir}/Makefile"
 	fi
 
@@ -152,7 +155,6 @@ function post_family_config__ask_kernel_patch() {
 	cp "${patch_src}" "${patch_dst}/003-mono-gateway-ask-kernel_linux_6_12.patch"
 	display_alert "ASK extension" "ASK kernel patch staged in userpatches" "info"
 }
-
 
 # Install module autoload config (modules are in the kernel .deb, just need the load list)
 function post_install_kernel_debs__ask_module_autoload() {
@@ -211,8 +213,8 @@ function pre_customize_image__001_build_ask_userspace() {
 	chroot_sdcard "cd /tmp/ask-userspace/fmlib && \
 		patch -p1 < /tmp/ask-userspace/01-mono-ask-extensions.patch && \
 		make KERNEL_SRC=${kdir} libfm-arm.a && \
-		make DESTDIR=/ PREFIX=/usr LIB_DEST_DIR=/usr/lib/${ASK_HOST_TRIPLET} install-libfm-arm" \
-		|| exit_with_error "fmlib build failed"
+		make DESTDIR=/ PREFIX=/usr LIB_DEST_DIR=/usr/lib/${ASK_HOST_TRIPLET} install-libfm-arm" ||
+		exit_with_error "fmlib build failed"
 
 	# --- fmc ---
 	display_alert "ASK extension" "building fmc" "info"
@@ -233,8 +235,8 @@ function pre_customize_image__001_build_ask_userspace() {
 		install -m 644 source/fmc.h /usr/include/fmc/ && \
 		install -m 644 source/libfmc.a /usr/lib/${ASK_HOST_TRIPLET}/ && \
 		install -d /etc/fmc/config && \
-		install -m 644 etc/fmc/config/* /etc/fmc/config/" \
-		|| exit_with_error "fmc build failed"
+		install -m 644 etc/fmc/config/* /etc/fmc/config/" ||
+		exit_with_error "fmc build failed"
 
 	# --- libcli ---
 	display_alert "ASK extension" "building libcli" "info"
@@ -243,8 +245,8 @@ function pre_customize_image__001_build_ask_userspace() {
 
 	chroot_sdcard "cd /tmp/ask-userspace/libcli && \
 		make CFLAGS='-Wno-calloc-transposed-args' && \
-		make PREFIX=/usr DESTDIR=/ install" \
-		|| exit_with_error "libcli build failed"
+		make PREFIX=/usr DESTDIR=/ install" ||
+		exit_with_error "libcli build failed"
 
 	# --- libfci ---
 	display_alert "ASK extension" "building libfci" "info"
@@ -253,8 +255,8 @@ function pre_customize_image__001_build_ask_userspace() {
 	chroot_sdcard "cd /tmp/ask-userspace/libfci && \
 		make && \
 		install -m 644 libfci.a /usr/lib/${ASK_HOST_TRIPLET}/ && \
-		install -m 644 include/libfci.h /usr/include/" \
-		|| exit_with_error "libfci build failed"
+		install -m 644 include/libfci.h /usr/include/" ||
+		exit_with_error "libfci build failed"
 
 	# --- dpa-app ---
 	display_alert "ASK extension" "building dpa-app" "info"
@@ -269,8 +271,8 @@ function pre_customize_image__001_build_ask_userspace() {
 				-I/usr/include/fmc -I/usr/include/fmd -I/usr/include/fmd/integrations \
 				-I/usr/include/fmd/Peripherals -I/usr/include/fmd/Peripherals/common -I/usr/include/cdx' \
 			LDFLAGS='-lfmc -lfm-arm -lstdc++ -lxml2 -lpthread -lcli' && \
-		install -m 755 dpa_app /usr/bin/" \
-		|| exit_with_error "dpa-app build failed"
+		install -m 755 dpa_app /usr/bin/" ||
+		exit_with_error "dpa-app build failed"
 
 	# Install DPA-App config files (from ASK repo)
 	cp "${ASK_CACHE_DIR}/config/gateway-dk/cdx_cfg.xml" "${SDCARD}/etc/"
@@ -295,8 +297,8 @@ function pre_customize_image__001_build_ask_userspace() {
 		install -d /usr/lib/${ASK_HOST_TRIPLET}/xtables && \
 		for name in ${ask_xtables_modules[*]}; do \
 			install -m 644 \"\${name}.so\" /usr/lib/${ASK_HOST_TRIPLET}/xtables/ || exit 1; \
-		done" \
-		|| exit_with_error "xtables extensions build failed"
+		done" ||
+		exit_with_error "xtables extensions build failed"
 
 	# --- Patched system libraries (must be before CMM which depends on patched libnetfilter-conntrack) ---
 	build_ask_patched_libraries
@@ -318,8 +320,8 @@ function pre_customize_image__001_build_ask_userspace() {
 			LIBFCI_DIR=/tmp/ask-userspace/libfci \
 			ABM_DIR=/usr \
 			SYSROOT=/ && \
-		install -m 755 src/cmm /usr/bin/" \
-		|| exit_with_error "cmm build failed"
+		install -m 755 src/cmm /usr/bin/" ||
+		exit_with_error "cmm build failed"
 
 	# Install and enable CMM service (from ASK repo)
 	# Guarded by ConditionPathExists=/dev/cdx_ctrl — won't start without ASK FMAN ucode on NOR
@@ -379,7 +381,7 @@ function pre_customize_image__001_build_ask_userspace() {
 	# Libraries — snapshot all ASK-installed libs from chroot
 	mkdir -p "${pkgdir}/usr/lib/${ASK_HOST_TRIPLET}"
 	for lib in libfm-arm.a libfmc.a; do
-		[[ -f "${SDCARD}/usr/lib/${ASK_HOST_TRIPLET}/${lib}" ]] && \
+		[[ -f "${SDCARD}/usr/lib/${ASK_HOST_TRIPLET}/${lib}" ]] &&
 			cp -a "${SDCARD}/usr/lib/${ASK_HOST_TRIPLET}/${lib}" "${pkgdir}/usr/lib/${ASK_HOST_TRIPLET}/"
 	done
 	for pattern in libcli libfci; do
@@ -463,11 +465,11 @@ CONFFILES
 	# Build .deb once, install in chroot and save to output
 	local debfile="${pkgname}_${ask_version}_arm64.deb"
 	mkdir -p "${SRC}/output/debs"
-	run_host_command_logged dpkg-deb -b "${pkgdir}" "${SRC}/output/debs/${debfile}" \
-		|| exit_with_error "dpkg-deb failed for ${debfile}"
+	run_host_command_logged dpkg-deb -b "${pkgdir}" "${SRC}/output/debs/${debfile}" ||
+		exit_with_error "dpkg-deb failed for ${debfile}"
 	cp "${SRC}/output/debs/${debfile}" "${SDCARD}/root/"
-	chroot_sdcard "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends /root/${debfile}" \
-		|| exit_with_error "apt install failed for ${debfile}"
+	chroot_sdcard "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends /root/${debfile}" ||
+		exit_with_error "apt install failed for ${debfile}"
 	rm -f "${SDCARD}/root/${debfile}"
 
 	rm -rf "${pkgdir}"
@@ -494,10 +496,9 @@ function build_ask_patched_libraries() {
 		"01-nxp-ask-nonblocking-heap-buffer.patch" \
 		"libnfnetlink0_*.deb libnfnetlink-dev_*.deb"
 
-
 	# Copy patched .debs to output for distribution
 	mkdir -p "${SRC}/output/debs"
-	cp "${SDCARD}"/tmp/ask-patched-debs/*.deb "${SRC}/output/debs/" 2>/dev/null || true
+	cp "${SDCARD}"/tmp/ask-patched-debs/*.deb "${SRC}/output/debs/" 2> /dev/null || true
 	rm -rf "${SDCARD}/tmp/ask-patched-debs"
 }
 
@@ -528,6 +529,6 @@ function rebuild_patched_deb() {
 		DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -b -uc -us && \
 		cd '${workdir}' && dpkg -i ${debs} && \
 		cp ${debs} /tmp/ask-patched-debs/ && \
-		rm -rf '${workdir}'" \
-		|| exit_with_error "${pkg} rebuild failed"
+		rm -rf '${workdir}'" ||
+		exit_with_error "${pkg} rebuild failed"
 }

--- a/extensions/gateway-dk-ask.sh
+++ b/extensions/gateway-dk-ask.sh
@@ -154,20 +154,34 @@ function custom_kernel_config__ask_modules() {
 	fi
 }
 
-# Copy ASK kernel patch to userpatches (gitignored) so it's applied during kernel build.
+# Copy ASK kernel patch to userpatches so it's applied during kernel build.
 # userpatches/ is the Armbian-standard location for extension-provided patches — the build
-# framework merges them with patches from patch/kernel/ at build time. The directory is
-# gitignored and ephemeral; it does not persist across clean builds.
-function post_family_config__ask_kernel_patch() {
+# framework merges them with patches from patch/kernel/ at build time.
+function kernel_extra_create_patches__ask_kernel_patch() {
 	display_alert "ASK extension" "ASK kernel patch being staged in userpatches" "wrn"
-	[[ "${CONFIG_DEFS_ONLY}" == "yes" ]] && return 0 # cache wasn't populated during config-dump-json
-	local patch_src="${ASK_CACHE_DIR}/patches/kernel/002-mono-gateway-ask-kernel_linux_6_12.patch"
+	declare patch_src="${ASK_CACHE_DIR}/patches/kernel/002-mono-gateway-ask-kernel_linux_6_12.patch"
 	[[ -f "${patch_src}" ]] || exit_with_error "ASK kernel patch not found" "${patch_src}"
-	local patch_dst="${SRC}/userpatches/kernel/${KERNELPATCHDIR}"
+	declare patch_dst="${SRC}/userpatches/kernel/${KERNELPATCHDIR}"
+	declare patch_dst_file="${patch_dst}/003-mono-gateway-ask-kernel_linux_6_12.patch"
 	run_host_command_logged mkdir -pv "${patch_dst}"
 	# Renamed to 003- to apply after 001-ina234 and 002-device-tree in the Armbian patch dir
-	run_host_command_logged cp -v "${patch_src}" "${patch_dst}/003-mono-gateway-ask-kernel_linux_6_12.patch"
+	run_host_command_logged cp -v "${patch_src}" "${patch_dst_file}"
+	run_host_command_logged touch "${patch_dst_file}" # always recently-modified
 	display_alert "ASK extension" "ASK kernel patch staged in userpatches" "info"
+}
+
+function post_family_config__cleanup_ask_kernel_patch() {
+	declare patch_dst="${SRC}/userpatches/kernel/${KERNELPATCHDIR}"
+	declare patch_dst_file="${patch_dst}/003-mono-gateway-ask-kernel_linux_6_12.patch"
+	# if patch_dst_file exists, remove it -- it shouldn't be there in post_family_config stage (pre-hashing)
+	# read: "the previous build left a staged ASK kernel patch in userpatches, remove it so patches hash doesn't change"
+	if [[ -f "${patch_dst_file}" ]]; then
+		display_alert "ASK extension" "removing staged ASK kernel patch from userpatches" "info"
+		run_host_command_logged rm -f "${patch_dst_file}"
+	else
+		display_alert "ASK extension" "no staged ASK kernel patch found in userpatches, nothing to remove" "info"
+	fi
+	return 0
 }
 
 # Install module autoload config (modules are in the kernel .deb, just need the load list)

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -151,7 +151,10 @@ function artifact_kernel_prepare_version() {
 	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
 
 	# Hash the extension hooks
-	declare -a extension_hooks_to_hash=("pre_package_kernel_image" "kernel_copy_extra_sources" "pre_package_kernel_headers")
+	declare -a extension_hooks_to_hash=(
+		"pre_package_kernel_image" "kernel_copy_extra_sources" "pre_package_kernel_headers"
+		"kernel_extra_create_patches"
+	)
 	declare -a extension_hooks_hashed=("$(dump_extension_method_sources_functions "${extension_hooks_to_hash[@]}")")
 	declare hash_hooks="undetermined"
 	hash_hooks="$(echo "${extension_hooks_hashed[@]}" | sha256sum | cut -d' ' -f1)"

--- a/lib/functions/compilation/kernel-patching.sh
+++ b/lib/functions/compilation/kernel-patching.sh
@@ -75,6 +75,14 @@ function kernel_main_patching() {
 	declare kernel_drivers_patch_file kernel_drivers_patch_hash
 	LOG_SECTION="kernel_drivers_create_patches" do_with_logging do_with_hooks kernel_drivers_create_patches "${kernel_work_dir}" "${kernel_git_revision}"
 
+	call_extension_method "kernel_extra_create_patches" <<- 'KERNEL_EXTRA_CREATE_PATCHES'
+		*stage more patches for kernel, after kernel_drivers*
+		This is called after kernel_drivers_create_patches (wifi-drivers) and can be used to stage more patches
+		to be applied. This is done immediately before actually patching, and thus, after any hashing is done.
+		This allows implementors to stage custom patches (eg, from an out-of-tree driver into userpatches) without
+		impacting the kernel version/hash.
+	KERNEL_EXTRA_CREATE_PATCHES
+
 	# Python patching will git reset to the kernel SHA1 git revision, and remove all untracked files.
 	LOG_SECTION="kernel_main_patching_python" do_with_logging do_with_hooks kernel_main_patching_python
 


### PR DESCRIPTION
#### gateway-dk(-ask): fixes for eternal CI rebuilding

- 🌿 gateway-dk: shellfmt, no changes
- 🍃 gateway-dk: better logging
  - trying to find why one can't rebuild (1st build is okay)
- 🍀 gateway-dk-ask: cleanup previous `ask` tree if present
  - fixes re-builds
  - otherwise, files are 1 level off:
    - 1st clean build: `drivers/net/ethernet/freescale/ask/cdx/Makefile`
    - 2nd+ rebuild: `drivers/net/ethernet/freescale/ask/cdx/cdx/Makefile`
- 🌴 kernel: introduce hook `kernel_extra_create_patches`
  - immediately after `kernel_drivers_create_patches`
  - immediately before actually applying kernel sources
  - this helps boards/families/extensions that need to stage out-of-tree patches into eg userpatches, without impacting the patches hash
  - the hook itself is hashed, so changes to it do impact the hooks hash
- 🌵 gateway-dk-ask: use new hook `kernel_extra_create_patches` to stage ask patch
  - before this, ask extension would stage a userpatch during post_family_config, if it was not in CONFIG_DEFS_ONLY mode
  - this would cause hashing to differ between matrix-prepare and actual build
    - matrix patches hash wouldn't have the patch
    - actual-build patches hash would
    - this caused infinite rebuilding of the kernel in CI
  - previous commit introduced a new hook made for this purpose
    - implement it here -- unconditionally, as it only ever run in actual build
  - also implement a cleanup (in post_family_config) so any leftovers are removed and won't affect further
  - remove claims that userpatches are gitignored (they aren't) and that they don't survive across builds (they do, unless handled as explained above)
- 🐸 gateway-dk-ask: don't fetch ask repo also during download-artifact
  - `download-artifact` should not cause a fetch, as it would fail anyway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved kernel patch handling so additional patches can be staged before hashing, making the build flow more flexible.
  * Updated ASK kernel integration to better manage module source setup and patch staging.

* **Bug Fixes**
  * Added clearer missing-file reporting for platform-specific builds.
  * Strengthened build and packaging steps so failures are surfaced immediately instead of continuing silently.
  * Made patched-library output handling more reliable by ensuring required output folders exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->