### PR TITLE
jethome: fix jethub-burn extension: add BETA=yes support

### DIFF
--- a/extensions/jethub-burn.sh
+++ b/extensions/jethub-burn.sh
@@ -127,7 +127,7 @@ function post_build_image__900_jethub_burn() {
 
 	bootstrap_tools
 
-	local -r debs_dir="${SRC}/output/debs"
+	local -r debs_dir="${DEB_STORAGE:-${SRC}/output/debs}"
 	local uboot_deb uboot_bin
 	uboot_deb=$(find "${debs_dir}" -maxdepth 1 -type f -name "linux-u-boot-${BOARD}-*.deb" | sort -V | tail -n1)
 	[[ -n "${uboot_deb}" ]] || exit_with_error "u-boot deb not found for ${BOARD}"


### PR DESCRIPTION
# Description

Nightly image jobs for JetHub boards fail while converting the image to Amlogic burn format:

```
INFO: Converting image to Amlogic burn format [ jethub-burn :: jethubj80 ]
ERROR: u-boot deb not found for jethubj80
ERROR: Exiting with error 43
   post_build_image__900_jethub_burn() --> extensions/jethub-burn.sh:133
```

# How Has This Been Tested?

- [X] BETA=yes build ok

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package lookup for image creation so it now uses the preferred storage location when available, with a fallback to the build output directory.
  * This helps the burn-image process find the correct Debian package more reliably during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->