### PR TITLE
sunxi64: bump self-pinned H616/H618 boards to v2026.07 (zero2w, zero3, longanpi-3h)

### DIFF
--- a/config/boards/longanpi-3h.csc
+++ b/config/boards/longanpi-3h.csc
@@ -5,9 +5,10 @@ BOARDFAMILY="sun50iw9"
 BOARD_MAINTAINER=""
 INTRODUCED="2023"
 BOOTCONFIG="longanpi_3h_defconfig"
-BOOTBRANCH="tag:v2024.10"
-BOOTPATCHDIR="v2024.10"
-BOOTDIR="u-boot-${BOARD}"
+# u-boot rides the sunxi64 family default (v2026.07-rc4 / v2026.07-sunxi64).
+# DT (sun50i-h618-longanpi-3h + longan-module-3h.dtsi, incl. eMMC) is upstream;
+# the defconfig is carried board-scoped in v2026.07-sunxi64/board_longanpi-3h.
+# Was self-pinned to v2024.10.
 BOOT_LOGO="desktop"
 OVERLAY_PREFIX="sun50i-h616"
 KERNEL_TARGET="current,edge"

--- a/config/boards/orangepizero2w.csc
+++ b/config/boards/orangepizero2w.csc
@@ -5,8 +5,9 @@ BOARDFAMILY="sun50iw9"
 BOARD_MAINTAINER="chraac"
 INTRODUCED="2023"
 BOOTCONFIG="orangepi_zero2w_defconfig"
-BOOTBRANCH="tag:v2025.04"
-BOOTPATCHDIR="v2025-sunxi"
+# u-boot rides the sunxi64 family default (v2026.07-rc4 / v2026.07-sunxi64);
+# defconfig + DT are upstream. Was self-pinned to v2025.04 (H616 DRAM patches
+# it needed are now upstream: size-detection rework + 1.5GB).
 BOOT_LOGO="desktop"
 OVERLAY_PREFIX="sun50i-h616"
 KERNEL_TARGET="current,edge"

--- a/config/boards/orangepizero3.csc
+++ b/config/boards/orangepizero3.csc
@@ -5,8 +5,9 @@ BOARDFAMILY="sun50iw9"
 BOARD_MAINTAINER="alexl83 chraac"
 INTRODUCED="2023"
 BOOTCONFIG="orangepi_zero3_defconfig"
-BOOTBRANCH="tag:v2025.04"
-BOOTPATCHDIR="v2025-sunxi"
+# u-boot rides the sunxi64 family default (v2026.07-rc4 / v2026.07-sunxi64);
+# defconfig + DT are upstream. Was self-pinned to v2025.04 (H616 DRAM patches
+# it needed are now upstream: size-detection rework + 1.5GB).
 BOOT_LOGO="desktop"
 OVERLAY_PREFIX="sun50i-h616"
 KERNEL_TARGET="current,edge"

