### PR TITLE
labels: only clear review labels when the approval actually counts

### DIFF
--- a/.github/workflows/data-sync-labels.yml
+++ b/.github/workflows/data-sync-labels.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0

--- a/.github/workflows/maintenance-auto-label.yml
+++ b/.github/workflows/maintenance-auto-label.yml
@@ -25,6 +25,10 @@ jobs:
     steps:
       - name: Checkout the pull request
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # only here so `gh` can resolve the repo from the git remote; no
+          # authenticated git commands run, so don't leave the token behind
+          persist-credentials: false
 
       - name: Check for label using GH CLI
         id: check
@@ -49,6 +53,8 @@ jobs:
     steps:
       # Checks out the repository to read files for matching with labeler config
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Applies labels based on the .github/labeler.yml config
       - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0

--- a/.github/workflows/maintenance-label-on-approval.yml
+++ b/.github/workflows/maintenance-label-on-approval.yml
@@ -53,11 +53,16 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            const issue_number = Number.parseInt(process.env.PR_NUMBER || "", 10);
-            if (!Number.isInteger(issue_number) || issue_number <= 0) {
-              core.setFailed("Invalid PR number in PR_NUMBER");
+            // Strict on purpose: Number.parseInt takes the longest valid prefix,
+            // so "123abc" and "1e3" would coerce to 123 and 1 and sail past an
+            // isInteger check -- stripping labels off whatever PR that happens to
+            // be. Demand canonical digits and fail loudly otherwise.
+            const raw = (process.env.PR_NUMBER || "").trim();
+            if (!/^[1-9][0-9]*$/.test(raw)) {
+              core.setFailed(`Invalid PR number in PR_NUMBER: ${JSON.stringify(raw)}`);
               return;
             }
+            const issue_number = Number(raw);
             const labelsToRemove = ["Needs review", "Work in progress", "Backlog", "Can be closed?", "Help needed", "Needs Documentation"];
 
             for (const name of labelsToRemove) {

--- a/.github/workflows/maintenance-label-on-approval.yml
+++ b/.github/workflows/maintenance-label-on-approval.yml
@@ -30,6 +30,7 @@ jobs:
         run: echo "number=$(cat pr.txt)" >> $GITHUB_OUTPUT
 
       - name: Label when approved
+        id: approval
         uses: j-fulbright/label-when-approved-action@911c622c75f8ea99ee00cdd66e2cd888bac530c6 # v1.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,7 +41,12 @@ jobs:
           pullRequestNumber: ${{ steps.pr.outputs.number }}
 
       - name: Remove review-related labels
-        if: ${{ success() }}
+        # Not just success(): the action exits 0 and reports isApproved=false when
+        # the approval does not come from a committer (require_committers_approval),
+        # and anyone with read access can approve a PR on a public repo. Without
+        # this gate a drive-by approval clears the review-tracking labels below
+        # while "Ready to merge" is (correctly) never added.
+        if: ${{ success() && steps.approval.outputs.isApproved == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/maintenance-label-on-approval.yml
+++ b/.github/workflows/maintenance-label-on-approval.yml
@@ -26,8 +26,18 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}           # ← CRITICAL: fetch from the upstream run
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Validate here, at the point the value enters the job: everything below
+      # consumes it, starting with an action that parseInt()s it and then reads
+      # and writes labels. A check further down would run after those writes --
+      # and on the not-approved path would not run at all.
       - id: pr
-        run: echo "number=$(cat pr.txt)" >> $GITHUB_OUTPUT
+        run: |
+          number="$(tr -d '[:space:]' < pr.txt)"
+          case "${number}" in
+            '' | *[!0-9]*) echo "::error::pr.txt is not a PR number: '${number}'"; exit 1 ;;
+            0*)            echo "::error::pr.txt is not a canonical PR number: '${number}'"; exit 1 ;;
+          esac
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
 
       - name: Label when approved
         id: approval
@@ -53,10 +63,10 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            // Strict on purpose: Number.parseInt takes the longest valid prefix,
-            // so "123abc" and "1e3" would coerce to 123 and 1 and sail past an
-            // isInteger check -- stripping labels off whatever PR that happens to
-            // be. Demand canonical digits and fail loudly otherwise.
+            // Belt and braces: the `pr` step above already rejects anything that
+            // is not canonical digits. Kept because Number.parseInt takes the
+            // longest valid prefix, so "123abc" and "1e3" would coerce to 123 and
+            // 1 and sail past an isInteger check if that gate ever moved.
             const raw = (process.env.PR_NUMBER || "").trim();
             if (!/^[1-9][0-9]*$/.test(raw)) {
               core.setFailed(`Invalid PR number in PR_NUMBER: ${JSON.stringify(raw)}`);


### PR DESCRIPTION
## Problem

In `maintenance-label-on-approval.yml`, the "Remove review-related labels" step ran on a bare `success()`. That asks "did the previous step exit 0", which is not the same question as "was this PR approved".

The chain fires on **any** approving review, but the action is configured with `require_committers_approval: 'true'`, so it counts only approvals from people with write access. On a public repo, anyone with read access can submit an approving review.

When a non-committer approves:

1. `label-when-approved-action` exits **0** and reports `isApproved=false`
2. it correctly declines to add `Ready to merge`
3. the next step ran anyway and stripped `Needs review`, `Work in progress`, `Backlog`, `Can be closed?`, `Help needed`, `Needs Documentation`

So any passer-by could clear a PR's review-tracking state without the PR being approved by anyone who counts. Labels only — but the labels are what the review process is steered by.

## Fix

Gate the cleanup on the `isApproved` output the action already declares:

```yaml
      - name: Label when approved
        id: approval
        ...
      - name: Remove review-related labels
        if: ${{ success() && steps.approval.outputs.isApproved == 'true' }}
```

Two lines plus a comment explaining why `success()` alone is not enough, so it does not get simplified back.

## Context

Found by CodeRabbit on armbian/ci#59, which ports this workflow to `armbian/ci`. The same file is in `armbian/build`, `armbian/ci` and `armbian/armbian.github.io`, so it is fixed here first — build is where it has had the most exposure — and the identical change follows to the other two, keeping the three in lockstep.

## Not addressed here

Two further points from that review, both judgement calls about Armbian's label policy rather than bugs, left for a maintainer decision:

- **`Needs Documentation` is cleared on approval.** Arguably it should survive, since approval does not mean the documentation entry was written.
- **`Ready to merge` can go stale.** `remove_label_when_approval_missing: 'true'` is set, but the listener only runs for `pull_request_review: [submitted]` filtered to `state == 'approved'`, so a later dismissal or changes-requested never re-runs it. Fixing that properly means reworking both workflows, not just adding `dismissed` — `changes_requested` arrives as `submitted` and is filtered out by the job condition.

Signed-off-by: Igor Pecovnik <igor@armbian.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Review-tracking labels are now removed only after successful approval by an authorized committer.
  * Non-committer approvals and malformed pull request numbers no longer incorrectly remove review labels.

* **Security**
  * Automated workflows no longer persist access credentials during repository checkouts, reducing the risk of unintended credential exposure.
  * Invalid workflow inputs are rejected and reported instead of being interpreted unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->