### PR TITLE
kickpik2b: Change vendor from SoC-level to board-level (KICKPI)

### DIFF
--- a/config/boards/kickpik2b.csc
+++ b/config/boards/kickpik2b.csc
@@ -1,6 +1,6 @@
 # Allwinner H618 quad core 1/2/4GB RAM SoC WiFi SPI USB-C
 BOARD_NAME="KickPi K2B"
-BOARD_VENDOR="allwinner"
+BOARD_VENDOR="kickpi"
 BOARDFAMILY="sun50iw9-bpi"
 BOARD_MAINTAINER="pyavitz"
 INTRODUCED="2024"


### PR DESCRIPTION
Depends on this [PR](https://github.com/armbian/armbian.github.io/pull/355).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the board vendor label to the new `kickpi` branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->