### PR TITLE
Update the xiaomi-sheng bleedingedge kernel to 7.2.2

### DIFF
--- a/config/kernel/linux-sm8550-sheng-bleedingedge.config
+++ b/config/kernel/linux-sm8550-sheng-bleedingedge.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 7.2.0-rc7 Kernel Configuration
+# Linux/arm64 7.2.2 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="Debian clang version 21.1.8 (10)"
 CONFIG_GCC_VERSION=0

--- a/config/sources/families/sm8550-sheng.conf
+++ b/config/sources/families/sm8550-sheng.conf
@@ -18,8 +18,8 @@ case $BRANCH in
 		;;
 
 	bleedingedge)
-		declare -g KERNELSOURCE="https://github.com/map220v/sm8550-mainline.git"
-		declare -g KERNELBRANCH='branch:sheng-7.2'
+		declare -g KERNELSOURCE="https://github.com/ianchb/sm8550-mainline.git"
+		declare -g KERNELBRANCH='branch:sheng-7.2.2'
 		declare -g KERNEL_MAJOR_MINOR="7.2"
 		declare -g LINUXCONFIG="linux-sm8550-sheng-bleedingedge"
 		;;


### PR DESCRIPTION
Description

Update sheng kernel to 7.2.2.


How Has This Been Tested?

☑ Tested on Ubuntu 26, no errors found.

Checklist:

☑ My code follows the style guidelines of this project
☑ I have performed a self-review of my own code
☐ I have commented my code, particularly in hard-to-understand areas
☑ My changes generate no new warnings
☑ Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bleeding-edge kernel configuration to version 7.2.2.
  * Switched the bleeding-edge build to the updated kernel source and `sheng-7.2.2` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->