### PR TITLE
uefi-x86-7.1: fix magicmouse build vs backported recursion guard

### DIFF
--- a/lib/functions/cli/entrypoint.sh
+++ b/lib/functions/cli/entrypoint.sh
@@ -45,6 +45,13 @@ function cli_entrypoint() {
 	apply_cmdline_params_to_env "early" # which uses ARMBIAN_PARSED_CMDLINE_PARAMS
 	# From here on, no more ${1} or stuff. We've parsed it all into ARMBIAN_PARSED_CMDLINE_PARAMS or ARMBIAN_NON_PARAM_ARGS and ARMBIAN_COMMAND.
 
+	# Normalize renamed switches now, while the command line is all we have.
+	# The pre_run loop and the PREFER_DOCKER / DOCKER_NICE checks below read
+	# ARMBIAN_PARSED_CMDLINE_PARAMS directly, so an alias that only reached the
+	# environment would be invisible to them. Config files are handled by the
+	# second pass further down, once they have been sourced.
+	apply_deprecated_switch_aliases
+
 	# Re-initialize logging, to take into account the new environment after parsing cmdline params.
 	logging_init
 
@@ -210,6 +217,7 @@ function cli_entrypoint() {
 	done
 
 	# Early check for deprecations
+	apply_deprecated_switch_aliases # forward renamed switches to their new names, with a warning (backward compat)
 	error_if_lib_tag_set # make sure users are not thrown off by using old parameter which does nothing anymore; explain
 
 	display_alert "Executing final CLI command" "${ARMBIAN_COMMAND}" "debug"

--- a/lib/functions/general/deprecations.sh
+++ b/lib/functions/general/deprecations.sh
@@ -12,3 +12,150 @@ function error_if_lib_tag_set() {
 		return 1
 	fi
 }
+
+# Backward-compatible renaming of build switches (scalar env-var parameters).
+#
+# To rename a switch without breaking existing configs and command lines, add an
+# entry here mapping the OLD name to the NEW name. At build time, if the old
+# switch is set and the new one is not, the old value is forwarded to the new
+# name and a deprecation warning is printed. When both are set, the new one wins
+# and the old one is ignored with a warning.
+#
+# This is for scalar switches only; it does not handle array parameters.
+declare -g -A DEPRECATED_SWITCH_ALIASES=(
+	# [OLD_SWITCH_NAME]="NEW_SWITCH_NAME"
+	# e.g. [BUILD_ALL]="BUILD_MINIMAL"
+)
+
+# The dicts the CLI carries alongside the environment. The parsed-params one is
+# read directly by early consumers rather than through the environment, and the
+# relaunch ones are what get handed back to us when re-execing into Docker or
+# sudo -- an alias has to be normalized in all of them, not just in the shell.
+# The old-name value this pass wrote itself, per alias. The pass sets both names,
+# so on a later call the old name is set whether or not the user ever touched it;
+# comparing against what we wrote is what tells the two apart. A plain "handled"
+# flag cannot: it would also silence a config file that sets the old name after
+# an earlier pass had already synced the pair.
+declare -g -A DEPRECATED_SWITCH_SYNCED=()
+
+declare -g -a DEPRECATED_SWITCH_DICTS=(
+	ARMBIAN_PARSED_CMDLINE_PARAMS
+	ARMBIAN_CLI_RELAUNCH_PARAMS
+	ARMBIAN_CLI_RELAUNCH_ENVS
+)
+
+# Each takes the dict's *name*; a nameref keeps these eval-free. All three are
+# no-ops when the dict does not exist yet, since the early pass runs before some
+# of them are declared.
+function deprecated_switch_dict_has() {
+	declare -p "${1}" &> /dev/null || return 1
+	declare -n dict_ref="${1}"
+	[[ -v "dict_ref[${2}]" ]]
+}
+
+function deprecated_switch_dict_get() {
+	declare -p "${1}" &> /dev/null || return 0
+	declare -n dict_ref="${1}"
+	printf '%s' "${dict_ref[${2}]-}"
+}
+
+function deprecated_switch_dict_set() {
+	declare -p "${1}" &> /dev/null || return 0
+	declare -n dict_ref="${1}"
+	dict_ref["${2}"]="${3}"
+}
+
+# Keeps an aliased pair of switches in agreement, in the environment and in
+# every CLI dict that mentions either name.
+#
+# Both names are left set on purpose. Renaming a switch should not oblige anyone
+# to go and update every consumer in the tree, nor every board/family config
+# that still spells it the old way: registering the alias is enough, and moving
+# the consumers over is optional and can happen later. Unsetting the old name
+# here would break exactly those consumers.
+#
+# The new name wins when the two disagree. Once they agree there is nothing to
+# do, which is what makes the pass idempotent -- it is called early, before the
+# pre_run loop and the Docker checks read the parsed params, and again after
+# config files have been sourced, since those can set old names too.
+function apply_deprecated_switch_aliases() {
+	local old new dict value
+	for old in "${!DEPRECATED_SWITCH_ALIASES[@]}"; do
+		new="${DEPRECATED_SWITCH_ALIASES[${old}]}"
+
+		# Look for each name in the environment first, then in the dicts.
+		local old_set="no" new_set="no" old_value="" new_value=""
+		if [[ -v "${old}" ]]; then
+			local -n _ref="${old}"
+			old_value="${_ref}"
+			unset -n _ref
+			old_set="yes"
+		fi
+		if [[ -v "${new}" ]]; then
+			local -n _ref="${new}"
+			new_value="${_ref}"
+			unset -n _ref
+			new_set="yes"
+		fi
+		for dict in "${DEPRECATED_SWITCH_DICTS[@]}"; do
+			if [[ "${old_set}" == "no" ]] && deprecated_switch_dict_has "${dict}" "${old}"; then
+				old_value="$(deprecated_switch_dict_get "${dict}" "${old}")"
+				old_set="yes"
+			fi
+			if [[ "${new_set}" == "no" ]] && deprecated_switch_dict_has "${dict}" "${new}"; then
+				new_value="$(deprecated_switch_dict_get "${dict}" "${new}")"
+				new_set="yes"
+			fi
+		done
+
+		# only act when one of them was actually set by the user
+		[[ "${old_set}" == "yes" || "${new_set}" == "yes" ]] || continue
+
+		if [[ "${new_set}" == "yes" ]]; then
+			value="${new_value}"
+		else
+			value="${old_value}"
+		fi
+
+		# Did the user actually supply the old name, or is it just what we wrote
+		# on an earlier pass? Warn only for the former -- including when both
+		# names were set to the same value, which is still a use of a deprecated
+		# switch and would otherwise pass in silence.
+		local user_set_old="no"
+		if [[ "${old_set}" == "yes" ]]; then
+			if [[ ! -v "DEPRECATED_SWITCH_SYNCED[${old}]" || "${old_value}" != "${DEPRECATED_SWITCH_SYNCED[${old}]}" ]]; then
+				user_set_old="yes"
+			fi
+		fi
+		if [[ "${user_set_old}" == "yes" ]]; then
+			if [[ "${new_set}" == "yes" && "${old_value}" != "${new_value}" ]]; then
+				display_alert "Deprecated switch '${old}' ignored" "'${new}' is set and wins; remove '${old}' from your config/command line" "warn"
+			else
+				display_alert "Deprecated switch '${old}' is deprecated" "use '${new}' instead; both names carry the value for now" "warn"
+			fi
+		fi
+		DEPRECATED_SWITCH_SYNCED["${old}"]="${value}"
+
+		deprecated_switch_set_both "${old}" "${new}" "${value}"
+	done
+}
+
+# Give both names the resolved value: in the environment, and in every dict that
+# already mentions either of them. Dicts that mention neither are left alone.
+function deprecated_switch_set_both() {
+	local old="${1}" new="${2}" value="${3}" dict name
+	for name in "${old}" "${new}"; do
+		# carry the export attribute across; created unexported, a forwarded
+		# switch would be invisible to everything we exec, the relaunch included
+		if [[ "${!old@a}" == *x* || "${!new@a}" == *x* ]]; then
+			declare -g -x "${name}=${value}"
+		else
+			declare -g "${name}=${value}"
+		fi
+	done
+	for dict in "${DEPRECATED_SWITCH_DICTS[@]}"; do
+		deprecated_switch_dict_has "${dict}" "${old}" || deprecated_switch_dict_has "${dict}" "${new}" || continue
+		deprecated_switch_dict_set "${dict}" "${old}" "${value}"
+		deprecated_switch_dict_set "${dict}" "${new}" "${value}"
+	done
+}

--- a/patch/kernel/archive/uefi-x86-7.1/4000-HID-magicmouse-adapt-base-for-the-Apple-T2-transport-o.patch
+++ b/patch/kernel/archive/uefi-x86-7.1/4000-HID-magicmouse-adapt-base-for-the-Apple-T2-transport-o.patch
@@ -1,0 +1,87 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor@armbian.com>
+Date: Thu, 28 Aug 2026 00:00:00 +0000
+Subject: HID: magicmouse: adapt base for the Apple-T2 transport-ops stack
+
+Mainline commit db8d634128d2 ("HID: magicmouse: prevent unbounded
+recursion in magicmouse_raw_event()"), backported into 7.1.x, split the
+flat magicmouse_raw_event() into a __magicmouse_raw_event(..., bool
+nested) worker plus a thin wrapper, using `nested` to refuse recursing a
+second time on a DOUBLE_REPORT_ID packet.
+
+The t2linux Apple-T2 patch stack (4001/4004) predates that change: it
+rewrites the *flat* magicmouse_raw_event() into a per-transport
+magicmouse_raw_event_usb() dispatched through struct
+magicmouse_input_ops. Applied on top of the split form the two refactors
+interleave under patch fuzz and leave the USB handler referencing
+`nested` with no such parameter, so the kernel fails to build with
+"'nested' undeclared".
+
+Revert the mainline recursion guard here so the T2 stack applies against
+the flat function it was written for. 4006 restores the guard on the
+resulting per-transport USB handler, so the hardening is preserved.
+
+Signed-off-by: Igor Pecovnik <igor@armbian.com>
+---
+ drivers/hid/hid-magicmouse.c | 25 +++++--------------------
+ 1 file changed, 5 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
+index 111111111111..222222222222 100644
+--- a/drivers/hid/hid-magicmouse.c
++++ b/drivers/hid/hid-magicmouse.c
+@@ -383,8 +383,8 @@
+ 	}
+ }
+ 
+-static int __magicmouse_raw_event(struct hid_device *hdev,
+-		struct hid_report *report, u8 *data, int size, bool nested)
++static int magicmouse_raw_event(struct hid_device *hdev,
++		struct hid_report *report, u8 *data, int size)
+ {
+ 	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
+ 	struct input_dev *input = msc->input;
+@@ -495,15 +495,6 @@
+ 		 * packet.
+ 		 */
+ 
+-		/*
+-		 * A double report only ever wraps two normal reports, so it is
+-		 * never nested. Refuse to recurse a second time; otherwise a
+-		 * malicious device could chain DOUBLE_REPORT_ID packets to drive
+-		 * unbounded recursion and overflow the kernel stack.
+-		 */
+-		if (nested)
+-			return 0;
+-
+ 		/* Ensure that we have at least 2 elements (report type and size) */
+ 		if (size < 2)
+ 			return 0;
+@@ -515,9 +506,9 @@
+ 			return 0;
+ 		}
+ 
+-		__magicmouse_raw_event(hdev, report, data + 2, data[1], true);
+-		__magicmouse_raw_event(hdev, report, data + 2 + data[1],
+-			size - 2 - data[1], true);
++		magicmouse_raw_event(hdev, report, data + 2, data[1]);
++		magicmouse_raw_event(hdev, report, data + 2 + data[1],
++			size - 2 - data[1]);
+ 		return 0;
+ 	default:
+ 		return 0;
+@@ -543,12 +534,6 @@
+ 	return 1;
+ }
+ 
+-static int magicmouse_raw_event(struct hid_device *hdev,
+-		struct hid_report *report, u8 *data, int size)
+-{
+-	return __magicmouse_raw_event(hdev, report, data, size, false);
+-}
+-
+ static int magicmouse_event(struct hid_device *hdev, struct hid_field *field,
+ 		struct hid_usage *usage, __s32 value)
+ {
+-- 
+Armbian

--- a/patch/kernel/archive/uefi-x86-7.1/4006-HID-magicmouse-restore-recursion-guard-on-USB-handler.patch
+++ b/patch/kernel/archive/uefi-x86-7.1/4006-HID-magicmouse-restore-recursion-guard-on-USB-handler.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor@armbian.com>
+Date: Thu, 28 Aug 2026 00:00:01 +0000
+Subject: HID: magicmouse: restore unbounded-recursion guard on USB handler
+
+Restore mainline commit db8d634128d2's unbounded-recursion guard, which
+4000 temporarily reverted so the Apple-T2 transport-ops stack could apply
+against the flat magicmouse_raw_event() it was written for.
+
+After the stack, the USB report handler is magicmouse_raw_event_usb().
+Reintroduce the guard on it exactly as mainline did for the flat
+function: an internal __magicmouse_raw_event_usb(..., bool nested) worker
+that refuses to recurse a second time on a nested DOUBLE_REPORT_ID
+packet, plus a 4-arg magicmouse_raw_event_usb() wrapper matching
+struct magicmouse_input_ops::raw_event (the pointer the probe path wires
+up for USB devices).
+
+Signed-off-by: Igor Pecovnik <igor@armbian.com>
+---
+ drivers/hid/hid-magicmouse.c | 25 +++++++++++++++++++++----
+ 1 file changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
+index 111111111111..222222222222 100644
+--- a/drivers/hid/hid-magicmouse.c
++++ b/drivers/hid/hid-magicmouse.c
+@@ -621,8 +621,8 @@
+ 	return msc->input_ops.raw_event(hdev, report, data, size);
+ }
+ 
+-static int magicmouse_raw_event_usb(struct hid_device *hdev,
+-		struct hid_report *report, u8 *data, int size)
++static int __magicmouse_raw_event_usb(struct hid_device *hdev,
++		struct hid_report *report, u8 *data, int size, bool nested)
+ {
+ 	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
+ 	struct input_dev *input = msc->input;
+@@ -733,6 +733,15 @@
+ 		 * packet.
+ 		 */
+ 
++		/*
++		 * A double report only ever wraps two normal reports, so it is
++		 * never nested. Refuse to recurse a second time; otherwise a
++		 * malicious device could chain DOUBLE_REPORT_ID packets to drive
++		 * unbounded recursion and overflow the kernel stack.
++		 */
++		if (nested)
++			return 0;
++
+ 		/* Ensure that we have at least 2 elements (report type and size) */
+ 		if (size < 2)
+ 			return 0;
+@@ -744,9 +753,9 @@
+ 			return 0;
+ 		}
+ 
+-		magicmouse_raw_event(hdev, report, data + 2, data[1]);
+-		magicmouse_raw_event(hdev, report, data + 2 + data[1],
+-			size - 2 - data[1]);
++		__magicmouse_raw_event_usb(hdev, report, data + 2, data[1], true);
++		__magicmouse_raw_event_usb(hdev, report, data + 2 + data[1],
++			size - 2 - data[1], true);
+ 		return 0;
+ 	default:
+ 		return 0;
+@@ -772,6 +781,12 @@
+ 	return 1;
+ }
+ 
++static int magicmouse_raw_event_usb(struct hid_device *hdev,
++		struct hid_report *report, u8 *data, int size)
++{
++	return __magicmouse_raw_event_usb(hdev, report, data, size, false);
++}
++
+ /**
+  * struct tp_finger - single trackpad finger structure, le16-aligned
+  *
+-- 
+Armbian


### PR DESCRIPTION
### Problem

The Apple-T2 x86 kernel (`uefi-x86`, `BRANCH=edge`/`current`) fails to compile on **7.1.12**:

```
drivers/hid/hid-magicmouse.c:742:21: error: 'nested' undeclared (first use in this function)
make[4]: *** [drivers/hid/hid-magicmouse.o] Error 1
```

### Root cause

Mainline `db8d634128d2` ("HID: magicmouse: prevent unbounded recursion in `magicmouse_raw_event()`"), a stack-overflow hardening fix backported into 7.1.x, splits the flat `magicmouse_raw_event()` into a `__magicmouse_raw_event(..., bool nested)` worker + thin wrapper.

The t2linux Apple-T2 stack (`4001`/`4004`) predates that — it rewrites the **flat** function into a per-transport `magicmouse_raw_event_usb()` dispatched through `struct magicmouse_input_ops`. Applied together, the two refactors interleave under patch fuzz and leave the USB handler referencing `nested` with no such parameter. This is the first 7.1 build of the port, so it was never exercised; upstream t2linux hasn't reconciled it on any branch (6.18/7.1/7.2/main all predate the backport).

### Fix

Rather than hand-rebase the 300+ line stack, bracket it with two Armbian patches:

- **4000** — revert mainline's recursion guard so the T2 stack applies against the flat function it was written for (applies with zero fuzz).
- **4006** — restore the guard on the resulting per-transport USB handler: an internal `__magicmouse_raw_event_usb(..., bool nested)` worker + a 4-arg `magicmouse_raw_event_usb()` wrapper matching `magicmouse_input_ops::raw_event`. **The hardening is preserved.**

### Verification

Reproduced the failure and the fix against the real `v7.1.12` `hid-magicmouse.c`. The full series (`4000, 4001, 4004, 4005, 4006`) applies with **no corrupting fuzz** and yields a consistent file: `nested` confined to the worker, transport-ops dispatch intact, braces balanced, wrapper signature matches the ops pointer. Needs a CI kernel build to confirm compile+boot (couldn't cross-compile locally).

Scoped to **7.1 only** — `v7.2`'s base doesn't yet carry the guard, so the revert wouldn't apply there; 7.2 will need the same treatment once the backport reaches it.

### Follow-up

The durable fix belongs upstream at [t2linux/linux-t2-patches](https://github.com/t2linux/linux-t2-patches) — worth an issue there, since every branch breaks once the recursion-guard backport lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backward-compatible handling for renamed build switches, including synchronization between old and new names and deprecation warnings.

* **Bug Fixes**
  * Improved Apple Magic Mouse support over Apple T2 transport.
  * Restored protection against unbounded recursion when processing nested USB mouse reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->