### PR TITLE
rk35xx/rockchip-rk3588: vendor u-boot: more logs for 0-byte-dtb (or not)

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -65,7 +65,9 @@ function check_uboot_produced_binary_file__check_vendor_uboot_for_0_byte_dtb() {
 
 	# Run dumpimage -l, grep it for string 'Data Size:    0 Bytes', if found, exit_with_error
 	if dumpimage -l "${binfile}" | grep -q "Data Size:    0 Bytes"; then
-		exit_with_error "u-boot for ${BOARD}::${BRANCH}::${base_binfile}: Error: The produced u-boot.itb file contains a 0-byte DTB; built on ${HOSTRELEASE}"
+		exit_with_error "u-boot for ${BOARD}::${BRANCH}::${base_binfile}: Error: The produced u-boot.itb file contains a 0-byte DTB; built on ${HOSTRELEASE} (${RUNNER_NAME}::${RUNNER_ENVIRONMENT}::${RUNNER_ARCH})"
+	else
+		display_alert "u-boot for ${BOARD}::${BRANCH}::${base_binfile}" "OK, produced u-boot.itb does NOT have 0-byte-dtb; built on ${HOSTRELEASE} (${RUNNER_NAME}::${RUNNER_ENVIRONMENT}::${RUNNER_ARCH})" "notice" # logs to CI log
 	fi
 
 	return 0

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -63,7 +63,9 @@ function check_uboot_produced_binary_file__check_vendor_uboot_for_0_byte_dtb() {
 
 	# Run dumpimage -l, grep it for string 'Data Size:    0 Bytes', if found, exit_with_error
 	if dumpimage -l "${binfile}" | grep -q "Data Size:    0 Bytes"; then
-		exit_with_error "u-boot for ${BOARD}::${BRANCH}::${base_binfile}: Error: The produced u-boot.itb file contains a 0-byte DTB; built on ${HOSTRELEASE}"
+		exit_with_error "u-boot for ${BOARD}::${BRANCH}::${base_binfile}: Error: The produced u-boot.itb file contains a 0-byte DTB; built on ${HOSTRELEASE} (${RUNNER_NAME}::${RUNNER_ENVIRONMENT}::${RUNNER_ARCH})"
+	else
+		display_alert "u-boot for ${BOARD}::${BRANCH}::${base_binfile}" "OK, produced u-boot.itb does NOT have 0-byte-dtb; built on ${HOSTRELEASE} (${RUNNER_NAME}::${RUNNER_ENVIRONMENT}::${RUNNER_ARCH})" "notice" # logs to CI log
 	fi
 
 	return 0

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -526,6 +526,9 @@ function docker_cli_prepare_launch() {
 		"--env" "GITHUB_SHA=${GITHUB_SHA}"
 		"--env" "GITHUB_WORKFLOW=${GITHUB_WORKFLOW}"
 		"--env" "GITHUB_WORKSPACE=${GITHUB_WORKSPACE}"
+		"--env" "RUNNER_ARCH=${RUNNER_ARCH}"
+		"--env" "RUNNER_ENVIRONMENT=${RUNNER_ENVIRONMENT}"
+		"--env" "RUNNER_NAME=${RUNNER_NAME}"
 
 		# Pass proxy args
 		"--env" "http_proxy=${http_proxy:-${HTTP_PROXY:-}}"

--- a/lib/functions/logging/display-alert.sh
+++ b/lib/functions/logging/display-alert.sh
@@ -148,6 +148,13 @@ function display_alert() {
 			ci_log="warning"
 			;;
 
+		notice )
+			level="notice"
+			level_indicator="🥦"
+			inline_logs_color="\e[1;32m"
+			ci_log="notice"
+			;;
+
 		ext)
 			level_indicator="✨"
 			case "${background_dark_or_light}" in


### PR DESCRIPTION
#### rk35xx/rockchip-rk3588: vendor u-boot: more logs for 0-byte-dtb (or not)

- 🌴 docker: pass down GHA envs RUNNER_ARCH/RUNNER_ENVIRONMENT/RUNNER_NAME
  - so we can know runner info from GHA to help debug runner-related issues
  - see https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables
- 🌳 display-alert: new `notice` level; a brocolli that also goes to GHA logs
- 🌱 rk35xx/rockchip-rk3588: vendor u-boot: more logs for 0-byte-dtb (or not)
  - so we can take a single look at CI logs and see what breaks or not and where

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI and build messages now include additional runner environment details, making it easier to identify where a check ran.
  * A new `notice` log level is now supported, with a distinct symbol and green styling for clearer alerts.

* **Bug Fixes**
  * Success and error messages for boot image validation now provide more context when reporting issues, improving troubleshooting in CI logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->