### PR TITLE
nanopct6(-lts): u-boot: bump to v2026.07

### DIFF
--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -45,8 +45,8 @@ function post_family_config__nanopct6_use_mainline_uboot() {
 	declare -g BOOTCONFIG="nanopc-t6-rk3588_defconfig"
 	declare -g BOOTDELAY=1
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"
-	declare -g BOOTBRANCH="tag:v2026.04"
-	declare -g BOOTPATCHDIR="v2026.04"
+	declare -g BOOTBRANCH="tag:v2026.07"
+	declare -g BOOTPATCHDIR="v2026.07"
 	declare -g BOOTDIR="u-boot-${BOARD}"
 	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
@@ -138,6 +138,12 @@ function post_config_uboot_target__extra_configs_for_nanopct6_mainline_environme
 	run_host_command_logged scripts/config --enable CONFIG_CMD_MII
 	run_host_command_logged scripts/config --enable CONFIG_NET_LWIP
 
+	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable MBed TLS stuff" "info"
+	run_host_command_logged scripts/config --enable CONFIG_WGET_HTTPS
+	run_host_command_logged scripts/config --enable CONFIG_WGET_CACERT
+	#run_host_command_logged scripts/config --enable CONFIG_WGET_BUILTIN_CACERT # not yet
+	run_host_command_logged scripts/config --enable CONFIG_MBEDTLS_LIB
+
 	# UMS, RockUSB, gadget stuff
 	display_alert "u-boot for ${BOARD}/${BRANCH}" "u-boot: enable UMS/RockUSB gadget" "info"
 	declare -a enable_configs=("CONFIG_CMD_USB_MASS_STORAGE" "CONFIG_USB_GADGET" "USB_GADGET_DOWNLOAD" "CONFIG_USB_FUNCTION_ROCKUSB" "CONFIG_USB_FUNCTION_ACM" "CONFIG_CMD_ROCKUSB")
@@ -146,6 +152,8 @@ function post_config_uboot_target__extra_configs_for_nanopct6_mainline_environme
 	done
 	# Auto-enabled by the above, force off...
 	run_host_command_logged scripts/config --disable USB_FUNCTION_FASTBOOT
+
+	return 0
 }
 
 # Include fw_setenv, configured to point to the correct spot on the SPI Flash
@@ -154,7 +162,7 @@ function post_family_tweaks__config_nanopct6_fwenv() {
 	[[ "${BRANCH}" == "vendor" ]] && return 0 # Not for 'vendor' branch, which uses 2017.09 vendor u-boot from Radxa
 	display_alert "Configuring fw_printenv and fw_setenv" "for ${BOARD} and u-boot ${BOOTBRANCH}" "info"
 	# Addresses below come from CONFIG_ENV_OFFSET and CONFIG_ENV_SIZE in defconfig
-	cat <<- 'FW_ENV_CONFIG' > "${SDCARD}"/etc/fw_env.config
+	cat <<- FW_ENV_CONFIG > "${SDCARD}"/etc/fw_env.config
 		# MTD/SPI u-boot env for the ${BOARD_NAME}
 		# MTD device name Device offset Env. size Flash sector size Number of sectors
 		/dev/mtd0         0xc00000      0x20000


### PR DESCRIPTION
- 🌴 also enable fancy u-boot mbedTLS support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled secure HTTPS and certificate support for bootloader downloads.
  * Added support for the latest U-Boot release, improving compatibility with current bootloader updates.

* **Improvements**
  * Updated generated board configuration details to reflect the active board name more accurately.
  * Improved configuration handling to report successful completion consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->