### PR TITLE
starfive2-vendor: fix img-rogue build on GNU Make 4.4 (trixie)

### DIFF
--- a/patch/kernel/starfive2-vendor/drm-img-rogue-drop-bare-SECONDARY-for-gnu-make-4.4.patch
+++ b/patch/kernel/starfive2-vendor/drm-img-rogue-drop-bare-SECONDARY-for-gnu-make-4.4.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor@armbian.com>
+Date: Fri, 25 Jul 2026 00:00:00 +0200
+Subject: [PATCH] drm: img-rogue: drop bare .SECONDARY: to build with GNU Make 4.4
+
+GNU Make 4.4 (Debian trixie) aborts building the PowerVR img-rogue driver
+with:
+
+  .NOTINTERMEDIATE and .SECONDARY are mutually exclusive.  Stop.
+
+The error fires only when a global (no-prerequisite) '.SECONDARY:' and a
+global '.NOTINTERMEDIATE:' are both in effect; Make 4.4 derives the latter
+implicitly for the DDK's rules, while drivers/gpu/drm/img/img-rogue/Makefile
+also declares a bare '.SECONDARY:'. Older Make (<= 4.3) had no
+'.NOTINTERMEDIATE' and tolerated this. Reproduced with GNU Make 4.4.1.
+
+Drop the redundant bare '.SECONDARY:'; intermediate-file preservation for
+this build is already covered by Make's default handling of the DDK rules.
+
+Signed-off-by: Igor Pecovnik <igor@armbian.com>
+---
+ drivers/gpu/drm/img/img-rogue/Makefile | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/img/img-rogue/Makefile b/drivers/gpu/drm/img/img-rogue/Makefile
+--- a/drivers/gpu/drm/img/img-rogue/Makefile
++++ b/drivers/gpu/drm/img/img-rogue/Makefile
+@@ -73,7 +73,6 @@ WINDOW_SYSTEM=nulldrmws
+ #include $(OUT)/config_kernel.mk
+ include $(srctree)/$(src)/config_kernel.mk
+
+-.SECONDARY:
+
+ define symlink-source-file
+ @if [ ! -e $(dir $@) ]; then mkdir -p $(dir $@); fi


### PR DESCRIPTION
## Problem

`kernel-starfive2-vendor` (StarFive VF2, RISC-V, vendor 6.6.20) fails to **compile** the PowerVR img-rogue GPU driver on **GNU Make 4.4** (Debian trixie) — [ci job](https://github.com/armbian/ci/actions/runs/30164602579/job/89703540711):

```
make: *** .NOTINTERMEDIATE and .SECONDARY are mutually exclusive.  Stop.
make[6]: *** [scripts/Makefile.build:480: drivers/gpu/drm/img/img-rogue] Error 2
```

## Root cause (reproduced locally)

GNU Make 4.4 raises this error **only** when a global (no-prerequisite) `.SECONDARY:` and a global `.NOTINTERMEDIATE:` are both in effect. Confirmed with GNU Make 4.4.1:
- bare `.SECONDARY:` alone → builds fine
- `.SECONDARY:` + `.NOTINTERMEDIATE:` → the exact error above

`drivers/gpu/drm/img/img-rogue/Makefile:76` declares a bare `.SECONDARY:`. `.NOTINTERMEDIATE` is not written in any of the 13 img-rogue makefiles nor the kernel build files — Make 4.4 derives it implicitly for the DDK's rule chains. Make ≤ 4.3 had no `.NOTINTERMEDIATE`, so this built before trixie.

## Fix

New `patch/kernel/starfive2-vendor/` patchdir (none existed) with a patch that drops the redundant bare `.SECONDARY:`. My local reproduction shows a Makefile with only `.SECONDARY:` removed no longer errors, and intermediate-file handling for this build is covered by Make's defaults.

## Verification
- Patch applies cleanly to the real vendor Makefile (`patch --dry-run` and `git apply --check` both clean).
- **Could not run the kernel build locally** (no Docker, and it's a GPU driver) — CI must confirm img-rogue compiles through. If a *generated* makefile still carries `.SECONDARY:`, the same one-line removal can be applied there.

Same class as the other trixie host-toolchain breakages (SWIG 4.3, gcc 14) — here it's GNU Make 4.4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build failures with GNU Make 4.4 when compiling the img-rogue graphics driver.
  * Improved compatibility with newer build environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->