### PR TITLE
k3-beagle: fix malformed csi0-imx219 overlay patch (bad hunk count)

### DIFF
--- a/patch/kernel/archive/k3-beagle-6.18/0003-arm64-dts-ti-add-beagley-ai-csi0-imx219-overlay.patch
+++ b/patch/kernel/archive/k3-beagle-6.18/0003-arm64-dts-ti-add-beagley-ai-csi0-imx219-overlay.patch
@@ -15,8 +15,8 @@ then consume the raw frames through the TI media graph.
 Assisted-by: Codex <codex@openai.com>
 ---
  arch/arm64/boot/dts/ti/Makefile                    |  1 +
- .../dts/ti/k3-am67a-beagley-ai-csi0-imx219.dtso    | 130 +++++++++++++++++++++
- 2 files changed, 131 insertions(+)
+ .../dts/ti/k3-am67a-beagley-ai-csi0-imx219.dtso    | 128 +++++++++++++++++++++
+ 2 files changed, 129 insertions(+)
  create mode 100644 arch/arm64/boot/dts/ti/k3-am67a-beagley-ai-csi0-imx219.dtso
 
 diff --git a/arch/arm64/boot/dts/ti/Makefile b/arch/arm64/boot/dts/ti/Makefile
@@ -36,7 +36,7 @@ new file mode 100644
 index 000000000000..333333333333
 --- /dev/null
 +++ b/arch/arm64/boot/dts/ti/k3-am67a-beagley-ai-csi0-imx219.dtso
-@@ -0,0 +1,130 @@
+@@ -0,0 +1,128 @@
 +// SPDX-License-Identifier: GPL-2.0-only OR MIT
 +/*
 + * DT Overlay for Raspberry Pi Camera V2.1 on BeagleY-AI CSI0.
@@ -165,5 +165,5 @@ index 000000000000..333333333333
 +&dphy0 {
 +	status = "okay";
 +};
---
+-- 
 2.43.0


### PR DESCRIPTION
## Problem

The BeagleY-AI CSI0 IMX219 overlay patch fails to apply on **edge / linux-6.18.y** kernel builds (board `beagley-ai`, family `k3-beagle`), breaking the kernel artifact:

```
patch: **** malformed patch at line 152: --
Failed to parse unidiff ... 'Hunk is longer than expected'
Summary: 5 total patches; 4 applied; 1 invalid_diff; 1 failed_apply
Exception: Failed to apply 1 patches.
```

## Root cause

In `0003-arm64-dts-ti-add-beagley-ai-csi0-imx219-overlay.patch`, the new-file hunk header declared **`@@ -0,0 +1,130 @@`** but the body contains only **128** added lines. `patch(1)` therefore ran past the hunk and consumed the `-- ` / `2.43.0` git signature footer as diff body. The footer's trailing space had also been stripped (`--` instead of `-- `).

## Fix

- Hunk count `+1,130` → `+1,128`
- Diffstat aligned (`128` / `129 insertions(+)`)
- Restored the `-- ` signature separator

The overlay content is **unchanged and complete** (brace/bracket balanced — 21/21 `{}`, 36/36 `<>`).

## Verification

Both tools that failed in the build now pass against a matching Makefile context:

- `git apply --check` → exit 0
- `patch -p1 --dry-run` → exit 0

Note: this fixes the patch envelope only. Ideally the same correction lands at the source (original patch author) so it doesn't regress on the next import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Raspberry Pi Camera V2.1 (Sony IMX219) on BeagleY-AI CSI0.
  * Expanded the BeagleY-AI overlay list so the new camera overlay is available in builds.
  * Enabled camera-related hardware configuration, including I2C, CSI-2, clock, and power setup, for improved plug-and-play camera use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->