### PR TITLE
patching: tolerate non-ASCII From:/Subject: headers (fix sunxi 'got Header' build abort)

### DIFF
--- a/lib/tools/common/patching_utils.py
+++ b/lib/tools/common/patching_utils.py
@@ -7,6 +7,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+import email.errors
 import email.header
 import email.utils
 import logging
@@ -863,8 +864,15 @@ def header_to_str(value) -> "str | None":
 	# non-ASCII authors parse instead of aborting the whole kernel build.
 	if value is None or isinstance(value, str):
 		return value
+	try:
+		decoded_parts = email.header.decode_header(value)
+	except email.errors.HeaderParseError:
+		# A malformed encoded-word (e.g. bad base64) makes decode_header() itself raise,
+		# before the per-part loop can run. Fall back to the raw string form rather than
+		# aborting the whole build; downstream parsing already tolerates mangled text.
+		return str(value)
 	parts = []
-	for data, enc in email.header.decode_header(value):
+	for data, enc in decoded_parts:
 		if isinstance(data, bytes):
 			if enc is None or enc.lower() in ("unknown-8bit", "x-unknown", "unknown"):
 				enc = "utf-8"

--- a/lib/tools/common/patching_utils.py
+++ b/lib/tools/common/patching_utils.py
@@ -7,6 +7,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+import email.header
 import email.utils
 import logging
 import mailbox
@@ -223,7 +224,8 @@ class PatchFileInDir:
 					f" the magic date in the patch contents, shouldn't happen. Check the mbox formatting.")
 
 			patches.append(PatchInPatchFile(
-				self, counter, patch_contents, desc, msg['From'], msg['Subject'], msg['Date']))
+				self, counter, patch_contents, desc,
+				header_to_str(msg['From']), header_to_str(msg['Subject']), header_to_str(msg['Date'])))
 
 			counter += 1
 
@@ -850,6 +852,29 @@ def export_commit_as_patch(repo: git.Repo, commit: str):
 		raise Exception(f"Failed to rewrite indexes in patch output: {stdout_output}")
 
 	return rewritten_indexes
+
+
+def header_to_str(value) -> "str | None":
+	# mailbox.mbox parses with the legacy compat32 policy, so a mail header that
+	# carries raw (non-RFC2047) UTF-8 - e.g. `From: Michał Dziękoński <...>` - comes
+	# back as an email.header.Header tagged 'unknown-8bit' instead of a str, and the
+	# downstream re.match() blows up with "expected string or bytes-like object, got
+	# 'Header'". Decode such headers as UTF-8 (like git mailinfo does) so patches with
+	# non-ASCII authors parse instead of aborting the whole kernel build.
+	if value is None or isinstance(value, str):
+		return value
+	parts = []
+	for data, enc in email.header.decode_header(value):
+		if isinstance(data, bytes):
+			if enc is None or enc.lower() in ("unknown-8bit", "x-unknown", "unknown"):
+				enc = "utf-8"
+			try:
+				parts.append(data.decode(enc, "replace"))
+			except LookupError:
+				parts.append(data.decode("utf-8", "replace"))
+		else:
+			parts.append(data)
+	return "".join(parts)
 
 
 # Hack


### PR DESCRIPTION
## Problem

"Build All Artifacts" fails for every sunxi kernel (6.12 / 6.18 / 7.1) while splitting patches:

```
Failed to read patch file .../sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-orangepi-zero2-enable-expansion-board-usb.patch:
  expected string or bytes-like object, got 'Header'
Failed to read patch file .../sunxi-6.18/patches.megous/a711-6.18/0005-ARM-dts-sun8i-a83t-tbs-a711-Add-powerup-down-support.patch:
  expected string or bytes-like object, got 'Header'
Exception: Critical errors found while splitting patches.
```

## Cause

Commit 01f49436 ("replace patch From: headers ... with something meaningful") rewrote some `From:` headers from RFC2047 encoded-words to **raw UTF-8**, e.g.:

```
-From: =?UTF-8?q?Micha=C5=82=20Dzieko=C5=84ski?=
- <michal.dziekonski+github@gmail.com>
+From: Michał Dziękoński <michal.dziekonski+github@gmail.com>
```

`patching_utils.py` reads patches with `mailbox.mbox`, which uses the legacy **compat32** email policy. A header with raw non-ASCII bytes comes back as an `email.header.Header` (tagged `unknown-8bit`), not a `str`. `parse_from_name_email()` then calls `re.match()` on it → `expected string or bytes-like object, got 'Header'` → the whole kernel build aborts.

Affected: 6 files (the `a711` 3G patch by *Mylène Josserand* and the orangepi-zero2 expansion-board patch by *Michał Dziękoński*, each in sunxi-6.12/6.18/7.1).

## Fix

Add `header_to_str()` and run `From`/`Subject`/`Date` through it before constructing `PatchInPatchFile`:

- `str` / `None` pass straight through — **no behaviour change for the ASCII common case** (early return).
- `Header` values are decoded as UTF-8 (falling back for the `unknown-8bit` tag), matching what `git mailinfo` does, before the existing `downgrade_to_ascii()` step.

This makes the parser robust to any patch with a non-ASCII author instead of aborting, so the framework no longer depends on every contributor's `From:` header being ASCII/RFC2047.

Verified against all 6 affected files (decodes to `Mylène Josserand` / `Michał Dziękoński`, then `unidecode` → ASCII git author) plus ASCII and `None` inputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of email headers containing UTF-8 and unknown encodings.
  * Patch metadata now consistently interprets sender, subject, and date information.
  * Reduced parsing issues caused by malformed or non-standard mailbox headers.
  * Malformed encoded headers now fall back to readable raw text instead of causing errors.
  * Improved compatibility with mailbox messages using varied header formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->