### PR TITLE
fix: stop setting LC_ALL in armbian-lang.sh

### DIFF
--- a/packages/bsp/common/etc/profile.d/armbian-lang.sh
+++ b/packages/bsp/common/etc/profile.d/armbian-lang.sh
@@ -1,4 +1,7 @@
-# This should fix
-# perl: warning: Setting locale failed.
+# Suppress "perl: warning: Setting locale failed." on minimal images.
+# Only ensure LANG has a fallback value - do NOT set LC_ALL here because
+# it overrides every individual LC_* category and breaks update-locale.
 
-export LC_ALL=$LANG
+if [ -z "$LANG" ]; then
+	export LANG="C.UTF-8"
+fi


### PR DESCRIPTION
Fixes #10131

`export LC_ALL=$LANG` overrides every individual LC_* variable unconditionally, so any per-category locale set via `update-locale` (like LC_TIME=en_GB.UTF-8) gets ignored at login. The original intent was to suppress perl locale warnings on minimal images where LANG might be unset.

Replaced with a LANG fallback guard - if LANG is empty, default it to C.UTF-8. This still suppresses the perl warnings but lets update-locale work as expected.

saschabuehrle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale handling so existing language settings are no longer overridden.
  * Default language is now only applied when no `LANG` value is set, helping preserve custom locale configuration.
  * This change reduces unexpected behavior for tools that rely on system locale settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->