### PR TITLE
recomputer-rk3588-devkit: mali fw is handled by armbian-firmware

### DIFF
--- a/config/boards/recomputer-rk3588-devkit.conf
+++ b/config/boards/recomputer-rk3588-devkit.conf
@@ -74,30 +74,6 @@ function post_family_tweaks__recomputer_rk3588_install_panthor_mesa() {
 		mesa-vulkan-drivers mesa-utils vulkan-tools
 }
 
-function pre_update_initramfs__recomputer_rk3588_install_panthor_firmware() {
-	[[ "${RECOMPUTER_GPU_STACK}" == "panthor" ]] || return 0
-
-	local root_dir="${MOUNT:-${SDCARD}}"
-	local fw_src=""
-	local -a fw_candidates=(
-		"${SRC}/cache/sources/${LINUXSOURCEDIR:-}/drivers/gpu/arm/bifrost/mali_csffw.bin"
-		"${SRC}/../linux-rockchip/drivers/gpu/arm/bifrost/mali_csffw.bin"
-	)
-	fw_candidates+=("${SRC}"/cache/sources/linux-kernel-worktree/*/drivers/gpu/arm/bifrost/mali_csffw.bin)
-
-	for candidate in "${fw_candidates[@]}"; do
-		if [[ -f "${candidate}" ]]; then
-			fw_src="${candidate}"
-			break
-		fi
-	done
-
-	[[ -n "${fw_src}" ]] || exit_with_error "Panthor firmware not found" "mali_csffw.bin"
-
-	display_alert "Panthor firmware" "Installing ${fw_src}" "info"
-	install -Dm0644 "${fw_src}" "${root_dir}/lib/firmware/arm/mali/arch10.8/mali_csffw.bin"
-}
-
 # Install RK camera engine package for RK3588
 function pre_install_distribution_specific__recomputer_rk3588_install_camera_engine() {
 	display_alert "Installing camera engine from APT repo" "camera-engine-rkaiq" "info"


### PR DESCRIPTION
- 🌳 see https://github.com/armbian/firmware/tree/master/arm/mali
- 🐸 also, this would not always work as the kernel source/cache is not available on image builder machines
- 🌵 fixes 07cd7fb7538093cf6ce6cdb7f91f10e6124571c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Recomputer RK3588 DevKit setup to avoid installing legacy Panthor firmware during system image preparation.
  * Other board configuration and installation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->