### PR TITLE
repo-reprepro: skip debs missing on disk instead of aborting the whole repo

### DIFF
--- a/lib/tools/info/repo-reprepro.py
+++ b/lib/tools/info/repo-reprepro.py
@@ -117,10 +117,23 @@ for one_repo_target in repo_targets:
 	all_debs_to_include_quoted = ['"${INCOMING_DEBS_DIR}/' + x + '"' for x in all_debs_to_include]
 
 	if len(all_debs_to_include) > 0:
-		# add all debs to the repop
-		cmds = ["reprepro", "-b", '"${REPO_LOCATION}"', "--component", "main", "includedeb", one_repo_target] + all_debs_to_include_quoted
-		bash_lines.append(f"echo 'reprepro importing {len(all_debs_to_include_quoted)} debs for target {one_repo_target}...' ")
-		bash_lines.append(" ".join(cmds))
+		# Import only the debs that are actually present on disk. A partial build
+		# (some artifacts not yet published to OCI, so debs-to-repo-download could
+		# not fetch them) would otherwise make reprepro error out on the first
+		# missing file and, under the script's `set -e`, abort before the export --
+		# losing the whole repository. Collect the present ones at run time and skip
+		# (with a log line) the rest, mirroring how the raw-deb sync tolerates gaps.
+		bash_lines.append(f"echo 'reprepro: target {one_repo_target}: selecting present debs (of {len(all_debs_to_include_quoted)} expected)...'")
+		bash_lines.append("present_debs=()")
+		bash_lines.append("for one_deb in " + " ".join(all_debs_to_include_quoted) + "; do")
+		bash_lines.append('	if [ -f "${one_deb}" ]; then present_debs+=("${one_deb}"); else echo "  skipping missing deb: ${one_deb}"; fi')
+		bash_lines.append("done")
+		bash_lines.append('if [ "${#present_debs[@]}" -gt 0 ]; then')
+		bash_lines.append(f'	echo "reprepro importing ${{#present_debs[@]}} debs for target {one_repo_target}..."')
+		bash_lines.append(f'	reprepro -b "${{REPO_LOCATION}}" --component main includedeb {one_repo_target} "${{present_debs[@]}}"')
+		bash_lines.append("else")
+		bash_lines.append(f'	echo "reprepro: target {one_repo_target}: no debs present, skipping includedeb"')
+		bash_lines.append("fi")
 
 # Always export at the end
 export_cmds = ["reprepro", "-b", '"${REPO_LOCATION}"', "export"]


### PR DESCRIPTION
The `debs-to-repo-reprepro` generator emitted one `reprepro includedeb <target> <all expected debs>` per target. On a **partial build** — where some artifacts are not yet published to OCI, so `debs-to-repo-download` cannot fetch their `.deb`s — reprepro errors on the first missing file:

```
Error 2 opening .../base-files_..._armhf...deb: No such file or directory
There have been errors!
```

and the generated `reprepro.sh` (`set -e`) aborts **before `reprepro export`**, so `dists/` and `pool/` are never created and the whole repository is lost.

### Fix
Generate a run-time filter: collect the debs that actually exist into an array (logging each skipped one), `includedeb` only those, and skip the call entirely when none are present. `reprepro export` always runs at the end, so a repository is produced from whatever debs are available — mirroring how the raw-deb rsync path already tolerates gaps.

Generated snippet per target:
```bash
present_debs=()
for one_deb in "${INCOMING_DEBS_DIR}/..." ...; do
  if [ -f "${one_deb}" ]; then present_debs+=("${one_deb}"); else echo "  skipping missing deb: ${one_deb}"; fi
done
if [ "${#present_debs[@]}" -gt 0 ]; then
  reprepro -b "${REPO_LOCATION}" --component main includedeb <target> "${present_debs[@]}"
else
  echo "reprepro: target <target>: no debs present, skipping includedeb"
fi
```

### Testing
- Python parses; the generated bash passes `bash -n`.
- Behaviour test with one present + one missing deb: the missing one is logged and skipped, `includedeb` receives only the present deb.

Surfaced by armbian/ci#35 (optional reprepro repo in the build pipeline), where a normal partial `trunk` build produced no repo for exactly this reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository import scripts now process only package files that are present.
  * Missing package files are logged and skipped instead of causing invalid imports.
  * Imports are skipped entirely when no applicable package files are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->