### PR TITLE
fix(bsp): do not block basic.target while resizing the rootfs

### DIFF
--- a/packages/bsp/armbian-lowmem/lowmem-mkswap.service
+++ b/packages/bsp/armbian-lowmem/lowmem-mkswap.service
@@ -1,9 +1,7 @@
 [Unit]
 Description=Armbian lowmem: Create a swapfile
-DefaultDependencies=no
 Wants=armbian-resize-filesystem.service
-After=armbian-resize-filesystem.service
-Before=basic.target
+After=armbian-resize-filesystem.service local-fs.target
 
 [Service]
 Type=oneshot
@@ -11,4 +9,4 @@ ExecStart=/usr/bin/lowmem-mkswap.sh
 RemainAfterExit=yes
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target

--- a/packages/bsp/common/lib/systemd/system/armbian-resize-filesystem.service
+++ b/packages/bsp/common/lib/systemd/system/armbian-resize-filesystem.service
@@ -1,12 +1,10 @@
 # Armbian resize filesystem service
 # Resizes partition and filesystem on first/second boot
-# This service may block the boot process for up to 3 minutes
+# Runs alongside the rest of the boot; it must not block basic.target
 
 [Unit]
 Description=Armbian filesystem resize
-Before=basic.target
-After=sysinit.target local-fs.target
-DefaultDependencies=no
+After=local-fs.target
 
 [Service]
 Type=oneshot
@@ -15,4 +13,4 @@ ExecStart=/usr/lib/armbian/armbian-resize-filesystem start
 TimeoutStartSec=6min
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target


### PR DESCRIPTION
# Description

 **Note: this is a workaround, not a fix for #10521**

Problem produced by any udev timeout. 

armbian-resize-filesystem runs with DefaultDependencies=no and Before=basic.target, so the entire boot waits for it. The script calls partprobe, which waits for the udev queue to drain. A udev worker that never finishes its event stalls that queue for the full 180s worker timeout, and basic.target - together with dbus.service - is delayed by the same amount.

That delay breaks DNS on the first boot. systemd-resolved is ordered before sysinit.target, so it starts while dbus is still not up and never acquires org.freedesktop.resolve1. NetworkManager hands DNS servers to resolved over D-Bus only, so the DHCP-provided servers never reach it and name resolution stays dead for the whole session, which is exactly when armbian-firstrun and apt need it.

Resizing need not run that early: resize2fs operates online on the mounted rootfs, and the only unit ordered against it is lowmem-mkswap. Move both units to multi-user.target so a stalled udev queue can no longer hold up the boot. armbian-firstlogin already waits for queued jobs through systemctl is-system-running --wait, and the script disables itself with systemctl disable, which follows the new [Install] section on its own.


[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: #10521

# How Has This Been Tested?

First book is ok in any case.

- [X] resolute desktop VIM4
- [X] trixie minimal VIM4

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved boot-time service ordering for low-memory swap setup and filesystem resizing.
  - Services now start after the local filesystem is ready and run during the multi-user boot stage.
  - Reduced the risk of boot delays caused by these services blocking earlier system targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->