### PR TITLE
arm64: dts: sun50i-h618: bananapi-m4-zero: fix EMAC1 to use AC300 internal EPHY

### DIFF
--- a/patch/kernel/archive/sunxi-6.18/dt_64/sun50i-h618-bananapi-m4-zero.dts
+++ b/patch/kernel/archive/sunxi-6.18/dt_64/sun50i-h618-bananapi-m4-zero.dts
@@ -8,104 +8,144 @@
 #include "sun50i-h618-bananapi-m4.dtsi"
 
 / {
-	model = "BananaPi BPI-M4-Zero";
-	compatible = "sinovoip,bpi-m4-zero", "allwinner,sun50i-h618";
+        model = "BananaPi BPI-M4-Zero";
+        compatible = "sinovoip,bpi-m4-zero", "allwinner,sun50i-h618";
 
-	aliases {
-		ethernet0 = &emac1;
-		i2c0 = &i2c0;
-		i2c1 = &i2c1;
-		i2c3 = &i2c3;
-		i2c4 = &i2c4;
-		serial4 = &uart4;
-		serial5 = &uart5;
-		spi1 = &spi1;
-	};
+        aliases {
+                ethernet0 = &emac1;
+                i2c0 = &i2c0;
+                i2c1 = &i2c1;
+                i2c3 = &i2c3;
+                i2c4 = &i2c4;
+                serial4 = &uart4;
+                serial5 = &uart5;
+                spi1 = &spi1;
+        };
 
-	leds {
-		compatible = "gpio-leds";
+        leds {
+                compatible = "gpio-leds";
 
-		led-0 {
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&pio 2 12 GPIO_ACTIVE_HIGH>;	/* PC12 */
-			linux,default-trigger = "heartbeat";
-		};
-	};
+                led-0 {
+                        color = <LED_COLOR_ID_RED>;
+                        function = LED_FUNCTION_STATUS;
+                        gpios = <&pio 2 12 GPIO_ACTIVE_HIGH>;   /* PC12 */
+                        linux,default-trigger = "heartbeat";
+                };
+        };
+
+        ac300_pwm_clk: ac300-clk {
+                compatible = "pwm-clock";
+                #clock-cells = <0>;
+                /* 500ns period -> 2MHz */
+                pwms = <&pwm 5 500 0>;
+                clock-frequency = <2000000>;
+                status = "okay";
+        };
+
 };
 
 /* Connected to an on-board RTL8821CU USB WiFi chip. */
 &ehci1 {
-	status = "okay";
+        status = "okay";
 };
 
 &ehci2 {
-	status = "okay";
+        status = "okay";
 };
 
 &ehci3 {
-	status = "okay";
+        status = "okay";
 };
 
 &emac1 {
-	status = "disabled";
-	pinctrl-names = "default";
-	pinctrl-0 = <&rmii_pins>;
-	phy-mode = "rmii";
-	phy-handle = <&rmii_phy>;
-	phy-supply = <&reg_dldo1>;
-	allwinner,rx-delay-ps = <3100>;
-	allwinner,tx-delay-ps = <700>;
-};
+        compatible = "allwinner,sun50i-h616-internal-emac";
+        pinctrl-names = "default";
+        pinctrl-0 = <&rmii_pins>;
+        phy-mode = "rmii";
+        phy-handle = <&ac300_ephy>;
+        phy-supply = <&reg_dldo1>;
+        allwinner,rx-delay-ps = <3100>;
+        allwinner,tx-delay-ps = <700>;
+        status = "disabled";
 
-&mdio1 {
-	rmii_phy: ethernet-phy@1 {
-		compatible = "ethernet-phy-ieee802.3-c22";
-		reg = <1>;
-	};
-};
+        mdio-mux {
+                compatible = "allwinner,sun8i-h3-mdio-mux";
+                #address-cells = <1>;
+                #size-cells = <0>;
+                mdio-parent-bus = <&mdio1>;
 
+                internal_mdio: mdio@1 {
+                        compatible = "allwinner,sun8i-h3-mdio-internal";
+                        reg = <1>;
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        ac300_ephy: ethernet-phy@0 {
+                                compatible = "ethernet-phy-id0044.1400",
+                                             "allwinner,sun50i-h618-ac300-ephy",
+                                             "ethernet-phy-ieee802.3-c22";
+                                reg = <0>;
+                                clocks = <&ccu CLK_EMAC_25M>, <&ac300_pwm_clk>;
+                                clock-names = "ephy", "pwm";
+                                nvmem-cells = <&ephy_calibration>;
+                                nvmem-cell-names = "calibration";
+                                status = "okay";
+                        };
+                };
+        };
+};
 /* SDIO */
 &mmc1 {
-	status = "disabled";
-	bus-width = <4>;
-	max-frequency = <100000000>;
+        status = "disabled";
+        bus-width = <4>;
+        max-frequency = <100000000>;
 
-	non-removable;
-	disable-wp;
+        non-removable;
+        disable-wp;
 
-	/* WiFi firmware requires power to be kept while in suspend */
-	keep-power-in-suspend;
+        /* WiFi firmware requires power to be kept while in suspend */
+        keep-power-in-suspend;
 
-	mmc-pwrseq = <&wifi_pwrseq>;
+        mmc-pwrseq = <&wifi_pwrseq>;
 
-	cd-gpios = <&pio 6 15 GPIO_ACTIVE_HIGH>; /* PG15 */
-	vmmc-supply = <&reg_vcc3v3>;
+        cd-gpios = <&pio 6 15 GPIO_ACTIVE_HIGH>; /* PG15 */
+        vmmc-supply = <&reg_vcc3v3>;
 
-	sdio: wifi@1 {
-		reg = <1>;
-		compatible = "brcm,bcm4329-fmac";
-	};
+        sdio: wifi@1 {
+                reg = <1>;
+                compatible = "brcm,bcm4329-fmac";
+        };
 };
 
 &ohci1 {
-	status = "okay";
+        status = "okay";
 };
 
 &ohci2 {
-	status = "okay";
+        status = "okay";
 };
 
 &ohci3 {
-	status = "okay";
+        status = "okay";
 };
 
 &usbotg {
-	status = "okay";
-	dr_mode = "peripheral";
+        status = "okay";
+        dr_mode = "peripheral";
 };
 
 &usbphy {
-	status = "okay";
-	usb1_vbus-supply = <&reg_usb_vbus>;
+        status = "okay";
+        usb1_vbus-supply = <&reg_usb_vbus>;
+};
+
+&sid {
+        ephy_calibration: ephy-calibration@2c {
+                reg = <0x2c 0x2>;
+        };
+};
+
+&codec {
+        allwinner,audio-routing = "Line Out", "LINEOUT";
+        status = "okay";
 };

