### PR TITLE
sophgo-sg200x-aic8800: don't git-fetch the driver during config-dump

### DIFF
--- a/extensions/sophgo-sg200x-aic8800.sh
+++ b/extensions/sophgo-sg200x-aic8800.sh
@@ -51,8 +51,19 @@ declare -g AIC8800_REF="commit:ccf8fd059f70384fae4878c1048603510c2df700"
 declare -g AIC8800_FW_DIR="/lib/firmware/aic8800/SDIO/aic8800D80"
 
 function post_family_config__sophgo_sg200x_aic8800_fetch() {
-	fetch_from_repo "${AIC8800_REPO}" "aic8800-milkv-duos" "${AIC8800_REF}" "yes"
+	# The source dir is a deterministic path off the pinned ref; always declare it.
 	declare -g AIC8800_SRC_DIR="${SRC}/cache/sources/aic8800-milkv-duos/${AIC8800_REF#*:}"
+
+	# Don't fetch during config-dump / version calculation. post_family_config
+	# also runs under `config-dump-json` (CONFIG_DEFS_ONLY=yes), which the
+	# inventory runs in parallel for every board×branch; a real git fetch here
+	# has no kernel tree to feed and races on the global git config
+	# (`git config --global --add safe.directory ...` -> exit 128), which then
+	# breaks the whole inventory. The driver is fetched for real when the kernel
+	# builds (custom_kernel_config, guarded on a present .config).
+	[[ "${CONFIG_DEFS_ONLY}" == "yes" ]] && return 0
+
+	fetch_from_repo "${AIC8800_REPO}" "aic8800-milkv-duos" "${AIC8800_REF}" "yes"
 }
 
 function custom_kernel_config__sophgo_sg200x_aic8800_modules() {


### PR DESCRIPTION
## Why the "Generate build engine inventory" job fails

The inventory job (`compile.sh inventory-boards` → `config-dump-json` per board×branch) dies on the **milkv-duos** boards:

```
Error calling Armbian command: compile.sh config-dump-json ... BOARD=milkv-duos-arm ...
code: 128 - stacktrace for failed command exit code 128:
  git --no-pager config --global --add safe.directory \
    /armbian/cache/sources/aic8800-milkv-duos/ccf8fd059f70384fae4878c1048603510c2df700
...
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
KeyError: 'in.inventory.BOARD'   # ← whole inventory job exits 1
```

## Why milkv-duos and not the other aic8800 boards

Every other aic8800 board installs a **prebuilt DKMS deb** (`radxa-aic8800`, `brostrend-aic8800-dkms`) — no git fetch at config time. `sophgo-sg200x-aic8800` is the only one that pulls a **vendor driver from git**, and it did so **unconditionally in `post_family_config`**:

```bash
function post_family_config__sophgo_sg200x_aic8800_fetch() {
	fetch_from_repo "${AIC8800_REPO}" "aic8800-milkv-duos" "${AIC8800_REF}" "yes"
	...
}
```

`post_family_config` also runs under `config-dump-json` (`CONFIG_DEFS_ONLY=yes`), which the inventory runs **in parallel** for all four milkv-duos board×branch combos. So the inventory triggers a real git fetch that (a) has no kernel tree to feed and (b) races on the global git config (`git config --global --add safe.directory` → **exit 128**). That empties the config JSON, and `inventory-boards-csv.py` then `KeyError`s and takes the whole job down.

The extension already guards its **kernel** hook against config-dump (`[[ ! -f .config ]] && return 0`) — it just missed the **fetch** hook.

## Fix

Skip the fetch when `CONFIG_DEFS_ONLY=yes` — the framework's own idiom (used by `main-config.sh`, `cli-docker.sh`). `AIC8800_SRC_DIR` is still declared (deterministic path off the pinned ref) so version/hash calculation is unchanged. In a real build, `post_family_config` runs with `CONFIG_DEFS_ONLY` unset, so the fetch happens as before, ahead of `custom_kernel_config` copying from it (that copy is itself `.config`-guarded, i.e. real-build only).

## Validation

- `bash -n` clean.
- Verified `AIC8800_SRC_DIR`'s only real use (the `cp -a` at line 96) is behind the `[[ ! -f .config ]]` guard, so the config-dump path never needs the fetched files.

This unblocks the inventory job at the source. (A defensive follow-up could also make `inventory-boards-csv.py` skip a board whose config gather failed instead of `KeyError`-ing, so no single board can ever crash the whole inventory — happy to do that separately.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration-only and version-calculation runs no longer fetch the AIC8800 source repository unnecessarily.
  * AIC8800 sources continue to be fetched during actual kernel builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->