### PR TITLE
Fix ethernet on tx6s-axp-313

### DIFF
--- a/patch/kernel/archive/sunxi-6.12/dt_64/sun50i-h616-tanix-tx6s-axp313.dts
+++ b/patch/kernel/archive/sunxi-6.12/dt_64/sun50i-h616-tanix-tx6s-axp313.dts
@@ -96,15 +96,6 @@
 		compatible = "linux,spdif-dit";
 	};
 
-	ac300_pwm_clk: ac300-clk {
-		compatible = "pwm-clock";
-		#clock-cells = <0>;
-		/* 500ns period -> 2MHz */
-		pwms = <&pwm 5 500 0>;
-		clock-frequency = <2000000>;
-		status = "okay";
-	};
-
 	openvfd {
 		compatible = "open,vfd";
 		dev_name = "openvfd";
@@ -164,56 +155,21 @@
 };
 
 &emac1 {
-	compatible = "allwinner,sun50i-h616-internal-emac";
 	pinctrl-names = "default";
 	pinctrl-0 = <&rmii_pins>;
 	phy-mode = "rmii";
-	phy-handle = <&ac300_ephy>;
+	phy-handle = <&rmii_phy>;
 	phy-supply = <&reg_aldo1>;
 	allwinner,rx-delay-ps = <3100>;
 	allwinner,tx-delay-ps = <700>;
 	status = "okay";
-
-	mdio-mux {
-		compatible = "allwinner,sun8i-h3-mdio-mux";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		mdio-parent-bus = <&mdio1>;
-
-		internal_mdio: mdio@1 {
-			compatible = "allwinner,sun8i-h3-mdio-internal";
-			reg = <1>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			ac300_ephy: ethernet-phy@0 {
-				compatible = "ethernet-phy-id0044.1400",
-					     "allwinner,sun50i-h618-ac300-ephy",
-					     "ethernet-phy-ieee802.3-c22";
-				reg = <0>;
-				clocks = <&ccu CLK_EMAC_25M>, <&ac300_pwm_clk>;
-				clock-names = "ephy", "pwm";
-				nvmem-cells = <&ephy_calibration>;
-				nvmem-cell-names = "calibration";
-				status = "okay";
-			};
-		};
-	};
 };
 
 &mdio1 {
-	compatible = "snps,dwmac-mdio";
-};
-
-&pwm {
-	status = "okay";
-};
-
-&pwm5 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pwm5_pin>;
-	clk_bypass_output = <0x1>;
-	status = "okay";
+	rmii_phy: ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <1>;
+	};
 };
 
 &mmc0 {
@@ -308,12 +264,6 @@
 				regulator-name = "vcc3v3";
 			};
 		};
-	};
-};
-
-&sid {
-	ephy_calibration: ephy-calibration@2c {
-		reg = <0x2c 0x2>;
 	};
 };
 

--- a/patch/kernel/archive/sunxi-6.12/dt_64/sun50i-h616-tanix-tx6s-axp313.dts
+++ b/patch/kernel/archive/sunxi-6.12/dt_64/sun50i-h616-tanix-tx6s-axp313.dts
@@ -96,6 +96,15 @@
 		compatible = "linux,spdif-dit";
 	};
 
