### PR TITLE
mainline: bump `bleedingedge` to v7.2-rc3

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0          # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "7.2" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v7.2-rc2"
+		declare -g KERNELBRANCH="tag:v7.2-rc3"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }
@@ -26,11 +26,11 @@ function mainline_kernel_decide_version__upstream_release_candidate_number() {
 
 # Example: 6.7-rc7 was released by Linus, but kernel.org git and google git mirrors took a while to catch up; change the source to pull directly from Linus.
 # This was necessary for a few days in late December 2023, but no longer; tag was pushed on 28/Dec/2023.
-function mainline_kernel_decide_version__750_use_torvalds_for_7.2-rc2() {
-	if [[ "${KERNELBRANCH}" == 'tag:v7.2-rc2' ]]; then
-		display_alert "Using Linus kernel repo for 7.2-rc2" "${KERNELBRANCH}" "warn"
+function mainline_kernel_decide_version__750_use_torvalds_for_7.2-rc3() {
+	if [[ "${KERNELBRANCH}" == 'tag:v7.2-rc3' ]]; then
+		display_alert "Using Linus kernel repo for 7.2-rc3" "${KERNELBRANCH}" "warn"
 		declare -g KERNELSOURCE="https://github.com/torvalds/linux.git"
-		display_alert "mainline-kernel: missing torvalds tag on 7.2-rc2" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
+		display_alert "mainline-kernel: missing torvalds tag on 7.2-rc3" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
 	fi
 }
 

--- a/patch/kernel/archive/meson64-7.2/hwmon-emc2305-fixups-for-driver-submitted-to-mailing.patch
+++ b/patch/kernel/archive/meson64-7.2/hwmon-emc2305-fixups-for-driver-submitted-to-mailing.patch
@@ -1,7 +1,7 @@
-From 65e43cf694d2eba4d5219c3f432d6de7d94ef1e2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.com>
 Date: Thu, 5 May 2022 15:46:07 +0100
-Subject: [PATCH] hwmon: emc2305: fixups for driver submitted to mailing lists
+Subject: hwmon: emc2305: fixups for driver submitted to mailing lists
 
 The driver had a number of issues, checkpatch warnings/errors,
 and other limitations, so fix these up to make it usable.
@@ -33,11 +33,11 @@ As this is all downstream only, revert to u8 to match 5.15.
 
 Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
 ---
- drivers/hwmon/emc2305.c | 112 +++++++++++++++++++++++++++++++++++++---
+ drivers/hwmon/emc2305.c | 112 +++++++++-
  1 file changed, 106 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/hwmon/emc2305.c b/drivers/hwmon/emc2305.c
-index eef3b021671b..4aa9855aa0bd 100644
+index 111111111111..222222222222 100644
 --- a/drivers/hwmon/emc2305.c
 +++ b/drivers/hwmon/emc2305.c
 @@ -15,6 +15,8 @@
@@ -249,5 +249,5 @@ index eef3b021671b..4aa9855aa0bd 100644
  };
  
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.2/orangepi5-ultra-hdmirx-dts-fix.patch
+++ b/patch/kernel/archive/rockchip64-7.2/orangepi5-ultra-hdmirx-dts-fix.patch
@@ -1,8 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: pdapandapda <linyuqiang55@gmail.com>
 Date: Sun, 12 Jul 2026 06:09:45 +0000
-Subject: arm64: dts: rk3588-orangepi-5-ultra: Enable HDMI RX with HPD detection
- arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
+Subject: arm64: dts: rk3588-orangepi-5-ultra: Enable HDMI RX with HPD
+ detection arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
 
 Signed-off-by: pdapandapda <linyuqiang55@gmail.com>
 ---
@@ -10,12 +10,10 @@ Signed-off-by: pdapandapda <linyuqiang55@gmail.com>
  1 file changed, 13 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
-index 2b693dfb434c..753abb4a0e75 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
-@@ -50,10 +50,17 @@ &hdmi1_sound {
- 
- &hdptxphy1 {
+@@ -52,6 +52,13 @@ &hdptxphy1 {
  	status = "okay";
  };
  
@@ -29,11 +27,7 @@ index 2b693dfb434c..753abb4a0e75 100644
  &i2s6_8ch {
  	status = "okay";
  };
- 
- &led_blue_pwm {
-@@ -69,10 +76,16 @@ hdmi {
- 		hdmi1_tx_on_h: hdmi1-tx-on-h {
- 			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
+@@ -71,6 +78,12 @@ hdmi1_tx_on_h: hdmi1-tx-on-h {
  		};
  	};
  
@@ -46,8 +40,6 @@ index 2b693dfb434c..753abb4a0e75 100644
  	usb {
  		usb_otg_pwren: usb-otg-pwren {
  			rockchip,pins = <4 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.2/rk3399-usbc-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3399-usbc-Revert-usb-typec-tcpm-unregister-existing-source-cap.patch
@@ -13,7 +13,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3306,7 +3306,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3311,7 +3311,7 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  {
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
@@ -22,7 +22,7 @@ index 111111111111..222222222222 100644
  
  	if (!port->partner_pd)
  		port->partner_pd = usb_power_delivery_register(NULL, &desc);
-@@ -3316,11 +3316,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3321,11 +3321,6 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	memcpy(caps.pdo, port->source_caps, sizeof(u32) * port->nr_source_caps);
  	caps.role = TYPEC_SOURCE;
  

--- a/patch/kernel/archive/rockchip64-7.2/rk3399-usbc-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3399-usbc-usb-typec-tcpm-Fix-PD-devices-capabilities-registrat.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -3307,15 +3307,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
+@@ -3312,15 +3312,22 @@ static int tcpm_register_source_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -45,7 +45,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -3330,15 +3337,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
+@@ -3335,15 +3342,22 @@ static int tcpm_register_sink_caps(struct tcpm_port *port)
  	struct usb_power_delivery_desc desc = { port->negotiated_rev };
  	struct usb_power_delivery_capabilities_desc caps = { };
  	struct usb_power_delivery_capabilities *cap;
@@ -72,7 +72,7 @@ index 111111111111..222222222222 100644
  	cap = usb_power_delivery_register_capabilities(port->partner_pd, &caps);
  	if (IS_ERR(cap))
  		return PTR_ERR(cap);
-@@ -7743,10 +7757,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
+@@ -7748,10 +7762,17 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
  		port->pds[i] = usb_power_delivery_register(port->dev, &desc);
  		if (IS_ERR(port->pds[i])) {
  			ret = PTR_ERR(port->pds[i]);

--- a/patch/kernel/archive/rockchip64-7.2/rk3399-usbc-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3399-usbc-usb-typec-tcpm-Unregister-altmodes-before-registerin.patch
@@ -37,7 +37,7 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -2030,6 +2030,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
+@@ -2035,6 +2035,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
  		return;
  
  	for (i = 0; i < modep->altmodes; i++) {

--- a/patch/kernel/archive/uefi-x86-7.2/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-7.2/4001-asahi-trackpad.patch
@@ -22,7 +22,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2363,6 +2363,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2370,6 +2370,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_I2C:
  		bus = "I2C";
  		break;
@@ -136,7 +136,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2366,6 +2366,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2373,6 +2373,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_SPI:
  		bus = "SPI";
  		break;


### PR DESCRIPTION
# Description

- bump to rc3
- rewrite patches for meson64, rockchip64, both uefi-arm64 (no changes) and -x86

# How Has This Been Tested?

- [x] build meson64, rockchip64, uefi-arm64 and uefi-x86

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added HDMI receiver support with hot-plug detection for the Orange Pi 5 Ultra.
  - Added Apple Silicon trackpad and keyboard support over SPI and host-based transports.

- **Bug Fixes**
  - Improved USB-C Power Delivery capability and alternate-mode registration, preventing duplicate entries and enabling reliable retries.
  - Updated support to Linux 7.2 release candidate 3 for applicable systems.

- **Revert**
  - Restored previous USB-C source-capability registration behavior where required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->