### PR TITLE
mainline: bump to 7.2-rc6

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0          # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "7.2" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v7.2-rc4"
+		declare -g KERNELBRANCH="tag:v7.2-rc6"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }
@@ -26,11 +26,11 @@ function mainline_kernel_decide_version__upstream_release_candidate_number() {
 
 # Example: 6.7-rc7 was released by Linus, but kernel.org git and google git mirrors took a while to catch up; change the source to pull directly from Linus.
 # This was necessary for a few days in late December 2023, but no longer; tag was pushed on 28/Dec/2023.
-function mainline_kernel_decide_version__750_use_torvalds_for_7.2-rc4() {
-	if [[ "${KERNELBRANCH}" == 'tag:v7.2-rc4' ]]; then
-		display_alert "Using Linus kernel repo for 7.2-rc4" "${KERNELBRANCH}" "warn"
+function mainline_kernel_decide_version__750_use_torvalds_for_7.2-rc6() {
+	if [[ "${KERNELBRANCH}" == 'tag:v7.2-rc6' ]]; then
+		display_alert "Using Linus kernel repo for 7.2-rc6" "${KERNELBRANCH}" "warn"
 		declare -g KERNELSOURCE="https://github.com/torvalds/linux.git"
-		display_alert "mainline-kernel: missing torvalds tag on 7.2-rc4" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
+		display_alert "mainline-kernel: missing torvalds tag on 7.2-rc6" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
 	fi
 }
 

--- a/patch/kernel/archive/rockchip64-7.2/board-odroidm2-support-for-vu8s-panel.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-odroidm2-support-for-vu8s-panel.patch
@@ -430,7 +430,7 @@ index 111111111111..222222222222 100644
  static int ili9881c_get_modes(struct drm_panel *panel,
  			      struct drm_connector *connector)
  {
-@@ -2700,6 +2918,15 @@ static const struct ili9881c_desc waveshare_7inch_a_desc = {
+@@ -2703,6 +2921,15 @@ static const struct ili9881c_desc waveshare_7inch_a_desc = {
  	.lanes = 2,
  };
  
@@ -446,7 +446,7 @@ index 111111111111..222222222222 100644
  static const struct of_device_id ili9881c_of_match[] = {
  	{ .compatible = "bananapi,lhr050h41", .data = &lhr050h41_desc },
  	{ .compatible = "bestar,bsd1218-a101kl68", .data = &bsd1218_a101kl68_desc },
-@@ -2712,6 +2939,7 @@ static const struct of_device_id ili9881c_of_match[] = {
+@@ -2715,6 +2942,7 @@ static const struct of_device_id ili9881c_of_match[] = {
  	{ .compatible = "ampire,am8001280g", .data = &am8001280g_desc },
  	{ .compatible = "raspberrypi,dsi-5inch", &rpi_5inch_desc },
  	{ .compatible = "raspberrypi,dsi-7inch", &rpi_7inch_desc },

--- a/patch/kernel/archive/rockchip64-7.2/board-rockpi-4a-cap-spi-nor-frequency.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-rockpi-4a-cap-spi-nor-frequency.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Velkov <iav@iav.lv>
-Date: Tue, 22 Jul 2026 05:30:00 +0000
+Date: Wed, 22 Jul 2026 05:30:00 +0000
 Subject: arm64: dts: rockchip: cap SPI NOR frequency on ROCK Pi 4A
 
 Commit fa16d7a820e4 ("arm64: dts: rockchip: Increase maximum frequency of
@@ -32,7 +32,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4a.dts b/arch/arm64/boo
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4a.dts
-@@ -19,6 +19,6 @@
+@@ -19,6 +19,6 @@ &spi1 {
  	flash@0 {
  		compatible = "jedec,spi-nor";
  		reg = <0>;
@@ -40,3 +40,6 @@ index 111111111111..222222222222 100644
 +		spi-max-frequency = <10000000>;
  	};
  };
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/general-disable-mtu-validation.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-disable-mtu-validation.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/eth
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -6105,27 +6105,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
+@@ -6092,27 +6092,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
  static int stmmac_change_mtu(struct net_device *dev, int new_mtu)
  {
  	struct stmmac_priv *priv = netdev_priv(dev);

--- a/patch/kernel/archive/rockchip64-7.2/general-drm-panel-add-rocknix-generic-dsi.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-drm-panel-add-rocknix-generic-dsi.patch
@@ -1,49 +1,19 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] board: anbernic-rg-vita-pro - move ROCKNIX panel to its
- alphabetical slot
+Subject: drm/panel: add generic DSI panel driver (ROCKNIX)
 
-> X-Git-Archeology: > recovered message: > The ROCKNIX prefix rename left the Kconfig entry and the Makefile object
-> X-Git-Archeology: > recovered message: > where the old GENERIC name sorted, between DSI_CM and LVDS. Move both to
-> X-Git-Archeology: > recovered message: > where ROCKNIX belongs, between RENESAS_R69328 and RONBO_RB070D30.
-> X-Git-Archeology: > recovered message: > No functional change.
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision a1190cae429ce0b8c28ec95b3fd55d2dc30d34e7: https://github.com/armbian/build/commit/a1190cae429ce0b8c28ec95b3fd55d2dc30d34e7
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - move ROCKNIX panel to its alphabetical slot
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 802c0f45ecaea6afa72db516ab5bfecab169a2c5: https://github.com/armbian/build/commit/802c0f45ecaea6afa72db516ab5bfecab169a2c5
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - address review feedback
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 2cfa897ddbb543b22945951ede51d64e5808ff9e: https://github.com/armbian/build/commit/2cfa897ddbb543b22945951ede51d64e5808ff9e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - fix eMMC HS400 timeouts (rk3576 DLL calibration)
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision dcb7c65121b60e68126b99e3781f2770cb0889b0: https://github.com/armbian/build/commit/dcb7c65121b60e68126b99e3781f2770cb0889b0
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: adapt generic-dsi panel to refcounted panel alloc
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
-> X-Git-Archeology:
+Add the ROCKNIX "rocknix,generic-dsi" MIPI-DSI panel driver, which reads
+its display timings and init sequence from a device-tree "panel_description"
+string rather than hardcoding a specific panel. Required for the Anbernic
+RG Vita Pro LCD to probe, letting rockchip-drm bind and bring up display.
+
+Driver by Danil Zagoskin (ROCKNIX); Kconfig/Makefile added for mainline.
+
+Adapted for the refcounted panel allocation in 7.2 (devm_drm_panel_alloc
+replaces devm_kzalloc + the removed drm_panel_init).
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/gpu/drm/panel/Kconfig                     |  11 +
  drivers/gpu/drm/panel/Makefile                    |   1 +

--- a/patch/kernel/archive/rockchip64-7.2/general-drm-panel-add-rocknix-generic-dsi.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-drm-panel-add-rocknix-generic-dsi.patch
@@ -1,26 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] drm/panel: add generic DSI panel driver (ROCKNIX)
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] board: anbernic-rg-vita-pro - move ROCKNIX panel to its
+ alphabetical slot
 
-Add the ROCKNIX "rocknix,generic-dsi" MIPI-DSI panel driver, which reads
-its display timings and init sequence from a device-tree "panel_description"
-string rather than hardcoding a specific panel. Required for the Anbernic
-RG Vita Pro LCD to probe, letting rockchip-drm bind and bring up display.
-
-Driver by Danil Zagoskin (ROCKNIX); Kconfig/Makefile added for mainline.
-
-Adapted for the refcounted panel allocation in 7.2 (devm_drm_panel_alloc
-replaces devm_kzalloc + the removed drm_panel_init).
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > The ROCKNIX prefix rename left the Kconfig entry and the Makefile object
+> X-Git-Archeology: > recovered message: > where the old GENERIC name sorted, between DSI_CM and LVDS. Move both to
+> X-Git-Archeology: > recovered message: > where ROCKNIX belongs, between RENESAS_R69328 and RONBO_RB070D30.
+> X-Git-Archeology: > recovered message: > No functional change.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision a1190cae429ce0b8c28ec95b3fd55d2dc30d34e7: https://github.com/armbian/build/commit/a1190cae429ce0b8c28ec95b3fd55d2dc30d34e7
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - move ROCKNIX panel to its alphabetical slot
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 802c0f45ecaea6afa72db516ab5bfecab169a2c5: https://github.com/armbian/build/commit/802c0f45ecaea6afa72db516ab5bfecab169a2c5
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - address review feedback
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2cfa897ddbb543b22945951ede51d64e5808ff9e: https://github.com/armbian/build/commit/2cfa897ddbb543b22945951ede51d64e5808ff9e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - fix eMMC HS400 timeouts (rk3576 DLL calibration)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dcb7c65121b60e68126b99e3781f2770cb0889b0: https://github.com/armbian/build/commit/dcb7c65121b60e68126b99e3781f2770cb0889b0
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: adapt generic-dsi panel to refcounted panel alloc
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
+> X-Git-Archeology:
 ---
+ drivers/gpu/drm/panel/Kconfig                     |  11 +
+ drivers/gpu/drm/panel/Makefile                    |   1 +
+ drivers/gpu/drm/panel/panel-rocknix-generic-dsi.c | 697 ++++++++++
+ 3 files changed, 709 insertions(+)
+
 diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
-index 7450b27..884e722 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/panel/Kconfig
 +++ b/drivers/gpu/drm/panel/Kconfig
-@@ -810,6 +810,17 @@ config DRM_PANEL_RENESAS_R69328
+@@ -812,6 +812,17 @@ config DRM_PANEL_RENESAS_R69328
  	  This panel controller can be found in LG Optimus 4X P895 smartphone
  	  in combination with LCD panel.
-
+ 
 +config DRM_PANEL_ROCKNIX_GENERIC_DSI
 +	tristate "Generic DSI panel (ROCKNIX, timings via DT panel_description)"
 +	depends on OF
@@ -36,10 +73,10 @@ index 7450b27..884e722 100644
  	tristate "Ronbo Electronics RB070D30 panel"
  	depends on OF
 diff --git a/drivers/gpu/drm/panel/Makefile b/drivers/gpu/drm/panel/Makefile
-index c2c5cf8..5a316b2 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/panel/Makefile
 +++ b/drivers/gpu/drm/panel/Makefile
-@@ -79,6 +79,7 @@ obj-$(CONFIG_DRM_PANEL_RAYDIUM_RM69380) += panel-raydium-rm69380.o
+@@ -79,6 +79,7 @@ obj-$(CONFIG_DRM_PANEL_RAYDIUM_RM692E5) += panel-raydium-rm692e5.o
  obj-$(CONFIG_DRM_PANEL_RAYDIUM_RM69380) += panel-raydium-rm69380.o
  obj-$(CONFIG_DRM_PANEL_RENESAS_R61307) += panel-renesas-r61307.o
  obj-$(CONFIG_DRM_PANEL_RENESAS_R69328) += panel-renesas-r69328.o
@@ -47,12 +84,9 @@ index c2c5cf8..5a316b2 100644
  obj-$(CONFIG_DRM_PANEL_RONBO_RB070D30) += panel-ronbo-rb070d30.o
  obj-$(CONFIG_DRM_PANEL_SAMSUNG_AMS581VF01) += panel-samsung-ams581vf01.o
  obj-$(CONFIG_DRM_PANEL_SAMSUNG_AMS639RQ08) += panel-samsung-ams639rq08.o
- obj-$(CONFIG_DRM_PANEL_LVDS) += panel-lvds.o
- obj-$(CONFIG_DRM_PANEL_SIMPLE) += panel-simple.o
- obj-$(CONFIG_DRM_PANEL_EDP) += panel-edp.o
 diff --git a/drivers/gpu/drm/panel/panel-rocknix-generic-dsi.c b/drivers/gpu/drm/panel/panel-rocknix-generic-dsi.c
 new file mode 100644
-index 0000000..726ccba
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/gpu/drm/panel/panel-rocknix-generic-dsi.c
 @@ -0,0 +1,697 @@
@@ -753,3 +787,6 @@ index 0000000..726ccba
 +MODULE_AUTHOR("Danil Zagoskin <z@gosk.in>");
 +MODULE_DESCRIPTION("DRM driver for generic MIPI DSI panel");
 +MODULE_LICENSE("GPL v2");
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/general-drm-panel-add-yixian-yx0345-panel.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-drm-panel-add-yixian-yx0345-panel.patch
@@ -13,7 +13,7 @@ diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
 index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/panel/Kconfig
 +++ b/drivers/gpu/drm/panel/Kconfig
-@@ -1336,6 +1336,15 @@ config DRM_PANEL_WIDECHIPS_WS2401
+@@ -1350,6 +1350,15 @@ config DRM_PANEL_WIDECHIPS_WS2401
  	  480x800 display controller used in panels such as Samsung LMS380KF01.
  	  This display is used in the Samsung Galaxy Ace 2 GT-I8160 (Codina).
  
@@ -33,7 +33,7 @@ diff --git a/drivers/gpu/drm/panel/Makefile b/drivers/gpu/drm/panel/Makefile
 index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/panel/Makefile
 +++ b/drivers/gpu/drm/panel/Makefile
-@@ -131,3 +131,4 @@ obj-$(CONFIG_DRM_PANEL_VISIONOX_VTDR6130) += panel-visionox-vtdr6130.o
+@@ -132,3 +132,4 @@ obj-$(CONFIG_DRM_PANEL_VISIONOX_VTDR6130) += panel-visionox-vtdr6130.o
  obj-$(CONFIG_DRM_PANEL_VISIONOX_R66451) += panel-visionox-r66451.o
  obj-$(CONFIG_DRM_PANEL_WIDECHIPS_WS2401) += panel-widechips-ws2401.o
  obj-$(CONFIG_DRM_PANEL_XINPENG_XPP055C272) += panel-xinpeng-xpp055c272.o

--- a/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-01-options.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-01-options.patch
@@ -1,36 +1,15 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
- bleedingedge
+Subject: input: joystick: add spi-mcu-joypad Kconfig and Makefile
 
-> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
-> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
-> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
-> X-Git-Archeology: > recovered message: > - 12 apply unchanged
-> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
-> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
-> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
-> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
-> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
-> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
-> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
-> X-Git-Archeology:
+Wire up the spi-mcu-joypad driver in the joystick subsystem Kconfig and
+Makefile, and add the driver's own Kconfig/Makefile
+(CONFIG_JOYSTICK_SPI_MCU_JOYPAD). The driver serves the analog sticks
+and RGB LEDs found on Anbernic RK35xx handhelds (e.g. the RG Vita Pro),
+where an MCU exposes them over SPI. Driver from ROCKNIX.
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/input/joystick/Kconfig                 |  2 ++
  drivers/input/joystick/Makefile                |  1 +

--- a/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-01-options.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-01-options.patch
@@ -1,17 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] input: joystick: add spi-mcu-joypad Kconfig and Makefile
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
+ bleedingedge
 
-Wire up the spi-mcu-joypad driver in the joystick subsystem Kconfig and
-Makefile, and add the driver's own Kconfig/Makefile
-(CONFIG_JOYSTICK_SPI_MCU_JOYPAD). The driver serves the analog sticks
-and RGB LEDs found on Anbernic RK35xx handhelds (e.g. the RG Vita Pro),
-where an MCU exposes them over SPI. Driver from ROCKNIX.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
+> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
+> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
+> X-Git-Archeology: > recovered message: > - 12 apply unchanged
+> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
+> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
+> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
+> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
+> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
+> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
+> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
+> X-Git-Archeology:
 ---
+ drivers/input/joystick/Kconfig                 |  2 ++
+ drivers/input/joystick/Makefile                |  1 +
+ drivers/input/joystick/spi-mcu-joypad/Kconfig  | 15 ++++++++++
+ drivers/input/joystick/spi-mcu-joypad/Makefile |  7 +++++
+ 4 files changed, 25 insertions(+)
+
+diff --git a/drivers/input/joystick/Kconfig b/drivers/input/joystick/Kconfig
+index 111111111111..222222222222 100644
 --- a/drivers/input/joystick/Kconfig
 +++ b/drivers/input/joystick/Kconfig
-@@ -364,6 +364,8 @@
+@@ -364,6 +364,8 @@ config JOYSTICK_PSXPAD_SPI_FF
  
  	  To drive rumble motor a dedicated power supply is required.
  
@@ -20,9 +51,11 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
  config JOYSTICK_PXRC
  	tristate "PhoenixRC Flight Controller Adapter"
  	depends on USB_ARCH_HAS_HCD
+diff --git a/drivers/input/joystick/Makefile b/drivers/input/joystick/Makefile
+index 111111111111..222222222222 100644
 --- a/drivers/input/joystick/Makefile
 +++ b/drivers/input/joystick/Makefile
-@@ -26,6 +26,7 @@
+@@ -26,6 +26,7 @@ obj-$(CONFIG_JOYSTICK_MAGELLAN)		+= magellan.o
  obj-$(CONFIG_JOYSTICK_MAPLE)		+= maplecontrol.o
  obj-$(CONFIG_JOYSTICK_N64)		+= n64joy.o
  obj-$(CONFIG_JOYSTICK_PSXPAD_SPI)	+= psxpad-spi.o
@@ -30,7 +63,10 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
  obj-$(CONFIG_JOYSTICK_PXRC)		+= pxrc.o
  obj-$(CONFIG_JOYSTICK_QWIIC)		+= qwiic-joystick.o
  obj-$(CONFIG_JOYSTICK_SEESAW)		+= adafruit-seesaw.o
---- a/drivers/input/joystick/spi-mcu-joypad/Kconfig
+diff --git a/drivers/input/joystick/spi-mcu-joypad/Kconfig b/drivers/input/joystick/spi-mcu-joypad/Kconfig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
 +++ b/drivers/input/joystick/spi-mcu-joypad/Kconfig
 @@ -0,0 +1,15 @@
 +# SPDX-License-Identifier: GPL-2.0-only
@@ -48,7 +84,10 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +
 +	  To compile this driver as a module, choose M here: the
 +	  module will be called spi-mcu-joypad.
---- a/drivers/input/joystick/spi-mcu-joypad/Makefile
+diff --git a/drivers/input/joystick/spi-mcu-joypad/Makefile b/drivers/input/joystick/spi-mcu-joypad/Makefile
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
 +++ b/drivers/input/joystick/spi-mcu-joypad/Makefile
 @@ -0,0 +1,7 @@
 +# SPDX-License-Identifier: GPL-2.0-only
@@ -58,3 +97,6 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +
 +obj-$(CONFIG_JOYSTICK_SPI_MCU_JOYPAD)	+= spi-mcu-joypad.o
 +spi-mcu-joypad-y			:= spi-mcu-joypad-core.o spi-mcu-joypad-input.o spi-mcu-joypad-leds.o
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-02-core.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-02-core.patch
@@ -1,15 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] input: joystick: add spi-mcu-joypad core driver
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
+ bleedingedge
 
-Add the core of the SPI MCU joypad driver: the SPI transport, periodic
-polling via delayed_work and RX frame parsing, plus the shared header.
-Input reporting and LED control live in companion files compiled into
-the same module. Matches "anbernic,spi-mcu-joypad" in DT. Driver from
-ROCKNIX.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
+> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
+> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
+> X-Git-Archeology: > recovered message: > - 12 apply unchanged
+> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
+> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
+> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
+> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
+> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
+> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
+> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
+> X-Git-Archeology:
 ---
---- a/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-core.c
+ drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-core.c | 325 ++++++++++
+ drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad.h      | 143 ++++
+ 2 files changed, 468 insertions(+)
+
+diff --git a/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-core.c b/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-core.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
 +++ b/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-core.c
 @@ -0,0 +1,325 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
@@ -337,7 +367,10 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +MODULE_AUTHOR("ROCKNIX");
 +MODULE_DESCRIPTION("SPI MCU Joypad — analog sticks and RGB LEDs");
 +MODULE_LICENSE("GPL");
---- a/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad.h
+diff --git a/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad.h b/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad.h
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
 +++ b/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad.h
 @@ -0,0 +1,143 @@
 +/* SPDX-License-Identifier: GPL-2.0-or-later */
@@ -483,3 +516,6 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +void mcu_joypad_leds_suspend(struct mcu_joypad *mjp);
 +
 +#endif /* _SPI_MCU_JOYPAD_H */
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-02-core.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-02-core.patch
@@ -1,36 +1,15 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
- bleedingedge
+Subject: input: joystick: add spi-mcu-joypad core driver
 
-> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
-> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
-> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
-> X-Git-Archeology: > recovered message: > - 12 apply unchanged
-> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
-> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
-> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
-> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
-> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
-> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
-> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
-> X-Git-Archeology:
+Add the core of the SPI MCU joypad driver: the SPI transport, periodic
+polling via delayed_work and RX frame parsing, plus the shared header.
+Input reporting and LED control live in companion files compiled into
+the same module. Matches "anbernic,spi-mcu-joypad" in DT. Driver from
+ROCKNIX.
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-core.c | 325 ++++++++++
  drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad.h      | 143 ++++

--- a/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-03-input.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-03-input.patch
@@ -1,36 +1,12 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
- bleedingedge
+Subject: input: joystick: spi-mcu-joypad - input device
 
-> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
-> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
-> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
-> X-Git-Archeology: > recovered message: > - 12 apply unchanged
-> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
-> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
-> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
-> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
-> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
-> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
-> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
-> X-Git-Archeology:
+Register the input_dev and report the six analog axes decoded from the
+MCU frames. Part of the spi-mcu-joypad module. Driver from ROCKNIX.
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-input.c | 424 ++++++++++
  1 file changed, 424 insertions(+)

--- a/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-03-input.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-03-input.patch
@@ -1,12 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] input: joystick: spi-mcu-joypad - input device
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
+ bleedingedge
 
-Register the input_dev and report the six analog axes decoded from the
-MCU frames. Part of the spi-mcu-joypad module. Driver from ROCKNIX.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
+> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
+> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
+> X-Git-Archeology: > recovered message: > - 12 apply unchanged
+> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
+> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
+> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
+> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
+> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
+> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
+> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
+> X-Git-Archeology:
 ---
---- a/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-input.c
+ drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-input.c | 424 ++++++++++
+ 1 file changed, 424 insertions(+)
+
+diff --git a/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-input.c b/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-input.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
 +++ b/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-input.c
 @@ -0,0 +1,424 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
@@ -433,3 +465,6 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +
 +	return 0;
 +}
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-04-leds.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-04-leds.patch
@@ -1,36 +1,13 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
- bleedingedge
+Subject: input: joystick: spi-mcu-joypad - multicolor LED rings
 
-> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
-> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
-> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
-> X-Git-Archeology: > recovered message: > - 12 apply unchanged
-> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
-> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
-> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
-> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
-> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
-> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
-> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
-> X-Git-Archeology:
+Expose the two RGB LED rings (one per stick) via the multicolor LED
+class, driven over the same SPI MCU link. Part of the spi-mcu-joypad
+module (needs LEDS_CLASS_MULTICOLOR). Driver from ROCKNIX.
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-leds.c | 204 ++++++++++
  1 file changed, 204 insertions(+)

--- a/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-04-leds.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-04-leds.patch
@@ -1,13 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] input: joystick: spi-mcu-joypad - multicolor LED rings
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
+ bleedingedge
 
-Expose the two RGB LED rings (one per stick) via the multicolor LED
-class, driven over the same SPI MCU link. Part of the spi-mcu-joypad
-module (needs LEDS_CLASS_MULTICOLOR). Driver from ROCKNIX.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
+> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
+> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
+> X-Git-Archeology: > recovered message: > - 12 apply unchanged
+> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
+> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
+> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
+> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
+> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
+> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
+> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
+> X-Git-Archeology:
 ---
---- a/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-leds.c
+ drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-leds.c | 204 ++++++++++
+ 1 file changed, 204 insertions(+)
+
+diff --git a/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-leds.c b/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-leds.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
 +++ b/drivers/input/joystick/spi-mcu-joypad/spi-mcu-joypad-leds.c
 @@ -0,0 +1,204 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
@@ -214,3 +245,6 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +
 +	spi_sync_transfer(mjp->spi, &xfer, 1);
 +}
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/general-input-rmi4-reset-gpio.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-input-rmi4-reset-gpio.patch
@@ -1,24 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] Input: synaptics-rmi4 - hard-reset via reset GPIO instead of
- chip-wide SW reset
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
+ bleedingedge
 
