### PR TITLE
rockchip64: fix errexit build failure on SPI boards (undefined hook)

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -324,8 +324,9 @@ uboot_custom_postprocess() {
 		# (e.g. for Maskrom recovery). Invoked after both rkspi_loader.img
 		# build paths so the hook contract is consistent regardless of
 		# BOOT_SPI_RKSPI_LOADER.
-		declare -F board_uboot_spi_image_after_build >/dev/null && \
+		if declare -F board_uboot_spi_image_after_build >/dev/null; then
 			board_uboot_spi_image_after_build
+		fi
 	fi
 }
 


### PR DESCRIPTION
## Problem

Commit 944f2f9 (`uboot: add board/extension hooks for SPL blobs and SPI image postprocess`) broke u-boot builds for **every rockchip board with `BOOT_SUPPORT_SPI=yes`** — e.g. `orangepi5-ultra` and other rk35xx SPI-boot boards:

```
Error 1 occurred in main shell at lib/functions/compilation/uboot.sh:286
```

## Root cause

The commit added the SPI-image hook using this idiom at the end of the `BOOT_SUPPORT_SPI` branch of `uboot_custom_postprocess()`:

```sh
declare -F board_uboot_spi_image_after_build >/dev/null && \
    board_uboot_spi_image_after_build
```

No board defines this hook, so `declare -F` returns **1**, the `&&` chain short-circuits to exit status **1**, and because this is the **last statement** in the function it becomes the return value of `uboot_custom_postprocess`. Under the runner's `set -e -o pipefail`, that non-zero return aborts the build.

Boards without SPI support end the function on a successful command, so they were unaffected — which is why only *some* rockchip devices broke.

(The sibling `board_uboot_spl_blobs_postprocess` hook is written as a proper `if … then … elif`, so it is safe.)

## Fix

Guard the optional hook with a proper `if` so a missing hook no longer propagates a non-zero exit:

```sh
if declare -F board_uboot_spi_image_after_build >/dev/null; then
    board_uboot_spi_image_after_build
fi
```

## Test

- `bash -n` passes.
- Reproduced the original failure and confirmed the `if`-guarded form returns 0 with the hook undefined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal processing for optional board-specific post-build handling with no change to user-facing behavior.
  * Preserved existing conditions so the hook still runs only when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->