### PR TITLE
board: anbernic-rg-ds: make OTG-C port dual-role so USB hubs work

### DIFF
--- a/patch/kernel/archive/rockchip64-7.1/board-rgds-04-usb-otg-dual-role.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-rgds-04-usb-otg-dual-role.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: crackerjacques <jack@supremeoverlordjabs.co>
+Date: Fri, 3 Jul 2026 12:00:00 +0200
+Subject: [PATCH] arm64: dts: rockchip: rg-ds: make OTG-C port dual-role so USB
+ hubs work
+
+The mainline rk3568-anbernic-rg-ds DTS pins the type-C OTG controller to
+dr_mode = "peripheral" so the ttyGS0 gadget console is guaranteed. The side
+effect is that the OTG-C port can never enter host mode: plugging in a USB
+hub (or any downstream device) does nothing, because the controller stays a
+gadget and no VBUS is driven.
+
+Switch the port to dr_mode = "otg" (the same dual-role approach used on the
+Anbernic RG Vita Pro and the mainline Powkiddy X55). When the port is idle or
+tethered to a host PC it still enumerates as a gadget, so the g_serial ttyGS0
+console keeps working; when a downstream device/hub is attached the rockchip
+usb2phy ID/VBUS detection flips it to host mode.
+
+Wire the rk817 OTG_SWITCH boost regulator as the otg-port phy-supply so the
+port actually drives 5V VBUS in host mode (previously the otg_switch regulator
+was declared but had no consumer).
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+---
+ .../dts/rockchip/rk3568-anbernic-rg-ds.dts    | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts b/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts
+@@ -1217,7 +1217,7 @@
+ };
+
+ &usb_host0_xhci {
+-	dr_mode = "peripheral";
++	dr_mode = "otg";
+ 	phy-names = "usb2-phy";
+ 	phys = <&usb2phy0_otg>;
+ 	maximum-speed = "high-speed";
+@@ -1237,6 +1237,7 @@
+ };
+
+ &usb2phy0_otg {
++	phy-supply = <&otg_switch>;
+ 	status = "okay";
+ };
+
+--
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/board-rgds-04-usb-otg-dual-role.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-rgds-04-usb-otg-dual-role.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: crackerjacques <jack@supremeoverlordjabs.co>
+Date: Fri, 3 Jul 2026 12:00:00 +0200
+Subject: [PATCH] arm64: dts: rockchip: rg-ds: make OTG-C port dual-role so USB
+ hubs work
+
+The mainline rk3568-anbernic-rg-ds DTS pins the type-C OTG controller to
+dr_mode = "peripheral" so the ttyGS0 gadget console is guaranteed. The side
+effect is that the OTG-C port can never enter host mode: plugging in a USB
+hub (or any downstream device) does nothing, because the controller stays a
+gadget and no VBUS is driven.
+
+Switch the port to dr_mode = "otg" (the same dual-role approach used on the
+Anbernic RG Vita Pro and the mainline Powkiddy X55). When the port is idle or
+tethered to a host PC it still enumerates as a gadget, so the g_serial ttyGS0
+console keeps working; when a downstream device/hub is attached the rockchip
+usb2phy ID/VBUS detection flips it to host mode.
+
+Wire the rk817 OTG_SWITCH boost regulator as the otg-port phy-supply so the
+port actually drives 5V VBUS in host mode (previously the otg_switch regulator
+was declared but had no consumer).
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+---
+ .../dts/rockchip/rk3568-anbernic-rg-ds.dts    | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts b/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-anbernic-rg-ds.dts
+@@ -1217,7 +1217,7 @@
+ };
+
+ &usb_host0_xhci {
+-	dr_mode = "peripheral";
++	dr_mode = "otg";
+ 	phy-names = "usb2-phy";
+ 	phys = <&usb2phy0_otg>;
+ 	maximum-speed = "high-speed";
+@@ -1237,6 +1237,7 @@
+ };
+
+ &usb2phy0_otg {
++	phy-supply = <&otg_switch>;
+ 	status = "okay";
+ };
+
+--
+Armbian
+


### PR DESCRIPTION
### What
Make the Anbernic RG DS type-C **OTG port dual-role** so USB hubs (and any downstream device) work on it.

Adds `board-rgds-04-usb-otg-dual-role.patch` to both `rockchip64-7.1` and `rockchip64-7.2`, overriding two nodes in the mainline `rk3568-anbernic-rg-ds.dts`:

- `&usb_host0_xhci`: `dr_mode = "peripheral"` → `dr_mode = "otg"`
- `&usb2phy0_otg`: add `phy-supply = <&otg_switch>`

### Why
The mainline DTS pins `usb_host0_xhci` to `dr_mode = "peripheral"` to guarantee the `ttyGS0` gadget serial console (this board has no accessible physical UART). The side effect is the OTG-C port can never enter host mode — plugging in a USB hub does nothing, and the `otg_switch` (rk817 OTG boost) regulator has no consumer so no VBUS is ever driven.

### How
`dr_mode = "otg"` is the same dual-role approach already used by the mainline **Powkiddy X55** (`rk3566-powkiddy-x55.dts`, inherits `otg`) and the in-progress **Anbernic RG Vita Pro**:

- Idle / tethered to a host PC → still enumerates as a gadget, so the `g_serial` `ttyGS0` console is **preserved**.
- Downstream device / hub attached → rockchip `usb2phy0` ID/VBUS detection flips the controller to host mode.

Wiring the rk817 `OTG_SWITCH` boost as the otg-port `phy-supply` makes the port drive 5V VBUS in host mode. `phy-supply` on `&usb2phy0_otg` is the standard rockchip-inno-usb2phy binding used by every mainline RK3568 board (rock-3a, quartz64-b, bpi-r2-pro, …).

### Scope
- Follow-up to the merged RG DS board (#9934). Board files/DTS are unchanged; this is a two-node override patch.
- Applies cleanly against current mainline (`git apply --check` strict, exit 0).

### Testing
- [x] Patch applies cleanly to the mainline `rk3568-anbernic-rg-ds.dts` (7.1 + 7.2).
- [x] On-device: USB hub enumerates in host mode **and** the `ttyGS0` console still works when tethered — confirmed on real hardware.
