### PR TITLE
firstlogin: replace session kill with flock

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -786,6 +786,14 @@ set_user_icon() {
 
 if [[ -f /root/.not_logged_in_yet ]] && tty -s; then
 
+	# tty1, the serial console and an early ssh login all start the setup at once.
+	# Let the first one own it, or they race each other through the prompts.
+	exec 9> /run/armbian-firstlogin.lock || exit 1
+	if ! flock -n 9; then
+		echo -e "\nFirst login setup is already running in another session.\n"
+		exit 0
+	fi
+
 	. /root/.not_logged_in_yet
 
 	# override configuration from URL
@@ -925,18 +933,6 @@ if [[ -f /root/.not_logged_in_yet ]] && tty -s; then
 				fi
 			fi
 		fi
-
-		# Get current session identifiers
-		current_tty=$(tty | sed 's:/dev/::')  # e.g., "tty1"
-		current_pid=$$
-
-		# Kill ONLY other active root SHELL sessions (not login processes)
-		ps -u root -o pid,tty,comm |
-		  awk -v me="$current_tty" -v mypid="$current_pid" '
-		    NR>1 && $2 != "?" && $2 != me && $1 != mypid && $3 ~ /sh$/ {
-		      print $1
-		    }' |
-		  xargs --no-run-if-empty kill -9
 
 		# enable motd
 		chmod +x /etc/update-motd.d/*


### PR DESCRIPTION
Fixes #9032.

On a fresh image root is logged in on tty1, on the serial console and over ssh at the same time, and every one of those sessions runs armbian-firstlogin. Each one killed the other root shells so it could have the prompts to itself, so a session sitting at a password prompt gets SIGKILLed and the setup is left unfinished with the marker still in place. From the surviving session it looks like the login hangs. This takes /run/armbian-firstlogin.lock instead: the first session runs the setup, the others print one line and exit. The kill block is then unnecessary and removed, along with its habit of killing unrelated root shells that happen to end in sh. Flock comes from util-linux, which is Essential, so it is always present.

that was catched up and fixed, also reproduced and tested. i think this should be merged, i couldn't imagine more idiomatic solution to this.

**Board: Orange Pi Zero (Allwinner H3, 4× Cortex-A7), Armbian community 26.11 trunk, Debian trixie, kernel 6.18.44-current-sunxi.**

setup mirrors the preset from the report:
```
# /root/.not_logged_in_yet
PRESET_ROOT_PASSWORD="123"
```
with a preset password the script skips the prompt and goes straight to the kill block, which makes the race deterministic. two root logins over ssh, started at the same moment.

**before (current main)  - first run, both sessions killed:**

```
systemd[1]: Started session-15.scope - Session 15 of User root.
systemd[1]: Started session-16.scope - Session 16 of User root.
systemd[1]: session-16.scope: Deactivated successfully.
systemd[1]: session-15.scope: Deactivated successfully.

```
**second run, one session killed 7 s in, its transcript cut mid-banner:**

```
[  0.0s] A: spawned
[  0.0s] B: spawned
[  7.0s] B: PTY CLOSED   (ssh rc=255)


Waiting for system to finish booting ...
Welcome to Armbian_community!
Documentation: https://docs.armbian.com | Community su     <-- cut
```
**after (this PR):**

A: alive=True  steppedaside=False  shell_responded=False   <- owns the setup
B: alive=True  steppedaside=True   shell_responded=True   

B printed First login setup is already running in another session., dropped to a normal shell and answered a command; A kept the prompts. Nothing was killed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented multiple first-login setup sessions from running simultaneously.
  * Setup now exits gracefully when another session is already active.
  * Removed behavior that could forcibly terminate other root shell sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->