### PR TITLE
Add a BTRFS_CHECKSUM build switch for choosing the checksum algorithm

### DIFF
--- a/extensions/fs-btrfs-support.sh
+++ b/extensions/fs-btrfs-support.sh
@@ -11,3 +11,16 @@ function add_host_dependencies__add_btrfs_tooling() {
 	display_alert "Extension: ${EXTENSION}: Adding packages to host dependencies" "btrfs-progs" "debug"
 	EXTRA_BUILD_DEPS+=("fs-tools::btrfs-progs")
 }
+
+function pre_update_initramfs__add_compression_module_to_initramfs() {
+	local modules=()
+	case "$BTRFS_CHECKSUM" in
+		xxhash) modules+=( xxhash_generic ) ;;
+		blake2) modules+=( blake2b_generic ) ;;
+		*) ;;
+	esac
+	if [[ "${#modules[@]}" -gt 0 ]]; then
+		display_alert "Extension: ${EXTENSION}: Adding extra boot-time module(s)" "${modules[*]}" info
+		printf '%s\n' "${modules[@]}" >> "$MOUNT"/etc/initramfs-tools/modules
+	fi
+}

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -155,6 +155,7 @@ function do_main_configuration() {
 			;;
 		btrfs)
 			enable_extension "fs-btrfs-support"
+			[[ -n "$BTRFS_CHECKSUM" && ! "$BTRFS_CHECKSUM" =~ ^(crc32c|xxhash|sha256|blake2)$ ]] && exit_with_error "Unknown btrfs checksum algorithm" "$BTRFS_CHECKSUM"
 			[[ -z $BTRFS_COMPRESSION ]] && BTRFS_COMPRESSION=zlib # default btrfs filesystem compression method is zlib
 			[[ ! $BTRFS_COMPRESSION =~ zlib|lzo|zstd|none ]] && exit_with_error "Unknown btrfs compression method" "$BTRFS_COMPRESSION"
 			;;

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -51,7 +51,6 @@ function prepare_partitions() {
 	else
 		display_alert "e2fsprogs version" "$e2fsprogs_version does not support orphan_file" "info"
 	fi
-
 	# mkopts[fat] is empty
 	# mkopts[ext2] is empty
 	# mkopts[f2fs] is empty
@@ -59,6 +58,10 @@ function prepare_partitions() {
 	# mkopts[nilfs2] is empty
 	# mkopts[xfs] is empty
 	# mkopts[nfs] is empty
+
+	if [[ -n "$BTRFS_CHECKSUM" ]]; then
+		mkopts[btrfs]+=" --checksum=$BTRFS_CHECKSUM "
+	fi
 
 	mkopts_label[ext4]='-L '
 	mkopts_label[ext2]='-L '


### PR DESCRIPTION
# Description

Adds a `BTRFS_CHECKSUM` build switch for choosing the checksum algorithm.  This allows getting extra error-detection reliability by using `blake2` or `sha256` instead of `crc32c`.

# Documentation summary for feature / change

See armbian/documentation#946.

# How Has This Been Tested?

Common options used for testing: `./compile.sh BTRFS_COMPRESSION=none BRANCH=current RELEASE=trixie BOARD=nanopi-r3s-lts BUILD_MINIMAL=yes KERNEL_CONFIGURE=no` plus `ROOTFS_TYPE` and `BTRFS_CHECKSUM` as indicated below.

Images were built, copied to an SD card, and then booted on a nanopi-r3s-lts board (with 1GiB RAM and no eMMC).

- [X] ROOTFS_TYPE=ext4
- [X] ROOTFS_TYPE=btrfs
- [X] ROOTFS_TYPE=btrfs BTRFS_CHECKSUM=crc32c
- [X] ROOTFS_TYPE=btrfs BTRFS_CHECKSUM=xxhash
- [X] ROOTFS_TYPE=btrfs BTRFS_CHECKSUM=sha256
- [X] ROOTFS_TYPE=btrfs BTRFS_CHECKSUM=blake2

* **Note:** I needed to use `BTRFS_COMPRESSION=none`, even before applying my patch, to make `ROOTFS_TYPE=btrfs` work reliably.  It seems that u-boot doesn't fully support BTRFS compression, and would give the error "BTRFS: An error occurred while reading file /boot/armbianEnv.txt" and then fail to provide the correct command-line to the kernel.  I don't have time right now to debug that issue further, but I've determined that it's unrelated to my change here.

# Checklist:

- [ ] My code follows the style guidelines of this project (I think so? Where are these guidelines?)
- [X] I have performed a self-review of my own code
- [ ] My changes generate no new warnings (I think so, but compile output is large and I might have missed something.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a Btrfs checksum algorithm during filesystem creation.
  * Automatically selects the matching boot-time initramfs compression module for supported checksum algorithms.
* **Bug Fixes**
  * Now validates any provided Btrfs checksum algorithm value during configuration and stops with a clear error if it’s not recognized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->