### PR TITLE
rockchip64-6.18: rework `rk3588-0010-fix-clk-divisions` to avoid patching `include/linux/math.h`

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/rk3588-0010-fix-clk-divisions-INLINE-REWORK.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3588-0010-fix-clk-divisions-INLINE-REWORK.patch
@@ -1,43 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sebastian Reichel <sebastian.reichel@collabora.com>
-Date: Tue, 24 Oct 2023 16:09:35 +0200
-Subject: math.h: add DIV_ROUND_UP_NO_OVERFLOW
-
-Add a new DIV_ROUND_UP helper, which cannot overflow when
-big numbers are being used.
-
-Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
----
- include/linux/math.h | 11 ++++++++++
- 1 file changed, 11 insertions(+)
-
-diff --git a/include/linux/math.h b/include/linux/math.h
-index 111111111111..222222222222 100644
---- a/include/linux/math.h
-+++ b/include/linux/math.h
-@@ -48,6 +48,17 @@
- 
- #define DIV_ROUND_UP __KERNEL_DIV_ROUND_UP
- 
-+/**
-+ * DIV_ROUND_UP_NO_OVERFLOW - divide two numbers and always round up
-+ * @n: numerator / dividend
-+ * @d: denominator / divisor
-+ *
-+ * This functions does the same as DIV_ROUND_UP, but internally uses a
-+ * division and a modulo operation instead of math tricks. This way it
-+ * avoids overflowing when handling big numbers.
-+ */
-+#define DIV_ROUND_UP_NO_OVERFLOW(n, d) (((n) / (d)) + !!((n) % (d)))
-+
- #define DIV_ROUND_DOWN_ULL(ll, d) \
- 	({ unsigned long long _tmp = (ll); do_div(_tmp, d); _tmp; })
- 
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Sebastian Reichel <sebastian.reichel@collabora.com>
 Date: Tue, 24 Oct 2023 16:13:50 +0200
 Subject: clk: divider: Fix divisor masking on 64 bit platforms
 
@@ -57,43 +19,67 @@ effectively request ca. 5 MHz. Requesting clk_round_rate(clk, ULONG_MAX)
 is a bit of a special case, since that still returns correct values as
 long as the parent clock is below 8.5 GHz.
 
-Fix this by switching to DIV_ROUND_UP_NO_OVERFLOW, which cannot
+Fix this by using a local division-and-modulo helper, which cannot
 overflow. This avoids any requirements on the arguments (except
 that divisor should not be 0 obviously).
 
+- rpardini: Inlined the DIV_ROUND_UP helper into clk-divider.c;
+  having a patch touch include/linux/math.h caused almost of full
+  kernel rebuild everytime, since Armbian re-patches (and thus modifies)
+  files on every build. Sorry!
+
 Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- drivers/clk/clk-divider.c | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ drivers/clk/clk-divider.c | 17 ++++++++--
+ 1 file changed, 14 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/clk/clk-divider.c b/drivers/clk/clk-divider.c
 index 111111111111..222222222222 100644
 --- a/drivers/clk/clk-divider.c
 +++ b/drivers/clk/clk-divider.c
