### PR TITLE
rockchip64: fix rk3328 dmc driver on newer kernels

### DIFF
--- a/patch/kernel/archive/rockchip64-7.1/rk3328-add-dmc-driver.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3328-add-dmc-driver.patch
@@ -410,10 +410,10 @@ index 111111111111..222222222222 100644
  		compatible = "rockchip,rk3328-efuse";
  		reg = <0x0 0xff260000 0x0 0x50>;
 diff --git a/drivers/clk/rockchip/clk-ddr.c b/drivers/clk/rockchip/clk-ddr.c
-index 111111111111..222222222222 100644
+index 81ae8a4ee30e..42dd7a37aa16 100644
 --- a/drivers/clk/rockchip/clk-ddr.c
 +++ b/drivers/clk/rockchip/clk-ddr.c
-@@ -88,6 +88,133 @@ static const struct clk_ops rockchip_ddrclk_sip_ops = {
+@@ -88,6 +88,136 @@ static const struct clk_ops rockchip_ddrclk_sip_ops = {
  	.get_parent = rockchip_ddrclk_get_parent,
  };
  
@@ -513,9 +513,8 @@ index 111111111111..222222222222 100644
 +		return 0;
 +}
 +
-+static long rockchip_ddrclk_sip_round_rate_v2(struct clk_hw *hw,
-+					      unsigned long rate,
-+					      unsigned long *prate)
++static int rockchip_ddrclk_sip_determine_rate_v2(struct clk_hw *hw,
++						 struct clk_rate_request *req)
 +{
 +	struct share_params *p;
 +	struct arm_smccc_res res;
@@ -525,21 +524,25 @@ index 111111111111..222222222222 100644
 +
 +	p = (struct share_params *)ddr_data.share_memory;
 +
-+	p->hz = rate;
++	p->hz = req->rate;
 +
 +	arm_smccc_smc(ROCKCHIP_SIP_DRAM_FREQ,
 +		      SHARE_PAGE_TYPE_DDR, 0,
 +		      ROCKCHIP_SIP_CONFIG_DRAM_ROUND_RATE,
 +		      0, 0, 0, 0, &res);
 +
-+	if (!res.a0)
-+		return res.a1;
-+	else
-+		return 0;
++	if (res.a0)
++		return -EINVAL;
++
++	req->rate = res.a1;
++
++	return 0;
++
 +}
 +
 +static const struct clk_ops rockchip_ddrclk_sip_ops_v2 = {
 +	.recalc_rate = rockchip_ddrclk_sip_recalc_rate_v2,
++	.determine_rate = rockchip_ddrclk_sip_determine_rate_v2,
 +	.set_rate = rockchip_ddrclk_sip_set_rate_v2,
 +	.get_parent = rockchip_ddrclk_get_parent,
 +};
@@ -547,7 +550,7 @@ index 111111111111..222222222222 100644
  struct clk *rockchip_clk_register_ddrclk(const char *name, int flags,
  					 const char *const *parent_names,
  					 u8 num_parents, int mux_offset,
-@@ -115,6 +242,9 @@ struct clk *rockchip_clk_register_ddrclk(const char *name, int flags,
+@@ -115,6 +245,9 @@ struct clk *rockchip_clk_register_ddrclk(const char *name, int flags,
  	case ROCKCHIP_DDRCLK_SIP:
  		init.ops = &rockchip_ddrclk_sip_ops;
  		break;
@@ -633,7 +636,7 @@ index 111111111111..222222222222 100644
  obj-$(CONFIG_ARM_TEGRA_DEVFREQ)		+= tegra30-devfreq.o
  
 diff --git a/drivers/devfreq/event/rockchip-dfi.c b/drivers/devfreq/event/rockchip-dfi.c
-index 111111111111..222222222222 100644
+index 5e6e7e900bda..ade65e839c93 100644
 --- a/drivers/devfreq/event/rockchip-dfi.c
 +++ b/drivers/devfreq/event/rockchip-dfi.c
 @@ -25,6 +25,8 @@
@@ -653,7 +656,19 @@ index 111111111111..222222222222 100644
  	struct regmap *regmap_pmu;
  	struct clk *clk;
  	int usecount;
-@@ -711,6 +714,46 @@ static int rockchip_ddr_perf_init(struct rockchip_dfi *dfi)
+@@ -158,9 +161,8 @@ static int rockchip_dfi_ddrtype_to_ctrl(struct rockchip_dfi *dfi, u32 *ctrl)
+ 			ddrmon_ver);
+ 		return -EOPNOTSUPP;
+ 	default:
+-		dev_err(&dfi->edev->dev, "unsupported memory type 0x%X\n",
+-			dfi->ddr_type);
+-		return -EOPNOTSUPP;
++		*ctrl = 0;
++		break;
+ 	}
+ 
+ 	return 0;
+@@ -711,6 +713,46 @@ static int rockchip_ddr_perf_init(struct rockchip_dfi *dfi)
  }
  #endif
  
