### PR TITLE
drivers: fix out-of-tree wifi build on 6.12.101 (cfg80211 set_monitor_channel)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -80,6 +80,9 @@ driver_rtl8189ES() {
 		sed -i "s/^CONFIG_RTW_DEBUG.*/CONFIG_RTW_DEBUG = n/" \
 			"$kerneldir/drivers/net/wireless/rtl8189es/Makefile"
 
+		# cfg80211 set_monitor_channel gained a net_device arg (6.13 mainline; backported to 6.12.101)
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8189es-set-monitor-channel-6.12.101.patch" "applying"
+
 	fi
 }
 
@@ -119,6 +122,9 @@ driver_rtl8189FS() {
 		sed -i "s/^CONFIG_RTW_DEBUG.*/CONFIG_RTW_DEBUG = n/" \
 			"$kerneldir/drivers/net/wireless/rtl8189fs/Makefile"
 
+		# cfg80211 set_monitor_channel gained a net_device arg (6.13 mainline; backported to 6.12.101)
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8189fs-set-monitor-channel-6.12.101.patch" "applying"
+
 	fi
 }
 
@@ -153,6 +159,9 @@ driver_rtl8192EU() {
 		echo "obj-\$(CONFIG_RTL8192EU) += rtl8192eu/" >> "$kerneldir/drivers/net/wireless/Makefile"
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8192eu\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
+
+		# cfg80211 set_monitor_channel gained a net_device arg (6.13 mainline; backported to 6.12.101)
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8192eu-set-monitor-channel-6.12.101.patch" "applying"
 
 	fi
 }
@@ -202,6 +211,7 @@ driver_rtl8811_rtl8812_rtl8814_rtl8821() {
 
 		# fix compilation for kernels >= 6.16
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8812au-Fix-6.16.patch" "applying"
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8812au-set-monitor-channel-6.12.101.patch" "applying"
 	fi
 }
 
@@ -328,6 +338,7 @@ driver_rtl8811CU_rtl8821C() {
 
 		# fix compilation for kernels >= 6.16
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8811cu-Fix-6.16.patch" "applying"
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8811cu-set-monitor-channel-6.12.101.patch" "applying"
 	fi
 }
 
@@ -370,6 +381,7 @@ driver_rtl88x2bu() {
 
 		# fix compilation for kernels >= 6.16
 		process_patch_file "${SRC}/patch/misc/wireless-rtl88x2bu-Fix-6.16.patch" "applying"
+		process_patch_file "${SRC}/patch/misc/wireless-rtl88x2bu-set-monitor-channel-6.12.101.patch" "applying"
 
 	fi
 }

--- a/patch/misc/wireless-rtl8189es-set-monitor-channel-6.12.101.patch
+++ b/patch/misc/wireless-rtl8189es-set-monitor-channel-6.12.101.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/net/wireless/rtl8189es/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8189es/os_dep/linux/ioctl_cfg80211.c
+--- a/drivers/net/wireless/rtl8189es/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8189es/os_dep/linux/ioctl_cfg80211.c
+@@ -6218,7 +6218,7 @@
+ #endif /*#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 6, 0))*/
+ 
+ static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 101))
+ 	, struct net_device *dev
+ 	, struct cfg80211_chan_def *chandef
+ #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))

--- a/patch/misc/wireless-rtl8189fs-set-monitor-channel-6.12.101.patch
+++ b/patch/misc/wireless-rtl8189fs-set-monitor-channel-6.12.101.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/net/wireless/rtl8189fs/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8189fs/os_dep/linux/ioctl_cfg80211.c
+--- a/drivers/net/wireless/rtl8189fs/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8189fs/os_dep/linux/ioctl_cfg80211.c
+@@ -6051,7 +6051,7 @@
+ #endif /*#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 6, 0))*/
+ 
+ static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 101))
+ 	, struct net_device *dev
+ 	, struct cfg80211_chan_def *chandef
+ #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))

