### PR TITLE
RV1106-family: update DDR, TEE, add ROCKUSB_BLOB

### DIFF
--- a/config/sources/families/rockchip-rv1106.conf
+++ b/config/sources/families/rockchip-rv1106.conf
@@ -33,14 +33,17 @@ BOOTPATCHDIR="legacy/u-boot-rockchip-buildroot"
 BOOTDIR="u-boot-rockchip"
 
 # Set defaults based on BOOT_SOC (overridable in board config)
+# ROCKUSB_BLOB is used to flash a board with rkdeveloptool (Linux, can use 'rkdevflash' extension) or RKDevTool (Windows) in MASKROM mode
 if [[ "$BOOT_SOC" == "rv1103b" ]]; then
-	DDR_BLOB="${DDR_BLOB:-"rv11/rv1103b_ddr_924MHz_v1.05.bin"}"
-	TEE_BLOB="${TEE_BLOB:-"rv11/rv1103b_tee_ta_v1.03.bin"}"
+	DDR_BLOB="${DDR_BLOB:-"rv11/rv1103b_ddr_924MHz_v1.07.bin"}"
+	TEE_BLOB="${TEE_BLOB:-"rv11/rv1103b_tee_ta_v1.05.bin"}"
 	USBPLUG_BLOB="${USBPLUG_BLOB:-"rv11/rv1103b_usbplug_v1.00.bin"}"
+	ROCKUSB_BLOB="rv11/rv1103b_download_v1.07.101.bin"
 elif [[ "$BOOT_SOC" == "rv1106" || "$BOOT_SOC" == "rv1103g" ]]; then
-	DDR_BLOB="${DDR_BLOB:-"rv11/rv1106_ddr_924MHz_v1.15.bin"}"
-	TEE_BLOB="${TEE_BLOB:-"rv11/rv1106_tee_ta_v1.13.bin"}"
+	DDR_BLOB="${DDR_BLOB:-"rv11/rv1106_ddr_924MHz_v1.18.bin"}"
+	TEE_BLOB="${TEE_BLOB:-"rv11/rv1106_tee_ta_v1.14.bin"}"
 	USBPLUG_BLOB="${USBPLUG_BLOB:-"rv11/rv1106_usbplug_v1.09.bin"}"
+	ROCKUSB_BLOB="rv11/rv1106_download_v1.18.103.bin"
 else
 	display_alert "$BOARD" "Unknown BOOT_SOC: ${BOOT_SOC} in rockchip-rv1106 family" "error"
 	exit 1


### PR DESCRIPTION
# Description

Update DDR and TEE blobs, introduce ROCKUSB_BLOB (for rkdevtool) for RV1106 family.

# How Has This Been Tested?

Boot-tested on both boards in the RV1106 family:
- [x] `luckfox-pico-mini`
- [x] `luckfox-pico-max`

# Checklist:

- [x] I have performed a self-review of my own code

## Depends on

- https://github.com/armbian/rkbin/pull/52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MASKROM flashing support for RV1103B and RV1106/RV1103G devices.

* **Bug Fixes**
  * Updated firmware blob versions for improved compatibility with supported Rockchip SoC variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->