### PR TITLE
k3: enable TI Rogue GPU acceleration

### DIFF
--- a/config/boards/beaglebone-ai64.conf
+++ b/config/boards/beaglebone-ai64.conf
@@ -22,6 +22,7 @@ ATF_PLAT="k3"
 ATF_BOARD="generic"
 OPTEE_ARGS=""
 OPTEE_PLATFORM="k3-j721e"
+GPU_SUPPORT="yes"
 TI_DEBPKGS_FALLBACK_SUITES=("noble" "jammy")
 TI_PACKAGES+=(
 	"ti-img-rogue-driver-j721e-dkms"

--- a/config/boards/beagleplay.conf
+++ b/config/boards/beagleplay.conf
@@ -21,6 +21,7 @@ ATF_PLAT="k3"
 ATF_BOARD="lite"
 OPTEE_ARGS="CFG_TEE_CORE_LOG_LEVEL=1"
 OPTEE_PLATFORM="k3-am62x"
+GPU_SUPPORT="yes"
 TI_DEBPKGS_FALLBACK_SUITES=("noble" "jammy")
 TI_PACKAGES+=(
 	"ti-img-rogue-driver-am62-dkms"

--- a/config/boards/beagley-ai.conf
+++ b/config/boards/beagley-ai.conf
@@ -22,6 +22,7 @@ OPTEE_ARGS=""
 OPTEE_PLATFORM="k3-am62x"
 CC33XX_SUPPORT="yes"
 # TI Rogue driver builds J722S with the AM62P GPU system.
+GPU_SUPPORT="yes"
 TI_DEBPKGS_FALLBACK_SUITES=("noble" "jammy")
 TI_PACKAGES+=(
 	"ti-img-rogue-driver-am62p-dkms"

--- a/extensions/ti-debpkgs.sh
+++ b/extensions/ti-debpkgs.sh
@@ -1,15 +1,8 @@
 function post_repo_customize_image__install_ti_packages() {
-
-	# Read JSON array into Bash array safely
-	mapfile -t valid_suites < <(
-		curl -s https://api.github.com/repos/TexasInstruments/ti-debpkgs/contents/dists |
-			jq -r '.[].name'
-	)
-	display_alert "TI Repo has the following valid suites - ${valid_suites[@]}..."
-
 	local ti_repo_suite=""
 	local ti_candidate_suite
 	local -a ti_candidate_suites=("${RELEASE}")
+	local ti_repo_url="https://TexasInstruments.github.io/ti-debpkgs"
 
 	if [[ -n "${TI_DEBPKGS_SUITE:-}" ]]; then
 		ti_candidate_suites=("${TI_DEBPKGS_SUITE}")
@@ -18,42 +11,159 @@ function post_repo_customize_image__install_ti_packages() {
 	fi
 
 	for ti_candidate_suite in "${ti_candidate_suites[@]}"; do
-		if printf '%s\n' "${valid_suites[@]}" | grep -qx "${ti_candidate_suite}"; then
+		if [[ ! "${ti_candidate_suite}" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+			display_alert "Ignoring invalid TI package suite" "${ti_candidate_suite}" "warn"
+			continue
+		fi
+
+		if curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+			--connect-timeout 15 --max-time 60 -o /dev/null \
+			"${ti_repo_url}/dists/${ti_candidate_suite}/Release"; then
 			ti_repo_suite="${ti_candidate_suite}"
 			break
 		fi
 	done
 
-	if [[ -n "${ti_repo_suite}" ]]; then
-		if [[ "${ti_repo_suite}" != "${RELEASE}" ]]; then
-			display_alert "Using TI package suite '${ti_repo_suite}' for release '${RELEASE}'" "fallback requested by board config" "warn"
+	if [[ -z "${ti_repo_suite}" ]]; then
+		if ti_debpkgs_rogue_requested; then
+			display_alert "TI package suite is unavailable" "tried: ${ti_candidate_suites[*]}; required for TI Rogue" "err"
+			return 1
 		fi
 
-		# Get the sources file
-		run_host_command_logged "mkdir -p \"$SDCARD/tmp\""
-		run_host_command_logged "wget -qO $SDCARD/tmp/ti-debpkgs.sources https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources"
-
-		# Update suite in source file
-		chroot_sdcard "sed -i 's/^Suites:.*/Suites: ${ti_repo_suite}/' /tmp/ti-debpkgs.sources"
-
-		# Copy updated sources file into chroot
-		chroot_sdcard "cp /tmp/ti-debpkgs.sources /etc/apt/sources.list.d/ti-debpkgs.sources"
-
-		# Clean up inside the chroot
-		chroot_sdcard "rm -f /tmp/ti-debpkgs.sources"
-
-		chroot_sdcard "mkdir -p /etc/apt/preferences.d/"
-		run_host_command_logged "cp \"$SRC/packages/bsp/ti/ti-debpkgs/ti-debpkgs\" \"$SDCARD/etc/apt/preferences.d/\""
-
-		# Install packages
-		if [[ ${#TI_PACKAGES[@]} -gt 0 ]]; then
-			do_with_retries 3 chroot_sdcard_apt_get_update
-			do_with_retries 3 chroot_sdcard_apt_get --no-install-recommends --allow-downgrades install "${TI_PACKAGES[@]}"
-		fi
-
-	else
-		# Error if suite is not valid but continue building image anyway
-		display_alert "Error: Detected OS suite '$RELEASE' is not valid based on TI package repository. Skipping!"
-		display_alert "Valid Options Would Have Been: ${valid_suites[@]}"
+		display_alert "TI package suite is unavailable" "tried: ${ti_candidate_suites[*]}; skipping optional TI packages" "warn"
+		return 0
 	fi
+
+	if [[ "${ti_repo_suite}" != "${RELEASE}" ]]; then
+		display_alert "Using TI package suite '${ti_repo_suite}' for release '${RELEASE}'" "fallback requested by board config" "warn"
+	fi
+
+	# Get the sources file
+	run_host_command_logged "mkdir -p \"$SDCARD/tmp\""
+	run_host_command_logged "wget -qO $SDCARD/tmp/ti-debpkgs.sources https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources"
+
+	# Update suite in source file
+	chroot_sdcard "sed -i 's/^Suites:.*/Suites: ${ti_repo_suite}/' /tmp/ti-debpkgs.sources"
+	chroot_sdcard "grep -qx 'Suites: ${ti_repo_suite}' /tmp/ti-debpkgs.sources"
+
+	# Copy updated sources file into chroot
+	chroot_sdcard "cp /tmp/ti-debpkgs.sources /etc/apt/sources.list.d/ti-debpkgs.sources"
+
+	# Clean up inside the chroot
+	chroot_sdcard "rm -f /tmp/ti-debpkgs.sources"
+
+	chroot_sdcard "mkdir -p /etc/apt/preferences.d/"
+	run_host_command_logged "cp \"$SRC/packages/bsp/ti/ti-debpkgs/ti-debpkgs\" \"$SDCARD/etc/apt/preferences.d/\""
+
+	# Remove all ti-img-rogue-* packages if GPU_SUPPORT is not yes
+	local -a ti_packages_for_image=()
+	local ti_package
+	for ti_package in "${TI_PACKAGES[@]}"; do
+		if [[ "${GPU_SUPPORT:-no}" != "yes" ]]; then
+			case "${ti_package}" in
+				ti-img-rogue-*)
+					display_alert "Skipping TI Rogue package" "${ti_package}; GPU_SUPPORT is not yes" "debug"
+					continue
+					;;
+			esac
+		fi
+		ti_packages_for_image+=("${ti_package}")
+	done
+
+	# Install packages
+	if [[ ${#ti_packages_for_image[@]} -gt 0 ]]; then
+		do_with_retries 3 chroot_sdcard_apt_get_update
+		do_with_retries 3 chroot_sdcard_apt_get --no-install-recommends --allow-downgrades install "${ti_packages_for_image[@]}"
+		if ti_debpkgs_rogue_requested; then
+			build_ti_rogue_dkms_for_image
+			ti_debpkgs_configure_rogue_module
+		fi
+	fi
+}
+
+function ti_debpkgs_has_rogue_packages() {
+	local ti_package
+
+	for ti_package in "${TI_PACKAGES[@]}"; do
+		case "${ti_package}" in
+			ti-img-rogue-*) return 0 ;;
+		esac
+	done
+
+	return 1
+}
+
+function ti_debpkgs_count_rogue_dkms_packages() {
+	local ti_package
+	local count=0
+
+	for ti_package in "${TI_PACKAGES[@]}"; do
+		case "${ti_package}" in
+			ti-img-rogue-driver-*-dkms) count=$((count + 1)) ;;
+		esac
+	done
+
+	printf '%d\n' "${count}"
+}
+
+function ti_debpkgs_rogue_requested() {
+	[[ "${GPU_SUPPORT:-no}" == "yes" ]] && ti_debpkgs_has_rogue_packages
+}
+
+function extension_finish_config__install_kernel_headers_for_ti_rogue_dkms() {
+	ti_debpkgs_rogue_requested || return 0
+
+	local rogue_dkms_count
+	rogue_dkms_count="$(ti_debpkgs_count_rogue_dkms_packages)"
+	if [[ "${rogue_dkms_count}" -ne 1 ]]; then
+		display_alert "Invalid TI Rogue package configuration" "expected exactly one explicit Rogue DKMS package, found ${rogue_dkms_count}" "err"
+		return 1
+	fi
+
+	if [[ "${KERNEL_HAS_WORKING_HEADERS:-no}" != "yes" ]]; then
+		display_alert "Kernel headers are unavailable" "cannot build TI Rogue DKMS for ${BOARD}" "err"
+		return 1
+	fi
+
+	declare -g INSTALL_HEADERS="yes"
+	display_alert "Forcing INSTALL_HEADERS=yes" "TI Rogue DKMS" "debug"
+}
+
+function build_ti_rogue_dkms_for_image() {
+	ti_debpkgs_rogue_requested || return 0
+
+	if [[ "${INSTALL_HEADERS:-no}" != "yes" || "${KERNEL_HAS_WORKING_HEADERS:-no}" != "yes" ]]; then
+		display_alert "Cannot build TI Rogue DKMS" "working target headers are required" "err"
+		return 1
+	fi
+
+	local target_kver="${IMAGE_INSTALLED_KERNEL_VERSION:-}"
+	if [[ -z "${target_kver}" ]]; then
+		display_alert "Cannot determine target kernel version" "TI Rogue DKMS" "err"
+		return 1
+	fi
+	if [[ "${target_kver}" != *"-${BRANCH}-${LINUXFAMILY}" ]]; then
+		target_kver+="-${BRANCH}-${LINUXFAMILY}"
+	fi
+
+	declare -g if_error_detail_message="TI Rogue DKMS build failed for ${target_kver}"
+	declare -ag if_error_find_files_sdcard=("/var/lib/dkms/ti-img-rogue-driver/*/build/make.log")
+	display_alert "Building TI Rogue DKMS" "${target_kver}" "info"
+	use_clean_environment="yes" chroot_sdcard "dkms autoinstall --verbose --kernelver ${target_kver}"
+	chroot_sdcard "find /lib/modules/${target_kver} -type f -name 'pvrsrvkm.ko*' -print -quit | grep -q ."
+	chroot_sdcard "depmod -a ${target_kver}"
+}
+
+function ti_debpkgs_configure_rogue_module() {
+	run_host_command_logged "mkdir -p ${SDCARD}/etc/modules-load.d ${SDCARD}/etc/modprobe.d"
+	cat > "${SDCARD}/etc/modules-load.d/ti-rogue.conf" << 'EOF'
+# TI's out-of-tree Rogue PowerVR driver for supported K3 GPUs.
+pvrsrvkm
+EOF
+	cat > "${SDCARD}/etc/modprobe.d/blacklist-upstream-powervr.conf" << 'EOF'
+# Prefer TI's Rogue stack on K3 images configured with GPU_SUPPORT.
+# The upstream driver's K3 coverage and performance vary, and it can bind first.
+blacklist powervr
+EOF
+	display_alert "Configured TI Rogue module loading" "pvrsrvkm; upstream powervr blacklisted" "info"
 }

--- a/patch/kernel/archive/k3-7.2/0001-FROMLIST-dt-bindings-gpu-img-Add-J721E-compatible.patch
+++ b/patch/kernel/archive/k3-7.2/0001-FROMLIST-dt-bindings-gpu-img-Add-J721E-compatible.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Antonios Christidis <a-christidis@ti.com>
+Date: Tue, 24 Feb 2026 12:09:16 -0600
+Subject: [PATCH] FROMLIST: dt-bindings: gpu: img: Add J721E compatible
+
+Add the J721E SoC-specific compatible and constrain its single clock and
+the GE8430 GPU's two power domains.
+
+Link: https://lore.kernel.org/all/20260224-gpu_dts-v1-2-cc5ddffe140c@ti.com/
+Signed-off-by: Antonios Christidis <a-christidis@ti.com>
+[Andrei Aldea: order the binding before its user, preserve the separating
+ blank line, and add the reviewed GE8430 power-domain constraints.]
+Signed-off-by: Andrei Aldea <andrei1998@gmail.com>
+---
+ .../devicetree/bindings/gpu/img,powervr-rogue.yaml | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/gpu/img,powervr-rogue.yaml b/Documentation/devicetree/bindings/gpu/img,powervr-rogue.yaml
+index a1f54dbae3f3..226de1fdbf9c 100644
+--- a/Documentation/devicetree/bindings/gpu/img,powervr-rogue.yaml
++++ b/Documentation/devicetree/bindings/gpu/img,powervr-rogue.yaml
+@@ -44,6 +44,11 @@ properties:
+               - ti,j721s2-gpu
+           - const: img,img-bxs-4-64
+           - const: img,img-rogue
++      - items:
++          - enum:
++              - ti,j721e-gpu
++          - const: img,img-ge8430
++          - const: img,img-rogue
+ 
+       # This legacy combination of compatible strings was introduced early on
+       # before the more specific GPU identifiers were used.
+@@ -103,6 +108,7 @@ allOf:
+               - ti,am62-gpu
+               - ti,am62p-gpu
+               - ti,j721s2-gpu
++              - ti,j721e-gpu
+     then:
+       properties:
+         clocks:
+@@ -144,6 +150,7 @@ allOf:
+           contains:
+             enum:
+               - img,img-bxs-4-64
++              - img,img-ge8430
+               - img,img-ge7800
+               - img,img-gx6250
+     then:
+-- 
+2.53.0

--- a/patch/kernel/archive/k3-7.2/0002-FROMLIST-arm64-dts-ti-k3-j721e-Add-GPU-node.patch
+++ b/patch/kernel/archive/k3-7.2/0002-FROMLIST-arm64-dts-ti-k3-j721e-Add-GPU-node.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Antonios Christidis <a-christidis@ti.com>
+Date: Tue, 24 Feb 2026 12:09:16 -0600
+Subject: [PATCH] FROMLIST: arm64: dts: ti: k3-j721e: Add GPU node
+
+Add the Series8XE GPU node to the J721E device tree.
+
+Link: https://lore.kernel.org/all/20260224-gpu_dts-v1-1-cc5ddffe140c@ti.com/
+Signed-off-by: Antonios Christidis <a-christidis@ti.com>
+---
+ arch/arm64/boot/dts/ti/k3-j721e-main.dtsi | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/ti/k3-j721e-main.dtsi b/arch/arm64/boot/dts/ti/k3-j721e-main.dtsi
+index d5fd30a01032..be91e7a2afe5 100644
+--- a/arch/arm64/boot/dts/ti/k3-j721e-main.dtsi
++++ b/arch/arm64/boot/dts/ti/k3-j721e-main.dtsi
+@@ -2624,6 +2624,20 @@ icssg1_mdio: mdio@32400 {
+ 		};
+ 	};
+ 
++	gpu: gpu@4e20000000 {
++		compatible = "ti,j721e-gpu", "img,img-ge8430", "img,img-rogue";
++		reg = <0x4e 0x20000000 0x00 0x80000>;
++		clocks = <&k3_clks 125 0>;
++		clock-names = "core";
++		assigned-clocks = <&k3_clks 125 0>;
++		assigned-clock-rates = <750000000>;
++		interrupts = <GIC_SPI 24 IRQ_TYPE_LEVEL_HIGH>;
++		power-domains = <&k3_pds 125 TI_SCI_PD_EXCLUSIVE>,
++				<&k3_pds 126 TI_SCI_PD_EXCLUSIVE>;
++		power-domain-names = "a", "b";
++		dma-coherent;
++	};
++
+ 	main_mcan0: can@2701000 {
+ 		compatible = "bosch,m_can";
+ 		reg = <0x00 0x02701000 0x00 0x200>,
+-- 
+2.53.0

--- a/patch/kernel/archive/k3-beagle-7.2/0022-FROMLIST-arm64-dts-ti-add-J722S-GPU-node.patch
+++ b/patch/kernel/archive/k3-beagle-7.2/0022-FROMLIST-arm64-dts-ti-add-J722S-GPU-node.patch
@@ -1,0 +1,38 @@
+From c5e1393d136b6efe1883947d7bc813f21b8821ff Mon Sep 17 00:00:00 2001
+From: Michael Walle <mwalle@kernel.org>
+Date: Tue, 24 Feb 2026 16:55:27 -0600
+Subject: [PATCH] FROMLIST: arm64: dts: ti: add GPU node
+
+The J722S features a BXS-4 GPU. Add the node for it.
+
+Link: https://lore.kernel.org/all/20260224-gpu_dts-v1-4-cc5ddffe140c@ti.com/
+Signed-off-by: Michael Walle <mwalle@kernel.org>
+Signed-off-by: Antonios Christidis <a-christidis@ti.com>
+---
+ .../arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi b/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
+index c6a2d671a..2e3201a36 100644
+--- a/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
++++ b/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
+@@ -1244,6 +1244,17 @@ dsi0: dsi@30500000 {
+ 		status = "disabled";
+ 	};
+ 
++	gpu: gpu@fd80000 {
++		compatible = "ti,am62p-gpu", "img,img-bxs-4-64", "img,img-rogue";
++		reg = <0x00 0x0fd80000 0x00 0x80000>;
++		clocks = <&k3_clks 237 3>;
++		clock-names = "core";
++		interrupts = <GIC_SPI 241 IRQ_TYPE_LEVEL_HIGH>;
++		power-domains = <&k3_pds 237 TI_SCI_PD_EXCLUSIVE>,
++				<&k3_pds 242 TI_SCI_PD_EXCLUSIVE>;
++		power-domain-names = "a", "b";
++	};
++
+ 	vpu: video-codec@30210000 {
+ 		compatible = "ti,j721s2-wave521c", "cnm,wave521c";
+ 		reg = <0x00 0x30210000 0x00 0x10000>;
+-- 
+2.53.0

--- a/patch/kernel/archive/k3-beagle-7.2/dt/k3-am67a-beagley-ai-armbian.dtsi
+++ b/patch/kernel/archive/k3-beagle-7.2/dt/k3-am67a-beagley-ai-armbian.dtsi
@@ -312,6 +312,11 @@
 	};
 };
 
+&gpu {
+	assigned-clocks = <&k3_clks 237 3>;
+	assigned-clock-rates = <800000000>;
+};
+
 &dss1 {
 	status = "okay";
 	pinctrl-names = "default";


### PR DESCRIPTION
Enable the TI Rogue GPU stack for BeagleY-AI, BeaglePlay, and BeagleBone AI-64 when `GPU_SUPPORT=yes`, including target-ABI DKMS builds and required GPU DT patches.

For performance reasons also blacklist upstream PowerVR driver. 

Assisted w/Codex Sol 5.6 Extra High

# How Has This Been Tested?

- [x] Tested on BeagleY-AI with Linux 7.2.0-rc4: `pvrsrvkm` bound successfully, Vulkan hardware acceleration and PVR tests passed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled GPU support for BeagleBone AI-64, BeaglePlay, and BeagleY-AI images.
  - Added GPU support for TI J721E and J722S platforms.
  - Added Rogue GPU driver and DKMS setup when GPU support is enabled.
  - Configured GPU clocks and module loading for supported boards.

- **Bug Fixes**
  - Improved TI package repository detection and handling when compatible packages are unavailable.
  - Prevented unnecessary Rogue GPU packages from being installed on systems without GPU support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->