-The rmi4 core issues an F01 device reset command (0x01) over i2c during
-probe (rmi_initial_reset). On TDDI modules - touch and display driver in
-a single IC, as on the Anbernic RG Vita Pro (Synaptics BACA281300, which
-shares the vdd_lcd rail with the DSI panel) - that software reset also
-resets the display half of the chip: the LCD loses its DSI init right
-before the login prompt and stays black (backlight on) until the panel
-is re-prepared via a DPMS cycle.
-
-When a dedicated touch reset line is described in DT (reset-gpios),
-install a transport reset op that pulses that GPIO instead, which
-rmi_initial_reset() uses in place of the chip-wide command. Also pulse
-it on resume, and defer probe while the touch IC is not ready.
-
-Patch from ROCKNIX (RK3576 device patch 0008).
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
+> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
+> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
+> X-Git-Archeology: > recovered message: > - 12 apply unchanged
+> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
+> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
+> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
+> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
+> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
+> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
+> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
+> X-Git-Archeology:
 ---
+ drivers/input/rmi4/rmi_i2c.c | 52 +++++++++-
+ 1 file changed, 51 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/input/rmi4/rmi_i2c.c b/drivers/input/rmi4/rmi_i2c.c
+index 111111111111..222222222222 100644
 --- a/drivers/input/rmi4/rmi_i2c.c
 +++ b/drivers/input/rmi4/rmi_i2c.c
 @@ -8,6 +8,7 @@
