### PR TITLE
Add git.u-boot-project.org to GitLab rules, mirrors

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -275,6 +275,9 @@ function do_main_configuration() {
 		gitee)
 			declare -g -r MAINLINE_UBOOT_SOURCE='https://gitee.com/mirrors/u-boot.git'
 			;;
+		u-boot-project)
+			declare -g -r MAINLINE_UBOOT_SOURCE='https://git.u-boot-project.org/u-boot/u-boot.git'
+			;;
 		denx)
 			declare -g -r MAINLINE_UBOOT_SOURCE='https://source.denx.de/u-boot/u-boot.git'
 			;;

--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -197,7 +197,7 @@ function memoized_git_ref_to_info() {
 					esac
 					;;
 
-				"https://gitlab.com/"* | "https://source.denx.de/"* | "https://gitlab.collabora.com/"*)
+				"https://gitlab.com/"* | "https://git.u-boot-project.org/"* | "https://source.denx.de/"* | "https://gitlab.collabora.com/"*)
 					# GitLab is more complex than GitHub, there can be more levels.
 					# This code is incomplete... but it works for now.
 					# Example: input:  https://gitlab.com/rk3588_linux/rk/kernel.git


### PR DESCRIPTION
# Description

Uboot development has moved (at least in part) from https://source.denx.de/ (unreliable/often-down) to https://git.u-boot-project.org/

Add the new URL to the list of GitLab servers and the uboot mirror list, so that it can be used in Armbian packaging.

# How Has This Been Tested?

Tested changing origin from source.denx.de to git.u-boot-project.org for `rockchip` kwiboo.
GitLab makefile resolution is functional after this change.

# Checklist:

- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the official U-Boot Project repository as a U-Boot mirror option.
  * Improved retrieval of Makefiles from the U-Boot Project Git repository.

* **Bug Fixes**
  * Corrected repository URL handling to ensure Makefiles are fetched successfully from U-Boot Project sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->