-@@ -226,7 +226,7 @@ static int _div_round_up(const struct clk_div_table *table,
+@@ -26,6 +26,17 @@
+  * parent - fixed parent.  No clk_set_parent support
+  */
+ 
++/*
++ * Same as DIV_ROUND_UP, but internally uses a division and a modulo
++ * operation instead of math tricks. This way it avoids overflowing
++ * when handling big numbers (e.g. clock rates >= 4.3 GHz on 64-bit).
++ */
++static inline unsigned long clk_divider_round_up_no_overflow(unsigned long n,
++							     unsigned long d)
++{
++	return (n / d) + !!(n % d);
++}
++
+ static inline u32 clk_div_readl(struct clk_divider *divider)
+ {
+ 	if (divider->flags & CLK_DIVIDER_BIG_ENDIAN)
+@@ -226,7 +237,7 @@ static int _div_round_up(const struct clk_div_table *table,
  			 unsigned long parent_rate, unsigned long rate,
  			 unsigned long flags)
  {
 -	int div = DIV_ROUND_UP_ULL((u64)parent_rate, rate);
-+	int div = DIV_ROUND_UP_NO_OVERFLOW(parent_rate, rate);
++	int div = clk_divider_round_up_no_overflow(parent_rate, rate);
  
  	if (flags & CLK_DIVIDER_POWER_OF_TWO)
  		div = __roundup_pow_of_two(div);
-@@ -243,7 +243,7 @@ static int _div_round_closest(const struct clk_div_table *table,
+@@ -243,7 +254,7 @@ static int _div_round_closest(const struct clk_div_table *table,
  	int up, down;
  	unsigned long up_rate, down_rate;
  
 -	up = DIV_ROUND_UP_ULL((u64)parent_rate, rate);
-+	up = DIV_ROUND_UP_NO_OVERFLOW(parent_rate, rate);
++	up = clk_divider_round_up_no_overflow(parent_rate, rate);
  	down = parent_rate / rate;
  
  	if (flags & CLK_DIVIDER_POWER_OF_TWO) {
-@@ -414,7 +414,7 @@ int divider_get_val(unsigned long rate, unsigned long parent_rate,
+@@ -414,7 +425,7 @@ int divider_get_val(unsigned long rate, unsigned long parent_rate,
  {
  	unsigned int div, value;
  
 -	div = DIV_ROUND_UP_ULL((u64)parent_rate, rate);
-+	div = DIV_ROUND_UP_NO_OVERFLOW(parent_rate, rate);
++	div = clk_divider_round_up_no_overflow(parent_rate, rate);
  
  	if (!_is_valid_div(table, div, flags))
  		return -EINVAL;

--- a/patch/kernel/archive/rockchip64-7.1/rk3588-0010-fix-clk-divisions-INLINE-REWORK.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3588-0010-fix-clk-divisions-INLINE-REWORK.patch
@@ -1,43 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sebastian Reichel <sebastian.reichel@collabora.com>
-Date: Tue, 24 Oct 2023 16:09:35 +0200
-Subject: math.h: add DIV_ROUND_UP_NO_OVERFLOW
-
-Add a new DIV_ROUND_UP helper, which cannot overflow when
-big numbers are being used.
-
-Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
----
- include/linux/math.h | 11 ++++++++++
- 1 file changed, 11 insertions(+)
-
-diff --git a/include/linux/math.h b/include/linux/math.h
-index 111111111111..222222222222 100644
---- a/include/linux/math.h
-+++ b/include/linux/math.h
-@@ -48,6 +48,17 @@
- 
- #define DIV_ROUND_UP __KERNEL_DIV_ROUND_UP
- 
-+/**
-+ * DIV_ROUND_UP_NO_OVERFLOW - divide two numbers and always round up
-+ * @n: numerator / dividend
-+ * @d: denominator / divisor
-+ *
-+ * This functions does the same as DIV_ROUND_UP, but internally uses a
-+ * division and a modulo operation instead of math tricks. This way it
-+ * avoids overflowing when handling big numbers.
-+ */
-+#define DIV_ROUND_UP_NO_OVERFLOW(n, d) (((n) / (d)) + !!((n) % (d)))
-+
- #define DIV_ROUND_DOWN_ULL(ll, d) \
- 	({ unsigned long long _tmp = (ll); do_div(_tmp, d); _tmp; })
- 
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Sebastian Reichel <sebastian.reichel@collabora.com>
 Date: Tue, 24 Oct 2023 16:13:50 +0200
 Subject: clk: divider: Fix divisor masking on 64 bit platforms
 
@@ -57,43 +19,67 @@ effectively request ca. 5 MHz. Requesting clk_round_rate(clk, ULONG_MAX)
 is a bit of a special case, since that still returns correct values as
 long as the parent clock is below 8.5 GHz.
 
-Fix this by switching to DIV_ROUND_UP_NO_OVERFLOW, which cannot
+Fix this by using a local division-and-modulo helper, which cannot
 overflow. This avoids any requirements on the arguments (except
 that divisor should not be 0 obviously).
 
+- rpardini: Inlined the DIV_ROUND_UP helper into clk-divider.c;
+  having a patch touch include/linux/math.h caused almost of full
+  kernel rebuild everytime, since Armbian re-patches (and thus modifies)
+  files on every build. Sorry!
+
 Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- drivers/clk/clk-divider.c | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ drivers/clk/clk-divider.c | 17 ++++++++--
+ 1 file changed, 14 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/clk/clk-divider.c b/drivers/clk/clk-divider.c
 index 111111111111..222222222222 100644
 --- a/drivers/clk/clk-divider.c
 +++ b/drivers/clk/clk-divider.c
-@@ -226,7 +226,7 @@ static int _div_round_up(const struct clk_div_table *table,
+@@ -26,6 +26,17 @@
+  * parent - fixed parent.  No clk_set_parent support
+  */
+ 
++/*
++ * Same as DIV_ROUND_UP, but internally uses a division and a modulo
++ * operation instead of math tricks. This way it avoids overflowing
++ * when handling big numbers (e.g. clock rates >= 4.3 GHz on 64-bit).
++ */
++static inline unsigned long clk_divider_round_up_no_overflow(unsigned long n,
++							     unsigned long d)
++{
++	return (n / d) + !!(n % d);
++}
++
+ static inline u32 clk_div_readl(struct clk_divider *divider)
+ {
+ 	if (divider->flags & CLK_DIVIDER_BIG_ENDIAN)
+@@ -226,7 +237,7 @@ static int _div_round_up(const struct clk_div_table *table,
  			 unsigned long parent_rate, unsigned long rate,
  			 unsigned long flags)
  {
 -	int div = DIV_ROUND_UP_ULL((u64)parent_rate, rate);
-+	int div = DIV_ROUND_UP_NO_OVERFLOW(parent_rate, rate);
++	int div = clk_divider_round_up_no_overflow(parent_rate, rate);
  
  	if (flags & CLK_DIVIDER_POWER_OF_TWO)
  		div = __roundup_pow_of_two(div);
-@@ -243,7 +243,7 @@ static int _div_round_closest(const struct clk_div_table *table,
+@@ -243,7 +254,7 @@ static int _div_round_closest(const struct clk_div_table *table,
  	int up, down;
  	unsigned long up_rate, down_rate;
  
 -	up = DIV_ROUND_UP_ULL((u64)parent_rate, rate);
-+	up = DIV_ROUND_UP_NO_OVERFLOW(parent_rate, rate);
++	up = clk_divider_round_up_no_overflow(parent_rate, rate);
  	down = parent_rate / rate;
  
  	if (flags & CLK_DIVIDER_POWER_OF_TWO) {
-@@ -458,7 +458,7 @@ int divider_get_val(unsigned long rate, unsigned long parent_rate,
+@@ -414,7 +425,7 @@ int divider_get_val(unsigned long rate, unsigned long parent_rate,
  {
  	unsigned int div, value;
  
 -	div = DIV_ROUND_UP_ULL((u64)parent_rate, rate);
-+	div = DIV_ROUND_UP_NO_OVERFLOW(parent_rate, rate);
++	div = clk_divider_round_up_no_overflow(parent_rate, rate);
  
  	if (!_is_valid_div(table, div, flags))
  		return -EINVAL;
@@ -125,7 +111,7 @@ index 111111111111..222222222222 100644
  #include <linux/slab.h>
  
  static u8 clk_composite_get_parent(struct clk_hw *hw)
-@@ -119,10 +120,7 @@ static int clk_composite_determine_rate(struct clk_hw *hw,
+@@ -106,10 +107,7 @@ static int clk_composite_determine_rate(struct clk_hw *hw,
  			if (ret)
  				continue;
  

--- a/patch/kernel/archive/rockchip64-7.2/rk3588-0010-fix-clk-divisions-INLINE-REWORK.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3588-0010-fix-clk-divisions-INLINE-REWORK.patch
@@ -1,43 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sebastian Reichel <sebastian.reichel@collabora.com>
-Date: Tue, 24 Oct 2023 16:09:35 +0200
-Subject: math.h: add DIV_ROUND_UP_NO_OVERFLOW
-
-Add a new DIV_ROUND_UP helper, which cannot overflow when
-big numbers are being used.
-
-Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
----
- include/linux/math.h | 11 ++++++++++
- 1 file changed, 11 insertions(+)
-
-diff --git a/include/linux/math.h b/include/linux/math.h
-index 111111111111..222222222222 100644
---- a/include/linux/math.h
-+++ b/include/linux/math.h
-@@ -48,6 +48,17 @@
- 
- #define DIV_ROUND_UP __KERNEL_DIV_ROUND_UP
- 
-+/**
-+ * DIV_ROUND_UP_NO_OVERFLOW - divide two numbers and always round up
-+ * @n: numerator / dividend
-+ * @d: denominator / divisor
-+ *
-+ * This functions does the same as DIV_ROUND_UP, but internally uses a
-+ * division and a modulo operation instead of math tricks. This way it
-+ * avoids overflowing when handling big numbers.
-+ */
-+#define DIV_ROUND_UP_NO_OVERFLOW(n, d) (((n) / (d)) + !!((n) % (d)))
-+
- #define DIV_ROUND_DOWN_ULL(ll, d) \
- 	({ unsigned long long _tmp = (ll); do_div(_tmp, d); _tmp; })
- 
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Sebastian Reichel <sebastian.reichel@collabora.com>
 Date: Tue, 24 Oct 2023 16:13:50 +0200
 Subject: clk: divider: Fix divisor masking on 64 bit platforms
 
@@ -57,43 +19,67 @@ effectively request ca. 5 MHz. Requesting clk_round_rate(clk, ULONG_MAX)
 is a bit of a special case, since that still returns correct values as
 long as the parent clock is below 8.5 GHz.
 
-Fix this by switching to DIV_ROUND_UP_NO_OVERFLOW, which cannot
+Fix this by using a local division-and-modulo helper, which cannot
 overflow. This avoids any requirements on the arguments (except
 that divisor should not be 0 obviously).
 
+- rpardini: Inlined the DIV_ROUND_UP helper into clk-divider.c;
+  having a patch touch include/linux/math.h caused almost of full
+  kernel rebuild everytime, since Armbian re-patches (and thus modifies)
+  files on every build. Sorry!
+
 Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- drivers/clk/clk-divider.c | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ drivers/clk/clk-divider.c | 17 ++++++++--
+ 1 file changed, 14 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/clk/clk-divider.c b/drivers/clk/clk-divider.c
 index 111111111111..222222222222 100644
 --- a/drivers/clk/clk-divider.c
 +++ b/drivers/clk/clk-divider.c
-@@ -226,7 +226,7 @@ static int _div_round_up(const struct clk_div_table *table,
+@@ -26,6 +26,17 @@
+  * parent - fixed parent.  No clk_set_parent support
+  */
+ 
++/*
++ * Same as DIV_ROUND_UP, but internally uses a division and a modulo
++ * operation instead of math tricks. This way it avoids overflowing
++ * when handling big numbers (e.g. clock rates >= 4.3 GHz on 64-bit).
++ */
++static inline unsigned long clk_divider_round_up_no_overflow(unsigned long n,
++							     unsigned long d)
++{
++	return (n / d) + !!(n % d);
++}
++
+ static inline u32 clk_div_readl(struct clk_divider *divider)
+ {
+ 	if (divider->flags & CLK_DIVIDER_BIG_ENDIAN)
+@@ -226,7 +237,7 @@ static int _div_round_up(const struct clk_div_table *table,
  			 unsigned long parent_rate, unsigned long rate,
  			 unsigned long flags)
  {
 -	int div = DIV_ROUND_UP_ULL((u64)parent_rate, rate);
-+	int div = DIV_ROUND_UP_NO_OVERFLOW(parent_rate, rate);
++	int div = clk_divider_round_up_no_overflow(parent_rate, rate);
  
  	if (flags & CLK_DIVIDER_POWER_OF_TWO)
  		div = __roundup_pow_of_two(div);
-@@ -243,7 +243,7 @@ static int _div_round_closest(const struct clk_div_table *table,
+@@ -243,7 +254,7 @@ static int _div_round_closest(const struct clk_div_table *table,
  	int up, down;
  	unsigned long up_rate, down_rate;
  
 -	up = DIV_ROUND_UP_ULL((u64)parent_rate, rate);
-+	up = DIV_ROUND_UP_NO_OVERFLOW(parent_rate, rate);
++	up = clk_divider_round_up_no_overflow(parent_rate, rate);
  	down = parent_rate / rate;
  
  	if (flags & CLK_DIVIDER_POWER_OF_TWO) {
-@@ -414,7 +414,7 @@ int divider_get_val(unsigned long rate, unsigned long parent_rate,
+@@ -414,7 +425,7 @@ int divider_get_val(unsigned long rate, unsigned long parent_rate,
  {
  	unsigned int div, value;
  
 -	div = DIV_ROUND_UP_ULL((u64)parent_rate, rate);
-+	div = DIV_ROUND_UP_NO_OVERFLOW(parent_rate, rate);
++	div = clk_divider_round_up_no_overflow(parent_rate, rate);
  
  	if (!_is_valid_div(table, div, flags))
  		return -EINVAL;


### PR DESCRIPTION
#### rockchip64-6.18: rework `rk3588-0010-fix-clk-divisions` to avoid patching `include/linux/math.h`

- 🌳 rockchip64-7.2: rework `rk3588-0010-fix-clk-divisions` to avoid patching `include/linux/math.h`
  - patching  `include/linux/math.h` (which is included by everything and their mum) causes full rebuilds everytime
- 🐸 rockchip64-7.1: rework `rk3588-0010-fix-clk-divisions` to avoid patching `include/linux/math.h`
  - patching  `include/linux/math.h` (which is included by everything and their mum) causes full rebuilds everytime
- 🌱 rockchip64-6.18: rework `rk3588-0010-fix-clk-divisions` to avoid patching `include/linux/math.h`
  - patching  `include/linux/math.h` (which is included by everything and their mum) causes full rebuilds everytime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed clock divider calculations on 64-bit systems, improving accuracy at higher frequencies.
  * Prevented overflow-related errors when rounding clock rates.
  * Improved composite clock rate comparisons for more reliable frequency selection.
  * Applied the clocking fixes consistently across supported Rockchip64 kernel versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->