### PR TITLE
nanopi-m6: fix nvme prevents sd card from booting

### DIFF
--- a/config/boards/nanopi-m6.conf
+++ b/config/boards/nanopi-m6.conf
@@ -80,8 +80,16 @@ function post_family_config__nanopi_m6_use_mainline_uboot() {
 }
 
 function pre_config_uboot_target__nanopi_m6_patch_rockchip_common_boot_order() {
-	declare -a rockchip_uboot_targets=("mmc0" "nvme" "mmc1" "scsi" "usb" "pxe" "dhcp" "spi") # for future make-this-generic delight
-	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: adjust boot order to '${rockchip_uboot_targets[*]}'" "info"
-	sed -i -e "s/#define BOOT_TARGETS.*/#define BOOT_TARGETS \"${rockchip_uboot_targets[*]}\"/" include/configs/rockchip-common.h
-	regular_git diff -u include/configs/rockchip-common.h || true
+    declare -a rockchip_uboot_targets=("mmc1" "nvme" "mmc0" "scsi" "usb" "pxe" "dhcp" "spi")
+	local efi_mgr_file="boot/bootmeth_efi_mgr.c"
+
+    display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: adjust boot targets and bootmeths" "info"
+    sed -i -e "s/#define BOOT_TARGETS.*/#define BOOT_TARGETS \"${rockchip_uboot_targets[*]}\"/" include/configs/rockchip-common.h
+
+    if [[ -f "${efi_mgr_file}" ]]; then
+        sed -i 's/plat->flags = BOOTMETHF_GLOBAL;/plat->flags = 0;/g' "${efi_mgr_file}"
+        display_alert "u-boot" "Patched ${efi_mgr_file} successfully" "info"
+    else
+        display_alert "u-boot" "File ${efi_mgr_file} not found!" "warning"
+    fi
 }


### PR DESCRIPTION
# Description

When uboot is looking for efi-mgr bootmeth and finds a bootable OS in NVME, it just skips SD Card because efi and efimgr is always GLOBE according to the bootmeth ordering. This PR fixes it by removing GLOBE flag from the uboot source code.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?
- [x] Tested several boot cases

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated boot target ordering for the NanoPi M6 to improve boot selection behavior.
  * Adjusted EFI boot method handling for improved compatibility during startup.
  * Added clearer status and warning messages when boot configuration updates succeed or cannot be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->