### PR TITLE
SpacemiT K1: Exclude Musebook from USB boot

### DIFF
--- a/patch/u-boot/legacy/u-boot-spacemit-k1/010-SpacemiT-K1-Exclude-Musebook-from-USB-boot.patch
+++ b/patch/u-boot/legacy/u-boot-spacemit-k1/010-SpacemiT-K1-Exclude-Musebook-from-USB-boot.patch
@@ -1,0 +1,39 @@
+From ca0adf6a3998254a4e2f528b155488fc0300cae7 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@gmail.com>
+Date: Sat, 15 Aug 2026 07:25:40 -0400
+Subject: [PATCH] SpacemiT K1: Exclude Musebook from USB boot
+
+Signed-off-by: Patrick Yavitz <pyavitz@gmail.com>
+---
+ board/spacemit/k1-x/k1-x.env | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/board/spacemit/k1-x/k1-x.env b/board/spacemit/k1-x/k1-x.env
+index d2f59a92..03dad8e7 100644
+--- a/board/spacemit/k1-x/k1-x.env
++++ b/board/spacemit/k1-x/k1-x.env
+@@ -14,14 +14,16 @@ bootfunc=if test -e ${devtype} ${devnum}:${distro_bootpart} /extlinux/extlinux.c
+ 		load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} EFI/BOOT/BOOTRISCV64.EFI; bootefi ${kernel_addr_r}; \
+ 	fi;
+ 
+-autoboot=echo "Loading K1 environment"; \
+-	echo ""; \
++autoboot=echo ""; \
++	echo "Loading K1 environment"; \
+ 	setenv devnum 0; \
+ 	setenv distro_bootpart 1; \
+ 	// usb boot
+-	setenv devtype usb; \
+-	usb start; \
+-	run bootfunc; \
++	if test "${product_name}" != "k1-x_MUSE-Book"; then \
++		setenv devtype usb; \
++		usb start; \
++		run bootfunc; \
++	fi; \
+ 	// sd card boot
+ 	setenv devtype mmc; \
+ 	run bootfunc; \
+-- 
+2.53.0
+


### PR DESCRIPTION
For reasons currrently unknown it puts the unit into a boot loop.

