### PR TITLE
wifi: rtw88: sdio: Fix unhandled RX request interrupt storm

### DIFF
--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/0999-rtw88-sdio-fix-interrupt-storm.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/0999-rtw88-sdio-fix-interrupt-storm.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alastair D'Silva <alastair@d-silva.org>
+Date: Tue, 30 Jun 2026 21:16:30 +1000
+Subject: [PATCH] wifi: rtw88: sdio: Fix RCU stalls / interrupt storm by clearing RX_REQUEST interrupt
+
+In rtw_sdio_handle_interrupt(), the HISR status register is cleared using
+W1C (Write 1 to Clear) semantics. However, the driver masks out the
+REG_SDIO_HISR_RX_REQUEST bit in the local 'hisr' variable before writing
+it back, causing a 0 to be written to that bit. This prevents the RX request
+interrupt from being cleared, trapping the CPU core in an infinite interrupt
+storm loop (starving the RCU preempt kthread and locking up the system).
+
+Remove the masking of REG_SDIO_HISR_RX_REQUEST so that the interrupt status
+is correctly written back as a 1 and acknowledged by the hardware.
+
+Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+Assisted-by: Antigravity <antigravity@google.com>
+---
+ drivers/net/wireless/realtek/rtw88/sdio.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/sdio.c b/drivers/net/wireless/realtek/rtw88/sdio.c
+index 2614b0b8c6ea..6301a086b51c 100644
+--- a/drivers/net/wireless/realtek/rtw88/sdio.c
++++ b/drivers/net/wireless/realtek/rtw88/sdio.c
+@@ -1085,7 +1085,6 @@ static void rtw_sdio_handle_interrupt(struct sdio_func *sdio_func)
+ 	if (hisr & REG_SDIO_HISR_TXERR)
+ 		rtw_sdio_tx_err_isr(rtwdev);
+ 	if (hisr & REG_SDIO_HISR_RX_REQUEST) {
+-		hisr &= ~REG_SDIO_HISR_RX_REQUEST;
+ 		rtw_sdio_rx_isr(rtwdev);
+ 	}
+ 
+-- 
+2.34.1

--- a/patch/kernel/archive/sunxi-6.18/series.conf
+++ b/patch/kernel/archive/sunxi-6.18/series.conf
@@ -564,3 +564,4 @@
 	patches.armbian/drv-usb-gadget-composite-rename-serial-manufacturer.patch
 	patches.armbian/drv-video-st7796s-fb-tft-driver.patch
 	patches.armbian/include-uapi-drm_fourcc-add-ARM-tiled-format-modifier.patch
+        patches.armbian/0999-rtw88-sdio-fix-interrupt-storm.patch

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/0999-rtw88-sdio-fix-interrupt-storm.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/0999-rtw88-sdio-fix-interrupt-storm.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alastair D'Silva <alastair@d-silva.org>
+Date: Tue, 30 Jun 2026 21:16:30 +1000
+Subject: [PATCH] wifi: rtw88: sdio: Fix RCU stalls / interrupt storm by clearing RX_REQUEST interrupt
+
+In rtw_sdio_handle_interrupt(), the HISR status register is cleared using
+W1C (Write 1 to Clear) semantics. However, the driver masks out the
+REG_SDIO_HISR_RX_REQUEST bit in the local 'hisr' variable before writing
+it back, causing a 0 to be written to that bit. This prevents the RX request
+interrupt from being cleared, trapping the CPU core in an infinite interrupt
+storm loop (starving the RCU preempt kthread and locking up the system).
+
+Remove the masking of REG_SDIO_HISR_RX_REQUEST so that the interrupt status
+is correctly written back as a 1 and acknowledged by the hardware.
+
+Signed-off-by: Alastair D'Silva <alastair@d-silva.org>
+Assisted-by: Antigravity <antigravity@google.com>
+---
+ drivers/net/wireless/realtek/rtw88/sdio.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/sdio.c b/drivers/net/wireless/realtek/rtw88/sdio.c
+index 2614b0b8c6ea..6301a086b51c 100644
+--- a/drivers/net/wireless/realtek/rtw88/sdio.c
++++ b/drivers/net/wireless/realtek/rtw88/sdio.c
+@@ -1085,7 +1085,6 @@ static void rtw_sdio_handle_interrupt(struct sdio_func *sdio_func)
+ 	if (hisr & REG_SDIO_HISR_TXERR)
+ 		rtw_sdio_tx_err_isr(rtwdev);
+ 	if (hisr & REG_SDIO_HISR_RX_REQUEST) {
+-		hisr &= ~REG_SDIO_HISR_RX_REQUEST;
+ 		rtw_sdio_rx_isr(rtwdev);
+ 	}
+ 
+-- 
+2.34.1

--- a/patch/kernel/archive/sunxi-7.0/series.conf
+++ b/patch/kernel/archive/sunxi-7.0/series.conf
@@ -521,3 +521,4 @@
 	patches.armbian/drv-usb-gadget-composite-rename-serial-manufacturer.patch
 	patches.armbian/drv-video-st7796s-fb-tft-driver.patch
 	patches.armbian/include-uapi-drm_fourcc-add-ARM-tiled-format-modifier.patch
+	patches.armbian/0999-rtw88-sdio-fix-interrupt-storm.patch


### PR DESCRIPTION
Fixes an unhandled RX request interrupt storm on Realtek rtw88 SDIO-based wifi devices (such as the RTL8821CS). In the SDIO interrupt handler rtw_sdio_handle_interrupt(), when REG_SDIO_HISR_RX_REQUEST is flagged, the driver was clearing the bit in local variable hisr but not acknowledging/clearing the interrupt on the physical device register. This resulted in an immediate re-triggering of the interrupt, causing a CPU-hogging interrupt storm.

Acknowledge the RX request interrupt properly so the interrupt controller can deassert it.

This patch applies to both sunxi-6.18 (current) and sunxi-7.0 (edge) kernels.

This was detected by noting that RCU stalls frequently occurred after WiFi association.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a wireless SDIO interrupt issue that could cause repeated interrupts and system stalls on some devices.
  * Improved reliability of Realtek Wi‑Fi handling by ensuring interrupts are properly cleared.
* **Chores**
  * Added the fix to the supported kernel patch series for multiple kernel tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->