### PR TITLE
pip/python/pylibfdt: use forked pylibfdt with upstream fixes for swig/newer-gcc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,6 @@ oras == 0.2.43         # for OCI stuff in mapper-oci-update
 Jinja2 == 3.1.6        # for templating
 rich == 15.0.0         # for rich text formatting
 Pygments == 2.21.0     # syntax highlighting, required by rich.syntax (imported by lib/tools/patching.py)
+pylibfdt @ git+https://github.com/rpardini/devicetree-pylibfdt.git@e5f19fc9b54bc159d7d0785133b45f1f3055bf74 # fork to sync with upstream and fix .i vs swig/newer-gcc
 dtschema == 2026.6     # for checking dts files and dt bindings
 yamllint == 1.38.0     # for checking dts files and dt bindings


### PR DESCRIPTION
- 🍀 the way dtc code ends up in pypi is very strange / non-obvious
- 🍃 there is an upstream fix at git.kernel.org/pub/scm/utils/dtc/dtc.git/commit?id=5008d1d6a356b8d0a78060da2e1021507d529cff
  - but that is not yet in Rob Herring's pypi adaptation at devicetree-org/pylibfdt
  - I've a fork with the upstream sync at https://github.com/rpardini/devicetree-pylibfdt/tree/sync-with-upstream-26.08

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a compatibility-focused dependency to support improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->