### PR TITLE
rootfs: revert resolute tar pin (#10187) — fixed upstream

### DIFF
--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -370,20 +370,6 @@ function install_distribution_agnostic() {
 
 	# install kernel: image/dtb/headers
 	if [[ "${KERNELSOURCE}" != "none" ]]; then
-		# resolute ships a tar that hits an ENOSYS bug while dpkg unpacks the
-		# kernel debs in the build chroot; pin it to a known-good version for the
-		# install and restore it afterwards. Applies to ALL families/boards, not
-		# just one. Remove once upstream tar is fixed.
-		if [[ "${RELEASE}" == "resolute" ]]; then
-			display_alert "Pinning tar" "to 1.35+dfsg-4 for resolute kernel deb install" "info"
-			cat > "${SDCARD}/etc/apt/preferences.d/tar-pin" <<-'EOF'
-				Package: tar
-				Pin: version 1.35+dfsg-4*
-				Pin-Priority: 1001
-			EOF
-			do_with_retries 3 chroot_sdcard_apt_get --allow-downgrades install tar
-		fi
-
 		install_artifact_deb_chroot "linux-image"
 
 		if [[ "${KERNEL_BUILD_DTBS:-"yes"}" == "yes" ]]; then
@@ -400,12 +386,6 @@ function install_distribution_agnostic() {
 		IMAGE_INSTALLED_KERNEL_VERSION=$(dpkg --info "${DEB_STORAGE}/${image_artifacts_debs_reversioned["linux-image"]}" | grep "^ Source:" | sed -e 's/ Source: linux-//')
 		display_alert "Parsed kernel version from local package" "${IMAGE_INSTALLED_KERNEL_VERSION}" "debug"
 
-		# Restore the distro's tar after the kernel debs are installed (see the pin above).
-		if [[ "${RELEASE}" == "resolute" ]]; then
-			display_alert "Unpinning tar" "restoring resolute tar after kernel deb install" "info"
-			rm -f "${SDCARD}/etc/apt/preferences.d/tar-pin"
-			do_with_retries 3 chroot_sdcard_apt_get install tar
-		fi
 	fi
 
 	call_extension_method "post_install_kernel_debs" <<- 'POST_INSTALL_KERNEL_DEBS'


### PR DESCRIPTION
Reverts #10187 (commit `6584ff35c`).

## Why
#10187 pinned `tar` to `1.35+dfsg-4` as a workaround for the resolute ENOSYS bug where the `linux-headers` postinst's `tar` (openat2-based extraction under qemu-user) failed with `Cannot open: Function not implemented`, breaking `INSTALL_HEADERS=yes` builds (#10166).

That bug is now **fixed upstream** in [`tar 1.35+dfsg-4ubuntu0.3`](https://launchpad.net/ubuntu/+source/tar/1.35+dfsg-4ubuntu0.3), so the workaround is no longer needed — the PR that added it said "remove once upstream tar is fixed." Reverting has been verified to build cleanly on resolute (https://paste.armbian.com/luxobamonu).

Removing the pin lets resolute rootfs use the fixed distro `tar` directly.

Fixes #10166.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved distro-agnostic root filesystem installation for the Resolute release.
  - Kernel installation no longer performs unnecessary `tar` package version changes, reducing installation complexity and potential package conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->