### PR TITLE
patch maint: rewrite various patch sets against upstream

### DIFF
--- a/patch/kernel/archive/mvebu-6.18/11-mvebu-pcie-aer-fixes.patch
+++ b/patch/kernel/archive/mvebu-6.18/11-mvebu-pcie-aer-fixes.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Velkov <325961+iav@users.noreply.github.com>
-Date: Tue, 22 Apr 2026 00:00:00 +0000
+Date: Wed, 22 Apr 2026 00:00:00 +0000
 Subject: mvebu/pcie: fix DEVCTL change detection and trim RTCTL handling
 
 Compute the relevant PCI_EXP_DEVCTL change mask before clearing the
@@ -12,17 +12,17 @@ Also restrict the PCI_EXP_RTCTL-triggered IRQ mask update to PMEIE.
 mvebu_pcie_handle_irq_change() only uses rootctl.PMEIE, so reacting to
 SECEE/SENFEE/SEFEE changes only reruns the helper without affecting the
 hardware interrupt mask.
-
 ---
- drivers/pci/controller/pci-mvebu.c | 13 ++++++++-----
+ drivers/pci/controller/pci-mvebu.c | 13 ++++++----
  1 file changed, 8 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/pci/controller/pci-mvebu.c b/drivers/pci/controller/pci-mvebu.c
+index 111111111111..222222222222 100644
 --- a/drivers/pci/controller/pci-mvebu.c
 +++ b/drivers/pci/controller/pci-mvebu.c
