### PR TITLE
cpufreq: add boost support and enable the 1.8 GHz turbo on spacemit

### DIFF
--- a/config/sources/families/spacemit.conf
+++ b/config/sources/families/spacemit.conf
@@ -10,6 +10,10 @@
 declare -g ARCH="riscv64"
 declare -g LINUXFAMILY="spacemit"
 declare -g GOVERNOR="performance"
+declare -g CPUMIN="614400"
+# 1.8 GHz is a turbo-mode OPP in k1-x_opp_table.dtsi, gated behind the cpufreq boost flag
+declare -g CPUMAX="1800000"
+declare -g CPUBOOST="true"
 
 # OpenSBI
 declare -g ATFSOURCE="https://github.com/pyavitz/spacemit-opensbi.git"

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -108,6 +108,7 @@ function install_distribution_agnostic() {
 		MIN_SPEED=$CPUMIN
 		MAX_SPEED=$CPUMAX
 		GOVERNOR=$GOVERNOR
+		BOOST=${CPUBOOST:-false}
 	EOF
 
 	# disable selinux by default

--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -73,6 +73,8 @@ prepare_board() {
 	# FIXME literally just borrowing the cpufrequtils config file -- should configuration be driven by a new file?
 	if [ -r /etc/default/cpufrequtils ] ; then
 		. /etc/default/cpufrequtils
+		# turbo OPPs stay hidden until boost is set, so scaling_max_freq below would clamp
+		[ "X${BOOST}" = "Xtrue" ] && [ -w /sys/devices/system/cpu/cpufreq/boost ] && echo 1 > /sys/devices/system/cpu/cpufreq/boost
 		for Cluster in /sys/devices/system/cpu/cpufreq/policy* ; do
 			[[ -e "${Cluster}" ]] || break
 			grep -q "${GOVERNOR}" "${Cluster}/scaling_available_governors" && [ -w "${Cluster}/scaling_governor" ] && echo "${GOVERNOR}" >"${Cluster}/scaling_governor"


### PR DESCRIPTION
# Description

OPPs marked `turbo-mode` are hidden behind the cpufreq boost flag. Until `/sys/devices/system/cpu/cpufreq/boost` is set, a write of a turbo frequency to `scaling_max_freq` is clamped with no error, so any board with a turbo OPP runs below what its own DT declares.

This reads a `BOOST` key out of `/etc/default/cpufrequtils` and raises the flag in `armbian-hardware-optimization`. It defaults to false, so nothing changes unless a board opts in.

The placement matters: it has to come before the loop that sets governor, min and max, because the governor write in that loop is what makes the new ceiling take effect. Boost on with the governor left alone leaves the CPU at 1.6 GHz.

The second commit opts spacemit in. `k1-x_opp_table.dtsi` already carries the 1.8 GHz entry and the driver has allowed it since `004-Max-freq-limitation-1.8GHz.patch`.

# How Has This Been Tested?

- [x] MUSE Book on legacy 6.6.100
- [x] `boost=0` with `cpuinfo_max_freq=1600000` before, `boost=1` with `scaling_cur_freq=1800000` under load after
- [x] `pll3` at `1800000000` in `clk_summary`
- [x] Applied by the service across a reboot, not by hand
- [x] 57 C after 65 seconds at full load against a 75 C trip point, frequency never dropped
- [x] armbianmonitor: https://paste.armbian.com/nugagitazo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled CPU frequency boosting on SpacemiT K1 devices when supported.
  * Set SpacemiT K1 CPU frequency limits to 614.4 MHz minimum and 1.8 GHz maximum.

* **Bug Fixes**
  * Improved application of CPU boost settings during hardware optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->