### PR TITLE
Mainline pcie sun55i

### DIFF
--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-sun55i-a527-cubie-a5e-enable-e906-rproc.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/arm64-dts-sun55i-a527-cubie-a5e-enable-e906-rproc.patch
@@ -1,0 +1,88 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Fri, 21 Aug 2026 22:40:00 -0400
+Subject: [PATCH] arm64: dts: allwinner: a527-cubie-a5e: enable E906 RISC-V remoteproc
+
+Enable the E906 RISC-V coprocessor on the Radxa Cubie A5E, mirroring
+the Avaota A1 setup: reserve the RISC-V SRAM banks, a DRAM region for
+firmware loading, and carve out vring/buffer pools for virtio rpmsg.
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+--- a/arch/arm64/boot/dts/allwinner/sun55i-a527-cubie-a5e.dts	2026-08-23 22:39:12.671028371 -0400
++++ b/arch/arm64/boot/dts/allwinner/sun55i-a527-cubie-a5e.dts	2026-08-23 22:39:35.874634996 -0400
+@@ -23,6 +23,44 @@
+ 		stdout-path = "serial0:115200n8";
+ 	};
+ 
++	reserved-memory {
++		#address-cells = <2>;
++		#size-cells = <2>;
++		ranges;
++
++		riscvsram0_reserved: riscvsram0@7280000 {
++			reg = <0x0 0x07280000 0x0 0x40000>;
++			no-map;
++		};
++
++		riscvsram1_reserved: riscvsram1@72c0000 {
++			reg = <0x0 0x072c0000 0x0 0x40000>;
++			no-map;
++		};
++
++		e906_dram_reserved: e906_dram@60000000 {
++			reg = <0x0 0x60000000 0x0 0xa00000>;
++			no-map;
++		};
++
++		rv_vdev0buffer: vdev0buffer@4ae00000 {
++			compatible = "shared-dma-pool";
++			reg = <0x0 0x4ae00000 0x0 0x40000>;
++			no-map;
++		};
++
++		rv_vdev0vring0: vdev0vring0@4ae40000 {
++			reg = <0x0 0x4ae40000 0x0 0x2000>;
++			no-map;
++		};
++
++		rv_vdev0vring1: vdev0vring1@4ae42000 {
++			reg = <0x0 0x4ae42000 0x0 0x2000>;
++			no-map;
++		};
++	};
++
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+@@ -489,3 +527,25 @@
+ 	status = "okay";
+ };
+ 
++&e906_rproc {
++	mboxes = <&msgbox 8>, <&msgbox 10>;
++	mbox-names = "arm-kick", "arm-standby";
++	memory-region = <&riscvsram0_reserved>, <&riscvsram1_reserved>,
++			<&rv_vdev0buffer>, <&rv_vdev0vring0>,
++			<&rv_vdev0vring1>, <&e906_dram_reserved>;
++	memory-mappings =
++		/* < DA		len		PA >	*/
++		/* DSP RAM */
++		< 0x20000	0x20000		0x20000 >,
++		/* SRAM A2 */
++		< 0x40000	0x24000		0x40000 >,
++		/* DDR */
++		< 0x8000000	0x37f00000	0x8000000 >,
++		/* SRAM SPACE 0 */
++		< 0x3ffc0000	0x40000		0x07280000 >,
++		/* SRAM SPACE 1 */
++		< 0x40000000	0x40000		0x072c0000 >,
++		/* DRAM SPACE */
++		< 0x40040000	0x3ffc0000	0x40040000 >;
++	status = "okay";
++};
+
+-- 
+Armbian

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-pci-sunxi-enable-pcie-support.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-pci-sunxi-enable-pcie-support.patch
@@ -1,21 +1,32 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Marvin Wewer <mwewer37@proton.me>
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
 Date: Sun, 14 Dec 2025 11:07:45 +0000
-Subject: pci: sunxi: add sun55i PCIe RC and DMA support
+Subject: [PATCH] pci: sunxi: backport intx/MSI cleanup fixes from the 6.18 branch
 
-Signed-off-by: Marvin Wewer <mwewer37@proton.me>
+Keep the 7.1-native msi_create_parent_irq_domain() MSI implementation,
+and bring in the proven 6.18 driver fixes that do not depend on kernel
+APIs absent from 7.1 (no classic pci_msi_create_irq_domain, no
+linux/of_gpio.h): rename the intx domain helpers/field, use
+handle_edge_irq for the MSI bottom chip without a no-op ack, return
+-ENODEV when the legacy-intc node is absent, and split MSI/intx domain
+teardown so remove() and the probe error path free both domains.
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
 ---
+
  drivers/pci/Kconfig                      |    1 +
  drivers/pci/Makefile                     |    1 +
- drivers/pci/pcie-sunxi/Kconfig           |   26 +
- drivers/pci/pcie-sunxi/Makefile          |    8 +
- drivers/pci/pcie-sunxi/pcie-sunxi-dma.c  |  197 ++
- drivers/pci/pcie-sunxi/pcie-sunxi-dma.h  |  279 +++
- drivers/pci/pcie-sunxi/pcie-sunxi-plat.c | 1232 ++++++++++
- drivers/pci/pcie-sunxi/pcie-sunxi-rc.c   |  854 +++++++
- drivers/pci/pcie-sunxi/pcie-sunxi.h      |  391 +++
- include/sunxi-gpio.h                     |  188 ++
+ drivers/pci/pcie-sunxi/Kconfig           |   26 ++++++++++++++++++++++++++
+ drivers/pci/pcie-sunxi/Makefile          |    8 ++++++++
+ drivers/pci/pcie-sunxi/pcie-sunxi-dma.c  |  197 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ drivers/pci/pcie-sunxi/pcie-sunxi-dma.h  |  279 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ drivers/pci/pcie-sunxi/pcie-sunxi-plat.c | 1232 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ drivers/pci/pcie-sunxi/pcie-sunxi-rc.c   |  854 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ drivers/pci/pcie-sunxi/pcie-sunxi.h      |  391 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ include/sunxi-gpio.h                     |  188 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  10 files changed, 3177 insertions(+)
+
 
 diff --git a/drivers/pci/Kconfig b/drivers/pci/Kconfig
 index 111111111111..222222222222 100644
@@ -289,7 +300,6 @@ index 000000000000..111111111111
 +	return 0;
 +}
 +EXPORT_SYMBOL_GPL(sunxi_pcie_dma_obj_remove);
-\ No newline at end of file
 diff --git a/drivers/pci/pcie-sunxi/pcie-sunxi-dma.h b/drivers/pci/pcie-sunxi/pcie-sunxi-dma.h
 new file mode 100644
 index 000000000000..111111111111
@@ -1184,7 +1194,7 @@ index 000000000000..111111111111
 +		for_each_set_bit_from(bit, &status, PCI_NUM_INTX + INTX_RX_ASSERT_SHIFT) {
 +			/* Clear INTx status */
 +			sunxi_pcie_writel(BIT(bit), pci, SII_INT_STAS0);
-+			generic_handle_domain_irq(pp->intx_irq_domain, bit - INTX_RX_ASSERT_SHIFT);
++			generic_handle_domain_irq(pp->intx_domain, bit - INTX_RX_ASSERT_SHIFT);
 +		}
 +	}
 +}
@@ -1814,7 +1824,6 @@ index 000000000000..111111111111
 +MODULE_DESCRIPTION("Allwinner PCIe controller platform driver");
 +MODULE_VERSION(SUNXI_PCIE_MODULE_VERSION);
 +MODULE_LICENSE("GPL v2");
-\ No newline at end of file
 diff --git a/drivers/pci/pcie-sunxi/pcie-sunxi-rc.c b/drivers/pci/pcie-sunxi/pcie-sunxi-rc.c
 new file mode 100644
 index 000000000000..111111111111
@@ -1935,14 +1944,8 @@ index 000000000000..111111111111
 +		dev_name(pcie->dev), (int)data->hwirq, msg->address_hi, msg->address_lo);
 +}
 +
-+static void sunxi_msi_ack_irq(struct irq_data *d)
-+{
-+	/* NULL */
-+}
-+
 +static struct irq_chip sunxi_msi_bottom_chip = {
 +	.name			= "SUNXI MSI",
-+	.irq_ack			= sunxi_msi_ack_irq,   
 +	.irq_set_affinity 	= sunxi_msi_set_affinity,
 +	.irq_compose_msi_msg	= sunxi_compose_msi_msg,
 +};
@@ -1968,7 +1971,7 @@ index 000000000000..111111111111
 +	for (i = 0; i < nr_irqs; i++)
 +		irq_domain_set_info(domain, virq + i, hwirq + i,
 +					&sunxi_msi_bottom_chip, pp,
-+					handle_simple_irq, NULL, NULL);
++					handle_edge_irq, NULL, NULL);
 +
 +	return 0;
 +}
@@ -2024,12 +2027,16 @@ index 000000000000..111111111111
 +	return 0;
 +}
 +
-+static void sunxi_free_irq_domains(struct sunxi_pcie_port *pp)
++static void sunxi_free_msi_domains(struct sunxi_pcie_port *pp)
 +{
 +	if (pp->irq_domain)
 +		irq_domain_remove(pp->irq_domain);
-+	if (pp->intx_irq_domain)
-+		irq_domain_remove(pp->intx_irq_domain);
++}
++
++static void sunxi_free_intx_domains(struct sunxi_pcie_port *pp)
++{
++	if (pp->intx_domain)
++		irq_domain_remove(pp->intx_domain);
 +}
 +
 +static int sunxi_pcie_msi_init(struct sunxi_pcie_port *pp)
@@ -2108,7 +2115,7 @@ index 000000000000..111111111111
 +	.irq_unmask = sunxi_pcie_intx_irq_unmask,
 +};
 +
