### PR TITLE
image-output-iso: accept vmlinux-* kernels (arm64 cloud branch)

### DIFF
--- a/extensions/image-output-iso.sh
+++ b/extensions/image-output-iso.sh
@@ -104,7 +104,10 @@ function pre_umount_final_image__800_build_image_output_iso() {
 
 	# --- kernel + initrd (newest real files in the image /boot) ---
 	declare kernel_file initrd_file
-	kernel_file="$(ls -1 "${MOUNT}"/boot/vmlinuz-* 2>/dev/null | grep -vE '\.(manifest|dtb|old)$' | sort -V | tail -1)"
+	# Debian/Ubuntu name the compressed kernel vmlinuz-*, but some arm64 kernels
+	# (e.g. the 'cloud' branch) install the image as vmlinux-* instead. GRUB boots
+	# either, so accept both; prefer vmlinuz-* when both are present.
+	kernel_file="$(ls -1 "${MOUNT}"/boot/vmlinuz-* "${MOUNT}"/boot/vmlinux-* 2>/dev/null | grep -vE '\.(manifest|dtb|old)$' | sort -V | tail -1)"
 	initrd_file="$(ls -1 "${MOUNT}"/boot/initrd.img-* 2>/dev/null | grep -vE '\.manifest$' | sort -V | tail -1)"
 	[[ -f "${kernel_file}" ]] || exit_with_error "image-output-iso: no kernel found under ${MOUNT}/boot"
 	[[ -f "${initrd_file}" ]] || exit_with_error "image-output-iso: no initrd found under ${MOUNT}/boot"


### PR DESCRIPTION
## Problem
CI build of `BOARD=uefi-arm64 BRANCH=cloud RELEASE=resolute` (`ENABLE_EXTENSIONS=image-output-iso`) fails at the live UEFI ISO step:

```
--> ERROR: error! [ image-output-iso: no kernel found under .../boot ]
--> ERROR: Exiting with error 43
```

([failing job](https://github.com/armbian/ci/actions/runs/30850383428/job/91810031437), on `origin/main` @ `6c0c712ca`.)

## Cause
The extension locates the image kernel by globbing only `/boot/vmlinuz-*`. The `cloud` arm64 kernel installs its image as **`vmlinux-*`** (`/boot/vmlinux-6.18.42-cloud-arm64`), so the glob comes up empty. GRUB itself has no trouble — its `10_linux` already handles `vmlinux-*` (`Found linux image: /boot/vmlinux-6.18.42-cloud-arm64` in the same log) — only the ISO builder was stricter.

## Fix
Glob both `vmlinuz-*` and `vmlinux-*`. `sort -V | tail -1` still prefers `vmlinuz-*` when both exist, so the common case is unchanged; the copy target stays `/live/vmlinuz` (GRUB loads either). Initrd handling is untouched (already matched `initrd.img-*`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel detection during image creation by recognizing both compressed and uncompressed kernel filenames.
  * Preserved version filtering and selection of the newest available kernel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->