### PR TITLE
rockchip64: orangepi-5b: set Type-C/OTG controller to host mode

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3588s-orangepi-5b.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3588s-orangepi-5b.dts
@@ -99,3 +99,20 @@
 	};
 };
 
+&usb_host0_xhci {
+	/*
+	 * usb_host0_xhci (fc000000) is the Type-C/DRD controller on this board (wired
+	 * to the Type-C connector via a FUSB302); it also drives the USB2.0 type-A port
+	 * that shares the Type-C's OTG PHY. Upstream sets dr_mode = "otg" with
+	 * usb-role-switch, and on mainline it settles into peripheral role and registers
+	 * no host, so the Type-C port and the shared USB2.0 type-A port are dead for host
+	 * use -- VBUS is present but nothing enumerates.
+	 *
+	 * Force host to make both usable for peripherals (verified: an RME Babyface Pro
+	 * enumerates here). The cost is USB-C device/gadget role on this controller,
+	 * which becomes host-only; USB-C power, U-Boot/maskrom flashing, and USB-C as a
+	 * host are unaffected. The board's separate USB 3.0 type-A port is a different
+	 * controller and is not touched by this change.
+	 */
+	dr_mode = "host";
+};

--- a/patch/kernel/archive/rockchip64-7.1/dt/rk3588s-orangepi-5b.dts
+++ b/patch/kernel/archive/rockchip64-7.1/dt/rk3588s-orangepi-5b.dts
@@ -99,3 +99,20 @@
 	};
 };
 
+&usb_host0_xhci {
+	/*
+	 * usb_host0_xhci (fc000000) is the Type-C/DRD controller on this board (wired
+	 * to the Type-C connector via a FUSB302); it also drives the USB2.0 type-A port
+	 * that shares the Type-C's OTG PHY. Upstream sets dr_mode = "otg" with
+	 * usb-role-switch, and on mainline it settles into peripheral role and registers
+	 * no host, so the Type-C port and the shared USB2.0 type-A port are dead for host
+	 * use -- VBUS is present but nothing enumerates.
+	 *
+	 * Force host to make both usable for peripherals (verified: an RME Babyface Pro
+	 * enumerates here). The cost is USB-C device/gadget role on this controller,
+	 * which becomes host-only; USB-C power, U-Boot/maskrom flashing, and USB-C as a
+	 * host are unaffected. The board's separate USB 3.0 type-A port is a different
+	 * controller and is not touched by this change.
+	 */
+	dr_mode = "host";
+};

--- a/patch/kernel/archive/rockchip64-7.2/dt/rk3588s-orangepi-5b.dts
+++ b/patch/kernel/archive/rockchip64-7.2/dt/rk3588s-orangepi-5b.dts
@@ -99,3 +99,20 @@
 	};
 };
 
+&usb_host0_xhci {
+	/*
+	 * usb_host0_xhci (fc000000) is the Type-C/DRD controller on this board (wired
+	 * to the Type-C connector via a FUSB302); it also drives the USB2.0 type-A port
+	 * that shares the Type-C's OTG PHY. Upstream sets dr_mode = "otg" with
+	 * usb-role-switch, and on mainline it settles into peripheral role and registers
+	 * no host, so the Type-C port and the shared USB2.0 type-A port are dead for host
+	 * use -- VBUS is present but nothing enumerates.
+	 *
+	 * Force host to make both usable for peripherals (verified: an RME Babyface Pro
+	 * enumerates here). The cost is USB-C device/gadget role on this controller,
+	 * which becomes host-only; USB-C power, U-Boot/maskrom flashing, and USB-C as a
+	 * host are unaffected. The board's separate USB 3.0 type-A port is a different
+	 * controller and is not touched by this change.
+	 */
+	dr_mode = "host";
+};


### PR DESCRIPTION
## What
Force `dr_mode = "host"` on `usb_host0_xhci` (fc000000) — the Orange Pi 5B's Type-C / DRD controller.

## Why
On mainline this controller defaults to `otg` and settles into peripheral role, registering no host. As a result the **Type-C port and the USB2.0 type-A port that shares its OTG PHY are dead for host use** — VBUS is present but nothing enumerates. (Unpatched mainline registers zero USB buses on `fc000000`.)

Forcing `host` revives both for peripherals. Verified on hardware: an RME Babyface Pro enumerates on `fc000000`; without the override, no USB bus registers there.

## The trade-off — a maintainer call
This gives up **USB-C device/gadget role** on the controller; it becomes host-only. **Unaffected:** USB-C power input, U-Boot/maskrom flashing (both pre-kernel), and USB-C as a host. The board's separate **USB 3.0 type-A port is a different controller (`fcd00000`, 5 Gbps) and is untouched** — it already works.

So this is a deliberate trade: a dead-for-host port-group revived, in exchange for USB-C-as-a-gadget — a mode most 5B users don't use. Whether that is the right default for the board is Armbian's decision; posting it with accurate scope so you can make it.

## Scope
6.18 / 7.1 / 7.2, matching the board's maintained DTS set. 6.12 (different radio modeling) untouched.