### PR TITLE
docker: warn when buildx is missing, and reap leftover per-build images

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -138,7 +138,8 @@ function docker_cli_prepare() {
 	[[ -z "${build_suffix}" ]] && build_suffix="${EPOCHREALTIME:-$(date +%s%N)}-$$-${RANDOM}${RANDOM}"
 	build_suffix="$(printf '%s' "${build_suffix}" | sha256sum 2> /dev/null | cut -c1-8)"
 	[[ -z "${build_suffix}" ]] && build_suffix="$(printf '%08x' "$$")" # no sha256sum: PID hex
-	declare -g DOCKER_ARMBIAN_INITIAL_IMAGE_TAG="armbian.local.only/armbian-build:${build_suffix}"
+	declare -g DOCKER_ARMBIAN_LOCAL_IMAGE_REPO="armbian.local.only/armbian-build"
+	declare -g DOCKER_ARMBIAN_INITIAL_IMAGE_TAG="${DOCKER_ARMBIAN_LOCAL_IMAGE_REPO}:${build_suffix}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:trixie"}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:bookworm"}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:sid"}"
@@ -846,6 +847,33 @@ function docker_cleanup_old_images() {
 			done
 		fi
 	done
+
+	# Reap leftovers of the per-build tag (see DOCKER_ARMBIAN_INITIAL_IMAGE_TAG). Every run coins its
+	# own tag, so the "keep the newest 2" rule above never sees more than one image per tag and can
+	# never reap them; 'docker image prune' ignores them too, since they are tagged, not dangling.
+	# Group by repository instead, and work on tag references rather than image IDs: a cached rebuild
+	# hangs a new tag on the image it reused, and 'docker rmi <id>' refuses an image carrying several
+	# tags, so those leftovers would survive. Age comes from LastTagTime rather than the creation
+	# date, which belongs to whatever build first produced the image and can be far older than a tag
+	# that a build in flight -- possibly another user's on a shared daemon -- has only just attached
+	# to it. LastTagTime tracks the image, not the individual tag, so re-tagging shields the older
+	# tags on that image as well; erring towards keeping them costs one image worth of disk, while
+	# the opposite error kills a running build.
+	declare stale_ref stale_tag_time stale_tag_is_zero stale_tagged_at
+	declare -i stale_tag_cutoff=$(($(date +%s) - 48 * 3600))
+	while read -r stale_ref; do
+		[[ -z "${stale_ref}" ]] && continue
+		stale_tag_time="$(docker image inspect --format '{{.Metadata.LastTagTime.IsZero}} {{.Metadata.LastTagTime.Unix}}' "${stale_ref}" 2> /dev/null || true)"
+		stale_tag_is_zero="${stale_tag_time%% *}"
+		stale_tagged_at="${stale_tag_time##* }"
+		# An unset tag time renders as the year-one zero value, which would read as ancient: leave it.
+		[[ "${stale_tag_is_zero}" != "false" ]] && continue
+		[[ ! "${stale_tagged_at}" =~ ^[0-9]+$ ]] && continue
+		if [[ ${stale_tagged_at} -lt ${stale_tag_cutoff} ]]; then
+			display_alert "Removing leftover per-build image" "${stale_ref}" "debug"
+			docker rmi "${stale_ref}" > /dev/null 2>&1 || true
+		fi
+	done < <(docker images --format '{{.Repository}}:{{.Tag}}' "${DOCKER_ARMBIAN_LOCAL_IMAGE_REPO:-"armbian.local.only/armbian-build"}" 2> /dev/null)
 
 	display_alert "Docker cleanup complete" "dangling images removed, old armbian images pruned" "info"
 }

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -467,6 +467,15 @@ function docker_cli_build_dockerfile() {
 		display_alert "Re-created" "Dockerfile, proceeding, build from scratch" "debug"
 	fi
 
+	# Without buildx, the classic builder keeps its layer cache only in the image store, so the
+	# per-build image removed at the end of every run (see docker_cli_launch) takes the cache with
+	# it: each invocation re-runs the whole Dockerfile, including the expensive requirements step.
+	# Those images also escape both reapers -- 'docker image prune' skips tagged ones, and
+	# docker_cleanup_old_images() matches a different repo -- so they pile up as well.
+	if [[ "${DOCKER_HAS_BUILDX}" != "yes" ]]; then
+		display_alert "Docker buildx not available" "install it, or this image is rebuilt from scratch on every run (and the leftovers are never cleaned up); see 'docker buildx' / package docker-buildx(-plugin)" "err"
+	fi
+
 	display_alert "Building" "Dockerfile via '${DOCKER_BUILDX_OR_BUILD[*]}'" "info"
 
 	BUILDKIT_COLORS="run=123,20,245:error=yellow:cancel=blue:warning=white" \


### PR DESCRIPTION
Two follow-ups to #9878, which gave each build its own image tag and removes that image at the end of the run. Both only bite on hosts without `docker buildx`.

## Rebuilt from scratch on every run

With BuildKit, removing the per-build image is harmless — the layer cache lives in the builder cache, independent of the image store. With the classic builder the cache lives *only* in the image store, so removing the image takes the cache with it and the next run re-executes the whole Dockerfile, including the expensive `compile.sh requirements` step.

Observed on a host without buildx:

```
docker build -t armbian.local.only/armbian-build:caa8bf8c ...
Step 2/19 : RUN echo "--> CACHE MISS IN DOCKERFILE: apt update." && apt-get -y update
```

19 of 19 steps, no `---> Using cache`.

The first commit warns about this in red right before the image is built, non-fatally — the build still works without buildx, it is just slow.

```
[💥] Docker buildx not available [ install it, or this image is rebuilt from scratch on every run ... ]
[🌱] Building [ Dockerfile via 'build' ]
```

## Leftovers are never cleaned up

The same images accumulate: they are tagged, so the dangling-only `docker image prune` skips them, and `docker_cleanup_old_images()` matched `docker-armbian-build`, not the local `armbian.local.only/armbian-build` repository. A host that had been building for a few weeks:

```
armbian.local.only/armbian-build:initial     5 weeks ago   2.68GB
armbian.local.only/armbian-build:dae0d66e   12 days ago    2.89GB
armbian.local.only/armbian-build:fbf62831    2 weeks ago    2.70GB
```

Widening the existing grep would not have been enough: each run coins a unique tag, so the per-tag "keep the newest 2" rule never sees more than one image per tag. The second commit groups that repository as a whole, and deletes by tag reference rather than by image ID — a cached rebuild hangs a new tag on the image it reused, and `docker rmi <id>` refuses an image carrying several tags:

```
Error response from daemon: conflict: unable to delete 8874f1d3b2ed (must be forced) - image is referenced in multiple repositories
```

Staleness comes from `LastTagTime` rather than the creation date, which belongs to whatever build first produced the image and can be far older than a tag a build in flight has just attached to it. An unset `LastTagTime` renders as the year-one zero value, so images whose tag time is unknown are left alone instead of reading as ancient. This path only runs under the opt-in `DOCKER_PRUNE=yes`.

## Testing

Warning path: hiding the plugin so `docker info` reports no buildx makes the alert fire and the build proceed via `'build'`; with the plugin present it stays silent and goes via `'buildx build'`.

Cleanup path: three tags pointing at one image, reaped by a real `DOCKER_PRUNE=yes` run — the multi-tag conflict above is what the by-reference deletion fixes, and unrelated images in the store were left untouched.

```
./compile.sh uboot BOARD=rockpi-4a BRANCH=edge
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of stale per-build Docker images older than 48 hours.
  - Added clearer alerts when Buildx is unavailable, including information about cache limitations and leftover build artifacts.

- **Maintenance**
  - Improved consistency when creating and tagging local build images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->