### PR TITLE
u-boot/rk3588: carry the SCMI CPU clock raise into v2026.07

### DIFF
--- a/patch/u-boot/v2026.07/general-rk3588-raise-cpu-clocks-via-scmi.patch
+++ b/patch/u-boot/v2026.07/general-rk3588-raise-cpu-clocks-via-scmi.patch
@@ -1,0 +1,90 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 4 Jul 2026 15:14:08 +0200
+Subject: clk: rockchip: rk3588: raise CPU clocks through SCMI in U-Boot proper
+
+The CPU clusters leave reset on the 24 MHz oscillator and nothing
+raises them before OS cpufreq takes over, so early boot work landing
+on a big core crawls: a 23 MiB initramfs unpack took 64 seconds, 0.7
+after this change. Raise the clusters to 1008 MHz via SCMI, letting
+BL31 handle the PVTPLL sequencing, as the vendor U-Boot does.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ arch/arm/include/asm/arch-rockchip/cru_rk3588.h |  6 ++
+ drivers/clk/rockchip/clk_rk3588.c               | 35 ++++++++++
+ 2 files changed, 41 insertions(+)
+
+diff --git a/arch/arm/include/asm/arch-rockchip/cru_rk3588.h b/arch/arm/include/asm/arch-rockchip/cru_rk3588.h
+index 111111111111..222222222222 100644
+--- a/arch/arm/include/asm/arch-rockchip/cru_rk3588.h
++++ b/arch/arm/include/asm/arch-rockchip/cru_rk3588.h
+@@ -17,6 +17,12 @@
+ #define NPLL_HZ         (850 * MHz)
+ #define PPLL_HZ		(1100 * MHz)
+ #define SPLL_HZ		(702 * MHz)
++#define CPU_PVTPLL_HZ	(1008 * MHz)
++
++/* SCMI clock ids, from dt-bindings/clock/rockchip,rk3588-cru.h */
++#define SCMI_CLK_CPUL		0
++#define SCMI_CLK_CPUB01		2
++#define SCMI_CLK_CPUB23		3
+ 
+ /* RK3588 pll id */
+ enum rk3588_pll_id {
+diff --git a/drivers/clk/rockchip/clk_rk3588.c b/drivers/clk/rockchip/clk_rk3588.c
+index 111111111111..222222222222 100644
+--- a/drivers/clk/rockchip/clk_rk3588.c
++++ b/drivers/clk/rockchip/clk_rk3588.c
+@@ -1958,6 +1958,37 @@ static void rk3588_clk_init(struct rk3588_clk_priv *priv)
+ 		     (ACLK_TOP_S200_SEL_200M << ACLK_TOP_S200_SEL_SHIFT));
+ }
+ 
++#if CONFIG_IS_ENABLED(CLK_SCMI) && !defined(CONFIG_XPL_BUILD)
++/*
++ * The CPU clusters leave reset clocked from the 24 MHz oscillator.
++ * Raise them through SCMI so BL31 handles the PVTPLL sequencing.
++ */
++static void rk3588_clk_raise_cpu_clocks(void)
++{
++	const ulong scmi_cpu_clks[] = {
++		SCMI_CLK_CPUL, SCMI_CLK_CPUB01, SCMI_CLK_CPUB23
++	};
++	struct udevice *scmi_dev;
++	struct clk clk;
++	int ret, i;
++
++	ret = uclass_get_device_by_driver(UCLASS_CLK,
++					  DM_DRIVER_GET(scmi_clock),
++					  &scmi_dev);
++	if (ret)
++		return;
++
++	clk.dev = scmi_dev;
++	for (i = 0; i < ARRAY_SIZE(scmi_cpu_clks); i++) {
++		clk.id = scmi_cpu_clks[i];
++		ret = clk_set_rate(&clk, CPU_PVTPLL_HZ);
++		if (ret < 0)
++			printf("Failed to set SCMI cpu clk %lu: %d\n",
++			       clk.id, ret);
++	}
++}
++#endif
++
+ static int rk3588_clk_probe(struct udevice *dev)
+ {
+ 	struct rk3588_clk_priv *priv = dev_get_priv(dev);
+@@ -1986,6 +2017,10 @@ static int rk3588_clk_probe(struct udevice *dev)
+ 
+ 	rk3588_clk_init(priv);
+ 
++#if CONFIG_IS_ENABLED(CLK_SCMI) && !defined(CONFIG_XPL_BUILD)
++	rk3588_clk_raise_cpu_clocks();
++#endif
++
+ 	/* Process 'assigned-{clocks/clock-parents/clock-rates}' properties */
+ 	ret = clk_set_defaults(dev, 1);
+ 	if (ret)
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

The SCMI CPU clock raise landed in `patch/u-boot/v2026.04` (#10125) but never followed the boards that moved on to the v2026.07 tag, so those boards boot again with the CPU clusters parked on the 24 MHz oscillator until kernel cpufreq takes over.

Affected boards on `BOOTPATCHDIR="v2026.07"`: turing-rk1, nanopct6, mekotronics-r58x-pro.

The patch is copied over unchanged. Between the two tags `cru_rk3588.h` is identical and `clk_rk3588.c` only lost `DECLARE_GLOBAL_DATA_PTR;`, so both hunks apply at a two line offset.

# How Has This Been Tested?

- [x] u-boot artifact builds clean for nanopct6 on both `current` and `edge` (both branches take the mainline override, only `vendor` stays on the Radxa tree)
- [x] `CONFIG_CLK_SCMI=y` in the generated config, so the `CONFIG_IS_ENABLED(CLK_SCMI)` guard keeps the code in
- [x] `"Failed to set SCMI cpu clk"` present in the resulting `u-boot-rockchip.bin` for both branches, the helper itself is inlined into `rk3588_clk_probe` so it has no symbol of its own

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring RK3588 CPU clock rates through SCMI during system startup.
  * Little and big CPU core clusters are set to a target frequency of 1008 MHz.
  * Clock configuration failures are now reported during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->