### PR TITLE
nanopi-m5: drop GMAC tx_delay to stop the gigabit link flapping

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/board-nanopi-m5-add-wifi-bt-ufs-and-misc.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-nanopi-m5-add-wifi-bt-ufs-and-misc.patch
@@ -25,11 +25,6 @@ schematics. Fill in the gaps:
   - Pinctrl: add the matching wireless-bluetooth and wireless-wlan
     groups for uart5_gpios / wifi_host_wake_irq / wifi_poweren_gpio.
 
-  - GMAC: set RGMII tx_delay (0x21 on gmac0, 0x20 on gmac1) to match
-    the FriendlyElec vendor kernel. Leave rx_delay unset: the on-board
-    RTL8211F PHYs use rgmii-id and apply the RX delay internally, so an
-    extra SoC-side rx_delay double-delays RX and breaks gigabit.
-
   - ADC keys: add the saradc back button on saradc channel 0
     (~17 mV press threshold) so the BACK key on the carrier works.
 
@@ -49,8 +44,8 @@ schematics. Fill in the gaps:
 
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 110 +++++++++-
- 1 file changed, 108 insertions(+), 2 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 108 +++++++++-
+ 1 file changed, 106 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts b/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts
 index 111111111111..222222222222 100644
@@ -108,23 +103,7 @@ index 111111111111..222222222222 100644
  	sound {
  		compatible = "simple-audio-card";
  		pinctrl-names = "default";
-@@ -288,6 +326,7 @@ &gmac0 {
- 		    <&eth0m0_rx_bus2>,
- 		    <&eth0m0_rgmii_clk>,
- 		    <&eth0m0_rgmii_bus>;
-+	tx_delay = <0x21>;
- 	status = "okay";
- };
- 
-@@ -302,6 +341,7 @@ &gmac1 {
- 		    <&eth1m0_rx_bus2>,
- 		    <&eth1m0_rgmii_clk>,
- 		    <&eth1m0_rgmii_bus>;
-+	tx_delay = <0x20>;
- 	status = "okay";
- };
- 
-@@ -846,6 +886,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
+@@ -846,6 +884,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
  			rockchip,pins = <0 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -147,7 +126,7 @@ index 111111111111..222222222222 100644
  };
  
  &sai2 {
-@@ -857,6 +913,24 @@ &saradc {
+@@ -857,6 +911,24 @@ &saradc {
  	status = "okay";
  };
  
@@ -172,7 +151,7 @@ index 111111111111..222222222222 100644
  &sdmmc {
  	bus-width = <4>;
  	cap-mmc-highspeed;
-@@ -910,13 +984,45 @@ &uart0 {
+@@ -910,13 +982,45 @@ &uart0 {
  	status = "okay";
  };
  

--- a/patch/kernel/archive/rockchip64-7.1/board-nanopi-m5-add-wifi-bt-and-misc.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-nanopi-m5-add-wifi-bt-and-misc.patch
@@ -18,11 +18,6 @@ Fill in the gaps:
   - Pinctrl: add the matching wireless-bluetooth and wireless-wlan
     groups for uart5_gpios / wifi_host_wake_irq / wifi_poweren_gpio.
 
-  - GMAC: set RGMII tx_delay (0x21 on gmac0, 0x20 on gmac1) to match
-    the FriendlyElec vendor kernel. Leave rx_delay unset: the on-board
-    RTL8211F PHYs use rgmii-id and apply the RX delay internally, so an
-    extra SoC-side rx_delay double-delays RX and breaks gigabit.
-
   - ADC keys: add the saradc back button on saradc channel 0
     (~17 mV press threshold) so the BACK key on the carrier works.
 
@@ -42,8 +37,8 @@ Fill in the gaps:
 
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 86 +++++++++-
- 1 file changed, 84 insertions(+), 2 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 84 +++++++++-
+ 1 file changed, 82 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts b/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts
 index 111111111111..222222222222 100644
@@ -78,23 +73,7 @@ index 111111111111..222222222222 100644
  	sound {
  		compatible = "simple-audio-card";
  		pinctrl-names = "default";
-@@ -304,6 +326,7 @@ &gmac0 {
- 		    <&eth0m0_rx_bus2>,
- 		    <&eth0m0_rgmii_clk>,
- 		    <&eth0m0_rgmii_bus>;
-+	tx_delay = <0x21>;
- 	status = "okay";
- };
- 
-@@ -318,6 +341,7 @@ &gmac1 {
- 		    <&eth1m0_rx_bus2>,
- 		    <&eth1m0_rgmii_clk>,
- 		    <&eth1m0_rgmii_bus>;
-+	tx_delay = <0x20>;
- 	status = "okay";
- };
- 
-@@ -866,6 +890,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
+@@ -866,6 +888,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
  			rockchip,pins = <0 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -117,7 +96,7 @@ index 111111111111..222222222222 100644
  };
  
  &sai2 {
-@@ -881,6 +921,24 @@ &saradc {
+@@ -881,6 +919,24 @@ &saradc {
  	status = "okay";
  };
  
@@ -142,7 +121,7 @@ index 111111111111..222222222222 100644
  &sdmmc {
  	bus-width = <4>;
  	cap-mmc-highspeed;
-@@ -934,6 +992,31 @@ &uart0 {
+@@ -934,6 +990,31 @@ &uart0 {
  	status = "okay";
  };
  
@@ -174,7 +153,7 @@ index 111111111111..222222222222 100644
  &ufshc {
  	vcc-supply = <&vcc_3v3_s3>;
  	vccq-supply = <&vcc1v2_ufs_vccq>;
-@@ -947,8 +1030,7 @@ &usbdp_phy {
+@@ -947,8 +1028,7 @@ &usbdp_phy {
  };
  
  &usb_drd0_dwc3 {

--- a/patch/kernel/archive/rockchip64-7.2/board-nanopi-m5-add-wifi-bt-and-misc.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-nanopi-m5-add-wifi-bt-and-misc.patch
@@ -18,11 +18,6 @@ Fill in the gaps:
   - Pinctrl: add the matching wireless-bluetooth and wireless-wlan
     groups for uart5_gpios / wifi_host_wake_irq / wifi_poweren_gpio.
 
-  - GMAC: set RGMII tx_delay (0x21 on gmac0, 0x20 on gmac1) to match
-    the FriendlyElec vendor kernel. Leave rx_delay unset: the on-board
-    RTL8211F PHYs use rgmii-id and apply the RX delay internally, so an
-    extra SoC-side rx_delay double-delays RX and breaks gigabit.
-
   - ADC keys: add the saradc back button on saradc channel 0
     (~17 mV press threshold) so the BACK key on the carrier works.
 
@@ -42,8 +37,8 @@ Fill in the gaps:
 
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 86 +++++++++-
- 1 file changed, 84 insertions(+), 2 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts | 84 +++++++++-
+ 1 file changed, 82 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts b/arch/arm64/boot/dts/rockchip/rk3576-nanopi-m5.dts
 index 111111111111..222222222222 100644
@@ -78,23 +73,7 @@ index 111111111111..222222222222 100644
  	sound {
  		compatible = "simple-audio-card";
  		pinctrl-names = "default";
-@@ -304,6 +326,7 @@ &gmac0 {
- 		    <&eth0m0_rx_bus2>,
- 		    <&eth0m0_rgmii_clk>,
- 		    <&eth0m0_rgmii_bus>;
-+	tx_delay = <0x21>;
- 	status = "okay";
- };
- 
-@@ -318,6 +341,7 @@ &gmac1 {
- 		    <&eth1m0_rx_bus2>,
- 		    <&eth1m0_rgmii_clk>,
- 		    <&eth1m0_rgmii_bus>;
-+	tx_delay = <0x20>;
- 	status = "okay";
- };
- 
-@@ -875,6 +899,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
+@@ -875,6 +897,22 @@ usb_otg0_pwren_h: usb-otg0-pwren-h {
  			rockchip,pins = <0 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -117,7 +96,7 @@ index 111111111111..222222222222 100644
  };
  
  &sai2 {
-@@ -890,6 +930,24 @@ &saradc {
+@@ -890,6 +928,24 @@ &saradc {
  	status = "okay";
  };
  
@@ -142,7 +121,7 @@ index 111111111111..222222222222 100644
  &sdmmc {
  	bus-width = <4>;
  	cap-mmc-highspeed;
-@@ -943,6 +1001,31 @@ &uart0 {
+@@ -943,6 +999,31 @@ &uart0 {
  	status = "okay";
  };
  
@@ -174,7 +153,7 @@ index 111111111111..222222222222 100644
  &ufshc {
  	vcc-supply = <&vcc_3v3_s3>;
  	vccq-supply = <&vcc1v2_ufs_vccq>;
-@@ -956,8 +1039,7 @@ &usbdp_phy {
+@@ -956,8 +1037,7 @@ &usbdp_phy {
  };
  
  &usb_drd0_dwc3 {


### PR DESCRIPTION
# Description

The M5 declares `tx_delay` on both GMACs while the DTS keeps `phy-mode = "rgmii-id"`, so the on-board RTL8211F is already adding that delay itself. Mainline dwmac-rk ignores the DT values in that mode and passes 0/0, so the property sat there doing nothing and nobody noticed it was wrong.

rockchip64-6.18 carries a WIP rework of dwmac-rk, picked up for the Radxa E24C switch, that collapses the four RGMII cases into one and programs whatever the DT asks for even in rgmii-id. From that point the 0x21 and 0x20 land on top of the delay the PHY applies, TX timing goes out of spec, and the link comes up at 1Gbps and drops a few seconds later, over and over, with no usable traffic in between.

This is the other half of #9901. Dropping `rx_delay` there fixed the receive side for the same reason and left `tx_delay` behind. Upstream's `rk3576-nanopi-m5.dts` declares no delays at all, which is where the board ends up here.

edge and bleedingedge are not affected today, the same rework sits in those families as `.disabled`, but the property is equally meaningless there so it goes from all three.

# How Has This Been Tested?

- [x] NanoPi M5 on current 6.18.42 built from this branch
- [x] Before: 70 link events in dmesg, `Link is Up - 1Gbps/Full` followed by `Link is Down` every 6 seconds or so, carrier_changes at 32 on end0 and 38 on end1
- [x] After: a single link event, carrier_changes stays at 1, DHCP lease picked up straight away
- [x] `ping -f -s 1472 -c 20000` at the gateway: 20000 transmitted, 20000 received, 0% packet loss, rtt avg 0.323 ms, and every ethtool error counter still zero
- [x] Both ports, end0 and end1
- [x] DTBs for current 6.18.42, edge 7.1.6 and bleedingedge 7.2-rc4 built and read back with fdtget: no `tx_delay` on either GMAC, `phy-mode` still rgmii-id
- [x] armbianmonitor: https://paste.armbian.com/hequqiwici

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
