### PR TITLE
rtl88x2cs: bump driver to a2066739 (2026-08-20)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -466,7 +466,7 @@ driver_rtl88x2cs() {
 	if linux-version compare "${version}" ge 5.9 && [[ "$LINUXFAMILY" == meson64 ]]; then
 
 		# Attach to specific commit (track branch:tune_for_jethub)
-		local rtl88x2csver='commit:4741c414b87be0a9cf8b7e53ef822403a495f995' # Commit date: Jun 30, 2026 (please update when updating commit ref)
+		local rtl88x2csver='commit:a206673937708aa5d2fb8c42b6b12f2fb96dd9b3' # Commit date: Aug 20, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 88x2cs chipsets ${rtl88x2csver}" "info"
 


### PR DESCRIPTION
Picks up the merged warning/hardening work in jethome-iot/rtl88x2cs:
proc write handlers now read only what was written (#42), dead recv-frame
helpers and an always-warning DPK status test removed (#43), trailing
variable-length arrays converted to C99 flexible array members (#44), and
the gcc 7.1-header warnings (maybe-uninitialized 74, format-truncation 5,
frame-larger-than 1 -> 0) fixed (#41). Also included from adeepn:
set_monitor_channel gained a net_device argument in 6.12.101, plus the CI
build matrix.

In-tree patch wireless-rtl88x2cs-Fix-VFS-import.patch still applies against
the new tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled wireless driver to a newer revision, improving compatibility and reliability for supported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->