### PR TITLE
rockchip64: fix RK3568 IOMMU v2 page table allocation for NPU workloads

### DIFF
--- a/patch/kernel/rockchip64-current/0001-iommu-rockchip-force-DMA32-for-rk3568-iommu-v2.patch
+++ b/patch/kernel/rockchip64-current/0001-iommu-rockchip-force-DMA32-for-rk3568-iommu-v2.patch
@@ -1,37 +1,53 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Vitalij Borissow <250549977+vitalijborissow@users.noreply.github.com>
-Date: Sat, 15 Feb 2026 21:30:00 +0100
+From: Frantisek Repkovsky <frantisek.repkovsky@gmail.com>
+Date: Sun, 2 Aug 2026 18:47:32 +0000
 Subject: iommu/rockchip: Force GFP_DMA32 for rk3568-iommu v2
 
-On systems with >4GB RAM, the RK3568 IOMMU v2 allocates page tables from
-high memory (above 4GB). While the IOMMU claims 40-bit address support,
-some devices like the NPU cannot properly handle page tables located
-above 4GB, resulting in DMA mapping failures and NPU timeouts.
+This patch originates from here:
+https://lore.kernel.org/all/20260331075010.1463-1-midgy971@gmail.com/#t
 
-This patch forces GFP_DMA32 allocation for IOMMU v2 page tables,
-ensuring all allocations are within the first 4GB of physical memory.
+On boards with more than 4 GB of RAM (e.g. 8 GB LPDDR4X), removing
+GFP_DMA32 causes two distinct failure modes:
 
-Tested on ODROID-M1 with 8GB RAM running kernel 6.18.9-current-rockchip64.
-Without this patch, NPU inference fails with IOMMU page table access errors.
-With this patch, NPU operates correctly with full IOMMU support enabled.
+1. Direct allocation above 4 GB: iommu_alloc_pages_sz() may return
+   memory above 0x100000000.  The hardware page-table walker issues a
+   bus error trying to dereference those addresses, causing an IOMMU
+   fault on the first DMA transaction.
 
-Signed-off-by: Vitalij Borissow <250549977+vitalijborissow@users.noreply.github.com>
+2. SWIOTLB bounce-buffer poisoning: without GFP_DMA32, page tables land
+   above the SWIOTLB window.  dma_map_single() with DMA_BIT_MASK(32)
+   then bounces them into a buffer below 4 GB.  rk_dte_get_page_table()
+   returns phys_to_virt() of the bounce buffer address; PTEs are written
+   there; the next dma_sync_single_for_device(DMA_TO_DEVICE) copies the
+   original (zero) data back over the bounce buffer, silently erasing the
+   freshly written PTEs.  The IOMMU faults because every PTE reads as zero.
+
+Restore GFP_DMA32 (and DMA_BIT_MASK(32)) for iommu_data_ops_v2, which
+currently only serves "rockchip,rk3568-iommu" in mainline.
+
+Signed-off-by: Frantisek Repkovsky <frantisek.repkovsky@gmail.com>
 ---
- drivers/iommu/rockchip-iommu.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ drivers/iommu/rockchip-iommu.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/iommu/rockchip-iommu.c b/drivers/iommu/rockchip-iommu.c
-index 111111111111..222222222222 100644
+index 0861dd469..daea5dd8c 100644
 --- a/drivers/iommu/rockchip-iommu.c
 +++ b/drivers/iommu/rockchip-iommu.c
