### PR TITLE
kernel: k3-6.18: fix BeagleBadge e-ink overlay patch not applying

### DIFF
--- a/patch/kernel/archive/k3-6.18/0003-arm64-dts-ti-add-BeagleBadge-GDEY042T81-overlay.patch
+++ b/patch/kernel/archive/k3-6.18/0003-arm64-dts-ti-add-BeagleBadge-GDEY042T81-overlay.patch
@@ -19,14 +19,14 @@ diff --git a/arch/arm64/boot/dts/ti/Makefile b/arch/arm64/boot/dts/ti/Makefile
 index cb2623885b0c..6c5d6dd4b3a6 100644
 --- a/arch/arm64/boot/dts/ti/Makefile
 +++ b/arch/arm64/boot/dts/ti/Makefile
-@@ -64,6 +64,7 @@ dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm-eqep.dtbo
- dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm-mcan.dtbo
- dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm-pwm.dtbo
- dtb-$(CONFIG_ARCH_K3) += k3-am62l3-badge.dtb
-+dtb-$(CONFIG_ARCH_K3) += k3-am62l3-badge-eink-gdey042t81.dtbo
+@@ -67,6 +67,7 @@
  
  # Boards with AM62Lx SoCs
+ dtb-$(CONFIG_ARCH_K3) += k3-am62l3-beaglebadge.dtb
++dtb-$(CONFIG_ARCH_K3) += k3-am62l3-badge-eink-gdey042t81.dtbo
  dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm.dtb
+ dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm-dsi-rpi-7inch-panel.dtbo
+ dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm-lpm-wkup-sources.dtbo
 diff --git a/arch/arm64/boot/dts/ti/k3-am62l3-badge-eink-gdey042t81.dtso b/arch/arm64/boot/dts/ti/k3-am62l3-badge-eink-gdey042t81.dtso
 new file mode 100644
 index 000000000000..3295568b416f


### PR DESCRIPTION
## Problem

`k3` kernel builds (e.g. `sk-am62-lp` / `BRANCH=vendor-edge`) fail during kernel patching:

```
0003-arm64-dts-ti-add-BeagleBadge-GDEY042T81-overlay.patch
  Hunk #1 FAILED at 64  →  1 out of 1 hunk FAILED
Exception: Failed to apply 1 patches.  →  build aborts
```
(reported via a build log paste)

## Root cause

The overlay patch's `arch/arm64/boot/dts/ti/Makefile` hunk anchors on a base-board line:

```makefile
dtb-$(CONFIG_ARCH_K3) += k3-am62l3-badge.dtb        # ← does not exist
```

That line isn't in the `ti-linux` 6.18 kernel. The board is actually named **`k3-am62l3-beaglebadge.dtb`** there (and lives *after* the `# Boards with AM62Lx SoCs` comment). The patch was generated against a tree that named/placed the board differently, so the hunk context never matches and the whole k3 patch series fails.

## Fix

Re-anchor the Makefile hunk onto the real `k3-am62l3-beaglebadge.dtb` line, adding the overlay entry next to its board. Only the patch's Makefile hunk changes; the `.dtso` payload is untouched.

## Verification

Applied the patch with the **exact command the build uses** — `patch --batch -p1 -N --reject-file=… --quoting-style=c` (from `lib/tools/common/patching_utils.py`) — against the real `ti-linux` 6.18 `arch/arm64/boot/dts/ti/Makefile`:

- **exit 0, no rejects**; the `.dtso` overlay file is created.
- The canonical `diff -u` hunk applies at GNU patch's default fuzz (the previous hand-anchor needed fuzz 3, which the build's default-fuzz `patch` call would reject).

## Note

The base BeagleBadge board is `k3-am62l3-beaglebadge`, but the overlay this patch adds is still named `k3-am62l3-badge-eink-gdey042t81` (as the original author wrote it). It compiles fine standalone. If the maintainer (@andrei1998 / the SSD16xx series) wants naming consistency, the overlay could be renamed to `k3-am62l3-beaglebadge-eink-gdey042t81` in a follow-up — out of scope for this unblock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the GDEY042T81 e-paper display on the AM62L BeagleBadge.
  * Configured display communication, control signals, and 2 MHz operation.
  * Included the display overlay in the device tree build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->