### PR TITLE
meson64: add GPIO shared-proxy/pinctrl cansleep series (upstream v3)

### DIFF
--- a/patch/kernel/archive/meson64-7.1/general-gpio-shared-cansleep-0001-gpio-shared-proxy-always-mutex.patch
+++ b/patch/kernel/archive/meson64-7.1/general-gpio-shared-cansleep-0001-gpio-shared-proxy-always-mutex.patch
@@ -1,7 +1,7 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 770d943aac95c337f91280425f154846a9a41ef6 Mon Sep 17 00:00:00 2001
 From: Viacheslav Bocharov <v@baodeep.com>
 Date: Tue, 9 Jun 2026 16:37:20 +0300
-Subject: gpio: shared-proxy: always serialize with a sleeping mutex
+Subject: [PATCH] gpio: shared-proxy: always serialize with a sleeping mutex
 
 The shared GPIO descriptor used either a mutex or a spinlock, chosen at
 runtime from the underlying chip's can_sleep:
@@ -39,6 +39,14 @@ underlying GPIO through the cansleep value accessors: those are valid
 for both sleeping and non-sleeping chips, so value access keeps working
 on fast controllers, at the cost of no longer being atomic.
 
+With every vote edge now driven through the cansleep value setter,
+gpio_shared_proxy_set_unlocked() no longer needs a per-call setter: drop
+its set_func callback and call gpiod_set_value_cansleep() directly. The
+shared direction_output path reaches it only once the line is already an
+output, so driving the value there is equivalent to re-issuing
+gpiod_direction_output(), without the redundant per-edge re-assertion of
+drive config and bias.
+
 This is observable: consumers gating on gpiod_cansleep() take their
 sleeping branch on a proxied GPIO (mmc-pwrseq-emmc skips its
 emergency-restart reset handler; its normal reset is unaffected), and
@@ -59,39 +67,129 @@ Reported-by: Marek Szyprowski <m.szyprowski@samsung.com>
 Closes: https://lore.kernel.org/all/00107523-7737-4b92-a785-14ce4e93b8cb@samsung.com/
 Signed-off-by: Viacheslav Bocharov <v@baodeep.com>
 ---
- drivers/gpio/gpio-shared-proxy.c | 43 ++--------
- drivers/gpio/gpiolib-shared.c    |  9 +-
- drivers/gpio/gpiolib-shared.h    | 31 +++----
- 3 files changed, 23 insertions(+), 60 deletions(-)
+ drivers/gpio/gpio-shared-proxy.c | 76 ++++++++++++--------------------
+ drivers/gpio/gpiolib-shared.c    |  9 +---
+ drivers/gpio/gpiolib-shared.h    | 28 +-----------
+ 3 files changed, 32 insertions(+), 81 deletions(-)
 
 diff --git a/drivers/gpio/gpio-shared-proxy.c b/drivers/gpio/gpio-shared-proxy.c
-index 111111111111..222222222222 100644
+index 6941e4be6cf1..10ca2ef77ef3 100644
 --- a/drivers/gpio/gpio-shared-proxy.c
 +++ b/drivers/gpio/gpio-shared-proxy.c
