### PR TITLE
maintenance-rewrite-kernel-patches: enable parallel patch rewriting

### DIFF
--- a/.github/workflows/maintenance-rewrite-kernel-patches.yml
+++ b/.github/workflows/maintenance-rewrite-kernel-patches.yml
@@ -23,6 +23,14 @@ on:
         options:
           - rewrite-kernel-patches
           - rewrite-uboot-patches
+      parallel_patches:
+        description: "Rewrite patches in parallel (faster; set no if a board misbehaves)"
+        required: false
+        type: choice
+        options:
+          - 'yes'
+          - 'no'
+        default: 'yes'
 
 permissions:
   contents: write
@@ -57,8 +65,12 @@ jobs:
           BOARD: ${{ inputs.board }}
           BRANCH: ${{ inputs.branch }}
           WHATTODO: ${{ inputs.whattodo }}
+          # Parallel patch rewriting (lib/tools/common/patching_parallel.py). Only
+          # takes effect for the rewrite-* commands (REWRITE_PATCHES=yes); worker
+          # count auto-calculates when PARALLEL_WORKERS is unset.
+          PARALLEL_PATCHES: ${{ inputs.parallel_patches }}
         run: |
-          ./compile.sh "BOARD=$BOARD" "BRANCH=$BRANCH" "$WHATTODO" KERNEL_GIT=shallow
+          ./compile.sh "BOARD=$BOARD" "BRANCH=$BRANCH" "$WHATTODO" KERNEL_GIT=shallow "PARALLEL_PATCHES=$PARALLEL_PATCHES"
 
       - name: Check for changes
         env:


### PR DESCRIPTION
Wires the recently added **parallel patch rewriting** feature (`lib/tools/common/patching_parallel.py`, introduced in `205a36f2`) into the rewrite-patches maintenance workflow.

## Change

- New dispatch toggle `parallel_patches` (choice, default **yes**, with `no` as an escape hatch if a board misbehaves).
- Passed through as `PARALLEL_PATCHES` to `./compile.sh … rewrite-kernel-patches|rewrite-uboot-patches`. `PARALLEL_WORKERS` is left unset so the worker count auto-calculates.

## Why here, not the configs workflow

You pointed at `maintenance-rewrite-kernel-configs.yml`, but the feature can't work there. The gate in `lib/tools/patching.py` is:

```python
parallel_patches = rewrite_patches_in_place and (PARALLEL_PATCHES == "yes")
```

`rewrite_patches_in_place` is only true when `REWRITE_PATCHES=yes` — i.e. the `rewrite-kernel-patches` / `rewrite-uboot-patches` commands, which live in **this** workflow. `rewrite-kernel-config` never sets it, so `PARALLEL_PATCHES` would be a no-op in the configs workflow. Both `whattodo` options here set `REWRITE_PATCHES=yes`, so the toggle applies to kernel and u-boot patch rewrites alike.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable option to enable parallel patch rewriting during maintenance builds.
  - Maintenance builds can now process eligible patch rewrites concurrently, potentially reducing execution time.
  - Parallel processing applies specifically when patch rewriting is enabled and can be controlled through the workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->