### PR TITLE
rockchip64-6.18: overlays: rewrite README.md

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/README.rockchip-overlays
@@ -8,92 +8,180 @@ rockchip (Rockchip)
 
 ### Provided overlays:
 
-- can0, can1, can2, i2c7, i2c8, pcie-gen2, spi-spidev, uart4, w1-gpio
-- rk3399-helios64-cpu-stability (Helios64 only)
+**Common / multi-SoC:**
+- can0, can1, can2, pcie-gen2, spi-jedec-nor, spi-spidev, dwc3-0-host, w1-gpio
 
-for RK3308:
-- b@1,3ghz, bs, bs-1.3ghz, otg-host, uart1, uart2, uart3, s0-ext-antenna
+**RK3308:**
+- b@1.3ghz, bs, bs@1.3ghz, otg-host, pcm5102a, s0-ext-antenna, uart1, uart2, uart3
+
+**RK3318-box:**
+- cpu-hs, emmc-ddr, emmc-hs200, led-conf1-7, wlan-ap6330, wlan-ap6334, wlan-ext
+
+**RK3328:**
+- i2c0, i2s1-pcm5102, opp-1.4ghz, opp-1.5ghz, spi-spidev, uart1, mksklipad50-enable-rtc-end1,
+  mksklipad50-enable-v4l2, mkspi-disable-lcd-spi, dusun-010r-rp3328b
+
+**RK3399:**
+- helios64-cpu-stability, i2c7, i2c8, opp-2ghz, pcie-gen2, rockpi4cplus-usb-host,
+  rockpro64-lcd, spi-jedec-nor, spi-spidev, uart4, w1-gpio
+
+**RK3566:**
+- i2c2-m1, i2c3-m0, i2c4-m0, pwm7, pwm11-m1, pwm15-m1, sata2, spi3-m0-cs0-spidev,
+  uart3-m0, uart7-m2, uart9-m2, radxa-zero-3w-ext-ant
+
+**RK3568:**
+- hk-i2c0, hk-i2c1, hk-pwm1, hk-pwm2, hk-pwm9, hk-spi-spidev, hk-uart0, hk-uart0-rts_cts,
+  hk-uart1, nanopi-r5c-leds, nanopi-r5s-leds, rock-3a-disable-uart2
+
+**RK3588:**
+- can0-m0/m1, can1-m0/m1, can2-m0/m1, fanctrl, hdmirx, i2c8-m2, nanopc-t6-mmc-frequency,
+  nanopi-m6-spi-nor-flash, nanopi-m6-display-dsi1-yx35, odroidm2-display-vu8s,
+  odroidm2-weather-board-zero, rkvenc-overlay, rock-5-itx-pwm-fan, sata0, sata1, sata2,
+  pwm0-m0/m1/m2, pwm1-m0/m1/m2, pwm2-m1, pwm3-m0/m1/m2/m3, pwm5-m2, pwm6-m0/m2,
+  pwm7-m0/m3, pwm8-m0, pwm10-m0, pwm11-m0/m1, pwm12-m0, pwm13-m0/m2, pwm14-m0/m1/m2,
+  pwm15-m0/m1/m2/m3, uart1-m1, uart3-m1, uart4-m2, uart6-m1, uart7-m2, uart8-m1,
+  hinlink-h88k-240x135-lcd
 
 ### Overlay details:
 
-### mksklipad-enable-rtc-end1
+### w1-gpio
 
-Enables end1 ethernet adapter, which also makes rtc work better.
-There is no physical port for end1, so this overlay is merely for
-testing the rtc.
-The rtc still tends to stall sometimes. In the original makerbase
-image, the rtc was completely unusable though.
+Activates 1-Wire GPIO master
+Requires an external pull-up resistor on the data pin
+or enabling the internal pull-up
 
-### mksklipad-enable-v4l2
+Default pin: GPIO1_A4
 
-Enables the video4linux devices /dev/video[012] /dev/media[01]
-Not sure, if they are of any use.
+Parameters:
 
-### mkspi-disable-lcd-spi
+param_w1_pin (string)
+	GPIO pin in format GPIO<bank>_<port><pin> (e.g., GPIO1_A4)
+	Optional
+	Default: GPIO1_A4
 
-DTBO to disable spi_for_{lcd,touch} when enabling uart1
+### spi-spidev
 
-### i2c7
+Activates SPIdev device node (/dev/spidevX.Y) for userspace SPI access,
+where X is the bus number and Y is the CS number
 
