### PR TITLE
mainline: bump `bleedingedge` to 7.2-rc4

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0          # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "7.2" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v7.2-rc3"
+		declare -g KERNELBRANCH="tag:v7.2-rc4"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }
@@ -26,11 +26,11 @@ function mainline_kernel_decide_version__upstream_release_candidate_number() {
 
 # Example: 6.7-rc7 was released by Linus, but kernel.org git and google git mirrors took a while to catch up; change the source to pull directly from Linus.
 # This was necessary for a few days in late December 2023, but no longer; tag was pushed on 28/Dec/2023.
-function mainline_kernel_decide_version__750_use_torvalds_for_7.2-rc3() {
-	if [[ "${KERNELBRANCH}" == 'tag:v7.2-rc3' ]]; then
-		display_alert "Using Linus kernel repo for 7.2-rc3" "${KERNELBRANCH}" "warn"
+function mainline_kernel_decide_version__750_use_torvalds_for_7.2-rc4() {
+	if [[ "${KERNELBRANCH}" == 'tag:v7.2-rc4' ]]; then
+		display_alert "Using Linus kernel repo for 7.2-rc4" "${KERNELBRANCH}" "warn"
 		declare -g KERNELSOURCE="https://github.com/torvalds/linux.git"
-		display_alert "mainline-kernel: missing torvalds tag on 7.2-rc3" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
+		display_alert "mainline-kernel: missing torvalds tag on 7.2-rc4" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
 	fi
 }
 

--- a/patch/kernel/archive/rockchip64-7.2/general-dw-hdmi-qp-error2info-logging-k7.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-dw-hdmi-qp-error2info-logging-k7.patch
@@ -1,12 +1,7 @@
-From git@z Thu Jan  1 00:00:00 1970
-Subject: [PATCH v2 1/3] drm/bridge: dw-hdmi-qp: Return 0 in audio prepare
- when disconnected
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Detlev Casanova <detlev.casanova@collabora.com>
 Date: Tue, 22 Jul 2025 15:54:35 -0400
-Message-Id: <20250722195437.1347865-2-detlev.casanova@collabora.com>
-MIME-Version: 1.0
-Content-Type: text/plain; charset="utf-8"
-Content-Transfer-Encoding: 7bit
+Subject: drm/bridge: dw-hdmi-qp: Return 0 in audio prepare when disconnected
 
 To configure audio registers, the clock of the video port in use must be
 enabled.
@@ -41,10 +36,10 @@ Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
-index 5e5f8c2f95be1..9b9d43c02e3a5 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
 +++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
-@@ -458,8 +458,16 @@ static int dw_hdmi_qp_audio_prepare(struct drm_connector *connector,
+@@ -481,8 +481,16 @@ static int dw_hdmi_qp_audio_prepare(struct drm_bridge *bridge,
  	struct dw_hdmi_qp *hdmi = dw_hdmi_qp_from_bridge(bridge);
  	bool ref2stream = false;
  
@@ -63,17 +58,12 @@ index 5e5f8c2f95be1..9b9d43c02e3a5 100644
  	if (fmt->bit_clk_provider | fmt->frame_clk_provider) {
  		dev_err(hdmi->dev, "unsupported clock settings\n");
 -- 
-2.50.1
+Armbian
 
-From git@z Thu Jan  1 00:00:00 1970
-Subject: [PATCH v2 2/3] ASoC: hdac_hdmi: Use dev_info on invalid ELD
- version
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Detlev Casanova <detlev.casanova@collabora.com>
 Date: Tue, 22 Jul 2025 15:54:36 -0400
-Message-Id: <20250722195437.1347865-3-detlev.casanova@collabora.com>
-MIME-Version: 1.0
-Content-Type: text/plain; charset="utf-8"
-Content-Transfer-Encoding: 7bit
+Subject: ASoC: hdac_hdmi: Use dev_info on invalid ELD version
 
 When disconnected, the ELD data cannot be read by the display driver, so
 it just sets the data to 0.
@@ -94,10 +84,10 @@ Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/sound/soc/codecs/hdac_hdmi.c b/sound/soc/codecs/hdac_hdmi.c
-index 1139a2754ca33..4cc3b7a1062bd 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/hdac_hdmi.c
 +++ b/sound/soc/codecs/hdac_hdmi.c
-@@ -1236,7 +1236,7 @@ static int hdac_hdmi_parse_eld(struct hd
+@@ -1238,7 +1238,7 @@ static int hdac_hdmi_parse_eld(struct hdac_device *hdev,
  						>> DRM_ELD_VER_SHIFT;
  
  	if (ver != ELD_VER_CEA_861D && ver != ELD_VER_PARTIAL) {
@@ -106,19 +96,13 @@ index 1139a2754ca33..4cc3b7a1062bd 100644
  				    "HDMI: Unknown ELD version %d\n", ver);
  		return -EINVAL;
  	}
- 
 -- 
-2.50.1
+Armbian
 
-From git@z Thu Jan  1 00:00:00 1970
-Subject: [PATCH v2 3/3] drm/bridge: synopsys: Do not warn about audio
- params computation
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Detlev Casanova <detlev.casanova@collabora.com>
 Date: Tue, 22 Jul 2025 15:54:37 -0400
-Message-Id: <20250722195437.1347865-4-detlev.casanova@collabora.com>
-MIME-Version: 1.0
-Content-Type: text/plain; charset="utf-8"
-Content-Transfer-Encoding: 7bit
+Subject: drm/bridge: synopsys: Do not warn about audio params computation
 
 There is no need to warn about non pre-computed values, just change it to
 dbg.
@@ -130,10 +114,10 @@ Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
-index 9b9d43c02e3a5..d974bcad8f94a 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
 +++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
-@@ -276,8 +276,7 @@ static unsigned int dw_hdmi_qp_find_n(struct dw_hdmi_qp *hdmi, unsigned long pix
+@@ -299,8 +299,7 @@ static unsigned int dw_hdmi_qp_find_n(struct dw_hdmi_qp *hdmi, unsigned long pix
  	if (n > 0)
  		return n;
  
@@ -144,5 +128,5 @@ index 9b9d43c02e3a5..d974bcad8f94a 100644
  	return dw_hdmi_qp_compute_n(hdmi, pixel_clk, sample_rate);
  }
 -- 
-2.50.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.2/rk3588-1230-can-rockchip-add-rk3588-can-support.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3588-1230-can-rockchip-add-rk3588-can-support.patch
@@ -45,12 +45,10 @@ Signed-off-by: luch00 <1579567540@qq.com>
  5 files changed, 76 insertions(+), 3 deletions(-)
 
 diff --git a/Documentation/devicetree/bindings/net/can/rockchip,rk3568v2-canfd.yaml b/Documentation/devicetree/bindings/net/can/rockchip,rk3568v2-canfd.yaml
-index a077c0330013..81e2b6dfeb02 100644
+index 111111111111..222222222222 100644
 --- a/Documentation/devicetree/bindings/net/can/rockchip,rk3568v2-canfd.yaml
 +++ b/Documentation/devicetree/bindings/net/can/rockchip,rk3568v2-canfd.yaml
-@@ -14,11 +14,13 @@ allOf:
-   - $ref: can-controller.yaml#
- 
+@@ -16,7 +16,9 @@ allOf:
  properties:
    compatible:
      oneOf:
@@ -61,15 +59,11 @@ index a077c0330013..81e2b6dfeb02 100644
        - items:
            - const: rockchip,rk3568v3-canfd
            - const: rockchip,rk3568v2-canfd
- 
-   reg:
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-index c47bb3c68c6c..4c36e7602588 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-@@ -2658,10 +2658,49 @@ dmac1: dma-controller@fea30000 {
- 		clocks = <&cru ACLK_DMAC1>;
- 		clock-names = "apb_pclk";
+@@ -2648,6 +2648,45 @@ dmac1: dma-controller@fea30000 {
  		#dma-cells = <1>;
  	};
  
@@ -115,15 +109,11 @@ index c47bb3c68c6c..4c36e7602588 100644
  	i2c1: i2c@fea90000 {
  		compatible = "rockchip,rk3588-i2c", "rockchip,rk3399-i2c";
  		reg = <0x0 0xfea90000 0x0 0x1000>;
- 		clocks = <&cru CLK_I2C1>, <&cru PCLK_I2C1>;
- 		clock-names = "i2c", "pclk";
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-core.c b/drivers/net/can/rockchip/rockchip_canfd-core.c
-index 29de0c01e4ed..37c1c22c40c9 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-core.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-core.c
-@@ -48,17 +48,25 @@ static const struct rkcanfd_devtype_data rkcanfd_devtype_data_rk3568v3 = {
- 		RKCANFD_QUIRK_RK3568_ERRATUM_8 | RKCANFD_QUIRK_RK3568_ERRATUM_10 |
- 		RKCANFD_QUIRK_RK3568_ERRATUM_11 | RKCANFD_QUIRK_RK3568_ERRATUM_12 |
+@@ -50,6 +50,12 @@ static const struct rkcanfd_devtype_data rkcanfd_devtype_data_rk3568v3 = {
  		RKCANFD_QUIRK_CANFD_BROKEN,
  };
  
@@ -136,7 +126,7 @@ index 29de0c01e4ed..37c1c22c40c9 100644
  static const char *__rkcanfd_get_model_str(enum rkcanfd_model model)
  {
  	switch (model) {
- 	case RKCANFD_MODEL_RK3568V2:
+@@ -57,6 +63,8 @@ static const char *__rkcanfd_get_model_str(enum rkcanfd_model model)
  		return "rk3568v2";
  	case RKCANFD_MODEL_RK3568V3:
  		return "rk3568v3";
@@ -145,11 +135,7 @@ index 29de0c01e4ed..37c1c22c40c9 100644
  	}
  
  	return "<unknown>";
- }
- 
-@@ -146,10 +154,16 @@ static int rkcanfd_set_bittiming(struct rkcanfd_priv *priv)
- 		FIELD_PREP(RKCANFD_REG_FD_DATA_BITTIMING_TSEG1,
- 			   dbt->prop_seg + dbt->phase_seg1 - 1);
+@@ -148,6 +156,12 @@ static int rkcanfd_set_bittiming(struct rkcanfd_priv *priv)
  
  	rkcanfd_write(priv, RKCANFD_REG_FD_DATA_BITTIMING, reg_dbt);
  
@@ -162,11 +148,7 @@ index 29de0c01e4ed..37c1c22c40c9 100644
  	tdco = (priv->can.clock.freq / dbt->bitrate) * 2 / 3;
  	tdco = min(tdco, FIELD_MAX(RKCANFD_REG_TRANSMIT_DELAY_COMPENSATION_TDC_OFFSET));
  
- 	reg_tdc = FIELD_PREP(RKCANFD_REG_TRANSMIT_DELAY_COMPENSATION_TDC_OFFSET, tdco) |
- 		RKCANFD_REG_TRANSMIT_DELAY_COMPENSATION_TDC_ENABLE;
-@@ -844,10 +858,13 @@ static const struct of_device_id rkcanfd_of_match[] = {
- 		.compatible = "rockchip,rk3568v2-canfd",
- 		.data = &rkcanfd_devtype_data_rk3568v2,
+@@ -846,6 +860,9 @@ static const struct of_device_id rkcanfd_of_match[] = {
  	}, {
  		.compatible = "rockchip,rk3568v3-canfd",
  		.data = &rkcanfd_devtype_data_rk3568v3,
@@ -176,15 +158,11 @@ index 29de0c01e4ed..37c1c22c40c9 100644
  	}, {
  		/* sentinel */
  	},
- };
- MODULE_DEVICE_TABLE(of, rkcanfd_of_match);
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-rx.c b/drivers/net/can/rockchip/rockchip_canfd-rx.c
-index 475c0409e215..24e87daa1df0 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-rx.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-rx.c
-@@ -279,11 +279,14 @@ static int rkcanfd_handle_rx_int_one(struct rkcanfd_priv *priv)
- static inline unsigned int
- rkcanfd_rx_fifo_get_len(const struct rkcanfd_priv *priv)
+@@ -281,7 +281,10 @@ rkcanfd_rx_fifo_get_len(const struct rkcanfd_priv *priv)
  {
  	const u32 reg = rkcanfd_read(priv, RKCANFD_REG_RX_FIFO_CTRL);
  
@@ -196,15 +174,11 @@ index 475c0409e215..24e87daa1df0 100644
  }
  
  int rkcanfd_handle_rx_int(struct rkcanfd_priv *priv)
- {
- 	unsigned int len;
 diff --git a/drivers/net/can/rockchip/rockchip_canfd.h b/drivers/net/can/rockchip/rockchip_canfd.h
-index 93131c7d7f54..95bea9bfd8a2 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd.h
 +++ b/drivers/net/can/rockchip/rockchip_canfd.h
-@@ -212,11 +212,12 @@
- #define RKCANFD_REG_TXEVENT_FIFO_CTRL_TXE_FIFO_CNT GENMASK(8, 5)
- #define RKCANFD_REG_TXEVENT_FIFO_CTRL_TXE_FIFO_WATERMARK GENMASK(4, 1)
+@@ -214,7 +214,8 @@
  #define RKCANFD_REG_TXEVENT_FIFO_CTRL_TXE_FIFO_ENABLE BIT(0)
  
  #define RKCANFD_REG_RX_FIFO_CTRL 0x118
@@ -214,11 +188,7 @@ index 93131c7d7f54..95bea9bfd8a2 100644
  #define RKCANFD_REG_RX_FIFO_CTRL_RX_FIFO_FULL_WATERMARK GENMASK(3, 1)
  #define RKCANFD_REG_RX_FIFO_CTRL_RX_FIFO_ENABLE BIT(0)
  
- #define RKCANFD_REG_AFC_CTRL 0x11c
- #define RKCANFD_REG_AFC_CTRL_UAF5 BIT(4)
-@@ -329,10 +330,15 @@
-  *
-  * On the rk3568v2 and rk3568v3, this problem only occurs extremely
+@@ -331,6 +332,11 @@
   * rarely with the standard clock of 300 MHz, but almost immediately
   * at 80 MHz.
   *
@@ -230,11 +200,7 @@ index 93131c7d7f54..95bea9bfd8a2 100644
   * To workaround this problem, check for empty FIFO with
   * rkcanfd_fifo_header_empty() in rkcanfd_handle_rx_int_one() and exit
   * early.
-  *
-  * To reproduce:
-@@ -342,10 +348,12 @@
- #define RKCANFD_QUIRK_RK3568_ERRATUM_5 BIT(4)
- 
+@@ -344,6 +350,8 @@
  /* Erratum 6: The CAN controller's transmission of extended frames may
   * intermittently change into standard frames
   *
@@ -243,11 +209,7 @@ index 93131c7d7f54..95bea9bfd8a2 100644
   * Work around this issue by activating self reception (RXSTX). If we
   * have pending TX CAN frames, check all RX'ed CAN frames in
   * rkcanfd_rxstx_filter().
-  *
-  * If it's a frame we've send and it's OK, call the TX complete
-@@ -422,20 +430,24 @@
-  *   DUT:
-  *     cangen can0 -I2 -L1 -Di -p10 -c10 -g 1 -e
+@@ -424,6 +432,9 @@
   *     cansequence -rv -i 1
   *
   * - TX starvation after repeated Bus-Off
@@ -257,10 +219,7 @@ index 93131c7d7f54..95bea9bfd8a2 100644
   *   To reproduce:
   *   host:
   *     sleep 3 && cangen can0 -I2 -Li -Di -p10 -g 0.0
-  *   DUT:
-  *     cangen can0 -I2 -Li -Di -p10 -g 0.05
-  */
- 
+@@ -434,6 +445,7 @@
  enum rkcanfd_model {
  	RKCANFD_MODEL_RK3568V2 = 0x35682,
  	RKCANFD_MODEL_RK3568V3 = 0x35683,
@@ -268,8 +227,6 @@ index 93131c7d7f54..95bea9bfd8a2 100644
  };
  
  struct rkcanfd_devtype_data {
- 	enum rkcanfd_model model;
- 	u32 quirks;
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.2/rk35xx-panthor-1GHz.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk35xx-panthor-1GHz.patch
@@ -704,7 +704,7 @@ index 111111111111..222222222222 100644
  	drm_info(&ptdev->base, "clock rate = %lu\n", clk_get_rate(ptdev->clks.core));
  	return 0;
  }
-@@ -496,10 +502,14 @@ int panthor_device_resume(struct device *dev)
+@@ -499,10 +505,14 @@ int panthor_device_resume(struct device *dev)
  
  	atomic_set(&ptdev->pm.state, PANTHOR_DEVICE_PM_STATE_RESUMING);
  
@@ -720,7 +720,7 @@ index 111111111111..222222222222 100644
  	ret = clk_prepare_enable(ptdev->clks.stacks);
  	if (ret)
  		goto err_disable_core_clk;
-@@ -558,6 +568,9 @@ int panthor_device_resume(struct device *dev)
+@@ -561,6 +571,9 @@ int panthor_device_resume(struct device *dev)
  err_disable_core_clk:
  	clk_disable_unprepare(ptdev->clks.core);
  
@@ -730,7 +730,7 @@ index 111111111111..222222222222 100644
  err_set_suspended:
  	atomic_set(&ptdev->pm.state, PANTHOR_DEVICE_PM_STATE_SUSPENDED);
  	atomic_set(&ptdev->pm.recovery_needed, 1);
-@@ -605,6 +618,7 @@ int panthor_device_suspend(struct device *dev)
+@@ -608,6 +621,7 @@ int panthor_device_suspend(struct device *dev)
  	clk_disable_unprepare(ptdev->clks.coregroup);
  	clk_disable_unprepare(ptdev->clks.stacks);
  	clk_disable_unprepare(ptdev->clks.core);


### PR DESCRIPTION
# Description

- as per title
- rewritten rockchip64-7.2 patchset against rc4
- no changes for meson64 and both uefi 

# How Has This Been Tested?

- [x] build rockchip64, meson64, both uefi

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for RK3588 CAN-FD controllers, including three available controller nodes and improved CAN-FD timing.
  - Updated the mainline kernel integration to use Linux 7.2-rc4.

- **Bug Fixes**
  - Improved HDMI audio handling during disconnects and reduced unnecessary error and warning messages.
  - Improved Panthor GPU power management by handling the optional bus clock during suspend and resume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->