### PR TITLE
k3: handle optional boot firmware artifacts cleanly

### DIFF
--- a/config/sources/families/include/k3_common.inc
+++ b/config/sources/families/include/k3_common.inc
@@ -43,7 +43,7 @@ esac
 
 ATF_TARGET_MAP="PLAT=${ATF_PLAT} TARGET_BOARD=${ATF_BOARD} SPD=opteed ${ATF_ARGS} all;;build/${ATF_PLAT}/${ATF_BOARD}/release/bl31.bin:bl31.bin ${EXTRA_ATF_TARGETS}"
 
-UBOOT_TARGET_MAP="BL31=bl31.bin ${EXTRA_BOOT_ARGS} TEE=${SRC}/cache/sources/optee-os/out/arm-plat-k3/core/tee-pager_v2.bin BINMAN_INDIRS=${SRC}/cache/sources/ti-linux-firmware all;;tiboot3.bin ${SYSFW_FILE:+sysfw.itb} tispl.bin u-boot.img"
+UBOOT_TARGET_MAP="BL31=bl31.bin ${EXTRA_BOOT_ARGS} TEE=${SRC}/cache/sources/optee-os/out/arm-plat-k3/core/tee-pager_v2.bin BINMAN_INDIRS=${SRC}/cache/sources/ti-linux-firmware all;;tiboot3.bin ${SYSFW_FILE:+sysfw.itb} ${TISPL_FILE:-tispl.bin}:tispl.bin ${UBOOT_FILE:-u-boot.img}:u-boot.img"
 
 # To match what our current SDK produces
 BOOT_FS_LABEL="boot"
@@ -79,14 +79,11 @@ function pre_config_uboot_target__build_first_stage() {
 	compile_k3_bootgen
 
 	if [[ "${BOOT_SOC}" != "am62l" ]]; then
-		cp ${SRC}/cache/sources/u-boot-worktree/${BOOTDIR}/${BOOTBRANCH##*:}/build-r5/${TIBOOT3_FILE} tiboot3.bin
-		cp ${SRC}/cache/sources/u-boot-worktree/${BOOTDIR}/${BOOTBRANCH##*:}/build-r5/${SYSFW_FILE} sysfw.itb || true
+		cp "${SRC}/cache/sources/u-boot-worktree/${BOOTDIR}/${BOOTBRANCH##*:}/build-r5/${TIBOOT3_FILE}" tiboot3.bin
+		if [[ -n "${SYSFW_FILE:-}" ]]; then
+			cp "${SRC}/cache/sources/u-boot-worktree/${BOOTDIR}/${BOOTBRANCH##*:}/build-r5/${SYSFW_FILE}" sysfw.itb
+		fi
 	fi
-}
-
-function post_uboot_custom_postprocess__update_uboot_names() {
-	cp ${TISPL_FILE} tispl.bin || true
-	cp ${UBOOT_FILE} u-boot.img || true
 }
 
 function pre_prepare_partitions() {
@@ -108,8 +105,10 @@ function format_partitions() {
 }
 
 function write_uboot_platform() {
-	cp $1/tiboot3.bin ${MOUNT}/boot
-	cp $1/sysfw.itb ${MOUNT}/boot || true
-	cp $1/tispl.bin ${MOUNT}/boot
-	cp $1/u-boot.img ${MOUNT}/boot
+	cp "$1/tiboot3.bin" "${MOUNT}/boot"
+	if [[ -f "$1/sysfw.itb" ]]; then
+		cp "$1/sysfw.itb" "${MOUNT}/boot"
+	fi
+	cp "$1/tispl.bin" "${MOUNT}/boot"
+	cp "$1/u-boot.img" "${MOUNT}/boot"
 }


### PR DESCRIPTION
# Description

Clean up TI K3 U-Boot artifact handling by using `UBOOT_TARGET_MAP` for canonical filenames and only packaging `sysfw.itb` when the board actually provides it. This removes unnecessary post-build renaming and avoids missing `sysfw.itb` warnings.

Thanks @SuperKali for @ing me to stop ignoring it 😛 

# How Has This Been Tested?

- [x] Built U-Boot packages for BeagleY-AI, BeaglePlay, BeagleBone AI-64, SK-AM64B, and SK-AM68.
- [x] Verified each package contains the expected boot artifacts, including `sysfw.itb` only for BeagleBone AI-64.
- [x] Boot-tested BeagleY-AI from SD and confirmed successful boot.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved K3 boot artifact generation and packaging.
  * Added safer handling for custom TISPL filenames and optional system firmware files.
  * Prevented boot preparation from failing when optional firmware artifacts are unavailable.
  * Improved support for paths containing spaces during boot image preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->