-Activates TWI/I2C bus 7
+RK3399 SPI pins (MOSI, MISO, SCK, CS):
+ SPI 0: GPIO3_A5, GPIO3_A4, GPIO3_A6, GPIO3_A7
+ SPI 1: GPIO1_B0, GPIO1_A7, GPIO1_B1, GPIO1_B2
+ SPI 2: GPIO2_B2, GPIO2_B1, GPIO2_B3, GPIO2_B4
+ SPI 3: GPIO1_C0, GPIO1_B7, GPIO1_C1, GPIO1_C2
 
-I2C7 pins (SCL, SDA): GPIO2-B0, GPIO2-A7 GPIO1-C5, GPIO1-C4
+Parameters:
 
-### i2c8
+param_spidev_spi_bus (int)
+	SPI bus to activate SPIdev support on
+	Required
+	Supported values: 0, 1, 2, 3
 
-Activates TWI/I2C bus 8
+param_spidev_spi_cs (int)
+	SPI chip select number
+	Optional
+	Default: 0
+	Supported values: 0, 1
 
-I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
+param_spidev_max_freq (int)
+	Maximum SPIdev frequency
+	Optional
+	Default: 1000000
+	Range: 3000 - 100000000
 
-### can0
+### spi-jedec-nor
 
-Activates CAN0.
+Activates MTD support for JEDEC compatible SPI NOR flash chips on SPI bus
+supported by the kernel SPI NOR driver
 
-rockchip-rk3588-can0-m0: mux mode 0, pins (RX, TX): GPIO0_C0, GPIO0_B7
+RK3399 SPI pins (MOSI, MISO, SCK, CS):
+ SPI 0: GPIO3_A5, GPIO3_A4, GPIO3_A6, GPIO3_A7
+ SPI 1: GPIO1_B0, GPIO1_A7, GPIO1_B1, GPIO1_B2
+ SPI 2: GPIO2_B2, GPIO2_B1, GPIO2_B3, GPIO2_B4
+ SPI 3: GPIO1_C0, GPIO1_B7, GPIO1_C1, GPIO1_C2
 
-rockchip-rk3588-can0-m1: mux mode 1, pins (RX, TX): GPIO4_D5, GPIO4_D4
+Parameters:
 
-### can1
+param_spinor_spi_bus (int)
+	SPI bus to activate SPI NOR flash support on
+	Required
+	Supported values: 0, 1, 2, 3
 
-Activates CAN1.
+param_spinor_max_freq (int)
+	Maximum SPI frequency
+	Optional
+	Default: 1000000
+	Range: 3000 - 100000000
 
-rockchip-rk3588-can1-m0: mux mode 0, pins (RX, TX): GPIO3_B5, GPIO3_B6
-
-rockchip-rk3588-can1-m1: mux mode 1, pins (RX, TX): GPIO4_B2, GPIO4_B3
-
-### can2
-
-Activates CAN2.
-
-rockchip-rk3588-can2-m0: mux mode 0, pins (RX, TX): GPIO3_C4, GPIO3_C5
-
-rockchip-rk3588-can2-m1: mux mode 1, pins (RX, TX): GPIO0_D4, GPIO0_D5
+param_spinor_spi_cs (int)
+	SPI chip select number
+	Optional
+	Default: 0
+	Supported values: 0, 1
 
 ### pcie-gen2
 
 Enables PCIe Gen2 link speed on RK3399.
 WARNING! Not officially supported by Rockchip!!!
 
+### dwc3-0-host
+
+Forces port 0 of the DesignWare xHCI controller to host mode.
+
+This can be used on platforms such as NanoPC-T4, where devices plugged into the
+USB-C port may not be detected otherwise.
+
+### uart4
+
+Activates UART4 on RK3399
+
+UART4 pins (RX, TX): GPIO1_B0, GPIO1_A7
+
+Notice: UART4 cannot be activated together with SPI1 - they share the same pins.
+Enabling this overlay disables SPI1.
+
+### i2c7
+
+Activates TWI/I2C bus 7 on RK3399
+
+I2C7 pins (SCL, SDA): GPIO2_B0, GPIO2_A7
+
+### i2c8
+
+Activates TWI/I2C bus 8 on RK3399
+
+I2C8 pins (SCL, SDA): GPIO1_C5, GPIO1_C4
+
 ### rk3328-i2c0
 
-Activates TWI/I2C bus 0
+Activates TWI/I2C bus 0 on RK3328
 
-I2C0 (SCL, SDA): GPIO2-D0, GPIO2-D1
+I2C0 pins (SCL, SDA): GPIO2_D0, GPIO2_D1
 
 ### rk3328-uart1
 
-Activates UART1
+Activates UART1 on RK3328
 
 UART1 pins (RX, TX): GPIO3_A6, GPIO3_A4
 
