### PR TITLE
firstlogin: use useradd/groupadd instead of the adduser suite

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -258,9 +258,11 @@ set_shell() {
 	SHELL_PATH=$(grep "/$USER_SHELL$" /etc/shells | tail -1)
 	chsh -s "$(grep -iF "/$USER_SHELL" /etc/shells | tail -1)"
 
-	# change shell for future users
+	# change shell for future users. useradd (Essential, from passwd) reads
+	# /etc/default/useradd; /etc/adduser.conf only exists when the (now optional
+	# on Debian forky+) adduser package is installed, so guard that edit.
 	sed -i "s|^SHELL=.*|SHELL=${SHELL_PATH}|" /etc/default/useradd
-	sed -i "s|^DSHELL=.*|DSHELL=${SHELL_PATH}|" /etc/adduser.conf
+	[[ -f /etc/adduser.conf ]] && sed -i "s|^DSHELL=.*|DSHELL=${SHELL_PATH}|" /etc/adduser.conf
 
 }
 
@@ -586,7 +588,13 @@ add_user() {
 				RealName="$PRESET_DEFAULT_REALNAME"
 			fi
 
-			adduser --quiet --disabled-password --home /home/"$RealUserName" --gecos "$RealName" "$RealUserName"
+			# useradd (Essential, from passwd) instead of adduser (optional on
+			# Debian forky+, absent from minimal images). --user-group mirrors
+			# adduser's per-user group; --create-home copies /etc/skel; login shell
+			# comes from SHELL_PATH (set_shell ran first). Password is disabled here
+			# and set right below, same as adduser --disabled-password.
+			useradd --create-home --home-dir /home/"$RealUserName" --shell "$SHELL_PATH" \
+				--comment "$RealName" --user-group "$RealUserName"
 
 			# download and add SSH key if defined
 			if [[ -n "${PRESET_USER_KEY}" ]]; then
@@ -608,7 +616,7 @@ add_user() {
 			# (docker-ce package creates this group automatically during postinst, but we create it early
 			# to guarantee group membership is ready immediately after user creation.)
 			if ! getent group docker >/dev/null; then
-				if ! addgroup --system --quiet docker 2>/dev/null; then
+				if ! groupadd --system docker 2>/dev/null; then
 					echo "Warning: Failed to create docker group" >&2
 				fi
 			fi


### PR DESCRIPTION
Fixes armbian/os#470.

## Problem
Debian **Forky** demoted `adduser` from the essential/minimal set, so minimal images ship without it. `armbian-firstlogin` then fails at user creation:

> Forky minimal: firstlogin needs adduser — `adduser: command not found`, `/sbin/adduser` absent from the image. Trixie minimal still has it.

## Fix
Switch firstlogin off the `adduser` suite to the **Essential `passwd`/shadow-utils tools**, matching the recent precedent `a6cb68a1f` ("switch rockchip family_tweaks from addgroup to groupadd", 2026-05):

| Was (`adduser` pkg) | Now (`passwd`, Essential) |
|---|---|
| `adduser --disabled-password --home … --gecos …` | `useradd --create-home --home-dir … --shell "$SHELL_PATH" --comment … --user-group` |
| `addgroup --system --quiet docker` | `groupadd --system docker` (getent guard already present) |
| `sed … /etc/adduser.conf` (DSHELL) | guarded on the file existing; `useradd` reads `/etc/default/useradd`, which `set_shell` already updates |

Behaviour preserved: `--user-group` gives the per-user primary group `adduser` created by default; `--create-home` copies `/etc/skel`; the login shell comes from `SHELL_PATH` (`set_shell` runs before `add_user`); the account is created with a disabled password and the real password is set immediately after, exactly as before.

No package added — `useradd`/`groupadd` are Essential (`passwd`), present on every image including minimal. Rather than re-adding `adduser` to the base (the 2023-era approach), this keeps the current direction of not depending on the optional suite.

## Testing
- `bash -n` clean.
- Chose `useradd` over re-adding `adduser` per the 2026 precedent; the user-creation path can't be boot-tested here, so a Forky-minimal firstlogin run is worth a sanity check before/after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved first-login account setup to avoid failures on systems where certain configuration files are missing.
  * Updated user account creation so the selected login shell, home directory, and account details are applied more reliably at creation time.
  * Made automatic group setup more consistent when preparing the system for container-related access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->