### PR TITLE
mt7623: bump u-boot to v2026.07 and current kernel to 6.18

### DIFF
--- a/config/sources/families/mt7623.conf
+++ b/config/sources/families/mt7623.conf
@@ -9,8 +9,8 @@
 BOOTSCRIPT='boot-mt7623.cmd:boot.cmd'
 BOOTENV_FILE='mt7623.txt'
 UBOOT_TARGET_MAP=";;$SRC/packages/blobs/mt7623n/BPI-R2-HEAD440-0k.img $SRC/packages/blobs/mt7623n/BPI-R2-HEAD1-512b.img $SRC/packages/blobs/mt7623n/BPI-R2-preloader-2k.img $SRC/packages/blobs/mt7623n/BPI-R2-EMMC-boot0-0K-0905.img u-boot.bin"
-BOOTPATCHDIR='v2024.07'
-BOOTBRANCH='tag:v2024.07'
+BOOTPATCHDIR='v2026.07'
+BOOTBRANCH='tag:v2026.07'
 ARCH=armhf
 ATF_COMPILE="no"
 EXTRAWIFI="no"
@@ -20,7 +20,7 @@ case $BRANCH in
 	# 07/2024: This family only has one board (BananaPi R2) and has not been properly maintained in many years, so 'current' LTS kernel is enough.
 	#          No need for 'edge' kernel unless someone plans to step in as maintainer who bumps and tests it on every new kernel release.
 	current)
-		KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
+		KERNEL_MAJOR_MINOR="6.18" # Major and minor versions of this kernel.
 		# No need to set KERNELPATCHDIR, since default is: KERNELPATCHDIR='archive/${BOARDFAMILY}-${KERNEL_MAJOR_MINOR}'
 		;;
 

