### PR TITLE
rockchip64: scope the rk3576 HS400 DLL calibration to rk3576 only

### DIFF
--- a/patch/kernel/archive/rockchip64-7.1/rk3576-0013-mmc-sdhci-dwcmshc-rk3576-dll-tap-calibration.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk3576-0013-mmc-sdhci-dwcmshc-rk3576-dll-tap-calibration.patch
@@ -1,16 +1,16 @@
 From: crackerjacques <jack@supremeoverlordjabs.co>
 Subject: [PATCH] mmc: sdhci-of-dwcmshc: rk3576: calibrate the HS400 DLL taps
 
-On dwcmshc revision 1 (rk3576) the HS400 path programs fixed DLL taps
-(TX and CMDOUT at 90 degrees, STRBIN at the generic default) and never
-feeds the measured DLL lock value back into the tap-value select. The
+On dwcmshc revision 1 the HS400 path programs fixed DLL taps (TX and
+CMDOUT at 90 degrees, STRBIN at the generic default) and never feeds the
+measured DLL lock value back into the tap-value select. The rk3576
 vendor driver does both: it reads the locked DLL value out of
 DLL_STATUS0 and supplies it as the tap-value select on every DLL clock
 line, and it uses different HS400 taps (TX 7, CMDOUT 7, STRBIN 5) plus
 BOTH_CLK_EDGE rather than EN_SRC_CLK_NEG on CMDOUT.
 
