### PR TITLE
csc board: NORCO EMB-3531: Do not reset LTE moden

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3399-emb-3531.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3399-emb-3531.dts
@@ -150,6 +150,23 @@
 		regulator-boot-on;
 	};
 
+	/*
+	 * PERST# pin in the Mini PCIe slot.
+	 * This needs to be pulled high to enable LTE modules such as the Quectel EC20.
+	 */
+	regulator-perst {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&perst_pin>;
+		regulator-name = "perst";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
 	regulator-wifi-en {
 		compatible = "regulator-fixed";
 		enable-active-high;
@@ -549,8 +566,6 @@
 	ep-gpios = <&gpio4 RK_PD5 GPIO_ACTIVE_HIGH>;
 	num-lanes = <4>;
 	max-link-speed = <2>;
-	pinctrl-0 = <&pcie_clkreqn>;
-	pinctrl-names = "default";
 	status = "okay";
 };
 
@@ -585,12 +600,6 @@
 		};
 	};
 
-	pcie {
-		pcie_clkreqn: pci-clkreqn {
-			rockchip,pins = <2 RK_PD2 2 &pcfg_pull_none>;
-		};
-	};
-
 	pmic {
 		pmic_int_l: pmic-int-l {
 			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
@@ -612,6 +621,10 @@
 
 		otg_vbus_en: otg-vbus-en {
 			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		perst_pin: perst-en {
+			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 
 		wifi_en: wifi-en {

--- a/patch/kernel/archive/rockchip64-7.1/dt/rk3399-emb-3531.dts
+++ b/patch/kernel/archive/rockchip64-7.1/dt/rk3399-emb-3531.dts
@@ -150,6 +150,23 @@
 		regulator-boot-on;
 	};
 
+	/*
+	 * PERST# pin in the Mini PCIe slot.
+	 * This needs to be pulled high to enable LTE modules such as the Quectel EC20.
+	 */
+	regulator-perst {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&perst_pin>;
+		regulator-name = "perst";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
 	regulator-wifi-en {
 		compatible = "regulator-fixed";
 		enable-active-high;
@@ -549,8 +566,6 @@
 	ep-gpios = <&gpio4 RK_PD5 GPIO_ACTIVE_HIGH>;
 	num-lanes = <4>;
 	max-link-speed = <2>;
-	pinctrl-0 = <&pcie_clkreqn>;
-	pinctrl-names = "default";
 	status = "okay";
 };
 
@@ -585,12 +600,6 @@
 		};
 	};
 
-	pcie {
-		pcie_clkreqn: pci-clkreqn {
-			rockchip,pins = <2 RK_PD2 2 &pcfg_pull_none>;
-		};
-	};
-
 	pmic {
 		pmic_int_l: pmic-int-l {
 			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
@@ -612,6 +621,10 @@
 
 		otg_vbus_en: otg-vbus-en {
 			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		perst_pin: perst-en {
+			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 
 		wifi_en: wifi-en {

--- a/patch/kernel/archive/rockchip64-7.2/dt/rk3399-emb-3531.dts
+++ b/patch/kernel/archive/rockchip64-7.2/dt/rk3399-emb-3531.dts
@@ -150,6 +150,23 @@
 		regulator-boot-on;
 	};
 
+	/*
+	 * PERST# pin in the Mini PCIe slot.
+	 * This needs to be pulled high to enable LTE modules such as the Quectel EC20.
+	 */
+	regulator-perst {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&perst_pin>;
+		regulator-name = "perst";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
 	regulator-wifi-en {
 		compatible = "regulator-fixed";
 		enable-active-high;
@@ -549,8 +566,6 @@
 	ep-gpios = <&gpio4 RK_PD5 GPIO_ACTIVE_HIGH>;
 	num-lanes = <4>;
 	max-link-speed = <2>;
-	pinctrl-0 = <&pcie_clkreqn>;
-	pinctrl-names = "default";
 	status = "okay";
 };
 
@@ -585,12 +600,6 @@
 		};
 	};
 
-	pcie {
-		pcie_clkreqn: pci-clkreqn {
-			rockchip,pins = <2 RK_PD2 2 &pcfg_pull_none>;
-		};
-	};
-
 	pmic {
 		pmic_int_l: pmic-int-l {
 			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
@@ -612,6 +621,10 @@
 
 		otg_vbus_en: otg-vbus-en {
 			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		perst_pin: perst-en {
+			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 
 		wifi_en: wifi-en {

--- a/patch/u-boot/v2026.01/board_norco-emb-3531/add-board-norco-emb-3531.patch
+++ b/patch/u-boot/v2026.01/board_norco-emb-3531/add-board-norco-emb-3531.patch
@@ -92,10 +92,10 @@ index 00000000..6c6fe382
 +CONFIG_ERRNO_STR=y
 diff --git a/dts/upstream/src/arm64/rockchip/rk3399-emb-3531.dts b/dts/upstream/src/arm64/rockchip/rk3399-emb-3531.dts
 new file mode 100644
-index 00000000..86eb46c7
+index 00000000..298e262d
 --- /dev/null
 +++ b/dts/upstream/src/arm64/rockchip/rk3399-emb-3531.dts
-@@ -0,0 +1,782 @@
+@@ -0,0 +1,795 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -246,6 +246,23 @@ index 00000000..86eb46c7
 +		regulator-name = "otg_vbus";
 +		regulator-always-on;
 +		regulator-boot-on;
++	};
++
++	/*
++	 * PERST# pin in the Mini PCIe slot.
++	 * This needs to be pulled high to enable LTE modules such as the Quectel EC20.
++	 */
++	regulator-perst {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&perst_pin>;
++		regulator-name = "perst";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
 +	};
 +
 +	regulator-wifi-en {
@@ -647,8 +664,6 @@ index 00000000..86eb46c7
 +	ep-gpios = <&gpio4 RK_PD5 GPIO_ACTIVE_HIGH>;
 +	num-lanes = <4>;
 +	max-link-speed = <2>;
-+	pinctrl-0 = <&pcie_clkreqn>;
-+	pinctrl-names = "default";
 +	status = "okay";
 +};
 +
@@ -683,12 +698,6 @@ index 00000000..86eb46c7
 +		};
 +	};
 +
-+	pcie {
-+		pcie_clkreqn: pci-clkreqn {
-+			rockchip,pins = <2 RK_PD2 2 &pcfg_pull_none>;
-+		};
-+	};
-+
 +	pmic {
 +		pmic_int_l: pmic-int-l {
 +			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
@@ -710,6 +719,10 @@ index 00000000..86eb46c7
 +
 +		otg_vbus_en: otg-vbus-en {
 +			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		perst_pin: perst-en {
++			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
 +
 +		wifi_en: wifi-en {


### PR DESCRIPTION
# Description

Remove the incorrect PCIe pinctrl and enable the USB LTE modem functionality for the Mini PCIe slot.

https://github.com/armbian/build/pull/9456#issuecomment-4988684462

# How Has This Been Tested?

After re-compiling and flashing the image, ensure that the PCIe NIC still works, measure the voltage level of PERST#, and test the LTE modem functionality.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added U-Boot board support for the NORCO EMB-3531 RK3399 platform.
  - Added board-specific device-tree configuration for storage, networking, USB, PCIe, regulators, and peripherals.
  - Added PCIe Mini PCIe reset control for improved LTE module support.
  - Updated PCIe link configuration and initialization settings.
  - Added a dedicated U-Boot configuration target for the board.

- **Bug Fixes**
  - Adjusted PCIe pin configuration to prevent conflicts with clock-request signaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->