@@ -37,7 +55,7 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
   */
  struct rmi_i2c_xport {
  	struct rmi_transport_dev xport;
-@@ -40,6 +42,8 @@
+@@ -40,6 +42,8 @@ struct rmi_i2c_xport {
  
  	struct regulator_bulk_data supplies[2];
  	u32 startup_delay;
@@ -46,7 +64,7 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
  };
  
  #define RMI_PAGE_SELECT_REGISTER 0xff
-@@ -198,6 +202,28 @@
+@@ -198,6 +202,28 @@ static void rmi_i2c_unregister_transport(void *data)
  	rmi_unregister_transport_device(&rmi_i2c->xport);
  }
  
@@ -75,7 +93,7 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
  static int rmi_i2c_probe(struct i2c_client *client)
  {
  	struct rmi_device_platform_data *pdata;
-@@ -251,21 +277,43 @@
+@@ -251,21 +277,43 @@ static int rmi_i2c_probe(struct i2c_client *client)
  
  	msleep(rmi_i2c->startup_delay);
  
@@ -98,7 +116,7 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
  
  	i2c_set_clientdata(client, rmi_i2c);
  
- 	/*
++	/*
 +	 * Read reset_delay_ms from DT now so rmi_i2c_reset() can use it
 +	 * before rmi_driver_of_probe() is called later during transport
 +	 * device registration.
@@ -108,7 +126,7 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +
 +	rmi_i2c_reset(rmi_i2c);
 +
-+	/*
+ 	/*
  	 * Setting the page to zero will (a) make sure the PSR is in a
  	 * known state, and (b) make sure we can talk to the device.
  	 */
@@ -120,7 +138,7 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
  		dev_err(&client->dev, "Failed to set page select to 0\n");
  		return error;
  	}
-@@ -315,6 +363,7 @@
+@@ -315,6 +363,7 @@ static int rmi_i2c_resume(struct device *dev)
  		return ret;
  
  	msleep(rmi_i2c->startup_delay);
@@ -128,7 +146,7 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
  
  	ret = rmi_driver_resume(rmi_i2c->xport.rmi_dev, true);
  	if (ret)
-@@ -351,6 +400,7 @@
+@@ -351,6 +400,7 @@ static int rmi_i2c_runtime_resume(struct device *dev)
  		return ret;
  
  	msleep(rmi_i2c->startup_delay);
@@ -136,3 +154,6 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
  
  	ret = rmi_driver_resume(rmi_i2c->xport.rmi_dev, false);
  	if (ret)
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/general-input-rmi4-reset-gpio.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-input-rmi4-reset-gpio.patch
@@ -1,36 +1,25 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
- bleedingedge
+Subject: Input: synaptics-rmi4 - hard-reset via reset GPIO instead of
+ chip-wide SW reset
 
-> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
-> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
-> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
-> X-Git-Archeology: > recovered message: > - 12 apply unchanged
-> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
-> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
-> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
-> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
-> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
-> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
-> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
-> X-Git-Archeology:
+The rmi4 core issues an F01 device reset command (0x01) over i2c during
+probe (rmi_initial_reset). On TDDI modules - touch and display driver in
+a single IC, as on the Anbernic RG Vita Pro (Synaptics BACA281300, which
+shares the vdd_lcd rail with the DSI panel) - that software reset also
+resets the display half of the chip: the LCD loses its DSI init right
+before the login prompt and stays black (backlight on) until the panel
+is re-prepared via a DPMS cycle.
+
+When a dedicated touch reset line is described in DT (reset-gpios),
+install a transport reset op that pulses that GPIO instead, which
+rmi_initial_reset() uses in place of the chip-wide command. Also pulse
+it on resume, and defer probe while the touch IC is not ready.
+
+Patch from ROCKNIX (RK3576 device patch 0008).
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/input/rmi4/rmi_i2c.c | 52 +++++++++-
  1 file changed, 51 insertions(+), 1 deletion(-)

--- a/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-cw221x.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-cw221x.patch
@@ -1,46 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] board: anbernic-rg-vita-pro - address review feedback
+Subject: power: supply: add CW221x battery fuel gauge driver
 
