### PR TITLE
fix(sc8280xp-vendor): rebase DP retrain patch onto moving radxa 7.0.11 branch

### DIFF
--- a/patch/kernel/archive/sc8280xp-vendor/drm-msm-dp-retrain-link-in-place.patch
+++ b/patch/kernel/archive/sc8280xp-vendor/drm-msm-dp-retrain-link-in-place.patch
@@ -21,16 +21,16 @@ being ignored.
 
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- drivers/gpu/drm/msm/dp/dp_ctrl.c    | 18 +++
- drivers/gpu/drm/msm/dp/dp_ctrl.h    |  1 +
- drivers/gpu/drm/msm/dp/dp_display.c | 74 +++++++++-
- 3 files changed, 85 insertions(+), 8 deletions(-)
+  drivers/gpu/drm/msm/dp/dp_ctrl.c    | 18 +++++++++
+  drivers/gpu/drm/msm/dp/dp_ctrl.h    |  1 +
+  drivers/gpu/drm/msm/dp/dp_display.c | 81 +++++++++++++++++++++++++++++--------
+  3 files changed, 84 insertions(+), 16 deletions(-)
 
 diff --git a/drivers/gpu/drm/msm/dp/dp_ctrl.c b/drivers/gpu/drm/msm/dp/dp_ctrl.c
 index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/msm/dp/dp_ctrl.c
 +++ b/drivers/gpu/drm/msm/dp/dp_ctrl.c
-@@ -2135,6 +2135,24 @@ static int msm_dp_ctrl_link_maintenance(struct msm_dp_ctrl_private *ctrl)
+@@ -2133,6 +2133,24 @@ end:
  	return ret;
  }
  
@@ -98,10 +98,11 @@ index 111111111111..222222222222 100644
  
  	struct delayed_work edid_recheck_work;
  	unsigned int edid_recheck_left;
-@@ -423,14 +429,61 @@ static void msm_dp_hpd_recovery_work(struct work_struct *work)
+@@ -426,25 +432,63 @@ static void msm_dp_hpd_recovery_work(struct work_struct *work)
  	struct delayed_work *dw = to_delayed_work(work);
  	struct msm_dp_display_private *dp =
  		container_of(dw, struct msm_dp_display_private, hpd_recovery_work);
+-	int rc;
 +	struct drm_connector *connector = dp->msm_dp_display.connector;
 +	struct drm_device *dev = dp->drm_dev;
 +	struct drm_modeset_acquire_ctx ctx;
@@ -109,20 +110,29 @@ index 111111111111..222222222222 100644
 +	int rc = 0;
 +	int ret;
  
--	if (!dp->msm_dp_display.power_on || !dp->plugged)
+-	mutex_lock(&dp->plugged_lock);
 +	if (!dp->msm_dp_display.power_on || !dp->plugged) {
 +		dp->hpd_recovery_tries = 0;
- 		return;
++		return;
 +	}
-+
+ 
+-	if (!dp->msm_dp_display.power_on || !dp->plugged)
+-		goto unlock;
 +	/* clocks stay on, and the locks serialize any concurrent commit */
 +	drm_modeset_acquire_init(&ctx, 0);
-+
+ 
+-	msm_dp_ctrl_off_link_stream(dp->ctrl);
+-	msm_dp_ctrl_on_link(dp->ctrl);
+-	rc = msm_dp_ctrl_on_stream(dp->ctrl, false);
+-	if (rc)
 +retry:
 +	ret = drm_modeset_lock(&dev->mode_config.connection_mutex, &ctx);
 +	if (ret)
-+		goto unlock;
-+
+ 		goto unlock;
+ 
+-	drm_connector_set_link_status_property(dp->msm_dp_display.connector,
+-					       DRM_MODE_LINK_STATUS_GOOD);
+-	msm_dp_display_handle_plugged_change(&dp->msm_dp_display, true);
 +	crtc = connector->state->crtc;
 +	if (crtc) {
 +		ret = drm_modeset_lock(&crtc->mutex, &ctx);
@@ -133,10 +143,8 @@ index 111111111111..222222222222 100644
 +	if (dp->msm_dp_display.power_on && dp->plugged)
 +		rc = msm_dp_ctrl_retrain_link(dp->ctrl);
  
--	msm_dp_ctrl_off_link_stream(dp->ctrl);
--	msm_dp_ctrl_on_link(dp->ctrl);
--	msm_dp_ctrl_on_stream(dp->ctrl, false);
-+unlock:
+ unlock:
+-	mutex_unlock(&dp->plugged_lock);
 +	if (ret == -EDEADLK) {
 +		ret = drm_modeset_backoff(&ctx);
 +		if (!ret)
@@ -151,7 +159,7 @@ index 111111111111..222222222222 100644
 +					      msecs_to_jiffies(HPD_RECOVERY_DELAY_MS));
 +			return;
 +		}
