### PR TITLE
nanopi-r4s: add missing #cooling-cells to pwm-fan node

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/board-nanopi-r4s-pwmfan.patch
+++ b/patch/kernel/archive/rockchip64-6.12/board-nanopi-r4s-pwmfan.patch
@@ -4,14 +4,14 @@ Date: Sun, 18 Jun 2023 11:56:34 +0200
 Subject: Add pwm-fan support to nanopi r4s
 
 ---
- arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts | 35 ++++++++++
- 1 file changed, 35 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts | 36 ++++++++++
+ 1 file changed, 36 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
-@@ -62,6 +62,41 @@ vdd_5v: vdd-5v {
+@@ -62,6 +62,42 @@ vdd_5v: vdd-5v {
  		regulator-always-on;
  		regulator-boot-on;
  	};
@@ -21,6 +21,7 @@ index 111111111111..222222222222 100644
 +		cooling-levels = <0 18 102 170 255>;
 +		fan-supply = <&vdd_5v>;
 +		pwms = <&pwm1 0 50000 0>;
++		#cooling-cells = <2>;
 +	};
 +};
 +

--- a/patch/kernel/archive/rockchip64-6.18/board-nanopi-r4s-pwmfan.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-nanopi-r4s-pwmfan.patch
@@ -4,14 +4,14 @@ Date: Sun, 18 Jun 2023 11:56:34 +0200
 Subject: Add pwm-fan support to nanopi r4s
 
 ---
- arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi | 35 ++++++++++
- 1 file changed, 35 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi | 36 ++++++++++
+ 1 file changed, 36 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi
-@@ -60,6 +60,41 @@ vdd_5v: regulator-vdd-5v {
+@@ -60,6 +60,42 @@ vdd_5v: regulator-vdd-5v {
  		regulator-always-on;
  		regulator-boot-on;
  	};
@@ -21,6 +21,7 @@ index 111111111111..222222222222 100644
 +		cooling-levels = <0 18 102 170 255>;
 +		fan-supply = <&vdd_5v>;
 +		pwms = <&pwm1 0 50000 0>;
++		#cooling-cells = <2>;
 +	};
 +};
 +

--- a/patch/kernel/archive/rockchip64-7.1/board-nanopi-r4s-pwmfan.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-nanopi-r4s-pwmfan.patch
@@ -4,14 +4,14 @@ Date: Sun, 18 Jun 2023 11:56:34 +0200
 Subject: Add pwm-fan support to nanopi r4s
 
 ---
- arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi | 35 ++++++++++
- 1 file changed, 35 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi | 36 ++++++++++
+ 1 file changed, 36 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi
-@@ -60,6 +60,41 @@ vdd_5v: regulator-vdd-5v {
+@@ -60,6 +60,42 @@ vdd_5v: regulator-vdd-5v {
  		regulator-always-on;
  		regulator-boot-on;
  	};
@@ -21,6 +21,7 @@ index 111111111111..222222222222 100644
 +		cooling-levels = <0 18 102 170 255>;
 +		fan-supply = <&vdd_5v>;
 +		pwms = <&pwm1 0 50000 0>;
++		#cooling-cells = <2>;
 +	};
 +};
 +

--- a/patch/kernel/archive/rockchip64-7.2/board-nanopi-r4s-pwmfan.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-nanopi-r4s-pwmfan.patch
@@ -4,14 +4,14 @@ Date: Sun, 18 Jun 2023 11:56:34 +0200
 Subject: Add pwm-fan support to nanopi r4s
 
 ---
- arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi | 35 ++++++++++
- 1 file changed, 35 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi | 36 ++++++++++
+ 1 file changed, 36 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi
-@@ -60,6 +60,41 @@ vdd_5v: regulator-vdd-5v {
+@@ -60,6 +60,42 @@ vdd_5v: regulator-vdd-5v {
  		regulator-always-on;
  		regulator-boot-on;
  	};
@@ -21,6 +21,7 @@ index 111111111111..222222222222 100644
 +		cooling-levels = <0 18 102 170 255>;
 +		fan-supply = <&vdd_5v>;
 +		pwms = <&pwm1 0 50000 0>;
++		#cooling-cells = <2>;
 +	};
 +};
 +


### PR DESCRIPTION
The pwm-fan patch wires the fan into the CPU thermal zone cooling-maps (map2/map3, two-cell references) but never declares `#cooling-cells` on the fan node. The thermal core cannot parse such a cooling-device phandle, so both maps are dropped at thermal zone registration and the fan is never driven by the cpu_warm (55°C) / cpu_hot (65°C) trips. DTC reports exactly this during kernel builds (two cooling_device_property warnings). One-line fix in all four patch copies (6.12/6.18/7.1/7.2).

Build-verified on rockchip64 7.1: rk3399-nanopi-r4s.dtb compiles without the two warnings and the resulting dtb carries `#cooling-cells` with map2/map3 intact.

**Runtime not tested — I have no R4S. If you own a NanoPi R4S with the fan connected, please test:**
1. On your current kernel, note the baseline: `grep . /sys/class/thermal/thermal_zone0/cdev*/type` — `pwm-fan` should NOT be listed (that is the bug).
2. Build and install a kernel from this branch, reboot.
3. `grep . /sys/class/thermal/thermal_zone0/cdev*/type` — `pwm-fan` should now appear among the bound cooling devices.
4. Load the CPU (`stress-ng --cpu 6 --timeout 180`) and watch `watch -n2 'cat /sys/class/thermal/thermal_zone0/temp /sys/class/hwmon/hwmon*/pwm1 2>/dev/null'`: above ~55°C pwm1 should rise from 0 and the fan should spin up, above ~65°C speed up further, and stop again after cooldown.
5. Please paste the before/after output of steps 3-4 in a comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PWM-controlled fan support for the NanoPi R4S.
  * Fan speed now increases progressively as CPU temperature reaches 55°C and 65°C.
  * Supports five cooling levels for improved thermal management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->