### PR TITLE
kernel: add opt-in linux-image-dbg package with debug info

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -19,6 +19,17 @@ function artifact_kernel_config_dump() {
 	artifact_input_variables[KERNELPATCHDIR]="${KERNELPATCHDIR}"
 	artifact_input_variables[ARCH]="${ARCH}"
 	artifact_input_variables[EXTRAWIFI]="${EXTRAWIFI:-"yes"}"
+	artifact_input_variables[KERNEL_DBG_PACKAGE]="${KERNEL_DBG_PACKAGE:-"no"}" # dbg and non-dbg targets must not be coalesced by the artifact reducer
+	if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+		# compiler inputs split the dbg artifact version, so they must split reducer groups too
+		artifact_input_variables[KERNEL_COMPILER]="${KERNEL_COMPILER}"
+		artifact_input_variables[KERNEL_EXTRA_CFLAGS]="${KERNEL_EXTRA_CFLAGS:-""}"
+		# make-time hooks also split the dbg version (artifact_kernel_prepare_version hashes their
+		# sources); mirror that here or the reducer coalesces two hook-distinct dbg/image pairs into one
+		declare dbg_make_hooks_hash=""
+		dbg_make_hooks_hash="$(dump_extension_method_sources_functions kernel_make_config custom_kernel_make_params | sha256sum | cut -d' ' -f1)"
+		artifact_input_variables[KERNEL_DBG_MAKE_HOOKS_HASH]="${dbg_make_hooks_hash}"
+	fi
 }
 
 # This is run in a logging section.
