### PR TITLE
arduino: fetch qcombin at image-build time, not config time

### DIFF
--- a/extensions/image-output-arduino.sh
+++ b/extensions/image-output-arduino.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 
-# Fetch Qualcomm flash binaries early in the build
-function post_family_config__fetch_qcombin() {
-	[[ "${CONFIG_DEFS_ONLY}" == "yes" ]] && return 0 # skip fetch during config-dump-json (no $HOME, no network needed)
-	display_alert "Fetching qcombin" "${BOARD}" "info"
-	fetch_from_repo "https://github.com/armbian/qcombin" "qcombin" "branch:main"
-}
-
 declare -g ARDUINO_ROOTFS_LOOP=""
 declare -g ARDUINO_ROOTFS_MOUNT=""
 
 # Convert standard Armbian image into a QDL-flashable archive for Arduino UNO Q
 function post_build_image__900_convert_to_arduino_img() {
 	[[ -z $version ]] && exit_with_error "version is not set"
+
+	# Fetch the Qualcomm QDL flash binaries (qcombin) here, at the point of use.
+	# This deliberately does NOT run at config time (post_family_config): that hook
+	# also fires for download-artifact and config-dump-json, which run with a
+	# throwaway/absent $HOME, so 'git config --global' inside fetch_from_repo fails
+	# (exit 128) - and qcombin is only ever consumed when actually building an image.
+	display_alert "Fetching qcombin" "${BOARD}" "info"
+	fetch_from_repo "https://github.com/armbian/qcombin" "qcombin" "branch:main"
 
 	display_alert "Creating QDL flash archive" "${version}" "info"
 


### PR DESCRIPTION
The Arduino UNO Q (Qualcomm QRB2210) image extension fetched the QDL flash binaries (`qcombin`) from a **config-phase** hook, `post_family_config__fetch_qcombin`.

## Problem

`post_family_config` fires for **every** config-prepare — `download-artifact`, `artifact-config-dump-json`, and image builds alike — not just image builds. In `download-artifact` mode (e.g. the parallel `debs-to-repo-download` workers, which run with a throwaway `HOME=/armbian/.tmp/work-<uuid>`), `git config --global --add safe.directory` inside `fetch_from_repo` fails:

```
Error 128 ... git --no-pager config --global --add safe.directory /armbian/cache/sources/qcombin
      git_ensure_safe_directory() --> git.sh
                fetch_from_repo() --> git.sh
   post_family_config__fetch_qcombin() --> extensions/image-output-arduino.sh:7
```

The old hook only guarded `CONFIG_DEFS_ONLY` (the config-dump path — *"no $HOME"*); `download-artifact` was left unguarded. arduino-uno-q is the **only** board that does a git fetch at config-prepare time, so it is the only one that hits this. In the `debs-to-repo-download` job it shows up as `download_ok: False` for the arduino-uno-q kernel and uboot artifacts (non-fatal — the debs are simply dropped).

## Fix

`qcombin` is consumed solely by `post_build_image__900_convert_to_arduino_img` (assembling the QDL flash archive from `${QCOMBIN_DIR}/Agatti/...`). Move the fetch there, at the point of use. It then only runs during real image builds — which have a proper `$HOME` and network — and the `CONFIG_DEFS_ONLY` guard is no longer needed.

- No behavioural change for image builds (qcombin is fetched right before it is used).
- Eliminates the exit-128 failure and a pointless clone during every arduino `download-artifact` / config-dump.
- shellcheck clean.

Independent of #10225 (that one silences the benign safe.directory *read*; this removes the fatal *write* for arduino).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * QDL flash binaries are now fetched only when building an Arduino QDL flash archive.
  * Configuration-only operations no longer trigger unnecessary repository downloads or related processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->