### PR TITLE
Fix maintainers-sync / CODEOWNERS job errors

### DIFF
--- a/.github/workflows/data-sync-maintainers.yml
+++ b/.github/workflows/data-sync-maintainers.yml
@@ -190,6 +190,8 @@ jobs:
             ### Want to maintain a board?
             Add or update your details — [adjust the maintainer data here](https://www.armbian.com/update-data/).
 
+            Active maintainers are listed automatically on [armbian.com/authors](https://armbian.com/authors), based on their recent activity.
+
             ### References
             - [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)
             - [Contribute](https://docs.armbian.com/Process_Contribute/)

--- a/.github/workflows/data-sync-maintainers.yml
+++ b/.github/workflows/data-sync-maintainers.yml
@@ -49,6 +49,11 @@ jobs:
 
       - name: "Update maintainers"
         run: |
+          # A support-level class can currently be empty (e.g. there are no
+          # *.wip boards). nullglob makes such an unmatched pattern expand to
+          # nothing instead of the literal path, which sed/the loop below would
+          # otherwise fail on (No such file or directory) under -e/pipefail.
+          shopt -s nullglob
 
           # reset all maintainers so we generate from scratch
           sed -i "s/BOARD_MAINTAINER.*/BOARD_MAINTAINER=\"\"/" config/boards/*.{conf,wip,csc,eos,tvb}
@@ -98,8 +103,11 @@ jobs:
 
       - name: "Mark csc for no maintainer"
         run: |
+          shopt -s nullglob   # no *.wip boards -> don't choke on the literal glob
 
-          grep BOARD_MAINTAINER=\"\" config/boards/*.{wip,conf} | cut -d":" -f1 |
+          # `|| true`: grep exits 1 when no conf/wip board has an empty
+          # maintainer, which would trip pipefail; having nothing to demote is fine.
+          { grep BOARD_MAINTAINER=\"\" config/boards/*.{wip,conf} || true; } | cut -d":" -f1 |
             while read -r line; do
               if [[ "${line}" != "${line/.conf/.csc}" ]]; then
                 mv -v "$line" "${line/.conf/.csc}"

--- a/.github/workflows/data-sync-maintainers.yml
+++ b/.github/workflows/data-sync-maintainers.yml
@@ -173,16 +173,26 @@ jobs:
           delete-branch: true
           title: '`Automatic` board configs status synchronise'
           body: |
-            Update maintainers and board status
+            > [!IMPORTANT]
+            > This is an automatically generated PR — do not edit board configs here by hand.
 
-            - synced status from the database
-            - rename to .`csc` where we don't have anyone
+            ## Automated maintainers & board-status sync
 
-            If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).
+            Generated automatically from the Armbian maintainers database to keep each
+            board's `BOARD_MAINTAINER` and support level in step with who actually looks
+            after it.
 
-            Ref:
-              - [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)
-              - [Contribute](https://docs.armbian.com/Process_Contribute/)
+            ### What changed
+            - **Maintainers synced** — every board's `BOARD_MAINTAINER` is regenerated from the database.
+            - **Unmaintained boards demoted to CSC** — any board left without a maintainer is renamed to `.csc` (community-supported), so its status matches reality.
+            - **CODEOWNERS refreshed** — long-inactive maintainers are dropped from `CODEOWNERS` (so they aren't review-requested) while staying listed in `BOARD_MAINTAINER`.
+
+            ### Want to maintain a board?
+            Add or update your details — [adjust the maintainer data here](https://www.armbian.com/update-data/).
+
+            ### References
+            - [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)
+            - [Contribute](https://docs.armbian.com/Process_Contribute/)
 
           labels: |
             Work in progress

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -70,7 +70,7 @@ esac
 # - binman-atf-mainline:  u-boot builds full boot image with mainline ATF from information in device tree.  See: https://docs.u-boot.org/en/latest/develop/package/binman.html
 
 #BOOT_SOC=`expr $BOOTCONFIG : '.*\(rk[[:digit:]]\+.*\)_.*'`
-BOOT_SOC=${BOOT_SOC:=$(expr $BOOTCONFIG : '.*\(rk[[:digit:]]\+.*\)_.*' || true)}
+BOOT_SOC=${BOOT_SOC:=$(expr "${BOOTCONFIG}" : '.*\(rk[[:digit:]]\+.*\)_.*' || true)}
 
 if [[ "a${BOOT_SOC}a" == "aa" ]]; then
 	if [[ "${BOOTCONFIG}" != "" && "${BOOTCONFIG}" != " none" ]]; then # only warn if BOOTCONFIG set and not 'none'


### PR DESCRIPTION
Two fixes for the scheduled **Data: Sync maintainers** job.

## 1. Job fails: no `.wip` boards left

```
sed: can't read config/boards/*.wip: No such file or directory
##[error]Process completed with exit code 2
```

Now that the last `.wip` board became `.csc`, the brace-glob `config/boards/*.{conf,wip,csc,eos,tvb}` leaves `*.wip` **literal** (no `nullglob`), so `sed` / `grep` read a nonexistent path and GitHub's default `bash -e -o pipefail` aborts. Affects **Update maintainers** and **Mark csc for no maintainer**.

Fix: `shopt -s nullglob` in both steps (empty class → nothing), plus `|| true` on the demote `grep` so "nothing to demote" (grep exit 1) doesn't trip `pipefail`.

## 2. `expr: syntax error` noise during CODEOWNERS generation

```
expr: syntax error: unexpected argument '.*\(rk[[:digit:]]\+.*\)_.*'
```

`config/sources/families/include/rockchip64_common.inc` had `expr $BOOTCONFIG : '...'` **unquoted**. For a board with no `BOOTCONFIG`, the empty operand vanishes and `expr` sees `: REGEX` → syntax error. The `|| true` hid the exit code but not the stderr. Quote it (`"${BOOTCONFIG}"`) so an empty value is a proper empty-string argument.

## Verification

- Reproduced the `.wip` failure with a fixture lacking `.wip`; after `nullglob` the reset `sed`, the per-board loop, and the demote `grep` all run clean.
- Reproduced the `expr` error with empty `BOOTCONFIG`; quoted form yields empty (no error) and still extracts the SoC (`rk3588-orangepi-5_defconfig` → `rk3588-orangepi-5`) for a real value.
- YAML + `bash -n` clean.