### PR TITLE
bluetooth-hciattach: only deploy the service on BSP (vendor/legacy) branches

### DIFF
--- a/extensions/bluetooth-hciattach.sh
+++ b/extensions/bluetooth-hciattach.sh
@@ -29,6 +29,14 @@ function post_family_config__bluetooth_hciattach_add_bluetooth_packages() {
 
 # Deploy the script and the systemd service in the BSP. It'll be enabled below in the image.
 function post_family_tweaks_bsp__bluetooth_hciattach_add_systemd_service() {
+	# hciattach is only needed on BSP kernels. On mainline branches (edge, current,
+	# bleedingedge) the kernel binds BT via serdev, so the service is redundant and
+	# fails on every boot. Only deploy on vendor*/legacy* (BSP) branches.
+	if [[ "${BRANCH}" != vendor* && "${BRANCH}" != legacy* ]]; then
+		display_alert "Extension: ${EXTENSION}: ${BOARD}" "skipping hciattach service on non-BSP branch '${BRANCH}' (kernel binds BT via serdev)" "info"
+		return 0
+	fi
+
 	display_alert "Extension: ${EXTENSION}: ${BOARD}" "adding bluetooth hciattach service to BSP" "info"
 	: "${destination:?destination is not set}"
 
@@ -61,6 +69,12 @@ function post_family_tweaks_bsp__bluetooth_hciattach_add_systemd_service() {
 
 # Enable the service created in the BSP above.
 function post_family_tweaks__bluetooth_hciattach_enable_bt_service_in_image() {
+	# Match the deploy guard above: the service only exists on vendor*/legacy* (BSP)
+	# branches, so only enable it there. Nothing to enable on mainline branches.
+	if [[ "${BRANCH}" != vendor* && "${BRANCH}" != legacy* ]]; then
+		return 0
+	fi
+
 	display_alert "Extension: ${EXTENSION}: ${BOARD}" "enabling bluetooth hciattach service in the image" "info"
 
 	chroot_sdcard systemctl --no-reload enable "bluetooth-hciattach.service"


### PR DESCRIPTION
## What

Guard the `bluetooth-hciattach` extension so its systemd service is only deployed and enabled on **BSP branches** (`vendor*` / `legacy*`), not on mainline ones.

## Why

The extension deploys a service that runs `hciattach` to bring up Bluetooth. On mainline branches (`edge`, `current`, `bleedingedge`) the kernel binds the BT UART via **serdev** — `hci0` comes up with no userspace attach — so the service is redundant there and **fails on every boot** (reported in #10395, observed on the Orange Pi 5B).

## Approach

Per @rpardini's guidance in #10395, the guard lives in the extension's own functions rather than in each board file — so **no board file changes are needed and every board using the extension is fixed at once**. Branch match is `vendor*` / `legacy*` (positive glob, covers `vendor-rt` etc. and excludes all mainline variants including `bleedingedge`).

- Guarded: `..._add_systemd_service` (deploy) and `..._enable_bt_service_in_image` (enable).
- **Left unconditional:** `..._add_bluetooth_packages` — `bluez`/`rfkill` are still wanted on mainline for the serdev-bound radio.

Closes #10395.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited Bluetooth HCI attachment deployment and service enablement to supported vendor and legacy BSP branches.
  * Non-BSP branches now skip the deployment and service enablement steps without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->