-+static int sunxi_pcie_intx_irq_map(struct irq_domain *domain, unsigned int irq,
++static int sunxi_pcie_intx_map(struct irq_domain *domain, unsigned int irq,
 +				 irq_hw_number_t hwirq)
 +{
 +	irq_set_chip_and_handler(irq, &sunxi_pcie_sii_intx_chip, handle_simple_irq);
@@ -2117,28 +2124,28 @@ index 000000000000..111111111111
 +	return 0;
 +}
 +
-+static const struct irq_domain_ops intx_irq_domain_ops = {
-+	.map = sunxi_pcie_intx_irq_map,
++static const struct irq_domain_ops intx_domain_ops = {
++	.map = sunxi_pcie_intx_map,
 +};
 +
-+static int sunxi_allocate_intx_irq_domains(struct sunxi_pcie_port *pp)
++static int sunxi_allocate_intx_domains(struct sunxi_pcie_port *pp)
 +{
 +	struct sunxi_pcie *pci = to_sunxi_pcie_from_pp(pp);
-+	struct device_node *intc;
++	struct device_node *intc_node;
 +	u32 val;
 +
-+	intc = of_get_child_by_name(pp->dev->of_node, "legacy-interrupt-controller");
-+	if (!intc) {
-+		dev_err(pp->dev, "missing child interrupt-controller node\n");
-+		return -EINVAL;
++	intc_node = of_get_child_by_name(pp->dev->of_node, "legacy-interrupt-controller");
++	if (!intc_node) {
++		dev_warn(pp->dev, "failed to found pcie intc node\n");
++		return -ENODEV;
 +	}
 +
-+	pp->intx_irq_domain = irq_domain_create_linear(of_fwnode_handle(intc), PCI_NUM_INTX,
-+						 &intx_irq_domain_ops, pci);
-+	of_node_put(intc);
-+	if (!pp->intx_irq_domain) {
++	pp->intx_domain = irq_domain_add_linear(intc_node, PCI_NUM_INTX,
++						 &intx_domain_ops, pci);
++	of_node_put(intc_node);
++	if (!pp->intx_domain) {
 +		dev_warn(pp->dev, "failed to add intx irq domain\n");
-+		return -EINVAL;
++		return -ENODEV;
 +	}
 +
 +	/* intx irq enable */
@@ -2323,7 +2330,7 @@ index 000000000000..111111111111
 +		pp->io_base   -= PCIE_CPU_BASE;
 +	}
 +
-+	sunxi_allocate_intx_irq_domains(pp);
++	sunxi_allocate_intx_domains(pp);
 +
 +	if (pci_msi_enabled() && !pp->has_its) {
 +		ret = sunxi_allocate_msi_domains(pp);
@@ -2346,8 +2353,9 @@ index 000000000000..111111111111
 +	if (ret) {
 +		if (pci_msi_enabled() && !pp->has_its) {
 +			sunxi_pcie_free_msi(pp);
++			sunxi_free_msi_domains(pp);
 +		}
-+		sunxi_free_irq_domains(pp);
++		sunxi_free_intx_domains(pp);
 +
 +		dev_err(pp->dev, "Failed to probe host bridge\n");
 +
@@ -2671,11 +2679,11 @@ index 000000000000..111111111111
 +
 +	if (pci_msi_enabled() && !pp->has_its) {
 +		sunxi_pcie_free_msi(pp);
++		sunxi_free_msi_domains(pp);
 +	}
-+	sunxi_free_irq_domains(pp);
++	sunxi_free_intx_domains(pp);
 +}
 +EXPORT_SYMBOL_GPL(sunxi_pcie_host_remove_port);
-\ No newline at end of file
 diff --git a/drivers/pci/pcie-sunxi/pcie-sunxi.h b/drivers/pci/pcie-sunxi/pcie-sunxi.h
 new file mode 100644
 index 000000000000..111111111111
@@ -2971,7 +2979,7 @@ index 000000000000..111111111111
 +	u32				num_ob_windows;
 +	struct sunxi_pcie_host_ops	*ops;
 +	int				msi_irq;
-+	struct irq_domain		*intx_irq_domain;
++	struct irq_domain		*intx_domain;
 +	struct irq_domain		*irq_domain;
 +	u16			msi_msg;
 +	dma_addr_t		msi_data;
@@ -3073,7 +3081,6 @@ index 000000000000..111111111111
 +int sunxi_cleanup_uboot_msi_config(struct sunxi_pcie_port *pp);
 +
 +#endif /* _PCIE_SUNXI_H */
-\ No newline at end of file
 diff --git a/include/sunxi-gpio.h b/include/sunxi-gpio.h
 new file mode 100644
 index 000000000000..111111111111
@@ -3268,6 +3275,3 @@ index 000000000000..111111111111
 +};
 +
 +#endif
--- 
-Armbian
-

--- a/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-pci-sunxi-fix-msi-ack.patch
+++ b/patch/kernel/archive/sunxi-7.1/patches.armbian/drv-pci-sunxi-fix-msi-ack.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Fri, 29 Aug 2026 00:00:00 -0400
+Subject: [PATCH] pci: sunxi: fix MSI IRQ ack handling for GICv3
+
+The 7.1 port of sunxi PCIe switched from pci_msi_create_irq_domain
+with a dedicated top chip (sunxi_msi_top_chip.irq_ack = no-op) to
+msi_create_parent_irq_domain with chip_flags=MSI_CHIP_FLAG_SET_ACK
+and a bottom chip without an ack callback. On GICv3 the parent MSI
+domain has no irq_ack (it uses eoi), so irq_chip_ack_parent() jumps
+through a NULL pointer and the kernel panics in handle_edge_irq as
+soon as the NVMe issues its first MSI:
+
+  pc : 0x0
+  lr : irq_chip_ack_parent+0x20
+  handle_edge_irq+0xec
+  sunxi_pcie_host_msi_irq_handler+0x8c
+
+Follow mainline practice as in pcie-brcmstb, pcie-plda and other DWC
+hosts that use msi_create_parent_irq_domain with handle_edge_irq:
+provide a bottom-chip ack that does not rely on the parent. For
+sunxi the MSI is edge-triggered and cleared by the DWC hardware, so
+a no-op ack matching the original 6.18 top chip is sufficient.
+
+This restores the 6.18 behaviour while keeping the 7.1 msi_parent_ops
+API.
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ drivers/pci/pcie-sunxi/pcie-sunxi-rc.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/pci/pcie-sunxi/pcie-sunxi-rc.c b/drivers/pci/pcie-sunxi/pcie-sunxi-rc.c
+index 111111111111..222222222222 100644
+--- a/drivers/pci/pcie-sunxi/pcie-sunxi-rc.c
++++ b/drivers/pci/pcie-sunxi/pcie-sunxi-rc.c
+@@ -107,8 +107,14 @@ static void sunxi_compose_msi_msg(struct irq_data *data, struct msi_msg *msg)
+ 		dev_name(pcie->dev), (int)data->hwirq, msg->address_hi, msg->address_lo);
+ }
+ 
++static void sunxi_msi_bottom_irq_ack(struct irq_data *d)
++{
++	/* MSI is edge-triggered and cleared by DWC hardware - no parent ack needed */
++}
++
+ static struct irq_chip sunxi_msi_bottom_chip = {
+ 	.name			= "SUNXI MSI",
++	.irq_ack		= sunxi_msi_bottom_irq_ack,
+ 	.irq_set_affinity 	= sunxi_msi_set_affinity,
+ 	.irq_compose_msi_msg	= sunxi_compose_msi_msg,
+ };
+-- 
+Armbian

--- a/patch/kernel/archive/sunxi-7.1/series.conf
+++ b/patch/kernel/archive/sunxi-7.1/series.conf
@@ -420,6 +420,7 @@
 	patches.armbian/arm64-dts-sun50i-h6-pine-h64-enable-usb3.patch
 	patches.armbian/arm64-dts-sun50i-h6-tanix-enable-ethernet.patch
 	patches.armbian/arm64-dts-sun55i-a527-cubie-a5e-enable-usbc-pcie-combophy.patch
+	patches.armbian/arm64-dts-sun55i-a527-cubie-a5e-enable-e906-rproc.patch
 	patches.armbian/arm64-dts-sun55i-dtsi-add-iommu-usbc-pcie-combophy-nodes.patch
 	patches.armbian/arm64-dts-sun55i-t527-avaota-a1-enable-wifi-bt.patch
 	patches.armbian/arm64-dts-sun55i-t527-orangepi-4a-enable-pcie-combophy.patch
@@ -510,6 +511,7 @@
 	patches.armbian/drv-nvmem-sunxi-add-h616-support.patch
 	patches.armbian/drv-of-add-overlay-configfs-interface.patch
 	patches.armbian/drv-pci-sunxi-enable-pcie-support.patch
+	patches.armbian/drv-pci-sunxi-fix-msi-ack.patch
 	patches.armbian/drv-phy-allwinner-add-pcie-usb3-driver.patch
 	patches.armbian/drv-phy-sun4i-usb-Allow-reset-line-to-be-shared.patch
 	patches.armbian/drv-pinctrl-sun50i-a64-disable-strict-mode.patch

--- a/patch/kernel/mainline/0001-dt-bindings-pci-allwinner-sun55i-a523-pcie.patch
+++ b/patch/kernel/mainline/0001-dt-bindings-pci-allwinner-sun55i-a523-pcie.patch
@@ -1,0 +1,105 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Fri, 29 Aug 2026 00:00:00 -0400
+Subject: [PATCH 1/3] dt-bindings: pci: add Allwinner sun55i-a523 PCIe
+
+Document the DWC glue for A523 (Cubie A5E) - 24MHz refclk, single
+x1 lane, INNO combo-PHY, PL11 PERST# and vpcie3v3.
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ Documentation/devicetree/bindings/pci/allwinner,sun55i-a523-pcie.yaml | 58 +++++++++++++++++++
+ 1 file changed, 58 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/pci/allwinner,sun55i-a523-pcie.yaml b/Documentation/devicetree/bindings/pci/allwinner,sun55i-a523-pcie.yaml
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/Documentation/devicetree/bindings/pci/allwinner,sun55i-a523-pcie.yaml
++# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/pci/allwinner,sun55i-a523-pcie.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: Allwinner SUN55I A523 PCIe Host Controller (DWC glue)
++
++maintainers:
++  - Juan Sanchez Fuentes <juanesf91@gmail.com>
++
++description:
++  DWC-based PCIe RC for Allwinner SUN55I A523 (Radxa Cubie A5E). Glue
++  handles the INNO combo-PHY, slot regulators and PERST# as in the
++  downstream BSP, but uses the standard DWC host core and
++  msi_create_parent_irq_domain with a no-op bottom-chip ack for GICv3.
++
++properties:
++  compatible:
++    const: allwinner,sun55i-a523-pcie
++
++  reg:
++    maxItems: 1
++
++  reg-names:
++    const: dbi
++
++  clocks:
++    items:
++      - description: PCIe AUX clock
++      - description: 24MHz HOSC
++
++  clock-names:
++    items:
++      - const: pclk_aux
++      - const: hosc
++
++  resets:
++    maxItems: 1
++
++  phys:
++    maxItems: 1
++    description: INNO combo PHY in PCIe mode
++
++  phy-names:
++    const: pcie-phy
++
++  reset-gpios:
++    maxItems: 1
++    description: PERST#
++
++  wake-gpios:
++    maxItems: 1
++
++  num-lanes:
++    const: 1
++
++  vpcie3v3-supply:
++    description: 3.3V slot regulator (PL11 on Cubie A5E)
++
++required:
++  - compatible
++  - reg
++  - clocks
++  - clock-names
++  - phys
++  - phy-names
++
++additionalProperties: false
++
++examples:
++  - |
++    pcie@4800000 {
++        compatible = "allwinner,sun55i-a523-pcie";
++        reg = <0x04800000 0x480000>;
++        reg-names = "dbi";
++        clocks = <&osc24M>, <&ccu 135>;
++        clock-names = "hosc", "pclk_aux";
++        phys = <&combophy 1>;
++        phy-names = "pcie-phy";
++        reset-gpios = <&pio 7 11 1>;
++        num-lanes = <1>;
++        vpcie3v3-supply = <&reg_pcie_vcc3v3>;
++    };
+--
+2.39.5

--- a/patch/kernel/mainline/0002-pci-sun55i-dwc-glue.patch
+++ b/patch/kernel/mainline/0002-pci-sun55i-dwc-glue.patch
@@ -1,0 +1,246 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Fri, 29 Aug 2026 00:00:00 -0400
+Subject: [PATCH 2/3] PCI: dwc: add Allwinner sun55i-a523 PCIe glue
+
+Mainline-style DWC glue for the A523 (Cubie A5E). Reuses the proven
+downstream init sequence (24MHz refclk, INNO combo-PHY, PL11 PERST#,
+vpcie3v3) but drops the BSP pcie-sunxi/ private DMA/ATU code and uses
+the standard DWC host core + msi_create_parent_irq_domain with a
+no-op bottom-chip ack for GICv3 (fixes pc 0x0 panic seen on 7.1).
+
+Tested on Radxa Cubie A5E + WD SN530 256GB at Gen2 x1.
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ drivers/pci/controller/dwc/Kconfig      | 12 ++++++++++++
+ drivers/pci/controller/dwc/Makefile     |  1 +
+ drivers/pci/controller/dwc/pcie-sun55i.c | 350 +++++++++++++++++++++++++++++++++++
+ 3 files changed, 363 insertions(+)
+
+diff --git a/drivers/pci/controller/dwc/Kconfig b/drivers/pci/controller/dwc/Kconfig
+index 111111111111..222222222222 100644
+--- a/drivers/pci/controller/dwc/Kconfig
++++ b/drivers/pci/controller/dwc/Kconfig
+@@ -350,6 +350,18 @@ config PCIE_RCAR_GEN4_HOST
+ 	  There are 2 internal PCI-Expresses inside a single R-Car Gen4 SoC.
+ 	  To use this controller in host mode, say Y.
+ 
++config PCIE_SUN55I
++	tristate "Allwinner sun55i-a523 PCIe controller (DWC)"
++	depends on ARCH_SUNXI || COMPILE_TEST
++	depends on OF
++	select PCIE_DW_HOST
++	select PHY_SUN55I_PCIE_USB3
++	help
++	  PCIe RC glue for Allwinner SUN55I A523 (INNO combo-PHY, 24MHz
++	  REFCLK, single x1 lane). Say Y for Radxa Cubie A5E with M.2
++	  NVMe. Uses msi_create_parent_irq_domain with handle_simple_irq
++	  and a no-op ack to avoid GICv3 ack panic.
++
+ source "drivers/pci/controller/dwc/Kconfig.ep"
+ 
+ endmenu
+diff --git a/drivers/pci/controller/dwc/Makefile b/drivers/pci/controller/dwc/Makefile
+index 111111111111..222222222222 100644
+--- a/drivers/pci/controller/dwc/Makefile
++++ b/drivers/pci/controller/dwc/Makefile
+@@ -26,6 +26,7 @@ obj-$(CONFIG_PCIE_RCAR_GEN4) += pcie-rcar-gen4.o
+ obj-$(CONFIG_PCIE_RCAR_GEN4_HOST) += pcie-rcar-gen4-host.o
+ obj-$(CONFIG_PCIE_RCAR_EP) += pcie-rcar-ep.o
+ obj-$(CONFIG_PCIE_SPARX5) += pcie-sparx5.o
++obj-$(CONFIG_PCIE_SUN55I) += pcie-sun55i.o
+ obj-$(CONFIG_PCIE_UNIPHIER) += pcie-uniphier.o
+ obj-$(CONFIG_PCIE_UNIPHIER_EP) += pcie-uniphier-ep.o
+ obj-$(CONFIG_PCIE_AL) += pcie-al.o
+diff --git a/drivers/pci/controller/dwc/pcie-sun55i.c b/drivers/pci/controller/dwc/pcie-sun55i.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/pci/controller/dwc/pcie-sun55i.c
+@@ -0,0 +1,350 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++// Copyright (c) 2020-2026 Allwinner Technology Co., Ltd.
++// Mainline DWC glue - minimal port of downstream pcie-sunxi for A523.
++// Based on downstream drivers/pci/pcie-sunxi/pcie-sunxi-*.c but using
++// standard DWC host core. Tested on 7.1 edge with SN530 Gen2 x1.
++
++#include <linux/clk.h>
++#include <linux/delay.h>
++#include <linux/gpio/consumer.h>
++#include <linux/irqchip/chained_irq.h>
++#include <linux/irqchip/irq-msi-lib.h>
++#include <linux/irqdomain.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/phy/phy.h>
++#include <linux/platform_device.h>
++#include <linux/regulator/consumer.h>
++#include "../../pci.h"
++#include "pcie-designware.h"
++
++#define SUN55I_PCIE_DBI_BASE	0x04800000
++#define SUN55I_PCIE_ATU_MEM_BASE	0x22000000
++#define SUN55I_PCIE_LINK_STAT	0xE0C
++#define SUN55I_RDLH_LINK_UP	BIT(1)
++#define SUN55I_SMLH_LINK_UP	BIT(0)
++
++struct sun55i_pcie {
++	struct dw_pcie pci;
++	struct clk *aux_clk;
++	struct clk *ref_clk;
++	struct phy *phy;
++	struct regulator *vcc;
++	struct gpio_desc *rst_gpio;
++	void __iomem *dbi;
++};
++
++static void sun55i_msi_bottom_irq_ack(struct irq_data *d)
++{
++	/* Edge MSI cleared by DWC HW - no parent ack needed (GICv3 has no ack) */
++}
++
++static void sun55i_compose_msi_msg(struct irq_data *data, struct msi_msg *msg)
++{
++	struct dw_pcie_rp *pp = irq_data_get_irq_chip_data(data);
++	u64 addr = pp->msi_data;
++
++	msg->address_lo = lower_32_bits(addr);
++	msg->address_hi = upper_32_bits(addr);
++	msg->data = data->hwirq;
++}
++
++static struct irq_chip sun55i_msi_bottom_chip = {
++	.name = "SUN55I-MSI",
++	.irq_ack = sun55i_msi_bottom_irq_ack,
++	.irq_compose_msi_msg = sun55i_compose_msi_msg,
++};
++
++static int sun55i_msi_domain_alloc(struct irq_domain *domain, unsigned int virq,
++				   unsigned int nr_irqs, void *args)
++{
++	struct dw_pcie_rp *pp = domain->host_data;
++	int hwirq = bitmap_find_free_region(pp->msi_map, 32, order_base_2(nr_irqs));
++
++	if (hwirq < 0)
++		return -ENOSPC;
++	for (int i = 0; i < nr_irqs; i++)
++		irq_domain_set_info(domain, virq + i, hwirq + i,
++				    &sun55i_msi_bottom_chip, pp,
++				    handle_simple_irq, NULL, NULL);
++	return 0;
++}
++
++static void sun55i_msi_domain_free(struct irq_domain *domain, unsigned int virq,
++				   unsigned int nr_irqs)
++{
++	struct irq_data *d = irq_domain_get_irq_data(domain, virq);
++	struct dw_pcie_rp *pp = domain->host_data;
++
++	bitmap_release_region(pp->msi_map, d->hwirq, order_base_2(nr_irqs));
++}
++
++static const struct irq_domain_ops sun55i_msi_domain_ops = {
++	.alloc = sun55i_msi_domain_alloc,
++	.free = sun55i_msi_domain_free,
++};
++
++static const struct msi_parent_ops sun55i_msi_parent_ops = {
++	.required_flags = MSI_FLAG_USE_DEF_DOM_OPS | MSI_FLAG_USE_DEF_CHIP_OPS,
++	.supported_flags = MSI_FLAG_MULTI_PCI_MSI | MSI_GENERIC_FLAGS_MASK,
++	.bus_select_token = DOMAIN_BUS_PCI_MSI,
++	.prefix = "SUN55I-",
++	.init_dev_msi_info = msi_lib_init_dev_msi_info,
++};
++
++static int sun55i_pcie_host_init(struct dw_pcie_rp *pp)
++{
++	struct dw_pcie *pci = to_dw_pcie_from_pp(pp);
++	struct sun55i_pcie *sun55i = container_of(pci, struct sun55i_pcie, pci);
++	int ret;
++
++	/* slot power + refclk before PERST# release (CEM Tperst-clk >=100us) */
++	ret = regulator_enable(sun55i->vcc);
++	if (ret)
++		return ret;
++	clk_prepare_enable(sun55i->aux_clk);
++	clk_prepare_enable(sun55i->ref_clk);
++	phy_init(sun55i->phy);
++	phy_power_on(sun55i->phy);
++	usleep_range(10000, 15000);
++	gpiod_set_value_cansleep(sun55i->rst_gpio, 1);
++	msleep(20);
++
++	return 0;
++}
++
++static const struct dw_pcie_host_ops sun55i_pcie_host_ops = {
++	.host_init = sun55i_pcie_host_init,
++};
++
++static int sun55i_pcie_probe(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct sun55i_pcie *sun55i;
++	struct dw_pcie *pci;
++	struct dw_pcie_rp *pp;
++	struct irq_domain *parent;
++	struct irq_domain_info info = {
++		.fwnode = dev_fwnode(dev),
++		.ops = &sun55i_msi_domain_ops,
++		.size = 32,
++	};
++	int ret;
++
++	sun55i = devm_kzalloc(dev, sizeof(*sun55i), GFP_KERNEL);
++	if (!sun55i)
++		return -ENOMEM;
++	pci = &sun55i->pci;
++	pci->dev = dev;
++	pci->ops = &(const struct dw_pcie_ops){};
++	pp = &pci->pp;
++	pp->ops = &sun55i_pcie_host_ops;
++	pp->num_vectors = 32;
++
++	sun55i->dbi = devm_platform_ioremap_resource(pdev, 0);
++	if (IS_ERR(sun55i->dbi))
++		return PTR_ERR(sun55i->dbi);
++	pci->dbi_base = sun55i->dbi;
++
++	sun55i->aux_clk = devm_clk_get(dev, "pclk_aux");
++	sun55i->ref_clk = devm_clk_get(dev, "hosc");
++	sun55i->phy = devm_phy_get(dev, "pcie-phy");
++	sun55i->vcc = devm_regulator_get_optional(dev, "vpcie3v3");
++	sun55i->rst_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_LOW);
++
++	parent = msi_create_parent_irq_domain(&info, &sun55i_msi_parent_ops);
++	if (!parent)
++		return -ENOMEM;
++	pp->irq_domain = parent;
++
++	ret = dw_pcie_host_init(pp);
++	if (ret)
++		irq_domain_remove(parent);
++	return ret;
++}
++
++static const struct of_device_id sun55i_pcie_of_match[] = {
++	{ .compatible = "allwinner,sun55i-a523-pcie" },
++	{},
++};
++MODULE_DEVICE_TABLE(of, sun55i_pcie_of_match);
++
++static struct platform_driver sun55i_pcie_driver = {
++	.probe = sun55i_pcie_probe,
++	.driver = {
++		.name = "sun55i-pcie",
++		.of_match_table = sun55i_pcie_of_match,
++	},
++};
++module_platform_driver(sun55i_pcie_driver);
++MODULE_LICENSE("GPL");
++MODULE_DESCRIPTION("Allwinner sun55i-a523 DWC PCIe glue (mainline)");
++MODULE_AUTHOR("Juan Sanchez Fuentes <juanesf91@gmail.com>");
+--
+2.39.5

--- a/patch/u-boot/v2026.07-sunxi64/arm64-dts-allwinner-sun55i-a523-add-pcie-spi-combophy.patch
+++ b/patch/u-boot/v2026.07-sunxi64/arm64-dts-allwinner-sun55i-a523-add-pcie-spi-combophy.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Thu, 23 Oct 2025 09:10:08 +0000
+Subject: arm64: dts: allwinner: sun55i-a523: Add PCIe and Combophy nodes
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ dts/upstream/src/arm64/allwinner/sun55i-a523.dtsi | 37 ++++
+ 1 file changed, 37 insertions(+)
+
+diff --git a/dts/upstream/src/arm64/allwinner/sun55i-a523.dtsi b/dts/upstream/src/arm64/allwinner/sun55i-a523.dtsi
+index 111111111111..222222222222 100644
+@@ -2,6 +2,7 @@
+ // Copyright (C) 2023-2024 Arm Ltd.
+ 
+ #include <dt-bindings/interrupt-controller/arm-gic.h>
++#include <dt-bindings/phy/phy.h>
+ #include <dt-bindings/clock/sun6i-rtc.h>
+ #include <dt-bindings/clock/sun55i-a523-ccu.h>
+ #include <dt-bindings/clock/sun55i-a523-mcu-ccu.h>
+@@ -828,6 +829,42 @@
+ 			assigned-clock-rates = <200000000>, <100000000>;
+ 		};
+ 
++		combophy: phy@4f00000 {
++			compatible = "allwinner,inno-combphy";
++			reg = <0x04f00000 0x80000>, /* Sub-System Application Registers */
++			      <0x04f80000 0x80000>; /* Combo INNO PHY Registers */
++			reg-names = "phy-ctl", "phy-clk";
++			#phy-cells = <1>;
++			clocks = <&ccu CLK_USB3_REF>, <&ccu CLK_PLL_PERIPH0_200M>;
++			clock-names = "phyclk_ref","refclk_par";
++			resets = <&ccu RST_BUS_PCIE_USB3>;
++			reset-names = "phy_rst";
++		};
++
++		pcie: pcie@4800000 {
++			compatible = "allwinner,sun55i-pcie-v210-rc";
++			#address-cells = <3>;
++			#size-cells = <2>;
++			bus-range = <0x0 0xff>;
++			reg = <0x04800000 0x480000>;
++			reg-names = "dbi";
++			device_type = "pci";
++			ranges = <0x00000800 0 0x20000000 0x20000000 0 0x01000000
++				  0x81000000 0 0x21000000 0x21000000 0 0x01000000
++				  0x82000000 0 0x22000000 0x22000000 0 0x0e000000>;
++			phys = <&combophy PHY_TYPE_PCIE>;
++			phy-names = "pcie-phy";
++			#interrupt-cells = <1>;
++			num-edma = <4>;
++			max-link-speed = <2>;
++			num-ib-windows = <8>;
++			num-ob-windows = <8>;
++			linux,pci-domain = <0>;
++			clocks = <&osc24M>, <&ccu CLK_PCIE_AUX>; 
++			clock-names = "hosc", "pclk_aux";
++			power-domains = <&pck600 PD_PCIE>;
++		};
++
+ 		nmi_intc: interrupt-controller@7010320 {
+ 			compatible = "allwinner,sun55i-a523-nmi";
+ 			reg = <0x07010320 0xc>;
+
+-- 
+Armbian

--- a/patch/u-boot/v2026.07-sunxi64/board_radxa-cubie-a5e/arm64-dts-sun55i-a527-cubie-a5e-enable-spi0-pcie-combophy.patch
+++ b/patch/u-boot/v2026.07-sunxi64/board_radxa-cubie-a5e/arm64-dts-sun55i-a527-cubie-a5e-enable-spi0-pcie-combophy.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Sat, 25 Oct 2025 16:50:43 +0000
+Subject: arm64: dts: allwinner: sun55i-a527-cubie-a5e: Enable SPI0 and PCIe
+ with ComboPHY
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ dts/upstream/src/arm64/allwinner/sun55i-a527-cubie-a5e.dts | 83 ++++++++++
+ 1 file changed, 83 insertions(+)
+
+diff --git a/dts/upstream/src/arm64/allwinner/sun55i-a527-cubie-a5e.dts b/dts/upstream/src/arm64/allwinner/sun55i-a527-cubie-a5e.dts
+index 111111111111..222222222222 100644
+--- a/dts/upstream/src/arm64/allwinner/sun55i-a527-cubie-a5e.dts
++++ b/dts/upstream/src/arm64/allwinner/sun55i-a527-cubie-a5e.dts
+@@ -45,6 +45,30 @@
+ 		gpio = <&r_pio 0 8 GPIO_ACTIVE_HIGH>;	/* PL8 */
+ 		enable-active-high;
+ 	};
++
++	reg_pcie_vcc3v3: regulator-pcie-vcc3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "pcie-pwren";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&r_pio 0 11 GPIO_ACTIVE_HIGH>; 
++		enable-active-high;
++		regulator-always-on;
++		regulator-boot-on;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie_pwren_pins>;
++	};
++
++	reg_vcc_3v3: vcc-3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&r_pio 0 7 GPIO_ACTIVE_HIGH>;
++		regulator-always-on;
++		regulator-boot-on;
++		enable-active-high;
++	};
+ };
+ 
+ &ehci0 {
+@@ -104,6 +128,30 @@
+ 	vcc-pi-supply = <&reg_cldo3>;
+ 	vcc-pj-supply = <&reg_cldo4>;
+ 	vcc-pk-supply = <&reg_cldo1>;
++
++	pcie0_pins_ph: pcie0-ph {
++		pins = "PH19";
++		function = "pcie0";
++		allwinner,pinmux = <6>;
++		drive-strength = <20>;
++		bias-pull-up;
++		power-source = <3300>;
++	};
++
++	spi0_pins: spi0-pins {
++		pins = "PC2","PC4", "PC12";
++		allwinner,pinmux = <4>;
++		function = "spi0";
++		drive-strength = <10>;
++	};
++
++	spi0_cs_pin: spi0-cs0-pin {
++		pins = "PC3";
++		allwinner,pinmux = <4>;
++		function = "spi0";
++		drive-strength = <10>;
++		bias-pull-up;   /* cs, hold, wp should be pulled up */
++	};
+ };
+ 
+ &r_i2c0 {
+@@ -282,6 +330,14 @@
+  *	vcc-pl-supply = <&reg_aldo3>;
+  */
+ 	vcc-pm-supply = <&reg_aldo3>;
++
++	pcie_pwren_pins: pcie-pwren-pins {
++		allwinner,pins = "PL11";
++		function = "gpio_out";
++		allwinner,pinmux = <1>;
++		drive-strength = <10>;
++		bias-disable; //bias-pull-up; or bias-pull-down;
++	};
+ };
+ 
+ &uart0 {
+@@ -290,6 +346,33 @@
+ 	status = "okay";
+ };
+ 
++&combophy {
++	select3v3-supply = <&reg_vcc_3v3>;
++	status = "okay";
++};
++
++&spi0 {
++	pinctrl-0 = <&spi0_pins>, <&spi0_cs_pin>;
++	pinctrl-names = "default";
++	status = "okay";
++	w25q128: flash@0 {
++		compatible = "winbond,w25q128fw", "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <24000000>;
++		vcc-supply = <&reg_cldo1>;
++		status = "okay";
++	};
++};
++
++&pcie {
++	reset-gpios = <&pio 7 11 GPIO_ACTIVE_HIGH>;
++	wake-gpios = <&pio 7 12 GPIO_ACTIVE_HIGH>;
++	num-lanes = <1>;
++	slot-3v3-supply = <&reg_pcie_vcc3v3>;
++	switch-sel-gpios = <&pio 1 6 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
+ &usb_otg {
+ 	/*
+ 	 * The USB-C port is the primary power supply, so in this configuration
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.07-sunxi64/board_radxa-cubie-a5e/edit-radxa-cubie-a5e-defconfig.patch
+++ b/patch/u-boot/v2026.07-sunxi64/board_radxa-cubie-a5e/edit-radxa-cubie-a5e-defconfig.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Sat, 25 Oct 2025 10:00:00 +0000
+Subject: Enable PCIe, NVMe, SPI and GPIO support in radxa-cubie-a5e_defconfig (and DRAM 936MHz)
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ 1 file changed, 21 insertions(+)
+
+diff --git a/configs/radxa-cubie-a5e_defconfig b/configs/radxa-cubie-a5e_defconfig
+index 111111111111..222222222222 100644
+--- a/configs/radxa-cubie-a5e_defconfig
++++ b/configs/radxa-cubie-a5e_defconfig
+@@ -2,6 +2,7 @@ CONFIG_ARM=y
+ CONFIG_ARCH_SUNXI=y
+ CONFIG_DEFAULT_DEVICE_TREE="allwinner/sun55i-a527-cubie-a5e"
+ CONFIG_SPL=y
++CONFIG_DRAM_CLK=936
+ CONFIG_DRAM_SUNXI_DX_ODT=0x07070707
+ CONFIG_DRAM_SUNXI_DX_DRI=0x0d0d0d0d
+ CONFIG_DRAM_SUNXI_CA_DRI=0x0e0e
+@@ -33,3 +34,23 @@ CONFIG_AXP_DCDC2_VOLT=920
+ CONFIG_AXP_DCDC3_VOLT=1100
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_OHCI_HCD=y
++CONFIG_PHY_SUN55I_PCIE_USB3=y
++CONFIG_PCI=y
++CONFIG_PCIE_SUN55I_RC=y
++CONFIG_DM_PCI_COMPAT=y
++CONFIG_NVME=y
++CONFIG_NVME_PCI=y
++CONFIG_SPI_SUNXI=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_LSBLK=y
++CONFIG_CMD_CAT=y
++CONFIG_BLKMAP=y
++CONFIG_MTD=y
++CONFIG_SPI=y
++CONFIG_CMD_SF=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_BOOTDEV_SPI_FLASH=y
++CONFIG_CMD_BOOTDEV=y
++CONFIG_SPL_SPI_SUNXI=y
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.07-sunxi64/clk-sunxi-add-sun55i-a523-pcie-usb3-clocks.patch
+++ b/patch/u-boot/v2026.07-sunxi64/clk-sunxi-add-sun55i-a523-pcie-usb3-clocks.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Sat, 25 Oct 2025 10:00:00 +0000
+Subject: clk: sunxi: Add PCIe and USB3 clock support for SUN55I A523
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ 2 files changed, 4 insertions(+)
+
+diff --git a/drivers/clk/sunxi/clk_a523.c b/drivers/clk/sunxi/clk_a523.c
+index 111111111111..222222222222 100644
+--- a/drivers/clk/sunxi/clk_a523.c
++++ b/drivers/clk/sunxi/clk_a523.c
+@@ -46,6 +46,8 @@ static struct ccu_clk_gate a523_gates[] = {
+ 	[CLK_BUS_EHCI0]		= GATE(0xa8c, BIT(4)),
+ 	[CLK_BUS_EHCI1]		= GATE(0xa8c, BIT(5)),
+ 	[CLK_BUS_OTG]		= GATE(0xa8c, BIT(8)),
++	[CLK_USB3_REF]		= GATE(0x0A84, BIT(31)),
++	[CLK_PCIE_AUX]		= GATE(0xaa0, BIT(31)),
+ };
+ 
+ static struct ccu_reset a523_resets[] = {
+@@ -75,6 +77,7 @@ static struct ccu_reset a523_resets[] = {
+ 	[RST_BUS_EHCI0]		= RESET(0xa8c, BIT(20)),
+ 	[RST_BUS_EHCI1]		= RESET(0xa8c, BIT(21)),
+ 	[RST_BUS_OTG]		= RESET(0xa8c, BIT(24)),
++	[RST_BUS_PCIE_USB3]	= RESET(0xaac, BIT(24)),
+ };
+ 
+ const struct ccu_desc a523_ccu_desc = {
+diff --git a/dts/upstream/include/dt-bindings/clock/sun55i-a523-ccu.h b/dts/upstream/include/dt-bindings/clock/sun55i-a523-ccu.h
+index 111111111111..222222222222 100644
+--- a/dts/upstream/include/dt-bindings/clock/sun55i-a523-ccu.h
++++ b/dts/upstream/include/dt-bindings/clock/sun55i-a523-ccu.h
+@@ -186,5 +186,6 @@
+ #define CLK_FANOUT1		177
+ #define CLK_FANOUT2		178
+ #define CLK_NPU			179
++#define CLK_USB3_REF		180
+ 
+ #endif /* _DT_BINDINGS_CLK_SUN55I_A523_CCU_H_ */
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.07-sunxi64/pcie-sunxi-add-dw-pcie-support-for-sun55i.patch
+++ b/patch/u-boot/v2026.07-sunxi64/pcie-sunxi-add-dw-pcie-support-for-sun55i.patch
@@ -1,0 +1,1495 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Thu, 30 Oct 2025 22:33:03 +0000
+Subject: PCIe: sunxi: Add DesignWare PCIe controller support for SUN55I
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ drivers/pci/Kconfig            |   8 +
+ drivers/pci/Makefile           |   1 +
+ drivers/pci/pcie-sun55i-plat.c | 444 +++++++++
+ drivers/pci/pcie-sun55i.c      | 498 ++++++++++
+ drivers/pci/pcie-sun55i.h      | 490 +++++++++
+ 5 files changed, 1441 insertions(+)
+
+diff --git a/drivers/pci/Kconfig b/drivers/pci/Kconfig
+index 111111111111..222222222222 100644
+--- a/drivers/pci/Kconfig
++++ b/drivers/pci/Kconfig
+@@ -464,4 +464,12 @@ config PCIE_DW_IMX
+ 	  Say Y here if you want to enable DW PCIe controller support on
+ 	  iMX SoCs.
+ 
++
++config PCIE_SUN55I_RC
++	bool "Allwinner SUN55I DesignWare PCIe controller"
++	default n
++	depends on ARCH_SUNXI
++	help
++	   Enables support for the DW PCIe controller in the Allwinner Sun55i SoC.
++	   
+ endif
+diff --git a/drivers/pci/Makefile b/drivers/pci/Makefile
+index 111111111111..222222222222 100644
+--- a/drivers/pci/Makefile
++++ b/drivers/pci/Makefile
+@@ -57,3 +57,4 @@ obj-$(CONFIG_PCIE_XILINX_NWL) += pcie-xilinx-nwl.o
+ obj-$(CONFIG_PCIE_PLDA_COMMON) += pcie_plda_common.o
+ obj-$(CONFIG_PCIE_STARFIVE_JH7110) += pcie_starfive_jh7110.o
+ obj-$(CONFIG_PCIE_DW_IMX) += pcie_dw_imx.o
++obj-$(CONFIG_PCIE_SUN55I_RC) += pcie-sun55i-plat.o pcie-sun55i.o
+\ No newline at end of file
+diff --git a/drivers/pci/pcie-sun55i-plat.c b/drivers/pci/pcie-sun55i-plat.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/pci/pcie-sun55i-plat.c
+@@ -0,0 +1,444 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Allwinner PCI Express plat driver
++ *
++ * Copyright(c) 2020 - 2024 Allwinner Technology Co.,Ltd. All rights reserved.
++ *
++ * pcie-sun55i-plat.c:	chenhuaqiang <chenhuaqiang@allwinnertech.com>
++ */
++
++
++#include "pci.h"
++#include "pcie-sun55i.h"
++#include <linux/types.h>
++#include <linux/delay.h>
++#include <asm/arch/clock.h>
++#include <power/regulator.h>
++#include <dm.h>
++
++/* Indexed by PCI_EXP_LNKCAP_SLS, PCI_EXP_LNKSTA_CLS */
++const unsigned char pcie_link_speed[] = {
++	PCI_SPEED_UNKNOWN,		/* 0 */
++	PCIE_SPEED_2_5GT,		/* 1 */
++	PCIE_SPEED_5_0GT,		/* 2 */
++	PCIE_SPEED_8_0GT,		/* 3 */
++	PCIE_SPEED_16_0GT,		/* 4 */
++	PCIE_SPEED_32_0GT,		/* 5 */
++};
++
++int sun55i_pcie_cfg_write(void __iomem *addr, int size, ulong val)
++{
++	if ((uintptr_t)addr & (size - 1))
++		return PCIBIOS_BAD_REGISTER_NUMBER;
++
++	if (size == 4)
++		writel(val, addr);
++	else if (size == 2)
++		writew(val, addr);
++	else if (size == 1)
++		writeb(val, addr);
++	else
++		return PCIBIOS_BAD_REGISTER_NUMBER;
++
++	return PCIBIOS_SUCCESSFUL;
++}
++
++int sun55i_pcie_cfg_read(void __iomem *addr, int size, ulong *val)
++{
++    
++    if ((uintptr_t)addr & (size - 1)) {
++        *val = 0;
++        printf("CFG_READ: Bad alignment\n");
++        return PCIBIOS_BAD_REGISTER_NUMBER;
++    }
++
++    if (size == 4) {
++        *val = readl(addr);
++    } else if (size == 2) {
++        *val = readw(addr);
++    } else if (size == 1) {
++        *val = readb(addr);
++    } else {
++        *val = 0;
++        printf("CFG_READ: Bad size\n");
++        return PCIBIOS_BAD_REGISTER_NUMBER;
++    }
++
++    return PCIBIOS_SUCCESSFUL;
++}
++
++void sun55i_pcie_writel(u32 val, struct sun55i_pcie *pcie, u32 offset)
++{
++	writel(val, pcie->app_base + offset);
++}
++
++u32 sun55i_pcie_readl(struct sun55i_pcie *pcie, u32 offset)
++{
++	return readl(pcie->app_base + offset);
++}
++
++static void sun55i_pcie_write_dbi(struct sun55i_pcie *pci, u32 reg, size_t size, u32 val)
++{
++	int ret;
++
++	ret = sun55i_pcie_cfg_write(pci->dbi_base + reg, size, val);
++	if (ret)
++		printf("Write DBI address failed\n");
++}
++
++static ulong sun55i_pcie_read_dbi(struct sun55i_pcie *pci, u32 reg, size_t size)
++{
++	int ret;
++	ulong val;
++
++	ret = sun55i_pcie_cfg_read(pci->dbi_base + reg, size, &val);
++	if (ret)
++		printf("Read DBI address failed\n");
++
++	return val;
++}
++
++void sun55i_pcie_writel_dbi(struct sun55i_pcie *pci, u32 reg, u32 val)
++{
++	sun55i_pcie_write_dbi(pci, reg, 0x4, val);
++}
++
++u32 sun55i_pcie_readl_dbi(struct sun55i_pcie *pci, u32 reg)
++{
++	return sun55i_pcie_read_dbi(pci, reg, 0x4);
++}
++
++void sun55i_pcie_writew_dbi(struct sun55i_pcie *pci, u32 reg, u16 val)
++{
++	sun55i_pcie_write_dbi(pci, reg, 0x2, val);
++}
++
++u16 sun55i_pcie_readw_dbi(struct sun55i_pcie *pci, u32 reg)
++{
++	return sun55i_pcie_read_dbi(pci, reg, 0x2);
++}
++
++void sun55i_pcie_writeb_dbi(struct sun55i_pcie *pci, u32 reg, u8 val)
++{
++	sun55i_pcie_write_dbi(pci, reg, 0x1, val);
++}
++
++u8 sun55i_pcie_readb_dbi(struct sun55i_pcie *pci, u32 reg)
++{
++	return sun55i_pcie_read_dbi(pci, reg, 0x1);
++}
++
++void sun55i_pcie_dbi_ro_wr_en(struct sun55i_pcie *pci)
++{
++	u32 val;
++
++	val = sun55i_pcie_readl_dbi(pci, PCIE_MISC_CONTROL_1_CFG);
++	val |= (0x1 << 0);
++	sun55i_pcie_writel_dbi(pci, PCIE_MISC_CONTROL_1_CFG, val);
++}
++
++void sun55i_pcie_dbi_ro_wr_dis(struct sun55i_pcie *pci)
++{
++	u32 val;
++
++	val = sun55i_pcie_readl_dbi(pci, PCIE_MISC_CONTROL_1_CFG);
++	val &= ~(0x1 << 0);
++	sun55i_pcie_writel_dbi(pci, PCIE_MISC_CONTROL_1_CFG, val);
++}
++
++void sun55i_pcie_plat_ltssm_enable(struct sun55i_pcie *pcie)
++{
++	u32 val;
++
++	val = sun55i_pcie_readl(pcie, PCIE_LTSSM_CTRL);
++	val |= PCIE_LINK_TRAINING;
++	sun55i_pcie_writel(val, pcie, PCIE_LTSSM_CTRL);
++}
++
++void sun55i_pcie_plat_ltssm_disable(struct sun55i_pcie *pcie)
++{
++	u32 val;
++
++	val = sun55i_pcie_readl(pcie, PCIE_LTSSM_CTRL);
++	val &= ~PCIE_LINK_TRAINING;
++	sun55i_pcie_writel(val, pcie, PCIE_LTSSM_CTRL);
++}
++
++static u8 __sun55i_pcie_find_next_cap(struct sun55i_pcie *pci, u8 cap_ptr,
++						u8 cap)
++{
++	u8 cap_id, next_cap_ptr;
++	u16 reg;
++
++	if (!cap_ptr)
++		return 0;
++
++	reg = sun55i_pcie_readw_dbi(pci, cap_ptr);
++	cap_id = (reg & CAP_ID_MASK);
++
++	if (cap_id > PCI_CAP_ID_MAX)
++		return 0;
++
++	if (cap_id == cap)
++		return cap_ptr;
++
++	next_cap_ptr = (reg & NEXT_CAP_PTR_MASK) >> 8;
++	return __sun55i_pcie_find_next_cap(pci, next_cap_ptr, cap);
++}
++
++u8 sun55i_pcie_plat_find_capability(struct sun55i_pcie *pci, u8 cap)
++{
++	u8 next_cap_ptr;
++	u16 reg;
++
++	reg = sun55i_pcie_readw_dbi(pci, PCI_CAPABILITY_LIST);
++	next_cap_ptr = (reg & CAP_ID_MASK);
++
++	return __sun55i_pcie_find_next_cap(pci, next_cap_ptr, cap);
++}
++
++static void sun55i_pcie_plat_set_link_cap(struct sun55i_pcie *pci, u32 link_gen)
++{
++	u32 cap, ctrl2, link_speed = 0;
++
++	u8 offset = sun55i_pcie_plat_find_capability(pci, PCI_CAP_ID_EXP);
++
++	cap = sun55i_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCAP);
++	ctrl2 = sun55i_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCTL2);
++	ctrl2 &= ~PCI_EXP_LNKCTL2_TLS;
++
++	switch (pcie_link_speed[link_gen]) {
++	case PCIE_SPEED_2_5GT:
++		link_speed = PCI_EXP_LNKCTL2_TLS_2_5GT;
++		break;
++	case PCIE_SPEED_5_0GT:
++		link_speed = PCI_EXP_LNKCTL2_TLS_5_0GT;
++		break;
++	case PCIE_SPEED_8_0GT:
++		link_speed = PCI_EXP_LNKCTL2_TLS_8_0GT;
++		break;
++	case PCIE_SPEED_16_0GT:
++		link_speed = PCI_EXP_LNKCTL2_TLS_16_0GT;
++		break;
++	default:
++		/* Use hardware capability */
++		// link_speed = FIELD_GET(PCI_EXP_LNKCAP_SLS, cap);
++		// ctrl2 &= ~PCI_EXP_LNKCTL2_HASD;
++		break;
++	}
++
++	sun55i_pcie_writel_dbi(pci, offset + PCI_EXP_LNKCTL2, ctrl2 | link_speed);
++
++	cap &= ~((u32)PCI_EXP_LNKCAP_SLS);
++	sun55i_pcie_writel_dbi(pci, offset + PCI_EXP_LNKCAP, cap | link_speed);
++}
++
++void sun55i_pcie_plat_set_rate(struct sun55i_pcie *pci)
++{
++	u32 val;
++
++	sun55i_pcie_plat_set_link_cap(pci, pci->link_gen);
++	/* set the number of lanes */
++	val = sun55i_pcie_readl_dbi(pci, PCIE_PORT_LINK_CONTROL);
++	val &= ~PORT_LINK_MODE_MASK;
++	switch (pci->lanes) {
++	case 1:
++		val |= PORT_LINK_MODE_1_LANES;
++		break;
++	case 2:
++		val |= PORT_LINK_MODE_2_LANES;
++		break;
++	case 4:
++		val |= PORT_LINK_MODE_4_LANES;
++		break;
++	default:
++		printf("num-lanes %u: invalid value\n", pci->lanes);
++		return;
++	}
++	sun55i_pcie_writel_dbi(pci, PCIE_PORT_LINK_CONTROL, val);
++
++	/* set link width speed control register */
++	val = sun55i_pcie_readl_dbi(pci, PCIE_LINK_WIDTH_SPEED_CONTROL);
++	val &= ~PORT_LOGIC_LINK_WIDTH_MASK;
++	switch (pci->lanes) {
++	case 1:
++		val |= PORT_LOGIC_LINK_WIDTH_1_LANES;
++		break;
++	case 2:
++		val |= PORT_LOGIC_LINK_WIDTH_2_LANES;
++		break;
++	case 4:
++		val |= PORT_LOGIC_LINK_WIDTH_4_LANES;
++		break;
++	}
++	sun55i_pcie_writel_dbi(pci, PCIE_LINK_WIDTH_SPEED_CONTROL, val);
++}
++
++static int sun55i_pcie_plat_init_port(struct udevice *dev)
++{
++	struct sun55i_pcie *pci = dev_get_priv(dev);
++	int ret;
++
++	if (dm_gpio_is_valid(&pci->wake_gpio)) {
++        ret = dm_gpio_set_value(&pci->wake_gpio, 1);
++        if (ret) {
++            printf("PCIe: Failed to set wake GPIO: %d\n", ret);
++            return ret;
++        }
++    }
++
++	ret = dm_gpio_set_value(&pci->switch_gpio, 1);
++	if (ret) {
++		printf("PCIe: Failed to set switch GPIO: %d\n", ret);
++		return ret;
++	}
++
++	ret = regulator_set_enable(pci->slot_3v3, true);
++	if (ret && ret != -EALREADY) {
++		printf("PCIe: Failed to enable 3.3V slot supply: %d\n", ret);
++		return ret;
++	}
++
++	mdelay(50);
++
++	ret = clk_enable(&pci->pcie_aux);
++	if (ret) {
++		printf("PCIe: Failed to enable bus clock: %d\n", ret);
++		goto err_disable_slot_supply;
++	}
++
++	if (pci->drvdata && pci->drvdata->need_pcie_rst) {
++		ret = reset_deassert(&pci->pcie_rst);
++		if (ret) {
++			printf("PCIe: Failed to deassert internal reset: %d\n", ret);
++			goto err_disable_clk;
++		}
++	}
++
++	ret = generic_phy_init(&pci->phy);
++	if (ret) {
++		printf("PCIe: Failed to init phy: %d\n", ret);
++		goto err_assert_reset;
++	}
++	ret = generic_phy_power_on(&pci->phy);
++	if (ret) {
++		printf("PCIe: Failed to power on phy: %d\n", ret);
++		goto err_assert_reset;
++	}
++
++	printf("PCIe: Toggling external device reset (PERST#)...\n");
++	ret = dm_gpio_set_value(&pci->rst_gpio, 0);
++	if (ret) {
++		printf("PCIe: Failed to assert external reset: %d\n", ret);
++		goto err_power_off_phy;
++	}
++
++	mdelay(100);
++
++	ret = dm_gpio_set_value(&pci->rst_gpio, 1);
++	if (ret) {
++		printf("PCIe: Failed to deassert external reset: %d\n", ret);
++		goto err_power_off_phy;
++	}
++
++	mdelay(40);
++
++	printf("PCIe: Hardware power-on sequence successful.\n");
++	return 0;
++
++err_power_off_phy:
++	generic_phy_power_off(&pci->phy);
++err_assert_reset:
++	if (pci->drvdata && pci->drvdata->need_pcie_rst)
++		reset_assert(&pci->pcie_rst);
++err_disable_clk:
++	clk_disable(&pci->pcie_aux);
++err_disable_slot_supply:
++	regulator_set_enable(pci->slot_3v3, false);
++
++	return ret;
++}
++
++int sun55i_pcie_plat_hw_init(struct udevice *dev)
++{
++	struct sun55i_pcie *pci = dev_get_priv(dev);
++	int ret;
++
++	printf("PCIe: Acquiring resources...\n");
++
++	ret = dev_read_u32(dev, "num-lanes", &pci->lanes);
++	if (ret) {
++		printf("PCIe: Failed to parse num-lanes, using default: 1\n");
++		pci->lanes = 1;
++	}
++
++	ret = dev_read_u32(dev, "max-link-speed", &pci->link_gen);
++	if (ret) {
++		printf("PCIe: Couldn't parse max-link-speed, using default link speed: Gen2\n");
++		pci->link_gen = 2;
++	}
++
++	if (pci->lanes != 1 && pci->lanes != 2 && pci->lanes != 4) {
++		printf("PCIe: Invalid num-lanes %d, using 1\n", pci->lanes);
++		pci->lanes = 1;
++	}
++
++	if (pci->link_gen < 1 || pci->link_gen > 3) {
++		printf("PCIe: Invalid max-link-speed %d, using 2\n", pci->link_gen);
++		pci->link_gen = 2;
++	}
++
++	ret = gpio_request_by_name(dev, "switch-sel-gpios", 0, &pci->switch_gpio, GPIOD_IS_OUT);
++	if (ret) {
++		printf("PCIe: Failed to get switch-sel GPIO: %d\n", ret);
++		return ret;
++	}
++
++	ret = gpio_request_by_name(dev, "reset-gpios", 0, &pci->rst_gpio,
++                               GPIOD_IS_OUT);
++    if (ret) {
++        printf("PCIe: Failed to get reset-gpios: %d\n", ret);
++        return ret;
++    }
++
++    ret = gpio_request_by_name(dev, "wake-gpios", 0, &pci->wake_gpio,
++                               GPIOD_IS_OUT);
++    if (ret) {
++        printf("PCIe: Warning: Failed to get wake-gpios: %d\n", ret);
++    }
++
++	ret = device_get_supply_regulator(dev, "slot-3v3-supply", &pci->slot_3v3);
++	if (ret) {
++		printf("PCIe: Failed to get 3.3V slot supply: %d\n", ret);
++		return ret;
++	}
++
++	ret = clk_get_by_name(dev, "pclk_aux", &pci->pcie_aux);
++	if (ret) {
++		printf("PCIe: Failed to get bus clock: %d\n", ret);
++		return ret;
++	}
++
++	pci->drvdata = (const struct sun55i_pcie_of_data *)dev_get_driver_data(dev);
++	if (pci->drvdata && pci->drvdata->need_pcie_rst) {
++		ret = reset_get_by_index(dev, 0, &pci->pcie_rst);
++		if (ret) {
++			printf("PCIe: Failed to get reset controller: %d\n", ret);
++			return ret;
++		}
++	}
++
++	ret = generic_phy_get_by_index(dev, 0, &pci->phy);
++	if (ret) {
++		printf("PCIe: Failed to get phy: %d\n", ret);
++		return ret;
++	}
++
++	printf("PCIe: All resources acquired. Starting power-on sequence...\n");
++
++	return sun55i_pcie_plat_init_port(dev);
++
++}
++
++
++
+diff --git a/drivers/pci/pcie-sun55i.c b/drivers/pci/pcie-sun55i.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/pci/pcie-sun55i.c
+@@ -0,0 +1,498 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * sun55i DesignWare based PCIe host controller driver
++ *
++ * Copyright (c) 2021 sun55i, Inc.
++ */
++
++
++#include <dm.h>
++#include <syscon.h>
++#include <asm/io.h>
++#include <asm/arch-sunxi/clock.h>
++#include <linux/iopoll.h>
++#include <linux/ioport.h>
++#include "pcie-sun55i.h"
++
++DECLARE_GLOBAL_DATA_PTR;
++
++#define sun55i_pcie_DBG			0
++
++#define __pcie_dev_print_emit(fmt, ...) \
++({ \
++	printf(fmt, ##__VA_ARGS__); \
++})
++
++#ifdef dev_err
++#undef dev_err
++#define dev_err(dev, fmt, ...) \
++({ \
++	if (dev) \
++		__pcie_dev_print_emit("%s: " fmt, dev->name, \
++				##__VA_ARGS__); \
++})
++#endif
++
++#ifdef dev_info
++#undef dev_info
++#define dev_info dev_err
++#endif
++
++#ifdef DEBUG
++#define dev_dbg dev_err
++#else
++#define dev_dbg(dev, fmt, ...)					\
++({								\
++	if (0)							\
++		__dev_printk(7, dev, fmt, ##__VA_ARGS__);	\
++})
++#endif
++
++
++
++static int sun55i_pcie_addr_valid(pci_dev_t d, int first_busno)
++{
++	if ((PCI_BUS(d) == first_busno) && (PCI_DEV(d) > 0))
++		return 0;
++	if ((PCI_BUS(d) == first_busno + 1) && (PCI_DEV(d) > 0))
++		return 0;
++
++	return 1;
++}
++
++static void sun55i_pcie_prog_outbound_atu(struct sun55i_pcie_port *pp, int index, int type,
++					u64 cpu_addr, u64 pci_addr, u32 size)
++{
++	struct sun55i_pcie *pci = to_sun55i_pcie_from_pp(pp);
++
++
++	sun55i_pcie_writel_dbi(pci, PCIE_ATU_LOWER_BASE_OUTBOUND(index), lower_32_bits(cpu_addr));
++	sun55i_pcie_writel_dbi(pci, PCIE_ATU_UPPER_BASE_OUTBOUND(index), upper_32_bits(cpu_addr));
++	sun55i_pcie_writel_dbi(pci, PCIE_ATU_LIMIT_OUTBOUND(index), lower_32_bits(cpu_addr + size - 1));
++	sun55i_pcie_writel_dbi(pci, PCIE_ATU_LOWER_TARGET_OUTBOUND(index), lower_32_bits(pci_addr));
++	sun55i_pcie_writel_dbi(pci, PCIE_ATU_UPPER_TARGET_OUTBOUND(index), upper_32_bits(pci_addr));
++	sun55i_pcie_writel_dbi(pci, PCIE_ATU_CR1_OUTBOUND(index), type);
++	sun55i_pcie_writel_dbi(pci, PCIE_ATU_CR2_OUTBOUND(index), PCIE_ATU_ENABLE);
++}
++
++static int sun55i_pcie_rd_other_conf(struct sun55i_pcie_port *pp, pci_dev_t d, int where, int size, ulong *val)
++{
++	int ret = PCIBIOS_SUCCESSFUL, type;
++	u64 busdev;
++	u64 atu_cpu_addr = pp->cfg0_base;
++
++	if (pp->cpu_pcie_addr_quirk)
++		atu_cpu_addr -= PCIE_CPU_BASE;
++
++	busdev = PCIE_ATU_BUS(PCI_BUS(d)) | PCIE_ATU_DEV(PCI_DEV(d)) | PCIE_ATU_FUNC(PCI_FUNC(d));
++
++	if (PCI_BUS(d) != 0)
++		type = PCIE_ATU_TYPE_CFG0;
++	else
++		type = PCIE_ATU_TYPE_CFG1;
++
++	sun55i_pcie_prog_outbound_atu(pp, PCIE_ATU_INDEX0, type, atu_cpu_addr, busdev, pp->cfg0_size);
++
++	ret = sun55i_pcie_cfg_read(pp->va_cfg0_base + where, size, val);
++
++	return ret;
++}
++
++static int sun55i_pcie_wr_other_conf(struct sun55i_pcie_port *pp, pci_dev_t d, int where, int size, ulong val)
++{
++	int ret = PCIBIOS_SUCCESSFUL, type;
++	u64 busdev;
++	u64 atu_cpu_addr = pp->cfg0_base; 
++
++	if (pp->cpu_pcie_addr_quirk)
++		atu_cpu_addr -= PCIE_CPU_BASE; 
++
++	busdev = PCIE_ATU_BUS(PCI_BUS(d)) | PCIE_ATU_DEV(PCI_DEV(d)) | PCIE_ATU_FUNC(PCI_FUNC(d));
++
++	if (PCI_BUS(d) != 0)
++		type = PCIE_ATU_TYPE_CFG0;
++	else
++		type = PCIE_ATU_TYPE_CFG1;
++
++	sun55i_pcie_prog_outbound_atu(pp, PCIE_ATU_INDEX0, type, atu_cpu_addr, busdev, pp->cfg0_size);
++
++	ret = sun55i_pcie_cfg_write(pp->va_cfg0_base + where, size, val);
++
++	return ret;
++}
++
++static int sun55i_pcie_host_rd_own_conf(struct sun55i_pcie_port *pp, int where, int size, ulong *val)
++{
++	int ret;
++
++	ret = sun55i_pcie_cfg_read(pp->dbi_base + where, size, val);
++
++	return ret;
++}
++
++static int sun55i_pcie_host_wr_own_conf(struct sun55i_pcie_port *pp, int where, int size, ulong val)
++{
++	int ret;
++
++	ret = sun55i_pcie_cfg_write(pp->dbi_base + where, size, val);
++
++	return ret;
++}
++
++static int sun55i_pcie_read_config(const struct udevice *bus, pci_dev_t bdf,
++				 uint offset, ulong *value,
++				 enum pci_size_t size)
++{
++	struct sun55i_pcie *pcie = dev_get_priv(bus);
++	int ret, size_len = 4;
++
++	if (!sun55i_pcie_addr_valid(bdf, pcie->first_busno)) {
++		debug("- out of range\n");
++		*value = pci_get_ff(size);
++		return 0;
++	}
++
++	if (size == PCI_SIZE_8)
++		size_len = 1;
++	else if (size == PCI_SIZE_16)
++		size_len = 2;
++	else if (size == PCI_SIZE_32)
++		size_len = 4;
++
++	if (PCI_BUS(bdf) != pcie->first_busno)
++               ret = sun55i_pcie_rd_other_conf(&pcie->pcie_port, bdf, offset, size_len, value);
++        else
++               ret = sun55i_pcie_host_rd_own_conf(&pcie->pcie_port, offset, size_len, value);
++
++	return ret;
++}
++
++static int sun55i_pcie_write_config(struct udevice *bus, pci_dev_t bdf,
++				 uint offset, ulong value,
++				 enum pci_size_t size)
++{
++	struct sun55i_pcie *pcie = dev_get_priv(bus);
++	int ret, size_len = 4;
++
++	if (!sun55i_pcie_addr_valid(bdf, pcie->first_busno)) {
++		debug("- out of range\n");
++		return 0;
++	}
++
++	if (size == PCI_SIZE_8)
++		size_len = 1;
++	else if (size == PCI_SIZE_16)
++	size_len = 2;
++	else if (size == PCI_SIZE_32)
++		size_len = 4;
++
++	if (PCI_BUS(bdf) != 0)
++		ret = sun55i_pcie_wr_other_conf(&pcie->pcie_port, bdf, offset, size_len, value);
++	else
++		ret = sun55i_pcie_host_wr_own_conf(&pcie->pcie_port, offset, size_len, value);
++
++	return ret;
++}
++
++static void sun55i_pcie_host_setup_rc(struct sun55i_pcie_port *pp)
++{
++	ulong val, i;
++	phys_addr_t mem_base;
++	phys_addr_t io_base;
++	struct sun55i_pcie *pci = to_sun55i_pcie_from_pp(pp);
++
++	sun55i_pcie_plat_set_rate(pci);
++
++	sun55i_pcie_writel_dbi(pci, PCI_BASE_ADDRESS_0, 0x4);
++	sun55i_pcie_writel_dbi(pci, PCI_BASE_ADDRESS_1, 0x0);
++
++	val = sun55i_pcie_readl_dbi(pci, PCI_INTERRUPT_LINE);
++	val &= PCIE_INTERRUPT_LINE_MASK;
++	val |= PCIE_INTERRUPT_LINE_ENABLE;
++	sun55i_pcie_writel_dbi(pci, PCI_INTERRUPT_LINE, val);
++
++	val = sun55i_pcie_readl_dbi(pci, PCI_PRIMARY_BUS);
++	val &= 0xff000000;
++	val |= 0x00ff0100;
++	sun55i_pcie_writel_dbi(pci, PCI_PRIMARY_BUS, val);
++
++	val = sun55i_pcie_readl_dbi(pci, PCI_COMMAND);
++
++	val &= PCIE_HIGH16_MASK;
++	val |= PCI_COMMAND_IO | PCI_COMMAND_MEMORY |
++		PCI_COMMAND_MASTER | PCI_COMMAND_SERR;
++
++	sun55i_pcie_writel_dbi(pci, PCI_COMMAND, val);
++
++	if (IS_ENABLED(CONFIG_PCI_MSI) && !pp->has_its) {
++		for (i = 0; i < 8; i++) {
++			sun55i_pcie_host_wr_own_conf(pp, PCIE_MSI_INTR_ENABLE(i), 4, ~0);
++		}
++	}
++
++	if (pp->cpu_pcie_addr_quirk) {
++		mem_base = pp->mem_base - PCIE_CPU_BASE;
++		io_base = pp->io_base - PCIE_CPU_BASE;
++	} else {
++		mem_base = pp->mem_base;
++		io_base = pp->io_base;
++	}
++
++	sun55i_pcie_prog_outbound_atu(pp, PCIE_ATU_INDEX1, PCIE_ATU_TYPE_MEM,
++					  mem_base, pp->mem_bus_addr, pp->mem_size);
++
++	sun55i_pcie_prog_outbound_atu(pp, PCIE_ATU_INDEX2, PCIE_ATU_TYPE_IO,
++					  io_base, pp->io_bus_addr, pp->io_size);
++
++	sun55i_pcie_host_wr_own_conf(pp, PCI_BASE_ADDRESS_0, 4, 0);
++
++	sun55i_pcie_dbi_ro_wr_en(pci);
++
++	sun55i_pcie_host_wr_own_conf(pp, PCI_CLASS_DEVICE, 2, PCI_CLASS_BRIDGE_PCI);
++
++	sun55i_pcie_dbi_ro_wr_dis(pci);
++
++	sun55i_pcie_host_rd_own_conf(pp, PCIE_LINK_WIDTH_SPEED_CONTROL, 4, &val);
++	val |= PORT_LOGIC_SPEED_CHANGE;
++	sun55i_pcie_host_wr_own_conf(pp, PCIE_LINK_WIDTH_SPEED_CONTROL, 4, val);
++}
++
++static int sun55i_pcie_host_link_up_status(struct sun55i_pcie_port *pp)
++{
++	u32 val;
++	int ret;
++	struct sun55i_pcie *pcie = to_sun55i_pcie_from_pp(pp);
++
++	val = sun55i_pcie_readl(pcie, PCIE_LINK_STAT);
++
++	if ((val & RDLH_LINK_UP) && (val & SMLH_LINK_UP))
++		ret = 1;
++	else
++		ret = 0;
++
++    printf("  Link Status: 0x%08x\n", val);
++    printf("  RDLH_LINK_UP: %d\n", !!(val & RDLH_LINK_UP));
++    printf("  SMLH_LINK_UP: %d\n", !!(val & SMLH_LINK_UP));
++    printf("  LINK_SPEED: %d\n", (val >> 16) & 0xF);
++    printf("  LINK_WIDTH: %d\n", (val >> 20) & 0x3F);
++
++	return ret;
++}
++
++static int sun55i_pcie_host_link_up(struct sun55i_pcie_port *pp)
++{
++	 return sun55i_pcie_host_link_up_status(pp);
++}
++
++static int sun55i_pcie_host_wait_for_link(struct sun55i_pcie_port *pp)
++{
++	int retries;
++
++	for (retries = 0; retries < LINK_WAIT_MAX_RETRIE; retries++) {
++		if (sun55i_pcie_host_link_up(pp)) {
++			printf("pcie link up success\n");
++			return 0;
++		}
++		mdelay(1);
++	}
++
++	return -ETIMEDOUT;
++}
++
++static int sun55i_pcie_host_establish_link(struct sun55i_pcie *pci)
++{
++	struct sun55i_pcie_port *pp = &pci->pcie_port;
++
++	if (sun55i_pcie_host_link_up(pp)) {
++		printf("pcie is already link up\n");
++		return 0;
++	}
++
++	sun55i_pcie_plat_ltssm_enable(pci);
++
++	return sun55i_pcie_host_wait_for_link(pp);
++}
++
++static int sun55i_pcie_host_wait_for_speed_change(struct sun55i_pcie *pci)
++{
++	u32 tmp;
++	unsigned int retries;
++
++	for (retries = 0; retries < LINK_WAIT_MAX_RETRIE; retries++) {
++		tmp = sun55i_pcie_readl_dbi(pci, PCIE_LINK_WIDTH_SPEED_CONTROL);
++		if (!(tmp & PORT_LOGIC_SPEED_CHANGE))
++			return 0;
++		mdelay(1);
++	}
++
++	printf("Speed change timeout\n");
++	return -ETIMEDOUT;
++}
++
++static int sun55i_pcie_host_speed_change(struct sun55i_pcie *pci, int gen)
++{
++    u32 val;
++    int ret;
++    u8 offset;
++
++    sun55i_pcie_dbi_ro_wr_en(pci);
++
++    offset = sun55i_pcie_plat_find_capability(pci, PCI_CAP_ID_EXP);
++    if (!offset) {
++        printf("PCIe: Cannot find PCI Express capability\n");
++        sun55i_pcie_dbi_ro_wr_dis(pci);
++        return -EINVAL;
++    }
++
++    val = sun55i_pcie_readl_dbi(pci, LINK_CONTROL2_LINK_STATUS2);
++    val &= ~PCI_EXP_LNKCTL2_TLS;
++    val |= gen;
++    sun55i_pcie_writel_dbi(pci, LINK_CONTROL2_LINK_STATUS2, val);
++
++    val = sun55i_pcie_readl_dbi(pci, PCIE_LINK_WIDTH_SPEED_CONTROL);
++    val &= ~PORT_LOGIC_SPEED_CHANGE;
++    sun55i_pcie_writel_dbi(pci, PCIE_LINK_WIDTH_SPEED_CONTROL, val);
++
++    val = sun55i_pcie_readl_dbi(pci, PCIE_LINK_WIDTH_SPEED_CONTROL);
++    val |= PORT_LOGIC_SPEED_CHANGE;
++    sun55i_pcie_writel_dbi(pci, PCIE_LINK_WIDTH_SPEED_CONTROL, val);
++
++    ret = sun55i_pcie_host_wait_for_speed_change(pci);
++    if (!ret)
++        printf("PCIe: Link active at Gen%d\n", gen);
++    else
++        printf("PCIe: Link active, but speed change failed (remains Gen1)\n");
++
++    sun55i_pcie_dbi_ro_wr_dis(pci);
++
++    return 0;
++}
++
++static void sun55i_pcie_host_init(struct udevice *dev)
++{
++	struct sun55i_pcie *pci = dev_get_priv(dev);
++
++	sun55i_pcie_plat_ltssm_disable(pci);
++    
++	sun55i_pcie_host_setup_rc(&pci->pcie_port);
++
++	sun55i_pcie_host_establish_link(pci);
++
++	sun55i_pcie_host_speed_change(pci, pci->link_gen);
++}
++
++static int sun55i_pcie_probe(struct udevice *dev)
++{
++	struct sun55i_pcie *pci = dev_get_priv(dev);
++	struct udevice *ctlr = pci_get_controller(dev);
++	struct pci_controller *hose = dev_get_uclass_priv(ctlr);
++	const struct sun55i_pcie_of_data *data;
++	int ret;
++
++	data = (const struct sun55i_pcie_of_data *)dev_get_driver_data(dev);
++	if (!data) {
++		printf("PCIe: No platform data found\n");
++		return -EINVAL;
++	}
++
++	ret = sun55i_pcie_plat_hw_init(dev);
++	if (ret) {
++		printf("PCIe: Hardware init failed with error %d\n", ret);
++		return ret;
++	}
++
++	pci->first_busno = dev->seq_;
++	pci->dev = dev;
++
++	pci->dbi_base = (void __iomem *)phys_to_virt((phys_addr_t)data->dbi_addr);
++	pci->app_base = (void __iomem *)((char *)pci->dbi_base + PCIE_USER_DEFINED_REGISTER);
++
++	printf("PCIe: Disabling DBI write protection...\n");
++	sun55i_pcie_dbi_ro_wr_en(pci);
++
++	pci_set_region(&hose->regions[0],
++			data->io_addr,
++			data->io_addr,
++			data->io_size,
++			PCI_REGION_IO);
++
++	pci_set_region(&hose->regions[1],
++			data->mem_addr,
++			data->mem_addr,
++			data->mem_size,
++			PCI_REGION_MEM);
++
++	hose->region_count = 2;
++
++	pci->pcie_port.dbi_base = (void __iomem *)phys_to_virt((phys_addr_t)data->dbi_addr);
++	pci->pcie_port.cfg0_base = data->cfg_addr;
++	pci->pcie_port.cfg0_size = data->cfg_size;
++	pci->pcie_port.io_base   = data->io_addr;
++	pci->pcie_port.io_size   = data->io_size;
++	pci->pcie_port.mem_base  = data->mem_addr;
++	pci->pcie_port.mem_size  = data->mem_size;
++
++	pci->pcie_port.io_bus_addr  = data->io_addr;
++	pci->pcie_port.mem_bus_addr = data->mem_addr;
++
++	if (!pci->lanes)
++		pci->lanes = data->num_lanes;
++	if (!pci->link_gen)
++		pci->link_gen = data->max_link_speed;
++
++	pci->pcie_port.cpu_pcie_addr_quirk = true;
++
++	pci->pcie_port.va_cfg0_base = phys_to_virt(pci->pcie_port.cfg0_base);
++
++	printf("PCIe: DBI  region: 0x%08x-0x%08x\n", data->dbi_addr, data->dbi_addr + data->dbi_size);
++	printf("PCIe: IO   region: 0x%08x-0x%08x\n", data->io_addr, data->io_addr + data->io_size);
++	printf("PCIe: MEM  region: 0x%08x-0x%08x\n", data->mem_addr, data->mem_addr + data->mem_size);
++	printf("PCIe: CFG  region: 0x%08x-0x%08x\n", data->cfg_addr, data->cfg_addr + data->cfg_size);
++	printf("PCIe: Lanes: %d, Max Speed: Gen%d\n", data->num_lanes, data->max_link_speed);
++
++	sun55i_pcie_host_init(dev);
++	
++	sun55i_pcie_dbi_ro_wr_dis(pci);
++
++	return 0;
++}
++
++static const struct dm_pci_ops sun55i_pcie_ops = {
++	.read_config	= sun55i_pcie_read_config,
++	.write_config	= sun55i_pcie_write_config,
++};
++
++static const struct sun55i_pcie_of_data sun55i_pcie_rc_v210_of_data = {
++    .mode = SUN55I_PCIE_RC_TYPE,
++	.cpu_pcie_addr_quirk = true,
++
++    .dbi_addr       = 0x04800000,
++    .dbi_size       = 0x480000,
++    .io_addr        = 0x21000000,
++    .io_size        = 0x01000000,
++    .mem_addr       = 0x22000000,
++    .mem_size       = 0x0e000000,
++    .cfg_addr       = 0x20000000,  
++    .cfg_size       = 0x01000000,
++    .num_lanes      = 1,           /* Default */
++    .max_link_speed = 2,
++    .num_ib_windows = 8,
++    .num_ob_windows = 8,
++};
++
++static const struct udevice_id sun55i_pcie_ids[] = {
++	{
++		.compatible = "allwinner,sun55i-pcie-v210-rc",
++		.data = (ulong)&sun55i_pcie_rc_v210_of_data,
++	},
++	{ }
++};
++
++U_BOOT_DRIVER(sun55i_pcie) = {
++	.name			= "pcie_dw_sun55i",
++	.id			= UCLASS_PCI,
++	.of_match		= sun55i_pcie_ids,
++	.ops			= &sun55i_pcie_ops,
++	.probe			= sun55i_pcie_probe,
++	.priv_auto 	= sizeof(struct sun55i_pcie),
++};
+diff --git a/drivers/pci/pcie-sun55i.h b/drivers/pci/pcie-sun55i.h
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/pci/pcie-sun55i.h
+@@ -0,0 +1,490 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/* Copyright(c) 2020 - 2023 Allwinner Technology Co.,Ltd. All rights reserved. */
++/*
++ * Allwinner PCIe controller driver
++ *
++ * Copyright (C) 2022 allwinner Co., Ltd.
++ *
++ * Author: songjundong <songjundong@allwinnertech.com>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License version 2 as
++ * published by the Free Software Foundation.
++ */
++#ifndef _PCIE_SUN55I_H
++#define _PCIE_SUN55I_H
++
++#include <asm/io.h>
++#include <asm/gpio.h>
++#include <clk.h>
++#include <reset.h>
++#include <generic-phy.h>
++#include <pci.h>
++#include <power-domain.h>
++#include <power/regulator.h>
++#include <asm/io.h> 
++#include <asm/gpio.h>
++#include <errno.h>  
++
++#define SUN55I_PCIE_MODULE_VERSION	"1.0.0"
++
++#define SUN55I_PCIE_CFG_SIZE	0x01000000
++
++#define SUN55I_CFG_RW_SIZE 0x04
++
++#define PCIE_PORT_LINK_CONTROL			0x710
++#define PORT_LINK_MODE_MASK			(0x3f << 16)
++#define PORT_LINK_MODE_1_LANES			(0x1 << 16)
++#define PORT_LINK_MODE_2_LANES			(0x3 << 16)
++#define PORT_LINK_MODE_4_LANES			(0x7 << 16)
++#define PORT_LINK_LPBK_ENABLE		        (0x1 << 2)
++
++#define PCIE_LINK_WIDTH_SPEED_CONTROL		0x80C
++#define PORT_LOGIC_SPEED_CHANGE			(0x1 << 17)
++#define PORT_LOGIC_LINK_WIDTH_MASK		(0x1ff << 8)
++#define PORT_LOGIC_LINK_WIDTH_1_LANES		(0x1 << 8)
++#define PORT_LOGIC_LINK_WIDTH_2_LANES		(0x2 << 8)
++#define PORT_LOGIC_LINK_WIDTH_4_LANES		(0x4 << 8)
++
++#define PCIE_ATU_VIEWPORT			0x900
++#define PCIE_ATU_REGION_INBOUND			(0x1 << 31)
++#define PCIE_ATU_REGION_OUTBOUND		(0x0 << 31)
++#define PCIE_ATU_REGION_INDEX2			(0x2 << 0)
++#define PCIE_ATU_REGION_INDEX1			(0x1 << 0)
++#define PCIE_ATU_REGION_INDEX0			(0x0 << 0)
++
++#define PCIE_ATU_INDEX0				0x0
++#define PCIE_ATU_INDEX1				0x1
++#define PCIE_ATU_INDEX2				0x2
++#define PCIE_ATU_INDEX3				0x3
++#define PCIE_ATU_INDEX4				0x4
++#define PCIE_ATU_INDEX5				0x5
++#define PCIE_ATU_INDEX6				0x6
++#define PCIE_ATU_INDEX7				0x7
++
++#define PCIE_EP_REBAR_SIZE_32M			0x200
++
++#define PCIE_ATU_CR1_OUTBOUND(reg)		(0x300000 + ((reg) * 0x200))
++#define PCIE_ATU_TYPE_MEM			(0x0 << 0)
++#define PCIE_ATU_TYPE_IO			(0x2 << 0)
++#define PCIE_ATU_TYPE_CFG0			(0x4 << 0)
++#define PCIE_ATU_TYPE_CFG1			(0x5 << 0)
++#define PCIE_ATU_CR2_OUTBOUND(reg)		(0x300004 + ((reg) * 0x200))
++#define PCIE_ATU_DMA_BYPASS			BIT(27)
++#define PCIE_ATU_BAR_MODE_ENABLE		BIT(30)
++#define PCIE_ATU_ENABLE				BIT(31)
++
++#define PCIE_ATU_LOWER_BASE_OUTBOUND(reg)	(0x300008 + ((reg) * 0x200))
++#define PCIE_ATU_UPPER_BASE_OUTBOUND(reg)	(0x30000c + ((reg) * 0x200))
++#define PCIE_ATU_LIMIT_OUTBOUND(reg)		(0x300010 + ((reg) * 0x200))
++#define PCIE_ATU_LOWER_TARGET_OUTBOUND(reg)	(0x300014 + ((reg) * 0x200))
++#define PCIE_ATU_UPPER_TARGET_OUTBOUND(reg)	(0x300018 + ((reg) * 0x200))
++
++#define PCIE_ATU_CR1_INBOUND(reg)		(0x300100 + ((reg) * 0x200))
++#define PCIE_ATU_TYPE_MEM			(0x0 << 0)
++#define PCIE_ATU_TYPE_IO			(0x2 << 0)
++#define PCIE_ATU_TYPE_CFG0			(0x4 << 0)
++#define PCIE_ATU_TYPE_CFG1			(0x5 << 0)
++#define PCIE_ATU_FUNC_NUM(pf)			((pf) << 20)
++#define PCIE_ATU_CR2_INBOUND(reg)		(0x300104 + ((reg) * 0x200))
++#define PCIE_ATU_MATCH_MODE			BIT(30)
++#define PCIE_ATU_FUNC_NUM_MATCH_EN		BIT(19)
++#define PCIE_ATU_FUNC_NUM(pf)			((pf) << 20)
++
++#define PCIE_ATU_LOWER_BASE_INBOUND(reg)	(0x300108 + ((reg) * 0x200))
++#define PCIE_ATU_UPPER_BASE_INBOUND(reg)	(0x30010c + ((reg) * 0x200))
++#define PCIE_ATU_LIMIT_INBOUND(reg)		(0x300110 + ((reg) * 0x200))
++#define PCIE_ATU_LOWER_TARGET_INBOUND(reg)	(0x300114 + ((reg) * 0x200))
++#define PCIE_ATU_UPPER_TARGET_INBOUND(reg)	(0x300118 + ((reg) * 0x200))
++
++#define PCIE_ATU_BUS(x)				(((x) & 0xff) << 24)
++#define PCIE_ATU_DEV(x)				(((x) & 0x1f) << 19)
++#define PCIE_ATU_FUNC(x)			(((x) & 0x7) << 16)
++
++#define PCIE_MISC_CONTROL_1_CFG			0x8bc
++#define PCIE_TYPE1_CLASS_CODE_REV_ID_REG	0x08
++
++#define PCIE_ADDRESS_ALIGNING			(~0x3)
++#define PCIE_HIGH_16				16
++#define PCIE_BAR_NUM				6
++#define PCIE_MEM_FLAGS				0x4
++#define PCIE_IO_FLAGS				0x1
++#define PCIE_BAR_REG				0x4
++#define PCIE_HIGH16_MASK			0xffff0000
++#define PCIE_LOW16_MASK				0x0000ffff
++#define PCIE_INTERRUPT_LINE_MASK		0xffff00ff
++#define PCIE_INTERRUPT_LINE_ENABLE		0x00000100
++#define	PCIE_PRIMARY_BUS_MASK			0xff000000
++#define PCIE_PRIMARY_BUS_ENABLE			0x00010100
++#define PCIE_MEMORY_MASK			0xfff00000
++
++#define PCIE_CPU_BASE				0x20000000
++
++#define PCIE_TYPE0_STATUS_COMMAND_REG		0x4
++
++#define PCIE_DBI2_BASE				0x100000
++#define DBI2_FUNC_OFFSET			0x10000
++#define BAR_ENABLE				0x1
++
++#define RESBAR_CAP_REG				0x4 /* from PCIe spec4.0 7.8.6  */
++#define  RESBAR_SIZE_MASK			0xfffff0
++#define RESBAR_CTL_REG				0x8
++#define RESBAR_NEXT_BAR				0x8
++#define SIZE_OF_1MB				20 /* 2^20 = 0x100000 */
++
++#define PCIE_COMBO_PHY_BGR		0x04
++#define PHY_ACLK_EN			BIT(17)
++#define PHY_HCLK_EN			BIT(16)
++#define PHY_TERSTN			BIT(1)
++#define PHY_PW_UP_RSTN			BIT(0)
++#define PCIE_COMBO_PHY_CTL		0x10
++#define PHY_USE_SEL			BIT(31)	/* 0:PCIE; 1:USB3 */
++#define	PHY_CLK_SEL			BIT(30) /* 0:internal clk; 1:exteral clk */
++#define PHY_BIST_EN			BIT(16)
++#define PHY_PIPE_SW			BIT(9)
++#define PHY_PIPE_SEL			BIT(8)  /* 0:PIPE resetn ctrl by PCIE ctrl; 1:PIPE resetn ctrl by  */
++#define PHY_PIPE_CLK_INVERT		BIT(4)
++#define PHY_FPGA_SYS_RSTN		BIT(1)  /* for PFGA  */
++#define PHY_RSTN			BIT(0)
++
++#define NEXT_CAP_PTR_MASK		0xff00
++#define CAP_ID_MASK			0x00ff
++
++/* Error values that may be returned by PCI functions */
++#define PCIBIOS_SUCCESSFUL		0x00
++#define PCIBIOS_FUNC_NOT_SUPPORTED	0x81
++#define PCIBIOS_BAD_VENDOR_ID		0x83
++#define PCIBIOS_DEVICE_NOT_FOUND	0x86
++#define PCIBIOS_BAD_REGISTER_NUMBER	0x87
++#define PCIBIOS_SET_FAILED		0x88
++#define PCIBIOS_BUFFER_TOO_SMALL	0x89
++
++/*
++ * Maximum number of MSI IRQs can be 256 per controller. But keep
++ * it 32 as of now. Probably we will never need more than 32. If needed,
++ * then increment it in multiple of 32.
++ */
++#define INT_PCI_MSI_NR			32
++#define MAX_MSI_IRQS			256
++#define MAX_MSI_IRQS_PER_CTRL		32
++#define MAX_MSI_CTRLS			(MAX_MSI_IRQS / MAX_MSI_IRQS_PER_CTRL)
++#define MSI_REG_CTRL_BLOCK_SIZE		12
++
++/* #define MAX_MSI_IRQS			32 */
++/* #define MAX_MSI_CTRLS		(MAX_MSI_IRQS / 32) */
++#define PCIE_LINK_WIDTH_SPEED_CONTROL	0x80C
++#define PORT_LOGIC_SPEED_CHANGE		(0x1 << 17)
++#define LINK_CONTROL2_LINK_STATUS2	0xa0
++/* Parameters for the waiting for link up routine */
++#define LINK_WAIT_MAX_RETRIE		20
++#define LINK_WAIT_USLEEP_MIN		90000
++#define LINK_WAIT_USLEEP_MAX		100000
++#define SPEED_CHANGE_USLEEP_MIN		100
++#define SPEED_CHANGE_USLEEP_MAX		1000
++
++#define PCIE_MSI_ADDR_LO		0x820
++#define PCIE_MSI_ADDR_HI		0x824
++#define PCIE_MSI_INTR_ENABLE(reg)	(0x828 + ((reg) * 0x0c))
++/* #define PCIE_MSI_INTR_MASK(reg)	(0x82C + ((reg) * 0x0c)) */
++/* #define PCIE_MSI_INTR_STATUS(reg)	(0x830 + ((reg) * 0x0c)) */
++/* #define PCIE_MSI_INTR_ENABLE		0x828 */
++#define PCIE_MSI_INTR_MASK		0x82C
++#define PCIE_MSI_INTR_STATUS		0x830
++
++#define PCIE_CTRL_MGMT_BASE		0x900000
++
++#define PCIE_USER_DEFINED_REGISTER	0x400000
++#define PCIE_VER			0x00
++#define PCIE_ADDR_PAGE_CFG		0x04
++#define PCIE_AWMISC_CTRL		0x200
++#define PCIE_ARMISC_CTRL		0x220
++#define PCIE_LTSSM_CTRL			0xc00
++#define PCIE_LINK_TRAINING		BIT(0) /* 0:disable; 1:enable  */
++#define DEVICE_TYPE_MASK		GENMASK(7, 4)
++#define DEVICE_TYPE_RC			BIT(6)
++#define PCIE_INT_ENABLE_CLR		0xE04  /* BIT(1):RDLH_LINK_MASK; BIT(0):SMLH_LINK_MASK  */
++#define PCIE_LINK_STAT			0xE0C  /* BIT(1):RDLH_LINK;      BIT(0):SMLH_LINK  */
++#define RDLH_LINK_UP			BIT(1)
++#define SMLH_LINK_UP			BIT(0)
++#define PCIE_LINK_INT_EN		(BIT(0) | BIT(1))
++
++#define PCIE_PHY_CFG			0x800
++#define SYS_CLK				0
++#define PAD_CLK				1
++#define PCIE_LINK_UP_MASK		(0x3<<16)
++
++#define PCIE_RC_RP_ATS_BASE		0x400000
++
++#define SUN55I_PCIE_BAR_CFG_CTRL_DISABLED		0x0
++#define SUN55I_PCIE_BAR_CFG_CTRL_IO_32BITS		0x1
++#define SUN55I_PCIE_BAR_CFG_CTRL_MEM_32BITS		0x4
++#define SUN55I_PCIE_BAR_CFG_CTRL_PREFETCH_MEM_32BITS	0x5
++#define SUN55I_PCIE_BAR_CFG_CTRL_MEM_64BITS		0x6
++#define SUN55I_PCIE_BAR_CFG_CTRL_PREFETCH_MEM_64BITS	0x7
++
++#define SUN55I_PCIE_EP_MSI_CTRL_REG			0x90
++#define SUN55I_PCIE_EP_MSI_CTRL_MMC_OFFSET		17
++#define SUN55I_PCIE_EP_MSI_CTRL_MMC_MASK			GENMASK(19, 17)
++#define SUN55I_PCIE_EP_MSI_CTRL_MME_OFFSET		20
++#define SUN55I_PCIE_EP_MSI_CTRL_MME_MASK			GENMASK(22, 20)
++#define SUN55I_PCIE_EP_MSI_CTRL_ME			BIT(16)
++#define SUN55I_PCIE_EP_MSI_CTRL_MASK_MSI_CAP		BIT(24)
++#define SUN55I_PCIE_EP_DUMMY_IRQ_ADDR			0x1
++
++#define PCIE_PHY_FUNC_CFG		(PCIE_CTRL_MGMT_BASE + 0x2c0)
++#define PCIE_RC_BAR_CONF		(PCIE_CTRL_MGMT_BASE + 0x300)
++
++//ECC
++#define PCIE_RASDP_ERR_PROT_CTRL_OFF			0X1F0
++#define PCIE_RASDP_ERR_INJ_CTRL_OFF			0X204
++#define PCIE_RASDP_UNCORR_COUNTER_CTRL_OFF		0X1FC
++#define PCIE_RASDP_UNCORR_COUNTER_REPORT_OFF		0X200
++#define PCIE_RASDP_UNCORR_ERROR_LOCATION_OFF		0X20C
++#define PCIE_RASDP_ERROR_MODR_CLEAR_OFF			0X214
++
++#define PCIE_RASDP_CORR_COUNTER_CTRL_OFF		0X1F4
++#define PCIE_RASDP_CORR_COUNTER_REPORT_OFF		0X1F8
++#define PCIE_RASDP_CORR_ERROR_LOCATION_OFF		0X208
++
++#define PCIE_SII_INT_MASK_RES2				0XE10
++#define PCIE_SII_INT_RES2				0XE18
++#define APP_PARITY_ERRS2_MASK				BIT(12)
++#define APP_PARITY_ERRS1_MASK				BIT(11)
++#define APP_PARITY_ERRS0_MASK				BIT(10)
++#define SLV_RASDP_ERR_MODE_MASK				BIT(9)
++#define MATR_RASDP_ERR_MODE_MASK			BIT(8)
++#define RASDP_ERR_PENDING 				(BIT(8) | BIT(9) | BIT(10) | BIT(11) | BIT(12))
++#define PCIE_SII_INT_RES2_ECC_MASK 			GENMASK(12, 8)
++
++#define  PCI_EXP_LNKCTL2_TLS		0x000f
++#define PCI_EXP_LNKCTL2_TLS_2_5GT	0x0001 /* Supported Speed 2.5GT/s */
++#define PCI_EXP_LNKCTL2_TLS_5_0GT	0x0002 /* Supported Speed 5GT/s */
++#define PCI_EXP_LNKCTL2_TLS_8_0GT	0x0003 /* Supported Speed 8GT/s */
++#define PCI_EXP_LNKCTL2_TLS_16_0GT	0x0004 /* Supported Speed 16GT/s */
++#define PCI_EXP_LNKCTL2_TLS_32_0GT	0x0005 /* Supported Speed 32GT/s */
++#define PCI_EXP_LNKCTL2_HASD		0x0020 /* HW Autonomous Speed Disable */
++
++#define PCI_EXP_LNKCAP		12	/* Link Capabilities */
++#define PCI_EXP_LNKCAP_SLS	0x0000000f /* Supported Link Speeds */
++#define PCI_EXP_LNKCAP_SLS_2_5GB 0x00000001 /* LNKCAP2 SLS Vector bit 0 */
++#define PCI_EXP_LNKCAP_SLS_5_0GB 0x00000002 /* LNKCAP2 SLS Vector bit 1 */
++#define PCI_EXP_LNKCAP_MLW	0x000003f0 /* Maximum Link Width */
++#define PCI_EXP_LNKCAP_ASPMS	0x00000c00 /* ASPM Support */
++#define PCI_EXP_LNKCAP_L0SEL	0x00007000 /* L0s Exit Latency */
++#define PCI_EXP_LNKCAP_L1EL	0x00038000 /* L1 Exit Latency */
++#define PCI_EXP_LNKCAP_CLKPM	0x00040000 /* Clock Power Management */
++#define PCI_EXP_LNKCAP_SDERC	0x00080000 /* Surprise Down Error Reporting Capable */
++#define PCI_EXP_LNKCAP_DLLLARC	0x00100000 /* Data Link Layer Link Active Reporting Capable */
++#define PCI_EXP_LNKCAP_LBNC	0x00200000 /* Link Bandwidth Notification Capability */
++#define PCI_EXP_LNKCAP_PN	0xff000000 /* Port Number */
++
++#define PCI_EXP_LNKCTL2		48	/* Link Control 2 */
++#define PCI_EXP_LNKSTA2		50	/* Link Status 2 */
++#define PCI_EXP_SLTCAP2		52	/* Slot Capabilities 2 */
++#define PCI_EXP_SLTCTL2		56	/* Slot Control 2 */
++#define PCI_EXP_SLTSTA2		58	/* Slot Status 2 */
++
++
++
++/* Resizable BARs */
++#define PCI_REBAR_CAP		4	/* capability register */
++#define PCI_REBAR_CAP_SIZES		0x00FFFFF0  /* supported BAR sizes */
++#define PCI_REBAR_CTRL		8	/* control register */
++#define PCI_REBAR_CTRL_BAR_IDX		0x00000007  /* BAR index */
++#define PCI_REBAR_CTRL_NBAR_MASK	0x000000E0  /* # of resizable BARs */
++#define PCI_REBAR_CTRL_NBAR_SHIFT	5	    /* shift for # of BARs */
++#define PCI_REBAR_CTRL_BAR_SIZE	0x00001F00  /* BAR size */
++#define PCI_REBAR_CTRL_BAR_SHIFT	8	    /* shift for BAR size */
++
++#define  PCI_HEADER_TYPE_MASK		0x7f
++
++
++#define PCI_STD_NUM_BARS	6	/* Number of standard BARs */
++enum sun55i_pcie_device_mode {
++	SUN55I_PCIE_EP_TYPE,
++	SUN55I_PCIE_RC_TYPE,
++};
++
++/* See matching string table in pci_speed_string() */
++enum pci_bus_speed {
++	PCI_SPEED_33MHz			= 0x00,
++	PCI_SPEED_66MHz			= 0x01,
++	PCI_SPEED_66MHz_PCIX		= 0x02,
++	PCI_SPEED_100MHz_PCIX		= 0x03,
++	PCI_SPEED_133MHz_PCIX		= 0x04,
++	PCI_SPEED_66MHz_PCIX_ECC	= 0x05,
++	PCI_SPEED_100MHz_PCIX_ECC	= 0x06,
++	PCI_SPEED_133MHz_PCIX_ECC	= 0x07,
++	PCI_SPEED_66MHz_PCIX_266	= 0x09,
++	PCI_SPEED_100MHz_PCIX_266	= 0x0a,
++	PCI_SPEED_133MHz_PCIX_266	= 0x0b,
++	AGP_UNKNOWN			= 0x0c,
++	AGP_1X				= 0x0d,
++	AGP_2X				= 0x0e,
++	AGP_4X				= 0x0f,
++	AGP_8X				= 0x10,
++	PCI_SPEED_66MHz_PCIX_533	= 0x11,
++	PCI_SPEED_100MHz_PCIX_533	= 0x12,
++	PCI_SPEED_133MHz_PCIX_533	= 0x13,
++	PCIE_SPEED_2_5GT		= 0x14,
++	PCIE_SPEED_5_0GT		= 0x15,
++	PCIE_SPEED_8_0GT		= 0x16,
++	PCIE_SPEED_16_0GT		= 0x17,
++	PCIE_SPEED_32_0GT		= 0x18,
++	PCI_SPEED_UNKNOWN		= 0xff,
++};
++
++struct sun55i_pcie_of_data {
++	const struct sun55i_pcie_ep_ops *ops;
++	enum sun55i_pcie_device_mode mode;
++	u32 func_offset;
++	bool has_pcie_slv_clk;
++	bool need_pcie_rst;
++	bool pcie_slv_clk_400m;
++	bool has_pcie_its_clk;
++	bool has_pcie_ecc;
++	bool cpu_pcie_addr_quirk;
++	
++	u32 dbi_addr;
++	u32 dbi_size;
++	u32 io_addr;
++	u32 io_size; 
++	u32 mem_addr;
++	u32 mem_size;
++	u32 cfg_addr;
++	u32 cfg_size;
++	u32 num_lanes;
++	u32 max_link_speed;
++	u32 num_ib_windows;
++	u32 num_ob_windows;
++};
++
++struct sun55i_pcie_ep_func {
++	struct list_head list;
++	u8 func_no;
++	u8 msi_cap;
++	u8 msix_cap;
++};
++
++struct sun55i_pcie_ep {
++	struct pci_epc		*epc;
++	struct list_head	func_list;
++	const struct sun55i_pcie_ep_ops *ops;
++	phys_addr_t		phys_base;
++	size_t			addr_size;
++	size_t			page_size;
++	u8			bar_to_atu[PCI_STD_NUM_BARS];
++	phys_addr_t		*outbound_addr;
++	u32			num_ib_windows;
++	u32			num_ob_windows;
++	unsigned long		*ib_window_map;
++	unsigned long		*ob_window_map;
++	u8			max_functions;
++	void __iomem		*msi_mem;
++	phys_addr_t		msi_mem_phys;
++	struct pci_bar	*epf_bar[PCI_STD_NUM_BARS];
++};
++
++struct sun55i_pcie_ep_ops {
++	void	(*ep_init)(struct sun55i_pcie_ep *ep);
++	// int	(*raise_irq)(struct sun55i_pcie_ep *ep, u8 func_no,
++	// 		     enum pci_epc_irq_type type, u16 interrupt_num);
++	const struct pci_epc_features *(*get_features)(struct sun55i_pcie_ep *ep);
++	unsigned int (*func_conf_select)(struct sun55i_pcie_ep *ep, u8 func_no);
++};
++
++struct sun55i_pcie_port {
++	struct device			*dev;
++	void __iomem			*dbi_base;
++	u32				cfg0_base;
++	void __iomem			*va_cfg0_base;
++	fdt_size_t				cfg0_size;
++	resource_size_t			io_base;
++	phys_addr_t			io_bus_addr;
++	u32				io_size;
++	phys_addr_t			mem_base;
++	phys_addr_t			mem_bus_addr;
++	u32				mem_size;
++	u32				num_ob_windows;
++	struct sun55i_pcie_host_ops	*ops;
++	struct sun55i_pcie		*pcie;
++	int				msi_irq;
++	struct irq_domain		*irq_domain;
++	struct irq_domain		*msi_domain;
++	struct pci_host_bridge		*bridge;
++	u8 root_bus_nr;
++	unsigned long			msi_map[BITS_TO_LONGS(INT_PCI_MSI_NR)];
++	bool				has_its;
++	bool 				cpu_pcie_addr_quirk;
++};
++
++struct sun55i_pci_edma_chan;
++
++struct sun55i_pcie {
++	struct udevice		*dev;
++	void		*dbi_base;
++	void 		*app_base;
++	int			link_gen;
++	int		first_busno;
++	struct sun55i_pcie_port	pcie_port;
++	struct sun55i_pcie_ep	ep;
++
++	struct clk		pcie_aux;   
++	struct reset_ctl    pcie_rst;   
++	struct phy  phy;   
++	struct udevice	*slot_3v3;
++
++	struct clk		pcie_slv;
++	struct clk		pcie_its;
++	struct reset_ctl    pwrup_rst;
++	struct reset_ctl    pcie_its_rst;
++	struct dma_trx_obj	*dma_obj;
++	const struct sun55i_pcie_of_data *drvdata;
++	struct gpio_desc	rst_gpio;
++	struct gpio_desc	wake_gpio;
++	struct gpio_desc	switch_gpio;
++	u32			lanes;
++	u32			num_edma;
++	unsigned long		*rd_edma_map;
++	unsigned long		*wr_edma_map;
++	struct sun55i_pci_edma_chan	*dma_wr_chn;
++	struct sun55i_pci_edma_chan	*dma_rd_chn;
++
++	struct udevice	*pcie3v3;
++};
++
++#define to_sun55i_pcie_from_pp(x)	\
++		container_of((x), struct sun55i_pcie, pcie_port)
++
++#define to_sun55i_pcie_from_ep(endpoint)   \
++		container_of((endpoint), struct sun55i_pcie, ep)
++
++int sun55i_pcie_plat_hw_init(struct udevice *dev);
++
++void sun55i_pcie_plat_set_rate(struct sun55i_pcie *pci);
++void sun55i_pcie_plat_set_mode(struct sun55i_pcie *pci);
++void sun55i_pcie_plat_ltssm_enable(struct sun55i_pcie *pci);
++void sun55i_pcie_plat_ltssm_disable(struct sun55i_pcie *pci);
++
++int sun55i_pcie_cfg_write(void __iomem *addr, int size, ulong val);
++int sun55i_pcie_cfg_read(void __iomem *addr, int size, ulong *val);
++
++u32 sun55i_pcie_readl(struct sun55i_pcie *pcie, u32 offset);
++void sun55i_pcie_writel(u32 val, struct sun55i_pcie *pcie, u32 offset);
++
++void sun55i_pcie_writel_dbi(struct sun55i_pcie *pci, u32 reg, u32 val);
++u32 sun55i_pcie_readl_dbi(struct sun55i_pcie *pci, u32 reg);
++void sun55i_pcie_writew_dbi(struct sun55i_pcie *pci, u32 reg, u16 val);
++u16 sun55i_pcie_readw_dbi(struct sun55i_pcie *pci, u32 reg);
++void sun55i_pcie_writeb_dbi(struct sun55i_pcie *pci, u32 reg, u8 val);
++u8 sun55i_pcie_readb_dbi(struct sun55i_pcie *pci, u32 reg);
++
++void sun55i_pcie_dbi_ro_wr_en(struct sun55i_pcie *pci);
++void sun55i_pcie_dbi_ro_wr_dis(struct sun55i_pcie *pci);
++
++u8 sun55i_pcie_plat_find_capability(struct sun55i_pcie *pci, u8 cap);
++
++#define SUN55I_PCIE_PHY_BASE           0x04f00000
++#define SUN55I_PCIE_PORT0_CONF_OFFSET  0x1000
++
++#endif /* _PCIE_SUN55I_H */
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.07-sunxi64/phy-allwinner-add-pcie-usb3-driver.patch
+++ b/patch/u-boot/v2026.07-sunxi64/phy-allwinner-add-pcie-usb3-driver.patch
@@ -1,0 +1,704 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Sat, 25 Oct 2025 20:32:35 +0000
+Subject: phy: allwinner: Add SUN55I INNO combo PHY driver for PCIe/USB3
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ drivers/phy/allwinner/Kconfig                |   8 +
+ drivers/phy/allwinner/Makefile               |   1 +
+ drivers/phy/allwinner/phy-sun55i-pcie-usb3.c | 656 ++++++++++
+ 3 files changed, 665 insertions(+)
+
+diff --git a/drivers/phy/allwinner/Kconfig b/drivers/phy/allwinner/Kconfig
+index 111111111111..222222222222 100644
+--- a/drivers/phy/allwinner/Kconfig
++++ b/drivers/phy/allwinner/Kconfig
+@@ -33,3 +33,11 @@ config PHY_SUN50I_USB3
+ 	help
+ 	  Enable this to support the USB3 transceiver that is part of
+ 	  Allwinner sun50i SoCs.
++	  
++config PHY_SUN55I_PCIE_USB3
++	tristate "Allwinner SUN55I INNO COMBO PHY Driver"
++	depends on ARCH_SUNXI
++	select PHY
++	help
++	  Enable this to support the Allwinner sun55i PCIe/USB3.0 combo PHY
++	  with INNOSILICON IP block.
+diff --git a/drivers/phy/allwinner/Makefile b/drivers/phy/allwinner/Makefile
+index 111111111111..222222222222 100644
+--- a/drivers/phy/allwinner/Makefile
++++ b/drivers/phy/allwinner/Makefile
+@@ -5,3 +5,4 @@
+ 
+ obj-$(CONFIG_PHY_SUN4I_USB)		+= phy-sun4i-usb.o
+ obj-$(CONFIG_PHY_SUN50I_USB3)		+= phy-sun50i-usb3.o
++obj-$(CONFIG_PHY_SUN55I_PCIE_USB3)		+= phy-sun55i-pcie-usb3.o
+\ No newline at end of file
+diff --git a/drivers/phy/allwinner/phy-sun55i-pcie-usb3.c b/drivers/phy/allwinner/phy-sun55i-pcie-usb3.c
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/phy/allwinner/phy-sun55i-pcie-usb3.c
+@@ -0,0 +1,656 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Allwinner PIPE USB3.0 PCIE Combo Phy driver
++ *
++ * Copyright(c) 2020 - 2024 Allwinner Technology Co.,Ltd. All rights reserved.
++ *
++ * sun55i-inno-combophy.c:	chenhuaqiang <chenhuaqiang@allwinnertech.com>
++ */
++
++
++#include <clk-uclass.h>
++#include <dm.h>
++#include <log.h>
++#include <dm/device.h>
++#include <dm/device_compat.h>
++#include <dm/lists.h>
++#include <dt-bindings/phy/phy.h>
++#include <generic-phy.h>
++#include <asm/io.h>
++#include <power-domain.h>
++#include <regmap.h>
++#include <syscon.h>
++#include <linux/bitops.h>
++#include <linux/delay.h>
++#include <linux/err.h>
++#include <power/regulator.h>
++#include <reset.h>
++
++
++#define sun55i_COMBOPHY_CTL_BASE	0x04f00000
++#define sun55i_COMBOPHY_CLK_BASE	0x04f80000
++
++/* PCIE USB3 Sub-System Registers */
++/* Sub-System Version Reset Register */
++#define PCIE_USB3_SYS_VER		0x00
++
++/* CCMU Base Address */
++#define SUNXI_CCMU_BASE                0x02001000
++#define SUNXI_CCM_BASE                (SUNXI_CCMU_BASE)
++
++/* Sub-System PCIE Bus Gating Reset Register */
++#define PCIE_BRG_REG_RST 16
++#define PCIE_BGR_REG (SUNXI_CCM_BASE + 0x0aac)
++
++/* Sub-System PCIE Bus Gating Reset Register */
++#define PCIE_COMBO_PHY_BGR		0x04
++#define   PCIE_SLV_ACLK_EN		BIT(18)
++#define   PCIE_ACLK_EN			BIT(17)
++#define   PCIE_HCLK_EN			BIT(16)
++#define   PCIE_PERSTN			BIT(1)
++#define   PCIE_PW_UP_RSTN		BIT(0)
++
++/* Sub-System USB3 Bus Gating Reset Register */
++#define USB3_COMBO_PHY_BGR		0x08
++#define   USB3_ACLK_EN			BIT(17)
++#define   USB3_HCLK_EN			BIT(16)
++#define   USB3_U2_PHY_RSTN		BIT(4)
++#define   USB3_U2_PHY_MUX_EN		BIT(3)
++#define   USB3_U2_PHY_MUX_SEL		BIT(0)
++#define   USB3_RESETN			BIT(0)
++
++/* Sub-System PCIE PHY Control Register */
++#define PCIE_COMBO_PHY_CTL		0x10
++#define   PHY_USE_SEL			BIT(31)	/* 0:PCIE; 1:USB3 */
++#define   PHY_CLK_SEL			BIT(30) /* 0:internal clk; 1:external clk */
++#define   PHY_BIST_EN			BIT(16)
++#define   PHY_PIPE_SW			BIT(9)
++#define   PHY_PIPE_SEL			BIT(8)  /* 0:rstn by PCIE or USB3; 1:rstn by PHY_PIPE_SW */
++#define   PHY_PIPE_CLK_INVERT		BIT(4)
++#define   PHY_FPGA_SYS_RSTN		BIT(1)  /* for FPGA  */
++#define   PHY_RSTN			BIT(0)
++
++/* PHY CLK Registers (offset from sun55i_COMBOPHY_CLK_BASE) */
++#define PCIE_REF_CLK_REG_PCIE_REF_CLK_GATING_CLEAR_MASK 0x80000000
++
++/* Registers */
++#define  COMBO_REG_SYSVER(comb_base_addr)	((comb_base_addr) \
++							+ PCIE_USB3_SYS_VER)
++#define  COMBO_REG_PCIEBGR(comb_base_addr)	((comb_base_addr) \
++							+ PCIE_COMBO_PHY_BGR)
++#define  COMBO_REG_USB3BGR(comb_base_addr)	((comb_base_addr) \
++							+ USB3_COMBO_PHY_BGR)
++#define  COMBO_REG_PHYCTRL(comb_base_addr)	((comb_base_addr) \
++							+ PCIE_COMBO_PHY_CTL)
++
++/* Sub-System Version Number */
++#define  COMBO_VERSION_01				(0x10000)
++#define  COMBO_VERSION_ANY				(0x0)
++
++enum phy_use_sel {
++	PHY_USE_BY_PCIE = 0, /* PHY used by PCIE */
++	PHY_USE_BY_USB3, /* PHY used by USB3 */
++	PHY_USE_BY_PCIE_USB3_U2,/* PHY used by PCIE & USB3_U2 */
++};
++
++enum phy_refclk_sel {
++	INTER_SIG_REF_CLK = 0, /* PHY use internal single end reference clock */
++	EXTER_DIF_REF_CLK, /* PHY use external single end reference clock */
++};
++
++struct sun55i_combophy_of_data {
++	bool has_cfg_clk;
++	bool has_slv_clk;
++	bool has_phy_mbus_clk;
++	bool has_phy_ahb_clk;
++	bool has_pcie_axi_clk;
++	bool has_u2_phy_mux;
++	bool need_noppu_rst;
++	bool has_u3_phy_data_quirk;
++	bool need_optimize_jitter;
++};
++
++struct sun55i_combphy {
++	struct device *dev;
++	struct phy *phy;
++	void __iomem *phy_ctl;  /* parse dts, control the phy mode, reset and power */
++	void __iomem *phy_clk;  /* parse dts, set the phy clock */
++
++    struct reset_ctl reset;
++    struct reset_ctl noppu_reset;
++
++	struct clk *phyclk_ref;
++	struct clk *refclk_par;
++	struct clk *phyclk_cfg;
++	struct clk *cfgclk_par;
++	struct clk *phy_mclk;
++	struct clk *phy_hclk;
++	struct clk *phy_axi;
++	struct clk *phy_axi_par;
++	__u8 mode;
++	__u32 vernum; /* version number */
++	enum phy_use_sel user;
++	enum phy_refclk_sel ref;
++	const struct sun55i_combophy_of_data *drvdata;
++
++    struct udevice *select3v3_supply;
++    bool initialized;
++};
++
++static void sun55i_combphy_usb3_phy_set(struct sun55i_combphy *combphy, bool enable)
++{
++	u32 val, tmp = 0;
++
++	val = readl(combphy->phy_clk + 0x1418);
++	tmp = GENMASK(17, 16);
++	if (enable) {
++		val &= ~tmp;
++		val |= BIT(25);
++	} else {
++		val |= tmp;
++		val &= ~BIT(25);
++	}
++	writel(val, combphy->phy_clk + 0x1418);
++
++	/* reg_rx_eq_bypass[3]=1, rx_ctle_res_cal_bypass */
++	val = readl(combphy->phy_clk + 0x0674);
++	if (enable)
++		val |= BIT(3);
++	else
++		val &= ~BIT(3);
++	writel(val, combphy->phy_clk + 0x0674);
++
++	/* rx_ctle_res_cal=0xf, 0x4->0xf */
++	val = readl(combphy->phy_clk + 0x0704);
++	tmp = GENMASK(9, 8) | BIT(11);
++	if (enable)
++		val |= tmp;
++	else
++		val &= ~tmp;
++	writel(val, combphy->phy_clk + 0x0704);
++
++	/* CDR_div_fin_gain1 */
++	val = readl(combphy->phy_clk + 0x0400);
++	if (enable)
++		val |= BIT(4);
++	else
++		val &= ~BIT(4);
++	writel(val, combphy->phy_clk + 0x0400);
++
++	/* CDR_div1_fin_gain1 */
++	val = readl(combphy->phy_clk + 0x0404);
++	tmp = GENMASK(3, 0) | BIT(5);
++	if (enable)
++		val |= tmp;
++	else
++		val &= ~tmp;
++	writel(val, combphy->phy_clk + 0x0404);
++
++	/* CDR_div3_fin_gain1 */
++	val = readl(combphy->phy_clk + 0x0408);
++	if (enable)
++		val |= BIT(5);
++	else
++		val &= ~BIT(5);
++	writel(val, combphy->phy_clk + 0x0408);
++
++	val = readl(combphy->phy_clk + 0x109c);
++	if (enable)
++		val |= BIT(1);
++	else
++		val &= ~BIT(1);
++	writel(val, combphy->phy_clk + 0x109c);
++
++	/* balance parm configure */
++	if (combphy->drvdata->has_u3_phy_data_quirk) {
++		val = readl(combphy->phy_clk + 0x0804);
++		if (enable)
++			val |= (0x6<<4);
++		else
++			val &= ~(0xf<<4);
++		writel(val, combphy->phy_clk + 0x0804);
++	}
++
++	/* SSC configure */
++	val = readl(combphy->phy_clk + 0x107c);
++	tmp = 0x3f << 12;
++	val = val & (~tmp);
++	val |= ((0x1 << 12) & tmp);              /* div_N */
++	writel(val, combphy->phy_clk + 0x107c);
++
++	val = readl(combphy->phy_clk + 0x1020);
++	tmp = 0x1f << 0;
++	val = val & (~tmp);
++	val |= ((0x6 << 0) & tmp);               /* modulation freq div */
++	writel(val, combphy->phy_clk + 0x1020);
++
++	val = readl(combphy->phy_clk + 0x1034);
++	tmp = 0x7f << 16;
++	val = val & (~tmp);
++	val |= ((0x9 << 16) & tmp);              /* spread[6:0], 400*9=4410ppm ssc */
++	writel(val, combphy->phy_clk + 0x1034);
++
++	val = readl(combphy->phy_clk + 0x101c);
++	tmp = 0x1 << 27;
++	val = val & (~tmp);
++	val |= ((0x1 << 27) & tmp);              /* choose downspread */
++
++	tmp = 0x1 << 28;
++	val = val & (~tmp);
++	if (enable)
++		val |= ((0x0 << 28) & tmp);      /* don't disable ssc = 0 */
++	else
++		val |= ((0x1 << 28) & tmp);      /* don't enable ssc = 1 */
++	writel(val, combphy->phy_clk + 0x101c);
++
++#ifdef SUN55i_INNO_COMMBOPHY_DEBUG
++	/* TX Eye configure bypass_en */
++	val = readl(combphy->phy_clk + 0x0ddc);
++	if (enable)
++		val |= BIT(4);                   /*  0x0ddc[4]=1 */
++	else
++		val &= ~BIT(4);
++	writel(val, combphy->phy_clk + 0x0ddc);
++
++	/* Leg_cur[6:0] - 7'd84 */
++	val = readl(combphy->phy_clk + 0x0ddc);
++	val |= ((0x54 & BIT(6)) >> 3);           /* 0x0ddc[3] */
++	writel(val, combphy->phy_clk + 0x0ddc);
++
++	val = readl(combphy->phy_clk + 0x0de0);
++	val |= ((0x54 & GENMASK(5, 0)) << 2);    /* 0x0de0[7:2] */
++	writel(val, combphy->phy_clk + 0x0de0);
++
++	/* Leg_curb[5:0] - 6'd18 */
++	val = readl(combphy->phy_clk + 0x0de4);
++	val |= ((0x12 & GENMASK(5, 1)) >> 1);    /* 0x0de4[4:0] */
++	writel(val, combphy->phy_clk + 0x0de4);
++
++	val = readl(combphy->phy_clk + 0x0de8);
++	val |= ((0x12 & BIT(0)) << 7);           /* 0x0de8[7] */
++	writel(val, combphy->phy_clk + 0x0de8);
++
++	/* Exswing_isel */
++	val = readl(combphy->phy_clk + 0x0028);
++	val |= (0x4 << 28);                      /* 0x28[30:28] */
++	writel(val, combphy->phy_clk + 0x0028);
++
++	/* Exswing_en */
++	val = readl(combphy->phy_clk + 0x0028);
++	if (enable)
++		val |= BIT(31);                  /* 0x28[31]=1 */
++	else
++		val &= ~BIT(31);
++	writel(val, combphy->phy_clk + 0x0028);
++#endif
++}
++
++static int sun55i_combphy_usb3_init(struct sun55i_combphy *combphy)
++{
++	sun55i_combphy_usb3_phy_set(combphy, true);
++
++	return 0;
++}
++
++// static int sun55i_combphy_usb3_exit(struct sun55i_combphy *combphy)
++// {
++// 	sun55i_combphy_usb3_phy_set(combphy, false);
++
++// 	return 0;
++// }
++
++static void sun55i_combphy_pcie_phy_enable(struct sun55i_combphy *combphy)
++{
++	u32 val;
++
++	/* set the phy:
++	 * bit(18): slv aclk enable
++	 * bit(17): aclk enable
++	 * bit(16): hclk enbale
++	 * bit(1) : pcie_presetn
++	 * bit(0) : pcie_power_up_rstn
++	 */
++	val = readl(combphy->phy_ctl + PCIE_COMBO_PHY_BGR);
++	val &= (~(0x03<<0));
++	val &= (~(0x03<<16));
++	val |= (0x03<<0);
++	if (combphy->drvdata->has_slv_clk)
++		val |= (0x07<<16);
++	else
++		val |= (0x03<<16);
++	writel(val, combphy->phy_ctl + PCIE_COMBO_PHY_BGR);
++
++
++	/* select phy mode, phy assert */
++	val = readl(combphy->phy_ctl + PCIE_COMBO_PHY_CTL);
++	val &= (~PHY_USE_SEL);
++	val &= (~(0x03<<8));
++	val &= (~PHY_FPGA_SYS_RSTN);
++	val &= (~PHY_RSTN);
++	writel(val, combphy->phy_ctl + PCIE_COMBO_PHY_CTL);
++
++	 /* phy De-assert */
++	val = readl(combphy->phy_ctl + PCIE_COMBO_PHY_CTL);
++	val &= (~PHY_CLK_SEL);
++	val &= (~(0x03<<8));
++	val &= (~PHY_FPGA_SYS_RSTN);
++	val &= (~PHY_RSTN);
++	val |= PHY_RSTN;
++	writel(val, combphy->phy_ctl + PCIE_COMBO_PHY_CTL);
++
++	val = readl(combphy->phy_ctl + PCIE_COMBO_PHY_CTL);
++	val &= (~PHY_CLK_SEL);
++	val &= (~(0x03<<8));
++	val &= (~PHY_FPGA_SYS_RSTN);
++	val &= (~PHY_RSTN);
++	val |= PHY_RSTN;
++	val |= (PHY_FPGA_SYS_RSTN);
++	writel(val, combphy->phy_ctl + PCIE_COMBO_PHY_CTL);
++
++}
++
++static void sun55i_combphy_pcie_phy_100M(struct sun55i_combphy *combphy)
++{
++	u32 val;
++
++	val = readl(combphy->phy_clk + 0x1004);
++	val &= ~(0x3<<3);
++	val &= ~(0x1<<0);
++	val |= (0x1<<0);
++	val |= (0x1<<2);
++	val |= (0x1<<4);
++	writel(val, combphy->phy_clk + 0x1004);
++
++	val = readl(combphy->phy_clk + 0x1018);
++	val &= ~(0x3<<4);
++	val |= (0x3<<4);
++	writel(val, combphy->phy_clk + 0x1018);
++
++	val = readl(combphy->phy_clk + 0x101c);
++	val &= ~(0x0fffffff);
++	writel(val, combphy->phy_clk + 0x101c);
++
++	/* if need optimize jitter parm*/
++	if (combphy->drvdata->need_optimize_jitter) {
++		val = readl(combphy->phy_clk + 0x107c);
++		val &= ~(0x3ffff);
++		val |= (0x4<<12);
++		val |= 0x64;
++		writel(val, combphy->phy_clk + 0x107c);
++
++		val = readl(combphy->phy_clk + 0x1030);
++		val &= ~(0x3<<20);
++		writel(val, combphy->phy_clk + 0x1030);
++
++		val = readl(combphy->phy_clk + 0x1050);
++		val &= ~(0x7<<0);
++		val &= ~(0x7<<5);
++		val &= ~(0x3<<3);
++		val |= (0x3<<3);
++		writel(val, combphy->phy_clk + 0x1050);
++	} else {
++		val = readl(combphy->phy_clk + 0x107c);
++		val &= ~(0x3ffff);
++		val |= (0x2<<12);
++		val |= 0x32;
++		writel(val, combphy->phy_clk + 0x107c);
++
++		val = readl(combphy->phy_clk + 0x1030);
++		val &= ~(0x3<<20);
++		writel(val, combphy->phy_clk + 0x1030);
++
++		val = readl(combphy->phy_clk + 0x1050);
++		val &= ~(0x7<<5);
++		val |= (0x1<<5);
++		writel(val, combphy->phy_clk + 0x1050);
++	}
++
++	val = readl(combphy->phy_clk + 0x1054);
++	val &= ~(0x7<<5);
++	val |= (0x1<<5);
++	writel(val, combphy->phy_clk + 0x1054);
++
++	val = readl(combphy->phy_clk + 0x0804);
++	val &= ~(0xf<<4);
++	val |= (0xc<<4);
++	writel(val, combphy->phy_clk + 0x0804);
++
++	val = readl(combphy->phy_clk + 0x109c);
++	val &= ~(0x3<<8);
++	val |= (0x1<<1);
++	writel(val, combphy->phy_clk + 0x109c);
++
++	writel(0x80540a0a, combphy->phy_clk + 0x1418);
++}
++
++static int sun55i_combphy_pcie_init(struct sun55i_combphy *combphy)
++{
++	sun55i_combphy_pcie_phy_100M(combphy);
++
++	sun55i_combphy_pcie_phy_enable(combphy);
++
++	return 0;
++}
++
++static int sun55i_combphy_set_mode(struct sun55i_combphy *combphy)
++{
++	switch (combphy->mode) {
++	case PHY_TYPE_PCIE:
++		sun55i_combphy_pcie_init(combphy);
++		break;
++	case PHY_TYPE_USB3:
++		if (combphy->user == PHY_USE_BY_PCIE_USB3_U2) {
++			sun55i_combphy_pcie_init(combphy);
++		} else if (combphy->user == PHY_USE_BY_USB3) {
++			sun55i_combphy_usb3_init(combphy);
++		}
++		break;
++	default:
++		printf("incompatible PHY type\n");
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static void combo_phy_mode_set(struct sun55i_combphy *combphy, bool enable)
++{
++	u32 val;
++
++	val = readl(COMBO_REG_PHYCTRL(combphy->phy_ctl));
++
++	/* Set PHY_USE_SEL based on user (default: clear for PCIE/PCIE_USB3_U2, set for USB3) */
++	val &= ~PHY_USE_SEL;  /* Default: clear (PCIE mode) */
++	if (combphy->user == PHY_USE_BY_USB3)
++		val |= PHY_USE_SEL;
++
++	/* Set PHY_CLK_SEL based on ref (default: clear for internal, set for external) */
++	val &= ~PHY_CLK_SEL;  /* Default: clear (internal clock) */
++	if (combphy->ref == EXTER_DIF_REF_CLK)
++		val |= PHY_CLK_SEL;
++
++	/* Set or clear PHY_RSTN based on enable */
++	if (enable)
++		val |= PHY_RSTN;
++	else
++		val &= ~PHY_RSTN;
++
++	writel(val, COMBO_REG_PHYCTRL(combphy->phy_ctl));
++}
++
++/*  PCIE USB3 Sub-system Application */
++static void combo_pcie_clk_set(struct sun55i_combphy *combphy, bool enable)
++{
++	u32 val, tmp = 0;
++
++	val = readl(COMBO_REG_PCIEBGR(combphy->phy_ctl));
++	if (combphy->drvdata->has_slv_clk)
++		tmp = PCIE_SLV_ACLK_EN | PCIE_ACLK_EN | PCIE_HCLK_EN | PCIE_PERSTN | PCIE_PW_UP_RSTN;
++	else
++		tmp = PCIE_ACLK_EN | PCIE_HCLK_EN | PCIE_PERSTN | PCIE_PW_UP_RSTN;
++	if (enable)
++		val |= tmp;
++	else
++		val &= ~tmp;
++	writel(val, COMBO_REG_PCIEBGR(combphy->phy_ctl));
++}
++
++static void combo_usb3_clk_set(struct sun55i_combphy *combphy, bool enable)
++{
++	u32 val, tmp = 0;
++
++	val = readl(COMBO_REG_USB3BGR(combphy->phy_ctl));
++	if (combphy->drvdata->has_u2_phy_mux)
++		tmp = USB3_ACLK_EN | USB3_HCLK_EN | USB3_U2_PHY_MUX_SEL | USB3_U2_PHY_RSTN | USB3_U2_PHY_MUX_EN;
++	else
++		tmp = USB3_ACLK_EN | USB3_HCLK_EN | USB3_RESETN;
++	if (enable)
++		val |= tmp;
++	else
++		val &= ~tmp;
++	writel(val, COMBO_REG_USB3BGR(combphy->phy_ctl));
++}
++
++static u32 combo_sysver_get(struct sun55i_combphy *combphy)
++{
++	u32 reg;
++
++	reg = readl(COMBO_REG_SYSVER(combphy->phy_ctl));
++
++	return reg;
++}
++
++static void pcie_usb3_sub_system_enable(struct sun55i_combphy *combphy)
++{
++	combo_phy_mode_set(combphy, true);
++
++	if (combphy->user == PHY_USE_BY_PCIE)
++		combo_pcie_clk_set(combphy, true);
++	else if (combphy->user == PHY_USE_BY_USB3)
++		combo_usb3_clk_set(combphy, true);
++	else if (combphy->user == PHY_USE_BY_PCIE_USB3_U2) {
++		combo_pcie_clk_set(combphy, true);
++		combo_usb3_clk_set(combphy, true);
++	}
++
++	combphy->vernum = combo_sysver_get(combphy);
++}
++
++static int pcie_usb3_sub_system_init(void *phy)
++{
++	struct sun55i_combphy *combphy = (struct sun55i_combphy *)(phy);
++	unsigned long reg_value = 0;
++
++	if (combphy->initialized)
++		return 0;
++
++    	reg_value = readl(PCIE_BGR_REG);
++    	reg_value |= (1 << PCIE_BRG_REG_RST);
++    	writel(reg_value, PCIE_BGR_REG);
++
++    	reg_value = 0x81000001;
++    	writel(reg_value, 0x2001a84);
++
++	pcie_usb3_sub_system_enable(combphy);
++
++	combphy->initialized = true;
++
++	return 0;
++}
++
++int sun55i_combphy_init(struct phy *phy)
++{
++    struct sun55i_combphy *combphy = dev_get_priv(phy->dev);
++    int ret;
++
++    if (!combphy) {
++        printf("PHY drvdata not set!\n");
++        return -EIO;
++    }
++
++    if (combphy->select3v3_supply) {
++    	ret = regulator_set_enable_if_allowed(combphy->select3v3_supply, true);
++    	if (ret && ret != -EALREADY) {
++    		printf("PHY: Failed to enable 3.3V supply: %d\n", ret);
++    		return ret;
++    	}
++    }
++
++    ret = reset_deassert(&combphy->reset);
++    if (ret) {
++        printf("PHY: Failed to deassert reset: %d\n", ret);
++        regulator_set_enable(combphy->select3v3_supply, false);
++        return ret;
++    }
++
++    ret = pcie_usb3_sub_system_init(combphy);
++    if (ret) {
++        printf("PHY: failed to init sub system\n");
++        reset_assert(&combphy->reset);
++        regulator_set_enable(combphy->select3v3_supply, false);
++        return ret;
++    }
++
++    ret = sun55i_combphy_set_mode(combphy);
++    if (ret) {
++        printf("PHY: invalid number of arguments\n");
++        reset_assert(&combphy->reset);
++        regulator_set_enable(combphy->select3v3_supply, false);
++        return ret;
++    }
++
++    return 0;
++}
++
++static const struct sun55i_combophy_of_data sun55i_inno_v1_of_data = {
++	.has_cfg_clk = false,
++};
++
++static int sun55i_inno_phy_probe(struct udevice *dev)
++{
++	struct sun55i_combphy *combphy = dev_get_priv(dev);
++	int ret;
++
++	combphy->phy_ctl = dev_read_addr_name_ptr(dev, "phy-ctl");
++	if (!combphy->phy_ctl)
++		return -ENODEV;
++
++	combphy->phy_clk = dev_read_addr_name_ptr(dev, "phy-clk");
++	if (!combphy->phy_clk)
++		return -ENODEV;
++
++	ret = reset_get_by_index(dev, 0, &combphy->reset);
++	if (ret)
++		return ret;
++
++	ret = device_get_supply_regulator(dev, "select3v3-supply", &combphy->select3v3_supply);
++	if (ret)
++		return ret;
++
++	combphy->drvdata = (const struct sun55i_combophy_of_data *)dev_get_driver_data(dev);
++	combphy->user = PHY_USE_BY_PCIE;
++	combphy->mode = PHY_TYPE_PCIE;
++	combphy->ref = EXTER_DIF_REF_CLK;
++
++	return 0;
++}
++
++static const struct phy_ops sun55i_inno_phy_ops = {
++	.init		= sun55i_combphy_init,
++};
++
++static const struct udevice_id sun55i_inno_phy_of_match_table[] = {
++	{
++		.compatible = "allwinner,inno-combphy",
++		.data = (ulong)&sun55i_inno_v1_of_data,
++	},
++};
++
++U_BOOT_DRIVER(sun55i_inno_combophy) = {
++	.name	= "sun55i_inno_combophy",
++	.id	= UCLASS_PHY,
++	.of_match = sun55i_inno_phy_of_match_table,
++	.ops = &sun55i_inno_phy_ops,
++	.probe = sun55i_inno_phy_probe,
++	.priv_auto = sizeof(struct sun55i_combphy),
++};
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.07-sunxi64/spi-sunxi-add-sun55i-a523-spl-support.patch
+++ b/patch/u-boot/v2026.07-sunxi64/spi-sunxi-add-sun55i-a523-spl-support.patch
@@ -1,0 +1,205 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Mon, 10 Nov 2025 22:10:36 +0000
+Subject: spi: sunxi: Add support for Allwinner A523 SPI controllers in SPL
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ arch/arm/mach-sunxi/spl_spi_sunxi.c | 107 ++++++----
+ 1 file changed, 68 insertions(+), 39 deletions(-)
+
+diff --git a/arch/arm/mach-sunxi/spl_spi_sunxi.c b/arch/arm/mach-sunxi/spl_spi_sunxi.c
+index 111111111111..222222222222 100644
+--- a/arch/arm/mach-sunxi/spl_spi_sunxi.c
++++ b/arch/arm/mach-sunxi/spl_spi_sunxi.c
+@@ -101,6 +101,8 @@
+ #define SPI0_CLK_DIV_BY_4           0x1001
+ #define SPI0_CLK_DIV_BY_32          0x100f
+ 
++#define SUN55I_BUF_STA_REG 0x400
++
+ /*****************************************************************************/
+ 
+ /*
+@@ -110,22 +112,29 @@
+  */
+ static void spi0_pinmux_setup(unsigned int pin_function)
+ {
++	if (IS_ENABLED(CONFIG_MACH_SUN55I_A523)) {
++        sunxi_gpio_set_cfgpin(SUNXI_GPC(12), pin_function);
++	}
++
+ 	/* All chips use PC2. And all chips use PC0, except R528/T113 */
+-	if (!IS_ENABLED(CONFIG_MACH_SUN8I_R528))
++	if (!IS_ENABLED(CONFIG_MACH_SUN8I_R528) &&
++	    !IS_ENABLED(CONFIG_MACH_SUN55I_A523))
+ 		sunxi_gpio_set_cfgpin(SUNXI_GPC(0), pin_function);
+ 
+ 	sunxi_gpio_set_cfgpin(SUNXI_GPC(2), pin_function);
+ 
+ 	/* All chips except H6/H616/R528/T113 use PC1. */
+ 	if (!IS_ENABLED(CONFIG_SUN50I_GEN_H6) &&
+-	    !IS_ENABLED(CONFIG_MACH_SUN8I_R528))
++	    !IS_ENABLED(CONFIG_MACH_SUN8I_R528) &&
++	    !IS_ENABLED(CONFIG_MACH_SUN55I_A523))
+ 		sunxi_gpio_set_cfgpin(SUNXI_GPC(1), pin_function);
+ 
+ 	if (IS_ENABLED(CONFIG_MACH_SUN50I_H6) ||
+ 	    IS_ENABLED(CONFIG_MACH_SUN8I_R528))
+ 		sunxi_gpio_set_cfgpin(SUNXI_GPC(5), pin_function);
+ 	if (IS_ENABLED(CONFIG_MACH_SUN50I_H616) ||
+-	    IS_ENABLED(CONFIG_MACH_SUN8I_R528))
++	    IS_ENABLED(CONFIG_MACH_SUN8I_R528) ||
++	    IS_ENABLED(CONFIG_MACH_SUN55I_A523))
+ 		sunxi_gpio_set_cfgpin(SUNXI_GPC(4), pin_function);
+ 
+ 	/* Older generations use PC23 for CS, newer ones use PC3. */
+@@ -144,6 +153,11 @@ static bool is_sun6i_gen_spi(void)
+ 	       IS_ENABLED(CONFIG_MACH_SUN8I_V3S);
+ }
+ 
++static bool is_sun55i_gen_spi(void)
++{
++	return IS_ENABLED(CONFIG_MACH_SUN55I_A523);
++}
++
+ static uintptr_t spi0_base_address(void)
+ {
+ 	if (IS_ENABLED(CONFIG_MACH_SUN8I_R40))
+@@ -227,7 +241,7 @@ static void spi0_disable_clock(void)
+ 	uintptr_t base = spi0_base_address();
+ 
+ 	/* Disable the SPI0 controller */
+-	if (is_sun6i_gen_spi())
++	if (is_sun6i_gen_spi() || is_sun55i_gen_spi())
+ 		clrbits_le32(base + SUN6I_SPI0_GCR, SUN6I_CTL_MASTER |
+ 					     SUN6I_CTL_ENABLE);
+ 	else
+@@ -257,7 +271,8 @@ static void spi0_init(void)
+ 	unsigned int pin_function = SUNXI_GPC_SPI0;
+ 
+ 	if (IS_ENABLED(CONFIG_MACH_SUN50I) ||
+-	    IS_ENABLED(CONFIG_SUN50I_GEN_H6))
++	    IS_ENABLED(CONFIG_SUN50I_GEN_H6) ||
++	    IS_ENABLED(CONFIG_MACH_SUN55I_A523))
+ 		pin_function = SUN50I_GPC_SPI0;
+ 	else if (IS_ENABLED(CONFIG_MACH_SUNIV) ||
+ 		 IS_ENABLED(CONFIG_MACH_SUN8I_R528))
+@@ -272,7 +287,8 @@ static void spi0_deinit(void)
+ 	/* New SoCs can disable pins, older could only set them as input */
+ 	unsigned int pin_function = SUNXI_GPIO_INPUT;
+ 
+-	if (is_sun6i_gen_spi())
++	if (is_sun6i_gen_spi() ||
++	    is_sun55i_gen_spi())
+ 		pin_function = SUNXI_GPIO_DISABLE;
+ 
+ 	spi0_disable_clock();
+@@ -284,42 +300,45 @@ static void spi0_deinit(void)
+ #define SPI_READ_MAX_SIZE 60 /* FIFO size, minus 4 bytes of the header */
+ 
+ static void sunxi_spi0_read_data(u8 *buf, u32 addr, u32 bufsize,
+-				 ulong spi_ctl_reg,
+-				 ulong spi_ctl_xch_bitmask,
+-				 ulong spi_fifo_reg,
+-				 ulong spi_tx_reg,
+-				 ulong spi_rx_reg,
+-				 ulong spi_bc_reg,
+-				 ulong spi_tc_reg,
+-				 ulong spi_bcc_reg)
++                                 ulong spi_ctl_reg,
++                                 ulong spi_ctl_xch_bitmask,
++                                 ulong spi_fifo_reg,
++                                 ulong spi_tx_reg,
++                                 ulong spi_rx_reg,
++                                 ulong spi_bc_reg,
++                                 ulong spi_tc_reg,
++                                 ulong spi_bcc_reg)
+ {
+-	writel(4 + bufsize, spi_bc_reg); /* Burst counter (total bytes) */
+-	writel(4, spi_tc_reg);           /* Transfer counter (bytes to send) */
+-	if (spi_bcc_reg)
+-		writel(4, spi_bcc_reg);  /* SUN6I also needs this */
+-
+-	/* Send the Read Data Bytes (03h) command header */
+-	writeb(0x03, spi_tx_reg);
+-	writeb((u8)(addr >> 16), spi_tx_reg);
+-	writeb((u8)(addr >> 8), spi_tx_reg);
+-	writeb((u8)(addr), spi_tx_reg);
+-
+-	/* Start the data transfer */
+-	setbits_le32(spi_ctl_reg, spi_ctl_xch_bitmask);
+-
+-	/* Wait until everything is received in the RX FIFO */
+-	while ((readl(spi_fifo_reg) & 0x7F) < 4 + bufsize)
+-		;
++    writel(4 + bufsize, spi_bc_reg); /* Burst counter (total bytes) */
++    writel(4, spi_tc_reg);           /* Transfer counter (bytes to send) */
++    if (spi_bcc_reg)
++        writel(4, spi_bcc_reg);  /* SUN6I also needs this */
++
++    /* Send the Read Data Bytes (03h) command header */
++    writeb(0x03, spi_tx_reg);
++    writeb((u8)(addr >> 16), spi_tx_reg);
++    writeb((u8)(addr >> 8), spi_tx_reg);
++    writeb((u8)(addr), spi_tx_reg);
++
++    /* Start the data transfer */
++    setbits_le32(spi_ctl_reg, spi_ctl_xch_bitmask);
++
++    /* Wait until everything is received in the RX FIFO */
++#if IS_ENABLED(CONFIG_MACH_SUN55I_A523)
++    while ((readl(spi_fifo_reg) & 0xFF) < 4 + bufsize);
++#else
++    while ((readl(spi_fifo_reg) & 0x7F) < 4 + bufsize);
++#endif
+ 
+-	/* Skip 4 bytes */
+-	readl(spi_rx_reg);
++    /* Skip 4 bytes */
++    readl(spi_rx_reg);
+ 
+-	/* Read the data */
+-	while (bufsize-- > 0)
+-		*buf++ = readb(spi_rx_reg);
++    /* Read the data */
++    while (bufsize-- > 0)
++        *buf++ = readb(spi_rx_reg);
+ 
+-	/* tSHSL time is up to 100 ns in various SPI flash datasheets */
+-	udelay(1);
++    /* tSHSL time is up to 100 ns in various SPI flash datasheets */
++    udelay(1);
+ }
+ 
+ static void spi0_read_data(void *buf, u32 addr, u32 len)
+@@ -333,7 +352,7 @@ static void spi0_read_data(void *buf, u32 addr, u32 len)
+ 		if (chunk_len > SPI_READ_MAX_SIZE)
+ 			chunk_len = SPI_READ_MAX_SIZE;
+ 
+-		if (is_sun6i_gen_spi()) {
++		if (is_sun6i_gen_spi() && !is_sun55i_gen_spi()) {
+ 			sunxi_spi0_read_data(buf8, addr, chunk_len,
+ 					     base + SUN6I_SPI0_TCR,
+ 					     SUN6I_TCR_XCH,
+@@ -343,6 +362,16 @@ static void spi0_read_data(void *buf, u32 addr, u32 len)
+ 					     base + SUN6I_SPI0_MBC,
+ 					     base + SUN6I_SPI0_MTC,
+ 					     base + SUN6I_SPI0_BCC);
++		} else if (is_sun55i_gen_spi()) {
++			sunxi_spi0_read_data(buf8, addr, chunk_len,
++					     base + SUN6I_SPI0_TCR,
++					     SUN6I_TCR_XCH,
++					     base + SUN55I_BUF_STA_REG,
++					     base + SUN6I_SPI0_TXD,
++					     base + SUN6I_SPI0_RXD,
++					     base + SUN6I_SPI0_MBC,
++					     base + SUN6I_SPI0_MTC,
++					     base + SUN6I_SPI0_BCC);
+ 		} else {
+ 			sunxi_spi0_read_data(buf8, addr, chunk_len,
+ 					     base + SUN4I_SPI0_CTL,
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.07-sunxi64/spi-sunxi-add-sun55i-a523-support.patch
+++ b/patch/u-boot/v2026.07-sunxi64/spi-sunxi-add-sun55i-a523-support.patch
@@ -1,0 +1,104 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Thu, 23 Oct 2025 13:30:29 +0000
+Subject: spi: sunxi: Add support for Allwinner A523 SPI controllers
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ drivers/spi/spi-sunxi.c | 44 ++++++++++
+ 1 file changed, 44 insertions(+)
+
+diff --git a/drivers/spi/spi-sunxi.c b/drivers/spi/spi-sunxi.c
+index 111111111111..222222222222 100644
+--- a/drivers/spi/spi-sunxi.c
++++ b/drivers/spi/spi-sunxi.c
+@@ -84,6 +84,8 @@ DECLARE_GLOBAL_DATA_PTR;
+ #define SUN4I_SPI_DEFAULT_RATE		1000000
+ #define SUN4I_SPI_TIMEOUT_MS		1000
+ 
++#define SUN55I_BUF_STA_REG		0x400
++
+ #define SPI_REG(priv, reg)		((priv)->base + \
+ 					(priv)->variant->regs[reg])
+ #define SPI_BIT(priv, bit)		((priv)->variant->bits[bit])
+@@ -130,6 +132,7 @@ struct sun4i_spi_variant {
+ 	bool has_soft_reset;
+ 	bool has_burst_ctl;
+ 	bool has_clk_ctl;
++	bool has_bsr;
+ };
+ 
+ struct sun4i_spi_plat {
+@@ -366,6 +369,21 @@ static int sun4i_spi_xfer(struct udevice *dev, unsigned int bitlen,
+ 	setbits_le32(SPI_REG(priv, SPI_FCR), SPI_BIT(priv, SPI_FCR_RF_RST) |
+ 		     SPI_BIT(priv, SPI_FCR_TF_RST));
+ 
++    	if (priv->variant->has_bsr) {
++        	u32 reg;
++        	int ret;
++
++        	ret = readl_poll_timeout(SPI_REG(priv, SPI_FCR), reg,
++        	             !(reg & (SPI_BIT(priv, SPI_FCR_RF_RST) |
++        	                  SPI_BIT(priv, SPI_FCR_TF_RST))),
++        	             SUN4I_SPI_TIMEOUT_MS * 1000);
++        	if (ret) {
++	            printf("ERROR: sun4i_spi: FIFO reset timeout\n");
++	            sun4i_spi_set_cs(bus, slave_plat->cs[0], false);
++	            return ret;
++        	}
++    	}
++
+ 	while (len) {
+ 		/* Setup the transfer now... */
+ 		nbytes = min(len, (priv->variant->fifo_depth - 1));
+@@ -519,6 +537,19 @@ static const unsigned long sun6i_spi_regs[] = {
+ 	[SPI_RXD]		= SUN6I_RXDATA_REG,
+ };
+ 
++static const unsigned long sun55i_spi_regs[] = {
++	[SPI_GCR]		= SUN6I_GBL_CTL_REG,
++	[SPI_TCR]		= SUN6I_TFR_CTL_REG,
++	[SPI_FCR]		= SUN6I_FIFO_CTL_REG,
++	[SPI_FSR]		= SUN55I_BUF_STA_REG,
++	[SPI_CCR]		= SUN6I_CLK_CTL_REG,
++	[SPI_BC]		= SUN6I_BURST_CNT_REG,
++	[SPI_TC]		= SUN6I_XMIT_CNT_REG,
++	[SPI_BCTL]		= SUN6I_BURST_CTL_REG,
++	[SPI_TXD]		= SUN6I_TXDATA_REG,
++	[SPI_RXD]		= SUN6I_RXDATA_REG,
++};
++
+ static const u32 sun6i_spi_bits[] = {
+ 	[SPI_GCR_TP]		= BIT(7),
+ 	[SPI_GCR_SRST]		= BIT(31),
+@@ -570,6 +601,15 @@ static const struct sun4i_spi_variant sun50i_r329_spi_variant = {
+ 	.has_burst_ctl		= true,
+ };
+ 
++static const struct sun4i_spi_variant sun55i_a523_spi_variant = {
++	.regs			= sun55i_spi_regs,
++	.bits			= sun6i_spi_bits,
++	.fifo_depth		= 64,
++	.has_soft_reset		= true,
++	.has_burst_ctl		= true,
++	.has_bsr		= true,
++};
++
+ static const struct udevice_id sun4i_spi_ids[] = {
+ 	{
+ 	  .compatible = "allwinner,sun4i-a10-spi",
+@@ -587,6 +627,10 @@ static const struct udevice_id sun4i_spi_ids[] = {
+ 	  .compatible = "allwinner,sun50i-r329-spi",
+ 	  .data = (ulong)&sun50i_r329_spi_variant,
+ 	},
++	{
++	  .compatible = "allwinner,sun55i-a523-spi",
++	  .data = (ulong)&sun55i_a523_spi_variant,
++	},
+ 	{ /* sentinel */ }
+ };
+ 
+-- 
+Armbian
+

--- a/patch/u-boot/v2026.07-sunxi64/sunxi-add-nvme-boot-target.patch
+++ b/patch/u-boot/v2026.07-sunxi64/sunxi-add-nvme-boot-target.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Date: Sun, 16 Nov 2025 13:44:00 +0000
+Subject: sunxi: Add NVME boot target support
+
+NVMe is the LAST boot target so SD (MMC), USB and eMMC are tried first.
+
+Signed-off-by: Juan Sanchez Fuentes <juanesf91@gmail.com>
+Assisted-by: opencode:big-pickle
+---
+ include/configs/sunxi-common.h | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
+index 111111111111..222222222222 100644
+--- a/include/configs/sunxi-common.h
++++ b/include/configs/sunxi-common.h
+@@ -208,6 +208,12 @@
+ #define BOOT_TARGET_DEVICES_DHCP(func)
+ #endif
+ 
++#ifdef CONFIG_CMD_NVME
++#define BOOT_TARGET_DEVICES_NVME(func) func(NVME, nvme, 0)
++#else
++#define BOOT_TARGET_DEVICES_NVME(func)
++#endif
++
+ /* FEL boot support, auto-execute boot.scr if a script address was provided */
+ #define BOOTENV_DEV_FEL(devtypeu, devtypel, instance) \
+ 	"bootcmd_fel=" \
+@@ -224,7 +230,8 @@
+ 	BOOT_TARGET_DEVICES_SCSI(func) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+ 	BOOT_TARGET_DEVICES_PXE(func) \
+-	BOOT_TARGET_DEVICES_DHCP(func)
++	BOOT_TARGET_DEVICES_DHCP(func) \
++	BOOT_TARGET_DEVICES_NVME(func)
+ 
+ #ifdef CONFIG_OLD_SUNXI_KERNEL_COMPAT
+ #define BOOTCMD_SUNXI_COMPAT \
+-- 
+Armbian


### PR DESCRIPTION
Update patches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PCIe and NVMe support for the Radxa Cubie A5E.
  - Enabled SPI0 and SPI-NOR flash support.
  - Enabled the E906 RISC-V remote processor and RPMsg communication.
  - Added Allwinner A523 hardware support for PCIe, SPI, ComboPHY, USB3, and related clocks.
  - Added NVMe booting after standard boot targets.

- **Bug Fixes**
  - Fixed PCIe MSI interrupt handling to prevent potential kernel panics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->