### PR TITLE
cli-flash: fix bare ./compile.sh flash silently doing nothing

### DIFF
--- a/lib/functions/cli/cli-flash.sh
+++ b/lib/functions/cli/cli-flash.sh
@@ -27,14 +27,49 @@ function cli_flash_run() {
 
 function cli_flash() {
 	declare image_file="${IMAGE:-""}"
-	# If not set, find the latest .img file in ${SRC}/output/images/
+
+	# If not set, find the most recent .img in ${SRC}/output/images/, narrowed by
+	# whichever of BOARD/RELEASE/BRANCH this invocation actually set.
+	#
+	# Composing one glob out of all three unconditionally collapses it to
+	# '*__*.img' when none is set, which is what a bare './compile.sh flash'
+	# does. That matches no Armbian image -- they are named
+	# <version>_<Board>_<release>_<branch>_... -- so the command failed with a
+	# raw "ls: cannot access" even when output/images held a perfectly good
+	# image. Filter the listing instead of building a pattern from empty parts.
 	if [[ -z "${image_file}" ]]; then
-		# shellcheck disable=SC2012
-		image_file="$(ls -1t "${SRC}/output/images"/*"${BOARD^}_${RELEASE}_${BRANCH}"*.img | head -1)"
-		display_alert "cli_flash" "No image file specified. Using latest built image file found: ${image_file}" "info"
+		declare -a images=()
+		declare candidate token
+		# Newest first. find, not a glob, so a missing or empty directory gives
+		# an empty list rather than an unexpanded pattern on stderr.
+		while read -r candidate; do
+			images+=("${candidate}")
+		done < <(find "${SRC}/output/images" -maxdepth 1 -type f -name '*.img' -printf '%T@\t%p\n' 2> /dev/null | sort -rn | cut -f2-)
+
+		declare board_token="${BOARD:+${BOARD^}}"
+		for token in "${board_token}" "${RELEASE}" "${BRANCH}"; do
+			if [[ -z "${token}" ]]; then
+				continue
+			fi
+			declare -a kept=()
+			for candidate in "${images[@]}"; do
+				if [[ "${candidate##*/}" == *"${token}"* ]]; then
+					kept+=("${candidate}")
+				fi
+			done
+			images=("${kept[@]}")
+		done
+
+		if [[ ${#images[@]} -eq 0 ]]; then
+			exit_with_error "No image found in ${SRC}/output/images to flash" \
+				"build one first, or pass IMAGE=/path/to/image.img"
+		fi
+
+		image_file="${images[0]}"
+		display_alert "cli_flash" "No image file specified. Using latest built image file found: ${image_file##*/}" "info"
 	fi
 	if [[ ! -f "${image_file}" ]]; then
-		exit_with_error "No image file to flash."
+		exit_with_error "No image file to flash" "${image_file}"
 	fi
 	declare image_file_basename
 	image_file_basename="$(basename "${image_file}")"

--- a/lib/functions/cli/cli-flash.sh
+++ b/lib/functions/cli/cli-flash.sh
@@ -26,6 +26,21 @@ function cli_flash_run() {
 }
 
 function cli_flash() {
+	# Without a target device there is nothing downstream to catch it:
+	# write_image_to_device's `lsblk "${device}"` test is false for an empty
+	# device, and its in-container branch needs a non-empty device too, so the
+	# write is skipped and `flash` exits 0 having done nothing at all -- after
+	# announcing the image and counting down, which reads as success.
+	# Docker is not the obstacle: the launcher passes CARD_DEVICE into the
+	# container when it is set.
+	if [[ -z "${CARD_DEVICE:-}" ]]; then
+		exit_with_error "No target device to flash to" \
+			"pass CARD_DEVICE=/dev/sdX (see 'lsblk' for the device name)"
+	fi
+	if [[ ! -b "${CARD_DEVICE}" ]]; then
+		exit_with_error "CARD_DEVICE is not a block device" "${CARD_DEVICE}"
+	fi
+
 	declare image_file="${IMAGE:-""}"
 
 	# If not set, find the most recent .img in ${SRC}/output/images/, narrowed by

--- a/lib/functions/cli/cli-flash.sh
+++ b/lib/functions/cli/cli-flash.sh
@@ -68,7 +68,12 @@ function cli_flash() {
 			fi
 			declare -a kept=()
 			for candidate in "${images[@]}"; do
-				if [[ "${candidate##*/}" == *"${token}"* ]]; then
+				# Match the selector as a complete underscore-delimited field, not
+				# a loose substring: image names are
+				# VENDOR_VERSION_Board_release_branch_kver..., where Board/release/
+				# branch are all middle fields, so a short release/branch (e.g.
+				# 'sid', 'edge') can't accidentally match inside another field.
+				if [[ "${candidate##*/}" == *"_${token}_"* ]]; then
 					kept+=("${candidate}")
 				fi
 			done


### PR DESCRIPTION
`./compile.sh flash` was broken in two ways, both ending with the command reporting success while writing nothing.

## 1. The image is never found

```
ls: cannot access '/armbian/output/images/*__*.img': No such file or directory
error! [ No image file to flash. ]
```

The lookup built one glob from `BOARD`, `RELEASE` and `BRANCH` together. With none set it collapses to `*__*.img`, which matches no Armbian image — they use single underscores (`rootfs-to-image.sh:19`). Partially specified invocations broke too: `BOARD=x BRANCH=edge` with no `RELEASE` gave `*X__edge*.img`.

Now: list `output/images` newest-first, then narrow by whichever selectors were actually given. Each selector is matched as a complete `_`-delimited field, so a short one like `sid` or `edge` can't match inside another field.

## 2. With the image found, it flashes nowhere

`write_image_to_device` guards the write with `lsblk "${device}"`, and its in-container fallback with `[[ -n ${device} ]]`. With `CARD_DEVICE` unset **both branches fall through silently** — the command announces the image, counts down, and exits 0 having written nothing.

Now validated up front, before the countdown, naming what to pass. A `CARD_DEVICE` that isn't a block device took the same silent path and is rejected too.

Docker is not the obstacle and the message doesn't mention it: `docker.sh:636` passes `CARD_DEVICE` into the container when set.

## Notes

`IMAGE=/path/to.img` still short-circuits the search. Verified against a fixture of three images with staggered mtimes, across bare / board / board+release / board+branch / no-match / empty-dir, and `CARD_DEVICE` unset / non-block / real. `bash -n` and `shellcheck -S warning` clean; exercised under `set -e -o errexit -o pipefail -o nounset` to match `compile.sh`.