### PR TITLE
rockchip64: fix clang -Wincompatible-pointer-types-discards-qualifiers in carried patches

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/general-add-panel-simple-dsi.patch
+++ b/patch/kernel/archive/rockchip64-6.12/general-add-panel-simple-dsi.patch
@@ -388,7 +388,7 @@ index 000000000000..111111111111
 +	if (!mode)
 +		return 0;
 +
-+	ret = of_get_drm_display_mode(panel->dev->of_node, mode, &p->desc->bus_format,
++	ret = of_get_drm_display_mode(panel->dev->of_node, mode, (u32 *)&p->desc->bus_format,
 +				      OF_USE_NATIVE_MODE);
 +	if (ret) {
 +		dev_dbg(panel->dev, "failed to find dts display timings\n");

--- a/patch/kernel/archive/rockchip64-6.18/general-add-panel-simple-dsi.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-add-panel-simple-dsi.patch
@@ -388,7 +388,7 @@ index 000000000000..111111111111
 +	if (!mode)
 +		return 0;
 +
-+	ret = of_get_drm_display_mode(panel->dev->of_node, mode, &p->desc->bus_format,
++	ret = of_get_drm_display_mode(panel->dev->of_node, mode, (u32 *)&p->desc->bus_format,
 +				      OF_USE_NATIVE_MODE);
 +	if (ret) {
 +		dev_dbg(panel->dev, "failed to find dts display timings\n");

--- a/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-notify-typec-dp-hpd-state-through-extcon.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3399-usbc-notify-typec-dp-hpd-state-through-extcon.patch
@@ -31,7 +31,7 @@ index 111111111111..222222222222 100644
 +/* Notify DP hotplug change via extcon. Current rockchip cdn-dp driver need this signal
 + * to reset DP link. */
 +static void dp_altmode_update_extcon_hpd_status(struct dp_altmode *dp, bool new_hpd) {
-+	const struct device *dev = &dp->alt->dev;
++	struct device *dev = &dp->alt->dev;
 +	struct extcon_dev* edev = NULL;
 +	int ret;
 +

--- a/patch/kernel/archive/rockchip64-6.6/general-add-panel-simple-dsi.patch
+++ b/patch/kernel/archive/rockchip64-6.6/general-add-panel-simple-dsi.patch
@@ -388,7 +388,7 @@ index 000000000000..e3c8dcf8cb5e
 +	if (!mode)
 +		return 0;
 +
-+	ret = of_get_drm_display_mode(panel->dev->of_node, mode, &p->desc->bus_format,
++	ret = of_get_drm_display_mode(panel->dev->of_node, mode, (u32 *)&p->desc->bus_format,
 +				      OF_USE_NATIVE_MODE);
 +	if (ret) {
 +		dev_dbg(panel->dev, "failed to find dts display timings\n");

--- a/patch/kernel/archive/rockchip64-7.1/general-add-panel-simple-dsi.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-add-panel-simple-dsi.patch
@@ -389,7 +389,7 @@ index 000000000000..111111111111
 +	if (!mode)
 +		return 0;
 +
-+	ret = of_get_drm_display_mode(panel->dev->of_node, mode, &p->desc->bus_format,
++	ret = of_get_drm_display_mode(panel->dev->of_node, mode, (u32 *)&p->desc->bus_format,
 +				      OF_USE_NATIVE_MODE);
 +	if (ret) {
 +		dev_dbg(panel->dev, "failed to find dts display timings\n");


### PR DESCRIPTION
# Description

Two carried rockchip64 kernel patches assign a `const` pointer to a non-const one, which clang rejects under `-Werror,-Wincompatible-pointer-types-discards-qualifiers`:

- `general-add-panel-simple-dsi.patch`: `of_get_drm_display_mode(..., &p->desc->bus_format, ...)` — `desc` is `const`.
- `rk3399-usbc-notify-typec-dp-hpd-state-through-extcon.patch`: `const struct device *dev = &dp->alt->dev;` is passed to `extcon_get_edev_by_phandle()`, which takes a non-const `struct device *`.

**Fix:**
- **panel-simple-dsi**: cast `(u32 *)&p->desc->bus_format` — the pointed-to memory is writable (a `devm_kmemdup` copy), only the pointer type is `const`. Replicated to `rockchip64-{6.6,6.12,6.18,7.1}` (7.2 has the patch `.disabled`).
- **displayport extcon**: drop the needless `const` on the local `dev` (6.18 only; 6.6/6.12 don't carry this patch, 7.1/7.2 already use the non-const form).

Behaviour-preserving; GCC was already silent on both.

# How Has This Been Tested?

rockchip64 clang build (armsom-sige5) — both files compile clean under clang.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for simple MIPI-DSI DRM display panels, with device-tree driven initialization/exit command sequences.
  * Added device-tree configurable panel power, reset, and enable GPIO handling, plus automatic mode/physical size, preferred mode selection, orientation, and timing reporting.
* **Bug Fixes**
  * Improved DisplayPort HPD hotplug state propagation to external hotplug signaling for more reliable display event updates.
  * Enhanced display mode probing behavior to set preferred mode and physical dimensions more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->