### PR TITLE
Fix ethernet on BigTreeTech CB1

### DIFF
--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
@@ -1,0 +1,113 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JohnTheCoolingFan <ivan8215145640@gmail.com>
+Date: Fri, 10 Jul 2026 05:01:33 +0000
+Subject: arm64: dts: allwinner: BigTreeTech CB1 emac1 ac300
+
+Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 58 +++++++++-
+ 1 file changed, 53 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
+index 6bc49f6c4..c8cf794a8 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
+@@ -110,10 +110,19 @@ ws2812: ws2812 {
+ 		rgb_cnt = <2>;
+ 		rgb_value = <0x000001 0x010000>;
+ 		status = "disabled";
+ 	};
+ 
++	ac300_pwm_clk: ac300-clk {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		/* 500ns period -> 2MHz */
++		pwms = <&pwm 5 500 0>;
++		clock-frequency = <2000000>;
++		status = "okay";
++	};
++
+ 	i2c_gpio: i2c-gpio {
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+ 		compatible = "i2c-gpio";
+ 		status = "disabled";
+@@ -147,31 +156,70 @@ mcp2515_clock: mcp2515_clock {
+ 
+ &cpu0 {
+ 	cpu-supply = <&reg_dcdc2>;
+ };
+ 
++&sid {
++	ephy_calibration: ephy-calibration@2c {
++		reg = <0x2c 0x2>;
++	};
++};
++
+ &gpu {
+ 	mali-supply = <&reg_dcdc1>;
+ 	status = "okay";
+ };
+ 
+ &emac1 {
++	compatible = "allwinner,sun50i-h616-internal-emac";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&rmii_pins>;
+ 	phy-mode = "rmii";
+-	phy-handle = <&rmii_phy>;
++	phy-handle = <&ac300_ephy>;
+ 	phy-supply = <&reg_dldo1>;
+ 	allwinner,rx-delay-ps = <3100>;
+ 	allwinner,tx-delay-ps = <700>;
+ 	status = "okay";
++
++	mdio-mux {
++		compatible = "allwinner-sun8i-h3-mdio-mux";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		mdio-parent-bus = <&mdio1>;
++
++		internal_mdio: mdio@1 {
++			compatible = "allwinner,sun8i-h3-mdio-internal";
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			ac300_ephy: ethernet-phy@0 {
++				compatible = "ethernet-phy-id0044.1400", "allwinner,sun50i-h618-ac300-ephy", "ethernet-phy-ieee802.3-c22";
++				reg = <0>;
++				clocks = <&ccu CLK_EMAC_25M>, <&ac300_pwm_clk>;
++				clock-names = "ephy", "pwm";
++				nvmem-cells = <&ephy_calibration>;
++				nvmem-cell-names = "calibration";
++				status = "okay";
++			};
++		};
++	};
+ };
+ 
+ &mdio1 {
+-	rmii_phy: ethernet-phy@1 {
+-		compatible = "ethernet-phy-ieee802.3-c22";
+-		reg = <1>;
+-	};
++	compatible = "snps,dwmac-mdio";
++};
++
++&pwm {
++	status = "okay";
++};
++
++&pwm5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm5_pin>;
++	clk_bypass_output = <0x1>;
++	status = "okay";
+ };
+ 
+ &mmc0 {
+ 	vmmc-supply = <&reg_dldo1>;
+ 	broken-cd;
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
@@ -62,7 +62,7 @@ index 6bc49f6c4..c8cf794a8 100644
  	status = "okay";
 +
 +	mdio-mux {
-+		compatible = "allwinner-sun8i-h3-mdio-mux";
++		compatible = "allwinner,sun8i-h3-mdio-mux";
 +		#address-cells = <1>;
 +		#size-cells = <0>;
 +		mdio-parent-bus = <&mdio1>;

--- a/patch/kernel/archive/sunxi-6.18/series.conf
+++ b/patch/kernel/archive/sunxi-6.18/series.conf
@@ -399,7 +399,7 @@
 	patches.backports/32-pinctrl-sunxi-a523-Remove_unneeded_IRQ_remuxing_flag.patch
 	patches.backports/33-arm64-dts-allwinner-a523-Add_missing_GPIO_interrupt.patch
 	patches.backports/34-fix-wifi-regulator-cubie-a5e.patch
-	
+
 
 ################################################################################
 #
@@ -564,5 +564,5 @@
 	patches.armbian/drv-usb-gadget-composite-rename-serial-manufacturer.patch
 	patches.armbian/drv-video-st7796s-fb-tft-driver.patch
 	patches.armbian/include-uapi-drm_fourcc-add-ARM-tiled-format-modifier.patch
-        patches.armbian/0996-sunxi-ng-ccu-common-atomic-lock-wait.patch
-        patches.armbian/0999-rtw88-sdio-fix-interrupt-storm.patch
+	patches.armbian/0996-sunxi-ng-ccu-common-atomic-lock-wait.patch
+	patches.armbian/0999-rtw88-sdio-fix-interrupt-storm.patch

--- a/patch/kernel/archive/sunxi-6.18/series.conf
+++ b/patch/kernel/archive/sunxi-6.18/series.conf
@@ -566,3 +566,4 @@
 	patches.armbian/include-uapi-drm_fourcc-add-ARM-tiled-format-modifier.patch
 	patches.armbian/0996-sunxi-ng-ccu-common-atomic-lock-wait.patch
 	patches.armbian/0999-rtw88-sdio-fix-interrupt-storm.patch
+	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
@@ -1,0 +1,113 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JohnTheCoolingFan <ivan8215145640@gmail.com>
+Date: Fri, 10 Jul 2026 05:01:33 +0000
+Subject: arm64: dts: allwinner: BigTreeTech CB1 emac1 ac300
+
+Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 58 +++++++++-
+ 1 file changed, 53 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
+index 6bc49f6c4..c8cf794a8 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
+@@ -110,10 +110,19 @@ ws2812: ws2812 {
+ 		rgb_cnt = <2>;
+ 		rgb_value = <0x000001 0x010000>;
+ 		status = "disabled";
+ 	};
+ 
++	ac300_pwm_clk: ac300-clk {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		/* 500ns period -> 2MHz */
++		pwms = <&pwm 5 500 0>;
++		clock-frequency = <2000000>;
++		status = "okay";
++	};
++
+ 	i2c_gpio: i2c-gpio {
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+ 		compatible = "i2c-gpio";
+ 		status = "disabled";
+@@ -147,31 +156,70 @@ mcp2515_clock: mcp2515_clock {
+ 
+ &cpu0 {
+ 	cpu-supply = <&reg_dcdc2>;
+ };
+ 
++&sid {
++	ephy_calibration: ephy-calibration@2c {
++		reg = <0x2c 0x2>;
++	};
++};
++
+ &gpu {
+ 	mali-supply = <&reg_dcdc1>;
+ 	status = "okay";
+ };
+ 
+ &emac1 {
++	compatible = "allwinner,sun50i-h616-internal-emac";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&rmii_pins>;
+ 	phy-mode = "rmii";
+-	phy-handle = <&rmii_phy>;
++	phy-handle = <&ac300_ephy>;
+ 	phy-supply = <&reg_dldo1>;
+ 	allwinner,rx-delay-ps = <3100>;
+ 	allwinner,tx-delay-ps = <700>;
+ 	status = "okay";
++
++	mdio-mux {
++		compatible = "allwinner-sun8i-h3-mdio-mux";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		mdio-parent-bus = <&mdio1>;
++
++		internal_mdio: mdio@1 {
++			compatible = "allwinner,sun8i-h3-mdio-internal";
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			ac300_ephy: ethernet-phy@0 {
++				compatible = "ethernet-phy-id0044.1400", "allwinner,sun50i-h618-ac300-ephy", "ethernet-phy-ieee802.3-c22";
++				reg = <0>;
++				clocks = <&ccu CLK_EMAC_25M>, <&ac300_pwm_clk>;
++				clock-names = "ephy", "pwm";
++				nvmem-cells = <&ephy_calibration>;
++				nvmem-cell-names = "calibration";
++				status = "okay";
++			};
++		};
++	};
+ };
+ 
+ &mdio1 {
+-	rmii_phy: ethernet-phy@1 {
+-		compatible = "ethernet-phy-ieee802.3-c22";
+-		reg = <1>;
+-	};
++	compatible = "snps,dwmac-mdio";
++};
++
++&pwm {
++	status = "okay";
++};
++
++&pwm5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm5_pin>;
++	clk_bypass_output = <0x1>;
++	status = "okay";
+ };
+ 
+ &mmc0 {
+ 	vmmc-supply = <&reg_dldo1>;
+ 	broken-cd;
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
@@ -62,7 +62,7 @@ index 6bc49f6c4..c8cf794a8 100644
  	status = "okay";
 +
 +	mdio-mux {
-+		compatible = "allwinner-sun8i-h3-mdio-mux";
++		compatible = "allwinner,sun8i-h3-mdio-mux";
 +		#address-cells = <1>;
 +		#size-cells = <0>;
 +		mdio-parent-bus = <&mdio1>;

--- a/patch/kernel/archive/sunxi-7.0/series.conf
+++ b/patch/kernel/archive/sunxi-7.0/series.conf
@@ -524,3 +524,4 @@
 	patches.armbian/0997-i2c-mv64xxx-pin-runtime-pm.patch
 	patches.armbian/0998-sunxi-mmc-pin-runtime-pm.patch
 	patches.armbian/0999-rtw88-sdio-fix-interrupt-storm.patch
+	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch


### PR DESCRIPTION
# Description

Issue is described in https://github.com/armbian/build/issues/10084 and reached a solution thanks to help from @deece  

# How Has This Been Tested?

- [x] Build and boot to test Ethernet connectivity on `current` (6.18) and `edge` (7.0)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AC300 Ethernet PHY support for the BigTreeTech CB1 on Allwinner H616 systems.
  * Enabled supporting clock generation and calibration data, with updated Ethernet/MDIO routing.
  * Included the hardware support in both the 6.18 and 7.0 kernel patch series.
* **Bug Fixes**
  * Improved Ethernet bring-up and PHY calibration for the CB1’s EMAC1 interface.
* **Chores**
  * Updated kernel patch series ordering/whitespace and appended the CB1 AC300 device-tree patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->