+### rk3328-spi-spidev
+
+Activates SPIdev on SPI0 for RK3328
+SPI base address: ff190000, max frequency 10MHz
+
+### rk3328-i2s1-pcm5102
+
+Activates PCM5102A DAC on I2S1 for RK3328 (tested on Rock Pi E)
+Disables the internal codec.
+
 ### rk3328-opp-1.4ghz
 
-Adds the 1.4GHz opp for overclocking
+Adds the 1.4GHz OPP for RK3328 overclocking
 WARNING! Not officially supported by Rockchip!!!
 
 ### rk3328-opp-1.5ghz
 
-Adds the 1.5GHz opp for overclocking
+Adds the 1.5GHz OPP for RK3328 overclocking
 WARNING! Not officially supported by Rockchip!!!
 
 ### rk3399-helios64-cpu-stability
@@ -111,225 +199,313 @@ you observe random crashes or hangs on a Helios64.
 
 ### rk3399-opp-2ghz
 
-Adds the 2GHz big and 1.5 GHz LITTLE opps for overclocking
+Adds the 2GHz big and 1.5 GHz LITTLE OPPs for RK3399 overclocking
 WARNING! Not officially supported by Rockchip!!!
 
 ### rockpi4cplus-usb-host
 
-Switches the top USB 3.0 port to host mode.
+Switches the top USB 3.0 port to host mode on ROCK Pi 4 C+.
 WARNING! Not officially supported by Rockchip!!!
 
-### spi-jedec-nor
+### rockpro64-lcd
 
-Activates MTD support for JEDEC compatible SPI NOR flash chips on SPI bus
-supported by the kernel SPI NOR driver
+Enables 7" LCD + touchscreen on RockPro64 (RK3399).
+Enables backlight, touch controller, MIPI DSI, VOPL and VOPB with MMUs.
 
-SPI 0 pins (MOSI, MISO, SCK, CS): GPIO3_A5, GPIO3_A4, GPIO3_A6, GPIO3_A7
-SPI 1 pins (MOSI, MISO, SCK, CS): GPIO1_A7, GPIO1_B0, GPIO1_B1, GPIO1_B2
-SPI 2 pins (MOSI, MISO, SCK, CS): GPIO1_C0, GPIO1_B7, GPIO1_C1, GPIO1_C2
-SPI 3 pins (MOSI, MISO, SCK, CS): GPIO2_B2, GPIO2_B1, GPIO2_B3, GPIO2_B4
+### rockchip-rk3399-w1-gpio
 
-Parameters:
-
-param_spinor_spi_bus (int)
-	SPI bus to activate SPI NOR flash support on
-	Required
-	Supported values: 0, 1, 2
-
-param_spinor_max_freq (int)
-	Maximum SPI frequency
-	Optional
-	Default: 1000000
-	Range: 3000 - 100000000
-
-### spi-spidev
-
-Activates SPIdev device node (/dev/spidevX.Y) for userspace SPI access,
-where X is the bus number and Y is the CS number
-
-SPI 0 pins (MOSI, MISO, SCK, CS): GPIO3_A5, GPIO3_A4, GPIO3_A6, GPIO3_A7
-SPI 1 pins (MOSI, MISO, SCK, CS): GPIO1_A7, GPIO1_B0, GPIO1_B1, GPIO1_B2
-SPI 2 pins (MOSI, MISO, SCK, CS): GPIO1_C0, GPIO1_B7, GPIO1_C1, GPIO1_C2
-SPI 3 pins (MOSI, MISO, SCK, CS): GPIO2_B2, GPIO2_B1, GPIO2_B3, GPIO2_B4
+Activates 1-Wire GPIO master on RK3399
+Default pin: GPIO1_A4
 
 Parameters:
 
-param_spidev_spi_bus (int)
-	SPI bus to activate SPIdev support on
-	Required
-	Supported values: 0, 1
-
-param_spidev_spi_cs (int)
-	SPI chip select number
+param_w1_pin (string)
+	GPIO pin in format GPIO<bank>_<port><pin>
 	Optional
-	Default: 0
-	Supported values: 0, 1
-	Using chip select 1 requires using "spi-add-cs1" overlay
+	Default: GPIO1_A4
 
-param_spidev_max_freq (int)
-	Maximum SPIdev frequency
-	Optional
-	Default: 1000000
-	Range: 3000 - 100000000
+### can0 / can1 / can2
 
-### uart4
+Activates CAN0/1/2 on RK3588 with selectable mux modes.
 
