### PR TITLE
sunxi: cb1: stop exposing wifi power lines as gpio LEDs

### DIFF
--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-sd-emmc.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-sd-emmc.patch
@@ -157,7 +157,7 @@ index 111111111111..222222222222 100644
   */
  
  /dts-v1/;
-@@ -13,22 +14,41 @@
+@@ -13,22 +14,29 @@
  #include <dt-bindings/leds/common.h>
  
  / {
@@ -184,18 +184,6 @@ index 111111111111..222222222222 100644
 +		act_led: led-0 {
 +			gpios = <&pio 7 5 GPIO_ACTIVE_LOW>; /* PH5 */
 +			linux,default-trigger = "heartbeat";
-+		};
-+
-+		gpio_1 {
-+			function = "wifi_power";
-+			gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>; /* PF6 */
-+			default-state = "on";
-+		};
-+
-+		gpio_2 {
-+			function = "wifi_wake";
-+			gpios = <&pio 6 15 GPIO_ACTIVE_HIGH>; /* PG15 */
-+			default-state = "on";
  		};
  	};
  

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
@@ -31,7 +31,7 @@ index 111111111111..222222222222 100644
   */
  
  /dts-v1/;
-@@ -13,22 +14,52 @@
+@@ -13,22 +14,40 @@
  #include <dt-bindings/leds/common.h>
  
  / {
@@ -69,18 +69,6 @@ index 111111111111..222222222222 100644
 +		act_led: led-0 {
 +			gpios = <&pio 7 5 GPIO_ACTIVE_LOW>; /* PH5 */
 +			linux,default-trigger = "heartbeat";
-+		};
-+
-+		gpio_1 {
-+			function = "wifi_power";
-+			gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>; /* PF6 */
-+			default-state = "on";
-+		};
-+
-+		gpio_2 {
-+			function = "wifi_wake";
-+			gpios = <&pio 6 15 GPIO_ACTIVE_HIGH>; /* PG15 */
-+			default-state = "on";
  		};
  	};
  

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
@@ -31,7 +31,7 @@ index 111111111111..222222222222 100644
   */
  
  /dts-v1/;
-@@ -13,22 +14,52 @@
+@@ -13,22 +14,40 @@
  #include <dt-bindings/leds/common.h>
  
  / {
@@ -69,18 +69,6 @@ index 111111111111..222222222222 100644
 +		act_led: led-0 {
 +			gpios = <&pio 7 5 GPIO_ACTIVE_LOW>; /* PH5 */
 +			linux,default-trigger = "heartbeat";
-+		};
-+
-+		gpio_1 {
-+			function = "wifi_power";
-+			gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>; /* PF6 */
-+			default-state = "on";
-+		};
-+
-+		gpio_2 {
-+			function = "wifi_wake";
-+			gpios = <&pio 6 15 GPIO_ACTIVE_HIGH>; /* PG15 */
-+			default-state = "on";
  		};
  	};
  


### PR DESCRIPTION
# Description

The BigTreeTech CB1 dts patches add the wifi module power and wake lines (PF6, PG15) to the `leds` node as gpio LEDs:

```dts
gpio_1 {
	function = "wifi_power";
	gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>; /* PF6 */
	default-state = "on";
};

gpio_2 {
	function = "wifi_wake";
	gpios = <&pio 6 15 GPIO_ACTIVE_HIGH>; /* PG15 */
	default-state = "on";
};
```

Modern kernels register these as `/sys/class/leds/:wifi_power` and `/sys/class/leds/:wifi_wake`, which makes the wifi module's power rail writable by anything that manages LEDs.

`armbian-led-state.service` does exactly that on every boot. While restoring saved LED states, its `trigger=none` handling deliberately writes `default-on` and then `none` to clear the LED, which pulses the wifi power line low. On 6.18 that lands in the middle of the RTL8189FTV SDIO bring-up: the card resets and stops responding, every subsequent CMD52/CMD53 times out with `-110`, and `wlan0` stays dead until the mmc host is fully re-initialized. The result is a wifi interface that is present but never associates, on a large fraction of boots.

These lines are not LEDs and nothing needs to drive them: the wifi card enumerates seconds before `leds-gpio` ever binds them, and it works fine with them left untouched. This change drops both pseudo-LEDs from all three kernel branches carrying the CB1 patches (sunxi-6.12, sunxi-6.18, sunxi-7.0), leaving the real activity LED in place.

This is a companion to https://github.com/armbian/build/pull/10240 — same patch series, independent bugs, no dependency between the two.

GitHub issue reference: none

Jira reference number: none

# How Has This Been Tested?

Test configuration: a genuine BigTreeTech CB1 (H616) running 6.18.39, wifi over the onboard RTL8189FTV.

I first reproduced the failure on demand with the pseudo-LEDs still present: `echo 0 > /sys/class/leds/:wifi_power/brightness` kills the card outright, every SDIO transfer after it times out, and wifi does not recover until the mmc host is re-initialized.

I then confirmed the mechanism across a full boot with the `mmc:mmc_request_done` tracepoint enabled from early userspace. The card answers ordinary 4-byte CMD53 transfers, goes mute between two of them at exactly the moment the LED state restore runs, and returns `-110` for everything afterwards, CMD52 included.

With the two LEDs removed from the device tree, boot completes with zero SDIO errors and wifi associates natively. I also checked the upgrade path for existing installs that still list the old LED names: booting with `armbian-led-state.service` active and the stale entries left in `/etc/armbian-leds.conf`, the restore script logs four `could not be restored` warnings for the now-missing `:wifi_power` and `:wifi_wake` trigger and brightness paths, skips them, and has no other effect on boot.

I did not run a full image build. The change only deletes lines from an existing patch hunk, so I verified the hunk arithmetic for every hunk in all three patch files instead — context plus removed lines match the old count, context plus added lines match the new count, and all three patches still apply cleanly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full BigTreeTech CB1 board support for Allwinner H616 systems.
  * Added separate SD-card and eMMC boot configurations.
  * Enabled board identification, serial console output, HDMI, Ethernet, USB host, and USB peripheral operation.
  * Improved storage configuration for SD and eMMC devices.
  * Added support definitions for Wi‑Fi controls, status LEDs, RGB LEDs, software I²C, CAN, and SPI displays.
  * Updated power management and regulator settings for improved hardware compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->