### PR TITLE
rockchip: udev: grant video group access to MPP codec devices and DMA-heaps

### DIFF
--- a/packages/bsp/rockchip/60-media.rules
+++ b/packages/bsp/rockchip/60-media.rules
@@ -1,2 +1,4 @@
 KERNEL=="media*", MODE="0660", GROUP="video"
 KERNEL=="rga", MODE="0660", GROUP="video"
+KERNEL=="mpp_service", MODE="0660", GROUP="video"
+SUBSYSTEM=="dma_heap", MODE="0660", GROUP="video"


### PR DESCRIPTION
## What

Grant the `video` group access to the Rockchip MPP hardware-codec devices and
the DMA-heaps their userspace allocates from:

```udev
# packages/bsp/rockchip/60-media.rules
 KERNEL=="media*", MODE="0660", GROUP="video"
 KERNEL=="rga", MODE="0660", GROUP="video"
+KERNEL=="mpp_service", MODE="0660", GROUP="video"
+SUBSYSTEM=="dma_heap", MODE="0660", GROUP="video"
```

## Why

The current Rockchip BSP exposes its hardware video codec stack (VEPU/VDPU, via
the MPP framework) through `/dev/mpp_service`, and the MPP userspace (rkmpp /
ffmpeg-rockchip, Jellyfin, ...) allocates every frame/stream buffer from the
kernel DMA-heaps under `/dev/dma_heap/*`. `60-media.rules` covers `media*` and
`rga` but neither of these, and both are root-only by default -- so hardware
encode/decode only works as `root`.

Granting `mpp_service` **alone is not enough**: even with it opened, the encoder
still fails at init --

```
mpp_buffer: MppBufferService get_group failed to get allocater with mode 0 type 1
hal_h264e_vepu580: init vepu buffer failed ret: -1
mpp: error found on mpp initialization
```

-- because rkmpp can't open `/dev/dma_heap/system` (`root root 0600`) to allocate
buffers. `dma_heap` is matched by `SUBSYSTEM` since the heap node's kernel name
is just `system`.

## How to reproduce / test

On a ROCK 5B (RK3588) with a Rockchip-MPP kernel, as a non-root user in `video`:

| | `/dev/mpp_service` | `/dev/dma_heap/system` | `h264_rkmpp` encode |
|---|---|---|---|
| **stock** | `crw------- root root` | `crw------- root root` | fails at MPP init |
| **mpp_service rule only** | `crw-rw---- root video` | `crw------- root root` | still fails (dma-heap) |
| **both rules** | `crw-rw---- root video` | `crw-rw---- root video` | transcodes |

Reload with `udevadm control --reload-rules && udevadm trigger`.

## Choice of group (`video`)

`video` matches the other codec rules in this file (`mpp_service`, `rga`,
`media*`) and [Jellyfin's Rockchip HWA guide](https://jellyfin.org/docs/general/post-install/transcoding/hardware-acceleration/rockchip/),
which grants the `system*` dma-heaps to `video` for exactly this rkmpp use case --
so a codec user needs a single group. The `uaccess` tag (the desktop/libcamera
direction) is deliberately avoided here: it only grants the logged-in seat user,
so it does **not** cover headless service accounts (`jellyfin`/`plex`), which are
the common consumers on these boards.

For awareness: the one existing dma-heap rule in the tree --
`config/sources/vendors/seeed-studio/recomputer-rk35xx-common.inc` -- uses
`render`, because its purpose is **Mali GBM** (a render-node concern) rather than
codec buffers. On a reComputer board this `60-media.rules` (ordered after
`50-mali-dma-heap.rules`) would set the heaps to `video`; that's harmless since
the documented setup puts users in both `video` and `render`. Happy to switch the
dma-heap line to `render` instead if you'd prefer a single dma-heap group across
the tree.

---

_Disclosure: prepared with AI assistance (Claude Code), then reviewed and
hardware-tested on a ROCK 5B (RK3588) by the submitter before opening._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKCpnfYKkg7SHwkG7coJii
