### PR TITLE
rtl8852bs: bump driver to 58840d11 (2026-08-18)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -409,7 +409,7 @@ driver_rtl8852bs() {
 	if linux-version compare "${version}" ge 6.1 && [[ "${LINUXFAMILY}" == spacemit || "${LINUXFAMILY}" == rk35xx || "${LINUXFAMILY}" == rockchip64 ]]; then
 
 		# Attach to specific commit
-		local rtl8852bs_ver='commit:6099b02169460aa99e9e1ca8c37de28d248cbe83' # Commit date: Aug 15, 2026 (please update when updating commit ref)
+		local rtl8852bs_ver='commit:58840d11af91d0b72bc830980b4aff740a37b5e3' # Commit date: Aug 18, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8852BS SDIO chipset ${rtl8852bs_ver}" "info"
 


### PR DESCRIPTION
### Description
Bump `rtl8852bs_ver` to `58840d11` (2026-08-18). Picks up armbian/wifi-rtl8852bs #19–#25 (17 commits): -Warray-bounds / -Wformat-truncation / -Wframe-larger-than cleanup, -Wmaybe-uninitialized 84→0 with a bounded mp-ioctl input copy, two clang findings (`sscanf "%7s"` target size, `rtw_vht` `max_bw` for non-2.4/5 GHz bands), proc write handlers reading only what was written, `kern_path()` reference leak, TX-power-limit parser (missing `continue` in the column-define stage) and the external parameter file path that was never composed correctly.

### How Has This Been Tested?
- [x] Full module build of `58840d11` against 7.1.8 arm64 headers with `CONFIG_RTW_DEBUG=n` (as `drivers_network.sh` sets it): 0 errors, `8852bs.ko` linked; remaining warnings are the known deliberately-kept set (unused-variable 45, missing-prototypes 42, unused-function 17)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the RTL8852BS network driver source to a newer revision, improving compatibility and reliability for supported hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->