--- a/patch/u-boot/v2026.07/board_bananapir2/enable-boot-from-ext4.patch
+++ b/patch/u-boot/v2026.07/board_bananapir2/enable-boot-from-ext4.patch
@@ -1,0 +1,105 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@****l.com>
+Date: Tue, 13 Jun 2023 14:21:30 +0000
+Subject: Patching u-boot mt7623 files include/configs/mt7623.h
+ mt7623n_bpir2_defconfig
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@****l.com>
+---
+ configs/mt7623n_bpir2_defconfig |  5 +
+ include/configs/mt7623.h        | 46 +++++++++-
+ 2 files changed, 47 insertions(+), 4 deletions(-)
+
+diff --git a/configs/mt7623n_bpir2_defconfig b/configs/mt7623n_bpir2_defconfig
+index 111111111111..222222222222 100644
+--- a/configs/mt7623n_bpir2_defconfig
++++ b/configs/mt7623n_bpir2_defconfig
+@@ -23,6 +23,7 @@ CONFIG_SYS_CONSOLE_IS_IN_ENV=y
+ # CONFIG_DISPLAY_BOARDINFO is not set
+ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_SYS_MAXARGS=8
++CONFIG_CMD_BOOTZ=y
+ CONFIG_CMD_BOOTMENU=y
+ # CONFIG_CMD_ELF is not set
+ # CONFIG_CMD_XIMG is not set
+@@ -60,5 +61,9 @@ CONFIG_SYSRESET_WATCHDOG=y
+ CONFIG_TIMER=y
+ CONFIG_MTK_TIMER=y
+ CONFIG_WDT_MTK=y
++CONFIG_FS_EXT4=y
++CONFIG_EXT4_WRITE=y
+ CONFIG_LZMA=y
+ # CONFIG_EFI_GRUB_ARM32_WORKAROUND is not set
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_EXT4_WRITE=y
+diff --git a/include/configs/mt7623.h b/include/configs/mt7623.h
+index 111111111111..222222222222 100644
+--- a/include/configs/mt7623.h
++++ b/include/configs/mt7623.h
+@@ -18,11 +18,27 @@
+ #define CFG_SYS_SDRAM_BASE		0x80000000
+ 
+ /* This is needed for kernel booting */
+-#define FDT_HIGH			"0xac000000"
++#define SCRIPT_BOOT \
++	"fileload=${mmctype}load mmc ${devnum}:${mmcpart} " \
++		"${loadaddr} ${mmcfile}\0" \
++	"kernload=setenv loadaddr ${kernel_addr_r};" \
++		"setenv mmcfile ${mmckernfile};" \
++		"run fileload\0" \
++	"initrdload=setenv loadaddr ${rdaddr};" \
++		"setenv mmcfile ${mmcinitrdfile};" \
++		"run fileload\0" \
++	"fdtload=setenv loadaddr ${fdtaddr};" \
++		"setenv mmcfile ${mmcfdtfile};" \
++		"run fileload\0" \
++	"scriptload=setenv loadaddr ${scriptaddr};" \
++		"setenv mmcfile ${mmcscriptfile};" \
++		"run fileload\0" \
++	"scriptboot=echo Running ${mmcscriptfile} from: mmc ${devnum}:${mmcpart} using ${mmcscriptfile};" \
++		"source ${scriptaddr};" \
+ 
+ #define ENV_MEM_LAYOUT_SETTINGS				\
+ 	"fdt_high=" FDT_HIGH "\0"			\
+-	"kernel_addr_r=0x84000000\0"			\
++	"kernel_addr_r=0x82000000\0"			\
+ 	"fdt_addr_r=" FDT_HIGH "\0"			\
+ 	"fdtfile=" CONFIG_DEFAULT_FDT_FILE "\0"
+ 
+@@ -35,9 +51,31 @@
+ 
+ /* Extra environment variables */
+ #define CFG_EXTRA_ENV_SETTINGS	\
+-	ENV_MEM_LAYOUT_SETTINGS		\
+-	BOOTENV
++	"loadaddr=0x82000000\0" \
++	"kernel_addr_r=0x82000000\0" \
++	"scriptaddr=0x85F80000\0" \
++	"fdtaddr=0x86000000\0" \
++	"fdt_addr_r=0x86000000\0" \
++	"rdaddr=0x86080000\0" \
++	"ramdisk_addr_r=0x86080000\0" \
++	"bootm_size=0x10000000\0" \
++	"mmckernfile=boot/zImage\0" \
++	"mmcinitrdfile= boot/uInitrd\0" \
++	"mmcfdtfile=boot/dtb/mt7623n-bananapi-bpi-r2.dtb\0" \
++	"mmcscriptfile=boot/boot.scr\0" \
++	"mmctype=ext4\0" \
++	"devnum=1\0" \
++	"mmcpart=1\0" \
++	SCRIPT_BOOT
+ 
++#define CONFIG_BOOTCOMMAND \
++	"mmc dev 1;" \
++	"run scriptload;" \
++	"run scriptboot;" \
++	"setenv devnum 0;" \
++	"mmc dev 0;" \
++	"run scriptload;" \
++	"run scriptboot"
+ #endif /* ifdef CONFIG_DISTRO_DEFAULTS*/
+ 
+ #endif
+-- 
+Armbian
+


### PR DESCRIPTION
Maintenance bump for the mt7623 family (Banana Pi R2), reviving PR #4873's intent on today's tree.

## Changes

- **u-boot `v2024.07` → `v2026.07`** — `BOOTBRANCH=tag:v2026.07`, `BOOTPATCHDIR=v2026.07`. The mainline `v2026.07` tag and patch dir are already in use by other families (sunxi, rv1126). Ported the board patch `board_bananapir2/enable-boot-from-ext4.patch` into `patch/u-boot/v2026.07/`.
- **current kernel `6.6` → `6.18`** — aligns mt7623 with Armbian's current LTS (sunxi/rockchip already on 6.18.x). The family carries **no `mt7623` kernel patch dir**, so this is a pure mainline version bump (no patches to port).

## Notes / testing

mt7623 shares the versioned u-boot patch dir with other boards, so moving to `v2026.07` swaps the set of *general* u-boot patches it inherits — this needs a real build + boot on a Banana Pi R2 to confirm:

- [ ] u-boot v2026.07 builds and boots the R2 (SD + eMMC)
- [ ] kernel 6.18 boots; networking (DSA switch: wan/lan0-3, br0), SATA, USB, HDMI OK
- [ ] `linux-mt7623-current.config` carries forward cleanly under 6.18 `olddefconfig` (refresh in a follow-up if needed)

Supersedes the u-boot/kernel portions of the stale draft #4873.