### PR TITLE
targets-compositor: add include-eos for userspace inventory

### DIFF
--- a/lib/tools/info/targets-compositor.py
+++ b/lib/tools/info/targets-compositor.py
@@ -95,10 +95,14 @@ def get_userspace_inventory(opts: dict):
 	# explicitly in their items-from-inventory.userspace block.
 	if "tiers" not in opts:
 		opts["tiers"] = ["mid"]
+	# EOS userspace releases are skipped by default. Set include-eos: yes to
+	# also emit them (e.g. base-files, which every release still needs).
+	if "include-eos" not in opts:
+		opts["include-eos"] = False
 
 	# loop over the userspace inventory
 	for userspace in userspace_inventory:
-		if userspace["support"] == "eos":
+		if userspace["support"] == "eos" and not opts["include-eos"]:
 			log.debug(f"Skipping userspace inventory entry: '{userspace['id']}' has support '{userspace['support']}'")
 			continue
 


### PR DESCRIPTION
`items-from-inventory.userspace` always skips EOS releases. That's correct for images/rootfs, but **base-files is needed on every release, EOS included** (armbian/build#9476 — a dedicated base-files build should cover all userspace releases).

Add an opt-in **`include-eos`** flag (default `false`, so existing targets are unchanged):

```yaml
items-from-inventory:
  userspace:
    include-eos: yes   # also emit EOS releases
```

Implementation: the hard `support == "eos"` skip becomes `support == "eos" and not opts["include-eos"]`. Used by the new base-files-only workflow (armbian/ci) so base-files publish for all releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to include EOS userspace releases in inventory results.

* **Bug Fixes**
  * Inventory collection now includes EOS releases when explicitly enabled, while preserving the existing default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->