### PR TITLE
action: version nightly builds from the latest trunk tag (not stable+1)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -161,36 +161,38 @@ runs:
         # Resolve base version (prefer workflow input if provided)
         BASE_VERSION="${{ inputs.armbian_version }}"
         if [ -z "$BASE_VERSION" ]; then
-          # os/stable.json is deprecated. Derive the base from the latest stable
-          # release of armbian/ci -- the repo that owns the version series. ci also
-          # publishes -trunk.N nightlies, so match only clean MAJOR.MINOR.PATCH tags
-          # and take the highest with sort -V (release order/date is not reliable).
+          # armbian/ci owns the version series. It publishes clean MAJOR.MINOR.PATCH
+          # stable tags AND MAJOR.MINOR.PATCH-trunk.N nightlies (the current
+          # in-development series). Take the highest tag across BOTH with sort -V
+          # (release order/date is not reliable), so a build from main tracks the
+          # live trunk rather than an old stable line.
           BASE_VERSION="$(gh api --paginate repos/armbian/ci/releases \
-            --jq '.[] | .tag_name | select(test("^[0-9]+[.][0-9]+[.][0-9]+$"))' \
+            --jq '.[] | .tag_name | select(test("^[0-9]+[.][0-9]+[.][0-9]+(-trunk[.][0-9]+)?$"))' \
             | sort -V | tail -1)"
         fi
         if [ -z "$BASE_VERSION" ]; then
-          echo "::error::Could not resolve base version: no armbian_version input and no armbian/ci stable release found"
+          echo "::error::Could not resolve base version: no armbian_version input and no armbian/ci release found"
           exit 1
         fi
 
-        # Preserve optional 'v' prefix but strip it for math
-        PREFIX=''
-        if [[ "$BASE_VERSION" == v* ]]; then
-          PREFIX='v'
-          BASE_NO_PREFIX="${BASE_VERSION#v}"
+        if [[ "$BASE_VERSION" == *-trunk.* ]]; then
+          # Nightly/trunk tag: reuse it verbatim. It already denotes the current
+          # unreleased dev version, so it is NOT incremented.
+          NEXT_VERSION="$BASE_VERSION"
         else
+          # Clean stable tag: that patch is already released, so the next build is
+          # the next patch up. Preserve an optional 'v' prefix; drop -rc/+meta.
+          PREFIX=''
           BASE_NO_PREFIX="$BASE_VERSION"
+          if [[ "$BASE_VERSION" == v* ]]; then
+            PREFIX='v'
+            BASE_NO_PREFIX="${BASE_VERSION#v}"
+          fi
+          CORE="${BASE_NO_PREFIX%%[-+]*}"
+          IFS='.' read -r MAJOR MINOR PATCH <<<"$CORE"
+          PATCH=${PATCH:-0}
+          NEXT_VERSION="${PREFIX}${MAJOR}.${MINOR}.$((PATCH + 1))"
         fi
-
-        # Drop any pre-release/build metadata (e.g., -rc1, +meta)
-        CORE="${BASE_NO_PREFIX%%[-+]*}"
-
-        # Split and increment patch
-        IFS='.' read -r MAJOR MINOR PATCH <<<"$CORE"
-        PATCH=${PATCH:-0}
-        NEXT_PATCH=$((PATCH + 1))
-        NEXT_VERSION="${PREFIX}${MAJOR}.${MINOR}.${NEXT_PATCH}"
 
         {
           echo "ARMBIAN_VERSION=${NEXT_VERSION}"


### PR DESCRIPTION
### Problem

The build action's base-version resolver only matched **clean**
`MAJOR.MINOR.PATCH` tags from `armbian/ci` and then **+1'd the patch**:

```jq
select(test("^[0-9]+[.][0-9]+[.][0-9]+$"))   # excludes the nightlies
```

So a build from `main` picked the latest *stable* (`26.8.3`) and produced
`26.8.4` — even though `armbian/ci`'s live development series was already
**`26.11.0-trunk.20`**. The SDK's images and its `armbian-images.json` were
therefore stamped with a stale, wrong version (`26.8.4`).

### Fix

Include the `X.Y.Z-trunk.N` nightly tags in the candidate set and take the
highest across both with `sort -V`:

- **Winner is a trunk tag** → reuse it **verbatim** (`26.11.0-trunk.20`); it
  already denotes the current unreleased dev version, so **no `+1`**.
- **Winner is a clean stable tag** → next-patch bump, exactly as before.

### Verified

| latest ci tag | old result | new result |
|---|---|---|
| `26.11.0-trunk.20` (+ `26.8.3` stable) | `26.8.4` ❌ | `26.11.0-trunk.20` ✅ |
| `26.8.3` (no trunk) | `26.8.4` | `26.8.4` (unchanged) |
| `v26.8.3` | `v26.8.4` | `v26.8.4` (unchanged) |

`sort -V` over the real tag set selects `26.11.0-trunk.20`. The framework
already supports a `-trunk.N` REVISION (that's how ci's own nightlies are
versioned), so filenames/manifests parse it fine.

Pairs with the SDK ISO/manifest work (armbian/build#10495, armbian/sdk#40).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving nightly `-trunk.N` release versions.
  * Preserves trunk version identifiers instead of incrementing them.

* **Bug Fixes**
  * Improved version selection across stable and trunk releases.
  * Updated error messaging when no release version can be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->