### PR TITLE
config: bootscripts: adjust meson64 U-Boot addresses for 512MB RAM boards

### DIFF
--- a/config/bootscripts/boot-meson64.cmd
+++ b/config/bootscripts/boot-meson64.cmd
@@ -3,7 +3,7 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-setenv scriptaddr "0x10000000"
+setenv scriptaddr "0x08000000"
 setenv kernel_addr_r "0x08080000"
 setenv fdt_addr_r "0x4080000"
 setenv overlay_error "false"

--- a/config/bootscripts/boot-meson64.cmd
+++ b/config/bootscripts/boot-meson64.cmd
@@ -3,8 +3,8 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-setenv scriptaddr "0x32000000"
-setenv kernel_addr_r "0x34000000"
+setenv scriptaddr "0x10000000"
+setenv kernel_addr_r "0x08080000"
 setenv fdt_addr_r "0x4080000"
 setenv overlay_error "false"
 # default values


### PR DESCRIPTION
Updated memory addresses for script and kernel in boot configuration, to fix a bug that impeded the OS boot on Radxa Zero models having less than 1 GB RAM (tested). See issue (and attached image below):
https://github.com/armbian/build/issues/10231

### Description
This PR addresses a critical boot loop issue on low-RAM Amlogic meson64 boards (such as the Radxa Zero 512MB variant). 

### Context
The default hardware configuration template assigned `scriptaddr` to `0x32000000` (800MB) and `kernel_addr_r` to `0x34000000` (832MB). While this works flawlessly on 1GB, 2GB, or 4GB models, it causes an immediate out-of-bounds memory allocation crash and silent CPU boot loop on 512MB hardware SKUs.

### Solution
Lowered `scriptaddr` to `0x10000000` (256MB) and `kernel_addr_r` to `0x08080000` (128.5MB). This establishes a safe, lower common denominator that accommodates 512MB models perfectly without impacting variants with larger RAM capacities. Verified and fully working on physical hardware.

<img width="1240" height="1429" alt="Ram_error" src="https://github.com/user-attachments/assets/6cde069c-23ee-47e0-8eac-50667f38918b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the startup/boot configuration to adjust where boot scripts and the kernel are loaded and executed, improving compatibility and reliability during system startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->