### PR TITLE
fix the hdmirx HPD patch against kernel6.18 & kernel 7.1

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/orangepi5-ultra-hdmirx-dts-fix.patch
+++ b/patch/kernel/archive/rockchip64-6.18/orangepi5-ultra-hdmirx-dts-fix.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: pdapandapda <linyuqiang55@gmail.com>
-Date: Sun, 12 Jul 2026 06:09:45 +0000
+Date: Mon, 13 Jul 2026 21:47:55 +0000
 Subject: arm64: dts: rk3588-orangepi-5-ultra: Enable HDMI RX with HPD detection
  arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
 
@@ -10,10 +10,10 @@ Signed-off-by: pdapandapda <linyuqiang55@gmail.com>
  1 file changed, 13 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
-index 2b693dfb434c..753abb4a0e75 100644
+index f8c6c080e418..9b5ca029134b 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
-@@ -50,10 +50,17 @@ &hdmi1_sound {
+@@ -49,10 +49,17 @@ &hdmi1_sound {
  
  &hdptxphy1 {
  	status = "okay";
@@ -31,12 +31,12 @@ index 2b693dfb434c..753abb4a0e75 100644
  };
  
  &led_blue_pwm {
-@@ -69,10 +76,16 @@ hdmi {
- 		hdmi1_tx_on_h: hdmi1-tx-on-h {
- 			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
+@@ -62,10 +69,16 @@ &led_blue_pwm {
+ &led_green_pwm {
+ 	pwms = <&pwm5 0 25000 PWM_POLARITY_INVERTED>;
+ };
  
+ &pinctrl {
 +	hdmirx {
 +		hdmirx_hpd: hdmirx-5v-detection {
 +			rockchip,pins = <3 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;

--- a/patch/kernel/archive/rockchip64-7.1/orangepi5-ultra-hdmirx-dts-fix.patch
+++ b/patch/kernel/archive/rockchip64-7.1/orangepi5-ultra-hdmirx-dts-fix.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: pdapandapda <linyuqiang55@gmail.com>
-Date: Sun, 12 Jul 2026 06:09:45 +0000
+Date: Mon, 13 Jul 2026 21:47:55 +0000
 Subject: arm64: dts: rk3588-orangepi-5-ultra: Enable HDMI RX with HPD detection
  arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
 
@@ -10,10 +10,10 @@ Signed-off-by: pdapandapda <linyuqiang55@gmail.com>
  1 file changed, 13 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
-index 2b693dfb434c..753abb4a0e75 100644
+index f8c6c080e418..9b5ca029134b 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
-@@ -50,10 +50,17 @@ &hdmi1_sound {
+@@ -49,10 +49,17 @@ &hdmi1_sound {
  
  &hdptxphy1 {
  	status = "okay";
@@ -31,12 +31,12 @@ index 2b693dfb434c..753abb4a0e75 100644
  };
  
  &led_blue_pwm {
-@@ -69,10 +76,16 @@ hdmi {
- 		hdmi1_tx_on_h: hdmi1-tx-on-h {
- 			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
+@@ -62,10 +69,16 @@ &led_blue_pwm {
+ &led_green_pwm {
+ 	pwms = <&pwm5 0 25000 PWM_POLARITY_INVERTED>;
+ };
  
+ &pinctrl {
 +	hdmirx {
 +		hdmirx_hpd: hdmirx-5v-detection {
 +			rockchip,pins = <3 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;


### PR DESCRIPTION
# Description
Sorry for implemented a patch mismatch for rockchip64-6.18 and rockchip64-7.1  with commit  d14878c7e9f68106b2cde368f1cf576ab9f61e60  

[GitHub issue]https://github.com/armbian/build/issues/10179#issue-4878196381

Here is a quick fix against kernel 6.18 and kernel 7.1.

The issue was the patch try to search structure hdmi1_tx_on_h: hdmi1-tx-on-h  on throse versions but  do not exist except  for kernel 7.2.  The issue is addressed now.
# Documentation summary for feature / change


# How Has This Been Tested?



- [x ] Tried to compile with kernel current and  edge 


# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enabled HDMI input (HDMI RX) on the Orange Pi 5 Ultra.
  * Added HDMI hot-plug/HPD detection using a dedicated GPIO signal.

* **Bug Fixes**
  * Improved HDMI RX reliability by configuring the correct HPD signaling and HDMI-RX pin routing for HPD/5V detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->