-> X-Git-Archeology: > recovered message: > CodeRabbit / maintainer review round:
-> X-Git-Archeology: > recovered message: > - cw221x: return early when the battery-profile property is absent so the
-> X-Git-Archeology: > recovered message: > built-in profile is used instead of failing on a negative devm_kzalloc
-> X-Git-Archeology: > recovered message: > length; check create_singlethread_workqueue() for NULL.
-> X-Git-Archeology: > recovered message: > - generic-dsi panel: check the four devm_kzalloc() calls, stop
-> X-Git-Archeology: > recovered message: > dereferencing the failed drm_mode_duplicate() result, and propagate the
-> X-Git-Archeology: > recovered message: > enable-gpio error instead of swallowing it.
-> X-Git-Archeology: > recovered message: > - pwmv4: use device_set_of_node_from_dev() so the shared OF node is
-> X-Git-Archeology: > recovered message: > reused by the child without detaching it from the MFD parent.
-> X-Git-Archeology: > recovered message: > - Rename the generic DSI panel driver to a ROCKNIX prefix
-> X-Git-Archeology: > recovered message: > (DRM_PANEL_ROCKNIX_GENERIC_DSI, panel-rocknix-generic-dsi.c); the
-> X-Git-Archeology: > recovered message: > "rocknix,generic-dsi" DT compatible is unchanged.
-> X-Git-Archeology: > recovered message: > - vita-offcharge: fix the stale PWRON_MASK example, guard the config
-> X-Git-Archeology: > recovered message: > float() parsing, and add an opt-in charge/CPU trace (LOGFILE=, off by
-> X-Git-Archeology: > recovered message: > default). vita-pad2key-toggle: report a message when systemctl fails.
-> X-Git-Archeology: > recovered message: > - Drop the bogus factory-internal-resistance-micro-ohms = <80> from the
-> X-Git-Archeology: > recovered message: > battery node (no driver consumes it and the value is not physical).
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 802c0f45ecaea6afa72db516ab5bfecab169a2c5: https://github.com/armbian/build/commit/802c0f45ecaea6afa72db516ab5bfecab169a2c5
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - address review feedback
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
-> X-Git-Archeology:
+Add the CellWise CW2215/CW2217/CW2218 fuel gauge driver (I2C; reports
+SoC, voltage, current, temperature, cycle count and SoH). Used for the
+Anbernic RG Vita Pro battery (cellwise,cw221X node with battery-profile
+in the board DT). Driver from ROCKNIX (RK3576 device patch 0006).
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/power/supply/Kconfig          |  14 +
  drivers/power/supply/Makefile         |   1 +

--- a/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-cw221x.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-cw221x.patch
@@ -1,19 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] power: supply: add CW221x battery fuel gauge driver
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] board: anbernic-rg-vita-pro - address review feedback
 
-Add the CellWise CW2215/CW2217/CW2218 fuel gauge driver (I2C; reports
-SoC, voltage, current, temperature, cycle count and SoH). Used for the
-Anbernic RG Vita Pro battery (cellwise,cw221X node with battery-profile
-in the board DT). Driver from ROCKNIX (RK3576 device patch 0006).
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > CodeRabbit / maintainer review round:
+> X-Git-Archeology: > recovered message: > - cw221x: return early when the battery-profile property is absent so the
+> X-Git-Archeology: > recovered message: > built-in profile is used instead of failing on a negative devm_kzalloc
+> X-Git-Archeology: > recovered message: > length; check create_singlethread_workqueue() for NULL.
+> X-Git-Archeology: > recovered message: > - generic-dsi panel: check the four devm_kzalloc() calls, stop
+> X-Git-Archeology: > recovered message: > dereferencing the failed drm_mode_duplicate() result, and propagate the
+> X-Git-Archeology: > recovered message: > enable-gpio error instead of swallowing it.
+> X-Git-Archeology: > recovered message: > - pwmv4: use device_set_of_node_from_dev() so the shared OF node is
+> X-Git-Archeology: > recovered message: > reused by the child without detaching it from the MFD parent.
+> X-Git-Archeology: > recovered message: > - Rename the generic DSI panel driver to a ROCKNIX prefix
+> X-Git-Archeology: > recovered message: > (DRM_PANEL_ROCKNIX_GENERIC_DSI, panel-rocknix-generic-dsi.c); the
+> X-Git-Archeology: > recovered message: > "rocknix,generic-dsi" DT compatible is unchanged.
+> X-Git-Archeology: > recovered message: > - vita-offcharge: fix the stale PWRON_MASK example, guard the config
+> X-Git-Archeology: > recovered message: > float() parsing, and add an opt-in charge/CPU trace (LOGFILE=, off by
+> X-Git-Archeology: > recovered message: > default). vita-pad2key-toggle: report a message when systemctl fails.
+> X-Git-Archeology: > recovered message: > - Drop the bogus factory-internal-resistance-micro-ohms = <80> from the
+> X-Git-Archeology: > recovered message: > battery node (no driver consumes it and the value is not physical).
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 802c0f45ecaea6afa72db516ab5bfecab169a2c5: https://github.com/armbian/build/commit/802c0f45ecaea6afa72db516ab5bfecab169a2c5
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - address review feedback
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
+> X-Git-Archeology:
 ---
+ drivers/power/supply/Kconfig          |  14 +
+ drivers/power/supply/Makefile         |   1 +
+ drivers/power/supply/cw221x_battery.c | 958 ++++++++++
+ 3 files changed, 973 insertions(+)
+
+diff --git a/drivers/power/supply/Kconfig b/drivers/power/supply/Kconfig
+index 111111111111..222222222222 100644
 --- a/drivers/power/supply/Kconfig
 +++ b/drivers/power/supply/Kconfig
-@@ -138,6 +138,20 @@ config BATTERY_CW2015
+@@ -141,6 +141,20 @@ config BATTERY_CW2015
  	  This driver can also be built as a module. If so, the module will be
  	  called cw2015_battery.
-
+ 
 +config BATTERY_CW221X
 +	tristate "CW221x Battery Fuel Gauge"
 +	depends on I2C
@@ -31,15 +72,21 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
  config BATTERY_DS2760
  	tristate "DS2760 battery driver (HP iPAQ & others)"
  	depends on W1
+diff --git a/drivers/power/supply/Makefile b/drivers/power/supply/Makefile
+index 111111111111..222222222222 100644
 --- a/drivers/power/supply/Makefile
 +++ b/drivers/power/supply/Makefile
-@@ -27,5 +27,6 @@ obj-$(CONFIG_BATTERY_CHAGALL)	+= chagall-battery.o
+@@ -27,6 +27,7 @@ obj-$(CONFIG_CHARGER_AXP20X)	+= axp20x_ac_power.o
+ obj-$(CONFIG_BATTERY_CHAGALL)	+= chagall-battery.o
  obj-$(CONFIG_BATTERY_CPCAP)	+= cpcap-battery.o
  obj-$(CONFIG_BATTERY_CW2015)	+= cw2015_battery.o
 +obj-$(CONFIG_BATTERY_CW221X)	+= cw221x_battery.o
  obj-$(CONFIG_BATTERY_DS2760)	+= ds2760_battery.o
  obj-$(CONFIG_BATTERY_DS2780)	+= ds2780_battery.o
  obj-$(CONFIG_BATTERY_DS2781)	+= ds2781_battery.o
+diff --git a/drivers/power/supply/cw221x_battery.c b/drivers/power/supply/cw221x_battery.c
+new file mode 100644
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/power/supply/cw221x_battery.c
 @@ -0,0 +1,958 @@
@@ -1001,3 +1048,6 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +MODULE_AUTHOR("Xu Shengfei <xsf@rock-chips.com>");
 +MODULE_DESCRIPTION("CW221X FGADC Device Driver V0.1");
 +MODULE_LICENSE("GPL");
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-sgm41542.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-sgm41542.patch
@@ -1,41 +1,15 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] board: anbernic-rg-vita-pro - sgm41542: fix charging
- from a plugged-in charger and harden probe
+Subject: power: supply: add SGM41542 charger driver
 
-> X-Git-Archeology: > recovered message: > When the board is powered on by plugging in the charger (the off-charge
-> X-Git-Archeology: > recovered message: > path), VBUS is already present at probe and no attach interrupt arrives,
-> X-Git-Archeology: > recovered message: > so the input current limit was left at the 500mA USB default and the
-> X-Git-Archeology: > recovered message: > battery charged at ~350mA. Factor the charger-type -> input-limit
-> X-Git-Archeology: > recovered message: > selection into a helper and call it from probe when VBUS is already
-> X-Git-Archeology: > recovered message: > present, so charging comes up at the full 2.4A (measured ~7%/h -> ~46%/h).
-> X-Git-Archeology: > recovered message: > Also address review feedback in the same driver: route the OTG setup
-> X-Git-Archeology: > recovered message: > failures through error_out instead of returning early (which skipped
-> X-Git-Archeology: > recovered message: > unregister_pm_notifier), check alloc_ordered_workqueue() for NULL, and
-> X-Git-Archeology: > recovered message: > arm the charge watchdog with 40 seconds rather than the register bit
-> X-Git-Archeology: > recovered message: > value (which selected the 160s timeout).
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 109daedcb9c03d9130bb5279b9295ec8cd4fc497: https://github.com/armbian/build/commit/109daedcb9c03d9130bb5279b9295ec8cd4fc497
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - sgm41542: fix charging from a plugged-in charger and harden probe
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
-> X-Git-Archeology:
+Add the SGMICRO SGM41542 single-cell Li-ion charger driver (I2C; OTG
+VBUS regulator, input DPM, watchdog, NTC monitoring). Used by the
+Anbernic RG Vita Pro (sgm,sgm41542 node, provides vbus5v0_typec).
+Driver from ROCKNIX (RK3576 device patch 0007); Kconfig/Makefile hunks
+regenerated against linux 7.2.
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/power/supply/Kconfig            |   11 +
  drivers/power/supply/Makefile           |    1 +

--- a/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-sgm41542.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-sgm41542.patch
@@ -1,16 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] power: supply: add SGM41542 charger driver
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] board: anbernic-rg-vita-pro - sgm41542: fix charging
+ from a plugged-in charger and harden probe
 
