### PR TITLE
radxa-aic8800: bump conditional to allow  Linux version 7.2

### DIFF
--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -10,7 +10,7 @@ function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
 function post_install_kernel_debs__install_aic8800_dkms_package() {
 
-	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 7.2; then
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 7.3; then
 		display_alert "Kernel version is too recent" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi


### PR DESCRIPTION
build tested for usb and sdio variant via radxa zero3 and rock 2f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AIC8800 DKMS installation compatibility for newer kernel versions, including kernel 7.3 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->