-Activates UART4
+**can0-m0:** mux mode 0, pins (RX, TX): GPIO0_C0, GPIO0_B7
+**can0-m1:** mux mode 1, pins (RX, TX): GPIO4_D5, GPIO4_D4
 
-UART4 pins (RX, TX): GPIO1_A7, GPIO1_B0
+**can1-m0:** mux mode 0, pins (RX, TX): GPIO3_B5, GPIO3_B6
+**can1-m1:** mux mode 1, pins (RX, TX): GPIO4_B2, GPIO4_B3
 
-Notice: UART4 cannot be activated together with SPI1 - they share the sam pins.
-Enabling this overlay disables SPI1.
+**can2-m0:** mux mode 0, pins (RX, TX): GPIO3_C4, GPIO3_C5
+**can2-m1:** mux mode 1, pins (RX, TX): GPIO0_D4, GPIO0_D5
 
-### dwc3-0-host
+### rockchip-rk3588-fanctrl
 
-Forces port 0 of the DesignWare xHCI controller to host mode.
+Sets fan cooling levels for the RK3588 fan controller.
 
-This can be used on plaforms such as NanoPC-T4, where devices plugged into the
-USB-C port may not be detected otherwise.
+### rockchip-rk3588-rock-5-itx-pwm-fan
 
-### w1-gpio
+Configures PWM fan for ROCK 5 ITX: sets cooling-levels and temperature trips
+for the /pwm-fan device.
 
-Activates 1-Wire GPIO master
-Requires an external pull-up resistor on the data pin
-or enabling the internal pull-up
+### rockchip-rk3588-sata0 / sata1 / sata2
 
-### rk3318-box-led-conf1
+Enables SATA0/1/2 on RK3588 by disabling the corresponding PCIe controller
+and enabling the SATA controller.
+- sata0: disables pcie2x1l2, enables sata0
+- sata1: disables pcie2x1l0, enables sata1
+- sata2: disables pcie2x1l1, enables sata2
 
-Generic default led/gpio configuration for rk3318 tv box boards.
-Does not enable any specific or peculiar hardware.
+### rockchip-rk3588-hdmirx
 
-### rk3318-box-led-conf2
+Enables HDMI input receiver on RK3588.
+Activates hdmi_receiver_cma and hdmi_receiver nodes for HDMI-in capture.
 
-Activates led/gpio configuration for rk3318 tv box boards withs signature
-X88_PRO_B and clones
+### rockchip-rk3588-i2c8-m2
 
-### rk3318-box-led-conf3
+Activates I2C8 on RK3588 mux mode 2 (i2c8m2_xfer pins).
 
-This device tree overlay is suitable for MXQ-RK3328-D4_A board which
-has an integrated PMIC (RK805). The dtbo is very important to achieve
-1.3 Ghz speed for CPU and stable voltages for other parts of the
-system. Also enables gpio leds and keys.
+### rockchip-rk3588-rkvenc-overlay
 
