### PR TITLE
fix(sunxi): use named i2c-gpio properties on BigTreeTech CB1

### DIFF
--- a/patch/kernel/archive/sunxi-6.18/dt_64/sun50i-h616-bigtreetech-cb1-emmc.dts
+++ b/patch/kernel/archive/sunxi-6.18/dt_64/sun50i-h616-bigtreetech-cb1-emmc.dts
@@ -21,8 +21,8 @@
 };
 
 &i2c_gpio {
-	gpios = <&pio 8 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>, /* SDA PI6 */
-			<&pio 8 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* SCL PI4 */
+	sda-gpios = <&pio 8 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* PI6 */
+	scl-gpios = <&pio 8 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* PI4 */
 };
 
 &can0_pin_irq {

--- a/patch/kernel/archive/sunxi-6.18/dt_64/sun50i-h616-bigtreetech-cb1-sd.dts
+++ b/patch/kernel/archive/sunxi-6.18/dt_64/sun50i-h616-bigtreetech-cb1-sd.dts
@@ -12,8 +12,8 @@
 };
 
 &i2c_gpio {
-	gpios = <&pio 2 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>, /* SDA PC12 */
-			<&pio 2 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* SCL PC10 */
+	sda-gpios = <&pio 2 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* PC12 */
+	scl-gpios = <&pio 2 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* PC10 */
 };
 
 &can0_pin_irq {

--- a/patch/kernel/archive/sunxi-7.0/dt_64/sun50i-h616-bigtreetech-cb1-emmc.dts
+++ b/patch/kernel/archive/sunxi-7.0/dt_64/sun50i-h616-bigtreetech-cb1-emmc.dts
@@ -21,8 +21,8 @@
 };
 
 &i2c_gpio {
-	gpios = <&pio 8 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>, /* SDA PI6 */
-			<&pio 8 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* SCL PI4 */
+	sda-gpios = <&pio 8 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* PI6 */
+	scl-gpios = <&pio 8 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* PI4 */
 };
 
 &can0_pin_irq {

--- a/patch/kernel/archive/sunxi-7.0/dt_64/sun50i-h616-bigtreetech-cb1-sd.dts
+++ b/patch/kernel/archive/sunxi-7.0/dt_64/sun50i-h616-bigtreetech-cb1-sd.dts
@@ -12,8 +12,8 @@
 };
 
 &i2c_gpio {
-	gpios = <&pio 2 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>, /* SDA PC12 */
-			<&pio 2 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* SCL PC10 */
+	sda-gpios = <&pio 2 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* PC12 */
+	scl-gpios = <&pio 2 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>; /* PC10 */
 };
 
 &can0_pin_irq {


### PR DESCRIPTION
# Description

The i2c-gpio binding lists `sda-gpios` and `scl-gpios` as required and keeps the combined `gpios` form under a `# Deprecated properties, do not use in new device tree sources:` heading. The four CB1 board files still carry the combined form, while the Sovol boards that include the same `sun50i-h616-bigtreetech-cb1.dtsi` already use the named one, so the family is split across two styles.

Nothing moves at runtime. The base `i2c_gpio` node in the dtsi carries no `gpios` of its own, so a board file is the only source and the two forms can't both land on one node. `i2c_gpio_get_desc()` in `drivers/i2c/busses/i2c-gpio.c` tries `devm_gpiod_get(dev, "sda", gflags)` first and falls back to `devm_gpiod_get_index(dev, NULL, 0, gflags)` with the same flags, so the descriptor comes out identical. Pin assignment is unchanged: index 0 was SDA, index 1 was SCL, which matches the comments already in these files.

# How Has This Been Tested?

- [x] Checked the binding and the driver at the source, both quoted above
- [x] Local kernel build for `bigtreetech-cb1` passes, and the decompiled dtbs carry the expected pins and flags (details in the comment below)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
