### PR TITLE
odroidxu4: fix u-boot build on trixie (GCC 14 implicit-decl errors)

### DIFF
--- a/config/sources/families/odroidxu4.conf
+++ b/config/sources/families/odroidxu4.conf
@@ -52,6 +52,20 @@ function custom_kernel_config__hack_odroidxu4_firmware() {
 	fi
 }
 
+# GCC 14 on the trixie host promotes -Wimplicit-function-declaration (and
+# -Wimplicit-int / -Wincompatible-pointer-types) from warning to hard error,
+# which this 2017-era hardkernel u-boot trips on (e.g. mmc_rst_n_func_status in
+# drivers/mmc/mmc_boot.c). Downgrade them back to warnings so it builds again;
+# the symbols are defined at link time, only their prototypes are missing.
+function post_config_uboot_target__odroidxu4_downgrade_gcc14_errors() {
+	uboot_cflags_array+=(
+		"-Wno-error=implicit-function-declaration"
+		"-Wno-error=implicit-int"
+		"-Wno-error=incompatible-pointer-types"
+	)
+	return 0
+}
+
 setup_write_uboot_platform() {
 	# this will update u-boot on the device rootfs is located on
 	# in case it's a mmc device, otherwise DEVICE will not be changed


### PR DESCRIPTION
## Problem

CI "Build All Artifacts" fails `uboot-odroidxu4-current` on the trixie host:

```
drivers/mmc/mmc_boot.c:120:13: error: implicit declaration of function
'mmc_rst_n_func_status' [-Wimplicit-function-declaration]
```

GCC 14 promotes `-Wimplicit-function-declaration` (plus `-Wimplicit-int` and `-Wincompatible-pointer-types`) from warning to **hard error** by default. The hardkernel `odroidxu4-v2017.05` u-boot predates that and trips on it — it built fine on noble/GCC 13.

**Not** the pylibfdt/SWIG break (that's already handled by the board's `fix_build_for_recent_host-side_libfdt` + `fix-compilation-on-noble` distutils→setuptools patches; the SWIG step succeeds in the log). So #10094 does not address this.

## Fix

A `post_config_uboot_target` hook that appends the three `-Wno-error=` flags to `uboot_cflags_array` — the same mechanism `rockchip-rv1106.conf` already uses for its GCC downgrade. The missing prototypes are cosmetic (the symbols resolve at link time on 32-bit ARM), so downgrading to warnings is safe and keeps the known-good hardkernel boot chain intact (no mainline migration, no blob changes).

## Testing

- **Build: confirmed passing** on the trixie host (GCC 14).
- **Boot: confirmed** — boots on real Odroid XU4 hardware. The boot chain (hardkernel BL1/BL2/u-boot/TZSW, offsets, write logic) is untouched, so behaviour matches the pre-GCC-14 build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build compatibility for ODROID XU4 images by preventing newer compiler warnings from breaking the U-Boot build.
  * Kept affected warnings as warnings instead of errors, helping the build complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

