### PR TITLE
sunxi-6.18: enable composite TV output on H3 and H5

### DIFF
--- a/patch/kernel/archive/sunxi-6.18/overlay_32/Makefile
+++ b/patch/kernel/archive/sunxi-6.18/overlay_32/Makefile
@@ -75,6 +75,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
 	sun8i-h3-uart1.dtbo \
 	sun8i-h3-uart2.dtbo \
 	sun8i-h3-uart3.dtbo \
+	sun8i-h3-tve.dtbo \
 	sun8i-h3-usbhost0.dtbo \
 	sun8i-h3-usbhost1.dtbo \
 	sun8i-h3-usbhost2.dtbo \

--- a/patch/kernel/archive/sunxi-6.18/overlay_32/README.sun8i-h3-overlays
+++ b/patch/kernel/archive/sunxi-6.18/overlay_32/README.sun8i-h3-overlays
@@ -26,6 +26,7 @@ adding fixed software (GPIO) chip selects is possible with a separate overlay
 - spi-add-cs1
 - spi-jedec-nor
 - spi-spidev
+- tve
 - uart1
 - uart2
 - uart3
@@ -248,3 +249,11 @@ param_w1_pin_int_pullup (bool)
 	Set to 1 to enable the pull-up
 	This option should not be used with multiple devices, parasite power setup
 		or long wires -	please use external pull-up resistor instead
+
+### tve
+
+Activates the composite (CVBS) TV encoder.
+
+For boards whose DTS does not enable the output itself. It switches on the
+display engine and the TV encoder. PAL/NTSC follows the mode the display
+asks for.