--- a/patch/u-boot/v2026.07-sunxi64/board_longanpi-3h/0001-add-longanpi-3h-defconfig.patch
+++ b/patch/u-boot/v2026.07-sunxi64/board_longanpi-3h/0001-add-longanpi-3h-defconfig.patch
@@ -1,0 +1,54 @@
+From: Armbian
+Subject: [PATCH] longanpi-3h: add defconfig for v2026.07 (H618 LPDDR4)
+
+Forward-ported from the v2024.10 board patchset (0006/0007). The DT
+(sun50i-h618-longanpi-3h + longan-module-3h.dtsi, including the eMMC mmc2 node)
+is now upstream in v2026.07 and already drops mmc-hs400-1_8v, so only the
+defconfig is carried here.
+
+Adaptations for v2026.07:
+- DRAM Kconfig renamed DRAM_SUN50I_H616_* -> DRAM_SUNXI_* (same values as the
+  already-validated cherryba-m1; identical H618 LPDDR4 tuning).
+- CONFIG_DEFAULT_DEVICE_TREE gains the allwinner/ prefix (OF_UPSTREAM).
+- Added MMC_SUNXI_SLOT_EXTRA=2 + SUPPORT_EMMC_BOOT=y for the onboard eMMC
+  (matches cherryba-m1).
+
+SD boot is the primary path; if eMMC boot proves flaky on hardware, revisit the
+old sdc_no==2 f_max=20MHz reduction (the family already carries the generic
+mmc 20ms stabilization delay).
+
+--- /dev/null
++++ b/configs/longanpi_3h_defconfig
+@@ -0,0 +1,32 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_DEFAULT_DEVICE_TREE="allwinner/sun50i-h618-longanpi-3h"
++CONFIG_SPL=y
++CONFIG_DRAM_SUNXI_DX_ODT=0x07070707
++CONFIG_DRAM_SUNXI_DX_DRI=0x0e0e0e0e
++CONFIG_DRAM_SUNXI_CA_DRI=0x0e0e
++CONFIG_DRAM_SUNXI_ODT_EN=0xaaaaeeee
++CONFIG_DRAM_SUNXI_TPR6=0x48808080
++CONFIG_DRAM_SUNXI_TPR10=0x402f6663
++CONFIG_DRAM_SUNXI_TPR11=0x26262524
++CONFIG_DRAM_SUNXI_TPR12=0x100f100f
++CONFIG_MACH_SUN50I_H616=y
++CONFIG_SUNXI_DRAM_H616_LPDDR4=y
++CONFIG_DRAM_CLK=792
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++CONFIG_SUPPORT_EMMC_BOOT=y
++CONFIG_R_I2C_ENABLE=y
++CONFIG_SPL_SPI_SUNXI=y
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_SPL_I2C=y
++CONFIG_SPL_SYS_I2C_LEGACY=y
++CONFIG_SYS_I2C_MVTWSI=y
++CONFIG_SYS_I2C_SLAVE=0x7f
++CONFIG_SYS_I2C_SPEED=400000
++CONFIG_MTD=y
++CONFIG_SPI_FLASH_ZBIT=y
++CONFIG_AXP313_POWER=y
++CONFIG_SPI=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_MUSB_GADGET=y


### PR DESCRIPTION
Bumps three self-pinned H616/H618 (sun50iw9) boards off their old u-boot pins onto the **v2026.07-sunxi64** family default, continuing the sunxi migration (#10089). #10089 is now merged to `main`, so this targets `main` directly.

## Ported

| board | SoC | was | how |
|---|---|---|---|
| orangepizero2w | H618 | v2025.04 / v2025-sunxi | defconfig + DT upstream → drop self-pin |
| orangepizero3 | H616 | v2025.04 / v2025-sunxi | defconfig + DT upstream → drop self-pin |
| longanpi-3h | H618 LPDDR4 | v2024.10 / v2024.10 | DT (+ eMMC) upstream; defconfig forward-ported board-scoped |

- The H616 DRAM patches the zero2w/zero3 relied on (size-detection rework, address-wrapping, 1.5GB) are all upstream in v2026.07; CB1/cherryba already validate H616/H618 DRAM there.
- longanpi-3h: DT `sun50i-h618-longanpi-3h` + `longan-module-3h.dtsi` (incl. eMMC, already without `mmc-hs400-1_8v`) are upstream, so only the defconfig is carried. DRAM Kconfig renamed `DRAM_SUN50I_H616_*` → `DRAM_SUNXI_*` (identical values to the validated cherryba-m1), `allwinner/` OF_UPSTREAM DT prefix.

## Deliberately left pinned (not in this PR)

`bananapim4berry` (v2025.04), `bananapim4zero` + `kickpik2b` (v2026.01) — all build on trixie, are maintainer-pinned, not upstream, and porting would require untested edits to shared H616 files (m4berry edits the shared `sun50i-h616.dtsi` ethernet pinmux affecting all H616 boards; m4zero/k2b carry GPU/THS/DRAM HACKs to shared core files). No build-break justifies the risk.

## Testing

Not hardware-tested. Needs a boot check on each (SD boot; longanpi-3h eMMC — if flaky, revisit the old `sdc_no==2` f_max=20MHz reduction; the family already carries the mmc 20ms stabilization delay).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added initial U-Boot support for the LonganPi 3H board, including board-specific boot and hardware setup.
  * Enabled eMMC boot support and broader peripheral support for storage, power, SPI, I2C, and USB.
  * Updated Orange Pi Zero 2W, Zero 3, and LonganPi 3H board configs to use the latest shared U-Boot defaults instead of fixed versions.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->