-Without that calibration the HS400 timing has very little margin on this
-SoC. On an Anbernic RG Vita Pro (rk3576, Micron eMMC in HS400-ES at
+Without that calibration the HS400 timing has very little margin on
+rk3576. On an Anbernic RG Vita Pro (rk3576, Micron eMMC in HS400-ES at
 200MHz) sustained I/O stalls with
 
   mmc0: Timeout waiting for hardware interrupt.
@@ -23,8 +23,10 @@ makes the stalls disappear entirely, which points at the HS400 timing
 rather than at the card or the filesystem: the eMMC reports a pristine
 PRE_EOL/LIFE_TIME and fsck finds nothing.
 
-Port the vendor calibration for revision 1 only, leaving revision 0
-(rk3566/rk3568) on its existing fixed taps.
+revision == 1 is shared by every non-rk356x SoC (rk3576, rk3588, ...),
+so gate the calibration on a dedicated needs_hs400_dll_calibration flag
+set only for rk3576. rk3588 and the other revision-1 SoCs keep their
+existing 90-degree CMDOUT taps and STRBIN default untouched.
 
 Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
@@ -37,85 +39,126 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +#define DLL_CMDOUT_BOTH_CLK_EDGE	BIT(30)
 +#define DLL_TAP_VALUE_SEL		BIT(25)
 +#define DLL_TAP_VALUE_OFFSET		8
-+/* HS400 DLL taps used by revision 1 (rk3576), taken from the vendor driver */
++/* HS400 DLL taps used by rk3576, taken from the vendor driver */
 +#define DLL_TXCLK_TAPNUM_RK3576		0x7
 +#define DLL_CMDOUT_TAPNUM_RK3576	0x7
 +#define DLL_STRBIN_TAPNUM_RK3576	0x5
-
+ 
  #define DLL_LOCK_WO_TMOUT(x) \
  	((((x) & DWCMSHC_EMMC_DLL_LOCKED) == DWCMSHC_EMMC_DLL_LOCKED) && \
-@@ -756,7 +763,7 @@
+@@ -333,6 +340,13 @@ struct rockchip_pltfm_data {
+ 	 * - Revision 1: Implemented in all other Rockchip SoCs, including RK3576, RK3588, etc.
+ 	 */
+ 	int revision;
++	/*
++	 * rk3576 additionally needs the vendor HS400 DLL tap calibration
++	 * (see dwcmshc_phy_1_8v_init()). Other revision-1 SoCs such as rk3588
++	 * must keep their existing taps, so gate it on a dedicated flag rather
++	 * than on revision == 1 (which is shared by all revision-1 SoCs).
++	 */
++	bool needs_hs400_dll_calibration;
+ };
+ 
+ static void dwcmshc_enable_card_clk(struct sdhci_host *host)
+@@ -756,7 +770,7 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
  	struct rk35xx_priv *priv = dwc_priv->priv;
  	const struct rockchip_pltfm_data *rockchip_pdata = to_pltfm_data(dwc_priv, rockchip);
  	u8 txclk_tapnum = DLL_TXCLK_TAPNUM_DEFAULT;
 -	u32 extra, reg;
 +	u32 extra, reg, dll_lock_value;
  	int err;
-
+ 
  	host->mmc->actual_clock = 0;
-@@ -842,23 +849,40 @@
+@@ -842,23 +856,54 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
  		goto enable_clk;
  	}
-
+ 
 +	dll_lock_value = ((sdhci_readl(host, DWCMSHC_EMMC_DLL_STATUS0) & 0xFF) * 2) & 0xFF;
 +
  	extra = 0x1 << 16 | /* tune clock stop en */
  		0x3 << 17 | /* pre-change delay */
  		0x3 << 19;  /* post-change delay */
  	sdhci_writel(host, extra, dwc_priv->vendor_specific_area1 + DWCMSHC_EMMC_ATCTRL);
-+
+ 
 +	/*
-+	 * Revision 1 (rk3576) feeds the measured DLL lock value back as the
-+	 * tap-value select on every DLL clock line. Without that calibration
-+	 * the HS400 timing has little margin and sustained I/O stalls with
-+	 * "Timeout waiting for hardware interrupt".
++	 * rk3576 feeds the measured DLL lock value back as the tap-value
++	 * select on every DLL clock line. Without that calibration the HS400
++	 * timing has little margin and sustained I/O stalls with "Timeout
++	 * waiting for hardware interrupt". Other revision-1 SoCs (rk3588, ...)
++	 * keep their existing taps, so gate this on the dedicated flag.
 +	 */
-+	if (rockchip_pdata->revision == 1) {
++	if (rockchip_pdata->needs_hs400_dll_calibration &&
++	    host->mmc->ios.timing == MMC_TIMING_MMC_HS400) {
 +		extra = DWCMSHC_EMMC_DLL_DLYENA |
 +			DLL_TAP_VALUE_SEL |
 +			dll_lock_value << DLL_TAP_VALUE_OFFSET;
 +		sdhci_writel(host, extra, DWCMSHC_EMMC_DLL_RXCLK);
 +	}
-
++
  	if (host->mmc->ios.timing == MMC_TIMING_MMC_HS200 ||
  	    host->mmc->ios.timing == MMC_TIMING_MMC_HS400)
  		txclk_tapnum = priv->txclk_tapnum;
-
+ 
  	if (rockchip_pdata->revision == 1 && host->mmc->ios.timing == MMC_TIMING_MMC_HS400) {
 -		txclk_tapnum = DLL_TXCLK_TAPNUM_90_DEGREES;
-+		txclk_tapnum = DLL_TXCLK_TAPNUM_RK3576;
-
- 		extra = DLL_CMDOUT_SRC_CLK_NEG |
+-
+-		extra = DLL_CMDOUT_SRC_CLK_NEG |
 -			DLL_CMDOUT_EN_SRC_CLK_NEG |
-+			DLL_CMDOUT_BOTH_CLK_EDGE |
- 			DWCMSHC_EMMC_DLL_DLYENA |
+-			DWCMSHC_EMMC_DLL_DLYENA |
 -			DLL_CMDOUT_TAPNUM_90_DEGREES |
 -			DLL_CMDOUT_TAPNUM_FROM_SW;
-+			DLL_CMDOUT_TAPNUM_RK3576 |
-+			DLL_CMDOUT_TAPNUM_FROM_SW |
-+			DLL_TAP_VALUE_SEL |
-+			dll_lock_value << DLL_TAP_VALUE_OFFSET;
++		if (rockchip_pdata->needs_hs400_dll_calibration) {
++			/* rk3576: calibrated taps plus the measured DLL lock value */
++			txclk_tapnum = DLL_TXCLK_TAPNUM_RK3576;
++
++			extra = DLL_CMDOUT_SRC_CLK_NEG |
++				DLL_CMDOUT_BOTH_CLK_EDGE |
++				DWCMSHC_EMMC_DLL_DLYENA |
++				DLL_CMDOUT_TAPNUM_RK3576 |
++				DLL_CMDOUT_TAPNUM_FROM_SW |
++				DLL_TAP_VALUE_SEL |
++				dll_lock_value << DLL_TAP_VALUE_OFFSET;
++		} else {
++			/* rk3588 and other revision-1 SoCs: original fixed taps */
++			txclk_tapnum = DLL_TXCLK_TAPNUM_90_DEGREES;
++
++			extra = DLL_CMDOUT_SRC_CLK_NEG |
++				DLL_CMDOUT_EN_SRC_CLK_NEG |
++				DWCMSHC_EMMC_DLL_DLYENA |
++				DLL_CMDOUT_TAPNUM_90_DEGREES |
++				DLL_CMDOUT_TAPNUM_FROM_SW;
++		}
  		sdhci_writel(host, extra, DECMSHC_EMMC_DLL_CMDOUT);
  	}
-
-@@ -866,11 +892,19 @@
+ 
+@@ -866,11 +911,21 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
  		DLL_TXCLK_TAPNUM_FROM_SW |
  		DLL_RXCLK_NO_INVERTER << DWCMSHC_EMMC_DLL_RXCLK_SRCSEL |
  		txclk_tapnum;
-+	if (rockchip_pdata->revision == 1)
++	if (rockchip_pdata->needs_hs400_dll_calibration &&
++	    host->mmc->ios.timing == MMC_TIMING_MMC_HS400)
 +		extra |= DLL_TAP_VALUE_SEL |
 +			 dll_lock_value << DLL_TAP_VALUE_OFFSET;
  	sdhci_writel(host, extra, DWCMSHC_EMMC_DLL_TXCLK);
-
+ 
  	extra = DWCMSHC_EMMC_DLL_DLYENA |
 -		DLL_STRBIN_TAPNUM_DEFAULT |
  		DLL_STRBIN_TAPNUM_FROM_SW;
-+	if (rockchip_pdata->revision == 1)
++	if (rockchip_pdata->needs_hs400_dll_calibration &&
++	    host->mmc->ios.timing == MMC_TIMING_MMC_HS400)
 +		extra |= DLL_STRBIN_TAPNUM_RK3576 |
 +			 DLL_TAP_VALUE_SEL |
 +			 dll_lock_value << DLL_TAP_VALUE_OFFSET;
 +	else
 +		extra |= DLL_STRBIN_TAPNUM_DEFAULT;
  	sdhci_writel(host, extra, DWCMSHC_EMMC_DLL_STRBIN);
-
+ 
  enable_clk:
+@@ -2152,6 +2207,7 @@ static const struct rockchip_pltfm_data sdhci_dwcmshc_rk3576_pdata = {
+ 		.postinit = dwcmshc_rk3576_postinit,
+ 	},
+ 	.revision = 1,
++	.needs_hs400_dll_calibration = true,
+ };
+ 
+ static const struct rockchip_pltfm_data sdhci_dwcmshc_rk3588_pdata = {

--- a/patch/kernel/archive/rockchip64-7.2/rk3576-0013-mmc-sdhci-dwcmshc-rk3576-dll-tap-calibration.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3576-0013-mmc-sdhci-dwcmshc-rk3576-dll-tap-calibration.patch
@@ -1,18 +1,16 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Date: Wed, 29 Jul 2026 19:19:21 +0200
-Subject: mmc: sdhci-of-dwcmshc: rk3576: calibrate the HS400 DLL taps
+Subject: [PATCH] mmc: sdhci-of-dwcmshc: rk3576: calibrate the HS400 DLL taps
 
-On dwcmshc revision 1 (rk3576) the HS400 path programs fixed DLL taps
-(TX and CMDOUT at 90 degrees, STRBIN at the generic default) and never
-feeds the measured DLL lock value back into the tap-value select. The
+On dwcmshc revision 1 the HS400 path programs fixed DLL taps (TX and
+CMDOUT at 90 degrees, STRBIN at the generic default) and never feeds the
+measured DLL lock value back into the tap-value select. The rk3576
 vendor driver does both: it reads the locked DLL value out of
 DLL_STATUS0 and supplies it as the tap-value select on every DLL clock
 line, and it uses different HS400 taps (TX 7, CMDOUT 7, STRBIN 5) plus
 BOTH_CLK_EDGE rather than EN_SRC_CLK_NEG on CMDOUT.
 
-Without that calibration the HS400 timing has very little margin on this
-SoC. On an Anbernic RG Vita Pro (rk3576, Micron eMMC in HS400-ES at
+Without that calibration the HS400 timing has very little margin on
+rk3576. On an Anbernic RG Vita Pro (rk3576, Micron eMMC in HS400-ES at
 200MHz) sustained I/O stalls with
 
   mmc0: Timeout waiting for hardware interrupt.
@@ -25,16 +23,13 @@ makes the stalls disappear entirely, which points at the HS400 timing
 rather than at the card or the filesystem: the eMMC reports a pristine
 PRE_EOL/LIFE_TIME and fsck finds nothing.
 
-Port the vendor calibration for revision 1 only, leaving revision 0
-(rk3566/rk3568) on its existing fixed taps.
+revision == 1 is shared by every non-rk356x SoC (rk3576, rk3588, ...),
+so gate the calibration on a dedicated needs_hs400_dll_calibration flag
+set only for rk3576. rk3588 and the other revision-1 SoCs keep their
+existing 90-degree CMDOUT taps and STRBIN default untouched.
 
 Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 ---
- drivers/mmc/host/sdhci-of-dwcmshc.c | 44 ++++++++--
- 1 file changed, 38 insertions(+), 6 deletions(-)
-
-diff --git a/drivers/mmc/host/sdhci-of-dwcmshc.c b/drivers/mmc/host/sdhci-of-dwcmshc.c
-index 111111111111..222222222222 100644
 --- a/drivers/mmc/host/sdhci-of-dwcmshc.c
 +++ b/drivers/mmc/host/sdhci-of-dwcmshc.c
 @@ -117,6 +117,13 @@
@@ -44,14 +39,28 @@ index 111111111111..222222222222 100644
 +#define DLL_CMDOUT_BOTH_CLK_EDGE	BIT(30)
 +#define DLL_TAP_VALUE_SEL		BIT(25)
 +#define DLL_TAP_VALUE_OFFSET		8
-+/* HS400 DLL taps used by revision 1 (rk3576), taken from the vendor driver */
++/* HS400 DLL taps used by rk3576, taken from the vendor driver */
 +#define DLL_TXCLK_TAPNUM_RK3576		0x7
 +#define DLL_CMDOUT_TAPNUM_RK3576	0x7
 +#define DLL_STRBIN_TAPNUM_RK3576	0x5
  
  #define DLL_LOCK_WO_TMOUT(x) \
  	((((x) & DWCMSHC_EMMC_DLL_LOCKED) == DWCMSHC_EMMC_DLL_LOCKED) && \
-@@ -756,7 +763,7 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
+@@ -333,6 +340,13 @@ struct rockchip_pltfm_data {
+ 	 * - Revision 1: Implemented in all other Rockchip SoCs, including RK3576, RK3588, etc.
+ 	 */
+ 	int revision;
++	/*
++	 * rk3576 additionally needs the vendor HS400 DLL tap calibration
++	 * (see dwcmshc_phy_1_8v_init()). Other revision-1 SoCs such as rk3588
++	 * must keep their existing taps, so gate it on a dedicated flag rather
++	 * than on revision == 1 (which is shared by all revision-1 SoCs).
++	 */
++	bool needs_hs400_dll_calibration;
+ };
+ 
+ static void dwcmshc_enable_card_clk(struct sdhci_host *host)
+@@ -756,7 +770,7 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
  	struct rk35xx_priv *priv = dwc_priv->priv;
  	const struct rockchip_pltfm_data *rockchip_pdata = to_pltfm_data(dwc_priv, rockchip);
  	u8 txclk_tapnum = DLL_TXCLK_TAPNUM_DEFAULT;
@@ -60,7 +69,7 @@ index 111111111111..222222222222 100644
  	int err;
  
  	host->mmc->actual_clock = 0;
-@@ -842,23 +849,40 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
+@@ -842,23 +856,54 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
  		goto enable_clk;
  	}
  
@@ -72,12 +81,14 @@ index 111111111111..222222222222 100644
  	sdhci_writel(host, extra, dwc_priv->vendor_specific_area1 + DWCMSHC_EMMC_ATCTRL);
  
 +	/*
-+	 * Revision 1 (rk3576) feeds the measured DLL lock value back as the
-+	 * tap-value select on every DLL clock line. Without that calibration
-+	 * the HS400 timing has little margin and sustained I/O stalls with
-+	 * "Timeout waiting for hardware interrupt".
++	 * rk3576 feeds the measured DLL lock value back as the tap-value
++	 * select on every DLL clock line. Without that calibration the HS400
++	 * timing has little margin and sustained I/O stalls with "Timeout
++	 * waiting for hardware interrupt". Other revision-1 SoCs (rk3588, ...)
++	 * keep their existing taps, so gate this on the dedicated flag.
 +	 */
-+	if (rockchip_pdata->revision == 1) {
++	if (rockchip_pdata->needs_hs400_dll_calibration &&
++	    host->mmc->ios.timing == MMC_TIMING_MMC_HS400) {
 +		extra = DWCMSHC_EMMC_DLL_DLYENA |
 +			DLL_TAP_VALUE_SEL |
 +			dll_lock_value << DLL_TAP_VALUE_OFFSET;
@@ -90,26 +101,42 @@ index 111111111111..222222222222 100644
  
  	if (rockchip_pdata->revision == 1 && host->mmc->ios.timing == MMC_TIMING_MMC_HS400) {
 -		txclk_tapnum = DLL_TXCLK_TAPNUM_90_DEGREES;
-+		txclk_tapnum = DLL_TXCLK_TAPNUM_RK3576;
- 
- 		extra = DLL_CMDOUT_SRC_CLK_NEG |
+-
+-		extra = DLL_CMDOUT_SRC_CLK_NEG |
 -			DLL_CMDOUT_EN_SRC_CLK_NEG |
-+			DLL_CMDOUT_BOTH_CLK_EDGE |
- 			DWCMSHC_EMMC_DLL_DLYENA |
+-			DWCMSHC_EMMC_DLL_DLYENA |
 -			DLL_CMDOUT_TAPNUM_90_DEGREES |
 -			DLL_CMDOUT_TAPNUM_FROM_SW;
-+			DLL_CMDOUT_TAPNUM_RK3576 |
-+			DLL_CMDOUT_TAPNUM_FROM_SW |
-+			DLL_TAP_VALUE_SEL |
-+			dll_lock_value << DLL_TAP_VALUE_OFFSET;
++		if (rockchip_pdata->needs_hs400_dll_calibration) {
++			/* rk3576: calibrated taps plus the measured DLL lock value */
++			txclk_tapnum = DLL_TXCLK_TAPNUM_RK3576;
++
++			extra = DLL_CMDOUT_SRC_CLK_NEG |
++				DLL_CMDOUT_BOTH_CLK_EDGE |
++				DWCMSHC_EMMC_DLL_DLYENA |
++				DLL_CMDOUT_TAPNUM_RK3576 |
++				DLL_CMDOUT_TAPNUM_FROM_SW |
++				DLL_TAP_VALUE_SEL |
++				dll_lock_value << DLL_TAP_VALUE_OFFSET;
++		} else {
++			/* rk3588 and other revision-1 SoCs: original fixed taps */
++			txclk_tapnum = DLL_TXCLK_TAPNUM_90_DEGREES;
++
++			extra = DLL_CMDOUT_SRC_CLK_NEG |
++				DLL_CMDOUT_EN_SRC_CLK_NEG |
++				DWCMSHC_EMMC_DLL_DLYENA |
++				DLL_CMDOUT_TAPNUM_90_DEGREES |
++				DLL_CMDOUT_TAPNUM_FROM_SW;
++		}
  		sdhci_writel(host, extra, DECMSHC_EMMC_DLL_CMDOUT);
  	}
  
-@@ -866,11 +890,19 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
+@@ -866,11 +911,21 @@ static void dwcmshc_rk3568_set_clock(struct sdhci_host *host, unsigned int clock
  		DLL_TXCLK_TAPNUM_FROM_SW |
  		DLL_RXCLK_NO_INVERTER << DWCMSHC_EMMC_DLL_RXCLK_SRCSEL |
  		txclk_tapnum;
-+	if (rockchip_pdata->revision == 1)
++	if (rockchip_pdata->needs_hs400_dll_calibration &&
++	    host->mmc->ios.timing == MMC_TIMING_MMC_HS400)
 +		extra |= DLL_TAP_VALUE_SEL |
 +			 dll_lock_value << DLL_TAP_VALUE_OFFSET;
  	sdhci_writel(host, extra, DWCMSHC_EMMC_DLL_TXCLK);
@@ -117,7 +144,8 @@ index 111111111111..222222222222 100644
  	extra = DWCMSHC_EMMC_DLL_DLYENA |
 -		DLL_STRBIN_TAPNUM_DEFAULT |
  		DLL_STRBIN_TAPNUM_FROM_SW;
-+	if (rockchip_pdata->revision == 1)
++	if (rockchip_pdata->needs_hs400_dll_calibration &&
++	    host->mmc->ios.timing == MMC_TIMING_MMC_HS400)
 +		extra |= DLL_STRBIN_TAPNUM_RK3576 |
 +			 DLL_TAP_VALUE_SEL |
 +			 dll_lock_value << DLL_TAP_VALUE_OFFSET;
@@ -126,6 +154,11 @@ index 111111111111..222222222222 100644
  	sdhci_writel(host, extra, DWCMSHC_EMMC_DLL_STRBIN);
  
  enable_clk:
--- 
-Armbian
-
+@@ -2152,6 +2207,7 @@ static const struct rockchip_pltfm_data sdhci_dwcmshc_rk3576_pdata = {
+ 		.postinit = dwcmshc_rk3576_postinit,
+ 	},
+ 	.revision = 1,
++	.needs_hs400_dll_calibration = true,
+ };
+ 
+ static const struct rockchip_pltfm_data sdhci_dwcmshc_rk3588_pdata = {


### PR DESCRIPTION
## What

The rk3576 HS400 DLL tap calibration added for the Anbernic RG Vita Pro
(`rk3576-0013-mmc-sdhci-dwcmshc-rk3576-dll-tap-calibration.patch`) was gated on
`rockchip_pdata->revision == 1`. Revision 1 is shared by every non-rk356x dwcmshc
SoC — rk3576 **and rk3588** (the driver's own comment says as much). As written it
also fed the rk3576 tap values, `DLL_TAP_VALUE_SEL` and `BOTH_CLK_EDGE` into
rk3588's HS400 path, changing its eMMC timing.

## Fix

Gate the calibration on a dedicated `needs_hs400_dll_calibration` flag in
`struct rockchip_pltfm_data`, set only for `sdhci_dwcmshc_rk3576_pdata`. rk3588 and
the other revision-1 SoCs keep their original 90-degree CMDOUT taps and STRBIN
default untouched; only rk3576 gets the calibrated taps and the measured DLL lock
value feedback.

Reported by CodeRabbit on #10321.

## Testing

Built rockchip64 `edge` (7.1) and `bleedingedge` (7.2-rc6). rk3576 HS400 behaviour
is unchanged (still calibrated, no more `Timeout waiting for hardware interrupt` on
the RG Vita Pro); the rk3588 path is restored to its pre-patch register values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HS400 eMMC reliability on RK3576 devices through device-specific DLL calibration.
  * Automatically tunes clock and data timing for high-speed memory communication.
  * Preserved existing behavior for other supported Rockchip SoCs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->