### PR TITLE
armbian-install: report bootloader write failures instead of "Done."

### DIFF
--- a/packages/bsp/common/usr/bin/armbian-install
+++ b/packages/bsp/common/usr/bin/armbian-install
@@ -25,6 +25,11 @@ trap "systemctl start docker >/dev/null 2>&1; exit" INT TERM
 
 [[ -f /usr/lib/u-boot/platform_install.sh ]] && source /usr/lib/u-boot/platform_install.sh
 
+# Some board write_uboot_platform hooks are notice-only and call the build-side
+# display_alert, which does not exist in this runtime script; provide a minimal
+# shim so those hooks print their message and return 0 instead of failing 127.
+declare -F display_alert > /dev/null || display_alert() { echo "$1${2:+ $2}"; }
+
 # ORIGINAL_SCRIPT_NAME: Must be either armbian-install or nand-sata-install
 ORIGINAL_SCRIPT_NAME=$(basename $0)
 # script configuration - derive from ORIGINAL_SCRIPT_NAME
@@ -969,6 +974,40 @@ write_uboot_to_mtd_flash()
 	fi
 }
 
+# Write the platform bootloader to a block device and confirm it worked.
+# write_uboot_platform runs 'dd' without checking its exit status; callers
+# then printed "Done." unconditionally, so a failed write (a dying eMMC
+# returning -110 on cache flush, a write-protected or wrong target) was
+# indistinguishable from success and left the bootloader silently stale.
+# Capture the output, log it, and surface a real error to the user.
+#  $1 = u-boot files directory
+#  $2 = target block device
+write_bootloader_checked()
+{
+	local dir="$1" target="$2" out rc syncout
+	out=$(write_uboot_platform "$dir" "$target" 2>&1)
+	rc=$?
+	# The platform writer's dd may only queue the write (some families omit
+	# conv=fsync); flush the target so a writeback/cache-flush failure (a failing
+	# eMMC returns -110 here) is caught rather than reported as success.
+	if [[ $rc -eq 0 ]]; then
+		syncout=$(sync "$target" 2>&1)
+		rc=$?
+		[[ -n "$syncout" ]] && out+=$'\n'"$syncout"
+	fi
+	printf '%s: write bootloader to %s (rc=%d)\n%s\n' "$(date)" "${target}" "${rc}" "${out}" >> "$logfile"
+	if [[ $rc -ne 0 ]]; then
+		dialog --backtitle "$backtitle" --title ' Bootloader update FAILED ' --colors --cr-wrap --msgbox \
+			"\Z1The bootloader update on ${target} FAILED (exit ${rc}).\Zn\n\n${out}\n\nThe write may be incomplete - the board may not boot until the bootloader is rewritten successfully. Do not assume the previous bootloader is still usable. Check 'dmesg' for I/O errors." 0 0
+	elif [[ -n "$out" ]]; then
+		# Some families' write_uboot_platform prints required manual steps
+		# (e.g. fastboot instructions) instead of writing; surface that output
+		# to the user rather than swallowing it behind "Done.".
+		echo "$out"
+	fi
+	return "$rc"
+}
+
 main()
 {
 	export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -1133,14 +1172,14 @@ main()
 				;;
 			5)
 				show_warning "This script will update the bootloader on ${root_partition_device}.\n\n    Continue?"
-				write_uboot_platform "$DIR" "${root_partition_device}"
+				write_bootloader_checked "$DIR" "${root_partition_device}" || return
 				update_bootscript
 				dialog --backtitle "$backtitle" --title 'Writing bootloader' --msgbox '\n          Done.' 7 30
 				return
 				;;
 			6)
 				show_warning "This script will update the bootloader on ${BOOTPART}.\n\n    Continue?"
-				write_uboot_platform "$DIR" ${BOOTPART}
+				write_bootloader_checked "$DIR" "${BOOTPART}" || return
 				echo 'Done'
 				return
 				;;


### PR DESCRIPTION
## Problem

The option 5/6 bootloader-update paths in `armbian-install` call `write_uboot_platform` and then print `Done.` unconditionally. `write_uboot_platform` runs `dd` without checking its exit status, so a failed write — a dying eMMC returning `-110` on cache flush, a write-protected or wrong target — is indistinguishable from success, and the bootloader is left silently stale. On a board with a failing eMMC the installer reports success while nothing was written.

## Change

Wrap the write in `write_bootloader_checked()`:
- capture the writer's output and log it;
- flush the target with a checked `sync` (some family writers omit `conv=fsync`, so a queued writeback/cache-flush failure would otherwise pass unnoticed — this is exactly the eMMC `-110` case);
- on any non-zero status, show an auto-sized failure dialog naming the target and the error. The dialog does not claim the old bootloader is still intact — a partial write may leave the board unbootable.

`Done.`/`update_bootscript` run only on success, and options 5/6 propagate the failure as the script exit status so callers (armbian-config, automation) see the error too.

## Scope / known limitation

This is a caller-side change. Per-family `write_uboot_platform` writers that issue multiple raw `dd` commands without chaining (`|| return` / `set -e`) can still mask an earlier failure behind a later success — the wrapper only observes the function's final status. Hardening each of the ~36 writers to fail fast is a separate cross-cutting change; this PR fixes the common cases (read-only/missing target, final-status failure, and the writeback/cache-flush failure the checked `sync` now catches).

## Testing

ODROID-N2 (meson64, eMMC, btrfs rootfs): failure dialog rendered against a read-only target; success path unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootloader update reliability by verifying the bootloader write result and running a follow-up sync to catch delayed flush/writeback issues.
  * Installer logs now include the bootloader target, return code, and captured output for faster diagnosis.
  * On failure (including captured errors), the installer shows the output and stops before any success messaging.
  * Added a safe fallback for missing alert display support to prevent “command not found” failures in notice-only board implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->