@@ -700,7 +715,7 @@ index 111111111111..222222222222 100644
  static int rk3399_dfi_init(struct rockchip_dfi *dfi)
  {
  	struct regmap *regmap_pmu = dfi->regmap_pmu;
-@@ -808,6 +851,8 @@ static int rk3588_dfi_init(struct rockchip_dfi *dfi)
+@@ -808,6 +850,8 @@ static int rk3588_dfi_init(struct rockchip_dfi *dfi)
  };
  
  static const struct of_device_id rockchip_dfi_id_match[] = {
@@ -709,7 +724,7 @@ index 111111111111..222222222222 100644
  	{ .compatible = "rockchip,rk3399-dfi", .data = rk3399_dfi_init },
  	{ .compatible = "rockchip,rk3568-dfi", .data = rk3568_dfi_init },
  	{ .compatible = "rockchip,rk3588-dfi", .data = rk3588_dfi_init },
-@@ -837,14 +882,30 @@ static int rockchip_dfi_probe(struct platform_device *pdev)
+@@ -837,14 +881,30 @@ static int rockchip_dfi_probe(struct platform_device *pdev)
  	if (IS_ERR(dfi->regs))
  		return PTR_ERR(dfi->regs);
  
@@ -747,7 +762,7 @@ index 111111111111..222222222222 100644
  
  	dfi->dev = dev;
  	mutex_init(&dfi->mutex);
-@@ -869,6 +930,8 @@ static int rockchip_dfi_probe(struct platform_device *pdev)
+@@ -869,6 +929,8 @@ static int rockchip_dfi_probe(struct platform_device *pdev)
  	if (ret)
  		return ret;
  

--- a/patch/kernel/archive/rockchip64-7.2/rk3328-add-dmc-driver.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3328-add-dmc-driver.patch
@@ -410,10 +410,10 @@ index 111111111111..222222222222 100644
  		compatible = "rockchip,rk3328-efuse";
  		reg = <0x0 0xff260000 0x0 0x50>;
 diff --git a/drivers/clk/rockchip/clk-ddr.c b/drivers/clk/rockchip/clk-ddr.c
-index 111111111111..222222222222 100644
+index 81ae8a4ee30e..42dd7a37aa16 100644
 --- a/drivers/clk/rockchip/clk-ddr.c
 +++ b/drivers/clk/rockchip/clk-ddr.c
-@@ -88,6 +88,133 @@ static const struct clk_ops rockchip_ddrclk_sip_ops = {
+@@ -88,6 +88,136 @@ static const struct clk_ops rockchip_ddrclk_sip_ops = {
  	.get_parent = rockchip_ddrclk_get_parent,
  };
  
@@ -513,9 +513,8 @@ index 111111111111..222222222222 100644
 +		return 0;
 +}
 +
-+static long rockchip_ddrclk_sip_round_rate_v2(struct clk_hw *hw,
-+					      unsigned long rate,
-+					      unsigned long *prate)
++static int rockchip_ddrclk_sip_determine_rate_v2(struct clk_hw *hw,
++						 struct clk_rate_request *req)
 +{
 +	struct share_params *p;
 +	struct arm_smccc_res res;
@@ -525,21 +524,25 @@ index 111111111111..222222222222 100644
 +
 +	p = (struct share_params *)ddr_data.share_memory;
 +
-+	p->hz = rate;
++	p->hz = req->rate;
 +
 +	arm_smccc_smc(ROCKCHIP_SIP_DRAM_FREQ,
 +		      SHARE_PAGE_TYPE_DDR, 0,
 +		      ROCKCHIP_SIP_CONFIG_DRAM_ROUND_RATE,
 +		      0, 0, 0, 0, &res);
 +
-+	if (!res.a0)
-+		return res.a1;
-+	else
-+		return 0;
++	if (res.a0)
++		return -EINVAL;
++
++	req->rate = res.a1;
++
++	return 0;
++
 +}
 +
 +static const struct clk_ops rockchip_ddrclk_sip_ops_v2 = {
 +	.recalc_rate = rockchip_ddrclk_sip_recalc_rate_v2,
++	.determine_rate = rockchip_ddrclk_sip_determine_rate_v2,
 +	.set_rate = rockchip_ddrclk_sip_set_rate_v2,
 +	.get_parent = rockchip_ddrclk_get_parent,
 +};
@@ -547,7 +550,7 @@ index 111111111111..222222222222 100644
  struct clk *rockchip_clk_register_ddrclk(const char *name, int flags,
  					 const char *const *parent_names,
  					 u8 num_parents, int mux_offset,
-@@ -115,6 +242,9 @@ struct clk *rockchip_clk_register_ddrclk(const char *name, int flags,
+@@ -115,6 +245,9 @@ struct clk *rockchip_clk_register_ddrclk(const char *name, int flags,
  	case ROCKCHIP_DDRCLK_SIP:
  		init.ops = &rockchip_ddrclk_sip_ops;
  		break;
@@ -633,7 +636,7 @@ index 111111111111..222222222222 100644
  obj-$(CONFIG_ARM_TEGRA_DEVFREQ)		+= tegra30-devfreq.o
  
 diff --git a/drivers/devfreq/event/rockchip-dfi.c b/drivers/devfreq/event/rockchip-dfi.c
-index 111111111111..222222222222 100644
+index 5e6e7e900bda..ade65e839c93 100644
 --- a/drivers/devfreq/event/rockchip-dfi.c
 +++ b/drivers/devfreq/event/rockchip-dfi.c
 @@ -25,6 +25,8 @@
@@ -653,7 +656,19 @@ index 111111111111..222222222222 100644
  	struct regmap *regmap_pmu;
  	struct clk *clk;
  	int usecount;
-@@ -711,6 +714,46 @@ static int rockchip_ddr_perf_init(struct rockchip_dfi *dfi)
+@@ -158,9 +161,8 @@ static int rockchip_dfi_ddrtype_to_ctrl(struct rockchip_dfi *dfi, u32 *ctrl)
+ 			ddrmon_ver);
+ 		return -EOPNOTSUPP;
+ 	default:
+-		dev_err(&dfi->edev->dev, "unsupported memory type 0x%X\n",
+-			dfi->ddr_type);
+-		return -EOPNOTSUPP;
++		*ctrl = 0;
++		break;
+ 	}
+ 
+ 	return 0;
+@@ -711,6 +713,46 @@ static int rockchip_ddr_perf_init(struct rockchip_dfi *dfi)
  }
  #endif
  
@@ -700,7 +715,7 @@ index 111111111111..222222222222 100644
  static int rk3399_dfi_init(struct rockchip_dfi *dfi)
  {
  	struct regmap *regmap_pmu = dfi->regmap_pmu;
-@@ -808,6 +851,8 @@ static int rk3588_dfi_init(struct rockchip_dfi *dfi)
+@@ -808,6 +850,8 @@ static int rk3588_dfi_init(struct rockchip_dfi *dfi)
  };
  
  static const struct of_device_id rockchip_dfi_id_match[] = {
@@ -709,7 +724,7 @@ index 111111111111..222222222222 100644
  	{ .compatible = "rockchip,rk3399-dfi", .data = rk3399_dfi_init },
  	{ .compatible = "rockchip,rk3568-dfi", .data = rk3568_dfi_init },
  	{ .compatible = "rockchip,rk3588-dfi", .data = rk3588_dfi_init },
-@@ -837,14 +882,30 @@ static int rockchip_dfi_probe(struct platform_device *pdev)
+@@ -837,14 +881,30 @@ static int rockchip_dfi_probe(struct platform_device *pdev)
  	if (IS_ERR(dfi->regs))
  		return PTR_ERR(dfi->regs);
  
@@ -747,7 +762,7 @@ index 111111111111..222222222222 100644
  
  	dfi->dev = dev;
  	mutex_init(&dfi->mutex);
-@@ -869,6 +930,8 @@ static int rockchip_dfi_probe(struct platform_device *pdev)
+@@ -869,6 +929,8 @@ static int rockchip_dfi_probe(struct platform_device *pdev)
  	if (ret)
  		return ret;
  


### PR DESCRIPTION
# Description

On recent kernels (>= 7.0), rockchip dfi driver does not recognize DDR3 memories anymore as suitable for events; moreover with kernel >= 7.1 clock providers require `clk_osp.determine_rate` member to be populated.

This PR fixes the dfi driver allowing falling through when an unknown DDR memory is detected (just like it was in previous kernels). Also fixes the dmc driver providing `.determine_rate` member using the existing `ROCKCHIP_SIP_CONFIG_DRAM_ROUND_RATE` ATF function facility.

Fixes are provided for edge (7.1) and bleedingedge (7.2) rockchip64 kernels.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2859]

# How Has This Been Tested?

- [x] Edge kernel compiled successfully and tested on rockpi-e (rk3328)
- [x] Bleedingedge kernel compiled successfully and tested on rockpi-e (rk3328)

Although the driver seems to work again right now, the ATF for rockpi-e does not seem to support DDR3 frequencies below 786MHz, thus in essence it is ineffective on this board. Nonetheless other boards may benefit from these fixes and, at least, the fixes remove the warning messages in dmesg.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


[AR-2859]: https://armbian.atlassian.net/browse/AR-2859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic memory frequency scaling support for RK3328 devices.
  * Added DDR timing and operating-point configuration for improved memory performance and power efficiency.
  * Added thermal cooling and suspend/resume support for the memory controller.
  * Added support for RK3228/RK3328 DDR monitoring and clock-rate management.
* **Documentation**
  * Added device-tree bindings and configuration definitions for RK3328 memory and DDR settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->