### PR TITLE
docker: forward CPUTHREADS into the build container

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -526,6 +526,11 @@ function docker_cli_prepare_launch() {
 		# Change the ccache directory to the named volume or bind created. @TODO: this needs more love. it works for Docker, but not sudo
 		"--env" "CCACHE_DIR=${DOCKER_ARMBIAN_TARGET_PATH}/cache/ccache"
 
+		# Forward CPUTHREADS (the build's `make -j` override) into the container.
+		# It is an env var, not a CLI arg, so without this passthrough the container
+		# never sees it and falls back to the default CPU-based thread count.
+		"--env" "CPUTHREADS=${CPUTHREADS-}"
+
 		# Pass down the TERM, COLORFGBG, and the COLUMNS. docker run has no --tty,
 		# so the container can't measure the terminal itself; forward the width
 		# captured on the host (ARMBIAN_TTY_COLUMNS) so patch tables match it.


### PR DESCRIPTION
## Problem
`CPUTHREADS` overrides the build's `make -j` thread count (see `compilation-config.sh`). When set as an **environment variable**, a host build honours it — but the build relaunches itself **inside Docker** with an explicit `--env` allowlist plus the CLI args only. `CPUTHREADS` is on neither, so inside the container `$CPUTHREADS` is unset and compilation falls back to the default (150% of detected CPUs).

## Fix
Add `CPUTHREADS` to the container `--env` passthrough:

```bash
"--env" "CPUTHREADS=${CPUTHREADS-}"
```

`${CPUTHREADS-}` keeps it empty when unset, so builds that don't set it are unchanged. With this, an env-provided `CPUTHREADS` reaches the in-container compile:

```
Using user-defined thread count: -j<N>
```

Single-file change; host builds and CLI-arg builds behave as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docker-based launches now receive the configured host CPU thread setting.
  * Unset CPU thread values are preserved correctly when starting containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->