### PR TITLE
rtl8852bs: drop RTW_WARN_LMT sed workaround

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -438,11 +438,6 @@ driver_rtl8852bs() {
 		sed -i "s/^CONFIG_RTW_DEBUG.*/CONFIG_RTW_DEBUG = n/" \
 			"$kerneldir/drivers/net/wireless/realtek/rtl8852bs/Makefile"
 
-		# Bugfix/workaround: Comment undefined RTW_WARN_LMT
-		# @TODO Check on update if this fix is still needed (added 2024-July-10)
-		sed -i "s/RTW_WARN_LMT(/\/\/RTW_WARN_LMT(/g" \
-			"$kerneldir/drivers/net/wireless/realtek/rtl8852bs/core/rtw_xmit.c"
-
 		# Add to section Makefile
 		echo "obj-\$(CONFIG_RTL8852BS) += rtl8852bs/" >> "$kerneldir/drivers/net/wireless/realtek/Makefile"
 		sed -i '/source "drivers\/net\/wireless\/realtek\/rtw89\/Kconfig"/a source "drivers\/net\/wireless\/realtek\/rtl8852bs\/Kconfig"' \


### PR DESCRIPTION
Since pin 3e7d964 the driver defines RTW_WARN_LMT for both CONFIG_RTW_DEBUG settings (stubs added in armbian/wifi-rtl8852bs#11), so the 2024 sed workaround is no longer needed. The spacemit patches touching the same line are unaffected — they comment the call in their own hunk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a workaround that suppressed wireless driver warning messages, allowing relevant network diagnostics to appear normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->