### PR TITLE
sun60iw2: fix libbpf const build error on resolute (gcc 15)

### DIFF
--- a/patch/kernel/archive/sun60iw2-opi-vendor/tools-libbpf-const-next-path-gcc15.patch
+++ b/patch/kernel/archive/sun60iw2-opi-vendor/tools-libbpf-const-next-path-gcc15.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor@armbian.com>
+Date: Sat, 09 Aug 2026 16:00:00 +0200
+Subject: [PATCH] tools/libbpf: const next_path in resolve_full_path (gcc 15)
+
+The linux-headers postinst rebuilds tools/bpf/resolve_btfids in the target
+rootfs. On resolute (gcc 15 / newer glibc) that build fails:
+
+  tools/lib/bpf/libbpf.c: error: assignment discards 'const' qualifier from
+  pointer target type [-Werror=discarded-qualifiers]
+     next_path = strchr(s, ':');
+
+'s' is const char *, so strchr() yields const char *; assigning it to a plain
+char * discards const. On trixie (the build container, gcc <= 14) this is only
+a warning, so the kernel artifact builds, but the postinst rebuild in the
+resolute chroot is a hard error and the image build dies at
+install_artifact_deb_chroot.
+
+next_path is only read (pointer diff), so make it const. Mainline libbpf
+already carries this; the Allwinner orange-pi-6.6-sun60iw2 vendor kernel still
+ships the pre-fix copy. Scoped to that vendor kernel (sun60iw2 / orangepizero3w).
+
+Signed-off-by: Igor Pecovnik <igor@armbian.com>
+---
+diff --git a/tools/lib/bpf/libbpf.c b/tools/lib/bpf/libbpf.c
+index 111111111111..222222222222 100644
+--- a/tools/lib/bpf/libbpf.c
++++ b/tools/lib/bpf/libbpf.c
+@@ -11250,9 +11250,9 @@ static int resolve_full_path(const char *file, char *result, size_t result_sz)
+
+ 		if (!search_paths[i])
+ 			continue;
+ 		for (s = search_paths[i]; s != NULL; s = strchr(s, ':')) {
+-			char *next_path;
++			const char *next_path;
+ 			int seg_len;
+
+ 			if (s[0] == ':')
+ 				s++;
+--
+Armbian


### PR DESCRIPTION
## Problem

Building **orangepizero3w** (sun60iw2 vendor 6.6.98) for **`RELEASE=resolute`** fails while configuring `linux-headers-vendor-sun60iw2`:

```
tools/lib/bpf/libbpf.c: In function 'resolve_full_path':
libbpf.c:11245:35: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
   11245 |   next_path = strchr(s, ':');
cc1: all warnings being treated as errors
...
dpkg: error processing package linux-headers-vendor-sun60iw2 (--configure)
```

The `linux-headers` postinst rebuilds `tools/bpf/resolve_btfids` (and its bundled libbpf) **inside the resolute chroot**. On resolute's newer glibc, `strchr(const char *s, …)` yields `const char *`, so assigning it to a plain `char *next_path` discards `const` → fatal under `-Werror`.

## Why it builds on trixie but not resolute

The build container (trixie, gcc ≤ 14) only **warns**, so the kernel artifact builds fine there. The failure is the **postinst rebuild in the resolute target rootfs**, whose toolchain makes it a hard error. (Confirmed by the reporter: trixie compilation passes.)

## Fix

Add the same const-correctness patch several other families already carry (`imx8ulp-6.1`, `k3-beagle-6.12`, `ls1046a-6.12`, `qcs6490-6.18`): make `next_path` `const` in `resolve_full_path`. Mainline libbpf already has this — the Allwinner `orange-pi-6.6-sun60iw2` vendor kernel just ships the pre-fix copy. `next_path` is only read (pointer diff), so `const` is correct.

New file: `patch/kernel/archive/sun60iw2-opi-vendor/tools-libbpf-const-next-path-gcc15.patch`.

## Verification

Applied against the vendor libbpf with the **exact command the build uses** (`patch --batch -p1 -N --quoting-style=c`, from `patching_utils.py`): **exit 0, no rejects** (benign 3-line offset), `char *next_path;` → `const char *next_path;`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with GCC 15 by fixing a compiler warning/error related to path handling.
  * Preserved read-only path data during full-path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->