### PR TITLE
armbian-zsh: modernize (bash-compat builtins, bump oh-my-zsh, autosuggestions + highlighting, history)

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-zsh.sh
+++ b/lib/functions/artifacts/artifact-armbian-zsh.sh
@@ -17,7 +17,7 @@ function artifact_armbian-zsh_prepare_version() {
 	artifact_version_reason="undetermined" # outer scope
 
 	declare -g ARMBIAN_ZSH_SOURCE="${ARMBIAN_ZSH_SOURCE:-"https://github.com/ohmyzsh/ohmyzsh"}"
-	declare -g ARMBIAN_ZSH_BRANCH="commit:bfeeda1491b5366aa5798a86cf6f3621536b171c" # 2023-05-21, update this once in a while
+	declare -g ARMBIAN_ZSH_BRANCH="commit:4b657407c98bbc8830ae66c2ac7ff3d737c55a83" # 2026-08-29, update this once in a while
 
 	debug_var ARMBIAN_ZSH_SOURCE
 	debug_var ARMBIAN_ZSH_BRANCH

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -85,15 +85,40 @@ compile_armbian-zsh() {
 		# bash-completion file works under zsh too.
 		autoload -Uz +X bashcompinit 2>/dev/null && bashcompinit 2>/dev/null
 
-		# mapfile / readarray: read stdin lines into an array. The array name is the
-		# last argument; -t/-d/... flags are accepted and ignored and the trailing
-		# newline is always stripped (the -t common case).
+		# mapfile / readarray: read records from stdin into an array, matching Bash:
+		# name defaults to MAPFILE; -t strips the delimiter, otherwise it is kept;
+		# -d DELIM sets the delimiter (default newline); a final record with no
+		# trailing delimiter is still captured; other Bash flags are accepted and
+		# ignored. readarray delegates to mapfile.
 		if (( ! ${+builtins[mapfile]} )); then
 			mapfile() {
 				emulate -L zsh
-				local __name=${@[-1]} __line
+				local __name __delim=$'\n' __strip=0
+				while [[ $1 == -* && $1 != - && $1 != -- ]]; do
+					case $1 in
+						-t) __strip=1; shift ;;
+						-d) __delim=${2-}; shift 2 ;;
+						-d*) __delim=${1#-d}; shift ;;
+						-[nOsCc]) shift 2 ;;
+						-[nOsCc]*) shift ;;
+						*) shift ;;
+					esac
+				done
+				[[ $1 == -- ]] && shift
+				__name=${1:-MAPFILE}
+				[[ -n $__delim ]] || __delim=$'\n'
 				local -a __buf
