### PR TITLE
fake-ubuntu-advantage-tools: provide ubuntu-pro-client

### DIFF
--- a/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
+++ b/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
@@ -27,9 +27,9 @@ function compile_fake_ubuntu_advantage_tools() {
 		Version: ${artifact_version}
 		Architecture: all
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
-		Conflicts: ubuntu-advantage-tools
-		Breaks: ubuntu-advantage-tools
-		Provides: ubuntu-advantage-tools (= 65535)
+		Conflicts: ubuntu-advantage-tools, ubuntu-pro-client
+		Breaks: ubuntu-advantage-tools, ubuntu-pro-client
+		Provides: ubuntu-advantage-tools (= 65535), ubuntu-pro-client (= 65535)
 		Priority: optional
 		Section: admin
 		Description: Ban ubuntu-advantage-tools while satisfying ubuntu-minimal dependency


### PR DESCRIPTION
# Description

Ubuntu releases now use `ubuntu-pro-client` for the Ubuntu Pro/ESM client

Update `fake-ubuntu-advantage-tools` so it also provides, conflicts with, and breaks `ubuntu-pro-client`.

Without this some builds fail with conffile prompt/dependency errors on Ubuntu Resolute + GNOME 

# How Has This Been Tested?

- [x] Build test locally w/BeagleY Ubuntu Resolute Target

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package compatibility so the generated Ubuntu advantage tools package now properly conflicts with and replaces the newer client package as expected.
  * Updated package metadata to advertise support for the newer client name, helping avoid installation and upgrade issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->