### PR TITLE
board: add BT support to bananpim5pro edge kernel

### DIFF
--- a/patch/kernel/archive/rockchip64-7.1/dt/rk3576-bananapi-m5-pro.dts
+++ b/patch/kernel/archive/rockchip64-7.1/dt/rk3576-bananapi-m5-pro.dts
@@ -8,3 +8,22 @@
 	model = "Banana Pi M5 Pro";
 	compatible = "bananapi,m5-pro", "rockchip,rk3576";
 };
+
+&uart4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart4m1_xfer
+		     &uart4m1_ctsn
+		     &uart4m1_rtsn>;
+
+	uart-has-rtscts;
+	status = "okay";
+
+	bluetooth {
+		compatible = "realtek,rtl8822cs-bt";
+		enable-gpios = <&gpio1 RK_PC7 GPIO_ACTIVE_HIGH>;
+		device-wake-gpios = <&gpio1 RK_PD4 GPIO_ACTIVE_HIGH>;
+		host-wake-gpios = <&gpio0 RK_PB1 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&bt_reg_on &host_wake_bt &bt_wake_host>;
+	};
+};

--- a/patch/kernel/archive/rockchip64-7.2/dt/rk3576-bananapi-m5-pro.dts
+++ b/patch/kernel/archive/rockchip64-7.2/dt/rk3576-bananapi-m5-pro.dts
@@ -8,3 +8,22 @@
 	model = "Banana Pi M5 Pro";
 	compatible = "bananapi,m5-pro", "rockchip,rk3576";
 };
+
+&uart4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart4m1_xfer
+		     &uart4m1_ctsn
+		     &uart4m1_rtsn>;
+
+	uart-has-rtscts;
+	status = "okay";
+
+	bluetooth {
+		compatible = "realtek,rtl8822cs-bt";
+		enable-gpios = <&gpio1 RK_PC7 GPIO_ACTIVE_HIGH>;
+		device-wake-gpios = <&gpio1 RK_PD4 GPIO_ACTIVE_HIGH>;
+		host-wake-gpios = <&gpio0 RK_PB1 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&bt_reg_on &host_wake_bt &bt_wake_host>;
+	};
+};


### PR DESCRIPTION
# Description

This PR adds BT support for Bananpi M5 Pro by adding missing uart4 nodes.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] BT functionality tested.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bluetooth support for the Banana Pi M5 Pro using the Realtek RTL8822CS chipset.
  * Enabled UART communication with RTS/CTS hardware flow control.
  * Added power, wake, and host-wake control support for improved Bluetooth operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->