### PR TITLE
patching: actually delete empty patch files on rewrite (rebased + review fix)

### DIFF
--- a/lib/tools/patching.py
+++ b/lib/tools/patching.py
@@ -375,9 +375,11 @@ if apply_patches:
 			parent.rewrite_patch_file(patches)
 		FAILED_PATCHES = [one_patch for one_patch in VALID_PATCHES if (not one_patch.applied_ok) or (one_patch.rewritten_patch is None)]
 		for failed_patch in FAILED_PATCHES:
-			log.info(
-				f"Consider removing {failed_patch.parent.full_file_path()}(:{failed_patch.counter}); "
-				f"it was not applied successfully.")
+			log.warning(
+				f"Removing {failed_patch.parent.full_file_path()}(:{failed_patch.counter}); "
+				f" it failed to apply/was not rewritten.")
+			os.remove(failed_patch.parent.full_file_path())
+
 
 # Create markdown about the patches
 readme_markdown: "str | None" = None

--- a/lib/tools/patching.py
+++ b/lib/tools/patching.py
@@ -374,11 +374,19 @@ if apply_patches:
 			patches = patch_files_by_parent[parent]
 			parent.rewrite_patch_file(patches)
 		FAILED_PATCHES = [one_patch for one_patch in VALID_PATCHES if (not one_patch.applied_ok) or (one_patch.rewritten_patch is None)]
-		for failed_patch in FAILED_PATCHES:
-			log.warning(
-				f"Removing {failed_patch.parent.full_file_path()}(:{failed_patch.counter}); "
-				f" it failed to apply/was not rewritten.")
-			os.remove(failed_patch.parent.full_file_path())
+		# A single (mbox) patch file can hold multiple patches, so several entries
+		# in FAILED_PATCHES may share one parent file. Deduplicate the file paths
+		# before deleting, otherwise the second os.remove() of the same file raises
+		# FileNotFoundError and aborts patching. Guard removal against races too.
+		failed_patch_files = {failed_patch.parent.full_file_path() for failed_patch in FAILED_PATCHES}
+		for patch_file_path in sorted(failed_patch_files):
+			log.warning(f"Removing {patch_file_path}; it failed to apply/was not rewritten.")
+			try:
+				os.remove(patch_file_path)
+			except FileNotFoundError:
+				log.debug(f"Patch file already removed: {patch_file_path}")
+			except OSError as e:
+				log.error(f"Failed to remove patch file {patch_file_path}: {e}")
 
 
 # Create markdown about the patches


### PR DESCRIPTION
Rebased **#9209** (by @rpardini) onto current `main` and addressed the review.

## What

The patch Rewriter now **deletes** patch files that failed to apply / weren't rewritten, instead of just logging "consider removing" — so `patches-to-git` filtering is actually useful.

## Review fix (CodeRabbit's critical comment on #9209)

`FAILED_PATCHES` holds one entry **per patch**, but a single mbox patch file can contain **several** patches, so multiple entries share one parent file. The original loop `os.remove()`'d the same file once per patch — the second call raised `FileNotFoundError` and aborted patching. It also had no guard for other removal errors.

Fixed by:
- **Deduplicating** parent file paths (`set`) before deleting, iterated in sorted order for deterministic logs.
- Wrapping `os.remove` in `try/except` for `FileNotFoundError` (already gone → debug) and `OSError` (permissions/locked → error, non-fatal).

## Commits

1. `patching: Rewriter: actually delete empty patch files on rewrite` — @rpardini's original, rebased.
2. `patching: dedup and guard patch-file deletion on rewrite` — the review fix.

`python3 -m py_compile lib/tools/patching.py` passes. Supersedes #9209 (whose branch was ~1600 commits behind main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed patch files are now automatically removed during cleanup.
  * Cleanup handles duplicate files and missing files safely.
  * Other file-removal errors are reported for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->