### PR TITLE
uwe5622: bump driver commit

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -509,7 +509,7 @@ driver_uwe5622() {
 	if linux-version compare "${version}" ge 5.15 && linux-version compare "${version}" lt 7.2 && [[ "$LINUXFAMILY" == sun* || "$LINUXFAMILY" == rockchip64 || "$LINUXFAMILY" == rk35xx ]]; then
 
 		# Attach to specific commit
-		local uwe5622ver='commit:836e959704a87e0117b2e7b61a43f80216601e77' # Commit date: Jul 28, 2026 (please update when updating commit ref)
+		local uwe5622ver='commit:fe49fbeba25be33a581f276ff33e051bb48f166c' # Commit date: Aug 02, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Unisoc uwe5622 driver ${uwe5622ver}" "info"
 


### PR DESCRIPTION
# Description

pin uwe5622 driver to a new commit include recently merged fixes https://github.com/armbian/uwe5622/commits/master/

# How Has This Been Tested?

- [x] build tests were actually the same as https://github.com/armbian/build/pull/10316

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pinned network driver version to a newer revision.
  * Includes upstream driver updates and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->