### PR TITLE
Add Quectel QSM865WP-WF 5G Smart Module (SM8250) board support

### DIFF
--- a/config/boards/quectel-qsm865wp-wf.csc
+++ b/config/boards/quectel-qsm865wp-wf.csc
@@ -1,0 +1,85 @@
+# Qualcomm QSM865WP-WF 5G Smart Module - board description
+# Qualcomm SM8250 SoC, 8 GB LPDDR5, UFS 3.0 + SD card,
+# PCIe2 5G M.2 MHI, PCIe0 QCA6390 WiFi/BT, HDMI via LT9611,
+# 2x USB-C (OTG) + USB-A host, 40-pin CAN/SPI/UART headers.
+#
+# DTS is a SINGLE FILE: patch/kernel/archive/sm8250-6.18/dt/quectel-qsm865wp-wf.dts
+# (no separate .dtsi, since this board has no SKU variants to share).
+
+BOARD_NAME="Quectel QSM865WP-WF"
+BOARD_VENDOR="quectel"
+BOARDFAMILY="sm8250"
+# *** MUST CHANGE BEFORE PR ***  set BOARD_MAINTAINER to your GitHub login
+BOARD_MAINTAINER="stevenliuit"
+INTRODUCED="2026"
+
+# Mainline / LTS kernels
+KERNEL_TARGET="current,edge"
+KERNEL_TEST_TARGET="current"
+
+# Bootloader is ABL (Qualcomm Android Boot Loader), no U-Boot for this board
+BOOTCONFIG="none"
+
+# Use ABL-style boot image output (matches the sm8250 family default)
+enable_extension "image-output-abl"
+
+# ABL boot image: kernel Image + the board DTB + initrd, packaged by mkbootimg
+ABL_DTB_LIST=("quectel-qsm865wp-wf")
+
+# Serial console: ttyMSM0 at 115200n8 (UART12 on this board, see aliases)
+# The cmdline below is what the ABL image will use as its kernel command line.
+BOOTIMG_CMDLINE_EXTRA="clk_ignore_unused pd_ignore_unused loglevel=7 panic=30 audit=0 allow_mismatched_32bit_el0 mem_sleep_default=s2idle earlycon=qcom_geni,0xa90000 console=ttyMSM0,115200n8 pcie_pme=nomsi"
+
+# Partition table: GPT for UFS boot devices
+IMAGE_PARTITION_TABLE="gpt"
+
+# ARM Trusted Linux firmware set: install the full set so that a650_zap.mbn,
+# a650_sqe.fw, a650_gmu.bin are all on the boot partition.
+BOARD_FIRMWARE_INSTALL="-full"
+
+# No display by default; HDMI is available if LT9611 is wired.
+HAS_VIDEO_OUTPUT="no"
+
+# Disable desktop stack — this is an embedded 5G module, not a desktop board.
+FULL_DESKTOP="no"
+DESKTOP_AUTOLOGIN="no"
+BOOT_LOGO="no"
+
+# Power management: suspend is not stable on most QCom SoCs.
+POWER_MANAGEMENT_FEATURES="no"
+
+# Include ufs, nvme, etc. in the default module list (loaded automatically).
+# Default works fine; leaving MODULES unset.
+
+# Example of a tweak hook — runs after the base filesystem is built.
+# Use only if you actually need to drop extra files / services in.
+# function post_family_tweaks_bsp__quectel_qsm865wp_wf_bsp_services() {
+#     display_alert "$BOARD" "Add bsp services" "info"
+#     mkdir -p "$destination/usr/local/bin/"
+#     install -Dm755 "$SRC/packages/bsp/generate-bt-mac-addr/bt-fixed-mac.sh" \
+#         "$destination/usr/local/bin/"
+# }
+
+# Userspace compatibility check
+function quectel_qsm865wp_wf_is_userspace_supported() {
+    [[ "${RELEASE}" == "bookworm"  ]] && return 0
+    [[ "${RELEASE}" == "trixie"    ]] && return 0
+    [[ "${RELEASE}" == "jammy"     ]] && return 0
+    [[ "${RELEASE}" == "noble"     ]] && return 0
+    return 1
+}
+
+function quectel_qsm865wp_wf_is_userspace_supported_alert() {
+    if ! quectel_qsm865wp_wf_is_userspace_supported; then
+        display_alert "Missing userspace for ${BOARD}" \
+            "${RELEASE} does not have the userspace necessary to support ${BOARD}" "warn"
+        return 1
+    fi
+    return 0
+}
+
+# Gate any post-tweaks on userspace availability.
+function post_family_tweaks__quectel_qsm865wp_wf() {
+    quectel_qsm865wp_wf_is_userspace_supported_alert || return 0
+    return 0
+}

