### PR TITLE
sunxi: fix BigTreeTech CB1 patches failing to apply (all kernel branches)

### DIFF
--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-sd-emmc.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-sd-emmc.patch
@@ -42,10 +42,10 @@ Subject: arm64: dts: sun50i-h616-bigtreetech-cb1(sd, emmc)
  4 files changed, 287 insertions(+), 17 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 111111111111..222222222222 100644
+index 00bed41..5c6ed1f 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -51,6 +51,8 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
+@@ -41,6 +41,8 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h313-tanix-tx1.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-manta.dtb
@@ -56,7 +56,7 @@ index 111111111111..222222222222 100644
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1-emmc.dts b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1-emmc.dts
 new file mode 100644
-index 000000000000..111111111111
+index 0000000..f878c23
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1-emmc.dts
 @@ -0,0 +1,44 @@
@@ -106,7 +106,7 @@ index 000000000000..111111111111
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1-sd.dts b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1-sd.dts
 new file mode 100644
-index 000000000000..111111111111
+index 0000000..e18dd85
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1-sd.dts
 @@ -0,0 +1,35 @@
@@ -146,7 +146,7 @@ index 000000000000..111111111111
 +			   <&pio 2 13 GPIO_ACTIVE_HIGH>; /* PC13 */
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-index 111111111111..222222222222 100644
+index d12b01c..73c68ff 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 @@ -1,6 +1,7 @@
@@ -193,7 +193,7 @@ index 111111111111..222222222222 100644
  		compatible = "regulator-fixed";
  		regulator-name = "vcc-5v";
  		regulator-min-microvolt = <5000000>;
-@@ -36,7 +56,17 @@ reg_vcc5v: regulator-vcc5v {
+@@ -36,7 +44,17 @@
  		regulator-always-on;
  	};
  
@@ -211,7 +211,7 @@ index 111111111111..222222222222 100644
  		compatible = "regulator-fixed";
  		regulator-name = "vcc33-wifi";
  		regulator-min-microvolt = <3300000>;
