### PR TITLE
kernel: enable F2FS on all kernels (central config hook)

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -447,18 +447,22 @@ function armbian_kernel_config__enable_netfilter_xtables_legacy() {
 # Filesystems enabled:
 #   BTRFS_FS          - Btrfs filesystem with copy-on-write and snapshots
 #   EXT4_FS           - Extended filesystem 4 (standard Linux filesystem)
+#   F2FS_FS           - Flash-Friendly File System (armbian-install root option)
 #   EROFS_FS          - Enhanced Read-Only File System (useful for Docker images)
 #
 # Options enabled:
 #   BTRFS_FS_POSIX_ACL - POSIX Access Control Lists for Btrfs
 #   EXT4_FS_POSIX_ACL  - POSIX Access Control Lists for ext4
 #   EXT4_FS_SECURITY   - Security extensions for ext4
+#   F2FS_FS_SECURITY   - Security extensions for f2fs
 function armbian_kernel_config__enable_various_filesystems() {
 	opts_m+=("BTRFS_FS")           # Enables Btrfs filesystem (copy-on-write, snapshots)
 	opts_y+=("BTRFS_FS_POSIX_ACL") # Enables POSIX ACL support for Btrfs
 	opts_y+=("EXT4_FS")            # Enables ext4 filesystem support
 	opts_y+=("EXT4_FS_POSIX_ACL")  # Enables POSIX ACL support for ext4
 	opts_y+=("EXT4_FS_SECURITY")   # Enables security extensions for ext4
+	opts_m+=("F2FS_FS")            # Flash-Friendly FS - module, like btrfs (armbian-install root option)
+	opts_y+=("F2FS_FS_SECURITY")   # Enables security extensions for f2fs
 	opts_m+=("EROFS_FS")           # Enhanced Read-Only FS (useful for Docker images)
 }
 

--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -454,6 +454,7 @@ function armbian_kernel_config__enable_netfilter_xtables_legacy() {
 #   BTRFS_FS_POSIX_ACL - POSIX Access Control Lists for Btrfs
 #   EXT4_FS_POSIX_ACL  - POSIX Access Control Lists for ext4
 #   EXT4_FS_SECURITY   - Security extensions for ext4
+#   F2FS_FS_XATTR      - Extended attributes for f2fs (required by F2FS_FS_SECURITY)
 #   F2FS_FS_SECURITY   - Security extensions for f2fs
 function armbian_kernel_config__enable_various_filesystems() {
 	opts_m+=("BTRFS_FS")           # Enables Btrfs filesystem (copy-on-write, snapshots)
@@ -462,6 +463,7 @@ function armbian_kernel_config__enable_various_filesystems() {
 	opts_y+=("EXT4_FS_POSIX_ACL")  # Enables POSIX ACL support for ext4
 	opts_y+=("EXT4_FS_SECURITY")   # Enables security extensions for ext4
 	opts_m+=("F2FS_FS")            # Flash-Friendly FS - module, like btrfs (armbian-install root option)
+	opts_y+=("F2FS_FS_XATTR")      # Extended attributes for f2fs (F2FS_FS_SECURITY depends on it)
 	opts_y+=("F2FS_FS_SECURITY")   # Enables security extensions for f2fs
 	opts_m+=("EROFS_FS")           # Enhanced Read-Only FS (useful for Docker images)
 }


### PR DESCRIPTION
## What

Add F2FS to `armbian_kernel_config__enable_various_filesystems()` in `lib/functions/compilation/armbian-kernel.sh` — the central hook that enforces the filesystem set on **every** kernel build (via `call_extension_method "armbian_kernel_config"`). One line, applies to all current and future kernels.

```
opts_m+=("F2FS_FS")            # module, like BTRFS_FS
opts_y+=("F2FS_FS_SECURITY")
```

## Why

`armbian-install` (redesign in armbian/configng#951) offers **f2fs** as a root filesystem. F2FS was missing from this hook, so it was left to each defconfig and ended up disabled or absent on several kernels — notably **`linux-uefi-x86-cloud`** and **`linux-uefi-arm64-cloud`**. `mkfs.f2fs` then succeeded while the root mount failed for lack of a driver. Found installing to f2fs on a KVM x86 guest.

## Why `=m` (not `=y`)

Mirrors Armbian's existing `BTRFS_FS=m` policy — enabled but not built-in, so no kernel-size bloat. As a module the driver is present and `mount` auto-loads it, which fixes the reported failure. Booting an f2fs (or btrfs) **root** under Armbian's `MODULES=list` initramfs is handled installer-side: the installer now regenerates the target initramfs with the root-fs module (companion change in configng), so this stays lean and consistent.

## Note

Supersedes the earlier per-config approach (editing 112 `.config` files) — the hook is the authoritative layer and covers future kernels too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added F2FS filesystem support to the kernel configuration.
  * Enabled F2FS-specific xattr and security options alongside existing filesystem ACL/security settings.
* **Documentation**
  * Updated the “Filesystems enabled” and “Options enabled” configuration sections to include the new F2FS requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->