### PR TITLE
odroidc1: fix u-boot build on trixie (GCC 14) via config.mk -fpermissive

### DIFF
--- a/config/boards/odroidc1.conf
+++ b/config/boards/odroidc1.conf
@@ -26,3 +26,20 @@ write_uboot_platform() {
 	dd if=$1/u-boot.bin of=$2 bs=512 seek=64 conv=fsync > /dev/null 2>&1
 	dd if=/dev/zero of=$2 seek=1024 count=32 bs=512 conv=fsync > /dev/null 2>&1
 }
+
+# GCC 14 (trixie host) promotes -Wint-conversion, -Wimplicit-function-declaration,
+# -Wimplicit-int and -Wincompatible-pointer-types from warning to hard error. This
+# 2011-era hardkernel Amlogic u-boot (odroidc-v2011.03) trips on all of them
+# (board.c / gpio.c / bootm.c: get_dev_by_name, vpu_probe, amlogic_gpio_*, malloc,
+# pointer-from-integer, ...). It built on noble/GCC 13; downgrade back to warnings
+# so it builds on trixie. ARCH=armhf, so the int<->pointer conversions are
+# same-width and benign.
+function post_config_uboot_target__odroidc1_downgrade_gcc14_errors() {
+	uboot_cflags_array+=(
+		"-Wno-error=implicit-function-declaration"
+		"-Wno-error=implicit-int"
+		"-Wno-error=int-conversion"
+		"-Wno-error=incompatible-pointer-types"
+	)
+	return 0
+}

--- a/config/boards/odroidc1.conf
+++ b/config/boards/odroidc1.conf
@@ -27,19 +27,7 @@ write_uboot_platform() {
 	dd if=/dev/zero of=$2 seek=1024 count=32 bs=512 conv=fsync > /dev/null 2>&1
 }
 
-# GCC 14 (trixie host) promotes -Wint-conversion, -Wimplicit-function-declaration,
-# -Wimplicit-int and -Wincompatible-pointer-types from warning to hard error. This
-# 2011-era hardkernel Amlogic u-boot (odroidc-v2011.03) trips on all of them
-# (board.c / gpio.c / bootm.c: get_dev_by_name, vpu_probe, amlogic_gpio_*, malloc,
-# pointer-from-integer, ...). It built on noble/GCC 13; downgrade back to warnings
-# so it builds on trixie. ARCH=armhf, so the int<->pointer conversions are
-# same-width and benign.
-function post_config_uboot_target__odroidc1_downgrade_gcc14_errors() {
-	uboot_cflags_array+=(
-		"-Wno-error=implicit-function-declaration"
-		"-Wno-error=implicit-int"
-		"-Wno-error=int-conversion"
-		"-Wno-error=incompatible-pointer-types"
-	)
-	return 0
-}
+# NB: the GCC 14 build fix lives in the u-boot source patch
+# patch/u-boot/legacy/board_odroidc1/fix-gcc14-permissive.patch, not a
+# uboot_cflags_array hook: this 2011 u-boot's config.mk assigns CFLAGS with :=
+# and ignores the framework-injected KCFLAGS, so a hook has no effect here.

--- a/patch/u-boot/legacy/board_odroidc1/fix-gcc14-permissive.patch
+++ b/patch/u-boot/legacy/board_odroidc1/fix-gcc14-permissive.patch
@@ -1,0 +1,34 @@
+From: Armbian
+Subject: [PATCH] odroidc1: build config.mk with -fpermissive for GCC 14
+
+This 2011-era hardkernel Amlogic u-boot (odroidc-v2011.03) uses the pre-Kbuild
+build system: config.mk assigns CFLAGS with `:=`, ignoring the environment /
+KCFLAGS the Armbian build framework injects. So a post_config_uboot_target hook
+appending -Wno-error flags to uboot_cflags_array has no effect here (unlike the
+newer odroidxu4 u-boot, which honours KCFLAGS).
+
+GCC 14 makes implicit-function-declaration, implicit-int, int-conversion,
+incompatible-pointer-types and return-mismatch hard errors *by default* (no
+-Werror needed), and this codebase trips on all of them (board.c/gpio.c/bootm.c:
+get_dev_by_name, vpu_probe, amlogic_gpio_*, malloc, pointer-from-integer, ...).
+It built fine on GCC 13 / noble.
+
+-fpermissive downgrades exactly those C permerrors back to warnings (GCC 14 C
+behaviour, verified accepted by arm-linux-gnueabi-gcc 14). Add it straight to
+config.mk's CFLAGS so it lands on every object. ARCH is armhf, so the
+int<->pointer conversions are same-width and benign.
+
+--- a/config.mk
++++ b/config.mk
+@@ -192,6 +192,11 @@
+
+ CFLAGS += $(call cc-option,-fno-stack-protector)
+
++# GCC 14 makes implicit-function-declaration, implicit-int, int-conversion,
++# incompatible-pointer-types and return-mismatch hard errors by default; this
++# 2011 u-boot predates that. -fpermissive downgrades them back to warnings.
++CFLAGS += $(call cc-option,-fpermissive)
++
+ # $(CPPFLAGS) sets -g, which causes gcc to pass a suitable -g<format>
+ # option to the assembler.
+ AFLAGS_DEBUG :=


### PR DESCRIPTION
## Problem

CI "Build All Artifacts" fails `uboot-odroidc1-current` on the trixie host. The 2011-era hardkernel Amlogic u-boot (`odroidc-v2011.03`) hits warnings that **GCC 14 makes hard errors by default** (no `-Werror` needed): `-Wimplicit-function-declaration` (`get_dev_by_name`, `vpu_probe`, `amlogic_gpio_*`, `malloc`, `free`), `-Wint-conversion` (pointer-from-integer in `board.c`/`gpio.c`), `-Wincompatible-pointer-types` (`gpio.c`). Built fine on GCC 13 / noble.

## Why a source patch, not a cflags hook

First attempt appended `-Wno-error=` flags to `uboot_cflags_array` (the odroidxu4 approach). That's a **no-op here**: this pre-Kbuild `config.mk` assigns `CFLAGS :=` and ignores the framework's injected `KCFLAGS`/env `CFLAGS` — the flags never reach the per-file `gcc` command lines, so it kept failing identically.

## Fix

Source patch adding `-fpermissive` to `config.mk`'s `CFLAGS`. In GCC 14, `-fpermissive` downgrades exactly those C permerrors (implicit-function-declaration, implicit-int, int-conversion, incompatible-pointer-types, return-mismatch) back to warnings — one flag, on every object. Verified accepted by `arm-linux-gnueabi-gcc 14`.

`ARCH=armhf`, so the int↔pointer conversions are same-width and benign. Boot chain (hardkernel BL1 + u-boot.bin) untouched — build fix only.

## Testing

- **Build: confirmed passing** locally (compilation succeeded after this patch).
- **Boot: confirmed** — boots on real Odroid C1 hardware, network works. Boot chain (hardkernel BL1 + u-boot.bin, offsets) untouched, so behaviour matches the pre-GCC-14 build.

Sibling of #10110 (odroidxu4) — same root cause (GCC 14), different injection point because odroidc1's u-boot is much older and ignores KCFLAGS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build compatibility for the Odroid C1 board with newer GCC versions.
  * Reduced several compiler warnings that were being treated as errors, helping older bootloader sources continue to compile successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