-Add the SGMICRO SGM41542 single-cell Li-ion charger driver (I2C; OTG
-VBUS regulator, input DPM, watchdog, NTC monitoring). Used by the
-Anbernic RG Vita Pro (sgm,sgm41542 node, provides vbus5v0_typec).
-Driver from ROCKNIX (RK3576 device patch 0007); Kconfig/Makefile hunks
-regenerated against linux 7.2.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > When the board is powered on by plugging in the charger (the off-charge
+> X-Git-Archeology: > recovered message: > path), VBUS is already present at probe and no attach interrupt arrives,
+> X-Git-Archeology: > recovered message: > so the input current limit was left at the 500mA USB default and the
+> X-Git-Archeology: > recovered message: > battery charged at ~350mA. Factor the charger-type -> input-limit
+> X-Git-Archeology: > recovered message: > selection into a helper and call it from probe when VBUS is already
+> X-Git-Archeology: > recovered message: > present, so charging comes up at the full 2.4A (measured ~7%/h -> ~46%/h).
+> X-Git-Archeology: > recovered message: > Also address review feedback in the same driver: route the OTG setup
+> X-Git-Archeology: > recovered message: > failures through error_out instead of returning early (which skipped
+> X-Git-Archeology: > recovered message: > unregister_pm_notifier), check alloc_ordered_workqueue() for NULL, and
+> X-Git-Archeology: > recovered message: > arm the charge watchdog with 40 seconds rather than the register bit
+> X-Git-Archeology: > recovered message: > value (which selected the 160s timeout).
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 109daedcb9c03d9130bb5279b9295ec8cd4fc497: https://github.com/armbian/build/commit/109daedcb9c03d9130bb5279b9295ec8cd4fc497
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - sgm41542: fix charging from a plugged-in charger and harden probe
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
+> X-Git-Archeology:
 ---
+ drivers/power/supply/Kconfig            |   11 +
+ drivers/power/supply/Makefile           |    1 +
+ drivers/power/supply/sgm41542_charger.c | 1419 ++++++++++
+ 3 files changed, 1431 insertions(+)
+
 diff --git a/drivers/power/supply/Kconfig b/drivers/power/supply/Kconfig
-index f35e037..8ae8ff5 100644
+index 111111111111..222222222222 100644
 --- a/drivers/power/supply/Kconfig
 +++ b/drivers/power/supply/Kconfig
 @@ -880,6 +880,17 @@ config CHARGER_S2M
@@ -32,7 +65,7 @@ index f35e037..8ae8ff5 100644
  	tristate "Summit Microelectronics SMB3XX Battery Charger"
  	depends on I2C
 diff --git a/drivers/power/supply/Makefile b/drivers/power/supply/Makefile
-index ff0450f..3b01e00 100644
+index 111111111111..222222222222 100644
 --- a/drivers/power/supply/Makefile
 +++ b/drivers/power/supply/Makefile
 @@ -109,6 +109,7 @@ obj-$(CONFIG_CHARGER_BQ25980)	+= bq25980_charger.o
@@ -45,7 +78,7 @@ index ff0450f..3b01e00 100644
  obj-$(CONFIG_CHARGER_TPS65217)	+= tps65217_charger.o
 diff --git a/drivers/power/supply/sgm41542_charger.c b/drivers/power/supply/sgm41542_charger.c
 new file mode 100644
-index 0000000..b438237
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/power/supply/sgm41542_charger.c
 @@ -0,0 +1,1419 @@
@@ -1468,3 +1501,6 @@ index 0000000..b438237
 +MODULE_AUTHOR("Xu Shengfei <xsf@rock-chips.com>");
 +MODULE_DESCRIPTION("sgm4154x charger driver");
 +MODULE_LICENSE("GPL");
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/general-usb-typec-rt1711h-add-husb311.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-usb-typec-rt1711h-add-husb311.patch
@@ -1,36 +1,19 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
- bleedingedge
+Subject: usb: typec: tcpci_rt1711h: add Hynetek HUSB311 IDs
 
-> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
-> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
-> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
-> X-Git-Archeology: > recovered message: > - 12 apply unchanged
-> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
-> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
-> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
-> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
-> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
-> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
-> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
-> X-Git-Archeology:
+The Hynetek HUSB311 is a pin- and register-compatible drop-in
+replacement for the Richtek RT1711H (same approach as the existing
+etekmicro ET7304 entry; the driver no longer verifies VID/PID, so only
+ID-table entries are needed). Used as the USB-C port controller on the
+Anbernic RG Vita Pro (hynetek,husb311 node in the board DT), providing
+role and orientation switching for the usb_drd0/usbdp-phy port.
+
+Based on ROCKNIX RK3576 device patch 0005 by Alexey Charkov, reduced to
+what linux 7.2 still needs.
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/usb/typec/tcpm/tcpci_rt1711h.c | 2 ++
  1 file changed, 2 insertions(+)

--- a/patch/kernel/archive/rockchip64-7.2/general-usb-typec-rt1711h-add-husb311.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-usb-typec-rt1711h-add-husb311.patch
@@ -1,23 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] usb: typec: tcpci_rt1711h: add Hynetek HUSB311 IDs
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
+ bleedingedge
 
-The Hynetek HUSB311 is a pin- and register-compatible drop-in
-replacement for the Richtek RT1711H (same approach as the existing
-etekmicro ET7304 entry; the driver no longer verifies VID/PID, so only
-ID-table entries are needed). Used as the USB-C port controller on the
-Anbernic RG Vita Pro (hynetek,husb311 node in the board DT), providing
-role and orientation switching for the usb_drd0/usbdp-phy port.
-
-Based on ROCKNIX RK3576 device patch 0005 by Alexey Charkov, reduced to
-what linux 7.2 still needs.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
+> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
+> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
+> X-Git-Archeology: > recovered message: > - 12 apply unchanged
+> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
+> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
+> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
+> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
+> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
+> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
+> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8: https://github.com/armbian/build/commit/e67caa6ddb85f5a6191fdfb3d462c10c3ba5cee8
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: device drivers for Anbernic RG Vita Pro
+> X-Git-Archeology:
 ---
+ drivers/usb/typec/tcpm/tcpci_rt1711h.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
 diff --git a/drivers/usb/typec/tcpm/tcpci_rt1711h.c b/drivers/usb/typec/tcpm/tcpci_rt1711h.c
-index 9d3b1fc..0a7e034 100644
+index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/tcpm/tcpci_rt1711h.c
 +++ b/drivers/usb/typec/tcpm/tcpci_rt1711h.c