@@ -153,6 +164,36 @@ function artifact_kernel_prepare_version() {
 	# Extra stubble DTBs change the packaged UKI. Appended ONLY when set, so
 	# families that don't use them keep their exact previous -V hash (no churn).
 	[[ ${#EXTRA_STUBBLE_DEVICETREES[@]} -gt 0 ]] && vars_to_hash+=("${EXTRA_STUBBLE_DEVICETREES[*]}")
+	# Hash KERNEL_DBG_PACKAGE only when enabled, giving dbg-enabled builds a cache entry
+	# distinct from regular builds (a cached tarball without the dbg deb would poison them).
+	# The linux-image/-dbg pairing keys exactness on artifact_version, so builds differing
+	# in cflags, cross-toolchain prefix or toolchain version must not share a version.
+	# The linker is hashed alongside the compiler: it decides the layout of vmlinux, so two
+	# builds sharing a compiler but not a binutils would otherwise pair a dbg package with an
+	# image whose symbol addresses came out elsewhere.
+	# Versions are resolved here directly, not via the kernel-version-toolchain extension:
+	# that extension is force-enabled in main-config, which hooks running later
+	# (post_family_config, user_config) can no longer trigger — the hash must not depend
+	# on extension-enablement timing. The extension still adds the visible version part.
+	if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+		declare dbg_compiler_bin="${KERNEL_COMPILER}gcc"
+		declare dbg_linker_bin="${KERNEL_COMPILER}ld" # CROSS_COMPILE prefix; LLVM=1 uses ld.lld instead
+		if [[ "${KERNEL_COMPILER}" == "clang" ]]; then
+			dbg_compiler_bin="clang"
+			dbg_linker_bin="ld.lld"
+		fi
+		declare dbg_compiler_version=""
+		dbg_compiler_version="$("${dbg_compiler_bin}" -dumpfullversion -dumpversion 2> /dev/null || true)"
+		declare dbg_linker_version=""
+		dbg_linker_version="$("${dbg_linker_bin}" --version 2> /dev/null | head -1 || true)"
+		vars_to_hash+=(
+			"KERNEL_DBG_PACKAGE=yes"
+			"KERNEL_COMPILER=${KERNEL_COMPILER}"
+			"KERNEL_COMPILER_VERSION=${dbg_compiler_version}"
+			"KERNEL_LINKER_VERSION=${dbg_linker_version}"
+			"KERNEL_EXTRA_CFLAGS=${KERNEL_EXTRA_CFLAGS:-""}"
+		)
+	fi
 	declare hash_variables="undetermined" # will be set by calculate_hash_for_variables(), which normalizes the input
 	calculate_hash_for_variables "${vars_to_hash[@]}"
 	declare vars_config_hash="${hash_variables}"
@@ -163,6 +204,11 @@ function artifact_kernel_prepare_version() {
 		"pre_package_kernel_image" "kernel_copy_extra_sources" "pre_package_kernel_headers"
 		"kernel_extra_create_patches"
 	)
+	# dbg pairing keys exactness on artifact_version: make-time hooks can change compile
+	# flags (e.g. KERNEL_EXTRA_CFLAGS), so their sources must be part of the dbg hash.
+	if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+		extension_hooks_to_hash+=("kernel_make_config" "custom_kernel_make_params")
+	fi
 	declare -a extension_hooks_hashed=("$(dump_extension_method_sources_functions "${extension_hooks_to_hash[@]}")")
 	declare hash_hooks="undetermined"
 	hash_hooks="$(echo "${extension_hooks_hashed[@]}" | sha256sum | cut -d' ' -f1)"
@@ -204,6 +250,23 @@ function artifact_kernel_prepare_version() {
 		  - Remove: remove entry from array or unset the key in artifact_version_parts
 		  Keys starting with "_" are not included in output (only value is used).
 	ARTIFACT_KERNEL_VERSION_PARTS
+
+	# The dbg package pairs with its image by artifact_version, so the toolchain has to be
+	# visible in that version. Added here, and not by enabling kernel-version-toolchain from
+	# main-config: extensions are enabled before post_family_config runs, which can still flip
+	# KERNEL_DBG_PACKAGE - the version must not depend on that timing, same as the hash above.
+	# Skipped when the extension is enabled on its own, so the part is never added twice.
+	if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" && -z "${artifact_version_parts[_T]:-}" ]]; then
+		declare dbg_toolchain_id="unknown"
+		if [[ -n "${dbg_compiler_version}" ]]; then
+			declare dbg_compiler_short
+			dbg_compiler_short="$(cut -d'.' -f1-2 <<< "${dbg_compiler_version}")" # 13.3.0 -> 13.3
+			dbg_toolchain_id="gcc${dbg_compiler_short}"
+			[[ "${KERNEL_COMPILER}" == "clang" ]] && dbg_toolchain_id="clang${dbg_compiler_short}"
+		fi
+		artifact_version_parts["_T"]="${dbg_toolchain_id}"
+		artifact_version_part_order+=("0085-_T")
+	fi
 
 	# Sort and validate: keys after stripping numeric prefixes must be unique
 	mapfile -t artifact_version_part_order < <(printf '%s\n' "${artifact_version_part_order[@]}" | LC_ALL=C sort)
@@ -260,6 +323,12 @@ function artifact_kernel_prepare_version() {
 		if [[ "${KERNEL_HAS_WORKING_HEADERS:-"no"}" == "yes" ]]; then
 			artifact_map_packages+=(["linux-headers"]="linux-headers-${BRANCH}-${LINUXFAMILY}")
 		fi
+
+		# opt-in debug package: unstripped vmlinux for crash/drgn/gdb analysis of vmcores.
+		# Debian-style name: "-dbg" suffixed to the name of the package it complements.
+		if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+			artifact_map_packages+=(["linux-dbg"]="linux-image-${BRANCH}-${LINUXFAMILY}-dbg")
+		fi
 	fi
 
 	# x86, specially, does not have working dtbs...
@@ -274,6 +343,11 @@ function artifact_kernel_prepare_version() {
 	# Separate artifact name if we're in DTB-only mode, so stuff doesn't get mixed up later
 	if [[ "${KERNEL_DTB_ONLY}" == "yes" ]]; then
 		artifact_name="kernel-dtb-only-${LINUXFAMILY}-${BRANCH}"
+		# Say it out loud rather than failing: KERNEL_DBG_PACKAGE may come from the family config,
+		# and a DTB-only build has no reason to break just because it inherited the request.
+		if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+			display_alert "Ignoring KERNEL_DBG_PACKAGE=yes" "KERNEL_DTB_ONLY=yes never links vmlinux" "warn"
+		fi
 	fi
 
 	artifact_type="deb-tar" # this triggers processing of .deb files in the maps to produce a tarball

--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -110,7 +110,24 @@ function armbian_kernel_config__force_pa_va_48_bits_on_arm64() {
 # Returns:
 #   0 on successful configuration application.
 function armbian_kernel_config__600_enable_ebpf_and_btf_info() {
+	# A DTB-only build never links vmlinux, so the debug package is dropped there anyway; such a
+	# build must not gain options for it, nor fail on the conflict below.
+	declare dbg_package_effective="no"
+	if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" && "${KERNEL_DTB_ONLY:-"no"}" != "yes" ]]; then
+		dbg_package_effective="yes"
+	fi
+
+	if [[ "${dbg_package_effective}" == "yes" ]]; then
+		opts_y+=("PROC_KCORE") # crash/drgn read /proc/kcore to inspect a running kernel, not just a dump
+	fi
 	if [[ "${KERNEL_BTF}" == "no" ]]; then # If user is explicit by passing "KERNEL_BTF=no", then actually disable all debug info.
+		# Reject the conflict instead of overriding it: the debug package exists to ship the very
+		# debug info this branch turns off. Checked here, where both values are final -- config
+		# hooks running after main-config can still set either one.
+		if [[ "${dbg_package_effective}" == "yes" ]]; then
+			exit_with_error "KERNEL_BTF=no conflicts with KERNEL_DBG_PACKAGE=yes" \
+				"KERNEL_BTF=no disables CONFIG_DEBUG_INFO, leaving vmlinux without the debug info that crash, drgn and gdb need; either set KERNEL_BTF=yes (or leave it unset for Armbian's default) or drop KERNEL_DBG_PACKAGE=yes"
+		fi
 		display_alert "Disabling eBPF and BTF info for kernel" "as requested by KERNEL_BTF=no" "info"
 		opts_y+=("DEBUG_INFO_NONE")        # Enable the "none" option
 		opts_n+=("DEBUG_INFO")             # Disables debug information

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -88,6 +88,11 @@ function prepare_kernel_packaging_debs() {
 
 		display_alert "Packaging linux-libc-dev" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
 		create_kernel_deb "linux-libc-dev-${BRANCH}-${LINUXFAMILY}" "${debs_target_dir}" kernel_package_callback_linux_libc_dev "linux-libc-dev"
+
+		if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+			display_alert "Packaging linux-image-dbg" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
+			create_kernel_deb "linux-image-${BRANCH}-${LINUXFAMILY}-dbg" "${debs_target_dir}" kernel_package_callback_linux_dbg "linux-dbg"
+		fi
 	fi
 
 	return 0
@@ -286,6 +291,14 @@ function kernel_package_callback_linux_image() {
 		run_host_command_logged cp -rp "${tmp_kernel_install_dirs[INSTALL_DTBS_PATH]}" "${package_directory}/usr/lib/linux-image-${kernel_version_family}"
 	fi
 
+	# The versioned virtual "-build" provide pairs linux-image with its linux-dbg package.
+	# Reversioning rewrites only the Version: field, so the artifact_version pinned here and
+	# in the dbg package's Depends survives it, keeping the pairing exact per-build.
+	declare provides_dbg_pair=""
+	if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+		provides_dbg_pair=", linux-image-${BRANCH}-${LINUXFAMILY}-build (= ${artifact_version})"
+	fi
+
 	# Generate a control file
 	cat <<- CONTROL_FILE > "${package_DEBIAN_dir}/control"
 		Package: ${package_name}
@@ -298,7 +311,7 @@ function kernel_package_callback_linux_image() {
 		Section: kernel
 		Priority: optional
 		Depends: initramfs-tools | linux-initramfs-tool
-		Provides: linux-image, linux-image-armbian, armbian-$BRANCH, wireguard-modules
+		Provides: linux-image, linux-image-armbian, armbian-$BRANCH, wireguard-modules${provides_dbg_pair}
 		Description: Armbian Linux $BRANCH kernel image $kernel_version_family
 		 This package contains the Linux kernel, modules and corresponding other files.
 		 ${artifact_version_reason:-"${kernel_version_family}"}
@@ -621,6 +634,58 @@ function kernel_package_callback_linux_headers() {
 			fi
 		EOT_POSTINST_FINISH
 	)
+}
+
+function kernel_package_callback_linux_dbg() {
+	display_alert "linux-dbg packaging" "${package_directory}" "debug"
+
+	[[ -f "${kernel_work_dir}/vmlinux" ]] || exit_with_error "KERNEL_DBG_PACKAGE=yes, but vmlinux not found in '${kernel_work_dir}'"
+
+	# Last line of defence, after the final .config: any hook may still have turned debug info off.
+	if ! is_enabled CONFIG_DEBUG_INFO; then
+		exit_with_error "KERNEL_DBG_PACKAGE=yes, but kernel built without CONFIG_DEBUG_INFO" "vmlinux carries no DWARF, so the package would be useless to crash, drgn and gdb; check for a kernel config hook or an interactive KERNEL_CONFIGURE=yes session turning DEBUG_INFO off"
+	fi
+
+	# The config bit only records the intent. KERNEL_EXTRA_CFLAGS or a make-params hook can pass
+	# -g0 through KCFLAGS and leave CONFIG_DEBUG_INFO=y standing over an ELF with no debug
+	# sections, so ask the ELF itself. Captured, not piped into grep: grep -q exits on the first
+	# match and the SIGPIPE would surface as a pipeline failure.
+	declare vmlinux_sections=""
+	vmlinux_sections="$(readelf -S "${kernel_work_dir}/vmlinux" 2> /dev/null || true)"
+	if [[ -z "${vmlinux_sections}" ]]; then
+		display_alert "Could not read vmlinux section headers" "readelf unavailable; skipping .debug_info verification" "wrn"
+	elif [[ "${vmlinux_sections}" != *".debug_info"* ]]; then
+		exit_with_error "KERNEL_DBG_PACKAGE=yes, but vmlinux has no .debug_info section" "CONFIG_DEBUG_INFO=y is set, so the debug sections were suppressed at compile time — check KERNEL_EXTRA_CFLAGS and any kernel_make_config/custom_kernel_make_params hook for -g0 or similar"
+	fi
+
+	if is_enabled CONFIG_DEBUG_INFO_SPLIT; then
+		exit_with_error "KERNEL_DBG_PACKAGE=yes does not support CONFIG_DEBUG_INFO_SPLIT" "DWARF lives in .dwo sidecar files that are not packaged; rebuild with CONFIG_DEBUG_INFO_SPLIT=n (distro debug kernels use non-split DWARF)"
+	fi
+
+	# /usr/lib/debug/lib/modules/<ver>/vmlinux is the standard search path of crash, drgn and gdb
+	declare vmlinux_debug_dir="${package_directory}/usr/lib/debug/lib/modules/${kernel_version_family}"
+	mkdir -p "${vmlinux_debug_dir}"
+	run_host_command_logged cp -v "${kernel_work_dir}/vmlinux" "${vmlinux_debug_dir}/vmlinux"
+
+	# Generate a control file.
+	# The versioned virtual "-build" dependency pins these debug symbols to the exact kernel
+	# build: artifact_version encodes every input hash (source SHA1, patches, .config, hooks,
+	# toolchain), and reversioning does not touch Provides/Depends, so dpkg refuses to install
+	# debug symbols for a kernel built from any other combination of inputs.
+	cat <<- CONTROL_FILE > "${package_DEBIAN_dir}/control"
+		Version: ${artifact_version}
+		Maintainer: ${MAINTAINER} <${MAINTAINERMAIL}>
+		Section: debug
+		Package: ${package_name}
+		Architecture: ${ARCH}
+		Priority: optional
+		Depends: linux-image-${BRANCH}-${LINUXFAMILY}, linux-image-${BRANCH}-${LINUXFAMILY}-build (= ${artifact_version})
+		Provides: linux-image-dbg, linux-image-armbian-dbg
+		Description: Armbian Linux $BRANCH debug symbols (vmlinux) ${kernel_version_family}
+		 This package contains the unstripped vmlinux for ${kernel_version_family}.
+		 It is used by crash, drgn and gdb to analyze kdump vmcores and the live kernel.
+		 ${artifact_version_reason:-"${kernel_version_family}"}
+	CONTROL_FILE
 }
 
 function kernel_package_callback_linux_libc_dev() {


### PR DESCRIPTION
## Description

Kernels built with `CONFIG_DEBUG_INFO` produce a vmlinux with full debug info, but only the stripped Image is packaged — vmlinux is discarded with the build tree, leaving nothing to analyze kdump vmcores with. Debian ships it as `linux-image-*-dbg`, Ubuntu as `-dbgsym` ddebs, Fedora as `kernel-debuginfo`.

This adds `KERNEL_DBG_PACKAGE=yes` (default `no`) producing a `linux-image-<BRANCH>-<LINUXFAMILY>-dbg` package (Debian-style `-dbg` suffix) with vmlinux at `/usr/lib/debug/lib/modules/<version>/vmlinux` — the standard search path of crash, drgn and gdb. Split DWARF (`CONFIG_DEBUG_INFO_SPLIT`) is rejected with a rebuild hint: a vmlinux-only package would be an empty shell there.

**Exact build pairing:** linux-image declares a versioned virtual `Provides: linux-image-<BRANCH>-<LINUXFAMILY>-build (= artifact_version)`, and the dbg package carries a versioned Depends on it. Deployment reversioning rewrites only the `Version:` field, so the pairing survives it and dpkg refuses to install debug symbols for a kernel built from any other inputs. With `KERNEL_DBG_PACKAGE=yes` the artifact hash additionally covers `KERNEL_COMPILER` (prefix), the probed compiler version, `KERNEL_EXTRA_CFLAGS`, and the sources of the make-time hooks (`kernel_make_config`, `custom_kernel_make_params`); the `kernel-version-toolchain` extension is force-enabled for a visible toolchain part in the version string. `config_dump` emits `KERNEL_DBG_PACKAGE` and the compiler inputs so the artifact reducer never coalesces dbg and non-dbg targets.

**Scope:** an opt-in for local builds; the feature is not wired into the apt repository publishing pipeline.

**Why a build variable and not an extension:** there is currently no hook point to add a package to the kernel artifact — `artifact_map_packages` is built after the last extension hook runs, and without an entry in that map the deb would not be part of the deb-tar artifact and thus invisible to the ORAS cache. The dbg package's siblings (dtb, headers, libc-dev) are all gated by core variables; this follows the same pattern.

**Cache correctness:** the variable is hashed into the artifact version only when enabled — regular builds keep their existing cache entries.

**Cost:** vmlinux with DWARF5 is ~0.5–1 GB unpacked (measured deb: ~520 MB for meson64-edge) — hence opt-in.

## How Has This Been Tested?

- [x] `./compile.sh kernel BOARD=odroidn2 BRANCH=edge KERNEL_DBG_PACKAGE=yes` — deb produced; vmlinux is `with debug_info, not stripped` (BuildID present); gdb resolves `info line start_kernel` → `init/main.c:1018` from the packaged vmlinux
- [x] Boot-environment install matrix: the pair installs; dbg without/against a foreign image is refused by dpkg in both directions; replacing installed kernels is clean; a bare `dpkg -i` of the image with a stale dbg present is caught by `apt-get check` and healed by `--fix-broken`
- [x] Reversioned control verified: `Version: 26.08.0-trunk` with the versioned `-build` pairing intact
- [x] 5 bot-review rounds in the staging PR (iav/armbian#192), all findings fixed or scoped

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in kernel debug package generation for builds configured with `KERNEL_DBG_PACKAGE=yes`.
  * Generated debug packages now include kernel symbols and are emitted as an additional `-dbg` variant.
  * Debug packages are paired with the exact matching kernel build via strict version pinning.

* **Bug Fixes**
  * Prevented debug and non-debug kernel artifacts from sharing cached outputs by separating hash/version inputs.
  * Improved validation of debug-symbol configuration, with clear failure/warnings for unsupported setups (e.g., missing required debug inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->