### PR TITLE
board: set HAS_VIDEO_OUTPUT at board level so the build-list inventory sees it

### DIFF
--- a/config/boards/cubie-a7z.csc
+++ b/config/boards/cubie-a7z.csc
@@ -7,6 +7,7 @@ INTRODUCED="2025"
 KERNEL_TARGET="vendor"
 KERNEL_TEST_TARGET="vendor"
 IMAGE_PARTITION_TABLE="msdos"
+HAS_VIDEO_OUTPUT="no" # no desktop on this vendor kernel; board-level so the build-list inventory sees it
 
 # --- Board-specific build configuration ---
 BOOT_FDT_FILE="allwinner/sun60i-a733-cubie-a7z.dtb"

--- a/config/boards/orangepi4pro.csc
+++ b/config/boards/orangepi4pro.csc
@@ -7,6 +7,7 @@ INTRODUCED="2025"
 KERNEL_TARGET="vendor"
 KERNEL_TEST_TARGET="vendor"
 IMAGE_PARTITION_TABLE="msdos"
+HAS_VIDEO_OUTPUT="no" # no desktop on this vendor kernel; board-level so the build-list inventory sees it
 
 BOOT_FDT_FILE="allwinner/sun60i-a733-orangepi-4-pro.dtb"
 SUNXI_BOOT0_SDCARD_FEX="${SRC}/packages/blobs/sunxi/sun60iw2/boot0_sdcard_orangepi4pro.fex"

--- a/config/boards/orangepizero3w.csc
+++ b/config/boards/orangepizero3w.csc
@@ -7,6 +7,7 @@ INTRODUCED="2025"
 KERNEL_TARGET="vendor"
 KERNEL_TEST_TARGET="vendor"
 IMAGE_PARTITION_TABLE="msdos"
+HAS_VIDEO_OUTPUT="no" # no desktop on this vendor kernel; board-level so the build-list inventory sees it
 
 BOOT_FDT_FILE="allwinner/sun60i-a733-orangepi-zero3w.dtb"
 SUNXI_BOOT0_SDCARD_FEX="${SRC}/packages/blobs/sunxi/sun60iw2/boot0_sdcard_orangepizero3w.fex"

--- a/config/boards/radxa-cubie-a5e.csc
+++ b/config/boards/radxa-cubie-a5e.csc
@@ -10,7 +10,7 @@ OVERLAY_PREFIX="sun55i-a527"
 KERNEL_TARGET="current,edge"
 KERNEL_TEST_TARGET="current,edge"
 BOOT_FDT_FILE="sun55i-a527-cubie-a5e.dtb"
-HAS_VIDEO_OUTPUT=no
+HAS_VIDEO_OUTPUT="no" # quoted so the build-list inventory (it parses only quoted values) sees it
 
 PACKAGE_LIST_BOARD="rfkill bluetooth bluez bluez-tools"
 

--- a/config/sources/families/sun60iw2.conf
+++ b/config/sources/families/sun60iw2.conf
@@ -40,8 +40,9 @@ declare -g UBOOT_TARGET_MAP=";;boot0_sdcard.fex boot0_spinor.fex boot_package.fe
 declare -g OVERLAY_DIR="/boot/dtb/allwinner/overlay"
 
 # Video output DOES work without GPU acceleration but we still don't want to
-# build desktop targets by default.
-declare -g HAS_VIDEO_OUTPUT="no"
+# build desktop targets by default. HAS_VIDEO_OUTPUT="no" is set per board (not
+# here) so the build-list inventory -- which parses only board configs, not
+# family files -- sees it and doesn't emit desktop targets that then fail.
 declare -g FULL_DESKTOP="no"
 
 function add_host_dependencies__sun60iw2_uboot_xxd() {


### PR DESCRIPTION
The build-list generator (`generate-build-lists` in armbian.github.io, running the framework's info-gatherer / `targets-compositor`) floods with errors like:

```
Error calling Armbian command: .../compile.sh config-dump-json ... BUILD_DESKTOP=yes ... BOARD=orangepi4pro ...
code: 43 - err: error! HAS_VIDEO_OUTPUT is set to no. So we shouldn't build desktop environment
```

### Cause
`targets-compositor.py:52` emits **desktop** targets when `BOARD_HAS_VIDEO` is true. That flag is computed in `armbian_utils.py` **from the board `.conf` only**, and only from a **quoted** assignment (its regex is `...=(?:'|")(.*)(?:'|")`). The actual build then reads `HAS_VIDEO_OUTPUT` (family + board) and aborts at `main-config.sh:321` when it is `no` but a desktop was requested.

Two ways the mismatch happened:
- **sun60iw2** boards (`orangepi4pro`, `cubie-a7z`, `orangepizero3w`) set `HAS_VIDEO_OUTPUT="no"` **in the family**, which the inventory never parses → `BOARD_HAS_VIDEO=True` → desktop targets → error.
- **`radxa-cubie-a5e`** set it in the board file but **unquoted** (`HAS_VIDEO_OUTPUT=no`), which the quoted-only regex ignores → same result.

### Fix
Set `HAS_VIDEO_OUTPUT="no"` at **board level, quoted**, on all four boards; drop it from `sun60iw2.conf` (the family keeps `FULL_DESKTOP="no"`). Verified against the inventory regex: all four now resolve to `BOARD_HAS_VIDEO=False`, so no desktop targets are emitted and the config-dump errors disappear.

Build-time behaviour is unchanged (board-level `HAS_VIDEO_OUTPUT="no"` is the same mechanism dozens of other boards already use, e.g. `nanopi-r4s`, `rockpi-s`).

> Note: the inventory regex silently ignoring unquoted values is a sharp edge worth hardening separately, but this change fixes the immediate build-list breakage without touching parser logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected board capability reporting for several Radxa and Orange Pi devices.
  - Boards without desktop or video output are now accurately identified in build and inventory listings.
  - Improved recognition of the no-video setting for the Radxa Cubie A5E.
  - Updated desktop target selection so it reflects each board’s reported capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->