### PR TITLE
SpacemiT K1: Enable PCIe on OrangePi R2S and  add other misc thermal spi and pcie fixups

### DIFF
--- a/patch/kernel/archive/spacemit-7.2/005-PATCH-PCI-dwc-spacemit-add-missing-MODULE_DEVICE_TABLE.patch
+++ b/patch/kernel/archive/spacemit-7.2/005-PATCH-PCI-dwc-spacemit-add-missing-MODULE_DEVICE_TABLE.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pengpeng Hou <pengpeng@iscas.ac.cn>
+Subject: [PATCH] PCI: dwc: spacemit: add missing MODULE_DEVICE_TABLE()
+Date: Sat,  4 Jul 2026 20:25:38 +0800
+
+The driver has an OF match table wired to .of_match_table, but does
+not export the table with MODULE_DEVICE_TABLE().
+
+Add the missing MODULE_DEVICE_TABLE(of, ...) entry so module alias
+information is generated for OF based module autoloading.
+
+This is a source-level fix.  It does not claim dynamic hardware
+reproduction; the evidence is the driver-owned match table, its use by
+the platform driver, and the missing module alias publication.
+
+Signed-off-by: Pengpeng Hou <pengpeng@iscas.ac.cn>
+---
+ drivers/pci/controller/dwc/pcie-spacemit-k1.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/pci/controller/dwc/pcie-spacemit-k1.c b/drivers/pci/controller/dwc/pcie-spacemit-k1.c
+index 04241df8fd59..0b187efe8551 100644
+--- a/drivers/pci/controller/dwc/pcie-spacemit-k1.c
++++ b/drivers/pci/controller/dwc/pcie-spacemit-k1.c
+@@ -341,6 +341,7 @@ static const struct of_device_id k1_pcie_of_match_table[] = {
+ 	{ .compatible = "spacemit,k1-pcie", },
+ 	{ }
+ };
++MODULE_DEVICE_TABLE(of, k1_pcie_of_match_table);
+ 
+ static struct platform_driver k1_pcie_driver = {
+ 	.probe	= k1_pcie_probe,
+
+

--- a/patch/kernel/archive/spacemit-7.2/006-PATCH-v2-thermal-spacemit-k1-add-shutdown-action-and-reorder-registration-order.patch
+++ b/patch/kernel/archive/spacemit-7.2/006-PATCH-v2-thermal-spacemit-k1-add-shutdown-action-and-reorder-registration-order.patch
@@ -1,0 +1,136 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pei Xiao <xiaopei01@kylinos.cn>
+Subject: [PATCH v2] thermal: spacemit: k1: add shutdown action and reorder registration order
+Date: Thu, 16 Jul 2026 15:04:19 +0800
+
+Add a devm action to clean hardware interrupts, sampling, and control
+registers on driver unbind, mirroring what k1_tsensor_init() sets up.
+
+Reorder the registration order within probe(): register the thermal
+zones first, then request the IRQ, and register the shutdown action
+last.  On removal, the hardware interrupt is disabled first, then the
+IRQ is released, and finally the thermal zones are released.  This
+avoids the IRQ thread accessing an already unregistered thermal zone
+during devres cleanup.
+
+Signed-off-by: Pei Xiao <xiaopei01@kylinos.cn>
+---
+changlog in v2:
+1.Disable all regs mirroring what k1_tsensor_init() sets up
+2.reorder registration order
+3.rename devm_k1_tsensor_shutdown to k1_tsensor_shutdown_action
+4.modify git commit log 
+---
+ drivers/thermal/spacemit/k1_tsensor.c | 73 ++++++++++++++++++++++-----
+ 1 file changed, 60 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/thermal/spacemit/k1_tsensor.c b/drivers/thermal/spacemit/k1_tsensor.c
+index 79222d233129..ab12e2ec8ae4 100644
+--- a/drivers/thermal/spacemit/k1_tsensor.c
++++ b/drivers/thermal/spacemit/k1_tsensor.c
+@@ -199,6 +199,39 @@ static irqreturn_t k1_tsensor_irq_thread(int irq, void *data)
+ 	return IRQ_HANDLED;
+ }
+ 
++static void k1_tsensor_shutdown(struct k1_tsensor *ts)
++{
++	u32 val;
++
++	/* Disable all interrupts */
++	writel(0xffffffff, ts->base + K1_TSENSOR_INT_EN_REG);
++
++	/* Disable all sensors */
++	val = readl(ts->base + K1_TSENSOR_EN_REG);
++	val &= ~K1_TSENSOR_EN_ALL;
++	writel(val, ts->base + K1_TSENSOR_EN_REG);
++
++	/* Clear the sampling configuration set by k1_tsensor_init() */
++	val = readl(ts->base + K1_TSENSOR_TIME_REG);
++	val &= ~(K1_TSENSOR_TIME_FILTER_PERIOD |
++		 K1_TSENSOR_TIME_ADC_CNT_RST |
++		 K1_TSENSOR_TIME_WAIT_REF_CNT);
++	writel(val, ts->base + K1_TSENSOR_TIME_REG);
++
++	/* Clear the control bits configured by k1_tsensor_init() */
++	val = readl(ts->base + K1_TSENSOR_PCTRL_REG);
++	val &= ~(K1_TSENSOR_PCTRL_RAW_SEL |
++		 K1_TSENSOR_PCTRL_TEMP_MODE |
++		 K1_TSENSOR_PCTRL_HW_AUTO_MODE |
++		 K1_TSENSOR_PCTRL_ENABLE);
++	writel(val, ts->base + K1_TSENSOR_PCTRL_REG);
++}
++
++static void k1_tsensor_shutdown_action(void *data)
++{
++	k1_tsensor_shutdown(data);
++}
++
+ static int k1_tsensor_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+@@ -229,34 +262,48 @@ static int k1_tsensor_probe(struct platform_device *pdev)
+ 
+ 	k1_tsensor_init(ts);
+ 
+-	irq = platform_get_irq(pdev, 0);
+-	if (irq < 0)
+-		return irq;
+-
+-	ret = devm_request_threaded_irq(dev, irq, NULL,
+-					k1_tsensor_irq_thread,
+-					IRQF_ONESHOT, "k1_tsensor", ts);
+-	if (ret < 0)
+-		return ret;
+-
+ 	for (i = 0; i < MAX_SENSOR_NUMBER; ++i) {
+ 		ts->ch[i].id = i;
+ 		ts->ch[i].ts = ts;
+ 		ts->ch[i].tzd = devm_thermal_of_zone_register(dev, i, ts->ch + i, &k1_tsensor_ops);
+-		if (IS_ERR(ts->ch[i].tzd))
+-			return PTR_ERR(ts->ch[i].tzd);
++		if (IS_ERR(ts->ch[i].tzd)) {
++			ret = PTR_ERR(ts->ch[i].tzd);
++			goto err_shutdown;
++		}
+ 
+ 		/* Attach sysfs hwmon attributes for userspace monitoring */
+ 		ret = devm_thermal_add_hwmon_sysfs(dev, ts->ch[i].tzd);
+ 		if (ret)
+ 			dev_warn(dev, "Failed to add hwmon sysfs attributes\n");
++	}
+ 
+-		k1_tsensor_enable_irq(ts->ch + i);
++	irq = platform_get_irq(pdev, 0);
++	if (irq < 0) {
++		ret = irq;
++		goto err_shutdown;
+ 	}
+ 
++	ret = devm_request_threaded_irq(dev, irq, NULL,
++					k1_tsensor_irq_thread,
++					IRQF_ONESHOT, "k1_tsensor", ts);
++	if (ret < 0)
++		goto err_shutdown;
++
++	ret = devm_add_action_or_reset(dev, k1_tsensor_shutdown_action, ts);
++	if (ret)
++		return ret;
++
++	/* Enable interrupts only after all zones and the handler are ready */
++	for (i = 0; i < MAX_SENSOR_NUMBER; ++i)
++		k1_tsensor_enable_irq(ts->ch + i);
++
+ 	platform_set_drvdata(pdev, ts);
+ 
+ 	return 0;
++
++err_shutdown:
++	k1_tsensor_shutdown(ts);
++	return ret;
+ }
+ 
+ static const struct of_device_id k1_tsensor_dt_ids[] = {
+-- 
+2.25.1
+
+

--- a/patch/kernel/archive/spacemit-7.2/007-PATCH-2-2-spi-spacemit-drop-redundant-dev_err_probe-around-irq-helpers.patch
+++ b/patch/kernel/archive/spacemit-7.2/007-PATCH-2-2-spi-spacemit-drop-redundant-dev_err_probe-around-irq-helpers.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pei Xiao <xiaopei01@kylinos.cn>
+Subject: [PATCH 2/2] spi: spacemit: drop redundant dev_err_probe() around irq helpers
+Date: Mon, 20 Jul 2026 14:08:44 +0800
+
+platform_get_irq() and devm_request_irq() already print an error
+message via dev_err_probe() on failure, so wrapping them with
+another dev_err_probe() results in duplicate error output.
+
+Return the error code directly instead.
+
+Signed-off-by: Pei Xiao <xiaopei01@kylinos.cn>
+---
+ drivers/spi/spi-spacemit-k1.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/spi/spi-spacemit-k1.c b/drivers/spi/spi-spacemit-k1.c
+index cd2955949c5c..4348d77ec77c 100644
+--- a/drivers/spi/spi-spacemit-k1.c
++++ b/drivers/spi/spi-spacemit-k1.c
+@@ -737,12 +737,12 @@ static int k1_spi_probe(struct platform_device *pdev)
+ 
+ 	drv_data->irq = platform_get_irq(pdev, 0);
+ 	if (drv_data->irq < 0)
+-		return dev_err_probe(dev, drv_data->irq, "error getting IRQ\n");
++		return drv_data->irq;
+ 
+ 	ret = devm_request_irq(dev, drv_data->irq, k1_spi_ssp_isr,
+ 			       IRQF_SHARED, dev_name(dev), drv_data);
+ 	if (ret < 0)
+-		return dev_err_probe(dev, ret, "error requesting IRQ\n");
++		return ret;
+ 
+ 	/* Initialize the host structure, then register it */
+ 	host->dev.of_node = dev_of_node(dev);
+-- 
+2.25.1
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pei Xiao <xiaopei01@kylinos.cn>
+Subject: [PATCH 1/2] spi: spacemit: fix dangling TX DMA descriptor on RX prep failure
+Date: Mon, 20 Jul 2026 14:08:43 +0800
+
+In k1_spi_dma_one(), the TX DMA descriptor is submitted via
+dmaengine_submit() before the RX descriptor is prepared.  If
+k1_spi_dma_prep() fails for RX, the function jumps to the fallback
+path without terminating the already-submitted TX descriptor.
+
+So terminate the TX channel with dmaengine_terminate_sync() when RX
+descriptor preparation fails.
+
+Fixes: efcd8b9d1111 ("spi: spacemit: introduce SpacemiT K1 SPI controller driver")
+Signed-off-by: Pei Xiao <xiaopei01@kylinos.cn>
+---
+ drivers/spi/spi-spacemit-k1.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/spi/spi-spacemit-k1.c b/drivers/spi/spi-spacemit-k1.c
+index 215fe66d27b4..cd2955949c5c 100644
+--- a/drivers/spi/spi-spacemit-k1.c
++++ b/drivers/spi/spi-spacemit-k1.c
+@@ -289,8 +289,10 @@ static int k1_spi_dma_one(struct spi_controller *host, struct spi_device *spi,
+ 
+ 	/* Prepare the RX descriptor and submit it */
+ 	desc = k1_spi_dma_prep(drv_data, transfer, false);
+-	if (!desc)
++	if (!desc) {
++		dmaengine_terminate_sync(host->dma_tx);
+ 		goto fallback;
++	}
+ 
+ 	/* When RX is complete we also know TX has completed */
+ 	desc->callback = k1_spi_dma_callback;
+-- 
+2.25.1
+
+

--- a/patch/kernel/archive/spacemit-7.2/008-PATCH-thermal-spacemit-validate-clamped-trip-thresholds.patch
+++ b/patch/kernel/archive/spacemit-7.2/008-PATCH-thermal-spacemit-validate-clamped-trip-thresholds.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: kr494167@gmail.com
+Subject: [PATCH] thermal: spacemit: validate clamped trip thresholds
+Date: Mon, 20 Jul 2026 16:06:06 +0530
+
+k1_tsensor_set_trips() checks the requested trip temperatures before
+converting them to the sensor register representation. Distinct
+out-of-range temperatures can clamp to the same hardware value, leaving the
+sensor with an invalid low/high threshold pair.
+
+Signed-off-by: surendra <kr494167@gmail.com>
+---
+ drivers/thermal/spacemit/k1_tsensor.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/thermal/spacemit/k1_tsensor.c b/drivers/thermal/spacemit/k1_tsensor.c
+index 79222d233129..a9eaedefdac3 100644
+--- a/drivers/thermal/spacemit/k1_tsensor.c
++++ b/drivers/thermal/spacemit/k1_tsensor.c
+@@ -156,13 +156,12 @@ static int k1_tsensor_set_trips(struct thermal_zone_device *tz, int low, int hig
+ 	struct k1_tsensor *ts = ch->ts;
+ 	u32 val;
+ 
+-	if (low >= high)
+-		return -EINVAL;
+-
+ 	low = clamp_val(low / 1000 + TEMPERATURE_OFFSET, TEMPERATURE_OFFSET,
+ 			FIELD_MAX(K1_TSENSOR_THRSH_LOW_MASK));
+ 	high = clamp_val(high / 1000 + TEMPERATURE_OFFSET, TEMPERATURE_OFFSET,
+ 			 FIELD_MAX(K1_TSENSOR_THRSH_HIGH_MASK));
++	if (low >= high)
++		return -EINVAL;
+ 
+ 	val = readl(ts->base + K1_TSENSOR_THRSH_REG(ch->id));
+ 
+-- 
+2.55.0
+

--- a/patch/kernel/archive/spacemit-7.2/008-PATCH-thermal-spacemit-validate-clamped-trip-thresholds.patch
+++ b/patch/kernel/archive/spacemit-7.2/008-PATCH-thermal-spacemit-validate-clamped-trip-thresholds.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kr494167@gmail.com
+From: surendra <kr494167@gmail.com>
 Subject: [PATCH] thermal: spacemit: validate clamped trip thresholds
 Date: Mon, 20 Jul 2026 16:06:06 +0530
 

--- a/patch/kernel/archive/spacemit-7.2/009-PATCH-v3-07-16-PCI-dwc-eswin-Use-cached-PCIe-capability-offset.patch
+++ b/patch/kernel/archive/spacemit-7.2/009-PATCH-v3-07-16-PCI-dwc-eswin-Use-cached-PCIe-capability-offset.patch
@@ -1,0 +1,387 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hans Zhang <18255117159@163.com>
+Subject: [PATCH v3 07/16] PCI: dwc: eswin: Use cached PCIe capability offset
+Date: Mon, 20 Jul 2026 23:06:10 +0800
+
+This function is called after dw_pcie_host_init() has already cached the
+offset (dw_pcie_link_up() is called after .init and after caching).
+Therefore, we can directly use pci->pcie_cap.
+
+Signed-off-by: Hans Zhang <18255117159@163.com>
+---
+In pcie-eswin, the call chain is:
+
+  static const struct dw_pcie_ops dw_pcie_ops = {
+    .link_up = eswin_pcie_link_up,
+  };
+  eswin_pcie_link_up()
+    -> dw_pcie_find_capability()
+---
+ drivers/pci/controller/dwc/pcie-eswin.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/pci/controller/dwc/pcie-eswin.c b/drivers/pci/controller/dwc/pcie-eswin.c
+index ce8d64f8a395..6a37fd5a8384 100644
+--- a/drivers/pci/controller/dwc/pcie-eswin.c
++++ b/drivers/pci/controller/dwc/pcie-eswin.c
+@@ -84,8 +84,7 @@ static int eswin_pcie_start_link(struct dw_pcie *pci)
+ 
+ static bool eswin_pcie_link_up(struct dw_pcie *pci)
+ {
+-	u16 offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+-	u16 val = dw_pcie_readw_dbi(pci, offset + PCI_EXP_LNKSTA);
++	u16 val = dw_pcie_readw_dbi(pci, pci->pcie_cap + PCI_EXP_LNKSTA);
+ 
+ 	return val & PCI_EXP_LNKSTA_DLLLA;
+ }
+-- 
+2.34.1
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hans Zhang <18255117159@163.com>
+Subject: [PATCH v3 02/16] PCI: dwc: Use cached PCIe capability offset in core
+Date: Mon, 20 Jul 2026 23:06:05 +0800
+
+Modify the DWC core functions to use the cached pcie_cap offset instead
+of calling dw_pcie_find_capability() each time.
+
+In the DWC core, dw_pcie_find_capability() is called at several locations:
+- dw_pcie_ep_init_non_sticky_registers()
+- dw_pcie_wait_for_link()
+- dw_pcie_link_set_max_speed()
+- dw_pcie_link_get_max_link_width()
+- dw_pcie_link_set_max_link_width()
+
+The cached offset is initialized after hardware is ready:
+- In host mode: dw_pcie_host_init() calls pp->ops->host_init() (enables
+  clocks/resets), then dw_pcie_get_pcie_cap() caches the offset.
+- In endpoint mode: the core no longer caches automatically. Instead,
+  drivers must call dw_pcie_get_pcie_cap() after hardware is enabled
+  (e.g., after PERST# deassert). dw_pcie_ep_init_non_sticky_registers()
+  is called after that point, so it can safely use pci->pcie_cap.
+
+dw_pcie_ep_init_non_sticky_registers() now assumes pci->pcie_cap is
+valid. if not, it prints a warning and skips the operation. The other
+functions run after probe, so pci->pcie_cap is already valid and can
+be used directly.
+
+Signed-off-by: Hans Zhang <18255117159@163.com>
+---
+ drivers/pci/controller/dwc/pcie-designware-ep.c   |  2 +-
+ drivers/pci/controller/dwc/pcie-designware-host.c |  2 ++
+ drivers/pci/controller/dwc/pcie-designware.c      | 15 ++++++---------
+ 3 files changed, 9 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/pci/controller/dwc/pcie-designware-ep.c b/drivers/pci/controller/dwc/pcie-designware-ep.c
+index 7d2794945704..14228be8bbce 100644
+--- a/drivers/pci/controller/dwc/pcie-designware-ep.c
++++ b/drivers/pci/controller/dwc/pcie-designware-ep.c
+@@ -1246,7 +1246,7 @@ static void dw_pcie_ep_init_non_sticky_registers(struct dw_pcie *pci)
+ 	 * to all other functions as well.
+ 	 */
+ 	if (funcs > 1) {
+-		offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
++		offset = pci->pcie_cap;
+ 		func0_lnkcap = dw_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCAP);
+ 		func0_lnkcap = FIELD_GET(PCI_EXP_LNKCAP_MLW |
+ 					 PCI_EXP_LNKCAP_SLS, func0_lnkcap);
+diff --git a/drivers/pci/controller/dwc/pcie-designware-host.c b/drivers/pci/controller/dwc/pcie-designware-host.c
+index 06722259d2e3..fee800ac56d4 100644
+--- a/drivers/pci/controller/dwc/pcie-designware-host.c
++++ b/drivers/pci/controller/dwc/pcie-designware-host.c
+@@ -593,6 +593,8 @@ int dw_pcie_host_init(struct dw_pcie_rp *pp)
+ 			goto err_free_ecam;
+ 	}
+ 
++	dw_pcie_get_pcie_cap(pci);
++
+ 	if (pci_msi_enabled()) {
+ 		pp->use_imsi_rx = !(pp->ops->msi_init ||
+ 				     of_property_present(np, "msi-parent") ||
+diff --git a/drivers/pci/controller/dwc/pcie-designware.c b/drivers/pci/controller/dwc/pcie-designware.c
+index ec4722ed9303..810729b91892 100644
+--- a/drivers/pci/controller/dwc/pcie-designware.c
++++ b/drivers/pci/controller/dwc/pcie-designware.c
+@@ -766,7 +766,7 @@ const char *dw_pcie_ltssm_status_string(enum dw_pcie_ltssm ltssm)
+  */
+ int dw_pcie_wait_for_link(struct dw_pcie *pci)
+ {
+-	u32 offset, val, ltssm;
++	u32 val, ltssm;
+ 	int retries;
+ 
+ 	/* Check if the link is up or not */
+@@ -806,8 +806,7 @@ int dw_pcie_wait_for_link(struct dw_pcie *pci)
+ 
+ 	pci_host_common_link_train_delay(pci->max_link_speed);
+ 
+-	offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+-	val = dw_pcie_readw_dbi(pci, offset + PCI_EXP_LNKSTA);
++	val = dw_pcie_readw_dbi(pci, pci->pcie_cap + PCI_EXP_LNKSTA);
+ 
+ 	dev_info(pci->dev, "PCIe Gen.%u x%u link up\n",
+ 		 FIELD_GET(PCI_EXP_LNKSTA_CLS, val),
+@@ -843,7 +842,7 @@ EXPORT_SYMBOL_GPL(dw_pcie_upconfig_setup);
+ static void dw_pcie_link_set_max_speed(struct dw_pcie *pci)
+ {
+ 	u32 cap, ctrl2, link_speed;
+-	u8 offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
++	u8 offset = pci->pcie_cap;
+ 
+ 	cap = dw_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCAP);
+ 
+@@ -890,7 +889,7 @@ static void dw_pcie_link_set_max_speed(struct dw_pcie *pci)
+ int dw_pcie_link_get_max_link_width(struct dw_pcie *pci)
+ {
+ 	u8 cap = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+-	u32 lnkcap = dw_pcie_readl_dbi(pci, cap + PCI_EXP_LNKCAP);
++	u32 lnkcap = dw_pcie_readl_dbi(pci, pci->pcie_cap + PCI_EXP_LNKCAP);
+ 
+ 	return FIELD_GET(PCI_EXP_LNKCAP_MLW, lnkcap);
+ }
+@@ -898,7 +897,6 @@ int dw_pcie_link_get_max_link_width(struct dw_pcie *pci)
+ static void dw_pcie_link_set_max_link_width(struct dw_pcie *pci, u32 num_lanes)
+ {
+ 	u32 lnkcap, lwsc, plc;
+-	u8 cap;
+ 
+ 	if (!num_lanes)
+ 		return;
+@@ -935,10 +933,9 @@ static void dw_pcie_link_set_max_link_width(struct dw_pcie *pci, u32 num_lanes)
+ 	dw_pcie_writel_dbi(pci, PCIE_PORT_LINK_CONTROL, plc);
+ 	dw_pcie_writel_dbi(pci, PCIE_LINK_WIDTH_SPEED_CONTROL, lwsc);
+ 
+-	cap = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+-	lnkcap = dw_pcie_readl_dbi(pci, cap + PCI_EXP_LNKCAP);
++	lnkcap = dw_pcie_readl_dbi(pci, pci->pcie_cap + PCI_EXP_LNKCAP);
+ 	FIELD_MODIFY(PCI_EXP_LNKCAP_MLW, &lnkcap, num_lanes);
+-	dw_pcie_writel_dbi(pci, cap + PCI_EXP_LNKCAP, lnkcap);
++	dw_pcie_writel_dbi(pci, pci->pcie_cap + PCI_EXP_LNKCAP, lnkcap);
+ }
+ 
+ void dw_pcie_iatu_detect(struct dw_pcie *pci)
+-- 
+2.34.1
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hans Zhang <18255117159@163.com>
+Subject: [PATCH v3 01/16] PCI: dwc: Add pcie_cap field and helper in designware header
+Date: Mon, 20 Jul 2026 23:06:04 +0800
+
+Add a pcie_cap field to struct dw_pcie to store the offset of the
+PCI Express Capability structure. Provide a helper dw_pcie_get_pcie_cap()
+which performs the capability search on first call and caches the result.
+
+This is a preparatory step for replacing repetitive capability searches
+in both core and platform drivers.
+
+Signed-off-by: Hans Zhang <18255117159@163.com>
+---
+ drivers/pci/controller/dwc/pcie-designware.h | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/drivers/pci/controller/dwc/pcie-designware.h b/drivers/pci/controller/dwc/pcie-designware.h
+index de4b245b1758..8113efd33a24 100644
+--- a/drivers/pci/controller/dwc/pcie-designware.h
++++ b/drivers/pci/controller/dwc/pcie-designware.h
+@@ -591,6 +591,8 @@ struct dw_pcie {
+ 	 * use_parent_dt_ranges to true to avoid this warning.
+ 	 */
+ 	bool			use_parent_dt_ranges;
++
++	u8			pcie_cap;	/* PCIe capability offset */
+ };
+ 
+ #define to_dw_pcie_from_pp(port) container_of((port), struct dw_pcie, pp)
+@@ -829,6 +831,21 @@ static inline void dw_pcie_dbi_ro_wr_dis(struct dw_pcie *pci)
+ 	dw_pcie_writel_dbi(pci, reg, val);
+ }
+ 
++/**
++ * dw_pcie_get_pcie_cap() - Return cached PCIe Capability offset
++ * @pci: DWC instance
++ *
++ * Finds and caches the offset of PCI_CAP_ID_EXP on first call.
++ * Returns 0 if the capability is not present.
++ */
++static inline u8 dw_pcie_get_pcie_cap(struct dw_pcie *pci)
++{
++	if (!pci->pcie_cap)
++		pci->pcie_cap = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
++
++	return pci->pcie_cap;
++}
++
+ static inline int dw_pcie_start_link(struct dw_pcie *pci)
+ {
+ 	if (pci->ops && pci->ops->start_link)
+-- 
+2.34.1
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hans Zhang <18255117159@163.com>
+Subject: [PATCH v3 05/16] PCI: dwc: meson: Use cached PCIe capability offset
+Date: Mon, 20 Jul 2026 23:06:08 +0800
+
+dw_pcie_host_init() calls pp->ops->init (meson_pcie_host_init) before
+caching the offset. Therefore, inside .init we must call
+dw_pcie_get_pcie_cap() to obtain the offset (the helper will perform the
+DBI read and cache the result). This is safe because the hardware is
+already enabled by the driver's own initialization.
+
+Signed-off-by: Hans Zhang <18255117159@163.com>
+---
+In pci-meson, the call chain is:
+
+  static const struct dw_pcie_host_ops meson_pcie_host_ops = {
+    .init = meson_pcie_host_init,
+  };
+  meson_pcie_host_init()
+    -> meson_set_max_payload()
+      -> dw_pcie_find_capability()
+    -> meson_set_max_rd_req_size()
+      -> dw_pcie_find_capability()
+---
+ drivers/pci/controller/dwc/pci-meson.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/pci/controller/dwc/pci-meson.c b/drivers/pci/controller/dwc/pci-meson.c
+index 7a4da9fae1ea..c9d0388d262b 100644
+--- a/drivers/pci/controller/dwc/pci-meson.c
++++ b/drivers/pci/controller/dwc/pci-meson.c
+@@ -277,7 +277,7 @@ static void meson_set_max_payload(struct meson_pcie *mp, int size)
+ {
+ 	struct dw_pcie *pci = &mp->pci;
+ 	u32 val;
+-	u16 offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
++	u8 offset = dw_pcie_get_pcie_cap(pci);
+ 	int max_payload_size = meson_size_to_payload(mp, size);
+ 
+ 	val = dw_pcie_readl_dbi(pci, offset + PCI_EXP_DEVCTL);
+@@ -293,7 +293,7 @@ static void meson_set_max_rd_req_size(struct meson_pcie *mp, int size)
+ {
+ 	struct dw_pcie *pci = &mp->pci;
+ 	u32 val;
+-	u16 offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
++	u8 offset = dw_pcie_get_pcie_cap(pci);
+ 	int max_rd_req_size = meson_size_to_payload(mp, size);
+ 
+ 	val = dw_pcie_readl_dbi(pci, offset + PCI_EXP_DEVCTL);
+-- 
+2.34.1
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hans Zhang <18255117159@163.com>
+Subject: [PATCH v3 04/16] PCI: dwc: layerscape-ep: Use cached PCIe capability offset
+Date: Mon, 20 Jul 2026 23:06:07 +0800
+
+Replace these with dw_pcie_get_pcie_cap(). The hardware is already enabled
+by the driver before ls_pcie_ep_probe() and before the interrupt handler
+runs. dw_pcie_get_pcie_cap() will cache the offset on first call, and
+subsequent calls (including inside dw_pcie_ep_init) will use the cached
+value without re-searching.
+
+Signed-off-by: Hans Zhang <18255117159@163.com>
+---
+In pci-layerscape-ep, dw_pcie_find_capability() is called in:
+
+  ls_pcie_ep_probe()
+    -> offset = dw_pcie_find_capability()
+    -> pcie->lnkcap = dw_pcie_readl_dbi(offset + PCI_EXP_LNKCAP)
+    -> dw_pcie_ep_init()
+    -> ls_pcie_ep_interrupt_init()
+        -> devm_request_irq(..., ls_pcie_ep_event_handler)
+          -> ls_pcie_ep_event_handler()
+            -> dw_pcie_find_capability()
+---
+ drivers/pci/controller/dwc/pci-layerscape-ep.c | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/pci/controller/dwc/pci-layerscape-ep.c b/drivers/pci/controller/dwc/pci-layerscape-ep.c
+index 8936975ff104..b2d0b51df3c5 100644
+--- a/drivers/pci/controller/dwc/pci-layerscape-ep.c
++++ b/drivers/pci/controller/dwc/pci-layerscape-ep.c
+@@ -74,7 +74,6 @@ static irqreturn_t ls_pcie_ep_event_handler(int irq, void *dev_id)
+ 	struct ls_pcie_ep *pcie = dev_id;
+ 	struct dw_pcie *pci = pcie->pci;
+ 	u32 val, cfg;
+-	u8 offset;
+ 
+ 	val = ls_pcie_pf_lut_readl(pcie, PEX_PF0_PME_MES_DR);
+ 	ls_pcie_pf_lut_writel(pcie, PEX_PF0_PME_MES_DR, val);
+@@ -83,9 +82,6 @@ static irqreturn_t ls_pcie_ep_event_handler(int irq, void *dev_id)
+ 		return IRQ_NONE;
+ 
+ 	if (val & PEX_PF0_PME_MES_DR_LUD) {
+-
+-		offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+-
+ 		/*
+ 		 * The values of the Maximum Link Width and Supported Link
+ 		 * Speed from the Link Capabilities Register will be lost
+@@ -93,7 +89,8 @@ static irqreturn_t ls_pcie_ep_event_handler(int irq, void *dev_id)
+ 		 * that configured by the Reset Configuration Word (RCW).
+ 		 */
+ 		dw_pcie_dbi_ro_wr_en(pci);
+-		dw_pcie_writel_dbi(pci, offset + PCI_EXP_LNKCAP, pcie->lnkcap);
++		dw_pcie_writel_dbi(pci, pci->pcie_cap + PCI_EXP_LNKCAP,
++				   pcie->lnkcap);
+ 		dw_pcie_dbi_ro_wr_dis(pci);
+ 
+ 		cfg = ls_pcie_pf_lut_readl(pcie, PEX_PF0_CONFIG);
+@@ -266,7 +263,7 @@ static int __init ls_pcie_ep_probe(struct platform_device *pdev)
+ 
+ 	platform_set_drvdata(pdev, pcie);
+ 
+-	offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
++	offset = dw_pcie_get_pcie_cap(pci);
+ 	pcie->lnkcap = dw_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCAP);
+ 
+ 	ret = dw_pcie_ep_init(&pci->ep);
+-- 
+2.34.1
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hans Zhang <18255117159@163.com>
+Subject: [PATCH v3 13/16] PCI: dwc: spacemit-k1: Use cached PCIe capability offset
+Date: Mon, 20 Jul 2026 23:06:16 +0800
+
+Because .init runs before core caching, we call dw_pcie_get_pcie_cap()
+inside k1_pcie_disable_aspm_l1() to get the capability base, then add
+PCI_EXP_LNKCAP. Hardware is already enabled at this point.
+
+Signed-off-by: Hans Zhang <18255117159@163.com>
+---
+In pcie-spacemit-k1, the call chain is:
+
+  static const struct dw_pcie_host_ops k1_pcie_host_ops = {
+    .init = k1_pcie_init,
+  };
+  k1_pcie_init()
+    -> k1_pcie_disable_aspm_l1()
+      -> dw_pcie_find_capability()
+---
+ drivers/pci/controller/dwc/pcie-spacemit-k1.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/pci/controller/dwc/pcie-spacemit-k1.c b/drivers/pci/controller/dwc/pcie-spacemit-k1.c
+index 04241df8fd59..3e741324f44a 100644
+--- a/drivers/pci/controller/dwc/pcie-spacemit-k1.c
++++ b/drivers/pci/controller/dwc/pcie-spacemit-k1.c
+@@ -116,7 +116,7 @@ static void k1_pcie_disable_aspm_l1(struct k1_pcie *k1)
+ 	u8 offset;
+ 	u32 val;
+ 
+-	offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
++	offset = dw_pcie_get_pcie_cap(pci);
+ 	offset += PCI_EXP_LNKCAP;
+ 
+ 	dw_pcie_dbi_ro_wr_en(pci);
+-- 
+2.34.1
+

--- a/patch/kernel/archive/spacemit-7.2/010-PATCH-1-1-riscv-dts-spacemit-enable-PCIe-on-OrangePi-R2S.patch
+++ b/patch/kernel/archive/spacemit-7.2/010-PATCH-1-1-riscv-dts-spacemit-enable-PCIe-on-OrangePi-R2S.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Subject: [PATCH 1/1] riscv: dts: spacemit: enable PCIe on OrangePi R2S
+Date: Tue,  2 Jun 2026 18:00:00 +0800
+
+Enable the two RTL8125 network controllers and corresponding
+PHYs connected via the PCIe controllers on the OrangePi R2S.
+
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+---
+Current PCIe drivers can only negotiate down to Gen.1,
+so the RTL8125 cannot reach speeds above 2Gbps.
+---
+ .../boot/dts/spacemit/k1-orangepi-r2s.dts     | 38 +++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+
+diff --git a/arch/riscv/boot/dts/spacemit/k1-orangepi-r2s.dts b/arch/riscv/boot/dts/spacemit/k1-orangepi-r2s.dts
+index b13a8d6a2670..919e5b451109 100644
+--- a/arch/riscv/boot/dts/spacemit/k1-orangepi-r2s.dts
++++ b/arch/riscv/boot/dts/spacemit/k1-orangepi-r2s.dts
+@@ -23,6 +23,14 @@ chosen {
+ 		stdout-path = "serial0";
+ 	};
+ 
++	pcie_vcc3v3: regulator-pcie-vcc3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "pcie_vcc3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-always-on;
++	};
++
+ 	vcc4v0: regulator-vcc4v0 {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc4v0";
+@@ -228,6 +236,36 @@ dldo7 {
+ 	};
+ };
+ 
++&pcie1_phy {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie1_3_cfg>;
++	status = "okay";
++};
++
++&pcie1_port {
++	phys = <&pcie1_phy>;
++	vpcie3v3-supply = <&pcie_vcc3v3>;
++};
++
++&pcie1 {
++	status = "okay";
++};
++
++&pcie2_phy {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie2_4_cfg>;
++	status = "okay";
++};
++
++&pcie2_port {
++	phys = <&pcie2_phy>;
++	vpcie3v3-supply = <&pcie_vcc3v3>;
++};
++
++&pcie2 {
++	status = "okay";
++};
++
+ &pdma {
+ 	status = "okay";
+ };
+-- 
+2.34.1
+


### PR DESCRIPTION
* Enable PCIe on OrangePi R2S
* Add thermal, SPI and PCIe fixups


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled PCIe connectivity on the OrangePi R2S, including required power and PHY support.
  - Improved PCIe controller initialization and link handling across supported platforms.

- **Bug Fixes**
  - Improved thermal sensor shutdown and cleanup during device removal or initialization failures.
  - Corrected thermal trip threshold validation for out-of-range temperatures.
  - Prevented stale SPI DMA transfers when receive setup fails.
  - Improved automatic loading of the PCIe driver when hardware is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->