### PR TITLE
fix(sm8250-6.18): rebase fastrpc revert patches onto current 6.18.y

### DIFF
--- a/patch/kernel/archive/sm8250-6.18/0061-Revert-misc-fastrpc-Rename-tgid-and-pid-to-client_id.patch
+++ b/patch/kernel/archive/sm8250-6.18/0061-Revert-misc-fastrpc-Rename-tgid-and-pid-to-client_id.patch
@@ -12,10 +12,10 @@ Signed-off-by: Jiali Chen <chenjiali@radxa.com>
  1 file changed, 24 insertions(+), 24 deletions(-)
 
 diff --git a/drivers/misc/fastrpc.c b/drivers/misc/fastrpc.c
-index 53e88a1bc430..cf00fd704086 100644
+index e240b94..de4ced4 100644
 --- a/drivers/misc/fastrpc.c
 +++ b/drivers/misc/fastrpc.c
-@@ -139,14 +139,14 @@ struct fastrpc_mmap_rsp_msg {
+@@ -136,14 +136,14 @@ struct fastrpc_mmap_rsp_msg {
  };
  
  struct fastrpc_mmap_req_msg {
@@ -32,7 +32,7 @@ index 53e88a1bc430..cf00fd704086 100644
  	s32 fd;
  	s32 offset;
  	u32 flags;
-@@ -156,20 +156,20 @@ struct fastrpc_mem_map_req_msg {
+@@ -153,20 +153,20 @@ struct fastrpc_mem_map_req_msg {
  };
  
  struct fastrpc_munmap_req_msg {
@@ -56,7 +56,7 @@ index 53e88a1bc430..cf00fd704086 100644
  	int tid;		/* thread id */
  	u64 ctx;		/* invoke caller context */
  	u32 handle;	/* handle to invoke */
-@@ -234,7 +234,7 @@ struct fastrpc_invoke_ctx {
+@@ -231,7 +231,7 @@ struct fastrpc_invoke_ctx {
  	int nbufs;
  	int retval;
  	int pid;
@@ -65,7 +65,7 @@ index 53e88a1bc430..cf00fd704086 100644
  	u32 sc;
  	u32 *crc;
  	u64 ctxid;
-@@ -614,7 +614,7 @@ static struct fastrpc_invoke_ctx *fastrpc_context_alloc(
+@@ -663,7 +663,7 @@ static struct fastrpc_invoke_ctx *fastrpc_context_alloc(
  	ctx->sc = sc;
  	ctx->retval = -1;
  	ctx->pid = current->pid;
@@ -74,7 +74,7 @@ index 53e88a1bc430..cf00fd704086 100644
  	ctx->cctx = cctx;
  	init_completion(&ctx->work);
  	INIT_WORK(&ctx->put_work, fastrpc_context_put_wq);
-@@ -1115,11 +1115,11 @@ static int fastrpc_invoke_send(struct fastrpc_session_ctx *sctx,
+@@ -1188,11 +1188,11 @@ static int fastrpc_invoke_send(struct fastrpc_session_ctx *sctx,
  	int ret;
  
  	cctx = fl->cctx;
@@ -88,7 +88,7 @@ index 53e88a1bc430..cf00fd704086 100644
  
  	msg->ctx = ctx->ctxid | fl->pd;
  	msg->handle = handle;
-@@ -1244,7 +1244,7 @@ static int fastrpc_init_create_static_process(struct fastrpc_user *fl,
+@@ -1319,7 +1319,7 @@ static int fastrpc_init_create_static_process(struct fastrpc_user *fl,
  	int err;
  	bool scm_done = false;
  	struct {
@@ -97,16 +97,16 @@ index 53e88a1bc430..cf00fd704086 100644
  		u32 namelen;
  		u32 pageslen;
  	} inbuf;
-@@ -1293,7 +1293,7 @@ static int fastrpc_init_create_static_process(struct fastrpc_user *fl,
- 		}
+@@ -1344,7 +1344,7 @@ static int fastrpc_init_create_static_process(struct fastrpc_user *fl,
+ 		err = PTR_ERR(name);
+ 		goto err;
  	}
- 
 -	inbuf.client_id = fl->client_id;
 +	inbuf.pgid = fl->client_id;
  	inbuf.namelen = init.namelen;
  	inbuf.pageslen = 0;
- 	fl->pd = USER_PD;
-@@ -1363,7 +1363,7 @@ static int fastrpc_init_create_process(struct fastrpc_user *fl,
+ 	if (!fl->cctx->remote_heap) {
+@@ -1439,7 +1439,7 @@ static int fastrpc_init_create_process(struct fastrpc_user *fl,
  	int memlen;
  	int err;
  	struct {
@@ -115,7 +115,7 @@ index 53e88a1bc430..cf00fd704086 100644
  		u32 namelen;
  		u32 filelen;
  		u32 pageslen;
-@@ -1395,7 +1395,7 @@ static int fastrpc_init_create_process(struct fastrpc_user *fl,
+@@ -1471,7 +1471,7 @@ static int fastrpc_init_create_process(struct fastrpc_user *fl,
  		goto err;
  	}
  
@@ -124,7 +124,7 @@ index 53e88a1bc430..cf00fd704086 100644
  	inbuf.namelen = strlen(current->comm) + 1;
  	inbuf.filelen = init.filelen;
  	inbuf.pageslen = 1;
-@@ -1504,12 +1504,12 @@ static void fastrpc_session_free(struct fastrpc_channel_ctx *cctx,
+@@ -1580,12 +1580,12 @@ static void fastrpc_session_free(struct fastrpc_channel_ctx *cctx,
  static int fastrpc_release_current_dsp_process(struct fastrpc_user *fl)
  {
  	struct fastrpc_invoke_args args[1];
@@ -141,7 +141,7 @@ index 53e88a1bc430..cf00fd704086 100644
  	args[0].fd = -1;
  	sc = FASTRPC_SCALARS(FASTRPC_RMID_INIT_RELEASE, 1, 0);
  
-@@ -1649,11 +1649,11 @@ static int fastrpc_dmabuf_alloc(struct fastrpc_user *fl, char __user *argp)
+@@ -1705,11 +1705,11 @@ static int fastrpc_dmabuf_alloc(struct fastrpc_user *fl, char __user *argp)
  static int fastrpc_init_attach(struct fastrpc_user *fl, int pd)
  {
  	struct fastrpc_invoke_args args[1];
@@ -156,7 +156,7 @@ index 53e88a1bc430..cf00fd704086 100644
  	args[0].fd = -1;
  	sc = FASTRPC_SCALARS(FASTRPC_RMID_INIT_ATTACH, 1, 0);
  	fl->pd = pd;
-@@ -1805,7 +1805,7 @@ static int fastrpc_req_munmap_impl(struct fastrpc_user *fl, struct fastrpc_buf *
+@@ -1849,7 +1849,7 @@ static int fastrpc_req_munmap_impl(struct fastrpc_user *fl, struct fastrpc_buf *
  	int err;
  	u32 sc;
  
@@ -165,7 +165,7 @@ index 53e88a1bc430..cf00fd704086 100644
  	req_msg.size = buf->size;
  	req_msg.vaddr = buf->raddr;
  
-@@ -1891,7 +1891,7 @@ static int fastrpc_req_mmap(struct fastrpc_user *fl, char __user *argp)
+@@ -1941,7 +1941,7 @@ static int fastrpc_req_mmap(struct fastrpc_user *fl, char __user *argp)
  		return err;
  	}
  
@@ -174,7 +174,7 @@ index 53e88a1bc430..cf00fd704086 100644
  	req_msg.flags = req.flags;
  	req_msg.vaddr = req.vaddrin;
  	req_msg.num = sizeof(pages);
-@@ -1980,7 +1980,7 @@ static int fastrpc_req_mem_unmap_impl(struct fastrpc_user *fl, struct fastrpc_me
+@@ -2030,7 +2030,7 @@ static int fastrpc_req_mem_unmap_impl(struct fastrpc_user *fl, struct fastrpc_me
  		return -EINVAL;
  	}
  
@@ -183,7 +183,7 @@ index 53e88a1bc430..cf00fd704086 100644
  	req_msg.len = map->len;
  	req_msg.vaddrin = map->raddr;
  	req_msg.fd = map->fd;
-@@ -2033,7 +2033,7 @@ static int fastrpc_req_mem_map(struct fastrpc_user *fl, char __user *argp)
+@@ -2083,7 +2083,7 @@ static int fastrpc_req_mem_map(struct fastrpc_user *fl, char __user *argp)
  		return err;
  	}
  

--- a/patch/kernel/archive/sm8250-6.18/0062-Revert-misc-fastrpc-Add-support-for-multiple-PD-from.patch
+++ b/patch/kernel/archive/sm8250-6.18/0062-Revert-misc-fastrpc-Add-support-for-multiple-PD-from.patch
@@ -12,10 +12,10 @@ Signed-off-by: Jiali Chen <chenjiali@radxa.com>
  1 file changed, 14 insertions(+), 16 deletions(-)
 
 diff --git a/drivers/misc/fastrpc.c b/drivers/misc/fastrpc.c
-index cf00fd704086..3d6fcadc66b8 100644
+index de4ced4..47410c2 100644
 --- a/drivers/misc/fastrpc.c
 +++ b/drivers/misc/fastrpc.c
-@@ -299,7 +299,7 @@ struct fastrpc_user {
+@@ -296,7 +296,7 @@ struct fastrpc_user {
  	struct fastrpc_session_ctx *sctx;
  	struct fastrpc_buf *init_mem;
  
@@ -24,7 +24,7 @@ index cf00fd704086..3d6fcadc66b8 100644
  	int pd;
  	bool is_secure_dev;
  	/* Lock for lists */
-@@ -614,7 +614,7 @@ static struct fastrpc_invoke_ctx *fastrpc_context_alloc(
+@@ -663,7 +663,7 @@ static struct fastrpc_invoke_ctx *fastrpc_context_alloc(
  	ctx->sc = sc;
  	ctx->retval = -1;
  	ctx->pid = current->pid;
@@ -33,7 +33,7 @@ index cf00fd704086..3d6fcadc66b8 100644
  	ctx->cctx = cctx;
  	init_completion(&ctx->work);
  	INIT_WORK(&ctx->put_work, fastrpc_context_put_wq);
-@@ -1115,7 +1115,7 @@ static int fastrpc_invoke_send(struct fastrpc_session_ctx *sctx,
+@@ -1188,7 +1188,7 @@ static int fastrpc_invoke_send(struct fastrpc_session_ctx *sctx,
  	int ret;
  
  	cctx = fl->cctx;
@@ -42,16 +42,16 @@ index cf00fd704086..3d6fcadc66b8 100644
  	msg->tid = current->pid;
  
  	if (kernel)
-@@ -1293,7 +1293,7 @@ static int fastrpc_init_create_static_process(struct fastrpc_user *fl,
- 		}
+@@ -1344,7 +1344,7 @@ static int fastrpc_init_create_static_process(struct fastrpc_user *fl,
+ 		err = PTR_ERR(name);
+ 		goto err;
  	}
- 
 -	inbuf.pgid = fl->client_id;
 +	inbuf.pgid = fl->tgid;
  	inbuf.namelen = init.namelen;
  	inbuf.pageslen = 0;
- 	fl->pd = USER_PD;
-@@ -1395,7 +1395,7 @@ static int fastrpc_init_create_process(struct fastrpc_user *fl,
+ 	if (!fl->cctx->remote_heap) {
+@@ -1471,7 +1471,7 @@ static int fastrpc_init_create_process(struct fastrpc_user *fl,
  		goto err;
  	}
  
@@ -60,7 +60,7 @@ index cf00fd704086..3d6fcadc66b8 100644
  	inbuf.namelen = strlen(current->comm) + 1;
  	inbuf.filelen = init.filelen;
  	inbuf.pageslen = 1;
-@@ -1469,9 +1469,8 @@ static int fastrpc_init_create_process(struct fastrpc_user *fl,
+@@ -1545,9 +1545,8 @@ err:
  }
  
  static struct fastrpc_session_ctx *fastrpc_session_alloc(
@@ -71,7 +71,7 @@ index cf00fd704086..3d6fcadc66b8 100644
  	struct fastrpc_session_ctx *session = NULL;
  	unsigned long flags;
  	int i;
-@@ -1481,8 +1480,6 @@ static struct fastrpc_session_ctx *fastrpc_session_alloc(
+@@ -1557,8 +1556,6 @@ static struct fastrpc_session_ctx *fastrpc_session_alloc(
  		if (!cctx->session[i].used && cctx->session[i].valid) {
  			cctx->session[i].used = true;
  			session = &cctx->session[i];
@@ -80,7 +80,7 @@ index cf00fd704086..3d6fcadc66b8 100644
  			break;
  		}
  	}
-@@ -1507,7 +1504,7 @@ static int fastrpc_release_current_dsp_process(struct fastrpc_user *fl)
+@@ -1583,7 +1580,7 @@ static int fastrpc_release_current_dsp_process(struct fastrpc_user *fl)
  	int tgid = 0;
  	u32 sc;
  
@@ -89,7 +89,7 @@ index cf00fd704086..3d6fcadc66b8 100644
  	args[0].ptr = (u64)(uintptr_t) &tgid;
  	args[0].length = sizeof(tgid);
  	args[0].fd = -1;
-@@ -1582,10 +1579,11 @@ static int fastrpc_device_open(struct inode *inode, struct file *filp)
+@@ -1637,10 +1634,11 @@ static int fastrpc_device_open(struct inode *inode, struct file *filp)
  	INIT_LIST_HEAD(&fl->maps);
  	INIT_LIST_HEAD(&fl->mmaps);
  	INIT_LIST_HEAD(&fl->user);
@@ -102,7 +102,7 @@ index cf00fd704086..3d6fcadc66b8 100644
  	if (!fl->sctx) {
  		dev_err(&cctx->rpdev->dev, "No session available\n");
  		mutex_destroy(&fl->mutex);
-@@ -1649,7 +1647,7 @@ static int fastrpc_dmabuf_alloc(struct fastrpc_user *fl, char __user *argp)
+@@ -1705,7 +1703,7 @@ static int fastrpc_dmabuf_alloc(struct fastrpc_user *fl, char __user *argp)
  static int fastrpc_init_attach(struct fastrpc_user *fl, int pd)
  {
  	struct fastrpc_invoke_args args[1];
@@ -111,7 +111,7 @@ index cf00fd704086..3d6fcadc66b8 100644
  	u32 sc;
  
  	args[0].ptr = (u64)(uintptr_t) &tgid;
-@@ -1805,7 +1803,7 @@ static int fastrpc_req_munmap_impl(struct fastrpc_user *fl, struct fastrpc_buf *
+@@ -1849,7 +1847,7 @@ static int fastrpc_req_munmap_impl(struct fastrpc_user *fl, struct fastrpc_buf *
  	int err;
  	u32 sc;
  
@@ -120,7 +120,7 @@ index cf00fd704086..3d6fcadc66b8 100644
  	req_msg.size = buf->size;
  	req_msg.vaddr = buf->raddr;
  
-@@ -1891,7 +1889,7 @@ static int fastrpc_req_mmap(struct fastrpc_user *fl, char __user *argp)
+@@ -1941,7 +1939,7 @@ static int fastrpc_req_mmap(struct fastrpc_user *fl, char __user *argp)
  		return err;
  	}
  
@@ -129,7 +129,7 @@ index cf00fd704086..3d6fcadc66b8 100644
  	req_msg.flags = req.flags;
  	req_msg.vaddr = req.vaddrin;
  	req_msg.num = sizeof(pages);
-@@ -1980,7 +1978,7 @@ static int fastrpc_req_mem_unmap_impl(struct fastrpc_user *fl, struct fastrpc_me
+@@ -2030,7 +2028,7 @@ static int fastrpc_req_mem_unmap_impl(struct fastrpc_user *fl, struct fastrpc_me
  		return -EINVAL;
  	}
  
@@ -138,7 +138,7 @@ index cf00fd704086..3d6fcadc66b8 100644
  	req_msg.len = map->len;
  	req_msg.vaddrin = map->raddr;
  	req_msg.fd = map->fd;
-@@ -2033,7 +2031,7 @@ static int fastrpc_req_mem_map(struct fastrpc_user *fl, char __user *argp)
+@@ -2083,7 +2081,7 @@ static int fastrpc_req_mem_map(struct fastrpc_user *fl, char __user *argp)
  		return err;
  	}
  


### PR DESCRIPTION
## Problem

`kernel-sm8250-current` (6.18) fails in "Build All Artifacts":

```
Problem with ->0061-Revert-misc-fastrpc-Rename-tgid-and-pid-to-client_id ... {fastrpc.c}
Problem with ->0062-Revert-misc-fastrpc-Add-support-for-multiple-PD-from ... {fastrpc.c}
  1 out of 15 hunks FAILED
Exception: Failed to apply 2 patches.
```

## Cause

`0061`/`0062` revert two upstream fastrpc commits (`ff5e0c847042`, `37d56e0fb08e`) to keep the vendor fastrpc ABI. The `linux-6.18.y` stable branch has drifted since they were generated: `drivers/misc/fastrpc.c` moved by **+50..+76 lines**, and hunk 7 of `0061` needs **fuzz 3** — beyond the patcher's tolerance — so it rejects (`1/15 hunks FAILED`) and the whole kernel build aborts. The reverted commits are still present in 6.18.y, so the reverts are wanted; this is pure context drift.

## Fix

Re-anchor both reverts against the current `linux-6.18.y` `fastrpc.c`. Only the `@@` hunk offsets change — the reverted content, mbox headers and diffstats are unchanged (still 24/24 and 14/16).

**Verified:** both apply at **fuzz 0, exact offset**, in sequence, against the live `linux-6.18.y` `drivers/misc/fastrpc.c`.

Third of three unrelated failures in that run — separate from the sunxi header crash (#10481) and the rockchip64 already-upstream drop (#10482).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored FastRPC process and session identification behavior for improved protocol compatibility.
  * Corrected process ID handling across invocation, process creation, attachment, release, mapping, and unmapping operations.
  * Reverted multiple-PD client ID handling to use the process identity consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->