### PR TITLE
kernel-debs: normalize misnamed arm64 vmlinux-* boot image back to vmlinuz-*

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -204,6 +204,18 @@ function kernel_package_callback_linux_image() {
 	declare kernel_pre_package_path="${tmp_kernel_install_dirs[INSTALL_PATH]}"
 	kernel_image_installed_file_name=$(basename $(ls ${kernel_pre_package_path}/vmlinu*-${kernel_version_family}))
 	kernel_image_name=${kernel_image_installed_file_name%%-*}
+
+	# installkernel(8) (/sbin/installkernel) and arch/arm64/boot/install.sh name an *uncompressed* arm64
+	# 'Image' as vmlinux-<ver> -- only Image.gz / vmlinuz.efi become vmlinuz-<ver>. That file is a perfectly
+	# bootable Image, but every Armbian consumer and boot script (image-output-abl/-iso, extlinux/boot.cmd,
+	# the vfat-cleanup hook below) expects vmlinuz-<ver>. Normalize the name back to vmlinuz -- unless this
+	# arch genuinely boots a raw vmlinux (KERNEL_IMAGE_TYPE=vmlinux, e.g. loong64), where the name is correct.
+	if [[ "${kernel_image_name}" == "vmlinux" && "${KERNEL_IMAGE_TYPE}" != "vmlinux" ]]; then
+		display_alert "Normalizing misnamed kernel image" "${kernel_image_installed_file_name} -> vmlinuz-${kernel_version_family}" "info"
+		run_host_command_logged mv "${kernel_pre_package_path}/${kernel_image_installed_file_name}" "${kernel_pre_package_path}/vmlinuz-${kernel_version_family}"
+		kernel_image_installed_file_name="vmlinuz-${kernel_version_family}"
+		kernel_image_name="vmlinuz"
+	fi
 	display_alert "linux-image deb packaging kernel_image_name" "${kernel_image_name}" "info"
 	declare kernel_image_pre_package_path="${kernel_pre_package_path}/${kernel_image_name}-${kernel_version_family}"
 	declare installed_image_path="boot/${kernel_image_name}-${kernel_version_family}" # using old mkdebian terminology here for compatibility


### PR DESCRIPTION
## Problem

arm64 boards that build a plain (uncompressed) `Image` ship the kernel as `/boot/vmlinux-<ver>` instead of the historical `/boot/vmlinuz-<ver>`. The file is a perfectly bootable Image (`file`: *"Linux kernel ARM64 boot executable Image"*), just **misnamed**.

This breaks `image-output-abl` (Qualcomm Android boot image), which locates the kernel with:
```sh
gzip -c "${…}"/boot/vmlinuz-*-* > "${DESTIMG}/Image.gz"
```
The glob matches nothing → the ABL image step fails.

`image-output-abl` is enabled at **family** level, so this affects **every Qualcomm-abl board**, not just one:
- **sm8250**: xiaomi-elish, oneplus-kebab, dg-svr-865-tiny, retroidpocket-rp5, retroidpocket-rpmini
- **sm8550**: ayn-odin2, ayn-odin2mini, ayn-thor, ayn-odin2portal

**Observed in:** armbian/ci run [30941608953](https://github.com/armbian/ci/actions/runs/30941608953) — job `Xiaomi-elish_trixie_edge_6.19.y_minimal`.

## Root cause

`installkernel(8)` (`/sbin/installkernel`) and mainline `arch/arm64/boot/install.sh` name an **uncompressed** arm64 `Image` as `vmlinux-<ver>` — only `Image.gz` / `vmlinuz.efi` become `vmlinuz-<ver>`:
```sh
case "$(basename $img)" in
  "vmlinux"|"Image")  img_dest=vmlinux ;;
  *)                  img_dest=vmlinuz ;;
esac
```
Since `124da1406` (*"use dynamic kernel image name installed by installkernel"*) the deb packages that name verbatim (it used to hardcode `vmlinuz-<ver>`), so the misnaming now reaches the image.

`image-output-iso` hit the same thing and was band-aided in `bfec3b487` (accept `vmlinux-*`); `image-output-abl` never got that treatment.

## Fix

Normalize the boot image name back to `vmlinuz-<ver>` before packaging, **unless** the arch genuinely boots a raw vmlinux (`KERNEL_IMAGE_TYPE=vmlinux`, e.g. loong64):

```sh
if [[ "${kernel_image_name}" == "vmlinux" && "${KERNEL_IMAGE_TYPE}" != "vmlinux" ]]; then
    mv .../vmlinux-<ver> .../vmlinuz-<ver>
    kernel_image_name="vmlinuz"
fi
```

Because it lives in the kernel packaging layer, one change fixes all 9 abl boards (and any future one). Arch safety:
- **arm64 / riscv64 / imx / ls1046a** (`KERNEL_IMAGE_TYPE=Image`) — had the same latent bug → now correctly ship `vmlinuz-<ver>` again.
- **loong64** (`KERNEL_IMAGE_TYPE=vmlinux`) — skipped, keeps `vmlinux-<ver>`.
- **amd64 / armhf** (`bzImage` / `zImage`) — `installkernel` already names them `vmlinuz`, so the branch never fires.

Fixes `image-output-abl`, `image-output-iso`, extlinux/`boot.cmd`, and the vfat-cleanup hook at the root — the `bfec3b487` iso band-aid becomes redundant (left in place, harmless).