### PR TITLE
wireless drivers: bump rtl8189es pin, re-point rtl8723ds pin

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -51,7 +51,7 @@ driver_rtl8189ES() {
 	if linux-version compare "${version}" ge 3.14; then
 
 		# Attach to specific commit (was "branch:master")
-		local rtl8189esver='commit:7aff01915502ea0687b499800c34404a10c57721' # Commit date: 2026-06-29 (please update when updating commit ref)
+		local rtl8189esver='commit:a1c0892d03223590b6f4d9f106709d452f5fe07f' # Commit date: 2026-06-30 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8189ES chipsets ${rtl8189esver}" "info"
 

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -649,7 +649,7 @@ driver_rtl8723DS() {
 	if linux-version compare "${version}" ge 5.0 && [[ "$LINUXFAMILY" == rockchip64 ]]; then
 
 		# Attach to specific commit (was "branch:master")
-		local rtl8723dsver='commit:938bc4c52daad88c7217fa6771482e5c820f0dde' # Commit date: Aug 06, 2026 (please update when updating commit ref)
+		local rtl8723dsver='commit:2e63716ff6357fe188f0118d6f4c9f4694912f71' # Commit date: Aug 06, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8723DS chipsets ${rtl8723dsver}" "info"
 


### PR DESCRIPTION
rtl8189es: bump 7aff0191 -> a1c0892d (2026-06-30), the merged
-Wmissing-prototypes cleanup (556 -> 42 warnings). Nothing else is on the
branch, and wireless-rtl8189es-set-monitor-channel-6.12.101.patch still
applies against the new tree.

rtl8723ds: the pin held 938bc4c5, the pre-rebase commit from the "add
compat for 7.2" pull request branch; main carries the same change as
2e63716f. Same tree (7f8546ea), same parent - the built driver does not
change, the pin just stops pointing at a commit outside main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the wireless driver source versions for RTL8189ES and RTL8723DS hardware.
  * Improved compatibility and reliability for supported wireless devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->