### PR TITLE
imx8ulp: fix libbpf const-discard so resolve_btfids builds on gcc 15

### DIFF
--- a/patch/kernel/archive/imx8ulp-6.1/tools-libbpf-const-next-path-gcc15.patch
+++ b/patch/kernel/archive/imx8ulp-6.1/tools-libbpf-const-next-path-gcc15.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor@armbian.com>
+Date: Thu, 30 Jul 2026 12:00:00 +0200
+Subject: [PATCH] tools/libbpf: const next_path in resolve_full_path (gcc 15)
+
+The linux-headers postinst rebuilds tools/bpf/resolve_btfids in the target
+rootfs. On resolute (gcc 15) that build fails:
+
+  tools/lib/bpf/libbpf.c: error: assignment discards 'const' qualifier from
+  pointer target type [-Werror=discarded-qualifiers]
+     next_path = strchr(s, ':');
+
+'s' is const char *, so strchr() yields const char *; assigning it to a plain
+char * discards const. gcc <= 14 (the build container, trixie) only warned, so
+the kernel artifact builds, but the postinst rebuild in the resolute chroot is
+a hard error and the image build dies at install_artifact_deb_chroot.
+
+next_path is only read (pointer diff), so make it const. Scoped to the Avnet
+linux-imx 6.1.22 vendor kernel (imx8ulp / maaxboard-8ulp).
+
+Signed-off-by: Igor Pecovnik <igor@armbian.com>
+---
+diff --git a/tools/lib/bpf/libbpf.c b/tools/lib/bpf/libbpf.c
+index 111111111111..222222222222 100644
+--- a/tools/lib/bpf/libbpf.c
++++ b/tools/lib/bpf/libbpf.c
+@@ -10721,9 +10721,9 @@ static int resolve_full_path(const char *file, char *result, size_t result_sz)
+ 
+ 		if (!search_paths[i])
+ 			continue;
+ 		for (s = search_paths[i]; s != NULL; s = strchr(s, ':')) {
+-			char *next_path;
++			const char *next_path;
+ 			int seg_len;
+ 
+ 			if (s[0] == ':')
+ 				s++;
+-- 
+Armbian
+


### PR DESCRIPTION
## Symptom

`maaxboard-8ulp` community image builds fail — [ci run](https://github.com/armbian/ci/actions/runs/30535843965) — during the `linux-headers` postinst, on **every** runner (native arm64 `ampere-1-38` included, so it's **not** the qemu issue and **not** version-related):

```
Compiling resolve_btfids tools ...
tools/lib/bpf/libbpf.c:...: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
    next_path = strchr(s, ':');
cc1: all warnings being treated as errors
make[1]: *** [Makefile:76: bpf/resolve_btfids] Error 2
→ install_artifact_deb_chroot() → apt-install.sh:107 → image build failed
```

## Root cause

`kernel-debs.sh:583` — the linux-headers postinst rebuilds `tools/bpf/resolve_btfids` **inside the target rootfs** with a plain `make`, so the family's `KERNEL_EXTRA_CFLAGS` (which already carry `-Wno-error=enum-int-mismatch` for imx8ulp) never reach it.

In `resolve_full_path()`, `s` is `const char *`, so `strchr(s, ':')` yields `const char *`; assigning it to `char *next_path` discards const. **gcc ≤ 14** (the trixie build container) only warns — so the kernel *artifact* compiles — but the postinst rebuild runs in the **resolute chroot under gcc 15**, where it's a hard `-Werror`.

## Fix

`next_path` is only read (a pointer diff), so make it `const char *`. One line, in the Avnet `linux-imx` 6.1.22 vendor source, so the shipped headers carry the fix and the chroot rebuild succeeds. New patch dir `patch/kernel/archive/imx8ulp-6.1/` (this family had no kernel patches before). Verified it applies clean to the pristine vendor tree; `next_path` has no other uses.

Scoped to imx8ulp/maaxboard-8ulp only. If further `-Werror=discarded-qualifiers` sites surface in this old libbpf under gcc 15, they'd need the same one-line treatment, but this is the one that's currently blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a compilation failure with GCC 15 during post-install artifact rebuilding.
  * Improved const-correctness in path handling to prevent discarded-qualifier errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->