### PR TITLE
git: silence spurious SUBSHELL error annotation from safe.directory check

### DIFF
--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -62,9 +62,17 @@ function git_ensure_safe_directory() {
 			# already-added longer one (…/amlogic-boot-fip-jethub) and we skip
 			# adding it -> later "dubious ownership". Compare values literally.
 			local existing found=no
+			# Suppress only the two benign exit codes from --get-all: 1 when the key is
+			# unset (first run) and 141 (SIGPIPE) when the loop's 'break' closes the pipe
+			# early. Both are the last command in this '<(…)' process-substitution
+			# subshell, which inherits the framework's errtrace ERR trap and would
+			# otherwise emit a spurious "Error occurred in SUBSHELL git.sh" annotation.
+			# Any other exit code is a real git config failure and is deliberately left
+			# to trip the ERR trap (unlike a blanket '|| true', which would hide it).
 			while IFS= read -r existing; do
 				[[ "$existing" == "$git_dir" ]] && { found=yes; break; }
-			done < <(git config --global --get-all safe.directory 2> /dev/null)
+			done < <(git config --global --get-all safe.directory 2> /dev/null \
+				|| { rc=$?; [[ "$rc" == 1 || "$rc" == 141 ]]; })
 			[[ "$found" == yes ]] || regular_git config --global --add safe.directory "$git_dir"
 		fi
 	else


### PR DESCRIPTION
Since **21b73bcef** ("git: match safe.directory literally, not as a regex", merged today), some uboot/kernel artifact jobs are flagged red in GitHub Actions with:

```
Error 1 occurred in SUBSHELL SUBSHELL at /armbian/lib/functions/general/git.sh:55
```

even though the build succeeds ("error but does not break compilation").

## Root cause

`git_ensure_safe_directory()` reads existing entries via a process substitution:

```bash
done < <(git config --global --get-all safe.directory 2> /dev/null)
```

`git config --get-all` exits **1** when the key is unset (first run) and gets **SIGPIPE (141)** when the loop `break`s before reading all entries. That is the last command in the `<(…)` subshell, which inherits the framework `errtrace` ERR trap, so the non-zero exit fires the trap ([traps.sh:66](https://github.com/armbian/build/blob/main/lib/functions/logging/traps.sh#L66)) and prints the SUBSHELL error — which GHA renders as an error annotation. The loop still adds the entry, so the build recovers; only a few jobs hit the failing path, which is why it looks random.

## Fix

Suppress **only** the two benign exit codes and let anything else trip the ERR trap:

```bash
done < <(git config --global --get-all safe.directory 2> /dev/null \
    || { rc=$?; [[ "$rc" == 1 || "$rc" == 141 ]]; })
```

A blanket `|| true` would also hide a genuine `git config` failure (e.g. a corrupt global config), so it is deliberately avoided. The literal-match behaviour from 21b73bcef is unchanged.

## Verification

Exercised the exact construct under `set -o errtrace` with a trap mimicking `traps.sh`:

| `git config` exit | result |
|---|---|
| 0 | silent |
| 1 (key unset) | silent |
| 141 (SIGPIPE from `break`) | silent |
| 3 (real failure) | **ERR trap fires** |

Loop always finishes and adds the entry. Affects os and ci equally; noise/annotation fix with real-error propagation preserved, no behavioural change to the happy path.