### PR TITLE
recore: fix ATF v2.8.0 build - drop -Wl, prefix from LD flag

### DIFF
--- a/config/boards/recore.csc
+++ b/config/boards/recore.csc
@@ -14,6 +14,10 @@ function post_family_config__shrink_atf() {
 	display_alert "Choose ATF branch 🍰" "recore"
 	declare -g ATFBRANCH="tag:v2.8.0"
 
+	# ATF v2.8.0 passes TF_LDFLAGS directly to the linker (ld.bfd), not to gcc,
+	# so the '-Wl,' prefix on --no-warn-rwx-segment is rejected. Drop the prefix.
+	declare -g ATF_SKIP_LDFLAGS_WL="yes"
+
 	declare -g ATF_TARGET_MAP="PLAT=$ATF_PLAT DEBUG=0 SUNXI_PSCI_USE_SCPI=0 bl31;;build/$ATF_PLAT/release/bl31.bin"
 	display_alert "Compile without SCP binary 🍰" "recore"
 	UBOOT_TARGET_MAP="SCP=/dev/null;;u-boot-sunxi-with-spl.bin"


### PR DESCRIPTION
## Problem

The `recore` board pins ATF **v2.8.0**, whose Makefile passes `TF_LDFLAGS` **directly to `ld.bfd`** rather than through gcc. The framework's default `-Wl,--no-warn-rwx-segment` is therefore rejected by the linker:

```
LD      .../build/sun50i_a64/release/bl31/bl31.elf
/usr/bin/aarch64-linux-gnu-ld.bfd: unrecognized option '-Wl,--no-warn-rwx-segment'
make: *** [Makefile:1342: .../bl31.elf] Error 1
```

The `-Wl,` prefix only applies when the linker is invoked *through gcc* (as newer ATF versions do).

## Fix

Set `ATF_SKIP_LDFLAGS_WL=yes` in the board's `post_family_config__shrink_atf()`. The framework then passes the bare `--no-warn-rwx-segment` instead of the `-Wl,`-prefixed form (`ld.bfd` accepts it as an abbreviation of `--no-warn-rwx-segments`).

The flag itself is retained — it suppresses the binutils 2.39+ RWX-segment warning. Only the incompatible prefix is dropped.

Same knob already used by `genio`, `imx93`, `phytiumpi`, and `nuvoton-ma35d1`.

## Test

ATF `bl31.elf` links successfully with the bare flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue that could prevent builds from completing with newer toolchain behavior.
  * Updated board configuration to better handle linker flag compatibility, improving build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->