### PR TITLE
ci(board-assets): don't check out fork head under pull_request_target

### DIFF
--- a/.github/workflows/maintenance-check-board-assets.yml
+++ b/.github/workflows/maintenance-check-board-assets.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+          # Defense-in-depth for pull_request_target: don't leave the privileged
+          # GITHUB_TOKEN in .git/config. The PR-head fetch below is anonymous
+          # (public repo) and the comment step uses secrets.GITHUB_TOKEN directly.
+          persist-credentials: false
 
       - name: "Fetch PR head objects (no checkout)"
         shell: bash
@@ -51,6 +55,7 @@ jobs:
           ref: ${{ env.WEBSITE_REF }}
           path: website
           fetch-depth: 1
+          persist-credentials: false # read-only checkout; don't retain the token in .git/config
 
       - name: "Find newly added board configs in PR"
         id: added

--- a/.github/workflows/maintenance-check-board-assets.yml
+++ b/.github/workflows/maintenance-check-board-assets.yml
@@ -26,11 +26,23 @@ jobs:
       issues: write
 
     steps:
-      - name: "Checkout build repo (PR head)"
+      # Security: this runs as pull_request_target (trusted token/secrets). We do
+      # NOT check out the fork's head into the working tree - checkout@v7 refuses
+      # that as a "pwn request" risk. Instead we check out the trusted base and
+      # fetch the PR head as bare objects; the steps below only read data from it
+      # (git diff + git show), never execute fork code, so no unsafe opt-in is needed.
+      - name: "Checkout build repo (base)"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+
+      - name: "Fetch PR head objects (no checkout)"
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "+refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/pr/head"
 
       - name: "Checkout armbian.github.io (images repo)"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -71,6 +83,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
           missing_any=0
           comment_file="$(mktemp)"
 
@@ -92,7 +106,8 @@ jobs:
             board="${file%.*}"
 
             vendor="$(
-              grep -E '^[[:space:]]*(export[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?BOARD_VENDOR[[:space:]]*=' -m1 -- "$cfg" 2>/dev/null \
+              git show "${HEAD_SHA}:${cfg}" 2>/dev/null \
+              | grep -E '^[[:space:]]*(export[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?BOARD_VENDOR[[:space:]]*=' -m1 \
               | sed -E 's/^[[:space:]]*(export[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?BOARD_VENDOR[[:space:]]*=[[:space:]]*//; s/^"//; s/"$//' \
               | tr '[:upper:]' '[:lower:]' \
               | tr '_' '-' \


### PR DESCRIPTION
## Problem
The **"Verify assets for newly added boards"** job (`maintenance-check-board-assets.yml`) fails on every fork PR that touches `config/boards/**` — e.g. [#10135](https://github.com/armbian/build/pull/10135) — with:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. […] To opt in, review the risks […] and set 'allow-unsafe-pr-checkout: true'

`actions/checkout@v7` now hard-refuses checking out a fork's head SHA inside a `pull_request_target` workflow (the classic "pwn request" vector: trusted token + secrets + untrusted code). The failure is unrelated to the PR's contents; it blocks all board contributions from forks.

## Fix
Instead of opting into `allow-unsafe-pr-checkout: true`, **don't materialize the fork's working tree at all**. This job only needs to *read data*:
- `git diff base…head -- config/boards` to find newly added board configs;
- read `BOARD_VENDOR` from each added `.conf`.

So it now:
1. checks out the **trusted base** (`base.sha`, full history);
2. fetches the PR head as bare objects (`refs/pull/N/head`), no checkout;
3. reads added configs via `git show <head>:<file>` instead of the working tree.

Fork code is never checked out and never executed, so the trusted token/secrets are never exposed to untrusted input — no unsafe opt-in required. The existing PR-comment step (github-script) already passes untrusted values via `env`, not inline, so it stays injection-safe.

## Effect
Fork PRs adding/altering boards get this check running again (it was hard-failing at checkout before). Re-runs green on #10135 and similar.