### PR TITLE
youyeetoo-r1: fix M.2 PCIe reset gpio

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3588s-youyeetoo-r1.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3588s-youyeetoo-r1.dts
@@ -351,7 +351,7 @@
 };
 
 &pcie2x1l1 {
-	reset-gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_HIGH>;
+	reset-gpios = <&gpio1 RK_PB0 GPIO_ACTIVE_HIGH>;
 	rockchip,init-delay-ms = <100>;
 	vpcie3v3-supply = <&vcc_3v3_pcie20>;
 	status = "okay";

--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3588s-youyeetoo-r1.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3588s-youyeetoo-r1.dts
@@ -436,7 +436,7 @@
 };
 
 &pcie2x1l1 {
-	reset-gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_HIGH>;
+	reset-gpios = <&gpio1 RK_PB0 GPIO_ACTIVE_HIGH>;
 	rockchip,init-delay-ms = <100>;
 	vpcie3v3-supply = <&vcc_3v3_pcie20>;
 	status = "okay";

--- a/patch/kernel/archive/rockchip64-7.1/dt/rk3588s-youyeetoo-r1.dts
+++ b/patch/kernel/archive/rockchip64-7.1/dt/rk3588s-youyeetoo-r1.dts
@@ -436,7 +436,7 @@
 };
 
 &pcie2x1l1 {
-	reset-gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_HIGH>;
+	reset-gpios = <&gpio1 RK_PB0 GPIO_ACTIVE_HIGH>;
 	rockchip,init-delay-ms = <100>;
 	vpcie3v3-supply = <&vcc_3v3_pcie20>;
 	status = "okay";

--- a/patch/kernel/archive/rockchip64-7.2/dt/rk3588s-youyeetoo-r1.dts
+++ b/patch/kernel/archive/rockchip64-7.2/dt/rk3588s-youyeetoo-r1.dts
@@ -436,7 +436,7 @@
 };
 
 &pcie2x1l1 {
-	reset-gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_HIGH>;
+	reset-gpios = <&gpio1 RK_PB0 GPIO_ACTIVE_HIGH>;
 	rockchip,init-delay-ms = <100>;
 	vpcie3v3-supply = <&vcc_3v3_pcie20>;
 	status = "okay";


### PR DESCRIPTION
# Description

`pcie2x1l1` is the controller behind the M.2 M-key socket on the R1 v3. Its `reset-gpios` names GPIO1_A7, but the V3 schematic routes PERST# from CON1 pin 50 through R211 (22R) to GPIO1_B0. GPIO1_A7 is the SoC `PCIE20X1_1_PERSTN_M2` alternate function pin, which is probably why it got picked, but on this board that ball goes to pin 13 of the 30-pin user header (CON3) instead.

So the driver has been pulling a header pin low and high on every boot and every resume, while the card never sees a reset pulse. Anyone wiring something to CON3 pin 13 gets an unexplained glitch on it.

To be clear about the scope: this does not change whether an NVMe is detected. The link comes up Gen2 x1 either way, because the module releases PERST# on its own at power-up. It is a correctness fix, and it stops the kernel from driving a user pin.

Same one line change in the 6.12, 6.18, 7.1 and 7.2 patchsets. The vendor tree carries the same wrong pin and is fixed in armbian/linux-rockchip#530.

# How Has This Been Tested?

- [x] Vendor kernel 6.1.115 built from the same fix and booted on an R1 v3 with a Patriot P300 NVMe: `/sys/kernel/debug/gpio` shows the PCIe reset claimed on `gpio-40`, which is GPIO1_B0, and `/proc/device-tree/pcie@fe180000/reset-gpios` reads back pin `08`
- [x] Same board on edge 7.1.7 without the fix reads back pin `07` and claims `gpio-7` instead, and the NVMe links in both cases, which is why this is filed as a correctness fix rather than a functional one
- [x] Pin mapping taken from the V3 schematic and cross checked against the pin tables in `rk3588s-pinctrl.dtsi`: CON1 pin 50 goes through R211 to GPIO1_B0, and GPIO1_A7 lands on CON3 pin 13
- [x] `lspci` on the fixed build: `0003:30:00.0 LnkSta: Speed 5GT/s, Width x1` with the SSD enumerated behind it

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the PCIe 2x1 lane 1 reset signal configuration on the RK3588S Youyeetoo R1 board.
  * Improved PCIe device initialization and reset behavior across supported kernel versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->