+	ac300_pwm_clk: ac300-clk {
+		compatible = "pwm-clock";
+		#clock-cells = <0>;
+		/* 500ns period -> 2MHz */
+		pwms = <&pwm 5 500 0>;
+		clock-frequency = <2000000>;
+		status = "okay";
+	};
+
 	openvfd {
 		compatible = "open,vfd";
 		dev_name = "openvfd";
@@ -155,21 +164,56 @@
 };
 
 &emac1 {
+	compatible = "allwinner,sun50i-h616-internal-emac";
 	pinctrl-names = "default";
 	pinctrl-0 = <&rmii_pins>;
 	phy-mode = "rmii";
-	phy-handle = <&rmii_phy>;
+	phy-handle = <&ac300_ephy>;
 	phy-supply = <&reg_aldo1>;
 	allwinner,rx-delay-ps = <3100>;
 	allwinner,tx-delay-ps = <700>;
 	status = "okay";
+
+	mdio-mux {
+		compatible = "allwinner,sun8i-h3-mdio-mux";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		mdio-parent-bus = <&mdio1>;
+
+		internal_mdio: mdio@1 {
+			compatible = "allwinner,sun8i-h3-mdio-internal";
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ac300_ephy: ethernet-phy@0 {
+				compatible = "ethernet-phy-id0044.1400",
+					     "allwinner,sun50i-h618-ac300-ephy",
+					     "ethernet-phy-ieee802.3-c22";
+				reg = <0>;
+				clocks = <&ccu CLK_EMAC_25M>, <&ac300_pwm_clk>;
+				clock-names = "ephy", "pwm";
+				nvmem-cells = <&ephy_calibration>;
+				nvmem-cell-names = "calibration";
+				status = "okay";
+			};
+		};
+	};
 };
 
 &mdio1 {
-	rmii_phy: ethernet-phy@1 {
-		compatible = "ethernet-phy-ieee802.3-c22";
-		reg = <1>;
-	};
+	compatible = "snps,dwmac-mdio";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&pwm5 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm5_pin>;
+	clk_bypass_output = <0x1>;
+	status = "okay";
 };
 
 &mmc0 {
@@ -264,6 +308,12 @@
 				regulator-name = "vcc3v3";
 			};
 		};
+	};
+};
+
+&sid {
+	ephy_calibration: ephy-calibration@2c {
+		reg = <0x2c 0x2>;
 	};
 };
 

--- a/patch/kernel/archive/sunxi-6.18/dt_64/sun50i-h616-tanix-tx6s-axp313.dts
+++ b/patch/kernel/archive/sunxi-6.18/dt_64/sun50i-h616-tanix-tx6s-axp313.dts
@@ -201,6 +201,21 @@
 	};
 };
 
+&mdio1 {
+	compatible = "snps,dwmac-mdio";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&pwm5 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm5_pin>;
+	clk_bypass_output = <0x1>;
+	status = "okay";
+};
+
 &mmc0 {
 	vmmc-supply = <&reg_dldo1>;
 	broken-cd;

--- a/patch/kernel/archive/sunxi-6.18/dt_64/sun50i-h616-tanix-tx6s-axp313.dts
+++ b/patch/kernel/archive/sunxi-6.18/dt_64/sun50i-h616-tanix-tx6s-axp313.dts
@@ -96,6 +96,15 @@
 		compatible = "linux,spdif-dit";
 	};
 
+	ac300_pwm_clk: ac300-clk {
+		compatible = "pwm-clock";
+		#clock-cells = <0>;
+		/* 500ns period -> 2MHz */
+		pwms = <&pwm 5 500 0>;
+		clock-frequency = <2000000>;
+		status = "okay";
+	};
+
 	openvfd {
 		compatible = "open,vfd";
 		dev_name = "openvfd";
@@ -155,20 +164,40 @@
 };
 
 &emac1 {
+	compatible = "allwinner,sun50i-h616-internal-emac";
 	pinctrl-names = "default";
 	pinctrl-0 = <&rmii_pins>;
 	phy-mode = "rmii";
-	phy-handle = <&rmii_phy>;
+	phy-handle = <&ac300_ephy>;
 	phy-supply = <&reg_aldo1>;
 	allwinner,rx-delay-ps = <3100>;
 	allwinner,tx-delay-ps = <700>;
 	status = "okay";
-};
 
-&mdio1 {
-	rmii_phy: ethernet-phy@1 {
-		compatible = "ethernet-phy-ieee802.3-c22";
-		reg = <1>;
+	mdio-mux {
+		compatible = "allwinner,sun8i-h3-mdio-mux";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		mdio-parent-bus = <&mdio1>;
+
+		internal_mdio: mdio@1 {
+			compatible = "allwinner,sun8i-h3-mdio-internal";
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ac300_ephy: ethernet-phy@0 {
+				compatible = "ethernet-phy-id0044.1400",
+					     "allwinner,sun50i-h618-ac300-ephy",
+					     "ethernet-phy-ieee802.3-c22";
+				reg = <0>;
+				clocks = <&ccu CLK_EMAC_25M>, <&ac300_pwm_clk>;
+				clock-names = "ephy", "pwm";
+				nvmem-cells = <&ephy_calibration>;
+				nvmem-cell-names = "calibration";
+				status = "okay";
+			};
+		};
 	};
 };
 
@@ -264,6 +293,12 @@
 				regulator-name = "vcc3v3";
 			};
 		};
