### PR TITLE
v4l2loopback-dkms: skip when apt v4l2loopback < 0.15.3 (won't build)

### DIFF
--- a/extensions/v4l2loopback-dkms.sh
+++ b/extensions/v4l2loopback-dkms.sh
@@ -18,6 +18,56 @@ function post_install_kernel_debs__build_v4l2loopback_dkms_kernel_module() {
 		return 0
 	fi
 	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+
+	# v4l2loopback only builds against current kernels from 0.15.3 onwards. Earlier releases
+	# call v4l2_fh_add() with the pre-signature-change argument count and fail the DKMS build
+	# with "too few arguments to function 'v4l2_fh_add'". Debian trixie still ships 0.15.0-2 in
+	# main, so gate on the apt candidate version and skip (rather than fail the whole build)
+	# when only a too-old package is available.
+	declare -r v4l2loopback_min_version="0.15.3"
+	# The host-side apt lists are bind-mounted into the chroot only for the duration of a
+	# chroot_sdcard_apt_get* call, and the image's own /var/lib/apt/lists is not populated
+	# until much later in the build (apt_lists_copy_from_host_to_image_and_update). Asking
+	# apt-cache directly at this point therefore sees an empty index and answers nothing at
+	# all. Go through the apt-aware runner so the lists are mounted, and redirect to a file
+	# we read back host-side, since the runner logs stdout rather than returning it. That
+	# runner is also what pins LC_ALL=C, keeping "Candidate:" parseable.
+	declare -r v4l2loopback_policy_file="/tmp/.v4l2loopback-apt-policy"
+	declare v4l2loopback_candidate=""
+	declare v4l2loopback_policy_rc=0
+	# Clear any leftover first: if the runner dies before the redirect is even set up, a
+	# stale file must not be read as this query's answer and skip the extension on it.
+	run_host_command_logged rm -f "${SDCARD}${v4l2loopback_policy_file}"
+	# Keep the call out of errexit's reach. apt-cache itself exits 0 even for an unknown
+	# package, but the runner around it can fail (apt-cacher-ng restart, the cache bind
+	# mounts, the chroot itself), and a bare call would abort the whole build here instead
+	# of falling through to the inconclusive path below.
+	chroot_sdcard_custom_with_apt_logic "apt-cache" policy v4l2loopback-dkms "> ${v4l2loopback_policy_file}" ||
+		v4l2loopback_policy_rc=$?
+	if [[ "${v4l2loopback_policy_rc}" != "0" ]]; then
+		display_alert "Querying apt for v4l2loopback-dkms failed" "rc=${v4l2loopback_policy_rc}; ${EXTENSION}" "warn"
+	elif [[ -f "${SDCARD}${v4l2loopback_policy_file}" ]]; then
+		# Same reasoning for the parse: an unreadable file leaves the candidate empty and
+		# takes the inconclusive path, rather than aborting the build from a subshell.
+		if ! v4l2loopback_candidate="$(awk '/Candidate:/ {print $2; exit}' "${SDCARD}${v4l2loopback_policy_file}")"; then
+			v4l2loopback_candidate=""
+		fi
+	fi
+	# Unconditional: a failed query can still have left a partial file in the rootfs.
+	run_host_command_logged rm -f "${SDCARD}${v4l2loopback_policy_file}"
+	if [[ "${v4l2loopback_candidate}" == "(none)" ]]; then
+		display_alert "v4l2loopback-dkms not available from apt" "skipping ${EXTENSION}" "warn"
+		return 0
+	fi
+	if [[ -z "${v4l2loopback_candidate}" ]]; then
+		# Inconclusive, not negative. Skipping here would silently drop the module from the
+		# image behind a single warning line, so install as before and let apt be the judge.
+		display_alert "Could not read v4l2loopback-dkms apt candidate version" "installing anyway; ${EXTENSION}" "warn"
+	elif ! dpkg --compare-versions "${v4l2loopback_candidate}" ge "${v4l2loopback_min_version}"; then
+		display_alert "v4l2loopback-dkms ${v4l2loopback_candidate} < ${v4l2loopback_min_version}, won't build on kernel v${KERNEL_MAJOR_MINOR}" "skipping ${EXTENSION}" "warn"
+		return 0
+	fi
+
 	display_alert "Install v4l2loopback-dkms packages, will build kernel module in chroot" "${EXTENSION}" "info"
 	declare -g if_error_detail_message="v4l2loopback-dkms build failed, extension 'v4l2loopback-dkms'"
 	declare -ag if_error_find_files_sdcard=("/var/lib/dkms/v4l2loopback*/*/build/*.log")


### PR DESCRIPTION
## Problem

Image build fails installing `v4l2loopback-dkms` on current kernels:

```
v4l2loopback.c:2337:9: error: too few arguments to function 'v4l2_fh_add'
```

Hit on radxa-rock-4d, trixie, edge 7.1.10.

## Root cause

`v4l2_fh_add()` gained a parameter; v4l2loopback adapted in **0.15.3**. Debian trixie still ships **0.15.0-2**, which calls it the old way. The existing `>= 7.2` kernel guard doesn't help, because the breakage depends on the *package* version, not the kernel.

## Fix

Read the apt candidate version in the chroot; skip the extension with a warning when it's older than 0.15.3, instead of failing the whole build. Boards pick the module back up automatically once a fixed package lands. The `>= 7.2` guard stays.

Two things worth knowing for review:

- The query goes through `chroot_sdcard_custom_with_apt_logic`, not a plain `apt-cache`. Apt lists are only bind-mounted into the chroot during a `chroot_sdcard_apt_get*` call, so a direct query this early reads an empty index and returns nothing — the first version of this PR did exactly that and silently skipped the extension on *every* build. That runner also pins `LC_ALL=C`, keeping `Candidate:` parseable.
- An unreadable candidate installs rather than skips. Inconclusive is not the same as too-old, and a silent skip drops the module behind one warning line. Only a confirmed too-old version, or `(none)`, skips.

## Build tested

https://github.com/armbian/ci/actions/runs/32891364379 — success, 12 images on radxa-rock-4d: 3 × `trixie` (the skip path) and 9 × `resolute` (the install path), across vendor/current/edge and minimal/desktop.

Signed-off-by: Igor Pecovnik <igor@armbian.com>
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented installation of incompatible `v4l2loopback-dkms` package versions.
  * Installation is now skipped when the package is unavailable or older than version 0.15.3.
  * The installation proceeds with a warning if the package version cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

