### PR TITLE
uboot: demote int-conversion & incompatible-pointer-types to warnings (gcc 14)

### DIFF
--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -193,6 +193,8 @@ function compile_uboot_target() {
 		"-Wno-error=address-of-packed-member"      # for very old-uboots
 		"-Wno-error=implicit-function-declaration" # gcc >= 14 (trixie) makes these hard errors; old u-boots miss #include <env.h> etc.
 		"-Wno-error=implicit-int"                  # companion to the above on gcc >= 14
+		"-Wno-error=int-conversion"                # gcc >= 14 hard error; vendor u-boots (e.g. Realtek rtd16xxb) assign ptr<->int
+		"-Wno-error=incompatible-pointer-types"    # gcc >= 14 hard error; vendor driver callback signatures mismatch
 	)
 	if linux-version compare "${gcc_version_main}" ge "11.0"; then
 		uboot_cflags_array+=(


### PR DESCRIPTION
## Problem

The Realtek rtd1619b vendor u-boot (`xpressreal-t3-vendor`, `BOOTSOURCE=XpressReal/u-boot` `v2024.01-xpressreal`) fails to **compile** under the GCC 14 (trixie) toolchain:

```
arch/arm/mach-realtek/mcp.c:121: error: assignment to 'unsigned int' from 'unsigned int *' makes integer from pointer without a cast [-Wint-conversion]
drivers/phy/realtek/phy-rtk-usb3.c:645: error: ... from 'const struct phy_cfg *' ... [-Wint-conversion]
drivers/phy/realtek/phy-rtk-usb2.c:1193: error: ... [-Wint-conversion]
drivers/mmc/rtkemmc_rtd161xb.c:2385: error: ... incompatible pointer type ... [-Wincompatible-pointer-types]
-> Error 2 occurred in main shell at lib/functions/compilation/uboot.sh:275
```

(e.g. https://github.com/armbian/ci/actions/runs/29671922467/job/88158297124)

GCC 14 promotes `-Wint-conversion` and `-Wincompatible-pointer-types` from warnings to **hard errors** by default. These files are Realtek vendor platform code (`mach-realtek`, `drivers/phy/realtek`, `rtkemmc`) that does not exist upstream, so bumping to mainline u-boot is not an option for this SoC — the board can only boot from the vendor tree.

## Fix

`uboot_cflags_array` in `lib/functions/compilation/uboot.sh` already demotes the same GCC-14 class of newly-hard errors (`implicit-function-declaration`, `implicit-int`, `array-parameter`, …). Add the two missing ones so legacy/vendor trees keep building. Both warnings exist in every relevant GCC (≥5), so no version guard is needed, and a clean modern u-boot emits neither — no behavior change there.

Verified: `xpressreal-t3-vendor` u-boot now compiles.

This is a pragmatic unblock (demote to warning, matching existing convention); it masks rather than fixes the underlying vendor-code pointer/int mismatches, which would ideally be corrected in the XpressReal fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer GCC versions when building vendor U-Boot code.
  * Prevented specific compiler warnings from unnecessarily stopping the build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->