-				while IFS= read -r __line; do __buf+=("$__line"); done
+				local __rec
+				while true; do
+					if IFS= read -r -d "$__delim" __rec; then
+						(( __strip )) || __rec+=$__delim
+					elif [[ -n $__rec ]]; then
+						:
+					else
+						break
+					fi
+					__buf+=("$__rec")
+				done
 				set -A "$__name" "${__buf[@]}"
 			}
 			readarray() { mapfile "$@" }

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -87,7 +87,7 @@ compile_armbian-zsh() {
 
 		# mapfile / readarray: read records from stdin into an array, matching Bash:
 		# name defaults to MAPFILE; -t strips the delimiter, otherwise it is kept;
-		# -d DELIM sets the delimiter (default newline); -u FD reads from a file
+		# -d DELIM sets the delimiter (default newline; -d '' means NUL); -u FD reads from a file
 		# descriptor; a final record with no trailing delimiter is still captured;
 		# other Bash flags are accepted and ignored. readarray delegates to mapfile.
 		if (( ! ${+builtins[mapfile]} )); then
@@ -108,7 +108,9 @@ compile_armbian-zsh() {
 				done
 				[[ $1 == -- ]] && shift
 				__name=${1:-MAPFILE}
-				[[ -n $__delim ]] || __delim=$'\n'
+				# keep an explicitly empty -d '' (Bash's NUL delimiter; zsh's
+				# `read -d ""` splits on NUL) — only an omitted -d stays newline,
+				# which the initial default above already handles.
 				local -a __ropts=(-r -d "$__delim")
 				[[ -n $__fd ]] && __ropts+=(-u "$__fd")
 				local -a __buf

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -59,6 +59,37 @@ compile_armbian-zsh() {
 	# @TODO: do this properly (not-copy it to begin with)
 	rm -rf "${tmp_dir}/${armbian_zsh_dir}"/etc/.git "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/plugins/.git
 
+	# bash<->zsh compatibility shims, auto-loaded for every user via oh-my-zsh
+	# ($ZSH/custom/*.zsh) so it is not baked per-.zshrc. Restores the bash builtins
+	# zsh lacks (complete/compgen/compopt via bashcompinit; mapfile/readarray).
+	# NB: scripts with a #!/bin/bash shebang always run under bash regardless of
+	# the login shell — this only smooths bash typed/sourced into interactive zsh.
+	mkdir -p "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/custom
+	cat > "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/custom/armbian-compat.zsh <<- 'ARMBIAN_COMPAT_EOF'
+		# Armbian bash<->zsh interactive compatibility shims (auto-loaded by oh-my-zsh).
+		# Scripts with a #!/bin/bash shebang run under bash regardless of the login
+		# shell; this only smooths bash snippets typed at the prompt or sourced into an
+		# interactive zsh, restoring the bash builtins zsh omits.
+
+		# bashcompinit provides the complete/compgen/compopt builtins so a tool's
+		# bash-completion file works under zsh too.
+		autoload -Uz +X bashcompinit 2>/dev/null && bashcompinit 2>/dev/null
+
+		# mapfile / readarray: read stdin lines into an array. The array name is the
+		# last argument; -t/-d/... flags are accepted and ignored and the trailing
+		# newline is always stripped (the -t common case).
+		if (( ! ${+builtins[mapfile]} )); then
+			mapfile() {
+				emulate -L zsh
+				local __name=${@[-1]} __line
+				local -a __buf
+				while IFS= read -r __line; do __buf+=("$__line"); done
+				set -A "$__name" "${__buf[@]}"
+			}
+			readarray() { mapfile "$@" }
+		fi
+	ARMBIAN_COMPAT_EOF
+
 	cp "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/templates/zshrc.zsh-template "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc
 
 	chmod -R g-w,o-w "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -87,18 +87,20 @@ compile_armbian-zsh() {
 
 		# mapfile / readarray: read records from stdin into an array, matching Bash:
 		# name defaults to MAPFILE; -t strips the delimiter, otherwise it is kept;
-		# -d DELIM sets the delimiter (default newline); a final record with no
-		# trailing delimiter is still captured; other Bash flags are accepted and
-		# ignored. readarray delegates to mapfile.
+		# -d DELIM sets the delimiter (default newline); -u FD reads from a file
+		# descriptor; a final record with no trailing delimiter is still captured;
+		# other Bash flags are accepted and ignored. readarray delegates to mapfile.
 		if (( ! ${+builtins[mapfile]} )); then
 			mapfile() {
 				emulate -L zsh
-				local __name __delim=$'\n' __strip=0
+				local __name __delim=$'\n' __strip=0 __fd
 				while [[ $1 == -* && $1 != - && $1 != -- ]]; do
 					case $1 in
 						-t) __strip=1; shift ;;
 						-d) __delim=${2-}; shift 2 ;;
 						-d*) __delim=${1#-d}; shift ;;
+						-u) __fd=${2-}; shift 2 ;;
+						-u*) __fd=${1#-u}; shift ;;
 						-[nOsCc]) shift 2 ;;
 						-[nOsCc]*) shift ;;
 						*) shift ;;
