### PR TITLE
uefi-x86: drop upstreamed magicmouse .reset_resume T2 sub-patch

### DIFF
--- a/patch/kernel/archive/uefi-x86-6.12/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-6.12/4001-asahi-trackpad.patch
@@ -4549,53 +4549,6 @@ Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Janne Grunau <j@jannau.net>
-Date: Sun, 11 Dec 2022 22:56:16 +0100
-Subject: HID: magicmouse: Add .reset_resume for SPI trackpads
-
-The trackpad has to request multi touch reports during resume.
-
-Signed-off-by: Janne Grunau <j@jannau.net>
----
- drivers/hid/hid-magicmouse.c | 14 ++++++++++
- 1 file changed, 14 insertions(+)
-
-diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
-index 111111111111..222222222222 100644
---- a/drivers/hid/hid-magicmouse.c
-+++ b/drivers/hid/hid-magicmouse.c
-@@ -1317,6 +1317,16 @@ static const struct hid_device_id magic_mice[] = {
- };
- MODULE_DEVICE_TABLE(hid, magic_mice);
- 
-+#ifdef CONFIG_PM
-+static int magicmouse_reset_resume(struct hid_device *hdev)
-+{
-+	if (hdev->bus == BUS_SPI)
-+		return magicmouse_enable_multitouch(hdev);
-+
-+	return 0;
-+}
-+#endif
-+
- static struct hid_driver magicmouse_driver = {
- 	.name = "magicmouse",
- 	.id_table = magic_mice,
-@@ -1327,6 +1337,10 @@ static struct hid_driver magicmouse_driver = {
- 	.event = magicmouse_event,
- 	.input_mapping = magicmouse_input_mapping,
- 	.input_configured = magicmouse_input_configured,
-+#ifdef CONFIG_PM
-+        .reset_resume = magicmouse_reset_resume,
-+#endif
-+
- };
- module_hid_driver(magicmouse_driver);
- 
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Janne Grunau <j@jannau.net>
 Date: Sun, 11 Dec 2022 23:24:41 +0100
 Subject: HID: transport: spi: Add suspend support
 

--- a/patch/kernel/archive/uefi-x86-6.18/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-6.18/4001-asahi-trackpad.patch
@@ -1069,53 +1069,6 @@ index 111111111111..222222222222 100644
 Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Janne Grunau <j@jannau.net>
-Date: Sun, 11 Dec 2022 22:56:16 +0100
-Subject: HID: magicmouse: Add .reset_resume for SPI trackpads
-
-The trackpad has to request multi touch reports during resume.
-
-Signed-off-by: Janne Grunau <j@jannau.net>
----
- drivers/hid/hid-magicmouse.c | 14 ++++++++++
- 1 file changed, 14 insertions(+)
-
-diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
-index 111111111111..222222222222 100644
---- a/drivers/hid/hid-magicmouse.c
-+++ b/drivers/hid/hid-magicmouse.c
-@@ -1353,6 +1353,16 @@ static const struct hid_device_id magic_mice[] = {
- };
- MODULE_DEVICE_TABLE(hid, magic_mice);
- 
-+#ifdef CONFIG_PM
-+static int magicmouse_reset_resume(struct hid_device *hdev)
-+{
-+	if (hdev->bus == BUS_SPI)
-+		return magicmouse_enable_multitouch(hdev);
-+
-+	return 0;
-+}
-+#endif
-+
- static struct hid_driver magicmouse_driver = {
- 	.name = "magicmouse",
- 	.id_table = magic_mice,
-@@ -1363,6 +1373,10 @@ static struct hid_driver magicmouse_driver = {
- 	.event = magicmouse_event,
- 	.input_mapping = magicmouse_input_mapping,
- 	.input_configured = magicmouse_input_configured,
-+#ifdef CONFIG_PM
-+        .reset_resume = magicmouse_reset_resume,
-+#endif
-+
- };
- module_hid_driver(magicmouse_driver);
- 
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Hector Martin <marcan@marcan.st>
 Date: Sun, 30 Apr 2023 23:48:45 +0900
 Subject: HID: magicmouse: Handle touch controller resets on SPI devices

--- a/patch/kernel/archive/uefi-x86-7.1/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-7.1/4001-asahi-trackpad.patch
@@ -1068,53 +1068,6 @@ index 111111111111..222222222222 100644
 Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Janne Grunau <j@jannau.net>
-Date: Sun, 11 Dec 2022 22:56:16 +0100
-Subject: HID: magicmouse: Add .reset_resume for SPI trackpads
-
-The trackpad has to request multi touch reports during resume.
-
-Signed-off-by: Janne Grunau <j@jannau.net>
----
- drivers/hid/hid-magicmouse.c | 14 ++++++++++
- 1 file changed, 14 insertions(+)
-
-diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
-index 111111111111..222222222222 100644
---- a/drivers/hid/hid-magicmouse.c
-+++ b/drivers/hid/hid-magicmouse.c
-@@ -1371,6 +1371,16 @@ static const struct hid_device_id magic_mice[] = {
- };
- MODULE_DEVICE_TABLE(hid, magic_mice);
- 
-+#ifdef CONFIG_PM
-+static int magicmouse_reset_resume(struct hid_device *hdev)
-+{
-+	if (hdev->bus == BUS_SPI)
-+		return magicmouse_enable_multitouch(hdev);
-+
-+	return 0;
-+}
-+#endif
-+
- static struct hid_driver magicmouse_driver = {
- 	.name = "magicmouse",
- 	.id_table = magic_mice,
-@@ -1381,6 +1391,10 @@ static struct hid_driver magicmouse_driver = {
- 	.event = magicmouse_event,
- 	.input_mapping = magicmouse_input_mapping,
- 	.input_configured = magicmouse_input_configured,
-+#ifdef CONFIG_PM
-+        .reset_resume = magicmouse_reset_resume,
-+#endif
-+
- };
- module_hid_driver(magicmouse_driver);
- 
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Hector Martin <marcan@marcan.st>
 Date: Sun, 30 Apr 2023 23:48:45 +0900
 Subject: HID: magicmouse: Handle touch controller resets on SPI devices

--- a/patch/kernel/archive/uefi-x86-7.2/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-7.2/4001-asahi-trackpad.patch
@@ -1068,53 +1068,6 @@ index 111111111111..222222222222 100644
 Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Janne Grunau <j@jannau.net>
-Date: Sun, 11 Dec 2022 22:56:16 +0100
-Subject: HID: magicmouse: Add .reset_resume for SPI trackpads
-
-The trackpad has to request multi touch reports during resume.
-
-Signed-off-by: Janne Grunau <j@jannau.net>
----
- drivers/hid/hid-magicmouse.c | 14 ++++++++++
- 1 file changed, 14 insertions(+)
-
-diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
-index 111111111111..222222222222 100644
---- a/drivers/hid/hid-magicmouse.c
-+++ b/drivers/hid/hid-magicmouse.c
-@@ -1371,6 +1371,16 @@ static const struct hid_device_id magic_mice[] = {
- };
- MODULE_DEVICE_TABLE(hid, magic_mice);
- 
-+#ifdef CONFIG_PM
-+static int magicmouse_reset_resume(struct hid_device *hdev)
-+{
-+	if (hdev->bus == BUS_SPI)
-+		return magicmouse_enable_multitouch(hdev);
-+
-+	return 0;
-+}
-+#endif
-+
- static struct hid_driver magicmouse_driver = {
- 	.name = "magicmouse",
- 	.id_table = magic_mice,
-@@ -1381,6 +1391,10 @@ static struct hid_driver magicmouse_driver = {
- 	.event = magicmouse_event,
- 	.input_mapping = magicmouse_input_mapping,
- 	.input_configured = magicmouse_input_configured,
-+#ifdef CONFIG_PM
-+        .reset_resume = magicmouse_reset_resume,
-+#endif
-+
- };
- module_hid_driver(magicmouse_driver);
- 
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Hector Martin <marcan@marcan.st>
 Date: Sun, 30 Apr 2023 23:48:45 +0900
 Subject: HID: magicmouse: Handle touch controller resets on SPI devices


### PR DESCRIPTION
## Problem

The nightly [Build All Artifacts](https://github.com/armbian/ci/actions/runs/33140983968) run fails on **every** x86 kernel target (edge / current / cloud / legacy):

```
Failed to apply patch .../4001-asahi-trackpad.patch
Hunk #2 FAILED at 1391   {drivers/hid/hid-magicmouse.c}
```

## Root cause

The Asahi/T2 magicmouse work has been **upstreamed**. Mainline and the stable trees the build now tracks carry both `magicmouse_reset_resume()` and the `.reset_resume` field of `struct hid_driver magicmouse_driver`. The committed T2 patch still *adds* them, so it collides and Armbian aborts the whole kernel build.

Each target is now a few point releases past its last patch rewrite, and the releases carrying the backport all landed ~2026-08-27 — exactly when the nightly started failing (green through the 26th):

| Target | Kernel now | Patch last rewritten against |
|---|---|---|
| legacy | 6.12.107 | (Nov 2025) |
| current / cloud | 6.18.48 | 6.18.46 |
| edge | 7.1.12 | 7.1.x (Jun 2026) |

## Fix

Drop the self-contained sub-patch **"HID: magicmouse: Add .reset_resume for SPI trackpads"** from all four x86 T2 patch dirs. It adds *both* the function and the struct field — both now upstream — so the entire 47-line sub-patch is redundant, not just the failing hunk. (7.2/bleedingedge isn't in the failing nightly but carries the identical collision, so it's fixed too for consistency.)

Unrelated `hid_driver_reset_resume()` calls in the SPI-transport sub-patch are left untouched; the other sub-patches still apply today.

## Caveat / follow-up

The rest of the Asahi magicmouse series is actively landing upstream, so other sub-patches may collide on a future point release. The durable fix is a full **t2linux re-sync** against the new point releases (the established "rewrite patches against `<ver>`" workflow); this PR is the minimal change to get nightlies green now.

## Testing

Patch-file edit only (188 lines removed across 4 files); **needs a CI/test kernel build** to confirm all four x86 targets patch and compile cleanly — I could not compile a kernel locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Apple Silicon keyboards and trackpads over SPI and DockChannel connections.
  * Improved multitouch input handling, device detection, firmware support, and controller reset recovery.
  * Added support for Apple DockChannel communication and related coprocessor integration.
  * Improved suspend and resume behavior across supported Apple input devices.

* **Bug Fixes**
  * Increased compatibility with larger HID reports and additional Apple device types.
  * Removed an obsolete trackpad resume workaround.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->