-### rk3318-box-led-conf4
-
-Generic rk3318-box configuration but with sdio chip on sdmmc-ext connector
-
-### rk3318-box-led-conf5
-
-Configuration for rk3318 boards with with signature YX_RK3328 and clones.
-
-### rk3318-box-led-conf6
-
-Configuration for rk3318 boards with with signature T98_RK3318 and clones.
-Seen in commercial tv boxes like Hongtop H50.
-
-### rk3318-box-led-conf7
-
-Configuration for rk3318 boards with with signature T9_RK3318 and clones.
-Seen in commercial tv boxes like T9 Sunwell 3318.
-
-### rk3318-box-emmc-ddr
-
-Activates eMMC DDR capability for rk3318 tv box boards. Probably all the eMMC chips
-nowadays support DDR mode, but its reliability heavily depends upon the quality
-of board wiring
-
-### rk3318-box-emmc-hs200
-
-Activates eMMC HS200 capability for rk3318 tv box boards.
-It should in autodetect mode, but some board have faulty or cheap circuitry that
-enable the mode but then it doesn't work correctly.
-
-### rk3318-box-wlan-ap6334
-
-Set up additional device tree bits to properly support ap6334 (broadcom BCM4334)
-wifi chip and clones
-
-### rk3318-box-wlan-ext
-
-Use sdmmc_ext device for sdio devices, enabled wifi on some boards (notably
-X88 Pro) which have wifi chip attached to sdmmc_ext controller.
-
-### rk3318-box-wlan-ap6330
-
-Set up additional device tree bits properly support ap6330 (broaccom BCM4330)
-wifi + bt chip and clones.
-
-### rk3318-box-cpu-hs
-
-Enable additional cpu "high-speed" bins up to 1.3ghz
-
-
-**********************************
-RK3308 OTG USB mode  (14 Sep 2025):
-
-Most Armbian RK3308 kernels configured the OTG port to operate in peripheral mode by default
-To configure the OTG USB port as an additional host port:
-###  rk3308-otg-host
-
-
-**********************************
-RK3308 enable uart  (31 Oct 2025):
-
-###  rk3308-uart1
-###  rk3308-uart2
-###  rk3308-uart3
-
-
-**********************************
-Details for Rock Pi-S overlays  (14 Sep 2025):
-
-Older V1.1 and V1.2 boards use the B variant of the RK3308.
-Some V1.3 boards manufactured after October 2023 also use the B variant.
-To overclock the RK3308B, apply:
-###  rk3308-b@1.3ghz
-
-V1.3 boards produced during 2022 and most of 2023 use the lower voltage
-B-S variant of the RK3308.
-Per Radxa, these chips will be marked RK3308BS instead of RK3308B
-All boards utilizing the RK3308B-S part should apply the:
-###  rk3308-bs
-overlay to operate at the appropriate (lower) the core voltage.
-This overlay also enables operation at 1.1Ghz.
-
-Optionally, boards utilizing the RK3308B-S parts may add the
-###  rk3308-bs@1.3ghz
-to overclock the B-S CPU to 1.3Ghz.
-Apply the rk3308-bs@1.3Ghz overlay  *after applying*  rk3308-bs
-
-Applying the *-bs overlays to the B variant of the SOC may result in
-unstable operation due to undervolting.
-Applying the rk3308-b@1.3ghz to a BS variant chip consumes more power and
-has the potential to damage the SOC due to overvolting.
-
-
-**********************************
-Details for Rock S0 overlays  (10 Apr 2024):
-
-By default, the internal WiFi selects its internal chip antenna.
-This antenna is so noisy as to be nearly unusable.
-The external antenna, fortunately, works quite well.
-Connect an external WiFi antenna and select it with:
-###  rk3308-s0-ext-antenna
-
-All Rock S0 boards use the RK3308B chip.
-The:
-###  rk3308-b@1.3ghz
-overlay enables (overclocked) operation at 1.3ghz
-1.3Ghz operation appears stable on the two boards I've tested.
-
-The legacy kernel is not supported on the Rock S0
-
-Enable pcm5102a analog codec connected to i2s0 bus:
-### rk3308-pcm5102a
-
-**********************************
-Details for NanoPC-T6 overlays  (11 Oct 2025):
+Adds RKVE (Rockchip Video Encoder) nodes to RK3588 for boards lacking VENC.
+Includes rkvenc CCU, rkvenc0/1 cores with MMUs, and mpp-service.
 
 ### rockchip-rk3588-nanopc-t6-mmc-frequency
 
-Some NanoPC-T6 boards use a A3A444 eMMC chip. Under heavy I/O load when running
+Some NanoPC-T6 boards use an A3A444 eMMC chip. Under heavy I/O load when running
 in HS400 mode, this will often result in I/O errors.
 Reducing the eMMC frequency from the default 200000000 Hz to 150000000 Hz improves
 stability and eliminates the I/O errors.
