### PR TITLE
sunxi64: a64-olinuxino u-boot — build eMMC device tree (fix eMMC boot)

### DIFF
--- a/patch/u-boot/v2026.07-sunxi64/board_lime-a64/a64-olinuxino-build-emmc-devicetree.patch
+++ b/patch/u-boot/v2026.07-sunxi64/board_lime-a64/a64-olinuxino-build-emmc-devicetree.patch
@@ -1,0 +1,39 @@
+From: Igor Pecovnik <igor@armbian.com>
+Date: Wed, 6 Aug 2026 00:00:00 +0000
+Subject: [PATCH] a64-olinuxino: build the eMMC device tree so u-boot can use eMMC
+
+The base sun50i-a64-olinuxino device tree has no eMMC (mmc2) node, so full
+u-boot cannot initialize the on-board eMMC. It fails during MMC init with
+
+    Card did not respond to voltage select! : -110
+
+and, unable to read the eMMC, falls through to USB/network - so eMMC installs
+do not boot even though the BROM/SPL loaded u-boot from the eMMC.
+
+Upstream already ships sun50i-a64-olinuxino-emmc.dts, which includes the base
+DT and adds the mmc2 node with both regulators (vmmc = dcdc1, vqmmc = eldo1 -
+the 1.8V I/O rail the "voltage select" step needs), 8-bit bus, non-removable
+and cap-mmc-hw-reset. Select it as the default device tree.
+
+This restores eMMC support that was lost when the sunxi64 u-boot bump to
+v2026.07 (commit aea0a3c24) dropped the old board_lime-a64 eMMC DT patch.
+CONFIG_MMC_SUNXI_SLOT_EXTRA=2 is already set, so the driver probes the slot;
+only the DT node was missing.
+
+Signed-off-by: Igor Pecovnik <igor@armbian.com>
+---
+ configs/a64-olinuxino_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configs/a64-olinuxino_defconfig b/configs/a64-olinuxino_defconfig
+index 01fcb86..528fe16 100644
+--- a/configs/a64-olinuxino_defconfig
++++ b/configs/a64-olinuxino_defconfig
+@@ -1,6 +1,6 @@
+ CONFIG_ARM=y
+ CONFIG_ARCH_SUNXI=y
+-CONFIG_DEFAULT_DEVICE_TREE="sun50i-a64-olinuxino"
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-a64-olinuxino-emmc"
+ CONFIG_SPL=y
+ CONFIG_MACH_SUN50I=y
+ CONFIG_MMC_SUNXI_SLOT_EXTRA=2

--- a/patch/u-boot/v2026.07-sunxi64/board_lime-a64/a64-olinuxino-build-emmc-devicetree.patch
+++ b/patch/u-boot/v2026.07-sunxi64/board_lime-a64/a64-olinuxino-build-emmc-devicetree.patch
@@ -1,5 +1,5 @@
 From: Igor Pecovnik <igor@armbian.com>
-Date: Wed, 6 Aug 2026 00:00:00 +0000
+Date: Thu, 6 Aug 2026 00:00:00 +0000
 Subject: [PATCH] a64-olinuxino: build the eMMC device tree so u-boot can use eMMC
 
 The base sun50i-a64-olinuxino device tree has no eMMC (mmc2) node, so full


### PR DESCRIPTION
## Problem

On the Olimex **A64-OLinuXino (eMMC)**, eMMC installs don't boot after the sunxi64 u-boot bump **v2024.01 → v2026.07** (`aea0a3c24`). Serial shows full u-boot loading fine, then failing to initialize the eMMC:

```
=> ls mmc 2:1
Card did not respond to voltage select! : -110
** Bad device specification mmc 2 **
```

u-boot can't read the eMMC → no `boot.scr` → falls through to USB/network. The eMMC hardware and the install are fine (Linux mounts `mmcblk2` normally; BROM/SPL still load u-boot from it) — only **full u-boot** can't bring the eMMC up.

## Root cause

The bump started a fresh `v2026.07-sunxi64` patchdir and, per its commit message, only re-added a **listed set** of board patches. **`board_lime-a64` was dropped.** Its `add-a64-olinuxino-emmc-support.patch` injected the `&mmc2` eMMC node into the DT. Without it, `a64-olinuxino_defconfig` builds the **base** `sun50i-a64-olinuxino` DT, which has **no eMMC node** → u-boot has nothing to init.

## Fix

Point the defconfig at upstream's ready-made **`sun50i-a64-olinuxino-emmc`** DT instead of re-carrying the old patch. It's *more complete* than the dropped patch — it adds **`vqmmc-supply = <&reg_eldo1>`** (the 1.8 V I/O rail the "voltage select" step needs) on top of `vmmc`, 8-bit bus, `non-removable`, `cap-mmc-hw-reset`. `CONFIG_MMC_SUNXI_SLOT_EXTRA=2` is already set.

```diff
-CONFIG_DEFAULT_DEVICE_TREE="sun50i-a64-olinuxino"
+CONFIG_DEFAULT_DEVICE_TREE="sun50i-a64-olinuxino-emmc"
```

## Validation

- Patch applies clean to u-boot v2026.07; the `-emmc` DTS is present upstream and includes the base DT + the `mmc2` node.
- **Hardware test pending:** rebuild u-boot for `lime-a64` and reflash — the eMMC should init and boot standalone.

## Note

The same board dir's `add-a64-olinuxino-spl-spi.patch` (SPL SPI-flash boot) was also dropped in the bump — separate feature, not restored here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default hardware configuration for A64 OLinuXino boards to use the eMMC-specific device tree.
  * Improved device detection and initialization for systems using onboard eMMC storage.
  * Preserved support for the additional MMC slot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->