### PR TITLE
nanopi-r3s: Add "ethernet1" alias for the LAN port

### DIFF
--- a/patch/kernel/archive/rockchip64-7.1/board-nanopi-r3s-fix-missing-ethernet1-alias.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-nanopi-r3s-fix-missing-ethernet1-alias.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Darsey Litzenberger <dlitz@dlitz.net>
+Date: Fri, 24 Jul 2026 01:25:51 -0600
+Subject: arm64: dts: rockchip: nanopi-r3s: Add "ethernet1" alias for the LAN
+ port
+
+This makes u-boot pass a stable MAC address to the kernel, and makes
+systemd recognize the port as an "onboard" interface rather than
+defaulting to using the PCI bus & slot numbers.
+
+Before this change:
+	# ip -brief link
+	lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
+	end0             UP             fa:ac:75:c1:e9:0c <BROADCAST,MULTICAST,UP,LOWER_UP>
+	enp1s0           DOWN           72:8c:0a:17:ed:e3 <NO-CARRIER,BROADCAST,MULTICAST,UP>
+
+After this change:
+	# ip -brief link
+	lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
+	end0             UP             fa:ac:75:c1:e9:0c <BROADCAST,MULTICAST,UP,LOWER_UP>
+	end1             DOWN           fa:ac:75:c1:e9:0d <NO-CARRIER,BROADCAST,MULTICAST,UP>
+---
+ arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts b/arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts
+@@ -22,6 +22,7 @@ / {
+ 
+ 	aliases {
+ 		ethernet0 = &gmac1;
++		ethernet1 = &r8169;
+ 		mmc0 = &sdhci;
+ 		mmc1 = &sdmmc0;
+ 	};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/board-nanopi-r3s-fix-missing-ethernet1-alias.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-nanopi-r3s-fix-missing-ethernet1-alias.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Darsey Litzenberger <dlitz@dlitz.net>
+Date: Fri, 24 Jul 2026 01:25:51 -0600
+Subject: arm64: dts: rockchip: nanopi-r3s: Add "ethernet1" alias for the LAN
+ port
+
+This makes u-boot pass a stable MAC address to the kernel, and makes
+systemd recognize the port as an "onboard" interface rather than
+defaulting to using the PCI bus & slot numbers.
+
+Before this change:
+	# ip -brief link
+	lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
+	end0             UP             fa:ac:75:c1:e9:0c <BROADCAST,MULTICAST,UP,LOWER_UP>
+	enp1s0           DOWN           72:8c:0a:17:ed:e3 <NO-CARRIER,BROADCAST,MULTICAST,UP>
+
+After this change:
+	# ip -brief link
+	lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
+	end0             UP             fa:ac:75:c1:e9:0c <BROADCAST,MULTICAST,UP,LOWER_UP>
+	end1             DOWN           fa:ac:75:c1:e9:0d <NO-CARRIER,BROADCAST,MULTICAST,UP>
+---
+ arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts b/arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts
+@@ -22,6 +22,7 @@ / {
+ 
+ 	aliases {
+ 		ethernet0 = &gmac1;
++		ethernet1 = &r8169;
+ 		mmc0 = &sdhci;
+ 		mmc1 = &sdmmc0;
+ 	};
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

This makes u-boot pass a stable MAC address to the kernel, and makes systemd recognize the port as an "onboard" interface rather than defaulting to using the PCI bus & slot numbers.

Before this change:
```
lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
end0             UP             fa:ac:75:c1:e9:0c <BROADCAST,MULTICAST,UP,LOWER_UP>
enp1s0           DOWN           72:8c:0a:17:ed:e3 <NO-CARRIER,BROADCAST,MULTICAST,UP>
```

After this change:
```
lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
end0             UP             fa:ac:75:c1:e9:0c <BROADCAST,MULTICAST,UP,LOWER_UP>
end1             DOWN           fa:ac:75:c1:e9:0d <NO-CARRIER,BROADCAST,MULTICAST,UP>
```

This affects both the nanopi-r3s and nanopi-r3s-lts boards.

Applied to "edge" (7.1) and "bleedingedge" (7.2).  Not applying to "current" (6.18) because changing interface names/MAC addresses in a point release might be considered rude.

# Documentation summary for feature / change

This changes an interface name & MAC address.  I'm not sure if/how to document that.

# How Has This Been Tested?

Tested on nanopi-r3s-lts using "current" (6.18), "edge" (7.1), and "bleedingedge" (7.2-rc4) configurations.

# Checklist:

- [ ] My code follows the style guidelines of this project (?)
- [X] I have performed a self-review of my own code
- [ ] My changes generate no new warnings (?)

I'm not a regular contributor, and I'm not sure if this is the correct way to submit device-tree patches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing Ethernet interface aliasing on NanoPi R3S devices.
  * The secondary LAN interface is now consistently recognized as `ethernet1`, improving stable interface naming across supported Rockchip kernel versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->