### PR TITLE
drivers: bump wifi-rtl8852bs to 6099b02 (Aug 15, 2026)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -409,7 +409,7 @@ driver_rtl8852bs() {
 	if linux-version compare "${version}" ge 6.1 && [[ "${LINUXFAMILY}" == spacemit || "${LINUXFAMILY}" == rk35xx || "${LINUXFAMILY}" == rockchip64 ]]; then
 
 		# Attach to specific commit
-		local rtl8852bs_ver='commit:3e7d964fac3063f7ff3645827e3180d59f33feec' # Commit date: Aug 14, 2026 (please update when updating commit ref)
+		local rtl8852bs_ver='commit:6099b02169460aa99e9e1ca8c37de28d248cbe83' # Commit date: Aug 15, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8852BS SDIO chipset ${rtl8852bs_ver}" "info"
 


### PR DESCRIPTION
Picks up armbian/wifi-rtl8852bs#15, #16, #17, #18: unused-function 140→6, efuse NULL-deref fixes, unused-variable 1545→48, proc sscanf checks.

Kernel build output for the driver goes from ~2800 warnings to ~190 (maybe-uninitialized 84, missing-prototypes 42, unused-function 17, unused-variable 45). Verified with kernel 7.1.7 (DEBUG=y/n), 6.18 and 6.1: 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the RTL8852BS wireless driver to a newer source revision, improving compatibility and reliability for supported wireless hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->