```
U-Boot SPL 2022.10_armbian-2022.10-Sd61c-P02cb-H770d-Vbe78-B5da4-R448a (Aug 15 2026 - 07:31:29 -0400)
[   0.361] DDR type LPDDR4X
[   0.362] set ddr tx odt to 80ohm!
[   0.382] lpddr silicon init consume 20ms
[   0.383] Change DDR data rate to 2400MT/s
[   0.628] Boot from fit configuration k1-x_MUSE-Book
[   0.630] ## Checking hash(es) for config conf_6 ... OK
[   0.635] ## Checking hash(es) for Image uboot ... crc32+ OK
[   0.647] ## Checking hash(es) for Image fdt_6 ... crc32+ OK
[   0.669] ## Checking hash(es) for config config_1 ... OK
[   0.672] ## Checking hash(es) for Image opensbi ... crc32+ OK
[   0.716] 

U-Boot 2022.10_armbian-2022.10-Sd61c-P02cb-H770d-Vbe78-B5da4-R448a (Aug 15 2026 - 07:31:29 -0400)

[   0.723] CPU:   rv64imafdcv
[   0.726] Model: M1-MUSE-BOOK
[   0.728] DRAM:  DDR size = 8192 MB
[   0.732] 8 GiB
[   0.770] reset driver probe start 
[   0.772] reset driver probe finish 
[   0.797] Core:  413 devices, 31 uclasses, devicetree: board
[   0.810] WDT:   Started PMIC_WDT with servicing (60s timeout)
[   0.814] WDT:   Started watchdog@D4080000 with servicing (60s timeout)
[   0.823] MMC:   sdh@d4280000: probe done.
[   0.828] sdh@d4281000: probe done.
[   0.828] sdh@d4280000: 0, sdh@d4281000: 2
[   0.833] Loading Environment from MMC... sdh@d4280000: set tx_delaycode: 127
[   0.989] sdh@d4280000: pass window [0 12) 
[   0.992] sdh@d4280000: pass window [13 14) 
[   0.996] sdh@d4280000: pass window [15 16) 
[   1.057] sdh@d4280000: pass window [43 74) 
[   1.223] sdh@d4280000: pass window [78 235) 
[   1.226] sdh@d4280000: pass window [236 237) 
[   1.230] sdh@d4280000: pass window [238 239) 
[   1.248] sdh@d4280000: pass window [255 256) 
[   1.249] sdh@d4280000: tuning done, use the firstly delay_code:156
[   1.273] *** Warning - bad CRC, using default environment

[   1.278] initialize_console_log_buffer
[   1.279] Have allocated memory for console log buffer
[   1.284] In:    serial
[   1.287] Out:   serial
[   1.289] Err:   serial
[   1.292] Default to 100kHz
[   1.410] Found 2 valid MAC addresses.
[   1.410] Serial number is valid.
[   1.414] TLV item: product_name = k1-x_MUSE-Book
[   1.418] TLV item: part# = MSQ82408005900075
[   1.422] TLV item: serial# = YLMBM1008U49B0074
[   1.433] Found device 'mipi@d421a800', disp_uc_priv=000000007dea2b40
[   1.437] spacemit_panel_of_to_plat panel lcd_lt8911_edp_1920x1080 
[   1.451] Panel is lcd_lt8911_edp_1920x1080
[   1.453] spacemit_display_init: lcd name lcd_lt8911_edp_1920x1080
[   1.458] fb=7f700000, size=1920x1080
[   2.228] All buttons probed successfully
[   2.232] k1x_qspi spi@d420c000: qspi iobase:0x0x00000000d420c000, ahb_addr:0x0x00000000b8000000, max_hz:26500000Hz
[   2.239] k1x_qspi spi@d420c000: rx buf size:128, tx buf size:256, ahb buf size=512
[   2.247] k1x_qspi spi@d420c000: AHB read enabled
[   2.251] k1x_qspi spi@d420c000: bus clock: 26500000Hz, PMUap reg[0xd4282860]:0x0000075b
[   2.259] k1x_qspi spi@d420c000: AHB buf size: 512
[   2.264] SF: Detected FM25Q64AI3 with page size 256 Bytes, erase size 4 KiB, total 8 MiB
List of MTD devices:
[   2.274] * nor0
[   2.275]   - device: flash@0
[   2.278]   - parent: spi@d420c000
[   2.281]   - driver: jedec_spi_nor
[   2.285]   - path: /soc/spi@d420c000/flash@0
[   2.289]   - type: NOR flash
[   2.291]   - block size: 0x1000 bytes
[   2.295]   - min I/O: 0x1 bytes
[   2.298]   - 0x000000000000-0x000000800000 : "nor0"
[   2.303] 	  - 0x000000000000-0x000000010000 : "bootinfo"
[   2.308] 	  - 0x000000010000-0x000000020000 : "private"
[   2.313] 	  - 0x000000020000-0x000000060000 : "fsbl"
[   2.318] 	  - 0x000000060000-0x000000070000 : "env"
[   2.323] 	  - 0x000000070000-0x0000000a0000 : "opensbi"
[   2.328] 	  - 0x0000000a0000-0x000000800000 : "uboot"
[   2.334] Read PMIC reg ab value f0
[   2.336] Failed to get fastboot key config: -19
[   2.341] Net flash mode not enabled
[   2.344] Failed to probe HUSB239: -19
[   2.348] Continue to boot
[   2.350] No ethernet found.
[   2.353] MAC mapping file path not set in environment
[   2.358] K1X: :_load_env_from_blk
[   2.379] Failed to load 'env_k1-x.txt'
[   2.380] Net:   No ethernet found.
[   2.385] Hit any key to stop autoboot:  0 

[   3.391] Loading K1 environment
[   3.439] Booting from mmc 0:1 ...
[   3.439] Retrieving file: /boot/extlinux/extlinux.conf
[   3.477] 1:	Armbian
[   3.477] Retrieving file: /boot/uInitrd
[   3.709] Retrieving file: /boot/Image
[   4.203] append: root=UUID=1407000d-eb0b-403c-85a2-f0e7f8675960 console=ttyS0,115200 console=tty1 loglevel=1 plymouth.prefer-fbcon clk_ignore_unused rw no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0 splash plymouth.ignore-serial-consoles
[   4.224] Retrieving file: /boot/dtb/spacemit/k1-musebook.dtb
[   4.273] Moving Image from 0x10000000 to 0x200000, end=2d55000
[   4.296] ## Loading init Ramdisk from Legacy Image at 21000000 ...
[   4.299]    Image Name:   uInitrd
[   4.302]    Image Type:   RISC-V Linux RAMDisk Image (gzip compressed)
[   4.309]    Data Size:    19294028 Bytes = 18.4 MiB
[   4.314]    Load Address: 00000000
[   4.317]    Entry Point:  00000000
   Verifying Checksum ... OK
[   4.406] ## Flattened Device Tree blob at 31000000
[   4.408]    Booting using the fdt blob at 0x31000000
[   4.413]    Loading Ramdisk to 7cb1b000, end 7dd8174c ... OK
[   4.431]    Loading Device Tree to 000000007cafe000, end 000000007cb1ade0 ... OK

Starting kernel ...

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SpacemiT K1 boot behavior so MUSE-Book devices skip USB boot attempts.
  * Preserved USB boot support for other compatible products.
  * Maintained the existing SD-card boot fallback flow.
  * Adjusted the autoboot message order for clearer boot status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->