### PR TITLE
Fix Darwin Docker Host Arch

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -357,7 +357,14 @@ function docker_cli_prepare_dockerfile() {
 	# so the arch-specific host-dependency guards (skipping cross-compilers that
 	# don't exist on riscv64, etc.) match the image being produced, not the runner.
 	declare host_arch
-	host_arch="${DOCKER_ARMBIAN_HOST_ARCH:-"$(dpkg --print-architecture)"}"
+	if [[ -n "${DOCKER_ARMBIAN_HOST_ARCH:-}" ]]; then
+		host_arch="${DOCKER_ARMBIAN_HOST_ARCH}"
+	else
+		# Resolve the architecture where the Dockerfile will actually build.
+		# This also avoids relying on host tools such as dpkg, which may not
+		# exist on macOS or non-Debian Docker hosts.
+		host_arch="$(docker version --format '{{.Server.Arch}}')"
+	fi
 	host_release="${DOCKER_WANTED_RELEASE}" host_arch="${host_arch}" early_prepare_host_dependencies # hooks: add_host_dependencies // host_dependencies_known
 	display_alert "Pre-game host dependencies for host_release '${DOCKER_WANTED_RELEASE}' host_arch '${host_arch}'" "${host_dependencies[*]}" "debug"
 


### PR DESCRIPTION
# Description

Build command stopped working as of a recent commit on macOS Hosts. 

Fix Dockerfile generation on macOS and non-Debian hosts by detecting architecture from the Docker server instead of relying on host dpkg. The existing DOCKER_ARMBIAN_HOST_ARCH override remains supported for foreign-architecture builds.

<img width="1362" height="361" alt="Screenshot 2026-07-25 at 12 49 01 PM" src="https://github.com/user-attachments/assets/e33f27e9-0b8f-4454-9675-a3628659bddb" />

# How Has This Been Tested?

- [x] Compile Test on M5 MacBook Pro MacOS 26.5.2 (25F84) and Docker Desktop v4.83.0

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker-based architecture detection to use the Docker server’s architecture when no override is provided.
  * Increased compatibility when the host system architecture differs from the Docker environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->