### PR TITLE
u-boot: fix old pylibfdt build against SWIG ≥ 4.3 (trixie)

### DIFF
--- a/extensions/uboot-fix-pylibfdt-swig.sh
+++ b/extensions/uboot-fix-pylibfdt-swig.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2013-2026 Igor Pecovnik, igor@armbian.com
+#
+# This file is a part of the Armbian Build Framework
+# https://github.com/armbian/build/
+#
+# Fix old U-Boot's pylibfdt failing to build against SWIG >= 4.3
+# (Debian trixie ships 4.3+).
+#
+# SWIG 4.3.0 gave SWIG_Python_AppendOutput() a third parameter (is_void),
+# so the 2-argument calls in old pylibfdt SWIG interfaces no longer compile:
+#
+#   scripts/dtc/pylibfdt/libfdt_wrap.c: error: too few arguments to
+#   function 'SWIG_Python_AppendOutput'
+#
+# Upstream (dtc/U-Boot >= v2026.07) switched to the version-agnostic
+# SWIG_AppendOutput() macro. Do the same substitution at build time on the
+# checked-in interface (libfdt.i / libfdt.i_shipped) and, if present, on an
+# already-generated wrapper (libfdt_wrap.c), so SWIG regenerates a wrapper
+# that compiles.
+#
+# Safe for all U-Boot versions: no-op when the old 2-arg call is absent.
+# Handles both the old (lib/libfdt/pylibfdt) and new (scripts/dtc/pylibfdt)
+# pylibfdt locations. Can be removed once all BOOTBRANCH versions ship the
+# SWIG_AppendOutput() form (>= v2026.07).
+
+function pre_config_uboot_target__fix_pylibfdt_swig() {
+	local patched=0 f
+	for f in \
+		scripts/dtc/pylibfdt/libfdt.i \
+		scripts/dtc/pylibfdt/libfdt.i_shipped \
+		scripts/dtc/pylibfdt/libfdt_wrap.c \
+		lib/libfdt/pylibfdt/libfdt.i \
+		lib/libfdt/pylibfdt/libfdt.i_shipped \
+		lib/libfdt/pylibfdt/libfdt_wrap.c; do
+
+		[[ -f "${f}" ]] || continue
+		# Only rewrite genuine 2-arg calls; the fixed 3-arg definition
+		# 'SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void)'
+		# and any SWIG_AppendOutput() use are left untouched.
+		grep -q 'SWIG_Python_AppendOutput(resultobj' "${f}" || continue
+
+		display_alert "Patching pylibfdt" "SWIG_Python_AppendOutput -> SWIG_AppendOutput in ${f}" "info"
+		sed -i 's/SWIG_Python_AppendOutput(resultobj/SWIG_AppendOutput(resultobj/g' "${f}"
+		patched=1
+	done
+
+	[[ "${patched}" -eq 1 ]] && display_alert "pylibfdt" "patched for SWIG >= 4.3 (SWIG_AppendOutput)" "info"
+
+	return 0
+}

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -68,6 +68,9 @@ function do_main_configuration() {
 	# Fix binman pkg_resources removal in setuptools >= 82. Can be removed when all U-Boot versions are >= v2025.10.
 	enable_extension "uboot-binman-fix-pkg-resources"
 
+	# Fix old U-Boot pylibfdt failing against SWIG >= 4.3 (trixie). No-op on newer U-Boot. Can be removed when all U-Boot versions are >= v2026.07.
+	enable_extension "uboot-fix-pylibfdt-swig"
+
 	# Network stack to use, default to network-manager; configuration can override this.
 	# Will be made read-only further down.
 	declare -g NETWORKING_STACK="${NETWORKING_STACK}"


### PR DESCRIPTION
## Problem

Boards on a **pre-v2026.07 U-Boot** fail to build host tools on **Debian trixie**, e.g. `uboot-station-m2-edge` ([ci run 29647723383](https://github.com/armbian/ci/actions/runs/29647723383/job/88089888008), Radxa fork `branch:rk35xx-2024.01`):

```
scripts/dtc/pylibfdt/libfdt_wrap.c:5581:17: error: too few arguments to function 'SWIG_Python_AppendOutput'
 5581 |   resultobj = SWIG_Python_AppendOutput(resultobj, val);
 1262 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
make[2]: *** [scripts/dtc/pylibfdt/Makefile:33: rebuild] Error 1
Error 2 occurred in main shell at lib/functions/compilation/uboot.sh:273
```

**SWIG 4.3.0** added a third parameter (`is_void`) to `SWIG_Python_AppendOutput()`; trixie ships ≥ 4.3. Old pylibfdt SWIG interfaces still call it with two args → won't compile. This hits the Radxa-fork boards, mainline v2024.04, and anything older.

(Distinct from the `distutils` failure in #10094 — that stops `setup.py` earlier; this is a C compile error after SWIG runs.)

## Fix

Auto-enabled extension `uboot-fix-pylibfdt-swig` that, before the U-Boot build, rewrites the 2-arg calls to the version-agnostic `SWIG_AppendOutput()` macro — the exact change dtc/U-Boot shipped in v2026.07:

```diff
- resultobj = SWIG_Python_AppendOutput(resultobj, val);
+ resultobj = SWIG_AppendOutput(resultobj, val);
```

- Patches both pylibfdt locations (`scripts/dtc/pylibfdt` and old `lib/libfdt/pylibfdt`) and any pre-generated `libfdt_wrap.c`.
- Guarded by `grep` — **no-op** when the source already uses `SWIG_AppendOutput` (≥ v2026.07). The 3-arg definition line is not matched.
- Mirrors the existing `uboot-binman-fix-pkg-resources` extension; enabled next to it in `main-config.sh`.

## Scope

Fixes all pre-v2026.07 boards at once (systemic), unlike the per-board bump in #10216 (turing-rk1). That bump is still worthwhile on its own merits; this extension is a no-op there.

## Test status

Needs a CI build of an affected board (e.g. `uboot-station-m2-edge`) on trixie to confirm green. Removable once all `BOOTBRANCH` versions are ≥ v2026.07.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when building older U-Boot versions with SWIG 4.3 and later.
  * Automatically applies the necessary pylibfdt compatibility fix during configuration.
  * Leaves newer U-Boot versions unchanged when no fix is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->