### PR TITLE
cix-p1: pin edge kernel to v7.1.4 (Panthor patchset breaks on 7.1.5)

### DIFF
--- a/config/sources/families/cix-p1.conf
+++ b/config/sources/families/cix-p1.conf
@@ -25,6 +25,12 @@ case $BRANCH in
 		;;
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="7.1"
+		# Freeze to v7.1.4 — the newest 7.1.y that still has
+		# drivers/gpu/drm/panthor/panthor_regs.h, which 7.1.5 removed (a Panthor
+		# restructure) and which breaks cixtech's out-of-tree Panthor ACPI patch
+		# (0011-drm-panthor-add-acpi-support-for-cix-p1). Unfreeze once the CIX BSP
+		# patchset is rebased onto a newer 7.1.y.
+		declare -g KERNELBRANCH="tag:v7.1.4"
 		;;
 esac
 


### PR DESCRIPTION
## Problem

`kernel-cix-p1-edge` fails patching on **linux-stable 7.1.5** ([ci job](https://github.com/armbian/ci/actions/runs/30164602579/job/89703540710)):

```
Failed to apply: 0011-drm-panthor-add-acpi-support-for-cix-p1  (+829/-71, 10 Panthor files)
84 total; 83 applied; 1 failed_apply; 1 missing_file
```

**7.1.5 removed `drivers/gpu/drm/panthor/panthor_regs.h`** (an upstream Panthor restructure), and cixtech's out-of-tree ACPI patch modifies that file → `missing_file` / `failed_apply`.

## Fix (stopgap)

The CIX edge kernel tracked moving 7.1.y HEAD (no pin). **Freeze it to `tag:v7.1.4`** — the newest 7.1.y that still ships `panthor_regs.h`, so the patchset applies again. Same freeze pattern used elsewhere (e.g. `meson_common.inc` `tag:v6.12.28`).

Timeline that pinned the target:
- CIX edge bumped to 7.1: **2026-07-18 10:46 UTC**
- v7.1.3 (07-04) / **v7.1.4 (07-18 14:55 UTC)** — both have `panthor_regs.h`
- v7.1.5 (07-24) — **removed** `panthor_regs.h` → break

## Verification
- `panthor_regs.h` present at v7.1.4, absent at v7.1.5 (confirmed).
- Build tested on v7.1.4 (per @igorpecovnik).

## @amazingfate — patch rebase needed

This is a **stopgap pin**. The real fix is to rebase the CIX Panthor ACPI patchset (`0011-drm-panthor-add-acpi-support-for-cix-p1`, by Jianfeng Liu @ cixtech) onto the restructured Panthor driver in **7.1.5+** (which drops `panthor_regs.h`). Once that's done we can unpin and resume tracking 7.1.y. cc @HeyMeco @EvilOlaf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated edge builds to use a fixed Linux 7.1.4 kernel version.
  - Improves consistency and reproducibility across edge releases.
  - Prevents unexpected kernel changes from affecting build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->