### PR TITLE
git: match safe.directory literally, not as a regex

### DIFF
--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -57,7 +57,15 @@ function git_ensure_safe_directory() {
 		local git_dir="$1"
 		if [[ -e "$1/.git" ]]; then
 			display_alert "git: Marking all directories as safe, which should include" "$git_dir" "debug"
-			git config --global --get safe.directory "$1" > /dev/null || regular_git config --global --add safe.directory "$1"
+			# NB: 'git config --get safe.directory <path>' treats <path> as a
+			# regex, so a shorter path (…/amlogic-boot-fip) spuriously matches an
+			# already-added longer one (…/amlogic-boot-fip-jethub) and we skip
+			# adding it -> later "dubious ownership". Compare values literally.
+			local existing found=no
+			while IFS= read -r existing; do
+				[[ "$existing" == "$git_dir" ]] && { found=yes; break; }
+			done < <(git config --global --get-all safe.directory 2> /dev/null)
+			[[ "$found" == yes ]] || regular_git config --global --add safe.directory "$git_dir"
 		fi
 	else
 		display_alert "git not installed" "a true wonder how you got this far without git - it will be installed for you" "warn"


### PR DESCRIPTION
## Problem

jethub (and other meson64) u-boot builds fail during source fetch — not compile — with:

\`\`\`
fatal: detected dubious ownership in repository at '/armbian/cache/sources/amlogic-boot-fip'
...
[💥] improved_git, too many retries  git fetch ... https://github.com/LibreELEC/amlogic-boot-fip master
[💥] Error 17 occurred in main shell at /armbian/lib/functions/general/git.sh:51
\`\`\`

(e.g. https://github.com/armbian/ci/actions/runs/29671233407/job/88154298406)

## Root cause

\`git_ensure_safe_directory()\` probed for an existing entry with:

\`\`\`bash
git config --global --get safe.directory "$1"
\`\`\`

The value argument to \`git config --get\` is a **regex**, so a shorter path is a prefix-regex of a longer one. On meson64/jethub boards two FIP repos are fetched, in order:

1. \`amlogic-boot-fip-jethub\` — [\`config/sources/families/jethub.conf\`](../blob/main/config/sources/families/jethub.conf) — adds \`…/amlogic-boot-fip-jethub\` to global \`safe.directory\`
2. \`amlogic-boot-fip\` — [\`config/sources/families/include/meson64_common.inc\`](../blob/main/config/sources/families/include/meson64_common.inc)

For repo 2, \`--get safe.directory "…/amlogic-boot-fip"\` matches the already-present \`…/amlogic-boot-fip-jethub\` as a regex → returns success → the \`|| add\` is skipped → the repo is never marked safe. git running as root over the bind-mounted, non-root-owned cache then aborts with "dubious ownership" and the fetch fails after 3 retries.

It only surfaces on runners with a persistent, non-root-owned source cache, which is why it looks intermittent/runner-specific.

## Fix

Enumerate \`--get-all safe.directory\` and compare each value **literally** instead of via regex. Fixes the false match for any prefix-colliding repo pair, stays idempotent (no duplicate entries), and is portable to focal's git 2.25 (no \`--fixed-value\`, which needs 2.30).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git safe-directory handling to recognize exact path matches.
  * Prevented incorrectly treating similar paths as already trusted.
  * Avoided adding duplicate safe-directory entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->