### PR TITLE
board: promote Anbernic RG Vita Pro to supported

### DIFF
--- a/config/boards/anbernic-rg-vita-pro.conf
+++ b/config/boards/anbernic-rg-vita-pro.conf
@@ -1,6 +1,6 @@
 # Rockchip RK3576 SoC octa core handheld 5.5" 1080x1920 touch LCD eMMC MicroSD USB3 WiFi/BT HDMI
 BOARD_NAME="RG Vita Pro"
-BOARD_VENDOR="Anbernic"
+BOARD_VENDOR="anbernic"
 BOARDFAMILY="rk35xx"
 BOOTCONFIG="generic-rk3576_defconfig"
 BOARD_MAINTAINER="crackerjacques"


### PR DESCRIPTION
Following the 26.08 release announcement (#10336) inviting maintainers to
promote well-working CSC boards to Supported.

The **Anbernic RG Vita Pro** (RK3576) has been in the tree since #10128. It boots
and all the hardware I care about is solid on its `edge` target — display/touch,
audio, gamepad, battery/charging, USB3 host + DP alt-mode, HDMI, off-charge.
Renamed `config/boards/anbernic-rg-vita-pro.csc` → `.conf`; `BOARD_MAINTAINER` is
already set to my handle.

`current` (6.18) support is planned as a follow-up for 26.11.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the board vendor identifier for the Anbernic RG Vita Pro configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->