### PR TITLE
k3: fit am62p/am62-lp R5 SPL into SRAM (GCC 13 + per-SoC size handling), fix tispl rename & u-boot artifact hashing

### DIFF
--- a/config/sources/families/include/k3_common.inc
+++ b/config/sources/families/include/k3_common.inc
@@ -60,8 +60,96 @@ function compile_k3_bootgen() {
 
 	if [[ "${BOOT_SOC}" != "am62l" ]]; then
 		pushd ${SRC}/cache/sources/u-boot-worktree/${BOOTDIR}/${BOOTBRANCH##*:} || exit
-		run_host_command_logged make -j$(nproc) CROSS_COMPILE=arm-linux-gnueabi- ARCH=arm O=build-r5 ${TIBOOT3_BOOTCONFIG}
-		run_host_command_logged make -j$(nproc) CROSS_COMPILE=arm-linux-gnueabi- ARCH=arm O=build-r5 BINMAN_INDIRS=${SRC}/cache/sources/ti-linux-firmware
+
+		# Build the R5 first-stage SPL (tiboot3) with GCC 13. GCC 14 (the Trixie
+		# default) produces oversized SPL code that overruns CONFIG_SPL_SIZE_LIMIT
+		# on am62p/am62-lp; GCC 13 is smaller and fits. Passed as CC (u-boot Kbuild
+		# honours a command-line CC); CROSS_COMPILE stays for binutils. Needs
+		# gcc-13-arm-linux-gnueabi (soft-float) in the build image.
+		declare r5_cc="CC=arm-linux-gnueabi-gcc-13"
+		# Be certain the pinned compiler is present and really is GCC 13: fail
+		# early and clearly rather than let a missing binary surface as a cryptic
+		# mid-build error, and never silently fall back to the default GCC (which
+		# would reintroduce the SPL oversize).
+		declare r5_gcc_major
+		r5_gcc_major="$(arm-linux-gnueabi-gcc-13 -dumpversion 2>/dev/null | cut -d. -f1 || true)"
+		[[ "${r5_gcc_major}" == "13" ]] || exit_with_error "K3 R5 SPL requires arm-linux-gnueabi-gcc-13" "found version '${r5_gcc_major:-none}'"
+		display_alert "K3 R5 SPL first-stage compiler" "arm-linux-gnueabi-gcc-13 (GCC ${r5_gcc_major})" "info"
+		run_host_command_logged make -j$(nproc) CROSS_COMPILE=arm-linux-gnueabi- ${r5_cc} ARCH=arm O=build-r5 ${TIBOOT3_BOOTCONFIG}
+
+		# Per-config R5 SPL size handling, on top of the GCC 13 build above. The
+		# vendor R5 defconfigs overrun CONFIG_SPL_SIZE_LIMIT; the remedy depends on
+		# the SoC's SRAM layout (see CONFIG_CUSTOM_SYS_INIT_SP_ADDR vs the limit).
+		# Only tiboot3 (R5 first stage) is affected; the A53 SPL and u-boot proper
+		# are untouched.
+		declare r5_config_changed="no"
+		case "${TIBOOT3_BOOTCONFIG}" in
+			am62px_evm_r5_defconfig)
+				# AM62Px (AM62P5): the R5 SPL overruns the enforced SPL_SIZE_LIMIT by
+				# ~0x1c8a-0x1dfe even at -Os, so size cuts alone cannot close it. Unlike
+				# AM625, this SoC has ~0xE7f0 of MCU SRAM headroom above the limit: the
+				# early stack pointer (CONFIG_CUSTOM_SYS_INIT_SP_ADDR) is at base+0x4a7f0
+				# and BSS at base+0x4b000, but SPL_SIZE_LIMIT is only 0x3C000 -- the
+				# image budget can grow well past 0x3C000 without touching stack/BSS.
+				# Raise SPL_SIZE_LIMIT/SPL_MAX_SIZE into that headroom and keep the -Os
+				# build for extra margin. All SPI + SPI-NAND boot paths are preserved;
+				# only the R5 first stage is affected.
+				display_alert "$BOARD" "Raising am62p R5 SPL size limit into SRAM headroom + building for size (-Os)" "info"
+				run_host_command_logged scripts/config --file build-r5/.config \
+					--set-val CONFIG_SPL_SIZE_LIMIT 0x40000 \
+					--set-val CONFIG_SPL_MAX_SIZE 0x3F000 \
+					--enable CONFIG_CC_OPTIMIZE_FOR_SIZE \
+					--disable CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE
+				r5_config_changed="yes"
+				;;
+			am62x_lpsk_r5_defconfig)
+				# AM625: SPL_SIZE_LIMIT (0x3A7F0) already sits exactly at the stack
+				# pointer (base+0x3A7F0), with BSS just above at 0x43c3b000 - there is
+				# no MCU SRAM to raise the limit into (unlike AM62Px, which has ~0xE7f0
+				# of headroom). So the fix here is purely subtractive: shrink the R5
+				# SPL image until it fits.
+				#
+				# am62x_lpsk = am62x_evm (which fits) + a SPI-NOR *and* SPI-NAND boot
+				# stack. Armbian boots tiboot3 from SD/eMMC-FAT and never from SPI-NOR
+				# or SPI-NAND, so both are dead weight in the first stage: drop the
+				# SPI-NOR chip drivers + spi-nor framework + the YMODEM UART-recovery
+				# loader, AND the SPI-NAND/MTD boot stack (SPL_MTD*, SPL_NAND_SPI,
+				# MTD_SPI_NAND, DM_MTD) that am62x_lpsk adds on top of am62x_evm. That
+				# reclaims well over the ~0xfe0 that dropping SPI-NOR + -Os alone left
+				# over on the newer vendor u-boot. olddefconfig cascades the deps.
+				#
+				# Also build tiboot3 for size: the R5 defconfig has no explicit
+				# CC_OPTIMIZE, so u-boot defaults to -O2 (PERFORMANCE); switch to -Os
+				# for margin. Only the R5 first stage is affected.
+				display_alert "$BOARD" "Dropping unused SPI-NOR + SPI-NAND boot stacks + building R5 SPL for size (-Os) to fit SRAM" "info"
+				run_host_command_logged scripts/config --file build-r5/.config \
+					--disable CONFIG_SPL_SPI_FLASH_SUPPORT \
+					--disable CONFIG_SPL_SPI_LOAD \
+					--disable CONFIG_SPL_DM_SPI_FLASH \
+					--disable CONFIG_SPL_SPI_FLASH_SFDP_SUPPORT \
+					--disable CONFIG_DM_SPI_FLASH \
+					--disable CONFIG_SPI_FLASH_SFDP_SUPPORT \
+					--disable CONFIG_SPI_FLASH_SOFT_RESET \
+					--disable CONFIG_SPI_FLASH_SOFT_RESET_ON_BOOT \
+					--disable CONFIG_SPI_FLASH_SPANSION \
+					--disable CONFIG_SPI_FLASH_S28HX_T \
+					--disable CONFIG_SPL_YMODEM_SUPPORT \
+					--disable CONFIG_SPL_MTD \
+					--disable CONFIG_SPL_MTD_LOAD \
+					--disable CONFIG_SPL_MTD_NAND_LOAD \
+					--disable CONFIG_SPL_NAND_SPI_SUPPORT \
+					--disable CONFIG_MTD_SPI_NAND \
+					--disable CONFIG_DM_MTD \
+					--enable CONFIG_CC_OPTIMIZE_FOR_SIZE \
+					--disable CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE
+				r5_config_changed="yes"
+				;;
+		esac
+		if [[ "${r5_config_changed}" == "yes" ]]; then
+			run_host_command_logged make -j$(nproc) CROSS_COMPILE=arm-linux-gnueabi- ${r5_cc} ARCH=arm O=build-r5 olddefconfig
+		fi
+
+		run_host_command_logged make -j$(nproc) CROSS_COMPILE=arm-linux-gnueabi- ${r5_cc} ARCH=arm O=build-r5 BINMAN_INDIRS=${SRC}/cache/sources/ti-linux-firmware
 		popd
 	fi
 }
