### PR TITLE
action: sign every image format, not only .img.xz

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -246,10 +246,32 @@ runs:
     - name: Sign
       shell: bash
       if: ${{ inputs.armbian_pgp_password != '' }}
+      env:
+        ARMBIAN_PGP_PASSWORD: ${{ inputs.armbian_pgp_password }}
       run: |
-        printf '%s' "${{ inputs.armbian_pgp_password }}" | \
-        gpg --passphrase-fd 0 --armor --detach-sign --pinentry-mode loopback --batch --yes \
-        build/output/images/*.img*.xz
+        set -euo pipefail
+
+        # Sign whatever the build actually produced. The glob used to be
+        # *.img*.xz, which is only the classic compressed raw image: an
+        # image-output-iso build emits a .iso and image-output-qcow2 emits an
+        # uncompressed .img.qcow2, so the glob matched nothing, gpg received the
+        # literal pattern and the job died with "can't open ... No such file".
+        mapfile -t images < <(find build/output/images -maxdepth 1 -type f \
+          \( -name '*.img*.xz' -o -name '*.iso' -o -name '*.qcow2' \) | sort)
+
+        if [[ ${#images[@]} -eq 0 ]]; then
+          echo "::error::Sign: no image artifacts found in build/output/images"
+          ls -la build/output/images || true
+          exit 1
+        fi
+
+        # One gpg call per file: --detach-sign takes a single input, and this
+        # way each artifact gets its own .asc.
+        for image in "${images[@]}"; do
+          echo "Signing $(basename "${image}")"
+          printf '%s' "${ARMBIAN_PGP_PASSWORD}" | \
+            gpg --passphrase-fd 0 --armor --detach-sign --pinentry-mode loopback --batch --yes "${image}"
+        done
 
     - name: "Generate release assets manifest"
       shell: bash


### PR DESCRIPTION
Fixes the SDK build: [armbian/sdk run 32568458926](https://github.com/armbian/sdk/actions/runs/32568458926), all 8 cells red.

```
gpg: can't open 'build/output/images/*.img*.xz': No such file or directory
gpg: signing failed: No such file or directory
##[error]Process completed with exit code 2.
```

## Cause

`action.yml` signed exactly one shape of artifact:

```bash
gpg … --detach-sign … build/output/images/*.img*.xz
```

That is the classic compressed raw image. What the SDK cells actually produce:

| extension | artifact | matches `*.img*.xz`? |
|---|---|---|
| `image-output-iso` | `Armbian_….iso` | no |
| `image-output-qcow2` | `Armbian_….img.qcow2` (uncompressed) | no |

So the glob expanded to nothing, bash passed the literal pattern through, and gpg failed on a file that never existed. Every SDK cell uses one of those two extensions, which is why the whole run is red.

## Change

Collect artifacts with `find` (`*.img*.xz`, `*.iso`, `*.qcow2`), sign each separately — `--detach-sign` takes a single input, and this way every artifact gets its own `.asc` — and fail with a directory listing when there is genuinely nothing to sign, rather than letting gpg report a missing file that was never a file.

The passphrase also moves from inline `${{ inputs… }}` into `env:`.

## Verified

| output directory contains | before | after |
|---|---|---|
| `….img.qcow2` (+ .sha) | ❌ gpg error | signs the qcow2 |
| `….iso` (+ .sha) | ❌ gpg error | signs the iso |
| `….img.xz` (+ .sha) | ✅ | ✅ unchanged |
| no image artifacts | ❌ confusing gpg error | explicit error + `ls` of the directory |

`.sha` files are not picked up in any case.