### PR TITLE
uboot: fix old pylibfdt build on Python 3.12+ (distutils removed)

### DIFF
--- a/extensions/uboot-fix-pylibfdt-distutils.sh
+++ b/extensions/uboot-fix-pylibfdt-distutils.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2013-2026 Igor Pecovnik, igor@armbian.com
+#
+# This file is a part of the Armbian Build Framework
+# https://github.com/armbian/build/
+#
+# Fix old U-Boot's pylibfdt build on modern hosts.
+#
+# distutils was removed from the Python stdlib in 3.12 (trixie ships 3.13), so
+# old U-Boot's pylibfdt setup.py fails at:
+#     from distutils.core import setup, Extension
+#     ModuleNotFoundError: No module named 'distutils'
+# setuptools provides drop-in setup + Extension (incl. swig_opts), so swap the
+# import to setuptools. Also raw-string the RE_KEY_VALUE regex to silence the
+# "invalid escape sequence '\w'" SyntaxWarning (a hard SyntaxError on newer
+# Python). Both the old (lib/libfdt/pylibfdt) and newer (scripts/dtc/pylibfdt)
+# locations are handled.
+#
+# Safe for all U-Boot versions: no-op when setup.py is absent or already uses
+# setuptools. Can be removed once all BOOTBRANCH versions ship a setuptools-based
+# pylibfdt setup.py.
+
+function pre_config_uboot_target__fix_pylibfdt_distutils() {
+	local sp patched=0
+	for sp in lib/libfdt/pylibfdt/setup.py scripts/dtc/pylibfdt/setup.py; do
+		[[ -f "${sp}" ]] || continue
+
+		if grep -q '^from distutils' "${sp}"; then
+			display_alert "Patching pylibfdt" "distutils -> setuptools in ${sp}" "info"
+			# setuptools re-exports setup and Extension (with swig_opts support)
+			sed -i \
+				-e 's/^from distutils\.core import /from setuptools import /' \
+				-e 's/^from distutils\.extension import /from setuptools import /' \
+				"${sp}"
+			patched=1
+		fi
+
+		# Raw-string the Makefile-parser regex to kill the '\w' SyntaxWarning.
+		# Matches the single line regardless of which pylibfdt vintage it is.
+		if grep -q "re\.compile('(?P<key>" "${sp}"; then
+			sed -i "s/re\.compile('(?P<key>/re.compile(r'(?P<key>/" "${sp}"
+			patched=1
+		fi
+	done
+
+	[[ "${patched}" -eq 1 ]] && display_alert "pylibfdt" "patched for modern Python (no distutils)" "info"
+	return 0
+}

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -68,6 +68,9 @@ function do_main_configuration() {
 	# Fix binman pkg_resources removal in setuptools >= 82. Can be removed when all U-Boot versions are >= v2025.10.
 	enable_extension "uboot-binman-fix-pkg-resources"
 
+	# Fix old U-Boot pylibfdt: distutils removed in Python 3.12+ (trixie ships 3.13). No-op on newer U-Boot.
+	enable_extension "uboot-fix-pylibfdt-distutils"
+
 	# Network stack to use, default to network-manager; configuration can override this.
 	# Will be made read-only further down.
 	declare -g NETWORKING_STACK="${NETWORKING_STACK}"


### PR DESCRIPTION
## Problem

Boards still on an old `BOOTBRANCH` (e.g. **udoo / imx6 on v2017.11**) fail to build u-boot host tools on **trixie**:

```
lib/libfdt/pylibfdt/setup.py: from distutils.core import setup, Extension
ModuleNotFoundError: No module named 'distutils'
make[1]: *** [tools/Makefile:134: tools/_libfdt.so] Error 1
```

`distutils` was removed from the Python stdlib in **3.12** and trixie ships **3.13**. This is independent of the SWIG 4.3 pylibfdt break that drove the sunxi migration — it hits even older u-boot whose `setup.py` uses `distutils` directly.

## Fix

Auto-enabled extension (`pre_config_uboot_target` hook, same pattern as the existing `uboot-binman-fix-pkg-resources`) that:

1. Swaps `from distutils.core import setup, Extension` → `from setuptools import setup, Extension`. setuptools re-exports `setup` and `Extension` (incl. `swig_opts`), so it's a drop-in.
2. Raw-strings the `RE_KEY_VALUE` regex to silence the `invalid escape sequence '\w'` SyntaxWarning (a hard `SyntaxError` on newer Python) — same fix Florian Schmaus sent upstream.

Handles both the old (`lib/libfdt/pylibfdt`) and newer (`scripts/dtc/pylibfdt`) locations. **No-op** when `setup.py` is absent or already setuptools-based, so it's safe across all `BOOTBRANCH` versions and can be dropped once everything is new enough.

## Verification

On a trixie host against the real v2017.11 `setup.py`:
- transform yields **valid Python**, no `distutils` references left
- `from setuptools import setup, Extension` imports fine

Enabled at `lib/functions/configuration/main-config.sh` right next to the binman fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer Python versions during U-Boot configuration.
  * Reduced the chance of build failures caused by outdated Python packaging and regex handling in certain U-Boot helper files.
  * The fix is applied automatically as part of the normal configuration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->