### PR TITLE
fix(sovol): reuse CB1 u-boot board patches on Sovol H616 boards

### DIFF
--- a/patch/u-boot/v2026.07-sunxi64/board_sovol-sv08
+++ b/patch/u-boot/v2026.07-sunxi64/board_sovol-sv08
@@ -1,0 +1,1 @@
+board_bigtreetech-cb1

--- a/patch/u-boot/v2026.07-sunxi64/board_sovol-sv08-max
+++ b/patch/u-boot/v2026.07-sunxi64/board_sovol-sv08-max
@@ -1,0 +1,1 @@
+board_bigtreetech-cb1

--- a/patch/u-boot/v2026.07-sunxi64/board_sovol-zero
+++ b/patch/u-boot/v2026.07-sunxi64/board_sovol-zero
@@ -1,0 +1,1 @@
+board_bigtreetech-cb1


### PR DESCRIPTION
# Description

Sovol Zero, SV08 and SV08 Max are the eMMC-variant BigTreeTech CB1 electrically: same SoC, same pinout. They set `BOOTCONFIG="bigtreetech_cb1_defconfig"`, but the board-level u-boot patches that go with it sit in `patch/u-boot/v2026.07-sunxi64/board_bigtreetech-cb1/`, and `lib/tools/patching.py` only applies a `board_<name>` subdir when `BOARD` matches. Neither patch ever reached the Sovol boards. The defconfig is never created, so the build fails outright, and the PC3 eMMC selpin is never pulled down, so boot from eMMC doesn't work.

Symlinks rather than copies, so the boards stay in sync with the one they clone. Same as `board_kickpik2b -> board_bananapim4zero` in `v2026.01`.

#10280 fixes the defconfig half by moving that patch to the general `v2026.07-sunxi64/` dir. No conflict, either order works: that one is a rename, so afterwards `board_bigtreetech-cb1/` holds only the selpin patch, which is the genuinely board-specific part.

# How Has This Been Tested?

- [x] `os.path.isdir` and `os.listdir` in `lib/tools/common/patching_utils.py` follow symlinks, so a symlinked board dir is read like a real one
- [x] Same as the existing symlinked board dirs in `patch/u-boot/v2026.01/`
- [x] Local `uboot-sovol-zero-current` build passes, both CB1 patches apply through the symlink; `bigtreetech-cb1` built from the same tree is unchanged (details in the comment below)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
