### PR TITLE
boards/youyeetoo-yy3588: name audio outputs on pipewire too

### DIFF
--- a/config/boards/youyeetoo-yy3588.conf
+++ b/config/boards/youyeetoo-yy3588.conf
@@ -47,11 +47,35 @@ function pre_config_uboot_target__youyeetoo_yy3588_patch_rockchip_common_boot_or
 function post_family_tweaks__youyeetoo_yy3588_naming_audios() {
 	display_alert "$BOARD" "Renaming Youyeetoo YY3588 audios" "info"
 
+	# PulseAudio releases (bookworm, jammy, noble): udev SOUND_DESCRIPTION maps to PA_PROP_DEVICE_DESCRIPTION.
 	mkdir -p $SDCARD/etc/udev/rules.d/
 	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
 	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmiin-sound", ENV{SOUND_DESCRIPTION}="HDMI-In Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
 	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-dp0-sound", ENV{SOUND_DESCRIPTION}="DP0 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
 	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-analog-sound", ENV{SOUND_DESCRIPTION}="ES8388 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+
+	# PipeWire releases (trixie, forky, sid, resolute+): WirePlumber 0.5 ignores udev, set device.description directly.
+	mkdir -p $SDCARD/etc/wireplumber/wireplumber.conf.d/
+	cat > $SDCARD/etc/wireplumber/wireplumber.conf.d/51-youyeetoo-yy3588-audio-names.conf <<-'WPCONF'
+		monitor.alsa.rules = [
+		  {
+		    matches = [ { device.name = "alsa_card.platform-analog-sound" } ]
+		    actions = { update-props = { device.description = "ES8388 Audio" } }
+		  }
+		  {
+		    matches = [ { device.name = "alsa_card.platform-hdmi0-sound" } ]
+		    actions = { update-props = { device.description = "HDMI0 Audio" } }
+		  }
+		  {
+		    matches = [ { device.name = "alsa_card.platform-dp0-sound" } ]
+		    actions = { update-props = { device.description = "DP0 Audio" } }
+		  }
+		  {
+		    matches = [ { device.name = "alsa_card.platform-hdmiin-sound" } ]
+		    actions = { update-props = { device.description = "HDMI-In Audio" } }
+		  }
+		]
+	WPCONF
 
 	return 0
 }


### PR DESCRIPTION
# Description

On PipeWire releases every YY3588 audio output shows up as a generic "Built-in Audio", so HDMI, DisplayPort and the onboard analog codec are impossible to tell apart in the sound settings. The board already renames them for PulseAudio through a udev rule, and this adds the matching WirePlumber drop-in so the names also show on PipeWire.

# How Has This Been Tested?

- [x] Booted Ubuntu resolute on the YY3588 (WirePlumber 0.5.13) and compared the audio outputs before and after. armbianmonitor: https://paste.armbian.com/dutitimenu

Before, the three outputs were indistinguishable:

```
Sinks:
   Built-in Audio Stereo
   Built-in Audio Stereo
   Built-in Audio Stereo
```

After, each one is named:

```
Sinks:
   HDMI0 Audio Stereo
   DP0 Audio Stereo
   ES8388 Audio Stereo
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved audio device naming on the YY3588 board for clearer device labels in system audio menus.
  * Added updated names for analog, HDMI, and DPI-IO audio cards so they are easier to identify.

* **Bug Fixes**
  * Expanded audio naming support to include WirePlumber-based configuration, helping audio devices appear with more consistent descriptions across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->