### PR TITLE
beaglebadge: drop vendor-edge u-boot target (not in ti-u-boot-2026.01)

### DIFF
--- a/config/boards/beaglebadge.conf
+++ b/config/boards/beaglebadge.conf
@@ -11,7 +11,12 @@ BOOTFS_TYPE="fat"
 BOOT_FDT_FILE="ti/k3-am62l3-badge.dts"
 TIBOOT3_FILE="tiboot3.bin"
 DEFAULT_CONSOLE="serial"
-KERNEL_TARGET="vendor,vendor-rt,vendor-edge"
+# vendor-edge dropped: it builds u-boot from ti-u-boot branch ti-u-boot-2026.01,
+# which does not yet carry the AM62L BeagleBadge port (am62lx_badge_defconfig +
+# k3-am62l3-badge DTS) — the uboot artifact fails to configure. Those files DO
+# exist in the vendor/vendor-rt tree (TI SDK tag 12.00.00.07); re-add vendor-edge
+# once TI forward-ports BeagleBadge to ti-u-boot-2026.01.
+KERNEL_TARGET="vendor,vendor-rt"
 KERNEL_TEST_TARGET="vendor"
 SERIALCON="ttyS2"
 ATF_PLAT="k3low"


### PR DESCRIPTION
## Problem
`uboot-beaglebadge-vendor-edge` fails to even configure u-boot:

```
cc1: fatal error: ./arch/../configs/am62lx_badge_defconfig: No such file or directory
Failed to configure u-boot 2026.01 am62lx_badge_defconfig
```

## Cause (verified against TI's ti-u-boot)
The AM62L BeagleBadge u-boot port (`am62lx_badge_defconfig` + `k3-am62l3-badge` DTS) **isn't in the branch `vendor-edge` builds**:

| ti-u-boot ref | Armbian target | `am62lx_badge_defconfig` |
|---|---|---|
| tag `12.00.00.07` (`TI_PSDK_TAG`) | `vendor`, `vendor-rt` | ✅ present |
| `ti-u-boot-2025.01` | — | ✅ present |
| **`ti-u-boot-2026.01`** | **`vendor-edge`** | ❌ **missing** (only the EVM defconfig is there) |

So `vendor`/`vendor-rt` build fine; only `vendor-edge` is broken, because TI hasn't forward-ported BeagleBadge to their 2026.01 branch yet. It's a TI upstream gap, not an Armbian omission.

## Fix
Drop `vendor-edge` from `KERNEL_TARGET` (keep `vendor,vendor-rt`; `KERNEL_TEST_TARGET` stays `vendor`). Re-add it once TI carries AM62L BeagleBadge in `ti-u-boot-2026.01`. Comment in the board file records why.

cc @Grippy98 (board maintainer) — the `vendor-edge` u-boot target just needs TI to forward-port the badge board to `ti-u-boot-2026.01`; nothing to fix on your board files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the BeagleBadge build configuration to use the supported kernel targets only.
  * Added a note clarifying why one kernel option is no longer included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->