### PR TITLE
rootfs: bump force-rebuild counter to 007

### DIFF
--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -193,4 +193,4 @@ function extract_rootfs_artifact() {
 }
 
 # This comment strategically introduced to force a rebuild of all rootfs, as this file's contents are hashed into all rootfs versions.
-# Just a number to force rebuild 006
+# Just a number to force rebuild 007


### PR DESCRIPTION
Bumps the force-rebuild counter in `lib/functions/rootfs/create-cache.sh` (006 → 007).

This file's contents are hashed into every rootfs version, so changing the counter comment invalidates all cached rootfs and forces a clean rebuild across the board.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the root filesystem cache marker, triggering a rebuild of all root filesystem versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->