+
+### rockchip-rk3588-nanopi-m6-spi-nor-flash
+
+Enables SPI NOR flash on NanoPi M6 (RK3588).
+Disables sdhci (eMMC slot), enables SFC (fspim0) with jedec spi-nor at 50MHz
+with 4-bit RX.
+
+### rockchip-rk3588-nanopi-m6-display-dsi1-yx35
+
+Enables Yixian YX0345WV00V2 DSI1 panel on NanoPi M6 (RK3588).
+- Panel: yixian,yx0345wv00v2 on DSI1
+- Backlight: pwm11 mux mode 3
+- Touch: GT911 on I2C5 mux mode 2
+- Enables mipidcphy1
+
+### rockchip-rk3588-odroidm2-display-vu8s
+
+Enables ODROID-VU8S DSI0 display on ODROID M2 (RK3588).
+- Panel: odroid,vu8s on DSI0
+- Backlight: pwm14
+- Touch controller enabled
+- Enables mipidcphy0
+- Board compatibility: hardkernel,odroid-m2
+
+### rockchip-rk3588-odroidm2-weather-board-zero
+
+Enables ODROID Weather Board Zero on ODROID M2 (RK3588).
+- I2C5 mux mode 2
+- SHTC1 temperature/humidity sensor @ I2C address 0x70
+
+### hinlink-h88k-240x135-lcd
+
+Enables 240x135 SPI LCD on Hinlink H88K (RK3588).
+- SPI4 with custom M2 pin configuration
+- Panel: hinlink-h88k-240x135-lcd (MIPI DBI SPI)
+- Frequency: 2MHz
+
+### PWM overlays (RK3588)
+
+All PWM overlays enable a PWM controller with a specific mux mode.
+Format: pwmN-mM where N is PWM number (0-15) and M is mux mode (0-3).
+Each overlay sets status = "okay" and pinctrl-0 = <&pwmNmM_pins>.
+
+Available PWM overlays:
+- pwm0-m0, pwm0-m1, pwm0-m2
+- pwm1-m0, pwm1-m1, pwm1-m2
+- pwm2-m1
+- pwm3-m0, pwm3-m1, pwm3-m2, pwm3-m3
+- pwm5-m2
+- pwm6-m0, pwm6-m2
+- pwm7-m0, pwm7-m3
+- pwm8-m0
+- pwm10-m0
+- pwm11-m0, pwm11-m1
+- pwm12-m0
+- pwm13-m0, pwm13-m2
+- pwm14-m0, pwm14-m1, pwm14-m2
+- pwm15-m0, pwm15-m1, pwm15-m2, pwm15-m3
+
+### UART overlays (RK3588)
+
+Enable UART controllers with specific mux modes.
+Format: uartN-mM where N is UART number and M is mux mode.
+
+Available:
+- uart1-m1: UART1 mux mode 1
+- uart3-m1: UART3 mux mode 1
+- uart4-m2: UART4 mux mode 2
+- uart6-m1: UART6 mux mode 1
+- uart7-m2: UART7 mux mode 2
+- uart8-m1: UART8 mux mode 1
+
+### RK3566 overlays
+
+**rockchip-rk3566-sata2:** Enables SATA2 controller on RK3566.
+
+**rockchip-rk3566-i2c2-m1 / i2c3-m0 / i2c4-m0:**
+Enables I2C2/3/4 with specified mux mode (i2cNmM_xfer pins).
+
+**rockchip-rk3566-pwm7:**
+Enables PWM7 (no mux change, status only).
+
+**rockchip-rk3566-pwm11-m1 / pwm15-m1:**
+Enables PWM11/15 with mux mode 1 (pwmNmM_pins).
+
+**rockchip-rk3566-spi3-m0-cs0-spidev:**
+Enables SPI3 mux mode 0 with spidev@0 at 50MHz.
+
+**rockchip-rk3566-uart3-m0 / uart7-m2 / uart9-m2:**
+Enables UART3/7/9 with specified mux mode (uartNmM_xfer pins).
+
+**rockchip-rk3566-radxa-zero-3w-ext-ant:**
+Radxa Zero 3W (RK3566) external antenna selection.
+- GPIO control: GPIO3_PD2
+- Disables board_antenna, enables external antenna
+
+### RK3568 overlays (HK prefix = Hardkernel boards)
+
+**rockchip-rk3568-hk-i2c0:**
+Enables i2c3, aliased as i2c0 (for HK board variant).
+
+**rockchip-rk3568-hk-i2c1:**
+Enables i2c1.
+
+**rockchip-rk3568-hk-pwm1 / pwm2 / pwm9:**
+Enables PWM1/2/9 at specific addresses (fdd70010, fdd70020, fe6f0010).
+
+**rockchip-rk3568-hk-spi-spidev:**
+Enables SPI0 with spidev@0 at 100MHz.
+
+**rockchip-rk3568-hk-uart0:**
+Enables uart1, aliased as serial0 (main debug UART).
+
+**rockchip-rk3568-hk-uart0-rts_cts:**
+Enables uart1 with RTS/CTS hardware flow control pins.
+
+**rockchip-rk3568-hk-uart1:**
+Enables uart0, aliased as serial1, with DMA enabled.
+
+**rockchip-rk3568-nanopi-r5c-leds / nanopi-r5s-leds:**
+Sets LED default triggers for NanoPi R5C/R5S.
+- R5C: triggers set to r8169 (Ethernet)
+- R5S: triggers set to stmmac (Ethernet)
+
+**rockchip-rk3568-rock-3a-disable-uart2:**
+Disables UART2 (debug UART) on ROCK 3A.
+
+### RK3308 overlays
+
+**rk3308-b@1.3ghz:**
+Overclocks RK3308 B variant to 1.3GHz (requires 1.25/1.30V).
+For Rock Pi S V1.1/V1.2 and some V1.3 boards using RK3308B.
+
+**rk3308-bs:**
+Applies correct OPP table for RK3308B-S variant (lower voltage, 1.1GHz max).
+Required for B-S variant; applying to B variant causes undervoltage instability.
+
+**rk3308-bs@1.3ghz:**
+Overclocks RK3308B-S to 1.3GHz @ 1.2V.
+Apply AFTER rk3308-bs. Do NOT apply to B variant (risk of overvoltage damage).
+
+**rk3308-otg-host:**
+Switches OTG USB port to host mode (peripheral mode is default on most kernels).
+
+**rk3308-pcm5102a:**
+Enables PCM5102A DAC on I2S_8CH_0 for Rock Pi S.
+Simple audio card on i2s_8ch_0 bus.
+
+**rk3308-s0-ext-antenna:**
+Rock S0: selects external WiFi antenna.
+Disables internal board_antenna, uses GPIO0_PA6.
+Recommended due to poor performance of internal antenna.
+
+**rk3308-uart1 / uart2 / uart3:**
+Enables UART1/2/3 on RK3308.
+
+**rockchip-sakurapi-rk3308b-ws2812:**
+Enables WS2812 LED support on SakuraPi RK3308B via SPI1.
+Requires external WS2812 driver from GitHub.
+
+### RK3318-box overlays
+
+**rk3318-box-led-conf1:**
+Generic default LED/GPIO configuration for RK3318 TV box boards.
+LED on GPIO2_PC7, enables mmc2. No specific hardware enabled.
+
+**rk3318-box-led-conf2:**
+LED configuration for X88_PRO_B signature and clones.
+FD628 7-segment display via SPI-GPIO, WiFi on SDIO extension.
+
+**rk3318-box-led-conf3:**
+Configuration for MXQ-RK3328-D4_A boards.
+Enables integrated RK805 PMIC with regulators, power key, GPIO LEDs, and keys.
+Important: enables 1.3GHz CPU speed and stable voltages.
+
+**rk3318-box-led-conf4:**
+Generic configuration with SDIO on sdmmc_ext connector.
+
+**rk3318-box-led-conf5:**
+Configuration for YX_RK3318 signature and clones.
+FD6551 7-segment display via I2C-GPIO.
+
+**rk3318-box-led-conf6:**
+Configuration for T98_RK3318 / Hongtop H50 signature and clones.
+FD650 7-segment display.
+
+**rk3318-box-led-conf7:**
+Configuration for T9_RK3318 / Sunwell signature and clones.
+FD655 7-segment display.
+
+**rk3318-box-emmc-ddr:**
+Activates eMMC DDR mode. All modern eMMC chips support it, but reliability
+depends heavily on board wiring quality.
+
+**rk3318-box-emmc-hs200:**
+Activates eMMC HS200 mode. Should autodetect, but some boards have faulty
+circuitry that enables the mode incorrectly.
+
+**rk3318-box-wlan-ap6330:**
+Support for ap6330 (Broadcom BCM4330) WiFi + BT chip and clones.
+
+**rk3318-box-wlan-ap6334:**
+Support for ap6334 (Broadcom BCM4334) WiFi + BT chip and clones.
+Includes BCM4334B0-BT and enables UHS modes.
+
+**rk3318-box-wlan-ext:**
+Moves WiFi to sdmmc_ext controller. Enables WiFi on boards (notably X88 Pro)
+with WiFi chip on SDIO extension bus.
+
+**rk3318-box-cpu-hs:**
+Enables high-speed CPU OPP bins up to 1.3GHz (1200MHz, 1296MHz).
+
+### Other board overlays
+
+**rockchip-dusun-010r-rp3328b:**
+Dusun DSOM-010R SoM (RK3328) on RP3328-B carrier board.
+- LED: GPIO2_PC5
+- GPIO fan: GPIO2_PC4
+- Audio amp: GPIO0_PA2
+- WiFi/BT: AP6212
+- RTC: hym8563 @ I2C1
+- USB hub: GL850G
+
+**mksklipad-enable-rtc-end1:**
+Enables END1 ethernet adapter on MKSKlipad 3D printer board.
+This also improves RTC stability (though it may still stall occasionally).
+No physical port for END1; mainly for RTC testing.
+
+**mksklipad-enable-v4l2:**
+Enables video4linux devices /dev/video[012] and /dev/media[01] on MKSKlipad.
+Usefulness uncertain.
+
+**mkspi-disable-lcd-spi:**
+Disables SPI for LCD and touch when enabling UART1 on MKSKlipad.
+Required to prevent pin conflicts.

