### PR TITLE
rockchip64: backport 8250 DMA reopen crash fix

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/general-fix-serial-8250-dma-state-on-reopen.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-fix-serial-8250-dma-state-on-reopen.patch
@@ -1,0 +1,63 @@
+From e2fe6a0efecbef00e3ecc2db64dd5afa8c212b41 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Mon, 27 Jul 2026 14:25:22 +0800
+Subject: serial: 8250_dma: Clear stale RX state on shutdown
+
+serial8250_release_dma() terminates RX DMA and releases the channel, but
+leaves rx_running set.  If the port is closed while an RX transfer is
+active, the stale state remains while rxchan is NULL until the channel is
+requested again on the next open.
+
+The DesignWare BUSY workaround added by commit a7b9ce39fbe4
+("serial: 8250_dw: Ensure BUSY is deasserted") calls
+serial8250_rx_dma_flush() from the LCR write path during startup.  This
+happens before serial8250_request_dma() obtains a new RX channel.  On
+reopen, the stale rx_running state therefore makes the flush path pass a
+NULL channel to dmaengine_pause(), causing a kernel Oops.
+
+Clear rx_running after terminating RX DMA, matching the TX cleanup.  Also
+make the flush helper return if the DMA object or RX channel is not
+available so startup and teardown paths cannot pass a NULL channel to the
+DMAengine API.
+
+Fixes: 0fcb7901f9d6 ("tty: serial: 8250_dma: keep own book keeping about RX transfers")
+Cc: stable <stable@kernel.org>
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+Link: https://patch.msgid.link/tencent_9EE2945F4C933B4D810C73C2D7485E000F06@qq.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/tty/serial/8250/8250_dma.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/tty/serial/8250/8250_dma.c b/drivers/tty/serial/8250/8250_dma.c
+index 3b6452e759d5b..5a83e5269b415 100644
+--- a/drivers/tty/serial/8250/8250_dma.c
++++ b/drivers/tty/serial/8250/8250_dma.c
+@@ -211,11 +211,12 @@ void serial8250_rx_dma_flush(struct uart_8250_port *p)
+ {
+ 	struct uart_8250_dma *dma = p->dma;
+ 
+-	if (dma->rx_running) {
+-		dmaengine_pause(dma->rxchan);
+-		__dma_rx_complete(p);
+-		dmaengine_terminate_async(dma->rxchan);
+-	}
++	if (!dma || !dma->rxchan || !dma->rx_running)
++		return;
++
++	dmaengine_pause(dma->rxchan);
++	__dma_rx_complete(p);
++	dmaengine_terminate_async(dma->rxchan);
+ }
+ EXPORT_SYMBOL_GPL(serial8250_rx_dma_flush);
+ 
+@@ -324,6 +325,7 @@ void serial8250_release_dma(struct uart_8250_port *p)
+ 
+ 	/* Release RX resources */
+ 	dmaengine_terminate_sync(dma->rxchan);
++	dma->rx_running = 0;
+ 	dma_free_coherent(dma->rxchan->device->dev, dma->rx_size, dma->rx_buf,
+ 			  dma->rx_addr);
+ 	dma_release_channel(dma->rxchan);
+-- 
+cgit 1.3-korg

