### PR TITLE
board: orangepi-5b: fix BT host-wake IRQ direction

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3588s-orangepi-5b.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3588s-orangepi-5b.dts
@@ -26,6 +26,11 @@
 };
 
 &pinctrl {
+	pcfg_input_enable: pcfg-input-enable {
+		bias-disable;
+		input-enable;
+	};
+
 	wireless-bluetooth {
 		bt_reset_pin: bt-reset-pin {
 			rockchip,pins = <3 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
@@ -36,7 +41,7 @@
 		};
 
 		bt_wake_host_irq: bt-wake-host-irq {
-			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_down>;
+			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_input_enable>;
 		};
 
 	};

--- a/patch/kernel/archive/rockchip64-7.1/dt/rk3588s-orangepi-5b.dts
+++ b/patch/kernel/archive/rockchip64-7.1/dt/rk3588s-orangepi-5b.dts
@@ -26,6 +26,11 @@
 };
 
 &pinctrl {
+	pcfg_input_enable: pcfg-input-enable {
+		bias-disable;
+		input-enable;
+	};
+
 	wireless-bluetooth {
 		bt_reset_pin: bt-reset-pin {
 			rockchip,pins = <3 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
@@ -36,7 +41,7 @@
 		};
 
 		bt_wake_host_irq: bt-wake-host-irq {
-			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_down>;
+			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_input_enable>;
 		};
 
 	};

--- a/patch/kernel/archive/rockchip64-7.2/dt/rk3588s-orangepi-5b.dts
+++ b/patch/kernel/archive/rockchip64-7.2/dt/rk3588s-orangepi-5b.dts
@@ -26,6 +26,11 @@
 };
 
 &pinctrl {
+	pcfg_input_enable: pcfg-input-enable {
+		bias-disable;
+		input-enable;
+	};
+
 	wireless-bluetooth {
 		bt_reset_pin: bt-reset-pin {
 			rockchip,pins = <3 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
@@ -36,7 +41,7 @@
 		};
 
 		bt_wake_host_irq: bt-wake-host-irq {
-			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_down>;
+			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_input_enable>;
 		};
 
 	};


### PR DESCRIPTION
# Description

Fixes #10370.

GPIO0_C5 boots as an output, so `gpiochip_lock_as_irq()` returns `-EIO` and the
BT host-wake IRQ never registers - two error lines every boot, and wake-on-BT
does not work. `pcfg_pull_down` sets bias only, not direction;
`PIN_CONFIG_INPUT_ENABLE` forces the GPIO mux and calls `direction_input()`.

`rockchip-pinconf.dtsi` has no pcfg node carrying `input-enable` (only
`pcfg_output_high` / `pcfg_output_low`), so one is declared locally.

Follow-up to #10289, which was untested on the 5B.

# How Has This Been Tested?

- [x] Tested on Orange Pi 5B hardware

Before: `gpioinfo` shows line 21 as `output`, unclaimed; no host_wake entry in
`/proc/interrupts`.

After: line 21 reads `input`, and the IRQ registers and delivers:

    99:  20  0  0  0  0  0  0  0  rockchip_gpio_irq  21 Edge  host_wake

WiFi and Bluetooth are otherwise unchanged. Verified on a mainline 7.1.3 kernel
using this DT wiring rather than via an Armbian build.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth host-wakeup pin handling on supported Orange Pi 5B devices.
  * Prevented unintended pull-down bias while keeping the wake-up input enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->