--- a/patch/kernel/archive/sunxi-6.18/overlay_64/Makefile
+++ b/patch/kernel/archive/sunxi-6.18/overlay_64/Makefile
@@ -61,6 +61,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
 	sun50i-h616-bananapi-m4-spi1-cs0-cs1-spidev.dtbo \
 	sun50i-h616-bananapi-m4-spi1-cs0-spidev.dtbo \
 	sun50i-h616-bananapi-m4-spi1-cs1-spidev.dtbo \
+	sun50i-h616-bananapi-m4-zero-fpc24-eth.dtbo \
 	sun50i-h616-gpu.dtbo \
 	sun50i-h616-i2c0-pi.dtbo \
 	sun50i-h616-i2c1-pi.dtbo \

--- a/patch/kernel/archive/sunxi-6.18/overlay_64/sun50i-h616-bananapi-m4-zero-fpc24-eth.dtso
+++ b/patch/kernel/archive/sunxi-6.18/overlay_64/sun50i-h616-bananapi-m4-zero-fpc24-eth.dtso
@@ -1,0 +1,32 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "sinovoip,bpi-m4-zero", "allwinner,sun50i-h616", "allwinner,sun50i-h618";
+
+        /* PWM5 provides the 2MHz reference clock for the AC300 EPHY */
+        fragment@0 {
+                target = <&pwm>;
+                __overlay__ {
+                        status = "okay";
+                };
+        };
+
+        fragment@1 {
+                target = <&pwm5>;
+                __overlay__ {
+                        pinctrl-names = "default";
+                        pinctrl-0 = <&pwm5_pin>;
+                        clk_bypass_output = <0x1>;
+                        status = "okay";
+                };
+        };
+
+        /* Fast Ethernet, only reachable through the 24-pin FPC connector */
+        fragment@2 {
+                target = <&emac1>;
+                __overlay__ {
+                        status = "okay";
+                };
+        };
+};


### PR DESCRIPTION
## Description

The BPI-M4-Zero DTS describes an external RMII PHY at MDIO address 1,
which does not exist on this board. The Fast Ethernet is provided by the
SoC-internal AC300 EPHY, reachable through the 24-pin FPC connector.

This replaces that description with the AC300, following the approach
already used in `arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch`.

EMAC1 is kept `disabled` because it requires the FPC expansion board, and
enabling it would reserve PA0-PA9 plus PWM5 on boards without it. A new
overlay handles enabling.

The analog audio codec is also enabled with Line Out routing, matching
`sun50i-h618-orangepi-zero2w.dts` for the same hardware arrangement.

## Changes

- `dt_64/sun50i-h618-bananapi-m4-zero.dts` — AC300 description, PWM clock,
  SID calibration cell, codec enabled
- `overlay_64/sun50i-h616-bananapi-m4-zero-fpc24-eth.dtso` — new overlay
- `overlay_64/Makefile` — build the new overlay

## Testing

Tested on BPI-M4-Zero v2, Noble, `current` (6.18.42):

- Without the overlay: no network interface, no pins reserved
- With the overlay: `end0` links at 100Mb/s full duplex, DHCP on first boot
- `iperf3`: 94.7 Mbit/s over 20s, zero retransmissions
- Audio: analog codec card present without any overlay

Note: `ethtool` reports `Supported link modes: 10baseT` even though the
link negotiates 100/Full and reaches line rate. This appears to be a
capability-reporting issue in the AC300 PHY driver, not in this DTS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Banana Pi M4 Zero board support with working Ethernet through the onboard controller and AC300 PHY.
  - Added Ethernet support for the 24-pin FPC connector on compatible Banana Pi M4 Zero configurations.
  - Added a heartbeat status LED for clearer system activity feedback.
  - Enabled board-specific audio routing and calibration for improved hardware compatibility.
  - Preserved and refined USB, storage, and OTG device support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->