### PR TITLE
ci: auto-label PRs "Work in progress" from review state

### DIFF
--- a/.github/scripts/wip-label.js
+++ b/.github/scripts/wip-label.js
@@ -1,0 +1,103 @@
+// Shared logic for the "Work in progress" label automation.
+//
+// A pull request is "work in progress" when a reviewer has requested changes
+// OR any review conversation is still unresolved. The label is recomputed from
+// the PR's live state, so it is idempotent and the same regardless of what
+// triggered the run.
+//
+// Used by:
+//   - maintenance-label-wip.yml   (workflow_run worker: instant, one PR)
+//   - maintenance-label-wip-sweep.yml (cron backstop: all open PRs)
+//
+// These run from the default branch context (workflow_run / schedule), which
+// has a read/write GITHUB_TOKEN even for fork PRs -- unlike a pull_request_review
+// trigger, whose token is read-only on forks.
+
+const LABEL = "Work in progress";
+
+// Returns { wip, reviewDecision, unresolved } for a single PR.
+async function evaluate(github, owner, repo, number) {
+  let reviewDecision = null;
+  let unresolved = 0;
+  let after = null;
+
+  do {
+    const query = `
+      query($owner:String!, $repo:String!, $number:Int!, $after:String) {
+        repository(owner:$owner, name:$repo) {
+          pullRequest(number:$number) {
+            reviewDecision
+            reviewThreads(first:100, after:$after) {
+              nodes { isResolved }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+      }`;
+    const data = await github.graphql(query, { owner, repo, number, after });
+    const pr = data.repository.pullRequest;
+    reviewDecision = pr.reviewDecision;
+    for (const t of pr.reviewThreads.nodes) {
+      if (!t.isResolved) unresolved++;
+    }
+    after = pr.reviewThreads.pageInfo.hasNextPage
+      ? pr.reviewThreads.pageInfo.endCursor
+      : null;
+  } while (after);
+
+  return { wip: reviewDecision === "CHANGES_REQUESTED" || unresolved > 0, reviewDecision, unresolved };
+}
+
+// Add or remove the label on one PR to match its evaluated state.
+async function syncOne({ github, core, owner, repo, number }) {
+  const { wip, reviewDecision, unresolved } = await evaluate(github, owner, repo, number);
+
+  const current = await github.rest.issues.listLabelsOnIssue({
+    owner, repo, issue_number: number, per_page: 100,
+  });
+  const has = current.data.some(l => l.name === LABEL);
+  const state = `reviewDecision=${reviewDecision} unresolved=${unresolved}`;
+
+  if (wip && !has) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: [LABEL] });
+    core.info(`PR #${number}: added "${LABEL}" (${state})`);
+  } else if (!wip && has) {
+    await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name: LABEL });
+    core.info(`PR #${number}: removed "${LABEL}" (${state})`);
+  } else {
+    core.info(`PR #${number}: no change, has=${has} (${state})`);
+  }
+}
+
+// Sweep every open PR (paginated). One PR failing does not abort the rest.
+async function syncAllOpen({ github, core, owner, repo }) {
+  let after = null;
+  let count = 0;
+
+  do {
+    const query = `
+      query($owner:String!, $repo:String!, $after:String) {
+        repository(owner:$owner, name:$repo) {
+          pullRequests(states: OPEN, first: 50, after: $after) {
+            nodes { number }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }`;
+    const data = await github.graphql(query, { owner, repo, after });
+    const conn = data.repository.pullRequests;
+    for (const pr of conn.nodes) {
+      count++;
+      try {
+        await syncOne({ github, core, owner, repo, number: pr.number });
+      } catch (e) {
+        core.warning(`PR #${pr.number}: sync failed: ${e.message}`);
+      }
+    }
+    after = conn.pageInfo.hasNextPage ? conn.pageInfo.endCursor : null;
+  } while (after);
+
+  core.info(`Swept ${count} open PR(s).`);
+}
+
+module.exports = { syncOne, syncAllOpen };

