### PR TITLE
mainline: bump to 7.2-rc7

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0          # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "7.2" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v7.2-rc6"
+		declare -g KERNELBRANCH="tag:v7.2-rc7"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }
@@ -26,11 +26,11 @@ function mainline_kernel_decide_version__upstream_release_candidate_number() {
 
 # Example: 6.7-rc7 was released by Linus, but kernel.org git and google git mirrors took a while to catch up; change the source to pull directly from Linus.
 # This was necessary for a few days in late December 2023, but no longer; tag was pushed on 28/Dec/2023.
-function mainline_kernel_decide_version__750_use_torvalds_for_7.2-rc6() {
-	if [[ "${KERNELBRANCH}" == 'tag:v7.2-rc6' ]]; then
-		display_alert "Using Linus kernel repo for 7.2-rc6" "${KERNELBRANCH}" "warn"
+function mainline_kernel_decide_version__750_use_torvalds_for_7.2-rc7() {
+	if [[ "${KERNELBRANCH}" == 'tag:v7.2-rc7' ]]; then
+		display_alert "Using Linus kernel repo for 7.2-rc7" "${KERNELBRANCH}" "warn"
 		declare -g KERNELSOURCE="https://github.com/torvalds/linux.git"
-		display_alert "mainline-kernel: missing torvalds tag on 7.2-rc6" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
+		display_alert "mainline-kernel: missing torvalds tag on 7.2-rc7" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
 	fi
 }
 


### PR DESCRIPTION
# Description

just bump to rc7
patchsets are still in decent state

# How Has This Been Tested?

- [x] build rockchip64-7.2, meson64-7.2, both uefi 7.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated mainline kernel version handling to support the 7.2 release candidate 7.
  * Updated upstream branch selection and fallback behavior for the new release candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->