### PR TITLE
cloud-init: stop persisting zram swap into /etc/fstab (slow cloud boot)

### DIFF
--- a/extensions/cloud-init/config/99-armbian-no-zram-swap.cfg
+++ b/extensions/cloud-init/config/99-armbian-no-zram-swap.cfg
@@ -1,0 +1,16 @@
+# Do not let cloud-init persist the (dynamic) zram swap into /etc/fstab.
+#
+# Armbian sets up zram swap at boot via armbian-zram-config.service. cloud-init's
+# `mounts` module otherwise sees that active swap and writes a matching
+# "/dev/zram0 none swap ... comment=cloudconfig" line to /etc/fstab. On the next
+# boot systemd turns that line into a dev-zram0.swap unit and blocks ~90s on the
+# device timeout waiting for /dev/zram0 — which only appears once
+# armbian-zram-config runs — before swap.target fails/recovers. Result: a very
+# slow boot every time.
+#
+# Setting the `swap` mount to null removes cloud-init's default swap mount, so it
+# leaves zram/swap management to Armbian while keeping the rest of the `mounts`
+# module intact. (cc_mounts sanitizes the config before de-duplicating, so this
+# suppresses the auto-added default swap entry too.)
+mounts:
+  - [ swap, null ]


### PR DESCRIPTION
On the arm64 **cloud** images, boot takes ~90 s longer than it should. Root cause:

- `armbian-zram-config.service` sets up zram swap at boot.
- cloud-init's `mounts` module sees that active swap and **persists it to `/etc/fstab`**: `/dev/zram0 none swap sw,comment=cloudconfig 0 0`.
- On the next boot systemd turns that line into a `dev-zram0.swap` unit that **blocks ~90 s on the device timeout** waiting for `/dev/zram0` (which only appears once `armbian-zram-config` runs), failing `swap.target` until it recovers.

Confirmed on two production cloud hosts (`armbian-aarch64-1/2`), both with the identical fstab line and a 90 s `dev-zram0.device` timeout in `dmesg`.

### Fix
A `cloud.cfg.d` drop-in (`99-armbian-no-zram-swap.cfg`) that sets cloud-init's `swap` mount to `null`:

```yaml
mounts:
  - [ swap, null ]
```

This removes cloud-init's default swap mount so it leaves zram/swap management to Armbian, while keeping the rest of the `mounts` module. Verified against `cc_mounts.py` (26.1): `handle()` runs `sanitize_mounts_configuration` **before** `add_default_mounts_to_cfg`, so the sanitized `swap`→`/dev/zram0` entry suppresses the auto-added default swap entry, and the null mountpoint keeps it out of fstab.

Deployed cloud hosts were already fixed by removing the stale fstab line (armbian-zram-config still provides the swap); this stops **new** images from shipping the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cloud-init from persisting dynamically configured Armbian zram swap in `/etc/fstab`.
  * Preserved processing for other mount configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->