### PR TITLE
u-boot: don't error on implicit declarations (gcc ≥ 14 / trixie)

### DIFF
--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -188,9 +188,11 @@ function compile_uboot_target() {
 	local -a uboot_cflags_array=(
 		"-fdiagnostics-color=always" # color messages
 		"-Wno-error=maybe-uninitialized"
-		"-Wno-error=misleading-indentation"   # patches have mismatching indentation
-		"-Wno-error=attributes"               # for very old-uboots
-		"-Wno-error=address-of-packed-member" # for very old-uboots
+		"-Wno-error=misleading-indentation"        # patches have mismatching indentation
+		"-Wno-error=attributes"                    # for very old-uboots
+		"-Wno-error=address-of-packed-member"      # for very old-uboots
+		"-Wno-error=implicit-function-declaration" # gcc >= 14 (trixie) makes these hard errors; old u-boots miss #include <env.h> etc.
+		"-Wno-error=implicit-int"                  # companion to the above on gcc >= 14
 	)
 	if linux-version compare "${gcc_version_main}" ge "11.0"; then
 		uboot_cflags_array+=(


### PR DESCRIPTION
## Problem

With the SWIG 4.3 pylibfdt fix (#10217) in place, old vendor u-boots now get **past** host-tool generation and fail at the board compile on **gcc 14** (Debian trixie), e.g. `uboot-luckfox-core3566-vendor` ([ci run 29658106368](https://github.com/armbian/ci/actions/runs/29658106368/job/88121082226), Radxa fork `branch:rk35xx-2024.01`):

```
board/rockchip/evb_rk3568/evb_rk3568.c:58:25: error: implicit declaration of function 'env_set' [-Wimplicit-function-declaration]
make[1]: *** [scripts/Makefile.build:257: board/rockchip/evb_rk3568/evb_rk3568.o] Error 1
```

**gcc 14** promoted implicit function/int declarations from warning to a default **hard error**. The old u-boot source just misses newer includes (`env_set` lives in `<env.h>`).

## Fix

Add `-Wno-error=implicit-function-declaration` and its companion `-Wno-error=implicit-int` to `uboot_cflags_array` in `lib/functions/compilation/uboot.sh` (passed as both `CFLAGS` and `KCFLAGS`). This is the same treatment the surrounding flags already give other old-u-boot warnings (`-Wno-error=maybe-uninitialized`, `-Wno-error=array-parameter`, …).

`env_set()` returns `int`, so demoting the implicit declaration back to a warning is safe (no LP64 return-truncation hazard here).

## Sequence of trixie u-boot fixes

1. `distutils` removed in Python 3.13 → #10094
2. `SWIG_Python_AppendOutput` arg change (SWIG 4.3) → #10217
3. **implicit declarations are errors (gcc 14)** → this PR

Each one unmasks the next for old vendor u-boots; this is the third layer.

## Test status

Needs a CI build of `uboot-luckfox-core3566-vendor` (and siblings) on trixie to confirm green. Removable once all `BOOTBRANCH` versions build clean on gcc ≥ 14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved U-Boot compilation compatibility with newer GCC versions by preventing certain compiler warnings from being treated as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->