### PR TITLE
sunxi-6.12: fix bluetooth park-link quirk to use pre-6.16 API (test_bit)

### DIFF
--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/drv-bluetooth-hci-sprd-broken-park-link-quirk-v6.1-6.15.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/drv-bluetooth-hci-sprd-broken-park-link-quirk-v6.1-6.15.patch
@@ -55,7 +55,7 @@ index 9e5c26c41f6e..477e38434271 100644
  	if (lmp_sniff_capable(hdev))
  		link_policy |= HCI_LP_SNIFF;
 -	if (lmp_park_capable(hdev))
-+	if (lmp_park_capable(hdev) && !hci_test_quirk(hdev, HCI_QUIRK_BROKEN_PARK_LINK_STATUS))
++	if (lmp_park_capable(hdev) && !test_bit(HCI_QUIRK_BROKEN_PARK_LINK_STATUS, &hdev->quirks))
  		link_policy |= HCI_LP_PARK;
 
  	cp.policy = cpu_to_le16(link_policy);


### PR DESCRIPTION
Every sunxi/sunxi64 **legacy (6.12)** kernel artifact is failing to build, e.g. [ci run 30284100606](https://github.com/armbian/ci/actions/runs/30284100606/job/90059819455):

```
net/bluetooth/hci_sync.c:4243: error: implicit declaration of function
  hci_test_quirk; did you mean hci_get_irk?
make: net/bluetooth/hci_sync.o Error 1  →  kernel.sh:260 Error 2
```

## Cause

`drv-bluetooth-hci-sprd-broken-park-link-quirk-v6.1-6.15.patch` (sunxi-6.12) **sets** the quirk with `set_bit(…, &hdev->quirks)` — the correct pre-6.16 form — but **tests** it with `hci_test_quirk()`, a helper that only exists from **6.16** onward. On 6.12.98 that call has no declaration and the build fails. Introduced in `9dee1d386`, whose message even notes the 6.12 API is older (it got the `set` side right, the `test` side wrong).

## Fix

Match the set side with the pre-6.16 bitops test:

```diff
-if (lmp_park_capable(hdev) && !hci_test_quirk(hdev, HCI_QUIRK_BROKEN_PARK_LINK_STATUS))
+if (lmp_park_capable(hdev) && !test_bit(HCI_QUIRK_BROKEN_PARK_LINK_STATUS, &hdev->quirks))
```

## Scope — audited all variants

| Patch | Kernel | Tests via | Status |
|---|---|---|---|
| sunxi-6.12 `…v6.1-6.15` | 6.12 | ~~`hci_test_quirk`~~ → `test_bit` | **fixed here** |
| rk35xx-vendor-6.1 `…v6.1-v6.15` | 6.1 | `test_bit` | already correct |
| sunxi-6.18 / sunxi-7.0 / rockchip64-6.18 / rockchip64-7.1 `…v6.16-plus` | ≥6.16 | `hci_test_quirk` | correct (helper exists) |

Only this one old-kernel patch was wrong. Diff header counts unchanged (1 `-` / 1 `+`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth compatibility for supported Spreadtrum controllers.
  * Prevented failed Park link initialization on devices that incorrectly report Park link support.
  * Enhanced Bluetooth connection reliability during link policy setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->