### PR TITLE
radxa-dragon-q6a: bump alsa-ucm-conf backport to 1.2.16.1-radxa-1

### DIFF
--- a/config/boards/radxa-dragon-q6a.conf
+++ b/config/boards/radxa-dragon-q6a.conf
@@ -36,7 +36,7 @@ function post_family_tweaks_bsp__radxa-dragon-q6a_bsp_firmware_in_initrd() {
 
 function post_family_tweaks__radxa-dragon-q6a_install_alsa_ucm_conf() {
 	# Radxa backport bundles the Q6A device UCM plus the DMI matcher (fork only, not upstream).
-	declare alsa_ucm_ver="1.2.15.3-radxa-1"
+	declare alsa_ucm_ver="1.2.16.1-radxa-1"
 	display_alert "Installing alsa-ucm-conf" "${BOARD}: Radxa ALSA UCM backport ${alsa_ucm_ver}" "info"
 	declare alsa_ucm_url="https://github.com/radxa-pkg/alsa-ucm-conf/releases/download/${alsa_ucm_ver}/alsa-ucm-conf_${alsa_ucm_ver}_all.deb"
 	declare alsa_ucm_deb="/tmp/alsa-ucm-conf_${alsa_ucm_ver}_all.deb"


### PR DESCRIPTION
# Description

The Q6A pulls its ALSA use case configuration from Radxa's alsa-ucm-conf backport, pinned at 1.2.15.3-radxa-1. That release predates the 1.2.16.1 upstream base, so two changes that land on the Q6A audio path are missing.

Upstream added the board under conf.d and changed the wcd938x headphone enable sequence from CLS_H_ULP to CLS_H_LOHIFI. The Q6A HiFi profile includes that sequence directly, so the headphone output has been running in the low power mode.

Bump the pin to 1.2.16.1-radxa-1. Nothing else in the board config changes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Radxa ALSA audio configuration package to version 1.2.16.1-radxa-1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->