### PR TITLE
uefidt: bump edge kernel to 7.1

### DIFF
--- a/config/sources/families/uefidt.conf
+++ b/config/sources/families/uefidt.conf
@@ -15,7 +15,7 @@ declare -g KERNEL_DO_STUBBLE="yes"
 case $BRANCH in
 
 	edge)
-		declare -g KERNEL_MAJOR_MINOR="7.0"    # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="7.1"    # Major and minor versions of this kernel.
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		;;
 esac


### PR DESCRIPTION
Bumps the `uefidt` family's `edge` kernel from `7.0` to `7.1` in `config/sources/families/uefidt.conf`.