### PR TITLE
rockchip64: fix CAN TX stalls and races

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/general-can-1-skb-make-echo-skb-freeing-safe-in-any-IRQ-contex.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-can-1-skb-make-echo-skb-freeing-safe-in-any-IRQ-contex.patch
@@ -1,0 +1,68 @@
+From 22bc38b1ea127f19276e188f6dbcd15ff774b583 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:14:24 +0800
+Subject: [PATCH 1/3] can: skb: make echo skb freeing safe in any IRQ context
+
+can_put_echo_skb() can be called with hardware interrupts disabled. Its
+direct drop paths use kfree_skb(), while can_create_echo_skb() uses
+kfree_skb() when cloning fails and consume_skb() after a successful clone.
+None of these helpers is safe in every IRQ context.
+
+Use dev_kfree_skb_any() for all drop paths and dev_consume_skb_any() when
+consuming a successfully cloned skb. This preserves the respective skb drop
+and consumed semantics regardless of the caller IRQ context.
+
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+Changes in v3:
+- Cover can_create_echo_skb() clone failure and successful-clone consume
+  paths with IRQ-context-independent helpers.
+---
+ drivers/net/can/dev/skb.c | 4 ++--
+ include/linux/can/skb.h   | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
+index 95fcdc1026f8..d7b5a5d17ff2 100644
+--- a/drivers/net/can/dev/skb.c
++++ b/drivers/net/can/dev/skb.c
+@@ -62,7 +62,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+ 	    (skb->protocol != htons(ETH_P_CAN) &&
+ 	     skb->protocol != htons(ETH_P_CANFD) &&
+ 	     skb->protocol != htons(ETH_P_CANXL))) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		return 0;
+ 	}
+ 
+@@ -90,7 +90,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+ 	} else {
+ 		/* locking problem with netif_stop_queue() ?? */
+ 		netdev_err(dev, "%s: BUG! echo_skb %d is occupied!\n", __func__, idx);
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		return -EBUSY;
+ 	}
+ 
+diff --git a/include/linux/can/skb.h b/include/linux/can/skb.h
+index a70a02967071..78c5870e2f9a 100644
+--- a/include/linux/can/skb.h
++++ b/include/linux/can/skb.h
+@@ -76,12 +76,12 @@ static inline struct sk_buff *can_create_echo_skb(struct sk_buff *skb)
+ 
+ 	nskb = skb_clone(skb, GFP_ATOMIC);
+ 	if (unlikely(!nskb)) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		return NULL;
+ 	}
+ 
+ 	can_skb_set_owner(nskb, skb->sk);
+-	consume_skb(skb);
++	dev_consume_skb_any(skb);
+ 	return nskb;
+ }
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-6.18/general-can-3-dev-can_put_echo_skb-free-skb-on-invalid-echo-in.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-can-3-dev-can_put_echo_skb-free-skb-on-invalid-echo-in.patch
@@ -1,0 +1,40 @@
+From fefeeb8d95a0dedf8050612c04771ee37ea20dc4 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:14:56 +0800
+Subject: [PATCH 3/3] can: dev: can_put_echo_skb(): free skb on invalid echo
+ index
+
+can_put_echo_skb() consumes the skb on all paths except when the echo
+index is out of bounds. This leaves ownership with the caller on -EINVAL,
+unlike the other error paths, and can leak the skb if the caller expects
+consistent semantics.
+
+Free the skb before returning -EINVAL so that all return paths consume it.
+
+Fixes: 6411959c10fe ("can: dev: can_put_echo_skb(): don't crash kernel if can_priv::echo_skb is accessed out of bounds")
+Cc: stable@vger.kernel.org
+Reviewed-by: Vincent Mailhol <mailhol@kernel.org>
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+Changes in v2:
+- Free the skb with dev_kfree_skb_any() on an invalid echo index.
+- Collect Vincent's Reviewed-by tag
+---
+ drivers/net/can/dev/skb.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
+index d34d3e7d4c9f..e985616c062c 100644
+--- a/drivers/net/can/dev/skb.c
++++ b/drivers/net/can/dev/skb.c
+@@ -54,6 +54,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+ 	if (idx >= priv->echo_skb_max) {
+ 		netdev_err(dev, "%s: BUG! Trying to access can_priv::echo_skb out of bounds (%u/max %u)\n",
+ 			   __func__, idx, priv->echo_skb_max);
++		dev_kfree_skb_any(skb);
+ 		return -EINVAL;
+ 	}
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-6.18/general-can-4-rockchip_canfd-prevent-TX-stall-on-echo-skb-fail.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-can-4-rockchip_canfd-prevent-TX-stall-on-echo-skb-fail.patch
@@ -1,0 +1,72 @@
+From 08956ae250aabf15d728a7502ff86986f540be55 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Thu, 30 Jul 2026 23:16:17 +0800
+Subject: [PATCH 1/3] can: rockchip_canfd: prevent TX stall on echo skb failure
+
+rkcanfd_start_xmit() advances tx_head and requests transmission even when
+can_put_echo_skb() fails. This creates a pending TX entry without the echo
+skb that the RXSTX completion path needs to match the self-received frame.
+The entry cannot be completed, and the netdev TX queue can remain stopped
+after the two-entry software FIFO fills.
+
+Install the echo skb before loading the hardware TX buffer. If installation
+fails, account the frame as dropped and leave both the hardware FIFO and
+software TX state unchanged. After the echo skb is installed, use the
+stored echo skb as the source for the hardware frame data.
+
+This depends on the standalone can_put_echo_skb() ownership fix. It makes
+the remaining -EINVAL path consume the skb and was posted at:
+
+Link: https://lore.kernel.org/linux-can/tencent_944DADCC4B42C8484EC01DA2B15F42132906@qq.com
+Fixes: b6661d73290c ("can: rockchip_canfd: add TX PATH")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+ drivers/net/can/rockchip/rockchip_canfd-tx.c | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+index 12200dcfd338..86fa8f2e1c8b 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+@@ -88,7 +88,16 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 		return NETDEV_TX_BUSY;
+ 	}
+ 
+-	cfd = (struct canfd_frame *)skb->data;
++	tx_head = rkcanfd_get_tx_head(priv);
++	frame_len = can_skb_get_frame_len(skb);
++	err = can_put_echo_skb(skb, ndev, tx_head, frame_len);
++	if (err) {
++		ndev->stats.tx_dropped++;
++		return NETDEV_TX_OK;
++	}
++
++	skb = priv->can.echo_skb[tx_head];
++	cfd = (const struct canfd_frame *)skb->data;
+ 
+ 	if (cfd->can_id & CAN_EFF_FLAG) {
+ 		reg_frameinfo = RKCANFD_REG_FD_FRAMEINFO_FRAME_FORMAT;
+@@ -114,7 +123,6 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 					    cfd->len);
+ 	}
+ 
+-	tx_head = rkcanfd_get_tx_head(priv);
+ 	reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_head);
+ 
+ 	rkcanfd_write(priv, RKCANFD_REG_FD_TXFRAMEINFO, reg_frameinfo);
+@@ -123,10 +131,7 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 		rkcanfd_write(priv, RKCANFD_REG_FD_TXDATA0 + i,
+ 			      *(u32 *)(cfd->data + i));
+ 
+-	frame_len = can_skb_get_frame_len(skb);
+-	err = can_put_echo_skb(skb, ndev, tx_head, frame_len);
+-	if (!err)
+-		netdev_sent_queue(priv->ndev, frame_len);
++	netdev_sent_queue(priv->ndev, frame_len);
+ 
+ 	WRITE_ONCE(priv->tx_head, priv->tx_head + 1);
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-6.18/general-can-5-rockchip_canfd-retry-the-outstanding-TX-buffer.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-can-5-rockchip_canfd-retry-the-outstanding-TX-buffer.patch
@@ -1,0 +1,41 @@
+From 20fc9c7818d49faa1d6587ac2da6cfdb1f4b94b3 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:16:27 +0800
+Subject: [PATCH 2/3] can: rockchip_canfd: retry the outstanding TX buffer
+
+rkcanfd_xmit_retry() originally operated with a TX FIFO depth of one. At
+that depth, the masked head and tail indices both select buffer 0, so using
+tx_head happened to select the correct buffer.
+
+After the FIFO depth was increased to two, tx_head instead identifies the
+next free buffer when one frame is outstanding. The erratum 6 workaround
+therefore requests transmission from the wrong buffer, leaving the
+outstanding echo entry incomplete and the netdev TX queue stopped.
+
+Use tx_tail to select the outstanding buffer for retransmission.
+
+Fixes: a5605d61c7dd ("can: rockchip_canfd: enable full TX-FIFO depth of 2")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+ drivers/net/can/rockchip/rockchip_canfd-tx.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+index 86fa8f2e1c8b..fc338ea865fe 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+@@ -57,8 +57,8 @@ static void rkcanfd_start_xmit_write_cmd(const struct rkcanfd_priv *priv,
+ 
+ void rkcanfd_xmit_retry(struct rkcanfd_priv *priv)
+ {
+-	const unsigned int tx_head = rkcanfd_get_tx_head(priv);
+-	const u32 reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_head);
++	const unsigned int tx_tail = rkcanfd_get_tx_tail(priv);
++	const u32 reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_tail);
+ 
+ 	rkcanfd_start_xmit_write_cmd(priv, reg_cmd);
+ }
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-6.18/general-can-6-rockchip_canfd-serialize-TX-state-and-command-wr.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-can-6-rockchip_canfd-serialize-TX-state-and-command-wr.patch
@@ -1,0 +1,276 @@
+From d88c17cb3aa0b055cf7d652e95f5696864e60e75 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:17:29 +0800
+Subject: [PATCH 3/3] can: rockchip_canfd: serialize TX state and command
+ writes
+
+The TX completion path removes an echo skb before advancing tx_tail. In
+parallel, the transmit path reads tx_head, tx_tail and the tail echo slot
+when applying the erratum 6 queue restriction. There is no synchronization
+between these operations.
+
+On SMP, the transmit path can consequently observe a pending frame with
+an empty echo slot. It can also keep a pointer to an echo skb while the
+completion path removes and queues it for NAPI, where it can be freed on
+another CPU. The inconsistent snapshot can stop the netdev TX queue when
+there is no later completion to wake it.
+
+There is a second race in the command submission sequence.
+rkcanfd_start_xmit() runs in softirq context.
+rkcanfd_xmit_retry() runs from the RX interrupt handler. On controllers
+affected by erratum 12, both execute a MODE/CMD/MODE register sequence. The
+interrupt handler can restore the default MODE between the softirq writes.
+The resumed softirq then issues CMD without SPACE_RX_MODE and bypasses the
+erratum 12 workaround.
+
+Add a TX state lock and use it to protect tx_head, tx_tail and the echo skb
+ring as one state. The same lock serializes the MODE/CMD/MODE sequence
+between the transmit and interrupt paths. Keep completion and wakeup
+outside the lock to avoid nesting the TX state lock with the netdev TX
+queue lock. Install the echo skb before loading the hardware TX buffer so
+an echo setup failure cannot desynchronize the hardware and software TX
+state.
+
+Tested on an RK3588 rev2.2 at 1 Mbit/s with 100,000 extended CAN frames.
+The run triggered 138 erratum 6 retries and completed without drops, queue
+stalls or driver warnings. RK3588 does not enable erratum 12, so this test
+does not exercise that hardware workaround.
+
+Fixes: ae002cc32ec4 ("can: rockchip_canfd: prepare to use full TX-FIFO depth")
+Fixes: 83f9bd6bf39d ("can: rockchip_canfd: implement workaround for erratum 12")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+ .../net/can/rockchip/rockchip_canfd-core.c    |  1 +
+ drivers/net/can/rockchip/rockchip_canfd-rx.c  | 31 ++++++++++++++-----
+ drivers/net/can/rockchip/rockchip_canfd-tx.c  | 26 ++++++++++++++--
+ drivers/net/can/rockchip/rockchip_canfd.h     |  4 ++-
+ 4 files changed, 50 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-core.c b/drivers/net/can/rockchip/rockchip_canfd-core.c
+index 29de0c01e4ed..c8257858b452 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-core.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-core.c
+@@ -904,6 +904,7 @@ static int rkcanfd_probe(struct platform_device *pdev)
+ 	priv->can.do_set_mode = rkcanfd_set_mode;
+ 	priv->can.do_get_berr_counter = rkcanfd_get_berr_counter;
+ 	priv->ndev = ndev;
++	spin_lock_init(&priv->tx_lock);
+ 
+ 	match = device_get_match_data(&pdev->dev);
+ 	if (match) {
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-rx.c b/drivers/net/can/rockchip/rockchip_canfd-rx.c
+index 475c0409e215..02efc8c0cddc 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-rx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-rx.c
+@@ -100,14 +100,25 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 	const struct canfd_frame *cfd_nominal;
+ 	const struct sk_buff *skb;
+ 	unsigned int tx_tail;
++	unsigned long flags;
++
++	spin_lock_irqsave(&priv->tx_lock, flags);
++
++	if (!rkcanfd_get_tx_pending(priv))
++		goto out_unlock;
+ 
+ 	tx_tail = rkcanfd_get_tx_tail(priv);
+ 	skb = priv->can.echo_skb[tx_tail];
+ 	if (!skb) {
++		const unsigned int tx_head_unmasked = priv->tx_head;
++		const unsigned int tx_tail_unmasked = priv->tx_tail;
++
++		spin_unlock_irqrestore(&priv->tx_lock, flags);
++
+ 		netdev_err(priv->ndev,
+ 			   "%s: echo_skb[%u]=NULL tx_head=0x%08x tx_tail=0x%08x\n",
+ 			   __func__, tx_tail,
+-			   priv->tx_head, priv->tx_tail);
++			   tx_head_unmasked, tx_tail_unmasked);
+ 
+ 		return -ENOMSG;
+ 	}
+@@ -123,17 +134,18 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 		rkcanfd_handle_tx_done_one(priv, ts, &frame_len);
+ 
+ 		WRITE_ONCE(priv->tx_tail, priv->tx_tail + 1);
++		*tx_done = true;
++
++		spin_unlock_irqrestore(&priv->tx_lock, flags);
+ 		netif_subqueue_completed_wake(priv->ndev, 0, 1, frame_len,
+ 					      rkcanfd_get_effective_tx_free(priv),
+ 					      RKCANFD_TX_START_THRESHOLD);
+ 
+-		*tx_done = true;
+-
+ 		return 0;
+ 	}
+ 
+ 	if (!(priv->devtype_data.quirks & RKCANFD_QUIRK_RK3568_ERRATUM_6))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Erratum 6: Extended frames may be send as standard frames.
+ 	 *
+@@ -143,7 +155,7 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 	 */
+ 	if (!(cfd_nominal->can_id & CAN_EFF_FLAG) ||
+ 	    (cfd_rx->can_id & CAN_EFF_FLAG))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Not affected if:
+ 	 * - standard part and RTR flag of the TX'ed frame
+@@ -151,20 +163,20 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 	 */
+ 	if ((cfd_nominal->can_id & (CAN_RTR_FLAG | CAN_SFF_MASK)) !=
+ 	    (cfd_rx->can_id & (CAN_RTR_FLAG | CAN_SFF_MASK)))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Not affected if:
+ 	 * - length is not the same
+ 	 */
+ 	if (cfd_nominal->len != cfd_rx->len)
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Not affected if:
+ 	 * - the data of non RTR frames is different
+ 	 */
+ 	if (!(cfd_nominal->can_id & CAN_RTR_FLAG) &&
+ 	    memcmp(cfd_nominal->data, cfd_rx->data, cfd_nominal->len))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Affected by Erratum 6 */
+ 	u64_stats_update_begin(&rkcanfd_stats->syncp);
+@@ -185,6 +197,9 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 
+ 	rkcanfd_xmit_retry(priv);
+ 
++out_unlock:
++	spin_unlock_irqrestore(&priv->tx_lock, flags);
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+index fc338ea865fe..b367341dd0ae 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+@@ -14,6 +14,8 @@ static bool rkcanfd_tx_tail_is_eff(const struct rkcanfd_priv *priv)
+ 	const struct sk_buff *skb;
+ 	unsigned int tx_tail;
+ 
++	lockdep_assert_held(&priv->tx_lock);
++
+ 	if (!rkcanfd_get_tx_pending(priv))
+ 		return false;
+ 
+@@ -33,13 +35,22 @@ static bool rkcanfd_tx_tail_is_eff(const struct rkcanfd_priv *priv)
+ 	return cfd->can_id & CAN_EFF_FLAG;
+ }
+ 
+-unsigned int rkcanfd_get_effective_tx_free(const struct rkcanfd_priv *priv)
++unsigned int rkcanfd_get_effective_tx_free(struct rkcanfd_priv *priv)
+ {
++	unsigned int tx_free;
++	unsigned long flags;
++
++	spin_lock_irqsave(&priv->tx_lock, flags);
++
+ 	if (priv->devtype_data.quirks & RKCANFD_QUIRK_RK3568_ERRATUM_6 &&
+ 	    rkcanfd_tx_tail_is_eff(priv))
+-		return 0;
++		tx_free = 0;
++	else
++		tx_free = rkcanfd_get_tx_free(priv);
++
++	spin_unlock_irqrestore(&priv->tx_lock, flags);
+ 
+-	return rkcanfd_get_tx_free(priv);
++	return tx_free;
+ }
+ 
+ static void rkcanfd_start_xmit_write_cmd(const struct rkcanfd_priv *priv,
+@@ -60,6 +71,8 @@ void rkcanfd_xmit_retry(struct rkcanfd_priv *priv)
+ 	const unsigned int tx_tail = rkcanfd_get_tx_tail(priv);
+ 	const u32 reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_tail);
+ 
++	lockdep_assert_held(&priv->tx_lock);
++
+ 	rkcanfd_start_xmit_write_cmd(priv, reg_cmd);
+ }
+ 
+@@ -69,6 +82,7 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 	u32 reg_frameinfo, reg_id, reg_cmd;
+ 	unsigned int tx_head, frame_len;
+ 	const struct canfd_frame *cfd;
++	unsigned long flags;
+ 	int err;
+ 	u8 i;
+ 
+@@ -88,10 +102,13 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 		return NETDEV_TX_BUSY;
+ 	}
+ 
++	spin_lock_irqsave(&priv->tx_lock, flags);
+ 	tx_head = rkcanfd_get_tx_head(priv);
+ 	frame_len = can_skb_get_frame_len(skb);
+ 	err = can_put_echo_skb(skb, ndev, tx_head, frame_len);
+ 	if (err) {
++		spin_unlock_irqrestore(&priv->tx_lock, flags);
++
+ 		ndev->stats.tx_dropped++;
+ 		return NETDEV_TX_OK;
+ 	}
+@@ -136,6 +153,7 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 	WRITE_ONCE(priv->tx_head, priv->tx_head + 1);
+ 
+ 	rkcanfd_start_xmit_write_cmd(priv, reg_cmd);
++	spin_unlock_irqrestore(&priv->tx_lock, flags);
+ 
+ 	netif_subqueue_maybe_stop(priv->ndev, 0,
+ 				  rkcanfd_get_effective_tx_free(priv),
+@@ -152,6 +170,8 @@ void rkcanfd_handle_tx_done_one(struct rkcanfd_priv *priv, const u32 ts,
+ 	unsigned int tx_tail;
+ 	struct sk_buff *skb;
+ 
++	lockdep_assert_held(&priv->tx_lock);
++
+ 	tx_tail = rkcanfd_get_tx_tail(priv);
+ 	skb = priv->can.echo_skb[tx_tail];
+ 
+diff --git a/drivers/net/can/rockchip/rockchip_canfd.h b/drivers/net/can/rockchip/rockchip_canfd.h
+index 93131c7d7f54..3cf283a7b380 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd.h
++++ b/drivers/net/can/rockchip/rockchip_canfd.h
+@@ -15,6 +15,7 @@
+ #include <linux/netdevice.h>
+ #include <linux/reset.h>
+ #include <linux/skbuff.h>
++#include <linux/spinlock.h>
+ #include <linux/timecounter.h>
+ #include <linux/types.h>
+ #include <linux/u64_stats_sync.h>
+@@ -462,6 +463,7 @@ struct rkcanfd_priv {
+ 	struct can_rx_offload offload;
+ 	struct net_device *ndev;
+ 
++	spinlock_t tx_lock; /* protects tx_head, tx_tail and echo_skb */
+ 	void __iomem *regs;
+ 	unsigned int tx_head;
+ 	unsigned int tx_tail;
+@@ -544,7 +546,7 @@ void rkcanfd_timestamp_start(struct rkcanfd_priv *priv);
+ void rkcanfd_timestamp_stop(struct rkcanfd_priv *priv);
+ void rkcanfd_timestamp_stop_sync(struct rkcanfd_priv *priv);
+ 
+-unsigned int rkcanfd_get_effective_tx_free(const struct rkcanfd_priv *priv);
++unsigned int rkcanfd_get_effective_tx_free(struct rkcanfd_priv *priv);
+ void rkcanfd_xmit_retry(struct rkcanfd_priv *priv);
+ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev);
+ void rkcanfd_handle_tx_done_one(struct rkcanfd_priv *priv, const u32 ts,
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.1/general-can-1-skb-make-echo-skb-freeing-safe-in-any-IRQ-contex.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-can-1-skb-make-echo-skb-freeing-safe-in-any-IRQ-contex.patch
@@ -1,0 +1,68 @@
+From 22bc38b1ea127f19276e188f6dbcd15ff774b583 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:14:24 +0800
+Subject: [PATCH 1/3] can: skb: make echo skb freeing safe in any IRQ context
+
+can_put_echo_skb() can be called with hardware interrupts disabled. Its
+direct drop paths use kfree_skb(), while can_create_echo_skb() uses
+kfree_skb() when cloning fails and consume_skb() after a successful clone.
+None of these helpers is safe in every IRQ context.
+
+Use dev_kfree_skb_any() for all drop paths and dev_consume_skb_any() when
+consuming a successfully cloned skb. This preserves the respective skb drop
+and consumed semantics regardless of the caller IRQ context.
+
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+Changes in v3:
+- Cover can_create_echo_skb() clone failure and successful-clone consume
+  paths with IRQ-context-independent helpers.
+---
+ drivers/net/can/dev/skb.c | 4 ++--
+ include/linux/can/skb.h   | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
+index 95fcdc1026f8..d7b5a5d17ff2 100644
+--- a/drivers/net/can/dev/skb.c
++++ b/drivers/net/can/dev/skb.c
+@@ -62,7 +62,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+ 	    (skb->protocol != htons(ETH_P_CAN) &&
+ 	     skb->protocol != htons(ETH_P_CANFD) &&
+ 	     skb->protocol != htons(ETH_P_CANXL))) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		return 0;
+ 	}
+ 
+@@ -90,7 +90,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+ 	} else {
+ 		/* locking problem with netif_stop_queue() ?? */
+ 		netdev_err(dev, "%s: BUG! echo_skb %d is occupied!\n", __func__, idx);
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		return -EBUSY;
+ 	}
+ 
+diff --git a/include/linux/can/skb.h b/include/linux/can/skb.h
+index a70a02967071..78c5870e2f9a 100644
+--- a/include/linux/can/skb.h
++++ b/include/linux/can/skb.h
+@@ -76,12 +76,12 @@ static inline struct sk_buff *can_create_echo_skb(struct sk_buff *skb)
+ 
+ 	nskb = skb_clone(skb, GFP_ATOMIC);
+ 	if (unlikely(!nskb)) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		return NULL;
+ 	}
+ 
+ 	can_skb_set_owner(nskb, skb->sk);
+-	consume_skb(skb);
++	dev_consume_skb_any(skb);
+ 	return nskb;
+ }
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.1/general-can-2-skb-make-CAN-skb-allocation-failure-paths-IRQ-sa.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-can-2-skb-make-CAN-skb-allocation-failure-paths-IRQ-sa.patch
@@ -1,0 +1,53 @@
+From 56aae92b2a29364793e98d06e64b9eda731706b6 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:14:38 +0800
+Subject: [PATCH 2/3] can: skb: make CAN skb allocation failure paths IRQ-safe
+
+The CAN skb allocation helpers are used from hardware interrupt receive
+handlers. If can_skb_ext_add() fails, they release the newly allocated skb
+with kfree_skb(), which is not safe in hardware interrupt context.
+
+Use dev_kfree_skb_any() for the allocation failure paths in
+alloc_can_skb(), alloc_canfd_skb(), and alloc_canxl_skb().
+
+Fixes: 96ea3a1e2d31 ("can: add CAN skb extension infrastructure")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+ drivers/net/can/dev/skb.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
+index d7b5a5d17ff2..d34d3e7d4c9f 100644
+--- a/drivers/net/can/dev/skb.c
++++ b/drivers/net/can/dev/skb.c
+@@ -223,7 +223,7 @@ struct sk_buff *alloc_can_skb(struct net_device *dev, struct can_frame **cf)
+ 
+ 	csx = can_skb_ext_add(skb);
+ 	if (!csx) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		goto out_error_cc;
+ 	}
+ 
+@@ -254,7 +254,7 @@ struct sk_buff *alloc_canfd_skb(struct net_device *dev,
+ 
+ 	csx = can_skb_ext_add(skb);
+ 	if (!csx) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		goto out_error_fd;
+ 	}
+ 
+@@ -292,7 +292,7 @@ struct sk_buff *alloc_canxl_skb(struct net_device *dev,
+ 
+ 	csx = can_skb_ext_add(skb);
+ 	if (!csx) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		goto out_error_xl;
+ 	}
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.1/general-can-3-dev-can_put_echo_skb-free-skb-on-invalid-echo-in.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-can-3-dev-can_put_echo_skb-free-skb-on-invalid-echo-in.patch
@@ -1,0 +1,40 @@
+From fefeeb8d95a0dedf8050612c04771ee37ea20dc4 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:14:56 +0800
+Subject: [PATCH 3/3] can: dev: can_put_echo_skb(): free skb on invalid echo
+ index
+
+can_put_echo_skb() consumes the skb on all paths except when the echo
+index is out of bounds. This leaves ownership with the caller on -EINVAL,
+unlike the other error paths, and can leak the skb if the caller expects
+consistent semantics.
+
+Free the skb before returning -EINVAL so that all return paths consume it.
+
+Fixes: 6411959c10fe ("can: dev: can_put_echo_skb(): don't crash kernel if can_priv::echo_skb is accessed out of bounds")
+Cc: stable@vger.kernel.org
+Reviewed-by: Vincent Mailhol <mailhol@kernel.org>
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+Changes in v2:
+- Free the skb with dev_kfree_skb_any() on an invalid echo index.
+- Collect Vincent's Reviewed-by tag
+---
+ drivers/net/can/dev/skb.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
+index d34d3e7d4c9f..e985616c062c 100644
+--- a/drivers/net/can/dev/skb.c
++++ b/drivers/net/can/dev/skb.c
+@@ -54,6 +54,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+ 	if (idx >= priv->echo_skb_max) {
+ 		netdev_err(dev, "%s: BUG! Trying to access can_priv::echo_skb out of bounds (%u/max %u)\n",
+ 			   __func__, idx, priv->echo_skb_max);
++		dev_kfree_skb_any(skb);
+ 		return -EINVAL;
+ 	}
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.1/general-can-4-rockchip_canfd-prevent-TX-stall-on-echo-skb-fail.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-can-4-rockchip_canfd-prevent-TX-stall-on-echo-skb-fail.patch
@@ -1,0 +1,72 @@
+From 08956ae250aabf15d728a7502ff86986f540be55 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Thu, 30 Jul 2026 23:16:17 +0800
+Subject: [PATCH 1/3] can: rockchip_canfd: prevent TX stall on echo skb failure
+
+rkcanfd_start_xmit() advances tx_head and requests transmission even when
+can_put_echo_skb() fails. This creates a pending TX entry without the echo
+skb that the RXSTX completion path needs to match the self-received frame.
+The entry cannot be completed, and the netdev TX queue can remain stopped
+after the two-entry software FIFO fills.
+
+Install the echo skb before loading the hardware TX buffer. If installation
+fails, account the frame as dropped and leave both the hardware FIFO and
+software TX state unchanged. After the echo skb is installed, use the
+stored echo skb as the source for the hardware frame data.
+
+This depends on the standalone can_put_echo_skb() ownership fix. It makes
+the remaining -EINVAL path consume the skb and was posted at:
+
+Link: https://lore.kernel.org/linux-can/tencent_944DADCC4B42C8484EC01DA2B15F42132906@qq.com
+Fixes: b6661d73290c ("can: rockchip_canfd: add TX PATH")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+ drivers/net/can/rockchip/rockchip_canfd-tx.c | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+index 12200dcfd338..86fa8f2e1c8b 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+@@ -88,7 +88,16 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 		return NETDEV_TX_BUSY;
+ 	}
+ 
+-	cfd = (struct canfd_frame *)skb->data;
++	tx_head = rkcanfd_get_tx_head(priv);
++	frame_len = can_skb_get_frame_len(skb);
++	err = can_put_echo_skb(skb, ndev, tx_head, frame_len);
++	if (err) {
++		ndev->stats.tx_dropped++;
++		return NETDEV_TX_OK;
++	}
++
++	skb = priv->can.echo_skb[tx_head];
++	cfd = (const struct canfd_frame *)skb->data;
+ 
+ 	if (cfd->can_id & CAN_EFF_FLAG) {
+ 		reg_frameinfo = RKCANFD_REG_FD_FRAMEINFO_FRAME_FORMAT;
+@@ -114,7 +123,6 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 					    cfd->len);
+ 	}
+ 
+-	tx_head = rkcanfd_get_tx_head(priv);
+ 	reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_head);
+ 
+ 	rkcanfd_write(priv, RKCANFD_REG_FD_TXFRAMEINFO, reg_frameinfo);
+@@ -123,10 +131,7 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 		rkcanfd_write(priv, RKCANFD_REG_FD_TXDATA0 + i,
+ 			      *(u32 *)(cfd->data + i));
+ 
+-	frame_len = can_skb_get_frame_len(skb);
+-	err = can_put_echo_skb(skb, ndev, tx_head, frame_len);
+-	if (!err)
+-		netdev_sent_queue(priv->ndev, frame_len);
++	netdev_sent_queue(priv->ndev, frame_len);
+ 
+ 	WRITE_ONCE(priv->tx_head, priv->tx_head + 1);
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.1/general-can-5-rockchip_canfd-retry-the-outstanding-TX-buffer.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-can-5-rockchip_canfd-retry-the-outstanding-TX-buffer.patch
@@ -1,0 +1,41 @@
+From 20fc9c7818d49faa1d6587ac2da6cfdb1f4b94b3 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:16:27 +0800
+Subject: [PATCH 2/3] can: rockchip_canfd: retry the outstanding TX buffer
+
+rkcanfd_xmit_retry() originally operated with a TX FIFO depth of one. At
+that depth, the masked head and tail indices both select buffer 0, so using
+tx_head happened to select the correct buffer.
+
+After the FIFO depth was increased to two, tx_head instead identifies the
+next free buffer when one frame is outstanding. The erratum 6 workaround
+therefore requests transmission from the wrong buffer, leaving the
+outstanding echo entry incomplete and the netdev TX queue stopped.
+
+Use tx_tail to select the outstanding buffer for retransmission.
+
+Fixes: a5605d61c7dd ("can: rockchip_canfd: enable full TX-FIFO depth of 2")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+ drivers/net/can/rockchip/rockchip_canfd-tx.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+index 86fa8f2e1c8b..fc338ea865fe 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+@@ -57,8 +57,8 @@ static void rkcanfd_start_xmit_write_cmd(const struct rkcanfd_priv *priv,
+ 
+ void rkcanfd_xmit_retry(struct rkcanfd_priv *priv)
+ {
+-	const unsigned int tx_head = rkcanfd_get_tx_head(priv);
+-	const u32 reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_head);
++	const unsigned int tx_tail = rkcanfd_get_tx_tail(priv);
++	const u32 reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_tail);
+ 
+ 	rkcanfd_start_xmit_write_cmd(priv, reg_cmd);
+ }
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.1/general-can-6-rockchip_canfd-serialize-TX-state-and-command-wr.patch
+++ b/patch/kernel/archive/rockchip64-7.1/general-can-6-rockchip_canfd-serialize-TX-state-and-command-wr.patch
@@ -1,0 +1,276 @@
+From d88c17cb3aa0b055cf7d652e95f5696864e60e75 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:17:29 +0800
+Subject: [PATCH 3/3] can: rockchip_canfd: serialize TX state and command
+ writes
+
+The TX completion path removes an echo skb before advancing tx_tail. In
+parallel, the transmit path reads tx_head, tx_tail and the tail echo slot
+when applying the erratum 6 queue restriction. There is no synchronization
+between these operations.
+
+On SMP, the transmit path can consequently observe a pending frame with
+an empty echo slot. It can also keep a pointer to an echo skb while the
+completion path removes and queues it for NAPI, where it can be freed on
+another CPU. The inconsistent snapshot can stop the netdev TX queue when
+there is no later completion to wake it.
+
+There is a second race in the command submission sequence.
+rkcanfd_start_xmit() runs in softirq context.
+rkcanfd_xmit_retry() runs from the RX interrupt handler. On controllers
+affected by erratum 12, both execute a MODE/CMD/MODE register sequence. The
+interrupt handler can restore the default MODE between the softirq writes.
+The resumed softirq then issues CMD without SPACE_RX_MODE and bypasses the
+erratum 12 workaround.
+
+Add a TX state lock and use it to protect tx_head, tx_tail and the echo skb
+ring as one state. The same lock serializes the MODE/CMD/MODE sequence
+between the transmit and interrupt paths. Keep completion and wakeup
+outside the lock to avoid nesting the TX state lock with the netdev TX
+queue lock. Install the echo skb before loading the hardware TX buffer so
+an echo setup failure cannot desynchronize the hardware and software TX
+state.
+
+Tested on an RK3588 rev2.2 at 1 Mbit/s with 100,000 extended CAN frames.
+The run triggered 138 erratum 6 retries and completed without drops, queue
+stalls or driver warnings. RK3588 does not enable erratum 12, so this test
+does not exercise that hardware workaround.
+
+Fixes: ae002cc32ec4 ("can: rockchip_canfd: prepare to use full TX-FIFO depth")
+Fixes: 83f9bd6bf39d ("can: rockchip_canfd: implement workaround for erratum 12")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+ .../net/can/rockchip/rockchip_canfd-core.c    |  1 +
+ drivers/net/can/rockchip/rockchip_canfd-rx.c  | 31 ++++++++++++++-----
+ drivers/net/can/rockchip/rockchip_canfd-tx.c  | 26 ++++++++++++++--
+ drivers/net/can/rockchip/rockchip_canfd.h     |  4 ++-
+ 4 files changed, 50 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-core.c b/drivers/net/can/rockchip/rockchip_canfd-core.c
+index 29de0c01e4ed..c8257858b452 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-core.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-core.c
+@@ -904,6 +904,7 @@ static int rkcanfd_probe(struct platform_device *pdev)
+ 	priv->can.do_set_mode = rkcanfd_set_mode;
+ 	priv->can.do_get_berr_counter = rkcanfd_get_berr_counter;
+ 	priv->ndev = ndev;
++	spin_lock_init(&priv->tx_lock);
+ 
+ 	match = device_get_match_data(&pdev->dev);
+ 	if (match) {
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-rx.c b/drivers/net/can/rockchip/rockchip_canfd-rx.c
+index 475c0409e215..02efc8c0cddc 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-rx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-rx.c
+@@ -100,14 +100,25 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 	const struct canfd_frame *cfd_nominal;
+ 	const struct sk_buff *skb;
+ 	unsigned int tx_tail;
++	unsigned long flags;
++
++	spin_lock_irqsave(&priv->tx_lock, flags);
++
++	if (!rkcanfd_get_tx_pending(priv))
++		goto out_unlock;
+ 
+ 	tx_tail = rkcanfd_get_tx_tail(priv);
+ 	skb = priv->can.echo_skb[tx_tail];
+ 	if (!skb) {
++		const unsigned int tx_head_unmasked = priv->tx_head;
++		const unsigned int tx_tail_unmasked = priv->tx_tail;
++
++		spin_unlock_irqrestore(&priv->tx_lock, flags);
++
+ 		netdev_err(priv->ndev,
+ 			   "%s: echo_skb[%u]=NULL tx_head=0x%08x tx_tail=0x%08x\n",
+ 			   __func__, tx_tail,
+-			   priv->tx_head, priv->tx_tail);
++			   tx_head_unmasked, tx_tail_unmasked);
+ 
+ 		return -ENOMSG;
+ 	}
+@@ -123,17 +134,18 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 		rkcanfd_handle_tx_done_one(priv, ts, &frame_len);
+ 
+ 		WRITE_ONCE(priv->tx_tail, priv->tx_tail + 1);
++		*tx_done = true;
++
++		spin_unlock_irqrestore(&priv->tx_lock, flags);
+ 		netif_subqueue_completed_wake(priv->ndev, 0, 1, frame_len,
+ 					      rkcanfd_get_effective_tx_free(priv),
+ 					      RKCANFD_TX_START_THRESHOLD);
+ 
+-		*tx_done = true;
+-
+ 		return 0;
+ 	}
+ 
+ 	if (!(priv->devtype_data.quirks & RKCANFD_QUIRK_RK3568_ERRATUM_6))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Erratum 6: Extended frames may be send as standard frames.
+ 	 *
+@@ -143,7 +155,7 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 	 */
+ 	if (!(cfd_nominal->can_id & CAN_EFF_FLAG) ||
+ 	    (cfd_rx->can_id & CAN_EFF_FLAG))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Not affected if:
+ 	 * - standard part and RTR flag of the TX'ed frame
+@@ -151,20 +163,20 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 	 */
+ 	if ((cfd_nominal->can_id & (CAN_RTR_FLAG | CAN_SFF_MASK)) !=
+ 	    (cfd_rx->can_id & (CAN_RTR_FLAG | CAN_SFF_MASK)))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Not affected if:
+ 	 * - length is not the same
+ 	 */
+ 	if (cfd_nominal->len != cfd_rx->len)
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Not affected if:
+ 	 * - the data of non RTR frames is different
+ 	 */
+ 	if (!(cfd_nominal->can_id & CAN_RTR_FLAG) &&
+ 	    memcmp(cfd_nominal->data, cfd_rx->data, cfd_nominal->len))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Affected by Erratum 6 */
+ 	u64_stats_update_begin(&rkcanfd_stats->syncp);
+@@ -185,6 +197,9 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 
+ 	rkcanfd_xmit_retry(priv);
+ 
++out_unlock:
++	spin_unlock_irqrestore(&priv->tx_lock, flags);
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+index fc338ea865fe..b367341dd0ae 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+@@ -14,6 +14,8 @@ static bool rkcanfd_tx_tail_is_eff(const struct rkcanfd_priv *priv)
+ 	const struct sk_buff *skb;
+ 	unsigned int tx_tail;
+ 
++	lockdep_assert_held(&priv->tx_lock);
++
+ 	if (!rkcanfd_get_tx_pending(priv))
+ 		return false;
+ 
+@@ -33,13 +35,22 @@ static bool rkcanfd_tx_tail_is_eff(const struct rkcanfd_priv *priv)
+ 	return cfd->can_id & CAN_EFF_FLAG;
+ }
+ 
+-unsigned int rkcanfd_get_effective_tx_free(const struct rkcanfd_priv *priv)
++unsigned int rkcanfd_get_effective_tx_free(struct rkcanfd_priv *priv)
+ {
++	unsigned int tx_free;
++	unsigned long flags;
++
++	spin_lock_irqsave(&priv->tx_lock, flags);
++
+ 	if (priv->devtype_data.quirks & RKCANFD_QUIRK_RK3568_ERRATUM_6 &&
+ 	    rkcanfd_tx_tail_is_eff(priv))
+-		return 0;
++		tx_free = 0;
++	else
++		tx_free = rkcanfd_get_tx_free(priv);
++
++	spin_unlock_irqrestore(&priv->tx_lock, flags);
+ 
+-	return rkcanfd_get_tx_free(priv);
++	return tx_free;
+ }
+ 
+ static void rkcanfd_start_xmit_write_cmd(const struct rkcanfd_priv *priv,
+@@ -60,6 +71,8 @@ void rkcanfd_xmit_retry(struct rkcanfd_priv *priv)
+ 	const unsigned int tx_tail = rkcanfd_get_tx_tail(priv);
+ 	const u32 reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_tail);
+ 
++	lockdep_assert_held(&priv->tx_lock);
++
+ 	rkcanfd_start_xmit_write_cmd(priv, reg_cmd);
+ }
+ 
+@@ -69,6 +82,7 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 	u32 reg_frameinfo, reg_id, reg_cmd;
+ 	unsigned int tx_head, frame_len;
+ 	const struct canfd_frame *cfd;
++	unsigned long flags;
+ 	int err;
+ 	u8 i;
+ 
+@@ -88,10 +102,13 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 		return NETDEV_TX_BUSY;
+ 	}
+ 
++	spin_lock_irqsave(&priv->tx_lock, flags);
+ 	tx_head = rkcanfd_get_tx_head(priv);
+ 	frame_len = can_skb_get_frame_len(skb);
+ 	err = can_put_echo_skb(skb, ndev, tx_head, frame_len);
+ 	if (err) {
++		spin_unlock_irqrestore(&priv->tx_lock, flags);
++
+ 		ndev->stats.tx_dropped++;
+ 		return NETDEV_TX_OK;
+ 	}
+@@ -136,6 +153,7 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 	WRITE_ONCE(priv->tx_head, priv->tx_head + 1);
+ 
+ 	rkcanfd_start_xmit_write_cmd(priv, reg_cmd);
++	spin_unlock_irqrestore(&priv->tx_lock, flags);
+ 
+ 	netif_subqueue_maybe_stop(priv->ndev, 0,
+ 				  rkcanfd_get_effective_tx_free(priv),
+@@ -152,6 +170,8 @@ void rkcanfd_handle_tx_done_one(struct rkcanfd_priv *priv, const u32 ts,
+ 	unsigned int tx_tail;
+ 	struct sk_buff *skb;
+ 
++	lockdep_assert_held(&priv->tx_lock);
++
+ 	tx_tail = rkcanfd_get_tx_tail(priv);
+ 	skb = priv->can.echo_skb[tx_tail];
+ 
+diff --git a/drivers/net/can/rockchip/rockchip_canfd.h b/drivers/net/can/rockchip/rockchip_canfd.h
+index 93131c7d7f54..3cf283a7b380 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd.h
++++ b/drivers/net/can/rockchip/rockchip_canfd.h
+@@ -15,6 +15,7 @@
+ #include <linux/netdevice.h>
+ #include <linux/reset.h>
+ #include <linux/skbuff.h>
++#include <linux/spinlock.h>
+ #include <linux/timecounter.h>
+ #include <linux/types.h>
+ #include <linux/u64_stats_sync.h>
+@@ -462,6 +463,7 @@ struct rkcanfd_priv {
+ 	struct can_rx_offload offload;
+ 	struct net_device *ndev;
+ 
++	spinlock_t tx_lock; /* protects tx_head, tx_tail and echo_skb */
+ 	void __iomem *regs;
+ 	unsigned int tx_head;
+ 	unsigned int tx_tail;
+@@ -544,7 +546,7 @@ void rkcanfd_timestamp_start(struct rkcanfd_priv *priv);
+ void rkcanfd_timestamp_stop(struct rkcanfd_priv *priv);
+ void rkcanfd_timestamp_stop_sync(struct rkcanfd_priv *priv);
+ 
+-unsigned int rkcanfd_get_effective_tx_free(const struct rkcanfd_priv *priv);
++unsigned int rkcanfd_get_effective_tx_free(struct rkcanfd_priv *priv);
+ void rkcanfd_xmit_retry(struct rkcanfd_priv *priv);
+ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev);
+ void rkcanfd_handle_tx_done_one(struct rkcanfd_priv *priv, const u32 ts,
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.2/general-can-1-skb-make-echo-skb-freeing-safe-in-any-IRQ-contex.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-1-skb-make-echo-skb-freeing-safe-in-any-IRQ-contex.patch
@@ -1,0 +1,68 @@
+From 22bc38b1ea127f19276e188f6dbcd15ff774b583 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:14:24 +0800
+Subject: [PATCH 1/3] can: skb: make echo skb freeing safe in any IRQ context
+
+can_put_echo_skb() can be called with hardware interrupts disabled. Its
+direct drop paths use kfree_skb(), while can_create_echo_skb() uses
+kfree_skb() when cloning fails and consume_skb() after a successful clone.
+None of these helpers is safe in every IRQ context.
+
+Use dev_kfree_skb_any() for all drop paths and dev_consume_skb_any() when
+consuming a successfully cloned skb. This preserves the respective skb drop
+and consumed semantics regardless of the caller IRQ context.
+
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+Changes in v3:
+- Cover can_create_echo_skb() clone failure and successful-clone consume
+  paths with IRQ-context-independent helpers.
+---
+ drivers/net/can/dev/skb.c | 4 ++--
+ include/linux/can/skb.h   | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
+index 95fcdc1026f8..d7b5a5d17ff2 100644
+--- a/drivers/net/can/dev/skb.c
++++ b/drivers/net/can/dev/skb.c
+@@ -62,7 +62,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+ 	    (skb->protocol != htons(ETH_P_CAN) &&
+ 	     skb->protocol != htons(ETH_P_CANFD) &&
+ 	     skb->protocol != htons(ETH_P_CANXL))) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		return 0;
+ 	}
+ 
+@@ -90,7 +90,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+ 	} else {
+ 		/* locking problem with netif_stop_queue() ?? */
+ 		netdev_err(dev, "%s: BUG! echo_skb %d is occupied!\n", __func__, idx);
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		return -EBUSY;
+ 	}
+ 
+diff --git a/include/linux/can/skb.h b/include/linux/can/skb.h
+index a70a02967071..78c5870e2f9a 100644
+--- a/include/linux/can/skb.h
++++ b/include/linux/can/skb.h
+@@ -76,12 +76,12 @@ static inline struct sk_buff *can_create_echo_skb(struct sk_buff *skb)
+ 
+ 	nskb = skb_clone(skb, GFP_ATOMIC);
+ 	if (unlikely(!nskb)) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		return NULL;
+ 	}
+ 
+ 	can_skb_set_owner(nskb, skb->sk);
+-	consume_skb(skb);
++	dev_consume_skb_any(skb);
+ 	return nskb;
+ }
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.2/general-can-2-skb-make-CAN-skb-allocation-failure-paths-IRQ-sa.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-2-skb-make-CAN-skb-allocation-failure-paths-IRQ-sa.patch
@@ -1,0 +1,53 @@
+From 56aae92b2a29364793e98d06e64b9eda731706b6 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:14:38 +0800
+Subject: [PATCH 2/3] can: skb: make CAN skb allocation failure paths IRQ-safe
+
+The CAN skb allocation helpers are used from hardware interrupt receive
+handlers. If can_skb_ext_add() fails, they release the newly allocated skb
+with kfree_skb(), which is not safe in hardware interrupt context.
+
+Use dev_kfree_skb_any() for the allocation failure paths in
+alloc_can_skb(), alloc_canfd_skb(), and alloc_canxl_skb().
+
+Fixes: 96ea3a1e2d31 ("can: add CAN skb extension infrastructure")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+ drivers/net/can/dev/skb.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
+index d7b5a5d17ff2..d34d3e7d4c9f 100644
+--- a/drivers/net/can/dev/skb.c
++++ b/drivers/net/can/dev/skb.c
+@@ -223,7 +223,7 @@ struct sk_buff *alloc_can_skb(struct net_device *dev, struct can_frame **cf)
+ 
+ 	csx = can_skb_ext_add(skb);
+ 	if (!csx) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		goto out_error_cc;
+ 	}
+ 
+@@ -254,7 +254,7 @@ struct sk_buff *alloc_canfd_skb(struct net_device *dev,
+ 
+ 	csx = can_skb_ext_add(skb);
+ 	if (!csx) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		goto out_error_fd;
+ 	}
+ 
+@@ -292,7 +292,7 @@ struct sk_buff *alloc_canxl_skb(struct net_device *dev,
+ 
+ 	csx = can_skb_ext_add(skb);
+ 	if (!csx) {
+-		kfree_skb(skb);
++		dev_kfree_skb_any(skb);
+ 		goto out_error_xl;
+ 	}
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.2/general-can-3-dev-can_put_echo_skb-free-skb-on-invalid-echo-in.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-3-dev-can_put_echo_skb-free-skb-on-invalid-echo-in.patch
@@ -1,0 +1,40 @@
+From fefeeb8d95a0dedf8050612c04771ee37ea20dc4 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:14:56 +0800
+Subject: [PATCH 3/3] can: dev: can_put_echo_skb(): free skb on invalid echo
+ index
+
+can_put_echo_skb() consumes the skb on all paths except when the echo
+index is out of bounds. This leaves ownership with the caller on -EINVAL,
+unlike the other error paths, and can leak the skb if the caller expects
+consistent semantics.
+
+Free the skb before returning -EINVAL so that all return paths consume it.
+
+Fixes: 6411959c10fe ("can: dev: can_put_echo_skb(): don't crash kernel if can_priv::echo_skb is accessed out of bounds")
+Cc: stable@vger.kernel.org
+Reviewed-by: Vincent Mailhol <mailhol@kernel.org>
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+Changes in v2:
+- Free the skb with dev_kfree_skb_any() on an invalid echo index.
+- Collect Vincent's Reviewed-by tag
+---
+ drivers/net/can/dev/skb.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
+index d34d3e7d4c9f..e985616c062c 100644
+--- a/drivers/net/can/dev/skb.c
++++ b/drivers/net/can/dev/skb.c
+@@ -54,6 +54,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+ 	if (idx >= priv->echo_skb_max) {
+ 		netdev_err(dev, "%s: BUG! Trying to access can_priv::echo_skb out of bounds (%u/max %u)\n",
+ 			   __func__, idx, priv->echo_skb_max);
++		dev_kfree_skb_any(skb);
+ 		return -EINVAL;
+ 	}
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.2/general-can-4-rockchip_canfd-prevent-TX-stall-on-echo-skb-fail.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-4-rockchip_canfd-prevent-TX-stall-on-echo-skb-fail.patch
@@ -1,0 +1,72 @@
+From 08956ae250aabf15d728a7502ff86986f540be55 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Thu, 30 Jul 2026 23:16:17 +0800
+Subject: [PATCH 1/3] can: rockchip_canfd: prevent TX stall on echo skb failure
+
+rkcanfd_start_xmit() advances tx_head and requests transmission even when
+can_put_echo_skb() fails. This creates a pending TX entry without the echo
+skb that the RXSTX completion path needs to match the self-received frame.
+The entry cannot be completed, and the netdev TX queue can remain stopped
+after the two-entry software FIFO fills.
+
+Install the echo skb before loading the hardware TX buffer. If installation
+fails, account the frame as dropped and leave both the hardware FIFO and
+software TX state unchanged. After the echo skb is installed, use the
+stored echo skb as the source for the hardware frame data.
+
+This depends on the standalone can_put_echo_skb() ownership fix. It makes
+the remaining -EINVAL path consume the skb and was posted at:
+
+Link: https://lore.kernel.org/linux-can/tencent_944DADCC4B42C8484EC01DA2B15F42132906@qq.com
+Fixes: b6661d73290c ("can: rockchip_canfd: add TX PATH")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+ drivers/net/can/rockchip/rockchip_canfd-tx.c | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+index 12200dcfd338..86fa8f2e1c8b 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+@@ -88,7 +88,16 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 		return NETDEV_TX_BUSY;
+ 	}
+ 
+-	cfd = (struct canfd_frame *)skb->data;
++	tx_head = rkcanfd_get_tx_head(priv);
++	frame_len = can_skb_get_frame_len(skb);
++	err = can_put_echo_skb(skb, ndev, tx_head, frame_len);
++	if (err) {
++		ndev->stats.tx_dropped++;
++		return NETDEV_TX_OK;
++	}
++
++	skb = priv->can.echo_skb[tx_head];
++	cfd = (const struct canfd_frame *)skb->data;
+ 
+ 	if (cfd->can_id & CAN_EFF_FLAG) {
+ 		reg_frameinfo = RKCANFD_REG_FD_FRAMEINFO_FRAME_FORMAT;
+@@ -114,7 +123,6 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 					    cfd->len);
+ 	}
+ 
+-	tx_head = rkcanfd_get_tx_head(priv);
+ 	reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_head);
+ 
+ 	rkcanfd_write(priv, RKCANFD_REG_FD_TXFRAMEINFO, reg_frameinfo);
+@@ -123,10 +131,7 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 		rkcanfd_write(priv, RKCANFD_REG_FD_TXDATA0 + i,
+ 			      *(u32 *)(cfd->data + i));
+ 
+-	frame_len = can_skb_get_frame_len(skb);
+-	err = can_put_echo_skb(skb, ndev, tx_head, frame_len);
+-	if (!err)
+-		netdev_sent_queue(priv->ndev, frame_len);
++	netdev_sent_queue(priv->ndev, frame_len);
+ 
+ 	WRITE_ONCE(priv->tx_head, priv->tx_head + 1);
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.2/general-can-5-rockchip_canfd-retry-the-outstanding-TX-buffer.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-5-rockchip_canfd-retry-the-outstanding-TX-buffer.patch
@@ -1,0 +1,41 @@
+From 20fc9c7818d49faa1d6587ac2da6cfdb1f4b94b3 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:16:27 +0800
+Subject: [PATCH 2/3] can: rockchip_canfd: retry the outstanding TX buffer
+
+rkcanfd_xmit_retry() originally operated with a TX FIFO depth of one. At
+that depth, the masked head and tail indices both select buffer 0, so using
+tx_head happened to select the correct buffer.
+
+After the FIFO depth was increased to two, tx_head instead identifies the
+next free buffer when one frame is outstanding. The erratum 6 workaround
+therefore requests transmission from the wrong buffer, leaving the
+outstanding echo entry incomplete and the netdev TX queue stopped.
+
+Use tx_tail to select the outstanding buffer for retransmission.
+
+Fixes: a5605d61c7dd ("can: rockchip_canfd: enable full TX-FIFO depth of 2")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+ drivers/net/can/rockchip/rockchip_canfd-tx.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+index 86fa8f2e1c8b..fc338ea865fe 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+@@ -57,8 +57,8 @@ static void rkcanfd_start_xmit_write_cmd(const struct rkcanfd_priv *priv,
+ 
+ void rkcanfd_xmit_retry(struct rkcanfd_priv *priv)
+ {
+-	const unsigned int tx_head = rkcanfd_get_tx_head(priv);
+-	const u32 reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_head);
++	const unsigned int tx_tail = rkcanfd_get_tx_tail(priv);
++	const u32 reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_tail);
+ 
+ 	rkcanfd_start_xmit_write_cmd(priv, reg_cmd);
+ }
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-7.2/general-can-6-rockchip_canfd-serialize-TX-state-and-command-wr.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-6-rockchip_canfd-serialize-TX-state-and-command-wr.patch
@@ -1,0 +1,276 @@
+From d88c17cb3aa0b055cf7d652e95f5696864e60e75 Mon Sep 17 00:00:00 2001
+From: Cunhao Lu <1579567540@qq.com>
+Date: Fri, 31 Jul 2026 17:17:29 +0800
+Subject: [PATCH 3/3] can: rockchip_canfd: serialize TX state and command
+ writes
+
+The TX completion path removes an echo skb before advancing tx_tail. In
+parallel, the transmit path reads tx_head, tx_tail and the tail echo slot
+when applying the erratum 6 queue restriction. There is no synchronization
+between these operations.
+
+On SMP, the transmit path can consequently observe a pending frame with
+an empty echo slot. It can also keep a pointer to an echo skb while the
+completion path removes and queues it for NAPI, where it can be freed on
+another CPU. The inconsistent snapshot can stop the netdev TX queue when
+there is no later completion to wake it.
+
+There is a second race in the command submission sequence.
+rkcanfd_start_xmit() runs in softirq context.
+rkcanfd_xmit_retry() runs from the RX interrupt handler. On controllers
+affected by erratum 12, both execute a MODE/CMD/MODE register sequence. The
+interrupt handler can restore the default MODE between the softirq writes.
+The resumed softirq then issues CMD without SPACE_RX_MODE and bypasses the
+erratum 12 workaround.
+
+Add a TX state lock and use it to protect tx_head, tx_tail and the echo skb
+ring as one state. The same lock serializes the MODE/CMD/MODE sequence
+between the transmit and interrupt paths. Keep completion and wakeup
+outside the lock to avoid nesting the TX state lock with the netdev TX
+queue lock. Install the echo skb before loading the hardware TX buffer so
+an echo setup failure cannot desynchronize the hardware and software TX
+state.
+
+Tested on an RK3588 rev2.2 at 1 Mbit/s with 100,000 extended CAN frames.
+The run triggered 138 erratum 6 retries and completed without drops, queue
+stalls or driver warnings. RK3588 does not enable erratum 12, so this test
+does not exercise that hardware workaround.
+
+Fixes: ae002cc32ec4 ("can: rockchip_canfd: prepare to use full TX-FIFO depth")
+Fixes: 83f9bd6bf39d ("can: rockchip_canfd: implement workaround for erratum 12")
+Cc: stable@vger.kernel.org
+Signed-off-by: Cunhao Lu <1579567540@qq.com>
+---
+ .../net/can/rockchip/rockchip_canfd-core.c    |  1 +
+ drivers/net/can/rockchip/rockchip_canfd-rx.c  | 31 ++++++++++++++-----
+ drivers/net/can/rockchip/rockchip_canfd-tx.c  | 26 ++++++++++++++--
+ drivers/net/can/rockchip/rockchip_canfd.h     |  4 ++-
+ 4 files changed, 50 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-core.c b/drivers/net/can/rockchip/rockchip_canfd-core.c
+index 29de0c01e4ed..c8257858b452 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-core.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-core.c
+@@ -904,6 +904,7 @@ static int rkcanfd_probe(struct platform_device *pdev)
+ 	priv->can.do_set_mode = rkcanfd_set_mode;
+ 	priv->can.do_get_berr_counter = rkcanfd_get_berr_counter;
+ 	priv->ndev = ndev;
++	spin_lock_init(&priv->tx_lock);
+ 
+ 	match = device_get_match_data(&pdev->dev);
+ 	if (match) {
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-rx.c b/drivers/net/can/rockchip/rockchip_canfd-rx.c
+index 475c0409e215..02efc8c0cddc 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-rx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-rx.c
+@@ -100,14 +100,25 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 	const struct canfd_frame *cfd_nominal;
+ 	const struct sk_buff *skb;
+ 	unsigned int tx_tail;
++	unsigned long flags;
++
++	spin_lock_irqsave(&priv->tx_lock, flags);
++
++	if (!rkcanfd_get_tx_pending(priv))
++		goto out_unlock;
+ 
+ 	tx_tail = rkcanfd_get_tx_tail(priv);
+ 	skb = priv->can.echo_skb[tx_tail];
+ 	if (!skb) {
++		const unsigned int tx_head_unmasked = priv->tx_head;
++		const unsigned int tx_tail_unmasked = priv->tx_tail;
++
++		spin_unlock_irqrestore(&priv->tx_lock, flags);
++
+ 		netdev_err(priv->ndev,
+ 			   "%s: echo_skb[%u]=NULL tx_head=0x%08x tx_tail=0x%08x\n",
+ 			   __func__, tx_tail,
+-			   priv->tx_head, priv->tx_tail);
++			   tx_head_unmasked, tx_tail_unmasked);
+ 
+ 		return -ENOMSG;
+ 	}
+@@ -123,17 +134,18 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 		rkcanfd_handle_tx_done_one(priv, ts, &frame_len);
+ 
+ 		WRITE_ONCE(priv->tx_tail, priv->tx_tail + 1);
++		*tx_done = true;
++
++		spin_unlock_irqrestore(&priv->tx_lock, flags);
+ 		netif_subqueue_completed_wake(priv->ndev, 0, 1, frame_len,
+ 					      rkcanfd_get_effective_tx_free(priv),
+ 					      RKCANFD_TX_START_THRESHOLD);
+ 
+-		*tx_done = true;
+-
+ 		return 0;
+ 	}
+ 
+ 	if (!(priv->devtype_data.quirks & RKCANFD_QUIRK_RK3568_ERRATUM_6))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Erratum 6: Extended frames may be send as standard frames.
+ 	 *
+@@ -143,7 +155,7 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 	 */
+ 	if (!(cfd_nominal->can_id & CAN_EFF_FLAG) ||
+ 	    (cfd_rx->can_id & CAN_EFF_FLAG))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Not affected if:
+ 	 * - standard part and RTR flag of the TX'ed frame
+@@ -151,20 +163,20 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 	 */
+ 	if ((cfd_nominal->can_id & (CAN_RTR_FLAG | CAN_SFF_MASK)) !=
+ 	    (cfd_rx->can_id & (CAN_RTR_FLAG | CAN_SFF_MASK)))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Not affected if:
+ 	 * - length is not the same
+ 	 */
+ 	if (cfd_nominal->len != cfd_rx->len)
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Not affected if:
+ 	 * - the data of non RTR frames is different
+ 	 */
+ 	if (!(cfd_nominal->can_id & CAN_RTR_FLAG) &&
+ 	    memcmp(cfd_nominal->data, cfd_rx->data, cfd_nominal->len))
+-		return 0;
++		goto out_unlock;
+ 
+ 	/* Affected by Erratum 6 */
+ 	u64_stats_update_begin(&rkcanfd_stats->syncp);
+@@ -185,6 +197,9 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
+ 
+ 	rkcanfd_xmit_retry(priv);
+ 
++out_unlock:
++	spin_unlock_irqrestore(&priv->tx_lock, flags);
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+index fc338ea865fe..b367341dd0ae 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
++++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
+@@ -14,6 +14,8 @@ static bool rkcanfd_tx_tail_is_eff(const struct rkcanfd_priv *priv)
+ 	const struct sk_buff *skb;
+ 	unsigned int tx_tail;
+ 
++	lockdep_assert_held(&priv->tx_lock);
++
+ 	if (!rkcanfd_get_tx_pending(priv))
+ 		return false;
+ 
+@@ -33,13 +35,22 @@ static bool rkcanfd_tx_tail_is_eff(const struct rkcanfd_priv *priv)
+ 	return cfd->can_id & CAN_EFF_FLAG;
+ }
+ 
+-unsigned int rkcanfd_get_effective_tx_free(const struct rkcanfd_priv *priv)
++unsigned int rkcanfd_get_effective_tx_free(struct rkcanfd_priv *priv)
+ {
++	unsigned int tx_free;
++	unsigned long flags;
++
++	spin_lock_irqsave(&priv->tx_lock, flags);
++
+ 	if (priv->devtype_data.quirks & RKCANFD_QUIRK_RK3568_ERRATUM_6 &&
+ 	    rkcanfd_tx_tail_is_eff(priv))
+-		return 0;
++		tx_free = 0;
++	else
++		tx_free = rkcanfd_get_tx_free(priv);
++
++	spin_unlock_irqrestore(&priv->tx_lock, flags);
+ 
+-	return rkcanfd_get_tx_free(priv);
++	return tx_free;
+ }
+ 
+ static void rkcanfd_start_xmit_write_cmd(const struct rkcanfd_priv *priv,
+@@ -60,6 +71,8 @@ void rkcanfd_xmit_retry(struct rkcanfd_priv *priv)
+ 	const unsigned int tx_tail = rkcanfd_get_tx_tail(priv);
+ 	const u32 reg_cmd = RKCANFD_REG_CMD_TX_REQ(tx_tail);
+ 
++	lockdep_assert_held(&priv->tx_lock);
++
+ 	rkcanfd_start_xmit_write_cmd(priv, reg_cmd);
+ }
+ 
+@@ -69,6 +82,7 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 	u32 reg_frameinfo, reg_id, reg_cmd;
+ 	unsigned int tx_head, frame_len;
+ 	const struct canfd_frame *cfd;
++	unsigned long flags;
+ 	int err;
+ 	u8 i;
+ 
+@@ -88,10 +102,13 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 		return NETDEV_TX_BUSY;
+ 	}
+ 
++	spin_lock_irqsave(&priv->tx_lock, flags);
+ 	tx_head = rkcanfd_get_tx_head(priv);
+ 	frame_len = can_skb_get_frame_len(skb);
+ 	err = can_put_echo_skb(skb, ndev, tx_head, frame_len);
+ 	if (err) {
++		spin_unlock_irqrestore(&priv->tx_lock, flags);
++
+ 		ndev->stats.tx_dropped++;
+ 		return NETDEV_TX_OK;
+ 	}
+@@ -136,6 +153,7 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+ 	WRITE_ONCE(priv->tx_head, priv->tx_head + 1);
+ 
+ 	rkcanfd_start_xmit_write_cmd(priv, reg_cmd);
++	spin_unlock_irqrestore(&priv->tx_lock, flags);
+ 
+ 	netif_subqueue_maybe_stop(priv->ndev, 0,
+ 				  rkcanfd_get_effective_tx_free(priv),
+@@ -152,6 +170,8 @@ void rkcanfd_handle_tx_done_one(struct rkcanfd_priv *priv, const u32 ts,
+ 	unsigned int tx_tail;
+ 	struct sk_buff *skb;
+ 
++	lockdep_assert_held(&priv->tx_lock);
++
+ 	tx_tail = rkcanfd_get_tx_tail(priv);
+ 	skb = priv->can.echo_skb[tx_tail];
+ 
+diff --git a/drivers/net/can/rockchip/rockchip_canfd.h b/drivers/net/can/rockchip/rockchip_canfd.h
+index 93131c7d7f54..3cf283a7b380 100644
+--- a/drivers/net/can/rockchip/rockchip_canfd.h
++++ b/drivers/net/can/rockchip/rockchip_canfd.h
+@@ -15,6 +15,7 @@
+ #include <linux/netdevice.h>
+ #include <linux/reset.h>
+ #include <linux/skbuff.h>
++#include <linux/spinlock.h>
+ #include <linux/timecounter.h>
+ #include <linux/types.h>
+ #include <linux/u64_stats_sync.h>
+@@ -462,6 +463,7 @@ struct rkcanfd_priv {
+ 	struct can_rx_offload offload;
+ 	struct net_device *ndev;
+ 
++	spinlock_t tx_lock; /* protects tx_head, tx_tail and echo_skb */
+ 	void __iomem *regs;
+ 	unsigned int tx_head;
+ 	unsigned int tx_tail;
+@@ -544,7 +546,7 @@ void rkcanfd_timestamp_start(struct rkcanfd_priv *priv);
+ void rkcanfd_timestamp_stop(struct rkcanfd_priv *priv);
+ void rkcanfd_timestamp_stop_sync(struct rkcanfd_priv *priv);
+ 
+-unsigned int rkcanfd_get_effective_tx_free(const struct rkcanfd_priv *priv);
++unsigned int rkcanfd_get_effective_tx_free(struct rkcanfd_priv *priv);
+ void rkcanfd_xmit_retry(struct rkcanfd_priv *priv);
+ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev);
+ void rkcanfd_handle_tx_done_one(struct rkcanfd_priv *priv, const u32 ts,
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

Fix CAN bus failures observed on LubanCat 5IO by backporting two related
upstream patch series to the Rockchip64 kernel patch sets for Linux 6.18,
7.1, and 7.2.

These fixes apply to all CAN-capable Rockchip SoCs using the
`rockchip_canfd` driver with mainline kernels, including RK3568 and RK3588.

The changes make CAN skb cleanup safe from any IRQ context and fix several
`rockchip_canfd` transmit-path problems:

- Do not submit a hardware transmission when echo skb setup fails.
- Retry an outstanding TX buffer instead of allowing the queue to stall.
- Serialize TX state updates and command register writes to eliminate races.
- Free CAN skbs safely on error paths, including invalid echo indexes.

The CAN skb extension allocation fix is included for Linux 7.1 and 7.2.
Linux 6.18 does not have the affected allocation paths, so that patch is not
applicable there.

The corresponding changes have been submitted to the Linux CAN community:

- [[PATCH v5 0/3] can: rockchip_canfd: fix TX stalls and races](https://lore.kernel.org/linux-can/tencent_E25C9BE6689264E4138A464803B810FDFD09@qq.com)
- [[PATCH v3 0/3] can: skb: make CAN skb freeing safe in any IRQ context](https://lore.kernel.org/linux-can/tencent_CD05F020BAFB2537F5D1F4CBB425588EA80A@qq.com)

# How Has This Been Tested?

- [x] Reproduced the CAN bus failure on LubanCat 5IO.
- [x] Verified CAN bus operation on LubanCat 5IO with the fixes applied.
- [x] Verified the patch sets for the Rockchip64 Linux 6.18, 7.1, and 7.2 kernels.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CAN buffer cleanup across interrupt contexts, including allocation, cloning, and invalid-index error paths.
  * Prevented Rockchip CAN-FD transmission stalls when echo-buffer setup fails.
  * Corrected retransmission buffer selection.
  * Serialized transmit operations to improve reliability during concurrent hardware and interrupt activity.
  * Improved TX queue accounting and recovery during completion and error-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->