### PR TITLE
Add configuration for Banana Pi M2 Berry board

### DIFF
--- a/config/boards/bananapim2berry.csc
+++ b/config/boards/bananapim2berry.csc
@@ -1,0 +1,11 @@
+# Allwinner V40 quad core 1Gb SoC Wifi SATA
+BOARD_NAME="Banana Pi M2 Berry"
+BOARD_VENDOR="sinovoip"
+BOARDFAMILY="sun8i"
+BOARD_MAINTAINER=""
+INTRODUCED="2017"
+BOOTCONFIG="Bananapi_M2_Ultra_defconfig"
+OVERLAY_PREFIX="sun8i-r40"
+BOOT_FDT_FILE="sun8i-v40-bananapi-m2-berry.dtb"
+KERNEL_TARGET="current,edge,legacy"
+KERNEL_TEST_TARGET="current"


### PR DESCRIPTION
# Description

BananaPi M2 Berry shares much of the M2 Ultra which is already supported. But for HDMI output, it needs a different device tree in armbianEnv.txt.


# How Has This Been Tested?

Added entry manually to /boot/armbianEnv.txt and successfully verified the correct output to the HDMI port.


# Checklist:

_Please delete options that are not relevant._

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Banana Pi M2 Berry board, including boot configuration, device-tree files, and supported kernel targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->