### PR TITLE
firstrun: set per-model hostname on the NanoPi 6-series unified image

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -139,6 +139,30 @@ case "$1" in
 		hostnamectl set-hostname "$NEW_HOSTNAME"
 	fi
 
+	# adjust hostname for the FriendlyElec NanoPi 6-series unified image.
+	# A single image boots on several boards; the unified U-Boot detects the
+	# model via SARADC and exports nanopi6_model=<model> on the kernel command
+	# line, which is only present on these images.
+	if grep -q 'nanopi6_model=' /proc/cmdline; then
+		nanopi6_model=$(sed -n 's/.*nanopi6_model=\([^ ]*\).*/\1/p' /proc/cmdline)
+		NEW_HOSTNAME=""
+		case "$nanopi6_model" in
+			r6s) NEW_HOSTNAME="nanopi-r6s" ;;
+			r6c) NEW_HOSTNAME="nanopi-r6c" ;;
+			m6) NEW_HOSTNAME="nanopi-m6" ;;
+			m6v2) NEW_HOSTNAME="nanopi-m6v2" ;;
+			t6) NEW_HOSTNAME="nanopct6" ;;
+			t6-lts) NEW_HOSTNAME="nanopct6-lts" ;;
+			t6-lts-plus) NEW_HOSTNAME="nanopct6-lts-plus" ;;
+		esac
+		if [[ -n "$NEW_HOSTNAME" && "$NEW_HOSTNAME" != "$(hostname)" ]]; then
+			# Update /etc/hosts to reflect the new hostname
+			sed -i "s/$(hostname)/$NEW_HOSTNAME/g" /etc/hosts
+			# Change the hostname
+			hostnamectl set-hostname "$NEW_HOSTNAME"
+		fi
+	fi
+
 	# Remove KDE Neon base files upgrade pin
 	[[ -f /etc/apt/preferences.d/99-neon-base-files ]] && rm -f /etc/apt/preferences.d/99-neon-base-files
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -12,6 +12,21 @@
 . /lib/lsb/init-functions
 . /usr/lib/armbian/armbian-common
 
+# Apply a new system hostname once and mirror it in /etc/hosts. Replaces the
+# previous hostname only where it stands as a whole word (the 127.0.1.1 and ::1
+# records written at build time), leaving loopback names, aliases and comments
+# untouched. No-op when the target is empty or already current; the /etc/hosts
+# edit runs only after the rename itself succeeds.
+set_new_hostname() {
+	local new="$1" old esc_old esc_new
+	old="$(hostname)"
+	[[ -z "$new" || "$new" == "$old" ]] && return 0
+	hostnamectl set-hostname "$new" || return 1
+	esc_old=$(printf '%s' "$old" | sed 's#[][\\.*^$/]#\\&#g')
+	esc_new=$(printf '%s' "$new" | sed 's#[\\/&]#\\&#g')
+	sed -i "s/\b${esc_old}\b/${esc_new}/g" /etc/hosts
+}
+
 case "$1" in
 	start)
 
@@ -129,22 +144,27 @@ case "$1" in
 	# adjust hostname for rpi's
 	if [[ "${BOARD}" == rpi4b && "$(hostname)" == rpi4b ]]; then
 		BOARD_NAME=$(cat /proc/device-tree/model | tr '\0' '\n' | sed -E 's/ Rev [0-9.]+$//')
+		NEW_HOSTNAME=""
 		[[ "$BOARD_NAME" == *"Zero 2 W"* ]] && NEW_HOSTNAME="rpizero2w"
 		[[ "$BOARD_NAME" == *"Pi 5 Model B"* ]] && NEW_HOSTNAME="rpi5b"
 		[[ "$BOARD_NAME" == *"Pi 3 Model B"* ]] && NEW_HOSTNAME="rpi3b"
 		[[ "$BOARD_NAME" == *"Pi 400"* ]] && NEW_HOSTNAME="rpi400"
-		# Update /etc/hosts to reflect the new hostname
-		sed -i "s/$(hostname)/$NEW_HOSTNAME/g" /etc/hosts
-		# Change the hostname
-		hostnamectl set-hostname "$NEW_HOSTNAME"
+		# Leaves the default rpi4b hostname in place when no model matched.
+		set_new_hostname "$NEW_HOSTNAME"
 	fi
 
 	# adjust hostname for the FriendlyElec NanoPi 6-series unified image.
 	# A single image boots on several boards; the unified U-Boot detects the
-	# model via SARADC and exports nanopi6_model=<model> on the kernel command
-	# line, which is only present on these images.
-	if grep -q 'nanopi6_model=' /proc/cmdline; then
-		nanopi6_model=$(sed -n 's/.*nanopi6_model=\([^ ]*\).*/\1/p' /proc/cmdline)
+	# model via SARADC and exports nanopi6_model=<model> as its own token on the
+	# kernel command line, present only on these images. Parse it word-by-word so
+	# it can never match text embedded inside another kernel argument.
+	nanopi6_model=""
+	for arg in $(cat /proc/cmdline); do
+		case "$arg" in
+			nanopi6_model=*) nanopi6_model="${arg#nanopi6_model=}"; break ;;
+		esac
+	done
+	if [[ -n "$nanopi6_model" ]]; then
 		NEW_HOSTNAME=""
 		case "$nanopi6_model" in
 			r6s) NEW_HOSTNAME="nanopi-r6s" ;;
@@ -155,12 +175,7 @@ case "$1" in
 			t6-lts) NEW_HOSTNAME="nanopct6-lts" ;;
 			t6-lts-plus) NEW_HOSTNAME="nanopct6-lts-plus" ;;
 		esac