-@@ -373,6 +373,7 @@ static const struct rt1711h_chip_info rt1715 = {
+@@ -377,6 +377,7 @@ static const struct rt1711h_chip_info rt1715 = {
  
  static const struct i2c_device_id rt1711h_id[] = {
  	{ .name = "et7304", .driver_data = (kernel_ulong_t)&rt1715 },
@@ -25,7 +47,7 @@ index 9d3b1fc..0a7e034 100644
  	{ .name = "rt1711h", .driver_data = (kernel_ulong_t)&rt1711h },
  	{ .name = "rt1715", .driver_data = (kernel_ulong_t)&rt1715 },
  	{ }
-@@ -381,6 +382,7 @@ MODULE_DEVICE_TABLE(i2c, rt1711h_id);
+@@ -385,6 +386,7 @@ MODULE_DEVICE_TABLE(i2c, rt1711h_id);
  
  static const struct of_device_id rt1711h_of_match[] = {
  	{ .compatible = "etekmicro,et7304", .data = &rt1715 },
@@ -33,3 +55,6 @@ index 9d3b1fc..0a7e034 100644
  	{ .compatible = "richtek,rt1711h", .data = &rt1711h },
  	{ .compatible = "richtek,rt1715", .data = &rt1715 },
  	{}
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/rk3328-add-dmc-driver.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3328-add-dmc-driver.patch
@@ -6,19 +6,19 @@ Subject: rk3328 dmc driver
 ---
  arch/arm64/boot/dts/rockchip/rk3328-dram-default-timing.dtsi | 311 ++++
  arch/arm64/boot/dts/rockchip/rk3328.dtsi                     |  61 +
- drivers/clk/rockchip/clk-ddr.c                               | 130 ++
+ drivers/clk/rockchip/clk-ddr.c                               | 133 ++
  drivers/clk/rockchip/clk-rk3328.c                            |  13 +-
  drivers/clk/rockchip/clk.h                                   |   3 +-
  drivers/devfreq/Kconfig                                      |  12 +
  drivers/devfreq/Makefile                                     |   1 +
- drivers/devfreq/event/rockchip-dfi.c                         |  77 +-
+ drivers/devfreq/event/rockchip-dfi.c                         |  82 +-
  drivers/devfreq/rk3328_dmc.c                                 | 836 ++++++++++
  include/dt-bindings/clock/rockchip-ddr.h                     |  63 +
  include/dt-bindings/memory/rk3328-dram.h                     | 159 ++
  include/soc/rockchip/rk3228_grf.h                            |  14 +
  include/soc/rockchip/rk3328_grf.h                            |  14 +
  include/soc/rockchip/rockchip_sip.h                          |  11 +
- 14 files changed, 1691 insertions(+), 14 deletions(-)
+ 14 files changed, 1696 insertions(+), 17 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-dram-default-timing.dtsi b/arch/arm64/boot/dts/rockchip/rk3328-dram-default-timing.dtsi
 new file mode 100644
@@ -410,7 +410,7 @@ index 111111111111..222222222222 100644
  		compatible = "rockchip,rk3328-efuse";
  		reg = <0x0 0xff260000 0x0 0x50>;
 diff --git a/drivers/clk/rockchip/clk-ddr.c b/drivers/clk/rockchip/clk-ddr.c
-index 81ae8a4ee30e..42dd7a37aa16 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/rockchip/clk-ddr.c
 +++ b/drivers/clk/rockchip/clk-ddr.c
 @@ -88,6 +88,136 @@ static const struct clk_ops rockchip_ddrclk_sip_ops = {
@@ -636,7 +636,7 @@ index 111111111111..222222222222 100644
  obj-$(CONFIG_ARM_TEGRA_DEVFREQ)		+= tegra30-devfreq.o
  
 diff --git a/drivers/devfreq/event/rockchip-dfi.c b/drivers/devfreq/event/rockchip-dfi.c
-index 5e6e7e900bda..ade65e839c93 100644
+index 111111111111..222222222222 100644
 --- a/drivers/devfreq/event/rockchip-dfi.c
 +++ b/drivers/devfreq/event/rockchip-dfi.c
 @@ -25,6 +25,8 @@

--- a/patch/kernel/archive/rockchip64-7.2/rk3528-net-dsa-realtek-fixes-for-radxa-e24c-switch-chip.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3528-net-dsa-realtek-fixes-for-radxa-e24c-switch-chip.patch
@@ -31,7 +31,7 @@ diff --git a/drivers/net/dsa/realtek/rtl83xx.c b/drivers/net/dsa/realtek/rtl83xx
 index 111111111111..222222222222 100644
 --- a/drivers/net/dsa/realtek/rtl83xx.c
 +++ b/drivers/net/dsa/realtek/rtl83xx.c
-@@ -188,17 +188,18 @@ rtl83xx_probe(struct device *dev,
+@@ -196,17 +196,18 @@ rtl83xx_probe(struct device *dev,
  						    "realtek,disable-leds");
  
  	/* TODO: if power is software controlled, set up any regulators here */

--- a/patch/kernel/archive/rockchip64-7.2/rk3576-0010-drm-rockchip-vop2-fix-gamma-lut-write-mask.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3576-0010-drm-rockchip-vop2-fix-gamma-lut-write-mask.patch
@@ -1,36 +1,23 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
- bleedingedge
+Subject: drm/rockchip: vop2: fix gamma LUT port select on rk3576
 
-> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
-> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
-> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
-> X-Git-Archeology: > recovered message: > - 12 apply unchanged
-> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
-> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
-> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
-> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
-> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
-> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
-> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 583284679ebeb601fcb93f55fd774bd88fc859a0: https://github.com/armbian/build/commit/583284679ebeb601fcb93f55fd774bd88fc859a0
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: rk3576 VOP2/DP generic fixes
-> X-Git-Archeology:
+On rk3576 the LUT_PORT_SEL register (0x058) is a write-masked register
+(bits [31:16] are a write-enable mask for bits [15:0]), unlike rk3588
+where it is a plain register - the vendor driver marks it VOP_REG_MASK
+for rk3576 only. The seamless gamma path does a plain write, which the
+hardware silently ignores: the AHB write port stays at VP0, the LUT data
+lands in VP0's table, and the video port being configured gets its
+never-initialized LUT enabled instead. On the Anbernic RG Vita Pro
+(panel on VP1) this shows up as psychedelic rainbow gamma corruption in
+any session that programs legacy gamma (Xorg does on every startup;
+fbcon and wayland-after-settling do not, which is why only X11 looked
+broken).
+
+Set the write-enable bits when the VOP is an rk3576.
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/gpu/drm/rockchip/rockchip_drm_vop2.c | 15 ++++++++--
  1 file changed, 13 insertions(+), 2 deletions(-)

--- a/patch/kernel/archive/rockchip64-7.2/rk3576-0010-drm-rockchip-vop2-fix-gamma-lut-write-mask.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3576-0010-drm-rockchip-vop2-fix-gamma-lut-write-mask.patch
@@ -1,24 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] drm/rockchip: vop2: fix gamma LUT port select on rk3576
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
+ bleedingedge
 
-On rk3576 the LUT_PORT_SEL register (0x058) is a write-masked register
-(bits [31:16] are a write-enable mask for bits [15:0]), unlike rk3588
-where it is a plain register - the vendor driver marks it VOP_REG_MASK
-for rk3576 only. The seamless gamma path does a plain write, which the
-hardware silently ignores: the AHB write port stays at VP0, the LUT data
-lands in VP0's table, and the video port being configured gets its
-never-initialized LUT enabled instead. On the Anbernic RG Vita Pro
-(panel on VP1) this shows up as psychedelic rainbow gamma corruption in
-any session that programs legacy gamma (Xorg does on every startup;
-fbcon and wayland-after-settling do not, which is why only X11 looked
-broken).
-
-Set the write-enable bits when the VOP is an rk3576.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
+> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
+> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
+> X-Git-Archeology: > recovered message: > - 12 apply unchanged
+> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
+> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
+> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
+> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
+> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
+> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
+> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 583284679ebeb601fcb93f55fd774bd88fc859a0: https://github.com/armbian/build/commit/583284679ebeb601fcb93f55fd774bd88fc859a0
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: rk3576 VOP2/DP generic fixes
+> X-Git-Archeology:
 ---
+ drivers/gpu/drm/rockchip/rockchip_drm_vop2.c | 15 ++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
 diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
-index 843c7ef..33dce5a 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
 +++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
 @@ -1475,8 +1475,19 @@ static void vop2_crtc_atomic_set_gamma_seamless(struct vop2 *vop2,
@@ -43,3 +61,6 @@ index 843c7ef..33dce5a 100644
  	vop2_vp_dsp_lut_enable(vp);
  	vop2_crtc_write_gamma_lut(vop2, crtc);
  	vop2_vp_dsp_lut_update_enable(vp);
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/rk3576-0011-drm-rockchip-vop2-vp2-primary-plane.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3576-0011-drm-rockchip-vop2-vp2-primary-plane.patch
@@ -1,38 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] drm/rockchip: vop2: give RK3576 VP2 a primary plane
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
+ bleedingedge
 
-The RK3576 VOP2 has three video ports: VP0 and VP1 each have a
-Cluster window as their primary plane, but VP2 (the one connected to
-the DesignWare DP controller) has only Esmart windows available, all
-of which are typed DRM_PLANE_TYPE_OVERLAY.  The VOP2 driver requires
-every active VP to have a DRM_PLANE_TYPE_PRIMARY plane; without one it
-returns -ENOENT and the entire VOP2 bind fails, taking down the whole
-display subsystem.
-
-Promote Esmart0 to DRM_PLANE_TYPE_PRIMARY.  This is safe because:
-- Esmart0's layer_sel_id[2] = 0 (valid VP2 layer slot)
-- VP0 still has Cluster0 as primary and retains Esmart2 as overlay
-
-Resulting plane assignment:
-  VP0: primary=Cluster0, overlay=Esmart2
-  VP1: primary=Cluster1, overlays=Esmart1, Esmart3
-  VP2: primary=Esmart0,  overlays=Esmart1, Esmart2, Esmart3
-
-Based on ROCKNIX RK3576 device patch 0015, reduced: the second half
-of that patch (forcing if_pixclk_div=0 for DP in rk3576_set_intf_mux)
-is intentionally NOT applied - mainline pairs the divider with
-DW_DP_MP_DUAL_PIXEL in rk3576_dp_plat_data instead, which is an
-equivalent but different consistent configuration.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
+> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
+> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
+> X-Git-Archeology: > recovered message: > - 12 apply unchanged
+> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
+> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
+> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
+> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
+> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
+> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
+> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 583284679ebeb601fcb93f55fd774bd88fc859a0: https://github.com/armbian/build/commit/583284679ebeb601fcb93f55fd774bd88fc859a0
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: rk3576 VOP2/DP generic fixes
+> X-Git-Archeology:
 ---
  drivers/gpu/drm/rockchip/rockchip_vop2_reg.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/rockchip/rockchip_vop2_reg.c b/drivers/gpu/drm/rockchip/rockchip_vop2_reg.c
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/rockchip/rockchip_vop2_reg.c
 +++ b/drivers/gpu/drm/rockchip/rockchip_vop2_reg.c
-@@ -895,7 +895,7 @@
+@@ -894,7 +894,7 @@ static const struct vop2_win_data rk3576_vop_win_data[] = {
  		.format_modifiers = format_modifiers,
  		.layer_sel_id = { 2, 0xf, 0, 0xf },
  		.supported_rotations = DRM_MODE_REFLECT_Y,
@@ -41,3 +48,6 @@ diff --git a/drivers/gpu/drm/rockchip/rockchip_vop2_reg.c b/drivers/gpu/drm/rock
  		.axi_bus_id = 0,
  		.axi_yrgb_r_id = 0x10,
  		.axi_uv_r_id = 0x11,
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/rk3576-0011-drm-rockchip-vop2-vp2-primary-plane.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3576-0011-drm-rockchip-vop2-vp2-primary-plane.patch
@@ -1,36 +1,32 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
- bleedingedge
+Subject: drm/rockchip: vop2: give RK3576 VP2 a primary plane
 
-> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
-> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
-> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
-> X-Git-Archeology: > recovered message: > - 12 apply unchanged
-> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
-> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
-> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
-> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
-> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
-> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
-> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 583284679ebeb601fcb93f55fd774bd88fc859a0: https://github.com/armbian/build/commit/583284679ebeb601fcb93f55fd774bd88fc859a0
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: rk3576 VOP2/DP generic fixes
-> X-Git-Archeology:
+The RK3576 VOP2 has three video ports: VP0 and VP1 each have a
+Cluster window as their primary plane, but VP2 (the one connected to
+the DesignWare DP controller) has only Esmart windows available, all
+of which are typed DRM_PLANE_TYPE_OVERLAY.  The VOP2 driver requires
+every active VP to have a DRM_PLANE_TYPE_PRIMARY plane; without one it
+returns -ENOENT and the entire VOP2 bind fails, taking down the whole
+display subsystem.
+
+Promote Esmart0 to DRM_PLANE_TYPE_PRIMARY.  This is safe because:
+- Esmart0's layer_sel_id[2] = 0 (valid VP2 layer slot)
+- VP0 still has Cluster0 as primary and retains Esmart2 as overlay
+
+Resulting plane assignment:
+  VP0: primary=Cluster0, overlay=Esmart2
+  VP1: primary=Cluster1, overlays=Esmart1, Esmart3
+  VP2: primary=Esmart0,  overlays=Esmart1, Esmart2, Esmart3
+
+Based on ROCKNIX RK3576 device patch 0015, reduced: the second half
+of that patch (forcing if_pixclk_div=0 for DP in rk3576_set_intf_mux)
+is intentionally NOT applied - mainline pairs the divider with
+DW_DP_MP_DUAL_PIXEL in rk3576_dp_plat_data instead, which is an
+equivalent but different consistent configuration.
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/gpu/drm/rockchip/rockchip_vop2_reg.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/patch/kernel/archive/rockchip64-7.2/rk3576-0012-phy-rockchip-usbdp-replay-hpd-on-dp-phy-init.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3576-0012-phy-rockchip-usbdp-replay-hpd-on-dp-phy-init.patch
@@ -1,36 +1,21 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
- bleedingedge
+Subject: phy: rockchip: usbdp: replay HPD state on DP PHY init
 
-> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
-> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
-> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
-> X-Git-Archeology: > recovered message: > - 12 apply unchanged
-> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
-> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
-> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
-> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
-> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
-> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
-> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 583284679ebeb601fcb93f55fd774bd88fc859a0: https://github.com/armbian/build/commit/583284679ebeb601fcb93f55fd774bd88fc859a0
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: rockchip64-edge: rk3576 VOP2/DP generic fixes
-> X-Git-Archeology:
+When a USB-C DP Alt Mode display is already connected before the DP
+PHY is initialized (TCPM negotiates the alt mode at boot, before the
+DesignWare DP bridge finishes probing), the HPD notification arrives
+while dp_in_use is still false and rk_udphy_dp_hpd_event_trigger()
+only records it in dp_sink_hpd_sel/dp_sink_hpd_cfg without writing the
+VOGRF HPD trigger. Nothing replays that state later, so the DP
+controller never sees an HPD edge and displays connected at boot stay
+invisible until the cable is re-plugged.
+
+Replay the saved HPD state once dp_in_use is set in
+rk_udphy_dp_phy_init(). Based on ROCKNIX RK3576 device patch 0018.
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/phy/rockchip/phy-rockchip-usbdp.c | 4 ++++
  1 file changed, 4 insertions(+)

--- a/patch/kernel/archive/rockchip64-7.2/rk3576-0012-phy-rockchip-usbdp-replay-hpd-on-dp-phy-init.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3576-0012-phy-rockchip-usbdp-replay-hpd-on-dp-phy-init.patch
@@ -1,25 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] phy: rockchip: usbdp: replay HPD state on DP PHY init
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] rockchip64-7.2: carry Anbernic RG Vita Pro patches to
+ bleedingedge
 
-When a USB-C DP Alt Mode display is already connected before the DP
-PHY is initialized (TCPM negotiates the alt mode at boot, before the
-DesignWare DP bridge finishes probing), the HPD notification arrives
-while dp_in_use is still false and rk_udphy_dp_hpd_event_trigger()
-only records it in dp_sink_hpd_sel/dp_sink_hpd_cfg without writing the
-VOGRF HPD trigger. Nothing replays that state later, so the DP
-controller never sees an HPD edge and displays connected at boot stay
-invisible until the cable is re-plugged.
-
-Replay the saved HPD state once dp_in_use is set in
-rk_udphy_dp_phy_init(). Based on ROCKNIX RK3576 device patch 0018.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Review feedback: also target v7.2 so the board and the rk3576 fixes are
+> X-Git-Archeology: > recovered message: > not lost when 7.2 becomes edge. Same 14 patches as rockchip64-7.1 plus
+> X-Git-Archeology: > recovered message: > the board DTS; verified to apply against current mainline (7.2-rc):
+> X-Git-Archeology: > recovered message: > - 12 apply unchanged
+> X-Git-Archeology: > recovered message: > - general-power-supply-add-sgm41542: Kconfig/Makefile contexts
+> X-Git-Archeology: > recovered message: > regenerated (new CHARGER_S2M entries landed next to the anchor)
+> X-Git-Archeology: > recovered message: > - general-usb-typec-rt1711h-add-husb311: regenerated for the new
+> X-Git-Archeology: > recovered message: > designated-initializer style of the rt1711h ID tables
+> X-Git-Archeology: > recovered message: > The board DTS needs no changes for 7.2 (all referenced dtsi/pinctrl
+> X-Git-Archeology: > recovered message: > labels still exist, no node collisions). The kernel config additions
+> X-Git-Archeology: > recovered message: > mirror linux-rockchip64-edge.config.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 1845d2b3d9259e6d6aad7dda325ffa82b9087e2e: https://github.com/armbian/build/commit/1845d2b3d9259e6d6aad7dda325ffa82b9087e2e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.2: carry Anbernic RG Vita Pro patches to bleedingedge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9105fe7e160b72a7baddc2b005ffff5ae642b376: https://github.com/armbian/build/commit/9105fe7e160b72a7baddc2b005ffff5ae642b376
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-7.1: rename Vita patches to match patch naming conventions
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 583284679ebeb601fcb93f55fd774bd88fc859a0: https://github.com/armbian/build/commit/583284679ebeb601fcb93f55fd774bd88fc859a0
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64-edge: rk3576 VOP2/DP generic fixes
+> X-Git-Archeology:
 ---
+ drivers/phy/rockchip/phy-rockchip-usbdp.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
 diff --git a/drivers/phy/rockchip/phy-rockchip-usbdp.c b/drivers/phy/rockchip/phy-rockchip-usbdp.c
-index fba3551..053d3b2 100644
+index 111111111111..222222222222 100644
 --- a/drivers/phy/rockchip/phy-rockchip-usbdp.c
 +++ b/drivers/phy/rockchip/phy-rockchip-usbdp.c
-@@ -1048,6 +1048,10 @@ static int rk_udphy_dp_phy_init(struct phy *phy)
+@@ -1047,6 +1047,10 @@ static int rk_udphy_dp_phy_init(struct phy *phy)
  
  	udphy->dp_in_use = true;
  
@@ -30,3 +50,6 @@ index fba3551..053d3b2 100644
  	mutex_unlock(&udphy->mutex);
  
  	return 0;
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/rk3576-0013-mmc-sdhci-dwcmshc-rk3576-dll-tap-calibration.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3576-0013-mmc-sdhci-dwcmshc-rk3576-dll-tap-calibration.patch
@@ -1,33 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] mmc: sdhci-of-dwcmshc: rk3576: calibrate the HS400 DLL taps
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] board: anbernic-rg-vita-pro - fix eMMC HS400 timeouts
+ (rk3576 DLL calibration)
 
-On dwcmshc revision 1 (rk3576) the HS400 path programs fixed DLL taps
-(TX and CMDOUT at 90 degrees, STRBIN at the generic default) and never
-feeds the measured DLL lock value back into the tap-value select. The
-vendor driver does both: it reads the locked DLL value out of
-DLL_STATUS0 and supplies it as the tap-value select on every DLL clock
-line, and it uses different HS400 taps (TX 7, CMDOUT 7, STRBIN 5) plus
-BOTH_CLK_EDGE rather than EN_SRC_CLK_NEG on CMDOUT.
-
-Without that calibration the HS400 timing has very little margin on this
-SoC. On an Anbernic RG Vita Pro (rk3576, Micron eMMC in HS400-ES at
-200MHz) sustained I/O stalls with
-
-  mmc0: Timeout waiting for hardware interrupt.
-
-for CMD13/CMD18/CMD24 alike - the command or its data phase never
-completes, the block layer stalls for seconds, and a kernel compile or
-a large apt transaction grinds to a halt. Forcing the card down to
-HS200 (by dropping mmc-hs400-1_8v/mmc-hs400-enhanced-strobe from the DT)
-makes the stalls disappear entirely, which points at the HS400 timing
-rather than at the card or the filesystem: the eMMC reports a pristine
-PRE_EOL/LIFE_TIME and fsck finds nothing.
-
-Port the vendor calibration for revision 1 only, leaving revision 0
-(rk3566/rk3568) on its existing fixed taps.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Add a dwcmshc patch that ports the vendor rk3576 HS400 DLL tap
+> X-Git-Archeology: > recovered message: > calibration (revision 1 only): read the locked DLL value from
+> X-Git-Archeology: > recovered message: > DLL_STATUS0 and feed it back as the tap-value select on every DLL clock
+> X-Git-Archeology: > recovered message: > line, use taps 7/7/5 and BOTH_CLK_EDGE on CMDOUT.
+> X-Git-Archeology: > recovered message: > Without it the mainline HS400 timing has almost no margin on this board.
+> X-Git-Archeology: > recovered message: > Under sustained I/O (kernel compile, large apt transaction) the eMMC
+> X-Git-Archeology: > recovered message: > stalls with "mmc0: Timeout waiting for hardware interrupt" on
+> X-Git-Archeology: > recovered message: > CMD13/CMD18/CMD24 and grinds to a halt. Forcing HS200 makes it vanish,
+> X-Git-Archeology: > recovered message: > which pins it on the HS400 timing rather than the card (pristine
+> X-Git-Archeology: > recovered message: > PRE_EOL/LIFE_TIME, clean fsck). With the calibration the card stays in
+> X-Git-Archeology: > recovered message: > HS400-ES at 200MHz and the timeouts are gone.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 2cfa897ddbb543b22945951ede51d64e5808ff9e: https://github.com/armbian/build/commit/2cfa897ddbb543b22945951ede51d64e5808ff9e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - fix eMMC HS400 timeouts (rk3576 DLL calibration)
+> X-Git-Archeology:
 ---
+ drivers/mmc/host/sdhci-of-dwcmshc.c | 44 ++++++++--
+ 1 file changed, 38 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/mmc/host/sdhci-of-dwcmshc.c b/drivers/mmc/host/sdhci-of-dwcmshc.c
+index 111111111111..222222222222 100644
 --- a/drivers/mmc/host/sdhci-of-dwcmshc.c
 +++ b/drivers/mmc/host/sdhci-of-dwcmshc.c
 @@ -117,6 +117,13 @@
@@ -41,29 +40,29 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +#define DLL_TXCLK_TAPNUM_RK3576		0x7
 +#define DLL_CMDOUT_TAPNUM_RK3576	0x7
 +#define DLL_STRBIN_TAPNUM_RK3576	0x5
-
+ 
  #define DLL_LOCK_WO_TMOUT(x) \
  	((((x) & DWCMSHC_EMMC_DLL_LOCKED) == DWCMSHC_EMMC_DLL_LOCKED) && \
-@@ -756,7 +763,7 @@
+@@ -756,7 +763,7 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
  	struct rk35xx_priv *priv = dwc_priv->priv;
  	const struct rockchip_pltfm_data *rockchip_pdata = to_pltfm_data(dwc_priv, rockchip);
  	u8 txclk_tapnum = DLL_TXCLK_TAPNUM_DEFAULT;
 -	u32 extra, reg;
 +	u32 extra, reg, dll_lock_value;
  	int err;
-
+ 
  	host->mmc->actual_clock = 0;
-@@ -842,23 +849,40 @@
+@@ -842,23 +849,40 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
  		goto enable_clk;
  	}
-
+ 
 +	dll_lock_value = ((sdhci_readl(host, DWCMSHC_EMMC_DLL_STATUS0) & 0xFF) * 2) & 0xFF;
 +
  	extra = 0x1 << 16 | /* tune clock stop en */
  		0x3 << 17 | /* pre-change delay */
  		0x3 << 19;  /* post-change delay */
  	sdhci_writel(host, extra, dwc_priv->vendor_specific_area1 + DWCMSHC_EMMC_ATCTRL);
-+
+ 
 +	/*
 +	 * Revision 1 (rk3576) feeds the measured DLL lock value back as the
 +	 * tap-value select on every DLL clock line. Without that calibration
@@ -76,15 +75,15 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +			dll_lock_value << DLL_TAP_VALUE_OFFSET;
 +		sdhci_writel(host, extra, DWCMSHC_EMMC_DLL_RXCLK);
 +	}
-
++
  	if (host->mmc->ios.timing == MMC_TIMING_MMC_HS200 ||
  	    host->mmc->ios.timing == MMC_TIMING_MMC_HS400)
  		txclk_tapnum = priv->txclk_tapnum;
-
+ 
  	if (rockchip_pdata->revision == 1 && host->mmc->ios.timing == MMC_TIMING_MMC_HS400) {
 -		txclk_tapnum = DLL_TXCLK_TAPNUM_90_DEGREES;
 +		txclk_tapnum = DLL_TXCLK_TAPNUM_RK3576;
-
+ 
  		extra = DLL_CMDOUT_SRC_CLK_NEG |
 -			DLL_CMDOUT_EN_SRC_CLK_NEG |
 +			DLL_CMDOUT_BOTH_CLK_EDGE |
@@ -97,8 +96,8 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +			dll_lock_value << DLL_TAP_VALUE_OFFSET;
  		sdhci_writel(host, extra, DECMSHC_EMMC_DLL_CMDOUT);
  	}
-
-@@ -866,11 +892,19 @@
+ 
+@@ -866,11 +890,19 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
  		DLL_TXCLK_TAPNUM_FROM_SW |
  		DLL_RXCLK_NO_INVERTER << DWCMSHC_EMMC_DLL_RXCLK_SRCSEL |
  		txclk_tapnum;
@@ -106,7 +105,7 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +		extra |= DLL_TAP_VALUE_SEL |
 +			 dll_lock_value << DLL_TAP_VALUE_OFFSET;
  	sdhci_writel(host, extra, DWCMSHC_EMMC_DLL_TXCLK);
-
+ 
  	extra = DWCMSHC_EMMC_DLL_DLYENA |
 -		DLL_STRBIN_TAPNUM_DEFAULT |
  		DLL_STRBIN_TAPNUM_FROM_SW;
@@ -117,5 +116,8 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +	else
 +		extra |= DLL_STRBIN_TAPNUM_DEFAULT;
  	sdhci_writel(host, extra, DWCMSHC_EMMC_DLL_STRBIN);
-
+ 
  enable_clk:
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/rk3576-0013-mmc-sdhci-dwcmshc-rk3576-dll-tap-calibration.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3576-0013-mmc-sdhci-dwcmshc-rk3576-dll-tap-calibration.patch
@@ -1,26 +1,34 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: [ARCHEOLOGY] board: anbernic-rg-vita-pro - fix eMMC HS400 timeouts
- (rk3576 DLL calibration)
+Subject: mmc: sdhci-of-dwcmshc: rk3576: calibrate the HS400 DLL taps
 
-> X-Git-Archeology: > recovered message: > Add a dwcmshc patch that ports the vendor rk3576 HS400 DLL tap
-> X-Git-Archeology: > recovered message: > calibration (revision 1 only): read the locked DLL value from
-> X-Git-Archeology: > recovered message: > DLL_STATUS0 and feed it back as the tap-value select on every DLL clock
-> X-Git-Archeology: > recovered message: > line, use taps 7/7/5 and BOTH_CLK_EDGE on CMDOUT.
-> X-Git-Archeology: > recovered message: > Without it the mainline HS400 timing has almost no margin on this board.
-> X-Git-Archeology: > recovered message: > Under sustained I/O (kernel compile, large apt transaction) the eMMC
-> X-Git-Archeology: > recovered message: > stalls with "mmc0: Timeout waiting for hardware interrupt" on
-> X-Git-Archeology: > recovered message: > CMD13/CMD18/CMD24 and grinds to a halt. Forcing HS200 makes it vanish,
-> X-Git-Archeology: > recovered message: > which pins it on the HS400 timing rather than the card (pristine
-> X-Git-Archeology: > recovered message: > PRE_EOL/LIFE_TIME, clean fsck). With the calibration the card stays in
-> X-Git-Archeology: > recovered message: > HS400-ES at 200MHz and the timeouts are gone.
-> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology: - Revision 2cfa897ddbb543b22945951ede51d64e5808ff9e: https://github.com/armbian/build/commit/2cfa897ddbb543b22945951ede51d64e5808ff9e
-> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
-> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
-> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - fix eMMC HS400 timeouts (rk3576 DLL calibration)
-> X-Git-Archeology:
+On dwcmshc revision 1 (rk3576) the HS400 path programs fixed DLL taps
+(TX and CMDOUT at 90 degrees, STRBIN at the generic default) and never
+feeds the measured DLL lock value back into the tap-value select. The
+vendor driver does both: it reads the locked DLL value out of
+DLL_STATUS0 and supplies it as the tap-value select on every DLL clock
+line, and it uses different HS400 taps (TX 7, CMDOUT 7, STRBIN 5) plus
+BOTH_CLK_EDGE rather than EN_SRC_CLK_NEG on CMDOUT.
+
+Without that calibration the HS400 timing has very little margin on this
+SoC. On an Anbernic RG Vita Pro (rk3576, Micron eMMC in HS400-ES at
+200MHz) sustained I/O stalls with
+
+  mmc0: Timeout waiting for hardware interrupt.
+
+for CMD13/CMD18/CMD24 alike - the command or its data phase never
+completes, the block layer stalls for seconds, and a kernel compile or
+a large apt transaction grinds to a halt. Forcing the card down to
+HS200 (by dropping mmc-hs400-1_8v/mmc-hs400-enhanced-strobe from the DT)
+makes the stalls disappear entirely, which points at the HS400 timing
+rather than at the card or the filesystem: the eMMC reports a pristine
+PRE_EOL/LIFE_TIME and fsck finds nothing.
+
+Port the vendor calibration for revision 1 only, leaving revision 0
+(rk3566/rk3568) on its existing fixed taps.
+
+Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
  drivers/mmc/host/sdhci-of-dwcmshc.c | 44 ++++++++--
  1 file changed, 38 insertions(+), 6 deletions(-)

--- a/patch/kernel/archive/rockchip64-7.2/rk35xx-panthor-1GHz.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk35xx-panthor-1GHz.patch
@@ -212,7 +212,7 @@ index 111111111111..222222222222 100644
  		opp-300000000 {
  			opp-hz = /bits/ 64 <300000000>;
  			opp-microvolt = <712500 712500 875000>;
-@@ -1259,10 +1265,10 @@ power-domain@RK3576_PD_VO1 {
+@@ -1285,10 +1291,10 @@ power-domain@RK3576_PD_VO1 {
  		gpu: gpu@27800000 {
  			compatible = "rockchip,rk3576-mali", "arm,mali-bifrost";
  			reg = <0x0 0x27800000 0x0 0x20000>;

--- a/patch/kernel/archive/rockchip64-7.2/temporary-workaround-dma-reset.patch
+++ b/patch/kernel/archive/rockchip64-7.2/temporary-workaround-dma-reset.patch
@@ -17,7 +17,7 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/eth
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -3284,8 +3284,8 @@ static int stmmac_init_dma_engine(struct stmmac_priv *priv)
+@@ -3271,8 +3271,8 @@ static int stmmac_init_dma_engine(struct stmmac_priv *priv)
  
  	ret = stmmac_reset(priv);
  	if (ret) {

--- a/patch/kernel/archive/uefi-x86-7.2/2008-i915-4-lane-quirk-for-mbp15-1.patch
+++ b/patch/kernel/archive/uefi-x86-7.2/2008-i915-4-lane-quirk-for-mbp15-1.patch
@@ -16,7 +16,7 @@ diff --git a/drivers/gpu/drm/i915/display/intel_ddi.c b/drivers/gpu/drm/i915/dis
 index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/i915/display/intel_ddi.c
 +++ b/drivers/gpu/drm/i915/display/intel_ddi.c
-@@ -4938,6 +4938,9 @@ static bool intel_ddi_a_force_4_lanes(struct intel_digital_port *dig_port)
+@@ -4940,6 +4940,9 @@ static bool intel_ddi_a_force_4_lanes(struct intel_digital_port *dig_port)
  	if (dig_port->ddi_a_4_lanes)
  		return false;
  


### PR DESCRIPTION
# Description

- bump to v7.2-rc6
- still old 7.1 kernel config
- - wasn't bored enough to take care of the remaining wifi drivers...
- rewrite rockchip64
- - some patches underwent heavy archeology @crackerjacques 
- - I don't know how that happened but @rpardini: what was the best procedure to make a patch header subject stick rather than being overwritten?
- rewrite meson64: no changes
- rewrite both uefi variants: minor change

# How Has This Been Tested?

- [x] build rockchip64-7.2
- [x] build uefi-x86 
- [x] build uefi-arm64 
- [x] build meson64-7.2

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for additional Rockchip display panels, SPI MCU joypads with RGB lighting, battery gauges, chargers, and HUSB311 USB-C controllers.
  * Added RK3328 memory frequency management and improved GPU power management.
* **Bug Fixes**
  * Improved display output, hotplug handling, storage calibration, Ethernet switching, DMA initialization, touchscreen resets, MTU handling, and MacBook display compatibility.
* **Hardware Support**
  * Added disabled ODROID-Vu8S panel configuration and updated ROCK Pi 4A SPI-NOR settings.
  * Updated the kernel to the v7.2 release candidate 6 series.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->