### PR TITLE
spacemit: rtl8852bs: guard GCC-only warning flags for clang builds

### DIFF
--- a/patch/kernel/archive/spacemit-6.18/020-rtl8852bs-guard-gcc-only-warnings-for-clang.patch
+++ b/patch/kernel/archive/spacemit-6.18/020-rtl8852bs-guard-gcc-only-warnings-for-clang.patch
@@ -1,0 +1,46 @@
+From: Igor Velkov <iav@iav.lv>
+Date: Mon, 6 Jul 2026 00:00:00 +0000
+Subject: [PATCH] rtl8852bs: guard GCC-only warning flags for clang builds
+
+The bundled rtl8852bs Makefile adds -Wno-restrict and
+-Wno-old-style-declaration unconditionally. Both warning options exist
+only in GCC; clang rejects them and, together with the kernel's
+-Werror=unknown-warning-option, the build fails:
+
+    error: unknown warning option '-Wno-restrict'
+    error: unknown warning option '-Wno-old-style-declaration'
+
+On spacemit the rtl8852bs driver is in-tree (EXTRAWIFI is forced off in
+the family config), so this breaks every clang kernel build for the
+family.
+
+Wrap the two flags in $(call cc-disable-warning, ...) so each is added
+only when the compiler understands the positive warning name, i.e. for
+GCC. This is also robust against CC carrying a ccache prefix, unlike the
+existing 'ifeq ($(CC), clang)' string comparison further down the file.
+The remaining -Wno-* flags in this block (unused, empty-body,
+missing-prototypes, missing-declarations) are understood by clang too and
+are left untouched.
+
+Signed-off-by: Igor Velkov <iav@iav.lv>
+---
+ drivers/net/wireless/realtek/rtl8852bs/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/wireless/realtek/rtl8852bs/Makefile b/drivers/net/wireless/realtek/rtl8852bs/Makefile
+--- a/drivers/net/wireless/realtek/rtl8852bs/Makefile
++++ b/drivers/net/wireless/realtek/rtl8852bs/Makefile
+@@ -14,11 +14,11 @@ ccflags-y += -Wno-unused-variable
+ #ccflags-y += -Wno-unused-function
+ ccflags-y += -Wno-unused
+ #ccflags-y += -Wno-uninitialized
+-ccflags-y += -Wno-restrict
++ccflags-y += $(call cc-disable-warning, restrict)
+ ccflags-y += -Wno-empty-body
+ ccflags-y += -Wno-missing-prototypes
+ ccflags-y += -Wno-missing-declarations
+-ccflags-y += -Wno-old-style-declaration
++ccflags-y += $(call cc-disable-warning, old-style-declaration)
+
+ ############ ANDROID COMMON KERNEL ############
+ # clang


### PR DESCRIPTION
# Description

The rtl8852bs driver bundled in the spacemit vendor kernel adds two GCC-only warning options unconditionally in its `Makefile`:

    ccflags-y += -Wno-restrict
    ccflags-y += -Wno-old-style-declaration

clang does not know these options, and with the kernel's `-Werror=unknown-warning-option` the build fails:

    error: unknown warning option '-Wno-restrict' [-Werror,-Wunknown-warning-option]
    error: unknown warning option '-Wno-old-style-declaration'

On the `spacemit` family the driver is in-tree and `EXTRAWIFI` is forced off in the family config, so it cannot be excluded — this breaks every clang kernel build for the family.

**Fix:** wrap the two GCC-only flags in `$(call cc-disable-warning, ...)`, so each is added only for a compiler that understands the positive warning name (GCC). This is also robust against `CC` carrying a `ccache` prefix, unlike the `ifeq ($(CC), clang)` compare further down the same Makefile. The remaining `-Wno-*` in that block (`unused`, `empty-body`, `missing-prototypes`, `missing-declarations`) are understood by clang and left untouched. GCC behaviour is unchanged.

# How Has This Been Tested?

Kernel build for `bananapif3` (spacemit, kernel 6.18):

- [x] GCC full build: rtl8852bs (372 objects) + `8852bs.ko` + `linux-image` .deb — 0 errors.
- [x] clang full build with the driver enabled: `8852bs.ko` built under clang, 0 `unknown-warning-option` / 0 errors, `linux-image` .deb produced.

Repro:

    ./compile.sh kernel BOARD=bananapif3 BRANCH=current KERNEL_COMPILER=clang

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wireless driver build compatibility by avoiding compiler flags that can break clang-based builds.
  * Reduced build failures caused by unsupported warning options while keeping GCC-compatible warning handling intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->