-		if [[ -n "$NEW_HOSTNAME" && "$NEW_HOSTNAME" != "$(hostname)" ]]; then
-			# Update /etc/hosts to reflect the new hostname
-			sed -i "s/$(hostname)/$NEW_HOSTNAME/g" /etc/hosts
-			# Change the hostname
-			hostnamectl set-hostname "$NEW_HOSTNAME"
-		fi
+		set_new_hostname "$NEW_HOSTNAME"
 	fi
 
 	# Remove KDE Neon base files upgrade pin

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -141,14 +141,30 @@ case "$1" in
 	[[ "${LINUXFAMILY}" == meson64 ]] && set_fixed_mac
 	[[ "${BOARD}" == nanopi-r6* ]] && set_fixed_mac
 
-	# adjust hostname for rpi's
+	# adjust hostname for rpi's: the single arm64 image boots the whole Pi 3B+
+	# onward lineup, so pick a per-model hostname from the board model string.
+	# Ordered most-specific-first so e.g. "Model B Plus" wins over "Model B".
 	if [[ "${BOARD}" == rpi4b && "$(hostname)" == rpi4b ]]; then
 		BOARD_NAME=$(cat /proc/device-tree/model | tr '\0' '\n' | sed -E 's/ Rev [0-9.]+$//')
 		NEW_HOSTNAME=""
-		[[ "$BOARD_NAME" == *"Zero 2 W"* ]] && NEW_HOSTNAME="rpizero2w"
-		[[ "$BOARD_NAME" == *"Pi 5 Model B"* ]] && NEW_HOSTNAME="rpi5b"
-		[[ "$BOARD_NAME" == *"Pi 3 Model B"* ]] && NEW_HOSTNAME="rpi3b"
-		[[ "$BOARD_NAME" == *"Pi 400"* ]] && NEW_HOSTNAME="rpi400"
+		# Model strings are the upstream RPi kernel DT values (arm64 / 64-bit
+		# lineup only). Compute Modules report their carrier-board string, so a
+		# substring of the SoM name is matched.
+		case "$BOARD_NAME" in
+			*"Compute Module 3"*) NEW_HOSTNAME="rpicm3" ;;
+			*"Compute Module 4S"*) NEW_HOSTNAME="rpicm4s" ;;
+			*"Compute Module 4"*) NEW_HOSTNAME="rpicm4" ;;
+			*"Compute Module 5 Lite"*) NEW_HOSTNAME="rpicm5lite" ;;
+			*"Compute Module 5"*) NEW_HOSTNAME="rpicm5" ;;
+			*"Zero 2 W"*) NEW_HOSTNAME="rpizero2w" ;;
+			*"Pi 3 Model A+"*) NEW_HOSTNAME="rpi3aplus" ;;
+			*"Pi 3 Model B+"*) NEW_HOSTNAME="rpi3bplus" ;;
+			*"Pi 3 Model B"*) NEW_HOSTNAME="rpi3b" ;;
+			*"Pi 400"*) NEW_HOSTNAME="rpi400" ;;
+			*"Pi 4 Model B"*) NEW_HOSTNAME="rpi4b" ;;
+			*"Pi 500"*) NEW_HOSTNAME="rpi500" ;;
+			*"Pi 5"*) NEW_HOSTNAME="rpi5b" ;;
+		esac
 		# Leaves the default rpi4b hostname in place when no model matched.
 		set_new_hostname "$NEW_HOSTNAME"
 	fi


### PR DESCRIPTION
Companion to #10442 (FriendlyElec RK3588 unified image).

That PR makes a single image boot on NanoPi R6S/R6C/M6/M6V2 and NanoPC-T6 variants, with the unified U-Boot detecting the board via SARADC and exporting `nanopi6_model=<model>` on the kernel command line (already consumed by the PR's udev/ALSA hooks).

This mirrors the existing `rpi4b` first-boot hostname logic in `armbian-firstrun` for that image: read `nanopi6_model=` from `/proc/cmdline`, map it to the matching per-board hostname, and apply it with `/etc/hosts` + `hostnamectl` so the unified image ends up indistinguishable from a dedicated per-board build.

| `nanopi6_model` | hostname |
|---|---|
| `r6s` | `nanopi-r6s` |
| `r6c` | `nanopi-r6c` |
| `m6` | `nanopi-m6` |
| `m6v2` | `nanopi-m6v2` |
| `t6` | `nanopct6` |
| `t6-lts` | `nanopct6-lts` |
| `t6-lts-plus` | `nanopct6-lts-plus` |

Notes:
- Guarded on the **cmdline arg** rather than a single `${BOARD}` — several boards source the common config and can build the image, so `${BOARD}`/default-hostname varies. The `nanopi6_model=` arg is present only on these unified images.
- Only rewrites when the mapped name is non-empty **and** differs from the current hostname → an unknown model or a non-unified U-Boot (no cmdline arg) safely leaves the build-time default (`HOST`=`$BOARD`) in place. Avoids the empty-`NEW_HOSTNAME` caveat the rpi4b block has.
- Runs once via the self-disabling `armbian-firstrun` service; no new unit or marker needed.

Can be merged on its own (harmless no-op until #10442's U-Boot ships the cmdline arg) or folded into #10442.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Raspberry Pi models now receive a model-specific hostname during first boot, with a default fallback when needed.
  * Supported NanoPi 6-series devices automatically receive the correct hostname based on their detected model.
  * Hostname changes are synchronized with local host configuration.

* **Bug Fixes**
  * Improved device model detection and hostname assignment.
  * Prevented unnecessary updates and accidental partial hostname replacements.
  * Local host configuration is updated only after a successful rename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->