### PR TITLE
rockchip64: RG Vita Pro drivers - address CodeRabbit review comments from #10321

### DIFF
--- a/patch/kernel/archive/rockchip64-7.1/general-drm-panel-add-rocknix-generic-dsi.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-drm-panel-add-rocknix-generic-dsi.patch
@@ -532,7 +532,7 @@ index 0000000..74e1be2
 +
 +    msleep(ctx->delays.enable);
 +
-+    //msleep(ctx->delays.ready);
++    msleep(ctx->delays.ready);
 +
 +    ctx->prepared = true;
 +

--- a/patch/kernel/archive/rockchip64-7.1/general-input-add-spi-mcu-joypad-01-options.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-input-add-spi-mcu-joypad-01-options.patch
@@ -38,7 +38,7 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +config JOYSTICK_SPI_MCU_JOYPAD
 +	tristate "SPI MCU Joypad (Anbernic analog sticks + RGB LEDs)"
 +	depends on SPI
-+	depends on LEDS_CLASS_MULTICOLOR || LEDS_CLASS_MULTICOLOR=n
++	depends on LEDS_CLASS_MULTICOLOR
 +	help
 +	  Say Y here if you have an Anbernic handheld with analog sticks
 +	  and RGB LEDs controlled by an MCU over SPI.

--- a/patch/kernel/archive/rockchip64-7.1/general-power-supply-add-cw221x.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-power-supply-add-cw221x.patch
@@ -469,7 +469,7 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
 +	else if ((cw_bat->fw_version != 0) && ((cw_bat->fw_version & 0xC0) == CW2218_MARK))
 +		cw_current = cw_current * 3815 / cw_bat->user_rsense;
 +	else {
-+		cw_bat->cw_current = 0;
++		cw_current = 0;
 +		dev_err(cw_bat->dev, "error! cw221x firmware read error!\n");
 +	}
 +

--- a/patch/kernel/archive/rockchip64-7.1/general-power-supply-add-sgm41542.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-power-supply-add-sgm41542.patch
@@ -978,7 +978,7 @@ index 0000000..b438237
 +						  &sgm4154x_power_supply_desc,
 +						  &psy_cfg);
 +	if (IS_ERR(sgm->charger))
-+		return -EINVAL;
++		return PTR_ERR(sgm->charger);
 +
 +	return 0;
 +}

--- a/patch/kernel/archive/rockchip64-7.2/general-drm-panel-add-rocknix-generic-dsi.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-drm-panel-add-rocknix-generic-dsi.patch
@@ -539,7 +539,7 @@ index 000000000000..111111111111
 +
 +    msleep(ctx->delays.enable);
 +
-+    //msleep(ctx->delays.ready);
++    msleep(ctx->delays.ready);
 +
 +    ctx->prepared = true;
 +

--- a/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-01-options.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-input-add-spi-mcu-joypad-01-options.patch
@@ -53,7 +53,7 @@ index 000000000000..111111111111
 +config JOYSTICK_SPI_MCU_JOYPAD
 +	tristate "SPI MCU Joypad (Anbernic analog sticks + RGB LEDs)"
 +	depends on SPI
-+	depends on LEDS_CLASS_MULTICOLOR || LEDS_CLASS_MULTICOLOR=n
++	depends on LEDS_CLASS_MULTICOLOR
 +	help
 +	  Say Y here if you have an Anbernic handheld with analog sticks
 +	  and RGB LEDs controlled by an MCU over SPI.

--- a/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-cw221x.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-cw221x.patch
@@ -484,7 +484,7 @@ index 000000000000..111111111111
 +	else if ((cw_bat->fw_version != 0) && ((cw_bat->fw_version & 0xC0) == CW2218_MARK))
 +		cw_current = cw_current * 3815 / cw_bat->user_rsense;
 +	else {
-+		cw_bat->cw_current = 0;
++		cw_current = 0;
 +		dev_err(cw_bat->dev, "error! cw221x firmware read error!\n");
 +	}
 +

--- a/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-sgm41542.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-power-supply-add-sgm41542.patch
@@ -985,7 +985,7 @@ index 000000000000..111111111111
 +						  &sgm4154x_power_supply_desc,
 +						  &psy_cfg);
 +	if (IS_ERR(sgm->charger))
-+		return -EINVAL;
++		return PTR_ERR(sgm->charger);
 +
 +	return 0;
 +}


### PR DESCRIPTION
Follow-up to #10321: addresses the CodeRabbit findings on the Anbernic RG Vita Pro
driver patches that were left unaddressed at merge. Four independent, low-risk
fixes, each applied to both `rockchip64-7.1` and `rockchip64-7.2`:

- **rocknix generic-dsi panel** — honor the configured `ready` delay. `load_globals()`
  parsed `ctx->delays.ready` but the `msleep()` using it was commented out, so the
  panel-description ready delay was ignored.
- **spi-mcu-joypad** — `depends on LEDS_CLASS_MULTICOLOR`. The driver calls
  `devm_led_classdev_multicolor_register()` unconditionally, but the old
  `depends on LEDS_CLASS_MULTICOLOR || LEDS_CLASS_MULTICOLOR=n` allowed building it
  with the multicolor LED class disabled, which fails to link.
- **sgm41542** — return `PTR_ERR(sgm->charger)` instead of `-EINVAL` on
  `IS_ERR()`, so `-EPROBE_DEFER` from `devm_power_supply_register()` is preserved.
- **cw221x** — fix the dead zero-assignment on the firmware-mismatch path: the error
  branch set `cw_bat->cw_current = 0` but a later unconditional
  `cw_bat->cw_current = cw_current` overwrote it with the stale unscaled value, so the
  reported current was never actually zeroed.

The remaining CodeRabbit comments on these drivers are either intentional
(rmi4 `-EPROBE_DEFER` for the TDDI touch IC startup) or hardware limitations
(the MCU exposes a single global LED brightness level, not per-ring), so they are
left as-is.

## Testing

Built rockchip64 `edge` (7.1) and `bleedingedge` (7.2-rc6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable generic MIPI-DSI display panels, including display modes, orientation, backlight, power sequencing, and initialization.
  * Added SPI MCU joypad support with analog controls and multicolor RGB LED functionality.
  * Added battery monitoring for CW2215/CW2217/CW2218 fuel gauges, including capacity, temperature, current, cycle count, and health reporting.
  * Added SGM41542 single-cell charger support with charging controls, battery status, fault reporting, and USB OTG power output.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->