--- a/patch/kernel/archive/rockchip64-6.18/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.18/overlay/README.rockchip-overlays
@@ -8,11 +8,8 @@ rockchip (Rockchip)
 
 ### Provided overlays:
 
-**Common / multi-SoC:**
-- can0, can1, can2, pcie-gen2, spi-jedec-nor, spi-spidev, dwc3-0-host, w1-gpio
-
 **RK3308:**
-- b@1.3ghz, bs, bs@1.3ghz, otg-host, pcm5102a, s0-ext-antenna, uart1, uart2, uart3
+- b@1.3ghz, bs, bs@1.3ghz, otg-host, pcm5102a, s0-ext-antenna, sakurapi-rk3308b-ws2812, uart1, uart2, uart3
 
 **RK3318-box:**
 - cpu-hs, emmc-ddr, emmc-hs200, led-conf1-7, wlan-ap6330, wlan-ap6334, wlan-ext
@@ -22,8 +19,8 @@ rockchip (Rockchip)
   mksklipad50-enable-v4l2, mkspi-disable-lcd-spi, dusun-010r-rp3328b
 
 **RK3399:**
-- helios64-cpu-stability, i2c7, i2c8, opp-2ghz, pcie-gen2, rockpi4cplus-usb-host,
-  rockpro64-lcd, spi-jedec-nor, spi-spidev, uart4, w1-gpio
+- dwc3-0-host, helios64-cpu-stability, i2c7, i2c8, opp-2ghz, pcie-gen2,
+  rockpi4cplus-usb-host, rockpro64-lcd, spi-jedec-nor, spi-spidev, uart4, w1-gpio
 
 **RK3566:**
 - i2c2-m1, i2c3-m0, i2c4-m0, pwm7, pwm11-m1, pwm15-m1, sata2, spi3-m0-cs0-spidev,
