### PR TITLE
imx8ulp: enable scoped kernel patches so the libbpf/gcc-15 fix applies

### DIFF
--- a/config/sources/families/imx8ulp.conf
+++ b/config/sources/families/imx8ulp.conf
@@ -20,10 +20,13 @@ declare -g BOOTSIZE=128
 declare -g BOOTFS_TYPE="fat"
 declare -g BOOTSCRIPT="boot-maaxboard-8ulp.cmd:uEnv.txt"
 declare -g ATF_SKIP_LDFLAGS_WL="yes"
-# Avnet vendor linux-imx 6.1.22 BSP tree: Armbian's mainline archive patches and
-# out-of-tree driver harness (EXTRAWIFI) target mainline and don't apply here.
-# This also implies EXTRAWIFI=no via common.conf.
-declare -g DISABLE_KERNEL_PATCHES="yes"
+# Avnet vendor linux-imx 6.1.22 BSP tree: Armbian's out-of-tree driver harness
+# (EXTRAWIFI) targets mainline and doesn't apply here, so keep it off.
+# NOT DISABLE_KERNEL_PATCHES=yes: that force-empties KERNELPATCHDIR, so no patch
+# could ever apply (and the artifact hash stayed at P0000, never re-cached). We
+# do need patches — scoped to archive/imx8ulp-6.1 below, which holds only the
+# GCC-15 libbpf fix; the generic mainline archive patches are not pulled in.
+declare -g EXTRAWIFI="no"
 
 declare -g ATF_PLAT="imx8ulp"
 
@@ -38,6 +41,9 @@ case $BRANCH in
 		declare -g KERNEL_MAJOR_MINOR="6.1"
 		declare -g KERNELSOURCE='https://github.com/Avnet/linux-imx.git'
 		declare -g KERNELBRANCH='commit:78ce688d5a792c053827e1edd4a347807c63c06c'
+		# Scope patching to this family's dir (only the GCC-15 libbpf fix lives here);
+		# set explicitly like other vendor families rather than relying on the default.
+		declare -g KERNELPATCHDIR='archive/imx8ulp-6.1'
 		;;
 esac
 


### PR DESCRIPTION
Makes #10310 actually take effect. On its own #10310 was **completely inert** — the patch sat unapplied and unhashed.

## Root cause (traced via config-dump)

imx8ulp sets `DISABLE_KERNEL_PATCHES="yes"` (the Avnet vendor BSP can't take Armbian's mainline archive patches or the EXTRAWIFI driver harness). But that switch, in `common.conf`, **force-empties `KERNELPATCHDIR`** — so **no kernel patch can ever apply** to this family, and the artifact hash is pinned at `P0000` (patches) / `D0000` (drivers). `config-dump-json` on `maaxboard-8ulp/vendor` confirms:

```
KERNELPATCHDIR = ''
EXTRAWIFI = 'no'
DISABLE_KERNEL_PATCHES = 'yes'
```

So:
- #10310's `patch/kernel/archive/imx8ulp-6.1/…libbpf…patch` was **never applied**, and
- it **never changed the hash**, so no rebuild — the cached kernel headers still ship the unpatched libbpf.

Result: every imx8ulp image that installs headers (desktop / DKMS) dies in the `linux-headers` postinst on `libbpf.c: -Werror=discarded-qualifiers` → `resolve_btfids` Error 2 → dpkg configure fails. Minimal (no headers) passes with the byte-identical kernel — which is why it looked like "different kernels" earlier. It's the same `…-P0000-…` deb both times.

## Fix

Replace the blunt `DISABLE_KERNEL_PATCHES` with **scoped** patching:
- `KERNELPATCHDIR='archive/imx8ulp-6.1'` — applies **only** the libbpf fix that lives there; the generic mainline archive patches are *not* pulled in.
- `EXTRAWIFI="no"` — keep the out-of-tree driver harness off, exactly as before (`D` stays `0000`).

After this, `config-dump` shows `KERNELPATCHDIR='archive/imx8ulp-6.1'`; the patch applies, `P` flips off `0000`, and a fresh (fixed) kernel builds and re-caches. Verified with `config-dump-json`.

Depends on #10310 (the patch itself). Separately, the newly-built `kernel-imx8ulp-vendor` ghcr package must be **public** for image builds to pull it anonymously (that's the os→ci package-visibility item, not this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed kernel patch application for imx8ulp systems, ensuring the appropriate vendor patches are applied and build artifact caching works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->