### PR TITLE
drivers: bump wifi-rtl8852bs to 3e7d964 (Aug 14, 2026)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -409,7 +409,7 @@ driver_rtl8852bs() {
 	if linux-version compare "${version}" ge 6.1 && [[ "${LINUXFAMILY}" == spacemit || "${LINUXFAMILY}" == rk35xx || "${LINUXFAMILY}" == rockchip64 ]]; then
 
 		# Attach to specific commit
-		local rtl8852bs_ver='commit:916053dd2805d16c458d92c3216c731ec956eb12' # Commit date: Aug 06, 2026 (please update when updating commit ref)
+		local rtl8852bs_ver='commit:3e7d964fac3063f7ff3645827e3180d59f33feec' # Commit date: Aug 14, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8852BS SDIO chipset ${rtl8852bs_ver}" "info"
 


### PR DESCRIPTION
Bumps the Realtek **8852BS SDIO** driver pin in `driver_rtl8852bs()`:

`916053dd` (Aug 06) → **`3e7d964`** (Aug 14, 2026)

Range: [`916053dd...3e7d964`](https://github.com/armbian/wifi-rtl8852bs/compare/916053dd2805d16c458d92c3216c731ec956eb12...3e7d964fac3063f7ff3645827e3180d59f33feec)

Latest commit fixes mixed-enum usage outside `h2cb_alloc` (`-Wenum-conversion`, 143 → 116 warnings).

Comment date updated alongside the ref, per the in-file reminder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the RTL8852BS wireless driver source to a newer revision, improving compatibility and reliability for supported hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->