### PR TITLE
k3: sk-am62-lp: shrink R5 SPL to fit SRAM + silence k3 cp noise

### DIFF
--- a/config/sources/families/include/k3_common.inc
+++ b/config/sources/families/include/k3_common.inc
@@ -85,8 +85,14 @@ function pre_config_uboot_target__build_first_stage() {
 }
 
 function post_uboot_custom_postprocess__update_uboot_names() {
-	cp ${TISPL_FILE} tispl.bin || true
-	cp ${UBOOT_FILE} u-boot.img || true
+	# Only rename when the board actually declares a differently-named signed
+	# output. Boards that don't set these (e.g. sk-am62-lp) already have binman's
+	# tispl.bin/u-boot.img; the old unconditional 'cp ${VAR} tispl.bin || true'
+	# ran as 'cp tispl.bin' with the var empty, logging a spurious
+	# "cp: missing destination file operand" that was only hidden by '|| true'.
+	[[ -n "${TISPL_FILE}" ]] && cp "${TISPL_FILE}" tispl.bin
+	[[ -n "${UBOOT_FILE}" ]] && cp "${UBOOT_FILE}" u-boot.img
+	return 0
 }
 
 function pre_prepare_partitions() {

--- a/patch/u-boot/u-boot-k3/am62x-lpsk-r5-drop-spi-nand-spl-to-fit-sram.patch
+++ b/patch/u-boot/u-boot-k3/am62x-lpsk-r5-drop-spi-nand-spl-to-fit-sram.patch
@@ -1,0 +1,51 @@
+Reduce am62x_lpsk R5 SPL so it fits the SRAM size limit
+
+The R5 first-stage SPL (tiboot3) for SK-AM62-LP is built from the stock TI
+am62x_lpsk_r5_defconfig, which is am62x_evm_r5_defconfig plus a SPI-NAND boot
+stack (SPL MTD/NAND loaders + the DM_MTD/MTD_SPI_NAND framework and vendor
+drivers). With the 12.00.00.07 baseline that stack pushes the R5 SPL past the
+on-chip SRAM budget:
+
+    spl/u-boot-spl.bin exceeds file size limit:
+      limit:  0x30210 bytes
+      actual: 0x34828 bytes
+      excess: 0x4618 bytes
+
+Armbian builds this board as an SD/eMMC image (tiboot3 is placed on the SD
+card and loaded from MMC by the ROM), so the R5 SPL never boots from SPI-NAND
+and the whole MTD/SPI-NAND stack is dead weight in the first stage. Drop it so
+the R5 SPL matches the EVM R5 config (which fits) plus only the LP-SK device
+tree. This affects only tiboot3 (the R5 first stage); the A53 SPL and u-boot
+proper (am62x_lpsk_a53_defconfig) are unchanged, so runtime OSPI/MTD access is
+retained. The generic CONFIG_SPL_DM_DEVICE_REMOVE is kept.
+
+Booting from SPI-NAND with this u-boot is no longer possible, which Armbian
+does not do for this board.
+
+diff --git a/configs/am62x_lpsk_r5_defconfig b/configs/am62x_lpsk_r5_defconfig
+--- a/configs/am62x_lpsk_r5_defconfig
++++ b/configs/am62x_lpsk_r5_defconfig
+@@ -5,23 +5,4 @@
+ CONFIG_DEFAULT_DEVICE_TREE="k3-am62-r5-lp-sk"
+ CONFIG_SOC_K3_AM625=y
+ CONFIG_TARGET_AM625_R5_EVM=y
+-CONFIG_SPL_MTD=y
+-CONFIG_SPL_MTD_LOAD=y
+-CONFIG_SPL_MTD_NAND_LOAD=y
+-CONFIG_SPL_NAND_SPI_SUPPORT=y
+ CONFIG_SPL_DM_DEVICE_REMOVE=y
+-CONFIG_DM_MTD=y
+-CONFIG_MTD_SPI_NAND=y
+-CONFIG_MTD_SPI_NAND_WINBOND=y
+-CONFIG_MTD_SPI_NAND_MICRON=y
+-CONFIG_MTD_SPI_NAND_GIGADEVICE=y
+-# CONFIG_MTD_SPI_NAND_ALLIANCEMEMORY is not set
+-# CONFIG_MTD_SPI_NAND_ATO is not set
+-# CONFIG_MTD_SPI_NAND_ESMT is not set
+-# CONFIG_MTD_SPI_NAND_FMSH is not set
+-# CONFIG_MTD_SPI_NAND_FORESEE is not set
+-# CONFIG_MTD_SPI_NAND_MACRONIX is not set
+-# CONFIG_MTD_SPI_NAND_PARAGON is not set
+-# CONFIG_MTD_SPI_NAND_SKYHIGH is not set
+-# CONFIG_MTD_SPI_NAND_TOSHIBA is not set
+-# CONFIG_MTD_SPI_NAND_XTX is not set


### PR DESCRIPTION
The `uboot-sk-am62-lp-vendor` artifact fails to build — the **R5 first-stage SPL** (`tiboot3`) overflows the on-chip SRAM budget:

```
spl/u-boot-spl.bin exceeds file size limit:
  limit:  0x30210 bytes
  actual: 0x34828 bytes
  excess: 0x4618 bytes
make[1]: *** [Makefile:2359: spl/u-boot-spl.bin] Error 1
```

## Cause

`am62x_lpsk_r5_defconfig` (TI 12.00.00.07) is `#include <am62x_evm_r5_defconfig>` **plus a SPI-NAND boot stack** — the SPL MTD/NAND loaders and the `DM_MTD`/`MTD_SPI_NAND` framework + vendor drivers. That stack (~18 KB) is exactly what pushes the R5 SPL past the limit; the EVM R5 config (used by sk-am62b, which builds fine) does not have it.

Armbian ships this board as an **SD/eMMC** image — `tiboot3.bin` is written to the SD card and loaded from MMC by the ROM — so the R5 SPL never boots from SPI-NAND and the whole stack is dead weight in the first stage.

## Changes

**1. `k3: sk-am62-lp: shrink R5 SPL to fit SRAM`** — new u-boot patch in `patch/u-boot/u-boot-k3/` (the k3 family default `BOOTPATCHDIR`) that drops the SPI-NAND SPL loaders and the MTD framework/drivers from `am62x_lpsk_r5_defconfig`, leaving it as the EVM R5 config + the LP-SK device tree. Only `tiboot3` (R5 first stage) is affected; the A53 SPL and u-boot proper (`am62x_lpsk_a53_defconfig`) are unchanged, so runtime OSPI/MTD access is retained. Booting *this* u-boot from SPI-NAND is no longer possible, which Armbian does not do for this board.

**2. `k3: dont run cp on unset TISPL_FILE/UBOOT_FILE`** — `post_uboot_custom_postprocess__update_uboot_names()` ran `cp ${TISPL_FILE} tispl.bin || true` unconditionally; boards that dont set those vars (like sk-am62-lp) expanded them to nothing → `cp tispl.bin` → `cp: missing destination file operand`, hidden only by `|| true`. Now guarded so it only copies when a source name is set (and the vars are quoted). Pre-existing noise affecting every k3 board without those vars.

## Validation

Local `./compile.sh uboot BOARD=sk-am62-lp BRANCH=vendor` (u-boot 2026.01 / TI 12.00.00.07):

- R5 SPL builds clean — **no size overflow**.
- Full artifact packages: `linux-u-boot-sk-am62-lp-vendor_2026.01-S2549-Pe178-H4a87-Vd147-Bdd54-R448a_arm64.deb` (patch-hash `Pe178` confirms the patch applied).
- No `cp: missing destination` noise with change #2.

⚠️ **Needs a card boot smoke on real SK-AM62-LP hardware before merge** — change #1 alters what goes into `tiboot3` (the R5 first stage). Change #2 is build-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot artifact generation by avoiding unnecessary copy attempts when artifact names are not configured.
  * Reduced AM62x LP SK R5 SPL size to fit on-chip SRAM limits.

* **Compatibility**
  * SPI-NAND booting is no longer supported on the AM62x LP SK with this U-Boot configuration.
  * Existing A53 SPL, U-Boot, and runtime OSPI/MTD functionality remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->