### PR TITLE
generate_CODEOWNERS: handle multi-dir KERNELPATCHDIR (fixes malformed spacemit-k3 entry)

### DIFF
--- a/.github/generate_CODEOWNERS.sh
+++ b/.github/generate_CODEOWNERS.sh
@@ -61,14 +61,22 @@ function generate_for_board() {
 					config/boards/${board_config}			${maintainers}
 					config/kernel/${LINUXCONFIG%-*}-*.config	${maintainers}
 					sources/families/${BOARDFAMILY}.conf		${maintainers}
-					patch/kernel/${KERNELPATCHDIR%-*}-*/		${maintainers}
 				EOF
 
-				local patch_archive="$(readlink "patch/kernel/${KERNELPATCHDIR}" || true)"
-				if [[ -n "${patch_archive}" ]]; then
-					patch_archive="${patch_archive%/}"
-					echo "patch/kernel/${patch_archive%-*}-*/	${maintainers}"
-				fi
+				# KERNELPATCHDIR may list several patch dirs (space-separated) - e.g.
+				# spacemit-k3 uses "archive/<fam>-<ver> archive/<fam>-<branch>-<ver>".
+				# Emit one owners line per dir (collapsing the trailing -<ver> to -*/),
+				# and follow a symlinked dir to its real target. Iterating avoids the
+				# old single-value bug where a 2nd dir leaked into the owners column.
+				while read -r kpd; do
+					[[ -n "${kpd}" ]] || continue
+					echo "patch/kernel/${kpd%-*}-*/		${maintainers}"
+					local patch_archive="$(readlink "patch/kernel/${kpd}" 2>/dev/null || true)"
+					if [[ -n "${patch_archive}" ]]; then
+						patch_archive="${patch_archive%/}"
+						echo "patch/kernel/${patch_archive%-*}-*/	${maintainers}"
+					fi
+				done < <(echo "${KERNELPATCHDIR}" | xargs -n1)
 
 				if [[ -n "${BOOTCONFIG}" && "${BOOTCONFIG}" != "none" ]]; then
 					while read -r d; do


### PR DESCRIPTION
### How is `@pyavitz archive/spacemit-k3-current-*/ archive/spacemit-k3-legacy-*/` possible?

Spotted in the auto-sync PR #10456:

```
patch/kernel/archive/spacemit-k3-6.18   @pyavitz archive/spacemit-k3-current-*/ archive/spacemit-k3-legacy-*/
```

The owners column should only be names — here it holds two path globs. Cause:

`config/sources/families/spacemit-k3.conf` sets **`KERNELPATCHDIR` to a
space-separated list of two patch dirs** (a supported framework feature — apply
patches from several dirs):

```bash
# current branch
KERNELPATCHDIR="archive/spacemit-k3-6.18 archive/spacemit-k3-current-6.18"
# legacy branch
KERNELPATCHDIR="archive/spacemit-k3-6.18 archive/spacemit-k3-legacy-6.18"
```

But `generate_CODEOWNERS.sh` treated it as a **single** dir:

```bash
patch/kernel/${KERNELPATCHDIR%-*}-*/    ${maintainers}
```

`${KERNELPATCHDIR%-*}` runs on the *whole* string, trimming only the **last**
token's `-6.18`. So the emitted line becomes:

```
patch/kernel/archive/spacemit-k3-6.18 archive/spacemit-k3-current-*/    @pyavitz
```

`merge()` then splits on whitespace: field 1 (`patch/kernel/archive/spacemit-k3-6.18`)
is the path, everything after (`archive/spacemit-k3-current-*/ @pyavitz`) is
"owners". Dedup across both branches yields the mangled line above. Reproduced
locally byte-for-byte.

### Fix

Iterate over each whitespace-separated dir in `KERNELPATCHDIR` (the way
`BOOTPATCHDIR` is already handled), emitting one owners line per dir and still
following a symlinked dir to its target:

```bash
while read -r kpd; do
  [[ -n "${kpd}" ]] || continue
  echo "patch/kernel/${kpd%-*}-*/    ${maintainers}"
  ...symlink follow...
done < <(echo "${KERNELPATCHDIR}" | xargs -n1)
```

spacemit-k3 now produces three clean entries, each owned only by `@pyavitz`:

```
patch/kernel/archive/spacemit-k3-*/           @pyavitz
patch/kernel/archive/spacemit-k3-current-*/   @pyavitz
patch/kernel/archive/spacemit-k3-legacy-*/    @pyavitz
```

`spacemit-k3` is currently the **only** family with a multi-dir `KERNELPATCHDIR`,
so it's the sole entry affected. `bash -n` clean.

> After this merges, the next maintainers auto-sync regenerates `.github/CODEOWNERS`
> correctly; the bad line in #10456 gets overwritten.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved ownership metadata generation for projects containing multiple kernel patch directories.
  - Added support for tracking ownership of targets referenced through symbolic links.
  - Ensured each applicable directory receives a separate ownership entry, improving accuracy and maintainability of repository contribution guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->