### PR TITLE
imx93: fix kernel-imx93-current build — drop redundant blk-ctrl.c hunk (6.18.42)

### DIFF
--- a/patch/kernel/archive/imx93-6.18/0001-arm64-dts-freescale-add-MBa93xxLA-MINI-modifications.patch
+++ b/patch/kernel/archive/imx93-6.18/0001-arm64-dts-freescale-add-MBa93xxLA-MINI-modifications.patch
@@ -10,8 +10,7 @@ Signed-off-by: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 ---
  .../boot/dts/freescale/imx91_93_common.dtsi   | 12 ++++
  arch/arm64/boot/dts/freescale/imx93.dtsi      | 62 +++++++++++++++++++
- drivers/pmdomain/imx/imx93-blk-ctrl.c         |  9 +++
- 3 files changed, 83 insertions(+)
+ 2 files changed, 74 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/freescale/imx91_93_common.dtsi b/arch/arm64/boot/dts/freescale/imx91_93_common.dtsi
 index 52da571f26c4..32c32a90b042 100644
@@ -109,35 +108,6 @@ index 7b27012dfcb5..89a9ae71230c 100644
  &src {
  	mlmix: power-domain@44461800 {
  		compatible = "fsl,imx93-src-slice";
-diff --git a/drivers/pmdomain/imx/imx93-blk-ctrl.c b/drivers/pmdomain/imx/imx93-blk-ctrl.c
-index e094fe5a42bf..ad9467419cd9 100644
---- a/drivers/pmdomain/imx/imx93-blk-ctrl.c
-+++ b/drivers/pmdomain/imx/imx93-blk-ctrl.c
-@@ -7,6 +7,7 @@
- #include <linux/device.h>
- #include <linux/module.h>
- #include <linux/of.h>
-+#include <linux/of_platform.h>
- #include <linux/platform_device.h>
- #include <linux/pm_domain.h>
- #include <linux/pm_runtime.h>
-@@ -300,8 +301,16 @@ static int imx93_blk_ctrl_probe(struct platform_device *pdev)
- 
- 	dev_set_drvdata(dev, bc);
- 
-+	ret = devm_of_platform_populate(dev);
-+	if (ret) {
-+		dev_err_probe(dev, ret, "failed to populate blk-ctrl sub-devices\n");
-+		goto cleanup_provider;
-+	}
-+
- 	return 0;
- 
-+cleanup_provider:
-+	of_genpd_del_provider(dev->of_node);
- cleanup_pds:
- 	for (i--; i >= 0; i--)
- 		pm_genpd_remove(&bc->domains[i].genpd);
 -- 
 2.43.0
 


### PR DESCRIPTION
Fixes the `kernel-imx93-current` failure ([run 30825508798](https://github.com/armbian/ci/actions/runs/30825508798)):

```
Failed to apply patch 0001-arm64-dts-freescale-add-MBa93xxLA-MINI-modifications.patch
  Hunk #2 FAILED at 301 (drivers/pmdomain/imx/imx93-blk-ctrl.c)
  1 out of 2 hunks FAILED → failed_apply → build abort
```

### Root cause
The MBa93xxLA-MINI patch adds `devm_of_platform_populate()` + `#include <linux/of_platform.h>` to `imx93_blk_ctrl_probe()` (to probe the added LCDIF sub-node). **That change is already upstream** — mainline `imx93-blk-ctrl.c` has the include (line 10) and `devm_of_platform_populate(dev)` (line 360). On the 6.18.42 base the code is already present, so the hunk conflicts.

### Fix
Drop the `blk-ctrl.c` changes from the patch; keep the DTS additions (`imx91_93_common.dtsi` LCDIF node + `imx93.dtsi`), which are still needed and applied cleanly. CI will confirm the patch now applies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled LCD display controller support on compatible i.MX93 boards.
  * Added display bridge connectivity, clock configuration, power management, and endpoint wiring for LCD and LVDS output.

* **Refactor**
  * Simplified display support by removing automatic sub-device population and related cleanup logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->