### PR TITLE
bootscripts: seeed-rk35xx: harden armbianEnv.txt import against CRLF and invalid fdtfile

### DIFF
--- a/config/bootscripts/boot-seeed-rk35xx.cmd
+++ b/config/bootscripts/boot-seeed-rk35xx.cmd
@@ -24,18 +24,33 @@ echo "Boot script loaded from ${devtype} ${devnum}:${distro_bootpart}"
 # Load armbianEnv.txt with corruption detection and .dist fallback.
 # Power loss can fill the file with 0xFF (eMMC erased block) or ^@ (NUL,
 # on other storage media) which passes "env import -t" without error but
-# imports zero variables. Clear rootdev before import; if it remains
-# empty, the file was corrupt.
+# imports zero variables. Editor-induced CRLF pollution keeps a trailing
+# \r in every value with plain "env import -t"; "env import -t -r"
+# strips it at import (device-verified on the Radxa next-dev-v2024.10
+# U-Boot these boards ship - the banner says 2017.09 because Rockchip
+# pins the version in the Makefile, the code is much newer).
+# Clear rootdev and fdtfile so a stale built-in value can't satisfy the
+# probe below when a corrupt file imports zero variables.
 setenv rootdev
+setenv fdtfile
 if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt; then
-	env import -t ${load_addr} ${filesize}
+	env import -t -r ${load_addr} ${filesize}
 fi
-if test -z "${rootdev}"; then
+# Defense in depth: probe the imported file by loading the DTB its
+# fdtfile points to. On failure (stale fdtfile from an older image,
+# typo, missing dtb) reload .dist, which restores all key vars (rootdev,
+# fdtfile, overlays, ...) from the clean baseline maintained by the
+# build hook and OTA sync.
+if load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${prefix}dtb/${fdtfile}; then
+	:
+else
+	echo "WARNING: armbianEnv.txt fdtfile ${fdtfile} not loadable, loading .dist fallback"
+	setenv rootdev
+	setenv fdtfile
 	if load ${devtype} ${devnum}:${distro_bootpart} ${load_addr} ${prefix}armbianEnv.txt.dist; then
-		echo "WARNING: armbianEnv.txt corrupt, loading .dist fallback"
-		setenv rootdev
-		env import -t ${load_addr} ${filesize}
+		env import -t -r ${load_addr} ${filesize}
 	fi
+	load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${prefix}dtb/${fdtfile}
 fi
 # Final safety: derive rootdev from boot source if still unset
 if test -z "${rootdev}"; then


### PR DESCRIPTION
## Summary
- `armbianEnv.txt` corruption comes in two flavours: 0xFF/NUL fill (power loss; passes `env import -t` but imports zero variables) and editor-induced CRLF pollution, where plain `env import -t` keeps a trailing `\r` in every value (byte-verified on a reComputer RK3588) while hush string comparison silently strips it — so neither `test -z` nor `=` can catch it.
- Use `env import -t -r`, which strips the CR at import. These boards ship the Radxa `next-dev-v2024.10` U-Boot (banner says "2017.09" — Rockchip pins the version number in the Makefile); `-r` is implemented via `himport_r(crlf_is_lf)` and device testing confirms imported values come out clean. CRLF'd files now import cleanly and keep their user settings instead of falling back to `.dist`.
- As defense in depth, probe the imported file by loading `dtb/${fdtfile}`: on failure (stale fdtfile from an older image, a typo, a missing dtb, or a U-Boot where `-r` is unavailable) clear `rootdev`/`fdtfile` and restore all key vars from the clean `armbianEnv.txt.dist` baseline.

## Testing
- [x] Byte-level device test (reComputer RK3588, U-Boot `2017.09-S39cd-…` = Radxa next-dev-v2024.10): importing a hand-built `testkey=val1\r\n` buffer and re-exporting gives `... 0d 0a` with plain `env import -t` but `... 0a` with `-r`
- [x] 0xFF/NUL corruption → `.dist` fallback (device-tested 2026-08-14)
- [ ] Full boot with clean `armbianEnv.txt` — no warning, normal boot
- [ ] Full boot with CRLF'd `armbianEnv.txt` (`unix2dos`) — boots normally with user settings (CR stripped at import), no `.dist` fallback
- [ ] Remove/rename the pointed DTB — expect `.dist` fallback (same path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot configuration validation and handling of line-ending issues.
  * Invalid device tree settings are now detected before startup.
  * Automatically restores default boot settings when configured values cannot be validated or loaded.
  * Improved recovery when boot configuration is incomplete, malformed, or corrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->