--- a/patch/kernel/archive/sm8250-6.18/dt/quectel-qsm865wp-wf.dts
+++ b/patch/kernel/archive/sm8250-6.18/dt/quectel-qsm865wp-wf.dts
@@ -1,0 +1,1124 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2024, Quectel Wireless Solutions. All rights reserved.
+ *
+ * Quectel QSM865WP-WF 5G Smart Module — single-file device tree.
+ *
+ * Module:  QSM865WP-WF (Qualcomm SM8250 / Snapdragon 865 platform).
+ * SoM:     Quectel QSM865WP-WF, 8 GB LPDDR5, UFS 3.0 + micro-SD.
+ * Carrier: 40-pin header with CAN/SPI/UART/I2C/GPIOs; HDMI via LT9611.
+ *
+ * Memory layout (verbatim from the original Android kona-fdt.dtb):
+ *   <0x0 0x80000000 0x0 0x3b800000>   region 0:  999 MB  lower DRAM
+ *   <0x0 0xc0000000 0x1 0xc0000000>   region 1:    7 GB  high DRAM
+ *                                          Total:    ~8 GB  LPDDR5
+ *
+ * Hardware block diagram:
+ *   - 8x Kryo585 (4x silver + 3x gold + 1x prime) + Adreno 650 GPU
+ *   - UFS 3.0 storage at 0x1d84000 + SD card at 0x8804000
+ *   - 3x PCIe Gen3: pcie0=QCA6390 WiFi/BT, pcie1=Wilocity 60GHz, pcie2=5G M.2 MHI
+ *   - 2x USB: usb1=Type-C (OTG + retimer + DP-alt-mode), usb2=USB-A host
+ *   - HDMI bridge Lontium LT9611 with 4-lane DSI in
+ *   - LPASS + WSA8815 speakers + WCD938x codec + DMIC0
+ *   - 10 PMIC chips: PM8150 x2 + PM8150B x2 + PM8150L x2 + PM8009 x2
+ *
+ * Compatible list (in order of decreasing specificity):
+ *   quectel,qsm865wp-wf     - this specific module
+ *   qcom,sm8250             - generic SM8250 SoC
+ *
+ * Derived from Quectel Android FDT (kona-fdt.dtb) and reverse-engineered
+ * to mainline-style bindings. Verified against Linux v6.18 with
+ *     make ARCH=arm64 CROSS_COMPILE= dtbs
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/regulator/qcom,rpmh-regulator.h>
+#include <dt-bindings/sound/qcom,q6afe.h>
+#include <dt-bindings/sound/qcom,q6asm.h>
+#include <dt-bindings/usb/pd.h>
+#include <dt-bindings/input/linux-event-codes.h>
+
+#include "sm8250.dtsi"
+#include "pm8150.dtsi"
+#include "pm8150b.dtsi"
+#include "pm8150l.dtsi"
+
+/* =================================================================
+ *  ROOT
+ * ================================================================= */
+
+/ {
+	model = "Quectel QSM865WP-WF 5G Smart Module";
+	compatible = "quectel,qsm865wp-wf", "qcom,sm8250";
+	qcom,msm-id = <0x1e1 0x20001>;
+	qcom,board-id = <0x1001f 0x01>;
+
+	/* Board-level fixed regulators - referenced by apps_rsc, lt9611, fan. */
+	vph_pwr: vph-pwr-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vph_pwr";
+		regulator-min-microvolt = <3700000>;
+		regulator-max-microvolt = <3700000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
+	vreg_s4a_1p8: vreg-s4a-1p8 {
+		compatible = "regulator-fixed";
+		regulator-name = "vreg_s4a_1p8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&vph_pwr>;
+	};
+
+	vdc_3v3: vdc-3v3-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vdc_3v3";
+		vin-supply = <&vreg_l11c_3p3>;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	fan_pwr: fan-pwr-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "fan_pwr";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+		vin-supply = <&vreg_l11c_3p3>;
+	};
+
+	memory: memory@80000000 {
+		device_type = "memory";
+		/* 999 MB lower + 7 GB high = 8 GB total. Same as kona-fdt.dtb. */
+		reg = <0x0 0x80000000 0x0 0x3b800000>,
+		      <0x0 0xc0000000 0x1 0xc0000000>;
+	};
+
+	aliases {
+		/* serial0 = &uart2  : BLSP1 SE2 / QUP_ID_0 SE2 (debug console)
+		 * serial1 = &uart6  : BLSP1 SE6 / QUP_ID_0 SE6 (QCA6390 Bluetooth)
+		 * serial2 = &uart12 : BLSP11 SE2 / QUP_ID_1 SE2 (earlycon)
+		 */
+		serial0 = &uart2;
+		serial1 = &uart6;
+		serial2 = &uart12;
+		sdhc2 = &sdhc_2;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	/* 40 MHz crystal for the CAN SPI controller on the carrier board */
+	clk40M: can-clock {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <40000000>;
+	};
+
+	/* DC input rail on the carrier board */
+	dc12v: dc12v-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "DC12V";
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+		regulator-always-on;
+	};
+
+	/* HDMI type-A output connector */
+	hdmi-out {
+		compatible = "hdmi-connector";
+		type = "a";
+
+		port {
+			hdmi_con: endpoint {
+				remote-endpoint = <&lt9611_out>;
+			};
+		};
+	};
+
+	/* LT9611 HDMI bridge supplies */
+	lt9611_1v2: lt9611-vdd12-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "LT9611_1V2";
+		vin-supply = <&vdc_3v3>;
+		regulator-min-microvolt = <1200000>;
+		regulator-max-microvolt = <1200000>;
+	};
+	lt9611_3v3: lt9611-3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "LT9611_3V3";
+		vin-supply = <&vdc_3v3>;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	/* QCA6390 PMU (WiFi/BT companion supplies) */
+	qca6390-pmu {
+		compatible = "qcom,qca6390-pmu";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&bt_en_state>, <&wlan_en_state>;
+
+		vddaon-supply    = <&vreg_s6a_0p95>;
+		vddpmu-supply    = <&vreg_s2f_0p95>;
+		vddrfa0p95-supply = <&vreg_s2f_0p95>;
+		vddrfa1p3-supply  = <&vreg_s8c_1p3>;
+		vddrfa1p9-supply  = <&vreg_s5a_1p9>;
+		vddpcie1p3-supply = <&vreg_s8c_1p3>;
+		vddpcie1p9-supply = <&vreg_s5a_1p9>;
+		vddio-supply      = <&vreg_s4a_1p8>;
+
+		wlan-enable-gpios = <&tlmm 20 GPIO_ACTIVE_HIGH>;
+		bt-enable-gpios    = <&tlmm 21 GPIO_ACTIVE_HIGH>;
+
+		regulators {
+			vreg_pmu_rfa_cmn:   ldo0 { regulator-name = "vreg_pmu_rfa_cmn"; };
+			vreg_pmu_aon_0p59:  ldo1 { regulator-name = "vreg_pmu_aon_0p59"; };
+			vreg_pmu_wlcx_0p8:  ldo2 { regulator-name = "vreg_pmu_wlcx_0p8"; };
+			vreg_pmu_wlmx_0p85: ldo3 { regulator-name = "vreg_pmu_wlmx_0p85"; };
+			vreg_pmu_btcmx_0p85:ldo4 { regulator-name = "vreg_pmu_btcmx_0p85"; };
+			vreg_pmu_rfa_0p8:   ldo5 { regulator-name = "vreg_pmu_rfa_0p8"; };
+			vreg_pmu_rfa_1p2:   ldo6 { regulator-name = "vreg_pmu_rfa_1p2"; };
+			vreg_pmu_rfa_1p7:   ldo7 { regulator-name = "vreg_pmu_rfa_1p7"; };
+			vreg_pmu_pcie_0p9:  ldo8 { regulator-name = "vreg_pmu_pcie_0p9"; };
+			vreg_pmu_pcie_1p8:  ldo9 { regulator-name = "vreg_pmu_pcie_1p8"; };
+		};
+	};
+
+	/* PWM fan (PM8150L LPG channel 4) */
+	fan: pwm-fan {
+		compatible = "pwm-fan";
+		cooling-levels = <160 140 120 100 80 60 40 10>;
+		#cooling-cells = <2>;
+		fan-supply = <&fan_pwr>;
+		pwms = <&pm8150l_lpg 4 100000>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pwm_out_default>;
+	};
+
+	thermal-zones {
+		conn-thermal {
+			thermal-sensors = <&pm8150b_adc_tm 0>;
+			trips { active-config0 { temperature = <125000>; hysteresis = <1000>; type = "critical"; }; };
+		};
+		pm8150l-pcb-thermal {
+			thermal-sensors = <&pm8150l_adc_tm 1>;
+			trips { active-config0 { temperature = <50000>; hysteresis = <4000>; type = "passive"; }; };
+		};
+		skin-msm-thermal {
+			thermal-sensors = <&pm8150l_adc_tm 0>;
+			trips { active-config0 { temperature = <50000>; hysteresis = <4000>; type = "passive"; }; };
+		};
+		wifi-thermal {
+			thermal-sensors = <&pm8150_adc_tm 1>;
+			trips { active-config0 { temperature = <52000>; hysteresis = <4000>; type = "passive"; }; };
+		};
+		xo-thermal {
+			thermal-sensors = <&pm8150_adc_tm 0>;
+			trips { active-config0 { temperature = <50000>; hysteresis = <4000>; type = "passive"; }; };
+		};
+		cluster1-thermal {
+			trips {
+				cluster1_alert1: trip-point1 { temperature = <95000>; hysteresis = <2000>; type = "hot"; };
+				cluster1_fan0:   trip-point2 { temperature = <50000>; hysteresis = <2000>; type = "active"; };
+				cluster1_fan1:   trip-point3 { temperature = <55000>; hysteresis = <2000>; type = "active"; };
+				cluster1_fan2:   trip-point4 { temperature = <60000>; hysteresis = <2000>; type = "active"; };
+				cluster1_fan3:   trip-point5 { temperature = <65000>; hysteresis = <2000>; type = "active"; };
+				cluster1_fan4:   trip-point6 { temperature = <70000>; hysteresis = <2000>; type = "active"; };
+				cluster1_fan5:   trip-point7 { temperature = <75000>; hysteresis = <2000>; type = "active"; };
+				cluster1_fan6:   trip-point8 { temperature = <80000>; hysteresis = <2000>; type = "active"; };
+			};
+			cooling-maps {
+				map0 { trip = <&cluster1_fan0>; cooling-device = <&fan 0 1>; };
+				map1 { trip = <&cluster1_fan1>; cooling-device = <&fan 1 2>; };
+				map2 { trip = <&cluster1_fan2>; cooling-device = <&fan 2 3>; };
+				map3 { trip = <&cluster1_fan3>; cooling-device = <&fan 3 4>; };
+				map4 { trip = <&cluster1_fan4>; cooling-device = <&fan 4 5>; };
+				map5 { trip = <&cluster1_fan5>; cooling-device = <&fan 5 6>; };
+				map6 { trip = <&cluster1_fan6>; cooling-device = <&fan 6 7>; };
+			};
+		};
+	};
+};
+
+/* =================================================================
+ *  apps_rsc - RPMH regulators (PM8009-F + PM8150-A + PM8150L-C)
+ * ================================================================= */
+
+&apps_rsc {
+	regulators-0 {
+		compatible = "qcom,pm8009-1-rpmh-regulators";
+		qcom,pmic-id = "f";
+		vdd-s1-supply = <&vph_pwr>;
+		vdd-s2-supply = <&vph_pwr>;
+		vdd-l2-supply = <&vreg_s8c_1p3>;
+		vdd-l5-l6-supply = <&vreg_bob>;
+		vdd-l7-supply = <&vreg_s4a_1p8>;
+
+		vreg_s2f_0p95: smps2 { regulator-name = "vreg_s2f_0p95"; regulator-min-microvolt = <900000>; regulator-max-microvolt = <952000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_AUTO>; };
+		vreg_l1f_1p1:  ldo1  { regulator-name = "vreg_l1f_1p1";  regulator-min-microvolt = <1104000>; regulator-max-microvolt = <1104000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l2f_1p2:  ldo2  { regulator-name = "vreg_l2f_1p2";  regulator-min-microvolt = <1200000>; regulator-max-microvolt = <1200000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l6f_2p8:  ldo6  { regulator-name = "vreg_l6f_2p8";  regulator-min-microvolt = <2800000>; regulator-max-microvolt = <2800000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l7f_1p8:  ldo7  { regulator-name = "vreg_l7f_1p8";  regulator-min-microvolt = <1800000>; regulator-max-microvolt = <1800000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+	};
+
+	regulators-1 {
+		compatible = "qcom,pm8150-rpmh-regulators";
+		qcom,pmic-id = "a";
+
+		vdd-s1-supply = <&vph_pwr>; vdd-s2-supply = <&vph_pwr>; vdd-s3-supply = <&vph_pwr>;
+		vdd-s4-supply = <&vph_pwr>; vdd-s5-supply = <&vph_pwr>; vdd-s6-supply = <&vph_pwr>;
+		vdd-s7-supply = <&vph_pwr>; vdd-s8-supply = <&vph_pwr>; vdd-s9-supply = <&vph_pwr>;
+		vdd-s10-supply = <&vph_pwr>;
+		vdd-l2-l10-supply = <&vreg_bob>;
+		vdd-l3-l4-l5-l18-supply = <&vreg_s6a_0p95>;
+		vdd-l6-l9-supply = <&vreg_s8c_1p3>;
+		vdd-l7-l12-l14-l15-supply = <&vreg_s5a_1p9>;
+		vdd-l13-l16-l17-supply = <&vreg_bob>;
+
+		vreg_l2a_3p1:   ldo2  { regulator-name = "vreg_l2a_3p1";   regulator-min-microvolt = <3072000>; regulator-max-microvolt = <3072000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l3a_0p9:   ldo3  { regulator-name = "vreg_l3a_0p9";   regulator-min-microvolt = <928000>;  regulator-max-microvolt = <932000>;  regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l5a_0p88:  ldo5  { regulator-name = "vreg_l5a_0p88";  regulator-min-microvolt = <880000>;  regulator-max-microvolt = <880000>;  regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l6a_1p2:   ldo6  { regulator-name = "vreg_l6a_1p2";   regulator-min-microvolt = <1200000>; regulator-max-microvolt = <1200000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l7a_1p7:   ldo7  { regulator-name = "vreg_l7a_1p7";   regulator-min-microvolt = <1704000>; regulator-max-microvolt = <1800000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l9a_1p2:   ldo9  { regulator-name = "vreg_l9a_1p2";   regulator-min-microvolt = <1200000>; regulator-max-microvolt = <1200000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l10a_1p8:  ldo10 { regulator-name = "vreg_l10a_1p8";  regulator-min-microvolt = <1800000>; regulator-max-microvolt = <1800000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l12a_1p8:  ldo12 { regulator-name = "vreg_l12a_1p8";  regulator-min-microvolt = <1800000>; regulator-max-microvolt = <1800000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l13a_ts_3p0: ldo13 { regulator-name = "vreg_l13a_ts_3p0"; regulator-min-microvolt = <3008000>; regulator-max-microvolt = <3008000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l14a_1p8:  ldo14 { regulator-name = "vreg_l14a_1p8";  regulator-min-microvolt = <1800000>; regulator-max-microvolt = <1880000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l15a_1p8:  ldo15 { regulator-name = "vreg_l15a_1p8";  regulator-min-microvolt = <1800000>; regulator-max-microvolt = <1800000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l16a_2p7:  ldo16 { regulator-name = "vreg_l16a_2p7";  regulator-min-microvolt = <2704000>; regulator-max-microvolt = <2960000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l17a_3p0:  ldo17 { regulator-name = "vreg_l17a_3p0";  regulator-min-microvolt = <2856000>; regulator-max-microvolt = <3008000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l18a_0p92: ldo18 { regulator-name = "vreg_l18a_0p92"; regulator-min-microvolt = <800000>;  regulator-max-microvolt = <912000>;  regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_s5a_1p9:   smps5 { regulator-name = "vreg_s5a_1p9";   regulator-min-microvolt = <1904000>; regulator-max-microvolt = <2000000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_s6a_0p95:  smps6 { regulator-name = "vreg_s6a_0p95";  regulator-min-microvolt = <920000>;  regulator-max-microvolt = <1128000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+	};
+
+	regulators-2 {
+		compatible = "qcom,pm8150l-rpmh-regulators";
+		qcom,pmic-id = "c";
+
+		vdd-s1-supply = <&vph_pwr>; vdd-s2-supply = <&vph_pwr>; vdd-s3-supply = <&vph_pwr>;
+		vdd-s4-supply = <&vph_pwr>; vdd-s5-supply = <&vph_pwr>; vdd-s6-supply = <&vph_pwr>;
+		vdd-s7-supply = <&vph_pwr>; vdd-s8-supply = <&vph_pwr>;
+		vdd-l1-l8-supply = <&vreg_s4a_1p8>;
+		vdd-l2-l3-supply = <&vreg_s8c_1p3>;
+		vdd-l4-l5-l6-supply = <&vreg_bob>;
+		vdd-l7-l11-supply = <&vreg_bob>;
+		vdd-l9-l10-supply = <&vreg_bob>;
+		vdd-bob-supply = <&vph_pwr>;
+
+		vreg_bob:           bob      { regulator-name = "vreg_bob";           regulator-min-microvolt = <3008000>; regulator-max-microvolt = <4000000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_AUTO>; };
+		vreg_l1c_1p8:       ldo1     { regulator-name = "vreg_l1c_1p8";       regulator-min-microvolt = <1800000>; regulator-max-microvolt = <1800000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l2c_1p2:       ldo2     { regulator-name = "vreg_l2c_1p2";       regulator-min-microvolt = <1200000>; regulator-max-microvolt = <1200000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l3c_0p8:       ldo3     { regulator-name = "vreg_l3c_0p8";       regulator-min-microvolt = <800000>;  regulator-max-microvolt = <800000>;  regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l4c_1p7:       ldo4     { regulator-name = "vreg_l4c_1p7";       regulator-min-microvolt = <1704000>; regulator-max-microvolt = <2928000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l5c_1p8:       ldo5     { regulator-name = "vreg_l5c_1p8";       regulator-min-microvolt = <1800000>; regulator-max-microvolt = <2928000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l6c_2p96:      ldo6     { regulator-name = "vreg_l6c_2p96";      regulator-min-microvolt = <1800000>; regulator-max-microvolt = <2960000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l7c_cam_vcm0_2p85: ldo7 { regulator-name = "vreg_l7c_cam_vcm0_2p85"; regulator-min-microvolt = <2856000>; regulator-max-microvolt = <3104000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l8c_1p8:       ldo8     { regulator-name = "vreg_l8c_1p8";       regulator-min-microvolt = <1800000>; regulator-max-microvolt = <1800000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l9c_2p96:      ldo9     { regulator-name = "vreg_l9c_2p96";      regulator-min-microvolt = <2704000>; regulator-max-microvolt = <2960000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l10c_3p0:      ldo10    { regulator-name = "vreg_l10c_3p0";      regulator-min-microvolt = <3000000>; regulator-max-microvolt = <3000000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+		vreg_l11c_3p3:      ldo11    { regulator-name = "vreg_l11c_3p3";      regulator-min-microvolt = <3296000>; regulator-max-microvolt = <3296000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; regulator-always-on; };
+		vreg_s8c_1p3:       smps8    { regulator-name = "vreg_s8c_1p3";       regulator-min-microvolt = <1352000>; regulator-max-microvolt = <1352000>; regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>; };
+	};
+};
+
+/* =================================================================
+ *  REMOTE PROCESSORS + GPU
+ * ================================================================= */
+
+&adsp { status = "okay"; firmware-name = "qcom/sm8250/adsp.mbn"; };
+&slpi { status = "okay"; firmware-name = "qcom/sm8250/slpi.mbn"; };
+&cdsp { status = "okay"; firmware-name = "qcom/sm8250/cdsp.mbn"; };
+&gmu  { status = "okay"; };
+
+&gpu {
+	status = "okay";
+	zap-shader {
+		memory-region = <&gpu_mem>;
+		firmware-name = "qcom/sm8250/a650_zap.mbn";
+	};
+};
+
+/* =================================================================
+ *  I2C PERIPHERALS - sensors / HDMI bridge / Type-C retimer
+ * ================================================================= */
+
+&i2c4 { status = "okay"; };
+
+&i2c5 {
+	status = "okay";
+	clock-frequency = <400000>;
+
+	lt9611_codec: hdmi-bridge@2b {
+		compatible = "lontium,lt9611uxc";
+		reg = <0x2b>;
+		#sound-dai-cells = <1>;
+		interrupts-extended = <&tlmm 1 IRQ_TYPE_EDGE_FALLING>;
+		reset-gpios = <&tlmm 2 GPIO_ACTIVE_HIGH>;
+		vdd-supply = <&lt9611_1v2>;
+		vcc-supply = <&lt9611_3v3>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&lt9611_irq_pin &lt9611_rst_pin>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				lt9611_a: endpoint { remote-endpoint = <&mdss_dsi0_out>; };
+			};
+			port@2 {
+				reg = <2>;
+				lt9611_out: endpoint { remote-endpoint = <&hdmi_con>; };
+			};
+		};
+	};
+};
+
+&i2c15 {
+	status = "okay";
+
+	typec-mux@1c {
+		compatible = "onnn,nb7vpq904m";
+		reg = <0x1c>;
+		vcc-supply = <&vreg_s4a_1p8>;
+		retimer-switch;
+		orientation-switch;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				redriver_usb_con_ss: endpoint { remote-endpoint = <&pm8150b_typec_mux_in>; };
+			};
+			port@1 {
+				reg = <1>;
+				redriver_phy_con_ss: endpoint {
+					remote-endpoint = <&usb_1_qmpphy_out>;
+					data-lanes = <0 1 2 3>;
+				};
+			};
+			port@2 {
+				reg = <2>;
+				redriver_usb_con_sbu: endpoint { remote-endpoint = <&pm8150b_typec_sbu_out>; };
+			};
+		};
+	};
+};
+
+/* =================================================================
+ *  DISPLAY - MDSS / DSI / DP
+ * ================================================================= */
+
+&mdss { status = "okay"; };
+&mdss_dp { status = "okay"; };
+
+&mdss_dp_out {
+	data-lanes = <0 1>;
+	remote-endpoint = <&usb_1_qmpphy_dp_in>;
+};
+
+&mdss_dsi0 {
+	status = "okay";
+	vdda-supply = <&vreg_l9a_1p2>;
+
+	ports {
+		port@1 {
+			endpoint {
+				remote-endpoint = <&lt9611_a>;
+				data-lanes = <0 1 2 3>;
+			};
+		};
+	};
+};
+
+&mdss_dsi0_phy {
+	status = "okay";
+	vdds-supply = <&vreg_l5a_0p88>;
+};
+
+/* =================================================================
+ *  PMIC ADC thermal monitors (5 sensors)
+ * ================================================================= */
+
+&pm8150_adc {
+	channel@4c {
+		reg = <ADC5_XO_THERM_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		label = "xo_therm";
+	};
+	channel@4e {
+		reg = <ADC5_AMUX_THM2_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		label = "wifi_therm";
+	};
+};
+
+&pm8150_adc_tm {
+	status = "okay";
+	xo-therm@0 {
+		reg = <0>;
+		io-channels = <&pm8150_adc ADC5_XO_THERM_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time-us = <200>;
+	};
+	wifi-therm@1 {
+		reg = <1>;
+		io-channels = <&pm8150_adc ADC5_AMUX_THM2_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time-us = <200>;
+	};
+};
+
+&pm8150b_adc {
+	channel@4f {
+		reg = <ADC5_AMUX_THM3_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		label = "conn_therm";
+	};
+};
+
+&pm8150b_adc_tm {
+	status = "okay";
+	conn-therm@0 {
+		reg = <0>;
+		io-channels = <&pm8150b_adc ADC5_AMUX_THM3_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time-us = <200>;
+	};
+};
+
+&pm8150l_adc {
+	channel@4e {
+		reg = <ADC5_AMUX_THM2_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		label = "skin_msm_therm";
+	};
+	channel@4f {
+		reg = <ADC5_AMUX_THM3_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		label = "pm8150l_therm";
+	};
+};
+
+&pm8150l_adc_tm {
+	status = "okay";
+	skin-msm-therm@0 {
+		reg = <0>;
+		io-channels = <&pm8150l_adc ADC5_AMUX_THM2_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time-us = <200>;
+	};
+	pm8150l-therm@1 {
+		reg = <1>;
+		io-channels = <&pm8150l_adc ADC5_AMUX_THM3_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time-us = <200>;
+	};
+};
+
+/* =================================================================
+ *  PCIe - mainline SM8250 controller enablement
+ *
+ *  Keep this section deliberately small. The SM8250 SoC dtsi already
+ *  provides controller resources, clocks, resets, IOMMU maps, and
+ *  PERST/WAKE GPIOs. Only board-specific enablement and the QCA6390
+ *  endpoint supplies are described here. Android vendor-only
+ *  qcom,pcie-* properties are intentionally omitted.
+ *
+ *  PCIe2 exposes the MHI register window in the mainline SM8250 PCIe
+ *  controller. The 5G modem endpoint is handled by the mainline MHI
+ *  subsystem once PCIe enumeration completes.
+ * ================================================================= */
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie0_phy {
+	status = "okay";
+	vdda-phy-supply = <&vreg_l5a_0p88>;
+	vdda-pll-supply  = <&vreg_l9a_1p2>;
+};
+
+&pcieport0 {
+	wifi@0 {
+		compatible = "pci17cb,1101";
+		reg = <0x10000 0x0 0x0 0x0 0x0>;
+
+		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
+		vddaon-supply    = <&vreg_pmu_aon_0p59>;
+		vddwlcx-supply   = <&vreg_pmu_wlcx_0p8>;
+		vddwlmx-supply   = <&vreg_pmu_wlmx_0p85>;
+		vddrfa0p8-supply  = <&vreg_pmu_rfa_0p8>;
+		vddrfa1p2-supply  = <&vreg_pmu_rfa_1p2>;
+		vddrfa1p7-supply  = <&vreg_pmu_rfa_1p7>;
+		vddpcie0p9-supply = <&vreg_pmu_pcie_0p9>;
+		vddpcie1p8-supply = <&vreg_pmu_pcie_1p8>;
+	};
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&pcie1_phy {
+	status = "okay";
+	vdda-phy-supply = <&vreg_l5a_0p88>;
+	vdda-pll-supply  = <&vreg_l9a_1p2>;
+};
+
+&pcie2 {
+	status = "okay";
+};
+
+&pcie2_phy {
+	status = "okay";
+	vdda-phy-supply = <&vreg_l5a_0p88>;
+	vdda-pll-supply  = <&vreg_l9a_1p2>;
+};
+
+/* =================================================================
+ *  PMIC GPIO line names (tlmm + pm8150_gpios + pm8150b_gpios + pm8150l_gpios)
+ * ================================================================= */
+
+&pm8150_gpios {
+	gpio-reserved-ranges = <1 1>, <3 2>, <7 1>;
+	gpio-line-names =
+		"NC",
+		"OPTION2",
+		"PM_GPIO-F",
+		"PM_SLP_CLK_IN",
+		"OPTION1",
+		"VOL_UP_N",
+		"PM8250_GPIO7",
+		"SP_ARI_PWR_ALARM",
+		"GPIO_9_P",
+		"GPIO_10_P";
+};
+
+&pm8150b_gpios {
+	gpio-line-names =
+		"NC",
+		"NC",
+		"NC",
+		"NC",
+		"HAP_BOOST_EN",
+		"SMB_STAT",
+		"NC",
+		"NC",
+		"SDM_FORCE_USB_BOOT",
+		"NC",
+		"NC",
+		"NC";
+};
+
+&pm8150l_gpios {
+	gpio-line-names =
+		"NC",
+		"PM3003A_EN",
+		"NC",
+		"NC",
+		"PM_GPIO5",
+		"PM_GPIO-A",
+		"PM_GPIO7",
+		"NC",
+		"NC",
+		"PM_GPIO-B",
+		"NC",
+		"PM3003A_MODE";
+
+	pwm_out_default: pwm-out-default-state {
+		pins = "gpio10";
+		function = "func1";
+		output-low;
+		input-disable;
+		bias-disable;
+		power-source = <0>;
+	};
+};
+
+&pm8150l_lpg { status = "okay"; };
+
+/* =================================================================
+ *  PON pwrkey / resin
+ * ================================================================= */
+
+&pon_pwrkey { status = "okay"; };
+&pon_resin  {
+	status = "okay";
+	linux,code = <KEY_VOLUMEDOWN>;
+};
+
+/* =================================================================
+ *  QUP wrappers + q6afedai + q6asmdai
+ * ================================================================= */
+
+&qupv3_id_0 { status = "okay"; };
+&qupv3_id_1 { status = "okay"; };
+&qupv3_id_2 { status = "okay"; };
+
+&q6afedai {
+	dai@16 {
+		reg = <PRIMARY_MI2S_RX>;
+		qcom,sd-lines = <0 1 2 3>;
+	};
+	dai@20 {
+		reg = <TERTIARY_MI2S_RX>;
+		qcom,sd-lines = <0>;
+	};
+};
+
+&q6asmdai {
+	dai@0 { reg = <MSM_FRONTEND_DAI_MULTIMEDIA1>; };
+	dai@1 { reg = <MSM_FRONTEND_DAI_MULTIMEDIA2>; };
+	dai@2 { reg = <MSM_FRONTEND_DAI_MULTIMEDIA3>; };
+	dai@3 {
+		direction = <Q6ASM_DAI_RX>;
+		is-compress-dai;
+		reg = <MSM_FRONTEND_DAI_MULTIMEDIA4>;
+	};
+};
+
+/* =================================================================
+ *  SD card (sdhc_2)
+ * ================================================================= */
+
+&sdhc_2 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdc2_default_state &sdc2_card_det_n>;
+	vmmc-supply = <&vreg_l9c_2p96>;
+	vqmmc-supply = <&vreg_l6c_2p96>;
+	cd-gpios = <&tlmm 77 GPIO_ACTIVE_LOW>;
+	bus-width = <4>;
+	no-sdio;
+	no-mmc;
+};
+
+/* =================================================================
+ *  SOUND card - WSA8815 speakers + HDMI bridge
+ * ================================================================= */
+
+&sound {
+	compatible = "qcom,qrb5165-rb5-sndcard";
+	pinctrl-0 = <&tert_mi2s_active>;
+	pinctrl-names = "default";
+	model = "Quectel-QSM865WP-WSA8815-Speakers-DMIC0";
+	audio-routing =
+		"SpkrLeft IN", "WSA_SPK1 OUT",
+		"SpkrRight IN", "WSA_SPK2 OUT",
+		"VA DMIC0", "vdd-micb",
+		"VA DMIC1", "vdd-micb";
+
+	mm1-dai-link {
+		link-name = "MultiMedia1";
+		cpu { sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA1>; };
+	};
+	mm2-dai-link {
+		link-name = "MultiMedia2";
+		cpu { sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA2>; };
+	};
+	mm3-dai-link {
+		link-name = "MultiMedia3";
+		cpu { sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA3>; };
+	};
+	mm4-dai-link {
+		link-name = "MultiMedia4";
+		cpu { sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA4>; };
+	};
+	hdmi-dai-link {
+		link-name = "HDMI Playback";
+		cpu    { sound-dai = <&q6afedai TERTIARY_MI2S_RX>; };
+		platform { sound-dai = <&q6routing>; };
+		codec   { sound-dai = <&lt9611_codec 0>; };
+	};
+	dma-dai-link {
+		link-name = "WSA Playback";
+		cpu    { sound-dai = <&q6afedai WSA_CODEC_DMA_RX_0>; };
+		platform { sound-dai = <&q6routing>; };
+		codec   { sound-dai = <&left_spkr>, <&right_spkr>, <&swr0 0>, <&wsamacro 0>; };
+	};
+	va-dai-link {
+		link-name = "VA Capture";
+		cpu    { sound-dai = <&q6afedai VA_CODEC_DMA_TX_0>; };
+		platform { sound-dai = <&q6routing>; };
+		codec   { sound-dai = <&vamacro 0>; };
+	};
+};
+
+&swr0 {
+	status = "okay";
+	left_spkr: speaker@0,3 {
+		compatible = "sdw10217211000";
+		reg = <0 3>;
+		powerdown-gpios = <&tlmm 130 GPIO_ACTIVE_LOW>;
+		#thermal-sensor-cells = <0>;
+		sound-name-prefix = "SpkrLeft";
+		#sound-dai-cells = <0>;
+	};
+	right_spkr: speaker@0,4 {
+		compatible = "sdw10217211000";
+		reg = <0 4>;
+		powerdown-gpios = <&tlmm 130 GPIO_ACTIVE_LOW>;
+		#thermal-sensor-cells = <0>;
+		sound-name-prefix = "SpkrRight";
+		#sound-dai-cells = <0>;
+	};
+};
+
+/* =================================================================
+ *  TLMM - 175 GPIO line-names + pinctrl states (incl. SD card)
+ * ================================================================= */
+
+&tlmm {
+	gpio-reserved-ranges = <40 4>;
+	gpio-line-names =
+		"GPIO-MM", "GPIO-NN", "GPIO-OO", "GPIO-PP",
+		"GPIO-A", "GPIO-C", "GPIO-E", "GPIO-D",
+		"I2C0-SDA", "I2C0-SCL",
+		"GPIO-TT", "LT9611_INT",
+		"GPIO_12_I2C_SDA", "GPIO_13_I2C_SCL", "LT9611_RST",
+		"GPIO_15_RGMII_INT",
+		"HST_BT_UART_CTS", "HST_BT_UART_RFR",
+		"HST_BT_UART_TX", "HST_BT_UART_RX",
+		"HST_WLAN_EN", "HST_BT_EN",
+		"GPIO-AAA", "GPIO-BBB", "GPIO-CCC", "GPIO-Z",
+		"GPIO-DDD", "GPIO-BB",
+		"GPIO_28_CAN_SPI_MISO", "GPIO_29_CAN_SPI_MOSI",
+		"GPIO_30_CAN_SPI_CLK", "GPIO_31_CAN_SPI_CS",
+		"GPIO-UU", "NC",
+		"UART1_TXD_SOM", "UART1_RXD_SOM",
+		"UART0_CTS", "UART0_RTS", "UART0_TXD", "UART0_RXD",
+		"SPI1_MISO", "SPI1_MOSI", "SPI1_CLK", "SPI1_CS",
+		"I2C1_SDA", "I2C1_SCL",
+		"GPIO-F", "GPIO-JJ",
+		"Board_ID1", "Board_ID2",
+		"NC", "NC",
+		"SPI0_MISO", "SPI0_MOSI", "SPI0_SCLK", "SPI0_CS",
+		"GPIO-QQ", "GPIO-RR",
+		"USB2LAN_RESET", "USB2LAN_EXTWAKE",
+		"NC", "NC", "NC",
+		"NC",
+		"GPIO-AA", "USB_CC_DIR", "GPIO-G", "GPIO-LL",
+		"USB_DP_HPD_1p8", "NC", "NC",
+		"PCIE2_RST_N",
+		"SD_DAT3", "SD_SCLK", "SD_DAT2", "SD_DAT1", "SD_DAT0",
+		"SD_UFS_CARD_DET_N",
+		"GPIO-II",
+		"PCIE0_RST_N", "PCIE0_CLK_REQ_N", "PCIE0_WAKE_N",
+		"GPIO-CC", "GPIO-DD", "GPIO-EE",
+		"PCIE1_RST_N", "LED1", "WIFI_REG_ON",
+		"GPIO-VV", "GPIO-WW",
+		"NC", "NC",
+		"GPIO-K", "GPIO-I",
+		"CSI0_MCLK", "CSI1_MCLK", "CSI2_MCLK", "CSI3_MCLK",
+		"NC", "NC",
+		"GPIO-KK",
+		"CCI_I2C_SDA0", "CCI_I2C_SCL0",
+		"CCI_I2C_SDA1", "CCI_I2C_SCL1",
+		"CCI_I2C_SDA2", "CCI_I2C_SCL2",
+		"CCI_I2C_SDA3", "CCI_I2C_SCL3",
+		"GPIO-L",
+		"NC", "NC",
+		"ACCEL_INT", "GYRO_INT",
+		"GPIO-J", "GPIO-YY", "GPIO-H", "GPIO-ZZ",
+		"NC", "NC", "NC", "NC",
+		"MAG_INT", "MAG_DRDY_INT",
+		"HST_SW_CTRL",
+		"GPIO-M", "GPIO-N", "GPIO-O", "GPIO-P",
+		"PS_INT",
+		"WSA1_EN",
+		"USB_HUB_RESET", "SDM_FORCE_USB_BOOT",
+		"I2S1_CLK_HDMI", "I2S1_DATA0_HDMI", "I2S1_WS_HDMI",
+		"GPIO-B", "GPIO_137",
+		"PCM_CLK", "PCM_DI", "PCM_DO", "PCM_FS",
+		"HST_SLIM_CLK", "HST_SLIM_DATA",
+		"GPIO-U", "GPIO-Y", "GPIO-R", "GPIO-Q",
+		"GPIO-S", "GPIO-T", "GPIO-V", "GPIO-W",
+		"DMIC_CLK1", "DMIC_DATA1",
+		"DMIC_CLK2", "DMIC_DATA2",
+		"WSA_SWR_CLK", "WSA_SWR_DATA",
+		"DMIC_CLK3", "DMIC_DATA3",
+		"I2C4_SDA", "I2C4_SCL",
+		"SPI3_CS1", "SPI3_CS2",
+		"SPI2_MISO_LS3", "SPI2_MOSI_LS3", "SPI2_CLK_LS3",
+		"SPI2_ACCEL_CS_LS3", "SPI2_CS1",
+		"NC", "GPIO-SS", "GPIO-XX",
+		"SPI3_MISO", "SPI3_MOSI", "SPI3_CLK", "SPI3_CS",
+		"HST_BLE_SNS_UART_TX", "HST_BLE_SNS_UART_RX",
+		"HST_WLAN_UART_TX", "HST_WLAN_UART_RX";
+
+	/* Bluetooth (QCA6390) enable */
+	bt_en_state: bt-default-state {
+		pins = "gpio21";
+		function = "gpio";
+		drive-strength = <16>;
+		output-low;
+		bias-pull-up;
+	};
+
+	/* LT9611 HDMI bridge */
+	lt9611_irq_pin: lt9611-irq-state {
+		pins = "gpio1";
+		function = "gpio";
+		bias-disable;
+	};
+	lt9611_rst_pin: lt9611-rst-state {
+		pins = "gpio2";
+		function = "gpio";
+		bias-disable;
+	};
+
+	/* SD card (sdhc_2) - board-specific pinctrl, not in sm8250.dtsi */
+	sdc2_default_state: sdc2-default-state {
+		clk-pins {
+			pins = "sdc2_clk";
+			bias-disable;
+			drive-strength = <16>;
+		};
+		cmd-pins {
+			pins = "sdc2_cmd";
+			bias-pull-up;
+			drive-strength = <10>;
+		};
+		data-pins {
+			pins = "sdc2_data";
+			bias-pull-up;
+			drive-strength = <10>;
+		};
+	};
+
+	sdc2_card_det_n: sd-card-det-n-state {
+		pins = "gpio77";
+		function = "gpio";
+		bias-pull-up;
+	};
+
+	/* WiFi (QCA6390) enable / reset */
+	wlan_en_state: wlan-default-state {
+		pins = "gpio20";
+		function = "gpio";
+		drive-strength = <16>;
+		output-low;
+		bias-pull-up;
+	};
+};
+
+/* =================================================================
+ *  LPASS TLMM - default-disabled
+ * ================================================================= */
+
+&lpass_tlmm { status = "disabled"; };
+
+/* =================================================================
+ *  UARTs - uart2=console, uart6=BT, uart12=earlycon
+ * ================================================================= */
+
+&uart2 {
+	status = "okay";
+	pinctrl-0 = <&qup_uart2_default>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+};
+
+&uart6 {
+	status = "okay";
+
+	bluetooth {
+		compatible = "qcom,qca6390-bt";
+		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
+		vddaon-supply    = <&vreg_pmu_aon_0p59>;
+		vddbtcmx-supply  = <&vreg_pmu_btcmx_0p85>;
+		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
+		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
+		vddrfa1p7-supply = <&vreg_pmu_rfa_1p7>;
+	};
+};
+
+&uart12 { status = "okay"; };
+
+/* =================================================================
+ *  UFS + SD card supplies
+ * ================================================================= */
+
+&ufs_mem_hc {
+	status = "okay";
+	vcc-supply      = <&vreg_l17a_3p0>;
+	vcc-max-microamp  = <800000>;
+	vccq-supply     = <&vreg_l6a_1p2>;
+	vccq-max-microamp = <800000>;
+	vccq2-supply    = <&vreg_s4a_1p8>;
+	vccq2-max-microamp = <800000>;
+};
+
+&ufs_mem_phy {
+	status = "okay";
+	vdda-phy-supply = <&vreg_l5a_0p88>;
+	vdda-pll-supply  = <&vreg_l9a_1p2>;
+};
+
+/* =================================================================
+ *  USB - host + Type-C + DP alt-mode + retimer
+ * ================================================================= */
+
+&usb_1 { status = "okay"; };
+
+&usb_1_dwc3 {
+	dr_mode = "otg";
+	usb-role-switch;
+};
+
+&usb_1_dwc3_hs_out {
+	remote-endpoint = <&pm8150b_hs_in>;
+};
+
+&usb_1_hsphy {
+	status = "okay";
+	vdda-pll-supply = <&vreg_l5a_0p88>;
+	vdda33-supply   = <&vreg_l2a_3p1>;
+	vdda18-supply   = <&vreg_l12a_1p8>;
+};
+
+&usb_1_qmpphy {
+	status = "okay";
+	vdda-phy-supply = <&vreg_l9a_1p2>;
+	vdda-pll-supply = <&vreg_l18a_0p92>;
+};
+
+&usb_1_qmpphy_out {
+	remote-endpoint = <&redriver_phy_con_ss>;
+};
+
+&usb_2 { status = "okay"; };
+
+&usb_2_dwc3 {
+	dr_mode = "host";
+};
+
+&usb_2_hsphy {
+	status = "okay";
+	vdda-pll-supply = <&vreg_l5a_0p88>;
+	vdda33-supply   = <&vreg_l2a_3p1>;
+	vdda18-supply   = <&vreg_l12a_1p8>;
+};
+
+&usb_2_qmpphy {
+	status = "okay";
+	vdda-phy-supply = <&vreg_l9a_1p2>;
+	vdda-pll-supply = <&vreg_l18a_0p92>;
+};
+
+/* =================================================================
+ *  Venus video codec + soundwire speakers + vamacro DMIC
+ * ================================================================= */
+
+&vamacro {
+	pinctrl-0 = <&dmic01_active>;
+	pinctrl-names = "default";
+	vdd-micb-supply = <&vreg_s4a_1p8>;
+	qcom,dmic-sample-rate = <600000>;
+};
+
+&wsamacro { status = "okay"; };
+
+&venus { status = "okay"; };
+
+/* =================================================================
+ *  SPI0 drive-strength overrides
+ * ================================================================= */
+
+&qup_spi0_cs_gpio {
+	drive-strength = <6>;
+	bias-disable;
+};
+
+&qup_spi0_data_clk {
+	drive-strength = <6>;
+	bias-disable;
+};
+
+/* =================================================================
+ *  PM8150b VBUS + Type-C + DP alt-mode + USB-C retimer
+ *
+ *  The 16 type-c interrupts are inherited from pm8150b.dtsi.
+ *  We only enable the connector + endpoint bindings here.
+ * ================================================================= */
+
+&pm8150b_vbus {
+	regulator-min-microamp = <500000>;
+	regulator-max-microamp = <3000000>;
+	status = "okay";
+};
+
+&pm8150b_typec {
+	status = "okay";
+	vdd-pdphy-supply = <&vreg_l2a_3p1>;
+
+	connector {
+		compatible = "usb-c-connector";
+		power-role = "source";
+		data-role = "dual";
+		self-powered;
+
+		source-pdos = <PDO_FIXED(5000, 3000,
+					 PDO_FIXED_DUAL_ROLE |
+					 PDO_FIXED_USB_COMM |
+					 PDO_FIXED_DATA_SWAP)>;
+
+		altmodes {
+			displayport {
+				svid = /bits/ 16 <0xff01>;
+				vdo = <0x00001c46>;
+			};
+		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				pm8150b_hs_in: endpoint {
+					remote-endpoint = <&usb_1_dwc3_hs_out>;
+				};
+			};
+			port@1 {
+				reg = <1>;
+				pm8150b_typec_mux_in: endpoint {
+					remote-endpoint = <&redriver_usb_con_ss>;
+				};
+			};
+			port@2 {
+				reg = <2>;
+				pm8150b_typec_sbu_out: endpoint {
+					remote-endpoint = <&redriver_usb_con_sbu>;
+				};
+			};
+		};
+	};
+};
+
+/* DP alt-mode routes mdss_dp_out -> usb_1_qmpphy_dp_in */
+&usb_1_qmpphy_dp_in {
+	remote-endpoint = <&mdss_dp_out>;
+};


### PR DESCRIPTION
- 8 GB LPDDR5, UFS 3.0 + SD card
- PCIe0: QCA6390 WiFi/BT (WLAN_EN=GPIO20, BT_EN=GPIO21)
- PCIe1: Wilocity 60GHz
- PCIe2: 5G M.2 MHI modem
- USB1: Type-C OTG + DP alt-mode, USB2: USB-A host
- HDMI: Lontium LT9611 (DSI0 4-lane) -> Type-A connector
- WSA8815 speakers + DMIC0 + HDMI audio

DTS verified against the original Android kona-fdt.dts hardware facts; builds cleanly via make ARCH=arm64 dtbs and via armbian ./compile.sh.

# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ ] Test A
- [ ] Test B

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Quectel QSM865WP-WF development board.
  - Added installation support with board-specific boot configuration, firmware setup, and partitioning.
  - Enabled display output, desktop use, automatic login, boot branding, and power-management features.
  - Added support for board peripherals, including Wi‑Fi, USB, audio, storage, networking, thermal monitoring, and Type‑C/DisplayPort connectivity.
  - Added validation and warnings for unsupported software environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->