### PR TITLE
sun55iw3-syterkit: skip TF-A build (SyterKit is self-contained)

### DIFF
--- a/config/sources/families/sun55iw3-syterkit.conf
+++ b/config/sources/families/sun55iw3-syterkit.conf
@@ -12,6 +12,14 @@ ARCH="arm64"
 LINUXFAMILY="sun55iw3-syterkit"
 enable_extension "syterkit-allwinner"
 
+# SyterKit is a prebuilt, self-contained bootloader (downloaded as an image by the
+# extension above), so this family needs no TF-A. Without this, arm64.conf's
+# default ATFSOURCE (mainline ARM TF-A) is inherited and the build compiles the
+# useless default PLAT=fvp, which then fails to link
+# ("ld.bfd: unrecognized option '-Wl,--no-warn-rwx-segment'"). "none" skips the
+# ATF build entirely (see lib/functions/compilation/atf.sh).
+declare -g ATFSOURCE="none"
+
 case "${BRANCH}" in
 
 	legacy)


### PR DESCRIPTION
Fixes the `uboot-avaota-a1-legacy` build failure ([failing run](https://github.com/armbian/os/actions/runs/29644475109/job/88081436086)).

## Diagnosis
The build dies compiling **TF-A for `PLAT=fvp`**:
```
/usr/bin/aarch64-linux-gnu-ld.bfd: unrecognized option '-Wl,--no-warn-rwx-segment'
make: *** [.../build/fvp/release/bl2.elf] Error 1
```
Two problems, one root cause:
1. The `sun55iw3-syterkit` family (Avaota-A1) uses **SyterKit** as its bootloader — `write_uboot_platform` says as much, and the `syterkit-allwinner` extension just **downloads a prebuilt, self-contained SyterKit image**. It builds/needs **no TF-A**.
2. But the family never overrode `ATFSOURCE`, so it inherited [`arm64.conf`'s default](config/sources/arm64.conf) (mainline ARM TF-A) and compiled the **default `PLAT=fvp`** (the ARM simulator — useless here), which then fails to link: TF-A links `bl*.elf` with `ld` directly, and the framework passed the flag in gcc form (`-Wl,…`), which `ld.bfd` rejects.

## Fix
Set `ATFSOURCE="none"` in the family — [`atf.sh` skips the ATF build](lib/functions/compilation/atf.sh#L11) when `ATFSOURCE` is empty/`none`. No pointless fvp TF-A, no link failure. Same pattern as `genio.conf`.

This is the correct fix rather than the `ATF_SKIP_LDFLAGS_WL=yes` band-aid, which would still build a useless fvp TF-A.

Config is bash-valid. Unrelated to any other in-flight PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed builds for the `sun55iw3-syterkit` family by disabling the unnecessary ARM TF-A build when using its prebuilt bootloader image.
  * Prevented ATF-related build and linking failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->