### PR TITLE
Fix sata2 target-supply for Orange Pi 3B and Station M2

### DIFF
--- a/patch/kernel/archive/rockchip64-7.1/board-orangepi3b-0002-specify-target-supply-for-sata2.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-orangepi3b-0002-specify-target-supply-for-sata2.patch
@@ -18,7 +18,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-+&sata2 {
++&sata2_port0 {
 +	target-supply = <&vcc3v3_pcie30>;
 +};
 +

--- a/patch/kernel/archive/rockchip64-7.1/board-station-m2.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-station-m2.patch
@@ -209,7 +209,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-+&sata2 {
++&sata2_port0 {
 +	target-supply = <&vcc3v3_pcie>;
 +};
 +

--- a/patch/kernel/archive/rockchip64-7.2/board-orangepi3b-0002-specify-target-supply-for-sata2.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-orangepi3b-0002-specify-target-supply-for-sata2.patch
@@ -18,7 +18,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-+&sata2 {
++&sata2_port0 {
 +	target-supply = <&vcc3v3_pcie30>;
 +};
 +

--- a/patch/kernel/archive/rockchip64-7.2/board-station-m2.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-station-m2.patch
@@ -209,7 +209,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-+&sata2 {
++&sata2_port0 {
 +	target-supply = <&vcc3v3_pcie>;
 +};
 +


### PR DESCRIPTION
# Description

The sata2 node for rk356x has changed in kernel 7.1 (see [kernel commit 5918bf2](https://github.com/torvalds/linux/commit/5918bf2a17f4689abfb94d341c5240088f8bd16e)). Update patches and migrate target-supply based on change.

# How Has This Been Tested?

Tested on Orange Pi 3B:
1. Build fresh edge image.
2. Enable `rockchip-rk3566-sata2.dtbo`. After restart, `lsblk` does not detect sata SSD.
3. Update patches (per this PR) and rebuild DTB with `./compile.sh kernel-dtb BOARD=orangepi3b BRANCH=edge`.
4. After .deb install and restart, `lsblk` now detects sata SSD.

Not tested on Station M2.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an onboard status LED with a heartbeat indicator.
  * Added headset detection support and improved SD card, USB, Bluetooth, and serial hardware handling.

* **Bug Fixes**
  * Improved SATA SSD reliability, especially when PCIe is disabled.
  * Updated power and pin assignments to better match supported hardware, helping prevent storage and peripheral issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->