### PR TITLE
sunxi-6.12: fix AP6275P brcmfmac patch (BRCM_CC_43752 now upstream)

### DIFF
--- a/patch/kernel/archive/sunxi-6.12/patches.megous/net-wireless-brcmfmac-Add-support-for-detecting-AP6275P.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.megous/net-wireless-brcmfmac-Add-support-for-detecting-AP6275P.patch
@@ -15,8 +15,8 @@ one.)
 Signed-off-by: Ondrej Jirman <megi@xff.cz>
 ---
  drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c       | 5 ++++-
- drivers/net/wireless/broadcom/brcm80211/include/brcm_hw_ids.h | 2 ++
- 2 files changed, 6 insertions(+), 1 deletion(-)
+ drivers/net/wireless/broadcom/brcm80211/include/brcm_hw_ids.h | 1 +
+ 2 files changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
 index 111111111111..222222222222 100644
@@ -59,15 +59,7 @@ diff --git a/drivers/net/wireless/broadcom/brcm80211/include/brcm_hw_ids.h b/dri
 index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/broadcom/brcm80211/include/brcm_hw_ids.h
 +++ b/drivers/net/wireless/broadcom/brcm80211/include/brcm_hw_ids.h
-@@ -52,6 +52,7 @@
- #define BRCM_CC_43664_CHIP_ID		43664
- #define BRCM_CC_43666_CHIP_ID		43666
- #define BRCM_CC_4371_CHIP_ID		0x4371
-+#define BRCM_CC_43752_CHIP_ID		43752
- #define BRCM_CC_4377_CHIP_ID		0x4377
- #define BRCM_CC_4378_CHIP_ID		0x4378
- #define BRCM_CC_4387_CHIP_ID		0x4387
-@@ -94,6 +95,7 @@
+@@ -94,6 +94,7 @@
  #define BRCM_PCIE_4366_5G_DEVICE_ID	0x43c5
  #define BRCM_PCIE_4371_DEVICE_ID	0x440d
  #define BRCM_PCIE_43596_DEVICE_ID	0x4415


### PR DESCRIPTION
## Problem

Kernel patching fails on **sunxi 6.12** (e.g. `bananapi` / `BRANCH=legacy`, but any sunxi-6.12 board), aborting the build:

```
Failed to apply 1 patches:
  patches.megous/net-wireless-brcmfmac-Add-support-for-detecting-AP6275P {pcie.c, brcm_hw_ids.h}

brcm_hw_ids.h: Reversed (or previously applied) patch detected! Skipping patch.
  2 out of 2 hunks ignored
Summary: 457 total; 456 applied; 1 failed_apply
```

## Root cause

The megous patch adds two `brcm_hw_ids.h` defines and several `pcie.c` changes for the BCM43752 (AP6275P). **Mainline 6.12 already defines `BRCM_CC_43752_CHIP_ID`**, so the patch's *first* header hunk reverse-detects as already-applied. GNU `patch` (the build uses `patch --batch -p1 -N`) then treats the **whole file** as already-patched and skips **both** header hunks — including the second one (`BRCM_PCIE_43752_DEVICE_ID`), which is **not** upstream and is referenced by the `pcie.c` device table. Patch returns non-zero → Armbian marks the patch failed → build stops.

Verified upstream `linux-6.12.y`: `BRCM_CC_43752_CHIP_ID` **is** present; `BRCM_PCIE_43752_DEVICE_ID` and the `pcie.c` 43752 entries are **not**.

## Fix

Drop only the now-upstream `BRCM_CC_43752_CHIP_ID` hunk from the patch. Keep the `BRCM_PCIE_43752_DEVICE_ID` hunk and all `pcie.c` hunks, so AP6275P support stays complete (chip id from upstream, device id from the patch).

## Verification

Applied the edited patch to pristine `linux-6.12.y` `pcie.c` + `brcm_hw_ids.h` with the build's exact command (`patch --batch -p1 -N --quoting-style=c`):

- **exit 0, no rejects** (pcie.c hunks apply with the usual small offsets).
- `BRCM_CC_43752_CHIP_ID` present once (upstream); `BRCM_PCIE_43752_DEVICE_ID` added; all four `pcie.c` 43752 changes present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AP6275P/BCM43752 wireless hardware.
  * Added firmware mapping for BCM43752 PCIe devices.
  * Improved operation when hardware OTP data is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->