### PR TITLE
rootfs: harden chroot apt against transient fetch failures (retries + fail-fast update)

### DIFF
--- a/lib/functions/logging/runners.sh
+++ b/lib/functions/logging/runners.sh
@@ -85,6 +85,20 @@ function chroot_sdcard_apt_get() {
 	#     APT::Get::List-Cleanup.
 	apt_params+=(-o "APT::Get::List-Cleanup=0") # Armbian frequently changes ours sources list; it's dynamic via aggregation
 
+	# Harden apt against transient mirror / proxy / DNS failures:
+	#   Acquire::Retries=3          - retry a failed download a few times instead of
+	#                                 dying on the first blip (apt does not retry at all
+	#                                 otherwise; a flaky mirror/acng/DNS then fails hard).
+	#   APT::Update::Error-Mode=any - make `apt-get update` a HARD failure when ANY index
+	#                                 fails, so the build aborts *at update* with the real
+	#                                 cause (e.g. "Temporary failure resolving ...") rather
+	#                                 than continuing with empty package lists and dying
+	#                                 later at install with a misleading
+	#                                 "E: Unable to locate package ...". Ignored by the
+	#                                 non-update apt-get subcommands.
+	apt_params+=(-o "Acquire::Retries=3")
+	apt_params+=(-o "APT::Update::Error-Mode=any")
+
 	if [[ "${DONT_MAINTAIN_APT_CACHE:-no}" == "yes" ]]; then
 		# Configure Clean-Installed to off
 		display_alert "Configuring APT to not clean up the cache" "APT will not clean up the cache" "debug"


### PR DESCRIPTION
## Problem
A DNS/proxy outage made **every** `apt-get update` index fetch fail in the build chroot — via the acng proxy, all repos returned `Temporary failure resolving deb.debian.org` (and `apt.armbian.com`, `github.armbian.com`, …). But the build **sailed past the failed update** and only blew up much later at install with a misleading error ([trixie gnome rootfs](https://github.com/armbian/os/actions/runs/29556772658/job/87811956639)):

```
E: Unable to locate package mesa-utils
E: Unable to locate package pipewire-audio
E: Unable to locate package wireplumber
...
Error: gnome package install failed
```

The packages exist — the package **lists were empty** because `update` failed and nothing caught it.

## Fix
Add two options to every chroot apt invocation (`chroot_sdcard_apt_get`), so they apply to `update` and `install` alike:

- **`Acquire::Retries=3`** — retry a transient download/DNS blip instead of dying on the first miss (apt does not retry at all otherwise).
- **`APT::Update::Error-Mode=any`** — make `apt-get update` a **hard failure** when any index fails, so the build aborts *at update* with the real cause instead of continuing with empty lists and failing confusingly at install. (Ignored by non-update subcommands; the exit code already propagates via `chroot_apt_result`.)

Command-line `-o` options only — nothing is written into the shipped image.

## Effect
Transient mirror/proxy/DNS blips now retry and usually succeed; a genuine outage fails loudly and early with the actual reason, instead of masquerading as "Unable to locate package". Complements disabling/replacing the flaky apt-cacher-ng proxy at the runner level.

`bash -n` + `shellcheck --severity=error` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package update reliability by retrying failed downloads up to three times.
  * Updates now fail clearly when any package index cannot be downloaded, preventing later installation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->