### PR TITLE
docker: add DOCKER_FORCE_PULL=yes to bypass the base-image pull cache

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -401,8 +401,13 @@ function docker_cli_prepare_dockerfile() {
 }
 
 function docker_cli_build_dockerfile() {
-	local do_force_pull="no"
+	# DOCKER_FORCE_PULL=yes forces a re-pull of the base image, bypassing the
+	# ~24h marker cache below. Use it to pick up a freshly-published framework
+	# image immediately (e.g. after a docker-armbian-build change) instead of
+	# waiting for the marker to expire or the local copy to be removed.
+	local do_force_pull="${DOCKER_FORCE_PULL:-no}"
 	local local_image_sha
+	[[ "${do_force_pull}" == "yes" ]] && display_alert "Docker base image" "DOCKER_FORCE_PULL=yes: forcing a re-pull" "info"
 
 	declare docker_marker_dir="${SRC}"/cache/docker
 


### PR DESCRIPTION
## Problem
`docker_cli_build_dockerfile()` only pulls the base framework image when the local pull marker is older than ~24h (`find -mtime +1`) or the image is absent. Otherwise it logs *"Armbian docker image already exists"* and reuses the local copy.

So a runner that pulled the image within the last day keeps using that **stale** local image even after a newer one is published to ghcr — a freshly-fixed image (e.g. a new cross toolchain) isn't picked up until the marker expires or the local image is manually removed. There was no switch to force it.

## Fix
Honour a `DOCKER_FORCE_PULL` env var:
```bash
local do_force_pull="${DOCKER_FORCE_PULL:-no}"
```
So `DOCKER_FORCE_PULL=yes ./compile.sh …` (or setting it in a CI config/env) forces a re-pull, bypassing the marker cache. Default behaviour is unchanged. Logs a clear line when active.

## Use
```
DOCKER_FORCE_PULL=yes ./compile.sh …
```
Useful right after publishing a new framework image, to pick it up immediately instead of waiting out the 24h marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for forcing Docker base image re-pulls through the `DOCKER_FORCE_PULL` environment setting.
  * Displays an informational alert when a forced re-pull is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->