### PR TITLE
sc8280xp: fix wrong LINUXCONFIG name for the sc8280xp branch

### DIFF
--- a/config/sources/families/sc8280xp.conf
+++ b/config/sources/families/sc8280xp.conf
@@ -24,7 +24,11 @@ case $BRANCH in
 		declare -g KERNEL_MAJOR_MINOR="7.0"
 		declare -g KERNELSOURCE='https://github.com/steev/linux.git'
 		declare -g KERNELBRANCH='branch:lenovo-x13s-linux-7.0.y'
-		declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}"
+		# LINUXCONFIG intentionally not set: the default (linux-${LINUXFAMILY}-${BRANCH}
+		# = linux-sc8280xp-sc8280xp) matches the shipped config file, same as the
+		# vendor/edge branches below. The old "linux-${ARCH}-${BRANCH}" override pointed
+		# at a non-existent linux-arm64-sc8280xp.config (leftover from the board->family
+		# refactor that renamed the configs to linux-sc8280xp-*).
 		declare -g GRUB_CMDLINE_LINUX_DEFAULT="clk_ignore_unused pd_ignore_unused arm64.nopauth efi=noruntime"
 		;;
 


### PR DESCRIPTION
The JSON-matrix (prepare) job logs a non-fatal error for `thinkpad-x13s`/`sc8280xp`:

```
[LEAKED]:sha256sum: config/kernel/linux-arm64-sc8280xp.config: No such file or directory
Error 1 occurred in ... hash-files.sh:74
→ Failed config up-to-date check target, ignoring
```

## Cause

The `sc8280xp` branch in [`config/sources/families/sc8280xp.conf`](config/sources/families/sc8280xp.conf) sets:

```bash
declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}"   # → linux-arm64-sc8280xp
```

but no such config exists. The shipped files are `linux-sc8280xp-*`:

```
config/kernel/linux-sc8280xp-sc8280xp.config
config/kernel/linux-sc8280xp-vendor.config
config/kernel/linux-sc8280xp-edge.config
```

This is leftover from **e4678b604** (board → family refactor), which renamed the config files to `linux-sc8280xp-*` but kept the old `${ARCH}`-based override.

The `vendor` and `edge` branches dont set `LINUXCONFIG` at all — [`common.conf`](config/sources/common.conf#L132) defaults it (only when unset) to `linux-${LINUXFAMILY}-${BRANCH}`, which resolves to the correct `linux-sc8280xp-vendor` / `linux-sc8280xp-edge`. The family conf is sourced *before* common.conf, so a value set in the branch is kept and the default is skipped — which is why only the `sc8280xp` branch is broken.

## Fix

Drop the wrong override so the `sc8280xp` branch behaves like vendor/edge: `common.conf` defaults `LINUXCONFIG` to `linux-sc8280xp-sc8280xp`, which exists.

Verified: `LINUXFAMILY=sc8280xp`, `BRANCH=sc8280xp` → `linux-sc8280xp-sc8280xp.config` is present. shellcheck: no new findings.

Note: this is the *config-file* half of the sc8280xp matrix noise; the other half (the `raw.githubusercontent` Makefile-fetch flakiness for `steev/linux`) is a separate reliability issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected kernel configuration selection for the `sc8280xp` branch.
  * Builds now use the standard family-based configuration naming, including vendor and edge variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->