### PR TITLE
Fix build with podman - no .Server.Arch

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -359,6 +359,9 @@ function docker_cli_prepare_dockerfile() {
 	declare host_arch
 	if [[ -n "${DOCKER_ARMBIAN_HOST_ARCH:-}" ]]; then
 		host_arch="${DOCKER_ARMBIAN_HOST_ARCH}"
+	elif [[ "${DOCKER_IS_PODMAN}" == "yes" ]]; then
+		host_arch="$(docker version --format '{{.OsArch}}')"
+		host_arch="${host_arch##*/}"
 	else
 		# Resolve the architecture where the Dockerfile will actually build.
 		# This also avoids relying on host tools such as dpkg, which may not


### PR DESCRIPTION
`docker version --format '{{.Server.Arch}}'` doesn't work in podman - there's no .Server. 

Changed to instead use `.OsArch` when `DOCKER_IS_PODMAN`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved architecture detection when using Docker-compatible Podman environments.
  * Dependency preparation now correctly handles architecture values reported with an operating-system prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->