-@@ -865,7 +865,11 @@
+@@ -865,7 +865,11 @@ mvebu_pci_bridge_emul_pcie_conf_write(struct pci_bridge_emul *bridge,
  	struct mvebu_pcie_port *port = bridge->data;
-
+ 
  	switch (reg) {
 -	case PCI_EXP_DEVCTL:
 +	case PCI_EXP_DEVCTL: {
@@ -33,22 +33,22 @@ diff --git a/drivers/pci/controller/pci-mvebu.c b/drivers/pci/controller/pci-mve
  		/*
  		 * Armada370 data says these bits must always
  		 * be zero when in root complex mode.
-@@ -875,10 +879,10 @@
-
+@@ -875,10 +879,10 @@ mvebu_pci_bridge_emul_pcie_conf_write(struct pci_bridge_emul *bridge,
+ 
  		mvebu_writel(port, new, PCIE_CAP_PCIEXP + PCI_EXP_DEVCTL);
-
+ 
 -		if ((new ^ old) & (PCI_EXP_DEVCTL_FERE | PCI_EXP_DEVCTL_NFERE |
 -				   PCI_EXP_DEVCTL_CERE | PCI_EXP_DEVCTL_URRE))
 +		if (aer_changed)
  			mvebu_pcie_handle_irq_change(port);
  		break;
 +	}
-
+ 
  	case PCI_EXP_LNKCTL:
  		/*
-@@ -941,8 +945,7 @@
+@@ -941,8 +945,7 @@ mvebu_pci_bridge_emul_pcie_conf_write(struct pci_bridge_emul *bridge,
  		break;
-
+ 
  	case PCI_EXP_RTCTL:
 -		if ((new ^ old) & (PCI_EXP_RTCTL_SECEE | PCI_EXP_RTCTL_SENFEE |
 -				   PCI_EXP_RTCTL_SEFEE | PCI_EXP_RTCTL_PMEIE))
@@ -56,6 +56,6 @@ diff --git a/drivers/pci/controller/pci-mvebu.c b/drivers/pci/controller/pci-mve
  			mvebu_pcie_handle_irq_change(port);
  		break;
  	}
---
+-- 
 Armbian
 

--- a/patch/kernel/archive/mvebu-6.18/20-ARM-dts-helios4-add-vcc-supply-to-EEPROM.patch
+++ b/patch/kernel/archive/mvebu-6.18/20-ARM-dts-helios4-add-vcc-supply-to-EEPROM.patch
@@ -1,7 +1,7 @@
-From 880bf48b805ba6a43e5121c4e96804e859c82275 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Rosen Penev <rosenp@gmail.com>
 Date: Sat, 20 Jun 2026 23:13:27 -0700
-Subject: [PATCH] ARM: dts: helios4: add vcc-supply to EEPROM
+Subject: ARM: dts: helios4: add vcc-supply to EEPROM
 
 The at24 driver requests a 'vcc' supply for the EEPROM, producing
 'supply vcc not found, using dummy regulator' at boot when the
@@ -19,7 +19,7 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
  1 file changed, 4 insertions(+)
 
 diff --git a/arch/arm/boot/dts/marvell/armada-388-helios4.dts b/arch/arm/boot/dts/marvell/armada-388-helios4.dts
-index 390e98df49c9..05540b8012c2 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/boot/dts/marvell/armada-388-helios4.dts
 +++ b/arch/arm/boot/dts/marvell/armada-388-helios4.dts
 @@ -201,6 +201,10 @@ temp_sensor: temp@4c {
@@ -34,5 +34,5 @@ index 390e98df49c9..05540b8012c2 100644
  
  			i2c@11100 {
 -- 
-2.54.0
+Armbian
 

--- a/patch/kernel/archive/mvebu-6.18/21-ARM-dts-helios4-add-vcc-supply-to-GPIO-expander.patch
+++ b/patch/kernel/archive/mvebu-6.18/21-ARM-dts-helios4-add-vcc-supply-to-GPIO-expander.patch
@@ -1,7 +1,7 @@
-From 5328bd6eaf5b994e51680a2f71bec99022a0bedd Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Rosen Penev <rosenp@gmail.com>
 Date: Sat, 20 Jun 2026 23:39:00 -0700
-Subject: [PATCH] ARM: dts: helios4: add vcc-supply to GPIO expander
+Subject: ARM: dts: helios4: add vcc-supply to GPIO expander
 
 The pca953x driver requests a 'vcc' supply, producing:
   pca953x 0-0020: supply vcc not found, using dummy regulator
@@ -18,7 +18,7 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/arm/boot/dts/marvell/armada-388-helios4.dts b/arch/arm/boot/dts/marvell/armada-388-helios4.dts
-index 05540b8012c2..cf0432a0e71a 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/boot/dts/marvell/armada-388-helios4.dts
 +++ b/arch/arm/boot/dts/marvell/armada-388-helios4.dts
 @@ -169,6 +169,7 @@ expander0: gpio-expander@20 {
@@ -30,5 +30,5 @@ index 05540b8012c2..cf0432a0e71a 100644
  					pinctrl-0 = <&pca0_pins>;
  					interrupt-parent = <&gpio0>;
 -- 
-2.54.0
+Armbian
 

--- a/patch/kernel/archive/mvebu-6.18/22-ARM-dts-helios4-add-SATA-regulator-supplies.patch
+++ b/patch/kernel/archive/mvebu-6.18/22-ARM-dts-helios4-add-SATA-regulator-supplies.patch
@@ -1,7 +1,7 @@
-From bdcacaa9278e7050f346061b5114f16b1ee1cc19 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Rosen Penev <rosenp@gmail.com>
 Date: Sat, 20 Jun 2026 23:17:16 -0700
-Subject: [PATCH] ARM: dts: helios4: add SATA regulator supplies
+Subject: ARM: dts: helios4: add SATA regulator supplies
 
 The ahci-mvebu driver and libahci_platform request three supplies
 on SATA controller and port nodes:
@@ -26,7 +26,7 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
  1 file changed, 8 insertions(+)
 
 diff --git a/arch/arm/boot/dts/marvell/armada-388-helios4.dts b/arch/arm/boot/dts/marvell/armada-388-helios4.dts
-index cf0432a0e71a..626a7339a5d0 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/boot/dts/marvell/armada-388-helios4.dts
 +++ b/arch/arm/boot/dts/marvell/armada-388-helios4.dts
 @@ -222,13 +222,17 @@ sata@a8000 {
@@ -66,5 +66,5 @@ index cf0432a0e71a..626a7339a5d0 100644
  			};
  
 -- 
-2.54.0
+Armbian
 

--- a/patch/kernel/archive/mvebu-6.18/23-ARM-dts-helios4-wire-LM75-into-a-thermal-zone-with-f.patch
+++ b/patch/kernel/archive/mvebu-6.18/23-ARM-dts-helios4-wire-LM75-into-a-thermal-zone-with-f.patch
@@ -1,8 +1,7 @@
-From c8a7d8f4f4e698ecb49452fa19e5e094b1c58018 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Rosen Penev <rosenp@gmail.com>
 Date: Sat, 20 Jun 2026 23:32:55 -0700
-Subject: [PATCH] ARM: dts: helios4: wire LM75 into a thermal zone with fan
- cooling
+Subject: ARM: dts: helios4: wire LM75 into a thermal zone with fan cooling
 
 The LM75 temperature sensor on i2c0 creates a hwmon interface but was
 not referenced by any thermal zone, producing:
@@ -11,11 +10,11 @@ not referenced by any thermal zone, producing:
 Assisted-by: opencode:big-pickle
 Signed-off-by: Rosen Penev <rosenp@gmail.com>
 ---
- .../boot/dts/marvell/armada-388-helios4.dts   | 33 +++++++++++++++++++
+ arch/arm/boot/dts/marvell/armada-388-helios4.dts | 33 ++++++++++
  1 file changed, 33 insertions(+)
 
 diff --git a/arch/arm/boot/dts/marvell/armada-388-helios4.dts b/arch/arm/boot/dts/marvell/armada-388-helios4.dts
-index 626a7339a5d0..6e0452217265 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/boot/dts/marvell/armada-388-helios4.dts
 +++ b/arch/arm/boot/dts/marvell/armada-388-helios4.dts
 @@ -8,6 +8,7 @@
@@ -87,5 +86,5 @@ index 626a7339a5d0..6e0452217265 100644
  
  				eeprom@53 {
 -- 
-2.54.0
+Armbian
 

--- a/patch/kernel/archive/mvebu-6.18/92-mvebu-gpio-add_wake_on_gpio_support.patch
+++ b/patch/kernel/archive/mvebu-6.18/92-mvebu-gpio-add_wake_on_gpio_support.patch
@@ -70,7 +70,7 @@ index 111111111111..222222222222 100644
  #include <linux/io.h>
  #include <linux/irq.h>
  #include <linux/irqchip/chained_irq.h>
-@@ -113,7 +114,7 @@ struct mvebu_gpio_chip {
+@@ -114,7 +115,7 @@ struct mvebu_gpio_chip {
  	struct regmap     *regs;
  	u32		   offset;
  	struct regmap     *percpu_regs;
@@ -79,8 +79,8 @@ index 111111111111..222222222222 100644
  	struct irq_domain *domain;
  	int		   soc_variant;
  
-@@ -609,6 +610,33 @@ static const struct regmap_config mvebu_gpio_regmap_config = {
- 	.fast_io = true,
+@@ -604,6 +605,33 @@ static const struct regmap_config mvebu_gpio_regmap_config = {
+ 	.val_bits = 32,
  };
  
 +/*
@@ -113,7 +113,7 @@ index 111111111111..222222222222 100644
  /*
   * Functions implementing the pwm_chip methods
   */
-@@ -1255,7 +1283,7 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
+@@ -1254,7 +1282,7 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
  
  	err = irq_alloc_domain_generic_chips(
  	    mvchip->domain, ngpios, 2, np->name, handle_level_irq,
@@ -122,7 +122,7 @@ index 111111111111..222222222222 100644
  	if (err) {
  		dev_err(&pdev->dev, "couldn't allocate irq chips %s (DT).\n",
  			mvchip->chip.label);
-@@ -1273,6 +1301,8 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
+@@ -1272,6 +1300,8 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
  	ct->chip.irq_mask = mvebu_gpio_level_irq_mask;
  	ct->chip.irq_unmask = mvebu_gpio_level_irq_unmask;
  	ct->chip.irq_set_type = mvebu_gpio_irq_set_type;
@@ -131,7 +131,7 @@ index 111111111111..222222222222 100644
  	ct->chip.name = mvchip->chip.label;
  
  	ct = &gc->chip_types[1];
-@@ -1281,6 +1311,8 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
+@@ -1280,6 +1310,8 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
  	ct->chip.irq_mask = mvebu_gpio_edge_irq_mask;
  	ct->chip.irq_unmask = mvebu_gpio_edge_irq_unmask;
  	ct->chip.irq_set_type = mvebu_gpio_irq_set_type;
@@ -140,7 +140,7 @@ index 111111111111..222222222222 100644
  	ct->handler = handle_edge_irq;
  	ct->chip.name = mvchip->chip.label;
  
-@@ -1296,6 +1328,7 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
+@@ -1295,6 +1327,7 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
  			continue;
  		irq_set_chained_handler_and_data(irq, mvebu_gpio_irq_handler,
  						 mvchip);

--- a/patch/kernel/archive/mvebu-6.18/92-mvebu-gpio-multi-pwm-per-bank.patch
+++ b/patch/kernel/archive/mvebu-6.18/92-mvebu-gpio-multi-pwm-per-bank.patch
@@ -45,7 +45,11 @@ Co-authored-by: Rosen Penev <rosenp@gmail.com>
 Assisted-by: Claude:claude-opus-4.8
 Signed-off-by: Igor Velkov <325961+iav@users.noreply.github.com>
 ---
+ drivers/gpio/gpio-mvebu.c | 335 +++++++---
+ 1 file changed, 253 insertions(+), 82 deletions(-)
+
 diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
+index 111111111111..222222222222 100644
 --- a/drivers/gpio/gpio-mvebu.c
 +++ b/drivers/gpio/gpio-mvebu.c
 @@ -96,20 +96,69 @@
@@ -123,7 +127,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  struct mvebu_gpio_chip {
  	struct gpio_chip   chip;
  	struct regmap     *regs;
-@@ -286,14 +335,14 @@
+@@ -286,14 +335,14 @@ mvebu_gpio_write_level_mask(struct mvebu_gpio_chip *mvchip, u32 val)
   * Functions returning offsets of individual registers for a given
   * PWM controller.
   */
@@ -142,7 +146,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  }
  
  /*
-@@ -644,40 +693,90 @@
+@@ -644,40 +693,90 @@ static int mvebu_pwm_request(struct pwm_chip *chip, struct pwm_device *pwm)
  {
  	struct mvebu_pwm *mvpwm = to_mvebu_pwm(chip);
  	struct mvebu_gpio_chip *mvchip = mvpwm->mvchip;
@@ -191,8 +195,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
 +	if (counter)
 +		counter->in_use = true;
 +	spin_unlock_irqrestore(&mvebu_pwm_lock, flags);
- 
--		mvpwm->gpiod = desc;
++
 +	if (!counter) {
 +		clear_bit(pwm->hwpwm, mvpwm->hwlock);
 +		/*
@@ -200,11 +203,9 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
 +		 * ask the consumer to retry instead of failing permanently.
 +		 */
 +		return incomplete ? -EPROBE_DEFER : -EBUSY;
- 	}
--out:
--	spin_unlock_irqrestore(&mvpwm->lock, flags);
--	return ret;
-+
++	}
+ 
+-		mvpwm->gpiod = desc;
 +	desc = gpiochip_request_own_desc(&mvchip->chip, pwm->hwpwm, "mvebu-pwm",
 +					 GPIO_ACTIVE_HIGH, GPIOD_OUT_LOW);
 +	if (IS_ERR(desc)) {
@@ -213,7 +214,10 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
 +		spin_unlock_irqrestore(&mvebu_pwm_lock, flags);
 +		clear_bit(pwm->hwpwm, mvpwm->hwlock);
 +		return PTR_ERR(desc);
-+	}
+ 	}
+-out:
+-	spin_unlock_irqrestore(&mvpwm->lock, flags);
+-	return ret;
 +
 +	/* Route this line to the claimed counter (select bit: 0 -> A, 1 -> B). */
 +	spin_lock_irqsave(&mvebu_pwm_lock, flags);
@@ -253,7 +257,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  }
  
  static int mvebu_pwm_get_state(struct pwm_chip *chip,
-@@ -687,36 +786,38 @@
+@@ -687,36 +786,38 @@ static int mvebu_pwm_get_state(struct pwm_chip *chip,
  
  	struct mvebu_pwm *mvpwm = to_mvebu_pwm(chip);
  	struct mvebu_gpio_chip *mvchip = mvpwm->mvchip;
@@ -302,7 +306,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  
  	return 0;
  }
-@@ -726,6 +827,8 @@
+@@ -726,6 +827,8 @@ static int mvebu_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
  {
  	struct mvebu_pwm *mvpwm = to_mvebu_pwm(chip);
  	struct mvebu_gpio_chip *mvchip = mvpwm->mvchip;
@@ -311,7 +315,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  	unsigned long long val;
  	unsigned long flags;
  	unsigned int on, off;
-@@ -733,7 +836,7 @@
+@@ -733,7 +836,7 @@ static int mvebu_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
  	if (state->polarity != PWM_POLARITY_NORMAL)
  		return -EINVAL;
  
@@ -320,7 +324,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  	do_div(val, NSEC_PER_SEC);
  	if (val > UINT_MAX + 1ULL)
  		return -EINVAL;
-@@ -748,7 +851,7 @@
+@@ -748,7 +851,7 @@ static int mvebu_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
  	else
  		on = 1;
  
@@ -329,7 +333,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  	do_div(val, NSEC_PER_SEC);
  	val -= on;
  	if (val > UINT_MAX + 1ULL)
-@@ -760,16 +863,16 @@
+@@ -760,16 +863,16 @@ static int mvebu_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
  	else
  		off = 1;
  
@@ -350,7 +354,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  
  	return 0;
  }
-@@ -784,25 +887,38 @@
+@@ -784,25 +887,38 @@ static const struct pwm_ops mvebu_pwm_ops = {
  static void __maybe_unused mvebu_pwm_suspend(struct mvebu_gpio_chip *mvchip)
  {
  	struct mvebu_pwm *mvpwm = mvchip->mvpwm;
@@ -397,7 +401,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  }
  
  static int mvebu_pwm_probe(struct platform_device *pdev,
-@@ -810,15 +926,20 @@
+@@ -810,15 +926,20 @@ static int mvebu_pwm_probe(struct platform_device *pdev,
  			   int id)
  {
  	struct device *dev = &pdev->dev;
@@ -420,7 +424,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  		if (ret < 0)
  			return 0;
  	} else {
-@@ -836,28 +957,21 @@
+@@ -836,28 +957,21 @@ static int mvebu_pwm_probe(struct platform_device *pdev,
  	if (IS_ERR(mvchip->clk))
  		return PTR_ERR(mvchip->clk);
  
@@ -453,7 +457,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  			break;
  		default:
  			return -EINVAL;
-@@ -867,37 +981,87 @@
+@@ -867,37 +981,87 @@ static int mvebu_pwm_probe(struct platform_device *pdev,
  		if (IS_ERR(base))
  			return PTR_ERR(base);
  
@@ -557,7 +561,7 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  }
  
  #ifdef CONFIG_DEBUG_FS
-@@ -1333,6 +1497,13 @@
+@@ -1337,6 +1501,13 @@ static struct platform_driver mvebu_gpio_driver = {
  	.driver		= {
  		.name		= "mvebu-gpio",
  		.of_match_table = mvebu_gpio_of_match,
@@ -571,3 +575,6 @@ diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
  	},
  	.probe		= mvebu_gpio_probe,
  	.suspend        = mvebu_gpio_suspend,
+-- 
+Armbian
+

--- a/patch/kernel/archive/mvebu-6.18/94-helios4-dts-add-wake-on-lan-support.patch
+++ b/patch/kernel/archive/mvebu-6.18/94-helios4-dts-add-wake-on-lan-support.patch
@@ -66,7 +66,7 @@ diff --git a/arch/arm/boot/dts/marvell/armada-388-helios4.dts b/arch/arm/boot/dt
 index 111111111111..222222222222 100644
 --- a/arch/arm/boot/dts/marvell/armada-388-helios4.dts
 +++ b/arch/arm/boot/dts/marvell/armada-388-helios4.dts
-@@ -87,6 +87,18 @@ fault-led {
+@@ -117,6 +117,18 @@ fault-led {
  		};
  	};
  

--- a/patch/kernel/archive/rockchip64-6.18/drv-bluetooth-hci-sprd-broken-park-link-quirk-v6.16-plus.patch
+++ b/patch/kernel/archive/rockchip64-6.18/drv-bluetooth-hci-sprd-broken-park-link-quirk-v6.16-plus.patch
@@ -49,7 +49,7 @@ diff --git a/net/bluetooth/hci_sync.c b/net/bluetooth/hci_sync.c
 index 111111111111..222222222222 100644
 --- a/net/bluetooth/hci_sync.c
 +++ b/net/bluetooth/hci_sync.c
-@@ -4261,7 +4261,7 @@ static int hci_setup_link_policy_sync(struct hci_dev *hdev)
+@@ -4324,7 +4324,7 @@ static int hci_setup_link_policy_sync(struct hci_dev *hdev)
  		link_policy |= HCI_LP_HOLD;
  	if (lmp_sniff_capable(hdev))
  		link_policy |= HCI_LP_SNIFF;

--- a/patch/kernel/archive/rockchip64-6.18/general-can-1-skb-make-echo-skb-freeing-safe-in-any-IRQ-contex.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-can-1-skb-make-echo-skb-freeing-safe-in-any-IRQ-contex.patch
@@ -1,7 +1,7 @@
-From 22bc38b1ea127f19276e188f6dbcd15ff774b583 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cunhao Lu <1579567540@qq.com>
 Date: Fri, 31 Jul 2026 17:14:24 +0800
-Subject: [PATCH 1/3] can: skb: make echo skb freeing safe in any IRQ context
+Subject: can: skb: make echo skb freeing safe in any IRQ context
 
 can_put_echo_skb() can be called with hardware interrupts disabled. Its
 direct drop paths use kfree_skb(), while can_create_echo_skb() uses
@@ -23,10 +23,10 @@ Changes in v3:
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
-index 95fcdc1026f8..d7b5a5d17ff2 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/dev/skb.c
 +++ b/drivers/net/can/dev/skb.c
-@@ -62,7 +62,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+@@ -60,7 +60,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
  	    (skb->protocol != htons(ETH_P_CAN) &&
  	     skb->protocol != htons(ETH_P_CANFD) &&
  	     skb->protocol != htons(ETH_P_CANXL))) {
@@ -35,7 +35,7 @@ index 95fcdc1026f8..d7b5a5d17ff2 100644
  		return 0;
  	}
  
-@@ -90,7 +90,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+@@ -86,7 +86,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
  	} else {
  		/* locking problem with netif_stop_queue() ?? */
  		netdev_err(dev, "%s: BUG! echo_skb %d is occupied!\n", __func__, idx);
@@ -45,10 +45,10 @@ index 95fcdc1026f8..d7b5a5d17ff2 100644
  	}
  
 diff --git a/include/linux/can/skb.h b/include/linux/can/skb.h
-index a70a02967071..78c5870e2f9a 100644
+index 111111111111..222222222222 100644
 --- a/include/linux/can/skb.h
 +++ b/include/linux/can/skb.h
-@@ -76,12 +76,12 @@ static inline struct sk_buff *can_create_echo_skb(struct sk_buff *skb)
+@@ -90,12 +90,12 @@ static inline struct sk_buff *can_create_echo_skb(struct sk_buff *skb)
  
  	nskb = skb_clone(skb, GFP_ATOMIC);
  	if (unlikely(!nskb)) {
@@ -64,5 +64,5 @@ index a70a02967071..78c5870e2f9a 100644
  }
  
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/general-can-3-dev-can_put_echo_skb-free-skb-on-invalid-echo-in.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-can-3-dev-can_put_echo_skb-free-skb-on-invalid-echo-in.patch
@@ -1,8 +1,7 @@
-From fefeeb8d95a0dedf8050612c04771ee37ea20dc4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cunhao Lu <1579567540@qq.com>
 Date: Fri, 31 Jul 2026 17:14:56 +0800
-Subject: [PATCH 3/3] can: dev: can_put_echo_skb(): free skb on invalid echo
- index
+Subject: can: dev: can_put_echo_skb(): free skb on invalid echo index
 
 can_put_echo_skb() consumes the skb on all paths except when the echo
 index is out of bounds. This leaves ownership with the caller on -EINVAL,
@@ -24,10 +23,10 @@ Changes in v2:
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
-index d34d3e7d4c9f..e985616c062c 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/dev/skb.c
 +++ b/drivers/net/can/dev/skb.c
-@@ -54,6 +54,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
+@@ -52,6 +52,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
  	if (idx >= priv->echo_skb_max) {
  		netdev_err(dev, "%s: BUG! Trying to access can_priv::echo_skb out of bounds (%u/max %u)\n",
  			   __func__, idx, priv->echo_skb_max);
@@ -36,5 +35,5 @@ index d34d3e7d4c9f..e985616c062c 100644
  	}
  
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/general-can-4-rockchip_canfd-prevent-TX-stall-on-echo-skb-fail.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-can-4-rockchip_canfd-prevent-TX-stall-on-echo-skb-fail.patch
@@ -1,7 +1,7 @@
-From 08956ae250aabf15d728a7502ff86986f540be55 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cunhao Lu <1579567540@qq.com>
 Date: Thu, 30 Jul 2026 23:16:17 +0800
-Subject: [PATCH 1/3] can: rockchip_canfd: prevent TX stall on echo skb failure
+Subject: can: rockchip_canfd: prevent TX stall on echo skb failure
 
 rkcanfd_start_xmit() advances tx_head and requests transmission even when
 can_put_echo_skb() fails. This creates a pending TX entry without the echo
@@ -22,11 +22,11 @@ Fixes: b6661d73290c ("can: rockchip_canfd: add TX PATH")
 Cc: stable@vger.kernel.org
 Signed-off-by: Cunhao Lu <1579567540@qq.com>
 ---
- drivers/net/can/rockchip/rockchip_canfd-tx.c | 17 +++++++++++------
+ drivers/net/can/rockchip/rockchip_canfd-tx.c | 17 ++++++----
  1 file changed, 11 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
-index 12200dcfd338..86fa8f2e1c8b 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
 @@ -88,7 +88,16 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
@@ -68,5 +68,5 @@ index 12200dcfd338..86fa8f2e1c8b 100644
  	WRITE_ONCE(priv->tx_head, priv->tx_head + 1);
  
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/general-can-5-rockchip_canfd-retry-the-outstanding-TX-buffer.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-can-5-rockchip_canfd-retry-the-outstanding-TX-buffer.patch
@@ -1,7 +1,7 @@
-From 20fc9c7818d49faa1d6587ac2da6cfdb1f4b94b3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cunhao Lu <1579567540@qq.com>
 Date: Fri, 31 Jul 2026 17:16:27 +0800
-Subject: [PATCH 2/3] can: rockchip_canfd: retry the outstanding TX buffer
+Subject: can: rockchip_canfd: retry the outstanding TX buffer
 
 rkcanfd_xmit_retry() originally operated with a TX FIFO depth of one. At
 that depth, the masked head and tail indices both select buffer 0, so using
@@ -22,7 +22,7 @@ Signed-off-by: Cunhao Lu <1579567540@qq.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
-index 86fa8f2e1c8b..fc338ea865fe 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
 @@ -57,8 +57,8 @@ static void rkcanfd_start_xmit_write_cmd(const struct rkcanfd_priv *priv,
@@ -37,5 +37,5 @@ index 86fa8f2e1c8b..fc338ea865fe 100644
  	rkcanfd_start_xmit_write_cmd(priv, reg_cmd);
  }
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/general-can-6-rockchip_canfd-serialize-TX-state-and-command-wr.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-can-6-rockchip_canfd-serialize-TX-state-and-command-wr.patch
@@ -1,8 +1,7 @@
-From d88c17cb3aa0b055cf7d652e95f5696864e60e75 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cunhao Lu <1579567540@qq.com>
 Date: Fri, 31 Jul 2026 17:17:29 +0800
-Subject: [PATCH 3/3] can: rockchip_canfd: serialize TX state and command
- writes
+Subject: can: rockchip_canfd: serialize TX state and command writes
 
 The TX completion path removes an echo skb before advancing tx_tail. In
 parallel, the transmit path reads tx_head, tx_tail and the tail echo slot
@@ -41,17 +40,17 @@ Fixes: 83f9bd6bf39d ("can: rockchip_canfd: implement workaround for erratum 12")
 Cc: stable@vger.kernel.org
 Signed-off-by: Cunhao Lu <1579567540@qq.com>
 ---
- .../net/can/rockchip/rockchip_canfd-core.c    |  1 +
- drivers/net/can/rockchip/rockchip_canfd-rx.c  | 31 ++++++++++++++-----
- drivers/net/can/rockchip/rockchip_canfd-tx.c  | 26 ++++++++++++++--
- drivers/net/can/rockchip/rockchip_canfd.h     |  4 ++-
+ drivers/net/can/rockchip/rockchip_canfd-core.c |  1 +
+ drivers/net/can/rockchip/rockchip_canfd-rx.c   | 31 +++++++---
+ drivers/net/can/rockchip/rockchip_canfd-tx.c   | 26 +++++++-
+ drivers/net/can/rockchip/rockchip_canfd.h      |  4 +-
  4 files changed, 50 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-core.c b/drivers/net/can/rockchip/rockchip_canfd-core.c
-index 29de0c01e4ed..c8257858b452 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-core.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-core.c
-@@ -904,6 +904,7 @@ static int rkcanfd_probe(struct platform_device *pdev)
+@@ -905,6 +905,7 @@ static int rkcanfd_probe(struct platform_device *pdev)
  	priv->can.do_set_mode = rkcanfd_set_mode;
  	priv->can.do_get_berr_counter = rkcanfd_get_berr_counter;
  	priv->ndev = ndev;
@@ -60,7 +59,7 @@ index 29de0c01e4ed..c8257858b452 100644
  	match = device_get_match_data(&pdev->dev);
  	if (match) {
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-rx.c b/drivers/net/can/rockchip/rockchip_canfd-rx.c
-index 475c0409e215..02efc8c0cddc 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-rx.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-rx.c
 @@ -100,14 +100,25 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
@@ -156,7 +155,7 @@ index 475c0409e215..02efc8c0cddc 100644
  }
  
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
-index fc338ea865fe..b367341dd0ae 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
 @@ -14,6 +14,8 @@ static bool rkcanfd_tx_tail_is_eff(const struct rkcanfd_priv *priv)
@@ -243,7 +242,7 @@ index fc338ea865fe..b367341dd0ae 100644
  	skb = priv->can.echo_skb[tx_tail];
  
 diff --git a/drivers/net/can/rockchip/rockchip_canfd.h b/drivers/net/can/rockchip/rockchip_canfd.h
-index 93131c7d7f54..3cf283a7b380 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd.h
 +++ b/drivers/net/can/rockchip/rockchip_canfd.h
 @@ -15,6 +15,7 @@
@@ -272,5 +271,5 @@ index 93131c7d7f54..3cf283a7b380 100644
  netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev);
  void rkcanfd_handle_tx_done_one(struct rkcanfd_priv *priv, const u32 ts,
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.18/general-disable-mtu-validation.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-disable-mtu-validation.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/eth
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -5833,27 +5833,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
+@@ -5842,27 +5842,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
  static int stmmac_change_mtu(struct net_device *dev, int new_mtu)
  {
  	struct stmmac_priv *priv = netdev_priv(dev);

--- a/patch/kernel/archive/rockchip64-6.18/rk3588-1202-arm64-dts-rockchip-Enable-the-NPU-on-Turing-RK1.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3588-1202-arm64-dts-rockchip-Enable-the-NPU-on-Turing-RK1.patch
@@ -15,7 +15,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi b/arch/arm64/bo
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
-@@ -324,6 +324,10 @@ &pd_gpu {
+@@ -294,6 +294,10 @@ &pd_gpu {
  	domain-supply = <&vdd_gpu_s0>;
  };
  
@@ -26,7 +26,7 @@ index 111111111111..222222222222 100644
  &pinctrl {
  	fan {
  		fan_int: fan-int {
-@@ -364,6 +368,36 @@ &pwm0 {
+@@ -334,6 +338,36 @@ &pwm0 {
  	status = "okay";
  };
  

--- a/patch/kernel/archive/rockchip64-6.18/rk3588-1230-can-rockchip-add-rk3588-can-support.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3588-1230-can-rockchip-add-rk3588-can-support.patch
@@ -162,7 +162,7 @@ diff --git a/drivers/net/can/rockchip/rockchip_canfd-rx.c b/drivers/net/can/rock
 index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-rx.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-rx.c
-@@ -281,7 +281,10 @@ rkcanfd_rx_fifo_get_len(const struct rkcanfd_priv *priv)
+@@ -296,7 +296,10 @@ rkcanfd_rx_fifo_get_len(const struct rkcanfd_priv *priv)
  {
  	const u32 reg = rkcanfd_read(priv, RKCANFD_REG_RX_FIFO_CTRL);
  
@@ -178,7 +178,7 @@ diff --git a/drivers/net/can/rockchip/rockchip_canfd.h b/drivers/net/can/rockchi
 index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd.h
 +++ b/drivers/net/can/rockchip/rockchip_canfd.h
-@@ -214,7 +214,8 @@
+@@ -215,7 +215,8 @@
  #define RKCANFD_REG_TXEVENT_FIFO_CTRL_TXE_FIFO_ENABLE BIT(0)
  
  #define RKCANFD_REG_RX_FIFO_CTRL 0x118
@@ -188,7 +188,7 @@ index 111111111111..222222222222 100644
  #define RKCANFD_REG_RX_FIFO_CTRL_RX_FIFO_FULL_WATERMARK GENMASK(3, 1)
  #define RKCANFD_REG_RX_FIFO_CTRL_RX_FIFO_ENABLE BIT(0)
  
-@@ -331,6 +332,11 @@
+@@ -332,6 +333,11 @@
   * rarely with the standard clock of 300 MHz, but almost immediately
   * at 80 MHz.
   *
@@ -200,7 +200,7 @@ index 111111111111..222222222222 100644
   * To workaround this problem, check for empty FIFO with
   * rkcanfd_fifo_header_empty() in rkcanfd_handle_rx_int_one() and exit
   * early.
-@@ -344,6 +350,8 @@
+@@ -345,6 +351,8 @@
  /* Erratum 6: The CAN controller's transmission of extended frames may
   * intermittently change into standard frames
   *
@@ -209,7 +209,7 @@ index 111111111111..222222222222 100644
   * Work around this issue by activating self reception (RXSTX). If we
   * have pending TX CAN frames, check all RX'ed CAN frames in
   * rkcanfd_rxstx_filter().
-@@ -424,6 +432,9 @@
+@@ -425,6 +433,9 @@
   *     cansequence -rv -i 1
   *
   * - TX starvation after repeated Bus-Off
@@ -219,7 +219,7 @@ index 111111111111..222222222222 100644
   *   To reproduce:
   *   host:
   *     sleep 3 && cangen can0 -I2 -Li -Di -p10 -g 0.0
-@@ -434,6 +445,7 @@
+@@ -435,6 +446,7 @@
  enum rkcanfd_model {
  	RKCANFD_MODEL_RK3568V2 = 0x35682,
  	RKCANFD_MODEL_RK3568V3 = 0x35683,

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-orangepi-zero2-enable-expansion-board-usb.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-sun50i-h616-orangepi-zero2-enable-expansion-board-usb.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Michał Dziękoński <michal.dziekonski+github@gmail.com>
+From: Michal Dziekonski <michal.dziekonski+github@gmail.com>
 Date: Sun, 28 May 2023 00:26:43 +0000
 Subject: arm64: dts: allwinner: h616 orangepi zero2: Enable expansion board
  USB ports

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-bluetooth-hci-sprd-broken-park-link-quirk-v6.16-plus.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-bluetooth-hci-sprd-broken-park-link-quirk-v6.16-plus.patch
@@ -49,7 +49,7 @@ diff --git a/net/bluetooth/hci_sync.c b/net/bluetooth/hci_sync.c
 index 111111111111..222222222222 100644
 --- a/net/bluetooth/hci_sync.c
 +++ b/net/bluetooth/hci_sync.c
-@@ -4261,7 +4261,7 @@ static int hci_setup_link_policy_sync(struct hci_dev *hdev)
+@@ -4324,7 +4324,7 @@ static int hci_setup_link_policy_sync(struct hci_dev *hdev)
  		link_policy |= HCI_LP_HOLD;
  	if (lmp_sniff_capable(hdev))
  		link_policy |= HCI_LP_SNIFF;

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-net-wireless-brcmfmac-add-ap6330-firmware.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-net-wireless-brcmfmac-add-ap6330-firmware.patch
@@ -1,10 +1,164 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Al Nahian <alnahian201@gmail.com>
+Date: Wed, 5 Aug 2026 06:15:39 +0200
+Subject: [ARCHEOLOGY] Feat/add tanix tx6s axp313 (#10290)
+
+> X-Git-Archeology: > recovered message: > * TX6s AXP313 board port + WiFi pwrseq/compatible fixes
+> X-Git-Archeology: > recovered message: > * Rename board config to .tvb classification for TV box
+> X-Git-Archeology: > recovered message: > * wifi: drop host-wake interrupt from wlan node
+> X-Git-Archeology: > recovered message: > The host-wake GPIO/interrupt config (PG15, edge-rising) was copied
+> X-Git-Archeology: > recovered message: > from an AP6330-pattern reference board. This board's actual WiFi
+> X-Git-Archeology: > recovered message: > chip is XR819 (xradio_wlan), not AP6330/brcmfmac. WiFi connects
+> X-Git-Archeology: > recovered message: > and passes traffic correctly without claiming this interrupt, and
+> X-Git-Archeology: > recovered message: > host-wake is only relevant for WoWLAN suspend, not basic
+> X-Git-Archeology: > recovered message: > connectivity, so it's safer to leave unclaimed until confirmed
+> X-Git-Archeology: > recovered message: > correct for this variant.
+> X-Git-Archeology: > recovered message: > * fix: enable SPDIF controller in axp313 DTS
+> X-Git-Archeology: > recovered message: > sound-spdif card was defined but the &spdif controller itself was
+> X-Git-Archeology: > recovered message: > never enabled, so the audio card couldn't bind. Add the missing
+> X-Git-Archeology: > recovered message: > &spdif { status = "okay"; }; override, matching the standard
+> X-Git-Archeology: > recovered message: > (non-axp313) TX6s variant.
+> X-Git-Archeology: > recovered message: > * Update maintainer for Tanix TX6s AXP313 board
+> X-Git-Archeology: > recovered message: > * fix: remove conflicting R_I2C PMIC node from tanix-tx6s defconfig
+> X-Git-Archeology: > recovered message: > axp305_1 under &r_i2c was a dummy placeholder (its own comment
+> X-Git-Archeology: > recovered message: > says 'appease the driver for now') with no real regulator config
+> X-Git-Archeology: > recovered message: > and a fake interrupt. The actual PMIC config lives under &r_rsb
+> X-Git-Archeology: > recovered message: > (axp305), which already provides all real regulators. R_I2C and
+> X-Git-Archeology: > recovered message: > R_RSB share the same physical pins (PL0/PL1) and can't both be
+> X-Git-Archeology: > recovered message: > enabled, so the dummy &r_i2c block was a real pinmux conflict.
+> X-Git-Archeology: > recovered message: > * fix: PR review round 1 (MAC, symlink, R_I2C conflict, maintainer)
+> X-Git-Archeology: > recovered message: > - Remove hardcoded WiFi MAC address from wlan node (all 3 kernel
+> X-Git-Archeology: > recovered message: > versions) to avoid address collisions across boards
+> X-Git-Archeology: > recovered message: > - Remove AP6330 firmware symlink; board's actual chip is XR819
+> X-Git-Archeology: > recovered message: > - Set BOARD_MAINTAINER
+> X-Git-Archeology: > recovered message: > - Replace duplicate cp -R with install -Dm755 for audio config
+> X-Git-Archeology: > recovered message: > - Remove conflicting &r_i2c/axp305_1 dummy PMIC node from
+> X-Git-Archeology: > recovered message: > tanix-tx6s defconfig; real PMIC config is under &r_rsb/axp305
+> X-Git-Archeology: > recovered message: > * fix: correct DRAM config namespace in axp313 defconfig
+> X-Git-Archeology: > recovered message: > CONFIG_SUNXI_DRAM_H616_DDR3_1333=y expects DRAM tuning values under
+> X-Git-Archeology: > recovered message: > the CONFIG_DRAM_SUN50I_H616_* namespace (matching tanix_tx6s_defconfig),
+> X-Git-Archeology: > recovered message: > but the axp313 defconfig had them under the wrong CONFIG_DRAM_SUNXI_*
+> X-Git-Archeology: > recovered message: > namespace. Kconfig was silently discarding these vendor-tuned DRAM
+> X-Git-Archeology: > recovered message: > timings and falling back to defaults instead.
+> X-Git-Archeology: > recovered message: > * fix: correct ethernet-phy node unit-address to match reg value
+> X-Git-Archeology: > recovered message: > DT convention requires the node's @unit-address suffix to match
+> X-Git-Archeology: > recovered message: > the reg property value in hex. reg = <16> is 0x10 in hex, so the
+> X-Git-Archeology: > recovered message: > node was renamed from ethernet-phy@16 to ethernet-phy@10 to match.
+> X-Git-Archeology: > recovered message: > The actual PHY address (reg = <16>) is unchanged.
+> X-Git-Archeology: > recovered message: > * fix: give axp313 variant a distinct compatible string
+> X-Git-Archeology: > recovered message: > Both the standard TX6s (AXP305) and TX6s AXP313 variant shared the
+> X-Git-Archeology: > recovered message: > identical compatible = "tanix,tx6s", "allwinner,sun50i-h616" string,
+> X-Git-Archeology: > recovered message: > making them indistinguishable to anything matching on compatible.
+> X-Git-Archeology: > recovered message: > Added a distinct primary compatible ("tanix,tx6s-axp313") for the
+> X-Git-Archeology: > recovered message: > AXP313 variant while keeping the shared fallbacks, updated
+> X-Git-Archeology: > recovered message: > consistently across the U-Boot defconfig and all 3 kernel DTS
+> X-Git-Archeology: > recovered message: > patch versions.
+> X-Git-Archeology: > recovered message: > * fix: add missing startup-delay-us to WiFi regulator on AXP305 variant
+> X-Git-Archeology: > recovered message: > The AXP313 variant's WiFi power regulator (reg_vcc_wifi) had
+> X-Git-Archeology: > recovered message: > startup-delay-us = <200000> to give the WiFi chip time to settle
+> X-Git-Archeology: > recovered message: > after WL_REG_ON goes high before SDIO probes it. The standard
+> X-Git-Archeology: > recovered message: > AXP305 variant was missing this delay entirely despite using the
+> X-Git-Archeology: > recovered message: > identical WiFi chip and power sequencing. Added for consistency
+> X-Git-Archeology: > recovered message: > and to avoid the same SDIO probe-timing issue across all 3 kernel
+> X-Git-Archeology: > recovered message: > versions.
+> X-Git-Archeology: > recovered message: > * revert: restore correct DRAM_SUNXI_* Kconfig namespace in axp313 defconfig
+> X-Git-Archeology: > recovered message: > An earlier commit changed these DRAM tuning symbols from
+> X-Git-Archeology: > recovered message: > CONFIG_DRAM_SUNXI_* to CONFIG_DRAM_SUN50I_H616_*, based on a
+> X-Git-Archeology: > recovered message: > mistaken comparison against the naming used in the standard
+> X-Git-Archeology: > recovered message: > tanix_tx6s_defconfig. Verified against this U-Boot version's
+> X-Git-Archeology: > recovered message: > actual Kconfig (arch/arm/mach-sunxi/Kconfig): DRAM_SUN50I_H616
+> X-Git-Archeology: > recovered message: > is only the top-level enable symbol; the individual DRAM tuning
+> X-Git-Archeology: > recovered message: > parameters underneath it (DX_ODT, DX_DRI, CA_DRI, ODT_EN, TPR0/2/
+> X-Git-Archeology: > recovered message: > 10/11/12, etc.) are genuinely namespaced DRAM_SUNXI_*. The
+> X-Git-Archeology: > recovered message: > previous change caused Kconfig to reject the values as invalid
+> X-Git-Archeology: > recovered message: > symbols and drop into an interactive reconfigure prompt, hanging
+> X-Git-Archeology: > recovered message: > non-interactive builds. Confirmed fixed with a full clean build.
+> X-Git-Archeology: > recovered message: > * fix: remove stale AIC8800 patch reference from sunxi-7.0 series.conf
+> X-Git-Archeology: > recovered message: > series.conf referenced patches.armbian/3401-net-wireless-backport-aic8800-sdio-v2025_0926_91c9dae5-mm2.patch,
+> X-Git-Archeology: > recovered message: > which doesn't exist anywhere in the tree. This would break kernel
+> X-Git-Archeology: > recovered message: > patch application for anyone building the sunxi-7.0 branch.
+> X-Git-Archeology: > recovered message: > * fix: correct indentation and remove stale patch references per review
+> X-Git-Archeology: > recovered message: > - Fix series.conf indentation for 0110-...ap6330-firmware.patch in
+> X-Git-Archeology: > recovered message: > sunxi-6.18 and sunxi-7.0 (spaces -> tab, matching surrounding lines)
+> X-Git-Archeology: > recovered message: > - Remove stale disabled references to
+> X-Git-Archeology: > recovered message: > patches.backports/32-pinctrl-sunxi-a523-Remove_unneeded_IRQ_remuxing_flag.patch
+> X-Git-Archeology: > recovered message: > and patches.backports/33-arm64-dts-allwinner-a523-Add_missing_GPIO_interrupt.patch
+> X-Git-Archeology: > recovered message: > from sunxi-6.18/series.conf. These were disabled with a leading '-'
+> X-Git-Archeology: > recovered message: > earlier to unblock the build (unrelated to this board), but upstream
+> X-Git-Archeology: > recovered message: > has since fully deleted both patch files and their series.conf
+> X-Git-Archeology: > recovered message: > entries, so these leftover references pointed to nothing.
+> X-Git-Archeology: > recovered message: > * refactor: move axp313 DTS to dt_64 folder (sunxi-6.18)
+> X-Git-Archeology: > recovered message: > Per review feedback, plain device trees that don't modify any
+> X-Git-Archeology: > recovered message: > existing upstream file can go directly in dt_64/ instead of being
+> X-Git-Archeology: > recovered message: > wrapped in a null-patch. Moved sun50i-h616-tanix-tx6s-axp313.dts
+> X-Git-Archeology: > recovered message: > there and removed the now-redundant 0646 patch and its series.conf
+> X-Git-Archeology: > recovered message: > entry. Confirmed with a clean build that the DTB still gets picked
+> X-Git-Archeology: > recovered message: > up and compiles correctly with no separate Makefile patch needed.
+> X-Git-Archeology: > recovered message: > * refactor: move standard TX6s DTS to dt_64 folder (sunxi-6.18)
+> X-Git-Archeology: > recovered message: > Same as the axp313 variant: 0645 only created a new file and never
+> X-Git-Archeology: > recovered message: > modified anything upstream, so per review feedback it's now a plain
+> X-Git-Archeology: > recovered message: > .dts in dt_64/ instead of a wrapped null-patch. Removed the 0645
+> X-Git-Archeology: > recovered message: > patch and its series.conf entry. Confirmed with a clean build that
+> X-Git-Archeology: > recovered message: > both TX6s variants' DTBs still compile correctly together.
+> X-Git-Archeology: > recovered message: > * fix: align DRAM Kconfig namespace across all TX6s U-Boot defconfigs
+> X-Git-Archeology: > recovered message: > CodeRabbit flagged an inconsistency between 0010/0011/0012's DRAM
+> X-Git-Archeology: > recovered message: > tuning symbols. Verified against this U-Boot version's actual
+> X-Git-Archeology: > recovered message: > Kconfig (arch/arm/mach-sunxi/Kconfig): the real namespace for these
+> X-Git-Archeology: > recovered message: > DRAM tuning parameters is CONFIG_DRAM_SUNXI_*, not
+> X-Git-Archeology: > recovered message: > CONFIG_DRAM_SUN50I_H616_* (that's only the top-level DRAM_SUN50I_H616
+> X-Git-Archeology: > recovered message: > enable symbol). This was confirmed empirically: 0011 briefly used
+> X-Git-Archeology: > recovered message: > the SUN50I_H616_* namespace and caused Kconfig to reject the values
+> X-Git-Archeology: > recovered message: > and hang on an interactive reconfigure prompt during a non-interactive
+> X-Git-Archeology: > recovered message: > build. Aligned 0010 and 0012 to the same DRAM_SUNXI_* namespace 0011
+> X-Git-Archeology: > recovered message: > already uses, since 0011 is the one actually build-tested for this PR.
+> X-Git-Archeology: > recovered message: > * refactor: move TX6s DTS to dt_64 folder (sunxi-6.12, sunxi-7.0)
+> X-Git-Archeology: > recovered message: > Completes the dt_64 migration started for sunxi-6.18. Both variants'
+> X-Git-Archeology: > recovered message: > DTS content moved to plain .dts files under dt_64/, and 0645/0646
+> X-Git-Archeology: > recovered message: > patches plus their series.conf entries removed for both kernel
+> X-Git-Archeology: > recovered message: > versions. Also caught and fixed the same WiFi host-wake interrupt
+> X-Git-Archeology: > recovered message: > issue in sunxi-6.12's axp313 DTS that was already fixed in
+> X-Git-Archeology: > recovered message: > sunxi-6.18 but never carried over here (sunxi-7.0 was already
+> X-Git-Archeology: > recovered message: > consistent). Confirmed with a clean full rebuild.
+> X-Git-Archeology: > recovered message: > * remove: armbian-audio-config script
+> X-Git-Archeology: > recovered message: > Per maintainer feedback, this script's scope and provenance were
+> X-Git-Archeology: > recovered message: > unclear for this PR - it targets multiple boards/families, not just
+> X-Git-Archeology: > recovered message: > this one, and its placement under h618 blobs read as more official
+> X-Git-Archeology: > recovered message: > than warranted. Confirmed by testing that audio works correctly
+> X-Git-Archeology: > recovered message: > without it; the only issue was selecting the right PulseAudio
+> X-Git-Archeology: > recovered message: > output (board has 3 stereo outputs: analog, HDMI, SPDIF). A properly
+> X-Git-Archeology: > recovered message: > scoped version can be proposed separately later if needed.
+> X-Git-Archeology: > recovered message: > * fix: remove stale WiFi host-wake interrupt from standard TX6s variant
+> X-Git-Archeology: > recovered message: > CodeRabbit correctly caught that the earlier host-wake interrupt
+> X-Git-Archeology: > recovered message: > removal only applied to the axp313 variant's wlan node - the
+> X-Git-Archeology: > recovered message: > standard (AXP305) TX6s variant still had interrupt-parent,
+> X-Git-Archeology: > recovered message: > interrupts, and interrupt-names in its wlan node across all three
+> X-Git-Archeology: > recovered message: > kernel versions, now migrated to dt_64/sun50i-h616-tanix-tx6s.dts.
+> X-Git-Archeology: > recovered message: > Removed for consistency with the axp313 variant, since this board
+> X-Git-Archeology: > recovered message: > family's actual WiFi chip doesn't correctly drive PG15 as host-wake.
+> X-Git-Archeology: > recovered message: > Confirmed with a clean build.
+> X-Git-Archeology: > recovered message: > ---------
+> X-Git-Archeology: > recovered message: > Co-authored-by: alnahian2011 <214164097+alnahian2011@users.noreply.github.com>
+> X-Git-Archeology: - Revision 43d7f8a43d8525aa3983c9d675a96dd2f99798f2: https://github.com/armbian/build/commit/43d7f8a43d8525aa3983c9d675a96dd2f99798f2
+> X-Git-Archeology:   Date: Wed, 05 Aug 2026 06:15:39 +0200
+> X-Git-Archeology:   From: Al Nahian <alnahian201@gmail.com>
+> X-Git-Archeology:   Subject: Feat/add tanix tx6s axp313 (#10290)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2eea5e9d722919a68dbdaa3d951e8d6e895ba000: https://github.com/armbian/build/commit/2eea5e9d722919a68dbdaa3d951e8d6e895ba000
+> X-Git-Archeology:   Date: Fri, 14 Aug 2026 07:32:12 +0200
+> X-Git-Archeology:   From: EvilOlaf <werner@armbian.com>
+> X-Git-Archeology:   Subject: sunxi-6.18: cleanup patch names, remove long broken patches
+> X-Git-Archeology:
+---
+ drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
 diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c
-index a907d7b06..ec71996c7 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c
-@@ -619,13 +619,17 @@ BRCMF_FW_DEF(4354, "brcmfmac4354-sdio");
- BRCMF_FW_DEF(4356, "brcmfmac4356-sdio");
- BRCMF_FW_DEF(4373, "brcmfmac4373-sdio");
+@@ -632,13 +632,17 @@ MODULE_FIRMWARE(BRCMF_FW_DEFAULT_PATH "brcmfmac*-sdio.*.txt");
+ /* per-board firmware binaries */
+ MODULE_FIRMWARE(BRCMF_FW_DEFAULT_PATH "brcmfmac*-sdio.*.bin");
  
 +/* AMPAK */
 +BRCMF_FW_DEF(AP6330, "brcmfmac-ap6330-sdio");
@@ -21,3 +175,6 @@ index a907d7b06..ec71996c7 100644
  	BRCMF_FW_ENTRY(BRCM_CC_4334_CHIP_ID, 0xFFFFFFFF, 4334),
  	BRCMF_FW_ENTRY(BRCM_CC_43340_CHIP_ID, 0xFFFFFFFF, 43340),
  	BRCMF_FW_ENTRY(BRCM_CC_43341_CHIP_ID, 0xFFFFFFFF, 43340),
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-6.18/patches.media/dma-sun6i-dma-add-sun50i-h616-support.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.media/dma-sun6i-dma-add-sun50i-h616-support.patch
@@ -11,7 +11,7 @@ diff --git a/drivers/dma/sun6i-dma.c b/drivers/dma/sun6i-dma.c
 index 111111111111..222222222222 100644
 --- a/drivers/dma/sun6i-dma.c
 +++ b/drivers/dma/sun6i-dma.c
-@@ -1258,6 +1258,28 @@ static struct sun6i_dma_config sun50i_h6_dma_cfg = {
+@@ -1255,6 +1255,28 @@ static struct sun6i_dma_config sun50i_h6_dma_cfg = {
  	.has_mbus_clk = true,
  };
  
@@ -40,7 +40,7 @@ index 111111111111..222222222222 100644
  /*
   * The V3s have only 8 physical channels, a maximum DRQ port id of 23,
   * and a total of 24 usable source and destination endpoints.
-@@ -1291,6 +1313,7 @@ static const struct of_device_id sun6i_dma_match[] = {
+@@ -1288,6 +1310,7 @@ static const struct of_device_id sun6i_dma_match[] = {
  	{ .compatible = "allwinner,sun50i-a64-dma", .data = &sun50i_a64_dma_cfg },
  	{ .compatible = "allwinner,sun50i-a100-dma", .data = &sun50i_a100_dma_cfg },
  	{ .compatible = "allwinner,sun50i-h6-dma", .data = &sun50i_h6_dma_cfg },

--- a/patch/kernel/archive/sunxi-6.18/patches.megous/a711-6.18/0005-ARM-dts-sun8i-a83t-tbs-a711-Add-powerup-down-support.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.megous/a711-6.18/0005-ARM-dts-sun8i-a83t-tbs-a711-Add-powerup-down-support.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Mylène Josserand <mylene.josserand@bootlin.com>
+From: Mylene Josserand <mylene.josserand@bootlin.com>
 Date: Thu, 6 Jul 2017 10:57:55 +0200
 Subject: ARM: dts: sun8i-a83t-tbs-a711: Add powerup/down support for the 3G
  modem

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-sun55i-a523-add-e906-rproc-node.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-sun55i-a523-add-e906-rproc-node.patch
@@ -1,20 +1,20 @@
-From 9f0a6b2e00000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Date: Wed, 5 Aug 2026 19:25:00 -0400
-Subject: [PATCH] arm64: dts: allwinner: a523: add E906 RISC-V remoteproc node
+Subject: arm64: dts: allwinner: a523: add E906 RISC-V remoteproc node
 
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Assisted-by: opencode:big-pickle
 ---
- arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi | 30 ++++++++++++++++++++++++++++++
- arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts | 60 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi          | 30 +++++
+ arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts | 60 ++++++++++
  2 files changed, 90 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
-index 82d095b..da2c079 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
-@@ -604,6 +604,19 @@
+@@ -574,6 +574,19 @@ sid: efuse@3006000 {
  			#size-cells = <1>;
  		};
  
@@ -34,7 +34,7 @@ index 82d095b..da2c079 100644
  		gic: interrupt-controller@3400000 {
  			compatible = "arm,gic-v3";
  			#address-cells = <1>;
-@@ -1206,5 +1219,22 @@
+@@ -1087,5 +1100,22 @@ npu: npu@7122000 {
  			resets = <&mcu_ccu RST_BUS_MCU_NPU>;
  			power-domains = <&ppu PD_NPU>;
  		};
@@ -58,10 +58,10 @@ index 82d095b..da2c079 100644
  	};
  };
 diff --git a/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts b/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
-index 84d665a..3bcd11e 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
-@@ -24,6 +24,43 @@
+@@ -22,6 +22,43 @@ chosen {
  		stdout-path = "serial0:115200n8";
  	};
  
@@ -105,7 +105,7 @@ index 84d665a..3bcd11e 100644
  	ext_osc32k: ext-osc32k-clk {
  		#clock-cells = <0>;
  		compatible = "fixed-clock";
-@@ -524,3 +561,26 @@
+@@ -442,3 +479,26 @@ &usbphy {
  	usb0_vbus_det-gpios = <&pio 8 13 GPIO_ACTIVE_HIGH>; /* PI13 */
  	status = "okay";
  };
@@ -132,3 +132,6 @@ index 84d665a..3bcd11e 100644
 +		< 0x40040000	0x3ffc0000	0x40040000 >;
 +	status = "okay";
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-sun55i-a523-add-ir-receiver-nodes.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-sun55i-a523-add-ir-receiver-nodes.patch
@@ -1,9 +1,7 @@
-From 20260722233604.3001063-3-utilityemal77@gmail.com Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin Suess <utilityemal77@gmail.com>
 Date: Wed, 22 Jul 2026 19:36:02 -0400
-Subject: [PATCH] arm64: dts: allwinner: a523: add IR receiver nodes
-
-
+Subject: arm64: dts: allwinner: a523: add IR receiver nodes
 
 The A523 has two CIR receivers, both compatible with the A31 CIR: one
 in the CPUX domain, clocked from the main CCU, and one in the RTC
@@ -20,14 +18,14 @@ Signed-off-by: Justin Suess <utilityemal77@gmail.com>
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Assisted-by: opencode:big-pickle
 ---
- .../arm64/boot/dts/allwinner/sun55i-a523.dtsi | 28 +++++++++++++++++++
+ arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi | 28 ++++++++++
  1 file changed, 28 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
-index ca6a16807049..c2de662140ce 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
-@@ -327,6 +327,17 @@ ccu: clock-controller@2001000 {
+@@ -326,6 +326,17 @@ ccu: clock-controller@2001000 {
  			#reset-cells = <1>;
  		};
  
@@ -45,7 +43,7 @@ index ca6a16807049..c2de662140ce 100644
  		ledc: led-controller@2008000 {
  			compatible = "allwinner,sun55i-a523-ledc",
  				     "allwinner,sun50i-a100-ledc";
-@@ -927,6 +938,23 @@ r_i2c_pins: r-i2c-pins {
+@@ -926,6 +937,23 @@ r_i2c_pins: r-i2c-pins {
  				allwinner,pinmux = <2>;
  				function = "r_i2c0";
  			};
@@ -70,7 +68,5 @@ index ca6a16807049..c2de662140ce 100644
  
  		pck600: power-controller@7060000 {
 -- 
-2.54.0
-
-
+Armbian
 

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-sun55i-a523-add-ths.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-sun55i-a523-add-ths.patch
@@ -1,7 +1,7 @@
-From 9f0a6b2e00000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Date: Mon, 10 Aug 2026 21:00:00 -0400
-Subject: [PATCH] arm64: dts: allwinner: a523: add THS nodes and thermal zones
+Subject: arm64: dts: allwinner: a523: add THS nodes and thermal zones
 
 Add thermal.h include, #cooling-cells on all CPUs, ths1@2009400 and
 ths0@200a000 sensor nodes with SID calibration cells and cpu0/cpu4/
@@ -10,12 +10,14 @@ gpu/ddr thermal zones with trips.
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Assisted-by: opencode:big-pickle
 ---
+ arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi | 154 ++++++++++
+ 1 file changed, 154 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
-index 36c8bca5ac63..112dfb49f686 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
-@@ -4,8 +4,9 @@
+@@ -4,6 +4,7 @@
  #include <dt-bindings/interrupt-controller/arm-gic.h>
  #include <dt-bindings/clock/sun6i-rtc.h>
  #include <dt-bindings/clock/sun55i-a523-ccu.h>
@@ -23,9 +25,7 @@ index 36c8bca5ac63..112dfb49f686 100644
  #include <dt-bindings/clock/sun55i-a523-mcu-ccu.h>
  #include <dt-bindings/clock/sun55i-a523-r-ccu.h>
  #include <dt-bindings/reset/sun55i-a523-ccu.h>
- 
- / {
-@@ -27,6 +28,7 @@ cpu0: cpu@0 {
+@@ -26,6 +27,7 @@ cpu0: cpu@0 {
  			device_type = "cpu";
  			reg = <0x000>;
  			enable-method = "psci";
@@ -33,7 +33,7 @@ index 36c8bca5ac63..112dfb49f686 100644
  		};
  
  		cpu1: cpu@100 {
-@@ -34,6 +36,7 @@ cpu1: cpu@100 {
+@@ -33,6 +35,7 @@ cpu1: cpu@100 {
  			device_type = "cpu";
  			reg = <0x100>;
  			enable-method = "psci";
@@ -41,7 +41,7 @@ index 36c8bca5ac63..112dfb49f686 100644
  		};
  
  		cpu2: cpu@200 {
-@@ -41,6 +44,7 @@ cpu2: cpu@200 {
+@@ -40,6 +43,7 @@ cpu2: cpu@200 {
  			device_type = "cpu";
  			reg = <0x200>;
  			enable-method = "psci";
@@ -49,7 +49,7 @@ index 36c8bca5ac63..112dfb49f686 100644
  		};
  
  		cpu3: cpu@300 {
-@@ -48,6 +52,7 @@ cpu3: cpu@300 {
+@@ -47,6 +51,7 @@ cpu3: cpu@300 {
  			device_type = "cpu";
  			reg = <0x300>;
  			enable-method = "psci";
@@ -57,7 +57,7 @@ index 36c8bca5ac63..112dfb49f686 100644
  		};
  
  		cpu4: cpu@400 {
-@@ -55,6 +60,7 @@ cpu4: cpu@400 {
+@@ -54,6 +59,7 @@ cpu4: cpu@400 {
  			device_type = "cpu";
  			reg = <0x400>;
  			enable-method = "psci";
@@ -65,7 +65,7 @@ index 36c8bca5ac63..112dfb49f686 100644
  		};
  
  		cpu5: cpu@500 {
-@@ -62,6 +68,7 @@ cpu5: cpu@500 {
+@@ -61,6 +67,7 @@ cpu5: cpu@500 {
  			device_type = "cpu";
  			reg = <0x500>;
  			enable-method = "psci";
@@ -73,7 +73,7 @@ index 36c8bca5ac63..112dfb49f686 100644
  		};
  
  		cpu6: cpu@600 {
-@@ -69,6 +76,7 @@ cpu6: cpu@600 {
+@@ -68,6 +75,7 @@ cpu6: cpu@600 {
  			device_type = "cpu";
  			reg = <0x600>;
  			enable-method = "psci";
@@ -81,7 +81,7 @@ index 36c8bca5ac63..112dfb49f686 100644
  		};
  
  		cpu7: cpu@700 {
-@@ -76,6 +84,7 @@ cpu7: cpu@700 {
+@@ -75,6 +83,7 @@ cpu7: cpu@700 {
  			device_type = "cpu";
  			reg = <0x700>;
  			enable-method = "psci";
@@ -89,7 +89,7 @@ index 36c8bca5ac63..112dfb49f686 100644
  		};
  	};
  
-@@ -596,12 +605,46 @@ dma: dma-controller@3002000 {
+@@ -577,12 +586,46 @@ dma: dma-controller@3002000 {
  			#dma-cells = <1>;
  		};
  
@@ -136,7 +136,7 @@ index 36c8bca5ac63..112dfb49f686 100644
  		};
  
  		msgbox: mailbox@3003000 {
-@@ -1237,4 +1280,115 @@ e906_rproc: e906_rproc@7130000 {
+@@ -1146,4 +1189,115 @@ e906_rproc: e906_rproc@7130000 {
  			status = "disabled";
  		};
  	};
@@ -254,3 +254,4 @@ index 36c8bca5ac63..112dfb49f686 100644
  };
 -- 
 Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-sun55i-t527-avaota-a1-enable-ir.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-sun55i-t527-avaota-a1-enable-ir.patch
@@ -1,9 +1,7 @@
-From 20260722233604.3001063-5-utilityemal77@gmail.com Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin Suess <utilityemal77@gmail.com>
 Date: Wed, 22 Jul 2026 19:36:04 -0400
-Subject: [PATCH] arm64: dts: allwinner: a523: enable IR on the Avaota A1
-
-
+Subject: arm64: dts: allwinner: a523: enable IR on the Avaota A1
 
 From: Andre Przywara <andre.przywara@arm.com>
 
@@ -24,10 +22,10 @@ Assisted-by: opencode:big-pickle
  2 files changed, 13 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
-index c2de662140ce..219fd76a4710 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
-@@ -155,6 +155,13 @@ i2s2_pi_pins: i2s2-pi-pins {
+@@ -163,6 +163,13 @@ i2s2_pi_pins: i2s2-pi-pins {
  				bias-disable;
  			};
  
@@ -42,10 +40,10 @@ index c2de662140ce..219fd76a4710 100644
  			ledc_ph_pin: ledc-ph-pin {
  				pins = "PH19";
 diff --git a/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts b/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
-index 474354fbfcec..994f1e4f0ce7 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
-@@ -100,6 +100,12 @@ &gpu {
+@@ -137,6 +137,12 @@ &gpu {
  	status = "okay";
  };
  
@@ -59,7 +57,5 @@ index 474354fbfcec..994f1e4f0ce7 100644
  	pinctrl-names = "default";
  	pinctrl-0 = <&ledc_ph_pin>;
 -- 
-2.54.0
-
-
+Armbian
 

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-sun55i-t527-avaota-a1-enable-spi-lcd.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-sun55i-t527-avaota-a1-enable-spi-lcd.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Date: Sat, 1 Aug 2026 00:00:00 +0000
-Subject: [PATCH] arm64: dts: allwinner: sun55i-t527-avaota-a1: Enable SPI LCD
+Subject: arm64: dts: allwinner: sun55i-t527-avaota-a1: Enable SPI LCD
 
 The Avaota A1 has a 1.14" 135x240 ST7789V LCD connected to the R-domain
 SPI0 controller (r_spi0), with the data/command, reset and backlight
@@ -32,14 +32,14 @@ PIO, which handles transfers of any size.
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Assisted-by: opencode:big-pickle
 ---
- arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts | 33 ++++++++++++++++++++++++++
- 1 file changed, 33 insertions(+)
+ arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts | 32 ++++++++++
+ 1 file changed, 32 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts b/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
-index 4ede89104d79..fba626732877 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
-@@ -444,6 +444,12 @@ &r_pio {
+@@ -436,6 +436,12 @@ &r_pio {
   *	vcc-pl-supply = <&reg_aldo3>;
   */
  	vcc-pm-supply = <&reg_aldo3>;
@@ -52,7 +52,7 @@ index 4ede89104d79..fba626732877 100644
  };
  
  &rtc {
-@@ -454,6 +460,32 @@ &rtc {
+@@ -446,6 +452,32 @@ &rtc {
  	assigned-clock-rates = <32768>;
  };
  
@@ -86,4 +86,5 @@ index 4ede89104d79..fba626732877 100644
  	pinctrl-names = "default";
  	pinctrl-0 = <&spi0_pj_pins>, <&spi0_cs0_pj_pin>,
 -- 
-2.54.0
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-and-drivers-sun55i-t527-avaota-a1-st7789v-lcd-fix.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-and-drivers-sun55i-t527-avaota-a1-st7789v-lcd-fix.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Date: Sun, 2 Aug 2026 00:00:00 +0000
-Subject: [PATCH] Avaota A1: fix ST7789V LCD write errors and panel geometry
+Subject: Avaota A1: fix ST7789V LCD write errors and panel geometry
 
 Fix two bugs preventing reliable use of the 135x240 ST7789V LCD on the
 Avaota A1 (sun55i t527) board with the fbtft staging driver:
@@ -38,17 +38,16 @@ tree so the address-mode BGR bit is set.
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Assisted-by: opencode:big-pickle
 ---
- arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts | 1 +
- drivers/gpu/drm/panel/panel-sitronix-st7789v.c          | 3 +-
- drivers/staging/fbtft/fb_st7789v.c                      | 69 +++-------
- 3 files changed, 25 insertions(+), 48 deletions(-)
+ arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts |  1 +
+ drivers/gpu/drm/panel/panel-sitronix-st7789v.c          |  4 +-
+ drivers/staging/fbtft/fb_st7789v.c                      | 92 ++++------
+ 3 files changed, 39 insertions(+), 58 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts b/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
-index fba626732877..9c80576d3ce3 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
-@@ -480,6 +480,7 @@ lcd: st7789v@0 {
- 		width = <135>;
+@@ -475,6 +475,7 @@ lcd: st7789v@0 {
  		height = <240>;
  		buswidth = <8>;
  		rotate = <90>;
@@ -57,7 +56,7 @@ index fba626732877..9c80576d3ce3 100644
  };
  
 diff --git a/drivers/gpu/drm/panel/panel-sitronix-st7789v.c b/drivers/gpu/drm/panel/panel-sitronix-st7789v.c
-index d5f821d6b23c..1b51bc43a9ee 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/panel/panel-sitronix-st7789v.c
 +++ b/drivers/gpu/drm/panel/panel-sitronix-st7789v.c
 @@ -627,8 +627,10 @@ static int st7789v_probe(struct spi_device *spi)
@@ -73,7 +72,7 @@ index d5f821d6b23c..1b51bc43a9ee 100644
  	ctx->info = device_get_match_data(&spi->dev);
  
 diff --git a/drivers/staging/fbtft/fb_st7789v.c b/drivers/staging/fbtft/fb_st7789v.c
-index 861a154144e6..2cce94beb56d 100644
+index 111111111111..222222222222 100644
 --- a/drivers/staging/fbtft/fb_st7789v.c
 +++ b/drivers/staging/fbtft/fb_st7789v.c
 @@ -21,14 +21,8 @@
@@ -219,4 +218,5 @@ index 861a154144e6..2cce94beb56d 100644
  		.blank = blank,
  	},
 -- 
-2.34.1
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-sun50i-h616-orangepi-zero2-enable-expansion-board-usb.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-sun50i-h616-orangepi-zero2-enable-expansion-board-usb.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Michał Dziękoński <michal.dziekonski+github@gmail.com>
+From: Michal Dziekonski <michal.dziekonski+github@gmail.com>
 Date: Sun, 28 May 2023 00:26:43 +0000
 Subject: arm64: dts: allwinner: h616 orangepi zero2: Enable expansion board
  USB ports

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-sun55i-dtsi-add-iommu-usbc-pcie-combophy-nodes.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-sun55i-dtsi-add-iommu-usbc-pcie-combophy-nodes.patch
@@ -12,7 +12,7 @@ diff --git a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi b/arch/arm64/boot/dt
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
-@@ -11,6 +11,7 @@
+@@ -12,6 +12,7 @@
  #include <dt-bindings/reset/sun55i-a523-r-ccu.h>
  #include <dt-bindings/power/allwinner,sun55i-a523-ppu.h>
  #include <dt-bindings/power/allwinner,sun55i-a523-pck-600.h>
@@ -20,7 +20,7 @@ index 111111111111..222222222222 100644
  
  / {
  	interrupt-parent = <&gic>;
-@@ -104,6 +105,17 @@ timer {
+@@ -113,6 +114,17 @@ timer {
  			     <GIC_PPI 10 IRQ_TYPE_LEVEL_HIGH>;
  	};
  
@@ -38,7 +38,7 @@ index 111111111111..222222222222 100644
  	soc {
  		compatible = "simple-bus";
  		#address-cells = <1>;
-@@ -859,6 +871,78 @@ gmac1_mtl_tx_setup: tx-queues-config {
+@@ -933,6 +945,78 @@ gmac1_mtl_tx_setup: tx-queues-config {
  			};
  		};
  

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-sun55i-t527-avaota-a1-enable-wifi-bt.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-sun55i-t527-avaota-a1-enable-wifi-bt.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Juan Sanchez Fuentes <juanesf91@gmail.com>
-Date: Fri, 18 Jul 2026 01:25:00 +0000
+Date: Sat, 18 Jul 2026 01:25:00 +0000
 Subject: arm64: dts: allwinner: t527: avaota-a1: enable WiFi and Bluetooth
 
 The Avaota A1 board has an AIC8800 WiFi/BT combo chip connected via
@@ -16,8 +16,11 @@ pull-ups).
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Assisted-by: opencode:big-pickle
 ---
+ arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts | 43 ++++++++++
+ 1 file changed, 43 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts b/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
-index 994f1e4..5645a35 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun55i-t527-avaota-a1.dts
 @@ -6,6 +6,7 @@
@@ -28,7 +31,7 @@ index 994f1e4..5645a35 100644
  #include <dt-bindings/leds/common.h>
  
  / {
-@@ -16,6 +17,7 @@
+@@ -16,6 +17,7 @@ aliases {
  		ethernet0 = &gmac0;
  		ethernet1 = &gmac1;
  		serial0 = &uart0;
@@ -36,7 +39,7 @@ index 994f1e4..5645a35 100644
  	};
  
  	chosen {
-@@ -63,6 +65,12 @@
+@@ -100,6 +102,12 @@ reg_usb_vbus: vbus {
  		gpio = <&pio 8 12 GPIO_ACTIVE_HIGH>;	/* PI12 */
  		enable-active-high;
  	};
@@ -49,7 +52,7 @@ index 994f1e4..5645a35 100644
  };
  
  &ehci0 {
-@@ -173,6 +181,25 @@
+@@ -210,6 +218,25 @@ &mmc0 {
  	status = "okay";
  };
  
@@ -75,7 +78,7 @@ index 994f1e4..5645a35 100644
  &mmc2 {
  	bus-width = <8>;
  	cap-mmc-hw-reset;
-@@ -289,6 +316,8 @@
+@@ -326,6 +353,8 @@ reg_aldo4: aldo4 {
  			};
  
  			reg_bldo1: bldo1 {
@@ -84,7 +87,7 @@ index 994f1e4..5645a35 100644
  				regulator-min-microvolt = <1800000>;
  				regulator-max-microvolt = <1800000>;
  				regulator-name = "vcc-pg-wifi-lvds";
-@@ -430,6 +459,20 @@
+@@ -500,6 +529,20 @@ &uart0 {
  	status = "okay";
  };
  
@@ -105,3 +108,6 @@ index 994f1e4..5645a35 100644
  &usb_otg {
  	 /*
  	  * The CC pins of the USB-C port have two pull-down resistors
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/doc-dt-bindings-thermal-sun55i-a523-add-ths.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/doc-dt-bindings-thermal-sun55i-a523-add-ths.patch
@@ -1,7 +1,7 @@
-From 9f0a6b2e00000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Date: Mon, 10 Aug 2026 21:00:00 -0400
-Subject: [PATCH] dt-bindings: thermal: sun8i: add sun55i A523 THS compatibles
+Subject: dt-bindings: thermal: sun8i: add sun55i A523 THS compatibles
 
 Add allwinner,sun55i-a523-ths0/ths1 compatibles, multi-cell nvmem
 calibration support and a ths1 example (THS v5 backport).
@@ -9,9 +9,11 @@ calibration support and a ths1 example (THS v5 backport).
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Assisted-by: opencode:big-pickle
 ---
+ Documentation/devicetree/bindings/thermal/allwinner,sun8i-a83t-ths.yaml | 63 +++++++++-
+ 1 file changed, 60 insertions(+), 3 deletions(-)
 
 diff --git a/Documentation/devicetree/bindings/thermal/allwinner,sun8i-a83t-ths.yaml b/Documentation/devicetree/bindings/thermal/allwinner,sun8i-a83t-ths.yaml
-index 3e61689f6dd4..d17c42b2e418 100644
+index 111111111111..222222222222 100644
 --- a/Documentation/devicetree/bindings/thermal/allwinner,sun8i-a83t-ths.yaml
 +++ b/Documentation/devicetree/bindings/thermal/allwinner,sun8i-a83t-ths.yaml
 @@ -24,6 +24,8 @@ properties:
@@ -114,3 +116,4 @@ index 3e61689f6dd4..d17c42b2e418 100644
  ...
 -- 
 Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-clk-sunxi-ng-a523-fix-mp-clocks.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-clk-sunxi-ng-a523-fix-mp-clocks.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Date: Wed, 22 Jul 2026 23:00:00 +0000
-Subject: [PATCH] clk: sunxi-ng: a523: fix MP clocks with only one divider
+Subject: clk: sunxi-ng: a523: fix MP clocks with only one divider
 
 Some A523 clock definitions use the MP clock class but only have a single
 divider (either M or P), leaving the other divider with zero width. This
@@ -16,11 +16,11 @@ SUNXI_CCU_P_DATA_WITH_MUX_GATE, which applies CLK_DIVIDER_POWER_OF_TWO.
 Assisted-by: opencode:deepseek-v4-flash-free
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 ---
- drivers/clk/sunxi-ng/ccu-sun55i-a523.c | 42 ++++++++++++++++---------
- 1 file changed, 27 insertions(+), 15 deletions(-)
+ drivers/clk/sunxi-ng/ccu-sun55i-a523.c | 78 +++++-----
+ 1 file changed, 42 insertions(+), 36 deletions(-)
 
 diff --git a/drivers/clk/sunxi-ng/ccu-sun55i-a523.c b/drivers/clk/sunxi-ng/ccu-sun55i-a523.c
-index 20dad06b37ca..d469a6b22556 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/sunxi-ng/ccu-sun55i-a523.c
 +++ b/drivers/clk/sunxi-ng/ccu-sun55i-a523.c
 @@ -380,14 +380,18 @@ static const struct clk_parent_data mbus_parents[] = {
@@ -165,3 +165,6 @@ index 20dad06b37ca..d469a6b22556 100644
  
  static SUNXI_CCU_GATE_HWS(mbus_dma_clk, "mbus-dma", mbus_hws,
  			  0x804, BIT(0), 0);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-clk-sunxi-ng-a523-r-fix-mp-clocks.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-clk-sunxi-ng-a523-r-fix-mp-clocks.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Date: Wed, 22 Jul 2026 23:00:00 +0000
-Subject: [PATCH] clk: sunxi-ng: a523-r: fix MP clocks with P divider only
+Subject: clk: sunxi-ng: a523-r: fix MP clocks with P divider only
 
 The R CPU timer clocks (r-timer0/1/2) use the MP clock class but only
 have a P divider, leaving the M divider with zero width. Switch them
@@ -11,11 +11,11 @@ and avoids the invalid GENMASK() from the zero-width M field.
 Assisted-by: opencode:deepseek-v4-flash-free
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 ---
- drivers/clk/sunxi-ng/ccu-sun55i-a523-r.c | 12 +++++-------
- 1 file changed, 5 insertions(+), 7 deletions(-)
+ drivers/clk/sunxi-ng/ccu-sun55i-a523-r.c | 13 ++++------
+ 1 file changed, 5 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/clk/sunxi-ng/ccu-sun55i-a523-r.c b/drivers/clk/sunxi-ng/ccu-sun55i-a523-r.c
-index db0e36d8838e..452616e6f9e1 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/sunxi-ng/ccu-sun55i-a523-r.c
 +++ b/drivers/clk/sunxi-ng/ccu-sun55i-a523-r.c
 @@ -43,27 +43,24 @@ static SUNXI_CCU_M_DATA_WITH_MUX(r_apb1_clk, "r-apb1",
@@ -51,3 +51,6 @@ index db0e36d8838e..452616e6f9e1 100644
  
  static SUNXI_CCU_GATE_HW(bus_r_timer_clk, "bus-r-timer", &r_ahb_clk.common.hw,
  			 0x11c, BIT(0), 0);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-clk-sunxi-ng-fix-clock-handling-for-ccu-sun55i-a523.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-clk-sunxi-ng-fix-clock-handling-for-ccu-sun55i-a523.patch
@@ -13,7 +13,7 @@ diff --git a/drivers/clk/sunxi-ng/ccu-sun55i-a523.c b/drivers/clk/sunxi-ng/ccu-s
 index 111111111111..222222222222 100644
 --- a/drivers/clk/sunxi-ng/ccu-sun55i-a523.c
 +++ b/drivers/clk/sunxi-ng/ccu-sun55i-a523.c
-@@ -1186,6 +1186,15 @@ static SUNXI_CCU_MUX_DATA_WITH_GATE(fanout2_clk, "fanout2", fanout_parents,
+@@ -1192,6 +1192,15 @@ static SUNXI_CCU_MUX_DATA_WITH_GATE(fanout2_clk, "fanout2", fanout_parents,
  				    BIT(23),	/* gate */
  				    0);
  
@@ -29,7 +29,7 @@ index 111111111111..222222222222 100644
  /*
   * Contains all clocks that are controlled by a hardware register. They
   * have a (sunxi) .common member, which needs to be initialised by the common
-@@ -1354,6 +1363,7 @@ static struct ccu_common *sun55i_a523_ccu_clks[] = {
+@@ -1360,6 +1369,7 @@ static struct ccu_common *sun55i_a523_ccu_clks[] = {
  	&fanout0_clk.common,
  	&fanout1_clk.common,
  	&fanout2_clk.common,
@@ -37,7 +37,7 @@ index 111111111111..222222222222 100644
  };
  
  static struct clk_hw_onecell_data sun55i_a523_hw_clks = {
-@@ -1538,8 +1548,9 @@ static struct clk_hw_onecell_data sun55i_a523_hw_clks = {
+@@ -1544,8 +1554,9 @@ static struct clk_hw_onecell_data sun55i_a523_hw_clks = {
  		[CLK_FANOUT1]		= &fanout1_clk.common.hw,
  		[CLK_FANOUT2]		= &fanout2_clk.common.hw,
  		[CLK_NPU]		= &npu_clk.common.hw,

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-mailbox-sun55i-add-msgbox-driver.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-mailbox-sun55i-add-msgbox-driver.patch
@@ -1,19 +1,18 @@
-From 5e890554155186500a092031c1455fd6a134ea02 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Date: Wed, 29 Jul 2026 11:45:40 -0400
-Subject: [PATCH] mailbox: sun55i: add T527/A523 msgbox driver
+Subject: mailbox: sun55i: add T527/A523 msgbox driver
 
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Assisted-by: opencode:big-pickle
 ---
  drivers/mailbox/Kconfig         |   9 +
  drivers/mailbox/Makefile        |   1 +
- drivers/mailbox/sun55i-msgbox.c | 437 ++++++++++++++++++++++++++++++++
+ drivers/mailbox/sun55i-msgbox.c | 437 ++++++++++
  3 files changed, 447 insertions(+)
- create mode 100644 drivers/mailbox/sun55i-msgbox.c
 
 diff --git a/drivers/mailbox/Kconfig b/drivers/mailbox/Kconfig
-index 5bf4155..dee77a6 100644
+index 111111111111..222222222222 100644
 --- a/drivers/mailbox/Kconfig
 +++ b/drivers/mailbox/Kconfig
 @@ -332,6 +332,15 @@ config SUN6I_MSGBOX
@@ -33,7 +32,7 @@ index 5bf4155..dee77a6 100644
  	tristate "Spreadtrum Mailbox"
  	depends on ARCH_SPRD || COMPILE_TEST
 diff --git a/drivers/mailbox/Makefile b/drivers/mailbox/Makefile
-index 944d8ea..4c0b038 100644
+index 111111111111..222222222222 100644
 --- a/drivers/mailbox/Makefile
 +++ b/drivers/mailbox/Makefile
 @@ -70,6 +70,7 @@ obj-$(CONFIG_MTK_VCP_MBOX)	+= mtk-vcp-mailbox.o
@@ -46,7 +45,7 @@ index 944d8ea..4c0b038 100644
  
 diff --git a/drivers/mailbox/sun55i-msgbox.c b/drivers/mailbox/sun55i-msgbox.c
 new file mode 100644
-index 0000000..a209ac80
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/mailbox/sun55i-msgbox.c
 @@ -0,0 +1,437 @@
@@ -488,4 +487,5 @@ index 0000000..a209ac80
 +MODULE_DESCRIPTION("Allwinner sun55i (T527/A523) Message Box");
 +MODULE_LICENSE("GPL");
 -- 
-2.53.0
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-pinctrl-sunxi-a523-fix-voltage-withstand-encoding.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-pinctrl-sunxi-a523-fix-voltage-withstand-encoding.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andre Przywara <andre.przywara@arm.com>
 Date: Wed, 22 Jul 2026 00:39:56 +0200
-Subject: [PATCH] pinctrl: sunxi: A523: fix voltage withstand encoding
+Subject: pinctrl: sunxi: A523: fix voltage withstand encoding
 
 The Allwinner A523 uses the same GPIO voltage "withstand" programming
 (setting the input level voltage thresholds) as the previous SoCs, but
@@ -22,15 +22,16 @@ Assisted-by: opencode:big-pickle
 ---
  drivers/pinctrl/sunxi/pinctrl-sun55i-a523-r.c | 2 +-
  drivers/pinctrl/sunxi/pinctrl-sun55i-a523.c   | 2 +-
- drivers/pinctrl/sunxi/pinctrl-sunxi.c         | 7 +++++++
+ drivers/pinctrl/sunxi/pinctrl-sunxi.c         | 8 ++++++++
  drivers/pinctrl/sunxi/pinctrl-sunxi.h         | 1 +
  4 files changed, 11 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/pinctrl/sunxi/pinctrl-sun55i-a523-r.c b/drivers/pinctrl/sunxi/pinctrl-sun55i-a523-r.c
-index 69cd2b4ebd7d..4be2423ff061 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pinctrl/sunxi/pinctrl-sun55i-a523-r.c
 +++ b/drivers/pinctrl/sunxi/pinctrl-sun55i-a523-r.c
-@@ -27,6 +27,6 @@ static struct sunxi_pinctrl_desc a523_r_pinctrl_data = {
+@@ -26,7 +26,7 @@ static const u8 a523_r_irq_bank_muxes[SUNXI_PINCTRL_MAX_BANKS] =
+ static struct sunxi_pinctrl_desc a523_r_pinctrl_data = {
  	.irq_banks = ARRAY_SIZE(a523_r_irq_bank_map),
  	.irq_bank_map = a523_r_irq_bank_map,
 -	.io_bias_cfg_variant = BIAS_VOLTAGE_PIO_POW_MODE_SEL,
@@ -39,10 +40,11 @@ index 69cd2b4ebd7d..4be2423ff061 100644
  };
  
 diff --git a/drivers/pinctrl/sunxi/pinctrl-sun55i-a523.c b/drivers/pinctrl/sunxi/pinctrl-sun55i-a523.c
-index 7d2308c37d29..92219e07b992 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pinctrl/sunxi/pinctrl-sun55i-a523.c
 +++ b/drivers/pinctrl/sunxi/pinctrl-sun55i-a523.c
-@@ -27,5 +27,5 @@ static struct sunxi_pinctrl_desc a523_pinctrl_data = {
+@@ -26,7 +26,7 @@ static const u8 a523_irq_bank_muxes[SUNXI_PINCTRL_MAX_BANKS] =
+ static struct sunxi_pinctrl_desc a523_pinctrl_data = {
  	.irq_banks = ARRAY_SIZE(a523_irq_bank_map),
  	.irq_bank_map = a523_irq_bank_map,
 -	.io_bias_cfg_variant = BIAS_VOLTAGE_PIO_POW_MODE_SEL,
@@ -51,7 +53,7 @@ index 7d2308c37d29..92219e07b992 100644
  
  static int a523_pinctrl_probe(struct platform_device *pdev)
 diff --git a/drivers/pinctrl/sunxi/pinctrl-sunxi.c b/drivers/pinctrl/sunxi/pinctrl-sunxi.c
-index d3042e0c9712..11bff46dc04f 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pinctrl/sunxi/pinctrl-sunxi.c
 +++ b/drivers/pinctrl/sunxi/pinctrl-sunxi.c
 @@ -728,6 +728,7 @@ static int sunxi_pinctrl_set_io_bias_cfg(struct sunxi_pinctrl *pctl,
@@ -84,7 +86,7 @@ index d3042e0c9712..11bff46dc04f 100644
  		reg = readl(pctl->membase + pctl->pow_mod_sel_offset);
  		reg &= ~(1 << bank);
 diff --git a/drivers/pinctrl/sunxi/pinctrl-sunxi.h b/drivers/pinctrl/sunxi/pinctrl-sunxi.h
-index 0daf7600e2fb..7f8101538b70 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pinctrl/sunxi/pinctrl-sunxi.h
 +++ b/drivers/pinctrl/sunxi/pinctrl-sunxi.h
 @@ -118,6 +118,7 @@ enum sunxi_desc_bias_voltage {
@@ -95,3 +97,6 @@ index 0daf7600e2fb..7f8101538b70 100644
  };
  
  struct sunxi_desc_function {
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-remoteproc-sun55i-e906-add-rv-driver.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-remoteproc-sun55i-e906-add-rv-driver.patch
@@ -1,5 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez <juanesf91@gmail.com>
+Date: Mon, 17 Aug 2026 05:47:10 +0200
+Subject: [ARCHEOLOGY] sunxi-7.1: add E906 RISC-V remoteproc support
+
+> X-Git-Archeology: > recovered message: > Port the A523/T527 E906 RISC-V core support from the vendor kernel to the
+> X-Git-Archeology: > recovered message: > 7.1 kernel: a sun55i E906 remoteproc driver, the sun55i msgbox driver
+> X-Git-Archeology: > recovered message: > (re-added, shared with the HiFi4 DSP), the msgbox and e906_rproc
+> X-Git-Archeology: > recovered message: > device-tree nodes with their reserved-memory regions and mailbox/memory
+> X-Git-Archeology: > recovered message: > mappings, and the new patches in the sunxi64 edge kernel config.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+> X-Git-Archeology: > recovered message: > Assisted-by: opencode:big-pickle
+> X-Git-Archeology: - Revision cd021522dc5c4a4767d25a0777690afecf9f7f41: https://github.com/armbian/build/commit/cd021522dc5c4a4767d25a0777690afecf9f7f41
+> X-Git-Archeology:   Date: Mon, 17 Aug 2026 05:47:10 +0200
+> X-Git-Archeology:   From: Juan Sanchez <juanesf91@gmail.com>
+> X-Git-Archeology:   Subject: sunxi-7.1: add E906 RISC-V remoteproc support
+> X-Git-Archeology:
+---
+ drivers/remoteproc/Kconfig             |  13 +
+ drivers/remoteproc/Makefile            |   1 +
+ drivers/remoteproc/sun55i_e906_rproc.c | 734 ++++++++++
+ 3 files changed, 748 insertions(+)
+
 diff --git a/drivers/remoteproc/Kconfig b/drivers/remoteproc/Kconfig
-index ee54436fea5a..5dce1a82822f 100644
+index 111111111111..222222222222 100644
 --- a/drivers/remoteproc/Kconfig
 +++ b/drivers/remoteproc/Kconfig
 @@ -380,6 +380,19 @@ config XLNX_R5_REMOTEPROC
@@ -23,7 +46,7 @@ index ee54436fea5a..5dce1a82822f 100644
  
  endmenu
 diff --git a/drivers/remoteproc/Makefile b/drivers/remoteproc/Makefile
-index 1c7598b8475d..3d1fd410690f 100644
+index 111111111111..222222222222 100644
 --- a/drivers/remoteproc/Makefile
 +++ b/drivers/remoteproc/Makefile
 @@ -40,3 +40,4 @@ obj-$(CONFIG_TI_K3_DSP_REMOTEPROC)	+= ti_k3_dsp_remoteproc.o ti_k3_common.o
@@ -33,7 +56,7 @@ index 1c7598b8475d..3d1fd410690f 100644
 +obj-$(CONFIG_SUN55I_E906_REMOTEPROC)	+= sun55i_e906_rproc.o
 diff --git a/drivers/remoteproc/sun55i_e906_rproc.c b/drivers/remoteproc/sun55i_e906_rproc.c
 new file mode 100644
-index 000000000000..5bf1bc477293
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/remoteproc/sun55i_e906_rproc.c
 @@ -0,0 +1,734 @@
@@ -771,3 +794,6 @@ index 000000000000..5bf1bc477293
 +
 +MODULE_DESCRIPTION("Allwinner T527/A523 E906 RISC-V remoteproc driver");
 +MODULE_LICENSE("GPL");
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-rpmsg-char-bind-sunxi-channels.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-rpmsg-char-bind-sunxi-channels.patch
@@ -1,5 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez <juanesf91@gmail.com>
+Date: Mon, 17 Aug 2026 05:47:10 +0200
+Subject: [ARCHEOLOGY] sunxi-7.1: add E906 RISC-V remoteproc support
+
+> X-Git-Archeology: > recovered message: > Port the A523/T527 E906 RISC-V core support from the vendor kernel to the
+> X-Git-Archeology: > recovered message: > 7.1 kernel: a sun55i E906 remoteproc driver, the sun55i msgbox driver
+> X-Git-Archeology: > recovered message: > (re-added, shared with the HiFi4 DSP), the msgbox and e906_rproc
+> X-Git-Archeology: > recovered message: > device-tree nodes with their reserved-memory regions and mailbox/memory
+> X-Git-Archeology: > recovered message: > mappings, and the new patches in the sunxi64 edge kernel config.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+> X-Git-Archeology: > recovered message: > Assisted-by: opencode:big-pickle
+> X-Git-Archeology: - Revision cd021522dc5c4a4767d25a0777690afecf9f7f41: https://github.com/armbian/build/commit/cd021522dc5c4a4767d25a0777690afecf9f7f41
+> X-Git-Archeology:   Date: Mon, 17 Aug 2026 05:47:10 +0200
+> X-Git-Archeology:   From: Juan Sanchez <juanesf91@gmail.com>
+> X-Git-Archeology:   Subject: sunxi-7.1: add E906 RISC-V remoteproc support
+> X-Git-Archeology:
+---
+ drivers/rpmsg/rpmsg_char.c       | 22 ++++++++++
+ drivers/rpmsg/virtio_rpmsg_bus.c |  8 ++++
+ 2 files changed, 30 insertions(+)
+
 diff --git a/drivers/rpmsg/rpmsg_char.c b/drivers/rpmsg/rpmsg_char.c
-index bff5aefee212..e6f14262673fe7d1f1ef722410551403a4cedbc7 100644
+index 111111111111..222222222222 100644
 --- a/drivers/rpmsg/rpmsg_char.c
 +++ b/drivers/rpmsg/rpmsg_char.c
 @@ -176,6 +176,26 @@ static int rpmsg_eptdev_open(struct inode *inode, struct file *filp)
@@ -29,7 +51,7 @@ index bff5aefee212..e6f14262673fe7d1f1ef722410551403a4cedbc7 100644
  	filp->private_data = eptdev;
  	mutex_unlock(&eptdev->ept_lock);
  
-@@ -534,6 +544,8 @@ static void rpmsg_chrdev_remove(struct rpmsg_device *rpdev)
+@@ -534,6 +554,8 @@ static void rpmsg_chrdev_remove(struct rpmsg_device *rpdev)
  static struct rpmsg_device_id rpmsg_chrdev_id_table[] = {
  	{ .name	= "rpmsg-raw" },
  	{ .name	= "rpmsg_chrdev" },
@@ -39,7 +61,7 @@ index bff5aefee212..e6f14262673fe7d1f1ef722410551403a4cedbc7 100644
  };
  MODULE_DEVICE_TABLE(rpmsg, rpmsg_chrdev_id_table);
 diff --git a/drivers/rpmsg/virtio_rpmsg_bus.c b/drivers/rpmsg/virtio_rpmsg_bus.c
-index 1b8bb05924af..eee98af52212 100644
+index 111111111111..222222222222 100644
 --- a/drivers/rpmsg/virtio_rpmsg_bus.c
 +++ b/drivers/rpmsg/virtio_rpmsg_bus.c
 @@ -420,6 +420,14 @@ static struct rpmsg_device *__rpmsg_create_channel(struct virtproc_info *vrp,
@@ -57,3 +79,6 @@ index 1b8bb05924af..eee98af52212 100644
  	strscpy(rpdev->id.name, chinfo->name, sizeof(rpdev->id.name));
  
  	rpdev->dev.parent = &vrp->vdev->dev;
+-- 
+Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-thermal-sun8i-sun55i-a523-ths.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-thermal-sun8i-sun55i-a523-ths.patch
@@ -1,7 +1,7 @@
-From 9f0a6b2e00000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Date: Mon, 10 Aug 2026 21:00:00 -0400
-Subject: [PATCH] thermal: sun8i: add sun55i A523 (THS v5) support
+Subject: thermal: sun8i: add sun55i A523 (THS v5) support
 
 Backport of the THS v5 series for the A523/T527 SoC:
 sun55i_a523_calc_temp (delimiter 0x7c8, scales 74/65), multi-cell
@@ -12,9 +12,11 @@ reset for the bus reset control.
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Assisted-by: opencode:big-pickle
 ---
+ drivers/thermal/sun8i_thermal.c | 279 ++++++++--
+ 1 file changed, 231 insertions(+), 48 deletions(-)
 
 diff --git a/drivers/thermal/sun8i_thermal.c b/drivers/thermal/sun8i_thermal.c
-index 1fc7fe3a1531..7b0c74c13294 100644
+index 111111111111..222222222222 100644
 --- a/drivers/thermal/sun8i_thermal.c
 +++ b/drivers/thermal/sun8i_thermal.c
 @@ -59,6 +59,12 @@
@@ -297,7 +299,7 @@ index 1fc7fe3a1531..7b0c74c13294 100644
  static struct regmap *sun8i_ths_get_sram_regmap(struct device_node *node)
  {
  	struct platform_device *sram_pdev;
-@@ -398,21 +557,12 @@ static int sun8i_ths_resource_init(struct ths_device *tmdev)
+@@ -398,21 +564,12 @@ static int sun8i_ths_resource_init(struct ths_device *tmdev)
  	}
  
  	if (tmdev->chip->has_bus_clk_reset) {
@@ -320,7 +322,7 @@ index 1fc7fe3a1531..7b0c74c13294 100644
  		tmdev->bus_clk = devm_clk_get_enabled(&pdev->dev, "bus");
  		if (IS_ERR(tmdev->bus_clk))
  			return PTR_ERR(tmdev->bus_clk);
-@@ -725,6 +875,30 @@ static const struct ths_thermal_chip sun50i_h616_ths = {
+@@ -725,6 +882,30 @@ static const struct ths_thermal_chip sun50i_h616_ths = {
  	.calc_temp = sun8i_ths_calc_temp,
  };
  
@@ -351,7 +353,7 @@ index 1fc7fe3a1531..7b0c74c13294 100644
  static const struct of_device_id of_ths_match[] = {
  	{ .compatible = "allwinner,sun8i-a83t-ths", .data = &sun8i_a83t_ths },
  	{ .compatible = "allwinner,sun8i-h3-ths", .data = &sun8i_h3_ths },
-@@ -735,6 +909,8 @@ static const struct of_device_id of_ths_match[] = {
+@@ -735,6 +916,8 @@ static const struct of_device_id of_ths_match[] = {
  	{ .compatible = "allwinner,sun50i-h6-ths", .data = &sun50i_h6_ths },
  	{ .compatible = "allwinner,sun20i-d1-ths", .data = &sun20i_d1_ths },
  	{ .compatible = "allwinner,sun50i-h616-ths", .data = &sun50i_h616_ths },
@@ -362,3 +364,4 @@ index 1fc7fe3a1531..7b0c74c13294 100644
  MODULE_DEVICE_TABLE(of, of_ths_match);
 -- 
 Armbian
+

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-video-st7796s-fb-tft-driver.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-video-st7796s-fb-tft-driver.patch
@@ -34,8 +34,7 @@ diff --git a/drivers/staging/fbtft/Makefile b/drivers/staging/fbtft/Makefile
 index 111111111111..222222222222 100644
 --- a/drivers/staging/fbtft/Makefile
 +++ b/drivers/staging/fbtft/Makefile
-@@ -30,7 +30,8 @@
- obj-$(CONFIG_FB_TFT_SSD1331)     += fb_ssd1331.o
+@@ -31,6 +31,7 @@ obj-$(CONFIG_FB_TFT_SSD1331)     += fb_ssd1331.o
  obj-$(CONFIG_FB_TFT_SSD1351)     += fb_ssd1351.o
  obj-$(CONFIG_FB_TFT_ST7735R)     += fb_st7735r.o
  obj-$(CONFIG_FB_TFT_ST7789V)     += fb_st7789v.o

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/media-dt-bindings-allwinner-sun4i-a10-ir-add-a523-compatible.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/media-dt-bindings-allwinner-sun4i-a10-ir-add-a523-compatible.patch
@@ -1,9 +1,7 @@
-From 20260722233604.3001063-2-utilityemal77@gmail.com Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin Suess <utilityemal77@gmail.com>
 Date: Wed, 22 Jul 2026 19:36:01 -0400
-Subject: [PATCH] media: dt-bindings: allwinner,sun4i-a10-ir: add A523 compatible
-
-
+Subject: media: dt-bindings: allwinner,sun4i-a10-ir: add A523 compatible
 
 The A523 (sun55i) contains a newer revision of the sunxi CIR receiver.
 The reset defaults match the fixed behaviour of the older IP, so the
@@ -19,11 +17,11 @@ Signed-off-by: Justin Suess <utilityemal77@gmail.com>
 Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Assisted-by: opencode:big-pickle
 ---
- .../devicetree/bindings/media/allwinner,sun4i-a10-ir.yaml | 8 +++++---
+ Documentation/devicetree/bindings/media/allwinner,sun4i-a10-ir.yaml | 8 +++++---
  1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/Documentation/devicetree/bindings/media/allwinner,sun4i-a10-ir.yaml b/Documentation/devicetree/bindings/media/allwinner,sun4i-a10-ir.yaml
-index 42dfe22ad5f1..18b28feacf83 100644
+index 111111111111..222222222222 100644
 --- a/Documentation/devicetree/bindings/media/allwinner,sun4i-a10-ir.yaml
 +++ b/Documentation/devicetree/bindings/media/allwinner,sun4i-a10-ir.yaml
 @@ -16,9 +16,10 @@ allOf:
@@ -49,7 +47,5 @@ index 42dfe22ad5f1..18b28feacf83 100644
  
    reg:
 -- 
-2.54.0
-
-
+Armbian
 

--- a/patch/kernel/archive/sunxi-7.1/patches.megous/a711-7.1/0005-ARM-dts-sun8i-a83t-tbs-a711-Add-powerup-down-support.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.megous/a711-7.1/0005-ARM-dts-sun8i-a83t-tbs-a711-Add-powerup-down-support.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Mylène Josserand <mylene.josserand@bootlin.com>
+From: Mylene Josserand <mylene.josserand@bootlin.com>
 Date: Thu, 6 Jul 2017 10:57:55 +0200
 Subject: ARM: dts: sun8i-a83t-tbs-a711: Add powerup/down support for the 3G
  modem

--- a/patch/kernel/archive/uefi-x86-6.18/2008-i915-4-lane-quirk-for-mbp15-1.patch
+++ b/patch/kernel/archive/uefi-x86-6.18/2008-i915-4-lane-quirk-for-mbp15-1.patch
@@ -16,7 +16,7 @@ diff --git a/drivers/gpu/drm/i915/display/intel_ddi.c b/drivers/gpu/drm/i915/dis
 index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/i915/display/intel_ddi.c
 +++ b/drivers/gpu/drm/i915/display/intel_ddi.c
-@@ -4868,6 +4868,9 @@ static bool intel_ddi_a_force_4_lanes(struct intel_digital_port *dig_port)
+@@ -4870,6 +4870,9 @@ static bool intel_ddi_a_force_4_lanes(struct intel_digital_port *dig_port)
  	if (dig_port->ddi_a_4_lanes)
  		return false;
  

--- a/patch/kernel/archive/uefi-x86-6.18/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-6.18/4001-asahi-trackpad.patch
@@ -22,7 +22,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2320,6 +2320,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2366,6 +2366,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_I2C:
  		bus = "I2C";
  		break;
@@ -136,7 +136,7 @@ diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
 index 111111111111..222222222222 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2323,6 +2323,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2369,6 +2369,9 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_SPI:
  		bus = "SPI";
  		break;
@@ -252,7 +252,7 @@ index 111111111111..222222222222 100644
  			else
  				table = apple_fn_keys;
  		}
-@@ -940,6 +949,10 @@ static int apple_probe(struct hid_device *hdev,
+@@ -942,6 +951,10 @@ static int apple_probe(struct hid_device *hdev,
  	struct apple_sc *asc;
  	int ret;
  
@@ -263,7 +263,7 @@ index 111111111111..222222222222 100644
  	asc = devm_kzalloc(&hdev->dev, sizeof(*asc), GFP_KERNEL);
  	if (asc == NULL) {
  		hid_err(hdev, "can't alloc apple descriptor\n");
-@@ -1218,6 +1231,8 @@ static const struct hid_device_id apple_devices[] = {
+@@ -1220,6 +1233,8 @@ static const struct hid_device_id apple_devices[] = {
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK | APPLE_RDESC_BATTERY },
  	{ HID_BLUETOOTH_DEVICE(BT_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_MAGIC_KEYBOARD_NUMPAD_2024),
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
@@ -303,7 +303,7 @@ index 111111111111..222222222222 100644
  					table = macbookpro_dedicated_esc_fn_keys;
  					break;
  				default:
-@@ -949,7 +950,7 @@ static int apple_probe(struct hid_device *hdev,
+@@ -951,7 +952,7 @@ static int apple_probe(struct hid_device *hdev,
  	struct apple_sc *asc;
  	int ret;
  
@@ -312,7 +312,7 @@ index 111111111111..222222222222 100644
  	    hdev->type != HID_TYPE_SPI_KEYBOARD)
  		return -ENODEV;
  
-@@ -1233,6 +1234,8 @@ static const struct hid_device_id apple_devices[] = {
+@@ -1235,6 +1236,8 @@ static const struct hid_device_id apple_devices[] = {
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
  	{ HID_SPI_DEVICE(SPI_VENDOR_ID_APPLE, HID_ANY_ID),
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },

--- a/patch/kernel/archive/uefi-x86-6.18/4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch
+++ b/patch/kernel/archive/uefi-x86-6.18/4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch
@@ -25,7 +25,7 @@ index 111111111111..222222222222 100644
  #define APPLE_HAS_FN		BIT(2)
  /* BIT(3) reserved, was: APPLE_HIDDEV */
  #define APPLE_ISO_TILDE_QUIRK	BIT(4)
-@@ -954,6 +954,9 @@ static int apple_probe(struct hid_device *hdev,
+@@ -956,6 +956,9 @@ static int apple_probe(struct hid_device *hdev,
  	    hdev->type != HID_TYPE_SPI_KEYBOARD)
  		return -ENODEV;
  
@@ -35,7 +35,7 @@ index 111111111111..222222222222 100644
  	asc = devm_kzalloc(&hdev->dev, sizeof(*asc), GFP_KERNEL);
  	if (asc == NULL) {
  		hid_err(hdev, "can't alloc apple descriptor\n");
-@@ -1176,27 +1179,31 @@ static const struct hid_device_id apple_devices[] = {
+@@ -1178,27 +1181,31 @@ static const struct hid_device_id apple_devices[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRING9_JIS),
  		.driver_data = APPLE_HAS_FN | APPLE_RDESC_JIS },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K),


### PR DESCRIPTION
# Description

rewrite various patch sets against current upstream

# How Has This Been Tested?

- [ ] none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Wake-on-LAN and GPIO wake support for Helios4 systems.
  * Improved Helios4 fan PWM support and hardware power-supply configuration.
  * Enabled RK3588 CAN-FD and Turing RK1 NPU support.
  * Added Allwinner A523/T527 support for thermal monitoring, DMA, remote processors, infrared, Wi‑Fi/Bluetooth, USB-C, PCIe, displays, and messaging.
  * Added AP6330 Wi‑Fi firmware support and ST7796S display support.
  * Added Apple Silicon keyboard and trackpad support.

* **Bug Fixes**
  * Improved PCIe error handling, Bluetooth compatibility, CAN reliability, clock operation, thermal calibration, display rendering, and MacBook trackpad detection.
  * Improved support for larger network MTUs on affected Rockchip devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->