### PR TITLE
rockchip64: yy3588: fix HDMI-RX detect GPIO to GPIO1_D5

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3588-youyeetoo-yy3588.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3588-youyeetoo-yy3588.dts
@@ -340,7 +340,7 @@
 };
 
 &hdmi_receiver {
-	hpd-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
+	hpd-gpios = <&gpio1 RK_PD5 GPIO_ACTIVE_LOW>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_5v_det>;
 	status = "okay";
@@ -605,7 +605,7 @@
 &pinctrl {
 	hdmirx {
 		hdmirx_5v_det: hdmirx-5v-det {
-			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 

--- a/patch/kernel/archive/rockchip64-7.1/dt/rk3588-youyeetoo-yy3588.dts
+++ b/patch/kernel/archive/rockchip64-7.1/dt/rk3588-youyeetoo-yy3588.dts
@@ -340,7 +340,7 @@
 };
 
 &hdmi_receiver {
-	hpd-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
+	hpd-gpios = <&gpio1 RK_PD5 GPIO_ACTIVE_LOW>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_5v_det>;
 	status = "okay";
@@ -605,7 +605,7 @@
 &pinctrl {
 	hdmirx {
 		hdmirx_5v_det: hdmirx-5v-det {
-			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 

--- a/patch/kernel/archive/rockchip64-7.2/dt/rk3588-youyeetoo-yy3588.dts
+++ b/patch/kernel/archive/rockchip64-7.2/dt/rk3588-youyeetoo-yy3588.dts
@@ -340,7 +340,7 @@
 };
 
 &hdmi_receiver {
-	hpd-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
+	hpd-gpios = <&gpio1 RK_PD5 GPIO_ACTIVE_LOW>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_5v_det>;
 	status = "okay";
@@ -605,7 +605,7 @@
 &pinctrl {
 	hdmirx {
 		hdmirx_5v_det: hdmirx-5v-det {
-			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 


### PR DESCRIPTION
# Description

The YY3588 device tree in the rockchip64 kernels declares the HDMI-RX signal detect on GPIO1_C6, which is wrong: the receiver never sees an attached source and cannot capture.

The detect is wired to GPIO1_D5. The value comes from the board's Android device tree. Applied to the 6.18, 7.1 and 7.2 dt drop-ins so current and edge get it before the upstream change lands.

Same fix sent upstream: https://lore.kernel.org/all/20260709-yy3588-hdmirx-d5-fix-v1-1-900a6790386c@superkali.me/

# How Has This Been Tested?

Verified the detect GPIO on a YY3588 with a NanoPC-T6 driving the HDMI-IN port. Tested on the vendor 6.1 kernel where the HDMI-RX driver is functional, the pin is the same physical net on the rockchip64 kernels.

- [x] With GPIO1_D5 the receiver locks, v4l2 reports 1920x1080p60, and a frame captures
- [x] With GPIO1_C6 the detect stays high, no lock, no capture

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the HDMI hot-plug detect and 5V-detect pin assignment on the RK3588 Youyeetoo YY3588 board.
  * Updated the board configuration so HDMI receiver detection uses the new GPIO pin consistently across supported kernel versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->