### PR TITLE
sunxi: cb1: fix wifi pwrseq clock name so the 32k LPO is actually enabled

### DIFF
--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-sd-emmc.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-sd-emmc.patch
@@ -235,8 +235,7 @@ index 111111111111..222222222222 100644
  	wifi_pwrseq: wifi-pwrseq {
  		compatible = "mmc-pwrseq-simple";
  		clocks = <&rtc 1>;
--		clock-names = "ext_clock";
-+		clock-names = "osc32k-out";
+ 		clock-names = "ext_clock";
  		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>; /* PG18 */
  		post-power-on-delay-ms = <200>;
  	};

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
@@ -120,8 +120,7 @@ index 111111111111..222222222222 100644
  	wifi_pwrseq: wifi-pwrseq {
  		compatible = "mmc-pwrseq-simple";
  		clocks = <&rtc 1>;
--		clock-names = "ext_clock";
-+		clock-names = "osc32k-out";
+ 		clock-names = "ext_clock";
  		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>; /* PG18 */
  		post-power-on-delay-ms = <200>;
  	};

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
@@ -120,8 +120,7 @@ index 111111111111..222222222222 100644
  	wifi_pwrseq: wifi-pwrseq {
  		compatible = "mmc-pwrseq-simple";
  		clocks = <&rtc 1>;
--		clock-names = "ext_clock";
-+		clock-names = "osc32k-out";
+ 		clock-names = "ext_clock";
  		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>; /* PG18 */
  		post-power-on-delay-ms = <200>;
  	};


### PR DESCRIPTION
# Description

The BigTreeTech CB1 dts patches rename the wifi power-sequence clock from mainline's `ext_clock` to `osc32k-out`:

```diff
-		clock-names = "ext_clock";
+		clock-names = "osc32k-out";
```

`mmc-pwrseq-simple` looks the clock up strictly by the name `ext_clock` (`drivers/mmc/core/pwrseq_simple.c`) and silently tolerates `-ENOENT`. With the renamed property the clock is never claimed and never enabled: `clk_summary` shows `osc32k-fanout` permanently gated with zero consumers. As a result the RTL8189FTV wifi chip runs without its external 32.768 kHz LPO clock on every Armbian kernel, on every boot.

This change drops the rename from all three kernel branches carrying the CB1 patches (sunxi-6.12, sunxi-6.18, sunxi-7.0), restoring the mainline property untouched.

GitHub issue reference: none

Jira reference number: none

# Documentation summary for feature / change

No documentation entry is needed. This is a bug fix inside an existing dts patch; there are no user-facing options, build switches, or behaviour changes to document.

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

Verified on a genuine BTT CB1 (H616) by editing the deployed dtb and rebooting, so the running kernel used the fixed property.

- [x] Before the change: `osc32k-fanout` is permanently gated in `/sys/kernel/debug/clk/clk_summary` with no consumer, on every boot.
- [x] After the change: the pwrseq claims the clock and `clk_summary` shows it enabled with `wifi-pwrseq` as its consumer:

```text
osc32k-fanout    1    1    0    32768    ...    Y    wifi-pwrseq    ext_clock
```

- [x] Wifi association and traffic keep working with the clock actually enabled.
- [ ] Full image build not run: the change only removes a rename inside an existing patch hunk, and the surrounding hunk context and hunk headers are unchanged.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — not applicable, the change only deletes a property rename and restores the mainline line as patch context
- [ ] My changes generate no new warnings — not verified, I did not run a full image build
- [ ] Any dependent changes have been merged and published in downstream modules — not applicable, this change has no dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for BigTreeTech CB1 boards with SD and eMMC storage variants.
  * Enabled Ethernet, HDMI, USB host connectivity, serial console, and improved Wi‑Fi power handling.
  * Added optional support for RGB LEDs, CAN, TFT displays, touch input, and ambient-light sensing.
* **Bug Fixes**
  * Improved SD/eMMC reliability, power regulation, device wake behavior, and USB peripheral mode.
  * Updated LED activity and heartbeat indicators for more accurate status feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->