### PR TITLE
board: beaglebadge: blacklist crashing Bluetooth UART

### DIFF
--- a/config/boards/beaglebadge.conf
+++ b/config/boards/beaglebadge.conf
@@ -27,6 +27,10 @@ OPTEE_PLATFORM="k3-am62lx"
 EXTRA_BOOT_ARGS="BL1=bl1.bin"
 CC33XX_SUPPORT="yes"
 PACKAGE_LIST_BOARD="network-manager bluetooth bluez-tools"
+# The vendor btti_uart driver oopses while probing the CC33xx Bluetooth UART.
+# That leaves the SSD16xx DRM framebuffer powered down and the e-paper panel
+# stuck on the U-Boot image. Keep the driver disabled until the crash is fixed.
+MODULES_BLACKLIST="btti_uart"
 TI_PACKAGES+=("badge-launcher")
 enable_extension "lowmem"
 


### PR DESCRIPTION
TI's vendor btti_uart driver oopses while probing the onboard CC33xx Bluetooth UART. The resulting oops prevents the SSD16xx DRM framebuffer from unblanking, leaving the e-paper display stuck on the U-Boot image.

# How Has This Been Tested?

- [x] Boot test on Trixie w/Vendor kernel

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the unstable Bluetooth UART driver on BeagleBadge boards to prevent startup crashes.
  * Prevented the e-paper display from becoming stuck on the bootloader image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->