### PR TITLE
repo-reprepro: log a count of skipped debs, not one line each

### DIFF
--- a/lib/tools/info/repo-reprepro.py
+++ b/lib/tools/info/repo-reprepro.py
@@ -122,12 +122,16 @@ for one_repo_target in repo_targets:
 		# not fetch them) would otherwise make reprepro error out on the first
 		# missing file and, under the script's `set -e`, abort before the export --
 		# losing the whole repository. Collect the present ones at run time and skip
-		# (with a log line) the rest, mirroring how the raw-deb sync tolerates gaps.
+		# the rest, mirroring how the raw-deb sync tolerates gaps. Only the count of
+		# skipped debs is logged (not one line each): a target can hold thousands of
+		# debs, so per-deb logging balloons the CI log to hundreds of MB.
 		bash_lines.append(f"echo 'reprepro: target {one_repo_target}: selecting present debs (of {len(all_debs_to_include_quoted)} expected)...'")
 		bash_lines.append("present_debs=()")
+		bash_lines.append("missing_debs=0")
 		bash_lines.append("for one_deb in " + " ".join(all_debs_to_include_quoted) + "; do")
-		bash_lines.append('	if [ -f "${one_deb}" ]; then present_debs+=("${one_deb}"); else echo "  skipping missing deb: ${one_deb}"; fi')
+		bash_lines.append('	if [ -f "${one_deb}" ]; then present_debs+=("${one_deb}"); else missing_debs=$((missing_debs + 1)); fi')
 		bash_lines.append("done")
+		bash_lines.append('[ "${missing_debs}" -gt 0 ] && echo "  ${missing_debs} expected deb(s) not present on disk, skipped"')
 		bash_lines.append('if [ "${#present_debs[@]}" -gt 0 ]; then')
 		bash_lines.append(f'	echo "reprepro importing ${{#present_debs[@]}} debs for target {one_repo_target}..."')
 		bash_lines.append(f'	reprepro -b "${{REPO_LOCATION}}" --component main includedeb {one_repo_target} "${{present_debs[@]}}"')


### PR DESCRIPTION
Follow-up to #10301. That change skips debs missing on disk, but echoed **one line per missing deb**. A single target (e.g. `armbian`) holds **thousands** of debs, and on a partial build most are absent — so the generated `reprepro.sh` printed thousands of skip lines.

Combined with the caller running it under `set -x` (which reprints the very long `for one_deb in <all debs>` header on **every** iteration), a CI run produced a **~200 MB log** and a multi-minute step (observed in armbian/ci#35 test runs).

### Fix
Count the skipped debs and log a single summary line per target instead of one per deb:
```bash
[ "${missing_debs}" -gt 0 ] && echo "  ${missing_debs} expected deb(s) not present on disk, skipped"
```
Selection and `includedeb` behaviour are unchanged. (The `set -x` half is fixed on the caller side in armbian/ci#35.)

### Testing
- Python parses; generated bash passes `bash -n`.
- Behaviour test (2 present, 3 missing): prints `3 expected deb(s) not present on disk, skipped` and `includedeb` receives only the 2 present debs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository processing output by replacing repeated missing-package messages with a single summary indicating how many expected packages were unavailable.
  * Continued processing available packages as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->