### PR TITLE
fix: accept underscores and hyphens in usernames

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -600,12 +600,12 @@ add_user() {
 		else
 			username="$PRESET_USER_NAME"
 		fi
-		if ! grep '^[a-zA-Z][a-zA-Z0-9]*$' <<< "$username" > /dev/null; then
+		if ! grep '^[a-zA-Z][a-zA-Z0-9_-]*$' <<< "$username" > /dev/null; then
 			echo -e "\n\x1B[91mError\x1B[0m: illegal characters in username"
 			return
 		fi
 
-		RealUserName="$(echo "$username" | tr '[:upper:]' '[:lower:]' | tr -d -c '[:alnum:]')"
+		RealUserName="$(echo "$username" | tr '[:upper:]' '[:lower:]' | tr -d -c '[:alnum:]_-')"
 		[ -z "$RealUserName" ] && return
 		if ! id "$RealUserName" > /dev/null 2>&1; then
 			break


### PR DESCRIPTION
## What changed

Fix the username handling used by `armbian-firstlogin` so names such as `armbian_user` and `armbian-user` are accepted consistently with the issue report in armbian/configng#961.

The validation pattern now permits `_` and `-` after the initial letter, and the normalization step preserves those characters instead of silently removing them before `useradd` runs. Names must still start with a letter and remain limited to ASCII letters, digits, `_`, and `-`.

The related report is in the `armbian/configng` tracker, but the affected script is maintained in this repository under `packages/bsp/common/usr/lib/armbian/armbian-firstlogin`.

## Validation

- `bash -n` on the script after removing the repository file's existing CRLF line endings
- Bash checks for `armbian_user`, `armbian-user`, and `User_2`
- Rejection checks for `_armbian` and `armbian.user`
- `git diff --check`

The separate Imager-side validation mentioned in the report is intentionally out of scope for this focused build-side fix.