### PR TITLE
python-tools: workaround pylibfdt/pypi/swig/newer-gcc issue vs dtschema

### DIFF
--- a/lib/functions/general/python-tools.sh
+++ b/lib/functions/general/python-tools.sh
@@ -142,7 +142,8 @@ function prepare_python_and_pip() {
 
 		# Install the dependencies
 		display_alert "Installing Python dependencies" "from ${python3_pip_dependencies_path}" "info"
-		run_host_command_logged env -i "${python_proxy_env[@]@Q}" "${PYTHON3_VARS[@]@Q}" "${PYTHON3_INFO[BIN]}" -m pip install "${pip3_extra_args[@]}" -r "${python3_pip_dependencies_path}"
+		# CFLAGS hack for old pyfdtlib
+		run_host_command_logged env -i "${python_proxy_env[@]@Q}" "${PYTHON3_VARS[@]@Q}" "'CFLAGS=-Wno-error=implicit-function-declaration -Wno-error=int-conversion'" "${PYTHON3_INFO[BIN]}" -m pip install "${pip3_extra_args[@]}" -r "${python3_pip_dependencies_path}"
 
 		# Create the hash file
 		run_host_command_logged touch "${python_hash_file}"


### PR DESCRIPTION
- 🍃 the way dtc code ends up in pypi is very strange
- 🌳 there is an upstream fix at https://git.kernel.org/pub/scm/utils/dtc/dtc.git/commit/?id=5008d1d6a356b8d0a78060da2e1021507d529cff
  - but that is not yet in Rob Herring's pypi adaptation at https://github.com/devicetree-org/pylibfdt
- 🍀 for now, pass some CFLAGS during `pip install` to workaround

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python dependency installation compatibility for legacy packages.
  * Prevented selected compiler warnings from blocking installation of older `pyfdtlib` dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->