### PR TITLE
bsp: ship sysctl defaults and Provide linux-sysctl-defaults

### DIFF
--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -280,11 +280,16 @@ function reversion_armbian-bsp-cli_deb_contents() {
 	if [[ "${KEEP_ORIGINAL_OS_RELEASE:-"no"}" == "yes" ]]; then
 		depends_base_files=""
 	fi
+	# Provides/Conflicts/Replaces linux-sysctl-defaults: the BSP ships
+	# /usr/lib/sysctl.d/50-default.conf itself (armbian's copy of the distro
+	# defaults), so it satisfies that dependency without pulling the external
+	# package, and cleanly takes over its file if it was ever installed.
 	cat <<- EOF >> "${control_file_new}"
 		Depends: bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping, device-tree-compiler${depends_base_files}${EXTRA_BSPDEPS:+, ${EXTRA_BSPDEPS}}
-		Replaces: zram-config, armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
+		Replaces: zram-config, linux-sysctl-defaults, armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
 		Breaks: armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
-		Provides: armbian-bsp-cli
+		Conflicts: linux-sysctl-defaults
+		Provides: armbian-bsp-cli, linux-sysctl-defaults
 	EOF
 
 	artifact_deb_reversion_unpack_data_deb

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -393,7 +393,10 @@ function board_side_bsp_cli_preinst() {
 			echo vm.swappiness=100 >> /etc/sysctl.conf
 			;;
 	esac
-	sysctl -p > /dev/null 2>&1
+	# --system (not -p) so the change to /etc/sysctl.conf above *and* the
+	# drop-ins under /usr/lib/sysctl.d (our 50-default.conf) are applied on
+	# upgrade; -p reads only /etc/sysctl.conf and would leave them to next boot.
+	sysctl --system > /dev/null 2>&1
 	# replace canonical advertisement
 	if [[ -d "/var/lib/ubuntu-advantage/messages/" ]]; then
 		echo -e "\nSupport Armbian! \nLearn more at https://armbian.com/donate" > /var/lib/ubuntu-advantage/messages/apt-pre-invoke-esm-service-status

--- a/packages/bsp/common/usr/lib/sysctl.d/50-default.conf
+++ b/packages/bsp/common/usr/lib/sysctl.d/50-default.conf
@@ -1,0 +1,37 @@
+# Armbian board-support package: kernel/sysctl defaults.
+#
+# Ships the same defaults as the distro's linux-sysctl-defaults package (which
+# installs systemd's 50-default.conf), so the BSP can Provide it instead of
+# pulling an external package. Kept in the pre-glob syntax (explicit .all/.default,
+# no `-key` unset lines) so it parses on every systemd version Armbian ships
+# (jammy/bookworm through the latest). Override in /etc/sysctl.d/90-*.conf.
+
+# System Request (SysRq) key: SYNC only (systemd default; conservative)
+kernel.sysrq = 16
+
+# Append the PID to the core filename
+kernel.core_uses_pid = 1
+
+# Reverse-path filtering in loose mode (safe with asymmetric routing)
+net.ipv4.conf.default.rp_filter = 2
+net.ipv4.conf.all.rp_filter = 2
+
+# Do not accept source routing
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv4.conf.all.accept_source_route = 0
+
+# Promote secondary addresses when the primary is removed
+net.ipv4.conf.default.promote_secondaries = 1
+net.ipv4.conf.all.promote_secondaries = 1
+
+# Allow ping(8) without setuid / CAP_NET_RAW (the primary reason for this file)
+net.ipv4.ping_group_range = 0 2147483647
+
+# Fair Queue CoDel packet scheduler to fight bufferbloat
+net.core.default_qdisc = fq_codel
+
+# Hard/soft link and regular-file/FIFO protection
+fs.protected_hardlinks = 1
+fs.protected_symlinks = 1
+fs.protected_regular = 1
+fs.protected_fifos = 1

--- a/packages/bsp/common/usr/lib/sysctl.d/50-default.conf
+++ b/packages/bsp/common/usr/lib/sysctl.d/50-default.conf
@@ -2,19 +2,26 @@
 #
 # Ships the same defaults as the distro's linux-sysctl-defaults package (which
 # installs systemd's 50-default.conf), so the BSP can Provide it instead of
-# pulling an external package. Kept in the pre-glob syntax (explicit .all/.default,
-# no `-key` unset lines) so it parses on every systemd version Armbian ships
-# (jammy/bookworm through the latest). Override in /etc/sysctl.d/90-*.conf.
+# pulling an external package. Values are kept in step with that package
+# (Debian trixie / Ubuntu). Keys are written explicitly (no glob patterns,
+# which older systemd does not parse); keys that may be absent on old vendor
+# kernels use the "-" failure-tolerant prefix (a missing key is then ignored
+# instead of logged as an error on every boot). Override in
+# /etc/sysctl.d/90-*.conf.
 
-# System Request (SysRq) key: SYNC only (systemd default; conservative)
-kernel.sysrq = 16
+# System Request (SysRq) functions: the same bitmask linux-sysctl-defaults
+# ships (0x01b6 = 438), which keeps sync / remount-ro / reboot etc. available
+# for headless recovery (REISUB, process kill, stack traces over serial).
+kernel.sysrq = 438
 
 # Append the PID to the core filename
 kernel.core_uses_pid = 1
 
-# Reverse-path filtering in loose mode (safe with asymmetric routing)
+# Reverse-path filtering in loose mode (safe with asymmetric routing). Only
+# .default is set, like the distro package: effective rp_filter is
+# max(all, per-interface), so setting .all here would override per-interface
+# choices on every interface.
 net.ipv4.conf.default.rp_filter = 2
-net.ipv4.conf.all.rp_filter = 2
 
 # Do not accept source routing
 net.ipv4.conf.default.accept_source_route = 0
@@ -24,14 +31,21 @@ net.ipv4.conf.all.accept_source_route = 0
 net.ipv4.conf.default.promote_secondaries = 1
 net.ipv4.conf.all.promote_secondaries = 1
 
-# Allow ping(8) without setuid / CAP_NET_RAW (the primary reason for this file)
-net.ipv4.ping_group_range = 0 2147483647
+# Allow ping(8) without setuid / CAP_NET_RAW (the primary reason for this
+# file). "-" so it is skipped on old kernels without ping_group_range.
+-net.ipv4.ping_group_range = 0 2147483647
 
-# Fair Queue CoDel packet scheduler to fight bufferbloat
-net.core.default_qdisc = fq_codel
+# Fair Queue CoDel packet scheduler to fight bufferbloat. "-" so it is skipped
+# on kernels without sch_fq_codel available.
+-net.core.default_qdisc = fq_codel
 
-# Hard/soft link and regular-file/FIFO protection
+# Hard/soft link and regular-file/FIFO protection (protected_regular = 2 to
+# match linux-sysctl-defaults)
 fs.protected_hardlinks = 1
 fs.protected_symlinks = 1
-fs.protected_regular = 1
+fs.protected_regular = 2
 fs.protected_fifos = 1
+
+# Raise the per-process memory-map limit to the distro default; matches
+# linux-sysctl-defaults (needed by some JVMs, games and Electron apps).
+vm.max_map_count = 1048576


### PR DESCRIPTION
## What

Ship the sysctl defaults in the **board-support package** and have the BSP **Provide `linux-sysctl-defaults`**, instead of adding the external package to every image.

This implements @tabrisnet's suggestion on #9698:
> we might want our own package… if we make it per-board, at which point we just stick it in the board bsp. No additional pkg needed. we could then make that pkg `Provide: linux-sysctl-defaults`.

## Changes

- **`packages/bsp/common/usr/lib/sysctl.d/50-default.conf`** — Armbian's copy of `linux-sysctl-defaults`' content (systemd's `50-default.conf`). The primary win is `net.ipv4.ping_group_range = 0 2147483647` so `ping` works without setuid/`CAP_NET_RAW`; plus `fs.protected_*` and the usual net hardening.
  - Kept in **pre-glob syntax** (explicit `.all`/`.default`, no `-key` unset lines) so it parses on **every** systemd version Armbian ships (jammy 249 … latest) — the upstream `main`/v252 file uses glob + dash-exclude syntax that older systemd can't parse, and the BSP is shared across all releases.
  - `kernel.sysrq = 16` (systemd's conservative default — not the `438` from Ubuntu's variant that @tabrisnet flagged).
- **`armbian-bsp-cli-deb.sh`** — `Provides: … linux-sysctl-defaults`, plus `Conflicts`/`Replaces` so the dependency is satisfied without the external package and its file is taken over cleanly if ever installed.

## Notes for reviewers

- `net.core.default_qdisc = fq_codel` is included (upstream default). @tabrisnet noted it adds per-packet CPU cost on low-end/battery devices — easy to drop or make per-board if we'd rather; flagging it rather than deciding unilaterally.
- **Supersedes #9698** (which added `linux-sysctl-defaults` to the base package list).

Signed-off-by: Igor Pecovnik <igor@armbian.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standard BSP sysctl defaults to improve kernel, networking, and filesystem hardening.
  * Includes safer networking settings, core filename behavior, and sets `fq_codel` as the default packet scheduler.
  * Added guidance for overriding defaults via `/etc/sysctl.d/`.

* **Bug Fixes**
  * Improved sysctl application during upgrades by applying all drop-ins from both `/etc/sysctl.conf` and `/usr/lib/sysctl.d`.
  * Enhanced deb upgrade metadata so `armbian-bsp-cli` correctly replaces/conflicts/provides `linux-sysctl-defaults` during transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->