### PR TITLE
arm64: dts: rockchip: rk3588s-orangepi-5: route ES8388 MCLK to the IO…

### DIFF
--- a/patch/kernel/archive/rockchip64-7.1/board-orangepi-5-es8388-route-mclk-to-io.patch
+++ b/patch/kernel/archive/rockchip64-7.1/board-orangepi-5-es8388-route-mclk-to-io.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: defcom5-rockchip <defcom5rockchip@proton.me>
+Date: Fri, 21 Aug 2026 21:43:53 -0700
+Subject: [PATCH] arm64: dts: rockchip: rk3588s-orangepi-5: route ES8388 MCLK
+ to the IO pin
+
+Analog audio through the on-board ES8388 codec is silent on the Orange Pi 5
+and 5B: the codec's master clock (MCLK) never reaches its pin.
+
+On RK3588(S) the I2S MCLK-to-IO routing is gated in SYS_GRF SOC_CON6 (bit 1
+for I2S1). U-Boot leaves this gate disabled, so the 12.288 MHz MCLK is
+generated inside the SoC but is never driven out to the ES8388. The codec
+cannot run; and because the board wires it as the I2S bit/frame master, the
+rockchip-i2s-tdm controller never receives a valid clock and aborts with
+"clear failed, reset txrx".
+
+The clock driver already models this route as I2S1_8CH_MCLKOUT_TO_IO (a
+GATE_GRF clock), but no board referenced it, so it stayed gated on every
+distribution tested. Point the es8388 node's "clocks" at
+I2S1_8CH_MCLKOUT_TO_IO so the codec driver enables the gate in
+clk_prepare_enable() at probe; "assigned-clocks" stays on I2S1_8CH_MCLKOUT to
+keep the 12.288 MHz rate.
+
+Enabling the route at codec probe (rather than forcing it on at clock init)
+is deliberate: on the 5B the I2S1 (M1 mux) pins live in the GPIO0/PMU domain
+shared with the FSPI/SPI0_M0 boot-flash interface (e.g. I2S1_LRCK =
+SPI0_CS1_M0, I2S1_SDI1 = SPI0_CLK_M0), and the board straps its boot source
+on SARADC_VIN0. Driving those lines during the boot-strap window (which a
+forced-on gate does, aggravated by a headphone load on the jack) stalls
+boot; opening the gate at codec probe is safely past that window.
+
+The es8388 node is shared by the Orange Pi 5 and 5B. The Orange Pi 5 Pro
+overrides it (codec on I2S2) and is unaffected.
+
+Signed-off-by: defcom5-rockchip <defcom5rockchip@proton.me>
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
+index 1111111111111..2222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
+@@ -273,7 +273,7 @@
+ 	es8388: audio-codec@10 {
+ 		compatible = "everest,es8388", "everest,es8328";
+ 		reg = <0x10>;
+-		clocks = <&cru I2S1_8CH_MCLKOUT>;
++		clocks = <&cru I2S1_8CH_MCLKOUT_TO_IO>;
+ 		AVDD-supply = <&vcc_3v3_s0>;
+ 		DVDD-supply = <&vcc_1v8_s0>;
+ 		HPVDD-supply = <&vcc_3v3_s0>;
+-- 
+Armbian

--- a/patch/kernel/archive/rockchip64-7.2/board-orangepi-5-es8388-route-mclk-to-io.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-orangepi-5-es8388-route-mclk-to-io.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: defcom5-rockchip <defcom5rockchip@proton.me>
+Date: Fri, 21 Aug 2026 21:43:53 -0700
+Subject: [PATCH] arm64: dts: rockchip: rk3588s-orangepi-5: route ES8388 MCLK
+ to the IO pin
+
+Analog audio through the on-board ES8388 codec is silent on the Orange Pi 5
+and 5B: the codec's master clock (MCLK) never reaches its pin.
+
+On RK3588(S) the I2S MCLK-to-IO routing is gated in SYS_GRF SOC_CON6 (bit 1
+for I2S1). U-Boot leaves this gate disabled, so the 12.288 MHz MCLK is
+generated inside the SoC but is never driven out to the ES8388. The codec
+cannot run; and because the board wires it as the I2S bit/frame master, the
+rockchip-i2s-tdm controller never receives a valid clock and aborts with
+"clear failed, reset txrx".
+
+The clock driver already models this route as I2S1_8CH_MCLKOUT_TO_IO (a
+GATE_GRF clock), but no board referenced it, so it stayed gated on every
+distribution tested. Point the es8388 node's "clocks" at
+I2S1_8CH_MCLKOUT_TO_IO so the codec driver enables the gate in
+clk_prepare_enable() at probe; "assigned-clocks" stays on I2S1_8CH_MCLKOUT to
+keep the 12.288 MHz rate.
+
+Enabling the route at codec probe (rather than forcing it on at clock init)
+is deliberate: on the 5B the I2S1 (M1 mux) pins live in the GPIO0/PMU domain
+shared with the FSPI/SPI0_M0 boot-flash interface (e.g. I2S1_LRCK =
+SPI0_CS1_M0, I2S1_SDI1 = SPI0_CLK_M0), and the board straps its boot source
+on SARADC_VIN0. Driving those lines during the boot-strap window (which a
+forced-on gate does, aggravated by a headphone load on the jack) stalls
+boot; opening the gate at codec probe is safely past that window.
+
+The es8388 node is shared by the Orange Pi 5 and 5B. The Orange Pi 5 Pro
+overrides it (codec on I2S2) and is unaffected.
+
+Signed-off-by: defcom5-rockchip <defcom5rockchip@proton.me>
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
+index 1111111111111..2222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
+@@ -273,7 +273,7 @@
+ 	es8388: audio-codec@10 {
+ 		compatible = "everest,es8388", "everest,es8328";
+ 		reg = <0x10>;
+-		clocks = <&cru I2S1_8CH_MCLKOUT>;
++		clocks = <&cru I2S1_8CH_MCLKOUT_TO_IO>;
+ 		AVDD-supply = <&vcc_3v3_s0>;
+ 		DVDD-supply = <&vcc_1v8_s0>;
+ 		HPVDD-supply = <&vcc_3v3_s0>;
+-- 
+Armbian


### PR DESCRIPTION
## Summary
One-line device-tree change: point the on-board ES8388 codec's `clocks` at
`I2S1_8CH_MCLKOUT_TO_IO` instead of the internal mux `I2S1_8CH_MCLKOUT`, so the codec
opens the SoC's MCLK-to-IO gate at probe. Fixes **silent 3.5 mm analog audio** on the
Orange Pi 5 and 5B.

```diff
 	es8388: audio-codec@10 {
 		compatible = "everest,es8388", "everest,es8328";
 		reg = <0x10>;
-		clocks = <&cru I2S1_8CH_MCLKOUT>;
+		clocks = <&cru I2S1_8CH_MCLKOUT_TO_IO>;
 		...
 		assigned-clocks = <&cru I2S1_8CH_MCLKOUT>;   /* unchanged: 12.288 MHz rate */
 		assigned-clock-rates = <12288000>;
```

## Root cause
The ES8388's MCLK never reaches its pin. On RK3588(S) the I2S MCLK-to-IO routing is a
gate in **SYS_GRF `SOC_CON6`, bit 1** (for I2S1). **U-Boot leaves that gate disabled**
(`0xfd58c318` reads `0x…7C7`, bit1=1), so the 12.288 MHz MCLK is generated *inside* the
SoC but is never driven out to the codec. The ES8388 can't run; and because the board
wires it as the I2S bit/frame **master**, the `rockchip-i2s-tdm` controller never gets a
valid clock and aborts:

```
rockchip-i2s-tdm fe480000.i2s: clear failed, reset txrx
```

The clock driver already models this route as `I2S1_8CH_MCLKOUT_TO_IO` (a `GATE_GRF`),
but **no board referenced it**, so it stayed gated on every distribution. Referencing it
from the codec's `clocks` makes the ES8388 driver enable it in `clk_prepare_enable()` at
probe (`0xfd58c318` → `0x…7C5`, bit1=0); the `i2s1_8ch_mclkout_to_io` clock then shows
consumer `6-0010` (the codec). `assigned-clocks` stays on the mux for the 12.288 MHz rate.

## Why *codec-probe* timing, not a forced-on clock
On the 5B the I2S1 (M1 mux) pins are in the **GPIO0 / PMU domain shared with the FSPI /
SPI0_M0 boot-flash interface** — traced in the 5B schematic:
- `I2S1_LRCK` = `SPI0_CS1_M0` (GPIO0_B6)
- `I2S1_SDI1` = `SPI0_CLK_M0` (GPIO0_C5)

and the board straps its boot source on `SARADC_VIN0` (FSPI M0/M1/M2 among the options).
Forcing the gate on at *clock-init* drives these boot-domain pins during the boot-strap
window; with a headphone load on the jack this manifests as a long (~144 s) boot stall.
Opening the gate at **codec probe** is safely past that window — hence the DT-reference
approach rather than a `CLK_IS_CRITICAL` force-on.

## It's an ecosystem-wide gap (not a config quirk)
`SOC_CON6` bit1 is left = 1 by u-boot on **every** image checked — no distro ships working
5B analog out of the box:

| Distro / kernel | `0xfd58c318` | Analog OOB |
|---|---|---|
| Debian trixie, `7.1.3+deb13-arm64` | `0x…7C7` | silent |
| Debian trixie, 7.1.8 | `0x…7C7` | silent |
| Ubuntu Noble, `7.1.8-edge-rockchip64` | `0x…7C7` | silent |
| Armbian trixie, `7.1.8-edge` (official trunk) | `0x…7C7` | silent |
| Vendor BSP 6.1 | `0x…7C7` | silent |

## Scope
The `es8388` node lives in the shared `rk3588s-orangepi-5.dtsi`, so this fixes both the
**Orange Pi 5** and **5B**. The **Orange Pi 5 Pro** overrides the node (`/delete-node/` +
codec on I2S2) and is **unaffected**. The Orange Pi 5-Plus is a different SoC (RK3588,
I2S0) and out of scope.

## Testing
Verified on **stock Armbian edge**, no downstream changes beyond this one DT cell:
- **Board:** Orange Pi 5B
- **Armbian:** `26.11.0-trunk` trixie, `BRANCH=edge`
- **Kernel:** `7.1.8-edge-rockchip64` (carries SuperKali's `_TO_IO` GRF-gate series)
- **es8328 driver:** in-tree / mainline (`snd_soc_es8328` + `_i2c`)

Results (devmem/service workaround disabled):
1. Gate opens via the codec at probe — `0xfd58c318` = `0x…7C5`, `i2s1_8ch_mclkout_to_io`
   consumer = `6-0010`. ✅
2. `aplay Front_Center.wav` → clean audio, correct pitch, no EIO. ✅
3. Cold boot **with headphones in the jack** → 7.0 s, 0 failed units (no boot stall). ✅


## Credit / relation to prior work
This **completes** SuperKali's RK3588 I2S "MCLK output to IO" GRF-gate series (which added
the `I2S1_8CH_MCLKOUT_TO_IO` clock and the SYS_GRF plumbing) by wiring the Orange Pi 5/5B
board to actually use it. Thanks to SuperKali for the infrastructure.

## Target
This PR targets the **edge** branch (which carries the `_TO_IO` gate series the reference
depends on). A mainline `linux-rockchip` submission of the same DT change is planned as the
durable follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved ES8388 audio codec initialization on Orange Pi 5 hardware.
- Corrected master-clock routing to the codec’s audio interface.
- Preserved the configured 12.288 MHz clock rate for consistent audio operation.
- Improved reliability for audio playback and recording when using supported Orange Pi 5 audio configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->