### PR TITLE
sunxi-6.18: fix H3/H5 RCU stall / CPU hang during DVFS (current kernel)

### DIFF
--- a/patch/kernel/archive/sunxi-6.18/series.conf
+++ b/patch/kernel/archive/sunxi-6.18/series.conf
@@ -64,7 +64,7 @@
 	patches.megous/audio-6.18/0010-sound-soc-sun8i-codec-Add-support-for-digital-part-o.patch
 	patches.megous/audio-6.18/0011-ASoC-ec25-New-codec-driver-for-the-EC25-modem.patch
 	patches.megous/aw-opp-6.18/0001-clk-sunxi-ng-Set-maximum-P-and-M-factors-to-1-for-H3.patch
-	patches.megous/aw-opp-6.18/0002-clk-sunxi-ng-Don-t-use-CPU-PLL-gating-and-CPUX-repar.patch
+-	patches.megous/aw-opp-6.18/0002-clk-sunxi-ng-Don-t-use-CPU-PLL-gating-and-CPUX-repar.patch
 	patches.megous/aw-opp-6.18/0003-ARM-dts-sun8i-h3-Use-my-own-more-aggressive-OPPs-on-.patch
 	patches.megous/aw-opp-6.18/0004-arm64-dts-sun50i-h5-Use-my-own-more-aggressive-OPPs-.patch
 	patches.megous/aw-opp-6.18/0005-ARM-dts-sun8i-h3-orange-pi-pc-Increase-max-CPUX-volt.patch


### PR DESCRIPTION
## Problem

H3/H5 sunxi boards on the **current (6.18)** kernel hang during early boot, right after thermal-zone init — manifesting as an **RCU stall** (a CPU that stopped responding). Legacy (6.12) boots fine on the same boards. Confirmed on **orangepizeroplus (H5)**.

## Root cause

The megous `aw-opp-6.18` patch **0002 "Don't use CPU PLL gating and CPUX reparenting to HOSC"** removes two CPU-clock safety notifiers from `ccu-sun8i-h3.c`:

- `sun8i_h3_pll_cpu_nb` — gates `pll_cpux` across rate changes so it relocks cleanly
- `sun8i_h3_cpu_nb` — reparents the CPU to the 24 MHz oscillator while `pll_cpux` is being reprogrammed, then switches back

Without them, the core keeps executing off `pll_cpux` **while the PLL is mid-relock**. On 6.18 the sunxi clk core was refactored (`round_rate` → `determine_rate` in `ccu_nkmp`, plus the `ccu_mp` rework), and that live PLL change now glitches the CPU at the **first cpufreq/DVFS transition** → core hang → RCU stall.

This is an **interaction regression**: the patch is byte-identical on legacy 6.12 (which boots), so the difference is purely the 6.18 clk-core rework — not a patch that stopped applying.

## Fix

Leave patch 0002 **unapplied** (via the documented `-` prefix in `series.conf`), restoring upstream's notifiers — i.e. the same behavior as legacy 6.12. Minimal and conservative: the OPP tables and patch 0001 (max P/M=1) are untouched.

## Why edge (7.0) is not touched

`aw-opp-7.0` is **already correct**: it applies 0002 but then **reverts it via 0012** and refines with `0013-Run-notifiers-just-once-on-H3` / `0008-Allow-to-run-CPU-clock-change-notifiers`. The notifiers are present in the patched 7.0 tree (verified). Disabling 0002 there would **break the build** — 0012 would have nothing to revert. The 6.18 aw-opp series is an older snapshot (0001–0007) taken before those upstream fixes.

## Test

- ✅ orangepizeroplus (H5), `BRANCH=current`: boots normally (was: RCU stall at boot)
- Expected to fix the other H3/H5 current-kernel boards too, since `archive/sunxi-6.18` is shared across them.

## Diff

One line in `patch/kernel/archive/sunxi-6.18/series.conf` — disables 0002 with an explanatory comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the kernel patch set to skip one previously applied change, helping keep the platform’s build and runtime behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closing https://github.com/armbian/build/issues/10075