### PR TITLE
rootfs: DNS fallback for build-time chroot resolv.conf

### DIFF
--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -7,6 +7,30 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
+# Write a build-time /etc/resolv.conf into the chroot: the primary resolver
+# (${NAMESERVER}) followed by public fallbacks, so a single flaky or unreachable
+# resolver doesn't break apt with "Temporary failure resolving ...". Order is
+# preserved (primary first), so a working primary is always tried before any
+# fallback; the glibc resolver honours at most MAXNS=3 nameservers, so we cap at
+# three. Build-time only — the shipped image's resolv.conf is finalized later
+# (resolvconf / systemd-resolved), so these public resolvers are never shipped.
+function write_build_resolv_conf() {
+	local target="${1}/etc/resolv.conf"
+	local -a ns=("${NAMESERVER}")
+	local fb
+	for fb in 1.1.1.1 8.8.8.8; do
+		[[ "${fb}" == "${NAMESERVER}" ]] && continue
+		ns+=("${fb}")
+	done
+	ns=("${ns[@]:0:3}") # cap at MAXNS=3; extra nameserver lines are ignored by glibc
+	run_host_command_logged rm -fv "${target}"
+	{
+		for fb in "${ns[@]}"; do echo "nameserver ${fb}"; done
+		echo "options timeout:3 attempts:2" # fail over to the next resolver quickly instead of hanging
+	} > "${target}"
+	display_alert "Wrote build-time resolv.conf" "${ns[*]}" "debug"
+}
+
 # called by artifact-rootfs::artifact_rootfs_prepare_version()
 function calculate_rootfs_cache_id() {
 	# Validate that AGGREGATED_ROOTFS_HASH is set
@@ -158,8 +182,7 @@ function extract_rootfs_artifact() {
 
 	wait_for_disk_sync "after restoring rootfs cache"
 
-	run_host_command_logged rm -v "${SDCARD}"/etc/resolv.conf
-	run_host_command_logged echo "nameserver ${NAMESERVER}" ">" "${SDCARD}"/etc/resolv.conf
+	write_build_resolv_conf "${SDCARD}"
 
 	# all sources etc.
 	# armbian repo is NOT yet included here, since we'll be building the image, and don't want the repo interferring.

--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -18,7 +18,7 @@ function write_build_resolv_conf() {
 	local target="${1}/etc/resolv.conf"
 	local -a ns=("${NAMESERVER}")
 	local fb
-	for fb in 1.1.1.1 8.8.8.8; do
+	for fb in 1.1.1.1 8.8.8.8 9.9.9.9; do
 		[[ "${fb}" == "${NAMESERVER}" ]] && continue
 		ns+=("${fb}")
 	done

--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -16,14 +16,15 @@
 # (resolvconf / systemd-resolved), so these public resolvers are never shipped.
 function write_build_resolv_conf() {
 	local target="${1}/etc/resolv.conf"
-	local -a ns=("${NAMESERVER}")
+	local -a ns=()
+	[[ -n "${NAMESERVER}" ]] && ns=("${NAMESERVER}") # omit an empty primary; never emit a blank "nameserver" line
 	local fb
 	for fb in 1.1.1.1 8.8.8.8 9.9.9.9; do
 		[[ "${fb}" == "${NAMESERVER}" ]] && continue
 		ns+=("${fb}")
 	done
 	ns=("${ns[@]:0:3}") # cap at MAXNS=3; extra nameserver lines are ignored by glibc
-	run_host_command_logged rm -fv "${target}"
+	run_host_command_logged rm -fv "${target@Q}"
 	{
 		for fb in "${ns[@]}"; do echo "nameserver ${fb}"; done
 		echo "options timeout:3 attempts:2" # fail over to the next resolver quickly instead of hanging

--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -236,8 +236,7 @@ function create_new_rootfs_cache_via_debootstrap() {
 	chroot_sdcard_apt_get_install "${AGGREGATED_PACKAGES_ROOTFS[@]}"
 
 	# Systemd resolver is not working yet
-	run_host_command_logged rm -fv "${SDCARD}"/etc/resolv.conf
-	run_host_command_logged echo "nameserver $NAMESERVER" ">" "${SDCARD}"/etc/resolv.conf
+	write_build_resolv_conf "${SDCARD}"
 
 	# Install desktop via armbian-config INSIDE rootfs-create (before the
 	# cache tarball is saved) so desktop packages are included in the
@@ -283,8 +282,7 @@ function create_new_rootfs_cache_via_debootstrap() {
 	display_alert "Free disk space on rootfs" "SDCARD: $(echo -e "${free_space}" | awk -v mp="${SDCARD}" '$6==mp {print $5}')" "info"
 
 	# this is needed for the build process later since resolvconf generated file in /run is not saved
-	run_host_command_logged rm -fv "${SDCARD}"/etc/resolv.conf
-	run_host_command_logged echo "nameserver $NAMESERVER" ">" "${SDCARD}"/etc/resolv.conf
+	write_build_resolv_conf "${SDCARD}"
 
 	# Remove `machine-id` (https://www.freedesktop.org/software/systemd/man/machine-id.html)
 	# Note: As we don't use systemd-firstboot.service functionality, we make it empty to prevent services


### PR DESCRIPTION
## Problem
The chroot's build-time `/etc/resolv.conf` is written with a **single** nameserver — `${NAMESERVER}`, which is the first non-loopback host resolver (or `1.0.0.1` as a last resort). If that one resolver is flaky or unreachable, apt fails for the entire build with no fallback:

```
W: Failed to fetch http://deb.debian.org/debian/dists/trixie/InRelease
   Temporary failure resolving 'deb.debian.org'
E: Unable to locate package ...
```

(seen on the [trixie gnome rootfs run](https://github.com/armbian/os/actions/runs/29556772658/job/87811956639)).

## Fix
New `write_build_resolv_conf()` writes a resilient resolv.conf and is used at all three build-time write sites (`create-cache.sh`, `rootfs-create.sh` ×2):

- **primary resolver first** (`${NAMESERVER}`) so a working internal/host DNS is always preferred;
- then **public fallbacks** `1.1.1.1`, `8.8.8.8` — deduped against the primary, capped at glibc's **MAXNS=3**;
- `options timeout:3 attempts:2` so it fails over to the next resolver quickly instead of hanging on a dead one.

Order is preserved (no `rotate`), so this never *prefers* public DNS over the site's resolver — it only adds a safety net when the primary is failing.

**Build-time only.** The shipped image's resolv.conf is finalized later (resolvconf / systemd-resolved via post-tweaks), so these public resolvers are never written into the image.

## Verification
`bash -n` + `shellcheck --severity=error` clean. Helper output tested:

```
NAMESERVER=10.0.40.2 -> 10.0.40.2, 1.1.1.1, 8.8.8.8      (+ options)
NAMESERVER=1.1.1.1   -> 1.1.1.1, 8.8.8.8   (deduped)     (+ options)
NAMESERVER=1.0.0.1   -> 1.0.0.1, 1.1.1.1, 8.8.8.8        (+ options)
```

Complements #10202 (apt retries + fail-fast update) and disabling the flaky acng proxy at the runner level — this hardens the resolver layer beneath both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS configuration during root filesystem creation to reliably generate `resolv.conf` in the build output.
  * Added ordered fallback name servers plus timeout and retry options, improving resilience when the primary resolver is unavailable.
  * Ensured resolver configuration is applied consistently across multiple root filesystem build steps, reducing cases where `resolv.conf` is missing or incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->