--- a/.github/workflows/maintenance-label-on-approval.yml
+++ b/.github/workflows/maintenance-label-on-approval.yml
@@ -27,7 +27,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - id: pr
-        run: echo "number=$(cat pr.txt)" >> $GITHUB_OUTPUT
+        run: echo "number=$(cat pr.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Label when approved
         uses: j-fulbright/label-when-approved-action@911c622c75f8ea99ee00cdd66e2cd888bac530c6 # v1.2
@@ -52,7 +52,9 @@ jobs:
               core.setFailed("Invalid PR number in PR_NUMBER");
               return;
             }
-            const labelsToRemove = ["Needs review", "Work in progress", "Backlog", "Can be closed?", "Help needed", "Needs Documentation"];
+            // "Work in progress" is owned by maintenance-label-wip.yml (synced from
+            // review decision + unresolved conversations), so it is not removed here.
+            const labelsToRemove = ["Needs review", "Backlog", "Can be closed?", "Help needed", "Needs Documentation"];
 
             for (const name of labelsToRemove) {
               try {

--- a/.github/workflows/maintenance-label-on-approval.yml
+++ b/.github/workflows/maintenance-label-on-approval.yml
@@ -73,7 +73,9 @@ jobs:
               return;
             }
             const issue_number = Number(raw);
-            const labelsToRemove = ["Needs review", "Work in progress", "Backlog", "Can be closed?", "Help needed", "Needs Documentation"];
+            // "Work in progress" is owned by maintenance-label-wip.yml (synced from
+            // review decision + unresolved conversations), so it is not removed here.
+            const labelsToRemove = ["Needs review", "Backlog", "Can be closed?", "Help needed", "Needs Documentation"];
 
             for (const name of labelsToRemove) {
               try {

--- a/.github/workflows/maintenance-label-wip-sweep.yml
+++ b/.github/workflows/maintenance-label-wip-sweep.yml
@@ -1,0 +1,44 @@
+name: "Maintenance: Sweep work in progress labels"
+
+# Backstop for the WIP-label automation. GitHub Actions has no trigger for a
+# review conversation being resolved/unresolved, so the event-driven worker
+# (maintenance-label-wip.yml) cannot react to that on its own. This scheduled
+# sweep recomputes the "Work in progress" label for every open PR, catching
+# conversation resolution and any missed events. Runs from the default branch,
+# so its GITHUB_TOKEN has write access. Tune the cron for more/less latency.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: label-wip-sweep
+  cancel-in-progress: true
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read          # check out the shared script
+      issues: write
+      pull-requests: write
+
+    steps:
+      # Pin to the default branch: workflow_dispatch can target any branch, and
+      # checkout would otherwise run that branch's copy of the script.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Sync "Work in progress" across open PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { syncAllOpen } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/wip-label.js`);
+            await syncAllOpen({ github, core, owner: context.repo.owner, repo: context.repo.repo });

--- a/.github/workflows/maintenance-label-wip.yml
+++ b/.github/workflows/maintenance-label-wip.yml
@@ -1,0 +1,65 @@
+name: "Maintenance: Label work in progress"
+
+# Privileged half of the WIP-label automation. Triggered when the fork-safe
+# listener (maintenance-listen-review-wip.yml) finishes, this runs in the
+# default-branch context with a write token and syncs the "Work in progress"
+# label for the reviewed PR. A cron backstop (maintenance-label-wip-sweep.yml)
+# additionally catches conversation-resolution events, which have no trigger.
+
+on:
+  workflow_run:
+    workflows: ["Maintenance: Listen PR review (WIP)"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+# One run per PR (keyed on the reviewed head branch); newer reviews supersede.
+concurrency:
+  group: label-wip-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  wip-label:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read           # download the artifact from the upstream run
+      contents: read          # check out the shared script from the default branch
+      issues: write
+      pull-requests: write
+
+    steps:
+      # Default branch (trusted) so the label logic is never PR-authored code.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The listener runs on pull_request_review (fork-controlled), so its
+      # artifact is untrusted: download it into RUNNER_TEMP, never the checkout,
+      # so it cannot overwrite the trusted wip-label.js the next step executes.
+      - name: Download PR number from the listener run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: wip-pr-number-${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/listener
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: pr
+        run: echo "number=$(cat "${{ runner.temp }}/listener/pr.txt")" >> "$GITHUB_OUTPUT"
+
+      - name: Sync "Work in progress" for the PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { syncOne } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/wip-label.js`);
+            const number = Number.parseInt(process.env.PR_NUMBER || "", 10);
+            if (!Number.isInteger(number) || number <= 0) {
+              core.setFailed("Invalid PR number from listener artifact");
+              return;
+            }
+            await syncOne({ github, core, owner: context.repo.owner, repo: context.repo.repo, number });

--- a/.github/workflows/maintenance-listen-review-wip.yml
+++ b/.github/workflows/maintenance-listen-review-wip.yml
@@ -1,0 +1,26 @@
+name: "Maintenance: Listen PR review (WIP)"
+
+# Fork PRs give pull_request_review a read-only GITHUB_TOKEN, so this workflow
+# only records which PR was reviewed and hands off to maintenance-label-wip.yml
+# (workflow_run), which runs in the default-branch context with write access.
+
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions:
+  contents: read
+
+jobs:
+  save-pr-number:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr.txt
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wip-pr-number-${{ github.run_id }}
+          path: pr.txt


### PR DESCRIPTION
Keeps the **`Work in progress`** label in sync with a PR's review state: present while a review requests changes or any conversation is unresolved, cleared once neither holds.

### Why hybrid

Two hard GitHub constraints rule out a single `pull_request_review`-triggered workflow (thanks @coderabbitai for catching both):

1. **No trigger for conversation resolution.** `pull_request_review_thread` is a webhook event but **not** a valid Actions trigger — actionlint rejects it. So nothing fires when a thread is resolved/unresolved.
2. **Fork PRs get a read-only `GITHUB_TOKEN`** on `pull_request_review`, so direct `addLabels`/`removeLabel` would silently fail on any fork PR.

So this uses an event path (fast, for the common cases) plus a cron backstop (for the case that has no event):

| File | Role |
|---|---|
| **`.github/scripts/wip-label.js`** | Shared logic — `reviewDecision` + paginated unresolved `reviewThreads` → add/remove label. Single source of truth so the two paths can't drift. |
| **`maintenance-listen-review-wip.yml`** | Listens on `pull_request_review` with a **read-only** token (fork-safe); only records the PR number as an artifact. |
| **`maintenance-label-wip.yml`** | `workflow_run` worker fired by the listener — runs in the **default-branch context with a write token**, checks out the trusted script, syncs that one PR. |
| **`maintenance-label-wip-sweep.yml`** | Scheduled backstop (`*/30`), recomputes the label for **every open PR** — catches conversation resolution and any missed events. |

> **`Work in progress` = `reviewDecision == CHANGES_REQUESTED` OR any review conversation unresolved.**

### How this addresses the review

- **Invalid `pull_request_review_thread` trigger** → removed entirely; conversation-resolution is handled by the cron sweep instead.
- **Fork read-only token** → the fork event only records the PR number (read-only, safe); all label writes happen in the `workflow_run`/`schedule` context, which has a write token even for fork PRs. The worker checks out the **default branch**, so the label logic is never PR-authored code.
- **Concurrency** → the worker uses a per-PR concurrency group (keyed on the reviewed head repo + branch) with `cancel-in-progress`; the sweep serialises with its own group.

### Also
- Dropped `Work in progress` from the blanket removal list in `maintenance-label-on-approval.yml` (now owned by this automation, so an approved-but-unresolved PR keeps the label until resolved), and quoted `$GITHUB_OUTPUT` there (shellcheck SC2086).
- `Work in progress` label already exists in `.github/labels.yml`.
- Validated locally with `actionlint` — clean.

### Trade-off / tunables
The event path is instant for "changes requested" and re-reviews. The one case with no event — *resolving the last conversation without submitting a review* — is picked up by the sweep within its cron interval (`*/30`, tunable). Set it looser to reduce Actions runs, tighter for faster resolution latency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated synchronization of the “Work in progress” label based on review decisions and unresolved review conversations.
  * The label now updates after review activity and is periodically refreshed across open pull requests.
  * Added an option to manually refresh the label synchronization.

* **Bug Fixes**
  * Review-related label cleanup no longer removes the “Work in progress” label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->