### PR TITLE
k3: don't copy sysfw.itb on AM62 (BeaglePlay) — it doesn't exist

### DIFF
--- a/config/sources/families/include/k3_common.inc
+++ b/config/sources/families/include/k3_common.inc
@@ -80,7 +80,9 @@ function pre_config_uboot_target__build_first_stage() {
 
 	if [[ "${BOOT_SOC}" != "am62l" ]]; then
 		cp ${SRC}/cache/sources/u-boot-worktree/${BOOTDIR}/${BOOTBRANCH##*:}/build-r5/${TIBOOT3_FILE} tiboot3.bin
-		cp ${SRC}/cache/sources/u-boot-worktree/${BOOTDIR}/${BOOTBRANCH##*:}/build-r5/${SYSFW_FILE} sysfw.itb || true
+		# sysfw.itb only exists on older K3 (J721E: SYSFW_FILE set). On AM62 the
+		# system firmware is combined into tiboot3.bin, so there is nothing to copy.
+		[[ -n "${SYSFW_FILE}" ]] && cp ${SRC}/cache/sources/u-boot-worktree/${BOOTDIR}/${BOOTBRANCH##*:}/build-r5/${SYSFW_FILE} sysfw.itb
 	fi
 }
 
@@ -109,7 +111,10 @@ function format_partitions() {
 
 function write_uboot_platform() {
 	cp $1/tiboot3.bin ${MOUNT}/boot
-	cp $1/sysfw.itb ${MOUNT}/boot || true
+	# sysfw.itb is only present on older K3 (J721E); on AM62 it is folded into
+	# tiboot3.bin. Copy it only if it exists, so AM62 boards (e.g. BeaglePlay)
+	# do not log a misleading "cp: cannot stat sysfw.itb" during install.
+	[[ -f $1/sysfw.itb ]] && cp $1/sysfw.itb ${MOUNT}/boot
 	cp $1/tispl.bin ${MOUNT}/boot
 	cp $1/u-boot.img ${MOUNT}/boot
 }


### PR DESCRIPTION
## What

Guard the `sysfw.itb` copy in the k3 u-boot assembly so it only runs when the file actually exists.

## Why

`sysfw.itb` is only produced for older K3 SoCs that set **`SYSFW_FILE`** — J721E (`sk-tda4vm`, `beaglebone-ai64`). On **AM62** (BeaglePlay, etc.) the system firmware (TIFS) is **folded into `tiboot3.bin`** by binman, so there is no separate `sysfw.itb`, and its absence is correct.

But `write_uboot_platform` copied it **unconditionally**:
```sh
cp $1/sysfw.itb ${MOUNT}/boot || true
```
so every AM62 install logged a misleading error:
```
cp: cannot stat '/usr/lib/linux-u-boot-vendor-beagleplay/sysfw.itb': No such file or directory
```
Surfaced in an `armbian-install` **BeaglePlay** test report (armbian/build#10176), where it read like u-boot flashing had failed.

## Change

Guard both copies in `config/sources/families/include/k3_common.inc`:
- build-time first-stage copy → only when `SYSFW_FILE` is set,
- runtime `write_uboot_platform` → only when `$1/sysfw.itb` exists.

No behavior change for J721E boards (they still get `sysfw.itb`); AM62 boards just stop logging the spurious error.

Signed-off-by: Igor Pecovnik <igor@armbian.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved K3 bootloader preparation for platforms with system firmware bundled in `tiboot3.bin`.
  * Prevented unnecessary `sysfw.itb` creation and misleading missing-file messages during bootloader installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->