### PR TITLE
action: include .iso images in the release assets manifest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -298,6 +298,9 @@ runs:
             ("hyperv.zip.xz",  "hyperv.zip"),
             ("hyperv.zip.zst", "hyperv.zip"),
             ("hyperv.zip",     "hyperv.zip"),
+            ("iso.xz",         "iso"),
+            ("iso.zst",        "iso"),
+            ("iso",            "iso"),
             ("img.xz",         "img"),
             ("img.zst",        "img"),
             ("img",            "img"),
@@ -306,7 +309,7 @@ runs:
         # image_format -> redi_url variant suffix (canonical generator
         # appends "-qcow2" / "-hyperv" to the friendly redirect path so a
         # board can serve multiple formats at distinct URLs).
-        FORMAT_SUFFIX = {"img.qcow2": "qcow2", "img.vhdx": "vhdx", "hyperv.zip": "hyperv"}
+        FORMAT_SUFFIX = {"img.qcow2": "qcow2", "img.vhdx": "vhdx", "hyperv.zip": "hyperv", "iso": "iso"}
 
         # Filename: Armbian[-unofficial]_{version}_{Board}_{distro}_{branch}_{kernel}[_{variant[.app]}]
         # Variant token is optional (some legacy / hand-crafted builds omit it).


### PR DESCRIPTION
### Problem

The release-assets-manifest generator in `action.yml` builds one
`<image>.assets.json` per image by matching filenames against an `EXTS`
table. That table covered `img`, `img.qcow2`, `img.vhdx`, and `hyperv.zip`
— but **not `iso`**. So an `image-output-iso` build (e.g. the **Armbian
SDK**) produced an `.iso.xz` that matched nothing: it got **no manifest**,
and therefore never appeared in the aggregated `armbian-images.json`.

Confirmed on the SDK run (`resolute,uefi-x86,image-output-iso`): the ISO
builds and compresses fine (`…_minimal.iso.xz`, ~1.8 GiB), but it was
invisible to the manifest.

### Fix

- Add `iso.xz` / `iso.zst` / `iso` rows to `EXTS` (image_format `iso`),
  ordered xz > zst > raw like the other formats — so both the compressed
  (`.iso.xz`, the form the SDK ships to stay under GitHub's 2 GiB asset
  limit) and an uncompressed `.iso` are recognised.
- Add `"iso": "iso"` to `FORMAT_SUFFIX`, so in `dl.armbian.com`-style URLs
  the friendly redirect variant is disambiguated from the raw image
  (`…_minimal-iso`) instead of colliding with it.

### Verification

Ran the embedded generator against a fake image dir:

- `…_minimal.iso.xz` → manifest written, `file_extension: "iso.xz"`,
  variant/distro/branch/kernel all parsed correctly. (Before: *"No images
  found"*, zero manifests.)
- A raw `.img.xz` and an `.iso.xz` for the same board coexist as **separate**
  entries; their redirect URLs differ (`…_minimal` vs `…_minimal-iso`).

No behavioural change for existing formats.