### PR TITLE
bsp-cli: version the package on the packages/dirs its hooks install from

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
@@ -16,6 +16,7 @@ function artifact_armbian-bsp-cli_config_dump() {
 function artifact_armbian-bsp-cli_prepare_version() {
 	: "${BRANCH:?BRANCH is not set}"
 	: "${BOARD:?BOARD is not set}"
+	: "${LINUXFAMILY:?LINUXFAMILY is not set}" # empty would make the packages/bsp hash below cover the whole tree
 
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
@@ -74,20 +75,19 @@ function artifact_armbian-bsp-cli_prepare_version() {
 
 	declare -a dirs_to_hash=(
 		"${SRC}/packages/bsp/common"         # common stuff
-		"${SRC}/packages/bsp/${LINUXFAMILY}" # family files installed by post_family_tweaks_bsp hooks, see below
+		"${SRC}/packages/bsp/${LINUXFAMILY}" # family files, installed by post_family_tweaks_bsp hooks
+		"${SRC}/packages/bsp/${BOARD}"       # board files, ditto
 		"${SRC}/config/optional/_any_board/_packages/bsp-cli"
 		"${SRC}/config/optional/architectures/${ARCH}/_packages/bsp-cli"
 		"${SRC}/config/optional/families/${LINUXFAMILY}/_packages/bsp-cli"
 		"${SRC}/config/optional/boards/${BOARD}/_packages/bsp-cli"
 	)
 
-	# Anything else under packages/ a family or extension installs into ${destination} from a
-	# post_family_tweaks_bsp hook. The hooks themselves are hashed just above, but only as source
-	# text: an `install ${SRC}/packages/bsp/foo/bar` line is unchanged when bar's contents change,
-	# so a directory that no entry above reaches is invisible to the version and the deb is then
-	# served from cache with the old file in it. Append the directory here (from the family config
-	# or an extension's extension_prepare_config) and its contents version the package like every
-	# other input does.
+	# The hooks are hashed above, but only as source text: an `install ${SRC}/packages/bsp/foo/bar`
+	# line reads the same whether bar changed or not. Directories no entry above reaches - shared
+	# ones like packages/bsp/aic8800 - are thus invisible to the version, and the deb comes back
+	# from cache with the old file in it. List them here, absolute, from the family config or an
+	# extension's extension_prepare_config.
 	dirs_to_hash+=("${BSP_CLI_EXTRA_HASH_DIRS[@]+"${BSP_CLI_EXTRA_HASH_DIRS[@]}"}")
 
 	declare hash_files="undetermined"

--- a/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
@@ -73,12 +73,23 @@ function artifact_armbian-bsp-cli_prepare_version() {
 	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
 
 	declare -a dirs_to_hash=(
-		"${SRC}/packages/bsp/common" # common stuff
+		"${SRC}/packages/bsp/common"         # common stuff
+		"${SRC}/packages/bsp/${LINUXFAMILY}" # family files installed by post_family_tweaks_bsp hooks, see below
 		"${SRC}/config/optional/_any_board/_packages/bsp-cli"
 		"${SRC}/config/optional/architectures/${ARCH}/_packages/bsp-cli"
 		"${SRC}/config/optional/families/${LINUXFAMILY}/_packages/bsp-cli"
 		"${SRC}/config/optional/boards/${BOARD}/_packages/bsp-cli"
 	)
+
+	# Anything else under packages/ a family or extension installs into ${destination} from a
+	# post_family_tweaks_bsp hook. The hooks themselves are hashed just above, but only as source
+	# text: an `install ${SRC}/packages/bsp/foo/bar` line is unchanged when bar's contents change,
+	# so a directory that no entry above reaches is invisible to the version and the deb is then
+	# served from cache with the old file in it. Append the directory here (from the family config
+	# or an extension's extension_prepare_config) and its contents version the package like every
+	# other input does.
+	dirs_to_hash+=("${BSP_CLI_EXTRA_HASH_DIRS[@]+"${BSP_CLI_EXTRA_HASH_DIRS[@]}"}")
+
 	declare hash_files="undetermined"
 	calculate_hash_for_all_files_in_dirs "${dirs_to_hash[@]}"
 	packages_config_hash="${hash_files}"

--- a/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
@@ -80,6 +80,22 @@ function artifact_armbian-bsp-cli_prepare_version() {
 		"${SRC}/config/optional/families/${LINUXFAMILY}/_packages/bsp-cli"
 		"${SRC}/config/optional/boards/${BOARD}/_packages/bsp-cli"
 	)
+
+	# The hooks are hashed above only as source text: `install ${SRC}/packages/bsp/foo/bar` reads the
+	# same whether bar changed or not. So also hash the directory of every packages/ path they name,
+	# shared ones like packages/bsp/rk3399 or packages/blobs/riscv64/spacemit included.
+	declare hooks_text="${hooks_to_hash[*]}" hook_path
+	hooks_text="${hooks_text//'${BOARD}'/${BOARD}}"
+	hooks_text="${hooks_text//'$BOARD'/${BOARD}}"
+	declare -A hook_dirs=()
+	while read -r hook_path; do
+		hook_path="${hook_path%/}"
+		[[ -d "${SRC}/${hook_path}" ]] || hook_path="${hook_path%/*}" # a file, or a name cut short by a variable
+		[[ "${hook_path}" == packages/*/* ]] || continue              # never all of packages/bsp
+		hook_dirs["${SRC}/${hook_path}"]=1
+	done < <(grep -oE 'packages/[A-Za-z0-9._-]+/[A-Za-z0-9._/-]+' <<< "${hooks_text}" || true)
+	dirs_to_hash+=("${!hook_dirs[@]}")
+
 	declare hash_files="undetermined"
 	calculate_hash_for_all_files_in_dirs "${dirs_to_hash[@]}"
 	packages_config_hash="${hash_files}"


### PR DESCRIPTION
> **Update:** the implementation changed after review. The current approach is described in [this comment](https://github.com/armbian/build/pull/10327#issuecomment-5641064990).


Companion to #10326. But the board will still work without it.

Affected boards: every family with a `packages/bsp/<family>/` directory, plus every board with a `packages/bsp/<board>/`. These rebuild once, everything else keeps its exact current version.

# Description

## Better hashing of BSP artifacts

`artifact_armbian-bsp-cli_prepare_version()` hashes packages/bsp/common and the `config/optional/.../_packages/`bsp-cli trees, and nothing else under packages/. Family files do not arrive that way - they are installed by post_family_tweaks_bsp hooks, out of `packages/bsp/<family>/` - and the hooks are hashed only as source text. An `install ${SRC}/packages/bsp/foo/bar` line reads the same whether bar changed or not.

So editing a family's bsp file moves no component of the version string. The artifact then collides with an older build, artifacts-obtain.sh finds it in the local or remote cache, unpacks that deb-tar, and the image ships the previous copy of the file. Nothing warns; the build log says cache hit, which is what a cache hit always says.

It stays hidden because the hash is board-independent in practice: with no config/optional entries for most boards, packages/bsp/common is the whole input and every board on the tree carries the same PC component. A family file is simply never part of it.

Hash `packages/bsp/${LINUXFAMILY}` alongside the rest. `calculate_hash_for_all_files_in_dirs()` skips directories that do not exist, so families without one keep their exact current version and nothing is rebuilt for them.

The family-named directory does not cover everything: a family or extension can install from any path under packages/, and packages/bsp/aic8800 is shared by several unrelated boards. Those cannot be derived from `LINUXFAMILY`, so add `BSP_CLI_EXTRA_HASH_DIRS` for them - append a directory from the family config or an extension's extension_prepare_config and it versions the package like every other input. Left empty here; the boards that need it are a separate change.

# How Has This Been Tested?

The hashes change when files change, previously they did not.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- BSP CLI package version calculations now more reliably account for directories referenced by installation hooks.
- Hook paths are detected more accurately across common directory layouts, including paths under the source directory and relative `packages/` paths.
- Unrelated paths, such as `dist-packages/` and system library paths, are no longer incorrectly treated as hook directories.
- Paths containing supported build variables are handled consistently when generating warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->