@@ -367,7 +364,7 @@ Enables UART3/7/9 with specified mux mode (uartNmM_xfer pins).
 
 **rockchip-rk3566-radxa-zero-3w-ext-ant:**
 Radxa Zero 3W (RK3566) external antenna selection.
-- GPIO control: GPIO3_PD2
+- GPIO control: GPIO3_D2
 - Disables board_antenna, enables external antenna
 
 ### RK3568 overlays (HK prefix = Hardkernel boards)
@@ -424,7 +421,7 @@ Simple audio card on i2s_8ch_0 bus.
 
 **rk3308-s0-ext-antenna:**
 Rock S0: selects external WiFi antenna.
-Disables internal board_antenna, uses GPIO0_PA6.
+Disables internal board_antenna, uses GPIO0_A6.
 Recommended due to poor performance of internal antenna.
 
 **rk3308-uart1 / uart2 / uart3:**
@@ -438,7 +435,7 @@ Requires external WS2812 driver from GitHub.
 
 **rk3318-box-led-conf1:**
 Generic default LED/GPIO configuration for RK3318 TV box boards.
-LED on GPIO2_PC7, enables mmc2. No specific hardware enabled.
+LED on GPIO2_C7, enables mmc2. No specific hardware enabled.
 
 **rk3318-box-led-conf2:**
 LED configuration for X88_PRO_B signature and clones.
@@ -490,19 +487,19 @@ Enables high-speed CPU OPP bins up to 1.3GHz (1200MHz, 1296MHz).
 
 **rockchip-dusun-010r-rp3328b:**
 Dusun DSOM-010R SoM (RK3328) on RP3328-B carrier board.
-- LED: GPIO2_PC5
-- GPIO fan: GPIO2_PC4
-- Audio amp: GPIO0_PA2
+- LED: GPIO2_C5
+- GPIO fan: GPIO2_C4
+- Audio amp: GPIO0_A2
 - WiFi/BT: AP6212
 - RTC: hym8563 @ I2C1
 - USB hub: GL850G
 
-**mksklipad-enable-rtc-end1:**
+**mksklipad50-enable-rtc-end1:**
 Enables END1 ethernet adapter on MKSKlipad 3D printer board.
 This also improves RTC stability (though it may still stall occasionally).
 No physical port for END1; mainly for RTC testing.
 
-**mksklipad-enable-v4l2:**
+**mksklipad50-enable-v4l2:**
 Enables video4linux devices /dev/video[012] and /dev/media[01] on MKSKlipad.
 Usefulness uncertain.
 


### PR DESCRIPTION
Let AI analyze all available overlays
rewrite README to reflect reality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized Rockchip overlay documentation into a consistent, platform/board-grouped layout for easier browsing.
  * Expanded and standardized the catalog of available RK33xx/RK39xx/RK3588/RK356x/RK330x overlays, including shared and board-specific options.
  * Updated overlay sections with consistent headings, standardized pin naming, and clearer `param_*` descriptions (including defaults and valid ranges where applicable).
  * Added or expanded documentation for features such as PWM, UART muxing, CAN variants, display, storage, fan control, and connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->