### PR TITLE
recomputer-rk3588: do not fail the image when Panthor firmware is absent

### DIFF
--- a/config/boards/recomputer-rk3588-devkit.conf
+++ b/config/boards/recomputer-rk3588-devkit.conf
@@ -78,6 +78,17 @@ function pre_update_initramfs__recomputer_rk3588_install_panthor_firmware() {
 	[[ "${RECOMPUTER_GPU_STACK}" == "panthor" ]] || return 0
 
 	local root_dir="${MOUNT:-${SDCARD}}"
+	local fw_target="${root_dir}/lib/firmware/arm/mali/arch10.8/mali_csffw.bin"
+
+	# armbian-firmware ships arm/mali/arch10.8/mali_csffw.bin already, so on a
+	# normal image build the firmware is in place before this hook runs.
+	if [[ -f "${fw_target}" ]]; then
+		display_alert "Panthor firmware" "already provided by armbian-firmware" "info"
+		return 0
+	fi
+
+	# Fallback for a build that has kernel sources at hand - a local
+	# ./compile.sh, where the vendor tree carries the same blob.
 	local fw_src=""
 	local -a fw_candidates=(
 		"${SRC}/cache/sources/${LINUXSOURCEDIR:-}/drivers/gpu/arm/bifrost/mali_csffw.bin"
@@ -92,10 +103,18 @@ function pre_update_initramfs__recomputer_rk3588_install_panthor_firmware() {
 		fi
 	done
 
-	[[ -n "${fw_src}" ]] || exit_with_error "Panthor firmware not found" "mali_csffw.bin"
+	# Not fatal. Every candidate above is a kernel source tree, and an image
+	# build assembled from cached artifacts has none - the kernel arrives as a
+	# prebuilt .deb - so this used to kill the image at the very last step, after
+	# the rootfs and /boot had already been written. Without the blob Panthor
+	# does not accelerate; the image is otherwise complete and bootable.
+	if [[ -z "${fw_src}" ]]; then
+		display_alert "Panthor firmware not found" "mali_csffw.bin - GPU acceleration will be unavailable" "wrn"
+		return 0
+	fi
 
 	display_alert "Panthor firmware" "Installing ${fw_src}" "info"
-	install -Dm0644 "${fw_src}" "${root_dir}/lib/firmware/arm/mali/arch10.8/mali_csffw.bin"
+	install -Dm0644 "${fw_src}" "${fw_target}"
 }
 
 # Install RK camera engine package for RK3588


### PR DESCRIPTION
Fixes the failure in [this build](https://paste.armbian.com/ebetokosin):

```
ERROR: error! [ Panthor firmware not found mali_csffw.bin ]
  pre_update_initramfs__recomputer_rk3588_install_panthor_firmware()
    --> config/boards/recomputer-rk3588-devkit.conf:95
ERROR: Exiting with error 43
```

## Cause

The hook searched for `mali_csffw.bin` in three places, all of them **kernel source trees**. An image build assembled from cached artifacts has none — the kernel arrives as a prebuilt `.deb`:

```
install /root/linux-image-vendor-seeed-rk3588_26.8.2_arm64__6.1.115-….deb
```

`LINUXSOURCEDIR` is still *set* (`linux-kernel-worktree/6.1__seeed-rk3588__arm64`) because it is a config variable, which makes the miss look surprising, but nothing ever cloned that tree. So the hook works for a local `./compile.sh` and fails for every CI image build — and it fails at the very last step, after the rootfs and `/boot` have already been rsynced into the image.

## It was also redundant

`armbian-firmware` is built from the armbian/firmware repo:

```bash
git -C …/armbian-firmware-git archive --format=tar "${sha1}" | tar -C …/lib/firmware/ -xf -
```

and that repo contains `arm/mali/arch10.8/mali_csffw.bin` — exactly the path this hook installs to. The failing build had already installed the package (log line 1569), so the firmware was in the rootfs when the hook declared it missing.

## Change

1. Check the rootfs first; return early when the firmware is already there.
2. Keep the kernel-source lookup as a fallback for local builds.
3. Downgrade a miss from `exit_with_error` to a warning — without the blob Panthor does not accelerate, but the image is complete and bootable.

## Verification

All four paths exercised against the real function body:

| scenario | result |
|---|---|
| firmware already in rootfs (CI image build) | info, exit 0, no copy |
| absent, no kernel sources (the old failure) | **warning, exit 0** |
| absent, kernel worktree present (local build) | copied from source, exit 0 |
| `RECOMPUTER_GPU_STACK` != panthor | no-op, exit 0 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Panthor firmware installation by reusing firmware supplied with the system when available.
  * Builds now continue with a warning when firmware cannot be found, instead of failing.
  * Firmware is installed consistently using the configured target location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->