### PR TITLE
recomputer: drop 'Devkit' from BOARD_NAME

### DIFF
--- a/config/boards/recomputer-rk3576-devkit.conf
+++ b/config/boards/recomputer-rk3576-devkit.conf
@@ -1,5 +1,5 @@
 # Seeed Studio Rockchip RK3576 octa core 8GB RAM eMMC GbE USB3 HDMI WiFi BT
-BOARD_NAME="reComputer RK3576 Devkit"
+BOARD_NAME="reComputer RK3576"
 BOARDFAMILY="seeed-rk3576"
 BOOT_SOC="rk3576"
 BOARD_MAINTAINER="Pillar1989"

--- a/config/boards/recomputer-rk3588-devkit.conf
+++ b/config/boards/recomputer-rk3588-devkit.conf
@@ -1,5 +1,5 @@
 # Seeed Studio Rockchip RK3588 octa core 4/8/16GB RAM eMMC NVMe 2.5GbE USB3 HDMI DP WiFi BT
-BOARD_NAME="reComputer RK3588 Devkit"
+BOARD_NAME="reComputer RK3588"
 BOARDFAMILY="seeed-rk3588"
 BOARD_MAINTAINER="Pillar1989"
 BOARD_VENDOR="seeed-studio"


### PR DESCRIPTION
Shortens the display names:

| Board file | Before | After |
|---|---|---|
| `recomputer-rk3576-devkit.conf` | `reComputer RK3576 Devkit` | `reComputer RK3576` |
| `recomputer-rk3588-devkit.conf` | `reComputer RK3588 Devkit` | `reComputer RK3588` |

Only the `BOARD_NAME` label changes. The board slug (`recomputer-rk35xx-devkit`), `BOOTCONFIG`/defconfig (`recomputer-rk3588-devkit_defconfig`), `BOOT_FDT_FILE` (`rk3588-recomputer-rk3588-devkit.dtb`) and hook function names are intentionally left unchanged — they reference the vendor's actual u-boot defconfig and kernel DTB, so renaming them would break the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated the displayed board names for the reComputer RK3576 and RK3588 boards.
  - Simplified the names by removing the “Devkit” suffix for clearer, more consistent identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Requested by the vendor (Seeed Studio); noted in a comment above `BOARD_NAME` in both board files.