@@ -107,10 +109,12 @@ compile_armbian-zsh() {
 				[[ $1 == -- ]] && shift
 				__name=${1:-MAPFILE}
 				[[ -n $__delim ]] || __delim=$'\n'
+				local -a __ropts=(-r -d "$__delim")
+				[[ -n $__fd ]] && __ropts+=(-u "$__fd")
 				local -a __buf
 				local __rec
 				while true; do
-					if IFS= read -r -d "$__delim" __rec; then
+					if IFS= read "${__ropts[@]}" __rec; then
 						(( __strip )) || __rec+=$__delim
 					elif [[ -n $__rec ]]; then
 						:
@@ -136,6 +140,21 @@ compile_armbian-zsh() {
 		setopt HIST_REDUCE_BLANKS HIST_FIND_NO_DUPS
 	ARMBIAN_DEFAULTS_EOF
 
+	# Enable the bundled plugins from the package-owned custom dir instead of the
+	# per-user plugins=() line, so a package upgrade turns them on for EXISTING
+	# users too (this dir is refreshed on upgrade; ~/.zshrc is only written for new
+	# users). "armbian-plugins" sorts last among the custom snippets, so
+	# zsh-syntax-highlighting is sourced after every other widget is defined.
+	cat > "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/custom/armbian-plugins.zsh <<- 'ARMBIAN_PLUGINS_EOF'
+		# Load the plugins Armbian bundles into custom/plugins. Done here (not in
+		# ~/.zshrc's plugins=()) so upgrades reach existing users. Order matters:
+		# zsh-syntax-highlighting must be sourced last.
+		for _armbian_plugin in zsh-autosuggestions zsh-syntax-highlighting; do
+			source "${ZSH_CUSTOM:-$ZSH/custom}/plugins/${_armbian_plugin}/${_armbian_plugin}.plugin.zsh" 2>/dev/null
+		done
+		unset _armbian_plugin
+	ARMBIAN_PLUGINS_EOF
+
 	cp "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/templates/zshrc.zsh-template "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc
 
 	chmod -R g-w,o-w "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/
@@ -153,9 +172,7 @@ compile_armbian-zsh() {
 	sed -i "s/^# zstyle ':omz:update' mode disabled.*/zstyle ':omz:update' mode disabled/g" "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc
 
 	# define default plugins
-	# zsh-syntax-highlighting must stay LAST — it wraps the line editor and has to
-	# load after every other plugin's widgets are defined.
-	sed -i 's/^plugins=.*/plugins=(evalcache git git-extras debian tmux screen history extract colorize web-search docker zsh-autosuggestions zsh-syntax-highlighting)/' "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc
+	sed -i 's/^plugins=.*/plugins=(evalcache git git-extras debian tmux screen history extract colorize web-search docker)/' "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc
 
 	# add collection of Armbian BASH aliases also to ZSH. They are compatible
 	cat "${SRC}"/packages/bsp/common/etc/skel/.bash_aliases >> "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -19,6 +19,8 @@ compile_armbian-zsh() {
 
 	fetch_from_repo "$GITHUB_SOURCE/ohmyzsh/ohmyzsh" "oh-my-zsh" "${ARMBIAN_ZSH_BRANCH}"
 	fetch_from_repo "$GITHUB_SOURCE/mroth/evalcache" "evalcache" "commit:d6973f8c3ecde3eabd75c17b47e2222e24ab3e87" # 2025-11-24
+	fetch_from_repo "$GITHUB_SOURCE/zsh-users/zsh-autosuggestions" "zsh-autosuggestions" "commit:85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5" # 2025-06-24
+	fetch_from_repo "$GITHUB_SOURCE/zsh-users/zsh-syntax-highlighting" "zsh-syntax-highlighting" "commit:2fc57d63067c18b1100ecdbf684fa5baf49459d1" # 2026-08-22
 
 	mkdir -p "${tmp_dir}/${armbian_zsh_dir}"/{DEBIAN,etc/skel/,etc/oh-my-zsh/,/etc/skel/.oh-my-zsh/cache}
 
@@ -56,8 +58,16 @@ compile_armbian-zsh() {
 	cp -R "${SRC}"/cache/sources/oh-my-zsh "${tmp_dir}/${armbian_zsh_dir}"/etc/
 	cp -R "${SRC}"/cache/sources/evalcache "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/plugins
 
+	# the two most-wanted external plugins: fish-style history suggestions and
+	# command-line syntax highlighting. Dropped into custom/plugins (where oh-my-zsh
+	# resolves plugin names first) and enabled in the plugins=() list below.
+	mkdir -p "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/custom/plugins
+	cp -R "${SRC}"/cache/sources/zsh-autosuggestions "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/custom/plugins
+	cp -R "${SRC}"/cache/sources/zsh-syntax-highlighting "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/custom/plugins
+
 	# @TODO: do this properly (not-copy it to begin with)
 	rm -rf "${tmp_dir}/${armbian_zsh_dir}"/etc/.git "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/plugins/.git
+	find "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/custom/plugins -type d -name .git -prune -exec rm -rf {} +
 
 	# bash<->zsh compatibility shims, auto-loaded for every user via oh-my-zsh
 	# ($ZSH/custom/*.zsh) so it is not baked per-.zshrc. Restores the bash builtins
@@ -107,7 +117,9 @@ compile_armbian-zsh() {
 	sed -i "s/^# zstyle ':omz:update' mode disabled.*/zstyle ':omz:update' mode disabled/g" "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc
 
 	# define default plugins
-	sed -i 's/^plugins=.*/plugins=(evalcache git git-extras debian tmux screen history extract colorize web-search docker)/' "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc
+	# zsh-syntax-highlighting must stay LAST — it wraps the line editor and has to
+	# load after every other plugin's widgets are defined.
+	sed -i 's/^plugins=.*/plugins=(evalcache git git-extras debian tmux screen history extract colorize web-search docker zsh-autosuggestions zsh-syntax-highlighting)/' "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc
 
 	# add collection of Armbian BASH aliases also to ZSH. They are compatible
 	cat "${SRC}"/packages/bsp/common/etc/skel/.bash_aliases >> "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -100,6 +100,17 @@ compile_armbian-zsh() {
 		fi
 	ARMBIAN_COMPAT_EOF
 
+	# Small history deltas layered on top of oh-my-zsh's own config (which already
+	# sets HISTSIZE/dedup/share_history/hist_verify and the completion styling).
+	# Loaded after it via $ZSH/custom/*.zsh.
+	cat > "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/custom/armbian-defaults.zsh <<- 'ARMBIAN_DEFAULTS_EOF'
+		# Armbian zsh defaults, layered on oh-my-zsh's history/completion config.
+		# oh-my-zsh caps SAVEHIST at 10000 while keeping 50000 in memory; persist the
+		# full set to disk, and trim blanks / skip duplicate search hits.
+		SAVEHIST=$HISTSIZE
+		setopt HIST_REDUCE_BLANKS HIST_FIND_NO_DUPS
+	ARMBIAN_DEFAULTS_EOF
+
 	cp "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/templates/zshrc.zsh-template "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc
 
 	chmod -R g-w,o-w "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -18,7 +18,7 @@ compile_armbian-zsh() {
 	mkdir -p "${tmp_dir}/${armbian_zsh_dir}"
 
 	fetch_from_repo "$GITHUB_SOURCE/ohmyzsh/ohmyzsh" "oh-my-zsh" "${ARMBIAN_ZSH_BRANCH}"
-	fetch_from_repo "$GITHUB_SOURCE/mroth/evalcache" "evalcache" "branch:master"
+	fetch_from_repo "$GITHUB_SOURCE/mroth/evalcache" "evalcache" "commit:d6973f8c3ecde3eabd75c17b47e2222e24ab3e87" # 2025-11-24
 
 	mkdir -p "${tmp_dir}/${armbian_zsh_dir}"/{DEBIAN,etc/skel/,etc/oh-my-zsh/,/etc/skel/.oh-my-zsh/cache}
 

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -145,16 +145,25 @@ compile_armbian-zsh() {
 	# Enable the bundled plugins from the package-owned custom dir instead of the
 	# per-user plugins=() line, so a package upgrade turns them on for EXISTING
 	# users too (this dir is refreshed on upgrade; ~/.zshrc is only written for new
-	# users). "armbian-plugins" sorts last among the custom snippets, so
-	# zsh-syntax-highlighting is sourced after every other widget is defined.
+	# users). syntax-highlighting is deferred to a one-shot precmd hook so it hooks
+	# the line editor after all other init, regardless of custom-file order.
 	cat > "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/custom/armbian-plugins.zsh <<- 'ARMBIAN_PLUGINS_EOF'
-		# Load the plugins Armbian bundles into custom/plugins. Done here (not in
-		# ~/.zshrc's plugins=()) so upgrades reach existing users. Order matters:
-		# zsh-syntax-highlighting must be sourced last.
-		for _armbian_plugin in zsh-autosuggestions zsh-syntax-highlighting; do
-			source "${ZSH_CUSTOM:-$ZSH/custom}/plugins/${_armbian_plugin}/${_armbian_plugin}.plugin.zsh" 2>/dev/null
-		done
-		unset _armbian_plugin
+		# Load the plugins Armbian bundles, from their fixed install path under
+		# $ZSH/custom (NOT $ZSH_CUSTOM, which a user may repoint elsewhere). Done here
+		# rather than in ~/.zshrc's plugins=() so upgrades reach existing users.
+		source "$ZSH/custom/plugins/zsh-autosuggestions/zsh-autosuggestions.plugin.zsh" 2>/dev/null
+
+		# zsh-syntax-highlighting must hook the line editor LAST. Custom files load in
+		# filename order, so a later one could add widgets after us; defer it to a
+		# one-shot precmd hook that fires just before the first prompt, after all init
+		# (including the user's ~/.zshrc) has run.
+		autoload -Uz add-zsh-hook
+		_armbian_zsh_highlight() {
+			source "$ZSH/custom/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.plugin.zsh" 2>/dev/null
+			add-zsh-hook -d precmd _armbian_zsh_highlight
+			unfunction _armbian_zsh_highlight
+		}
+		add-zsh-hook precmd _armbian_zsh_highlight
 	ARMBIAN_PLUGINS_EOF
 
 	cp "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/templates/zshrc.zsh-template "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc


### PR DESCRIPTION
Four focused, independent improvements to the `armbian-zsh` package — each its own commit so they can be reviewed (or dropped) individually.

### 1. Restore bash-only builtins for interactive parity
zsh lacks a few bash builtins, so bash one-liners typed at the prompt fail after switching the login shell. Ship `/etc/oh-my-zsh/custom/armbian-compat.zsh` (auto-loaded for every user via `$ZSH/custom/*.zsh`, after `compinit`) that runs `bashcompinit` (restores `complete`/`compgen`/`compopt`) and shims `mapfile`/`readarray`. Scope note: `#!/bin/bash` scripts run under bash regardless of login shell, so this only affects interactive input.

### 2. Bump oh-my-zsh (was **2023-05-21**) and pin evalcache
The bundled oh-my-zsh was pinned to a commit ~2.5 years old — missed fixes, completions and security updates. Bumped to current. Also pinned `evalcache` to a commit instead of tracking `branch:master`, so builds are reproducible.

### 3. Bundle zsh-autosuggestions + zsh-syntax-highlighting
The two external plugins that make zsh feel modern weren't shipped. Vendored the same way `evalcache` already is (pinned commits), dropped into `custom/plugins`, enabled in `plugins=()` with `zsh-syntax-highlighting` **last** (it wraps the line editor). `.git` dirs stripped so they don't bloat the `.deb`.

### 4. Persist more shell history
oh-my-zsh already sets sane history + completion defaults, so nothing is duplicated. The one gap is `SAVEHIST=10000` while 50000 is kept in memory. A small `custom/armbian-defaults.zsh` raises `SAVEHIST` to `HISTSIZE` and adds `HIST_REDUCE_BLANKS` / `HIST_FIND_NO_DUPS`.

## Testing
- `bash -n` + editorconfig clean on both packaging scripts.
- Both generated custom snippets pass `zsh -n`; verified under zsh 5.9: `complete`/`compgen` resolve, `mapfile -t`/`readarray` populate arrays, `SAVEHIST=50000` and the two options applied.
- Confirmed via upstream oh-my-zsh that `$ZSH_CUSTOM/*.zsh` auto-sources after `compinit`, and that its `lib/history.zsh` / `lib/completion.zsh` already cover the rest (so #4 is only the delta).

## Deliberately not included
- `tmux` → `Recommends` (footprint win) — happy to add, kept out to stay behavior-neutral here.
- Moving `.bash_aliases` to a shared runtime-sourced file (kills snapshot drift) — its own PR, since it changes behavior slightly.
- `SH_WORD_SPLIT` — real plugin-regression risk; left opt-in.

> Note: needs a package build to smoke-test the new omz pin + plugins end-to-end before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bundled Zsh autosuggestions and syntax-highlighting plugins.
  - Enabled automatic plugin activation for existing installations.
  - Added improved shell history defaults, including configurable history size, duplicate suppression, and blank-line reduction.

- **Improvements**
  - Updated the packaged Zsh source revision.
  - Improved array-input compatibility, including delimiter handling, final records, and file-descriptor input.
  - Ensured syntax highlighting loads after other Zsh plugins for reliable shell startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->