### PR TITLE
fix(chroot): add Dpkg conffile options to prevent interactive prompts

### DIFF
--- a/lib/functions/logging/runners.sh
+++ b/lib/functions/logging/runners.sh
@@ -70,6 +70,14 @@ function chroot_sdcard_apt_get() {
 
 	apt_params+=(-o "Dpkg::Use-Pty=0") # Please be quiet
 
+	# Prevent dpkg from prompting about modified conffiles in non-interactive chroot builds.
+	# Without this, packages like ubuntu-pro-client that ship modified conffiles (e.g.
+	# /etc/apt/apt.conf.d/20apt-esm-hook.conf) will prompt on stdin, get EOF, and fail.
+	# --force-confdef: use dpkg's default action (no prompt)
+	# --force-confold: if the default is ambiguous, keep the existing conffile
+	apt_params+=(-o "Dpkg::Options::=--force-confdef")
+	apt_params+=(-o "Dpkg::Options::=--force-confold")
+
 	# --list-cleanup
 	#     This option is on by default; use --no-list-cleanup to turn it off. When it is on, apt-get will
 	#     automatically manage the contents of /var/lib/apt/lists to ensure that obsolete files are erased. The only


### PR DESCRIPTION
# Description

When a cached rootfs contains a modified conffile (e.g. ubuntu-pro-client's /etc/apt/apt.conf.d/20apt-esm-hook.conf), dpkg prompts during apt-get install. In a non-interactive chroot stdin is closed, so dpkg reads EOF and exits with error 1 -- causing the build to fail after 3 retries.

DEBIAN_FRONTEND=noninteractive alone is insufficient: the conffile prompt is driven by dpkg's own logic and is not suppressed by the frontend var when stdin is a closed pipe rather than a terminal.

Fix: pass --force-confdef and --force-confold as Dpkg options in the central chroot_sdcard_apt_get function so all apt-get invocations in chroot builds resolve conffile conflicts without prompting.

This resolves the Beaglebadge_resolute_vendor_6.18.y_gnome_desktop failure where ubuntu-pro-client and its 9 dependent packages all failed to configure because of this conffile prompt.

Assisted by Claude Sonnet 4.6

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Built Beaglebadge Resolute vendor Image w/Gnome Desktop and verified conffile prompt failure is resolved. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chroot package installation reliability by preventing interactive prompts during package upgrades.
  * Reduced build failures caused by modified configuration files requiring manual input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->