### PR TITLE
rootfs: bump force-rebuild counter to 006

### DIFF
--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -193,4 +193,4 @@ function extract_rootfs_artifact() {
 }
 
 # This comment strategically introduced to force a rebuild of all rootfs, as this file's contents are hashed into all rootfs versions.
-# Just a number to force rebuild 005
+# Just a number to force rebuild 006


### PR DESCRIPTION
Bumps the force-rebuild counter in `lib/functions/rootfs/create-cache.sh` (005 → 006).

This file's contents are hashed into every rootfs version, so changing the counter comment invalidates all cached rootfs and forces a clean rebuild across the board.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated root filesystem cache invalidation so relevant changes trigger a fresh rebuild instead of reusing an outdated cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->