-@@ -1349,7 +1349,7 @@ static struct rk_iommu_ops iommu_data_ops_v2 = {
+@@ -1346,12 +1346,12 @@ static struct rk_iommu_ops iommu_data_ops_v1 = {
+ 
+ static struct rk_iommu_ops iommu_data_ops_v2 = {
+ 	.pt_address = &rk_dte_pt_address_v2,
  	.mk_dtentries = &rk_mk_dte_v2,
  	.mk_ptentries = &rk_mk_pte_v2,
- 	.dma_bit_mask = DMA_BIT_MASK(40),
+-	.dma_bit_mask = DMA_BIT_MASK(40),
 -	.gfp_flags = 0,
++	.dma_bit_mask = DMA_BIT_MASK(32),
 +	.gfp_flags = GFP_DMA32,
  };
  
  static const struct of_device_id rk_iommu_dt_ids[] = {
+ 	{	.compatible = "rockchip,iommu",
+ 		.data = &iommu_data_ops_v1,
 -- 
-Armbian
+Created with Armbian build tools https://github.com/armbian/build


### PR DESCRIPTION
# Description

This PR updates the RK3568 IOMMU v2 patch originally introduced in PR #9403.

While testing NPU enablement on an ODROID-M1 (RK3568, 8 GB RAM), I found that the existing patch was not sufficient to reliably support RKNN inference workloads. The NPU driver and runtime initialized correctly, but inference failed when the first NPU job was submitted.

### Problem

With the NPU IOMMU enabled, RKNN model execution failed with errors similar to:

```
E RKNN: failed to submit, op id: 1
E RKNN: op name: Conv:/model.0/convsp/Conv
rknn_run fail! ret=-1
```

As a temporary workaround, disabling the NPU IOMMU in the DTS allowed inference to complete successfully, indicating that the issue was related to the IOMMU path rather than the NPU driver, runtime, clocks, power domain, or devfreq configuration.

### Root Cause

The RK3568 NPU appears to be unable to reliably operate when IOMMU v2 page tables are allocated above the 4 GB physical address boundary.

The existing patch addressed part of the issue, but iommu_data_ops_v2 was still configured in a way that allowed allocations outside the range that the NPU can handle.

### Fix

Update iommu_data_ops_v2 to use:

```
.dma_bit_mask = DMA_BIT_MASK(32)
.gfp_flags = GFP_DMA32
```
# Discussion and Background

Updated IOMMU patch is based on the original [upstream discussion](https://lore.kernel.org/all/20260331075010.1463-1-midgy971@gmail.com/#t)
 
The issue and investigation details have been discussed on the Armbian forum:
[ODROID-M1 NPU fully working on Armbian 6.18.x](https://forum.armbian.com/topic/58036-odroid-m1-npu-fully-working-on-armbian-618x/)
 
The forum thread contains the testing history, DTS changes, NPU bring-up work, troubleshooting steps, and validation results that led to identifying the incomplete IOMMU v2 configuration.

# Documentation summary for feature / change

- [x] short description: [iommu/rockchip: force 32-bit DMA for RK3568 IOMMU v2](rockchip64: fix RK3568 IOMMU v2 page table allocation for NPU workloads)
- [x] summary: This patch fixes IOMMU page table allocation on RK3568 boards with more than 4GB of RAM, enabling proper operation of the NPU and other 32-bit DMA devices. The patch forces IOMMU page tables to be allocated below 4GB, which is required for devices that cannot access high memory addresses.
- [x] example of usage: After applying this patch and installing RKNPU DKMS drivers, users can verify NPU operation with:

```
# dmesg | grep -i rkn
[drm] Initialized rknpu 0.9.8 for fde40000.npu on minor 1
RKNPU fde40000.npu: RKNPU: DKMS: /dev/rknpu registered (DMA-BUF import only)
RKNPU fde40000.npu: RKNPU: SCMI clock 198 MHz
RKNPU fde40000.npu: RKNPU: devfreq active (SCMI-only, OPP 200-1000 MHz)
RKNPU fde40000.npu: RKNPU: thermal throttling enabled
RKNPU fde40000.npu: RKNPU: sram region: [0x00000000fdcc0000, 0x00000000fdccb000), sram size: 0xb000

# dmesg | grep -i iommu
iommu: Default domain type: Translated
iommu: DMA domain TLB invalidation policy: strict mode
platform fde40000.npu: Adding to iommu group 0
platform fdea0000.video-codec: Adding to iommu group 1
platform fdee0000.video-codec: Adding to iommu group 2
platform fe040000.vop: Adding to iommu group 3 

```
# How Has This Been Tested?

- Board: ODROID-M1 (RK3568)
- RAM: 8 GB
- Kernel: 6.18.42-current-rockchip64
- Driver: [community DKMS RKNPU driver](https://github.com/frepkovsky/rk3568-npu-ODROID-M1)
- Runtime: RKNN runtime 2.3.2

Results:

- NPU driver loads successfully
- /dev/rknpu is created
- NPU devfreq operates correctly
- IOMMU remains enabled
- RKNN YOLOv5 inference completes successfully
- Object detection results are produced correctly

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DMA memory handling for Rockchip RK3568 systems.
  * Enhanced compatibility and stability for devices using the Rockchip IOMMU v2 hardware.
  * Resolved issues that could affect memory allocation and device operation when addressing DMA buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->