-@@ -46,6 +76,7 @@ reg_vcc33_wifi: vcc33-wifi {
+@@ -46,6 +64,7 @@
  	};
  
  	reg_vcc_wifi_io: vcc-wifi-io {
@@ -219,11 +219,7 @@ index 111111111111..222222222222 100644
  		compatible = "regulator-fixed";
  		regulator-name = "vcc-wifi-io";
  		regulator-min-microvolt = <1800000>;
-@@ -57,10 +88,50 @@ reg_vcc_wifi_io: vcc-wifi-io {
- 	wifi_pwrseq: wifi-pwrseq {
- 		compatible = "mmc-pwrseq-simple";
- 		clocks = <&rtc 1>;
- 		clock-names = "ext_clock";
+@@ -61,6 +80,46 @@
  		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>; /* PG18 */
  		post-power-on-delay-ms = <200>;
  	};
@@ -270,7 +266,7 @@ index 111111111111..222222222222 100644
  };
  
  &cpu0 {
-@@ -69,9 +140,9 @@ &cpu0 {
+@@ -69,9 +128,9 @@
  
  &mmc0 {
  	vmmc-supply = <&reg_dldo1>;
@@ -281,7 +277,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-@@ -80,12 +151,56 @@ &mmc1 {
+@@ -80,12 +139,56 @@
  	vqmmc-supply = <&reg_vcc_wifi_io>;
  	mmc-pwrseq = <&wifi_pwrseq>;
  	bus-width = <4>;
@@ -290,8 +286,7 @@ index 111111111111..222222222222 100644
  	mmc-ddr-1_8v;
  	status = "okay";
 +};
- 
--	rtl8189ftv: wifi@1 {
++
 +&pio {
 +	can0_pin_irq: can0_pin_irq {
 +		function = "irq";
@@ -305,7 +300,8 @@ index 111111111111..222222222222 100644
 +	status = "disabled";
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&spi1_pins>;
-+
+ 
+-	rtl8189ftv: wifi@1 {
 +	can: mcp2515@0 {
 +		status = "disabled";
 +		compatible = "microchip,mcp2515";
@@ -339,7 +335,7 @@ index 111111111111..222222222222 100644
  	};
  };
  
-@@ -95,29 +210,34 @@ &r_i2c {
+@@ -95,29 +198,34 @@
  	axp313a: pmic@36 {
  		compatible = "x-powers,axp313a";
  		reg = <0x36>;
@@ -382,7 +378,7 @@ index 111111111111..222222222222 100644
  				regulator-always-on;
  			};
  
-@@ -125,6 +245,8 @@ reg_aldo1: aldo1 {
+@@ -125,6 +233,8 @@
  				regulator-name = "vcc-1v8-pll";
  				regulator-min-microvolt = <1800000>;
  				regulator-max-microvolt = <1800000>;
@@ -391,7 +387,7 @@ index 111111111111..222222222222 100644
  				regulator-always-on;
  			};
  
-@@ -132,12 +254,79 @@ reg_dldo1: dldo1 {
+@@ -132,12 +242,79 @@
  				regulator-name = "vcc-3v3-io";
  				regulator-min-microvolt = <3300000>;
  				regulator-max-microvolt = <3300000>;
@@ -471,6 +467,3 @@ index 111111111111..222222222222 100644
 +	dr_mode = "peripheral";
  	status = "okay";
  };
--- 
-Armbian
-

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
@@ -9,12 +9,10 @@ Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
  1 file changed, 53 insertions(+), 5 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-index 6bc49f6c4..c8cf794a8 100644
+index 00c497b..5eab23b 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-@@ -110,10 +110,19 @@ ws2812: ws2812 {
- 		rgb_cnt = <2>;
- 		rgb_value = <0x000001 0x010000>;
+@@ -100,6 +100,15 @@
  		status = "disabled";
  	};
  
@@ -30,11 +28,7 @@ index 6bc49f6c4..c8cf794a8 100644
  	i2c_gpio: i2c-gpio {
  		#address-cells = <1>;
  		#size-cells = <0>;
- 		compatible = "i2c-gpio";
- 		status = "disabled";
-@@ -147,31 +156,70 @@ mcp2515_clock: mcp2515_clock {
- 
- &cpu0 {
+@@ -137,27 +146,66 @@
  	cpu-supply = <&reg_dcdc2>;
  };
  
@@ -106,8 +100,3 @@ index 6bc49f6c4..c8cf794a8 100644
  };
  
  &mmc0 {
- 	vmmc-supply = <&reg_dldo1>;
- 	broken-cd;
--- 
-Created with Armbian build tools https://github.com/armbian/build
-

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
@@ -20,7 +20,7 @@ Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
  1 file changed, 250 insertions(+), 17 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-index 111111111111..222222222222 100644
+index bebfeb2..00c497b 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 @@ -1,6 +1,7 @@
@@ -78,7 +78,7 @@ index 111111111111..222222222222 100644
  		compatible = "regulator-fixed";
  		regulator-name = "vcc-5v";
  		regulator-min-microvolt = <5000000>;
-@@ -36,7 +67,17 @@ reg_vcc5v: regulator-vcc5v {
+@@ -36,7 +55,17 @@
  		regulator-always-on;
  	};
  
@@ -96,7 +96,7 @@ index 111111111111..222222222222 100644
  		compatible = "regulator-fixed";
  		regulator-name = "vcc33-wifi";
  		regulator-min-microvolt = <3300000>;
-@@ -46,6 +87,7 @@ reg_vcc33_wifi: vcc33-wifi {
+@@ -46,6 +75,7 @@
  	};
  
  	reg_vcc_wifi_io: vcc-wifi-io {
@@ -104,11 +104,7 @@ index 111111111111..222222222222 100644
  		compatible = "regulator-fixed";
  		regulator-name = "vcc-wifi-io";
  		regulator-min-microvolt = <1800000>;
-@@ -57,10 +99,50 @@ reg_vcc_wifi_io: vcc-wifi-io {
- 	wifi_pwrseq: wifi-pwrseq {
- 		compatible = "mmc-pwrseq-simple";
- 		clocks = <&rtc 1>;
- 		clock-names = "ext_clock";
+@@ -61,6 +91,46 @@
  		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>; /* PG18 */
  		post-power-on-delay-ms = <200>;
  	};
@@ -155,7 +151,7 @@ index 111111111111..222222222222 100644
  };
  
  &cpu0 {
-@@ -72,11 +154,29 @@ &gpu {
+@@ -72,11 +142,29 @@
  	status = "okay";
  };
  
@@ -186,7 +182,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-@@ -85,12 +185,56 @@ &mmc1 {
+@@ -85,12 +173,56 @@
  	vqmmc-supply = <&reg_vcc_wifi_io>;
  	mmc-pwrseq = <&wifi_pwrseq>;
  	bus-width = <4>;
@@ -195,7 +191,8 @@ index 111111111111..222222222222 100644
  	mmc-ddr-1_8v;
  	status = "okay";
 +};
-+
+ 
+-	rtl8189ftv: wifi@1 {
 +&pio {
 +	can0_pin_irq: can0_pin_irq {
 +		function = "irq";
@@ -209,8 +206,7 @@ index 111111111111..222222222222 100644
 +	status = "disabled";
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&spi1_pins>;
- 
--	rtl8189ftv: wifi@1 {
++
 +	can: mcp2515@0 {
 +		status = "disabled";
 +		compatible = "microchip,mcp2515";
@@ -244,7 +240,7 @@ index 111111111111..222222222222 100644
  	};
  };
  
-@@ -100,29 +244,34 @@ &r_i2c {
+@@ -100,29 +232,34 @@
  	axp313a: pmic@36 {
  		compatible = "x-powers,axp313a";
  		reg = <0x36>;
@@ -287,7 +283,7 @@ index 111111111111..222222222222 100644
  				regulator-always-on;
  			};
  
-@@ -130,6 +279,8 @@ reg_aldo1: aldo1 {
+@@ -130,6 +267,8 @@
  				regulator-name = "vcc-1v8-pll";
  				regulator-min-microvolt = <1800000>;
  				regulator-max-microvolt = <1800000>;
@@ -296,7 +292,7 @@ index 111111111111..222222222222 100644
  				regulator-always-on;
  			};
  
-@@ -137,12 +288,94 @@ reg_dldo1: dldo1 {
+@@ -137,12 +276,94 @@
  				regulator-name = "vcc-3v3-io";
  				regulator-min-microvolt = <3300000>;
  				regulator-max-microvolt = <3300000>;
@@ -391,6 +387,3 @@ index 111111111111..222222222222 100644
 +	dr_mode = "peripheral";
  	status = "okay";
  };
--- 
-Armbian
-

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
@@ -9,12 +9,10 @@ Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
  1 file changed, 53 insertions(+), 5 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-index 6bc49f6c4..c8cf794a8 100644
+index 00c497b..5eab23b 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-@@ -110,10 +110,19 @@ ws2812: ws2812 {
- 		rgb_cnt = <2>;
- 		rgb_value = <0x000001 0x010000>;
+@@ -100,6 +100,15 @@
  		status = "disabled";
  	};
  
@@ -30,11 +28,7 @@ index 6bc49f6c4..c8cf794a8 100644
  	i2c_gpio: i2c-gpio {
  		#address-cells = <1>;
  		#size-cells = <0>;
- 		compatible = "i2c-gpio";
- 		status = "disabled";
-@@ -147,31 +156,70 @@ mcp2515_clock: mcp2515_clock {
- 
- &cpu0 {
+@@ -137,27 +146,66 @@
  	cpu-supply = <&reg_dcdc2>;
  };
  
@@ -106,8 +100,3 @@ index 6bc49f6c4..c8cf794a8 100644
  };
  
  &mmc0 {
- 	vmmc-supply = <&reg_dldo1>;
- 	broken-cd;
--- 
-Created with Armbian build tools https://github.com/armbian/build
-

--- a/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
+++ b/patch/kernel/archive/sunxi-7.0/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
@@ -20,7 +20,7 @@ Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
  1 file changed, 250 insertions(+), 17 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-index 111111111111..222222222222 100644
+index bebfeb2..00c497b 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 @@ -1,6 +1,7 @@
@@ -78,7 +78,7 @@ index 111111111111..222222222222 100644
  		compatible = "regulator-fixed";
  		regulator-name = "vcc-5v";
  		regulator-min-microvolt = <5000000>;
-@@ -36,7 +67,17 @@ reg_vcc5v: regulator-vcc5v {
+@@ -36,7 +55,17 @@
  		regulator-always-on;
  	};
  
@@ -96,7 +96,7 @@ index 111111111111..222222222222 100644
  		compatible = "regulator-fixed";
  		regulator-name = "vcc33-wifi";
  		regulator-min-microvolt = <3300000>;
-@@ -46,6 +87,7 @@ reg_vcc33_wifi: vcc33-wifi {
+@@ -46,6 +75,7 @@
  	};
  
  	reg_vcc_wifi_io: vcc-wifi-io {
@@ -104,11 +104,7 @@ index 111111111111..222222222222 100644
  		compatible = "regulator-fixed";
  		regulator-name = "vcc-wifi-io";
  		regulator-min-microvolt = <1800000>;
-@@ -57,10 +99,50 @@ reg_vcc_wifi_io: vcc-wifi-io {
- 	wifi_pwrseq: wifi-pwrseq {
- 		compatible = "mmc-pwrseq-simple";
- 		clocks = <&rtc 1>;
- 		clock-names = "ext_clock";
+@@ -61,6 +91,46 @@
  		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>; /* PG18 */
  		post-power-on-delay-ms = <200>;
  	};
@@ -155,7 +151,7 @@ index 111111111111..222222222222 100644
  };
  
  &cpu0 {
-@@ -72,11 +154,29 @@ &gpu {
+@@ -72,11 +142,29 @@
  	status = "okay";
  };
  
@@ -186,7 +182,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-@@ -85,12 +185,56 @@ &mmc1 {
+@@ -85,12 +173,56 @@
  	vqmmc-supply = <&reg_vcc_wifi_io>;
  	mmc-pwrseq = <&wifi_pwrseq>;
  	bus-width = <4>;
@@ -195,7 +191,8 @@ index 111111111111..222222222222 100644
  	mmc-ddr-1_8v;
  	status = "okay";
 +};
-+
+ 
+-	rtl8189ftv: wifi@1 {
 +&pio {
 +	can0_pin_irq: can0_pin_irq {
 +		function = "irq";
@@ -209,8 +206,7 @@ index 111111111111..222222222222 100644
 +	status = "disabled";
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&spi1_pins>;
- 
--	rtl8189ftv: wifi@1 {
++
 +	can: mcp2515@0 {
 +		status = "disabled";
 +		compatible = "microchip,mcp2515";
@@ -244,7 +240,7 @@ index 111111111111..222222222222 100644
  	};
  };
  
-@@ -100,29 +244,34 @@ &r_i2c {
+@@ -100,29 +232,34 @@
  	axp313a: pmic@36 {
  		compatible = "x-powers,axp313a";
  		reg = <0x36>;
@@ -287,7 +283,7 @@ index 111111111111..222222222222 100644
  				regulator-always-on;
  			};
  
-@@ -130,6 +279,8 @@ reg_aldo1: aldo1 {
+@@ -130,6 +267,8 @@
  				regulator-name = "vcc-1v8-pll";
  				regulator-min-microvolt = <1800000>;
  				regulator-max-microvolt = <1800000>;
@@ -296,7 +292,7 @@ index 111111111111..222222222222 100644
  				regulator-always-on;
  			};
  
-@@ -137,12 +288,94 @@ reg_dldo1: dldo1 {
+@@ -137,12 +276,94 @@
  				regulator-name = "vcc-3v3-io";
  				regulator-min-microvolt = <3300000>;
  				regulator-max-microvolt = <3300000>;
@@ -391,6 +387,3 @@ index 111111111111..222222222222 100644
 +	dr_mode = "peripheral";
  	status = "okay";
  };
--- 
-Armbian
-


### PR DESCRIPTION
Every sunxi/sunxi64 kernel build (legacy/current/edge) has been aborting at the patch stage:

```
Exception: Failed to apply patch .../arm64-dts-sun50i-h616-bigtreetech-cb1*.patch
```

seen in [ci run 29812760916](https://github.com/armbian/ci/actions/runs/29812760916) across `kernel-sunxi{,64}-{legacy,current,edge}`.

## Root cause

Commit **5ab741fd7** ("cb1: stop exposing wifi power lines as gpio LEDs") hand-edited the CB1 device-tree patches, removing 12 lines from one `.dtsi` hunk and updating **that** hunks count (`+14,52` → `+14,40`) but **not** the new-side start line of every subsequent hunk — they were all left **+12 too high**. The git-based Armbian patch engine rejects the now-inconsistent `@@` headers as `failed_apply`.

The **DTS content is fine** — `git apply --recount` (which recomputes the headers) applies it cleanly. Only the hunk line-numbers are wrong.

Where it hit (matching the files 5ab741fd7 / 3a89651f1 actually edited):

| Kernel dir | Broken patch | Cascaded to |
|---|---|---|
| sunxi-6.18 (current) | `arm64-dts-…-cb1.patch` | `…-cb1-emac1-ac300.patch` |
| sunxi-7.0 (edge) | `arm64-dts-…-cb1.patch` | `…-cb1-emac1-ac300.patch` |
| sunxi-6.12 (legacy) | `…-cb1-sd-emmc.patch` | i2c-gpio/ws2812, ghost-touches-tsc2007 |

(The dependent/later patches werent themselves broken — they just had no correct `.dtsi` state to apply onto once the base failed.)

## Fix

Re-export the three edited patches with correct, self-consistent hunk headers by round-tripping through git against the (unchanged) mainline base. **The DTS/Makefile payload is byte-for-byte identical** — verified equal added-content line counts (206 for cb1, 232 for sd-emmc); only the `@@` numbers/grouping are corrected. The 07-20 wifi fixes are fully preserved: `ext_clock` restored, `wifi_power`/`wifi_wake` pseudo-LEDs removed, `ac300` pwm clock present.

## Verification (per branch, on the matching mainline dtsi)

- 6.18/7.0: `cb1` + `emac1-ac300` apply cleanly in series order with both `patch` and `git apply`; resulting DTS has balanced braces; wifi fixes + emac1 alias present.
- 6.12: regenerated `sd-emmc` applies cleanly (braces balanced, both variant `.dts` created), and the previously-cascading `i2c-gpio-mode/ws2812` patch then applies on top.

⚠️ Board DTS change — a **boot smoke on real BTT CB1 hardware** is the final gate before merge (the payload is unchanged from what 5ab741fd7/3a89651f1 intended, so behaviour should match, but the patches simply couldnt be applied before this).

cc the CB1 maintainers (the 07-20 commits were hardware-verified by @lexfrei @JohnTheCoolingFan ).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added full device support for the BigTreeTech CB1 on Allwinner H616, including separate SD and eMMC configurations.
  * Enabled HDMI output/connector linking, Ethernet (RMII via EMAC1), and USB-C in peripheral mode.
  * Added/declared optional peripherals: WS2812 RGB LED, CAN controller, SPI display, I2C touch/light sensors.
  * Added support for Ethernet using the AC300 PHY.
* **Updates**
  * Improved board console routing, status LED behavior, and refined power/regulator and storage timing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->