### PR TITLE
arduino-uno-q: enable desktop hardware acceleration in Debian Trixie by pinning Mesa to trixie-backports

### DIFF
--- a/config/boards/arduino-uno-q.csc
+++ b/config/boards/arduino-uno-q.csc
@@ -42,7 +42,7 @@ function post_family_tweaks__arduino-uno-q() {
 
 # Pin src:mesa to trixie-backports for the Adreno 702 (qrb2210, chip 0xb2070002;
 # needs Mesa >= 25.2.0). trixie ships 25.0.7, backports has 26.x. Desktop only.
-function post_family_tweaks__arduino_uno_q_mesa_backports_pin() {
+function post_family_tweaks__arduino-uno-q_mesa_backports_pin() {
 	if [[ "${DISTRIBUTION}" != "Debian" || "${RELEASE}" != "trixie" || "${BUILD_DESKTOP}" != "yes" ]]; then
 		display_alert "Skipping Mesa backports pin" "${DISTRIBUTION} ${RELEASE} desktop=${BUILD_DESKTOP}" "info"
 		return 0

--- a/config/boards/arduino-uno-q.csc
+++ b/config/boards/arduino-uno-q.csc
@@ -40,6 +40,30 @@ function post_family_tweaks__arduino-uno-q() {
 	chroot_sdcard systemctl enable armbian-resize-filesystem-qcom.service
 }
 
+# Pin src:mesa to trixie-backports for the Adreno 702 (qrb2210, chip 0xb2070002;
+# needs Mesa >= 25.2.0). trixie ships 25.0.7, backports has 26.x. Desktop only.
+function post_family_tweaks__arduino_uno_q_mesa_backports_pin() {
+	if [[ "${DISTRIBUTION}" != "Debian" || "${RELEASE}" != "trixie" || "${BUILD_DESKTOP}" != "yes" ]]; then
+		display_alert "Skipping Mesa backports pin" "${DISTRIBUTION} ${RELEASE} desktop=${BUILD_DESKTOP}" "info"
+		return 0
+	fi
+
+	display_alert "Pinning Mesa to trixie-backports" "${BOARD}" "info"
+
+	install -d -m755 "${SDCARD}/etc/apt/preferences.d"
+	cat > "${SDCARD}/etc/apt/preferences.d/armbian-mesa-from-backports" <<-'EOF'
+		Package: src:mesa
+		Pin: release n=trixie-backports
+		Pin-Priority: 990
+	EOF
+
+	do_with_retries 3 chroot_sdcard_apt_get_update
+
+	# full-upgrade: lets apt drop mesa-va-drivers/mesa-vdpau-drivers
+	# (their drivers are now provided directly by mesa-libgallium).
+	do_with_retries 3 chroot_sdcard_apt_get full-upgrade
+}
+
 function post_family_tweaks_bsp__arduino-uno-q_usb_gadget() {
 	# BSP is built once and cached across distros, so install files unconditionally.
 	# The usbgadget-rndis service is enabled in post_family_tweaks__ only when adbd is unavailable.


### PR DESCRIPTION
# Description

Enables desktop hardware acceleration on the Arduino Uno Q in Debian Trixie by pinning Mesa to trixie-backports.

Debian Trixie ships Mesa 25.0.7, which predates support for the Adreno 702 (qrb2210, chip `0xb2070002`). Mesa 25.2.0 is the first version with Adreno 702 support, and trixie-backports has 26.1.2.

This PR adds a `post_family_tweaks` hook to the Arduino Uno Q board config that pins `src:mesa` to `trixie-backports`, so the shipped desktop image gets Mesa 26.1.2 instead of trixie's 25.0.7.

`apt full-upgrade` (not plain `upgrade`) is required so the APT solver is able to uninstall `mesa-va-drivers` and `mesa-vdpau-drivers`, which are now provided directly by the `mesa-libgallium` package.

This hook will only apply on Debian Trixie with `BUILD_DESKTOP=yes`, so CLI images, other distros, and other boards sharing the rootfs cache are not affected.

# How Has This Been Tested?

I first build this image from the `main` branch:

```
./compile.sh build BOARD=arduino-uno-q BRANCH=edge BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_ENVIRONMENT=gnome DESKTOP_TIER=minimal KERNEL_CONFIGURE=no RELEASE=trixie
```

The resulting desktop image does work, but only with Software Rendering.

I then build the same image from the `feat/arduino-uno-q-mesa-backports` branch.
The resulting desktop image is hardware accellerated.

# Checklist:

_Please delete options that are not relevant._

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop graphics support on Arduino Uno Q systems running Debian Trixie by sourcing Mesa from the correct backports repository to ensure compatibility.
  * During image creation, the graphics stack is updated so the resulting build includes the appropriate Mesa packages for improved performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->