### PR TITLE
uwe5622: source the driver from armbian/uwe5622 (incl. the >=7.1 gpiod fix)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -509,11 +509,11 @@ driver_uwe5622() {
 	if linux-version compare "${version}" ge 5.15 && linux-version compare "${version}" lt 7.2 && [[ "$LINUXFAMILY" == sun* || "$LINUXFAMILY" == rockchip64 || "$LINUXFAMILY" == rk35xx ]]; then
 
 		# Attach to specific commit
-		local uwe5622ver='commit:7bfaaf46ea6834a964672b91b4bf7fd9f0a834e7' # Commit date: Jul 22, 2026 (please update when updating commit ref)
+		local uwe5622ver='commit:836e959704a87e0117b2e7b61a43f80216601e77' # Commit date: Jul 28, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Unisoc uwe5622 driver ${uwe5622ver}" "info"
 
-		fetch_from_repo "$GITHUB_SOURCE/EvilOlaf/uwe5622" "uwe5622" "${uwe5622ver}" "yes" # https://github.com/EvilOlaf/uwe5622
+		fetch_from_repo "$GITHUB_SOURCE/armbian/uwe5622" "uwe5622" "${uwe5622ver}" "yes" # https://github.com/armbian/uwe5622
 		cd "$kerneldir" || exit
 
 		rm -rf "$kerneldir/drivers/net/wireless/uwe5622"

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/drv-bluetooth-hci-sprd-broken-park-link-quirk-v6.1-6.15.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/drv-bluetooth-hci-sprd-broken-park-link-quirk-v6.1-6.15.patch
@@ -55,7 +55,7 @@ index 9e5c26c41f6e..477e38434271 100644
  	if (lmp_sniff_capable(hdev))
  		link_policy |= HCI_LP_SNIFF;
 -	if (lmp_park_capable(hdev))
-+	if (lmp_park_capable(hdev) && !hci_test_quirk(hdev, HCI_QUIRK_BROKEN_PARK_LINK_STATUS))
++	if (lmp_park_capable(hdev) && !test_bit(HCI_QUIRK_BROKEN_PARK_LINK_STATUS, &hdev->quirks))
  		link_policy |= HCI_LP_PARK;
 
  	cp.policy = cpu_to_le16(link_policy);


### PR DESCRIPTION
Switches the Unisoc **uwe5622** WiFi driver source in `drivers_network.sh` from `EvilOlaf/uwe5622` to the armbian-org fork **`armbian/uwe5622`**, and bumps the pinned commit to `836e959`.

## Why

That commit ([`armbian/uwe5622#1`](https://github.com/armbian/uwe5622/pull/1)) fixes the `sdio_pub_int_init()` call for the ≥7.1 gpiod `int_ap`. Without it, GCC 14s `-Wint-conversion` is a hard error and **every rockchip64 edge (7.1.x) kernel artifact fails to build** ([ci run 30325524045](https://github.com/armbian/ci/actions/runs/30325524045/job/90177692468)):

```
wcn_boot.c: error: passing argument 1 of sdio_pub_int_init makes integer
  from pointer without a cast [-Wint-conversion]
```

## Notes

- The pinned commit `836e959` is already present in `armbian/uwe5622` (it is `refs/pull/1/head`; once #1 merges it is also on `master`), so `fetch_from_repo` resolves it today.
- Only the source URL + commit ref change; the cached-source path uses `${uwe5622ver#*:}` and tracks the new commit automatically.
- Other EvilOlaf-hosted drivers (rtl8189es, rtl8192eu) are left untouched — out of scope.

Depends on `armbian/uwe5622#1` for the fix content (already reachable by SHA).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Unisoc `uwe5622` driver to a newer revision and switched to the maintained upstream source while keeping the same install safeguards/behavior.
  * Adjusted Spreadtrum Bluetooth HCI “broken Park link status” quirk handling to use a direct quirk check, improving link-policy behavior for affected devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->