### PR TITLE
rootfs-image: move `pre_install_distribution_specific` inside `install_distribution_specific()`

### DIFF
--- a/lib/functions/main/rootfs-image.sh
+++ b/lib/functions/main/rootfs-image.sh
@@ -19,14 +19,8 @@ function build_rootfs_and_image() {
 	# stage: with a basic rootfs available, we mount the chroot and work on it
 	LOG_SECTION="mount_chroot_sdcard" do_with_logging mount_chroot "${SDCARD}"
 
-	call_extension_method "pre_install_distribution_specific" "config_pre_install_distribution_specific" <<- 'PRE_INSTALL_DISTRIBUTION_SPECIFIC'
-		*give config a chance to act before install_distribution_specific*
-		Called after `create_rootfs_cache` (_prepare basic rootfs: unpack cache or create from scratch_) but before `install_distribution_specific` (_install distribution and board specific applications_).
-	PRE_INSTALL_DISTRIBUTION_SPECIFIC
-
 	# stage: install kernel and u-boot packages
 	# install distribution and board specific applications
-
 	LOG_SECTION="install_distribution_specific_${RELEASE}" do_with_logging install_distribution_specific
 	LOG_SECTION="install_distribution_agnostic" do_with_logging install_distribution_agnostic # does apt update
 

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -10,6 +10,11 @@
 function install_distribution_specific() {
 	display_alert "Applying distribution specific tweaks for" "${RELEASE:-}" "info"
 
+	call_extension_method "pre_install_distribution_specific" "config_pre_install_distribution_specific" <<- 'PRE_INSTALL_DISTRIBUTION_SPECIFIC'
+		*give config a chance to act before install_distribution_specific*
+		Called after `create_rootfs_cache` (_prepare basic rootfs: unpack cache or create from scratch_) but before `install_distribution_specific` (_install distribution and board specific applications_).
+	PRE_INSTALL_DISTRIBUTION_SPECIFIC
+
 	# disable broken service, the problem is in default misconfiguration
 	disable_systemd_service_sdcard smartmontools.service smartd.service
 


### PR DESCRIPTION
- 🌵 so we can get proper logging (`install_distribution_specific()` is run via `do_with_logging`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the timing of distribution-specific pre-installation steps during system image creation.
  * Ensured these preparation steps run after root filesystem cache setup and before distribution and board-specific applications are installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->