### PR TITLE
sun60iw2: enable CONFIG_TUN as module for VPN support (Tailscale/WireGuard)

### DIFF
--- a/config/kernel/linux-sun60iw2-vendor.config
+++ b/config/kernel/linux-sun60iw2-vendor.config
@@ -3169,7 +3169,7 @@ CONFIG_VXLAN=y
 # CONFIG_AMT is not set
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
-# CONFIG_TUN is not set
+CONFIG_TUN=m
 # CONFIG_TUN_VNET_CROSS_LE is not set
 CONFIG_VETH=m
 # CONFIG_VIRTIO_NET is not set


### PR DESCRIPTION
# Description
Enables `CONFIG_TUN` (as a loadable module) in the vendor kernel config for the Orange Pi 4 Pro 
(sun60iw2 family). This is required for userspace VPN clients such as 
Tailscale, WireGuard-go, and OpenVPN, which all depend on the 
`/dev/net/tun` device to create virtual network interfaces.

# Motivation
Without this, users cannot use VPN mesh tools on this board — a common 
use case for SBCs (home servers, remote access, etc).

# How Has This Been Tested?
- Built with `./compile.sh BOARD=orangepi4pro BRANCH=vendor RELEASE=trixie BUILD_MINIMAL=yes BUILD_DESKTOP=no KERNEL_CONFIGURE=no`
- Booted on real Orange Pi 4 Pro hardware
- Confirmed `/dev/net/tun` present after boot:
<img width="325" height="29" alt="image" src="https://github.com/user-attachments/assets/33e0aede-fc07-4d2c-a330-616d5179feb7" />
- Installed and connected Tailscale successfully:
<img width="700" height="166" alt="image" src="https://github.com/user-attachments/assets/e114224b-913c-46ad-a6bd-74d8311de71c" />
- Device shows up and routes correctly in the tailnet alongside other nodes.

# Checklist
- [x] Tested on real hardware
- [x] Single, minimal, additive config change
- [x] No other boards affected (sun60iw2 config is specific to this family)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled kernel support for TUN/TAP userspace networking interfaces by providing it as a loadable kernel module, allowing TUN/TAP functionality to be used without needing it built directly into the kernel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->