### PR TITLE
rockchip64: rk356x rkvdec2: drop stray 4th interrupt cell

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/rk356x-add-rkvdec2-support.patch
+++ b/patch/kernel/archive/rockchip64-6.12/rk356x-add-rkvdec2-support.patch
@@ -53,7 +53,7 @@ index 111111111111..222222222222 100644
 +		compatible = "rockchip,rk3588-vdec";
 +		reg = <0x0 0xfdf80100 0x0 0x100>, <0x0 0xfdf80200 0x0 0x500>, <0x0 0xfdf80700 0x0 0x100>;
 +		reg-names = "link", "function", "cache";
-+		interrupts = <GIC_SPI 91 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupts = <GIC_SPI 91 IRQ_TYPE_LEVEL_HIGH>;
 +		clocks = <&cru ACLK_RKVDEC>, <&cru HCLK_RKVDEC>, <&cru CLK_RKVDEC_CA>,
 +			 <&cru CLK_RKVDEC_CORE>, <&cru CLK_RKVDEC_HEVC_CA>;
 +		clock-names = "axi", "ahb", "cabac", "core", "hevc_cabac";

--- a/patch/kernel/archive/rockchip64-6.18/rk356x-add-rkvdec2-support.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk356x-add-rkvdec2-support.patch
@@ -53,7 +53,7 @@ index 111111111111..222222222222 100644
 +		compatible = "rockchip,rk3588-vdec";
 +		reg = <0x0 0xfdf80100 0x0 0x100>, <0x0 0xfdf80200 0x0 0x500>, <0x0 0xfdf80700 0x0 0x100>;
 +		reg-names = "link", "function", "cache";
-+		interrupts = <GIC_SPI 91 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupts = <GIC_SPI 91 IRQ_TYPE_LEVEL_HIGH>;
 +		clocks = <&cru ACLK_RKVDEC>, <&cru HCLK_RKVDEC>, <&cru CLK_RKVDEC_CA>,
 +			 <&cru CLK_RKVDEC_CORE>, <&cru CLK_RKVDEC_HEVC_CA>;
 +		clock-names = "axi", "ahb", "cabac", "core", "hevc_cabac";

--- a/patch/kernel/archive/rockchip64-7.1/rk356x-add-rkvdec2-support.patch
+++ b/patch/kernel/archive/rockchip64-7.1/rk356x-add-rkvdec2-support.patch
@@ -53,7 +53,7 @@ index 111111111111..222222222222 100644
 +		compatible = "rockchip,rk3588-vdec";
 +		reg = <0x0 0xfdf80100 0x0 0x100>, <0x0 0xfdf80200 0x0 0x500>, <0x0 0xfdf80700 0x0 0x100>;
 +		reg-names = "link", "function", "cache";
-+		interrupts = <GIC_SPI 91 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupts = <GIC_SPI 91 IRQ_TYPE_LEVEL_HIGH>;
 +		clocks = <&cru ACLK_RKVDEC>, <&cru HCLK_RKVDEC>, <&cru CLK_RKVDEC_CA>,
 +			 <&cru CLK_RKVDEC_CORE>, <&cru CLK_RKVDEC_HEVC_CA>;
 +		clock-names = "axi", "ahb", "cabac", "core", "hevc_cabac";

--- a/patch/kernel/archive/rockchip64-7.2/rk356x-add-rkvdec2-support.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk356x-add-rkvdec2-support.patch
@@ -53,7 +53,7 @@ index 111111111111..222222222222 100644
 +		compatible = "rockchip,rk3588-vdec";
 +		reg = <0x0 0xfdf80100 0x0 0x100>, <0x0 0xfdf80200 0x0 0x500>, <0x0 0xfdf80700 0x0 0x100>;
 +		reg-names = "link", "function", "cache";
-+		interrupts = <GIC_SPI 91 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupts = <GIC_SPI 91 IRQ_TYPE_LEVEL_HIGH>;
 +		clocks = <&cru ACLK_RKVDEC>, <&cru HCLK_RKVDEC>, <&cru CLK_RKVDEC_CA>,
 +			 <&cru CLK_RKVDEC_CORE>, <&cru CLK_RKVDEC_HEVC_CA>;
 +		clock-names = "axi", "ahb", "cabac", "core", "hevc_cabac";


### PR DESCRIPTION
### Description
rk356x GIC has `#interrupt-cells = <3>`; the vdec node in `rk356x-add-rkvdec2-support.patch` (copied from rk3588) carries a 4th cell, so every rk356x DTB build warns:

    rk356x-base.dtsi:304.3-26: Warning (interrupts_property): /video-codec@fdf80200:#interrupt-cells: size is (16), expected multiple of 12

The kernel silently uses the first three cells, so this is warning-only. Same one-line change in all four copies (6.12, 6.18, 7.1, 7.2).

### How Has This Been Tested?
- [x] `./compile.sh kernel BOARD=odroidm1 BRANCH=edge KERNEL_DTB_ONLY=yes`: main → 71 warnings (one per rk356x DTB), this branch → 0

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the RKVDEC2 hardware video decoder on RK356x devices.
  * Enabled required decoder memory, clock, reset, power, interrupt, and SRAM resources.
* **Bug Fixes**
  * Updated video processor compatibility declarations to improve hardware recognition and driver support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->