### PR TITLE
Switch the build host and default Docker image to Debian Trixie

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ cd build
 - **Architecture:** x86_64, aarch64, or riscv64
 
 ### Operating System
-- **Native builds:** Armbian or Ubuntu 24.04 (Noble)
+- **Native builds:** Armbian or Debian 13 (Trixie)
 - **Containerized:** Any Docker-capable Linux
-- **Windows:** WSL2 with Armbian/Ubuntu 24.04
+- **Windows:** WSL2 with Armbian/Debian 13 (Trixie)
 
 ### Software
 - Superuser privileges (`sudo` or root)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cd build
 - **Architecture:** x86_64, aarch64, or riscv64
 
 ### Operating System
-- **Native builds:** Armbian or Debian 13 (Trixie)
+- **Native builds:** Armbian/Debian 13 (Trixie)
 - **Containerized:** Any Docker-capable Linux
 - **Windows:** WSL2 with Armbian/Debian 13 (Trixie)
 

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -140,9 +140,6 @@ function docker_cli_prepare() {
 	[[ -z "${build_suffix}" ]] && build_suffix="$(printf '%08x' "$$")" # no sha256sum: PID hex
 	declare -g DOCKER_ARMBIAN_LOCAL_IMAGE_REPO="armbian.local.only/armbian-build"
 	declare -g DOCKER_ARMBIAN_INITIAL_IMAGE_TAG="${DOCKER_ARMBIAN_LOCAL_IMAGE_REPO}:${build_suffix}"
-	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:bookworm"}"
-	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:sid"}"
-	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"ubuntu:noble"}"
 	declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:trixie"}"
 	declare -g DOCKER_ARMBIAN_TARGET_PATH="${DOCKER_ARMBIAN_TARGET_PATH:-"/armbian"}"
 

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -140,10 +140,10 @@ function docker_cli_prepare() {
 	[[ -z "${build_suffix}" ]] && build_suffix="$(printf '%08x' "$$")" # no sha256sum: PID hex
 	declare -g DOCKER_ARMBIAN_LOCAL_IMAGE_REPO="armbian.local.only/armbian-build"
 	declare -g DOCKER_ARMBIAN_INITIAL_IMAGE_TAG="${DOCKER_ARMBIAN_LOCAL_IMAGE_REPO}:${build_suffix}"
-	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:trixie"}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:bookworm"}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:sid"}"
-	declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"ubuntu:noble"}"
+	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"ubuntu:noble"}"
+	declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:trixie"}"
 	declare -g DOCKER_ARMBIAN_TARGET_PATH="${DOCKER_ARMBIAN_TARGET_PATH:-"/armbian"}"
 
 	declare wanted_os_tag="${DOCKER_ARMBIAN_BASE_IMAGE%%:*}"


### PR DESCRIPTION
The officially supported build host moved to Armbian/Debian 13 (Trixie). This makes the framework follow, and updates the README to match.

## The default Docker image

`lib/functions/host/docker.sh` still built inside `ubuntu:noble`, with `debian:trixie` sitting commented out directly above it:

```diff
-	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${…:-"debian:trixie"}"
-	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${…:-"debian:bookworm"}"
-	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${…:-"debian:sid"}"
-	declare -g DOCKER_ARMBIAN_BASE_IMAGE="${…:-"ubuntu:noble"}"
+	declare -g DOCKER_ARMBIAN_BASE_IMAGE="${…:-"debian:trixie"}"
```

The commented-out alternatives go with it — the `:-` default already says the variable is overridable, so anyone wanting noble back can still set `DOCKER_ARMBIAN_BASE_IMAGE`.

**No new image needs publishing.** The framework derives the prebuilt base from this value (`wanted_os_tag` + `DOCKER_WANTED_RELEASE`), giving `ghcr.io/armbian/docker-armbian-build:armbian-debian-trixie-latest` — already one of the two tags the auto-pull cronjob at `docker.sh:946` fetches, so it is on the runners.

⚠️ This changes the container **every** Docker build runs in, CI included. It is the one line here that can actually affect a build.

## README

```diff
-- **Native builds:** Armbian or Ubuntu 24.04 (Noble)
+- **Native builds:** Armbian/Debian 13 (Trixie)
 - **Containerized:** Any Docker-capable Linux
-- **Windows:** WSL2 with Armbian/Ubuntu 24.04
+- **Windows:** WSL2 with Armbian/Debian 13 (Trixie)
```

## Related

- armbian/documentation#974 — same claim in `Developer-Guide_Build-Preparation.md` and the Multipass guide
- armbian/sdk#37 — SDK stops generating noble images and builds in the Trixie container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified native build requirements to reference Armbian/Debian 13 (Trixie).

* **Build Improvements**
  * Native Docker builds now use Debian 13 (Trixie) as the default base image, providing a more consistent build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->