### PR TITLE
v4l2loopback-dkms: raise kernel skip cutoff from 6.12 to 7.2

### DIFF
--- a/extensions/v4l2loopback-dkms.sh
+++ b/extensions/v4l2loopback-dkms.sh
@@ -13,7 +13,7 @@ function extension_finish_config__build_v4l2loopback_dkms_kernel_module() {
 }
 
 function post_install_kernel_debs__build_v4l2loopback_dkms_kernel_module() {
-	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.12; then
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 7.2; then
 		display_alert "Kernel version is too recent" "skipping v4l2loopback-dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi


### PR DESCRIPTION
## What

Raise the "kernel too recent" guard in `post_install_kernel_debs__build_v4l2loopback_dkms_kernel_module` from `>= 6.12` to `>= 7.2`.

```diff
-	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 6.12; then
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 7.2; then
```

## Why

v4l2loopback (0.15.3) now builds against the newer kernels. Confirmed on 7.1.9-edge — the DKMS module builds and installs in-chroot:

```
Building initial module v4l2loopback/0.15.3 for 7.1.9-edge-arm64
Building module(s).......... done.
Installing /lib/modules/7.1.9-edge-arm64/updates/dkms/v4l2loopback.ko
Running depmod... done.
```

So there's no reason to skip it for 6.12..7.1.x. Those kernels get the module again; 7.2+ stays guarded until verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated v4l2loopback-dkms installation handling to support kernels below version 7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->