### PR TITLE
compress-checksum: SKIP_COMPRESSING to leave chosen formats uncompressed

### DIFF
--- a/lib/functions/image/compress-checksum.sh
+++ b/lib/functions/image/compress-checksum.sh
@@ -138,6 +138,24 @@ function output_images_compress_and_checksum() {
 		# get just the filename, sans path
 		declare uncompressed_file_basename
 		uncompressed_file_basename=$(basename "${uncompressed_file}")
+
+		# Per-format compression skip. SKIP_COMPRESSING is a global, comma- or
+		# space-separated list of file extensions to leave UNCOMPRESSED (still
+		# checksummed if COMPRESS_OUTPUTIMAGE requests sha), e.g.
+		# SKIP_COMPRESSING="iso,qcow2" — for formats consumed as-is (mounted /
+		# imported) that gain little from xz. Empty (default) = compress everything.
+		if [[ -n "${SKIP_COMPRESSING:-}" ]]; then
+			declare skip_list=",${SKIP_COMPRESSING//[[:space:]]/,},"
+			declare file_ext="${uncompressed_file_basename##*.}"
+			if [[ "${skip_list}" == *",${file_ext},"* ]]; then
+				display_alert "Leaving image uncompressed" "${uncompressed_file_basename} (SKIP_COMPRESSING=${SKIP_COMPRESSING})" "info"
+				if [[ $COMPRESS_OUTPUTIMAGE == *sha* ]]; then
+					display_alert "SHA256 calculating" "${uncompressed_file_basename}" "info"
+					sha256sum -b "${uncompressed_file}" | awk '{split($2, a, "/"); print $1, a[length(a)]}' > "${uncompressed_file}".sha
+				fi
+				continue
+			fi
+		fi
 		# Stable release builds (BETA=no) deploy to own infra (no size cap) and
 		# favour speed: force xz -0. Nightly/user builds publish to GitHub releases
 		# (2 GB asset cap) and use the elastic level to compress as much as the


### PR DESCRIPTION
Bulk builds set `COMPRESS_OUTPUTIMAGE=xz`, which compresses **every** output image — including `.qcow2` and `.iso`. Those formats are consumed as-is (imported into a hypervisor, mounted as a virtual CD) and gain little from xz, so shipping them as `.xz` just forces an extra decompress.

Adds a global **`SKIP_COMPRESSING`** — a comma- or space-separated list of file **extensions** to leave uncompressed:

```bash
SKIP_COMPRESSING="iso,qcow2"
```

- Matches by file extension (`.iso`, `.img.qcow2` → `qcow2`, …).
- Skipped files are **still checksummed** when `COMPRESS_OUTPUTIMAGE` includes `sha`.
- **Empty (default) = compress everything** — no behaviour change for existing builds.
- Accepts `iso,qcow2`, `iso qcow2`, or `iso, qcow2`.

Slots into the per-file loop in `compress-checksum.sh` right before the xz/zstd block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for skipping image compression by file extension.
  * Skipped images are logged and can optionally receive SHA256 checksums.
  * Processing continues automatically with remaining images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->