@@ -84,6 +172,21 @@ function pre_config_uboot_target__build_first_stage() {
 			cp "${SRC}/cache/sources/u-boot-worktree/${BOOTDIR}/${BOOTBRANCH##*:}/build-r5/${SYSFW_FILE}" sysfw.itb
 		fi
 	fi
+}
+
+function post_uboot_custom_postprocess__update_uboot_names() {
+	# Rename a board's override output onto tispl.bin/u-boot.img, but only if it
+	# was actually produced, and never let the copy be fatal. Both an absent
+	# source and a failing cp trip Armbian's ERR trap, so guard on the file
+	# existing (an 'if', not '[[ -f ]] && cp', whose false test returns 1) and
+	# keep '|| true' on the cp. This matters because newer u-boot (mainline
+	# 2026.07 / recent TI SDK) renamed the GP outputs to ti-spl_unsigned.fit.*
+	# (source absent -> skip, fall back to binman's standard tispl.bin), and on
+	# GP parts binman can make the *_unsigned image and tispl.bin the same file,
+	# so 'cp src dst' errors with "are the same file" (present -> tolerate).
+	if [[ -f "${TISPL_FILE}" ]]; then cp "${TISPL_FILE}" tispl.bin || true; fi
+	if [[ -f "${UBOOT_FILE}" ]]; then cp "${UBOOT_FILE}" u-boot.img || true; fi
+	return 0
 }
 
 function pre_prepare_partitions() {

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -88,9 +88,13 @@ function artifact_uboot_prepare_version() {
 	hash_hooks="$(echo "${extension_hooks_hashed[@]}" | sha256sum | cut -d' ' -f1)"
 
 	# Hash the old-timey hooks and regular core functions (atf code, used by u-boot build process)
+	# calculate_hash_for_function_bodies skips functions that don't exist, so family-specific
+	# builders (e.g. K3's compile_k3_bootgen/optee, which are called from a hashed hook but whose
+	# bodies would otherwise not be hashed) can be listed here without affecting other families.
 	declare hash_functions="undetermined"
 	calculate_hash_for_function_bodies "uboot_custom_postprocess" "write_uboot_platform" "write_uboot_platform_mtd" \
-		"setup_write_uboot_platform" "compile_atf"
+		"setup_write_uboot_platform" "compile_atf" \
+		"compile_k3_bootgen" "compile_k3_optee"
 	declare hash_uboot_functions="${hash_functions}"
 
 	# Hash those two together


### PR DESCRIPTION
Fixes the K3 `am62p` / `am62-lp` u-boot builds that were failing across all vendor branches (`vendor`, `vendor-rt`, `vendor-edge`) plus mainline `edge` — the R5 first-stage SPL overflowing its SRAM size limit, and the tispl/u-boot rename breaking on newer u-boot. Touches two files: `config/sources/families/include/k3_common.inc` and `lib/functions/artifacts/artifact-uboot.sh`. The R5 stage builds with soft-float `gcc-13-arm-linux-gnueabi`, already present in the framework image (armbian/docker-armbian-build#37, merged).

### 1. R5 SPL overruns its SRAM size limit → GCC 13 + per-SoC size handling

The R5 first-stage SPL (tiboot3) for am62p and am62-lp overruns `CONFIG_SPL_SIZE_LIMIT`:

```
spl/u-boot-spl.bin exceeds file size limit
```

Two forces push it over: **GCC 14** (the Trixie default) produces larger SPL code than TI validated, and the newer TI vendor trees (`ti-u-boot-2026.01`, TI SDK `12.00.00.07`) grew the SPL. GCC 13 is necessary but **not sufficient** on its own, so `compile_k3_bootgen` combines it with a size remedy chosen per SoC.

**Compiler:** the R5 stage is built with `CC=arm-linux-gnueabi-gcc-13` (u-boot Kbuild honours a command-line `CC`; `CROSS_COMPILE` stays for binutils). Passing `CC` explicitly means no silent fallback — an early `-dumpversion` check asserts the major version is `13` and fails loudly otherwise, rather than reverting to gcc-14 and reintroducing the overflow. Only the R5 first stage changes compiler; the A53 SPL and u-boot proper are untouched.

The two SoCs need **different** size remedies because their MCU SRAM layout differs:

| Board | Stack ptr | BSS | `SPL_SIZE_LIMIT` | Headroom | Remedy |
|---|---|---|---|---|---|
| **am62p** (AM62P5) | base+`0x4a7f0` | base+`0x4b000` | `0x3C000` | **~0xE7f0 free** | raise limit + `-Os` |
| **am62-lp** (AM625) | base+`0x3a7f0` | base+`0x3b000` | `0x3A7F0` | none (limit *is* the stack ptr) | strip unused boot stacks + `-Os` |

- **am62p** — there is ~58 KB of unused MCU SRAM above the limit, so raise `SPL_SIZE_LIMIT` `0x3C000`→`0x40000` and `SPL_MAX_SIZE` `0x3B000`→`0x3F000` (both stay well below the stack pointer) and build for size (`-Os`). **No boot paths are removed** — SPI-NOR and SPI-NAND stay intact.
- **am62-lp** — the limit already sits exactly at the stack pointer with BSS immediately above, so there is nowhere to raise into; the image must shrink instead. Armbian boots tiboot3 from **SD/eMMC-FAT only**, so drop the unused SPI-NOR **and** SPI-NAND/MTD boot stacks that `am62x_lpsk` adds over `am62x_evm` (`SPL_SPI_FLASH*`, `DM_SPI_FLASH`, `SPI_FLASH_*`, `SPL_MTD*`, `SPL_NAND_SPI_SUPPORT`, `MTD_SPI_NAND`, `DM_MTD`, `SPL_YMODEM_SUPPORT`) and build for size (`-Os`). `olddefconfig` cascades the dependencies.

> [!NOTE]
> The am62-lp change **removes SPI-NAND/SPI-NOR boot support from that board's tiboot3** — dead weight for Armbian's SD/eMMC images, but a capability change. @jonaswood01 (board maintainer): flag if you need am62-lp to boot from SPI-NAND.

### 2. tispl/u-boot rename breaks on newer u-boot (beagleplay & other GP boards)

`post_uboot_custom_postprocess__update_uboot_names` copied a board's override image (`TISPL_FILE`/`UBOOT_FILE`) onto `tispl.bin`/`u-boot.img`. Newer u-boot broke this two ways, each tripping Armbian's `ERR` trap:

- **renamed outputs** — mainline 2026.07 / recent TI SDK renamed the GP outputs to `ti-spl_unsigned.fit.*`; the old `*_unsigned` files no longer exist, so `cp <absent>` failed (broke `beagleplay-{edge,vendor,vendor-rt}`, sk-tda4vm, beaglebone-ai64);
- **same file** — on GP parts binman can make the `*_unsigned` image and `tispl.bin` the same file, so `cp src dst` errors "are the same file".

Fix: guard each copy on the file existing (an `if`, since `[[ -f x ]] && cp` returns 1 when absent and would itself trap) and keep `|| true` so a same-file copy is tolerated. When skipped, binman's standard `tispl.bin`/`u-boot.img` is left in place. (`nounset` is off, so this is not an unbound-var issue.)

### 3. u-boot artifact hash now tracks the K3 recipe

The u-boot artifact version hashes specific hook/function bodies, but `compile_k3_bootgen`/`compile_k3_optee` weren't among them — the hashed `pre_config_uboot_target` hook only *calls* them. So changing the R5 recipe (e.g. the GCC 13 switch and size handling above) didn't change the artifact hash and a **stale cached u-boot was reused**. Add both to `calculate_hash_for_function_bodies`; it skips functions that don't exist, so non-K3 families are unaffected (K3 boards rebuild once, then track correctly).

---

### Testing

All affected u-boot artifacts compile once the gcc-13 image is live; the size remedies were verified against CI run [30202614279](https://github.com/armbian/ci/actions/runs/30202614279) (the pre-fix R5 overflow of `0x1c8a`–`0x1dfe` on am62p and `0xe88`–`0xfe0` on am62-lp).

**A card boot smoke test is still needed before merge** — to confirm the raised-limit am62p R5 SPL boots, and that am62-lp boots from SD/eMMC with the SPI-NOR/SPI-NAND stacks stripped.
