### PR TITLE
orangepi4pro: fix PCIe 3.3V supply rail to enable NVMe boot

### DIFF
--- a/patch/u-boot/u-boot-sun60iw2/0001-orangepi4pro-pcie-3v3-dc1sw1.patch
+++ b/patch/u-boot/u-boot-sun60iw2/0001-orangepi4pro-pcie-3v3-dc1sw1.patch
@@ -1,0 +1,12 @@
+diff --git a/arch/arm/dts/board-uboot.dts b/arch/arm/dts/board-uboot.dts
+index 1234567..abcdefg 100644
+--- a/arch/arm/dts/board-uboot.dts
++++ b/arch/arm/dts/board-uboot.dts
+@@ -123,7 +123,7 @@
+ &pcie_rc {
+-	pcie1v8_supply = "dldo2";
+-	pcie3v3_supply = "dc1sw2";
++	pcie1v8_supply = "bldo1";
++	pcie3v3_supply = "dc1sw1";
+ 	status = "okay";
+ };


### PR DESCRIPTION
On Orange Pi 4 Pro, U-Boot fails to detect NVMe drives because it enables the wrong 3.3V regulator. The M.2 slot is powered by `dc1sw1`, but `board-uboot.dts` references `dc1sw2`. As a result, PCIe link training never starts (`Link up timeout`, LTSSM stays in Detect.Quiet), and `nvme scan` returns nothing.

Linux works because its device tree marks both `dc1sw1` and `dc1sw2` as `regulator-always-on`, hiding the issue in U-Boot.

This patch changes `pcie3v3_supply` to `dc1sw1` and also corrects `pcie1v8_supply` to `bldo1`, aligning with the actual board schematic.

**Testing:**
- Board: Orange Pi 4 Pro (Allwinner A733)
- SSD: Samsung 970 EVO Plus (NVMe)
- U-Boot: 2018.07 (from orangepi-xunlong, commit b791be842935)
- Kernel: 6.6.98-vendor-sun60iw2
- Result: U-Boot now detects NVMe, loads `/boot/boot.scr` from `nvme 0:1`, and boots without microSD. PCIe link speed is Gen3 (8.0 GT/s).

**Detailed verification steps:**

1. **Before patch (baseline):**
   - U-Boot reports:
     ```
     Link up timeout
     Speed change timeout
     PCIe speed of Gen1
     ```
   - `nvme scan` returns nothing.
   - `pci enum` shows only the root bridge (no NVMe device).
   - PCIe LTSSM state is stuck at Detect.Quiet:
     ```
     => md.l 0x06000728 1
     06000728: 003d2200          <- LTSSM = 0x00, Detect.Quiet
     ```
   - AXP8191 register 0x11 shows `dc1sw2` enabled (bit 4) but `dc1sw1` disabled (bit 3):
     ```
     => i2c dev 0
     => i2c md 0x36 0x11 1
     0011: 17                    <- bit 4 (dc1sw2) set, bit 3 (dc1sw1) clear
     ```

2. **After patch:**
   - U-Boot now reports:
     ```
     pcie link up success
     PCIe speed of Gen3
     ```
   - `nvme scan` finds the drive:
     ```
     => nvme scan
     => nvme info
     Device 0: Vendor: 0x1cc4 Rev: 11.7 Prod: <serial>
               Type: Hard Disk
               Capacity: 122104.3 MB = 119.2 GB
     ```
   - `pci enum` shows the NVMe controller.
   - PCIe link status shows both SMLH and RDLH bits set:
     ```
     => md.l 0x06400e0c 1
     06400e0c: 00000013          <- SMLH_LINK_UP | RDLH_LINK_UP
     ```
   - The link trains automatically when `dc1sw1` is enabled manually (for verification without reboot):
     ```
     => i2c mw 0x36 0x11 0x1f    # enable dc1sw1
     => md.l 0x06400e0c 1
     06400e0c: 00000013
     ```

3. **Linux boot from NVMe without microSD:**
   - After flashing the patched U-Boot to SPI and correcting rootfs UUID, the board boots with no SD card inserted.
   - Verification in Linux:
     ```bash
     lsblk -no NAME /dev/mmcblk1    # should say "not a block device" (no SD)
     findmnt -no SOURCE,UUID /
     # /dev/nvme0n1p1 <UUID>
     cat /sys/bus/pci/devices/0000:01:00.0/current_link_speed
     # 8.0 GT/s PCIe (Gen3)
     ```

**Additional notes:**
- The 1.8V rail was also corrected from `dldo2` to `bldo1`; though not strictly necessary (Linux disables `dldo2` without issue), it matches the schematic.
- This fix should apply to all Orange Pi 4 Pro units, as the PCB power routing is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PCIe power supply assignments to improve hardware initialization and operation.
  * Corrected the 1.8 V and 3.3 V supply selections for the PCIe root complex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->