### PR TITLE
Use relative symbolic links for some BSP files

### DIFF
--- a/config/boards/bestv-r3300-l.csc
+++ b/config/boards/bestv-r3300-l.csc
@@ -47,9 +47,7 @@ function post_family_tweaks_bsp__bestv-r3300-l() {
 	install -Dm644 "${SRC}/packages/bsp/S905X-P212/S905X-P212.conf" \
 		"${destination}/usr/share/alsa/ucm2/Amlogic/gx-sound-card/S905X-P212.conf"
 
-	if [ ! -d "${destination}/usr/share/alsa/ucm2/conf.d/gx-sound-card" ]; then
-		mkdir -p "${destination}/usr/share/alsa/ucm2/conf.d/gx-sound-card"
-	fi
-	ln -sfv /usr/share/alsa/ucm2/Amlogic/gx-sound-card/S905X-P212.conf \
+	mkdir -p "${destination}/usr/share/alsa/ucm2/conf.d/gx-sound-card"
+	ln -sfv ../../Amlogic/gx-sound-card/S905X-P212.conf \
 		"${destination}/usr/share/alsa/ucm2/conf.d/gx-sound-card/S905X-P212.conf"
 }

--- a/config/boards/cainiao-cniot-core.csc
+++ b/config/boards/cainiao-cniot-core.csc
@@ -47,9 +47,7 @@ function post_family_tweaks_bsp__cainiao-cniot-core() {
 	install -Dm644 "${SRC}/packages/bsp/cainiao-cniot-core/cniot-core.conf" \
 		"${destination}/usr/share/alsa/ucm2/Amlogic/axg-sound-card/cniot-core.conf"
 
-	if [ ! -d "${destination}/usr/share/alsa/ucm2/conf.d/axg-sound-card" ]; then
-		mkdir -p "${destination}/usr/share/alsa/ucm2/conf.d/axg-sound-card"
-	fi
-	ln -sfv /usr/share/alsa/ucm2/Amlogic/axg-sound-card/cniot-core.conf \
+	mkdir -p "${destination}/usr/share/alsa/ucm2/conf.d/axg-sound-card"
+	ln -sfv ../../Amlogic/axg-sound-card/cniot-core.conf \
 		"${destination}/usr/share/alsa/ucm2/conf.d/axg-sound-card/cniot-core.conf"
 }

--- a/config/boards/norco-emb-3531.csc
+++ b/config/boards/norco-emb-3531.csc
@@ -38,9 +38,7 @@ function post_family_tweaks_bsp__norco-emb-3531() {
 	install -Dm644 "${SRC}/packages/bsp/norco-emb-3531/emb-3531.conf" \
 		"${destination}/usr/share/alsa/ucm2/Rockchip/emb-3531/emb-3531.conf"
 
-	if [ ! -d "${destination}/usr/share/alsa/ucm2/conf.d/simple-card" ]; then
-		mkdir -p "${destination}/usr/share/alsa/ucm2/conf.d/simple-card"
-	fi
-	ln -sfv /usr/share/alsa/ucm2/Rockchip/emb-3531/emb-3531.conf \
+	mkdir -p "${destination}/usr/share/alsa/ucm2/conf.d/simple-card"
+	ln -sfv ../../Rockchip/emb-3531/emb-3531.conf \
 		"${destination}/usr/share/alsa/ucm2/conf.d/simple-card/emb-3531.conf"
 }


### PR DESCRIPTION
# How Has This Been Tested?

Build the full imgs for these boards to make sure the compilation doesn't fail. Then use losetup to check if the symlinks inside the image are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio configuration setup during installation so the needed directories are created consistently.
  * Updated sound profile links to use more reliable relative paths, helping prevent missing or broken audio configuration on supported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->