### PR TITLE
LowMem extension: Fix swapfile creation on btrfs; Fix permission race

### DIFF
--- a/packages/bsp/armbian-lowmem/lowmem-mkswap.sh
+++ b/packages/bsp/armbian-lowmem/lowmem-mkswap.sh
@@ -26,7 +26,15 @@ fi
 # Prevent permission race
 umask 077
 
-# Create swapfile, set permissions, and enable it
+# Create empty swapfile
+truncate -s0 "${SWAPFILE_PATH}"
+
+# Set the "disable copy-on-write" attribute, since the kernel doesn't support
+# copy-on-write swapfiles.  Ignore error, which probably indicates that the
+# fileystem doesn't support CoW (e.g. on ext4).
+chattr -f +C "${SWAPFILE_PATH}" || true
+
+# Allocate swap space, ensure correct permissions, and enable it
 fallocate -l "${SWAPFILE_SIZE_MB}M" "${SWAPFILE_PATH}"
 chmod 600 "${SWAPFILE_PATH}"
 mkswap "${SWAPFILE_PATH}"

--- a/packages/bsp/armbian-lowmem/lowmem-mkswap.sh
+++ b/packages/bsp/armbian-lowmem/lowmem-mkswap.sh
@@ -23,6 +23,9 @@ if (( FREE_MB < NEEDED_MB )); then
     exit 1
 fi
 
+# Prevent permission race
+umask 077
+
 # Create swapfile, set permissions, and enable it
 fallocate -l "${SWAPFILE_SIZE_MB}M" "${SWAPFILE_PATH}"
 chmod 600 "${SWAPFILE_PATH}"


### PR DESCRIPTION
# Description

This PR includes a fix for the creation of the `/swapfile` when building with `ENABLE_EXTENSIONS=lowmem` and a btrfs root filesystem.  Specifically, it ensures that the swapfile is created with the No_COW attribute (`chattr +C`).  Otherwise, swapon fails. 

This PR also includes a one-line fix (as a separate commit) to set the umask so that there is no moment where `/swapfile` is world-readable.

# How Has This Been Tested?

- [X] `BOARD=qemu-uefi-x86` without this patch
- [X] `BOARD=qemu-uefi-x86` with this patch
- [X] `BOARD=nanopi-r3s-lts` without this patch
- [X] `BOARD=nanopi-r3s-lts` with this patch

Common build options: `./compile.sh RELEASE=trixie BRANCH=edge BUILD_MINIMAL=yes KERNEL_CONFIGURE=no ROOTFS_TYPE=btrfs BTRFS_COMPRESSION=zstd ENABLE_EXTENSIONS=lowmem CLEAN_LEVEL=debs`

Notes:
* `CLEAN_LEVEL=debs` seems to be needed to prevent the build process from including an old, cached copy of the `lowmem-mkswap.sh` script.
* `BTRFS_COMPRESSION=zstd` or `BTRFS_COMPRESSION=none` seems to be needed on `nanopi-r3s-lts` because u-boot apparently can't properly read /boot/armbianEnv.txt from a zlib-compressed btrfs.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened swapfile setup by starting with restrictive permissions (`umask 077`).
  * Ensured the swapfile target is reset to empty before allocation.
  * Improved behavior on copy-on-write filesystems by attempting to disable CoW on the swapfile (without failing if unsupported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->