--- a/patch/misc/wireless-rtl8192eu-set-monitor-channel-6.12.101.patch
+++ b/patch/misc/wireless-rtl8192eu-set-monitor-channel-6.12.101.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/net/wireless/rtl8192eu/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8192eu/os_dep/linux/ioctl_cfg80211.c
+--- a/drivers/net/wireless/rtl8192eu/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8192eu/os_dep/linux/ioctl_cfg80211.c
+@@ -6122,7 +6122,7 @@
+ }
+ 
+ static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 101))
+ 	, struct net_device *dev
+ 	, struct cfg80211_chan_def *chandef
+ #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))

--- a/patch/misc/wireless-rtl8811cu-set-monitor-channel-6.12.101.patch
+++ b/patch/misc/wireless-rtl8811cu-set-monitor-channel-6.12.101.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/net/wireless/rtl8811cu/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8811cu/os_dep/linux/ioctl_cfg80211.c
+--- a/drivers/net/wireless/rtl8811cu/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8811cu/os_dep/linux/ioctl_cfg80211.c
+@@ -6966,7 +6966,7 @@
+ #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)) */
+ 
+ static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 101))
+ 	, struct net_device *dev
+ 	, struct cfg80211_chan_def *chandef
+ #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))

--- a/patch/misc/wireless-rtl8812au-set-monitor-channel-6.12.101.patch
+++ b/patch/misc/wireless-rtl8812au-set-monitor-channel-6.12.101.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/net/wireless/rtl8812au/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8812au/os_dep/linux/ioctl_cfg80211.c
+--- a/drivers/net/wireless/rtl8812au/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8812au/os_dep/linux/ioctl_cfg80211.c
+@@ -6311,7 +6311,7 @@
+ }
+ 
+ static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 101))
+ 	, struct net_device *dev
+ 	, struct cfg80211_chan_def *chandef
+ #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))

--- a/patch/misc/wireless-rtl88x2bu-set-monitor-channel-6.12.101.patch
+++ b/patch/misc/wireless-rtl88x2bu-set-monitor-channel-6.12.101.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c
+--- a/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c
+@@ -6914,7 +6914,7 @@
+ #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)) */
+ 
+ static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 101))
+ 	, struct net_device *dev
+ 	, struct cfg80211_chan_def *chandef
+ #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))


### PR DESCRIPTION
## Problem

The cfg80211 `->set_monitor_channel()` callback gained a `struct net_device *dev` argument in **6.13 mainline**, which was **backported into the 6.12.101 stable release**. The out-of-tree Realtek drivers guard the new 3-arg prototype at `KERNEL_VERSION(6, 13, 0)`, so on 6.12.101 they still emit the old 2-arg signature and the build fails:

```
error: initialization of 'int (*)(struct wiphy *, struct net_device *, struct cfg80211_chan_def *)'
       from incompatible pointer type
```

This breaks **x86-legacy**, **mvebu64-current** and every other family that tracks 6.12.101.

## Fix

Add **one patch per affected driver** under `patch/misc/`, following the hashed per-driver convention already used by the `wireless-*-Fix-*.patch` files, lowering the version guard from `KERNEL_VERSION(6, 13, 0)` to `KERNEL_VERSION(6, 12, 101)`. Each patch is applied from its driver function in `drivers_network.sh` via `process_patch_file`.

Affected drivers:
- rtl8189es
- rtl8189fs
- rtl8192eu
- rtl8812au
- rtl8811cu
- rtl88x2bu

The patches live in `patch/misc/` so they are picked up by the drivers hash and only affect kernels that actually build these drivers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for supported Realtek wireless adapters on Linux kernel 6.12.101 and newer.
  * Preserved monitor-mode channel selection when building affected wireless drivers.
  * Reduced compilation issues caused by changes to the kernel’s wireless driver interface.
  * Updated compatibility handling across six Realtek driver families, including RTL8189ES, RTL8189FS, RTL8192EU, RTL8812AU, RTL8811CU/RTL8821C, and RTL88x2BU.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->