### PR TITLE
BeagleY - Fix small broken GRS Arcade Button Mapping

### DIFF
--- a/patch/kernel/archive/k3-beagle-7.2/dt/k3-am67a-beagley-ai-grs-build-a-cade-buttons.dtso
+++ b/patch/kernel/archive/k3-beagle-7.2/dt/k3-am67a-beagley-ai-grs-build-a-cade-buttons.dtso
@@ -17,7 +17,8 @@
 	grs_arcade_keys: grs-arcade-keys {
 		compatible = "gpio-keys";
 		pinctrl-names = "default";
-		pinctrl-0 = <&grs_arcade_keys_pins>;
+		pinctrl-0 = <&grs_arcade_keys_pins
+			     &grs_arcade_mcu_keys_pins>;
 		label = "GRS Build-A-Cade controls";
 
 		joystick-left {
@@ -57,14 +58,14 @@
 
 		button-select {
 			label = "Coin 1 Select";
-			gpios = <&main_gpio0 4 GPIO_ACTIVE_LOW>;
+			gpios = <&mcu_gpio0 4 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_5>;
 			debounce-interval = <10>;
 		};
 
 		button-start {
 			label = "Player 1 Start";
-			gpios = <&main_gpio0 3 GPIO_ACTIVE_LOW>;
+			gpios = <&mcu_gpio0 3 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_1>;
 			debounce-interval = <10>;
 		};
@@ -148,8 +149,6 @@
 			J722S_IOPAD(0x0198, PIN_INPUT_PULLUP, 7) /* GPIO1_8: BCM17 */
 			J722S_IOPAD(0x0088, PIN_INPUT_PULLUP, 7) /* GPIO0_33: BCM27 */
 			J722S_IOPAD(0x00a8, PIN_INPUT_PULLUP, 7) /* GPIO0_41: BCM22 */
-			J722S_IOPAD(0x000c, PIN_INPUT_PULLUP, 7) /* GPIO0_3: BCM10 */
-			J722S_IOPAD(0x0010, PIN_INPUT_PULLUP, 7) /* GPIO0_4: BCM9 */
 			J722S_IOPAD(0x01b4, PIN_INPUT_PULLUP, 7) /* GPIO1_15: BCM5 */
 			J722S_IOPAD(0x01bc, PIN_INPUT_PULLUP, 7) /* GPIO1_17: BCM6 */
 			J722S_IOPAD(0x01a8, PIN_INPUT_PULLUP, 7) /* GPIO1_12: BCM19 */
@@ -161,6 +160,15 @@
 			J722S_IOPAD(0x00ac, PIN_INPUT_PULLUP, 7) /* GPIO0_42: BCM25 */
 			J722S_IOPAD(0x01a0, PIN_INPUT_PULLUP, 7) /* GPIO1_10: BCM20 */
 			J722S_IOPAD(0x019c, PIN_INPUT_PULLUP, 7) /* GPIO1_9: BCM21 */
+		>;
+	};
+};
+
+&mcu_pmx0 {
+	grs_arcade_mcu_keys_pins: grs-arcade-mcu-keys-pins {
+		pinctrl-single,pins = <
+			J722S_MCU_IOPAD(0x000c, PIN_INPUT_PULLUP, 7) /* MCU_GPIO0_3: BCM10 */
+			J722S_MCU_IOPAD(0x0010, PIN_INPUT_PULLUP, 7) /* MCU_GPIO0_4: BCM9 */
 		>;
 	};
 };


### PR DESCRIPTION
Missed GPIO assignment for 2 of the buttons in previous commit. 

# How Has This Been Tested?

Tested locally on-device. 

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
