### PR TITLE
k3-6.18: make BeagleBadge e-ink overlay patch apply on all branches

### DIFF
--- a/patch/kernel/archive/k3-6.18/0003-arm64-dts-ti-add-BeagleBadge-GDEY042T81-overlay.patch
+++ b/patch/kernel/archive/k3-6.18/0003-arm64-dts-ti-add-BeagleBadge-GDEY042T81-overlay.patch
@@ -19,14 +19,12 @@ diff --git a/arch/arm64/boot/dts/ti/Makefile b/arch/arm64/boot/dts/ti/Makefile
 index cb2623885b0c..6c5d6dd4b3a6 100644
 --- a/arch/arm64/boot/dts/ti/Makefile
 +++ b/arch/arm64/boot/dts/ti/Makefile
-@@ -67,6 +67,7 @@
- 
- # Boards with AM62Lx SoCs
- dtb-$(CONFIG_ARCH_K3) += k3-am62l3-beaglebadge.dtb
+@@ -62,4 +62,5 @@
+ dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm-epaper.dtbo
+ dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm-eqep.dtbo
 +dtb-$(CONFIG_ARCH_K3) += k3-am62l3-badge-eink-gdey042t81.dtbo
- dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm.dtb
- dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm-dsi-rpi-7inch-panel.dtbo
- dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm-lpm-wkup-sources.dtbo
+ dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm-mcan.dtbo
+ dtb-$(CONFIG_ARCH_K3) += k3-am62l3-evm-pwm.dtbo
 diff --git a/arch/arm64/boot/dts/ti/k3-am62l3-badge-eink-gdey042t81.dtso b/arch/arm64/boot/dts/ti/k3-am62l3-badge-eink-gdey042t81.dtso
 new file mode 100644
 index 000000000000..3295568b416f


### PR DESCRIPTION
## Problem

`kernel-k3-vendor-rt` (e.g. `BOARD=beaglebadge BRANCH=vendor-rt`) fails patching:

```
0003-arm64-dts-ti-add-BeagleBadge-GDEY042T81-overlay: Hunk #1 FAILED at 67
Failed to apply 1 patches
```

## Root cause

The k3 branches pull **different kernel snapshots**, and each names/places the BeagleBadge board differently in `arch/arm64/boot/dts/ti/Makefile`:

| Branch | Kernel | Board line |
|---|---|---|
| `vendor` / `vendor-rt` | TI PSDK **tag 12.00.00.07** | `k3-am62l3-badge.dtb` (before the `# Boards…` comment) |
| `edge` / `vendor-edge` | **ti-linux-6.18.y** branch | `k3-am62l3-beaglebadge.dtb` (after the comment) |

The original patch anchored on `k3-am62l3-badge.dtb` (worked on the tag), and #10380 re-anchored on `k3-am62l3-beaglebadge.dtb` (fixed edge) — so each fix worked for one snapshot and broke the other.

## Fix

Anchor the Makefile insertion on the **evm overlay entries** (`…-eqep.dtbo` / `…-mcan.dtbo` / `…-pwm.dtbo`), which are **identical and contiguous in both snapshots**, and add the e-ink `.dtbo` there. It's an overlay, so it belongs in the overlay group anyway — and this avoids the board line that differs between trees entirely.

## Verification

Applied with the build's exact command (`patch --batch -p1 -N --quoting-style=c`) against **both** `arch/arm64/boot/dts/ti/Makefile`s:

- **PSDK tag 12.00.00.07** (vendor/vendor-rt): exit 0, no rejects.
- **ti-linux-6.18.y** (edge/vendor-edge): exit 0, no rejects (1-line offset).

The `.dtso` payload is unchanged; only the Makefile hunk anchor moved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the BeagleBadge GDEY042T81 e-paper display.
  * Enabled display communication and required control signals on compatible TI K3-based boards.
  * The display is now available through the device tree overlay for supported hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->