### PR TITLE
image-output-abl: wait for loop partition node before blkid (fix flaky build)

### DIFF
--- a/extensions/image-output-abl.sh
+++ b/extensions/image-output-abl.sh
@@ -25,6 +25,10 @@ function post_build_image__900_convert_to_abl_img() {
 	mkfs.ext4 -F "${ROOTFS_IMAGE_FILE}"
 	new_rootfs_image_uuid=$(blkid -s UUID -o value "${ROOTFS_IMAGE_FILE}")
 	old_image_loop_device=$(losetup -f -P --show "${DESTIMG}/${version}.img")
+	# losetup -P scans partitions asynchronously; wait for the p1 node to appear
+	# (and let CONTAINER_COMPAT create it) before blkid/mount, otherwise blkid
+	# races the node and exits 2 -> flaky "Error 2 in SUBSHELL".
+	check_loop_device "${old_image_loop_device}p1"
 	old_rootfs_image_uuid=$(blkid -s UUID -o value "${old_image_loop_device}p1")
 	mount "${old_image_loop_device}p1" "${old_rootfs_image_mount_dir}"
 	mount "${ROOTFS_IMAGE_FILE}" "${new_rootfs_image_mount_dir}"

--- a/lib/functions/image/loop.sh
+++ b/lib/functions/image/loop.sh
@@ -11,6 +11,7 @@
 # check_loop_device <device_node>
 #
 function check_loop_device() {
+	local device="${1}" # $device is local to check_loop_device_internal; keep our own for the error message
 	do_with_retries 5 check_loop_device_internal "${@}" || {
 		exit_with_error "Device node ${device} does not exist after 5 tries."
 	}


### PR DESCRIPTION
## Symptom

sm8250 (xiaomi-sheng) ABL image builds fail intermittently in the `image-output-abl` extension:

```
Error  2 occurred in SUBSHELL [ SUBSHELL at /armbian/extensions/image-output-abl.sh:28 ]
  post_build_image__900_convert_to_abl_img() --> extensions/image-output-abl.sh:28
```

(The job usually passes on the docker-run retry — hence flaky.)

## Cause

```bash
old_image_loop_device=$(losetup -f -P --show "...img")
old_rootfs_image_uuid=$(blkid -s UUID -o value "${old_image_loop_device}p1")   # line 28
```

`losetup -P` scans partitions **asynchronously**, so the immediate `blkid` on `${loop}p1` races the device-node creation. When the node isn't ready yet, `blkid` exits `2` ("nothing to display"), the command-substitution subshell fails, and the build aborts. On the retry the node is present, so it passes.

## Fix

Call the framework's `check_loop_device "${loop}p1"` right after `losetup` — it retries 5× for the node (and `mknod`s it under `CONTAINER_COMPAT`), exactly as `partitioning.sh` already does. The node is then guaranteed present before `blkid`/`mount`, making the conversion deterministic instead of racing.

Same loop-partition-node class as the K3picoitx image failure, but here the extension does its own raw `losetup` outside the partitioning path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image handling by waiting for the first partition to become available before identifying and mounting it.
  * Reduced the risk of intermittent failures during image setup.
  * Improved error reporting when a loop device is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->