- 
++
 +		DRM_ERROR("link recovery failed after %u tries. rc=%d\n",
 +			  dp->hpd_recovery_tries, rc);
 +		dp->hpd_recovery_tries = 0;
@@ -161,10 +169,12 @@ index 111111111111..222222222222 100644
 +	}
 +
 +	dp->hpd_recovery_tries = 0;
- 	drm_connector_set_link_status_property(dp->msm_dp_display.connector,
- 					       DRM_MODE_LINK_STATUS_GOOD);
++	drm_connector_set_link_status_property(dp->msm_dp_display.connector,
++					       DRM_MODE_LINK_STATUS_GOOD);
  }
-@@ -471,7 +524,9 @@ static int msm_dp_hpd_plug_handle(struct msm_dp_display_private *dp)
+ 
+ static int msm_dp_hpd_plug_handle(struct msm_dp_display_private *dp)
+@@ -483,7 +527,9 @@ static int msm_dp_hpd_plug_handle(struct msm_dp_display_private *dp)
  		drm_connector_set_link_status_property(dp->msm_dp_display.connector,
  						       DRM_MODE_LINK_STATUS_BAD);
  
@@ -175,7 +185,7 @@ index 111111111111..222222222222 100644
  	}
  
  	if (!ret && drm_dp_is_branch(dp->panel->dpcd)) {
-@@ -1623,9 +1678,12 @@ void msm_dp_bridge_atomic_enable(struct drm_bridge *drm_bridge,
+@@ -1635,9 +1681,12 @@ void msm_dp_bridge_atomic_enable(struct drm_bridge *drm_bridge,
  	}
  
  	rc = msm_dp_ctrl_on_link(msm_dp_display->ctrl);


### PR DESCRIPTION
## Problem

`kernel-sc8280xp-vendor` (radxa/kernel `branch:linux-7.0.11`, kernel 7.0.11) fails at the patching stage — [ci run 30448454441](https://github.com/armbian/ci/actions/runs/30448454441/attempts/4):

```
Problem with ->drm-msm-dp-retrain-link-in-place<-: Failed to apply patch
Exception: Failed to apply 1 patches
```

A `failed_apply` on any kernel patch aborts the whole kernel build.

## Root cause — moving-branch drift, not a stale header

`KERNELBRANCH='branch:linux-7.0.11'` is a **moving branch**. Since `drm-msm-dp-retrain-link-in-place.patch` was authored (2 Jul, commit 0968961ce), radxa **rewrote the exact function the patch rewrites** — `msm_dp_hpd_recovery_work()`:

| | recovery-work body |
|---|---|
| **patch was written against** | bare `off_link_stream` → `on_link` → `on_stream`, then set `LINK_STATUS_GOOD` |
| **radxa's current body** | wraps that in `mutex_lock(&dp->plugged_lock)`, gates on the `on_stream()` return, adds `msm_dp_display_handle_plugged_change()` + `unlock:` |

The patch's `-`/context lines no longer match the base, so the recovery-body hunk (`@@ -423,14 @@`) rejects. The other five hunks only drifted by line offset and still fuzz-apply — that's why the patcher reported `2 needs_rebase; 1 failed_apply`.

## Fix

Regenerated the patch against the **current** radxa 7.0.11 tree (with the two preceding sibling DP patches applied). Only the recovery-body hunk's context changes; `dp_ctrl.c` / `dp_ctrl.h` and the include/define/struct/plug-handler/`atomic_enable` hunks are semantically identical, just re-offset. SuperKali's authorship and commit message are preserved.

Verified: the full `sc8280xp-vendor` series applies in order on a clean radxa `linux-7.0.11` tree, **retrain with zero fuzz**.

## ⚠️ Review note (semantic)

This patch is a deliberate **complete rewrite** of `msm_dp_hpd_recovery_work()` — in-place retrain under DRM modeset locks — so it now **supersedes radxa's newer `plugged_lock` / `on_stream`-rc / `handle_plugged_change()` variant** of the same function. That is by design: modeset locks serialize against commits and the link is never torn down, so there is no plug-state change to report. **If the `msm_dp_display_handle_plugged_change()` audio notification is still wanted on the recovery path**, @SuperKali should fold it into the new body — flagging so it's a conscious call, not an accidental drop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DisplayPort link recovery by retraining links in place without interrupting active display clocks.
  * Added automatic retries for transient link failures.
  * Improved synchronization during recovery to reduce conflicts with display updates.
  * Failed link recovery now notifies the system to perform a fresh display configuration.
  * DisplayPort enable failures now trigger automatic recovery attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->