### PR TITLE
drivers: bump uwe5622 to d6bec75 (Aug 15, 2026)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -511,7 +511,7 @@ driver_uwe5622() {
 	if linux-version compare "${version}" ge 5.15 && [[ "$LINUXFAMILY" == sun* || "$LINUXFAMILY" == rockchip64 || "$LINUXFAMILY" == rk35xx ]]; then
 
 		# Attach to specific commit
-		local uwe5622ver='commit:ce59d2aafbdad2cd740ee203053ccfba058a20bc' # Commit date: Aug 06, 2026 (please update when updating commit ref)
+		local uwe5622ver='commit:d6bec7538a0b4b67e35715ad71eaa056555524cb' # Commit date: Aug 15, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Unisoc uwe5622 driver ${uwe5622ver}" "info"
 


### PR DESCRIPTION
Picks up armbian/uwe5622#11–#16: forward declaration of `struct sprdwl_intf` in intf_ops.h, sm_state → wifi_connection_state mapping in the llstat handler, `int_ap` gpio_desc comparison, unused locals, the two annotated switch fall-throughs and the `pcie_addr` flexible array member. Warning count from the driver on the 6-kernel CI matrix drops from ~17 per build to the VLA family only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled wireless driver source to a newer pinned revision for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->