### PR TITLE
odroidm1: clear SPI u-boot env on every (re)flash (fixes NVMe boot from SPI)

### DIFF
--- a/config/boards/odroidm1.conf
+++ b/config/boards/odroidm1.conf
@@ -50,10 +50,15 @@ function post_family_config__uboot_config() {
 		fi
 		flashcp "${extra_opts_flashcp[@]}" "${1}/idbloader-spi.img" /dev/mtd0 # write SPL
 		flashcp "${extra_opts_flashcp[@]}" "${1}/u-boot.itb" /dev/mtd2        # write u-boot
-		if fw_printenv | grep -q -i petitboot; then                           # Petitboot leaves a horrible env behind, clear it off if so
-			echo "Found traces of Petitboot in SPI u-boot environment, clearing SPI environment..." >&2
-			flash_erase /dev/mtd1 0 0 # clear u-boot env
-		fi
+		# Always clear the SPI env (mtd1) when (re)flashing u-boot. A saved env
+		# left behind by a previous u-boot - Hardkernel's petitboot, or an older
+		# Armbian build - is loaded in preference to the new u-boot's built-in
+		# environment and SHADOWS its boot order. Symptom: the board runs a stale
+		# 'bootcmd' (e.g. an undefined "mtd_boot") and a pre-nvme 'boot_targets',
+		# so it never scans NVMe and falls through to USB/network. Erasing mtd1
+		# lets the fresh u-boot regenerate its default env (which includes nvme).
+		echo "Clearing SPI u-boot environment (mtd1) so the new u-boot's boot order takes effect..." >&2
+		flash_erase /dev/mtd1 0 0
 	}
 }
 


### PR DESCRIPTION
## Problem

"Boot from SPI, root on NVMe" on the Odroid M1 doesn't boot. Serial shows u-boot loads from SPI fine, then:

```
Loading Environment from SPIFlash... OK
Card did not respond to voltage select! : -110
## Error: "mtd_boot" not defined            (×3)
starting USB... → BOOTP/DHCP → no boot
```

It **never scans NVMe**, and reflashing a newer u-boot (2026.01 → 2026.07) changes nothing.

## Root cause — stale SPI env shadows the new u-boot

`write_uboot_platform_mtd` writes SPL (mtd0) and u-boot (mtd2) but only erases the env partition (mtd1) **if it detects petitboot**:

```bash
if fw_printenv | grep -q -i petitboot; then flash_erase /dev/mtd1 0 0; fi
```

Any *other* saved env — an older Armbian u-boot, or a factory env that doesn't match the petitboot string — survives, and u-boot loads it (`Loading Environment from SPIFlash... OK`) in preference to its built-in default. That stale env's `bootcmd` runs **`mtd_boot`** (which doesn't exist in the current u-boot — grep of the whole 2026.07 tree finds nothing) and its `boot_targets` predates **nvme**. So NVMe is never scanned. Because the reflash never touches mtd1, both 2026.01 and 2026.07 fail identically.

The board's built-in `BOOT_TARGETS` (and the board's boot-order override) already include nvme — they're just being overridden by the saved env.

## Fix

Always `flash_erase /dev/mtd1` when (re)flashing u-boot to SPI, so the fresh u-boot regenerates its default env with the correct boot order. A fresh install should reset the env to match the bootloader.

## Confirming on hardware (no rebuild needed)

At the M1 u-boot prompt this reproduces the fix immediately:
```
printenv bootcmd        # references mtd_boot
printenv boot_targets   # no nvme
env default -a ; saveenv ; reset   # → scans NVMe, boots
```

## Scope

This is the board-hook side. The configng installer (PR #973) correctly calls `write_uboot_platform_mtd`; nothing to change there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Odroid M1 U-Boot flashing reliability by consistently clearing the SPI environment partition after updating bootloader images.
  * Prevents stale boot configuration data from interfering with newly flashed systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->