### PR TITLE
rk35xx/rockchip-rk3588: vendor u-boot: touch logging to force rebuild

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -65,7 +65,7 @@ function check_uboot_produced_binary_file__check_vendor_uboot_for_0_byte_dtb() {
 
 	# Run dumpimage -l, grep it for string 'Data Size:    0 Bytes', if found, exit_with_error
 	if dumpimage -l "${binfile}" | grep -q "Data Size:    0 Bytes"; then
-		exit_with_error "u-boot for ${BOARD}::${BRANCH}::${base_binfile}: Error: The produced u-boot.itb file contains a 0-byte DTB; built on ${HOSTRELEASE} (${RUNNER_NAME}::${RUNNER_ENVIRONMENT}::${RUNNER_ARCH})"
+		exit_with_error "u-boot for ${BOARD}::${BRANCH}::${base_binfile}: ERROR: The produced u-boot.itb file contains a 0-byte DTB; built on ${HOSTRELEASE} (${RUNNER_NAME}::${RUNNER_ENVIRONMENT}::${RUNNER_ARCH})"
 	else
 		display_alert "u-boot for ${BOARD}::${BRANCH}::${base_binfile}" "OK, produced u-boot.itb does NOT have 0-byte-dtb; built on ${HOSTRELEASE} (${RUNNER_NAME}::${RUNNER_ENVIRONMENT}::${RUNNER_ARCH})" "notice" # logs to CI log
 	fi

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -63,7 +63,7 @@ function check_uboot_produced_binary_file__check_vendor_uboot_for_0_byte_dtb() {
 
 	# Run dumpimage -l, grep it for string 'Data Size:    0 Bytes', if found, exit_with_error
 	if dumpimage -l "${binfile}" | grep -q "Data Size:    0 Bytes"; then
-		exit_with_error "u-boot for ${BOARD}::${BRANCH}::${base_binfile}: Error: The produced u-boot.itb file contains a 0-byte DTB; built on ${HOSTRELEASE} (${RUNNER_NAME}::${RUNNER_ENVIRONMENT}::${RUNNER_ARCH})"
+		exit_with_error "u-boot for ${BOARD}::${BRANCH}::${base_binfile}: ERROR: The produced u-boot.itb file contains a 0-byte DTB; built on ${HOSTRELEASE} (${RUNNER_NAME}::${RUNNER_ENVIRONMENT}::${RUNNER_ARCH})"
 	else
 		display_alert "u-boot for ${BOARD}::${BRANCH}::${base_binfile}" "OK, produced u-boot.itb does NOT have 0-byte-dtb; built on ${HOSTRELEASE} (${RUNNER_NAME}::${RUNNER_ENVIRONMENT}::${RUNNER_ARCH})" "notice" # logs to CI log
 	fi


### PR DESCRIPTION
- 🍀 this time I'm gonna try vs GHA-hosted runners to see what happens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the error label to `ERROR:` in boot image checks when a generated DTB is empty, making failure messages clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->