### PR TITLE
cli-patch: generalize to-git push (PUSH_TO_GITHUB / PUSH_TO_REPO), for u-boot too

### DIFF
--- a/lib/functions/cli/cli-patch.sh
+++ b/lib/functions/cli/cli-patch.sh
@@ -47,18 +47,10 @@ function cli_patch_kernel_run() {
 	obtain_kernel_git_info_and_makefile # this populates GIT_INFO_KERNEL and sets KERNEL_GIT_SHA1 readonly global
 	# </prepare the git sha1>
 
-	declare ymd vendor_lc target_repo_url summary_url
-	ymd="$(date +%Y%m%d)"
-	# lowercase ${VENDOR} and replace spaces with underscores
-	vendor_lc="$(tr '[:upper:]' '[:lower:]' <<< "${VENDOR}" | tr ' ' '_')-next"
-	target_branch="${vendor_lc}-${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}-${ymd}${PUSH_BRANCH_POSTFIX:-""}"
-	target_repo_url="git@github.com:${PUSH_TO_REPO:-"${PUSH_TO_USER:-"rpardini"}/${PUSH_TO_REPO:-"linux"}"}.git"
-	summary_url="https://${PUSH_TO_USER:-"rpardini"}.github.io/${PUSH_TO_REPO:-"linux"}/${target_branch}.html"
-
-	declare -a push_command
-	push_command=(git -C "${SRC}/cache/git-bare/kernel" push "--force" "--verbose"
-		"${target_repo_url}"
-		"kernel-${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}:${target_branch}")
+	# prepare push details, if set
+	declare target_repo_url target_branch do_push="no"
+	declare -a push_command=()
+	determine_git_push_details "${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}" # fills in the above; parameter is the branch name
 
 	# Prepare the host and build kernel; without using standard build
 	prepare_host   # This handles its own logging sections, and is possibly interactive.
@@ -66,28 +58,16 @@ function cli_patch_kernel_run() {
 
 	display_alert "Done patching kernel" "${BRANCH} - ${LINUXFAMILY} - ${KERNEL_MAJOR_MINOR}" "cachehit"
 
-	declare do_push="no"
-	if git -C "${SRC}" remote get-url origin &> /dev/null; then
-		declare src_origin_url
-		src_origin_url="$(git -C "${SRC}" remote get-url origin | xargs echo -n)"
-
-		declare prefix="git@github.com:${PUSH_TO_USER:-"rpardini"}/" # @TODO refactor var
-		# if the src_origin_url begins with the prefix
-		if [[ "${src_origin_url}" == "${prefix}"* ]]; then
-			do_push="yes"
-		fi
-	fi
-
-	display_alert "Git push command: " "${push_command[*]}" "info"
 	if [[ "${do_push}" == "yes" ]]; then
-		display_alert "Pushing to ${target_branch}" "${target_repo_url}" "info"
+		display_alert "Pushing kernel to Git branch ${target_branch}" "${target_repo_url}" "info"
 		git_ensure_safe_directory "${SRC}/cache/git-bare/kernel"
-		# @TODO: do NOT allow shallow trees here, we need the full history to be able to push
-		GIT_SSH_COMMAND="ssh -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "${push_command[@]}"
-		display_alert "Done pushing to ${target_branch}" "${summary_url}" "info"
+		push_command=(git -C "${SRC}/cache/git-bare/kernel" push "--force" "--verbose" "${target_repo_url}" "kernel-${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}:${target_branch}")
+		display_alert "Git push command: " "${push_command[*]}" "info"
+		execute_git_push
 	fi
 
-	display_alert "Summary URL (after push & gh-pages deploy): " "${summary_url}" "info"
+	return 0
+
 }
 
 ## Similar stuff as kernel, but for u-boot.
@@ -108,6 +88,11 @@ function cli_patch_uboot_run() {
 	[[ "${GIT_INFO_UBOOT[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_UBOOT[SHA1]}'"
 	# </prepare the git sha1>
 
+	# prepare push details, if set
+	declare target_repo_url target_branch do_push="no"
+	declare -a push_command=()
+	determine_git_push_details "${BOARD}-${BRANCH}" # fills in the above; parameter is the branch name
+
 	# Prepare the host
 	prepare_host # This handles its own logging sections, and is possibly interactive.
 
@@ -123,4 +108,45 @@ function cli_patch_uboot_run() {
 	LOG_SECTION="patch_uboot_target" do_with_logging patch_uboot_target
 
 	display_alert "Done patching u-boot" "${BRANCH} - ${LINUXFAMILY} - ${BOOTSOURCE}#${BOOTBRANCH}" "cachehit"
+
+	if [[ "${do_push}" == "yes" ]]; then
+		display_alert "Pushing u-boot to Git branch ${target_branch}" "${target_repo_url}" "info"
+		git_ensure_safe_directory "${SRC}/cache/git-bare/u-boot"
+		push_command=(git -C "${SRC}/cache/git-bare/u-boot" push "--force" "--verbose" "${target_repo_url}" "u-boot-${BRANCH}-${BOARD}:${target_branch}")
+		display_alert "Git push command: " "${push_command[*]}" "info"
+		execute_git_push
+	fi
+
+}
+
+function determine_git_push_details() {
+	if [[ -n "${PUSH_TO_GITHUB}" ]]; then
+		PUSH_TO_REPO="git@github.com:${PUSH_TO_GITHUB}.git"
+		display_alert "Will push to GitHub" "${PUSH_TO_REPO}" "info"
+	fi
+
+	if [[ -n "${PUSH_TO_REPO}" ]]; then
+		do_push="yes"
+		declare ymd vendor_lc
+		ymd="$(date +%Y%m%d)"
+		vendor_lc="$(tr '[:upper:]' '[:lower:]' <<< "${VENDOR}" | tr ' ' '_')" # lowercase ${VENDOR} and replace spaces with underscores
+		target_branch="${vendor_lc}-${1}-${ymd}${PUSH_BRANCH_POSTFIX:-""}"
+		target_repo_url="${PUSH_TO_REPO}"
+		display_alert "Will push to Git" "${target_repo_url} branch ${target_branch}" "info"
+	else
+		display_alert "Will NOT push to Git" "use PUSH_TO_GITHUB=org/repo or PUSH_TO_REPO=<url> to push" "info"
+	fi
+}
+
+function execute_git_push() {
+	display_alert "Pushing to ${target_branch}" "${target_repo_url}" "info"
+	# @TODO: do NOT allow shallow trees here, we need the full history to be able to push
+	GIT_SSH_COMMAND="ssh -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "${push_command[@]}"
+	display_alert "Done pushing to ${target_branch}" "${target_repo_url}" "info"
+
+	# If GitHub, link there to both the branch main view and History view
+	if [[ -n "${PUSH_TO_GITHUB}" ]]; then
+		display_alert "GitHub tree URL" "https://github.com/${PUSH_TO_GITHUB}/tree/${target_branch}" "info"
+		display_alert "GitHub commits URL" "https://github.com/${PUSH_TO_GITHUB}/commits/${target_branch}" "info"
+	fi
 }

--- a/lib/functions/cli/cli-patch.sh
+++ b/lib/functions/cli/cli-patch.sh
@@ -48,7 +48,7 @@ function cli_patch_kernel_run() {
 	# </prepare the git sha1>
 
 	# prepare push details, if set
-	declare target_repo_url target_branch do_push="no"
+	declare target_repo_url target_branch do_push="no" used_github_shorthand="no"
 	declare -a push_command=()
 	determine_git_push_details "next-${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}" # fills in the above; parameter is the branch name
 
@@ -89,7 +89,7 @@ function cli_patch_uboot_run() {
 	# </prepare the git sha1>
 
 	# prepare push details, if set
-	declare target_repo_url target_branch do_push="no"
+	declare target_repo_url target_branch do_push="no" used_github_shorthand="no"
 	declare -a push_command=()
 	determine_git_push_details "${BOARD}-${BRANCH}" # fills in the above; parameter is the branch name
 
@@ -134,6 +134,7 @@ function determine_git_push_details() {
 	# explicit PUSH_TO_REPO (e.g. a CI HTTPS/token URL) - only synthesize when empty.
 	if [[ -n "${PUSH_TO_GITHUB}" && -z "${PUSH_TO_REPO}" ]]; then
 		PUSH_TO_REPO="git@github.com:${PUSH_TO_GITHUB}.git"
+		used_github_shorthand="yes" # the push target IS github.com/${PUSH_TO_GITHUB}
 		display_alert "Will push to GitHub" "${PUSH_TO_GITHUB}" "info"
 	fi
 
@@ -159,8 +160,10 @@ function execute_git_push() {
 	GIT_SSH_COMMAND="ssh -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "${push_command[@]}"
 	display_alert "Done pushing to ${target_branch}" "$(git_redact_credentials "${target_repo_url}")" "info"
 
-	# If GitHub, link there to both the branch main view and History view
-	if [[ -n "${PUSH_TO_GITHUB}" ]]; then
+	# If we synthesized the target from the PUSH_TO_GITHUB shorthand, link there to both
+	# the branch main view and History view. Skipped when an explicit PUSH_TO_REPO took
+	# precedence, since then the push went elsewhere and these URLs would be misleading.
+	if [[ "${used_github_shorthand:-no}" == "yes" ]]; then
 		display_alert "GitHub tree URL" "https://github.com/${PUSH_TO_GITHUB}/tree/${target_branch}" "info"
 		display_alert "GitHub commits URL" "https://github.com/${PUSH_TO_GITHUB}/commits/${target_branch}" "info"
 	fi

--- a/lib/functions/cli/cli-patch.sh
+++ b/lib/functions/cli/cli-patch.sh
@@ -50,7 +50,7 @@ function cli_patch_kernel_run() {
 	# prepare push details, if set
 	declare target_repo_url target_branch do_push="no"
 	declare -a push_command=()
-	determine_git_push_details "${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}" # fills in the above; parameter is the branch name
+	determine_git_push_details "next-${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}" # fills in the above; parameter is the branch name
 
 	# Prepare the host and build kernel; without using standard build
 	prepare_host   # This handles its own logging sections, and is possibly interactive.
@@ -59,10 +59,10 @@ function cli_patch_kernel_run() {
 	display_alert "Done patching kernel" "${BRANCH} - ${LINUXFAMILY} - ${KERNEL_MAJOR_MINOR}" "cachehit"
 
 	if [[ "${do_push}" == "yes" ]]; then
-		display_alert "Pushing kernel to Git branch ${target_branch}" "${target_repo_url}" "info"
+		display_alert "Pushing kernel to Git branch ${target_branch}" "$(git_redact_credentials "${target_repo_url}")" "info"
 		git_ensure_safe_directory "${SRC}/cache/git-bare/kernel"
 		push_command=(git -C "${SRC}/cache/git-bare/kernel" push "--force" "--verbose" "${target_repo_url}" "kernel-${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}:${target_branch}")
-		display_alert "Git push command: " "${push_command[*]}" "info"
+		display_alert "Git push command: " "$(git_redact_credentials "${push_command[*]}")" "info"
 		execute_git_push
 	fi
 
@@ -110,19 +110,31 @@ function cli_patch_uboot_run() {
 	display_alert "Done patching u-boot" "${BRANCH} - ${LINUXFAMILY} - ${BOOTSOURCE}#${BOOTBRANCH}" "cachehit"
 
 	if [[ "${do_push}" == "yes" ]]; then
-		display_alert "Pushing u-boot to Git branch ${target_branch}" "${target_repo_url}" "info"
+		display_alert "Pushing u-boot to Git branch ${target_branch}" "$(git_redact_credentials "${target_repo_url}")" "info"
 		git_ensure_safe_directory "${SRC}/cache/git-bare/u-boot"
 		push_command=(git -C "${SRC}/cache/git-bare/u-boot" push "--force" "--verbose" "${target_repo_url}" "u-boot-${BRANCH}-${BOARD}:${target_branch}")
-		display_alert "Git push command: " "${push_command[*]}" "info"
+		display_alert "Git push command: " "$(git_redact_credentials "${push_command[*]}")" "info"
 		execute_git_push
 	fi
 
 }
 
+# Redact user:pass@ / token@ credentials from a git URL (or a command string
+# containing one) before logging. Only matches scheme://...@ forms, so the SSH
+# "git@github.com:" user is left untouched.
+function git_redact_credentials() {
+	sed -E 's|(://)[^/@[:space:]]*@|\1***@|g' <<< "${1}"
+}
+
+# Determine the git push target from PUSH_TO_GITHUB / PUSH_TO_REPO.
+#   $1: middle of the branch name (kernel: "next-<family>-<ver>"; u-boot: "<board>-<branch>")
+# Sets parent-scope vars: do_push, target_branch, target_repo_url. Uses VENDOR.
 function determine_git_push_details() {
-	if [[ -n "${PUSH_TO_GITHUB}" ]]; then
+	# PUSH_TO_GITHUB=org/repo is shorthand for the SSH URL, but must NOT clobber an
+	# explicit PUSH_TO_REPO (e.g. a CI HTTPS/token URL) - only synthesize when empty.
+	if [[ -n "${PUSH_TO_GITHUB}" && -z "${PUSH_TO_REPO}" ]]; then
 		PUSH_TO_REPO="git@github.com:${PUSH_TO_GITHUB}.git"
-		display_alert "Will push to GitHub" "${PUSH_TO_REPO}" "info"
+		display_alert "Will push to GitHub" "${PUSH_TO_GITHUB}" "info"
 	fi
 
 	if [[ -n "${PUSH_TO_REPO}" ]]; then
@@ -132,17 +144,20 @@ function determine_git_push_details() {
 		vendor_lc="$(tr '[:upper:]' '[:lower:]' <<< "${VENDOR}" | tr ' ' '_')" # lowercase ${VENDOR} and replace spaces with underscores
 		target_branch="${vendor_lc}-${1}-${ymd}${PUSH_BRANCH_POSTFIX:-""}"
 		target_repo_url="${PUSH_TO_REPO}"
-		display_alert "Will push to Git" "${target_repo_url} branch ${target_branch}" "info"
+		display_alert "Will push to Git" "$(git_redact_credentials "${target_repo_url}") branch ${target_branch}" "info"
 	else
 		display_alert "Will NOT push to Git" "use PUSH_TO_GITHUB=org/repo or PUSH_TO_REPO=<url> to push" "info"
 	fi
 }
 
 function execute_git_push() {
-	display_alert "Pushing to ${target_branch}" "${target_repo_url}" "info"
+	display_alert "Pushing to ${target_branch}" "$(git_redact_credentials "${target_repo_url}")" "info"
 	# @TODO: do NOT allow shallow trees here, we need the full history to be able to push
+	# Host-key checking is disabled: build hosts are ephemeral/headless and the push
+	# target (GitHub, or the operator-configured server via PUSH_TO_*) is trusted by
+	# whoever set those vars; this just avoids an interactive host-key prompt in CI.
 	GIT_SSH_COMMAND="ssh -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "${push_command[@]}"
-	display_alert "Done pushing to ${target_branch}" "${target_repo_url}" "info"
+	display_alert "Done pushing to ${target_branch}" "$(git_redact_credentials "${target_repo_url}")" "info"
 
 	# If GitHub, link there to both the branch main view and History view
 	if [[ -n "${PUSH_TO_GITHUB}" ]]; then

--- a/lib/functions/cli/cli-patch.sh
+++ b/lib/functions/cli/cli-patch.sh
@@ -50,7 +50,7 @@ function cli_patch_kernel_run() {
 	# prepare push details, if set
 	declare target_repo_url target_branch do_push="no" used_github_shorthand="no"
 	declare -a push_command=()
-	determine_git_push_details "next-${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}" # fills in the above; parameter is the branch name
+	determine_git_push_details "${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}" # fills in the above; parameter is the branch name
 
 	# Prepare the host and build kernel; without using standard build
 	prepare_host   # This handles its own logging sections, and is possibly interactive.
@@ -127,7 +127,7 @@ function git_redact_credentials() {
 }
 
 # Determine the git push target from PUSH_TO_GITHUB / PUSH_TO_REPO.
-#   $1: middle of the branch name (kernel: "next-<family>-<ver>"; u-boot: "<board>-<branch>")
+#   $1: middle of the branch name (kernel: "<family>-<ver>"; u-boot: "<board>-<branch>")
 # Sets parent-scope vars: do_push, target_branch, target_repo_url. Uses VENDOR.
 function determine_git_push_details() {
 	# PUSH_TO_GITHUB=org/repo is shorthand for the SSH URL, but must NOT clobber an


### PR DESCRIPTION
Rebased and review-completed successor to #9194 by @rpardini (whose commit is preserved here). I cannot push to the fork branch, so this opens a fresh branch off current `main`.

## What it does (from @rpardini's original)
Generalizes the `PATCHES_TO_GIT` push in `cli-patch.sh` so the patched tree can be pushed to an arbitrary git target, and enables it for **u-boot** as well as the kernel:

- `PUSH_TO_GITHUB=org/repo` — shorthand for the SSH URL `git@github.com:org/repo.git`.
- `PUSH_TO_REPO=<url>` — push to any git URL (e.g. a CI HTTPS/token endpoint).
- Shared `determine_git_push_details` / `execute_git_push` helpers used by both `cli_patch_kernel_run` and `cli_patch_uboot_run`.

## Review fixes applied on top (addressing @iav's comments on #9194)
- **Precedence:** an explicit `PUSH_TO_REPO` is no longer clobbered by `PUSH_TO_GITHUB`; the SSH URL is only synthesized when `PUSH_TO_REPO` is empty.
- **Credential redaction:** every logged URL and the echoed push command run through `git_redact_credentials`, which scrubs `scheme://user:pass@` / `scheme://token@` to `***@`. The SSH `git@host:` user is left intact, and the actual push still uses the real URL.
- **`-next` restored:** kernel branch names are back to `armbian-next-<family>-<ver>-<date>`; the generalized helper had dropped the `-next` component.
- Documented `determine_git_push_details`' contract and the reason host-key checking is disabled in CI (CodeRabbit nitpicks).

## Verified
Sourced the two helpers in isolation:
- precedence — both vars set → `PUSH_TO_REPO` wins;
- `-next` present in kernel branch name;
- no-push gating when neither var is set;
- redaction scrubs `user:tok@` / `ghp_…@` and leaves SSH `git@github.com` untouched.

Supersedes #9194.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel and bootloader patch publishing across supported repository targets.
  * Added safer handling to redact credentials in logged Git URLs and commands.
  * Refined automated publishing behavior for headless and CI runs.
  * Improved clarity of links to published changes when GitHub publishing is enabled.
* **Refactor**
  * Consolidated Git push handling into a shared publishing flow to keep behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->