### PR TITLE
setup-usbgadget-network.sh: fix breaking copy&paste flaw

### DIFF
--- a/packages/bsp/usb-gadget-network/setup-usbgadget-network.sh
+++ b/packages/bsp/usb-gadget-network/setup-usbgadget-network.sh
@@ -85,7 +85,7 @@ set_usbgadget_ipaddress() {
 	INTERFACE=""
 	ip a add "${host_ip}/255.255.0.0" dev usb0 2> /dev/null && ip link set usb0 up && INTERFACE=usb0
 	if [ -z $INTERFACE ]; then
-		ip a add "${host_ip}/255.255.0.0" dev eth0 2> /dev/null && eth0 && INTERFACE=eth0
+		ip a add "${host_ip}/255.255.0.0" dev eth0 2> /dev/null && ip link set eth0 up && INTERFACE=eth0
 	fi
 
 	if [ -z $INTERFACE ]; then


### PR DESCRIPTION
fixes https://github.com/armbian/build/issues/8602

the script has more design issues which need attention, like the classic unquoted variables, service file still mentions rndis, error handling inconsistencies and the obvious hardcoded iface names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ethernet fallback setup so `eth0` is properly activated before use.
  * Improved network connectivity when USB gadget networking falls back to Ethernet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->