### PR TITLE
rootfs: pin tar for resolute kernel deb install (all families)

### DIFF
--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -376,7 +376,6 @@ function install_distribution_agnostic() {
 		# just one. Remove once upstream tar is fixed.
 		if [[ "${RELEASE}" == "resolute" ]]; then
 			display_alert "Pinning tar" "to 1.35+dfsg-4 for resolute kernel deb install" "info"
-			chroot_sdcard apt-get update
 			cat > "${SDCARD}/etc/apt/preferences.d/tar-pin" <<-'EOF'
 				Package: tar
 				Pin: version 1.35+dfsg-4*

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -404,7 +404,7 @@ function install_distribution_agnostic() {
 		if [[ "${RELEASE}" == "resolute" ]]; then
 			display_alert "Unpinning tar" "restoring resolute tar after kernel deb install" "info"
 			rm -f "${SDCARD}/etc/apt/preferences.d/tar-pin"
-			chroot_sdcard apt-get upgrade -y
+			chroot_sdcard apt-get install -y tar
 		fi
 	fi
 

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -370,6 +370,21 @@ function install_distribution_agnostic() {
 
 	# install kernel: image/dtb/headers
 	if [[ "${KERNELSOURCE}" != "none" ]]; then
+		# resolute ships a tar that hits an ENOSYS bug while dpkg unpacks the
+		# kernel debs in the build chroot; pin it to a known-good version for the
+		# install and restore it afterwards. Applies to ALL families/boards, not
+		# just one. Remove once upstream tar is fixed.
+		if [[ "${RELEASE}" == "resolute" ]]; then
+			display_alert "Pinning tar" "to 1.35+dfsg-4 for resolute kernel deb install" "info"
+			chroot_sdcard apt-get update
+			cat > "${SDCARD}/etc/apt/preferences.d/tar-pin" <<-'EOF'
+				Package: tar
+				Pin: version 1.35+dfsg-4*
+				Pin-Priority: 1001
+			EOF
+			chroot_sdcard apt-get -y --allow-downgrades install tar=1.35+dfsg-4
+		fi
+
 		install_artifact_deb_chroot "linux-image"
 
 		if [[ "${KERNEL_BUILD_DTBS:-"yes"}" == "yes" ]]; then
@@ -386,6 +401,12 @@ function install_distribution_agnostic() {
 		IMAGE_INSTALLED_KERNEL_VERSION=$(dpkg --info "${DEB_STORAGE}/${image_artifacts_debs_reversioned["linux-image"]}" | grep "^ Source:" | sed -e 's/ Source: linux-//')
 		display_alert "Parsed kernel version from local package" "${IMAGE_INSTALLED_KERNEL_VERSION}" "debug"
 
+		# Restore the distro's tar after the kernel debs are installed (see the pin above).
+		if [[ "${RELEASE}" == "resolute" ]]; then
+			display_alert "Unpinning tar" "restoring resolute tar after kernel deb install" "info"
+			rm -f "${SDCARD}/etc/apt/preferences.d/tar-pin"
+			chroot_sdcard apt-get upgrade -y
+		fi
 	fi
 
 	call_extension_method "post_install_kernel_debs" <<- 'POST_INSTALL_KERNEL_DEBS'

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -381,7 +381,7 @@ function install_distribution_agnostic() {
 				Pin: version 1.35+dfsg-4*
 				Pin-Priority: 1001
 			EOF
-			chroot_sdcard apt-get -y --allow-downgrades install tar
+			do_with_retries 3 chroot_sdcard_apt_get --allow-downgrades install tar
 		fi
 
 		install_artifact_deb_chroot "linux-image"
@@ -404,7 +404,7 @@ function install_distribution_agnostic() {
 		if [[ "${RELEASE}" == "resolute" ]]; then
 			display_alert "Unpinning tar" "restoring resolute tar after kernel deb install" "info"
 			rm -f "${SDCARD}/etc/apt/preferences.d/tar-pin"
-			chroot_sdcard apt-get install -y tar
+			do_with_retries 3 chroot_sdcard_apt_get install tar
 		fi
 	fi
 

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -381,7 +381,7 @@ function install_distribution_agnostic() {
 				Pin: version 1.35+dfsg-4*
 				Pin-Priority: 1001
 			EOF
-			chroot_sdcard apt-get -y --allow-downgrades install tar=1.35+dfsg-4
+			chroot_sdcard apt-get -y --allow-downgrades install tar
 		fi
 
 		install_artifact_deb_chroot "linux-image"


### PR DESCRIPTION
## What

Pin `tar` to `1.35+dfsg-4` while the Armbian kernel debs are installed in the build chroot, **for every family/board when `RELEASE=resolute`**. Restored right after. Placed in `install_kernel_debs()` (`lib/functions/rootfs/distro-agnostic.sh`), gated on `RELEASE == resolute`.

## Why

`resolute` ships a `tar` that hits an **ENOSYS bug** when `dpkg` unpacks the kernel debs in the build chroot, breaking the image build. The same workaround was added per-board (cix: `pre/post_install_kernel_debs__*_tar_resolute`), but the bug is **distro-wide**, so it belongs in the framework, not one family.

## Change

Around the `linux-image`/`linux-dtb`/`linux-headers` install:
- **pin**: write an apt preferences file (`Pin-Priority: 1001`) and `apt-get --allow-downgrades install tar=1.35+dfsg-4`
- **unpin**: remove the pin file and `apt-get upgrade -y`

No-op for every non-resolute release. Remove once upstream `tar` is fixed.

The cix-specific hooks (e.g. in armbian/build#10167) become redundant and can be dropped.

Signed-off-by: Igor Pecovnik <igor@armbian.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability for the Resolute release by adding a temporary workaround during kernel package installation.
  * The installer now pins a known-good `tar` version for the kernel step, then automatically removes the pin to restore standard package versions afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->