--- a/patch/kernel/archive/rockchip64-7.1/general-fix-serial-8250-dma-state-on-reopen.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-fix-serial-8250-dma-state-on-reopen.patch
@@ -1,0 +1,63 @@
+From e2fe6a0efecbef00e3ecc2db64dd5afa8c212b41 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Mon, 27 Jul 2026 14:25:22 +0800
+Subject: serial: 8250_dma: Clear stale RX state on shutdown
+
+serial8250_release_dma() terminates RX DMA and releases the channel, but
+leaves rx_running set.  If the port is closed while an RX transfer is
+active, the stale state remains while rxchan is NULL until the channel is
+requested again on the next open.
+
+The DesignWare BUSY workaround added by commit a7b9ce39fbe4
+("serial: 8250_dw: Ensure BUSY is deasserted") calls
+serial8250_rx_dma_flush() from the LCR write path during startup.  This
+happens before serial8250_request_dma() obtains a new RX channel.  On
+reopen, the stale rx_running state therefore makes the flush path pass a
+NULL channel to dmaengine_pause(), causing a kernel Oops.
+
+Clear rx_running after terminating RX DMA, matching the TX cleanup.  Also
+make the flush helper return if the DMA object or RX channel is not
+available so startup and teardown paths cannot pass a NULL channel to the
+DMAengine API.
+
+Fixes: 0fcb7901f9d6 ("tty: serial: 8250_dma: keep own book keeping about RX transfers")
+Cc: stable <stable@kernel.org>
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+Link: https://patch.msgid.link/tencent_9EE2945F4C933B4D810C73C2D7485E000F06@qq.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/tty/serial/8250/8250_dma.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/tty/serial/8250/8250_dma.c b/drivers/tty/serial/8250/8250_dma.c
+index 3b6452e759d5b..5a83e5269b415 100644
+--- a/drivers/tty/serial/8250/8250_dma.c
++++ b/drivers/tty/serial/8250/8250_dma.c
+@@ -211,11 +211,12 @@ void serial8250_rx_dma_flush(struct uart_8250_port *p)
+ {
+ 	struct uart_8250_dma *dma = p->dma;
+ 
+-	if (dma->rx_running) {
+-		dmaengine_pause(dma->rxchan);
+-		__dma_rx_complete(p);
+-		dmaengine_terminate_async(dma->rxchan);
+-	}
++	if (!dma || !dma->rxchan || !dma->rx_running)
++		return;
++
++	dmaengine_pause(dma->rxchan);
++	__dma_rx_complete(p);
++	dmaengine_terminate_async(dma->rxchan);
+ }
+ EXPORT_SYMBOL_GPL(serial8250_rx_dma_flush);
+ 
+@@ -324,6 +325,7 @@ void serial8250_release_dma(struct uart_8250_port *p)
+ 
+ 	/* Release RX resources */
+ 	dmaengine_terminate_sync(dma->rxchan);
++	dma->rx_running = 0;
+ 	dma_free_coherent(dma->rxchan->device->dev, dma->rx_size, dma->rx_buf,
+ 			  dma->rx_addr);
+ 	dma_release_channel(dma->rxchan);
+-- 
+cgit 1.3-korg


### PR DESCRIPTION
# Description

Backport upstream commit [`e2fe6a0efecb`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e2fe6a0efecbef00e3ecc2db64dd5afa8c212b41) ("serial: 8250_dma: Clear stale RX state on shutdown") to the `rockchip64-6.18` and `rockchip64-7.1` kernel patch sets.

The kernel crash was observed while testing LubanCat-5IO. If a serial port is closed while RX DMA is active, `serial8250_release_dma()` can release the RX channel without clearing `rx_running`. When the port is reopened, the DesignWare BUSY workaround may call `serial8250_rx_dma_flush()` before a new RX channel is acquired, causing `dmaengine_pause()` to dereference a NULL channel and trigger a kernel Oops.

The upstream fix clears the stale RX state during shutdown and guards the flush path when the DMA object or RX channel is unavailable. Although the issue was found on LubanCat-5IO, the fix is not board-specific and also benefits other RK3588 boards using the mainline 8250 DesignWare DMA driver.

The fix is included in the mainline kernel starting with tag `v7.2-rc7`. This PR backports it to the Armbian rockchip64 6.18 and 7.1 kernels.

# How Has This Been Tested?

- [x] Tested the affected serial port close and reopen path on LubanCat-5IO.
- [x] Added the same upstream patch to both the rockchip64 6.18 and 7.1 patch sets.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial port DMA cleanup during close and reopen operations.
  * Prevented invalid DMA operations when receive channels are unavailable or inactive.
  * Cleared stale receive state to improve reliability across repeated port use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->