### PR TITLE
config: add git_sources.json with pinned source SHA1s

### DIFF
--- a/config/sources/git_sources.json
+++ b/config/sources/git_sources.json
@@ -1,0 +1,247 @@
+[
+  {
+    "source": "https://github.com/armbian/firmware",
+    "branch": "master",
+    "sha1": "d9846710f54da5e4383e2d67311819659ac2cf5c"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git",
+    "branch": "main",
+    "sha1": "2398c20fc6563d41af79ce329de7c5b245345d5a"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-7.1.y",
+    "sha1": "25c76bea853d0db65b51fb4697a47cbfd9e35e76"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-6.18.y",
+    "sha1": "1efe5d048a391de3ead2804b2e7f86376c356cc5"
+  },
+  {
+    "source": "https://github.com/armbian/linux-rockchip.git",
+    "branch": "rk-6.1-rkr5.1",
+    "sha1": "5280f9b4336199c4025c8eed894d2b4e2268dcc6"
+  },
+  {
+    "source": "https://github.com/AvaotaSBC/linux.git",
+    "branch": "linux-5.15",
+    "sha1": "a464bc4feaff7b102dac6362b44ac3303ec7cae1"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-6.6.y",
+    "sha1": "d27334b2888c10d2b60c954c59b186182d833107"
+  },
+  {
+    "source": "https://github.com/jmontleon/linux-bianbu.git",
+    "branch": "linux-6.6.y",
+    "sha1": "4d95dd94cbc7262efe90d952409b91fb8e3b7dd0"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-6.19.y",
+    "sha1": "b9dbb4576bc8c69e87b4ca4caa2fb1c0db47d722"
+  },
+  {
+    "source": "https://github.com/beagleboard/linux",
+    "branch": "v6.12.49-ti-arm64-r56",
+    "sha1": "8fb21420a704ea36aaf66df8288ed8ee9da2762d"
+  },
+  {
+    "source": "https://github.com/TexasInstruments/ti-linux-kernel",
+    "branch": "ti-linux-6.18.y",
+    "sha1": "9098671a2d2ce1876543f6d6fd576285a184f5a4"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-6.12.y",
+    "sha1": "25c09b42358e73e1476e517b296edb6344f2e4bd"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-7.0.y",
+    "sha1": "458c6079fc1d41d564c37679c8ace02cd83ee817"
+  },
+  {
+    "source": "https://gitlab.com/jmontleon/kernel-ark",
+    "branch": "fedora-6.18.y-riscv-k1.0",
+    "sha1": "1b8a05ff71d9f1d69157ed2716120371e5c41d0e"
+  },
+  {
+    "source": "https://github.com/orangepi-xunlong/linux-orangepi.git",
+    "branch": "orange-pi-6.6-sun60iw2",
+    "sha1": "8a9be72c9006a87f786736b3aa4e2dfd971c1429"
+  },
+  {
+    "source": "https://github.com/khadas/linux.git",
+    "branch": "khadas-vims-5.15.y",
+    "sha1": "4e557e233b9da219f48b82bfa313f353386097ec"
+  },
+  {
+    "source": "https://github.com/khadas/common_drivers",
+    "branch": "khadas-vims-5.15.y",
+    "sha1": "3a11a86a02e759fc57fc79410215f7c0c3a0d8e0"
+  },
+  {
+    "source": "https://github.com/arduino/u-boot.git",
+    "branch": "qcom-mainline",
+    "sha1": "8008ca96a4dc53ddb3e51b96ea7e86d881ab7969"
+  },
+  {
+    "source": "https://github.com/radxa/u-boot.git",
+    "branch": "next-dev-v2024.10",
+    "sha1": "39cd993e5d6296635438e84f4576b3a9bf76f86e"
+  },
+  {
+    "source": "https://github.com/u-boot/u-boot",
+    "branch": "master",
+    "sha1": "ece349ade2973e220f524ce59e59711cc919263f"
+  },
+  {
+    "source": "https://github.com/beagleboard/u-boot",
+    "branch": "v2025.07-am6232-pocketbeagle2",
+    "sha1": "a2b9f59b4fa23266d014c8bf45baeaa189630355"
+  },
+  {
+    "source": "https://github.com/stvhay/u-boot.git",
+    "branch": "rockchip-rk3588-unified",
+    "sha1": "2f6e967dc901ae570f522d1b47309e7c34acf542"
+  },
+  {
+    "source": "https://github.com/spacemit-com/linux-6.18.git",
+    "branch": "k3-br-v1.0.y",
+    "sha1": "2551d53ea5ef0c12ccac545ec286df4d873b70b9"
+  },
+  {
+    "source": "https://gitlab.com/jmontleon/kernel-ark",
+    "branch": "fedora-6.18.y-riscv-k3.0",
+    "sha1": "7ba80e300f8acbd852120b3e0ceb165e37ba3439"
+  },
+  {
+    "source": "https://github.com/CoreELEC/u-boot.git",
+    "branch": "khadas-vims-v2019.01",
+    "sha1": "4a16015168d00d08487781fc914e048944554c6e"
+  },
+  {
+    "source": "https://github.com/radxa/u-boot.git",
+    "branch": "rk35xx-2024.01",
+    "sha1": "31b85240876dc43492b0826a74b99c23fbf6ed9d"
+  },
+  {
+    "source": "https://github.com/radxa/u-boot.git",
+    "branch": "next-dev-buildroot",
+    "sha1": "3c60a711e61015c1a61247837afbeaa85bd7fbf2"
+  },
+  {
+    "source": "https://github.com/radxa/u-boot.git",
+    "branch": "next-dev-v2024.03",
+    "sha1": "22849bf1cf13c2f0a6f2741a51d4802793d2aecc"
+  },
+  {
+    "source": "https://github.com/hardkernel/u-boot.git",
+    "branch": "odroidc-v2011.03",
+    "sha1": "b7b8dc21b64b9494618325c9b4d2fbae728aeed6"
+  },
+  {
+    "source": "https://github.com/OpenNuvoton/MA35D1_u-boot-v2020.07.git",
+    "branch": "master",
+    "sha1": "7d5cb5fd7e9c8d3d00de7aa8f86a7f47dfd229b4"
+  },
+  {
+    "source": "https://github.com/OpenNuvoton/MA35D1_linux-5.10.y.git",
+    "branch": "master",
+    "sha1": "4cab445079545bd74d006b8a6cd00131c3d8dd7b"
+  },
+  {
+    "source": "https://github.com/hardkernel/u-boot.git",
+    "branch": "odroidxu4-v2017.05",
+    "sha1": "42ac93dcfbbb8a08c2bdc02e19f96eb35a81891a"
+  },
+  {
+    "source": "https://github.com/hardkernel/linux",
+    "branch": "odroid-6.6.y",
+    "sha1": "2721ed4be281c9022b27f0c62618aa7b9fbf6a87"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-6.15.y",
+    "sha1": "4afb9d6bd4c4b3dad7e2c9c48b6c8a55275d8f46"
+  },
+  {
+    "source": "https://github.com/orangepi-xunlong/u-boot-orangepi.git",
+    "branch": "v2017.09-rk3588",
+    "sha1": "59fb85d0f6c435c9e5a8e6e0c54aa93b7a65ddfc"
+  },
+  {
+    "source": "https://github.com/chainsx/phytium-linux-kernel",
+    "branch": "linux-6.6",
+    "sha1": "46471440b5ea96f5caa7ad70ce457735070f9f8e"
+  },
+  {
+    "source": "https://github.com/chainsx/phytium-linux-kernel",
+    "branch": "linux-5.10",
+    "sha1": "89f1409f9ce3d206348995ff7ac6fb624eb09c7b"
+  },
+  {
+    "source": "https://github.com/radxa/kernel.git",
+    "branch": "linux-6.18.2",
+    "sha1": "559f4f921a01e5358602153364c618fe2a3e431e"
+  },
+  {
+    "source": "https://github.com/radxa/kernel.git",
+    "branch": "linux-7.0.11",
+    "sha1": "8a05c2cc9a37c6b0cd21873c048f41ee451b05b7"
+  },
+  {
+    "source": "https://github.com/raspberrypi/linux",
+    "branch": "rpi-6.18.y",
+    "sha1": "ce0873cb5e0c24dd4730d87f4777982035733a0d"
+  },
+  {
+    "source": "https://github.com/raspberrypi/linux",
+    "branch": "rpi-7.1.y",
+    "sha1": "db6416f1b6285aca5374ce23ed3b2fb07bf7529e"
+  },
+  {
+    "source": "https://github.com/raspberrypi/linux",
+    "branch": "rpi-6.12.y",
+    "sha1": "f7b06ac140e17a0e6d30fcc9ddeebc0e60943cea"
+  },
+  {
+    "source": "https://github.com/TexasInstruments/ti-u-boot",
+    "branch": "ti-u-boot-2026.01",
+    "sha1": "5fb29434232110fb5a176136086d26ecb299932e"
+  },
+  {
+    "source": "https://github.com/steev/linux.git",
+    "branch": "lenovo-x13s-linux-7.0.y",
+    "sha1": "d73346660f8f61ffb6e716c68ad97687eb63a8c7"
+  },
+  {
+    "source": "https://github.com/starfive-tech/linux",
+    "branch": "JH7110_VisionFive2_6.6.y_devel",
+    "sha1": "c09d91536baa616af1538a5bd2dbdf95c6e107d8"
+  },
+  {
+    "source": "https://github.com/XpressReal/u-boot.git",
+    "branch": "v2024.01-xpressreal",
+    "sha1": "4cac3d9b64ef3d3a87ceec824ca341b1871432e4"
+  },
+  {
+    "source": "https://github.com/XpressReal/linux.git",
+    "branch": "v6.6.54-xpressreal-t3",
+    "sha1": "be79582cba58b749c4f03cfeff3ad18d1a0b3ac9"
+  },
+  {
+    "source": "https://github.com/frank-w/BPI-Router-Linux.git",
+    "branch": "6.12-main",
+    "sha1": "2579ef9e812d8ddcd3fe9542bdd571b6a03cf651"
+  },
+  {
+    "source": "https://github.com/SolidRun/u-boot",
+    "branch": "v2018.01-solidrun-a38x",
+    "sha1": "a8004c1f1112ca2f867badccce5a76f052034853"
+  }
+]


### PR DESCRIPTION
`_git_sources_pinned_sha1()` in [lib/functions/general/git-ref2info.sh](https://github.com/armbian/build/blob/v26.08/lib/functions/general/git-ref2info.sh) reads `config/sources/git_sources.json` to resolve a source+branch pair to a commit without hitting the network. The file itself was never in the tree, so `OFFLINE_WORK=yes` had no fallback and aborted with `no SHA1 available for ...` for any ref that was not already in the memoize cache.

49 entries covering the kernel, u-boot, firmware and vendor trees currently in use.

Validated: uniform `{source, branch, sha1}` schema across all entries, every sha1 a 40-char hex, no duplicate source+branch pairs, and the exact jq expression from `_git_sources_pinned_sha1` returns a value.

Based on `v26.08` since that is where the pins were generated — say the word if this should target `main` instead.