+	};
+};
+
+&sid {
+	ephy_calibration: ephy-calibration@2c {
+		reg = <0x2c 0x2>;
 	};
 };
 

--- a/patch/kernel/archive/sunxi-7.1/dt_64/sun50i-h616-tanix-tx6s-axp313.dts
+++ b/patch/kernel/archive/sunxi-7.1/dt_64/sun50i-h616-tanix-tx6s-axp313.dts
@@ -96,6 +96,15 @@
 		compatible = "linux,spdif-dit";
 	};
 
+	ac300_pwm_clk: ac300-clk {
+		compatible = "pwm-clock";
+		#clock-cells = <0>;
+		/* 500ns period -> 2MHz */
+		pwms = <&pwm 5 500 0>;
+		clock-frequency = <2000000>;
+		status = "okay";
+	};
+
 	openvfd {
 		compatible = "open,vfd";
 		dev_name = "openvfd";
@@ -155,21 +164,56 @@
 };
 
 &emac1 {
+	compatible = "allwinner,sun50i-h616-internal-emac";
 	pinctrl-names = "default";
 	pinctrl-0 = <&rmii_pins>;
 	phy-mode = "rmii";
-	phy-handle = <&rmii_phy>;
+	phy-handle = <&ac300_ephy>;
 	phy-supply = <&reg_aldo1>;
 	allwinner,rx-delay-ps = <3100>;
 	allwinner,tx-delay-ps = <700>;
 	status = "okay";
+
+	mdio-mux {
+		compatible = "allwinner,sun8i-h3-mdio-mux";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		mdio-parent-bus = <&mdio1>;
+
+		internal_mdio: mdio@1 {
+			compatible = "allwinner,sun8i-h3-mdio-internal";
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ac300_ephy: ethernet-phy@0 {
+				compatible = "ethernet-phy-id0044.1400",
+					     "allwinner,sun50i-h618-ac300-ephy",
+					     "ethernet-phy-ieee802.3-c22";
+				reg = <0>;
+				clocks = <&ccu CLK_EMAC_25M>, <&ac300_pwm_clk>;
+				clock-names = "ephy", "pwm";
+				nvmem-cells = <&ephy_calibration>;
+				nvmem-cell-names = "calibration";
+				status = "okay";
+			};
+		};
+	};
 };
 
 &mdio1 {
-	rmii_phy: ethernet-phy@1 {
-		compatible = "ethernet-phy-ieee802.3-c22";
-		reg = <1>;
-	};
+	compatible = "snps,dwmac-mdio";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&pwm5 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm5_pin>;
+	clk_bypass_output = <0x1>;
+	status = "okay";
 };
 
 &mmc0 {
@@ -264,6 +308,12 @@
 				regulator-name = "vcc3v3";
 			};
 		};
+	};
+};
+
+&sid {
+	ephy_calibration: ephy-calibration@2c {
+		reg = <0x2c 0x2>;
 	};
 };
 


### PR DESCRIPTION
# Description
So few days ago i encountered that my ethernet is not working in my tv box so after examing the issue i found it was identical to issue [10084](https://github.com/armbian/build/issues/10084)
For reference, I obtained understanding from #9952 and #10155 

# How Has This Been Tested?
- [x] I tested both stable(6.18) and edge (7.1) kernel and both works in my test.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Ethernet support for Tanix TX6S devices on newer kernel versions.
  * Added AC300 PHY clocking, calibration data, internal MDIO configuration, and required PWM support.
* **Bug Fixes**
  * Replaced the previous external PHY setup with the correct internal AC300 PHY configuration.
* **Compatibility**
  * Removed the Tanix TX6S device configuration from the 6.12 kernel series.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->