### PR TITLE
fix hdmi rx on orangepi5 ultra by adding hpd-gpios

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/orangepi5-ultra-hdmirx-dts-fix.patch
+++ b/patch/kernel/archive/rockchip64-6.18/orangepi5-ultra-hdmirx-dts-fix.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: pdapandapda <linyuqiang55@gmail.com>
 Date: Sun, 12 Jul 2026 06:09:45 +0000
-Subject: Patching kernel rockchip64 files
+Subject: arm64: dts: rk3588-orangepi-5-ultra: Enable HDMI RX with HPD detection
  arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
 
 Signed-off-by: pdapandapda <linyuqiang55@gmail.com>

--- a/patch/kernel/archive/rockchip64-6.18/orangepi5-ultra-hdmirx-dts-fix.patch
+++ b/patch/kernel/archive/rockchip64-6.18/orangepi5-ultra-hdmirx-dts-fix.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pdapandapda <linyuqiang55@gmail.com>
+Date: Sun, 12 Jul 2026 06:09:45 +0000
+Subject: Patching kernel rockchip64 files
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
+
+Signed-off-by: pdapandapda <linyuqiang55@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts | 13 ++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
+index 2b693dfb434c..753abb4a0e75 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
+@@ -50,10 +50,17 @@ &hdmi1_sound {
+ 
+ &hdptxphy1 {
+ 	status = "okay";
+ };
+ 
++&hdmi_receiver {
++	pinctrl-0 = <&hdmim2_rx_cec &hdmim2_rx_hpdin &hdmim2_rx_scl &hdmim2_rx_sda &hdmirx_hpd>;
++	pinctrl-names = "default";
++	hpd-gpios = <&gpio3 RK_PD3 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
+ &i2s6_8ch {
+ 	status = "okay";
+ };
+ 
+ &led_blue_pwm {
+@@ -69,10 +76,16 @@ hdmi {
+ 		hdmi1_tx_on_h: hdmi1-tx-on-h {
+ 			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
++	hdmirx {
++		hdmirx_hpd: hdmirx-5v-detection {
++			rockchip,pins = <3 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	usb {
+ 		usb_otg_pwren: usb-otg-pwren {
+ 			rockchip,pins = <4 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-7.1/orangepi5-ultra-hdmirx-dts-fix.patch
+++ b/patch/kernel/archive/rockchip64-7.1/orangepi5-ultra-hdmirx-dts-fix.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: pdapandapda <linyuqiang55@gmail.com>
 Date: Sun, 12 Jul 2026 06:09:45 +0000
-Subject: Patching kernel rockchip64 files
+Subject: arm64: dts: rk3588-orangepi-5-ultra: Enable HDMI RX with HPD detection
  arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
 
 Signed-off-by: pdapandapda <linyuqiang55@gmail.com>

--- a/patch/kernel/archive/rockchip64-7.1/orangepi5-ultra-hdmirx-dts-fix.patch
+++ b/patch/kernel/archive/rockchip64-7.1/orangepi5-ultra-hdmirx-dts-fix.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pdapandapda <linyuqiang55@gmail.com>
+Date: Sun, 12 Jul 2026 06:09:45 +0000
+Subject: Patching kernel rockchip64 files
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
+
+Signed-off-by: pdapandapda <linyuqiang55@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts | 13 ++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
+index 2b693dfb434c..753abb4a0e75 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
+@@ -50,10 +50,17 @@ &hdmi1_sound {
+ 
+ &hdptxphy1 {
+ 	status = "okay";
+ };
+ 
++&hdmi_receiver {
++	pinctrl-0 = <&hdmim2_rx_cec &hdmim2_rx_hpdin &hdmim2_rx_scl &hdmim2_rx_sda &hdmirx_hpd>;
++	pinctrl-names = "default";
++	hpd-gpios = <&gpio3 RK_PD3 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
+ &i2s6_8ch {
+ 	status = "okay";
+ };
+ 
+ &led_blue_pwm {
+@@ -69,10 +76,16 @@ hdmi {
+ 		hdmi1_tx_on_h: hdmi1-tx-on-h {
+ 			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
++	hdmirx {
++		hdmirx_hpd: hdmirx-5v-detection {
++			rockchip,pins = <3 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	usb {
+ 		usb_otg_pwren: usb-otg-pwren {
+ 			rockchip,pins = <4 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-7.2/orangepi5-ultra-hdmirx-dts-fix.patch
+++ b/patch/kernel/archive/rockchip64-7.2/orangepi5-ultra-hdmirx-dts-fix.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: pdapandapda <linyuqiang55@gmail.com>
 Date: Sun, 12 Jul 2026 06:09:45 +0000
-Subject: Patching kernel rockchip64 files
+Subject: arm64: dts: rk3588-orangepi-5-ultra: Enable HDMI RX with HPD detection
  arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
 
 Signed-off-by: pdapandapda <linyuqiang55@gmail.com>

--- a/patch/kernel/archive/rockchip64-7.2/orangepi5-ultra-hdmirx-dts-fix.patch
+++ b/patch/kernel/archive/rockchip64-7.2/orangepi5-ultra-hdmirx-dts-fix.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pdapandapda <linyuqiang55@gmail.com>
+Date: Sun, 12 Jul 2026 06:09:45 +0000
+Subject: Patching kernel rockchip64 files
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
+
+Signed-off-by: pdapandapda <linyuqiang55@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts | 13 ++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
+index 2b693dfb434c..753abb4a0e75 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
+@@ -50,10 +50,17 @@ &hdmi1_sound {
+ 
+ &hdptxphy1 {
+ 	status = "okay";
+ };
+ 
++&hdmi_receiver {
++	pinctrl-0 = <&hdmim2_rx_cec &hdmim2_rx_hpdin &hdmim2_rx_scl &hdmim2_rx_sda &hdmirx_hpd>;
++	pinctrl-names = "default";
++	hpd-gpios = <&gpio3 RK_PD3 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
+ &i2s6_8ch {
+ 	status = "okay";
+ };
+ 
+ &led_blue_pwm {
+@@ -69,10 +76,16 @@ hdmi {
+ 		hdmi1_tx_on_h: hdmi1-tx-on-h {
+ 			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
++	hdmirx {
++		hdmirx_hpd: hdmirx-5v-detection {
++			rockchip,pins = <3 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	usb {
+ 		usb_otg_pwren: usb-otg-pwren {
+ 			rockchip,pins = <4 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

The default  rk3588-orangepi-5-ultra.dts from mainline lacks of  definition on hpd-gpios,which made hdmirx fail to
initialize.
This patch defined hpd-gpios,add the  hdmirx-5v-detection node for orangepi5 ultra.
The structure is on par with what is  in  rk3588-rock-5b-plus.dts ,but using hdmirxm2 nodes,which is documented in the Schematic  of  orangepi5 ultra  SBC boad  link:https://drive.google.com/drive/folders/1fftZIgPlZFxuFWhwwb8Ma00PaSx2ugER
<img width="3060" height="1089" alt="屏幕截图_20260713_044238" src="https://github.com/user-attachments/assets/9572605d-c42d-4989-8ac2-48c09043763d" />
<img width="3508" height="2480" alt="OPI 5 ULTRA V1_0_SCH_10" src="https://github.com/user-attachments/assets/8f486c78-291e-4181-bc71-451394020025" />

The HDMI_RX_DET_L uses GPIO3 D3 


# Documentation summary for feature / change

- [x] short description (copy / paste of PR title)
Fix Orangepi5 ulra hdmirx by adding hpd-gios in dts

- [x] summary (description relevant for end users)
To check the hdmirx function, end user should enable the rockchip-rk3588-hdmirx.dtbo in armbian-config  .

- [x] example of usage (how to see this in function)
check  v4l2-ctl --list-devices ,and  ffplay -f v4l2 -pixel_format nv12 -video_size 640x480 -i /dev/your-snps_hdmirx-node
# How Has This Been Tested?
- [x] Try  ffplay -f v4l2 -pixel_format nv12 -video_size 640x480 -i /dev/video2  
```
pda@orangepi5-ultra:~$ v4l2-ctl --list-devices
rockchip,rk3328-vpu-dec (platform:fdb50000.video-codec):
        /dev/video3
        /dev/media0

rockchip,rk3588-vepu121-enc (platform:fdba0000.video-codec):
        /dev/video4
        /dev/media1

rockchip,rk3588-av1-vpu-dec (platform:fdc70000.video-codec):
        /dev/video5
        /dev/media2

snps_hdmirx (platform:fdee0000.hdmi_receiver):
        /dev/video2

rga2 (platform:rga):
        /dev/video0
        /dev/video1

rkvdec (platform:rkvdec):
        /dev/video6
        /dev/media3
pda@orangepi5-ultra:~$ v4l2-ctl -d /dev/video2 --get-dv-timings
DV timings:
        Active width: 640
        Active height: 480
        Total width: 800
        Total height: 525
        Frame format: progressive
        Polarities: -vsync -hsync
        Pixelclock: 25175000 Hz (59.94 frames per second)
        Horizontal frontporch: 16
        Horizontal sync: 96
        Horizontal backporch: 48
        Vertical frontporch: 10
        Vertical sync: 2
        Vertical backporch: 33
        Standards: CTA-861, DMT
        CTA-861 VIC: 1
        Flags: has CTA-861 VIC
pda@orangepi5-ultra:~$ gst-launch-1.0 v4l2src device=/dev/video2 io-mode=2 ! video/x-raw,width=640,height=480,format=NV12 ! kmssink
Setting pipeline to PAUSED ...
Pipeline is live and does not need PREROLL ...
Pipeline is PREROLLED ...
Setting pipeline to PLAYING ...
New clock: GstSystemClock
ERROR: from element /GstPipeline:pipeline0/GstV4l2Src:v4l2src0: Internal data stream error.
Additional debug info:
../libs/gst/base/gstbasesrc.c(3187): gst_base_src_loop (): /GstPipeline:pipeline0/GstV4l2Src:v4l2src0:
streaming stopped, reason not-negotiated (-4)
Details:
details, flow-return=(int)-4;
Execution ended after 0:00:00.008210021
Setting pipeline to NULL ...
Freeing pipeline ...
pda@orangepi5-ultra:~$ # 强制使用 NV12 格式读取，这通常是 RK3588 的默认格式
ffplay -f v4l2 -pixel_format nv12 -video_size 640x480 -i /dev/video2
mpp[3863]: mpp_platform: client 1 driver is not ready!
mpp[3863]: mpp_platform: client 3 driver is not ready!
mpp[3863]: mpp_platform: client 4 driver is not ready!
mpp[3863]: mpp_platform: client 9 driver is not ready!
mpp[3863]: mpp_platform: client 12 driver is not ready!
mpp[3863]: mpp_platform: client 13 driver is not ready!
mpp[3863]: mpp_platform: client 18 driver is not ready!
mpp[3863]: mpp_platform: client 19 driver is not ready!
ffplay version f66f2f8046 Copyright (c) 2003-2026 the FFmpeg developers
  built with gcc 13 (Ubuntu 13.4.0-10ubuntu1)
  configuration: --prefix=/usr/local --enable-gpl --enable-version3 --enable-nonfree --enable-static --enable-shared --enable-libdrm --enable-rkmpp --enable-rkrga --enable-v4l2-m2m --enable-libx264 --enable-libaom --enable-libass --enable-libfdk-aac --enable-libfreetype --enable-libmp3lame --enable-libopus --enable-libsvtav1 --enable-libdav1d --enable-libvorbis --enable-libvpx --enable-libx265 --extra-cflags='-march=armv8.2-a+crypto+fp16+rcpc+dotprod' --extra-libs='-lpthread -lm -lz -ldl'
  libavutil      60. 26.100 / 60. 26.100
  libavcodec     62. 28.100 / 62. 28.100
  libavformat    62. 12.100 / 62. 12.100
  libavdevice    62.  3.100 / 62.  3.100
  libavfilter    11. 14.100 / 11. 14.100
  libswscale      9.  5.100 /  9.  5.100
  libswresample   6.  3.100 /  6.  3.100
[video4linux2,v4l2 @ 0xffff64000930] The V4L2 driver changed the video from 640x480 to 1920x1080
Input #0, video4linux2,v4l2, from '/dev/video2':
  Duration: N/A, start: 277.263996, bitrate: 1491499 kb/s
  Stream #0:0: Video: rawvideo (NV12 / 0x3231564E), nv12, 1920x1080, 1491499 kb/s, 59.94 fps, 59.94 tbr, 1000k tbn, start 277.263996
Aborted                    (core dumped) ffplay -f v4l2 -pixel_format nv12 -video_size 640x480 -i /dev/video2
pda@orangepi5-ultra:~$ 

```




# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enabled HDMI receiver support on the Orange Pi 5 Ultra.
  * Configured HDMI input detection, hot-plug (HPD) detection, and related signal pin multiplexing (including CEC/SCL/SDA/HPDIN).
  * Improved HDMI source compatibility by setting HPD to active-low GPIO handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->