### PR TITLE
show-extensions: fix hook-doc rendering (heading marker + btrfs docs)

### DIFF
--- a/lib/functions/cli/cli-show-extensions.sh
+++ b/lib/functions/cli/cli-show-extensions.sh
@@ -99,10 +99,14 @@ function cli_show_extensions_run() {
 		!seen[$1]++ { # dedup hook points called from more than one site
 			if (ENVIRON["format"] != "docs") { print $1; next }
 			nlines = split($3, bl, "\001")
+			summary = bl[1]
+			sub(/^[ \t]*#+[ \t]*/, "", summary) # strip leading "#" so the summary cannot become a heading inside the blockquote
 			print "### `" $1 "`"
-			print "> " bl[1]
-			print ""
-			for (j = 2; j <= nlines; j++) print bl[j]
+			print "> " summary
+			if (nlines >= 2) {
+				print ""
+				for (j = 2; j <= nlines; j++) print bl[j]
+			}
 			if ($2 != "") {
 				print ""
 				print "Also known as (for backwards compatibility only):"

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -359,15 +359,17 @@ function prepare_partitions() {
 			run_host_command_logged btrfs subvolume set-default "$MOUNT/$btrfs_root_subvolume"
 
 			call_extension_method "btrfs_root_add_subvolumes" <<- 'BTRFS_ROOT_ADD_SUBVOLUMES'
-				# *custom post btrfs rootfs creation hook*
-				# Called if rootfs btrfs after creating the subvolume "@" for rootfs
-				# Used to create other separate btrfs subvolume if needed.
-				# Mountpoints and fstab records should be created too.
+				custom post-btrfs-rootfs-creation hook
+				Called when the rootfs is btrfs, right after the `@` subvolume is created, so an
+				extension can add other separate btrfs subvolumes (creating their mountpoints and
+				fstab entries too). Example:
+				```
 				run_host_command_logged btrfs subvolume create $MOUNT/@home
 				run_host_command_logged btrfs subvolume create $MOUNT/@var
 				run_host_command_logged btrfs subvolume create $MOUNT/@var_log
 				run_host_command_logged btrfs subvolume create $MOUNT/@var_cache
 				run_host_command_logged btrfs subvolume create $MOUNT/@srv
+				```
 			BTRFS_ROOT_ADD_SUBVOLUMES
 
 			run_host_command_logged umount "$rootdevice"
@@ -379,6 +381,10 @@ function prepare_partitions() {
 		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults${mountopts[$ROOTFS_TYPE]} 0 1" >> "${SDCARD}/etc/fstab"
 		if [[ $ROOTFS_TYPE == btrfs ]]; then
 			call_extension_method "btrfs_root_add_subvolumes_fstab" <<- 'BTRFS_ROOT_ADD_SUBVOLUMES_FSTAB'
+				custom hook to add the btrfs subvolume fstab entries
+				Called after `btrfs_root_add_subvolumes`, to mount the extra subvolumes and write
+				their `/etc/fstab` entries. Example:
+				```
 				run_host_command_logged mkdir -p $MOUNT/home
 				run_host_command_logged mount -odefaults${mountopts[$ROOTFS_TYPE]},subvol=@home $rootdevice $MOUNT/home
 				echo "$rootfs /home btrfs defaults${mountopts[$ROOTFS_TYPE]},subvol=@home 0 2" >> $SDCARD/etc/fstab
@@ -394,6 +400,7 @@ function prepare_partitions() {
 				run_host_command_logged mkdir -p  $MOUNT/srv
 				run_host_command_logged mount -odefaults${mountopts[$ROOTFS_TYPE]},subvol=@srv $rootdevice $MOUNT/srv
 				echo "$rootfs /srv btrfs defaults${mountopts[$ROOTFS_TYPE]},subvol=@srv 0 2" >> $SDCARD/etc/fstab
+				```
 			BTRFS_ROOT_ADD_SUBVOLUMES_FSTAB
 		fi
 


### PR DESCRIPTION
## Problem

The generated [Extension Hooks](https://docs.armbian.com/build-framework/extensions/hooks/) page had two rendering bugs:

1. **Broken TOC + giant blockquote.** The docs formatter printed the hook summary as `> <first inline-doc line>`. When that line started with `#` (e.g. `btrfs_root_add_subvolumes`, whose comment opens `# custom post btrfs...`), it became `> # text` — a **level-1 heading inside a blockquote**. It rendered oversized *and* broke the page's table of contents for every hook after it.
2. **Raw-shell hook docs.** The two `btrfs_root_add_subvolumes[_fstab]` hook docs were shell comments + example commands, not markdown, so they rendered as run-together text.

## Fix

- `lib/functions/cli/cli-show-extensions.sh`: strip a leading `#` from the summary so it can never become a heading; guard the body so summary-only hooks don't emit a trailing blank. Bodies stay prose (with inline code), as intended.
- `lib/functions/image/partitioning.sh`: rewrite the two btrfs hook docs as a prose summary + description + a fenced example.

Hook doc comments **are** markdown and should be written as such; this makes the two offenders conform and stops one of them from breaking the page.

`bash -n` clean. Verified: full 65-hook TOC, clean prose rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of extension documentation output.
  * Updated Btrfs partitioning hook guidance with clearer descriptions and fenced examples.
  * Improved handling of optional documentation content and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->