### PR TITLE
docker: allow overriding host_arch for foreign-arch Dockerfile generation

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -349,9 +349,14 @@ function docker_cli_prepare_dockerfile() {
 	fi
 	declare -a -g host_dependencies=()
 
-	# Get the actual host architecture for proper cross-compiler selection
+	# Get the host architecture for proper cross-compiler selection. Normally this
+	# is the machine running the build, but when generating a Dockerfile for a
+	# foreign-arch image (e.g. a riscv64 build image built under QEMU on an amd64
+	# runner) the caller sets DOCKER_ARMBIAN_HOST_ARCH to the image's target arch,
+	# so the arch-specific host-dependency guards (skipping cross-compilers that
+	# don't exist on riscv64, etc.) match the image being produced, not the runner.
 	declare host_arch
-	host_arch="$(dpkg --print-architecture)"
+	host_arch="${DOCKER_ARMBIAN_HOST_ARCH:-"$(dpkg --print-architecture)"}"
 	host_release="${DOCKER_WANTED_RELEASE}" host_arch="${host_arch}" early_prepare_host_dependencies # hooks: add_host_dependencies // host_dependencies_known
 	display_alert "Pre-game host dependencies for host_release '${DOCKER_WANTED_RELEASE}' host_arch '${host_arch}'" "${host_dependencies[*]}" "debug"
 


### PR DESCRIPTION
Follow-up to #9589. Enables the riscv64 framework Docker image to build.

## Problem
`generate-dockerfile` derives `host_arch` from `dpkg --print-architecture` on the machine running it. The framework Docker images are built per-arch, but riscv64 has no GitHub-hosted runner, so its image is built **under QEMU on an amd64 runner**. `generate-dockerfile` therefore sees `host_arch=amd64`, #9589's "skip cross-compilers unavailable on riscv64" guard never fires, and the generated Dockerfile installs `gcc-x86-64-linux-gnu` / `libc6-amd64-cross`, which have **no installation candidate on riscv64** — the image build fails:

```
E: Package 'gcc-x86-64-linux-gnu' has no installation candidate
```
([failing run](https://github.com/armbian/docker-armbian-build/actions/runs/29636271077/job/88059065499))

## Fix
Honour `DOCKER_ARMBIAN_HOST_ARCH` as an override:
```bash
host_arch="${DOCKER_ARMBIAN_HOST_ARCH:-"$(dpkg --print-architecture)"}"
```
so the caller (the `docker-armbian-build` workflow) can generate the Dockerfile for the **image's** target arch. Unset → falls back to `dpkg` → native builds unchanged.

Paired with a `docker-armbian-build` PR that passes `DOCKER_ARMBIAN_HOST_ARCH: ${{ matrix.arch }}` to the generate step.

`bash -n` + `shellcheck --severity=error` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image builds for cross-architecture environments.
  * Host dependency selection now correctly follows the configured target architecture, with a fallback to the system architecture when no target is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->