### PR TITLE
realtek-rtd1619b: don't error on int/pointer conversions (gcc >= 14)

### DIFF
--- a/config/sources/families/realtek-rtd1619b.conf
+++ b/config/sources/families/realtek-rtd1619b.conf
@@ -23,6 +23,11 @@ case $BRANCH in
 		KERNELBRANCH='branch:v6.6.54-xpressreal-t3'
 		LINUXCONFIG="linux-xpressreal-t3-6.6"
 		KERNEL_BTF="no"
+		# gcc >= 14 (trixie) promotes int<->pointer conversions to hard errors;
+		# this XpressReal vendor 6.6 kernel has such mismatches (e.g.
+		# drivers/soc/realtek/cpudvfs/rtk_cpu_volt_sel.c, drivers/mfd/apw8886-i2c.c).
+		# Demote to warnings so the vendor tree builds as it did on gcc <= 13.
+		declare -g KERNEL_EXTRA_CFLAGS="${KERNEL_EXTRA_CFLAGS:-} -Wno-error=int-conversion -Wno-error=incompatible-pointer-types"
 		;;
 esac
 


### PR DESCRIPTION
## Problem

`kernel-realtek-rtd1619b-vendor` (XpressReal vendor kernel 6.6.54) fails to **compile** on **gcc 14** (Debian trixie) — [ci job](https://github.com/armbian/ci/actions/runs/30164602579/job/89703540746):

```
drivers/soc/realtek/cpudvfs/rtk_cpu_volt_sel.c:147: error: assignment to 'struct opp_table *' from 'int' [-Wint-conversion]
drivers/mfd/apw8886-i2c.c:79: error: returning 'const void *' ... makes integer from pointer without a cast [-Wint-conversion]
```

gcc 14 promotes `-Wint-conversion` / `-Wincompatible-pointer-types` from warning to a default **hard error**. This vendor 6.6 tree has int↔pointer mismatches that gcc ≤ 13 only warned about, so it built before.

## Fix

Demote those two classes back to warnings via **`KERNEL_EXTRA_CFLAGS`** (appended to the kernel `KCFLAGS` in `kernel-make.sh`), **scoped to the realtek-rtd1619b vendor family only** — not global. Same mechanism and idiom `imx8ulp.conf` already uses (`-Wno-error=enum-int-mismatch`), and the class `crust.sh`/`atf.sh` handle with `-Wno-error=incompatible-pointer-types`.

This restores the pre-gcc-14 behaviour (same generated code) rather than changing the driver logic.

## Notes
- Kernel analog of the u-boot gcc-14 fix (#10221, implicit-function-declaration).
- Couldn't run a full kernel build locally (no Docker). If more gcc-14 error classes surface behind these two, they can be added to the same `KERNEL_EXTRA_CFLAGS`. The proper long-term fix is for the XpressReal BSP to correct the int/pointer types.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when building the Realtek RTD1619B vendor kernel with GCC 14.
  * Specific type-conversion compiler warnings are now handled without stopping the build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->