--- a/patch/kernel/archive/sunxi-6.18/overlay_32/sun8i-h3-tve.dtso
+++ b/patch/kernel/archive/sunxi-6.18/overlay_32/sun8i-h3-tve.dtso
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Composite (CVBS) TV output on H2+/H3.
+ *
+ * For boards whose DTS does not enable the output itself. It switches on the
+ * display engine and the TV encoder; the second mixer and TCON that feed it
+ * are already described by the SoC dtsi.
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun8i-h3";
+
+	fragment@0 {
+		target = <&de>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&mixer1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&tcon1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&tve>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/patch/kernel/archive/sunxi-6.18/overlay_64/Makefile
+++ b/patch/kernel/archive/sunxi-6.18/overlay_64/Makefile
@@ -27,6 +27,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
 	sun50i-h5-spi-add-cs1.dtbo \
 	sun50i-h5-spi-jedec-nor.dtbo \
 	sun50i-h5-spi-spidev.dtbo \
+	sun50i-h5-tve.dtbo \
 	sun50i-h5-uart1.dtbo \
 	sun50i-h5-uart2.dtbo \
 	sun50i-h5-uart3.dtbo \

--- a/patch/kernel/archive/sunxi-6.18/overlay_64/README.sun50i-h5-overlays
+++ b/patch/kernel/archive/sunxi-6.18/overlay_64/README.sun50i-h5-overlays
@@ -26,6 +26,7 @@ adding fixed software (GPIO) chip selects is possible with a separate overlay
 - spi-add-cs1
 - spi-jedec-nor
 - spi-spidev
+- tve
 - uart1
 - uart2
 - uart3
@@ -248,3 +249,7 @@ param_w1_pin_int_pullup (bool)
 	Set to 1 to enable the pull-up
 	This option should not be used with multiple devices, parasite power setup
 		or long wires -	please use external pull-up resistor instead
+
+### tve
+
+Activates the composite (CVBS) TV encoder.

--- a/patch/kernel/archive/sunxi-6.18/overlay_64/sun50i-h5-tve.dtso
+++ b/patch/kernel/archive/sunxi-6.18/overlay_64/sun50i-h5-tve.dtso
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Composite (CVBS) TV output on H5.
+ *
+ * For boards whose DTS does not enable the output itself. It switches on the
+ * display engine and the TV encoder; the second mixer and TCON that feed it
+ * are already described by the SoC dtsi.
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun50i-h5";
+
+	fragment@0 {
+		target = <&de>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&mixer1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&tcon1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&tve>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm-dts-sunxi-h3-describe-the-tv-encoder-pipeline.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm-dts-sunxi-h3-describe-the-tv-encoder-pipeline.patch
@@ -1,0 +1,200 @@
+From 68b4f1e59201f757a893a5966c4b0ae86f52ff87 Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 03:26:23 +0300
+Subject: [PATCH] ARM: dts: sunxi: h3: describe the TV encoder pipeline
+
+The H3 display engine has a second pipeline -- mixer1 feeding TCON1 and
+from there the TV encoder -- that the device tree never described, so
+composite output has never worked on these boards. Add the nodes, with
+port endpoints wired so that either mixer can drive either TCON.
+
+It stays disabled. On a board with no other display output, switching
+the display engine on costs a permanently running 432 MHz PLL whether
+or not a television is plugged in, so enabling it is left to the board
+that routes the signal somewhere.
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ arch/arm/boot/dts/allwinner/sun8i-h3.dtsi    | 22 +++++
+ arch/arm/boot/dts/allwinner/sunxi-h3-h5.dtsi | 95 +++++++++++++++++++-
+ 2 files changed, 114 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/boot/dts/allwinner/sun8i-h3.dtsi b/arch/arm/boot/dts/allwinner/sun8i-h3.dtsi
+index 8c2f59777..35c864fe4 100644
+--- a/arch/arm/boot/dts/allwinner/sun8i-h3.dtsi
++++ b/arch/arm/boot/dts/allwinner/sun8i-h3.dtsi
+@@ -295,6 +295,20 @@ ths: thermal-sensor@1c25000 {
+ 			nvmem-cell-names = "calibration";
+ 			#thermal-sensor-cells = <0>;
+ 		};
++
++		tve: tv-encoder@1e00000 {
++			compatible = "allwinner,sun8i-h3-tv-encoder";
++			reg = <0x01e00000 0x1000>;
++			clocks = <&ccu CLK_BUS_TVE>;
++			resets = <&ccu RST_BUS_TVE>;
++			status = "disabled";
++
++			port {
++				tve_in_tcon1: endpoint {
++					remote-endpoint = <&tcon1_out_tve>;
++				};
++			};
++		};
+ 	};
+ 
+ 	thermal-zones {
+@@ -384,6 +398,10 @@ &mbus {
+ 	compatible = "allwinner,sun8i-h3-mbus";
+ };
+ 
++&mixer1 {
++	resets = <&display_clocks RST_WB>;
++};
++
+ &mmc0 {
+ 	compatible = "allwinner,sun7i-a20-mmc";
+ 	clocks = <&ccu CLK_BUS_MMC0>,
+@@ -431,3 +449,7 @@ &rtc {
+ &sid {
+ 	compatible = "allwinner,sun8i-h3-sid";
+ };
++
++&tcon1_out_tve {
++	remote-endpoint = <&tve_in_tcon1>;
++};
+diff --git a/arch/arm/boot/dts/allwinner/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/allwinner/sunxi-h3-h5.dtsi
+index d911e0927..edd681a60 100644
+--- a/arch/arm/boot/dts/allwinner/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/allwinner/sunxi-h3-h5.dtsi
+@@ -102,7 +102,7 @@ osc32k: osc32k-clk {
+ 
+ 	de: display-engine {
+ 		compatible = "allwinner,sun8i-h3-display-engine";
+-		allwinner,pipelines = <&mixer0>;
++		allwinner,pipelines = <&mixer0>, <&mixer1>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -160,11 +160,50 @@ ports {
+ 				#size-cells = <0>;
+ 
+ 				mixer0_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
+ 					reg = <1>;
+ 
+-					mixer0_out_tcon0: endpoint {
++					mixer0_out_tcon0: endpoint@0 {
++						reg = <0>;
+ 						remote-endpoint = <&tcon0_in_mixer0>;
+ 					};
++
++					mixer0_out_tcon1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&tcon1_in_mixer0>;
++					};
++				};
++			};
++		};
++
++		mixer1: mixer@1200000 {
++			compatible = "allwinner,sun8i-h3-de2-mixer-1";
++			reg = <0x01200000 0x100000>;
++			clocks = <&display_clocks CLK_BUS_MIXER1>,
++				 <&display_clocks CLK_MIXER1>;
++			clock-names = "bus",
++				      "mod";
++			/* reset is added by the SoC dtsi */
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				mixer1_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <1>;
++
++					mixer1_out_tcon0: endpoint@0 {
++						reg = <0>;
++						remote-endpoint = <&tcon0_in_mixer1>;
++					};
++
++					mixer1_out_tcon1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&tcon1_in_mixer1>;
++					};
+ 				};
+ 			};
+ 		};
+@@ -193,11 +232,19 @@ ports {
+ 				#size-cells = <0>;
+ 
+ 				tcon0_in: port@0 {
++					#address-cells = <1>;
++					#size-cells = <0>;
+ 					reg = <0>;
+ 
+-					tcon0_in_mixer0: endpoint {
++					tcon0_in_mixer0: endpoint@0 {
++						reg = <0>;
+ 						remote-endpoint = <&mixer0_out_tcon0>;
+ 					};
++
++					tcon0_in_mixer1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&mixer1_out_tcon0>;
++					};
+ 				};
+ 
+ 				tcon0_out: port@1 {
+@@ -213,6 +260,48 @@ tcon0_out_hdmi: endpoint@1 {
+ 			};
+ 		};
+ 
++		tcon1: lcd-controller@1c0d000 {
++			compatible = "allwinner,sun8i-h3-tcon-tv",
++				     "allwinner,sun8i-a83t-tcon-tv";
++			reg = <0x01c0d000 0x1000>;
++			interrupts = <GIC_SPI 87 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_TCON1>, <&ccu CLK_TVE>;
++			clock-names = "ahb", "tcon-ch1";
++			resets = <&ccu RST_BUS_TCON1>;
++			reset-names = "lcd";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				tcon1_in: port@0 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <0>;
++
++					tcon1_in_mixer0: endpoint@0 {
++						reg = <0>;
++						remote-endpoint = <&mixer0_out_tcon1>;
++					};
++
++					tcon1_in_mixer1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&mixer1_out_tcon1>;
++					};
++				};
++
++				tcon1_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <1>;
++
++					tcon1_out_tve: endpoint@1 {
++						reg = <1>;
++					};
++				};
++			};
++		};
++
+ 		mmc0: mmc@1c0f000 {
+ 			/* compatible and clocks are in per SoC .dtsi file */
+ 			reg = <0x01c0f000 0x1000>;

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-allwinner-h5-add-the-tv-encoder.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/arm64-dts-allwinner-h5-add-the-tv-encoder.patch
@@ -1,0 +1,61 @@
+From fc77105272f92f1a4783ea9a7b600541204faa65 Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 03:26:24 +0300
+Subject: [PATCH] arm64: dts: allwinner: h5: add the TV encoder
+
+The H5 has the same TV encoder as the H3 at a different address, and
+the second mixer and TCON that feed it are already described in the
+shared H3/H5 dtsi. Add the encoder node and the resets it needs. It
+stays disabled, like the rest of the pipeline.
+
+Build-tested only, I have no H5 board.
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi | 22 ++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+index c211f2825..afd78ef2a 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+@@ -199,6 +199,20 @@ ths: thermal-sensor@1c25000 {
+ 			nvmem-cell-names = "calibration";
+ 			#thermal-sensor-cells = <1>;
+ 		};
++
++		tve: tv-encoder@1e40000 {
++			compatible = "allwinner,sun50i-h5-tv-encoder";
++			reg = <0x01e40000 0x1000>;
++			clocks = <&ccu CLK_BUS_TVE>;
++			resets = <&ccu RST_BUS_TVE>;
++			status = "disabled";
++
++			port {
++				tve_in_tcon1: endpoint {
++					remote-endpoint = <&tcon1_out_tve>;
++				};
++			};
++		};
+ 	};
+ 
+ 	thermal-zones {
+@@ -303,6 +317,10 @@ &mbus {
+ 	compatible = "allwinner,sun50i-h5-mbus";
+ };
+ 
++&mixer1 {
++	resets = <&display_clocks RST_MIXER1>;
++};
++
+ &mmc0 {
+ 	compatible = "allwinner,sun50i-h5-mmc",
+ 		     "allwinner,sun50i-a64-mmc";
+@@ -338,3 +356,7 @@ &rtc {
+ &sid {
+ 	compatible = "allwinner,sun50i-h5-sid";
+ };
++
++&tcon1_out_tve {
++	remote-endpoint = <&tve_in_tcon1>;
++};

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/clk-sunxi-ng-h3-add-the-tve-clock.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/clk-sunxi-ng-h3-add-the-tve-clock.patch
@@ -1,0 +1,46 @@
+From 77248dd14b4189017617471ff4e4c55c14ba370f Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 03:26:23 +0300
+Subject: [PATCH] clk: sunxi-ng: h3: add the TVE clock
+
+The H3 CCU never modelled the clock that feeds the TV encoder. It sits
+at 0x120 with the usual gate, divider and mux, but also has a fixed
+post-divider of 16 that the register layout gives no hint of: without
+it the rate the encoder asks for is set sixteen times too high and the
+picture never locks.
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ drivers/clk/sunxi-ng/ccu-sun8i-h3.c | 19 +++++++++++++++++--
+ 1 file changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+index 33254d63e..94d2e46c3 100644
+--- a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
++++ b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+@@ -469,8 +469,23 @@ static SUNXI_CCU_M_WITH_MUX_GATE(tcon_clk, "tcon", tcon_parents,
+ 				 CLK_SET_RATE_PARENT);
+ 
+ static const char * const tve_parents[] = { "pll-de", "pll-periph1" };
+-static SUNXI_CCU_M_WITH_MUX_GATE(tve_clk, "tve", tve_parents,
+-				 0x120, 0, 4, 24, 3, BIT(31), 0);
++/*
++ * The TVE clock has an undocumented fixed post-divider of 16. Without it the
++ * rate the TV encoder asks for is set sixteen times too high and the picture
++ * never locks.
++ */
++static struct ccu_div tve_clk = {
++	.enable	= BIT(31),
++	.div	= _SUNXI_CCU_DIV(0, 4),
++	.mux	= _SUNXI_CCU_MUX(24, 3),
++	.fixed_post_div = 16,
++	.common	= {
++		.reg		= 0x120,
++		.features	= CCU_FEATURE_FIXED_POSTDIV,
++		.hw.init	= CLK_HW_INIT_PARENTS("tve", tve_parents,
++						      &ccu_div_ops, 0),
++	},
++};
+ 
+ static const char * const deinterlace_parents[] = { "pll-periph0", "pll-periph1" };
+ static SUNXI_CCU_M_WITH_MUX_GATE(deinterlace_clk, "deinterlace", deinterlace_parents,

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/drm-sun4i-fix-null-deref-when-unbinding-the-tv-encoder.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/drm-sun4i-fix-null-deref-when-unbinding-the-tv-encoder.patch
@@ -1,0 +1,40 @@
+From 4790cf1d3443361eaeec6aea32873efdc8a81313 Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 05:11:20 +0300
+Subject: [PATCH] drm/sun4i: fix NULL deref when unbinding the TV encoder
+
+sun4i_drv_unbind() calls drm_mode_config_cleanup() before
+component_unbind_all(). The connector's .destroy is drm_connector_cleanup
+and the encoder comes from drm_simple_encoder_init, so both objects are
+already torn down by the time the components are unbound.
+sun4i_tv_unbind() then cleans them a second time and dereferences NULL:
+
+  Internal error: Oops: 5 [#1] SMP THUMB2
+  PC is at drm_connector_cleanup+0x60/0x210
+  LR is at platform_device_unregister+0x9/0x20
+
+No other sun4i component cleans up its connector or encoder in unbind,
+for the same reason. Drop the two calls.
+
+Reproduced on an OrangePi Zero (H2+) with:
+
+  echo display-engine > /sys/bus/platform/drivers/sun4i-drm/unbind
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ drivers/gpu/drm/sun4i/sun4i_tv.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/sun4i/sun4i_tv.c b/drivers/gpu/drm/sun4i/sun4i_tv.c
+index 4c9bfb3c2..07c60d79c 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_tv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_tv.c
+@@ -551,8 +551,6 @@ static void sun4i_tv_unbind(struct device *dev, struct device *master,
+ {
+ 	struct sun4i_tv *tv = dev_get_drvdata(dev);
+ 
+-	drm_connector_cleanup(&tv->connector);
+-	drm_encoder_cleanup(&tv->encoder);
+ 	clk_disable_unprepare(tv->clk);
+ 	reset_control_assert(tv->reset);
+ }

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/drm-sun4i-support-the-h3-and-h5-tv-encoders.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/drm-sun4i-support-the-h3-and-h5-tv-encoders.patch
@@ -1,0 +1,237 @@
+From 5e5ac4e0c8bbe7462c7fb7b9b4b2bf2e5af973b8 Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 03:26:23 +0300
+Subject: [PATCH] drm/sun4i: support the H3 and H5 TV encoders
+
+sun4i_tv.c drives the A10 TV encoder. The H3 and H5 carry the same
+block behind the DE2 display engine, but need a calibration value
+written before the DAC drives anything, and the H5 needs one further
+undocumented register. Add a quirks structure so the A10 keeps its
+current behaviour and the two new compatibles get theirs.
+
+The encoder consumes YUV while the mixer outputs RGB, so the mixer has
+to convert on the way out. Program the DCSC sub-engine with the BT.601
+coefficients through the apply_color_correction and
+disable_color_correction callbacks the engine already exposes. mixer1,
+which is the one that feeds the encoder, is a cut-down block -- one UI
+channel and two scalers against mixer0's three and four -- so it needs
+its own configuration entry.
+
+Tested on an OrangePi Zero (H2+): the connector reports connected, the
+mode comes up as 720x480i, the tve clock runs at 13.5 MHz, and a
+framebuffer image written to /dev/fb0 reproduces correctly on a capture
+card.
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ drivers/gpu/drm/sun4i/sun4i_tv.c    | 39 +++++++++++++++++++-
+ drivers/gpu/drm/sun4i/sun8i_mixer.c | 57 +++++++++++++++++++++++++++--
+ drivers/gpu/drm/sun4i/sun8i_mixer.h |  8 +++-
+ 3 files changed, 98 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/gpu/drm/sun4i/sun4i_tv.c b/drivers/gpu/drm/sun4i/sun4i_tv.c
+index cce4e3878..4c9bfb3c2 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_tv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_tv.c
+@@ -9,6 +9,7 @@
+ #include <linux/clk.h>
+ #include <linux/component.h>
+ #include <linux/module.h>
++#include <linux/of.h>
+ #include <linux/of_address.h>
+ #include <linux/platform_device.h>
+ #include <linux/regmap.h>
+@@ -159,6 +160,16 @@ struct tv_mode {
+ 	const struct resync_parameters	*resync_params;
+ };
+ 
++/*
++ * The H3 and H5 encoders need a calibration value written before the DAC will
++ * drive anything, and the H5 needs one more undocumented register. The A10
++ * encoder this driver was written for needs neither, so it takes the empty set.
++ */
++struct sun4i_tv_quirks {
++	unsigned int calibration;
++	unsigned int unknown : 1;
++};
++
+ struct sun4i_tv {
+ 	struct drm_connector	connector;
+ 	struct drm_encoder	encoder;
+@@ -419,7 +430,7 @@ static const struct regmap_config sun4i_tv_regmap_config = {
+ 	.reg_bits	= 32,
+ 	.val_bits	= 32,
+ 	.reg_stride	= 4,
+-	.max_register	= SUN4I_TVE_WSS_DATA2_REG,
++	.max_register	= 0x400,
+ 	.name		= "tv-encoder",
+ };
+ 
+@@ -429,10 +440,15 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
+ 	struct platform_device *pdev = to_platform_device(dev);
+ 	struct drm_device *drm = data;
+ 	struct sun4i_drv *drv = drm->dev_private;
++	const struct sun4i_tv_quirks *quirks;
+ 	struct sun4i_tv *tv;
+ 	void __iomem *regs;
+ 	int ret;
+ 
++	quirks = of_device_get_match_data(dev);
++	if (!quirks)
++		return -EINVAL;
++
+ 	tv = devm_kzalloc(dev, sizeof(*tv), GFP_KERNEL);
+ 	if (!tv)
+ 		return -ENOMEM;
+@@ -472,6 +488,11 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
+ 	}
+ 	clk_prepare_enable(tv->clk);
+ 
++	if (quirks->calibration)
++		regmap_write(tv->regs, 0x304, quirks->calibration);
++	if (quirks->unknown)
++		regmap_write(tv->regs, 0x30c, 0x00101110);
++
+ 	drm_encoder_helper_add(&tv->encoder,
+ 			       &sun4i_tv_helper_funcs);
+ 	ret = drm_simple_encoder_init(drm, &tv->encoder,
+@@ -551,8 +572,22 @@ static void sun4i_tv_remove(struct platform_device *pdev)
+ 	component_del(&pdev->dev, &sun4i_tv_ops);
+ }
+ 
++static const struct sun4i_tv_quirks a10_quirks = {
++};
++
++static const struct sun4i_tv_quirks h3_quirks = {
++	.calibration = 0x02000c00,
++};
++
++static const struct sun4i_tv_quirks h5_quirks = {
++	.calibration = 0x02850000,
++	.unknown = 1,
++};
++
+ static const struct of_device_id sun4i_tv_of_table[] = {
+-	{ .compatible = "allwinner,sun4i-a10-tv-encoder" },
++	{ .compatible = "allwinner,sun4i-a10-tv-encoder", .data = &a10_quirks },
++	{ .compatible = "allwinner,sun8i-h3-tv-encoder", .data = &h3_quirks },
++	{ .compatible = "allwinner,sun50i-h5-tv-encoder", .data = &h5_quirks },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(of, sun4i_tv_of_table);
+diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.c b/drivers/gpu/drm/sun4i/sun8i_mixer.c
+index 584681dd4..248c651d5 100644
+--- a/drivers/gpu/drm/sun4i/sun8i_mixer.c
++++ b/drivers/gpu/drm/sun4i/sun8i_mixer.c
+@@ -36,6 +36,16 @@ struct de2_fmt_info {
+ 	u32	de2_fmt;
+ };
+ 
++/*
++ * The TV encoder takes YUV, so the mixer has to convert on the way out. These
++ * are the BT.601 coefficients the DCSC sub-engine is programmed with.
++ */
++static const u32 sun8i_rgb2yuv_coef[12] = {
++	0x00000107, 0x00000204, 0x00000064, 0x00004200,
++	0x00001f68, 0x00001ed6, 0x000001c2, 0x00020200,
++	0x000001c2, 0x00001e87, 0x00001fb7, 0x00020200,
++};
++
+ static const struct de2_fmt_info de2_formats[] = {
+ 	{
+ 		.drm_fmt = DRM_FORMAT_ARGB8888,
+@@ -412,10 +422,28 @@ static void sun8i_mixer_mode_set(struct sunxi_engine *engine,
+ 			 interlaced ? "on" : "off");
+ }
+ 
++static void sun8i_mixer_apply_color_correction(struct sunxi_engine *engine)
++{
++	DRM_DEBUG_DRIVER("Applying RGB to YUV color correction\n");
++
++	regmap_bulk_write(engine->regs, SUN8I_MIXER_DCSC_COEF_REG(0),
++			  sun8i_rgb2yuv_coef, 12);
++	regmap_write(engine->regs, SUN8I_MIXER_DCSC_EN, 1);
++}
++
++static void sun8i_mixer_disable_color_correction(struct sunxi_engine *engine)
++{
++	DRM_DEBUG_DRIVER("Disabling color correction\n");
++
++	regmap_write(engine->regs, SUN8I_MIXER_DCSC_EN, 0);
++}
++
+ static const struct sunxi_engine_ops sun8i_engine_ops = {
+-	.commit		= sun8i_mixer_commit,
+-	.layers_init	= sun8i_layers_init,
+-	.mode_set	= sun8i_mixer_mode_set,
++	.commit			= sun8i_mixer_commit,
++	.layers_init		= sun8i_layers_init,
++	.mode_set		= sun8i_mixer_mode_set,
++	.apply_color_correction	= sun8i_mixer_apply_color_correction,
++	.disable_color_correction = sun8i_mixer_disable_color_correction,
+ };
+ 
+ static const struct sunxi_engine_ops sun50i_engine_ops = {
+@@ -766,6 +794,25 @@ static const struct sun8i_mixer_cfg sun8i_h3_mixer0_cfg = {
+ 	.vi_num		= 1,
+ };
+ 
++/*
++ * Mixer1 drives TCON1 and from there the TV encoder. It is a cut-down block:
++ * one UI channel and two scalers, against mixer0's three and four.
++ */
++static const struct sun8i_mixer_cfg sun8i_h3_mixer1_cfg = {
++	.lay_cfg = {
++		.ccsc		= CCSC_MIXER1_LAYOUT,
++		.de_type	= SUN8I_MIXER_DE2,
++		.vi_scaler_num	= 1,
++		.scaler_mask	= 0x3,
++		.scanline_yuv	= 2048,
++		.de2_fcc_alpha	= 1,
++	},
++	.de_type	= SUN8I_MIXER_DE2,
++	.mod_rate	= 432000000,
++	.ui_num		= 1,
++	.vi_num		= 1,
++};
++
+ static const struct sun8i_mixer_cfg sun8i_r40_mixer0_cfg = {
+ 	.lay_cfg = {
+ 		.ccsc		= CCSC_MIXER0_LAYOUT,
+@@ -901,6 +948,10 @@ static const struct of_device_id sun8i_mixer_of_table[] = {
+ 		.compatible = "allwinner,sun8i-h3-de2-mixer-0",
+ 		.data = &sun8i_h3_mixer0_cfg,
+ 	},
++	{
++		.compatible = "allwinner,sun8i-h3-de2-mixer-1",
++		.data = &sun8i_h3_mixer1_cfg,
++	},
+ 	{
+ 		.compatible = "allwinner,sun8i-r40-de2-mixer-0",
+ 		.data = &sun8i_r40_mixer0_cfg,
+diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.h b/drivers/gpu/drm/sun4i/sun8i_mixer.h
+index 7abc88c89..402e1c98f 100644
+--- a/drivers/gpu/drm/sun4i/sun8i_mixer.h
++++ b/drivers/gpu/drm/sun4i/sun8i_mixer.h
+@@ -125,6 +125,13 @@
+ /* format 20 is packed YVU444 10-bit */
+ /* format 21 is packed YUV444 10-bit */
+ 
++/*
++ * The DCSC sub-engine converts the mixer's RGB output to YUV, which is what
++ * the TV encoder expects. It is unused on the HDMI path.
++ */
++#define SUN8I_MIXER_DCSC_EN			0xb0000
++#define SUN8I_MIXER_DCSC_COEF_REG(x)		(0xb0010 + 0x4 * (x))
++
+ /*
+  * Sub-engines listed bellow are unused for now. The EN registers are here only
+  * to be used to disable these sub-engines.
+@@ -135,7 +142,6 @@
+ #define SUN8I_MIXER_PEAK_EN			0xa6000
+ #define SUN8I_MIXER_ASE_EN			0xa8000
+ #define SUN8I_MIXER_FCC_EN			0xaa000
+-#define SUN8I_MIXER_DCSC_EN			0xb0000
+ 
+ #define SUN50I_MIXER_FCE_EN			0x70000
+ #define SUN50I_MIXER_PEAK_EN			0x70800

--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/dt-bindings-display-allwinner-add-h3-h5-tv-encoder-and-mixer1.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/dt-bindings-display-allwinner-add-h3-h5-tv-encoder-and-mixer1.patch
@@ -1,0 +1,54 @@
+From ceb848106390a166d00acb07540d15b168187698 Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 02:59:23 +0300
+Subject: [PATCH] dt-bindings: display: allwinner: add H3/H5 TV encoder and H3
+ mixer1
+
+The H3 and H5 carry the same TV encoder the A10 binding already
+describes, and the H3 has a second DE2 mixer alongside the documented
+mixer0. Add the three compatibles so the device trees that use them
+validate.
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ .../bindings/display/allwinner,sun4i-a10-tv-encoder.yaml   | 7 +++++--
+ .../bindings/display/allwinner,sun8i-a83t-de2-mixer.yaml   | 1 +
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/devicetree/bindings/display/allwinner,sun4i-a10-tv-encoder.yaml b/Documentation/devicetree/bindings/display/allwinner,sun4i-a10-tv-encoder.yaml
+index c39e90a59..ce85b474b 100644
+--- a/Documentation/devicetree/bindings/display/allwinner,sun4i-a10-tv-encoder.yaml
++++ b/Documentation/devicetree/bindings/display/allwinner,sun4i-a10-tv-encoder.yaml
+@@ -4,7 +4,7 @@
+ $id: http://devicetree.org/schemas/display/allwinner,sun4i-a10-tv-encoder.yaml#
+ $schema: http://devicetree.org/meta-schemas/core.yaml#
+ 
+-title: Allwinner A10 TV Encoder
++title: Allwinner A10/H3/H5 TV Encoder
+ 
+ maintainers:
+   - Chen-Yu Tsai <wens@csie.org>
+@@ -12,7 +12,10 @@ maintainers:
+ 
+ properties:
+   compatible:
+-    const: allwinner,sun4i-a10-tv-encoder
++    enum:
++      - allwinner,sun4i-a10-tv-encoder
++      - allwinner,sun8i-h3-tv-encoder
++      - allwinner,sun50i-h5-tv-encoder
+ 
+   reg:
+     maxItems: 1
+diff --git a/Documentation/devicetree/bindings/display/allwinner,sun8i-a83t-de2-mixer.yaml b/Documentation/devicetree/bindings/display/allwinner,sun8i-a83t-de2-mixer.yaml
+index 064e4ca7e..f65682449 100644
+--- a/Documentation/devicetree/bindings/display/allwinner,sun8i-a83t-de2-mixer.yaml
++++ b/Documentation/devicetree/bindings/display/allwinner,sun8i-a83t-de2-mixer.yaml
+@@ -16,6 +16,7 @@ properties:
+       - allwinner,sun8i-a83t-de2-mixer-0
+       - allwinner,sun8i-a83t-de2-mixer-1
+       - allwinner,sun8i-h3-de2-mixer-0
++      - allwinner,sun8i-h3-de2-mixer-1
+       - allwinner,sun8i-r40-de2-mixer-0
+       - allwinner,sun8i-r40-de2-mixer-1
+       - allwinner,sun8i-v3s-de2-mixer

--- a/patch/kernel/archive/sunxi-6.18/series.conf
+++ b/patch/kernel/archive/sunxi-6.18/series.conf
@@ -418,7 +418,9 @@
 	patches.armbian/0701-arm64-dts-sun50i-h616-orangepi-zero-enable-sound.patch
 	patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
 	patches.armbian/arch-arm-patch-flush-icache-earlier.patch
+	patches.armbian/arm-dts-sunxi-h3-describe-the-tv-encoder-pipeline.patch
 	patches.armbian/arm64-dts-add-axp313a-pmic.patch
+	patches.armbian/arm64-dts-allwinner-h5-add-the-tv-encoder.patch
 	patches.armbian/arm64-dts-sun50i-a64.dtsi-adjust-thermal-trip-points.patch
 	patches.armbian/arm64-dts-sun50i-a64-force-mmc0-bus-width.patch
 	patches.armbian/arm64-dts-sun50i-a64-nanopi-fix-ethernet-phy-mode.patch
@@ -515,13 +517,10 @@
 	patches.armbian/build-scripts-add-overlay-compilation.patch
 	patches.armbian/build-scripts-add-scr-fixup-support.patch
 	patches.armbian/build-scripts-dtc-enable-symbols-node.patch
+	patches.armbian/clk-sunxi-ng-h3-add-the-tve-clock.patch
 	patches.armbian/Doc-dt-bindings-usb-allwinner-dwc3.patch
 	patches.armbian/drm-sun4i-fix-null-deref-when-unbinding-the-tv-encoder.patch
-	patches.armbian/dt-bindings-display-allwinner-add-h3-h5-tv-encoder-and-mixer1.patch
-	patches.armbian/clk-sunxi-ng-h3-add-the-tve-clock.patch
 	patches.armbian/drm-sun4i-support-the-h3-and-h5-tv-encoders.patch
-	patches.armbian/arm-dts-sunxi-h3-describe-the-tv-encoder-pipeline.patch
-	patches.armbian/arm64-dts-allwinner-h5-add-the-tv-encoder.patch
 	patches.armbian/drv-asoc-ac200-codec.patch
 	patches.armbian/drv-asoc-sunxi-provoke-early-load-sun8i-codec-analog.patch
 	patches.armbian/drv-asoc-sunxi-sun4i-codec-select-capture-source.patch
@@ -572,4 +571,5 @@
 	patches.armbian/drv-staging-rtl8723bs-AP-bugfix.patch
 	patches.armbian/drv-usb-gadget-composite-rename-serial-manufacturer.patch
 	patches.armbian/drv-video-st7796s-fb-tft-driver.patch
+	patches.armbian/dt-bindings-display-allwinner-add-h3-h5-tv-encoder-and-mixer1.patch
 	patches.armbian/include-uapi-drm_fourcc-add-ARM-tiled-format-modifier.patch

--- a/patch/kernel/archive/sunxi-6.18/series.conf
+++ b/patch/kernel/archive/sunxi-6.18/series.conf
@@ -516,6 +516,12 @@
 	patches.armbian/build-scripts-add-scr-fixup-support.patch
 	patches.armbian/build-scripts-dtc-enable-symbols-node.patch
 	patches.armbian/Doc-dt-bindings-usb-allwinner-dwc3.patch
+	patches.armbian/drm-sun4i-fix-null-deref-when-unbinding-the-tv-encoder.patch
+	patches.armbian/dt-bindings-display-allwinner-add-h3-h5-tv-encoder-and-mixer1.patch
+	patches.armbian/clk-sunxi-ng-h3-add-the-tve-clock.patch
+	patches.armbian/drm-sun4i-support-the-h3-and-h5-tv-encoders.patch
+	patches.armbian/arm-dts-sunxi-h3-describe-the-tv-encoder-pipeline.patch
+	patches.armbian/arm64-dts-allwinner-h5-add-the-tv-encoder.patch
 	patches.armbian/drv-asoc-ac200-codec.patch
 	patches.armbian/drv-asoc-sunxi-provoke-early-load-sun8i-codec-analog.patch
 	patches.armbian/drv-asoc-sunxi-sun4i-codec-select-capture-source.patch

--- a/patch/kernel/archive/sunxi-7.1/overlay_32/Makefile
+++ b/patch/kernel/archive/sunxi-7.1/overlay_32/Makefile
@@ -72,6 +72,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
 	sun8i-h3-spi-add-cs1.dtbo \
 	sun8i-h3-spi-jedec-nor.dtbo \
 	sun8i-h3-spi-spidev.dtbo \
+	sun8i-h3-tve.dtbo \
 	sun8i-h3-uart1.dtbo \
 	sun8i-h3-uart2.dtbo \
 	sun8i-h3-uart3.dtbo \

--- a/patch/kernel/archive/sunxi-7.1/overlay_32/README.sun8i-h3-overlays
+++ b/patch/kernel/archive/sunxi-7.1/overlay_32/README.sun8i-h3-overlays
@@ -26,6 +26,7 @@ adding fixed software (GPIO) chip selects is possible with a separate overlay
 - spi-add-cs1
 - spi-jedec-nor
 - spi-spidev
+- tve
 - uart1
 - uart2
 - uart3
@@ -248,3 +249,11 @@ param_w1_pin_int_pullup (bool)
 	Set to 1 to enable the pull-up
 	This option should not be used with multiple devices, parasite power setup
 		or long wires -	please use external pull-up resistor instead
+
+### tve
+
+Activates the composite (CVBS) TV encoder.
+
+For boards whose DTS does not enable the output itself. It switches on the
+display engine and the TV encoder. PAL/NTSC follows the mode the display
+asks for.

--- a/patch/kernel/archive/sunxi-7.1/overlay_32/sun8i-h3-tve.dtso
+++ b/patch/kernel/archive/sunxi-7.1/overlay_32/sun8i-h3-tve.dtso
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Composite (CVBS) TV output on H2+/H3.
+ *
+ * For boards whose DTS does not enable the output itself. It switches on the
+ * display engine and the TV encoder; the second mixer and TCON that feed it
+ * are already described by the SoC dtsi.
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun8i-h3";
+
+	fragment@0 {
+		target = <&de>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&mixer1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&tcon1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&tve>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/patch/kernel/archive/sunxi-7.1/overlay_64/Makefile
+++ b/patch/kernel/archive/sunxi-7.1/overlay_64/Makefile
@@ -35,6 +35,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
 	sun50i-h5-usbhost2.dtbo \
 	sun50i-h5-usbhost3.dtbo \
 	sun50i-h5-w1-gpio.dtbo \
+	sun50i-h5-tve.dtbo \
 	sun50i-h6-i2c0.dtbo \
 	sun50i-h6-i2c1.dtbo \
 	sun50i-h6-i2c2.dtbo \

--- a/patch/kernel/archive/sunxi-7.1/overlay_64/README.sun50i-h5-overlays
+++ b/patch/kernel/archive/sunxi-7.1/overlay_64/README.sun50i-h5-overlays
@@ -26,6 +26,7 @@ adding fixed software (GPIO) chip selects is possible with a separate overlay
 - spi-add-cs1
 - spi-jedec-nor
 - spi-spidev
+- tve
 - uart1
 - uart2
 - uart3
@@ -248,3 +249,7 @@ param_w1_pin_int_pullup (bool)
 	Set to 1 to enable the pull-up
 	This option should not be used with multiple devices, parasite power setup
 		or long wires -	please use external pull-up resistor instead
+
+### tve
+
+Activates the composite (CVBS) TV encoder.

--- a/patch/kernel/archive/sunxi-7.1/overlay_64/sun50i-h5-tve.dtso
+++ b/patch/kernel/archive/sunxi-7.1/overlay_64/sun50i-h5-tve.dtso
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Composite (CVBS) TV output on H5.
+ *
+ * For boards whose DTS does not enable the output itself. It switches on the
+ * display engine and the TV encoder; the second mixer and TCON that feed it
+ * are already described by the SoC dtsi.
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun50i-h5";
+
+	fragment@0 {
+		target = <&de>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&mixer1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&tcon1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&tve>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm-dts-sunxi-h3-describe-the-tv-encoder-pipeline.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm-dts-sunxi-h3-describe-the-tv-encoder-pipeline.patch
@@ -1,0 +1,200 @@
+From d4e8656d8bff2c2a3b5e3767ce35476a60515ba0 Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 13:50:39 +0300
+Subject: [PATCH] ARM: dts: sunxi: h3: describe the TV encoder pipeline
+
+The H3 display engine has a second pipeline -- mixer1 feeding TCON1 and
+from there the TV encoder -- that the device tree never described, so
+composite output has never worked on these boards. Add the nodes, with
+port endpoints wired so that either mixer can drive either TCON.
+
+It stays disabled. On a board with no other display output, switching
+the display engine on costs a permanently running 432 MHz PLL whether
+or not a television is plugged in, so enabling it is left to the board
+that routes the signal somewhere.
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ arch/arm/boot/dts/allwinner/sun8i-h3.dtsi    | 22 +++++
+ arch/arm/boot/dts/allwinner/sunxi-h3-h5.dtsi | 95 +++++++++++++++++++-
+ 2 files changed, 114 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/boot/dts/allwinner/sun8i-h3.dtsi b/arch/arm/boot/dts/allwinner/sun8i-h3.dtsi
+index 6d3adae641..f15fb1055e 100644
+--- a/arch/arm/boot/dts/allwinner/sun8i-h3.dtsi
++++ b/arch/arm/boot/dts/allwinner/sun8i-h3.dtsi
+@@ -289,6 +289,20 @@ ths: thermal-sensor@1c25000 {
+ 			nvmem-cell-names = "calibration";
+ 			#thermal-sensor-cells = <0>;
+ 		};
++
++		tve: tv-encoder@1e00000 {
++			compatible = "allwinner,sun8i-h3-tv-encoder";
++			reg = <0x01e00000 0x1000>;
++			clocks = <&ccu CLK_BUS_TVE>;
++			resets = <&ccu RST_BUS_TVE>;
++			status = "disabled";
++
++			port {
++				tve_in_tcon1: endpoint {
++					remote-endpoint = <&tcon1_out_tve>;
++				};
++			};
++		};
+ 	};
+ 
+ 	thermal-zones {
+@@ -378,6 +392,10 @@ &mbus {
+ 	compatible = "allwinner,sun8i-h3-mbus";
+ };
+ 
++&mixer1 {
++	resets = <&display_clocks RST_WB>;
++};
++
+ &mmc0 {
+ 	compatible = "allwinner,sun7i-a20-mmc";
+ 	clocks = <&ccu CLK_BUS_MMC0>,
+@@ -425,3 +443,7 @@ &rtc {
+ &sid {
+ 	compatible = "allwinner,sun8i-h3-sid";
+ };
++
++&tcon1_out_tve {
++	remote-endpoint = <&tve_in_tcon1>;
++};
+diff --git a/arch/arm/boot/dts/allwinner/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/allwinner/sunxi-h3-h5.dtsi
+index d911e09271..edd681a60a 100644
+--- a/arch/arm/boot/dts/allwinner/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/allwinner/sunxi-h3-h5.dtsi
+@@ -102,7 +102,7 @@ osc32k: osc32k-clk {
+ 
+ 	de: display-engine {
+ 		compatible = "allwinner,sun8i-h3-display-engine";
+-		allwinner,pipelines = <&mixer0>;
++		allwinner,pipelines = <&mixer0>, <&mixer1>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -160,11 +160,50 @@ ports {
+ 				#size-cells = <0>;
+ 
+ 				mixer0_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
+ 					reg = <1>;
+ 
+-					mixer0_out_tcon0: endpoint {
++					mixer0_out_tcon0: endpoint@0 {
++						reg = <0>;
+ 						remote-endpoint = <&tcon0_in_mixer0>;
+ 					};
++
++					mixer0_out_tcon1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&tcon1_in_mixer0>;
++					};
++				};
++			};
++		};
++
++		mixer1: mixer@1200000 {
++			compatible = "allwinner,sun8i-h3-de2-mixer-1";
++			reg = <0x01200000 0x100000>;
++			clocks = <&display_clocks CLK_BUS_MIXER1>,
++				 <&display_clocks CLK_MIXER1>;
++			clock-names = "bus",
++				      "mod";
++			/* reset is added by the SoC dtsi */
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				mixer1_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <1>;
++
++					mixer1_out_tcon0: endpoint@0 {
++						reg = <0>;
++						remote-endpoint = <&tcon0_in_mixer1>;
++					};
++
++					mixer1_out_tcon1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&tcon1_in_mixer1>;
++					};
+ 				};
+ 			};
+ 		};
+@@ -193,11 +232,19 @@ ports {
+ 				#size-cells = <0>;
+ 
+ 				tcon0_in: port@0 {
++					#address-cells = <1>;
++					#size-cells = <0>;
+ 					reg = <0>;
+ 
+-					tcon0_in_mixer0: endpoint {
++					tcon0_in_mixer0: endpoint@0 {
++						reg = <0>;
+ 						remote-endpoint = <&mixer0_out_tcon0>;
+ 					};
++
++					tcon0_in_mixer1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&mixer1_out_tcon0>;
++					};
+ 				};
+ 
+ 				tcon0_out: port@1 {
+@@ -213,6 +260,48 @@ tcon0_out_hdmi: endpoint@1 {
+ 			};
+ 		};
+ 
++		tcon1: lcd-controller@1c0d000 {
++			compatible = "allwinner,sun8i-h3-tcon-tv",
++				     "allwinner,sun8i-a83t-tcon-tv";
++			reg = <0x01c0d000 0x1000>;
++			interrupts = <GIC_SPI 87 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_TCON1>, <&ccu CLK_TVE>;
++			clock-names = "ahb", "tcon-ch1";
++			resets = <&ccu RST_BUS_TCON1>;
++			reset-names = "lcd";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				tcon1_in: port@0 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <0>;
++
++					tcon1_in_mixer0: endpoint@0 {
++						reg = <0>;
++						remote-endpoint = <&mixer0_out_tcon1>;
++					};
++
++					tcon1_in_mixer1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&mixer1_out_tcon1>;
++					};
++				};
++
++				tcon1_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <1>;
++
++					tcon1_out_tve: endpoint@1 {
++						reg = <1>;
++					};
++				};
++			};
++		};
++
+ 		mmc0: mmc@1c0f000 {
+ 			/* compatible and clocks are in per SoC .dtsi file */
+ 			reg = <0x01c0f000 0x1000>;

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-h5-add-the-tv-encoder.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-allwinner-h5-add-the-tv-encoder.patch
@@ -1,0 +1,61 @@
+From 2e46b64e42e2ed6701619c092fbef6340f349046 Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 13:50:40 +0300
+Subject: [PATCH] arm64: dts: allwinner: h5: add the TV encoder
+
+The H5 has the same TV encoder as the H3 at a different address, and
+the second mixer and TCON that feed it are already described in the
+shared H3/H5 dtsi. Add the encoder node and the resets it needs. It
+stays disabled, like the rest of the pipeline.
+
+Build-tested only, I have no H5 board.
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi | 22 ++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+index 75a97bcbc5..9e4c535194 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+@@ -193,6 +193,20 @@ ths: thermal-sensor@1c25000 {
+ 			nvmem-cell-names = "calibration";
+ 			#thermal-sensor-cells = <1>;
+ 		};
++
++		tve: tv-encoder@1e40000 {
++			compatible = "allwinner,sun50i-h5-tv-encoder";
++			reg = <0x01e40000 0x1000>;
++			clocks = <&ccu CLK_BUS_TVE>;
++			resets = <&ccu RST_BUS_TVE>;
++			status = "disabled";
++
++			port {
++				tve_in_tcon1: endpoint {
++					remote-endpoint = <&tcon1_out_tve>;
++				};
++			};
++		};
+ 	};
+ 
+ 	thermal-zones {
+@@ -288,6 +302,10 @@ &mbus {
+ 	compatible = "allwinner,sun50i-h5-mbus";
+ };
+ 
++&mixer1 {
++	resets = <&display_clocks RST_MIXER1>;
++};
++
+ &mmc0 {
+ 	compatible = "allwinner,sun50i-h5-mmc",
+ 		     "allwinner,sun50i-a64-mmc";
+@@ -323,3 +341,7 @@ &rtc {
+ &sid {
+ 	compatible = "allwinner,sun50i-h5-sid";
+ };
++
++&tcon1_out_tve {
++	remote-endpoint = <&tve_in_tcon1>;
++};

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/clk-sunxi-ng-h3-add-the-tve-clock.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/clk-sunxi-ng-h3-add-the-tve-clock.patch
@@ -1,0 +1,46 @@
+From 728a9bab7b2737d69ba15160daa1397116edcfc1 Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 13:50:38 +0300
+Subject: [PATCH] clk: sunxi-ng: h3: add the TVE clock
+
+The H3 CCU never modelled the clock that feeds the TV encoder. It sits
+at 0x120 with the usual gate, divider and mux, but also has a fixed
+post-divider of 16 that the register layout gives no hint of: without
+it the rate the encoder asks for is set sixteen times too high and the
+picture never locks.
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ drivers/clk/sunxi-ng/ccu-sun8i-h3.c | 19 +++++++++++++++++--
+ 1 file changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+index edb10f6b1b..841086e959 100644
+--- a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
++++ b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+@@ -469,8 +469,23 @@ static SUNXI_CCU_M_WITH_MUX_GATE(tcon_clk, "tcon", tcon_parents,
+ 				 CLK_SET_RATE_PARENT);
+ 
+ static const char * const tve_parents[] = { "pll-de", "pll-periph1" };
+-static SUNXI_CCU_M_WITH_MUX_GATE(tve_clk, "tve", tve_parents,
+-				 0x120, 0, 4, 24, 3, BIT(31), 0);
++/*
++ * The TVE clock has an undocumented fixed post-divider of 16. Without it the
++ * rate the TV encoder asks for is set sixteen times too high and the picture
++ * never locks.
++ */
++static struct ccu_div tve_clk = {
++	.enable	= BIT(31),
++	.div	= _SUNXI_CCU_DIV(0, 4),
++	.mux	= _SUNXI_CCU_MUX(24, 3),
++	.fixed_post_div = 16,
++	.common	= {
++		.reg		= 0x120,
++		.features	= CCU_FEATURE_FIXED_POSTDIV,
++		.hw.init	= CLK_HW_INIT_PARENTS("tve", tve_parents,
++						      &ccu_div_ops, 0),
++	},
++};
+ 
+ static const char * const deinterlace_parents[] = { "pll-periph0", "pll-periph1" };
+ static SUNXI_CCU_M_WITH_MUX_GATE(deinterlace_clk, "deinterlace", deinterlace_parents,

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drm-sun4i-fix-null-deref-when-unbinding-the-tv-encoder.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drm-sun4i-fix-null-deref-when-unbinding-the-tv-encoder.patch
@@ -1,0 +1,40 @@
+From 4e20fa629bbdbbecee9dd62013df28199058a97e Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 13:50:38 +0300
+Subject: [PATCH] drm/sun4i: fix NULL deref when unbinding the TV encoder
+
+sun4i_drv_unbind() calls drm_mode_config_cleanup() before
+component_unbind_all(). The connector's .destroy is drm_connector_cleanup
+and the encoder comes from drm_simple_encoder_init, so both objects are
+already torn down by the time the components are unbound.
+sun4i_tv_unbind() then cleans them a second time and dereferences NULL:
+
+  Internal error: Oops: 5 [#1] SMP THUMB2
+  PC is at drm_connector_cleanup+0x60/0x210
+  LR is at platform_device_unregister+0x9/0x20
+
+No other sun4i component cleans up its connector or encoder in unbind,
+for the same reason. Drop the two calls.
+
+Reproduced on an OrangePi Zero (H2+) with:
+
+  echo display-engine > /sys/bus/platform/drivers/sun4i-drm/unbind
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ drivers/gpu/drm/sun4i/sun4i_tv.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/sun4i/sun4i_tv.c b/drivers/gpu/drm/sun4i/sun4i_tv.c
+index cce4e38789..1e5f88d3a6 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_tv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_tv.c
+@@ -530,8 +530,6 @@ static void sun4i_tv_unbind(struct device *dev, struct device *master,
+ {
+ 	struct sun4i_tv *tv = dev_get_drvdata(dev);
+ 
+-	drm_connector_cleanup(&tv->connector);
+-	drm_encoder_cleanup(&tv->encoder);
+ 	clk_disable_unprepare(tv->clk);
+ 	reset_control_assert(tv->reset);
+ }

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drm-sun4i-support-the-h3-and-h5-tv-encoders.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drm-sun4i-support-the-h3-and-h5-tv-encoders.patch
@@ -1,0 +1,237 @@
+From 41489e6259abcfc4d7c126ec3a4d201cbf4f5748 Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 13:50:38 +0300
+Subject: [PATCH] drm/sun4i: support the H3 and H5 TV encoders
+
+sun4i_tv.c drives the A10 TV encoder. The H3 and H5 carry the same
+block behind the DE2 display engine, but need a calibration value
+written before the DAC drives anything, and the H5 needs one further
+undocumented register. Add a quirks structure so the A10 keeps its
+current behaviour and the two new compatibles get theirs.
+
+The encoder consumes YUV while the mixer outputs RGB, so the mixer has
+to convert on the way out. Program the DCSC sub-engine with the BT.601
+coefficients through the apply_color_correction and
+disable_color_correction callbacks the engine already exposes. mixer1,
+which is the one that feeds the encoder, is a cut-down block -- one UI
+channel and two scalers against mixer0's three and four -- so it needs
+its own configuration entry.
+
+Tested on an OrangePi Zero (H2+): the connector reports connected, the
+mode comes up as 720x480i, the tve clock runs at 13.5 MHz, and a
+framebuffer image written to /dev/fb0 reproduces correctly on a capture
+card.
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ drivers/gpu/drm/sun4i/sun4i_tv.c    | 39 +++++++++++++++++++-
+ drivers/gpu/drm/sun4i/sun8i_mixer.c | 57 +++++++++++++++++++++++++++--
+ drivers/gpu/drm/sun4i/sun8i_mixer.h |  8 +++-
+ 3 files changed, 98 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/gpu/drm/sun4i/sun4i_tv.c b/drivers/gpu/drm/sun4i/sun4i_tv.c
+index 1e5f88d3a6..07c60d79c8 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_tv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_tv.c
+@@ -9,6 +9,7 @@
+ #include <linux/clk.h>
+ #include <linux/component.h>
+ #include <linux/module.h>
++#include <linux/of.h>
+ #include <linux/of_address.h>
+ #include <linux/platform_device.h>
+ #include <linux/regmap.h>
+@@ -159,6 +160,16 @@ struct tv_mode {
+ 	const struct resync_parameters	*resync_params;
+ };
+ 
++/*
++ * The H3 and H5 encoders need a calibration value written before the DAC will
++ * drive anything, and the H5 needs one more undocumented register. The A10
++ * encoder this driver was written for needs neither, so it takes the empty set.
++ */
++struct sun4i_tv_quirks {
++	unsigned int calibration;
++	unsigned int unknown : 1;
++};
++
+ struct sun4i_tv {
+ 	struct drm_connector	connector;
+ 	struct drm_encoder	encoder;
+@@ -419,7 +430,7 @@ static const struct regmap_config sun4i_tv_regmap_config = {
+ 	.reg_bits	= 32,
+ 	.val_bits	= 32,
+ 	.reg_stride	= 4,
+-	.max_register	= SUN4I_TVE_WSS_DATA2_REG,
++	.max_register	= 0x400,
+ 	.name		= "tv-encoder",
+ };
+ 
+@@ -429,10 +440,15 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
+ 	struct platform_device *pdev = to_platform_device(dev);
+ 	struct drm_device *drm = data;
+ 	struct sun4i_drv *drv = drm->dev_private;
++	const struct sun4i_tv_quirks *quirks;
+ 	struct sun4i_tv *tv;
+ 	void __iomem *regs;
+ 	int ret;
+ 
++	quirks = of_device_get_match_data(dev);
++	if (!quirks)
++		return -EINVAL;
++
+ 	tv = devm_kzalloc(dev, sizeof(*tv), GFP_KERNEL);
+ 	if (!tv)
+ 		return -ENOMEM;
+@@ -472,6 +488,11 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
+ 	}
+ 	clk_prepare_enable(tv->clk);
+ 
++	if (quirks->calibration)
++		regmap_write(tv->regs, 0x304, quirks->calibration);
++	if (quirks->unknown)
++		regmap_write(tv->regs, 0x30c, 0x00101110);
++
+ 	drm_encoder_helper_add(&tv->encoder,
+ 			       &sun4i_tv_helper_funcs);
+ 	ret = drm_simple_encoder_init(drm, &tv->encoder,
+@@ -549,8 +570,22 @@ static void sun4i_tv_remove(struct platform_device *pdev)
+ 	component_del(&pdev->dev, &sun4i_tv_ops);
+ }
+ 
++static const struct sun4i_tv_quirks a10_quirks = {
++};
++
++static const struct sun4i_tv_quirks h3_quirks = {
++	.calibration = 0x02000c00,
++};
++
++static const struct sun4i_tv_quirks h5_quirks = {
++	.calibration = 0x02850000,
++	.unknown = 1,
++};
++
+ static const struct of_device_id sun4i_tv_of_table[] = {
+-	{ .compatible = "allwinner,sun4i-a10-tv-encoder" },
++	{ .compatible = "allwinner,sun4i-a10-tv-encoder", .data = &a10_quirks },
++	{ .compatible = "allwinner,sun8i-h3-tv-encoder", .data = &h3_quirks },
++	{ .compatible = "allwinner,sun50i-h5-tv-encoder", .data = &h5_quirks },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(of, sun4i_tv_of_table);
+diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.c b/drivers/gpu/drm/sun4i/sun8i_mixer.c
+index 957db09384..b06eabb944 100644
+--- a/drivers/gpu/drm/sun4i/sun8i_mixer.c
++++ b/drivers/gpu/drm/sun4i/sun8i_mixer.c
+@@ -37,6 +37,16 @@ struct de2_fmt_info {
+ 	u32	de2_fmt;
+ };
+ 
++/*
++ * The TV encoder takes YUV, so the mixer has to convert on the way out. These
++ * are the BT.601 coefficients the DCSC sub-engine is programmed with.
++ */
++static const u32 sun8i_rgb2yuv_coef[12] = {
++	0x00000107, 0x00000204, 0x00000064, 0x00004200,
++	0x00001f68, 0x00001ed6, 0x000001c2, 0x00020200,
++	0x000001c2, 0x00001e87, 0x00001fb7, 0x00020200,
++};
++
+ static const struct de2_fmt_info de2_formats[] = {
+ 	{
+ 		.drm_fmt = DRM_FORMAT_ARGB8888,
+@@ -410,10 +420,28 @@ static void sun8i_mixer_mode_set(struct sunxi_engine *engine,
+ 			 interlaced ? "on" : "off");
+ }
+ 
++static void sun8i_mixer_apply_color_correction(struct sunxi_engine *engine)
++{
++	DRM_DEBUG_DRIVER("Applying RGB to YUV color correction\n");
++
++	regmap_bulk_write(engine->regs, SUN8I_MIXER_DCSC_COEF_REG(0),
++			  sun8i_rgb2yuv_coef, 12);
++	regmap_write(engine->regs, SUN8I_MIXER_DCSC_EN, 1);
++}
++
++static void sun8i_mixer_disable_color_correction(struct sunxi_engine *engine)
++{
++	DRM_DEBUG_DRIVER("Disabling color correction\n");
++
++	regmap_write(engine->regs, SUN8I_MIXER_DCSC_EN, 0);
++}
++
+ static const struct sunxi_engine_ops sun8i_engine_ops = {
+-	.commit		= sun8i_mixer_commit,
+-	.layers_init	= sun8i_layers_init,
+-	.mode_set	= sun8i_mixer_mode_set,
++	.commit			= sun8i_mixer_commit,
++	.layers_init		= sun8i_layers_init,
++	.mode_set		= sun8i_mixer_mode_set,
++	.apply_color_correction	= sun8i_mixer_apply_color_correction,
++	.disable_color_correction = sun8i_mixer_disable_color_correction,
+ };
+ 
+ static const struct sunxi_engine_ops sun50i_engine_ops = {
+@@ -768,6 +796,25 @@ static const struct sun8i_mixer_cfg sun8i_h3_mixer0_cfg = {
+ 	.vi_num		= 1,
+ };
+ 
++/*
++ * Mixer1 drives TCON1 and from there the TV encoder. It is a cut-down block:
++ * one UI channel and two scalers, against mixer0's three and four.
++ */
++static const struct sun8i_mixer_cfg sun8i_h3_mixer1_cfg = {
++	.lay_cfg = {
++		.ccsc		= CCSC_MIXER1_LAYOUT,
++		.de_type	= SUN8I_MIXER_DE2,
++		.vi_scaler_num	= 1,
++		.scaler_mask	= 0x3,
++		.scanline_yuv	= 2048,
++		.de2_fcc_alpha	= 1,
++	},
++	.de_type	= SUN8I_MIXER_DE2,
++	.mod_rate	= 432000000,
++	.ui_num		= 1,
++	.vi_num		= 1,
++};
++
+ static const struct sun8i_mixer_cfg sun8i_r40_mixer0_cfg = {
+ 	.lay_cfg = {
+ 		.ccsc		= CCSC_MIXER0_LAYOUT,
+@@ -903,6 +950,10 @@ static const struct of_device_id sun8i_mixer_of_table[] = {
+ 		.compatible = "allwinner,sun8i-h3-de2-mixer-0",
+ 		.data = &sun8i_h3_mixer0_cfg,
+ 	},
++	{
++		.compatible = "allwinner,sun8i-h3-de2-mixer-1",
++		.data = &sun8i_h3_mixer1_cfg,
++	},
+ 	{
+ 		.compatible = "allwinner,sun8i-r40-de2-mixer-0",
+ 		.data = &sun8i_r40_mixer0_cfg,
+diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.h b/drivers/gpu/drm/sun4i/sun8i_mixer.h
+index 7abc88c898..402e1c98f3 100644
+--- a/drivers/gpu/drm/sun4i/sun8i_mixer.h
++++ b/drivers/gpu/drm/sun4i/sun8i_mixer.h
+@@ -125,6 +125,13 @@
+ /* format 20 is packed YVU444 10-bit */
+ /* format 21 is packed YUV444 10-bit */
+ 
++/*
++ * The DCSC sub-engine converts the mixer's RGB output to YUV, which is what
++ * the TV encoder expects. It is unused on the HDMI path.
++ */
++#define SUN8I_MIXER_DCSC_EN			0xb0000
++#define SUN8I_MIXER_DCSC_COEF_REG(x)		(0xb0010 + 0x4 * (x))
++
+ /*
+  * Sub-engines listed bellow are unused for now. The EN registers are here only
+  * to be used to disable these sub-engines.
+@@ -135,7 +142,6 @@
+ #define SUN8I_MIXER_PEAK_EN			0xa6000
+ #define SUN8I_MIXER_ASE_EN			0xa8000
+ #define SUN8I_MIXER_FCC_EN			0xaa000
+-#define SUN8I_MIXER_DCSC_EN			0xb0000
+ 
+ #define SUN50I_MIXER_FCE_EN			0x70000
+ #define SUN50I_MIXER_PEAK_EN			0x70800

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/dt-bindings-display-allwinner-add-h3-h5-tv-encoder-and-mixer1.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/dt-bindings-display-allwinner-add-h3-h5-tv-encoder-and-mixer1.patch
@@ -1,0 +1,55 @@
+From ccc0c211385d8764ce018c579274042e9d07b896 Mon Sep 17 00:00:00 2001
+From: enthropy7 <enthropy7@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 13:50:38 +0300
+Subject: [PATCH] dt-bindings: display: allwinner: add H3/H5 TV encoder and H3
+
+ mixer1
+
+The H3 and H5 carry the same TV encoder the A10 binding already
+describes, and the H3 has a second DE2 mixer alongside the documented
+mixer0. Add the three compatibles so the device trees that use them
+validate.
+
+Signed-off-by: enthropy7 <enthropy7@users.noreply.github.com>
+---
+ .../bindings/display/allwinner,sun4i-a10-tv-encoder.yaml   | 7 +++++--
+ .../bindings/display/allwinner,sun8i-a83t-de2-mixer.yaml   | 1 +
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/devicetree/bindings/display/allwinner,sun4i-a10-tv-encoder.yaml b/Documentation/devicetree/bindings/display/allwinner,sun4i-a10-tv-encoder.yaml
+index c39e90a594..ce85b474b1 100644
+--- a/Documentation/devicetree/bindings/display/allwinner,sun4i-a10-tv-encoder.yaml
++++ b/Documentation/devicetree/bindings/display/allwinner,sun4i-a10-tv-encoder.yaml
+@@ -4,7 +4,7 @@
+ $id: http://devicetree.org/schemas/display/allwinner,sun4i-a10-tv-encoder.yaml#
+ $schema: http://devicetree.org/meta-schemas/core.yaml#
+ 
+-title: Allwinner A10 TV Encoder
++title: Allwinner A10/H3/H5 TV Encoder
+ 
+ maintainers:
+   - Chen-Yu Tsai <wens@csie.org>
+@@ -12,7 +12,10 @@ maintainers:
+ 
+ properties:
+   compatible:
+-    const: allwinner,sun4i-a10-tv-encoder
++    enum:
++      - allwinner,sun4i-a10-tv-encoder
++      - allwinner,sun8i-h3-tv-encoder
++      - allwinner,sun50i-h5-tv-encoder
+ 
+   reg:
+     maxItems: 1
+diff --git a/Documentation/devicetree/bindings/display/allwinner,sun8i-a83t-de2-mixer.yaml b/Documentation/devicetree/bindings/display/allwinner,sun8i-a83t-de2-mixer.yaml
+index 064e4ca7e4..f65682449c 100644
+--- a/Documentation/devicetree/bindings/display/allwinner,sun8i-a83t-de2-mixer.yaml
++++ b/Documentation/devicetree/bindings/display/allwinner,sun8i-a83t-de2-mixer.yaml
+@@ -16,6 +16,7 @@ properties:
+       - allwinner,sun8i-a83t-de2-mixer-0
+       - allwinner,sun8i-a83t-de2-mixer-1
+       - allwinner,sun8i-h3-de2-mixer-0
++      - allwinner,sun8i-h3-de2-mixer-1
+       - allwinner,sun8i-r40-de2-mixer-0
+       - allwinner,sun8i-r40-de2-mixer-1
+       - allwinner,sun8i-v3s-de2-mixer

--- a/patch/kernel/archive/sunxi-7.1/series.conf
+++ b/patch/kernel/archive/sunxi-7.1/series.conf
@@ -361,7 +361,9 @@
 	patches.armbian/0701-arm64-dts-sun50i-h616-orangepi-zero-enable-sound.patch
 	patches.armbian/0702-arm64-dts-sun50i-h616-add-digital-audio-node.patch
 	patches.armbian/arch-arm-patch-flush-icache-earlier.patch
+	patches.armbian/arm-dts-sunxi-h3-describe-the-tv-encoder-pipeline.patch
 	patches.armbian/arm64-dts-add-axp313a-pmic.patch
+	patches.armbian/arm64-dts-allwinner-h5-add-the-tv-encoder.patch
 	patches.armbian/arm64-dts-allwinner-sun55i-a523-add-e906-rproc-node.patch
 	patches.armbian/arm64-dts-allwinner-sun55i-a523-add-ir-receiver-nodes.patch
 	patches.armbian/arm64-dts-allwinner-sun55i-a523-add-ths.patch
@@ -465,14 +467,11 @@
 	patches.armbian/build-scripts-add-overlay-compilation.patch
 	patches.armbian/build-scripts-add-scr-fixup-support.patch
 	patches.armbian/build-scripts-dtc-enable-symbols-node.patch
+	patches.armbian/clk-sunxi-ng-h3-add-the-tve-clock.patch
 	patches.armbian/doc-dt-bindings-thermal-sun55i-a523-add-ths.patch
 	patches.armbian/Doc-dt-bindings-usb-allwinner-dwc3.patch
 	patches.armbian/drm-sun4i-fix-null-deref-when-unbinding-the-tv-encoder.patch
-	patches.armbian/dt-bindings-display-allwinner-add-h3-h5-tv-encoder-and-mixer1.patch
-	patches.armbian/clk-sunxi-ng-h3-add-the-tve-clock.patch
 	patches.armbian/drm-sun4i-support-the-h3-and-h5-tv-encoders.patch
-	patches.armbian/arm-dts-sunxi-h3-describe-the-tv-encoder-pipeline.patch
-	patches.armbian/arm64-dts-allwinner-h5-add-the-tv-encoder.patch
 	patches.armbian/drv-asoc-ac200-codec.patch
 	patches.armbian/drv-asoc-sunxi-provoke-early-load-sun8i-codec-analog.patch
 	patches.armbian/drv-asoc-sunxi-sun4i-codec-select-capture-source.patch
@@ -532,5 +531,6 @@
 	patches.armbian/drv-thermal-sun8i-sun55i-a523-ths.patch
 	patches.armbian/drv-usb-gadget-composite-rename-serial-manufacturer.patch
 	patches.armbian/drv-video-st7796s-fb-tft-driver.patch
+	patches.armbian/dt-bindings-display-allwinner-add-h3-h5-tv-encoder-and-mixer1.patch
 	patches.armbian/include-uapi-drm_fourcc-add-ARM-tiled-format-modifier.patch
 	patches.armbian/media-dt-bindings-allwinner-sun4i-a10-ir-add-a523-compatible.patch

--- a/patch/kernel/archive/sunxi-7.1/series.conf
+++ b/patch/kernel/archive/sunxi-7.1/series.conf
@@ -467,6 +467,12 @@
 	patches.armbian/build-scripts-dtc-enable-symbols-node.patch
 	patches.armbian/doc-dt-bindings-thermal-sun55i-a523-add-ths.patch
 	patches.armbian/Doc-dt-bindings-usb-allwinner-dwc3.patch
+	patches.armbian/drm-sun4i-fix-null-deref-when-unbinding-the-tv-encoder.patch
+	patches.armbian/dt-bindings-display-allwinner-add-h3-h5-tv-encoder-and-mixer1.patch
+	patches.armbian/clk-sunxi-ng-h3-add-the-tve-clock.patch
+	patches.armbian/drm-sun4i-support-the-h3-and-h5-tv-encoders.patch
+	patches.armbian/arm-dts-sunxi-h3-describe-the-tv-encoder-pipeline.patch
+	patches.armbian/arm64-dts-allwinner-h5-add-the-tv-encoder.patch
 	patches.armbian/drv-asoc-ac200-codec.patch
 	patches.armbian/drv-asoc-sunxi-provoke-early-load-sun8i-codec-analog.patch
 	patches.armbian/drv-asoc-sunxi-sun4i-codec-select-capture-source.patch


### PR DESCRIPTION
The H3 and H5 have a TV encoder sitting behind a second display pipeline - `mixer1` into `TCON1` into the encoder, and mainline describes none of it for either SoC. The encoder driver is already there and is already built for `CONFIG_DRM_SUN4I`, it simply has nothing to attach to, which is why composite output on these boards has never worked on a mainline kernel. This adds the missing plumbing.

On the device tree side the `mixer1`, `tcon1` and `tv-encoder` nodes are added to the shared H3/H5 `dtsi`, with port endpoints wired so that either mixer can drive either TCON, and the matching resets go into the per-SoC files. The TVE clock was not modelled in the H3 CCU at all: it has a fixed post-divider of 16, and without it the rate the encoder asks for is set sixteen times too high and the picture never locks. On the driver side the mixer outputs RGB while the encoder wants YUV, so the DCSC sub-engine is programmed with BT.601 coefficients through the `apply_color_correction` and `disable_color_correction` callbacks the engine already exposes. `mixer1` is a smaller block than `mixer0`, one UI channel and two scalers against three and four, thus it needs a config entry of its own.

It is a five-patch series, split by subsystem so it can be sent upstream as it stands: bindings, then the clock, then the driver, then the two device tree patches. The order matters, since the device tree references `CLK_TVE`. Nothing is enabled by default. Boards differ in whether the signal is routed anywhere at all, and on one with no other display output, switching the display engine on costs a permanently running 432 MHz PLL and roughly 1.6 MB of CMA whether or not a television is plugged in. The output is therefore opt-in: a new `tve` overlay turns on the display engine and the encoder, and without it nothing changes for anyone.

**Board: Orange Pi Zero (Allwinner H2+, 4× Cortex-A7), Armbian community 26.11 trunk, Debian trixie, kernel 6.18.44 built from this tree.**

Out of the box the pipeline stays down, exactly as before — `display-engine` and `tv-encoder` are both `disabled` in the board dtb. Adding `overlays=tve` to `armbianEnv.txt` brings the whole chain up:

```
sun4i-drm    -> display-engine
sun4i-tcon   -> 1c0c000.lcd-controller  1c0d000.lcd-controller
sun8i-mixer  -> 1100000.mixer           1200000.mixer
sun4i-tve    -> 1e00000.tv-encoder
```

and the connector is live at the right mode and clock:

```
# cat /sys/class/drm/card0-Composite-1/status
connected
# cat /sys/class/drm/card0-Composite-1/modes
720x480i
# cat /sys/class/graphics/fb0/name /sys/class/graphics/fb0/virtual_size
sun4i-drmdrmfb
720,480
# grep -w tve /sys/kernel/debug/clk/clk_summary
 tve   1  1  1  13500000  50000  0  50000  Y  1c0d000.lcd-controller  tcon-ch1
```

13.5 MHz is the composite pixel clock, so the encoder is running as it should.

For an end-to-end check I wired pin 9 of the 13-pin header to a USB capture card and wrote images straight into `/dev/fb0`. Colour bars came back in the right order and the right colours, and a photographic image came back with its fine detail and gradients intact. A black frame captures as 2 KB of JPEG and the image as 230 KB, so there is no mistaking signal for noise. Correct colour means the RGB to YUV conversion is right, and stable geometry means the mode and the clock are.

The series applies onto vanilla 6.18.44 after the full sunxi-6.18 stack with no rejects and no fuzz, and all five patches are clean under `checkpatch --strict`. Both architectures build clean: `drivers/gpu/drm/sun4i`, `drivers/clk/sunxi-ng` and every `arch/arm` dtb, every `arch/arm64` dtb with the `tv-encoder` node present in all 13 H5 device trees, and both overlays compile.

The H5 half is build-tested only, I have no H5 board here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added composite (CVBS) TV-out support for Sun8i-H3 and Sun50i-H5 boards.
  * Added `tve` overlays to enable TV output and required display components.
  * PAL/NTSC output follows the selected display mode.

* **Bug Fixes**
  * Prevented display-engine unbinding from causing a crash when disconnecting TV-out.

* **Documentation**
  * Documented the new TV encoder overlays and activation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->