-@@ -109,7 +109,7 @@ static void gpio_shared_proxy_free(struct gpio_chip *gc, unsigned int offset)
+@@ -9,8 +9,10 @@
+ #include <linux/err.h>
+ #include <linux/gpio/consumer.h>
+ #include <linux/gpio/driver.h>
++#include <linux/lockdep.h>
+ #include <linux/mod_devicetable.h>
+ #include <linux/module.h>
++#include <linux/mutex.h>
+ #include <linux/string_choices.h>
+ #include <linux/types.h>
+ 
+@@ -24,15 +26,13 @@ struct gpio_shared_proxy_data {
+ };
+ 
+ static int
+-gpio_shared_proxy_set_unlocked(struct gpio_shared_proxy_data *proxy,
+-			       int (*set_func)(struct gpio_desc *desc, int value),
+-			       int value)
++gpio_shared_proxy_set_unlocked(struct gpio_shared_proxy_data *proxy, int value)
+ {
+ 	struct gpio_shared_desc *shared_desc = proxy->shared_desc;
+ 	struct gpio_desc *desc = shared_desc->desc;
+ 	int ret = 0;
+ 
+-	gpio_shared_lockdep_assert(shared_desc);
++	lockdep_assert_held(&shared_desc->mutex);
+ 
+ 	if (value) {
+ 	       /* User wants to set value to high. */
+@@ -46,7 +46,7 @@ gpio_shared_proxy_set_unlocked(struct gpio_shared_proxy_data *proxy,
+ 			 * Current value is low, need to actually set value
+ 			 * to high.
+ 			 */
+-			ret = set_func(desc, 1);
++			ret = gpiod_set_value_cansleep(desc, 1);
+ 			if (ret)
+ 				goto out;
+ 		}
+@@ -65,7 +65,7 @@ gpio_shared_proxy_set_unlocked(struct gpio_shared_proxy_data *proxy,
+ 	/* We previously voted for high. */
+ 	if (shared_desc->highcnt == 1) {
+ 		/* This is the last remaining vote for high, set value  to low. */
+-		ret = set_func(desc, 0);
++		ret = gpiod_set_value_cansleep(desc, 0);
+ 		if (ret)
+ 			goto out;
+ 	}
+@@ -89,7 +89,7 @@ static int gpio_shared_proxy_request(struct gpio_chip *gc, unsigned int offset)
+ 	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
+ 	struct gpio_shared_desc *shared_desc = proxy->shared_desc;
+ 
+-	guard(gpio_shared_desc_lock)(shared_desc);
++	guard(mutex)(&shared_desc->mutex);
+ 
+ 	proxy->shared_desc->usecnt++;
+ 
+@@ -105,11 +105,10 @@ static void gpio_shared_proxy_free(struct gpio_chip *gc, unsigned int offset)
+ 	struct gpio_shared_desc *shared_desc = proxy->shared_desc;
+ 	int ret;
+ 
+-	guard(gpio_shared_desc_lock)(shared_desc);
++	guard(mutex)(&shared_desc->mutex);
  
  	if (proxy->voted_high) {
- 		ret = gpio_shared_proxy_set_unlocked(proxy,
+-		ret = gpio_shared_proxy_set_unlocked(proxy,
 -			shared_desc->can_sleep ? gpiod_set_value_cansleep : gpiod_set_value, 0);
-+			gpiod_set_value_cansleep, 0);
++		ret = gpio_shared_proxy_set_unlocked(proxy, 0);
  		if (ret)
  			dev_err(proxy->dev,
  				"Failed to unset the shared GPIO value on release: %d\n", ret);
-@@ -222,13 +222,6 @@ static int gpio_shared_proxy_direction_output(struct gpio_chip *gc,
- 	return gpio_shared_proxy_set_unlocked(proxy, gpiod_direction_output, value);
- }
+@@ -129,7 +128,7 @@ static int gpio_shared_proxy_set_config(struct gpio_chip *gc,
+ 	struct gpio_desc *desc = shared_desc->desc;
+ 	int ret;
  
+-	guard(gpio_shared_desc_lock)(shared_desc);
++	guard(mutex)(&shared_desc->mutex);
+ 
+ 	if (shared_desc->usecnt > 1) {
+ 		if (shared_desc->cfg != cfg) {
+@@ -157,7 +156,7 @@ static int gpio_shared_proxy_direction_input(struct gpio_chip *gc,
+ 	struct gpio_desc *desc = shared_desc->desc;
+ 	int dir;
+ 
+-	guard(gpio_shared_desc_lock)(shared_desc);
++	guard(mutex)(&shared_desc->mutex);
+ 
+ 	if (shared_desc->usecnt == 1) {
+ 		dev_dbg(proxy->dev,
+@@ -187,7 +186,7 @@ static int gpio_shared_proxy_direction_output(struct gpio_chip *gc,
+ 	struct gpio_desc *desc = shared_desc->desc;
+ 	int ret, dir;
+ 
+-	guard(gpio_shared_desc_lock)(shared_desc);
++	guard(mutex)(&shared_desc->mutex);
+ 
+ 	if (shared_desc->usecnt == 1) {
+ 		dev_dbg(proxy->dev,
+@@ -219,14 +218,7 @@ static int gpio_shared_proxy_direction_output(struct gpio_chip *gc,
+ 		return -EPERM;
+ 	}
+ 
+-	return gpio_shared_proxy_set_unlocked(proxy, gpiod_direction_output, value);
+-}
+-
 -static int gpio_shared_proxy_get(struct gpio_chip *gc, unsigned int offset)
 -{
 -	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
 -
 -	return gpiod_get_value(proxy->shared_desc->desc);
--}
--
++	return gpio_shared_proxy_set_unlocked(proxy, value);
+ }
+ 
  static int gpio_shared_proxy_get_cansleep(struct gpio_chip *gc,
- 					  unsigned int offset)
- {
-@@ -237,29 +230,15 @@ static int gpio_shared_proxy_get_cansleep(struct gpio_chip *gc,
+@@ -237,29 +229,14 @@ static int gpio_shared_proxy_get_cansleep(struct gpio_chip *gc,
  	return gpiod_get_value_cansleep(proxy->shared_desc->desc);
  }
  
@@ -118,19 +216,27 @@ index 111111111111..222222222222 100644
  	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
  
 -	return gpio_shared_proxy_do_set(proxy, gpiod_set_value_cansleep, value);
-+	guard(gpio_shared_desc_lock)(proxy->shared_desc);
++	guard(mutex)(&proxy->shared_desc->mutex);
 +
-+	return gpio_shared_proxy_set_unlocked(proxy, gpiod_set_value_cansleep,
-+					      value);
++	return gpio_shared_proxy_set_unlocked(proxy, value);
  }
  
  static int gpio_shared_proxy_get_direction(struct gpio_chip *gc,
-@@ -302,20 +281,16 @@ static int gpio_shared_proxy_probe(struct auxiliary_device *adev,
+@@ -302,20 +279,25 @@ static int gpio_shared_proxy_probe(struct auxiliary_device *adev,
  	gc->label = dev_name(dev);
  	gc->parent = dev;
  	gc->owner = THIS_MODULE;
 -	gc->can_sleep = shared_desc->can_sleep;
-+	/* Always a sleeping gpiochip: see the lock comment in gpiolib-shared.h. */
++	/*
++	 * Under the descriptor mutex the proxy may call
++	 * gpiod_set_config()/gpiod_direction_*(), which can reach pinctrl
++	 * paths that take a mutex (e.g. gpiod_set_config() ->
++	 * gpiochip_generic_config() -> pinctrl_gpio_set_config()), independent
++	 * of the underlying chip's can_sleep. So the descriptor lock must be a
++	 * mutex and the proxy gpiochip is therefore always sleeping; drive the
++	 * underlying GPIO through the cansleep value accessors, which are valid
++	 * for both sleeping and non-sleeping chips.
++	 */
 +	gc->can_sleep = true;
  
  	gc->request = gpio_shared_proxy_request;
@@ -151,7 +257,7 @@ index 111111111111..222222222222 100644
  	gc->to_irq = gpio_shared_proxy_to_irq;
  
 diff --git a/drivers/gpio/gpiolib-shared.c b/drivers/gpio/gpiolib-shared.c
-index 111111111111..222222222222 100644
+index de72776fb154..495bd3d0ddf0 100644
 --- a/drivers/gpio/gpiolib-shared.c
 +++ b/drivers/gpio/gpiolib-shared.c
 @@ -627,8 +627,7 @@ static void gpio_shared_release(struct kref *kref)
@@ -178,18 +284,21 @@ index 111111111111..222222222222 100644
  	return shared_desc;
  }
 diff --git a/drivers/gpio/gpiolib-shared.h b/drivers/gpio/gpiolib-shared.h
-index 111111111111..222222222222 100644
+index 15e72a8dcdb1..bbdc0ab7b647 100644
 --- a/drivers/gpio/gpiolib-shared.h
 +++ b/drivers/gpio/gpiolib-shared.h
-@@ -6,7 +6,6 @@
- #include <linux/cleanup.h>
- #include <linux/lockdep.h>
+@@ -3,10 +3,7 @@
+ #ifndef __LINUX_GPIO_SHARED_H
+ #define __LINUX_GPIO_SHARED_H
+ 
+-#include <linux/cleanup.h>
+-#include <linux/lockdep.h>
  #include <linux/mutex.h>
 -#include <linux/spinlock.h>
  
  struct gpio_device;
  struct gpio_desc;
-@@ -42,35 +41,29 @@ static inline int gpio_shared_add_proxy_lookup(struct device *consumer,
+@@ -42,35 +39,12 @@ static inline int gpio_shared_add_proxy_lookup(struct device *consumer,
  
  struct gpio_shared_desc {
  	struct gpio_desc *desc;
@@ -206,15 +315,7 @@ index 111111111111..222222222222 100644
  
  struct gpio_shared_desc *devm_gpiod_shared_get(struct device *dev);
  
-+/*
-+ * Under this lock the proxy may call gpiod_set_config()/gpiod_direction_*(),
-+ * which can reach pinctrl paths that take a mutex (e.g. gpiod_set_config() ->
-+ * gpiochip_generic_config() -> pinctrl_gpio_set_config()), independent of the
-+ * underlying chip's can_sleep. A spinlock would run that sleeping call from
-+ * atomic context, so the descriptor lock must be a mutex and the proxy
-+ * gpiochip is therefore sleeping (can_sleep=true).
-+ */
- DEFINE_LOCK_GUARD_1(gpio_shared_desc_lock, struct gpio_shared_desc,
+-DEFINE_LOCK_GUARD_1(gpio_shared_desc_lock, struct gpio_shared_desc,
 -	if (_T->lock->can_sleep)
 -		mutex_lock(&_T->lock->mutex);
 -	else
@@ -224,19 +325,16 @@ index 111111111111..222222222222 100644
 -	else
 -		spin_unlock_irqrestore(&_T->lock->spinlock, _T->flags),
 -	unsigned long flags)
-+	mutex_lock(&_T->lock->mutex),
-+	mutex_unlock(&_T->lock->mutex))
- 
- static inline void gpio_shared_lockdep_assert(struct gpio_shared_desc *shared_desc)
- {
+-
+-static inline void gpio_shared_lockdep_assert(struct gpio_shared_desc *shared_desc)
+-{
 -	if (shared_desc->can_sleep)
 -		lockdep_assert_held(&shared_desc->mutex);
 -	else
 -		lockdep_assert_held(&shared_desc->spinlock);
-+	lockdep_assert_held(&shared_desc->mutex);
- }
- 
+-}
+-
  #endif /* __LINUX_GPIO_SHARED_H */
 -- 
-Armbian
+2.54.0
 

--- a/patch/kernel/archive/meson64-7.1/general-gpio-shared-cansleep-0002-pinctrl-meson-restore-non-sleeping-gpio.patch
+++ b/patch/kernel/archive/meson64-7.1/general-gpio-shared-cansleep-0002-pinctrl-meson-restore-non-sleeping-gpio.patch
@@ -1,7 +1,7 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 9e027834094551ae19de58e2eada10079693e81c Mon Sep 17 00:00:00 2001
 From: Viacheslav Bocharov <v@baodeep.com>
 Date: Tue, 9 Jun 2026 16:37:20 +0300
-Subject: pinctrl: meson: restore non-sleeping GPIO access
+Subject: [PATCH] pinctrl: meson: restore non-sleeping GPIO access
 
 Commit 28f240683871 ("pinctrl: meson: mark the GPIO controller as
 sleeping") set gpio_chip.can_sleep = true to work around
@@ -41,7 +41,7 @@ Signed-off-by: Viacheslav Bocharov <v@baodeep.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pinctrl/meson/pinctrl-meson.c b/drivers/pinctrl/meson/pinctrl-meson.c
-index 111111111111..222222222222 100644
+index 4507dc8b5563..18295b15ecd9 100644
 --- a/drivers/pinctrl/meson/pinctrl-meson.c
 +++ b/drivers/pinctrl/meson/pinctrl-meson.c
 @@ -619,7 +619,7 @@ static int meson_gpiolib_register(struct meson_pinctrl *pc)
@@ -54,5 +54,5 @@ index 111111111111..222222222222 100644
  	ret = gpiochip_add_data(&pc->chip, pc);
  	if (ret) {
 -- 
-Armbian
+2.54.0
 

--- a/patch/kernel/archive/meson64-7.2/general-gpio-shared-cansleep-0001-gpio-shared-proxy-always-mutex.patch
+++ b/patch/kernel/archive/meson64-7.2/general-gpio-shared-cansleep-0001-gpio-shared-proxy-always-mutex.patch
@@ -1,4 +1,4 @@
-From e6d479eeaa03b9073304c0475dd72d781911b196 Mon Sep 17 00:00:00 2001
+From 770d943aac95c337f91280425f154846a9a41ef6 Mon Sep 17 00:00:00 2001
 From: Viacheslav Bocharov <v@baodeep.com>
 Date: Tue, 9 Jun 2026 16:37:20 +0300
 Subject: [PATCH] gpio: shared-proxy: always serialize with a sleeping mutex
@@ -39,6 +39,14 @@ underlying GPIO through the cansleep value accessors: those are valid
 for both sleeping and non-sleeping chips, so value access keeps working
 on fast controllers, at the cost of no longer being atomic.
 
+With every vote edge now driven through the cansleep value setter,
+gpio_shared_proxy_set_unlocked() no longer needs a per-call setter: drop
+its set_func callback and call gpiod_set_value_cansleep() directly. The
+shared direction_output path reaches it only once the line is already an
+output, so driving the value there is equivalent to re-issuing
+gpiod_direction_output(), without the redundant per-edge re-assertion of
+drive config and bias.
+
 This is observable: consumers gating on gpiod_cansleep() take their
 sleeping branch on a proxied GPIO (mmc-pwrseq-emmc skips its
 emergency-restart reset handler; its normal reset is unaffected), and
@@ -59,39 +67,129 @@ Reported-by: Marek Szyprowski <m.szyprowski@samsung.com>
 Closes: https://lore.kernel.org/all/00107523-7737-4b92-a785-14ce4e93b8cb@samsung.com/
 Signed-off-by: Viacheslav Bocharov <v@baodeep.com>
 ---
- drivers/gpio/gpio-shared-proxy.c | 43 +++++++-------------------------
- drivers/gpio/gpiolib-shared.c    |  9 ++-----
- drivers/gpio/gpiolib-shared.h    | 31 +++++++++--------------
- 3 files changed, 23 insertions(+), 60 deletions(-)
+ drivers/gpio/gpio-shared-proxy.c | 76 ++++++++++++--------------------
+ drivers/gpio/gpiolib-shared.c    |  9 +---
+ drivers/gpio/gpiolib-shared.h    | 28 +-----------
+ 3 files changed, 32 insertions(+), 81 deletions(-)
 
 diff --git a/drivers/gpio/gpio-shared-proxy.c b/drivers/gpio/gpio-shared-proxy.c
-index 6941e4be6cf1..856e5b9d6163 100644
+index 6941e4be6cf1..10ca2ef77ef3 100644
 --- a/drivers/gpio/gpio-shared-proxy.c
 +++ b/drivers/gpio/gpio-shared-proxy.c
-@@ -109,7 +109,7 @@ static void gpio_shared_proxy_free(struct gpio_chip *gc, unsigned int offset)
+@@ -9,8 +9,10 @@
+ #include <linux/err.h>
+ #include <linux/gpio/consumer.h>
+ #include <linux/gpio/driver.h>
++#include <linux/lockdep.h>
+ #include <linux/mod_devicetable.h>
+ #include <linux/module.h>
++#include <linux/mutex.h>
+ #include <linux/string_choices.h>
+ #include <linux/types.h>
+ 
+@@ -24,15 +26,13 @@ struct gpio_shared_proxy_data {
+ };
+ 
+ static int
+-gpio_shared_proxy_set_unlocked(struct gpio_shared_proxy_data *proxy,
+-			       int (*set_func)(struct gpio_desc *desc, int value),
+-			       int value)
++gpio_shared_proxy_set_unlocked(struct gpio_shared_proxy_data *proxy, int value)
+ {
+ 	struct gpio_shared_desc *shared_desc = proxy->shared_desc;
+ 	struct gpio_desc *desc = shared_desc->desc;
+ 	int ret = 0;
+ 
+-	gpio_shared_lockdep_assert(shared_desc);
++	lockdep_assert_held(&shared_desc->mutex);
+ 
+ 	if (value) {
+ 	       /* User wants to set value to high. */
+@@ -46,7 +46,7 @@ gpio_shared_proxy_set_unlocked(struct gpio_shared_proxy_data *proxy,
+ 			 * Current value is low, need to actually set value
+ 			 * to high.
+ 			 */
+-			ret = set_func(desc, 1);
++			ret = gpiod_set_value_cansleep(desc, 1);
+ 			if (ret)
+ 				goto out;
+ 		}
+@@ -65,7 +65,7 @@ gpio_shared_proxy_set_unlocked(struct gpio_shared_proxy_data *proxy,
+ 	/* We previously voted for high. */
+ 	if (shared_desc->highcnt == 1) {
+ 		/* This is the last remaining vote for high, set value  to low. */
+-		ret = set_func(desc, 0);
++		ret = gpiod_set_value_cansleep(desc, 0);
+ 		if (ret)
+ 			goto out;
+ 	}
+@@ -89,7 +89,7 @@ static int gpio_shared_proxy_request(struct gpio_chip *gc, unsigned int offset)
+ 	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
+ 	struct gpio_shared_desc *shared_desc = proxy->shared_desc;
+ 
+-	guard(gpio_shared_desc_lock)(shared_desc);
++	guard(mutex)(&shared_desc->mutex);
+ 
+ 	proxy->shared_desc->usecnt++;
+ 
+@@ -105,11 +105,10 @@ static void gpio_shared_proxy_free(struct gpio_chip *gc, unsigned int offset)
+ 	struct gpio_shared_desc *shared_desc = proxy->shared_desc;
+ 	int ret;
+ 
+-	guard(gpio_shared_desc_lock)(shared_desc);
++	guard(mutex)(&shared_desc->mutex);
  
  	if (proxy->voted_high) {
- 		ret = gpio_shared_proxy_set_unlocked(proxy,
+-		ret = gpio_shared_proxy_set_unlocked(proxy,
 -			shared_desc->can_sleep ? gpiod_set_value_cansleep : gpiod_set_value, 0);
-+			gpiod_set_value_cansleep, 0);
++		ret = gpio_shared_proxy_set_unlocked(proxy, 0);
  		if (ret)
  			dev_err(proxy->dev,
  				"Failed to unset the shared GPIO value on release: %d\n", ret);
-@@ -222,13 +222,6 @@ static int gpio_shared_proxy_direction_output(struct gpio_chip *gc,
- 	return gpio_shared_proxy_set_unlocked(proxy, gpiod_direction_output, value);
- }
+@@ -129,7 +128,7 @@ static int gpio_shared_proxy_set_config(struct gpio_chip *gc,
+ 	struct gpio_desc *desc = shared_desc->desc;
+ 	int ret;
  
+-	guard(gpio_shared_desc_lock)(shared_desc);
++	guard(mutex)(&shared_desc->mutex);
+ 
+ 	if (shared_desc->usecnt > 1) {
+ 		if (shared_desc->cfg != cfg) {
+@@ -157,7 +156,7 @@ static int gpio_shared_proxy_direction_input(struct gpio_chip *gc,
+ 	struct gpio_desc *desc = shared_desc->desc;
+ 	int dir;
+ 
+-	guard(gpio_shared_desc_lock)(shared_desc);
++	guard(mutex)(&shared_desc->mutex);
+ 
+ 	if (shared_desc->usecnt == 1) {
+ 		dev_dbg(proxy->dev,
+@@ -187,7 +186,7 @@ static int gpio_shared_proxy_direction_output(struct gpio_chip *gc,
+ 	struct gpio_desc *desc = shared_desc->desc;
+ 	int ret, dir;
+ 
+-	guard(gpio_shared_desc_lock)(shared_desc);
++	guard(mutex)(&shared_desc->mutex);
+ 
+ 	if (shared_desc->usecnt == 1) {
+ 		dev_dbg(proxy->dev,
+@@ -219,14 +218,7 @@ static int gpio_shared_proxy_direction_output(struct gpio_chip *gc,
+ 		return -EPERM;
+ 	}
+ 
+-	return gpio_shared_proxy_set_unlocked(proxy, gpiod_direction_output, value);
+-}
+-
 -static int gpio_shared_proxy_get(struct gpio_chip *gc, unsigned int offset)
 -{
 -	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
 -
 -	return gpiod_get_value(proxy->shared_desc->desc);
--}
--
++	return gpio_shared_proxy_set_unlocked(proxy, value);
+ }
+ 
  static int gpio_shared_proxy_get_cansleep(struct gpio_chip *gc,
- 					  unsigned int offset)
- {
-@@ -237,29 +230,15 @@ static int gpio_shared_proxy_get_cansleep(struct gpio_chip *gc,
+@@ -237,29 +229,14 @@ static int gpio_shared_proxy_get_cansleep(struct gpio_chip *gc,
  	return gpiod_get_value_cansleep(proxy->shared_desc->desc);
  }
  
@@ -118,19 +216,27 @@ index 6941e4be6cf1..856e5b9d6163 100644
  	struct gpio_shared_proxy_data *proxy = gpiochip_get_data(gc);
  
 -	return gpio_shared_proxy_do_set(proxy, gpiod_set_value_cansleep, value);
-+	guard(gpio_shared_desc_lock)(proxy->shared_desc);
++	guard(mutex)(&proxy->shared_desc->mutex);
 +
-+	return gpio_shared_proxy_set_unlocked(proxy, gpiod_set_value_cansleep,
-+					      value);
++	return gpio_shared_proxy_set_unlocked(proxy, value);
  }
  
  static int gpio_shared_proxy_get_direction(struct gpio_chip *gc,
-@@ -302,20 +281,16 @@ static int gpio_shared_proxy_probe(struct auxiliary_device *adev,
+@@ -302,20 +279,25 @@ static int gpio_shared_proxy_probe(struct auxiliary_device *adev,
  	gc->label = dev_name(dev);
  	gc->parent = dev;
  	gc->owner = THIS_MODULE;
 -	gc->can_sleep = shared_desc->can_sleep;
-+	/* Always a sleeping gpiochip: see the lock comment in gpiolib-shared.h. */
++	/*
++	 * Under the descriptor mutex the proxy may call
++	 * gpiod_set_config()/gpiod_direction_*(), which can reach pinctrl
++	 * paths that take a mutex (e.g. gpiod_set_config() ->
++	 * gpiochip_generic_config() -> pinctrl_gpio_set_config()), independent
++	 * of the underlying chip's can_sleep. So the descriptor lock must be a
++	 * mutex and the proxy gpiochip is therefore always sleeping; drive the
++	 * underlying GPIO through the cansleep value accessors, which are valid
++	 * for both sleeping and non-sleeping chips.
++	 */
 +	gc->can_sleep = true;
  
  	gc->request = gpio_shared_proxy_request;
@@ -178,18 +284,21 @@ index de72776fb154..495bd3d0ddf0 100644
  	return shared_desc;
  }
 diff --git a/drivers/gpio/gpiolib-shared.h b/drivers/gpio/gpiolib-shared.h
-index 15e72a8dcdb1..5c725118b1af 100644
+index 15e72a8dcdb1..bbdc0ab7b647 100644
 --- a/drivers/gpio/gpiolib-shared.h
 +++ b/drivers/gpio/gpiolib-shared.h
-@@ -6,7 +6,6 @@
- #include <linux/cleanup.h>
- #include <linux/lockdep.h>
+@@ -3,10 +3,7 @@
+ #ifndef __LINUX_GPIO_SHARED_H
+ #define __LINUX_GPIO_SHARED_H
+ 
+-#include <linux/cleanup.h>
+-#include <linux/lockdep.h>
  #include <linux/mutex.h>
 -#include <linux/spinlock.h>
  
  struct gpio_device;
  struct gpio_desc;
-@@ -42,35 +41,29 @@ static inline int gpio_shared_add_proxy_lookup(struct device *consumer,
+@@ -42,35 +39,12 @@ static inline int gpio_shared_add_proxy_lookup(struct device *consumer,
  
  struct gpio_shared_desc {
  	struct gpio_desc *desc;
@@ -206,15 +315,7 @@ index 15e72a8dcdb1..5c725118b1af 100644
  
  struct gpio_shared_desc *devm_gpiod_shared_get(struct device *dev);
  
-+/*
-+ * Under this lock the proxy may call gpiod_set_config()/gpiod_direction_*(),
-+ * which can reach pinctrl paths that take a mutex (e.g. gpiod_set_config() ->
-+ * gpiochip_generic_config() -> pinctrl_gpio_set_config()), independent of the
-+ * underlying chip's can_sleep. A spinlock would run that sleeping call from
-+ * atomic context, so the descriptor lock must be a mutex and the proxy
-+ * gpiochip is therefore sleeping (can_sleep=true).
-+ */
- DEFINE_LOCK_GUARD_1(gpio_shared_desc_lock, struct gpio_shared_desc,
+-DEFINE_LOCK_GUARD_1(gpio_shared_desc_lock, struct gpio_shared_desc,
 -	if (_T->lock->can_sleep)
 -		mutex_lock(&_T->lock->mutex);
 -	else
@@ -224,18 +325,15 @@ index 15e72a8dcdb1..5c725118b1af 100644
 -	else
 -		spin_unlock_irqrestore(&_T->lock->spinlock, _T->flags),
 -	unsigned long flags)
-+	mutex_lock(&_T->lock->mutex),
-+	mutex_unlock(&_T->lock->mutex))
- 
- static inline void gpio_shared_lockdep_assert(struct gpio_shared_desc *shared_desc)
- {
+-
+-static inline void gpio_shared_lockdep_assert(struct gpio_shared_desc *shared_desc)
+-{
 -	if (shared_desc->can_sleep)
 -		lockdep_assert_held(&shared_desc->mutex);
 -	else
 -		lockdep_assert_held(&shared_desc->spinlock);
-+	lockdep_assert_held(&shared_desc->mutex);
- }
- 
+-}
+-
  #endif /* __LINUX_GPIO_SHARED_H */
 -- 
 2.54.0

--- a/patch/kernel/archive/meson64-7.2/general-gpio-shared-cansleep-0002-pinctrl-meson-restore-non-sleeping-gpio.patch
+++ b/patch/kernel/archive/meson64-7.2/general-gpio-shared-cansleep-0002-pinctrl-meson-restore-non-sleeping-gpio.patch
@@ -1,4 +1,4 @@
-From cd3a7b205c14a4a1ea44de10105e783b7a0baaa1 Mon Sep 17 00:00:00 2001
+From 9e027834094551ae19de58e2eada10079693e81c Mon Sep 17 00:00:00 2001
 From: Viacheslav Bocharov <v@baodeep.com>
 Date: Tue, 9 Jun 2026 16:37:20 +0300
 Subject: [PATCH] pinctrl: meson: restore non-sleeping GPIO access


### PR DESCRIPTION
Adds the upstream Linux GPIO cansleep fix series to the meson64 kernel patch sets, grouped under one prefix:

- `general-gpio-shared-cansleep-0001-gpio-shared-proxy-always-mutex.patch`
- `general-gpio-shared-cansleep-0002-pinctrl-meson-restore-non-sleeping-gpio.patch`

Added to `meson64-7.1` and `meson64-7.2` (identical in both). `meson64-7.2` previously shipped an earlier draft of these under separate filenames; this replaces it with the grouped versions. `meson64-6.12`/`6.18` have no shared-proxy driver and keep their standalone restore patch.

Verified: `git apply --check` on stable 7.1 and v7.2-rc1; edge(7.1) and bleedingedge(7.2) kernels build clean.

Supersedes #10088.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored non-sleeping GPIO behavior on Meson systems by marking the GPIO controller as not sleep-capable, improving expected GPIO access patterns.
  * Improved shared GPIO reliability by consistently serializing shared GPIO proxy operations, reducing the chance of locking and timing-related issues during GPIO requests and updates.
* **Refactor**
  * Simplified shared GPIO synchronization to use a single mutex-based locking approach across proxy operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->