### PR TITLE
sm8550-sheng: scope clang to kernel build (fix linux-headers postinst clang: not found)

### DIFF
--- a/config/sources/families/sm8550-sheng.conf
+++ b/config/sources/families/sm8550-sheng.conf
@@ -26,5 +26,9 @@ case $BRANCH in
 
 esac
 
-export CC="clang"
-export LLVM=1
+# Build the kernel with clang/LLVM. Use KERNEL_COMPILER (scoped to the kernel
+# make, passed as LLVM=1 under `env -i`) rather than exporting CC/LLVM globally:
+# a global export leaks into the image-assembly chroot, where the linux-headers
+# postinst's `make scripts` then invokes clang (not installed in the rootfs -
+# the headers package Depends on gcc) and fails with "clang: not found".
+declare -g KERNEL_COMPILER="clang"


### PR DESCRIPTION
## Problem

Image build for `xiaomi-sheng` (sm8550-sheng) fails while configuring the kernel headers in the target rootfs:

```
Setting up linux-headers-edge-sm8550-sheng ...
Configuring kernel-headers (7.1.8-edge-sm8550-sheng) - please wait ...
make[1]: clang: No such file or directory
  HOSTCC  scripts/basic/fixdep
/bin/sh: 1: clang: not found
make[2]: *** [scripts/Makefile.host:114: scripts/basic/fixdep] Error 127
dpkg: error processing package linux-headers-edge-sm8550-sheng (--configure)
```

## Cause

The family built the kernel with clang by exporting `CC="clang"` and `LLVM=1` **globally**. Those exports leak out of the kernel compilation into the image-assembly chroot. The `linux-headers` postinst runs `make ... scripts` to rebuild `scripts/basic/fixdep` in the target rootfs, inherits `LLVM=1` from the environment, and invokes `clang` — which is not installed in the image. The `linux-headers` package `Depends: make, gcc, ...` (gcc, not clang), so the postinst is meant to build with gcc.

## Fix

Use the framework's first-class clang path: `KERNEL_COMPILER="clang"`. That adds `LLVM=1` only to the kernel `make` parameters, which run under `env -i` (clean environment), so the flag never escapes into the rootfs. The kernel is still built with clang; the headers postinst rebuilds scripts with gcc (its declared dependency).

No functional change to the kernel build — same compiler, just scoped correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel compilation configuration to prevent compiler settings from affecting image assembly.
  * Resolved an issue that could cause linux-headers installation to fail during image creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->