### PR TITLE
ayn-odin3: stock ABL UEFI default, ROCKNIX sync, headphone and fan fixes

### DIFF
--- a/config/boards/ayn-odin3.csc
+++ b/config/boards/ayn-odin3.csc
@@ -91,6 +91,8 @@ function pre_customize_image__ayn-odin3_alsa_ucm_conf() {
 			unzip_dir=$(unzip -Z1 temp.zip | head -n1 | cut -d/ -f1)
 			cp -rf "${unzip_dir}/"* .
 			rm -rf "$unzip_dir" temp.zip
+			# UEFI boot composes a different UCM card name than the ABL bootimg one
+			ln -sf SM8750-AYN.conf ucm2/conf.d/sm8750/ayn-AYNOdin3-.conf
 		)
 	)
 }

--- a/config/boards/ayn-odin3.csc
+++ b/config/boards/ayn-odin3.csc
@@ -82,19 +82,11 @@ else
 fi
 
 function pre_customize_image__ayn-odin3_alsa_ucm_conf() {
-	display_alert "Add alsa-ucm-conf for ${BOARD}" "${RELEASE}" "warn"
-	(
-		(
-			cd "${SDCARD}/usr/share/alsa" || exit 6
-			curl -L -o temp.zip "${GITHUB_SOURCE}/AYNTechnologies/alsa-ucm-conf/archive/refs/heads/ayn/v1.2.15.3.zip"
-			unzip -o temp.zip
-			unzip_dir=$(unzip -Z1 temp.zip | head -n1 | cut -d/ -f1)
-			cp -rf "${unzip_dir}/"* .
-			rm -rf "$unzip_dir" temp.zip
-			# UEFI boot composes a different UCM card name than the ABL bootimg one
-			ln -sf SM8750-AYN.conf ucm2/conf.d/sm8750/ayn-AYNOdin3-.conf
-		)
-	)
+	# Vendored AYN SM8750 UCM with the Class-AB headphone bring-up and the
+	# entrypoint for the UEFI card name; stock codec sequences come from the
+	# distro alsa-ucm-conf package.
+	display_alert "Install alsa-ucm for ${BOARD}" "vendored AYN SM8750 UCM" "info"
+	cp -a "${SRC}/packages/bsp/${BOARD}/usr/share/alsa/." "${SDCARD}"/usr/share/alsa/
 }
 
 function post_family_tweaks_bsp__ayn-odin3_firmware() {

--- a/config/boards/ayn-odin3.csc
+++ b/config/boards/ayn-odin3.csc
@@ -55,16 +55,16 @@ else
 
 		gzip -c "${MOUNT}"/boot/Image > /tmp/Image.gz
 		cat /tmp/Image.gz "${MOUNT}"/boot/dtb/qcom/cq8725s-ayn-odin3.dtb > /tmp/Image.gz-dtb
-		/tmp/mkbootimg  \
-			--kernel /tmp/Image.gz-dtb  \
-			--ramdisk "${MOUNT}"/boot/initrd.img-${initrd_name}  \
-			--base 0x0  \
-			--second_offset 0x00f00000  \
-			--cmdline "clk_ignore_unused pd_ignore_unused console=tty0 ignore_loglevel rw rootwait root=UUID=${rootfs_image_uuid}"  \
-			--kernel_offset 0x10008000          \
-			--ramdisk_offset 0x16000000         \
-			--tags_offset 0x10000100         \
-			--pagesize 2048   -o "${MOUNT}"/boot/KERNEL
+		/tmp/mkbootimg \
+			--kernel /tmp/Image.gz-dtb \
+			--ramdisk "${MOUNT}"/boot/initrd.img-${initrd_name} \
+			--base 0x0 \
+			--second_offset 0x00f00000 \
+			--cmdline "clk_ignore_unused pd_ignore_unused console=tty0 ignore_loglevel rw rootwait root=UUID=${rootfs_image_uuid}" \
+			--kernel_offset 0x10008000 \
+			--ramdisk_offset 0x16000000 \
+			--tags_offset 0x10000100 \
+			--pagesize 2048 -o "${MOUNT}"/boot/KERNEL
 		rm /tmp/Image.gz /tmp/Image.gz-dtb /tmp/mkbootimg
 	}
 

--- a/config/boards/ayn-odin3.csc
+++ b/config/boards/ayn-odin3.csc
@@ -146,6 +146,23 @@ function post_family_tweaks__ayn-odin3_enable_services() {
 	return 0
 }
 
+function post_family_tweaks__ayn-odin3_mesa_backports() {
+	# The Adreno 830 needs a newer Mesa than trixie ships; pull the GL and
+	# Vulkan stack from backports, otherwise the desktop falls back to llvmpipe.
+	# Only trixie needs this: sid and forky already carry 26.1, and Ubuntu has
+	# no backports pocket with a newer Mesa (noble 25.2, resolute 26.0).
+	# The Armbian rootfs already lists trixie-backports in debian.sources.
+	if [[ "${DISTRIBUTION}" != "Debian" || "${RELEASE}" != "trixie" ]]; then
+		display_alert "No Mesa backports path for this release" "${DISTRIBUTION} ${RELEASE}" "warn"
+		return 0
+	fi
+	do_with_retries 3 chroot_sdcard_apt_get -t trixie-backports install libgl1-mesa-dri libegl-mesa0 libgbm1 mesa-vulkan-drivers
+
+	# GMEM workaround for the A830, harmless where it does not apply
+	mkdir -p "${SDCARD}"/etc/environment.d
+	echo "FD_MESA_DEBUG=sysmem" > "${SDCARD}"/etc/environment.d/50-odin3-mesa.conf
+}
+
 function post_family_tweaks_bsp__ayn-odin3_bsp_firmware_in_initrd() {
 	display_alert "Adding to bsp-cli" "${BOARD}: firmware in initrd" "warn"
 	declare file_added_to_bsp_destination # Will be filled in by add_file_from_stdin_to_bsp_destination

--- a/config/boards/ayn-odin3.csc
+++ b/config/boards/ayn-odin3.csc
@@ -20,46 +20,66 @@ if [[ ! " ${VALID_BOARDS[*]} " =~ " ${BOARD} " ]]; then
 	exit_with_error "Error: Invalid board '$BOARD'. Valid options are: ${VALID_BOARDS[*]}" >&2
 fi
 
-declare -g BOOTFS_TYPE="fat"
-declare -g BOOTSIZE="512"
-declare -g IMAGE_PARTITION_TABLE="msdos"
-declare -g BOOTIMG_CMDLINE_EXTRA="clk_ignore_unused pd_ignore_unused rw quiet rootwait"
+# Default boots via the stock ABL UEFI (GRUB on an ESP, nothing gets flashed);
+# WITH_GRUB=no switches to the Android bootimg path over the ROCKNIX ABL.
+declare -g WITH_GRUB="${WITH_GRUB:-yes}"
 
-function pre_umount_final_image__update_ABL_settings() {
-	if [ -z "$BOOTFS_TYPE" ]; then
-		return 0
-	fi
-	display_alert "Update ABL settings for " "${BOARD}" "info"
-	uuid_line=$(head -n 1 "${SDCARD}"/etc/fstab)
-	rootfs_image_uuid=$(echo "${uuid_line}" | awk '{print $1}' | awk -F '=' '{print $2}')
-	[[ -n "$rootfs_image_uuid" ]] || exit_with_error "Could not determine rootfs UUID"
-	initrd_name=$(find "${SDCARD}/boot/" -type f -name "config-*" | sed 's/.*config-//')
+if [[ "${WITH_GRUB}" == "yes" ]]; then
+	declare -g UEFI_GRUB_TERMINAL="gfxterm"
+	declare -g GRUB_CMDLINE_LINUX_DEFAULT="rootwait quiet video=efifb:off console=tty0 irqaffinity=0-1 cgroup.memory=nokmem,nosocket nosoftlockup arm64.nopauth efi=noruntime fbcon=rotate:1"
+	declare -g BOOT_FDT_FILE="qcom/cq8725s-${BOARD}.dtb"
+	declare -g SERIALCON="${SERIALCON:-tty0}"
 
-	cp /usr/bin/mkbootimg /tmp/mkbootimg
-	sed -i 's/from gki.generate_gki_certificate import generate_gki_certificate/# &/' /tmp/mkbootimg
-	chmod +x /tmp/mkbootimg
+	enable_extension "grub"
+	enable_extension "grub-with-dtb"
+else
+	declare -g BOOTFS_TYPE="fat"
+	declare -g BOOTSIZE="512"
+	declare -g IMAGE_PARTITION_TABLE="msdos"
+	declare -g BOOTIMG_CMDLINE_EXTRA="clk_ignore_unused pd_ignore_unused rw quiet rootwait"
 
-	gzip -c "${MOUNT}"/boot/Image > /tmp/Image.gz
-	cat /tmp/Image.gz "${MOUNT}"/boot/dtb/qcom/cq8725s-ayn-odin3.dtb > /tmp/Image.gz-dtb
-	/tmp/mkbootimg  \
-		--kernel /tmp/Image.gz-dtb  \
-		--ramdisk "${MOUNT}"/boot/initrd.img-${initrd_name}  \
-		--base 0x0  \
-		--second_offset 0x00f00000  \
-		--cmdline "clk_ignore_unused pd_ignore_unused console=tty0 ignore_loglevel rw rootwait root=UUID=${rootfs_image_uuid}"  \
-		--kernel_offset 0x10008000          \
-		--ramdisk_offset 0x16000000         \
-		--tags_offset 0x10000100         \
-		--pagesize 2048   -o "${MOUNT}"/boot/KERNEL
-	rm /tmp/Image.gz /tmp/Image.gz-dtb /tmp/mkbootimg
-}
+	function extension_prepare_config__ayn_odin3_image_suffix() {
+		EXTRA_IMAGE_SUFFIXES+=("-abl")
+	}
 
-function post_create_partitions__change_bootpart_type() {
-	display_alert "Setting boot partition type to Win95 on" "${SDCARD}.raw" "info"
+	function pre_umount_final_image__update_ABL_settings() {
+		display_alert "Update ABL settings for " "${BOARD}" "info"
+		uuid_line=$(head -n 1 "${SDCARD}"/etc/fstab)
+		rootfs_image_uuid=$(echo "${uuid_line}" | awk '{print $1}' | awk -F '=' '{print $2}')
+		[[ -n "$rootfs_image_uuid" ]] || exit_with_error "Could not determine rootfs UUID"
+		initrd_name=$(find "${SDCARD}/boot/" -type f -name "config-*" | sed 's/.*config-//')
 
-	# Needed for Android to mount this partition
-	run_host_command_logged parted "${SDCARD}".raw type 1 0xb
-}
+		cp /usr/bin/mkbootimg /tmp/mkbootimg
+		sed -i 's/from gki.generate_gki_certificate import generate_gki_certificate/# &/' /tmp/mkbootimg
+		chmod +x /tmp/mkbootimg
+
+		gzip -c "${MOUNT}"/boot/Image > /tmp/Image.gz
+		cat /tmp/Image.gz "${MOUNT}"/boot/dtb/qcom/cq8725s-ayn-odin3.dtb > /tmp/Image.gz-dtb
+		/tmp/mkbootimg  \
+			--kernel /tmp/Image.gz-dtb  \
+			--ramdisk "${MOUNT}"/boot/initrd.img-${initrd_name}  \
+			--base 0x0  \
+			--second_offset 0x00f00000  \
+			--cmdline "clk_ignore_unused pd_ignore_unused console=tty0 ignore_loglevel rw rootwait root=UUID=${rootfs_image_uuid}"  \
+			--kernel_offset 0x10008000          \
+			--ramdisk_offset 0x16000000         \
+			--tags_offset 0x10000100         \
+			--pagesize 2048   -o "${MOUNT}"/boot/KERNEL
+		rm /tmp/Image.gz /tmp/Image.gz-dtb /tmp/mkbootimg
+	}
+
+	function post_create_partitions__change_bootpart_type() {
+		display_alert "Setting boot partition type to Win95 on" "${SDCARD}.raw" "info"
+
+		# Needed for Android to mount this partition
+		run_host_command_logged parted "${SDCARD}".raw type 1 0xb
+	}
+
+	function post_family_tweaks_bsp__ayn_odin3_abl_kernel_postinst() {
+		# Kernel postinst script to update abl boot partition
+		install -Dm755 $SRC/packages/bsp/ayn-odin3/zz-update-abl-kernel $destination/etc/kernel/postinst.d/
+	}
+fi
 
 function pre_customize_image__ayn-odin3_alsa_ucm_conf() {
 	display_alert "Add alsa-ucm-conf for ${BOARD}" "${RELEASE}" "warn"
@@ -90,9 +110,6 @@ function post_family_tweaks_bsp__ayn-odin3_firmware() {
 	install -Dm755 $SRC/packages/bsp/usb-gadget-network/dropbear $destination/etc/initramfs-tools/scripts/init-premount/
 	install -Dm755 $SRC/packages/bsp/usb-gadget-network/kill-dropbear $destination/etc/initramfs-tools/scripts/init-bottom/
 
-	# Kernel postinst script to update abl boot partition
-	install -Dm755 $SRC/packages/bsp/ayn-odin3/zz-update-abl-kernel $destination/etc/kernel/postinst.d/
-
 	return 0
 }
 
@@ -102,11 +119,17 @@ function post_family_tweaks__ayn-odin3_enable_services() {
 
 	do_with_retries 3 chroot_sdcard_apt_get_update
 	display_alert "Installing ${BOARD} tweaks" "warn"
-	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools unudhcpd mkbootimg
+	declare -a abl_only_pkgs=()
+	if [[ "${WITH_GRUB}" != "yes" ]]; then
+		abl_only_pkgs+=(qbootctl mkbootimg)
+	fi
+	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qrtr-tools unudhcpd "${abl_only_pkgs[@]}"
 	# disable armbian repo back
 	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.sources "${SDCARD}"/etc/apt/sources.list.d/armbian.sources.disabled
 	do_with_retries 3 chroot_sdcard_apt_get_update
-	chroot_sdcard systemctl enable qbootctl.service
+	if [[ "${WITH_GRUB}" != "yes" ]]; then
+		chroot_sdcard systemctl enable qbootctl.service
+	fi
 
 	# Add Gamepad udev rule
 	echo 'SUBSYSTEM=="input", ATTRS{name}=="AYN Odin3 Gamepad", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"' > "${SDCARD}"/etc/udev/rules.d/99-ignore-gamepad.rules
@@ -114,7 +137,9 @@ function post_family_tweaks__ayn-odin3_enable_services() {
 	chroot_sdcard systemctl mask suspend.target
 
 	chroot_sdcard systemctl enable usbgadget-rndis.service
-	cp -a "${SRC}/packages/bsp/${BOARD}/rocknix_abl" "${SDCARD}"/boot/
+	if [[ "${WITH_GRUB}" != "yes" ]]; then
+		cp -a "${SRC}/packages/bsp/${BOARD}/rocknix_abl" "${SDCARD}"/boot/
+	fi
 
 	return 0
 }

--- a/packages/bsp/ayn-odin3/usr/share/alsa/ucm2/AYN/SM8750/HiFi.conf
+++ b/packages/bsp/ayn-odin3/usr/share/alsa/ucm2/AYN/SM8750/HiFi.conf
@@ -1,0 +1,46 @@
+# Use case configuration for AYN SM8750
+# Author: Teguh Sobirin <teguh@sobir.in>
+
+SectionVerb {
+	EnableSequence [
+		cset "name='SECONDARY_MI2S_RX Audio Mixer MultiMedia1' 1"
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
+		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
+	]
+
+	Include.wcde.File "/codecs/wcd939x/DefaultEnableSeq.conf"
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones playback"
+
+	Include.wcdhpe.File "/codecs/wcd939x/HeadphoneABEnableSeq.conf"
+	Include.wcdhpd.File "/codecs/wcd939x/HeadphoneDisableSeq.conf"
+	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
+	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "HP Digital"
+		JackControl "Headphone Jack"
+		JackHWMute "Speaker"
+	}
+}

--- a/packages/bsp/ayn-odin3/usr/share/alsa/ucm2/AYN/SM8750/SM8750-AYN.conf
+++ b/packages/bsp/ayn-odin3/usr/share/alsa/ucm2/AYN/SM8750/SM8750-AYN.conf
@@ -1,0 +1,31 @@
+# Use case configuration for AYN SM8750
+# Author: Teguh Sobirin <teguh@sobir.in>
+
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/AYN/SM8750/HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+BootSequence [
+	cset "name='RX_RX0 Digital Volume' 84"
+	cset "name='RX_RX1 Digital Volume' 84"
+	cset "name='HPHL Volume' 22"
+	cset "name='HPHR Volume' 22"
+	cset "name='ADC2 Volume' 10"
+]
+
+LibraryConfig.remap.Config {
+
+	ctl.default.map {
+		"name='HP Volume'" {
+			"name='HPHL Volume'".vindex.0 0
+			"name='HPHR Volume'".vindex.1 0
+		}
+	}
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wcd-init.File "/codecs/wcd939x/init.conf"

--- a/packages/bsp/ayn-odin3/usr/share/alsa/ucm2/codecs/wcd939x/HeadphoneABEnableSeq.conf
+++ b/packages/bsp/ayn-odin3/usr/share/alsa/ucm2/codecs/wcd939x/HeadphoneABEnableSeq.conf
@@ -1,0 +1,18 @@
+# Class-AB HiFi headphone bring-up for wcd939x.
+# The stock HeadphoneEnableSeq brings the amp up in CLS_H_ULP with the
+# compander on: weak drive, audible distortion and an output that
+# collapses at high volume. CLS_AB_HIFI provides the headroom, HD2
+# compensates the RDAC even-order harmonics and the compander stays off.
+# Same operating point radxa ships for the wcd938x Dragon Q8B
+# (radxa-pkg/alsa-ucm-conf#18), adapted to the wcd939x control names.
+EnableSequence [
+	cset "name='HPHL_RDAC Switch' 1"
+	cset "name='HPHR_RDAC Switch' 1"
+	cset "name='RX_HPH HD2 Mode Switch' 1"
+	cset "name='HPHL_COMP Switch' 0"
+	cset "name='HPHR_COMP Switch' 0"
+	cset "name='HPHL Switch' 1"
+	cset "name='HPHR Switch' 1"
+	cset "name='CLSH Switch' 1"
+	cset "name='RX HPH Mode' CLS_AB_HIFI"
+]

--- a/packages/bsp/ayn-odin3/usr/share/alsa/ucm2/conf.d/sm8750/SM8750-AYN.conf
+++ b/packages/bsp/ayn-odin3/usr/share/alsa/ucm2/conf.d/sm8750/SM8750-AYN.conf
@@ -1,0 +1,31 @@
+# Use case configuration for AYN SM8750
+# Author: Teguh Sobirin <teguh@sobir.in>
+
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/AYN/SM8750/HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+BootSequence [
+	cset "name='RX_RX0 Digital Volume' 84"
+	cset "name='RX_RX1 Digital Volume' 84"
+	cset "name='HPHL Volume' 22"
+	cset "name='HPHR Volume' 22"
+	cset "name='ADC2 Volume' 10"
+]
+
+LibraryConfig.remap.Config {
+
+	ctl.default.map {
+		"name='HP Volume'" {
+			"name='HPHL Volume'".vindex.0 0
+			"name='HPHR Volume'".vindex.1 0
+		}
+	}
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wcd-init.File "/codecs/wcd939x/init.conf"

--- a/packages/bsp/ayn-odin3/usr/share/alsa/ucm2/conf.d/sm8750/ayn-AYNOdin3-.conf
+++ b/packages/bsp/ayn-odin3/usr/share/alsa/ucm2/conf.d/sm8750/ayn-AYNOdin3-.conf
@@ -1,0 +1,1 @@
+../../AYN/SM8750/SM8750-AYN.conf

--- a/patch/kernel/archive/sm8750-7.1/0026-dt-bindings-arm-qcom-ids-Add-SoC-ID-for-CQ8725S.patch
+++ b/patch/kernel/archive/sm8750-7.1/0026-dt-bindings-arm-qcom-ids-Add-SoC-ID-for-CQ8725S.patch
@@ -1,7 +1,7 @@
-From bddc7653fb7c4226f618efd88f9ffc31c251289c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Tue, 7 Apr 2026 16:15:46 +0800
-Subject: [PATCH] dt-bindings: arm: qcom,ids: Add SoC ID for CQ8725S
+Subject: dt-bindings: arm: qcom,ids: Add SoC ID for CQ8725S
 
 Add the ID for the Qualcomm CQ8725S SoC which represents the Pakala
 platform.
@@ -12,7 +12,7 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  1 file changed, 1 insertion(+)
 
 diff --git a/include/dt-bindings/arm/qcom,ids.h b/include/dt-bindings/arm/qcom,ids.h
-index 336f7bb..4c9527e 100644
+index 111111111111..222222222222 100644
 --- a/include/dt-bindings/arm/qcom,ids.h
 +++ b/include/dt-bindings/arm/qcom,ids.h
 @@ -294,6 +294,7 @@
@@ -23,3 +23,6 @@ index 336f7bb..4c9527e 100644
  #define QCOM_ID_QCS8275			675
  #define QCOM_ID_QCS9075			676
  #define QCOM_ID_QCS615			680
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0027-soc-qcom-socinfo-Add-CQ8725S-SoC-ID.patch
+++ b/patch/kernel/archive/sm8750-7.1/0027-soc-qcom-socinfo-Add-CQ8725S-SoC-ID.patch
@@ -1,7 +1,7 @@
-From da5d624f4ffb26427dfff5299bd98c95f3ac8327 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Tue, 7 Apr 2026 16:21:01 +0800
-Subject: [PATCH] soc: qcom: socinfo: Add CQ8725S SoC ID
+Subject: soc: qcom: socinfo: Add CQ8725S SoC ID
 
 Add the ID for the Qualcomm CQ8725S SoC which represents the Pakala
 platform.
@@ -12,7 +12,7 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/soc/qcom/socinfo.c b/drivers/soc/qcom/socinfo.c
-index 8ffd903..b2a5357 100644
+index 111111111111..222222222222 100644
 --- a/drivers/soc/qcom/socinfo.c
 +++ b/drivers/soc/qcom/socinfo.c
 @@ -522,6 +522,7 @@ static const struct soc_id soc_id[] = {
@@ -23,3 +23,6 @@ index 8ffd903..b2a5357 100644
  	{ qcom_board_id(QCS8300) },
  	{ qcom_board_id(QCS8275) },
  	{ qcom_board_id(QCS9075) },
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0028-drm-panel-Add-panel-driver-for-Chipone-ICNA35XX-base.patch
+++ b/patch/kernel/archive/sm8750-7.1/0028-drm-panel-Add-panel-driver-for-Chipone-ICNA35XX-base.patch
@@ -1,23 +1,22 @@
-From 4c5e76e974db7cca853619ca138eecd8f004622f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Mon, 27 Oct 2025 16:51:01 +0800
-Subject: [PATCH] drm/panel: Add panel driver for Chipone ICNA35XX based panels
+Subject: drm/panel: Add panel driver for Chipone ICNA35XX based panels
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
- drivers/gpu/drm/panel/Kconfig                 |  11 +
- drivers/gpu/drm/panel/Makefile                |   1 +
- .../gpu/drm/panel/panel-chipone-icna35xx.c    | 551 ++++++++++++++++++
- 3 files changed, 563 insertions(+)
- create mode 100644 drivers/gpu/drm/panel/panel-chipone-icna35xx.c
+ drivers/gpu/drm/panel/Kconfig                  |  11 +
+ drivers/gpu/drm/panel/Makefile                 |   1 +
+ drivers/gpu/drm/panel/panel-chipone-icna35xx.c | 572 ++++++++++
+ 3 files changed, 584 insertions(+)
 
 diff --git a/drivers/gpu/drm/panel/Kconfig b/drivers/gpu/drm/panel/Kconfig
-index 3bcf710414dd..cc2b93322628 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/panel/Kconfig
 +++ b/drivers/gpu/drm/panel/Kconfig
-@@ -115,6 +115,17 @@ config DRM_PANEL_BOE_XM91080G
- 	  Say Y if you want to enable support for panels based on the
- 	  Xm-Plus XM91080G controller.
+@@ -105,6 +105,17 @@ config DRM_PANEL_BOE_TV101WUM_LL2
+ 	  Say Y here if you want to support for BOE TV101WUM-LL2
+ 	  WUXGA PANEL DSI Video Mode panel
  
 +config DRM_PANEL_CHIPONE_ICNA35XX
 +	tristate "Chipone ICNA35XX panel driver"
@@ -34,10 +33,10 @@ index 3bcf710414dd..cc2b93322628 100644
  	tristate "EBBG FT8719 panel driver"
  	depends on OF
 diff --git a/drivers/gpu/drm/panel/Makefile b/drivers/gpu/drm/panel/Makefile
-index 4b64459f88b5..339a5cb9f31b 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/panel/Makefile
 +++ b/drivers/gpu/drm/panel/Makefile
-@@ -9,6 +9,7 @@
+@@ -9,6 +9,7 @@ obj-$(CONFIG_DRM_PANEL_BOE_TD4320) += panel-boe-td4320.o
  obj-$(CONFIG_DRM_PANEL_BOE_TH101MB31UIG002_28A) += panel-boe-th101mb31ig002-28a.o
  obj-$(CONFIG_DRM_PANEL_BOE_TV101WUM_LL2) += panel-boe-tv101wum-ll2.o
  obj-$(CONFIG_DRM_PANEL_BOE_TV101WUM_NL6) += panel-boe-tv101wum-nl6.o
@@ -47,7 +46,7 @@ index 4b64459f88b5..339a5cb9f31b 100644
  obj-$(CONFIG_DRM_PANEL_SIMPLE) += panel-simple.o
 diff --git a/drivers/gpu/drm/panel/panel-chipone-icna35xx.c b/drivers/gpu/drm/panel/panel-chipone-icna35xx.c
 new file mode 100644
-index 000000000000..fe4742678c00
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/gpu/drm/panel/panel-chipone-icna35xx.c
 @@ -0,0 +1,572 @@
@@ -625,4 +624,5 @@ index 000000000000..fe4742678c00
 +MODULE_LICENSE("GPL");
 \ No newline at end of file
 -- 
-2.34.1
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0029-Input-edt-ft5x06-add-no_regmap_bulk_read-option.patch
+++ b/patch/kernel/archive/sm8750-7.1/0029-Input-edt-ft5x06-add-no_regmap_bulk_read-option.patch
@@ -1,17 +1,17 @@
-From 5d03573d867f15f248b9f05f6d75cc9ff0f510c3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Mon, 27 Oct 2025 18:32:01 +0800
-Subject: [PATCH 31/59] Input: edt-ft5x06 - add no_regmap_bulk_read option
+Subject: Input: edt-ft5x06 - add no_regmap_bulk_read option
 
 AYN SM8550 have problem with regmap_bulk_read under i2c_hub_*
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
- drivers/input/touchscreen/edt-ft5x06.c | 42 ++++++++++++++++++++++++--
+ drivers/input/touchscreen/edt-ft5x06.c | 42 +++++++++-
  1 file changed, 40 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/input/touchscreen/edt-ft5x06.c b/drivers/input/touchscreen/edt-ft5x06.c
-index d0ab644be006..6d745b564f7c 100644
+index 111111111111..222222222222 100644
 --- a/drivers/input/touchscreen/edt-ft5x06.c
 +++ b/drivers/input/touchscreen/edt-ft5x06.c
 @@ -146,6 +146,7 @@ struct edt_ft5x06_ts_data {
@@ -75,7 +75,7 @@ index d0ab644be006..6d745b564f7c 100644
  	if (error) {
  		dev_err_ratelimited(dev, "Unable to fetch data, error: %d\n",
  				    error);
-@@ -1232,6 +1268,8 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client)
+@@ -1210,6 +1246,8 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client)
  		return error;
  	}
  
@@ -85,5 +85,5 @@ index d0ab644be006..6d745b564f7c 100644
  	 * Check which sleep modes we can support. Power-off requires the
  	 * reset-pin to ensure correct power-down/power-up behaviour. Start with
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0030-leds-Add-driver-for-HEROIC-HTR3212.patch
+++ b/patch/kernel/archive/sm8750-7.1/0030-leds-Add-driver-for-HEROIC-HTR3212.patch
@@ -1,18 +1,17 @@
-From 3b3022ba1468aa2d12f8fe69751479efae21d2c8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Wed, 8 Apr 2026 16:32:31 +0800
-Subject: [PATCH 05/32] leds: Add driver for HEROIC HTR3212
+Subject: leds: Add driver for HEROIC HTR3212
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
  drivers/leds/Kconfig        |  10 +
  drivers/leds/Makefile       |   1 +
- drivers/leds/leds-htr3212.c | 362 ++++++++++++++++++++++++++++++++++++
+ drivers/leds/leds-htr3212.c | 362 ++++++++++
  3 files changed, 373 insertions(+)
- create mode 100644 drivers/leds/leds-htr3212.c
 
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index f4a0a3c8c870..95dc7f9f21f4 100644
+index 111111111111..222222222222 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -227,6 +227,16 @@ config LEDS_EL15203000
@@ -33,7 +32,7 @@ index f4a0a3c8c870..95dc7f9f21f4 100644
  	tristate "LED support for CZ.NIC's Turris Omnia"
  	depends on LEDS_CLASS_MULTICOLOR
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 8fdb45d5b439..674bee2173c2 100644
+index 111111111111..222222222222 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -34,6 +34,7 @@ obj-$(CONFIG_LEDS_DA9052)		+= leds-da9052.o
@@ -46,7 +45,7 @@ index 8fdb45d5b439..674bee2173c2 100644
  obj-$(CONFIG_LEDS_IPAQ_MICRO)		+= leds-ipaq-micro.o
 diff --git a/drivers/leds/leds-htr3212.c b/drivers/leds/leds-htr3212.c
 new file mode 100644
-index 000000000000..599a864d804f
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/leds/leds-htr3212.c
 @@ -0,0 +1,362 @@
@@ -413,5 +412,5 @@ index 000000000000..599a864d804f
 +MODULE_DESCRIPTION("HEROIC HTR3212 LED Driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0031_input--Add-driver-for-RSInput-Gamepad.patch
+++ b/patch/kernel/archive/sm8750-7.1/0031_input--Add-driver-for-RSInput-Gamepad.patch
@@ -1,17 +1,16 @@
-From d7c33ba5a969fbcbbbe845c0dbe7b4d29c400463 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Philippe Simons <simons.philippe@gmail.com>
 Date: Sat, 21 Feb 2026 19:06:28 +0100
-Subject: [PATCH 06/32] input: Add driver for RSInput Gamepad
+Subject: input: Add driver for RSInput Gamepad
 
 ---
  drivers/input/joystick/Kconfig   |   4 +
  drivers/input/joystick/Makefile  |   1 +
- drivers/input/joystick/rsinput.c | 590 +++++++++++++++++++++++++++++++
+ drivers/input/joystick/rsinput.c | 590 ++++++++++
  3 files changed, 595 insertions(+)
- create mode 100644 drivers/input/joystick/rsinput.c
 
 diff --git a/drivers/input/joystick/Kconfig b/drivers/input/joystick/Kconfig
-index 7755e5b454d2..0da3c0f44ecf 100644
+index 111111111111..222222222222 100644
 --- a/drivers/input/joystick/Kconfig
 +++ b/drivers/input/joystick/Kconfig
 @@ -383,6 +383,10 @@ config JOYSTICK_QWIIC
@@ -26,7 +25,7 @@ index 7755e5b454d2..0da3c0f44ecf 100644
  	tristate "FlySky FS-iA6B RC Receiver"
  	select SERIO
 diff --git a/drivers/input/joystick/Makefile b/drivers/input/joystick/Makefile
-index 9976f596a920..3de503e29489 100644
+index 111111111111..222222222222 100644
 --- a/drivers/input/joystick/Makefile
 +++ b/drivers/input/joystick/Makefile
 @@ -28,6 +28,7 @@ obj-$(CONFIG_JOYSTICK_N64)		+= n64joy.o
@@ -39,7 +38,7 @@ index 9976f596a920..3de503e29489 100644
  obj-$(CONFIG_JOYSTICK_SIDEWINDER)	+= sidewinder.o
 diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
 new file mode 100644
-index 000000000000..50f3e43343ae
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/input/joystick/rsinput.c
 @@ -0,0 +1,590 @@
@@ -634,5 +633,5 @@ index 000000000000..50f3e43343ae
 +MODULE_LICENSE("GPL");
 +MODULE_DESCRIPTION("RSInput Gamepad Driver");
 -- 
-2.53.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0032-ASoC-codecs-aw88166-AYN-Products-Specific-modificati.patch
+++ b/patch/kernel/archive/sm8750-7.1/0032-ASoC-codecs-aw88166-AYN-Products-Specific-modificati.patch
@@ -1,8 +1,7 @@
-From 17f32da23dcacf6d6c06fb5131b9d1006fe1f28c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Wed, 24 Dec 2025 18:23:27 +0800
-Subject: [PATCH 34/58] ASoC: codecs: aw88166: AYN Products Specific
- modification
+Subject: ASoC: codecs: aw88166: AYN Products Specific modification
 
 - AYN Products have problem with regmap_raw_write under i2c_hub_*
 - Add .ops in aw88166_dai
@@ -11,11 +10,11 @@ Subject: [PATCH 34/58] ASoC: codecs: aw88166: AYN Products Specific
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
- sound/soc/codecs/aw88166.c | 95 ++++++++++++++++++++++++++++++++++----
- 1 file changed, 87 insertions(+), 8 deletions(-)
+ sound/soc/codecs/aw88166.c | 79 +++++++++-
+ 1 file changed, 75 insertions(+), 4 deletions(-)
 
 diff --git a/sound/soc/codecs/aw88166.c b/sound/soc/codecs/aw88166.c
-index daee4de9e3b0..8c23c6db2547 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/aw88166.c
 +++ b/sound/soc/codecs/aw88166.c
 @@ -12,7 +12,10 @@
@@ -138,7 +137,7 @@ index daee4de9e3b0..8c23c6db2547 100644
  	},
  };
  
-@@ -1802,9 +1874,16 @@ static const struct i2c_device_id aw88166_i2c_id[] = {
+@@ -1806,9 +1870,16 @@ static const struct i2c_device_id aw88166_i2c_id[] = {
  };
  MODULE_DEVICE_TABLE(i2c, aw88166_i2c_id);
  
@@ -156,5 +155,5 @@ index daee4de9e3b0..8c23c6db2547 100644
  	.probe = aw88166_i2c_probe,
  	.id_table = aw88166_i2c_id,
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0033-arm64-dts-qcom-sm8750-gpu-clock-controllers.patch
+++ b/patch/kernel/archive/sm8750-7.1/0033-arm64-dts-qcom-sm8750-gpu-clock-controllers.patch
@@ -1,18 +1,17 @@
-From cff35555a24bb9be7558c918fc505797eec4e240 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ROCKNIX <rocknix@rocknix.org>
 Date: Thu, 9 Jul 2026 00:40:08 +0100
-Subject: [PATCH] arm64: dts: qcom: sm8750: add gpucc/gxclkctl/adreno-smmu
- nodes
+Subject: arm64: dts: qcom: sm8750: add gpucc/gxclkctl/adreno-smmu nodes
 
 7.1 upstreamed the GPU/clk drivers but not the SM8750 DTS wiring.
 Carry only the dtsi provider nodes + clock-binding includes (the rest
 of the old 0000_to_0025 enablement is now upstream).
 ---
- arch/arm64/boot/dts/qcom/sm8750.dtsi | 68 ++++++++++++++++++++++++++++
+ arch/arm64/boot/dts/qcom/sm8750.dtsi | 68 ++++++++++
  1 file changed, 68 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-index 18fb52c..d5ed070 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
 @@ -6,7 +6,9 @@
@@ -25,7 +24,7 @@ index 18fb52c..d5ed070 100644
  #include <dt-bindings/clock/qcom,sm8750-tcsr.h>
  #include <dt-bindings/clock/qcom,sm8750-videocc.h>
  #include <dt-bindings/dma/qcom-gpi.h>
-@@ -3436,6 +3438,34 @@ dispcc: clock-controller@af00000 {
+@@ -3440,6 +3442,34 @@ dispcc: clock-controller@af00000 {
  			#power-domain-cells = <1>;
  		};
  
@@ -60,7 +59,7 @@ index 18fb52c..d5ed070 100644
  		pdc: interrupt-controller@b220000 {
  			compatible = "qcom,sm8750-pdc", "qcom,pdc";
  			reg = <0x0 0x0b220000 0x0 0x10000>, <0x0 0x164400f0 0x0 0x64>;
-@@ -4998,6 +5028,44 @@ tpdm_swao_out: endpoint {
+@@ -5002,6 +5032,44 @@ tpdm_swao_out: endpoint {
  			};
  		};
  
@@ -105,3 +104,6 @@ index 18fb52c..d5ed070 100644
  		apps_smmu: iommu@15000000 {
  			compatible = "qcom,sm8750-smmu-500", "qcom,smmu-500", "arm,mmu-500";
  			reg = <0x0 0x15000000 0x0 0x100000>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0034-arm64-dts-qcom-sm8750-Add-UART15.patch
+++ b/patch/kernel/archive/sm8750-7.1/0034-arm64-dts-qcom-sm8750-Add-UART15.patch
@@ -1,18 +1,18 @@
-From 3d311c4025c6b9b02de3ee7fa5338ac87c45d132 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Mon, 24 Nov 2025 14:36:51 +0800
-Subject: [PATCH 34/54] arm64: dts: qcom: sm8750: Add UART15
+Subject: arm64: dts: qcom: sm8750: Add UART15
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
- arch/arm64/boot/dts/qcom/sm8750.dtsi | 30 ++++++++++++++++++++++++++++
+ arch/arm64/boot/dts/qcom/sm8750.dtsi | 30 ++++++++++
  1 file changed, 30 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-index 0e7a343297e3..a453a350200c 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-@@ -1207,6 +1207,28 @@ &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
+@@ -1210,6 +1210,28 @@ &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
  
  				status = "disabled";
  			};
@@ -41,7 +41,7 @@ index 0e7a343297e3..a453a350200c 100644
  		};
  
  		i2c_master_hub_0: geniqup@9c0000 {
-@@ -3553,6 +3575,14 @@ qup_uart14_cts_rts: qup-uart14-cts-rts-state {
+@@ -4040,6 +4062,14 @@ qup_uart14_cts_rts: qup-uart14-cts-rts-state {
  				bias-pull-down;
  			};
  
@@ -57,5 +57,5 @@ index 0e7a343297e3..a453a350200c 100644
  				clk-pins {
  					pins = "sdc2_clk";
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0038-arm64-dts-qcom-sm8750-add-GPU-nodes.patch
+++ b/patch/kernel/archive/sm8750-7.1/0038-arm64-dts-qcom-sm8750-add-GPU-nodes.patch
@@ -1,20 +1,20 @@
-From ef99bd612f95dc880426236e82ddd8138bbe5e73 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Mon, 2 Mar 2026 16:34:11 +0800
-Subject: [PATCH 38/54] arm64: dts: qcom: sm8750: add GPU nodes
+Subject: arm64: dts: qcom: sm8750: add GPU nodes
 
 Add GPU nodes for the SM8750 platform.
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
- arch/arm64/boot/dts/qcom/sm8750.dtsi | 182 +++++++++++++++++++++++++++
+ arch/arm64/boot/dts/qcom/sm8750.dtsi | 182 ++++++++++
  1 file changed, 182 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-index c19912178fb8..1a713ef2e006 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-@@ -3028,6 +3028,188 @@ videocc: clock-controller@aaf0000 {
+@@ -3464,6 +3464,188 @@ dispcc: clock-controller@af00000 {
  			#power-domain-cells = <1>;
  		};
  
@@ -204,5 +204,5 @@ index c19912178fb8..1a713ef2e006 100644
  			compatible = "qcom,sm8750-gxclkctl";
  			reg = <0x0 0x03d64000 0x0 0x6000>;
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0039-wifi-ath12k-add-initial-hardware-definition-for-WCN7.patch
+++ b/patch/kernel/archive/sm8750-7.1/0039-wifi-ath12k-add-initial-hardware-definition-for-WCN7.patch
@@ -1,8 +1,7 @@
-From 5912ed531f24a8c8ca8d8a205747a247d9768023 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Wed, 25 Mar 2026 23:53:30 +0800
-Subject: [PATCH 39/54] wifi: ath12k: add initial hardware definition for
- WCN7860
+Subject: wifi: ath12k: add initial hardware definition for WCN7860
 
 Uses QCC2072 as a base as they seem to be from the same family.
 
@@ -11,25 +10,25 @@ Signed-off-by: Gianni Spadoni <me@gio.blue>
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
  drivers/net/wireless/ath/ath12k/core.h      |  1 +
- drivers/net/wireless/ath/ath12k/wifi7/hal.c |  7 ++
- drivers/net/wireless/ath/ath12k/wifi7/hw.c  | 88 +++++++++++++++++++++
- drivers/net/wireless/ath/ath12k/wifi7/pci.c | 22 ++++++
+ drivers/net/wireless/ath/ath12k/wifi7/hal.c |  7 +
+ drivers/net/wireless/ath/ath12k/wifi7/hw.c  | 88 ++++++++++
+ drivers/net/wireless/ath/ath12k/wifi7/pci.c | 22 +++
  4 files changed, 118 insertions(+)
 
 diff --git a/drivers/net/wireless/ath/ath12k/core.h b/drivers/net/wireless/ath/ath12k/core.h
-index 990934ec92fc..6583e0be5f66 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/ath/ath12k/core.h
 +++ b/drivers/net/wireless/ath/ath12k/core.h
-@@ -155,6 +155,7 @@ enum ath12k_hw_rev {
+@@ -156,6 +156,7 @@ enum ath12k_hw_rev {
  	ATH12K_HW_QCN9274_HW20,
  	ATH12K_HW_WCN7850_HW20,
  	ATH12K_HW_IPQ5332_HW10,
 +	ATH12K_HW_WCN7860_HW20,
  	ATH12K_HW_QCC2072_HW10,
+ 	ATH12K_HW_IPQ5424_HW10,
  };
- 
 diff --git a/drivers/net/wireless/ath/ath12k/wifi7/hal.c b/drivers/net/wireless/ath/ath12k/wifi7/hal.c
-index bd1753ca0db6..7dc8c71d3057 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/ath/ath12k/wifi7/hal.c
 +++ b/drivers/net/wireless/ath/ath12k/wifi7/hal.c
 @@ -43,6 +43,13 @@ static const struct ath12k_hw_version_map ath12k_wifi7_hw_ver_map[] = {
@@ -47,10 +46,10 @@ index bd1753ca0db6..7dc8c71d3057 100644
  		.hal_ops = &hal_qcc2072_ops,
  		.hal_desc_sz = sizeof(struct hal_rx_desc_qcc2072),
 diff --git a/drivers/net/wireless/ath/ath12k/wifi7/hw.c b/drivers/net/wireless/ath/ath12k/wifi7/hw.c
-index df045ddf42da..1eebfbb5f7a7 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/ath/ath12k/wifi7/hw.c
 +++ b/drivers/net/wireless/ath/ath12k/wifi7/hw.c
-@@ -666,6 +666,94 @@ static const struct ath12k_hw_params ath12k_wifi7_hw_params[] = {
+@@ -681,6 +681,94 @@ static const struct ath12k_hw_params ath12k_wifi7_hw_params[] = {
  
  		.dp_primary_link_only = true,
  	},
@@ -146,7 +145,7 @@ index df045ddf42da..1eebfbb5f7a7 100644
  		.name = "qcc2072 hw1.0",
  		.hw_rev = ATH12K_HW_QCC2072_HW10,
 diff --git a/drivers/net/wireless/ath/ath12k/wifi7/pci.c b/drivers/net/wireless/ath/ath12k/wifi7/pci.c
-index 6c96b52dec13..893474de488d 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/ath/ath12k/wifi7/pci.c
 +++ b/drivers/net/wireless/ath/ath12k/wifi7/pci.c
 @@ -19,6 +19,7 @@
@@ -193,5 +192,5 @@ index 6c96b52dec13..893474de488d 100644
  		ab->id.bdf_search = ATH12K_BDF_SEARCH_BUS_AND_BOARD;
  		ab_pci->msi_config = &ath12k_wifi7_msi_config[0];
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0040-wifi-ath12k-send-QDSS-config-when-CNSS_QDSS_CFG_MISS.patch
+++ b/patch/kernel/archive/sm8750-7.1/0040-wifi-ath12k-send-QDSS-config-when-CNSS_QDSS_CFG_MISS.patch
@@ -1,8 +1,8 @@
-From 23cc0f8644cba9e298d6b1a4b159a405ed203290 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gianni Spadoni <me@gio.blue>
 Date: Wed, 11 Mar 2026 16:08:41 +0800
-Subject: [PATCH 40/54] wifi: ath12k: send QDSS config when
- CNSS_QDSS_CFG_MISS_V01 is disabled
+Subject: wifi: ath12k: send QDSS config when CNSS_QDSS_CFG_MISS_V01 is
+ disabled
 
 When CNSS_QDSS_CFG_MISS_V01 is enabled, the WCN7860 crashes when initializing firmware.
 
@@ -14,15 +14,15 @@ As it stands, ath12k doesn't support sending the QDSS config - this commit adds 
 Signed-off-by: Gianni Spadoni <me@gio.blue>
 ---
  drivers/net/wireless/ath/ath12k/hw.h  |   1 +
- drivers/net/wireless/ath/ath12k/qmi.c | 203 ++++++++++++++++++++++++++
- drivers/net/wireless/ath/ath12k/qmi.h |  21 +++
+ drivers/net/wireless/ath/ath12k/qmi.c | 203 ++++++++++
+ drivers/net/wireless/ath/ath12k/qmi.h |  21 +
  3 files changed, 225 insertions(+)
 
 diff --git a/drivers/net/wireless/ath/ath12k/hw.h b/drivers/net/wireless/ath/ath12k/hw.h
-index a9888e0521a1..42999c1c8d84 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/ath/ath12k/hw.h
 +++ b/drivers/net/wireless/ath/ath12k/hw.h
-@@ -78,6 +78,7 @@
+@@ -82,6 +82,7 @@ struct ieee80211_rx_status;
  #define ATH12K_DEFAULT_CAL_FILE		"caldata.bin"
  #define ATH12K_AMSS_FILE		"amss.bin"
  #define ATH12K_M3_FILE			"m3.bin"
@@ -31,7 +31,7 @@ index a9888e0521a1..42999c1c8d84 100644
  #define ATH12K_REGDB_FILE_NAME		"regdb.bin"
  
 diff --git a/drivers/net/wireless/ath/ath12k/qmi.c b/drivers/net/wireless/ath/ath12k/qmi.c
-index c11b84b56f8f..1a7263e71aa6 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/ath/ath12k/qmi.c
 +++ b/drivers/net/wireless/ath/ath12k/qmi.c
 @@ -1582,6 +1582,113 @@ static const struct qmi_elem_info qmi_wlanfw_bdf_download_resp_msg_v01_ei[] = {
@@ -259,7 +259,7 @@ index c11b84b56f8f..1a7263e71aa6 100644
  }
  
 diff --git a/drivers/net/wireless/ath/ath12k/qmi.h b/drivers/net/wireless/ath/ath12k/qmi.h
-index b5a4a01391cb..dee0b8f4e719 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/ath/ath12k/qmi.h
 +++ b/drivers/net/wireless/ath/ath12k/qmi.h
 @@ -529,6 +529,27 @@ struct qmi_wlanfw_bdf_download_resp_msg_v01 {
@@ -291,5 +291,5 @@ index b5a4a01391cb..dee0b8f4e719 100644
  #define QMI_WLANFW_M3_INFO_RESP_MSG_V01_MAX_MSG_LEN	7
  #define QMI_WLANFW_M3_INFO_RESP_V01		0x003C
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0041-wifi-ath12k-disable-CNSS_QDSS_CFG_MISS_V01-for-the-W.patch
+++ b/patch/kernel/archive/sm8750-7.1/0041-wifi-ath12k-disable-CNSS_QDSS_CFG_MISS_V01-for-the-W.patch
@@ -1,8 +1,7 @@
-From b516f595aa98696525b8b892b0675a67618e24ea Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gianni Spadoni <me@gio.blue>
 Date: Wed, 11 Mar 2026 16:19:06 +0800
-Subject: [PATCH 41/54] wifi: ath12k: disable CNSS_QDSS_CFG_MISS_V01 for the
- WCN7860
+Subject: wifi: ath12k: disable CNSS_QDSS_CFG_MISS_V01 for the WCN7860
 
 This chip requires this change currently to negate a firmware crash. Follows up on the QDSS support in the previous commit.
 
@@ -12,10 +11,10 @@ Signed-off-by: Gianni Spadoni <me@gio.blue>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/net/wireless/ath/ath12k/wifi7/hw.c b/drivers/net/wireless/ath/ath12k/wifi7/hw.c
-index 1eebfbb5f7a7..89be65aa9d84 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/ath/ath12k/wifi7/hw.c
 +++ b/drivers/net/wireless/ath/ath12k/wifi7/hw.c
-@@ -721,8 +721,7 @@ static const struct ath12k_hw_params ath12k_wifi7_hw_params[] = {
+@@ -736,8 +736,7 @@ static const struct ath12k_hw_params ath12k_wifi7_hw_params[] = {
  
  		.wmi_init = ath12k_wifi7_wmi_init_wcn7850,
  
@@ -26,5 +25,5 @@ index 1eebfbb5f7a7..89be65aa9d84 100644
  
  		.rfkill_pin = 0,
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0042-PCI-pwrctrl-pwrseq-add-support-for-WCN7860.patch
+++ b/patch/kernel/archive/sm8750-7.1/0042-PCI-pwrctrl-pwrseq-add-support-for-WCN7860.patch
@@ -1,7 +1,7 @@
-From f29d3bbcd28fd252f3453d2e3286ebd20e5ec9af Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Wed, 25 Mar 2026 21:39:34 +0800
-Subject: [PATCH 42/54] PCI/pwrctrl: pwrseq: add support for WCN7860
+Subject: PCI/pwrctrl: pwrseq: add support for WCN7860
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  1 file changed, 5 insertions(+)
 
 diff --git a/drivers/pci/pwrctrl/pci-pwrctrl-pwrseq.c b/drivers/pci/pwrctrl/pci-pwrctrl-pwrseq.c
-index c7e4beec160a..77112a2d5b2e 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pci/pwrctrl/pci-pwrctrl-pwrseq.c
 +++ b/drivers/pci/pwrctrl/pci-pwrctrl-pwrseq.c
 @@ -123,6 +123,11 @@ static const struct of_device_id pwrseq_pwrctrl_of_match[] = {
@@ -25,5 +25,5 @@ index c7e4beec160a..77112a2d5b2e 100644
  };
  MODULE_DEVICE_TABLE(of, pwrseq_pwrctrl_of_match);
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0043-power-sequencing-qcom-wcn-add-support-for-WCN7860.patch
+++ b/patch/kernel/archive/sm8750-7.1/0043-power-sequencing-qcom-wcn-add-support-for-WCN7860.patch
@@ -1,15 +1,15 @@
-From 9d34fd9d3ae84419dd3e4dc233364a3a54bd1ae0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Wed, 25 Mar 2026 21:37:37 +0800
-Subject: [PATCH 43/54] power: sequencing: qcom-wcn: add support for WCN7860
+Subject: power: sequencing: qcom-wcn: add support for WCN7860
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
- drivers/power/sequencing/pwrseq-qcom-wcn.c | 20 ++++++++++++++++++++
+ drivers/power/sequencing/pwrseq-qcom-wcn.c | 20 ++++++++++
  1 file changed, 20 insertions(+)
 
 diff --git a/drivers/power/sequencing/pwrseq-qcom-wcn.c b/drivers/power/sequencing/pwrseq-qcom-wcn.c
-index b55b4317e21b..d43b9086c0d1 100644
+index 111111111111..222222222222 100644
 --- a/drivers/power/sequencing/pwrseq-qcom-wcn.c
 +++ b/drivers/power/sequencing/pwrseq-qcom-wcn.c
 @@ -402,6 +402,22 @@ static const struct pwrseq_qcom_wcn_pdata pwrseq_wcn7850_of_data = {
@@ -47,5 +47,5 @@ index b55b4317e21b..d43b9086c0d1 100644
  		.compatible = "qcom,wcn6750-pmu",
  		.data = &pwrseq_wcn6750_of_data,
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0044-clk-qcom-gcc-sm8750-Do-not-turn-off-PCIe-GDSCs-durin.patch
+++ b/patch/kernel/archive/sm8750-7.1/0044-clk-qcom-gcc-sm8750-Do-not-turn-off-PCIe-GDSCs-durin.patch
@@ -1,8 +1,8 @@
-From f29ed9b660f37e5228a2611cf398bfa79a7a9049 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Mon, 30 Mar 2026 11:53:45 +0800
-Subject: [PATCH 44/54] clk: qcom: gcc-sm8750: Do not turn off PCIe GDSCs
- during gdsc_disable()
+Subject: clk: qcom: gcc-sm8750: Do not turn off PCIe GDSCs during
+ gdsc_disable()
 
 With PWRSTS_OFF_ON, PCIe GDSCs are turned off during gdsc_disable(). This
 can happen during scenarios such as system suspend and breaks the resume
@@ -21,7 +21,7 @@ Signed-off-by: Teguh Sobirin <teguh@sobir.in>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/clk/qcom/gcc-sm8750.c b/drivers/clk/qcom/gcc-sm8750.c
-index db81569dd4b1..9b782e49eabf 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/qcom/gcc-sm8750.c
 +++ b/drivers/clk/qcom/gcc-sm8750.c
 @@ -2891,7 +2891,7 @@ static struct gdsc gcc_pcie_0_gdsc = {
@@ -43,5 +43,5 @@ index db81569dd4b1..9b782e49eabf 100644
  };
  
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0045-Bluetooth-qca-add-WCN7860-support.patch
+++ b/patch/kernel/archive/sm8750-7.1/0045-Bluetooth-qca-add-WCN7860-support.patch
@@ -1,12 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
-Subject: [PATCH] Bluetooth: qca: add WCN7860 support (rebased onto 7.1)
+Date: Sun, 9 Aug 2026 09:11:00 +0200
+Subject: Bluetooth: qca: add WCN7860 support (rebased onto 7.1)
 
-Rebased onto Linux 7.1: hci_qca.c switches were restructured upstream
-(QCA6390 regrouped, qca_power_shutdown renamed qca_power_off), so the
-WCN7860 case/function/struct insertions were re-derived against 7.1.
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
 ---
+ drivers/bluetooth/btqca.c   | 13 +-
+ drivers/bluetooth/btqca.h   |  1 +
+ drivers/bluetooth/hci_qca.c | 69 +++++++++-
+ 3 files changed, 81 insertions(+), 2 deletions(-)
+
 diff --git a/drivers/bluetooth/btqca.c b/drivers/bluetooth/btqca.c
-index dda7636..350c470 100644
+index 111111111111..222222222222 100644
 --- a/drivers/bluetooth/btqca.c
 +++ b/drivers/bluetooth/btqca.c
 @@ -843,6 +843,11 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
@@ -58,7 +67,7 @@ index dda7636..350c470 100644
  		err = qca_read_fw_build_info(hdev);
  		if (err < 0)
 diff --git a/drivers/bluetooth/btqca.h b/drivers/bluetooth/btqca.h
-index 8f3c1b1..3fe1873 100644
+index 111111111111..222222222222 100644
 --- a/drivers/bluetooth/btqca.h
 +++ b/drivers/bluetooth/btqca.h
 @@ -158,6 +158,7 @@ enum qca_btsoc_type {
@@ -70,10 +79,10 @@ index 8f3c1b1..3fe1873 100644
  
  #if IS_ENABLED(CONFIG_BT_QCA)
 diff --git a/drivers/bluetooth/hci_qca.c b/drivers/bluetooth/hci_qca.c
-index 3450013..9a29126 100644
+index 111111111111..222222222222 100644
 --- a/drivers/bluetooth/hci_qca.c
 +++ b/drivers/bluetooth/hci_qca.c
-@@ -1380,6 +1380,7 @@ static int qca_set_baudrate(struct hci_dev *hdev, uint8_t baudrate)
+@@ -1384,6 +1384,7 @@ static int qca_set_baudrate(struct hci_dev *hdev, uint8_t baudrate)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -81,7 +90,7 @@ index 3450013..9a29126 100644
  		usleep_range(1000, 10000);
  		break;
  
-@@ -1398,6 +1399,36 @@ static inline void host_set_baudrate(struct hci_uart *hu, unsigned int speed)
+@@ -1402,6 +1403,36 @@ static inline void host_set_baudrate(struct hci_uart *hu, unsigned int speed)
  		hci_uart_set_baudrate(hu, speed);
  }
  
@@ -118,7 +127,7 @@ index 3450013..9a29126 100644
  static int qca_send_power_pulse(struct hci_uart *hu, bool on)
  {
  	int timeout = CMD_TRANS_TIMEOUT;
-@@ -1467,6 +1498,7 @@ static int qca_check_speeds(struct hci_uart *hu)
+@@ -1471,6 +1502,7 @@ static int qca_check_speeds(struct hci_uart *hu)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -126,7 +135,7 @@ index 3450013..9a29126 100644
  		if (!qca_get_speed(hu, QCA_INIT_SPEED) &&
  		    !qca_get_speed(hu, QCA_OPER_SPEED))
  			return -EINVAL;
-@@ -1510,6 +1542,7 @@ static int qca_set_speed(struct hci_uart *hu, enum qca_speed_type speed_type)
+@@ -1514,6 +1546,7 @@ static int qca_set_speed(struct hci_uart *hu, enum qca_speed_type speed_type)
  		case QCA_WCN6750:
  		case QCA_WCN6855:
  		case QCA_WCN7850:
@@ -134,7 +143,7 @@ index 3450013..9a29126 100644
  			hci_uart_set_flow_control(hu, true);
  			break;
  
-@@ -1545,6 +1578,7 @@ error:
+@@ -1549,6 +1582,7 @@ static int qca_set_speed(struct hci_uart *hu, enum qca_speed_type speed_type)
  		case QCA_WCN6750:
  		case QCA_WCN6855:
  		case QCA_WCN7850:
@@ -142,7 +151,7 @@ index 3450013..9a29126 100644
  			hci_uart_set_flow_control(hu, false);
  			break;
  
-@@ -1861,6 +1895,7 @@ static int qca_power_on(struct hci_dev *hdev)
+@@ -1865,6 +1899,7 @@ static int qca_power_on(struct hci_dev *hdev)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -150,7 +159,7 @@ index 3450013..9a29126 100644
  		ret = qca_regulator_init(hu);
  		break;
  
-@@ -1957,6 +1992,10 @@ static int qca_setup(struct hci_uart *hu)
+@@ -1964,6 +1999,10 @@ static int qca_setup(struct hci_uart *hu)
  		soc_name = "wcn7850";
  		break;
  
@@ -161,7 +170,7 @@ index 3450013..9a29126 100644
  	default:
  		soc_name = "ROME/QCA6390";
  	}
-@@ -1980,6 +2019,7 @@ retry:
+@@ -1987,6 +2026,7 @@ static int qca_setup(struct hci_uart *hu)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -169,7 +178,7 @@ index 3450013..9a29126 100644
  		if (qcadev && qcadev->bdaddr_property_broken)
  			hci_set_quirk(hdev, HCI_QUIRK_BDADDR_PROPERTY_BROKEN);
  
-@@ -1994,6 +2034,12 @@ retry:
+@@ -2001,6 +2041,12 @@ static int qca_setup(struct hci_uart *hu)
  		qca_set_speed(hu, QCA_INIT_SPEED);
  	}
  
@@ -182,7 +191,7 @@ index 3450013..9a29126 100644
  	/* Setup user speed if needed */
  	speed = qca_get_speed(hu, QCA_OPER_SPEED);
  	if (speed) {
-@@ -2013,6 +2059,7 @@ retry:
+@@ -2020,6 +2066,7 @@ static int qca_setup(struct hci_uart *hu)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -190,7 +199,7 @@ index 3450013..9a29126 100644
  		break;
  
  	default:
-@@ -2213,6 +2260,21 @@ static const struct qca_device_data qca_soc_data_wcn7850 __maybe_unused = {
+@@ -2220,6 +2267,21 @@ static const struct qca_device_data qca_soc_data_wcn7850 __maybe_unused = {
  			QCA_CAP_HFP_HW_OFFLOAD,
  };
  
@@ -212,7 +221,7 @@ index 3450013..9a29126 100644
  static void qca_power_off(struct hci_uart *hu)
  {
  	struct qca_serdev *qcadev;
-@@ -2423,6 +2485,7 @@ static int qca_serdev_probe(struct serdev_device *serdev)
+@@ -2430,6 +2492,7 @@ static int qca_serdev_probe(struct serdev_device *serdev)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -220,7 +229,7 @@ index 3450013..9a29126 100644
  		qcadev->bt_power = devm_kzalloc(&serdev->dev,
  						sizeof(struct qca_power),
  						GFP_KERNEL);
-@@ -2442,6 +2505,7 @@ static int qca_serdev_probe(struct serdev_device *serdev)
+@@ -2449,6 +2512,7 @@ static int qca_serdev_probe(struct serdev_device *serdev)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -228,7 +237,7 @@ index 3450013..9a29126 100644
  		if (!device_property_present(&serdev->dev, "enable-gpios")) {
  			/*
  			 * Backward compatibility with old DT sources. If the
-@@ -2492,7 +2556,8 @@ static int qca_serdev_probe(struct serdev_device *serdev)
+@@ -2499,7 +2563,8 @@ static int qca_serdev_probe(struct serdev_device *serdev)
  		if (IS_ERR(qcadev->sw_ctrl) &&
  		    (data->soc_type == QCA_WCN6750 ||
  		     data->soc_type == QCA_WCN6855 ||
@@ -238,7 +247,7 @@ index 3450013..9a29126 100644
  			dev_err(&serdev->dev, "failed to acquire SW_CTRL gpio\n");
  			return PTR_ERR(qcadev->sw_ctrl);
  		}
-@@ -2577,6 +2642,7 @@ static void qca_serdev_remove(struct serdev_device *serdev)
+@@ -2584,6 +2649,7 @@ static void qca_serdev_remove(struct serdev_device *serdev)
  	case QCA_WCN6750:
  	case QCA_WCN6855:
  	case QCA_WCN7850:
@@ -246,7 +255,7 @@ index 3450013..9a29126 100644
  		if (power->vregs_on)
  			qca_power_off(&qcadev->serdev_hu);
  		break;
-@@ -2779,6 +2845,7 @@ static const struct of_device_id qca_bluetooth_of_match[] = {
+@@ -2786,6 +2852,7 @@ static const struct of_device_id qca_bluetooth_of_match[] = {
  	{ .compatible = "qcom,wcn6750-bt", .data = &qca_soc_data_wcn6750},
  	{ .compatible = "qcom,wcn6855-bt", .data = &qca_soc_data_wcn6855},
  	{ .compatible = "qcom,wcn7850-bt", .data = &qca_soc_data_wcn7850},
@@ -254,3 +263,6 @@ index 3450013..9a29126 100644
  	{ /* sentinel */ }
  };
  MODULE_DEVICE_TABLE(of, qca_bluetooth_of_match);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0046-arm64-dts-qcom-Add-AYN-CQ8725S-Common.patch
+++ b/patch/kernel/archive/sm8750-7.1/0046-arm64-dts-qcom-Add-AYN-CQ8725S-Common.patch
@@ -1,17 +1,16 @@
-From 7bf76677fc4a0deb9cd7b82a482795694e9d4842 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
 Date: Wed, 15 Apr 2026 18:04:33 +0800
-Subject: [PATCH 53/54] arm64: dts: qcom: Add AYN CQ8725S Common
+Subject: arm64: dts: qcom: Add AYN CQ8725S Common
 
 Signed-off-by: Teguh Sobirin <teguh@sobir.in>
 ---
- .../boot/dts/qcom/cq8725s-ayn-common.dtsi     | 1237 +++++++++++++++++
+ arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi | 1237 ++++++++++
  1 file changed, 1237 insertions(+)
- create mode 100644 arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 
 diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 new file mode 100644
-index 000000000000..6090b5b3c668
+index 000000000000..111111111111
 --- /dev/null
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 @@ -0,0 +1,1237 @@
@@ -1253,5 +1252,5 @@ index 000000000000..6090b5b3c668
 +	status = "okay";
 +};
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0047-arm64-dts-qcom-Add-AYN-Odin3.patch
+++ b/patch/kernel/archive/sm8750-7.1/0047-arm64-dts-qcom-Add-AYN-Odin3.patch
@@ -1,17 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
-Subject: [PATCH] arm64: dts: qcom: Add AYN Odin3
+Date: Sun, 9 Aug 2026 09:11:00 +0200
+Subject: arm64: dts: qcom: Add AYN Odin3
 
-Signed-off-by: Teguh Sobirin <teguh@sobir.in>
-[Anze: expose the two back paddles (M1 left / M2 right) as gpio-keys.
-They are plain active-low SoC TLMM GPIOs 3 / 7 (not on the gamepad MCU
-UART, not ADC), reverse-engineered from AYN's Android keydetect.ko
-(gpio_request 515/519 = TLMM base 512 + offsets 3/7). They emit
-BTN_Z / BTN_C - the codes AYN's own firmware uses and which the
-existing InputPlumber map (ayn_mcu.yaml) already routes to
-Left/RightPaddle1.]
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
 ---
+ arch/arm64/boot/dts/qcom/Makefile              |   1 +
+ arch/arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts | 352 ++++++++++
+ 2 files changed, 353 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/qcom/Makefile b/arch/arm64/boot/dts/qcom/Makefile
-index 4ba8e730641..4ca5d0b88a6 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/Makefile
 +++ b/arch/arm64/boot/dts/qcom/Makefile
 @@ -4,6 +4,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= apq8016-sbc.dtb
@@ -24,7 +27,7 @@ index 4ba8e730641..4ca5d0b88a6 100644
  dtb-$(CONFIG_ARCH_QCOM)	+= apq8016-sbc-d3-camera-mezzanine.dtb
 diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts b/arch/arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts
 new file mode 100644
-index 00000000000..421d73d4aa5
+index 000000000000..111111111111
 --- /dev/null
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-odin3.dts
 @@ -0,0 +1,352 @@
@@ -380,3 +383,6 @@ index 00000000000..421d73d4aa5
 +		};
 +	};
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0048-drm-msm-dsi-reparent-byte-pixel-src-to-xo-on-disable.patch
+++ b/patch/kernel/archive/sm8750-7.1/0048-drm-msm-dsi-reparent-byte-pixel-src-to-xo-on-disable.patch
@@ -1,16 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: tiopex <tiopxyz@gmail.com>
-Date: Mon, 8 Jun 2026 00:00:00 +0000
-Subject: [PATCH] drm/msm/dsi: reparent byte/pixel src clocks to XO on disable
+Date: Sun, 9 Aug 2026 09:11:00 +0200
+Subject: drm/msm/dsi: reparent byte/pixel src clocks to XO on disable
 
-Reparent the byte/pixel source clocks back to their original (XO) parent
-in msm_dsi_host_power_off, while the PLL is still running, so the RCGs are
-left on a live parent. The next enable then cleanly reparents them back to
-the PLL.
-
-Signed-off-by: tiopex <tiopxyz@gmail.com>
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
 ---
+ drivers/gpu/drm/msm/dsi/dsi_host.c | 12 ++++++++++
+ 1 file changed, 12 insertions(+)
+
 diff --git a/drivers/gpu/drm/msm/dsi/dsi_host.c b/drivers/gpu/drm/msm/dsi/dsi_host.c
-index 982abaa..80f0016 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/msm/dsi/dsi_host.c
 +++ b/drivers/gpu/drm/msm/dsi/dsi_host.c
 @@ -127,6 +127,8 @@ struct msm_dsi_host {
@@ -47,4 +50,5 @@ index 982abaa..80f0016 100644
  	pm_runtime_put(&msm_host->pdev->dev);
  
 -- 
-2.43.0
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0049-drm-msm-a8xx-add-adreno-830-catalog.patch
+++ b/patch/kernel/archive/sm8750-7.1/0049-drm-msm-a8xx-add-adreno-830-catalog.patch
@@ -1,13 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
-Subject: [PATCH] drm/msm/a8xx: add Adreno 830 (SM8750/Odin3) catalog entry
+Date: Sun, 9 Aug 2026 09:11:00 +0200
+Subject: drm/msm/a8xx: add Adreno 830 (SM8750/Odin3) catalog entry
 
-7.1 upstreamed a840 (0x43051401) but not the Odin3's Adreno 830
-(chip 0x44050000). Without it the GPU is 'Unknown GPU revision' and
-never binds -> no Vulkan -> sway can't render -> no GUI. Carry the
-a830 reglists + catalog entry on top of 7.1's a8xx support.
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
 ---
+ drivers/gpu/drm/msm/adreno/a6xx_catalog.c | 303 ++++++++++
+ drivers/gpu/drm/msm/adreno/adreno_gpu.h   |   5 +
+ 2 files changed, 308 insertions(+)
+
 diff --git a/drivers/gpu/drm/msm/adreno/a6xx_catalog.c b/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
-index 550ff3a9b82e..a97bf2c0c89d 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
 +++ b/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
 @@ -1799,6 +1799,272 @@ static const struct adreno_reglist_pipe x285_dyn_pwrup_reglist_regs[] = {
@@ -328,10 +335,10 @@ index 550ff3a9b82e..a97bf2c0c89d 100644
  		.chip_ids = ADRENO_CHIP_IDS(0x44050a01),
  		.family = ADRENO_8XX_GEN2,
 diff --git a/drivers/gpu/drm/msm/adreno/adreno_gpu.h b/drivers/gpu/drm/msm/adreno/adreno_gpu.h
-index c0ee544ce257..2dd009b1ced5 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/msm/adreno/adreno_gpu.h
 +++ b/drivers/gpu/drm/msm/adreno/adreno_gpu.h
-@@ -601,6 +601,11 @@ static inline int adreno_is_x285(struct adreno_gpu *gpu)
+@@ -597,6 +597,11 @@ static inline int adreno_is_x285(struct adreno_gpu *gpu)
  	return gpu->info->chip_ids[0] == 0x44070001;
  }
  
@@ -344,5 +351,5 @@ index c0ee544ce257..2dd009b1ced5 100644
  {
  	return gpu->info->chip_ids[0] == 0x44050a01;
 -- 
-2.43.0
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0050-clk-qcom-gxclkctl-kaanapali-fix-gx-gdsc-collapse.patch
+++ b/patch/kernel/archive/sm8750-7.1/0050-clk-qcom-gxclkctl-kaanapali-fix-gx-gdsc-collapse.patch
@@ -1,11 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Teguh Sobirin <teguh@sobir.in>
-Subject: [PATCH] clk: qcom: gxclkctl-kaanapali: GX GDSC collapse only on synced_poweroff (SM8750 a830)
+Date: Sun, 9 Aug 2026 09:11:00 +0200
+Subject: clk: qcom: gxclkctl-kaanapali: GX GDSC collapse only on
+ synced_poweroff (SM8750 a830)
 
-Adds gdsc_gx_disable and wires it as GX GDSC .power_off so the HW-managed
-rail collapses only during GMU recovery, silencing the gdsc_toggle_logic WARN.
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
 ---
+ drivers/clk/qcom/gdsc.c               | 22 ++++++++++
+ drivers/clk/qcom/gdsc.h               |  1 +
+ drivers/clk/qcom/gxclkctl-kaanapali.c |  1 +
+ 3 files changed, 24 insertions(+)
+
 diff --git a/drivers/clk/qcom/gdsc.c b/drivers/clk/qcom/gdsc.c
-index 95aa071..ab5d741 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/qcom/gdsc.c
 +++ b/drivers/clk/qcom/gdsc.c
 @@ -675,3 +675,25 @@ int gdsc_gx_do_nothing_enable(struct generic_pm_domain *domain)
@@ -35,7 +46,7 @@ index 95aa071..ab5d741 100644
 +}
 +EXPORT_SYMBOL_GPL(gdsc_gx_disable);
 diff --git a/drivers/clk/qcom/gdsc.h b/drivers/clk/qcom/gdsc.h
-index dd843e8..495daeb 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/qcom/gdsc.h
 +++ b/drivers/clk/qcom/gdsc.h
 @@ -88,6 +88,7 @@ int gdsc_register(struct gdsc_desc *desc, struct reset_controller_dev *,
@@ -47,7 +58,7 @@ index dd843e8..495daeb 100644
  static inline int gdsc_register(struct gdsc_desc *desc,
  				struct reset_controller_dev *rcdev,
 diff --git a/drivers/clk/qcom/gxclkctl-kaanapali.c b/drivers/clk/qcom/gxclkctl-kaanapali.c
-index 40d8563..d7cf683 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/qcom/gxclkctl-kaanapali.c
 +++ b/drivers/clk/qcom/gxclkctl-kaanapali.c
 @@ -26,6 +26,7 @@ static struct gdsc gx_clkctl_gx_gdsc = {
@@ -58,3 +69,6 @@ index 40d8563..d7cf683 100644
  	},
  	.pwrsts = PWRSTS_OFF_ON,
  	.flags = POLL_CFG_GDSCR | RETAIN_FF_ENABLE,
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0051-drm-msm-a6xx-limit-gxpd-votes-to-recovery-in-a8x.patch
+++ b/patch/kernel/archive/sm8750-7.1/0051-drm-msm-a6xx-limit-gxpd-votes-to-recovery-in-a8x.patch
@@ -1,25 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Akhil P Oommen <akhilpo@oss.qualcomm.com>
-Date: Tue, 7 Apr 2026 15:00:56 +0530
-Subject: [PATCH] drm/msm/a6xx: Limit GXPD votes to recovery in A8x
+Date: Sun, 9 Aug 2026 09:11:00 +0200
+Subject: drm/msm/a6xx: Limit GXPD votes to recovery in A8x
 
-In A8x GPUs, the GX GDSC is moved to a separate block called GXCLKCTL
-which is under the GX power domain. Due to the way the support for this
-block is implemented in its driver, pm_runtime votes result in a vote on
-GX/GMxC/MxC rails from the APPS RSC. This is against the Adreno
-architecture which require GMU to be the sole voter of these collapsible
-rails on behalf of GPU, except during the GPU/GMU recovery.
-
-To align with this architectural requirement and to realize the power
-benefits of the IFPC feature, remove the GXPD votes during gmu resume
-and suspend. And during the recovery sequence, enable/disable the GXPD
-along with the 'synced_poweroff' genpd hint to force collapse this GDSC.
-
-Signed-off-by: Akhil P Oommen <akhilpo@oss.qualcomm.com>
-Signed-off-by: Taniya Das <taniya.das@oss.qualcomm.com>
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
 ---
+ drivers/gpu/drm/msm/adreno/a6xx_gmu.c | 65 ++++++++--
+ 1 file changed, 55 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/adreno/a6xx_gmu.c b/drivers/gpu/drm/msm/adreno/a6xx_gmu.c
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/msm/adreno/a6xx_gmu.c
 +++ b/drivers/gpu/drm/msm/adreno/a6xx_gmu.c
-@@ -1251,6 +1251,57 @@
+@@ -1251,6 +1251,57 @@ static int a6xx_gmu_secure_init(struct a6xx_gpu *a6xx_gpu)
  }
  
  
@@ -77,7 +74,7 @@ Signed-off-by: Taniya Das <taniya.das@oss.qualcomm.com>
  int a6xx_gmu_resume(struct a6xx_gpu *a6xx_gpu)
  {
  	struct adreno_gpu *adreno_gpu = &a6xx_gpu->base;
-@@ -1266,13 +1317,7 @@
+@@ -1266,13 +1317,7 @@ int a6xx_gmu_resume(struct a6xx_gpu *a6xx_gpu)
  	/* Turn on the resources */
  	pm_runtime_get_sync(gmu->dev);
  
@@ -92,7 +89,7 @@ Signed-off-by: Taniya Das <taniya.das@oss.qualcomm.com>
  
  	/* Use a known rate to bring up the GMU */
  	clk_set_rate(gmu->core_clk, 200000000);
-@@ -1339,7 +1384,8 @@
+@@ -1339,7 +1384,8 @@ int a6xx_gmu_resume(struct a6xx_gpu *a6xx_gpu)
  disable_clk:
  	clk_bulk_disable_unprepare(gmu->nr_clocks, gmu->clocks);
  rpm_put:
@@ -102,7 +99,7 @@ Signed-off-by: Taniya Das <taniya.das@oss.qualcomm.com>
  	pm_runtime_put(gmu->dev);
  
  	return ret;
-@@ -1455,8 +1501,7 @@
+@@ -1455,8 +1501,7 @@ int a6xx_gmu_stop(struct a6xx_gpu *a6xx_gpu)
  	 * domain. Usually the GMU does this but only if the shutdown sequence
  	 * was successful
  	 */
@@ -112,3 +109,6 @@ Signed-off-by: Taniya Das <taniya.das@oss.qualcomm.com>
  
  	clk_bulk_disable_unprepare(gmu->nr_clocks, gmu->clocks);
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0052-arm64-dts-qcom-cq8725s-ayn-wire-ss-through-redriver.patch
+++ b/patch/kernel/archive/sm8750-7.1/0052-arm64-dts-qcom-cq8725s-ayn-wire-ss-through-redriver.patch
@@ -1,0 +1,78 @@
+From: André Braga <code@andrebraga.com>
+Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn: wire USB-C SS through NB7VPQ904M redriver
+
+The AYN CQ8725S routes the Type-C SuperSpeed lanes through an ON Semi
+NB7VPQ904M redriver at i2c5 0x1c, between the USB-C connector and the
+combo USB/DP QMP PHY. The common dtsi wired the connector's SS endpoint
+straight to usb_dp_qmpphy_out, so the redriver stayed in reset and
+never passed the SS/DP lanes; DisplayPort alt-mode output over USB-C
+never came up.
+
+Describe the redriver as a Type-C mux/retimer and route the SS path
+through it (connector -> redriver -> qmpphy).
+
+Signed-off-by: André Braga <code@andrebraga.com>
+---
+ arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi | 35 +++++++--
+ 1 file changed, 33 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+index 6090b5b3c..fc16d0432 100644
+--- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+@@ -213,7 +213,7 @@ port@1 {
+ 					reg = <1>;
+ 
+ 					pmic_glink_ss_in: endpoint {
+-						remote-endpoint = <&usb_dp_qmpphy_out>;
++						remote-endpoint = <&redriver_ss_out>;
+ 					};
+ 				};
+ 
+@@ -888,6 +888,37 @@ spk_amp_r: spk_amp_r@35 {
+ 		awinic,sync-flag;
+ 		sound-name-prefix = "SPK_R";
+ 	};
++
++	typec_mux_redriver: typec-mux@1c {
++		compatible = "onnn,nb7vpq904m";
++		reg = <0x1c>;
++
++		vcc-supply = <&vreg_l15b_1p8>;
++
++		retimer-switch;
++		orientation-switch;
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++
++				redriver_ss_out: endpoint {
++					remote-endpoint = <&pmic_glink_ss_in>;
++				};
++			};
++
++			port@1 {
++				reg = <1>;
++
++				redriver_ss_in: endpoint {
++					remote-endpoint = <&usb_dp_qmpphy_out>;
++				};
++			};
++		};
++	};
+ };
+ 
+ &iris {
+@@ -1220,7 +1251,7 @@ &usb_dp_qmpphy {
+ };
+ 
+ &usb_dp_qmpphy_out {
+-	remote-endpoint = <&pmic_glink_ss_in>;
++	remote-endpoint = <&redriver_ss_in>;
+ };
+ 
+ &usb_dwc3_hs {

--- a/patch/kernel/archive/sm8750-7.1/0052-arm64-dts-qcom-cq8725s-ayn-wire-ss-through-redriver.patch
+++ b/patch/kernel/archive/sm8750-7.1/0052-arm64-dts-qcom-cq8725s-ayn-wire-ss-through-redriver.patch
@@ -1,23 +1,28 @@
-From: André Braga <code@andrebraga.com>
-Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn: wire USB-C SS through NB7VPQ904M redriver
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andre Braga <code@andrebraga.com>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: arm64: dts: qcom: cq8725s-ayn: wire USB-C SS through NB7VPQ904M
+ redriver
 
-The AYN CQ8725S routes the Type-C SuperSpeed lanes through an ON Semi
-NB7VPQ904M redriver at i2c5 0x1c, between the USB-C connector and the
-combo USB/DP QMP PHY. The common dtsi wired the connector's SS endpoint
-straight to usb_dp_qmpphy_out, so the redriver stayed in reset and
-never passed the SS/DP lanes; DisplayPort alt-mode output over USB-C
-never came up.
-
-Describe the redriver as a Type-C mux/retimer and route the SS path
-through it (connector -> redriver -> qmpphy).
-
-Signed-off-by: André Braga <code@andrebraga.com>
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
- arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi | 35 +++++++--
+ arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi | 35 +++++++++-
  1 file changed, 33 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
-index 6090b5b3c..fc16d0432 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 @@ -213,7 +213,7 @@ port@1 {
@@ -76,3 +81,6 @@ index 6090b5b3c..fc16d0432 100644
  };
  
  &usb_dwc3_hs {
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0053-pmdomain-qcom-rpmhpd-presync-floor-gmu-rails.patch
+++ b/patch/kernel/archive/sm8750-7.1/0053-pmdomain-qcom-rpmhpd-presync-floor-gmu-rails.patch
@@ -1,13 +1,27 @@
-Subject: [PATCH] pmdomain: qcom: rpmhpd: floor GMU managed rails low pre sync_state
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: pmdomain qcom rpmhpd presync floor gmu rails
 
-Floor gfx/gmxc at their lowest functional corner until sync_state
-instead: low enough for ACD to calibrate against real levels, alive
-enough for the GMU's first ramp. Skip the retention level so the
-floor is a corner logic can run at.
-
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ drivers/pmdomain/qcom/rpmhpd.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
 diff --git a/drivers/pmdomain/qcom/rpmhpd.c b/drivers/pmdomain/qcom/rpmhpd.c
-index ffc46de8d..729949804 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pmdomain/qcom/rpmhpd.c
 +++ b/drivers/pmdomain/qcom/rpmhpd.c
 @@ -42,6 +42,7 @@
@@ -34,8 +48,8 @@ index ffc46de8d..729949804 100644
 +	.skip_retention_level = true,
  };
  
- static struct rpmhpd gfx1 = {
-@@ -235,6 +239,8 @@ static struct rpmhpd qphy = {
+ static struct rpmhpd lcx = {
+@@ -225,6 +229,8 @@ static struct rpmhpd qphy = {
  static struct rpmhpd gmxc = {
  	.pd = { .name = "gmxc", },
  	.res_name = "gmxc.lvl",
@@ -44,7 +58,7 @@ index ffc46de8d..729949804 100644
  };
  
  /* Eliza RPMH powerdomains */
-@@ -975,6 +981,10 @@ static int rpmhpd_aggregate_corner(struct rpmhpd *pd, unsigned int corner)
+@@ -940,6 +946,10 @@ static int rpmhpd_aggregate_corner(struct rpmhpd *pd, unsigned int corner)
  
  	if (pd->state_synced) {
  		to_active_sleep(pd, corner, &this_active_corner, &this_sleep_corner);
@@ -55,3 +69,6 @@ index ffc46de8d..729949804 100644
  	} else {
  		/* Clamp to highest corner if sync_state hasn't happened */
  		this_active_corner = pd->level_count - 1;
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0053-pmdomain-qcom-rpmhpd-presync-floor-gmu-rails.patch
+++ b/patch/kernel/archive/sm8750-7.1/0053-pmdomain-qcom-rpmhpd-presync-floor-gmu-rails.patch
@@ -1,0 +1,57 @@
+Subject: [PATCH] pmdomain: qcom: rpmhpd: floor GMU managed rails low pre sync_state
+
+Floor gfx/gmxc at their lowest functional corner until sync_state
+instead: low enough for ACD to calibrate against real levels, alive
+enough for the GMU's first ramp. Skip the retention level so the
+floor is a corner logic can run at.
+
+---
+diff --git a/drivers/pmdomain/qcom/rpmhpd.c b/drivers/pmdomain/qcom/rpmhpd.c
+index ffc46de8d..729949804 100644
+--- a/drivers/pmdomain/qcom/rpmhpd.c
++++ b/drivers/pmdomain/qcom/rpmhpd.c
+@@ -42,6 +42,7 @@
+  *			cmd-db
+  * @state_synced:	Indicator that sync_state has been invoked for the rpmhpd resource
+  * @skip_retention_level: Indicate that retention level should not be used for the power domain
++ * @presync_floor:	Clamp to the lowest functional corner instead of the highest before sync_state
+  */
+ struct rpmhpd {
+ 	struct device	*dev;
+@@ -59,6 +60,7 @@ struct rpmhpd {
+ 	u32		addr;
+ 	bool		state_synced;
+ 	bool            skip_retention_level;
++	bool		presync_floor;
+ };
+ 
+ struct rpmhpd_desc {
+@@ -120,6 +122,8 @@ static struct rpmhpd gbx = {
+ static struct rpmhpd gfx = {
+ 	.pd = { .name = "gfx", },
+ 	.res_name = "gfx.lvl",
++	.presync_floor = true,
++	.skip_retention_level = true,
+ };
+ 
+ static struct rpmhpd gfx1 = {
+@@ -235,6 +239,8 @@ static struct rpmhpd qphy = {
+ static struct rpmhpd gmxc = {
+ 	.pd = { .name = "gmxc", },
+ 	.res_name = "gmxc.lvl",
++	.presync_floor = true,
++	.skip_retention_level = true,
+ };
+ 
+ /* Eliza RPMH powerdomains */
+@@ -975,6 +981,10 @@ static int rpmhpd_aggregate_corner(struct rpmhpd *pd, unsigned int corner)
+ 
+ 	if (pd->state_synced) {
+ 		to_active_sleep(pd, corner, &this_active_corner, &this_sleep_corner);
++	} else if (pd->presync_floor) {
++		/* Keep GMU managed rails alive but low until sync_state */
++		to_active_sleep(pd, max(corner, pd->enable_corner),
++				&this_active_corner, &this_sleep_corner);
+ 	} else {
+ 		/* Clamp to highest corner if sync_state hasn't happened */
+ 		this_active_corner = pd->level_count - 1;

--- a/patch/kernel/archive/sm8750-7.1/0060-ASoC-qcom-sc8280xp-enable-MI2S-bit-clock-on-BE-startup.patch
+++ b/patch/kernel/archive/sm8750-7.1/0060-ASoC-qcom-sc8280xp-enable-MI2S-bit-clock-on-BE-startup.patch
@@ -1,0 +1,106 @@
+ASoC: qcom: sc8280xp: enable the MI2S bit clock around MI2S streams
+
+Cards served by this driver can carry MI2S BE dai-links (the AYN Odin3
+and KONKR Pocket FIT Elite route their speaker amps over MI2S), but
+unlike sc7280/sdm845 the driver never enables the MI2S bit clock: the
+BE streams, yet IBIT stays at enable_count 0, no BCLK leaves the SoC
+and BCLK-slaved amps (aw88261: "check pll lock fail, cannot start")
+never power up. Take the card-level "i2s_clk" (optional, NULL-safe -
+boards without the property are unaffected) and prepare/enable it
+around MI2S BE startup/shutdown, refcounted across the MI2S links.
+
+diff --git a/sound/soc/qcom/sc8280xp.c b/sound/soc/qcom/sc8280xp.c
+index 7925aa3..ffb405f 100644
+--- a/sound/soc/qcom/sc8280xp.c
++++ b/sound/soc/qcom/sc8280xp.c
+@@ -2,6 +2,7 @@
+ // Copyright (c) 2022, Linaro Limited
+ 
+ #include <dt-bindings/sound/qcom,q6afe.h>
++#include <linux/clk.h>
+ #include <linux/module.h>
+ #include <linux/platform_device.h>
+ #include <sound/soc.h>
+@@ -21,6 +22,8 @@ struct sc8280xp_snd_data {
+ 	struct snd_soc_jack jack;
+ 	struct snd_soc_jack dp_jack[8];
+ 	bool jack_setup;
++	struct clk *i2s_clk;
++	int mi2s_clk_count;
+ };
+ 
+ static int sc8280xp_snd_init(struct snd_soc_pcm_runtime *rtd)
+@@ -114,9 +117,59 @@ static int sc8280xp_snd_hw_free(struct snd_pcm_substream *substream)
+ 	return qcom_snd_sdw_hw_free(substream, &data->stream_prepared[cpu_dai->id]);
+ }
+ 
++static int sc8280xp_snd_startup(struct snd_pcm_substream *substream)
++{
++	struct snd_soc_pcm_runtime *rtd = snd_soc_substream_to_rtd(substream);
++	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
++	struct sc8280xp_snd_data *data = snd_soc_card_get_drvdata(rtd->card);
++	int ret;
++
++	switch (cpu_dai->id) {
++	case PRIMARY_MI2S_RX...QUATERNARY_MI2S_TX:
++	case QUINARY_MI2S_RX...QUINARY_MI2S_TX:
++		/*
++		 * The MI2S bit clock (DT clock "i2s_clk", a q6prm clock) is
++		 * not managed by the DSP graph: without an explicit enable
++		 * the BE streams but no BCLK ever leaves the SoC and
++		 * BCLK-slaved speaker amps cannot lock their PLL.
++		 */
++		if (++data->mi2s_clk_count == 1) {
++			ret = clk_prepare_enable(data->i2s_clk);
++			if (ret) {
++				data->mi2s_clk_count--;
++				return ret;
++			}
++		}
++		break;
++	default:
++		break;
++	}
++
++	return qcom_snd_sdw_startup(substream);
++}
++
++static void sc8280xp_snd_shutdown(struct snd_pcm_substream *substream)
++{
++	struct snd_soc_pcm_runtime *rtd = snd_soc_substream_to_rtd(substream);
++	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
++	struct sc8280xp_snd_data *data = snd_soc_card_get_drvdata(rtd->card);
++
++	switch (cpu_dai->id) {
++	case PRIMARY_MI2S_RX...QUATERNARY_MI2S_TX:
++	case QUINARY_MI2S_RX...QUINARY_MI2S_TX:
++		if (--data->mi2s_clk_count == 0)
++			clk_disable_unprepare(data->i2s_clk);
++		break;
++	default:
++		break;
++	}
++
++	qcom_snd_sdw_shutdown(substream);
++}
++
+ static const struct snd_soc_ops sc8280xp_be_ops = {
+-	.startup = qcom_snd_sdw_startup,
+-	.shutdown = qcom_snd_sdw_shutdown,
++	.startup = sc8280xp_snd_startup,
++	.shutdown = sc8280xp_snd_shutdown,
+ 	.hw_free = sc8280xp_snd_hw_free,
+ 	.prepare = sc8280xp_snd_prepare,
+ };
+@@ -158,6 +211,11 @@ static int sc8280xp_platform_probe(struct platform_device *pdev)
+ 	if (ret)
+ 		return ret;
+ 
++	data->i2s_clk = devm_clk_get_optional(dev, "i2s_clk");
++	if (IS_ERR(data->i2s_clk))
++		return dev_err_probe(dev, PTR_ERR(data->i2s_clk),
++				     "failed to get i2s_clk\n");
++
+ 	card->driver_name = of_device_get_match_data(dev);
+ 	sc8280xp_add_be_ops(card);
+ 	return devm_snd_soc_register_card(dev, card);

--- a/patch/kernel/archive/sm8750-7.1/0060-ASoC-qcom-sc8280xp-enable-MI2S-bit-clock-on-BE-startup.patch
+++ b/patch/kernel/archive/sm8750-7.1/0060-ASoC-qcom-sc8280xp-enable-MI2S-bit-clock-on-BE-startup.patch
@@ -1,16 +1,27 @@
-ASoC: qcom: sc8280xp: enable the MI2S bit clock around MI2S streams
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: ASoC qcom sc8280xp enable MI2S bit clock on BE startup
 
-Cards served by this driver can carry MI2S BE dai-links (the AYN Odin3
-and KONKR Pocket FIT Elite route their speaker amps over MI2S), but
-unlike sc7280/sdm845 the driver never enables the MI2S bit clock: the
-BE streams, yet IBIT stays at enable_count 0, no BCLK leaves the SoC
-and BCLK-slaved amps (aw88261: "check pll lock fail, cannot start")
-never power up. Take the card-level "i2s_clk" (optional, NULL-safe -
-boards without the property are unaffected) and prepare/enable it
-around MI2S BE startup/shutdown, refcounted across the MI2S links.
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
+---
+ sound/soc/qcom/sc8280xp.c | 62 +++++++++-
+ 1 file changed, 60 insertions(+), 2 deletions(-)
 
 diff --git a/sound/soc/qcom/sc8280xp.c b/sound/soc/qcom/sc8280xp.c
-index 7925aa3..ffb405f 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/qcom/sc8280xp.c
 +++ b/sound/soc/qcom/sc8280xp.c
 @@ -2,6 +2,7 @@
@@ -104,3 +115,6 @@ index 7925aa3..ffb405f 100644
  	card->driver_name = of_device_get_match_data(dev);
  	sc8280xp_add_be_ops(card);
  	return devm_snd_soc_register_card(dev, card);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0063-ASoC-wcd939x-route-usbss-on-integrated-jack-insert.patch
+++ b/patch/kernel/archive/sm8750-7.1/0063-ASoC-wcd939x-route-usbss-on-integrated-jack-insert.patch
@@ -1,15 +1,30 @@
-From: KONKR Pocket FIT Elite port
-Subject: [PATCH] ASoC: wcd939x: route USBSS to audio on integrated-jack insert
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: KONKR Pocket FIT Elite port <unknown-email@domain.tld>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: ASoC: wcd939x: route USBSS to audio on integrated-jack insert
 
-On boards with a dedicated 3.5mm jack wired through the WCD939x USBSS
-analog switch, the jack is found by the MBHC mechanical path and produces
-no Type-C connector event, so the switch is never put in audio mode and
-HPHL/HPHR float -> MBHC reports a ground/mic swap. Add an mbhc_cb hook the
-codec uses (via a qcom,usbss phandle) to route the switch to audio on
-insert and back on removal, reusing the USBSS audio FSM path.
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ drivers/usb/typec/mux/wcd939x-usbss.c | 30 +++++++
+ sound/soc/codecs/wcd-mbhc-v2.c        | 10 +++
+ sound/soc/codecs/wcd-mbhc-v2.h        |  7 ++
+ sound/soc/codecs/wcd939x.c            | 39 ++++++++++
+ 4 files changed, 86 insertions(+)
+
 diff --git a/drivers/usb/typec/mux/wcd939x-usbss.c b/drivers/usb/typec/mux/wcd939x-usbss.c
-index 73db3aa3c..195a8983c 100644
+index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/mux/wcd939x-usbss.c
 +++ b/drivers/usb/typec/mux/wcd939x-usbss.c
 @@ -752,6 +752,36 @@ static void wcd939x_usbss_remove(struct i2c_client *client)
@@ -47,10 +62,10 @@ index 73db3aa3c..195a8983c 100644
 +EXPORT_SYMBOL_GPL(wcd939x_usbss_audio_config);
 +
  static const struct i2c_device_id wcd939x_usbss_table[] = {
- 	{ .name = "wcd9390-usbss" },
+ 	{ "wcd9390-usbss" },
  	{ }
 diff --git a/sound/soc/codecs/wcd-mbhc-v2.c b/sound/soc/codecs/wcd-mbhc-v2.c
-index bb0c8478a..f98fc7b9e 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/wcd-mbhc-v2.c
 +++ b/sound/soc/codecs/wcd-mbhc-v2.c
 @@ -535,11 +535,21 @@ static void mbhc_plug_detect_fn(struct work_struct *work)
@@ -76,7 +91,7 @@ index bb0c8478a..f98fc7b9e 100644
  		wcd_mbhc_write_field(mbhc, WCD_MBHC_FSM_EN, 0);
  		wcd_mbhc_write_field(mbhc, WCD_MBHC_BTN_ISRC_CTL, 0);
 diff --git a/sound/soc/codecs/wcd-mbhc-v2.h b/sound/soc/codecs/wcd-mbhc-v2.h
-index a5d52b964..f85b3d010 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/wcd-mbhc-v2.h
 +++ b/sound/soc/codecs/wcd-mbhc-v2.h
 @@ -265,6 +265,13 @@ struct wcd_mbhc_cb {
@@ -94,7 +109,7 @@ index a5d52b964..f85b3d010 100644
  
  #if IS_ENABLED(CONFIG_SND_SOC_WCD_MBHC)
 diff --git a/sound/soc/codecs/wcd939x.c b/sound/soc/codecs/wcd939x.c
-index 010d12466..1b6bfa2ce 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/wcd939x.c
 +++ b/sound/soc/codecs/wcd939x.c
 @@ -17,6 +17,7 @@
@@ -142,7 +157,7 @@ index 010d12466..1b6bfa2ce 100644
  	.mbhc_bias = wcd939x_mbhc_mbhc_bias_control,
  	.set_btn_thr = wcd939x_mbhc_program_btn_thr,
  	.micbias_enable_status = wcd939x_mbhc_micb_en_status,
-@@ -3219,6 +3241,23 @@ static int wcd939x_populate_dt_data(struct wcd939x_priv *wcd939x, struct device
+@@ -3224,6 +3246,23 @@ static int wcd939x_populate_dt_data(struct wcd939x_priv *wcd939x, struct device
  	}
  #endif /* CONFIG_TYPEC */
  
@@ -166,3 +181,6 @@ index 010d12466..1b6bfa2ce 100644
  	return 0;
  }
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0063-ASoC-wcd939x-route-usbss-on-integrated-jack-insert.patch
+++ b/patch/kernel/archive/sm8750-7.1/0063-ASoC-wcd939x-route-usbss-on-integrated-jack-insert.patch
@@ -1,0 +1,168 @@
+From: KONKR Pocket FIT Elite port
+Subject: [PATCH] ASoC: wcd939x: route USBSS to audio on integrated-jack insert
+
+On boards with a dedicated 3.5mm jack wired through the WCD939x USBSS
+analog switch, the jack is found by the MBHC mechanical path and produces
+no Type-C connector event, so the switch is never put in audio mode and
+HPHL/HPHR float -> MBHC reports a ground/mic swap. Add an mbhc_cb hook the
+codec uses (via a qcom,usbss phandle) to route the switch to audio on
+insert and back on removal, reusing the USBSS audio FSM path.
+---
+diff --git a/drivers/usb/typec/mux/wcd939x-usbss.c b/drivers/usb/typec/mux/wcd939x-usbss.c
+index 73db3aa3c..195a8983c 100644
+--- a/drivers/usb/typec/mux/wcd939x-usbss.c
++++ b/drivers/usb/typec/mux/wcd939x-usbss.c
+@@ -752,6 +752,36 @@ static void wcd939x_usbss_remove(struct i2c_client *client)
+ 	typec_mux_put(usbss->codec);
+ }
+ 
++/*
++ * wcd939x_usbss_audio_config - drive the analog switch into (or out of)
++ * audio-accessory routing on behalf of the WCD codec's MBHC.
++ *
++ * On boards with an *integrated* 3.5mm jack wired through this switch, the jack
++ * is detected by the codec's MBHC mechanical path and produces no Type-C
++ * connector event, so the normal connector -> mux_set(AUDIO) routing never
++ * runs.  Until the switch is in audio mode the codec's HPHL/HPHR sense lines
++ * float and MBHC mis-classifies the plug as a ground/mic swap.  The codec calls
++ * this on insert/removal so the same routing the connector would have applied
++ * is in place before MBHC measures the plug.  @dev is this USBSS i2c device.
++ */
++int wcd939x_usbss_audio_config(struct device *dev, bool enable)
++{
++	struct wcd939x_usbss *usbss = dev ? dev_get_drvdata(dev) : NULL;
++	int ret;
++
++	if (!usbss)
++		return -ENODEV;
++
++	mutex_lock(&usbss->lock);
++	usbss->mode = enable ? TYPEC_MODE_AUDIO : TYPEC_STATE_SAFE;
++	usbss->svid = 0;
++	ret = wcd939x_usbss_set(usbss);
++	mutex_unlock(&usbss->lock);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(wcd939x_usbss_audio_config);
++
+ static const struct i2c_device_id wcd939x_usbss_table[] = {
+ 	{ .name = "wcd9390-usbss" },
+ 	{ }
+diff --git a/sound/soc/codecs/wcd-mbhc-v2.c b/sound/soc/codecs/wcd-mbhc-v2.c
+index bb0c8478a..f98fc7b9e 100644
+--- a/sound/soc/codecs/wcd-mbhc-v2.c
++++ b/sound/soc/codecs/wcd-mbhc-v2.c
+@@ -535,11 +535,21 @@ static void mbhc_plug_detect_fn(struct work_struct *work)
+ 	if (detection_type) {
+ 		if (mbhc->current_plug != MBHC_PLUG_TYPE_NONE)
+ 			goto exit;
++		/*
++		 * Route the external analog switch (if any) into audio mode so
++		 * an integrated jack presents a real HPHL/HPHR load to plug
++		 * detection instead of floating (which reads as a gnd/mic swap).
++		 */
++		if (mbhc->mbhc_cb->mbhc_ext_switch_ctrl)
++			mbhc->mbhc_cb->mbhc_ext_switch_ctrl(component, true);
+ 		/* Make sure MASTER_BIAS_CTL is enabled */
+ 		mbhc->mbhc_cb->mbhc_bias(component, true);
+ 		mbhc->is_btn_press = false;
+ 		wcd_mbhc_adc_detect_plug_type(mbhc);
+ 	} else {
++		/* Jack removed: take the external analog switch out of audio. */
++		if (mbhc->mbhc_cb->mbhc_ext_switch_ctrl)
++			mbhc->mbhc_cb->mbhc_ext_switch_ctrl(component, false);
+ 		/* Disable HW FSM */
+ 		wcd_mbhc_write_field(mbhc, WCD_MBHC_FSM_EN, 0);
+ 		wcd_mbhc_write_field(mbhc, WCD_MBHC_BTN_ISRC_CTL, 0);
+diff --git a/sound/soc/codecs/wcd-mbhc-v2.h b/sound/soc/codecs/wcd-mbhc-v2.h
+index a5d52b964..f85b3d010 100644
+--- a/sound/soc/codecs/wcd-mbhc-v2.h
++++ b/sound/soc/codecs/wcd-mbhc-v2.h
+@@ -265,6 +265,13 @@ struct wcd_mbhc_cb {
+ 	bool (*mbhc_get_moisture_status)(struct snd_soc_component *component);
+ 	void (*mbhc_moisture_polling_ctrl)(struct snd_soc_component *component, bool enable);
+ 	void (*mbhc_moisture_detect_en)(struct snd_soc_component *component, bool enable);
++	/*
++	 * Route an external analog switch (e.g. WCD939x USBSS) into/out of
++	 * audio-accessory mode when an integrated jack is detected via the
++	 * mechanical path.  Optional; only set on boards whose HP lines are
++	 * wired through such a switch.
++	 */
++	void (*mbhc_ext_switch_ctrl)(struct snd_soc_component *component, bool enable);
+ };
+ 
+ #if IS_ENABLED(CONFIG_SND_SOC_WCD_MBHC)
+diff --git a/sound/soc/codecs/wcd939x.c b/sound/soc/codecs/wcd939x.c
+index 010d12466..1b6bfa2ce 100644
+--- a/sound/soc/codecs/wcd939x.c
++++ b/sound/soc/codecs/wcd939x.c
+@@ -17,6 +17,7 @@
+ #include <sound/tlv.h>
+ #include <linux/of_graph.h>
+ #include <linux/of.h>
++#include <linux/i2c.h>
+ #include <sound/jack.h>
+ #include <sound/pcm.h>
+ #include <sound/pcm_params.h>
+@@ -187,6 +188,8 @@ struct wcd939x_priv {
+ 	unsigned long typec_mode;
+ 	struct typec_switch *typec_switch;
+ #endif /* CONFIG_TYPEC */
++	/* external analog switch (WCD939x USBSS) for an integrated jack */
++	struct device *usbss_dev;
+ 	/* mbhc module */
+ 	struct wcd_mbhc *wcd_mbhc;
+ 	struct wcd_mbhc_config mbhc_cfg;
+@@ -2411,8 +2414,27 @@ static void wcd939x_mbhc_moisture_polling_ctrl(struct snd_soc_component *compone
+ 				      enable);
+ }
+ 
++/* Provided by the WCD939x USBSS analog-switch driver (built-in). */
++int wcd939x_usbss_audio_config(struct device *dev, bool enable);
++
++/*
++ * Route the WCD939x USBSS into/out of audio-accessory mode when the MBHC
++ * detects an integrated 3.5mm jack via the mechanical path.  Without it the
++ * jack's HPHL/HPHR lines float through the switch and MBHC reports a gnd/mic
++ * swap.  No-op on boards without a USBSS (usbss_dev == NULL).
++ */
++static void wcd939x_mbhc_ext_switch_ctrl(struct snd_soc_component *component,
++					 bool enable)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	if (wcd939x->usbss_dev)
++		wcd939x_usbss_audio_config(wcd939x->usbss_dev, enable);
++}
++
+ static const struct wcd_mbhc_cb mbhc_cb = {
+ 	.clk_setup = wcd939x_mbhc_clk_setup,
++	.mbhc_ext_switch_ctrl = wcd939x_mbhc_ext_switch_ctrl,
+ 	.mbhc_bias = wcd939x_mbhc_mbhc_bias_control,
+ 	.set_btn_thr = wcd939x_mbhc_program_btn_thr,
+ 	.micbias_enable_status = wcd939x_mbhc_micb_en_status,
+@@ -3219,6 +3241,23 @@ static int wcd939x_populate_dt_data(struct wcd939x_priv *wcd939x, struct device
+ 	}
+ #endif /* CONFIG_TYPEC */
+ 
++	/*
++	 * If an external analog switch (WCD939x USBSS) carries the HP lines to
++	 * an integrated jack, grab its device so MBHC can route it on insert.
++	 */
++	{
++		struct device_node *usbss_np;
++		struct i2c_client *usbss_client;
++
++		usbss_np = of_parse_phandle(dev->of_node, "qcom,usbss", 0);
++		if (usbss_np) {
++			usbss_client = of_find_i2c_device_by_node(usbss_np);
++			of_node_put(usbss_np);
++			if (usbss_client)
++				wcd939x->usbss_dev = &usbss_client->dev;
++		}
++	}
++
+ 	return 0;
+ }
+ 

--- a/patch/kernel/archive/sm8750-7.1/0064-ASoC-wcd-mbhc-clear-stale-jack-report-on-mechanical-removal.patch
+++ b/patch/kernel/archive/sm8750-7.1/0064-ASoC-wcd-mbhc-clear-stale-jack-report-on-mechanical-removal.patch
@@ -1,0 +1,69 @@
+From: KONKR Pocket FIT Elite port
+Subject: [PATCH] ASoC: wcd-mbhc-v2: clear stale jack report on mechanical removal
+
+The mechanical-detection removal path only reports a jack removal when
+mbhc->current_plug names a known plug type.  On boards with an integrated
+3.5mm jack wired through an analog switch (WCD939x USBSS, see the
+"route USBSS on integrated-jack insert" change), the ADC plug-type
+detection can desync and leave current_plug == MBHC_PLUG_TYPE_NONE -- or
+classify the plug as a gnd/mic swap -- while hph_status still holds the
+SND_JACK_HEADPHONE bit from the insertion report.
+
+When that happens the swch IRQ handler takes one of the "goto exit" paths
+without reporting removal, so the "Headphone Jack" control stays latched
+at "inserted" with nothing physically plugged in.  Userspace (PipeWire)
+then keeps routing to the headphone path and mutes the speaker forever.
+
+Mechanical detection is the physical ground truth that the jack is out.
+Funnel the NONE / gnd-mic-swap / default removal paths through a new
+report_removed label that force-clears a stale hph_status and reports a
+clean removal, so the speaker route returns on unplug.
+---
+--- a/sound/soc/codecs/wcd-mbhc-v2.c
++++ b/sound/soc/codecs/wcd-mbhc-v2.c
+@@ -556,7 +556,7 @@
+ 		mbhc->extn_cable_hph_rem = false;
+ 
+ 		if (mbhc->current_plug == MBHC_PLUG_TYPE_NONE)
+-			goto exit;
++			goto report_removed;
+ 
+ 		mbhc->is_btn_press = false;
+ 		switch (mbhc->current_plug) {
+@@ -573,17 +573,34 @@
+ 			break;
+ 		case MBHC_PLUG_TYPE_GND_MIC_SWAP:
+ 			dev_err(mbhc->dev, "Ground and Mic Swapped on plug\n");
+-			goto exit;
++			goto report_removed;
+ 		default:
+ 			dev_err(mbhc->dev, "Invalid current plug: %d\n",
+ 				mbhc->current_plug);
+-			goto exit;
++			goto report_removed;
+ 		}
+ 		disable_irq_nosync(mbhc->intr_ids->mbhc_hs_rem_intr);
+ 		disable_irq_nosync(mbhc->intr_ids->mbhc_hs_ins_intr);
+ 		wcd_mbhc_write_field(mbhc, WCD_MBHC_ELECT_DETECTION_TYPE, 1);
+ 		wcd_mbhc_write_field(mbhc, WCD_MBHC_ELECT_SCHMT_ISRC, 0);
+ 		wcd_mbhc_report_plug(mbhc, 0, jack_type);
++		goto exit;
++
++ report_removed:
++		/*
++		 * Mechanical detection is the physical ground truth that the
++		 * jack is out. On boards with an integrated jack wired behind an
++		 * analog switch (e.g. WCD939x USBSS) the ADC plug-type path can
++		 * desync and leave current_plug == NONE (or a gnd/mic-swap
++		 * error) while hph_status still holds the headphone bit -- which
++		 * freezes the "Headphone Jack" control at "inserted", so
++		 * userspace keeps the speaker muted forever. Force a clean
++		 * removal report so the speaker route comes back.
++		 */
++		if (mbhc->hph_status) {
++			mbhc->hph_status = 0;
++			snd_soc_jack_report(mbhc->jack, 0, WCD_MBHC_JACK_MASK);
++		}
+ 	}
+ 
+ exit:

--- a/patch/kernel/archive/sm8750-7.1/0064-ASoC-wcd-mbhc-clear-stale-jack-report-on-mechanical-removal.patch
+++ b/patch/kernel/archive/sm8750-7.1/0064-ASoC-wcd-mbhc-clear-stale-jack-report-on-mechanical-removal.patch
@@ -1,27 +1,30 @@
-From: KONKR Pocket FIT Elite port
-Subject: [PATCH] ASoC: wcd-mbhc-v2: clear stale jack report on mechanical removal
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: KONKR Pocket FIT Elite port <unknown-email@domain.tld>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: ASoC: wcd-mbhc-v2: clear stale jack report on mechanical removal
 
-The mechanical-detection removal path only reports a jack removal when
-mbhc->current_plug names a known plug type.  On boards with an integrated
-3.5mm jack wired through an analog switch (WCD939x USBSS, see the
-"route USBSS on integrated-jack insert" change), the ADC plug-type
-detection can desync and leave current_plug == MBHC_PLUG_TYPE_NONE -- or
-classify the plug as a gnd/mic swap -- while hph_status still holds the
-SND_JACK_HEADPHONE bit from the insertion report.
-
-When that happens the swch IRQ handler takes one of the "goto exit" paths
-without reporting removal, so the "Headphone Jack" control stays latched
-at "inserted" with nothing physically plugged in.  Userspace (PipeWire)
-then keeps routing to the headphone path and mutes the speaker forever.
-
-Mechanical detection is the physical ground truth that the jack is out.
-Funnel the NONE / gnd-mic-swap / default removal paths through a new
-report_removed label that force-clears a stale hph_status and reports a
-clean removal, so the speaker route returns on unplug.
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ sound/soc/codecs/wcd-mbhc-v2.c | 23 ++++++++--
+ 1 file changed, 20 insertions(+), 3 deletions(-)
+
+diff --git a/sound/soc/codecs/wcd-mbhc-v2.c b/sound/soc/codecs/wcd-mbhc-v2.c
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/wcd-mbhc-v2.c
 +++ b/sound/soc/codecs/wcd-mbhc-v2.c
-@@ -556,7 +556,7 @@
+@@ -556,7 +556,7 @@ static void mbhc_plug_detect_fn(struct work_struct *work)
  		mbhc->extn_cable_hph_rem = false;
  
  		if (mbhc->current_plug == MBHC_PLUG_TYPE_NONE)
@@ -30,7 +33,7 @@ clean removal, so the speaker route returns on unplug.
  
  		mbhc->is_btn_press = false;
  		switch (mbhc->current_plug) {
-@@ -573,17 +573,34 @@
+@@ -573,17 +573,34 @@ static void mbhc_plug_detect_fn(struct work_struct *work)
  			break;
  		case MBHC_PLUG_TYPE_GND_MIC_SWAP:
  			dev_err(mbhc->dev, "Ground and Mic Swapped on plug\n");
@@ -67,3 +70,6 @@ clean removal, so the speaker route returns on unplug.
  	}
  
  exit:
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0065-arm64-dts-qcom-cq8725s-ayn-point-the-codec-at-the-USBSS-switch.patch
+++ b/patch/kernel/archive/sm8750-7.1/0065-arm64-dts-qcom-cq8725s-ayn-point-the-codec-at-the-USBSS-switch.patch
@@ -1,0 +1,33 @@
+From 645e6e4eee7ef3b631bc797668713f0be65b9bbe Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 29 Aug 2026 12:41:52 +0200
+Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn: point the codec at the USBSS
+ switch
+
+The integrated 3.5mm jack on these boards is wired through the
+WCD9395 USBSS analog switch, and the codec driver looks the switch
+up via a qcom,usbss phandle to route it into audio-accessory mode
+when MBHC detects a mechanical insert. The phandle was never added,
+so the switch stayed in safe mode, the HPH lines floated and the
+jack never produced usable audio.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+index 6090b5b3c668..99c30e0db499 100644
+--- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+@@ -40,6 +40,7 @@ wcd939x: audio-codec {
+ 		qcom,mbhc-headphone-vthreshold-microvolt = <50000>;
+ 		qcom,rx-device = <&wcd_rx>;
+ 		qcom,tx-device = <&wcd_tx>;
++		qcom,usbss = <&wcd_usbss>;
+ 
+ 		reset-gpios = <&tlmm 101 GPIO_ACTIVE_LOW>;
+ 
+-- 
+2.47.3
+

--- a/patch/kernel/archive/sm8750-7.1/0065-arm64-dts-qcom-cq8725s-ayn-point-the-codec-at-the-USBSS-switch.patch
+++ b/patch/kernel/archive/sm8750-7.1/0065-arm64-dts-qcom-cq8725s-ayn-point-the-codec-at-the-USBSS-switch.patch
@@ -1,8 +1,7 @@
-From 645e6e4eee7ef3b631bc797668713f0be65b9bbe Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
 Date: Sat, 29 Aug 2026 12:41:52 +0200
-Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn: point the codec at the USBSS
- switch
+Subject: arm64: dts: qcom: cq8725s-ayn: point the codec at the USBSS switch
 
 The integrated 3.5mm jack on these boards is wired through the
 WCD9395 USBSS analog switch, and the codec driver looks the switch
@@ -17,7 +16,7 @@ Signed-off-by: SuperKali <hello@superkali.me>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
-index 6090b5b3c668..99c30e0db499 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 @@ -40,6 +40,7 @@ wcd939x: audio-codec {
@@ -29,5 +28,5 @@ index 6090b5b3c668..99c30e0db499 100644
  		reset-gpios = <&tlmm 101 GPIO_ACTIVE_LOW>;
  
 -- 
-2.47.3
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0066-scsi-ufs-ufs-qcom-add-sm8750-compatible.patch
+++ b/patch/kernel/archive/sm8750-7.1/0066-scsi-ufs-ufs-qcom-add-sm8750-compatible.patch
@@ -1,0 +1,20 @@
+From: KONKR Pocket FIT Elite port
+Subject: [PATCH] scsi: ufs: ufs-qcom: add SM8750 controller compatible
+
+The SM8750 UFS host controller (hw_ver 6.1.0) otherwise falls through to
+the generic "qcom,ufshc" match with no drvdata. Match
+"qcom,sm8750-ufshc" to ufs_qcom_sm8550_drvdata (as SM8650 does) so it
+picks up UFSHCD_QUIRK_BROKEN_LSDBS_CAP and no_phy_retention.
+---
+diff --git a/drivers/ufs/host/ufs-qcom.c b/drivers/ufs/host/ufs-qcom.c
+index 291c43448..7a7553f3d 100644
+--- a/drivers/ufs/host/ufs-qcom.c
++++ b/drivers/ufs/host/ufs-qcom.c
+@@ -3008,6 +3008,7 @@ static const struct of_device_id ufs_qcom_of_match[] __maybe_unused = {
+ 	{ .compatible = "qcom,ufshc" },
+ 	{ .compatible = "qcom,sm8550-ufshc", .data = &ufs_qcom_sm8550_drvdata },
+ 	{ .compatible = "qcom,sm8650-ufshc", .data = &ufs_qcom_sm8550_drvdata },
++	{ .compatible = "qcom,sm8750-ufshc", .data = &ufs_qcom_sm8550_drvdata },
+ 	{ .compatible = "qcom,sa8255p-ufshc", .data = &ufs_qcom_sa8255p_drvdata },
+ 	{},
+ };

--- a/patch/kernel/archive/sm8750-7.1/0066-scsi-ufs-ufs-qcom-add-sm8750-compatible.patch
+++ b/patch/kernel/archive/sm8750-7.1/0066-scsi-ufs-ufs-qcom-add-sm8750-compatible.patch
@@ -1,16 +1,30 @@
-From: KONKR Pocket FIT Elite port
-Subject: [PATCH] scsi: ufs: ufs-qcom: add SM8750 controller compatible
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: KONKR Pocket FIT Elite port <unknown-email@domain.tld>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: scsi: ufs: ufs-qcom: add SM8750 controller compatible
 
-The SM8750 UFS host controller (hw_ver 6.1.0) otherwise falls through to
-the generic "qcom,ufshc" match with no drvdata. Match
-"qcom,sm8750-ufshc" to ufs_qcom_sm8550_drvdata (as SM8650 does) so it
-picks up UFSHCD_QUIRK_BROKEN_LSDBS_CAP and no_phy_retention.
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ drivers/ufs/host/ufs-qcom.c | 1 +
+ 1 file changed, 1 insertion(+)
+
 diff --git a/drivers/ufs/host/ufs-qcom.c b/drivers/ufs/host/ufs-qcom.c
-index 291c43448..7a7553f3d 100644
+index 111111111111..222222222222 100644
 --- a/drivers/ufs/host/ufs-qcom.c
 +++ b/drivers/ufs/host/ufs-qcom.c
-@@ -3008,6 +3008,7 @@ static const struct of_device_id ufs_qcom_of_match[] __maybe_unused = {
+@@ -2995,6 +2995,7 @@ static const struct of_device_id ufs_qcom_of_match[] __maybe_unused = {
  	{ .compatible = "qcom,ufshc" },
  	{ .compatible = "qcom,sm8550-ufshc", .data = &ufs_qcom_sm8550_drvdata },
  	{ .compatible = "qcom,sm8650-ufshc", .data = &ufs_qcom_sm8550_drvdata },
@@ -18,3 +32,6 @@ index 291c43448..7a7553f3d 100644
  	{ .compatible = "qcom,sa8255p-ufshc", .data = &ufs_qcom_sa8255p_drvdata },
  	{},
  };
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0072-ASoC-lpass-rx-macro-add-HPH-PCM-mode.patch
+++ b/patch/kernel/archive/sm8750-7.1/0072-ASoC-lpass-rx-macro-add-HPH-PCM-mode.patch
@@ -1,0 +1,136 @@
+From: KONKR Pocket FIT Elite port
+Subject: [PATCH] ASoC: lpass-rx-macro: add HPH PCM mode
+
+In HPH PCM ("HiFi") mode the WCD codec receives interpolated PCM over a
+dedicated SoundWire port and runs interpolation, DC droop and compander
+itself; the RX macro only keeps the main interpolator path running and
+routes its output to the PCM tap (TOP_SWR_CTRL bit1, SoundWire clock
+9.6 MHz). Add an is_pcm_enabled flag ("RX_HPH PCM Switch") that skips
+the PDM-mode signal conditioning (compander coefficients, HD2, LUT
+bypass, DC droop) and selects the PCM path, refcounted across the HPH
+interpolators. Mirrors the vendor lpass-cdc rx-macro behavior.
+---
+--- a/sound/soc/codecs/lpass-rx-macro.c	2026-05-23 13:09:44.000000000 +0200
++++ b/sound/soc/codecs/lpass-rx-macro.c	2026-06-11 21:30:18.468959312 +0200
+@@ -657,6 +657,8 @@
+ 	u16 bit_width[RX_MACRO_MAX_DAIS];
+ 	int is_softclip_on;
+ 	int is_aux_hpf_on;
++	int is_pcm_enabled;
++	int pcm_select_users;
+ 	int softclip_clk_users;
+ 	struct lpass_macro *pds;
+ 	struct regmap *regmap;
+@@ -2644,6 +2646,28 @@
+ 	return 0;
+ }
+ 
++static int rx_macro_hph_pcm_enable_get(struct snd_kcontrol *kcontrol,
++					struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct rx_macro *rx = snd_soc_component_get_drvdata(component);
++
++	ucontrol->value.integer.value[0] = rx->is_pcm_enabled;
++
++	return 0;
++}
++
++static int rx_macro_hph_pcm_enable_put(struct snd_kcontrol *kcontrol,
++					struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct rx_macro *rx = snd_soc_component_get_drvdata(component);
++
++	rx->is_pcm_enabled = ucontrol->value.integer.value[0];
++
++	return 0;
++}
++
+ static int rx_macro_hphdelay_lutbypass(struct snd_soc_component *component,
+ 					struct rx_macro *rx,
+ 					u16 interp_idx, int event)
+@@ -2715,16 +2739,30 @@
+ 						      CDC_RX_RXn_DSM_CLK_EN_MASK, 0x1);
+ 			snd_soc_component_update_bits(component, rx_cfg2_reg,
+ 					CDC_RX_RXn_HPF_CUT_FREQ_MASK, 0x03);
+-			rx_macro_load_compander_coeff(component, rx, interp_idx, event);
+-			if (rx->hph_hd2_mode)
+-				rx_macro_hd2_control(component, interp_idx, event);
+-			rx_macro_hphdelay_lutbypass(component, rx, interp_idx, event);
+-			rx_macro_config_compander(component, rx, interp_idx, event);
++			/*
++			 * In HPH PCM mode the WCD codec owns interpolation,
++			 * DC droop and compander; skip the PDM-mode signal
++			 * conditioning here.
++			 */
++			if (!rx->is_pcm_enabled) {
++				rx_macro_load_compander_coeff(component, rx, interp_idx, event);
++				if (rx->hph_hd2_mode)
++					rx_macro_hd2_control(component, interp_idx, event);
++				rx_macro_hphdelay_lutbypass(component, rx, interp_idx, event);
++				rx_macro_config_compander(component, rx, interp_idx, event);
++			}
+ 			if (interp_idx == INTERP_AUX) {
+ 				rx_macro_config_softclip(component, rx,	event);
+ 				rx_macro_config_aux_hpf(component, rx, event);
+ 			}
+ 			rx_macro_config_classh(component, rx, interp_idx, event);
++			/* select PCM path over SoundWire (swr clk 9.6 MHz) */
++			if (rx->is_pcm_enabled && interp_idx != INTERP_AUX) {
++				if (rx->pcm_select_users++ == 0)
++					snd_soc_component_update_bits(component,
++							CDC_RX_TOP_SWR_CTRL,
++							BIT(1), BIT(1));
++			}
+ 		}
+ 		rx->main_clk_users[interp_idx]++;
+ 	}
+@@ -2736,6 +2774,14 @@
+ 			/* Main path PGA mute enable */
+ 			snd_soc_component_write_field(component, main_reg,
+ 						      CDC_RX_PATH_PGA_MUTE_MASK, 0x1);
++			/* unselect PCM path over SoundWire */
++			if (rx->is_pcm_enabled && interp_idx != INTERP_AUX) {
++				if (rx->pcm_select_users > 0 &&
++				    --rx->pcm_select_users == 0)
++					snd_soc_component_update_bits(component,
++							CDC_RX_TOP_SWR_CTRL,
++							BIT(1), 0);
++			}
+ 			/* Clk Disable */
+ 			snd_soc_component_write_field(component, dsm_reg,
+ 						      CDC_RX_RXn_DSM_CLK_EN_MASK, 0);
+@@ -2753,14 +2799,18 @@
+ 			snd_soc_component_update_bits(component, rx_cfg2_reg,
+ 						      CDC_RX_RXn_HPF_CUT_FREQ_MASK, 0x00);
+ 			rx_macro_config_classh(component, rx, interp_idx, event);
+-			rx_macro_config_compander(component, rx, interp_idx, event);
++			if (!rx->is_pcm_enabled) {
++				rx_macro_config_compander(component, rx, interp_idx, event);
++			}
+ 			if (interp_idx ==  INTERP_AUX) {
+ 				rx_macro_config_softclip(component, rx,	event);
+ 				rx_macro_config_aux_hpf(component, rx, event);
+ 			}
+-			rx_macro_hphdelay_lutbypass(component, rx, interp_idx, event);
+-			if (rx->hph_hd2_mode)
+-				rx_macro_hd2_control(component, interp_idx, event);
++			if (!rx->is_pcm_enabled) {
++				rx_macro_hphdelay_lutbypass(component, rx, interp_idx, event);
++				if (rx->hph_hd2_mode)
++					rx_macro_hd2_control(component, interp_idx, event);
++			}
+ 		}
+ 	}
+ 
+@@ -3024,6 +3074,9 @@
+ 	SOC_SINGLE_EXT("RX_HPH HD2 Mode Switch", SND_SOC_NOPM, 0, 1, 0,
+ 		rx_macro_get_hph_hd2_mode, rx_macro_put_hph_hd2_mode),
+ 
++	SOC_SINGLE_EXT("RX_HPH PCM Switch", SND_SOC_NOPM, 0, 1, 0,
++		rx_macro_hph_pcm_enable_get, rx_macro_hph_pcm_enable_put),
++
+ 	SOC_ENUM_EXT("RX_HPH PWR Mode", rx_macro_hph_pwr_mode_enum,
+ 		rx_macro_get_hph_pwr_mode, rx_macro_put_hph_pwr_mode),
+ 

--- a/patch/kernel/archive/sm8750-7.1/0072-ASoC-lpass-rx-macro-add-HPH-PCM-mode.patch
+++ b/patch/kernel/archive/sm8750-7.1/0072-ASoC-lpass-rx-macro-add-HPH-PCM-mode.patch
@@ -1,18 +1,30 @@
-From: KONKR Pocket FIT Elite port
-Subject: [PATCH] ASoC: lpass-rx-macro: add HPH PCM mode
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: KONKR Pocket FIT Elite port <unknown-email@domain.tld>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: ASoC: lpass-rx-macro: add HPH PCM mode
 
-In HPH PCM ("HiFi") mode the WCD codec receives interpolated PCM over a
-dedicated SoundWire port and runs interpolation, DC droop and compander
-itself; the RX macro only keeps the main interpolator path running and
-routes its output to the PCM tap (TOP_SWR_CTRL bit1, SoundWire clock
-9.6 MHz). Add an is_pcm_enabled flag ("RX_HPH PCM Switch") that skips
-the PDM-mode signal conditioning (compander coefficients, HD2, LUT
-bypass, DC droop) and selects the PCM path, refcounted across the HPH
-interpolators. Mirrors the vendor lpass-cdc rx-macro behavior.
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
---- a/sound/soc/codecs/lpass-rx-macro.c	2026-05-23 13:09:44.000000000 +0200
-+++ b/sound/soc/codecs/lpass-rx-macro.c	2026-06-11 21:30:18.468959312 +0200
-@@ -657,6 +657,8 @@
+ sound/soc/codecs/lpass-rx-macro.c | 71 ++++++++--
+ 1 file changed, 62 insertions(+), 9 deletions(-)
+
+diff --git a/sound/soc/codecs/lpass-rx-macro.c b/sound/soc/codecs/lpass-rx-macro.c
+index 111111111111..222222222222 100644
+--- a/sound/soc/codecs/lpass-rx-macro.c
++++ b/sound/soc/codecs/lpass-rx-macro.c
+@@ -657,6 +657,8 @@ struct rx_macro {
  	u16 bit_width[RX_MACRO_MAX_DAIS];
  	int is_softclip_on;
  	int is_aux_hpf_on;
@@ -21,7 +33,7 @@ interpolators. Mirrors the vendor lpass-cdc rx-macro behavior.
  	int softclip_clk_users;
  	struct lpass_macro *pds;
  	struct regmap *regmap;
-@@ -2644,6 +2646,28 @@
+@@ -2644,6 +2646,28 @@ static int rx_macro_aux_hpf_mode_put(struct snd_kcontrol *kcontrol,
  	return 0;
  }
  
@@ -50,7 +62,7 @@ interpolators. Mirrors the vendor lpass-cdc rx-macro behavior.
  static int rx_macro_hphdelay_lutbypass(struct snd_soc_component *component,
  					struct rx_macro *rx,
  					u16 interp_idx, int event)
-@@ -2715,16 +2739,30 @@
+@@ -2715,16 +2739,30 @@ static int rx_macro_enable_interp_clk(struct snd_soc_component *component,
  						      CDC_RX_RXn_DSM_CLK_EN_MASK, 0x1);
  			snd_soc_component_update_bits(component, rx_cfg2_reg,
  					CDC_RX_RXn_HPF_CUT_FREQ_MASK, 0x03);
@@ -86,7 +98,7 @@ interpolators. Mirrors the vendor lpass-cdc rx-macro behavior.
  		}
  		rx->main_clk_users[interp_idx]++;
  	}
-@@ -2736,6 +2774,14 @@
+@@ -2736,6 +2774,14 @@ static int rx_macro_enable_interp_clk(struct snd_soc_component *component,
  			/* Main path PGA mute enable */
  			snd_soc_component_write_field(component, main_reg,
  						      CDC_RX_PATH_PGA_MUTE_MASK, 0x1);
@@ -101,7 +113,7 @@ interpolators. Mirrors the vendor lpass-cdc rx-macro behavior.
  			/* Clk Disable */
  			snd_soc_component_write_field(component, dsm_reg,
  						      CDC_RX_RXn_DSM_CLK_EN_MASK, 0);
-@@ -2753,14 +2799,18 @@
+@@ -2753,14 +2799,18 @@ static int rx_macro_enable_interp_clk(struct snd_soc_component *component,
  			snd_soc_component_update_bits(component, rx_cfg2_reg,
  						      CDC_RX_RXn_HPF_CUT_FREQ_MASK, 0x00);
  			rx_macro_config_classh(component, rx, interp_idx, event);
@@ -124,7 +136,7 @@ interpolators. Mirrors the vendor lpass-cdc rx-macro behavior.
  		}
  	}
  
-@@ -3024,6 +3074,9 @@
+@@ -3024,6 +3074,9 @@ static const struct snd_kcontrol_new rx_macro_snd_controls[] = {
  	SOC_SINGLE_EXT("RX_HPH HD2 Mode Switch", SND_SOC_NOPM, 0, 1, 0,
  		rx_macro_get_hph_hd2_mode, rx_macro_put_hph_hd2_mode),
  
@@ -134,3 +146,6 @@ interpolators. Mirrors the vendor lpass-cdc rx-macro behavior.
  	SOC_ENUM_EXT("RX_HPH PWR Mode", rx_macro_hph_pwr_mode_enum,
  		rx_macro_get_hph_pwr_mode, rx_macro_put_hph_pwr_mode),
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0073-ASoC-wcd939x-add-HPH-PCM-HiFi-mode.patch
+++ b/patch/kernel/archive/sm8750-7.1/0073-ASoC-wcd939x-add-HPH-PCM-HiFi-mode.patch
@@ -1,0 +1,531 @@
+From: KONKR Pocket FIT Elite port
+Subject: [PATCH] ASoC: wcd939x: add HPH PCM (HiFi) mode
+
+The WCD9390/9395 support a PCM playback path for HPH ("later" per the
+original driver submission, never implemented): the stream arrives as
+384 kHz PCM on SoundWire port 6 (HIFI_PCM, already declared in
+wcd939x-sdw) and the codec runs its own interpolator, DC droop filter
+and analog compander instead of the legacy PDM receive path. On the
+KONKR Pocket FIT Elite the PDM path produces a constant hiss on the
+jack; the PCM path is what stock Android ships and is silent.
+
+Add an "HPH PCM Switch" kcontrol (kept ahead of the COMP/HPH switches:
+alsa-state restore order matters). When enabled:
+- HPHL/HPHR Switch connect HIFI_PCM_L/R (port 6) instead of HPH_L/R,
+  and the COMP gain port stays unused;
+- DAC bring-up programs the analog compander (zone RMS per power mode,
+  clock + sync-reset pulse), crosstalk coefficients, gain source, and
+  keeps the RDAC chopper running; VNEG_CTRL_1/RDAC bias per vendor;
+- PA bring-up programs the interpolator (INT_EN/DLY_ZN staged, DC droop
+  for 9.6 MHz), DAC rate select by mode, and forces PA power level 0b11
+  (the 0b10 the class-H controller picks leaves a constant hiss);
+- the PDM watchdog and its interrupts stay off (no PDM data to guard);
+- symmetric teardown on power-down.
+
+Register values match a stock Android WCD9395 trace on this device.
+Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
+---
+--- a/sound/soc/codecs/wcd939x.c	2026-06-11 21:30:18.467792000 +0200
++++ b/sound/soc/codecs/wcd939x.c	2026-06-11 21:30:18.469036928 +0200
+@@ -211,6 +211,7 @@
+ 	int ear_pdm_wd_int;
+ 	bool comp1_enable;
+ 	bool comp2_enable;
++	bool hph_pcm_enabled;
+ 	bool ldoh;
+ };
+ 
+@@ -411,6 +412,7 @@
+ 
+ 	snd_soc_component_write(component, WCD939X_E_CFG0,
+ 				WCD939X_CFG0_IDLE_STEREO |
++				WCD939X_CFG0_AUTO_DISABLE_DSD |
+ 				WCD939X_CFG0_AUTO_DISABLE_ANC);
+ 
+ 	return 0;
+@@ -502,6 +504,165 @@
+ 	return 0;
+ }
+ 
++/*
++ * HPH PCM ("HiFi") mode: the HPH stream arrives as PCM samples on SoundWire
++ * port 6 (HIFI_PCM) and the codec runs its own interpolator, DC droop filter
++ * and analog compander, replacing the legacy PDM receive path. Vendor
++ * hph_pcm_enabled behavior; register values match the stock WCD9395 trace
++ * (SoundWire clock fixed at 9.6 MHz on this platform).
++ */
++static void wcd939x_hph_pcm_pre_dac(struct snd_soc_component *component,
++				    bool hphr)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	bool comp_en = hphr ? wcd939x->comp2_enable : wcd939x->comp1_enable;
++	u16 comp_base = hphr ? WCD939X_R_CTL0 : WCD939X_COMPANDER_HPHL_CTL0;
++	u16 sec_base = hphr ? WCD939X_RX_TOP_HPHR_PATH_SEC0 :
++			      WCD939X_RX_TOP_HPHL_PATH_SEC0;
++
++	/*
++	 * PCM mode keeps the RDAC chopper running (stock 0x30d9 = 0x80);
++	 * set it explicitly in case a PDM-mode bring-up cleared it earlier.
++	 */
++	snd_soc_component_write_field(component, WCD939X_HPH_RDAC_CLK_CTL1,
++				      WCD939X_RDAC_CLK_CTL1_OPAMP_CHOP_CLK_EN,
++				      true);
++
++	if (wcd939x->hph_mode == CLS_H_ULP) {
++		snd_soc_component_write_field(component, WCD939X_HPH_REFBUFF_UHQA_CTL,
++					      WCD939X_REFBUFF_UHQA_CTL_REFBUFP_IOUT_CTL, 1);
++		snd_soc_component_write_field(component, WCD939X_HPH_REFBUFF_UHQA_CTL,
++					      WCD939X_REFBUFF_UHQA_CTL_REFBUFN_IOUT_CTL, 1);
++	}
++
++	if (!comp_en) {
++		/* compander bypassed, gain from register */
++		if (hphr)
++			snd_soc_component_write_field(component, WCD939X_HPH_R_EN,
++						      WCD939X_R_EN_GAIN_SOURCE_SEL, true);
++		else
++			snd_soc_component_write_field(component, WCD939X_HPH_L_EN,
++						      WCD939X_L_EN_GAIN_SOURCE_SEL, true);
++		return;
++	}
++
++	/* compander zone RMS thresholds + path gain per power mode */
++	if (wcd939x->hph_mode == CLS_H_ULP) {
++		snd_soc_component_write(component, comp_base + 12, 0x21);
++		snd_soc_component_write(component, comp_base + 13, 0x30);
++		snd_soc_component_write(component, comp_base + 14, 0x3f);
++		snd_soc_component_write(component, comp_base + 15, 0x48);
++		snd_soc_component_write(component, comp_base + 17, 0x0c);
++	} else {
++		snd_soc_component_write(component, comp_base + 12, 0x1e);
++		snd_soc_component_write(component, comp_base + 13, 0x2a);
++		snd_soc_component_write(component, comp_base + 14, 0x36);
++		snd_soc_component_write(component, comp_base + 15, 0x3c);
++		snd_soc_component_write(component, comp_base + 17, 0x00);
++	}
++
++	/* gain follows the compander */
++	if (hphr)
++		snd_soc_component_write_field(component, WCD939X_HPH_R_EN,
++					      WCD939X_R_EN_GAIN_SOURCE_SEL, false);
++	else
++		snd_soc_component_write_field(component, WCD939X_HPH_L_EN,
++					      WCD939X_L_EN_GAIN_SOURCE_SEL, false);
++
++	/* compander clock enable + sync-reset pulse */
++	snd_soc_component_write(component, comp_base + 7, 0x00);
++	snd_soc_component_write(component, comp_base + 0, 0x61);
++	/* 250us sleep required as per HW sequence */
++	usleep_range(250, 260);
++	snd_soc_component_write(component, comp_base + 0, 0x63);
++	snd_soc_component_write(component, comp_base + 0, 0x61);
++
++	if (hphr)
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_COMP_CTL_0,
++					      WCD939X_CDC_COMP_CTL_0_HPHR_COMP_EN, true);
++	else
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_COMP_CTL_0,
++					      WCD939X_CDC_COMP_CTL_0_HPHL_COMP_EN, true);
++
++	/* crosstalk coefficients (stock: scale 0x1f, sec2/3 0x11/0x4f) */
++	snd_soc_component_write(component, sec_base + 0, 0x1f);
++	snd_soc_component_write(component, sec_base + 3, 0x4f);
++	snd_soc_component_write(component, sec_base + 2, 0x11);
++}
++
++static void wcd939x_hph_pcm_post_dac(struct snd_soc_component *component)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_TIMER1,
++				      WCD939X_TIMER1_AUTOCHOP_TIMER_CTL_EN, false);
++	snd_soc_component_write(component, WCD939X_FLYBACK_VNEG_CTRL_1, 0xeb);
++	if (wcd939x->hph_mode == CLS_H_LOHIFI)
++		snd_soc_component_write(component,
++					WCD939X_RX_NEW_INT_HPH_RDAC_BIAS_LOHIFI, 0x52);
++	else
++		snd_soc_component_write(component,
++					WCD939X_RX_NEW_INT_HPH_RDAC_BIAS_LOHIFI, 0x64);
++}
++
++static void wcd939x_hph_pcm_dac_teardown(struct snd_soc_component *component,
++					 bool hphr)
++{
++	u16 comp_base = hphr ? WCD939X_R_CTL0 : WCD939X_COMPANDER_HPHL_CTL0;
++
++	/* disable both companders, whichever channel powers down first */
++	snd_soc_component_update_bits(component, WCD939X_DIGITAL_CDC_COMP_CTL_0,
++				      WCD939X_CDC_COMP_CTL_0_HPHL_COMP_EN |
++				      WCD939X_CDC_COMP_CTL_0_HPHR_COMP_EN, 0);
++
++	/* gain source back to register */
++	snd_soc_component_write_field(component, WCD939X_HPH_L_EN,
++				      WCD939X_L_EN_GAIN_SOURCE_SEL, true);
++	snd_soc_component_write_field(component, WCD939X_HPH_R_EN,
++				      WCD939X_R_EN_GAIN_SOURCE_SEL, true);
++
++	/* compander clock off, hold soft reset */
++	snd_soc_component_update_bits(component, comp_base + 0, 0x03, 0x02);
++}
++
++static void wcd939x_hph_pcm_pre_pa(struct snd_soc_component *component,
++				   bool hphr)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	u16 cfg0 = hphr ? WCD939X_RX_TOP_HPHR_PATH_CFG0 : WCD939X_RX_TOP_HPHL_PATH_CFG0;
++	u16 cfg1 = hphr ? WCD939X_RX_TOP_HPHR_PATH_CFG1 : WCD939X_RX_TOP_HPHL_PATH_CFG1;
++
++	/* crosstalk enable for L and R */
++	snd_soc_component_write(component, WCD939X_RX_TOP_PATH_CFG2, 0x0f);
++	/* DC droop coefficient for 9.6 MHz RX clock */
++	snd_soc_component_write(component, cfg1, 0x03);
++	/* delay zero-notch enable, then interpolator enable (stock order) */
++	if (hphr) {
++		snd_soc_component_write(component, cfg0, 0x02);
++		snd_soc_component_write(component, cfg0, 0x06);
++	} else {
++		snd_soc_component_write(component, cfg0, 0x01);
++		snd_soc_component_write(component, cfg0, 0x03);
++	}
++
++	if (wcd939x->hph_mode == CLS_H_HIFI || wcd939x->hph_mode == CLS_AB_HIFI)
++		snd_soc_component_write_field(component, WCD939X_RX_TOP_TOP_CFG0,
++					      WCD939X_TOP_CFG0_HPH_DAC_RATE_SEL, true);
++	else
++		snd_soc_component_write_field(component, WCD939X_RX_TOP_TOP_CFG0,
++					      WCD939X_TOP_CFG0_HPH_DAC_RATE_SEL, false);
++}
++
++static void wcd939x_hph_pcm_post_pa(struct snd_soc_component *component,
++				    bool hphr)
++{
++	u16 cfg0 = hphr ? WCD939X_RX_TOP_HPHR_PATH_CFG0 : WCD939X_RX_TOP_HPHL_PATH_CFG0;
++	u16 cfg1 = hphr ? WCD939X_RX_TOP_HPHR_PATH_CFG1 : WCD939X_RX_TOP_HPHL_PATH_CFG1;
++
++	snd_soc_component_write(component, cfg0, 0x00);
++	snd_soc_component_write(component, cfg1, 0x00);
++}
++
+ static int wcd939x_codec_hphl_dac_event(struct snd_soc_dapm_widget *w,
+ 					struct snd_kcontrol *kcontrol,
+ 					int event)
+@@ -511,9 +672,12 @@
+ 
+ 	switch (event) {
+ 	case SND_SOC_DAPM_PRE_PMU:
+-		snd_soc_component_write_field(component, WCD939X_HPH_RDAC_CLK_CTL1,
+-					      WCD939X_RDAC_CLK_CTL1_OPAMP_CHOP_CLK_EN,
+-					      false);
++		if (wcd939x->hph_pcm_enabled)
++			wcd939x_hph_pcm_pre_dac(component, false);
++		else
++			snd_soc_component_write_field(component, WCD939X_HPH_RDAC_CLK_CTL1,
++						      WCD939X_RDAC_CLK_CTL1_OPAMP_CHOP_CLK_EN,
++						      false);
+ 
+ 		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
+ 					      WCD939X_CDC_HPH_GAIN_CTL_HPHL_RX_EN, true);
+@@ -521,7 +685,9 @@
+ 	case SND_SOC_DAPM_POST_PMU:
+ 		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_L,
+ 					      WCD939X_RDAC_HD2_CTL_L_HD2_RES_DIV_CTL_L, 0x1d);
+-		if (wcd939x->comp1_enable) {
++		if (wcd939x->hph_pcm_enabled) {
++			wcd939x_hph_pcm_post_dac(component);
++		} else if (wcd939x->comp1_enable) {
+ 			snd_soc_component_write_field(component,
+ 						      WCD939X_DIGITAL_CDC_COMP_CTL_0,
+ 						      WCD939X_CDC_COMP_CTL_0_HPHL_COMP_EN,
+@@ -546,6 +712,8 @@
+ 		}
+ 		break;
+ 	case SND_SOC_DAPM_POST_PMD:
++		if (wcd939x->hph_pcm_enabled)
++			wcd939x_hph_pcm_dac_teardown(component, false);
+ 		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_L,
+ 					      WCD939X_RDAC_HD2_CTL_L_HD2_RES_DIV_CTL_L, 1);
+ 		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
+@@ -568,9 +736,12 @@
+ 
+ 	switch (event) {
+ 	case SND_SOC_DAPM_PRE_PMU:
+-		snd_soc_component_write_field(component, WCD939X_HPH_RDAC_CLK_CTL1,
+-					      WCD939X_RDAC_CLK_CTL1_OPAMP_CHOP_CLK_EN,
+-					      false);
++		if (wcd939x->hph_pcm_enabled)
++			wcd939x_hph_pcm_pre_dac(component, true);
++		else
++			snd_soc_component_write_field(component, WCD939X_HPH_RDAC_CLK_CTL1,
++						      WCD939X_RDAC_CLK_CTL1_OPAMP_CHOP_CLK_EN,
++						      false);
+ 
+ 		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
+ 					      WCD939X_CDC_HPH_GAIN_CTL_HPHR_RX_EN, true);
+@@ -578,7 +749,9 @@
+ 	case SND_SOC_DAPM_POST_PMU:
+ 		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_R,
+ 					      WCD939X_RDAC_HD2_CTL_R_HD2_RES_DIV_CTL_R, 0x1d);
+-		if (wcd939x->comp2_enable) {
++		if (wcd939x->hph_pcm_enabled) {
++			wcd939x_hph_pcm_post_dac(component);
++		} else if (wcd939x->comp2_enable) {
+ 			snd_soc_component_write_field(component,
+ 						      WCD939X_DIGITAL_CDC_COMP_CTL_0,
+ 						      WCD939X_CDC_COMP_CTL_0_HPHR_COMP_EN,
+@@ -602,6 +775,8 @@
+ 		}
+ 		break;
+ 	case SND_SOC_DAPM_POST_PMD:
++		if (wcd939x->hph_pcm_enabled)
++			wcd939x_hph_pcm_dac_teardown(component, true);
+ 		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_R,
+ 					      WCD939X_RDAC_HD2_CTL_R_HD2_RES_DIV_CTL_R, 1);
+ 		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
+@@ -658,11 +833,15 @@
+ 			snd_soc_component_write_field(component, WCD939X_LDOH_MODE,
+ 						      WCD939X_MODE_LDOH_EN, true);
+ 
++		if (wcd939x->hph_pcm_enabled)
++			wcd939x_hph_pcm_pre_pa(component, true);
++
+ 		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_PRE_DAC,
+ 					WCD_CLSH_STATE_HPHR, hph_mode);
+ 		wcd_clsh_set_hph_mode(wcd939x->clsh_info, CLS_H_HIFI);
+ 
+-		if (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI || hph_mode == CLS_H_ULP)
++		if (!wcd939x->hph_pcm_enabled &&
++		    (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI || hph_mode == CLS_H_ULP))
+ 			snd_soc_component_write_field(component,
+ 					WCD939X_HPH_REFBUFF_LP_CTL,
+ 					WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS, true);
+@@ -680,8 +859,10 @@
+ 			usleep_range(2500, 2600); /* 2.5msec delay as per HW requirement */
+ 
+ 		set_bit(HPH_PA_DELAY, &wcd939x->status_mask);
+-		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL1,
+-					      WCD939X_PDM_WD_CTL1_PDM_WD_EN, 3);
++		/* PDM watchdog guards the PDM data path only */
++		if (!wcd939x->hph_pcm_enabled)
++			snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL1,
++						      WCD939X_PDM_WD_CTL1_PDM_WD_EN, 3);
+ 		break;
+ 	case SND_SOC_DAPM_POST_PMU:
+ 		/*
+@@ -695,8 +876,9 @@
+ 			else
+ 				usleep_range(7000, 7100);
+ 
+-			if (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI ||
+-			    hph_mode == CLS_H_ULP)
++			if (!wcd939x->hph_pcm_enabled &&
++			    (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI ||
++			     hph_mode == CLS_H_ULP))
+ 				snd_soc_component_write_field(component,
+ 						WCD939X_HPH_REFBUFF_LP_CTL,
+ 						WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS,
+@@ -711,10 +893,20 @@
+ 						      WCD939X_RX_SUPPLIES_REGULATOR_MODE,
+ 						      true);
+ 
+-		enable_irq(wcd939x->hphr_pdm_wd_int);
++		/*
++		 * PCM mode: PA power level 0b11 as on stock; the 0b10 the
++		 * class-H controller picks leaves a constant output hiss.
++		 */
++		if (wcd939x->hph_pcm_enabled)
++			snd_soc_component_write_field(component, WCD939X_ANA_HPH,
++						      WCD939X_HPH_PWR_LEVEL, 3);
++		/* PDM watchdog interrupt for the PDM data path only */
++		if (!wcd939x->hph_pcm_enabled)
++			enable_irq(wcd939x->hphr_pdm_wd_int);
+ 		break;
+ 	case SND_SOC_DAPM_PRE_PMD:
+-		disable_irq_nosync(wcd939x->hphr_pdm_wd_int);
++		if (!wcd939x->hph_pcm_enabled)
++			disable_irq_nosync(wcd939x->hphr_pdm_wd_int);
+ 		/*
+ 		 * 7ms sleep is required if compander is enabled as per
+ 		 * HW requirement. If compander is disabled, then
+@@ -752,6 +944,8 @@
+ 					      WCD939X_HPH_HPHR_REF_ENABLE, false);
+ 		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL1,
+ 					      WCD939X_PDM_WD_CTL1_PDM_WD_EN, 0);
++		if (wcd939x->hph_pcm_enabled)
++			wcd939x_hph_pcm_post_pa(component, true);
+ 
+ 		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_POST_PA,
+ 					WCD_CLSH_STATE_HPHR, hph_mode);
+@@ -780,11 +974,16 @@
+ 		if (wcd939x->ldoh)
+ 			snd_soc_component_write_field(component, WCD939X_LDOH_MODE,
+ 						      WCD939X_MODE_LDOH_EN, true);
++
++		if (wcd939x->hph_pcm_enabled)
++			wcd939x_hph_pcm_pre_pa(component, false);
++
+ 		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_PRE_DAC,
+ 					WCD_CLSH_STATE_HPHL, hph_mode);
+ 		wcd_clsh_set_hph_mode(wcd939x->clsh_info, CLS_H_HIFI);
+ 
+-		if (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI || hph_mode == CLS_H_ULP)
++		if (!wcd939x->hph_pcm_enabled &&
++		    (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI || hph_mode == CLS_H_ULP))
+ 			snd_soc_component_write_field(component,
+ 						WCD939X_HPH_REFBUFF_LP_CTL,
+ 						WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS,
+@@ -803,8 +1002,10 @@
+ 			usleep_range(2500, 2600); /* 2.5msec delay as per HW requirement */
+ 
+ 		set_bit(HPH_PA_DELAY, &wcd939x->status_mask);
+-		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL0,
+-					      WCD939X_PDM_WD_CTL0_PDM_WD_EN, 3);
++		/* PDM watchdog guards the PDM data path only */
++		if (!wcd939x->hph_pcm_enabled)
++			snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL0,
++						      WCD939X_PDM_WD_CTL0_PDM_WD_EN, 3);
+ 		break;
+ 	case SND_SOC_DAPM_POST_PMU:
+ 		/*
+@@ -817,8 +1018,9 @@
+ 				usleep_range(20000, 20100);
+ 			else
+ 				usleep_range(7000, 7100);
+-			if (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI ||
+-			    hph_mode == CLS_H_ULP)
++			if (!wcd939x->hph_pcm_enabled &&
++			    (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI ||
++			     hph_mode == CLS_H_ULP))
+ 				snd_soc_component_write_field(component,
+ 						WCD939X_HPH_REFBUFF_LP_CTL,
+ 						WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS,
+@@ -832,10 +1034,20 @@
+ 			snd_soc_component_write_field(component, WCD939X_ANA_RX_SUPPLIES,
+ 						      WCD939X_RX_SUPPLIES_REGULATOR_MODE,
+ 						      true);
+-		enable_irq(wcd939x->hphl_pdm_wd_int);
++		/*
++		 * PCM mode: PA power level 0b11 as on stock; the 0b10 the
++		 * class-H controller picks leaves a constant output hiss.
++		 */
++		if (wcd939x->hph_pcm_enabled)
++			snd_soc_component_write_field(component, WCD939X_ANA_HPH,
++						      WCD939X_HPH_PWR_LEVEL, 3);
++		/* PDM watchdog interrupt for the PDM data path only */
++		if (!wcd939x->hph_pcm_enabled)
++			enable_irq(wcd939x->hphl_pdm_wd_int);
+ 		break;
+ 	case SND_SOC_DAPM_PRE_PMD:
+-		disable_irq_nosync(wcd939x->hphl_pdm_wd_int);
++		if (!wcd939x->hph_pcm_enabled)
++			disable_irq_nosync(wcd939x->hphl_pdm_wd_int);
+ 		/*
+ 		 * 7ms sleep is required if compander is enabled as per
+ 		 * HW requirement. If compander is disabled, then
+@@ -871,6 +1083,8 @@
+ 					      WCD939X_HPH_HPHL_REF_ENABLE, false);
+ 		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL0,
+ 					      WCD939X_PDM_WD_CTL0_PDM_WD_EN, 0);
++		if (wcd939x->hph_pcm_enabled)
++			wcd939x_hph_pcm_post_pa(component, false);
+ 		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_POST_PA,
+ 					WCD_CLSH_STATE_HPHL, hph_mode);
+ 		if (wcd939x->ldoh)
+@@ -1549,6 +1763,13 @@
+ 	else
+ 		wcd939x->comp1_enable = value;
+ 
++	/*
++	 * In HPH PCM mode the compander runs inside the codec and the
++	 * SoundWire COMP gain port stays unused.
++	 */
++	if (wcd939x->hph_pcm_enabled)
++		return 1;
++
+ 	if (value)
+ 		wcd939x_connect_port(wcd, portidx, mc->reg, true);
+ 	else
+@@ -1557,6 +1778,31 @@
+ 	return 1;
+ }
+ 
++static int wcd939x_hph_pcm_enable_get(struct snd_kcontrol *kcontrol,
++				      struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	ucontrol->value.integer.value[0] = wcd939x->hph_pcm_enabled ? 1 : 0;
++
++	return 0;
++}
++
++static int wcd939x_hph_pcm_enable_put(struct snd_kcontrol *kcontrol,
++				      struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	if (wcd939x->hph_pcm_enabled == !!ucontrol->value.integer.value[0])
++		return 0;
++
++	wcd939x->hph_pcm_enabled = !!ucontrol->value.integer.value[0];
++
++	return 1;
++}
++
+ static int wcd939x_ldoh_get(struct snd_kcontrol *kcontrol,
+ 			    struct snd_ctl_elem_value *ucontrol)
+ {
+@@ -1795,7 +2041,17 @@
+ 	struct snd_soc_component *comp = snd_kcontrol_chip(kcontrol);
+ 	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(comp);
+ 	struct wcd939x_sdw_priv *wcd = wcd939x->sdw_priv[mixer->shift];
+-	unsigned int portidx = wcd->ch_info[mixer->reg].port_num;
++	unsigned int ch_id = mixer->reg;
++	unsigned int portidx;
++
++	/* in HPH PCM mode the HPH stream rides the HIFI_PCM port */
++	if (wcd939x->hph_pcm_enabled) {
++		if (ch_id == WCD939X_HPH_L)
++			ch_id = WCD939X_HIFI_PCM_L;
++		else if (ch_id == WCD939X_HPH_R)
++			ch_id = WCD939X_HIFI_PCM_R;
++	}
++	portidx = wcd->ch_info[ch_id].port_num;
+ 
+ 	ucontrol->value.integer.value[0] = wcd->port_enable[portidx] ? 1 : 0;
+ 
+@@ -1822,11 +2078,21 @@
+ 	struct snd_soc_component *comp = snd_kcontrol_chip(kcontrol);
+ 	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(comp);
+ 	struct wcd939x_sdw_priv *wcd = wcd939x->sdw_priv[mixer->shift];
+-	unsigned int portidx = wcd->ch_info[mixer->reg].port_num;
++	unsigned int ch_id = mixer->reg;
++	unsigned int portidx;
++
++	/* in HPH PCM mode the HPH stream rides the HIFI_PCM port */
++	if (wcd939x->hph_pcm_enabled) {
++		if (ch_id == WCD939X_HPH_L)
++			ch_id = WCD939X_HIFI_PCM_L;
++		else if (ch_id == WCD939X_HPH_R)
++			ch_id = WCD939X_HIFI_PCM_R;
++	}
++	portidx = wcd->ch_info[ch_id].port_num;
+ 
+ 	wcd->port_enable[portidx] = !!ucontrol->value.integer.value[0];
+ 
+-	wcd939x_connect_port(wcd, portidx, mixer->reg, wcd->port_enable[portidx]);
++	wcd939x_connect_port(wcd, portidx, ch_id, wcd->port_enable[portidx]);
+ 
+ 	return 1;
+ }
+@@ -2533,6 +2799,9 @@
+ 
+ static const struct snd_kcontrol_new wcd939x_snd_controls[] = {
+ 	/* RX Path */
++	/* must stay ahead of the COMP/HPH switches: restore order matters */
++	SOC_SINGLE_EXT("HPH PCM Switch", SND_SOC_NOPM, 0, 1, 0,
++		       wcd939x_hph_pcm_enable_get, wcd939x_hph_pcm_enable_put),
+ 	SOC_SINGLE_EXT("HPHL_COMP Switch", WCD939X_COMP_L, 0, 1, 0,
+ 		       wcd939x_get_compander, wcd939x_set_compander),
+ 	SOC_SINGLE_EXT("HPHR_COMP Switch", WCD939X_COMP_R, 1, 1, 0,

--- a/patch/kernel/archive/sm8750-7.1/0073-ASoC-wcd939x-add-HPH-PCM-HiFi-mode.patch
+++ b/patch/kernel/archive/sm8750-7.1/0073-ASoC-wcd939x-add-HPH-PCM-HiFi-mode.patch
@@ -1,33 +1,30 @@
-From: KONKR Pocket FIT Elite port
-Subject: [PATCH] ASoC: wcd939x: add HPH PCM (HiFi) mode
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: KONKR Pocket FIT Elite port <unknown-email@domain.tld>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: ASoC: wcd939x: add HPH PCM (HiFi) mode
 
-The WCD9390/9395 support a PCM playback path for HPH ("later" per the
-original driver submission, never implemented): the stream arrives as
-384 kHz PCM on SoundWire port 6 (HIFI_PCM, already declared in
-wcd939x-sdw) and the codec runs its own interpolator, DC droop filter
-and analog compander instead of the legacy PDM receive path. On the
-KONKR Pocket FIT Elite the PDM path produces a constant hiss on the
-jack; the PCM path is what stock Android ships and is silent.
-
-Add an "HPH PCM Switch" kcontrol (kept ahead of the COMP/HPH switches:
-alsa-state restore order matters). When enabled:
-- HPHL/HPHR Switch connect HIFI_PCM_L/R (port 6) instead of HPH_L/R,
-  and the COMP gain port stays unused;
-- DAC bring-up programs the analog compander (zone RMS per power mode,
-  clock + sync-reset pulse), crosstalk coefficients, gain source, and
-  keeps the RDAC chopper running; VNEG_CTRL_1/RDAC bias per vendor;
-- PA bring-up programs the interpolator (INT_EN/DLY_ZN staged, DC droop
-  for 9.6 MHz), DAC rate select by mode, and forces PA power level 0b11
-  (the 0b10 the class-H controller picks leaves a constant hiss);
-- the PDM watchdog and its interrupts stay off (no PDM data to guard);
-- symmetric teardown on power-down.
-
-Register values match a stock Android WCD9395 trace on this device.
-Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
---- a/sound/soc/codecs/wcd939x.c	2026-06-11 21:30:18.467792000 +0200
-+++ b/sound/soc/codecs/wcd939x.c	2026-06-11 21:30:18.469036928 +0200
-@@ -211,6 +211,7 @@
+ sound/soc/codecs/wcd939x.c | 319 +++++++++-
+ 1 file changed, 294 insertions(+), 25 deletions(-)
+
+diff --git a/sound/soc/codecs/wcd939x.c b/sound/soc/codecs/wcd939x.c
+index 111111111111..222222222222 100644
+--- a/sound/soc/codecs/wcd939x.c
++++ b/sound/soc/codecs/wcd939x.c
+@@ -211,6 +211,7 @@ struct wcd939x_priv {
  	int ear_pdm_wd_int;
  	bool comp1_enable;
  	bool comp2_enable;
@@ -35,7 +32,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  	bool ldoh;
  };
  
-@@ -411,6 +412,7 @@
+@@ -411,6 +412,7 @@ static int wcd939x_io_init(struct snd_soc_component *component)
  
  	snd_soc_component_write(component, WCD939X_E_CFG0,
  				WCD939X_CFG0_IDLE_STEREO |
@@ -43,7 +40,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  				WCD939X_CFG0_AUTO_DISABLE_ANC);
  
  	return 0;
-@@ -502,6 +504,165 @@
+@@ -502,6 +504,165 @@ static int wcd939x_codec_enable_rxclk(struct snd_soc_dapm_widget *w,
  	return 0;
  }
  
@@ -209,7 +206,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  static int wcd939x_codec_hphl_dac_event(struct snd_soc_dapm_widget *w,
  					struct snd_kcontrol *kcontrol,
  					int event)
-@@ -511,9 +672,12 @@
+@@ -511,9 +672,12 @@ static int wcd939x_codec_hphl_dac_event(struct snd_soc_dapm_widget *w,
  
  	switch (event) {
  	case SND_SOC_DAPM_PRE_PMU:
@@ -225,7 +222,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  
  		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
  					      WCD939X_CDC_HPH_GAIN_CTL_HPHL_RX_EN, true);
-@@ -521,7 +685,9 @@
+@@ -521,7 +685,9 @@ static int wcd939x_codec_hphl_dac_event(struct snd_soc_dapm_widget *w,
  	case SND_SOC_DAPM_POST_PMU:
  		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_L,
  					      WCD939X_RDAC_HD2_CTL_L_HD2_RES_DIV_CTL_L, 0x1d);
@@ -236,7 +233,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  			snd_soc_component_write_field(component,
  						      WCD939X_DIGITAL_CDC_COMP_CTL_0,
  						      WCD939X_CDC_COMP_CTL_0_HPHL_COMP_EN,
-@@ -546,6 +712,8 @@
+@@ -546,6 +712,8 @@ static int wcd939x_codec_hphl_dac_event(struct snd_soc_dapm_widget *w,
  		}
  		break;
  	case SND_SOC_DAPM_POST_PMD:
@@ -245,7 +242,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_L,
  					      WCD939X_RDAC_HD2_CTL_L_HD2_RES_DIV_CTL_L, 1);
  		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
-@@ -568,9 +736,12 @@
+@@ -568,9 +736,12 @@ static int wcd939x_codec_hphr_dac_event(struct snd_soc_dapm_widget *w,
  
  	switch (event) {
  	case SND_SOC_DAPM_PRE_PMU:
@@ -261,7 +258,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  
  		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
  					      WCD939X_CDC_HPH_GAIN_CTL_HPHR_RX_EN, true);
-@@ -578,7 +749,9 @@
+@@ -578,7 +749,9 @@ static int wcd939x_codec_hphr_dac_event(struct snd_soc_dapm_widget *w,
  	case SND_SOC_DAPM_POST_PMU:
  		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_R,
  					      WCD939X_RDAC_HD2_CTL_R_HD2_RES_DIV_CTL_R, 0x1d);
@@ -272,7 +269,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  			snd_soc_component_write_field(component,
  						      WCD939X_DIGITAL_CDC_COMP_CTL_0,
  						      WCD939X_CDC_COMP_CTL_0_HPHR_COMP_EN,
-@@ -602,6 +775,8 @@
+@@ -602,6 +775,8 @@ static int wcd939x_codec_hphr_dac_event(struct snd_soc_dapm_widget *w,
  		}
  		break;
  	case SND_SOC_DAPM_POST_PMD:
@@ -281,7 +278,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_R,
  					      WCD939X_RDAC_HD2_CTL_R_HD2_RES_DIV_CTL_R, 1);
  		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
-@@ -658,11 +833,15 @@
+@@ -658,11 +833,15 @@ static int wcd939x_codec_enable_hphr_pa(struct snd_soc_dapm_widget *w,
  			snd_soc_component_write_field(component, WCD939X_LDOH_MODE,
  						      WCD939X_MODE_LDOH_EN, true);
  
@@ -298,7 +295,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  			snd_soc_component_write_field(component,
  					WCD939X_HPH_REFBUFF_LP_CTL,
  					WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS, true);
-@@ -680,8 +859,10 @@
+@@ -680,8 +859,10 @@ static int wcd939x_codec_enable_hphr_pa(struct snd_soc_dapm_widget *w,
  			usleep_range(2500, 2600); /* 2.5msec delay as per HW requirement */
  
  		set_bit(HPH_PA_DELAY, &wcd939x->status_mask);
@@ -311,7 +308,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  		break;
  	case SND_SOC_DAPM_POST_PMU:
  		/*
-@@ -695,8 +876,9 @@
+@@ -695,8 +876,9 @@ static int wcd939x_codec_enable_hphr_pa(struct snd_soc_dapm_widget *w,
  			else
  				usleep_range(7000, 7100);
  
@@ -323,7 +320,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  				snd_soc_component_write_field(component,
  						WCD939X_HPH_REFBUFF_LP_CTL,
  						WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS,
-@@ -711,10 +893,20 @@
+@@ -711,10 +893,20 @@ static int wcd939x_codec_enable_hphr_pa(struct snd_soc_dapm_widget *w,
  						      WCD939X_RX_SUPPLIES_REGULATOR_MODE,
  						      true);
  
@@ -346,7 +343,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  		/*
  		 * 7ms sleep is required if compander is enabled as per
  		 * HW requirement. If compander is disabled, then
-@@ -752,6 +944,8 @@
+@@ -752,6 +944,8 @@ static int wcd939x_codec_enable_hphr_pa(struct snd_soc_dapm_widget *w,
  					      WCD939X_HPH_HPHR_REF_ENABLE, false);
  		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL1,
  					      WCD939X_PDM_WD_CTL1_PDM_WD_EN, 0);
@@ -355,7 +352,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  
  		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_POST_PA,
  					WCD_CLSH_STATE_HPHR, hph_mode);
-@@ -780,11 +974,16 @@
+@@ -780,11 +974,16 @@ static int wcd939x_codec_enable_hphl_pa(struct snd_soc_dapm_widget *w,
  		if (wcd939x->ldoh)
  			snd_soc_component_write_field(component, WCD939X_LDOH_MODE,
  						      WCD939X_MODE_LDOH_EN, true);
@@ -373,7 +370,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  			snd_soc_component_write_field(component,
  						WCD939X_HPH_REFBUFF_LP_CTL,
  						WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS,
-@@ -803,8 +1002,10 @@
+@@ -803,8 +1002,10 @@ static int wcd939x_codec_enable_hphl_pa(struct snd_soc_dapm_widget *w,
  			usleep_range(2500, 2600); /* 2.5msec delay as per HW requirement */
  
  		set_bit(HPH_PA_DELAY, &wcd939x->status_mask);
@@ -386,7 +383,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  		break;
  	case SND_SOC_DAPM_POST_PMU:
  		/*
-@@ -817,8 +1018,9 @@
+@@ -817,8 +1018,9 @@ static int wcd939x_codec_enable_hphl_pa(struct snd_soc_dapm_widget *w,
  				usleep_range(20000, 20100);
  			else
  				usleep_range(7000, 7100);
@@ -398,7 +395,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  				snd_soc_component_write_field(component,
  						WCD939X_HPH_REFBUFF_LP_CTL,
  						WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS,
-@@ -832,10 +1034,20 @@
+@@ -832,10 +1034,20 @@ static int wcd939x_codec_enable_hphl_pa(struct snd_soc_dapm_widget *w,
  			snd_soc_component_write_field(component, WCD939X_ANA_RX_SUPPLIES,
  						      WCD939X_RX_SUPPLIES_REGULATOR_MODE,
  						      true);
@@ -421,7 +418,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  		/*
  		 * 7ms sleep is required if compander is enabled as per
  		 * HW requirement. If compander is disabled, then
-@@ -871,6 +1083,8 @@
+@@ -871,6 +1083,8 @@ static int wcd939x_codec_enable_hphl_pa(struct snd_soc_dapm_widget *w,
  					      WCD939X_HPH_HPHL_REF_ENABLE, false);
  		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL0,
  					      WCD939X_PDM_WD_CTL0_PDM_WD_EN, 0);
@@ -430,7 +427,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_POST_PA,
  					WCD_CLSH_STATE_HPHL, hph_mode);
  		if (wcd939x->ldoh)
-@@ -1549,6 +1763,13 @@
+@@ -1549,6 +1763,13 @@ static int wcd939x_set_compander(struct snd_kcontrol *kcontrol,
  	else
  		wcd939x->comp1_enable = value;
  
@@ -444,7 +441,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  	if (value)
  		wcd939x_connect_port(wcd, portidx, mc->reg, true);
  	else
-@@ -1557,6 +1778,31 @@
+@@ -1557,6 +1778,31 @@ static int wcd939x_set_compander(struct snd_kcontrol *kcontrol,
  	return 1;
  }
  
@@ -476,7 +473,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  static int wcd939x_ldoh_get(struct snd_kcontrol *kcontrol,
  			    struct snd_ctl_elem_value *ucontrol)
  {
-@@ -1795,7 +2041,17 @@
+@@ -1795,7 +2041,17 @@ static int wcd939x_get_swr_port(struct snd_kcontrol *kcontrol,
  	struct snd_soc_component *comp = snd_kcontrol_chip(kcontrol);
  	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(comp);
  	struct wcd939x_sdw_priv *wcd = wcd939x->sdw_priv[mixer->shift];
@@ -495,7 +492,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  
  	ucontrol->value.integer.value[0] = wcd->port_enable[portidx] ? 1 : 0;
  
-@@ -1822,11 +2078,21 @@
+@@ -1822,11 +2078,21 @@ static int wcd939x_set_swr_port(struct snd_kcontrol *kcontrol,
  	struct snd_soc_component *comp = snd_kcontrol_chip(kcontrol);
  	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(comp);
  	struct wcd939x_sdw_priv *wcd = wcd939x->sdw_priv[mixer->shift];
@@ -519,7 +516,7 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  
  	return 1;
  }
-@@ -2533,6 +2799,9 @@
+@@ -2533,6 +2799,9 @@ static void wcd939x_mbhc_deinit(struct snd_soc_component *component)
  
  static const struct snd_kcontrol_new wcd939x_snd_controls[] = {
  	/* RX Path */
@@ -529,3 +526,6 @@ Also set AUTO_DISABLE_DSD in E_CFG0 (stock runs 0x07).
  	SOC_SINGLE_EXT("HPHL_COMP Switch", WCD939X_COMP_L, 0, 1, 0,
  		       wcd939x_get_compander, wcd939x_set_compander),
  	SOC_SINGLE_EXT("HPHR_COMP Switch", WCD939X_COMP_R, 1, 1, 0,
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0074-soundwire-qcom-PCM-data-port-format-enable.patch
+++ b/patch/kernel/archive/sm8750-7.1/0074-soundwire-qcom-PCM-data-port-format-enable.patch
@@ -1,0 +1,81 @@
+From: KONKR Pocket FIT Elite port
+Subject: [PATCH] soundwire: qcom: PCM data port format enable
+
+Data ports carrying PCM samples (e.g. the WCD939x HIFI_PCM headphone
+port) need the controller's per-port PCM format enable
+(SWRM_DOUT_DP_PCM_PORT_CTRL(n) = 0x1054 + 0x100*n, value 0x3) while
+enabled, in addition to the transport parameters; PDM ports don't care,
+which is why mainline never missed it. Vendor reference:
+swr-mstr-ctrl.c swrm_pcm_port_config().
+
+Take the set of PCM ports from an optional qcom,pcm-ports-mask DT
+property, overridable via the pcm_ports_mask module parameter for
+kernels whose DTB predates the property. Set-only: port_enable also
+fires for the inactive bank's disable during bank switches and clearing
+there would strip the format mid-stream.
+---
+--- a/drivers/soundwire/qcom.c	2026-05-23 13:09:44.000000000 +0200
++++ b/drivers/soundwire/qcom.c	2026-06-11 21:30:18.469610305 +0200
+@@ -111,6 +111,7 @@
+ #define SWRM_DPn_PORT_HCTRL_BANK(offset,  n, m)	(offset + 0x100 * (n - 1) + 0x40 * m)
+ #define SWRM_DPn_BLOCK_CTRL3_BANK(offset, n, m)	(offset + 0x100 * (n - 1) + 0x40 * m)
+ #define SWRM_DPn_SAMPLECTRL2_BANK(offset, n, m)	(offset + 0x100 * (n - 1) + 0x40 * m)
++#define SWRM_DOUT_DP_PCM_PORT_CTRL(n)		(0x1054 + 0x100 * n)
+ 
+ #define SWR_V1_3_MSTR_MAX_REG_ADDR				0x1740
+ #define SWR_V2_0_MSTR_MAX_REG_ADDR				0x50ac
+@@ -209,6 +210,7 @@
+ 	int nports;
+ 	int cols_index;
+ 	int rows_index;
++	u32 pcm_ports_mask;
+ 	unsigned long port_mask;
+ 	u32 intr_mask;
+ 	u8 rcmd_id;
+@@ -1026,6 +1028,18 @@
+ 				p_params->bps - 1);
+ }
+ 
++/*
++ * Ports carrying PCM samples (e.g. the WCD939x HIFI_PCM headphone port)
++ * additionally need the controller's per-port PCM format enable
++ * (SWRM_DOUT_DP_PCM_PORT_CTRL) set; PDM ports don't care. Mainline has no
++ * binding for per-port stream type yet, so take the port set from an
++ * optional DT mask, overridable via module parameter for kernels whose DTB
++ * predates the property.
++ */
++static uint pcm_ports_mask;
++module_param(pcm_ports_mask, uint, 0644);
++MODULE_PARM_DESC(pcm_ports_mask, "Bitmask of data ports carrying PCM (overrides qcom,pcm-ports-mask)");
++
+ static int qcom_swrm_transport_params(struct sdw_bus *bus,
+ 				      struct sdw_transport_params *params,
+ 				      enum sdw_reg_bank bank)
+@@ -1121,6 +1135,18 @@
+ 	else
+ 		val &= ~(0xff << SWRM_DP_PORT_CTRL_EN_CHAN_SHFT);
+ 
++	/*
++	 * Only set, never clear: port_enable also fires for the inactive
++	 * bank's disable during bank switches and would strip the PCM format
++	 * mid-stream. The register only affects PCM-mode ports, so a sticky
++	 * 0x3 is harmless.
++	 */
++	if (((ctrl->pcm_ports_mask | pcm_ports_mask) & BIT(enable_ch->port_num)) &&
++	    enable_ch->enable)
++		ctrl->reg_write(ctrl,
++				SWRM_DOUT_DP_PCM_PORT_CTRL(enable_ch->port_num),
++				0x3);
++
+ 	return ctrl->reg_write(ctrl, reg, val);
+ }
+ 
+@@ -1434,6 +1460,8 @@
+ 		ctrl->num_din_ports = val;
+ 	}
+ 
++	of_property_read_u32(np, "qcom,pcm-ports-mask", &ctrl->pcm_ports_mask);
++
+ 	ret = of_property_read_u32(np, "qcom,dout-ports", &val);
+ 	if (!ret) { /* only if present */
+ 		if (val != ctrl->num_dout_ports) {

--- a/patch/kernel/archive/sm8750-7.1/0074-soundwire-qcom-PCM-data-port-format-enable.patch
+++ b/patch/kernel/archive/sm8750-7.1/0074-soundwire-qcom-PCM-data-port-format-enable.patch
@@ -1,21 +1,29 @@
-From: KONKR Pocket FIT Elite port
-Subject: [PATCH] soundwire: qcom: PCM data port format enable
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: KONKR Pocket FIT Elite port <unknown-email@domain.tld>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: soundwire: qcom: PCM data port format enable
 
-Data ports carrying PCM samples (e.g. the WCD939x HIFI_PCM headphone
-port) need the controller's per-port PCM format enable
-(SWRM_DOUT_DP_PCM_PORT_CTRL(n) = 0x1054 + 0x100*n, value 0x3) while
-enabled, in addition to the transport parameters; PDM ports don't care,
-which is why mainline never missed it. Vendor reference:
-swr-mstr-ctrl.c swrm_pcm_port_config().
-
-Take the set of PCM ports from an optional qcom,pcm-ports-mask DT
-property, overridable via the pcm_ports_mask module parameter for
-kernels whose DTB predates the property. Set-only: port_enable also
-fires for the inactive bank's disable during bank switches and clearing
-there would strip the format mid-stream.
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
---- a/drivers/soundwire/qcom.c	2026-05-23 13:09:44.000000000 +0200
-+++ b/drivers/soundwire/qcom.c	2026-06-11 21:30:18.469610305 +0200
+ drivers/soundwire/qcom.c | 28 ++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/drivers/soundwire/qcom.c b/drivers/soundwire/qcom.c
+index 111111111111..222222222222 100644
+--- a/drivers/soundwire/qcom.c
++++ b/drivers/soundwire/qcom.c
 @@ -111,6 +111,7 @@
  #define SWRM_DPn_PORT_HCTRL_BANK(offset,  n, m)	(offset + 0x100 * (n - 1) + 0x40 * m)
  #define SWRM_DPn_BLOCK_CTRL3_BANK(offset, n, m)	(offset + 0x100 * (n - 1) + 0x40 * m)
@@ -24,7 +32,7 @@ there would strip the format mid-stream.
  
  #define SWR_V1_3_MSTR_MAX_REG_ADDR				0x1740
  #define SWR_V2_0_MSTR_MAX_REG_ADDR				0x50ac
-@@ -209,6 +210,7 @@
+@@ -209,6 +210,7 @@ struct qcom_swrm_ctrl {
  	int nports;
  	int cols_index;
  	int rows_index;
@@ -32,7 +40,7 @@ there would strip the format mid-stream.
  	unsigned long port_mask;
  	u32 intr_mask;
  	u8 rcmd_id;
-@@ -1026,6 +1028,18 @@
+@@ -1026,6 +1028,18 @@ static int qcom_swrm_port_params(struct sdw_bus *bus,
  				p_params->bps - 1);
  }
  
@@ -51,7 +59,7 @@ there would strip the format mid-stream.
  static int qcom_swrm_transport_params(struct sdw_bus *bus,
  				      struct sdw_transport_params *params,
  				      enum sdw_reg_bank bank)
-@@ -1121,6 +1135,18 @@
+@@ -1121,6 +1135,18 @@ static int qcom_swrm_port_enable(struct sdw_bus *bus,
  	else
  		val &= ~(0xff << SWRM_DP_PORT_CTRL_EN_CHAN_SHFT);
  
@@ -70,7 +78,7 @@ there would strip the format mid-stream.
  	return ctrl->reg_write(ctrl, reg, val);
  }
  
-@@ -1434,6 +1460,8 @@
+@@ -1434,6 +1460,8 @@ static int qcom_swrm_get_port_config(struct qcom_swrm_ctrl *ctrl)
  		ctrl->num_din_ports = val;
  	}
  
@@ -79,3 +87,6 @@ there would strip the format mid-stream.
  	ret = of_property_read_u32(np, "qcom,dout-ports", &val);
  	if (!ret) { /* only if present */
  		if (val != ctrl->num_dout_ports) {
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0075-arm64-dts-qcom-sm8750-add-CPU-thermal-cooling.patch
+++ b/patch/kernel/archive/sm8750-7.1/0075-arm64-dts-qcom-sm8750-add-CPU-thermal-cooling.patch
@@ -1,20 +1,30 @@
-From: KONKR Pocket FIT Elite port
-Subject: [PATCH] arm64: dts: qcom: sm8750: add CPU thermal cooling
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: KONKR Pocket FIT Elite port <unknown-email@domain.tld>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: arm64: dts: qcom: sm8750: add CPU thermal cooling
 
-The per-core thermal zones only had a 120C hot and 125C critical trip,
-so nothing ever throttled the CPU: the SoC runs at the top OPP until it
-hits the critical shutdown temperature. Add the standard cpufreq
-cooling wiring, mirroring sm8250: two passive trips (90C/95C) on each
-of the 16 per-core zones with cooling maps over the cluster's cores,
-polling-delay-passive of 250ms, and #cooling-cells on the CPU nodes.
-scmi-cpufreq carries CPUFREQ_IS_COOLING_DEV, so the cooling devices
-register automatically once the CPU nodes advertise #cooling-cells.
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ arch/arm64/boot/dts/qcom/sm8750.dtsi | 576 +++++++++-
+ 1 file changed, 560 insertions(+), 16 deletions(-)
+
 diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-index 4e16c765c..220e9b1de 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-@@ -6320,10 +6320,46 @@ aoss0-critical {
+@@ -6246,10 +6246,46 @@ aoss0-critical {
  		};
  
  		cpu-0-0-0-thermal {
@@ -62,7 +72,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6338,10 +6374,46 @@ cpu-0-0-0-critical {
+@@ -6264,10 +6300,46 @@ cpu-0-0-0-critical {
  		};
  
  		cpu-0-0-1-thermal {
@@ -110,7 +120,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6356,10 +6428,46 @@ cpu-0-0-1-critical {
+@@ -6282,10 +6354,46 @@ cpu-0-0-1-critical {
  		};
  
  		cpu-0-1-0-thermal {
@@ -158,7 +168,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6374,10 +6482,46 @@ cpu-0-1-0-critical {
+@@ -6300,10 +6408,46 @@ cpu-0-1-0-critical {
  		};
  
  		cpu-0-1-1-thermal {
@@ -206,7 +216,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6392,10 +6536,46 @@ cpu-0-1-1-critical {
+@@ -6318,10 +6462,46 @@ cpu-0-1-1-critical {
  		};
  
  		cpu-0-2-0-thermal {
@@ -254,7 +264,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6410,10 +6590,46 @@ cpu-0-2-0-critical {
+@@ -6336,10 +6516,46 @@ cpu-0-2-0-critical {
  		};
  
  		cpu-0-2-1-thermal {
@@ -302,7 +312,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6428,10 +6644,46 @@ cpu-0-2-1-critical {
+@@ -6354,10 +6570,46 @@ cpu-0-2-1-critical {
  		};
  
  		cpu-0-3-0-thermal {
@@ -350,7 +360,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6446,10 +6698,46 @@ cpu-0-3-0-critical {
+@@ -6372,10 +6624,46 @@ cpu-0-3-0-critical {
  		};
  
  		cpu-0-3-1-thermal {
@@ -398,7 +408,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6464,10 +6752,46 @@ cpu-0-3-1-critical {
+@@ -6390,10 +6678,46 @@ cpu-0-3-1-critical {
  		};
  
  		cpu-0-4-0-thermal {
@@ -446,7 +456,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6482,10 +6806,46 @@ cpu-0-4-0-critical {
+@@ -6408,10 +6732,46 @@ cpu-0-4-0-critical {
  		};
  
  		cpu-0-4-1-thermal {
@@ -494,7 +504,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6500,10 +6860,46 @@ cpu-0-4-1-critical {
+@@ -6426,10 +6786,46 @@ cpu-0-4-1-critical {
  		};
  
  		cpu-0-5-0-thermal {
@@ -542,7 +552,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6518,10 +6914,46 @@ cpu-0-5-0-critical {
+@@ -6444,10 +6840,46 @@ cpu-0-5-0-critical {
  		};
  
  		cpu-0-5-1-thermal {
@@ -590,7 +600,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6590,10 +7022,38 @@ aoss1-critical {
+@@ -6516,10 +6948,38 @@ aoss1-critical {
  		};
  
  		cpu-1-0-0-thermal {
@@ -630,7 +640,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6608,10 +7068,38 @@ cpu-1-0-0-critical {
+@@ -6534,10 +6994,38 @@ cpu-1-0-0-critical {
  		};
  
  		cpu-1-0-1-thermal {
@@ -670,7 +680,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6626,10 +7114,38 @@ cpu-1-0-1-critical {
+@@ -6552,10 +7040,38 @@ cpu-1-0-1-critical {
  		};
  
  		cpu-1-1-0-thermal {
@@ -710,7 +720,7 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
-@@ -6644,10 +7160,38 @@ cpu-1-1-0-critical {
+@@ -6570,10 +7086,38 @@ cpu-1-1-0-critical {
  		};
  
  		cpu-1-1-1-thermal {
@@ -750,3 +760,6 @@ index 4e16c765c..220e9b1de 100644
  					temperature = <120000>;
  					hysteresis = <5000>;
  					type = "hot";
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0075-arm64-dts-qcom-sm8750-add-CPU-thermal-cooling.patch
+++ b/patch/kernel/archive/sm8750-7.1/0075-arm64-dts-qcom-sm8750-add-CPU-thermal-cooling.patch
@@ -1,0 +1,752 @@
+From: KONKR Pocket FIT Elite port
+Subject: [PATCH] arm64: dts: qcom: sm8750: add CPU thermal cooling
+
+The per-core thermal zones only had a 120C hot and 125C critical trip,
+so nothing ever throttled the CPU: the SoC runs at the top OPP until it
+hits the critical shutdown temperature. Add the standard cpufreq
+cooling wiring, mirroring sm8250: two passive trips (90C/95C) on each
+of the 16 per-core zones with cooling maps over the cluster's cores,
+polling-delay-passive of 250ms, and #cooling-cells on the CPU nodes.
+scmi-cpufreq carries CPUFREQ_IS_COOLING_DEV, so the cooling devices
+register automatically once the CPU nodes advertise #cooling-cells.
+---
+diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
+index 4e16c765c..220e9b1de 100644
+--- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
+@@ -6320,10 +6320,46 @@ aoss0-critical {
+ 		};
+ 
+ 		cpu-0-0-0-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 1>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_0_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_0_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_0_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_0_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6338,10 +6374,46 @@ cpu-0-0-0-critical {
+ 		};
+ 
+ 		cpu-0-0-1-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 2>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_0_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_0_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_0_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_0_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6356,10 +6428,46 @@ cpu-0-0-1-critical {
+ 		};
+ 
+ 		cpu-0-1-0-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 3>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_1_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_1_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_1_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_1_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6374,10 +6482,46 @@ cpu-0-1-0-critical {
+ 		};
+ 
+ 		cpu-0-1-1-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 4>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_1_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_1_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_1_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_1_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6392,10 +6536,46 @@ cpu-0-1-1-critical {
+ 		};
+ 
+ 		cpu-0-2-0-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 5>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_2_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_2_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_2_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_2_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6410,10 +6590,46 @@ cpu-0-2-0-critical {
+ 		};
+ 
+ 		cpu-0-2-1-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 6>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_2_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_2_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_2_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_2_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6428,10 +6644,46 @@ cpu-0-2-1-critical {
+ 		};
+ 
+ 		cpu-0-3-0-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 7>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_3_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_3_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_3_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_3_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6446,10 +6698,46 @@ cpu-0-3-0-critical {
+ 		};
+ 
+ 		cpu-0-3-1-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 8>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_3_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_3_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_3_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_3_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6464,10 +6752,46 @@ cpu-0-3-1-critical {
+ 		};
+ 
+ 		cpu-0-4-0-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 9>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_4_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_4_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_4_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_4_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6482,10 +6806,46 @@ cpu-0-4-0-critical {
+ 		};
+ 
+ 		cpu-0-4-1-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 10>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_4_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_4_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_4_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_4_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6500,10 +6860,46 @@ cpu-0-4-1-critical {
+ 		};
+ 
+ 		cpu-0-5-0-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 11>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_5_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_5_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_5_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_5_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6518,10 +6914,46 @@ cpu-0-5-0-critical {
+ 		};
+ 
+ 		cpu-0-5-1-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens0 12>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_5_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_5_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_0_5_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_5_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6590,10 +7022,38 @@ aoss1-critical {
+ 		};
+ 
+ 		cpu-1-0-0-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens1 1>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_1_0_0_alert0>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_1_0_0_alert1>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_1_0_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_1_0_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6608,10 +7068,38 @@ cpu-1-0-0-critical {
+ 		};
+ 
+ 		cpu-1-0-1-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens1 2>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_1_0_1_alert0>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_1_0_1_alert1>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_1_0_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_1_0_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6626,10 +7114,38 @@ cpu-1-0-1-critical {
+ 		};
+ 
+ 		cpu-1-1-0-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens1 3>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_1_1_0_alert0>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_1_1_0_alert1>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_1_1_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_1_1_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";
+@@ -6644,10 +7160,38 @@ cpu-1-1-0-critical {
+ 		};
+ 
+ 		cpu-1-1-1-thermal {
++			polling-delay-passive = <250>;
++
+ 			thermal-sensors = <&tsens1 4>;
+ 
++			cooling-maps {
++				map0 {
++					trip = <&cpu_1_1_1_alert0>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_1_1_1_alert1>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
+ 			trips {
+-				trip-point0 {
++				cpu_1_1_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_1_1_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
+ 					temperature = <120000>;
+ 					hysteresis = <5000>;
+ 					type = "hot";

--- a/patch/kernel/archive/sm8750-7.1/0076-arm64-dts-qcom-sm8750-set-CPU-capacity-dmips-mhz.patch
+++ b/patch/kernel/archive/sm8750-7.1/0076-arm64-dts-qcom-sm8750-set-CPU-capacity-dmips-mhz.patch
@@ -1,20 +1,30 @@
-From: KONKR Pocket FIT Elite port
-Subject: [PATCH] arm64: dts: qcom: sm8750: set CPU capacity-dmips-mhz
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: KONKR Pocket FIT Elite port <unknown-email@domain.tld>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: arm64: dts: qcom: sm8750: set CPU capacity-dmips-mhz
 
-Without capacity-dmips-mhz all eight cores report capacity 1024 and the
-scheduler cannot tell the clusters apart, even though the prime cluster
-clocks 16% higher (4.09 vs 3.53 GHz). Use the values the vendor Android
-DT ships (dumped from a KONKR Pocket FIT Elite; Qualcomm sun baseline):
-1792 on the six-core cluster, 1894 on the prime pair, giving the prime
-cores their ~6% per-MHz edge. arch_topology then scales each core's
-capacity by its cpufreq maximum, which differentiates the clusters and
-enables the asymmetric-capacity scheduler paths.
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ arch/arm64/boot/dts/qcom/sm8750.dtsi | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-index 220e9b1de..04be5c816 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
-@@ -43,6 +43,7 @@ cpu0: cpu@0 {
+@@ -41,6 +41,7 @@ cpu0: cpu@0 {
  			compatible = "qcom,oryon";
  			reg = <0x0 0x0>;
  			enable-method = "psci";
@@ -22,7 +32,7 @@ index 220e9b1de..04be5c816 100644
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd0>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
-@@ -60,6 +61,7 @@ cpu1: cpu@100 {
+@@ -57,6 +58,7 @@ cpu1: cpu@100 {
  			compatible = "qcom,oryon";
  			reg = <0x0 0x100>;
  			enable-method = "psci";
@@ -30,7 +40,7 @@ index 220e9b1de..04be5c816 100644
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd1>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
-@@ -71,6 +73,7 @@ cpu2: cpu@200 {
+@@ -67,6 +69,7 @@ cpu2: cpu@200 {
  			compatible = "qcom,oryon";
  			reg = <0x0 0x200>;
  			enable-method = "psci";
@@ -38,7 +48,7 @@ index 220e9b1de..04be5c816 100644
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd2>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
-@@ -82,6 +85,7 @@ cpu3: cpu@300 {
+@@ -77,6 +80,7 @@ cpu3: cpu@300 {
  			compatible = "qcom,oryon";
  			reg = <0x0 0x300>;
  			enable-method = "psci";
@@ -46,7 +56,7 @@ index 220e9b1de..04be5c816 100644
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd3>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
-@@ -93,6 +97,7 @@ cpu4: cpu@400 {
+@@ -87,6 +91,7 @@ cpu4: cpu@400 {
  			compatible = "qcom,oryon";
  			reg = <0x0 0x400>;
  			enable-method = "psci";
@@ -54,7 +64,7 @@ index 220e9b1de..04be5c816 100644
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd4>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
-@@ -104,6 +109,7 @@ cpu5: cpu@500 {
+@@ -97,6 +102,7 @@ cpu5: cpu@500 {
  			compatible = "qcom,oryon";
  			reg = <0x0 0x500>;
  			enable-method = "psci";
@@ -62,7 +72,7 @@ index 220e9b1de..04be5c816 100644
  			next-level-cache = <&l2_0>;
  			power-domains = <&cpu_pd5>, <&scmi_dvfs 0>;
  			power-domain-names = "psci", "perf";
-@@ -115,6 +121,7 @@ cpu6: cpu@10000 {
+@@ -107,6 +113,7 @@ cpu6: cpu@10000 {
  			compatible = "qcom,oryon";
  			reg = <0x0 0x10000>;
  			enable-method = "psci";
@@ -70,7 +80,7 @@ index 220e9b1de..04be5c816 100644
  			next-level-cache = <&l2_1>;
  			power-domains = <&cpu_pd6>, <&scmi_dvfs 1>;
  			power-domain-names = "psci", "perf";
-@@ -132,6 +139,7 @@ cpu7: cpu@10100 {
+@@ -123,6 +130,7 @@ cpu7: cpu@10100 {
  			compatible = "qcom,oryon";
  			reg = <0x0 0x10100>;
  			enable-method = "psci";
@@ -78,3 +88,6 @@ index 220e9b1de..04be5c816 100644
  			next-level-cache = <&l2_1>;
  			power-domains = <&cpu_pd7>, <&scmi_dvfs 1>;
  			power-domain-names = "psci", "perf";
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0076-arm64-dts-qcom-sm8750-set-CPU-capacity-dmips-mhz.patch
+++ b/patch/kernel/archive/sm8750-7.1/0076-arm64-dts-qcom-sm8750-set-CPU-capacity-dmips-mhz.patch
@@ -1,0 +1,80 @@
+From: KONKR Pocket FIT Elite port
+Subject: [PATCH] arm64: dts: qcom: sm8750: set CPU capacity-dmips-mhz
+
+Without capacity-dmips-mhz all eight cores report capacity 1024 and the
+scheduler cannot tell the clusters apart, even though the prime cluster
+clocks 16% higher (4.09 vs 3.53 GHz). Use the values the vendor Android
+DT ships (dumped from a KONKR Pocket FIT Elite; Qualcomm sun baseline):
+1792 on the six-core cluster, 1894 on the prime pair, giving the prime
+cores their ~6% per-MHz edge. arch_topology then scales each core's
+capacity by its cpufreq maximum, which differentiates the clusters and
+enables the asymmetric-capacity scheduler paths.
+---
+diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi b/arch/arm64/boot/dts/qcom/sm8750.dtsi
+index 220e9b1de..04be5c816 100644
+--- a/arch/arm64/boot/dts/qcom/sm8750.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi
+@@ -43,6 +43,7 @@ cpu0: cpu@0 {
+ 			compatible = "qcom,oryon";
+ 			reg = <0x0 0x0>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1792>;
+ 			next-level-cache = <&l2_0>;
+ 			power-domains = <&cpu_pd0>, <&scmi_dvfs 0>;
+ 			power-domain-names = "psci", "perf";
+@@ -60,6 +61,7 @@ cpu1: cpu@100 {
+ 			compatible = "qcom,oryon";
+ 			reg = <0x0 0x100>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1792>;
+ 			next-level-cache = <&l2_0>;
+ 			power-domains = <&cpu_pd1>, <&scmi_dvfs 0>;
+ 			power-domain-names = "psci", "perf";
+@@ -71,6 +73,7 @@ cpu2: cpu@200 {
+ 			compatible = "qcom,oryon";
+ 			reg = <0x0 0x200>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1792>;
+ 			next-level-cache = <&l2_0>;
+ 			power-domains = <&cpu_pd2>, <&scmi_dvfs 0>;
+ 			power-domain-names = "psci", "perf";
+@@ -82,6 +85,7 @@ cpu3: cpu@300 {
+ 			compatible = "qcom,oryon";
+ 			reg = <0x0 0x300>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1792>;
+ 			next-level-cache = <&l2_0>;
+ 			power-domains = <&cpu_pd3>, <&scmi_dvfs 0>;
+ 			power-domain-names = "psci", "perf";
+@@ -93,6 +97,7 @@ cpu4: cpu@400 {
+ 			compatible = "qcom,oryon";
+ 			reg = <0x0 0x400>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1792>;
+ 			next-level-cache = <&l2_0>;
+ 			power-domains = <&cpu_pd4>, <&scmi_dvfs 0>;
+ 			power-domain-names = "psci", "perf";
+@@ -104,6 +109,7 @@ cpu5: cpu@500 {
+ 			compatible = "qcom,oryon";
+ 			reg = <0x0 0x500>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1792>;
+ 			next-level-cache = <&l2_0>;
+ 			power-domains = <&cpu_pd5>, <&scmi_dvfs 0>;
+ 			power-domain-names = "psci", "perf";
+@@ -115,6 +121,7 @@ cpu6: cpu@10000 {
+ 			compatible = "qcom,oryon";
+ 			reg = <0x0 0x10000>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1894>;
+ 			next-level-cache = <&l2_1>;
+ 			power-domains = <&cpu_pd6>, <&scmi_dvfs 1>;
+ 			power-domain-names = "psci", "perf";
+@@ -132,6 +139,7 @@ cpu7: cpu@10100 {
+ 			compatible = "qcom,oryon";
+ 			reg = <0x0 0x10100>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1894>;
+ 			next-level-cache = <&l2_1>;
+ 			power-domains = <&cpu_pd7>, <&scmi_dvfs 1>;
+ 			power-domain-names = "psci", "perf";

--- a/patch/kernel/archive/sm8750-7.1/0500-ROCKNIX-set-boot-fanspeed.patch
+++ b/patch/kernel/archive/sm8750-7.1/0500-ROCKNIX-set-boot-fanspeed.patch
@@ -1,7 +1,12663 @@
-diff -rupbN linux.orig/drivers/hwmon/pwm-fan.c linux/drivers/hwmon/pwm-fan.c
---- linux.orig/drivers/hwmon/pwm-fan.c	2024-10-19 13:35:29.516991617 +0000
-+++ linux/drivers/hwmon/pwm-fan.c	2024-11-18 15:41:47.343729846 +0000
-@@ -530,7 +530,7 @@ static int pwm_fan_probe(struct platform
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: FantasyGmm <16450052+FantasyGmm@users.noreply.github.com>
+Date: Sat, 15 Mar 2025 10:29:56 +0100
+Subject: ROCKNIX set boot fanspeed
+
+> X-Git-Archeology: - Revision 0ccbe8bcc70daf3629425ce0e99fb3e8c62d1554: https://github.com/armbian/build/commit/0ccbe8bcc70daf3629425ce0e99fb3e8c62d1554
+> X-Git-Archeology:   Date: Sat, 15 Mar 2025 10:29:56 +0100
+> X-Git-Archeology:   From: FantasyGmm <16450052+FantasyGmm@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Update Odin2 Config
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f785a6d9fdd2f6751f739d6863e1beec6d98484b: https://github.com/armbian/build/commit/f785a6d9fdd2f6751f739d6863e1beec6d98484b
+> X-Git-Archeology:   Date: Wed, 04 Mar 2026 19:57:23 +0100
+> X-Git-Archeology:   From: Christian Wang <christian.gnaw@gmail.com>
+> X-Git-Archeology:   Subject: Added SM8550 Patches from ROCKNIX and also kernel config from ROCKNIX
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 9298ab108afe52e7eea761a4885dc69512eb3216: https://github.com/armbian/build/commit/9298ab108afe52e7eea761a4885dc69512eb3216
+> X-Git-Archeology:   Date: Wed, 04 Mar 2026 19:57:23 +0100
+> X-Git-Archeology:   From: Christian Wang <christian.gnaw@gmail.com>
+> X-Git-Archeology:   Subject: Added sm8550-6.13 patches and changed sm8550 config to support 6.13 as current and 6.12 as old
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/qcom/sm8750.dtsi.orig       | 7668 ++++++++++
+ drivers/bluetooth/hci_qca.c.orig                | 2846 ++++
+ drivers/gpu/drm/msm/adreno/adreno_gpu.h.orig    |  764 +
+ drivers/gpu/drm/panel/Kconfig.orig              | 1310 ++
+ drivers/hwmon/pwm-fan.c                         |    2 +-
+ drivers/hwmon/pwm-fan.c.orig                    |  747 +
+ drivers/input/touchscreen/edt-ft5x06.c.orig     | 1534 ++
+ drivers/net/wireless/ath/ath12k/core.h.orig     | 1438 ++
+ drivers/net/wireless/ath/ath12k/hw.h.orig       |  308 +
+ drivers/net/wireless/ath/ath12k/wifi7/hw.c.orig | 1231 ++
+ drivers/pmdomain/qcom/rpmhpd.c.orig             | 1205 ++
+ drivers/ufs/host/ufs-qcom.c.orig                | 3037 ++++
+ drivers/usb/typec/mux/wcd939x-usbss.c.orig      |  779 +
+ sound/soc/codecs/aw88166.c.orig                 | 1819 +++
+ sound/soc/codecs/wcd939x.c.orig                 | 3622 +++++
+ 15 files changed, 28309 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/sm8750.dtsi.orig b/arch/arm64/boot/dts/qcom/sm8750.dtsi.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/sm8750.dtsi.orig
+@@ -0,0 +1,7668 @@
++// SPDX-License-Identifier: BSD-3-Clause
++/*
++ * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
++ */
++
++#include <dt-bindings/clock/qcom,dsi-phy-28nm.h>
++#include <dt-bindings/clock/qcom,rpmh.h>
++#include <dt-bindings/clock/qcom,sm8750-dispcc.h>
++#include <dt-bindings/clock/qcom,kaanapali-gxclkctl.h>
++#include <dt-bindings/clock/qcom,sm8750-gcc.h>
++#include <dt-bindings/clock/qcom,sm8750-gpucc.h>
++#include <dt-bindings/clock/qcom,sm8750-tcsr.h>
++#include <dt-bindings/clock/qcom,sm8750-videocc.h>
++#include <dt-bindings/dma/qcom-gpi.h>
++#include <dt-bindings/firmware/qcom,scm.h>
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/interconnect/qcom,icc.h>
++#include <dt-bindings/interconnect/qcom,sm8750-rpmh.h>
++#include <dt-bindings/interrupt-controller/arm-gic.h>
++#include <dt-bindings/mailbox/qcom-ipcc.h>
++#include <dt-bindings/phy/phy-qcom-qmp.h>
++#include <dt-bindings/power/qcom,rpmhpd.h>
++#include <dt-bindings/power/qcom-rpmpd.h>
++#include <dt-bindings/soc/qcom,gpr.h>
++#include <dt-bindings/soc/qcom,rpmh-rsc.h>
++#include <dt-bindings/sound/qcom,q6dsp-lpass-ports.h>
++#include <dt-bindings/thermal/thermal.h>
++
++/ {
++	interrupt-parent = <&intc>;
++
++	#address-cells = <2>;
++	#size-cells = <2>;
++
++	cpus {
++		#address-cells = <2>;
++		#size-cells = <0>;
++
++		cpu0: cpu@0 {
++			device_type = "cpu";
++			compatible = "qcom,oryon";
++			reg = <0x0 0x0>;
++			enable-method = "psci";
++			next-level-cache = <&l2_0>;
++			power-domains = <&cpu_pd0>, <&scmi_dvfs 0>;
++			power-domain-names = "psci", "perf";
++
++			l2_0: l2-cache {
++				compatible = "cache";
++				cache-level = <2>;
++				cache-unified;
++			};
++		};
++
++		cpu1: cpu@100 {
++			device_type = "cpu";
++			compatible = "qcom,oryon";
++			reg = <0x0 0x100>;
++			enable-method = "psci";
++			next-level-cache = <&l2_0>;
++			power-domains = <&cpu_pd1>, <&scmi_dvfs 0>;
++			power-domain-names = "psci", "perf";
++		};
++
++		cpu2: cpu@200 {
++			device_type = "cpu";
++			compatible = "qcom,oryon";
++			reg = <0x0 0x200>;
++			enable-method = "psci";
++			next-level-cache = <&l2_0>;
++			power-domains = <&cpu_pd2>, <&scmi_dvfs 0>;
++			power-domain-names = "psci", "perf";
++		};
++
++		cpu3: cpu@300 {
++			device_type = "cpu";
++			compatible = "qcom,oryon";
++			reg = <0x0 0x300>;
++			enable-method = "psci";
++			next-level-cache = <&l2_0>;
++			power-domains = <&cpu_pd3>, <&scmi_dvfs 0>;
++			power-domain-names = "psci", "perf";
++		};
++
++		cpu4: cpu@400 {
++			device_type = "cpu";
++			compatible = "qcom,oryon";
++			reg = <0x0 0x400>;
++			enable-method = "psci";
++			next-level-cache = <&l2_0>;
++			power-domains = <&cpu_pd4>, <&scmi_dvfs 0>;
++			power-domain-names = "psci", "perf";
++		};
++
++		cpu5: cpu@500 {
++			device_type = "cpu";
++			compatible = "qcom,oryon";
++			reg = <0x0 0x500>;
++			enable-method = "psci";
++			next-level-cache = <&l2_0>;
++			power-domains = <&cpu_pd5>, <&scmi_dvfs 0>;
++			power-domain-names = "psci", "perf";
++		};
++
++		cpu6: cpu@10000 {
++			device_type = "cpu";
++			compatible = "qcom,oryon";
++			reg = <0x0 0x10000>;
++			enable-method = "psci";
++			next-level-cache = <&l2_1>;
++			power-domains = <&cpu_pd6>, <&scmi_dvfs 1>;
++			power-domain-names = "psci", "perf";
++
++			l2_1: l2-cache {
++				compatible = "cache";
++				cache-level = <2>;
++				cache-unified;
++			};
++		};
++
++		cpu7: cpu@10100 {
++			device_type = "cpu";
++			compatible = "qcom,oryon";
++			reg = <0x0 0x10100>;
++			enable-method = "psci";
++			next-level-cache = <&l2_1>;
++			power-domains = <&cpu_pd7>, <&scmi_dvfs 1>;
++			power-domain-names = "psci", "perf";
++		};
++
++		cpu-map {
++			cluster0 {
++				core0 {
++					cpu = <&cpu0>;
++				};
++
++				core1 {
++					cpu = <&cpu1>;
++				};
++
++				core2 {
++					cpu = <&cpu2>;
++				};
++
++				core3 {
++					cpu = <&cpu3>;
++				};
++
++				core4 {
++					cpu = <&cpu4>;
++				};
++
++				core5 {
++					cpu = <&cpu5>;
++				};
++			};
++
++			cluster1 {
++				core0 {
++					cpu = <&cpu6>;
++				};
++
++				core1 {
++					cpu = <&cpu7>;
++				};
++			};
++		};
++
++		idle-states {
++			entry-method = "psci";
++
++			cluster0_c4: cpu-sleep-0 {
++				compatible = "arm,idle-state";
++				idle-state-name = "ret";
++				arm,psci-suspend-param = <0x00000004>;
++				entry-latency-us = <93>;
++				exit-latency-us = <129>;
++				min-residency-us = <560>;
++			};
++
++			cluster1_c4: cpu-sleep-1 {
++				compatible = "arm,idle-state";
++				idle-state-name = "ret";
++				arm,psci-suspend-param = <0x00000004>;
++				entry-latency-us = <172>;
++				exit-latency-us = <130>;
++				min-residency-us = <686>;
++			};
++		};
++
++		domain-idle-states {
++			cluster_cl5: cluster-sleep-0 {
++				compatible = "domain-idle-state";
++				arm,psci-suspend-param = <0x01000054>;
++				entry-latency-us = <2150>;
++				exit-latency-us = <1983>;
++				min-residency-us = <9144>;
++			};
++
++			domain_ss3: domain-sleep-0 {
++				compatible = "domain-idle-state";
++				arm,psci-suspend-param = <0x0200c354>;
++				entry-latency-us = <2800>;
++				exit-latency-us = <4400>;
++				min-residency-us = <10150>;
++			};
++		};
++	};
++
++	firmware {
++		scm: scm {
++			compatible = "qcom,scm-sm8750", "qcom,scm";
++			interconnects = <&aggre2_noc MASTER_CRYPTO QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++		};
++
++		scmi {
++			compatible = "arm,scmi";
++			mboxes = <&cpucp_mbox 0>, <&cpucp_mbox 2>;
++			mbox-names = "tx", "rx";
++			shmem = <&cpu_scp_lpri0>, <&cpu_scp_lpri1>;
++
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			scmi_dvfs: protocol@13 {
++				reg = <0x13>;
++				#power-domain-cells = <1>;
++			};
++		};
++	};
++
++	clk_virt: interconnect-0 {
++		compatible = "qcom,sm8750-clk-virt";
++		#interconnect-cells = <2>;
++		qcom,bcm-voters = <&apps_bcm_voter>;
++	};
++
++	mc_virt: interconnect-1 {
++		compatible = "qcom,sm8750-mc-virt";
++		#interconnect-cells = <2>;
++		qcom,bcm-voters = <&apps_bcm_voter>;
++	};
++
++	memory@a0000000 {
++		device_type = "memory";
++		/* We expect the bootloader to fill in the size */
++		reg = <0x0 0xa0000000 0x0 0x0>;
++	};
++
++	pmu {
++		compatible = "arm,armv8-pmuv3";
++		interrupts = <GIC_PPI 7 IRQ_TYPE_LEVEL_LOW>;
++	};
++
++	psci {
++		compatible = "arm,psci-1.0";
++		method = "smc";
++
++		cpu_pd0: power-domain-cpu0 {
++			#power-domain-cells = <0>;
++			power-domains = <&cluster0_pd>;
++			domain-idle-states = <&cluster0_c4>;
++		};
++
++		cpu_pd1: power-domain-cpu1 {
++			#power-domain-cells = <0>;
++			power-domains = <&cluster0_pd>;
++			domain-idle-states = <&cluster0_c4>;
++		};
++
++		cpu_pd2: power-domain-cpu2 {
++			#power-domain-cells = <0>;
++			power-domains = <&cluster0_pd>;
++			domain-idle-states = <&cluster0_c4>;
++		};
++
++		cpu_pd3: power-domain-cpu3 {
++			#power-domain-cells = <0>;
++			power-domains = <&cluster0_pd>;
++			domain-idle-states = <&cluster0_c4>;
++		};
++
++		cpu_pd4: power-domain-cpu4 {
++			#power-domain-cells = <0>;
++			power-domains = <&cluster0_pd>;
++			domain-idle-states = <&cluster0_c4>;
++		};
++
++		cpu_pd5: power-domain-cpu5 {
++			#power-domain-cells = <0>;
++			power-domains = <&cluster0_pd>;
++			domain-idle-states = <&cluster0_c4>;
++		};
++
++		cpu_pd6: power-domain-cpu6 {
++			#power-domain-cells = <0>;
++			power-domains = <&cluster1_pd>;
++			domain-idle-states = <&cluster1_c4>;
++		};
++
++		cpu_pd7: power-domain-cpu7 {
++			#power-domain-cells = <0>;
++			power-domains = <&cluster1_pd>;
++			domain-idle-states = <&cluster1_c4>;
++		};
++
++		cluster0_pd: power-domain-cluster0 {
++			#power-domain-cells = <0>;
++			domain-idle-states = <&cluster_cl5>;
++			power-domains = <&system_pd>;
++		};
++
++		cluster1_pd: power-domain-cluster1 {
++			#power-domain-cells = <0>;
++			domain-idle-states = <&cluster_cl5>;
++			power-domains = <&system_pd>;
++		};
++
++		system_pd: power-domain-system {
++			#power-domain-cells = <0>;
++			domain-idle-states = <&domain_ss3>;
++		};
++	};
++
++	reserved-memory {
++		#address-cells = <2>;
++		#size-cells = <2>;
++		ranges;
++
++		gunyah_hyp_mem: gunyah-hyp@80000000 {
++			reg = <0x0 0x80000000 0x0 0xe00000>;
++			no-map;
++		};
++
++		cpusys_vm_mem: cpusys-vm-mem@80e00000 {
++			reg = <0x0 0x80e00000 0x0 0x40000>;
++			no-map;
++		};
++
++		cpucp_mem: cpucp@81200000 {
++			reg = <0x0 0x81200000 0x0 0x200000>;
++			no-map;
++		};
++
++		xbl_dtlog_mem: xbl-dtlog@81a00000 {
++			reg = <0x0 0x81a00000 0x0 0x40000>;
++			no-map;
++		};
++
++		aop_image_mem: aop-image@81c00000 {
++			reg = <0x0 0x81c00000 0x0 0x60000>;
++			no-map;
++		};
++
++		aop_cmd_db_mem: aop-cmd-db@81c60000 {
++			compatible = "qcom,cmd-db";
++			reg = <0x0 0x81c60000 0x0 0x20000>;
++			no-map;
++		};
++
++		/* Merged aop_config, tme_crash_dump, tme_log and uefi_log regions */
++		aop_tme_uefi_merged_mem: aop-tme-uefi-merged@81c80000 {
++			reg = <0x0 0x81c80000 0x0 0x74000>;
++			no-map;
++		};
++
++		/* Secdata region can be reused by apps */
++
++		smem_mem: smem@81d00000 {
++			compatible = "qcom,smem";
++			reg = <0x0 0x81d00000 0x0 0x200000>;
++			hwlocks = <&tcsr_mutex 3>;
++			no-map;
++		};
++
++		pdp_ns_shared_mem: pdp-ns-shared@81f00000 {
++			reg = <0x0 0x81f00000 0x0 0x100000>;
++			no-map;
++		};
++
++		cpucp_scandump_mem: cpucp-scandump@82000000 {
++			reg = <0x0 0x82000000 0x0 0x380000>;
++			no-map;
++		};
++
++		adsp_mhi_mem: adsp-mhi@82380000 {
++			reg = <0x0 0x82380000 0x0 0x20000>;
++			no-map;
++		};
++
++		soccp_sdi_mem: soccp-sdi@823a0000 {
++			reg = <0x0 0x823a0000 0x0 0x40000>;
++			no-map;
++		};
++
++		pmic_minii_dump_mem: pmic-minii-dump@823e0000 {
++			reg = <0x0 0x823e0000 0x0 0x80000>;
++			no-map;
++		};
++
++		pvmfw_mem: pvmfw@824a0000 {
++			reg = <0x0 0x824a0000 0x0 0x100000>;
++			no-map;
++		};
++
++		global_sync_mem: global-sync@82600000 {
++			reg = <0x0 0x82600000 0x0 0x100000>;
++			no-map;
++		};
++
++		tz_stat_mem: tz-stat@82700000 {
++			reg = <0x0 0x82700000 0x0 0x100000>;
++			no-map;
++		};
++
++		qdss_mem: qdss@82800000 {
++			reg = <0x0 0x82800000 0x0 0x2000000>;
++			no-map;
++		};
++
++		dsm_partition_1_mem: dsm-partition-1@84a00000 {
++			reg = <0x0 0x84a00000 0x0 0x4900000>;
++			no-map;
++		};
++
++		dsm_partition_2_mem: dsm-partition-2@89300000 {
++			reg = <0x0 0x89300000 0x0 0xa80000>;
++			no-map;
++		};
++
++		mpss_mem: mpss@8ba00000 {
++			reg = <0x0 0x8ba00000 0x0 0xf600000>;
++			no-map;
++		};
++
++		q6_mpss_dtb_mem: q6-mpss-dtb@9b000000 {
++			reg = <0x0 0x9b000000 0x0 0x80000>;
++			no-map;
++		};
++
++		ipa_fw_mem: ipa-fw@9b080000 {
++			reg = <0x0 0x9b080000 0x0 0x10000>;
++			no-map;
++		};
++
++		ipa_gsi_mem: ipa-gsi@9b090000 {
++			reg = <0x0 0x9b090000 0x0 0xa000>;
++			no-map;
++		};
++
++		gpu_micro_code_mem: gpu-micro-code@9b09a000 {
++			reg = <0x0 0x9b09a000 0x0 0x2000>;
++			no-map;
++		};
++
++		spss_region_mem: spss@9b0a0000  {
++			reg = <0x0 0x9b0a0000 0x0 0x1e0000>;
++			no-map;
++		};
++
++		/* First part of the "SPU secure shared memory" region */
++		spu_tz_shared_mem: spu-tz-shared@9b280000 {
++			reg = <0x0 0x9b280000 0x0 0x40000>;
++			no-map;
++		};
++
++		/* Second part of the "SPU secure shared memory" region */
++		spu_modem_shared_mem: spu-modem-shared@9b2c0000 {
++			reg = <0x0 0x9b2c0000 0x0 0x40000>;
++			no-map;
++		};
++
++		camera_mem: camera@9b300000 {
++			reg = <0x0 0x9b300000 0x0 0x800000>;
++			no-map;
++		};
++
++		camera_2_mem: camera-2@9bb00000 {
++			reg = <0x0 0x9bb00000 0x0 0x800000>;
++			no-map;
++		};
++
++		video_mem: video@9c300000 {
++			reg = <0x0 0x9c300000 0x0 0x800000>;
++			no-map;
++		};
++
++		cvp_mem: cvp@9cb00000 {
++			reg = <0x0 0x9cb00000 0x0 0x700000>;
++			no-map;
++		};
++
++		cdsp_mem: cdsp@9d200000 {
++			reg = <0x0 0x9d200000 0x0 0x1900000>;
++			no-map;
++		};
++
++		q6_cdsp_dtb_mem: q6-cdsp-dtb@9eb00000 {
++			reg = <0x0 0x9eb00000 0x0 0x80000>;
++			no-map;
++		};
++
++		soccp_mem: soccp@9ec00000 {
++			reg = <0x0 0x9ec00000 0x0 0x180000>;
++			no-map;
++		};
++
++		q6_adsp_dtb_mem: q6-adsp-dtb@9ed80000 {
++			reg = <0x0 0x9ed80000 0x0 0x80000>;
++			no-map;
++		};
++
++		adspslpi_mem: adspslpi@9ee00000 {
++			reg = <0x0 0x9ee00000 0x0 0x3a80000>;
++			no-map;
++		};
++
++		xbl_ramdump_mem: xbl-ramdump@b8000000 {
++			reg = <0x0 0xb8000000 0x0 0x1c0000>;
++			no-map;
++		};
++
++		hwfence_shbuf: hwfence-shbuf@d4e23000 {
++			no-map;
++			reg = <0x0 0xd4e23000 0x0 0x2dd000>;
++		};
++
++		/* Merged tz_reserved, xbl_sc, and qtee regions */
++		tz_merged_mem: tz-merged@d8000000 {
++			reg = <0x0 0xd8000000 0x0 0x600000>;
++			no-map;
++		};
++
++		trust_ui_vm_mem: trust-ui-vm@f3800000 {
++			reg = <0x0 0xf3800000 0x0 0x4400000>;
++			no-map;
++		};
++
++		oem_vm_mem: oem-vm@f7c00000 {
++			reg = <0x0 0xf7c00000 0x0 0x4c00000>;
++			no-map;
++		};
++
++		llcc_lpi_mem: llcc-lpi@ff800000 {
++			reg = <0x0 0xff800000 0x0 0x800000>;
++			no-map;
++		};
++
++		adsp_rpc_remote_heap_mem: adsp-rpc-remote-heap {
++			compatible = "shared-dma-pool";
++			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
++			alignment = <0x0 0x400000>;
++			size = <0x0 0xc00000>;
++			reusable;
++		};
++	};
++
++	smp2p-adsp {
++		compatible = "qcom,smp2p";
++
++		interrupts-extended = <&ipcc IPCC_CLIENT_LPASS
++					     IPCC_MPROC_SIGNAL_SMP2P
++					     IRQ_TYPE_EDGE_RISING>;
++
++		mboxes = <&ipcc IPCC_CLIENT_LPASS
++				IPCC_MPROC_SIGNAL_SMP2P>;
++
++		qcom,smem = <443>, <429>;
++		qcom,local-pid = <0>;
++		qcom,remote-pid = <2>;
++
++		smp2p_adsp_out: master-kernel {
++			qcom,entry-name = "master-kernel";
++			#qcom,smem-state-cells = <1>;
++		};
++
++		smp2p_adsp_in: slave-kernel {
++			qcom,entry-name = "slave-kernel";
++			interrupt-controller;
++			#interrupt-cells = <2>;
++		};
++	};
++
++	smp2p-cdsp {
++		compatible = "qcom,smp2p";
++
++		interrupts-extended = <&ipcc IPCC_CLIENT_CDSP
++					     IPCC_MPROC_SIGNAL_SMP2P
++					     IRQ_TYPE_EDGE_RISING>;
++
++		mboxes = <&ipcc IPCC_CLIENT_CDSP
++				IPCC_MPROC_SIGNAL_SMP2P>;
++
++		qcom,smem = <94>, <432>;
++		qcom,local-pid = <0>;
++		qcom,remote-pid = <5>;
++
++		smp2p_cdsp_out: master-kernel {
++			qcom,entry-name = "master-kernel";
++			#qcom,smem-state-cells = <1>;
++		};
++
++		smp2p_cdsp_in: slave-kernel {
++			qcom,entry-name = "slave-kernel";
++			interrupt-controller;
++			#interrupt-cells = <2>;
++		};
++	};
++
++	smp2p-modem {
++		compatible = "qcom,smp2p";
++
++		interrupts-extended = <&ipcc IPCC_CLIENT_MPSS
++					     IPCC_MPROC_SIGNAL_SMP2P
++					     IRQ_TYPE_EDGE_RISING>;
++
++		mboxes = <&ipcc IPCC_CLIENT_MPSS
++				IPCC_MPROC_SIGNAL_SMP2P>;
++
++		qcom,smem = <435>, <428>;
++		qcom,local-pid = <0>;
++		qcom,remote-pid = <1>;
++
++		smp2p_modem_out: master-kernel {
++			qcom,entry-name = "master-kernel";
++			#qcom,smem-state-cells = <1>;
++		};
++
++		smp2p_modem_in: slave-kernel {
++			qcom,entry-name = "slave-kernel";
++			interrupt-controller;
++			#interrupt-cells = <2>;
++		};
++
++		ipa_smp2p_out: ipa-ap-to-modem {
++			qcom,entry-name = "ipa";
++			#qcom,smem-state-cells = <1>;
++		};
++
++		ipa_smp2p_in: ipa-modem-to-ap {
++			qcom,entry-name = "ipa";
++			interrupt-controller;
++			#interrupt-cells = <2>;
++		};
++
++		/* TODO: smem mailbox in and out */
++	};
++
++	soc: soc@0 {
++		compatible = "simple-bus";
++
++		#address-cells = <2>;
++		#size-cells = <2>;
++		dma-ranges = <0 0 0 0 0x10 0>;
++		ranges = <0 0 0 0 0x10 0>;
++
++		gcc: clock-controller@100000 {
++			compatible = "qcom,sm8750-gcc";
++			reg = <0x0 0x00100000 0x0 0x1f4200>;
++
++			clocks = <&bi_tcxo_div2>,
++				 <0>,
++				 <&sleep_clk>,
++				 <&pcie0_phy>,
++				 <0>,
++				 <0>,
++				 <0>,
++				 <&usb_dp_qmpphy QMP_USB43DP_USB3_PIPE_CLK>;
++
++			#clock-cells = <1>;
++			#reset-cells = <1>;
++			#power-domain-cells = <1>;
++		};
++
++		ipcc: mailbox@406000 {
++			compatible = "qcom,sm8750-ipcc", "qcom,ipcc";
++			reg = <0x0 0x00406000 0x0 0x1000>;
++
++			interrupts = <GIC_SPI 229 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-controller;
++			#interrupt-cells = <3>;
++
++			#mbox-cells = <2>;
++		};
++
++		gpi_dma2: dma-controller@800000 {
++			compatible = "qcom,sm8750-gpi-dma", "qcom,sm6350-gpi-dma";
++			reg = <0x0 0x00800000 0x0 0x60000>;
++
++			interrupts = <GIC_SPI 588 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 589 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 590 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 591 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 592 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 593 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 594 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 595 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 596 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 597 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 598 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 599 IRQ_TYPE_LEVEL_HIGH>;
++
++			dma-channels = <12>;
++			dma-channel-mask = <0x1e>;
++			#dma-cells = <3>;
++
++			iommus = <&apps_smmu 0x436 0x0>;
++
++			status = "disabled";
++		};
++
++		qupv3_2: geniqup@8c0000 {
++			compatible = "qcom,geni-se-qup";
++			reg = <0x0 0x008c0000 0x0 0x2000>;
++
++			clocks = <&gcc GCC_QUPV3_WRAP_2_M_AHB_CLK>,
++				 <&gcc GCC_QUPV3_WRAP_2_S_AHB_CLK>;
++			clock-names = "m-ahb",
++				      "s-ahb";
++
++			iommus = <&apps_smmu 0x423 0x0>;
++
++			#address-cells = <2>;
++			#size-cells = <2>;
++			ranges;
++
++			status = "disabled";
++
++			i2c8: i2c@880000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00880000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 373 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S0_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 0 QCOM_GPI_I2C>,
++				       <&gpi_dma2 1 0 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c8_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi8: spi@880000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00880000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 373 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S0_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 0 QCOM_GPI_SPI>,
++				       <&gpi_dma2 1 0 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi8_data_clk>, <&qup_spi8_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c9: i2c@884000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00884000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 583 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S1_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 1 QCOM_GPI_I2C>,
++				       <&gpi_dma2 1 1 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c9_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi9: spi@884000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00884000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 583 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S1_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 1 QCOM_GPI_SPI>,
++				       <&gpi_dma2 1 1 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi9_data_clk>, <&qup_spi9_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c10: i2c@888000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00888000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 584 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S2_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 2 QCOM_GPI_I2C>,
++				       <&gpi_dma2 1 2 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c10_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi10: spi@888000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00888000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 584 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S2_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 2 QCOM_GPI_SPI>,
++				       <&gpi_dma2 1 2 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi10_data_clk>, <&qup_spi10_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c11: i2c@88c000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x0088c000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 585 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S3_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 3 QCOM_GPI_I2C>,
++				       <&gpi_dma2 1 3 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c11_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi11: spi@88c000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x0088c000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 585 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S3_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 3 QCOM_GPI_SPI>,
++				       <&gpi_dma2 1 3 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi11_data_clk>, <&qup_spi11_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c12: i2c@890000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00890000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 586 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S4_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 4 QCOM_GPI_I2C>,
++				       <&gpi_dma2 1 4 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c12_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi12: spi@890000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00890000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 586 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S4_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 4 QCOM_GPI_SPI>,
++				       <&gpi_dma2 1 4 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi12_data_clk>, <&qup_spi12_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c13: i2c@894000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00894000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 587 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S5_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 5 QCOM_GPI_I2C>,
++				       <&gpi_dma2 1 5 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c13_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi13: spi@894000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00894000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 587 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S5_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 5 QCOM_GPI_SPI>,
++				       <&gpi_dma2 1 5 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi13_data_clk>, <&qup_spi13_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			uart14: serial@898000 {
++				compatible = "qcom,geni-uart";
++				reg = <0x0 0x00898000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 461 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S6_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&qup_uart14_default>;
++				pinctrl-names = "default";
++
++				status = "disabled";
++			};
++
++			i2c15: i2c@89c000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x0089c000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 462 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S7_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 7 QCOM_GPI_I2C>,
++				       <&gpi_dma2 1 7 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c15_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi15: spi@89c000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x0089c000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 462 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S7_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre2_noc MASTER_QUP_2 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma2 0 7 QCOM_GPI_SPI>,
++				       <&gpi_dma2 1 7 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi15_data_clk>, <&qup_spi15_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			uart15: serial@89c000 {
++				compatible = "qcom,geni-uart";
++				reg = <0x0 0x0089c000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 462 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP2_S7_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&qup_uart15_default>;
++				pinctrl-names = "default";
++
++				status = "disabled";
++			};
++		};
++
++		i2c_master_hub_0: geniqup@9c0000 {
++			compatible = "qcom,geni-se-i2c-master-hub";
++			reg = <0x0 0x009c0000 0x0 0x2000>;
++
++			clocks = <&gcc GCC_QUPV3_I2C_S_AHB_CLK>;
++			clock-names = "s-ahb";
++
++			#address-cells = <2>;
++			#size-cells = <2>;
++			ranges;
++
++			status = "disabled";
++
++			i2c_hub_0: i2c@980000 {
++				compatible = "qcom,geni-i2c-master-hub";
++				reg = <0x0 0x00980000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 464 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_I2C_S0_CLK>,
++					 <&gcc GCC_QUPV3_I2C_CORE_CLK>;
++				clock-names = "se",
++					      "core";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_I2C QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&hub_i2c0_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c_hub_1: i2c@984000 {
++				compatible = "qcom,geni-i2c-master-hub";
++				reg = <0x0 0x00984000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 465 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_I2C_S1_CLK>,
++					 <&gcc GCC_QUPV3_I2C_CORE_CLK>;
++				clock-names = "se",
++					      "core";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_I2C QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&hub_i2c1_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c_hub_2: i2c@988000 {
++				compatible = "qcom,geni-i2c-master-hub";
++				reg = <0x0 0x00988000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 466 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_I2C_S2_CLK>,
++					 <&gcc GCC_QUPV3_I2C_CORE_CLK>;
++				clock-names = "se",
++					      "core";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_I2C QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&hub_i2c2_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c_hub_3: i2c@98c000 {
++				compatible = "qcom,geni-i2c-master-hub";
++				reg = <0x0 0x0098c000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 467 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_I2C_S3_CLK>,
++					 <&gcc GCC_QUPV3_I2C_CORE_CLK>;
++				clock-names = "se",
++					      "core";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_I2C QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&hub_i2c3_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c_hub_4: i2c@990000 {
++				compatible = "qcom,geni-i2c-master-hub";
++				reg = <0x0 0x00990000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 468 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_I2C_S4_CLK>,
++					 <&gcc GCC_QUPV3_I2C_CORE_CLK>;
++				clock-names = "se",
++					      "core";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_I2C QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&hub_i2c4_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c_hub_5: i2c@994000 {
++				compatible = "qcom,geni-i2c-master-hub";
++				reg = <0x0 0x00994000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 469 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_I2C_S5_CLK>,
++					 <&gcc GCC_QUPV3_I2C_CORE_CLK>;
++				clock-names = "se",
++					      "core";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_I2C QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&hub_i2c5_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c_hub_6: i2c@998000 {
++				compatible = "qcom,geni-i2c-master-hub";
++				reg = <0x0 0x00998000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 470 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_I2C_S6_CLK>,
++					 <&gcc GCC_QUPV3_I2C_CORE_CLK>;
++				clock-names = "se",
++					      "core";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_I2C QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&hub_i2c6_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c_hub_7: i2c@99c000 {
++				compatible = "qcom,geni-i2c-master-hub";
++				reg = <0x0 0x0099c000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 471 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_I2C_S7_CLK>,
++					 <&gcc GCC_QUPV3_I2C_CORE_CLK>;
++				clock-names = "se",
++					      "core";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_I2C QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&hub_i2c7_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c_hub_8: i2c@9a0000 {
++				compatible = "qcom,geni-i2c-master-hub";
++				reg = <0x0 0x009a0000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 472 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_I2C_S8_CLK>,
++					 <&gcc GCC_QUPV3_I2C_CORE_CLK>;
++				clock-names = "se",
++					      "core";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_I2C QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&hub_i2c8_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c_hub_9: i2c@9a4000 {
++				compatible = "qcom,geni-i2c-master-hub";
++				reg = <0x0 0x009a4000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 473 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_I2C_S9_CLK>,
++					 <&gcc GCC_QUPV3_I2C_CORE_CLK>;
++				clock-names = "se",
++					      "core";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_0 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_I2C QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&hub_i2c9_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++		};
++
++		gpi_dma1: dma-controller@a00000 {
++			compatible = "qcom,sm8750-gpi-dma", "qcom,sm6350-gpi-dma";
++			reg = <0x0 0x00a00000 0x0 0x60000>;
++
++			interrupts = <GIC_SPI 279 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 280 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 281 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 282 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 283 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 284 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 293 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 294 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 295 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 296 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 297 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 298 IRQ_TYPE_LEVEL_HIGH>;
++
++			dma-channels = <12>;
++			dma-channel-mask = <0x1e>;
++			#dma-cells = <3>;
++
++			iommus = <&apps_smmu 0xb6 0x0>;
++
++			status = "disabled";
++		};
++
++		qupv3_1: geniqup@ac0000 {
++			compatible = "qcom,geni-se-qup";
++			reg = <0x0 0x00ac0000 0x0 0x2000>;
++
++			clocks = <&gcc GCC_QUPV3_WRAP_1_M_AHB_CLK>,
++				 <&gcc GCC_QUPV3_WRAP_1_S_AHB_CLK>;
++			clock-names = "m-ahb",
++				      "s-ahb";
++
++			iommus = <&apps_smmu 0xa3 0x0>;
++
++			#address-cells = <2>;
++			#size-cells = <2>;
++			ranges;
++
++			status = "disabled";
++
++			i2c0: i2c@a80000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00a80000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 353 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S0_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 0 QCOM_GPI_I2C>,
++				       <&gpi_dma1 1 0 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c0_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi0: spi@a80000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00a80000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 353 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S0_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 0 QCOM_GPI_SPI>,
++				       <&gpi_dma1 1 0 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi0_data_clk>, <&qup_spi0_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c1: i2c@a84000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00a84000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 354 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S1_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 1 QCOM_GPI_I2C>,
++				       <&gpi_dma1 1 1 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c1_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi1: spi@a84000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00a84000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 354 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S1_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 1 QCOM_GPI_SPI>,
++				       <&gpi_dma1 1 1 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi1_data_clk>, <&qup_spi1_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c2: i2c@a88000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00a88000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 355 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S2_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 2 QCOM_GPI_I2C>,
++				       <&gpi_dma1 1 2 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c2_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi2: spi@a88000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00a88000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 355 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S2_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 2 QCOM_GPI_SPI>,
++				       <&gpi_dma1 1 2 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi2_data_clk>, <&qup_spi2_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c3: i2c@a8c000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00a8c000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 356 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S3_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 3 QCOM_GPI_I2C>,
++				       <&gpi_dma1 1 3 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c3_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi3: spi@a8c000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00a8c000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 356 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S3_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 3 QCOM_GPI_SPI>,
++				       <&gpi_dma1 1 3 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi3_data_clk>, <&qup_spi3_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c4: i2c@a90000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00a90000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 357 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S4_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 4 QCOM_GPI_I2C>,
++				       <&gpi_dma1 1 4 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c4_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi4: spi@a90000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00a90000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 357 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S4_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 4 QCOM_GPI_SPI>,
++				       <&gpi_dma1 1 4 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi4_data_clk>, <&qup_spi4_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c5: i2c@a94000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00a94000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 358 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S5_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 5 QCOM_GPI_I2C>,
++				       <&gpi_dma1 1 5 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c5_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi5: spi@a94000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00a94000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 358 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S5_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 5 QCOM_GPI_SPI>,
++				       <&gpi_dma1 1 5 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi5_data_clk>, <&qup_spi5_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			i2c6: i2c@a98000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0x0 0x00a98000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 363 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S6_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 6 QCOM_GPI_I2C>,
++				       <&gpi_dma1 1 6 QCOM_GPI_I2C>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_i2c6_data_clk>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			spi6: spi@a98000 {
++				compatible = "qcom,geni-spi";
++				reg = <0x0 0x00a98000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 363 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S6_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>,
++						<&aggre1_noc MASTER_QUP_1 QCOM_ICC_TAG_ALWAYS
++						 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config",
++						     "qup-memory";
++
++				dmas = <&gpi_dma1 0 6 QCOM_GPI_SPI>,
++				       <&gpi_dma1 1 6 QCOM_GPI_SPI>;
++				dma-names = "tx",
++					    "rx";
++
++				pinctrl-0 = <&qup_spi6_data_clk>, <&qup_spi6_cs>;
++				pinctrl-names = "default";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++			};
++
++			uart7: serial@a9c000 {
++				compatible = "qcom,geni-debug-uart";
++				reg = <0x0 0x00a9c000 0x0 0x4000>;
++
++				interrupts = <GIC_SPI 579 IRQ_TYPE_LEVEL_HIGH>;
++
++				clocks = <&gcc GCC_QUPV3_WRAP1_S7_CLK>;
++				clock-names = "se";
++
++				interconnects = <&clk_virt MASTER_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS
++						 &clk_virt SLAVE_QUP_CORE_1 QCOM_ICC_TAG_ALWAYS>,
++						<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++						 &config_noc SLAVE_QUP_1 QCOM_ICC_TAG_ALWAYS>;
++				interconnect-names = "qup-core",
++						     "qup-config";
++
++				pinctrl-0 = <&qup_uart7_default>;
++				pinctrl-names = "default";
++
++				status = "disabled";
++			};
++		};
++
++		rng: rng@10c3000 {
++			compatible = "qcom,sm8750-trng", "qcom,trng";
++			reg = <0x0 0x010c3000 0x0 0x1000>;
++		};
++
++		cnoc_main: interconnect@1500000 {
++			compatible = "qcom,sm8750-cnoc-main";
++			reg = <0x0 0x01500000 0x0 0x16080>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++		};
++
++		config_noc: interconnect@1600000 {
++			compatible = "qcom,sm8750-config-noc";
++			reg = <0x0 0x01600000 0x0 0x6200>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++		};
++
++		system_noc: interconnect@1680000 {
++			compatible = "qcom,sm8750-system-noc";
++			reg = <0x0 0x01680000 0x0 0x1d080>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++		};
++
++		pcie_noc: interconnect@16c0000 {
++			compatible = "qcom,sm8750-pcie-anoc";
++			reg = <0x0 0x016c0000 0x0 0x11400>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++			clocks = <&gcc GCC_AGGRE_UFS_PHY_AXI_CLK>,
++				 <&gcc GCC_AGGRE_USB3_PRIM_AXI_CLK>;
++		};
++
++		aggre1_noc: interconnect@16e0000 {
++			compatible = "qcom,sm8750-aggre1-noc";
++			reg = <0x0 0x016e0000 0x0 0x16400>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++			clocks = <&gcc GCC_AGGRE_UFS_PHY_AXI_CLK>,
++				 <&gcc GCC_AGGRE_USB3_PRIM_AXI_CLK>;
++		};
++
++		aggre2_noc: interconnect@1700000 {
++			compatible = "qcom,sm8750-aggre2-noc";
++			reg = <0x0 0x01700000 0x0 0x1f400>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++			clocks = <&rpmhcc RPMH_IPA_CLK>;
++		};
++
++		mmss_noc: interconnect@1780000 {
++			compatible = "qcom,sm8750-mmss-noc";
++			reg = <0x0 0x01780000 0x0 0x5b800>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++		};
++
++		ice: crypto@1d88000 {
++			compatible = "qcom,sm8750-inline-crypto-engine",
++				     "qcom,inline-crypto-engine";
++			reg = <0x0 0x01d88000 0x0 0x18000>;
++
++			clocks = <&gcc GCC_UFS_PHY_ICE_CORE_CLK>,
++				 <&gcc GCC_UFS_PHY_AHB_CLK>;
++			clock-names = "core",
++				      "iface";
++			power-domains = <&gcc GCC_UFS_PHY_GDSC>;
++		};
++
++		cryptobam: dma-controller@1dc4000 {
++			compatible = "qcom,bam-v1.7.4", "qcom,bam-v1.7.0";
++			reg = <0x0 0x01dc4000 0x0 0x28000>;
++
++			interrupts = <GIC_SPI 272 IRQ_TYPE_LEVEL_HIGH>;
++
++			#dma-cells = <1>;
++
++			iommus = <&apps_smmu 0x480 0>,
++				 <&apps_smmu 0x481 0>;
++
++			qcom,ee = <0>;
++			qcom,num-ees = <4>;
++			num-channels = <20>;
++			qcom,controlled-remotely;
++		};
++
++		crypto: crypto@1dfa000 {
++			compatible = "qcom,sm8750-qce", "qcom,sm8150-qce", "qcom,qce";
++			reg = <0x0 0x01dfa000 0x0 0x6000>;
++
++			interconnects = <&aggre2_noc MASTER_CRYPTO QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++			interconnect-names = "memory";
++
++			dmas = <&cryptobam 4>, <&cryptobam 5>;
++			dma-names = "rx", "tx";
++
++			iommus = <&apps_smmu 0x480 0>,
++				 <&apps_smmu 0x481 0>;
++		};
++
++		tcsr_mutex: hwlock@1f40000 {
++			compatible = "qcom,tcsr-mutex";
++			reg = <0x0 0x01f40000 0x0 0x20000>;
++			#hwlock-cells = <1>;
++		};
++
++		remoteproc_mpss: remoteproc@4080000 {
++			compatible = "qcom,sm8750-mpss-pas";
++			reg = <0x0 0x04080000 0x0 0x10000>;
++
++			interrupts-extended = <&intc GIC_SPI 264 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_modem_in 0 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_modem_in 1 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_modem_in 2 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_modem_in 3 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_modem_in 7 IRQ_TYPE_EDGE_RISING>;
++			interrupt-names = "wdog",
++					  "fatal",
++					  "ready",
++					  "handover",
++					  "stop-ack",
++					  "shutdown-ack";
++
++			clocks = <&rpmhcc RPMH_CXO_CLK>;
++			clock-names = "xo";
++
++			interconnects = <&mc_virt MASTER_LLCC QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++
++			power-domains = <&rpmhpd RPMHPD_CX>,
++					<&rpmhpd RPMHPD_MSS>;
++			power-domain-names = "cx",
++					     "mss";
++
++			memory-region = <&mpss_mem>, <&q6_mpss_dtb_mem>,
++					<&dsm_partition_1_mem>,
++					<&dsm_partition_2_mem>;
++
++			qcom,qmp = <&aoss_qmp>;
++
++			qcom,smem-states = <&smp2p_modem_out 0>;
++			qcom,smem-state-names = "stop";
++
++			status = "disabled";
++
++			glink-edge {
++				interrupts-extended = <&ipcc IPCC_CLIENT_MPSS
++							     IPCC_MPROC_SIGNAL_GLINK_QMP
++							     IRQ_TYPE_EDGE_RISING>;
++
++				mboxes = <&ipcc IPCC_CLIENT_MPSS
++						IPCC_MPROC_SIGNAL_GLINK_QMP>;
++
++				qcom,remote-pid = <1>;
++
++				label = "mpss";
++			};
++		};
++
++		remoteproc_adsp: remoteproc@6800000 {
++			compatible = "qcom,sm8750-adsp-pas", "qcom,sm8550-adsp-pas";
++			reg = <0x0 0x06800000 0x0 0x10000>;
++
++			interrupts-extended = <&pdc 6 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_adsp_in 0 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_adsp_in 1 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_adsp_in 2 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_adsp_in 3 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_adsp_in 7 IRQ_TYPE_EDGE_RISING>;
++			interrupt-names = "wdog",
++					  "fatal",
++					  "ready",
++					  "handover",
++					  "stop-ack",
++					  "shutdown-ack";
++
++			clocks = <&rpmhcc RPMH_CXO_CLK>;
++			clock-names = "xo";
++
++			interconnects = <&lpass_lpicx_noc MASTER_LPASS_PROC QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++
++			power-domains = <&rpmhpd RPMHPD_LCX>,
++					<&rpmhpd RPMHPD_LMX>;
++			power-domain-names = "lcx",
++					     "lmx";
++
++			memory-region = <&adspslpi_mem>, <&q6_adsp_dtb_mem>;
++
++			qcom,qmp = <&aoss_qmp>;
++
++			qcom,smem-states = <&smp2p_adsp_out 0>;
++			qcom,smem-state-names = "stop";
++
++			status = "disabled";
++
++			remoteproc_adsp_glink: glink-edge {
++				interrupts-extended = <&ipcc IPCC_CLIENT_LPASS
++							     IPCC_MPROC_SIGNAL_GLINK_QMP
++							     IRQ_TYPE_EDGE_RISING>;
++				mboxes = <&ipcc IPCC_CLIENT_LPASS
++						IPCC_MPROC_SIGNAL_GLINK_QMP>;
++				qcom,remote-pid = <2>;
++				label = "lpass";
++
++				fastrpc {
++					compatible = "qcom,fastrpc";
++					qcom,glink-channels = "fastrpcglink-apps-dsp";
++					label = "adsp";
++					memory-region = <&adsp_rpc_remote_heap_mem>;
++					qcom,vmids = <QCOM_SCM_VMID_LPASS
++						      QCOM_SCM_VMID_ADSP_HEAP>;
++					#address-cells = <1>;
++					#size-cells = <0>;
++
++					compute-cb@3 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <3>;
++						iommus = <&apps_smmu 0x1003 0x80>,
++							 <&apps_smmu 0x1043 0x20>;
++						dma-coherent;
++					};
++
++					compute-cb@4 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <4>;
++						iommus = <&apps_smmu 0x1004 0x80>,
++							 <&apps_smmu 0x1044 0x20>;
++						dma-coherent;
++					};
++
++					compute-cb@5 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <5>;
++						iommus = <&apps_smmu 0x1005 0x80>,
++							 <&apps_smmu 0x1045 0x20>;
++						dma-coherent;
++					};
++
++					compute-cb@6 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <6>;
++						iommus = <&apps_smmu 0x1006 0x80>,
++							 <&apps_smmu 0x1046 0x20>;
++						dma-coherent;
++					};
++
++					compute-cb@7 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <7>;
++						iommus = <&apps_smmu 0x1007 0x40>,
++							 <&apps_smmu 0x1067 0x0>,
++							 <&apps_smmu 0x1087 0x0>;
++						dma-coherent;
++					};
++
++					compute-cb@8 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <8>;
++						iommus = <&apps_smmu 0x1008 0x80>,
++							 <&apps_smmu 0x1048 0x20>;
++						dma-coherent;
++					};
++				};
++
++				gpr {
++					compatible = "qcom,gpr";
++					qcom,glink-channels = "adsp_apps";
++					qcom,domain = <GPR_DOMAIN_ID_ADSP>;
++					qcom,intents = <512 20>;
++					#address-cells = <1>;
++					#size-cells = <0>;
++
++					q6apm: service@1 {
++						compatible = "qcom,q6apm";
++						reg = <GPR_APM_MODULE_IID>;
++						#sound-dai-cells = <0>;
++						qcom,protection-domain = "avs/audio",
++									 "msm/adsp/audio_pd";
++
++						q6apmbedai: bedais {
++							compatible = "qcom,q6apm-lpass-dais";
++							#sound-dai-cells = <1>;
++						};
++
++						q6apmdai: dais {
++							compatible = "qcom,q6apm-dais";
++							iommus = <&apps_smmu 0x1001 0x80>,
++								 <&apps_smmu 0x1041 0x20>;
++						};
++					};
++
++					q6prm: service@2 {
++						compatible = "qcom,q6prm";
++						reg = <GPR_PRM_MODULE_IID>;
++						qcom,protection-domain = "avs/audio",
++									 "msm/adsp/audio_pd";
++
++						q6prmcc: clock-controller {
++							compatible = "qcom,q6prm-lpass-clocks";
++							#clock-cells = <2>;
++						};
++					};
++				};
++			};
++		};
++
++		lpass_wsa2macro: codec@6aa0000 {
++			compatible = "qcom,sm8750-lpass-wsa-macro", "qcom,sm8550-lpass-wsa-macro";
++			reg = <0x0 0x06aa0000 0x0 0x1000>;
++			clocks = <&q6prmcc LPASS_CLK_ID_WSA2_CORE_TX_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6prmcc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6prmcc LPASS_HW_DCODEC_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&lpass_vamacro>;
++			clock-names = "mclk",
++				      "macro",
++				      "dcodec",
++				      "fsgen";
++
++			#clock-cells = <0>;
++			clock-output-names = "wsa2-mclk";
++			#sound-dai-cells = <1>;
++		};
++
++		swr3: soundwire@6ab0000 {
++			compatible = "qcom,soundwire-v2.1.0", "qcom,soundwire-v2.0.0";
++			reg = <0x0 0x06ab0000 0x0 0x10000>;
++			interrupts = <GIC_SPI 171 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&lpass_wsa2macro>;
++			clock-names = "iface";
++			label = "WSA2";
++
++			pinctrl-0 = <&wsa2_swr_active>;
++			pinctrl-names = "default";
++
++			qcom,din-ports = <4>;
++			qcom,dout-ports = <9>;
++
++			qcom,ports-sinterval =		/bits/ 16 <0x07 0x1f 0x3f 0x07 0x1f 0x3f 0x18f 0x18f 0x18f 0x0f 0x0f 0xff 0x31f>;
++			qcom,ports-offset1 =		/bits/ 8 <0x01 0x03 0x05 0x02 0x04 0x15 0x00 0x00 0x00 0x06 0x0d 0xff 0x00>;
++			qcom,ports-offset2 =		/bits/ 8 <0xff 0x07 0x1f 0xff 0x07 0x1f 0xff 0xff 0xff 0xff 0xff 0xff 0xff>;
++			qcom,ports-hstart =		/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0x08 0x0e 0x0e 0xff 0xff 0xff 0x0f>;
++			qcom,ports-hstop =		/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0x08 0x0e 0x0e 0xff 0xff 0xff 0x0f>;
++			qcom,ports-word-length =	/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0x08 0x0f 0x0f 0x00 0xff 0xff 0x18>;
++			qcom,ports-block-pack-mode =	/bits/ 8 <0x00 0x01 0x01 0x00 0x01 0x01 0x00 0x01 0x01 0x01 0x01 0x00 0x00>;
++			qcom,ports-block-group-count =	/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff 0x00 0x00 0xff 0xff 0xff 0xff>;
++			qcom,ports-lane-control =	/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff 0x00 0x00 0xff 0xff 0xff 0xff>;
++
++			#address-cells = <2>;
++			#size-cells = <0>;
++			#sound-dai-cells = <1>;
++			status = "disabled";
++		};
++
++		lpass_rxmacro: codec@6ac0000 {
++			compatible = "qcom,sm8750-lpass-rx-macro", "qcom,sm8550-lpass-rx-macro";
++			reg = <0x0 0x06ac0000 0x0 0x1000>;
++			clocks = <&q6prmcc LPASS_CLK_ID_RX_CORE_TX_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6prmcc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6prmcc LPASS_HW_DCODEC_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&lpass_vamacro>;
++			clock-names = "mclk",
++				      "macro",
++				      "dcodec",
++				      "fsgen";
++
++			#clock-cells = <0>;
++			clock-output-names = "mclk";
++			#sound-dai-cells = <1>;
++		};
++
++		swr1: soundwire@6ad0000 {
++			compatible = "qcom,soundwire-v2.1.0", "qcom,soundwire-v2.0.0";
++			reg = <0x0 0x06ad0000 0x0 0x10000>;
++			interrupts = <GIC_SPI 155 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&lpass_rxmacro>;
++			clock-names = "iface";
++			label = "RX";
++
++			pinctrl-0 = <&rx_swr_active>;
++			pinctrl-names = "default";
++
++			qcom,din-ports = <1>;
++			qcom,dout-ports = <11>;
++
++			qcom,ports-sinterval =		/bits/ 16 <0x03 0x3f 0x1f 0x07 0x00 0x18f 0xff 0xff 0x31 0xff 0xff 0xff>;
++			qcom,ports-offset1 =		/bits/ 8 <0x00 0x00 0x0b 0x01 0x00 0x00 0xff 0xff 0x00 0xff 0xff 0xff>;
++			qcom,ports-offset2 =		/bits/ 8 <0x00 0x00 0x0b 0x00 0x00 0x00 0xff 0xff 0x00 0xff 0xff 0xff>;
++			qcom,ports-hstart =		/bits/ 8 <0xff 0x03 0xff 0xff 0xff 0x08 0xff 0xff 0x00 0xff 0xff 0xff>;
++			qcom,ports-hstop =		/bits/ 8 <0xff 0x06 0xff 0xff 0xff 0x08 0xff 0xff 0x0f 0xff 0xff 0xff>;
++			qcom,ports-word-length =	/bits/ 8 <0x01 0x07 0x04 0xff 0xff 0x0f 0xff 0xff 0x18 0xff 0xff 0xff>;
++			qcom,ports-block-pack-mode =	/bits/ 8 <0xff 0x00 0x01 0xff 0xff 0x00 0xff 0xff 0x01 0xff 0xff 0xff>;
++			qcom,ports-block-group-count =	/bits/ 8 <0xff 0xff 0xff 0xff 0x00 0x00 0xff 0xff 0x00 0xff 0xff 0xff>;
++			qcom,ports-lane-control =	/bits/ 8 <0x01 0x00 0x00 0x00 0x00 0x00 0xff 0xff 0x01 0xff 0xff 0xff>;
++
++			#address-cells = <2>;
++			#size-cells = <0>;
++			#sound-dai-cells = <1>;
++			status = "disabled";
++		};
++
++		lpass_txmacro: codec@6ae0000 {
++			compatible = "qcom,sm8750-lpass-tx-macro", "qcom,sm8550-lpass-tx-macro";
++			reg = <0x0 0x06ae0000 0x0 0x1000>;
++			clocks = <&q6prmcc LPASS_CLK_ID_TX_CORE_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6prmcc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6prmcc LPASS_HW_DCODEC_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&lpass_vamacro>;
++			clock-names = "mclk",
++				      "macro",
++				      "dcodec",
++				      "fsgen";
++
++			#clock-cells = <0>;
++			clock-output-names = "mclk";
++			#sound-dai-cells = <1>;
++		};
++
++		lpass_wsamacro: codec@6b00000 {
++			compatible = "qcom,sm8750-lpass-wsa-macro", "qcom,sm8550-lpass-wsa-macro";
++			reg = <0x0 0x06b00000 0x0 0x1000>;
++			clocks = <&q6prmcc LPASS_CLK_ID_WSA_CORE_TX_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6prmcc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6prmcc LPASS_HW_DCODEC_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&lpass_vamacro>;
++			clock-names = "mclk",
++				      "macro",
++				      "dcodec",
++				      "fsgen";
++
++			#clock-cells = <0>;
++			clock-output-names = "mclk";
++			#sound-dai-cells = <1>;
++		};
++
++		swr0: soundwire@6b10000 {
++			compatible = "qcom,soundwire-v2.1.0", "qcom,soundwire-v2.0.0";
++			reg = <0x0 0x06b10000 0x0 0x10000>;
++			interrupts = <GIC_SPI 170 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&lpass_wsamacro>;
++			clock-names = "iface";
++			label = "WSA";
++
++			pinctrl-0 = <&wsa_swr_active>;
++			pinctrl-names = "default";
++
++			qcom,din-ports = <4>;
++			qcom,dout-ports = <9>;
++
++			qcom,ports-sinterval =		/bits/ 16 <0x07 0x1f 0x3f 0x07 0x1f 0x3f 0x18f 0x18f 0x18f 0x0f 0x0f 0xff 0x31f>;
++			qcom,ports-offset1 =		/bits/ 8 <0x01 0x03 0x05 0x02 0x04 0x15 0x00 0x00 0x00 0x06 0x0d 0xff 0x00>;
++			qcom,ports-offset2 =		/bits/ 8 <0xff 0x07 0x1f 0xff 0x07 0x1f 0xff 0xff 0xff 0xff 0xff 0xff 0xff>;
++			qcom,ports-hstart =		/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0x08 0x0e 0x0e 0xff 0xff 0xff 0x0f>;
++			qcom,ports-hstop =		/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0x08 0x0e 0x0e 0xff 0xff 0xff 0x0f>;
++			qcom,ports-word-length =	/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0x08 0x0f 0x0f 0x00 0xff 0xff 0x18>;
++			qcom,ports-block-pack-mode =	/bits/ 8 <0x00 0x01 0x01 0x00 0x01 0x01 0x00 0x01 0x01 0x01 0x01 0x00 0x00>;
++			qcom,ports-block-group-count =	/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff 0x00 0x00 0xff 0xff 0xff 0xff>;
++			qcom,ports-lane-control =	/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff 0x00 0x00 0xff 0xff 0xff 0xff>;
++
++			#address-cells = <2>;
++			#size-cells = <0>;
++			#sound-dai-cells = <1>;
++			status = "disabled";
++		};
++
++		lpass_ag_noc: interconnect@7e40000 {
++			compatible = "qcom,sm8750-lpass-ag-noc";
++			reg = <0x0 0x07e40000 0x0 0xe080>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++		};
++
++		lpass_lpiaon_noc: interconnect@7400000 {
++			compatible = "qcom,sm8750-lpass-lpiaon-noc";
++			reg = <0x0 0x07400000 0x0 0x19080>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++		};
++
++		lpass_lpicx_noc: interconnect@7420000 {
++			compatible = "qcom,sm8750-lpass-lpicx-noc";
++			reg = <0x0 0x07420000 0x0 0x44080>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++		};
++
++		swr2: soundwire@7630000 {
++			compatible = "qcom,soundwire-v2.1.0", "qcom,soundwire-v2.0.0";
++			reg = <0x0 0x07630000 0x0 0x10000>;
++			interrupts = <GIC_SPI 761 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 785 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "core", "wakeup";
++			clocks = <&lpass_txmacro>;
++			clock-names = "iface";
++			label = "TX";
++
++			pinctrl-0 = <&tx_swr_active>;
++			pinctrl-names = "default";
++
++			qcom,din-ports = <4>;
++			qcom,dout-ports = <0>;
++
++			qcom,ports-sinterval-low =	/bits/ 8 <0x01 0x01 0x03 0x03>;
++			qcom,ports-offset1 =		/bits/ 8 <0x00 0x00 0x01 0x01>;
++			qcom,ports-offset2 =		/bits/ 8 <0x00 0x00 0x00 0x00>;
++			qcom,ports-hstart =		/bits/ 8 <0xff 0xff 0xff 0xff>;
++			qcom,ports-hstop =		/bits/ 8 <0xff 0xff 0xff 0xff>;
++			qcom,ports-word-length =	/bits/ 8 <0xff 0xff 0xff 0xff>;
++			qcom,ports-block-pack-mode =	/bits/ 8 <0xff 0xff 0xff 0xff>;
++			qcom,ports-block-group-count =	/bits/ 8 <0xff 0xff 0xff 0xff>;
++			qcom,ports-lane-control =	/bits/ 8 <0x01 0x02 0x00 0x00>;
++
++			#address-cells = <2>;
++			#size-cells = <0>;
++			#sound-dai-cells = <1>;
++			status = "disabled";
++		};
++
++		lpass_vamacro: codec@7660000 {
++			compatible = "qcom,sm8750-lpass-va-macro", "qcom,sm8550-lpass-va-macro";
++			reg = <0x0 0x07660000 0x0 0x2000>;
++			clocks = <&q6prmcc LPASS_CLK_ID_TX_CORE_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6prmcc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6prmcc LPASS_HW_DCODEC_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++			clock-names = "mclk",
++				      "macro",
++				      "dcodec";
++
++			#clock-cells = <0>;
++			clock-output-names = "fsgen";
++			#sound-dai-cells = <1>;
++		};
++
++		lpass_tlmm: pinctrl@7760000 {
++			compatible = "qcom,sm8750-lpass-lpi-pinctrl",
++				     "qcom,sm8650-lpass-lpi-pinctrl";
++			reg = <0x0 0x07760000 0x0 0x20000>;
++
++			clocks = <&q6prmcc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
++				 <&q6prmcc LPASS_HW_DCODEC_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++			clock-names = "core", "audio";
++
++			gpio-controller;
++			#gpio-cells = <2>;
++			gpio-ranges = <&lpass_tlmm 0 0 23>;
++
++			tx_swr_active: tx-swr-active-state {
++				clk-pins {
++					pins = "gpio0";
++					function = "swr_tx_clk";
++					drive-strength = <2>;
++					slew-rate = <1>;
++					bias-disable;
++				};
++
++				data-pins {
++					pins = "gpio1", "gpio2", "gpio14";
++					function = "swr_tx_data";
++					drive-strength = <2>;
++					slew-rate = <1>;
++					bias-bus-hold;
++				};
++			};
++
++			rx_swr_active: rx-swr-active-state {
++				clk-pins {
++					pins = "gpio3";
++					function = "swr_rx_clk";
++					drive-strength = <2>;
++					slew-rate = <1>;
++					bias-disable;
++				};
++
++				data-pins {
++					pins = "gpio4", "gpio5";
++					function = "swr_rx_data";
++					drive-strength = <2>;
++					slew-rate = <1>;
++					bias-bus-hold;
++				};
++			};
++
++			dmic01_default: dmic01-default-state {
++				clk-pins {
++					pins = "gpio6";
++					function = "dmic1_clk";
++					drive-strength = <8>;
++					output-high;
++				};
++
++				data-pins {
++					pins = "gpio7";
++					function = "dmic1_data";
++					drive-strength = <8>;
++					input-enable;
++				};
++			};
++
++			dmic23_default: dmic23-default-state {
++				clk-pins {
++					pins = "gpio8";
++					function = "dmic2_clk";
++					drive-strength = <8>;
++					output-high;
++				};
++
++				data-pins {
++					pins = "gpio9";
++					function = "dmic2_data";
++					drive-strength = <8>;
++					input-enable;
++				};
++			};
++
++			wsa_swr_active: wsa-swr-active-state {
++				clk-pins {
++					pins = "gpio10";
++					function = "wsa_swr_clk";
++					drive-strength = <2>;
++					slew-rate = <1>;
++					bias-disable;
++				};
++
++				data-pins {
++					pins = "gpio11";
++					function = "wsa_swr_data";
++					drive-strength = <2>;
++					slew-rate = <1>;
++					bias-bus-hold;
++				};
++			};
++
++			wsa2_swr_active: wsa2-swr-active-state {
++				clk-pins {
++					pins = "gpio15";
++					function = "wsa2_swr_clk";
++					drive-strength = <2>;
++					slew-rate = <1>;
++					bias-disable;
++				};
++
++				data-pins {
++					pins = "gpio16";
++					function = "wsa2_swr_data";
++					drive-strength = <2>;
++					slew-rate = <1>;
++					bias-bus-hold;
++				};
++			};
++		};
++
++		sdhc_2: mmc@8804000 {
++			compatible = "qcom,sm8750-sdhci", "qcom,sdhci-msm-v5";
++			reg = <0x0 0x08804000 0x0 0x1000>;
++
++			interrupts = <GIC_SPI 207 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 223 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "hc_irq",
++					  "pwr_irq";
++
++			clocks = <&gcc GCC_SDCC2_AHB_CLK>,
++				 <&gcc GCC_SDCC2_APPS_CLK>,
++				 <&rpmhcc RPMH_CXO_CLK>;
++			clock-names = "iface",
++				      "core",
++				      "xo";
++
++			interconnects = <&aggre2_noc MASTER_SDCC_2 QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>,
++					<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ACTIVE_ONLY
++					 &config_noc SLAVE_SDCC_2 QCOM_ICC_TAG_ACTIVE_ONLY>;
++			interconnect-names = "sdhc-ddr",
++					     "cpu-sdhc";
++
++			power-domains = <&rpmhpd RPMHPD_CX>;
++			operating-points-v2 = <&sdhc2_opp_table>;
++
++			qcom,dll-config = <0x0007442c>;
++			qcom,ddr-config = <0x80040868>;
++
++			iommus = <&apps_smmu 0x540 0x0>;
++			dma-coherent;
++
++			bus-width = <4>;
++			max-sd-hs-hz = <37500000>;
++
++			resets = <&gcc GCC_SDCC2_BCR>;
++
++			status = "disabled";
++
++			sdhc2_opp_table: opp-table {
++				compatible = "operating-points-v2";
++
++				opp-100000000 {
++					opp-hz = /bits/ 64 <100000000>;
++					required-opps = <&rpmhpd_opp_low_svs>;
++				};
++
++				opp-202000000 {
++					opp-hz = /bits/ 64 <202000000>;
++					required-opps = <&rpmhpd_opp_svs_l1>;
++				};
++			};
++		};
++
++		usb_hsphy: phy@88e3000 {
++			compatible = "qcom,sm8750-m31-eusb2-phy";
++			reg = <0x0 0x88e3000 0x0 0x29c>;
++
++			clocks = <&tcsrcc TCSR_USB2_CLKREF_EN>;
++			clock-names = "ref";
++
++			resets = <&gcc GCC_QUSB2PHY_PRIM_BCR>;
++
++			#phy-cells = <0>;
++
++			status = "disabled";
++		};
++
++		usb_dp_qmpphy: phy@88e8000 {
++			compatible = "qcom,sm8750-qmp-usb3-dp-phy";
++			reg = <0x0 0x088e8000 0x0 0x4000>;
++
++			clocks = <&gcc GCC_USB3_PRIM_PHY_AUX_CLK>,
++				 <&tcsrcc TCSR_USB3_CLKREF_EN>,
++				 <&gcc GCC_USB3_PRIM_PHY_COM_AUX_CLK>,
++				 <&gcc GCC_USB3_PRIM_PHY_PIPE_CLK>;
++			clock-names = "aux",
++				      "ref",
++				      "com_aux",
++				      "usb3_pipe";
++
++			resets = <&gcc GCC_USB3_PHY_PRIM_BCR>,
++				 <&gcc GCC_USB3_DP_PHY_PRIM_BCR>;
++			reset-names = "phy",
++				      "common";
++
++			power-domains = <&gcc GCC_USB3_PHY_GDSC>;
++
++			#clock-cells = <1>;
++			#phy-cells = <1>;
++
++			orientation-switch;
++
++			status = "disabled";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					usb_dp_qmpphy_out: endpoint {
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					usb_dp_qmpphy_usb_ss_in: endpoint {
++						remote-endpoint = <&usb_dwc3_ss>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					usb_dp_qmpphy_dp_in: endpoint {
++						remote-endpoint = <&mdss_dp0_out>;
++					};
++				};
++			};
++		};
++
++		usb: usb@a600000 {
++			compatible = "qcom,sm8750-dwc3", "qcom,snps-dwc3";
++			reg = <0x0 0x0a600000 0x0 0xfc100>;
++
++			clocks = <&gcc GCC_CFG_NOC_USB3_PRIM_AXI_CLK>,
++				 <&gcc GCC_USB30_PRIM_MASTER_CLK>,
++				 <&gcc GCC_AGGRE_USB3_PRIM_AXI_CLK>,
++				 <&gcc GCC_USB30_PRIM_SLEEP_CLK>,
++				 <&gcc GCC_USB30_PRIM_MOCK_UTMI_CLK>;
++			clock-names = "cfg_noc",
++				      "core",
++				      "iface",
++				      "sleep",
++				      "mock_utmi";
++
++			assigned-clocks = <&gcc GCC_USB30_PRIM_MOCK_UTMI_CLK>,
++					  <&gcc GCC_USB30_PRIM_MASTER_CLK>;
++			assigned-clock-rates = <19200000>,
++					       <200000000>;
++
++			interrupts-extended = <&intc GIC_SPI 133 IRQ_TYPE_LEVEL_HIGH>,
++					      <&intc GIC_SPI 130 IRQ_TYPE_LEVEL_HIGH>,
++					      <&intc GIC_SPI 131 IRQ_TYPE_LEVEL_HIGH>,
++					      <&pdc 14 IRQ_TYPE_EDGE_BOTH>,
++					      <&pdc 15 IRQ_TYPE_EDGE_BOTH>,
++					      <&pdc 17 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "dwc_usb3",
++					  "pwr_event",
++					  "hs_phy_irq",
++					  "dp_hs_phy_irq",
++					  "dm_hs_phy_irq",
++					  "ss_phy_irq";
++
++			power-domains = <&gcc GCC_USB30_PRIM_GDSC>;
++			required-opps = <&rpmhpd_opp_nom>;
++
++			resets = <&gcc GCC_USB30_PRIM_BCR>;
++
++			interconnects = <&aggre1_noc MASTER_USB3_0 QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>,
++					<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ACTIVE_ONLY
++					 &config_noc SLAVE_USB3_0 QCOM_ICC_TAG_ACTIVE_ONLY>;
++			interconnect-names = "usb-ddr", "apps-usb";
++
++			iommus = <&apps_smmu 0x40 0x0>;
++
++			phys = <&usb_hsphy>,
++			       <&usb_dp_qmpphy QMP_USB43DP_USB3_PHY>;
++			phy-names = "usb2-phy",
++				    "usb3-phy";
++
++			snps,hird-threshold = /bits/ 8 <0x0>;
++			snps,usb2-gadget-lpm-disable;
++			snps,dis_u2_susphy_quirk;
++			snps,dis_enblslpm_quirk;
++			snps,dis-u1-entry-quirk;
++			snps,dis-u2-entry-quirk;
++			snps,is-utmi-l1-suspend;
++			snps,usb3_lpm_capable;
++			snps,usb2-lpm-disable;
++			snps,has-lpm-erratum;
++			tx-fifo-resize;
++
++			dma-coherent;
++			usb-role-switch;
++
++			status = "disabled";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					usb_dwc3_hs: endpoint {
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					usb_dwc3_ss: endpoint {
++						remote-endpoint = <&usb_dp_qmpphy_usb_ss_in>;
++					};
++				};
++			};
++		};
++
++		iris: video-codec@aa00000 {
++			compatible = "qcom,sm8750-iris";
++			reg = <0x0 0x0aa00000 0x0 0xf0000>;
++
++			clocks = <&gcc GCC_VIDEO_AXI0_CLK>,
++				 <&videocc VIDEO_CC_MVS0C_CLK>,
++				 <&videocc VIDEO_CC_MVS0_CLK>,
++				 <&gcc GCC_VIDEO_AXI1_CLK>,
++				 <&videocc VIDEO_CC_MVS0C_FREERUN_CLK>,
++				 <&videocc VIDEO_CC_MVS0_FREERUN_CLK>;
++			clock-names = "iface",
++				      "core",
++				      "vcodec0_core",
++				      "iface1",
++				      "core_freerun",
++				      "vcodec0_core_freerun";
++
++			dma-coherent;
++			iommus = <&apps_smmu 0x1940 0>,
++				 <&apps_smmu 0x1947 0>;
++
++			interconnects = <&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ACTIVE_ONLY
++					 &config_noc SLAVE_VENUS_CFG QCOM_ICC_TAG_ACTIVE_ONLY>,
++					<&mmss_noc MASTER_VIDEO_MVP QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++			interconnect-names = "cpu-cfg",
++					     "video-mem";
++
++			interrupts = <GIC_SPI 174 IRQ_TYPE_LEVEL_HIGH>;
++
++			memory-region = <&video_mem>;
++
++			operating-points-v2 = <&iris_opp_table>;
++
++			power-domains = <&videocc VIDEO_CC_MVS0C_GDSC>,
++					<&videocc VIDEO_CC_MVS0_GDSC>,
++					<&rpmhpd RPMHPD_MXC>,
++					<&rpmhpd RPMHPD_MMCX>;
++			power-domain-names = "venus",
++					     "vcodec0",
++					     "mxc",
++					     "mmcx";
++
++			resets = <&gcc GCC_VIDEO_AXI0_CLK_ARES>,
++				 <&gcc GCC_VIDEO_AXI1_CLK_ARES>,
++				 <&videocc VIDEO_CC_MVS0C_FREERUN_CLK_ARES>,
++				 <&videocc VIDEO_CC_MVS0_FREERUN_CLK_ARES>;
++			reset-names = "bus0",
++				      "bus1",
++				      "core",
++				      "vcodec0_core";
++
++			/*
++			 * IRIS firmware is signed by vendors, only
++			 * enable in boards where the proper signed firmware
++			 * is available.
++			 */
++			status = "disabled";
++
++			iris_opp_table: opp-table {
++				compatible = "operating-points-v2";
++
++				opp-240000000 {
++					opp-hz = /bits/ 64 <240000000>;
++					required-opps = <&rpmhpd_opp_svs>,
++							<&rpmhpd_opp_low_svs_d1>;
++				};
++
++				opp-338000000 {
++					opp-hz = /bits/ 64 <338000000>;
++					required-opps = <&rpmhpd_opp_svs>,
++							<&rpmhpd_opp_low_svs>;
++				};
++
++				opp-420000000 {
++					opp-hz = /bits/ 64 <420000000>;
++					required-opps = <&rpmhpd_opp_svs_l1>,
++							<&rpmhpd_opp_svs>;
++				};
++
++				opp-444000000 {
++					opp-hz = /bits/ 64 <444000000>;
++					required-opps = <&rpmhpd_opp_svs_l1>,
++							<&rpmhpd_opp_svs_l1>;
++				};
++
++				opp-533333334 {
++					opp-hz = /bits/ 64 <533333334>;
++					required-opps = <&rpmhpd_opp_svs_l1>,
++							<&rpmhpd_opp_nom>;
++				};
++
++				opp-570000000 {
++					opp-hz = /bits/ 64 <570000000>;
++					required-opps = <&rpmhpd_opp_nom>,
++							<&rpmhpd_opp_nom_l1>;
++				};
++
++				opp-630000000 {
++					opp-hz = /bits/ 64 <630000000>;
++					required-opps = <&rpmhpd_opp_nom>,
++							<&rpmhpd_opp_turbo>;
++				};
++			};
++		};
++
++		videocc: clock-controller@aaf0000 {
++			compatible = "qcom,sm8750-videocc";
++			reg = <0x0 0x0aaf0000 0x0 0x10000>;
++			clocks = <&bi_tcxo_div2>,
++				 <&gcc GCC_VIDEO_AHB_CLK>;
++			power-domains = <&rpmhpd RPMHPD_MMCX>,
++					<&rpmhpd RPMHPD_MXC>;
++			required-opps = <&rpmhpd_opp_low_svs>,
++					<&rpmhpd_opp_low_svs>;
++			#clock-cells = <1>;
++			#reset-cells = <1>;
++			#power-domain-cells = <1>;
++		};
++
++		mdss: display-subsystem@ae00000 {
++			compatible = "qcom,sm8750-mdss";
++			reg = <0x0 0x0ae00000 0x0 0x1000>;
++			reg-names = "mdss";
++
++			interrupts = <GIC_SPI 83 IRQ_TYPE_LEVEL_HIGH>;
++
++			clocks = <&dispcc DISP_CC_MDSS_AHB_CLK>,
++				 <&gcc GCC_DISP_HF_AXI_CLK>,
++				 <&dispcc DISP_CC_MDSS_MDP_CLK>;
++
++			resets = <&dispcc DISP_CC_MDSS_CORE_BCR>;
++
++			interconnects = <&mmss_noc MASTER_MDP QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>,
++					<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ACTIVE_ONLY
++					 &config_noc SLAVE_DISPLAY_CFG QCOM_ICC_TAG_ACTIVE_ONLY>;
++			interconnect-names = "mdp0-mem",
++					     "cpu-cfg";
++
++			power-domains = <&dispcc MDSS_GDSC>;
++
++			iommus = <&apps_smmu 0x800 0x2>;
++
++			interrupt-controller;
++			#interrupt-cells = <1>;
++
++			#address-cells = <2>;
++			#size-cells = <2>;
++			ranges;
++
++			status = "disabled";
++
++			mdss_mdp: display-controller@ae01000 {
++				compatible = "qcom,sm8750-dpu";
++				reg = <0x0 0x0ae01000 0x0 0x93000>,
++				      <0x0 0x0aeb0000 0x0 0x2008>;
++				reg-names = "mdp",
++					    "vbif";
++
++				interrupts-extended = <&mdss 0>;
++
++				clocks = <&gcc GCC_DISP_HF_AXI_CLK>,
++					 <&dispcc DISP_CC_MDSS_AHB_CLK>,
++					 <&dispcc DISP_CC_MDSS_MDP_LUT_CLK>,
++					 <&dispcc DISP_CC_MDSS_MDP_CLK>,
++					 <&dispcc DISP_CC_MDSS_VSYNC_CLK>;
++				clock-names = "nrt_bus",
++					      "iface",
++					      "lut",
++					      "core",
++					      "vsync";
++
++				assigned-clocks = <&dispcc DISP_CC_MDSS_VSYNC_CLK>;
++				assigned-clock-rates = <19200000>;
++
++				operating-points-v2 = <&mdp_opp_table>;
++
++				power-domains = <&rpmhpd RPMHPD_MMCX>;
++
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++
++					port@0 {
++						reg = <0>;
++
++						dpu_intf1_out: endpoint {
++							remote-endpoint = <&mdss_dsi0_in>;
++						};
++					};
++
++					port@1 {
++						reg = <1>;
++
++						dpu_intf2_out: endpoint {
++							remote-endpoint = <&mdss_dsi1_in>;
++						};
++					};
++
++					port@2 {
++						reg = <2>;
++
++						dpu_intf0_out: endpoint {
++							remote-endpoint = <&mdss_dp0_in>;
++						};
++					};
++				};
++
++				mdp_opp_table: opp-table {
++					compatible = "operating-points-v2";
++
++					opp-156000000 {
++						opp-hz = /bits/ 64 <156000000>;
++						required-opps = <&rpmhpd_opp_low_svs_d1>;
++					};
++
++					opp-207000000 {
++						opp-hz = /bits/ 64 <207000000>;
++						required-opps = <&rpmhpd_opp_low_svs>;
++					};
++
++					opp-337000000 {
++						opp-hz = /bits/ 64 <337000000>;
++						required-opps = <&rpmhpd_opp_svs>;
++					};
++
++					opp-417000000 {
++						opp-hz = /bits/ 64 <417000000>;
++						required-opps = <&rpmhpd_opp_svs_l1>;
++					};
++
++					opp-532000000 {
++						opp-hz = /bits/ 64 <532000000>;
++						required-opps = <&rpmhpd_opp_nom>;
++					};
++
++					opp-575000000 {
++						opp-hz = /bits/ 64 <575000000>;
++						required-opps = <&rpmhpd_opp_nom_l1>;
++					};
++				};
++			};
++
++			mdss_dsi0: dsi@ae94000 {
++				compatible = "qcom,sm8750-dsi-ctrl", "qcom,mdss-dsi-ctrl";
++				reg = <0x0 0x0ae94000 0x0 0x400>;
++				reg-names = "dsi_ctrl";
++
++				interrupts-extended = <&mdss 4>;
++
++				clocks = <&dispcc DISP_CC_MDSS_BYTE0_CLK>,
++					 <&dispcc DISP_CC_MDSS_BYTE0_INTF_CLK>,
++					 <&dispcc DISP_CC_MDSS_PCLK0_CLK>,
++					 <&dispcc DISP_CC_MDSS_ESC0_CLK>,
++					 <&dispcc DISP_CC_MDSS_AHB_CLK>,
++					 <&gcc GCC_DISP_HF_AXI_CLK>,
++					 <&mdss_dsi0_phy DSI_PIXEL_PLL_CLK>,
++					 <&mdss_dsi0_phy DSI_BYTE_PLL_CLK>,
++					 <&dispcc DISP_CC_ESYNC0_CLK>,
++					 <&dispcc DISP_CC_OSC_CLK>,
++					 <&dispcc DISP_CC_MDSS_BYTE0_CLK_SRC>,
++					 <&dispcc DISP_CC_MDSS_PCLK0_CLK_SRC>;
++				clock-names = "byte",
++					      "byte_intf",
++					      "pixel",
++					      "core",
++					      "iface",
++					      "bus",
++					      "dsi_pll_pixel",
++					      "dsi_pll_byte",
++					      "esync",
++					      "osc",
++					      "byte_src",
++					      "pixel_src";
++
++				operating-points-v2 = <&mdss_dsi_opp_table>;
++
++				power-domains = <&rpmhpd RPMHPD_MMCX>;
++
++				phys = <&mdss_dsi0_phy>;
++				phy-names = "dsi";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++
++					port@0 {
++						reg = <0>;
++
++						mdss_dsi0_in: endpoint {
++							remote-endpoint = <&dpu_intf1_out>;
++						};
++					};
++
++					port@1 {
++						reg = <1>;
++
++						mdss_dsi0_out: endpoint {
++						};
++					};
++				};
++
++				mdss_dsi_opp_table: opp-table {
++					compatible = "operating-points-v2";
++
++					opp-140630000 {
++						opp-hz = /bits/ 64 <140630000>;
++						required-opps = <&rpmhpd_opp_low_svs_d1>;
++					};
++
++					opp-187500000 {
++						opp-hz = /bits/ 64 <187500000>;
++						required-opps = <&rpmhpd_opp_low_svs>;
++					};
++
++					opp-300000000 {
++						opp-hz = /bits/ 64 <300000000>;
++						required-opps = <&rpmhpd_opp_svs>;
++					};
++
++					opp-358000000 {
++						opp-hz = /bits/ 64 <358000000>;
++						required-opps = <&rpmhpd_opp_svs_l1>;
++					};
++				};
++			};
++
++			mdss_dsi0_phy: phy@ae95000 {
++				compatible = "qcom,sm8750-dsi-phy-3nm";
++				reg = <0x0 0x0ae95000 0x0 0x200>,
++				      <0x0 0x0ae95200 0x0 0x280>,
++				      <0x0 0x0ae95500 0x0 0x400>;
++				reg-names = "dsi_phy",
++					    "dsi_phy_lane",
++					    "dsi_pll";
++
++				clocks = <&dispcc DISP_CC_MDSS_AHB_CLK>,
++					 <&bi_tcxo_div2>;
++				clock-names = "iface",
++					      "ref";
++
++				#clock-cells = <1>;
++				#phy-cells = <0>;
++
++				status = "disabled";
++			};
++
++			mdss_dsi1: dsi@ae96000 {
++				compatible = "qcom,sm8750-dsi-ctrl", "qcom,mdss-dsi-ctrl";
++				reg = <0x0 0x0ae96000 0x0 0x400>;
++				reg-names = "dsi_ctrl";
++
++				interrupts-extended = <&mdss 5>;
++
++				clocks = <&dispcc DISP_CC_MDSS_BYTE1_CLK>,
++					 <&dispcc DISP_CC_MDSS_BYTE1_INTF_CLK>,
++					 <&dispcc DISP_CC_MDSS_PCLK1_CLK>,
++					 <&dispcc DISP_CC_MDSS_ESC1_CLK>,
++					 <&dispcc DISP_CC_MDSS_AHB_CLK>,
++					 <&gcc GCC_DISP_HF_AXI_CLK>,
++					 <&mdss_dsi1_phy DSI_PIXEL_PLL_CLK>,
++					 <&mdss_dsi1_phy DSI_BYTE_PLL_CLK>,
++					 <&dispcc DISP_CC_ESYNC1_CLK>,
++					 <&dispcc DISP_CC_OSC_CLK>,
++					 <&dispcc DISP_CC_MDSS_BYTE1_CLK_SRC>,
++					 <&dispcc DISP_CC_MDSS_PCLK1_CLK_SRC>;
++				clock-names = "byte",
++					      "byte_intf",
++					      "pixel",
++					      "core",
++					      "iface",
++					      "bus",
++					      "dsi_pll_pixel",
++					      "dsi_pll_byte",
++					      "esync",
++					      "osc",
++					      "byte_src",
++					      "pixel_src";
++
++				operating-points-v2 = <&mdss_dsi_opp_table>;
++
++				power-domains = <&rpmhpd RPMHPD_MMCX>;
++
++				phys = <&mdss_dsi1_phy>;
++				phy-names = "dsi";
++
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				status = "disabled";
++
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++
++					port@0 {
++						reg = <0>;
++
++						mdss_dsi1_in: endpoint {
++							remote-endpoint = <&dpu_intf2_out>;
++						};
++					};
++
++					port@1 {
++						reg = <1>;
++
++						mdss_dsi1_out: endpoint {
++						};
++					};
++				};
++			};
++
++			mdss_dsi1_phy: phy@ae97000 {
++				compatible = "qcom,sm8750-dsi-phy-3nm";
++				reg = <0x0 0x0ae97000 0x0 0x200>,
++				      <0x0 0x0ae97200 0x0 0x280>,
++				      <0x0 0x0ae97500 0x0 0x400>;
++				reg-names = "dsi_phy",
++					    "dsi_phy_lane",
++					    "dsi_pll";
++
++				clocks = <&dispcc DISP_CC_MDSS_AHB_CLK>,
++					 <&bi_tcxo_div2>;
++				clock-names = "iface",
++					      "ref";
++
++				#clock-cells = <1>;
++				#phy-cells = <0>;
++
++				status = "disabled";
++			};
++
++			mdss_dp0: displayport-controller@af54000 {
++				compatible = "qcom,sm8750-dp", "qcom,sm8650-dp";
++				reg = <0x0 0xaf54000 0x0 0x104>,
++				      <0x0 0xaf54200 0x0 0xc0>,
++				      <0x0 0xaf55000 0x0 0x770>,
++				      <0x0 0xaf56000 0x0 0x9c>,
++				      <0x0 0xaf57000 0x0 0x9c>;
++
++				interrupts-extended = <&mdss 12>;
++
++				clocks = <&dispcc DISP_CC_MDSS_AHB_CLK>,
++					 <&dispcc DISP_CC_MDSS_DPTX0_AUX_CLK>,
++					 <&dispcc DISP_CC_MDSS_DPTX0_LINK_CLK>,
++					 <&dispcc DISP_CC_MDSS_DPTX0_LINK_INTF_CLK>,
++					 <&dispcc DISP_CC_MDSS_DPTX0_PIXEL0_CLK>,
++					 <&dispcc DISP_CC_MDSS_DPTX0_PIXEL1_CLK>;
++				clock-names = "core_iface",
++					      "core_aux",
++					      "ctrl_link",
++					      "ctrl_link_iface",
++					      "stream_pixel",
++					      "stream_1_pixel";
++
++				assigned-clocks = <&dispcc DISP_CC_MDSS_DPTX0_LINK_CLK_SRC>,
++						  <&dispcc DISP_CC_MDSS_DPTX0_PIXEL0_CLK_SRC>,
++						  <&dispcc DISP_CC_MDSS_DPTX0_PIXEL1_CLK_SRC>;
++				assigned-clock-parents = <&usb_dp_qmpphy QMP_USB43DP_DP_LINK_CLK>,
++							 <&usb_dp_qmpphy QMP_USB43DP_DP_VCO_DIV_CLK>,
++							 <&usb_dp_qmpphy QMP_USB43DP_DP_VCO_DIV_CLK>;
++
++				operating-points-v2 = <&dp_opp_table>;
++
++				power-domains = <&rpmhpd RPMHPD_MMCX>;
++
++				phys = <&usb_dp_qmpphy QMP_USB43DP_DP_PHY>;
++				phy-names = "dp";
++
++				#sound-dai-cells = <0>;
++
++				status = "disabled";
++
++				dp_opp_table: opp-table {
++					compatible = "operating-points-v2";
++
++					opp-270000000 {
++						opp-hz = /bits/ 64 <270000000>;
++						required-opps = <&rpmhpd_opp_low_svs>;
++					};
++
++					opp-540000000 {
++						opp-hz = /bits/ 64 <540000000>;
++						required-opps = <&rpmhpd_opp_svs_l1>;
++					};
++
++					opp-810000000 {
++						opp-hz = /bits/ 64 <810000000>;
++						required-opps = <&rpmhpd_opp_nom>;
++					};
++				};
++
++				ports {
++					#address-cells = <1>;
++					#size-cells = <0>;
++
++					port@0 {
++						reg = <0>;
++
++						mdss_dp0_in: endpoint {
++							remote-endpoint = <&dpu_intf0_out>;
++						};
++					};
++
++					port@1 {
++						reg = <1>;
++
++						mdss_dp0_out: endpoint {
++							data-lanes = <0 1 2 3>;
++							remote-endpoint = <&usb_dp_qmpphy_dp_in>;
++						};
++					};
++				};
++			};
++		};
++
++		dispcc: clock-controller@af00000 {
++			compatible = "qcom,sm8750-dispcc";
++			reg = <0x0 0x0af00000 0x0 0x20000>;
++
++			clocks = <&bi_tcxo_div2>,
++				 <&bi_tcxo_ao_div2>,
++				 <&gcc GCC_DISP_AHB_CLK>,
++				 <&sleep_clk>,
++				 <&mdss_dsi0_phy DSI_BYTE_PLL_CLK>,
++				 <&mdss_dsi0_phy DSI_PIXEL_PLL_CLK>,
++				 <&mdss_dsi1_phy DSI_BYTE_PLL_CLK>,
++				 <&mdss_dsi1_phy DSI_PIXEL_PLL_CLK>,
++				 <&usb_dp_qmpphy QMP_USB43DP_DP_LINK_CLK>,
++				 <&usb_dp_qmpphy QMP_USB43DP_DP_VCO_DIV_CLK>,
++				 <0>, /* dp1 */
++				 <0>,
++				 <0>, /* dp2 */
++				 <0>,
++				 <0>, /* dp3 */
++				 <0>;
++
++			power-domains = <&rpmhpd RPMHPD_MMCX>;
++			required-opps = <&rpmhpd_opp_low_svs>;
++
++			#clock-cells = <1>;
++			#reset-cells = <1>;
++			#power-domain-cells = <1>;
++		};
++
++		gpu: gpu@3d00000 {
++			compatible = "qcom,adreno-44050000", "qcom,adreno";
++			reg = <0x0 0x03d00000 0x0 0x40000>,
++			      <0x0 0x03d9e000 0x0 0x2000>,
++			      <0x0 0x03d61000 0x0 0x800>;
++			reg-names = "kgsl_3d0_reg_memory",
++				    "cx_mem",
++				    "cx_dbgc";
++
++			interrupts = <GIC_SPI 300 IRQ_TYPE_LEVEL_HIGH>;
++
++			iommus = <&adreno_smmu 0 0x0>,
++				 <&adreno_smmu 1 0x0>;
++
++			operating-points-v2 = <&gpu_opp_table>;
++
++			qcom,gmu = <&gmu>;
++			#cooling-cells = <2>;
++
++			interconnects = <&gem_noc MASTER_GFX3D QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++			interconnect-names = "gfx-mem";
++
++			status = "disabled";
++
++			gpu_zap_shader: zap-shader {
++				memory-region = <&gpu_micro_code_mem>;
++			};
++
++			gpu_opp_table: opp-table {
++				compatible = "operating-points-v2-adreno",
++						"operating-points-v2";
++
++				opp-1100000000 {
++					opp-hz = /bits/ 64 <1100000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_TURBO_L3>;
++					opp-peak-kBps = <20832031>;
++					qcom,opp-acd-level = <0x882a5ffd>;
++				};
++
++				opp-1050000000 {
++					opp-hz = /bits/ 64 <1050000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_TURBO_L1>;
++					opp-peak-kBps = <20832031>;
++					qcom,opp-acd-level = <0x882a5ffd>;
++				};
++
++				opp-967000000 {
++					opp-hz = /bits/ 64 <967000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_NOM_L1>;
++					opp-peak-kBps = <12449218>;
++					qcom,opp-acd-level = <0x882b5ffd>;
++				};
++
++				opp-900000000 {
++					opp-hz = /bits/ 64 <900000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_NOM>;
++					opp-peak-kBps = <12449218>;
++					qcom,opp-acd-level = <0x882b5ffd>;
++				};
++
++				opp-832000000 {
++					opp-hz = /bits/ 64 <832000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_SVS_L2>;
++					opp-peak-kBps = <12449218>;
++					qcom,opp-acd-level = <0x882b5ffd>;
++				};
++
++				opp-734000000 {
++					opp-hz = /bits/ 64 <734000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_SVS_L1>;
++					opp-peak-kBps = <8171875>;
++					qcom,opp-acd-level = <0xa82b5ffd>;
++				};
++
++				opp-660000000 {
++					opp-hz = /bits/ 64 <660000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_SVS_L0>;
++					opp-peak-kBps = <8171875>;
++					qcom,opp-acd-level = <0x882d5ffd>;
++				};
++
++				opp-607000000 {
++					opp-hz = /bits/ 64 <607000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_SVS>;
++					opp-peak-kBps = <6074218>;
++					qcom,opp-acd-level = <0xa82e5ffd>;
++				};
++
++				opp-525000000 {
++					opp-hz = /bits/ 64 <525000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS_L1>;
++					opp-peak-kBps = <6074218>;
++					qcom,opp-acd-level = <0xc0285ffd>;
++				};
++
++				opp-443000000 {
++					opp-hz = /bits/ 64 <443000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS>;
++					opp-peak-kBps = <6074218>;
++					qcom,opp-acd-level = <0xe02d5ffd>;
++				};
++
++				opp-389000000 {
++					opp-hz = /bits/ 64 <389000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS_D0>;
++					opp-peak-kBps = <5285156>;
++					qcom,opp-acd-level = <0xe02f5ffd>;
++				};
++
++				opp-342000000 {
++					opp-hz = /bits/ 64 <342000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS_D1>;
++					opp-peak-kBps = <5285156>;
++				};
++
++				opp-222000000 {
++					opp-hz = /bits/ 64 <222000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS_D2>;
++					opp-peak-kBps = <2136718>;
++				};
++
++				opp-160000000 {
++					opp-hz = /bits/ 64 <160000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS_D3>;
++					opp-peak-kBps = <2136718>;
++				};
++			};
++		};
++
++		gmu: gmu@3d37000 {
++			compatible = "qcom,adreno-gmu-830.1", "qcom,adreno-gmu";
++
++			reg = <0x0 0x03d37000 0x0 0x68000>;
++			reg-names = "gmu";
++
++			interrupts = <GIC_SPI 304 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 305 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "hfi", "gmu";
++
++			clocks = <&gpucc GPU_CC_AHB_CLK>,
++				 <&gpucc GPU_CC_CX_GMU_CLK>,
++				 <&gpucc GPU_CC_CXO_CLK>,
++				 <&gcc GCC_GPU_GEMNOC_GFX_CLK>,
++				 <&gpucc GPU_CC_HUB_CX_INT_CLK>;
++			clock-names = "ahb",
++				      "gmu",
++				      "cxo",
++				      "memnoc",
++				      "hub";
++
++			power-domains = <&gpucc GPU_CC_CX_GDSC>,
++					<&gxclkctl GX_CLKCTL_GX_GDSC>;
++			power-domain-names = "cx",
++						 "gx";
++
++			iommus = <&adreno_smmu 5 0x0>;
++
++			qcom,qmp = <&aoss_qmp>;
++
++			operating-points-v2 = <&gmu_opp_table>;
++
++			gmu_opp_table: opp-table {
++				compatible = "operating-points-v2";
++
++				opp-500000000 {
++					opp-hz = /bits/ 64 <500000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS>;
++				};
++
++				opp-650000000 {
++					opp-hz = /bits/ 64 <650000000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_SVS>;
++				};
++
++				opp-687500000 {
++					opp-hz = /bits/ 64 <687500000>;
++					opp-level = <RPMH_REGULATOR_LEVEL_NOM>;
++				};
++			};
++		};
++
++		gxclkctl: clock-controller@3d64000 {
++			compatible = "qcom,sm8750-gxclkctl";
++			reg = <0x0 0x03d64000 0x0 0x6000>;
++
++			power-domains = <&rpmhpd RPMHPD_GFX>,
++					<&rpmhpd RPMHPD_GMXC>,
++					<&gpucc GPU_CC_CX_GDSC>;
++
++			#power-domain-cells = <1>;
++		};
++
++		gpucc: clock-controller@3d90000 {
++			compatible = "qcom,sm8750-gpucc";
++			reg = <0x0 0x03d90000 0x0 0x9800>;
++
++			clocks = <&bi_tcxo_div2>,
++				 <&gcc GCC_GPU_GPLL0_CLK_SRC>,
++				 <&gcc GCC_GPU_GPLL0_DIV_CLK_SRC>;
++
++			power-domains = <&rpmhpd RPMHPD_MX>,
++					<&rpmhpd RPMHPD_CX>;
++			required-opps = <&rpmhpd_opp_low_svs>,
++					<&rpmhpd_opp_low_svs>;
++			#clock-cells = <1>;
++			#reset-cells = <1>;
++			#power-domain-cells = <1>;
++		};
++
++		pdc: interrupt-controller@b220000 {
++			compatible = "qcom,sm8750-pdc", "qcom,pdc";
++			reg = <0x0 0x0b220000 0x0 0x10000>, <0x0 0x164400f0 0x0 0x64>;
++
++			qcom,pdc-ranges = <0 745 51>, <51 527 47>,
++					  <98 609 32>, <130 717 12>,
++					  <142 251 5>, <147 796 16>;
++			#interrupt-cells = <2>;
++			interrupt-parent = <&intc>;
++			interrupt-controller;
++		};
++
++		tsens0: thermal-sensor@c228000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c228000 0x0 0x1000>,
++			      <0x0 0x0c222000 0x0 0x1000>;
++			interrupts = <GIC_SPI 771 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 484 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <15>;
++			#thermal-sensor-cells = <1>;
++		};
++
++		tsens1: thermal-sensor@c229000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c229000 0x0 0x1000>,
++			      <0x0 0x0c223000 0x0 0x1000>;
++			interrupts = <GIC_SPI 772 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 485 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <7>;
++			#thermal-sensor-cells = <1>;
++		};
++
++		tsens2: thermal-sensor@c22a000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c22a000 0x0 0x1000>,
++			      <0x0 0x0c224000 0x0 0x1000>;
++			interrupts = <GIC_SPI 773 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 486 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <16>;
++			#thermal-sensor-cells = <1>;
++		};
++
++		tsens3: thermal-sensor@c22b000 {
++			compatible = "qcom,sm8750-tsens", "qcom,tsens-v2";
++			reg = <0x0 0x0c22b000 0x0 0x1000>,
++			      <0x0 0x0c225000 0x0 0x1000>;
++			interrupts = <GIC_SPI 774 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 487 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "uplow",
++					  "critical";
++			#qcom,sensors = <9>;
++			#thermal-sensor-cells = <1>;
++		};
++
++		aoss_qmp: power-management@c300000 {
++			compatible = "qcom,sm8750-aoss-qmp", "qcom,aoss-qmp";
++			reg = <0x0 0x0c300000 0x0 0x400>;
++
++			interrupt-parent = <&ipcc>;
++			interrupts-extended = <&ipcc IPCC_CLIENT_AOP IPCC_MPROC_SIGNAL_GLINK_QMP
++						     IRQ_TYPE_EDGE_RISING>;
++
++			mboxes = <&ipcc IPCC_CLIENT_AOP IPCC_MPROC_SIGNAL_GLINK_QMP>;
++
++			#clock-cells = <0>;
++		};
++
++		sram@c3f0000 {
++			compatible = "qcom,rpmh-stats";
++			reg = <0x0 0x0c3f0000 0x0 0x400>;
++			qcom,qmp = <&aoss_qmp>;
++		};
++
++		spmi_bus: spmi@c400000 {
++			compatible = "qcom,spmi-pmic-arb";
++			reg = <0x0 0x0c400000 0x0 0x3000>,
++			      <0x0 0x0c500000 0x0 0x400000>,
++			      <0x0 0x0c440000 0x0 0x80000>,
++			      <0x0 0x0c4c0000 0x0 0x10000>,
++			      <0x0 0x0c42d000 0x0 0x4000>;
++			reg-names = "core",
++				    "chnls",
++				    "obsrvr",
++				    "intr",
++				    "cnfg";
++
++			interrupts-extended = <&pdc 1 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "periph_irq";
++
++			qcom,ee = <0>;
++			qcom,channel = <0>;
++			qcom,bus-id = <0>;
++
++			interrupt-controller;
++			#interrupt-cells = <4>;
++
++			#address-cells = <2>;
++			#size-cells = <0>;
++		};
++
++		tlmm: pinctrl@f100000 {
++			compatible = "qcom,sm8750-tlmm";
++			reg = <0x0 0x0f100000 0x0 0x102000>;
++
++			interrupts = <GIC_SPI 208 IRQ_TYPE_LEVEL_HIGH>;
++
++			gpio-controller;
++			#gpio-cells = <2>;
++
++			interrupt-controller;
++			#interrupt-cells = <2>;
++
++			gpio-ranges = <&tlmm 0 0 216>;
++			wakeup-parent = <&pdc>;
++
++			hub_i2c0_data_clk: hub-i2c0-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio64", "gpio65";
++				function = "i2chub0_se0";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			hub_i2c1_data_clk: hub-i2c1-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio66", "gpio67";
++				function = "i2chub0_se1";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			hub_i2c2_data_clk: hub-i2c2-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio68", "gpio69";
++				function = "i2chub0_se2";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			hub_i2c3_data_clk: hub-i2c3-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio70", "gpio71";
++				function = "i2chub0_se3";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			hub_i2c4_data_clk: hub-i2c4-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio72", "gpio73";
++				function = "i2chub0_se4";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			hub_i2c5_data_clk: hub-i2c5-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio74", "gpio75";
++				function = "i2chub0_se5";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			hub_i2c6_data_clk: hub-i2c6-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio76", "gpio77";
++				function = "i2chub0_se6";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			hub_i2c7_data_clk: hub-i2c7-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio82", "gpio83";
++				function = "i2chub0_se7";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			hub_i2c8_data_clk: hub-i2c8-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio206", "gpio207";
++				function = "i2chub0_se8";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			hub_i2c9_data_clk: hub-i2c9-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio80", "gpio81";
++				function = "i2chub0_se9";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			pcie0_default_state: pcie0-default-state {
++				perst-pins {
++					pins = "gpio102";
++					function = "gpio";
++					drive-strength = <2>;
++					bias-pull-down;
++				};
++
++				clkreq-pins {
++					pins = "gpio103";
++					function = "pcie0_clk_req_n";
++					drive-strength = <2>;
++					bias-pull-up;
++				};
++
++				wake-pins {
++					pins = "gpio104";
++					function = "gpio";
++					drive-strength = <2>;
++					bias-pull-up;
++				};
++			};
++
++			qup_i2c0_data_clk: qup-i2c0-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio32", "gpio33";
++				function = "qup1_se0";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c1_data_clk: qup-i2c1-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio36", "gpio37";
++				function = "qup1_se1";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c2_data_clk: qup-i2c2-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio40", "gpio41";
++				function = "qup1_se2";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c3_data_clk: qup-i2c3-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio44", "gpio45";
++				function = "qup1_se3";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c4_data_clk: qup-i2c4-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio48", "gpio49";
++				function = "qup1_se4";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c5_data_clk: qup-i2c5-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio52", "gpio53";
++				function = "qup1_se5";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c6_data_clk: qup-i2c6-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio56", "gpio57";
++				function = "qup1_se6";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c8_data_clk: qup-i2c8-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio0", "gpio1";
++				function = "qup2_se0";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c9_data_clk: qup-i2c9-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio4", "gpio5";
++				function = "qup2_se1";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c10_data_clk: qup-i2c10-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio8", "gpio9";
++				function = "qup2_se2";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c11_data_clk: qup-i2c11-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio12", "gpio13";
++				function = "qup2_se3";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c12_data_clk: qup-i2c12-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio16", "gpio17";
++				function = "qup2_se4";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c13_data_clk: qup-i2c13-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio20", "gpio21";
++				function = "qup2_se5";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_i2c15_data_clk: qup-i2c15-data-clk-state {
++				/* SDA, SCL */
++				pins = "gpio28", "gpio29";
++				function = "qup2_se7";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_spi0_cs: qup-spi0-cs-state {
++				pins = "gpio35";
++				function = "qup1_se0";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi0_data_clk: qup-spi0-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio32", "gpio33", "gpio34";
++				function = "qup1_se0";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi1_cs: qup-spi1-cs-state {
++				pins = "gpio39";
++				function = "qup1_se1";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi1_data_clk: qup-spi1-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio36", "gpio37", "gpio38";
++				function = "qup1_se1";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi2_cs: qup-spi2-cs-state {
++				pins = "gpio43";
++				function = "qup1_se2";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi2_data_clk: qup-spi2-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio40", "gpio41", "gpio42";
++				function = "qup1_se2";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi3_cs: qup-spi3-cs-state {
++				pins = "gpio47";
++				function = "qup1_se3";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi3_data_clk: qup-spi3-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio44", "gpio45", "gpio46";
++				function = "qup1_se3";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi4_cs: qup-spi4-cs-state {
++				pins = "gpio51";
++				function = "qup1_se4";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi4_data_clk: qup-spi4-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio48", "gpio49", "gpio50";
++				function = "qup1_se4";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi5_cs: qup-spi5-cs-state {
++				pins = "gpio55";
++				function = "qup1_se5";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi5_data_clk: qup-spi5-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio52", "gpio53", "gpio54";
++				function = "qup1_se5";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi6_cs: qup-spi6-cs-state {
++				pins = "gpio59";
++				function = "qup1_se6";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi6_data_clk: qup-spi6-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio56", "gpio57", "gpio58";
++				function = "qup1_se6";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi8_cs: qup-spi8-cs-state {
++				pins = "gpio3";
++				function = "qup2_se0";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi8_data_clk: qup-spi8-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio0", "gpio1", "gpio2";
++				function = "qup2_se0";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi9_cs: qup-spi9-cs-state {
++				pins = "gpio7";
++				function = "qup2_se1";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi9_data_clk: qup-spi9-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio4", "gpio5", "gpio6";
++				function = "qup2_se1";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi10_cs: qup-spi10-cs-state {
++				pins = "gpio11";
++				function = "qup2_se2";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi10_data_clk: qup-spi10-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio8", "gpio9", "gpio10";
++				function = "qup2_se2";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi11_cs: qup-spi11-cs-state {
++				pins = "gpio15";
++				function = "qup2_se3";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi11_data_clk: qup-spi11-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio12", "gpio13", "gpio14";
++				function = "qup2_se3";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi12_cs: qup-spi12-cs-state {
++				pins = "gpio19";
++				function = "qup2_se4";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi12_data_clk: qup-spi12-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio16", "gpio17", "gpio18";
++				function = "qup2_se4";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi13_cs: qup-spi13-cs-state {
++				pins = "gpio23";
++				function = "qup2_se5";
++				drive-strength = <6>;
++				bias-pull-up;
++			};
++
++			qup_spi13_data_clk: qup-spi13-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio20", "gpio21", "gpio22";
++				function = "qup2_se5";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi15_cs: qup-spi15-cs-state {
++				pins = "gpio31";
++				function = "qup2_se7";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_spi15_data_clk: qup-spi15-data-clk-state {
++				/* MISO, MOSI, CLK */
++				pins = "gpio28", "gpio29", "gpio30";
++				function = "qup2_se7";
++				drive-strength = <6>;
++				bias-disable;
++			};
++
++			qup_uart7_default: qup-uart7-default-state {
++				/* TX, RX */
++				pins = "gpio62", "gpio63";
++				function = "qup1_se7";
++				drive-strength = <2>;
++				bias-disable;
++			};
++
++			qup_uart14_default: qup-uart14-default-state {
++				/* TX, RX */
++				pins = "gpio26", "gpio27";
++				function = "qup2_se6";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			qup_uart14_cts_rts: qup-uart14-cts-rts-state {
++				/* CTS, RTS */
++				pins = "gpio24", "gpio25";
++				function = "qup2_se6";
++				drive-strength = <2>;
++				bias-pull-down;
++			};
++
++			qup_uart15_default: qup-uart15-default-state {
++				/* TX, RX */
++				pins = "gpio30", "gpio31";
++				function = "qup2_se7";
++				drive-strength = <2>;
++				bias-pull-up;
++			};
++
++			sdc2_sleep: sdc2-sleep-state {
++				clk-pins {
++					pins = "sdc2_clk";
++					drive-strength = <2>;
++					bias-disable;
++				};
++
++				cmd-pins {
++					pins = "sdc2_cmd";
++					drive-strength = <2>;
++					bias-pull-up;
++				};
++
++				data-pins {
++					pins = "sdc2_data";
++					drive-strength = <2>;
++					bias-pull-up;
++				};
++			};
++
++			sdc2_default: sdc2-default-state {
++				clk-pins {
++					pins = "sdc2_clk";
++					drive-strength = <16>;
++					bias-disable;
++				};
++
++				cmd-pins {
++					pins = "sdc2_cmd";
++					drive-strength = <10>;
++					bias-pull-up;
++				};
++
++				data-pins {
++					pins = "sdc2_data";
++					drive-strength = <10>;
++					bias-pull-up;
++				};
++			};
++		};
++
++		tcsrcc: clock-controller@f204008 {
++			compatible = "qcom,sm8750-tcsr", "syscon";
++			reg = <0x0 0x0f204008 0x0 0x3004>;
++
++			clocks = <&rpmhcc RPMH_CXO_CLK>;
++
++			#clock-cells = <1>;
++			#reset-cells = <1>;
++		};
++
++		stm@10002000 {
++			compatible = "arm,coresight-stm", "arm,primecell";
++			reg = <0x0 0x10002000 0x0 0x1000>,
++			      <0x0 0x37280000 0x0 0x180000>;
++			reg-names = "stm-base",
++				    "stm-stimulus-base";
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			out-ports {
++				port {
++					stm_out: endpoint {
++						remote-endpoint = <&funnel_in0_in7>;
++					};
++				};
++			};
++		};
++
++		tpda@10004000 {
++			compatible = "qcom,coresight-tpda", "arm,primecell";
++			reg = <0x0 0x10004000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			in-ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@1 {
++					reg = <1>;
++
++					tpda_qdss_in1: endpoint {
++						remote-endpoint = <&tpdm_spdm_out>;
++					};
++				};
++
++			};
++
++			out-ports {
++				port {
++					tpda_qdss_out: endpoint {
++						remote-endpoint = <&funnel_in0_in6>;
++					};
++				};
++			};
++		};
++
++		tpdm@1000f000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x1000f000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-element-bits = <64>;
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_spdm_out: endpoint {
++						remote-endpoint = <&tpda_qdss_in1>;
++					};
++				};
++			};
++		};
++
++		funnel@10041000 {
++			compatible = "arm,coresight-dynamic-funnel", "arm,primecell";
++			reg = <0x0 0x10041000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			in-ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					funnel_in0_in0: endpoint {
++						remote-endpoint = <&tn_ag_out>;
++					};
++				};
++
++				port@6 {
++					reg = <6>;
++
++					funnel_in0_in6: endpoint {
++						remote-endpoint = <&tpda_qdss_out>;
++					};
++				};
++
++				port@7 {
++					reg = <7>;
++
++					funnel_in0_in7: endpoint {
++						remote-endpoint = <&stm_out>;
++					};
++				};
++			};
++
++			out-ports {
++				port {
++					funnel_in0_out: endpoint {
++						remote-endpoint = <&funnel_aoss_in7>;
++					};
++				};
++			};
++		};
++
++		tpdm@10800000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x10800000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,dsb-element-bits = <32>;
++			qcom,dsb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_modem0_out: endpoint {
++						remote-endpoint = <&tpda_modem_in0>;
++					};
++				};
++			};
++		};
++
++		tpda@10803000 {
++			compatible = "qcom,coresight-tpda", "arm,primecell";
++			reg = <0x0 0x10803000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			in-ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					tpda_modem_in0: endpoint {
++						remote-endpoint = <&tpdm_modem0_out>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					tpda_modem_in1: endpoint {
++						remote-endpoint = <&tpdm_modem1_out>;
++					};
++				};
++			};
++
++			out-ports {
++				port {
++					tpda_modem_out: endpoint {
++						remote-endpoint = <&funnel_modem_dl_in0>;
++					};
++				};
++			};
++		};
++
++		funnel@10804000 {
++			compatible = "arm,coresight-dynamic-funnel", "arm,primecell";
++			reg = <0x0 0x10804000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			in-ports {
++				port {
++					funnel_modem_dl_in0: endpoint {
++						remote-endpoint = <&tpda_modem_out>;
++					};
++				};
++			};
++
++			out-ports {
++				port {
++					funnel_modem_dl_out: endpoint {
++						remote-endpoint = <&tn_ag_in13>;
++					};
++				};
++			};
++		};
++
++		cti@1080b000 {
++			compatible = "arm,coresight-cti", "arm,primecell";
++			reg = <0x0 0x1080b000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++		};
++
++		tpdm@1082c000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x1082c000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,dsb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_gcc_out: endpoint {
++						remote-endpoint = <&tn_ag_in17>;
++					};
++				};
++			};
++		};
++
++		tpdm@10841000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x10841000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_prng_out: endpoint {
++						remote-endpoint = <&tn_ag_in18>;
++					};
++				};
++			};
++		};
++
++		tpdm@1084e000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x1084e000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-element-bits = <32>;
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_mm_bcv_out: endpoint {
++						remote-endpoint = <&tpda_mm_in0>;
++					};
++				};
++			};
++		};
++
++		tpdm@1084f000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x1084f000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-element-bits = <32>;
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_mm_lmh_out: endpoint {
++						remote-endpoint = <&tpda_mm_in1>;
++					};
++				};
++			};
++		};
++
++		tpdm@10850000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x10850000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-element-bits = <64>;
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_mm_dpm_out: endpoint {
++						remote-endpoint = <&tpda_mm_in2>;
++					};
++				};
++			};
++		};
++
++		tpda@10851000 {
++			compatible = "qcom,coresight-tpda", "arm,primecell";
++			reg = <0x0 0x10851000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			in-ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					tpda_mm_in0: endpoint {
++						remote-endpoint = <&tpdm_mm_bcv_out>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					tpda_mm_in1: endpoint {
++						remote-endpoint = <&tpdm_mm_lmh_out>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					tpda_mm_in2: endpoint {
++						remote-endpoint = <&tpdm_mm_dpm_out>;
++					};
++				};
++			};
++
++			out-ports {
++				port {
++					tpda_mm_out: endpoint {
++						remote-endpoint = <&tn_ag_in4>;
++					};
++				};
++			};
++		};
++
++		tpdm@10980000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x10980000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,dsb-element-bits = <32>;
++			qcom,dsb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_cdsp_out: endpoint {
++						remote-endpoint = <&tpda_cdsp_in0>;
++					};
++				};
++			};
++		};
++
++		tpda@10986000 {
++			compatible = "qcom,coresight-tpda", "arm,primecell";
++			reg = <0x0 0x10986000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			in-ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					tpda_cdsp_in0: endpoint {
++						remote-endpoint = <&tpdm_cdsp_out>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					tpda_cdsp_in1: endpoint {
++						remote-endpoint = <&tpdm_cdsp_llm_out>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					tpda_cdsp_in2: endpoint {
++						remote-endpoint = <&tpdm_cdsp_llm2_out>;
++					};
++				};
++			};
++
++			out-ports {
++				port {
++					tpda_cdsp_out: endpoint {
++						remote-endpoint = <&funnel_cdsp_in0>;
++					};
++				};
++			};
++		};
++
++		funnel@10987000 {
++			compatible = "arm,coresight-dynamic-funnel", "arm,primecell";
++			reg = <0x0 0x10987000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			in-ports {
++				port {
++					funnel_cdsp_in0: endpoint {
++						remote-endpoint = <&tpda_cdsp_out>;
++					};
++				};
++			};
++
++			out-ports {
++				port {
++					funnel_cdsp_out: endpoint {
++						remote-endpoint = <&tn_ag_in16>;
++					};
++				};
++			};
++		};
++
++		cti@1098b000 {
++			compatible = "arm,coresight-cti", "arm,primecell";
++			reg = <0x0 0x1098b000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++		};
++
++		tpdm@109a3000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x109a3000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-msrs-num = <32>;
++			qcom,dsb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_pmu_out: endpoint {
++						remote-endpoint = <&tn_ag_in29>;
++					};
++				};
++			};
++		};
++
++		tpdm@109a4000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x109a4000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_ipcc_cmb_out: endpoint {
++						remote-endpoint = <&tn_ag_in28>;
++					};
++				};
++			};
++		};
++
++		tpdm@109a5000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x109a5000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,dsb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_dl_mm_out: endpoint {
++						remote-endpoint = <&tn_ag_in25>;
++					};
++				};
++			};
++		};
++
++		tpdm@109a6000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x109a6000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,dsb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_north_dsb_out: endpoint {
++						remote-endpoint = <&tn_ag_in26>;
++					};
++				};
++			};
++		};
++
++		tpdm@109a7000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x109a7000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,dsb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_south_dsb_out: endpoint {
++						remote-endpoint = <&tn_ag_in27>;
++					};
++				};
++			};
++		};
++
++		tpdm@109a8000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x109a8000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_rdpm_cmb0_out: endpoint {
++						remote-endpoint = <&tn_ag_in30>;
++					};
++				};
++			};
++		};
++
++		tpdm@109a9000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x109a9000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_rdpm_cmb1_out: endpoint {
++						remote-endpoint = <&tn_ag_in31>;
++					};
++				};
++			};
++		};
++
++		tpdm@109aa000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x109aa000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_rdpm_cmb2_out: endpoint {
++						remote-endpoint = <&tn_ag_in32>;
++					};
++				};
++			};
++		};
++
++		tn@109ab000 {
++			compatible = "qcom,coresight-tnoc", "arm,primecell";
++			reg = <0x0 0x109ab000 0x0 0x4200>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			in-ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@4 {
++					reg = <4>;
++
++					tn_ag_in4: endpoint {
++						remote-endpoint = <&tpda_mm_out>;
++					};
++				};
++
++				port@d {
++					reg = <0xd>;
++
++					tn_ag_in13: endpoint {
++						remote-endpoint = <&funnel_modem_dl_out>;
++					};
++				};
++
++				port@10 {
++					reg = <0x10>;
++
++					tn_ag_in16: endpoint {
++						remote-endpoint = <&funnel_cdsp_out>;
++					};
++				};
++
++				port@11 {
++					reg = <0x11>;
++
++					tn_ag_in17: endpoint {
++						remote-endpoint = <&tpdm_gcc_out>;
++					};
++				};
++
++				port@12 {
++					reg = <0x12>;
++
++					tn_ag_in18: endpoint {
++						remote-endpoint = <&tpdm_prng_out>;
++					};
++				};
++
++				port@13 {
++					reg = <0x13>;
++
++					tn_ag_in19: endpoint {
++						remote-endpoint = <&tpdm_qm_out>;
++					};
++				};
++
++				port@19 {
++					reg = <0x19>;
++
++					tn_ag_in25: endpoint {
++						remote-endpoint = <&tpdm_dl_mm_out>;
++					};
++				};
++
++				port@1a {
++					reg = <0x1a>;
++
++					tn_ag_in26: endpoint {
++						remote-endpoint = <&tpdm_north_dsb_out>;
++					};
++				};
++
++				port@1b {
++					reg = <0x1b>;
++
++					tn_ag_in27: endpoint {
++						remote-endpoint = <&tpdm_south_dsb_out>;
++					};
++				};
++
++				port@1c {
++					reg = <0x1c>;
++
++					tn_ag_in28: endpoint {
++						remote-endpoint = <&tpdm_ipcc_cmb_out>;
++					};
++				};
++
++				port@1d {
++					reg = <0x1d>;
++
++					tn_ag_in29: endpoint {
++						remote-endpoint = <&tpdm_pmu_out>;
++					};
++				};
++
++				port@1e {
++					reg = <0x1e>;
++
++					tn_ag_in30: endpoint {
++						remote-endpoint = <&tpdm_rdpm_cmb0_out>;
++					};
++				};
++
++				port@1f {
++					reg = <0x1f>;
++
++					tn_ag_in31: endpoint {
++						remote-endpoint = <&tpdm_rdpm_cmb1_out>;
++					};
++				};
++
++				port@20 {
++					reg = <0x20>;
++
++					tn_ag_in32: endpoint {
++						remote-endpoint = <&tpdm_rdpm_cmb2_out>;
++					};
++				};
++			};
++
++			out-ports {
++				port {
++					tn_ag_out: endpoint {
++						remote-endpoint = <&funnel_in0_in0>;
++					};
++				};
++			};
++		};
++
++		tpdm@109d0000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x109d0000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,dsb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_qm_out: endpoint {
++						remote-endpoint = <&tn_ag_in19>;
++					};
++				};
++			};
++		};
++
++		funnel@10b04000 {
++			compatible = "arm,coresight-dynamic-funnel", "arm,primecell";
++			reg = <0x0 0x10b04000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			in-ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@6 {
++					reg = <6>;
++
++					funnel_aoss_in6: endpoint {
++						remote-endpoint = <&tpda_aoss_out>;
++					};
++				};
++
++				port@7 {
++					reg = <7>;
++
++					funnel_aoss_in7: endpoint {
++						remote-endpoint = <&funnel_in0_out>;
++					};
++				};
++
++			};
++
++			out-ports {
++				port {
++					funnel_aoss_out: endpoint {
++						remote-endpoint = <&tmc_etf_in>;
++					};
++				};
++			};
++		};
++
++		tmc@10b05000 {
++			compatible = "arm,coresight-tmc", "arm,primecell";
++			reg = <0x0 0x10b05000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			in-ports {
++				port {
++					tmc_etf_in: endpoint {
++						remote-endpoint = <&funnel_aoss_out>;
++					};
++				};
++			};
++		};
++
++		tpda@10b08000 {
++			compatible = "qcom,coresight-tpda", "arm,primecell";
++			reg = <0x0 0x10b08000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			in-ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					tpda_aoss_in0: endpoint {
++						remote-endpoint = <&tpdm_swao_prio0_out>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					tpda_aoss_in1: endpoint {
++						remote-endpoint = <&tpdm_swao_prio1_out>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					tpda_aoss_in2: endpoint {
++						remote-endpoint = <&tpdm_swao_prio2_out>;
++					};
++				};
++
++				port@3 {
++					reg = <3>;
++
++					tpda_aoss_in3: endpoint {
++						remote-endpoint = <&tpdm_swao_prio3_out>;
++					};
++				};
++
++				port@4 {
++					reg = <4>;
++
++					tpda_aoss_in4: endpoint {
++						remote-endpoint =<&tpdm_swao_out>;
++					};
++				};
++			};
++
++			out-ports {
++				port {
++					tpda_aoss_out: endpoint {
++						remote-endpoint = <&funnel_aoss_in6>;
++					};
++				};
++			};
++		};
++
++		tpdm@10b09000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x10b09000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-element-bits = <64>;
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_swao_prio0_out: endpoint {
++						remote-endpoint = <&tpda_aoss_in0>;
++					};
++				};
++			};
++		};
++
++		tpdm@10b0a000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x10b0a000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-element-bits = <64>;
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_swao_prio1_out: endpoint {
++						remote-endpoint = <&tpda_aoss_in1>;
++					};
++				};
++			};
++		};
++
++		tpdm@10b0b000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x10b0b000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-element-bits = <64>;
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_swao_prio2_out: endpoint {
++						remote-endpoint = <&tpda_aoss_in2>;
++					};
++				};
++			};
++		};
++
++		tpdm@10b0c000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x10b0c000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,cmb-element-bits = <64>;
++			qcom,cmb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_swao_prio3_out: endpoint {
++						remote-endpoint = <&tpda_aoss_in3>;
++					};
++				};
++			};
++		};
++
++		tpdm@10b0d000 {
++			compatible = "qcom,coresight-tpdm", "arm,primecell";
++			reg = <0x0 0x10b0d000 0x0 0x1000>;
++
++			clocks = <&aoss_qmp>;
++			clock-names = "apb_pclk";
++
++			qcom,dsb-element-bits = <32>;
++			qcom,dsb-msrs-num = <32>;
++
++			out-ports {
++				port {
++					tpdm_swao_out: endpoint {
++						remote-endpoint = <&tpda_aoss_in4>;
++					};
++				};
++			};
++		};
++
++		adreno_smmu: iommu@3da0000 {
++			compatible = "qcom,sm8750-smmu-500", "qcom,adreno-smmu",
++				     "qcom,smmu-500", "arm,mmu-500";
++			reg = <0x0 0x03da0000 0x0 0x40000>;
++			#iommu-cells = <2>;
++			#global-interrupts = <1>;
++			interrupts = <GIC_SPI 674 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 678 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 679 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 680 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 681 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 682 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 683 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 684 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 685 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 686 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 687 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 688 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 422 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 476 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 574 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 575 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 576 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 577 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 660 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 662 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 665 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 666 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 667 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 669 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 670 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 700 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&gpucc GPU_CC_HLOS1_VOTE_GPU_SMMU_CLK>;
++			clock-names = "hlos";
++			power-domains = <&gpucc GPU_CC_CX_GDSC>;
++			dma-coherent;
++		};
++
++		apps_smmu: iommu@15000000 {
++			compatible = "qcom,sm8750-smmu-500", "qcom,smmu-500", "arm,mmu-500";
++			reg = <0x0 0x15000000 0x0 0x100000>;
++
++			interrupts = <GIC_SPI 65 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 97 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 98 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 99 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 100 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 101 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 102 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 103 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 104 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 105 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 106 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 107 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 108 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 109 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 110 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 111 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 112 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 113 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 114 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 115 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 116 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 117 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 118 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 181 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 182 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 183 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 184 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 185 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 186 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 187 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 188 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 189 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 190 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 191 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 192 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 315 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 316 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 317 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 318 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 319 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 320 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 321 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 322 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 323 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 324 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 325 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 326 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 327 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 328 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 329 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 330 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 331 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 332 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 333 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 334 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 335 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 336 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 337 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 338 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 339 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 340 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 341 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 342 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 343 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 344 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 345 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 395 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 396 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 397 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 398 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 399 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 400 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 401 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 402 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 403 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 404 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 405 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 406 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 407 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 408 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 409 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 418 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 419 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 412 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 421 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 707 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 423 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 424 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 425 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 690 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 691 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 692 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 693 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 694 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 695 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 696 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 697 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 410 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 488 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 489 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 490 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 491 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 492 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 493 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 494 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 495 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 496 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 497 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 498 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 499 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 500 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 501 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 502 IRQ_TYPE_LEVEL_HIGH>;
++
++			#iommu-cells = <2>;
++			#global-interrupts = <1>;
++
++			dma-coherent;
++		};
++
++		intc: interrupt-controller@16000000 {
++			compatible = "arm,gic-v3";
++			reg = <0x0 0x16000000 0x0 0x10000>,
++			      <0x0 0x16080000 0x0 0x200000>;
++
++			interrupts = <GIC_PPI 9 IRQ_TYPE_LEVEL_HIGH>;
++
++			#interrupt-cells = <3>;
++			interrupt-controller;
++
++			#redistributor-regions = <1>;
++			redistributor-stride = <0x0 0x40000>;
++
++			#address-cells = <2>;
++			#size-cells = <2>;
++			ranges;
++
++			gic_its: msi-controller@16040000 {
++				compatible = "arm,gic-v3-its";
++				reg = <0x0 0x16040000 0x0 0x40000>;
++
++				msi-controller;
++				#msi-cells = <1>;
++			};
++		};
++
++		pcie0: pcie@1c00000 {
++			device_type = "pci";
++			compatible = "qcom,pcie-sm8750", "qcom,pcie-sm8550";
++			reg = <0x0 0x01c00000 0x0 0x3000>,
++			      <0x0 0x40000000 0x0 0xf1d>,
++			      <0x0 0x40000f20 0x0 0xa8>,
++			      <0x0 0x40001000 0x0 0x1000>,
++			      <0x0 0x40100000 0x0 0x100000>,
++			      <0x0 0x01c03000 0x0 0x1000>;
++			reg-names = "parf",
++				    "dbi",
++				    "elbi",
++				    "atu",
++				    "config",
++				    "mhi";
++
++			#address-cells = <3>;
++			#size-cells = <2>;
++			ranges = <0x01000000 0x0 0x00000000 0x0 0x40200000 0x0 0x100000>,
++				 <0x02000000 0x0 0x40300000 0x0 0x40300000 0x0 0x23d00000>,
++				 <0x03000000 0x4 0x00000000 0x4 0x00000000 0x3 0x00000000>;
++			bus-range = <0x00 0xff>;
++
++			dma-coherent;
++
++			linux,pci-domain = <0>;
++
++			msi-map = <0x0 &gic_its 0x1400 0x1>,
++				  <0x100 &gic_its 0x1401 0x1>;
++			msi-map-mask = <0xff00>;
++
++			num-lanes = <2>;
++
++			interrupts = <GIC_SPI 141 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 142 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 143 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 144 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 145 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 146 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 147 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 148 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 140 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "msi0",
++					  "msi1",
++					  "msi2",
++					  "msi3",
++					  "msi4",
++					  "msi5",
++					  "msi6",
++					  "msi7",
++					  "global";
++
++			#interrupt-cells = <1>;
++			interrupt-map-mask = <0 0 0 0x7>;
++			interrupt-map = <0 0 0 1 &intc 0 0 0 149 IRQ_TYPE_LEVEL_HIGH>,
++					<0 0 0 2 &intc 0 0 0 150 IRQ_TYPE_LEVEL_HIGH>,
++					<0 0 0 3 &intc 0 0 0 151 IRQ_TYPE_LEVEL_HIGH>,
++					<0 0 0 4 &intc 0 0 0 152 IRQ_TYPE_LEVEL_HIGH>;
++
++			clocks = <&gcc GCC_PCIE_0_AUX_CLK>,
++				 <&gcc GCC_PCIE_0_CFG_AHB_CLK>,
++				 <&gcc GCC_PCIE_0_MSTR_AXI_CLK>,
++				 <&gcc GCC_PCIE_0_SLV_AXI_CLK>,
++				 <&gcc GCC_PCIE_0_SLV_Q2A_AXI_CLK>,
++				 <&gcc GCC_DDRSS_PCIE_SF_QTB_CLK>,
++				 <&gcc GCC_AGGRE_NOC_PCIE_AXI_CLK>,
++				 <&gcc GCC_CNOC_PCIE_SF_AXI_CLK>;
++			clock-names = "aux",
++				      "cfg",
++				      "bus_master",
++				      "bus_slave",
++				      "slave_q2a",
++				      "ddrss_sf_tbu",
++				      "noc_aggr",
++				      "cnoc_sf_axi";
++
++			interconnects = <&pcie_noc MASTER_PCIE_0 QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>,
++					<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
++					 &cnoc_main SLAVE_PCIE_0 QCOM_ICC_TAG_ALWAYS>;
++			interconnect-names = "pcie-mem",
++					     "cpu-pcie";
++
++			iommu-map = <0x0   &apps_smmu 0x1400 0x1>,
++				    <0x100 &apps_smmu 0x1401 0x1>;
++
++			resets = <&gcc GCC_PCIE_0_BCR>;
++			reset-names = "pci";
++
++			power-domains = <&gcc GCC_PCIE_0_GDSC>;
++
++			operating-points-v2 = <&pcie0_opp_table>;
++
++			status = "disabled";
++
++			pcie0_opp_table: opp-table {
++				compatible = "operating-points-v2";
++
++				/* GEN 1 x1 */
++				opp-2500000 {
++					opp-hz = /bits/ 64 <2500000>;
++					required-opps = <&rpmhpd_opp_low_svs>;
++					opp-peak-kBps = <250000 1>;
++				};
++
++				/* GEN 1 x2 and GEN 2 x1 */
++				opp-5000000 {
++					opp-hz = /bits/ 64 <5000000>;
++					required-opps = <&rpmhpd_opp_low_svs>;
++					opp-peak-kBps = <500000 1>;
++				};
++
++				/* GEN 2 x2 */
++				opp-10000000 {
++					opp-hz = /bits/ 64 <10000000>;
++					required-opps = <&rpmhpd_opp_low_svs>;
++					opp-peak-kBps = <1000000 1>;
++				};
++
++				/* GEN 3 x1 */
++				opp-8000000 {
++					opp-hz = /bits/ 64 <8000000>;
++					required-opps = <&rpmhpd_opp_nom>;
++					opp-peak-kBps = <984500 1>;
++				};
++
++				/* GEN 3 x2 */
++				opp-16000000 {
++					opp-hz = /bits/ 64 <16000000>;
++					required-opps = <&rpmhpd_opp_nom>;
++					opp-peak-kBps = <1969000 1>;
++				};
++
++			};
++
++			pcieport0: pcie@0 {
++				device_type = "pci";
++				reg = <0x0 0x0 0x0 0x0 0x0>;
++				bus-range = <0x01 0xff>;
++
++				#address-cells = <3>;
++				#size-cells = <2>;
++				ranges;
++				phys = <&pcie0_phy>;
++			};
++		};
++
++		pcie0_phy: phy@1c06000 {
++			compatible = "qcom,sm8750-qmp-gen3x2-pcie-phy";
++			reg = <0 0x01c06000 0 0x2000>;
++
++			clocks = <&gcc GCC_PCIE_0_AUX_CLK>,
++				 <&gcc GCC_PCIE_0_CFG_AHB_CLK>,
++				 <&tcsrcc TCSR_PCIE_0_CLKREF_EN>,
++				 <&gcc GCC_PCIE_0_PHY_RCHNG_CLK>,
++				 <&gcc GCC_PCIE_0_PIPE_CLK>;
++			clock-names = "aux",
++				      "cfg_ahb",
++				      "ref",
++				      "rchng",
++				      "pipe";
++
++			assigned-clocks = <&gcc GCC_PCIE_0_PHY_RCHNG_CLK>;
++			assigned-clock-rates = <100000000>;
++
++			resets = <&gcc GCC_PCIE_0_PHY_BCR>;
++			reset-names = "phy";
++
++			power-domains = <&gcc GCC_PCIE_0_PHY_GDSC>;
++
++			#clock-cells = <0>;
++			clock-output-names = "pcie0_pipe_clk";
++
++			#phy-cells = <0>;
++
++			status = "disabled";
++		};
++
++		ufs_mem_phy: phy@1d80000 {
++			compatible = "qcom,sm8750-qmp-ufs-phy";
++			reg = <0x0 0x01d80000 0x0 0x2000>;
++
++			clocks = <&rpmhcc RPMH_CXO_CLK>,
++				 <&gcc GCC_UFS_PHY_PHY_AUX_CLK>,
++				 <&tcsrcc TCSR_UFS_CLKREF_EN>;
++
++			clock-names = "ref",
++				      "ref_aux",
++				      "qref";
++
++			resets = <&ufs_mem_hc 0>;
++			reset-names = "ufsphy";
++
++			power-domains = <&gcc GCC_UFS_MEM_PHY_GDSC>;
++
++			#clock-cells = <1>;
++			#phy-cells = <0>;
++
++			status = "disabled";
++		};
++
++		ufs_mem_hc: ufs@1d84000 {
++			compatible = "qcom,sm8750-ufshc", "qcom,ufshc", "jedec,ufs-2.0";
++			reg = <0x0 0x01d84000 0x0 0x3000>;
++
++			interrupts = <GIC_SPI 265 IRQ_TYPE_LEVEL_HIGH>;
++
++			clocks = <&gcc GCC_UFS_PHY_AXI_CLK>,
++				 <&gcc GCC_AGGRE_UFS_PHY_AXI_CLK>,
++				 <&gcc GCC_UFS_PHY_AHB_CLK>,
++				 <&gcc GCC_UFS_PHY_UNIPRO_CORE_CLK>,
++				 <&rpmhcc RPMH_LN_BB_CLK3>,
++				 <&gcc GCC_UFS_PHY_TX_SYMBOL_0_CLK>,
++				 <&gcc GCC_UFS_PHY_RX_SYMBOL_0_CLK>,
++				 <&gcc GCC_UFS_PHY_RX_SYMBOL_1_CLK>;
++			clock-names = "core_clk",
++				      "bus_aggr_clk",
++				      "iface_clk",
++				      "core_clk_unipro",
++				      "ref_clk",
++				      "tx_lane0_sync_clk",
++				      "rx_lane0_sync_clk",
++				      "rx_lane1_sync_clk";
++
++			operating-points-v2 = <&ufs_opp_table>;
++
++			resets = <&gcc GCC_UFS_PHY_BCR>;
++			reset-names = "rst";
++
++			interconnects = <&aggre1_noc MASTER_UFS_MEM QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>,
++					<&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ACTIVE_ONLY
++					 &config_noc SLAVE_UFS_MEM_CFG QCOM_ICC_TAG_ACTIVE_ONLY>;
++			interconnect-names = "ufs-ddr",
++					     "cpu-ufs";
++
++			power-domains = <&gcc GCC_UFS_PHY_GDSC>;
++			required-opps = <&rpmhpd_opp_nom>;
++
++			iommus = <&apps_smmu 0x60 0>;
++			dma-coherent;
++
++			lanes-per-direction = <2>;
++
++			phys = <&ufs_mem_phy>;
++			phy-names = "ufsphy";
++
++			#reset-cells = <1>;
++
++			status = "disabled";
++
++			ufs_opp_table: opp-table {
++				compatible = "operating-points-v2";
++
++				opp-100000000 {
++					opp-hz = /bits/ 64 <100000000>,
++						 /bits/ 64 <0>,
++						 /bits/ 64 <0>,
++						 /bits/ 64 <100000000>,
++						 /bits/ 64 <0>,
++						 /bits/ 64 <0>,
++						 /bits/ 64 <0>,
++						 /bits/ 64 <0>;
++					required-opps = <&rpmhpd_opp_low_svs>;
++				};
++
++				opp-403000000 {
++					opp-hz = /bits/ 64 <403000000>,
++						 /bits/ 64 <0>,
++						 /bits/ 64 <0>,
++						 /bits/ 64 <403000000>,
++						 /bits/ 64 <0>,
++						 /bits/ 64 <0>,
++						 /bits/ 64 <0>,
++						 /bits/ 64 <0>;
++					required-opps = <&rpmhpd_opp_nom>;
++				};
++			};
++		};
++
++		cpucp_mbox: mailbox@16430000 {
++			compatible = "qcom,sm8750-cpucp-mbox", "qcom,x1e80100-cpucp-mbox";
++			reg = <0x0 0x16430000 0x0 0x8000>, <0x0 0x17830000 0x0 0x8000>;
++			interrupts = <GIC_SPI 26 IRQ_TYPE_LEVEL_HIGH>;
++			#mbox-cells = <1>;
++		};
++
++		apps_rsc: rsc@16500000 {
++			compatible = "qcom,rpmh-rsc";
++			reg = <0x0 0x16500000 0x0 0x10000>,
++			      <0x0 0x16510000 0x0 0x10000>,
++			      <0x0 0x16520000 0x0 0x10000>;
++			reg-names = "drv-0",
++				    "drv-1",
++				    "drv-2";
++
++			interrupts = <GIC_SPI 3 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 5 IRQ_TYPE_LEVEL_HIGH>;
++			qcom,tcs-offset = <0xd00>;
++			qcom,drv-id = <2>;
++			qcom,tcs-config = <ACTIVE_TCS    3>, <SLEEP_TCS     2>,
++					  <WAKE_TCS      2>, <CONTROL_TCS   0>;
++
++			label = "apps_rsc";
++
++			power-domains = <&system_pd>;
++
++			apps_bcm_voter: bcm-voter {
++				compatible = "qcom,bcm-voter";
++			};
++
++			rpmhcc: clock-controller {
++				compatible = "qcom,sm8750-rpmh-clk";
++
++				clocks = <&xo_board>;
++				clock-names = "xo";
++
++				#clock-cells = <1>;
++			};
++
++			rpmhpd: power-controller {
++				compatible = "qcom,sm8750-rpmhpd";
++
++				operating-points-v2 = <&rpmhpd_opp_table>;
++
++				#power-domain-cells = <1>;
++
++				rpmhpd_opp_table: opp-table {
++					compatible = "operating-points-v2";
++
++					rpmhpd_opp_ret: opp-16 {
++						opp-level = <RPMH_REGULATOR_LEVEL_RETENTION>;
++					};
++
++					rpmhpd_opp_min_svs: opp-48 {
++						opp-level = <RPMH_REGULATOR_LEVEL_MIN_SVS>;
++					};
++
++					rpmhpd_opp_low_svs_d3: opp-50 {
++						opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS_D3>;
++					};
++
++					rpmhpd_opp_low_svs_d2: opp-52 {
++						opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS_D2>;
++					};
++
++					rpmhpd_opp_low_svs_d1: opp-56 {
++						opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS_D1>;
++					};
++
++					rpmhpd_opp_low_svs_d0: opp-60 {
++						opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS_D0>;
++					};
++
++					rpmhpd_opp_low_svs: opp-64 {
++						opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS>;
++					};
++
++					rpmhpd_opp_low_svs_l1: opp-80 {
++						opp-level = <RPMH_REGULATOR_LEVEL_LOW_SVS_L1>;
++					};
++
++					rpmhpd_opp_svs: opp-128 {
++						opp-level = <RPMH_REGULATOR_LEVEL_SVS>;
++					};
++
++					rpmhpd_opp_svs_l0: opp-144 {
++						opp-level = <RPMH_REGULATOR_LEVEL_SVS_L0>;
++					};
++
++					rpmhpd_opp_svs_l1: opp-192 {
++						opp-level = <RPMH_REGULATOR_LEVEL_SVS_L1>;
++					};
++
++					rpmhpd_opp_svs_l2: opp-224 {
++						opp-level = <RPMH_REGULATOR_LEVEL_SVS_L2>;
++					};
++
++					rpmhpd_opp_nom: opp-256 {
++						opp-level = <RPMH_REGULATOR_LEVEL_NOM>;
++					};
++
++					rpmhpd_opp_nom_l1: opp-320 {
++						opp-level = <RPMH_REGULATOR_LEVEL_NOM_L1>;
++					};
++
++					rpmhpd_opp_nom_l2: opp-336 {
++						opp-level = <RPMH_REGULATOR_LEVEL_NOM_L2>;
++					};
++
++					rpmhpd_opp_turbo: opp-384 {
++						opp-level = <RPMH_REGULATOR_LEVEL_TURBO>;
++					};
++
++					rpmhpd_opp_turbo_l1: opp-416 {
++						opp-level = <RPMH_REGULATOR_LEVEL_TURBO_L1>;
++					};
++
++					rpmhpd_opp_turbo_l2: opp-432 {
++						opp-level = <RPMH_REGULATOR_LEVEL_TURBO_L2>;
++					};
++
++					rpmhpd_opp_turbo_l3: opp-448 {
++						opp-level = <RPMH_REGULATOR_LEVEL_TURBO_L3>;
++					};
++
++					rpmhpd_opp_turbo_l4: opp-452 {
++						opp-level = <RPMH_REGULATOR_LEVEL_TURBO_L4>;
++					};
++
++					rpmhpd_opp_super_turbo_no_cpr: opp-480 {
++						opp-level =
++							<RPMH_REGULATOR_LEVEL_SUPER_TURBO_NO_CPR>;
++					};
++				};
++			};
++		};
++
++		timer@16800000 {
++			compatible = "arm,armv7-timer-mem";
++			reg = <0x0 0x16800000 0x0 0x1000>;
++
++			#address-cells = <2>;
++			#size-cells = <1>;
++			ranges = <0 0 0 0 0x20000000>;
++
++			frame@16801000 {
++				reg = <0x0 0x16801000 0x1000>,
++				      <0x0 0x16802000 0x1000>;
++
++				interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL_HIGH>,
++					     <GIC_SPI 6 IRQ_TYPE_LEVEL_HIGH>;
++
++				frame-number = <0>;
++			};
++
++			frame@16803000 {
++				reg = <0x0 0x16803000 0x1000>;
++
++				interrupts = <GIC_SPI 9 IRQ_TYPE_LEVEL_HIGH>;
++
++				frame-number = <1>;
++
++				status = "disabled";
++			};
++
++			frame@16805000 {
++				reg = <0x0 0x16805000 0x1000>;
++
++				interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL_HIGH>;
++
++				frame-number = <2>;
++
++				status = "disabled";
++			};
++
++			frame@16807000 {
++				reg = <0x0 0x16807000 0x1000>;
++
++				interrupts = <GIC_SPI 11 IRQ_TYPE_LEVEL_HIGH>;
++
++				frame-number = <3>;
++
++				status = "disabled";
++			};
++
++			frame@16809000 {
++				reg = <0x0 0x16809000 0x1000>;
++
++				interrupts = <GIC_SPI 12 IRQ_TYPE_LEVEL_HIGH>;
++
++				frame-number = <4>;
++
++				status = "disabled";
++			};
++
++			frame@1680b000 {
++				reg = <0x0 0x1680b000 0x1000>;
++
++				interrupts = <GIC_SPI 13 IRQ_TYPE_LEVEL_HIGH>;
++
++				frame-number = <5>;
++
++				status = "disabled";
++			};
++
++			frame@1680d000 {
++				reg = <0x0 0x1680d000 0x1000>;
++
++				interrupts = <GIC_SPI 14 IRQ_TYPE_LEVEL_HIGH>;
++
++				frame-number = <6>;
++
++				status = "disabled";
++			};
++		};
++
++		sram: sram@17b4e000 {
++			compatible = "mmio-sram";
++			reg = <0x0 0x17b4e000 0x0 0x400>;
++
++			#address-cells = <1>;
++			#size-cells = <1>;
++			ranges = <0x0 0x0 0x17b4e000 0x400>;
++
++			cpu_scp_lpri0: scp-sram-section@0 {
++				compatible = "arm,scmi-shmem";
++				reg = <0x0 0x200>;
++			};
++
++			cpu_scp_lpri1: scp-sram-section@200 {
++				compatible = "arm,scmi-shmem";
++				reg = <0x200 0x200>;
++			};
++		};
++
++		/* cluster0 */
++		pmu@240b3400 {
++			compatible = "qcom,sm8750-cpu-bwmon", "qcom,sdm845-bwmon";
++			reg = <0x0 0x240b3400 0x0 0x600>;
++
++			interrupts = <GIC_SPI 581 IRQ_TYPE_LEVEL_HIGH>;
++
++			interconnects = <&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ACTIVE_ONLY
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ACTIVE_ONLY>;
++
++			operating-points-v2 = <&cpu_bwmon_opp_table>;
++
++			nonposted-mmio;
++
++			cpu_bwmon_opp_table: opp-table {
++				compatible = "operating-points-v2";
++
++				opp-0 {
++					opp-peak-kBps = <800000>;
++				};
++
++				opp-1 {
++					opp-peak-kBps = <2188000>;
++				};
++
++				opp-2 {
++					opp-peak-kBps = <5414400>;
++				};
++
++				opp-3 {
++					opp-peak-kBps = <6220800>;
++				};
++
++				opp-4 {
++					opp-peak-kBps = <6835200>;
++				};
++
++				opp-5 {
++					opp-peak-kBps = <8371200>;
++				};
++
++				opp-6 {
++					opp-peak-kBps = <10944000>;
++				};
++
++				opp-7 {
++					opp-peak-kBps = <12748800>;
++				};
++
++				opp-8 {
++					opp-peak-kBps = <14745600>;
++				};
++
++				opp-9 {
++					opp-peak-kBps = <16896000>;
++				};
++
++				opp-10 {
++					opp-peak-kBps = <19046400>;
++				};
++			};
++		};
++
++		/* cluster1 */
++		pmu@240b7400 {
++			compatible = "qcom,sm8750-cpu-bwmon", "qcom,sdm845-bwmon";
++			reg = <0x0 0x240b7400 0x0 0x600>;
++
++			interrupts = <GIC_SPI 581 IRQ_TYPE_LEVEL_HIGH>;
++
++			interconnects = <&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ACTIVE_ONLY
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ACTIVE_ONLY>;
++
++			operating-points-v2 = <&cpu_bwmon_opp_table>;
++		};
++
++		gem_noc: interconnect@24100000 {
++			compatible = "qcom,sm8750-gem-noc";
++			reg = <0x0 0x24100000 0x0 0x14b080>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++		};
++
++		system-cache-controller@24800000 {
++			compatible = "qcom,sm8750-llcc";
++			reg = <0x0 0x24800000 0x0 0x200000>,
++			      <0x0 0x25800000 0x0 0x200000>,
++			      <0x0 0x24c00000 0x0 0x200000>,
++			      <0x0 0x25c00000 0x0 0x200000>,
++			      <0x0 0x26800000 0x0 0x200000>,
++			      <0x0 0x26c00000 0x0 0x200000>;
++			reg-names = "llcc0_base",
++				    "llcc1_base",
++				    "llcc2_base",
++				    "llcc3_base",
++				    "llcc_broadcast_base",
++				    "llcc_broadcast_and_base";
++
++			interrupts = <GIC_SPI 266 IRQ_TYPE_LEVEL_HIGH>;
++		};
++
++		nsp_noc: interconnect@320c0000 {
++			compatible = "qcom,sm8750-nsp-noc";
++			reg = <0x0 0x320c0000 0x0 0x13080>;
++			qcom,bcm-voters = <&apps_bcm_voter>;
++			#interconnect-cells = <2>;
++		};
++
++		remoteproc_cdsp: remoteproc@32300000 {
++			compatible = "qcom,sm8750-cdsp-pas", "qcom,sm8650-cdsp-pas";
++			reg = <0x0 0x32300000 0x0 0x10000>;
++
++			interrupts-extended = <&intc GIC_SPI 578 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_cdsp_in 0 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_cdsp_in 1 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_cdsp_in 2 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_cdsp_in 3 IRQ_TYPE_EDGE_RISING>,
++					      <&smp2p_cdsp_in 7 IRQ_TYPE_EDGE_RISING>;
++			interrupt-names = "wdog",
++					  "fatal",
++					  "ready",
++					  "handover",
++					  "stop-ack",
++					  "shutdown-ack";
++
++			clocks = <&rpmhcc RPMH_CXO_CLK>;
++			clock-names = "xo";
++
++			interconnects = <&nsp_noc MASTER_CDSP_PROC QCOM_ICC_TAG_ALWAYS
++					 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
++
++			power-domains = <&rpmhpd RPMHPD_CX>,
++					<&rpmhpd RPMHPD_MXC>,
++					<&rpmhpd RPMHPD_NSP>;
++			power-domain-names = "cx",
++					     "mxc",
++					     "nsp";
++
++			memory-region = <&cdsp_mem>, <&q6_cdsp_dtb_mem>, <&global_sync_mem>;
++			qcom,qmp = <&aoss_qmp>;
++			qcom,smem-states = <&smp2p_cdsp_out 0>;
++			qcom,smem-state-names = "stop";
++
++			status = "disabled";
++
++			glink-edge {
++				interrupts-extended = <&ipcc IPCC_CLIENT_CDSP
++							     IPCC_MPROC_SIGNAL_GLINK_QMP
++							     IRQ_TYPE_EDGE_RISING>;
++				mboxes = <&ipcc IPCC_CLIENT_CDSP
++						IPCC_MPROC_SIGNAL_GLINK_QMP>;
++				qcom,remote-pid = <5>;
++				label = "cdsp";
++
++				fastrpc {
++					compatible = "qcom,fastrpc";
++					qcom,glink-channels = "fastrpcglink-apps-dsp";
++					label = "cdsp";
++					qcom,non-secure-domain;
++					#address-cells = <1>;
++					#size-cells = <0>;
++
++					compute-cb@1 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <1>;
++						iommus = <&apps_smmu 0x19c1 0x0>,
++							 <&apps_smmu 0x0c21 0x0>,
++							 <&apps_smmu 0x0c01 0x40>;
++						dma-coherent;
++					};
++
++					compute-cb@2 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <2>;
++						iommus = <&apps_smmu 0x1962 0x0>,
++							 <&apps_smmu 0x0c02 0x20>,
++							 <&apps_smmu 0x0c42 0x0>,
++							 <&apps_smmu 0x19c2 0x0>;
++						dma-coherent;
++					};
++
++					compute-cb@3 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <3>;
++						iommus = <&apps_smmu 0x1963 0x0>,
++							 <&apps_smmu 0x0c23 0x0>,
++							 <&apps_smmu 0x0c03 0x40>,
++							 <&apps_smmu 0x19c3 0x0>;
++						dma-coherent;
++					};
++
++					compute-cb@4 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <4>;
++						iommus = <&apps_smmu 0x1964 0x0>,
++							 <&apps_smmu 0x0c24 0x0>,
++							 <&apps_smmu 0x0c04 0x40>,
++							 <&apps_smmu 0x19c4 0x0>;
++						dma-coherent;
++					};
++
++					compute-cb@5 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <5>;
++						iommus = <&apps_smmu 0x1965 0x0>,
++							 <&apps_smmu 0x0c25 0x0>,
++							 <&apps_smmu 0x0c05 0x40>,
++							 <&apps_smmu 0x19c5 0x0>;
++						dma-coherent;
++					};
++
++					compute-cb@6 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <6>;
++						iommus = <&apps_smmu 0x1966 0x0>,
++							 <&apps_smmu 0x0c06 0x20>,
++							 <&apps_smmu 0x0c46 0x0>,
++							 <&apps_smmu 0x19c6 0x0>;
++						dma-coherent;
++					};
++
++					compute-cb@7 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <7>;
++						iommus = <&apps_smmu 0x1967 0x0>,
++							 <&apps_smmu 0x0c27 0x0>,
++							 <&apps_smmu 0x0c07 0x40>,
++							 <&apps_smmu 0x19c7 0x0>;
++						dma-coherent;
++					};
++
++					compute-cb@8 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <8>;
++						iommus = <&apps_smmu 0x1968 0x0>,
++							 <&apps_smmu 0x0c08 0x20>,
++							 <&apps_smmu 0x0c48 0x0>,
++							 <&apps_smmu 0x19c8 0x0>;
++						dma-coherent;
++					};
++
++					/* note: secure cb9 in downstream */
++
++					compute-cb@12 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <12>;
++						iommus = <&apps_smmu 0x196c 0x0>,
++							 <&apps_smmu 0x0c2c 0x20>,
++							 <&apps_smmu 0x0c0c 0x40>,
++							 <&apps_smmu 0x19cc 0x0>;
++						dma-coherent;
++					};
++
++					compute-cb@13 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <13>;
++						iommus = <&apps_smmu 0x196d 0x0>,
++							 <&apps_smmu 0x0c0d 0x20>,
++							 <&apps_smmu 0x0c2e 0x0>,
++							 <&apps_smmu 0x0c4d 0x0>,
++							 <&apps_smmu 0x19cd 0x0>;
++						dma-coherent;
++					};
++
++					compute-cb@14 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <14>;
++						iommus = <&apps_smmu 0x196e 0x0>,
++							 <&apps_smmu 0x0c0e 0x20>,
++							 <&apps_smmu 0x19ce 0x0>;
++						dma-coherent;
++					};
++				};
++			};
++		};
++	};
++
++	thermal-zones {
++		aoss0-thermal {
++			thermal-sensors = <&tsens0 0>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				aoss0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-0-0-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 1>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_0_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_0_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_0_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_0_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-0-0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-0-1-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 2>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_0_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_0_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_0_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_0_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-0-1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-1-0-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 3>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_1_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_1_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_1_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_1_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-1-0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-1-1-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 4>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_1_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_1_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_1_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_1_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-1-1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-2-0-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 5>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_2_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_2_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_2_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_2_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-2-0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-2-1-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 6>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_2_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_2_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_2_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_2_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-2-1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-3-0-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 7>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_3_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_3_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_3_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_3_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-3-0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-3-1-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 8>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_3_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_3_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_3_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_3_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-3-1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-4-0-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 9>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_4_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_4_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_4_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_4_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-4-0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-4-1-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 10>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_4_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_4_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_4_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_4_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-4-1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-5-0-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 11>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_5_0_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_5_0_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_5_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_5_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-5-0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-0-5-1-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens0 12>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_0_5_1_alert0>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_0_5_1_alert1>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_0_5_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_0_5_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-0-5-1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpuss-0-0-thermal {
++			thermal-sensors = <&tsens0 13>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpuss-0-0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpuss-0-1-thermal {
++			thermal-sensors = <&tsens0 14>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpuss-0-1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		aoss1-thermal {
++			thermal-sensors = <&tsens1 0>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				aoss1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-1-0-0-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens1 1>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_1_0_0_alert0>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_1_0_0_alert1>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_1_0_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_1_0_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-1-0-0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-1-0-1-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens1 2>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_1_0_1_alert0>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_1_0_1_alert1>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_1_0_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_1_0_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-1-0-1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-1-1-0-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens1 3>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_1_1_0_alert0>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_1_1_0_alert1>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_1_1_0_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_1_1_0_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-1-1-0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpu-1-1-1-thermal {
++			polling-delay-passive = <250>;
++
++			thermal-sensors = <&tsens1 4>;
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_1_1_1_alert0>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_1_1_1_alert1>;
++					cooling-device = <&cpu6 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu7 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++
++			trips {
++				cpu_1_1_1_alert0: trip-point0 {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_1_1_1_alert1: trip-point1 {
++					temperature = <95000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				trip-point2 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpu-1-1-1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpuss-1-0-thermal {
++			thermal-sensors = <&tsens1 5>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpuss-1-0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		cpuss-1-1-thermal {
++			thermal-sensors = <&tsens1 6>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				cpuss-1-1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		aoss2-thermal {
++			thermal-sensors = <&tsens2 0>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				aoss2-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		gpuss0-thermal {
++			thermal-sensors = <&tsens2 1>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				gpuss0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		gpuss1-thermal {
++			thermal-sensors = <&tsens2 2>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				gpuss1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		gpuss2-thermal {
++			thermal-sensors = <&tsens2 3>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				gpuss2-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		gpuss3-thermal {
++			thermal-sensors = <&tsens2 4>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				gpuss3-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		gpuss4-thermal {
++			thermal-sensors = <&tsens2 5>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				gpuss4-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		gpuss5-thermal {
++			thermal-sensors = <&tsens2 6>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				gpuss5-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		gpuss6-thermal {
++			thermal-sensors = <&tsens2 7>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				gpuss6-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		gpuss7-thermal {
++			thermal-sensors = <&tsens2 8>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				gpuss7-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		modem0-thermal {
++			thermal-sensors = <&tsens2 9>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				modem0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		modem1-thermal {
++			thermal-sensors = <&tsens2 10>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				modem1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		modem2-thermal {
++			thermal-sensors = <&tsens2 11>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				modem2-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		modem3-thermal {
++			thermal-sensors = <&tsens2 12>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				modem3-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		camera0-thermal {
++			thermal-sensors = <&tsens2 13>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				camera0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		camera1-thermal {
++			thermal-sensors = <&tsens2 14>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				camera1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		video-thermal {
++			thermal-sensors = <&tsens2 15>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				video-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		aoss3-thermal {
++			thermal-sensors = <&tsens3 0>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				aoss3-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		nsphvx0-thermal {
++			thermal-sensors = <&tsens3 1>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				nsphvx0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		nsphvx1-thermal {
++			thermal-sensors = <&tsens3 2>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				nsphvx1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		nsphvx2-thermal {
++			thermal-sensors = <&tsens3 3>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				nsphvx2-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		nsphmx0-thermal {
++			thermal-sensors = <&tsens3 4>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				nsphmx0-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		nsphmx1-thermal {
++			thermal-sensors = <&tsens3 5>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				nsphmx1-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		nsphmx2-thermal {
++			thermal-sensors = <&tsens3 6>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				nsphmx2-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		nsphmx3-thermal {
++			thermal-sensors = <&tsens3 7>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <5000>;
++					type = "hot";
++				};
++
++				nsphmx3-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++
++		ddr-thermal {
++			thermal-sensors = <&tsens3 8>;
++
++			trips {
++				trip-point0 {
++					temperature = <120000>;
++					hysteresis = <2000>;
++					type = "hot";
++				};
++
++				ddr-critical {
++					temperature = <125000>;
++					hysteresis = <0>;
++					type = "critical";
++				};
++			};
++		};
++	};
++
++	timer {
++		compatible = "arm,armv8-timer";
++
++		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL_LOW>,
++			     <GIC_PPI 14 IRQ_TYPE_LEVEL_LOW>,
++			     <GIC_PPI 11 IRQ_TYPE_LEVEL_LOW>,
++			     <GIC_PPI 10 IRQ_TYPE_LEVEL_LOW>;
++	};
++
++	tpdm-cdsp-llm {
++		compatible = "qcom,coresight-static-tpdm";
++		qcom,cmb-element-bits = <32>;
++
++		out-ports {
++			port {
++				tpdm_cdsp_llm_out: endpoint {
++					remote-endpoint = <&tpda_cdsp_in1>;
++				};
++			};
++		};
++	};
++
++	tpdm-cdsp-llm2 {
++		compatible = "qcom,coresight-static-tpdm";
++		qcom,cmb-element-bits = <32>;
++
++		out-ports {
++			port {
++				tpdm_cdsp_llm2_out: endpoint {
++					remote-endpoint = <&tpda_cdsp_in2>;
++				};
++			};
++		};
++	};
++
++	tpdm-modem1 {
++		compatible = "qcom,coresight-static-tpdm";
++		qcom,dsb-element-bits = <32>;
++
++		out-ports {
++			port {
++				tpdm_modem1_out: endpoint {
++					remote-endpoint = <&tpda_modem_in1>;
++				};
++			};
++		};
++	};
++};
+diff --git a/drivers/bluetooth/hci_qca.c.orig b/drivers/bluetooth/hci_qca.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/bluetooth/hci_qca.c.orig
+@@ -0,0 +1,2846 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ *  Bluetooth Software UART Qualcomm protocol
++ *
++ *  HCI_IBS (HCI In-Band Sleep) is Qualcomm's power management
++ *  protocol extension to H4.
++ *
++ *  Copyright (C) 2007 Texas Instruments, Inc.
++ *  Copyright (c) 2010, 2012, 2018 The Linux Foundation. All rights reserved.
++ *
++ *  Acknowledgements:
++ *  This file is based on hci_ll.c, which was...
++ *  Written by Ohad Ben-Cohen <ohad@bencohen.org>
++ *  which was in turn based on hci_h4.c, which was written
++ *  by Maxim Krasnyansky and Marcel Holtmann.
++ */
++
++#include <linux/kernel.h>
++#include <linux/clk.h>
++#include <linux/completion.h>
++#include <linux/debugfs.h>
++#include <linux/delay.h>
++#include <linux/devcoredump.h>
++#include <linux/device.h>
++#include <linux/gpio/consumer.h>
++#include <linux/mod_devicetable.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/acpi.h>
++#include <linux/platform_device.h>
++#include <linux/pwrseq/consumer.h>
++#include <linux/regulator/consumer.h>
++#include <linux/serdev.h>
++#include <linux/string_choices.h>
++#include <linux/mutex.h>
++#include <linux/unaligned.h>
++
++#include <net/bluetooth/bluetooth.h>
++#include <net/bluetooth/hci_core.h>
++
++#include "hci_uart.h"
++#include "btqca.h"
++
++/* HCI_IBS protocol messages */
++#define HCI_IBS_SLEEP_IND	0xFE
++#define HCI_IBS_WAKE_IND	0xFD
++#define HCI_IBS_WAKE_ACK	0xFC
++#define HCI_MAX_IBS_SIZE	10
++
++#define IBS_WAKE_RETRANS_TIMEOUT_MS	100
++#define IBS_BTSOC_TX_IDLE_TIMEOUT	msecs_to_jiffies(200)
++#define IBS_HOST_TX_IDLE_TIMEOUT_MS	2000
++#define CMD_TRANS_TIMEOUT		msecs_to_jiffies(100)
++#define MEMDUMP_TIMEOUT			msecs_to_jiffies(8000)
++#define FW_DOWNLOAD_TIMEOUT		msecs_to_jiffies(3000)
++#define IBS_DISABLE_SSR_TIMEOUT		(MEMDUMP_TIMEOUT + FW_DOWNLOAD_TIMEOUT)
++
++/* susclk rate */
++#define SUSCLK_RATE_32KHZ	32768
++
++/* Controller debug log header */
++#define QCA_DEBUG_HANDLE	0x2EDC
++
++/* max retry count when init fails */
++#define MAX_INIT_RETRIES 3
++
++/* Controller dump header */
++#define QCA_SSR_DUMP_HANDLE		0x0108
++#define QCA_DUMP_PACKET_SIZE		255
++#define QCA_LAST_SEQUENCE_NUM		0xFFFF
++#define QCA_CRASHBYTE_PACKET_LEN	1096
++#define QCA_MEMDUMP_BYTE		0xFB
++
++enum qca_flags {
++	QCA_IBS_DISABLED,
++	QCA_DROP_VENDOR_EVENT,
++	QCA_SUSPENDING,
++	QCA_MEMDUMP_COLLECTION,
++	QCA_HW_ERROR_EVENT,
++	QCA_SSR_TRIGGERED,
++	QCA_BT_OFF,
++	QCA_ROM_FW,
++	QCA_DEBUGFS_CREATED,
++};
++
++enum qca_capabilities {
++	QCA_CAP_WIDEBAND_SPEECH = BIT(0),
++	QCA_CAP_VALID_LE_STATES = BIT(1),
++	QCA_CAP_HFP_HW_OFFLOAD  = BIT(2),
++};
++
++/* HCI_IBS transmit side sleep protocol states */
++enum tx_ibs_states {
++	HCI_IBS_TX_ASLEEP,
++	HCI_IBS_TX_WAKING,
++	HCI_IBS_TX_AWAKE,
++};
++
++/* HCI_IBS receive side sleep protocol states */
++enum rx_states {
++	HCI_IBS_RX_ASLEEP,
++	HCI_IBS_RX_AWAKE,
++};
++
++/* HCI_IBS transmit and receive side clock state vote */
++enum hci_ibs_clock_state_vote {
++	HCI_IBS_VOTE_STATS_UPDATE,
++	HCI_IBS_TX_VOTE_CLOCK_ON,
++	HCI_IBS_TX_VOTE_CLOCK_OFF,
++	HCI_IBS_RX_VOTE_CLOCK_ON,
++	HCI_IBS_RX_VOTE_CLOCK_OFF,
++};
++
++/* Controller memory dump states */
++enum qca_memdump_states {
++	QCA_MEMDUMP_IDLE,
++	QCA_MEMDUMP_COLLECTING,
++	QCA_MEMDUMP_COLLECTED,
++	QCA_MEMDUMP_TIMEOUT,
++};
++
++struct qca_memdump_info {
++	u32 current_seq_no;
++	u32 received_dump;
++	u32 ram_dump_size;
++};
++
++struct qca_memdump_event_hdr {
++	__u8    evt;
++	__u8    plen;
++	__u16   opcode;
++	__le16   seq_no;
++	__u8    reserved;
++} __packed;
++
++
++struct qca_dump_size {
++	__le32 dump_size;
++} __packed;
++
++struct qca_data {
++	struct hci_uart *hu;
++	struct sk_buff *rx_skb;
++	struct sk_buff_head txq;
++	struct sk_buff_head tx_wait_q;	/* HCI_IBS wait queue	*/
++	struct sk_buff_head rx_memdump_q;	/* Memdump wait queue	*/
++	spinlock_t hci_ibs_lock;	/* HCI_IBS state lock	*/
++	u8 tx_ibs_state;	/* HCI_IBS transmit side power state*/
++	u8 rx_ibs_state;	/* HCI_IBS receive side power state */
++	bool tx_vote;		/* Clock must be on for TX */
++	bool rx_vote;		/* Clock must be on for RX */
++	struct timer_list tx_idle_timer;
++	u32 tx_idle_delay;
++	struct timer_list wake_retrans_timer;
++	u32 wake_retrans;
++	struct workqueue_struct *workqueue;
++	struct work_struct ws_awake_rx;
++	struct work_struct ws_awake_device;
++	struct work_struct ws_rx_vote_off;
++	struct work_struct ws_tx_vote_off;
++	struct work_struct ctrl_memdump_evt;
++	struct delayed_work ctrl_memdump_timeout;
++	struct qca_memdump_info *qca_memdump;
++	unsigned long flags;
++	struct completion drop_ev_comp;
++	wait_queue_head_t suspend_wait_q;
++	enum qca_memdump_states memdump_state;
++	struct mutex hci_memdump_lock;
++
++	u16 fw_version;
++	u16 controller_id;
++	/* For debugging purpose */
++	u64 ibs_sent_wacks;
++	u64 ibs_sent_slps;
++	u64 ibs_sent_wakes;
++	u64 ibs_recv_wacks;
++	u64 ibs_recv_slps;
++	u64 ibs_recv_wakes;
++	u64 vote_last_jif;
++	u32 vote_on_ms;
++	u32 vote_off_ms;
++	u64 tx_votes_on;
++	u64 rx_votes_on;
++	u64 tx_votes_off;
++	u64 rx_votes_off;
++	u64 votes_on;
++	u64 votes_off;
++};
++
++enum qca_speed_type {
++	QCA_INIT_SPEED = 1,
++	QCA_OPER_SPEED
++};
++
++/*
++ * Voltage regulator information required for configuring the
++ * QCA Bluetooth chipset
++ */
++struct qca_vreg {
++	const char *name;
++	unsigned int load_uA;
++};
++
++struct qca_device_data {
++	enum qca_btsoc_type soc_type;
++	struct qca_vreg *vregs;
++	size_t num_vregs;
++	uint32_t capabilities;
++};
++
++/*
++ * Platform data for the QCA Bluetooth power driver.
++ */
++struct qca_power {
++	struct device *dev;
++	struct regulator_bulk_data *vreg_bulk;
++	int num_vregs;
++	bool vregs_on;
++	struct pwrseq_desc *pwrseq;
++};
++
++struct qca_serdev {
++	struct hci_uart	 serdev_hu;
++	struct gpio_desc *bt_en;
++	struct gpio_desc *sw_ctrl;
++	struct clk	 *susclk;
++	enum qca_btsoc_type btsoc_type;
++	struct qca_power *bt_power;
++	u32 init_speed;
++	u32 oper_speed;
++	bool bdaddr_property_broken;
++	bool support_hfp_hw_offload;
++	const char *firmware_name[2];
++};
++
++static int qca_regulator_enable(struct qca_serdev *qcadev);
++static void qca_regulator_disable(struct qca_serdev *qcadev);
++static void qca_power_off(struct hci_uart *hu);
++static void qca_controller_memdump(struct work_struct *work);
++static void qca_dmp_hdr(struct hci_dev *hdev, struct sk_buff *skb);
++
++static enum qca_btsoc_type qca_soc_type(struct hci_uart *hu)
++{
++	enum qca_btsoc_type soc_type;
++
++	if (hu->serdev) {
++		struct qca_serdev *qsd = serdev_device_get_drvdata(hu->serdev);
++
++		soc_type = qsd->btsoc_type;
++	} else {
++		soc_type = QCA_ROME;
++	}
++
++	return soc_type;
++}
++
++static const char *qca_get_firmware_name(struct hci_uart *hu)
++{
++	if (hu->serdev) {
++		struct qca_serdev *qsd = serdev_device_get_drvdata(hu->serdev);
++
++		return qsd->firmware_name[0];
++	} else {
++		return NULL;
++	}
++}
++
++static const char *qca_get_rampatch_name(struct hci_uart *hu)
++{
++	if (hu->serdev) {
++		struct qca_serdev *qsd = serdev_device_get_drvdata(hu->serdev);
++
++		return qsd->firmware_name[1];
++	} else {
++		return NULL;
++	}
++}
++
++static void __serial_clock_on(struct tty_struct *tty)
++{
++	/* TODO: Some chipset requires to enable UART clock on client
++	 * side to save power consumption or manual work is required.
++	 * Please put your code to control UART clock here if needed
++	 */
++}
++
++static void __serial_clock_off(struct tty_struct *tty)
++{
++	/* TODO: Some chipset requires to disable UART clock on client
++	 * side to save power consumption or manual work is required.
++	 * Please put your code to control UART clock off here if needed
++	 */
++}
++
++/* serial_clock_vote needs to be called with the ibs lock held */
++static void serial_clock_vote(unsigned long vote, struct hci_uart *hu)
++{
++	struct qca_data *qca = hu->priv;
++	unsigned int diff;
++
++	bool old_vote = (qca->tx_vote | qca->rx_vote);
++	bool new_vote;
++
++	switch (vote) {
++	case HCI_IBS_VOTE_STATS_UPDATE:
++		diff = jiffies_to_msecs(jiffies - qca->vote_last_jif);
++
++		if (old_vote)
++			qca->vote_off_ms += diff;
++		else
++			qca->vote_on_ms += diff;
++		return;
++
++	case HCI_IBS_TX_VOTE_CLOCK_ON:
++		qca->tx_vote = true;
++		qca->tx_votes_on++;
++		break;
++
++	case HCI_IBS_RX_VOTE_CLOCK_ON:
++		qca->rx_vote = true;
++		qca->rx_votes_on++;
++		break;
++
++	case HCI_IBS_TX_VOTE_CLOCK_OFF:
++		qca->tx_vote = false;
++		qca->tx_votes_off++;
++		break;
++
++	case HCI_IBS_RX_VOTE_CLOCK_OFF:
++		qca->rx_vote = false;
++		qca->rx_votes_off++;
++		break;
++
++	default:
++		BT_ERR("Voting irregularity");
++		return;
++	}
++
++	new_vote = qca->rx_vote | qca->tx_vote;
++
++	if (new_vote != old_vote) {
++		if (new_vote)
++			__serial_clock_on(hu->tty);
++		else
++			__serial_clock_off(hu->tty);
++
++		BT_DBG("Vote serial clock %s(%s)", str_true_false(new_vote),
++		       str_true_false(vote));
++
++		diff = jiffies_to_msecs(jiffies - qca->vote_last_jif);
++
++		if (new_vote) {
++			qca->votes_on++;
++			qca->vote_off_ms += diff;
++		} else {
++			qca->votes_off++;
++			qca->vote_on_ms += diff;
++		}
++		qca->vote_last_jif = jiffies;
++	}
++}
++
++/* Builds and sends an HCI_IBS command packet.
++ * These are very simple packets with only 1 cmd byte.
++ */
++static int send_hci_ibs_cmd(u8 cmd, struct hci_uart *hu)
++{
++	int err = 0;
++	struct sk_buff *skb = NULL;
++	struct qca_data *qca = hu->priv;
++
++	BT_DBG("hu %p send hci ibs cmd 0x%x", hu, cmd);
++
++	skb = bt_skb_alloc(1, GFP_ATOMIC);
++	if (!skb) {
++		BT_ERR("Failed to allocate memory for HCI_IBS packet");
++		return -ENOMEM;
++	}
++
++	/* Assign HCI_IBS type */
++	skb_put_u8(skb, cmd);
++
++	skb_queue_tail(&qca->txq, skb);
++
++	return err;
++}
++
++static void qca_wq_awake_device(struct work_struct *work)
++{
++	struct qca_data *qca = container_of(work, struct qca_data,
++					    ws_awake_device);
++	struct hci_uart *hu = qca->hu;
++	unsigned long retrans_delay;
++	unsigned long flags;
++
++	BT_DBG("hu %p wq awake device", hu);
++
++	/* Vote for serial clock */
++	serial_clock_vote(HCI_IBS_TX_VOTE_CLOCK_ON, hu);
++
++	spin_lock_irqsave(&qca->hci_ibs_lock, flags);
++
++	/* Send wake indication to device */
++	if (send_hci_ibs_cmd(HCI_IBS_WAKE_IND, hu) < 0)
++		BT_ERR("Failed to send WAKE to device");
++
++	qca->ibs_sent_wakes++;
++
++	/* Start retransmit timer */
++	retrans_delay = msecs_to_jiffies(qca->wake_retrans);
++	mod_timer(&qca->wake_retrans_timer, jiffies + retrans_delay);
++
++	spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++
++	/* Actually send the packets */
++	hci_uart_tx_wakeup(hu);
++}
++
++static void qca_wq_awake_rx(struct work_struct *work)
++{
++	struct qca_data *qca = container_of(work, struct qca_data,
++					    ws_awake_rx);
++	struct hci_uart *hu = qca->hu;
++	unsigned long flags;
++
++	BT_DBG("hu %p wq awake rx", hu);
++
++	serial_clock_vote(HCI_IBS_RX_VOTE_CLOCK_ON, hu);
++
++	spin_lock_irqsave(&qca->hci_ibs_lock, flags);
++	qca->rx_ibs_state = HCI_IBS_RX_AWAKE;
++
++	/* Always acknowledge device wake up,
++	 * sending IBS message doesn't count as TX ON.
++	 */
++	if (send_hci_ibs_cmd(HCI_IBS_WAKE_ACK, hu) < 0)
++		BT_ERR("Failed to acknowledge device wake up");
++
++	qca->ibs_sent_wacks++;
++
++	spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++
++	/* Actually send the packets */
++	hci_uart_tx_wakeup(hu);
++}
++
++static void qca_wq_serial_rx_clock_vote_off(struct work_struct *work)
++{
++	struct qca_data *qca = container_of(work, struct qca_data,
++					    ws_rx_vote_off);
++	struct hci_uart *hu = qca->hu;
++
++	BT_DBG("hu %p rx clock vote off", hu);
++
++	serial_clock_vote(HCI_IBS_RX_VOTE_CLOCK_OFF, hu);
++}
++
++static void qca_wq_serial_tx_clock_vote_off(struct work_struct *work)
++{
++	struct qca_data *qca = container_of(work, struct qca_data,
++					    ws_tx_vote_off);
++	struct hci_uart *hu = qca->hu;
++
++	BT_DBG("hu %p tx clock vote off", hu);
++
++	/* Run HCI tx handling unlocked */
++	hci_uart_tx_wakeup(hu);
++
++	/* Now that message queued to tty driver, vote for tty clocks off.
++	 * It is up to the tty driver to pend the clocks off until tx done.
++	 */
++	serial_clock_vote(HCI_IBS_TX_VOTE_CLOCK_OFF, hu);
++}
++
++static void hci_ibs_tx_idle_timeout(struct timer_list *t)
++{
++	struct qca_data *qca = timer_container_of(qca, t, tx_idle_timer);
++	struct hci_uart *hu = qca->hu;
++	unsigned long flags;
++
++	BT_DBG("hu %p idle timeout in %d state", hu, qca->tx_ibs_state);
++
++	spin_lock_irqsave_nested(&qca->hci_ibs_lock,
++				 flags, SINGLE_DEPTH_NESTING);
++
++	switch (qca->tx_ibs_state) {
++	case HCI_IBS_TX_AWAKE:
++		/* TX_IDLE, go to SLEEP */
++		if (send_hci_ibs_cmd(HCI_IBS_SLEEP_IND, hu) < 0) {
++			BT_ERR("Failed to send SLEEP to device");
++			break;
++		}
++		qca->tx_ibs_state = HCI_IBS_TX_ASLEEP;
++		qca->ibs_sent_slps++;
++		queue_work(qca->workqueue, &qca->ws_tx_vote_off);
++		break;
++
++	case HCI_IBS_TX_ASLEEP:
++	case HCI_IBS_TX_WAKING:
++	default:
++		BT_ERR("Spurious timeout tx state %d", qca->tx_ibs_state);
++		break;
++	}
++
++	spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++}
++
++static void hci_ibs_wake_retrans_timeout(struct timer_list *t)
++{
++	struct qca_data *qca = timer_container_of(qca, t, wake_retrans_timer);
++	struct hci_uart *hu = qca->hu;
++	unsigned long flags, retrans_delay;
++	bool retransmit = false;
++
++	BT_DBG("hu %p wake retransmit timeout in %d state",
++		hu, qca->tx_ibs_state);
++
++	spin_lock_irqsave_nested(&qca->hci_ibs_lock,
++				 flags, SINGLE_DEPTH_NESTING);
++
++	/* Don't retransmit the HCI_IBS_WAKE_IND when suspending. */
++	if (test_bit(QCA_SUSPENDING, &qca->flags)) {
++		spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++		return;
++	}
++
++	switch (qca->tx_ibs_state) {
++	case HCI_IBS_TX_WAKING:
++		/* No WAKE_ACK, retransmit WAKE */
++		retransmit = true;
++		if (send_hci_ibs_cmd(HCI_IBS_WAKE_IND, hu) < 0) {
++			BT_ERR("Failed to acknowledge device wake up");
++			break;
++		}
++		qca->ibs_sent_wakes++;
++		retrans_delay = msecs_to_jiffies(qca->wake_retrans);
++		mod_timer(&qca->wake_retrans_timer, jiffies + retrans_delay);
++		break;
++
++	case HCI_IBS_TX_ASLEEP:
++	case HCI_IBS_TX_AWAKE:
++	default:
++		BT_ERR("Spurious timeout tx state %d", qca->tx_ibs_state);
++		break;
++	}
++
++	spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++
++	if (retransmit)
++		hci_uart_tx_wakeup(hu);
++}
++
++
++static void qca_controller_memdump_timeout(struct work_struct *work)
++{
++	struct qca_data *qca = container_of(work, struct qca_data,
++					ctrl_memdump_timeout.work);
++	struct hci_uart *hu = qca->hu;
++
++	mutex_lock(&qca->hci_memdump_lock);
++	if (test_bit(QCA_MEMDUMP_COLLECTION, &qca->flags)) {
++		qca->memdump_state = QCA_MEMDUMP_TIMEOUT;
++		if (!test_bit(QCA_HW_ERROR_EVENT, &qca->flags)) {
++			/* Inject hw error event to reset the device
++			 * and driver.
++			 */
++			hci_reset_dev(hu->hdev);
++		}
++	}
++
++	mutex_unlock(&qca->hci_memdump_lock);
++}
++
++
++/* Initialize protocol */
++static int qca_open(struct hci_uart *hu)
++{
++	struct qca_serdev *qcadev;
++	struct qca_data *qca;
++
++	BT_DBG("hu %p qca_open", hu);
++
++	if (!hci_uart_has_flow_control(hu))
++		return -EOPNOTSUPP;
++
++	qca = kzalloc_obj(*qca);
++	if (!qca)
++		return -ENOMEM;
++
++	skb_queue_head_init(&qca->txq);
++	skb_queue_head_init(&qca->tx_wait_q);
++	skb_queue_head_init(&qca->rx_memdump_q);
++	spin_lock_init(&qca->hci_ibs_lock);
++	mutex_init(&qca->hci_memdump_lock);
++	qca->workqueue = alloc_ordered_workqueue("qca_wq", 0);
++	if (!qca->workqueue) {
++		BT_ERR("QCA Workqueue not initialized properly");
++		kfree(qca);
++		return -ENOMEM;
++	}
++
++	INIT_WORK(&qca->ws_awake_rx, qca_wq_awake_rx);
++	INIT_WORK(&qca->ws_awake_device, qca_wq_awake_device);
++	INIT_WORK(&qca->ws_rx_vote_off, qca_wq_serial_rx_clock_vote_off);
++	INIT_WORK(&qca->ws_tx_vote_off, qca_wq_serial_tx_clock_vote_off);
++	INIT_WORK(&qca->ctrl_memdump_evt, qca_controller_memdump);
++	INIT_DELAYED_WORK(&qca->ctrl_memdump_timeout,
++			  qca_controller_memdump_timeout);
++	init_waitqueue_head(&qca->suspend_wait_q);
++
++	qca->hu = hu;
++	init_completion(&qca->drop_ev_comp);
++
++	/* Assume we start with both sides asleep -- extra wakes OK */
++	qca->tx_ibs_state = HCI_IBS_TX_ASLEEP;
++	qca->rx_ibs_state = HCI_IBS_RX_ASLEEP;
++
++	qca->vote_last_jif = jiffies;
++
++	hu->priv = qca;
++
++	if (hu->serdev) {
++		qcadev = serdev_device_get_drvdata(hu->serdev);
++
++		switch (qcadev->btsoc_type) {
++		case QCA_WCN3950:
++		case QCA_WCN3988:
++		case QCA_WCN3990:
++		case QCA_WCN3991:
++		case QCA_WCN3998:
++		case QCA_WCN6750:
++			hu->init_speed = qcadev->init_speed;
++			break;
++
++		default:
++			break;
++		}
++
++		if (qcadev->oper_speed)
++			hu->oper_speed = qcadev->oper_speed;
++	}
++
++	timer_setup(&qca->wake_retrans_timer, hci_ibs_wake_retrans_timeout, 0);
++	qca->wake_retrans = IBS_WAKE_RETRANS_TIMEOUT_MS;
++
++	timer_setup(&qca->tx_idle_timer, hci_ibs_tx_idle_timeout, 0);
++	qca->tx_idle_delay = IBS_HOST_TX_IDLE_TIMEOUT_MS;
++
++	BT_DBG("HCI_UART_QCA open, tx_idle_delay=%u, wake_retrans=%u",
++	       qca->tx_idle_delay, qca->wake_retrans);
++
++	return 0;
++}
++
++static void qca_debugfs_init(struct hci_dev *hdev)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++	struct qca_data *qca = hu->priv;
++	struct dentry *ibs_dir;
++	umode_t mode;
++
++	if (!hdev->debugfs)
++		return;
++
++	if (test_and_set_bit(QCA_DEBUGFS_CREATED, &qca->flags))
++		return;
++
++	ibs_dir = debugfs_create_dir("ibs", hdev->debugfs);
++
++	/* read only */
++	mode = 0444;
++	debugfs_create_u8("tx_ibs_state", mode, ibs_dir, &qca->tx_ibs_state);
++	debugfs_create_u8("rx_ibs_state", mode, ibs_dir, &qca->rx_ibs_state);
++	debugfs_create_u64("ibs_sent_sleeps", mode, ibs_dir,
++			   &qca->ibs_sent_slps);
++	debugfs_create_u64("ibs_sent_wakes", mode, ibs_dir,
++			   &qca->ibs_sent_wakes);
++	debugfs_create_u64("ibs_sent_wake_acks", mode, ibs_dir,
++			   &qca->ibs_sent_wacks);
++	debugfs_create_u64("ibs_recv_sleeps", mode, ibs_dir,
++			   &qca->ibs_recv_slps);
++	debugfs_create_u64("ibs_recv_wakes", mode, ibs_dir,
++			   &qca->ibs_recv_wakes);
++	debugfs_create_u64("ibs_recv_wake_acks", mode, ibs_dir,
++			   &qca->ibs_recv_wacks);
++	debugfs_create_bool("tx_vote", mode, ibs_dir, &qca->tx_vote);
++	debugfs_create_u64("tx_votes_on", mode, ibs_dir, &qca->tx_votes_on);
++	debugfs_create_u64("tx_votes_off", mode, ibs_dir, &qca->tx_votes_off);
++	debugfs_create_bool("rx_vote", mode, ibs_dir, &qca->rx_vote);
++	debugfs_create_u64("rx_votes_on", mode, ibs_dir, &qca->rx_votes_on);
++	debugfs_create_u64("rx_votes_off", mode, ibs_dir, &qca->rx_votes_off);
++	debugfs_create_u64("votes_on", mode, ibs_dir, &qca->votes_on);
++	debugfs_create_u64("votes_off", mode, ibs_dir, &qca->votes_off);
++	debugfs_create_u32("vote_on_ms", mode, ibs_dir, &qca->vote_on_ms);
++	debugfs_create_u32("vote_off_ms", mode, ibs_dir, &qca->vote_off_ms);
++
++	/* read/write */
++	mode = 0644;
++	debugfs_create_u32("wake_retrans", mode, ibs_dir, &qca->wake_retrans);
++	debugfs_create_u32("tx_idle_delay", mode, ibs_dir,
++			   &qca->tx_idle_delay);
++}
++
++/* Flush protocol data */
++static int qca_flush(struct hci_uart *hu)
++{
++	struct qca_data *qca = hu->priv;
++
++	BT_DBG("hu %p qca flush", hu);
++
++	skb_queue_purge(&qca->tx_wait_q);
++	skb_queue_purge(&qca->txq);
++
++	return 0;
++}
++
++/* Close protocol */
++static int qca_close(struct hci_uart *hu)
++{
++	struct qca_data *qca = hu->priv;
++
++	BT_DBG("hu %p qca close", hu);
++
++	/* BT core skips qca_hci_shutdown() which calls qca_power_off() on rmmod */
++	if (!test_bit(QCA_BT_OFF, &qca->flags))
++		qca_power_off(hu);
++
++	serial_clock_vote(HCI_IBS_VOTE_STATS_UPDATE, hu);
++
++	skb_queue_purge(&qca->tx_wait_q);
++	skb_queue_purge(&qca->txq);
++	skb_queue_purge(&qca->rx_memdump_q);
++	/*
++	 * Shut the timers down so they can't be rearmed when
++	 * destroy_workqueue() drains pending work which in turn might try
++	 * to arm a timer.  After shutdown rearm attempts are silently
++	 * ignored by the timer core code.
++	 */
++	timer_shutdown_sync(&qca->tx_idle_timer);
++	timer_shutdown_sync(&qca->wake_retrans_timer);
++	destroy_workqueue(qca->workqueue);
++	qca->hu = NULL;
++
++	kfree_skb(qca->rx_skb);
++
++	hu->priv = NULL;
++
++	kfree(qca);
++
++	return 0;
++}
++
++/* Called upon a wake-up-indication from the device.
++ */
++static void device_want_to_wakeup(struct hci_uart *hu)
++{
++	unsigned long flags;
++	struct qca_data *qca = hu->priv;
++
++	BT_DBG("hu %p want to wake up", hu);
++
++	spin_lock_irqsave(&qca->hci_ibs_lock, flags);
++
++	qca->ibs_recv_wakes++;
++
++	/* Don't wake the rx up when suspending. */
++	if (test_bit(QCA_SUSPENDING, &qca->flags)) {
++		spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++		return;
++	}
++
++	switch (qca->rx_ibs_state) {
++	case HCI_IBS_RX_ASLEEP:
++		/* Make sure clock is on - we may have turned clock off since
++		 * receiving the wake up indicator awake rx clock.
++		 */
++		queue_work(qca->workqueue, &qca->ws_awake_rx);
++		spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++		return;
++
++	case HCI_IBS_RX_AWAKE:
++		/* Always acknowledge device wake up,
++		 * sending IBS message doesn't count as TX ON.
++		 */
++		if (send_hci_ibs_cmd(HCI_IBS_WAKE_ACK, hu) < 0) {
++			BT_ERR("Failed to acknowledge device wake up");
++			break;
++		}
++		qca->ibs_sent_wacks++;
++		break;
++
++	default:
++		/* Any other state is illegal */
++		BT_ERR("Received HCI_IBS_WAKE_IND in rx state %d",
++		       qca->rx_ibs_state);
++		break;
++	}
++
++	spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++
++	/* Actually send the packets */
++	hci_uart_tx_wakeup(hu);
++}
++
++/* Called upon a sleep-indication from the device.
++ */
++static void device_want_to_sleep(struct hci_uart *hu)
++{
++	unsigned long flags;
++	struct qca_data *qca = hu->priv;
++
++	BT_DBG("hu %p want to sleep in %d state", hu, qca->rx_ibs_state);
++
++	spin_lock_irqsave(&qca->hci_ibs_lock, flags);
++
++	qca->ibs_recv_slps++;
++
++	switch (qca->rx_ibs_state) {
++	case HCI_IBS_RX_AWAKE:
++		/* Update state */
++		qca->rx_ibs_state = HCI_IBS_RX_ASLEEP;
++		/* Vote off rx clock under workqueue */
++		queue_work(qca->workqueue, &qca->ws_rx_vote_off);
++		break;
++
++	case HCI_IBS_RX_ASLEEP:
++		break;
++
++	default:
++		/* Any other state is illegal */
++		BT_ERR("Received HCI_IBS_SLEEP_IND in rx state %d",
++		       qca->rx_ibs_state);
++		break;
++	}
++
++	wake_up_interruptible(&qca->suspend_wait_q);
++
++	spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++}
++
++/* Called upon wake-up-acknowledgement from the device
++ */
++static void device_woke_up(struct hci_uart *hu)
++{
++	unsigned long flags, idle_delay;
++	struct qca_data *qca = hu->priv;
++	struct sk_buff *skb = NULL;
++
++	BT_DBG("hu %p woke up", hu);
++
++	spin_lock_irqsave(&qca->hci_ibs_lock, flags);
++
++	qca->ibs_recv_wacks++;
++
++	/* Don't react to the wake-up-acknowledgment when suspending. */
++	if (test_bit(QCA_SUSPENDING, &qca->flags)) {
++		spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++		return;
++	}
++
++	switch (qca->tx_ibs_state) {
++	case HCI_IBS_TX_AWAKE:
++		/* Expect one if we send 2 WAKEs */
++		BT_DBG("Received HCI_IBS_WAKE_ACK in tx state %d",
++		       qca->tx_ibs_state);
++		break;
++
++	case HCI_IBS_TX_WAKING:
++		/* Send pending packets */
++		while ((skb = skb_dequeue(&qca->tx_wait_q)))
++			skb_queue_tail(&qca->txq, skb);
++
++		/* Switch timers and change state to HCI_IBS_TX_AWAKE */
++		timer_delete(&qca->wake_retrans_timer);
++		idle_delay = msecs_to_jiffies(qca->tx_idle_delay);
++		mod_timer(&qca->tx_idle_timer, jiffies + idle_delay);
++		qca->tx_ibs_state = HCI_IBS_TX_AWAKE;
++		break;
++
++	case HCI_IBS_TX_ASLEEP:
++	default:
++		BT_ERR("Received HCI_IBS_WAKE_ACK in tx state %d",
++		       qca->tx_ibs_state);
++		break;
++	}
++
++	spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++
++	/* Actually send the packets */
++	hci_uart_tx_wakeup(hu);
++}
++
++/* Enqueue frame for transmission (padding, crc, etc) may be called from
++ * two simultaneous tasklets.
++ */
++static int qca_enqueue(struct hci_uart *hu, struct sk_buff *skb)
++{
++	unsigned long flags = 0, idle_delay;
++	struct qca_data *qca = hu->priv;
++
++	BT_DBG("hu %p qca enq skb %p tx_ibs_state %d", hu, skb,
++	       qca->tx_ibs_state);
++
++	if (test_bit(QCA_SSR_TRIGGERED, &qca->flags)) {
++		/* As SSR is in progress, ignore the packets */
++		bt_dev_dbg(hu->hdev, "SSR is in progress");
++		kfree_skb(skb);
++		return 0;
++	}
++
++	/* Prepend skb with frame type */
++	memcpy(skb_push(skb, 1), &hci_skb_pkt_type(skb), 1);
++
++	spin_lock_irqsave(&qca->hci_ibs_lock, flags);
++
++	/* Don't go to sleep in middle of patch download or
++	 * Out-Of-Band(GPIOs control) sleep is selected.
++	 * Don't wake the device up when suspending.
++	 */
++	if (test_bit(QCA_IBS_DISABLED, &qca->flags) ||
++	    test_bit(QCA_SUSPENDING, &qca->flags)) {
++		skb_queue_tail(&qca->txq, skb);
++		spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++		return 0;
++	}
++
++	/* Act according to current state */
++	switch (qca->tx_ibs_state) {
++	case HCI_IBS_TX_AWAKE:
++		BT_DBG("Device awake, sending normally");
++		skb_queue_tail(&qca->txq, skb);
++		idle_delay = msecs_to_jiffies(qca->tx_idle_delay);
++		mod_timer(&qca->tx_idle_timer, jiffies + idle_delay);
++		break;
++
++	case HCI_IBS_TX_ASLEEP:
++		BT_DBG("Device asleep, waking up and queueing packet");
++		/* Save packet for later */
++		skb_queue_tail(&qca->tx_wait_q, skb);
++
++		qca->tx_ibs_state = HCI_IBS_TX_WAKING;
++		/* Schedule a work queue to wake up device */
++		queue_work(qca->workqueue, &qca->ws_awake_device);
++		break;
++
++	case HCI_IBS_TX_WAKING:
++		BT_DBG("Device waking up, queueing packet");
++		/* Transient state; just keep packet for later */
++		skb_queue_tail(&qca->tx_wait_q, skb);
++		break;
++
++	default:
++		BT_ERR("Illegal tx state: %d (losing packet)",
++		       qca->tx_ibs_state);
++		dev_kfree_skb_irq(skb);
++		break;
++	}
++
++	spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++
++	return 0;
++}
++
++static int qca_ibs_sleep_ind(struct hci_dev *hdev, struct sk_buff *skb)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++
++	BT_DBG("hu %p recv hci ibs cmd 0x%x", hu, HCI_IBS_SLEEP_IND);
++
++	device_want_to_sleep(hu);
++
++	kfree_skb(skb);
++	return 0;
++}
++
++static int qca_ibs_wake_ind(struct hci_dev *hdev, struct sk_buff *skb)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++
++	BT_DBG("hu %p recv hci ibs cmd 0x%x", hu, HCI_IBS_WAKE_IND);
++
++	device_want_to_wakeup(hu);
++
++	kfree_skb(skb);
++	return 0;
++}
++
++static int qca_ibs_wake_ack(struct hci_dev *hdev, struct sk_buff *skb)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++
++	BT_DBG("hu %p recv hci ibs cmd 0x%x", hu, HCI_IBS_WAKE_ACK);
++
++	device_woke_up(hu);
++
++	kfree_skb(skb);
++	return 0;
++}
++
++static int qca_recv_acl_data(struct hci_dev *hdev, struct sk_buff *skb)
++{
++	/* We receive debug logs from chip as an ACL packets.
++	 * Instead of sending the data to ACL to decode the
++	 * received data, we are pushing them to the above layers
++	 * as a diagnostic packet.
++	 */
++	if (get_unaligned_le16(skb->data) == QCA_DEBUG_HANDLE)
++		return hci_recv_diag(hdev, skb);
++
++	return hci_recv_frame(hdev, skb);
++}
++
++static void qca_dmp_hdr(struct hci_dev *hdev, struct sk_buff *skb)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++	struct qca_data *qca = hu->priv;
++	char buf[80];
++
++	snprintf(buf, sizeof(buf), "Controller Name: 0x%x\n",
++		qca->controller_id);
++	skb_put_data(skb, buf, strlen(buf));
++
++	snprintf(buf, sizeof(buf), "Firmware Version: 0x%x\n",
++		qca->fw_version);
++	skb_put_data(skb, buf, strlen(buf));
++
++	snprintf(buf, sizeof(buf), "Vendor:Qualcomm\n");
++	skb_put_data(skb, buf, strlen(buf));
++
++	snprintf(buf, sizeof(buf), "Driver: %s\n",
++		 hu->serdev ? hu->serdev->dev.driver->name : "hci_ldisc_qca");
++	skb_put_data(skb, buf, strlen(buf));
++}
++
++static void qca_controller_memdump(struct work_struct *work)
++{
++	struct qca_data *qca = container_of(work, struct qca_data,
++					    ctrl_memdump_evt);
++	struct hci_uart *hu = qca->hu;
++	struct sk_buff *skb;
++	struct qca_memdump_event_hdr *cmd_hdr;
++	struct qca_memdump_info *qca_memdump = qca->qca_memdump;
++	struct qca_dump_size *dump;
++	u16 seq_no;
++	u32 rx_size;
++	int ret = 0;
++	enum qca_btsoc_type soc_type = qca_soc_type(hu);
++
++	while ((skb = skb_dequeue(&qca->rx_memdump_q))) {
++
++		mutex_lock(&qca->hci_memdump_lock);
++		/* Skip processing the received packets if timeout detected
++		 * or memdump collection completed.
++		 */
++		if (qca->memdump_state == QCA_MEMDUMP_TIMEOUT ||
++		    qca->memdump_state == QCA_MEMDUMP_COLLECTED) {
++			mutex_unlock(&qca->hci_memdump_lock);
++			return;
++		}
++
++		if (!qca_memdump) {
++			qca_memdump = kzalloc_obj(*qca_memdump, GFP_ATOMIC);
++			if (!qca_memdump) {
++				mutex_unlock(&qca->hci_memdump_lock);
++				return;
++			}
++
++			qca->qca_memdump = qca_memdump;
++		}
++
++		qca->memdump_state = QCA_MEMDUMP_COLLECTING;
++		cmd_hdr = (void *) skb->data;
++		seq_no = __le16_to_cpu(cmd_hdr->seq_no);
++		skb_pull(skb, sizeof(struct qca_memdump_event_hdr));
++
++		if (!seq_no) {
++
++			/* This is the first frame of memdump packet from
++			 * the controller, Disable IBS to receive dump
++			 * with out any interruption, ideally time required for
++			 * the controller to send the dump is 8 seconds. let us
++			 * start timer to handle this asynchronous activity.
++			 */
++			set_bit(QCA_IBS_DISABLED, &qca->flags);
++			set_bit(QCA_MEMDUMP_COLLECTION, &qca->flags);
++			dump = (void *) skb->data;
++			qca_memdump->ram_dump_size = __le32_to_cpu(dump->dump_size);
++			if (!(qca_memdump->ram_dump_size)) {
++				bt_dev_err(hu->hdev, "Rx invalid memdump size");
++				kfree(qca_memdump);
++				qca->qca_memdump = NULL;
++				qca->memdump_state = QCA_MEMDUMP_COLLECTED;
++				clear_and_wake_up_bit(QCA_MEMDUMP_COLLECTION, &qca->flags);
++				clear_bit(QCA_IBS_DISABLED, &qca->flags);
++				kfree_skb(skb);
++				mutex_unlock(&qca->hci_memdump_lock);
++				return;
++			}
++
++			queue_delayed_work(qca->workqueue,
++					   &qca->ctrl_memdump_timeout,
++					   MEMDUMP_TIMEOUT);
++			skb_pull(skb, sizeof(qca_memdump->ram_dump_size));
++			qca_memdump->current_seq_no = 0;
++			qca_memdump->received_dump = 0;
++			ret = hci_devcd_init(hu->hdev, qca_memdump->ram_dump_size);
++			bt_dev_info(hu->hdev, "hci_devcd_init Return:%d",
++				    ret);
++			if (ret < 0) {
++				kfree(qca->qca_memdump);
++				qca->qca_memdump = NULL;
++				qca->memdump_state = QCA_MEMDUMP_COLLECTED;
++				cancel_delayed_work(&qca->ctrl_memdump_timeout);
++				clear_and_wake_up_bit(QCA_MEMDUMP_COLLECTION, &qca->flags);
++				clear_bit(QCA_IBS_DISABLED, &qca->flags);
++				mutex_unlock(&qca->hci_memdump_lock);
++				return;
++			}
++
++			bt_dev_info(hu->hdev, "QCA collecting dump of size:%u",
++				    qca_memdump->ram_dump_size);
++
++		}
++
++		/* If sequence no 0 is missed then there is no point in
++		 * accepting the other sequences.
++		 */
++		if (!test_bit(QCA_MEMDUMP_COLLECTION, &qca->flags)) {
++			bt_dev_err(hu->hdev, "QCA: Discarding other packets");
++			kfree(qca_memdump);
++			kfree_skb(skb);
++			mutex_unlock(&qca->hci_memdump_lock);
++			return;
++		}
++		/* There could be chance of missing some packets from
++		 * the controller. In such cases let us store the dummy
++		 * packets in the buffer.
++		 */
++		/* For QCA6390, controller does not lost packets but
++		 * sequence number field of packet sometimes has error
++		 * bits, so skip this checking for missing packet.
++		 */
++		while ((seq_no > qca_memdump->current_seq_no + 1) &&
++			(soc_type != QCA_QCA6390) &&
++			seq_no != QCA_LAST_SEQUENCE_NUM) {
++			bt_dev_err(hu->hdev, "QCA controller missed packet:%d",
++				   qca_memdump->current_seq_no);
++			rx_size = qca_memdump->received_dump;
++			rx_size += QCA_DUMP_PACKET_SIZE;
++			if (rx_size > qca_memdump->ram_dump_size) {
++				bt_dev_err(hu->hdev,
++					   "QCA memdump received %d, no space for missed packet",
++					   qca_memdump->received_dump);
++				break;
++			}
++			hci_devcd_append_pattern(hu->hdev, 0x00,
++				QCA_DUMP_PACKET_SIZE);
++			qca_memdump->received_dump += QCA_DUMP_PACKET_SIZE;
++			qca_memdump->current_seq_no++;
++		}
++
++		rx_size = qca_memdump->received_dump  + skb->len;
++		if (rx_size <= qca_memdump->ram_dump_size) {
++			if ((seq_no != QCA_LAST_SEQUENCE_NUM) &&
++			    (seq_no != qca_memdump->current_seq_no)) {
++				bt_dev_err(hu->hdev,
++					   "QCA memdump unexpected packet %d",
++					   seq_no);
++			}
++			bt_dev_dbg(hu->hdev,
++				   "QCA memdump packet %d with length %d",
++				   seq_no, skb->len);
++			hci_devcd_append(hu->hdev, skb);
++			qca_memdump->current_seq_no += 1;
++			qca_memdump->received_dump = rx_size;
++		} else {
++			bt_dev_err(hu->hdev,
++				   "QCA memdump received no space for packet %d",
++				    qca_memdump->current_seq_no);
++		}
++
++		if (seq_no == QCA_LAST_SEQUENCE_NUM) {
++			bt_dev_info(hu->hdev,
++				"QCA memdump Done, received %d, total %d",
++				qca_memdump->received_dump,
++				qca_memdump->ram_dump_size);
++			hci_devcd_complete(hu->hdev);
++			cancel_delayed_work(&qca->ctrl_memdump_timeout);
++			kfree(qca->qca_memdump);
++			qca->qca_memdump = NULL;
++			qca->memdump_state = QCA_MEMDUMP_COLLECTED;
++			clear_and_wake_up_bit(QCA_MEMDUMP_COLLECTION, &qca->flags);
++		}
++
++		mutex_unlock(&qca->hci_memdump_lock);
++	}
++
++}
++
++static int qca_controller_memdump_event(struct hci_dev *hdev,
++					struct sk_buff *skb)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++	struct qca_data *qca = hu->priv;
++
++	set_bit(QCA_SSR_TRIGGERED, &qca->flags);
++	skb_queue_tail(&qca->rx_memdump_q, skb);
++	queue_work(qca->workqueue, &qca->ctrl_memdump_evt);
++
++	return 0;
++}
++
++static int qca_recv_event(struct hci_dev *hdev, struct sk_buff *skb)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++	struct qca_data *qca = hu->priv;
++
++	if (test_bit(QCA_DROP_VENDOR_EVENT, &qca->flags)) {
++		struct hci_event_hdr *hdr = (void *)skb->data;
++
++		/* For the WCN3990 the vendor command for a baudrate change
++		 * isn't sent as synchronous HCI command, because the
++		 * controller sends the corresponding vendor event with the
++		 * new baudrate. The event is received and properly decoded
++		 * after changing the baudrate of the host port. It needs to
++		 * be dropped, otherwise it can be misinterpreted as
++		 * response to a later firmware download command (also a
++		 * vendor command).
++		 */
++
++		if (hdr->evt == HCI_EV_VENDOR)
++			complete(&qca->drop_ev_comp);
++
++		kfree_skb(skb);
++
++		return 0;
++	}
++	/* We receive chip memory dump as an event packet, With a dedicated
++	 * handler followed by a hardware error event. When this event is
++	 * received we store dump into a file before closing hci. This
++	 * dump will help in triaging the issues.
++	 */
++	if ((skb->data[0] == HCI_VENDOR_PKT) &&
++	    (get_unaligned_be16(skb->data + 2) == QCA_SSR_DUMP_HANDLE))
++		return qca_controller_memdump_event(hdev, skb);
++
++	return hci_recv_frame(hdev, skb);
++}
++
++#define QCA_IBS_SLEEP_IND_EVENT \
++	.type = HCI_IBS_SLEEP_IND, \
++	.hlen = 0, \
++	.loff = 0, \
++	.lsize = 0, \
++	.maxlen = HCI_MAX_IBS_SIZE
++
++#define QCA_IBS_WAKE_IND_EVENT \
++	.type = HCI_IBS_WAKE_IND, \
++	.hlen = 0, \
++	.loff = 0, \
++	.lsize = 0, \
++	.maxlen = HCI_MAX_IBS_SIZE
++
++#define QCA_IBS_WAKE_ACK_EVENT \
++	.type = HCI_IBS_WAKE_ACK, \
++	.hlen = 0, \
++	.loff = 0, \
++	.lsize = 0, \
++	.maxlen = HCI_MAX_IBS_SIZE
++
++static const struct h4_recv_pkt qca_recv_pkts[] = {
++	{ H4_RECV_ACL,             .recv = qca_recv_acl_data },
++	{ H4_RECV_SCO,             .recv = hci_recv_frame    },
++	{ H4_RECV_EVENT,           .recv = qca_recv_event    },
++	{ H4_RECV_ISO,             .recv = hci_recv_frame    },
++	{ QCA_IBS_WAKE_IND_EVENT,  .recv = qca_ibs_wake_ind  },
++	{ QCA_IBS_WAKE_ACK_EVENT,  .recv = qca_ibs_wake_ack  },
++	{ QCA_IBS_SLEEP_IND_EVENT, .recv = qca_ibs_sleep_ind },
++};
++
++static int qca_recv(struct hci_uart *hu, const void *data, int count)
++{
++	struct qca_data *qca = hu->priv;
++
++	if (!test_bit(HCI_UART_REGISTERED, &hu->flags))
++		return -EUNATCH;
++
++	qca->rx_skb = h4_recv_buf(hu, qca->rx_skb, data, count,
++				  qca_recv_pkts, ARRAY_SIZE(qca_recv_pkts));
++	if (IS_ERR(qca->rx_skb)) {
++		int err = PTR_ERR(qca->rx_skb);
++		bt_dev_err(hu->hdev, "Frame reassembly failed (%d)", err);
++		qca->rx_skb = NULL;
++		return err;
++	}
++
++	return count;
++}
++
++static struct sk_buff *qca_dequeue(struct hci_uart *hu)
++{
++	struct qca_data *qca = hu->priv;
++
++	return skb_dequeue(&qca->txq);
++}
++
++static uint8_t qca_get_baudrate_value(int speed)
++{
++	switch (speed) {
++	case 9600:
++		return QCA_BAUDRATE_9600;
++	case 19200:
++		return QCA_BAUDRATE_19200;
++	case 38400:
++		return QCA_BAUDRATE_38400;
++	case 57600:
++		return QCA_BAUDRATE_57600;
++	case 115200:
++		return QCA_BAUDRATE_115200;
++	case 230400:
++		return QCA_BAUDRATE_230400;
++	case 460800:
++		return QCA_BAUDRATE_460800;
++	case 500000:
++		return QCA_BAUDRATE_500000;
++	case 921600:
++		return QCA_BAUDRATE_921600;
++	case 1000000:
++		return QCA_BAUDRATE_1000000;
++	case 2000000:
++		return QCA_BAUDRATE_2000000;
++	case 3000000:
++		return QCA_BAUDRATE_3000000;
++	case 3200000:
++		return QCA_BAUDRATE_3200000;
++	case 3500000:
++		return QCA_BAUDRATE_3500000;
++	default:
++		return QCA_BAUDRATE_115200;
++	}
++}
++
++static int qca_set_baudrate(struct hci_dev *hdev, uint8_t baudrate)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++	struct qca_data *qca = hu->priv;
++	struct sk_buff *skb;
++	u8 cmd[] = { 0x01, 0x48, 0xFC, 0x01, 0x00 };
++
++	if (baudrate > QCA_BAUDRATE_3200000)
++		return -EINVAL;
++
++	cmd[4] = baudrate;
++
++	skb = bt_skb_alloc(sizeof(cmd), GFP_KERNEL);
++	if (!skb) {
++		bt_dev_err(hdev, "Failed to allocate baudrate packet");
++		return -ENOMEM;
++	}
++
++	/* Assign commands to change baudrate and packet type. */
++	skb_put_data(skb, cmd, sizeof(cmd));
++	hci_skb_pkt_type(skb) = HCI_COMMAND_PKT;
++
++	skb_queue_tail(&qca->txq, skb);
++	hci_uart_tx_wakeup(hu);
++
++	/* Wait for the baudrate change request to be sent */
++
++	while (!skb_queue_empty(&qca->txq))
++		usleep_range(100, 200);
++
++	if (hu->serdev)
++		serdev_device_wait_until_sent(hu->serdev,
++		      CMD_TRANS_TIMEOUT);
++
++	/* Give the controller time to process the request */
++	switch (qca_soc_type(hu)) {
++	case QCA_WCN3950:
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++	case QCA_WCN6750:
++	case QCA_WCN6855:
++	case QCA_WCN7850:
++		usleep_range(1000, 10000);
++		break;
++
++	default:
++		msleep(300);
++	}
++
++	return 0;
++}
++
++static inline void host_set_baudrate(struct hci_uart *hu, unsigned int speed)
++{
++	if (hu->serdev)
++		serdev_device_set_baudrate(hu->serdev, speed);
++	else
++		hci_uart_set_baudrate(hu, speed);
++}
++
++static int qca_send_power_pulse(struct hci_uart *hu, bool on)
++{
++	int timeout = CMD_TRANS_TIMEOUT;
++	int ret;
++	u8 cmd = on ? QCA_WCN3990_POWERON_PULSE : QCA_WCN3990_POWEROFF_PULSE;
++
++	/* These power pulses are single byte command which are sent
++	 * at required baudrate to wcn3990. On wcn3990, we have an external
++	 * circuit at Tx pin which decodes the pulse sent at specific baudrate.
++	 * For example, wcn3990 supports RF COEX antenna for both Wi-Fi/BT
++	 * and also we use the same power inputs to turn on and off for
++	 * Wi-Fi/BT. Powering up the power sources will not enable BT, until
++	 * we send a power on pulse at 115200 bps. This algorithm will help to
++	 * save power. Disabling hardware flow control is mandatory while
++	 * sending power pulses to SoC.
++	 */
++	bt_dev_dbg(hu->hdev, "sending power pulse %02x to controller", cmd);
++
++	serdev_device_write_flush(hu->serdev);
++	hci_uart_set_flow_control(hu, true);
++	ret = serdev_device_write_buf(hu->serdev, &cmd, sizeof(cmd));
++	if (ret < 0) {
++		bt_dev_err(hu->hdev, "failed to send power pulse %02x", cmd);
++		return ret;
++	}
++
++	serdev_device_wait_until_sent(hu->serdev, timeout);
++	hci_uart_set_flow_control(hu, false);
++
++	/* Give to controller time to boot/shutdown */
++	if (on)
++		msleep(100);
++	else
++		usleep_range(1000, 10000);
++
++	return 0;
++}
++
++static unsigned int qca_get_speed(struct hci_uart *hu,
++				  enum qca_speed_type speed_type)
++{
++	unsigned int speed = 0;
++
++	if (speed_type == QCA_INIT_SPEED) {
++		if (hu->init_speed)
++			speed = hu->init_speed;
++		else if (hu->proto->init_speed)
++			speed = hu->proto->init_speed;
++	} else {
++		if (hu->oper_speed)
++			speed = hu->oper_speed;
++		else if (hu->proto->oper_speed)
++			speed = hu->proto->oper_speed;
++	}
++
++	return speed;
++}
++
++static int qca_check_speeds(struct hci_uart *hu)
++{
++	switch (qca_soc_type(hu)) {
++	case QCA_WCN3950:
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++	case QCA_WCN6750:
++	case QCA_WCN6855:
++	case QCA_WCN7850:
++		if (!qca_get_speed(hu, QCA_INIT_SPEED) &&
++		    !qca_get_speed(hu, QCA_OPER_SPEED))
++			return -EINVAL;
++		break;
++
++	default:
++		if (!qca_get_speed(hu, QCA_INIT_SPEED) ||
++		    !qca_get_speed(hu, QCA_OPER_SPEED))
++			return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int qca_set_speed(struct hci_uart *hu, enum qca_speed_type speed_type)
++{
++	unsigned int speed, qca_baudrate;
++	struct qca_data *qca = hu->priv;
++	int ret = 0;
++
++	if (speed_type == QCA_INIT_SPEED) {
++		speed = qca_get_speed(hu, QCA_INIT_SPEED);
++		if (speed)
++			host_set_baudrate(hu, speed);
++	} else {
++		enum qca_btsoc_type soc_type = qca_soc_type(hu);
++
++		speed = qca_get_speed(hu, QCA_OPER_SPEED);
++		if (!speed)
++			return 0;
++
++		/* Disable flow control for wcn3990 to deassert RTS while
++		 * changing the baudrate of chip and host.
++		 */
++		switch (soc_type) {
++		case QCA_WCN3950:
++		case QCA_WCN3988:
++		case QCA_WCN3990:
++		case QCA_WCN3991:
++		case QCA_WCN3998:
++		case QCA_WCN6750:
++		case QCA_WCN6855:
++		case QCA_WCN7850:
++			hci_uart_set_flow_control(hu, true);
++			break;
++
++		default:
++			break;
++		}
++
++		switch (soc_type) {
++		case QCA_WCN3990:
++			reinit_completion(&qca->drop_ev_comp);
++			set_bit(QCA_DROP_VENDOR_EVENT, &qca->flags);
++			break;
++
++		default:
++			break;
++		}
++
++		qca_baudrate = qca_get_baudrate_value(speed);
++		bt_dev_dbg(hu->hdev, "Set UART speed to %d", speed);
++		ret = qca_set_baudrate(hu->hdev, qca_baudrate);
++		if (ret)
++			goto error;
++
++		host_set_baudrate(hu, speed);
++
++error:
++		switch (soc_type) {
++		case QCA_WCN3950:
++		case QCA_WCN3988:
++		case QCA_WCN3990:
++		case QCA_WCN3991:
++		case QCA_WCN3998:
++		case QCA_WCN6750:
++		case QCA_WCN6855:
++		case QCA_WCN7850:
++			hci_uart_set_flow_control(hu, false);
++			break;
++
++		default:
++			break;
++		}
++
++		switch (soc_type) {
++		case QCA_WCN3990:
++			/* Wait for the controller to send the vendor event
++			 * for the baudrate change command.
++			 */
++			if (!wait_for_completion_timeout(&qca->drop_ev_comp,
++						 msecs_to_jiffies(100))) {
++				bt_dev_err(hu->hdev,
++					   "Failed to change controller baudrate\n");
++				ret = -ETIMEDOUT;
++			}
++
++			clear_bit(QCA_DROP_VENDOR_EVENT, &qca->flags);
++			break;
++
++		default:
++			break;
++		}
++	}
++
++	return ret;
++}
++
++static int qca_send_crashbuffer(struct hci_uart *hu)
++{
++	struct qca_data *qca = hu->priv;
++	struct sk_buff *skb;
++
++	skb = bt_skb_alloc(QCA_CRASHBYTE_PACKET_LEN, GFP_KERNEL);
++	if (!skb) {
++		bt_dev_err(hu->hdev, "Failed to allocate memory for skb packet");
++		return -ENOMEM;
++	}
++
++	/* We forcefully crash the controller, by sending 0xfb byte for
++	 * 1024 times. We also might have chance of losing data, To be
++	 * on safer side we send 1096 bytes to the SoC.
++	 */
++	memset(skb_put(skb, QCA_CRASHBYTE_PACKET_LEN), QCA_MEMDUMP_BYTE,
++	       QCA_CRASHBYTE_PACKET_LEN);
++	hci_skb_pkt_type(skb) = HCI_COMMAND_PKT;
++	bt_dev_info(hu->hdev, "crash the soc to collect controller dump");
++	skb_queue_tail(&qca->txq, skb);
++	hci_uart_tx_wakeup(hu);
++
++	return 0;
++}
++
++static void qca_wait_for_dump_collection(struct hci_dev *hdev)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++	struct qca_data *qca = hu->priv;
++
++	wait_on_bit_timeout(&qca->flags, QCA_MEMDUMP_COLLECTION,
++			    TASK_UNINTERRUPTIBLE, MEMDUMP_TIMEOUT);
++
++	clear_bit(QCA_MEMDUMP_COLLECTION, &qca->flags);
++}
++
++static void qca_hw_error(struct hci_dev *hdev, u8 code)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++	struct qca_data *qca = hu->priv;
++
++	set_bit(QCA_SSR_TRIGGERED, &qca->flags);
++	set_bit(QCA_HW_ERROR_EVENT, &qca->flags);
++	bt_dev_info(hdev, "mem_dump_status: %d", qca->memdump_state);
++
++	if (qca->memdump_state == QCA_MEMDUMP_IDLE) {
++		/* If hardware error event received for other than QCA
++		 * soc memory dump event, then we need to crash the SOC
++		 * and wait here for 8 seconds to get the dump packets.
++		 * This will block main thread to be on hold until we
++		 * collect dump.
++		 */
++		set_bit(QCA_MEMDUMP_COLLECTION, &qca->flags);
++		qca_send_crashbuffer(hu);
++		qca_wait_for_dump_collection(hdev);
++	} else if (qca->memdump_state == QCA_MEMDUMP_COLLECTING) {
++		/* Let us wait here until memory dump collected or
++		 * memory dump timer expired.
++		 */
++		bt_dev_info(hdev, "waiting for dump to complete");
++		qca_wait_for_dump_collection(hdev);
++	}
++
++	mutex_lock(&qca->hci_memdump_lock);
++	if (qca->memdump_state != QCA_MEMDUMP_COLLECTED) {
++		bt_dev_err(hu->hdev, "clearing allocated memory due to memdump timeout");
++		hci_devcd_abort(hu->hdev);
++		if (qca->qca_memdump) {
++			kfree(qca->qca_memdump);
++			qca->qca_memdump = NULL;
++		}
++		qca->memdump_state = QCA_MEMDUMP_TIMEOUT;
++		cancel_delayed_work(&qca->ctrl_memdump_timeout);
++	}
++	mutex_unlock(&qca->hci_memdump_lock);
++
++	if (qca->memdump_state == QCA_MEMDUMP_TIMEOUT ||
++	    qca->memdump_state == QCA_MEMDUMP_COLLECTED) {
++		cancel_work_sync(&qca->ctrl_memdump_evt);
++		skb_queue_purge(&qca->rx_memdump_q);
++	}
++
++	/*
++	 * If the BT chip's bt_en pin is connected to a 3.3V power supply via
++	 * hardware and always stays high, driver cannot control the bt_en pin.
++	 * As a result, during SSR (SubSystem Restart), QCA_SSR_TRIGGERED and
++	 * QCA_IBS_DISABLED flags cannot be cleared, which leads to a reset
++	 * command timeout.
++	 * Add an msleep delay to ensure controller completes the SSR process.
++	 *
++	 * Host will not download the firmware after SSR, controller to remain
++	 * in the IBS_WAKE state, and the host needs to synchronize with it
++	 *
++	 * Since the bluetooth chip has been reset, clear the memdump state.
++	 */
++	if (!hci_test_quirk(hu->hdev, HCI_QUIRK_NON_PERSISTENT_SETUP)) {
++		/*
++		 * When the SSR (SubSystem Restart) duration exceeds 2 seconds,
++		 * it triggers host tx_idle_delay, which sets host TX state
++		 * to sleep. Reset tx_idle_timer after SSR to prevent
++		 * host enter TX IBS_Sleep mode.
++		 */
++		mod_timer(&qca->tx_idle_timer, jiffies +
++				  msecs_to_jiffies(qca->tx_idle_delay));
++
++		/* Wait for the controller to load the rampatch and NVM. */
++		msleep(100);
++
++		clear_bit(QCA_SSR_TRIGGERED, &qca->flags);
++		clear_bit(QCA_IBS_DISABLED, &qca->flags);
++
++		qca->tx_ibs_state = HCI_IBS_TX_AWAKE;
++		qca->memdump_state = QCA_MEMDUMP_IDLE;
++	}
++
++	clear_bit(QCA_HW_ERROR_EVENT, &qca->flags);
++}
++
++static void qca_reset(struct hci_dev *hdev)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++	struct qca_data *qca = hu->priv;
++
++	set_bit(QCA_SSR_TRIGGERED, &qca->flags);
++	if (qca->memdump_state == QCA_MEMDUMP_IDLE) {
++		set_bit(QCA_MEMDUMP_COLLECTION, &qca->flags);
++		qca_send_crashbuffer(hu);
++		qca_wait_for_dump_collection(hdev);
++	} else if (qca->memdump_state == QCA_MEMDUMP_COLLECTING) {
++		/* Let us wait here until memory dump collected or
++		 * memory dump timer expired.
++		 */
++		bt_dev_info(hdev, "waiting for dump to complete");
++		qca_wait_for_dump_collection(hdev);
++	}
++
++	mutex_lock(&qca->hci_memdump_lock);
++	if (qca->memdump_state != QCA_MEMDUMP_COLLECTED) {
++		qca->memdump_state = QCA_MEMDUMP_TIMEOUT;
++		if (!test_bit(QCA_HW_ERROR_EVENT, &qca->flags)) {
++			/* Inject hw error event to reset the device
++			 * and driver.
++			 */
++			hci_reset_dev(hu->hdev);
++		}
++	}
++	mutex_unlock(&qca->hci_memdump_lock);
++}
++
++static bool qca_wakeup(struct hci_dev *hdev)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++	bool wakeup;
++
++	if (!hu->serdev)
++		return true;
++
++	/* BT SoC attached through the serial bus is handled by the serdev driver.
++	 * So we need to use the device handle of the serdev driver to get the
++	 * status of device may wakeup.
++	 */
++	wakeup = device_may_wakeup(&hu->serdev->ctrl->dev);
++	bt_dev_dbg(hu->hdev, "wakeup status : %d", wakeup);
++
++	return wakeup;
++}
++
++static int qca_port_reopen(struct hci_uart *hu)
++{
++	int ret;
++
++	/* Now the device is in ready state to communicate with host.
++	 * To sync host with device we need to reopen port.
++	 * Without this, we will have RTS and CTS synchronization
++	 * issues.
++	 */
++	serdev_device_close(hu->serdev);
++	ret = serdev_device_open(hu->serdev);
++	if (ret) {
++		bt_dev_err(hu->hdev, "failed to open port");
++		return ret;
++	}
++
++	hci_uart_set_flow_control(hu, false);
++
++	return 0;
++}
++
++static int qca_regulator_init(struct hci_uart *hu)
++{
++	enum qca_btsoc_type soc_type = qca_soc_type(hu);
++	struct qca_serdev *qcadev;
++	int ret;
++	bool sw_ctrl_state;
++
++	/* Check for vregs status, may be hci down has turned
++	 * off the voltage regulator.
++	 */
++	qcadev = serdev_device_get_drvdata(hu->serdev);
++
++	if (!qcadev->bt_power->vregs_on) {
++		serdev_device_close(hu->serdev);
++		ret = qca_regulator_enable(qcadev);
++		if (ret)
++			return ret;
++
++		ret = serdev_device_open(hu->serdev);
++		if (ret) {
++			bt_dev_err(hu->hdev, "failed to open port");
++			return ret;
++		}
++	}
++
++	switch (soc_type) {
++	case QCA_WCN3950:
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++		/* Forcefully enable wcn399x to enter in to boot mode. */
++		host_set_baudrate(hu, 2400);
++		ret = qca_send_power_pulse(hu, false);
++		if (ret)
++			return ret;
++		break;
++
++	default:
++		break;
++	}
++
++	/* For wcn6750 need to enable gpio bt_en */
++	if (qcadev->bt_en) {
++		gpiod_set_value_cansleep(qcadev->bt_en, 0);
++		msleep(50);
++		gpiod_set_value_cansleep(qcadev->bt_en, 1);
++		msleep(50);
++		if (qcadev->sw_ctrl) {
++			sw_ctrl_state = gpiod_get_value_cansleep(qcadev->sw_ctrl);
++			bt_dev_dbg(hu->hdev, "SW_CTRL is %d", sw_ctrl_state);
++		}
++	}
++
++	qca_set_speed(hu, QCA_INIT_SPEED);
++
++	switch (soc_type) {
++	case QCA_WCN3950:
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++		ret = qca_send_power_pulse(hu, true);
++		if (ret)
++			return ret;
++		break;
++
++	default:
++		break;
++	}
++
++	return qca_port_reopen(hu);
++}
++
++static int qca_power_on(struct hci_dev *hdev)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++	enum qca_btsoc_type soc_type = qca_soc_type(hu);
++	struct qca_serdev *qcadev;
++	struct qca_data *qca = hu->priv;
++	int ret = 0;
++
++	/* Non-serdev device usually is powered by external power
++	 * and don't need additional action in driver for power on
++	 */
++	if (!hu->serdev)
++		return 0;
++
++	switch (soc_type) {
++	case QCA_QCA6390:
++	case QCA_WCN3950:
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++	case QCA_WCN6750:
++	case QCA_WCN6855:
++	case QCA_WCN7850:
++		ret = qca_regulator_init(hu);
++		break;
++
++	default:
++		qcadev = serdev_device_get_drvdata(hu->serdev);
++		if (qcadev->bt_en) {
++			gpiod_set_value_cansleep(qcadev->bt_en, 1);
++			/* Controller needs time to bootup. */
++			msleep(150);
++		}
++	}
++
++	clear_bit(QCA_BT_OFF, &qca->flags);
++	return ret;
++}
++
++static void hci_coredump_qca(struct hci_dev *hdev)
++{
++	int err;
++	static const u8 param[] = { 0x26 };
++
++	err = __hci_cmd_send(hdev, 0xfc0c, 1, param);
++	if (err < 0)
++		bt_dev_err(hdev, "%s: trigger crash failed (%d)", __func__, err);
++}
++
++static int qca_get_data_path_id(struct hci_dev *hdev, __u8 *data_path_id)
++{
++	/* QCA uses 1 as non-HCI data path id for HFP */
++	*data_path_id = 1;
++	return 0;
++}
++
++static int qca_configure_hfp_offload(struct hci_dev *hdev)
++{
++	bt_dev_info(hdev, "HFP non-HCI data transport is supported");
++	hdev->get_data_path_id = qca_get_data_path_id;
++	/* Do not need to send HCI_Configure_Data_Path to configure non-HCI
++	 * data transport path for QCA controllers, so set below field as NULL.
++	 */
++	hdev->get_codec_config_data = NULL;
++	return 0;
++}
++
++static int qca_setup(struct hci_uart *hu)
++{
++	struct hci_dev *hdev = hu->hdev;
++	struct qca_data *qca = hu->priv;
++	unsigned int speed, qca_baudrate = QCA_BAUDRATE_115200;
++	unsigned int retries = 0;
++	enum qca_btsoc_type soc_type = qca_soc_type(hu);
++	const char *firmware_name = qca_get_firmware_name(hu);
++	const char *rampatch_name = qca_get_rampatch_name(hu);
++	int ret;
++	struct qca_btsoc_version ver;
++	struct qca_serdev *qcadev = NULL;
++	const char *soc_name;
++
++	if (hu->serdev)
++		qcadev = serdev_device_get_drvdata(hu->serdev);
++
++	ret = qca_check_speeds(hu);
++	if (ret)
++		return ret;
++
++	clear_bit(QCA_ROM_FW, &qca->flags);
++	/* Patch downloading has to be done without IBS mode */
++	set_bit(QCA_IBS_DISABLED, &qca->flags);
++
++	/* Enable controller to do both LE scan and BR/EDR inquiry
++	 * simultaneously.
++	 */
++	hci_set_quirk(hdev, HCI_QUIRK_SIMULTANEOUS_DISCOVERY);
++
++	switch (soc_type) {
++	case QCA_QCA2066:
++		soc_name = "qca2066";
++		break;
++
++	case QCA_WCN3950:
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++		soc_name = "wcn399x";
++		break;
++
++	case QCA_WCN6750:
++		soc_name = "wcn6750";
++		break;
++
++	case QCA_WCN6855:
++		soc_name = "wcn6855";
++		break;
++
++	case QCA_WCN7850:
++		soc_name = "wcn7850";
++		break;
++
++	default:
++		soc_name = "ROME/QCA6390";
++	}
++	bt_dev_info(hdev, "setting up %s", soc_name);
++
++	qca->memdump_state = QCA_MEMDUMP_IDLE;
++
++retry:
++	ret = qca_power_on(hdev);
++	if (ret)
++		goto out;
++
++	clear_bit(QCA_SSR_TRIGGERED, &qca->flags);
++
++	switch (soc_type) {
++	case QCA_WCN3950:
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++	case QCA_WCN6750:
++	case QCA_WCN6855:
++	case QCA_WCN7850:
++		if (qcadev && qcadev->bdaddr_property_broken)
++			hci_set_quirk(hdev, HCI_QUIRK_BDADDR_PROPERTY_BROKEN);
++
++		hci_set_aosp_capable(hdev);
++
++		ret = qca_read_soc_version(hdev, &ver, soc_type);
++		if (ret)
++			goto out;
++		break;
++
++	default:
++		qca_set_speed(hu, QCA_INIT_SPEED);
++	}
++
++	/* Setup user speed if needed */
++	speed = qca_get_speed(hu, QCA_OPER_SPEED);
++	if (speed) {
++		ret = qca_set_speed(hu, QCA_OPER_SPEED);
++		if (ret)
++			goto out;
++
++		qca_baudrate = qca_get_baudrate_value(speed);
++	}
++
++	switch (soc_type) {
++	case QCA_WCN3950:
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++	case QCA_WCN6750:
++	case QCA_WCN6855:
++	case QCA_WCN7850:
++		break;
++
++	default:
++		/* Get QCA version information */
++		ret = qca_read_soc_version(hdev, &ver, soc_type);
++		if (ret)
++			goto out;
++	}
++
++	/* Setup patch / NVM configurations */
++	ret = qca_uart_setup(hdev, qca_baudrate, soc_type, ver,
++			firmware_name, rampatch_name);
++	if (!ret) {
++		clear_bit(QCA_IBS_DISABLED, &qca->flags);
++		qca_debugfs_init(hdev);
++		hu->hdev->hw_error = qca_hw_error;
++		hu->hdev->reset = qca_reset;
++		if (hu->serdev) {
++			if (device_can_wakeup(hu->serdev->ctrl->dev.parent))
++				hu->hdev->wakeup = qca_wakeup;
++		}
++	} else if (ret == -ENOENT) {
++		/* No patch/nvm-config found, run with original fw/config */
++		set_bit(QCA_ROM_FW, &qca->flags);
++		ret = 0;
++	} else if (ret == -EAGAIN) {
++		/*
++		 * Userspace firmware loader will return -EAGAIN in case no
++		 * patch/nvm-config is found, so run with original fw/config.
++		 */
++		set_bit(QCA_ROM_FW, &qca->flags);
++		ret = 0;
++	}
++
++out:
++	if (ret) {
++		qca_power_off(hu);
++
++		if (retries < MAX_INIT_RETRIES) {
++			bt_dev_warn(hdev, "Retry BT power ON:%d", retries);
++			if (hu->serdev) {
++				serdev_device_close(hu->serdev);
++				ret = serdev_device_open(hu->serdev);
++				if (ret) {
++					bt_dev_err(hdev, "failed to open port");
++					return ret;
++				}
++			}
++			retries++;
++			goto retry;
++		}
++		return ret;
++	}
++
++	/* Setup bdaddr */
++	if (soc_type == QCA_ROME)
++		hu->hdev->set_bdaddr = qca_set_bdaddr_rome;
++	else
++		hu->hdev->set_bdaddr = qca_set_bdaddr;
++
++	if (qcadev && qcadev->support_hfp_hw_offload)
++		qca_configure_hfp_offload(hdev);
++
++	qca->fw_version = le16_to_cpu(ver.patch_ver);
++	qca->controller_id = le16_to_cpu(ver.rom_ver);
++	hci_devcd_register(hdev, hci_coredump_qca, qca_dmp_hdr, NULL);
++
++	return ret;
++}
++
++static const struct hci_uart_proto qca_proto = {
++	.id		= HCI_UART_QCA,
++	.name		= "QCA",
++	.manufacturer	= 29,
++	.init_speed	= 115200,
++	.oper_speed	= 3000000,
++	.open		= qca_open,
++	.close		= qca_close,
++	.flush		= qca_flush,
++	.setup		= qca_setup,
++	.recv		= qca_recv,
++	.enqueue	= qca_enqueue,
++	.dequeue	= qca_dequeue,
++};
++
++static const struct qca_device_data qca_soc_data_qca2066 __maybe_unused = {
++	.soc_type = QCA_QCA2066,
++	.num_vregs = 0,
++	.capabilities = QCA_CAP_WIDEBAND_SPEECH | QCA_CAP_VALID_LE_STATES |
++			QCA_CAP_HFP_HW_OFFLOAD,
++};
++
++static const struct qca_device_data qca_soc_data_qca6390 __maybe_unused = {
++	.soc_type = QCA_QCA6390,
++	.num_vregs = 0,
++};
++
++static const struct qca_device_data qca_soc_data_wcn3950 __maybe_unused = {
++	.soc_type = QCA_WCN3950,
++	.vregs = (struct qca_vreg []) {
++		{ "vddio", 15000  },
++		{ "vddxo", 60000  },
++		{ "vddrf", 155000 },
++		{ "vddch0", 585000 },
++	},
++	.num_vregs = 4,
++};
++
++static const struct qca_device_data qca_soc_data_wcn3988 __maybe_unused = {
++	.soc_type = QCA_WCN3988,
++	.vregs = (struct qca_vreg []) {
++		{ "vddio", 15000  },
++		{ "vddxo", 80000  },
++		{ "vddrf", 300000 },
++		{ "vddch0", 450000 },
++	},
++	.num_vregs = 4,
++};
++
++static const struct qca_device_data qca_soc_data_wcn3990 __maybe_unused = {
++	.soc_type = QCA_WCN3990,
++	.vregs = (struct qca_vreg []) {
++		{ "vddio", 15000  },
++		{ "vddxo", 80000  },
++		{ "vddrf", 300000 },
++		{ "vddch0", 450000 },
++	},
++	.num_vregs = 4,
++};
++
++static const struct qca_device_data qca_soc_data_wcn3991 __maybe_unused = {
++	.soc_type = QCA_WCN3991,
++	.vregs = (struct qca_vreg []) {
++		{ "vddio", 15000  },
++		{ "vddxo", 80000  },
++		{ "vddrf", 300000 },
++		{ "vddch0", 450000 },
++	},
++	.num_vregs = 4,
++	.capabilities = QCA_CAP_WIDEBAND_SPEECH | QCA_CAP_VALID_LE_STATES,
++};
++
++static const struct qca_device_data qca_soc_data_wcn3998 __maybe_unused = {
++	.soc_type = QCA_WCN3998,
++	.vregs = (struct qca_vreg []) {
++		{ "vddio", 10000  },
++		{ "vddxo", 80000  },
++		{ "vddrf", 300000 },
++		{ "vddch0", 450000 },
++	},
++	.num_vregs = 4,
++};
++
++static const struct qca_device_data qca_soc_data_wcn6750 __maybe_unused = {
++	.soc_type = QCA_WCN6750,
++	.vregs = (struct qca_vreg []) {
++		{ "vddio", 5000 },
++		{ "vddaon", 26000 },
++		{ "vddbtcxmx", 126000 },
++		{ "vddrfacmn", 12500 },
++		{ "vddrfa0p8", 102000 },
++		{ "vddrfa1p7", 302000 },
++		{ "vddrfa1p2", 257000 },
++		{ "vddrfa2p2", 1700000 },
++		{ "vddasd", 200 },
++	},
++	.num_vregs = 9,
++	.capabilities = QCA_CAP_WIDEBAND_SPEECH | QCA_CAP_VALID_LE_STATES,
++};
++
++static const struct qca_device_data qca_soc_data_wcn6855 __maybe_unused = {
++	.soc_type = QCA_WCN6855,
++	.vregs = (struct qca_vreg []) {
++		{ "vddio", 5000 },
++		{ "vddbtcxmx", 126000 },
++		{ "vddrfacmn", 12500 },
++		{ "vddrfa0p8", 102000 },
++		{ "vddrfa1p7", 302000 },
++		{ "vddrfa1p2", 257000 },
++	},
++	.num_vregs = 6,
++	.capabilities = QCA_CAP_WIDEBAND_SPEECH | QCA_CAP_VALID_LE_STATES |
++			QCA_CAP_HFP_HW_OFFLOAD,
++};
++
++static const struct qca_device_data qca_soc_data_wcn7850 __maybe_unused = {
++	.soc_type = QCA_WCN7850,
++	.vregs = (struct qca_vreg []) {
++		{ "vddio", 5000 },
++		{ "vddaon", 26000 },
++		{ "vdddig", 126000 },
++		{ "vddrfa0p8", 102000 },
++		{ "vddrfa1p2", 257000 },
++		{ "vddrfa1p9", 302000 },
++	},
++	.num_vregs = 6,
++	.capabilities = QCA_CAP_WIDEBAND_SPEECH | QCA_CAP_VALID_LE_STATES |
++			QCA_CAP_HFP_HW_OFFLOAD,
++};
++
++static void qca_power_off(struct hci_uart *hu)
++{
++	struct qca_serdev *qcadev;
++	struct qca_data *qca = hu->priv;
++	unsigned long flags;
++	enum qca_btsoc_type soc_type = qca_soc_type(hu);
++	bool sw_ctrl_state;
++	struct qca_power *power;
++
++	/* From this point we go into power off state. But serial port is
++	 * still open, stop queueing the IBS data and flush all the buffered
++	 * data in skb's.
++	 */
++	spin_lock_irqsave(&qca->hci_ibs_lock, flags);
++	set_bit(QCA_IBS_DISABLED, &qca->flags);
++	qca_flush(hu);
++	spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++
++	/* Non-serdev device usually is powered by external power
++	 * and don't need additional action in driver for power down
++	 */
++	if (!hu->serdev)
++		return;
++
++	qcadev = serdev_device_get_drvdata(hu->serdev);
++	power = qcadev->bt_power;
++
++	switch (soc_type) {
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++		host_set_baudrate(hu, 2400);
++		qca_send_power_pulse(hu, false);
++		break;
++	default:
++		break;
++	}
++
++	if (power && power->pwrseq) {
++		pwrseq_power_off(power->pwrseq);
++		set_bit(QCA_BT_OFF, &qca->flags);
++		return;
++        }
++
++	switch (soc_type) {
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++		qca_regulator_disable(qcadev);
++		break;
++
++	case QCA_WCN6750:
++	case QCA_WCN6855:
++		gpiod_set_value_cansleep(qcadev->bt_en, 0);
++		msleep(100);
++		qca_regulator_disable(qcadev);
++		if (qcadev->sw_ctrl) {
++			sw_ctrl_state = gpiod_get_value_cansleep(qcadev->sw_ctrl);
++			BT_DBG("SW_CTRL is %d", sw_ctrl_state);
++		}
++		break;
++
++	default:
++		gpiod_set_value_cansleep(qcadev->bt_en, 0);
++	}
++
++	set_bit(QCA_BT_OFF, &qca->flags);
++}
++
++static int qca_hci_shutdown(struct hci_dev *hdev)
++{
++	struct hci_uart *hu = hci_get_drvdata(hdev);
++	struct qca_data *qca = hu->priv;
++	enum qca_btsoc_type soc_type = qca_soc_type(hu);
++
++	hu->hdev->hw_error = NULL;
++	hu->hdev->reset = NULL;
++
++	timer_delete_sync(&qca->wake_retrans_timer);
++	timer_delete_sync(&qca->tx_idle_timer);
++
++	/* Stop sending shutdown command if soc crashes. */
++	if (soc_type != QCA_ROME
++		&& qca->memdump_state == QCA_MEMDUMP_IDLE) {
++		qca_send_pre_shutdown_cmd(hdev);
++		usleep_range(8000, 10000);
++	}
++
++	qca_power_off(hu);
++	return 0;
++}
++
++static int qca_regulator_enable(struct qca_serdev *qcadev)
++{
++	struct qca_power *power = qcadev->bt_power;
++	int ret;
++
++	if (power->pwrseq)
++		return pwrseq_power_on(power->pwrseq);
++
++	/* Already enabled */
++	if (power->vregs_on)
++		return 0;
++
++	BT_DBG("enabling %d regulators)", power->num_vregs);
++
++	ret = regulator_bulk_enable(power->num_vregs, power->vreg_bulk);
++	if (ret)
++		return ret;
++
++	power->vregs_on = true;
++
++	ret = clk_prepare_enable(qcadev->susclk);
++	if (ret)
++		qca_regulator_disable(qcadev);
++
++	return ret;
++}
++
++static void qca_regulator_disable(struct qca_serdev *qcadev)
++{
++	struct qca_power *power;
++
++	if (!qcadev)
++		return;
++
++	power = qcadev->bt_power;
++
++	/* Already disabled? */
++	if (!power->vregs_on)
++		return;
++
++	regulator_bulk_disable(power->num_vregs, power->vreg_bulk);
++	power->vregs_on = false;
++
++	clk_disable_unprepare(qcadev->susclk);
++}
++
++static int qca_init_regulators(struct qca_power *qca,
++				const struct qca_vreg *vregs, size_t num_vregs)
++{
++	struct regulator_bulk_data *bulk;
++	int ret;
++	int i;
++
++	bulk = devm_kcalloc(qca->dev, num_vregs, sizeof(*bulk), GFP_KERNEL);
++	if (!bulk)
++		return -ENOMEM;
++
++	for (i = 0; i < num_vregs; i++)
++		bulk[i].supply = vregs[i].name;
++
++	ret = devm_regulator_bulk_get(qca->dev, num_vregs, bulk);
++	if (ret < 0)
++		return ret;
++
++	for (i = 0; i < num_vregs; i++) {
++		ret = regulator_set_load(bulk[i].consumer, vregs[i].load_uA);
++		if (ret)
++			return ret;
++	}
++
++	qca->vreg_bulk = bulk;
++	qca->num_vregs = num_vregs;
++
++	return 0;
++}
++
++static int qca_serdev_probe(struct serdev_device *serdev)
++{
++	struct qca_serdev *qcadev;
++	struct hci_dev *hdev;
++	const struct qca_device_data *data;
++	int err;
++	bool power_ctrl_enabled = true;
++
++	qcadev = devm_kzalloc(&serdev->dev, sizeof(*qcadev), GFP_KERNEL);
++	if (!qcadev)
++		return -ENOMEM;
++
++	qcadev->serdev_hu.serdev = serdev;
++	data = device_get_match_data(&serdev->dev);
++	serdev_device_set_drvdata(serdev, qcadev);
++	device_property_read_string_array(&serdev->dev, "firmware-name",
++					 qcadev->firmware_name, ARRAY_SIZE(qcadev->firmware_name));
++	device_property_read_u32(&serdev->dev, "max-speed",
++				 &qcadev->oper_speed);
++	if (!qcadev->oper_speed)
++		BT_DBG("UART will pick default operating speed");
++
++	qcadev->bdaddr_property_broken = device_property_read_bool(&serdev->dev,
++			"qcom,local-bd-address-broken");
++
++	if (data)
++		qcadev->btsoc_type = data->soc_type;
++	else
++		qcadev->btsoc_type = QCA_ROME;
++
++	switch (qcadev->btsoc_type) {
++	case QCA_QCA6390:
++	case QCA_WCN3950:
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++	case QCA_WCN6750:
++	case QCA_WCN6855:
++	case QCA_WCN7850:
++		qcadev->bt_power = devm_kzalloc(&serdev->dev,
++						sizeof(struct qca_power),
++						GFP_KERNEL);
++		if (!qcadev->bt_power)
++			return -ENOMEM;
++		break;
++	default:
++		break;
++	}
++
++	switch (qcadev->btsoc_type) {
++	case QCA_WCN3950:
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++	case QCA_WCN6750:
++	case QCA_WCN6855:
++	case QCA_WCN7850:
++		if (!device_property_present(&serdev->dev, "enable-gpios")) {
++			/*
++			 * Backward compatibility with old DT sources. If the
++			 * node doesn't have the 'enable-gpios' property then
++			 * let's use the power sequencer. Otherwise, let's
++			 * drive everything ourselves.
++			 */
++			qcadev->bt_power->pwrseq = devm_pwrseq_get(&serdev->dev,
++								   "bluetooth");
++
++			/*
++			 * Some modules have BT_EN enabled via a hardware pull-up,
++			 * meaning it is not defined in the DTS and is not controlled
++			 * through the power sequence. In such cases, fall through
++			 * to follow the legacy flow.
++			 */
++			if (IS_ERR(qcadev->bt_power->pwrseq))
++				qcadev->bt_power->pwrseq = NULL;
++			else
++				break;
++		}
++
++		qcadev->bt_power->dev = &serdev->dev;
++		err = qca_init_regulators(qcadev->bt_power, data->vregs,
++					  data->num_vregs);
++		if (err) {
++			BT_ERR("Failed to init regulators:%d", err);
++			return err;
++		}
++
++		qcadev->bt_power->vregs_on = false;
++
++		qcadev->bt_en = devm_gpiod_get_optional(&serdev->dev, "enable",
++					       GPIOD_OUT_LOW);
++		if (IS_ERR(qcadev->bt_en))
++			return dev_err_probe(&serdev->dev,
++					     PTR_ERR(qcadev->bt_en),
++					     "failed to acquire BT_EN gpio\n");
++
++		if (!qcadev->bt_en &&
++		    (data->soc_type == QCA_WCN6750 ||
++		     data->soc_type == QCA_WCN6855 ||
++		     data->soc_type == QCA_WCN7850))
++			power_ctrl_enabled = false;
++
++		qcadev->sw_ctrl = devm_gpiod_get_optional(&serdev->dev, "swctrl",
++					       GPIOD_IN);
++		if (IS_ERR(qcadev->sw_ctrl) &&
++		    (data->soc_type == QCA_WCN6750 ||
++		     data->soc_type == QCA_WCN6855 ||
++		     data->soc_type == QCA_WCN7850)) {
++			dev_err(&serdev->dev, "failed to acquire SW_CTRL gpio\n");
++			return PTR_ERR(qcadev->sw_ctrl);
++		}
++
++		qcadev->susclk = devm_clk_get_optional(&serdev->dev, NULL);
++		if (IS_ERR(qcadev->susclk)) {
++			dev_err(&serdev->dev, "failed to acquire clk\n");
++			return PTR_ERR(qcadev->susclk);
++		}
++		break;
++
++	case QCA_QCA6390:
++		if (dev_of_node(&serdev->dev)) {
++			qcadev->bt_power->pwrseq = devm_pwrseq_get(&serdev->dev,
++								   "bluetooth");
++			if (IS_ERR(qcadev->bt_power->pwrseq))
++				return PTR_ERR(qcadev->bt_power->pwrseq);
++			break;
++		}
++		fallthrough;
++
++	default:
++		qcadev->bt_en = devm_gpiod_get_optional(&serdev->dev, "enable",
++					       GPIOD_OUT_LOW);
++		if (IS_ERR(qcadev->bt_en)) {
++			dev_err(&serdev->dev, "failed to acquire enable gpio\n");
++			return PTR_ERR(qcadev->bt_en);
++		}
++
++		if (!qcadev->bt_en)
++			power_ctrl_enabled = false;
++
++		qcadev->susclk = devm_clk_get_optional_enabled_with_rate(
++					&serdev->dev, NULL, SUSCLK_RATE_32KHZ);
++		if (IS_ERR(qcadev->susclk)) {
++			dev_warn(&serdev->dev, "failed to acquire clk\n");
++			return PTR_ERR(qcadev->susclk);
++		}
++	}
++	
++	err = hci_uart_register_device(&qcadev->serdev_hu, &qca_proto);
++	if (err) {
++		BT_ERR("serdev registration failed");
++		return err;
++	}
++
++	hdev = qcadev->serdev_hu.hdev;
++
++	if (power_ctrl_enabled) {
++		hci_set_quirk(hdev, HCI_QUIRK_NON_PERSISTENT_SETUP);
++		hdev->shutdown = qca_hci_shutdown;
++	}
++
++	if (data) {
++		/* Wideband speech support must be set per driver since it can't
++		 * be queried via hci. Same with the valid le states quirk.
++		 */
++		if (data->capabilities & QCA_CAP_WIDEBAND_SPEECH)
++			hci_set_quirk(hdev,
++				      HCI_QUIRK_WIDEBAND_SPEECH_SUPPORTED);
++
++		if (!(data->capabilities & QCA_CAP_VALID_LE_STATES))
++			hci_set_quirk(hdev, HCI_QUIRK_BROKEN_LE_STATES);
++
++		if (data->capabilities & QCA_CAP_HFP_HW_OFFLOAD)
++			qcadev->support_hfp_hw_offload = true;
++	}
++
++	return 0;
++}
++
++static void qca_serdev_remove(struct serdev_device *serdev)
++{
++	struct qca_serdev *qcadev = serdev_device_get_drvdata(serdev);
++	struct qca_power *power = qcadev->bt_power;
++
++	switch (qcadev->btsoc_type) {
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++	case QCA_WCN6750:
++	case QCA_WCN6855:
++	case QCA_WCN7850:
++		if (power->vregs_on)
++			qca_power_off(&qcadev->serdev_hu);
++		break;
++	default:
++		break;
++	}
++
++	hci_uart_unregister_device(&qcadev->serdev_hu);
++}
++
++static void qca_serdev_shutdown(struct serdev_device *serdev)
++{
++	int ret;
++	int timeout = CMD_TRANS_TIMEOUT;
++	struct qca_serdev *qcadev = serdev_device_get_drvdata(serdev);
++	struct hci_uart *hu = &qcadev->serdev_hu;
++	struct hci_dev *hdev = hu->hdev;
++	const u8 ibs_wake_cmd[] = { 0xFD };
++	const u8 edl_reset_soc_cmd[] = { 0x01, 0x00, 0xFC, 0x01, 0x05 };
++
++	if (qcadev->btsoc_type == QCA_QCA6390) {
++		/* The purpose of sending the VSC is to reset SOC into a initial
++		 * state and the state will ensure next hdev->setup() success.
++		 * if HCI_QUIRK_NON_PERSISTENT_SETUP is set, it means that
++		 * hdev->setup() can do its job regardless of SoC state, so
++		 * don't need to send the VSC.
++		 * if HCI_SETUP is set, it means that hdev->setup() was never
++		 * invoked and the SOC is already in the initial state, so
++		 * don't also need to send the VSC.
++		 */
++		if (hci_test_quirk(hdev, HCI_QUIRK_NON_PERSISTENT_SETUP) ||
++		    hci_dev_test_flag(hdev, HCI_SETUP))
++			return;
++
++		/* The serdev must be in open state when control logic arrives
++		 * here, so also fix the use-after-free issue caused by that
++		 * the serdev is flushed or wrote after it is closed.
++		 */
++		serdev_device_write_flush(serdev);
++		ret = serdev_device_write_buf(serdev, ibs_wake_cmd,
++					      sizeof(ibs_wake_cmd));
++		if (ret < 0) {
++			BT_ERR("QCA send IBS_WAKE_IND error: %d", ret);
++			return;
++		}
++		serdev_device_wait_until_sent(serdev, timeout);
++		usleep_range(8000, 10000);
++
++		serdev_device_write_flush(serdev);
++		ret = serdev_device_write_buf(serdev, edl_reset_soc_cmd,
++					      sizeof(edl_reset_soc_cmd));
++		if (ret < 0) {
++			BT_ERR("QCA send EDL_RESET_REQ error: %d", ret);
++			return;
++		}
++		serdev_device_wait_until_sent(serdev, timeout);
++		usleep_range(8000, 10000);
++	}
++}
++
++static int __maybe_unused qca_suspend(struct device *dev)
++{
++	struct serdev_device *serdev = to_serdev_device(dev);
++	struct qca_serdev *qcadev = serdev_device_get_drvdata(serdev);
++	struct hci_uart *hu = &qcadev->serdev_hu;
++	struct qca_data *qca = hu->priv;
++	unsigned long flags;
++	bool tx_pending = false;
++	int ret = 0;
++	u8 cmd;
++	unsigned long wait_timeout = 0;
++
++	set_bit(QCA_SUSPENDING, &qca->flags);
++
++	/* if BT SoC is running with default firmware then it does not
++	 * support in-band sleep
++	 */
++	if (test_bit(QCA_ROM_FW, &qca->flags))
++		return 0;
++
++	/* During SSR after memory dump collection, controller will be
++	 * powered off and then powered on.If controller is powered off
++	 * during SSR then we should wait until SSR is completed.
++	 */
++	if (test_bit(QCA_BT_OFF, &qca->flags) &&
++	    !test_bit(QCA_SSR_TRIGGERED, &qca->flags))
++		return 0;
++
++	if (test_bit(QCA_IBS_DISABLED, &qca->flags) ||
++	    test_bit(QCA_SSR_TRIGGERED, &qca->flags)) {
++		wait_timeout = test_bit(QCA_SSR_TRIGGERED, &qca->flags) ?
++					IBS_DISABLE_SSR_TIMEOUT :
++					FW_DOWNLOAD_TIMEOUT;
++
++		/* QCA_IBS_DISABLED flag is set to true, During FW download
++		 * and during memory dump collection. It is reset to false,
++		 * After FW download complete.
++		 */
++		wait_on_bit_timeout(&qca->flags, QCA_IBS_DISABLED,
++			    TASK_UNINTERRUPTIBLE, wait_timeout);
++
++		if (test_bit(QCA_IBS_DISABLED, &qca->flags)) {
++			bt_dev_err(hu->hdev, "SSR or FW download time out");
++			ret = -ETIMEDOUT;
++			goto error;
++		}
++	}
++
++	cancel_work_sync(&qca->ws_awake_device);
++	cancel_work_sync(&qca->ws_awake_rx);
++
++	spin_lock_irqsave_nested(&qca->hci_ibs_lock,
++				 flags, SINGLE_DEPTH_NESTING);
++
++	switch (qca->tx_ibs_state) {
++	case HCI_IBS_TX_WAKING:
++		timer_delete(&qca->wake_retrans_timer);
++		fallthrough;
++	case HCI_IBS_TX_AWAKE:
++		timer_delete(&qca->tx_idle_timer);
++
++		serdev_device_write_flush(hu->serdev);
++		cmd = HCI_IBS_SLEEP_IND;
++		ret = serdev_device_write_buf(hu->serdev, &cmd, sizeof(cmd));
++
++		if (ret < 0) {
++			BT_ERR("Failed to send SLEEP to device");
++			break;
++		}
++
++		qca->tx_ibs_state = HCI_IBS_TX_ASLEEP;
++		qca->ibs_sent_slps++;
++		tx_pending = true;
++		break;
++
++	case HCI_IBS_TX_ASLEEP:
++		break;
++
++	default:
++		BT_ERR("Spurious tx state %d", qca->tx_ibs_state);
++		ret = -EINVAL;
++		break;
++	}
++
++	spin_unlock_irqrestore(&qca->hci_ibs_lock, flags);
++
++	if (ret < 0)
++		goto error;
++
++	if (tx_pending) {
++		serdev_device_wait_until_sent(hu->serdev,
++					      CMD_TRANS_TIMEOUT);
++		serial_clock_vote(HCI_IBS_TX_VOTE_CLOCK_OFF, hu);
++	}
++
++	/* Wait for HCI_IBS_SLEEP_IND sent by device to indicate its Tx is going
++	 * to sleep, so that the packet does not wake the system later.
++	 */
++	ret = wait_event_interruptible_timeout(qca->suspend_wait_q,
++			qca->rx_ibs_state == HCI_IBS_RX_ASLEEP,
++			IBS_BTSOC_TX_IDLE_TIMEOUT);
++	if (ret == 0) {
++		ret = -ETIMEDOUT;
++		goto error;
++	}
++
++	return 0;
++
++error:
++	clear_bit(QCA_SUSPENDING, &qca->flags);
++
++	return ret;
++}
++
++static int __maybe_unused qca_resume(struct device *dev)
++{
++	struct serdev_device *serdev = to_serdev_device(dev);
++	struct qca_serdev *qcadev = serdev_device_get_drvdata(serdev);
++	struct hci_uart *hu = &qcadev->serdev_hu;
++	struct qca_data *qca = hu->priv;
++
++	clear_bit(QCA_SUSPENDING, &qca->flags);
++
++	return 0;
++}
++
++static SIMPLE_DEV_PM_OPS(qca_pm_ops, qca_suspend, qca_resume);
++
++#ifdef CONFIG_OF
++static const struct of_device_id qca_bluetooth_of_match[] = {
++	{ .compatible = "qcom,qca2066-bt", .data = &qca_soc_data_qca2066},
++	{ .compatible = "qcom,qca6174-bt" },
++	{ .compatible = "qcom,qca6390-bt", .data = &qca_soc_data_qca6390},
++	{ .compatible = "qcom,qca9377-bt" },
++	{ .compatible = "qcom,wcn3950-bt", .data = &qca_soc_data_wcn3950},
++	{ .compatible = "qcom,wcn3988-bt", .data = &qca_soc_data_wcn3988},
++	{ .compatible = "qcom,wcn3990-bt", .data = &qca_soc_data_wcn3990},
++	{ .compatible = "qcom,wcn3991-bt", .data = &qca_soc_data_wcn3991},
++	{ .compatible = "qcom,wcn3998-bt", .data = &qca_soc_data_wcn3998},
++	{ .compatible = "qcom,wcn6750-bt", .data = &qca_soc_data_wcn6750},
++	{ .compatible = "qcom,wcn6855-bt", .data = &qca_soc_data_wcn6855},
++	{ .compatible = "qcom,wcn7850-bt", .data = &qca_soc_data_wcn7850},
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, qca_bluetooth_of_match);
++#endif
++
++#ifdef CONFIG_ACPI
++static const struct acpi_device_id qca_bluetooth_acpi_match[] = {
++	{ "QCOM2066", (kernel_ulong_t)&qca_soc_data_qca2066 },
++	{ "QCOM6390", (kernel_ulong_t)&qca_soc_data_qca6390 },
++	{ "DLA16390", (kernel_ulong_t)&qca_soc_data_qca6390 },
++	{ "DLB16390", (kernel_ulong_t)&qca_soc_data_qca6390 },
++	{ "DLB26390", (kernel_ulong_t)&qca_soc_data_qca6390 },
++	{ },
++};
++MODULE_DEVICE_TABLE(acpi, qca_bluetooth_acpi_match);
++#endif
++
++#ifdef CONFIG_DEV_COREDUMP
++static void hciqca_coredump(struct device *dev)
++{
++	struct serdev_device *serdev = to_serdev_device(dev);
++	struct qca_serdev *qcadev = serdev_device_get_drvdata(serdev);
++	struct hci_uart *hu = &qcadev->serdev_hu;
++	struct hci_dev  *hdev = hu->hdev;
++
++	if (hdev->dump.coredump)
++		hdev->dump.coredump(hdev);
++}
++#endif
++
++static struct serdev_device_driver qca_serdev_driver = {
++	.probe = qca_serdev_probe,
++	.remove = qca_serdev_remove,
++	.shutdown = qca_serdev_shutdown,
++	.driver = {
++		.name = "hci_uart_qca",
++		.of_match_table = of_match_ptr(qca_bluetooth_of_match),
++		.acpi_match_table = ACPI_PTR(qca_bluetooth_acpi_match),
++		.pm = &qca_pm_ops,
++#ifdef CONFIG_DEV_COREDUMP
++		.coredump = hciqca_coredump,
++#endif
++	},
++};
++
++int __init qca_init(void)
++{
++	serdev_device_driver_register(&qca_serdev_driver);
++
++	return hci_uart_register_proto(&qca_proto);
++}
++
++int __exit qca_deinit(void)
++{
++	serdev_device_driver_unregister(&qca_serdev_driver);
++
++	return hci_uart_unregister_proto(&qca_proto);
++}
+diff --git a/drivers/gpu/drm/msm/adreno/adreno_gpu.h.orig b/drivers/gpu/drm/msm/adreno/adreno_gpu.h.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/gpu/drm/msm/adreno/adreno_gpu.h.orig
+@@ -0,0 +1,764 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++/*
++ * Copyright (C) 2013 Red Hat
++ * Author: Rob Clark <robdclark@gmail.com>
++ *
++ * Copyright (c) 2014,2017, 2019 The Linux Foundation. All rights reserved.
++ */
++
++#ifndef __ADRENO_GPU_H__
++#define __ADRENO_GPU_H__
++
++#include <linux/firmware.h>
++#include <linux/iopoll.h>
++
++#include <linux/soc/qcom/ubwc.h>
++
++#include "msm_gpu.h"
++
++#include "adreno_common.xml.h"
++#include "adreno_pm4.xml.h"
++
++extern bool snapshot_debugbus;
++
++enum {
++	ADRENO_FW_PM4 = 0,
++	ADRENO_FW_SQE = 0, /* a6xx */
++	ADRENO_FW_PFP = 1,
++	ADRENO_FW_GMU = 1, /* a6xx */
++	ADRENO_FW_GPMU = 2,
++	ADRENO_FW_AQE = 3,
++	ADRENO_FW_MAX,
++};
++
++/**
++ * @enum adreno_family: identify generation and possibly sub-generation
++ *
++ * In some cases there are distinct sub-generations within a major revision
++ * so it helps to be able to group the GPU devices by generation and if
++ * necessary sub-generation.
++ */
++enum adreno_family {
++	ADRENO_2XX_GEN1,  /* a20x */
++	ADRENO_2XX_GEN2,  /* a22x */
++	ADRENO_3XX,
++	ADRENO_4XX,
++	ADRENO_5XX,
++	ADRENO_6XX_GEN1,  /* a630 family */
++	ADRENO_6XX_GEN2,  /* a640 family */
++	ADRENO_6XX_GEN3,  /* a650 family */
++	ADRENO_6XX_GEN4,  /* a660 family */
++	ADRENO_7XX_GEN1,  /* a730 family */
++	ADRENO_7XX_GEN2,  /* a740 family */
++	ADRENO_7XX_GEN3,  /* a750 family */
++	ADRENO_8XX_GEN1,  /* a830 family */
++	ADRENO_8XX_GEN2,  /* a840 family */
++};
++
++#define ADRENO_QUIRK_TWO_PASS_USE_WFI		BIT(0)
++#define ADRENO_QUIRK_FAULT_DETECT_MASK		BIT(1)
++#define ADRENO_QUIRK_LMLOADKILL_DISABLE		BIT(2)
++#define ADRENO_QUIRK_HAS_HW_APRIV		BIT(3)
++#define ADRENO_QUIRK_HAS_CACHED_COHERENT	BIT(4)
++#define ADRENO_QUIRK_PREEMPTION			BIT(5)
++#define ADRENO_QUIRK_4GB_VA			BIT(6)
++#define ADRENO_QUIRK_IFPC			BIT(7)
++#define ADRENO_QUIRK_SOFTFUSE			BIT(8)
++
++/* Helper for formating the chip_id in the way that userspace tools like
++ * crashdec expect.
++ */
++#define ADRENO_CHIPID_FMT "08x"
++#define ADRENO_CHIPID_ARGS(_c) (_c)
++
++struct adreno_gpu;
++
++struct adreno_gpu_funcs {
++	struct msm_gpu_funcs base;
++	struct msm_gpu *(*init)(struct drm_device *dev);
++	u64 (*get_timestamp)(struct msm_gpu *gpu);
++	void (*bus_halt)(struct adreno_gpu *adreno_gpu, bool gx_off);
++	int (*mmu_fault_handler)(void *arg, unsigned long iova, int flags, void *data);
++	bool (*gx_is_on)(struct adreno_gpu *adreno_gpu);
++	bool (*aqe_is_enabled)(struct adreno_gpu *adreno_gpu);
++};
++
++struct adreno_reglist {
++	u32 offset;
++	u32 value;
++};
++
++/* Reglist with pipe information */
++struct adreno_reglist_pipe {
++	u32 offset;
++	u32 value;
++	u32 pipe;
++};
++
++struct adreno_speedbin {
++	uint16_t fuse;
++	uint16_t speedbin;
++};
++
++struct a6xx_info;
++
++struct adreno_info {
++	const char *machine;
++	/**
++	 * @chipids: Table of matching chip-ids
++	 *
++	 * Terminated with 0 sentinal
++	 */
++	uint32_t *chip_ids;
++	enum adreno_family family;
++	uint32_t revn;
++	const char *fw[ADRENO_FW_MAX];
++	uint32_t gmem;
++	u64 quirks;
++	const struct adreno_gpu_funcs *funcs;
++	const char *zapfw;
++	u32 inactive_period;
++	union {
++		const struct a6xx_info *a6xx;
++	};
++	/**
++	 * @speedbins: Optional table of fuse to speedbin mappings
++	 *
++	 * Consists of pairs of fuse, index mappings, terminated with
++	 * {SHRT_MAX, 0} sentinal.
++	 */
++	struct adreno_speedbin *speedbins;
++	u64 preempt_record_size;
++};
++
++#define ADRENO_CHIP_IDS(tbl...) (uint32_t[]) { tbl, 0 }
++
++struct adreno_gpulist {
++	const struct adreno_info *gpus;
++	unsigned gpus_count;
++};
++
++#define DECLARE_ADRENO_GPULIST(name)                  \
++const struct adreno_gpulist name ## _gpulist = {      \
++	name ## _gpus, ARRAY_SIZE(name ## _gpus)      \
++}
++
++/*
++ * Helper to build a speedbin table, ie. the table:
++ *      fuse | speedbin
++ *      -----+---------
++ *        0  |   0
++ *       169 |   1
++ *       174 |   2
++ *
++ * would be declared as:
++ *
++ *     .speedbins = ADRENO_SPEEDBINS(
++ *                      { 0,   0 },
++ *                      { 169, 1 },
++ *                      { 174, 2 },
++ *     ),
++ */
++#define ADRENO_SPEEDBINS(tbl...) (struct adreno_speedbin[]) { tbl {SHRT_MAX, 0} }
++
++struct adreno_protect {
++	const uint32_t *regs;
++	uint32_t count;
++	uint32_t count_max;
++};
++
++#define DECLARE_ADRENO_PROTECT(name, __count_max)	\
++static const struct adreno_protect name = {		\
++	.regs = name ## _regs,				\
++	.count = ARRAY_SIZE(name ## _regs),		\
++	.count_max = __count_max,			\
++};
++
++struct adreno_reglist_list {
++	/** @reg: List of register **/
++	const u32 *regs;
++	/** @count: Number of registers in the list **/
++	u32 count;
++};
++
++#define DECLARE_ADRENO_REGLIST_LIST(name)	\
++static const struct adreno_reglist_list name = {		\
++	.regs = name ## _regs,				\
++	.count = ARRAY_SIZE(name ## _regs),		\
++};
++
++struct adreno_reglist_pipe_list {
++	/** @reg: List of register **/
++	const struct adreno_reglist_pipe *regs;
++	/** @count: Number of registers in the list **/
++	u32 count;
++};
++
++#define DECLARE_ADRENO_REGLIST_PIPE_LIST(name)	\
++static const struct adreno_reglist_pipe_list name = {		\
++	.regs = name ## _regs,				\
++	.count = ARRAY_SIZE(name ## _regs),		\
++};
++
++struct adreno_gpu {
++	struct msm_gpu base;
++	const struct adreno_info *info;
++	uint32_t chip_id;
++	uint16_t speedbin;
++	const struct adreno_gpu_funcs *funcs;
++
++	struct completion fault_coredump_done;
++
++	/* interesting register offsets to dump: */
++	const unsigned int *registers;
++
++	/*
++	 * Are we loading fw from legacy path?  Prior to addition
++	 * of gpu firmware to linux-firmware, the fw files were
++	 * placed in toplevel firmware directory, following qcom's
++	 * android kernel.  But linux-firmware preferred they be
++	 * placed in a 'qcom' subdirectory.
++	 *
++	 * For backwards compatibility, we try first to load from
++	 * the new path, using request_firmware_direct() to avoid
++	 * any potential timeout waiting for usermode helper, then
++	 * fall back to the old path (with direct load).  And
++	 * finally fall back to request_firmware() with the new
++	 * path to allow the usermode helper.
++	 */
++	enum {
++		FW_LOCATION_UNKNOWN = 0,
++		FW_LOCATION_NEW,       /* /lib/firmware/qcom/$fwfile */
++		FW_LOCATION_LEGACY,    /* /lib/firmware/$fwfile */
++		FW_LOCATION_HELPER,
++	} fwloc;
++
++	/* firmware: */
++	const struct firmware *fw[ADRENO_FW_MAX];
++
++	/*
++	 * The migration to the central UBWC config db is still in flight - keep
++	 * a copy containing some local fixups until that's done.
++	 */
++	const struct qcom_ubwc_cfg_data *ubwc_config;
++	struct qcom_ubwc_cfg_data _ubwc_config;
++
++	/*
++	 * Register offsets are different between some GPUs.
++	 * GPU specific offsets will be exported by GPU specific
++	 * code (a3xx_gpu.c) and stored in this common location.
++	 */
++	const unsigned int *reg_offsets;
++	bool gmu_is_wrapper;
++
++	bool has_ray_tracing;
++
++	u64 uche_trap_base;
++};
++#define to_adreno_gpu(x) container_of(x, struct adreno_gpu, base)
++
++struct adreno_ocmem {
++	struct ocmem *ocmem;
++	unsigned long base;
++	void *hdl;
++};
++
++/* platform config data (ie. from DT, or pdata) */
++struct adreno_platform_config {
++	uint32_t chip_id;
++	const struct adreno_info *info;
++};
++
++#define ADRENO_IDLE_TIMEOUT msecs_to_jiffies(1000)
++
++#define spin_until(X) ({                                   \
++	int __ret = -ETIMEDOUT;                            \
++	unsigned long __t = jiffies + ADRENO_IDLE_TIMEOUT; \
++	do {                                               \
++		if (X) {                                   \
++			__ret = 0;                         \
++			break;                             \
++		}                                          \
++	} while (time_before(jiffies, __t));               \
++	__ret;                                             \
++})
++
++static inline uint8_t adreno_patchid(const struct adreno_gpu *gpu)
++{
++	/* It is probably ok to assume legacy "adreno_rev" format
++	 * for all a6xx devices, but probably best to limit this
++	 * to older things.
++	 */
++	WARN_ON_ONCE(gpu->info->family >= ADRENO_6XX_GEN1);
++	return gpu->chip_id & 0xff;
++}
++
++static inline bool adreno_is_revn(const struct adreno_gpu *gpu, uint32_t revn)
++{
++	if (WARN_ON_ONCE(!gpu->info))
++		return false;
++	return gpu->info->revn == revn;
++}
++
++static inline bool adreno_has_gmu_wrapper(const struct adreno_gpu *gpu)
++{
++	return gpu->gmu_is_wrapper;
++}
++
++static inline bool adreno_is_a2xx(const struct adreno_gpu *gpu)
++{
++	if (WARN_ON_ONCE(!gpu->info))
++		return false;
++	return gpu->info->family <= ADRENO_2XX_GEN2;
++}
++
++static inline bool adreno_is_a20x(const struct adreno_gpu *gpu)
++{
++	if (WARN_ON_ONCE(!gpu->info))
++		return false;
++	return gpu->info->family == ADRENO_2XX_GEN1;
++}
++
++static inline bool adreno_is_a225(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 225);
++}
++
++static inline bool adreno_is_a305(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 305);
++}
++
++static inline bool adreno_is_a305b(const struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x03000512;
++}
++
++static inline bool adreno_is_a306(const struct adreno_gpu *gpu)
++{
++	/* yes, 307, because a305c is 306 */
++	return adreno_is_revn(gpu, 307);
++}
++
++static inline bool adreno_is_a306a(const struct adreno_gpu *gpu)
++{
++	/* a306a (marketing name is a308) */
++	return adreno_is_revn(gpu, 308);
++}
++
++static inline bool adreno_is_a320(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 320);
++}
++
++static inline bool adreno_is_a330(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 330);
++}
++
++static inline bool adreno_is_a330v2(const struct adreno_gpu *gpu)
++{
++	return adreno_is_a330(gpu) && (adreno_patchid(gpu) > 0);
++}
++
++static inline int adreno_is_a405(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 405);
++}
++
++static inline int adreno_is_a420(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 420);
++}
++
++static inline int adreno_is_a430(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 430);
++}
++
++static inline int adreno_is_a505(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 505);
++}
++
++static inline int adreno_is_a506(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 506);
++}
++
++static inline int adreno_is_a508(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 508);
++}
++
++static inline int adreno_is_a509(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 509);
++}
++
++static inline int adreno_is_a510(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 510);
++}
++
++static inline int adreno_is_a512(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 512);
++}
++
++static inline int adreno_is_a530(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 530);
++}
++
++static inline int adreno_is_a540(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 540);
++}
++
++static inline int adreno_is_a610(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 610);
++}
++
++static inline int adreno_is_a612(const struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x06010200;
++}
++
++static inline bool adreno_has_rgmu(const struct adreno_gpu *gpu)
++{
++	return adreno_is_a612(gpu);
++}
++
++static inline int adreno_is_a618(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 618);
++}
++
++static inline int adreno_is_a619(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 619);
++}
++
++static inline int adreno_is_a619_holi(const struct adreno_gpu *gpu)
++{
++	return adreno_is_a619(gpu) && adreno_has_gmu_wrapper(gpu);
++}
++
++static inline int adreno_is_a621(const struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x06020100;
++}
++
++static inline int adreno_is_a623(const struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x06020300;
++}
++
++static inline int adreno_is_a630(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 630);
++}
++
++static inline int adreno_is_a640(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 640);
++}
++
++static inline int adreno_is_a650(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 650);
++}
++
++static inline int adreno_is_7c3(const struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x06030500;
++}
++
++static inline int adreno_is_a660(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 660);
++}
++
++static inline int adreno_is_a680(const struct adreno_gpu *gpu)
++{
++	return adreno_is_revn(gpu, 680);
++}
++
++static inline int adreno_is_a663(const struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x06060300;
++}
++
++static inline int adreno_is_a690(const struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x06090000;
++}
++
++static inline int adreno_is_a702(const struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x07000200;
++}
++
++static inline int adreno_is_a610_family(const struct adreno_gpu *gpu)
++{
++	if (WARN_ON_ONCE(!gpu->info))
++		return false;
++	return adreno_is_a610(gpu) ||
++	       adreno_is_a612(gpu) ||
++	       adreno_is_a702(gpu);
++}
++
++/* TODO: 615/616 */
++static inline int adreno_is_a615_family(const struct adreno_gpu *gpu)
++{
++	return adreno_is_a618(gpu) ||
++	       adreno_is_a619(gpu);
++}
++
++static inline int adreno_is_a630_family(const struct adreno_gpu *gpu)
++{
++	if (WARN_ON_ONCE(!gpu->info))
++		return false;
++	return gpu->info->family == ADRENO_6XX_GEN1;
++}
++
++static inline int adreno_is_a660_family(const struct adreno_gpu *gpu)
++{
++	if (WARN_ON_ONCE(!gpu->info))
++		return false;
++	return gpu->info->family == ADRENO_6XX_GEN4;
++}
++
++/* check for a650, a660, or any derivatives */
++static inline int adreno_is_a650_family(const struct adreno_gpu *gpu)
++{
++	if (WARN_ON_ONCE(!gpu->info))
++		return false;
++	return gpu->info->family == ADRENO_6XX_GEN3 ||
++	       gpu->info->family == ADRENO_6XX_GEN4;
++}
++
++static inline int adreno_is_a640_family(const struct adreno_gpu *gpu)
++{
++	if (WARN_ON_ONCE(!gpu->info))
++		return false;
++	return gpu->info->family == ADRENO_6XX_GEN2;
++}
++
++static inline int adreno_is_a730(struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x07030001;
++}
++
++static inline int adreno_is_a740(struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x43050a01;
++}
++
++static inline int adreno_is_a750(struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x43051401;
++}
++
++static inline int adreno_is_x185(struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x43050c01;
++}
++
++static inline int adreno_is_a740_family(struct adreno_gpu *gpu)
++{
++	if (WARN_ON_ONCE(!gpu->info))
++		return false;
++	return gpu->info->family == ADRENO_7XX_GEN2 ||
++	       gpu->info->family == ADRENO_7XX_GEN3;
++}
++
++static inline int adreno_is_a750_family(struct adreno_gpu *gpu)
++{
++	return gpu->info->family == ADRENO_7XX_GEN3;
++}
++
++static inline int adreno_is_a7xx(struct adreno_gpu *gpu)
++{
++	/* Update with non-fake (i.e. non-A702) Gen 7 GPUs */
++	return gpu->info->family == ADRENO_7XX_GEN1 ||
++	       adreno_is_a740_family(gpu);
++}
++
++static inline int adreno_is_a8xx(struct adreno_gpu *gpu)
++{
++	return gpu->info->family >= ADRENO_8XX_GEN1;
++}
++
++static inline int adreno_is_x285(struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x44070001;
++}
++
++static inline int adreno_is_a840(struct adreno_gpu *gpu)
++{
++	return gpu->info->chip_ids[0] == 0x44050a01;
++}
++
++/* Put vm_start above 32b to catch issues with not setting xyz_BASE_HI */
++#define ADRENO_VM_START 0x100000000ULL
++u64 adreno_private_vm_size(struct msm_gpu *gpu);
++int adreno_get_param(struct msm_gpu *gpu, struct msm_context *ctx,
++		     uint32_t param, uint64_t *value, uint32_t *len);
++int adreno_set_param(struct msm_gpu *gpu, struct msm_context *ctx,
++		     uint32_t param, uint64_t value, uint32_t len);
++const struct firmware *adreno_request_fw(struct adreno_gpu *adreno_gpu,
++		const char *fwname);
++struct drm_gem_object *adreno_fw_create_bo(struct msm_gpu *gpu,
++		const struct firmware *fw, u64 *iova);
++int adreno_hw_init(struct msm_gpu *gpu);
++void adreno_recover(struct msm_gpu *gpu);
++void adreno_flush(struct msm_gpu *gpu, struct msm_ringbuffer *ring, u32 reg);
++bool adreno_idle(struct msm_gpu *gpu, struct msm_ringbuffer *ring);
++#if defined(CONFIG_DEBUG_FS) || defined(CONFIG_DEV_COREDUMP)
++void adreno_show(struct msm_gpu *gpu, struct msm_gpu_state *state,
++		struct drm_printer *p);
++#endif
++void adreno_dump_info(struct msm_gpu *gpu);
++void adreno_dump(struct msm_gpu *gpu);
++void adreno_wait_ring(struct msm_ringbuffer *ring, uint32_t ndwords);
++struct msm_ringbuffer *adreno_active_ring(struct msm_gpu *gpu);
++
++int adreno_gpu_ocmem_init(struct device *dev, struct adreno_gpu *adreno_gpu,
++			  struct adreno_ocmem *ocmem);
++void adreno_gpu_ocmem_cleanup(struct adreno_ocmem *ocmem);
++
++int adreno_gpu_init(struct drm_device *drm, struct platform_device *pdev,
++		struct adreno_gpu *gpu, const struct adreno_gpu_funcs *funcs,
++		int nr_rings);
++void adreno_gpu_cleanup(struct adreno_gpu *gpu);
++int adreno_load_fw(struct adreno_gpu *adreno_gpu);
++
++void adreno_gpu_state_destroy(struct msm_gpu_state *state);
++
++int adreno_gpu_state_get(struct msm_gpu *gpu, struct msm_gpu_state *state);
++int adreno_gpu_state_put(struct msm_gpu_state *state);
++void adreno_show_object(struct drm_printer *p, void **ptr, int len,
++		bool *encoded);
++
++/*
++ * Common helper function to initialize the default address space for arm-smmu
++ * attached targets
++ */
++struct drm_gpuvm *
++adreno_create_vm(struct msm_gpu *gpu,
++		 struct platform_device *pdev);
++
++struct drm_gpuvm *
++adreno_iommu_create_vm(struct msm_gpu *gpu,
++		       struct platform_device *pdev,
++		       unsigned long quirks);
++
++int adreno_fault_handler(struct msm_gpu *gpu, unsigned long iova, int flags,
++			 struct adreno_smmu_fault_info *info, const char *block,
++			 u32 scratch[4]);
++
++void adreno_check_and_reenable_stall(struct adreno_gpu *gpu);
++
++int adreno_read_speedbin(struct device *dev, u32 *speedbin);
++
++/*
++ * For a5xx and a6xx targets load the zap shader that is used to pull the GPU
++ * out of secure mode
++ */
++int adreno_zap_shader_load(struct msm_gpu *gpu, u32 pasid);
++
++/* ringbuffer helpers (the parts that are adreno specific) */
++
++static inline void
++OUT_PKT0(struct msm_ringbuffer *ring, uint16_t regindx, uint16_t cnt)
++{
++	adreno_wait_ring(ring, cnt+1);
++	OUT_RING(ring, CP_TYPE0_PKT | ((cnt-1) << 16) | (regindx & 0x7FFF));
++}
++
++/* no-op packet: */
++static inline void
++OUT_PKT2(struct msm_ringbuffer *ring)
++{
++	adreno_wait_ring(ring, 1);
++	OUT_RING(ring, CP_TYPE2_PKT);
++}
++
++static inline void
++OUT_PKT3(struct msm_ringbuffer *ring, uint8_t opcode, uint16_t cnt)
++{
++	adreno_wait_ring(ring, cnt+1);
++	OUT_RING(ring, CP_TYPE3_PKT | ((cnt-1) << 16) | ((opcode & 0xFF) << 8));
++}
++
++static inline u32 PM4_PARITY(u32 val)
++{
++	return (0x9669 >> (0xF & (val ^
++		(val >> 4) ^ (val >> 8) ^ (val >> 12) ^
++		(val >> 16) ^ ((val) >> 20) ^ (val >> 24) ^
++		(val >> 28)))) & 1;
++}
++
++/* Maximum number of values that can be executed for one opcode */
++#define TYPE4_MAX_PAYLOAD 127
++
++#define PKT4(_reg, _cnt) \
++	(CP_TYPE4_PKT | ((_cnt) << 0) | (PM4_PARITY((_cnt)) << 7) | \
++	 (((_reg) & 0x3FFFF) << 8) | (PM4_PARITY((_reg)) << 27))
++
++static inline void
++OUT_PKT4(struct msm_ringbuffer *ring, uint16_t regindx, uint16_t cnt)
++{
++	adreno_wait_ring(ring, cnt + 1);
++	OUT_RING(ring, PKT4(regindx, cnt));
++}
++
++#define PKT7(opcode, cnt) \
++	(CP_TYPE7_PKT | (cnt << 0) | (PM4_PARITY(cnt) << 15) | \
++		((opcode & 0x7F) << 16) | (PM4_PARITY(opcode) << 23))
++
++static inline void
++OUT_PKT7(struct msm_ringbuffer *ring, uint8_t opcode, uint16_t cnt)
++{
++	adreno_wait_ring(ring, cnt + 1);
++	OUT_RING(ring, PKT7(opcode, cnt));
++}
++
++static inline uint32_t get_wptr(struct msm_ringbuffer *ring)
++{
++	return (ring->cur - ring->start) % (MSM_GPU_RINGBUFFER_SZ >> 2);
++}
++
++/*
++ * Given a register and a count, return a value to program into
++ * REG_CP_PROTECT_REG(n) - this will block both reads and writes for _len
++ * registers starting at _reg.
++ *
++ * The register base needs to be a multiple of the length. If it is not, the
++ * hardware will quietly mask off the bits for you and shift the size. For
++ * example, if you intend the protection to start at 0x07 for a length of 4
++ * (0x07-0x0A) the hardware will actually protect (0x04-0x07) which might
++ * expose registers you intended to protect!
++ */
++#define ADRENO_PROTECT_RW(_reg, _len) \
++	((1 << 30) | (1 << 29) | \
++	((ilog2((_len)) & 0x1F) << 24) | (((_reg) << 2) & 0xFFFFF))
++
++/*
++ * Same as above, but allow reads over the range. For areas of mixed use (such
++ * as performance counters) this allows us to protect a much larger range with a
++ * single register
++ */
++#define ADRENO_PROTECT_RDONLY(_reg, _len) \
++	((1 << 29) \
++	((ilog2((_len)) & 0x1F) << 24) | (((_reg) << 2) & 0xFFFFF))
++
++
++#define gpu_poll_timeout(gpu, addr, val, cond, interval, timeout) \
++	readl_poll_timeout((gpu)->mmio + ((addr) << 2), val, cond, \
++		interval, timeout)
++
++#endif /* __ADRENO_GPU_H__ */
+diff --git a/drivers/gpu/drm/panel/Kconfig.orig b/drivers/gpu/drm/panel/Kconfig.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/gpu/drm/panel/Kconfig.orig
+@@ -0,0 +1,1310 @@
++# SPDX-License-Identifier: GPL-2.0-only
++config DRM_PANEL
++	bool
++	depends on DRM
++	help
++	  Panel registration and lookup framework.
++
++menu "Display Panels"
++	depends on DRM && DRM_PANEL
++
++config DRM_PANEL_ABT_Y030XX067A
++	tristate "ABT Y030XX067A 320x480 LCD panel"
++	depends on OF && SPI
++	select REGMAP_SPI
++	help
++	  Say Y here to enable support for the Asia Better Technology Ltd.
++	  Y030XX067A 320x480 3.0" panel as found in the YLM RG-280M, RG-300
++	  and RG-99 handheld gaming consoles.
++
++config DRM_PANEL_ARM_VERSATILE
++	tristate "ARM Versatile panel driver"
++	depends on OF
++	depends on MFD_SYSCON
++	select VIDEOMODE_HELPERS
++	help
++	  This driver supports the ARM Versatile panels connected to ARM
++	  reference designs. The panel is detected using special registers
++	  in the Versatile family syscon registers.
++
++config DRM_PANEL_ASUS_Z00T_TM5P5_NT35596
++	tristate "ASUS Z00T TM5P5 NT35596 panel"
++	depends on GPIOLIB && OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the ASUS TMP5P5
++	  NT35596 1080x1920 video mode panel as found in some Asus
++	  Zenfone 2 Laser Z00T devices.
++
++config DRM_PANEL_AUO_A030JTN01
++	tristate "AUO A030JTN01"
++	depends on SPI
++	select REGMAP_SPI
++	help
++	  Say Y here to enable support for the AUO A030JTN01 320x480 3.0" panel
++	  as found in the YLM RS-97 handheld gaming console.
++
++config DRM_PANEL_BOE_BF060Y8M_AJ0
++	tristate "Boe BF060Y8M-AJ0 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Boe BF060Y8M-AJ0
++	  5.99" AMOLED modules. The panel has a 1080x2160 resolution and
++	  uses 24 bit RGB per pixel. It provides a MIPI DSI interface to
++	  the host and backlight is controlled through DSI commands.
++
++config DRM_PANEL_BOE_HIMAX8279D
++	tristate "Boe Himax8279d panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Boe Himax8279d
++	  TFT-LCD modules. The panel has a 1200x1920 resolution and uses
++	  24 bit RGB per pixel. It provides a MIPI DSI interface to
++	  the host and has a built-in LED backlight.
++
++config DRM_PANEL_BOE_TD4320
++	tristate "BOE TD4320 DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for BOE TD4320 1080x2340
++	  video mode panel found in Xiaomi Redmi Note 7 smartphones.
++
++config DRM_PANEL_BOE_TH101MB31UIG002_28A
++	tristate "Boe TH101MB31UIG002-28A panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Boe
++	  TH101MB31UIG002-28A TFT-LCD modules. The panel has a 800x1280
++	  resolution and uses 24 bit RGB per pixel. It provides a MIPI DSI
++	  interface to the host and has a built-in LED backlight.
++
++config DRM_PANEL_BOE_TV101WUM_NL6
++	tristate "BOE TV101WUM and AUO KD101N80 45NA 1200x1920 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to support for BOE TV101WUM and AUO KD101N80
++	  45NA WUXGA PANEL DSI Video Mode panel
++
++config DRM_PANEL_BOE_TV101WUM_LL2
++	tristate "BOE TV101WUM LL2 1200x1920 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to support for BOE TV101WUM-LL2
++	  WUXGA PANEL DSI Video Mode panel
++
++config DRM_PANEL_EBBG_FT8719
++	tristate "EBBG FT8719 panel driver"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the EBBG FT8719
++	  video mode panel. Mainly found on Xiaomi Poco F1 mobile phone.
++	  The panel has a resolution of 1080x2246. It provides a MIPI DSI
++	  interface to the host.
++
++config DRM_PANEL_ELIDA_KD35T133
++	tristate "Elida KD35T133 panel driver"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Elida
++	  KD35T133 controller for 320x480 LCD panels with MIPI-DSI
++	  system interfaces.
++
++config DRM_PANEL_FEIXIN_K101_IM2BA02
++	tristate "Feixin K101 IM2BA02 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Feixin K101 IM2BA02
++	  4-lane 800x1280 MIPI DSI panel.
++
++config DRM_PANEL_FEIYANG_FY07024DI26A30D
++	tristate "Feiyang FY07024DI26A30-D MIPI-DSI LCD panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y if you want to enable support for panels based on the
++	  Feiyang FY07024DI26A30-D MIPI-DSI interface.
++
++config DRM_PANEL_DSI_CM
++	tristate "Generic DSI command mode panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  DRM panel driver for DSI command mode panels with support for
++	  embedded and external backlights.
++
++config DRM_PANEL_LVDS
++	tristate "Generic LVDS panel driver"
++	depends on OF
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++	help
++	  This driver supports LVDS panels that don't require device-specific
++	  handling of power supplies or control signals. It implements automatic
++	  backlight handling if the panel is attached to a backlight controller.
++
++config DRM_PANEL_HIMAX_HX8279
++	tristate "Himax HX8279-based panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y if you want to enable support for panels based on the
++	  Himax HX8279 controller, such as the Startek KD070FHFID078
++	  7.0" 1200x1920 IPS LCD panel that uses a MIPI-DSI interface
++	  and others.
++
++config DRM_PANEL_HIMAX_HX83102
++	tristate "Himax HX83102-based panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y if you want to enable support for panels based on the
++	  Himax HX83102 controller.
++
++config DRM_PANEL_HIMAX_HX83112A
++	tristate "Himax HX83112A-based DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_KMS_HELPER
++	help
++	  Say Y here if you want to enable support for Himax HX83112A-based
++	  display panels, such as the one found in the Fairphone 4 smartphone.
++
++config DRM_PANEL_HIMAX_HX83112B
++	tristate "Himax HX83112B-based DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_KMS_HELPER
++	help
++	  Say Y here if you want to enable support for Himax HX83112B-based
++	  display panels, such as the one found in the Fairphone 3 smartphone.
++
++config DRM_PANEL_HIMAX_HX83121A
++	tristate "Himax HX83121A-based DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_DISPLAY_HELPER
++	select DRM_DISPLAY_DSC_HELPER
++	select DRM_KMS_HELPER
++	help
++	  Say Y here if you want to enable support for Himax HX83121A-based
++	  display panels, such as the one found in the HUAWEI Matebook E Go
++          series.
++
++config DRM_PANEL_HIMAX_HX8394
++	tristate "HIMAX HX8394 MIPI-DSI LCD panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y if you want to enable support for panels based on the
++	  Himax HX8394 controller, such as the HannStar HSD060BHW4
++	  720x1440 TFT LCD panel that uses a MIPI-DSI interface.
++
++	  If M is selected the module will be called panel-himax-hx8394.
++
++config DRM_PANEL_HYDIS_HV101HD1
++	tristate "Hydis HV101HD1 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Hydis HV101HD1
++	  2-lane 1366x768 MIPI DSI panel found in ASUS VivoTab RT TF600T.
++	  HV101HD1 is a color active matrix TFT LCD module using amorphous
++	  silicon TFT's (Thin Film Transistors) as an active switching devices.
++
++	  If M is selected the module will be called panel-hydis-hv101hd1
++
++config DRM_PANEL_ILITEK_IL9322
++	tristate "Ilitek ILI9322 320x240 QVGA panels"
++	depends on OF && SPI
++	select REGMAP
++	help
++	  Say Y here if you want to enable support for Ilitek IL9322
++	  QVGA (320x240) RGB, YUV and ITU-T BT.656 panels.
++
++config DRM_PANEL_ILITEK_ILI9341
++	tristate "Ilitek ILI9341 240x320 QVGA panels"
++	depends on SPI
++	select DRM_KMS_HELPER
++	select DRM_GEM_DMA_HELPER
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_MIPI_DBI
++	help
++	  Say Y here if you want to enable support for Ilitek IL9341
++	  QVGA (240x320) RGB panels. support serial & parallel rgb
++	  interface.
++
++config DRM_PANEL_ILITEK_ILI9805
++	tristate "Ilitek ILI9805-based panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y if you want to enable support for panels based on the
++	  Ilitek ILI9805 controller.
++
++config DRM_PANEL_ILITEK_ILI9806E_CORE
++	tristate
++
++config DRM_PANEL_ILITEK_ILI9806E_DSI
++	tristate "Ilitek ILI9806E-based DSI panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_PANEL_ILITEK_ILI9806E_CORE
++	help
++	  Say Y if you want to enable support for panels based on the
++	  Ilitek ILI9806E controller using DSI.
++
++config DRM_PANEL_ILITEK_ILI9806E_SPI
++	tristate "Ilitek ILI9806E-based RGB SPI panel"
++	depends on OF
++	depends on SPI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_MIPI_DBI
++	select VIDEOMODE_HELPERS
++	select DRM_PANEL_ILITEK_ILI9806E_CORE
++	help
++	  Say Y if you want to enable support for panels based on the
++	  Ilitek ILI9806E controller using SPI.
++
++config DRM_PANEL_ILITEK_ILI9881C
++	tristate "Ilitek ILI9881C-based panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y if you want to enable support for panels based on the
++	  Ilitek ILI9881c controller.
++
++config DRM_PANEL_ILITEK_ILI9882T
++	tristate "Ilitek ILI9882t-based panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_DISPLAY_HELPER
++	select DRM_DISPLAY_DSC_HELPER
++	help
++	  Say Y if you want to enable support for panels based on the
++	  Ilitek ILI9882t controller.
++
++config DRM_PANEL_INNOLUX_EJ030NA
++        tristate "Innolux EJ030NA 320x480 LCD panel"
++        depends on OF && SPI
++        select REGMAP_SPI
++        help
++          Say Y here to enable support for the Innolux/Chimei EJ030NA
++          320x480 3.0" panel as found in the RS97 V2.1, RG300(non-ips)
++          and LDK handheld gaming consoles.
++
++config DRM_PANEL_INNOLUX_P079ZCA
++	tristate "Innolux P079ZCA panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Innolux P079ZCA
++	  TFT-LCD modules. The panel has a 1024x768 resolution and uses
++	  24 bit RGB per pixel. It provides a MIPI DSI interface to
++	  the host and has a built-in LED backlight.
++
++config DRM_PANEL_JADARD_JD9365DA_H3
++	tristate "Jadard JD9365DA-H3 WXGA DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Jadard JD9365DA-H3
++	  WXGA MIPI DSI panel. The panel support TFT dot matrix LCD with
++	  800RGBx1280 dots at maximum.
++
++config DRM_PANEL_JDI_LPM102A188A
++	tristate "JDI LPM102A188A DSI panel"
++	depends on OF && GPIOLIB
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for JDI LPM102A188A DSI
++	  command mode panel as found in Google Pixel C devices.
++	  The panel has a 2560×1800 resolution. It provides a MIPI DSI interface
++	  to the host.
++
++config DRM_PANEL_JDI_LT070ME05000
++	tristate "JDI LT070ME05000 WUXGA DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for JDI DSI video mode
++	  panel as found in Google Nexus 7 (2013) devices.
++	  The panel has a 1200(RGB)×1920 (WUXGA) resolution and uses
++	  24 bit per pixel.
++
++config DRM_PANEL_JDI_R63452
++	tristate "JDI R63452 Full HD DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the JDI R63452
++	  DSI command mode panel as found in Xiaomi Mi 5 Devices.
++
++config DRM_PANEL_KHADAS_TS050
++	tristate "Khadas TS050 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Khadas TS050 TFT-LCD
++	  panel module. The panel has a 1080x1920 resolution and uses
++	  24 bit RGB per pixel. It provides a MIPI DSI interface to
++	  the host, a built-in LED backlight and touch controller.
++
++config DRM_PANEL_KINGDISPLAY_KD097D04
++	tristate "Kingdisplay kd097d04 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Kingdisplay kd097d04
++	  TFT-LCD modules. The panel has a 1536x2048 resolution and uses
++	  24 bit RGB per pixel. It provides a MIPI DSI interface to
++	  the host and has a built-in LED backlight.
++
++config DRM_PANEL_LEADTEK_LTK050H3146W
++	tristate "Leadtek LTK050H3146W panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Leadtek LTK050H3146W
++	  TFT-LCD modules. The panel has a 720x1280 resolution and uses
++	  24 bit RGB per pixel. It provides a MIPI DSI interface to
++	  the host and has a built-in LED backlight.
++
++config DRM_PANEL_LEADTEK_LTK500HD1829
++	tristate "Leadtek LTK500HD1829 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Kingdisplay kd097d04
++	  TFT-LCD modules. The panel has a 1536x2048 resolution and uses
++	  24 bit RGB per pixel. It provides a MIPI DSI interface to
++	  the host and has a built-in LED backlight.
++
++config DRM_PANEL_LINCOLNTECH_LCD197
++	tristate "Lincoln Technologies lcd197 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for lincolntech lcd197
++	  TFT-LCD modules. The panel has a 1080x1920 resolution and uses
++	  24 bit RGB per pixel. It provides a MIPI DSI interface to
++	  the host.
++
++config DRM_PANEL_LG_LB035Q02
++	tristate "LG LB035Q024573 RGB panel"
++	depends on GPIOLIB && OF && SPI
++	help
++	  Say Y here if you want to enable support for the LB035Q02 RGB panel
++	  (found on the Gumstix Overo Palo35 board). To compile this driver as
++	  a module, choose M here.
++
++config DRM_PANEL_LG_LD070WX3
++	tristate "LG LD070WX3 MIPI DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++	help
++	  Say Y here if you want to enable support for the LD070WX3 MIPI DSI
++	  panel found in the NVIDIA Tegra Note 7 tablet.
++
++	  To compile this driver as a module, choose M here: the module will
++	  be called panel-lg-ld070wx3.
++
++config DRM_PANEL_LG_LG4573
++	tristate "LG4573 RGB/SPI panel"
++	depends on OF && SPI
++	select VIDEOMODE_HELPERS
++	help
++	  Say Y here if you want to enable support for LG4573 RGB panel.
++	  To compile this driver as a module, choose M here.
++
++config DRM_PANEL_LG_SW43408
++	tristate "LG SW43408 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_DISPLAY_DSC_HELPER
++	select DRM_DISPLAY_HELPER
++	help
++	  Say Y here if you want to enable support for LG sw43408 panel.
++	  The panel has a 1080x2160@60Hz resolution and uses 24 bit RGB per
++	  pixel. It provides a MIPI DSI interface to the host and has a
++	  built-in LED backlight.
++
++config DRM_PANEL_LXD_M9189A
++	tristate "LXD M9189A MIPI-DSI LCD panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y if you want to enable support for the LXD M9189A 4-Lane
++	  1024x600 MIPI DSI panel.
++
++config DRM_PANEL_MAGNACHIP_D53E6EA8966
++	tristate "Magnachip D53E6EA8966 DSI panel"
++	depends on OF && SPI
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_MIPI_DBI
++	help
++	  DRM panel driver for the Samsung AMS495QA01 panel controlled
++	  with the Magnachip D53E6EA8966 panel IC. This panel receives
++	  video data via DSI but commands via 9-bit SPI using DBI.
++
++config DRM_PANEL_MANTIX_MLAF057WE51
++	tristate "Mantix MLAF057WE51-X MIPI-DSI LCD panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Mantix
++	  MLAF057WE51-X MIPI DSI panel as e.g. used in the Librem 5. It
++	  has a resolution of 720x1440 pixels, a built in backlight and touch
++	  controller.
++
++config DRM_PANEL_MOTOROLA_MOT
++	tristate "Atrix 4G and Droid X2 540x960 DSI video mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++	help
++	  Say Y here if you want to enable support for the LCD panel module
++	  for Motorola Atrix 4G or Droid X2. Exact panel vendor and model are
++	  unknown. The panel has a 540x960 resolution and uses 24 bit RGB per
++	  pixel.
++
++config DRM_PANEL_NEC_NL8048HL11
++	tristate "NEC NL8048HL11 RGB panel"
++	depends on GPIOLIB && OF && SPI
++	help
++	  Say Y here if you want to enable support for the NEC NL8048HL11 RGB
++	  panel (found on the Zoom2/3/3630 SDP boards). To compile this driver
++	  as a module, choose M here.
++
++config DRM_PANEL_NEWVISION_NV3051D
++	tristate "NewVision NV3051D DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  This driver supports the NV3051D based panel found on the Anbernic
++	  RG353P and RG353V.
++
++config DRM_PANEL_NEWVISION_NV3052C
++	tristate "NewVision NV3052C RGB/SPI panel"
++	depends on OF && SPI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_MIPI_DBI
++	help
++	  Say Y here if you want to enable support for the panels built
++	  around the NewVision NV3052C display controller.
++
++config DRM_PANEL_NOVATEK_NT35510
++	tristate "Novatek NT35510 RGB panel driver"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the panels built
++	  around the Novatek NT35510 display controller, such as some
++	  Hydis panels.
++
++config DRM_PANEL_NOVATEK_NT35560
++	tristate "Novatek NT35560 DSI command mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++	help
++	  Say Y here if you want to enable the Novatek NT35560 display
++	  controller. This panel supports DSI in both command and video
++	  mode. This supports several panels such as Sony ACX424AKM and
++	  ACX424AKP.
++
++config DRM_PANEL_NOVATEK_NT35950
++	tristate "Novatek NT35950 DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the panels built
++	  around the Novatek NT35950 display controller, such as some
++	  Sharp panels used in Sony Xperia Z5 Premium and XZ Premium
++	  mobile phones.
++
++config DRM_PANEL_NOVATEK_NT36523
++	tristate "Novatek NT36523 panel driver"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the panels built
++	  around the Novatek NT36523 display controller, such as some
++	  Boe panels used in Xiaomi Mi Pad 5 and 5 Pro tablets.
++
++config DRM_PANEL_NOVATEK_NT36672A
++	tristate "Novatek NT36672A DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the panels built
++	  around the Novatek NT36672A display controller, such as some
++	  Tianma panels used in a few Xiaomi Poco F1 mobile phones.
++
++config DRM_PANEL_NOVATEK_NT36672E
++	tristate "Novatek NT36672E DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Novatek NT36672E DSI Video Mode
++	  LCD panel module. The panel has a resolution of 1080x2408 and uses 24 bit
++	  RGB per pixel.
++
++config DRM_PANEL_NOVATEK_NT37700F
++	tristate "Novatek NT37700F DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Novatek NT37700F DSI
++	  panel module. The panel has a resolution of 1080x2160.
++
++config DRM_PANEL_NOVATEK_NT37801
++	tristate "Novatek NT37801/NT37810 AMOLED DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_DISPLAY_DSC_HELPER
++	select DRM_DISPLAY_HELPER
++	help
++	  Say Y here if you want to enable support for Novatek NT37801 (or
++	  NT37810) AMOLED DSI Video Mode LCD panel module with 1440x3200
++	  resolution.
++
++config DRM_PANEL_NOVATEK_NT39016
++	tristate "Novatek NT39016 RGB/SPI panel"
++	depends on OF && SPI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select REGMAP_SPI
++	help
++	  Say Y here if you want to enable support for the panels built
++	  around the Novatek NT39016 display controller.
++
++config DRM_PANEL_OLIMEX_LCD_OLINUXINO
++	tristate "Olimex LCD-OLinuXino panel"
++	depends on OF
++	depends on I2C
++	depends on BACKLIGHT_CLASS_DEVICE
++	select CRC32
++	help
++	  The panel is used with different sizes LCDs, from 480x272 to
++	  1280x800, and 24 bit per pixel.
++
++	  Say Y here if you want to enable support for Olimex Ltd.
++	  LCD-OLinuXino panel.
++
++config DRM_PANEL_ORISETECH_OTA5601A
++        tristate "Orise Technology ota5601a RGB/SPI panel"
++        depends on SPI
++        depends on BACKLIGHT_CLASS_DEVICE
++        select REGMAP_SPI
++        help
++          Say Y here if you want to enable support for the panels built
++          around the Orise Technology OTA9601A display controller.
++
++config DRM_PANEL_ORISETECH_OTM8009A
++	tristate "Orise Technology otm8009a 480x800 dsi 2dl panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Orise Technology
++	  otm8009a 480x800 dsi 2dl panel.
++
++config DRM_PANEL_OSD_OSD101T2587_53TS
++	tristate "OSD OSD101T2587-53TS DSI 1920x1200 video mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for One Stop Displays
++	  OSD101T2587-53TS 10.1" 1920x1200 dsi panel.
++
++config DRM_PANEL_PANASONIC_VVX10F034N00
++	tristate "Panasonic VVX10F034N00 1920x1200 video mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Panasonic VVX10F034N00
++	  WUXGA (1920x1200) Novatek NT1397-based DSI panel as found in some
++	  Xperia Z2 tablets
++
++config DRM_PANEL_RASPBERRYPI_TOUCHSCREEN
++	tristate "Raspberry Pi 7-inch touchscreen panel"
++	depends on DRM_MIPI_DSI
++	help
++	  Say Y here if you want to enable support for the Raspberry
++	  Pi 7" Touchscreen.  To compile this driver as a module,
++	  choose M here.
++
++config DRM_PANEL_RAYDIUM_RM67191
++	tristate "Raydium RM67191 FHD 1080x1920 DSI video mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Raydium RM67191 FHD
++	  (1080x1920) DSI panel.
++
++config DRM_PANEL_RAYDIUM_RM67200
++	tristate "Raydium RM67200-based DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	help
++	  Say Y here if you want to enable support for Raydium RM67200-based
++	  DSI video mode panels. This panel controller can be found in the
++	  Wanchanglong W552793BAA panel found on the Rockchip RK3588 EVB1
++	  evaluation boards.
++
++config DRM_PANEL_RAYDIUM_RM68200
++	tristate "Raydium RM68200 720x1280 DSI video mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Raydium RM68200
++	  720x1280 DSI video mode panel.
++
++config DRM_PANEL_RAYDIUM_RM692E5
++	tristate "Raydium RM692E5-based DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_DISPLAY_DSC_HELPER
++	select DRM_DISPLAY_HELPER
++	help
++	  Say Y here if you want to enable support for Raydium RM692E5-based
++	  display panels, such as the one found in the Fairphone 5 smartphone.
++
++config DRM_PANEL_RAYDIUM_RM69380
++	tristate "Raydium RM69380-based DSI panel"
++	depends on OF && GPIOLIB
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Raydium RM69380-based
++	  display panels.
++
++	  This panel controller can be found in the Lenovo Xiaoxin Pad Pro 2021
++	  in combination with an EDO OLED panel.
++
++config DRM_PANEL_RENESAS_R61307
++	tristate "Renesas R61307 DSI video mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++	help
++	  Say Y here if you want to enable support for KOE tx13d100vm0eaa
++	  IPS-LCD module with Renesas R69328 IC. The panel has a 1024x768
++	  resolution and uses 24 bit RGB per pixel.
++
++	  This panel controller can be found in LG Optimus Vu P895 smartphone
++	  in combination with LCD panel.
++
++config DRM_PANEL_RENESAS_R69328
++	tristate "Renesas R69328 720x1280 DSI video mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++	help
++	  Say Y here if you want to enable support for JDI dx12d100vm0eaa
++	  IPS-LCD module with Renesas R69328 IC. The panel has a 720x1280
++	  resolution and uses 24 bit RGB per pixel.
++
++	  This panel controller can be found in LG Optimus 4X P895 smartphone
++	  in combination with LCD panel.
++
++config DRM_PANEL_RONBO_RB070D30
++	tristate "Ronbo Electronics RB070D30 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Ronbo Electronics
++	  RB070D30 1024x600 DSI panel.
++
++config DRM_PANEL_SAMSUNG_AMS581VF01
++	tristate "Samsung AMS581VF01 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y or M here if you want to enable support for the
++	  Samsung AMS581VF01 FHD Plus (2340x1080@60Hz) CMD mode panel.
++
++config DRM_PANEL_SAMSUNG_AMS639RQ08
++	tristate "Samsung AMS639RQ08 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y or M here if you want to enable support for the
++	  Samsung AMS639RQ08 FHD Plus (2340x1080@60Hz) CMD mode panel.
++
++config DRM_PANEL_SAMSUNG_S6E88A0_AMS427AP24
++	tristate "Samsung AMS427AP24 panel with S6E88A0 controller"
++	depends on GPIOLIB && OF && REGULATOR
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Samsung AMS427AP24 panel
++	  with S6E88A0 controller (found in Samsung Galaxy S4 Mini Value Edition
++	  GT-I9195I). To compile this driver as a module, choose M here.
++
++config DRM_PANEL_SAMSUNG_S6E88A0_AMS452EF01
++	tristate "Samsung AMS452EF01 panel with S6E88A0 DSI video mode controller"
++	depends on OF
++	select DRM_MIPI_DSI
++	select VIDEOMODE_HELPERS
++
++config DRM_PANEL_SAMSUNG_ATNA33XC20
++	tristate "Samsung ATNA33XC20 eDP panel"
++	depends on OF
++	depends on BACKLIGHT_CLASS_DEVICE
++	depends on PM
++	select DRM_DISPLAY_DP_HELPER
++	select DRM_DISPLAY_HELPER
++	select DRM_DISPLAY_DP_AUX_BUS
++	help
++	  DRM panel driver for the Samsung ATNA33XC20 panel. This panel can't
++	  be handled by the DRM_PANEL_SIMPLE driver because its power
++	  sequencing is non-standard.
++
++config DRM_PANEL_SAMSUNG_DB7430
++	tristate "Samsung DB7430-based DPI panels"
++	depends on OF && SPI && GPIOLIB
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_MIPI_DBI
++	help
++	  Say Y here if you want to enable support for the Samsung
++	  DB7430 DPI display controller used in such devices as the
++	  LMS397KF04 480x800 DPI panel.
++
++config DRM_PANEL_SAMSUNG_LD9040
++	tristate "Samsung LD9040 RGB/SPI panel"
++	depends on OF && SPI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++
++config DRM_PANEL_SAMSUNG_LTL106HL02
++	tristate "Samsung LTL106HL02 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++	help
++	  Say Y here if you want to enable support for the Samsung LTL106HL02
++	  panel driver which is used in Microsoft Surface 2.
++
++	  To compile this driver as a module, choose M here: the module
++	  will be called panel-samsung-ltl106hl02.
++
++config DRM_PANEL_SAMSUNG_S6E3FA7
++	tristate "Samsung S6E3FA7 panel driver"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Samsung S6E3FA7
++	  1920x2220 panel.
++
++config DRM_PANEL_SAMSUNG_S6D16D0
++	tristate "Samsung S6D16D0 DSI video mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	select VIDEOMODE_HELPERS
++
++config DRM_PANEL_SAMSUNG_S6D27A1
++	tristate "Samsung S6D27A1 DPI panel driver"
++	depends on OF && SPI && GPIOLIB
++	select DRM_MIPI_DBI
++	help
++	  Say Y here if you want to enable support for the Samsung
++	  S6D27A1 DPI 480x800 panel.
++
++	  This panel can be found in Samsung Galaxy Ace 2
++	  GT-I8160 mobile phone.
++
++config DRM_PANEL_SAMSUNG_S6D7AA0
++	tristate "Samsung S6D7AA0 MIPI-DSI video mode panel controller"
++	depends on OF
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_MIPI_DSI
++	select VIDEOMODE_HELPERS
++
++config DRM_PANEL_SAMSUNG_S6E3FC2X01
++	tristate "Samsung S6E3FC2X01 DSI panel controller"
++	depends on GPIOLIB
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y or M here if you want to enable support for the
++	  Samsung S6E3FC2 DDIC and connected MIPI DSI panel.
++	  Currently supported panels:
++
++	    Samsung AMS641RW (found in the OnePlus 6T smartphone)
++
++config DRM_PANEL_SAMSUNG_S6E3HA2
++	tristate "Samsung S6E3HA2 DSI video mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++
++config DRM_PANEL_SAMSUNG_S6E3HA8
++	tristate "Samsung S6E3HA8 DSI video mode panel"
++	depends on GPIOLIB
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_DISPLAY_HELPER
++	select DRM_DISPLAY_DSC_HELPER
++	help
++	  Say Y or M here if you want to enable support for the
++	  Samsung S6E3HA8 DDIC and connected MIPI DSI panel.
++	  Currently supported panels:
++
++	    Samsung AMB577PX01 (found in the Samsung S9 smartphone)
++
++
++config DRM_PANEL_SAMSUNG_S6E63J0X03
++	tristate "Samsung S6E63J0X03 DSI command mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++
++config DRM_PANEL_SAMSUNG_S6E63M0
++	tristate "Samsung S6E63M0 RGB panel"
++	depends on OF
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Samsung S6E63M0
++	  AMOLED LCD panel. This panel can be accessed using SPI or
++	  DSI.
++
++config DRM_PANEL_SAMSUNG_S6E63M0_SPI
++	tristate "Samsung S6E63M0 RGB SPI interface"
++	depends on SPI
++	depends on DRM_PANEL_SAMSUNG_S6E63M0
++	default DRM_PANEL_SAMSUNG_S6E63M0
++	select DRM_MIPI_DBI
++	help
++	  Say Y here if you want to be able to access the Samsung
++	  S6E63M0 panel using SPI.
++
++config DRM_PANEL_SAMSUNG_S6E63M0_DSI
++	tristate "Samsung S6E63M0 RGB DSI interface"
++	depends on DRM_MIPI_DSI
++	depends on DRM_PANEL_SAMSUNG_S6E63M0
++	help
++	  Say Y here if you want to be able to access the Samsung
++	  S6E63M0 panel using DSI.
++
++config DRM_PANEL_SAMSUNG_S6E8AA0
++	tristate "Samsung S6E8AA0 DSI video mode panel"
++	depends on OF
++	select DRM_MIPI_DSI
++	select VIDEOMODE_HELPERS
++
++config DRM_PANEL_SAMSUNG_S6E8AA5X01_AMS561RA01
++	tristate "Samsung AMS561RA01 panel with S6E8AA5X01 controller"
++	depends on GPIOLIB && OF && REGULATOR
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Samsung AMS561RA01
++	  panel, which uses Samsung's S6E8AA5X01 controller. The panel has a
++	  ~5.6 inch AMOLED display, and the controller is driven by the MIPI
++	  DSI protocol with 4 lanes.
++
++config DRM_PANEL_SAMSUNG_S6E8FC0
++	tristate "Samsung S6E8FC0 DSI controller"
++	depends on OF
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_MIPI_DSI
++	help
++	  Say Y or M here if you want to enable support for the Samsung
++	  S6E8FC0 DSI controller and connected panel.
++	  Currently supported panels:
++
++	    M1906F9 (M1906F9SH or M1906F9SI), 6.09 inch 720x1560, found
++	    in the Xiaomi Mi A3 smartphone (xiaomi-laurel).
++
++config DRM_PANEL_SAMSUNG_SOFEF00
++	tristate "Samsung SOFEF00 DSI panel controller"
++	depends on GPIOLIB
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y or M here if you want to enable support for the Samsung AMOLED
++	  panel SOFEF00 DDIC and connected panel.
++	  Currently supported panels:
++
++	    Samsung AMS628NW01 (found in OnePlus 6, 1080x2280@60Hz)
++
++config DRM_PANEL_SEIKO_43WVF1G
++	tristate "Seiko 43WVF1G panel"
++	depends on OF
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++	help
++	  Say Y here if you want to enable support for the Seiko
++	  43WVF1G controller for 800x480 LCD panels
++
++config DRM_PANEL_SHARP_LQ079L1SX01
++	tristate "Sharp LQ079L1SX01 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select VIDEOMODE_HELPERS
++	help
++	  Say Y here if you want to enable support for Sharp LQ079L1SX01
++	  TFT-LCD modules. The panel has a 2560x1600 resolution and uses
++	  24 bit RGB per pixel. It provides a dual MIPI DSI interface to
++	  the host.
++
++	  To compile this driver as a module, choose M here: the module
++	  will be called panel-sharp-lq079l1sx01.
++
++config DRM_PANEL_SHARP_LQ101R1SX01
++	tristate "Sharp LQ101R1SX01 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Sharp LQ101R1SX01
++	  TFT-LCD modules. The panel has a 2560x1600 resolution and uses
++	  24 bit RGB per pixel. It provides a dual MIPI DSI interface to
++	  the host and has a built-in LED backlight.
++
++	  To compile this driver as a module, choose M here: the module
++	  will be called panel-sharp-lq101r1sx01.
++
++config DRM_PANEL_SHARP_LS037V7DW01
++	tristate "Sharp LS037V7DW01 VGA LCD panel"
++	depends on GPIOLIB && OF && REGULATOR
++	help
++	  Say Y here if you want to enable support for Sharp LS037V7DW01 VGA
++	  (480x640) LCD panel (found on the TI SDP3430 board).
++
++config DRM_PANEL_SHARP_LS043T1LE01
++	tristate "Sharp LS043T1LE01 qHD video mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Sharp LS043T1LE01 qHD
++	  (540x960) DSI panel as found on the Qualcomm APQ8074 Dragonboard
++
++config DRM_PANEL_SHARP_LS060T1SX01
++	tristate "Sharp LS060T1SX01 FullHD video mode panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Sharp LS060T1SX01 6.0"
++	  FullHD (1080x1920) DSI panel as found in Dragonboard Display Adapter
++	  Bundle.
++
++config DRM_PANEL_SITRONIX_ST7701
++	tristate "Sitronix ST7701 panel driver"
++	depends on OF
++	depends on SPI || DRM_MIPI_DSI
++	select DRM_MIPI_DBI if SPI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Sitronix
++	  ST7701 controller for 480X864 LCD panels with MIPI/RGB/SPI
++	  system interfaces.
++
++config DRM_PANEL_SITRONIX_ST7703
++	tristate "Sitronix ST7703 based MIPI touchscreen panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Sitronix ST7703 based
++	  panels, souch as Rocktech JH057N00900 MIPI DSI panel as e.g. used in
++	  the Librem 5 devkit. It has a resolution of 720x1440 pixels, a built
++	  in backlight and touch controller.
++	  Touch input support is provided by the goodix driver and needs to be
++	  selected separately.
++
++config DRM_PANEL_SITRONIX_ST7789V
++	tristate "Sitronix ST7789V panel"
++	depends on OF && SPI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Sitronix
++	  ST7789V controller for 240x320 LCD panels
++
++config DRM_PANEL_SONY_ACX565AKM
++	tristate "Sony ACX565AKM panel"
++	depends on GPIOLIB && OF && SPI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Sony ACX565AKM
++	  800x600 3.5" panel (found on the Nokia N900).
++
++config DRM_PANEL_SONY_TD4353_JDI
++	tristate "Sony TD4353 JDI panel"
++	depends on GPIOLIB && OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Sony Tama
++	  TD4353 JDI command mode panel as found on some Sony Xperia
++	  XZ2 and XZ2 Compact smartphones.
++
++config DRM_PANEL_SONY_TULIP_TRULY_NT35521
++	tristate "Sony Tulip Truly NT35521 panel"
++	depends on GPIOLIB && OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Sony Tulip
++	  NT35521 1280x720 video mode panel as found on Sony Xperia M4
++	  Aqua phone.
++
++config DRM_PANEL_STARTEK_KD070FHFID015
++	tristate "STARTEK KD070FHFID015 panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for STARTEK KD070FHFID015 DSI panel
++	  based on RENESAS-R69429 controller. The panel is a 7-inch TFT LCD display
++	  with a resolution of 1024 x 600 pixels. It provides a MIPI DSI interface to
++	  the host, a built-in LED backlight and touch controller.
++
++config DRM_PANEL_EDP
++	tristate "support for simple Embedded DisplayPort panels"
++	depends on OF
++	depends on BACKLIGHT_CLASS_DEVICE
++	depends on PM
++	select VIDEOMODE_HELPERS
++	select DRM_DISPLAY_DP_HELPER
++	select DRM_DISPLAY_HELPER
++	select DRM_DISPLAY_DP_AUX_BUS
++	select DRM_KMS_HELPER
++	help
++	  DRM panel driver for dumb eDP panels that need at most a regulator and
++	  a GPIO to be powered up. Optionally a backlight can be attached so
++	  that it can be automatically turned off when the panel goes into a
++	  low power state.
++
++config DRM_PANEL_SIMPLE
++	tristate "support for simple panels (other than eDP ones)"
++	depends on OF
++	depends on BACKLIGHT_CLASS_DEVICE
++	depends on PM
++	select VIDEOMODE_HELPERS
++	help
++	  DRM panel driver for dumb non-eDP panels that need at most a regulator
++	  and a GPIO to be powered up. Optionally a backlight can be attached so
++	  that it can be automatically turned off when the panel goes into a
++	  low power state.
++
++config DRM_PANEL_SUMMIT
++	tristate "Apple Summit display panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y if you want to enable support for the "Summit" display panel
++	  used as a touchbar on certain Apple laptops.
++
++config DRM_PANEL_SYNAPTICS_R63353
++	tristate "Synaptics R63353-based panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y if you want to enable support for panels based on the
++	  Synaptics R63353 controller.
++
++config DRM_PANEL_SYNAPTICS_TDDI
++	tristate "Synaptics TDDI display panels"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y if you want to enable support for the Synaptics TDDI display
++	  panels. There are multiple MIPI DSI panels manufactured under the TDDI
++	  namesake, with varying resolutions and data lanes. They also have a
++	  built-in LED backlight and a touch controller.
++
++config DRM_PANEL_TDO_TL070WSH30
++	tristate "TDO TL070WSH30 DSI panel"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for TDO TL070WSH30 TFT-LCD
++	  panel module. The panel has a 1024×600 resolution and uses
++	  24 bit RGB per pixel. It provides a MIPI DSI interface to
++	  the host, a built-in LED backlight and touch controller.
++
++config DRM_PANEL_TPO_TD028TTEC1
++	tristate "Toppoly (TPO) TD028TTEC1 panel driver"
++	depends on OF && SPI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for TPO TD028TTEC1 480x640
++	  2.8" panel (found on the OpenMoko Neo FreeRunner and Neo 1973).
++
++config DRM_PANEL_TPO_TD043MTEA1
++	tristate "Toppoly (TPO) TD043MTEA1 panel driver"
++	depends on GPIOLIB && OF && REGULATOR && SPI
++	help
++	  Say Y here if you want to enable support for TPO TD043MTEA1 800x480
++	  4.3" panel (found on the OMAP3 Pandora board).
++
++config DRM_PANEL_TPO_TPG110
++	tristate "TPO TPG 800x400 panel"
++	depends on OF && SPI && GPIOLIB
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for TPO TPG110
++	  400CH LTPS TFT LCD Single Chip Digital Driver for up to
++	  800x400 LCD panels.
++
++config DRM_PANEL_TRULY_NT35597_WQXGA
++	tristate "Truly WQXGA"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	help
++	  Say Y here if you want to enable support for Truly NT35597 WQXGA Dual DSI
++	  Video Mode panel
++
++config DRM_PANEL_VISIONOX_G2647FB105
++	tristate "Visionox G2647FB105"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Visionox
++	  G2647FB105 (2340x1080@60Hz) AMOLED DSI cmd mode panel.
++
++config DRM_PANEL_VISIONOX_R66451
++	tristate "Visionox R66451"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_DISPLAY_DSC_HELPER
++	select DRM_DISPLAY_HELPER
++	help
++	  Say Y here if you want to enable support for Visionox
++	  R66451 1080x2340 AMOLED DSI panel.
++
++config DRM_PANEL_VISIONOX_RM69299
++	tristate "Visionox RM69299"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Visionox
++	  RM69299  DSI Video Mode panel.
++
++config DRM_PANEL_VISIONOX_RM692E5
++	tristate "Visionox RM692E5"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_DISPLAY_DSC_HELPER
++	select DRM_DISPLAY_HELPER
++	help
++	  Say Y here if you want to enable support for Visionox RM692E5 amoled
++	  display panels, such as the one found in the Nothing Phone (1)
++	  smartphone.
++
++config DRM_PANEL_VISIONOX_VTDR6130
++	tristate "Visionox VTDR6130"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for Visionox
++	  VTDR6130 1080x2400 AMOLED DSI panel.
++
++config DRM_PANEL_WIDECHIPS_WS2401
++	tristate "Widechips WS2401 DPI panel driver"
++	depends on SPI && GPIOLIB
++	depends on BACKLIGHT_CLASS_DEVICE
++	select DRM_MIPI_DBI
++	help
++	  Say Y here if you want to enable support for the Widechips WS2401 DPI
++	  480x800 display controller used in panels such as Samsung LMS380KF01.
++	  This display is used in the Samsung Galaxy Ace 2 GT-I8160 (Codina).
++
++config DRM_PANEL_XINPENG_XPP055C272
++	tristate "Xinpeng XPP055C272 panel driver"
++	depends on OF
++	depends on DRM_MIPI_DSI
++	depends on BACKLIGHT_CLASS_DEVICE
++	help
++	  Say Y here if you want to enable support for the Xinpeng
++	  XPP055C272 controller for 720x1280 LCD panels with MIPI/RGB/SPI
++	  system interfaces.
++endmenu
+diff --git a/drivers/hwmon/pwm-fan.c b/drivers/hwmon/pwm-fan.c
+index 111111111111..222222222222 100644
+--- a/drivers/hwmon/pwm-fan.c
++++ b/drivers/hwmon/pwm-fan.c
+@@ -566,7 +566,7 @@ static int pwm_fan_probe(struct platform_device *pdev)
  	 * Set duty cycle to maximum allowed and enable PWM output as well as
  	 * the regulator. In case of error nothing is changed
  	 */
@@ -10,3 +12666,15786 @@ diff -rupbN linux.orig/drivers/hwmon/pwm-fan.c linux/drivers/hwmon/pwm-fan.c
  	if (ret) {
  		dev_err(dev, "Failed to configure PWM: %d\n", ret);
  		return ret;
+diff --git a/drivers/hwmon/pwm-fan.c.orig b/drivers/hwmon/pwm-fan.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/hwmon/pwm-fan.c.orig
+@@ -0,0 +1,747 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * pwm-fan.c - Hwmon driver for fans connected to PWM lines.
++ *
++ * Copyright (c) 2014 Samsung Electronics Co., Ltd.
++ *
++ * Author: Kamil Debski <k.debski@samsung.com>
++ */
++
++#include <linux/delay.h>
++#include <linux/hwmon.h>
++#include <linux/interrupt.h>
++#include <linux/mod_devicetable.h>
++#include <linux/module.h>
++#include <linux/mutex.h>
++#include <linux/platform_device.h>
++#include <linux/property.h>
++#include <linux/pwm.h>
++#include <linux/regulator/consumer.h>
++#include <linux/sysfs.h>
++#include <linux/thermal.h>
++#include <linux/timer.h>
++
++#define MAX_PWM 255
++
++struct pwm_fan_tach {
++	int irq;
++	atomic_t pulses;
++	unsigned int rpm;
++};
++
++enum pwm_fan_enable_mode {
++	pwm_off_reg_off,
++	pwm_disable_reg_enable,
++	pwm_enable_reg_enable,
++	pwm_disable_reg_disable,
++};
++
++struct pwm_fan_ctx {
++	struct device *dev;
++
++	struct mutex lock;
++	struct pwm_device *pwm;
++	struct pwm_state pwm_state;
++	struct regulator *reg_en;
++	enum pwm_fan_enable_mode enable_mode;
++	bool regulator_enabled;
++	bool enabled;
++
++	int tach_count;
++	struct pwm_fan_tach *tachs;
++	u32 *pulses_per_revolution;
++	ktime_t sample_start;
++	struct timer_list rpm_timer;
++
++	unsigned int pwm_value;
++	unsigned int pwm_fan_state;
++	unsigned int pwm_fan_max_state;
++	unsigned int *pwm_fan_cooling_levels;
++	struct thermal_cooling_device *cdev;
++
++	struct hwmon_chip_info info;
++	struct hwmon_channel_info fan_channel;
++
++	u64 pwm_duty_cycle_from_stopped;
++	u32 pwm_usec_from_stopped;
++	u8 pwm_shutdown;
++};
++
++/* This handler assumes self resetting edge triggered interrupt. */
++static irqreturn_t pulse_handler(int irq, void *dev_id)
++{
++	struct pwm_fan_tach *tach = dev_id;
++
++	atomic_inc(&tach->pulses);
++
++	return IRQ_HANDLED;
++}
++
++static void sample_timer(struct timer_list *t)
++{
++	struct pwm_fan_ctx *ctx = timer_container_of(ctx, t, rpm_timer);
++	unsigned int delta = ktime_ms_delta(ktime_get(), ctx->sample_start);
++	int i;
++
++	if (delta) {
++		for (i = 0; i < ctx->tach_count; i++) {
++			struct pwm_fan_tach *tach = &ctx->tachs[i];
++			int pulses;
++
++			pulses = atomic_read(&tach->pulses);
++			atomic_sub(pulses, &tach->pulses);
++			tach->rpm = (unsigned int)(pulses * 1000 * 60) /
++				(ctx->pulses_per_revolution[i] * delta);
++		}
++
++		ctx->sample_start = ktime_get();
++	}
++
++	mod_timer(&ctx->rpm_timer, jiffies + HZ);
++}
++
++static void pwm_fan_enable_mode_2_state(int enable_mode,
++					struct pwm_state *state,
++					bool *enable_regulator)
++{
++	switch (enable_mode) {
++	case pwm_disable_reg_enable:
++		/* disable pwm, keep regulator enabled */
++		state->enabled = false;
++		*enable_regulator = true;
++		break;
++	case pwm_enable_reg_enable:
++		/* keep pwm and regulator enabled */
++		state->enabled = true;
++		*enable_regulator = true;
++		break;
++	case pwm_off_reg_off:
++	case pwm_disable_reg_disable:
++		/* disable pwm and regulator */
++		state->enabled = false;
++		*enable_regulator = false;
++	}
++}
++
++static int pwm_fan_switch_power(struct pwm_fan_ctx *ctx, bool on)
++{
++	int ret = 0;
++
++	if (!ctx->reg_en)
++		return ret;
++
++	if (!ctx->regulator_enabled && on) {
++		ret = regulator_enable(ctx->reg_en);
++		if (ret == 0)
++			ctx->regulator_enabled = true;
++	} else if (ctx->regulator_enabled && !on) {
++		ret = regulator_disable(ctx->reg_en);
++		if (ret == 0)
++			ctx->regulator_enabled = false;
++	}
++	return ret;
++}
++
++static int pwm_fan_power_on(struct pwm_fan_ctx *ctx)
++{
++	struct pwm_state *state = &ctx->pwm_state;
++	int ret;
++
++	if (ctx->enabled)
++		return 0;
++
++	ret = pwm_fan_switch_power(ctx, true);
++	if (ret < 0) {
++		dev_err(ctx->dev, "failed to enable power supply\n");
++		return ret;
++	}
++
++	state->enabled = true;
++	ret = pwm_apply_might_sleep(ctx->pwm, state);
++	if (ret) {
++		dev_err(ctx->dev, "failed to enable PWM\n");
++		goto disable_regulator;
++	}
++
++	ctx->enabled = true;
++
++	return 0;
++
++disable_regulator:
++	pwm_fan_switch_power(ctx, false);
++	return ret;
++}
++
++static int pwm_fan_power_off(struct pwm_fan_ctx *ctx, bool force_disable)
++{
++	struct pwm_state *state = &ctx->pwm_state;
++	bool enable_regulator = false;
++	int ret;
++
++	if (!ctx->enabled)
++		return 0;
++
++	pwm_fan_enable_mode_2_state(ctx->enable_mode,
++				    state,
++				    &enable_regulator);
++
++	if (force_disable)
++		state->enabled = false;
++	state->duty_cycle = 0;
++	ret = pwm_apply_might_sleep(ctx->pwm, state);
++	if (ret) {
++		dev_err(ctx->dev, "failed to disable PWM\n");
++		return ret;
++	}
++
++	pwm_fan_switch_power(ctx, enable_regulator);
++
++	ctx->enabled = false;
++
++	return 0;
++}
++
++static int  __set_pwm(struct pwm_fan_ctx *ctx, unsigned long pwm)
++{
++	struct pwm_state *state = &ctx->pwm_state;
++	unsigned long final_pwm = pwm;
++	unsigned long period;
++	bool update = false;
++	int ret = 0;
++
++	if (pwm > 0) {
++		if (ctx->enable_mode == pwm_off_reg_off)
++			/* pwm-fan hard disabled */
++			return 0;
++
++		period = state->period;
++		update = state->duty_cycle < ctx->pwm_duty_cycle_from_stopped;
++		if (update)
++			state->duty_cycle = ctx->pwm_duty_cycle_from_stopped;
++		else
++			state->duty_cycle = DIV_ROUND_UP(pwm * (period - 1), MAX_PWM);
++		ret = pwm_apply_might_sleep(ctx->pwm, state);
++		if (ret)
++			return ret;
++		ret = pwm_fan_power_on(ctx);
++		if (!ret && update) {
++			pwm = final_pwm;
++			state->duty_cycle = DIV_ROUND_UP(pwm * (period - 1), MAX_PWM);
++			usleep_range(ctx->pwm_usec_from_stopped,
++				     ctx->pwm_usec_from_stopped * 2);
++			ret = pwm_apply_might_sleep(ctx->pwm, state);
++		}
++	} else {
++		ret = pwm_fan_power_off(ctx, false);
++	}
++	if (!ret)
++		ctx->pwm_value = pwm;
++
++	return ret;
++}
++
++static int set_pwm(struct pwm_fan_ctx *ctx, unsigned long pwm)
++{
++	int ret;
++
++	mutex_lock(&ctx->lock);
++	ret = __set_pwm(ctx, pwm);
++	mutex_unlock(&ctx->lock);
++
++	return ret;
++}
++
++static void pwm_fan_update_state(struct pwm_fan_ctx *ctx, unsigned long pwm)
++{
++	int i;
++
++	for (i = 0; i < ctx->pwm_fan_max_state; ++i)
++		if (pwm < ctx->pwm_fan_cooling_levels[i + 1])
++			break;
++
++	ctx->pwm_fan_state = i;
++}
++
++static int pwm_fan_update_enable(struct pwm_fan_ctx *ctx, long val)
++{
++	int ret = 0;
++	int old_val;
++
++	mutex_lock(&ctx->lock);
++
++	if (ctx->enable_mode == val)
++		goto out;
++
++	old_val = ctx->enable_mode;
++	ctx->enable_mode = val;
++
++	if (val == 0) {
++		/* Disable pwm-fan unconditionally */
++		if (ctx->enabled)
++			ret = __set_pwm(ctx, 0);
++		else
++			ret = pwm_fan_switch_power(ctx, false);
++		if (ret)
++			ctx->enable_mode = old_val;
++		pwm_fan_update_state(ctx, 0);
++	} else {
++		/*
++		 * Change PWM and/or regulator state if currently disabled
++		 * Nothing to do if currently enabled
++		 */
++		if (!ctx->enabled) {
++			struct pwm_state *state = &ctx->pwm_state;
++			bool enable_regulator = false;
++
++			state->duty_cycle = 0;
++			pwm_fan_enable_mode_2_state(val,
++						    state,
++						    &enable_regulator);
++
++			pwm_apply_might_sleep(ctx->pwm, state);
++			pwm_fan_switch_power(ctx, enable_regulator);
++			pwm_fan_update_state(ctx, 0);
++		}
++	}
++out:
++	mutex_unlock(&ctx->lock);
++
++	return ret;
++}
++
++static int pwm_fan_write(struct device *dev, enum hwmon_sensor_types type,
++			 u32 attr, int channel, long val)
++{
++	struct pwm_fan_ctx *ctx = dev_get_drvdata(dev);
++	int ret;
++
++	switch (attr) {
++	case hwmon_pwm_input:
++		if (val < 0 || val > MAX_PWM)
++			return -EINVAL;
++		ret = set_pwm(ctx, val);
++		if (ret)
++			return ret;
++		pwm_fan_update_state(ctx, val);
++		break;
++	case hwmon_pwm_enable:
++		if (val < 0 || val > 3)
++			ret = -EINVAL;
++		else
++			ret = pwm_fan_update_enable(ctx, val);
++
++		return ret;
++	default:
++		return -EOPNOTSUPP;
++	}
++
++	return 0;
++}
++
++static int pwm_fan_read(struct device *dev, enum hwmon_sensor_types type,
++			u32 attr, int channel, long *val)
++{
++	struct pwm_fan_ctx *ctx = dev_get_drvdata(dev);
++
++	switch (type) {
++	case hwmon_pwm:
++		switch (attr) {
++		case hwmon_pwm_input:
++			*val = ctx->pwm_value;
++			return 0;
++		case hwmon_pwm_enable:
++			*val = ctx->enable_mode;
++			return 0;
++		}
++		return -EOPNOTSUPP;
++	case hwmon_fan:
++		*val = ctx->tachs[channel].rpm;
++		return 0;
++
++	default:
++		return -ENOTSUPP;
++	}
++}
++
++static umode_t pwm_fan_is_visible(const void *data,
++				  enum hwmon_sensor_types type,
++				  u32 attr, int channel)
++{
++	switch (type) {
++	case hwmon_pwm:
++		return 0644;
++
++	case hwmon_fan:
++		return 0444;
++
++	default:
++		return 0;
++	}
++}
++
++static const struct hwmon_ops pwm_fan_hwmon_ops = {
++	.is_visible = pwm_fan_is_visible,
++	.read = pwm_fan_read,
++	.write = pwm_fan_write,
++};
++
++/* thermal cooling device callbacks */
++static int pwm_fan_get_max_state(struct thermal_cooling_device *cdev,
++				 unsigned long *state)
++{
++	struct pwm_fan_ctx *ctx = cdev->devdata;
++
++	if (!ctx)
++		return -EINVAL;
++
++	*state = ctx->pwm_fan_max_state;
++
++	return 0;
++}
++
++static int pwm_fan_get_cur_state(struct thermal_cooling_device *cdev,
++				 unsigned long *state)
++{
++	struct pwm_fan_ctx *ctx = cdev->devdata;
++
++	if (!ctx)
++		return -EINVAL;
++
++	*state = ctx->pwm_fan_state;
++
++	return 0;
++}
++
++static int
++pwm_fan_set_cur_state(struct thermal_cooling_device *cdev, unsigned long state)
++{
++	struct pwm_fan_ctx *ctx = cdev->devdata;
++	int ret;
++
++	if (!ctx || (state > ctx->pwm_fan_max_state))
++		return -EINVAL;
++
++	if (state == ctx->pwm_fan_state)
++		return 0;
++
++	ret = set_pwm(ctx, ctx->pwm_fan_cooling_levels[state]);
++	if (ret) {
++		dev_err(&cdev->device, "Cannot set pwm!\n");
++		return ret;
++	}
++
++	ctx->pwm_fan_state = state;
++
++	return ret;
++}
++
++static const struct thermal_cooling_device_ops pwm_fan_cooling_ops = {
++	.get_max_state = pwm_fan_get_max_state,
++	.get_cur_state = pwm_fan_get_cur_state,
++	.set_cur_state = pwm_fan_set_cur_state,
++};
++
++static int pwm_fan_get_cooling_data(struct device *dev, struct pwm_fan_ctx *ctx)
++{
++	int num, i, ret;
++
++	if (!device_property_present(dev, "cooling-levels"))
++		return 0;
++
++	ret = device_property_count_u32(dev, "cooling-levels");
++	if (ret <= 0) {
++		dev_err(dev, "Wrong data!\n");
++		return ret ? : -EINVAL;
++	}
++
++	num = ret;
++	ctx->pwm_fan_cooling_levels = devm_kcalloc(dev, num, sizeof(u32),
++						   GFP_KERNEL);
++	if (!ctx->pwm_fan_cooling_levels)
++		return -ENOMEM;
++
++	ret = device_property_read_u32_array(dev, "cooling-levels",
++					     ctx->pwm_fan_cooling_levels, num);
++	if (ret) {
++		dev_err(dev, "Property 'cooling-levels' cannot be read!\n");
++		return ret;
++	}
++
++	for (i = 0; i < num; i++) {
++		if (ctx->pwm_fan_cooling_levels[i] > MAX_PWM) {
++			dev_err(dev, "PWM fan state[%d]:%d > %d\n", i,
++				ctx->pwm_fan_cooling_levels[i], MAX_PWM);
++			return -EINVAL;
++		}
++	}
++
++	ctx->pwm_fan_max_state = num - 1;
++
++	return 0;
++}
++
++static void pwm_fan_cleanup(void *__ctx)
++{
++	struct pwm_fan_ctx *ctx = __ctx;
++
++	timer_delete_sync(&ctx->rpm_timer);
++	if (ctx->pwm_shutdown) {
++		ctx->enable_mode = pwm_enable_reg_enable;
++		__set_pwm(ctx, ctx->pwm_shutdown);
++	} else {
++		/* Switch off everything */
++		ctx->enable_mode = pwm_disable_reg_disable;
++		pwm_fan_power_off(ctx, true);
++	}
++}
++
++static int pwm_fan_probe(struct platform_device *pdev)
++{
++	struct thermal_cooling_device *cdev;
++	struct device *dev = &pdev->dev;
++	struct pwm_fan_ctx *ctx;
++	struct device *hwmon;
++	int ret;
++	const struct hwmon_channel_info **channels;
++	u32 initial_pwm, pwm_min_from_stopped = 0;
++	u32 pwm_shutdown_percent = 0;
++	u32 *fan_channel_config;
++	int channel_count = 1;	/* We always have a PWM channel. */
++	int i;
++
++	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
++	if (!ctx)
++		return -ENOMEM;
++
++	mutex_init(&ctx->lock);
++
++	ctx->dev = &pdev->dev;
++	ctx->pwm = devm_pwm_get(dev, NULL);
++	if (IS_ERR(ctx->pwm))
++		return dev_err_probe(dev, PTR_ERR(ctx->pwm), "Could not get PWM\n");
++
++	platform_set_drvdata(pdev, ctx);
++
++	ctx->reg_en = devm_regulator_get_optional(dev, "fan");
++	if (IS_ERR(ctx->reg_en)) {
++		if (PTR_ERR(ctx->reg_en) != -ENODEV)
++			return PTR_ERR(ctx->reg_en);
++
++		ctx->reg_en = NULL;
++	}
++
++	pwm_init_state(ctx->pwm, &ctx->pwm_state);
++
++	/*
++	 * PWM fans are controlled solely by the duty cycle of the PWM signal,
++	 * they do not care about the exact timing. Thus set usage_power to true
++	 * to allow less flexible hardware to work as a PWM source for fan
++	 * control.
++	 */
++	ctx->pwm_state.usage_power = true;
++
++	/*
++	 * set_pwm assumes that MAX_PWM * (period - 1) fits into an unsigned
++	 * long. Check this here to prevent the fan running at a too low
++	 * frequency.
++	 */
++	if (ctx->pwm_state.period > ULONG_MAX / MAX_PWM + 1) {
++		dev_err(dev, "Configured period too big\n");
++		return -EINVAL;
++	}
++
++	ctx->enable_mode = pwm_disable_reg_enable;
++
++	ret = pwm_fan_get_cooling_data(dev, ctx);
++	if (ret)
++		return ret;
++
++	/* use maximum cooling level if provided */
++	if (ctx->pwm_fan_cooling_levels)
++		initial_pwm = ctx->pwm_fan_cooling_levels[ctx->pwm_fan_max_state];
++	else
++		initial_pwm = MAX_PWM;
++
++	/*
++	 * Set duty cycle to maximum allowed and enable PWM output as well as
++	 * the regulator. In case of error nothing is changed
++	 */
++	ret = set_pwm(ctx, initial_pwm);
++	if (ret) {
++		dev_err(dev, "Failed to configure PWM: %d\n", ret);
++		return ret;
++	}
++	timer_setup(&ctx->rpm_timer, sample_timer, 0);
++	ret = devm_add_action_or_reset(dev, pwm_fan_cleanup, ctx);
++	if (ret)
++		return ret;
++
++	ctx->tach_count = platform_irq_count(pdev);
++	if (ctx->tach_count < 0)
++		return dev_err_probe(dev, ctx->tach_count,
++				     "Could not get number of fan tachometer inputs\n");
++	dev_dbg(dev, "%d fan tachometer inputs\n", ctx->tach_count);
++
++	if (ctx->tach_count) {
++		channel_count++;	/* We also have a FAN channel. */
++
++		ctx->tachs = devm_kcalloc(dev, ctx->tach_count,
++					  sizeof(struct pwm_fan_tach),
++					  GFP_KERNEL);
++		if (!ctx->tachs)
++			return -ENOMEM;
++
++		ctx->fan_channel.type = hwmon_fan;
++		fan_channel_config = devm_kcalloc(dev, ctx->tach_count + 1,
++						  sizeof(u32), GFP_KERNEL);
++		if (!fan_channel_config)
++			return -ENOMEM;
++		ctx->fan_channel.config = fan_channel_config;
++
++		ctx->pulses_per_revolution = devm_kmalloc_array(dev,
++								ctx->tach_count,
++								sizeof(*ctx->pulses_per_revolution),
++								GFP_KERNEL);
++		if (!ctx->pulses_per_revolution)
++			return -ENOMEM;
++
++		/* Setup default pulses per revolution */
++		for (i = 0; i < ctx->tach_count; i++)
++			ctx->pulses_per_revolution[i] = 2;
++
++		device_property_read_u32_array(dev, "pulses-per-revolution",
++					       ctx->pulses_per_revolution, ctx->tach_count);
++	}
++
++	channels = devm_kcalloc(dev, channel_count + 1,
++				sizeof(struct hwmon_channel_info *), GFP_KERNEL);
++	if (!channels)
++		return -ENOMEM;
++
++	channels[0] = HWMON_CHANNEL_INFO(pwm, HWMON_PWM_INPUT | HWMON_PWM_ENABLE);
++
++	for (i = 0; i < ctx->tach_count; i++) {
++		struct pwm_fan_tach *tach = &ctx->tachs[i];
++
++		tach->irq = platform_get_irq(pdev, i);
++		if (tach->irq == -EPROBE_DEFER)
++			return tach->irq;
++		if (tach->irq > 0) {
++			ret = devm_request_irq(dev, tach->irq, pulse_handler,
++					       IRQF_NO_THREAD, pdev->name, tach);
++			if (ret) {
++				dev_err(dev,
++					"Failed to request interrupt: %d\n",
++					ret);
++				return ret;
++			}
++		}
++
++		if (!ctx->pulses_per_revolution[i]) {
++			dev_err(dev, "pulses-per-revolution can't be zero.\n");
++			return -EINVAL;
++		}
++
++		fan_channel_config[i] = HWMON_F_INPUT;
++
++		dev_dbg(dev, "tach%d: irq=%d, pulses_per_revolution=%d\n",
++			i, tach->irq, ctx->pulses_per_revolution[i]);
++	}
++
++	if (ctx->tach_count > 0) {
++		ctx->sample_start = ktime_get();
++		mod_timer(&ctx->rpm_timer, jiffies + HZ);
++
++		channels[1] = &ctx->fan_channel;
++	}
++
++	ret = device_property_read_u32(dev, "fan-shutdown-percent",
++				       &pwm_shutdown_percent);
++	if (!ret && pwm_shutdown_percent)
++		ctx->pwm_shutdown = (clamp(pwm_shutdown_percent, 0, 100) * 255) / 100;
++
++	ret = device_property_read_u32(dev, "fan-stop-to-start-percent",
++				       &pwm_min_from_stopped);
++	if (!ret && pwm_min_from_stopped) {
++		ctx->pwm_duty_cycle_from_stopped =
++			DIV_ROUND_UP_ULL(pwm_min_from_stopped *
++					 (ctx->pwm_state.period - 1),
++					 100);
++	}
++	ret = device_property_read_u32(dev, "fan-stop-to-start-us",
++				       &ctx->pwm_usec_from_stopped);
++	if (ret)
++		ctx->pwm_usec_from_stopped = 250000;
++
++	ctx->info.ops = &pwm_fan_hwmon_ops;
++	ctx->info.info = channels;
++
++	hwmon = devm_hwmon_device_register_with_info(dev, "pwmfan",
++						     ctx, &ctx->info, NULL);
++	if (IS_ERR(hwmon)) {
++		dev_err(dev, "Failed to register hwmon device\n");
++		return PTR_ERR(hwmon);
++	}
++
++	ctx->pwm_fan_state = ctx->pwm_fan_max_state;
++	if (IS_ENABLED(CONFIG_THERMAL)) {
++		cdev = devm_thermal_of_cooling_device_register(dev,
++			dev->of_node, "pwm-fan", ctx, &pwm_fan_cooling_ops);
++		if (IS_ERR(cdev)) {
++			ret = PTR_ERR(cdev);
++			dev_err(dev,
++				"Failed to register pwm-fan as cooling device: %d\n",
++				ret);
++			return ret;
++		}
++		ctx->cdev = cdev;
++	}
++
++	return 0;
++}
++
++static void pwm_fan_shutdown(struct platform_device *pdev)
++{
++	struct pwm_fan_ctx *ctx = platform_get_drvdata(pdev);
++
++	pwm_fan_cleanup(ctx);
++}
++
++static int pwm_fan_suspend(struct device *dev)
++{
++	struct pwm_fan_ctx *ctx = dev_get_drvdata(dev);
++
++	return pwm_fan_power_off(ctx, true);
++}
++
++static int pwm_fan_resume(struct device *dev)
++{
++	struct pwm_fan_ctx *ctx = dev_get_drvdata(dev);
++
++	return set_pwm(ctx, ctx->pwm_value);
++}
++
++static DEFINE_SIMPLE_DEV_PM_OPS(pwm_fan_pm, pwm_fan_suspend, pwm_fan_resume);
++
++static const struct of_device_id of_pwm_fan_match[] = {
++	{ .compatible = "pwm-fan", },
++	{},
++};
++MODULE_DEVICE_TABLE(of, of_pwm_fan_match);
++
++static struct platform_driver pwm_fan_driver = {
++	.probe		= pwm_fan_probe,
++	.shutdown	= pwm_fan_shutdown,
++	.driver	= {
++		.name		= "pwm-fan",
++		.pm		= pm_sleep_ptr(&pwm_fan_pm),
++		.of_match_table	= of_pwm_fan_match,
++	},
++};
++
++module_platform_driver(pwm_fan_driver);
++
++MODULE_AUTHOR("Kamil Debski <k.debski@samsung.com>");
++MODULE_ALIAS("platform:pwm-fan");
++MODULE_DESCRIPTION("PWM FAN driver");
++MODULE_LICENSE("GPL");
+diff --git a/drivers/input/touchscreen/edt-ft5x06.c.orig b/drivers/input/touchscreen/edt-ft5x06.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/input/touchscreen/edt-ft5x06.c.orig
+@@ -0,0 +1,1534 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2012 Simon Budig, <simon.budig@kernelconcepts.de>
++ * Daniel Wagener <daniel.wagener@kernelconcepts.de> (M09 firmware support)
++ * Lothar Waßmann <LW@KARO-electronics.de> (DT support)
++ * Dario Binacchi <dario.binacchi@amarulasolutions.com> (regmap support)
++ */
++
++/*
++ * This is a driver for the EDT "Polytouch" family of touch controllers
++ * based on the FocalTech FT5x06 line of chips.
++ *
++ * Development of this driver has been sponsored by Glyn:
++ *    http://www.glyn.com/Products/Displays
++ */
++
++#include <linux/debugfs.h>
++#include <linux/delay.h>
++#include <linux/gpio/consumer.h>
++#include <linux/i2c.h>
++#include <linux/interrupt.h>
++#include <linux/input.h>
++#include <linux/input/mt.h>
++#include <linux/input/touchscreen.h>
++#include <linux/irq.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/property.h>
++#include <linux/ratelimit.h>
++#include <linux/regmap.h>
++#include <linux/regulator/consumer.h>
++#include <linux/slab.h>
++#include <linux/uaccess.h>
++
++#include <linux/unaligned.h>
++
++#define WORK_REGISTER_THRESHOLD		0x00
++#define WORK_REGISTER_REPORT_RATE	0x08
++#define WORK_REGISTER_GAIN		0x30
++#define WORK_REGISTER_OFFSET		0x31
++#define WORK_REGISTER_NUM_X		0x33
++#define WORK_REGISTER_NUM_Y		0x34
++
++#define PMOD_REGISTER_ACTIVE		0x00
++#define PMOD_REGISTER_HIBERNATE		0x03
++
++#define M09_REGISTER_THRESHOLD		0x80
++#define M09_REGISTER_GAIN		0x92
++#define M09_REGISTER_OFFSET		0x93
++#define M09_REGISTER_NUM_X		0x94
++#define M09_REGISTER_NUM_Y		0x95
++
++#define M12_REGISTER_REPORT_RATE	0x88
++
++#define EV_REGISTER_THRESHOLD		0x40
++#define EV_REGISTER_GAIN		0x41
++#define EV_REGISTER_OFFSET_Y		0x45
++#define EV_REGISTER_OFFSET_X		0x46
++
++#define NO_REGISTER			0xff
++
++#define WORK_REGISTER_OPMODE		0x3c
++#define FACTORY_REGISTER_OPMODE		0x01
++#define PMOD_REGISTER_OPMODE		0xa5
++
++#define TOUCH_EVENT_DOWN		0x00
++#define TOUCH_EVENT_UP			0x01
++#define TOUCH_EVENT_ON			0x02
++#define TOUCH_EVENT_RESERVED		0x03
++
++#define EDT_NAME_LEN			23
++#define EDT_SWITCH_MODE_RETRIES		10
++#define EDT_SWITCH_MODE_DELAY		5 /* msec */
++#define EDT_RAW_DATA_RETRIES		100
++#define EDT_RAW_DATA_DELAY		1000 /* usec */
++
++#define EDT_DEFAULT_NUM_X		1024
++#define EDT_DEFAULT_NUM_Y		1024
++
++#define M06_REG_CMD(factory) ((factory) ? 0xf3 : 0xfc)
++#define M06_REG_ADDR(factory, addr) ((factory) ? (addr) & 0x7f : (addr) & 0x3f)
++
++enum edt_pmode {
++	EDT_PMODE_NOT_SUPPORTED,
++	EDT_PMODE_HIBERNATE,
++	EDT_PMODE_POWEROFF,
++};
++
++enum edt_ver {
++	EDT_M06,
++	EDT_M09,
++	EDT_M12,
++	EV_FT,
++	GENERIC_FT,
++};
++
++struct edt_reg_addr {
++	int reg_threshold;
++	int reg_report_rate;
++	int reg_gain;
++	int reg_offset;
++	int reg_offset_x;
++	int reg_offset_y;
++	int reg_num_x;
++	int reg_num_y;
++};
++
++struct edt_ft5x06_ts_data {
++	struct i2c_client *client;
++	struct input_dev *input;
++	struct touchscreen_properties prop;
++	u16 num_x;
++	u16 num_y;
++	struct regulator *vcc;
++	struct regulator *iovcc;
++
++	struct gpio_desc *reset_gpio;
++	struct gpio_desc *wake_gpio;
++
++	struct regmap *regmap;
++
++#if defined(CONFIG_DEBUG_FS)
++	u8 *raw_buffer;
++	size_t raw_bufsize;
++#endif
++
++	struct mutex mutex;
++	bool factory_mode;
++	enum edt_pmode suspend_mode;
++	int threshold;
++	int gain;
++	int offset;
++	int offset_x;
++	int offset_y;
++	int report_rate;
++	int max_support_points;
++	int point_len;
++	u8 tdata_cmd;
++	int tdata_len;
++	int tdata_offset;
++
++	char name[EDT_NAME_LEN];
++	char fw_version[EDT_NAME_LEN];
++
++	struct edt_reg_addr reg_addr;
++	enum edt_ver version;
++	unsigned int crc_errors;
++	unsigned int header_errors;
++};
++
++struct edt_i2c_chip_data {
++	int  max_support_points;
++};
++
++static const struct regmap_config edt_ft5x06_i2c_regmap_config = {
++	.reg_bits = 8,
++	.val_bits = 8,
++};
++
++static bool edt_ft5x06_ts_check_crc(struct edt_ft5x06_ts_data *tsdata,
++				    u8 *buf, int buflen)
++{
++	int i;
++	u8 crc = 0;
++
++	for (i = 0; i < buflen - 1; i++)
++		crc ^= buf[i];
++
++	if (crc != buf[buflen - 1]) {
++		tsdata->crc_errors++;
++		dev_err_ratelimited(&tsdata->client->dev,
++				    "crc error: 0x%02x expected, got 0x%02x\n",
++				    crc, buf[buflen - 1]);
++		return false;
++	}
++
++	return true;
++}
++
++static int edt_M06_i2c_read(void *context, const void *reg_buf, size_t reg_size,
++			    void *val_buf, size_t val_size)
++{
++	struct device *dev = context;
++	struct i2c_client *i2c = to_i2c_client(dev);
++	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(i2c);
++	struct i2c_msg xfer[2];
++	bool reg_read = false;
++	u8 addr;
++	u8 wlen;
++	u8 wbuf[4], rbuf[3];
++	int ret;
++
++	addr = *((u8 *)reg_buf);
++	wbuf[0] = addr;
++	switch (addr) {
++	case 0xf5:
++		wlen = 3;
++		wbuf[0] = 0xf5;
++		wbuf[1] = 0xe;
++		wbuf[2] = *((u8 *)val_buf);
++		break;
++	case 0xf9:
++		wlen = 1;
++		break;
++	default:
++		wlen = 2;
++		reg_read = true;
++		wbuf[0] = M06_REG_CMD(tsdata->factory_mode);
++		wbuf[1] = M06_REG_ADDR(tsdata->factory_mode, addr);
++		wbuf[1] |= tsdata->factory_mode ? 0x80 : 0x40;
++	}
++
++	xfer[0].addr  = i2c->addr;
++	xfer[0].flags = 0;
++	xfer[0].len = wlen;
++	xfer[0].buf = wbuf;
++
++	xfer[1].addr = i2c->addr;
++	xfer[1].flags = I2C_M_RD;
++	xfer[1].len = reg_read ? 2 : val_size;
++	xfer[1].buf = reg_read ? rbuf : val_buf;
++
++	ret = i2c_transfer(i2c->adapter, xfer, 2);
++	if (ret != 2) {
++		if (ret < 0)
++			return ret;
++
++		return -EIO;
++	}
++
++	if (addr == 0xf9) {
++		u8 *buf = (u8 *)val_buf;
++
++		if (buf[0] != 0xaa || buf[1] != 0xaa ||
++		    buf[2] != val_size) {
++			tsdata->header_errors++;
++			dev_err_ratelimited(dev,
++					    "Unexpected header: %02x%02x%02x\n",
++					    buf[0], buf[1], buf[2]);
++			return -EIO;
++		}
++
++		if (!edt_ft5x06_ts_check_crc(tsdata, val_buf, val_size))
++			return -EIO;
++	} else if (reg_read) {
++		wbuf[2] = rbuf[0];
++		wbuf[3] = rbuf[1];
++		if (!edt_ft5x06_ts_check_crc(tsdata, wbuf, 4))
++			return -EIO;
++
++		*((u8 *)val_buf) = rbuf[0];
++	}
++
++	return 0;
++}
++
++static int edt_M06_i2c_write(void *context, const void *data, size_t count)
++{
++	struct device *dev = context;
++	struct i2c_client *i2c = to_i2c_client(dev);
++	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(i2c);
++	u8 addr, val;
++	u8 wbuf[4];
++	struct i2c_msg xfer;
++	int ret;
++
++	addr = *((u8 *)data);
++	val = *((u8 *)data + 1);
++
++	wbuf[0] = M06_REG_CMD(tsdata->factory_mode);
++	wbuf[1] = M06_REG_ADDR(tsdata->factory_mode, addr);
++	wbuf[2] = val;
++	wbuf[3] = wbuf[0] ^ wbuf[1] ^ wbuf[2];
++
++	xfer.addr  = i2c->addr;
++	xfer.flags = 0;
++	xfer.len = 4;
++	xfer.buf = wbuf;
++
++	ret = i2c_transfer(i2c->adapter, &xfer, 1);
++	if (ret != 1) {
++		if (ret < 0)
++			return ret;
++
++		return -EIO;
++	}
++
++	return 0;
++}
++
++static const struct regmap_config edt_M06_i2c_regmap_config = {
++	.reg_bits = 8,
++	.val_bits = 8,
++	.read = edt_M06_i2c_read,
++	.write = edt_M06_i2c_write,
++};
++
++static irqreturn_t edt_ft5x06_ts_isr(int irq, void *dev_id)
++{
++	struct edt_ft5x06_ts_data *tsdata = dev_id;
++	struct device *dev = &tsdata->client->dev;
++	u8 rdbuf[63];
++	int i, type, x, y, id;
++	int error;
++
++	memset(rdbuf, 0, sizeof(rdbuf));
++	error = regmap_bulk_read(tsdata->regmap, tsdata->tdata_cmd, rdbuf,
++				 tsdata->tdata_len);
++	if (error) {
++		dev_err_ratelimited(dev, "Unable to fetch data, error: %d\n",
++				    error);
++		goto out;
++	}
++
++	for (i = 0; i < tsdata->max_support_points; i++) {
++		u8 *buf = &rdbuf[i * tsdata->point_len + tsdata->tdata_offset];
++
++		type = buf[0] >> 6;
++		/* ignore Reserved events */
++		if (type == TOUCH_EVENT_RESERVED)
++			continue;
++
++		/* M06 sometimes sends bogus coordinates in TOUCH_DOWN */
++		if (tsdata->version == EDT_M06 && type == TOUCH_EVENT_DOWN)
++			continue;
++
++		x = get_unaligned_be16(buf) & 0x0fff;
++		y = get_unaligned_be16(buf + 2) & 0x0fff;
++		/* The FT5x26 send the y coordinate first */
++		if (tsdata->version == EV_FT)
++			swap(x, y);
++
++		id = (buf[2] >> 4) & 0x0f;
++
++		input_mt_slot(tsdata->input, id);
++		if (input_mt_report_slot_state(tsdata->input, MT_TOOL_FINGER,
++					       type != TOUCH_EVENT_UP))
++			touchscreen_report_pos(tsdata->input, &tsdata->prop,
++					       x, y, true);
++	}
++
++	input_mt_report_pointer_emulation(tsdata->input, true);
++	input_sync(tsdata->input);
++
++out:
++	return IRQ_HANDLED;
++}
++
++struct edt_ft5x06_attribute {
++	struct device_attribute dattr;
++	size_t field_offset;
++	u8 limit_low;
++	u8 limit_high;
++	u8 addr_m06;
++	u8 addr_m09;
++	u8 addr_ev;
++};
++
++#define EDT_ATTR(_field, _mode, _addr_m06, _addr_m09, _addr_ev,		\
++		_limit_low, _limit_high)				\
++	struct edt_ft5x06_attribute edt_ft5x06_attr_##_field = {	\
++		.dattr = __ATTR(_field, _mode,				\
++				edt_ft5x06_setting_show,		\
++				edt_ft5x06_setting_store),		\
++		.field_offset = offsetof(struct edt_ft5x06_ts_data, _field), \
++		.addr_m06 = _addr_m06,					\
++		.addr_m09 = _addr_m09,					\
++		.addr_ev  = _addr_ev,					\
++		.limit_low = _limit_low,				\
++		.limit_high = _limit_high,				\
++	}
++
++static ssize_t edt_ft5x06_setting_show(struct device *dev,
++				       struct device_attribute *dattr,
++				       char *buf)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
++	struct edt_ft5x06_attribute *attr =
++			container_of(dattr, struct edt_ft5x06_attribute, dattr);
++	u8 *field = (u8 *)tsdata + attr->field_offset;
++	unsigned int val;
++	int error;
++	u8 addr;
++
++	guard(mutex)(&tsdata->mutex);
++
++	if (tsdata->factory_mode)
++		return -EIO;
++
++	switch (tsdata->version) {
++	case EDT_M06:
++		addr = attr->addr_m06;
++		break;
++
++	case EDT_M09:
++	case EDT_M12:
++	case GENERIC_FT:
++		addr = attr->addr_m09;
++		break;
++
++	case EV_FT:
++		addr = attr->addr_ev;
++		break;
++
++	default:
++		return -ENODEV;
++	}
++
++	if (addr != NO_REGISTER) {
++		error = regmap_read(tsdata->regmap, addr, &val);
++		if (error) {
++			dev_err(&tsdata->client->dev,
++				"Failed to fetch attribute %s, error %d\n",
++				dattr->attr.name, error);
++			return error;
++		}
++	} else {
++		val = *field;
++	}
++
++	if (val != *field) {
++		dev_warn(&tsdata->client->dev,
++			 "%s: read (%d) and stored value (%d) differ\n",
++			 dattr->attr.name, val, *field);
++		*field = val;
++	}
++
++	return sysfs_emit(buf, "%d\n", val);
++}
++
++static ssize_t edt_ft5x06_setting_store(struct device *dev,
++					struct device_attribute *dattr,
++					const char *buf, size_t count)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
++	struct edt_ft5x06_attribute *attr =
++			container_of(dattr, struct edt_ft5x06_attribute, dattr);
++	u8 *field = (u8 *)tsdata + attr->field_offset;
++	unsigned int val;
++	int error;
++	u8 addr;
++
++	guard(mutex)(&tsdata->mutex);
++
++	if (tsdata->factory_mode)
++		return -EIO;
++
++	error = kstrtouint(buf, 0, &val);
++	if (error)
++		return error;
++
++	if (val < attr->limit_low || val > attr->limit_high)
++		return -ERANGE;
++
++	switch (tsdata->version) {
++	case EDT_M06:
++		addr = attr->addr_m06;
++		break;
++
++	case EDT_M09:
++	case EDT_M12:
++	case GENERIC_FT:
++		addr = attr->addr_m09;
++		break;
++
++	case EV_FT:
++		addr = attr->addr_ev;
++		break;
++
++	default:
++		return -ENODEV;
++	}
++
++	if (addr != NO_REGISTER) {
++		error = regmap_write(tsdata->regmap, addr, val);
++		if (error) {
++			dev_err(&tsdata->client->dev,
++				"Failed to update attribute %s, error: %d\n",
++				dattr->attr.name, error);
++			return error;
++		}
++	}
++	*field = val;
++
++	return count;
++}
++
++/* m06, m09: range 0-31, m12: range 0-5 */
++static EDT_ATTR(gain, S_IWUSR | S_IRUGO, WORK_REGISTER_GAIN,
++		M09_REGISTER_GAIN, EV_REGISTER_GAIN, 0, 31);
++/* m06, m09: range 0-31, m12: range 0-16 */
++static EDT_ATTR(offset, S_IWUSR | S_IRUGO, WORK_REGISTER_OFFSET,
++		M09_REGISTER_OFFSET, NO_REGISTER, 0, 31);
++/* m06, m09, m12: no supported, ev_ft: range 0-80 */
++static EDT_ATTR(offset_x, S_IWUSR | S_IRUGO, NO_REGISTER, NO_REGISTER,
++		EV_REGISTER_OFFSET_X, 0, 80);
++/* m06, m09, m12: no supported, ev_ft: range 0-80 */
++static EDT_ATTR(offset_y, S_IWUSR | S_IRUGO, NO_REGISTER, NO_REGISTER,
++		EV_REGISTER_OFFSET_Y, 0, 80);
++/* m06: range 20 to 80, m09: range 0 to 30, m12: range 1 to 255... */
++static EDT_ATTR(threshold, S_IWUSR | S_IRUGO, WORK_REGISTER_THRESHOLD,
++		M09_REGISTER_THRESHOLD, EV_REGISTER_THRESHOLD, 0, 255);
++/* m06: range 3 to 14, m12: range 1 to 255 */
++static EDT_ATTR(report_rate, S_IWUSR | S_IRUGO, WORK_REGISTER_REPORT_RATE,
++		M12_REGISTER_REPORT_RATE, NO_REGISTER, 0, 255);
++
++static ssize_t model_show(struct device *dev, struct device_attribute *attr,
++			  char *buf)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
++
++	return sysfs_emit(buf, "%s\n", tsdata->name);
++}
++
++static DEVICE_ATTR_RO(model);
++
++static ssize_t fw_version_show(struct device *dev,
++			       struct device_attribute *attr, char *buf)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
++
++	return sysfs_emit(buf, "%s\n", tsdata->fw_version);
++}
++
++static DEVICE_ATTR_RO(fw_version);
++
++/* m06 only */
++static ssize_t header_errors_show(struct device *dev,
++				  struct device_attribute *attr, char *buf)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
++
++	return sysfs_emit(buf, "%d\n", tsdata->header_errors);
++}
++
++static DEVICE_ATTR_RO(header_errors);
++
++/* m06 only */
++static ssize_t crc_errors_show(struct device *dev,
++			       struct device_attribute *attr, char *buf)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
++
++	return sysfs_emit(buf, "%d\n", tsdata->crc_errors);
++}
++
++static DEVICE_ATTR_RO(crc_errors);
++
++static struct attribute *edt_ft5x06_attrs[] = {
++	&edt_ft5x06_attr_gain.dattr.attr,
++	&edt_ft5x06_attr_offset.dattr.attr,
++	&edt_ft5x06_attr_offset_x.dattr.attr,
++	&edt_ft5x06_attr_offset_y.dattr.attr,
++	&edt_ft5x06_attr_threshold.dattr.attr,
++	&edt_ft5x06_attr_report_rate.dattr.attr,
++	&dev_attr_model.attr,
++	&dev_attr_fw_version.attr,
++	&dev_attr_header_errors.attr,
++	&dev_attr_crc_errors.attr,
++	NULL
++};
++ATTRIBUTE_GROUPS(edt_ft5x06);
++
++static void edt_ft5x06_restore_reg_parameters(struct edt_ft5x06_ts_data *tsdata)
++{
++	struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
++	struct regmap *regmap = tsdata->regmap;
++
++	regmap_write(regmap, reg_addr->reg_threshold, tsdata->threshold);
++	regmap_write(regmap, reg_addr->reg_gain, tsdata->gain);
++	if (reg_addr->reg_offset != NO_REGISTER)
++		regmap_write(regmap, reg_addr->reg_offset, tsdata->offset);
++	if (reg_addr->reg_offset_x != NO_REGISTER)
++		regmap_write(regmap, reg_addr->reg_offset_x, tsdata->offset_x);
++	if (reg_addr->reg_offset_y != NO_REGISTER)
++		regmap_write(regmap, reg_addr->reg_offset_y, tsdata->offset_y);
++	if (reg_addr->reg_report_rate != NO_REGISTER)
++		regmap_write(regmap, reg_addr->reg_report_rate,
++			     tsdata->report_rate);
++}
++
++#ifdef CONFIG_DEBUG_FS
++static int edt_ft5x06_factory_mode(struct edt_ft5x06_ts_data *tsdata)
++{
++	struct i2c_client *client = tsdata->client;
++	int retries = EDT_SWITCH_MODE_RETRIES;
++	unsigned int val;
++	int error;
++
++	if (tsdata->version != EDT_M06) {
++		dev_err(&client->dev,
++			"No factory mode support for non-M06 devices\n");
++		return -EINVAL;
++	}
++
++	disable_irq(client->irq);
++
++	if (!tsdata->raw_buffer) {
++		tsdata->raw_bufsize = tsdata->num_x * tsdata->num_y *
++				      sizeof(u16);
++		tsdata->raw_buffer = kzalloc(tsdata->raw_bufsize, GFP_KERNEL);
++		if (!tsdata->raw_buffer) {
++			error = -ENOMEM;
++			goto err_out;
++		}
++	}
++
++	/* mode register is 0x3c when in the work mode */
++	error = regmap_write(tsdata->regmap, WORK_REGISTER_OPMODE, 0x03);
++	if (error) {
++		dev_err(&client->dev,
++			"failed to switch to factory mode, error %d\n", error);
++		goto err_out;
++	}
++
++	tsdata->factory_mode = true;
++	do {
++		mdelay(EDT_SWITCH_MODE_DELAY);
++		/* mode register is 0x01 when in factory mode */
++		error = regmap_read(tsdata->regmap, FACTORY_REGISTER_OPMODE,
++				    &val);
++		if (!error && val == 0x03)
++			break;
++	} while (--retries > 0);
++
++	if (retries == 0) {
++		dev_err(&client->dev, "not in factory mode after %dms.\n",
++			EDT_SWITCH_MODE_RETRIES * EDT_SWITCH_MODE_DELAY);
++		error = -EIO;
++		goto err_out;
++	}
++
++	return 0;
++
++err_out:
++	kfree(tsdata->raw_buffer);
++	tsdata->raw_buffer = NULL;
++	tsdata->factory_mode = false;
++	enable_irq(client->irq);
++
++	return error;
++}
++
++static int edt_ft5x06_work_mode(struct edt_ft5x06_ts_data *tsdata)
++{
++	struct i2c_client *client = tsdata->client;
++	int retries = EDT_SWITCH_MODE_RETRIES;
++	unsigned int val;
++	int error;
++
++	/* mode register is 0x01 when in the factory mode */
++	error = regmap_write(tsdata->regmap, FACTORY_REGISTER_OPMODE, 0x1);
++	if (error) {
++		dev_err(&client->dev,
++			"failed to switch to work mode, error: %d\n", error);
++		return error;
++	}
++
++	tsdata->factory_mode = false;
++
++	do {
++		mdelay(EDT_SWITCH_MODE_DELAY);
++		/* mode register is 0x01 when in factory mode */
++		error = regmap_read(tsdata->regmap, WORK_REGISTER_OPMODE, &val);
++		if (!error && val == 0x01)
++			break;
++	} while (--retries > 0);
++
++	if (retries == 0) {
++		dev_err(&client->dev, "not in work mode after %dms.\n",
++			EDT_SWITCH_MODE_RETRIES * EDT_SWITCH_MODE_DELAY);
++		tsdata->factory_mode = true;
++		return -EIO;
++	}
++
++	kfree(tsdata->raw_buffer);
++	tsdata->raw_buffer = NULL;
++
++	edt_ft5x06_restore_reg_parameters(tsdata);
++	enable_irq(client->irq);
++
++	return 0;
++}
++
++static int edt_ft5x06_debugfs_mode_get(void *data, u64 *mode)
++{
++	struct edt_ft5x06_ts_data *tsdata = data;
++
++	*mode = tsdata->factory_mode;
++
++	return 0;
++};
++
++static int edt_ft5x06_debugfs_mode_set(void *data, u64 mode)
++{
++	struct edt_ft5x06_ts_data *tsdata = data;
++
++	if (mode > 1)
++		return -ERANGE;
++
++	guard(mutex)(&tsdata->mutex);
++
++	if (mode == tsdata->factory_mode)
++		return 0;
++
++	return mode ? edt_ft5x06_factory_mode(tsdata) :
++		      edt_ft5x06_work_mode(tsdata);
++};
++
++DEFINE_SIMPLE_ATTRIBUTE(debugfs_mode_fops, edt_ft5x06_debugfs_mode_get,
++			edt_ft5x06_debugfs_mode_set, "%llu\n");
++
++static ssize_t edt_ft5x06_debugfs_raw_data_read(struct file *file,
++						char __user *buf, size_t count,
++						loff_t *off)
++{
++	struct edt_ft5x06_ts_data *tsdata = file->private_data;
++	struct i2c_client *client = tsdata->client;
++	int retries  = EDT_RAW_DATA_RETRIES;
++	unsigned int val;
++	int i, error;
++	size_t read = 0;
++	int colbytes;
++	u8 *rdbuf;
++
++	if (*off < 0 || *off >= tsdata->raw_bufsize)
++		return 0;
++
++	guard(mutex)(&tsdata->mutex);
++
++	if (!tsdata->factory_mode || !tsdata->raw_buffer)
++		return -EIO;
++
++	error = regmap_write(tsdata->regmap, 0x08, 0x01);
++	if (error) {
++		dev_err(&client->dev,
++			"failed to write 0x08 register, error %d\n", error);
++		return error;
++	}
++
++	do {
++		usleep_range(EDT_RAW_DATA_DELAY, EDT_RAW_DATA_DELAY + 100);
++		error = regmap_read(tsdata->regmap, 0x08, &val);
++		if (error) {
++			dev_err(&client->dev,
++				"failed to read 0x08 register, error %d\n",
++				error);
++			return error;
++		}
++
++		if (val == 1)
++			break;
++	} while (--retries > 0);
++
++	if (retries == 0) {
++		dev_err(&client->dev,
++			"timed out waiting for register to settle\n");
++		return -ETIMEDOUT;
++	}
++
++	rdbuf = tsdata->raw_buffer;
++	colbytes = tsdata->num_y * sizeof(u16);
++
++	for (i = 0; i < tsdata->num_x; i++) {
++		rdbuf[0] = i;  /* column index */
++		error = regmap_bulk_read(tsdata->regmap, 0xf5, rdbuf, colbytes);
++		if (error)
++			return error;
++
++		rdbuf += colbytes;
++	}
++
++	read = min_t(size_t, count, tsdata->raw_bufsize - *off);
++	if (copy_to_user(buf, tsdata->raw_buffer + *off, read))
++		return -EFAULT;
++
++	*off += read;
++	return read;
++};
++
++static const struct file_operations debugfs_raw_data_fops = {
++	.open = simple_open,
++	.read = edt_ft5x06_debugfs_raw_data_read,
++};
++
++static void edt_ft5x06_ts_prepare_debugfs(struct edt_ft5x06_ts_data *tsdata)
++{
++	struct dentry *debug_dir = tsdata->client->debugfs;
++
++	debugfs_create_u16("num_x", S_IRUSR, debug_dir, &tsdata->num_x);
++	debugfs_create_u16("num_y", S_IRUSR, debug_dir, &tsdata->num_y);
++
++	debugfs_create_file("mode", S_IRUSR | S_IWUSR,
++			    debug_dir, tsdata, &debugfs_mode_fops);
++	debugfs_create_file("raw_data", S_IRUSR,
++			    debug_dir, tsdata, &debugfs_raw_data_fops);
++}
++
++static void edt_ft5x06_ts_teardown_debugfs(struct edt_ft5x06_ts_data *tsdata)
++{
++	guard(mutex)(&tsdata->mutex);
++
++	kfree(tsdata->raw_buffer);
++	tsdata->raw_buffer = NULL;
++}
++
++#else
++
++static int edt_ft5x06_factory_mode(struct edt_ft5x06_ts_data *tsdata)
++{
++	return -ENOSYS;
++}
++
++static void edt_ft5x06_ts_prepare_debugfs(struct edt_ft5x06_ts_data *tsdata)
++{
++}
++
++static void edt_ft5x06_ts_teardown_debugfs(struct edt_ft5x06_ts_data *tsdata)
++{
++}
++
++#endif /* CONFIG_DEBUGFS */
++
++static int edt_ft5x06_ts_identify(struct i2c_client *client,
++				  struct edt_ft5x06_ts_data *tsdata)
++{
++	u8 rdbuf[EDT_NAME_LEN];
++	char *p;
++	int error;
++	char *model_name = tsdata->name;
++	char *fw_version = tsdata->fw_version;
++
++	/* see what we find if we assume it is a M06 *
++	 * if we get less than EDT_NAME_LEN, we don't want
++	 * to have garbage in there
++	 */
++	memset(rdbuf, 0, sizeof(rdbuf));
++	error = regmap_bulk_read(tsdata->regmap, 0xBB, rdbuf, EDT_NAME_LEN - 1);
++	if (error)
++		return error;
++
++	/* Probe content for something consistent.
++	 * M06 starts with a response byte, M12 gives the data directly.
++	 * M09/Generic does not provide model number information.
++	 */
++	if (!strncasecmp(rdbuf + 1, "EP0", 3)) {
++		tsdata->version = EDT_M06;
++
++		/* remove last '$' end marker */
++		rdbuf[EDT_NAME_LEN - 1] = '\0';
++		if (rdbuf[EDT_NAME_LEN - 2] == '$')
++			rdbuf[EDT_NAME_LEN - 2] = '\0';
++
++		/* look for Model/Version separator */
++		p = strchr(rdbuf, '*');
++		if (p)
++			*p++ = '\0';
++		strscpy(model_name, rdbuf + 1, EDT_NAME_LEN);
++		strscpy(fw_version, p ? p : "", EDT_NAME_LEN);
++
++		regmap_exit(tsdata->regmap);
++		tsdata->regmap = regmap_init_i2c(client,
++						 &edt_M06_i2c_regmap_config);
++		if (IS_ERR(tsdata->regmap)) {
++			dev_err(&client->dev, "regmap allocation failed\n");
++			return PTR_ERR(tsdata->regmap);
++		}
++	} else if (!strncasecmp(rdbuf, "EP0", 3)) {
++		tsdata->version = EDT_M12;
++
++		/* remove last '$' end marker */
++		rdbuf[EDT_NAME_LEN - 2] = '\0';
++		if (rdbuf[EDT_NAME_LEN - 3] == '$')
++			rdbuf[EDT_NAME_LEN - 3] = '\0';
++
++		/* look for Model/Version separator */
++		p = strchr(rdbuf, '*');
++		if (p)
++			*p++ = '\0';
++		strscpy(model_name, rdbuf, EDT_NAME_LEN);
++		strscpy(fw_version, p ? p : "", EDT_NAME_LEN);
++	} else {
++		/* If it is not an EDT M06/M12 touchscreen, then the model
++		 * detection is a bit hairy. The different ft5x06
++		 * firmwares around don't reliably implement the
++		 * identification registers. Well, we'll take a shot.
++		 *
++		 * The main difference between generic focaltec based
++		 * touches and EDT M09 is that we know how to retrieve
++		 * the max coordinates for the latter.
++		 */
++		tsdata->version = GENERIC_FT;
++
++		error = regmap_bulk_read(tsdata->regmap, 0xA6, rdbuf, 2);
++		if (error)
++			return error;
++
++		strscpy(fw_version, rdbuf, 2);
++
++		error = regmap_bulk_read(tsdata->regmap, 0xA8, rdbuf, 1);
++		if (error)
++			return error;
++
++		/* This "model identification" is not exact. Unfortunately
++		 * not all firmwares for the ft5x06 put useful values in
++		 * the identification registers.
++		 */
++		switch (rdbuf[0]) {
++		case 0x11:   /* EDT EP0110M09 */
++		case 0x35:   /* EDT EP0350M09 */
++		case 0x43:   /* EDT EP0430M09 */
++		case 0x50:   /* EDT EP0500M09 */
++		case 0x57:   /* EDT EP0570M09 */
++		case 0x70:   /* EDT EP0700M09 */
++			tsdata->version = EDT_M09;
++			snprintf(model_name, EDT_NAME_LEN, "EP0%i%i0M09",
++				 rdbuf[0] >> 4, rdbuf[0] & 0x0F);
++			break;
++		case 0xa1:   /* EDT EP1010ML00 */
++			tsdata->version = EDT_M09;
++			snprintf(model_name, EDT_NAME_LEN, "EP%i%i0ML00",
++				 rdbuf[0] >> 4, rdbuf[0] & 0x0F);
++			break;
++		case 0x5a:   /* Solomon Goldentek Display */
++			snprintf(model_name, EDT_NAME_LEN, "GKTW50SCED1R0");
++			break;
++		case 0x59:  /* Evervision Display with FT5xx6 TS */
++			tsdata->version = EV_FT;
++			error = regmap_bulk_read(tsdata->regmap, 0x53, rdbuf, 1);
++			if (error)
++				return error;
++			strscpy(fw_version, rdbuf, 1);
++			snprintf(model_name, EDT_NAME_LEN,
++				 "EVERVISION-FT5726NEi");
++			break;
++		default:
++			snprintf(model_name, EDT_NAME_LEN,
++				 "generic ft5x06 (%02x)",
++				 rdbuf[0]);
++			break;
++		}
++	}
++
++	return 0;
++}
++
++static void edt_ft5x06_ts_get_defaults(struct device *dev,
++				       struct edt_ft5x06_ts_data *tsdata)
++{
++	struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
++	struct regmap *regmap = tsdata->regmap;
++	u32 val;
++	int error;
++
++	error = device_property_read_u32(dev, "threshold", &val);
++	if (!error) {
++		regmap_write(regmap, reg_addr->reg_threshold, val);
++		tsdata->threshold = val;
++	}
++
++	error = device_property_read_u32(dev, "gain", &val);
++	if (!error) {
++		regmap_write(regmap, reg_addr->reg_gain, val);
++		tsdata->gain = val;
++	}
++
++	error = device_property_read_u32(dev, "offset", &val);
++	if (!error) {
++		if (reg_addr->reg_offset != NO_REGISTER)
++			regmap_write(regmap, reg_addr->reg_offset, val);
++		tsdata->offset = val;
++	}
++
++	error = device_property_read_u32(dev, "offset-x", &val);
++	if (!error) {
++		if (reg_addr->reg_offset_x != NO_REGISTER)
++			regmap_write(regmap, reg_addr->reg_offset_x, val);
++		tsdata->offset_x = val;
++	}
++
++	error = device_property_read_u32(dev, "offset-y", &val);
++	if (!error) {
++		if (reg_addr->reg_offset_y != NO_REGISTER)
++			regmap_write(regmap, reg_addr->reg_offset_y, val);
++		tsdata->offset_y = val;
++	}
++}
++
++static void edt_ft5x06_ts_get_parameters(struct edt_ft5x06_ts_data *tsdata)
++{
++	struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
++	struct regmap *regmap = tsdata->regmap;
++	unsigned int val;
++
++	regmap_read(regmap, reg_addr->reg_threshold, &tsdata->threshold);
++	regmap_read(regmap, reg_addr->reg_gain, &tsdata->gain);
++	if (reg_addr->reg_offset != NO_REGISTER)
++		regmap_read(regmap, reg_addr->reg_offset, &tsdata->offset);
++	if (reg_addr->reg_offset_x != NO_REGISTER)
++		regmap_read(regmap, reg_addr->reg_offset_x, &tsdata->offset_x);
++	if (reg_addr->reg_offset_y != NO_REGISTER)
++		regmap_read(regmap, reg_addr->reg_offset_y, &tsdata->offset_y);
++	if (reg_addr->reg_report_rate != NO_REGISTER)
++		regmap_read(regmap, reg_addr->reg_report_rate,
++			    &tsdata->report_rate);
++	tsdata->num_x = EDT_DEFAULT_NUM_X;
++	if (reg_addr->reg_num_x != NO_REGISTER) {
++		if (!regmap_read(regmap, reg_addr->reg_num_x, &val))
++			tsdata->num_x = val;
++	}
++	tsdata->num_y = EDT_DEFAULT_NUM_Y;
++	if (reg_addr->reg_num_y != NO_REGISTER) {
++		if (!regmap_read(regmap, reg_addr->reg_num_y, &val))
++			tsdata->num_y = val;
++	}
++}
++
++static void edt_ft5x06_ts_set_tdata_parameters(struct edt_ft5x06_ts_data *tsdata)
++{
++	int crclen;
++
++	if (tsdata->version == EDT_M06) {
++		tsdata->tdata_cmd = 0xf9;
++		tsdata->tdata_offset = 5;
++		tsdata->point_len = 4;
++		crclen = 1;
++	} else {
++		tsdata->tdata_cmd = 0x0;
++		tsdata->tdata_offset = 3;
++		tsdata->point_len = 6;
++		crclen = 0;
++	}
++
++	tsdata->tdata_len = tsdata->point_len * tsdata->max_support_points +
++		tsdata->tdata_offset + crclen;
++}
++
++static void edt_ft5x06_ts_set_regs(struct edt_ft5x06_ts_data *tsdata)
++{
++	struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
++
++	switch (tsdata->version) {
++	case EDT_M06:
++		reg_addr->reg_threshold = WORK_REGISTER_THRESHOLD;
++		reg_addr->reg_report_rate = WORK_REGISTER_REPORT_RATE;
++		reg_addr->reg_gain = WORK_REGISTER_GAIN;
++		reg_addr->reg_offset = WORK_REGISTER_OFFSET;
++		reg_addr->reg_offset_x = NO_REGISTER;
++		reg_addr->reg_offset_y = NO_REGISTER;
++		reg_addr->reg_num_x = WORK_REGISTER_NUM_X;
++		reg_addr->reg_num_y = WORK_REGISTER_NUM_Y;
++		break;
++
++	case EDT_M09:
++	case EDT_M12:
++		reg_addr->reg_threshold = M09_REGISTER_THRESHOLD;
++		reg_addr->reg_report_rate = tsdata->version == EDT_M12 ?
++			M12_REGISTER_REPORT_RATE : NO_REGISTER;
++		reg_addr->reg_gain = M09_REGISTER_GAIN;
++		reg_addr->reg_offset = M09_REGISTER_OFFSET;
++		reg_addr->reg_offset_x = NO_REGISTER;
++		reg_addr->reg_offset_y = NO_REGISTER;
++		reg_addr->reg_num_x = M09_REGISTER_NUM_X;
++		reg_addr->reg_num_y = M09_REGISTER_NUM_Y;
++		break;
++
++	case EV_FT:
++		reg_addr->reg_threshold = EV_REGISTER_THRESHOLD;
++		reg_addr->reg_report_rate = NO_REGISTER;
++		reg_addr->reg_gain = EV_REGISTER_GAIN;
++		reg_addr->reg_offset = NO_REGISTER;
++		reg_addr->reg_offset_x = EV_REGISTER_OFFSET_X;
++		reg_addr->reg_offset_y = EV_REGISTER_OFFSET_Y;
++		reg_addr->reg_num_x = NO_REGISTER;
++		reg_addr->reg_num_y = NO_REGISTER;
++		break;
++
++	case GENERIC_FT:
++		/* this is a guesswork */
++		reg_addr->reg_threshold = M09_REGISTER_THRESHOLD;
++		reg_addr->reg_report_rate = NO_REGISTER;
++		reg_addr->reg_gain = M09_REGISTER_GAIN;
++		reg_addr->reg_offset = M09_REGISTER_OFFSET;
++		reg_addr->reg_offset_x = NO_REGISTER;
++		reg_addr->reg_offset_y = NO_REGISTER;
++		reg_addr->reg_num_x = NO_REGISTER;
++		reg_addr->reg_num_y = NO_REGISTER;
++		break;
++	}
++}
++
++static void edt_ft5x06_exit_regmap(void *arg)
++{
++	struct edt_ft5x06_ts_data *data = arg;
++
++	if (!IS_ERR_OR_NULL(data->regmap))
++		regmap_exit(data->regmap);
++}
++
++static void edt_ft5x06_disable_regulators(void *arg)
++{
++	struct edt_ft5x06_ts_data *data = arg;
++
++	regulator_disable(data->vcc);
++	regulator_disable(data->iovcc);
++}
++
++static int edt_ft5x06_ts_probe(struct i2c_client *client)
++{
++	const struct i2c_device_id *id = i2c_client_get_device_id(client);
++	const struct edt_i2c_chip_data *chip_data;
++	struct edt_ft5x06_ts_data *tsdata;
++	unsigned int val;
++	struct input_dev *input;
++	unsigned long irq_flags;
++	int error;
++	u32 report_rate;
++
++	dev_dbg(&client->dev, "probing for EDT FT5x06 I2C\n");
++
++	tsdata = devm_kzalloc(&client->dev, sizeof(*tsdata), GFP_KERNEL);
++	if (!tsdata) {
++		dev_err(&client->dev, "failed to allocate driver data.\n");
++		return -ENOMEM;
++	}
++
++	tsdata->regmap = regmap_init_i2c(client, &edt_ft5x06_i2c_regmap_config);
++	if (IS_ERR(tsdata->regmap)) {
++		dev_err(&client->dev, "regmap allocation failed\n");
++		return PTR_ERR(tsdata->regmap);
++	}
++
++	/*
++	 * We are not using devm_regmap_init_i2c() and instead install a
++	 * custom action because we may replace regmap with M06-specific one
++	 * and we need to make sure that it will not be released too early.
++	 */
++	error = devm_add_action_or_reset(&client->dev, edt_ft5x06_exit_regmap,
++					 tsdata);
++	if (error)
++		return error;
++
++	chip_data = device_get_match_data(&client->dev);
++	if (!chip_data)
++		chip_data = (const struct edt_i2c_chip_data *)id->driver_data;
++	if (!chip_data || !chip_data->max_support_points) {
++		dev_err(&client->dev, "invalid or missing chip data\n");
++		return -EINVAL;
++	}
++
++	tsdata->max_support_points = chip_data->max_support_points;
++
++	tsdata->vcc = devm_regulator_get(&client->dev, "vcc");
++	if (IS_ERR(tsdata->vcc))
++		return dev_err_probe(&client->dev, PTR_ERR(tsdata->vcc),
++				     "failed to request regulator\n");
++
++	tsdata->iovcc = devm_regulator_get(&client->dev, "iovcc");
++	if (IS_ERR(tsdata->iovcc)) {
++		error = PTR_ERR(tsdata->iovcc);
++		if (error != -EPROBE_DEFER)
++			dev_err(&client->dev,
++				"failed to request iovcc regulator: %d\n", error);
++		return error;
++	}
++
++	error = regulator_enable(tsdata->iovcc);
++	if (error < 0) {
++		dev_err(&client->dev, "failed to enable iovcc: %d\n", error);
++		return error;
++	}
++
++	/* Delay enabling VCC for > 10us (T_ivd) after IOVCC */
++	usleep_range(10, 100);
++
++	error = regulator_enable(tsdata->vcc);
++	if (error < 0) {
++		dev_err(&client->dev, "failed to enable vcc: %d\n", error);
++		regulator_disable(tsdata->iovcc);
++		return error;
++	}
++
++	error = devm_add_action_or_reset(&client->dev,
++					 edt_ft5x06_disable_regulators,
++					 tsdata);
++	if (error)
++		return error;
++
++	tsdata->reset_gpio = devm_gpiod_get_optional(&client->dev,
++						     "reset", GPIOD_OUT_HIGH);
++	if (IS_ERR(tsdata->reset_gpio)) {
++		error = PTR_ERR(tsdata->reset_gpio);
++		dev_err(&client->dev,
++			"Failed to request GPIO reset pin, error %d\n", error);
++		return error;
++	}
++
++	tsdata->wake_gpio = devm_gpiod_get_optional(&client->dev,
++						    "wake", GPIOD_OUT_LOW);
++	if (IS_ERR(tsdata->wake_gpio)) {
++		error = PTR_ERR(tsdata->wake_gpio);
++		dev_err(&client->dev,
++			"Failed to request GPIO wake pin, error %d\n", error);
++		return error;
++	}
++
++	/*
++	 * Check which sleep modes we can support. Power-off requires the
++	 * reset-pin to ensure correct power-down/power-up behaviour. Start with
++	 * the EDT_PMODE_POWEROFF test since this is the deepest possible sleep
++	 * mode.
++	 */
++	if (tsdata->reset_gpio)
++		tsdata->suspend_mode = EDT_PMODE_POWEROFF;
++	else if (tsdata->wake_gpio)
++		tsdata->suspend_mode = EDT_PMODE_HIBERNATE;
++	else
++		tsdata->suspend_mode = EDT_PMODE_NOT_SUPPORTED;
++
++	if (tsdata->wake_gpio) {
++		usleep_range(5000, 6000);
++		gpiod_set_value_cansleep(tsdata->wake_gpio, 1);
++		usleep_range(5000, 6000);
++	}
++
++	if (tsdata->reset_gpio) {
++		usleep_range(5000, 6000);
++		gpiod_set_value_cansleep(tsdata->reset_gpio, 0);
++		msleep(300);
++	}
++
++	input = devm_input_allocate_device(&client->dev);
++	if (!input) {
++		dev_err(&client->dev, "failed to allocate input device.\n");
++		return -ENOMEM;
++	}
++
++	mutex_init(&tsdata->mutex);
++	tsdata->client = client;
++	tsdata->input = input;
++	tsdata->factory_mode = false;
++	i2c_set_clientdata(client, tsdata);
++
++	error = edt_ft5x06_ts_identify(client, tsdata);
++	if (error) {
++		dev_err(&client->dev, "touchscreen probe failed\n");
++		return error;
++	}
++
++	/*
++	 * Dummy read access. EP0700MLP1 returns bogus data on the first
++	 * register read access and ignores writes.
++	 */
++	regmap_read(tsdata->regmap, 0x00, &val);
++
++	edt_ft5x06_ts_set_tdata_parameters(tsdata);
++	edt_ft5x06_ts_set_regs(tsdata);
++	edt_ft5x06_ts_get_defaults(&client->dev, tsdata);
++	edt_ft5x06_ts_get_parameters(tsdata);
++
++	if (tsdata->reg_addr.reg_report_rate != NO_REGISTER &&
++	    !device_property_read_u32(&client->dev,
++				      "report-rate-hz", &report_rate)) {
++		if (tsdata->version == EDT_M06)
++			tsdata->report_rate = clamp_val(report_rate, 30, 140);
++		else
++			tsdata->report_rate = clamp_val(report_rate, 1, 255);
++
++		if (report_rate != tsdata->report_rate)
++			dev_warn(&client->dev,
++				 "report-rate %dHz is unsupported, use %dHz\n",
++				 report_rate, tsdata->report_rate);
++
++		if (tsdata->version == EDT_M06)
++			tsdata->report_rate /= 10;
++
++		regmap_write(tsdata->regmap, tsdata->reg_addr.reg_report_rate,
++			     tsdata->report_rate);
++	}
++
++	dev_dbg(&client->dev,
++		"Model \"%s\", Rev. \"%s\", %dx%d sensors\n",
++		tsdata->name, tsdata->fw_version, tsdata->num_x, tsdata->num_y);
++
++	input->name = tsdata->name;
++	input->id.bustype = BUS_I2C;
++	input->dev.parent = &client->dev;
++
++	input_set_abs_params(input, ABS_MT_POSITION_X,
++			     0, tsdata->num_x * 64 - 1, 0, 0);
++	input_set_abs_params(input, ABS_MT_POSITION_Y,
++			     0, tsdata->num_y * 64 - 1, 0, 0);
++
++	touchscreen_parse_properties(input, true, &tsdata->prop);
++
++	error = input_mt_init_slots(input, tsdata->max_support_points,
++				    INPUT_MT_DIRECT);
++	if (error) {
++		dev_err(&client->dev, "Unable to init MT slots.\n");
++		return error;
++	}
++
++	irq_flags = irq_get_trigger_type(client->irq);
++	if (irq_flags == IRQF_TRIGGER_NONE)
++		irq_flags = IRQF_TRIGGER_FALLING;
++	irq_flags |= IRQF_ONESHOT;
++
++	error = devm_request_threaded_irq(&client->dev, client->irq,
++					  NULL, edt_ft5x06_ts_isr, irq_flags,
++					  client->name, tsdata);
++	if (error) {
++		dev_err(&client->dev, "Unable to request touchscreen IRQ.\n");
++		return error;
++	}
++
++	error = input_register_device(input);
++	if (error)
++		return error;
++
++	edt_ft5x06_ts_prepare_debugfs(tsdata);
++
++	dev_dbg(&client->dev,
++		"EDT FT5x06 initialized: IRQ %d, WAKE pin %d, Reset pin %d.\n",
++		client->irq,
++		tsdata->wake_gpio ? desc_to_gpio(tsdata->wake_gpio) : -1,
++		tsdata->reset_gpio ? desc_to_gpio(tsdata->reset_gpio) : -1);
++
++	return 0;
++}
++
++static void edt_ft5x06_ts_remove(struct i2c_client *client)
++{
++	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
++
++	edt_ft5x06_ts_teardown_debugfs(tsdata);
++}
++
++static int edt_ft5x06_ts_suspend(struct device *dev)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
++	struct gpio_desc *reset_gpio = tsdata->reset_gpio;
++	int ret;
++
++	if (device_may_wakeup(dev))
++		return 0;
++
++	if (tsdata->suspend_mode == EDT_PMODE_NOT_SUPPORTED)
++		return 0;
++
++	/* Enter hibernate mode. */
++	ret = regmap_write(tsdata->regmap, PMOD_REGISTER_OPMODE,
++			   PMOD_REGISTER_HIBERNATE);
++	if (ret)
++		dev_warn(dev, "Failed to set hibernate mode\n");
++
++	if (tsdata->suspend_mode == EDT_PMODE_HIBERNATE)
++		return 0;
++
++	/*
++	 * Power-off according the datasheet. Cut the power may leaf the irq
++	 * line in an undefined state depending on the host pull resistor
++	 * settings. Disable the irq to avoid adjusting each host till the
++	 * device is back in a full functional state.
++	 */
++	disable_irq(tsdata->client->irq);
++
++	gpiod_set_value_cansleep(reset_gpio, 1);
++	usleep_range(1000, 2000);
++
++	ret = regulator_disable(tsdata->vcc);
++	if (ret)
++		dev_warn(dev, "Failed to disable vcc\n");
++	ret = regulator_disable(tsdata->iovcc);
++	if (ret)
++		dev_warn(dev, "Failed to disable iovcc\n");
++
++	return 0;
++}
++
++static int edt_ft5x06_ts_resume(struct device *dev)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
++	int ret = 0;
++
++	if (device_may_wakeup(dev))
++		return 0;
++
++	if (tsdata->suspend_mode == EDT_PMODE_NOT_SUPPORTED)
++		return 0;
++
++	if (tsdata->suspend_mode == EDT_PMODE_POWEROFF) {
++		struct gpio_desc *reset_gpio = tsdata->reset_gpio;
++
++		/*
++		 * We can't check if the regulator is a dummy or a real
++		 * regulator. So we need to specify the 5ms reset time (T_rst)
++		 * here instead of the 100us T_rtp time. We also need to wait
++		 * 300ms in case it was a real supply and the power was cutted
++		 * of. Toggle the reset pin is also a way to exit the hibernate
++		 * mode.
++		 */
++		gpiod_set_value_cansleep(reset_gpio, 1);
++		usleep_range(5000, 6000);
++
++		ret = regulator_enable(tsdata->iovcc);
++		if (ret) {
++			dev_err(dev, "Failed to enable iovcc\n");
++			return ret;
++		}
++
++		/* Delay enabling VCC for > 10us (T_ivd) after IOVCC */
++		usleep_range(10, 100);
++
++		ret = regulator_enable(tsdata->vcc);
++		if (ret) {
++			dev_err(dev, "Failed to enable vcc\n");
++			regulator_disable(tsdata->iovcc);
++			return ret;
++		}
++
++		usleep_range(1000, 2000);
++		gpiod_set_value_cansleep(reset_gpio, 0);
++		msleep(300);
++
++		edt_ft5x06_restore_reg_parameters(tsdata);
++		enable_irq(tsdata->client->irq);
++
++		if (tsdata->factory_mode)
++			ret = edt_ft5x06_factory_mode(tsdata);
++	} else {
++		struct gpio_desc *wake_gpio = tsdata->wake_gpio;
++
++		gpiod_set_value_cansleep(wake_gpio, 0);
++		usleep_range(5000, 6000);
++		gpiod_set_value_cansleep(wake_gpio, 1);
++	}
++
++	return ret;
++}
++
++static DEFINE_SIMPLE_DEV_PM_OPS(edt_ft5x06_ts_pm_ops,
++				edt_ft5x06_ts_suspend, edt_ft5x06_ts_resume);
++
++static const struct edt_i2c_chip_data edt_ft5x06_data = {
++	.max_support_points = 5,
++};
++
++static const struct edt_i2c_chip_data edt_ft3518_data = {
++	.max_support_points = 10,
++};
++
++static const struct edt_i2c_chip_data edt_ft5452_data = {
++	.max_support_points = 5,
++};
++
++static const struct edt_i2c_chip_data edt_ft5506_data = {
++	.max_support_points = 10,
++};
++
++static const struct edt_i2c_chip_data edt_ft6236_data = {
++	.max_support_points = 2,
++};
++
++static const struct edt_i2c_chip_data edt_ft8201_data = {
++	.max_support_points = 10,
++};
++
++static const struct edt_i2c_chip_data edt_ft8716_data = {
++	.max_support_points = 10,
++};
++
++static const struct edt_i2c_chip_data edt_ft8719_data = {
++	.max_support_points = 10,
++};
++
++static const struct i2c_device_id edt_ft5x06_ts_id[] = {
++	{ .name = "edt-ft5x06", .driver_data = (long)&edt_ft5x06_data },
++	{ .name = "edt-ft5506", .driver_data = (long)&edt_ft5506_data },
++	{ .name = "ev-ft5726", .driver_data = (long)&edt_ft5506_data },
++	{ .name = "ft3518", .driver_data = (long)&edt_ft3518_data },
++	{ .name = "ft5452", .driver_data = (long)&edt_ft5452_data },
++	/* Note no edt- prefix for compatibility with the ft6236.c driver */
++	{ .name = "ft6236", .driver_data = (long)&edt_ft6236_data },
++	{ .name = "ft8201", .driver_data = (long)&edt_ft8201_data },
++	{ .name = "ft8716", .driver_data = (long)&edt_ft8716_data },
++	{ .name = "ft8719", .driver_data = (long)&edt_ft8719_data },
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(i2c, edt_ft5x06_ts_id);
++
++static const struct of_device_id edt_ft5x06_of_match[] = {
++	{ .compatible = "edt,edt-ft5206", .data = &edt_ft5x06_data },
++	{ .compatible = "edt,edt-ft5306", .data = &edt_ft5x06_data },
++	{ .compatible = "edt,edt-ft5406", .data = &edt_ft5x06_data },
++	{ .compatible = "edt,edt-ft5506", .data = &edt_ft5506_data },
++	{ .compatible = "evervision,ev-ft5726", .data = &edt_ft5506_data },
++	{ .compatible = "focaltech,ft3518", .data = &edt_ft3518_data },
++	{ .compatible = "focaltech,ft5426", .data = &edt_ft5506_data },
++	{ .compatible = "focaltech,ft5452", .data = &edt_ft5452_data },
++	/* Note focaltech vendor prefix for compatibility with ft6236.c */
++	{ .compatible = "focaltech,ft6236", .data = &edt_ft6236_data },
++	{ .compatible = "focaltech,ft8201", .data = &edt_ft8201_data },
++	{ .compatible = "focaltech,ft8716", .data = &edt_ft8716_data },
++	{ .compatible = "focaltech,ft8719", .data = &edt_ft8719_data },
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, edt_ft5x06_of_match);
++
++static struct i2c_driver edt_ft5x06_ts_driver = {
++	.driver = {
++		.name = "edt_ft5x06",
++		.dev_groups = edt_ft5x06_groups,
++		.of_match_table = edt_ft5x06_of_match,
++		.pm = pm_sleep_ptr(&edt_ft5x06_ts_pm_ops),
++		.probe_type = PROBE_PREFER_ASYNCHRONOUS,
++	},
++	.id_table = edt_ft5x06_ts_id,
++	.probe    = edt_ft5x06_ts_probe,
++	.remove   = edt_ft5x06_ts_remove,
++};
++
++module_i2c_driver(edt_ft5x06_ts_driver);
++
++MODULE_AUTHOR("Simon Budig <simon.budig@kernelconcepts.de>");
++MODULE_DESCRIPTION("EDT FT5x06 I2C Touchscreen Driver");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/net/wireless/ath/ath12k/core.h.orig b/drivers/net/wireless/ath/ath12k/core.h.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/net/wireless/ath/ath12k/core.h.orig
+@@ -0,0 +1,1438 @@
++/* SPDX-License-Identifier: BSD-3-Clause-Clear */
++/*
++ * Copyright (c) 2018-2021 The Linux Foundation. All rights reserved.
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
++
++#ifndef ATH12K_CORE_H
++#define ATH12K_CORE_H
++
++#include <linux/types.h>
++#include <linux/interrupt.h>
++#include <linux/irq.h>
++#include <linux/bitfield.h>
++#include <linux/dmi.h>
++#include <linux/ctype.h>
++#include <linux/firmware.h>
++#include <linux/of_reserved_mem.h>
++#include <linux/panic_notifier.h>
++#include <linux/average.h>
++#include <linux/of.h>
++#include <linux/rhashtable.h>
++#include "qmi.h"
++#include "htc.h"
++#include "wmi.h"
++#include "hal.h"
++#include "dp.h"
++#include "ce.h"
++#include "mac.h"
++#include "hw.h"
++#include "reg.h"
++#include "dbring.h"
++#include "fw.h"
++#include "acpi.h"
++#include "wow.h"
++#include "debugfs_htt_stats.h"
++#include "coredump.h"
++#include "cmn_defs.h"
++#include "dp_cmn.h"
++#include "thermal.h"
++
++#define SM(_v, _f) (((_v) << _f##_LSB) & _f##_MASK)
++
++#define ATH12K_TX_MGMT_NUM_PENDING_MAX	512
++
++#define ATH12K_TX_MGMT_TARGET_MAX_SUPPORT_WMI 64
++
++/* Pending management packets threshold for dropping probe responses */
++#define ATH12K_PRB_RSP_DROP_THRESHOLD ((ATH12K_TX_MGMT_TARGET_MAX_SUPPORT_WMI * 3) / 4)
++
++/* SMBIOS type containing Board Data File Name Extension */
++#define ATH12K_SMBIOS_BDF_EXT_TYPE 0xF8
++
++/* SMBIOS type structure length (excluding strings-set) */
++#define ATH12K_SMBIOS_BDF_EXT_LENGTH 0x9
++
++/* The magic used by QCA spec */
++#define ATH12K_SMBIOS_BDF_EXT_MAGIC "BDF_"
++
++#define ATH12K_INVALID_HW_MAC_ID	0xFF
++#define ATH12K_CONNECTION_LOSS_HZ	(3 * HZ)
++
++#define ATH12K_MON_TIMER_INTERVAL  10
++#define ATH12K_RESET_TIMEOUT_HZ			(20 * HZ)
++#define ATH12K_RESET_MAX_FAIL_COUNT_FIRST	3
++#define ATH12K_RESET_MAX_FAIL_COUNT_FINAL	5
++#define ATH12K_RESET_FAIL_TIMEOUT_HZ		(20 * HZ)
++#define ATH12K_RECONFIGURE_TIMEOUT_HZ		(10 * HZ)
++#define ATH12K_RECOVER_START_TIMEOUT_HZ		(20 * HZ)
++
++#define ATH12K_INVALID_GROUP_ID  0xFF
++#define ATH12K_INVALID_DEVICE_ID 0xFF
++
++#define ATH12K_MAX_MLO_PEERS            256
++#define ATH12K_MLO_PEER_ID_INVALID      0xFFFF
++
++#define ATH12K_INVALID_RSSI_FULL -1
++#define ATH12K_INVALID_RSSI_EMPTY -128
++
++enum ath12k_bdf_search {
++	ATH12K_BDF_SEARCH_DEFAULT,
++	ATH12K_BDF_SEARCH_BUS_AND_BOARD,
++};
++
++enum wme_ac {
++	WME_AC_BE,
++	WME_AC_BK,
++	WME_AC_VI,
++	WME_AC_VO,
++	WME_NUM_AC
++};
++
++#define ATH12K_HT_MCS_MAX	7
++#define ATH12K_VHT_MCS_MAX	9
++#define ATH12K_HE_MCS_MAX	11
++#define ATH12K_EHT_MCS_MAX	15
++
++enum ath12k_crypt_mode {
++	/* Only use hardware crypto engine */
++	ATH12K_CRYPT_MODE_HW,
++	/* Only use software crypto */
++	ATH12K_CRYPT_MODE_SW,
++};
++
++static inline enum wme_ac ath12k_tid_to_ac(u32 tid)
++{
++	return (((tid == 0) || (tid == 3)) ? WME_AC_BE :
++		((tid == 1) || (tid == 2)) ? WME_AC_BK :
++		((tid == 4) || (tid == 5)) ? WME_AC_VI :
++		WME_AC_VO);
++}
++
++static inline u64 ath12k_le32hilo_to_u64(__le32 hi, __le32 lo)
++{
++	u64 hi64 = le32_to_cpu(hi);
++	u64 lo64 = le32_to_cpu(lo);
++
++	return (hi64 << 32) | lo64;
++}
++
++enum ath12k_skb_flags {
++	ATH12K_SKB_HW_80211_ENCAP = BIT(0),
++	ATH12K_SKB_CIPHER_SET = BIT(1),
++	ATH12K_SKB_MLO_STA = BIT(2),
++};
++
++struct ath12k_skb_cb {
++	dma_addr_t paddr;
++	struct ath12k *ar;
++	struct ieee80211_vif *vif;
++	dma_addr_t paddr_ext_desc;
++	u32 cipher;
++	u8 flags;
++	u8 link_id;
++};
++
++struct ath12k_skb_rxcb {
++	dma_addr_t paddr;
++	bool is_first_msdu;
++	bool is_last_msdu;
++	bool is_continuation;
++	bool is_mcbc;
++	bool is_eapol;
++	struct hal_rx_desc *rx_desc;
++	u8 err_rel_src;
++	u8 err_code;
++	u8 hw_link_id;
++	u8 unmapped;
++	u8 is_frag;
++	u8 tid;
++	u16 peer_id;
++	bool is_end_of_ppdu;
++};
++
++enum ath12k_hw_rev {
++	ATH12K_HW_QCN9274_HW10,
++	ATH12K_HW_QCN9274_HW20,
++	ATH12K_HW_WCN7850_HW20,
++	ATH12K_HW_IPQ5332_HW10,
++	ATH12K_HW_QCC2072_HW10,
++	ATH12K_HW_IPQ5424_HW10,
++};
++
++enum ath12k_firmware_mode {
++	/* the default mode, standard 802.11 functionality */
++	ATH12K_FIRMWARE_MODE_NORMAL,
++
++	/* factory tests etc */
++	ATH12K_FIRMWARE_MODE_FTM,
++};
++
++#define ATH12K_IRQ_NUM_MAX 57
++#define ATH12K_EXT_IRQ_NUM_MAX	16
++#define ATH12K_MAX_TCL_RING_NUM	3
++
++struct ath12k_ext_irq_grp {
++	struct ath12k_base *ab;
++	u32 irqs[ATH12K_EXT_IRQ_NUM_MAX];
++	u32 num_irq;
++	u32 grp_id;
++	u64 timestamp;
++	bool napi_enabled;
++	struct napi_struct napi;
++	struct net_device *napi_ndev;
++};
++
++enum ath12k_smbios_cc_type {
++	/* disable country code setting from SMBIOS */
++	ATH12K_SMBIOS_CC_DISABLE = 0,
++
++	/* set country code by ANSI country name, based on ISO3166-1 alpha2 */
++	ATH12K_SMBIOS_CC_ISO = 1,
++
++	/* worldwide regdomain */
++	ATH12K_SMBIOS_CC_WW = 2,
++};
++
++struct ath12k_smbios_bdf {
++	struct dmi_header hdr;
++	u8 features_disabled;
++
++	/* enum ath12k_smbios_cc_type */
++	u8 country_code_flag;
++
++	/* To set specific country, you need to set country code
++	 * flag=ATH12K_SMBIOS_CC_ISO first, then if country is United
++	 * States, then country code value = 0x5553 ("US",'U' = 0x55, 'S'=
++	 * 0x53). To set country to INDONESIA, then country code value =
++	 * 0x4944 ("IN", 'I'=0x49, 'D'=0x44). If country code flag =
++	 * ATH12K_SMBIOS_CC_WW, then you can use worldwide regulatory
++	 * setting.
++	 */
++	u16 cc_code;
++
++	u8 bdf_enabled;
++	u8 bdf_ext[];
++} __packed;
++
++#define HEHANDLE_CAP_PHYINFO_SIZE       3
++#define HECAP_PHYINFO_SIZE              9
++#define HECAP_MACINFO_SIZE              5
++#define HECAP_TXRX_MCS_NSS_SIZE         2
++#define HECAP_PPET16_PPET8_MAX_SIZE     25
++
++#define HE_PPET16_PPET8_SIZE            8
++
++/* 802.11ax PPE (PPDU packet Extension) threshold */
++struct he_ppe_threshold {
++	u32 numss_m1;
++	u32 ru_mask;
++	u32 ppet16_ppet8_ru3_ru0[HE_PPET16_PPET8_SIZE];
++};
++
++struct ath12k_he {
++	u8 hecap_macinfo[HECAP_MACINFO_SIZE];
++	u32 hecap_rxmcsnssmap;
++	u32 hecap_txmcsnssmap;
++	u32 hecap_phyinfo[HEHANDLE_CAP_PHYINFO_SIZE];
++	struct he_ppe_threshold   hecap_ppet;
++	u32 heop_param;
++};
++
++enum {
++	WMI_HOST_TP_SCALE_MAX   = 0,
++	WMI_HOST_TP_SCALE_50    = 1,
++	WMI_HOST_TP_SCALE_25    = 2,
++	WMI_HOST_TP_SCALE_12    = 3,
++	WMI_HOST_TP_SCALE_MIN   = 4,
++	WMI_HOST_TP_SCALE_SIZE   = 5,
++};
++
++enum ath12k_scan_state {
++	ATH12K_SCAN_IDLE,
++	ATH12K_SCAN_STARTING,
++	ATH12K_SCAN_RUNNING,
++	ATH12K_SCAN_ABORTING,
++};
++
++enum ath12k_11d_state {
++	ATH12K_11D_IDLE,
++	ATH12K_11D_PREPARING,
++	ATH12K_11D_RUNNING,
++};
++
++enum ath12k_hw_group_flags {
++	ATH12K_GROUP_FLAG_REGISTERED,
++	ATH12K_GROUP_FLAG_UNREGISTER,
++};
++
++enum ath12k_dev_flags {
++	ATH12K_FLAG_CAC_RUNNING,
++	ATH12K_FLAG_CRASH_FLUSH,
++	ATH12K_FLAG_RAW_MODE,
++	ATH12K_FLAG_HW_CRYPTO_DISABLED,
++	ATH12K_FLAG_RECOVERY,
++	ATH12K_FLAG_UNREGISTERING,
++	ATH12K_FLAG_REGISTERED,
++	ATH12K_FLAG_QMI_FAIL,
++	ATH12K_FLAG_HTC_SUSPEND_COMPLETE,
++	ATH12K_FLAG_CE_IRQ_ENABLED,
++	ATH12K_FLAG_EXT_IRQ_ENABLED,
++	ATH12K_FLAG_QMI_FW_READY_COMPLETE,
++	ATH12K_FLAG_FTM_SEGMENTED,
++	ATH12K_FLAG_FIXED_MEM_REGION,
++};
++
++struct ath12k_tx_conf {
++	bool changed;
++	u16 ac;
++	struct ieee80211_tx_queue_params tx_queue_params;
++};
++
++struct ath12k_key_conf {
++	enum set_key_cmd cmd;
++	struct list_head list;
++	struct ieee80211_sta *sta;
++	struct ieee80211_key_conf *key;
++};
++
++struct ath12k_vif_cache {
++	struct ath12k_tx_conf tx_conf;
++	struct ath12k_key_conf key_conf;
++	u32 bss_conf_changed;
++};
++
++struct ath12k_rekey_data {
++	u8 kck[NL80211_KCK_LEN];
++	u8 kek[NL80211_KCK_LEN];
++	u64 replay_ctr;
++	bool enable_offload;
++};
++
++struct ath12k_link_vif {
++	u32 vdev_id;
++	u32 beacon_interval;
++	u32 dtim_period;
++
++	struct ath12k *ar;
++
++	bool beacon_prot;
++
++	struct wmi_wmm_params_all_arg wmm_params;
++	struct list_head list;
++
++	bool is_created;
++	bool is_started;
++	bool is_up;
++	u8 bssid[ETH_ALEN];
++	struct cfg80211_bitrate_mask bitrate_mask;
++	struct delayed_work connection_loss_work;
++	int num_legacy_stations;
++	int rtscts_prot_mode;
++	int txpower;
++	bool rsnie_present;
++	bool wpaie_present;
++	u8 vdev_stats_id;
++	u32 punct_bitmap;
++	u8 link_id;
++	struct ath12k_vif *ahvif;
++	struct ath12k_rekey_data rekey_data;
++	struct ath12k_link_stats link_stats;
++	spinlock_t link_stats_lock; /* Protects updates to link_stats */
++
++	u8 current_cntdown_counter;
++
++	/* only used in station mode */
++	bool is_sta_assoc_link;
++
++	struct ath12k_reg_tpc_power_info reg_tpc_info;
++
++	bool group_key_valid;
++	struct wmi_vdev_install_key_arg group_key;
++	bool pairwise_key_done;
++	u16 num_stations;
++	bool is_csa_in_progress;
++	struct wiphy_work bcn_tx_work;
++};
++
++struct ath12k_vif {
++	struct ath12k_dp_vif dp_vif;
++
++	enum wmi_vdev_type vdev_type;
++	enum wmi_vdev_subtype vdev_subtype;
++	struct ieee80211_vif *vif;
++	struct ath12k_hw *ah;
++
++	union {
++		struct {
++			u32 uapsd;
++		} sta;
++		struct {
++			/* 127 stations; wmi limit */
++			u8 tim_bitmap[16];
++			u8 tim_len;
++			u32 ssid_len;
++			u8 ssid[IEEE80211_MAX_SSID_LEN];
++			bool hidden_ssid;
++			/* P2P_IE with NoA attribute for P2P_GO case */
++			u32 noa_len;
++			u8 *noa_data;
++		} ap;
++	} u;
++
++	u32 aid;
++	bool ps;
++
++	struct ath12k_link_vif deflink;
++	struct ath12k_link_vif __rcu *link[ATH12K_NUM_MAX_LINKS];
++	struct ath12k_vif_cache *cache[IEEE80211_MLD_MAX_NUM_LINKS];
++	/* indicates bitmap of link vif created in FW */
++	u32 links_map;
++	/* Must be last - ends in a flexible-array member.
++	 *
++	 * FIXME: Driver should not copy struct ieee80211_chanctx_conf,
++	 * especially because it has a flexible array. Find a better way.
++	 */
++	struct ieee80211_chanctx_conf chanctx;
++};
++
++struct ath12k_vif_iter {
++	u32 vdev_id;
++	struct ath12k *ar;
++	struct ath12k_link_vif *arvif;
++};
++
++#define ATH12K_SCAN_TIMEOUT_HZ (20 * HZ)
++
++#define ATH12K_HE_MCS_NUM       12
++#define ATH12K_VHT_MCS_NUM      10
++#define ATH12K_BW_NUM           5
++#define ATH12K_NSS_NUM          4
++#define ATH12K_LEGACY_NUM       12
++#define ATH12K_GI_NUM           4
++#define ATH12K_HT_MCS_NUM       32
++
++enum ath12k_pkt_rx_err {
++	ATH12K_PKT_RX_ERR_FCS,
++	ATH12K_PKT_RX_ERR_TKIP,
++	ATH12K_PKT_RX_ERR_CRYPT,
++	ATH12K_PKT_RX_ERR_PEER_IDX_INVAL,
++	ATH12K_PKT_RX_ERR_MAX,
++};
++
++enum ath12k_ampdu_subfrm_num {
++	ATH12K_AMPDU_SUBFRM_NUM_10,
++	ATH12K_AMPDU_SUBFRM_NUM_20,
++	ATH12K_AMPDU_SUBFRM_NUM_30,
++	ATH12K_AMPDU_SUBFRM_NUM_40,
++	ATH12K_AMPDU_SUBFRM_NUM_50,
++	ATH12K_AMPDU_SUBFRM_NUM_60,
++	ATH12K_AMPDU_SUBFRM_NUM_MORE,
++	ATH12K_AMPDU_SUBFRM_NUM_MAX,
++};
++
++enum ath12k_amsdu_subfrm_num {
++	ATH12K_AMSDU_SUBFRM_NUM_1,
++	ATH12K_AMSDU_SUBFRM_NUM_2,
++	ATH12K_AMSDU_SUBFRM_NUM_3,
++	ATH12K_AMSDU_SUBFRM_NUM_4,
++	ATH12K_AMSDU_SUBFRM_NUM_MORE,
++	ATH12K_AMSDU_SUBFRM_NUM_MAX,
++};
++
++enum ath12k_counter_type {
++	ATH12K_COUNTER_TYPE_BYTES,
++	ATH12K_COUNTER_TYPE_PKTS,
++	ATH12K_COUNTER_TYPE_MAX,
++};
++
++enum ath12k_stats_type {
++	ATH12K_STATS_TYPE_SUCC,
++	ATH12K_STATS_TYPE_FAIL,
++	ATH12K_STATS_TYPE_RETRY,
++	ATH12K_STATS_TYPE_AMPDU,
++	ATH12K_STATS_TYPE_MAX,
++};
++
++struct ath12k_htt_data_stats {
++	u64 legacy[ATH12K_COUNTER_TYPE_MAX][ATH12K_LEGACY_NUM];
++	u64 ht[ATH12K_COUNTER_TYPE_MAX][ATH12K_HT_MCS_NUM];
++	u64 vht[ATH12K_COUNTER_TYPE_MAX][ATH12K_VHT_MCS_NUM];
++	u64 he[ATH12K_COUNTER_TYPE_MAX][ATH12K_HE_MCS_NUM];
++	u64 bw[ATH12K_COUNTER_TYPE_MAX][ATH12K_BW_NUM];
++	u64 nss[ATH12K_COUNTER_TYPE_MAX][ATH12K_NSS_NUM];
++	u64 gi[ATH12K_COUNTER_TYPE_MAX][ATH12K_GI_NUM];
++	u64 transmit_type[ATH12K_COUNTER_TYPE_MAX][HAL_RX_RECEPTION_TYPE_MAX];
++	u64 ru_loc[ATH12K_COUNTER_TYPE_MAX][HAL_RX_RU_ALLOC_TYPE_MAX];
++};
++
++struct ath12k_htt_tx_stats {
++	struct ath12k_htt_data_stats stats[ATH12K_STATS_TYPE_MAX];
++	u64 tx_duration;
++	u64 ba_fails;
++	u64 ack_fails;
++	u16 ru_start;
++	u16 ru_tones;
++	u32 mu_group[MAX_MU_GROUP_ID];
++};
++
++struct ath12k_per_ppdu_tx_stats {
++	u16 succ_pkts;
++	u16 failed_pkts;
++	u16 retry_pkts;
++	u32 succ_bytes;
++	u32 failed_bytes;
++	u32 retry_bytes;
++};
++
++struct ath12k_link_sta {
++	struct ath12k_link_vif *arvif;
++	struct ath12k_sta *ahsta;
++
++	/* link address similar to ieee80211_link_sta */
++	u8 addr[ETH_ALEN];
++
++	/* the following are protected by ar->data_lock */
++	u32 changed; /* IEEE80211_RC_* */
++	u32 bw;
++	u32 nss;
++	u32 smps;
++
++	struct wiphy_work update_wk;
++	u8 link_id;
++	u32 bw_prev;
++	u32 peer_nss;
++	s8 rssi_beacon;
++	s8 chain_signal[IEEE80211_MAX_CHAINS];
++
++	/* For now the assoc link will be considered primary */
++	bool is_assoc_link;
++
++	 /* for firmware use only */
++	u8 link_idx;
++
++	/* peer addr based rhashtable list pointer */
++	struct rhash_head rhash_addr;
++};
++
++struct ath12k_sta {
++	struct ath12k_vif *ahvif;
++	enum hal_pn_type pn_type;
++	struct ath12k_link_sta deflink;
++	struct ath12k_link_sta __rcu *link[IEEE80211_MLD_MAX_NUM_LINKS];
++	/* indicates bitmap of link sta created in FW */
++	u16 links_map;
++	u8 assoc_link_id;
++	u16 ml_peer_id;
++	u16 free_logical_link_idx_map;
++
++	enum ieee80211_sta_state state;
++};
++
++#define ATH12K_HALF_20MHZ_BW	10
++#define ATH12K_2GHZ_MIN_CENTER	2412
++#define ATH12K_2GHZ_MAX_CENTER	2484
++#define ATH12K_5GHZ_MIN_CENTER	4900
++#define ATH12K_5GHZ_MAX_CENTER	5920
++#define ATH12K_6GHZ_MIN_CENTER	5935
++#define ATH12K_6GHZ_MAX_CENTER	7115
++#define ATH12K_MIN_2GHZ_FREQ	(ATH12K_2GHZ_MIN_CENTER - ATH12K_HALF_20MHZ_BW - 1)
++#define ATH12K_MAX_2GHZ_FREQ	(ATH12K_2GHZ_MAX_CENTER + ATH12K_HALF_20MHZ_BW + 1)
++#define ATH12K_MIN_5GHZ_FREQ	(ATH12K_5GHZ_MIN_CENTER - ATH12K_HALF_20MHZ_BW)
++#define ATH12K_MAX_5GHZ_FREQ	(ATH12K_5GHZ_MAX_CENTER + ATH12K_HALF_20MHZ_BW)
++#define ATH12K_MIN_6GHZ_FREQ	(ATH12K_6GHZ_MIN_CENTER - ATH12K_HALF_20MHZ_BW)
++#define ATH12K_MAX_6GHZ_FREQ	(ATH12K_6GHZ_MAX_CENTER + ATH12K_HALF_20MHZ_BW)
++#define ATH12K_NUM_CHANS 101
++#define ATH12K_MAX_5GHZ_CHAN 173
++
++static inline bool ath12k_is_2ghz_channel_freq(u32 freq)
++{
++	return freq >= ATH12K_MIN_2GHZ_FREQ &&
++	       freq <= ATH12K_MAX_2GHZ_FREQ;
++}
++
++enum ath12k_hw_state {
++	ATH12K_HW_STATE_OFF,
++	ATH12K_HW_STATE_ON,
++	ATH12K_HW_STATE_RESTARTING,
++	ATH12K_HW_STATE_RESTARTED,
++	ATH12K_HW_STATE_WEDGED,
++	ATH12K_HW_STATE_TM,
++	/* Add other states as required */
++};
++
++/* Antenna noise floor */
++#define ATH12K_DEFAULT_NOISE_FLOOR -95
++
++struct ath12k_ftm_event_obj {
++	u32 data_pos;
++	u32 expected_seq;
++	u8 *eventdata;
++};
++
++struct ath12k_fw_stats {
++	u32 pdev_id;
++	u32 stats_id;
++	struct list_head pdevs;
++	struct list_head vdevs;
++	struct list_head bcn;
++	u32 num_vdev_recvd;
++};
++
++struct ath12k_dbg_htt_stats {
++	enum ath12k_dbg_htt_ext_stats_type type;
++	u32 cfg_param[4];
++	u8 reset;
++	struct debug_htt_stats_req *stats_req;
++};
++
++struct ath12k_debug {
++	struct dentry *debugfs_pdev;
++	struct dentry *debugfs_pdev_symlink;
++	struct dentry *debugfs_pdev_symlink_default;
++	struct ath12k_dbg_htt_stats htt_stats;
++	enum wmi_halphy_ctrl_path_stats_id tpc_stats_type;
++	bool tpc_request;
++	struct completion tpc_complete;
++	struct wmi_tpc_stats_arg *tpc_stats;
++	u32 rx_filter;
++	bool extd_rx_stats;
++};
++
++struct ath12k_pdev_rssi_offsets {
++	s32 temp_offset;
++	s8 min_nf_dbm;
++	/* Cache the sum here to avoid calculating it every time in hot path
++	 * noise_floor = min_nf_dbm + temp_offset
++	 */
++	s32 noise_floor;
++};
++
++#define ATH12K_FLUSH_TIMEOUT (5 * HZ)
++#define ATH12K_VDEV_DELETE_TIMEOUT_HZ (5 * HZ)
++
++struct ath12k {
++	struct ath12k_base *ab;
++	struct ath12k_pdev *pdev;
++	struct ath12k_hw *ah;
++	struct ath12k_wmi_pdev *wmi;
++	struct ath12k_pdev_dp dp;
++	u8 mac_addr[ETH_ALEN];
++	u32 ht_cap_info;
++	u32 vht_cap_info;
++	struct ath12k_he ar_he;
++	bool supports_6ghz;
++	struct {
++		struct completion started;
++		struct completion completed;
++		struct completion on_channel;
++		struct delayed_work timeout;
++		enum ath12k_scan_state state;
++		bool is_roc;
++		int roc_freq;
++		bool roc_notify;
++		struct wiphy_work vdev_clean_wk;
++		struct ath12k_link_vif *arvif;
++	} scan;
++
++	struct {
++		struct ieee80211_supported_band sbands[NUM_NL80211_BANDS];
++		struct ieee80211_sband_iftype_data
++			iftype[NUM_NL80211_BANDS][NUM_NL80211_IFTYPES];
++	} mac;
++
++	unsigned long dev_flags;
++	unsigned int filter_flags;
++	u32 min_tx_power;
++	u32 max_tx_power;
++	u32 txpower_limit_2g;
++	u32 txpower_limit_5g;
++	u32 txpower_scale;
++	u32 power_scale;
++	u32 chan_tx_pwr;
++	u32 rts_threshold;
++	u32 num_stations;
++	u32 max_num_stations;
++
++	/* protects the radio specific data like debug stats, ppdu_stats_info stats,
++	 * vdev_stop_status info, scan data, ath12k_sta info, ath12k_link_vif info,
++	 * channel context data, survey info, test mode data, regd_channel_update_queue.
++	 */
++	spinlock_t data_lock;
++
++	struct list_head arvifs;
++	/* should never be NULL; needed for regular htt rx */
++	struct ieee80211_channel *rx_channel;
++
++	/* valid during scan; needed for mgmt rx during scan */
++	struct ieee80211_channel *scan_channel;
++
++	u8 cfg_tx_chainmask;
++	u8 cfg_rx_chainmask;
++	u8 num_rx_chains;
++	u8 num_tx_chains;
++	/* pdev_idx starts from 0 whereas pdev->pdev_id starts with 1 */
++	u8 pdev_idx;
++	u8 lmac_id;
++	u8 hw_link_id;
++	u8 radio_idx;
++
++	struct completion peer_assoc_done;
++	struct completion peer_delete_done;
++
++	int install_key_status;
++	struct completion install_key_done;
++
++	int last_wmi_vdev_start_status;
++	struct completion vdev_setup_done;
++	struct completion vdev_delete_done;
++
++	int num_peers;
++	int max_num_peers;
++	u32 num_started_vdevs;
++	u32 num_created_vdevs;
++	unsigned long long allocated_vdev_map;
++
++	struct idr txmgmt_idr;
++	/* protects txmgmt_idr data */
++	spinlock_t txmgmt_idr_lock;
++	atomic_t num_pending_mgmt_tx;
++	wait_queue_head_t txmgmt_empty_waitq;
++
++	/* cycle count is reported twice for each visited channel during scan.
++	 * access protected by data_lock
++	 */
++	u32 survey_last_rx_clear_count;
++	u32 survey_last_cycle_count;
++
++	/* Channel info events are expected to come in pairs without and with
++	 * COMPLETE flag set respectively for each channel visit during scan.
++	 *
++	 * However there are deviations from this rule. This flag is used to
++	 * avoid reporting garbage data.
++	 */
++	bool ch_info_can_report_survey;
++	struct survey_info survey[ATH12K_NUM_CHANS];
++	struct completion bss_survey_done;
++
++	struct work_struct regd_update_work;
++	struct work_struct regd_channel_update_work;
++	struct list_head regd_channel_update_queue;
++
++	struct wiphy_work wmi_mgmt_tx_work;
++	struct sk_buff_head wmi_mgmt_tx_queue;
++
++	struct ath12k_wow wow;
++	struct completion target_suspend;
++	bool target_suspend_ack;
++
++	struct ath12k_per_peer_tx_stats cached_stats;
++	u32 last_ppdu_id;
++	u32 cached_ppdu_id;
++#ifdef CONFIG_ATH12K_DEBUGFS
++	struct ath12k_debug debug;
++#endif
++
++	bool dfs_block_radar_events;
++	bool monitor_vdev_created;
++	bool monitor_started;
++	int monitor_vdev_id;
++
++	struct wiphy_radio_freq_range freq_range;
++
++	bool nlo_enabled;
++
++	/* Protected by wiphy::mtx lock. */
++	u32 vdev_id_11d_scan;
++	struct completion completed_11d_scan;
++	enum ath12k_11d_state state_11d;
++	u8 alpha2[REG_ALPHA2_LEN];
++	bool regdom_set_by_user;
++	struct completion regd_update_completed;
++
++	struct completion fw_stats_complete;
++	struct completion fw_stats_done;
++
++	struct completion mlo_setup_done;
++	u32 mlo_setup_status;
++	u8 ftm_msgref;
++	struct ath12k_fw_stats fw_stats;
++	unsigned long last_tx_power_update;
++
++	s8 max_allowed_tx_power;
++	struct ath12k_pdev_rssi_offsets rssi_info;
++
++	struct ath12k_thermal thermal;
++};
++
++struct ath12k_hw {
++	struct ieee80211_hw *hw;
++	struct device *dev;
++
++	/* Protect the write operation of the hardware state ath12k_hw::state
++	 * between hardware start<=>reconfigure<=>stop transitions.
++	 */
++	struct mutex hw_mutex;
++	enum ath12k_hw_state state;
++	bool regd_updated;
++	bool use_6ghz_regd;
++
++	u8 num_radio;
++
++	DECLARE_BITMAP(free_ml_peer_id_map, ATH12K_MAX_MLO_PEERS);
++
++	struct ath12k_dp_hw dp_hw;
++
++	/* Keep last */
++	struct ath12k radio[] __aligned(sizeof(void *));
++};
++
++struct ath12k_band_cap {
++	u32 phy_id;
++	u32 max_bw_supported;
++	u32 ht_cap_info;
++	u32 he_cap_info[2];
++	u32 he_mcs;
++	u32 he_cap_phy_info[PSOC_HOST_MAX_PHY_SIZE];
++	struct ath12k_wmi_ppe_threshold_arg he_ppet;
++	u16 he_6ghz_capa;
++	u32 eht_cap_mac_info[WMI_MAX_EHTCAP_MAC_SIZE];
++	u32 eht_cap_phy_info[WMI_MAX_EHTCAP_PHY_SIZE];
++	u32 eht_mcs_20_only;
++	u32 eht_mcs_80;
++	u32 eht_mcs_160;
++	u32 eht_mcs_320;
++	struct ath12k_wmi_ppe_threshold_arg eht_ppet;
++	u32 eht_cap_info_internal;
++};
++
++struct ath12k_pdev_cap {
++	u32 supported_bands;
++	u32 ampdu_density;
++	u32 vht_cap;
++	u32 vht_mcs;
++	u32 he_mcs;
++	u32 tx_chain_mask;
++	u32 rx_chain_mask;
++	u32 tx_chain_mask_shift;
++	u32 rx_chain_mask_shift;
++	struct ath12k_band_cap band[NUM_NL80211_BANDS];
++	u32 eml_cap;
++	u32 mld_cap;
++	bool nss_ratio_enabled;
++	u8 nss_ratio_info;
++};
++
++struct mlo_timestamp {
++	u32 info;
++	u32 sync_timestamp_lo_us;
++	u32 sync_timestamp_hi_us;
++	u32 mlo_offset_lo;
++	u32 mlo_offset_hi;
++	u32 mlo_offset_clks;
++	u32 mlo_comp_clks;
++	u32 mlo_comp_timer;
++};
++
++struct ath12k_pdev {
++	struct ath12k *ar;
++	u32 pdev_id;
++	u32 hw_link_id;
++	struct ath12k_pdev_cap cap;
++	u8 mac_addr[ETH_ALEN];
++	struct mlo_timestamp timestamp;
++};
++
++struct ath12k_fw_pdev {
++	u32 pdev_id;
++	u32 phy_id;
++	u32 supported_bands;
++};
++
++struct ath12k_board_data {
++	const struct firmware *fw;
++	const void *data;
++	size_t len;
++};
++
++struct ath12k_reg_freq {
++	u32 start_freq;
++	u32 end_freq;
++};
++
++struct ath12k_mlo_memory {
++	struct target_mem_chunk chunk[ATH12K_QMI_WLANFW_MAX_NUM_MEM_SEG_V01];
++	int mlo_mem_size;
++	bool init_done;
++};
++
++struct ath12k_hw_link {
++	u8 device_id;
++	u8 pdev_idx;
++};
++
++/* Holds info on the group of devices that are registered as a single
++ * wiphy, protected with struct ath12k_hw_group::mutex.
++ */
++struct ath12k_hw_group {
++	/* Keep dp_hw_grp as the first member to allow efficient
++	 * usage of cache lines for DP fields
++	 */
++	struct ath12k_dp_hw_group dp_hw_grp;
++	struct ath12k_hw_link hw_links[ATH12K_GROUP_MAX_RADIO];
++	struct list_head list;
++	u8 id;
++	u8 num_devices;
++	u8 num_probed;
++	u8 num_started;
++	unsigned long flags;
++	struct ath12k_base *ab[ATH12K_MAX_DEVICES];
++
++	/* protects access to this struct */
++	struct mutex mutex;
++
++	/* Holds information of wiphy (hw) registration.
++	 *
++	 * In Multi/Single Link Operation case, all pdevs are registered as
++	 * a single wiphy. In other (legacy/Non-MLO) cases, each pdev is
++	 * registered as separate wiphys.
++	 */
++	struct ath12k_hw *ah[ATH12K_GROUP_MAX_RADIO];
++	u8 num_hw;
++	bool mlo_capable;
++	struct device_node *wsi_node[ATH12K_MAX_DEVICES];
++	struct ath12k_mlo_memory mlo_mem;
++	bool hw_link_id_init_done;
++};
++
++/* Holds WSI info specific to each device, excluding WSI group info */
++struct ath12k_wsi_info {
++	u32 index;
++	u32 hw_link_id_base;
++};
++
++struct ath12k_dp_profile_params {
++	u32 tx_comp_ring_size;
++	u32 rxdma_monitor_buf_ring_size;
++	u32 rxdma_monitor_dst_ring_size;
++	u32 num_pool_tx_desc;
++	u32 rx_desc_count;
++};
++
++struct ath12k_mem_profile_based_param {
++	u32 num_vdevs;
++	u32 max_client_single;
++	u32 max_client_dbs;
++	u32 max_client_dbs_sbs;
++	struct ath12k_dp_profile_params dp_params;
++};
++
++enum ath12k_device_family {
++	ATH12K_DEVICE_FAMILY_START,
++	ATH12K_DEVICE_FAMILY_WIFI7 = ATH12K_DEVICE_FAMILY_START,
++	ATH12K_DEVICE_FAMILY_MAX,
++};
++
++/* Master structure to hold the hw data which may be used in core module */
++struct ath12k_base {
++	enum ath12k_hw_rev hw_rev;
++	struct platform_device *pdev;
++	struct device *dev;
++	struct ath12k_qmi qmi;
++	struct ath12k_wmi_base wmi_ab;
++	struct completion fw_ready;
++	u8 device_id;
++	int num_radios;
++	/* HW channel counters frequency value in hertz common to all MACs */
++	u32 cc_freq_hz;
++
++	struct ath12k_dump_file_data *dump_data;
++	size_t ath12k_coredump_len;
++	struct work_struct dump_work;
++
++	struct ath12k_htc htc;
++
++	struct ath12k_dp *dp;
++
++	void __iomem *mem;
++	unsigned long mem_len;
++
++	void __iomem *mem_ce;
++	u32 ce_remap_base_addr;
++	u32 cmem_offset;
++	bool ce_remap;
++
++	struct {
++		enum ath12k_bus bus;
++		const struct ath12k_hif_ops *ops;
++	} hif;
++
++	struct {
++		struct completion wakeup_completed;
++		u32 wmi_conf_rx_decap_mode;
++	} wow;
++
++	struct ath12k_ce ce;
++	struct timer_list rx_replenish_retry;
++	struct ath12k_hal hal;
++	/* To synchronize core_start/core_stop */
++	struct mutex core_lock;
++	/* Protects data like peers */
++	spinlock_t base_lock;
++
++	/* Single pdev device (struct ath12k_hw_params::single_pdev_only):
++	 *
++	 * Firmware maintains data for all bands but advertises a single
++	 * phy to the host which is stored as a single element in this
++	 * array.
++	 *
++	 * Other devices:
++	 *
++	 * This array will contain as many elements as the number of
++	 * radios.
++	 */
++	struct ath12k_pdev pdevs[MAX_RADIOS];
++
++	/* struct ath12k_hw_params::single_pdev_only devices use this to
++	 * store phy specific data
++	 */
++	struct ath12k_fw_pdev fw_pdev[MAX_RADIOS];
++	u8 fw_pdev_count;
++
++	struct ath12k_pdev __rcu *pdevs_active[MAX_RADIOS];
++
++	struct ath12k_wmi_hal_reg_capabilities_ext_arg hal_reg_cap[MAX_RADIOS];
++	unsigned long long free_vdev_map;
++	unsigned long long free_vdev_stats_id_map;
++	wait_queue_head_t peer_mapping_wq;
++	u8 mac_addr[ETH_ALEN];
++	bool wmi_ready;
++	u32 wlan_init_status;
++	int irq_num[ATH12K_IRQ_NUM_MAX];
++	struct ath12k_ext_irq_grp ext_irq_grp[ATH12K_EXT_IRQ_GRP_NUM_MAX];
++	struct napi_struct *napi;
++	struct ath12k_wmi_target_cap_arg target_caps;
++	u32 ext_service_bitmap[WMI_SERVICE_EXT_BM_SIZE];
++	bool pdevs_macaddr_valid;
++
++	const struct ath12k_hw_params *hw_params;
++
++	const struct firmware *cal_file;
++
++	/* Below regd's are protected by ab->data_lock */
++	/* This is the regd set for every radio
++	 * by the firmware during initialization
++	 */
++	struct ieee80211_regdomain *default_regd[MAX_RADIOS];
++	/* This regd is set during dynamic country setting
++	 * This may or may not be used during the runtime
++	 */
++	struct ieee80211_regdomain *new_regd[MAX_RADIOS];
++
++	struct ath12k_reg_info *reg_info[MAX_RADIOS];
++
++	/* Current DFS Regulatory */
++	enum ath12k_dfs_region dfs_region;
++#ifdef CONFIG_ATH12K_DEBUGFS
++	struct dentry *debugfs_soc;
++#endif
++
++	unsigned long dev_flags;
++	struct completion driver_recovery;
++	struct workqueue_struct *workqueue;
++	struct work_struct restart_work;
++	struct workqueue_struct *workqueue_aux;
++	struct work_struct reset_work;
++	atomic_t reset_count;
++	atomic_t recovery_count;
++	bool is_reset;
++	struct completion reset_complete;
++	/* continuous recovery fail count */
++	atomic_t fail_cont_count;
++	unsigned long reset_fail_timeout;
++	struct work_struct update_11d_work;
++	u8 new_alpha2[2];
++	struct {
++		/* protected by data_lock */
++		u32 fw_crash_counter;
++	} stats;
++	u32 pktlog_defs_checksum;
++
++	struct ath12k_dbring_cap *db_caps;
++	u32 num_db_cap;
++
++	struct completion htc_suspend;
++
++	u64 fw_soc_drop_count;
++	bool static_window_map;
++
++	struct work_struct rfkill_work;
++	/* true means radio is on */
++	bool rfkill_radio_on;
++
++	struct {
++		enum ath12k_bdf_search bdf_search;
++		u32 vendor;
++		u32 device;
++		u32 subsystem_vendor;
++		u32 subsystem_device;
++	} id;
++
++	struct {
++		u32 api_version;
++
++		const struct firmware *fw;
++		const u8 *amss_data;
++		size_t amss_len;
++		const u8 *amss_dualmac_data;
++		size_t amss_dualmac_len;
++		const u8 *m3_data;
++		size_t m3_len;
++		const u8 *aux_uc_data;
++		size_t aux_uc_len;
++
++		DECLARE_BITMAP(fw_features, ATH12K_FW_FEATURE_COUNT);
++		bool fw_features_valid;
++	} fw;
++
++	struct completion restart_completed;
++
++#ifdef CONFIG_ACPI
++
++	struct {
++		bool started;
++		u32 func_bit;
++		bool acpi_tas_enable;
++		bool acpi_bios_sar_enable;
++		bool acpi_disable_11be;
++		bool acpi_disable_rfkill;
++		bool acpi_cca_enable;
++		bool acpi_band_edge_enable;
++		bool acpi_enable_bdf;
++		u32 bit_flag;
++		char bdf_string[ATH12K_ACPI_BDF_MAX_LEN];
++		u8 tas_cfg[ATH12K_ACPI_DSM_TAS_CFG_SIZE];
++		u8 tas_sar_power_table[ATH12K_ACPI_DSM_TAS_DATA_SIZE];
++		u8 bios_sar_data[ATH12K_ACPI_DSM_BIOS_SAR_DATA_SIZE];
++		u8 geo_offset_data[ATH12K_ACPI_DSM_GEO_OFFSET_DATA_SIZE];
++		u8 cca_data[ATH12K_ACPI_DSM_CCA_DATA_SIZE];
++		u8 band_edge_power[ATH12K_ACPI_DSM_BAND_EDGE_DATA_SIZE];
++	} acpi;
++
++#endif /* CONFIG_ACPI */
++
++	struct notifier_block panic_nb;
++
++	struct ath12k_hw_group *ag;
++	struct ath12k_wsi_info wsi_info;
++	enum ath12k_firmware_mode fw_mode;
++	struct ath12k_ftm_event_obj ftm_event_obj;
++	bool hw_group_ref;
++
++	/* Denote whether MLO is possible within the device */
++	bool single_chip_mlo_support;
++
++	struct ath12k_reg_freq reg_freq_2ghz;
++	struct ath12k_reg_freq reg_freq_5ghz;
++	struct ath12k_reg_freq reg_freq_6ghz;
++	const struct ath12k_mem_profile_based_param *profile_param;
++	enum ath12k_qmi_mem_mode target_mem_mode;
++
++	/* FIXME: Define this field in a ag equivalent object available
++	 * during the initial phase of probe later.
++	 */
++	const struct ieee80211_ops *ath12k_ops;
++
++	struct rhashtable *rhead_sta_addr;
++	struct rhashtable_params rhash_sta_addr_param;
++
++	/* must be last */
++	u8 drv_priv[] __aligned(sizeof(void *));
++};
++
++struct ath12k_pdev_map {
++	struct ath12k_base *ab;
++	u8 pdev_idx;
++};
++
++struct ath12k_fw_stats_vdev {
++	struct list_head list;
++
++	u32 vdev_id;
++	u32 beacon_snr;
++	u32 data_snr;
++	u32 num_tx_frames[WLAN_MAX_AC];
++	u32 num_rx_frames;
++	u32 num_tx_frames_retries[WLAN_MAX_AC];
++	u32 num_tx_frames_failures[WLAN_MAX_AC];
++	u32 num_rts_fail;
++	u32 num_rts_success;
++	u32 num_rx_err;
++	u32 num_rx_discard;
++	u32 num_tx_not_acked;
++	u32 tx_rate_history[MAX_TX_RATE_VALUES];
++	u32 beacon_rssi_history[MAX_TX_RATE_VALUES];
++};
++
++struct ath12k_fw_stats_bcn {
++	struct list_head list;
++
++	u32 vdev_id;
++	u32 tx_bcn_succ_cnt;
++	u32 tx_bcn_outage_cnt;
++};
++
++struct ath12k_fw_stats_pdev {
++	struct list_head list;
++
++	/* PDEV stats */
++	s32 ch_noise_floor;
++	u32 tx_frame_count;
++	u32 rx_frame_count;
++	u32 rx_clear_count;
++	u32 cycle_count;
++	u32 phy_err_count;
++	u32 chan_tx_power;
++	u32 ack_rx_bad;
++	u32 rts_bad;
++	u32 rts_good;
++	u32 fcs_bad;
++	u32 no_beacons;
++	u32 mib_int_count;
++
++	/* PDEV TX stats */
++	s32 comp_queued;
++	s32 comp_delivered;
++	s32 msdu_enqued;
++	s32 mpdu_enqued;
++	s32 wmm_drop;
++	s32 local_enqued;
++	s32 local_freed;
++	s32 hw_queued;
++	s32 hw_reaped;
++	s32 underrun;
++	s32 tx_abort;
++	s32 mpdus_requed;
++	u32 tx_ko;
++	u32 data_rc;
++	u32 self_triggers;
++	u32 sw_retry_failure;
++	u32 illgl_rate_phy_err;
++	u32 pdev_cont_xretry;
++	u32 pdev_tx_timeout;
++	u32 pdev_resets;
++	u32 stateless_tid_alloc_failure;
++	u32 phy_underrun;
++	u32 txop_ovf;
++
++	/* PDEV RX stats */
++	s32 mid_ppdu_route_change;
++	s32 status_rcvd;
++	s32 r0_frags;
++	s32 r1_frags;
++	s32 r2_frags;
++	s32 r3_frags;
++	s32 htt_msdus;
++	s32 htt_mpdus;
++	s32 loc_msdus;
++	s32 loc_mpdus;
++	s32 oversize_amsdu;
++	s32 phy_errs;
++	s32 phy_err_drop;
++	s32 mpdu_errs;
++};
++
++int ath12k_core_qmi_firmware_ready(struct ath12k_base *ab);
++void ath12k_core_hw_group_cleanup(struct ath12k_hw_group *ag);
++int ath12k_core_pre_init(struct ath12k_base *ab);
++int ath12k_core_init(struct ath12k_base *ath12k);
++void ath12k_core_deinit(struct ath12k_base *ath12k);
++struct ath12k_base *ath12k_core_alloc(struct device *dev, size_t priv_size,
++				      enum ath12k_bus bus);
++void ath12k_core_free(struct ath12k_base *ath12k);
++int ath12k_core_fetch_board_data_api_1(struct ath12k_base *ab,
++				       struct ath12k_board_data *bd,
++				       char *filename);
++int ath12k_core_fetch_bdf(struct ath12k_base *ath12k,
++			  struct ath12k_board_data *bd);
++void ath12k_core_free_bdf(struct ath12k_base *ab, struct ath12k_board_data *bd);
++int ath12k_core_fetch_regdb(struct ath12k_base *ab, struct ath12k_board_data *bd);
++int ath12k_core_check_dt(struct ath12k_base *ath12k);
++int ath12k_core_check_smbios(struct ath12k_base *ab);
++void ath12k_core_halt(struct ath12k *ar);
++int ath12k_core_resume_early(struct ath12k_base *ab);
++int ath12k_core_resume(struct ath12k_base *ab);
++int ath12k_core_suspend(struct ath12k_base *ab);
++int ath12k_core_suspend_late(struct ath12k_base *ab);
++void ath12k_core_hw_group_unassign(struct ath12k_base *ab);
++u8 ath12k_get_num_partner_link(struct ath12k *ar);
++
++const struct firmware *ath12k_core_firmware_request(struct ath12k_base *ab,
++						    const char *filename);
++u32 ath12k_core_get_max_station_per_radio(struct ath12k_base *ab);
++u32 ath12k_core_get_max_peers_per_radio(struct ath12k_base *ab);
++
++void ath12k_core_hw_group_set_mlo_capable(struct ath12k_hw_group *ag);
++void ath12k_fw_stats_init(struct ath12k *ar);
++void ath12k_fw_stats_bcn_free(struct list_head *head);
++void ath12k_fw_stats_free(struct ath12k_fw_stats *stats);
++void ath12k_fw_stats_reset(struct ath12k *ar);
++struct reserved_mem *ath12k_core_get_reserved_mem(struct ath12k_base *ab,
++						  int index);
++enum ath12k_qmi_mem_mode ath12k_core_get_memory_mode(struct ath12k_base *ab);
++
++static inline const char *ath12k_scan_state_str(enum ath12k_scan_state state)
++{
++	switch (state) {
++	case ATH12K_SCAN_IDLE:
++		return "idle";
++	case ATH12K_SCAN_STARTING:
++		return "starting";
++	case ATH12K_SCAN_RUNNING:
++		return "running";
++	case ATH12K_SCAN_ABORTING:
++		return "aborting";
++	}
++
++	return "unknown";
++}
++
++static inline struct ath12k_skb_cb *ATH12K_SKB_CB(struct sk_buff *skb)
++{
++	BUILD_BUG_ON(sizeof(struct ath12k_skb_cb) >
++		     IEEE80211_TX_INFO_DRIVER_DATA_SIZE);
++	return (struct ath12k_skb_cb *)&IEEE80211_SKB_CB(skb)->driver_data;
++}
++
++static inline struct ath12k_skb_rxcb *ATH12K_SKB_RXCB(struct sk_buff *skb)
++{
++	BUILD_BUG_ON(sizeof(struct ath12k_skb_rxcb) > sizeof(skb->cb));
++	return (struct ath12k_skb_rxcb *)skb->cb;
++}
++
++static inline struct ath12k_vif *ath12k_vif_to_ahvif(struct ieee80211_vif *vif)
++{
++	return (struct ath12k_vif *)vif->drv_priv;
++}
++
++static inline struct ath12k_sta *ath12k_sta_to_ahsta(struct ieee80211_sta *sta)
++{
++	return (struct ath12k_sta *)sta->drv_priv;
++}
++
++static inline struct ieee80211_sta *ath12k_ahsta_to_sta(struct ath12k_sta *ahsta)
++{
++	return container_of((void *)ahsta, struct ieee80211_sta, drv_priv);
++}
++
++static inline struct ieee80211_vif *ath12k_ahvif_to_vif(struct ath12k_vif *ahvif)
++{
++	return container_of((void *)ahvif, struct ieee80211_vif, drv_priv);
++}
++
++static inline struct ath12k *ath12k_ab_to_ar(struct ath12k_base *ab,
++					     int mac_id)
++{
++	return ab->pdevs[ath12k_hw_mac_id_to_pdev_id(ab->hw_params, mac_id)].ar;
++}
++
++static inline void ath12k_core_create_firmware_path(struct ath12k_base *ab,
++						    const char *filename,
++						    void *buf, size_t buf_len)
++{
++	const char *fw_name = NULL;
++
++	of_property_read_string(ab->dev->of_node, "firmware-name", &fw_name);
++
++	if (fw_name && strncmp(filename, "board", 5))
++		snprintf(buf, buf_len, "%s/%s/%s/%s", ATH12K_FW_DIR,
++			 ab->hw_params->fw.dir, fw_name, filename);
++	else
++		snprintf(buf, buf_len, "%s/%s/%s", ATH12K_FW_DIR,
++			 ab->hw_params->fw.dir, filename);
++}
++
++static inline const char *ath12k_bus_str(enum ath12k_bus bus)
++{
++	switch (bus) {
++	case ATH12K_BUS_PCI:
++		return "pci";
++	case ATH12K_BUS_AHB:
++		return "ahb";
++	}
++
++	return "unknown";
++}
++
++static inline struct ath12k_hw *ath12k_hw_to_ah(struct ieee80211_hw  *hw)
++{
++	return hw->priv;
++}
++
++static inline struct ath12k *ath12k_ah_to_ar(struct ath12k_hw *ah, u8 radio_idx)
++{
++	if (WARN(radio_idx >= ah->num_radio,
++		 "bad radio index %d, use default radio\n", radio_idx))
++		radio_idx = 0;
++
++	return &ah->radio[radio_idx];
++}
++
++static inline struct ath12k_hw *ath12k_ar_to_ah(struct ath12k *ar)
++{
++	return ar->ah;
++}
++
++static inline struct ieee80211_hw *ath12k_ar_to_hw(struct ath12k *ar)
++{
++	return ar->ah->hw;
++}
++
++#define for_each_ar(ah, ar, index) \
++	for ((index) = 0; ((index) < (ah)->num_radio && \
++	     ((ar) = &(ah)->radio[(index)])); (index)++)
++
++static inline struct ath12k_hw *ath12k_ag_to_ah(struct ath12k_hw_group *ag, int idx)
++{
++	return ag->ah[idx];
++}
++
++static inline void ath12k_ag_set_ah(struct ath12k_hw_group *ag, int idx,
++				    struct ath12k_hw *ah)
++{
++	ag->ah[idx] = ah;
++}
++
++static inline struct ath12k_hw_group *ath12k_ab_to_ag(struct ath12k_base *ab)
++{
++	return ab->ag;
++}
++
++static inline struct ath12k_base *ath12k_ag_to_ab(struct ath12k_hw_group *ag,
++						  u8 device_id)
++{
++	return ag->ab[device_id];
++}
++
++static inline s32 ath12k_pdev_get_noise_floor(struct ath12k *ar)
++{
++	lockdep_assert_held(&ar->data_lock);
++
++	return ar->rssi_info.noise_floor;
++}
++
++/* The @ab->dp NULL check or assertion is intentionally omitted because
++ * @ab->dp is guaranteed to be non-NULL after a successful probe and
++ * remains valid until teardown. Invoking this before allocation or
++ * after teardown is considered invalid usage.
++ */
++static inline struct ath12k_dp *ath12k_ab_to_dp(struct ath12k_base *ab)
++{
++	return ab->dp;
++}
++
++static inline struct ath12k *ath12k_pdev_dp_to_ar(struct ath12k_pdev_dp *dp)
++{
++	return container_of(dp, struct ath12k, dp);
++}
++#endif /* _CORE_H_ */
+diff --git a/drivers/net/wireless/ath/ath12k/hw.h.orig b/drivers/net/wireless/ath/ath12k/hw.h.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/net/wireless/ath/ath12k/hw.h.orig
+@@ -0,0 +1,308 @@
++/* SPDX-License-Identifier: BSD-3-Clause-Clear */
++/*
++ * Copyright (c) 2018-2021 The Linux Foundation. All rights reserved.
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
++
++#ifndef ATH12K_HW_H
++#define ATH12K_HW_H
++
++#include <linux/mhi.h>
++#include <linux/uuid.h>
++
++#include "wmi.h"
++#include "hal.h"
++
++struct ath12k_dp_peer;
++struct ath12k_skb_rxcb;
++struct ieee80211_rx_status;
++
++/* Target configuration defines */
++
++/* Num VDEVS per radio */
++#define TARGET_NUM_VDEVS(ab)    ((ab)->profile_param->num_vdevs)
++
++/* Max num of stations for Single Radio mode */
++#define TARGET_NUM_STATIONS_SINGLE(ab) ((ab)->profile_param->max_client_single)
++
++/* Max num of stations for DBS */
++#define TARGET_NUM_STATIONS_DBS(ab)    ((ab)->profile_param->max_client_dbs)
++
++/* Max num of stations for DBS_SBS */
++#define TARGET_NUM_STATIONS_DBS_SBS(ab) \
++	((ab)->profile_param->max_client_dbs_sbs)
++
++#define TARGET_NUM_STATIONS(ab, x)     TARGET_NUM_STATIONS_##x(ab)
++
++#define TARGET_NUM_PEER_KEYS	2
++
++#define TARGET_AST_SKID_LIMIT	16
++#define TARGET_NUM_OFFLD_PEERS	4
++#define TARGET_NUM_OFFLD_REORDER_BUFFS 4
++
++#define TARGET_TX_CHAIN_MASK	(BIT(0) | BIT(1) | BIT(2) | BIT(4))
++#define TARGET_RX_CHAIN_MASK	(BIT(0) | BIT(1) | BIT(2) | BIT(4))
++#define TARGET_RX_TIMEOUT_LO_PRI	100
++#define TARGET_RX_TIMEOUT_HI_PRI	40
++
++#define TARGET_DECAP_MODE_RAW		0
++#define TARGET_DECAP_MODE_NATIVE_WIFI	1
++#define TARGET_DECAP_MODE_ETH		2
++
++#define TARGET_SCAN_MAX_PENDING_REQS	4
++#define TARGET_BMISS_OFFLOAD_MAX_VDEV	3
++#define TARGET_ROAM_OFFLOAD_MAX_VDEV	3
++#define TARGET_ROAM_OFFLOAD_MAX_AP_PROFILES	8
++#define TARGET_GTK_OFFLOAD_MAX_VDEV	3
++#define TARGET_NUM_MCAST_GROUPS		12
++#define TARGET_NUM_MCAST_TABLE_ELEMS	64
++#define TARGET_MCAST2UCAST_MODE		2
++#define TARGET_TX_DBG_LOG_SIZE		1024
++#define TARGET_RX_SKIP_DEFRAG_TIMEOUT_DUP_DETECTION_CHECK 1
++#define TARGET_VOW_CONFIG		0
++#define TARGET_NUM_MSDU_DESC		(2500)
++#define TARGET_MAX_FRAG_ENTRIES		6
++#define TARGET_MAX_BCN_OFFLD		16
++#define TARGET_NUM_WDS_ENTRIES		32
++#define TARGET_DMA_BURST_SIZE		1
++#define TARGET_RX_BATCHMODE		1
++#define TARGET_EMA_MAX_PROFILE_PERIOD	8
++
++#define ATH12K_HW_DEFAULT_QUEUE		0
++#define ATH12K_HW_MAX_QUEUES		4
++#define ATH12K_QUEUE_LEN		4096
++
++#define ATH12K_HW_RATECODE_CCK_SHORT_PREAM_MASK  0x4
++
++#define ATH12K_FW_DIR			"ath12k"
++
++#define ATH12K_BOARD_MAGIC		"QCA-ATH12K-BOARD"
++#define ATH12K_BOARD_API2_FILE		"board-2.bin"
++#define ATH12K_DEFAULT_BOARD_FILE	"board.bin"
++#define ATH12K_DEFAULT_CAL_FILE		"caldata.bin"
++#define ATH12K_AMSS_FILE		"amss.bin"
++#define ATH12K_M3_FILE			"m3.bin"
++#define ATH12K_AUX_UC_FILE		"aux_ucode.bin"
++#define ATH12K_REGDB_FILE_NAME		"regdb.bin"
++
++#define ATH12K_PCIE_MAX_PAYLOAD_SIZE	128
++#define ATH12K_IPQ5332_USERPD_ID	1
++
++enum ath12k_hw_rate_cck {
++	ATH12K_HW_RATE_CCK_LP_11M = 0,
++	ATH12K_HW_RATE_CCK_LP_5_5M,
++	ATH12K_HW_RATE_CCK_LP_2M,
++	ATH12K_HW_RATE_CCK_LP_1M,
++	ATH12K_HW_RATE_CCK_SP_11M,
++	ATH12K_HW_RATE_CCK_SP_5_5M,
++	ATH12K_HW_RATE_CCK_SP_2M,
++};
++
++enum ath12k_hw_rate_ofdm {
++	ATH12K_HW_RATE_OFDM_48M = 0,
++	ATH12K_HW_RATE_OFDM_24M,
++	ATH12K_HW_RATE_OFDM_12M,
++	ATH12K_HW_RATE_OFDM_6M,
++	ATH12K_HW_RATE_OFDM_54M,
++	ATH12K_HW_RATE_OFDM_36M,
++	ATH12K_HW_RATE_OFDM_18M,
++	ATH12K_HW_RATE_OFDM_9M,
++};
++
++enum ath12k_bus {
++	ATH12K_BUS_PCI,
++	ATH12K_BUS_AHB,
++};
++
++#define ATH12K_EXT_IRQ_GRP_NUM_MAX 11
++
++struct hal_rx_desc;
++struct hal_tcl_data_cmd;
++struct htt_rx_ring_tlv_filter;
++enum hal_encrypt_type;
++
++struct ath12k_hw_ring_mask {
++	u8 tx[ATH12K_EXT_IRQ_GRP_NUM_MAX];
++	u8 rx_mon_dest[ATH12K_EXT_IRQ_GRP_NUM_MAX];
++	u8 rx_mon_status[ATH12K_EXT_IRQ_GRP_NUM_MAX];
++	u8 rx[ATH12K_EXT_IRQ_GRP_NUM_MAX];
++	u8 rx_err[ATH12K_EXT_IRQ_GRP_NUM_MAX];
++	u8 rx_wbm_rel[ATH12K_EXT_IRQ_GRP_NUM_MAX];
++	u8 reo_status[ATH12K_EXT_IRQ_GRP_NUM_MAX];
++	u8 host2rxdma[ATH12K_EXT_IRQ_GRP_NUM_MAX];
++	u8 tx_mon_dest[ATH12K_EXT_IRQ_GRP_NUM_MAX];
++};
++
++enum ath12k_m3_fw_loaders {
++	ath12k_m3_fw_loader_driver,
++	ath12k_m3_fw_loader_remoteproc,
++};
++
++struct ath12k_hw_params {
++	const char *name;
++	u16 hw_rev;
++
++	struct {
++		const char *dir;
++		size_t board_size;
++		size_t cal_offset;
++		enum ath12k_m3_fw_loaders m3_loader;
++		bool download_aux_ucode:1;
++	} fw;
++
++	u8 max_radios;
++	bool single_pdev_only:1;
++	u32 qmi_service_ins_id;
++	bool internal_sleep_clock:1;
++
++	const struct ath12k_hw_ops *hw_ops;
++	const struct ath12k_hw_ring_mask *ring_mask;
++
++	const struct ce_attr *host_ce_config;
++	u32 ce_count;
++	const struct ce_pipe_config *target_ce_config;
++	u32 target_ce_count;
++	const struct service_to_pipe *svc_to_ce_map;
++	u32 svc_to_ce_map_len;
++
++	bool rxdma1_enable:1;
++	int num_rxdma_per_pdev;
++	int num_rxdma_dst_ring;
++	bool rx_mac_buf_ring:1;
++	bool vdev_start_delay:1;
++
++	u16 interface_modes;
++	bool supports_monitor:1;
++
++	bool idle_ps:1;
++	bool download_calib:1;
++	bool supports_suspend:1;
++	bool tcl_ring_retry:1;
++	bool reoq_lut_support:1;
++	bool supports_shadow_regs:1;
++	bool supports_aspm:1;
++	bool current_cc_support:1;
++
++	u32 num_tcl_banks;
++	u32 max_tx_ring;
++
++	const struct mhi_controller_config *mhi_config;
++
++	void (*wmi_init)(struct ath12k_base *ab,
++			 struct ath12k_wmi_resource_config_arg *config);
++
++	u64 qmi_cnss_feature_bitmap;
++
++	u32 rfkill_pin;
++	u32 rfkill_cfg;
++	u32 rfkill_on_level;
++
++	u32 rddm_size;
++
++	u8 def_num_link;
++	u16 max_mlo_peer;
++
++	u32 otp_board_id_register;
++
++	bool supports_sta_ps;
++
++	const guid_t *acpi_guid;
++	bool supports_dynamic_smps_6ghz;
++
++	u32 iova_mask;
++
++	const struct ce_ie_addr *ce_ie_addr;
++	const struct ce_remap *ce_remap;
++	u32 bdf_addr_offset;
++
++	/* setup REO queue, frag etc only for primary link peer */
++	bool dp_primary_link_only:1;
++};
++
++struct ath12k_hw_ops {
++	u8 (*get_hw_mac_from_pdev_id)(int pdev_id);
++	int (*mac_id_to_pdev_id)(const struct ath12k_hw_params *hw, int mac_id);
++	int (*mac_id_to_srng_id)(const struct ath12k_hw_params *hw, int mac_id);
++	int (*rxdma_ring_sel_config)(struct ath12k_base *ab);
++	u8 (*get_ring_selector)(struct sk_buff *skb);
++	bool (*dp_srng_is_tx_comp_ring)(int ring_num);
++	bool (*is_frame_link_agnostic)(struct ath12k_link_vif *arvif,
++				       struct ieee80211_mgmt *mgmt);
++	void (*set_rx_link_id)(struct ath12k_dp_peer *dp_peer,
++			       struct ath12k_skb_rxcb *rxcb,
++			       struct ieee80211_rx_status *status);
++};
++
++static inline
++int ath12k_hw_get_mac_from_pdev_id(const struct ath12k_hw_params *hw,
++				   int pdev_idx)
++{
++	if (hw->hw_ops->get_hw_mac_from_pdev_id)
++		return hw->hw_ops->get_hw_mac_from_pdev_id(pdev_idx);
++
++	return 0;
++}
++
++static inline int ath12k_hw_mac_id_to_pdev_id(const struct ath12k_hw_params *hw,
++					      int mac_id)
++{
++	if (hw->hw_ops->mac_id_to_pdev_id)
++		return hw->hw_ops->mac_id_to_pdev_id(hw, mac_id);
++
++	return 0;
++}
++
++static inline int ath12k_hw_mac_id_to_srng_id(const struct ath12k_hw_params *hw,
++					      int mac_id)
++{
++	if (hw->hw_ops->mac_id_to_srng_id)
++		return hw->hw_ops->mac_id_to_srng_id(hw, mac_id);
++
++	return 0;
++}
++
++static inline void ath12k_hw_set_rx_link_id(const struct ath12k_hw_params *hw,
++					    struct ath12k_dp_peer *dp_peer,
++					    struct ath12k_skb_rxcb *rxcb,
++					    struct ieee80211_rx_status *status)
++{
++	if (hw->hw_ops->set_rx_link_id)
++		hw->hw_ops->set_rx_link_id(dp_peer, rxcb, status);
++}
++
++struct ath12k_fw_ie {
++	__le32 id;
++	__le32 len;
++	u8 data[];
++};
++
++enum ath12k_bd_ie_board_type {
++	ATH12K_BD_IE_BOARD_NAME = 0,
++	ATH12K_BD_IE_BOARD_DATA = 1,
++};
++
++enum ath12k_bd_ie_regdb_type {
++	ATH12K_BD_IE_REGDB_NAME = 0,
++	ATH12K_BD_IE_REGDB_DATA = 1,
++};
++
++enum ath12k_bd_ie_type {
++	/* contains sub IEs of enum ath12k_bd_ie_board_type */
++	ATH12K_BD_IE_BOARD = 0,
++	/* contains sub IEs of enum ath12k_bd_ie_regdb_type */
++	ATH12K_BD_IE_REGDB = 1,
++};
++
++static inline const char *ath12k_bd_ie_type_str(enum ath12k_bd_ie_type type)
++{
++	switch (type) {
++	case ATH12K_BD_IE_BOARD:
++		return "board data";
++	case ATH12K_BD_IE_REGDB:
++		return "regdb data";
++	}
++
++	return "unknown";
++}
++
++#endif
+diff --git a/drivers/net/wireless/ath/ath12k/wifi7/hw.c.orig b/drivers/net/wireless/ath/ath12k/wifi7/hw.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/net/wireless/ath/ath12k/wifi7/hw.c.orig
+@@ -0,0 +1,1231 @@
++// SPDX-License-Identifier: BSD-3-Clause-Clear
++/*
++ * Copyright (c) 2018-2021 The Linux Foundation. All rights reserved.
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
++
++#include <linux/types.h>
++#include <linux/bitops.h>
++#include <linux/bitfield.h>
++
++#include "../debug.h"
++#include "../core.h"
++#include "../ce.h"
++#include "ce.h"
++#include "../hw.h"
++#include "hw.h"
++#include "../mhi.h"
++#include "mhi.h"
++#include "dp_rx.h"
++#include "../peer.h"
++#include "wmi.h"
++#include "../wow.h"
++#include "../debugfs.h"
++#include "../debugfs_sta.h"
++#include "../testmode.h"
++#include "hal.h"
++#include "dp_tx.h"
++
++static const guid_t wcn7850_uuid = GUID_INIT(0xf634f534, 0x6147, 0x11ec,
++					     0x90, 0xd6, 0x02, 0x42,
++					     0xac, 0x12, 0x00, 0x03);
++
++static u8 ath12k_wifi7_hw_qcn9274_mac_from_pdev_id(int pdev_idx)
++{
++	return pdev_idx;
++}
++
++static int
++ath12k_wifi7_hw_mac_id_to_pdev_id_qcn9274(const struct ath12k_hw_params *hw,
++					  int mac_id)
++{
++	return mac_id;
++}
++
++static int
++ath12k_wifi7_hw_mac_id_to_srng_id_qcn9274(const struct ath12k_hw_params *hw,
++					  int mac_id)
++{
++	return 0;
++}
++
++static u8 ath12k_wifi7_hw_get_ring_selector_qcn9274(struct sk_buff *skb)
++{
++	return smp_processor_id();
++}
++
++static bool ath12k_wifi7_dp_srng_is_comp_ring_qcn9274(int ring_num)
++{
++	if (ring_num < 3 || ring_num == 4)
++		return true;
++
++	return false;
++}
++
++static bool
++ath12k_wifi7_is_frame_link_agnostic_qcn9274(struct ath12k_link_vif *arvif,
++					    struct ieee80211_mgmt *mgmt)
++{
++	return ieee80211_is_action(mgmt->frame_control);
++}
++
++static int
++ath12k_wifi7_hw_mac_id_to_pdev_id_wcn7850(const struct ath12k_hw_params *hw,
++					  int mac_id)
++{
++	return 0;
++}
++
++static int
++ath12k_wifi7_hw_mac_id_to_srng_id_wcn7850(const struct ath12k_hw_params *hw,
++					  int mac_id)
++{
++	return mac_id;
++}
++
++static u8 ath12k_wifi7_hw_get_ring_selector_wcn7850(struct sk_buff *skb)
++{
++	return skb_get_queue_mapping(skb);
++}
++
++static bool ath12k_wifi7_dp_srng_is_comp_ring_wcn7850(int ring_num)
++{
++	if (ring_num == 0 || ring_num == 2 || ring_num == 4)
++		return true;
++
++	return false;
++}
++
++static bool ath12k_is_addba_resp_action_code(struct ieee80211_mgmt *mgmt)
++{
++	if (!ieee80211_is_action(mgmt->frame_control))
++		return false;
++
++	if (mgmt->u.action.category != WLAN_CATEGORY_BACK)
++		return false;
++
++	if (mgmt->u.action.action_code != WLAN_ACTION_ADDBA_RESP)
++		return false;
++
++	return true;
++}
++
++static bool
++ath12k_wifi7_is_frame_link_agnostic_wcn7850(struct ath12k_link_vif *arvif,
++					    struct ieee80211_mgmt *mgmt)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ath12k_hw *ah = ath12k_ar_to_ah(arvif->ar);
++	struct ath12k_base *ab = arvif->ar->ab;
++	struct ath12k_dp *dp = ath12k_ab_to_dp(ab);
++	struct ath12k_dp_peer *peer;
++	__le16 fc = mgmt->frame_control;
++
++	spin_lock_bh(&dp->dp_lock);
++	if (!ath12k_dp_link_peer_find_by_addr(dp, mgmt->da)) {
++		spin_lock_bh(&ah->dp_hw.peer_lock);
++		peer = ath12k_dp_peer_find_by_addr(&ah->dp_hw, mgmt->da);
++		if (!peer || (peer && !peer->is_mlo)) {
++			spin_unlock_bh(&ah->dp_hw.peer_lock);
++			spin_unlock_bh(&dp->dp_lock);
++			return false;
++		}
++		spin_unlock_bh(&ah->dp_hw.peer_lock);
++	}
++	spin_unlock_bh(&dp->dp_lock);
++
++	if (vif->type == NL80211_IFTYPE_STATION)
++		return arvif->is_up &&
++		       (vif->valid_links == vif->active_links) &&
++		       !ieee80211_is_probe_req(fc) &&
++		       !ieee80211_is_auth(fc) &&
++		       !ieee80211_is_deauth(fc) &&
++		       !ath12k_is_addba_resp_action_code(mgmt);
++
++	if (vif->type == NL80211_IFTYPE_AP)
++		return !(ieee80211_is_probe_resp(fc) || ieee80211_is_auth(fc) ||
++			 ieee80211_is_assoc_resp(fc) || ieee80211_is_reassoc_resp(fc) ||
++			 ath12k_is_addba_resp_action_code(mgmt));
++
++	return false;
++}
++
++static const struct ath12k_hw_ops qcn9274_ops = {
++	.get_hw_mac_from_pdev_id = ath12k_wifi7_hw_qcn9274_mac_from_pdev_id,
++	.mac_id_to_pdev_id = ath12k_wifi7_hw_mac_id_to_pdev_id_qcn9274,
++	.mac_id_to_srng_id = ath12k_wifi7_hw_mac_id_to_srng_id_qcn9274,
++	.rxdma_ring_sel_config = ath12k_dp_rxdma_ring_sel_config_qcn9274,
++	.get_ring_selector = ath12k_wifi7_hw_get_ring_selector_qcn9274,
++	.dp_srng_is_tx_comp_ring = ath12k_wifi7_dp_srng_is_comp_ring_qcn9274,
++	.is_frame_link_agnostic = ath12k_wifi7_is_frame_link_agnostic_qcn9274,
++	.set_rx_link_id = ath12k_wifi7_dp_rx_set_link_id_qcn9274,
++};
++
++static const struct ath12k_hw_ops wcn7850_ops = {
++	.get_hw_mac_from_pdev_id = ath12k_wifi7_hw_qcn9274_mac_from_pdev_id,
++	.mac_id_to_pdev_id = ath12k_wifi7_hw_mac_id_to_pdev_id_wcn7850,
++	.mac_id_to_srng_id = ath12k_wifi7_hw_mac_id_to_srng_id_wcn7850,
++	.rxdma_ring_sel_config = ath12k_dp_rxdma_ring_sel_config_wcn7850,
++	.get_ring_selector = ath12k_wifi7_hw_get_ring_selector_wcn7850,
++	.dp_srng_is_tx_comp_ring = ath12k_wifi7_dp_srng_is_comp_ring_wcn7850,
++	.is_frame_link_agnostic = ath12k_wifi7_is_frame_link_agnostic_wcn7850,
++	.set_rx_link_id = ath12k_wifi7_dp_rx_set_link_id_wcn7850,
++};
++
++static const struct ath12k_hw_ops qcc2072_ops = {
++	.get_hw_mac_from_pdev_id = ath12k_wifi7_hw_qcn9274_mac_from_pdev_id,
++	.mac_id_to_pdev_id = ath12k_wifi7_hw_mac_id_to_pdev_id_wcn7850,
++	.mac_id_to_srng_id = ath12k_wifi7_hw_mac_id_to_srng_id_wcn7850,
++	.rxdma_ring_sel_config = ath12k_dp_rxdma_ring_sel_config_qcc2072,
++	.get_ring_selector = ath12k_wifi7_hw_get_ring_selector_wcn7850,
++	.dp_srng_is_tx_comp_ring = ath12k_wifi7_dp_srng_is_comp_ring_wcn7850,
++	.is_frame_link_agnostic = ath12k_wifi7_is_frame_link_agnostic_wcn7850,
++	.set_rx_link_id = ath12k_wifi7_dp_rx_set_link_id_wcn7850,
++};
++
++#define ATH12K_TX_RING_MASK_0 0x1
++#define ATH12K_TX_RING_MASK_1 0x2
++#define ATH12K_TX_RING_MASK_2 0x4
++#define ATH12K_TX_RING_MASK_3 0x8
++#define ATH12K_TX_RING_MASK_4 0x10
++
++#define ATH12K_RX_RING_MASK_0 0x1
++#define ATH12K_RX_RING_MASK_1 0x2
++#define ATH12K_RX_RING_MASK_2 0x4
++#define ATH12K_RX_RING_MASK_3 0x8
++
++#define ATH12K_RX_ERR_RING_MASK_0 0x1
++
++#define ATH12K_RX_WBM_REL_RING_MASK_0 0x1
++
++#define ATH12K_REO_STATUS_RING_MASK_0 0x1
++
++#define ATH12K_HOST2RXDMA_RING_MASK_0 0x1
++
++#define ATH12K_RX_MON_RING_MASK_0 0x1
++#define ATH12K_RX_MON_RING_MASK_1 0x2
++#define ATH12K_RX_MON_RING_MASK_2 0x4
++
++#define ATH12K_TX_MON_RING_MASK_0 0x1
++#define ATH12K_TX_MON_RING_MASK_1 0x2
++
++#define ATH12K_RX_MON_STATUS_RING_MASK_0 0x1
++#define ATH12K_RX_MON_STATUS_RING_MASK_1 0x2
++#define ATH12K_RX_MON_STATUS_RING_MASK_2 0x4
++
++static const struct ath12k_hw_ring_mask ath12k_wifi7_hw_ring_mask_qcn9274 = {
++	.tx  = {
++		ATH12K_TX_RING_MASK_0,
++		ATH12K_TX_RING_MASK_1,
++		ATH12K_TX_RING_MASK_2,
++		ATH12K_TX_RING_MASK_3,
++	},
++	.rx_mon_dest = {
++		0, 0, 0, 0,
++		0, 0, 0, 0,
++		ATH12K_RX_MON_RING_MASK_0,
++		ATH12K_RX_MON_RING_MASK_1,
++		ATH12K_RX_MON_RING_MASK_2,
++	},
++	.rx = {
++		0, 0, 0, 0,
++		ATH12K_RX_RING_MASK_0,
++		ATH12K_RX_RING_MASK_1,
++		ATH12K_RX_RING_MASK_2,
++		ATH12K_RX_RING_MASK_3,
++	},
++	.rx_err = {
++		0, 0, 0,
++		ATH12K_RX_ERR_RING_MASK_0,
++	},
++	.rx_wbm_rel = {
++		0, 0, 0,
++		ATH12K_RX_WBM_REL_RING_MASK_0,
++	},
++	.reo_status = {
++		0, 0, 0,
++		ATH12K_REO_STATUS_RING_MASK_0,
++	},
++	.host2rxdma = {
++		0, 0, 0,
++		ATH12K_HOST2RXDMA_RING_MASK_0,
++	},
++	.tx_mon_dest = {
++		0, 0, 0,
++	},
++};
++
++static const struct ath12k_hw_ring_mask ath12k_wifi7_hw_ring_mask_ipq5332 = {
++	.tx  = {
++		ATH12K_TX_RING_MASK_0,
++		ATH12K_TX_RING_MASK_1,
++		ATH12K_TX_RING_MASK_2,
++		ATH12K_TX_RING_MASK_3,
++	},
++	.rx_mon_dest = {
++		0, 0, 0, 0, 0, 0, 0, 0,
++		ATH12K_RX_MON_RING_MASK_0,
++	},
++	.rx = {
++		0, 0, 0, 0,
++		ATH12K_RX_RING_MASK_0,
++		ATH12K_RX_RING_MASK_1,
++		ATH12K_RX_RING_MASK_2,
++		ATH12K_RX_RING_MASK_3,
++	},
++	.rx_err = {
++		0, 0, 0,
++		ATH12K_RX_ERR_RING_MASK_0,
++	},
++	.rx_wbm_rel = {
++		0, 0, 0,
++		ATH12K_RX_WBM_REL_RING_MASK_0,
++	},
++	.reo_status = {
++		0, 0, 0,
++		ATH12K_REO_STATUS_RING_MASK_0,
++	},
++	.host2rxdma = {
++		0, 0, 0,
++		ATH12K_HOST2RXDMA_RING_MASK_0,
++	},
++	.tx_mon_dest = {
++		ATH12K_TX_MON_RING_MASK_0,
++		ATH12K_TX_MON_RING_MASK_1,
++	},
++};
++
++static const struct ath12k_hw_ring_mask ath12k_wifi7_hw_ring_mask_wcn7850 = {
++	.tx  = {
++		ATH12K_TX_RING_MASK_0,
++		ATH12K_TX_RING_MASK_1,
++		ATH12K_TX_RING_MASK_2,
++	},
++	.rx_mon_dest = {
++	},
++	.rx_mon_status = {
++		0, 0, 0, 0,
++		ATH12K_RX_MON_STATUS_RING_MASK_0,
++		ATH12K_RX_MON_STATUS_RING_MASK_1,
++		ATH12K_RX_MON_STATUS_RING_MASK_2,
++	},
++	.rx = {
++		0, 0, 0,
++		ATH12K_RX_RING_MASK_0,
++		ATH12K_RX_RING_MASK_1,
++		ATH12K_RX_RING_MASK_2,
++		ATH12K_RX_RING_MASK_3,
++	},
++	.rx_err = {
++		ATH12K_RX_ERR_RING_MASK_0,
++	},
++	.rx_wbm_rel = {
++		ATH12K_RX_WBM_REL_RING_MASK_0,
++	},
++	.reo_status = {
++		ATH12K_REO_STATUS_RING_MASK_0,
++	},
++	.host2rxdma = {
++	},
++	.tx_mon_dest = {
++	},
++};
++
++static const struct ce_ie_addr ath12k_wifi7_ce_ie_addr_ipq5332 = {
++	.ie1_reg_addr = CE_HOST_IPQ5332_IE_ADDRESS - HAL_IPQ5332_CE_WFSS_REG_BASE,
++	.ie2_reg_addr = CE_HOST_IPQ5332_IE_2_ADDRESS - HAL_IPQ5332_CE_WFSS_REG_BASE,
++	.ie3_reg_addr = CE_HOST_IPQ5332_IE_3_ADDRESS - HAL_IPQ5332_CE_WFSS_REG_BASE,
++};
++
++static const struct ce_ie_addr ath12k_wifi7_ce_ie_addr_ipq5424 = {
++	.ie1_reg_addr = CE_HOST_IPQ5424_IE_ADDRESS - HAL_IPQ5424_CE_WFSS_REG_BASE,
++	.ie2_reg_addr = CE_HOST_IPQ5424_IE_2_ADDRESS - HAL_IPQ5424_CE_WFSS_REG_BASE,
++	.ie3_reg_addr = CE_HOST_IPQ5424_IE_3_ADDRESS - HAL_IPQ5424_CE_WFSS_REG_BASE,
++};
++
++static const struct ce_remap ath12k_wifi7_ce_remap_ipq5332 = {
++	.base = HAL_IPQ5332_CE_WFSS_REG_BASE,
++	.size = HAL_IPQ5332_CE_SIZE,
++	.cmem_offset = HAL_SEQ_WCSS_CMEM_OFFSET,
++};
++
++static const struct ce_remap ath12k_wifi7_ce_remap_ipq5424 = {
++	.base = HAL_IPQ5424_CE_WFSS_REG_BASE,
++	.size = HAL_IPQ5424_CE_SIZE,
++	.cmem_offset = HAL_SEQ_WCSS_CMEM_OFFSET,
++};
++
++static const struct ath12k_hw_params ath12k_wifi7_hw_params[] = {
++	{
++		.name = "qcn9274 hw1.0",
++		.hw_rev = ATH12K_HW_QCN9274_HW10,
++		.fw = {
++			.dir = "QCN9274/hw1.0",
++			.board_size = 256 * 1024,
++			.cal_offset = 128 * 1024,
++			.m3_loader = ath12k_m3_fw_loader_driver,
++			.download_aux_ucode = false,
++		},
++		.max_radios = 1,
++		.single_pdev_only = false,
++		.qmi_service_ins_id = ATH12K_QMI_WLFW_SERVICE_INS_ID_V01_QCN9274,
++		.internal_sleep_clock = false,
++
++		.hw_ops = &qcn9274_ops,
++		.ring_mask = &ath12k_wifi7_hw_ring_mask_qcn9274,
++
++		.host_ce_config = ath12k_wifi7_host_ce_config_qcn9274,
++		.ce_count = 16,
++		.target_ce_config = ath12k_wifi7_target_ce_config_wlan_qcn9274,
++		.target_ce_count = 12,
++		.svc_to_ce_map =
++			ath12k_wifi7_target_service_to_ce_map_wlan_qcn9274,
++		.svc_to_ce_map_len = 18,
++
++		.rxdma1_enable = false,
++		.num_rxdma_per_pdev = 1,
++		.num_rxdma_dst_ring = 0,
++		.rx_mac_buf_ring = false,
++		.vdev_start_delay = false,
++
++		.interface_modes = BIT(NL80211_IFTYPE_STATION) |
++					BIT(NL80211_IFTYPE_AP) |
++					BIT(NL80211_IFTYPE_MESH_POINT) |
++					BIT(NL80211_IFTYPE_AP_VLAN),
++		.supports_monitor = false,
++
++		.idle_ps = false,
++		.download_calib = true,
++		.supports_suspend = false,
++		.tcl_ring_retry = true,
++		.reoq_lut_support = true,
++		.supports_shadow_regs = false,
++
++		.num_tcl_banks = 48,
++		.max_tx_ring = 4,
++
++		.mhi_config = &ath12k_wifi7_mhi_config_qcn9274,
++
++		.wmi_init = ath12k_wifi7_wmi_init_qcn9274,
++
++		.qmi_cnss_feature_bitmap = BIT(CNSS_QDSS_CFG_MISS_V01),
++
++		.rfkill_pin = 0,
++		.rfkill_cfg = 0,
++		.rfkill_on_level = 0,
++
++		.rddm_size = 0x600000,
++
++		.def_num_link = 0,
++		.max_mlo_peer = 256,
++
++		.otp_board_id_register = QCN9274_QFPROM_RAW_RFA_PDET_ROW13_LSB,
++
++		.supports_sta_ps = false,
++
++		.acpi_guid = NULL,
++		.supports_dynamic_smps_6ghz = true,
++
++		.iova_mask = 0,
++
++		.supports_aspm = false,
++
++		.ce_ie_addr = NULL,
++		.ce_remap = NULL,
++		.bdf_addr_offset = 0,
++
++		.current_cc_support = false,
++
++		.dp_primary_link_only = true,
++	},
++	{
++		.name = "wcn7850 hw2.0",
++		.hw_rev = ATH12K_HW_WCN7850_HW20,
++
++		.fw = {
++			.dir = "WCN7850/hw2.0",
++			.board_size = 256 * 1024,
++			.cal_offset = 256 * 1024,
++			.m3_loader = ath12k_m3_fw_loader_driver,
++			.download_aux_ucode = false,
++		},
++
++		.max_radios = 1,
++		.single_pdev_only = true,
++		.qmi_service_ins_id = ATH12K_QMI_WLFW_SERVICE_INS_ID_V01_WCN7850,
++		.internal_sleep_clock = true,
++
++		.hw_ops = &wcn7850_ops,
++		.ring_mask = &ath12k_wifi7_hw_ring_mask_wcn7850,
++
++		.host_ce_config = ath12k_wifi7_host_ce_config_wcn7850,
++		.ce_count = 9,
++		.target_ce_config = ath12k_wifi7_target_ce_config_wlan_wcn7850,
++		.target_ce_count = 9,
++		.svc_to_ce_map =
++			ath12k_wifi7_target_service_to_ce_map_wlan_wcn7850,
++		.svc_to_ce_map_len = 14,
++
++		.rxdma1_enable = false,
++		.num_rxdma_per_pdev = 2,
++		.num_rxdma_dst_ring = 1,
++		.rx_mac_buf_ring = true,
++		.vdev_start_delay = true,
++
++		.interface_modes = BIT(NL80211_IFTYPE_STATION) |
++				   BIT(NL80211_IFTYPE_AP) |
++				   BIT(NL80211_IFTYPE_P2P_DEVICE) |
++				   BIT(NL80211_IFTYPE_P2P_CLIENT) |
++				   BIT(NL80211_IFTYPE_P2P_GO),
++		.supports_monitor = true,
++
++		.idle_ps = true,
++		.download_calib = false,
++		.supports_suspend = true,
++		.tcl_ring_retry = false,
++		.reoq_lut_support = false,
++		.supports_shadow_regs = true,
++
++		.num_tcl_banks = 7,
++		.max_tx_ring = 3,
++
++		.mhi_config = &ath12k_wifi7_mhi_config_wcn7850,
++
++		.wmi_init = ath12k_wifi7_wmi_init_wcn7850,
++
++		.qmi_cnss_feature_bitmap = BIT(CNSS_QDSS_CFG_MISS_V01) |
++					   BIT(CNSS_PCIE_PERST_NO_PULL_V01),
++
++		.rfkill_pin = 48,
++		.rfkill_cfg = 0,
++		.rfkill_on_level = 1,
++
++		.rddm_size = 0x780000,
++
++		.def_num_link = 2,
++		.max_mlo_peer = 32,
++
++		.otp_board_id_register = 0,
++
++		.supports_sta_ps = true,
++
++		.acpi_guid = &wcn7850_uuid,
++		.supports_dynamic_smps_6ghz = false,
++
++		.iova_mask = ATH12K_PCIE_MAX_PAYLOAD_SIZE - 1,
++
++		.supports_aspm = true,
++
++		.ce_ie_addr = NULL,
++		.ce_remap = NULL,
++		.bdf_addr_offset = 0,
++
++		.current_cc_support = true,
++
++		.dp_primary_link_only = false,
++	},
++	{
++		.name = "qcn9274 hw2.0",
++		.hw_rev = ATH12K_HW_QCN9274_HW20,
++		.fw = {
++			.dir = "QCN9274/hw2.0",
++			.board_size = 256 * 1024,
++			.cal_offset = 128 * 1024,
++			.m3_loader = ath12k_m3_fw_loader_driver,
++			.download_aux_ucode = false,
++		},
++		.max_radios = 2,
++		.single_pdev_only = false,
++		.qmi_service_ins_id = ATH12K_QMI_WLFW_SERVICE_INS_ID_V01_QCN9274,
++		.internal_sleep_clock = false,
++
++		.hw_ops = &qcn9274_ops,
++		.ring_mask = &ath12k_wifi7_hw_ring_mask_qcn9274,
++
++		.host_ce_config = ath12k_wifi7_host_ce_config_qcn9274,
++		.ce_count = 16,
++		.target_ce_config = ath12k_wifi7_target_ce_config_wlan_qcn9274,
++		.target_ce_count = 12,
++		.svc_to_ce_map =
++			ath12k_wifi7_target_service_to_ce_map_wlan_qcn9274,
++		.svc_to_ce_map_len = 18,
++
++		.rxdma1_enable = true,
++		.num_rxdma_per_pdev = 1,
++		.num_rxdma_dst_ring = 0,
++		.rx_mac_buf_ring = false,
++		.vdev_start_delay = false,
++
++		.interface_modes = BIT(NL80211_IFTYPE_STATION) |
++					BIT(NL80211_IFTYPE_AP) |
++					BIT(NL80211_IFTYPE_MESH_POINT) |
++					BIT(NL80211_IFTYPE_AP_VLAN),
++		.supports_monitor = true,
++
++		.idle_ps = false,
++		.download_calib = true,
++		.supports_suspend = false,
++		.tcl_ring_retry = true,
++		.reoq_lut_support = true,
++		.supports_shadow_regs = false,
++
++		.num_tcl_banks = 48,
++		.max_tx_ring = 4,
++
++		.mhi_config = &ath12k_wifi7_mhi_config_qcn9274,
++
++		.wmi_init = ath12k_wifi7_wmi_init_qcn9274,
++
++		.qmi_cnss_feature_bitmap = BIT(CNSS_QDSS_CFG_MISS_V01),
++
++		.rfkill_pin = 0,
++		.rfkill_cfg = 0,
++		.rfkill_on_level = 0,
++
++		.rddm_size = 0x600000,
++
++		.def_num_link = 0,
++		.max_mlo_peer = 256,
++
++		.otp_board_id_register = QCN9274_QFPROM_RAW_RFA_PDET_ROW13_LSB,
++
++		.supports_sta_ps = false,
++
++		.acpi_guid = NULL,
++		.supports_dynamic_smps_6ghz = true,
++
++		.iova_mask = 0,
++
++		.supports_aspm = false,
++
++		.ce_ie_addr = NULL,
++		.ce_remap = NULL,
++		.bdf_addr_offset = 0,
++
++		.current_cc_support = false,
++
++		.dp_primary_link_only = true,
++	},
++	{
++		.name = "ipq5332 hw1.0",
++		.hw_rev = ATH12K_HW_IPQ5332_HW10,
++		.fw = {
++			.dir = "IPQ5332/hw1.0",
++			.board_size = 256 * 1024,
++			.cal_offset = 128 * 1024,
++			.m3_loader = ath12k_m3_fw_loader_remoteproc,
++			.download_aux_ucode = false,
++		},
++		.max_radios = 1,
++		.single_pdev_only = false,
++		.qmi_service_ins_id = ATH12K_QMI_WLFW_SERVICE_INS_ID_V01_IPQ5332,
++		.internal_sleep_clock = false,
++
++		.hw_ops = &qcn9274_ops,
++		.ring_mask = &ath12k_wifi7_hw_ring_mask_ipq5332,
++
++		.host_ce_config = ath12k_wifi7_host_ce_config_ipq5332,
++		.ce_count = 12,
++		.target_ce_config = ath12k_wifi7_target_ce_config_wlan_ipq5332,
++		.target_ce_count = 12,
++		.svc_to_ce_map =
++			ath12k_wifi7_target_service_to_ce_map_wlan_ipq5332,
++		.svc_to_ce_map_len = 18,
++
++		.rxdma1_enable = true,
++		.num_rxdma_per_pdev = 1,
++		.num_rxdma_dst_ring = 0,
++		.rx_mac_buf_ring = false,
++		.vdev_start_delay = false,
++
++		.interface_modes = BIT(NL80211_IFTYPE_STATION) |
++				   BIT(NL80211_IFTYPE_AP) |
++				   BIT(NL80211_IFTYPE_MESH_POINT),
++		.supports_monitor = true,
++
++		.idle_ps = false,
++		.download_calib = true,
++		.supports_suspend = false,
++		.tcl_ring_retry = true,
++		.reoq_lut_support = false,
++		.supports_shadow_regs = false,
++
++		.num_tcl_banks = 48,
++		.max_tx_ring = 4,
++
++		.wmi_init = &ath12k_wifi7_wmi_init_qcn9274,
++
++		.qmi_cnss_feature_bitmap = BIT(CNSS_QDSS_CFG_MISS_V01),
++
++		.rfkill_pin = 0,
++		.rfkill_cfg = 0,
++		.rfkill_on_level = 0,
++
++		.rddm_size = 0,
++
++		.def_num_link = 0,
++		.max_mlo_peer = 256,
++
++		.otp_board_id_register = 0,
++
++		.supports_sta_ps = false,
++
++		.acpi_guid = NULL,
++		.supports_dynamic_smps_6ghz = false,
++		.iova_mask = 0,
++		.supports_aspm = false,
++
++		.ce_ie_addr = &ath12k_wifi7_ce_ie_addr_ipq5332,
++		.ce_remap = &ath12k_wifi7_ce_remap_ipq5332,
++		.bdf_addr_offset = 0xC00000,
++
++		.dp_primary_link_only = true,
++	},
++	{
++		.name = "wcn7860 hw2.0",
++		.hw_rev = ATH12K_HW_WCN7860_HW20,
++
++		.fw = {
++			.dir = "WCN7860/hw2.0",
++			.board_size = 256 * 1024,
++			.cal_offset = 256 * 1024,
++			.m3_loader = ath12k_m3_fw_loader_driver,
++			.download_aux_ucode = true,
++		},
++
++		.max_radios = 2,
++		.single_pdev_only = true,
++		.qmi_service_ins_id = ATH12K_QMI_WLFW_SERVICE_INS_ID_V01_WCN7850,
++		.internal_sleep_clock = true,
++
++		.hw_ops = &qcc2072_ops,
++		.ring_mask = &ath12k_wifi7_hw_ring_mask_wcn7850,
++
++		.host_ce_config = ath12k_wifi7_host_ce_config_wcn7850,
++		.ce_count = 9,
++		.target_ce_config = ath12k_wifi7_target_ce_config_wlan_wcn7850,
++		.target_ce_count = 9,
++		.svc_to_ce_map =
++			ath12k_wifi7_target_service_to_ce_map_wlan_wcn7850,
++		.svc_to_ce_map_len = 14,
++
++		.rxdma1_enable = false,
++		.num_rxdma_per_pdev = 2,
++		.num_rxdma_dst_ring = 1,
++		.rx_mac_buf_ring = true,
++		.vdev_start_delay = true,
++
++		.interface_modes = BIT(NL80211_IFTYPE_STATION) |
++				   BIT(NL80211_IFTYPE_AP) |
++				   BIT(NL80211_IFTYPE_P2P_DEVICE) |
++				   BIT(NL80211_IFTYPE_P2P_CLIENT) |
++				   BIT(NL80211_IFTYPE_P2P_GO),
++		.supports_monitor = true,
++
++		.idle_ps = true,
++		.download_calib = false,
++		.supports_suspend = true,
++		.tcl_ring_retry = false,
++		.reoq_lut_support = false,
++		.supports_shadow_regs = true,
++
++		.num_tcl_banks = 7,
++		.max_tx_ring = 3,
++
++		.mhi_config = &ath12k_wifi7_mhi_config_wcn7850,
++
++		.wmi_init = ath12k_wifi7_wmi_init_wcn7850,
++
++		.qmi_cnss_feature_bitmap = BIT(CNSS_QDSS_CFG_MISS_V01) |
++					   BIT(CNSS_PCIE_PERST_NO_PULL_V01) |
++					   BIT(CNSS_AUX_UC_SUPPORT_V01),
++
++		.rfkill_pin = 0,
++		.rfkill_cfg = 0,
++		.rfkill_on_level = 0,
++
++		.rddm_size = 0x780000,
++
++		.def_num_link = 2,
++		.max_mlo_peer = 32,
++
++		.otp_board_id_register = 0,
++
++		.supports_sta_ps = true,
++
++		.acpi_guid = &wcn7850_uuid,
++
++		.supports_dynamic_smps_6ghz = false,
++
++		.iova_mask = 0,
++
++		.supports_aspm = true,
++
++		.ce_ie_addr = NULL,
++		.ce_remap = NULL,
++		.bdf_addr_offset = 0,
++
++		.current_cc_support = true,
++
++		.dp_primary_link_only = false,
++	},
++	{
++		.name = "qcc2072 hw1.0",
++		.hw_rev = ATH12K_HW_QCC2072_HW10,
++
++		.fw = {
++			.dir = "QCC2072/hw1.0",
++			.board_size = 256 * 1024,
++			.cal_offset = 256 * 1024,
++			.m3_loader = ath12k_m3_fw_loader_driver,
++			.download_aux_ucode = true,
++		},
++
++		.max_radios = 1,
++		.single_pdev_only = true,
++		.qmi_service_ins_id = ATH12K_QMI_WLFW_SERVICE_INS_ID_V01_WCN7850,
++		.internal_sleep_clock = true,
++
++		.hw_ops = &qcc2072_ops,
++		.ring_mask = &ath12k_wifi7_hw_ring_mask_wcn7850,
++
++		.host_ce_config = ath12k_wifi7_host_ce_config_wcn7850,
++		.ce_count = 9,
++		.target_ce_config = ath12k_wifi7_target_ce_config_wlan_wcn7850,
++		.target_ce_count = 9,
++		.svc_to_ce_map =
++			ath12k_wifi7_target_service_to_ce_map_wlan_wcn7850,
++		.svc_to_ce_map_len = 14,
++
++		.rxdma1_enable = false,
++		.num_rxdma_per_pdev = 2,
++		.num_rxdma_dst_ring = 1,
++		.rx_mac_buf_ring = true,
++		.vdev_start_delay = true,
++
++		.interface_modes = BIT(NL80211_IFTYPE_STATION) |
++				   BIT(NL80211_IFTYPE_AP) |
++				   BIT(NL80211_IFTYPE_P2P_DEVICE) |
++				   BIT(NL80211_IFTYPE_P2P_CLIENT) |
++				   BIT(NL80211_IFTYPE_P2P_GO),
++		.supports_monitor = true,
++
++		.idle_ps = true,
++		.download_calib = false,
++		.supports_suspend = true,
++		.tcl_ring_retry = false,
++		.reoq_lut_support = false,
++		.supports_shadow_regs = true,
++
++		.num_tcl_banks = 7,
++		.max_tx_ring = 3,
++
++		.mhi_config = &ath12k_wifi7_mhi_config_wcn7850,
++
++		.wmi_init = ath12k_wifi7_wmi_init_wcn7850,
++
++		.qmi_cnss_feature_bitmap = BIT(CNSS_QDSS_CFG_MISS_V01) |
++					   BIT(CNSS_PCIE_PERST_NO_PULL_V01) |
++					   BIT(CNSS_AUX_UC_SUPPORT_V01),
++
++		.rfkill_pin = 0,
++		.rfkill_cfg = 0,
++		.rfkill_on_level = 0,
++
++		.rddm_size = 0x780000,
++
++		.def_num_link = 2,
++		.max_mlo_peer = 32,
++
++		.otp_board_id_register = 0,
++
++		.supports_sta_ps = true,
++
++		.acpi_guid = &wcn7850_uuid,
++		.supports_dynamic_smps_6ghz = false,
++
++		.iova_mask = 0,
++
++		.supports_aspm = true,
++
++		.ce_ie_addr = NULL,
++		.ce_remap = NULL,
++		.bdf_addr_offset = 0,
++
++		.current_cc_support = true,
++
++		.dp_primary_link_only = false,
++	},
++	{
++		.name = "ipq5424 hw1.0",
++		.hw_rev = ATH12K_HW_IPQ5424_HW10,
++		.fw = {
++			.dir = "IPQ5424/hw1.0",
++			.board_size = 256 * 1024,
++			.cal_offset = 128 * 1024,
++			.m3_loader = ath12k_m3_fw_loader_remoteproc,
++			.download_aux_ucode = false,
++		},
++		.max_radios = 1,
++		.single_pdev_only = false,
++		.qmi_service_ins_id = ATH12K_QMI_WLFW_SERVICE_INS_ID_V01_IPQ5332,
++		.internal_sleep_clock = false,
++
++		.hw_ops = &qcn9274_ops,
++		.ring_mask = &ath12k_wifi7_hw_ring_mask_ipq5332,
++
++		.host_ce_config = ath12k_wifi7_host_ce_config_ipq5332,
++		.ce_count = 12,
++		.target_ce_config = ath12k_wifi7_target_ce_config_wlan_ipq5332,
++		.target_ce_count = 12,
++		.svc_to_ce_map =
++			ath12k_wifi7_target_service_to_ce_map_wlan_ipq5332,
++		.svc_to_ce_map_len = 18,
++
++		.rxdma1_enable = true,
++		.num_rxdma_per_pdev = 1,
++		.num_rxdma_dst_ring = 0,
++		.rx_mac_buf_ring = false,
++		.vdev_start_delay = false,
++
++		.interface_modes = BIT(NL80211_IFTYPE_STATION) |
++				   BIT(NL80211_IFTYPE_AP) |
++				   BIT(NL80211_IFTYPE_MESH_POINT),
++		.supports_monitor = true,
++
++		.idle_ps = false,
++		.download_calib = true,
++		.supports_suspend = false,
++		.tcl_ring_retry = true,
++		.reoq_lut_support = false,
++		.supports_shadow_regs = false,
++
++		.num_tcl_banks = 48,
++		.max_tx_ring = 4,
++
++		.mhi_config = NULL,
++
++		.wmi_init = &ath12k_wifi7_wmi_init_qcn9274,
++
++		.qmi_cnss_feature_bitmap = BIT(CNSS_QDSS_CFG_MISS_V01),
++
++		.rfkill_pin = 0,
++		.rfkill_cfg = 0,
++		.rfkill_on_level = 0,
++
++		.rddm_size = 0,
++
++		.def_num_link = 0,
++		.max_mlo_peer = 256,
++
++		.otp_board_id_register = 0,
++
++		.supports_sta_ps = false,
++
++		.acpi_guid = NULL,
++		.supports_dynamic_smps_6ghz = false,
++		.iova_mask = 0,
++		.supports_aspm = false,
++
++		.ce_ie_addr = &ath12k_wifi7_ce_ie_addr_ipq5424,
++		.ce_remap = &ath12k_wifi7_ce_remap_ipq5424,
++		.bdf_addr_offset = 0x940000,
++
++		.current_cc_support = false,
++
++		.dp_primary_link_only = true,
++	},
++};
++
++/* Note: called under rcu_read_lock() */
++static void ath12k_wifi7_mac_op_tx(struct ieee80211_hw *hw,
++				   struct ieee80211_tx_control *control,
++				   struct sk_buff *skb)
++{
++	struct ath12k_skb_cb *skb_cb = ATH12K_SKB_CB(skb);
++	struct ieee80211_tx_info *info = IEEE80211_SKB_CB(skb);
++	struct ieee80211_vif *vif = info->control.vif;
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_link_vif *arvif = &ahvif->deflink;
++	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)skb->data;
++	struct ieee80211_key_conf *key = info->control.hw_key;
++	struct ieee80211_sta *sta = control->sta;
++	struct ath12k_link_vif *tmp_arvif;
++	u32 info_flags = info->flags;
++	struct sk_buff *msdu_copied;
++	struct ath12k *ar, *tmp_ar;
++	struct ath12k_pdev_dp *dp_pdev, *tmp_dp_pdev;
++	struct ath12k_dp_link_peer *peer;
++	unsigned long links_map;
++	bool is_mcast = false;
++	bool is_dvlan = false;
++	struct ethhdr *eth;
++	bool is_prb_rsp;
++	u16 mcbc_gsn;
++	u8 link_id;
++	int ret;
++	struct ath12k_dp *tmp_dp;
++
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_MONITOR) {
++		ieee80211_free_txskb(hw, skb);
++		return;
++	}
++
++	link_id = u32_get_bits(info->control.flags, IEEE80211_TX_CTRL_MLO_LINK);
++	memset(skb_cb, 0, sizeof(*skb_cb));
++	skb_cb->vif = vif;
++
++	if (key) {
++		skb_cb->cipher = key->cipher;
++		skb_cb->flags |= ATH12K_SKB_CIPHER_SET;
++	}
++
++	/* handle only for MLO case, use deflink for non MLO case */
++	if (ieee80211_vif_is_mld(vif)) {
++		link_id = ath12k_mac_get_tx_link(sta, vif, link_id, skb, info_flags);
++		if (link_id >= IEEE80211_MLD_MAX_NUM_LINKS) {
++			ieee80211_free_txskb(hw, skb);
++			return;
++		}
++	} else {
++		if (vif->type == NL80211_IFTYPE_P2P_DEVICE)
++			link_id = ATH12K_FIRST_SCAN_LINK;
++		else
++			link_id = 0;
++	}
++
++	arvif = rcu_dereference(ahvif->link[link_id]);
++	if (!arvif || !arvif->ar) {
++		ath12k_warn(ahvif->ah, "failed to find arvif link id %u for frame transmission",
++			    link_id);
++		ieee80211_free_txskb(hw, skb);
++		return;
++	}
++
++	ar = arvif->ar;
++	skb_cb->link_id = link_id;
++	/*
++	 * as skb_cb is common currently for dp and mgmt tx processing
++	 * set this in the common mac op tx function.
++	 */
++	skb_cb->ar = ar;
++	is_prb_rsp = ieee80211_is_probe_resp(hdr->frame_control);
++
++	if (info_flags & IEEE80211_TX_CTL_HW_80211_ENCAP) {
++		eth = (struct ethhdr *)skb->data;
++		is_mcast = is_multicast_ether_addr(eth->h_dest);
++
++		skb_cb->flags |= ATH12K_SKB_HW_80211_ENCAP;
++	} else if (ieee80211_is_mgmt(hdr->frame_control)) {
++		if (sta && sta->mlo)
++			skb_cb->flags |= ATH12K_SKB_MLO_STA;
++
++		ret = ath12k_mac_mgmt_tx(ar, skb, is_prb_rsp);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to queue management frame %d\n",
++				    ret);
++			ieee80211_free_txskb(hw, skb);
++		}
++		return;
++	}
++
++	if (!(info_flags & IEEE80211_TX_CTL_HW_80211_ENCAP))
++		is_mcast = is_multicast_ether_addr(hdr->addr1);
++
++	/* This is case only for P2P_GO */
++	if (vif->type == NL80211_IFTYPE_AP && vif->p2p)
++		ath12k_mac_add_p2p_noa_ie(ar, vif, skb, is_prb_rsp);
++
++	dp_pdev = ath12k_dp_to_pdev_dp(ar->ab->dp, ar->pdev_idx);
++	if (!dp_pdev) {
++		ieee80211_free_txskb(hw, skb);
++		return;
++	}
++
++	/* Checking if it is a DVLAN frame */
++	if (!test_bit(ATH12K_FLAG_HW_CRYPTO_DISABLED, &ar->ab->dev_flags) &&
++	    !(skb_cb->flags & ATH12K_SKB_HW_80211_ENCAP) &&
++	    !(skb_cb->flags & ATH12K_SKB_CIPHER_SET) &&
++	    ieee80211_has_protected(hdr->frame_control))
++		is_dvlan = true;
++
++	if (!vif->valid_links || !is_mcast || is_dvlan ||
++	    (skb_cb->flags & ATH12K_SKB_HW_80211_ENCAP) ||
++	    test_bit(ATH12K_FLAG_RAW_MODE, &ar->ab->dev_flags)) {
++		ret = ath12k_wifi7_dp_tx(dp_pdev, arvif, skb, false, 0, is_mcast);
++		if (unlikely(ret)) {
++			ath12k_warn(ar->ab, "failed to transmit frame %d\n", ret);
++			ieee80211_free_txskb(ar->ah->hw, skb);
++			return;
++		}
++	} else {
++		mcbc_gsn = atomic_inc_return(&ahvif->dp_vif.mcbc_gsn) & 0xfff;
++
++		links_map = ahvif->links_map;
++		for_each_set_bit(link_id, &links_map,
++				 IEEE80211_MLD_MAX_NUM_LINKS) {
++			tmp_arvif = rcu_dereference(ahvif->link[link_id]);
++			if (!tmp_arvif || !tmp_arvif->is_up)
++				continue;
++
++			tmp_ar = tmp_arvif->ar;
++			tmp_dp_pdev = ath12k_dp_to_pdev_dp(tmp_ar->ab->dp,
++							   tmp_ar->pdev_idx);
++			if (!tmp_dp_pdev)
++				continue;
++			msdu_copied = skb_copy(skb, GFP_ATOMIC);
++			if (!msdu_copied) {
++				ath12k_err(ar->ab,
++					   "skb copy failure link_id 0x%X vdevid 0x%X\n",
++					   link_id, tmp_arvif->vdev_id);
++				continue;
++			}
++
++			ath12k_mlo_mcast_update_tx_link_address(vif, link_id,
++								msdu_copied,
++								info_flags);
++
++			skb_cb = ATH12K_SKB_CB(msdu_copied);
++			skb_cb->link_id = link_id;
++			skb_cb->vif = vif;
++			skb_cb->ar = tmp_ar;
++
++			/* For open mode, skip peer find logic */
++			if (unlikely(!ahvif->dp_vif.key_cipher))
++				goto skip_peer_find;
++
++			tmp_dp = ath12k_ab_to_dp(tmp_ar->ab);
++			spin_lock_bh(&tmp_dp->dp_lock);
++			peer = ath12k_dp_link_peer_find_by_addr(tmp_dp,
++								tmp_arvif->bssid);
++			if (!peer || !peer->dp_peer) {
++				spin_unlock_bh(&tmp_dp->dp_lock);
++				ath12k_warn(tmp_ar->ab,
++					    "failed to find peer for vdev_id 0x%X addr %pM link_map 0x%X\n",
++					    tmp_arvif->vdev_id, tmp_arvif->bssid,
++					    ahvif->links_map);
++				dev_kfree_skb_any(msdu_copied);
++				continue;
++			}
++
++			key = peer->dp_peer->keys[peer->dp_peer->mcast_keyidx];
++			if (key) {
++				skb_cb->cipher = key->cipher;
++				skb_cb->flags |= ATH12K_SKB_CIPHER_SET;
++
++				hdr = (struct ieee80211_hdr *)msdu_copied->data;
++				if (!ieee80211_has_protected(hdr->frame_control))
++					hdr->frame_control |=
++						cpu_to_le16(IEEE80211_FCTL_PROTECTED);
++			}
++			spin_unlock_bh(&tmp_dp->dp_lock);
++
++skip_peer_find:
++			ret = ath12k_wifi7_dp_tx(tmp_dp_pdev, tmp_arvif,
++						 msdu_copied, true, mcbc_gsn, is_mcast);
++			if (unlikely(ret)) {
++				if (ret == -ENOMEM) {
++					/* Drops are expected during heavy multicast
++					 * frame flood. Print with debug log
++					 * level to avoid lot of console prints
++					 */
++					ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++						   "failed to transmit frame %d\n",
++						   ret);
++				} else {
++					ath12k_warn(ar->ab,
++						    "failed to transmit frame %d\n",
++						    ret);
++				}
++
++				dev_kfree_skb_any(msdu_copied);
++			}
++		}
++		ieee80211_free_txskb(ar->ah->hw, skb);
++	}
++}
++
++static const struct ieee80211_ops ath12k_ops_wifi7 = {
++	.tx				= ath12k_wifi7_mac_op_tx,
++	.wake_tx_queue			= ieee80211_handle_wake_tx_queue,
++	.start                          = ath12k_mac_op_start,
++	.stop                           = ath12k_mac_op_stop,
++	.reconfig_complete              = ath12k_mac_op_reconfig_complete,
++	.add_interface                  = ath12k_mac_op_add_interface,
++	.remove_interface		= ath12k_mac_op_remove_interface,
++	.update_vif_offload		= ath12k_mac_op_update_vif_offload,
++	.config                         = ath12k_mac_op_config,
++	.link_info_changed              = ath12k_mac_op_link_info_changed,
++	.vif_cfg_changed		= ath12k_mac_op_vif_cfg_changed,
++	.change_vif_links               = ath12k_mac_op_change_vif_links,
++	.configure_filter		= ath12k_mac_op_configure_filter,
++	.hw_scan                        = ath12k_mac_op_hw_scan,
++	.cancel_hw_scan                 = ath12k_mac_op_cancel_hw_scan,
++	.set_key                        = ath12k_mac_op_set_key,
++	.set_rekey_data	                = ath12k_mac_op_set_rekey_data,
++	.sta_state                      = ath12k_mac_op_sta_state,
++	.sta_set_txpwr			= ath12k_mac_op_sta_set_txpwr,
++	.link_sta_rc_update		= ath12k_mac_op_link_sta_rc_update,
++	.conf_tx                        = ath12k_mac_op_conf_tx,
++	.set_antenna			= ath12k_mac_op_set_antenna,
++	.get_antenna			= ath12k_mac_op_get_antenna,
++	.ampdu_action			= ath12k_mac_op_ampdu_action,
++	.add_chanctx			= ath12k_mac_op_add_chanctx,
++	.remove_chanctx			= ath12k_mac_op_remove_chanctx,
++	.change_chanctx			= ath12k_mac_op_change_chanctx,
++	.assign_vif_chanctx		= ath12k_mac_op_assign_vif_chanctx,
++	.unassign_vif_chanctx		= ath12k_mac_op_unassign_vif_chanctx,
++	.switch_vif_chanctx		= ath12k_mac_op_switch_vif_chanctx,
++	.get_txpower			= ath12k_mac_op_get_txpower,
++	.set_rts_threshold		= ath12k_mac_op_set_rts_threshold,
++	.set_frag_threshold		= ath12k_mac_op_set_frag_threshold,
++	.set_bitrate_mask		= ath12k_mac_op_set_bitrate_mask,
++	.get_survey			= ath12k_mac_op_get_survey,
++	.flush				= ath12k_mac_op_flush,
++	.sta_statistics			= ath12k_mac_op_sta_statistics,
++	.link_sta_statistics		= ath12k_mac_op_link_sta_statistics,
++	.remain_on_channel              = ath12k_mac_op_remain_on_channel,
++	.cancel_remain_on_channel       = ath12k_mac_op_cancel_remain_on_channel,
++	.change_sta_links               = ath12k_mac_op_change_sta_links,
++	.can_activate_links             = ath12k_mac_op_can_activate_links,
++#ifdef CONFIG_PM
++	.suspend			= ath12k_wow_op_suspend,
++	.resume				= ath12k_wow_op_resume,
++	.set_wakeup			= ath12k_wow_op_set_wakeup,
++#endif
++#ifdef CONFIG_ATH12K_DEBUGFS
++	.vif_add_debugfs                = ath12k_debugfs_op_vif_add,
++#endif
++	CFG80211_TESTMODE_CMD(ath12k_tm_cmd)
++#ifdef CONFIG_ATH12K_DEBUGFS
++	.link_sta_add_debugfs           = ath12k_debugfs_link_sta_op_add,
++#endif
++};
++
++int ath12k_wifi7_hw_init(struct ath12k_base *ab)
++{
++	const struct ath12k_hw_params *hw_params = NULL;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(ath12k_wifi7_hw_params); i++) {
++		hw_params = &ath12k_wifi7_hw_params[i];
++
++		if (hw_params->hw_rev == ab->hw_rev)
++			break;
++	}
++
++	if (i == ARRAY_SIZE(ath12k_wifi7_hw_params)) {
++		ath12k_err(ab, "Unsupported Wi-Fi 7 hardware version: 0x%x\n",
++			   ab->hw_rev);
++		return -EINVAL;
++	}
++
++	ab->hw_params = hw_params;
++	ab->ath12k_ops = &ath12k_ops_wifi7;
++
++	ath12k_wifi7_hal_init(ab);
++
++	ath12k_info(ab, "Wi-Fi 7 Hardware name: %s\n", ab->hw_params->name);
++
++	return 0;
++}
+diff --git a/drivers/pmdomain/qcom/rpmhpd.c.orig b/drivers/pmdomain/qcom/rpmhpd.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/pmdomain/qcom/rpmhpd.c.orig
+@@ -0,0 +1,1205 @@
++// SPDX-License-Identifier: GPL-2.0
++/* Copyright (c) 2018, The Linux Foundation. All rights reserved.*/
++
++#include <linux/cleanup.h>
++#include <linux/err.h>
++#include <linux/init.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/mutex.h>
++#include <linux/pm_domain.h>
++#include <linux/slab.h>
++#include <linux/of.h>
++#include <linux/platform_device.h>
++#include <linux/pm_opp.h>
++#include <soc/qcom/cmd-db.h>
++#include <soc/qcom/rpmh.h>
++#include <dt-bindings/power/qcom-rpmpd.h>
++#include <dt-bindings/power/qcom,rpmhpd.h>
++
++#define domain_to_rpmhpd(domain) container_of(domain, struct rpmhpd, pd)
++
++#define RPMH_ARC_MAX_LEVELS	32
++
++/**
++ * struct rpmhpd - top level RPMh power domain resource data structure
++ * @dev:		rpmh power domain controller device
++ * @pd:			generic_pm_domain corresponding to the power domain
++ * @parent:		generic_pm_domain corresponding to the parent's power domain
++ * @peer:		A peer power domain in case Active only Voting is
++ *			supported
++ * @active_only:	True if it represents an Active only peer
++ * @corner:		current corner
++ * @active_corner:	current active corner
++ * @enable_corner:	lowest non-zero corner
++ * @level:		An array of level (vlvl) to corner (hlvl) mappings
++ *			derived from cmd-db
++ * @level_count:	Number of levels supported by the power domain. max
++ *			being 16 (0 - 15)
++ * @enabled:		true if the power domain is enabled
++ * @res_name:		Resource name used for cmd-db lookup
++ * @addr:		Resource address as looped up using resource name from
++ *			cmd-db
++ * @state_synced:	Indicator that sync_state has been invoked for the rpmhpd resource
++ * @skip_retention_level: Indicate that retention level should not be used for the power domain
++ */
++struct rpmhpd {
++	struct device	*dev;
++	struct generic_pm_domain pd;
++	struct generic_pm_domain *parent;
++	struct rpmhpd	*peer;
++	const bool	active_only;
++	unsigned int	corner;
++	unsigned int	active_corner;
++	unsigned int	enable_corner;
++	u32		level[RPMH_ARC_MAX_LEVELS];
++	size_t		level_count;
++	bool		enabled;
++	const char	*res_name;
++	u32		addr;
++	bool		state_synced;
++	bool            skip_retention_level;
++};
++
++struct rpmhpd_desc {
++	struct rpmhpd **rpmhpds;
++	size_t num_pds;
++};
++
++static DEFINE_MUTEX(rpmhpd_lock);
++
++/* RPMH powerdomains */
++
++static struct rpmhpd cx_ao;
++static struct rpmhpd mx;
++static struct rpmhpd mx_ao;
++static struct rpmhpd cx = {
++	.pd = { .name = "cx", },
++	.peer = &cx_ao,
++	.res_name = "cx.lvl",
++};
++
++static struct rpmhpd cx_ao = {
++	.pd = { .name = "cx_ao", },
++	.active_only = true,
++	.peer = &cx,
++	.res_name = "cx.lvl",
++};
++
++static struct rpmhpd cx_ao_w_mx_parent;
++static struct rpmhpd cx_w_mx_parent = {
++	.pd = { .name = "cx", },
++	.peer = &cx_ao_w_mx_parent,
++	.parent = &mx.pd,
++	.res_name = "cx.lvl",
++};
++
++static struct rpmhpd cx_ao_w_mx_parent = {
++	.pd = { .name = "cx_ao", },
++	.active_only = true,
++	.peer = &cx_w_mx_parent,
++	.parent = &mx_ao.pd,
++	.res_name = "cx.lvl",
++};
++
++static struct rpmhpd dcx = {
++	.pd = { .name = "dcx", },
++	.res_name = "dcx.lvl",
++};
++
++static struct rpmhpd ebi = {
++	.pd = { .name = "ebi", },
++	.res_name = "ebi.lvl",
++};
++
++static struct rpmhpd gbx = {
++	.pd = { .name = "gbx", },
++	.res_name = "gbx.lvl",
++};
++
++static struct rpmhpd gfx = {
++	.pd = { .name = "gfx", },
++	.res_name = "gfx.lvl",
++};
++
++static struct rpmhpd lcx = {
++	.pd = { .name = "lcx", },
++	.res_name = "lcx.lvl",
++};
++
++static struct rpmhpd lmx = {
++	.pd = { .name = "lmx", },
++	.res_name = "lmx.lvl",
++};
++
++static struct rpmhpd mmcx_ao;
++static struct rpmhpd mmcx = {
++	.pd = { .name = "mmcx", },
++	.peer = &mmcx_ao,
++	.res_name = "mmcx.lvl",
++};
++
++static struct rpmhpd mmcx_ao = {
++	.pd = { .name = "mmcx_ao", },
++	.active_only = true,
++	.peer = &mmcx,
++	.res_name = "mmcx.lvl",
++};
++
++static struct rpmhpd mmcx_ao_w_cx_parent;
++static struct rpmhpd mmcx_w_cx_parent = {
++	.pd = { .name = "mmcx", },
++	.peer = &mmcx_ao_w_cx_parent,
++	.parent = &cx.pd,
++	.res_name = "mmcx.lvl",
++};
++
++static struct rpmhpd mmcx_ao_w_cx_parent = {
++	.pd = { .name = "mmcx_ao", },
++	.active_only = true,
++	.peer = &mmcx_w_cx_parent,
++	.parent = &cx_ao.pd,
++	.res_name = "mmcx.lvl",
++};
++
++static struct rpmhpd mss = {
++	.pd = { .name = "mss", },
++	.res_name = "mss.lvl",
++};
++
++static struct rpmhpd mx_ao;
++static struct rpmhpd mx = {
++	.pd = { .name = "mx", },
++	.peer = &mx_ao,
++	.res_name = "mx.lvl",
++};
++
++static struct rpmhpd mx_ao = {
++	.pd = { .name = "mx_ao", },
++	.active_only = true,
++	.peer = &mx,
++	.res_name = "mx.lvl",
++};
++
++static struct rpmhpd mxc_ao;
++static struct rpmhpd mxc = {
++	.pd = { .name = "mxc", },
++	.peer = &mxc_ao,
++	.res_name = "mxc.lvl",
++	.skip_retention_level = true,
++};
++
++static struct rpmhpd mxc_ao = {
++	.pd = { .name = "mxc_ao", },
++	.active_only = true,
++	.peer = &mxc,
++	.res_name = "mxc.lvl",
++	.skip_retention_level = true,
++};
++
++static struct rpmhpd nsp = {
++	.pd = { .name = "nsp", },
++	.res_name = "nsp.lvl",
++};
++
++static struct rpmhpd nsp0 = {
++	.pd = { .name = "nsp0", },
++	.res_name = "nsp0.lvl",
++};
++
++static struct rpmhpd nsp1 = {
++	.pd = { .name = "nsp1", },
++	.res_name = "nsp1.lvl",
++};
++
++static struct rpmhpd nsp2 = {
++	.pd = { .name = "nsp2", },
++	.res_name = "nsp2.lvl",
++};
++
++static struct rpmhpd qphy = {
++	.pd = { .name = "qphy", },
++	.res_name = "qphy.lvl",
++};
++
++static struct rpmhpd gmxc = {
++	.pd = { .name = "gmxc", },
++	.res_name = "gmxc.lvl",
++};
++
++/* Eliza RPMH powerdomains */
++static struct rpmhpd *eliza_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MMCX] = &mmcx,
++	[RPMHPD_MMCX_AO] = &mmcx_ao,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_MXC_AO] = &mxc_ao,
++	[RPMHPD_NSP] = &nsp,
++};
++
++static const struct rpmhpd_desc eliza_desc = {
++	.rpmhpds = eliza_rpmhpds,
++	.num_pds = ARRAY_SIZE(eliza_rpmhpds),
++};
++
++/* Milos RPMH powerdomains */
++static struct rpmhpd *milos_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++};
++
++static const struct rpmhpd_desc milos_desc = {
++	.rpmhpds = milos_rpmhpds,
++	.num_pds = ARRAY_SIZE(milos_rpmhpds),
++};
++
++/* SA8540P RPMH powerdomains */
++static struct rpmhpd *sa8540p_rpmhpds[] = {
++	[SC8280XP_CX] = &cx,
++	[SC8280XP_CX_AO] = &cx_ao,
++	[SC8280XP_EBI] = &ebi,
++	[SC8280XP_LCX] = &lcx,
++	[SC8280XP_LMX] = &lmx,
++	[SC8280XP_MMCX] = &mmcx,
++	[SC8280XP_MMCX_AO] = &mmcx_ao,
++	[SC8280XP_MX] = &mx,
++	[SC8280XP_MX_AO] = &mx_ao,
++	[SC8280XP_MXC] = &mxc,
++	[SC8280XP_MXC_AO] = &mxc_ao,
++	[SC8280XP_NSP] = &nsp,
++};
++
++static const struct rpmhpd_desc sa8540p_desc = {
++	.rpmhpds = sa8540p_rpmhpds,
++	.num_pds = ARRAY_SIZE(sa8540p_rpmhpds),
++};
++
++/* SA8775P RPMH power domains */
++static struct rpmhpd *sa8775p_rpmhpds[] = {
++	[SA8775P_CX] = &cx,
++	[SA8775P_CX_AO] = &cx_ao,
++	[SA8775P_EBI] = &ebi,
++	[SA8775P_GFX] = &gfx,
++	[SA8775P_LCX] = &lcx,
++	[SA8775P_LMX] = &lmx,
++	[SA8775P_MMCX] = &mmcx,
++	[SA8775P_MMCX_AO] = &mmcx_ao,
++	[SA8775P_MXC] = &mxc,
++	[SA8775P_MXC_AO] = &mxc_ao,
++	[SA8775P_MX] = &mx,
++	[SA8775P_MX_AO] = &mx_ao,
++	[SA8775P_NSP0] = &nsp0,
++	[SA8775P_NSP1] = &nsp1,
++};
++
++static const struct rpmhpd_desc sa8775p_desc = {
++	.rpmhpds = sa8775p_rpmhpds,
++	.num_pds = ARRAY_SIZE(sa8775p_rpmhpds),
++};
++
++/* SAR2130P RPMH powerdomains */
++static struct rpmhpd *sar2130p_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MMCX] = &mmcx_w_cx_parent,
++	[RPMHPD_MMCX_AO] = &mmcx_ao_w_cx_parent,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_MXC_AO] = &mxc_ao,
++	[RPMHPD_NSP] = &nsp,
++	[RPMHPD_QPHY] = &qphy,
++};
++
++static const struct rpmhpd_desc sar2130p_desc = {
++	.rpmhpds = sar2130p_rpmhpds,
++	.num_pds = ARRAY_SIZE(sar2130p_rpmhpds),
++};
++
++/* SDM670 RPMH powerdomains */
++static struct rpmhpd *sdm670_rpmhpds[] = {
++	[SDM670_CX] = &cx_w_mx_parent,
++	[SDM670_CX_AO] = &cx_ao_w_mx_parent,
++	[SDM670_GFX] = &gfx,
++	[SDM670_LCX] = &lcx,
++	[SDM670_LMX] = &lmx,
++	[SDM670_MSS] = &mss,
++	[SDM670_MX] = &mx,
++	[SDM670_MX_AO] = &mx_ao,
++};
++
++static const struct rpmhpd_desc sdm670_desc = {
++	.rpmhpds = sdm670_rpmhpds,
++	.num_pds = ARRAY_SIZE(sdm670_rpmhpds),
++};
++
++/* SDM845 RPMH powerdomains */
++static struct rpmhpd *sdm845_rpmhpds[] = {
++	[SDM845_CX] = &cx_w_mx_parent,
++	[SDM845_CX_AO] = &cx_ao_w_mx_parent,
++	[SDM845_EBI] = &ebi,
++	[SDM845_GFX] = &gfx,
++	[SDM845_LCX] = &lcx,
++	[SDM845_LMX] = &lmx,
++	[SDM845_MSS] = &mss,
++	[SDM845_MX] = &mx,
++	[SDM845_MX_AO] = &mx_ao,
++};
++
++static const struct rpmhpd_desc sdm845_desc = {
++	.rpmhpds = sdm845_rpmhpds,
++	.num_pds = ARRAY_SIZE(sdm845_rpmhpds),
++};
++
++/* SDX55 RPMH powerdomains */
++static struct rpmhpd *sdx55_rpmhpds[] = {
++	[SDX55_CX] = &cx_w_mx_parent,
++	[SDX55_MSS] = &mss,
++	[SDX55_MX] = &mx,
++};
++
++static const struct rpmhpd_desc sdx55_desc = {
++	.rpmhpds = sdx55_rpmhpds,
++	.num_pds = ARRAY_SIZE(sdx55_rpmhpds),
++};
++
++/* SDX65 RPMH powerdomains */
++static struct rpmhpd *sdx65_rpmhpds[] = {
++	[SDX65_CX] = &cx_w_mx_parent,
++	[SDX65_CX_AO] = &cx_ao_w_mx_parent,
++	[SDX65_MSS] = &mss,
++	[SDX65_MX] = &mx,
++	[SDX65_MX_AO] = &mx_ao,
++	[SDX65_MXC] = &mxc,
++};
++
++static const struct rpmhpd_desc sdx65_desc = {
++	.rpmhpds = sdx65_rpmhpds,
++	.num_pds = ARRAY_SIZE(sdx65_rpmhpds),
++};
++
++/* SDX75 RPMH powerdomains */
++static struct rpmhpd *sdx75_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MXC] = &mxc,
++};
++
++static const struct rpmhpd_desc sdx75_desc = {
++	.rpmhpds = sdx75_rpmhpds,
++	.num_pds = ARRAY_SIZE(sdx75_rpmhpds),
++};
++
++/* SM4450 RPMH powerdomains */
++static struct rpmhpd *sm4450_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_MX] = &mx,
++};
++
++static const struct rpmhpd_desc sm4450_desc = {
++	.rpmhpds = sm4450_rpmhpds,
++	.num_pds = ARRAY_SIZE(sm4450_rpmhpds),
++};
++
++/* SM6350 RPMH powerdomains */
++static struct rpmhpd *sm6350_rpmhpds[] = {
++	[SM6350_CX] = &cx_w_mx_parent,
++	[SM6350_GFX] = &gfx,
++	[SM6350_LCX] = &lcx,
++	[SM6350_LMX] = &lmx,
++	[SM6350_MSS] = &mss,
++	[SM6350_MX] = &mx,
++};
++
++static const struct rpmhpd_desc sm6350_desc = {
++	.rpmhpds = sm6350_rpmhpds,
++	.num_pds = ARRAY_SIZE(sm6350_rpmhpds),
++};
++
++/* SM7150 RPMH powerdomains */
++static struct rpmhpd *sm7150_rpmhpds[] = {
++	[RPMHPD_CX] = &cx_w_mx_parent,
++	[RPMHPD_CX_AO] = &cx_ao_w_mx_parent,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MSS] = &mss,
++};
++
++static const struct rpmhpd_desc sm7150_desc = {
++	.rpmhpds = sm7150_rpmhpds,
++	.num_pds = ARRAY_SIZE(sm7150_rpmhpds),
++};
++
++/* SM8150 RPMH powerdomains */
++static struct rpmhpd *sm8150_rpmhpds[] = {
++	[SM8150_CX] = &cx_w_mx_parent,
++	[SM8150_CX_AO] = &cx_ao_w_mx_parent,
++	[SM8150_EBI] = &ebi,
++	[SM8150_GFX] = &gfx,
++	[SM8150_LCX] = &lcx,
++	[SM8150_LMX] = &lmx,
++	[SM8150_MMCX] = &mmcx,
++	[SM8150_MMCX_AO] = &mmcx_ao,
++	[SM8150_MSS] = &mss,
++	[SM8150_MX] = &mx,
++	[SM8150_MX_AO] = &mx_ao,
++};
++
++static const struct rpmhpd_desc sm8150_desc = {
++	.rpmhpds = sm8150_rpmhpds,
++	.num_pds = ARRAY_SIZE(sm8150_rpmhpds),
++};
++
++static struct rpmhpd *sa8155p_rpmhpds[] = {
++	[SA8155P_CX] = &cx_w_mx_parent,
++	[SA8155P_CX_AO] = &cx_ao_w_mx_parent,
++	[SA8155P_EBI] = &ebi,
++	[SA8155P_GFX] = &gfx,
++	[SA8155P_MSS] = &mss,
++	[SA8155P_MX] = &mx,
++	[SA8155P_MX_AO] = &mx_ao,
++};
++
++static const struct rpmhpd_desc sa8155p_desc = {
++	.rpmhpds = sa8155p_rpmhpds,
++	.num_pds = ARRAY_SIZE(sa8155p_rpmhpds),
++};
++
++/* SM8250 RPMH powerdomains */
++static struct rpmhpd *sm8250_rpmhpds[] = {
++	[RPMHPD_CX] = &cx_w_mx_parent,
++	[RPMHPD_CX_AO] = &cx_ao_w_mx_parent,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MMCX] = &mmcx,
++	[RPMHPD_MMCX_AO] = &mmcx_ao,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++};
++
++static const struct rpmhpd_desc sm8250_desc = {
++	.rpmhpds = sm8250_rpmhpds,
++	.num_pds = ARRAY_SIZE(sm8250_rpmhpds),
++};
++
++/* SM8350 Power domains */
++static struct rpmhpd *sm8350_rpmhpds[] = {
++	[RPMHPD_CX] = &cx_w_mx_parent,
++	[RPMHPD_CX_AO] = &cx_ao_w_mx_parent,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MMCX] = &mmcx,
++	[RPMHPD_MMCX_AO] = &mmcx_ao,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_MXC_AO] = &mxc_ao,
++};
++
++static const struct rpmhpd_desc sm8350_desc = {
++	.rpmhpds = sm8350_rpmhpds,
++	.num_pds = ARRAY_SIZE(sm8350_rpmhpds),
++};
++
++/* SM8450 RPMH powerdomains */
++static struct rpmhpd *sm8450_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MMCX] = &mmcx_w_cx_parent,
++	[RPMHPD_MMCX_AO] = &mmcx_ao_w_cx_parent,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_MXC_AO] = &mxc_ao,
++};
++
++static const struct rpmhpd_desc sm8450_desc = {
++	.rpmhpds = sm8450_rpmhpds,
++	.num_pds = ARRAY_SIZE(sm8450_rpmhpds),
++};
++
++/* SM8550 RPMH powerdomains */
++static struct rpmhpd *sm8550_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MMCX] = &mmcx_w_cx_parent,
++	[RPMHPD_MMCX_AO] = &mmcx_ao_w_cx_parent,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_MXC_AO] = &mxc_ao,
++	[RPMHPD_NSP] = &nsp,
++};
++
++static const struct rpmhpd_desc sm8550_desc = {
++	.rpmhpds = sm8550_rpmhpds,
++	.num_pds = ARRAY_SIZE(sm8550_rpmhpds),
++};
++
++/* SM8650 RPMH powerdomains */
++static struct rpmhpd *sm8650_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MMCX] = &mmcx_w_cx_parent,
++	[RPMHPD_MMCX_AO] = &mmcx_ao_w_cx_parent,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_MXC_AO] = &mxc_ao,
++	[RPMHPD_NSP] = &nsp,
++	[RPMHPD_NSP2] = &nsp2,
++};
++
++static const struct rpmhpd_desc sm8650_desc = {
++	.rpmhpds = sm8650_rpmhpds,
++	.num_pds = ARRAY_SIZE(sm8650_rpmhpds),
++};
++
++/* SM8750 RPMH powerdomains */
++static struct rpmhpd *sm8750_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_GMXC] = &gmxc,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MMCX] = &mmcx_w_cx_parent,
++	[RPMHPD_MMCX_AO] = &mmcx_ao_w_cx_parent,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_MXC_AO] = &mxc_ao,
++	[RPMHPD_NSP] = &nsp,
++	[RPMHPD_NSP2] = &nsp2,
++};
++
++static const struct rpmhpd_desc sm8750_desc = {
++	.rpmhpds = sm8750_rpmhpds,
++	.num_pds = ARRAY_SIZE(sm8750_rpmhpds),
++};
++
++/* KAANAPALI RPMH powerdomains */
++static struct rpmhpd *kaanapali_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_GMXC] = &gmxc,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MMCX] = &mmcx,
++	[RPMHPD_MMCX_AO] = &mmcx_ao,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_MXC_AO] = &mxc_ao,
++	[RPMHPD_NSP] = &nsp,
++	[RPMHPD_NSP2] = &nsp2,
++};
++
++static const struct rpmhpd_desc kaanapali_desc = {
++	.rpmhpds = kaanapali_rpmhpds,
++	.num_pds = ARRAY_SIZE(kaanapali_rpmhpds),
++};
++
++/* Hawi RPMH powerdomains */
++static struct rpmhpd *hawi_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_DCX] = &dcx,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GBX] = &gbx,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_GMXC] = &gmxc,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MMCX] = &mmcx,
++	[RPMHPD_MMCX_AO] = &mmcx_ao,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_MXC_AO] = &mxc_ao,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_NSP] = &nsp,
++	[RPMHPD_NSP2] = &nsp2,
++};
++
++static const struct rpmhpd_desc hawi_desc = {
++	.rpmhpds = hawi_rpmhpds,
++	.num_pds = ARRAY_SIZE(hawi_rpmhpds),
++};
++
++/* QDU1000/QRU1000 RPMH powerdomains */
++static struct rpmhpd *qdu1000_rpmhpds[] = {
++	[QDU1000_CX] = &cx,
++	[QDU1000_EBI] = &ebi,
++	[QDU1000_MSS] = &mss,
++	[QDU1000_MX] = &mx,
++};
++
++static const struct rpmhpd_desc qdu1000_desc = {
++	.rpmhpds = qdu1000_rpmhpds,
++	.num_pds = ARRAY_SIZE(qdu1000_rpmhpds),
++};
++
++/* SC7180 RPMH powerdomains */
++static struct rpmhpd *sc7180_rpmhpds[] = {
++	[SC7180_CX] = &cx_w_mx_parent,
++	[SC7180_CX_AO] = &cx_ao_w_mx_parent,
++	[SC7180_GFX] = &gfx,
++	[SC7180_LCX] = &lcx,
++	[SC7180_LMX] = &lmx,
++	[SC7180_MSS] = &mss,
++	[SC7180_MX] = &mx,
++	[SC7180_MX_AO] = &mx_ao,
++};
++
++static const struct rpmhpd_desc sc7180_desc = {
++	.rpmhpds = sc7180_rpmhpds,
++	.num_pds = ARRAY_SIZE(sc7180_rpmhpds),
++};
++
++/* SC7280 RPMH powerdomains */
++static struct rpmhpd *sc7280_rpmhpds[] = {
++	[SC7280_CX] = &cx,
++	[SC7280_CX_AO] = &cx_ao,
++	[SC7280_EBI] = &ebi,
++	[SC7280_GFX] = &gfx,
++	[SC7280_LCX] = &lcx,
++	[SC7280_LMX] = &lmx,
++	[SC7280_MSS] = &mss,
++	[SC7280_MX] = &mx,
++	[SC7280_MX_AO] = &mx_ao,
++};
++
++static const struct rpmhpd_desc sc7280_desc = {
++	.rpmhpds = sc7280_rpmhpds,
++	.num_pds = ARRAY_SIZE(sc7280_rpmhpds),
++};
++
++/* SC8180x RPMH powerdomains */
++static struct rpmhpd *sc8180x_rpmhpds[] = {
++	[SC8180X_CX] = &cx_w_mx_parent,
++	[SC8180X_CX_AO] = &cx_ao_w_mx_parent,
++	[SC8180X_EBI] = &ebi,
++	[SC8180X_GFX] = &gfx,
++	[SC8180X_LCX] = &lcx,
++	[SC8180X_LMX] = &lmx,
++	[SC8180X_MMCX] = &mmcx,
++	[SC8180X_MMCX_AO] = &mmcx_ao,
++	[SC8180X_MSS] = &mss,
++	[SC8180X_MX] = &mx,
++	[SC8180X_MX_AO] = &mx_ao,
++};
++
++static const struct rpmhpd_desc sc8180x_desc = {
++	.rpmhpds = sc8180x_rpmhpds,
++	.num_pds = ARRAY_SIZE(sc8180x_rpmhpds),
++};
++
++/* SC8280xp RPMH powerdomains */
++static struct rpmhpd *sc8280xp_rpmhpds[] = {
++	[SC8280XP_CX] = &cx,
++	[SC8280XP_CX_AO] = &cx_ao,
++	[SC8280XP_EBI] = &ebi,
++	[SC8280XP_GFX] = &gfx,
++	[SC8280XP_LCX] = &lcx,
++	[SC8280XP_LMX] = &lmx,
++	[SC8280XP_MMCX] = &mmcx,
++	[SC8280XP_MMCX_AO] = &mmcx_ao,
++	[SC8280XP_MX] = &mx,
++	[SC8280XP_MX_AO] = &mx_ao,
++	[SC8280XP_MXC] = &mxc,
++	[SC8280XP_MXC_AO] = &mxc_ao,
++	[SC8280XP_NSP] = &nsp,
++	[SC8280XP_QPHY] = &qphy,
++};
++
++static const struct rpmhpd_desc sc8280xp_desc = {
++	.rpmhpds = sc8280xp_rpmhpds,
++	.num_pds = ARRAY_SIZE(sc8280xp_rpmhpds),
++};
++
++/* Glymur RPMH powerdomains */
++static struct rpmhpd *glymur_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MMCX] = &mmcx,
++	[RPMHPD_MMCX_AO] = &mmcx_ao,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_MXC_AO] = &mxc_ao,
++	[RPMHPD_MSS] = &mss,
++	[RPMHPD_NSP] = &nsp,
++	[RPMHPD_NSP2] = &nsp2,
++	[RPMHPD_GMXC] = &gmxc,
++};
++
++static const struct rpmhpd_desc glymur_desc = {
++	.rpmhpds = glymur_rpmhpds,
++	.num_pds = ARRAY_SIZE(glymur_rpmhpds),
++};
++
++/* X1E80100 RPMH powerdomains */
++static struct rpmhpd *x1e80100_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MMCX] = &mmcx,
++	[RPMHPD_MMCX_AO] = &mmcx_ao,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_NSP] = &nsp,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_GMXC] = &gmxc,
++};
++
++static const struct rpmhpd_desc x1e80100_desc = {
++	.rpmhpds = x1e80100_rpmhpds,
++	.num_pds = ARRAY_SIZE(x1e80100_rpmhpds),
++};
++
++/* QCS8300 RPMH power domains */
++static struct rpmhpd *qcs8300_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++	[RPMHPD_EBI] = &ebi,
++	[RPMHPD_GFX] = &gfx,
++	[RPMHPD_LCX] = &lcx,
++	[RPMHPD_LMX] = &lmx,
++	[RPMHPD_MMCX] = &mmcx_w_cx_parent,
++	[RPMHPD_MMCX_AO] = &mmcx_ao_w_cx_parent,
++	[RPMHPD_MXC] = &mxc,
++	[RPMHPD_MXC_AO] = &mxc_ao,
++	[RPMHPD_MX] = &mx,
++	[RPMHPD_MX_AO] = &mx_ao,
++	[RPMHPD_NSP0] = &nsp0,
++	[RPMHPD_NSP1] = &nsp1,
++};
++
++static const struct rpmhpd_desc qcs8300_desc = {
++	.rpmhpds = qcs8300_rpmhpds,
++	.num_pds = ARRAY_SIZE(qcs8300_rpmhpds),
++};
++
++/* QCS615 RPMH powerdomains */
++static struct rpmhpd *qcs615_rpmhpds[] = {
++	[RPMHPD_CX] = &cx,
++	[RPMHPD_CX_AO] = &cx_ao,
++};
++
++static const struct rpmhpd_desc qcs615_desc = {
++	.rpmhpds = qcs615_rpmhpds,
++	.num_pds = ARRAY_SIZE(qcs615_rpmhpds),
++};
++
++static const struct of_device_id rpmhpd_match_table[] = {
++	{ .compatible = "qcom,eliza-rpmhpd", .data = &eliza_desc },
++	{ .compatible = "qcom,glymur-rpmhpd", .data = &glymur_desc },
++	{ .compatible = "qcom,hawi-rpmhpd", .data = &hawi_desc },
++	{ .compatible = "qcom,kaanapali-rpmhpd", .data = &kaanapali_desc },
++	{ .compatible = "qcom,milos-rpmhpd", .data = &milos_desc },
++	{ .compatible = "qcom,qcs615-rpmhpd", .data = &qcs615_desc },
++	{ .compatible = "qcom,qcs8300-rpmhpd", .data = &qcs8300_desc },
++	{ .compatible = "qcom,qdu1000-rpmhpd", .data = &qdu1000_desc },
++	{ .compatible = "qcom,sa8155p-rpmhpd", .data = &sa8155p_desc },
++	{ .compatible = "qcom,sa8540p-rpmhpd", .data = &sa8540p_desc },
++	{ .compatible = "qcom,sa8775p-rpmhpd", .data = &sa8775p_desc },
++	{ .compatible = "qcom,sar2130p-rpmhpd", .data = &sar2130p_desc},
++	{ .compatible = "qcom,sc7180-rpmhpd", .data = &sc7180_desc },
++	{ .compatible = "qcom,sc7280-rpmhpd", .data = &sc7280_desc },
++	{ .compatible = "qcom,sc8180x-rpmhpd", .data = &sc8180x_desc },
++	{ .compatible = "qcom,sc8280xp-rpmhpd", .data = &sc8280xp_desc },
++	{ .compatible = "qcom,sdm670-rpmhpd", .data = &sdm670_desc },
++	{ .compatible = "qcom,sdm845-rpmhpd", .data = &sdm845_desc },
++	{ .compatible = "qcom,sdx55-rpmhpd", .data = &sdx55_desc},
++	{ .compatible = "qcom,sdx65-rpmhpd", .data = &sdx65_desc},
++	{ .compatible = "qcom,sdx75-rpmhpd", .data = &sdx75_desc},
++	{ .compatible = "qcom,sm4450-rpmhpd", .data = &sm4450_desc },
++	{ .compatible = "qcom,sm6350-rpmhpd", .data = &sm6350_desc },
++	{ .compatible = "qcom,sm7150-rpmhpd", .data = &sm7150_desc },
++	{ .compatible = "qcom,sm8150-rpmhpd", .data = &sm8150_desc },
++	{ .compatible = "qcom,sm8250-rpmhpd", .data = &sm8250_desc },
++	{ .compatible = "qcom,sm8350-rpmhpd", .data = &sm8350_desc },
++	{ .compatible = "qcom,sm8450-rpmhpd", .data = &sm8450_desc },
++	{ .compatible = "qcom,sm8550-rpmhpd", .data = &sm8550_desc },
++	{ .compatible = "qcom,sm8650-rpmhpd", .data = &sm8650_desc },
++	{ .compatible = "qcom,sm8750-rpmhpd", .data = &sm8750_desc },
++	{ .compatible = "qcom,x1e80100-rpmhpd", .data = &x1e80100_desc },
++	{ }
++};
++MODULE_DEVICE_TABLE(of, rpmhpd_match_table);
++
++static int rpmhpd_send_corner(struct rpmhpd *pd, int state,
++			      unsigned int corner, bool sync)
++{
++	struct tcs_cmd cmd = {
++		.addr = pd->addr,
++		.data = corner,
++	};
++
++	/*
++	 * Wait for an ack only when we are increasing the
++	 * perf state of the power domain
++	 */
++	if (sync)
++		return rpmh_write(pd->dev, state, &cmd, 1);
++	else
++		return rpmh_write_async(pd->dev, state, &cmd, 1);
++}
++
++static void to_active_sleep(struct rpmhpd *pd, unsigned int corner,
++			    unsigned int *active, unsigned int *sleep)
++{
++	*active = corner;
++
++	if (pd->active_only)
++		*sleep = 0;
++	else
++		*sleep = *active;
++}
++
++/*
++ * This function is used to aggregate the votes across the active only
++ * resources and its peers. The aggregated votes are sent to RPMh as
++ * ACTIVE_ONLY votes (which take effect immediately), as WAKE_ONLY votes
++ * (applied by RPMh on system wakeup) and as SLEEP votes (applied by RPMh
++ * on system sleep).
++ * We send ACTIVE_ONLY votes for resources without any peers. For others,
++ * which have an active only peer, all 3 votes are sent.
++ */
++static int rpmhpd_aggregate_corner(struct rpmhpd *pd, unsigned int corner)
++{
++	int ret;
++	struct rpmhpd *peer = pd->peer;
++	unsigned int active_corner, sleep_corner;
++	unsigned int this_active_corner = 0, this_sleep_corner = 0;
++	unsigned int peer_active_corner = 0, peer_sleep_corner = 0;
++	unsigned int peer_enabled_corner;
++
++	if (pd->state_synced) {
++		to_active_sleep(pd, corner, &this_active_corner, &this_sleep_corner);
++	} else {
++		/* Clamp to highest corner if sync_state hasn't happened */
++		this_active_corner = pd->level_count - 1;
++		this_sleep_corner = pd->level_count - 1;
++	}
++
++	if (peer && peer->enabled) {
++		peer_enabled_corner = max(peer->corner, peer->enable_corner);
++		to_active_sleep(peer, peer_enabled_corner, &peer_active_corner,
++				&peer_sleep_corner);
++	}
++
++	active_corner = max(this_active_corner, peer_active_corner);
++
++	ret = rpmhpd_send_corner(pd, RPMH_ACTIVE_ONLY_STATE, active_corner,
++				 active_corner > pd->active_corner);
++	if (ret)
++		return ret;
++
++	pd->active_corner = active_corner;
++
++	if (peer) {
++		peer->active_corner = active_corner;
++
++		ret = rpmhpd_send_corner(pd, RPMH_WAKE_ONLY_STATE,
++					 active_corner, false);
++		if (ret)
++			return ret;
++
++		sleep_corner = max(this_sleep_corner, peer_sleep_corner);
++
++		return rpmhpd_send_corner(pd, RPMH_SLEEP_STATE, sleep_corner,
++					  false);
++	}
++
++	return ret;
++}
++
++static int rpmhpd_power_on(struct generic_pm_domain *domain)
++{
++	struct rpmhpd *pd = domain_to_rpmhpd(domain);
++	unsigned int corner;
++	int ret;
++
++	mutex_lock(&rpmhpd_lock);
++
++	corner = max(pd->corner, pd->enable_corner);
++	ret = rpmhpd_aggregate_corner(pd, corner);
++	if (!ret)
++		pd->enabled = true;
++
++	mutex_unlock(&rpmhpd_lock);
++
++	return ret;
++}
++
++static int rpmhpd_power_off(struct generic_pm_domain *domain)
++{
++	struct rpmhpd *pd = domain_to_rpmhpd(domain);
++	int ret;
++
++	mutex_lock(&rpmhpd_lock);
++
++	ret = rpmhpd_aggregate_corner(pd, 0);
++	if (!ret)
++		pd->enabled = false;
++
++	mutex_unlock(&rpmhpd_lock);
++
++	return ret;
++}
++
++static int rpmhpd_set_performance_state(struct generic_pm_domain *domain,
++					unsigned int level)
++{
++	struct rpmhpd *pd = domain_to_rpmhpd(domain);
++	int ret, i;
++
++	guard(mutex)(&rpmhpd_lock);
++
++	for (i = 0; i < pd->level_count; i++)
++		if (level <= pd->level[i])
++			break;
++
++	/*
++	 * If the level requested is more than that supported by the
++	 * max corner, just set it to max anyway.
++	 */
++	if (i == pd->level_count)
++		i--;
++
++	if (pd->enabled) {
++		/* Ensure that the domain isn't turn off */
++		if (i < pd->enable_corner)
++			i = pd->enable_corner;
++
++		ret = rpmhpd_aggregate_corner(pd, i);
++		if (ret)
++			return ret;
++	}
++
++	pd->corner = i;
++
++	return 0;
++}
++
++static int rpmhpd_update_level_mapping(struct rpmhpd *rpmhpd)
++{
++	int i;
++	const u16 *buf;
++
++	buf = cmd_db_read_aux_data(rpmhpd->res_name, &rpmhpd->level_count);
++	if (IS_ERR(buf))
++		return PTR_ERR(buf);
++
++	/* 2 bytes used for each command DB aux data entry */
++	rpmhpd->level_count >>= 1;
++
++	if (rpmhpd->level_count > RPMH_ARC_MAX_LEVELS)
++		return -EINVAL;
++
++	for (i = 0; i < rpmhpd->level_count; i++) {
++		if (rpmhpd->skip_retention_level && buf[i] == RPMH_REGULATOR_LEVEL_RETENTION)
++			continue;
++
++		rpmhpd->level[i] = buf[i];
++
++		/* Remember the first corner with non-zero level */
++		if (!rpmhpd->level[rpmhpd->enable_corner] && rpmhpd->level[i])
++			rpmhpd->enable_corner = i;
++
++		/*
++		 * The AUX data may be zero padded.  These 0 valued entries at
++		 * the end of the map must be ignored.
++		 */
++		if (i > 0 && rpmhpd->level[i] == 0) {
++			rpmhpd->level_count = i;
++			break;
++		}
++		pr_debug("%s: ARC hlvl=%2d --> vlvl=%4u\n", rpmhpd->res_name, i,
++			 rpmhpd->level[i]);
++	}
++
++	return 0;
++}
++
++static int rpmhpd_probe(struct platform_device *pdev)
++{
++	int i, ret;
++	size_t num_pds;
++	struct device *dev = &pdev->dev;
++	struct genpd_onecell_data *data;
++	struct rpmhpd **rpmhpds;
++	const struct rpmhpd_desc *desc;
++
++	desc = of_device_get_match_data(dev);
++	if (!desc)
++		return -EINVAL;
++
++	rpmhpds = desc->rpmhpds;
++	num_pds = desc->num_pds;
++
++	data = devm_kzalloc(dev, sizeof(*data), GFP_KERNEL);
++	if (!data)
++		return -ENOMEM;
++
++	data->domains = devm_kcalloc(dev, num_pds, sizeof(*data->domains),
++				     GFP_KERNEL);
++	if (!data->domains)
++		return -ENOMEM;
++
++	data->num_domains = num_pds;
++
++	for (i = 0; i < num_pds; i++) {
++		if (!rpmhpds[i])
++			continue;
++
++		rpmhpds[i]->dev = dev;
++		rpmhpds[i]->addr = cmd_db_read_addr(rpmhpds[i]->res_name);
++		if (!rpmhpds[i]->addr) {
++			dev_err(dev, "Could not find RPMh address for resource %s\n",
++				rpmhpds[i]->res_name);
++			return -ENODEV;
++		}
++
++		ret = cmd_db_read_slave_id(rpmhpds[i]->res_name);
++		if (ret != CMD_DB_HW_ARC) {
++			dev_err(dev, "RPMh slave ID mismatch\n");
++			return -EINVAL;
++		}
++
++		ret = rpmhpd_update_level_mapping(rpmhpds[i]);
++		if (ret)
++			return ret;
++
++		rpmhpds[i]->pd.power_off = rpmhpd_power_off;
++		rpmhpds[i]->pd.power_on = rpmhpd_power_on;
++		rpmhpds[i]->pd.set_performance_state = rpmhpd_set_performance_state;
++		pm_genpd_init(&rpmhpds[i]->pd, NULL, true);
++
++		data->domains[i] = &rpmhpds[i]->pd;
++	}
++
++	/* Add subdomains */
++	for (i = 0; i < num_pds; i++) {
++		if (!rpmhpds[i])
++			continue;
++		if (rpmhpds[i]->parent)
++			pm_genpd_add_subdomain(rpmhpds[i]->parent,
++					       &rpmhpds[i]->pd);
++	}
++
++	return of_genpd_add_provider_onecell(pdev->dev.of_node, data);
++}
++
++static void rpmhpd_sync_state(struct device *dev)
++{
++	const struct rpmhpd_desc *desc = of_device_get_match_data(dev);
++	struct rpmhpd **rpmhpds = desc->rpmhpds;
++	unsigned int corner;
++	struct rpmhpd *pd;
++	unsigned int i;
++	int ret;
++
++	of_genpd_sync_state(dev->of_node);
++
++	mutex_lock(&rpmhpd_lock);
++	for (i = 0; i < desc->num_pds; i++) {
++		pd = rpmhpds[i];
++		if (!pd)
++			continue;
++
++		pd->state_synced = true;
++		if (pd->enabled)
++			corner = max(pd->corner, pd->enable_corner);
++		else
++			corner = 0;
++
++		ret = rpmhpd_aggregate_corner(pd, corner);
++		if (ret)
++			dev_err(dev, "failed to sync %s\n", pd->res_name);
++	}
++	mutex_unlock(&rpmhpd_lock);
++}
++
++static struct platform_driver rpmhpd_driver = {
++	.driver = {
++		.name = "qcom-rpmhpd",
++		.of_match_table = rpmhpd_match_table,
++		.suppress_bind_attrs = true,
++		.sync_state = rpmhpd_sync_state,
++	},
++	.probe = rpmhpd_probe,
++};
++
++static int __init rpmhpd_init(void)
++{
++	return platform_driver_register(&rpmhpd_driver);
++}
++core_initcall(rpmhpd_init);
++
++MODULE_DESCRIPTION("Qualcomm Technologies, Inc. RPMh Power Domain Driver");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/ufs/host/ufs-qcom.c.orig b/drivers/ufs/host/ufs-qcom.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/ufs/host/ufs-qcom.c.orig
+@@ -0,0 +1,3037 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) 2013-2016, Linux Foundation. All rights reserved.
++ */
++
++#include <linux/acpi.h>
++#include <linux/clk.h>
++#include <linux/cleanup.h>
++#include <linux/delay.h>
++#include <linux/devfreq.h>
++#include <linux/gpio/consumer.h>
++#include <linux/interconnect.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/phy/phy.h>
++#include <linux/platform_device.h>
++#include <linux/pm_domain.h>
++#include <linux/reset-controller.h>
++#include <linux/time.h>
++#include <linux/unaligned.h>
++#include <linux/units.h>
++
++#include <soc/qcom/ice.h>
++
++#include <ufs/ufshcd.h>
++#include <ufs/ufshci.h>
++#include <ufs/ufs_quirks.h>
++#include <ufs/unipro.h>
++#include "ufshcd-pltfrm.h"
++#include "ufs-qcom.h"
++
++#define MCQ_QCFGPTR_MASK	GENMASK(7, 0)
++#define MCQ_QCFGPTR_UNIT	0x200
++#define MCQ_SQATTR_OFFSET(c) \
++	((((c) >> 16) & MCQ_QCFGPTR_MASK) * MCQ_QCFGPTR_UNIT)
++#define MCQ_QCFG_SIZE	0x40
++
++/* De-emphasis for gear-5 */
++#define DEEMPHASIS_3_5_dB	0x04
++#define NO_DEEMPHASIS		0x0
++
++#define UFS_ICE_SYNC_RST_SEL	BIT(3)
++#define UFS_ICE_SYNC_RST_SW	BIT(4)
++
++enum {
++	TSTBUS_UAWM,
++	TSTBUS_UARM,
++	TSTBUS_TXUC,
++	TSTBUS_RXUC,
++	TSTBUS_DFC,
++	TSTBUS_TRLUT,
++	TSTBUS_TMRLUT,
++	TSTBUS_OCSC,
++	TSTBUS_UTP_HCI,
++	TSTBUS_COMBINED,
++	TSTBUS_WRAPPER,
++	TSTBUS_UNIPRO,
++	TSTBUS_MAX,
++};
++
++#define QCOM_UFS_MAX_GEAR 5
++#define QCOM_UFS_MAX_LANE 2
++
++enum {
++	MODE_MIN,
++	MODE_PWM,
++	MODE_HS_RA,
++	MODE_HS_RB,
++	MODE_MAX,
++};
++
++static const struct __ufs_qcom_bw_table {
++	u32 mem_bw;
++	u32 cfg_bw;
++} ufs_qcom_bw_table[MODE_MAX + 1][QCOM_UFS_MAX_GEAR + 1][QCOM_UFS_MAX_LANE + 1] = {
++	[MODE_MIN][0][0]		   = { 0,		0 }, /* Bandwidth values in KB/s */
++	[MODE_PWM][UFS_PWM_G1][UFS_LANE_1] = { 922,		1000 },
++	[MODE_PWM][UFS_PWM_G2][UFS_LANE_1] = { 1844,		1000 },
++	[MODE_PWM][UFS_PWM_G3][UFS_LANE_1] = { 3688,		1000 },
++	[MODE_PWM][UFS_PWM_G4][UFS_LANE_1] = { 7376,		1000 },
++	[MODE_PWM][UFS_PWM_G5][UFS_LANE_1] = { 14752,		1000 },
++	[MODE_PWM][UFS_PWM_G1][UFS_LANE_2] = { 1844,		1000 },
++	[MODE_PWM][UFS_PWM_G2][UFS_LANE_2] = { 3688,		1000 },
++	[MODE_PWM][UFS_PWM_G3][UFS_LANE_2] = { 7376,		1000 },
++	[MODE_PWM][UFS_PWM_G4][UFS_LANE_2] = { 14752,		1000 },
++	[MODE_PWM][UFS_PWM_G5][UFS_LANE_2] = { 29504,		1000 },
++	[MODE_HS_RA][UFS_HS_G1][UFS_LANE_1] = { 127796,		1000 },
++	[MODE_HS_RA][UFS_HS_G2][UFS_LANE_1] = { 255591,		1000 },
++	[MODE_HS_RA][UFS_HS_G3][UFS_LANE_1] = { 1492582,	102400 },
++	[MODE_HS_RA][UFS_HS_G4][UFS_LANE_1] = { 2915200,	204800 },
++	[MODE_HS_RA][UFS_HS_G5][UFS_LANE_1] = { 5836800,	409600 },
++	[MODE_HS_RA][UFS_HS_G1][UFS_LANE_2] = { 255591,		1000 },
++	[MODE_HS_RA][UFS_HS_G2][UFS_LANE_2] = { 511181,		1000 },
++	[MODE_HS_RA][UFS_HS_G3][UFS_LANE_2] = { 1492582,	204800 },
++	[MODE_HS_RA][UFS_HS_G4][UFS_LANE_2] = { 2915200,	409600 },
++	[MODE_HS_RA][UFS_HS_G5][UFS_LANE_2] = { 5836800,	819200 },
++	[MODE_HS_RB][UFS_HS_G1][UFS_LANE_1] = { 149422,		1000 },
++	[MODE_HS_RB][UFS_HS_G2][UFS_LANE_1] = { 298189,		1000 },
++	[MODE_HS_RB][UFS_HS_G3][UFS_LANE_1] = { 1492582,	102400 },
++	[MODE_HS_RB][UFS_HS_G4][UFS_LANE_1] = { 2915200,	204800 },
++	[MODE_HS_RB][UFS_HS_G5][UFS_LANE_1] = { 5836800,	409600 },
++	[MODE_HS_RB][UFS_HS_G1][UFS_LANE_2] = { 298189,		1000 },
++	[MODE_HS_RB][UFS_HS_G2][UFS_LANE_2] = { 596378,		1000 },
++	[MODE_HS_RB][UFS_HS_G3][UFS_LANE_2] = { 1492582,	204800 },
++	[MODE_HS_RB][UFS_HS_G4][UFS_LANE_2] = { 2915200,	409600 },
++	[MODE_HS_RB][UFS_HS_G5][UFS_LANE_2] = { 5836800,	819200 },
++	[MODE_MAX][0][0]		    = { 7643136,	819200 },
++};
++
++static const struct {
++	int nminor;
++	char *prefix;
++} testbus_info[TSTBUS_MAX] = {
++	[TSTBUS_UAWM]     = {32, "TSTBUS_UAWM"},
++	[TSTBUS_UARM]     = {32, "TSTBUS_UARM"},
++	[TSTBUS_TXUC]     = {32, "TSTBUS_TXUC"},
++	[TSTBUS_RXUC]     = {32, "TSTBUS_RXUC"},
++	[TSTBUS_DFC]      = {32, "TSTBUS_DFC"},
++	[TSTBUS_TRLUT]    = {32, "TSTBUS_TRLUT"},
++	[TSTBUS_TMRLUT]   = {32, "TSTBUS_TMRLUT"},
++	[TSTBUS_OCSC]     = {32, "TSTBUS_OCSC"},
++	[TSTBUS_UTP_HCI]  = {32, "TSTBUS_UTP_HCI"},
++	[TSTBUS_COMBINED] = {32, "TSTBUS_COMBINED"},
++	[TSTBUS_WRAPPER]  = {32, "TSTBUS_WRAPPER"},
++	[TSTBUS_UNIPRO]   = {256, "TSTBUS_UNIPRO"},
++};
++
++static void ufs_qcom_get_default_testbus_cfg(struct ufs_qcom_host *host);
++static unsigned long ufs_qcom_opp_freq_to_clk_freq(struct ufs_hba *hba,
++						   unsigned long freq, char *name);
++static int ufs_qcom_set_core_clk_ctrl(struct ufs_hba *hba, bool is_scale_up, unsigned long freq);
++
++static struct ufs_qcom_host *rcdev_to_ufs_host(struct reset_controller_dev *rcd)
++{
++	return container_of(rcd, struct ufs_qcom_host, rcdev);
++}
++
++#ifdef CONFIG_SCSI_UFS_CRYPTO
++/**
++ * ufs_qcom_config_ice_allocator() - ICE core allocator configuration
++ *
++ * @host: pointer to qcom specific variant structure.
++ */
++static void ufs_qcom_config_ice_allocator(struct ufs_qcom_host *host)
++{
++	struct ufs_hba *hba = host->hba;
++	static const uint8_t val[4] = { NUM_RX_R1W0, NUM_TX_R0W1, NUM_RX_R1W1, NUM_TX_R1W1 };
++	u32 config;
++
++	if (!(host->caps & UFS_QCOM_CAP_ICE_CONFIG) ||
++			!(host->hba->caps & UFSHCD_CAP_CRYPTO))
++		return;
++
++	config = get_unaligned_le32(val);
++
++	ufshcd_writel(hba, ICE_ALLOCATOR_TYPE, REG_UFS_MEM_ICE_CONFIG);
++	ufshcd_writel(hba, config, REG_UFS_MEM_ICE_NUM_CORE);
++}
++
++static inline void ufs_qcom_ice_enable(struct ufs_qcom_host *host)
++{
++	if (host->hba->caps & UFSHCD_CAP_CRYPTO)
++		qcom_ice_enable(host->ice);
++}
++
++static const struct blk_crypto_ll_ops ufs_qcom_crypto_ops; /* forward decl */
++
++static int ufs_qcom_ice_init(struct ufs_qcom_host *host)
++{
++	struct ufs_hba *hba = host->hba;
++	struct blk_crypto_profile *profile = &hba->crypto_profile;
++	struct device *dev = hba->dev;
++	struct qcom_ice *ice;
++	union ufs_crypto_capabilities caps;
++	union ufs_crypto_cap_entry cap;
++	int err;
++	int i;
++
++	ice = devm_of_qcom_ice_get(dev);
++	if (IS_ERR(ice)) {
++		if (ice != ERR_PTR(-EOPNOTSUPP))
++			return PTR_ERR(ice);
++
++		dev_warn(dev, "Disabling inline encryption support\n");
++		return 0;
++	}
++
++	host->ice = ice;
++
++	/* Initialize the blk_crypto_profile */
++
++	caps.reg_val = cpu_to_le32(ufshcd_readl(hba, REG_UFS_CCAP));
++
++	/* The number of keyslots supported is (CFGC+1) */
++	err = devm_blk_crypto_profile_init(dev, profile, caps.config_count + 1);
++	if (err)
++		return err;
++
++	profile->ll_ops = ufs_qcom_crypto_ops;
++	profile->max_dun_bytes_supported = 8;
++	profile->key_types_supported = qcom_ice_get_supported_key_type(ice);
++	profile->dev = dev;
++
++	/*
++	 * Currently this driver only supports AES-256-XTS.  All known versions
++	 * of ICE support it, but to be safe make sure it is really declared in
++	 * the crypto capability registers.  The crypto capability registers
++	 * also give the supported data unit size(s).
++	 */
++	for (i = 0; i < caps.num_crypto_cap; i++) {
++		cap.reg_val = cpu_to_le32(ufshcd_readl(hba,
++						       REG_UFS_CRYPTOCAP +
++						       i * sizeof(__le32)));
++		if (cap.algorithm_id == UFS_CRYPTO_ALG_AES_XTS &&
++		    cap.key_size == UFS_CRYPTO_KEY_SIZE_256)
++			profile->modes_supported[BLK_ENCRYPTION_MODE_AES_256_XTS] |=
++				cap.sdus_mask * 512;
++	}
++
++	hba->caps |= UFSHCD_CAP_CRYPTO;
++	hba->quirks |= UFSHCD_QUIRK_CUSTOM_CRYPTO_PROFILE;
++	return 0;
++}
++
++static inline int ufs_qcom_ice_resume(struct ufs_qcom_host *host)
++{
++	if (host->hba->caps & UFSHCD_CAP_CRYPTO)
++		return qcom_ice_resume(host->ice);
++
++	return 0;
++}
++
++static inline int ufs_qcom_ice_suspend(struct ufs_qcom_host *host)
++{
++	if (host->hba->caps & UFSHCD_CAP_CRYPTO)
++		return qcom_ice_suspend(host->ice);
++
++	return 0;
++}
++
++static int ufs_qcom_ice_keyslot_program(struct blk_crypto_profile *profile,
++					const struct blk_crypto_key *key,
++					unsigned int slot)
++{
++	struct ufs_hba *hba = ufs_hba_from_crypto_profile(profile);
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	int err;
++
++	ufshcd_hold(hba);
++	err = qcom_ice_program_key(host->ice, slot, key);
++	ufshcd_release(hba);
++	return err;
++}
++
++static int ufs_qcom_ice_keyslot_evict(struct blk_crypto_profile *profile,
++				      const struct blk_crypto_key *key,
++				      unsigned int slot)
++{
++	struct ufs_hba *hba = ufs_hba_from_crypto_profile(profile);
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	int err;
++
++	ufshcd_hold(hba);
++	err = qcom_ice_evict_key(host->ice, slot);
++	ufshcd_release(hba);
++	return err;
++}
++
++static int ufs_qcom_ice_derive_sw_secret(struct blk_crypto_profile *profile,
++					 const u8 *eph_key, size_t eph_key_size,
++					 u8 sw_secret[BLK_CRYPTO_SW_SECRET_SIZE])
++{
++	struct ufs_hba *hba = ufs_hba_from_crypto_profile(profile);
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	return qcom_ice_derive_sw_secret(host->ice, eph_key, eph_key_size,
++					 sw_secret);
++}
++
++static int ufs_qcom_ice_import_key(struct blk_crypto_profile *profile,
++				   const u8 *raw_key, size_t raw_key_size,
++				   u8 lt_key[BLK_CRYPTO_MAX_HW_WRAPPED_KEY_SIZE])
++{
++	struct ufs_hba *hba = ufs_hba_from_crypto_profile(profile);
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	return qcom_ice_import_key(host->ice, raw_key, raw_key_size, lt_key);
++}
++
++static int ufs_qcom_ice_generate_key(struct blk_crypto_profile *profile,
++				     u8 lt_key[BLK_CRYPTO_MAX_HW_WRAPPED_KEY_SIZE])
++{
++	struct ufs_hba *hba = ufs_hba_from_crypto_profile(profile);
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	return qcom_ice_generate_key(host->ice, lt_key);
++}
++
++static int ufs_qcom_ice_prepare_key(struct blk_crypto_profile *profile,
++				    const u8 *lt_key, size_t lt_key_size,
++				    u8 eph_key[BLK_CRYPTO_MAX_HW_WRAPPED_KEY_SIZE])
++{
++	struct ufs_hba *hba = ufs_hba_from_crypto_profile(profile);
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	return qcom_ice_prepare_key(host->ice, lt_key, lt_key_size, eph_key);
++}
++
++static const struct blk_crypto_ll_ops ufs_qcom_crypto_ops = {
++	.keyslot_program	= ufs_qcom_ice_keyslot_program,
++	.keyslot_evict		= ufs_qcom_ice_keyslot_evict,
++	.derive_sw_secret	= ufs_qcom_ice_derive_sw_secret,
++	.import_key		= ufs_qcom_ice_import_key,
++	.generate_key		= ufs_qcom_ice_generate_key,
++	.prepare_key		= ufs_qcom_ice_prepare_key,
++};
++
++#else
++
++static inline void ufs_qcom_ice_enable(struct ufs_qcom_host *host)
++{
++}
++
++static int ufs_qcom_ice_init(struct ufs_qcom_host *host)
++{
++	return 0;
++}
++
++static inline int ufs_qcom_ice_resume(struct ufs_qcom_host *host)
++{
++	return 0;
++}
++
++static inline int ufs_qcom_ice_suspend(struct ufs_qcom_host *host)
++{
++	return 0;
++}
++
++static void ufs_qcom_config_ice_allocator(struct ufs_qcom_host *host)
++{
++}
++
++#endif
++
++static void ufs_qcom_disable_lane_clks(struct ufs_qcom_host *host)
++{
++	if (!host->is_lane_clks_enabled)
++		return;
++
++	clk_bulk_disable_unprepare(host->num_clks, host->clks);
++
++	host->is_lane_clks_enabled = false;
++}
++
++static int ufs_qcom_enable_lane_clks(struct ufs_qcom_host *host)
++{
++	int err;
++
++	err = clk_bulk_prepare_enable(host->num_clks, host->clks);
++	if (err)
++		return err;
++
++	host->is_lane_clks_enabled = true;
++
++	return 0;
++}
++
++static int ufs_qcom_init_lane_clks(struct ufs_qcom_host *host)
++{
++	int err;
++	struct device *dev = host->hba->dev;
++
++	if (has_acpi_companion(dev))
++		return 0;
++
++	err = devm_clk_bulk_get_all(dev, &host->clks);
++	if (err <= 0)
++		return err;
++
++	host->num_clks = err;
++
++	return 0;
++}
++
++static int ufs_qcom_check_hibern8(struct ufs_hba *hba)
++{
++	int err;
++	u32 tx_fsm_val;
++	unsigned long timeout = jiffies + msecs_to_jiffies(HBRN8_POLL_TOUT_MS);
++
++	do {
++		err = ufshcd_dme_get(hba,
++				UIC_ARG_MIB_SEL(MPHY_TX_FSM_STATE,
++					UIC_ARG_MPHY_TX_GEN_SEL_INDEX(0)),
++				&tx_fsm_val);
++		if (err || tx_fsm_val == TX_FSM_HIBERN8)
++			break;
++
++		/* sleep for max. 200us */
++		usleep_range(100, 200);
++	} while (time_before(jiffies, timeout));
++
++	/*
++	 * we might have scheduled out for long during polling so
++	 * check the state again.
++	 */
++	if (time_after(jiffies, timeout))
++		err = ufshcd_dme_get(hba,
++				UIC_ARG_MIB_SEL(MPHY_TX_FSM_STATE,
++					UIC_ARG_MPHY_TX_GEN_SEL_INDEX(0)),
++				&tx_fsm_val);
++
++	if (err) {
++		dev_err(hba->dev, "%s: unable to get TX_FSM_STATE, err %d\n",
++				__func__, err);
++	} else if (tx_fsm_val != TX_FSM_HIBERN8) {
++		err = tx_fsm_val;
++		dev_err(hba->dev, "%s: invalid TX_FSM_STATE = %d\n",
++				__func__, err);
++	}
++
++	return err;
++}
++
++static void ufs_qcom_select_unipro_mode(struct ufs_qcom_host *host)
++{
++	ufshcd_rmwl(host->hba, QUNIPRO_SEL, QUNIPRO_SEL, REG_UFS_CFG1);
++
++	if (host->hw_ver.major >= 0x05)
++		ufshcd_rmwl(host->hba, QUNIPRO_G4_SEL, 0, REG_UFS_CFG0);
++}
++
++/*
++ * ufs_qcom_host_reset - reset host controller and PHY
++ */
++static int ufs_qcom_host_reset(struct ufs_hba *hba)
++{
++	int ret;
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	bool reenable_intr;
++
++	if (!host->core_reset)
++		return 0;
++
++	reenable_intr = hba->is_irq_enabled;
++	ufshcd_disable_irq(hba);
++
++	ret = reset_control_assert(host->core_reset);
++	if (ret) {
++		dev_err(hba->dev, "%s: core_reset assert failed, err = %d\n",
++				 __func__, ret);
++		return ret;
++	}
++
++	/*
++	 * The hardware requirement for delay between assert/deassert
++	 * is at least 3-4 sleep clock (32.7KHz) cycles, which comes to
++	 * ~125us (4/32768). To be on the safe side add 200us delay.
++	 */
++	usleep_range(200, 210);
++
++	ret = reset_control_deassert(host->core_reset);
++	if (ret) {
++		dev_err(hba->dev, "%s: core_reset deassert failed, err = %d\n",
++				 __func__, ret);
++		return ret;
++	}
++
++	usleep_range(1000, 1100);
++
++	if (reenable_intr)
++		ufshcd_enable_irq(hba);
++
++	return 0;
++}
++
++static u32 ufs_qcom_get_hs_gear(struct ufs_hba *hba)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	if (host->hw_ver.major >= 0x4)
++		return UFS_QCOM_MAX_GEAR(ufshcd_readl(hba, REG_UFS_PARAM0));
++
++	/* Default is HS-G3 */
++	return UFS_HS_G3;
++}
++
++static int ufs_qcom_power_up_sequence(struct ufs_hba *hba)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	struct ufs_host_params *host_params = &host->host_params;
++	struct phy *phy = host->generic_phy;
++	enum phy_mode mode;
++	int ret;
++
++	/*
++	 * HW ver 5 can only support up to HS-G5 Rate-A due to HW limitations.
++	 * If the HS-G5 PHY gear is used, update host_params->hs_rate to Rate-A,
++	 * so that the subsequent power mode change shall stick to Rate-A.
++	 */
++	if (host->hw_ver.major == 0x5 && host->phy_gear == UFS_HS_G5)
++		host_params->hs_rate = PA_HS_MODE_A;
++
++	mode = host_params->hs_rate == PA_HS_MODE_B ? PHY_MODE_UFS_HS_B : PHY_MODE_UFS_HS_A;
++
++	/* Reset UFS Host Controller and PHY */
++	ret = ufs_qcom_host_reset(hba);
++	if (ret)
++		return ret;
++
++	if (phy->power_count)
++		phy_power_off(phy);
++
++
++	/* phy initialization - calibrate the phy */
++	ret = phy_init(phy);
++	if (ret) {
++		dev_err(hba->dev, "%s: phy init failed, ret = %d\n",
++			__func__, ret);
++		return ret;
++	}
++
++	ret = phy_set_mode_ext(phy, mode, host->phy_gear);
++	if (ret)
++		goto out_disable_phy;
++
++	/* power on phy - start serdes and phy's power and clocks */
++	ret = phy_power_on(phy);
++	if (ret) {
++		dev_err(hba->dev, "%s: phy power on failed, ret = %d\n",
++			__func__, ret);
++		goto out_disable_phy;
++	}
++
++	ret = phy_calibrate(phy);
++	if (ret) {
++		dev_err(hba->dev, "Failed to calibrate PHY: %d\n", ret);
++		goto out_disable_phy;
++	}
++
++	ufs_qcom_select_unipro_mode(host);
++
++	return 0;
++
++out_disable_phy:
++	phy_exit(phy);
++
++	return ret;
++}
++
++/*
++ * The UTP controller has a number of internal clock gating cells (CGCs).
++ * Internal hardware sub-modules within the UTP controller control the CGCs.
++ * Hardware CGCs disable the clock to inactivate UTP sub-modules not involved
++ * in a specific operation, UTP controller CGCs are by default disabled and
++ * this function enables them (after every UFS link startup) to save some power
++ * leakage.
++ */
++static void ufs_qcom_enable_hw_clk_gating(struct ufs_hba *hba)
++{
++	int err;
++
++	/* Enable UTP internal clock gating */
++	ufshcd_rmwl(hba, REG_UFS_CFG2_CGC_EN_ALL, REG_UFS_CFG2_CGC_EN_ALL,
++		    REG_UFS_CFG2);
++
++	/* Ensure that HW clock gating is enabled before next operations */
++	ufshcd_readl(hba, REG_UFS_CFG2);
++
++	/* Enable Unipro internal clock gating */
++	err = ufshcd_dme_rmw(hba, DL_VS_CLK_CFG_MASK,
++			     DL_VS_CLK_CFG_MASK, DL_VS_CLK_CFG);
++	if (err)
++		goto out;
++
++	err = ufshcd_dme_rmw(hba, PA_VS_CLK_CFG_REG_MASK,
++			     PA_VS_CLK_CFG_REG_MASK, PA_VS_CLK_CFG_REG);
++	if (err)
++		goto out;
++
++	err = ufshcd_dme_rmw(hba, DME_VS_CORE_CLK_CTRL_DME_HW_CGC_EN,
++			     DME_VS_CORE_CLK_CTRL_DME_HW_CGC_EN,
++			     DME_VS_CORE_CLK_CTRL);
++out:
++	if (err)
++		dev_err(hba->dev, "hw clk gating enabled failed\n");
++}
++
++static int ufs_qcom_hce_enable_notify(struct ufs_hba *hba,
++				      enum ufs_notify_change_status status)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	int err;
++
++	switch (status) {
++	case PRE_CHANGE:
++		err = ufs_qcom_power_up_sequence(hba);
++		if (err)
++			return err;
++
++		/*
++		 * The PHY PLL output is the source of tx/rx lane symbol
++		 * clocks, hence, enable the lane clocks only after PHY
++		 * is initialized.
++		 */
++		err = ufs_qcom_enable_lane_clks(host);
++		break;
++	case POST_CHANGE:
++		/* check if UFS PHY moved from DISABLED to HIBERN8 */
++		err = ufs_qcom_check_hibern8(hba);
++		ufs_qcom_enable_hw_clk_gating(hba);
++		ufs_qcom_ice_enable(host);
++		ufs_qcom_config_ice_allocator(host);
++		break;
++	default:
++		dev_err(hba->dev, "%s: invalid status %d\n", __func__, status);
++		err = -EINVAL;
++		break;
++	}
++	return err;
++}
++
++static int ufs_qcom_fw_managed_hce_enable_notify(struct ufs_hba *hba,
++						 enum ufs_notify_change_status status)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	switch (status) {
++	case PRE_CHANGE:
++		ufs_qcom_select_unipro_mode(host);
++		break;
++	case POST_CHANGE:
++		ufs_qcom_enable_hw_clk_gating(hba);
++		ufs_qcom_ice_enable(host);
++		break;
++	default:
++		dev_err(hba->dev, "Invalid status %d\n", status);
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++/**
++ * ufs_qcom_cfg_timers - Configure ufs qcom cfg timers
++ *
++ * @hba: host controller instance
++ * @is_pre_scale_up: flag to check if pre scale up condition.
++ * @freq: target opp freq
++ * Return: zero for success and non-zero in case of a failure.
++ */
++static int ufs_qcom_cfg_timers(struct ufs_hba *hba, bool is_pre_scale_up, unsigned long freq)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	struct ufs_clk_info *clki;
++	unsigned long clk_freq = 0;
++	u32 core_clk_cycles_per_us;
++
++	/*
++	 * UTP controller uses SYS1CLK_1US_REG register for Interrupt
++	 * Aggregation logic.
++	 * It is mandatory to write SYS1CLK_1US_REG register on UFS host
++	 * controller V4.0.0 onwards.
++	 */
++	if (host->hw_ver.major < 4 && !ufshcd_is_intr_aggr_allowed(hba))
++		return 0;
++
++	if (hba->use_pm_opp && freq != ULONG_MAX) {
++		clk_freq = ufs_qcom_opp_freq_to_clk_freq(hba, freq, "core_clk");
++		if (clk_freq)
++			goto cfg_timers;
++	}
++
++	list_for_each_entry(clki, &hba->clk_list_head, list) {
++		if (!strcmp(clki->name, "core_clk")) {
++			if (freq == ULONG_MAX) {
++				clk_freq = clki->max_freq;
++				break;
++			}
++
++			if (is_pre_scale_up)
++				clk_freq = clki->max_freq;
++			else
++				clk_freq = clk_get_rate(clki->clk);
++			break;
++		}
++
++	}
++
++cfg_timers:
++	/* If frequency is smaller than 1MHz, set to 1MHz */
++	if (clk_freq < DEFAULT_CLK_RATE_HZ)
++		clk_freq = DEFAULT_CLK_RATE_HZ;
++
++	core_clk_cycles_per_us = clk_freq / USEC_PER_SEC;
++	if (ufshcd_readl(hba, REG_UFS_SYS1CLK_1US) != core_clk_cycles_per_us) {
++		ufshcd_writel(hba, core_clk_cycles_per_us, REG_UFS_SYS1CLK_1US);
++		/*
++		 * make sure above write gets applied before we return from
++		 * this function.
++		 */
++		ufshcd_readl(hba, REG_UFS_SYS1CLK_1US);
++	}
++
++	return 0;
++}
++
++static int ufs_qcom_link_startup_notify(struct ufs_hba *hba,
++					enum ufs_notify_change_status status)
++{
++	int err = 0;
++
++	switch (status) {
++	case PRE_CHANGE:
++		if (ufs_qcom_cfg_timers(hba, false, ULONG_MAX)) {
++			dev_err(hba->dev, "%s: ufs_qcom_cfg_timers() failed\n",
++				__func__);
++			return -EINVAL;
++		}
++
++		err = ufs_qcom_set_core_clk_ctrl(hba, true, ULONG_MAX);
++		if (err)
++			dev_err(hba->dev, "cfg core clk ctrl failed\n");
++		/*
++		 * Some UFS devices (and may be host) have issues if LCC is
++		 * enabled. So we are setting PA_Local_TX_LCC_Enable to 0
++		 * before link startup which will make sure that both host
++		 * and device TX LCC are disabled once link startup is
++		 * completed.
++		 */
++		err = ufshcd_disable_host_tx_lcc(hba);
++
++		break;
++	default:
++		break;
++	}
++
++	return err;
++}
++
++static void ufs_qcom_device_reset_ctrl(struct ufs_hba *hba, bool asserted)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	/* reset gpio is optional */
++	if (!host->device_reset)
++		return;
++
++	gpiod_set_value_cansleep(host->device_reset, asserted);
++}
++
++static int ufs_qcom_suspend(struct ufs_hba *hba, enum ufs_pm_op pm_op,
++	enum ufs_notify_change_status status)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	if (status == PRE_CHANGE)
++		return 0;
++
++	if (!ufs_qcom_is_link_active(hba))
++		ufs_qcom_disable_lane_clks(host);
++
++
++	/* reset the connected UFS device during power down */
++	if (ufs_qcom_is_link_off(hba) && host->device_reset) {
++		ufs_qcom_device_reset_ctrl(hba, true);
++		/*
++		 * After sending the SSU command, asserting the rst_n
++		 * line causes the device firmware to wake up and
++		 * execute its reset routine.
++		 *
++		 * During this process, the device may draw current
++		 * beyond the permissible limit for low-power mode (LPM).
++		 * A 10ms delay, based on experimental observations,
++		 * allows the UFS device to complete its hardware reset
++		 * before transitioning the power rail to LPM.
++		 */
++		usleep_range(10000, 11000);
++	}
++
++	return ufs_qcom_ice_suspend(host);
++}
++
++static int ufs_qcom_resume(struct ufs_hba *hba, enum ufs_pm_op pm_op)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	int err;
++	u32 reg_val;
++
++	err = ufs_qcom_enable_lane_clks(host);
++	if (err)
++		return err;
++
++	if ((!ufs_qcom_is_link_active(hba)) &&
++	    host->hw_ver.major == 5 &&
++	    host->hw_ver.minor == 0 &&
++	    host->hw_ver.step == 0) {
++		ufshcd_writel(hba, UFS_ICE_SYNC_RST_SEL | UFS_ICE_SYNC_RST_SW, UFS_MEM_ICE_CFG);
++		reg_val = ufshcd_readl(hba, UFS_MEM_ICE_CFG);
++		reg_val &= ~(UFS_ICE_SYNC_RST_SEL | UFS_ICE_SYNC_RST_SW);
++		/*
++		 * HW documentation doesn't recommend any delay between the
++		 * reset set and clear. But we are enforcing an arbitrary delay
++		 * to give flops enough time to settle in.
++		 */
++		usleep_range(50, 100);
++		ufshcd_writel(hba, reg_val, UFS_MEM_ICE_CFG);
++		ufshcd_readl(hba, UFS_MEM_ICE_CFG);
++	}
++
++	return ufs_qcom_ice_resume(host);
++}
++
++static int ufs_qcom_fw_managed_suspend(struct ufs_hba *hba, enum ufs_pm_op pm_op,
++				       enum ufs_notify_change_status status)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	if (status == PRE_CHANGE)
++		return 0;
++
++	pm_runtime_put_sync(hba->dev);
++
++	return ufs_qcom_ice_suspend(host);
++}
++
++static int ufs_qcom_fw_managed_resume(struct ufs_hba *hba, enum ufs_pm_op pm_op)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	int err;
++
++	err = pm_runtime_resume_and_get(hba->dev);
++	if (err) {
++		dev_err(hba->dev, "PM runtime resume failed: %d\n", err);
++		return err;
++	}
++
++	return ufs_qcom_ice_resume(host);
++}
++
++static void ufs_qcom_dev_ref_clk_ctrl(struct ufs_qcom_host *host, bool enable)
++{
++	if (host->dev_ref_clk_ctrl_mmio &&
++	    (enable ^ host->is_dev_ref_clk_enabled)) {
++		u32 temp = readl_relaxed(host->dev_ref_clk_ctrl_mmio);
++
++		if (enable)
++			temp |= host->dev_ref_clk_en_mask;
++		else
++			temp &= ~host->dev_ref_clk_en_mask;
++
++		/*
++		 * If we are here to disable this clock it might be immediately
++		 * after entering into hibern8 in which case we need to make
++		 * sure that device ref_clk is active for specific time after
++		 * hibern8 enter.
++		 */
++		if (!enable) {
++			unsigned long gating_wait;
++
++			gating_wait = host->hba->dev_info.clk_gating_wait_us;
++			if (!gating_wait) {
++				udelay(1);
++			} else {
++				/*
++				 * bRefClkGatingWaitTime defines the minimum
++				 * time for which the reference clock is
++				 * required by device during transition from
++				 * HS-MODE to LS-MODE or HIBERN8 state. Give it
++				 * more delay to be on the safe side.
++				 */
++				gating_wait += 10;
++				usleep_range(gating_wait, gating_wait + 10);
++			}
++		}
++
++		writel_relaxed(temp, host->dev_ref_clk_ctrl_mmio);
++
++		/*
++		 * Make sure the write to ref_clk reaches the destination and
++		 * not stored in a Write Buffer (WB).
++		 */
++		readl(host->dev_ref_clk_ctrl_mmio);
++
++		/*
++		 * If we call hibern8 exit after this, we need to make sure that
++		 * device ref_clk is stable for at least 1us before the hibern8
++		 * exit command.
++		 */
++		if (enable)
++			udelay(1);
++
++		host->is_dev_ref_clk_enabled = enable;
++	}
++}
++
++static int ufs_qcom_icc_set_bw(struct ufs_qcom_host *host, u32 mem_bw, u32 cfg_bw)
++{
++	struct device *dev = host->hba->dev;
++	int ret;
++
++	ret = icc_set_bw(host->icc_ddr, 0, mem_bw);
++	if (ret < 0) {
++		dev_err(dev, "failed to set bandwidth request: %d\n", ret);
++		return ret;
++	}
++
++	ret = icc_set_bw(host->icc_cpu, 0, cfg_bw);
++	if (ret < 0) {
++		dev_err(dev, "failed to set bandwidth request: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static struct __ufs_qcom_bw_table ufs_qcom_get_bw_table(struct ufs_qcom_host *host)
++{
++	struct ufs_pa_layer_attr *p = &host->dev_req_params;
++	int gear = max_t(u32, p->gear_rx, p->gear_tx);
++	int lane = max_t(u32, p->lane_rx, p->lane_tx);
++
++	if (WARN_ONCE(gear > QCOM_UFS_MAX_GEAR,
++		      "ICC scaling for UFS Gear (%d) not supported. Using Gear (%d) bandwidth\n",
++		      gear, QCOM_UFS_MAX_GEAR))
++		gear = QCOM_UFS_MAX_GEAR;
++
++	if (WARN_ONCE(lane > QCOM_UFS_MAX_LANE,
++		      "ICC scaling for UFS Lane (%d) not supported. Using Lane (%d) bandwidth\n",
++		      lane, QCOM_UFS_MAX_LANE))
++		lane = QCOM_UFS_MAX_LANE;
++
++	if (ufshcd_is_hs_mode(p)) {
++		if (p->hs_rate == PA_HS_MODE_B)
++			return ufs_qcom_bw_table[MODE_HS_RB][gear][lane];
++		else
++			return ufs_qcom_bw_table[MODE_HS_RA][gear][lane];
++	} else {
++		return ufs_qcom_bw_table[MODE_PWM][gear][lane];
++	}
++}
++
++static int ufs_qcom_icc_update_bw(struct ufs_qcom_host *host)
++{
++	struct __ufs_qcom_bw_table bw_table;
++
++	bw_table = ufs_qcom_get_bw_table(host);
++
++	return ufs_qcom_icc_set_bw(host, bw_table.mem_bw, bw_table.cfg_bw);
++}
++
++static void ufs_qcom_set_tx_hs_equalizer(struct ufs_hba *hba, u32 gear, u32 tx_lanes)
++{
++	u32 equalizer_val;
++	int ret, i;
++
++	/* Determine the equalizer value based on the gear */
++	equalizer_val = (gear == 5) ? DEEMPHASIS_3_5_dB : NO_DEEMPHASIS;
++
++	for (i = 0; i < tx_lanes; i++) {
++		ret = ufshcd_dme_set(hba, UIC_ARG_MIB_SEL(TX_HS_EQUALIZER, i),
++				     equalizer_val);
++		if (ret)
++			dev_err(hba->dev, "%s: failed equalizer lane %d\n",
++				__func__, i);
++	}
++}
++
++static int ufs_qcom_negotiate_pwr_mode(struct ufs_hba *hba,
++				       const struct ufs_pa_layer_attr *dev_max_params,
++				       struct ufs_pa_layer_attr *dev_req_params)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	struct ufs_host_params *host_params = &host->host_params;
++
++	return ufshcd_negotiate_pwr_params(host_params, dev_max_params, dev_req_params);
++}
++
++static int ufs_qcom_pwr_change_notify(struct ufs_hba *hba,
++				      enum ufs_notify_change_status status,
++				      struct ufs_pa_layer_attr *dev_req_params)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	int ret = 0;
++
++	if (!dev_req_params) {
++		pr_err("%s: incoming dev_req_params is NULL\n", __func__);
++		return -EINVAL;
++	}
++
++	switch (status) {
++	case PRE_CHANGE:
++		/*
++		 * During UFS driver probe, always update the PHY gear to match the negotiated
++		 * gear, so that, if quirk UFSHCD_QUIRK_REINIT_AFTER_MAX_GEAR_SWITCH is enabled,
++		 * the second init can program the optimal PHY settings. This allows one to start
++		 * the first init with either the minimum or the maximum support gear.
++		 */
++		if (hba->ufshcd_state == UFSHCD_STATE_RESET) {
++			/*
++			 * Skip REINIT if the negotiated gear matches with the
++			 * initial phy_gear. Otherwise, update the phy_gear to
++			 * program the optimal gear setting during REINIT.
++			 */
++			if (host->phy_gear == dev_req_params->gear_tx)
++				hba->quirks &= ~UFSHCD_QUIRK_REINIT_AFTER_MAX_GEAR_SWITCH;
++			else
++				host->phy_gear = dev_req_params->gear_tx;
++		}
++
++		/* enable the device ref clock before changing to HS mode */
++		if (!ufshcd_is_hs_mode(&hba->pwr_info) &&
++			ufshcd_is_hs_mode(dev_req_params))
++			ufs_qcom_dev_ref_clk_ctrl(host, true);
++
++		if (host->hw_ver.major >= 0x4) {
++			ufshcd_dme_configure_adapt(hba,
++						dev_req_params->gear_tx,
++						PA_INITIAL_ADAPT);
++		}
++
++		if (hba->dev_quirks & UFS_DEVICE_QUIRK_PA_TX_DEEMPHASIS_TUNING)
++			ufs_qcom_set_tx_hs_equalizer(hba,
++					dev_req_params->gear_tx, dev_req_params->lane_tx);
++
++		break;
++	case POST_CHANGE:
++		/* cache the power mode parameters to use internally */
++		memcpy(&host->dev_req_params,
++				dev_req_params, sizeof(*dev_req_params));
++
++		ufs_qcom_icc_update_bw(host);
++
++		/* disable the device ref clock if entered PWM mode */
++		if (ufshcd_is_hs_mode(&hba->pwr_info) &&
++			!ufshcd_is_hs_mode(dev_req_params))
++			ufs_qcom_dev_ref_clk_ctrl(host, false);
++		break;
++	default:
++		ret = -EINVAL;
++		break;
++	}
++
++	return ret;
++}
++
++static int ufs_qcom_quirk_host_pa_saveconfigtime(struct ufs_hba *hba)
++{
++	int err;
++	u32 pa_vs_config_reg1;
++
++	err = ufshcd_dme_get(hba, UIC_ARG_MIB(PA_VS_CONFIG_REG1),
++			     &pa_vs_config_reg1);
++	if (err)
++		return err;
++
++	/* Allow extension of MSB bits of PA_SaveConfigTime attribute */
++	return ufshcd_dme_set(hba, UIC_ARG_MIB(PA_VS_CONFIG_REG1),
++			    (pa_vs_config_reg1 | (1 << 12)));
++}
++
++static void ufs_qcom_override_pa_tx_hsg1_sync_len(struct ufs_hba *hba)
++{
++	int err;
++
++	err = ufshcd_dme_peer_set(hba, UIC_ARG_MIB(PA_TX_HSG1_SYNC_LENGTH),
++				  PA_TX_HSG1_SYNC_LENGTH_VAL);
++	if (err)
++		dev_err(hba->dev, "Failed (%d) set PA_TX_HSG1_SYNC_LENGTH\n", err);
++}
++
++/**
++ * ufs_qcom_double_t_adapt_l0l1l2l3 - Create a new adapt that doubles the
++ * adaptation duration TADAPT_L0_L1_L2_L3 derived from the old adapt.
++ *
++ * @old_adapt: Original ADAPT_L0_L1_L2_L3 capability
++ *
++ * ADAPT_length_L0_L1_L2_L3 formula from M-PHY spec:
++ * if (ADAPT_range_L0_L1_L2_L3 == COARSE) {
++ *   ADAPT_length_L0_L1_L2_L3 = [0, 12]
++ *   ADAPT_L0_L1_L2_L3 = 215 x 2^ADAPT_length_L0_L1_L2_L3
++ * } else if (ADAPT_range_L0_L1_L2_L3 == FINE) {
++ *   ADAPT_length_L0_L1_L2_L3 = [0, 127]
++ *   TADAPT_L0_L1_L2_L3 = 215 x (ADAPT_length_L0_L1_L2_L3 + 1)
++ * }
++ *
++ * To double the adaptation duration TADAPT_L0_L1_L2_L3:
++ * 1. If adapt range is COARSE (1'b1), new adapt = old adapt + 1.
++ * 2. If adapt range is FINE (1'b0):
++ *   a) If old adapt length is < 64, (new adapt + 1) = 2 * (old adapt + 1).
++ *   b) If old adapt length is >= 64, set new adapt to 0x88 using COARSE
++ *      range, because new adapt get from equation in a) shall exceed 127.
++ *
++ * Examples:
++ * ADAPT_range_L0_L1_L2_L3 | ADAPT_length_L0_L1_L2_L3 | TADAPT_L0_L1_L2_L3 (PAM-4 UI)
++ *		0			3			131072
++ *		0			7			262144
++ *		0			63			2097152
++ *		0			64			2129920
++ *		0			127			4194304
++ *		1			8			8388608
++ *		1			9			16777216
++ *		1			10			33554432
++ *		1			11			67108864
++ *		1			12			134217728
++ *
++ * Return: new adapt.
++ */
++static u32 ufs_qcom_double_t_adapt_l0l1l2l3(u32 old_adapt)
++{
++	u32 adapt_length = old_adapt & ADAPT_LENGTH_MASK;
++	u32 new_adapt;
++
++	if (IS_ADAPT_RANGE_COARSE(old_adapt)) {
++		new_adapt = (adapt_length + 1) | ADAPT_RANGE_BIT;
++	} else {
++		if (adapt_length < 64)
++			new_adapt = (adapt_length << 1) + 1;
++		else
++			/*
++			 * 0x88 is the very coarse Adapt value which is two
++			 * times of the largest fine Adapt value (0x7F)
++			 */
++			new_adapt = 0x88;
++	}
++
++	return new_adapt;
++}
++
++static void ufs_qcom_limit_max_gear(struct ufs_hba *hba,
++				    enum ufs_hs_gear_tag gear)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	struct ufs_pa_layer_attr *pwr_info = &hba->max_pwr_info.info;
++	struct ufs_host_params *host_params = &host->host_params;
++
++	host_params->hs_tx_gear = gear;
++	host_params->hs_rx_gear = gear;
++	pwr_info->gear_tx = gear;
++	pwr_info->gear_rx = gear;
++
++	dev_warn(hba->dev, "Limited max gear of host and device to HS-G%d\n", gear);
++}
++
++static void ufs_qcom_fixup_tx_adapt_l0l1l2l3(struct ufs_hba *hba)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	struct ufs_pa_layer_attr *pwr_info = &hba->max_pwr_info.info;
++	struct ufs_host_params *host_params = &host->host_params;
++	u32 old_adapt, new_adapt, actual_adapt;
++	bool limit_speed = false;
++	int err;
++
++	if (host->hw_ver.major != 0x7 || host->hw_ver.minor > 0x1 ||
++	    host_params->hs_tx_gear <= UFS_HS_G5 ||
++	    pwr_info->gear_tx <= UFS_HS_G5)
++		return;
++
++	err = ufshcd_dme_get(hba, UIC_ARG_MIB(PA_PEERRXHSG6ADAPTINITIALL0L1L2L3), &old_adapt);
++	if (err)
++		goto out;
++
++	if (old_adapt > ADAPT_L0L1L2L3_LENGTH_MAX) {
++		dev_err(hba->dev, "PA_PeerRxHsG6AdaptInitialL0L1L2L3 value (0x%x) exceeds MAX\n",
++			old_adapt);
++		err = -ERANGE;
++		goto out;
++	}
++
++	new_adapt = ufs_qcom_double_t_adapt_l0l1l2l3(old_adapt);
++	dev_dbg(hba->dev, "Original PA_PeerRxHsG6AdaptInitialL0L1L2L3 = 0x%x, new value = 0x%x\n",
++		old_adapt, new_adapt);
++
++	/*
++	 * 0x8C is the max possible value allowed by UniPro v3.0 spec, some HWs
++	 * can accept 0x8D but some cannot.
++	 */
++	if (new_adapt <= ADAPT_L0L1L2L3_LENGTH_MAX ||
++	    (new_adapt == ADAPT_L0L1L2L3_LENGTH_MAX + 1 && host->hw_ver.minor == 0x1)) {
++		err = ufshcd_dme_set(hba, UIC_ARG_MIB(PA_PEERRXHSG6ADAPTINITIALL0L1L2L3),
++				     new_adapt);
++		if (err)
++			goto out;
++
++		err = ufshcd_dme_get(hba, UIC_ARG_MIB(PA_PEERRXHSG6ADAPTINITIALL0L1L2L3),
++				     &actual_adapt);
++		if (err)
++			goto out;
++
++		if (actual_adapt != new_adapt) {
++			limit_speed = true;
++			dev_warn(hba->dev, "PA_PeerRxHsG6AdaptInitialL0L1L2L3 0x%x, expect 0x%x\n",
++				 actual_adapt, new_adapt);
++		}
++	} else {
++		limit_speed = true;
++		dev_warn(hba->dev, "New PA_PeerRxHsG6AdaptInitialL0L1L2L3 (0x%x) is too large!\n",
++			 new_adapt);
++	}
++
++	err = ufshcd_dme_get(hba, UIC_ARG_MIB(PA_PEERRXHSG6ADAPTREFRESHL0L1L2L3), &old_adapt);
++	if (err)
++		goto out;
++
++	if (old_adapt > ADAPT_L0L1L2L3_LENGTH_MAX) {
++		dev_err(hba->dev, "PA_PeerRxHsG6AdaptRefreshL0L1L2L3 value (0x%x) exceeds MAX\n",
++			old_adapt);
++		err = -ERANGE;
++		goto out;
++	}
++
++	new_adapt = ufs_qcom_double_t_adapt_l0l1l2l3(old_adapt);
++	dev_dbg(hba->dev, "Original PA_PeerRxHsG6AdaptRefreshL0L1L2L3 = 0x%x, new value = 0x%x\n",
++		old_adapt, new_adapt);
++
++	/*
++	 * 0x8C is the max possible value allowed by UniPro v3.0 spec, some HWs
++	 * can accept 0x8D but some cannot.
++	 */
++	if (new_adapt <= ADAPT_L0L1L2L3_LENGTH_MAX ||
++	    (new_adapt == ADAPT_L0L1L2L3_LENGTH_MAX + 1 && host->hw_ver.minor == 0x1)) {
++		err = ufshcd_dme_set(hba, UIC_ARG_MIB(PA_PEERRXHSG6ADAPTREFRESHL0L1L2L3),
++				     new_adapt);
++		if (err)
++			goto out;
++
++		err = ufshcd_dme_get(hba, UIC_ARG_MIB(PA_PEERRXHSG6ADAPTREFRESHL0L1L2L3),
++				     &actual_adapt);
++		if (err)
++			goto out;
++
++		if (actual_adapt != new_adapt) {
++			limit_speed = true;
++			dev_warn(hba->dev, "PA_PeerRxHsG6AdaptRefreshL0L1L2L3 0x%x, expect 0x%x\n",
++				 new_adapt, actual_adapt);
++		}
++	} else {
++		limit_speed = true;
++		dev_warn(hba->dev, "New PA_PeerRxHsG6AdaptRefreshL0L1L2L3 (0x%x) is too large!\n",
++			 new_adapt);
++	}
++
++out:
++	if (limit_speed || err)
++		ufs_qcom_limit_max_gear(hba, UFS_HS_G5);
++}
++
++static int ufs_qcom_apply_dev_quirks(struct ufs_hba *hba)
++{
++	int err = 0;
++
++	ufs_qcom_fixup_tx_adapt_l0l1l2l3(hba);
++
++	if (hba->dev_quirks & UFS_DEVICE_QUIRK_HOST_PA_SAVECONFIGTIME)
++		err = ufs_qcom_quirk_host_pa_saveconfigtime(hba);
++
++	if (hba->dev_quirks & UFS_DEVICE_QUIRK_PA_TX_HSG1_SYNC_LENGTH)
++		ufs_qcom_override_pa_tx_hsg1_sync_len(hba);
++
++	return err;
++}
++
++/* UFS device-specific quirks */
++static struct ufs_dev_quirk ufs_qcom_dev_fixups[] = {
++	{ .wmanufacturerid = UFS_VENDOR_SKHYNIX,
++	  .model = UFS_ANY_MODEL,
++	  .quirk = UFS_DEVICE_QUIRK_DELAY_BEFORE_LPM },
++	{ .wmanufacturerid = UFS_VENDOR_WDC,
++	  .model = UFS_ANY_MODEL,
++	  .quirk = UFS_DEVICE_QUIRK_HOST_PA_TACTIVATE },
++	{ .wmanufacturerid = UFS_VENDOR_SAMSUNG,
++	  .model = UFS_ANY_MODEL,
++	  .quirk = UFS_DEVICE_QUIRK_PA_TX_HSG1_SYNC_LENGTH |
++		   UFS_DEVICE_QUIRK_PA_TX_DEEMPHASIS_TUNING },
++	{}
++};
++
++static void ufs_qcom_fixup_dev_quirks(struct ufs_hba *hba)
++{
++	ufshcd_fixup_dev_quirks(hba, ufs_qcom_dev_fixups);
++}
++
++static u32 ufs_qcom_get_ufs_hci_version(struct ufs_hba *hba)
++{
++	return ufshci_version(2, 0);
++}
++
++/**
++ * ufs_qcom_advertise_quirks - advertise the known QCOM UFS controller quirks
++ * @hba: host controller instance
++ *
++ * QCOM UFS host controller might have some non standard behaviours (quirks)
++ * than what is specified by UFSHCI specification. Advertise all such
++ * quirks to standard UFS host controller driver so standard takes them into
++ * account.
++ */
++static void ufs_qcom_advertise_quirks(struct ufs_hba *hba)
++{
++	const struct ufs_qcom_drvdata *drvdata = of_device_get_match_data(hba->dev);
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	if (host->hw_ver.major == 0x2)
++		hba->quirks |= UFSHCD_QUIRK_BROKEN_UFS_HCI_VERSION;
++
++	if (host->hw_ver.major > 0x3)
++		hba->quirks |= UFSHCD_QUIRK_REINIT_AFTER_MAX_GEAR_SWITCH;
++
++	if (drvdata && drvdata->quirks)
++		hba->quirks |= drvdata->quirks;
++}
++
++static void ufs_qcom_set_phy_gear(struct ufs_qcom_host *host)
++{
++	struct ufs_host_params *host_params = &host->host_params;
++	u32 val, dev_major;
++
++	/*
++	 * Default to powering up the PHY to the max gear possible, which is
++	 * backwards compatible with lower gears but not optimal from
++	 * a power usage point of view. After device negotiation, if the
++	 * gear is lower a reinit will be performed to program the PHY
++	 * to the ideal gear for this combo of controller and device.
++	 */
++	host->phy_gear = host_params->hs_tx_gear;
++
++	if (host->hw_ver.major < 0x4) {
++		/*
++		 * These controllers only have one PHY init sequence,
++		 * let's power up the PHY using that (the minimum supported
++		 * gear, UFS_HS_G2).
++		 */
++		host->phy_gear = UFS_HS_G2;
++	} else if (host->hw_ver.major >= 0x5) {
++		val = ufshcd_readl(host->hba, REG_UFS_DEBUG_SPARE_CFG);
++		dev_major = FIELD_GET(UFS_DEV_VER_MAJOR_MASK, val);
++
++		/*
++		 * Since the UFS device version is populated, let's remove the
++		 * REINIT quirk as the negotiated gear won't change during boot.
++		 * So there is no need to do reinit.
++		 */
++		if (dev_major != 0x0)
++			host->hba->quirks &= ~UFSHCD_QUIRK_REINIT_AFTER_MAX_GEAR_SWITCH;
++
++		/*
++		 * For UFS 3.1 device and older, power up the PHY using HS-G4
++		 * PHY gear to save power.
++		 */
++		if (dev_major > 0x0 && dev_major < 0x4)
++			host->phy_gear = UFS_HS_G4;
++	}
++}
++
++static void ufs_qcom_parse_gear_limits(struct ufs_hba *hba)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	struct ufs_host_params *host_params = &host->host_params;
++	u32 hs_gear_old = host_params->hs_tx_gear;
++
++	ufshcd_parse_gear_limits(hba, host_params);
++	if (host_params->hs_tx_gear != hs_gear_old) {
++		host->phy_gear = host_params->hs_tx_gear;
++	}
++}
++
++static void ufs_qcom_set_host_params(struct ufs_hba *hba)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	struct ufs_host_params *host_params = &host->host_params;
++
++	ufshcd_init_host_params(host_params);
++
++	/* This driver only supports symmetic gear setting i.e., hs_tx_gear == hs_rx_gear */
++	host_params->hs_tx_gear = host_params->hs_rx_gear = ufs_qcom_get_hs_gear(hba);
++}
++
++static void ufs_qcom_set_host_caps(struct ufs_hba *hba)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	if (host->hw_ver.major >= 0x5)
++		host->caps |= UFS_QCOM_CAP_ICE_CONFIG;
++}
++
++static void ufs_qcom_set_caps(struct ufs_hba *hba)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	hba->caps |= UFSHCD_CAP_CLK_GATING | UFSHCD_CAP_HIBERN8_WITH_CLK_GATING;
++	hba->caps |= UFSHCD_CAP_CLK_SCALING | UFSHCD_CAP_WB_WITH_CLK_SCALING;
++	hba->caps |= UFSHCD_CAP_AUTO_BKOPS_SUSPEND;
++	hba->caps |= UFSHCD_CAP_WB_EN;
++	hba->caps |= UFSHCD_CAP_AGGR_POWER_COLLAPSE;
++	hba->caps |= UFSHCD_CAP_RPM_AUTOSUSPEND;
++
++	if (host->hw_ver.major >= 0x7)
++		hba->caps |= UFSHCD_CAP_TX_EQUALIZATION;
++
++	ufs_qcom_set_host_caps(hba);
++}
++
++/**
++ * ufs_qcom_setup_clocks - enables/disable clocks
++ * @hba: host controller instance
++ * @on: If true, enable clocks else disable them.
++ * @status: PRE_CHANGE or POST_CHANGE notify
++ *
++ * There are certain clocks which comes from the PHY so it needs
++ * to be managed together along with controller clocks which also
++ * provides a better power saving. Hence keep phy_power_off/on calls
++ * in ufs_qcom_setup_clocks, so that PHY's regulators & clks can be
++ * turned on/off along with UFS's clocks.
++ *
++ * Return: 0 on success, non-zero on failure.
++ */
++static int ufs_qcom_setup_clocks(struct ufs_hba *hba, bool on,
++				 enum ufs_notify_change_status status)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	struct phy *phy;
++	int err;
++
++	/*
++	 * In case ufs_qcom_init() is not yet done, simply ignore.
++	 * This ufs_qcom_setup_clocks() shall be called from
++	 * ufs_qcom_init() after init is done.
++	 */
++	if (!host)
++		return 0;
++
++	phy = host->generic_phy;
++
++	switch (status) {
++	case PRE_CHANGE:
++		if (on) {
++			ufs_qcom_icc_update_bw(host);
++			if (ufs_qcom_is_link_hibern8(hba)) {
++				err = ufs_qcom_enable_lane_clks(host);
++				if (err) {
++					dev_err(hba->dev, "enable lane clks failed, ret=%d\n", err);
++					return err;
++				}
++			}
++		} else {
++			if (!ufs_qcom_is_link_active(hba)) {
++				/* disable device ref_clk */
++				ufs_qcom_dev_ref_clk_ctrl(host, false);
++			}
++
++			err = phy_power_off(phy);
++			if (err) {
++				dev_err(hba->dev, "phy power off failed, ret=%d\n", err);
++				return err;
++			}
++		}
++		break;
++	case POST_CHANGE:
++		if (on) {
++			err = phy_power_on(phy);
++			if (err) {
++				dev_err(hba->dev, "phy power on failed, ret = %d\n", err);
++				return err;
++			}
++
++			/* enable the device ref clock for HS mode*/
++			if (ufshcd_is_hs_mode(&hba->pwr_info))
++				ufs_qcom_dev_ref_clk_ctrl(host, true);
++		} else {
++			if (ufs_qcom_is_link_hibern8(hba))
++				ufs_qcom_disable_lane_clks(host);
++
++			ufs_qcom_icc_set_bw(host, ufs_qcom_bw_table[MODE_MIN][0][0].mem_bw,
++					    ufs_qcom_bw_table[MODE_MIN][0][0].cfg_bw);
++		}
++		break;
++	}
++
++	return 0;
++}
++
++static int
++ufs_qcom_reset_assert(struct reset_controller_dev *rcdev, unsigned long id)
++{
++	struct ufs_qcom_host *host = rcdev_to_ufs_host(rcdev);
++
++	ufs_qcom_assert_reset(host->hba);
++	/* provide 1ms delay to let the reset pulse propagate. */
++	usleep_range(1000, 1100);
++	return 0;
++}
++
++static int
++ufs_qcom_reset_deassert(struct reset_controller_dev *rcdev, unsigned long id)
++{
++	struct ufs_qcom_host *host = rcdev_to_ufs_host(rcdev);
++
++	ufs_qcom_deassert_reset(host->hba);
++
++	/*
++	 * after reset deassertion, phy will need all ref clocks,
++	 * voltage, current to settle down before starting serdes.
++	 */
++	usleep_range(1000, 1100);
++	return 0;
++}
++
++static const struct reset_control_ops ufs_qcom_reset_ops = {
++	.assert = ufs_qcom_reset_assert,
++	.deassert = ufs_qcom_reset_deassert,
++};
++
++static int ufs_qcom_icc_init(struct ufs_qcom_host *host)
++{
++	struct device *dev = host->hba->dev;
++	int ret;
++
++	host->icc_ddr = devm_of_icc_get(dev, "ufs-ddr");
++	if (IS_ERR(host->icc_ddr))
++		return dev_err_probe(dev, PTR_ERR(host->icc_ddr),
++				    "failed to acquire interconnect path\n");
++
++	host->icc_cpu = devm_of_icc_get(dev, "cpu-ufs");
++	if (IS_ERR(host->icc_cpu))
++		return dev_err_probe(dev, PTR_ERR(host->icc_cpu),
++				    "failed to acquire interconnect path\n");
++
++	/*
++	 * Set Maximum bandwidth vote before initializing the UFS controller and
++	 * device. Ideally, a minimal interconnect vote would suffice for the
++	 * initialization, but a max vote would allow faster initialization.
++	 */
++	ret = ufs_qcom_icc_set_bw(host, ufs_qcom_bw_table[MODE_MAX][0][0].mem_bw,
++				  ufs_qcom_bw_table[MODE_MAX][0][0].cfg_bw);
++	if (ret < 0)
++		return dev_err_probe(dev, ret, "failed to set bandwidth request\n");
++
++	return 0;
++}
++
++/**
++ * ufs_qcom_init - bind phy with controller
++ * @hba: host controller instance
++ *
++ * Binds PHY with controller and powers up PHY enabling clocks
++ * and regulators.
++ *
++ * Return: -EPROBE_DEFER if binding fails, returns negative error
++ * on phy power up failure and returns zero on success.
++ */
++static int ufs_qcom_init(struct ufs_hba *hba)
++{
++	int err;
++	struct device *dev = hba->dev;
++	struct ufs_qcom_host *host;
++	struct ufs_clk_info *clki;
++	const struct ufs_qcom_drvdata *drvdata = of_device_get_match_data(hba->dev);
++
++	host = devm_kzalloc(dev, sizeof(*host), GFP_KERNEL);
++	if (!host)
++		return -ENOMEM;
++
++	/* Make a two way bind between the qcom host and the hba */
++	host->hba = hba;
++	ufshcd_set_variant(hba, host);
++
++	/* Setup the optional reset control of HCI */
++	host->core_reset = devm_reset_control_get_optional(hba->dev, "rst");
++	if (IS_ERR(host->core_reset)) {
++		err = dev_err_probe(dev, PTR_ERR(host->core_reset),
++				    "Failed to get reset control\n");
++		goto out_variant_clear;
++	}
++
++	/* Fire up the reset controller. Failure here is non-fatal. */
++	host->rcdev.of_node = dev->of_node;
++	host->rcdev.ops = &ufs_qcom_reset_ops;
++	host->rcdev.owner = dev->driver->owner;
++	host->rcdev.nr_resets = 1;
++	err = devm_reset_controller_register(dev, &host->rcdev);
++	if (err)
++		dev_warn(dev, "Failed to register reset controller\n");
++
++	if (!has_acpi_companion(dev)) {
++		host->generic_phy = devm_phy_get(dev, "ufsphy");
++		if (IS_ERR(host->generic_phy)) {
++			err = dev_err_probe(dev, PTR_ERR(host->generic_phy), "Failed to get PHY\n");
++			goto out_variant_clear;
++		}
++	}
++
++	err = ufs_qcom_icc_init(host);
++	if (err)
++		goto out_variant_clear;
++
++	host->device_reset = devm_gpiod_get_optional(dev, "reset",
++						     GPIOD_OUT_HIGH);
++	if (IS_ERR(host->device_reset)) {
++		err = dev_err_probe(dev, PTR_ERR(host->device_reset),
++				    "Failed to acquire device reset gpio\n");
++		goto out_variant_clear;
++	}
++
++	ufs_qcom_get_controller_revision(hba, &host->hw_ver.major,
++		&host->hw_ver.minor, &host->hw_ver.step);
++
++	host->dev_ref_clk_ctrl_mmio = hba->mmio_base + REG_UFS_CFG1;
++	host->dev_ref_clk_en_mask = BIT(26);
++
++	list_for_each_entry(clki, &hba->clk_list_head, list) {
++		if (!strcmp(clki->name, "core_clk_unipro"))
++			clki->keep_link_active = true;
++	}
++
++	err = ufs_qcom_init_lane_clks(host);
++	if (err)
++		goto out_variant_clear;
++
++	ufs_qcom_set_caps(hba);
++	ufs_qcom_advertise_quirks(hba);
++	ufs_qcom_set_host_params(hba);
++	ufs_qcom_set_phy_gear(host);
++	ufs_qcom_parse_gear_limits(hba);
++
++	err = ufs_qcom_ice_init(host);
++	if (err)
++		goto out_variant_clear;
++
++	ufs_qcom_setup_clocks(hba, true, POST_CHANGE);
++
++	ufs_qcom_get_default_testbus_cfg(host);
++	err = ufs_qcom_testbus_config(host);
++	if (err)
++		/* Failure is non-fatal */
++		dev_warn(dev, "%s: failed to configure the testbus %d\n",
++				__func__, err);
++
++	if (drvdata && drvdata->no_phy_retention)
++		hba->spm_lvl = UFS_PM_LVL_5;
++
++	return 0;
++
++out_variant_clear:
++	ufshcd_set_variant(hba, NULL);
++
++	return err;
++}
++
++static void ufs_qcom_exit(struct ufs_hba *hba)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	ufs_qcom_disable_lane_clks(host);
++	phy_power_off(host->generic_phy);
++	phy_exit(host->generic_phy);
++}
++
++static int ufs_qcom_fw_managed_init(struct ufs_hba *hba)
++{
++	struct device *dev = hba->dev;
++	struct ufs_qcom_host *host;
++	int err;
++
++	host = devm_kzalloc(dev, sizeof(*host), GFP_KERNEL);
++	if (!host)
++		return -ENOMEM;
++
++	host->hba = hba;
++	ufshcd_set_variant(hba, host);
++
++	ufs_qcom_get_controller_revision(hba, &host->hw_ver.major,
++					 &host->hw_ver.minor, &host->hw_ver.step);
++
++	err = ufs_qcom_ice_init(host);
++	if (err)
++		goto out_variant_clear;
++
++	ufs_qcom_get_default_testbus_cfg(host);
++	err = ufs_qcom_testbus_config(host);
++	if (err)
++		/* Failure is non-fatal */
++		dev_warn(dev, "Failed to configure the testbus %d\n", err);
++
++	hba->caps |= UFSHCD_CAP_WB_EN;
++
++	ufs_qcom_advertise_quirks(hba);
++	host->hba->quirks &= ~UFSHCD_QUIRK_REINIT_AFTER_MAX_GEAR_SWITCH;
++
++	hba->spm_lvl = hba->rpm_lvl = hba->pm_lvl_min = UFS_PM_LVL_5;
++
++	ufs_qcom_set_host_params(hba);
++	ufs_qcom_parse_gear_limits(hba);
++
++	return 0;
++
++out_variant_clear:
++	ufshcd_set_variant(hba, NULL);
++	return err;
++}
++
++static void ufs_qcom_fw_managed_exit(struct ufs_hba *hba)
++{
++	pm_runtime_put_sync(hba->dev);
++}
++
++/**
++ * ufs_qcom_set_clk_40ns_cycles - Configure 40ns clk cycles
++ *
++ * @hba: host controller instance
++ * @cycles_in_1us: No of cycles in 1us to be configured
++ *
++ * Returns error if dme get/set configuration for 40ns fails
++ * and returns zero on success.
++ */
++static int ufs_qcom_set_clk_40ns_cycles(struct ufs_hba *hba,
++					u32 cycles_in_1us)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	u32 cycles_in_40ns;
++	u32 reg;
++	int err;
++
++	/*
++	 * UFS host controller V4.0.0 onwards needs to program
++	 * PA_VS_CORE_CLK_40NS_CYCLES attribute per programmed
++	 * frequency of unipro core clk of UFS host controller.
++	 */
++	if (host->hw_ver.major < 4)
++		return 0;
++
++	/*
++	 * Generic formulae for cycles_in_40ns = (freq_unipro/25) is not
++	 * applicable for all frequencies. For ex: ceil(37.5 MHz/25) will
++	 * be 2 and ceil(403 MHZ/25) will be 17 whereas Hardware
++	 * specification expect to be 16. Hence use exact hardware spec
++	 * mandated value for cycles_in_40ns instead of calculating using
++	 * generic formulae.
++	 */
++	switch (cycles_in_1us) {
++	case UNIPRO_CORE_CLK_FREQ_403_MHZ:
++		cycles_in_40ns = 16;
++		break;
++	case UNIPRO_CORE_CLK_FREQ_300_MHZ:
++		cycles_in_40ns = 12;
++		break;
++	case UNIPRO_CORE_CLK_FREQ_201_5_MHZ:
++		cycles_in_40ns = 8;
++		break;
++	case UNIPRO_CORE_CLK_FREQ_150_MHZ:
++		cycles_in_40ns = 6;
++		break;
++	case UNIPRO_CORE_CLK_FREQ_100_MHZ:
++		cycles_in_40ns = 4;
++		break;
++	case  UNIPRO_CORE_CLK_FREQ_75_MHZ:
++		cycles_in_40ns = 3;
++		break;
++	case UNIPRO_CORE_CLK_FREQ_37_5_MHZ:
++		cycles_in_40ns = 2;
++		break;
++	default:
++		dev_err(hba->dev, "UNIPRO clk freq %u MHz not supported\n",
++				cycles_in_1us);
++		return -EINVAL;
++	}
++
++	err = ufshcd_dme_get(hba, UIC_ARG_MIB(PA_VS_CORE_CLK_40NS_CYCLES), &reg);
++	if (err)
++		return err;
++
++	reg &= ~PA_VS_CORE_CLK_40NS_CYCLES_MASK;
++	reg |= cycles_in_40ns;
++
++	return ufshcd_dme_set(hba, UIC_ARG_MIB(PA_VS_CORE_CLK_40NS_CYCLES), reg);
++}
++
++static int ufs_qcom_set_core_clk_ctrl(struct ufs_hba *hba, bool is_scale_up, unsigned long freq)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	struct list_head *head = &hba->clk_list_head;
++	struct ufs_clk_info *clki;
++	u32 cycles_in_1us = 0;
++	u32 core_clk_ctrl_reg;
++	unsigned long clk_freq;
++	int err;
++
++	if (hba->use_pm_opp && freq != ULONG_MAX) {
++		clk_freq = ufs_qcom_opp_freq_to_clk_freq(hba, freq, "core_clk_unipro");
++		if (clk_freq) {
++			cycles_in_1us = ceil(clk_freq, HZ_PER_MHZ);
++			goto set_core_clk_ctrl;
++		}
++	}
++
++	list_for_each_entry(clki, head, list) {
++		if (!IS_ERR_OR_NULL(clki->clk) &&
++		    !strcmp(clki->name, "core_clk_unipro")) {
++			if (!clki->max_freq) {
++				cycles_in_1us = 150; /* default for backwards compatibility */
++				break;
++			}
++
++			if (freq == ULONG_MAX) {
++				cycles_in_1us = ceil(clki->max_freq, HZ_PER_MHZ);
++				break;
++			}
++
++			if (is_scale_up)
++				cycles_in_1us = ceil(clki->max_freq, HZ_PER_MHZ);
++			else
++				cycles_in_1us = ceil(clk_get_rate(clki->clk), HZ_PER_MHZ);
++			break;
++		}
++	}
++
++set_core_clk_ctrl:
++	err = ufshcd_dme_get(hba,
++			    UIC_ARG_MIB(DME_VS_CORE_CLK_CTRL),
++			    &core_clk_ctrl_reg);
++	if (err)
++		return err;
++
++	/* Bit mask is different for UFS host controller V4.0.0 onwards */
++	if (host->hw_ver.major >= 4) {
++		if (!FIELD_FIT(CLK_1US_CYCLES_MASK_V4, cycles_in_1us))
++			return -ERANGE;
++		core_clk_ctrl_reg &= ~CLK_1US_CYCLES_MASK_V4;
++		core_clk_ctrl_reg |= FIELD_PREP(CLK_1US_CYCLES_MASK_V4, cycles_in_1us);
++	} else {
++		if (!FIELD_FIT(CLK_1US_CYCLES_MASK, cycles_in_1us))
++			return -ERANGE;
++		core_clk_ctrl_reg &= ~CLK_1US_CYCLES_MASK;
++		core_clk_ctrl_reg |= FIELD_PREP(CLK_1US_CYCLES_MASK, cycles_in_1us);
++	}
++
++	/* Clear CORE_CLK_DIV_EN */
++	core_clk_ctrl_reg &= ~DME_VS_CORE_CLK_CTRL_CORE_CLK_DIV_EN_BIT;
++
++	err = ufshcd_dme_set(hba,
++			    UIC_ARG_MIB(DME_VS_CORE_CLK_CTRL),
++			    core_clk_ctrl_reg);
++	if (err)
++		return err;
++
++	/* Configure unipro core clk 40ns attribute */
++	return ufs_qcom_set_clk_40ns_cycles(hba, cycles_in_1us);
++}
++
++static int ufs_qcom_clk_scale_up_pre_change(struct ufs_hba *hba, unsigned long freq)
++{
++	int ret;
++
++	ret = ufs_qcom_cfg_timers(hba, true, freq);
++	if (ret) {
++		dev_err(hba->dev, "%s ufs cfg timer failed\n", __func__);
++		return ret;
++	}
++	/* set unipro core clock attributes and clear clock divider */
++	return ufs_qcom_set_core_clk_ctrl(hba, true, freq);
++}
++
++static int ufs_qcom_clk_scale_up_post_change(struct ufs_hba *hba)
++{
++	return 0;
++}
++
++static int ufs_qcom_clk_scale_down_pre_change(struct ufs_hba *hba)
++{
++	int err;
++	u32 core_clk_ctrl_reg;
++
++	err = ufshcd_dme_get(hba,
++			    UIC_ARG_MIB(DME_VS_CORE_CLK_CTRL),
++			    &core_clk_ctrl_reg);
++
++	/* make sure CORE_CLK_DIV_EN is cleared */
++	if (!err &&
++	    (core_clk_ctrl_reg & DME_VS_CORE_CLK_CTRL_CORE_CLK_DIV_EN_BIT)) {
++		core_clk_ctrl_reg &= ~DME_VS_CORE_CLK_CTRL_CORE_CLK_DIV_EN_BIT;
++		err = ufshcd_dme_set(hba,
++				    UIC_ARG_MIB(DME_VS_CORE_CLK_CTRL),
++				    core_clk_ctrl_reg);
++	}
++
++	return err;
++}
++
++static int ufs_qcom_clk_scale_down_post_change(struct ufs_hba *hba, unsigned long freq)
++{
++	int ret;
++
++	ret = ufs_qcom_cfg_timers(hba, false, freq);
++	if (ret) {
++		dev_err(hba->dev, "%s: ufs_qcom_cfg_timers() failed\n",	__func__);
++		return ret;
++	}
++	/* set unipro core clock attributes and clear clock divider */
++	return ufs_qcom_set_core_clk_ctrl(hba, false, freq);
++}
++
++static int ufs_qcom_clk_scale_notify(struct ufs_hba *hba, bool scale_up,
++				     unsigned long target_freq,
++				     enum ufs_notify_change_status status)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	int err;
++
++	/* check the host controller state before sending hibern8 cmd */
++	if (!ufshcd_is_hba_active(hba))
++		return 0;
++
++	if (status == PRE_CHANGE) {
++		err = ufshcd_uic_hibern8_enter(hba);
++		if (err)
++			return err;
++		if (scale_up)
++			err = ufs_qcom_clk_scale_up_pre_change(hba, target_freq);
++		else
++			err = ufs_qcom_clk_scale_down_pre_change(hba);
++
++		if (err) {
++			ufshcd_uic_hibern8_exit(hba);
++			return err;
++		}
++	} else {
++		if (scale_up)
++			err = ufs_qcom_clk_scale_up_post_change(hba);
++		else
++			err = ufs_qcom_clk_scale_down_post_change(hba, target_freq);
++
++
++		if (err) {
++			ufshcd_uic_hibern8_exit(hba);
++			return err;
++		}
++
++		ufs_qcom_icc_update_bw(host);
++		ufshcd_uic_hibern8_exit(hba);
++	}
++
++	return 0;
++}
++
++static void ufs_qcom_enable_test_bus(struct ufs_qcom_host *host)
++{
++	ufshcd_rmwl(host->hba, UFS_REG_TEST_BUS_EN,
++			UFS_REG_TEST_BUS_EN, REG_UFS_CFG1);
++	ufshcd_rmwl(host->hba, TEST_BUS_EN, TEST_BUS_EN, REG_UFS_CFG1);
++}
++
++static void ufs_qcom_get_default_testbus_cfg(struct ufs_qcom_host *host)
++{
++	/* provide a legal default configuration */
++	host->testbus.select_major = TSTBUS_UNIPRO;
++	host->testbus.select_minor = 37;
++}
++
++static bool ufs_qcom_testbus_cfg_is_ok(struct ufs_qcom_host *host)
++{
++	if (host->testbus.select_major >= TSTBUS_MAX) {
++		dev_err(host->hba->dev,
++			"%s: UFS_CFG1[TEST_BUS_SEL} may not equal 0x%05X\n",
++			__func__, host->testbus.select_major);
++		return false;
++	}
++
++	return true;
++}
++
++int ufs_qcom_testbus_config(struct ufs_qcom_host *host)
++{
++	int reg;
++	int offset;
++	u32 mask = TEST_BUS_SUB_SEL_MASK;
++
++	if (!host)
++		return -EINVAL;
++
++	if (!ufs_qcom_testbus_cfg_is_ok(host))
++		return -EPERM;
++
++	switch (host->testbus.select_major) {
++	case TSTBUS_UAWM:
++		reg = UFS_TEST_BUS_CTRL_0;
++		offset = 24;
++		break;
++	case TSTBUS_UARM:
++		reg = UFS_TEST_BUS_CTRL_0;
++		offset = 16;
++		break;
++	case TSTBUS_TXUC:
++		reg = UFS_TEST_BUS_CTRL_0;
++		offset = 8;
++		break;
++	case TSTBUS_RXUC:
++		reg = UFS_TEST_BUS_CTRL_0;
++		offset = 0;
++		break;
++	case TSTBUS_DFC:
++		reg = UFS_TEST_BUS_CTRL_1;
++		offset = 24;
++		break;
++	case TSTBUS_TRLUT:
++		reg = UFS_TEST_BUS_CTRL_1;
++		offset = 16;
++		break;
++	case TSTBUS_TMRLUT:
++		reg = UFS_TEST_BUS_CTRL_1;
++		offset = 8;
++		break;
++	case TSTBUS_OCSC:
++		reg = UFS_TEST_BUS_CTRL_1;
++		offset = 0;
++		break;
++	case TSTBUS_WRAPPER:
++		reg = UFS_TEST_BUS_CTRL_2;
++		offset = 16;
++		break;
++	case TSTBUS_COMBINED:
++		reg = UFS_TEST_BUS_CTRL_2;
++		offset = 8;
++		break;
++	case TSTBUS_UTP_HCI:
++		reg = UFS_TEST_BUS_CTRL_2;
++		offset = 0;
++		break;
++	case TSTBUS_UNIPRO:
++		reg = UFS_UNIPRO_CFG;
++		offset = 20;
++		mask = 0xFFF;
++		break;
++	/*
++	 * No need for a default case, since
++	 * ufs_qcom_testbus_cfg_is_ok() checks that the configuration
++	 * is legal
++	 */
++	}
++	mask <<= offset;
++	ufshcd_rmwl(host->hba, TEST_BUS_SEL,
++		    (u32)host->testbus.select_major << 19,
++		    REG_UFS_CFG1);
++	ufshcd_rmwl(host->hba, mask,
++		    (u32)host->testbus.select_minor << offset,
++		    reg);
++	ufs_qcom_enable_test_bus(host);
++
++	return 0;
++}
++
++static void ufs_qcom_dump_testbus(struct ufs_hba *hba)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	int i, j, nminor = 0, testbus_len = 0;
++	char *prefix;
++
++	u32 *testbus __free(kfree) = kmalloc_array(256, sizeof(u32), GFP_KERNEL);
++	if (!testbus)
++		return;
++
++	for (j = 0; j < TSTBUS_MAX; j++) {
++		nminor = testbus_info[j].nminor;
++		prefix = testbus_info[j].prefix;
++		host->testbus.select_major = j;
++		testbus_len = nminor * sizeof(u32);
++		for (i = 0; i < nminor; i++) {
++			host->testbus.select_minor = i;
++			ufs_qcom_testbus_config(host);
++			testbus[i] = ufshcd_readl(hba, UFS_TEST_BUS);
++		}
++		print_hex_dump(KERN_ERR, prefix, DUMP_PREFIX_OFFSET,
++			       16, 4, testbus, testbus_len, false);
++	}
++}
++
++static int ufs_qcom_dump_regs(struct ufs_hba *hba, size_t offset, size_t len,
++			      const char *prefix, void __iomem *base)
++{
++	size_t pos;
++
++	if (offset % 4 != 0 || len % 4 != 0)
++		return -EINVAL;
++
++	u32 *regs __free(kfree) = kzalloc(len, GFP_ATOMIC);
++	if (!regs)
++		return -ENOMEM;
++
++	for (pos = 0; pos < len; pos += 4)
++		regs[pos / 4] = readl(base + offset + pos);
++
++	print_hex_dump(KERN_ERR, prefix,
++		       len > 4 ? DUMP_PREFIX_OFFSET : DUMP_PREFIX_NONE,
++		       16, 4, regs, len, false);
++
++	return 0;
++}
++
++static void ufs_qcom_dump_mcq_hci_regs(struct ufs_hba *hba)
++{
++	struct ufshcd_mcq_opr_info_t *opr = &hba->mcq_opr[0];
++	void __iomem *mcq_vs_base = hba->mcq_base + UFS_MEM_VS_BASE;
++
++	struct dump_info {
++		void __iomem *base;
++		size_t offset;
++		size_t len;
++		const char *prefix;
++	};
++
++	struct dump_info mcq_dumps[] = {
++		{hba->mcq_base, 0x0, 256 * 4, "MCQ HCI-0 "},
++		{hba->mcq_base, 0x400, 256 * 4, "MCQ HCI-1 "},
++		{mcq_vs_base, 0x0, 5 * 4, "MCQ VS-0 "},
++		{opr->base, 0x0, 256 * 4, "MCQ SQD-0 "},
++		{opr->base, 0x400, 256 * 4, "MCQ SQD-1 "},
++		{opr->base, 0x800, 256 * 4, "MCQ SQD-2 "},
++		{opr->base, 0xc00, 256 * 4, "MCQ SQD-3 "},
++		{opr->base, 0x1000, 256 * 4, "MCQ SQD-4 "},
++		{opr->base, 0x1400, 256 * 4, "MCQ SQD-5 "},
++		{opr->base, 0x1800, 256 * 4, "MCQ SQD-6 "},
++		{opr->base, 0x1c00, 256 * 4, "MCQ SQD-7 "},
++
++	};
++
++	for (int i = 0; i < ARRAY_SIZE(mcq_dumps); i++) {
++		ufs_qcom_dump_regs(hba, mcq_dumps[i].offset, mcq_dumps[i].len,
++				   mcq_dumps[i].prefix, mcq_dumps[i].base);
++		cond_resched();
++	}
++}
++
++static void ufs_qcom_dump_dbg_regs(struct ufs_hba *hba)
++{
++	u32 reg;
++	struct ufs_qcom_host *host;
++
++	host = ufshcd_get_variant(hba);
++
++	dev_err(hba->dev, "HW_H8_ENTER_CNT=%d\n", ufshcd_readl(hba, REG_UFS_HW_H8_ENTER_CNT));
++	dev_err(hba->dev, "HW_H8_EXIT_CNT=%d\n", ufshcd_readl(hba, REG_UFS_HW_H8_EXIT_CNT));
++
++	dev_err(hba->dev, "SW_H8_ENTER_CNT=%d\n", ufshcd_readl(hba, REG_UFS_SW_H8_ENTER_CNT));
++	dev_err(hba->dev, "SW_H8_EXIT_CNT=%d\n", ufshcd_readl(hba, REG_UFS_SW_H8_EXIT_CNT));
++
++	dev_err(hba->dev, "SW_AFTER_HW_H8_ENTER_CNT=%d\n",
++			ufshcd_readl(hba, REG_UFS_SW_AFTER_HW_H8_ENTER_CNT));
++
++	ufshcd_dump_regs(hba, REG_UFS_SYS1CLK_1US, 16 * 4,
++			 "HCI Vendor Specific Registers ");
++
++	reg = ufs_qcom_get_debug_reg_offset(host, UFS_UFS_DBG_RD_REG_OCSC);
++	ufshcd_dump_regs(hba, reg, 44 * 4, "UFS_UFS_DBG_RD_REG_OCSC ");
++
++	reg = ufshcd_readl(hba, REG_UFS_CFG1);
++	reg |= UTP_DBG_RAMS_EN;
++	ufshcd_writel(hba, reg, REG_UFS_CFG1);
++
++	reg = ufs_qcom_get_debug_reg_offset(host, UFS_UFS_DBG_RD_EDTL_RAM);
++	ufshcd_dump_regs(hba, reg, 32 * 4, "UFS_UFS_DBG_RD_EDTL_RAM ");
++
++	reg = ufs_qcom_get_debug_reg_offset(host, UFS_UFS_DBG_RD_DESC_RAM);
++	ufshcd_dump_regs(hba, reg, 128 * 4, "UFS_UFS_DBG_RD_DESC_RAM ");
++
++	reg = ufs_qcom_get_debug_reg_offset(host, UFS_UFS_DBG_RD_PRDT_RAM);
++	ufshcd_dump_regs(hba, reg, 64 * 4, "UFS_UFS_DBG_RD_PRDT_RAM ");
++
++	/* clear bit 17 - UTP_DBG_RAMS_EN */
++	ufshcd_rmwl(hba, UTP_DBG_RAMS_EN, 0, REG_UFS_CFG1);
++
++	reg = ufs_qcom_get_debug_reg_offset(host, UFS_DBG_RD_REG_UAWM);
++	ufshcd_dump_regs(hba, reg, 4 * 4, "UFS_DBG_RD_REG_UAWM ");
++
++	reg = ufs_qcom_get_debug_reg_offset(host, UFS_DBG_RD_REG_UARM);
++	ufshcd_dump_regs(hba, reg, 4 * 4, "UFS_DBG_RD_REG_UARM ");
++
++	reg = ufs_qcom_get_debug_reg_offset(host, UFS_DBG_RD_REG_TXUC);
++	ufshcd_dump_regs(hba, reg, 48 * 4, "UFS_DBG_RD_REG_TXUC ");
++
++	reg = ufs_qcom_get_debug_reg_offset(host, UFS_DBG_RD_REG_RXUC);
++	ufshcd_dump_regs(hba, reg, 27 * 4, "UFS_DBG_RD_REG_RXUC ");
++
++	reg = ufs_qcom_get_debug_reg_offset(host, UFS_DBG_RD_REG_DFC);
++	ufshcd_dump_regs(hba, reg, 19 * 4, "UFS_DBG_RD_REG_DFC ");
++
++	reg = ufs_qcom_get_debug_reg_offset(host, UFS_DBG_RD_REG_TRLUT);
++	ufshcd_dump_regs(hba, reg, 34 * 4, "UFS_DBG_RD_REG_TRLUT ");
++
++	reg = ufs_qcom_get_debug_reg_offset(host, UFS_DBG_RD_REG_TMRLUT);
++	ufshcd_dump_regs(hba, reg, 9 * 4, "UFS_DBG_RD_REG_TMRLUT ");
++
++	if (hba->mcq_enabled) {
++		reg = ufs_qcom_get_debug_reg_offset(host, UFS_RD_REG_MCQ);
++		ufshcd_dump_regs(hba, reg, 64 * 4, "HCI MCQ Debug Registers ");
++	}
++
++	/* ensure below dumps occur only in task context due to blocking calls. */
++	if (in_task()) {
++		/* Dump MCQ Host Vendor Specific Registers */
++		if (hba->mcq_enabled)
++			ufs_qcom_dump_mcq_hci_regs(hba);
++
++		/* voluntarily yield the CPU as we are dumping too much data */
++		ufshcd_dump_regs(hba, UFS_TEST_BUS, 4, "UFS_TEST_BUS ");
++		cond_resched();
++		ufs_qcom_dump_testbus(hba);
++	}
++}
++
++/**
++ * ufs_qcom_device_reset() - toggle the (optional) device reset line
++ * @hba: per-adapter instance
++ *
++ * Toggles the (optional) reset line to reset the attached device.
++ */
++static int ufs_qcom_device_reset(struct ufs_hba *hba)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	/* reset gpio is optional */
++	if (!host->device_reset)
++		return -EOPNOTSUPP;
++
++	/*
++	 * The UFS device shall detect reset pulses of 1us, sleep for 10us to
++	 * be on the safe side.
++	 */
++	ufs_qcom_device_reset_ctrl(hba, true);
++	usleep_range(10, 15);
++
++	ufs_qcom_device_reset_ctrl(hba, false);
++	usleep_range(10, 15);
++
++	return 0;
++}
++
++/**
++ * ufs_qcom_fw_managed_device_reset - Reset UFS device under FW-managed design
++ * @hba: pointer to UFS host bus adapter
++ *
++ * In the firmware-managed reset model, the power domain is powered on by genpd
++ * before the UFS controller driver probes. For subsequent resets (such as
++ * suspend/resume or recovery), the UFS driver must explicitly invoke PM runtime
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++static int ufs_qcom_fw_managed_device_reset(struct ufs_hba *hba)
++{
++	static bool is_boot = true;
++	int err;
++
++	/* Skip reset on cold boot; perform it on subsequent calls */
++	if (is_boot) {
++		is_boot = false;
++		return 0;
++	}
++
++	pm_runtime_put_sync(hba->dev);
++	err = pm_runtime_resume_and_get(hba->dev);
++	if (err < 0) {
++		dev_err(hba->dev, "PM runtime resume failed: %d\n", err);
++		return err;
++	}
++
++	return 0;
++}
++
++static void ufs_qcom_config_scaling_param(struct ufs_hba *hba,
++					struct devfreq_dev_profile *p,
++					struct devfreq_simple_ondemand_data *d)
++{
++	p->polling_ms = 60;
++	p->timer = DEVFREQ_TIMER_DELAYED;
++	d->upthreshold = 70;
++	d->downdifferential = 5;
++
++	hba->clk_scaling.suspend_on_no_request = true;
++}
++
++static int ufs_qcom_mcq_config_resource(struct ufs_hba *hba)
++{
++	struct platform_device *pdev = to_platform_device(hba->dev);
++	struct resource *res;
++
++	/* Map the MCQ configuration region */
++	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "mcq");
++	if (!res) {
++		dev_err(hba->dev, "MCQ resource not found in device tree\n");
++		return -ENODEV;
++	}
++
++	hba->mcq_base = devm_ioremap_resource(hba->dev, res);
++	if (IS_ERR(hba->mcq_base)) {
++		dev_err(hba->dev, "Failed to map MCQ region: %ld\n",
++			PTR_ERR(hba->mcq_base));
++		return PTR_ERR(hba->mcq_base);
++	}
++
++	return 0;
++}
++
++static int ufs_qcom_op_runtime_config(struct ufs_hba *hba)
++{
++	struct ufshcd_mcq_opr_info_t *opr;
++	int i;
++	u32 doorbell_offsets[OPR_MAX];
++
++	/*
++	 * Configure doorbell address offsets in MCQ configuration registers.
++	 * These values are offsets relative to mmio_base (UFS_HCI_BASE).
++	 *
++	 * Memory Layout:
++	 * - mmio_base = UFS_HCI_BASE
++	 * - mcq_base  = MCQ_CONFIG_BASE = mmio_base + (UFS_QCOM_MCQCAP_QCFGPTR * 0x200)
++	 * - Doorbell registers are at: mmio_base + (UFS_QCOM_MCQCAP_QCFGPTR * 0x200) +
++	 * -				UFS_QCOM_MCQ_SQD_OFFSET
++	 * - Which is also: mcq_base +  UFS_QCOM_MCQ_SQD_OFFSET
++	 */
++
++	doorbell_offsets[OPR_SQD] = UFS_QCOM_SQD_ADDR_OFFSET;
++	doorbell_offsets[OPR_SQIS] = UFS_QCOM_SQIS_ADDR_OFFSET;
++	doorbell_offsets[OPR_CQD] = UFS_QCOM_CQD_ADDR_OFFSET;
++	doorbell_offsets[OPR_CQIS] = UFS_QCOM_CQIS_ADDR_OFFSET;
++
++	/*
++	 * Configure MCQ operation registers.
++	 *
++	 * The doorbell registers are physically located within the MCQ region:
++	 * - doorbell_physical_addr = mmio_base + doorbell_offset
++	 * - doorbell_physical_addr = mcq_base + (doorbell_offset - MCQ_CONFIG_OFFSET)
++	 */
++	for (i = 0; i < OPR_MAX; i++) {
++		opr = &hba->mcq_opr[i];
++		opr->offset = doorbell_offsets[i];  /* Offset relative to mmio_base */
++		opr->stride = UFS_QCOM_MCQ_STRIDE;  /* 256 bytes between queues */
++
++		/*
++		 * Calculate the actual doorbell base address within MCQ region:
++		 * base = mcq_base + (doorbell_offset - MCQ_CONFIG_OFFSET)
++		 */
++		opr->base = hba->mcq_base + (opr->offset - UFS_QCOM_MCQ_CONFIG_OFFSET);
++	}
++
++	return 0;
++}
++
++static int ufs_qcom_get_hba_mac(struct ufs_hba *hba)
++{
++	/* Qualcomm HC supports up to 64 */
++	return MAX_SUPP_MAC;
++}
++
++static int ufs_qcom_get_outstanding_cqs(struct ufs_hba *hba,
++					unsigned long *ocqs)
++{
++	/* Read from MCQ vendor-specific register in MCQ region */
++	*ocqs = readl(hba->mcq_base + UFS_MEM_CQIS_VS);
++
++	return 0;
++}
++
++static void ufs_qcom_write_msi_msg(struct msi_desc *desc, struct msi_msg *msg)
++{
++	struct device *dev = msi_desc_to_dev(desc);
++	struct ufs_hba *hba = dev_get_drvdata(dev);
++
++	ufshcd_mcq_config_esi(hba, msg);
++}
++
++struct ufs_qcom_irq {
++	unsigned int		irq;
++	unsigned int		idx;
++	struct ufs_hba		*hba;
++};
++
++static irqreturn_t ufs_qcom_mcq_esi_handler(int irq, void *data)
++{
++	struct ufs_qcom_irq *qi = data;
++	struct ufs_hba *hba = qi->hba;
++	struct ufs_hw_queue *hwq = &hba->uhq[qi->idx];
++
++	ufshcd_mcq_write_cqis(hba, 0x1, qi->idx);
++	ufshcd_mcq_poll_cqe_lock(hba, hwq);
++
++	return IRQ_HANDLED;
++}
++
++static int ufs_qcom_config_esi(struct ufs_hba *hba)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	int nr_irqs, ret;
++
++	if (host->esi_enabled)
++		return 0;
++
++	/*
++	 * 1. We only handle CQs as of now.
++	 * 2. Poll queues do not need ESI.
++	 */
++	nr_irqs = hba->nr_hw_queues - hba->nr_queues[HCTX_TYPE_POLL];
++
++	ret = platform_device_msi_init_and_alloc_irqs(hba->dev, nr_irqs,
++						      ufs_qcom_write_msi_msg);
++	if (ret) {
++		dev_warn(hba->dev, "Platform MSI not supported or failed, continuing without ESI\n");
++		return ret; /* Continue without ESI */
++	}
++
++	struct ufs_qcom_irq *qi = devm_kcalloc(hba->dev, nr_irqs, sizeof(*qi), GFP_KERNEL);
++
++	if (!qi) {
++		platform_device_msi_free_irqs_all(hba->dev);
++		return -ENOMEM;
++	}
++
++	for (int idx = 0; idx < nr_irqs; idx++) {
++		qi[idx].irq = msi_get_virq(hba->dev, idx);
++		qi[idx].idx = idx;
++		qi[idx].hba = hba;
++
++		ret = devm_request_irq(hba->dev, qi[idx].irq, ufs_qcom_mcq_esi_handler,
++				       IRQF_SHARED, "qcom-mcq-esi", qi + idx);
++		if (ret) {
++			dev_err(hba->dev, "%s: Failed to request IRQ for %d, err = %d\n",
++				__func__, qi[idx].irq, ret);
++			/* Free previously allocated IRQs */
++			for (int j = 0; j < idx; j++)
++				devm_free_irq(hba->dev, qi[j].irq, qi + j);
++			platform_device_msi_free_irqs_all(hba->dev);
++			devm_kfree(hba->dev, qi);
++			return ret;
++		}
++	}
++
++	if (host->hw_ver.major >= 6) {
++		ufshcd_rmwl(hba, ESI_VEC_MASK, FIELD_PREP(ESI_VEC_MASK, MAX_ESI_VEC - 1),
++			    REG_UFS_CFG3);
++	}
++	ufshcd_mcq_enable_esi(hba);
++	host->esi_enabled = true;
++	return 0;
++}
++
++static unsigned long ufs_qcom_opp_freq_to_clk_freq(struct ufs_hba *hba,
++						   unsigned long freq, char *name)
++{
++	struct ufs_clk_info *clki;
++	struct dev_pm_opp *opp;
++	unsigned long clk_freq;
++	int idx = 0;
++	bool found = false;
++
++	opp = dev_pm_opp_find_freq_exact_indexed(hba->dev, freq, 0, true);
++	if (IS_ERR(opp)) {
++		dev_err(hba->dev, "Failed to find OPP for exact frequency %lu\n", freq);
++		return 0;
++	}
++
++	list_for_each_entry(clki, &hba->clk_list_head, list) {
++		if (!strcmp(clki->name, name)) {
++			found = true;
++			break;
++		}
++
++		idx++;
++	}
++
++	if (!found) {
++		dev_err(hba->dev, "Failed to find clock '%s' in clk list\n", name);
++		dev_pm_opp_put(opp);
++		return 0;
++	}
++
++	clk_freq = dev_pm_opp_get_freq_indexed(opp, idx);
++
++	dev_pm_opp_put(opp);
++
++	return clk_freq;
++}
++
++static u32 ufs_qcom_freq_to_gear_speed(struct ufs_hba *hba, unsigned long freq)
++{
++	u32 gear = UFS_HS_DONT_CHANGE;
++	unsigned long unipro_freq;
++
++	if (!hba->use_pm_opp)
++		return gear;
++
++	unipro_freq = ufs_qcom_opp_freq_to_clk_freq(hba, freq, "core_clk_unipro");
++	switch (unipro_freq) {
++	case 403000000:
++		gear = UFS_HS_G5;
++		break;
++	case 300000000:
++		gear = UFS_HS_G4;
++		break;
++	case 201500000:
++		gear = UFS_HS_G3;
++		break;
++	case 150000000:
++	case 100000000:
++		gear = UFS_HS_G2;
++		break;
++	case 75000000:
++	case 37500000:
++		gear = UFS_HS_G1;
++		break;
++	default:
++		dev_err(hba->dev, "%s: Unsupported clock freq : %lu\n", __func__, freq);
++		return UFS_HS_DONT_CHANGE;
++	}
++
++	return min_t(u32, gear, hba->max_pwr_info.info.gear_rx);
++}
++
++static int ufs_qcom_host_eom_config(struct ufs_hba *hba, int lane,
++				    const struct ufs_eom_coord *eom_coord,
++				    u32 target_test_count)
++{
++	enum ufs_eom_eye_mask eye_mask = eom_coord->eye_mask;
++	int v_step = eom_coord->v_step;
++	int t_step = eom_coord->t_step;
++	u32 volt_step, timing_step;
++	int ret;
++
++	if (abs(v_step) > UFS_QCOM_EOM_VOLTAGE_STEPS_MAX) {
++		dev_err(hba->dev, "Invalid EOM Voltage Step: %d\n", v_step);
++		return -ERANGE;
++	}
++
++	if (abs(t_step) > UFS_QCOM_EOM_TIMING_STEPS_MAX) {
++		dev_err(hba->dev, "Invalid EOM Timing Step: %d\n", t_step);
++		return -ERANGE;
++	}
++
++	if (v_step < 0)
++		volt_step = RX_EYEMON_NEGATIVE_STEP_BIT | (u32)(-v_step);
++	else
++		volt_step = (u32)v_step;
++
++	if (t_step < 0)
++		timing_step = RX_EYEMON_NEGATIVE_STEP_BIT | (u32)(-t_step);
++	else
++		timing_step = (u32)t_step;
++
++	ret = ufshcd_dme_set(hba, UIC_ARG_MIB_SEL(RX_EYEMON_ENABLE,
++				UIC_ARG_MPHY_RX_GEN_SEL_INDEX(lane)),
++			     BIT(eye_mask) | RX_EYEMON_EXTENDED_VRANGE_BIT);
++	if (ret) {
++		dev_err(hba->dev, "Failed to enable Host EOM on Lane %d: %d\n",
++			lane, ret);
++		return ret;
++	}
++
++	ret = ufshcd_dme_set(hba, UIC_ARG_MIB_SEL(RX_EYEMON_TIMING_STEPS,
++				UIC_ARG_MPHY_RX_GEN_SEL_INDEX(lane)),
++			     timing_step);
++	if (ret) {
++		dev_err(hba->dev, "Failed to set Host EOM timing step on Lane %d: %d\n",
++			lane, ret);
++		return ret;
++	}
++
++	ret = ufshcd_dme_set(hba, UIC_ARG_MIB_SEL(RX_EYEMON_VOLTAGE_STEPS,
++				UIC_ARG_MPHY_RX_GEN_SEL_INDEX(lane)),
++			     volt_step);
++	if (ret) {
++		dev_err(hba->dev, "Failed to set Host EOM voltage step on Lane %d: %d\n",
++			lane, ret);
++		return ret;
++	}
++
++	ret = ufshcd_dme_set(hba, UIC_ARG_MIB_SEL(RX_EYEMON_TARGET_TEST_COUNT,
++				UIC_ARG_MPHY_RX_GEN_SEL_INDEX(lane)),
++			     target_test_count);
++	if (ret)
++		dev_err(hba->dev, "Failed to set Host EOM target test count on Lane %d: %d\n",
++			lane, ret);
++
++	return ret;
++}
++
++static int ufs_qcom_host_eom_may_stop(struct ufs_hba *hba, int lane,
++				      u32 target_test_count, u32 *err_count)
++{
++	u32 start, tested_count, error_count;
++	int ret;
++
++	ret = ufshcd_dme_get(hba, UIC_ARG_MIB_SEL(RX_EYEMON_START,
++				UIC_ARG_MPHY_RX_GEN_SEL_INDEX(lane)),
++			     &start);
++	if (ret) {
++		dev_err(hba->dev, "Failed to get Host EOM start status on Lane %d: %d\n",
++			lane, ret);
++		return ret;
++	}
++
++	if (start & 0x1)
++		return -EAGAIN;
++
++	ret = ufshcd_dme_get(hba, UIC_ARG_MIB_SEL(RX_EYEMON_TESTED_COUNT,
++				UIC_ARG_MPHY_RX_GEN_SEL_INDEX(lane)),
++			     &tested_count);
++	if (ret) {
++		dev_err(hba->dev, "Failed to get Host EOM tested count on Lane %d: %d\n",
++			lane, ret);
++		return ret;
++	}
++
++	ret = ufshcd_dme_get(hba, UIC_ARG_MIB_SEL(RX_EYEMON_ERROR_COUNT,
++				UIC_ARG_MPHY_RX_GEN_SEL_INDEX(lane)),
++			     &error_count);
++	if (ret) {
++		dev_err(hba->dev, "Failed to get Host EOM error count on Lane %d: %d\n",
++			lane, ret);
++		return ret;
++	}
++
++	/* EOM can stop */
++	if ((tested_count >= target_test_count - 3) || error_count > 0) {
++		*err_count = error_count;
++
++		/* Disable EOM */
++		ret = ufshcd_dme_set(hba, UIC_ARG_MIB_SEL(RX_EYEMON_ENABLE,
++					UIC_ARG_MPHY_RX_GEN_SEL_INDEX(lane)),
++				     0x0);
++		if (ret) {
++			dev_err(hba->dev, "Failed to disable Host EOM on Lane %d: %d\n",
++				lane, ret);
++			return ret;
++		}
++	} else {
++		return -EAGAIN;
++	}
++
++	return 0;
++}
++
++static int ufs_qcom_host_eom_scan(struct ufs_hba *hba, int num_lanes,
++				  const struct ufs_eom_coord *eom_coord,
++				  u32 target_test_count, u32 *err_count)
++{
++	bool eom_stopped[PA_MAXDATALANES] = { 0 };
++	int lane, ret;
++	u32 setting;
++
++	if (!err_count || !eom_coord)
++		return -EINVAL;
++
++	if (target_test_count < UFS_QCOM_EOM_TARGET_TEST_COUNT_MIN) {
++		dev_err(hba->dev, "Target test count (%u) too small for Host EOM\n",
++			target_test_count);
++		return -ERANGE;
++	}
++
++	for (lane = 0; lane < num_lanes; lane++) {
++		ret = ufs_qcom_host_eom_config(hba, lane, eom_coord,
++					       target_test_count);
++		if (ret) {
++			dev_err(hba->dev, "Failed to config Host RX EOM: %d\n", ret);
++			return ret;
++		}
++	}
++
++	/*
++	 * Trigger a PACP_PWR_req to kick start EOM, but not to really change
++	 * the Power Mode.
++	 */
++	ret = ufshcd_uic_change_pwr_mode(hba, FAST_MODE << 4 | FAST_MODE);
++	if (ret) {
++		dev_err(hba->dev, "Failed to change power mode to kick start Host EOM: %d\n",
++			ret);
++		return ret;
++	}
++
++more_burst:
++	/* Create burst on Host RX Lane. */
++	ufshcd_dme_peer_get(hba, UIC_ARG_MIB(PA_LOCALVERINFO), &setting);
++
++	for (lane = 0; lane < num_lanes; lane++) {
++		if (eom_stopped[lane])
++			continue;
++
++		ret = ufs_qcom_host_eom_may_stop(hba, lane, target_test_count,
++						 &err_count[lane]);
++		if (!ret) {
++			eom_stopped[lane] = true;
++		} else if (ret == -EAGAIN) {
++			/* Need more burst to excercise EOM */
++			goto more_burst;
++		} else {
++			dev_err(hba->dev, "Failed to stop Host EOM: %d\n", ret);
++			return ret;
++		}
++
++		dev_dbg(hba->dev, "Host RX Lane %d EOM, v_step %d, t_step %d, error count %u\n",
++			lane, eom_coord->v_step, eom_coord->t_step,
++			err_count[lane]);
++	}
++
++	return 0;
++}
++
++static int ufs_qcom_host_sw_rx_fom(struct ufs_hba *hba, int num_lanes, u32 *fom)
++{
++	const struct ufs_eom_coord *eom_coord = sw_rx_fom_eom_coords_g6;
++	u32 eom_err_count[PA_MAXDATALANES] = { 0 };
++	u32 curr_ahit;
++	int lane, i, ret;
++
++	if (!fom)
++		return -EINVAL;
++
++	/* Stop the auto hibernate idle timer */
++	curr_ahit = ufshcd_readl(hba, REG_AUTO_HIBERNATE_IDLE_TIMER);
++	if (curr_ahit)
++		ufshcd_writel(hba, 0, REG_AUTO_HIBERNATE_IDLE_TIMER);
++
++	ret = ufshcd_dme_set(hba, UIC_ARG_MIB(PA_TXHSADAPTTYPE), PA_NO_ADAPT);
++	if (ret) {
++		dev_err(hba->dev, "Failed to select NO_ADAPT before starting Host EOM: %d\n", ret);
++		goto out;
++	}
++
++	for (i = 0; i < SW_RX_FOM_EOM_COORDS; i++, eom_coord++) {
++		ret = ufs_qcom_host_eom_scan(hba, num_lanes, eom_coord,
++					     UFS_QCOM_EOM_TARGET_TEST_COUNT_G6,
++					     eom_err_count);
++		if (ret) {
++			dev_err(hba->dev, "Failed to run Host EOM scan: %d\n", ret);
++			break;
++		}
++
++		for (lane = 0; lane < num_lanes; lane++) {
++			/* Bad coordinates have no weights */
++			if (eom_err_count[lane])
++				continue;
++			fom[lane] += SW_RX_FOM_EOM_COORDS_WEIGHT;
++		}
++	}
++
++out:
++	/* Restore the auto hibernate idle timer */
++	if (curr_ahit)
++		ufshcd_writel(hba, curr_ahit, REG_AUTO_HIBERNATE_IDLE_TIMER);
++
++	return ret;
++}
++
++static int ufs_qcom_get_rx_fom(struct ufs_hba *hba,
++			       struct ufs_pa_layer_attr *pwr_mode,
++			       struct tx_eqtr_iter *h_iter,
++			       struct tx_eqtr_iter *d_iter)
++{
++	struct ufshcd_tx_eq_params *params __free(kfree) =
++		kzalloc(sizeof(*params), GFP_KERNEL);
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	struct ufs_pa_layer_attr old_pwr_info;
++	u32 fom[PA_MAXDATALANES] = { 0 };
++	u32 gear = pwr_mode->gear_tx;
++	u32 rate = pwr_mode->hs_rate;
++	int lane, ret;
++
++	if (host->hw_ver.major != 0x7 || host->hw_ver.minor > 0x1 ||
++	    gear <= UFS_HS_G5 || !d_iter || !d_iter->is_updated)
++		return 0;
++
++	if (gear < UFS_HS_G1 || gear > UFS_HS_GEAR_MAX)
++		return -ERANGE;
++
++	if (!params)
++		return -ENOMEM;
++
++	memcpy(&old_pwr_info, &hba->pwr_info, sizeof(struct ufs_pa_layer_attr));
++
++	memcpy(params, &hba->tx_eq_params[gear - 1], sizeof(struct ufshcd_tx_eq_params));
++	for (lane = 0; lane < pwr_mode->lane_rx; lane++) {
++		params->device[lane].preshoot = d_iter->preshoot;
++		params->device[lane].deemphasis = d_iter->deemphasis;
++	}
++
++	/* Use TX EQTR settings as Device's TX Equalization settings. */
++	ret = ufshcd_apply_tx_eq_settings(hba, params, gear);
++	if (ret) {
++		dev_err(hba->dev, "%s: Failed to apply TX EQ settings for HS-G%u: %d\n",
++			__func__, gear, ret);
++		return ret;
++	}
++
++	/* Force PMC to target HS Gear to use new TX Equalization settings. */
++	ret = ufshcd_change_power_mode(hba, pwr_mode, UFSHCD_PMC_POLICY_FORCE);
++	if (ret) {
++		dev_err(hba->dev, "%s: Failed to change power mode to HS-G%u, Rate-%s: %d\n",
++			__func__, gear, ufs_hs_rate_to_str(rate), ret);
++		return ret;
++	}
++
++	ret = ufs_qcom_host_sw_rx_fom(hba, pwr_mode->lane_rx, fom);
++	if (ret) {
++		dev_err(hba->dev, "Failed to get SW FOM of TX (PreShoot: %u, DeEmphasis: %u): %d\n",
++			d_iter->preshoot, d_iter->deemphasis, ret);
++		return ret;
++	}
++
++	/* Restore Device's TX Equalization settings. */
++	ret = ufshcd_apply_tx_eq_settings(hba, &hba->tx_eq_params[gear - 1], gear);
++	if (ret) {
++		dev_err(hba->dev, "%s: Failed to apply TX EQ settings for HS-G%u: %d\n",
++			__func__, gear, ret);
++		return ret;
++	}
++
++	/* Restore Power Mode. */
++	ret = ufshcd_change_power_mode(hba, &old_pwr_info, UFSHCD_PMC_POLICY_FORCE);
++	if (ret) {
++		dev_err(hba->dev, "%s: Failed to restore power mode to HS-G%u: %d\n",
++			__func__, old_pwr_info.gear_tx, ret);
++		return ret;
++	}
++
++	for (lane = 0; lane < pwr_mode->lane_rx; lane++)
++		d_iter->fom[lane] = fom[lane];
++
++	return 0;
++}
++
++static int ufs_qcom_apply_tx_eqtr_settings(struct ufs_hba *hba,
++					   struct ufs_pa_layer_attr *pwr_mode,
++					   struct tx_eqtr_iter *h_iter,
++					   struct tx_eqtr_iter *d_iter)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	u32 setting = 0;
++	int lane;
++
++	if (host->hw_ver.major != 0x7 || host->hw_ver.minor > 0x1)
++		return 0;
++
++	for (lane = 0; lane < pwr_mode->lane_tx; lane++) {
++		setting |= TX_HS_PRESHOOT_BITS(lane, h_iter->preshoot);
++		setting |= TX_HS_DEEMPHASIS_BITS(lane, h_iter->deemphasis);
++	}
++
++	return ufshcd_dme_set(hba, UIC_ARG_MIB(PA_TXEQG1SETTING), setting);
++}
++
++static int ufs_qcom_tx_eqtr_notify(struct ufs_hba *hba,
++				   enum ufs_notify_change_status status,
++				   struct ufs_pa_layer_attr *pwr_mode)
++{
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++	struct ufs_pa_layer_attr pwr_mode_hs_g1 = {
++		.gear_rx = UFS_HS_G1,
++		.gear_tx = UFS_HS_G1,
++		.lane_rx = pwr_mode->lane_rx,
++		.lane_tx = pwr_mode->lane_tx,
++		.pwr_rx = FAST_MODE,
++		.pwr_tx = FAST_MODE,
++		.hs_rate = pwr_mode->hs_rate,
++	};
++	u32 gear = pwr_mode->gear_tx;
++	u32 rate = pwr_mode->hs_rate;
++	int ret;
++
++	if (host->hw_ver.major != 0x7 || host->hw_ver.minor > 0x1)
++		return 0;
++
++	if (status == PRE_CHANGE) {
++		ret = ufshcd_dme_get(hba, UIC_ARG_MIB(PA_TXEQG1SETTING),
++				     &host->saved_tx_eq_g1_setting);
++		if (ret)
++			return ret;
++
++		/* PMC to target HS Gear. */
++		ret = ufshcd_change_power_mode(hba, pwr_mode,
++					       UFSHCD_PMC_POLICY_DONT_FORCE);
++		if (ret)
++			dev_err(hba->dev, "%s: Failed to PMC to target HS-G%u, Rate-%s: %d\n",
++				__func__, gear, ufs_hs_rate_to_str(rate), ret);
++	} else {
++		ret = ufshcd_dme_set(hba, UIC_ARG_MIB(PA_TXEQG1SETTING),
++				     host->saved_tx_eq_g1_setting);
++		if (ret)
++			return ret;
++
++		/* PMC back to HS-G1. */
++		ret = ufshcd_change_power_mode(hba, &pwr_mode_hs_g1,
++					       UFSHCD_PMC_POLICY_DONT_FORCE);
++		if (ret)
++			dev_err(hba->dev, "%s: Failed to PMC to HS-G1, Rate-%s: %d\n",
++				__func__, ufs_hs_rate_to_str(rate), ret);
++	}
++
++	return ret;
++}
++
++/*
++ * struct ufs_hba_qcom_vops - UFS QCOM specific variant operations
++ *
++ * The variant operations configure the necessary controller and PHY
++ * handshake during initialization.
++ */
++static const struct ufs_hba_variant_ops ufs_hba_qcom_vops = {
++	.name                   = "qcom",
++	.init                   = ufs_qcom_init,
++	.exit                   = ufs_qcom_exit,
++	.get_ufs_hci_version	= ufs_qcom_get_ufs_hci_version,
++	.clk_scale_notify	= ufs_qcom_clk_scale_notify,
++	.setup_clocks           = ufs_qcom_setup_clocks,
++	.hce_enable_notify      = ufs_qcom_hce_enable_notify,
++	.link_startup_notify    = ufs_qcom_link_startup_notify,
++	.negotiate_pwr_mode	= ufs_qcom_negotiate_pwr_mode,
++	.pwr_change_notify	= ufs_qcom_pwr_change_notify,
++	.apply_dev_quirks	= ufs_qcom_apply_dev_quirks,
++	.fixup_dev_quirks       = ufs_qcom_fixup_dev_quirks,
++	.suspend		= ufs_qcom_suspend,
++	.resume			= ufs_qcom_resume,
++	.dbg_register_dump	= ufs_qcom_dump_dbg_regs,
++	.device_reset		= ufs_qcom_device_reset,
++	.config_scaling_param = ufs_qcom_config_scaling_param,
++	.mcq_config_resource	= ufs_qcom_mcq_config_resource,
++	.get_hba_mac		= ufs_qcom_get_hba_mac,
++	.op_runtime_config	= ufs_qcom_op_runtime_config,
++	.get_outstanding_cqs	= ufs_qcom_get_outstanding_cqs,
++	.config_esi		= ufs_qcom_config_esi,
++	.freq_to_gear_speed	= ufs_qcom_freq_to_gear_speed,
++	.get_rx_fom		= ufs_qcom_get_rx_fom,
++	.apply_tx_eqtr_settings	= ufs_qcom_apply_tx_eqtr_settings,
++	.tx_eqtr_notify		= ufs_qcom_tx_eqtr_notify,
++};
++
++static const struct ufs_hba_variant_ops ufs_hba_qcom_sa8255p_vops = {
++	.name                   = "qcom-sa8255p",
++	.init                   = ufs_qcom_fw_managed_init,
++	.exit                   = ufs_qcom_fw_managed_exit,
++	.hce_enable_notify      = ufs_qcom_fw_managed_hce_enable_notify,
++	.pwr_change_notify      = ufs_qcom_pwr_change_notify,
++	.apply_dev_quirks       = ufs_qcom_apply_dev_quirks,
++	.fixup_dev_quirks       = ufs_qcom_fixup_dev_quirks,
++	.suspend                = ufs_qcom_fw_managed_suspend,
++	.resume                 = ufs_qcom_fw_managed_resume,
++	.dbg_register_dump      = ufs_qcom_dump_dbg_regs,
++	.device_reset           = ufs_qcom_fw_managed_device_reset,
++};
++
++/**
++ * ufs_qcom_probe - probe routine of the driver
++ * @pdev: pointer to Platform device handle
++ *
++ * Return: zero for success and non-zero for failure.
++ */
++static int ufs_qcom_probe(struct platform_device *pdev)
++{
++	int err;
++	struct device *dev = &pdev->dev;
++	const struct ufs_hba_variant_ops *vops;
++	const struct ufs_qcom_drvdata *drvdata = device_get_match_data(dev);
++
++	if (drvdata && drvdata->vops)
++		vops = drvdata->vops;
++	else
++		vops = &ufs_hba_qcom_vops;
++
++	/* Perform generic probe */
++	err = ufshcd_pltfrm_init(pdev, vops);
++	if (err)
++		return dev_err_probe(dev, err, "ufshcd_pltfrm_init() failed\n");
++
++	return 0;
++}
++
++/**
++ * ufs_qcom_remove - set driver_data of the device to NULL
++ * @pdev: pointer to platform device handle
++ *
++ * Always returns 0
++ */
++static void ufs_qcom_remove(struct platform_device *pdev)
++{
++	struct ufs_hba *hba =  platform_get_drvdata(pdev);
++	struct ufs_qcom_host *host = ufshcd_get_variant(hba);
++
++	ufshcd_pltfrm_remove(pdev);
++	if (host->esi_enabled)
++		platform_device_msi_free_irqs_all(hba->dev);
++}
++
++static const struct ufs_qcom_drvdata ufs_qcom_sm8550_drvdata = {
++	.quirks = UFSHCD_QUIRK_BROKEN_LSDBS_CAP,
++	.no_phy_retention = true,
++};
++
++static const struct ufs_qcom_drvdata ufs_qcom_sa8255p_drvdata = {
++	.vops = &ufs_hba_qcom_sa8255p_vops
++};
++
++static const struct of_device_id ufs_qcom_of_match[] __maybe_unused = {
++	{ .compatible = "qcom,ufshc" },
++	{ .compatible = "qcom,sm8550-ufshc", .data = &ufs_qcom_sm8550_drvdata },
++	{ .compatible = "qcom,sm8650-ufshc", .data = &ufs_qcom_sm8550_drvdata },
++	{ .compatible = "qcom,sa8255p-ufshc", .data = &ufs_qcom_sa8255p_drvdata },
++	{},
++};
++MODULE_DEVICE_TABLE(of, ufs_qcom_of_match);
++
++#ifdef CONFIG_ACPI
++static const struct acpi_device_id ufs_qcom_acpi_match[] = {
++	{ "QCOM24A5" },
++	{ },
++};
++MODULE_DEVICE_TABLE(acpi, ufs_qcom_acpi_match);
++#endif
++
++static const struct dev_pm_ops ufs_qcom_pm_ops = {
++	SET_RUNTIME_PM_OPS(ufshcd_runtime_suspend, ufshcd_runtime_resume, NULL)
++	.prepare	 = ufshcd_suspend_prepare,
++	.complete	 = ufshcd_resume_complete,
++#ifdef CONFIG_PM_SLEEP
++	.suspend         = ufshcd_system_suspend,
++	.resume          = ufshcd_system_resume,
++	.freeze          = ufshcd_system_freeze,
++	.restore         = ufshcd_system_restore,
++	.thaw            = ufshcd_system_thaw,
++#endif
++};
++
++static struct platform_driver ufs_qcom_pltform = {
++	.probe	= ufs_qcom_probe,
++	.remove = ufs_qcom_remove,
++	.driver	= {
++		.name	= "ufshcd-qcom",
++		.pm	= &ufs_qcom_pm_ops,
++		.of_match_table = of_match_ptr(ufs_qcom_of_match),
++		.acpi_match_table = ACPI_PTR(ufs_qcom_acpi_match),
++	},
++};
++module_platform_driver(ufs_qcom_pltform);
++
++MODULE_DESCRIPTION("Qualcomm UFS host controller driver");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/usb/typec/mux/wcd939x-usbss.c.orig b/drivers/usb/typec/mux/wcd939x-usbss.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/usb/typec/mux/wcd939x-usbss.c.orig
+@@ -0,0 +1,779 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (C) 2023 Linaro Ltd.
++ */
++
++#include <linux/bits.h>
++#include <linux/i2c.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/mutex.h>
++#include <linux/regmap.h>
++#include <linux/bitfield.h>
++#include <linux/gpio/consumer.h>
++#include <linux/usb/typec_dp.h>
++#include <linux/usb/typec_mux.h>
++
++#define WCD_USBSS_PMP_OUT1			0x2
++
++#define WCD_USBSS_DP_DN_MISC1			0x20
++
++#define WCD_USBSS_DP_DN_MISC1_DP_PCOMP_2X_DYN_BST_ON_EN			BIT(3)
++#define WCD_USBSS_DP_DN_MISC1_DN_PCOMP_2X_DYN_BST_ON_EN			BIT(0)
++
++#define WCD_USBSS_MG1_EN			0x24
++
++#define WCD_USBSS_MG1_EN_CT_SNS_EN					BIT(1)
++
++#define WCD_USBSS_MG1_BIAS			0x25
++
++#define WCD_USBSS_MG1_BIAS_PCOMP_DYN_BST_EN				BIT(3)
++
++#define WCD_USBSS_MG1_MISC			0x27
++
++#define WCD_USBSS_MG1_MISC_PCOMP_2X_DYN_BST_ON_EN			BIT(5)
++
++#define WCD_USBSS_MG2_EN			0x28
++
++#define WCD_USBSS_MG2_EN_CT_SNS_EN					BIT(1)
++
++#define WCD_USBSS_MG2_BIAS			0x29
++
++#define WCD_USBSS_MG2_BIAS_PCOMP_DYN_BST_EN				BIT(3)
++
++#define WCD_USBSS_MG2_MISC			0x30
++
++#define WCD_USBSS_MG2_MISC_PCOMP_2X_DYN_BST_ON_EN			BIT(5)
++
++#define WCD_USBSS_DISP_AUXP_THRESH		0x80
++
++#define WCD_USBSS_DISP_AUXP_THRESH_DISP_AUXP_OVPON_CM			GENMASK(7, 5)
++
++#define WCD_USBSS_DISP_AUXP_CTL			0x81
++
++#define WCD_USBSS_DISP_AUXP_CTL_LK_CANCEL_TRK_COEFF			GENMASK(2, 0)
++
++#define WCD_USBSS_CPLDO_CTL2			0xa1
++
++#define WCD_USBSS_SWITCH_SETTINGS_ENABLE	0x403
++
++#define WCD_USBSS_SWITCH_SETTINGS_ENABLE_DEVICE_ENABLE			BIT(7)
++#define WCD_USBSS_SWITCH_SETTINGS_ENABLE_DP_AUXP_TO_MGX_SWITCHES	BIT(6)
++#define WCD_USBSS_SWITCH_SETTINGS_ENABLE_DP_AUXM_TO_MGX_SWITCHES	BIT(5)
++#define WCD_USBSS_SWITCH_SETTINGS_ENABLE_DNL_SWITCHES			BIT(4)
++#define WCD_USBSS_SWITCH_SETTINGS_ENABLE_DPR_SWITCHES			BIT(3)
++#define WCD_USBSS_SWITCH_SETTINGS_ENABLE_SENSE_SWITCHES			BIT(2)
++#define WCD_USBSS_SWITCH_SETTINGS_ENABLE_MIC_SWITCHES			BIT(1)
++#define WCD_USBSS_SWITCH_SETTINGS_ENABLE_AGND_SWITCHES			BIT(0)
++
++#define WCD_USBSS_SWITCH_SELECT0		0x404
++
++#define WCD_USBSS_SWITCH_SELECT0_DP_AUXP_SWITCHES			BIT(7)	/* 1-> MG2 */
++#define WCD_USBSS_SWITCH_SELECT0_DP_AUXM_SWITCHES			BIT(6)	/* 1-> MG2 */
++#define WCD_USBSS_SWITCH_SELECT0_DNL_SWITCHES				GENMASK(5, 4)
++#define WCD_USBSS_SWITCH_SELECT0_DPR_SWITCHES				GENMASK(3, 2)
++#define WCD_USBSS_SWITCH_SELECT0_SENSE_SWITCHES				BIT(1)	/* 1-> SBU2 */
++#define WCD_USBSS_SWITCH_SELECT0_MIC_SWITCHES				BIT(0)	/* 1-> MG2 */
++
++#define WCD_USBSS_SWITCH_SELECT0_DNL_SWITCH_L		0
++#define WCD_USBSS_SWITCH_SELECT0_DNL_SWITCH_DN		1
++#define WCD_USBSS_SWITCH_SELECT0_DNL_SWITCH_DN2		2
++
++#define WCD_USBSS_SWITCH_SELECT0_DPR_SWITCH_R		0
++#define WCD_USBSS_SWITCH_SELECT0_DPR_SWITCH_DP		1
++#define WCD_USBSS_SWITCH_SELECT0_DPR_SWITCH_DR2		2
++
++#define WCD_USBSS_SWITCH_SELECT1		0x405
++
++#define WCD_USBSS_SWITCH_SELECT1_AGND_SWITCHES				BIT(0)	/* 1-> MG2 */
++
++#define WCD_USBSS_DELAY_R_SW			0x40d
++#define WCD_USBSS_DELAY_MIC_SW			0x40e
++#define WCD_USBSS_DELAY_SENSE_SW		0x40f
++#define WCD_USBSS_DELAY_GND_SW			0x410
++#define WCD_USBSS_DELAY_L_SW			0x411
++
++#define WCD_USBSS_FUNCTION_ENABLE		0x413
++
++#define WCD_USBSS_FUNCTION_ENABLE_SOURCE_SELECT				GENMASK(1, 0)
++
++#define WCD_USBSS_FUNCTION_ENABLE_SOURCE_SELECT_MANUAL		1
++#define WCD_USBSS_FUNCTION_ENABLE_SOURCE_SELECT_AUDIO_FSM	2
++
++#define WCD_USBSS_EQUALIZER1			0x415
++
++#define WCD_USBSS_EQUALIZER1_EQ_EN					BIT(7)
++#define WCD_USBSS_EQUALIZER1_BW_SETTINGS				GENMASK(6, 3)
++
++#define WCD_USBSS_USB_SS_CNTL			0x419
++
++#define WCD_USBSS_USB_SS_CNTL_STANDBY_STATE				BIT(4)
++#define WCD_USBSS_USB_SS_CNTL_RCO_EN					BIT(3)
++#define WCD_USBSS_USB_SS_CNTL_USB_SS_MODE				GENMASK(2, 0)
++
++#define WCD_USBSS_USB_SS_CNTL_USB_SS_MODE_AATC		2
++#define WCD_USBSS_USB_SS_CNTL_USB_SS_MODE_USB		5
++
++#define WCD_USBSS_AUDIO_FSM_START		0x433
++
++#define WCD_USBSS_AUDIO_FSM_START_AUDIO_FSM_AUDIO_TRIG			BIT(0)
++
++#define WCD_USBSS_RATIO_SPKR_REXT_L_LSB		0x461
++#define WCD_USBSS_RATIO_SPKR_REXT_L_MSB		0x462
++#define WCD_USBSS_RATIO_SPKR_REXT_R_LSB		0x463
++#define WCD_USBSS_RATIO_SPKR_REXT_R_MSB		0x464
++#define WCD_USBSS_AUD_COEF_L_K0_0		0x475
++#define WCD_USBSS_AUD_COEF_L_K0_1		0x476
++#define WCD_USBSS_AUD_COEF_L_K0_2		0x477
++#define WCD_USBSS_AUD_COEF_L_K1_0		0x478
++#define WCD_USBSS_AUD_COEF_L_K1_1		0x479
++#define WCD_USBSS_AUD_COEF_L_K2_0		0x47a
++#define WCD_USBSS_AUD_COEF_L_K2_1		0x47b
++#define WCD_USBSS_AUD_COEF_L_K3_0		0x47c
++#define WCD_USBSS_AUD_COEF_L_K3_1		0x47d
++#define WCD_USBSS_AUD_COEF_L_K4_0		0x47e
++#define WCD_USBSS_AUD_COEF_L_K4_1		0x47f
++#define WCD_USBSS_AUD_COEF_L_K5_0		0x480
++#define WCD_USBSS_AUD_COEF_L_K5_1		0x481
++#define WCD_USBSS_AUD_COEF_R_K0_0		0x482
++#define WCD_USBSS_AUD_COEF_R_K0_1		0x483
++#define WCD_USBSS_AUD_COEF_R_K0_2		0x484
++#define WCD_USBSS_AUD_COEF_R_K1_0		0x485
++#define WCD_USBSS_AUD_COEF_R_K1_1		0x486
++#define WCD_USBSS_AUD_COEF_R_K2_0		0x487
++#define WCD_USBSS_AUD_COEF_R_K2_1		0x488
++#define WCD_USBSS_AUD_COEF_R_K3_0		0x489
++#define WCD_USBSS_AUD_COEF_R_K3_1		0x48a
++#define WCD_USBSS_AUD_COEF_R_K4_0		0x48b
++#define WCD_USBSS_AUD_COEF_R_K4_1		0x48c
++#define WCD_USBSS_AUD_COEF_R_K5_0		0x48d
++#define WCD_USBSS_AUD_COEF_R_K5_1		0x48e
++#define WCD_USBSS_GND_COEF_L_K0_0		0x48f
++#define WCD_USBSS_GND_COEF_L_K0_1		0x490
++#define WCD_USBSS_GND_COEF_L_K0_2		0x491
++#define WCD_USBSS_GND_COEF_L_K1_0		0x492
++#define WCD_USBSS_GND_COEF_L_K1_1		0x493
++#define WCD_USBSS_GND_COEF_L_K2_0		0x494
++#define WCD_USBSS_GND_COEF_L_K2_1		0x495
++#define WCD_USBSS_GND_COEF_L_K3_0		0x496
++#define WCD_USBSS_GND_COEF_L_K3_1		0x497
++#define WCD_USBSS_GND_COEF_L_K4_0		0x498
++#define WCD_USBSS_GND_COEF_L_K4_1		0x499
++#define WCD_USBSS_GND_COEF_L_K5_0		0x49a
++#define WCD_USBSS_GND_COEF_L_K5_1		0x49b
++#define WCD_USBSS_GND_COEF_R_K0_0		0x49c
++#define WCD_USBSS_GND_COEF_R_K0_1		0x49d
++#define WCD_USBSS_GND_COEF_R_K0_2		0x49e
++#define WCD_USBSS_GND_COEF_R_K1_0		0x49f
++#define WCD_USBSS_GND_COEF_R_K1_1		0x4a0
++#define WCD_USBSS_GND_COEF_R_K2_0		0x4a1
++#define WCD_USBSS_GND_COEF_R_K2_1		0x4a2
++#define WCD_USBSS_GND_COEF_R_K3_0		0x4a3
++#define WCD_USBSS_GND_COEF_R_K3_1		0x4a4
++#define WCD_USBSS_GND_COEF_R_K4_0		0x4a5
++#define WCD_USBSS_GND_COEF_R_K4_1		0x4a6
++#define WCD_USBSS_GND_COEF_R_K5_0		0x4a7
++#define WCD_USBSS_GND_COEF_R_K5_1		0x4a8
++
++#define WCD_USBSS_MAX_REGISTER			0x4c1
++
++struct wcd939x_usbss {
++	struct i2c_client *client;
++	struct gpio_desc *reset_gpio;
++	struct regulator *vdd_supply;
++
++	/* used to serialize concurrent change requests */
++	struct mutex lock;
++
++	struct typec_switch_dev *sw;
++	struct typec_mux_dev *mux;
++
++	struct regmap *regmap;
++
++	struct typec_mux *codec;
++	struct typec_switch *codec_switch;
++
++	enum typec_orientation orientation;
++	unsigned long mode;
++	unsigned int svid;
++};
++
++static const struct regmap_range_cfg wcd939x_usbss_ranges[] = {
++	{
++		.range_min = 0,
++		.range_max = WCD_USBSS_MAX_REGISTER,
++		.selector_reg = 0x0,
++		.selector_mask = 0xff,
++		.selector_shift = 0,
++		.window_start = 0,
++		.window_len = 0x100,
++	},
++};
++
++static const struct regmap_config wcd939x_usbss_regmap_config = {
++	.reg_bits = 8,
++	.val_bits = 8,
++	.max_register = WCD_USBSS_MAX_REGISTER,
++	.ranges = wcd939x_usbss_ranges,
++	.num_ranges = ARRAY_SIZE(wcd939x_usbss_ranges),
++};
++
++/* Linearlizer coefficients for 32ohm load */
++static const struct {
++	unsigned int offset;
++	unsigned int mask;
++	unsigned int value;
++} wcd939x_usbss_coeff_init[] = {
++	{ WCD_USBSS_AUD_COEF_L_K5_0, GENMASK(7, 0), 0x39 },
++	{ WCD_USBSS_AUD_COEF_R_K5_0, GENMASK(7, 0), 0x39 },
++	{ WCD_USBSS_GND_COEF_L_K2_0, GENMASK(7, 0), 0xe8 },
++	{ WCD_USBSS_GND_COEF_L_K4_0, GENMASK(7, 0), 0x73 },
++	{ WCD_USBSS_GND_COEF_R_K2_0, GENMASK(7, 0), 0xe8 },
++	{ WCD_USBSS_GND_COEF_R_K4_0, GENMASK(7, 0), 0x73 },
++	{ WCD_USBSS_RATIO_SPKR_REXT_L_LSB, GENMASK(7, 0), 0x00 },
++	{ WCD_USBSS_RATIO_SPKR_REXT_L_MSB, GENMASK(6, 0), 0x04 },
++	{ WCD_USBSS_RATIO_SPKR_REXT_R_LSB, GENMASK(7, 0), 0x00 },
++	{ WCD_USBSS_RATIO_SPKR_REXT_R_MSB, GENMASK(6, 0), 0x04 },
++};
++
++static int wcd939x_usbss_set(struct wcd939x_usbss *usbss)
++{
++	bool reverse = (usbss->orientation == TYPEC_ORIENTATION_REVERSE);
++	bool enable_audio = false;
++	bool enable_usb = false;
++	bool enable_dp = false;
++	int ret;
++
++	/* USB Mode */
++	if (usbss->mode < TYPEC_STATE_MODAL ||
++	    (!usbss->svid && (usbss->mode == TYPEC_MODE_USB2 ||
++			      usbss->mode == TYPEC_MODE_USB3))) {
++		enable_usb = true;
++	} else if (usbss->svid) {
++		switch (usbss->mode) {
++		/* DP Only */
++		case TYPEC_DP_STATE_C:
++		case TYPEC_DP_STATE_E:
++			enable_dp = true;
++			break;
++
++		/* DP + USB */
++		case TYPEC_DP_STATE_D:
++		case TYPEC_DP_STATE_F:
++			enable_usb = true;
++			enable_dp = true;
++			break;
++
++		default:
++			return -EOPNOTSUPP;
++		}
++	} else if (usbss->mode == TYPEC_MODE_AUDIO) {
++		enable_audio = true;
++	} else {
++		return -EOPNOTSUPP;
++	}
++
++	/* Disable all switches */
++	ret = regmap_clear_bits(usbss->regmap, WCD_USBSS_SWITCH_SETTINGS_ENABLE,
++				WCD_USBSS_SWITCH_SETTINGS_ENABLE_DP_AUXP_TO_MGX_SWITCHES |
++				WCD_USBSS_SWITCH_SETTINGS_ENABLE_DP_AUXM_TO_MGX_SWITCHES |
++				WCD_USBSS_SWITCH_SETTINGS_ENABLE_DPR_SWITCHES |
++				WCD_USBSS_SWITCH_SETTINGS_ENABLE_DNL_SWITCHES |
++				WCD_USBSS_SWITCH_SETTINGS_ENABLE_SENSE_SWITCHES |
++				WCD_USBSS_SWITCH_SETTINGS_ENABLE_MIC_SWITCHES |
++				WCD_USBSS_SWITCH_SETTINGS_ENABLE_AGND_SWITCHES);
++	if (ret)
++		return ret;
++
++	/* Clear switches */
++	ret = regmap_clear_bits(usbss->regmap, WCD_USBSS_SWITCH_SELECT0,
++				WCD_USBSS_SWITCH_SELECT0_DP_AUXP_SWITCHES |
++				WCD_USBSS_SWITCH_SELECT0_DP_AUXM_SWITCHES |
++				WCD_USBSS_SWITCH_SELECT0_DPR_SWITCHES |
++				WCD_USBSS_SWITCH_SELECT0_DNL_SWITCHES |
++				WCD_USBSS_SWITCH_SELECT0_SENSE_SWITCHES |
++				WCD_USBSS_SWITCH_SELECT0_MIC_SWITCHES);
++	if (ret)
++		return ret;
++
++	ret = regmap_clear_bits(usbss->regmap, WCD_USBSS_SWITCH_SELECT1,
++				WCD_USBSS_SWITCH_SELECT1_AGND_SWITCHES);
++	if (ret)
++		return ret;
++
++	/* Enable OVP_MG1_BIAS PCOMP_DYN_BST_EN */
++	ret = regmap_set_bits(usbss->regmap, WCD_USBSS_MG1_BIAS,
++			      WCD_USBSS_MG1_BIAS_PCOMP_DYN_BST_EN);
++	if (ret)
++		return ret;
++
++	/* Enable OVP_MG2_BIAS PCOMP_DYN_BST_EN */
++	ret = regmap_set_bits(usbss->regmap, WCD_USBSS_MG2_BIAS,
++			      WCD_USBSS_MG2_BIAS_PCOMP_DYN_BST_EN);
++	if (ret)
++		return ret;
++
++	/* Disable Equalizer in safe mode */
++	ret = regmap_clear_bits(usbss->regmap, WCD_USBSS_EQUALIZER1,
++				WCD_USBSS_EQUALIZER1_EQ_EN);
++	if (ret)
++		return ret;
++
++	/* Start FSM with all disabled, force write */
++	ret = regmap_write_bits(usbss->regmap, WCD_USBSS_AUDIO_FSM_START,
++				WCD_USBSS_AUDIO_FSM_START_AUDIO_FSM_AUDIO_TRIG,
++				WCD_USBSS_AUDIO_FSM_START_AUDIO_FSM_AUDIO_TRIG);
++
++	/* 35us to allow the SBU switch to turn off */
++	usleep_range(35, 1000);
++
++	/* Setup Audio Accessory mux/switch */
++	if (enable_audio) {
++		int i;
++
++		/*
++		 * AATC switch configuration:
++		 * "Normal":
++		 * - R: DNR
++		 * - L: DNL
++		 * - Sense: GSBU2
++		 * - Mic: MG1
++		 * - AGND: MG2
++		 * "Swapped":
++		 * - R: DNR
++		 * - L: DNL
++		 * - Sense: GSBU1
++		 * - Mic: MG2
++		 * - AGND: MG1
++		 * Swapped information is given by the codec MBHC logic
++		 */
++
++		/* Set AATC mode */
++		ret = regmap_update_bits(usbss->regmap, WCD_USBSS_USB_SS_CNTL,
++					 WCD_USBSS_USB_SS_CNTL_USB_SS_MODE,
++					 FIELD_PREP(WCD_USBSS_USB_SS_CNTL_USB_SS_MODE,
++						    WCD_USBSS_USB_SS_CNTL_USB_SS_MODE_AATC));
++		if (ret)
++			return ret;
++
++		/* Select L for DNL_SWITCHES and R for DPR_SWITCHES */
++		ret = regmap_update_bits(usbss->regmap, WCD_USBSS_SWITCH_SELECT0,
++				WCD_USBSS_SWITCH_SELECT0_DPR_SWITCHES |
++				WCD_USBSS_SWITCH_SELECT0_DNL_SWITCHES,
++				FIELD_PREP(WCD_USBSS_SWITCH_SELECT0_DNL_SWITCHES,
++					WCD_USBSS_SWITCH_SELECT0_DNL_SWITCH_L) |
++				FIELD_PREP(WCD_USBSS_SWITCH_SELECT0_DPR_SWITCHES,
++					WCD_USBSS_SWITCH_SELECT0_DPR_SWITCH_R));
++		if (ret)
++			return ret;
++
++		if (reverse)
++			/* Select MG2 for MIC, SBU1 for Sense */
++			ret = regmap_update_bits(usbss->regmap, WCD_USBSS_SWITCH_SELECT0,
++						 WCD_USBSS_SWITCH_SELECT0_MIC_SWITCHES,
++						 WCD_USBSS_SWITCH_SELECT0_MIC_SWITCHES);
++		else
++			/* Select MG1 for MIC, SBU2 for Sense */
++			ret = regmap_update_bits(usbss->regmap, WCD_USBSS_SWITCH_SELECT0,
++						 WCD_USBSS_SWITCH_SELECT0_SENSE_SWITCHES,
++						 WCD_USBSS_SWITCH_SELECT0_SENSE_SWITCHES);
++		if (ret)
++			return ret;
++
++		if (reverse)
++			/* Disable OVP_MG1_BIAS PCOMP_DYN_BST_EN */
++			ret = regmap_clear_bits(usbss->regmap, WCD_USBSS_MG1_BIAS,
++						WCD_USBSS_MG1_BIAS_PCOMP_DYN_BST_EN);
++		else
++			/* Disable OVP_MG2_BIAS PCOMP_DYN_BST_EN */
++			ret = regmap_clear_bits(usbss->regmap, WCD_USBSS_MG2_BIAS,
++						WCD_USBSS_MG2_BIAS_PCOMP_DYN_BST_EN);
++		if (ret)
++			return ret;
++
++		/*  Enable SENSE, MIC switches */
++		ret = regmap_set_bits(usbss->regmap, WCD_USBSS_SWITCH_SETTINGS_ENABLE,
++				      WCD_USBSS_SWITCH_SETTINGS_ENABLE_SENSE_SWITCHES |
++				      WCD_USBSS_SWITCH_SETTINGS_ENABLE_MIC_SWITCHES);
++		if (ret)
++			return ret;
++
++		if (reverse)
++			/* Select MG1 for AGND_SWITCHES */
++			ret = regmap_clear_bits(usbss->regmap, WCD_USBSS_SWITCH_SELECT1,
++						WCD_USBSS_SWITCH_SELECT1_AGND_SWITCHES);
++		else
++			/* Select MG2 for AGND_SWITCHES */
++			ret = regmap_set_bits(usbss->regmap, WCD_USBSS_SWITCH_SELECT1,
++					      WCD_USBSS_SWITCH_SELECT1_AGND_SWITCHES);
++		if (ret)
++			return ret;
++
++		/* Enable AGND switches */
++		ret = regmap_set_bits(usbss->regmap, WCD_USBSS_SWITCH_SETTINGS_ENABLE,
++				      WCD_USBSS_SWITCH_SETTINGS_ENABLE_AGND_SWITCHES);
++		if (ret)
++			return ret;
++
++		/* Enable DPR, DNL switches */
++		ret = regmap_set_bits(usbss->regmap, WCD_USBSS_SWITCH_SETTINGS_ENABLE,
++				      WCD_USBSS_SWITCH_SETTINGS_ENABLE_DNL_SWITCHES |
++				      WCD_USBSS_SWITCH_SETTINGS_ENABLE_DPR_SWITCHES);
++		if (ret)
++			return ret;
++
++		/* Setup FSM delays */
++		ret = regmap_write(usbss->regmap, WCD_USBSS_DELAY_L_SW, 0x02);
++		if (ret)
++			return ret;
++
++		ret = regmap_write(usbss->regmap, WCD_USBSS_DELAY_R_SW, 0x02);
++		if (ret)
++			return ret;
++
++		ret = regmap_write(usbss->regmap, WCD_USBSS_DELAY_MIC_SW, 0x01);
++		if (ret)
++			return ret;
++
++		/* Start FSM, force write */
++		ret = regmap_write_bits(usbss->regmap, WCD_USBSS_AUDIO_FSM_START,
++					WCD_USBSS_AUDIO_FSM_START_AUDIO_FSM_AUDIO_TRIG,
++					WCD_USBSS_AUDIO_FSM_START_AUDIO_FSM_AUDIO_TRIG);
++		if (ret)
++			return ret;
++
++		/* Default Linearlizer coefficients */
++		for (i = 0; i < ARRAY_SIZE(wcd939x_usbss_coeff_init); ++i)
++			regmap_update_bits(usbss->regmap,
++					   wcd939x_usbss_coeff_init[i].offset,
++					   wcd939x_usbss_coeff_init[i].mask,
++					   wcd939x_usbss_coeff_init[i].value);
++
++		return 0;
++	}
++
++	ret = regmap_update_bits(usbss->regmap, WCD_USBSS_USB_SS_CNTL,
++				 WCD_USBSS_USB_SS_CNTL_USB_SS_MODE,
++				 FIELD_PREP(WCD_USBSS_USB_SS_CNTL_USB_SS_MODE,
++					    WCD_USBSS_USB_SS_CNTL_USB_SS_MODE_USB));
++	if (ret)
++		return ret;
++
++	/* Enable USB muxes */
++	if (enable_usb) {
++		/* Do not enable Equalizer in safe mode */
++		if (usbss->mode != TYPEC_STATE_SAFE) {
++			ret = regmap_set_bits(usbss->regmap, WCD_USBSS_EQUALIZER1,
++					      WCD_USBSS_EQUALIZER1_EQ_EN);
++			if (ret)
++				return ret;
++		}
++
++		/* Select DN for DNL_SWITCHES and DP for DPR_SWITCHES */
++		ret = regmap_update_bits(usbss->regmap, WCD_USBSS_SWITCH_SELECT0,
++					 WCD_USBSS_SWITCH_SELECT0_DPR_SWITCHES |
++					 WCD_USBSS_SWITCH_SELECT0_DNL_SWITCHES,
++					 FIELD_PREP(WCD_USBSS_SWITCH_SELECT0_DNL_SWITCHES,
++						    WCD_USBSS_SWITCH_SELECT0_DNL_SWITCH_DN) |
++					 FIELD_PREP(WCD_USBSS_SWITCH_SELECT0_DPR_SWITCHES,
++						    WCD_USBSS_SWITCH_SELECT0_DPR_SWITCH_DP));
++		if (ret)
++			return ret;
++
++		/* Enable DNL_SWITCHES and DPR_SWITCHES */
++		ret = regmap_set_bits(usbss->regmap, WCD_USBSS_SWITCH_SETTINGS_ENABLE,
++				      WCD_USBSS_SWITCH_SETTINGS_ENABLE_DPR_SWITCHES |
++				      WCD_USBSS_SWITCH_SETTINGS_ENABLE_DNL_SWITCHES);
++		if (ret)
++			return ret;
++	}
++
++	/* Enable DP AUX muxes */
++	if (enable_dp) {
++		/* Update Leakage Canceller Coefficient for AUXP pins */
++		ret = regmap_update_bits(usbss->regmap, WCD_USBSS_DISP_AUXP_CTL,
++					 WCD_USBSS_DISP_AUXP_CTL_LK_CANCEL_TRK_COEFF,
++					 FIELD_PREP(WCD_USBSS_DISP_AUXP_CTL_LK_CANCEL_TRK_COEFF,
++						    5));
++		if (ret)
++			return ret;
++
++		ret = regmap_set_bits(usbss->regmap, WCD_USBSS_DISP_AUXP_THRESH,
++				      WCD_USBSS_DISP_AUXP_THRESH_DISP_AUXP_OVPON_CM);
++		if (ret)
++			return ret;
++
++		if (reverse)
++			/* Select MG2 for AUXP and MG1 for AUXM */
++			ret = regmap_update_bits(usbss->regmap, WCD_USBSS_SWITCH_SELECT0,
++						 WCD_USBSS_SWITCH_SELECT0_DP_AUXP_SWITCHES |
++						 WCD_USBSS_SWITCH_SELECT0_DP_AUXM_SWITCHES,
++						 WCD_USBSS_SWITCH_SELECT0_DP_AUXP_SWITCHES);
++		else
++			/* Select MG1 for AUXP and MG2 for AUXM */
++			ret = regmap_update_bits(usbss->regmap, WCD_USBSS_SWITCH_SELECT0,
++						 WCD_USBSS_SWITCH_SELECT0_DP_AUXP_SWITCHES |
++						 WCD_USBSS_SWITCH_SELECT0_DP_AUXM_SWITCHES,
++						 WCD_USBSS_SWITCH_SELECT0_DP_AUXM_SWITCHES);
++		if (ret)
++			return ret;
++
++		/* Enable DP_AUXP_TO_MGX and DP_AUXM_TO_MGX switches */
++		ret = regmap_set_bits(usbss->regmap, WCD_USBSS_SWITCH_SETTINGS_ENABLE,
++				      WCD_USBSS_SWITCH_SETTINGS_ENABLE_DP_AUXP_TO_MGX_SWITCHES |
++				      WCD_USBSS_SWITCH_SETTINGS_ENABLE_DP_AUXM_TO_MGX_SWITCHES);
++
++		/* 15us to allow the SBU switch to turn on again */
++		usleep_range(15, 1000);
++	}
++
++	return 0;
++}
++
++static int wcd939x_usbss_switch_set(struct typec_switch_dev *sw,
++				    enum typec_orientation orientation)
++{
++	struct wcd939x_usbss *usbss = typec_switch_get_drvdata(sw);
++	int ret = 0;
++
++	mutex_lock(&usbss->lock);
++
++	if (usbss->orientation != orientation) {
++		usbss->orientation = orientation;
++
++		ret = wcd939x_usbss_set(usbss);
++	}
++
++	mutex_unlock(&usbss->lock);
++
++	if (ret)
++		return ret;
++
++	/* Report orientation to codec after switch has been done */
++	return typec_switch_set(usbss->codec_switch, orientation);
++}
++
++static int wcd939x_usbss_mux_set(struct typec_mux_dev *mux,
++				 struct typec_mux_state *state)
++{
++	struct wcd939x_usbss *usbss = typec_mux_get_drvdata(mux);
++	int ret = 0;
++
++	mutex_lock(&usbss->lock);
++
++	if (usbss->mode != state->mode) {
++		usbss->mode = state->mode;
++
++		if (state->alt)
++			usbss->svid = state->alt->svid;
++		else
++			usbss->svid = 0; // No SVID
++
++		ret = wcd939x_usbss_set(usbss);
++	}
++
++	mutex_unlock(&usbss->lock);
++
++	if (ret)
++		return ret;
++
++	/* Report event to codec after switch has been done */
++	return typec_mux_set(usbss->codec, state);
++}
++
++static int wcd939x_usbss_probe(struct i2c_client *client)
++{
++	struct device *dev = &client->dev;
++	struct typec_switch_desc sw_desc = { };
++	struct typec_mux_desc mux_desc = { };
++	struct wcd939x_usbss *usbss;
++	int ret;
++
++	usbss = devm_kzalloc(dev, sizeof(*usbss), GFP_KERNEL);
++	if (!usbss)
++		return -ENOMEM;
++
++	usbss->client = client;
++	mutex_init(&usbss->lock);
++
++	usbss->regmap = devm_regmap_init_i2c(client, &wcd939x_usbss_regmap_config);
++	if (IS_ERR(usbss->regmap))
++		return dev_err_probe(dev, PTR_ERR(usbss->regmap), "failed to initialize regmap\n");
++
++	usbss->reset_gpio = devm_gpiod_get_optional(dev, "reset", GPIOD_OUT_LOW);
++	if (IS_ERR(usbss->reset_gpio))
++		return dev_err_probe(dev, PTR_ERR(usbss->reset_gpio),
++				     "unable to acquire reset gpio\n");
++
++	usbss->vdd_supply = devm_regulator_get_optional(dev, "vdd");
++	if (IS_ERR(usbss->vdd_supply))
++		return PTR_ERR(usbss->vdd_supply);
++
++	/* Get Codec's MUX & Switch devices */
++	usbss->codec = fwnode_typec_mux_get(dev->fwnode);
++	if (IS_ERR(usbss->codec))
++		return dev_err_probe(dev, PTR_ERR(usbss->codec),
++				     "failed to acquire codec mode-switch\n");
++
++	usbss->codec_switch = fwnode_typec_switch_get(dev->fwnode);
++	if (IS_ERR(usbss->codec_switch)) {
++		ret = dev_err_probe(dev, PTR_ERR(usbss->codec_switch),
++				    "failed to acquire codec orientation-switch\n");
++		goto err_mux_put;
++	}
++
++	usbss->mode = TYPEC_STATE_SAFE;
++	usbss->orientation = TYPEC_ORIENTATION_NONE;
++
++	gpiod_set_value(usbss->reset_gpio, 1);
++
++	ret = regulator_enable(usbss->vdd_supply);
++	if (ret) {
++		dev_err(dev, "Failed to enable vdd: %d\n", ret);
++		goto err_mux_switch;
++	}
++
++	msleep(20);
++
++	gpiod_set_value(usbss->reset_gpio, 0);
++
++	msleep(20);
++
++	/* Disable standby */
++	ret = regmap_clear_bits(usbss->regmap, WCD_USBSS_USB_SS_CNTL,
++				WCD_USBSS_USB_SS_CNTL_STANDBY_STATE);
++	if (ret)
++		goto err_regulator_disable;
++
++	/* Set manual mode by default */
++	ret = regmap_update_bits(usbss->regmap, WCD_USBSS_FUNCTION_ENABLE,
++				 WCD_USBSS_FUNCTION_ENABLE_SOURCE_SELECT,
++				 FIELD_PREP(WCD_USBSS_FUNCTION_ENABLE_SOURCE_SELECT,
++					    WCD_USBSS_FUNCTION_ENABLE_SOURCE_SELECT_MANUAL));
++	if (ret)
++		goto err_regulator_disable;
++
++	/* Enable dynamic boosting for DP and DN */
++	ret = regmap_set_bits(usbss->regmap, WCD_USBSS_DP_DN_MISC1,
++			      WCD_USBSS_DP_DN_MISC1_DP_PCOMP_2X_DYN_BST_ON_EN |
++			      WCD_USBSS_DP_DN_MISC1_DN_PCOMP_2X_DYN_BST_ON_EN);
++	if (ret)
++		goto err_regulator_disable;
++
++	/* Enable dynamic boosting for MG1 OVP */
++	ret = regmap_set_bits(usbss->regmap, WCD_USBSS_MG1_MISC,
++			      WCD_USBSS_MG1_MISC_PCOMP_2X_DYN_BST_ON_EN);
++	if (ret)
++		goto err_regulator_disable;
++
++	/* Enable dynamic boosting for MG2 OVP */
++	ret = regmap_set_bits(usbss->regmap, WCD_USBSS_MG2_MISC,
++			      WCD_USBSS_MG2_MISC_PCOMP_2X_DYN_BST_ON_EN);
++	if (ret)
++		goto err_regulator_disable;
++
++	/* Write 0xFF to WCD_USBSS_CPLDO_CTL2 */
++	ret = regmap_set_bits(usbss->regmap, WCD_USBSS_CPLDO_CTL2, 0xff);
++	if (ret)
++		goto err_regulator_disable;
++
++	/* Set RCO_EN: WCD_USBSS_USB_SS_CNTL Bit<3> --> 0x0 --> 0x1 */
++	ret = regmap_clear_bits(usbss->regmap, WCD_USBSS_USB_SS_CNTL,
++				WCD_USBSS_USB_SS_CNTL_RCO_EN);
++	if (ret)
++		goto err_regulator_disable;
++
++	ret = regmap_set_bits(usbss->regmap, WCD_USBSS_USB_SS_CNTL,
++			      WCD_USBSS_USB_SS_CNTL_RCO_EN);
++	if (ret)
++		goto err_regulator_disable;
++
++	/* Disable all switches but enable the mux */
++	ret = regmap_write(usbss->regmap, WCD_USBSS_SWITCH_SETTINGS_ENABLE,
++			   WCD_USBSS_SWITCH_SETTINGS_ENABLE_DEVICE_ENABLE);
++	if (ret)
++		goto err_regulator_disable;
++
++	/* Setup in SAFE mode */
++	ret = wcd939x_usbss_set(usbss);
++	if (ret)
++		goto err_regulator_disable;
++
++	sw_desc.drvdata = usbss;
++	sw_desc.fwnode = dev_fwnode(dev);
++	sw_desc.set = wcd939x_usbss_switch_set;
++
++	usbss->sw = typec_switch_register(dev, &sw_desc);
++	if (IS_ERR(usbss->sw)) {
++		ret = dev_err_probe(dev, PTR_ERR(usbss->sw), "failed to register typec switch\n");
++		goto err_regulator_disable;
++	}
++
++	mux_desc.drvdata = usbss;
++	mux_desc.fwnode = dev_fwnode(dev);
++	mux_desc.set = wcd939x_usbss_mux_set;
++
++	usbss->mux = typec_mux_register(dev, &mux_desc);
++	if (IS_ERR(usbss->mux)) {
++		ret = dev_err_probe(dev, PTR_ERR(usbss->mux), "failed to register typec mux\n");
++		goto err_switch_unregister;
++	}
++
++	i2c_set_clientdata(client, usbss);
++
++	return 0;
++
++err_switch_unregister:
++	typec_switch_unregister(usbss->sw);
++
++err_regulator_disable:
++	regulator_disable(usbss->vdd_supply);
++
++err_mux_switch:
++	typec_switch_put(usbss->codec_switch);
++
++err_mux_put:
++	typec_mux_put(usbss->codec);
++
++	return ret;
++}
++
++static void wcd939x_usbss_remove(struct i2c_client *client)
++{
++	struct wcd939x_usbss *usbss = i2c_get_clientdata(client);
++
++	typec_mux_unregister(usbss->mux);
++	typec_switch_unregister(usbss->sw);
++
++	regulator_disable(usbss->vdd_supply);
++
++	typec_switch_put(usbss->codec_switch);
++	typec_mux_put(usbss->codec);
++}
++
++static const struct i2c_device_id wcd939x_usbss_table[] = {
++	{ "wcd9390-usbss" },
++	{ }
++};
++MODULE_DEVICE_TABLE(i2c, wcd939x_usbss_table);
++
++static const struct of_device_id wcd939x_usbss_of_table[] = {
++	{ .compatible = "qcom,wcd9390-usbss" },
++	{ }
++};
++MODULE_DEVICE_TABLE(of, wcd939x_usbss_of_table);
++
++static struct i2c_driver wcd939x_usbss_driver = {
++	.driver = {
++		.name = "wcd939x-usbss",
++		.of_match_table = wcd939x_usbss_of_table,
++	},
++	.probe		= wcd939x_usbss_probe,
++	.remove		= wcd939x_usbss_remove,
++	.id_table	= wcd939x_usbss_table,
++};
++module_i2c_driver(wcd939x_usbss_driver);
++
++MODULE_DESCRIPTION("Qualcomm WCD939x USBSS driver");
++MODULE_LICENSE("GPL");
+diff --git a/sound/soc/codecs/aw88166.c.orig b/sound/soc/codecs/aw88166.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/sound/soc/codecs/aw88166.c.orig
+@@ -0,0 +1,1819 @@
++// SPDX-License-Identifier: GPL-2.0-only
++//
++// aw88166.c --  ALSA SoC AW88166 codec support
++//
++// Copyright (c) 2025 AWINIC Technology CO., LTD
++//
++// Author: Weidong Wang <wangweidong.a@awinic.com>
++//
++
++#include <linux/crc32.h>
++#include <linux/firmware.h>
++#include <linux/gpio/consumer.h>
++#include <linux/i2c.h>
++#include <linux/minmax.h>
++#include <linux/regmap.h>
++#include <sound/soc.h>
++#include "aw88166.h"
++#include "aw88395/aw88395_device.h"
++
++struct aw88166 {
++	struct aw_device *aw_pa;
++	struct mutex lock;
++	struct gpio_desc *reset_gpio;
++	struct delayed_work start_work;
++	struct regmap *regmap;
++	struct aw_container *aw_cfg;
++
++	unsigned int check_val;
++	unsigned int crc_init_val;
++	unsigned int vcalb_init_val;
++	unsigned int re_init_val;
++	unsigned int dither_st;
++	bool phase_sync;
++};
++
++static const struct regmap_config aw88166_remap_config = {
++	.val_bits = 16,
++	.reg_bits = 8,
++	.max_register = AW88166_REG_MAX,
++	.reg_format_endian = REGMAP_ENDIAN_LITTLE,
++	.val_format_endian = REGMAP_ENDIAN_BIG,
++};
++
++static void aw_dev_pwd(struct aw_device *aw_dev, bool pwd)
++{
++	int ret;
++
++	if (pwd)
++		ret = regmap_update_bits(aw_dev->regmap, AW88166_SYSCTRL_REG,
++				~AW88166_PWDN_MASK, AW88166_PWDN_POWER_DOWN_VALUE);
++	else
++		ret = regmap_update_bits(aw_dev->regmap, AW88166_SYSCTRL_REG,
++				~AW88166_PWDN_MASK, AW88166_PWDN_WORKING_VALUE);
++
++	if (ret)
++		dev_dbg(aw_dev->dev, "%s failed", __func__);
++}
++
++static void aw_dev_get_int_status(struct aw_device *aw_dev, unsigned short *int_status)
++{
++	unsigned int reg_val;
++	int ret;
++
++	ret = regmap_read(aw_dev->regmap, AW88166_SYSINT_REG, &reg_val);
++	if (ret)
++		dev_err(aw_dev->dev, "read interrupt reg fail, ret=%d", ret);
++	else
++		*int_status = reg_val;
++
++	dev_dbg(aw_dev->dev, "read interrupt reg=0x%04x", *int_status);
++}
++
++static void aw_dev_clear_int_status(struct aw_device *aw_dev)
++{
++	u16 int_status;
++
++	/* read int status and clear */
++	aw_dev_get_int_status(aw_dev, &int_status);
++	/* make sure int status is clear */
++	aw_dev_get_int_status(aw_dev, &int_status);
++	if (int_status)
++		dev_dbg(aw_dev->dev, "int status(%d) is not cleaned.\n", int_status);
++}
++
++static int aw_dev_get_iis_status(struct aw_device *aw_dev)
++{
++	unsigned int reg_val;
++	int ret;
++
++	ret = regmap_read(aw_dev->regmap, AW88166_SYSST_REG, &reg_val);
++	if (ret)
++		return ret;
++	if ((reg_val & AW88166_BIT_PLL_CHECK) != AW88166_BIT_PLL_CHECK) {
++		dev_err(aw_dev->dev, "check pll lock fail, reg_val:0x%04x", reg_val);
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int aw_dev_check_mode1_pll(struct aw_device *aw_dev)
++{
++	int ret, i;
++
++	for (i = 0; i < AW88166_DEV_SYSST_CHECK_MAX; i++) {
++		ret = aw_dev_get_iis_status(aw_dev);
++		if (ret) {
++			dev_err(aw_dev->dev, "mode1 iis signal check error");
++			usleep_range(AW88166_2000_US, AW88166_2000_US + 10);
++		} else {
++			return 0;
++		}
++	}
++
++	return -EPERM;
++}
++
++static int aw_dev_check_mode2_pll(struct aw_device *aw_dev)
++{
++	unsigned int reg_val;
++	int ret, i;
++
++	ret = regmap_read(aw_dev->regmap, AW88166_PLLCTRL2_REG, &reg_val);
++	if (ret)
++		return ret;
++
++	reg_val &= (~AW88166_CCO_MUX_MASK);
++	if (reg_val == AW88166_CCO_MUX_DIVIDED_VALUE) {
++		dev_dbg(aw_dev->dev, "CCO_MUX is already divider");
++		return -EPERM;
++	}
++
++	/* change mode2 */
++	ret = regmap_update_bits(aw_dev->regmap, AW88166_PLLCTRL2_REG,
++			~AW88166_CCO_MUX_MASK, AW88166_CCO_MUX_DIVIDED_VALUE);
++	if (ret)
++		return ret;
++
++	for (i = 0; i < AW88166_DEV_SYSST_CHECK_MAX; i++) {
++		ret = aw_dev_get_iis_status(aw_dev);
++		if (ret) {
++			dev_err(aw_dev->dev, "mode2 iis signal check error");
++			usleep_range(AW88166_2000_US, AW88166_2000_US + 10);
++		} else {
++			break;
++		}
++	}
++
++	/* change mode1 */
++	regmap_update_bits(aw_dev->regmap, AW88166_PLLCTRL2_REG,
++			~AW88166_CCO_MUX_MASK, AW88166_CCO_MUX_BYPASS_VALUE);
++	if (ret == 0) {
++		usleep_range(AW88166_2000_US, AW88166_2000_US + 10);
++		for (i = 0; i < AW88166_DEV_SYSST_CHECK_MAX; i++) {
++			ret = aw_dev_get_iis_status(aw_dev);
++			if (ret) {
++				dev_err(aw_dev->dev, "mode2 switch to mode1, iis signal check error");
++				usleep_range(AW88166_2000_US, AW88166_2000_US + 10);
++			} else {
++				break;
++			}
++		}
++	}
++
++	return ret;
++}
++
++static int aw_dev_check_syspll(struct aw_device *aw_dev)
++{
++	int ret;
++
++	ret = aw_dev_check_mode1_pll(aw_dev);
++	if (ret) {
++		dev_dbg(aw_dev->dev, "mode1 check iis failed try switch to mode2 check");
++		ret = aw_dev_check_mode2_pll(aw_dev);
++		if (ret) {
++			dev_err(aw_dev->dev, "mode2 check iis failed");
++			return ret;
++		}
++	}
++
++	return 0;
++}
++
++static int aw_dev_check_sysst(struct aw_device *aw_dev)
++{
++	unsigned int check_val;
++	unsigned int reg_val;
++	int ret, i;
++
++	ret = regmap_read(aw_dev->regmap, AW88166_PWMCTRL3_REG, &reg_val);
++	if (ret)
++		return ret;
++
++	if (reg_val & (~AW88166_NOISE_GATE_EN_MASK))
++		check_val = AW88166_BIT_SYSST_NOSWS_CHECK;
++	else
++		check_val = AW88166_BIT_SYSST_SWS_CHECK;
++
++	for (i = 0; i < AW88166_DEV_SYSST_CHECK_MAX; i++) {
++		ret = regmap_read(aw_dev->regmap, AW88166_SYSST_REG, &reg_val);
++		if (ret)
++			return ret;
++
++		if ((reg_val & (~AW88166_BIT_SYSST_CHECK_MASK) & check_val) != check_val) {
++			dev_err(aw_dev->dev, "check sysst fail, cnt=%d, reg_val=0x%04x, check:0x%x",
++				i, reg_val, AW88166_BIT_SYSST_NOSWS_CHECK);
++			usleep_range(AW88166_2000_US, AW88166_2000_US + 10);
++		} else {
++			return 0;
++		}
++	}
++
++	return -EPERM;
++}
++
++static void aw_dev_amppd(struct aw_device *aw_dev, bool amppd)
++{
++	int ret;
++
++	if (amppd)
++		ret = regmap_update_bits(aw_dev->regmap, AW88166_SYSCTRL_REG,
++				~AW88166_AMPPD_MASK, AW88166_AMPPD_POWER_DOWN_VALUE);
++	else
++		ret = regmap_update_bits(aw_dev->regmap, AW88166_SYSCTRL_REG,
++				~AW88166_AMPPD_MASK, AW88166_AMPPD_WORKING_VALUE);
++
++	if (ret)
++		dev_dbg(aw_dev->dev, "%s failed", __func__);
++}
++
++static void aw_dev_dsp_enable(struct aw_device *aw_dev, bool is_enable)
++{
++	int ret;
++
++	if (is_enable)
++		ret = regmap_update_bits(aw_dev->regmap, AW88166_SYSCTRL_REG,
++					~AW88166_DSPBY_MASK, AW88166_DSPBY_WORKING_VALUE);
++	else
++		ret = regmap_update_bits(aw_dev->regmap, AW88166_SYSCTRL_REG,
++					~AW88166_DSPBY_MASK, AW88166_DSPBY_BYPASS_VALUE);
++
++	if (ret)
++		dev_dbg(aw_dev->dev, "%s failed\n", __func__);
++}
++
++static int aw88166_dev_get_icalk(struct aw88166 *aw88166, int16_t *icalk)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	unsigned int efrm_reg_val, efrl_reg_val;
++	uint16_t ef_isn_geslp, ef_isn_h5bits;
++	uint16_t icalk_val;
++	int ret;
++
++	ret = regmap_read(aw_dev->regmap, AW88166_EFRM2_REG, &efrm_reg_val);
++	if (ret)
++		return ret;
++
++	ef_isn_geslp = (efrm_reg_val & (~AW88166_EF_ISN_GESLP_MASK)) >>
++						AW88166_EF_ISN_GESLP_SHIFT;
++
++	ret = regmap_read(aw_dev->regmap, AW88166_EFRL_REG, &efrl_reg_val);
++	if (ret)
++		return ret;
++
++	ef_isn_h5bits = (efrl_reg_val & (~AW88166_EF_ISN_H5BITS_MASK)) >>
++						AW88166_EF_ISN_H5BITS_SHIFT;
++
++	if (aw88166->check_val == AW_EF_AND_CHECK)
++		icalk_val = ef_isn_geslp & (ef_isn_h5bits | AW88166_EF_ISN_H5BITS_SIGN_MASK);
++	else
++		icalk_val = ef_isn_geslp | (ef_isn_h5bits & (~AW88166_EF_ISN_H5BITS_SIGN_MASK));
++
++	if (icalk_val & (~AW88166_ICALK_SIGN_MASK))
++		icalk_val = icalk_val | AW88166_ICALK_NEG_MASK;
++	*icalk = (int16_t)icalk_val;
++
++	return 0;
++}
++
++static int aw88166_dev_get_vcalk(struct aw88166 *aw88166, int16_t *vcalk)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	unsigned int efrm_reg_val, efrl_reg_val;
++	uint16_t ef_vsn_geslp, ef_vsn_h3bits;
++	uint16_t vcalk_val;
++	int ret;
++
++	ret = regmap_read(aw_dev->regmap, AW88166_EFRM2_REG, &efrm_reg_val);
++	if (ret)
++		return ret;
++
++	ef_vsn_geslp = (efrm_reg_val & (~AW88166_EF_VSN_GESLP_MASK)) >>
++					AW88166_EF_VSN_GESLP_SHIFT;
++
++	ret = regmap_read(aw_dev->regmap, AW88166_EFRL_REG, &efrl_reg_val);
++	if (ret)
++		return ret;
++
++	ef_vsn_h3bits = (efrl_reg_val & (~AW88166_EF_VSN_H3BITS_MASK)) >>
++					AW88166_EF_VSN_H3BITS_SHIFT;
++
++	if (aw88166->check_val == AW_EF_AND_CHECK)
++		vcalk_val = ef_vsn_geslp & (ef_vsn_h3bits | AW88166_EF_VSN_H3BITS_SIGN_MASK);
++	else
++		vcalk_val = ef_vsn_geslp | (ef_vsn_h3bits & (~AW88166_EF_VSN_H3BITS_SIGN_MASK));
++
++	if (vcalk_val & (~AW88166_VCALK_SIGN_MASK))
++		vcalk_val = vcalk_val | AW88166_VCALK_NEG_MASK;
++	*vcalk = (int16_t)vcalk_val;
++
++	return 0;
++}
++
++static int aw88166_dev_set_vcalb(struct aw88166 *aw88166)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	int32_t ical_k, vcal_k, vcalb;
++	int16_t icalk, vcalk;
++	unsigned int reg_val;
++	int ret;
++
++	ret = aw88166_dev_get_icalk(aw88166, &icalk);
++	if (ret) {
++		dev_err(aw_dev->dev, "get icalk failed\n");
++		return ret;
++	}
++	ical_k = icalk * AW88166_ICABLK_FACTOR + AW88166_CABL_BASE_VALUE;
++
++	ret = aw88166_dev_get_vcalk(aw88166, &vcalk);
++	if (ret) {
++		dev_err(aw_dev->dev, "get vbcalk failed\n");
++		return ret;
++	}
++	vcal_k = vcalk * AW88166_VCABLK_FACTOR + AW88166_CABL_BASE_VALUE;
++
++	vcalb = AW88166_VCALB_ACCURACY * AW88166_VSCAL_FACTOR /
++			AW88166_ISCAL_FACTOR * ical_k / vcal_k * aw88166->vcalb_init_val;
++
++	vcalb = vcalb >> AW88166_VCALB_ADJ_FACTOR;
++	reg_val = (uint32_t)vcalb;
++
++	regmap_write(aw_dev->regmap, AW88166_DSPVCALB_REG, reg_val);
++
++	return 0;
++}
++
++static int aw_dev_init_vcalb_update(struct aw88166 *aw88166, int flag)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	int ret;
++
++	switch (flag) {
++	case AW88166_RECOVERY_SEC_DATA:
++		ret = regmap_write(aw_dev->regmap, AW88166_DSPVCALB_REG, aw88166->vcalb_init_val);
++		break;
++	case AW88166_RECORD_SEC_DATA:
++		ret = regmap_read(aw_dev->regmap, AW88166_DSPVCALB_REG, &aw88166->vcalb_init_val);
++		break;
++	default:
++		dev_err(aw_dev->dev, "unsupported type:%d\n", flag);
++		ret = -EINVAL;
++		break;
++	}
++
++	return ret;
++}
++
++static int aw_dev_init_re_update(struct aw88166 *aw88166, int flag)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	unsigned int re_temp_h, re_temp_l;
++	int ret;
++
++	switch (flag) {
++	case AW88166_RECOVERY_SEC_DATA:
++		ret = regmap_write(aw_dev->regmap, AW88166_ACR1_REG, aw88166->re_init_val >> 16);
++		if (ret)
++			return ret;
++		ret = regmap_write(aw_dev->regmap, AW88166_ACR2_REG,
++						(uint16_t)aw88166->re_init_val);
++		if (ret)
++			return ret;
++		break;
++	case AW88166_RECORD_SEC_DATA:
++		ret = regmap_read(aw_dev->regmap, AW88166_ACR1_REG, &re_temp_h);
++		if (ret)
++			return ret;
++		ret = regmap_read(aw_dev->regmap, AW88166_ACR2_REG, &re_temp_l);
++		if (ret)
++			return ret;
++		aw88166->re_init_val = (re_temp_h << 16) + re_temp_l;
++		break;
++	default:
++		dev_err(aw_dev->dev, "unsupported type:%d\n", flag);
++		ret = -EINVAL;
++		break;
++	}
++
++	return ret;
++}
++
++static void aw_dev_backup_sec_record(struct aw88166 *aw88166)
++{
++	aw_dev_init_vcalb_update(aw88166, AW88166_RECORD_SEC_DATA);
++	aw_dev_init_re_update(aw88166, AW88166_RECOVERY_SEC_DATA);
++}
++
++static void aw_dev_backup_sec_recovery(struct aw88166 *aw88166)
++{
++	aw_dev_init_vcalb_update(aw88166, AW88166_RECOVERY_SEC_DATA);
++	aw_dev_init_re_update(aw88166, AW88166_RECOVERY_SEC_DATA);
++}
++
++static int aw_dev_update_cali_re(struct aw_cali_desc *cali_desc)
++{
++	struct aw_device *aw_dev =
++		container_of(cali_desc, struct aw_device, cali_desc);
++	uint16_t re_lbits, re_hbits;
++	u32 cali_re;
++	int ret;
++
++	if ((aw_dev->cali_desc.cali_re >= AW88166_CALI_RE_MAX) ||
++			(aw_dev->cali_desc.cali_re <= AW88166_CALI_RE_MIN))
++		return -EINVAL;
++
++	cali_re = AW88166_SHOW_RE_TO_DSP_RE((aw_dev->cali_desc.cali_re +
++				aw_dev->cali_desc.ra), AW88166_DSP_RE_SHIFT);
++
++	re_hbits = (cali_re & (~AW88166_CALI_RE_HBITS_MASK)) >> AW88166_CALI_RE_HBITS_SHIFT;
++	re_lbits = (cali_re & (~AW88166_CALI_RE_LBITS_MASK)) >> AW88166_CALI_RE_LBITS_SHIFT;
++
++	ret = regmap_write(aw_dev->regmap, AW88166_ACR1_REG, re_hbits);
++	if (ret) {
++		dev_err(aw_dev->dev, "set cali re error");
++		return ret;
++	}
++
++	ret = regmap_write(aw_dev->regmap, AW88166_ACR2_REG, re_lbits);
++	if (ret)
++		dev_err(aw_dev->dev, "set cali re error");
++
++	return ret;
++}
++
++static int aw_dev_fw_crc_check(struct aw_device *aw_dev)
++{
++	uint16_t check_val, fw_len_val;
++	unsigned int reg_val;
++	int ret;
++
++	/* calculate fw_end_addr */
++	fw_len_val = ((aw_dev->dsp_fw_len / AW_FW_ADDR_LEN) - 1) + AW88166_CRC_FW_BASE_ADDR;
++
++	/* write fw_end_addr to crc_end_addr */
++	ret = regmap_update_bits(aw_dev->regmap, AW88166_CRCCTRL_REG,
++					~AW88166_CRC_END_ADDR_MASK, fw_len_val);
++	if (ret)
++		return ret;
++	/* enable fw crc check */
++	ret = regmap_update_bits(aw_dev->regmap, AW88166_CRCCTRL_REG,
++		~AW88166_CRC_CODE_EN_MASK, AW88166_CRC_CODE_EN_ENABLE_VALUE);
++
++	usleep_range(AW88166_2000_US, AW88166_2000_US + 10);
++
++	/* read crc check result */
++	regmap_read(aw_dev->regmap, AW88166_HAGCST_REG, &reg_val);
++	if (ret)
++		return ret;
++
++	check_val = (reg_val & (~AW88166_CRC_CHECK_BITS_MASK)) >> AW88166_CRC_CHECK_START_BIT;
++
++	/* disable fw crc check */
++	ret = regmap_update_bits(aw_dev->regmap, AW88166_CRCCTRL_REG,
++		~AW88166_CRC_CODE_EN_MASK, AW88166_CRC_CODE_EN_DISABLE_VALUE);
++	if (ret)
++		return ret;
++
++	if (check_val != AW88166_CRC_CHECK_PASS_VAL) {
++		dev_err(aw_dev->dev, "%s failed, check_val 0x%x != 0x%x\n",
++				__func__, check_val, AW88166_CRC_CHECK_PASS_VAL);
++		ret = -EINVAL;
++	}
++
++	return ret;
++}
++
++static int aw_dev_cfg_crc_check(struct aw_device *aw_dev)
++{
++	uint16_t check_val, cfg_len_val;
++	unsigned int reg_val;
++	int ret;
++
++	/* calculate cfg end addr */
++	cfg_len_val = ((aw_dev->dsp_cfg_len / AW_FW_ADDR_LEN) - 1) + AW88166_CRC_CFG_BASE_ADDR;
++
++	/* write cfg_end_addr to crc_end_addr */
++	ret = regmap_update_bits(aw_dev->regmap, AW88166_CRCCTRL_REG,
++				~AW88166_CRC_END_ADDR_MASK, cfg_len_val);
++	if (ret)
++		return ret;
++
++	/* enable cfg crc check */
++	ret = regmap_update_bits(aw_dev->regmap, AW88166_CRCCTRL_REG,
++			~AW88166_CRC_CFG_EN_MASK, AW88166_CRC_CFG_EN_ENABLE_VALUE);
++	if (ret)
++		return ret;
++
++	usleep_range(AW88166_1000_US, AW88166_1000_US + 10);
++
++	/* read crc check result */
++	ret = regmap_read(aw_dev->regmap, AW88166_HAGCST_REG, &reg_val);
++	if (ret)
++		return ret;
++
++	check_val = (reg_val & (~AW88166_CRC_CHECK_BITS_MASK)) >> AW88166_CRC_CHECK_START_BIT;
++
++	/* disable cfg crc check */
++	ret = regmap_update_bits(aw_dev->regmap, AW88166_CRCCTRL_REG,
++			~AW88166_CRC_CFG_EN_MASK, AW88166_CRC_CFG_EN_DISABLE_VALUE);
++	if (ret)
++		return ret;
++
++	if (check_val != AW88166_CRC_CHECK_PASS_VAL) {
++		dev_err(aw_dev->dev, "crc_check failed, check val 0x%x != 0x%x\n",
++						check_val, AW88166_CRC_CHECK_PASS_VAL);
++		ret = -EINVAL;
++	}
++
++	return ret;
++}
++
++static int aw_dev_hw_crc_check(struct aw88166 *aw88166)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	int ret;
++
++	ret = regmap_update_bits(aw_dev->regmap, AW88166_I2SCFG1_REG,
++		~AW88166_RAM_CG_BYP_MASK, AW88166_RAM_CG_BYP_BYPASS_VALUE);
++	if (ret)
++		return ret;
++
++	ret = aw_dev_fw_crc_check(aw_dev);
++	if (ret) {
++		dev_err(aw_dev->dev, "fw_crc_check failed\n");
++		goto crc_check_failed;
++	}
++
++	ret = aw_dev_cfg_crc_check(aw_dev);
++	if (ret) {
++		dev_err(aw_dev->dev, "cfg_crc_check failed\n");
++		goto crc_check_failed;
++	}
++
++	ret = regmap_write(aw_dev->regmap, AW88166_CRCCTRL_REG, aw88166->crc_init_val);
++	if (ret)
++		return ret;
++
++	ret = regmap_update_bits(aw_dev->regmap, AW88166_I2SCFG1_REG,
++		~AW88166_RAM_CG_BYP_MASK, AW88166_RAM_CG_BYP_WORK_VALUE);
++
++	return ret;
++
++crc_check_failed:
++	regmap_update_bits(aw_dev->regmap, AW88166_I2SCFG1_REG,
++		~AW88166_RAM_CG_BYP_MASK, AW88166_RAM_CG_BYP_WORK_VALUE);
++	return ret;
++}
++
++static void aw_dev_i2s_tx_enable(struct aw_device *aw_dev, bool flag)
++{
++	int ret;
++
++	if (flag)
++		ret = regmap_update_bits(aw_dev->regmap, AW88166_I2SCTRL3_REG,
++			~AW88166_I2STXEN_MASK, AW88166_I2STXEN_ENABLE_VALUE);
++	else
++		ret = regmap_update_bits(aw_dev->regmap, AW88166_I2SCTRL3_REG,
++			~AW88166_I2STXEN_MASK, AW88166_I2STXEN_DISABLE_VALUE);
++
++	if (ret)
++		dev_dbg(aw_dev->dev, "%s failed", __func__);
++}
++
++static int aw_dev_get_dsp_status(struct aw_device *aw_dev)
++{
++	unsigned int reg_val;
++	int ret;
++
++	ret = regmap_read(aw_dev->regmap, AW88166_WDT_REG, &reg_val);
++	if (ret)
++		return ret;
++	if (!(reg_val & (~AW88166_WDT_CNT_MASK)))
++		return -EPERM;
++
++	return 0;
++}
++
++static int aw_dev_dsp_check(struct aw_device *aw_dev)
++{
++	int ret, i;
++
++	switch (aw_dev->dsp_cfg) {
++	case AW88166_DEV_DSP_BYPASS:
++		dev_dbg(aw_dev->dev, "dsp bypass");
++		ret = 0;
++		break;
++	case AW88166_DEV_DSP_WORK:
++		aw_dev_dsp_enable(aw_dev, false);
++		aw_dev_dsp_enable(aw_dev, true);
++		usleep_range(AW88166_1000_US, AW88166_1000_US + 10);
++		for (i = 0; i < AW88166_DEV_DSP_CHECK_MAX; i++) {
++			ret = aw_dev_get_dsp_status(aw_dev);
++			if (ret) {
++				dev_err(aw_dev->dev, "dsp wdt status error=%d", ret);
++				usleep_range(AW88166_2000_US, AW88166_2000_US + 10);
++			}
++		}
++		break;
++	default:
++		dev_err(aw_dev->dev, "unknown dsp cfg=%d", aw_dev->dsp_cfg);
++		ret = -EINVAL;
++		break;
++	}
++
++	return ret;
++}
++
++static int aw_dev_set_volume(struct aw_device *aw_dev, unsigned int value)
++{
++	struct aw_volume_desc *vol_desc = &aw_dev->volume_desc;
++	unsigned int reg_value;
++	u16 real_value;
++	int ret;
++
++	real_value = min((value + vol_desc->init_volume), (unsigned int)AW88166_MUTE_VOL);
++
++	ret = regmap_read(aw_dev->regmap, AW88166_SYSCTRL2_REG, &reg_value);
++	if (ret)
++		return ret;
++
++	dev_dbg(aw_dev->dev, "value 0x%x , reg:0x%x", value, real_value);
++
++	real_value = (real_value << AW88166_VOL_START_BIT) | (reg_value & AW88166_VOL_MASK);
++
++	ret = regmap_write(aw_dev->regmap, AW88166_SYSCTRL2_REG, real_value);
++
++	return ret;
++}
++
++static void aw_dev_fade_in(struct aw_device *aw_dev)
++{
++	struct aw_volume_desc *desc = &aw_dev->volume_desc;
++	u16 fade_in_vol = desc->ctl_volume;
++	int fade_step = aw_dev->fade_step;
++	int i;
++
++	if (fade_step == 0 || aw_dev->fade_in_time == 0) {
++		aw_dev_set_volume(aw_dev, fade_in_vol);
++		return;
++	}
++
++	for (i = AW88166_MUTE_VOL; i >= fade_in_vol; i -= fade_step) {
++		aw_dev_set_volume(aw_dev, i);
++		usleep_range(aw_dev->fade_in_time, aw_dev->fade_in_time + 10);
++	}
++
++	if (i != fade_in_vol)
++		aw_dev_set_volume(aw_dev, fade_in_vol);
++}
++
++static void aw_dev_fade_out(struct aw_device *aw_dev)
++{
++	struct aw_volume_desc *desc = &aw_dev->volume_desc;
++	int fade_step = aw_dev->fade_step;
++	int i;
++
++	if (fade_step == 0 || aw_dev->fade_out_time == 0) {
++		aw_dev_set_volume(aw_dev, AW88166_MUTE_VOL);
++		return;
++	}
++
++	for (i = desc->ctl_volume; i <= AW88166_MUTE_VOL; i += fade_step) {
++		aw_dev_set_volume(aw_dev, i);
++		usleep_range(aw_dev->fade_out_time, aw_dev->fade_out_time + 10);
++	}
++
++	if (i != AW88166_MUTE_VOL) {
++		aw_dev_set_volume(aw_dev, AW88166_MUTE_VOL);
++		usleep_range(aw_dev->fade_out_time, aw_dev->fade_out_time + 10);
++	}
++}
++
++static void aw88166_dev_mute(struct aw_device *aw_dev, bool is_mute)
++{
++	if (is_mute) {
++		aw_dev_fade_out(aw_dev);
++		regmap_update_bits(aw_dev->regmap, AW88166_SYSCTRL_REG,
++				~AW88166_HMUTE_MASK, AW88166_HMUTE_ENABLE_VALUE);
++	} else {
++		regmap_update_bits(aw_dev->regmap, AW88166_SYSCTRL_REG,
++				~AW88166_HMUTE_MASK, AW88166_HMUTE_DISABLE_VALUE);
++		aw_dev_fade_in(aw_dev);
++	}
++}
++
++static void aw88166_dev_set_dither(struct aw88166 *aw88166, bool dither)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++
++	if (dither)
++		regmap_update_bits(aw_dev->regmap, AW88166_DBGCTRL_REG,
++				~AW88166_DITHER_EN_MASK, AW88166_DITHER_EN_ENABLE_VALUE);
++	else
++		regmap_update_bits(aw_dev->regmap, AW88166_DBGCTRL_REG,
++				~AW88166_DITHER_EN_MASK, AW88166_DITHER_EN_DISABLE_VALUE);
++}
++
++static int aw88166_dev_start(struct aw88166 *aw88166)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	int ret;
++
++	if (aw_dev->status == AW88166_DEV_PW_ON) {
++		dev_dbg(aw_dev->dev, "already power on");
++		return 0;
++	}
++
++	aw88166_dev_set_dither(aw88166, false);
++
++	/* power on */
++	aw_dev_pwd(aw_dev, false);
++	usleep_range(AW88166_2000_US, AW88166_2000_US + 10);
++
++	ret = aw_dev_check_syspll(aw_dev);
++	if (ret) {
++		dev_err(aw_dev->dev, "pll check failed cannot start\n");
++		goto pll_check_fail;
++	}
++
++	/* amppd on */
++	aw_dev_amppd(aw_dev, false);
++	usleep_range(AW88166_1000_US, AW88166_1000_US + 50);
++
++	/* check i2s status */
++	ret = aw_dev_check_sysst(aw_dev);
++	if (ret) {
++		dev_err(aw_dev->dev, "sysst check failed\n");
++		goto sysst_check_fail;
++	}
++
++	if (aw_dev->dsp_cfg == AW88166_DEV_DSP_WORK) {
++		aw_dev_backup_sec_recovery(aw88166);
++		ret = aw_dev_hw_crc_check(aw88166);
++		if (ret) {
++			dev_err(aw_dev->dev, "dsp crc check failed\n");
++			goto crc_check_fail;
++		}
++		aw_dev_dsp_enable(aw_dev, false);
++		aw88166_dev_set_vcalb(aw88166);
++		aw_dev_update_cali_re(&aw_dev->cali_desc);
++		ret = aw_dev_dsp_check(aw_dev);
++		if (ret) {
++			dev_err(aw_dev->dev, "dsp status check failed\n");
++			goto dsp_check_fail;
++		}
++	} else {
++		dev_dbg(aw_dev->dev, "start pa with dsp bypass");
++	}
++
++	/* enable tx feedback */
++	aw_dev_i2s_tx_enable(aw_dev, true);
++
++	if (aw88166->dither_st == AW88166_DITHER_EN_ENABLE_VALUE)
++		aw88166_dev_set_dither(aw88166, true);
++
++	/* close mute */
++	aw88166_dev_mute(aw_dev, false);
++	/* clear inturrupt */
++	aw_dev_clear_int_status(aw_dev);
++	aw_dev->status = AW88166_DEV_PW_ON;
++
++	return 0;
++
++dsp_check_fail:
++crc_check_fail:
++	aw_dev_dsp_enable(aw_dev, false);
++sysst_check_fail:
++	aw_dev_clear_int_status(aw_dev);
++	aw_dev_amppd(aw_dev, true);
++pll_check_fail:
++	aw_dev_pwd(aw_dev, true);
++	aw_dev->status = AW88166_DEV_PW_OFF;
++
++	return ret;
++}
++
++static int aw_dev_dsp_update_container(struct aw_device *aw_dev,
++			unsigned char *data, unsigned int len, unsigned short base)
++{
++	u32 tmp_len;
++	int i, ret;
++
++	ret = regmap_write(aw_dev->regmap, AW88166_DSPMADD_REG, base);
++	if (ret)
++		return ret;
++
++	for (i = 0; i < len; i += AW88166_MAX_RAM_WRITE_BYTE_SIZE) {
++		tmp_len = min(len - i, AW88166_MAX_RAM_WRITE_BYTE_SIZE);
++		ret = regmap_raw_write(aw_dev->regmap, AW88166_DSPMDAT_REG,
++					&data[i], tmp_len);
++		if (ret)
++			return ret;
++	}
++
++	return 0;
++}
++
++static int aw_dev_get_ra(struct aw_cali_desc *cali_desc)
++{
++	struct aw_device *aw_dev =
++		container_of(cali_desc, struct aw_device, cali_desc);
++	u32 dsp_ra;
++	int ret;
++
++	ret = aw_dev_dsp_read(aw_dev, AW88166_DSP_REG_CFG_ADPZ_RA,
++				&dsp_ra, AW_DSP_32_DATA);
++	if (ret) {
++		dev_err(aw_dev->dev, "read ra error\n");
++		return ret;
++	}
++
++	cali_desc->ra = AW88166_DSP_RE_TO_SHOW_RE(dsp_ra,
++					AW88166_DSP_RE_SHIFT);
++
++	return 0;
++}
++
++static int aw_dev_dsp_update_cfg(struct aw_device *aw_dev,
++			unsigned char *data, unsigned int len)
++{
++	int ret;
++
++	dev_dbg(aw_dev->dev, "dsp config len:%d", len);
++
++	if (!len || !data) {
++		dev_err(aw_dev->dev, "dsp config data is null or len is 0\n");
++		return -EINVAL;
++	}
++
++	ret = aw_dev_dsp_update_container(aw_dev, data, len, AW88166_DSP_CFG_ADDR);
++	if (ret)
++		return ret;
++
++	aw_dev->dsp_cfg_len = len;
++
++	ret = aw_dev_get_ra(&aw_dev->cali_desc);
++
++	return ret;
++}
++
++static int aw_dev_dsp_update_fw(struct aw_device *aw_dev,
++			unsigned char *data, unsigned int len)
++{
++	int ret;
++
++	dev_dbg(aw_dev->dev, "dsp firmware len:%d", len);
++
++	if (!len || !data) {
++		dev_err(aw_dev->dev, "dsp firmware data is null or len is 0\n");
++		return -EINVAL;
++	}
++
++	aw_dev->dsp_fw_len = len;
++	ret = aw_dev_dsp_update_container(aw_dev, data, len, AW88166_DSP_FW_ADDR);
++
++	return ret;
++}
++
++static int aw_dev_check_sram(struct aw_device *aw_dev)
++{
++	unsigned int reg_val;
++
++	/* read dsp_rom_check_reg */
++	aw_dev_dsp_read(aw_dev, AW88166_DSP_ROM_CHECK_ADDR, &reg_val, AW_DSP_16_DATA);
++	if (reg_val != AW88166_DSP_ROM_CHECK_DATA) {
++		dev_err(aw_dev->dev, "check dsp rom failed, read[0x%x] != check[0x%x]\n",
++						reg_val, AW88166_DSP_ROM_CHECK_DATA);
++		return -EPERM;
++	}
++
++	/* check dsp_cfg_base_addr */
++	aw_dev_dsp_write(aw_dev, AW88166_DSP_CFG_ADDR,
++				AW88166_DSP_ODD_NUM_BIT_TEST, AW_DSP_16_DATA);
++	aw_dev_dsp_read(aw_dev, AW88166_DSP_CFG_ADDR, &reg_val, AW_DSP_16_DATA);
++	if (reg_val != AW88166_DSP_ODD_NUM_BIT_TEST) {
++		dev_err(aw_dev->dev, "check dsp cfg failed, read[0x%x] != write[0x%x]\n",
++						reg_val, AW88166_DSP_ODD_NUM_BIT_TEST);
++		return -EPERM;
++	}
++
++	return 0;
++}
++
++static void aw_dev_select_memclk(struct aw_device *aw_dev, unsigned char flag)
++{
++	int ret;
++
++	switch (flag) {
++	case AW88166_DEV_MEMCLK_PLL:
++		ret = regmap_update_bits(aw_dev->regmap, AW88166_DBGCTRL_REG,
++					~AW88166_MEM_CLKSEL_MASK,
++					AW88166_MEM_CLKSEL_DAPHCLK_VALUE);
++		if (ret)
++			dev_err(aw_dev->dev, "memclk select pll failed\n");
++		break;
++	case AW88166_DEV_MEMCLK_OSC:
++		ret = regmap_update_bits(aw_dev->regmap, AW88166_DBGCTRL_REG,
++					~AW88166_MEM_CLKSEL_MASK,
++					AW88166_MEM_CLKSEL_OSCCLK_VALUE);
++		if (ret)
++			dev_err(aw_dev->dev, "memclk select OSC failed\n");
++		break;
++	default:
++		dev_err(aw_dev->dev, "unknown memclk config, flag=0x%x\n", flag);
++		break;
++	}
++}
++
++static int aw_dev_update_reg_container(struct aw88166 *aw88166,
++				unsigned char *data, unsigned int len)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	struct aw_volume_desc *vol_desc = &aw_dev->volume_desc;
++	u16 read_vol, reg_val;
++	int data_len, i, ret;
++	int16_t *reg_data;
++	u8 reg_addr;
++
++	reg_data = (int16_t *)data;
++	data_len = len >> 1;
++
++	if (data_len & 0x1) {
++		dev_err(aw_dev->dev, "data len:%d unsupported\n",	data_len);
++		return -EINVAL;
++	}
++
++	for (i = 0; i < data_len; i += 2) {
++		reg_addr = reg_data[i];
++		reg_val = reg_data[i + 1];
++
++		if (reg_addr == AW88166_DSPVCALB_REG) {
++			aw88166->vcalb_init_val = reg_val;
++			continue;
++		}
++
++		if (reg_addr == AW88166_SYSCTRL_REG) {
++			if (reg_val & (~AW88166_DSPBY_MASK))
++				aw_dev->dsp_cfg = AW88166_DEV_DSP_BYPASS;
++			else
++				aw_dev->dsp_cfg = AW88166_DEV_DSP_WORK;
++
++			reg_val &= (AW88166_HMUTE_MASK | AW88166_PWDN_MASK |
++						AW88166_DSPBY_MASK);
++			reg_val |= (AW88166_HMUTE_ENABLE_VALUE | AW88166_PWDN_POWER_DOWN_VALUE |
++						AW88166_DSPBY_BYPASS_VALUE);
++		}
++
++		if (reg_addr == AW88166_I2SCTRL3_REG) {
++			reg_val &= AW88166_I2STXEN_MASK;
++			reg_val |= AW88166_I2STXEN_DISABLE_VALUE;
++		}
++
++		if (reg_addr == AW88166_SYSCTRL2_REG) {
++			read_vol = (reg_val & (~AW88166_VOL_MASK)) >>
++				AW88166_VOL_START_BIT;
++			aw_dev->volume_desc.init_volume = read_vol;
++		}
++
++		if (reg_addr == AW88166_DBGCTRL_REG) {
++			if ((reg_val & (~AW88166_EF_DBMD_MASK)) == AW88166_EF_DBMD_OR_VALUE)
++				aw88166->check_val = AW_EF_OR_CHECK;
++			else
++				aw88166->check_val = AW_EF_AND_CHECK;
++
++			aw88166->dither_st = reg_val & (~AW88166_DITHER_EN_MASK);
++		}
++
++		if (reg_addr == AW88166_ACR1_REG) {
++			aw88166->re_init_val |= (uint32_t)reg_val << 16;
++			continue;
++		}
++
++		if (reg_addr == AW88166_ACR2_REG) {
++			aw88166->re_init_val |= (uint32_t)reg_val;
++			continue;
++		}
++
++		if (reg_addr == AW88166_CRCCTRL_REG)
++			aw88166->crc_init_val = reg_val;
++
++		ret = regmap_write(aw_dev->regmap, reg_addr, reg_val);
++		if (ret)
++			return ret;
++	}
++
++	aw_dev_pwd(aw_dev, false);
++	usleep_range(AW88166_1000_US, AW88166_1000_US + 10);
++
++	if (aw_dev->prof_cur != aw_dev->prof_index)
++		vol_desc->ctl_volume = 0;
++	else
++		aw_dev_set_volume(aw_dev, vol_desc->ctl_volume);
++
++	return 0;
++}
++
++static int aw_dev_reg_update(struct aw88166 *aw88166,
++					unsigned char *data, unsigned int len)
++{
++	int ret;
++
++	if (!len || !data) {
++		dev_err(aw88166->aw_pa->dev, "reg data is null or len is 0\n");
++		return -EINVAL;
++	}
++
++	ret = aw_dev_update_reg_container(aw88166, data, len);
++	if (ret)
++		dev_err(aw88166->aw_pa->dev, "reg update failed\n");
++
++	return ret;
++}
++
++static int aw88166_dev_get_prof_name(struct aw_device *aw_dev, int index, char **prof_name)
++{
++	struct aw_prof_info *prof_info = &aw_dev->prof_info;
++	struct aw_prof_desc *prof_desc;
++
++	if ((index >= aw_dev->prof_info.count) || (index < 0)) {
++		dev_err(aw_dev->dev, "index[%d] overflow count[%d]\n",
++						index, aw_dev->prof_info.count);
++		return -EINVAL;
++	}
++
++	prof_desc = &aw_dev->prof_info.prof_desc[index];
++
++	*prof_name = prof_info->prof_name_list[prof_desc->id];
++
++	return 0;
++}
++
++static int aw88166_dev_get_prof_data(struct aw_device *aw_dev, int index,
++			struct aw_prof_desc **prof_desc)
++{
++	if ((index >= aw_dev->prof_info.count) || (index < 0)) {
++		dev_err(aw_dev->dev, "%s: index[%d] overflow count[%d]\n",
++				__func__, index, aw_dev->prof_info.count);
++		return -EINVAL;
++	}
++
++	*prof_desc = &aw_dev->prof_info.prof_desc[index];
++
++	return 0;
++}
++
++static int aw88166_dev_fw_update(struct aw88166 *aw88166, bool up_dsp_fw_en, bool force_up_en)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	struct aw_prof_desc *prof_index_desc;
++	struct aw_sec_data_desc *sec_desc;
++	char *prof_name;
++	int ret;
++
++	if ((aw_dev->prof_cur == aw_dev->prof_index) &&
++			(force_up_en == AW88166_FORCE_UPDATE_OFF)) {
++		dev_dbg(aw_dev->dev, "scene no change, not update");
++		return 0;
++	}
++
++	if (aw_dev->fw_status == AW88166_DEV_FW_FAILED) {
++		dev_err(aw_dev->dev, "fw status[%d] error\n", aw_dev->fw_status);
++		return -EPERM;
++	}
++
++	ret = aw88166_dev_get_prof_name(aw_dev, aw_dev->prof_index, &prof_name);
++	if (ret)
++		return ret;
++
++	dev_dbg(aw_dev->dev, "start update %s", prof_name);
++
++	ret = aw88166_dev_get_prof_data(aw_dev, aw_dev->prof_index, &prof_index_desc);
++	if (ret)
++		return ret;
++
++	/* update reg */
++	sec_desc = prof_index_desc->sec_desc;
++	ret = aw_dev_reg_update(aw88166, sec_desc[AW88395_DATA_TYPE_REG].data,
++					sec_desc[AW88395_DATA_TYPE_REG].len);
++	if (ret) {
++		dev_err(aw_dev->dev, "update reg failed\n");
++		return ret;
++	}
++
++	aw88166_dev_mute(aw_dev, true);
++
++	if (aw_dev->dsp_cfg == AW88166_DEV_DSP_WORK)
++		aw_dev_dsp_enable(aw_dev, false);
++
++	aw_dev_select_memclk(aw_dev, AW88166_DEV_MEMCLK_OSC);
++
++	ret = aw_dev_check_sram(aw_dev);
++	if (ret) {
++		dev_err(aw_dev->dev, "check sram failed\n");
++		goto error;
++	}
++
++	aw_dev_backup_sec_recovery(aw88166);
++
++	if (up_dsp_fw_en) {
++		dev_dbg(aw_dev->dev, "fw_ver: [%x]", prof_index_desc->fw_ver);
++		ret = aw_dev_dsp_update_fw(aw_dev, sec_desc[AW88395_DATA_TYPE_DSP_FW].data,
++					sec_desc[AW88395_DATA_TYPE_DSP_FW].len);
++		if (ret) {
++			dev_err(aw_dev->dev, "update dsp fw failed\n");
++			goto error;
++		}
++	}
++
++	/* update dsp config */
++	ret = aw_dev_dsp_update_cfg(aw_dev, sec_desc[AW88395_DATA_TYPE_DSP_CFG].data,
++					sec_desc[AW88395_DATA_TYPE_DSP_CFG].len);
++	if (ret) {
++		dev_err(aw_dev->dev, "update dsp cfg failed\n");
++		goto error;
++	}
++
++	aw_dev_backup_sec_record(aw88166);
++
++	aw_dev_select_memclk(aw_dev, AW88166_DEV_MEMCLK_PLL);
++
++	aw_dev->prof_cur = aw_dev->prof_index;
++
++	return 0;
++
++error:
++	aw_dev_select_memclk(aw_dev, AW88166_DEV_MEMCLK_PLL);
++	return ret;
++}
++
++static void aw88166_start_pa(struct aw88166 *aw88166)
++{
++	int ret, i;
++
++	for (i = 0; i < AW88166_START_RETRIES; i++) {
++		ret = aw88166_dev_start(aw88166);
++		if (ret) {
++			dev_err(aw88166->aw_pa->dev, "aw88166 device start failed. retry = %d", i);
++			ret = aw88166_dev_fw_update(aw88166, AW88166_DSP_FW_UPDATE_ON, true);
++			if (ret) {
++				dev_err(aw88166->aw_pa->dev, "fw update failed");
++				continue;
++			}
++		} else {
++			dev_dbg(aw88166->aw_pa->dev, "start success\n");
++			break;
++		}
++	}
++}
++
++static void aw88166_startup_work(struct work_struct *work)
++{
++	struct aw88166 *aw88166 =
++		container_of(work, struct aw88166, start_work.work);
++
++	mutex_lock(&aw88166->lock);
++	aw88166_start_pa(aw88166);
++	mutex_unlock(&aw88166->lock);
++}
++
++static void aw88166_start(struct aw88166 *aw88166, bool sync_start)
++{
++	int ret;
++
++	if (aw88166->aw_pa->fw_status != AW88166_DEV_FW_OK)
++		return;
++
++	if (aw88166->aw_pa->status == AW88166_DEV_PW_ON)
++		return;
++
++	ret = aw88166_dev_fw_update(aw88166, AW88166_DSP_FW_UPDATE_OFF, aw88166->phase_sync);
++	if (ret) {
++		dev_err(aw88166->aw_pa->dev, "fw update failed\n");
++		return;
++	}
++
++	if (sync_start == AW88166_SYNC_START)
++		aw88166_start_pa(aw88166);
++	else
++		queue_delayed_work(system_dfl_wq,
++			&aw88166->start_work,
++			AW88166_START_WORK_DELAY_MS);
++}
++
++static int aw_dev_check_sysint(struct aw_device *aw_dev)
++{
++	u16 reg_val;
++
++	aw_dev_get_int_status(aw_dev, &reg_val);
++	if (reg_val & AW88166_BIT_SYSINT_CHECK) {
++		dev_err(aw_dev->dev, "pa stop check fail:0x%04x\n", reg_val);
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int aw88166_stop(struct aw_device *aw_dev)
++{
++	struct aw_sec_data_desc *dsp_cfg =
++		&aw_dev->prof_info.prof_desc[aw_dev->prof_cur].sec_desc[AW88395_DATA_TYPE_DSP_CFG];
++	struct aw_sec_data_desc *dsp_fw =
++		&aw_dev->prof_info.prof_desc[aw_dev->prof_cur].sec_desc[AW88395_DATA_TYPE_DSP_FW];
++	int int_st;
++
++	if (aw_dev->status == AW88166_DEV_PW_OFF) {
++		dev_dbg(aw_dev->dev, "already power off");
++		return 0;
++	}
++
++	aw_dev->status = AW88166_DEV_PW_OFF;
++
++	aw88166_dev_mute(aw_dev, true);
++	usleep_range(AW88166_4000_US, AW88166_4000_US + 100);
++
++	aw_dev_i2s_tx_enable(aw_dev, false);
++	usleep_range(AW88166_1000_US, AW88166_1000_US + 100);
++
++	int_st = aw_dev_check_sysint(aw_dev);
++
++	aw_dev_dsp_enable(aw_dev, false);
++
++	aw_dev_amppd(aw_dev, true);
++
++	if (int_st) {
++		aw_dev_select_memclk(aw_dev, AW88166_DEV_MEMCLK_OSC);
++		aw_dev_dsp_update_fw(aw_dev, dsp_fw->data, dsp_fw->len);
++		aw_dev_dsp_update_cfg(aw_dev, dsp_cfg->data, dsp_cfg->len);
++		aw_dev_select_memclk(aw_dev, AW88166_DEV_MEMCLK_PLL);
++	}
++
++	aw_dev_pwd(aw_dev, true);
++
++	return 0;
++}
++
++static struct snd_soc_dai_driver aw88166_dai[] = {
++	{
++		.name = "aw88166-aif",
++		.id = 1,
++		.playback = {
++			.stream_name = "Speaker_Playback",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = AW88166_RATES,
++			.formats = AW88166_FORMATS,
++		},
++		.capture = {
++			.stream_name = "Speaker_Capture",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = AW88166_RATES,
++			.formats = AW88166_FORMATS,
++		},
++	},
++};
++
++static int aw88166_get_fade_in_time(struct snd_kcontrol *kcontrol,
++	struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(component);
++	struct aw_device *aw_dev = aw88166->aw_pa;
++
++	ucontrol->value.integer.value[0] = aw_dev->fade_in_time;
++
++	return 0;
++}
++
++static int aw88166_set_fade_in_time(struct snd_kcontrol *kcontrol,
++	struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(component);
++	struct soc_mixer_control *mc =
++		(struct soc_mixer_control *)kcontrol->private_value;
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	int time;
++
++	time = ucontrol->value.integer.value[0];
++
++	if (time < mc->min || time > mc->max)
++		return -EINVAL;
++
++	if (time != aw_dev->fade_in_time) {
++		aw_dev->fade_in_time = time;
++		return 1;
++	}
++
++	return 0;
++}
++
++static int aw88166_get_fade_out_time(struct snd_kcontrol *kcontrol,
++	struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(component);
++	struct aw_device *aw_dev = aw88166->aw_pa;
++
++	ucontrol->value.integer.value[0] = aw_dev->fade_out_time;
++
++	return 0;
++}
++
++static int aw88166_set_fade_out_time(struct snd_kcontrol *kcontrol,
++	struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(component);
++	struct soc_mixer_control *mc =
++		(struct soc_mixer_control *)kcontrol->private_value;
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	int time;
++
++	time = ucontrol->value.integer.value[0];
++	if (time < mc->min || time > mc->max)
++		return -EINVAL;
++
++	if (time != aw_dev->fade_out_time) {
++		aw_dev->fade_out_time = time;
++		return 1;
++	}
++
++	return 0;
++}
++
++static int aw88166_dev_set_profile_index(struct aw_device *aw_dev, int index)
++{
++	/* check the index whether is valid */
++	if ((index >= aw_dev->prof_info.count) || (index < 0))
++		return -EINVAL;
++	/* check the index whether change */
++	if (aw_dev->prof_index == index)
++		return -EINVAL;
++
++	aw_dev->prof_index = index;
++	dev_dbg(aw_dev->dev, "set prof[%s]",
++		aw_dev->prof_info.prof_name_list[aw_dev->prof_info.prof_desc[index].id]);
++
++	return 0;
++}
++
++static int aw88166_profile_info(struct snd_kcontrol *kcontrol,
++			 struct snd_ctl_elem_info *uinfo)
++{
++	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
++	char *prof_name;
++	int count, ret;
++
++	uinfo->type = SNDRV_CTL_ELEM_TYPE_ENUMERATED;
++	uinfo->count = 1;
++
++	count = aw88166->aw_pa->prof_info.count;
++	if (count <= 0) {
++		uinfo->value.enumerated.items = 0;
++		return 0;
++	}
++
++	uinfo->value.enumerated.items = count;
++
++	if (uinfo->value.enumerated.item >= count)
++		uinfo->value.enumerated.item = count - 1;
++
++	count = uinfo->value.enumerated.item;
++
++	ret = aw88166_dev_get_prof_name(aw88166->aw_pa, count, &prof_name);
++	if (ret) {
++		strscpy(uinfo->value.enumerated.name, "null");
++		return 0;
++	}
++
++	strscpy(uinfo->value.enumerated.name, prof_name);
++
++	return 0;
++}
++
++static int aw88166_profile_get(struct snd_kcontrol *kcontrol,
++			struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
++
++	ucontrol->value.integer.value[0] = aw88166->aw_pa->prof_index;
++
++	return 0;
++}
++
++static int aw88166_profile_set(struct snd_kcontrol *kcontrol,
++		struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
++	int ret;
++
++	mutex_lock(&aw88166->lock);
++	ret = aw88166_dev_set_profile_index(aw88166->aw_pa, ucontrol->value.integer.value[0]);
++	if (ret) {
++		dev_dbg(codec->dev, "profile index does not change");
++		mutex_unlock(&aw88166->lock);
++		return 0;
++	}
++
++	if (aw88166->aw_pa->status) {
++		aw88166_stop(aw88166->aw_pa);
++		aw88166_start(aw88166, AW88166_SYNC_START);
++	}
++
++	mutex_unlock(&aw88166->lock);
++
++	return 1;
++}
++
++static int aw88166_volume_get(struct snd_kcontrol *kcontrol,
++				struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
++	struct aw_volume_desc *vol_desc = &aw88166->aw_pa->volume_desc;
++
++	ucontrol->value.integer.value[0] = vol_desc->ctl_volume;
++
++	return 0;
++}
++
++static int aw88166_volume_set(struct snd_kcontrol *kcontrol,
++				struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
++	struct aw_volume_desc *vol_desc = &aw88166->aw_pa->volume_desc;
++	struct soc_mixer_control *mc =
++		(struct soc_mixer_control *)kcontrol->private_value;
++	int value;
++
++	value = ucontrol->value.integer.value[0];
++	if (value < mc->min || value > mc->max)
++		return -EINVAL;
++
++	if (vol_desc->ctl_volume != value) {
++		vol_desc->ctl_volume = value;
++		aw_dev_set_volume(aw88166->aw_pa, vol_desc->ctl_volume);
++
++		return 1;
++	}
++
++	return 0;
++}
++
++static int aw88166_get_fade_step(struct snd_kcontrol *kcontrol,
++				struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
++
++	ucontrol->value.integer.value[0] = aw88166->aw_pa->fade_step;
++
++	return 0;
++}
++
++static int aw88166_set_fade_step(struct snd_kcontrol *kcontrol,
++				struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
++	struct soc_mixer_control *mc =
++		(struct soc_mixer_control *)kcontrol->private_value;
++	int value;
++
++	value = ucontrol->value.integer.value[0];
++	if (value < mc->min || value > mc->max)
++		return -EINVAL;
++
++	if (aw88166->aw_pa->fade_step != value) {
++		aw88166->aw_pa->fade_step = value;
++		return 1;
++	}
++
++	return 0;
++}
++
++static int aw88166_re_get(struct snd_kcontrol *kcontrol,
++				struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
++	struct aw_device *aw_dev = aw88166->aw_pa;
++
++	ucontrol->value.integer.value[0] = aw_dev->cali_desc.cali_re;
++
++	return 0;
++}
++
++static int aw88166_re_set(struct snd_kcontrol *kcontrol,
++				struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
++	struct soc_mixer_control *mc =
++		(struct soc_mixer_control *)kcontrol->private_value;
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	int value;
++
++	value = ucontrol->value.integer.value[0];
++	if (value < mc->min || value > mc->max)
++		return -EINVAL;
++
++	if (aw_dev->cali_desc.cali_re != value) {
++		aw_dev->cali_desc.cali_re = value;
++		return 1;
++	}
++
++	return 0;
++}
++
++static int aw88166_dev_init(struct aw88166 *aw88166, struct aw_container *aw_cfg)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	int ret;
++
++	ret = aw88395_dev_cfg_load(aw_dev, aw_cfg);
++	if (ret) {
++		dev_err(aw_dev->dev, "aw_dev acf parse failed\n");
++		return -EINVAL;
++	}
++	aw_dev->fade_in_time = AW88166_1000_US / 10;
++	aw_dev->fade_out_time = AW88166_1000_US >> 1;
++	aw_dev->prof_cur = aw_dev->prof_info.prof_desc[0].id;
++	aw_dev->prof_index = aw_dev->prof_info.prof_desc[0].id;
++
++	ret = aw88166_dev_fw_update(aw88166, AW88166_FORCE_UPDATE_ON, AW88166_DSP_FW_UPDATE_ON);
++	if (ret) {
++		dev_err(aw_dev->dev, "fw update failed ret = %d\n", ret);
++		return ret;
++	}
++
++	aw88166_dev_mute(aw_dev, true);
++
++	/* close tx feedback */
++	aw_dev_i2s_tx_enable(aw_dev, false);
++	usleep_range(AW88166_1000_US, AW88166_1000_US + 100);
++
++	/* enable amppd */
++	aw_dev_amppd(aw_dev, true);
++
++	/* close dsp */
++	aw_dev_dsp_enable(aw_dev, false);
++	/* set power down */
++	aw_dev_pwd(aw_dev, true);
++
++	return 0;
++}
++
++static int aw88166_request_firmware_file(struct aw88166 *aw88166)
++{
++	const struct firmware *cont = NULL;
++	const char *fw_name;
++	int ret;
++
++	aw88166->aw_pa->fw_status = AW88166_DEV_FW_FAILED;
++
++	if (device_property_read_string(aw88166->aw_pa->dev, "firmware-name", &fw_name) < 0)
++		fw_name = AW88166_ACF_FILE;
++
++	ret = request_firmware(&cont, fw_name, aw88166->aw_pa->dev);
++	if (ret) {
++		dev_err(aw88166->aw_pa->dev, "request [%s] failed!\n", fw_name);
++		return ret;
++	}
++
++	dev_dbg(aw88166->aw_pa->dev, "loaded %s - size: %zu\n",
++			fw_name, cont ? cont->size : 0);
++
++	aw88166->aw_cfg = devm_kzalloc(aw88166->aw_pa->dev,
++			struct_size(aw88166->aw_cfg, data, cont->size), GFP_KERNEL);
++	if (!aw88166->aw_cfg) {
++		release_firmware(cont);
++		return -ENOMEM;
++	}
++	aw88166->aw_cfg->len = (int)cont->size;
++	memcpy(aw88166->aw_cfg->data, cont->data, cont->size);
++	release_firmware(cont);
++
++	ret = aw88395_dev_load_acf_check(aw88166->aw_pa, aw88166->aw_cfg);
++	if (ret) {
++		dev_err(aw88166->aw_pa->dev, "load [%s] failed!\n", fw_name);
++		return ret;
++	}
++
++	mutex_lock(&aw88166->lock);
++	/* aw device init */
++	ret = aw88166_dev_init(aw88166, aw88166->aw_cfg);
++	if (ret)
++		dev_err(aw88166->aw_pa->dev, "dev init failed\n");
++	mutex_unlock(&aw88166->lock);
++
++	return ret;
++}
++
++static const struct snd_kcontrol_new aw88166_controls[] = {
++	SOC_SINGLE_EXT("PCM Playback Volume", AW88166_SYSCTRL2_REG,
++		6, AW88166_MUTE_VOL, 0, aw88166_volume_get,
++		aw88166_volume_set),
++	SOC_SINGLE_EXT("Fade Step", 0, 0, AW88166_MUTE_VOL, 0,
++		aw88166_get_fade_step, aw88166_set_fade_step),
++	SOC_SINGLE_EXT("Volume Ramp Up Step", 0, 0, FADE_TIME_MAX, FADE_TIME_MIN,
++		aw88166_get_fade_in_time, aw88166_set_fade_in_time),
++	SOC_SINGLE_EXT("Volume Ramp Down Step", 0, 0, FADE_TIME_MAX, FADE_TIME_MIN,
++		aw88166_get_fade_out_time, aw88166_set_fade_out_time),
++	SOC_SINGLE_EXT("Calib", 0, 0, AW88166_CALI_RE_MAX, 0,
++		aw88166_re_get, aw88166_re_set),
++	AW88166_PROFILE_EXT("AW88166 Profile Set", aw88166_profile_info,
++		aw88166_profile_get, aw88166_profile_set),
++};
++
++static int aw88166_playback_event(struct snd_soc_dapm_widget *w,
++				struct snd_kcontrol *k, int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(component);
++
++	mutex_lock(&aw88166->lock);
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		aw88166_start(aw88166, AW88166_ASYNC_START);
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		aw88166_stop(aw88166->aw_pa);
++		break;
++	default:
++		break;
++	}
++	mutex_unlock(&aw88166->lock);
++
++	return 0;
++}
++
++static const struct snd_soc_dapm_widget aw88166_dapm_widgets[] = {
++	 /* playback */
++	SND_SOC_DAPM_AIF_IN_E("AIF_RX", "Speaker_Playback", 0, SND_SOC_NOPM, 0, 0,
++					aw88166_playback_event,
++					SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_OUTPUT("DAC Output"),
++
++	/* capture */
++	SND_SOC_DAPM_AIF_OUT("AIF_TX", "Speaker_Capture", 0, SND_SOC_NOPM, 0, 0),
++	SND_SOC_DAPM_INPUT("ADC Input"),
++};
++
++static const struct snd_soc_dapm_route aw88166_audio_map[] = {
++	{"DAC Output", NULL, "AIF_RX"},
++	{"AIF_TX", NULL, "ADC Input"},
++};
++
++static int aw88166_codec_probe(struct snd_soc_component *component)
++{
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(component);
++	int ret;
++
++	INIT_DELAYED_WORK(&aw88166->start_work, aw88166_startup_work);
++
++	ret = aw88166_request_firmware_file(aw88166);
++	if (ret)
++		dev_err(aw88166->aw_pa->dev, "%s failed\n", __func__);
++
++	return ret;
++}
++
++static void aw88166_codec_remove(struct snd_soc_component *aw_codec)
++{
++	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(aw_codec);
++
++	cancel_delayed_work_sync(&aw88166->start_work);
++}
++
++static const struct snd_soc_component_driver soc_codec_dev_aw88166 = {
++	.probe = aw88166_codec_probe,
++	.remove = aw88166_codec_remove,
++	.dapm_widgets = aw88166_dapm_widgets,
++	.num_dapm_widgets = ARRAY_SIZE(aw88166_dapm_widgets),
++	.dapm_routes = aw88166_audio_map,
++	.num_dapm_routes = ARRAY_SIZE(aw88166_audio_map),
++	.controls = aw88166_controls,
++	.num_controls = ARRAY_SIZE(aw88166_controls),
++};
++
++static void aw88166_hw_reset(struct aw88166 *aw88166)
++{
++	if (aw88166->reset_gpio) {
++		gpiod_set_value_cansleep(aw88166->reset_gpio, 1);
++		usleep_range(AW88166_1000_US, AW88166_1000_US + 10);
++		gpiod_set_value_cansleep(aw88166->reset_gpio, 0);
++		usleep_range(AW88166_1000_US, AW88166_1000_US + 10);
++	}
++}
++
++static void aw88166_parse_channel_dt(struct aw88166 *aw88166)
++{
++	struct aw_device *aw_dev = aw88166->aw_pa;
++	struct device_node *np = aw_dev->dev->of_node;
++	u32 channel_value;
++
++	of_property_read_u32(np, "awinic,audio-channel", &channel_value);
++	aw_dev->channel = channel_value;
++	aw88166->phase_sync = of_property_read_bool(np, "awinic,sync-flag");
++}
++
++static int aw88166_init(struct aw88166 *aw88166, struct i2c_client *i2c, struct regmap *regmap)
++{
++	struct aw_device *aw_dev;
++	unsigned int chip_id;
++	int ret;
++
++	ret = regmap_read(regmap, AW88166_ID_REG, &chip_id);
++	if (ret) {
++		dev_err(&i2c->dev, "%s read chipid error. ret = %d\n", __func__, ret);
++		return ret;
++	}
++
++	aw_dev = devm_kzalloc(&i2c->dev, sizeof(*aw_dev), GFP_KERNEL);
++	if (!aw_dev)
++		return -ENOMEM;
++	aw88166->aw_pa = aw_dev;
++
++	aw_dev->i2c = i2c;
++	aw_dev->dev = &i2c->dev;
++	aw_dev->regmap = regmap;
++	mutex_init(&aw_dev->dsp_lock);
++
++	aw_dev->chip_id = chip_id;
++	aw_dev->acf = NULL;
++	aw_dev->prof_info.prof_desc = NULL;
++	aw_dev->prof_info.count = 0;
++	aw_dev->prof_info.prof_type = AW88395_DEV_NONE_TYPE_ID;
++	aw_dev->channel = AW88166_DEV_DEFAULT_CH;
++	aw_dev->fw_status = AW88166_DEV_FW_FAILED;
++
++	aw_dev->fade_step = AW88166_VOLUME_STEP_DB;
++	aw_dev->volume_desc.ctl_volume = AW88166_VOL_DEFAULT_VALUE;
++
++	aw88166_parse_channel_dt(aw88166);
++
++	return 0;
++}
++
++static int aw88166_i2c_probe(struct i2c_client *i2c)
++{
++	struct aw88166 *aw88166;
++	int ret;
++
++	if (!i2c_check_functionality(i2c->adapter, I2C_FUNC_I2C))
++		return dev_err_probe(&i2c->dev, -ENXIO, "check_functionality failed\n");
++
++	aw88166 = devm_kzalloc(&i2c->dev, sizeof(*aw88166), GFP_KERNEL);
++	if (!aw88166)
++		return -ENOMEM;
++
++	mutex_init(&aw88166->lock);
++
++	i2c_set_clientdata(i2c, aw88166);
++
++	aw88166->reset_gpio = devm_gpiod_get_optional(&i2c->dev, "reset", GPIOD_OUT_LOW);
++	if (IS_ERR(aw88166->reset_gpio))
++		return dev_err_probe(&i2c->dev, PTR_ERR(aw88166->reset_gpio),
++							"reset gpio not defined\n");
++	aw88166_hw_reset(aw88166);
++
++	aw88166->regmap = devm_regmap_init_i2c(i2c, &aw88166_remap_config);
++	if (IS_ERR(aw88166->regmap))
++		return dev_err_probe(&i2c->dev, PTR_ERR(aw88166->regmap),
++							"failed to init regmap\n");
++
++	/* aw pa init */
++	ret = aw88166_init(aw88166, i2c, aw88166->regmap);
++	if (ret)
++		return ret;
++
++	return devm_snd_soc_register_component(&i2c->dev,
++			&soc_codec_dev_aw88166,
++			aw88166_dai, ARRAY_SIZE(aw88166_dai));
++}
++
++static const struct i2c_device_id aw88166_i2c_id[] = {
++	{ AW88166_I2C_NAME },
++	{ }
++};
++MODULE_DEVICE_TABLE(i2c, aw88166_i2c_id);
++
++static struct i2c_driver aw88166_i2c_driver = {
++	.driver = {
++		.name = AW88166_I2C_NAME,
++	},
++	.probe = aw88166_i2c_probe,
++	.id_table = aw88166_i2c_id,
++};
++module_i2c_driver(aw88166_i2c_driver);
++
++MODULE_DESCRIPTION("ASoC AW88166 Smart PA Driver");
++MODULE_LICENSE("GPL v2");
+diff --git a/sound/soc/codecs/wcd939x.c.orig b/sound/soc/codecs/wcd939x.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/sound/soc/codecs/wcd939x.c.orig
+@@ -0,0 +1,3622 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) 2018-2021, The Linux Foundation. All rights reserved.
++ * Copyright (c) 2022-2023, Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) 2023, Linaro Limited
++ */
++
++#include <linux/module.h>
++#include <linux/slab.h>
++#include <linux/platform_device.h>
++#include <linux/device.h>
++#include <linux/delay.h>
++#include <linux/gpio/consumer.h>
++#include <linux/kernel.h>
++#include <linux/pm_runtime.h>
++#include <linux/component.h>
++#include <sound/tlv.h>
++#include <linux/of_graph.h>
++#include <linux/of.h>
++#include <sound/jack.h>
++#include <sound/pcm.h>
++#include <sound/pcm_params.h>
++#include <linux/regmap.h>
++#include <sound/soc.h>
++#include <sound/soc-dapm.h>
++#include <linux/regulator/consumer.h>
++#include <linux/usb/typec_mux.h>
++#include <linux/usb/typec_altmode.h>
++
++#include "wcd-clsh-v2.h"
++#include "wcd-common.h"
++#include "wcd-mbhc-v2.h"
++#include "wcd939x.h"
++
++#define WCD939X_MAX_MICBIAS		(4)
++#define WCD939X_MBHC_MAX_BUTTONS	(8)
++#define TX_ADC_MAX			(4)
++#define WCD_MBHC_HS_V_MAX		1600
++
++#define CHIPID_WCD9390			0x0
++#define CHIPID_WCD9395			0x5
++
++/* Version major: 1.x */
++#define CHIPID_WCD939X_VER_MAJOR_1	0x0
++/* Version minor: x.1 */
++#define CHIPID_WCD939X_VER_MINOR_1	0x3
++
++enum {
++	WCD939X_VERSION_1_0 = 0,
++	WCD939X_VERSION_1_1,
++	WCD939X_VERSION_2_0,
++};
++
++#define WCD939X_RATES_MASK (SNDRV_PCM_RATE_8000 | SNDRV_PCM_RATE_16000 |\
++			    SNDRV_PCM_RATE_32000 | SNDRV_PCM_RATE_48000 |\
++			    SNDRV_PCM_RATE_96000 | SNDRV_PCM_RATE_192000 |\
++			    SNDRV_PCM_RATE_384000)
++/* Fractional Rates */
++#define WCD939X_FRAC_RATES_MASK (SNDRV_PCM_RATE_44100 | SNDRV_PCM_RATE_88200 |\
++				 SNDRV_PCM_RATE_176400 | SNDRV_PCM_RATE_352800)
++#define WCD939X_FORMATS (SNDRV_PCM_FMTBIT_S16_LE |\
++			 SNDRV_PCM_FMTBIT_S24_LE |\
++			 SNDRV_PCM_FMTBIT_S24_3LE |\
++			 SNDRV_PCM_FMTBIT_S32_LE)
++
++/* Convert from vout ctl to micbias voltage in mV */
++#define WCD_VOUT_CTL_TO_MICB(v)		(1000 + (v) * 50)
++#define SWR_CLK_RATE_0P6MHZ		(600000)
++#define SWR_CLK_RATE_1P2MHZ		(1200000)
++#define SWR_CLK_RATE_2P4MHZ		(2400000)
++#define SWR_CLK_RATE_4P8MHZ		(4800000)
++#define SWR_CLK_RATE_9P6MHZ		(9600000)
++#define SWR_CLK_RATE_11P2896MHZ		(1128960)
++
++#define ADC_MODE_VAL_HIFI		0x01
++#define ADC_MODE_VAL_LO_HIF		0x02
++#define ADC_MODE_VAL_NORMAL		0x03
++#define ADC_MODE_VAL_LP			0x05
++#define ADC_MODE_VAL_ULP1		0x09
++#define ADC_MODE_VAL_ULP2		0x0B
++
++/* Z value defined in milliohm */
++#define WCD939X_ZDET_VAL_32		(32000)
++#define WCD939X_ZDET_VAL_400		(400000)
++#define WCD939X_ZDET_VAL_1200		(1200000)
++#define WCD939X_ZDET_VAL_100K		(100000000)
++
++/* Z floating defined in ohms */
++#define WCD939X_ZDET_FLOATING_IMPEDANCE	(0x0FFFFFFE)
++#define WCD939X_ZDET_NUM_MEASUREMENTS	(900)
++#define WCD939X_MBHC_GET_C1(c)		(((c) & 0xC000) >> 14)
++#define WCD939X_MBHC_GET_X1(x)		((x) & 0x3FFF)
++
++/* Z value compared in milliOhm */
++#define WCD939X_ANA_MBHC_ZDET_CONST	(1018 * 1024)
++
++enum {
++	/* INTR_CTRL_INT_MASK_0 */
++	WCD939X_IRQ_MBHC_BUTTON_PRESS_DET = 0,
++	WCD939X_IRQ_MBHC_BUTTON_RELEASE_DET,
++	WCD939X_IRQ_MBHC_ELECT_INS_REM_DET,
++	WCD939X_IRQ_MBHC_ELECT_INS_REM_LEG_DET,
++	WCD939X_IRQ_MBHC_SW_DET,
++	WCD939X_IRQ_HPHR_OCP_INT,
++	WCD939X_IRQ_HPHR_CNP_INT,
++	WCD939X_IRQ_HPHL_OCP_INT,
++
++	/* INTR_CTRL_INT_MASK_1 */
++	WCD939X_IRQ_HPHL_CNP_INT,
++	WCD939X_IRQ_EAR_CNP_INT,
++	WCD939X_IRQ_EAR_SCD_INT,
++	WCD939X_IRQ_HPHL_PDM_WD_INT,
++	WCD939X_IRQ_HPHR_PDM_WD_INT,
++	WCD939X_IRQ_EAR_PDM_WD_INT,
++
++	/* INTR_CTRL_INT_MASK_2 */
++	WCD939X_IRQ_MBHC_MOISTURE_INT,
++	WCD939X_IRQ_HPHL_SURGE_DET_INT,
++	WCD939X_IRQ_HPHR_SURGE_DET_INT,
++	WCD939X_NUM_IRQS,
++};
++
++enum {
++	MICB_BIAS_DISABLE = 0,
++	MICB_BIAS_ENABLE,
++	MICB_BIAS_PULL_UP,
++	MICB_BIAS_PULL_DOWN,
++};
++
++enum {
++	WCD_ADC1 = 0,
++	WCD_ADC2,
++	WCD_ADC3,
++	WCD_ADC4,
++	HPH_PA_DELAY,
++};
++
++enum {
++	ADC_MODE_INVALID = 0,
++	ADC_MODE_HIFI,
++	ADC_MODE_LO_HIF,
++	ADC_MODE_NORMAL,
++	ADC_MODE_LP,
++	ADC_MODE_ULP1,
++	ADC_MODE_ULP2,
++};
++
++enum {
++	AIF1_PB = 0,
++	AIF1_CAP,
++	NUM_CODEC_DAIS,
++};
++
++static u8 tx_mode_bit[] = {
++	[ADC_MODE_INVALID] = 0x00,
++	[ADC_MODE_HIFI] = 0x01,
++	[ADC_MODE_LO_HIF] = 0x02,
++	[ADC_MODE_NORMAL] = 0x04,
++	[ADC_MODE_LP] = 0x08,
++	[ADC_MODE_ULP1] = 0x10,
++	[ADC_MODE_ULP2] = 0x20,
++};
++
++struct zdet_param {
++	u16 ldo_ctl;
++	u16 noff;
++	u16 nshift;
++	u16 btn5;
++	u16 btn6;
++	u16 btn7;
++};
++
++struct wcd939x_priv {
++	struct sdw_slave *tx_sdw_dev;
++	struct wcd939x_sdw_priv *sdw_priv[NUM_CODEC_DAIS];
++	struct device *txdev;
++	struct device *rxdev;
++	struct device_node *rxnode, *txnode;
++	struct regmap *regmap;
++	struct snd_soc_component *component;
++	/* micb setup lock */
++	struct mutex micb_lock;
++	/* typec handling */
++	bool typec_analog_mux;
++#if IS_ENABLED(CONFIG_TYPEC)
++	enum typec_orientation typec_orientation;
++	unsigned long typec_mode;
++	struct typec_switch *typec_switch;
++#endif /* CONFIG_TYPEC */
++	/* mbhc module */
++	struct wcd_mbhc *wcd_mbhc;
++	struct wcd_mbhc_config mbhc_cfg;
++	struct wcd_mbhc_intr intr_ids;
++	struct wcd_clsh_ctrl *clsh_info;
++	struct wcd_common common;
++	struct irq_domain *virq;
++	struct regmap_irq_chip_data *irq_chip;
++	struct snd_soc_jack *jack;
++	unsigned long status_mask;
++	s32 micb_ref[WCD939X_MAX_MICBIAS];
++	s32 pullup_ref[WCD939X_MAX_MICBIAS];
++	u32 hph_mode;
++	u32 tx_mode[TX_ADC_MAX];
++	int variant;
++	struct gpio_desc *reset_gpio;
++	int hphr_pdm_wd_int;
++	int hphl_pdm_wd_int;
++	int ear_pdm_wd_int;
++	bool comp1_enable;
++	bool comp2_enable;
++	bool ldoh;
++};
++
++static const char * const wcd939x_supplies[] = {
++	"vdd-rxtx", "vdd-io", "vdd-buck", "vdd-mic-bias", "vdd-px",
++};
++
++static const SNDRV_CTL_TLVD_DECLARE_DB_MINMAX(ear_pa_gain, 600, -1800);
++static const DECLARE_TLV_DB_SCALE(line_gain, 0, 7, 1);
++static const DECLARE_TLV_DB_SCALE(analog_gain, 0, 25, 1);
++
++static const struct wcd_mbhc_field wcd_mbhc_fields[WCD_MBHC_REG_FUNC_MAX] = {
++	WCD_MBHC_FIELD(WCD_MBHC_L_DET_EN, WCD939X_ANA_MBHC_MECH, 0x80),
++	WCD_MBHC_FIELD(WCD_MBHC_GND_DET_EN, WCD939X_ANA_MBHC_MECH, 0x40),
++	WCD_MBHC_FIELD(WCD_MBHC_MECH_DETECTION_TYPE, WCD939X_ANA_MBHC_MECH, 0x20),
++	WCD_MBHC_FIELD(WCD_MBHC_MIC_CLAMP_CTL, WCD939X_MBHC_NEW_PLUG_DETECT_CTL, 0x30),
++	WCD_MBHC_FIELD(WCD_MBHC_ELECT_DETECTION_TYPE, WCD939X_ANA_MBHC_ELECT, 0x08),
++	WCD_MBHC_FIELD(WCD_MBHC_HS_L_DET_PULL_UP_CTRL, WCD939X_MBHC_NEW_INT_MECH_DET_CURRENT, 0x1F),
++	WCD_MBHC_FIELD(WCD_MBHC_HS_L_DET_PULL_UP_COMP_CTRL, WCD939X_ANA_MBHC_MECH, 0x04),
++	WCD_MBHC_FIELD(WCD_MBHC_HPHL_PLUG_TYPE, WCD939X_ANA_MBHC_MECH, 0x10),
++	WCD_MBHC_FIELD(WCD_MBHC_GND_PLUG_TYPE, WCD939X_ANA_MBHC_MECH, 0x08),
++	WCD_MBHC_FIELD(WCD_MBHC_SW_HPH_LP_100K_TO_GND, WCD939X_ANA_MBHC_MECH, 0x01),
++	WCD_MBHC_FIELD(WCD_MBHC_ELECT_SCHMT_ISRC, WCD939X_ANA_MBHC_ELECT, 0x06),
++	WCD_MBHC_FIELD(WCD_MBHC_FSM_EN, WCD939X_ANA_MBHC_ELECT, 0x80),
++	WCD_MBHC_FIELD(WCD_MBHC_INSREM_DBNC, WCD939X_MBHC_NEW_PLUG_DETECT_CTL, 0x0F),
++	WCD_MBHC_FIELD(WCD_MBHC_BTN_DBNC, WCD939X_MBHC_NEW_CTL_1, 0x03),
++	WCD_MBHC_FIELD(WCD_MBHC_HS_VREF, WCD939X_MBHC_NEW_CTL_2, 0x03),
++	WCD_MBHC_FIELD(WCD_MBHC_HS_COMP_RESULT, WCD939X_ANA_MBHC_RESULT_3, 0x08),
++	WCD_MBHC_FIELD(WCD_MBHC_IN2P_CLAMP_STATE, WCD939X_ANA_MBHC_RESULT_3, 0x10),
++	WCD_MBHC_FIELD(WCD_MBHC_MIC_SCHMT_RESULT, WCD939X_ANA_MBHC_RESULT_3, 0x20),
++	WCD_MBHC_FIELD(WCD_MBHC_HPHL_SCHMT_RESULT, WCD939X_ANA_MBHC_RESULT_3, 0x80),
++	WCD_MBHC_FIELD(WCD_MBHC_HPHR_SCHMT_RESULT, WCD939X_ANA_MBHC_RESULT_3, 0x40),
++	WCD_MBHC_FIELD(WCD_MBHC_OCP_FSM_EN, WCD939X_HPH_OCP_CTL, 0x10),
++	WCD_MBHC_FIELD(WCD_MBHC_BTN_RESULT, WCD939X_ANA_MBHC_RESULT_3, 0x07),
++	WCD_MBHC_FIELD(WCD_MBHC_BTN_ISRC_CTL, WCD939X_ANA_MBHC_ELECT, 0x70),
++	WCD_MBHC_FIELD(WCD_MBHC_ELECT_RESULT, WCD939X_ANA_MBHC_RESULT_3, 0xFF),
++	WCD_MBHC_FIELD(WCD_MBHC_MICB_CTRL, WCD939X_ANA_MICB2, 0xC0),
++	WCD_MBHC_FIELD(WCD_MBHC_HPH_CNP_WG_TIME, WCD939X_HPH_CNP_WG_TIME, 0xFF),
++	WCD_MBHC_FIELD(WCD_MBHC_HPHR_PA_EN, WCD939X_ANA_HPH, 0x40),
++	WCD_MBHC_FIELD(WCD_MBHC_HPHL_PA_EN, WCD939X_ANA_HPH, 0x80),
++	WCD_MBHC_FIELD(WCD_MBHC_HPH_PA_EN, WCD939X_ANA_HPH, 0xC0),
++	WCD_MBHC_FIELD(WCD_MBHC_SWCH_LEVEL_REMOVE, WCD939X_ANA_MBHC_RESULT_3, 0x10),
++	WCD_MBHC_FIELD(WCD_MBHC_ANC_DET_EN, WCD939X_MBHC_CTL_BCS, 0x02),
++	WCD_MBHC_FIELD(WCD_MBHC_FSM_STATUS, WCD939X_MBHC_NEW_FSM_STATUS, 0x01),
++	WCD_MBHC_FIELD(WCD_MBHC_MUX_CTL, WCD939X_MBHC_NEW_CTL_2, 0x70),
++	WCD_MBHC_FIELD(WCD_MBHC_MOISTURE_STATUS, WCD939X_MBHC_NEW_FSM_STATUS, 0x20),
++	WCD_MBHC_FIELD(WCD_MBHC_HPHR_GND, WCD939X_HPH_PA_CTL2, 0x40),
++	WCD_MBHC_FIELD(WCD_MBHC_HPHL_GND, WCD939X_HPH_PA_CTL2, 0x10),
++	WCD_MBHC_FIELD(WCD_MBHC_HPHL_OCP_DET_EN, WCD939X_HPH_L_TEST, 0x01),
++	WCD_MBHC_FIELD(WCD_MBHC_HPHR_OCP_DET_EN, WCD939X_HPH_R_TEST, 0x01),
++	WCD_MBHC_FIELD(WCD_MBHC_HPHL_OCP_STATUS, WCD939X_DIGITAL_INTR_STATUS_0, 0x80),
++	WCD_MBHC_FIELD(WCD_MBHC_HPHR_OCP_STATUS, WCD939X_DIGITAL_INTR_STATUS_0, 0x20),
++	WCD_MBHC_FIELD(WCD_MBHC_ADC_EN, WCD939X_MBHC_NEW_CTL_1, 0x08),
++	WCD_MBHC_FIELD(WCD_MBHC_ADC_COMPLETE, WCD939X_MBHC_NEW_FSM_STATUS, 0x40),
++	WCD_MBHC_FIELD(WCD_MBHC_ADC_TIMEOUT, WCD939X_MBHC_NEW_FSM_STATUS, 0x80),
++	WCD_MBHC_FIELD(WCD_MBHC_ADC_RESULT, WCD939X_MBHC_NEW_ADC_RESULT, 0xFF),
++	WCD_MBHC_FIELD(WCD_MBHC_MICB2_VOUT, WCD939X_ANA_MICB2, 0x3F),
++	WCD_MBHC_FIELD(WCD_MBHC_ADC_MODE, WCD939X_MBHC_NEW_CTL_1, 0x10),
++	WCD_MBHC_FIELD(WCD_MBHC_DETECTION_DONE, WCD939X_MBHC_NEW_CTL_1, 0x04),
++	WCD_MBHC_FIELD(WCD_MBHC_ELECT_ISRC_EN, WCD939X_ANA_MBHC_ZDET, 0x02),
++};
++
++static const struct regmap_irq wcd939x_irqs[WCD939X_NUM_IRQS] = {
++	REGMAP_IRQ_REG(WCD939X_IRQ_MBHC_BUTTON_PRESS_DET, 0, 0x01),
++	REGMAP_IRQ_REG(WCD939X_IRQ_MBHC_BUTTON_RELEASE_DET, 0, 0x02),
++	REGMAP_IRQ_REG(WCD939X_IRQ_MBHC_ELECT_INS_REM_DET, 0, 0x04),
++	REGMAP_IRQ_REG(WCD939X_IRQ_MBHC_ELECT_INS_REM_LEG_DET, 0, 0x08),
++	REGMAP_IRQ_REG(WCD939X_IRQ_MBHC_SW_DET, 0, 0x10),
++	REGMAP_IRQ_REG(WCD939X_IRQ_HPHR_OCP_INT, 0, 0x20),
++	REGMAP_IRQ_REG(WCD939X_IRQ_HPHR_CNP_INT, 0, 0x40),
++	REGMAP_IRQ_REG(WCD939X_IRQ_HPHL_OCP_INT, 0, 0x80),
++	REGMAP_IRQ_REG(WCD939X_IRQ_HPHL_CNP_INT, 1, 0x01),
++	REGMAP_IRQ_REG(WCD939X_IRQ_EAR_CNP_INT, 1, 0x02),
++	REGMAP_IRQ_REG(WCD939X_IRQ_EAR_SCD_INT, 1, 0x04),
++	REGMAP_IRQ_REG(WCD939X_IRQ_HPHL_PDM_WD_INT, 1, 0x20),
++	REGMAP_IRQ_REG(WCD939X_IRQ_HPHR_PDM_WD_INT, 1, 0x40),
++	REGMAP_IRQ_REG(WCD939X_IRQ_EAR_PDM_WD_INT, 1, 0x80),
++	REGMAP_IRQ_REG(WCD939X_IRQ_MBHC_MOISTURE_INT, 2, 0x02),
++	REGMAP_IRQ_REG(WCD939X_IRQ_HPHL_SURGE_DET_INT, 2, 0x04),
++	REGMAP_IRQ_REG(WCD939X_IRQ_HPHR_SURGE_DET_INT, 2, 0x08),
++};
++
++static const struct regmap_irq_chip wcd939x_regmap_irq_chip = {
++	.name = "wcd939x",
++	.irqs = wcd939x_irqs,
++	.num_irqs = ARRAY_SIZE(wcd939x_irqs),
++	.num_regs = 3,
++	.status_base = WCD939X_DIGITAL_INTR_STATUS_0,
++	.mask_base = WCD939X_DIGITAL_INTR_MASK_0,
++	.ack_base = WCD939X_DIGITAL_INTR_CLEAR_0,
++	.use_ack = 1,
++	.runtime_pm = true,
++	.irq_drv_data = NULL,
++};
++
++static int wcd939x_get_clk_rate(int mode)
++{
++	int rate;
++
++	switch (mode) {
++	case ADC_MODE_ULP2:
++		rate = SWR_CLK_RATE_0P6MHZ;
++		break;
++	case ADC_MODE_ULP1:
++		rate = SWR_CLK_RATE_1P2MHZ;
++		break;
++	case ADC_MODE_LP:
++		rate = SWR_CLK_RATE_4P8MHZ;
++		break;
++	case ADC_MODE_NORMAL:
++	case ADC_MODE_LO_HIF:
++	case ADC_MODE_HIFI:
++	case ADC_MODE_INVALID:
++	default:
++		rate = SWR_CLK_RATE_9P6MHZ;
++		break;
++	}
++
++	return rate;
++}
++
++static int wcd939x_set_swr_clk_rate(struct snd_soc_component *component, int rate, int bank)
++{
++	u8 mask = (bank ? 0xF0 : 0x0F);
++	u8 val = 0;
++
++	switch (rate) {
++	case SWR_CLK_RATE_0P6MHZ:
++		val = 6;
++		break;
++	case SWR_CLK_RATE_1P2MHZ:
++		val = 5;
++		break;
++	case SWR_CLK_RATE_2P4MHZ:
++		val = 3;
++		break;
++	case SWR_CLK_RATE_4P8MHZ:
++		val = 1;
++		break;
++	case SWR_CLK_RATE_9P6MHZ:
++	default:
++		val = 0;
++		break;
++	}
++
++	snd_soc_component_write_field(component, WCD939X_DIGITAL_SWR_TX_CLK_RATE, mask, val);
++
++	return 0;
++}
++
++static int wcd939x_io_init(struct snd_soc_component *component)
++{
++	snd_soc_component_write_field(component, WCD939X_ANA_BIAS,
++				      WCD939X_BIAS_ANALOG_BIAS_EN, true);
++	snd_soc_component_write_field(component, WCD939X_ANA_BIAS,
++				      WCD939X_BIAS_PRECHRG_EN, true);
++
++	/* 10 msec delay as per HW requirement */
++	usleep_range(10000, 10010);
++	snd_soc_component_write_field(component, WCD939X_ANA_BIAS,
++				      WCD939X_BIAS_PRECHRG_EN, false);
++
++	snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_L,
++				      WCD939X_RDAC_HD2_CTL_L_HD2_RES_DIV_CTL_L, 0x15);
++	snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_R,
++				      WCD939X_RDAC_HD2_CTL_R_HD2_RES_DIV_CTL_R, 0x15);
++	snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_DMIC_CTL,
++				      WCD939X_CDC_DMIC_CTL_CLK_SCALE_EN, true);
++
++	snd_soc_component_write_field(component, WCD939X_TX_COM_NEW_INT_FE_ICTRL_STG2CASC_ULP,
++				      WCD939X_FE_ICTRL_STG2CASC_ULP_ICTRL_SCBIAS_ULP0P6M, 1);
++	snd_soc_component_write_field(component, WCD939X_TX_COM_NEW_INT_FE_ICTRL_STG2CASC_ULP,
++				      WCD939X_FE_ICTRL_STG2CASC_ULP_VALUE, 4);
++
++	snd_soc_component_write_field(component, WCD939X_TX_COM_NEW_INT_FE_ICTRL_STG2MAIN_ULP,
++				      WCD939X_FE_ICTRL_STG2MAIN_ULP_VALUE, 8);
++
++	snd_soc_component_write_field(component, WCD939X_MICB1_TEST_CTL_1,
++				      WCD939X_TEST_CTL_1_NOISE_FILT_RES_VAL, 7);
++	snd_soc_component_write_field(component, WCD939X_MICB2_TEST_CTL_1,
++				      WCD939X_TEST_CTL_1_NOISE_FILT_RES_VAL, 7);
++	snd_soc_component_write_field(component, WCD939X_MICB3_TEST_CTL_1,
++				      WCD939X_TEST_CTL_1_NOISE_FILT_RES_VAL, 7);
++	snd_soc_component_write_field(component, WCD939X_MICB4_TEST_CTL_1,
++				      WCD939X_TEST_CTL_1_NOISE_FILT_RES_VAL, 7);
++	snd_soc_component_write_field(component, WCD939X_TX_3_4_TEST_BLK_EN2,
++				      WCD939X_TEST_BLK_EN2_TXFE2_MBHC_CLKRST_EN, false);
++
++	snd_soc_component_write_field(component, WCD939X_HPH_SURGE_EN,
++				      WCD939X_EN_EN_SURGE_PROTECTION_HPHL, false);
++	snd_soc_component_write_field(component, WCD939X_HPH_SURGE_EN,
++				      WCD939X_EN_EN_SURGE_PROTECTION_HPHR, false);
++
++	snd_soc_component_write_field(component, WCD939X_HPH_OCP_CTL,
++				      WCD939X_OCP_CTL_OCP_FSM_EN, true);
++	snd_soc_component_write_field(component, WCD939X_HPH_OCP_CTL,
++				      WCD939X_OCP_CTL_SCD_OP_EN, true);
++
++	snd_soc_component_write(component, WCD939X_E_CFG0,
++				WCD939X_CFG0_IDLE_STEREO |
++				WCD939X_CFG0_AUTO_DISABLE_ANC);
++
++	return 0;
++}
++
++static int wcd939x_sdw_connect_port(const struct wcd_sdw_ch_info *ch_info,
++				    struct sdw_port_config *port_config,
++				    u8 enable)
++{
++	u8 ch_mask, port_num;
++
++	port_num = ch_info->port_num;
++	ch_mask = ch_info->ch_mask;
++
++	port_config->num = port_num;
++
++	if (enable)
++		port_config->ch_mask |= ch_mask;
++	else
++		port_config->ch_mask &= ~ch_mask;
++
++	return 0;
++}
++
++static int wcd939x_connect_port(struct wcd939x_sdw_priv *wcd, u8 port_num, u8 ch_id, u8 enable)
++{
++	return wcd939x_sdw_connect_port(&wcd->ch_info[ch_id],
++					&wcd->port_config[port_num - 1],
++					enable);
++}
++
++static int wcd939x_codec_enable_rxclk(struct snd_soc_dapm_widget *w,
++				      struct snd_kcontrol *kcontrol,
++				      int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		snd_soc_component_write_field(component, WCD939X_ANA_RX_SUPPLIES,
++					      WCD939X_RX_SUPPLIES_RX_BIAS_ENABLE, true);
++
++		/* Analog path clock controls */
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_ANA_CLK_CTL,
++					      WCD939X_CDC_ANA_CLK_CTL_ANA_RX_CLK_EN, true);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_ANA_CLK_CTL,
++					      WCD939X_CDC_ANA_CLK_CTL_ANA_RX_DIV2_CLK_EN,
++					      true);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_ANA_CLK_CTL,
++					      WCD939X_CDC_ANA_CLK_CTL_ANA_RX_DIV4_CLK_EN,
++					      true);
++
++		/* Digital path clock controls */
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++					      WCD939X_CDC_DIG_CLK_CTL_RXD0_CLK_EN, true);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++					      WCD939X_CDC_DIG_CLK_CTL_RXD1_CLK_EN, true);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++					      WCD939X_CDC_DIG_CLK_CTL_RXD2_CLK_EN, true);
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		snd_soc_component_write_field(component, WCD939X_ANA_RX_SUPPLIES,
++					      WCD939X_RX_SUPPLIES_VNEG_EN, false);
++		snd_soc_component_write_field(component, WCD939X_ANA_RX_SUPPLIES,
++					      WCD939X_RX_SUPPLIES_VPOS_EN, false);
++
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++					      WCD939X_CDC_DIG_CLK_CTL_RXD2_CLK_EN, false);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++					      WCD939X_CDC_DIG_CLK_CTL_RXD1_CLK_EN, false);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++					      WCD939X_CDC_DIG_CLK_CTL_RXD0_CLK_EN, false);
++
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_ANA_CLK_CTL,
++					      WCD939X_CDC_ANA_CLK_CTL_ANA_RX_DIV4_CLK_EN,
++					      false);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_ANA_CLK_CTL,
++					      WCD939X_CDC_ANA_CLK_CTL_ANA_RX_DIV2_CLK_EN,
++					      false);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_ANA_CLK_CTL,
++					      WCD939X_CDC_ANA_CLK_CTL_ANA_RX_CLK_EN, false);
++
++		snd_soc_component_write_field(component, WCD939X_ANA_RX_SUPPLIES,
++					      WCD939X_RX_SUPPLIES_RX_BIAS_ENABLE, false);
++
++		break;
++	}
++
++	return 0;
++}
++
++static int wcd939x_codec_hphl_dac_event(struct snd_soc_dapm_widget *w,
++					struct snd_kcontrol *kcontrol,
++					int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		snd_soc_component_write_field(component, WCD939X_HPH_RDAC_CLK_CTL1,
++					      WCD939X_RDAC_CLK_CTL1_OPAMP_CHOP_CLK_EN,
++					      false);
++
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
++					      WCD939X_CDC_HPH_GAIN_CTL_HPHL_RX_EN, true);
++		break;
++	case SND_SOC_DAPM_POST_PMU:
++		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_L,
++					      WCD939X_RDAC_HD2_CTL_L_HD2_RES_DIV_CTL_L, 0x1d);
++		if (wcd939x->comp1_enable) {
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_COMP_CTL_0,
++						      WCD939X_CDC_COMP_CTL_0_HPHL_COMP_EN,
++						      true);
++			/* 5msec compander delay as per HW requirement */
++			if (!wcd939x->comp2_enable ||
++			    snd_soc_component_read_field(component,
++							 WCD939X_DIGITAL_CDC_COMP_CTL_0,
++							 WCD939X_CDC_COMP_CTL_0_HPHR_COMP_EN))
++				usleep_range(5000, 5010);
++
++			snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_TIMER1,
++						      WCD939X_TIMER1_AUTOCHOP_TIMER_CTL_EN,
++						      false);
++		} else {
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_COMP_CTL_0,
++						      WCD939X_CDC_COMP_CTL_0_HPHL_COMP_EN,
++						      false);
++			snd_soc_component_write_field(component, WCD939X_HPH_L_EN,
++						      WCD939X_L_EN_GAIN_SOURCE_SEL, true);
++		}
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_L,
++					      WCD939X_RDAC_HD2_CTL_L_HD2_RES_DIV_CTL_L, 1);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
++					      WCD939X_CDC_HPH_GAIN_CTL_HPHL_RX_EN, false);
++		break;
++	}
++
++	return 0;
++}
++
++static int wcd939x_codec_hphr_dac_event(struct snd_soc_dapm_widget *w,
++					struct snd_kcontrol *kcontrol,
++					int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	dev_dbg(component->dev, "%s wname: %s event: %d\n", __func__,
++		w->name, event);
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		snd_soc_component_write_field(component, WCD939X_HPH_RDAC_CLK_CTL1,
++					      WCD939X_RDAC_CLK_CTL1_OPAMP_CHOP_CLK_EN,
++					      false);
++
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
++					      WCD939X_CDC_HPH_GAIN_CTL_HPHR_RX_EN, true);
++		break;
++	case SND_SOC_DAPM_POST_PMU:
++		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_R,
++					      WCD939X_RDAC_HD2_CTL_R_HD2_RES_DIV_CTL_R, 0x1d);
++		if (wcd939x->comp2_enable) {
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_COMP_CTL_0,
++						      WCD939X_CDC_COMP_CTL_0_HPHR_COMP_EN,
++						      true);
++			/* 5msec compander delay as per HW requirement */
++			if (!wcd939x->comp1_enable ||
++			    snd_soc_component_read_field(component,
++							 WCD939X_DIGITAL_CDC_COMP_CTL_0,
++							 WCD939X_CDC_COMP_CTL_0_HPHL_COMP_EN))
++				usleep_range(5000, 5010);
++			snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_TIMER1,
++						      WCD939X_TIMER1_AUTOCHOP_TIMER_CTL_EN,
++						      false);
++		} else {
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_COMP_CTL_0,
++						      WCD939X_CDC_COMP_CTL_0_HPHR_COMP_EN,
++						      false);
++			snd_soc_component_write_field(component, WCD939X_HPH_R_EN,
++						      WCD939X_R_EN_GAIN_SOURCE_SEL, true);
++		}
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_RDAC_HD2_CTL_R,
++					      WCD939X_RDAC_HD2_CTL_R_HD2_RES_DIV_CTL_R, 1);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_HPH_GAIN_CTL,
++					      WCD939X_CDC_HPH_GAIN_CTL_HPHR_RX_EN, false);
++		break;
++	}
++
++	return 0;
++}
++
++static int wcd939x_codec_ear_dac_event(struct snd_soc_dapm_widget *w,
++				       struct snd_kcontrol *kcontrol,
++				       int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_EAR_GAIN_CTL,
++					      WCD939X_CDC_EAR_GAIN_CTL_EAR_EN, true);
++
++		snd_soc_component_write_field(component, WCD939X_EAR_DAC_CON,
++					      WCD939X_DAC_CON_DAC_SAMPLE_EDGE_SEL, false);
++
++		/* 5 msec delay as per HW requirement */
++		usleep_range(5000, 5010);
++		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_PRE_DAC,
++					WCD_CLSH_STATE_EAR, CLS_AB_HIFI);
++
++		snd_soc_component_write_field(component, WCD939X_FLYBACK_VNEG_CTRL_4,
++					      WCD939X_VNEG_CTRL_4_ILIM_SEL, 0xd);
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		snd_soc_component_write_field(component, WCD939X_EAR_DAC_CON,
++					      WCD939X_DAC_CON_DAC_SAMPLE_EDGE_SEL, true);
++		break;
++	}
++
++	return 0;
++}
++
++static int wcd939x_codec_enable_hphr_pa(struct snd_soc_dapm_widget *w,
++					struct snd_kcontrol *kcontrol,
++					int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	int hph_mode = wcd939x->hph_mode;
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		if (wcd939x->ldoh)
++			snd_soc_component_write_field(component, WCD939X_LDOH_MODE,
++						      WCD939X_MODE_LDOH_EN, true);
++
++		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_PRE_DAC,
++					WCD_CLSH_STATE_HPHR, hph_mode);
++		wcd_clsh_set_hph_mode(wcd939x->clsh_info, CLS_H_HIFI);
++
++		if (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI || hph_mode == CLS_H_ULP)
++			snd_soc_component_write_field(component,
++					WCD939X_HPH_REFBUFF_LP_CTL,
++					WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS, true);
++		if (hph_mode == CLS_H_LOHIFI)
++			snd_soc_component_write_field(component, WCD939X_ANA_HPH,
++						       WCD939X_HPH_PWR_LEVEL, 0);
++
++		snd_soc_component_write_field(component, WCD939X_FLYBACK_VNEG_CTRL_4,
++					      WCD939X_VNEG_CTRL_4_ILIM_SEL, 0xd);
++		snd_soc_component_write_field(component, WCD939X_ANA_HPH,
++					      WCD939X_HPH_HPHR_REF_ENABLE, true);
++
++		if (snd_soc_component_read_field(component, WCD939X_ANA_HPH,
++						 WCD939X_HPH_HPHL_REF_ENABLE))
++			usleep_range(2500, 2600); /* 2.5msec delay as per HW requirement */
++
++		set_bit(HPH_PA_DELAY, &wcd939x->status_mask);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL1,
++					      WCD939X_PDM_WD_CTL1_PDM_WD_EN, 3);
++		break;
++	case SND_SOC_DAPM_POST_PMU:
++		/*
++		 * 7ms sleep is required if compander is enabled as per
++		 * HW requirement. If compander is disabled, then
++		 * 20ms delay is required.
++		 */
++		if (test_bit(HPH_PA_DELAY, &wcd939x->status_mask)) {
++			if (!wcd939x->comp2_enable)
++				usleep_range(20000, 20100);
++			else
++				usleep_range(7000, 7100);
++
++			if (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI ||
++			    hph_mode == CLS_H_ULP)
++				snd_soc_component_write_field(component,
++						WCD939X_HPH_REFBUFF_LP_CTL,
++						WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS,
++						false);
++			clear_bit(HPH_PA_DELAY, &wcd939x->status_mask);
++		}
++		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_TIMER1,
++					      WCD939X_TIMER1_AUTOCHOP_TIMER_CTL_EN, true);
++		if (hph_mode == CLS_AB || hph_mode == CLS_AB_HIFI ||
++		    hph_mode == CLS_AB_LP || hph_mode == CLS_AB_LOHIFI)
++			snd_soc_component_write_field(component, WCD939X_ANA_RX_SUPPLIES,
++						      WCD939X_RX_SUPPLIES_REGULATOR_MODE,
++						      true);
++
++		enable_irq(wcd939x->hphr_pdm_wd_int);
++		break;
++	case SND_SOC_DAPM_PRE_PMD:
++		disable_irq_nosync(wcd939x->hphr_pdm_wd_int);
++		/*
++		 * 7ms sleep is required if compander is enabled as per
++		 * HW requirement. If compander is disabled, then
++		 * 20ms delay is required.
++		 */
++		if (!wcd939x->comp2_enable)
++			usleep_range(20000, 20100);
++		else
++			usleep_range(7000, 7100);
++
++		snd_soc_component_write_field(component, WCD939X_ANA_HPH,
++					      WCD939X_HPH_HPHR_ENABLE, false);
++
++		wcd_mbhc_event_notify(wcd939x->wcd_mbhc,
++				      WCD_EVENT_PRE_HPHR_PA_OFF);
++		set_bit(HPH_PA_DELAY, &wcd939x->status_mask);
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		/*
++		 * 7ms sleep is required if compander is enabled as per
++		 * HW requirement. If compander is disabled, then
++		 * 20ms delay is required.
++		 */
++		if (test_bit(HPH_PA_DELAY, &wcd939x->status_mask)) {
++			if (!wcd939x->comp2_enable)
++				usleep_range(20000, 20100);
++			else
++				usleep_range(7000, 7100);
++			clear_bit(HPH_PA_DELAY, &wcd939x->status_mask);
++		}
++		wcd_mbhc_event_notify(wcd939x->wcd_mbhc,
++				      WCD_EVENT_POST_HPHR_PA_OFF);
++
++		snd_soc_component_write_field(component, WCD939X_ANA_HPH,
++					      WCD939X_HPH_HPHR_REF_ENABLE, false);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL1,
++					      WCD939X_PDM_WD_CTL1_PDM_WD_EN, 0);
++
++		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_POST_PA,
++					WCD_CLSH_STATE_HPHR, hph_mode);
++		if (wcd939x->ldoh)
++			snd_soc_component_write_field(component, WCD939X_LDOH_MODE,
++						      WCD939X_MODE_LDOH_EN, false);
++		break;
++	}
++
++	return 0;
++}
++
++static int wcd939x_codec_enable_hphl_pa(struct snd_soc_dapm_widget *w,
++					struct snd_kcontrol *kcontrol,
++					int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	int hph_mode = wcd939x->hph_mode;
++
++	dev_dbg(component->dev, "%s wname: %s event: %d\n", __func__,
++		w->name, event);
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		if (wcd939x->ldoh)
++			snd_soc_component_write_field(component, WCD939X_LDOH_MODE,
++						      WCD939X_MODE_LDOH_EN, true);
++		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_PRE_DAC,
++					WCD_CLSH_STATE_HPHL, hph_mode);
++		wcd_clsh_set_hph_mode(wcd939x->clsh_info, CLS_H_HIFI);
++
++		if (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI || hph_mode == CLS_H_ULP)
++			snd_soc_component_write_field(component,
++						WCD939X_HPH_REFBUFF_LP_CTL,
++						WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS,
++						true);
++		if (hph_mode == CLS_H_LOHIFI)
++			snd_soc_component_write_field(component, WCD939X_ANA_HPH,
++						       WCD939X_HPH_PWR_LEVEL, 0);
++
++		snd_soc_component_write_field(component, WCD939X_FLYBACK_VNEG_CTRL_4,
++					      WCD939X_VNEG_CTRL_4_ILIM_SEL, 0xd);
++		snd_soc_component_write_field(component, WCD939X_ANA_HPH,
++					      WCD939X_HPH_HPHL_REF_ENABLE, true);
++
++		if (snd_soc_component_read_field(component, WCD939X_ANA_HPH,
++						 WCD939X_HPH_HPHR_REF_ENABLE))
++			usleep_range(2500, 2600); /* 2.5msec delay as per HW requirement */
++
++		set_bit(HPH_PA_DELAY, &wcd939x->status_mask);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL0,
++					      WCD939X_PDM_WD_CTL0_PDM_WD_EN, 3);
++		break;
++	case SND_SOC_DAPM_POST_PMU:
++		/*
++		 * 7ms sleep is required if compander is enabled as per
++		 * HW requirement. If compander is disabled, then
++		 * 20ms delay is required.
++		 */
++		if (test_bit(HPH_PA_DELAY, &wcd939x->status_mask)) {
++			if (!wcd939x->comp1_enable)
++				usleep_range(20000, 20100);
++			else
++				usleep_range(7000, 7100);
++			if (hph_mode == CLS_H_LP || hph_mode == CLS_H_LOHIFI ||
++			    hph_mode == CLS_H_ULP)
++				snd_soc_component_write_field(component,
++						WCD939X_HPH_REFBUFF_LP_CTL,
++						WCD939X_REFBUFF_LP_CTL_PREREF_FILT_BYPASS,
++						false);
++			clear_bit(HPH_PA_DELAY, &wcd939x->status_mask);
++		}
++		snd_soc_component_write_field(component, WCD939X_HPH_NEW_INT_TIMER1,
++					      WCD939X_TIMER1_AUTOCHOP_TIMER_CTL_EN, true);
++		if (hph_mode == CLS_AB || hph_mode == CLS_AB_HIFI ||
++		    hph_mode == CLS_AB_LP || hph_mode == CLS_AB_LOHIFI)
++			snd_soc_component_write_field(component, WCD939X_ANA_RX_SUPPLIES,
++						      WCD939X_RX_SUPPLIES_REGULATOR_MODE,
++						      true);
++		enable_irq(wcd939x->hphl_pdm_wd_int);
++		break;
++	case SND_SOC_DAPM_PRE_PMD:
++		disable_irq_nosync(wcd939x->hphl_pdm_wd_int);
++		/*
++		 * 7ms sleep is required if compander is enabled as per
++		 * HW requirement. If compander is disabled, then
++		 * 20ms delay is required.
++		 */
++		if (!wcd939x->comp1_enable)
++			usleep_range(20000, 20100);
++		else
++			usleep_range(7000, 7100);
++
++		snd_soc_component_write_field(component, WCD939X_ANA_HPH,
++					      WCD939X_HPH_HPHL_ENABLE, false);
++
++		wcd_mbhc_event_notify(wcd939x->wcd_mbhc, WCD_EVENT_PRE_HPHL_PA_OFF);
++		set_bit(HPH_PA_DELAY, &wcd939x->status_mask);
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		/*
++		 * 7ms sleep is required if compander is enabled as per
++		 * HW requirement. If compander is disabled, then
++		 * 20ms delay is required.
++		 */
++		if (test_bit(HPH_PA_DELAY, &wcd939x->status_mask)) {
++			if (!wcd939x->comp1_enable)
++				usleep_range(21000, 21100);
++			else
++				usleep_range(7000, 7100);
++			clear_bit(HPH_PA_DELAY, &wcd939x->status_mask);
++		}
++		wcd_mbhc_event_notify(wcd939x->wcd_mbhc,
++				      WCD_EVENT_POST_HPHL_PA_OFF);
++		snd_soc_component_write_field(component, WCD939X_ANA_HPH,
++					      WCD939X_HPH_HPHL_REF_ENABLE, false);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL0,
++					      WCD939X_PDM_WD_CTL0_PDM_WD_EN, 0);
++		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_POST_PA,
++					WCD_CLSH_STATE_HPHL, hph_mode);
++		if (wcd939x->ldoh)
++			snd_soc_component_write_field(component, WCD939X_LDOH_MODE,
++						      WCD939X_MODE_LDOH_EN, false);
++		break;
++	}
++
++	return 0;
++}
++
++static int wcd939x_codec_enable_ear_pa(struct snd_soc_dapm_widget *w,
++				       struct snd_kcontrol *kcontrol, int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		/* Enable watchdog interrupt for HPHL */
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL0,
++					      WCD939X_PDM_WD_CTL0_PDM_WD_EN, 3);
++		/* For EAR, use CLASS_AB regulator mode */
++		snd_soc_component_write_field(component, WCD939X_ANA_RX_SUPPLIES,
++					      WCD939X_RX_SUPPLIES_REGULATOR_MODE, true);
++		snd_soc_component_write_field(component, WCD939X_ANA_EAR_COMPANDER_CTL,
++					      WCD939X_EAR_COMPANDER_CTL_GAIN_OVRD_REG, true);
++		break;
++	case SND_SOC_DAPM_POST_PMU:
++		/* 6 msec delay as per HW requirement */
++		usleep_range(6000, 6010);
++		enable_irq(wcd939x->ear_pdm_wd_int);
++		break;
++	case SND_SOC_DAPM_PRE_PMD:
++		disable_irq_nosync(wcd939x->ear_pdm_wd_int);
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		snd_soc_component_write_field(component, WCD939X_ANA_EAR_COMPANDER_CTL,
++					      WCD939X_EAR_COMPANDER_CTL_GAIN_OVRD_REG,
++					      false);
++		/* 7 msec delay as per HW requirement */
++		usleep_range(7000, 7010);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_PDM_WD_CTL0,
++					      WCD939X_PDM_WD_CTL0_PDM_WD_EN, 0);
++		wcd_clsh_ctrl_set_state(wcd939x->clsh_info, WCD_CLSH_EVENT_POST_PA,
++					WCD_CLSH_STATE_EAR, CLS_AB_HIFI);
++		break;
++	}
++
++	return 0;
++}
++
++/* TX Controls */
++
++static int wcd939x_codec_enable_dmic(struct snd_soc_dapm_widget *w,
++				     struct snd_kcontrol *kcontrol,
++				     int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	u16 dmic_clk_reg, dmic_clk_en_reg;
++	u8 dmic_clk_en_mask;
++	u8 dmic_ctl_mask;
++	u8 dmic_clk_mask;
++
++	switch (w->shift) {
++	case 0:
++	case 1:
++		dmic_clk_reg = WCD939X_DIGITAL_CDC_DMIC_RATE_1_2;
++		dmic_clk_en_reg = WCD939X_DIGITAL_CDC_DMIC1_CTL;
++		dmic_clk_en_mask = WCD939X_CDC_DMIC1_CTL_DMIC_CLK_EN;
++		dmic_clk_mask = WCD939X_CDC_DMIC_RATE_1_2_DMIC1_RATE;
++		dmic_ctl_mask = WCD939X_CDC_AMIC_CTL_AMIC1_IN_SEL;
++		break;
++	case 2:
++	case 3:
++		dmic_clk_reg = WCD939X_DIGITAL_CDC_DMIC_RATE_1_2;
++		dmic_clk_en_reg = WCD939X_DIGITAL_CDC_DMIC2_CTL;
++		dmic_clk_en_mask = WCD939X_CDC_DMIC2_CTL_DMIC_CLK_EN;
++		dmic_clk_mask = WCD939X_CDC_DMIC_RATE_1_2_DMIC2_RATE;
++		dmic_ctl_mask = WCD939X_CDC_AMIC_CTL_AMIC3_IN_SEL;
++		break;
++	case 4:
++	case 5:
++		dmic_clk_reg = WCD939X_DIGITAL_CDC_DMIC_RATE_3_4;
++		dmic_clk_en_reg = WCD939X_DIGITAL_CDC_DMIC3_CTL;
++		dmic_clk_en_mask = WCD939X_CDC_DMIC3_CTL_DMIC_CLK_EN;
++		dmic_clk_mask = WCD939X_CDC_DMIC_RATE_3_4_DMIC3_RATE;
++		dmic_ctl_mask = WCD939X_CDC_AMIC_CTL_AMIC4_IN_SEL;
++		break;
++	case 6:
++	case 7:
++		dmic_clk_reg = WCD939X_DIGITAL_CDC_DMIC_RATE_3_4;
++		dmic_clk_en_reg = WCD939X_DIGITAL_CDC_DMIC4_CTL;
++		dmic_clk_en_mask = WCD939X_CDC_DMIC4_CTL_DMIC_CLK_EN;
++		dmic_clk_mask = WCD939X_CDC_DMIC_RATE_3_4_DMIC4_RATE;
++		dmic_ctl_mask = WCD939X_CDC_AMIC_CTL_AMIC5_IN_SEL;
++		break;
++	default:
++		dev_err(component->dev, "%s: Invalid DMIC Selection\n", __func__);
++		return -EINVAL;
++	}
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_AMIC_CTL,
++					      dmic_ctl_mask, false);
++		/* 250us sleep as per HW requirement */
++		usleep_range(250, 260);
++		if (w->shift == 2)
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_DMIC2_CTL,
++						      WCD939X_CDC_DMIC2_CTL_DMIC_LEFT_EN,
++						      true);
++		/* Setting DMIC clock rate to 2.4MHz */
++		snd_soc_component_write_field(component, dmic_clk_reg,
++					      dmic_clk_mask, 3);
++		snd_soc_component_write_field(component, dmic_clk_en_reg,
++					      dmic_clk_en_mask, true);
++		/* enable clock scaling */
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_DMIC_CTL,
++					      WCD939X_CDC_DMIC_CTL_CLK_SCALE_EN, true);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_DMIC_CTL,
++					      WCD939X_CDC_DMIC_CTL_DMIC_DIV_BAK_EN, true);
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_AMIC_CTL,
++					      dmic_ctl_mask, 1);
++		if (w->shift == 2)
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_DMIC2_CTL,
++						      WCD939X_CDC_DMIC2_CTL_DMIC_LEFT_EN,
++						      false);
++		snd_soc_component_write_field(component, dmic_clk_en_reg,
++					      dmic_clk_en_mask, 0);
++		break;
++	}
++	return 0;
++}
++
++static int wcd939x_tx_swr_ctrl(struct snd_soc_dapm_widget *w,
++			       struct snd_kcontrol *kcontrol, int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	int bank;
++	int rate;
++
++	bank = sdw_slave_get_current_bank(wcd939x->sdw_priv[AIF1_CAP]->sdev);
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		if (strnstr(w->name, "ADC", sizeof("ADC"))) {
++			int mode = 0;
++
++			if (test_bit(WCD_ADC1, &wcd939x->status_mask))
++				mode |= tx_mode_bit[wcd939x->tx_mode[WCD_ADC1]];
++			if (test_bit(WCD_ADC2, &wcd939x->status_mask))
++				mode |= tx_mode_bit[wcd939x->tx_mode[WCD_ADC2]];
++			if (test_bit(WCD_ADC3, &wcd939x->status_mask))
++				mode |= tx_mode_bit[wcd939x->tx_mode[WCD_ADC3]];
++			if (test_bit(WCD_ADC4, &wcd939x->status_mask))
++				mode |= tx_mode_bit[wcd939x->tx_mode[WCD_ADC4]];
++
++			if (mode)
++				rate = wcd939x_get_clk_rate(ffs(mode) - 1);
++			else
++				rate = wcd939x_get_clk_rate(ADC_MODE_INVALID);
++			wcd939x_set_swr_clk_rate(component, rate, bank);
++			wcd939x_set_swr_clk_rate(component, rate, !bank);
++		}
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		if (strnstr(w->name, "ADC", sizeof("ADC"))) {
++			rate = wcd939x_get_clk_rate(ADC_MODE_INVALID);
++			wcd939x_set_swr_clk_rate(component, rate, !bank);
++			wcd939x_set_swr_clk_rate(component, rate, bank);
++		}
++		break;
++	}
++
++	return 0;
++}
++
++static int wcd939x_get_adc_mode(int val)
++{
++	int ret = 0;
++
++	switch (val) {
++	case ADC_MODE_INVALID:
++		ret = ADC_MODE_VAL_NORMAL;
++		break;
++	case ADC_MODE_HIFI:
++		ret = ADC_MODE_VAL_HIFI;
++		break;
++	case ADC_MODE_LO_HIF:
++		ret = ADC_MODE_VAL_LO_HIF;
++		break;
++	case ADC_MODE_NORMAL:
++		ret = ADC_MODE_VAL_NORMAL;
++		break;
++	case ADC_MODE_LP:
++		ret = ADC_MODE_VAL_LP;
++		break;
++	case ADC_MODE_ULP1:
++		ret = ADC_MODE_VAL_ULP1;
++		break;
++	case ADC_MODE_ULP2:
++		ret = ADC_MODE_VAL_ULP2;
++		break;
++	default:
++		ret = -EINVAL;
++		break;
++	}
++	return ret;
++}
++
++static int wcd939x_codec_enable_adc(struct snd_soc_dapm_widget *w,
++				    struct snd_kcontrol *kcontrol, int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_ANA_CLK_CTL,
++					      WCD939X_CDC_ANA_CLK_CTL_ANA_TX_CLK_EN, true);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_ANA_CLK_CTL,
++					      WCD939X_CDC_ANA_CLK_CTL_ANA_TX_DIV2_CLK_EN,
++					      true);
++		set_bit(w->shift, &wcd939x->status_mask);
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_ANA_CLK_CTL,
++					      WCD939X_CDC_ANA_CLK_CTL_ANA_TX_DIV2_CLK_EN,
++					      false);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_ANA_CLK_CTL,
++					      WCD939X_CDC_ANA_CLK_CTL_ANA_TX_CLK_EN,
++					      false);
++		clear_bit(w->shift, &wcd939x->status_mask);
++		break;
++	}
++
++	return 0;
++}
++
++static void wcd939x_tx_channel_config(struct snd_soc_component *component,
++				      int channel, bool init)
++{
++	int reg, mask;
++
++	switch (channel) {
++	case 0:
++		reg = WCD939X_ANA_TX_CH2;
++		mask = WCD939X_TX_CH2_HPF1_INIT;
++		break;
++	case 1:
++		reg = WCD939X_ANA_TX_CH2;
++		mask = WCD939X_TX_CH2_HPF2_INIT;
++		break;
++	case 2:
++		reg = WCD939X_ANA_TX_CH4;
++		mask = WCD939X_TX_CH4_HPF3_INIT;
++		break;
++	case 3:
++		reg = WCD939X_ANA_TX_CH4;
++		mask = WCD939X_TX_CH4_HPF4_INIT;
++		break;
++	default:
++		return;
++	}
++
++	snd_soc_component_write_field(component, reg, mask, init);
++}
++
++static int wcd939x_adc_enable_req(struct snd_soc_dapm_widget *w,
++				  struct snd_kcontrol *kcontrol, int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	int mode;
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_REQ_CTL,
++					      WCD939X_CDC_REQ_CTL_FS_RATE_4P8, true);
++		snd_soc_component_write_field(component, WCD939X_DIGITAL_CDC_REQ_CTL,
++					      WCD939X_CDC_REQ_CTL_NO_NOTCH, false);
++
++		wcd939x_tx_channel_config(component, w->shift, true);
++		mode = wcd939x_get_adc_mode(wcd939x->tx_mode[w->shift]);
++		if (mode < 0) {
++			dev_info(component->dev, "Invalid ADC mode\n");
++			return -EINVAL;
++		}
++
++		switch (w->shift) {
++		case 0:
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_TX_ANA_MODE_0_1,
++						      WCD939X_CDC_TX_ANA_MODE_0_1_TXD0_MODE,
++						      mode);
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						      WCD939X_CDC_DIG_CLK_CTL_TXD0_CLK_EN,
++						      true);
++			break;
++		case 1:
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_TX_ANA_MODE_0_1,
++						      WCD939X_CDC_TX_ANA_MODE_0_1_TXD1_MODE,
++						      mode);
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						      WCD939X_CDC_DIG_CLK_CTL_TXD1_CLK_EN,
++						      true);
++			break;
++		case 2:
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_TX_ANA_MODE_2_3,
++						      WCD939X_CDC_TX_ANA_MODE_2_3_TXD2_MODE,
++						      mode);
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						      WCD939X_CDC_DIG_CLK_CTL_TXD2_CLK_EN,
++						      true);
++			break;
++		case 3:
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_TX_ANA_MODE_2_3,
++						      WCD939X_CDC_TX_ANA_MODE_2_3_TXD3_MODE,
++						      mode);
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						      WCD939X_CDC_DIG_CLK_CTL_TXD3_CLK_EN,
++						      true);
++			break;
++		default:
++			break;
++		}
++
++		wcd939x_tx_channel_config(component, w->shift, false);
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		switch (w->shift) {
++		case 0:
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_TX_ANA_MODE_0_1,
++						      WCD939X_CDC_TX_ANA_MODE_0_1_TXD0_MODE,
++						      false);
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						      WCD939X_CDC_DIG_CLK_CTL_TXD0_CLK_EN,
++						      false);
++			break;
++		case 1:
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_TX_ANA_MODE_0_1,
++						      WCD939X_CDC_TX_ANA_MODE_0_1_TXD1_MODE,
++						      false);
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						      WCD939X_CDC_DIG_CLK_CTL_TXD1_CLK_EN,
++						      false);
++			break;
++		case 2:
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_TX_ANA_MODE_2_3,
++						      WCD939X_CDC_TX_ANA_MODE_2_3_TXD2_MODE,
++						      false);
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						      WCD939X_CDC_DIG_CLK_CTL_TXD2_CLK_EN,
++						      false);
++			break;
++		case 3:
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_TX_ANA_MODE_2_3,
++						      WCD939X_CDC_TX_ANA_MODE_2_3_TXD3_MODE,
++						      false);
++			snd_soc_component_write_field(component,
++						      WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						      WCD939X_CDC_DIG_CLK_CTL_TXD3_CLK_EN,
++						      false);
++			break;
++		default:
++			break;
++		}
++		break;
++	}
++
++	return 0;
++}
++
++static int wcd939x_micbias_control(struct snd_soc_component *component,
++				   int micb_num, int req, bool is_dapm)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	int micb_index = micb_num - 1;
++	u16 micb_reg;
++
++	switch (micb_num) {
++	case MIC_BIAS_1:
++		micb_reg = WCD939X_ANA_MICB1;
++		break;
++	case MIC_BIAS_2:
++		micb_reg = WCD939X_ANA_MICB2;
++		break;
++	case MIC_BIAS_3:
++		micb_reg = WCD939X_ANA_MICB3;
++		break;
++	case MIC_BIAS_4:
++		micb_reg = WCD939X_ANA_MICB4;
++		break;
++	default:
++		dev_err(component->dev, "%s: Invalid micbias number: %d\n",
++			__func__, micb_num);
++		return -EINVAL;
++	}
++
++	switch (req) {
++	case MICB_PULLUP_ENABLE:
++		wcd939x->pullup_ref[micb_index]++;
++		if (wcd939x->pullup_ref[micb_index] == 1 &&
++		    wcd939x->micb_ref[micb_index] == 0)
++			snd_soc_component_write_field(component, micb_reg,
++						      WCD939X_MICB_ENABLE,
++						      MICB_BIAS_PULL_UP);
++		break;
++	case MICB_PULLUP_DISABLE:
++		if (wcd939x->pullup_ref[micb_index] > 0)
++			wcd939x->pullup_ref[micb_index]--;
++		if (wcd939x->pullup_ref[micb_index] == 0 &&
++		    wcd939x->micb_ref[micb_index] == 0)
++			snd_soc_component_write_field(component, micb_reg,
++						      WCD939X_MICB_ENABLE,
++						      MICB_BIAS_DISABLE);
++		break;
++	case MICB_ENABLE:
++		wcd939x->micb_ref[micb_index]++;
++		if (wcd939x->micb_ref[micb_index] == 1) {
++			snd_soc_component_write_field(component,
++						WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						WCD939X_CDC_DIG_CLK_CTL_TXD3_CLK_EN, true);
++			snd_soc_component_write_field(component,
++						WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						WCD939X_CDC_DIG_CLK_CTL_TXD2_CLK_EN, true);
++			snd_soc_component_write_field(component,
++						WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						WCD939X_CDC_DIG_CLK_CTL_TXD1_CLK_EN, true);
++			snd_soc_component_write_field(component,
++						WCD939X_DIGITAL_CDC_DIG_CLK_CTL,
++						WCD939X_CDC_DIG_CLK_CTL_TXD0_CLK_EN, true);
++			snd_soc_component_write_field(component,
++						WCD939X_DIGITAL_CDC_ANA_CLK_CTL,
++						WCD939X_CDC_ANA_CLK_CTL_ANA_TX_DIV2_CLK_EN,
++						true);
++			snd_soc_component_write_field(component,
++						WCD939X_DIGITAL_CDC_ANA_TX_CLK_CTL,
++						WCD939X_CDC_ANA_TX_CLK_CTL_ANA_TXSCBIAS_CLK_EN,
++						true);
++			snd_soc_component_write_field(component,
++						WCD939X_MICB1_TEST_CTL_2,
++						WCD939X_TEST_CTL_2_IBIAS_LDO_DRIVER, true);
++			snd_soc_component_write_field(component,
++						WCD939X_MICB2_TEST_CTL_2,
++						WCD939X_TEST_CTL_2_IBIAS_LDO_DRIVER, true);
++			snd_soc_component_write_field(component,
++						WCD939X_MICB3_TEST_CTL_2,
++						WCD939X_TEST_CTL_2_IBIAS_LDO_DRIVER, true);
++			snd_soc_component_write_field(component,
++						WCD939X_MICB4_TEST_CTL_2,
++						WCD939X_TEST_CTL_2_IBIAS_LDO_DRIVER, true);
++			snd_soc_component_write_field(component, micb_reg,
++						      WCD939X_MICB_ENABLE,
++						      MICB_BIAS_ENABLE);
++			if (micb_num == MIC_BIAS_2)
++				wcd_mbhc_event_notify(wcd939x->wcd_mbhc,
++						      WCD_EVENT_POST_MICBIAS_2_ON);
++		}
++		if (micb_num == MIC_BIAS_2 && is_dapm)
++			wcd_mbhc_event_notify(wcd939x->wcd_mbhc,
++					      WCD_EVENT_POST_DAPM_MICBIAS_2_ON);
++		break;
++	case MICB_DISABLE:
++		if (wcd939x->micb_ref[micb_index] > 0)
++			wcd939x->micb_ref[micb_index]--;
++
++		if (wcd939x->micb_ref[micb_index] == 0 &&
++		    wcd939x->pullup_ref[micb_index] > 0)
++			snd_soc_component_write_field(component, micb_reg,
++						      WCD939X_MICB_ENABLE,
++						      MICB_BIAS_PULL_UP);
++		else if (wcd939x->micb_ref[micb_index] == 0 &&
++			 wcd939x->pullup_ref[micb_index] == 0) {
++			if (micb_num  == MIC_BIAS_2)
++				wcd_mbhc_event_notify(wcd939x->wcd_mbhc,
++						      WCD_EVENT_PRE_MICBIAS_2_OFF);
++
++			snd_soc_component_write_field(component, micb_reg,
++						      WCD939X_MICB_ENABLE,
++						      MICB_BIAS_DISABLE);
++			if (micb_num  == MIC_BIAS_2)
++				wcd_mbhc_event_notify(wcd939x->wcd_mbhc,
++						      WCD_EVENT_POST_MICBIAS_2_OFF);
++		}
++		if (is_dapm && micb_num  == MIC_BIAS_2)
++			wcd_mbhc_event_notify(wcd939x->wcd_mbhc,
++					      WCD_EVENT_POST_DAPM_MICBIAS_2_OFF);
++		break;
++	}
++
++	return 0;
++}
++
++static int wcd939x_codec_enable_micbias(struct snd_soc_dapm_widget *w,
++					struct snd_kcontrol *kcontrol,
++					int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	int micb_num = w->shift;
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		wcd939x_micbias_control(component, micb_num, MICB_ENABLE, true);
++		break;
++	case SND_SOC_DAPM_POST_PMU:
++		/* 1 msec delay as per HW requirement */
++		usleep_range(1000, 1100);
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		wcd939x_micbias_control(component, micb_num, MICB_DISABLE, true);
++		break;
++	}
++
++	return 0;
++}
++
++static int wcd939x_codec_enable_micbias_pullup(struct snd_soc_dapm_widget *w,
++					       struct snd_kcontrol *kcontrol,
++					       int event)
++{
++	struct snd_soc_component *component = snd_soc_dapm_to_component(w->dapm);
++	int micb_num = w->shift;
++
++	switch (event) {
++	case SND_SOC_DAPM_PRE_PMU:
++		wcd939x_micbias_control(component, micb_num,
++					MICB_PULLUP_ENABLE, true);
++		break;
++	case SND_SOC_DAPM_POST_PMU:
++		/* 1 msec delay as per HW requirement */
++		usleep_range(1000, 1100);
++		break;
++	case SND_SOC_DAPM_POST_PMD:
++		wcd939x_micbias_control(component, micb_num,
++					MICB_PULLUP_DISABLE, true);
++		break;
++	}
++
++	return 0;
++}
++
++static int wcd939x_tx_mode_get(struct snd_kcontrol *kcontrol,
++			       struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	struct soc_enum *e = (struct soc_enum *)kcontrol->private_value;
++	int path = e->shift_l;
++
++	ucontrol->value.enumerated.item[0] = wcd939x->tx_mode[path];
++
++	return 0;
++}
++
++static int wcd939x_tx_mode_put(struct snd_kcontrol *kcontrol,
++			       struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	struct soc_enum *e = (struct soc_enum *)kcontrol->private_value;
++	int path = e->shift_l;
++
++	if (wcd939x->tx_mode[path] == ucontrol->value.enumerated.item[0])
++		return 0;
++
++	wcd939x->tx_mode[path] = ucontrol->value.enumerated.item[0];
++
++	return 1;
++}
++
++/* RX Controls */
++
++static int wcd939x_rx_hph_mode_get(struct snd_kcontrol *kcontrol,
++				   struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	ucontrol->value.integer.value[0] = wcd939x->hph_mode;
++
++	return 0;
++}
++
++static int wcd939x_rx_hph_mode_put(struct snd_kcontrol *kcontrol,
++				   struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	u32 mode_val;
++
++	mode_val = ucontrol->value.enumerated.item[0];
++
++	if (mode_val == wcd939x->hph_mode)
++		return 0;
++
++	if (wcd939x->variant == CHIPID_WCD9390) {
++		switch (mode_val) {
++		case CLS_H_NORMAL:
++		case CLS_H_LP:
++		case CLS_AB:
++		case CLS_H_LOHIFI:
++		case CLS_H_ULP:
++		case CLS_AB_LP:
++		case CLS_AB_LOHIFI:
++			wcd939x->hph_mode = mode_val;
++			return 1;
++		}
++	} else {
++		switch (mode_val) {
++		case CLS_H_NORMAL:
++		case CLS_H_HIFI:
++		case CLS_H_LP:
++		case CLS_AB:
++		case CLS_H_LOHIFI:
++		case CLS_H_ULP:
++		case CLS_AB_HIFI:
++		case CLS_AB_LP:
++		case CLS_AB_LOHIFI:
++			wcd939x->hph_mode = mode_val;
++			return 1;
++		}
++	}
++
++	dev_dbg(component->dev, "%s: Invalid HPH Mode\n", __func__);
++	return -EINVAL;
++}
++
++static int wcd939x_get_compander(struct snd_kcontrol *kcontrol,
++				 struct snd_ctl_elem_value *ucontrol)
++{
++	struct soc_mixer_control *mc = (struct soc_mixer_control *)(kcontrol->private_value);
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	if (mc->shift)
++		ucontrol->value.integer.value[0] = wcd939x->comp2_enable ? 1 : 0;
++	else
++		ucontrol->value.integer.value[0] = wcd939x->comp1_enable ? 1 : 0;
++
++	return 0;
++}
++
++static int wcd939x_set_compander(struct snd_kcontrol *kcontrol,
++				 struct snd_ctl_elem_value *ucontrol)
++{
++	struct soc_mixer_control *mc = (struct soc_mixer_control *)(kcontrol->private_value);
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	struct wcd939x_sdw_priv *wcd = wcd939x->sdw_priv[AIF1_PB];
++	bool value = !!ucontrol->value.integer.value[0];
++	int portidx = wcd->ch_info[mc->reg].port_num;
++
++	if (mc->shift)
++		wcd939x->comp2_enable = value;
++	else
++		wcd939x->comp1_enable = value;
++
++	if (value)
++		wcd939x_connect_port(wcd, portidx, mc->reg, true);
++	else
++		wcd939x_connect_port(wcd, portidx, mc->reg, false);
++
++	return 1;
++}
++
++static int wcd939x_ldoh_get(struct snd_kcontrol *kcontrol,
++			    struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	ucontrol->value.integer.value[0] = wcd939x->ldoh ? 1 : 0;
++
++	return 0;
++}
++
++static int wcd939x_ldoh_put(struct snd_kcontrol *kcontrol,
++			    struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	if (wcd939x->ldoh == !!ucontrol->value.integer.value[0])
++		return 0;
++
++	wcd939x->ldoh = !!ucontrol->value.integer.value[0];
++
++	return 1;
++}
++
++static const char * const tx_mode_mux_text_wcd9390[] = {
++	"ADC_INVALID", "ADC_HIFI", "ADC_LO_HIF", "ADC_NORMAL", "ADC_LP",
++};
++
++static const struct soc_enum tx0_mode_mux_enum_wcd9390 =
++	SOC_ENUM_SINGLE(SND_SOC_NOPM, 0, ARRAY_SIZE(tx_mode_mux_text_wcd9390),
++			tx_mode_mux_text_wcd9390);
++
++static const struct soc_enum tx1_mode_mux_enum_wcd9390 =
++	SOC_ENUM_SINGLE(SND_SOC_NOPM, 1, ARRAY_SIZE(tx_mode_mux_text_wcd9390),
++			tx_mode_mux_text_wcd9390);
++
++static const struct soc_enum tx2_mode_mux_enum_wcd9390 =
++	SOC_ENUM_SINGLE(SND_SOC_NOPM, 2, ARRAY_SIZE(tx_mode_mux_text_wcd9390),
++			tx_mode_mux_text_wcd9390);
++
++static const struct soc_enum tx3_mode_mux_enum_wcd9390 =
++	SOC_ENUM_SINGLE(SND_SOC_NOPM, 3, ARRAY_SIZE(tx_mode_mux_text_wcd9390),
++			tx_mode_mux_text_wcd9390);
++
++static const char * const tx_mode_mux_text[] = {
++	"ADC_INVALID", "ADC_HIFI", "ADC_LO_HIF", "ADC_NORMAL", "ADC_LP",
++	"ADC_ULP1", "ADC_ULP2",
++};
++
++static const struct soc_enum tx0_mode_mux_enum =
++	SOC_ENUM_SINGLE(SND_SOC_NOPM, 0, ARRAY_SIZE(tx_mode_mux_text),
++			tx_mode_mux_text);
++
++static const struct soc_enum tx1_mode_mux_enum =
++	SOC_ENUM_SINGLE(SND_SOC_NOPM, 1, ARRAY_SIZE(tx_mode_mux_text),
++			tx_mode_mux_text);
++
++static const struct soc_enum tx2_mode_mux_enum =
++	SOC_ENUM_SINGLE(SND_SOC_NOPM, 2, ARRAY_SIZE(tx_mode_mux_text),
++			tx_mode_mux_text);
++
++static const struct soc_enum tx3_mode_mux_enum =
++	SOC_ENUM_SINGLE(SND_SOC_NOPM, 3, ARRAY_SIZE(tx_mode_mux_text),
++			tx_mode_mux_text);
++
++static const char * const rx_hph_mode_mux_text_wcd9390[] = {
++	"CLS_H_NORMAL", "CLS_H_INVALID_1", "CLS_H_LP", "CLS_AB",
++	"CLS_H_LOHIFI", "CLS_H_ULP", "CLS_H_INVALID_2", "CLS_AB_LP",
++	"CLS_AB_LOHIFI",
++};
++
++static const struct soc_enum rx_hph_mode_mux_enum_wcd9390 =
++	SOC_ENUM_SINGLE_EXT(ARRAY_SIZE(rx_hph_mode_mux_text_wcd9390),
++			    rx_hph_mode_mux_text_wcd9390);
++
++static const char * const rx_hph_mode_mux_text[] = {
++	"CLS_H_NORMAL", "CLS_H_HIFI", "CLS_H_LP", "CLS_AB", "CLS_H_LOHIFI",
++	"CLS_H_ULP", "CLS_AB_HIFI", "CLS_AB_LP", "CLS_AB_LOHIFI",
++};
++
++static const struct soc_enum rx_hph_mode_mux_enum =
++	SOC_ENUM_SINGLE_EXT(ARRAY_SIZE(rx_hph_mode_mux_text),
++			    rx_hph_mode_mux_text);
++
++static const struct snd_kcontrol_new wcd9390_snd_controls[] = {
++	SOC_SINGLE_TLV("EAR_PA Volume", WCD939X_ANA_EAR_COMPANDER_CTL,
++		       2, 0x10, 0, ear_pa_gain),
++
++	SOC_ENUM_EXT("RX HPH Mode", rx_hph_mode_mux_enum_wcd9390,
++		     wcd939x_rx_hph_mode_get, wcd939x_rx_hph_mode_put),
++
++	SOC_ENUM_EXT("TX0 MODE", tx0_mode_mux_enum_wcd9390,
++		     wcd939x_tx_mode_get, wcd939x_tx_mode_put),
++	SOC_ENUM_EXT("TX1 MODE", tx1_mode_mux_enum_wcd9390,
++		     wcd939x_tx_mode_get, wcd939x_tx_mode_put),
++	SOC_ENUM_EXT("TX2 MODE", tx2_mode_mux_enum_wcd9390,
++		     wcd939x_tx_mode_get, wcd939x_tx_mode_put),
++	SOC_ENUM_EXT("TX3 MODE", tx3_mode_mux_enum_wcd9390,
++		     wcd939x_tx_mode_get, wcd939x_tx_mode_put),
++};
++
++static const struct snd_kcontrol_new wcd9395_snd_controls[] = {
++	SOC_ENUM_EXT("RX HPH Mode", rx_hph_mode_mux_enum,
++		     wcd939x_rx_hph_mode_get, wcd939x_rx_hph_mode_put),
++
++	SOC_ENUM_EXT("TX0 MODE", tx0_mode_mux_enum,
++		     wcd939x_tx_mode_get, wcd939x_tx_mode_put),
++	SOC_ENUM_EXT("TX1 MODE", tx1_mode_mux_enum,
++		     wcd939x_tx_mode_get, wcd939x_tx_mode_put),
++	SOC_ENUM_EXT("TX2 MODE", tx2_mode_mux_enum,
++		     wcd939x_tx_mode_get, wcd939x_tx_mode_put),
++	SOC_ENUM_EXT("TX3 MODE", tx3_mode_mux_enum,
++		     wcd939x_tx_mode_get, wcd939x_tx_mode_put),
++};
++
++static const struct snd_kcontrol_new adc1_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new adc2_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new adc3_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new adc4_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new dmic1_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new dmic2_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new dmic3_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new dmic4_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new dmic5_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new dmic6_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new dmic7_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new dmic8_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new ear_rdac_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new hphl_rdac_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const struct snd_kcontrol_new hphr_rdac_switch[] = {
++	SOC_DAPM_SINGLE("Switch", SND_SOC_NOPM, 0, 1, 0)
++};
++
++static const char * const adc1_mux_text[] = {
++	"CH1_AMIC_DISABLE", "CH1_AMIC1", "CH1_AMIC2", "CH1_AMIC3", "CH1_AMIC4", "CH1_AMIC5"
++};
++
++static const struct soc_enum adc1_enum =
++	SOC_ENUM_SINGLE(WCD939X_TX_NEW_CH12_MUX, 0,
++			ARRAY_SIZE(adc1_mux_text), adc1_mux_text);
++
++static const struct snd_kcontrol_new tx_adc1_mux =
++	SOC_DAPM_ENUM("ADC1 MUX Mux", adc1_enum);
++
++static const char * const adc2_mux_text[] = {
++	"CH2_AMIC_DISABLE", "CH2_AMIC1", "CH2_AMIC2", "CH2_AMIC3", "CH2_AMIC4", "CH2_AMIC5"
++};
++
++static const struct soc_enum adc2_enum =
++	SOC_ENUM_SINGLE(WCD939X_TX_NEW_CH12_MUX, 3,
++			ARRAY_SIZE(adc2_mux_text), adc2_mux_text);
++
++static const struct snd_kcontrol_new tx_adc2_mux =
++	SOC_DAPM_ENUM("ADC2 MUX Mux", adc2_enum);
++
++static const char * const adc3_mux_text[] = {
++	"CH3_AMIC_DISABLE", "CH3_AMIC1", "CH3_AMIC3", "CH3_AMIC4", "CH3_AMIC5"
++};
++
++static const struct soc_enum adc3_enum =
++	SOC_ENUM_SINGLE(WCD939X_TX_NEW_CH34_MUX, 0,
++			ARRAY_SIZE(adc3_mux_text), adc3_mux_text);
++
++static const struct snd_kcontrol_new tx_adc3_mux =
++	SOC_DAPM_ENUM("ADC3 MUX Mux", adc3_enum);
++
++static const char * const adc4_mux_text[] = {
++	"CH4_AMIC_DISABLE", "CH4_AMIC1", "CH4_AMIC3", "CH4_AMIC4", "CH4_AMIC5"
++};
++
++static const struct soc_enum adc4_enum =
++	SOC_ENUM_SINGLE(WCD939X_TX_NEW_CH34_MUX, 3,
++			ARRAY_SIZE(adc4_mux_text), adc4_mux_text);
++
++static const struct snd_kcontrol_new tx_adc4_mux =
++	SOC_DAPM_ENUM("ADC4 MUX Mux", adc4_enum);
++
++static const char * const rdac3_mux_text[] = {
++	"RX3", "RX1"
++};
++
++static const struct soc_enum rdac3_enum =
++	SOC_ENUM_SINGLE(WCD939X_DIGITAL_CDC_EAR_PATH_CTL, 0,
++			ARRAY_SIZE(rdac3_mux_text), rdac3_mux_text);
++
++static const struct snd_kcontrol_new rx_rdac3_mux =
++	SOC_DAPM_ENUM("RDAC3_MUX Mux", rdac3_enum);
++
++static int wcd939x_get_swr_port(struct snd_kcontrol *kcontrol,
++				struct snd_ctl_elem_value *ucontrol)
++{
++	struct soc_mixer_control *mixer = (struct soc_mixer_control *)kcontrol->private_value;
++	struct snd_soc_component *comp = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(comp);
++	struct wcd939x_sdw_priv *wcd = wcd939x->sdw_priv[mixer->shift];
++	unsigned int portidx = wcd->ch_info[mixer->reg].port_num;
++
++	ucontrol->value.integer.value[0] = wcd->port_enable[portidx] ? 1 : 0;
++
++	return 0;
++}
++
++static const char *version_to_str(u32 version)
++{
++	switch (version) {
++	case WCD939X_VERSION_1_0:
++		return __stringify(WCD939X_1_0);
++	case WCD939X_VERSION_1_1:
++		return __stringify(WCD939X_1_1);
++	case WCD939X_VERSION_2_0:
++		return __stringify(WCD939X_2_0);
++	}
++	return NULL;
++}
++
++static int wcd939x_set_swr_port(struct snd_kcontrol *kcontrol,
++				struct snd_ctl_elem_value *ucontrol)
++{
++	struct soc_mixer_control *mixer = (struct soc_mixer_control *)kcontrol->private_value;
++	struct snd_soc_component *comp = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(comp);
++	struct wcd939x_sdw_priv *wcd = wcd939x->sdw_priv[mixer->shift];
++	unsigned int portidx = wcd->ch_info[mixer->reg].port_num;
++
++	wcd->port_enable[portidx] = !!ucontrol->value.integer.value[0];
++
++	wcd939x_connect_port(wcd, portidx, mixer->reg, wcd->port_enable[portidx]);
++
++	return 1;
++}
++
++/* MBHC Related */
++
++static void wcd939x_mbhc_clk_setup(struct snd_soc_component *component,
++				   bool enable)
++{
++	snd_soc_component_write_field(component, WCD939X_MBHC_NEW_CTL_1,
++				      WCD939X_CTL_1_RCO_EN, enable);
++}
++
++static void wcd939x_mbhc_mbhc_bias_control(struct snd_soc_component *component,
++					   bool enable)
++{
++	snd_soc_component_write_field(component, WCD939X_ANA_MBHC_ELECT,
++				      WCD939X_MBHC_ELECT_BIAS_EN, enable);
++}
++
++static void wcd939x_mbhc_program_btn_thr(struct snd_soc_component *component,
++					 int *btn_low, int *btn_high,
++					 int num_btn, bool is_micbias)
++{
++	int i, vth;
++
++	if (num_btn > WCD_MBHC_DEF_BUTTONS) {
++		dev_err(component->dev, "%s: invalid number of buttons: %d\n",
++			__func__, num_btn);
++		return;
++	}
++
++	for (i = 0; i < num_btn; i++) {
++		vth = (btn_high[i] * 2) / 25;
++		snd_soc_component_write_field(component, WCD939X_ANA_MBHC_BTN0 + i,
++					      WCD939X_MBHC_BTN0_VTH, vth);
++		dev_dbg(component->dev, "%s: btn_high[%d]: %d, vth: %d\n",
++			__func__, i, btn_high[i], vth);
++	}
++}
++
++static bool wcd939x_mbhc_micb_en_status(struct snd_soc_component *component, int micb_num)
++{
++	if (micb_num == MIC_BIAS_2) {
++		u8 val;
++
++		val = FIELD_GET(WCD939X_MICB_ENABLE,
++				snd_soc_component_read(component, WCD939X_ANA_MICB2));
++		if (val == MICB_BIAS_ENABLE)
++			return true;
++	}
++
++	return false;
++}
++
++static void wcd939x_mbhc_hph_l_pull_up_control(struct snd_soc_component *component,
++					       int pull_up_cur)
++{
++	/* Default pull up current to 2uA */
++	if (pull_up_cur > HS_PULLUP_I_OFF ||
++	    pull_up_cur < HS_PULLUP_I_3P0_UA ||
++	    pull_up_cur == HS_PULLUP_I_DEFAULT)
++		pull_up_cur = HS_PULLUP_I_2P0_UA;
++
++	dev_dbg(component->dev, "%s: HS pull up current:%d\n",
++		__func__, pull_up_cur);
++
++	snd_soc_component_write_field(component, WCD939X_MBHC_NEW_INT_MECH_DET_CURRENT,
++				      WCD939X_MECH_DET_CURRENT_HSDET_PULLUP_CTL, pull_up_cur);
++}
++
++static int wcd939x_mbhc_request_micbias(struct snd_soc_component *component,
++					int micb_num, int req)
++{
++	return wcd939x_micbias_control(component, micb_num, req, false);
++}
++
++static void wcd939x_mbhc_micb_ramp_control(struct snd_soc_component *component,
++					   bool enable)
++{
++	if (enable) {
++		snd_soc_component_write_field(component, WCD939X_ANA_MICB2_RAMP,
++					      WCD939X_MICB2_RAMP_SHIFT_CTL, 3);
++		snd_soc_component_write_field(component, WCD939X_ANA_MICB2_RAMP,
++					      WCD939X_MICB2_RAMP_RAMP_ENABLE, true);
++	} else {
++		snd_soc_component_write_field(component, WCD939X_ANA_MICB2_RAMP,
++					      WCD939X_MICB2_RAMP_RAMP_ENABLE, false);
++		snd_soc_component_write_field(component, WCD939X_ANA_MICB2_RAMP,
++					      WCD939X_MICB2_RAMP_SHIFT_CTL, 0);
++	}
++}
++
++static int wcd939x_mbhc_micb_adjust_voltage(struct snd_soc_component *component,
++					    int req_volt, int micb_num)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	unsigned int micb_reg, cur_vout_ctl, micb_en;
++	int req_vout_ctl;
++	int ret = 0;
++
++	switch (micb_num) {
++	case MIC_BIAS_1:
++		micb_reg = WCD939X_ANA_MICB1;
++		break;
++	case MIC_BIAS_2:
++		micb_reg = WCD939X_ANA_MICB2;
++		break;
++	case MIC_BIAS_3:
++		micb_reg = WCD939X_ANA_MICB3;
++		break;
++	case MIC_BIAS_4:
++		micb_reg = WCD939X_ANA_MICB4;
++		break;
++	default:
++		return -EINVAL;
++	}
++	mutex_lock(&wcd939x->micb_lock);
++
++	/*
++	 * If requested micbias voltage is same as current micbias
++	 * voltage, then just return. Otherwise, adjust voltage as
++	 * per requested value. If micbias is already enabled, then
++	 * to avoid slow micbias ramp-up or down enable pull-up
++	 * momentarily, change the micbias value and then re-enable
++	 * micbias.
++	 */
++	micb_en = snd_soc_component_read_field(component, micb_reg,
++					       WCD939X_MICB_ENABLE);
++	cur_vout_ctl = snd_soc_component_read_field(component, micb_reg,
++						    WCD939X_MICB_VOUT_CTL);
++
++	req_vout_ctl = wcd_get_micb_vout_ctl_val(component->dev, req_volt);
++	if (req_vout_ctl < 0) {
++		ret = req_vout_ctl;
++		goto exit;
++	}
++
++	if (cur_vout_ctl == req_vout_ctl) {
++		ret = 0;
++		goto exit;
++	}
++
++	dev_dbg(component->dev, "%s: micb_num: %d, cur_mv: %d, req_mv: %d, micb_en: %d\n",
++		__func__, micb_num, WCD_VOUT_CTL_TO_MICB(cur_vout_ctl),
++		 req_volt, micb_en);
++
++	if (micb_en == MICB_BIAS_ENABLE)
++		snd_soc_component_write_field(component, micb_reg,
++					      WCD939X_MICB_ENABLE,
++					      MICB_BIAS_PULL_DOWN);
++
++	snd_soc_component_write_field(component, micb_reg,
++				      WCD939X_MICB_VOUT_CTL, req_vout_ctl);
++
++	if (micb_en == MICB_BIAS_ENABLE) {
++		snd_soc_component_write_field(component, micb_reg,
++					      WCD939X_MICB_ENABLE,
++					      MICB_BIAS_ENABLE);
++		/*
++		 * Add 2ms delay as per HW requirement after enabling
++		 * micbias
++		 */
++		usleep_range(2000, 2100);
++	}
++
++exit:
++	mutex_unlock(&wcd939x->micb_lock);
++	return ret;
++}
++
++static int wcd939x_mbhc_micb_ctrl_threshold_mic(struct snd_soc_component *component,
++						int micb_num, bool req_en)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	int micb_mv;
++
++	if (micb_num != MIC_BIAS_2)
++		return -EINVAL;
++	/*
++	 * If device tree micbias level is already above the minimum
++	 * voltage needed to detect threshold microphone, then do
++	 * not change the micbias, just return.
++	 */
++	if (wcd939x->common.micb_mv[1] >= WCD_MBHC_THR_HS_MICB_MV)
++		return 0;
++
++	micb_mv = req_en ? WCD_MBHC_THR_HS_MICB_MV : wcd939x->common.micb_mv[1];
++
++	return wcd939x_mbhc_micb_adjust_voltage(component, micb_mv, MIC_BIAS_2);
++}
++
++/* Selected by WCD939X_MBHC_GET_C1() */
++static const s16 wcd939x_wcd_mbhc_d1_a[4] = {
++	0, 30, 30, 6
++};
++
++/* Selected by zdet_param.noff */
++static const int wcd939x_mbhc_mincode_param[] = {
++	3277, 1639, 820, 410, 205, 103, 52, 26
++};
++
++static const struct zdet_param wcd939x_mbhc_zdet_param = {
++	.ldo_ctl = 4,
++	.noff = 0,
++	.nshift = 6,
++	.btn5 = 0x18,
++	.btn6 = 0x60,
++	.btn7 = 0x78,
++};
++
++static void wcd939x_mbhc_get_result_params(struct snd_soc_component *component,
++					   int32_t *zdet)
++{
++	const struct zdet_param *zdet_param = &wcd939x_mbhc_zdet_param;
++	s32 x1, d1, denom;
++	int val;
++	s16 c1;
++	int i;
++
++	snd_soc_component_write_field(component, WCD939X_ANA_MBHC_ZDET,
++				      WCD939X_MBHC_ZDET_ZDET_CHG_EN, true);
++	for (i = 0; i < WCD939X_ZDET_NUM_MEASUREMENTS; i++) {
++		val = snd_soc_component_read_field(component, WCD939X_ANA_MBHC_RESULT_2,
++						   WCD939X_MBHC_RESULT_2_Z_RESULT_MSB);
++		if (val & BIT(7))
++			break;
++	}
++	val = val << 8;
++	val |= snd_soc_component_read_field(component, WCD939X_ANA_MBHC_RESULT_1,
++					    WCD939X_MBHC_RESULT_1_Z_RESULT_LSB);
++	snd_soc_component_write_field(component, WCD939X_ANA_MBHC_ZDET,
++				      WCD939X_MBHC_ZDET_ZDET_CHG_EN, false);
++	x1 = WCD939X_MBHC_GET_X1(val);
++	c1 = WCD939X_MBHC_GET_C1(val);
++
++	/* If ramp is not complete, give additional 5ms */
++	if (c1 < 2 && x1)
++		mdelay(5);
++
++	if (!c1 || !x1) {
++		dev_dbg(component->dev,
++			"%s: Impedance detect ramp error, c1=%d, x1=0x%x\n",
++			__func__, c1, x1);
++		goto ramp_down;
++	}
++
++	d1 = wcd939x_wcd_mbhc_d1_a[c1];
++	denom = (x1 * d1) - (1 << (14 - zdet_param->noff));
++	if (denom > 0)
++		*zdet = (WCD939X_ANA_MBHC_ZDET_CONST * 1000) / denom;
++	else if (x1 <  wcd939x_mbhc_mincode_param[zdet_param->noff])
++		*zdet = WCD939X_ZDET_FLOATING_IMPEDANCE;
++
++	dev_dbg(component->dev, "%s: d1=%d, c1=%d, x1=0x%x, z_val=%d(milliOhm)\n",
++		__func__, d1, c1, x1, *zdet);
++ramp_down:
++	i = 0;
++	while (x1) {
++		val = snd_soc_component_read_field(component, WCD939X_ANA_MBHC_RESULT_1,
++						   WCD939X_MBHC_RESULT_1_Z_RESULT_LSB) << 8;
++		val |= snd_soc_component_read_field(component, WCD939X_ANA_MBHC_RESULT_2,
++						    WCD939X_MBHC_RESULT_2_Z_RESULT_MSB);
++		x1 = WCD939X_MBHC_GET_X1(val);
++		i++;
++		if (i == WCD939X_ZDET_NUM_MEASUREMENTS)
++			break;
++	}
++}
++
++static void wcd939x_mbhc_zdet_ramp(struct snd_soc_component *component,
++				   s32 *zl, int32_t *zr)
++{
++	const struct zdet_param *zdet_param = &wcd939x_mbhc_zdet_param;
++	s32 zdet = 0;
++
++	snd_soc_component_write_field(component, WCD939X_MBHC_NEW_ZDET_ANA_CTL,
++				      WCD939X_ZDET_ANA_CTL_MAXV_CTL, zdet_param->ldo_ctl);
++	snd_soc_component_update_bits(component, WCD939X_ANA_MBHC_BTN5, WCD939X_MBHC_BTN5_VTH,
++				      zdet_param->btn5);
++	snd_soc_component_update_bits(component, WCD939X_ANA_MBHC_BTN6, WCD939X_MBHC_BTN6_VTH,
++				      zdet_param->btn6);
++	snd_soc_component_update_bits(component, WCD939X_ANA_MBHC_BTN7, WCD939X_MBHC_BTN7_VTH,
++				      zdet_param->btn7);
++	snd_soc_component_write_field(component, WCD939X_MBHC_NEW_ZDET_ANA_CTL,
++				      WCD939X_ZDET_ANA_CTL_RANGE_CTL, zdet_param->noff);
++	snd_soc_component_write_field(component, WCD939X_MBHC_NEW_ZDET_RAMP_CTL,
++				      WCD939X_ZDET_RAMP_CTL_TIME_CTL, zdet_param->nshift);
++	snd_soc_component_write_field(component, WCD939X_MBHC_NEW_ZDET_RAMP_CTL,
++				      WCD939X_ZDET_RAMP_CTL_ACC1_MIN_CTL, 6); /*acc1_min_63 */
++
++	if (!zl)
++		goto z_right;
++
++	/* Start impedance measurement for HPH_L */
++	snd_soc_component_write_field(component, WCD939X_ANA_MBHC_ZDET,
++				      WCD939X_MBHC_ZDET_ZDET_L_MEAS_EN, true);
++	dev_dbg(component->dev, "%s: ramp for HPH_L, noff = %d\n",
++		__func__, zdet_param->noff);
++	wcd939x_mbhc_get_result_params(component, &zdet);
++	snd_soc_component_write_field(component, WCD939X_ANA_MBHC_ZDET,
++				      WCD939X_MBHC_ZDET_ZDET_L_MEAS_EN, false);
++
++	*zl = zdet;
++
++z_right:
++	if (!zr)
++		return;
++
++	/* Start impedance measurement for HPH_R */
++	snd_soc_component_write_field(component, WCD939X_ANA_MBHC_ZDET,
++				      WCD939X_MBHC_ZDET_ZDET_R_MEAS_EN, true);
++	dev_dbg(component->dev, "%s: ramp for HPH_R, noff = %d\n",
++		__func__, zdet_param->noff);
++	wcd939x_mbhc_get_result_params(component, &zdet);
++	snd_soc_component_write_field(component, WCD939X_ANA_MBHC_ZDET,
++				      WCD939X_MBHC_ZDET_ZDET_R_MEAS_EN, false);
++
++	*zr = zdet;
++}
++
++static void wcd939x_wcd_mbhc_qfuse_cal(struct snd_soc_component *component,
++				       s32 *z_val, int flag_l_r)
++{
++	int q1_cal;
++	s16 q1;
++
++	q1 = snd_soc_component_read(component, WCD939X_DIGITAL_EFUSE_REG_21 + flag_l_r);
++	if (q1 & BIT(7))
++		q1_cal = (10000 - ((q1 & GENMASK(6, 0)) * 10));
++	else
++		q1_cal = (10000 + (q1 * 10));
++
++	if (q1_cal > 0)
++		*z_val = ((*z_val) * 10000) / q1_cal;
++}
++
++static void wcd939x_wcd_mbhc_calc_impedance(struct snd_soc_component *component,
++					    u32 *zl, uint32_t *zr)
++{
++	struct wcd939x_priv *wcd939x = dev_get_drvdata(component->dev);
++	unsigned int reg0, reg1, reg2, reg3, reg4;
++	int z_mono, z_diff1, z_diff2;
++	bool is_fsm_disable = false;
++	s32 z1l, z1r, z1ls;
++
++	reg0 = snd_soc_component_read(component, WCD939X_ANA_MBHC_BTN5);
++	reg1 = snd_soc_component_read(component, WCD939X_ANA_MBHC_BTN6);
++	reg2 = snd_soc_component_read(component, WCD939X_ANA_MBHC_BTN7);
++	reg3 = snd_soc_component_read(component, WCD939X_MBHC_CTL_CLK);
++	reg4 = snd_soc_component_read(component, WCD939X_MBHC_NEW_ZDET_ANA_CTL);
++
++	if (snd_soc_component_read_field(component, WCD939X_ANA_MBHC_ELECT,
++					 WCD939X_MBHC_ELECT_FSM_EN)) {
++		snd_soc_component_write_field(component, WCD939X_ANA_MBHC_ELECT,
++					      WCD939X_MBHC_ELECT_FSM_EN, false);
++		is_fsm_disable = true;
++	}
++
++	/* For NO-jack, disable L_DET_EN before Z-det measurements */
++	if (wcd939x->mbhc_cfg.hphl_swh)
++		snd_soc_component_write_field(component, WCD939X_ANA_MBHC_MECH,
++					      WCD939X_MBHC_MECH_L_DET_EN, false);
++
++	/* Turn off 100k pull down on HPHL */
++	snd_soc_component_write_field(component, WCD939X_ANA_MBHC_MECH,
++				      WCD939X_MBHC_MECH_SW_HPH_L_P_100K_TO_GND,
++				      false);
++
++	/*
++	 * Disable surge protection before impedance detection.
++	 * This is done to give correct value for high impedance.
++	 */
++	snd_soc_component_write_field(component, WCD939X_HPH_SURGE_EN,
++				      WCD939X_EN_EN_SURGE_PROTECTION_HPHR, false);
++	snd_soc_component_write_field(component, WCD939X_HPH_SURGE_EN,
++				      WCD939X_EN_EN_SURGE_PROTECTION_HPHL, false);
++
++	/* 1ms delay needed after disable surge protection */
++	usleep_range(1000, 1010);
++
++	/* First get impedance on Left */
++	wcd939x_mbhc_zdet_ramp(component, &z1l, NULL);
++	if (z1l == WCD939X_ZDET_FLOATING_IMPEDANCE || z1l > WCD939X_ZDET_VAL_100K) {
++		*zl = WCD939X_ZDET_FLOATING_IMPEDANCE;
++	} else {
++		*zl = z1l / 1000;
++		wcd939x_wcd_mbhc_qfuse_cal(component, zl, 0);
++	}
++	dev_dbg(component->dev, "%s: impedance on HPH_L = %d(ohms)\n",
++		__func__, *zl);
++
++	/* Start of right impedance ramp and calculation */
++	wcd939x_mbhc_zdet_ramp(component, NULL, &z1r);
++	if (z1r == WCD939X_ZDET_FLOATING_IMPEDANCE || z1r > WCD939X_ZDET_VAL_100K) {
++		*zr = WCD939X_ZDET_FLOATING_IMPEDANCE;
++	} else {
++		*zr = z1r / 1000;
++		wcd939x_wcd_mbhc_qfuse_cal(component, zr, 1);
++	}
++	dev_dbg(component->dev, "%s: impedance on HPH_R = %d(ohms)\n",
++		__func__, *zr);
++
++	/* Mono/stereo detection */
++	if (*zl == WCD939X_ZDET_FLOATING_IMPEDANCE &&
++	    *zr == WCD939X_ZDET_FLOATING_IMPEDANCE) {
++		dev_dbg(component->dev,
++			"%s: plug type is invalid or extension cable\n",
++			__func__);
++		goto zdet_complete;
++	}
++
++	if (*zl == WCD939X_ZDET_FLOATING_IMPEDANCE ||
++	    *zr == WCD939X_ZDET_FLOATING_IMPEDANCE ||
++	    (*zl < WCD_MONO_HS_MIN_THR && *zr > WCD_MONO_HS_MIN_THR) ||
++	    (*zl > WCD_MONO_HS_MIN_THR && *zr < WCD_MONO_HS_MIN_THR)) {
++		dev_dbg(component->dev,
++			"%s: Mono plug type with one ch floating or shorted to GND\n",
++			__func__);
++		wcd_mbhc_set_hph_type(wcd939x->wcd_mbhc, WCD_MBHC_HPH_MONO);
++		goto zdet_complete;
++	}
++
++	snd_soc_component_write_field(component, WCD939X_HPH_R_ATEST,
++				      WCD939X_R_ATEST_HPH_GND_OVR, true);
++	snd_soc_component_write_field(component, WCD939X_HPH_PA_CTL2,
++				      WCD939X_PA_CTL2_HPHPA_GND_R, true);
++	wcd939x_mbhc_zdet_ramp(component, &z1ls, NULL);
++	snd_soc_component_write_field(component, WCD939X_HPH_PA_CTL2,
++				      WCD939X_PA_CTL2_HPHPA_GND_R, false);
++	snd_soc_component_write_field(component, WCD939X_HPH_R_ATEST,
++				      WCD939X_R_ATEST_HPH_GND_OVR, false);
++
++	z1ls /= 1000;
++	wcd939x_wcd_mbhc_qfuse_cal(component, &z1ls, 0);
++
++	/* Parallel of left Z and 9 ohm pull down resistor */
++	z_mono = (*zl * 9) / (*zl + 9);
++	z_diff1 = z1ls > z_mono ? z1ls - z_mono : z_mono - z1ls;
++	z_diff2 = *zl > z1ls ? *zl - z1ls : z1ls - *zl;
++	if ((z_diff1 * (*zl + z1ls)) > (z_diff2 * (z1ls + z_mono))) {
++		dev_dbg(component->dev, "%s: stereo plug type detected\n",
++			__func__);
++		wcd_mbhc_set_hph_type(wcd939x->wcd_mbhc, WCD_MBHC_HPH_STEREO);
++	} else {
++		dev_dbg(component->dev, "%s: MONO plug type detected\n",
++			__func__);
++		wcd_mbhc_set_hph_type(wcd939x->wcd_mbhc, WCD_MBHC_HPH_MONO);
++	}
++
++	/* Enable surge protection again after impedance detection */
++	snd_soc_component_write_field(component, WCD939X_HPH_SURGE_EN,
++				      WCD939X_EN_EN_SURGE_PROTECTION_HPHR, true);
++	snd_soc_component_write_field(component, WCD939X_HPH_SURGE_EN,
++				      WCD939X_EN_EN_SURGE_PROTECTION_HPHL, true);
++
++zdet_complete:
++	snd_soc_component_write(component, WCD939X_ANA_MBHC_BTN5, reg0);
++	snd_soc_component_write(component, WCD939X_ANA_MBHC_BTN6, reg1);
++	snd_soc_component_write(component, WCD939X_ANA_MBHC_BTN7, reg2);
++
++	/* Turn on 100k pull down on HPHL */
++	snd_soc_component_write_field(component, WCD939X_ANA_MBHC_MECH,
++				      WCD939X_MBHC_MECH_SW_HPH_L_P_100K_TO_GND, true);
++
++	/* For NO-jack, re-enable L_DET_EN after Z-det measurements */
++	if (wcd939x->mbhc_cfg.hphl_swh)
++		snd_soc_component_write_field(component, WCD939X_ANA_MBHC_MECH,
++					      WCD939X_MBHC_MECH_L_DET_EN, true);
++
++	snd_soc_component_write(component, WCD939X_MBHC_NEW_ZDET_ANA_CTL, reg4);
++	snd_soc_component_write(component, WCD939X_MBHC_CTL_CLK, reg3);
++
++	if (is_fsm_disable)
++		snd_soc_component_write_field(component, WCD939X_ANA_MBHC_ELECT,
++					      WCD939X_MBHC_ELECT_FSM_EN, true);
++}
++
++static void wcd939x_mbhc_gnd_det_ctrl(struct snd_soc_component *component,
++				      bool enable)
++{
++	if (enable) {
++		snd_soc_component_write_field(component, WCD939X_ANA_MBHC_MECH,
++					      WCD939X_MBHC_MECH_MECH_HS_G_PULLUP_COMP_EN,
++					      true);
++		snd_soc_component_write_field(component, WCD939X_ANA_MBHC_MECH,
++					      WCD939X_MBHC_MECH_GND_DET_EN, true);
++	} else {
++		snd_soc_component_write_field(component, WCD939X_ANA_MBHC_MECH,
++					      WCD939X_MBHC_MECH_GND_DET_EN, false);
++		snd_soc_component_write_field(component, WCD939X_ANA_MBHC_MECH,
++					      WCD939X_MBHC_MECH_MECH_HS_G_PULLUP_COMP_EN,
++					      false);
++	}
++}
++
++static void wcd939x_mbhc_hph_pull_down_ctrl(struct snd_soc_component *component,
++					    bool enable)
++{
++	snd_soc_component_write_field(component, WCD939X_HPH_PA_CTL2,
++				      WCD939X_PA_CTL2_HPHPA_GND_R, enable);
++	snd_soc_component_write_field(component, WCD939X_HPH_PA_CTL2,
++				      WCD939X_PA_CTL2_HPHPA_GND_L, enable);
++}
++
++static void wcd939x_mbhc_moisture_config(struct snd_soc_component *component)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	if (wcd939x->mbhc_cfg.moist_rref == R_OFF || wcd939x->typec_analog_mux) {
++		snd_soc_component_write_field(component, WCD939X_MBHC_NEW_CTL_2,
++					      WCD939X_CTL_2_M_RTH_CTL, R_OFF);
++		return;
++	}
++
++	/* Do not enable moisture detection if jack type is NC */
++	if (!wcd939x->mbhc_cfg.hphl_swh) {
++		dev_dbg(component->dev, "%s: disable moisture detection for NC\n",
++			__func__);
++		snd_soc_component_write_field(component, WCD939X_MBHC_NEW_CTL_2,
++					      WCD939X_CTL_2_M_RTH_CTL, R_OFF);
++		return;
++	}
++
++	snd_soc_component_write_field(component, WCD939X_MBHC_NEW_CTL_2,
++				      WCD939X_CTL_2_M_RTH_CTL, wcd939x->mbhc_cfg.moist_rref);
++}
++
++static void wcd939x_mbhc_moisture_detect_en(struct snd_soc_component *component, bool enable)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	if (enable)
++		snd_soc_component_write_field(component, WCD939X_MBHC_NEW_CTL_2,
++					      WCD939X_CTL_2_M_RTH_CTL,
++					      wcd939x->mbhc_cfg.moist_rref);
++	else
++		snd_soc_component_write_field(component, WCD939X_MBHC_NEW_CTL_2,
++					      WCD939X_CTL_2_M_RTH_CTL, R_OFF);
++}
++
++static bool wcd939x_mbhc_get_moisture_status(struct snd_soc_component *component)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	bool ret = false;
++
++	if (wcd939x->mbhc_cfg.moist_rref == R_OFF || wcd939x->typec_analog_mux) {
++		snd_soc_component_write_field(component, WCD939X_MBHC_NEW_CTL_2,
++					      WCD939X_CTL_2_M_RTH_CTL, R_OFF);
++		goto done;
++	}
++
++	/* Do not enable moisture detection if jack type is NC */
++	if (!wcd939x->mbhc_cfg.hphl_swh) {
++		dev_dbg(component->dev, "%s: disable moisture detection for NC\n",
++			__func__);
++		snd_soc_component_write_field(component, WCD939X_MBHC_NEW_CTL_2,
++					      WCD939X_CTL_2_M_RTH_CTL, R_OFF);
++		goto done;
++	}
++
++	/*
++	 * If moisture_en is already enabled, then skip to plug type
++	 * detection.
++	 */
++	if (snd_soc_component_read_field(component, WCD939X_MBHC_NEW_CTL_2,
++					 WCD939X_CTL_2_M_RTH_CTL))
++		goto done;
++
++	wcd939x_mbhc_moisture_detect_en(component, true);
++
++	/* Read moisture comparator status, invert of status bit */
++	ret = !snd_soc_component_read_field(component, WCD939X_MBHC_NEW_FSM_STATUS,
++					    WCD939X_FSM_STATUS_HS_M_COMP_STATUS);
++done:
++	return ret;
++}
++
++static void wcd939x_mbhc_moisture_polling_ctrl(struct snd_soc_component *component,
++					       bool enable)
++{
++	snd_soc_component_write_field(component,
++				      WCD939X_MBHC_NEW_INT_MOISTURE_DET_POLLING_CTRL,
++				      WCD939X_MOISTURE_DET_POLLING_CTRL_MOIST_EN_POLLING,
++				      enable);
++}
++
++static const struct wcd_mbhc_cb mbhc_cb = {
++	.clk_setup = wcd939x_mbhc_clk_setup,
++	.mbhc_bias = wcd939x_mbhc_mbhc_bias_control,
++	.set_btn_thr = wcd939x_mbhc_program_btn_thr,
++	.micbias_enable_status = wcd939x_mbhc_micb_en_status,
++	.hph_pull_up_control_v2 = wcd939x_mbhc_hph_l_pull_up_control,
++	.mbhc_micbias_control = wcd939x_mbhc_request_micbias,
++	.mbhc_micb_ramp_control = wcd939x_mbhc_micb_ramp_control,
++	.mbhc_micb_ctrl_thr_mic = wcd939x_mbhc_micb_ctrl_threshold_mic,
++	.compute_impedance = wcd939x_wcd_mbhc_calc_impedance,
++	.mbhc_gnd_det_ctrl = wcd939x_mbhc_gnd_det_ctrl,
++	.hph_pull_down_ctrl = wcd939x_mbhc_hph_pull_down_ctrl,
++	.mbhc_moisture_config = wcd939x_mbhc_moisture_config,
++	.mbhc_get_moisture_status = wcd939x_mbhc_get_moisture_status,
++	.mbhc_moisture_polling_ctrl = wcd939x_mbhc_moisture_polling_ctrl,
++	.mbhc_moisture_detect_en = wcd939x_mbhc_moisture_detect_en,
++};
++
++static int wcd939x_get_hph_type(struct snd_kcontrol *kcontrol,
++				struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	ucontrol->value.integer.value[0] = wcd_mbhc_get_hph_type(wcd939x->wcd_mbhc);
++
++	return 0;
++}
++
++static int wcd939x_hph_impedance_get(struct snd_kcontrol *kcontrol,
++				     struct snd_ctl_elem_value *ucontrol)
++{
++	struct soc_mixer_control *mc = (struct soc_mixer_control *)(kcontrol->private_value);
++	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	bool hphr = mc->shift;
++	u32 zl, zr;
++
++	wcd_mbhc_get_impedance(wcd939x->wcd_mbhc, &zl, &zr);
++	dev_dbg(component->dev, "%s: zl=%u(ohms), zr=%u(ohms)\n", __func__, zl, zr);
++	ucontrol->value.integer.value[0] = hphr ? zr : zl;
++
++	return 0;
++}
++
++static const struct snd_kcontrol_new hph_type_detect_controls[] = {
++	SOC_SINGLE_EXT("HPH Type", 0, 0, UINT_MAX, 0,
++		       wcd939x_get_hph_type, NULL),
++};
++
++static const struct snd_kcontrol_new impedance_detect_controls[] = {
++	SOC_SINGLE_EXT("HPHL Impedance", 0, 0, UINT_MAX, 0,
++		       wcd939x_hph_impedance_get, NULL),
++	SOC_SINGLE_EXT("HPHR Impedance", 0, 1, UINT_MAX, 0,
++		       wcd939x_hph_impedance_get, NULL),
++};
++
++static int wcd939x_mbhc_init(struct snd_soc_component *component)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	struct wcd_mbhc_intr *intr_ids = &wcd939x->intr_ids;
++
++	intr_ids->mbhc_sw_intr = regmap_irq_get_virq(wcd939x->irq_chip,
++						     WCD939X_IRQ_MBHC_SW_DET);
++	intr_ids->mbhc_btn_press_intr = regmap_irq_get_virq(wcd939x->irq_chip,
++							    WCD939X_IRQ_MBHC_BUTTON_PRESS_DET);
++	intr_ids->mbhc_btn_release_intr = regmap_irq_get_virq(wcd939x->irq_chip,
++							      WCD939X_IRQ_MBHC_BUTTON_RELEASE_DET);
++	intr_ids->mbhc_hs_ins_intr = regmap_irq_get_virq(wcd939x->irq_chip,
++							 WCD939X_IRQ_MBHC_ELECT_INS_REM_LEG_DET);
++	intr_ids->mbhc_hs_rem_intr = regmap_irq_get_virq(wcd939x->irq_chip,
++							 WCD939X_IRQ_MBHC_ELECT_INS_REM_DET);
++	intr_ids->hph_left_ocp = regmap_irq_get_virq(wcd939x->irq_chip,
++						     WCD939X_IRQ_HPHL_OCP_INT);
++	intr_ids->hph_right_ocp = regmap_irq_get_virq(wcd939x->irq_chip,
++						      WCD939X_IRQ_HPHR_OCP_INT);
++
++	wcd939x->wcd_mbhc = wcd_mbhc_init(component, &mbhc_cb, intr_ids, wcd_mbhc_fields, true);
++	if (IS_ERR(wcd939x->wcd_mbhc))
++		return PTR_ERR(wcd939x->wcd_mbhc);
++
++	snd_soc_add_component_controls(component, impedance_detect_controls,
++				       ARRAY_SIZE(impedance_detect_controls));
++	snd_soc_add_component_controls(component, hph_type_detect_controls,
++				       ARRAY_SIZE(hph_type_detect_controls));
++
++	return 0;
++}
++
++static void wcd939x_mbhc_deinit(struct snd_soc_component *component)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	wcd_mbhc_deinit(wcd939x->wcd_mbhc);
++}
++
++/* END MBHC */
++
++static const struct snd_kcontrol_new wcd939x_snd_controls[] = {
++	/* RX Path */
++	SOC_SINGLE_EXT("HPHL_COMP Switch", WCD939X_COMP_L, 0, 1, 0,
++		       wcd939x_get_compander, wcd939x_set_compander),
++	SOC_SINGLE_EXT("HPHR_COMP Switch", WCD939X_COMP_R, 1, 1, 0,
++		       wcd939x_get_compander, wcd939x_set_compander),
++	SOC_SINGLE_EXT("HPHL Switch", WCD939X_HPH_L, 0, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("HPHR Switch", WCD939X_HPH_R, 0, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("CLSH Switch", WCD939X_CLSH, 0, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("LO Switch", WCD939X_LO, 0, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("DSD_L Switch", WCD939X_DSD_L, 0, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("DSD_R Switch", WCD939X_DSD_R, 0, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_TLV("HPHL Volume", WCD939X_HPH_L_EN, 0, 20, 1, line_gain),
++	SOC_SINGLE_TLV("HPHR Volume", WCD939X_HPH_R_EN, 0, 20, 1, line_gain),
++	SOC_SINGLE_EXT("LDOH Enable Switch", SND_SOC_NOPM, 0, 1, 0,
++		       wcd939x_ldoh_get, wcd939x_ldoh_put),
++
++	/* TX Path */
++	SOC_SINGLE_EXT("ADC1 Switch", WCD939X_ADC1, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("ADC2 Switch", WCD939X_ADC2, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("ADC3 Switch", WCD939X_ADC3, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("ADC4 Switch", WCD939X_ADC4, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("DMIC0 Switch", WCD939X_DMIC0, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("DMIC1 Switch", WCD939X_DMIC1, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("MBHC Switch", WCD939X_MBHC, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("DMIC2 Switch", WCD939X_DMIC2, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("DMIC3 Switch", WCD939X_DMIC3, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("DMIC4 Switch", WCD939X_DMIC4, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("DMIC5 Switch", WCD939X_DMIC5, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("DMIC6 Switch", WCD939X_DMIC6, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_EXT("DMIC7 Switch", WCD939X_DMIC7, 1, 1, 0,
++		       wcd939x_get_swr_port, wcd939x_set_swr_port),
++	SOC_SINGLE_TLV("ADC1 Volume", WCD939X_ANA_TX_CH1, 0, 20, 0,
++		       analog_gain),
++	SOC_SINGLE_TLV("ADC2 Volume", WCD939X_ANA_TX_CH2, 0, 20, 0,
++		       analog_gain),
++	SOC_SINGLE_TLV("ADC3 Volume", WCD939X_ANA_TX_CH3, 0, 20, 0,
++		       analog_gain),
++	SOC_SINGLE_TLV("ADC4 Volume", WCD939X_ANA_TX_CH4, 0, 20, 0,
++		       analog_gain),
++};
++
++static const struct snd_soc_dapm_widget wcd939x_dapm_widgets[] = {
++	/*input widgets*/
++	SND_SOC_DAPM_INPUT("AMIC1"),
++	SND_SOC_DAPM_INPUT("AMIC2"),
++	SND_SOC_DAPM_INPUT("AMIC3"),
++	SND_SOC_DAPM_INPUT("AMIC4"),
++	SND_SOC_DAPM_INPUT("AMIC5"),
++
++	SND_SOC_DAPM_MIC("Analog Mic1", NULL),
++	SND_SOC_DAPM_MIC("Analog Mic2", NULL),
++	SND_SOC_DAPM_MIC("Analog Mic3", NULL),
++	SND_SOC_DAPM_MIC("Analog Mic4", NULL),
++	SND_SOC_DAPM_MIC("Analog Mic5", NULL),
++
++	/* TX widgets */
++	SND_SOC_DAPM_ADC_E("ADC1", NULL, SND_SOC_NOPM, 0, 0,
++			   wcd939x_codec_enable_adc,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_ADC_E("ADC2", NULL, SND_SOC_NOPM, 1, 0,
++			   wcd939x_codec_enable_adc,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_ADC_E("ADC3", NULL, SND_SOC_NOPM, 2, 0,
++			   wcd939x_codec_enable_adc,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_ADC_E("ADC4", NULL, SND_SOC_NOPM, 3, 0,
++			   wcd939x_codec_enable_adc,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_ADC_E("DMIC1", NULL, SND_SOC_NOPM, 0, 0,
++			   wcd939x_codec_enable_dmic,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_ADC_E("DMIC2", NULL, SND_SOC_NOPM, 1, 0,
++			   wcd939x_codec_enable_dmic,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_ADC_E("DMIC3", NULL, SND_SOC_NOPM, 2, 0,
++			   wcd939x_codec_enable_dmic,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_ADC_E("DMIC4", NULL, SND_SOC_NOPM, 3, 0,
++			   wcd939x_codec_enable_dmic,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_ADC_E("DMIC5", NULL, SND_SOC_NOPM, 4, 0,
++			   wcd939x_codec_enable_dmic,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_ADC_E("DMIC6", NULL, SND_SOC_NOPM, 5, 0,
++			   wcd939x_codec_enable_dmic,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_ADC_E("DMIC7", NULL, SND_SOC_NOPM, 6, 0,
++			   wcd939x_codec_enable_dmic,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_ADC_E("DMIC8", NULL, SND_SOC_NOPM, 7, 0,
++			   wcd939x_codec_enable_dmic,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++
++	SND_SOC_DAPM_MIXER_E("ADC1 REQ", SND_SOC_NOPM, 0, 0, NULL, 0,
++			     wcd939x_adc_enable_req,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("ADC2 REQ", SND_SOC_NOPM, 1, 0, NULL, 0,
++			     wcd939x_adc_enable_req,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("ADC3 REQ", SND_SOC_NOPM, 2, 0, NULL, 0,
++			     wcd939x_adc_enable_req,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("ADC4 REQ", SND_SOC_NOPM, 3, 0, NULL, 0,
++			     wcd939x_adc_enable_req,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++
++	SND_SOC_DAPM_MUX("ADC1 MUX", SND_SOC_NOPM, 0, 0, &tx_adc1_mux),
++	SND_SOC_DAPM_MUX("ADC2 MUX", SND_SOC_NOPM, 0, 0, &tx_adc2_mux),
++	SND_SOC_DAPM_MUX("ADC3 MUX", SND_SOC_NOPM, 0, 0, &tx_adc3_mux),
++	SND_SOC_DAPM_MUX("ADC4 MUX", SND_SOC_NOPM, 0, 0, &tx_adc4_mux),
++
++	/* tx mixers */
++	SND_SOC_DAPM_MIXER_E("ADC1_MIXER", SND_SOC_NOPM, 0, 0,
++			     adc1_switch, ARRAY_SIZE(adc1_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("ADC2_MIXER", SND_SOC_NOPM, 0, 0,
++			     adc2_switch, ARRAY_SIZE(adc2_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("ADC3_MIXER", SND_SOC_NOPM, 0, 0,
++			     adc3_switch, ARRAY_SIZE(adc3_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("ADC4_MIXER", SND_SOC_NOPM, 0, 0,
++			     adc4_switch, ARRAY_SIZE(adc4_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("DMIC1_MIXER", SND_SOC_NOPM, 0, 0,
++			     dmic1_switch, ARRAY_SIZE(dmic1_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("DMIC2_MIXER", SND_SOC_NOPM, 0, 0,
++			     dmic2_switch, ARRAY_SIZE(dmic2_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("DMIC3_MIXER", SND_SOC_NOPM, 0, 0,
++			     dmic3_switch, ARRAY_SIZE(dmic3_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("DMIC4_MIXER", SND_SOC_NOPM, 0, 0,
++			     dmic4_switch, ARRAY_SIZE(dmic4_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("DMIC5_MIXER", SND_SOC_NOPM, 0, 0,
++			     dmic5_switch, ARRAY_SIZE(dmic5_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("DMIC6_MIXER", SND_SOC_NOPM, 0, 0,
++			     dmic6_switch, ARRAY_SIZE(dmic6_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("DMIC7_MIXER", SND_SOC_NOPM, 0, 0,
++			     dmic7_switch, ARRAY_SIZE(dmic7_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_MIXER_E("DMIC8_MIXER", SND_SOC_NOPM, 0, 0,
++			     dmic8_switch, ARRAY_SIZE(dmic8_switch), wcd939x_tx_swr_ctrl,
++			     SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
++
++	/* micbias widgets */
++	SND_SOC_DAPM_SUPPLY("MIC BIAS1", SND_SOC_NOPM, MIC_BIAS_1, 0,
++			    wcd939x_codec_enable_micbias,
++			    SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			    SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_SUPPLY("MIC BIAS2", SND_SOC_NOPM, MIC_BIAS_2, 0,
++			    wcd939x_codec_enable_micbias,
++			    SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			    SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_SUPPLY("MIC BIAS3", SND_SOC_NOPM, MIC_BIAS_3, 0,
++			    wcd939x_codec_enable_micbias,
++			    SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			    SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_SUPPLY("MIC BIAS4", SND_SOC_NOPM, MIC_BIAS_4, 0,
++			    wcd939x_codec_enable_micbias,
++			    SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			    SND_SOC_DAPM_POST_PMD),
++
++	/* micbias pull up widgets */
++	SND_SOC_DAPM_SUPPLY("VA MIC BIAS1", SND_SOC_NOPM, MIC_BIAS_1, 0,
++			    wcd939x_codec_enable_micbias_pullup,
++			    SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			    SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_SUPPLY("VA MIC BIAS2", SND_SOC_NOPM, MIC_BIAS_2, 0,
++			    wcd939x_codec_enable_micbias_pullup,
++			    SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			    SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_SUPPLY("VA MIC BIAS3", SND_SOC_NOPM, MIC_BIAS_3, 0,
++			    wcd939x_codec_enable_micbias_pullup,
++			    SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			    SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_SUPPLY("VA MIC BIAS4", SND_SOC_NOPM, MIC_BIAS_4, 0,
++			    wcd939x_codec_enable_micbias_pullup,
++			    SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			    SND_SOC_DAPM_POST_PMD),
++
++	/* output widgets tx */
++	SND_SOC_DAPM_OUTPUT("ADC1_OUTPUT"),
++	SND_SOC_DAPM_OUTPUT("ADC2_OUTPUT"),
++	SND_SOC_DAPM_OUTPUT("ADC3_OUTPUT"),
++	SND_SOC_DAPM_OUTPUT("ADC4_OUTPUT"),
++	SND_SOC_DAPM_OUTPUT("DMIC1_OUTPUT"),
++	SND_SOC_DAPM_OUTPUT("DMIC2_OUTPUT"),
++	SND_SOC_DAPM_OUTPUT("DMIC3_OUTPUT"),
++	SND_SOC_DAPM_OUTPUT("DMIC4_OUTPUT"),
++	SND_SOC_DAPM_OUTPUT("DMIC5_OUTPUT"),
++	SND_SOC_DAPM_OUTPUT("DMIC6_OUTPUT"),
++	SND_SOC_DAPM_OUTPUT("DMIC7_OUTPUT"),
++	SND_SOC_DAPM_OUTPUT("DMIC8_OUTPUT"),
++
++	SND_SOC_DAPM_INPUT("IN1_HPHL"),
++	SND_SOC_DAPM_INPUT("IN2_HPHR"),
++	SND_SOC_DAPM_INPUT("IN3_EAR"),
++
++	/* rx widgets */
++	SND_SOC_DAPM_PGA_E("EAR PGA", WCD939X_ANA_EAR, 7, 0, NULL, 0,
++			   wcd939x_codec_enable_ear_pa,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			   SND_SOC_DAPM_PRE_PMD | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_PGA_E("HPHL PGA", WCD939X_ANA_HPH, 7, 0, NULL, 0,
++			   wcd939x_codec_enable_hphl_pa,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			   SND_SOC_DAPM_PRE_PMD | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_PGA_E("HPHR PGA", WCD939X_ANA_HPH, 6, 0, NULL, 0,
++			   wcd939x_codec_enable_hphr_pa,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			   SND_SOC_DAPM_PRE_PMD | SND_SOC_DAPM_POST_PMD),
++
++	SND_SOC_DAPM_DAC_E("RDAC1", NULL, SND_SOC_NOPM, 0, 0,
++			   wcd939x_codec_hphl_dac_event,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			   SND_SOC_DAPM_PRE_PMD | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_DAC_E("RDAC2", NULL, SND_SOC_NOPM, 0, 0,
++			   wcd939x_codec_hphr_dac_event,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			   SND_SOC_DAPM_PRE_PMD | SND_SOC_DAPM_POST_PMD),
++	SND_SOC_DAPM_DAC_E("RDAC3", NULL, SND_SOC_NOPM, 0, 0,
++			   wcd939x_codec_ear_dac_event,
++			   SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			   SND_SOC_DAPM_PRE_PMD | SND_SOC_DAPM_POST_PMD),
++
++	SND_SOC_DAPM_MUX("RDAC3_MUX", SND_SOC_NOPM, 0, 0, &rx_rdac3_mux),
++
++	SND_SOC_DAPM_SUPPLY("VDD_BUCK", SND_SOC_NOPM, 0, 0, NULL, 0),
++	SND_SOC_DAPM_SUPPLY("RXCLK", SND_SOC_NOPM, 0, 0,
++			    wcd939x_codec_enable_rxclk,
++			    SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMU |
++			    SND_SOC_DAPM_POST_PMD),
++
++	SND_SOC_DAPM_SUPPLY_S("CLS_H_PORT", 1, SND_SOC_NOPM, 0, 0, NULL, 0),
++
++	SND_SOC_DAPM_MIXER_E("RX1", SND_SOC_NOPM, 0, 0, NULL, 0, NULL, 0),
++	SND_SOC_DAPM_MIXER_E("RX2", SND_SOC_NOPM, 0, 0, NULL, 0, NULL, 0),
++	SND_SOC_DAPM_MIXER_E("RX3", SND_SOC_NOPM, 0, 0, NULL, 0, NULL, 0),
++
++	/* rx mixer widgets */
++	SND_SOC_DAPM_MIXER("EAR_RDAC", SND_SOC_NOPM, 0, 0,
++			   ear_rdac_switch, ARRAY_SIZE(ear_rdac_switch)),
++	SND_SOC_DAPM_MIXER("HPHL_RDAC", SND_SOC_NOPM, 0, 0,
++			   hphl_rdac_switch, ARRAY_SIZE(hphl_rdac_switch)),
++	SND_SOC_DAPM_MIXER("HPHR_RDAC", SND_SOC_NOPM, 0, 0,
++			   hphr_rdac_switch, ARRAY_SIZE(hphr_rdac_switch)),
++
++	/* output widgets rx */
++	SND_SOC_DAPM_OUTPUT("EAR"),
++	SND_SOC_DAPM_OUTPUT("HPHL"),
++	SND_SOC_DAPM_OUTPUT("HPHR"),
++};
++
++static const struct snd_soc_dapm_route wcd939x_audio_map[] = {
++	/* TX Path */
++	{"ADC1_OUTPUT", NULL, "ADC1_MIXER"},
++	{"ADC1_MIXER", "Switch", "ADC1 REQ"},
++	{"ADC1 REQ", NULL, "ADC1"},
++	{"ADC1", NULL, "ADC1 MUX"},
++	{"ADC1 MUX", "CH1_AMIC1", "AMIC1"},
++	{"ADC1 MUX", "CH1_AMIC2", "AMIC2"},
++	{"ADC1 MUX", "CH1_AMIC3", "AMIC3"},
++	{"ADC1 MUX", "CH1_AMIC4", "AMIC4"},
++	{"ADC1 MUX", "CH1_AMIC5", "AMIC5"},
++
++	{"ADC2_OUTPUT", NULL, "ADC2_MIXER"},
++	{"ADC2_MIXER", "Switch", "ADC2 REQ"},
++	{"ADC2 REQ", NULL, "ADC2"},
++	{"ADC2", NULL, "ADC2 MUX"},
++	{"ADC2 MUX", "CH2_AMIC1", "AMIC1"},
++	{"ADC2 MUX", "CH2_AMIC2", "AMIC2"},
++	{"ADC2 MUX", "CH2_AMIC3", "AMIC3"},
++	{"ADC2 MUX", "CH2_AMIC4", "AMIC4"},
++	{"ADC2 MUX", "CH2_AMIC5", "AMIC5"},
++
++	{"ADC3_OUTPUT", NULL, "ADC3_MIXER"},
++	{"ADC3_MIXER", "Switch", "ADC3 REQ"},
++	{"ADC3 REQ", NULL, "ADC3"},
++	{"ADC3", NULL, "ADC3 MUX"},
++	{"ADC3 MUX", "CH3_AMIC1", "AMIC1"},
++	{"ADC3 MUX", "CH3_AMIC3", "AMIC3"},
++	{"ADC3 MUX", "CH3_AMIC4", "AMIC4"},
++	{"ADC3 MUX", "CH3_AMIC5", "AMIC5"},
++
++	{"ADC4_OUTPUT", NULL, "ADC4_MIXER"},
++	{"ADC4_MIXER", "Switch", "ADC4 REQ"},
++	{"ADC4 REQ", NULL, "ADC4"},
++	{"ADC4", NULL, "ADC4 MUX"},
++	{"ADC4 MUX", "CH4_AMIC1", "AMIC1"},
++	{"ADC4 MUX", "CH4_AMIC3", "AMIC3"},
++	{"ADC4 MUX", "CH4_AMIC4", "AMIC4"},
++	{"ADC4 MUX", "CH4_AMIC5", "AMIC5"},
++
++	{"DMIC1_OUTPUT", NULL, "DMIC1_MIXER"},
++	{"DMIC1_MIXER", "Switch", "DMIC1"},
++
++	{"DMIC2_OUTPUT", NULL, "DMIC2_MIXER"},
++	{"DMIC2_MIXER", "Switch", "DMIC2"},
++
++	{"DMIC3_OUTPUT", NULL, "DMIC3_MIXER"},
++	{"DMIC3_MIXER", "Switch", "DMIC3"},
++
++	{"DMIC4_OUTPUT", NULL, "DMIC4_MIXER"},
++	{"DMIC4_MIXER", "Switch", "DMIC4"},
++
++	{"DMIC5_OUTPUT", NULL, "DMIC5_MIXER"},
++	{"DMIC5_MIXER", "Switch", "DMIC5"},
++
++	{"DMIC6_OUTPUT", NULL, "DMIC6_MIXER"},
++	{"DMIC6_MIXER", "Switch", "DMIC6"},
++
++	{"DMIC7_OUTPUT", NULL, "DMIC7_MIXER"},
++	{"DMIC7_MIXER", "Switch", "DMIC7"},
++
++	{"DMIC8_OUTPUT", NULL, "DMIC8_MIXER"},
++	{"DMIC8_MIXER", "Switch", "DMIC8"},
++
++	/* RX Path */
++	{"IN1_HPHL", NULL, "VDD_BUCK"},
++	{"IN1_HPHL", NULL, "CLS_H_PORT"},
++
++	{"RX1", NULL, "IN1_HPHL"},
++	{"RX1", NULL, "RXCLK"},
++	{"RDAC1", NULL, "RX1"},
++	{"HPHL_RDAC", "Switch", "RDAC1"},
++	{"HPHL PGA", NULL, "HPHL_RDAC"},
++	{"HPHL", NULL, "HPHL PGA"},
++
++	{"IN2_HPHR", NULL, "VDD_BUCK"},
++	{"IN2_HPHR", NULL, "CLS_H_PORT"},
++	{"RX2", NULL, "IN2_HPHR"},
++	{"RDAC2", NULL, "RX2"},
++	{"RX2", NULL, "RXCLK"},
++	{"HPHR_RDAC", "Switch", "RDAC2"},
++	{"HPHR PGA", NULL, "HPHR_RDAC"},
++	{"HPHR", NULL, "HPHR PGA"},
++
++	{"IN3_EAR", NULL, "VDD_BUCK"},
++	{"RX3", NULL, "IN3_EAR"},
++	{"RX3", NULL, "RXCLK"},
++
++	{"RDAC3_MUX", "RX3", "RX3"},
++	{"RDAC3_MUX", "RX1", "RX1"},
++	{"RDAC3", NULL, "RDAC3_MUX"},
++	{"EAR_RDAC", "Switch", "RDAC3"},
++	{"EAR PGA", NULL, "EAR_RDAC"},
++	{"EAR", NULL, "EAR PGA"},
++};
++
++static void wcd939x_set_micbias_data(struct device *dev, struct wcd939x_priv *wcd939x)
++{
++	regmap_update_bits(wcd939x->regmap, WCD939X_ANA_MICB1,
++			   WCD939X_MICB_VOUT_CTL, wcd939x->common.micb_vout[0]);
++	regmap_update_bits(wcd939x->regmap, WCD939X_ANA_MICB2,
++			   WCD939X_MICB_VOUT_CTL, wcd939x->common.micb_vout[1]);
++	regmap_update_bits(wcd939x->regmap, WCD939X_ANA_MICB3,
++			   WCD939X_MICB_VOUT_CTL, wcd939x->common.micb_vout[2]);
++	regmap_update_bits(wcd939x->regmap, WCD939X_ANA_MICB4,
++			   WCD939X_MICB_VOUT_CTL, wcd939x->common.micb_vout[3]);
++}
++
++static irqreturn_t wcd939x_wd_handle_irq(int irq, void *data)
++{
++	/*
++	 * HPHR/HPHL/EAR Watchdog interrupt threaded handler
++	 *
++	 * Watchdog interrupts are expected to be enabled when switching
++	 * on the HPHL/R and EAR RX PGA in order to make sure the interrupts
++	 * are acked by the regmap_irq handler to allow PDM sync.
++	 * We could leave those interrupts masked but we would not have
++	 * any valid way to enable/disable them without violating irq layers.
++	 *
++	 * The HPHR/HPHL/EAR Watchdog interrupts are handled
++	 * by regmap_irq, so requesting a threaded handler is the
++	 * safest way to be able to ack those interrupts without
++	 * colliding with the regmap_irq setup.
++	 */
++
++	return IRQ_HANDLED;
++}
++
++/*
++ * Setup a virtual interrupt domain to hook regmap_irq
++ * The root domain will have a single interrupt which mapping
++ * will trigger the regmap_irq handler.
++ *
++ * root:
++ *   wcd_irq_chip
++ *     [0] wcd939x_regmap_irq_chip
++ *       [0] MBHC_BUTTON_PRESS_DET
++ *       [1] MBHC_BUTTON_RELEASE_DET
++ *       ...
++ *       [16] HPHR_SURGE_DET_INT
++ *
++ * Interrupt trigger:
++ *   soundwire_interrupt_callback()
++ *   \-handle_nested_irq(0)
++ *     \- regmap_irq_thread()
++ *         \- handle_nested_irq(i)
++ */
++static const struct irq_chip wcd_irq_chip = {
++	.name = "WCD939x",
++};
++
++static int wcd_irq_chip_map(struct irq_domain *irqd, unsigned int virq,
++			    irq_hw_number_t hw)
++{
++	irq_set_chip_and_handler(virq, &wcd_irq_chip, handle_simple_irq);
++	irq_set_nested_thread(virq, 1);
++	irq_set_noprobe(virq);
++
++	return 0;
++}
++
++static const struct irq_domain_ops wcd_domain_ops = {
++	.map = wcd_irq_chip_map,
++};
++
++static int wcd939x_irq_init(struct wcd939x_priv *wcd, struct device *dev)
++{
++	wcd->virq = irq_domain_create_linear(NULL, 1, &wcd_domain_ops, NULL);
++	if (!(wcd->virq)) {
++		dev_err(dev, "%s: Failed to add IRQ domain\n", __func__);
++		return -EINVAL;
++	}
++
++	return devm_regmap_add_irq_chip(dev, wcd->regmap,
++					irq_create_mapping(wcd->virq, 0),
++					IRQF_ONESHOT, 0, &wcd939x_regmap_irq_chip,
++					&wcd->irq_chip);
++}
++
++static int wcd939x_soc_codec_probe(struct snd_soc_component *component)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++	struct sdw_slave *tx_sdw_dev = wcd939x->tx_sdw_dev;
++	struct device *dev = component->dev;
++	unsigned long time_left;
++	int ret, i;
++
++	time_left = wait_for_completion_timeout(&tx_sdw_dev->initialization_complete,
++						msecs_to_jiffies(2000));
++	if (!time_left) {
++		dev_err(dev, "soundwire device init timeout\n");
++		return -ETIMEDOUT;
++	}
++
++	snd_soc_component_init_regmap(component, wcd939x->regmap);
++
++	ret = pm_runtime_resume_and_get(dev);
++	if (ret < 0)
++		return ret;
++
++	wcd939x->variant = snd_soc_component_read_field(component,
++							WCD939X_DIGITAL_EFUSE_REG_0,
++							WCD939X_EFUSE_REG_0_WCD939X_ID);
++
++	wcd939x->clsh_info = wcd_clsh_ctrl_alloc(component, WCD939X);
++	if (IS_ERR(wcd939x->clsh_info)) {
++		pm_runtime_put(dev);
++		return PTR_ERR(wcd939x->clsh_info);
++	}
++
++	wcd939x_io_init(component);
++
++	/* Set all interrupts as edge triggered */
++	for (i = 0; i < wcd939x_regmap_irq_chip.num_regs; i++)
++		regmap_write(wcd939x->regmap,
++			     (WCD939X_DIGITAL_INTR_LEVEL_0 + i), 0);
++
++	pm_runtime_put(dev);
++
++	/* Request for watchdog interrupt */
++	wcd939x->hphr_pdm_wd_int = regmap_irq_get_virq(wcd939x->irq_chip,
++						       WCD939X_IRQ_HPHR_PDM_WD_INT);
++	wcd939x->hphl_pdm_wd_int = regmap_irq_get_virq(wcd939x->irq_chip,
++						       WCD939X_IRQ_HPHL_PDM_WD_INT);
++	wcd939x->ear_pdm_wd_int = regmap_irq_get_virq(wcd939x->irq_chip,
++						      WCD939X_IRQ_EAR_PDM_WD_INT);
++
++	ret = request_threaded_irq(wcd939x->hphr_pdm_wd_int, NULL, wcd939x_wd_handle_irq,
++				   IRQF_ONESHOT | IRQF_TRIGGER_RISING,
++				   "HPHR PDM WD INT", wcd939x);
++	if (ret) {
++		dev_err(dev, "Failed to request HPHR WD interrupt (%d)\n", ret);
++		goto err_free_clsh_ctrl;
++	}
++
++	ret = request_threaded_irq(wcd939x->hphl_pdm_wd_int, NULL, wcd939x_wd_handle_irq,
++				   IRQF_ONESHOT | IRQF_TRIGGER_RISING,
++				   "HPHL PDM WD INT", wcd939x);
++	if (ret) {
++		dev_err(dev, "Failed to request HPHL WD interrupt (%d)\n", ret);
++		goto err_free_hphr_pdm_wd_int;
++	}
++
++	ret = request_threaded_irq(wcd939x->ear_pdm_wd_int, NULL, wcd939x_wd_handle_irq,
++				   IRQF_ONESHOT | IRQF_TRIGGER_RISING,
++				   "AUX PDM WD INT", wcd939x);
++	if (ret) {
++		dev_err(dev, "Failed to request Aux WD interrupt (%d)\n", ret);
++		goto err_free_hphl_pdm_wd_int;
++	}
++
++	/* Disable watchdog interrupt for HPH and AUX */
++	disable_irq_nosync(wcd939x->hphr_pdm_wd_int);
++	disable_irq_nosync(wcd939x->hphl_pdm_wd_int);
++	disable_irq_nosync(wcd939x->ear_pdm_wd_int);
++
++	switch (wcd939x->variant) {
++	case CHIPID_WCD9390:
++		ret = snd_soc_add_component_controls(component, wcd9390_snd_controls,
++						     ARRAY_SIZE(wcd9390_snd_controls));
++		if (ret < 0) {
++			dev_err(component->dev,
++				"%s: Failed to add snd ctrls for variant: %d\n",
++				__func__, wcd939x->variant);
++			goto err_free_ear_pdm_wd_int;
++		}
++		break;
++	case CHIPID_WCD9395:
++		ret = snd_soc_add_component_controls(component, wcd9395_snd_controls,
++						     ARRAY_SIZE(wcd9395_snd_controls));
++		if (ret < 0) {
++			dev_err(component->dev,
++				"%s: Failed to add snd ctrls for variant: %d\n",
++				__func__, wcd939x->variant);
++			goto err_free_ear_pdm_wd_int;
++		}
++		break;
++	default:
++		break;
++	}
++
++	ret = wcd939x_mbhc_init(component);
++	if (ret) {
++		dev_err(component->dev,  "mbhc initialization failed\n");
++		goto err_free_ear_pdm_wd_int;
++	}
++
++	return 0;
++
++err_free_ear_pdm_wd_int:
++	free_irq(wcd939x->ear_pdm_wd_int, wcd939x);
++err_free_hphl_pdm_wd_int:
++	free_irq(wcd939x->hphl_pdm_wd_int, wcd939x);
++err_free_hphr_pdm_wd_int:
++	free_irq(wcd939x->hphr_pdm_wd_int, wcd939x);
++err_free_clsh_ctrl:
++	wcd_clsh_ctrl_free(wcd939x->clsh_info);
++
++	return ret;
++}
++
++static void wcd939x_soc_codec_remove(struct snd_soc_component *component)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	wcd939x_mbhc_deinit(component);
++
++	free_irq(wcd939x->ear_pdm_wd_int, wcd939x);
++	free_irq(wcd939x->hphl_pdm_wd_int, wcd939x);
++	free_irq(wcd939x->hphr_pdm_wd_int, wcd939x);
++
++	wcd_clsh_ctrl_free(wcd939x->clsh_info);
++}
++
++static int wcd939x_codec_set_jack(struct snd_soc_component *comp,
++				  struct snd_soc_jack *jack, void *data)
++{
++	struct wcd939x_priv *wcd = dev_get_drvdata(comp->dev);
++
++	if (jack)
++		return wcd_mbhc_start(wcd->wcd_mbhc, &wcd->mbhc_cfg, jack);
++
++	wcd_mbhc_stop(wcd->wcd_mbhc);
++
++	return 0;
++}
++
++static const struct snd_soc_component_driver soc_codec_dev_wcd939x = {
++	.name = "wcd939x_codec",
++	.probe = wcd939x_soc_codec_probe,
++	.remove = wcd939x_soc_codec_remove,
++	.controls = wcd939x_snd_controls,
++	.num_controls = ARRAY_SIZE(wcd939x_snd_controls),
++	.dapm_widgets = wcd939x_dapm_widgets,
++	.num_dapm_widgets = ARRAY_SIZE(wcd939x_dapm_widgets),
++	.dapm_routes = wcd939x_audio_map,
++	.num_dapm_routes = ARRAY_SIZE(wcd939x_audio_map),
++	.set_jack = wcd939x_codec_set_jack,
++	.endianness = 1,
++};
++
++#if IS_ENABLED(CONFIG_TYPEC)
++/* Get USB-C plug orientation to provide swap event for MBHC */
++static int wcd939x_typec_switch_set(struct typec_switch_dev *sw,
++				    enum typec_orientation orientation)
++{
++	struct wcd939x_priv *wcd939x = typec_switch_get_drvdata(sw);
++
++	wcd939x->typec_orientation = orientation;
++
++	return 0;
++}
++
++static int wcd939x_typec_mux_set(struct typec_mux_dev *mux,
++				 struct typec_mux_state *state)
++{
++	struct wcd939x_priv *wcd939x = typec_mux_get_drvdata(mux);
++	unsigned int previous_mode = wcd939x->typec_mode;
++
++	if (!wcd939x->wcd_mbhc)
++		return -EINVAL;
++
++	if (wcd939x->typec_mode != state->mode) {
++		wcd939x->typec_mode = state->mode;
++
++		if (wcd939x->typec_mode == TYPEC_MODE_AUDIO)
++			return wcd_mbhc_typec_report_plug(wcd939x->wcd_mbhc);
++		else if (previous_mode == TYPEC_MODE_AUDIO)
++			return wcd_mbhc_typec_report_unplug(wcd939x->wcd_mbhc);
++	}
++
++	return 0;
++}
++#endif /* CONFIG_TYPEC */
++
++#if IS_ENABLED(CONFIG_TYPEC)
++static bool wcd939x_swap_gnd_mic(struct snd_soc_component *component)
++{
++	struct wcd939x_priv *wcd939x = snd_soc_component_get_drvdata(component);
++
++	if (!wcd939x->typec_analog_mux || !wcd939x->typec_switch)
++		return false;
++
++	/* Report inversion via Type Switch of USBSS */
++	typec_switch_set(wcd939x->typec_switch,
++			 wcd939x->typec_orientation == TYPEC_ORIENTATION_REVERSE ?
++				TYPEC_ORIENTATION_NORMAL : TYPEC_ORIENTATION_REVERSE);
++
++	return true;
++}
++#endif /* CONFIG_TYPEC */
++
++static int wcd939x_populate_dt_data(struct wcd939x_priv *wcd939x, struct device *dev)
++{
++	struct wcd_mbhc_config *cfg = &wcd939x->mbhc_cfg;
++#if IS_ENABLED(CONFIG_TYPEC)
++	struct device_node *np;
++#endif /* CONFIG_TYPEC */
++	int ret;
++
++	wcd939x->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_LOW);
++	if (IS_ERR(wcd939x->reset_gpio))
++		return dev_err_probe(dev, PTR_ERR(wcd939x->reset_gpio),
++				     "Failed to get reset gpio\n");
++
++	ret = devm_regulator_bulk_get_enable(dev, ARRAY_SIZE(wcd939x_supplies),
++					     wcd939x_supplies);
++	if (ret)
++		return dev_err_probe(dev, ret, "Failed to get and enable supplies\n");
++
++	ret = wcd_dt_parse_micbias_info(&wcd939x->common);
++	if (ret)
++		return dev_err_probe(dev, ret, "Failed to get micbias\n");
++
++	cfg->mbhc_micbias = MIC_BIAS_2;
++	cfg->anc_micbias = MIC_BIAS_2;
++	cfg->v_hs_max = WCD_MBHC_HS_V_MAX;
++	cfg->num_btn = WCD939X_MBHC_MAX_BUTTONS;
++	cfg->micb_mv = wcd939x->common.micb_mv[1];
++	cfg->linein_th = 5000;
++	cfg->hs_thr = 1700;
++	cfg->hph_thr = 50;
++
++	wcd_dt_parse_mbhc_data(dev, cfg);
++
++#if IS_ENABLED(CONFIG_TYPEC)
++	/*
++	 * Is node has a port and a valid remote endpoint
++	 * consider HP lines are connected to the USBSS part
++	 */
++	np = of_graph_get_remote_node(dev->of_node, 0, 0);
++	if (np) {
++		wcd939x->typec_analog_mux = true;
++		cfg->typec_analog_mux = true;
++		cfg->swap_gnd_mic = wcd939x_swap_gnd_mic;
++	}
++#endif /* CONFIG_TYPEC */
++
++	return 0;
++}
++
++static int wcd939x_reset(struct wcd939x_priv *wcd939x)
++{
++	gpiod_set_value(wcd939x->reset_gpio, 1);
++	/* 20us sleep required after pulling the reset gpio to LOW */
++	usleep_range(20, 30);
++	gpiod_set_value(wcd939x->reset_gpio, 0);
++	/* 20us sleep required after pulling the reset gpio to HIGH */
++	usleep_range(20, 30);
++
++	return 0;
++}
++
++static int wcd939x_codec_hw_params(struct snd_pcm_substream *substream,
++				   struct snd_pcm_hw_params *params,
++				struct snd_soc_dai *dai)
++{
++	struct wcd939x_priv *wcd939x = dev_get_drvdata(dai->dev);
++	struct wcd939x_sdw_priv *wcd = wcd939x->sdw_priv[dai->id];
++
++	return wcd939x_sdw_hw_params(wcd, substream, params, dai);
++}
++
++static int wcd939x_codec_free(struct snd_pcm_substream *substream,
++			      struct snd_soc_dai *dai)
++{
++	struct wcd939x_priv *wcd939x = dev_get_drvdata(dai->dev);
++	struct wcd939x_sdw_priv *wcd = wcd939x->sdw_priv[dai->id];
++
++	return wcd939x_sdw_free(wcd, substream, dai);
++}
++
++static int wcd939x_codec_set_sdw_stream(struct snd_soc_dai *dai,
++					void *stream, int direction)
++{
++	struct wcd939x_priv *wcd939x = dev_get_drvdata(dai->dev);
++	struct wcd939x_sdw_priv *wcd = wcd939x->sdw_priv[dai->id];
++
++	return wcd939x_sdw_set_sdw_stream(wcd, dai, stream, direction);
++}
++
++static const struct snd_soc_dai_ops wcd939x_sdw_dai_ops = {
++	.hw_params = wcd939x_codec_hw_params,
++	.hw_free = wcd939x_codec_free,
++	.set_stream = wcd939x_codec_set_sdw_stream,
++};
++
++static struct snd_soc_dai_driver wcd939x_dais[] = {
++	[0] = {
++		.name = "wcd939x-sdw-rx",
++		.playback = {
++			.stream_name = "WCD AIF1 Playback",
++			.rates = WCD939X_RATES_MASK | WCD939X_FRAC_RATES_MASK,
++			.formats = WCD939X_FORMATS,
++			.rate_max = 384000,
++			.rate_min = 8000,
++			.channels_min = 1,
++			.channels_max = 2,
++		},
++		.ops = &wcd939x_sdw_dai_ops,
++	},
++	[1] = {
++		.name = "wcd939x-sdw-tx",
++		.capture = {
++			.stream_name = "WCD AIF1 Capture",
++			.rates = WCD939X_RATES_MASK | WCD939X_FRAC_RATES_MASK,
++			.formats = WCD939X_FORMATS,
++			.rate_min = 8000,
++			.rate_max = 384000,
++			.channels_min = 1,
++			.channels_max = 4,
++		},
++		.ops = &wcd939x_sdw_dai_ops,
++	},
++};
++
++static int wcd939x_bind(struct device *dev)
++{
++	struct wcd939x_priv *wcd939x = dev_get_drvdata(dev);
++	unsigned int version, id1, status1;
++	int ret;
++
++#if IS_ENABLED(CONFIG_TYPEC)
++	/*
++	 * Get USBSS type-c switch to send gnd/mic swap events
++	 * typec_switch is fetched now to avoid a probe deadlock since
++	 * the USBSS depends on the typec_mux register in wcd939x_probe()
++	 */
++	if (wcd939x->typec_analog_mux) {
++		wcd939x->typec_switch = fwnode_typec_switch_get(dev->fwnode);
++		if (IS_ERR(wcd939x->typec_switch))
++			return dev_err_probe(dev, PTR_ERR(wcd939x->typec_switch),
++					     "failed to acquire orientation-switch\n");
++	}
++#endif /* CONFIG_TYPEC */
++
++	ret = component_bind_all(dev, wcd939x);
++	if (ret) {
++		dev_err(dev, "%s: Slave bind failed, ret = %d\n",
++			__func__, ret);
++		goto err_put_typec_switch;
++	}
++
++	wcd939x->rxdev = of_sdw_find_device_by_node(wcd939x->rxnode);
++	if (!wcd939x->rxdev) {
++		dev_err(dev, "could not find slave with matching of node\n");
++		ret = -EINVAL;
++		goto err_unbind;
++	}
++	wcd939x->sdw_priv[AIF1_PB] = dev_get_drvdata(wcd939x->rxdev);
++	wcd939x->sdw_priv[AIF1_PB]->wcd939x = wcd939x;
++
++	wcd939x->txdev = of_sdw_find_device_by_node(wcd939x->txnode);
++	if (!wcd939x->txdev) {
++		dev_err(dev, "could not find txslave with matching of node\n");
++		ret = -EINVAL;
++		goto err_put_rxdev;
++	}
++	wcd939x->sdw_priv[AIF1_CAP] = dev_get_drvdata(wcd939x->txdev);
++	wcd939x->sdw_priv[AIF1_CAP]->wcd939x = wcd939x;
++	wcd939x->tx_sdw_dev = dev_to_sdw_dev(wcd939x->txdev);
++
++	/*
++	 * As TX is main CSR reg interface, which should not be suspended first.
++	 * explicitly add the dependency link
++	 */
++	if (!device_link_add(wcd939x->rxdev, wcd939x->txdev, DL_FLAG_STATELESS |
++			    DL_FLAG_PM_RUNTIME)) {
++		dev_err(dev, "could not devlink tx and rx\n");
++		ret = -EINVAL;
++		goto err_put_txdev;
++	}
++
++	if (!device_link_add(dev, wcd939x->txdev, DL_FLAG_STATELESS |
++					DL_FLAG_PM_RUNTIME)) {
++		dev_err(dev, "could not devlink wcd and tx\n");
++		ret = -EINVAL;
++		goto err_remove_rxtx_link;
++	}
++
++	if (!device_link_add(dev, wcd939x->rxdev, DL_FLAG_STATELESS |
++					DL_FLAG_PM_RUNTIME)) {
++		dev_err(dev, "could not devlink wcd and rx\n");
++		ret = -EINVAL;
++		goto err_remove_tx_link;
++	}
++
++	/* Get regmap from TX SoundWire device */
++	wcd939x->regmap = wcd939x->sdw_priv[AIF1_CAP]->regmap;
++	if (!wcd939x->regmap) {
++		dev_err(dev, "could not get TX device regmap\n");
++		ret = -ENODEV;
++		goto err_remove_rx_link;
++	}
++
++	ret = wcd939x_irq_init(wcd939x, dev);
++	if (ret) {
++		dev_err(dev, "%s: IRQ init failed: %d\n", __func__, ret);
++		goto err_remove_rx_link;
++	}
++
++	wcd939x->sdw_priv[AIF1_PB]->slave_irq = wcd939x->virq;
++	wcd939x->sdw_priv[AIF1_CAP]->slave_irq = wcd939x->virq;
++
++	wcd939x_set_micbias_data(dev, wcd939x);
++
++	/* Check WCD9395 version */
++	regmap_read(wcd939x->regmap, WCD939X_DIGITAL_CHIP_ID1, &id1);
++	regmap_read(wcd939x->regmap, WCD939X_EAR_STATUS_REG_1, &status1);
++
++	if (id1 == CHIPID_WCD939X_VER_MAJOR_1)
++		version = ((status1 & CHIPID_WCD939X_VER_MINOR_1) ? WCD939X_VERSION_1_1 : WCD939X_VERSION_1_0);
++	else
++		version = WCD939X_VERSION_2_0;
++
++	dev_dbg(dev, "wcd939x version: %s\n", version_to_str(version));
++
++	ret = snd_soc_register_component(dev, &soc_codec_dev_wcd939x,
++					 wcd939x_dais, ARRAY_SIZE(wcd939x_dais));
++	if (ret) {
++		dev_err(dev, "%s: Codec registration failed\n",
++			__func__);
++		goto err_remove_rx_link;
++	}
++
++	return 0;
++
++err_remove_rx_link:
++	device_link_remove(dev, wcd939x->rxdev);
++err_remove_tx_link:
++	device_link_remove(dev, wcd939x->txdev);
++err_remove_rxtx_link:
++	device_link_remove(wcd939x->rxdev, wcd939x->txdev);
++err_put_txdev:
++	put_device(wcd939x->txdev);
++err_put_rxdev:
++	put_device(wcd939x->rxdev);
++err_unbind:
++	component_unbind_all(dev, wcd939x);
++err_put_typec_switch:
++#if IS_ENABLED(CONFIG_TYPEC)
++	if (wcd939x->typec_analog_mux)
++		typec_switch_put(wcd939x->typec_switch);
++#endif /* CONFIG_TYPEC */
++
++	return ret;
++}
++
++static void wcd939x_unbind(struct device *dev)
++{
++	struct wcd939x_priv *wcd939x = dev_get_drvdata(dev);
++
++	snd_soc_unregister_component(dev);
++	device_link_remove(dev, wcd939x->txdev);
++	device_link_remove(dev, wcd939x->rxdev);
++	device_link_remove(wcd939x->rxdev, wcd939x->txdev);
++	put_device(wcd939x->txdev);
++	put_device(wcd939x->rxdev);
++	component_unbind_all(dev, wcd939x);
++}
++
++static const struct component_master_ops wcd939x_comp_ops = {
++	.bind   = wcd939x_bind,
++	.unbind = wcd939x_unbind,
++};
++
++static void __maybe_unused wcd939x_typec_mux_unregister(void *data)
++{
++	struct typec_mux_dev *typec_mux = data;
++
++	typec_mux_unregister(typec_mux);
++}
++
++static void __maybe_unused wcd939x_typec_switch_unregister(void *data)
++{
++	struct typec_switch_dev *typec_sw = data;
++
++	typec_switch_unregister(typec_sw);
++}
++
++static int wcd939x_add_typec(struct wcd939x_priv *wcd939x, struct device *dev)
++{
++#if IS_ENABLED(CONFIG_TYPEC)
++	int ret;
++	struct typec_mux_dev *typec_mux;
++	struct typec_switch_dev *typec_sw;
++	struct typec_mux_desc mux_desc = {
++		.drvdata = wcd939x,
++		.fwnode = dev_fwnode(dev),
++		.set = wcd939x_typec_mux_set,
++	};
++	struct typec_switch_desc sw_desc = {
++		.drvdata = wcd939x,
++		.fwnode = dev_fwnode(dev),
++		.set = wcd939x_typec_switch_set,
++	};
++
++	/*
++	 * Is USBSS is used to mux analog lines,
++	 * register a typec mux/switch to get typec events
++	 */
++	if (!wcd939x->typec_analog_mux)
++		return 0;
++
++	typec_mux = typec_mux_register(dev, &mux_desc);
++	if (IS_ERR(typec_mux))
++		return dev_err_probe(dev, PTR_ERR(typec_mux),
++				     "failed to register typec mux\n");
++
++	ret = devm_add_action_or_reset(dev, wcd939x_typec_mux_unregister,
++				       typec_mux);
++	if (ret)
++		return ret;
++
++	typec_sw = typec_switch_register(dev, &sw_desc);
++	if (IS_ERR(typec_sw))
++		return dev_err_probe(dev, PTR_ERR(typec_sw),
++				     "failed to register typec switch\n");
++
++	ret = devm_add_action_or_reset(dev, wcd939x_typec_switch_unregister,
++				       typec_sw);
++	if (ret)
++		return ret;
++#endif
++
++	return 0;
++}
++
++static int wcd939x_add_slave_components(struct wcd939x_priv *wcd939x,
++					struct device *dev,
++					struct component_match **matchptr)
++{
++	struct device_node *np = dev->of_node;
++
++	wcd939x->rxnode = of_parse_phandle(np, "qcom,rx-device", 0);
++	if (!wcd939x->rxnode) {
++		dev_err(dev, "%s: Rx-device node not defined\n", __func__);
++		return -ENODEV;
++	}
++
++	component_match_add_release(dev, matchptr, component_release_of,
++				    component_compare_of, wcd939x->rxnode);
++
++	wcd939x->txnode = of_parse_phandle(np, "qcom,tx-device", 0);
++	if (!wcd939x->txnode) {
++		dev_err(dev, "%s: Tx-device node not defined\n", __func__);
++		return -ENODEV;
++	}
++
++	component_match_add_release(dev, matchptr, component_release_of,
++				    component_compare_of, wcd939x->txnode);
++	return 0;
++}
++
++static int wcd939x_probe(struct platform_device *pdev)
++{
++	struct component_match *match = NULL;
++	struct wcd939x_priv *wcd939x = NULL;
++	struct device *dev = &pdev->dev;
++	int ret;
++
++	wcd939x = devm_kzalloc(dev, sizeof(struct wcd939x_priv),
++			       GFP_KERNEL);
++	if (!wcd939x)
++		return -ENOMEM;
++
++	dev_set_drvdata(dev, wcd939x);
++	mutex_init(&wcd939x->micb_lock);
++	wcd939x->common.dev = dev;
++	wcd939x->common.max_bias = 4;
++
++	ret = wcd939x_populate_dt_data(wcd939x, dev);
++	if (ret) {
++		dev_err(dev, "%s: Fail to obtain platform data\n", __func__);
++		return -EINVAL;
++	}
++
++	ret = wcd939x_add_typec(wcd939x, dev);
++	if (ret)
++		return ret;
++
++	ret = wcd939x_add_slave_components(wcd939x, dev, &match);
++	if (ret)
++		return ret;
++
++	wcd939x_reset(wcd939x);
++
++	ret = component_master_add_with_match(dev, &wcd939x_comp_ops, match);
++	if (ret)
++		return ret;
++
++	pm_runtime_set_autosuspend_delay(dev, 1000);
++	pm_runtime_use_autosuspend(dev);
++	pm_runtime_mark_last_busy(dev);
++	pm_runtime_set_active(dev);
++	pm_runtime_enable(dev);
++	pm_runtime_idle(dev);
++
++	return 0;
++}
++
++static void wcd939x_remove(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++
++	component_master_del(dev, &wcd939x_comp_ops);
++
++	pm_runtime_disable(dev);
++	pm_runtime_set_suspended(dev);
++	pm_runtime_dont_use_autosuspend(dev);
++}
++
++#if defined(CONFIG_OF)
++static const struct of_device_id wcd939x_dt_match[] = {
++	{ .compatible = "qcom,wcd9390-codec" },
++	{ .compatible = "qcom,wcd9395-codec" },
++	{}
++};
++MODULE_DEVICE_TABLE(of, wcd939x_dt_match);
++#endif
++
++static struct platform_driver wcd939x_codec_driver = {
++	.probe = wcd939x_probe,
++	.remove = wcd939x_remove,
++	.driver = {
++		.name = "wcd939x_codec",
++		.of_match_table = of_match_ptr(wcd939x_dt_match),
++		.suppress_bind_attrs = true,
++	},
++};
++
++module_platform_driver(wcd939x_codec_driver);
++MODULE_DESCRIPTION("WCD939X Codec driver");
++MODULE_LICENSE("GPL");
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0501-ROCKNIX-fix-wifi-and-bt-mac.patch
+++ b/patch/kernel/archive/sm8750-7.1/0501-ROCKNIX-fix-wifi-and-bt-mac.patch
@@ -1,16 +1,16 @@
-From ef5a3345d6af58fbfa5d9b1ae2df11d6ac259498 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: spycat88 <spycat88@users.noreply.github.com>
 Date: Thu, 23 Jan 2025 15:18:25 +0000
-Subject: [PATCH] drivers: use soc serial for wifi and bluetooth
+Subject: drivers: use soc serial for wifi and bluetooth
 
 ---
- drivers/bluetooth/btqca.c             | 100 ++++++++++++++++++++++-
- drivers/soc/qcom/socinfo.c            |  10 +++
- drivers/net/wireless/ath/ath12k/mac.c | 109 ++++++++++++++++++++++++--
- 3 files changed, 209 insertions(+), 10 deletions(-)
+ drivers/bluetooth/btqca.c             | 100 +++++++++-
+ drivers/net/wireless/ath/ath12k/mac.c | 100 +++++++++-
+ drivers/soc/qcom/socinfo.c            |  10 +
+ 3 files changed, 203 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/bluetooth/btqca.c b/drivers/bluetooth/btqca.c
-index dfbbac92242a..dbe838040a67 100644
+index 111111111111..222222222222 100644
 --- a/drivers/bluetooth/btqca.c
 +++ b/drivers/bluetooth/btqca.c
 @@ -13,6 +13,78 @@
@@ -92,7 +92,7 @@ index dfbbac92242a..dbe838040a67 100644
  int qca_read_soc_version(struct hci_dev *hdev, struct qca_btsoc_version *ver,
  			 enum qca_btsoc_type soc_type)
  {
-@@ -668,7 +740,7 @@ int qca_set_bdaddr_rome(struct hci_dev *hdev, const bdaddr_t *bdaddr)
+@@ -697,7 +769,7 @@ int qca_set_bdaddr_rome(struct hci_dev *hdev, const bdaddr_t *bdaddr)
  }
  EXPORT_SYMBOL_GPL(qca_set_bdaddr_rome);
  
@@ -101,7 +101,7 @@ index dfbbac92242a..dbe838040a67 100644
  {
  	struct hci_rp_read_bd_addr *bda;
  	struct sk_buff *skb;
-@@ -739,6 +811,7 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
+@@ -773,6 +845,7 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
  	u8 rom_ver = 0;
  	u32 soc_ver;
  	u16 boardid = 0;
@@ -109,7 +109,7 @@ index dfbbac92242a..dbe838040a67 100644
  
  	bt_dev_dbg(hdev, "QCA setup on UART");
  
-@@ -918,9 +991,30 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
+@@ -1019,9 +1092,30 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
  		break;
  	}
  
@@ -142,48 +142,13 @@ index dfbbac92242a..dbe838040a67 100644
  
  	bt_dev_info(hdev, "QCA setup on UART is completed");
  
-diff --git a/drivers/soc/qcom/socinfo.c b/drivers/soc/qcom/socinfo.c
-index ecfd3da9d5e8..238f804e7fe0 100644
---- a/drivers/soc/qcom/socinfo.c
-+++ b/drivers/soc/qcom/socinfo.c
-@@ -163,6 +163,10 @@ struct smem_image_version {
- };
- #endif /* CONFIG_DEBUG_FS */
- 
-+/* Global variable to hold the serial number */
-+const char *qcom_serial_number;
-+EXPORT_SYMBOL(qcom_serial_number);
-+
- struct qcom_socinfo {
- 	struct soc_device *soc_dev;
- 	struct soc_device_attribute attr;
-@@ -795,6 +799,9 @@ static int qcom_socinfo_probe(struct platform_device *pdev)
- 							le32_to_cpu(info->serial_num));
- 		if (!qs->attr.serial_number)
- 			return -ENOMEM;
-+
-+		/* Assign the serial number to the global variable */
-+		qcom_serial_number = qs->attr.serial_number;
- 	}
- 
- 	qs->soc_dev = soc_device_register(&qs->attr);
-@@ -818,6 +825,9 @@ static void qcom_socinfo_remove(struct platform_device *pdev)
- 	soc_device_unregister(qs->soc_dev);
- 
- 	socinfo_debugfs_exit(qs);
-+
-+	/* Clear the global serial number */
-+	qcom_serial_number = NULL;
- }
- 
- static struct platform_driver qcom_socinfo_driver = {
 diff --git a/drivers/net/wireless/ath/ath12k/mac.c b/drivers/net/wireless/ath/ath12k/mac.c
-index d493ec812055..0e535e96e27b 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/wireless/ath/ath12k/mac.c
 +++ b/drivers/net/wireless/ath/ath12k/mac.c
-@@ -159,6 +159,91 @@ static const struct ieee80211_channel ath12k_6ghz_channels[] = {
- 	CHAN6G(233, 7115, 0),
- };
+@@ -172,6 +172,91 @@ static const struct ieee80211_channel ath12k_6ghz_channels[] = {
+ 	{ .bitrate = (bps), .hw_value = (code), .hw_value_short = (code_short),\
+ 	  .flags = IEEE80211_RATE_SHORT_PREAMBLE }
  
 +extern const char *qcom_serial_number;
 +
@@ -273,7 +238,7 @@ index d493ec812055..0e535e96e27b 100644
  static struct ieee80211_rate ath12k_legacy_rates[] = {
  	{ .bitrate = 10,
  	  .hw_value = ATH12K_HW_RATE_CCK_LP_1M },
-@@ -9533,6 +9618,7 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
+@@ -14486,6 +14571,7 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
  	struct ath12k_base *ab = ar->ab;
  	struct ath12k_pdev *pdev;
  	struct ath12k_pdev_cap *cap;
@@ -281,7 +246,7 @@ index d493ec812055..0e535e96e27b 100644
  	static const u32 cipher_suites[] = {
  		WLAN_CIPHER_SUITE_TKIP,
  		WLAN_CIPHER_SUITE_CCMP,
-@@ -9556,11 +9642,17 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
+@@ -14509,11 +14595,17 @@ static int ath12k_mac_hw_register(struct ath12k_hw *ah)
  		u32 ht_cap_info = 0;
  
  		pdev = ar->pdev;
@@ -303,3 +268,41 @@ index d493ec812055..0e535e96e27b 100644
  		}
  
  		ret = ath12k_mac_setup_register(ar, &ht_cap_info, hw->wiphy->bands);
+diff --git a/drivers/soc/qcom/socinfo.c b/drivers/soc/qcom/socinfo.c
+index 111111111111..222222222222 100644
+--- a/drivers/soc/qcom/socinfo.c
++++ b/drivers/soc/qcom/socinfo.c
+@@ -225,6 +225,10 @@ struct smem_image_version {
+ };
+ #endif /* CONFIG_DEBUG_FS */
+ 
++/* Global variable to hold the serial number */
++const char *qcom_serial_number;
++EXPORT_SYMBOL(qcom_serial_number);
++
+ struct qcom_socinfo {
+ 	struct soc_device *soc_dev;
+ 	struct soc_device_attribute attr;
+@@ -903,6 +907,9 @@ static int qcom_socinfo_probe(struct platform_device *pdev)
+ 							le32_to_cpu(info->serial_num));
+ 		if (!qs->attr.serial_number)
+ 			return -ENOMEM;
++
++		/* Assign the serial number to the global variable */
++		qcom_serial_number = qs->attr.serial_number;
+ 	}
+ 
+ 	qs->soc_dev = soc_device_register(&qs->attr);
+@@ -926,6 +933,9 @@ static void qcom_socinfo_remove(struct platform_device *pdev)
+ 	soc_device_unregister(qs->soc_dev);
+ 
+ 	socinfo_debugfs_exit(qs);
++
++	/* Clear the global serial number */
++	qcom_serial_number = NULL;
+ }
+ 
+ static struct platform_driver qcom_socinfo_driver = {
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0503-ROCKNIX-battery-name.patch
+++ b/patch/kernel/archive/sm8750-7.1/0503-ROCKNIX-battery-name.patch
@@ -1,0 +1,22 @@
+From 835401d628f5e5850900be90a061271fb817a73e Mon Sep 17 00:00:00 2001
+From: Philippe Simons <simons.philippe@gmail.com>
+Date: Mon, 19 Jan 2026 12:53:14 +0100
+Subject: [PATCH] power:supply: rename qcom battmgr sysfs
+
+---
+ drivers/power/supply/qcom_battmgr.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/power/supply/qcom_battmgr.c b/drivers/power/supply/qcom_battmgr.c
+index 490137a23..92a9729e9 100644
+--- a/drivers/power/supply/qcom_battmgr.c
++++ b/drivers/power/supply/qcom_battmgr.c
+@@ -921,7 +921,7 @@ static const enum power_supply_property sm8550_bat_props[] = {
+ };
+ 
+ static const struct power_supply_desc sm8550_bat_psy_desc = {
+-	.name = "qcom-battmgr-bat",
++	.name = "battery",
+ 	.type = POWER_SUPPLY_TYPE_BATTERY,
+ 	.properties = sm8550_bat_props,
+ 	.num_properties = ARRAY_SIZE(sm8550_bat_props),

--- a/patch/kernel/archive/sm8750-7.1/0503-ROCKNIX-battery-name.patch
+++ b/patch/kernel/archive/sm8750-7.1/0503-ROCKNIX-battery-name.patch
@@ -1,14 +1,14 @@
-From 835401d628f5e5850900be90a061271fb817a73e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Philippe Simons <simons.philippe@gmail.com>
 Date: Mon, 19 Jan 2026 12:53:14 +0100
-Subject: [PATCH] power:supply: rename qcom battmgr sysfs
+Subject: power:supply: rename qcom battmgr sysfs
 
 ---
  drivers/power/supply/qcom_battmgr.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/power/supply/qcom_battmgr.c b/drivers/power/supply/qcom_battmgr.c
-index 490137a23..92a9729e9 100644
+index 111111111111..222222222222 100644
 --- a/drivers/power/supply/qcom_battmgr.c
 +++ b/drivers/power/supply/qcom_battmgr.c
 @@ -921,7 +921,7 @@ static const enum power_supply_property sm8550_bat_props[] = {
@@ -20,3 +20,6 @@ index 490137a23..92a9729e9 100644
  	.type = POWER_SUPPLY_TYPE_BATTERY,
  	.properties = sm8550_bat_props,
  	.num_properties = ARRAY_SIZE(sm8550_bat_props),
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0504-Enable-64-bit-processes-to-use-compat-input-syscalls.patch
+++ b/patch/kernel/archive/sm8750-7.1/0504-Enable-64-bit-processes-to-use-compat-input-syscalls.patch
@@ -1,7 +1,7 @@
-From 897560fd00e1add63a9973c31fc437b006855680 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Tue, 8 Oct 2024 11:24:25 +0200
-Subject: [PATCH] Enable 64 bit processes to use compat input syscalls
+Subject: Enable 64 bit processes to use compat input syscalls
 
 The compat variant of input syscalls is only enabled for 32 bit
 tasks, but in some cases, such as userspace emulation, it's useful to
@@ -12,18 +12,18 @@ tasks to opt-in for compat input syscalls.
 
 Signed-off-by: Sergio Lopez <slp@redhat.com>
 ---
- drivers/input/input-compat.c |  6 +++---
+ drivers/input/input-compat.c |  4 +--
  drivers/input/input-compat.h |  2 +-
- include/linux/sched.h        |  5 +++++
- include/uapi/linux/prctl.h   |  5 +++++
- kernel/sys.c                 | 15 +++++++++++++++
- 5 files changed, 29 insertions(+), 4 deletions(-)
+ include/linux/sched.h        |  5 ++++
+ include/uapi/linux/prctl.h   |  5 ++++
+ kernel/sys.c                 | 15 ++++++++++
+ 5 files changed, 28 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/input/input-compat.c b/drivers/input/input-compat.c
-index 2ccd3eedbd6733..abb8cfb99d6cf9 100644
+index 111111111111..222222222222 100644
 --- a/drivers/input/input-compat.c
 +++ b/drivers/input/input-compat.c
-@@ -14,7 +14,7 @@
+@@ -15,7 +15,7 @@
  int input_event_from_user(const char __user *buffer,
  			  struct input_event *event)
  {
@@ -32,7 +32,7 @@ index 2ccd3eedbd6733..abb8cfb99d6cf9 100644
  		struct input_event_compat compat_event;
  
  		if (copy_from_user(&compat_event, buffer,
-@@ -38,7 +38,7 @@ int input_event_from_user(const char __user *buffer,
+@@ -39,7 +39,7 @@ int input_event_from_user(const char __user *buffer,
  int input_event_to_user(char __user *buffer,
  			const struct input_event *event)
  {
@@ -41,13 +41,8 @@ index 2ccd3eedbd6733..abb8cfb99d6cf9 100644
  		struct input_event_compat compat_event;
  
  		compat_event.sec = event->input_event_sec;
- int input_ff_effect_from_user(const char __user *buffer, size_t size,
- 			      struct ff_effect *effect)
- {
-	if (current->compat_input || in_compat_syscall()) {
- 		struct ff_effect_compat *compat_effect;
 diff --git a/drivers/input/input-compat.h b/drivers/input/input-compat.h
-index 3b7bb12b023bc6..e78c0492ce0d36 100644
+index 111111111111..222222222222 100644
 --- a/drivers/input/input-compat.h
 +++ b/drivers/input/input-compat.h
 @@ -53,7 +53,7 @@ struct ff_effect_compat {
@@ -60,12 +55,12 @@ index 3b7bb12b023bc6..e78c0492ce0d36 100644
  }
  
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 77f01ac385f7a5..01125573065ecd 100644
+index 111111111111..222222222222 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
-@@ -1535,6 +1535,11 @@ struct task_struct {
- #ifdef CONFIG_USER_EVENTS
- 	struct user_event_mm		*user_event_mm;
+@@ -1534,6 +1534,11 @@ struct task_struct {
+ 	int				kcov_saved_sequence;
+ 
  #endif
 +	/*
 +	 * Whether the task wants to use compat input syscalls even if it's
@@ -73,15 +68,15 @@ index 77f01ac385f7a5..01125573065ecd 100644
 +	 */
 +	bool compat_input;
  
- 	/*
- 	 * New fields for task_struct should be added above here, so that
+ #ifdef CONFIG_MEMCG_V1
+ 	struct mem_cgroup		*memcg_in_oom;
 diff --git a/include/uapi/linux/prctl.h b/include/uapi/linux/prctl.h
-index 961216093f11ab..86fca7d168cc66 100644
+index 111111111111..222222222222 100644
 --- a/include/uapi/linux/prctl.h
 +++ b/include/uapi/linux/prctl.h
-@@ -311,4 +311,9 @@ struct prctl_mm_map {
- # define PR_SET_MEM_MODEL_DEFAULT	0
- # define PR_SET_MEM_MODEL_TSO		1
+@@ -416,4 +416,9 @@ struct prctl_mm_map {
+ # define PR_CFI_DISABLE		_BITUL(1)
+ # define PR_CFI_LOCK		_BITUL(2)
  
 +#define PR_GET_COMPAT_INPUT    0x63494e50
 +#define PR_SET_COMPAT_INPUT    0x43494e50
@@ -90,12 +85,12 @@ index 961216093f11ab..86fca7d168cc66 100644
 +
  #endif /* _LINUX_PRCTL_H */
 diff --git a/kernel/sys.c b/kernel/sys.c
-index 2db751ce25a260..1be74620b0b659 100644
+index 111111111111..222222222222 100644
 --- a/kernel/sys.c
 +++ b/kernel/sys.c
-@@ -2768,6 +2768,21 @@ SYSCALL_DEFINE5(prctl, int, option, unsigned long, arg2, unsigned long, arg3,
- 			return -EINVAL;
- 		error = arch_prctl_mem_model_set(me, arg2);
+@@ -2907,6 +2907,21 @@ SYSCALL_DEFINE5(prctl, int, option, unsigned long, arg2, unsigned long, arg3,
+ 		if (arg3 & PR_CFI_LOCK && !(arg3 & PR_CFI_DISABLE))
+ 			error = arch_prctl_lock_branch_landing_pad_state(me);
  		break;
 +	case PR_GET_COMPAT_INPUT:
 +		if (arg2 || arg3 || arg4 || arg5)
@@ -113,5 +108,8 @@ index 2db751ce25a260..1be74620b0b659 100644
 +			return -EINVAL;
 +		break;
  	default:
+ 		trace_task_prctl_unknown(option, arg2, arg3, arg4, arg5);
  		error = -EINVAL;
- 		break;
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0504-wakeup-qcom-ipcc-remove-IRQF-NO-SUSPEND.patch
+++ b/patch/kernel/archive/sm8750-7.1/0504-wakeup-qcom-ipcc-remove-IRQF-NO-SUSPEND.patch
@@ -1,5 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sun, 9 Aug 2026 09:11:00 +0200
+Subject: wakeup qcom ipcc remove IRQF NO SUSPEND
+
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
+---
+ drivers/mailbox/qcom-ipcc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/drivers/mailbox/qcom-ipcc.c b/drivers/mailbox/qcom-ipcc.c
-index d957d989c..2e4bb5efb 100644
+index 111111111111..222222222222 100644
 --- a/drivers/mailbox/qcom-ipcc.c
 +++ b/drivers/mailbox/qcom-ipcc.c
 @@ -321,7 +321,7 @@ static int qcom_ipcc_probe(struct platform_device *pdev)
@@ -11,3 +25,6 @@ index d957d989c..2e4bb5efb 100644
  			       IRQF_NO_THREAD, name, ipcc);
  	if (ret < 0) {
  		dev_err(&pdev->dev, "Failed to register the irq: %d\n", ret);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0505-msm_gem-lock-before-put_iova_spaces.patch
+++ b/patch/kernel/archive/sm8750-7.1/0505-msm_gem-lock-before-put_iova_spaces.patch
@@ -1,5 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sun, 9 Aug 2026 09:11:00 +0200
+Subject: msm_gem lock before put_iova_spaces
+
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
+---
+ drivers/gpu/drm/msm/msm_gem.c       | 269 ++++++++--
+ drivers/gpu/drm/msm/msm_gem_prime.c |   4 +
+ 2 files changed, 231 insertions(+), 42 deletions(-)
+
 diff --git a/drivers/gpu/drm/msm/msm_gem.c b/drivers/gpu/drm/msm/msm_gem.c
-index b27abaa13..982c96366 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/msm/msm_gem.c
 +++ b/drivers/gpu/drm/msm/msm_gem.c
 @@ -53,25 +53,29 @@ static void msm_gem_close(struct drm_gem_object *obj, struct drm_file *file)
@@ -265,7 +280,7 @@ index b27abaa13..982c96366 100644
  }
  
  static struct drm_gpuva *get_vma_locked(struct drm_gem_object *obj,
-@@ -556,8 +730,10 @@ int msm_gem_get_and_pin_iova_range(struct drm_gem_object *obj,
+@@ -559,8 +733,10 @@ int msm_gem_get_and_pin_iova_range(struct drm_gem_object *obj,
  	struct drm_exec exec;
  	int ret;
  
@@ -278,7 +293,7 @@ index b27abaa13..982c96366 100644
  	drm_exec_fini(&exec);     /* drop locks */
  
  	return ret;
-@@ -579,14 +755,16 @@ int msm_gem_get_iova(struct drm_gem_object *obj, struct drm_gpuvm *vm,
+@@ -582,14 +758,16 @@ int msm_gem_get_iova(struct drm_gem_object *obj, struct drm_gpuvm *vm,
  {
  	struct drm_gpuva *vma;
  	struct drm_exec exec;
@@ -302,7 +317,7 @@ index b27abaa13..982c96366 100644
  	}
  	drm_exec_fini(&exec);     /* drop locks */
  
-@@ -620,17 +798,20 @@ int msm_gem_set_iova(struct drm_gem_object *obj,
+@@ -623,17 +801,20 @@ int msm_gem_set_iova(struct drm_gem_object *obj,
  	struct drm_exec exec;
  	int ret = 0;
  
@@ -334,7 +349,7 @@ index b27abaa13..982c96366 100644
  		}
  	}
  	drm_exec_fini(&exec);     /* drop locks */
-@@ -658,14 +839,18 @@ void msm_gem_unpin_iova(struct drm_gem_object *obj, struct drm_gpuvm *vm)
+@@ -661,14 +842,18 @@ void msm_gem_unpin_iova(struct drm_gem_object *obj, struct drm_gpuvm *vm)
  {
  	struct drm_gpuva *vma;
  	struct drm_exec exec;
@@ -360,7 +375,7 @@ index b27abaa13..982c96366 100644
  }
  
 diff --git a/drivers/gpu/drm/msm/msm_gem_prime.c b/drivers/gpu/drm/msm/msm_gem_prime.c
-index 036d34c67..12ae6ef16 100644
+index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/msm/msm_gem_prime.c
 +++ b/drivers/gpu/drm/msm/msm_gem_prime.c
 @@ -5,6 +5,7 @@
@@ -381,3 +396,6 @@ index 036d34c67..12ae6ef16 100644
  	msm_gem_vma_put(obj);
  	drm_gem_dmabuf_release(dma_buf);
  }
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0508-input-rsinput-add-pm-resume-to-reinit-mcu-after-suspend.patch
+++ b/patch/kernel/archive/sm8750-7.1/0508-input-rsinput-add-pm-resume-to-reinit-mcu-after-suspend.patch
@@ -1,8 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sun, 9 Aug 2026 09:11:00 +0200
+Subject: input rsinput add pm resume to reinit mcu after suspend
+
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
+---
+ drivers/input/joystick/rsinput.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
 diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
-index 457cd4c43..ca43a19bd 100644
+index 111111111111..222222222222 100644
 --- a/drivers/input/joystick/rsinput.c
 +++ b/drivers/input/joystick/rsinput.c
-@@ -557,6 +557,15 @@ static void rsinput_remove(struct serdev_device *serdev) {
+@@ -569,6 +569,15 @@ static void rsinput_remove(struct serdev_device *serdev) {
      regulator_disable(drv->vdd);
  }
  
@@ -18,7 +32,7 @@ index 457cd4c43..ca43a19bd 100644
  static const struct of_device_id rsinput_of_match[] = {
      { .compatible = "gamepad,rsinput" },
      { /* sentinel */ }
-@@ -569,6 +578,7 @@ static struct serdev_device_driver rsinput_driver = {
+@@ -581,6 +590,7 @@ static struct serdev_device_driver rsinput_driver = {
      .driver = {
          .name = "rsinput",
          .of_match_table = rsinput_of_match,
@@ -26,3 +40,6 @@ index 457cd4c43..ca43a19bd 100644
      },
  };
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0509-soc-qcom-pmic_glink_altmode-defer-until-mux-switch-ready.patch
+++ b/patch/kernel/archive/sm8750-7.1/0509-soc-qcom-pmic_glink_altmode-defer-until-mux-switch-ready.patch
@@ -1,0 +1,34 @@
+diff --git a/drivers/soc/qcom/pmic_glink_altmode.c b/drivers/soc/qcom/pmic_glink_altmode.c
+--- a/drivers/soc/qcom/pmic_glink_altmode.c
++++ b/drivers/soc/qcom/pmic_glink_altmode.c
+@@ -637,6 +637,17 @@
+ 					     "failed to acquire mode-switch for port: %d\n",
+ 					     port);
+ 		}
++		/*
++		 * A NULL mux means the connector's mode-switch supplier (e.g. the
++		 * wcd_usbss SBU switch on I2C) has not registered yet — defer and
++		 * retry rather than run permanently without SBU/DP-AUX routing.
++		 */
++		if (!alt_port->typec_mux) {
++			fwnode_handle_put(fwnode);
++			return dev_err_probe(dev, -EPROBE_DEFER,
++					     "mode-switch not registered yet for port: %d\n",
++					     port);
++		}
+ 
+ 		ret = devm_add_action_or_reset(dev, pmic_glink_altmode_put_mux,
+ 					       alt_port->typec_mux);
+@@ -667,6 +678,12 @@
+ 					     "failed to acquire orientation-switch for port: %d\n",
+ 					     port);
+ 		}
++		if (!alt_port->typec_switch) {
++			fwnode_handle_put(fwnode);
++			return dev_err_probe(dev, -EPROBE_DEFER,
++					     "orientation-switch not registered yet for port: %d\n",
++					     port);
++		}
+ 
+ 		ret = devm_add_action_or_reset(dev, pmic_glink_altmode_put_switch,
+ 					       alt_port->typec_switch);

--- a/patch/kernel/archive/sm8750-7.1/0509-soc-qcom-pmic_glink_altmode-defer-until-mux-switch-ready.patch
+++ b/patch/kernel/archive/sm8750-7.1/0509-soc-qcom-pmic_glink_altmode-defer-until-mux-switch-ready.patch
@@ -1,7 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: soc qcom pmic_glink_altmode defer until mux switch ready
+
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
+---
+ drivers/soc/qcom/pmic_glink_altmode.c | 17 ++++++++++
+ 1 file changed, 17 insertions(+)
+
 diff --git a/drivers/soc/qcom/pmic_glink_altmode.c b/drivers/soc/qcom/pmic_glink_altmode.c
+index 111111111111..222222222222 100644
 --- a/drivers/soc/qcom/pmic_glink_altmode.c
 +++ b/drivers/soc/qcom/pmic_glink_altmode.c
-@@ -637,6 +637,17 @@
+@@ -637,6 +637,17 @@ static int pmic_glink_altmode_probe(struct auxiliary_device *adev,
  					     "failed to acquire mode-switch for port: %d\n",
  					     port);
  		}
@@ -19,7 +42,7 @@ diff --git a/drivers/soc/qcom/pmic_glink_altmode.c b/drivers/soc/qcom/pmic_glink
  
  		ret = devm_add_action_or_reset(dev, pmic_glink_altmode_put_mux,
  					       alt_port->typec_mux);
-@@ -667,6 +678,12 @@
+@@ -667,6 +678,12 @@ static int pmic_glink_altmode_probe(struct auxiliary_device *adev,
  					     "failed to acquire orientation-switch for port: %d\n",
  					     port);
  		}
@@ -32,3 +55,6 @@ diff --git a/drivers/soc/qcom/pmic_glink_altmode.c b/drivers/soc/qcom/pmic_glink
  
  		ret = devm_add_action_or_reset(dev, pmic_glink_altmode_put_switch,
  					       alt_port->typec_switch);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0509-usb-typec-ucsi-clear-USB-role.patch
+++ b/patch/kernel/archive/sm8750-7.1/0509-usb-typec-ucsi-clear-USB-role.patch
@@ -1,0 +1,37 @@
+From: Anze <aanzdev@gmail.com>
+Date: Sun, 19 Jul 2026 00:30:00 +0200
+Subject: [PATCH] usb: typec: ucsi: clear USB role when partner lacks USB
+ data
+
+Commit 0c8ee850572 ("usb: typec: ucsi: Add UCSI_USB4_IMPLIES_USB quirk
+for X1E80100") gated the "partner advertises no USB data ->
+USB_ROLE_NONE" decision behind the UCSI_USB4_IMPLIES_USB quirk. On
+ports without that quirk (e.g. SM8750 / AYN Odin 3, pmic_glink UCSI)
+the USB data role is then never cleared for a charger-only partner, so
+it stays attached across system suspend. That keeps the USB power
+island up, and the deep-suspend firmware power-collapse hard-hangs the
+SoC when the cable is unplugged while suspended: dead screen, the SoC
+runs hot, only a forced reset recovers (7.0.x is fine, 7.1.x hangs).
+
+Restore the pre-0c8ee850572 behaviour: clear the USB role whenever the
+partner advertises no USB data.
+
+Signed-off-by: Anze <aanzdev@gmail.com>
+---
+diff --git a/drivers/usb/typec/ucsi/ucsi.c b/drivers/usb/typec/ucsi/ucsi.c
+index 49f1c5372..7505d160d 100644
+--- a/drivers/usb/typec/ucsi/ucsi.c
++++ b/drivers/usb/typec/ucsi/ucsi.c
+@@ -1366,10 +1366,8 @@ static void ucsi_partner_change(struct ucsi_connector *con)
+ 			typec_partner_set_usb_mode(con->partner, USB_MODE_USB4);
+ 	}
+ 
+-	if ((!UCSI_CONSTAT(con, PARTNER_FLAG_USB)) &&
+-	    ((con->ucsi->quirks & UCSI_USB4_IMPLIES_USB) &&
+-	     (!(UCSI_CONSTAT(con, PARTNER_FLAG_USB4_GEN3) ||
+-		UCSI_CONSTAT(con, PARTNER_FLAG_USB4_GEN4)))))
++	/* Only notify USB controller if partner supports USB data */
++	if (!(UCSI_CONSTAT(con, PARTNER_FLAG_USB)))
+ 		u_role = USB_ROLE_NONE;
+ 
+ 	ret = usb_role_switch_set_role(con->usb_role_sw, u_role);

--- a/patch/kernel/archive/sm8750-7.1/0509-usb-typec-ucsi-clear-USB-role.patch
+++ b/patch/kernel/archive/sm8750-7.1/0509-usb-typec-ucsi-clear-USB-role.patch
@@ -1,28 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anze <aanzdev@gmail.com>
-Date: Sun, 19 Jul 2026 00:30:00 +0200
-Subject: [PATCH] usb: typec: ucsi: clear USB role when partner lacks USB
- data
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: usb: typec: ucsi: clear USB role when partner lacks USB
 
-Commit 0c8ee850572 ("usb: typec: ucsi: Add UCSI_USB4_IMPLIES_USB quirk
-for X1E80100") gated the "partner advertises no USB data ->
-USB_ROLE_NONE" decision behind the UCSI_USB4_IMPLIES_USB quirk. On
-ports without that quirk (e.g. SM8750 / AYN Odin 3, pmic_glink UCSI)
-the USB data role is then never cleared for a charger-only partner, so
-it stays attached across system suspend. That keeps the USB power
-island up, and the deep-suspend firmware power-collapse hard-hangs the
-SoC when the cable is unplugged while suspended: dead screen, the SoC
-runs hot, only a forced reset recovers (7.0.x is fine, 7.1.x hangs).
-
-Restore the pre-0c8ee850572 behaviour: clear the USB role whenever the
-partner advertises no USB data.
-
-Signed-off-by: Anze <aanzdev@gmail.com>
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ drivers/usb/typec/ucsi/ucsi.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
 diff --git a/drivers/usb/typec/ucsi/ucsi.c b/drivers/usb/typec/ucsi/ucsi.c
-index 49f1c5372..7505d160d 100644
+index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/ucsi/ucsi.c
 +++ b/drivers/usb/typec/ucsi/ucsi.c
-@@ -1366,10 +1366,8 @@ static void ucsi_partner_change(struct ucsi_connector *con)
+@@ -1334,10 +1334,8 @@ static void ucsi_partner_change(struct ucsi_connector *con)
  			typec_partner_set_usb_mode(con->partner, USB_MODE_USB4);
  	}
  
@@ -35,3 +37,6 @@ index 49f1c5372..7505d160d 100644
  		u_role = USB_ROLE_NONE;
  
  	ret = usb_role_switch_set_role(con->usb_role_sw, u_role);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0517-usb-typec-mux-dont-swallow-EPROBE_DEFER.patch
+++ b/patch/kernel/archive/sm8750-7.1/0517-usb-typec-mux-dont-swallow-EPROBE_DEFER.patch
@@ -1,0 +1,74 @@
+From: Anze <aanzdev@gmail.com>
+Date: Mon, 27 Jul 2026 18:00:00 +0200
+Subject: [PATCH] usb: typec: mux: don't swallow EPROBE_DEFER in the dedup check
+
+The 7.1 merge window added a "skip duplicates" filter to typec_mux_match()
+and typec_switch_match(), and started passing the output array in as the
+match data so it can be compared against. Both halves are broken for a
+connector whose mux is not registered yet.
+
+struct device is the FIRST member of struct typec_mux_dev and struct
+typec_switch_dev, so container_of() on a NULL device yields NULL. When
+class_find_device() finds nothing - the normal case while the mux driver
+has not probed yet, e.g. an i2c retimer such as wcd939x-usbss - the dedup
+loop compares that NULL against an array slot that is also NULL, matches,
+and returns NULL. The caller reads that as "no such connection" instead
+of the -EPROBE_DEFER it used to get, so the connector is created WITHOUT
+its mux, permanently: the DP lanes and the AUX/SBU pair are never routed.
+
+The arrays are also uninitialised stack (`struct typec_switch_dev
+*sw_devs[TYPEC_MUX_MAX_DEVS];`), yet the dedup loop reads every slot
+before fwnode_connection_find_matches() has filled them, so a valid switch
+can be dropped by a chance comparison against stack garbage.
+
+7.2 fixed the typec_mux_match() half upstream: the dedup loop is gone from
+it and fwnode_typec_mux_get() passes NULL as the match data now. The
+typec_switch_match() half is unchanged, so only that one is patched here.
+
+Bail out with -EPROBE_DEFER before the dedup loop when no device was
+found, and zero-initialise the array.
+
+[7.1.6: mux half dropped. typec_mux_match() lost its dedup loop and
+fwnode_typec_mux_get() was rewritten (kzalloc_obj + bounded for-loop
+that only reads populated slots) between 7.1.3 and 7.1.6, so that half
+of this bug no longer exists upstream. typec_switch_match() and
+fwnode_typec_switch_get() are unchanged and still carry it -- kept.]
+
+Device-observed on an AYN Odin 3 (SM8750): dock DisplayPort output died
+with the 7.0.11 -> 7.1.3 bump. The firmware enters DP alt mode correctly
+(mux_ctrl=3, pin_assignment=4), raises HPD, and msm_dp powers up its
+clocks and PHY - then the very first DPCD read times out
+(drm_dp_dpcd_probe ... AUX -> (ret=-110)), link_ready stays false and the
+connector reports disconnected, because nothing ever routed the lanes.
+
+Signed-off-by: Anze <aanzdev@gmail.com>
+---
+--- a/drivers/usb/typec/mux.c
++++ b/drivers/usb/typec/mux.c
+@@ -57,6 +57,8 @@
+ 	 */
+ 	dev = class_find_device(&typec_mux_class, NULL, fwnode,
+ 				switch_fwnode_match);
++	if (!dev)
++		return ERR_PTR(-EPROBE_DEFER);
+ 
+ 	/* Skip duplicates */
+ 	for (i = 0; i < TYPEC_MUX_MAX_DEVS; i++)
+@@ -65,7 +67,7 @@
+ 			return NULL;
+ 		}
+ 
+-	return dev ? to_typec_switch_dev(dev) : ERR_PTR(-EPROBE_DEFER);
++	return to_typec_switch_dev(dev);
+ }
+ 
+ /**
+@@ -79,7 +81,7 @@
+  */
+ struct typec_switch *fwnode_typec_switch_get(struct fwnode_handle *fwnode)
+ {
+-	struct typec_switch_dev *sw_devs[TYPEC_MUX_MAX_DEVS];
++	struct typec_switch_dev *sw_devs[TYPEC_MUX_MAX_DEVS] = {};
+ 	struct typec_switch *sw;
+ 	int count;
+ 	int err;

--- a/patch/kernel/archive/sm8750-7.1/0517-usb-typec-mux-dont-swallow-EPROBE_DEFER.patch
+++ b/patch/kernel/archive/sm8750-7.1/0517-usb-typec-mux-dont-swallow-EPROBE_DEFER.patch
@@ -1,51 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anze <aanzdev@gmail.com>
-Date: Mon, 27 Jul 2026 18:00:00 +0200
-Subject: [PATCH] usb: typec: mux: don't swallow EPROBE_DEFER in the dedup check
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: usb: typec: mux: don't swallow EPROBE_DEFER in the dedup check
 
-The 7.1 merge window added a "skip duplicates" filter to typec_mux_match()
-and typec_switch_match(), and started passing the output array in as the
-match data so it can be compared against. Both halves are broken for a
-connector whose mux is not registered yet.
-
-struct device is the FIRST member of struct typec_mux_dev and struct
-typec_switch_dev, so container_of() on a NULL device yields NULL. When
-class_find_device() finds nothing - the normal case while the mux driver
-has not probed yet, e.g. an i2c retimer such as wcd939x-usbss - the dedup
-loop compares that NULL against an array slot that is also NULL, matches,
-and returns NULL. The caller reads that as "no such connection" instead
-of the -EPROBE_DEFER it used to get, so the connector is created WITHOUT
-its mux, permanently: the DP lanes and the AUX/SBU pair are never routed.
-
-The arrays are also uninitialised stack (`struct typec_switch_dev
-*sw_devs[TYPEC_MUX_MAX_DEVS];`), yet the dedup loop reads every slot
-before fwnode_connection_find_matches() has filled them, so a valid switch
-can be dropped by a chance comparison against stack garbage.
-
-7.2 fixed the typec_mux_match() half upstream: the dedup loop is gone from
-it and fwnode_typec_mux_get() passes NULL as the match data now. The
-typec_switch_match() half is unchanged, so only that one is patched here.
-
-Bail out with -EPROBE_DEFER before the dedup loop when no device was
-found, and zero-initialise the array.
-
-[7.1.6: mux half dropped. typec_mux_match() lost its dedup loop and
-fwnode_typec_mux_get() was rewritten (kzalloc_obj + bounded for-loop
-that only reads populated slots) between 7.1.3 and 7.1.6, so that half
-of this bug no longer exists upstream. typec_switch_match() and
-fwnode_typec_switch_get() are unchanged and still carry it -- kept.]
-
-Device-observed on an AYN Odin 3 (SM8750): dock DisplayPort output died
-with the 7.0.11 -> 7.1.3 bump. The firmware enters DP alt mode correctly
-(mux_ctrl=3, pin_assignment=4), raises HPD, and msm_dp powers up its
-clocks and PHY - then the very first DPCD read times out
-(drm_dp_dpcd_probe ... AUX -> (ret=-110)), link_ready stays false and the
-connector reports disconnected, because nothing ever routed the lanes.
-
-Signed-off-by: Anze <aanzdev@gmail.com>
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ drivers/usb/typec/mux.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/usb/typec/mux.c b/drivers/usb/typec/mux.c
+index 111111111111..222222222222 100644
 --- a/drivers/usb/typec/mux.c
 +++ b/drivers/usb/typec/mux.c
-@@ -57,6 +57,8 @@
+@@ -57,6 +57,8 @@ static void *typec_switch_match(const struct fwnode_handle *fwnode,
  	 */
  	dev = class_find_device(&typec_mux_class, NULL, fwnode,
  				switch_fwnode_match);
@@ -54,7 +33,7 @@ Signed-off-by: Anze <aanzdev@gmail.com>
  
  	/* Skip duplicates */
  	for (i = 0; i < TYPEC_MUX_MAX_DEVS; i++)
-@@ -65,7 +67,7 @@
+@@ -65,7 +67,7 @@ static void *typec_switch_match(const struct fwnode_handle *fwnode,
  			return NULL;
  		}
  
@@ -63,7 +42,7 @@ Signed-off-by: Anze <aanzdev@gmail.com>
  }
  
  /**
-@@ -79,7 +81,7 @@
+@@ -79,7 +81,7 @@ static void *typec_switch_match(const struct fwnode_handle *fwnode,
   */
  struct typec_switch *fwnode_typec_switch_get(struct fwnode_handle *fwnode)
  {
@@ -72,3 +51,6 @@ Signed-off-by: Anze <aanzdev@gmail.com>
  	struct typec_switch *sw;
  	int count;
  	int err;
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0601-ROCKNIX-odin3-pwm-fan-sysfs.patch
+++ b/patch/kernel/archive/sm8750-7.1/0601-ROCKNIX-odin3-pwm-fan-sysfs.patch
@@ -1,17 +1,33 @@
-Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn-common: Add pwm-fan cooling cells
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sun, 9 Aug 2026 09:11:00 +0200
+Subject: ROCKNIX odin3 pwm fan sysfs
 
-Add #cooling-cells and cooling-levels to the pwm-fan node so the fan
-is accessible to userspace fan control via sysfs.
-
-Cooling levels (8 states): 0=off, 1-7=30/45/60/70/90/120/150 PWM
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
 ---
+ arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi      |     2 +
+ arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi.orig |  1269 +
+ drivers/bluetooth/btqca.c.orig                        |  1058 +
+ drivers/gpu/drm/msm/msm_gem.c.orig                    |  1394 +
+ drivers/input/input-compat.c.orig                     |   163 +
+ drivers/input/joystick/rsinput.c.orig                 |   590 +
+ drivers/net/wireless/ath/ath12k/mac.c.orig            | 15255 ++++++++++
+ drivers/soc/qcom/socinfo.c.orig                       |   943 +
+ drivers/usb/typec/ucsi/ucsi.c.orig                    |  2368 ++
+ include/linux/sched.h.orig                            |  2532 ++
+ include/uapi/linux/prctl.h.orig                       |   419 +
+ kernel/sys.c.orig                                     |  3074 ++
+ 12 files changed, 29067 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
-@@ -91,10 +91,12 @@
- 	pwm_fan: pwm-fan {
- 		compatible = "pwm-fan";
- 
+@@ -95,6 +95,8 @@ pwm_fan: pwm-fan {
  		fan-supply = <&vdd_fan_5v0>;
  		pwms = <&pm8550_pwm 3 40000>;
  
@@ -20,3 +36,29137 @@ diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/
  		pinctrl-names = "default";
  		pinctrl-0 = <&fan_pwm_default>;
  	};
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi.orig b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi.orig
+@@ -0,0 +1,1269 @@
++// SPDX-License-Identifier: BSD-3-Clause
++/*
++ * Copyright (c) 2026 Teguh Sobirin.
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/regulator/qcom,rpmh-regulator.h>
++#include "sm8750.dtsi"
++#include "pm8550.dtsi"
++#define PMK8550VE_SID 8
++#include "pm8550ve.dtsi"
++#include "pmih0108.dtsi"
++#include "pmk8550.dtsi"
++#include "sm8750-pmics.dtsi"
++
++/ {
++	chassis-type = "handset";
++
++	aliases {
++		serial0 = &uart7;
++		serial1 = &uart14;
++		serial2 = &uart15;
++	};
++
++	wcd939x: audio-codec {
++		compatible = "qcom,wcd9395-codec", "qcom,wcd9390-codec";
++
++		pinctrl-0 = <&wcd_default>;
++		pinctrl-names = "default";
++
++		qcom,micbias1-microvolt = <1800000>;
++		qcom,micbias2-microvolt = <1800000>;
++		qcom,micbias3-microvolt = <1800000>;
++		qcom,micbias4-microvolt = <1800000>;
++		qcom,mbhc-buttons-vthreshold-microvolt = <75000 150000 237000 500000 500000 500000 500000 500000>;
++		qcom,mbhc-headset-vthreshold-microvolt = <1700000>;
++		qcom,mbhc-headphone-vthreshold-microvolt = <50000>;
++		qcom,rx-device = <&wcd_rx>;
++		qcom,tx-device = <&wcd_tx>;
++		qcom,usbss = <&wcd_usbss>;
++
++		reset-gpios = <&tlmm 101 GPIO_ACTIVE_LOW>;
++
++		vdd-buck-supply = <&vreg_l15b_1p8>;
++		vdd-rxtx-supply = <&vreg_l15b_1p8>;
++		vdd-io-supply = <&vreg_l15b_1p8>;
++		vdd-mic-bias-supply = <&vreg_bob1>;
++		vdd-px-supply = <&vreg_l2i_1p2>;
++
++		#sound-dai-cells = <1>;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	clocks {
++		xo_board: xo-board {
++			compatible = "fixed-clock";
++			clock-frequency = <76800000>;
++			#clock-cells = <0>;
++		};
++
++		sleep_clk: sleep-clk {
++			compatible = "fixed-clock";
++			clock-frequency = <32000>;
++			#clock-cells = <0>;
++		};
++
++		bi_tcxo_div2: bi-tcxo-div2-clk {
++			compatible = "fixed-factor-clock";
++			#clock-cells = <0>;
++
++			clocks = <&rpmhcc RPMH_CXO_CLK>;
++			clock-mult = <1>;
++			clock-div = <2>;
++		};
++
++		bi_tcxo_ao_div2: bi-tcxo-ao-div2-clk {
++			compatible = "fixed-factor-clock";
++			#clock-cells = <0>;
++
++			clocks = <&rpmhcc RPMH_CXO_CLK_A>;
++			clock-mult = <1>;
++			clock-div = <2>;
++		};
++	};
++
++	pwm_fan: pwm-fan {
++		compatible = "pwm-fan";
++
++		fan-supply = <&vdd_fan_5v0>;
++		pwms = <&pm8550_pwm 3 40000>;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&fan_pwm_default>;
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		pinctrl-0 = <&volume_up_n>;
++		pinctrl-names = "default";
++
++		key-volume-up {
++			label = "Volume Up";
++			linux,code = <KEY_VOLUMEUP>;
++			gpios = <&pm8550_gpios 6 GPIO_ACTIVE_LOW>;
++			debounce-interval = <15>;
++			linux,can-disable;
++			wakeup-source;
++		};
++	};
++
++	sound {
++		compatible = "qcom,sm8750-sndcard", "qcom,sm8450-sndcard";
++
++		pinctrl-0 = <&i2s1_default>;
++		pinctrl-names = "default";
++
++		clocks = <&q6prmcc LPASS_CLK_ID_SEC_MI2S_IBIT LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++		clock-names = "i2s_clk";
++
++		assigned-clocks = <&q6prmcc LPASS_CLK_ID_SEC_MI2S_IBIT LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
++		assigned-clock-rates = <1536000>;
++
++		model = "SM8750-AYN";
++		audio-routing = 
++				"IN1_HPHL", "HPHL_OUT",
++				"IN2_HPHR", "HPHR_OUT",
++				"AMIC2", "MIC BIAS2",
++				"TX SWR_INPUT1", "ADC2_OUTPUT";
++
++		spk-i2s-dai-link {
++			link-name = "Secondary MI2S Playback";
++
++			cpu {
++				sound-dai = <&q6apmbedai SECONDARY_MI2S_RX>;
++			};
++
++			codec {
++				sound-dai = <&spk_amp_l 0>, <&spk_amp_r 0>;
++			};
++
++			platform {
++				sound-dai = <&q6apm>;
++			};
++		};
++
++		wcd-playback-dai-link {
++			link-name = "WCD Playback";
++
++			codec {
++				sound-dai = <&wcd939x 0>, <&swr1 0>, <&lpass_rxmacro 0>;
++			};
++
++			cpu {
++				sound-dai = <&q6apmbedai RX_CODEC_DMA_RX_0>;
++			};
++
++			platform {
++				sound-dai = <&q6apm>;
++			};
++		};
++
++		wcd-capture-dai-link {
++			link-name = "WCD Capture";
++
++			codec {
++				sound-dai = <&wcd939x 1>, <&swr2 0>, <&lpass_txmacro 0>;
++			};
++
++			cpu {
++				sound-dai = <&q6apmbedai TX_CODEC_DMA_TX_3>;
++			};
++
++			platform {
++				sound-dai = <&q6apm>;
++			};
++		};
++	};
++
++	pmic-glink {
++		compatible = "qcom,sm8750-pmic-glink",
++			     "qcom,sm8550-pmic-glink",
++			     "qcom,pmic-glink";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		orientation-gpios = <&tlmm 61 GPIO_ACTIVE_HIGH>;
++
++		connector@0 {
++			compatible = "usb-c-connector";
++			reg = <0>;
++
++			power-role = "dual";
++			data-role = "dual";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					pmic_glink_hs_in: endpoint {
++						remote-endpoint = <&usb_dwc3_hs>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					pmic_glink_ss_in: endpoint {
++						remote-endpoint = <&redriver_ss_out>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					pmic_glink_sbu: endpoint {
++						remote-endpoint = <&wcd_usbss_sbu_mux>;
++					};
++				};
++			};
++		};
++	};
++
++	vdd_fan_5v0: vdd-fan-5v0-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_fan_5v0";
++
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++
++		gpio = <&tlmm 84 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&fan_pwr_default>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_mcu_3v3: vdd-mcu-3v3-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_mcu_3v3";
++
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++
++		gpio = <&tlmm 83 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&mcu_pwr_default>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vph_pwr: vph-pwr-regulator {
++		compatible = "regulator-fixed";
++
++		regulator-name = "vph_pwr";
++		regulator-min-microvolt = <3700000>;
++		regulator-max-microvolt = <3700000>;
++
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	wcn7860-pmu {
++		compatible = "qcom,wcn7860-pmu";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&wlan_en>, <&bt_default>;
++
++		wlan-enable-gpios = <&tlmm 16 GPIO_ACTIVE_HIGH>;
++		bt-enable-gpios = <&pm8550ve_f_gpios 3 GPIO_ACTIVE_HIGH>;
++
++		vddio-supply = <&vreg_l3f_1p8>;
++		vddio1p2-supply = <&vreg_l2f_1p2>;
++		vddaon-supply = <&vreg_s4d_0p85>;
++		vdddig-supply = <&vreg_s5f_0p85>;
++		vddrfa1p2-supply = <&vreg_s7i_1p2>;
++		vddrfa1p8-supply = <&vreg_s3g_1p8>;
++
++		clocks = <&rpmhcc RPMH_RF_CLK1>;
++
++		regulators {
++			vreg_pmu_rfa_cmn: ldo0 {
++				regulator-name = "vreg_pmu_rfa_cmn";
++			};
++
++			vreg_pmu_aon_0p59: ldo1 {
++				regulator-name = "vreg_pmu_aon_0p59";
++			};
++
++			vreg_pmu_wlcx_0p8: ldo2 {
++				regulator-name = "vreg_pmu_wlcx_0p8";
++			};
++
++			vreg_pmu_wlmx_0p85: ldo3 {
++				regulator-name = "vreg_pmu_wlmx_0p85";
++			};
++
++			vreg_pmu_btcmx_0p85: ldo4 {
++				regulator-name = "vreg_pmu_btcmx_0p85";
++			};
++
++			vreg_pmu_rfa_0p8: ldo5 {
++				regulator-name = "vreg_pmu_rfa_0p8";
++			};
++
++			vreg_pmu_rfa_1p2: ldo6 {
++				regulator-name = "vreg_pmu_rfa_1p2";
++			};
++
++			vreg_pmu_rfa_1p8: ldo7 {
++				regulator-name = "vreg_pmu_rfa_1p8";
++			};
++
++			vreg_pmu_pcie_0p9: ldo8 {
++				regulator-name = "vreg_pmu_pcie_0p9";
++			};
++
++			vreg_pmu_pcie_1p8: ldo9 {
++				regulator-name = "vreg_pmu_pcie_1p8";
++			};
++		};
++	};
++};
++
++&apps_rsc {
++	regulators-0 {
++		compatible = "qcom,pm8550-rpmh-regulators";
++
++		vdd-bob1-supply = <&vph_pwr>;
++		vdd-bob2-supply = <&vph_pwr>;
++		vdd-l1-l4-l10-supply = <&vreg_s3g_1p8>;
++		vdd-l2-l13-l14-supply = <&vreg_bob1>;
++		vdd-l3-supply = <&vreg_s7i_1p2>;
++		vdd-l5-l16-supply = <&vreg_bob1>;
++		vdd-l6-l7-supply = <&vreg_bob1>;
++		vdd-l8-l9-supply = <&vreg_bob1>;
++		vdd-l11-supply = <&vreg_s7i_1p2>;
++		vdd-l12-supply = <&vreg_s3g_1p8>;
++		vdd-l15-supply = <&vreg_s3g_1p8>;
++		vdd-l17-supply = <&vreg_bob2>;
++
++		qcom,pmic-id = "b";
++
++		vreg_bob1: bob1 {
++			regulator-name = "vreg_bob1";
++			regulator-min-microvolt = <3008000>;
++			regulator-max-microvolt = <4000000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_bob2: bob2 {
++			regulator-name = "vreg_bob2";
++			regulator-min-microvolt = <2704000>;
++			regulator-max-microvolt = <3008000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l1b_1p8: ldo1 {
++			regulator-name = "vreg_l1b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l2b_3p0: ldo2 {
++			regulator-name = "vreg_l2b_3p0";
++			regulator-min-microvolt = <3008000>;
++			regulator-max-microvolt = <3048000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l4b_1p8: ldo4 {
++			regulator-name = "vreg_l4b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l5b_3p1: ldo5 {
++			regulator-name = "vreg_l5b_3p1";
++			regulator-min-microvolt = <3100000>;
++			regulator-max-microvolt = <3148000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l6b_1p8: ldo6 {
++			regulator-name = "vreg_l6b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <3008000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l7b_1p8: ldo7 {
++			regulator-name = "vreg_l7b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <3008000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++
++		};
++
++		vreg_l8b_1p8: ldo8 {
++			regulator-name = "vreg_l8b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <3008000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l9b_2p9: ldo9 {
++			regulator-name = "vreg_l9b_2p9";
++			regulator-min-microvolt = <2960000>;
++			regulator-max-microvolt = <3008000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l10b_1p8: ldo10 {
++			regulator-name = "vreg_l10b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l11b_1p0: ldo11 {
++			regulator-name = "vreg_l11b_1p0";
++			regulator-min-microvolt = <1000000>;
++			regulator-max-microvolt = <1100000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l12b_1p8: ldo12 {
++			regulator-name = "vreg_l12b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l13b_3p0: ldo13 {
++			regulator-name = "vreg_l13b_3p0";
++			regulator-min-microvolt = <3000000>;
++			regulator-max-microvolt = <3000000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l14b_3p2: ldo14 {
++			regulator-name = "vreg_l14b_3p2";
++			regulator-min-microvolt = <3200000>;
++			regulator-max-microvolt = <3200000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l15b_1p8: ldo15 {
++			regulator-name = "vreg_l15b_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l16b_2p8: ldo16 {
++			regulator-name = "vreg_l16b_2p8";
++			regulator-min-microvolt = <2800000>;
++			regulator-max-microvolt = <2800000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l17b_2p5: ldo17 {
++			regulator-name = "vreg_l17b_2p5";
++			regulator-min-microvolt = <2504000>;
++			regulator-max-microvolt = <2504000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++
++	regulators-1 {
++		compatible = "qcom,pm8550ve-rpmh-regulators";
++
++		vdd-l1-supply = <&vreg_s7i_1p2>;
++		vdd-l2-supply = <&vreg_s1d_0p97>;
++		vdd-l3-supply = <&vreg_s1d_0p97>;
++		vdd-s1-supply = <&vph_pwr>;
++		vdd-s3-supply = <&vph_pwr>;
++		vdd-s4-supply = <&vph_pwr>;
++
++		qcom,pmic-id = "d";
++
++		vreg_s1d_0p97: smps1 {
++			regulator-name = "vreg_s1d_0p97";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <1100000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s3d_1p2: smps3 {
++			regulator-name = "vreg_s3d_1p2";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1300000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s4d_0p85: smps4 {
++			regulator-name = "vreg_s4d_0p85";
++			regulator-min-microvolt = <852000>;
++			regulator-max-microvolt = <1036000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l1d_1p2: ldo1 {
++			regulator-name = "vreg_l1d_1p2";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1200000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l2d_0p88: ldo2 {
++			regulator-name = "vreg_l2d_0p88";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <912000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l3d_0p88: ldo3 {
++			regulator-name = "vreg_l3d_0p88";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <920000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++
++	regulators-2 {
++		compatible = "qcom,pm8550ve-rpmh-regulators";
++
++		vdd-l1-supply = <&vreg_s1d_0p97>;
++		vdd-l2-supply = <&vreg_s7i_1p2>;
++		vdd-l3-supply = <&vreg_s3g_1p8>;
++		vdd-s5-supply = <&vph_pwr>;
++
++		qcom,pmic-id = "f";
++
++		vreg_s5f_0p85: smps5 {
++			regulator-name = "vreg_s5f_0p85";
++			regulator-min-microvolt = <852000>;
++			regulator-max-microvolt = <1000000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l1f_0p88: ldo1 {
++			regulator-name = "vreg_l1f_0p88";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <920000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l2f_1p2: ldo2 {
++			regulator-name = "vreg_l2f_1p2";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1200000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l3f_1p8: ldo3 {
++			regulator-name = "vreg_l3f_1p8";
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++	};
++
++	regulators-3 {
++		compatible = "qcom,pm8550ve-rpmh-regulators";
++
++		vdd-l1-supply = <&vreg_s1d_0p97>;
++		vdd-l2-supply = <&vreg_s3g_1p8>;
++		vdd-l3-supply = <&vreg_s7i_1p2>;
++		vdd-s1-supply = <&vph_pwr>;
++		vdd-s3-supply = <&vph_pwr>;
++
++		qcom,pmic-id = "g";
++
++		vreg_s1g_0p5: smps1 {
++			regulator-name = "vreg_s1g_0p5";
++			regulator-min-microvolt = <300000>;
++			regulator-max-microvolt = <700000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s3g_1p8: smps3 {
++			regulator-name = "vreg_s3g_1p8";
++			regulator-min-microvolt = <1856000>;
++			regulator-max-microvolt = <2000000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_LPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s4g_0p75: smps4 {
++			regulator-name = "vreg_s4g_0p75";
++			regulator-min-microvolt = <300000>;
++			regulator-max-microvolt = <900000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l1g_0p91: ldo1 {
++			regulator-name = "vreg_l1g_0p91";
++			regulator-min-microvolt = <912000>;
++			regulator-max-microvolt = <936000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l2g_1p8: ldo2 {
++			regulator-name = "vreg_l2g_1p8";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1860000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l3g_1p2: ldo3 {
++			regulator-name = "vreg_l3g_1p2";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1256000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++
++	regulators-4 {
++		compatible = "qcom,pm8550ve-rpmh-regulators";
++
++		vdd-l1-supply = <&vreg_s7i_1p2>;
++		vdd-l2-supply = <&vreg_s7i_1p2>;
++		vdd-l3-supply = <&vreg_s1d_0p97>;
++		vdd-s7-supply = <&vph_pwr>;
++		vdd-s8-supply = <&vph_pwr>;
++
++		qcom,pmic-id = "i";
++
++		vreg_s7i_1p2: smps7 {
++			regulator-name = "vreg_s7i_1p2";
++			regulator-min-microvolt = <1224000>;
++			regulator-max-microvolt = <1340000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s8i_0p9: smps8 {
++			regulator-name = "vreg_s8i_0p9";
++			regulator-min-microvolt = <900000>;
++			regulator-max-microvolt = <972000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l1i_1p2: ldo1 {
++			regulator-name = "vreg_l1i_1p2";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1200000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l2i_1p2: ldo2 {
++			regulator-name = "vreg_l2i_1p2";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1200000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l3i_0p88: ldo3 {
++			regulator-name = "vreg_l3i_0p88";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <912000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++
++	regulators-5 {
++		compatible = "qcom,pm8550vs-rpmh-regulators";
++
++		vdd-l1-supply = <&vreg_s1d_0p97>;
++		vdd-l2-supply = <&vreg_s7i_1p2>;
++		vdd-s2-supply = <&vph_pwr>;
++		vdd-s3-supply = <&vph_pwr>;
++		vdd-s4-supply = <&vph_pwr>;
++
++		qcom,pmic-id = "j";
++
++		vreg_s2j_1p1: smps2 {
++			regulator-name = "vreg_s2j_1p1";
++			regulator-min-microvolt = <1000000>;
++			regulator-max-microvolt = <1100000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_s3j_1p1: smps3 {
++			regulator-name = "vreg_s3j_1p1";
++			regulator-min-microvolt = <1000000>;
++			regulator-max-microvolt = <1100000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l1j_0p91: ldo1 {
++			regulator-name = "vreg_l1j_0p91";
++			regulator-min-microvolt = <880000>;
++			regulator-max-microvolt = <920000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++
++		vreg_l2j_1p2: ldo2 {
++			regulator-name = "vreg_l2j_1p2";
++			regulator-min-microvolt = <1200000>;
++			regulator-max-microvolt = <1200000>;
++			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
++			regulator-allow-set-load;
++			regulator-allowed-modes = <RPMH_REGULATOR_MODE_LPM
++						   RPMH_REGULATOR_MODE_HPM>;
++		};
++	};
++};
++
++&gpi_dma1 {
++	status = "okay";
++};
++
++&gpi_dma2 {
++	status = "okay";
++};
++
++&gpu {
++	status = "okay";
++};
++
++&gpu_zap_shader {
++	firmware-name = "qcom/sm8750/gen80000_zap.mbn";
++};
++
++&i2c3 {
++	status = "okay";
++
++	wcd_usbss: typec-mux@e {
++		compatible = "qcom,wcd9395-usbss", "qcom,wcd9390-usbss";
++		reg = <0xe>;
++
++		vdd-supply = <&vreg_l15b_1p8>;
++		reset-gpios = <&tlmm 152 GPIO_ACTIVE_HIGH>;
++
++		mode-switch;
++		orientation-switch;
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++
++				wcd_usbss_sbu_mux: endpoint {
++					remote-endpoint = <&pmic_glink_sbu>;
++				};
++			};
++
++			port@1 {
++				reg = <1>;
++
++				wcd_usbss_headset_out: endpoint {
++				};
++			};
++		};
++	};
++};
++
++&i2c5 {
++	clock-frequency = <400000>;
++	status = "okay";
++
++	spk_amp_l: spk_amp_l@34 {
++		compatible = "awinic,aw88166";
++		reg = <0x34>;
++		#sound-dai-cells = <1>;
++		reset-gpios = <&tlmm 128 GPIO_ACTIVE_LOW>;
++		awinic,audio-channel = <1>;
++		awinic,sync-flag;
++		sound-name-prefix = "SPK_L";
++	};
++
++	spk_amp_r: spk_amp_r@35 {
++		compatible = "awinic,aw88166";
++		reg = <0x35>;
++		#sound-dai-cells = <1>;
++		reset-gpios = <&tlmm 126 GPIO_ACTIVE_LOW>;
++		awinic,audio-channel = <0>;
++		awinic,sync-flag;
++		sound-name-prefix = "SPK_R";
++	};
++
++	typec_mux_redriver: typec-mux@1c {
++		compatible = "onnn,nb7vpq904m";
++		reg = <0x1c>;
++
++		vcc-supply = <&vreg_l15b_1p8>;
++
++		retimer-switch;
++		orientation-switch;
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++
++				redriver_ss_out: endpoint {
++					remote-endpoint = <&pmic_glink_ss_in>;
++				};
++			};
++
++			port@1 {
++				reg = <1>;
++
++				redriver_ss_in: endpoint {
++					remote-endpoint = <&usb_dp_qmpphy_out>;
++				};
++			};
++		};
++	};
++};
++
++&iris {
++	status = "okay";
++};
++
++&lpass_vamacro {
++	qcom,dmic-sample-rate = <4800000>;
++};
++
++&mdss {
++	status = "okay";
++};
++
++&mdss_dp0 {
++	status = "okay";
++};
++
++&mdss_dsi0 {
++	vdda-supply = <&vreg_l3g_1p2>;
++
++	status = "okay";
++
++	display_panel: panel@0 {
++		reg = <0>;
++
++		port {
++			panel0_in: endpoint {
++				remote-endpoint = <&mdss_dsi0_out>;
++			};
++		};
++	};
++};
++
++&mdss_dsi0_out {
++	remote-endpoint = <&panel0_in>;
++	data-lanes = <0 1 2 3>;
++};
++
++&mdss_dsi0_phy {
++	vdds-supply = <&vreg_l3i_0p88>;
++
++	status = "okay";
++};
++
++&pcie0 {
++	pinctrl-0 = <&pcie0_default_state>;
++	pinctrl-names = "default";
++
++	status = "okay";
++};
++
++&pcie0_phy {
++	vdda-phy-supply = <&vreg_l1f_0p88>;
++	vdda-pll-supply = <&vreg_l3g_1p2>;
++
++	status = "okay";
++};
++
++&pcieport0 {
++	wake-gpios = <&tlmm 104 GPIO_ACTIVE_HIGH>;
++	reset-gpios = <&tlmm 102 GPIO_ACTIVE_LOW>;
++
++	wifi@0 {
++		compatible = "pci17cb,110e";
++		reg = <0x10000 0x0 0x0 0x0 0x0>;
++
++		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
++		vddaon-supply = <&vreg_pmu_aon_0p59>;
++		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
++		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
++		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
++		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
++		vddrfa1p8-supply = <&vreg_pmu_rfa_1p8>;
++		vddpcie0p9-supply = <&vreg_pmu_pcie_0p9>;
++		vddpcie1p8-supply = <&vreg_pmu_pcie_1p8>;
++	};
++};
++
++&pm8550_gpios {
++	fan_pwm_default: fan-pwm-default-state {
++		pins = "gpio8";
++		function = "func1";
++		input-disable;
++		output-enable;
++		output-low;
++		bias-disable;
++		power-source = <1>;
++	};
++
++	volume_up_n: volume-up-n-state {
++		pins = "gpio6";
++		function = "normal";
++		bias-pull-up;
++		input-enable;
++		power-source = <1>;
++	};
++};
++
++&pm8550_pwm {
++	status = "okay";
++};
++
++&pon_pwrkey {
++	status = "okay";
++};
++
++&pon_resin {
++	linux,code = <KEY_VOLUMEDOWN>;
++
++	status = "okay";
++};
++
++&pmih0108_eusb2_repeater {
++	status = "okay";
++
++	vdd18-supply = <&vreg_l15b_1p8>;
++	vdd3-supply = <&vreg_l5b_3p1>;
++};
++
++&qupv3_1 {
++	status = "okay";
++};
++
++&qupv3_2 {
++	status = "okay";
++};
++
++&sdhc_2 {
++	cd-gpios = <&tlmm 55 GPIO_ACTIVE_LOW>;
++
++	vmmc-supply = <&vreg_l9b_2p9>;
++	vqmmc-supply = <&vreg_l8b_1p8>;
++
++	no-sdio;
++	no-mmc;
++
++	pinctrl-0 = <&sdc2_default &sdc2_card_det_n>;
++	pinctrl-1 = <&sdc2_sleep &sdc2_card_det_n>;
++	pinctrl-names = "default", "sleep";
++
++	status = "okay";
++};
++
++&swr1 {
++	status = "okay";
++
++	wcd_rx: codec@0,4 {
++		compatible = "sdw20217010e00";
++		reg = <0 4>;
++
++		qcom,rx-port-mapping = <1 2 3 4 5 9>;
++	};
++};
++
++&swr2 {
++	status = "okay";
++
++	wcd_tx: codec@0,3 {
++		compatible = "sdw20217010e00";
++		reg = <0 3>;
++
++		qcom,tx-port-mapping = <2 2 3 4>;
++	};
++};
++
++&tlmm {
++	/* reserved for secure world */
++	gpio-reserved-ranges = <36 4>, <74 1>;
++
++	bt_default: bt-default-state {
++		sw-ctrl-pins {
++			pins = "gpio18";
++			function = "gpio";
++			bias-pull-down;
++		};
++	};
++
++	fan_pwr_default: fan-pwr-default-state {
++		pins = "gpio84";
++		function = "gpio";
++		drive-strength = <2>;
++		bias-disable;
++		output-low;
++	};
++
++	i2s1_default: i2s1-default-state {
++		sck-pins {
++			pins = "gpio121";
++			function = "i2s1_sck";
++			drive-strength = <8>;
++			bias-disable;
++			output-high;
++		};
++
++		data0-pins {
++			pins = "gpio122";
++			function = "i2s1_data0";
++			drive-strength = <8>;
++			bias-disable;
++		};
++
++		ws-pins {
++			pins = "gpio123";
++			function = "i2s1_ws";
++			drive-strength = <8>;
++			bias-disable;
++			output-high;
++		};
++
++		data1-pins {
++			pins = "gpio124";
++			function = "i2s1_data1";
++			drive-strength = <8>;
++			bias-disable;
++			output-high;
++		};
++	};
++
++	mcu_en_default: mcu-en-default-state {
++		pins = "gpio85";
++		function = "gpio";
++		bias-pull-down;
++	};
++
++	mcu_pwr_default: mcu-pwr-default-state {
++		pins = "gpio83";
++		function = "gpio";
++		drive-strength = <2>;
++		bias-disable;
++		output-low;
++	};
++
++	sdc2_card_det_n: sd-card-det-n-state {
++		pins = "gpio55";
++		function = "gpio";
++		drive-strength = <2>;
++		bias-pull-up;
++	};
++
++	wcd_default: wcd-reset-n-active-state {
++		pins = "gpio101";
++		function = "gpio";
++		drive-strength = <16>;
++		bias-disable;
++		output-low;
++	};
++
++	wlan_en: wlan-en-state {
++		pins = "gpio16";
++		function = "gpio";
++		drive-strength = <8>;
++		bias-pull-down;
++	};
++};
++
++&uart7 {
++	status = "okay";
++};
++
++&uart14 {
++	status = "okay";
++
++	bluetooth {
++		compatible = "qcom,wcn7860-bt";
++
++		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
++		vddaon-supply = <&vreg_pmu_aon_0p59>;
++		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
++		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
++		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
++		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
++		vddrfa1p8-supply = <&vreg_pmu_rfa_1p8>;
++
++		max-speed = <3200000>;
++	};
++};
++
++&uart15 {
++	status = "okay";
++
++	gamepad {
++		compatible = "gamepad,rsinput";
++
++		gamepad-name = "AYN Odin3 Gamepad";
++		gamepad-bus = <0x0003>;
++		gamepad-vid = <0x2020>;
++		gamepad-pid = <0x3001>;
++		gamepad-rev = <0x0001>;
++
++		vdd-supply = <&vdd_mcu_3v3>;
++		enable-gpios = <&tlmm 85 GPIO_ACTIVE_HIGH>;
++		pinctrl-0 = <&mcu_en_default>;
++		pinctrl-names = "default";
++	};
++};
++
++&ufs_mem_phy {
++	vdda-phy-supply = <&vreg_l1j_0p91>;
++	vdda-pll-supply = <&vreg_l3g_1p2>;
++
++	status = "okay";
++};
++
++&ufs_mem_hc {
++	reset-gpios = <&tlmm 215 GPIO_ACTIVE_LOW>;
++
++	vcc-supply = <&vreg_l17b_2p5>;
++	vcc-max-microamp = <1300000>;
++	vccq-supply = <&vreg_l1d_1p2>;
++	vccq-max-microamp = <1200000>;
++
++	/delete-property/ resets;
++	/delete-property/ reset-names;
++
++	status = "okay";
++};
++
++&usb {
++	status = "okay";
++};
++
++&usb_dp_qmpphy {
++	vdda-phy-supply = <&vreg_l3g_1p2>;
++	vdda-pll-supply = <&vreg_l2d_0p88>;
++
++	mode-switch;
++
++	status = "okay";
++};
++
++&usb_dp_qmpphy_out {
++	remote-endpoint = <&redriver_ss_in>;
++};
++
++&usb_dwc3_hs {
++	remote-endpoint = <&pmic_glink_hs_in>;
++};
++
++&usb_hsphy {
++	vdd-supply = <&vreg_l2d_0p88>;
++	vdda12-supply = <&vreg_l3g_1p2>;
++
++	phys = <&pmih0108_eusb2_repeater>;
++
++	status = "okay";
++};
+diff --git a/drivers/bluetooth/btqca.c.orig b/drivers/bluetooth/btqca.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/bluetooth/btqca.c.orig
+@@ -0,0 +1,1058 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ *  Bluetooth supports for Qualcomm Atheros chips
++ *
++ *  Copyright (c) 2015 The Linux Foundation. All rights reserved.
++ */
++#include <linux/module.h>
++#include <linux/firmware.h>
++#include <linux/vmalloc.h>
++
++#include <net/bluetooth/bluetooth.h>
++#include <net/bluetooth/hci_core.h>
++
++#include "btqca.h"
++
++int qca_read_soc_version(struct hci_dev *hdev, struct qca_btsoc_version *ver,
++			 enum qca_btsoc_type soc_type)
++{
++	struct sk_buff *skb;
++	struct edl_event_hdr *edl;
++	char cmd;
++	int err = 0;
++	u8 event_type = HCI_EV_VENDOR;
++	u8 rlen = sizeof(*edl) + sizeof(*ver);
++	u8 rtype = EDL_APP_VER_RES_EVT;
++
++	bt_dev_dbg(hdev, "QCA Version Request");
++
++	/* Unlike other SoC's sending version command response as payload to
++	 * VSE event. WCN3991 sends version command response as a payload to
++	 * command complete event.
++	 */
++	if (soc_type >= QCA_WCN3991) {
++		event_type = 0;
++		rlen += 1;
++		rtype = EDL_PATCH_VER_REQ_CMD;
++	}
++
++	cmd = EDL_PATCH_VER_REQ_CMD;
++	skb = __hci_cmd_sync_ev(hdev, EDL_PATCH_CMD_OPCODE, EDL_PATCH_CMD_LEN,
++				&cmd, event_type, HCI_INIT_TIMEOUT);
++	if (IS_ERR(skb)) {
++		err = PTR_ERR(skb);
++		bt_dev_err(hdev, "Reading QCA version information failed (%d)",
++			   err);
++		return err;
++	}
++
++	if (skb->len != rlen) {
++		bt_dev_err(hdev, "QCA Version size mismatch len %d", skb->len);
++		err = -EILSEQ;
++		goto out;
++	}
++
++	edl = (struct edl_event_hdr *)(skb->data);
++
++	if (edl->cresp != EDL_CMD_REQ_RES_EVT ||
++	    edl->rtype != rtype) {
++		bt_dev_err(hdev, "QCA Wrong packet received %d %d", edl->cresp,
++			   edl->rtype);
++		err = -EIO;
++		goto out;
++	}
++
++	if (soc_type >= QCA_WCN3991)
++		memcpy(ver, edl->data + 1, sizeof(*ver));
++	else
++		memcpy(ver, &edl->data, sizeof(*ver));
++
++	bt_dev_info(hdev, "QCA Product ID   :0x%08x",
++		    le32_to_cpu(ver->product_id));
++	bt_dev_info(hdev, "QCA SOC Version  :0x%08x",
++		    le32_to_cpu(ver->soc_id));
++	bt_dev_info(hdev, "QCA ROM Version  :0x%08x",
++		    le16_to_cpu(ver->rom_ver));
++	bt_dev_info(hdev, "QCA Patch Version:0x%08x",
++		    le16_to_cpu(ver->patch_ver));
++
++	if (ver->soc_id == 0 || ver->rom_ver == 0)
++		err = -EILSEQ;
++
++out:
++	kfree_skb(skb);
++	if (err)
++		bt_dev_err(hdev, "QCA Failed to get version (%d)", err);
++
++	return err;
++}
++EXPORT_SYMBOL_GPL(qca_read_soc_version);
++
++static int qca_read_fw_build_info(struct hci_dev *hdev)
++{
++	struct sk_buff *skb;
++	struct edl_event_hdr *edl;
++	char *build_label;
++	char cmd;
++	int build_lbl_len, err = 0;
++
++	bt_dev_dbg(hdev, "QCA read fw build info");
++
++	cmd = EDL_GET_BUILD_INFO_CMD;
++	skb = __hci_cmd_sync_ev(hdev, EDL_PATCH_CMD_OPCODE, EDL_PATCH_CMD_LEN,
++				&cmd, 0, HCI_INIT_TIMEOUT);
++	if (IS_ERR(skb)) {
++		err = PTR_ERR(skb);
++		bt_dev_err(hdev, "Reading QCA fw build info failed (%d)",
++			   err);
++		return err;
++	}
++
++	if (skb->len < sizeof(*edl)) {
++		err = -EILSEQ;
++		goto out;
++	}
++
++	edl = (struct edl_event_hdr *)(skb->data);
++
++	if (edl->cresp != EDL_CMD_REQ_RES_EVT ||
++	    edl->rtype != EDL_GET_BUILD_INFO_CMD) {
++		bt_dev_err(hdev, "QCA Wrong packet received %d %d", edl->cresp,
++			   edl->rtype);
++		err = -EIO;
++		goto out;
++	}
++
++	if (skb->len < sizeof(*edl) + 1) {
++		err = -EILSEQ;
++		goto out;
++	}
++
++	build_lbl_len = edl->data[0];
++
++	if (skb->len < sizeof(*edl) + 1 + build_lbl_len) {
++		err = -EILSEQ;
++		goto out;
++	}
++
++	build_label = kstrndup(&edl->data[1], build_lbl_len, GFP_KERNEL);
++	if (!build_label) {
++		err = -ENOMEM;
++		goto out;
++	}
++
++	hci_set_fw_info(hdev, "%s", build_label);
++
++	kfree(build_label);
++out:
++	kfree_skb(skb);
++	return err;
++}
++
++static int qca_send_patch_config_cmd(struct hci_dev *hdev)
++{
++	const u8 cmd[] = { EDL_PATCH_CONFIG_CMD, 0x01, 0, 0, 0 };
++	struct sk_buff *skb;
++	struct edl_event_hdr *edl;
++	int err;
++
++	bt_dev_dbg(hdev, "QCA Patch config");
++
++	skb = __hci_cmd_sync_ev(hdev, EDL_PATCH_CMD_OPCODE, sizeof(cmd),
++				cmd, 0, HCI_INIT_TIMEOUT);
++	if (IS_ERR(skb)) {
++		err = PTR_ERR(skb);
++		bt_dev_err(hdev, "Sending QCA Patch config failed (%d)", err);
++		return err;
++	}
++
++	if (skb->len != 2) {
++		bt_dev_err(hdev, "QCA Patch config cmd size mismatch len %d", skb->len);
++		err = -EILSEQ;
++		goto out;
++	}
++
++	edl = (struct edl_event_hdr *)(skb->data);
++
++	if (edl->cresp != EDL_PATCH_CONFIG_RES_EVT || edl->rtype != EDL_PATCH_CONFIG_CMD) {
++		bt_dev_err(hdev, "QCA Wrong packet received %d %d", edl->cresp,
++			   edl->rtype);
++		err = -EIO;
++		goto out;
++	}
++
++	err = 0;
++
++out:
++	kfree_skb(skb);
++	return err;
++}
++
++static int qca_send_reset(struct hci_dev *hdev)
++{
++	struct sk_buff *skb;
++	int err;
++
++	bt_dev_dbg(hdev, "QCA HCI_RESET");
++
++	skb = __hci_cmd_sync(hdev, HCI_OP_RESET, 0, NULL, HCI_INIT_TIMEOUT);
++	if (IS_ERR(skb)) {
++		err = PTR_ERR(skb);
++		bt_dev_err(hdev, "QCA Reset failed (%d)", err);
++		return err;
++	}
++
++	kfree_skb(skb);
++
++	return 0;
++}
++
++static int qca_read_fw_board_id(struct hci_dev *hdev, u16 *bid)
++{
++	u8 cmd;
++	struct sk_buff *skb;
++	struct edl_event_hdr *edl;
++	int err = 0;
++
++	cmd = EDL_GET_BID_REQ_CMD;
++	skb = __hci_cmd_sync_ev(hdev, EDL_PATCH_CMD_OPCODE, EDL_PATCH_CMD_LEN,
++				&cmd, 0, HCI_INIT_TIMEOUT);
++	if (IS_ERR(skb)) {
++		err = PTR_ERR(skb);
++		bt_dev_err(hdev, "Reading QCA board ID failed (%d)", err);
++		return err;
++	}
++
++	edl = skb_pull_data(skb, sizeof(*edl));
++	if (!edl) {
++		bt_dev_err(hdev, "QCA read board ID with no header");
++		err = -EILSEQ;
++		goto out;
++	}
++
++	if (edl->cresp != EDL_CMD_REQ_RES_EVT ||
++	    edl->rtype != EDL_GET_BID_REQ_CMD) {
++		bt_dev_err(hdev, "QCA Wrong packet: %d %d", edl->cresp, edl->rtype);
++		err = -EIO;
++		goto out;
++	}
++
++	if (skb->len < 3) {
++		err = -EILSEQ;
++		goto out;
++	}
++
++	*bid = (edl->data[1] << 8) + edl->data[2];
++	bt_dev_dbg(hdev, "%s: bid = %x", __func__, *bid);
++
++out:
++	kfree_skb(skb);
++	return err;
++}
++
++int qca_send_pre_shutdown_cmd(struct hci_dev *hdev)
++{
++	struct sk_buff *skb;
++	int err;
++
++	bt_dev_dbg(hdev, "QCA pre shutdown cmd");
++
++	skb = __hci_cmd_sync_ev(hdev, QCA_PRE_SHUTDOWN_CMD, 0,
++				NULL, HCI_EV_CMD_COMPLETE, HCI_INIT_TIMEOUT);
++
++	if (IS_ERR(skb)) {
++		err = PTR_ERR(skb);
++		bt_dev_err(hdev, "QCA preshutdown_cmd failed (%d)", err);
++		return err;
++	}
++
++	kfree_skb(skb);
++
++	return 0;
++}
++EXPORT_SYMBOL_GPL(qca_send_pre_shutdown_cmd);
++
++static bool qca_filename_has_extension(const char *filename)
++{
++	const char *suffix = strrchr(filename, '.');
++
++	/* File extensions require a dot, but not as the first or last character */
++	if (!suffix || suffix == filename || *(suffix + 1) == '\0')
++		return 0;
++
++	/* Avoid matching directories with names that look like files with extensions */
++	return !strchr(suffix, '/');
++}
++
++static bool qca_get_alt_nvm_file(char *filename, size_t max_size)
++{
++	char fwname[64];
++	const char *suffix;
++
++	/* nvm file name has an extension, replace with .bin */
++	if (qca_filename_has_extension(filename)) {
++		suffix = strrchr(filename, '.');
++		strscpy(fwname, filename, suffix - filename + 1);
++		snprintf(fwname + (suffix - filename),
++		       sizeof(fwname) - (suffix - filename), ".bin");
++		/* If nvm file is already the default one, return false to skip the retry. */
++		if (strcmp(fwname, filename) == 0)
++			return false;
++
++		snprintf(filename, max_size, "%s", fwname);
++		return true;
++	}
++	return false;
++}
++
++static int qca_tlv_check_data(struct hci_dev *hdev,
++			       struct qca_fw_config *config,
++			       u8 *fw_data, size_t fw_size,
++			       enum qca_btsoc_type soc_type)
++{
++	const u8 *data;
++	u32 type_len;
++	u16 tag_id, tag_len;
++	int idx, length;
++	struct tlv_type_hdr *tlv;
++	struct tlv_type_patch *tlv_patch;
++	struct tlv_type_nvm *tlv_nvm;
++	uint8_t nvm_baud_rate = config->user_baud_rate;
++	u8 type;
++
++	config->dnld_mode = QCA_SKIP_EVT_NONE;
++	config->dnld_type = QCA_SKIP_EVT_NONE;
++
++	switch (config->type) {
++	case ELF_TYPE_PATCH:
++		if (fw_size < 7)
++			return -EINVAL;
++
++		config->dnld_mode = QCA_SKIP_EVT_VSE_CC;
++		config->dnld_type = QCA_SKIP_EVT_VSE_CC;
++
++		bt_dev_dbg(hdev, "File Class        : 0x%x", fw_data[4]);
++		bt_dev_dbg(hdev, "Data Encoding     : 0x%x", fw_data[5]);
++		bt_dev_dbg(hdev, "File version      : 0x%x", fw_data[6]);
++		break;
++	case TLV_TYPE_PATCH:
++		if (fw_size < sizeof(struct tlv_type_hdr) + sizeof(struct tlv_type_patch))
++			return -EINVAL;
++
++		tlv = (struct tlv_type_hdr *)fw_data;
++		type_len = le32_to_cpu(tlv->type_len);
++		tlv_patch = (struct tlv_type_patch *)tlv->data;
++
++		/* For Rome version 1.1 to 3.1, all segment commands
++		 * are acked by a vendor specific event (VSE).
++		 * For Rome >= 3.2, the download mode field indicates
++		 * if VSE is skipped by the controller.
++		 * In case VSE is skipped, only the last segment is acked.
++		 */
++		config->dnld_mode = tlv_patch->download_mode;
++		config->dnld_type = config->dnld_mode;
++
++		BT_DBG("TLV Type\t\t : 0x%x", type_len & 0x000000ff);
++		BT_DBG("Total Length           : %d bytes",
++		       le32_to_cpu(tlv_patch->total_size));
++		BT_DBG("Patch Data Length      : %d bytes",
++		       le32_to_cpu(tlv_patch->data_length));
++		BT_DBG("Signing Format Version : 0x%x",
++		       tlv_patch->format_version);
++		BT_DBG("Signature Algorithm    : 0x%x",
++		       tlv_patch->signature);
++		BT_DBG("Download mode          : 0x%x",
++		       tlv_patch->download_mode);
++		BT_DBG("Reserved               : 0x%x",
++		       tlv_patch->reserved1);
++		BT_DBG("Product ID             : 0x%04x",
++		       le16_to_cpu(tlv_patch->product_id));
++		BT_DBG("Rom Build Version      : 0x%04x",
++		       le16_to_cpu(tlv_patch->rom_build));
++		BT_DBG("Patch Version          : 0x%04x",
++		       le16_to_cpu(tlv_patch->patch_version));
++		BT_DBG("Reserved               : 0x%x",
++		       le16_to_cpu(tlv_patch->reserved2));
++		BT_DBG("Patch Entry Address    : 0x%x",
++		       le32_to_cpu(tlv_patch->entry));
++		break;
++
++	case TLV_TYPE_NVM:
++		if (fw_size < sizeof(struct tlv_type_hdr))
++			return -EINVAL;
++
++		tlv = (struct tlv_type_hdr *)fw_data;
++
++		type_len = le32_to_cpu(tlv->type_len);
++		length = type_len >> 8;
++		type = type_len & 0xff;
++
++		/* Some NVM files have more than one set of tags, only parse
++		 * the first set when it has type 2 for now. When there is
++		 * more than one set there is an enclosing header of type 4.
++		 */
++		if (type == 4) {
++			if (fw_size < 2 * sizeof(struct tlv_type_hdr))
++				return -EINVAL;
++
++			tlv++;
++
++			type_len = le32_to_cpu(tlv->type_len);
++			length = type_len >> 8;
++			type = type_len & 0xff;
++		}
++
++		BT_DBG("TLV Type\t\t : 0x%x", type);
++		BT_DBG("Length\t\t : %d bytes", length);
++
++		if (type != 2)
++			break;
++
++		if (fw_size < length + (tlv->data - fw_data))
++			return -EINVAL;
++
++		idx = 0;
++		data = tlv->data;
++		while (idx + sizeof(struct tlv_type_nvm) <= length) {
++			tlv_nvm = (struct tlv_type_nvm *)(data + idx);
++
++			tag_id = le16_to_cpu(tlv_nvm->tag_id);
++			tag_len = le16_to_cpu(tlv_nvm->tag_len);
++
++			if (length < idx + sizeof(struct tlv_type_nvm) + tag_len)
++				return -EINVAL;
++
++			/* Update NVM tags as needed */
++			switch (tag_id) {
++			case EDL_TAG_ID_BD_ADDR:
++				if (tag_len != sizeof(bdaddr_t))
++					return -EINVAL;
++
++				memcpy(&config->bdaddr, tlv_nvm->data, sizeof(bdaddr_t));
++
++				break;
++
++			case EDL_TAG_ID_HCI:
++				if (tag_len < 3)
++					return -EINVAL;
++
++				/* HCI transport layer parameters
++				 * enabling software inband sleep
++				 * onto controller side.
++				 */
++				tlv_nvm->data[0] |= 0x80;
++
++				/* UART Baud Rate */
++				if (soc_type >= QCA_WCN3991)
++					tlv_nvm->data[1] = nvm_baud_rate;
++				else
++					tlv_nvm->data[2] = nvm_baud_rate;
++
++				break;
++
++			case EDL_TAG_ID_DEEP_SLEEP:
++				if (tag_len < 1)
++					return -EINVAL;
++
++				/* Sleep enable mask
++				 * enabling deep sleep feature on controller.
++				 */
++				tlv_nvm->data[0] |= 0x01;
++
++				break;
++			}
++
++			idx += sizeof(struct tlv_type_nvm) + tag_len;
++		}
++		break;
++
++	default:
++		BT_ERR("Unknown TLV type %d", config->type);
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int qca_tlv_send_segment(struct hci_dev *hdev, int seg_size,
++				const u8 *data, enum qca_tlv_dnld_mode mode,
++				enum qca_btsoc_type soc_type)
++{
++	struct sk_buff *skb;
++	struct edl_event_hdr *edl;
++	struct tlv_seg_resp *tlv_resp;
++	u8 cmd[MAX_SIZE_PER_TLV_SEGMENT + 2];
++	int err = 0;
++	u8 event_type = HCI_EV_VENDOR;
++	u8 rlen = (sizeof(*edl) + sizeof(*tlv_resp));
++	u8 rtype = EDL_TVL_DNLD_RES_EVT;
++
++	cmd[0] = EDL_PATCH_TLV_REQ_CMD;
++	cmd[1] = seg_size;
++	memcpy(cmd + 2, data, seg_size);
++
++	if (mode == QCA_SKIP_EVT_VSE_CC || mode == QCA_SKIP_EVT_VSE)
++		return __hci_cmd_send(hdev, EDL_PATCH_CMD_OPCODE, seg_size + 2,
++				      cmd);
++
++	/* Unlike other SoC's sending version command response as payload to
++	 * VSE event. WCN3991 sends version command response as a payload to
++	 * command complete event.
++	 */
++	if (soc_type >= QCA_WCN3991) {
++		event_type = 0;
++		rlen = sizeof(*edl);
++		rtype = EDL_PATCH_TLV_REQ_CMD;
++	}
++
++	skb = __hci_cmd_sync_ev(hdev, EDL_PATCH_CMD_OPCODE, seg_size + 2, cmd,
++				event_type, HCI_INIT_TIMEOUT);
++	if (IS_ERR(skb)) {
++		err = PTR_ERR(skb);
++		bt_dev_err(hdev, "QCA Failed to send TLV segment (%d)", err);
++		return err;
++	}
++
++	if (skb->len != rlen) {
++		bt_dev_err(hdev, "QCA TLV response size mismatch");
++		err = -EILSEQ;
++		goto out;
++	}
++
++	edl = (struct edl_event_hdr *)(skb->data);
++
++	if (edl->cresp != EDL_CMD_REQ_RES_EVT || edl->rtype != rtype) {
++		bt_dev_err(hdev, "QCA TLV with error stat 0x%x rtype 0x%x",
++			   edl->cresp, edl->rtype);
++		err = -EIO;
++	}
++
++	if (soc_type >= QCA_WCN3991)
++		goto out;
++
++	tlv_resp = (struct tlv_seg_resp *)(edl->data);
++	if (tlv_resp->result) {
++		bt_dev_err(hdev, "QCA TLV with error stat 0x%x rtype 0x%x (0x%x)",
++			   edl->cresp, edl->rtype, tlv_resp->result);
++	}
++
++out:
++	kfree_skb(skb);
++
++	return err;
++}
++
++static int qca_inject_cmd_complete_event(struct hci_dev *hdev)
++{
++	struct hci_event_hdr *hdr;
++	struct hci_ev_cmd_complete *evt;
++	struct sk_buff *skb;
++
++	skb = bt_skb_alloc(sizeof(*hdr) + sizeof(*evt) + 1, GFP_KERNEL);
++	if (!skb)
++		return -ENOMEM;
++
++	hdr = skb_put(skb, sizeof(*hdr));
++	hdr->evt = HCI_EV_CMD_COMPLETE;
++	hdr->plen = sizeof(*evt) + 1;
++
++	evt = skb_put(skb, sizeof(*evt));
++	evt->ncmd = 1;
++	evt->opcode = cpu_to_le16(QCA_HCI_CC_OPCODE);
++
++	skb_put_u8(skb, QCA_HCI_CC_SUCCESS);
++
++	hci_skb_pkt_type(skb) = HCI_EVENT_PKT;
++
++	return hci_recv_frame(hdev, skb);
++}
++
++static int qca_download_firmware(struct hci_dev *hdev,
++				 struct qca_fw_config *config,
++				 enum qca_btsoc_type soc_type,
++				 u8 rom_ver)
++{
++	const struct firmware *fw;
++	u8 *data;
++	const u8 *segment;
++	int ret, size, remain, i = 0;
++
++	bt_dev_info(hdev, "QCA Downloading %s", config->fwname);
++
++	ret = request_firmware(&fw, config->fwname, &hdev->dev);
++	if (ret) {
++		/* If the board-specific file is missing, try loading the default
++		 * one, unless that was attempted already.
++		 */
++		if (config->type == TLV_TYPE_NVM &&
++		    qca_get_alt_nvm_file(config->fwname, sizeof(config->fwname))) {
++			bt_dev_info(hdev, "QCA Downloading %s", config->fwname);
++			ret = request_firmware(&fw, config->fwname, &hdev->dev);
++			if (ret) {
++				bt_dev_err(hdev, "QCA Failed to request file: %s (%d)",
++					   config->fwname, ret);
++				return ret;
++			}
++		} else {
++			bt_dev_err(hdev, "QCA Failed to request file: %s (%d)",
++				   config->fwname, ret);
++			return ret;
++		}
++	}
++
++	size = fw->size;
++	data = vmalloc(fw->size);
++	if (!data) {
++		bt_dev_err(hdev, "QCA Failed to allocate memory for file: %s",
++			   config->fwname);
++		release_firmware(fw);
++		return -ENOMEM;
++	}
++
++	memcpy(data, fw->data, size);
++	release_firmware(fw);
++
++	ret = qca_tlv_check_data(hdev, config, data, size, soc_type);
++	if (ret)
++		goto out;
++
++	segment = data;
++	remain = size;
++	while (remain > 0) {
++		int segsize = min(MAX_SIZE_PER_TLV_SEGMENT, remain);
++
++		bt_dev_dbg(hdev, "Send segment %d, size %d", i++, segsize);
++
++		remain -= segsize;
++		/* The last segment is always acked regardless download mode */
++		if (!remain || segsize < MAX_SIZE_PER_TLV_SEGMENT)
++			config->dnld_mode = QCA_SKIP_EVT_NONE;
++
++		ret = qca_tlv_send_segment(hdev, segsize, segment,
++					   config->dnld_mode, soc_type);
++		if (ret)
++			goto out;
++
++		segment += segsize;
++	}
++
++	/* Latest qualcomm chipsets are not sending a command complete event
++	 * for every fw packet sent. They only respond with a vendor specific
++	 * event for the last packet. This optimization in the chip will
++	 * decrease the BT in initialization time. Here we will inject a command
++	 * complete event to avoid a command timeout error message.
++	 */
++	if (config->dnld_type == QCA_SKIP_EVT_VSE_CC ||
++	    config->dnld_type == QCA_SKIP_EVT_VSE)
++		ret = qca_inject_cmd_complete_event(hdev);
++
++out:
++	vfree(data);
++
++	return ret;
++}
++
++static int qca_disable_soc_logging(struct hci_dev *hdev)
++{
++	struct sk_buff *skb;
++	u8 cmd[2];
++	int err;
++
++	cmd[0] = QCA_DISABLE_LOGGING_SUB_OP;
++	cmd[1] = 0x00;
++	skb = __hci_cmd_sync_ev(hdev, QCA_DISABLE_LOGGING, sizeof(cmd), cmd,
++				HCI_EV_CMD_COMPLETE, HCI_INIT_TIMEOUT);
++	if (IS_ERR(skb)) {
++		err = PTR_ERR(skb);
++		bt_dev_err(hdev, "QCA Failed to disable soc logging(%d)", err);
++		return err;
++	}
++
++	kfree_skb(skb);
++
++	return 0;
++}
++
++int qca_set_bdaddr_rome(struct hci_dev *hdev, const bdaddr_t *bdaddr)
++{
++	struct sk_buff *skb;
++	u8 cmd[9];
++	int err;
++
++	cmd[0] = EDL_NVM_ACCESS_SET_REQ_CMD;
++	cmd[1] = 0x02; 			/* TAG ID */
++	cmd[2] = sizeof(bdaddr_t);	/* size */
++	memcpy(cmd + 3, bdaddr, sizeof(bdaddr_t));
++	skb = __hci_cmd_sync_ev(hdev, EDL_NVM_ACCESS_OPCODE, sizeof(cmd), cmd,
++				HCI_EV_VENDOR, HCI_INIT_TIMEOUT);
++	if (IS_ERR(skb)) {
++		err = PTR_ERR(skb);
++		bt_dev_err(hdev, "QCA Change address command failed (%d)", err);
++		return err;
++	}
++
++	kfree_skb(skb);
++
++	return 0;
++}
++EXPORT_SYMBOL_GPL(qca_set_bdaddr_rome);
++
++static int qca_check_bdaddr(struct hci_dev *hdev, const struct qca_fw_config *config)
++{
++	struct hci_rp_read_bd_addr *bda;
++	struct sk_buff *skb;
++	int err;
++
++	if (bacmp(&hdev->public_addr, BDADDR_ANY))
++		return 0;
++
++	skb = __hci_cmd_sync(hdev, HCI_OP_READ_BD_ADDR, 0, NULL,
++			     HCI_INIT_TIMEOUT);
++	if (IS_ERR(skb)) {
++		err = PTR_ERR(skb);
++		bt_dev_err(hdev, "Failed to read device address (%d)", err);
++		return err;
++	}
++
++	if (skb->len != sizeof(*bda)) {
++		bt_dev_err(hdev, "Device address length mismatch");
++		kfree_skb(skb);
++		return -EIO;
++	}
++
++	bda = (struct hci_rp_read_bd_addr *)skb->data;
++	if (!bacmp(&bda->bdaddr, &config->bdaddr))
++		hci_set_quirk(hdev, HCI_QUIRK_USE_BDADDR_PROPERTY);
++
++	kfree_skb(skb);
++
++	return 0;
++}
++
++static void qca_get_nvm_name_by_board(char *fwname, size_t max_size,
++		const char *stem, enum qca_btsoc_type soc_type,
++		struct qca_btsoc_version ver, u8 rom_ver, u16 bid)
++{
++	const char *variant;
++	const char *prefix;
++
++	/* Set the default value to variant and prefix */
++	variant = "";
++	prefix = "b";
++
++	if (soc_type == QCA_QCA2066)
++		prefix = "";
++
++	if (soc_type == QCA_WCN6855 || soc_type == QCA_QCA2066) {
++		/* If the chip is manufactured by GlobalFoundries */
++		if ((le32_to_cpu(ver.soc_id) & QCA_HSP_GF_SOC_MASK) == QCA_HSP_GF_SOC_ID)
++			variant = "g";
++	}
++
++	if (rom_ver != 0) {
++		if (bid == 0x0 || bid == 0xffff)
++			snprintf(fwname, max_size, "qca/%s%02x%s.bin", stem, rom_ver, variant);
++		else
++			snprintf(fwname, max_size, "qca/%s%02x%s.%s%02x", stem, rom_ver,
++						variant, prefix, bid);
++	} else {
++		if (bid == 0x0 || bid == 0xffff)
++			snprintf(fwname, max_size, "qca/%s%s.bin", stem, variant);
++		else
++			snprintf(fwname, max_size, "qca/%s%s.%s%02x", stem, variant, prefix, bid);
++	}
++}
++
++int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
++		   enum qca_btsoc_type soc_type, struct qca_btsoc_version ver,
++		   const char *firmware_name, const char *rampatch_name)
++{
++	struct qca_fw_config config = {};
++	const char *variant = "";
++	int err;
++	u8 rom_ver = 0;
++	u32 soc_ver;
++	u16 boardid = 0;
++
++	bt_dev_dbg(hdev, "QCA setup on UART");
++
++	soc_ver = get_soc_ver(ver.soc_id, ver.rom_ver);
++
++	bt_dev_info(hdev, "QCA controller version 0x%08x", soc_ver);
++
++	config.user_baud_rate = baudrate;
++
++	/* Firmware files to download are based on ROM version.
++	 * ROM version is derived from last two bytes of soc_ver.
++	 */
++	if (soc_type == QCA_WCN3988)
++		rom_ver = ((soc_ver & 0x00000f00) >> 0x05) | (soc_ver & 0x0000000f);
++	else if (soc_type == QCA_WCN3998)
++		rom_ver = ((soc_ver & 0x0000f000) >> 0x07) | (soc_ver & 0x0000000f);
++	else
++		rom_ver = ((soc_ver & 0x00000f00) >> 0x04) | (soc_ver & 0x0000000f);
++
++	if (soc_type == QCA_WCN6750)
++		qca_send_patch_config_cmd(hdev);
++
++	/* Download rampatch file */
++	config.type = TLV_TYPE_PATCH;
++	if (rampatch_name) {
++		snprintf(config.fwname, sizeof(config.fwname), "qca/%s", rampatch_name);
++	} else {
++		switch (soc_type) {
++		case QCA_QCA2066:
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/hpbtfw%02x.tlv", rom_ver);
++			break;
++		case QCA_QCA6390:
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/htbtfw%02x.tlv", rom_ver);
++			break;
++		case QCA_WCN3950:
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/cmbtfw%02x.tlv", rom_ver);
++			break;
++		case QCA_WCN3990:
++		case QCA_WCN3991:
++		case QCA_WCN3998:
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/crbtfw%02x.tlv", rom_ver);
++			break;
++		case QCA_WCN3988:
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/apbtfw%02x.tlv", rom_ver);
++			break;
++		case QCA_WCN6750:
++			/* Choose mbn file by default.If mbn file is not found
++			 * then choose tlv file
++			 */
++			config.type = ELF_TYPE_PATCH;
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/msbtfw%02x.mbn", rom_ver);
++			break;
++		case QCA_WCN6855:
++			/* Due to historical reasons, WCN685x chip has been using firmware
++			 * without the "wcn" prefix. The mapping between the chip and its
++			 * corresponding firmware has now been corrected.
++			 */
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/wcnhpbtfw%02x.tlv", rom_ver);
++			break;
++		case QCA_WCN7850:
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/hmtbtfw%02x.tlv", rom_ver);
++			break;
++		case QCA_WCN7860:
++			config.type = ELF_TYPE_PATCH;
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/gngbtfw%02x.mbn", rom_ver);
++			break;
++		default:
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/rampatch_%08x.bin", soc_ver);
++		}
++	}
++
++	err = qca_download_firmware(hdev, &config, soc_type, rom_ver);
++	/* For WCN6750, if mbn file is not present then check for
++	 * tlv file.
++	 */
++	if (err < 0 && soc_type == QCA_WCN6750) {
++		bt_dev_dbg(hdev, "QCA Failed to request file: %s (%d)",
++			   config.fwname, err);
++		config.type = TLV_TYPE_PATCH;
++		snprintf(config.fwname, sizeof(config.fwname),
++			 "qca/msbtfw%02x.tlv", rom_ver);
++		bt_dev_info(hdev, "QCA Downloading %s", config.fwname);
++		err = qca_download_firmware(hdev, &config, soc_type, rom_ver);
++	} else if (err < 0 && !rampatch_name && soc_type == QCA_WCN6855) {
++		snprintf(config.fwname, sizeof(config.fwname),
++			 "qca/hpbtfw%02x.tlv", rom_ver);
++		err = qca_download_firmware(hdev, &config, soc_type, rom_ver);
++	}
++
++	if (err < 0) {
++		bt_dev_err(hdev, "QCA Failed to request file: %s (%d)",
++			   config.fwname, err);
++		return err;
++	}
++
++	/* Give the controller some time to get ready to receive the NVM */
++	msleep(10);
++
++	if (soc_type == QCA_QCA2066 || soc_type == QCA_WCN7850 || soc_type == QCA_WCN7860)
++		qca_read_fw_board_id(hdev, &boardid);
++
++	/* Download NVM configuration */
++	config.type = TLV_TYPE_NVM;
++	if (firmware_name) {
++		/* The firmware name has an extension, use it directly */
++		if (qca_filename_has_extension(firmware_name)) {
++			snprintf(config.fwname, sizeof(config.fwname), "qca/%s", firmware_name);
++		} else {
++			qca_read_fw_board_id(hdev, &boardid);
++			qca_get_nvm_name_by_board(config.fwname, sizeof(config.fwname),
++				 firmware_name, soc_type, ver, 0, boardid);
++		}
++	} else {
++		switch (soc_type) {
++		case QCA_QCA2066:
++			qca_get_nvm_name_by_board(config.fwname,
++						  sizeof(config.fwname),
++						  "hpnv", soc_type, ver,
++						  rom_ver, boardid);
++			break;
++		case QCA_QCA6390:
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/htnv%02x.bin", rom_ver);
++			break;
++		case QCA_WCN3950:
++			if (le32_to_cpu(ver.soc_id) == QCA_WCN3950_SOC_ID_T)
++				variant = "t";
++			else if (le32_to_cpu(ver.soc_id) == QCA_WCN3950_SOC_ID_S)
++				variant = "s";
++
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/cmnv%02x%s.bin", rom_ver, variant);
++			break;
++		case QCA_WCN3990:
++		case QCA_WCN3991:
++		case QCA_WCN3998:
++			if (le32_to_cpu(ver.soc_id) == QCA_WCN3991_SOC_ID)
++				variant = "u";
++
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/crnv%02x%s.bin", rom_ver, variant);
++			break;
++		case QCA_WCN3988:
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/apnv%02x.bin", rom_ver);
++			break;
++		case QCA_WCN6750:
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/msnv%02x.bin", rom_ver);
++			break;
++		case QCA_WCN6855:
++			qca_read_fw_board_id(hdev, &boardid);
++			qca_get_nvm_name_by_board(config.fwname, sizeof(config.fwname),
++						  "wcnhpnv", soc_type, ver, rom_ver, boardid);
++			break;
++		case QCA_WCN7850:
++			qca_get_nvm_name_by_board(config.fwname, sizeof(config.fwname),
++				 "hmtnv", soc_type, ver, rom_ver, boardid);
++			break;
++		case QCA_WCN7860:
++			qca_get_nvm_name_by_board(config.fwname, sizeof(config.fwname),
++				 "gngbtnv", soc_type, ver, rom_ver, boardid);
++			break;
++		default:
++			snprintf(config.fwname, sizeof(config.fwname),
++				 "qca/nvm_%08x.bin", soc_ver);
++		}
++	}
++
++	err = qca_download_firmware(hdev, &config, soc_type, rom_ver);
++	if (err < 0 && !firmware_name && soc_type == QCA_WCN6855) {
++		qca_get_nvm_name_by_board(config.fwname, sizeof(config.fwname),
++					  "hpnv", soc_type, ver, rom_ver, boardid);
++		err = qca_download_firmware(hdev, &config, soc_type, rom_ver);
++	}
++
++	if (err < 0) {
++		bt_dev_err(hdev, "QCA Failed to request file: %s (%d)",
++			   config.fwname, err);
++		return err;
++	}
++
++	switch (soc_type) {
++	case QCA_QCA2066:
++	case QCA_QCA6390:
++	case QCA_WCN3991:
++	case QCA_WCN6750:
++	case QCA_WCN6855:
++	case QCA_WCN7850:
++	case QCA_WCN7860:
++		err = qca_disable_soc_logging(hdev);
++		if (err < 0)
++			return err;
++		break;
++	default:
++		break;
++	}
++
++	/* WCN399x and WCN6750 supports the Microsoft vendor extension with 0xFD70 as the
++	 * VsMsftOpCode.
++	 */
++	switch (soc_type) {
++	case QCA_WCN3950:
++	case QCA_WCN3988:
++	case QCA_WCN3990:
++	case QCA_WCN3991:
++	case QCA_WCN3998:
++	case QCA_WCN6750:
++		hci_set_msft_opcode(hdev, 0xFD70);
++		break;
++	default:
++		break;
++	}
++
++	/* Perform HCI reset */
++	err = qca_send_reset(hdev);
++	if (err < 0) {
++		bt_dev_err(hdev, "QCA Failed to run HCI_RESET (%d)", err);
++		return err;
++	}
++
++	switch (soc_type) {
++	case QCA_WCN3991:
++	case QCA_WCN6750:
++	case QCA_WCN6855:
++	case QCA_WCN7850:
++	case QCA_WCN7860:
++		/* get fw build info */
++		err = qca_read_fw_build_info(hdev);
++		if (err < 0)
++			return err;
++		break;
++	default:
++		break;
++	}
++
++	err = qca_check_bdaddr(hdev, &config);
++	if (err)
++		return err;
++
++	bt_dev_info(hdev, "QCA setup on UART is completed");
++
++	return 0;
++}
++EXPORT_SYMBOL_GPL(qca_uart_setup);
++
++int qca_set_bdaddr(struct hci_dev *hdev, const bdaddr_t *bdaddr)
++{
++	bdaddr_t bdaddr_swapped;
++	struct sk_buff *skb;
++	int err;
++
++	baswap(&bdaddr_swapped, bdaddr);
++
++	skb = __hci_cmd_sync_ev(hdev, EDL_WRITE_BD_ADDR_OPCODE, 6,
++				&bdaddr_swapped, HCI_EV_VENDOR,
++				HCI_INIT_TIMEOUT);
++	if (IS_ERR(skb)) {
++		err = PTR_ERR(skb);
++		bt_dev_err(hdev, "QCA Change address cmd failed (%d)", err);
++		return err;
++	}
++
++	kfree_skb(skb);
++
++	return 0;
++}
++EXPORT_SYMBOL_GPL(qca_set_bdaddr);
++
++
++MODULE_AUTHOR("Ben Young Tae Kim <ytkim@qca.qualcomm.com>");
++MODULE_DESCRIPTION("Bluetooth support for Qualcomm Atheros family");
++MODULE_LICENSE("GPL");
+diff --git a/drivers/gpu/drm/msm/msm_gem.c.orig b/drivers/gpu/drm/msm/msm_gem.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/gpu/drm/msm/msm_gem.c.orig
+@@ -0,0 +1,1394 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (C) 2013 Red Hat
++ * Author: Rob Clark <robdclark@gmail.com>
++ */
++
++#include <linux/dma-map-ops.h>
++#include <linux/vmalloc.h>
++#include <linux/spinlock.h>
++#include <linux/shmem_fs.h>
++#include <linux/dma-buf.h>
++
++#include <drm/drm_dumb_buffers.h>
++#include <drm/drm_prime.h>
++#include <drm/drm_file.h>
++#include <drm/drm_fourcc.h>
++
++#include <trace/events/gpu_mem.h>
++
++#include "msm_drv.h"
++#include "msm_gem.h"
++#include "msm_gpu.h"
++#include "msm_kms.h"
++
++static void update_device_mem(struct msm_drm_private *priv, ssize_t size)
++{
++	uint64_t total_mem = atomic64_add_return(size, &priv->total_mem);
++	trace_gpu_mem_total(0, 0, total_mem);
++}
++
++static void update_ctx_mem(struct drm_file *file, ssize_t size)
++{
++	struct msm_context *ctx = file->driver_priv;
++	uint64_t ctx_mem = atomic64_add_return(size, &ctx->ctx_mem);
++
++	rcu_read_lock(); /* Locks file->pid! */
++	trace_gpu_mem_total(0, pid_nr(rcu_dereference(file->pid)), ctx_mem);
++	rcu_read_unlock();
++
++}
++
++static int msm_gem_open(struct drm_gem_object *obj, struct drm_file *file)
++{
++	msm_gem_vma_get(obj);
++	update_ctx_mem(file, obj->size);
++	return 0;
++}
++
++static void put_iova_spaces(struct drm_gem_object *obj, struct drm_gpuvm *vm,
++			    bool close, const char *reason);
++
++static void msm_gem_close(struct drm_gem_object *obj, struct drm_file *file)
++{
++	struct msm_context *ctx = file->driver_priv;
++	struct drm_exec exec;
++
++	update_ctx_mem(file, -obj->size);
++	msm_gem_vma_put(obj);
++
++	/*
++	 * If VM isn't created yet, nothing to cleanup.  And in fact calling
++	 * put_iova_spaces() with vm=NULL would be bad, in that it will tear-
++	 * down the mappings of shared buffers in other contexts.
++	 */
++	if (!ctx->vm)
++		return;
++
++	/*
++	 * VM_BIND does not depend on implicit teardown of VMAs on handle
++	 * close, but instead on implicit teardown of the VM when the device
++	 * is closed (see msm_gem_vm_close())
++	 */
++	if (msm_context_is_vmbind(ctx))
++		return;
++
++	/*
++	 * TODO we might need to kick this to a queue to avoid blocking
++	 * in CLOSE ioctl
++	 */
++	dma_resv_wait_timeout(obj->resv, DMA_RESV_USAGE_BOOKKEEP, false,
++			      MAX_SCHEDULE_TIMEOUT);
++
++	msm_gem_lock_vm_and_obj(&exec, obj, ctx->vm);
++	put_iova_spaces(obj, ctx->vm, true, "close");
++	drm_exec_fini(&exec);     /* drop locks */
++}
++
++/*
++ * Get/put for kms->vm VMA
++ */
++
++void msm_gem_vma_get(struct drm_gem_object *obj)
++{
++	atomic_inc(&to_msm_bo(obj)->vma_ref);
++}
++
++void msm_gem_vma_put(struct drm_gem_object *obj)
++{
++	struct msm_drm_private *priv = obj->dev->dev_private;
++
++	if (atomic_dec_return(&to_msm_bo(obj)->vma_ref))
++		return;
++
++	if (!priv->kms)
++		return;
++
++#ifdef CONFIG_DRM_MSM_KMS
++	struct drm_exec exec;
++
++	msm_gem_lock_vm_and_obj(&exec, obj, priv->kms->vm);
++	put_iova_spaces(obj, priv->kms->vm, true, "vma_put");
++	drm_exec_fini(&exec);     /* drop locks */
++#endif
++}
++
++/*
++ * Cache sync.. this is a bit over-complicated, to fit dma-mapping
++ * API.  Really GPU cache is out of scope here (handled on cmdstream)
++ * and all we need to do is invalidate newly allocated pages before
++ * mapping to CPU as uncached/writecombine.
++ *
++ * On top of this, we have the added headache, that depending on
++ * display generation, the display's iommu may be wired up to either
++ * the toplevel drm device (mdss), or to the mdp sub-node, meaning
++ * that here we either have dma-direct or iommu ops.
++ *
++ * Let this be a cautionary tail of abstraction gone wrong.
++ */
++
++static void sync_for_device(struct msm_gem_object *msm_obj)
++{
++	struct device *dev = msm_obj->base.dev->dev;
++
++	dma_map_sgtable(dev, msm_obj->sgt, DMA_BIDIRECTIONAL, 0);
++}
++
++static void sync_for_cpu(struct msm_gem_object *msm_obj)
++{
++	struct device *dev = msm_obj->base.dev->dev;
++
++	dma_unmap_sgtable(dev, msm_obj->sgt, DMA_BIDIRECTIONAL, 0);
++}
++
++static void update_lru_active(struct drm_gem_object *obj)
++{
++	struct msm_drm_private *priv = obj->dev->dev_private;
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	GEM_WARN_ON(!msm_obj->pages);
++
++	if (msm_obj->pin_count) {
++		drm_gem_lru_move_tail_locked(&priv->lru.pinned, obj);
++	} else if (msm_obj->madv == MSM_MADV_WILLNEED) {
++		drm_gem_lru_move_tail_locked(&priv->lru.willneed, obj);
++	} else {
++		GEM_WARN_ON(msm_obj->madv != MSM_MADV_DONTNEED);
++
++		drm_gem_lru_move_tail_locked(&priv->lru.dontneed, obj);
++	}
++}
++
++static void update_lru_locked(struct drm_gem_object *obj)
++{
++	struct msm_drm_private *priv = obj->dev->dev_private;
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	msm_gem_assert_locked(&msm_obj->base);
++
++	if (!msm_obj->pages) {
++		GEM_WARN_ON(msm_obj->pin_count);
++
++		drm_gem_lru_move_tail_locked(&priv->lru.unbacked, obj);
++	} else {
++		update_lru_active(obj);
++	}
++}
++
++static void update_lru(struct drm_gem_object *obj)
++{
++	struct drm_device *dev = obj->dev;
++
++	mutex_lock(&dev->gem_lru_mutex);
++	update_lru_locked(obj);
++	mutex_unlock(&dev->gem_lru_mutex);
++}
++
++static struct page **get_pages(struct drm_gem_object *obj)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	msm_gem_assert_locked(obj);
++
++	if (!msm_obj->pages) {
++		struct drm_device *dev = obj->dev;
++		struct page **p;
++		size_t npages = obj->size >> PAGE_SHIFT;
++
++		p = drm_gem_get_pages(obj);
++
++		if (IS_ERR(p)) {
++			DRM_DEV_ERROR(dev->dev, "could not get pages: %ld\n",
++					PTR_ERR(p));
++			return p;
++		}
++
++		update_device_mem(dev->dev_private, obj->size);
++
++		msm_obj->pages = p;
++
++		msm_obj->sgt = drm_prime_pages_to_sg(obj->dev, p, npages);
++		if (IS_ERR(msm_obj->sgt)) {
++			void *ptr = ERR_CAST(msm_obj->sgt);
++
++			DRM_DEV_ERROR(dev->dev, "failed to allocate sgt\n");
++			msm_obj->sgt = NULL;
++			return ptr;
++		}
++
++		/* For non-cached buffers, ensure the new pages are clean
++		 * because display controller, GPU, etc. are not coherent:
++		 */
++		if (msm_obj->flags & MSM_BO_WC)
++			sync_for_device(msm_obj);
++
++		update_lru(obj);
++	}
++
++	return msm_obj->pages;
++}
++
++static void put_pages(struct drm_gem_object *obj)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	/*
++	 * Skip gpuvm in the object free path to avoid a WARN_ON() splat.
++	 * See explaination in msm_gem_assert_locked()
++	 */
++	if (kref_read(&obj->refcount))
++		drm_gpuvm_bo_gem_evict(obj, true);
++
++	if (msm_obj->pages) {
++		if (msm_obj->sgt) {
++			/* For non-cached buffers, ensure the new
++			 * pages are clean because display controller,
++			 * GPU, etc. are not coherent:
++			 */
++			if (msm_obj->flags & MSM_BO_WC)
++				sync_for_cpu(msm_obj);
++
++			sg_free_table(msm_obj->sgt);
++			kfree(msm_obj->sgt);
++			msm_obj->sgt = NULL;
++		}
++
++		update_device_mem(obj->dev->dev_private, -obj->size);
++
++		drm_gem_put_pages(obj, msm_obj->pages, true, false);
++
++		msm_obj->pages = NULL;
++		update_lru(obj);
++	}
++}
++
++struct page **msm_gem_get_pages_locked(struct drm_gem_object *obj, unsigned madv)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	msm_gem_assert_locked(obj);
++
++	if (msm_obj->madv > madv) {
++		DRM_DEV_DEBUG_DRIVER(obj->dev->dev, "Invalid madv state: %u vs %u\n",
++				     msm_obj->madv, madv);
++		return ERR_PTR(-EBUSY);
++	}
++
++	return get_pages(obj);
++}
++
++/*
++ * Update the pin count of the object, call under lru.lock
++ */
++void msm_gem_pin_obj_locked(struct drm_gem_object *obj)
++{
++	struct msm_drm_private *priv = obj->dev->dev_private;
++
++	msm_gem_assert_locked(obj);
++
++	to_msm_bo(obj)->pin_count++;
++	drm_gem_lru_move_tail_locked(&priv->lru.pinned, obj);
++}
++
++static void pin_obj_locked(struct drm_gem_object *obj)
++{
++	struct drm_device *dev = obj->dev;
++
++	mutex_lock(&dev->gem_lru_mutex);
++	msm_gem_pin_obj_locked(obj);
++	mutex_unlock(&dev->gem_lru_mutex);
++}
++
++struct page **msm_gem_pin_pages_locked(struct drm_gem_object *obj)
++{
++	struct page **p;
++
++	msm_gem_assert_locked(obj);
++
++	p = msm_gem_get_pages_locked(obj, MSM_MADV_WILLNEED);
++	if (!IS_ERR(p))
++		pin_obj_locked(obj);
++
++	return p;
++}
++
++void msm_gem_unpin_pages_locked(struct drm_gem_object *obj)
++{
++	msm_gem_assert_locked(obj);
++
++	msm_gem_unpin_locked(obj);
++}
++
++static pgprot_t msm_gem_pgprot(struct msm_gem_object *msm_obj, pgprot_t prot)
++{
++	if (msm_obj->flags & MSM_BO_WC)
++		return pgprot_writecombine(prot);
++	return prot;
++}
++
++static vm_fault_t msm_gem_fault(struct vm_fault *vmf)
++{
++	struct vm_area_struct *vma = vmf->vma;
++	struct drm_gem_object *obj = vma->vm_private_data;
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++	struct page **pages;
++	unsigned long pfn;
++	pgoff_t pgoff;
++	int err;
++	vm_fault_t ret;
++
++	/*
++	 * vm_ops.open/drm_gem_mmap_obj and close get and put
++	 * a reference on obj. So, we dont need to hold one here.
++	 */
++	err = msm_gem_lock_interruptible(obj);
++	if (err) {
++		ret = VM_FAULT_NOPAGE;
++		goto out;
++	}
++
++	if (GEM_WARN_ON(msm_obj->madv != MSM_MADV_WILLNEED)) {
++		msm_gem_unlock(obj);
++		return VM_FAULT_SIGBUS;
++	}
++
++	/* make sure we have pages attached now */
++	pages = get_pages(obj);
++	if (IS_ERR(pages)) {
++		ret = vmf_error(PTR_ERR(pages));
++		goto out_unlock;
++	}
++
++	/* We don't use vmf->pgoff since that has the fake offset: */
++	pgoff = (vmf->address - vma->vm_start) >> PAGE_SHIFT;
++
++	pfn = page_to_pfn(pages[pgoff]);
++
++	VERB("Inserting %p pfn %lx, pa %lx", (void *)vmf->address,
++			pfn, pfn << PAGE_SHIFT);
++
++	ret = vmf_insert_pfn(vma, vmf->address, pfn);
++
++out_unlock:
++	msm_gem_unlock(obj);
++out:
++	return ret;
++}
++
++
++static struct drm_gpuva *lookup_vma(struct drm_gem_object *obj,
++				    struct drm_gpuvm *vm)
++{
++	struct drm_gpuvm_bo *vm_bo;
++
++	msm_gem_assert_locked(obj);
++
++	drm_gem_for_each_gpuvm_bo (vm_bo, obj) {
++		struct drm_gpuva *vma;
++
++		drm_gpuvm_bo_for_each_va (vma, vm_bo) {
++			if (vma->vm == vm) {
++				/* lookup_vma() should only be used in paths
++				 * with at most one vma per vm
++				 */
++				GEM_WARN_ON(!list_is_singular(&vm_bo->list.gpuva));
++
++				return vma;
++			}
++		}
++	}
++
++	return NULL;
++}
++
++/*
++ * If close is true, this also closes the VMA (releasing the allocated
++ * iova range) in addition to removing the iommu mapping.  In the eviction
++ * case (!close), we keep the iova allocated, but only remove the iommu
++ * mapping.
++ */
++static void
++put_iova_spaces(struct drm_gem_object *obj, struct drm_gpuvm *vm,
++		bool close, const char *reason)
++{
++	struct drm_gpuvm_bo *vm_bo, *tmp;
++
++	msm_gem_assert_locked(obj);
++
++	drm_gem_for_each_gpuvm_bo_safe (vm_bo, tmp, obj) {
++		struct drm_gpuva *vma, *vmatmp;
++
++		if (vm && vm_bo->vm != vm)
++			continue;
++
++		drm_gpuvm_bo_get(vm_bo);
++
++		drm_gpuvm_bo_for_each_va_safe (vma, vmatmp, vm_bo) {
++			msm_gem_vma_unmap(vma, reason);
++			if (close)
++				msm_gem_vma_close(vma);
++		}
++
++		drm_gpuvm_bo_put(vm_bo);
++	}
++}
++
++static struct drm_gpuva *get_vma_locked(struct drm_gem_object *obj,
++					struct drm_gpuvm *vm, u64 range_start,
++					u64 range_end)
++{
++	struct drm_gpuva *vma;
++
++	msm_gem_assert_locked(obj);
++
++	vma = lookup_vma(obj, vm);
++
++	if (!vma) {
++		vma = msm_gem_vma_new(vm, obj, 0, range_start, range_end);
++	} else {
++		GEM_WARN_ON(vma->va.addr < range_start);
++		GEM_WARN_ON((vma->va.addr + obj->size) > range_end);
++	}
++
++	return vma;
++}
++
++int msm_gem_prot(struct drm_gem_object *obj)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++	int prot = IOMMU_READ;
++
++	if (!(msm_obj->flags & MSM_BO_GPU_READONLY))
++		prot |= IOMMU_WRITE;
++
++	if (msm_obj->flags & MSM_BO_MAP_PRIV)
++		prot |= IOMMU_PRIV;
++
++	if (msm_obj->flags & MSM_BO_CACHED_COHERENT)
++		prot |= IOMMU_CACHE;
++
++	return prot;
++}
++
++int msm_gem_pin_vma_locked(struct drm_gem_object *obj, struct drm_gpuva *vma)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++	struct page **pages;
++	int prot = msm_gem_prot(obj);
++
++	msm_gem_assert_locked(obj);
++
++	pages = msm_gem_get_pages_locked(obj, MSM_MADV_WILLNEED);
++	if (IS_ERR(pages))
++		return PTR_ERR(pages);
++
++	return msm_gem_vma_map(vma, prot, msm_obj->sgt);
++}
++
++void msm_gem_unpin_locked(struct drm_gem_object *obj)
++{
++	struct drm_device *dev = obj->dev;
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	msm_gem_assert_locked(obj);
++
++	mutex_lock(&dev->gem_lru_mutex);
++	msm_obj->pin_count--;
++	GEM_WARN_ON(msm_obj->pin_count < 0);
++	update_lru_locked(obj);
++	mutex_unlock(&dev->gem_lru_mutex);
++}
++
++/* Special unpin path for use in fence-signaling path, avoiding the need
++ * to hold the obj lock by only depending on things that a protected by
++ * the LRU lock.  In particular we know that that we already have backing
++ * and and that the object's dma_resv has the fence for the current
++ * submit/job which will prevent us racing against page eviction.
++ */
++void msm_gem_unpin_active(struct drm_gem_object *obj)
++{
++	struct drm_device *dev = obj->dev;
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	GEM_WARN_ON(!mutex_is_locked(&dev->gem_lru_mutex));
++
++	msm_obj->pin_count--;
++	GEM_WARN_ON(msm_obj->pin_count < 0);
++	update_lru_active(obj);
++}
++
++struct drm_gpuva *msm_gem_get_vma_locked(struct drm_gem_object *obj,
++					 struct drm_gpuvm *vm)
++{
++	return get_vma_locked(obj, vm, 0, U64_MAX);
++}
++
++static int get_and_pin_iova_range_locked(struct drm_gem_object *obj,
++					 struct drm_gpuvm *vm, uint64_t *iova,
++					 u64 range_start, u64 range_end)
++{
++	struct drm_gpuva *vma;
++	int ret;
++
++	msm_gem_assert_locked(obj);
++
++	if (to_msm_bo(obj)->flags & MSM_BO_NO_SHARE)
++		return -EINVAL;
++
++	vma = get_vma_locked(obj, vm, range_start, range_end);
++	if (IS_ERR(vma))
++		return PTR_ERR(vma);
++
++	ret = msm_gem_pin_vma_locked(obj, vma);
++	if (!ret) {
++		*iova = vma->va.addr;
++		pin_obj_locked(obj);
++	}
++
++	return ret;
++}
++
++/*
++ * get iova and pin it. Should have a matching put
++ * limits iova to specified range (in pages)
++ */
++int msm_gem_get_and_pin_iova_range(struct drm_gem_object *obj,
++				   struct drm_gpuvm *vm, uint64_t *iova,
++				   u64 range_start, u64 range_end)
++{
++	struct drm_exec exec;
++	int ret;
++
++	msm_gem_lock_vm_and_obj(&exec, obj, vm);
++	ret = get_and_pin_iova_range_locked(obj, vm, iova, range_start, range_end);
++	drm_exec_fini(&exec);     /* drop locks */
++
++	return ret;
++}
++
++/* get iova and pin it. Should have a matching put */
++int msm_gem_get_and_pin_iova(struct drm_gem_object *obj, struct drm_gpuvm *vm,
++			     uint64_t *iova)
++{
++	return msm_gem_get_and_pin_iova_range(obj, vm, iova, 0, U64_MAX);
++}
++
++/*
++ * Get an iova but don't pin it. Doesn't need a put because iovas are currently
++ * valid for the life of the object
++ */
++int msm_gem_get_iova(struct drm_gem_object *obj, struct drm_gpuvm *vm,
++		     uint64_t *iova)
++{
++	struct drm_gpuva *vma;
++	struct drm_exec exec;
++	int ret = 0;
++
++	msm_gem_lock_vm_and_obj(&exec, obj, vm);
++	vma = get_vma_locked(obj, vm, 0, U64_MAX);
++	if (IS_ERR(vma)) {
++		ret = PTR_ERR(vma);
++	} else {
++		*iova = vma->va.addr;
++	}
++	drm_exec_fini(&exec);     /* drop locks */
++
++	return ret;
++}
++
++static int clear_iova(struct drm_gem_object *obj,
++		      struct drm_gpuvm *vm)
++{
++	struct drm_gpuva *vma = lookup_vma(obj, vm);
++
++	if (!vma)
++		return 0;
++
++	msm_gem_vma_unmap(vma, NULL);
++	msm_gem_vma_close(vma);
++
++	return 0;
++}
++
++/*
++ * Get the requested iova but don't pin it.  Fails if the requested iova is
++ * not available.  Doesn't need a put because iovas are currently valid for
++ * the life of the object.
++ *
++ * Setting an iova of zero will clear the vma.
++ */
++int msm_gem_set_iova(struct drm_gem_object *obj,
++		     struct drm_gpuvm *vm, uint64_t iova)
++{
++	struct drm_exec exec;
++	int ret = 0;
++
++	msm_gem_lock_vm_and_obj(&exec, obj, vm);
++	if (!iova) {
++		ret = clear_iova(obj, vm);
++	} else {
++		struct drm_gpuva *vma;
++		vma = get_vma_locked(obj, vm, iova, iova + obj->size);
++		if (IS_ERR(vma)) {
++			ret = PTR_ERR(vma);
++		} else if (GEM_WARN_ON(vma->va.addr != iova)) {
++			clear_iova(obj, vm);
++			ret = -EBUSY;
++		}
++	}
++	drm_exec_fini(&exec);     /* drop locks */
++
++	return ret;
++}
++
++static bool is_kms_vm(struct drm_gpuvm *vm)
++{
++#ifdef CONFIG_DRM_MSM_KMS
++	struct msm_drm_private *priv = vm->drm->dev_private;
++
++	return priv->kms && (priv->kms->vm == vm);
++#else
++	return false;
++#endif
++}
++
++/*
++ * Unpin a iova by updating the reference counts. The memory isn't actually
++ * purged until something else (shrinker, mm_notifier, destroy, etc) decides
++ * to get rid of it
++ */
++void msm_gem_unpin_iova(struct drm_gem_object *obj, struct drm_gpuvm *vm)
++{
++	struct drm_gpuva *vma;
++	struct drm_exec exec;
++
++	msm_gem_lock_vm_and_obj(&exec, obj, vm);
++	vma = lookup_vma(obj, vm);
++	if (vma) {
++		msm_gem_unpin_locked(obj);
++	}
++	if (!is_kms_vm(vm))
++		put_iova_spaces(obj, vm, true, "close");
++	drm_exec_fini(&exec);     /* drop locks */
++}
++
++int msm_gem_dumb_create(struct drm_file *file, struct drm_device *dev,
++		struct drm_mode_create_dumb *args)
++{
++	u32 fourcc;
++	u64 pitch_align;
++	int ret;
++
++	/*
++	 * Adreno needs pitch aligned to 32 pixels. Compute the number
++	 * of bytes for a block of 32 pixels at the given color format.
++	 * Use the result as pitch alignment.
++	 */
++	fourcc = drm_driver_color_mode_format(dev, args->bpp);
++	if (fourcc != DRM_FORMAT_INVALID) {
++		const struct drm_format_info *info;
++
++		info = drm_format_info(fourcc);
++		if (!info)
++			return -EINVAL;
++		pitch_align = drm_format_info_min_pitch(info, 0, 32);
++	} else {
++		pitch_align = round_up(args->width, 32) * DIV_ROUND_UP(args->bpp, SZ_8);
++	}
++	if (!pitch_align || pitch_align > U32_MAX)
++		return -EINVAL;
++	ret = drm_mode_size_dumb(dev, args, pitch_align, 0);
++	if (ret)
++		return ret;
++
++	return msm_gem_new_handle(dev, file, args->size,
++			MSM_BO_SCANOUT | MSM_BO_WC, &args->handle, "dumb");
++}
++
++static void *get_vaddr(struct drm_gem_object *obj, unsigned madv)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++	struct page **pages;
++	int ret = 0;
++
++	msm_gem_assert_locked(obj);
++
++	if (drm_gem_is_imported(obj))
++		return ERR_PTR(-ENODEV);
++
++	pages = msm_gem_get_pages_locked(obj, madv);
++	if (IS_ERR(pages))
++		return ERR_CAST(pages);
++
++	pin_obj_locked(obj);
++
++	/* increment vmap_count *before* vmap() call, so shrinker can
++	 * check vmap_count (is_vunmapable()) outside of msm_obj lock.
++	 * This guarantees that we won't try to msm_gem_vunmap() this
++	 * same object from within the vmap() call (while we already
++	 * hold msm_obj lock)
++	 */
++	msm_obj->vmap_count++;
++
++	if (!msm_obj->vaddr) {
++		msm_obj->vaddr = vmap(pages, obj->size >> PAGE_SHIFT,
++				VM_MAP, msm_gem_pgprot(msm_obj, PAGE_KERNEL));
++		if (msm_obj->vaddr == NULL) {
++			ret = -ENOMEM;
++			goto fail;
++		}
++	}
++
++	return msm_obj->vaddr;
++
++fail:
++	msm_obj->vmap_count--;
++	msm_gem_unpin_locked(obj);
++	return ERR_PTR(ret);
++}
++
++void *msm_gem_get_vaddr_locked(struct drm_gem_object *obj)
++{
++	return get_vaddr(obj, MSM_MADV_WILLNEED);
++}
++
++void *msm_gem_get_vaddr(struct drm_gem_object *obj)
++{
++	void *ret;
++
++	msm_gem_lock(obj);
++	ret = msm_gem_get_vaddr_locked(obj);
++	msm_gem_unlock(obj);
++
++	return ret;
++}
++
++/*
++ * Don't use this!  It is for the very special case of dumping
++ * submits from GPU hangs or faults, were the bo may already
++ * be MSM_MADV_DONTNEED, but we know the buffer is still on the
++ * active list.
++ */
++void *msm_gem_get_vaddr_active(struct drm_gem_object *obj)
++{
++	return get_vaddr(obj, __MSM_MADV_PURGED);
++}
++
++void msm_gem_put_vaddr_locked(struct drm_gem_object *obj)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	msm_gem_assert_locked(obj);
++	GEM_WARN_ON(msm_obj->vmap_count < 1);
++
++	msm_obj->vmap_count--;
++	msm_gem_unpin_locked(obj);
++}
++
++void msm_gem_put_vaddr(struct drm_gem_object *obj)
++{
++	msm_gem_lock(obj);
++	msm_gem_put_vaddr_locked(obj);
++	msm_gem_unlock(obj);
++}
++
++/* Update madvise status, returns true if not purged, else
++ * false or -errno.
++ */
++int msm_gem_madvise(struct drm_gem_object *obj, unsigned madv)
++{
++	struct drm_device *dev = obj->dev;
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	msm_gem_lock(obj);
++
++	mutex_lock(&dev->gem_lru_mutex);
++
++	if (msm_obj->madv != __MSM_MADV_PURGED)
++		msm_obj->madv = madv;
++
++	madv = msm_obj->madv;
++
++	/* If the obj is inactive, we might need to move it
++	 * between inactive lists
++	 */
++	update_lru_locked(obj);
++
++	mutex_unlock(&dev->gem_lru_mutex);
++
++	msm_gem_unlock(obj);
++
++	return (madv != __MSM_MADV_PURGED);
++}
++
++void msm_gem_purge(struct drm_gem_object *obj)
++{
++	struct drm_device *dev = obj->dev;
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	msm_gem_assert_locked(obj);
++	GEM_WARN_ON(!is_purgeable(msm_obj));
++
++	/* Get rid of any iommu mapping(s): */
++	put_iova_spaces(obj, NULL, false, "purge");
++
++	msm_gem_vunmap(obj);
++
++	drm_vma_node_unmap(&obj->vma_node, dev->anon_inode->i_mapping);
++
++	put_pages(obj);
++
++	mutex_lock(&dev->gem_lru_mutex);
++	/* A one-way transition: */
++	msm_obj->madv = __MSM_MADV_PURGED;
++	mutex_unlock(&dev->gem_lru_mutex);
++
++	drm_gem_free_mmap_offset(obj);
++
++	/* Our goal here is to return as much of the memory as
++	 * is possible back to the system as we are called from OOM.
++	 * To do this we must instruct the shmfs to drop all of its
++	 * backing pages, *now*.
++	 */
++	shmem_truncate_range(file_inode(obj->filp), 0, (loff_t)-1);
++
++	invalidate_mapping_pages(file_inode(obj->filp)->i_mapping,
++			0, (loff_t)-1);
++}
++
++/*
++ * Unpin the backing pages and make them available to be swapped out.
++ */
++void msm_gem_evict(struct drm_gem_object *obj)
++{
++	struct drm_device *dev = obj->dev;
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	msm_gem_assert_locked(obj);
++	GEM_WARN_ON(is_unevictable(msm_obj));
++
++	/* Get rid of any iommu mapping(s): */
++	put_iova_spaces(obj, NULL, false, "evict");
++
++	drm_vma_node_unmap(&obj->vma_node, dev->anon_inode->i_mapping);
++
++	put_pages(obj);
++}
++
++void msm_gem_vunmap(struct drm_gem_object *obj)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	msm_gem_assert_locked(obj);
++
++	if (!msm_obj->vaddr || GEM_WARN_ON(!is_vunmapable(msm_obj)))
++		return;
++
++	vunmap(msm_obj->vaddr);
++	msm_obj->vaddr = NULL;
++}
++
++bool msm_gem_active(struct drm_gem_object *obj)
++{
++	msm_gem_assert_locked(obj);
++
++	if (to_msm_bo(obj)->pin_count)
++		return true;
++
++	return !dma_resv_test_signaled(obj->resv, DMA_RESV_USAGE_BOOKKEEP);
++}
++
++int msm_gem_cpu_prep(struct drm_gem_object *obj, uint32_t op, ktime_t *timeout)
++{
++	bool write = !!(op & MSM_PREP_WRITE);
++	unsigned long remain =
++		op & MSM_PREP_NOSYNC ? 0 : timeout_to_jiffies(timeout);
++	long ret;
++
++	if (op & MSM_PREP_BOOST) {
++		dma_resv_set_deadline(obj->resv, dma_resv_usage_rw(write),
++				      ktime_get());
++	}
++
++	ret = dma_resv_wait_timeout(obj->resv, dma_resv_usage_rw(write),
++				    true,  remain);
++	if (ret == 0)
++		return remain == 0 ? -EBUSY : -ETIMEDOUT;
++	else if (ret < 0)
++		return ret;
++
++	/* TODO cache maintenance */
++
++	return 0;
++}
++
++int msm_gem_cpu_fini(struct drm_gem_object *obj)
++{
++	/* TODO cache maintenance */
++	return 0;
++}
++
++#ifdef CONFIG_DEBUG_FS
++void msm_gem_describe(struct drm_gem_object *obj, struct seq_file *m,
++		struct msm_gem_stats *stats)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++	struct dma_resv *robj = obj->resv;
++	uint64_t off = drm_vma_node_start(&obj->vma_node);
++	const char *madv;
++
++	if (!msm_gem_trylock(obj))
++		return;
++
++	stats->all.count++;
++	stats->all.size += obj->size;
++
++	if (msm_gem_active(obj)) {
++		stats->active.count++;
++		stats->active.size += obj->size;
++	}
++
++	if (msm_obj->pages) {
++		stats->resident.count++;
++		stats->resident.size += obj->size;
++	}
++
++	switch (msm_obj->madv) {
++	case __MSM_MADV_PURGED:
++		stats->purged.count++;
++		stats->purged.size += obj->size;
++		madv = " purged";
++		break;
++	case MSM_MADV_DONTNEED:
++		stats->purgeable.count++;
++		stats->purgeable.size += obj->size;
++		madv = " purgeable";
++		break;
++	case MSM_MADV_WILLNEED:
++	default:
++		madv = "";
++		break;
++	}
++
++	seq_printf(m, "%08x: %c %2d (%2d) %08llx %p",
++			msm_obj->flags, msm_gem_active(obj) ? 'A' : 'I',
++			obj->name, kref_read(&obj->refcount),
++			off, msm_obj->vaddr);
++
++	seq_printf(m, " %08zu %9s %-32s\n", obj->size, madv, msm_obj->name);
++
++	if (!list_empty(&obj->gpuva.list)) {
++		struct drm_gpuvm_bo *vm_bo;
++
++		seq_puts(m, "      vmas:");
++
++		drm_gem_for_each_gpuvm_bo (vm_bo, obj) {
++			struct drm_gpuva *vma;
++
++			drm_gpuvm_bo_for_each_va (vma, vm_bo) {
++				const char *name, *comm;
++				struct msm_gem_vm *vm = to_msm_vm(vma->vm);
++				struct task_struct *task =
++					get_pid_task(vm->pid, PIDTYPE_PID);
++				if (task) {
++					comm = kstrdup(task->comm, GFP_KERNEL);
++					put_task_struct(task);
++				} else {
++					comm = NULL;
++				}
++				name = vm->base.name;
++
++				seq_printf(m, " [%s%s%s: vm=%p, %08llx, %smapped]",
++					   name, comm ? ":" : "", comm ? comm : "",
++					   vma->vm, vma->va.addr,
++					   to_msm_vma(vma)->mapped ? "" : "un");
++				kfree(comm);
++			}
++		}
++
++		seq_puts(m, "\n");
++	}
++
++	dma_resv_describe(robj, m);
++	msm_gem_unlock(obj);
++}
++
++void msm_gem_describe_objects(struct list_head *list, struct seq_file *m)
++{
++	struct msm_gem_stats stats = {};
++	struct msm_gem_object *msm_obj;
++
++	seq_puts(m, "   flags       id ref  offset   kaddr            size     madv      name\n");
++	list_for_each_entry(msm_obj, list, node) {
++		struct drm_gem_object *obj = &msm_obj->base;
++		seq_puts(m, "   ");
++		msm_gem_describe(obj, m, &stats);
++	}
++
++	seq_printf(m, "Total:     %4d objects, %9zu bytes\n",
++			stats.all.count, stats.all.size);
++	seq_printf(m, "Active:    %4d objects, %9zu bytes\n",
++			stats.active.count, stats.active.size);
++	seq_printf(m, "Resident:  %4d objects, %9zu bytes\n",
++			stats.resident.count, stats.resident.size);
++	seq_printf(m, "Purgeable: %4d objects, %9zu bytes\n",
++			stats.purgeable.count, stats.purgeable.size);
++	seq_printf(m, "Purged:    %4d objects, %9zu bytes\n",
++			stats.purged.count, stats.purged.size);
++}
++#endif
++
++/* don't call directly!  Use drm_gem_object_put() */
++static void msm_gem_free_object(struct drm_gem_object *obj)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++	struct drm_device *dev = obj->dev;
++	struct msm_drm_private *priv = dev->dev_private;
++	struct drm_exec exec;
++
++	mutex_lock(&priv->obj_lock);
++	list_del(&msm_obj->node);
++	mutex_unlock(&priv->obj_lock);
++
++	/*
++	 * We need to lock any VMs the object is still attached to, but not
++	 * the object itself (see explaination in msm_gem_assert_locked()),
++	 * so just open-code this special case.
++	 *
++	 * Note that we skip the dance if we aren't attached to any VM.  This
++	 * is load bearing.  The driver needs to support two usage models:
++	 *
++	 * 1. Legacy kernel managed VM: Userspace expects the VMA's to be
++	 *    implicitly torn down when the object is freed, the VMA's do
++	 *    not hold a hard reference to the BO.
++	 *
++	 * 2. VM_BIND, userspace managed VM: The VMA holds a reference to the
++	 *    BO.  This can be dropped when the VM is closed and it's associated
++	 *    VMAs are torn down.  (See msm_gem_vm_close()).
++	 *
++	 * In the latter case the last reference to a BO can be dropped while
++	 * we already have the VM locked.  It would have already been removed
++	 * from the gpuva list, but lockdep doesn't know that.  Or understand
++	 * the differences between the two usage models.
++	 */
++	if (!list_empty(&obj->gpuva.list)) {
++		drm_exec_init(&exec, 0, 0);
++		drm_exec_until_all_locked (&exec) {
++			struct drm_gpuvm_bo *vm_bo;
++			drm_gem_for_each_gpuvm_bo (vm_bo, obj) {
++				drm_exec_lock_obj(&exec,
++						  drm_gpuvm_resv_obj(vm_bo->vm));
++				drm_exec_retry_on_contention(&exec);
++			}
++		}
++		put_iova_spaces(obj, NULL, true, "free");
++		drm_exec_fini(&exec);     /* drop locks */
++	}
++
++	if (drm_gem_is_imported(obj)) {
++		GEM_WARN_ON(msm_obj->vaddr);
++
++		/* Don't drop the pages for imported dmabuf, as they are not
++		 * ours, just free the array we allocated:
++		 */
++		kvfree(msm_obj->pages);
++
++		drm_prime_gem_destroy(obj, msm_obj->sgt);
++	} else {
++		msm_gem_vunmap(obj);
++		put_pages(obj);
++	}
++
++	/*
++	 * In error paths, we could end up here before msm_gem_new_handle()
++	 * has changed obj->resv to point to the shared resv.  In this case,
++	 * we don't want to drop a ref to the shared r_obj that we haven't
++	 * taken yet.
++	 */
++	if ((msm_obj->flags & MSM_BO_NO_SHARE) && (obj->resv != &obj->_resv)) {
++		struct drm_gem_object *r_obj =
++			container_of(obj->resv, struct drm_gem_object, _resv);
++
++		/* Drop reference we hold to shared resv obj: */
++		drm_gem_object_put(r_obj);
++	}
++
++	drm_gem_object_release(obj);
++
++	kfree(msm_obj->metadata);
++	kfree(msm_obj);
++}
++
++static int msm_gem_object_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++
++	vm_flags_set(vma, VM_PFNMAP | VM_DONTEXPAND | VM_DONTDUMP);
++	vma->vm_page_prot = msm_gem_pgprot(msm_obj, vm_get_page_prot(vma->vm_flags));
++
++	return 0;
++}
++
++/* convenience method to construct a GEM buffer object, and userspace handle */
++int msm_gem_new_handle(struct drm_device *dev, struct drm_file *file,
++		size_t size, uint32_t flags, uint32_t *handle,
++		char *name)
++{
++	struct drm_gem_object *obj;
++	int ret;
++
++	obj = msm_gem_new(dev, size, flags);
++
++	if (IS_ERR(obj))
++		return PTR_ERR(obj);
++
++	if (name)
++		msm_gem_object_set_name(obj, "%s", name);
++
++	if (flags & MSM_BO_NO_SHARE) {
++		struct msm_context *ctx = file->driver_priv;
++		struct drm_gem_object *r_obj = drm_gpuvm_resv_obj(ctx->vm);
++
++		drm_gem_object_get(r_obj);
++
++		obj->resv = r_obj->resv;
++	}
++
++	ret = drm_gem_handle_create(file, obj, handle);
++
++	/* drop reference from allocate - handle holds it now */
++	drm_gem_object_put(obj);
++
++	return ret;
++}
++
++static enum drm_gem_object_status msm_gem_status(struct drm_gem_object *obj)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(obj);
++	enum drm_gem_object_status status = 0;
++
++	if (msm_obj->pages)
++		status |= DRM_GEM_OBJECT_RESIDENT;
++
++	if (msm_obj->madv == MSM_MADV_DONTNEED)
++		status |= DRM_GEM_OBJECT_PURGEABLE;
++
++	return status;
++}
++
++static const struct vm_operations_struct vm_ops = {
++	.fault = msm_gem_fault,
++	.open = drm_gem_vm_open,
++	.close = drm_gem_vm_close,
++};
++
++static const struct drm_gem_object_funcs msm_gem_object_funcs = {
++	.free = msm_gem_free_object,
++	.open = msm_gem_open,
++	.close = msm_gem_close,
++	.export = msm_gem_prime_export,
++	.pin = msm_gem_prime_pin,
++	.unpin = msm_gem_prime_unpin,
++	.get_sg_table = msm_gem_prime_get_sg_table,
++	.vmap = msm_gem_prime_vmap,
++	.vunmap = msm_gem_prime_vunmap,
++	.mmap = msm_gem_object_mmap,
++	.status = msm_gem_status,
++	.vm_ops = &vm_ops,
++};
++
++static int msm_gem_new_impl(struct drm_device *dev, uint32_t flags,
++			    struct drm_gem_object **obj)
++{
++	struct msm_drm_private *priv = dev->dev_private;
++	struct msm_gem_object *msm_obj;
++
++	switch (flags & MSM_BO_CACHE_MASK) {
++	case MSM_BO_CACHED:
++	case MSM_BO_WC:
++		break;
++	case MSM_BO_CACHED_COHERENT:
++		if (priv->has_cached_coherent)
++			break;
++		fallthrough;
++	default:
++		DRM_DEV_DEBUG(dev->dev, "invalid cache flag: %x\n",
++				(flags & MSM_BO_CACHE_MASK));
++		return -EINVAL;
++	}
++
++	msm_obj = kzalloc_obj(*msm_obj);
++	if (!msm_obj)
++		return -ENOMEM;
++
++	msm_obj->flags = flags;
++	msm_obj->madv = MSM_MADV_WILLNEED;
++
++	INIT_LIST_HEAD(&msm_obj->node);
++
++	*obj = &msm_obj->base;
++	(*obj)->funcs = &msm_gem_object_funcs;
++
++	return 0;
++}
++
++struct drm_gem_object *msm_gem_new(struct drm_device *dev, size_t size, uint32_t flags)
++{
++	struct msm_drm_private *priv = dev->dev_private;
++	struct msm_gem_object *msm_obj;
++	struct drm_gem_object *obj = NULL;
++	int ret;
++
++	size = PAGE_ALIGN(size);
++
++	/* Disallow zero sized objects as they make the underlying
++	 * infrastructure grumpy
++	 */
++	if (size == 0)
++		return ERR_PTR(-EINVAL);
++
++	ret = msm_gem_new_impl(dev, flags, &obj);
++	if (ret)
++		return ERR_PTR(ret);
++
++	msm_obj = to_msm_bo(obj);
++
++	ret = drm_gem_object_init(dev, obj, size);
++	if (ret)
++		goto fail;
++	/*
++	 * Our buffers are kept pinned, so allocating them from the
++	 * MOVABLE zone is a really bad idea, and conflicts with CMA.
++	 * See comments above new_inode() why this is required _and_
++	 * expected if you're going to pin these pages.
++	 */
++	mapping_set_gfp_mask(obj->filp->f_mapping, GFP_HIGHUSER);
++
++	drm_gem_lru_move_tail(&priv->lru.unbacked, obj);
++
++	mutex_lock(&priv->obj_lock);
++	list_add_tail(&msm_obj->node, &priv->objects);
++	mutex_unlock(&priv->obj_lock);
++
++	ret = drm_gem_create_mmap_offset(obj);
++	if (ret)
++		goto fail;
++
++	return obj;
++
++fail:
++	drm_gem_object_put(obj);
++	return ERR_PTR(ret);
++}
++
++struct drm_gem_object *msm_gem_import(struct drm_device *dev,
++		struct dma_buf *dmabuf, struct sg_table *sgt)
++{
++	struct msm_drm_private *priv = dev->dev_private;
++	struct msm_gem_object *msm_obj;
++	struct drm_gem_object *obj;
++	size_t size, npages;
++	int ret;
++
++	size = PAGE_ALIGN(dmabuf->size);
++
++	ret = msm_gem_new_impl(dev, MSM_BO_WC, &obj);
++	if (ret)
++		return ERR_PTR(ret);
++
++	drm_gem_private_object_init(dev, obj, size);
++
++	npages = size / PAGE_SIZE;
++
++	msm_obj = to_msm_bo(obj);
++	msm_gem_lock(obj);
++	msm_obj->sgt = sgt;
++	msm_obj->pages = kvmalloc_objs(struct page *, npages);
++	if (!msm_obj->pages) {
++		msm_gem_unlock(obj);
++		ret = -ENOMEM;
++		goto fail;
++	}
++
++	ret = drm_prime_sg_to_page_array(sgt, msm_obj->pages, npages);
++	if (ret) {
++		msm_gem_unlock(obj);
++		goto fail;
++	}
++
++	msm_gem_unlock(obj);
++
++	drm_gem_lru_move_tail(&priv->lru.pinned, obj);
++
++	mutex_lock(&priv->obj_lock);
++	list_add_tail(&msm_obj->node, &priv->objects);
++	mutex_unlock(&priv->obj_lock);
++
++	ret = drm_gem_create_mmap_offset(obj);
++	if (ret)
++		goto fail;
++
++	return obj;
++
++fail:
++	drm_gem_object_put(obj);
++	return ERR_PTR(ret);
++}
++
++void *msm_gem_kernel_new(struct drm_device *dev, size_t size, uint32_t flags,
++			 struct drm_gpuvm *vm, struct drm_gem_object **bo,
++			 uint64_t *iova)
++{
++	void *vaddr;
++	struct drm_gem_object *obj = msm_gem_new(dev, size, flags);
++	int ret;
++
++	if (IS_ERR(obj))
++		return ERR_CAST(obj);
++
++	if (iova) {
++		ret = msm_gem_get_and_pin_iova(obj, vm, iova);
++		if (ret)
++			goto err;
++	}
++
++	vaddr = msm_gem_get_vaddr(obj);
++	if (IS_ERR(vaddr)) {
++		msm_gem_unpin_iova(obj, vm);
++		ret = PTR_ERR(vaddr);
++		goto err;
++	}
++
++	if (bo)
++		*bo = obj;
++
++	return vaddr;
++err:
++	drm_gem_object_put(obj);
++
++	return ERR_PTR(ret);
++
++}
++
++void msm_gem_kernel_put(struct drm_gem_object *bo, struct drm_gpuvm *vm)
++{
++	if (IS_ERR_OR_NULL(bo))
++		return;
++
++	msm_gem_put_vaddr(bo);
++	msm_gem_unpin_iova(bo, vm);
++	drm_gem_object_put(bo);
++}
++
++void msm_gem_object_set_name(struct drm_gem_object *bo, const char *fmt, ...)
++{
++	struct msm_gem_object *msm_obj = to_msm_bo(bo);
++	va_list ap;
++
++	if (!fmt)
++		return;
++
++	va_start(ap, fmt);
++	vsnprintf(msm_obj->name, sizeof(msm_obj->name), fmt, ap);
++	va_end(ap);
++}
+diff --git a/drivers/input/input-compat.c.orig b/drivers/input/input-compat.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/input/input-compat.c.orig
+@@ -0,0 +1,163 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * 32bit compatibility wrappers for the input subsystem.
++ *
++ * Very heavily based on evdev.c - Copyright (c) 1999-2002 Vojtech Pavlik
++ */
++
++#include <linux/export.h>
++#include <linux/sprintf.h>
++#include <linux/uaccess.h>
++#include "input-compat.h"
++
++#ifdef CONFIG_COMPAT
++
++int input_event_from_user(const char __user *buffer,
++			  struct input_event *event)
++{
++	if (in_compat_syscall() && !COMPAT_USE_64BIT_TIME) {
++		struct input_event_compat compat_event;
++
++		if (copy_from_user(&compat_event, buffer,
++				   sizeof(struct input_event_compat)))
++			return -EFAULT;
++
++		event->input_event_sec = compat_event.sec;
++		event->input_event_usec = compat_event.usec;
++		event->type = compat_event.type;
++		event->code = compat_event.code;
++		event->value = compat_event.value;
++
++	} else {
++		if (copy_from_user(event, buffer, sizeof(struct input_event)))
++			return -EFAULT;
++	}
++
++	return 0;
++}
++
++int input_event_to_user(char __user *buffer,
++			const struct input_event *event)
++{
++	if (in_compat_syscall() && !COMPAT_USE_64BIT_TIME) {
++		struct input_event_compat compat_event;
++
++		compat_event.sec = event->input_event_sec;
++		compat_event.usec = event->input_event_usec;
++		compat_event.type = event->type;
++		compat_event.code = event->code;
++		compat_event.value = event->value;
++
++		if (copy_to_user(buffer, &compat_event,
++				 sizeof(struct input_event_compat)))
++			return -EFAULT;
++
++	} else {
++		if (copy_to_user(buffer, event, sizeof(struct input_event)))
++			return -EFAULT;
++	}
++
++	return 0;
++}
++
++int input_ff_effect_from_user(const char __user *buffer, size_t size,
++			      struct ff_effect *effect)
++{
++	if (in_compat_syscall()) {
++		struct ff_effect_compat *compat_effect;
++
++		if (size != sizeof(struct ff_effect_compat))
++			return -EINVAL;
++
++		/*
++		 * It so happens that the pointer which needs to be changed
++		 * is the last field in the structure, so we can retrieve the
++		 * whole thing and replace just the pointer.
++		 */
++		compat_effect = (struct ff_effect_compat *)effect;
++
++		if (copy_from_user(compat_effect, buffer,
++				   sizeof(struct ff_effect_compat)))
++			return -EFAULT;
++
++		if (compat_effect->type == FF_PERIODIC &&
++		    compat_effect->u.periodic.waveform == FF_CUSTOM)
++			effect->u.periodic.custom_data =
++				compat_ptr(compat_effect->u.periodic.custom_data);
++	} else {
++		if (size != sizeof(struct ff_effect))
++			return -EINVAL;
++
++		if (copy_from_user(effect, buffer, sizeof(struct ff_effect)))
++			return -EFAULT;
++	}
++
++	return 0;
++}
++
++int input_bits_to_string(char *buf, int buf_size, unsigned long bits,
++			 bool skip_empty)
++{
++	int len = 0;
++
++	if (in_compat_syscall()) {
++		u32 dword = bits >> 32;
++		if (dword || !skip_empty)
++			len += snprintf(buf, buf_size, "%x ", dword);
++
++		dword = bits & 0xffffffffUL;
++		if (dword || !skip_empty || len)
++			len += snprintf(buf + len, max(buf_size - len, 0),
++					"%x", dword);
++	} else {
++		if (bits || !skip_empty)
++			len += snprintf(buf, buf_size, "%lx", bits);
++	}
++
++	return len;
++}
++
++#else
++
++int input_event_from_user(const char __user *buffer,
++			 struct input_event *event)
++{
++	if (copy_from_user(event, buffer, sizeof(struct input_event)))
++		return -EFAULT;
++
++	return 0;
++}
++
++int input_event_to_user(char __user *buffer,
++			const struct input_event *event)
++{
++	if (copy_to_user(buffer, event, sizeof(struct input_event)))
++		return -EFAULT;
++
++	return 0;
++}
++
++int input_ff_effect_from_user(const char __user *buffer, size_t size,
++			      struct ff_effect *effect)
++{
++	if (size != sizeof(struct ff_effect))
++		return -EINVAL;
++
++	if (copy_from_user(effect, buffer, sizeof(struct ff_effect)))
++		return -EFAULT;
++
++	return 0;
++}
++
++int input_bits_to_string(char *buf, int buf_size, unsigned long bits,
++			 bool skip_empty)
++{
++	return bits || !skip_empty ?
++		snprintf(buf, buf_size, "%lx", bits) : 0;
++}
++
++#endif /* CONFIG_COMPAT */
++
++EXPORT_SYMBOL_GPL(input_event_from_user);
++EXPORT_SYMBOL_GPL(input_event_to_user);
++EXPORT_SYMBOL_GPL(input_ff_effect_from_user);
+diff --git a/drivers/input/joystick/rsinput.c.orig b/drivers/input/joystick/rsinput.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/input/joystick/rsinput.c.orig
+@@ -0,0 +1,590 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * RSInput Gamepad Driver
++ *
++ * Copyright (C) 2024 Teguh Sobirin <teguh@sobir.in>
++ *
++ */
++
++#include <linux/errno.h>
++#include <linux/gpio/consumer.h>
++#include <linux/init.h>
++#include <linux/input.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/minmax.h>
++#include <linux/of.h>
++#include <linux/regulator/consumer.h>
++#include <linux/serdev.h>
++#include <linux/slab.h>
++#include <uapi/linux/sched/types.h>
++
++static int update_params=0;
++
++static int trigger_left_max=0x610;
++static int trigger_left_deadzone=0x0;
++static int trigger_left_antideadzone=0x0;
++
++static int trigger_right_max=0x610;
++static int trigger_right_deadzone=0x0;
++static int trigger_right_antideadzone=0x0;
++
++static int axis_leftx_min=-0x580;
++static int axis_leftx_center=0x0;
++static int axis_leftx_max=0x580;
++static int axis_leftx_deadzone=0x0;
++static int axis_leftx_antideadzone=0x0;
++
++static int axis_lefty_min=-0x580;
++static int axis_lefty_center=0x0;
++static int axis_lefty_max=0x580;
++static int axis_lefty_deadzone=0x0;
++static int axis_lefty_antideadzone=0x0;
++
++static int axis_rightx_min=-0x580;
++static int axis_rightx_center=0x0;
++static int axis_rightx_max=0x580;
++static int axis_rightx_deadzone=0x0;
++static int axis_rightx_antideadzone=0x0;
++
++static int axis_righty_min=-0x580;
++static int axis_righty_center=0x0;
++static int axis_righty_max=0x580;
++static int axis_righty_deadzone=0x0;
++static int axis_righty_antideadzone=0x0;
++
++module_param(update_params,int,0660);
++
++module_param(trigger_left_max,int,0660);
++module_param(trigger_left_deadzone,int,0660);
++module_param(trigger_left_antideadzone,int,0660);
++
++module_param(trigger_right_max,int,0660);
++module_param(trigger_right_deadzone,int,0660);
++module_param(trigger_right_antideadzone,int,0660);
++
++module_param(axis_leftx_min,int,0660);
++module_param(axis_leftx_center,int,0660);
++module_param(axis_leftx_max,int,0660);
++module_param(axis_leftx_deadzone,int,0660);
++module_param(axis_leftx_antideadzone,int,0660);
++
++module_param(axis_lefty_min,int,0660);
++module_param(axis_lefty_center,int,0660);
++module_param(axis_lefty_max,int,0660);
++module_param(axis_lefty_deadzone,int,0660);
++module_param(axis_lefty_antideadzone,int,0660);
++
++module_param(axis_rightx_min,int,0660);
++module_param(axis_rightx_center,int,0660);
++module_param(axis_rightx_max,int,0660);
++module_param(axis_rightx_deadzone,int,0660);
++module_param(axis_rightx_antideadzone,int,0660);
++
++module_param(axis_righty_min,int,0660);
++module_param(axis_righty_center,int,0660);
++module_param(axis_righty_max,int,0660);
++module_param(axis_righty_deadzone,int,0660);
++module_param(axis_righty_antideadzone,int,0660);
++
++#define INT_SIGN(X) ((X > 0) - (X < 0))
++
++#define FRAME_HEAD_1              0xA5
++#define FRAME_HEAD_2              0xD3
++#define FRAME_HEAD_3              0x5A
++#define FRAME_HEAD_4              0x3D
++
++#define CMD_COMMOD                0x01
++#define CMD_STATUS                0x02
++
++#define DATA_COMMOD_VERSION       0x02
++#define DATA_COMMOD_SET_PAR       0x05
++
++#define FRAME_POS_SEQ             4
++#define FRAME_POS_CMD             5
++#define FRAME_POS_LEN_L           6
++#define FRAME_POS_LEN_H           7
++#define FRAME_POS_DATA_1          8
++#define FRAME_POS_DATA_2          9
++#define FRAME_POS_DATA_3          10
++#define FRAME_POS_DATA_4          11
++#define FRAME_POS_DATA_5          12
++#define FRAME_POS_DATA_6          13
++#define FRAME_POS_DATA_7          14
++#define FRAME_POS_DATA_8          15
++#define FRAME_POS_DATA_9          16
++#define FRAME_POS_DATA_10         17
++#define FRAME_POS_DATA_11         18
++#define FRAME_POS_DATA_12         19
++#define FRAME_POS_DATA_13         20
++#define FRAME_POS_DATA_14         21
++
++#define MCU_PKT_SIZE_MIN          9
++
++#define MCU_VERSION_MAX_LEN       64
++
++struct rsinput_driver {
++    struct serdev_device *serdev;
++    struct input_dev *input;
++    struct regulator *vdd;
++    struct gpio_desc *boot_gpio;
++    struct gpio_desc *enable_gpio;
++    struct gpio_desc *reset_gpio;
++    bool invert_x;
++    bool invert_y;
++    bool invert_rx;
++    bool invert_ry;
++    uint8_t rx_buf[1024];
++    uint8_t sequence_number;
++};
++
++static const unsigned int keymap[] = {
++    BTN_DPAD_UP, BTN_DPAD_DOWN, BTN_DPAD_LEFT, BTN_DPAD_RIGHT,
++    BTN_NORTH,   BTN_WEST,	    BTN_EAST,	   BTN_SOUTH,
++    BTN_TL,	     BTN_TR,	    BTN_SELECT,	   BTN_START,
++    BTN_THUMBL,  BTN_THUMBR,    BTN_MODE,	   BTN_BACK
++};
++
++static uint8_t compute_checksum(const uint8_t *data, size_t len) {
++    uint8_t checksum = 0;
++
++    for (size_t i = FRAME_POS_SEQ; i < len - 1; i++) {
++        checksum ^= data[i];
++    }
++
++    return checksum;
++}
++
++static int rsinput_send_command(struct rsinput_driver *drv, uint8_t cmd, const uint8_t *data, size_t len) {
++    uint8_t frame[256];
++    uint8_t checksum = 0;
++    size_t frame_len = 0;
++
++    frame[frame_len++] = FRAME_HEAD_1;
++    frame[frame_len++] = FRAME_HEAD_2;
++    frame[frame_len++] = FRAME_HEAD_3;
++    frame[frame_len++] = FRAME_HEAD_4;
++
++    frame[frame_len++] = drv->sequence_number;
++    drv->sequence_number++;
++
++    frame[frame_len++] = cmd;
++
++    frame[frame_len++] = len & 0xFF;
++    frame[frame_len++] = (len >> 8) & 0xFF;
++
++    if (data && len) {
++        memcpy(&frame[frame_len], data, len);
++        frame_len += len;
++    }
++
++    checksum = compute_checksum(frame, frame_len + 1);
++    frame[frame_len++] = checksum;
++
++    return serdev_device_write_buf(drv->serdev, frame, frame_len);
++}
++
++static int rsinput_init_commands(struct rsinput_driver *drv) {
++    int error;
++
++    if (drv->boot_gpio)
++        gpiod_set_value_cansleep(drv->boot_gpio, 0);
++
++    if (drv->reset_gpio)
++        gpiod_set_value_cansleep(drv->reset_gpio, 0);
++
++    msleep(100);
++
++    if (drv->enable_gpio)
++        gpiod_set_value_cansleep(drv->enable_gpio, 1);
++
++    if (drv->reset_gpio)
++        gpiod_set_value_cansleep(drv->reset_gpio, 1);
++
++    msleep(100);
++    uint8_t version_request[] = {DATA_COMMOD_VERSION};
++    error = rsinput_send_command(drv, CMD_COMMOD, version_request, sizeof(version_request));
++    if (error < 0) {
++        dev_err(&drv->serdev->dev, "Failed to request MCU version: %d\n", error);
++        return error;
++    }
++
++    msleep(100);
++    uint8_t mcu_params[] = {
++        DATA_COMMOD_SET_PAR,
++        0x01,
++        0x00, 0x00, 0x00, 0x28,
++        0x00, 0x00, 0x00, 0x07
++    };
++    error = rsinput_send_command(drv, CMD_COMMOD, mcu_params, sizeof(mcu_params));
++    if (error < 0) {
++        dev_err(&drv->serdev->dev, "Failed to set MCU parameters: %d\n", error);
++        return error;
++    }
++
++    return 0;
++}
++
++static void handle_cmd_commod(struct rsinput_driver *drv, const uint8_t *data, size_t payload_length) {
++    switch (data[FRAME_POS_DATA_1]) {
++        case DATA_COMMOD_VERSION:
++            if (payload_length >= 1) {
++                char mcu_version[MCU_VERSION_MAX_LEN] = {0};
++                size_t version_length = payload_length;
++                if (version_length > MCU_VERSION_MAX_LEN - 1) {
++                    version_length = MCU_VERSION_MAX_LEN - 1;
++                }
++                memcpy(mcu_version, &data[FRAME_POS_DATA_1], version_length);
++                mcu_version[version_length] = '\0';
++                dev_info(&drv->serdev->dev, "MCU Version: %s\n", mcu_version);
++            } else {
++                dev_err(&drv->serdev->dev, "Invalid MCU version response length\n");
++            }
++            break;
++        case DATA_COMMOD_SET_PAR:
++            dev_info(&drv->serdev->dev, "MCU parameters set successfully\n");
++            break;
++        default:
++            dev_warn(&drv->serdev->dev, "Unhandled CMD_COMMOD sub-command: 0x%02x\n", data[FRAME_POS_DATA_1]);
++            break;
++    }
++}
++
++static void handle_cmd_status(struct rsinput_driver *drv, const uint8_t *data, size_t payload_length) {
++    if (payload_length >= 6) {
++    static unsigned long prev_states;
++    unsigned long keys = data[FRAME_POS_DATA_1] | (data[FRAME_POS_DATA_2] << 8);
++    unsigned long current_states = keys, changes;
++    int i;
++
++    if (update_params) {
++        input_set_abs_params(drv->input, ABS_X,
++            INT_SIGN(axis_leftx_min) * ( abs(axis_leftx_min) - axis_leftx_antideadzone ),
++            INT_SIGN(axis_leftx_max) * ( abs(axis_leftx_max) - axis_leftx_antideadzone ),
++            0, 0);
++        input_set_abs_params(drv->input, ABS_Y,
++            INT_SIGN(axis_lefty_min) * ( abs(axis_lefty_min) - axis_lefty_antideadzone ),
++            INT_SIGN(axis_lefty_max) * ( abs(axis_lefty_max) - axis_lefty_antideadzone ),
++             0, 0);
++        input_set_abs_params(drv->input, ABS_RX,
++            INT_SIGN(axis_rightx_min) * ( abs(axis_rightx_min) - axis_rightx_antideadzone ),
++            INT_SIGN(axis_rightx_max) * ( abs(axis_rightx_max) - axis_rightx_antideadzone ),
++            0, 0);
++        input_set_abs_params(drv->input, ABS_RY,
++            INT_SIGN(axis_righty_min) * ( abs(axis_righty_min) - axis_righty_antideadzone ),
++            INT_SIGN(axis_righty_max) * ( abs(axis_righty_max) - axis_righty_antideadzone ),
++             0, 0);
++        input_set_abs_params(drv->input, ABS_Z, 0, trigger_left_max - trigger_left_antideadzone, 0, 30);
++        input_set_abs_params(drv->input, ABS_RZ, 0, trigger_right_max - trigger_right_antideadzone, 0, 30);
++        update_params = 0;
++    }
++
++    bitmap_xor(&changes, &current_states, &prev_states, ARRAY_SIZE(keymap));
++
++    for_each_set_bit(i, &changes, ARRAY_SIZE(keymap)) {
++        input_report_key(drv->input, keymap[i], (current_states & BIT(i)));
++    }
++
++    int16_t raw_trig_l = (data[FRAME_POS_DATA_3] | (data[FRAME_POS_DATA_4] << 8));
++    int16_t z = trigger_left_max - raw_trig_l;
++    z = ( z < trigger_left_deadzone ) ? 0 : z - trigger_left_antideadzone;
++
++    int16_t raw_trig_r = (data[FRAME_POS_DATA_5] | (data[FRAME_POS_DATA_6] << 8));
++    int16_t rz = trigger_right_max - raw_trig_r;
++    rz = ( rz < trigger_right_deadzone ) ? 0 : rz - trigger_right_antideadzone;
++
++    int16_t raw_x = -(int16_t)(data[FRAME_POS_DATA_7] | (data[FRAME_POS_DATA_8] << 8));
++    int16_t x = raw_x + axis_leftx_center;
++    x = ( abs(x) < axis_leftx_deadzone ) ? 0 : INT_SIGN(x) * ( abs(x) - axis_leftx_antideadzone );
++
++    int16_t raw_y = -(int16_t)(data[FRAME_POS_DATA_9] | (data[FRAME_POS_DATA_10] << 8));
++    int16_t y = raw_y + axis_lefty_center;
++    y = ( abs(y) < axis_lefty_deadzone ) ? 0 : INT_SIGN(y) * ( abs(y) - axis_lefty_antideadzone );
++
++    int16_t raw_rx = -(int16_t)(data[FRAME_POS_DATA_11] | (data[FRAME_POS_DATA_12] << 8));
++    int16_t rx = raw_rx + axis_rightx_center;
++    rx = ( abs(rx) < axis_rightx_deadzone ) ? 0 : INT_SIGN(rx) * ( abs(rx) - axis_rightx_antideadzone );
++
++    int16_t raw_ry = -(int16_t)(data[FRAME_POS_DATA_13] | (data[FRAME_POS_DATA_14] << 8));
++    int16_t ry = raw_ry + axis_righty_center;
++    ry = ( abs(ry) < axis_righty_deadzone ) ? 0 : INT_SIGN(ry) * ( abs(ry) - axis_righty_antideadzone );
++
++    input_report_abs(drv->input, ABS_Z, z);
++    input_report_abs(drv->input, ABS_RZ, rz);
++    input_report_abs(drv->input, ABS_X, drv->invert_x ? x * (-1) : x);
++    input_report_abs(drv->input, ABS_Y, drv->invert_y ? y * (-1) : y);
++    input_report_abs(drv->input, ABS_RX, drv->invert_rx ? rx * (-1) : rx);
++    input_report_abs(drv->input, ABS_RY, drv->invert_ry ? ry * (-1) : ry);
++
++    input_sync(drv->input);
++    prev_states = keys;
++
++    } else {
++        dev_warn(&drv->serdev->dev, "Invalid CMD_STATUS response length\n");
++    }
++}
++
++static void rsinput_process_data(struct rsinput_driver *drv, const uint8_t *data, size_t len) {
++    while (len >= MCU_PKT_SIZE_MIN) {
++        uint16_t payload_length = data[FRAME_POS_LEN_L] | (data[FRAME_POS_LEN_H] << 8);
++        size_t frame_length = MCU_PKT_SIZE_MIN + payload_length;
++
++        if (len < frame_length) {
++            return;
++        }
++
++        uint8_t received_checksum = data[frame_length - 1];
++        uint8_t computed_checksum = compute_checksum(data, frame_length);
++        if (computed_checksum != received_checksum) {
++            data += frame_length;
++            len -= frame_length;
++            continue;
++        }
++
++        switch (data[FRAME_POS_CMD]) {
++            case CMD_COMMOD:
++                handle_cmd_commod(drv, data, payload_length);
++                break;
++            case CMD_STATUS:
++                handle_cmd_status(drv, data, payload_length);
++                break;
++            default:
++                dev_warn(&drv->serdev->dev, "Unhandled command: 0x%02X\n", data[FRAME_POS_CMD]);
++                break;
++        }
++
++        data += frame_length;
++        len -= frame_length;
++    }
++
++    if (len > 0) {
++        dev_warn(&drv->serdev->dev, "Trailing bytes after processing: %zu\n", len);
++    }
++}
++
++static size_t rsinput_rx(struct serdev_device *serdev, const u8 *data, size_t count) {
++    struct rsinput_driver *drv = serdev_device_get_drvdata(serdev);
++    uint8_t received_checksum, computed_checksum;
++
++    if (!drv || !data || count == 0) {
++        dev_warn_ratelimited(&serdev->dev, "Invalid RX data\n");
++        goto error;
++    }
++
++    if (count > sizeof(drv->rx_buf)) {
++        dev_warn_ratelimited(&serdev->dev, "RX buffer overflow\n");
++        goto error;
++    }
++
++    memcpy(drv->rx_buf, data, count);
++
++    if (count < MCU_PKT_SIZE_MIN) {
++        dev_warn_ratelimited(&serdev->dev, "Frame too short for checksum validation\n");
++        goto error;
++    }
++
++    received_checksum = drv->rx_buf[count - 1];
++
++    computed_checksum = compute_checksum(drv->rx_buf, count);
++
++    if (computed_checksum != received_checksum) {
++        dev_warn_ratelimited(&serdev->dev, "Checksum mismatch\n");
++        goto error;
++    }
++
++    rsinput_process_data(drv, drv->rx_buf, count);
++
++error:
++    return count;
++}
++
++static const struct serdev_device_ops rsinput_rx_ops = {
++    .receive_buf = rsinput_rx,
++};
++
++static int rsinput_probe(struct serdev_device *serdev) {
++    struct rsinput_driver *drv;
++    u32 gamepad_bus = 0;
++    u32 gamepad_vid = 0;
++    u32 gamepad_pid = 0;
++    u32 gamepad_rev = 0;
++    int error;
++
++    drv = devm_kzalloc(&serdev->dev, sizeof(*drv), GFP_KERNEL);
++    if (!drv)
++    return -ENOMEM;
++
++    drv->invert_x = device_property_present(&serdev->dev, "invert-x");
++    drv->invert_y = device_property_present(&serdev->dev, "invert-y");
++    drv->invert_rx = device_property_present(&serdev->dev, "invert-rx");
++    drv->invert_ry = device_property_present(&serdev->dev, "invert-ry");
++
++    {
++        u32 range;
++        if (!device_property_read_u32(&serdev->dev, "axis-range", &range)) {
++            axis_leftx_min  = -range;
++            axis_leftx_max  =  range;
++            axis_lefty_min  = -range;
++            axis_lefty_max  =  range;
++            axis_rightx_min = -range;
++            axis_rightx_max =  range;
++            axis_righty_min = -range;
++            axis_righty_max =  range;
++
++            dev_info(&serdev->dev, "DT axis-range override applied: ±%u\n", range);
++        }
++    }
++
++    drv->vdd = devm_regulator_get(&serdev->dev, "vdd");
++    if (IS_ERR(drv->vdd)) {
++        error = PTR_ERR(drv->vdd);
++        return error;
++    }
++
++    error = regulator_enable(drv->vdd);
++        if (error < 0) {
++        return error;
++    }
++
++    drv->boot_gpio =
++        devm_gpiod_get_optional(&serdev->dev, "boot", GPIOD_OUT_HIGH);
++    if (IS_ERR(drv->boot_gpio)) {
++        error = PTR_ERR(drv->boot_gpio);
++        dev_warn(&serdev->dev, "Unable to get boot gpio: %d\n", error);
++    }
++
++    drv->enable_gpio =
++        devm_gpiod_get_optional(&serdev->dev, "enable", GPIOD_OUT_HIGH);
++    if (IS_ERR(drv->enable_gpio)) {
++        error = PTR_ERR(drv->enable_gpio);
++        dev_warn(&serdev->dev, "Unable to get enable gpio: %d\n", error);
++    }
++
++    drv->reset_gpio =
++        devm_gpiod_get_optional(&serdev->dev, "reset", GPIOD_OUT_HIGH);
++    if (IS_ERR(drv->reset_gpio)) {
++        error = PTR_ERR(drv->reset_gpio);
++        dev_warn(&serdev->dev, "Unable to get reset gpio: %d\n", error);
++    }
++
++    error = serdev_device_open(serdev);
++    if (error) {
++	regulator_disable(drv->vdd);
++        return dev_err_probe(&serdev->dev, error, "Unable to open UART device\n");
++    }
++
++    drv->serdev = serdev;
++    drv->sequence_number = 0;
++
++    serdev_device_set_drvdata(serdev, drv);
++
++    error = serdev_device_set_baudrate(serdev, 115200);
++    if (error < 0) {
++	serdev_device_close(serdev);
++	regulator_disable(drv->vdd);
++        return dev_err_probe(&serdev->dev, error, "Failed to set up host baud rate\n");
++    }
++
++    serdev_device_set_flow_control(serdev, false);
++
++    drv->input = devm_input_allocate_device(&serdev->dev);
++    if (!drv->input) {
++	serdev_device_close(serdev);
++	regulator_disable(drv->vdd);
++        return -ENOMEM;
++    }
++
++    drv->input->phys = "rsinput-gamepad/input0";
++
++    error = device_property_read_string(&serdev->dev, "gamepad-name", &drv->input->name);
++    if (error) {
++        drv->input->name = "RSInput Gamepad";
++    }
++
++    device_property_read_u32(&serdev->dev, "gamepad-bus", &gamepad_bus);
++    device_property_read_u32(&serdev->dev, "gamepad-vid", &gamepad_vid);
++    device_property_read_u32(&serdev->dev, "gamepad-pid", &gamepad_pid);
++    device_property_read_u32(&serdev->dev, "gamepad-rev", &gamepad_rev);
++
++    drv->input->id.bustype = (u16)gamepad_bus;
++    drv->input->id.vendor  = (u16)gamepad_vid;
++    drv->input->id.product = (u16)gamepad_pid;
++    drv->input->id.version = (u16)gamepad_rev;
++
++    __set_bit(EV_KEY, drv->input->evbit);
++    for (int i = 0; i < ARRAY_SIZE(keymap); i++)
++        input_set_capability(drv->input, EV_KEY, keymap[i]);
++
++    __set_bit(EV_ABS, drv->input->evbit);
++    input_set_abs_params(drv->input, ABS_X,
++        INT_SIGN(axis_leftx_min) * ( abs(axis_leftx_min) - axis_leftx_antideadzone ),
++        INT_SIGN(axis_leftx_max) * ( abs(axis_leftx_max) - axis_leftx_antideadzone ),
++        0, 0);
++    input_set_abs_params(drv->input, ABS_Y,
++        INT_SIGN(axis_lefty_min) * ( abs(axis_lefty_min) - axis_lefty_antideadzone ),
++        INT_SIGN(axis_lefty_max) * ( abs(axis_lefty_max) - axis_lefty_antideadzone ),
++        0, 0);
++    input_set_abs_params(drv->input, ABS_RX,
++        INT_SIGN(axis_rightx_min) * ( abs(axis_rightx_min) - axis_rightx_antideadzone ),
++        INT_SIGN(axis_rightx_max) * ( abs(axis_rightx_max) - axis_rightx_antideadzone ),
++        0, 0);
++    input_set_abs_params(drv->input, ABS_RY,
++        INT_SIGN(axis_righty_min) * ( abs(axis_righty_min) - axis_righty_antideadzone ),
++        INT_SIGN(axis_righty_max) * ( abs(axis_righty_max) - axis_righty_antideadzone ),
++        0, 0);
++
++    input_set_abs_params(drv->input, ABS_Z, 0, trigger_left_max - trigger_left_antideadzone, 0, 30);
++    input_set_abs_params(drv->input, ABS_RZ, 0, trigger_right_max - trigger_right_antideadzone, 0, 30);
++
++    error = input_register_device(drv->input);
++    if (error) {
++	serdev_device_close(serdev);
++	regulator_disable(drv->vdd);
++        return error;
++    }
++
++    serdev_device_set_client_ops(serdev, &rsinput_rx_ops);
++
++    error = rsinput_init_commands(drv);
++    if (error < 0) {
++        serdev_device_close(serdev);
++	regulator_disable(drv->vdd);
++        return error;
++    }
++
++    return 0;
++}
++
++static void rsinput_remove(struct serdev_device *serdev) {
++    struct rsinput_driver *drv = serdev_device_get_drvdata(serdev);
++
++    serdev_device_close(serdev);
++    input_unregister_device(drv->input);
++    if (drv->enable_gpio)
++        gpiod_set_value_cansleep(drv->enable_gpio, 0);
++
++    if (drv->reset_gpio)
++        gpiod_set_value_cansleep(drv->reset_gpio, 0);
++
++    regulator_disable(drv->vdd);
++}
++
++static const struct of_device_id rsinput_of_match[] = {
++    { .compatible = "gamepad,rsinput" },
++    { /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, rsinput_of_match);
++
++static struct serdev_device_driver rsinput_driver = {
++    .probe = rsinput_probe,
++    .remove = rsinput_remove,
++    .driver = {
++        .name = "rsinput",
++        .of_match_table = rsinput_of_match,
++    },
++};
++
++module_serdev_device_driver(rsinput_driver);
++
++MODULE_LICENSE("GPL");
++MODULE_DESCRIPTION("RSInput Gamepad Driver");
+diff --git a/drivers/net/wireless/ath/ath12k/mac.c.orig b/drivers/net/wireless/ath/ath12k/mac.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/net/wireless/ath/ath12k/mac.c.orig
+@@ -0,0 +1,15255 @@
++// SPDX-License-Identifier: BSD-3-Clause-Clear
++/*
++ * Copyright (c) 2018-2021 The Linux Foundation. All rights reserved.
++ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++ */
++
++#include <net/mac80211.h>
++#include <net/cfg80211.h>
++#include <linux/etherdevice.h>
++
++#include "mac.h"
++#include "core.h"
++#include "debug.h"
++#include "wmi.h"
++#include "hw.h"
++#include "dp_tx.h"
++#include "dp_rx.h"
++#include "testmode.h"
++#include "peer.h"
++#include "debugfs.h"
++#include "hif.h"
++#include "wow.h"
++#include "debugfs_sta.h"
++#include "dp.h"
++#include "dp_cmn.h"
++
++#define CHAN2G(_channel, _freq, _flags) { \
++	.band                   = NL80211_BAND_2GHZ, \
++	.hw_value               = (_channel), \
++	.center_freq            = (_freq), \
++	.flags                  = (_flags), \
++	.max_antenna_gain       = 0, \
++	.max_power              = 30, \
++}
++
++#define CHAN5G(_channel, _freq, _flags) { \
++	.band                   = NL80211_BAND_5GHZ, \
++	.hw_value               = (_channel), \
++	.center_freq            = (_freq), \
++	.flags                  = (_flags), \
++	.max_antenna_gain       = 0, \
++	.max_power              = 30, \
++}
++
++#define CHAN6G(_channel, _freq, _flags) { \
++	.band                   = NL80211_BAND_6GHZ, \
++	.hw_value               = (_channel), \
++	.center_freq            = (_freq), \
++	.flags                  = (_flags), \
++	.max_antenna_gain       = 0, \
++	.max_power              = 30, \
++}
++
++static const struct ieee80211_channel ath12k_2ghz_channels[] = {
++	CHAN2G(1, 2412, 0),
++	CHAN2G(2, 2417, 0),
++	CHAN2G(3, 2422, 0),
++	CHAN2G(4, 2427, 0),
++	CHAN2G(5, 2432, 0),
++	CHAN2G(6, 2437, 0),
++	CHAN2G(7, 2442, 0),
++	CHAN2G(8, 2447, 0),
++	CHAN2G(9, 2452, 0),
++	CHAN2G(10, 2457, 0),
++	CHAN2G(11, 2462, 0),
++	CHAN2G(12, 2467, 0),
++	CHAN2G(13, 2472, 0),
++	CHAN2G(14, 2484, 0),
++};
++
++static const struct ieee80211_channel ath12k_5ghz_channels[] = {
++	CHAN5G(36, 5180, 0),
++	CHAN5G(40, 5200, 0),
++	CHAN5G(44, 5220, 0),
++	CHAN5G(48, 5240, 0),
++	CHAN5G(52, 5260, 0),
++	CHAN5G(56, 5280, 0),
++	CHAN5G(60, 5300, 0),
++	CHAN5G(64, 5320, 0),
++	CHAN5G(100, 5500, 0),
++	CHAN5G(104, 5520, 0),
++	CHAN5G(108, 5540, 0),
++	CHAN5G(112, 5560, 0),
++	CHAN5G(116, 5580, 0),
++	CHAN5G(120, 5600, 0),
++	CHAN5G(124, 5620, 0),
++	CHAN5G(128, 5640, 0),
++	CHAN5G(132, 5660, 0),
++	CHAN5G(136, 5680, 0),
++	CHAN5G(140, 5700, 0),
++	CHAN5G(144, 5720, 0),
++	CHAN5G(149, 5745, 0),
++	CHAN5G(153, 5765, 0),
++	CHAN5G(157, 5785, 0),
++	CHAN5G(161, 5805, 0),
++	CHAN5G(165, 5825, 0),
++	CHAN5G(169, 5845, 0),
++	CHAN5G(173, 5865, 0),
++};
++
++static const struct ieee80211_channel ath12k_6ghz_channels[] = {
++	/* Operating Class 136 */
++	CHAN6G(2, 5935, 0),
++
++	/* Operating Classes 131-135 */
++	CHAN6G(1, 5955, 0),
++	CHAN6G(5, 5975, 0),
++	CHAN6G(9, 5995, 0),
++	CHAN6G(13, 6015, 0),
++	CHAN6G(17, 6035, 0),
++	CHAN6G(21, 6055, 0),
++	CHAN6G(25, 6075, 0),
++	CHAN6G(29, 6095, 0),
++	CHAN6G(33, 6115, 0),
++	CHAN6G(37, 6135, 0),
++	CHAN6G(41, 6155, 0),
++	CHAN6G(45, 6175, 0),
++	CHAN6G(49, 6195, 0),
++	CHAN6G(53, 6215, 0),
++	CHAN6G(57, 6235, 0),
++	CHAN6G(61, 6255, 0),
++	CHAN6G(65, 6275, 0),
++	CHAN6G(69, 6295, 0),
++	CHAN6G(73, 6315, 0),
++	CHAN6G(77, 6335, 0),
++	CHAN6G(81, 6355, 0),
++	CHAN6G(85, 6375, 0),
++	CHAN6G(89, 6395, 0),
++	CHAN6G(93, 6415, 0),
++	CHAN6G(97, 6435, 0),
++	CHAN6G(101, 6455, 0),
++	CHAN6G(105, 6475, 0),
++	CHAN6G(109, 6495, 0),
++	CHAN6G(113, 6515, 0),
++	CHAN6G(117, 6535, 0),
++	CHAN6G(121, 6555, 0),
++	CHAN6G(125, 6575, 0),
++	CHAN6G(129, 6595, 0),
++	CHAN6G(133, 6615, 0),
++	CHAN6G(137, 6635, 0),
++	CHAN6G(141, 6655, 0),
++	CHAN6G(145, 6675, 0),
++	CHAN6G(149, 6695, 0),
++	CHAN6G(153, 6715, 0),
++	CHAN6G(157, 6735, 0),
++	CHAN6G(161, 6755, 0),
++	CHAN6G(165, 6775, 0),
++	CHAN6G(169, 6795, 0),
++	CHAN6G(173, 6815, 0),
++	CHAN6G(177, 6835, 0),
++	CHAN6G(181, 6855, 0),
++	CHAN6G(185, 6875, 0),
++	CHAN6G(189, 6895, 0),
++	CHAN6G(193, 6915, 0),
++	CHAN6G(197, 6935, 0),
++	CHAN6G(201, 6955, 0),
++	CHAN6G(205, 6975, 0),
++	CHAN6G(209, 6995, 0),
++	CHAN6G(213, 7015, 0),
++	CHAN6G(217, 7035, 0),
++	CHAN6G(221, 7055, 0),
++	CHAN6G(225, 7075, 0),
++	CHAN6G(229, 7095, 0),
++	CHAN6G(233, 7115, 0),
++};
++
++#define ATH12K_MAC_RATE_A_M(bps, code) \
++	{ .bitrate = (bps), .hw_value = (code),\
++	  .flags = IEEE80211_RATE_MANDATORY_A }
++
++#define ATH12K_MAC_RATE_B(bps, code, code_short) \
++	{ .bitrate = (bps), .hw_value = (code), .hw_value_short = (code_short),\
++	  .flags = IEEE80211_RATE_SHORT_PREAMBLE }
++
++static struct ieee80211_rate ath12k_legacy_rates[] = {
++	{ .bitrate = 10,
++	  .hw_value = ATH12K_HW_RATE_CCK_LP_1M },
++	ATH12K_MAC_RATE_B(20, ATH12K_HW_RATE_CCK_LP_2M,
++			  ATH12K_HW_RATE_CCK_SP_2M),
++	ATH12K_MAC_RATE_B(55, ATH12K_HW_RATE_CCK_LP_5_5M,
++			  ATH12K_HW_RATE_CCK_SP_5_5M),
++	ATH12K_MAC_RATE_B(110, ATH12K_HW_RATE_CCK_LP_11M,
++			  ATH12K_HW_RATE_CCK_SP_11M),
++	ATH12K_MAC_RATE_A_M(60, ATH12K_HW_RATE_OFDM_6M),
++	ATH12K_MAC_RATE_A_M(90, ATH12K_HW_RATE_OFDM_9M),
++	ATH12K_MAC_RATE_A_M(120, ATH12K_HW_RATE_OFDM_12M),
++	ATH12K_MAC_RATE_A_M(180, ATH12K_HW_RATE_OFDM_18M),
++	ATH12K_MAC_RATE_A_M(240, ATH12K_HW_RATE_OFDM_24M),
++	ATH12K_MAC_RATE_A_M(360, ATH12K_HW_RATE_OFDM_36M),
++	ATH12K_MAC_RATE_A_M(480, ATH12K_HW_RATE_OFDM_48M),
++	ATH12K_MAC_RATE_A_M(540, ATH12K_HW_RATE_OFDM_54M),
++};
++
++static const int
++ath12k_phymodes[NUM_NL80211_BANDS][ATH12K_CHAN_WIDTH_NUM] = {
++	[NL80211_BAND_2GHZ] = {
++			[NL80211_CHAN_WIDTH_5] = MODE_UNKNOWN,
++			[NL80211_CHAN_WIDTH_10] = MODE_UNKNOWN,
++			[NL80211_CHAN_WIDTH_20_NOHT] = MODE_11BE_EHT20_2G,
++			[NL80211_CHAN_WIDTH_20] = MODE_11BE_EHT20_2G,
++			[NL80211_CHAN_WIDTH_40] = MODE_11BE_EHT40_2G,
++			[NL80211_CHAN_WIDTH_80] = MODE_UNKNOWN,
++			[NL80211_CHAN_WIDTH_80P80] = MODE_UNKNOWN,
++			[NL80211_CHAN_WIDTH_160] = MODE_UNKNOWN,
++			[NL80211_CHAN_WIDTH_320] = MODE_UNKNOWN,
++	},
++	[NL80211_BAND_5GHZ] = {
++			[NL80211_CHAN_WIDTH_5] = MODE_UNKNOWN,
++			[NL80211_CHAN_WIDTH_10] = MODE_UNKNOWN,
++			[NL80211_CHAN_WIDTH_20_NOHT] = MODE_11BE_EHT20,
++			[NL80211_CHAN_WIDTH_20] = MODE_11BE_EHT20,
++			[NL80211_CHAN_WIDTH_40] = MODE_11BE_EHT40,
++			[NL80211_CHAN_WIDTH_80] = MODE_11BE_EHT80,
++			[NL80211_CHAN_WIDTH_160] = MODE_11BE_EHT160,
++			[NL80211_CHAN_WIDTH_80P80] = MODE_UNKNOWN,
++			[NL80211_CHAN_WIDTH_320] = MODE_11BE_EHT320,
++	},
++	[NL80211_BAND_6GHZ] = {
++			[NL80211_CHAN_WIDTH_5] = MODE_UNKNOWN,
++			[NL80211_CHAN_WIDTH_10] = MODE_UNKNOWN,
++			[NL80211_CHAN_WIDTH_20_NOHT] = MODE_11BE_EHT20,
++			[NL80211_CHAN_WIDTH_20] = MODE_11BE_EHT20,
++			[NL80211_CHAN_WIDTH_40] = MODE_11BE_EHT40,
++			[NL80211_CHAN_WIDTH_80] = MODE_11BE_EHT80,
++			[NL80211_CHAN_WIDTH_160] = MODE_11BE_EHT160,
++			[NL80211_CHAN_WIDTH_80P80] = MODE_UNKNOWN,
++			[NL80211_CHAN_WIDTH_320] = MODE_11BE_EHT320,
++	},
++
++};
++
++const struct htt_rx_ring_tlv_filter ath12k_mac_mon_status_filter_default = {
++	.rx_filter = HTT_RX_FILTER_TLV_FLAGS_MPDU_START |
++		     HTT_RX_FILTER_TLV_FLAGS_PPDU_END |
++		     HTT_RX_FILTER_TLV_FLAGS_PPDU_END_STATUS_DONE |
++		     HTT_RX_FILTER_TLV_FLAGS_PPDU_START_USER_INFO,
++	.pkt_filter_flags0 = HTT_RX_FP_MGMT_FILTER_FLAGS0,
++	.pkt_filter_flags1 = HTT_RX_FP_MGMT_FILTER_FLAGS1,
++	.pkt_filter_flags2 = HTT_RX_FP_CTRL_FILTER_FLASG2,
++	.pkt_filter_flags3 = HTT_RX_FP_DATA_FILTER_FLASG3 |
++			     HTT_RX_FP_CTRL_FILTER_FLASG3
++};
++
++#define ATH12K_MAC_FIRST_OFDM_RATE_IDX 4
++#define ath12k_g_rates ath12k_legacy_rates
++#define ath12k_g_rates_size (ARRAY_SIZE(ath12k_legacy_rates))
++#define ath12k_a_rates (ath12k_legacy_rates + 4)
++#define ath12k_a_rates_size (ARRAY_SIZE(ath12k_legacy_rates) - 4)
++
++#define ATH12K_MAC_SCAN_TIMEOUT_MSECS 200 /* in msecs */
++
++static const u32 ath12k_smps_map[] = {
++	[WLAN_HT_CAP_SM_PS_STATIC] = WMI_PEER_SMPS_STATIC,
++	[WLAN_HT_CAP_SM_PS_DYNAMIC] = WMI_PEER_SMPS_DYNAMIC,
++	[WLAN_HT_CAP_SM_PS_INVALID] = WMI_PEER_SMPS_PS_NONE,
++	[WLAN_HT_CAP_SM_PS_DISABLED] = WMI_PEER_SMPS_PS_NONE,
++};
++
++static int ath12k_start_vdev_delay(struct ath12k *ar,
++				   struct ath12k_link_vif *arvif);
++static void ath12k_mac_stop(struct ath12k *ar);
++static int ath12k_mac_vdev_create(struct ath12k *ar, struct ath12k_link_vif *arvif);
++static int ath12k_mac_vdev_delete(struct ath12k *ar, struct ath12k_link_vif *arvif);
++
++static const char *ath12k_mac_phymode_str(enum wmi_phy_mode mode)
++{
++	switch (mode) {
++	case MODE_11A:
++		return "11a";
++	case MODE_11G:
++		return "11g";
++	case MODE_11B:
++		return "11b";
++	case MODE_11GONLY:
++		return "11gonly";
++	case MODE_11NA_HT20:
++		return "11na-ht20";
++	case MODE_11NG_HT20:
++		return "11ng-ht20";
++	case MODE_11NA_HT40:
++		return "11na-ht40";
++	case MODE_11NG_HT40:
++		return "11ng-ht40";
++	case MODE_11AC_VHT20:
++		return "11ac-vht20";
++	case MODE_11AC_VHT40:
++		return "11ac-vht40";
++	case MODE_11AC_VHT80:
++		return "11ac-vht80";
++	case MODE_11AC_VHT160:
++		return "11ac-vht160";
++	case MODE_11AC_VHT80_80:
++		return "11ac-vht80+80";
++	case MODE_11AC_VHT20_2G:
++		return "11ac-vht20-2g";
++	case MODE_11AC_VHT40_2G:
++		return "11ac-vht40-2g";
++	case MODE_11AC_VHT80_2G:
++		return "11ac-vht80-2g";
++	case MODE_11AX_HE20:
++		return "11ax-he20";
++	case MODE_11AX_HE40:
++		return "11ax-he40";
++	case MODE_11AX_HE80:
++		return "11ax-he80";
++	case MODE_11AX_HE80_80:
++		return "11ax-he80+80";
++	case MODE_11AX_HE160:
++		return "11ax-he160";
++	case MODE_11AX_HE20_2G:
++		return "11ax-he20-2g";
++	case MODE_11AX_HE40_2G:
++		return "11ax-he40-2g";
++	case MODE_11AX_HE80_2G:
++		return "11ax-he80-2g";
++	case MODE_11BE_EHT20:
++		return "11be-eht20";
++	case MODE_11BE_EHT40:
++		return "11be-eht40";
++	case MODE_11BE_EHT80:
++		return "11be-eht80";
++	case MODE_11BE_EHT80_80:
++		return "11be-eht80+80";
++	case MODE_11BE_EHT160:
++		return "11be-eht160";
++	case MODE_11BE_EHT160_160:
++		return "11be-eht160+160";
++	case MODE_11BE_EHT320:
++		return "11be-eht320";
++	case MODE_11BE_EHT20_2G:
++		return "11be-eht20-2g";
++	case MODE_11BE_EHT40_2G:
++		return "11be-eht40-2g";
++	case MODE_UNKNOWN:
++		/* skip */
++		break;
++
++		/* no default handler to allow compiler to check that the
++		 * enum is fully handled
++		 */
++	}
++
++	return "<unknown>";
++}
++
++u16 ath12k_mac_he_convert_tones_to_ru_tones(u16 tones)
++{
++	switch (tones) {
++	case 26:
++		return RU_26;
++	case 52:
++		return RU_52;
++	case 106:
++		return RU_106;
++	case 242:
++		return RU_242;
++	case 484:
++		return RU_484;
++	case 996:
++		return RU_996;
++	case (996 * 2):
++		return RU_2X996;
++	default:
++		return RU_26;
++	}
++}
++EXPORT_SYMBOL(ath12k_mac_he_convert_tones_to_ru_tones);
++
++enum nl80211_eht_gi ath12k_mac_eht_gi_to_nl80211_eht_gi(u8 sgi)
++{
++	switch (sgi) {
++	case RX_MSDU_START_SGI_0_8_US:
++		return NL80211_RATE_INFO_EHT_GI_0_8;
++	case RX_MSDU_START_SGI_1_6_US:
++		return NL80211_RATE_INFO_EHT_GI_1_6;
++	case RX_MSDU_START_SGI_3_2_US:
++		return NL80211_RATE_INFO_EHT_GI_3_2;
++	default:
++		return NL80211_RATE_INFO_EHT_GI_0_8;
++	}
++}
++EXPORT_SYMBOL(ath12k_mac_eht_gi_to_nl80211_eht_gi);
++
++enum nl80211_eht_ru_alloc ath12k_mac_eht_ru_tones_to_nl80211_eht_ru_alloc(u16 ru_tones)
++{
++	switch (ru_tones) {
++	case 26:
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_26;
++	case 52:
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_52;
++	case (52 + 26):
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_52P26;
++	case 106:
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_106;
++	case (106 + 26):
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_106P26;
++	case 242:
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_242;
++	case 484:
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_484;
++	case (484 + 242):
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_484P242;
++	case 996:
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_996;
++	case (996 + 484):
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_996P484;
++	case (996 + 484 + 242):
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_996P484P242;
++	case (2 * 996):
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_2x996;
++	case (2 * 996 + 484):
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_2x996P484;
++	case (3 * 996):
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_3x996;
++	case (3 * 996 + 484):
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_3x996P484;
++	case (4 * 996):
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_4x996;
++	default:
++		return NL80211_RATE_INFO_EHT_RU_ALLOC_26;
++	}
++}
++EXPORT_SYMBOL(ath12k_mac_eht_ru_tones_to_nl80211_eht_ru_alloc);
++
++enum rate_info_bw
++ath12k_mac_bw_to_mac80211_bw(enum ath12k_supported_bw bw)
++{
++	u8 ret = RATE_INFO_BW_20;
++
++	switch (bw) {
++	case ATH12K_BW_20:
++		ret = RATE_INFO_BW_20;
++		break;
++	case ATH12K_BW_40:
++		ret = RATE_INFO_BW_40;
++		break;
++	case ATH12K_BW_80:
++		ret = RATE_INFO_BW_80;
++		break;
++	case ATH12K_BW_160:
++		ret = RATE_INFO_BW_160;
++		break;
++	case ATH12K_BW_320:
++		ret = RATE_INFO_BW_320;
++		break;
++	}
++
++	return ret;
++}
++EXPORT_SYMBOL(ath12k_mac_bw_to_mac80211_bw);
++
++enum ath12k_supported_bw ath12k_mac_mac80211_bw_to_ath12k_bw(enum rate_info_bw bw)
++{
++	switch (bw) {
++	case RATE_INFO_BW_20:
++		return ATH12K_BW_20;
++	case RATE_INFO_BW_40:
++		return ATH12K_BW_40;
++	case RATE_INFO_BW_80:
++		return ATH12K_BW_80;
++	case RATE_INFO_BW_160:
++		return ATH12K_BW_160;
++	case RATE_INFO_BW_320:
++		return ATH12K_BW_320;
++	default:
++		return ATH12K_BW_20;
++	}
++}
++
++int ath12k_mac_hw_ratecode_to_legacy_rate(u8 hw_rc, u8 preamble, u8 *rateidx,
++					  u16 *rate)
++{
++	/* As default, it is OFDM rates */
++	int i = ATH12K_MAC_FIRST_OFDM_RATE_IDX;
++	int max_rates_idx = ath12k_g_rates_size;
++
++	if (preamble == WMI_RATE_PREAMBLE_CCK) {
++		hw_rc &= ~ATH12K_HW_RATECODE_CCK_SHORT_PREAM_MASK;
++		i = 0;
++		max_rates_idx = ATH12K_MAC_FIRST_OFDM_RATE_IDX;
++	}
++
++	while (i < max_rates_idx) {
++		if (hw_rc == ath12k_legacy_rates[i].hw_value) {
++			*rateidx = i;
++			*rate = ath12k_legacy_rates[i].bitrate;
++			return 0;
++		}
++		i++;
++	}
++
++	return -EINVAL;
++}
++EXPORT_SYMBOL(ath12k_mac_hw_ratecode_to_legacy_rate);
++
++u8 ath12k_mac_bitrate_to_idx(const struct ieee80211_supported_band *sband,
++			     u32 bitrate)
++{
++	int i;
++
++	for (i = 0; i < sband->n_bitrates; i++)
++		if (sband->bitrates[i].bitrate == bitrate)
++			return i;
++
++	return 0;
++}
++
++static u32
++ath12k_mac_max_ht_nss(const u8 *ht_mcs_mask)
++{
++	int nss;
++
++	for (nss = IEEE80211_HT_MCS_MASK_LEN - 1; nss >= 0; nss--)
++		if (ht_mcs_mask[nss])
++			return nss + 1;
++
++	return 1;
++}
++
++static u32
++ath12k_mac_max_vht_nss(const u16 *vht_mcs_mask)
++{
++	int nss;
++
++	for (nss = NL80211_VHT_NSS_MAX - 1; nss >= 0; nss--)
++		if (vht_mcs_mask[nss])
++			return nss + 1;
++
++	return 1;
++}
++
++static u32
++ath12k_mac_max_he_nss(const u16 he_mcs_mask[NL80211_HE_NSS_MAX])
++{
++	int nss;
++
++	for (nss = NL80211_HE_NSS_MAX - 1; nss >= 0; nss--)
++		if (he_mcs_mask[nss])
++			return nss + 1;
++
++	return 1;
++}
++
++static u32
++ath12k_mac_max_eht_nss(const u16 eht_mcs_mask[NL80211_EHT_NSS_MAX])
++{
++	int nss;
++
++	for (nss = NL80211_EHT_NSS_MAX - 1; nss >= 0; nss--)
++		if (eht_mcs_mask[nss])
++			return nss + 1;
++
++	return 1;
++}
++
++static u32
++ath12k_mac_max_eht_mcs_nss(const u8 *eht_mcs, int eht_mcs_set_size)
++{
++	int i;
++	u8 nss = 0;
++
++	for (i = 0; i < eht_mcs_set_size; i++)
++		nss = max(nss, u8_get_bits(eht_mcs[i], IEEE80211_EHT_MCS_NSS_RX));
++
++	return nss;
++}
++
++static u8 ath12k_parse_mpdudensity(u8 mpdudensity)
++{
++/*  From IEEE Std 802.11-2020 defined values for "Minimum MPDU Start Spacing":
++ *   0 for no restriction
++ *   1 for 1/4 us
++ *   2 for 1/2 us
++ *   3 for 1 us
++ *   4 for 2 us
++ *   5 for 4 us
++ *   6 for 8 us
++ *   7 for 16 us
++ */
++	switch (mpdudensity) {
++	case 0:
++		return 0;
++	case 1:
++	case 2:
++	case 3:
++	/* Our lower layer calculations limit our precision to
++	 * 1 microsecond
++	 */
++		return 1;
++	case 4:
++		return 2;
++	case 5:
++		return 4;
++	case 6:
++		return 8;
++	case 7:
++		return 16;
++	default:
++		return 0;
++	}
++}
++
++static int ath12k_mac_vif_link_chan(struct ieee80211_vif *vif, u8 link_id,
++				    struct cfg80211_chan_def *def)
++{
++	struct ieee80211_bss_conf *link_conf;
++	struct ieee80211_chanctx_conf *conf;
++
++	rcu_read_lock();
++	link_conf = rcu_dereference(vif->link_conf[link_id]);
++
++	if (!link_conf) {
++		rcu_read_unlock();
++		return -ENOLINK;
++	}
++
++	conf = rcu_dereference(link_conf->chanctx_conf);
++	if (!conf) {
++		rcu_read_unlock();
++		return -ENOENT;
++	}
++	*def = conf->def;
++	rcu_read_unlock();
++
++	return 0;
++}
++
++static struct ath12k_link_vif *
++ath12k_mac_get_tx_arvif(struct ath12k_link_vif *arvif,
++			struct ieee80211_bss_conf *link_conf)
++{
++	struct ieee80211_bss_conf *tx_bss_conf;
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_vif *tx_ahvif;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	tx_bss_conf = wiphy_dereference(ath12k_ar_to_hw(ar)->wiphy,
++					link_conf->tx_bss_conf);
++	if (tx_bss_conf) {
++		tx_ahvif = ath12k_vif_to_ahvif(tx_bss_conf->vif);
++		return wiphy_dereference(tx_ahvif->ah->hw->wiphy,
++					 tx_ahvif->link[tx_bss_conf->link_id]);
++	}
++
++	return NULL;
++}
++
++static const u8 *ath12k_mac_get_tx_bssid(struct ath12k_link_vif *arvif)
++{
++	struct ieee80211_bss_conf *link_conf;
++	struct ath12k_link_vif *tx_arvif;
++	struct ath12k *ar = arvif->ar;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf) {
++		ath12k_warn(ar->ab,
++			    "unable to access bss link conf for link %u required to retrieve transmitting link conf\n",
++			    arvif->link_id);
++		return NULL;
++	}
++	if (link_conf->vif->type == NL80211_IFTYPE_STATION) {
++		if (link_conf->nontransmitted)
++			return link_conf->transmitter_bssid;
++	} else {
++		tx_arvif = ath12k_mac_get_tx_arvif(arvif, link_conf);
++		if (tx_arvif)
++			return tx_arvif->bssid;
++	}
++
++	return NULL;
++}
++
++struct ieee80211_bss_conf *
++ath12k_mac_get_link_bss_conf(struct ath12k_link_vif *arvif)
++{
++	struct ieee80211_vif *vif = arvif->ahvif->vif;
++	struct ieee80211_bss_conf *link_conf;
++	struct ath12k *ar = arvif->ar;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (arvif->link_id >= IEEE80211_MLD_MAX_NUM_LINKS)
++		return NULL;
++
++	link_conf = wiphy_dereference(ath12k_ar_to_hw(ar)->wiphy,
++				      vif->link_conf[arvif->link_id]);
++
++	return link_conf;
++}
++
++static struct ieee80211_link_sta *ath12k_mac_get_link_sta(struct ath12k_link_sta *arsta)
++{
++	struct ath12k_sta *ahsta = arsta->ahsta;
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(ahsta);
++	struct ieee80211_link_sta *link_sta;
++
++	lockdep_assert_wiphy(ahsta->ahvif->ah->hw->wiphy);
++
++	if (arsta->link_id >= IEEE80211_MLD_MAX_NUM_LINKS)
++		return NULL;
++
++	link_sta = wiphy_dereference(ahsta->ahvif->ah->hw->wiphy,
++				     sta->link[arsta->link_id]);
++
++	return link_sta;
++}
++
++static bool ath12k_mac_bitrate_is_cck(int bitrate)
++{
++	switch (bitrate) {
++	case 10:
++	case 20:
++	case 55:
++	case 110:
++		return true;
++	}
++
++	return false;
++}
++
++u8 ath12k_mac_hw_rate_to_idx(const struct ieee80211_supported_band *sband,
++			     u8 hw_rate, bool cck)
++{
++	const struct ieee80211_rate *rate;
++	int i;
++
++	for (i = 0; i < sband->n_bitrates; i++) {
++		rate = &sband->bitrates[i];
++
++		if (ath12k_mac_bitrate_is_cck(rate->bitrate) != cck)
++			continue;
++
++		/* To handle 802.11a PPDU type */
++		if ((!cck) && (rate->hw_value == hw_rate) &&
++		    (rate->flags & IEEE80211_RATE_MANDATORY_A))
++			return i;
++		/* To handle 802.11b short PPDU type */
++		else if (rate->flags & IEEE80211_RATE_SHORT_PREAMBLE &&
++			 rate->hw_value_short == hw_rate)
++			return i;
++		/* To handle 802.11b long PPDU type */
++		else if (rate->hw_value == hw_rate)
++			return i;
++	}
++
++	return 0;
++}
++
++static u8 ath12k_mac_bitrate_to_rate(int bitrate)
++{
++	return DIV_ROUND_UP(bitrate, 5) |
++	       (ath12k_mac_bitrate_is_cck(bitrate) ? BIT(7) : 0);
++}
++
++static void ath12k_get_arvif_iter(void *data, u8 *mac,
++				  struct ieee80211_vif *vif)
++{
++	struct ath12k_vif_iter *arvif_iter = data;
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	unsigned long links_map = ahvif->links_map;
++	struct ath12k_link_vif *arvif;
++	u8 link_id;
++
++	for_each_set_bit(link_id, &links_map, IEEE80211_MLD_MAX_NUM_LINKS) {
++		arvif = rcu_dereference(ahvif->link[link_id]);
++
++		if (WARN_ON(!arvif))
++			continue;
++
++		if (!arvif->is_created)
++			continue;
++
++		if (arvif->vdev_id == arvif_iter->vdev_id &&
++		    arvif->ar == arvif_iter->ar) {
++			arvif_iter->arvif = arvif;
++			break;
++		}
++	}
++}
++
++struct ath12k_link_vif *ath12k_mac_get_arvif(struct ath12k *ar, u32 vdev_id)
++{
++	struct ath12k_vif_iter arvif_iter = {};
++	u32 flags;
++
++	/* To use the arvif returned, caller must have held rcu read lock.
++	 */
++	lockdep_assert_in_rcu_read_lock();
++	arvif_iter.vdev_id = vdev_id;
++	arvif_iter.ar = ar;
++
++	flags = IEEE80211_IFACE_ITER_RESUME_ALL;
++	ieee80211_iterate_active_interfaces_atomic(ath12k_ar_to_hw(ar),
++						   flags,
++						   ath12k_get_arvif_iter,
++						   &arvif_iter);
++	if (!arvif_iter.arvif) {
++		ath12k_warn(ar->ab, "No VIF found for vdev %d\n", vdev_id);
++		return NULL;
++	}
++
++	return arvif_iter.arvif;
++}
++
++struct ath12k_link_vif *ath12k_mac_get_arvif_by_vdev_id(struct ath12k_base *ab,
++							u32 vdev_id)
++{
++	int i;
++	struct ath12k_pdev *pdev;
++	struct ath12k_link_vif *arvif;
++
++	for (i = 0; i < ab->num_radios; i++) {
++		pdev = rcu_dereference(ab->pdevs_active[i]);
++		if (pdev && pdev->ar &&
++		    (pdev->ar->allocated_vdev_map & (1LL << vdev_id))) {
++			arvif = ath12k_mac_get_arvif(pdev->ar, vdev_id);
++			if (arvif)
++				return arvif;
++		}
++	}
++
++	return NULL;
++}
++
++struct ath12k *ath12k_mac_get_ar_by_vdev_id(struct ath12k_base *ab, u32 vdev_id)
++{
++	int i;
++	struct ath12k_pdev *pdev;
++
++	for (i = 0; i < ab->num_radios; i++) {
++		pdev = rcu_dereference(ab->pdevs_active[i]);
++		if (pdev && pdev->ar) {
++			if (pdev->ar->allocated_vdev_map & (1LL << vdev_id))
++				return pdev->ar;
++		}
++	}
++
++	return NULL;
++}
++
++struct ath12k *ath12k_mac_get_ar_by_pdev_id(struct ath12k_base *ab, u32 pdev_id)
++{
++	int i;
++	struct ath12k_pdev *pdev;
++
++	if (ab->hw_params->single_pdev_only) {
++		pdev = rcu_dereference(ab->pdevs_active[0]);
++		return pdev ? pdev->ar : NULL;
++	}
++
++	if (WARN_ON(pdev_id > ab->num_radios))
++		return NULL;
++
++	for (i = 0; i < ab->num_radios; i++) {
++		if (ab->fw_mode == ATH12K_FIRMWARE_MODE_FTM)
++			pdev = &ab->pdevs[i];
++		else
++			pdev = rcu_dereference(ab->pdevs_active[i]);
++
++		if (pdev && pdev->pdev_id == pdev_id)
++			return (pdev->ar ? pdev->ar : NULL);
++	}
++
++	return NULL;
++}
++
++static bool ath12k_mac_is_ml_arvif(struct ath12k_link_vif *arvif)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++
++	lockdep_assert_wiphy(ahvif->ah->hw->wiphy);
++
++	if (ahvif->vif->valid_links & BIT(arvif->link_id))
++		return true;
++
++	return false;
++}
++
++static struct ath12k *ath12k_mac_get_ar_by_chan(struct ieee80211_hw *hw,
++						struct ieee80211_channel *channel)
++{
++	struct ath12k_hw *ah = hw->priv;
++	struct ath12k *ar;
++	int i;
++
++	ar = ah->radio;
++
++	if (ah->num_radio == 1)
++		return ar;
++
++	for_each_ar(ah, ar, i) {
++		if (channel->center_freq >= KHZ_TO_MHZ(ar->freq_range.start_freq) &&
++		    channel->center_freq <= KHZ_TO_MHZ(ar->freq_range.end_freq))
++			return ar;
++	}
++	return NULL;
++}
++
++static struct ath12k *ath12k_get_ar_by_ctx(struct ieee80211_hw *hw,
++					   struct ieee80211_chanctx_conf *ctx)
++{
++	if (!ctx)
++		return NULL;
++
++	return ath12k_mac_get_ar_by_chan(hw, ctx->def.chan);
++}
++
++struct ath12k *ath12k_get_ar_by_vif(struct ieee80211_hw *hw,
++				    struct ieee80211_vif *vif,
++				    u8 link_id)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k_link_vif *arvif;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	/* If there is one pdev within ah, then we return
++	 * ar directly.
++	 */
++	if (ah->num_radio == 1)
++		return ah->radio;
++
++	if (!(ahvif->links_map & BIT(link_id)))
++		return NULL;
++
++	arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++	if (arvif && arvif->is_created)
++		return arvif->ar;
++
++	return NULL;
++}
++
++void ath12k_mac_get_any_chanctx_conf_iter(struct ieee80211_hw *hw,
++					  struct ieee80211_chanctx_conf *conf,
++					  void *data)
++{
++	struct ath12k_mac_get_any_chanctx_conf_arg *arg = data;
++	struct ath12k *ctx_ar = ath12k_get_ar_by_ctx(hw, conf);
++
++	if (ctx_ar == arg->ar)
++		arg->chanctx_conf = conf;
++}
++
++static struct ath12k_link_vif *ath12k_mac_get_vif_up(struct ath12k *ar)
++{
++	struct ath12k_link_vif *arvif;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	list_for_each_entry(arvif, &ar->arvifs, list) {
++		if (arvif->is_up)
++			return arvif;
++	}
++
++	return NULL;
++}
++
++static bool ath12k_mac_band_match(enum nl80211_band band1, enum WMI_HOST_WLAN_BAND band2)
++{
++	switch (band1) {
++	case NL80211_BAND_2GHZ:
++		if (band2 & WMI_HOST_WLAN_2GHZ_CAP)
++			return true;
++		break;
++	case NL80211_BAND_5GHZ:
++	case NL80211_BAND_6GHZ:
++		if (band2 & WMI_HOST_WLAN_5GHZ_CAP)
++			return true;
++		break;
++	default:
++		return false;
++	}
++
++	return false;
++}
++
++static u8 ath12k_mac_get_target_pdev_id_from_vif(struct ath12k_link_vif *arvif)
++{
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_base *ab = ar->ab;
++	struct ieee80211_vif *vif = arvif->ahvif->vif;
++	struct cfg80211_chan_def def;
++	enum nl80211_band band;
++	u8 pdev_id = ab->fw_pdev[0].pdev_id;
++	int i;
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)))
++		return pdev_id;
++
++	band = def.chan->band;
++
++	for (i = 0; i < ab->fw_pdev_count; i++) {
++		if (ath12k_mac_band_match(band, ab->fw_pdev[i].supported_bands))
++			return ab->fw_pdev[i].pdev_id;
++	}
++
++	return pdev_id;
++}
++
++u8 ath12k_mac_get_target_pdev_id(struct ath12k *ar)
++{
++	struct ath12k_link_vif *arvif;
++	struct ath12k_base *ab = ar->ab;
++
++	if (!ab->hw_params->single_pdev_only)
++		return ar->pdev->pdev_id;
++
++	arvif = ath12k_mac_get_vif_up(ar);
++
++	/* fw_pdev array has pdev ids derived from phy capability
++	 * service ready event (pdev_and_hw_link_ids).
++	 * If no vif is active, return default first index.
++	 */
++	if (!arvif)
++		return ar->ab->fw_pdev[0].pdev_id;
++
++	/* If active vif is found, return the pdev id matching chandef band */
++	return ath12k_mac_get_target_pdev_id_from_vif(arvif);
++}
++
++static void ath12k_pdev_caps_update(struct ath12k *ar)
++{
++	struct ath12k_base *ab = ar->ab;
++
++	ar->max_tx_power = ab->target_caps.hw_max_tx_power;
++
++	/* FIXME: Set min_tx_power to ab->target_caps.hw_min_tx_power.
++	 * But since the received value in svcrdy is same as hw_max_tx_power,
++	 * we can set ar->min_tx_power to 0 currently until
++	 * this is fixed in firmware
++	 */
++	ar->min_tx_power = 0;
++
++	ar->txpower_limit_2g = ar->max_tx_power;
++	ar->txpower_limit_5g = ar->max_tx_power;
++	ar->txpower_scale = WMI_HOST_TP_SCALE_MAX;
++}
++
++static int ath12k_mac_txpower_recalc(struct ath12k *ar)
++{
++	struct ath12k_pdev *pdev = ar->pdev;
++	struct ath12k_link_vif *arvif;
++	int ret, txpower = -1;
++	u32 param;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	list_for_each_entry(arvif, &ar->arvifs, list) {
++		if (arvif->txpower <= 0)
++			continue;
++
++		if (txpower == -1)
++			txpower = arvif->txpower;
++		else
++			txpower = min(txpower, arvif->txpower);
++	}
++
++	if (txpower == -1)
++		return 0;
++
++	/* txpwr is set as 2 units per dBm in FW*/
++	txpower = min_t(u32, max_t(u32, ar->min_tx_power, txpower),
++			ar->max_tx_power) * 2;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "txpower to set in hw %d\n",
++		   txpower / 2);
++
++	if ((pdev->cap.supported_bands & WMI_HOST_WLAN_2GHZ_CAP) &&
++	    ar->txpower_limit_2g != txpower) {
++		param = WMI_PDEV_PARAM_TXPOWER_LIMIT2G;
++		ret = ath12k_wmi_pdev_set_param(ar, param,
++						txpower, ar->pdev->pdev_id);
++		if (ret)
++			goto fail;
++		ar->txpower_limit_2g = txpower;
++	}
++
++	if ((pdev->cap.supported_bands & WMI_HOST_WLAN_5GHZ_CAP) &&
++	    ar->txpower_limit_5g != txpower) {
++		param = WMI_PDEV_PARAM_TXPOWER_LIMIT5G;
++		ret = ath12k_wmi_pdev_set_param(ar, param,
++						txpower, ar->pdev->pdev_id);
++		if (ret)
++			goto fail;
++		ar->txpower_limit_5g = txpower;
++	}
++
++	return 0;
++
++fail:
++	ath12k_warn(ar->ab, "failed to recalc txpower limit %d using pdev param %d: %d\n",
++		    txpower / 2, param, ret);
++	return ret;
++}
++
++static int ath12k_recalc_rtscts_prot(struct ath12k_link_vif *arvif)
++{
++	struct ath12k *ar = arvif->ar;
++	u32 vdev_param, rts_cts;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	vdev_param = WMI_VDEV_PARAM_ENABLE_RTSCTS;
++
++	/* Enable RTS/CTS protection for sw retries (when legacy stations
++	 * are in BSS) or by default only for second rate series.
++	 * TODO: Check if we need to enable CTS 2 Self in any case
++	 */
++	rts_cts = WMI_USE_RTS_CTS;
++
++	if (arvif->num_legacy_stations > 0)
++		rts_cts |= WMI_RTSCTS_ACROSS_SW_RETRIES << 4;
++	else
++		rts_cts |= WMI_RTSCTS_FOR_SECOND_RATESERIES << 4;
++
++	/* Need not send duplicate param value to firmware */
++	if (arvif->rtscts_prot_mode == rts_cts)
++		return 0;
++
++	arvif->rtscts_prot_mode = rts_cts;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac vdev %d recalc rts/cts prot %d\n",
++		   arvif->vdev_id, rts_cts);
++
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    vdev_param, rts_cts);
++	if (ret)
++		ath12k_warn(ar->ab, "failed to recalculate rts/cts prot for vdev %d: %d\n",
++			    arvif->vdev_id, ret);
++
++	return ret;
++}
++
++static int ath12k_mac_set_kickout(struct ath12k_link_vif *arvif)
++{
++	struct ath12k *ar = arvif->ar;
++	u32 param;
++	int ret;
++
++	ret = ath12k_wmi_pdev_set_param(ar, WMI_PDEV_PARAM_STA_KICKOUT_TH,
++					ATH12K_KICKOUT_THRESHOLD,
++					ar->pdev->pdev_id);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set kickout threshold on vdev %i: %d\n",
++			    arvif->vdev_id, ret);
++		return ret;
++	}
++
++	param = WMI_VDEV_PARAM_AP_KEEPALIVE_MIN_IDLE_INACTIVE_TIME_SECS;
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id, param,
++					    ATH12K_KEEPALIVE_MIN_IDLE);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set keepalive minimum idle time on vdev %i: %d\n",
++			    arvif->vdev_id, ret);
++		return ret;
++	}
++
++	param = WMI_VDEV_PARAM_AP_KEEPALIVE_MAX_IDLE_INACTIVE_TIME_SECS;
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id, param,
++					    ATH12K_KEEPALIVE_MAX_IDLE);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set keepalive maximum idle time on vdev %i: %d\n",
++			    arvif->vdev_id, ret);
++		return ret;
++	}
++
++	param = WMI_VDEV_PARAM_AP_KEEPALIVE_MAX_UNRESPONSIVE_TIME_SECS;
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id, param,
++					    ATH12K_KEEPALIVE_MAX_UNRESPONSIVE);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set keepalive maximum unresponsive time on vdev %i: %d\n",
++			    arvif->vdev_id, ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static void ath12k_mac_link_sta_rhash_cleanup(void *data, struct ieee80211_sta *sta)
++{
++	u8 link_id;
++	unsigned long links_map;
++	struct ath12k_sta *ahsta;
++	struct ath12k *ar = data;
++	struct ath12k_link_sta *arsta;
++	struct ath12k_link_vif *arvif;
++	struct ath12k_base *ab = ar->ab;
++
++	ahsta = ath12k_sta_to_ahsta(sta);
++	links_map = ahsta->links_map;
++
++	rcu_read_lock();
++	for_each_set_bit(link_id, &links_map, IEEE80211_MLD_MAX_NUM_LINKS) {
++		arsta = rcu_dereference(ahsta->link[link_id]);
++		if (!arsta)
++			continue;
++		arvif = arsta->arvif;
++		if (!(arvif->ar == ar))
++			continue;
++
++		spin_lock_bh(&ab->base_lock);
++		ath12k_link_sta_rhash_delete(ab, arsta);
++		spin_unlock_bh(&ab->base_lock);
++	}
++	rcu_read_unlock();
++}
++
++void ath12k_mac_peer_cleanup_all(struct ath12k *ar)
++{
++	struct ath12k_dp_link_peer *peer, *tmp;
++	struct ath12k_base *ab = ar->ab;
++	struct ath12k_dp *dp = ath12k_ab_to_dp(ab);
++	struct ath12k_link_vif *arvif, *tmp_vif;
++	struct ath12k_dp_hw *dp_hw = &ar->ah->dp_hw;
++	struct ath12k_dp_peer *dp_peer = NULL;
++	u16 peerid_index;
++	struct list_head peers;
++
++	INIT_LIST_HEAD(&peers);
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	spin_lock_bh(&dp->dp_lock);
++	list_for_each_entry_safe(peer, tmp, &dp->peers, list) {
++		/* Skip Rx TID cleanup for self peer */
++		if (peer->sta && peer->dp_peer)
++			ath12k_dp_rx_peer_tid_cleanup(ar, peer);
++
++		/* cleanup dp peer */
++		spin_lock_bh(&dp_hw->peer_lock);
++		dp_peer = peer->dp_peer;
++		if (dp_peer) {
++			peerid_index = ath12k_dp_peer_get_peerid_index(dp, peer->peer_id);
++			rcu_assign_pointer(dp_peer->link_peers[peer->link_id], NULL);
++			WRITE_ONCE(dp_peer->link_peers_map,
++				   READ_ONCE(dp_peer->link_peers_map) & ~BIT(peer->link_id));
++			rcu_assign_pointer(dp_hw->dp_peers[peerid_index], NULL);
++		}
++		spin_unlock_bh(&dp_hw->peer_lock);
++
++		ath12k_dp_link_peer_rhash_delete(dp, peer);
++
++		list_move(&peer->list, &peers);
++	}
++	spin_unlock_bh(&dp->dp_lock);
++
++	synchronize_rcu();
++
++	list_for_each_entry_safe(peer, tmp, &peers, list) {
++		ath12k_dp_link_peer_free(peer);
++	}
++
++	ar->num_peers = 0;
++	ar->num_stations = 0;
++
++	/* Cleanup rhash table maintained for arsta by iterating over sta */
++	ieee80211_iterate_stations_mtx(ar->ah->hw, ath12k_mac_link_sta_rhash_cleanup,
++				       ar);
++
++	/* Delete all the self dp_peers on asserted radio */
++	list_for_each_entry_safe_reverse(arvif, tmp_vif, &ar->arvifs, list) {
++		if ((arvif->ahvif->vdev_type == WMI_VDEV_TYPE_AP) &&
++		    (arvif->link_id < IEEE80211_MLD_MAX_NUM_LINKS)) {
++			ath12k_dp_peer_delete(dp_hw, arvif->bssid, NULL);
++			arvif->num_stations = 0;
++		}
++	}
++}
++
++void ath12k_mac_dp_peer_cleanup(struct ath12k_hw *ah)
++{
++	struct list_head peers;
++	struct ath12k_dp_peer *dp_peer, *tmp;
++	struct ath12k_dp_hw *dp_hw = &ah->dp_hw;
++
++	INIT_LIST_HEAD(&peers);
++
++	spin_lock_bh(&dp_hw->peer_lock);
++	list_for_each_entry_safe(dp_peer, tmp, &dp_hw->dp_peers_list, list) {
++		if (dp_peer->is_mlo) {
++			struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(dp_peer->sta);
++
++			rcu_assign_pointer(dp_hw->dp_peers[dp_peer->peer_id], NULL);
++			clear_bit(ahsta->ml_peer_id, ah->free_ml_peer_id_map);
++			ahsta->ml_peer_id = ATH12K_MLO_PEER_ID_INVALID;
++		}
++
++		list_move(&dp_peer->list, &peers);
++	}
++
++	spin_unlock_bh(&dp_hw->peer_lock);
++
++	synchronize_rcu();
++
++	list_for_each_entry_safe(dp_peer, tmp, &peers, list) {
++		list_del(&dp_peer->list);
++		kfree(dp_peer);
++	}
++}
++
++static int ath12k_mac_vdev_setup_sync(struct ath12k *ar)
++{
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (test_bit(ATH12K_FLAG_CRASH_FLUSH, &ar->ab->dev_flags))
++		return -ESHUTDOWN;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "vdev setup timeout %d\n",
++		   ATH12K_VDEV_SETUP_TIMEOUT_HZ);
++
++	if (!wait_for_completion_timeout(&ar->vdev_setup_done,
++					 ATH12K_VDEV_SETUP_TIMEOUT_HZ))
++		return -ETIMEDOUT;
++
++	return ar->last_wmi_vdev_start_status ? -EINVAL : 0;
++}
++
++static int ath12k_monitor_vdev_up(struct ath12k *ar, int vdev_id)
++{
++	struct ath12k_wmi_vdev_up_params params = {};
++	int ret;
++
++	params.vdev_id = vdev_id;
++	params.bssid = ar->mac_addr;
++	ret = ath12k_wmi_vdev_up(ar, &params);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to put up monitor vdev %i: %d\n",
++			    vdev_id, ret);
++		return ret;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac monitor vdev %i started\n",
++		   vdev_id);
++	return 0;
++}
++
++static int ath12k_mac_monitor_vdev_start(struct ath12k *ar, int vdev_id,
++					 struct cfg80211_chan_def *chandef)
++{
++	struct ieee80211_channel *channel;
++	struct wmi_vdev_start_req_arg arg = {};
++	struct ath12k_wmi_vdev_up_params params = {};
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	channel = chandef->chan;
++	arg.vdev_id = vdev_id;
++	arg.freq = channel->center_freq;
++	arg.band_center_freq1 = chandef->center_freq1;
++	arg.band_center_freq2 = chandef->center_freq2;
++	arg.mode = ath12k_phymodes[chandef->chan->band][chandef->width];
++	arg.chan_radar = !!(channel->flags & IEEE80211_CHAN_RADAR);
++
++	arg.min_power = 0;
++	arg.max_power = channel->max_power;
++	arg.max_reg_power = channel->max_reg_power;
++	arg.max_antenna_gain = channel->max_antenna_gain;
++
++	arg.pref_tx_streams = ar->num_tx_chains;
++	arg.pref_rx_streams = ar->num_rx_chains;
++	arg.punct_bitmap = 0xFFFFFFFF;
++
++	arg.passive |= !!(chandef->chan->flags & IEEE80211_CHAN_NO_IR);
++
++	reinit_completion(&ar->vdev_setup_done);
++	reinit_completion(&ar->vdev_delete_done);
++
++	ret = ath12k_wmi_vdev_start(ar, &arg, false);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to request monitor vdev %i start: %d\n",
++			    vdev_id, ret);
++		return ret;
++	}
++
++	ret = ath12k_mac_vdev_setup_sync(ar);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to synchronize setup for monitor vdev %i start: %d\n",
++			    vdev_id, ret);
++		return ret;
++	}
++
++	params.vdev_id = vdev_id;
++	params.bssid = ar->mac_addr;
++	ret = ath12k_wmi_vdev_up(ar, &params);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to put up monitor vdev %i: %d\n",
++			    vdev_id, ret);
++		goto vdev_stop;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac monitor vdev %i started\n",
++		   vdev_id);
++	return 0;
++
++vdev_stop:
++	ret = ath12k_wmi_vdev_stop(ar, vdev_id);
++	if (ret)
++		ath12k_warn(ar->ab, "failed to stop monitor vdev %i after start failure: %d\n",
++			    vdev_id, ret);
++	return ret;
++}
++
++static int ath12k_mac_monitor_vdev_stop(struct ath12k *ar)
++{
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	reinit_completion(&ar->vdev_setup_done);
++
++	ret = ath12k_wmi_vdev_stop(ar, ar->monitor_vdev_id);
++	if (ret)
++		ath12k_warn(ar->ab, "failed to request monitor vdev %i stop: %d\n",
++			    ar->monitor_vdev_id, ret);
++
++	ret = ath12k_mac_vdev_setup_sync(ar);
++	if (ret)
++		ath12k_warn(ar->ab, "failed to synchronize monitor vdev %i stop: %d\n",
++			    ar->monitor_vdev_id, ret);
++
++	ret = ath12k_wmi_vdev_down(ar, ar->monitor_vdev_id);
++	if (ret)
++		ath12k_warn(ar->ab, "failed to put down monitor vdev %i: %d\n",
++			    ar->monitor_vdev_id, ret);
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac monitor vdev %i stopped\n",
++		   ar->monitor_vdev_id);
++	return ret;
++}
++
++static int ath12k_mac_monitor_vdev_delete(struct ath12k *ar)
++{
++	int ret;
++	unsigned long time_left;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (!ar->monitor_vdev_created)
++		return 0;
++
++	reinit_completion(&ar->vdev_delete_done);
++
++	ret = ath12k_wmi_vdev_delete(ar, ar->monitor_vdev_id);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to request wmi monitor vdev %i removal: %d\n",
++			    ar->monitor_vdev_id, ret);
++		return ret;
++	}
++
++	time_left = wait_for_completion_timeout(&ar->vdev_delete_done,
++						ATH12K_VDEV_DELETE_TIMEOUT_HZ);
++	if (time_left == 0) {
++		ath12k_warn(ar->ab, "Timeout in receiving vdev delete response\n");
++	} else {
++		ar->allocated_vdev_map &= ~(1LL << ar->monitor_vdev_id);
++		ar->ab->free_vdev_map |= 1LL << (ar->monitor_vdev_id);
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac monitor vdev %d deleted\n",
++			   ar->monitor_vdev_id);
++		ar->num_created_vdevs--;
++		ar->monitor_vdev_id = -1;
++		ar->monitor_vdev_created = false;
++	}
++
++	return ret;
++}
++
++static int ath12k_mac_monitor_start(struct ath12k *ar)
++{
++	struct ath12k_mac_get_any_chanctx_conf_arg arg;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (ar->monitor_started)
++		return 0;
++
++	arg.ar = ar;
++	arg.chanctx_conf = NULL;
++	ieee80211_iter_chan_contexts_atomic(ath12k_ar_to_hw(ar),
++					    ath12k_mac_get_any_chanctx_conf_iter,
++					    &arg);
++	if (!arg.chanctx_conf)
++		return 0;
++
++	ret = ath12k_mac_monitor_vdev_start(ar, ar->monitor_vdev_id,
++					    &arg.chanctx_conf->def);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to start monitor vdev: %d\n", ret);
++		return ret;
++	}
++
++	ret = ath12k_dp_tx_htt_monitor_mode_ring_config(ar, false);
++	if (ret) {
++		ath12k_warn(ar->ab, "fail to set monitor filter: %d\n", ret);
++		return ret;
++	}
++
++	ar->monitor_started = true;
++	ar->num_started_vdevs++;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac monitor started\n");
++
++	return 0;
++}
++
++static int ath12k_mac_monitor_stop(struct ath12k *ar)
++{
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (!ar->monitor_started)
++		return 0;
++
++	ret = ath12k_mac_monitor_vdev_stop(ar);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to stop monitor vdev: %d\n", ret);
++		return ret;
++	}
++
++	ar->monitor_started = false;
++	ar->num_started_vdevs--;
++	ret = ath12k_dp_tx_htt_monitor_mode_ring_config(ar, true);
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac monitor stopped ret %d\n", ret);
++	return ret;
++}
++
++int ath12k_mac_vdev_stop(struct ath12k_link_vif *arvif)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ath12k *ar = arvif->ar;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	reinit_completion(&ar->vdev_setup_done);
++
++	ret = ath12k_wmi_vdev_stop(ar, arvif->vdev_id);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to stop WMI vdev %i: %d\n",
++			    arvif->vdev_id, ret);
++		goto err;
++	}
++
++	ret = ath12k_mac_vdev_setup_sync(ar);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to synchronize setup for vdev %i: %d\n",
++			    arvif->vdev_id, ret);
++		goto err;
++	}
++
++	WARN_ON(ar->num_started_vdevs == 0);
++
++	ar->num_started_vdevs--;
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "vdev %pM stopped, vdev_id %d\n",
++		   ahvif->vif->addr, arvif->vdev_id);
++
++	if (test_bit(ATH12K_FLAG_CAC_RUNNING, &ar->dev_flags)) {
++		clear_bit(ATH12K_FLAG_CAC_RUNNING, &ar->dev_flags);
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "CAC Stopped for vdev %d\n",
++			   arvif->vdev_id);
++	}
++
++	return 0;
++err:
++	return ret;
++}
++
++int ath12k_mac_op_config(struct ieee80211_hw *hw, int radio_idx, u32 changed)
++{
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_config);
++
++static int ath12k_mac_setup_bcn_p2p_ie(struct ath12k_link_vif *arvif,
++				       struct sk_buff *bcn)
++{
++	struct ath12k *ar = arvif->ar;
++	struct ieee80211_mgmt *mgmt;
++	const u8 *p2p_ie;
++	int ret;
++
++	mgmt = (void *)bcn->data;
++	p2p_ie = cfg80211_find_vendor_ie(WLAN_OUI_WFA, WLAN_OUI_TYPE_WFA_P2P,
++					 mgmt->u.beacon.variable,
++					 bcn->len - (mgmt->u.beacon.variable -
++						     bcn->data));
++	if (!p2p_ie) {
++		ath12k_warn(ar->ab, "no P2P ie found in beacon\n");
++		return -ENOENT;
++	}
++
++	ret = ath12k_wmi_p2p_go_bcn_ie(ar, arvif->vdev_id, p2p_ie);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to submit P2P GO bcn ie for vdev %i: %d\n",
++			    arvif->vdev_id, ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static int ath12k_mac_remove_vendor_ie(struct sk_buff *skb, unsigned int oui,
++				       u8 oui_type, size_t ie_offset)
++{
++	const u8 *next, *end;
++	size_t len;
++	u8 *ie;
++
++	if (WARN_ON(skb->len < ie_offset))
++		return -EINVAL;
++
++	ie = (u8 *)cfg80211_find_vendor_ie(oui, oui_type,
++					   skb->data + ie_offset,
++					   skb->len - ie_offset);
++	if (!ie)
++		return -ENOENT;
++
++	len = ie[1] + 2;
++	end = skb->data + skb->len;
++	next = ie + len;
++
++	if (WARN_ON(next > end))
++		return -EINVAL;
++
++	memmove(ie, next, end - next);
++	skb_trim(skb, skb->len - len);
++
++	return 0;
++}
++
++static void ath12k_mac_set_arvif_ies(struct ath12k_link_vif *arvif,
++				     struct ath12k_link_vif *tx_arvif,
++				     struct sk_buff *bcn,
++				     u8 bssid_index, bool *nontx_profile_found)
++{
++	struct ieee80211_mgmt *mgmt = (struct ieee80211_mgmt *)bcn->data;
++	const struct element *elem, *nontx, *index, *nie, *ext_cap_ie;
++	const u8 *start, *tail;
++	u16 rem_len;
++	u8 i;
++
++	start = bcn->data + ieee80211_get_hdrlen_from_skb(bcn) + sizeof(mgmt->u.beacon);
++	tail = skb_tail_pointer(bcn);
++	rem_len = tail - start;
++
++	arvif->rsnie_present = false;
++	arvif->wpaie_present = false;
++
++	if (cfg80211_find_ie(WLAN_EID_RSN, start, rem_len))
++		arvif->rsnie_present = true;
++	if (cfg80211_find_vendor_ie(WLAN_OUI_MICROSOFT, WLAN_OUI_TYPE_MICROSOFT_WPA,
++				    start, rem_len))
++		arvif->wpaie_present = true;
++
++	ext_cap_ie = cfg80211_find_elem(WLAN_EID_EXT_CAPABILITY, start, rem_len);
++	if (ext_cap_ie && ext_cap_ie->datalen >= 11 &&
++	    (ext_cap_ie->data[10] & WLAN_EXT_CAPA11_BCN_PROTECT))
++		tx_arvif->beacon_prot = true;
++
++	/* Return from here for the transmitted profile */
++	if (!bssid_index)
++		return;
++
++	/* Initial rsnie_present for the nontransmitted profile is set to be same as that
++	 * of the transmitted profile. It will be changed if security configurations are
++	 * different.
++	 */
++	*nontx_profile_found = false;
++	for_each_element_id(elem, WLAN_EID_MULTIPLE_BSSID, start, rem_len) {
++		/* Fixed minimum MBSSID element length with at least one
++		 * nontransmitted BSSID profile is 12 bytes as given below;
++		 * 1 (max BSSID indicator) +
++		 * 2 (Nontransmitted BSSID profile: Subelement ID + length) +
++		 * 4 (Nontransmitted BSSID Capabilities: tag + length + info)
++		 * 2 (Nontransmitted BSSID SSID: tag + length)
++		 * 3 (Nontransmitted BSSID Index: tag + length + BSSID index
++		 */
++		if (elem->datalen < 12 || elem->data[0] < 1)
++			continue; /* Max BSSID indicator must be >=1 */
++
++		for_each_element(nontx, elem->data + 1, elem->datalen - 1) {
++			start = nontx->data;
++
++			if (nontx->id != 0 || nontx->datalen < 4)
++				continue; /* Invalid nontransmitted profile */
++
++			if (nontx->data[0] != WLAN_EID_NON_TX_BSSID_CAP ||
++			    nontx->data[1] != 2) {
++				continue; /* Missing nontransmitted BSS capabilities */
++			}
++
++			if (nontx->data[4] != WLAN_EID_SSID)
++				continue; /* Missing SSID for nontransmitted BSS */
++
++			index = cfg80211_find_elem(WLAN_EID_MULTI_BSSID_IDX,
++						   start, nontx->datalen);
++			if (!index || index->datalen < 1 || index->data[0] == 0)
++				continue; /* Invalid MBSSID Index element */
++
++			if (index->data[0] == bssid_index) {
++				*nontx_profile_found = true;
++
++				/* Check if nontx BSS has beacon protection enabled */
++				if (!tx_arvif->beacon_prot) {
++					ext_cap_ie =
++					    cfg80211_find_elem(WLAN_EID_EXT_CAPABILITY,
++							       nontx->data,
++							       nontx->datalen);
++					if (ext_cap_ie && ext_cap_ie->datalen >= 11 &&
++					    (ext_cap_ie->data[10] &
++					     WLAN_EXT_CAPA11_BCN_PROTECT))
++						tx_arvif->beacon_prot = true;
++				}
++
++				if (cfg80211_find_ie(WLAN_EID_RSN,
++						     nontx->data,
++						     nontx->datalen)) {
++					arvif->rsnie_present = true;
++					return;
++				} else if (!arvif->rsnie_present) {
++					return; /* Both tx and nontx BSS are open */
++				}
++
++				nie = cfg80211_find_ext_elem(WLAN_EID_EXT_NON_INHERITANCE,
++							     nontx->data,
++							     nontx->datalen);
++				if (!nie || nie->datalen < 2)
++					return; /* Invalid non-inheritance element */
++
++				for (i = 1; i < nie->datalen - 1; i++) {
++					if (nie->data[i] == WLAN_EID_RSN) {
++						arvif->rsnie_present = false;
++						break;
++					}
++				}
++
++				return;
++			}
++		}
++	}
++}
++
++static int ath12k_mac_setup_bcn_tmpl_ema(struct ath12k_link_vif *arvif,
++					 struct ath12k_link_vif *tx_arvif,
++					 u8 bssid_index)
++{
++	struct ath12k_wmi_bcn_tmpl_ema_arg ema_args;
++	struct ieee80211_ema_beacons *beacons;
++	bool nontx_profile_found = false;
++	int ret = 0;
++	u8 i;
++
++	beacons = ieee80211_beacon_get_template_ema_list(ath12k_ar_to_hw(tx_arvif->ar),
++							 tx_arvif->ahvif->vif,
++							 tx_arvif->link_id);
++	if (!beacons || !beacons->cnt) {
++		ath12k_warn(arvif->ar->ab,
++			    "failed to get ema beacon templates from mac80211\n");
++		return -EPERM;
++	}
++
++	if (tx_arvif == arvif)
++		ath12k_mac_set_arvif_ies(arvif, tx_arvif, beacons->bcn[0].skb, 0, NULL);
++
++	for (i = 0; i < beacons->cnt; i++) {
++		if (tx_arvif != arvif && !nontx_profile_found)
++			ath12k_mac_set_arvif_ies(arvif, tx_arvif, beacons->bcn[i].skb,
++						 bssid_index,
++						 &nontx_profile_found);
++
++		ema_args.bcn_cnt = beacons->cnt;
++		ema_args.bcn_index = i;
++		ret = ath12k_wmi_bcn_tmpl(tx_arvif, &beacons->bcn[i].offs,
++					  beacons->bcn[i].skb, &ema_args);
++		if (ret) {
++			ath12k_warn(tx_arvif->ar->ab,
++				    "failed to set ema beacon template id %i error %d\n",
++				    i, ret);
++			break;
++		}
++	}
++
++	if (tx_arvif != arvif && !nontx_profile_found)
++		ath12k_warn(arvif->ar->ab,
++			    "nontransmitted bssid index %u not found in beacon template\n",
++			    bssid_index);
++
++	ieee80211_beacon_free_ema_list(beacons);
++	return ret;
++}
++
++static int ath12k_mac_setup_bcn_tmpl(struct ath12k_link_vif *arvif)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(ahvif);
++	struct ieee80211_bss_conf *link_conf;
++	struct ath12k_link_vif *tx_arvif;
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_base *ab = ar->ab;
++	struct ieee80211_mutable_offsets offs = {};
++	bool nontx_profile_found = false;
++	struct sk_buff *bcn;
++	int ret;
++
++	if (ahvif->vdev_type != WMI_VDEV_TYPE_AP)
++		return 0;
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf) {
++		ath12k_warn(ar->ab, "unable to access bss link conf to set bcn tmpl for vif %pM link %u\n",
++			    vif->addr, arvif->link_id);
++		return -ENOLINK;
++	}
++
++	tx_arvif = ath12k_mac_get_tx_arvif(arvif, link_conf);
++	if (tx_arvif) {
++		if (tx_arvif != arvif && arvif->is_up)
++			return 0;
++
++		if (link_conf->ema_ap)
++			return ath12k_mac_setup_bcn_tmpl_ema(arvif, tx_arvif,
++							     link_conf->bssid_index);
++	} else {
++		tx_arvif = arvif;
++	}
++
++	bcn = ieee80211_beacon_get_template(ath12k_ar_to_hw(tx_arvif->ar),
++					    tx_arvif->ahvif->vif,
++					    &offs, tx_arvif->link_id);
++	if (!bcn) {
++		ath12k_warn(ab, "failed to get beacon template from mac80211\n");
++		return -EPERM;
++	}
++
++	if (tx_arvif == arvif) {
++		ath12k_mac_set_arvif_ies(arvif, tx_arvif, bcn, 0, NULL);
++	} else {
++		ath12k_mac_set_arvif_ies(arvif, tx_arvif, bcn,
++					 link_conf->bssid_index,
++					 &nontx_profile_found);
++		if (!nontx_profile_found)
++			ath12k_warn(ab,
++				    "nontransmitted profile not found in beacon template\n");
++	}
++
++	if (ahvif->vif->type == NL80211_IFTYPE_AP && ahvif->vif->p2p) {
++		ret = ath12k_mac_setup_bcn_p2p_ie(arvif, bcn);
++		if (ret) {
++			ath12k_warn(ab, "failed to setup P2P GO bcn ie: %d\n",
++				    ret);
++			goto free_bcn_skb;
++		}
++
++		/* P2P IE is inserted by firmware automatically (as
++		 * configured above) so remove it from the base beacon
++		 * template to avoid duplicate P2P IEs in beacon frames.
++		 */
++		ret = ath12k_mac_remove_vendor_ie(bcn, WLAN_OUI_WFA,
++						  WLAN_OUI_TYPE_WFA_P2P,
++						  offsetof(struct ieee80211_mgmt,
++							   u.beacon.variable));
++		if (ret) {
++			ath12k_warn(ab, "failed to remove P2P vendor ie: %d\n",
++				    ret);
++			goto free_bcn_skb;
++		}
++	}
++
++	ret = ath12k_wmi_bcn_tmpl(arvif, &offs, bcn, NULL);
++
++	if (ret)
++		ath12k_warn(ab, "failed to submit beacon template command: %d\n",
++			    ret);
++
++free_bcn_skb:
++	kfree_skb(bcn);
++	return ret;
++}
++
++static void ath12k_control_beaconing(struct ath12k_link_vif *arvif,
++				     struct ieee80211_bss_conf *info)
++{
++	struct ath12k_wmi_vdev_up_params params = {};
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ath12k *ar = arvif->ar;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(arvif->ar)->wiphy);
++
++	if (!info->enable_beacon) {
++		ret = ath12k_wmi_vdev_down(ar, arvif->vdev_id);
++		if (ret)
++			ath12k_warn(ar->ab, "failed to down vdev_id %i: %d\n",
++				    arvif->vdev_id, ret);
++
++		arvif->is_up = false;
++		return;
++	}
++
++	/* Install the beacon template to the FW */
++	ret = ath12k_mac_setup_bcn_tmpl(arvif);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to update bcn tmpl during vdev up: %d\n",
++			    ret);
++		return;
++	}
++
++	ahvif->aid = 0;
++
++	ether_addr_copy(arvif->bssid, info->addr);
++
++	params.vdev_id = arvif->vdev_id;
++	params.aid = ahvif->aid;
++	params.bssid = arvif->bssid;
++	params.tx_bssid = ath12k_mac_get_tx_bssid(arvif);
++	if (params.tx_bssid) {
++		params.nontx_profile_idx = info->bssid_index;
++		params.nontx_profile_cnt = 1 << info->bssid_indicator;
++	}
++	ret = ath12k_wmi_vdev_up(arvif->ar, &params);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to bring up vdev %d: %i\n",
++			    arvif->vdev_id, ret);
++		return;
++	}
++
++	arvif->is_up = true;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac vdev %d up\n", arvif->vdev_id);
++}
++
++static void ath12k_mac_handle_beacon_iter(void *data, u8 *mac,
++					  struct ieee80211_vif *vif)
++{
++	struct sk_buff *skb = data;
++	struct ieee80211_mgmt *mgmt = (void *)skb->data;
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_link_vif *arvif = &ahvif->deflink;
++
++	if (vif->type != NL80211_IFTYPE_STATION || !arvif->is_created)
++		return;
++
++	if (!ether_addr_equal(mgmt->bssid, vif->bss_conf.bssid))
++		return;
++
++	cancel_delayed_work(&arvif->connection_loss_work);
++}
++
++void ath12k_mac_handle_beacon(struct ath12k *ar, struct sk_buff *skb)
++{
++	ieee80211_iterate_active_interfaces_atomic(ath12k_ar_to_hw(ar),
++						   IEEE80211_IFACE_ITER_NORMAL,
++						   ath12k_mac_handle_beacon_iter,
++						   skb);
++}
++
++void ath12k_mac_handle_beacon_miss(struct ath12k *ar,
++				   struct ath12k_link_vif *arvif)
++{
++	struct ieee80211_hw *hw = ath12k_ar_to_hw(ar);
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++
++	if (!(arvif->is_created && arvif->is_up))
++		return;
++
++	ieee80211_beacon_loss(vif);
++
++	/* Firmware doesn't report beacon loss events repeatedly. If AP probe
++	 * (done by mac80211) succeeds but beacons do not resume then it
++	 * doesn't make sense to continue operation. Queue connection loss work
++	 * which can be cancelled when beacon is received.
++	 */
++	ieee80211_queue_delayed_work(hw, &arvif->connection_loss_work,
++				     ATH12K_CONNECTION_LOSS_HZ);
++}
++
++static void ath12k_mac_vif_sta_connection_loss_work(struct work_struct *work)
++{
++	struct ath12k_link_vif *arvif = container_of(work, struct ath12k_link_vif,
++						     connection_loss_work.work);
++	struct ieee80211_vif *vif = arvif->ahvif->vif;
++
++	if (!arvif->is_up)
++		return;
++
++	ieee80211_connection_loss(vif);
++}
++
++static void ath12k_peer_assoc_h_basic(struct ath12k *ar,
++				      struct ath12k_link_vif *arvif,
++				      struct ath12k_link_sta *arsta,
++				      struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct ieee80211_hw *hw = ath12k_ar_to_hw(ar);
++	struct ieee80211_bss_conf *bss_conf;
++	u32 aid;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (vif->type == NL80211_IFTYPE_STATION)
++		aid = vif->cfg.aid;
++	else
++		aid = sta->aid;
++
++	ether_addr_copy(arg->peer_mac, arsta->addr);
++	arg->vdev_id = arvif->vdev_id;
++	arg->peer_associd = aid;
++	arg->auth_flag = true;
++	/* TODO: STA WAR in ath10k for listen interval required? */
++	arg->peer_listen_intval = hw->conf.listen_interval;
++	arg->peer_nss = 1;
++
++	bss_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!bss_conf) {
++		ath12k_warn(ar->ab, "unable to access bss link conf in peer assoc for vif %pM link %u\n",
++			    vif->addr, arvif->link_id);
++		return;
++	}
++
++	arg->peer_caps = bss_conf->assoc_capability;
++}
++
++static void ath12k_peer_assoc_h_crypto(struct ath12k *ar,
++				       struct ath12k_link_vif *arvif,
++				       struct ath12k_link_sta *arsta,
++				       struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct ieee80211_bss_conf *info;
++	struct cfg80211_chan_def def;
++	struct cfg80211_bss *bss;
++	struct ieee80211_hw *hw = ath12k_ar_to_hw(ar);
++	const u8 *rsnie = NULL;
++	const u8 *wpaie = NULL;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	info = ath12k_mac_get_link_bss_conf(arvif);
++	if (!info) {
++		ath12k_warn(ar->ab, "unable to access bss link conf for peer assoc crypto for vif %pM link %u\n",
++			    vif->addr, arvif->link_id);
++		return;
++	}
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)))
++		return;
++
++	bss = cfg80211_get_bss(hw->wiphy, def.chan, info->bssid, NULL, 0,
++			       IEEE80211_BSS_TYPE_ANY, IEEE80211_PRIVACY_ANY);
++
++	if (arvif->rsnie_present || arvif->wpaie_present) {
++		arg->need_ptk_4_way = true;
++		if (arvif->wpaie_present)
++			arg->need_gtk_2_way = true;
++	} else if (bss) {
++		const struct cfg80211_bss_ies *ies;
++
++		rcu_read_lock();
++		rsnie = ieee80211_bss_get_ie(bss, WLAN_EID_RSN);
++
++		ies = rcu_dereference(bss->ies);
++
++		wpaie = cfg80211_find_vendor_ie(WLAN_OUI_MICROSOFT,
++						WLAN_OUI_TYPE_MICROSOFT_WPA,
++						ies->data,
++						ies->len);
++		rcu_read_unlock();
++		cfg80211_put_bss(hw->wiphy, bss);
++	}
++
++	/* FIXME: base on RSN IE/WPA IE is a correct idea? */
++	if (rsnie || wpaie) {
++		ath12k_dbg(ar->ab, ATH12K_DBG_WMI,
++			   "%s: rsn ie found\n", __func__);
++		arg->need_ptk_4_way = true;
++	}
++
++	if (wpaie) {
++		ath12k_dbg(ar->ab, ATH12K_DBG_WMI,
++			   "%s: wpa ie found\n", __func__);
++		arg->need_gtk_2_way = true;
++	}
++
++	if (sta->mfp) {
++		/* TODO: Need to check if FW supports PMF? */
++		arg->is_pmf_enabled = true;
++	}
++
++	/* TODO: safe_mode_enabled (bypass 4-way handshake) flag req? */
++}
++
++static void ath12k_peer_assoc_h_rates(struct ath12k *ar,
++				      struct ath12k_link_vif *arvif,
++				      struct ath12k_link_sta *arsta,
++				      struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct wmi_rate_set_arg *rateset = &arg->peer_legacy_rates;
++	struct ieee80211_link_sta *link_sta;
++	struct cfg80211_chan_def def;
++	const struct ieee80211_supported_band *sband;
++	const struct ieee80211_rate *rates;
++	struct ieee80211_hw *hw = ath12k_ar_to_hw(ar);
++	enum nl80211_band band;
++	u32 ratemask;
++	u8 rate;
++	int i;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)))
++		return;
++
++	link_sta = ath12k_mac_get_link_sta(arsta);
++	if (!link_sta) {
++		ath12k_warn(ar->ab, "unable to access link sta in peer assoc rates for sta %pM link %u\n",
++			    sta->addr, arsta->link_id);
++		return;
++	}
++
++	band = def.chan->band;
++	sband = hw->wiphy->bands[band];
++	ratemask = link_sta->supp_rates[band];
++	ratemask &= arvif->bitrate_mask.control[band].legacy;
++	rates = sband->bitrates;
++
++	rateset->num_rates = 0;
++
++	for (i = 0; i < 32; i++, ratemask >>= 1, rates++) {
++		if (!(ratemask & 1))
++			continue;
++
++		rate = ath12k_mac_bitrate_to_rate(rates->bitrate);
++		rateset->rates[rateset->num_rates] = rate;
++		rateset->num_rates++;
++	}
++}
++
++static bool
++ath12k_peer_assoc_h_ht_masked(const u8 *ht_mcs_mask)
++{
++	int nss;
++
++	for (nss = 0; nss < IEEE80211_HT_MCS_MASK_LEN; nss++)
++		if (ht_mcs_mask[nss])
++			return false;
++
++	return true;
++}
++
++static bool
++ath12k_peer_assoc_h_vht_masked(const u16 *vht_mcs_mask)
++{
++	int nss;
++
++	for (nss = 0; nss < NL80211_VHT_NSS_MAX; nss++)
++		if (vht_mcs_mask[nss])
++			return false;
++
++	return true;
++}
++
++static void ath12k_peer_assoc_h_ht(struct ath12k *ar,
++				   struct ath12k_link_vif *arvif,
++				   struct ath12k_link_sta *arsta,
++				   struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	const struct ieee80211_sta_ht_cap *ht_cap;
++	struct ieee80211_link_sta *link_sta;
++	struct cfg80211_chan_def def;
++	enum nl80211_band band;
++	const u8 *ht_mcs_mask;
++	int i, n;
++	u8 max_nss;
++	u32 stbc;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)))
++		return;
++
++	link_sta = ath12k_mac_get_link_sta(arsta);
++	if (!link_sta) {
++		ath12k_warn(ar->ab, "unable to access link sta in peer assoc ht for sta %pM link %u\n",
++			    sta->addr, arsta->link_id);
++		return;
++	}
++
++	ht_cap = &link_sta->ht_cap;
++	if (!ht_cap->ht_supported)
++		return;
++
++	band = def.chan->band;
++	ht_mcs_mask = arvif->bitrate_mask.control[band].ht_mcs;
++
++	if (ath12k_peer_assoc_h_ht_masked(ht_mcs_mask))
++		return;
++
++	arg->ht_flag = true;
++
++	arg->peer_max_mpdu = (1 << (IEEE80211_HT_MAX_AMPDU_FACTOR +
++				    ht_cap->ampdu_factor)) - 1;
++
++	arg->peer_mpdu_density =
++		ath12k_parse_mpdudensity(ht_cap->ampdu_density);
++
++	arg->peer_ht_caps = ht_cap->cap;
++	arg->peer_rate_caps |= WMI_HOST_RC_HT_FLAG;
++
++	if (ht_cap->cap & IEEE80211_HT_CAP_LDPC_CODING)
++		arg->ldpc_flag = true;
++
++	if (link_sta->bandwidth >= IEEE80211_STA_RX_BW_40) {
++		arg->bw_40 = true;
++		arg->peer_rate_caps |= WMI_HOST_RC_CW40_FLAG;
++	}
++
++	/* As firmware handles these two flags (IEEE80211_HT_CAP_SGI_20
++	 * and IEEE80211_HT_CAP_SGI_40) for enabling SGI, reset both
++	 * flags if guard interval is to force Long GI
++	 */
++	if (arvif->bitrate_mask.control[band].gi == NL80211_TXRATE_FORCE_LGI) {
++		arg->peer_ht_caps &= ~(IEEE80211_HT_CAP_SGI_20 | IEEE80211_HT_CAP_SGI_40);
++	} else {
++		/* Enable SGI flag if either SGI_20 or SGI_40 is supported */
++		if (ht_cap->cap & (IEEE80211_HT_CAP_SGI_20 | IEEE80211_HT_CAP_SGI_40))
++			arg->peer_rate_caps |= WMI_HOST_RC_SGI_FLAG;
++	}
++
++	if (ht_cap->cap & IEEE80211_HT_CAP_TX_STBC) {
++		arg->peer_rate_caps |= WMI_HOST_RC_TX_STBC_FLAG;
++		arg->stbc_flag = true;
++	}
++
++	if (ht_cap->cap & IEEE80211_HT_CAP_RX_STBC) {
++		stbc = ht_cap->cap & IEEE80211_HT_CAP_RX_STBC;
++		stbc = stbc >> IEEE80211_HT_CAP_RX_STBC_SHIFT;
++		stbc = stbc << WMI_HOST_RC_RX_STBC_FLAG_S;
++		arg->peer_rate_caps |= stbc;
++		arg->stbc_flag = true;
++	}
++
++	if (ht_cap->mcs.rx_mask[1] && ht_cap->mcs.rx_mask[2])
++		arg->peer_rate_caps |= WMI_HOST_RC_TS_FLAG;
++	else if (ht_cap->mcs.rx_mask[1])
++		arg->peer_rate_caps |= WMI_HOST_RC_DS_FLAG;
++
++	for (i = 0, n = 0, max_nss = 0; i < IEEE80211_HT_MCS_MASK_LEN * 8; i++)
++		if ((ht_cap->mcs.rx_mask[i / 8] & BIT(i % 8)) &&
++		    (ht_mcs_mask[i / 8] & BIT(i % 8))) {
++			max_nss = (i / 8) + 1;
++			arg->peer_ht_rates.rates[n++] = i;
++		}
++
++	/* This is a workaround for HT-enabled STAs which break the spec
++	 * and have no HT capabilities RX mask (no HT RX MCS map).
++	 *
++	 * As per spec, in section 20.3.5 Modulation and coding scheme (MCS),
++	 * MCS 0 through 7 are mandatory in 20MHz with 800 ns GI at all STAs.
++	 *
++	 * Firmware asserts if such situation occurs.
++	 */
++	if (n == 0) {
++		arg->peer_ht_rates.num_rates = 8;
++		for (i = 0; i < arg->peer_ht_rates.num_rates; i++)
++			arg->peer_ht_rates.rates[i] = i;
++	} else {
++		arg->peer_ht_rates.num_rates = n;
++		arg->peer_nss = min(link_sta->rx_nss, max_nss);
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac ht peer %pM mcs cnt %d nss %d\n",
++		   arg->peer_mac,
++		   arg->peer_ht_rates.num_rates,
++		   arg->peer_nss);
++}
++
++static int ath12k_mac_get_max_vht_mcs_map(u16 mcs_map, int nss)
++{
++	switch ((mcs_map >> (2 * nss)) & 0x3) {
++	case IEEE80211_VHT_MCS_SUPPORT_0_7: return BIT(8) - 1;
++	case IEEE80211_VHT_MCS_SUPPORT_0_8: return BIT(9) - 1;
++	case IEEE80211_VHT_MCS_SUPPORT_0_9: return BIT(10) - 1;
++	}
++	return 0;
++}
++
++static u16
++ath12k_peer_assoc_h_vht_limit(u16 tx_mcs_set,
++			      const u16 vht_mcs_limit[NL80211_VHT_NSS_MAX])
++{
++	int idx_limit;
++	int nss;
++	u16 mcs_map;
++	u16 mcs;
++
++	for (nss = 0; nss < NL80211_VHT_NSS_MAX; nss++) {
++		mcs_map = ath12k_mac_get_max_vht_mcs_map(tx_mcs_set, nss) &
++			  vht_mcs_limit[nss];
++
++		if (mcs_map)
++			idx_limit = fls(mcs_map) - 1;
++		else
++			idx_limit = -1;
++
++		switch (idx_limit) {
++		case 0:
++		case 1:
++		case 2:
++		case 3:
++		case 4:
++		case 5:
++		case 6:
++		case 7:
++			mcs = IEEE80211_VHT_MCS_SUPPORT_0_7;
++			break;
++		case 8:
++			mcs = IEEE80211_VHT_MCS_SUPPORT_0_8;
++			break;
++		case 9:
++			mcs = IEEE80211_VHT_MCS_SUPPORT_0_9;
++			break;
++		default:
++			WARN_ON(1);
++			fallthrough;
++		case -1:
++			mcs = IEEE80211_VHT_MCS_NOT_SUPPORTED;
++			break;
++		}
++
++		tx_mcs_set &= ~(0x3 << (nss * 2));
++		tx_mcs_set |= mcs << (nss * 2);
++	}
++
++	return tx_mcs_set;
++}
++
++static u8 ath12k_get_nss_160mhz(struct ath12k *ar,
++				u8 max_nss)
++{
++	u8 nss_ratio_info = ar->pdev->cap.nss_ratio_info;
++	u8 max_sup_nss = 0;
++
++	switch (nss_ratio_info) {
++	case WMI_NSS_RATIO_1BY2_NSS:
++		max_sup_nss = max_nss >> 1;
++		break;
++	case WMI_NSS_RATIO_3BY4_NSS:
++		ath12k_warn(ar->ab, "WMI_NSS_RATIO_3BY4_NSS not supported\n");
++		break;
++	case WMI_NSS_RATIO_1_NSS:
++		max_sup_nss = max_nss;
++		break;
++	case WMI_NSS_RATIO_2_NSS:
++		ath12k_warn(ar->ab, "WMI_NSS_RATIO_2_NSS not supported\n");
++		break;
++	default:
++		ath12k_warn(ar->ab, "invalid nss ratio received from fw: %d\n",
++			    nss_ratio_info);
++		break;
++	}
++
++	return max_sup_nss;
++}
++
++static void ath12k_peer_assoc_h_vht(struct ath12k *ar,
++				    struct ath12k_link_vif *arvif,
++				    struct ath12k_link_sta *arsta,
++				    struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	const struct ieee80211_sta_vht_cap *vht_cap;
++	struct ieee80211_link_sta *link_sta;
++	struct cfg80211_chan_def def;
++	enum nl80211_band band;
++	u16 *vht_mcs_mask;
++	u8 ampdu_factor;
++	u8 max_nss, vht_mcs;
++	int i, vht_nss, nss_idx;
++	bool user_rate_valid = true;
++	u32 rx_nss, tx_nss, nss_160;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)))
++		return;
++
++	link_sta = ath12k_mac_get_link_sta(arsta);
++	if (!link_sta) {
++		ath12k_warn(ar->ab, "unable to access link sta in peer assoc vht for sta %pM link %u\n",
++			    sta->addr, arsta->link_id);
++		return;
++	}
++
++	vht_cap = &link_sta->vht_cap;
++	if (!vht_cap->vht_supported)
++		return;
++
++	band = def.chan->band;
++	vht_mcs_mask = arvif->bitrate_mask.control[band].vht_mcs;
++
++	if (ath12k_peer_assoc_h_vht_masked(vht_mcs_mask))
++		return;
++
++	arg->vht_flag = true;
++
++	/* TODO: similar flags required? */
++	arg->vht_capable = true;
++
++	if (def.chan->band == NL80211_BAND_2GHZ)
++		arg->vht_ng_flag = true;
++
++	arg->peer_vht_caps = vht_cap->cap;
++
++	ampdu_factor = (vht_cap->cap &
++			IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK) >>
++		       IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_SHIFT;
++
++	/* Workaround: Some Netgear/Linksys 11ac APs set Rx A-MPDU factor to
++	 * zero in VHT IE. Using it would result in degraded throughput.
++	 * arg->peer_max_mpdu at this point contains HT max_mpdu so keep
++	 * it if VHT max_mpdu is smaller.
++	 */
++	arg->peer_max_mpdu = max(arg->peer_max_mpdu,
++				 (1U << (IEEE80211_HT_MAX_AMPDU_FACTOR +
++					ampdu_factor)) - 1);
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_80)
++		arg->bw_80 = true;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_160)
++		arg->bw_160 = true;
++
++	vht_nss =  ath12k_mac_max_vht_nss(vht_mcs_mask);
++
++	if (vht_nss > link_sta->rx_nss) {
++		user_rate_valid = false;
++		for (nss_idx = link_sta->rx_nss - 1; nss_idx >= 0; nss_idx--) {
++			if (vht_mcs_mask[nss_idx]) {
++				user_rate_valid = true;
++				break;
++			}
++		}
++	}
++
++	if (!user_rate_valid) {
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++			   "Setting vht range MCS value to peer supported nss:%d for peer %pM\n",
++			   link_sta->rx_nss, arsta->addr);
++		vht_mcs_mask[link_sta->rx_nss - 1] = vht_mcs_mask[vht_nss - 1];
++	}
++
++	/* Calculate peer NSS capability from VHT capabilities if STA
++	 * supports VHT.
++	 */
++	for (i = 0, max_nss = 0, vht_mcs = 0; i < NL80211_VHT_NSS_MAX; i++) {
++		vht_mcs = __le16_to_cpu(vht_cap->vht_mcs.rx_mcs_map) >>
++			  (2 * i) & 3;
++
++		if (vht_mcs != IEEE80211_VHT_MCS_NOT_SUPPORTED &&
++		    vht_mcs_mask[i])
++			max_nss = i + 1;
++	}
++	arg->peer_nss = min(link_sta->rx_nss, max_nss);
++	arg->rx_max_rate = __le16_to_cpu(vht_cap->vht_mcs.rx_highest);
++	arg->rx_mcs_set = __le16_to_cpu(vht_cap->vht_mcs.rx_mcs_map);
++	arg->rx_mcs_set = ath12k_peer_assoc_h_vht_limit(arg->rx_mcs_set, vht_mcs_mask);
++
++	arg->tx_max_rate = __le16_to_cpu(vht_cap->vht_mcs.tx_highest);
++	arg->tx_mcs_set = __le16_to_cpu(vht_cap->vht_mcs.tx_mcs_map);
++
++	/* In QCN9274 platform, VHT MCS rate 10 and 11 is enabled by default.
++	 * VHT MCS rate 10 and 11 is not supported in 11ac standard.
++	 * so explicitly disable the VHT MCS rate 10 and 11 in 11ac mode.
++	 */
++	arg->tx_mcs_set &= ~IEEE80211_VHT_MCS_SUPPORT_0_11_MASK;
++	arg->tx_mcs_set |= IEEE80211_DISABLE_VHT_MCS_SUPPORT_0_11;
++
++	if ((arg->tx_mcs_set & IEEE80211_VHT_MCS_NOT_SUPPORTED) ==
++			IEEE80211_VHT_MCS_NOT_SUPPORTED)
++		arg->peer_vht_caps &= ~IEEE80211_VHT_CAP_MU_BEAMFORMEE_CAPABLE;
++
++	/* TODO:  Check */
++	arg->tx_max_mcs_nss = 0xFF;
++
++	if (arg->peer_phymode == MODE_11AC_VHT160) {
++		tx_nss = ath12k_get_nss_160mhz(ar, max_nss);
++		rx_nss = min(arg->peer_nss, tx_nss);
++		arg->peer_bw_rxnss_override = ATH12K_BW_NSS_MAP_ENABLE;
++
++		if (!rx_nss) {
++			ath12k_warn(ar->ab, "invalid max_nss\n");
++			return;
++		}
++
++		nss_160 = u32_encode_bits(rx_nss - 1, ATH12K_PEER_RX_NSS_160MHZ);
++		arg->peer_bw_rxnss_override |= nss_160;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac vht peer %pM max_mpdu %d flags 0x%x nss_override 0x%x\n",
++		   arsta->addr, arg->peer_max_mpdu, arg->peer_flags,
++		   arg->peer_bw_rxnss_override);
++}
++
++static int ath12k_mac_get_max_he_mcs_map(u16 mcs_map, int nss)
++{
++	switch ((mcs_map >> (2 * nss)) & 0x3) {
++	case IEEE80211_HE_MCS_SUPPORT_0_7: return BIT(8) - 1;
++	case IEEE80211_HE_MCS_SUPPORT_0_9: return BIT(10) - 1;
++	case IEEE80211_HE_MCS_SUPPORT_0_11: return BIT(12) - 1;
++	}
++	return 0;
++}
++
++static u16 ath12k_peer_assoc_h_he_limit(u16 tx_mcs_set,
++					const u16 *he_mcs_limit)
++{
++	int idx_limit;
++	int nss;
++	u16 mcs_map;
++	u16 mcs;
++
++	for (nss = 0; nss < NL80211_HE_NSS_MAX; nss++) {
++		mcs_map = ath12k_mac_get_max_he_mcs_map(tx_mcs_set, nss) &
++			he_mcs_limit[nss];
++
++		if (mcs_map)
++			idx_limit = fls(mcs_map) - 1;
++		else
++			idx_limit = -1;
++
++		switch (idx_limit) {
++		case 0 ... 7:
++			mcs = IEEE80211_HE_MCS_SUPPORT_0_7;
++			break;
++		case 8:
++		case 9:
++			mcs = IEEE80211_HE_MCS_SUPPORT_0_9;
++			break;
++		case 10:
++		case 11:
++			mcs = IEEE80211_HE_MCS_SUPPORT_0_11;
++			break;
++		default:
++			WARN_ON(1);
++			fallthrough;
++		case -1:
++			mcs = IEEE80211_HE_MCS_NOT_SUPPORTED;
++			break;
++		}
++
++		tx_mcs_set &= ~(0x3 << (nss * 2));
++		tx_mcs_set |= mcs << (nss * 2);
++	}
++
++	return tx_mcs_set;
++}
++
++static bool
++ath12k_peer_assoc_h_he_masked(const u16 he_mcs_mask[NL80211_HE_NSS_MAX])
++{
++	int nss;
++
++	for (nss = 0; nss < NL80211_HE_NSS_MAX; nss++)
++		if (he_mcs_mask[nss])
++			return false;
++
++	return true;
++}
++
++static void ath12k_peer_assoc_h_he(struct ath12k *ar,
++				   struct ath12k_link_vif *arvif,
++				   struct ath12k_link_sta *arsta,
++				   struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	const struct ieee80211_sta_he_cap *he_cap;
++	struct ieee80211_bss_conf *link_conf;
++	struct ieee80211_link_sta *link_sta;
++	struct cfg80211_chan_def def;
++	int i;
++	u8 ampdu_factor, max_nss;
++	u8 rx_mcs_80 = IEEE80211_HE_MCS_NOT_SUPPORTED;
++	u8 rx_mcs_160 = IEEE80211_HE_MCS_NOT_SUPPORTED;
++	u16 mcs_160_map, mcs_80_map;
++	u8 link_id = arvif->link_id;
++	bool support_160;
++	enum nl80211_band band;
++	u16 *he_mcs_mask;
++	u8 he_mcs;
++	u16 he_tx_mcs = 0, v = 0;
++	int he_nss, nss_idx;
++	bool user_rate_valid = true;
++	u32 rx_nss, tx_nss, nss_160;
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, link_id, &def)))
++		return;
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf) {
++		ath12k_warn(ar->ab, "unable to access bss link conf in peer assoc he for vif %pM link %u",
++			    vif->addr, link_id);
++		return;
++	}
++
++	link_sta = ath12k_mac_get_link_sta(arsta);
++	if (!link_sta) {
++		ath12k_warn(ar->ab, "unable to access link sta in peer assoc he for sta %pM link %u\n",
++			    sta->addr, arsta->link_id);
++		return;
++	}
++
++	he_cap = &link_sta->he_cap;
++	if (!he_cap->has_he)
++		return;
++
++	band = def.chan->band;
++	he_mcs_mask = arvif->bitrate_mask.control[band].he_mcs;
++
++	if (ath12k_peer_assoc_h_he_masked(he_mcs_mask))
++		return;
++
++	arg->he_flag = true;
++
++	support_160 = !!(he_cap->he_cap_elem.phy_cap_info[0] &
++		  IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_160MHZ_IN_5G);
++
++	/* Supported HE-MCS and NSS Set of peer he_cap is intersection with self he_cp */
++	mcs_160_map = le16_to_cpu(he_cap->he_mcs_nss_supp.rx_mcs_160);
++	mcs_80_map = le16_to_cpu(he_cap->he_mcs_nss_supp.rx_mcs_80);
++
++	if (support_160) {
++		for (i = 7; i >= 0; i--) {
++			u8 mcs_160 = (mcs_160_map >> (2 * i)) & 3;
++
++			if (mcs_160 != IEEE80211_HE_MCS_NOT_SUPPORTED) {
++				rx_mcs_160 = i + 1;
++				break;
++			}
++		}
++	}
++
++	for (i = 7; i >= 0; i--) {
++		u8 mcs_80 = (mcs_80_map >> (2 * i)) & 3;
++
++		if (mcs_80 != IEEE80211_HE_MCS_NOT_SUPPORTED) {
++			rx_mcs_80 = i + 1;
++			break;
++		}
++	}
++
++	if (support_160)
++		max_nss = min(rx_mcs_80, rx_mcs_160);
++	else
++		max_nss = rx_mcs_80;
++
++	arg->peer_nss = min(link_sta->rx_nss, max_nss);
++
++	memcpy(&arg->peer_he_cap_macinfo, he_cap->he_cap_elem.mac_cap_info,
++	       sizeof(he_cap->he_cap_elem.mac_cap_info));
++	memcpy(&arg->peer_he_cap_phyinfo, he_cap->he_cap_elem.phy_cap_info,
++	       sizeof(he_cap->he_cap_elem.phy_cap_info));
++	arg->peer_he_ops = link_conf->he_oper.params;
++
++	/* the top most byte is used to indicate BSS color info */
++	arg->peer_he_ops &= 0xffffff;
++
++	/* As per section 26.6.1 IEEE Std 802.11ax‐2022, if the Max AMPDU
++	 * Exponent Extension in HE cap is zero, use the arg->peer_max_mpdu
++	 * as calculated while parsing VHT caps(if VHT caps is present)
++	 * or HT caps (if VHT caps is not present).
++	 *
++	 * For non-zero value of Max AMPDU Exponent Extension in HE MAC caps,
++	 * if a HE STA sends VHT cap and HE cap IE in assoc request then, use
++	 * MAX_AMPDU_LEN_FACTOR as 20 to calculate max_ampdu length.
++	 * If a HE STA that does not send VHT cap, but HE and HT cap in assoc
++	 * request, then use MAX_AMPDU_LEN_FACTOR as 16 to calculate max_ampdu
++	 * length.
++	 */
++	ampdu_factor = u8_get_bits(he_cap->he_cap_elem.mac_cap_info[3],
++				   IEEE80211_HE_MAC_CAP3_MAX_AMPDU_LEN_EXP_MASK);
++
++	if (ampdu_factor) {
++		if (link_sta->vht_cap.vht_supported)
++			arg->peer_max_mpdu = (1 << (IEEE80211_HE_VHT_MAX_AMPDU_FACTOR +
++						    ampdu_factor)) - 1;
++		else if (link_sta->ht_cap.ht_supported)
++			arg->peer_max_mpdu = (1 << (IEEE80211_HE_HT_MAX_AMPDU_FACTOR +
++						    ampdu_factor)) - 1;
++	}
++
++	if (he_cap->he_cap_elem.phy_cap_info[6] &
++	    IEEE80211_HE_PHY_CAP6_PPE_THRESHOLD_PRESENT) {
++		int bit = 7;
++		int nss, ru;
++
++		arg->peer_ppet.numss_m1 = he_cap->ppe_thres[0] &
++					  IEEE80211_PPE_THRES_NSS_MASK;
++		arg->peer_ppet.ru_bit_mask =
++			(he_cap->ppe_thres[0] &
++			 IEEE80211_PPE_THRES_RU_INDEX_BITMASK_MASK) >>
++			IEEE80211_PPE_THRES_RU_INDEX_BITMASK_POS;
++
++		for (nss = 0; nss <= arg->peer_ppet.numss_m1; nss++) {
++			for (ru = 0; ru < 4; ru++) {
++				u32 val = 0;
++				int i;
++
++				if ((arg->peer_ppet.ru_bit_mask & BIT(ru)) == 0)
++					continue;
++				for (i = 0; i < 6; i++) {
++					val >>= 1;
++					val |= ((he_cap->ppe_thres[bit / 8] >>
++						 (bit % 8)) & 0x1) << 5;
++					bit++;
++				}
++				arg->peer_ppet.ppet16_ppet8_ru3_ru0[nss] |=
++								val << (ru * 6);
++			}
++		}
++	}
++
++	if (he_cap->he_cap_elem.mac_cap_info[0] & IEEE80211_HE_MAC_CAP0_TWT_RES)
++		arg->twt_responder = true;
++	if (he_cap->he_cap_elem.mac_cap_info[0] & IEEE80211_HE_MAC_CAP0_TWT_REQ)
++		arg->twt_requester = true;
++
++	he_nss = ath12k_mac_max_he_nss(he_mcs_mask);
++
++	if (he_nss > link_sta->rx_nss) {
++		user_rate_valid = false;
++		for (nss_idx = link_sta->rx_nss - 1; nss_idx >= 0; nss_idx--) {
++			if (he_mcs_mask[nss_idx]) {
++				user_rate_valid = true;
++				break;
++			}
++		}
++	}
++
++	if (!user_rate_valid) {
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++			   "Setting he range MCS value to peer supported nss:%d for peer %pM\n",
++			   link_sta->rx_nss, arsta->addr);
++		he_mcs_mask[link_sta->rx_nss - 1] = he_mcs_mask[he_nss - 1];
++	}
++
++	switch (link_sta->bandwidth) {
++	case IEEE80211_STA_RX_BW_160:
++		v = le16_to_cpu(he_cap->he_mcs_nss_supp.rx_mcs_160);
++		v = ath12k_peer_assoc_h_he_limit(v, he_mcs_mask);
++		arg->peer_he_rx_mcs_set[WMI_HECAP_TXRX_MCS_NSS_IDX_160] = v;
++
++		v = le16_to_cpu(he_cap->he_mcs_nss_supp.tx_mcs_160);
++		arg->peer_he_tx_mcs_set[WMI_HECAP_TXRX_MCS_NSS_IDX_160] = v;
++
++		arg->peer_he_mcs_count++;
++		if (!he_tx_mcs)
++			he_tx_mcs = v;
++		fallthrough;
++
++	default:
++		v = le16_to_cpu(he_cap->he_mcs_nss_supp.rx_mcs_80);
++		v = ath12k_peer_assoc_h_he_limit(v, he_mcs_mask);
++		arg->peer_he_rx_mcs_set[WMI_HECAP_TXRX_MCS_NSS_IDX_80] = v;
++
++		v = le16_to_cpu(he_cap->he_mcs_nss_supp.tx_mcs_80);
++		arg->peer_he_tx_mcs_set[WMI_HECAP_TXRX_MCS_NSS_IDX_80] = v;
++
++		arg->peer_he_mcs_count++;
++		if (!he_tx_mcs)
++			he_tx_mcs = v;
++		break;
++	}
++
++	/* Calculate peer NSS capability from HE capabilities if STA
++	 * supports HE.
++	 */
++	for (i = 0, max_nss = 0, he_mcs = 0; i < NL80211_HE_NSS_MAX; i++) {
++		he_mcs = he_tx_mcs >> (2 * i) & 3;
++
++		/* In case of fixed rates, MCS Range in he_tx_mcs might have
++		 * unsupported range, with he_mcs_mask set, so check either of them
++		 * to find nss.
++		 */
++		if (he_mcs != IEEE80211_HE_MCS_NOT_SUPPORTED ||
++		    he_mcs_mask[i])
++			max_nss = i + 1;
++	}
++
++	max_nss = min(max_nss, ar->num_tx_chains);
++	arg->peer_nss = min(link_sta->rx_nss, max_nss);
++
++	if (arg->peer_phymode == MODE_11AX_HE160) {
++		tx_nss = ath12k_get_nss_160mhz(ar, ar->num_tx_chains);
++		rx_nss = min(arg->peer_nss, tx_nss);
++
++		arg->peer_nss = min(link_sta->rx_nss, ar->num_rx_chains);
++		arg->peer_bw_rxnss_override = ATH12K_BW_NSS_MAP_ENABLE;
++
++		if (!rx_nss) {
++			ath12k_warn(ar->ab, "invalid max_nss\n");
++			return;
++		}
++
++		nss_160 = u32_encode_bits(rx_nss - 1, ATH12K_PEER_RX_NSS_160MHZ);
++		arg->peer_bw_rxnss_override |= nss_160;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac he peer %pM nss %d mcs cnt %d nss_override 0x%x\n",
++		   arsta->addr, arg->peer_nss,
++		   arg->peer_he_mcs_count,
++		   arg->peer_bw_rxnss_override);
++}
++
++static void ath12k_peer_assoc_h_he_6ghz(struct ath12k *ar,
++					struct ath12k_link_vif *arvif,
++					struct ath12k_link_sta *arsta,
++					struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	const struct ieee80211_sta_he_cap *he_cap;
++	struct ieee80211_link_sta *link_sta;
++	struct cfg80211_chan_def def;
++	enum nl80211_band band;
++	u8 ampdu_factor, mpdu_density;
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)))
++		return;
++
++	band = def.chan->band;
++
++	link_sta = ath12k_mac_get_link_sta(arsta);
++	if (!link_sta) {
++		ath12k_warn(ar->ab, "unable to access link sta in peer assoc he 6ghz for sta %pM link %u\n",
++			    sta->addr, arsta->link_id);
++		return;
++	}
++
++	he_cap = &link_sta->he_cap;
++
++	if (!arg->he_flag || band != NL80211_BAND_6GHZ || !link_sta->he_6ghz_capa.capa)
++		return;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_40)
++		arg->bw_40 = true;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_80)
++		arg->bw_80 = true;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_160)
++		arg->bw_160 = true;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_320)
++		arg->bw_320 = true;
++
++	arg->peer_he_caps_6ghz = le16_to_cpu(link_sta->he_6ghz_capa.capa);
++
++	mpdu_density = u32_get_bits(arg->peer_he_caps_6ghz,
++				    IEEE80211_HE_6GHZ_CAP_MIN_MPDU_START);
++	arg->peer_mpdu_density = ath12k_parse_mpdudensity(mpdu_density);
++
++	/* From IEEE Std 802.11ax-2021 - Section 10.12.2: An HE STA shall be capable of
++	 * receiving A-MPDU where the A-MPDU pre-EOF padding length is up to the value
++	 * indicated by the Maximum A-MPDU Length Exponent Extension field in the HE
++	 * Capabilities element and the Maximum A-MPDU Length Exponent field in HE 6 GHz
++	 * Band Capabilities element in the 6 GHz band.
++	 *
++	 * Here, we are extracting the Max A-MPDU Exponent Extension from HE caps and
++	 * factor is the Maximum A-MPDU Length Exponent from HE 6 GHZ Band capability.
++	 */
++	ampdu_factor = u8_get_bits(he_cap->he_cap_elem.mac_cap_info[3],
++				   IEEE80211_HE_MAC_CAP3_MAX_AMPDU_LEN_EXP_MASK) +
++			u32_get_bits(arg->peer_he_caps_6ghz,
++				     IEEE80211_HE_6GHZ_CAP_MAX_AMPDU_LEN_EXP);
++
++	arg->peer_max_mpdu = (1u << (IEEE80211_HE_6GHZ_MAX_AMPDU_FACTOR +
++				     ampdu_factor)) - 1;
++}
++
++static int ath12k_get_smps_from_capa(const struct ieee80211_sta_ht_cap *ht_cap,
++				     const struct ieee80211_he_6ghz_capa *he_6ghz_capa,
++				     int *smps)
++{
++	if (ht_cap->ht_supported)
++		*smps = u16_get_bits(ht_cap->cap, IEEE80211_HT_CAP_SM_PS);
++	else
++		*smps = le16_get_bits(he_6ghz_capa->capa,
++				      IEEE80211_HE_6GHZ_CAP_SM_PS);
++
++	if (*smps >= ARRAY_SIZE(ath12k_smps_map))
++		return -EINVAL;
++
++	return 0;
++}
++
++static void ath12k_peer_assoc_h_smps(struct ath12k_link_sta *arsta,
++				     struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	const struct ieee80211_he_6ghz_capa *he_6ghz_capa;
++	struct ath12k_link_vif *arvif = arsta->arvif;
++	const struct ieee80211_sta_ht_cap *ht_cap;
++	struct ieee80211_link_sta *link_sta;
++	struct ath12k *ar = arvif->ar;
++	int smps;
++
++	link_sta = ath12k_mac_get_link_sta(arsta);
++	if (!link_sta) {
++		ath12k_warn(ar->ab, "unable to access link sta in peer assoc he for sta %pM link %u\n",
++			    sta->addr, arsta->link_id);
++		return;
++	}
++
++	he_6ghz_capa = &link_sta->he_6ghz_capa;
++	ht_cap = &link_sta->ht_cap;
++
++	if (!ht_cap->ht_supported && !he_6ghz_capa->capa)
++		return;
++
++	if (ath12k_get_smps_from_capa(ht_cap, he_6ghz_capa, &smps))
++		return;
++
++	switch (smps) {
++	case WLAN_HT_CAP_SM_PS_STATIC:
++		arg->static_mimops_flag = true;
++		break;
++	case WLAN_HT_CAP_SM_PS_DYNAMIC:
++		arg->dynamic_mimops_flag = true;
++		break;
++	case WLAN_HT_CAP_SM_PS_DISABLED:
++		arg->spatial_mux_flag = true;
++		break;
++	default:
++		break;
++	}
++}
++
++static void ath12k_peer_assoc_h_qos(struct ath12k *ar,
++				    struct ath12k_link_vif *arvif,
++				    struct ath12k_link_sta *arsta,
++				    struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++
++	switch (arvif->ahvif->vdev_type) {
++	case WMI_VDEV_TYPE_AP:
++		if (sta->wme) {
++			/* TODO: Check WME vs QoS */
++			arg->is_wme_set = true;
++			arg->qos_flag = true;
++		}
++
++		if (sta->wme && sta->uapsd_queues) {
++			/* TODO: Check WME vs QoS */
++			arg->is_wme_set = true;
++			arg->apsd_flag = true;
++			arg->peer_rate_caps |= WMI_HOST_RC_UAPSD_FLAG;
++		}
++		break;
++	case WMI_VDEV_TYPE_STA:
++		if (sta->wme) {
++			arg->is_wme_set = true;
++			arg->qos_flag = true;
++		}
++		break;
++	default:
++		break;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac peer %pM qos %d\n",
++		   arsta->addr, arg->qos_flag);
++}
++
++static int ath12k_peer_assoc_qos_ap(struct ath12k *ar,
++				    struct ath12k_link_vif *arvif,
++				    struct ath12k_link_sta *arsta)
++{
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct ath12k_wmi_ap_ps_arg arg;
++	u32 max_sp;
++	u32 uapsd;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	arg.vdev_id = arvif->vdev_id;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac uapsd_queues 0x%x max_sp %d\n",
++		   sta->uapsd_queues, sta->max_sp);
++
++	uapsd = 0;
++	if (sta->uapsd_queues & IEEE80211_WMM_IE_STA_QOSINFO_AC_VO)
++		uapsd |= WMI_AP_PS_UAPSD_AC3_DELIVERY_EN |
++			 WMI_AP_PS_UAPSD_AC3_TRIGGER_EN;
++	if (sta->uapsd_queues & IEEE80211_WMM_IE_STA_QOSINFO_AC_VI)
++		uapsd |= WMI_AP_PS_UAPSD_AC2_DELIVERY_EN |
++			 WMI_AP_PS_UAPSD_AC2_TRIGGER_EN;
++	if (sta->uapsd_queues & IEEE80211_WMM_IE_STA_QOSINFO_AC_BK)
++		uapsd |= WMI_AP_PS_UAPSD_AC1_DELIVERY_EN |
++			 WMI_AP_PS_UAPSD_AC1_TRIGGER_EN;
++	if (sta->uapsd_queues & IEEE80211_WMM_IE_STA_QOSINFO_AC_BE)
++		uapsd |= WMI_AP_PS_UAPSD_AC0_DELIVERY_EN |
++			 WMI_AP_PS_UAPSD_AC0_TRIGGER_EN;
++
++	max_sp = 0;
++	if (sta->max_sp < MAX_WMI_AP_PS_PEER_PARAM_MAX_SP)
++		max_sp = sta->max_sp;
++
++	arg.param = WMI_AP_PS_PEER_PARAM_UAPSD;
++	arg.value = uapsd;
++	ret = ath12k_wmi_send_set_ap_ps_param_cmd(ar, arsta->addr, &arg);
++	if (ret)
++		goto err;
++
++	arg.param = WMI_AP_PS_PEER_PARAM_MAX_SP;
++	arg.value = max_sp;
++	ret = ath12k_wmi_send_set_ap_ps_param_cmd(ar, arsta->addr, &arg);
++	if (ret)
++		goto err;
++
++	/* TODO: revisit during testing */
++	arg.param = WMI_AP_PS_PEER_PARAM_SIFS_RESP_FRMTYPE;
++	arg.value = DISABLE_SIFS_RESPONSE_TRIGGER;
++	ret = ath12k_wmi_send_set_ap_ps_param_cmd(ar, arsta->addr, &arg);
++	if (ret)
++		goto err;
++
++	arg.param = WMI_AP_PS_PEER_PARAM_SIFS_RESP_UAPSD;
++	arg.value = DISABLE_SIFS_RESPONSE_TRIGGER;
++	ret = ath12k_wmi_send_set_ap_ps_param_cmd(ar, arsta->addr, &arg);
++	if (ret)
++		goto err;
++
++	return 0;
++
++err:
++	ath12k_warn(ar->ab, "failed to set ap ps peer param %d for vdev %i: %d\n",
++		    arg.param, arvif->vdev_id, ret);
++	return ret;
++}
++
++static bool ath12k_mac_sta_has_ofdm_only(struct ieee80211_link_sta *sta)
++{
++	return sta->supp_rates[NL80211_BAND_2GHZ] >>
++	       ATH12K_MAC_FIRST_OFDM_RATE_IDX;
++}
++
++static enum wmi_phy_mode ath12k_mac_get_phymode_vht(struct ath12k *ar,
++						    struct ieee80211_link_sta *link_sta)
++{
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_160) {
++		if (link_sta->vht_cap.cap & (IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_160MHZ |
++		    IEEE80211_VHT_CAP_EXT_NSS_BW_MASK))
++			return MODE_11AC_VHT160;
++
++		/* Allow STA to connect even if it does not explicitly advertise 160 MHz
++		 * support
++		 */
++		return MODE_11AC_VHT160;
++	}
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_80)
++		return MODE_11AC_VHT80;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_40)
++		return MODE_11AC_VHT40;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_20)
++		return MODE_11AC_VHT20;
++
++	return MODE_UNKNOWN;
++}
++
++static enum wmi_phy_mode ath12k_mac_get_phymode_he(struct ath12k *ar,
++						   struct ieee80211_link_sta *link_sta)
++{
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_160) {
++		if (link_sta->he_cap.he_cap_elem.phy_cap_info[0] &
++		     IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_160MHZ_IN_5G)
++			return MODE_11AX_HE160;
++
++		return MODE_UNKNOWN;
++	}
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_80)
++		return MODE_11AX_HE80;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_40)
++		return MODE_11AX_HE40;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_20)
++		return MODE_11AX_HE20;
++
++	return MODE_UNKNOWN;
++}
++
++static enum wmi_phy_mode ath12k_mac_get_phymode_eht(struct ath12k *ar,
++						    struct ieee80211_link_sta *link_sta)
++{
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_320)
++		if (link_sta->eht_cap.eht_cap_elem.phy_cap_info[0] &
++		    IEEE80211_EHT_PHY_CAP0_320MHZ_IN_6GHZ)
++			return MODE_11BE_EHT320;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_160) {
++		if (link_sta->he_cap.he_cap_elem.phy_cap_info[0] &
++		    IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_160MHZ_IN_5G)
++			return MODE_11BE_EHT160;
++
++		ath12k_warn(ar->ab, "invalid EHT PHY capability info for 160 Mhz: %d\n",
++			    link_sta->he_cap.he_cap_elem.phy_cap_info[0]);
++
++		return MODE_UNKNOWN;
++	}
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_80)
++		return MODE_11BE_EHT80;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_40)
++		return MODE_11BE_EHT40;
++
++	if (link_sta->bandwidth == IEEE80211_STA_RX_BW_20)
++		return MODE_11BE_EHT20;
++
++	return MODE_UNKNOWN;
++}
++
++static bool
++ath12k_peer_assoc_h_eht_masked(const u16 eht_mcs_mask[NL80211_EHT_NSS_MAX])
++{
++	int nss;
++
++	for (nss = 0; nss < NL80211_EHT_NSS_MAX; nss++)
++		if (eht_mcs_mask[nss])
++			return false;
++
++	return true;
++}
++
++static void ath12k_peer_assoc_h_phymode(struct ath12k *ar,
++					struct ath12k_link_vif *arvif,
++					struct ath12k_link_sta *arsta,
++					struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_link_sta *link_sta;
++	struct cfg80211_chan_def def;
++	enum nl80211_band band;
++	const u8 *ht_mcs_mask;
++	const u16 *vht_mcs_mask;
++	const u16 *he_mcs_mask;
++	const u16 *eht_mcs_mask;
++	enum wmi_phy_mode phymode = MODE_UNKNOWN;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)))
++		return;
++
++	band = def.chan->band;
++	ht_mcs_mask = arvif->bitrate_mask.control[band].ht_mcs;
++	vht_mcs_mask = arvif->bitrate_mask.control[band].vht_mcs;
++	he_mcs_mask = arvif->bitrate_mask.control[band].he_mcs;
++	eht_mcs_mask = arvif->bitrate_mask.control[band].eht_mcs;
++
++	link_sta = ath12k_mac_get_link_sta(arsta);
++	if (!link_sta) {
++		ath12k_warn(ar->ab, "unable to access link sta in peer assoc he for sta %pM link %u\n",
++			    sta->addr, arsta->link_id);
++		return;
++	}
++
++	switch (band) {
++	case NL80211_BAND_2GHZ:
++		if (link_sta->eht_cap.has_eht &&
++		    !ath12k_peer_assoc_h_eht_masked(eht_mcs_mask)) {
++			if (link_sta->bandwidth == IEEE80211_STA_RX_BW_40)
++				phymode = MODE_11BE_EHT40_2G;
++			else
++				phymode = MODE_11BE_EHT20_2G;
++		} else if (link_sta->he_cap.has_he &&
++			   !ath12k_peer_assoc_h_he_masked(he_mcs_mask)) {
++			if (link_sta->bandwidth == IEEE80211_STA_RX_BW_80)
++				phymode = MODE_11AX_HE80_2G;
++			else if (link_sta->bandwidth == IEEE80211_STA_RX_BW_40)
++				phymode = MODE_11AX_HE40_2G;
++			else
++				phymode = MODE_11AX_HE20_2G;
++		} else if (link_sta->vht_cap.vht_supported &&
++		    !ath12k_peer_assoc_h_vht_masked(vht_mcs_mask)) {
++			if (link_sta->bandwidth == IEEE80211_STA_RX_BW_40)
++				phymode = MODE_11AC_VHT40;
++			else
++				phymode = MODE_11AC_VHT20;
++		} else if (link_sta->ht_cap.ht_supported &&
++			   !ath12k_peer_assoc_h_ht_masked(ht_mcs_mask)) {
++			if (link_sta->bandwidth == IEEE80211_STA_RX_BW_40)
++				phymode = MODE_11NG_HT40;
++			else
++				phymode = MODE_11NG_HT20;
++		} else if (ath12k_mac_sta_has_ofdm_only(link_sta)) {
++			phymode = MODE_11G;
++		} else {
++			phymode = MODE_11B;
++		}
++		break;
++	case NL80211_BAND_5GHZ:
++	case NL80211_BAND_6GHZ:
++		/* Check EHT first */
++		if (link_sta->eht_cap.has_eht) {
++			phymode = ath12k_mac_get_phymode_eht(ar, link_sta);
++		} else if (link_sta->he_cap.has_he &&
++			   !ath12k_peer_assoc_h_he_masked(he_mcs_mask)) {
++			phymode = ath12k_mac_get_phymode_he(ar, link_sta);
++		} else if (link_sta->vht_cap.vht_supported &&
++		    !ath12k_peer_assoc_h_vht_masked(vht_mcs_mask)) {
++			phymode = ath12k_mac_get_phymode_vht(ar, link_sta);
++		} else if (link_sta->ht_cap.ht_supported &&
++			   !ath12k_peer_assoc_h_ht_masked(ht_mcs_mask)) {
++			if (link_sta->bandwidth >= IEEE80211_STA_RX_BW_40)
++				phymode = MODE_11NA_HT40;
++			else
++				phymode = MODE_11NA_HT20;
++		} else {
++			phymode = MODE_11A;
++		}
++		break;
++	default:
++		break;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac peer %pM phymode %s\n",
++		   arsta->addr, ath12k_mac_phymode_str(phymode));
++
++	arg->peer_phymode = phymode;
++	WARN_ON(phymode == MODE_UNKNOWN);
++}
++
++#define ATH12K_EHT_MCS_7_ENABLED	0x00FF
++#define ATH12K_EHT_MCS_9_ENABLED	0x0300
++#define ATH12K_EHT_MCS_11_ENABLED	0x0C00
++#define ATH12K_EHT_MCS_13_ENABLED	0x3000
++
++static void ath12k_mac_set_eht_mcs(u8 rx_tx_mcs7, u8 rx_tx_mcs9,
++				   u8 rx_tx_mcs11, u8 rx_tx_mcs13,
++				   u32 *rx_mcs, u32 *tx_mcs,
++				   const u16 eht_mcs_limit[NL80211_EHT_NSS_MAX])
++{
++	int nss;
++	u8 mcs_7 = 0, mcs_9 = 0, mcs_11 = 0, mcs_13 = 0;
++	u8 peer_mcs_7, peer_mcs_9, peer_mcs_11, peer_mcs_13;
++
++	for (nss = 0; nss < NL80211_EHT_NSS_MAX; nss++) {
++		if (eht_mcs_limit[nss] & ATH12K_EHT_MCS_7_ENABLED)
++			mcs_7++;
++		if (eht_mcs_limit[nss] & ATH12K_EHT_MCS_9_ENABLED)
++			mcs_9++;
++		if (eht_mcs_limit[nss] & ATH12K_EHT_MCS_11_ENABLED)
++			mcs_11++;
++		if (eht_mcs_limit[nss] & ATH12K_EHT_MCS_13_ENABLED)
++			mcs_13++;
++	}
++
++	peer_mcs_7 = u8_get_bits(rx_tx_mcs7, IEEE80211_EHT_MCS_NSS_RX);
++	peer_mcs_9 = u8_get_bits(rx_tx_mcs9, IEEE80211_EHT_MCS_NSS_RX);
++	peer_mcs_11 = u8_get_bits(rx_tx_mcs11, IEEE80211_EHT_MCS_NSS_RX);
++	peer_mcs_13 = u8_get_bits(rx_tx_mcs13, IEEE80211_EHT_MCS_NSS_RX);
++
++	*rx_mcs = u32_encode_bits(min(peer_mcs_7, mcs_7), WMI_EHT_MCS_NSS_0_7) |
++		  u32_encode_bits(min(peer_mcs_9, mcs_9), WMI_EHT_MCS_NSS_8_9) |
++		  u32_encode_bits(min(peer_mcs_11, mcs_11), WMI_EHT_MCS_NSS_10_11) |
++		  u32_encode_bits(min(peer_mcs_13, mcs_13), WMI_EHT_MCS_NSS_12_13);
++
++	peer_mcs_7 = u8_get_bits(rx_tx_mcs7, IEEE80211_EHT_MCS_NSS_TX);
++	peer_mcs_9 = u8_get_bits(rx_tx_mcs9, IEEE80211_EHT_MCS_NSS_TX);
++	peer_mcs_11 = u8_get_bits(rx_tx_mcs11, IEEE80211_EHT_MCS_NSS_TX);
++	peer_mcs_13 = u8_get_bits(rx_tx_mcs13, IEEE80211_EHT_MCS_NSS_TX);
++
++	*tx_mcs = u32_encode_bits(min(peer_mcs_7, mcs_7), WMI_EHT_MCS_NSS_0_7) |
++		  u32_encode_bits(min(peer_mcs_9, mcs_9), WMI_EHT_MCS_NSS_8_9) |
++		  u32_encode_bits(min(peer_mcs_11, mcs_11), WMI_EHT_MCS_NSS_10_11) |
++		  u32_encode_bits(min(peer_mcs_13, mcs_13), WMI_EHT_MCS_NSS_12_13);
++}
++
++static void ath12k_mac_set_eht_ppe_threshold(const u8 *ppe_thres,
++					     struct ath12k_wmi_ppe_threshold_arg *ppet)
++{
++	u32 bit_pos = IEEE80211_EHT_PPE_THRES_INFO_HEADER_SIZE, val;
++	u8 nss, ru, i;
++	u8 ppet_bit_len_per_ru = IEEE80211_EHT_PPE_THRES_INFO_PPET_SIZE * 2;
++
++	ppet->numss_m1 = u8_get_bits(ppe_thres[0], IEEE80211_EHT_PPE_THRES_NSS_MASK);
++	ppet->ru_bit_mask = u16_get_bits(get_unaligned_le16(ppe_thres),
++					 IEEE80211_EHT_PPE_THRES_RU_INDEX_BITMASK_MASK);
++
++	for (nss = 0; nss <= ppet->numss_m1; nss++) {
++		for (ru = 0;
++		     ru < hweight16(IEEE80211_EHT_PPE_THRES_RU_INDEX_BITMASK_MASK);
++		     ru++) {
++			if ((ppet->ru_bit_mask & BIT(ru)) == 0)
++				continue;
++
++			val = 0;
++			for (i = 0; i < ppet_bit_len_per_ru; i++) {
++				val |= (((ppe_thres[bit_pos / 8] >>
++					  (bit_pos % 8)) & 0x1) << i);
++				bit_pos++;
++			}
++			ppet->ppet16_ppet8_ru3_ru0[nss] |=
++					(val << (ru * ppet_bit_len_per_ru));
++		}
++	}
++}
++
++static void ath12k_peer_assoc_h_eht(struct ath12k *ar,
++				    struct ath12k_link_vif *arvif,
++				    struct ath12k_link_sta *arsta,
++				    struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	const struct ieee80211_eht_mcs_nss_supp *own_eht_mcs_nss_supp;
++	const struct ieee80211_eht_mcs_nss_supp_20mhz_only *bw_20;
++	const struct ieee80211_sta_eht_cap *eht_cap, *own_eht_cap;
++	const struct ieee80211_sband_iftype_data *iftd;
++	const struct ieee80211_eht_mcs_nss_supp_bw *bw;
++	const struct ieee80211_sta_he_cap *he_cap;
++	struct ieee80211_link_sta *link_sta;
++	struct ieee80211_bss_conf *link_conf;
++	struct cfg80211_chan_def def;
++	bool user_rate_valid = true;
++	enum nl80211_band band;
++	int eht_nss, nss_idx;
++	u32 *rx_mcs, *tx_mcs;
++	u16 *eht_mcs_mask;
++	u8 max_nss = 0;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	link_sta = ath12k_mac_get_link_sta(arsta);
++	if (!link_sta) {
++		ath12k_warn(ar->ab, "unable to access link sta in peer assoc eht for sta %pM link %u\n",
++			    sta->addr, arsta->link_id);
++		return;
++	}
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf) {
++		ath12k_warn(ar->ab, "unable to access link_conf in peer assoc eht set\n");
++		return;
++	}
++
++	eht_cap = &link_sta->eht_cap;
++	he_cap = &link_sta->he_cap;
++	if (!he_cap->has_he || !eht_cap->has_eht)
++		return;
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)))
++		return;
++
++	band = def.chan->band;
++	eht_mcs_mask = arvif->bitrate_mask.control[band].eht_mcs;
++
++	iftd = ieee80211_get_sband_iftype_data(&ar->mac.sbands[band], vif->type);
++	if (!iftd) {
++		ath12k_warn(ar->ab,
++			    "unable to access iftype_data in struct ieee80211_supported_band\n");
++		return;
++	}
++
++	own_eht_cap = &iftd->eht_cap;
++	own_eht_mcs_nss_supp = &own_eht_cap->eht_mcs_nss_supp;
++
++	arg->eht_flag = true;
++
++	if ((eht_cap->eht_cap_elem.phy_cap_info[5] &
++	     IEEE80211_EHT_PHY_CAP5_PPE_THRESHOLD_PRESENT) &&
++	    eht_cap->eht_ppe_thres[0] != 0)
++		ath12k_mac_set_eht_ppe_threshold(eht_cap->eht_ppe_thres,
++						 &arg->peer_eht_ppet);
++
++	memcpy(arg->peer_eht_cap_mac, eht_cap->eht_cap_elem.mac_cap_info,
++	       sizeof(eht_cap->eht_cap_elem.mac_cap_info));
++	memcpy(arg->peer_eht_cap_phy, eht_cap->eht_cap_elem.phy_cap_info,
++	       sizeof(eht_cap->eht_cap_elem.phy_cap_info));
++
++	rx_mcs = arg->peer_eht_rx_mcs_set;
++	tx_mcs = arg->peer_eht_tx_mcs_set;
++
++	eht_nss = ath12k_mac_max_eht_mcs_nss((void *)own_eht_mcs_nss_supp,
++					     sizeof(*own_eht_mcs_nss_supp));
++	if (eht_nss > link_sta->rx_nss) {
++		user_rate_valid = false;
++		for (nss_idx = (link_sta->rx_nss - 1); nss_idx >= 0; nss_idx--) {
++			if (eht_mcs_mask[nss_idx]) {
++				user_rate_valid = true;
++				break;
++			}
++		}
++	}
++
++	if (!user_rate_valid) {
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++			   "Setting eht range MCS value to peer supported nss %d for peer %pM\n",
++			   link_sta->rx_nss, arsta->addr);
++		eht_mcs_mask[link_sta->rx_nss - 1] = eht_mcs_mask[eht_nss - 1];
++	}
++
++	bw_20 = &eht_cap->eht_mcs_nss_supp.only_20mhz;
++	bw = &eht_cap->eht_mcs_nss_supp.bw._80;
++
++	switch (link_sta->bandwidth) {
++	case IEEE80211_STA_RX_BW_320:
++		bw = &eht_cap->eht_mcs_nss_supp.bw._320;
++		ath12k_mac_set_eht_mcs(bw->rx_tx_mcs9_max_nss,
++				       bw->rx_tx_mcs9_max_nss,
++				       bw->rx_tx_mcs11_max_nss,
++				       bw->rx_tx_mcs13_max_nss,
++				       &rx_mcs[WMI_EHTCAP_TXRX_MCS_NSS_IDX_320],
++				       &tx_mcs[WMI_EHTCAP_TXRX_MCS_NSS_IDX_320],
++				       eht_mcs_mask);
++		arg->peer_eht_mcs_count++;
++		fallthrough;
++	case IEEE80211_STA_RX_BW_160:
++		bw = &eht_cap->eht_mcs_nss_supp.bw._160;
++		ath12k_mac_set_eht_mcs(bw->rx_tx_mcs9_max_nss,
++				       bw->rx_tx_mcs9_max_nss,
++				       bw->rx_tx_mcs11_max_nss,
++				       bw->rx_tx_mcs13_max_nss,
++				       &rx_mcs[WMI_EHTCAP_TXRX_MCS_NSS_IDX_160],
++				       &tx_mcs[WMI_EHTCAP_TXRX_MCS_NSS_IDX_160],
++				       eht_mcs_mask);
++		arg->peer_eht_mcs_count++;
++		fallthrough;
++	default:
++		if ((vif->type == NL80211_IFTYPE_AP ||
++		     vif->type == NL80211_IFTYPE_MESH_POINT) &&
++		    !(link_sta->he_cap.he_cap_elem.phy_cap_info[0] &
++		      IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_MASK_ALL)) {
++			bw_20 = &eht_cap->eht_mcs_nss_supp.only_20mhz;
++
++			ath12k_mac_set_eht_mcs(bw_20->rx_tx_mcs7_max_nss,
++					       bw_20->rx_tx_mcs9_max_nss,
++					       bw_20->rx_tx_mcs11_max_nss,
++					       bw_20->rx_tx_mcs13_max_nss,
++					       &rx_mcs[WMI_EHTCAP_TXRX_MCS_NSS_IDX_80],
++					       &tx_mcs[WMI_EHTCAP_TXRX_MCS_NSS_IDX_80],
++					       eht_mcs_mask);
++		} else {
++			bw = &eht_cap->eht_mcs_nss_supp.bw._80;
++			ath12k_mac_set_eht_mcs(bw->rx_tx_mcs9_max_nss,
++					       bw->rx_tx_mcs9_max_nss,
++					       bw->rx_tx_mcs11_max_nss,
++					       bw->rx_tx_mcs13_max_nss,
++					       &rx_mcs[WMI_EHTCAP_TXRX_MCS_NSS_IDX_80],
++					       &tx_mcs[WMI_EHTCAP_TXRX_MCS_NSS_IDX_80],
++					       eht_mcs_mask);
++		}
++
++		arg->peer_eht_mcs_count++;
++		break;
++	}
++
++	arg->punct_bitmap = ~arvif->punct_bitmap;
++	arg->eht_disable_mcs15 = link_conf->eht_disable_mcs15;
++
++	if ((vif->type == NL80211_IFTYPE_AP ||
++	     vif->type == NL80211_IFTYPE_MESH_POINT) &&
++	    !(link_sta->he_cap.he_cap_elem.phy_cap_info[0] &
++	      IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_MASK_ALL)) {
++		if (bw_20->rx_tx_mcs13_max_nss)
++			max_nss = max(max_nss, u8_get_bits(bw_20->rx_tx_mcs13_max_nss,
++							   IEEE80211_EHT_MCS_NSS_RX));
++		if (bw_20->rx_tx_mcs11_max_nss)
++			max_nss = max(max_nss, u8_get_bits(bw_20->rx_tx_mcs11_max_nss,
++							   IEEE80211_EHT_MCS_NSS_RX));
++		if (bw_20->rx_tx_mcs9_max_nss)
++			max_nss = max(max_nss, u8_get_bits(bw_20->rx_tx_mcs9_max_nss,
++							   IEEE80211_EHT_MCS_NSS_RX));
++		if (bw_20->rx_tx_mcs7_max_nss)
++			max_nss = max(max_nss, u8_get_bits(bw_20->rx_tx_mcs7_max_nss,
++							   IEEE80211_EHT_MCS_NSS_RX));
++	} else {
++		if (bw->rx_tx_mcs13_max_nss)
++			max_nss = max(max_nss, u8_get_bits(bw->rx_tx_mcs13_max_nss,
++							   IEEE80211_EHT_MCS_NSS_RX));
++		if (bw->rx_tx_mcs11_max_nss)
++			max_nss = max(max_nss, u8_get_bits(bw->rx_tx_mcs11_max_nss,
++							   IEEE80211_EHT_MCS_NSS_RX));
++		if (bw->rx_tx_mcs9_max_nss)
++			max_nss = max(max_nss, u8_get_bits(bw->rx_tx_mcs9_max_nss,
++							   IEEE80211_EHT_MCS_NSS_RX));
++	}
++
++	max_nss = min(max_nss, (uint8_t)eht_nss);
++
++	arg->peer_nss = min(link_sta->rx_nss, max_nss);
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac eht peer %pM nss %d mcs cnt %d ru_punct_bitmap 0x%x\n",
++		   arsta->addr, arg->peer_nss, arg->peer_eht_mcs_count,
++		   arg->punct_bitmap);
++}
++
++static void ath12k_peer_assoc_h_mlo(struct ath12k_link_sta *arsta,
++				    struct ath12k_wmi_peer_assoc_arg *arg)
++{
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct peer_assoc_mlo_params *ml = &arg->ml;
++	struct ath12k_sta *ahsta = arsta->ahsta;
++	struct ath12k_link_sta *arsta_p;
++	struct ath12k_link_vif *arvif;
++	unsigned long links;
++	u8 link_id;
++	int i;
++
++	if (!sta->mlo || ahsta->ml_peer_id == ATH12K_MLO_PEER_ID_INVALID)
++		return;
++
++	ml->enabled = true;
++	ml->assoc_link = arsta->is_assoc_link;
++
++	/* For now considering the primary umac based on assoc link */
++	ml->primary_umac = arsta->is_assoc_link;
++	ml->peer_id_valid = true;
++	ml->logical_link_idx_valid = true;
++
++	ether_addr_copy(ml->mld_addr, sta->addr);
++	ml->logical_link_idx = arsta->link_idx;
++	ml->ml_peer_id = ahsta->ml_peer_id;
++	ml->ieee_link_id = arsta->link_id;
++	ml->num_partner_links = 0;
++	ml->eml_cap = sta->eml_cap;
++	links = ahsta->links_map;
++
++	rcu_read_lock();
++
++	i = 0;
++
++	for_each_set_bit(link_id, &links, IEEE80211_MLD_MAX_NUM_LINKS) {
++		if (i >= ATH12K_WMI_MLO_MAX_LINKS)
++			break;
++
++		arsta_p = rcu_dereference(ahsta->link[link_id]);
++		arvif = rcu_dereference(ahsta->ahvif->link[link_id]);
++
++		if (arsta_p == arsta)
++			continue;
++
++		if (!arvif->is_started)
++			continue;
++
++		ml->partner_info[i].vdev_id = arvif->vdev_id;
++		ml->partner_info[i].hw_link_id = arvif->ar->pdev->hw_link_id;
++		ml->partner_info[i].assoc_link = arsta_p->is_assoc_link;
++		ml->partner_info[i].primary_umac = arsta_p->is_assoc_link;
++		ml->partner_info[i].logical_link_idx_valid = true;
++		ml->partner_info[i].logical_link_idx = arsta_p->link_idx;
++		ml->num_partner_links++;
++
++		i++;
++	}
++
++	rcu_read_unlock();
++}
++
++static void ath12k_peer_assoc_prepare(struct ath12k *ar,
++				      struct ath12k_link_vif *arvif,
++				      struct ath12k_link_sta *arsta,
++				      struct ath12k_wmi_peer_assoc_arg *arg,
++				      bool reassoc)
++{
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	memset(arg, 0, sizeof(*arg));
++
++	reinit_completion(&ar->peer_assoc_done);
++
++	arg->peer_new_assoc = !reassoc;
++	ath12k_peer_assoc_h_basic(ar, arvif, arsta, arg);
++	ath12k_peer_assoc_h_crypto(ar, arvif, arsta, arg);
++	ath12k_peer_assoc_h_rates(ar, arvif, arsta, arg);
++	ath12k_peer_assoc_h_ht(ar, arvif, arsta, arg);
++	ath12k_peer_assoc_h_vht(ar, arvif, arsta, arg);
++	ath12k_peer_assoc_h_he(ar, arvif, arsta, arg);
++	ath12k_peer_assoc_h_he_6ghz(ar, arvif, arsta, arg);
++	ath12k_peer_assoc_h_eht(ar, arvif, arsta, arg);
++	ath12k_peer_assoc_h_qos(ar, arvif, arsta, arg);
++	ath12k_peer_assoc_h_phymode(ar, arvif, arsta, arg);
++	ath12k_peer_assoc_h_smps(arsta, arg);
++	ath12k_peer_assoc_h_mlo(arsta, arg);
++
++	arsta->peer_nss = arg->peer_nss;
++	/* TODO: amsdu_disable req? */
++}
++
++static int ath12k_setup_peer_smps(struct ath12k *ar, struct ath12k_link_vif *arvif,
++				  const u8 *addr,
++				  const struct ieee80211_sta_ht_cap *ht_cap,
++				  const struct ieee80211_he_6ghz_capa *he_6ghz_capa)
++{
++	int smps, ret = 0;
++
++	if (!ht_cap->ht_supported && !he_6ghz_capa)
++		return 0;
++
++	ret = ath12k_get_smps_from_capa(ht_cap, he_6ghz_capa, &smps);
++	if (ret < 0)
++		return ret;
++
++	return ath12k_wmi_set_peer_param(ar, addr, arvif->vdev_id,
++					 WMI_PEER_MIMO_PS_STATE,
++					 ath12k_smps_map[smps]);
++}
++
++static int ath12k_mac_set_he_txbf_conf(struct ath12k_link_vif *arvif)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ath12k *ar = arvif->ar;
++	u32 param = WMI_VDEV_PARAM_SET_HEMU_MODE;
++	u32 value = 0;
++	int ret;
++	struct ieee80211_bss_conf *link_conf;
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf) {
++		ath12k_warn(ar->ab, "unable to access bss link conf in txbf conf\n");
++		return -EINVAL;
++	}
++
++	if (!link_conf->he_support)
++		return 0;
++
++	if (link_conf->he_su_beamformer) {
++		value |= u32_encode_bits(HE_SU_BFER_ENABLE, HE_MODE_SU_TX_BFER);
++		if (link_conf->he_mu_beamformer &&
++		    ahvif->vdev_type == WMI_VDEV_TYPE_AP)
++			value |= u32_encode_bits(HE_MU_BFER_ENABLE, HE_MODE_MU_TX_BFER);
++	}
++
++	if (ahvif->vif->type != NL80211_IFTYPE_MESH_POINT) {
++		value |= u32_encode_bits(HE_DL_MUOFDMA_ENABLE, HE_MODE_DL_OFDMA) |
++			 u32_encode_bits(HE_UL_MUOFDMA_ENABLE, HE_MODE_UL_OFDMA);
++
++		if (link_conf->he_full_ul_mumimo)
++			value |= u32_encode_bits(HE_UL_MUMIMO_ENABLE, HE_MODE_UL_MUMIMO);
++
++		if (link_conf->he_su_beamformee)
++			value |= u32_encode_bits(HE_SU_BFEE_ENABLE, HE_MODE_SU_TX_BFEE);
++	}
++
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id, param, value);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set vdev %d HE MU mode: %d\n",
++			    arvif->vdev_id, ret);
++		return ret;
++	}
++
++	param = WMI_VDEV_PARAM_SET_HE_SOUNDING_MODE;
++	value =	u32_encode_bits(HE_VHT_SOUNDING_MODE_ENABLE, HE_VHT_SOUNDING_MODE) |
++		u32_encode_bits(HE_TRIG_NONTRIG_SOUNDING_MODE_ENABLE,
++				HE_TRIG_NONTRIG_SOUNDING_MODE);
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    param, value);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set vdev %d sounding mode: %d\n",
++			    arvif->vdev_id, ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static int ath12k_mac_vif_recalc_sta_he_txbf(struct ath12k *ar,
++					     struct ath12k_link_vif *arvif,
++					     struct ieee80211_sta_he_cap *he_cap,
++					     int *hemode)
++{
++	struct ieee80211_vif *vif = arvif->ahvif->vif;
++	struct ieee80211_he_cap_elem he_cap_elem = {};
++	struct ieee80211_sta_he_cap *cap_band;
++	struct cfg80211_chan_def def;
++	u8 link_id = arvif->link_id;
++	struct ieee80211_bss_conf *link_conf;
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf) {
++		ath12k_warn(ar->ab, "unable to access bss link conf in recalc txbf conf\n");
++		return -EINVAL;
++	}
++
++	if (!link_conf->he_support)
++		return 0;
++
++	if (vif->type != NL80211_IFTYPE_STATION)
++		return -EINVAL;
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, link_id, &def)))
++		return -EINVAL;
++
++	if (def.chan->band == NL80211_BAND_2GHZ)
++		cap_band = &ar->mac.iftype[NL80211_BAND_2GHZ][vif->type].he_cap;
++	else
++		cap_band = &ar->mac.iftype[NL80211_BAND_5GHZ][vif->type].he_cap;
++
++	memcpy(&he_cap_elem, &cap_band->he_cap_elem, sizeof(he_cap_elem));
++
++	*hemode = 0;
++	if (HECAP_PHY_SUBFME_GET(he_cap_elem.phy_cap_info)) {
++		if (HECAP_PHY_SUBFMR_GET(he_cap->he_cap_elem.phy_cap_info))
++			*hemode |= u32_encode_bits(HE_SU_BFEE_ENABLE, HE_MODE_SU_TX_BFEE);
++		if (HECAP_PHY_MUBFMR_GET(he_cap->he_cap_elem.phy_cap_info))
++			*hemode |= u32_encode_bits(HE_MU_BFEE_ENABLE, HE_MODE_MU_TX_BFEE);
++	}
++
++	if (vif->type != NL80211_IFTYPE_MESH_POINT) {
++		*hemode |= u32_encode_bits(HE_DL_MUOFDMA_ENABLE, HE_MODE_DL_OFDMA) |
++			  u32_encode_bits(HE_UL_MUOFDMA_ENABLE, HE_MODE_UL_OFDMA);
++
++		if (HECAP_PHY_ULMUMIMO_GET(he_cap_elem.phy_cap_info))
++			if (HECAP_PHY_ULMUMIMO_GET(he_cap->he_cap_elem.phy_cap_info))
++				*hemode |= u32_encode_bits(HE_UL_MUMIMO_ENABLE,
++							  HE_MODE_UL_MUMIMO);
++
++		if (u32_get_bits(*hemode, HE_MODE_MU_TX_BFEE))
++			*hemode |= u32_encode_bits(HE_SU_BFEE_ENABLE, HE_MODE_SU_TX_BFEE);
++
++		if (u32_get_bits(*hemode, HE_MODE_MU_TX_BFER))
++			*hemode |= u32_encode_bits(HE_SU_BFER_ENABLE, HE_MODE_SU_TX_BFER);
++	}
++
++	return 0;
++}
++
++static int ath12k_mac_set_eht_txbf_conf(struct ath12k_link_vif *arvif)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ath12k *ar = arvif->ar;
++	u32 param = WMI_VDEV_PARAM_SET_EHT_MU_MODE;
++	u32 value = 0;
++	int ret;
++	struct ieee80211_bss_conf *link_conf;
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf) {
++		ath12k_warn(ar->ab, "unable to access bss link conf in eht txbf conf\n");
++		return -ENOENT;
++	}
++
++	if (!link_conf->eht_support)
++		return 0;
++
++	if (link_conf->eht_su_beamformer) {
++		value |= u32_encode_bits(EHT_SU_BFER_ENABLE, EHT_MODE_SU_TX_BFER);
++		if (link_conf->eht_mu_beamformer &&
++		    ahvif->vdev_type == WMI_VDEV_TYPE_AP)
++			value |= u32_encode_bits(EHT_MU_BFER_ENABLE,
++						 EHT_MODE_MU_TX_BFER) |
++				 u32_encode_bits(EHT_DL_MUOFDMA_ENABLE,
++						 EHT_MODE_DL_OFDMA_MUMIMO) |
++				 u32_encode_bits(EHT_UL_MUOFDMA_ENABLE,
++						 EHT_MODE_UL_OFDMA_MUMIMO);
++	}
++
++	if (ahvif->vif->type != NL80211_IFTYPE_MESH_POINT) {
++		value |= u32_encode_bits(EHT_DL_MUOFDMA_ENABLE, EHT_MODE_DL_OFDMA) |
++			 u32_encode_bits(EHT_UL_MUOFDMA_ENABLE, EHT_MODE_UL_OFDMA);
++
++		if (link_conf->eht_80mhz_full_bw_ul_mumimo)
++			value |= u32_encode_bits(EHT_UL_MUMIMO_ENABLE, EHT_MODE_MUMIMO);
++
++		if (link_conf->eht_su_beamformee)
++			value |= u32_encode_bits(EHT_SU_BFEE_ENABLE,
++						 EHT_MODE_SU_TX_BFEE);
++	}
++
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id, param, value);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set vdev %d EHT MU mode: %d\n",
++			    arvif->vdev_id, ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static u32 ath12k_mac_ieee80211_sta_bw_to_wmi(struct ath12k *ar,
++					      struct ieee80211_link_sta *link_sta)
++{
++	u32 bw;
++
++	switch (link_sta->bandwidth) {
++	case IEEE80211_STA_RX_BW_20:
++		bw = WMI_PEER_CHWIDTH_20MHZ;
++		break;
++	case IEEE80211_STA_RX_BW_40:
++		bw = WMI_PEER_CHWIDTH_40MHZ;
++		break;
++	case IEEE80211_STA_RX_BW_80:
++		bw = WMI_PEER_CHWIDTH_80MHZ;
++		break;
++	case IEEE80211_STA_RX_BW_160:
++		bw = WMI_PEER_CHWIDTH_160MHZ;
++		break;
++	case IEEE80211_STA_RX_BW_320:
++		bw = WMI_PEER_CHWIDTH_320MHZ;
++		break;
++	default:
++		ath12k_warn(ar->ab, "Invalid bandwidth %d for link station %pM\n",
++			    link_sta->bandwidth, link_sta->addr);
++		bw = WMI_PEER_CHWIDTH_20MHZ;
++		break;
++	}
++
++	return bw;
++}
++
++static void ath12k_bss_assoc(struct ath12k *ar,
++			     struct ath12k_link_vif *arvif,
++			     struct ieee80211_bss_conf *bss_conf)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(ahvif);
++	struct ath12k_wmi_vdev_up_params params = {};
++	struct ieee80211_link_sta *link_sta;
++	u8 link_id = bss_conf->link_id;
++	struct ath12k_link_sta *arsta;
++	struct ieee80211_sta *ap_sta;
++	struct ath12k_sta *ahsta;
++	struct ath12k_dp_link_peer *peer;
++	bool is_auth = false;
++	u32 hemode = 0;
++	int ret;
++	struct ath12k_dp *dp = ath12k_ab_to_dp(ar->ab);
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	struct ath12k_wmi_peer_assoc_arg *peer_arg __free(kfree) =
++					kzalloc_obj(*peer_arg);
++	if (!peer_arg)
++		return;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac vdev %i link id %u assoc bssid %pM aid %d\n",
++		   arvif->vdev_id, link_id, arvif->bssid, ahvif->aid);
++
++	rcu_read_lock();
++
++	/* During ML connection, cfg.ap_addr has the MLD address. For
++	 * non-ML connection, it has the BSSID.
++	 */
++	ap_sta = ieee80211_find_sta(vif, vif->cfg.ap_addr);
++	if (!ap_sta) {
++		ath12k_warn(ar->ab, "failed to find station entry for bss %pM vdev %i\n",
++			    vif->cfg.ap_addr, arvif->vdev_id);
++		rcu_read_unlock();
++		return;
++	}
++
++	ahsta = ath12k_sta_to_ahsta(ap_sta);
++
++	arsta = wiphy_dereference(ath12k_ar_to_hw(ar)->wiphy,
++				  ahsta->link[link_id]);
++	if (WARN_ON(!arsta)) {
++		rcu_read_unlock();
++		return;
++	}
++
++	link_sta = ath12k_mac_get_link_sta(arsta);
++	if (WARN_ON(!link_sta)) {
++		rcu_read_unlock();
++		return;
++	}
++
++	ath12k_peer_assoc_prepare(ar, arvif, arsta, peer_arg, false);
++
++	/* link_sta->he_cap must be protected by rcu_read_lock */
++	ret = ath12k_mac_vif_recalc_sta_he_txbf(ar, arvif, &link_sta->he_cap, &hemode);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to recalc he txbf for vdev %i on bss %pM: %d\n",
++			    arvif->vdev_id, bss_conf->bssid, ret);
++		rcu_read_unlock();
++		return;
++	}
++
++	rcu_read_unlock();
++
++	/* keep this before ath12k_wmi_send_peer_assoc_cmd() */
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    WMI_VDEV_PARAM_SET_HEMU_MODE, hemode);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to submit vdev param txbf 0x%x: %d\n",
++			    hemode, ret);
++		return;
++	}
++
++	peer_arg->is_assoc = true;
++	ret = ath12k_wmi_send_peer_assoc_cmd(ar, peer_arg);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to run peer assoc for %pM vdev %i: %d\n",
++			    bss_conf->bssid, arvif->vdev_id, ret);
++		return;
++	}
++
++	if (!wait_for_completion_timeout(&ar->peer_assoc_done, 1 * HZ)) {
++		ath12k_warn(ar->ab, "failed to get peer assoc conf event for %pM vdev %i\n",
++			    bss_conf->bssid, arvif->vdev_id);
++		return;
++	}
++
++	ret = ath12k_setup_peer_smps(ar, arvif, bss_conf->bssid,
++				     &link_sta->ht_cap, &link_sta->he_6ghz_capa);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to setup peer SMPS for vdev %d: %d\n",
++			    arvif->vdev_id, ret);
++		return;
++	}
++
++	WARN_ON(arvif->is_up);
++
++	ahvif->aid = vif->cfg.aid;
++	ether_addr_copy(arvif->bssid, bss_conf->bssid);
++
++	params.vdev_id = arvif->vdev_id;
++	params.aid = ahvif->aid;
++	params.bssid = arvif->bssid;
++	params.tx_bssid = ath12k_mac_get_tx_bssid(arvif);
++	if (params.tx_bssid) {
++		params.nontx_profile_idx = bss_conf->bssid_index;
++		params.nontx_profile_cnt = 1 << bss_conf->bssid_indicator;
++	}
++	ret = ath12k_wmi_vdev_up(ar, &params);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set vdev %d up: %d\n",
++			    arvif->vdev_id, ret);
++		return;
++	}
++
++	arvif->is_up = true;
++	arvif->rekey_data.enable_offload = false;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac vdev %d up (associated) bssid %pM aid %d\n",
++		   arvif->vdev_id, bss_conf->bssid, vif->cfg.aid);
++
++	spin_lock_bh(&dp->dp_lock);
++
++	peer = ath12k_dp_link_peer_find_by_vdev_and_addr(dp, arvif->vdev_id,
++							 arvif->bssid);
++	if (peer && peer->is_authorized)
++		is_auth = true;
++
++	spin_unlock_bh(&dp->dp_lock);
++
++	/* Authorize BSS Peer */
++	if (is_auth) {
++		ret = ath12k_wmi_set_peer_param(ar, arvif->bssid,
++						arvif->vdev_id,
++						WMI_PEER_AUTHORIZE,
++						1);
++		if (ret)
++			ath12k_warn(ar->ab, "Unable to authorize BSS peer: %d\n", ret);
++	}
++
++	ret = ath12k_wmi_send_obss_spr_cmd(ar, arvif->vdev_id,
++					   &bss_conf->he_obss_pd);
++	if (ret)
++		ath12k_warn(ar->ab, "failed to set vdev %i OBSS PD parameters: %d\n",
++			    arvif->vdev_id, ret);
++
++	if (test_bit(WMI_TLV_SERVICE_11D_OFFLOAD, ar->ab->wmi_ab.svc_map) &&
++	    ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
++	    ahvif->vdev_subtype == WMI_VDEV_SUBTYPE_NONE)
++		ath12k_mac_11d_scan_stop_all(ar->ab);
++}
++
++static void ath12k_bss_disassoc(struct ath12k *ar,
++				struct ath12k_link_vif *arvif)
++{
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac vdev %i disassoc bssid %pM\n",
++		   arvif->vdev_id, arvif->bssid);
++
++	ret = ath12k_wmi_vdev_down(ar, arvif->vdev_id);
++	if (ret)
++		ath12k_warn(ar->ab, "failed to down vdev %i: %d\n",
++			    arvif->vdev_id, ret);
++
++	arvif->is_up = false;
++
++	memset(&arvif->rekey_data, 0, sizeof(arvif->rekey_data));
++
++	cancel_delayed_work(&arvif->connection_loss_work);
++}
++
++static u32 ath12k_mac_get_rate_hw_value(int bitrate)
++{
++	u32 preamble;
++	u16 hw_value;
++	int rate;
++	size_t i;
++
++	if (ath12k_mac_bitrate_is_cck(bitrate))
++		preamble = WMI_RATE_PREAMBLE_CCK;
++	else
++		preamble = WMI_RATE_PREAMBLE_OFDM;
++
++	for (i = 0; i < ARRAY_SIZE(ath12k_legacy_rates); i++) {
++		if (ath12k_legacy_rates[i].bitrate != bitrate)
++			continue;
++
++		hw_value = ath12k_legacy_rates[i].hw_value;
++		rate = ATH12K_HW_RATE_CODE(hw_value, 0, preamble);
++
++		return rate;
++	}
++
++	return -EINVAL;
++}
++
++static void ath12k_recalculate_mgmt_rate(struct ath12k *ar,
++					 struct ath12k_link_vif *arvif,
++					 struct cfg80211_chan_def *def)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_hw *hw = ath12k_ar_to_hw(ar);
++	const struct ieee80211_supported_band *sband;
++	struct ieee80211_bss_conf *bss_conf;
++	u8 basic_rate_idx;
++	int hw_rate_code;
++	u32 vdev_param;
++	u16 bitrate;
++	int ret;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	bss_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!bss_conf) {
++		ath12k_warn(ar->ab, "unable to access bss link conf in mgmt rate calc for vif %pM link %u\n",
++			    vif->addr, arvif->link_id);
++		return;
++	}
++
++	sband = hw->wiphy->bands[def->chan->band];
++	if (bss_conf->basic_rates)
++		basic_rate_idx = __ffs(bss_conf->basic_rates);
++	else
++		basic_rate_idx = 0;
++	bitrate = sband->bitrates[basic_rate_idx].bitrate;
++
++	hw_rate_code = ath12k_mac_get_rate_hw_value(bitrate);
++	if (hw_rate_code < 0) {
++		ath12k_warn(ar->ab, "bitrate not supported %d\n", bitrate);
++		return;
++	}
++
++	vdev_param = WMI_VDEV_PARAM_MGMT_RATE;
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id, vdev_param,
++					    hw_rate_code);
++	if (ret)
++		ath12k_warn(ar->ab, "failed to set mgmt tx rate %d\n", ret);
++
++	vdev_param = WMI_VDEV_PARAM_BEACON_RATE;
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id, vdev_param,
++					    hw_rate_code);
++	if (ret)
++		ath12k_warn(ar->ab, "failed to set beacon tx rate %d\n", ret);
++}
++
++static void ath12k_mac_bcn_tx_event(struct ath12k_link_vif *arvif)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_bss_conf *link_conf;
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf) {
++		ath12k_warn(arvif->ar->ab, "failed to get link conf for vdev %u\n",
++			    arvif->vdev_id);
++		return;
++	}
++
++	if (link_conf->color_change_active) {
++		if (ieee80211_beacon_cntdwn_is_complete(vif, arvif->link_id)) {
++			ieee80211_color_change_finish(vif, arvif->link_id);
++			return;
++		}
++
++		ieee80211_beacon_update_cntdwn(vif, arvif->link_id);
++		ath12k_mac_setup_bcn_tmpl(arvif);
++	}
++}
++
++static void ath12k_mac_bcn_tx_work(struct wiphy *wiphy, struct wiphy_work *work)
++{
++	struct ath12k_link_vif *arvif = container_of(work, struct ath12k_link_vif,
++						     bcn_tx_work);
++
++	lockdep_assert_wiphy(wiphy);
++	ath12k_mac_bcn_tx_event(arvif);
++}
++
++static void ath12k_mac_init_arvif(struct ath12k_vif *ahvif,
++				  struct ath12k_link_vif *arvif, int link_id)
++{
++	struct ath12k_hw *ah = ahvif->ah;
++	u8 _link_id;
++	int i;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	if (WARN_ON(!arvif))
++		return;
++
++	if (WARN_ON(link_id >= ATH12K_NUM_MAX_LINKS))
++		return;
++
++	if (link_id < 0)
++		_link_id = 0;
++	else
++		_link_id = link_id;
++
++	arvif->ahvif = ahvif;
++	arvif->link_id = _link_id;
++
++	/* Protects the datapath stats update on a per link basis */
++	spin_lock_init(&arvif->link_stats_lock);
++
++	INIT_LIST_HEAD(&arvif->list);
++	INIT_DELAYED_WORK(&arvif->connection_loss_work,
++			  ath12k_mac_vif_sta_connection_loss_work);
++	wiphy_work_init(&arvif->bcn_tx_work, ath12k_mac_bcn_tx_work);
++
++	arvif->num_stations = 0;
++
++	for (i = 0; i < ARRAY_SIZE(arvif->bitrate_mask.control); i++) {
++		arvif->bitrate_mask.control[i].legacy = 0xffffffff;
++		arvif->bitrate_mask.control[i].gi = NL80211_TXRATE_DEFAULT_GI;
++		memset(arvif->bitrate_mask.control[i].ht_mcs, 0xff,
++		       sizeof(arvif->bitrate_mask.control[i].ht_mcs));
++		memset(arvif->bitrate_mask.control[i].vht_mcs, 0xff,
++		       sizeof(arvif->bitrate_mask.control[i].vht_mcs));
++		memset(arvif->bitrate_mask.control[i].he_mcs, 0xff,
++		       sizeof(arvif->bitrate_mask.control[i].he_mcs));
++		memset(arvif->bitrate_mask.control[i].eht_mcs, 0xff,
++		       sizeof(arvif->bitrate_mask.control[i].eht_mcs));
++	}
++
++	/* Handle MLO related assignments */
++	if (link_id >= 0) {
++		rcu_assign_pointer(ahvif->link[arvif->link_id], arvif);
++		ahvif->links_map |= BIT(_link_id);
++	}
++
++	ath12k_generic_dbg(ATH12K_DBG_MAC,
++			   "mac init link arvif (link_id %d%s) for vif %pM. links_map 0x%x",
++			   _link_id, (link_id < 0) ? " deflink" : "", ahvif->vif->addr,
++			   ahvif->links_map);
++}
++
++static void ath12k_mac_remove_link_interface(struct ieee80211_hw *hw,
++					     struct ath12k_link_vif *arvif)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ath12k_hw *ah = hw->priv;
++	struct ath12k *ar = arvif->ar;
++	int ret;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	cancel_delayed_work_sync(&arvif->connection_loss_work);
++	wiphy_work_cancel(ath12k_ar_to_hw(ar)->wiphy, &arvif->bcn_tx_work);
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac remove link interface (vdev %d link id %d)",
++		   arvif->vdev_id, arvif->link_id);
++
++	if (test_bit(WMI_TLV_SERVICE_11D_OFFLOAD, ar->ab->wmi_ab.svc_map) &&
++	    ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
++	    ahvif->vdev_subtype == WMI_VDEV_SUBTYPE_NONE)
++		ath12k_mac_11d_scan_stop(ar);
++
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_AP) {
++		ret = ath12k_peer_delete(ar, arvif->vdev_id, arvif->bssid);
++		if (ret)
++			ath12k_warn(ar->ab, "failed to submit AP self-peer removal on vdev %d link id %d: %d",
++				    arvif->vdev_id, arvif->link_id, ret);
++
++		if (arvif->link_id < IEEE80211_MLD_MAX_NUM_LINKS)
++			ath12k_dp_peer_delete(&ah->dp_hw, arvif->bssid, NULL);
++	}
++	ath12k_mac_vdev_delete(ar, arvif);
++}
++
++static struct ath12k_link_vif *ath12k_mac_assign_link_vif(struct ath12k_hw *ah,
++							  struct ieee80211_vif *vif,
++							  u8 link_id)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_link_vif *arvif;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	arvif = wiphy_dereference(ah->hw->wiphy, ahvif->link[link_id]);
++	if (arvif)
++		return arvif;
++
++	/* If this is the first link arvif being created for an ML VIF
++	 * use the preallocated deflink memory except for scan arvifs
++	 */
++	if (!ahvif->links_map && link_id < ATH12K_FIRST_SCAN_LINK) {
++		arvif = &ahvif->deflink;
++
++		if (vif->type == NL80211_IFTYPE_STATION)
++			arvif->is_sta_assoc_link = true;
++	} else {
++		arvif = kzalloc_obj(*arvif);
++		if (!arvif)
++			return NULL;
++	}
++
++	ath12k_mac_init_arvif(ahvif, arvif, link_id);
++
++	return arvif;
++}
++
++static void ath12k_mac_unassign_link_vif(struct ath12k_link_vif *arvif)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ath12k_hw *ah = ahvif->ah;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	rcu_assign_pointer(ahvif->link[arvif->link_id], NULL);
++	synchronize_rcu();
++	ahvif->links_map &= ~BIT(arvif->link_id);
++
++	if (arvif != &ahvif->deflink)
++		kfree(arvif);
++	else
++		memset(arvif, 0, sizeof(*arvif));
++}
++
++int
++ath12k_mac_op_change_vif_links(struct ieee80211_hw *hw,
++			       struct ieee80211_vif *vif,
++			       u16 old_links, u16 new_links,
++			       struct ieee80211_bss_conf *ol[IEEE80211_MLD_MAX_NUM_LINKS])
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	unsigned long to_remove = old_links & ~new_links;
++	unsigned long to_add = ~old_links & new_links;
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k_link_vif *arvif;
++	u8 link_id;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	ath12k_generic_dbg(ATH12K_DBG_MAC,
++			   "mac vif link changed for MLD %pM old_links 0x%x new_links 0x%x\n",
++			   vif->addr, old_links, new_links);
++
++	for_each_set_bit(link_id, &to_add, IEEE80211_MLD_MAX_NUM_LINKS) {
++		arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++		/* mac80211 wants to add link but driver already has the
++		 * link. This should not happen ideally.
++		 */
++		if (WARN_ON(arvif))
++			return -EINVAL;
++
++		arvif = ath12k_mac_assign_link_vif(ah, vif, link_id);
++		if (WARN_ON(!arvif))
++			return -EINVAL;
++	}
++
++	for_each_set_bit(link_id, &to_remove, IEEE80211_MLD_MAX_NUM_LINKS) {
++		arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++		if (WARN_ON(!arvif))
++			return -EINVAL;
++
++		if (!arvif->is_created) {
++			ath12k_mac_unassign_link_vif(arvif);
++			continue;
++		}
++
++		if (WARN_ON(!arvif->ar))
++			return -EINVAL;
++
++		ath12k_mac_remove_link_interface(hw, arvif);
++		ath12k_mac_unassign_link_vif(arvif);
++	}
++
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_change_vif_links);
++
++static int ath12k_mac_fils_discovery(struct ath12k_link_vif *arvif,
++				     struct ieee80211_bss_conf *info)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ath12k *ar = arvif->ar;
++	struct ieee80211_hw *hw = ath12k_ar_to_hw(ar);
++	struct sk_buff *tmpl;
++	int ret;
++	u32 interval;
++	bool unsol_bcast_probe_resp_enabled = false;
++
++	if (info->fils_discovery.max_interval) {
++		interval = info->fils_discovery.max_interval;
++
++		tmpl = ieee80211_get_fils_discovery_tmpl(hw, vif,
++							 info->link_id);
++		if (tmpl)
++			ret = ath12k_wmi_fils_discovery_tmpl(ar, arvif->vdev_id,
++							     tmpl);
++	} else if (info->unsol_bcast_probe_resp_interval) {
++		unsol_bcast_probe_resp_enabled = 1;
++		interval = info->unsol_bcast_probe_resp_interval;
++
++		tmpl = ieee80211_get_unsol_bcast_probe_resp_tmpl(hw, vif,
++								 info->link_id);
++		if (tmpl)
++			ret = ath12k_wmi_probe_resp_tmpl(ar, arvif->vdev_id,
++							 tmpl);
++	} else { /* Disable */
++		return ath12k_wmi_fils_discovery(ar, arvif->vdev_id, 0, false);
++	}
++
++	if (!tmpl) {
++		ath12k_warn(ar->ab,
++			    "mac vdev %i failed to retrieve %s template\n",
++			    arvif->vdev_id, (unsol_bcast_probe_resp_enabled ?
++			    "unsolicited broadcast probe response" :
++			    "FILS discovery"));
++		return -EPERM;
++	}
++	kfree_skb(tmpl);
++
++	if (!ret)
++		ret = ath12k_wmi_fils_discovery(ar, arvif->vdev_id, interval,
++						unsol_bcast_probe_resp_enabled);
++
++	return ret;
++}
++
++void ath12k_mac_op_vif_cfg_changed(struct ieee80211_hw *hw,
++				   struct ieee80211_vif *vif,
++				   u64 changed)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	unsigned long links = ahvif->links_map;
++	struct ieee80211_bss_conf *info;
++	struct ath12k_link_vif *arvif;
++	struct ieee80211_sta *sta;
++	struct ath12k_sta *ahsta;
++	struct ath12k *ar;
++	u8 link_id;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (changed & BSS_CHANGED_SSID && vif->type == NL80211_IFTYPE_AP) {
++		ahvif->u.ap.ssid_len = vif->cfg.ssid_len;
++		if (vif->cfg.ssid_len)
++			memcpy(ahvif->u.ap.ssid, vif->cfg.ssid, vif->cfg.ssid_len);
++	}
++
++	if (changed & BSS_CHANGED_ASSOC) {
++		if (vif->cfg.assoc) {
++			/* only in station mode we can get here, so it's safe
++			 * to use ap_addr
++			 */
++			rcu_read_lock();
++			sta = ieee80211_find_sta(vif, vif->cfg.ap_addr);
++			if (!sta) {
++				rcu_read_unlock();
++				WARN_ONCE(1, "failed to find sta with addr %pM\n",
++					  vif->cfg.ap_addr);
++				return;
++			}
++
++			ahsta = ath12k_sta_to_ahsta(sta);
++			arvif = wiphy_dereference(hw->wiphy,
++						  ahvif->link[ahsta->assoc_link_id]);
++			rcu_read_unlock();
++
++			ar = arvif->ar;
++			/* there is no reason for which an assoc link's
++			 * bss info does not exist
++			 */
++			info = ath12k_mac_get_link_bss_conf(arvif);
++			ath12k_bss_assoc(ar, arvif, info);
++
++			/* exclude assoc link as it is done above */
++			links &= ~BIT(ahsta->assoc_link_id);
++		}
++
++		for_each_set_bit(link_id, &links, IEEE80211_MLD_MAX_NUM_LINKS) {
++			arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++			if (!arvif || !arvif->ar)
++				continue;
++
++			ar = arvif->ar;
++
++			if (vif->cfg.assoc) {
++				info = ath12k_mac_get_link_bss_conf(arvif);
++				if (!info)
++					continue;
++
++				ath12k_bss_assoc(ar, arvif, info);
++			} else {
++				ath12k_bss_disassoc(ar, arvif);
++			}
++		}
++	}
++}
++EXPORT_SYMBOL(ath12k_mac_op_vif_cfg_changed);
++
++static void ath12k_mac_vif_setup_ps(struct ath12k_link_vif *arvif)
++{
++	struct ath12k *ar = arvif->ar;
++	struct ieee80211_vif *vif = arvif->ahvif->vif;
++	struct ieee80211_conf *conf = &ath12k_ar_to_hw(ar)->conf;
++	enum wmi_sta_powersave_param param;
++	struct ieee80211_bss_conf *info;
++	enum wmi_sta_ps_mode psmode;
++	int ret;
++	int timeout;
++	bool enable_ps;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (vif->type != NL80211_IFTYPE_STATION)
++		return;
++
++	enable_ps = arvif->ahvif->ps;
++	if (enable_ps) {
++		psmode = WMI_STA_PS_MODE_ENABLED;
++		param = WMI_STA_PS_PARAM_INACTIVITY_TIME;
++
++		timeout = conf->dynamic_ps_timeout;
++		if (timeout == 0) {
++			info = ath12k_mac_get_link_bss_conf(arvif);
++			if (!info) {
++				ath12k_warn(ar->ab, "unable to access bss link conf in setup ps for vif %pM link %u\n",
++					    vif->addr, arvif->link_id);
++				return;
++			}
++
++			/* firmware doesn't like 0 */
++			timeout = ieee80211_tu_to_usec(info->beacon_int) / 1000;
++		}
++
++		ret = ath12k_wmi_set_sta_ps_param(ar, arvif->vdev_id, param,
++						  timeout);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to set inactivity time for vdev %d: %i\n",
++				    arvif->vdev_id, ret);
++			return;
++		}
++	} else {
++		psmode = WMI_STA_PS_MODE_DISABLED;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac vdev %d psmode %s\n",
++		   arvif->vdev_id, psmode ? "enable" : "disable");
++
++	ret = ath12k_wmi_pdev_set_ps_mode(ar, arvif->vdev_id, psmode);
++	if (ret)
++		ath12k_warn(ar->ab, "failed to set sta power save mode %d for vdev %d: %d\n",
++			    psmode, arvif->vdev_id, ret);
++}
++
++static bool ath12k_mac_supports_tpc(struct ath12k *ar, struct ath12k_vif *ahvif,
++				    const struct cfg80211_chan_def *chandef)
++{
++	return ath12k_wmi_supports_6ghz_cc_ext(ar) &&
++		test_bit(WMI_TLV_SERVICE_EXT_TPC_REG_SUPPORT, ar->ab->wmi_ab.svc_map) &&
++		(ahvif->vdev_type == WMI_VDEV_TYPE_STA  ||
++		 ahvif->vdev_type == WMI_VDEV_TYPE_AP) &&
++		ahvif->vdev_subtype == WMI_VDEV_SUBTYPE_NONE &&
++		chandef->chan &&
++		chandef->chan->band == NL80211_BAND_6GHZ;
++}
++
++static void ath12k_wmi_vdev_params_up(struct ath12k *ar,
++				      struct ath12k_link_vif *arvif,
++				      struct ath12k_link_vif *tx_arvif,
++				      struct ieee80211_bss_conf *info, u16 aid)
++{
++	struct ath12k_wmi_vdev_up_params params = {
++		.vdev_id = arvif->vdev_id,
++		.aid = aid,
++		.bssid = arvif->bssid
++	};
++	int ret;
++
++	if (tx_arvif) {
++		params.tx_bssid = tx_arvif->bssid;
++		params.nontx_profile_idx = info->bssid_index;
++		params.nontx_profile_cnt = 1 << info->bssid_indicator;
++	}
++
++	ret = ath12k_wmi_vdev_up(arvif->ar, &params);
++	if (ret)
++		ath12k_warn(ar->ab, "failed to bring vdev up %d: %d\n",
++			    arvif->vdev_id, ret);
++}
++
++static int ath12k_mac_config_obss_pd(struct ath12k_link_vif *arvif,
++				     const struct ieee80211_he_obss_pd *he_obss_pd)
++{
++	struct ath12k_wmi_obss_pd_arg obss_pd_arg = {};
++	u32 srg_bitmap[2], non_srg_bitmap[2];
++	struct ath12k *ar = arvif->ar;
++	u32 param_id, pdev_id;
++	u32 param_val;
++	int ret;
++
++	if (ar->ab->hw_params->single_pdev_only)
++		pdev_id = ath12k_mac_get_target_pdev_id_from_vif(arvif);
++	else
++		pdev_id = ar->pdev->pdev_id;
++
++	/* Set and enable SRG/non-SRG OBSS PD threshold */
++	param_id = WMI_PDEV_PARAM_SET_CMD_OBSS_PD_THRESHOLD;
++	if (ar->monitor_started || !he_obss_pd->enable) {
++		ret = ath12k_wmi_pdev_set_param(ar, param_id, 0, pdev_id);
++		if (ret)
++			ath12k_warn(ar->ab,
++				    "failed to set OBSS PD threshold for pdev %u: %d\n",
++				    pdev_id, ret);
++		return ret;
++	}
++
++	/*
++	 * This service flag indicates firmware support for SRG/SRP-based
++	 * spatial reuse. It also specifies whether OBSS PD threshold values
++	 * should be interpreted as dB (offset) or dBm (absolute) units.
++	 */
++	obss_pd_arg.srp_support = test_bit(WMI_TLV_SERVICE_SRG_SRP_SPATIAL_REUSE_SUPPORT,
++					   ar->ab->wmi_ab.svc_map);
++
++	if (!(he_obss_pd->sr_ctrl &
++	      IEEE80211_HE_SPR_NON_SRG_OBSS_PD_SR_DISALLOWED)) {
++		if (he_obss_pd->sr_ctrl & IEEE80211_HE_SPR_NON_SRG_OFFSET_PRESENT)
++			obss_pd_arg.non_srg_th = ATH12K_OBSS_PD_MAX_THRESHOLD +
++						 he_obss_pd->non_srg_max_offset;
++		else
++			obss_pd_arg.non_srg_th = ATH12K_OBSS_PD_NON_SRG_MAX_THRESHOLD;
++
++		if (!obss_pd_arg.srp_support)
++			obss_pd_arg.non_srg_th -= ATH12K_DEFAULT_NOISE_FLOOR;
++
++		obss_pd_arg.non_srg_enabled = true;
++	}
++
++	if (he_obss_pd->sr_ctrl & IEEE80211_HE_SPR_SRG_INFORMATION_PRESENT) {
++		obss_pd_arg.srg_th = ATH12K_OBSS_PD_MAX_THRESHOLD +
++				     he_obss_pd->max_offset;
++		obss_pd_arg.srg_enabled = true;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "pdev %u OBSS PD sr_ctrl 0x%x srg_th %d dBm non_srg_th %d dBm\n",
++		   pdev_id, he_obss_pd->sr_ctrl,
++		   obss_pd_arg.srg_th, obss_pd_arg.non_srg_th);
++
++	param_val = ath12k_wmi_build_obss_pd(&obss_pd_arg);
++	ret = ath12k_wmi_pdev_set_param(ar, param_id, param_val, pdev_id);
++	if (ret) {
++		ath12k_warn(ar->ab,
++			    "failed to set OBSS PD threshold for pdev %u: %d\n",
++			    pdev_id, ret);
++		return ret;
++	}
++
++	/* Enable OBSS PD for all access category */
++	param_id  = WMI_PDEV_PARAM_SET_CMD_OBSS_PD_PER_AC;
++	param_val = 0xf;
++	ret = ath12k_wmi_pdev_set_param(ar, param_id, param_val, pdev_id);
++	if (ret) {
++		ath12k_warn(ar->ab,
++			    "failed to set OBSS PD per ac for pdev %u: %d\n",
++			    pdev_id, ret);
++		return ret;
++	}
++
++	/* Set SR prohibit */
++	param_id  = WMI_PDEV_PARAM_ENABLE_SR_PROHIBIT;
++	param_val = !!(he_obss_pd->sr_ctrl &
++		       IEEE80211_HE_SPR_HESIGA_SR_VAL15_ALLOWED);
++	ret = ath12k_wmi_pdev_set_param(ar, param_id, param_val, pdev_id);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set SR prohibit for pdev %u: %d\n",
++			    pdev_id, ret);
++		return ret;
++	}
++
++	if (!obss_pd_arg.srp_support)
++		return 0;
++
++	memcpy(srg_bitmap, he_obss_pd->bss_color_bitmap, sizeof(srg_bitmap));
++	/* Set SRG BSS color bitmap */
++	ret = ath12k_wmi_pdev_set_srg_bss_color_bitmap(ar, pdev_id, srg_bitmap);
++	if (ret) {
++		ath12k_warn(ar->ab,
++			    "failed to set SRG bss color bitmap for pdev %u: %d\n",
++			    pdev_id, ret);
++		return ret;
++	}
++
++	/* Enable BSS colors for SRG */
++	ret = ath12k_wmi_pdev_srg_obss_color_enable_bitmap(ar, pdev_id, srg_bitmap);
++	if (ret) {
++		ath12k_warn(ar->ab,
++			    "failed to enable SRG bss color bitmap pdev %u: %d\n",
++			    pdev_id, ret);
++		return ret;
++	}
++
++	memcpy(srg_bitmap, he_obss_pd->partial_bssid_bitmap, sizeof(srg_bitmap));
++	/* Set SRG partial bssid bitmap */
++	ret = ath12k_wmi_pdev_set_srg_partial_bssid_bitmap(ar, pdev_id, srg_bitmap);
++	if (ret) {
++		ath12k_warn(ar->ab,
++			    "failed to set SRG partial bssid bitmap for pdev %u: %d\n",
++			    pdev_id, ret);
++		return ret;
++	}
++
++	/* Enable partial bssid mask for SRG */
++	ret = ath12k_wmi_pdev_srg_obss_bssid_enable_bitmap(ar, pdev_id, srg_bitmap);
++	if (ret) {
++		ath12k_warn(ar->ab,
++			    "failed to enable SRG bssid bitmap pdev %u: %d\n",
++			    pdev_id, ret);
++		return ret;
++	}
++
++	/*
++	 * No explicit non-SRG bitmap from mac80211; enable all colors/bssids
++	 * as non-SRG candidates. Actual SRG members are filtered by SRG bitmaps.
++	 */
++	memset(non_srg_bitmap, 0xff, sizeof(non_srg_bitmap));
++
++	/* Enable BSS colors for non-SRG */
++	ret = ath12k_wmi_pdev_non_srg_obss_color_enable_bitmap(ar, pdev_id,
++							       non_srg_bitmap);
++	if (ret) {
++		ath12k_warn(ar->ab,
++			    "failed to enable non SRG color bitmap pdev %u: %d\n",
++			    pdev_id, ret);
++		return ret;
++	}
++
++	/* Enable partial bssid mask for non-SRG */
++	ret = ath12k_wmi_pdev_non_srg_obss_bssid_enable_bitmap(ar, pdev_id,
++							       non_srg_bitmap);
++	if (ret) {
++		ath12k_warn(ar->ab,
++			    "failed to enable non SRG bssid bitmap pdev %u: %d\n",
++			    pdev_id, ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static void ath12k_mac_bss_info_changed(struct ath12k *ar,
++					struct ath12k_link_vif *arvif,
++					struct ieee80211_bss_conf *info,
++					u64 changed)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(ahvif);
++	struct ieee80211_vif_cfg *vif_cfg = &vif->cfg;
++	struct ath12k_link_vif *tx_arvif;
++	struct cfg80211_chan_def def;
++	u32 param_id, param_value;
++	enum nl80211_band band;
++	u32 vdev_param;
++	int mcast_rate;
++	u32 preamble;
++	u16 hw_value;
++	u16 bitrate;
++	u8 rateidx;
++	u32 rate;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (changed & BSS_CHANGED_BEACON_INT) {
++		arvif->beacon_interval = info->beacon_int;
++
++		param_id = WMI_VDEV_PARAM_BEACON_INTERVAL;
++		ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++						    param_id,
++						    arvif->beacon_interval);
++		if (ret)
++			ath12k_warn(ar->ab, "Failed to set beacon interval for VDEV: %d\n",
++				    arvif->vdev_id);
++		else
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++				   "Beacon interval: %d set for VDEV: %d\n",
++				   arvif->beacon_interval, arvif->vdev_id);
++	}
++
++	if (changed & BSS_CHANGED_BEACON) {
++		param_id = WMI_PDEV_PARAM_BEACON_TX_MODE;
++		param_value = WMI_BEACON_BURST_MODE;
++		ret = ath12k_wmi_pdev_set_param(ar, param_id,
++						param_value, ar->pdev->pdev_id);
++		if (ret)
++			ath12k_warn(ar->ab, "Failed to set beacon mode for VDEV: %d\n",
++				    arvif->vdev_id);
++		else
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++				   "Set burst beacon mode for VDEV: %d\n",
++				   arvif->vdev_id);
++
++		/* In MBSSID case, need to install transmitting VIF's template first */
++
++		ret = ath12k_mac_setup_bcn_tmpl(arvif);
++		if (ret)
++			ath12k_warn(ar->ab, "failed to update bcn template: %d\n",
++				    ret);
++
++		if (!arvif->is_csa_in_progress)
++			goto skip_vdev_up;
++
++		tx_arvif = ath12k_mac_get_tx_arvif(arvif, info);
++		if (tx_arvif && arvif != tx_arvif && tx_arvif->is_csa_in_progress)
++			/* skip non tx vif's */
++			goto skip_vdev_up;
++
++		ath12k_wmi_vdev_params_up(ar, arvif, tx_arvif, info, ahvif->aid);
++
++		arvif->is_csa_in_progress = false;
++
++		if (tx_arvif && arvif == tx_arvif) {
++			struct ath12k_link_vif *arvif_itr;
++
++			list_for_each_entry(arvif_itr, &ar->arvifs, list) {
++				if (!arvif_itr->is_csa_in_progress)
++					continue;
++
++				ath12k_wmi_vdev_params_up(ar, arvif, tx_arvif,
++							  info, ahvif->aid);
++				arvif_itr->is_csa_in_progress = false;
++			}
++		}
++	}
++
++skip_vdev_up:
++
++	if (changed & (BSS_CHANGED_BEACON_INFO | BSS_CHANGED_BEACON)) {
++		arvif->dtim_period = info->dtim_period;
++
++		param_id = WMI_VDEV_PARAM_DTIM_PERIOD;
++		ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++						    param_id,
++						    arvif->dtim_period);
++
++		if (ret)
++			ath12k_warn(ar->ab, "Failed to set dtim period for VDEV %d: %i\n",
++				    arvif->vdev_id, ret);
++		else
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++				   "DTIM period: %d set for VDEV: %d\n",
++				   arvif->dtim_period, arvif->vdev_id);
++	}
++
++	if (changed & BSS_CHANGED_SSID &&
++	    vif->type == NL80211_IFTYPE_AP) {
++		ahvif->u.ap.ssid_len = vif->cfg.ssid_len;
++		if (vif->cfg.ssid_len)
++			memcpy(ahvif->u.ap.ssid, vif->cfg.ssid, vif->cfg.ssid_len);
++		ahvif->u.ap.hidden_ssid = info->hidden_ssid;
++	}
++
++	if (changed & BSS_CHANGED_BSSID && !is_zero_ether_addr(info->bssid))
++		ether_addr_copy(arvif->bssid, info->bssid);
++
++	if (changed & BSS_CHANGED_BEACON_ENABLED) {
++		if (info->enable_beacon) {
++			ret = ath12k_mac_set_he_txbf_conf(arvif);
++			if (ret)
++				ath12k_warn(ar->ab,
++					    "failed to set HE TXBF config for vdev: %d\n",
++					    arvif->vdev_id);
++
++			ret = ath12k_mac_set_eht_txbf_conf(arvif);
++			if (ret)
++				ath12k_warn(ar->ab,
++					    "failed to set EHT TXBF config for vdev: %d\n",
++					    arvif->vdev_id);
++		}
++		ath12k_control_beaconing(arvif, info);
++
++		if (arvif->is_up && info->he_support &&
++		    info->he_oper.params) {
++			/* TODO: Extend to support 1024 BA Bitmap size */
++			ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++							    WMI_VDEV_PARAM_BA_MODE,
++							    WMI_BA_MODE_BUFFER_SIZE_256);
++			if (ret)
++				ath12k_warn(ar->ab,
++					    "failed to set BA BUFFER SIZE 256 for vdev: %d\n",
++					    arvif->vdev_id);
++
++			param_id = WMI_VDEV_PARAM_HEOPS_0_31;
++			param_value = info->he_oper.params;
++			ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++							    param_id, param_value);
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++				   "he oper param: %x set for VDEV: %d\n",
++				   param_value, arvif->vdev_id);
++
++			if (ret)
++				ath12k_warn(ar->ab, "Failed to set he oper params %x for VDEV %d: %i\n",
++					    param_value, arvif->vdev_id, ret);
++		}
++	}
++
++	if (changed & BSS_CHANGED_ERP_CTS_PROT) {
++		u32 cts_prot;
++
++		cts_prot = !!(info->use_cts_prot);
++		param_id = WMI_VDEV_PARAM_PROTECTION_MODE;
++
++		if (arvif->is_started) {
++			ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++							    param_id, cts_prot);
++			if (ret)
++				ath12k_warn(ar->ab, "Failed to set CTS prot for VDEV: %d\n",
++					    arvif->vdev_id);
++			else
++				ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "Set CTS prot: %d for VDEV: %d\n",
++					   cts_prot, arvif->vdev_id);
++		} else {
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "defer protection mode setup, vdev is not ready yet\n");
++		}
++	}
++
++	if (changed & BSS_CHANGED_ERP_SLOT) {
++		u32 slottime;
++
++		if (info->use_short_slot)
++			slottime = WMI_VDEV_SLOT_TIME_SHORT; /* 9us */
++
++		else
++			slottime = WMI_VDEV_SLOT_TIME_LONG; /* 20us */
++
++		param_id = WMI_VDEV_PARAM_SLOT_TIME;
++		ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++						    param_id, slottime);
++		if (ret)
++			ath12k_warn(ar->ab, "Failed to set erp slot for VDEV: %d\n",
++				    arvif->vdev_id);
++		else
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++				   "Set slottime: %d for VDEV: %d\n",
++				   slottime, arvif->vdev_id);
++	}
++
++	if (changed & BSS_CHANGED_ERP_PREAMBLE) {
++		u32 preamble;
++
++		if (info->use_short_preamble)
++			preamble = WMI_VDEV_PREAMBLE_SHORT;
++		else
++			preamble = WMI_VDEV_PREAMBLE_LONG;
++
++		param_id = WMI_VDEV_PARAM_PREAMBLE;
++		ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++						    param_id, preamble);
++		if (ret)
++			ath12k_warn(ar->ab, "Failed to set preamble for VDEV: %d\n",
++				    arvif->vdev_id);
++		else
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++				   "Set preamble: %d for VDEV: %d\n",
++				   preamble, arvif->vdev_id);
++	}
++
++	if (changed & BSS_CHANGED_ASSOC) {
++		if (vif->cfg.assoc)
++			ath12k_bss_assoc(ar, arvif, info);
++		else
++			ath12k_bss_disassoc(ar, arvif);
++	}
++
++	if (changed & BSS_CHANGED_TXPOWER) {
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac vdev_id %i txpower %d\n",
++			   arvif->vdev_id, info->txpower);
++
++		arvif->txpower = info->txpower;
++		ath12k_mac_txpower_recalc(ar);
++	}
++
++	if (changed & BSS_CHANGED_MCAST_RATE &&
++	    !ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)) {
++		band = def.chan->band;
++		mcast_rate = info->mcast_rate[band];
++
++		if (mcast_rate > 0) {
++			rateidx = mcast_rate - 1;
++		} else {
++			if (info->basic_rates)
++				rateidx = __ffs(info->basic_rates);
++			else
++				rateidx = 0;
++		}
++
++		if (ar->pdev->cap.supported_bands & WMI_HOST_WLAN_5GHZ_CAP)
++			rateidx += ATH12K_MAC_FIRST_OFDM_RATE_IDX;
++
++		bitrate = ath12k_legacy_rates[rateidx].bitrate;
++		hw_value = ath12k_legacy_rates[rateidx].hw_value;
++
++		if (ath12k_mac_bitrate_is_cck(bitrate))
++			preamble = WMI_RATE_PREAMBLE_CCK;
++		else
++			preamble = WMI_RATE_PREAMBLE_OFDM;
++
++		rate = ATH12K_HW_RATE_CODE(hw_value, 0, preamble);
++
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++			   "mac vdev %d mcast_rate %x\n",
++			   arvif->vdev_id, rate);
++
++		vdev_param = WMI_VDEV_PARAM_MCAST_DATA_RATE;
++		ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++						    vdev_param, rate);
++		if (ret)
++			ath12k_warn(ar->ab,
++				    "failed to set mcast rate on vdev %i: %d\n",
++				    arvif->vdev_id,  ret);
++
++		vdev_param = WMI_VDEV_PARAM_BCAST_DATA_RATE;
++		ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++						    vdev_param, rate);
++		if (ret)
++			ath12k_warn(ar->ab,
++				    "failed to set bcast rate on vdev %i: %d\n",
++				    arvif->vdev_id,  ret);
++	}
++
++	if (changed & BSS_CHANGED_BASIC_RATES &&
++	    !ath12k_mac_vif_link_chan(vif, arvif->link_id, &def))
++		ath12k_recalculate_mgmt_rate(ar, arvif, &def);
++
++	if (changed & BSS_CHANGED_TWT) {
++		if (info->twt_requester || info->twt_responder)
++			ath12k_wmi_send_twt_enable_cmd(ar, ar->pdev->pdev_id);
++		else
++			ath12k_wmi_send_twt_disable_cmd(ar, ar->pdev->pdev_id);
++	}
++
++	if (changed & BSS_CHANGED_HE_OBSS_PD) {
++		if (vif->type == NL80211_IFTYPE_AP)
++			ath12k_mac_config_obss_pd(arvif, &info->he_obss_pd);
++		else
++			ath12k_wmi_send_obss_spr_cmd(ar, arvif->vdev_id,
++						     &info->he_obss_pd);
++	}
++
++	if (changed & BSS_CHANGED_HE_BSS_COLOR) {
++		if (vif->type == NL80211_IFTYPE_AP) {
++			ret = ath12k_wmi_obss_color_cfg_cmd(ar,
++							    arvif->vdev_id,
++							    info->he_bss_color.color,
++							    ATH12K_BSS_COLOR_AP_PERIODS,
++							    info->he_bss_color.enabled);
++			if (ret)
++				ath12k_warn(ar->ab, "failed to set bss color collision on vdev %u: %d\n",
++					    arvif->vdev_id,  ret);
++
++			param_id = WMI_VDEV_PARAM_BSS_COLOR;
++			if (info->he_bss_color.enabled)
++				param_value = info->he_bss_color.color <<
++					      IEEE80211_HE_OPERATION_BSS_COLOR_OFFSET;
++			else
++				param_value = IEEE80211_HE_OPERATION_BSS_COLOR_DISABLED;
++
++			ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++							    param_id,
++							    param_value);
++			if (ret)
++				ath12k_warn(ar->ab, "failed to set bss color param on vdev %u: %d\n",
++					    arvif->vdev_id,  ret);
++			else
++				ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "bss color param 0x%x set on vdev %u\n",
++					   param_value, arvif->vdev_id);
++		} else if (vif->type == NL80211_IFTYPE_STATION) {
++			ret = ath12k_wmi_send_bss_color_change_enable_cmd(ar,
++									  arvif->vdev_id,
++									  1);
++			if (ret)
++				ath12k_warn(ar->ab, "failed to enable bss color change on vdev %i: %d\n",
++					    arvif->vdev_id,  ret);
++			ret = ath12k_wmi_obss_color_cfg_cmd(ar,
++							    arvif->vdev_id,
++							    0,
++							    ATH12K_BSS_COLOR_STA_PERIODS,
++							    1);
++			if (ret)
++				ath12k_warn(ar->ab, "failed to set bss color collision on vdev %i: %d\n",
++					    arvif->vdev_id,  ret);
++		}
++	}
++
++	ath12k_mac_fils_discovery(arvif, info);
++
++	if (changed & BSS_CHANGED_PS &&
++	    ar->ab->hw_params->supports_sta_ps) {
++		ahvif->ps = vif_cfg->ps;
++		ath12k_mac_vif_setup_ps(arvif);
++	}
++}
++
++static struct ath12k_vif_cache *ath12k_ahvif_get_link_cache(struct ath12k_vif *ahvif,
++							    u8 link_id)
++{
++	if (!ahvif->cache[link_id]) {
++		ahvif->cache[link_id] = kzalloc_obj(*ahvif->cache[0]);
++		if (ahvif->cache[link_id])
++			INIT_LIST_HEAD(&ahvif->cache[link_id]->key_conf.list);
++	}
++
++	return ahvif->cache[link_id];
++}
++
++static void ath12k_ahvif_put_link_key_cache(struct ath12k_vif_cache *cache)
++{
++	struct ath12k_key_conf *key_conf, *tmp;
++
++	if (!cache || list_empty(&cache->key_conf.list))
++		return;
++	list_for_each_entry_safe(key_conf, tmp, &cache->key_conf.list, list) {
++		list_del(&key_conf->list);
++		kfree(key_conf);
++	}
++}
++
++static void ath12k_ahvif_put_link_cache(struct ath12k_vif *ahvif, u8 link_id)
++{
++	if (link_id >= IEEE80211_MLD_MAX_NUM_LINKS)
++		return;
++
++	ath12k_ahvif_put_link_key_cache(ahvif->cache[link_id]);
++	kfree(ahvif->cache[link_id]);
++	ahvif->cache[link_id] = NULL;
++}
++
++void ath12k_mac_op_link_info_changed(struct ieee80211_hw *hw,
++				     struct ieee80211_vif *vif,
++				     struct ieee80211_bss_conf *info,
++				     u64 changed)
++{
++	struct ath12k *ar;
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_vif_cache *cache;
++	struct ath12k_link_vif *arvif;
++	u8 link_id = info->link_id;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++
++	/* if the vdev is not created on a certain radio,
++	 * cache the info to be updated later on vdev creation
++	 */
++
++	if (!arvif || !arvif->is_created) {
++		cache = ath12k_ahvif_get_link_cache(ahvif, link_id);
++		if (!cache)
++			return;
++
++		cache->bss_conf_changed |= changed;
++
++		return;
++	}
++
++	ar = arvif->ar;
++
++	ath12k_mac_bss_info_changed(ar, arvif, info, changed);
++}
++EXPORT_SYMBOL(ath12k_mac_op_link_info_changed);
++
++static struct ath12k*
++ath12k_mac_select_scan_device(struct ieee80211_hw *hw,
++			      struct ieee80211_vif *vif,
++			      u32 center_freq)
++{
++	struct ath12k_hw *ah = hw->priv;
++	enum nl80211_band band;
++	struct ath12k *ar;
++	int i;
++
++	if (ah->num_radio == 1)
++		return ah->radio;
++
++	/* Currently mac80211 supports splitting scan requests into
++	 * multiple scan requests per band.
++	 * Loop through first channel and determine the scan radio
++	 * TODO: There could be 5 GHz low/high channels in that case
++	 * split the hw request and perform multiple scans
++	 */
++
++	if (center_freq < ATH12K_MIN_5GHZ_FREQ)
++		band = NL80211_BAND_2GHZ;
++	else if (center_freq < ATH12K_MIN_6GHZ_FREQ)
++		band = NL80211_BAND_5GHZ;
++	else
++		band = NL80211_BAND_6GHZ;
++
++	for_each_ar(ah, ar, i) {
++		if (ar->mac.sbands[band].channels &&
++		    center_freq >= KHZ_TO_MHZ(ar->freq_range.start_freq) &&
++		    center_freq <= KHZ_TO_MHZ(ar->freq_range.end_freq))
++			return ar;
++	}
++
++	return NULL;
++}
++
++void __ath12k_mac_scan_finish(struct ath12k *ar)
++{
++	struct ieee80211_hw *hw = ath12k_ar_to_hw(ar);
++
++	lockdep_assert_held(&ar->data_lock);
++
++	switch (ar->scan.state) {
++	case ATH12K_SCAN_IDLE:
++		break;
++	case ATH12K_SCAN_RUNNING:
++	case ATH12K_SCAN_ABORTING:
++		if (ar->scan.is_roc && ar->scan.roc_notify)
++			ieee80211_remain_on_channel_expired(hw);
++		fallthrough;
++	case ATH12K_SCAN_STARTING:
++		cancel_delayed_work(&ar->scan.timeout);
++		complete_all(&ar->scan.completed);
++		wiphy_work_queue(ar->ah->hw->wiphy, &ar->scan.vdev_clean_wk);
++		break;
++	}
++}
++
++void ath12k_mac_scan_finish(struct ath12k *ar)
++{
++	spin_lock_bh(&ar->data_lock);
++	__ath12k_mac_scan_finish(ar);
++	spin_unlock_bh(&ar->data_lock);
++}
++
++static int ath12k_scan_stop(struct ath12k *ar)
++{
++	struct ath12k_wmi_scan_cancel_arg arg = {
++		.req_type = WLAN_SCAN_CANCEL_SINGLE,
++		.scan_id = ATH12K_SCAN_ID,
++	};
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	/* TODO: Fill other STOP Params */
++	arg.pdev_id = ar->pdev->pdev_id;
++
++	ret = ath12k_wmi_send_scan_stop_cmd(ar, &arg);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to stop wmi scan: %d\n", ret);
++		goto out;
++	}
++
++	ret = wait_for_completion_timeout(&ar->scan.completed, 3 * HZ);
++	if (ret == 0) {
++		ath12k_warn(ar->ab,
++			    "failed to receive scan abort comple: timed out\n");
++		ret = -ETIMEDOUT;
++	} else if (ret > 0) {
++		ret = 0;
++	}
++
++out:
++	/* Scan state should be updated in scan completion worker but in
++	 * case firmware fails to deliver the event (for whatever reason)
++	 * it is desired to clean up scan state anyway. Firmware may have
++	 * just dropped the scan completion event delivery due to transport
++	 * pipe being overflown with data and/or it can recover on its own
++	 * before next scan request is submitted.
++	 */
++	spin_lock_bh(&ar->data_lock);
++	if (ret)
++		__ath12k_mac_scan_finish(ar);
++	spin_unlock_bh(&ar->data_lock);
++
++	return ret;
++}
++
++static void ath12k_scan_abort(struct ath12k *ar)
++{
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	spin_lock_bh(&ar->data_lock);
++
++	switch (ar->scan.state) {
++	case ATH12K_SCAN_IDLE:
++		/* This can happen if timeout worker kicked in and called
++		 * abortion while scan completion was being processed.
++		 */
++		break;
++	case ATH12K_SCAN_STARTING:
++	case ATH12K_SCAN_ABORTING:
++		ath12k_warn(ar->ab, "refusing scan abortion due to invalid scan state: %d\n",
++			    ar->scan.state);
++		break;
++	case ATH12K_SCAN_RUNNING:
++		ar->scan.state = ATH12K_SCAN_ABORTING;
++		spin_unlock_bh(&ar->data_lock);
++
++		ret = ath12k_scan_stop(ar);
++		if (ret)
++			ath12k_warn(ar->ab, "failed to abort scan: %d\n", ret);
++
++		spin_lock_bh(&ar->data_lock);
++		break;
++	}
++
++	spin_unlock_bh(&ar->data_lock);
++}
++
++static void ath12k_scan_timeout_work(struct work_struct *work)
++{
++	struct ath12k *ar = container_of(work, struct ath12k,
++					 scan.timeout.work);
++
++	wiphy_lock(ath12k_ar_to_hw(ar)->wiphy);
++	ath12k_scan_abort(ar);
++	wiphy_unlock(ath12k_ar_to_hw(ar)->wiphy);
++}
++
++static void ath12k_mac_scan_send_complete(struct ath12k *ar,
++					  struct cfg80211_scan_info *info)
++{
++	struct ath12k_hw *ah = ar->ah;
++	struct ath12k *partner_ar;
++	int i;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	for_each_ar(ah, partner_ar, i)
++		if (partner_ar != ar &&
++		    partner_ar->scan.state == ATH12K_SCAN_RUNNING)
++			return;
++
++	ieee80211_scan_completed(ah->hw, info);
++}
++
++static void ath12k_scan_vdev_clean_work(struct wiphy *wiphy, struct wiphy_work *work)
++{
++	struct ath12k *ar = container_of(work, struct ath12k,
++					 scan.vdev_clean_wk);
++	struct ath12k_hw *ah = ar->ah;
++	struct ath12k_link_vif *arvif;
++
++	lockdep_assert_wiphy(wiphy);
++
++	arvif = ar->scan.arvif;
++
++	/* The scan vdev has already been deleted. This can occur when a
++	 * new scan request is made on the same vif with a different
++	 * frequency, causing the scan arvif to move from one radio to
++	 * another. Or, scan was abrupted and via remove interface, the
++	 * arvif is already deleted. Alternatively, if the scan vdev is not
++	 * being used as an actual vdev, then do not delete it.
++	 */
++	if (!arvif || arvif->is_started)
++		goto work_complete;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac clean scan vdev (link id %u)",
++		   arvif->link_id);
++
++	ath12k_mac_remove_link_interface(ah->hw, arvif);
++	ath12k_mac_unassign_link_vif(arvif);
++
++work_complete:
++	spin_lock_bh(&ar->data_lock);
++	ar->scan.arvif = NULL;
++	if (!ar->scan.is_roc) {
++		struct cfg80211_scan_info info = {
++			.aborted = ((ar->scan.state ==
++				    ATH12K_SCAN_ABORTING) ||
++				    (ar->scan.state ==
++				    ATH12K_SCAN_STARTING)),
++		};
++
++		ath12k_mac_scan_send_complete(ar, &info);
++	}
++
++	ar->scan.state = ATH12K_SCAN_IDLE;
++	ar->scan_channel = NULL;
++	ar->scan.roc_freq = 0;
++	spin_unlock_bh(&ar->data_lock);
++}
++
++static int ath12k_start_scan(struct ath12k *ar,
++			     struct ath12k_wmi_scan_req_arg *arg)
++{
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	ret = ath12k_wmi_send_scan_start_cmd(ar, arg);
++	if (ret)
++		return ret;
++
++	ret = wait_for_completion_timeout(&ar->scan.started, 1 * HZ);
++	if (ret == 0) {
++		ret = ath12k_scan_stop(ar);
++		if (ret)
++			ath12k_warn(ar->ab, "failed to stop scan: %d\n", ret);
++
++		return -ETIMEDOUT;
++	}
++
++	/* If we failed to start the scan, return error code at
++	 * this point.  This is probably due to some issue in the
++	 * firmware, but no need to wedge the driver due to that...
++	 */
++	spin_lock_bh(&ar->data_lock);
++	if (ar->scan.state == ATH12K_SCAN_IDLE) {
++		spin_unlock_bh(&ar->data_lock);
++		return -EINVAL;
++	}
++	spin_unlock_bh(&ar->data_lock);
++
++	return 0;
++}
++
++int ath12k_mac_get_fw_stats(struct ath12k *ar,
++			    struct ath12k_fw_stats_req_params *param)
++{
++	struct ath12k_base *ab = ar->ab;
++	struct ath12k_hw *ah = ath12k_ar_to_ah(ar);
++	unsigned long time_left;
++	int ret;
++
++	guard(mutex)(&ah->hw_mutex);
++
++	if (ah->state != ATH12K_HW_STATE_ON)
++		return -ENETDOWN;
++
++	reinit_completion(&ar->fw_stats_complete);
++	reinit_completion(&ar->fw_stats_done);
++
++	ret = ath12k_wmi_send_stats_request_cmd(ar, param->stats_id,
++						param->vdev_id, param->pdev_id);
++	if (ret) {
++		ath12k_warn(ab, "failed to request fw stats: %d\n", ret);
++		return ret;
++	}
++
++	ath12k_dbg(ab, ATH12K_DBG_WMI,
++		   "get fw stat pdev id %d vdev id %d stats id 0x%x\n",
++		   param->pdev_id, param->vdev_id, param->stats_id);
++
++	time_left = wait_for_completion_timeout(&ar->fw_stats_complete, 1 * HZ);
++	if (!time_left) {
++		ath12k_warn(ab, "time out while waiting for get fw stats\n");
++		return -ETIMEDOUT;
++	}
++
++	/* Firmware sends WMI_UPDATE_STATS_EVENTID back-to-back
++	 * when stats data buffer limit is reached. fw_stats_complete
++	 * is completed once host receives first event from firmware, but
++	 * still there could be more events following. Below is to wait
++	 * until firmware completes sending all the events.
++	 */
++	time_left = wait_for_completion_timeout(&ar->fw_stats_done, 3 * HZ);
++	if (!time_left) {
++		ath12k_warn(ab, "time out while waiting for fw stats done\n");
++		return -ETIMEDOUT;
++	}
++
++	return 0;
++}
++
++int ath12k_mac_op_get_txpower(struct ieee80211_hw *hw,
++			      struct ieee80211_vif *vif,
++			      unsigned int link_id,
++			      int *dbm)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_fw_stats_req_params params = {};
++	struct ath12k_fw_stats_pdev *pdev;
++	struct ath12k_hw *ah = hw->priv;
++	struct ath12k_link_vif *arvif;
++	struct ath12k_base *ab;
++	struct ath12k *ar;
++	int ret;
++
++	/* Final Tx power is minimum of Target Power, CTL power, Regulatory
++	 * Power, PSD EIRP Power. We just know the Regulatory power from the
++	 * regulatory rules obtained. FW knows all these power and sets the min
++	 * of these. Hence, we request the FW pdev stats in which FW reports
++	 * the minimum of all vdev's channel Tx power.
++	 */
++	lockdep_assert_wiphy(hw->wiphy);
++
++	arvif = wiphy_dereference(ah->hw->wiphy, ahvif->link[link_id]);
++	if (!arvif || !arvif->ar)
++		return -EINVAL;
++
++	ar = arvif->ar;
++	ab = ar->ab;
++	if (ah->state != ATH12K_HW_STATE_ON)
++		goto err_fallback;
++
++	if (test_bit(ATH12K_FLAG_CAC_RUNNING, &ar->dev_flags))
++		return -EAGAIN;
++
++	/* Limit the requests to Firmware for fetching the tx power */
++	if (ar->chan_tx_pwr != ATH12K_PDEV_TX_POWER_INVALID &&
++	    time_before(jiffies,
++			msecs_to_jiffies(ATH12K_PDEV_TX_POWER_REFRESH_TIME_MSECS) +
++					 ar->last_tx_power_update))
++		goto send_tx_power;
++
++	params.pdev_id = ath12k_mac_get_target_pdev_id(ar);
++	params.vdev_id = arvif->vdev_id;
++	params.stats_id = WMI_REQUEST_PDEV_STAT;
++	ret = ath12k_mac_get_fw_stats(ar, &params);
++	if (ret) {
++		ath12k_warn(ab, "failed to request fw pdev stats: %d\n", ret);
++		goto err_fallback;
++	}
++
++	spin_lock_bh(&ar->data_lock);
++	pdev = list_first_entry_or_null(&ar->fw_stats.pdevs,
++					struct ath12k_fw_stats_pdev, list);
++	if (!pdev) {
++		spin_unlock_bh(&ar->data_lock);
++		goto err_fallback;
++	}
++
++	/* tx power reported by firmware is in units of 0.5 dBm */
++	ar->chan_tx_pwr = pdev->chan_tx_power / 2;
++	spin_unlock_bh(&ar->data_lock);
++	ar->last_tx_power_update = jiffies;
++	ath12k_fw_stats_reset(ar);
++
++send_tx_power:
++	*dbm = ar->chan_tx_pwr;
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "txpower fetched from firmware %d dBm\n",
++		   *dbm);
++	return 0;
++
++err_fallback:
++	/* We didn't get txpower from FW. Hence, relying on vif->bss_conf.txpower */
++	*dbm = vif->bss_conf.txpower;
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "txpower from firmware NaN, reported %d dBm\n",
++		   *dbm);
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_get_txpower);
++
++static u8
++ath12k_mac_find_link_id_by_ar(struct ath12k_vif *ahvif, struct ath12k *ar)
++{
++	struct ath12k_link_vif *arvif;
++	struct ath12k_hw *ah = ahvif->ah;
++	unsigned long links = ahvif->links_map;
++	unsigned long scan_links_map;
++	u8 link_id;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	for_each_set_bit(link_id, &links, ATH12K_NUM_MAX_LINKS) {
++		arvif = wiphy_dereference(ah->hw->wiphy, ahvif->link[link_id]);
++
++		if (!arvif || !arvif->is_created)
++			continue;
++
++		if (ar == arvif->ar)
++			return link_id;
++	}
++
++	/* input ar is not assigned to any of the links of ML VIF, use next
++	 * available scan link for scan vdev creation. There are cases where
++	 * single scan req needs to be split in driver and initiate separate
++	 * scan requests to firmware based on device.
++	 */
++
++	 /* Unset all non-scan links (0-14) of scan_links_map so that ffs() will
++	  * choose an available link among scan links (i.e link id >= 15)
++	  */
++	scan_links_map = ~ahvif->links_map & ATH12K_SCAN_LINKS_MASK;
++	if (scan_links_map)
++		return __ffs(scan_links_map);
++
++	return ATH12K_FIRST_SCAN_LINK;
++}
++
++static int ath12k_mac_initiate_hw_scan(struct ieee80211_hw *hw,
++				       struct ieee80211_vif *vif,
++				       struct ieee80211_scan_request *hw_req,
++				       int n_channels,
++				       struct ieee80211_channel **chan_list,
++				       struct ath12k *ar)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_link_vif *arvif;
++	struct cfg80211_scan_request *req = &hw_req->req;
++	struct ath12k_wmi_scan_req_arg *arg = NULL;
++	u8 link_id;
++	int ret;
++	int i;
++	bool create = true;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	arvif = &ahvif->deflink;
++
++	/* check if any of the links of ML VIF is already started on
++	 * radio(ar) corresponding to given scan frequency and use it,
++	 * if not use scan link (link id >= 15) for scan purpose.
++	 */
++	link_id = ath12k_mac_find_link_id_by_ar(ahvif, ar);
++	/* All scan links are occupied. ideally this shouldn't happen as
++	 * mac80211 won't schedule scan for same band until ongoing scan is
++	 * completed, don't try to exceed max links just in case if it happens.
++	 */
++	if (link_id >= ATH12K_NUM_MAX_LINKS)
++		return -EBUSY;
++
++	arvif = ath12k_mac_assign_link_vif(ah, vif, link_id);
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac link ID %d selected for scan",
++		   arvif->link_id);
++
++	/* If the vif is already assigned to a specific vdev of an ar,
++	 * check whether its already started, vdev which is started
++	 * are not allowed to switch to a new radio.
++	 * If the vdev is not started, but was earlier created on a
++	 * different ar, delete that vdev and create a new one. We don't
++	 * delete at the scan stop as an optimization to avoid redundant
++	 * delete-create vdev's for the same ar, in case the request is
++	 * always on the same band for the vif
++	 */
++	if (arvif->is_created) {
++		if (WARN_ON(!arvif->ar))
++			return -EINVAL;
++
++		if (ar != arvif->ar && arvif->is_started)
++			return -EINVAL;
++
++		if (ar != arvif->ar) {
++			ath12k_mac_remove_link_interface(hw, arvif);
++			ath12k_mac_unassign_link_vif(arvif);
++		} else {
++			create = false;
++		}
++	}
++
++	if (create) {
++		/* Previous arvif would've been cleared in radio switch block
++		 * above, assign arvif again for create.
++		 */
++		arvif = ath12k_mac_assign_link_vif(ah, vif, link_id);
++
++		ret = ath12k_mac_vdev_create(ar, arvif);
++		if (ret) {
++			ath12k_warn(ar->ab, "unable to create scan vdev %d\n", ret);
++			ath12k_mac_unassign_link_vif(arvif);
++			return ret;
++		}
++	}
++
++	spin_lock_bh(&ar->data_lock);
++	switch (ar->scan.state) {
++	case ATH12K_SCAN_IDLE:
++		reinit_completion(&ar->scan.started);
++		reinit_completion(&ar->scan.completed);
++		ar->scan.state = ATH12K_SCAN_STARTING;
++		ar->scan.is_roc = false;
++		ar->scan.arvif = arvif;
++		ret = 0;
++		break;
++	case ATH12K_SCAN_STARTING:
++	case ATH12K_SCAN_RUNNING:
++	case ATH12K_SCAN_ABORTING:
++		ret = -EBUSY;
++		break;
++	}
++	spin_unlock_bh(&ar->data_lock);
++
++	if (ret)
++		goto exit;
++
++	arg = kzalloc_obj(*arg);
++	if (!arg) {
++		ret = -ENOMEM;
++		goto exit;
++	}
++
++	ath12k_wmi_start_scan_init(ar, arg);
++	arg->vdev_id = arvif->vdev_id;
++	arg->scan_id = ATH12K_SCAN_ID;
++
++	if (req->ie_len) {
++		arg->extraie.ptr = kmemdup(req->ie, req->ie_len, GFP_KERNEL);
++		if (!arg->extraie.ptr) {
++			ret = -ENOMEM;
++			goto exit;
++		}
++		arg->extraie.len = req->ie_len;
++	}
++
++	if (req->n_ssids) {
++		arg->num_ssids = req->n_ssids;
++		for (i = 0; i < arg->num_ssids; i++)
++			arg->ssid[i] = req->ssids[i];
++	} else {
++		arg->scan_f_passive = 1;
++	}
++
++	if (n_channels) {
++		arg->num_chan = n_channels;
++		arg->chan_list = kcalloc(arg->num_chan, sizeof(*arg->chan_list),
++					 GFP_KERNEL);
++		if (!arg->chan_list) {
++			ret = -ENOMEM;
++			goto exit;
++		}
++
++		for (i = 0; i < arg->num_chan; i++)
++			arg->chan_list[i] = chan_list[i]->center_freq;
++	}
++
++	ret = ath12k_start_scan(ar, arg);
++	if (ret) {
++		if (ret == -EBUSY)
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++				   "scan engine is busy 11d state %d\n", ar->state_11d);
++		else
++			ath12k_warn(ar->ab, "failed to start hw scan: %d\n", ret);
++
++		spin_lock_bh(&ar->data_lock);
++		ar->scan.state = ATH12K_SCAN_IDLE;
++		spin_unlock_bh(&ar->data_lock);
++		goto exit;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac scan started");
++
++	/* Add a margin to account for event/command processing */
++	ieee80211_queue_delayed_work(ath12k_ar_to_hw(ar), &ar->scan.timeout,
++				     msecs_to_jiffies(arg->max_scan_time +
++						      ATH12K_MAC_SCAN_TIMEOUT_MSECS));
++
++exit:
++	if (arg) {
++		kfree(arg->chan_list);
++		kfree(arg->extraie.ptr);
++		kfree(arg);
++	}
++
++	if (ar->state_11d == ATH12K_11D_PREPARING &&
++	    ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
++	    ahvif->vdev_subtype == WMI_VDEV_SUBTYPE_NONE)
++		ath12k_mac_11d_scan_start(ar, arvif->vdev_id);
++
++	return ret;
++}
++
++int ath12k_mac_op_hw_scan(struct ieee80211_hw *hw,
++			  struct ieee80211_vif *vif,
++			  struct ieee80211_scan_request *hw_req)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ieee80211_channel **chan_list, *chan;
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	unsigned long links_map, link_id;
++	struct ath12k_link_vif *arvif;
++	struct ath12k *ar, *scan_ar;
++	int i, j, ret = 0;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	chan_list = kzalloc_objs(*chan_list, hw_req->req.n_channels);
++	if (!chan_list)
++		return -ENOMEM;
++
++	/* There could be channels that belong to multiple underlying radio
++	 * in same scan request as mac80211 sees it as single band. In that
++	 * case split the hw_req based on frequency range and schedule scans to
++	 * corresponding radio.
++	 */
++	for_each_ar(ah, ar, i) {
++		int n_chans = 0;
++
++		for (j = 0; j < hw_req->req.n_channels; j++) {
++			chan = hw_req->req.channels[j];
++			scan_ar = ath12k_mac_select_scan_device(hw, vif,
++								chan->center_freq);
++			if (!scan_ar) {
++				ath12k_hw_warn(ah, "unable to select scan device for freq %d\n",
++					       chan->center_freq);
++				ret = -EINVAL;
++				goto abort;
++			}
++			if (ar != scan_ar)
++				continue;
++
++			chan_list[n_chans++] = chan;
++		}
++		if (n_chans) {
++			ret = ath12k_mac_initiate_hw_scan(hw, vif, hw_req, n_chans,
++							  chan_list, ar);
++			if (ret)
++				goto abort;
++		}
++	}
++abort:
++	/* If any of the parallel scans initiated fails, abort all and
++	 * remove the scan interfaces created. Return complete scan
++	 * failure as mac80211 assumes this as single scan request.
++	 */
++	if (ret) {
++		ath12k_hw_warn(ah, "Scan failed %d , cleanup all scan vdevs\n", ret);
++		links_map = ahvif->links_map;
++		for_each_set_bit(link_id, &links_map, ATH12K_NUM_MAX_LINKS) {
++			arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++			if (!arvif)
++				continue;
++
++			ar = arvif->ar;
++			if (ar->scan.arvif == arvif) {
++				wiphy_work_cancel(hw->wiphy, &ar->scan.vdev_clean_wk);
++				spin_lock_bh(&ar->data_lock);
++				ar->scan.arvif = NULL;
++				ar->scan.state = ATH12K_SCAN_IDLE;
++				ar->scan_channel = NULL;
++				ar->scan.roc_freq = 0;
++				spin_unlock_bh(&ar->data_lock);
++			}
++			if (link_id >= ATH12K_FIRST_SCAN_LINK) {
++				ath12k_mac_remove_link_interface(hw, arvif);
++				ath12k_mac_unassign_link_vif(arvif);
++			}
++		}
++	}
++	kfree(chan_list);
++	return ret;
++}
++EXPORT_SYMBOL(ath12k_mac_op_hw_scan);
++
++void ath12k_mac_op_cancel_hw_scan(struct ieee80211_hw *hw,
++				  struct ieee80211_vif *vif)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	unsigned long link_id, links_map = ahvif->links_map;
++	struct ath12k_link_vif *arvif;
++	struct ath12k *ar;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	for_each_set_bit(link_id, &links_map, ATH12K_NUM_MAX_LINKS) {
++		arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++		if (!arvif || !arvif->is_created ||
++		    arvif->ar->scan.arvif != arvif)
++			continue;
++
++		ar = arvif->ar;
++
++		ath12k_scan_abort(ar);
++
++		cancel_delayed_work_sync(&ar->scan.timeout);
++	}
++}
++EXPORT_SYMBOL(ath12k_mac_op_cancel_hw_scan);
++
++static int ath12k_install_key(struct ath12k_link_vif *arvif,
++			      struct ieee80211_key_conf *key,
++			      enum set_key_cmd cmd,
++			      const u8 *macaddr, u32 flags)
++{
++	int ret;
++	struct ath12k *ar = arvif->ar;
++	struct wmi_vdev_install_key_arg arg = {
++		.vdev_id = arvif->vdev_id,
++		.key_idx = key->keyidx,
++		.key_len = key->keylen,
++		.key_data = key->key,
++		.key_flags = flags,
++		.ieee80211_key_cipher = key->cipher,
++		.macaddr = macaddr,
++	};
++	struct ath12k_vif *ahvif = arvif->ahvif;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (test_bit(ATH12K_FLAG_HW_CRYPTO_DISABLED, &ar->ab->dev_flags))
++		return 0;
++
++	if (cmd == DISABLE_KEY) {
++		/* TODO: Check if FW expects  value other than NONE for del */
++		/* arg.key_cipher = WMI_CIPHER_NONE; */
++		arg.key_len = 0;
++		arg.key_data = NULL;
++		goto check_order;
++	}
++
++	switch (key->cipher) {
++	case WLAN_CIPHER_SUITE_CCMP:
++	case WLAN_CIPHER_SUITE_CCMP_256:
++		arg.key_cipher = WMI_CIPHER_AES_CCM;
++		key->flags |= IEEE80211_KEY_FLAG_GENERATE_IV_MGMT;
++		break;
++	case WLAN_CIPHER_SUITE_TKIP:
++		arg.key_cipher = WMI_CIPHER_TKIP;
++		arg.key_txmic_len = 8;
++		arg.key_rxmic_len = 8;
++		break;
++	case WLAN_CIPHER_SUITE_GCMP:
++	case WLAN_CIPHER_SUITE_GCMP_256:
++		arg.key_cipher = WMI_CIPHER_AES_GCM;
++		key->flags |= IEEE80211_KEY_FLAG_GENERATE_IV_MGMT;
++		break;
++	case WLAN_CIPHER_SUITE_AES_CMAC:
++		arg.key_cipher = WMI_CIPHER_AES_CMAC;
++		break;
++	case WLAN_CIPHER_SUITE_BIP_GMAC_128:
++	case WLAN_CIPHER_SUITE_BIP_GMAC_256:
++		arg.key_cipher = WMI_CIPHER_AES_GMAC;
++		break;
++	case WLAN_CIPHER_SUITE_BIP_CMAC_256:
++		arg.key_cipher = WMI_CIPHER_AES_CMAC;
++		break;
++	default:
++		ath12k_warn(ar->ab, "cipher %d is not supported\n", key->cipher);
++		return -EOPNOTSUPP;
++	}
++
++	if (test_bit(ATH12K_FLAG_RAW_MODE, &ar->ab->dev_flags))
++		key->flags |= IEEE80211_KEY_FLAG_GENERATE_IV |
++			      IEEE80211_KEY_FLAG_RESERVE_TAILROOM;
++
++check_order:
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
++	    arg.key_flags == WMI_KEY_GROUP) {
++		if (cmd == SET_KEY) {
++			if (arvif->pairwise_key_done) {
++				ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++					   "vdev %u pairwise key done, go install group key\n",
++					   arg.vdev_id);
++				goto install;
++			} else {
++				/* WCN7850 firmware requires pairwise key to be installed
++				 * before group key. In case group key comes first, cache
++				 * it and return. Will revisit it once pairwise key gets
++				 * installed.
++				 */
++				arvif->group_key = arg;
++				arvif->group_key_valid = true;
++				ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++					   "vdev %u group key before pairwise key, cache and skip\n",
++					   arg.vdev_id);
++
++				ret = 0;
++				goto out;
++			}
++		} else {
++			arvif->group_key_valid = false;
++		}
++	}
++
++install:
++	reinit_completion(&ar->install_key_done);
++
++	ret = ath12k_wmi_vdev_install_key(arvif->ar, &arg);
++	if (ret)
++		return ret;
++
++	if (!wait_for_completion_timeout(&ar->install_key_done, 1 * HZ))
++		return -ETIMEDOUT;
++
++	if (ether_addr_equal(arg.macaddr, arvif->bssid))
++		ahvif->dp_vif.key_cipher = arg.ieee80211_key_cipher;
++
++	if (ar->install_key_status) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
++	    arg.key_flags == WMI_KEY_PAIRWISE) {
++		if (cmd == SET_KEY) {
++			arvif->pairwise_key_done = true;
++			if (arvif->group_key_valid) {
++				/* Install cached GTK */
++				arvif->group_key_valid = false;
++				arg = arvif->group_key;
++				ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++					   "vdev %u pairwise key done, group key ready, go install\n",
++					   arg.vdev_id);
++				goto install;
++			}
++		} else {
++			arvif->pairwise_key_done = false;
++		}
++	}
++
++out:
++	if (ret) {
++		/* In case of failure userspace may not do DISABLE_KEY
++		 * but triggers re-connection directly, so manually reset
++		 * status here.
++		 */
++		arvif->group_key_valid = false;
++		arvif->pairwise_key_done = false;
++	}
++
++	return ret;
++}
++
++static int ath12k_clear_peer_keys(struct ath12k_link_vif *arvif,
++				  const u8 *addr)
++{
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_base *ab = ar->ab;
++	struct ath12k_dp_link_peer *peer;
++	int first_errno = 0;
++	int ret;
++	int i, len;
++	u32 flags = 0;
++	struct ath12k_dp *dp = ath12k_ab_to_dp(ab);
++	struct ieee80211_key_conf *keys[WMI_MAX_KEY_INDEX + 1] = {};
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	spin_lock_bh(&dp->dp_lock);
++	peer = ath12k_dp_link_peer_find_by_vdev_and_addr(dp, arvif->vdev_id, addr);
++	if (!peer || !peer->dp_peer) {
++		spin_unlock_bh(&dp->dp_lock);
++		return -ENOENT;
++	}
++
++	len = ARRAY_SIZE(peer->dp_peer->keys);
++	for (i = 0; i < len; i++) {
++		if (!peer->dp_peer->keys[i])
++			continue;
++
++		keys[i] = peer->dp_peer->keys[i];
++		peer->dp_peer->keys[i] = NULL;
++	}
++
++	spin_unlock_bh(&dp->dp_lock);
++
++	for (i = 0; i < len; i++) {
++		if (!keys[i])
++			continue;
++
++		/* key flags are not required to delete the key */
++		ret = ath12k_install_key(arvif, keys[i],
++					 DISABLE_KEY, addr, flags);
++		if (ret < 0 && first_errno == 0)
++			first_errno = ret;
++
++		if (ret < 0)
++			ath12k_warn(ab, "failed to remove peer key %d: %d\n",
++				    i, ret);
++	}
++
++	return first_errno;
++}
++
++static int ath12k_mac_set_key(struct ath12k *ar, enum set_key_cmd cmd,
++			      struct ath12k_link_vif *arvif,
++			      struct ath12k_link_sta *arsta,
++			      struct ieee80211_key_conf *key)
++{
++	struct ieee80211_sta *sta = NULL;
++	struct ath12k_base *ab = ar->ab;
++	struct ath12k_dp_link_peer *peer;
++	struct ath12k_sta *ahsta;
++	const u8 *peer_addr;
++	int ret;
++	u32 flags = 0;
++	struct ath12k_dp *dp = ath12k_ab_to_dp(ab);
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (arsta)
++		sta = ath12k_ahsta_to_sta(arsta->ahsta);
++
++	if (test_bit(ATH12K_FLAG_HW_CRYPTO_DISABLED, &ab->dev_flags))
++		return 1;
++
++	if (sta)
++		peer_addr = arsta->addr;
++	else
++		peer_addr = arvif->bssid;
++
++	key->hw_key_idx = key->keyidx;
++
++	/* the peer should not disappear in mid-way (unless FW goes awry) since
++	 * we already hold wiphy lock. we just make sure its there now.
++	 */
++	spin_lock_bh(&dp->dp_lock);
++	peer = ath12k_dp_link_peer_find_by_vdev_and_addr(dp, arvif->vdev_id,
++							 peer_addr);
++	if (!peer || !peer->dp_peer) {
++		spin_unlock_bh(&dp->dp_lock);
++
++		if (cmd == SET_KEY) {
++			ath12k_warn(ab, "cannot install key for non-existent peer %pM\n",
++				    peer_addr);
++			return -EOPNOTSUPP;
++		}
++
++		/* if the peer doesn't exist there is no key to disable
++		 * anymore
++		 */
++		return 0;
++	}
++
++	spin_unlock_bh(&dp->dp_lock);
++
++	if (key->flags & IEEE80211_KEY_FLAG_PAIRWISE)
++		flags = WMI_KEY_PAIRWISE;
++	else
++		flags = WMI_KEY_GROUP;
++
++	ret = ath12k_install_key(arvif, key, cmd, peer_addr, flags);
++	if (ret) {
++		ath12k_warn(ab, "ath12k_install_key failed (%d)\n", ret);
++		return ret;
++	}
++
++	ret = ath12k_dp_rx_peer_pn_replay_config(arvif, peer_addr, cmd, key);
++	if (ret) {
++		ath12k_warn(ab, "failed to offload PN replay detection %d\n", ret);
++		return ret;
++	}
++
++	spin_lock_bh(&dp->dp_lock);
++	peer = ath12k_dp_link_peer_find_by_vdev_and_addr(dp, arvif->vdev_id,
++							 peer_addr);
++	if (peer && peer->dp_peer && cmd == SET_KEY) {
++		peer->dp_peer->keys[key->keyidx] = key;
++		if (key->flags & IEEE80211_KEY_FLAG_PAIRWISE) {
++			peer->dp_peer->ucast_keyidx = key->keyidx;
++			peer->dp_peer->sec_type =
++					ath12k_dp_tx_get_encrypt_type(key->cipher);
++		} else {
++			peer->dp_peer->mcast_keyidx = key->keyidx;
++			peer->dp_peer->sec_type_grp =
++					ath12k_dp_tx_get_encrypt_type(key->cipher);
++		}
++	} else if (peer && peer->dp_peer && cmd == DISABLE_KEY) {
++		peer->dp_peer->keys[key->keyidx] = NULL;
++		if (key->flags & IEEE80211_KEY_FLAG_PAIRWISE)
++			peer->dp_peer->ucast_keyidx = 0;
++		else
++			peer->dp_peer->mcast_keyidx = 0;
++	} else if (!peer)
++		/* impossible unless FW goes crazy */
++		ath12k_warn(ab, "peer %pM disappeared!\n", peer_addr);
++
++	if (sta) {
++		ahsta = ath12k_sta_to_ahsta(sta);
++
++		switch (key->cipher) {
++		case WLAN_CIPHER_SUITE_TKIP:
++		case WLAN_CIPHER_SUITE_CCMP:
++		case WLAN_CIPHER_SUITE_CCMP_256:
++		case WLAN_CIPHER_SUITE_GCMP:
++		case WLAN_CIPHER_SUITE_GCMP_256:
++			if (cmd == SET_KEY)
++				ahsta->pn_type = HAL_PN_TYPE_WPA;
++			else
++				ahsta->pn_type = HAL_PN_TYPE_NONE;
++			break;
++		default:
++			ahsta->pn_type = HAL_PN_TYPE_NONE;
++			break;
++		}
++	}
++
++	spin_unlock_bh(&dp->dp_lock);
++
++	return 0;
++}
++
++static int ath12k_mac_update_key_cache(struct ath12k_vif_cache *cache,
++				       enum set_key_cmd cmd,
++				       struct ieee80211_sta *sta,
++				       struct ieee80211_key_conf *key)
++{
++	struct ath12k_key_conf *key_conf, *tmp;
++
++	list_for_each_entry_safe(key_conf, tmp, &cache->key_conf.list, list) {
++		if (key_conf->key != key)
++			continue;
++
++		/* If SET key entry is already present in cache, nothing to do,
++		 * just return
++		 */
++		if (cmd == SET_KEY)
++			return 0;
++
++		/* DEL key for an old SET key which driver hasn't flushed yet.
++		 */
++		list_del(&key_conf->list);
++		kfree(key_conf);
++	}
++
++	if (cmd == SET_KEY) {
++		key_conf = kzalloc_obj(*key_conf);
++
++		if (!key_conf)
++			return -ENOMEM;
++
++		key_conf->cmd = cmd;
++		key_conf->sta = sta;
++		key_conf->key = key;
++		list_add_tail(&key_conf->list,
++			      &cache->key_conf.list);
++	}
++
++	return 0;
++}
++
++int ath12k_mac_op_set_key(struct ieee80211_hw *hw, enum set_key_cmd cmd,
++			  struct ieee80211_vif *vif, struct ieee80211_sta *sta,
++			  struct ieee80211_key_conf *key)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_link_vif *arvif;
++	struct ath12k_link_sta *arsta = NULL;
++	struct ath12k_vif_cache *cache;
++	struct ath12k_sta *ahsta;
++	unsigned long links;
++	u8 link_id;
++	int ret;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	/* IGTK needs to be done in host software */
++	if (key->keyidx == 4 || key->keyidx == 5)
++		return 1;
++
++	if (key->keyidx > WMI_MAX_KEY_INDEX)
++		return -ENOSPC;
++
++	if (sta) {
++		ahsta = ath12k_sta_to_ahsta(sta);
++
++		/* For an ML STA Pairwise key is same for all associated link Stations,
++		 * hence do set key for all link STAs which are active.
++		 */
++		if (sta->mlo) {
++			links = ahsta->links_map;
++			for_each_set_bit(link_id, &links, IEEE80211_MLD_MAX_NUM_LINKS) {
++				arvif = wiphy_dereference(hw->wiphy,
++							  ahvif->link[link_id]);
++				arsta = wiphy_dereference(hw->wiphy,
++							  ahsta->link[link_id]);
++
++				if (WARN_ON(!arvif || !arsta))
++					/* arvif and arsta are expected to be valid when
++					 * STA is present.
++					 */
++					continue;
++
++				ret = ath12k_mac_set_key(arvif->ar, cmd, arvif,
++							 arsta, key);
++				if (ret)
++					break;
++			}
++
++			return 0;
++		}
++
++		arsta = &ahsta->deflink;
++		arvif = arsta->arvif;
++		if (WARN_ON(!arvif))
++			return -EINVAL;
++
++		ret = ath12k_mac_set_key(arvif->ar, cmd, arvif, arsta, key);
++		if (ret)
++			return ret;
++
++		return 0;
++	}
++
++	if (key->link_id >= 0 && key->link_id < IEEE80211_MLD_MAX_NUM_LINKS) {
++		link_id = key->link_id;
++		arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++	} else {
++		link_id = 0;
++		arvif = &ahvif->deflink;
++	}
++
++	if (!arvif || !arvif->is_created) {
++		cache = ath12k_ahvif_get_link_cache(ahvif, link_id);
++		if (!cache)
++			return -ENOSPC;
++
++		ret = ath12k_mac_update_key_cache(cache, cmd, sta, key);
++		if (ret)
++			return ret;
++
++		return 0;
++	}
++
++	ret = ath12k_mac_set_key(arvif->ar, cmd, arvif, NULL, key);
++	if (ret)
++		return ret;
++
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_set_key);
++
++static int
++ath12k_mac_bitrate_mask_num_vht_rates(struct ath12k *ar,
++				      enum nl80211_band band,
++				      const struct cfg80211_bitrate_mask *mask)
++{
++	int num_rates = 0;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].vht_mcs); i++)
++		num_rates += hweight16(mask->control[band].vht_mcs[i]);
++
++	return num_rates;
++}
++
++static int
++ath12k_mac_bitrate_mask_num_he_rates(struct ath12k *ar,
++				     enum nl80211_band band,
++				     const struct cfg80211_bitrate_mask *mask)
++{
++	int num_rates = 0;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].he_mcs); i++)
++		num_rates += hweight16(mask->control[band].he_mcs[i]);
++
++	return num_rates;
++}
++
++static int
++ath12k_mac_bitrate_mask_num_eht_rates(struct ath12k *ar,
++				      enum nl80211_band band,
++				      const struct cfg80211_bitrate_mask *mask)
++{
++	int num_rates = 0;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].eht_mcs); i++)
++		num_rates += hweight16(mask->control[band].eht_mcs[i]);
++
++	return num_rates;
++}
++
++static int
++ath12k_mac_set_peer_vht_fixed_rate(struct ath12k_link_vif *arvif,
++				   struct ath12k_link_sta *arsta,
++				   const struct cfg80211_bitrate_mask *mask,
++				   enum nl80211_band band)
++{
++	struct ath12k *ar = arvif->ar;
++	u8 vht_rate, nss;
++	u32 rate_code;
++	int ret, i;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	nss = 0;
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].vht_mcs); i++) {
++		if (hweight16(mask->control[band].vht_mcs[i]) == 1) {
++			nss = i + 1;
++			vht_rate = ffs(mask->control[band].vht_mcs[i]) - 1;
++		}
++	}
++
++	if (!nss) {
++		ath12k_warn(ar->ab, "No single VHT Fixed rate found to set for %pM",
++			    arsta->addr);
++		return -EINVAL;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "Setting Fixed VHT Rate for peer %pM. Device will not switch to any other selected rates",
++		   arsta->addr);
++
++	rate_code = ATH12K_HW_RATE_CODE(vht_rate, nss - 1,
++					WMI_RATE_PREAMBLE_VHT);
++	ret = ath12k_wmi_set_peer_param(ar, arsta->addr,
++					arvif->vdev_id,
++					WMI_PEER_PARAM_FIXED_RATE,
++					rate_code);
++	if (ret)
++		ath12k_warn(ar->ab,
++			    "failed to update STA %pM Fixed Rate %d: %d\n",
++			     arsta->addr, rate_code, ret);
++
++	return ret;
++}
++
++static int
++ath12k_mac_set_peer_he_fixed_rate(struct ath12k_link_vif *arvif,
++				  struct ath12k_link_sta *arsta,
++				  const struct cfg80211_bitrate_mask *mask,
++				  enum nl80211_band band)
++{
++	struct ath12k *ar = arvif->ar;
++	u8 he_rate, nss;
++	u32 rate_code;
++	int ret, i;
++	struct ath12k_sta *ahsta = arsta->ahsta;
++	struct ieee80211_sta *sta;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	sta = ath12k_ahsta_to_sta(ahsta);
++	nss = 0;
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].he_mcs); i++) {
++		if (hweight16(mask->control[band].he_mcs[i]) == 1) {
++			nss = i + 1;
++			he_rate = ffs(mask->control[band].he_mcs[i]) - 1;
++		}
++	}
++
++	if (!nss) {
++		ath12k_warn(ar->ab, "No single HE Fixed rate found to set for %pM",
++			    arsta->addr);
++		return -EINVAL;
++	}
++
++	/* Avoid updating invalid nss as fixed rate*/
++	if (nss > sta->deflink.rx_nss)
++		return -EINVAL;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "Setting Fixed HE Rate for peer %pM. Device will not switch to any other selected rates",
++		   arsta->addr);
++
++	rate_code = ATH12K_HW_RATE_CODE(he_rate, nss - 1,
++					WMI_RATE_PREAMBLE_HE);
++
++	ret = ath12k_wmi_set_peer_param(ar, arsta->addr,
++					arvif->vdev_id,
++					WMI_PEER_PARAM_FIXED_RATE,
++					rate_code);
++	if (ret)
++		ath12k_warn(ar->ab,
++			    "failed to update STA %pM Fixed Rate %d: %d\n",
++			    arsta->addr, rate_code, ret);
++
++	return ret;
++}
++
++static int
++ath12k_mac_set_peer_eht_fixed_rate(struct ath12k_link_vif *arvif,
++				   struct ath12k_link_sta *arsta,
++				   const struct cfg80211_bitrate_mask *mask,
++				   enum nl80211_band band)
++{
++	struct ath12k_sta *ahsta = arsta->ahsta;
++	struct ath12k *ar = arvif->ar;
++	struct ieee80211_sta *sta;
++	struct ieee80211_link_sta *link_sta;
++	u8 eht_rate, nss = 0;
++	u32 rate_code;
++	int ret, i;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	sta = ath12k_ahsta_to_sta(ahsta);
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].eht_mcs); i++) {
++		if (hweight16(mask->control[band].eht_mcs[i]) == 1) {
++			nss = i + 1;
++			eht_rate = ffs(mask->control[band].eht_mcs[i]) - 1;
++		}
++	}
++
++	if (!nss) {
++		ath12k_warn(ar->ab, "No single EHT Fixed rate found to set for %pM\n",
++			    arsta->addr);
++		return -EINVAL;
++	}
++
++	/* Avoid updating invalid nss as fixed rate*/
++	link_sta = ath12k_mac_get_link_sta(arsta);
++	if (!link_sta || nss > link_sta->rx_nss) {
++		ath12k_warn(ar->ab,
++			    "unable to access link sta for sta %pM link %u or fixed nss of %u is not supported by sta\n",
++			    sta->addr, arsta->link_id, nss);
++		return -EINVAL;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "Setting Fixed EHT Rate for peer %pM. Device will not switch to any other selected rates\n",
++		   arsta->addr);
++
++	rate_code = ATH12K_HW_RATE_CODE(eht_rate, nss - 1,
++					WMI_RATE_PREAMBLE_EHT);
++
++	ret = ath12k_wmi_set_peer_param(ar, arsta->addr,
++					arvif->vdev_id,
++					WMI_PEER_PARAM_FIXED_RATE,
++					rate_code);
++	if (ret)
++		ath12k_warn(ar->ab,
++			    "failed to update STA %pM Fixed Rate %d: %d\n",
++			    arsta->addr, rate_code, ret);
++
++	return ret;
++}
++
++static int ath12k_mac_station_assoc(struct ath12k *ar,
++				    struct ath12k_link_vif *arvif,
++				    struct ath12k_link_sta *arsta,
++				    bool reassoc)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct ieee80211_link_sta *link_sta;
++	int ret;
++	struct cfg80211_chan_def def;
++	enum nl80211_band band;
++	struct cfg80211_bitrate_mask *mask;
++	u8 num_vht_rates, num_he_rates, num_eht_rates;
++	u8 link_id = arvif->link_id;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)))
++		return -EPERM;
++
++	if (WARN_ON(!rcu_access_pointer(sta->link[link_id])))
++		return -EINVAL;
++
++	band = def.chan->band;
++	mask = &arvif->bitrate_mask;
++
++	struct ath12k_wmi_peer_assoc_arg *peer_arg __free(kfree) =
++		kzalloc_obj(*peer_arg);
++	if (!peer_arg)
++		return -ENOMEM;
++
++	ath12k_peer_assoc_prepare(ar, arvif, arsta, peer_arg, reassoc);
++
++	if (peer_arg->peer_nss < 1) {
++		ath12k_warn(ar->ab,
++			    "invalid peer NSS %d\n", peer_arg->peer_nss);
++		return -EINVAL;
++	}
++
++	peer_arg->is_assoc = true;
++	ret = ath12k_wmi_send_peer_assoc_cmd(ar, peer_arg);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to run peer assoc for STA %pM vdev %i: %d\n",
++			    arsta->addr, arvif->vdev_id, ret);
++		return ret;
++	}
++
++	if (!wait_for_completion_timeout(&ar->peer_assoc_done, 1 * HZ)) {
++		ath12k_warn(ar->ab, "failed to get peer assoc conf event for %pM vdev %i\n",
++			    arsta->addr, arvif->vdev_id);
++		return -ETIMEDOUT;
++	}
++
++	num_vht_rates = ath12k_mac_bitrate_mask_num_vht_rates(ar, band, mask);
++	num_he_rates = ath12k_mac_bitrate_mask_num_he_rates(ar, band, mask);
++	num_eht_rates = ath12k_mac_bitrate_mask_num_eht_rates(ar, band, mask);
++
++	/* If single VHT/HE/EHT rate is configured (by set_bitrate_mask()),
++	 * peer_assoc will disable VHT/HE/EHT. This is now enabled by a peer
++	 * specific fixed param.
++	 * Note that all other rates and NSS will be disabled for this peer.
++	 */
++	link_sta = ath12k_mac_get_link_sta(arsta);
++	if (!link_sta) {
++		ath12k_warn(ar->ab, "unable to access link sta in station assoc\n");
++		return -EINVAL;
++	}
++
++	spin_lock_bh(&ar->data_lock);
++	arsta->bw = ath12k_mac_ieee80211_sta_bw_to_wmi(ar, link_sta);
++	arsta->bw_prev = link_sta->bandwidth;
++	spin_unlock_bh(&ar->data_lock);
++
++	if (link_sta->vht_cap.vht_supported && num_vht_rates == 1) {
++		ret = ath12k_mac_set_peer_vht_fixed_rate(arvif, arsta, mask, band);
++	} else if (link_sta->he_cap.has_he && num_he_rates == 1) {
++		ret = ath12k_mac_set_peer_he_fixed_rate(arvif, arsta, mask, band);
++		if (ret)
++			return ret;
++	} else if (link_sta->eht_cap.has_eht && num_eht_rates == 1) {
++		ret = ath12k_mac_set_peer_eht_fixed_rate(arvif, arsta, mask, band);
++		if (ret)
++			return ret;
++	}
++
++	/* Re-assoc is run only to update supported rates for given station. It
++	 * doesn't make much sense to reconfigure the peer completely.
++	 */
++	if (reassoc)
++		return 0;
++
++	ret = ath12k_setup_peer_smps(ar, arvif, arsta->addr,
++				     &link_sta->ht_cap, &link_sta->he_6ghz_capa);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to setup peer SMPS for vdev %d: %d\n",
++			    arvif->vdev_id, ret);
++		return ret;
++	}
++
++	if (!sta->wme) {
++		arvif->num_legacy_stations++;
++		ret = ath12k_recalc_rtscts_prot(arvif);
++		if (ret)
++			return ret;
++	}
++
++	if (sta->wme && sta->uapsd_queues) {
++		ret = ath12k_peer_assoc_qos_ap(ar, arvif, arsta);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to set qos params for STA %pM for vdev %i: %d\n",
++				    arsta->addr, arvif->vdev_id, ret);
++			return ret;
++		}
++	}
++
++	return 0;
++}
++
++static int ath12k_mac_station_disassoc(struct ath12k *ar,
++				       struct ath12k_link_vif *arvif,
++				       struct ath12k_link_sta *arsta)
++{
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (!sta->wme) {
++		arvif->num_legacy_stations--;
++		return ath12k_recalc_rtscts_prot(arvif);
++	}
++
++	return 0;
++}
++
++static void ath12k_sta_rc_update_wk(struct wiphy *wiphy, struct wiphy_work *wk)
++{
++	struct ieee80211_link_sta *link_sta;
++	struct ath12k *ar;
++	struct ath12k_link_vif *arvif;
++	struct ieee80211_sta *sta;
++	struct cfg80211_chan_def def;
++	enum nl80211_band band;
++	const u8 *ht_mcs_mask;
++	const u16 *vht_mcs_mask;
++	const u16 *he_mcs_mask;
++	const u16 *eht_mcs_mask;
++	u32 changed, bw, nss, mac_nss, smps, bw_prev;
++	int err, num_vht_rates, num_he_rates, num_eht_rates;
++	const struct cfg80211_bitrate_mask *mask;
++	enum wmi_phy_mode peer_phymode;
++	struct ath12k_link_sta *arsta;
++	struct ieee80211_vif *vif;
++
++	lockdep_assert_wiphy(wiphy);
++
++	arsta = container_of(wk, struct ath12k_link_sta, update_wk);
++	sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	arvif = arsta->arvif;
++	vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	ar = arvif->ar;
++
++	if (WARN_ON(ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)))
++		return;
++
++	band = def.chan->band;
++	ht_mcs_mask = arvif->bitrate_mask.control[band].ht_mcs;
++	vht_mcs_mask = arvif->bitrate_mask.control[band].vht_mcs;
++	he_mcs_mask = arvif->bitrate_mask.control[band].he_mcs;
++	eht_mcs_mask = arvif->bitrate_mask.control[band].eht_mcs;
++
++	spin_lock_bh(&ar->data_lock);
++
++	changed = arsta->changed;
++	arsta->changed = 0;
++
++	bw = arsta->bw;
++	bw_prev = arsta->bw_prev;
++	nss = arsta->nss;
++	smps = arsta->smps;
++
++	spin_unlock_bh(&ar->data_lock);
++
++	nss = max_t(u32, 1, nss);
++	mac_nss = max3(ath12k_mac_max_ht_nss(ht_mcs_mask),
++		       ath12k_mac_max_vht_nss(vht_mcs_mask),
++		       ath12k_mac_max_he_nss(he_mcs_mask));
++	mac_nss = max(mac_nss, ath12k_mac_max_eht_nss(eht_mcs_mask));
++	nss = min(nss, mac_nss);
++
++	struct ath12k_wmi_peer_assoc_arg *peer_arg __free(kfree) =
++					kzalloc_obj(*peer_arg);
++	if (!peer_arg)
++		return;
++
++	if (changed & IEEE80211_RC_BW_CHANGED) {
++		ath12k_peer_assoc_h_phymode(ar, arvif, arsta, peer_arg);
++		peer_phymode = peer_arg->peer_phymode;
++
++		if (bw > bw_prev) {
++			/* Phymode shows maximum supported channel width, if we
++			 * upgrade bandwidth then due to sanity check of firmware,
++			 * we have to send WMI_PEER_PHYMODE followed by
++			 * WMI_PEER_CHWIDTH
++			 */
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac bandwidth upgrade for sta %pM new %d old %d\n",
++				   arsta->addr, bw, bw_prev);
++			err = ath12k_wmi_set_peer_param(ar, arsta->addr,
++							arvif->vdev_id, WMI_PEER_PHYMODE,
++							peer_phymode);
++			if (err) {
++				ath12k_warn(ar->ab, "failed to update STA %pM to peer phymode %d: %d\n",
++					    arsta->addr, peer_phymode, err);
++				return;
++			}
++			err = ath12k_wmi_set_peer_param(ar, arsta->addr,
++							arvif->vdev_id, WMI_PEER_CHWIDTH,
++							bw);
++			if (err)
++				ath12k_warn(ar->ab, "failed to update STA %pM to peer bandwidth %d: %d\n",
++					    arsta->addr, bw, err);
++		} else {
++			/* When we downgrade bandwidth this will conflict with phymode
++			 * and cause to trigger firmware crash. In this case we send
++			 * WMI_PEER_CHWIDTH followed by WMI_PEER_PHYMODE
++			 */
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac bandwidth downgrade for sta %pM new %d old %d\n",
++				   arsta->addr, bw, bw_prev);
++			err = ath12k_wmi_set_peer_param(ar, arsta->addr,
++							arvif->vdev_id, WMI_PEER_CHWIDTH,
++							bw);
++			if (err) {
++				ath12k_warn(ar->ab, "failed to update STA %pM peer to bandwidth %d: %d\n",
++					    arsta->addr, bw, err);
++				return;
++			}
++			err = ath12k_wmi_set_peer_param(ar, arsta->addr,
++							arvif->vdev_id, WMI_PEER_PHYMODE,
++							peer_phymode);
++			if (err)
++				ath12k_warn(ar->ab, "failed to update STA %pM to peer phymode %d: %d\n",
++					    arsta->addr, peer_phymode, err);
++		}
++	}
++
++	if (changed & IEEE80211_RC_NSS_CHANGED) {
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac update sta %pM nss %d\n",
++			   arsta->addr, nss);
++
++		err = ath12k_wmi_set_peer_param(ar, arsta->addr, arvif->vdev_id,
++						WMI_PEER_NSS, nss);
++		if (err)
++			ath12k_warn(ar->ab, "failed to update STA %pM nss %d: %d\n",
++				    arsta->addr, nss, err);
++	}
++
++	if (changed & IEEE80211_RC_SMPS_CHANGED) {
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac update sta %pM smps %d\n",
++			   arsta->addr, smps);
++
++		err = ath12k_wmi_set_peer_param(ar, arsta->addr, arvif->vdev_id,
++						WMI_PEER_MIMO_PS_STATE, smps);
++		if (err)
++			ath12k_warn(ar->ab, "failed to update STA %pM smps %d: %d\n",
++				    arsta->addr, smps, err);
++	}
++
++	if (changed & IEEE80211_RC_SUPP_RATES_CHANGED) {
++		mask = &arvif->bitrate_mask;
++		num_vht_rates = ath12k_mac_bitrate_mask_num_vht_rates(ar, band,
++								      mask);
++		num_he_rates = ath12k_mac_bitrate_mask_num_he_rates(ar, band,
++								    mask);
++		num_eht_rates = ath12k_mac_bitrate_mask_num_eht_rates(ar, band,
++								      mask);
++
++		/* Peer_assoc_prepare will reject vht rates in
++		 * bitrate_mask if its not available in range format and
++		 * sets vht tx_rateset as unsupported. So multiple VHT MCS
++		 * setting(eg. MCS 4,5,6) per peer is not supported here.
++		 * But, Single rate in VHT mask can be set as per-peer
++		 * fixed rate. But even if any HT rates are configured in
++		 * the bitrate mask, device will not switch to those rates
++		 * when per-peer Fixed rate is set.
++		 * TODO: Check RATEMASK_CMDID to support auto rates selection
++		 * across HT/VHT and for multiple VHT MCS support.
++		 */
++		link_sta = ath12k_mac_get_link_sta(arsta);
++		if (!link_sta) {
++			ath12k_warn(ar->ab, "unable to access link sta in peer assoc he for sta %pM link %u\n",
++				    sta->addr, arsta->link_id);
++			return;
++		}
++
++		if (link_sta->vht_cap.vht_supported && num_vht_rates == 1) {
++			ath12k_mac_set_peer_vht_fixed_rate(arvif, arsta, mask,
++							   band);
++		} else if (link_sta->he_cap.has_he && num_he_rates == 1) {
++			ath12k_mac_set_peer_he_fixed_rate(arvif, arsta, mask, band);
++		} else if (link_sta->eht_cap.has_eht && num_eht_rates == 1) {
++			err = ath12k_mac_set_peer_eht_fixed_rate(arvif, arsta,
++								 mask, band);
++			if (err) {
++				ath12k_warn(ar->ab,
++					    "failed to set peer EHT fixed rate for STA %pM ret %d\n",
++					    arsta->addr, err);
++				return;
++			}
++		} else {
++			/* If the peer is non-VHT/HE/EHT or no fixed VHT/HE/EHT
++			 * rate is provided in the new bitrate mask we set the
++			 * other rates using peer_assoc command. Also clear
++			 * the peer fixed rate settings as it has higher proprity
++			 * than peer assoc
++			 */
++			err = ath12k_wmi_set_peer_param(ar, arsta->addr,
++							arvif->vdev_id,
++							WMI_PEER_PARAM_FIXED_RATE,
++							WMI_FIXED_RATE_NONE);
++			if (err)
++				ath12k_warn(ar->ab,
++					    "failed to disable peer fixed rate for STA %pM ret %d\n",
++					    arsta->addr, err);
++
++			ath12k_peer_assoc_prepare(ar, arvif, arsta,
++						  peer_arg, true);
++
++			peer_arg->is_assoc = false;
++			err = ath12k_wmi_send_peer_assoc_cmd(ar, peer_arg);
++			if (err)
++				ath12k_warn(ar->ab, "failed to run peer assoc for STA %pM vdev %i: %d\n",
++					    arsta->addr, arvif->vdev_id, err);
++
++			if (!wait_for_completion_timeout(&ar->peer_assoc_done, 1 * HZ))
++				ath12k_warn(ar->ab, "failed to get peer assoc conf event for %pM vdev %i\n",
++					    arsta->addr, arvif->vdev_id);
++		}
++	}
++}
++
++static void ath12k_mac_free_unassign_link_sta(struct ath12k_hw *ah,
++					      struct ath12k_sta *ahsta,
++					      u8 link_id)
++{
++	struct ath12k_link_sta *arsta;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	if (WARN_ON(link_id >= IEEE80211_MLD_MAX_NUM_LINKS))
++		return;
++
++	arsta = wiphy_dereference(ah->hw->wiphy, ahsta->link[link_id]);
++	if (WARN_ON(!arsta))
++		return;
++
++	ahsta->links_map &= ~BIT(link_id);
++	ahsta->free_logical_link_idx_map |= BIT(arsta->link_idx);
++
++	rcu_assign_pointer(ahsta->link[link_id], NULL);
++	synchronize_rcu();
++
++	if (arsta == &ahsta->deflink) {
++		arsta->link_id = ATH12K_INVALID_LINK_ID;
++		arsta->ahsta = NULL;
++		arsta->arvif = NULL;
++		return;
++	}
++
++	kfree(arsta);
++}
++
++static int ath12k_mac_inc_num_stations(struct ath12k_link_vif *arvif,
++				       struct ath12k_link_sta *arsta)
++{
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct ath12k *ar = arvif->ar;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (arvif->ahvif->vdev_type == WMI_VDEV_TYPE_STA && !sta->tdls)
++		return 0;
++
++	if (ar->num_stations >= ar->max_num_stations)
++		return -ENOBUFS;
++
++	ar->num_stations++;
++	arvif->num_stations++;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac station %pM connected to vdev %u num_stations %u\n",
++		   arsta->addr, arvif->vdev_id, arvif->num_stations);
++
++	return 0;
++}
++
++static void ath12k_mac_dec_num_stations(struct ath12k_link_vif *arvif,
++					struct ath12k_link_sta *arsta)
++{
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct ath12k *ar = arvif->ar;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (arvif->ahvif->vdev_type == WMI_VDEV_TYPE_STA && !sta->tdls)
++		return;
++
++	ar->num_stations--;
++
++	if (arvif->num_stations) {
++		arvif->num_stations--;
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++			   "mac station %pM disconnected from vdev %u num_stations %u\n",
++			   arsta->addr, arvif->vdev_id, arvif->num_stations);
++	} else {
++		ath12k_warn(ar->ab,
++			    "mac station %pM disconnect for vdev %u without any connected station\n",
++			    arsta->addr, arvif->vdev_id);
++	}
++}
++
++static void ath12k_mac_station_post_remove(struct ath12k *ar,
++					   struct ath12k_link_vif *arvif,
++					   struct ath12k_link_sta *arsta)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct ath12k_dp_link_peer *peer;
++	struct ath12k_dp *dp = ath12k_ab_to_dp(ar->ab);
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	ath12k_mac_dec_num_stations(arvif, arsta);
++
++	spin_lock_bh(&dp->dp_lock);
++
++	peer = ath12k_dp_link_peer_find_by_vdev_and_addr(dp, arvif->vdev_id,
++							 arsta->addr);
++	if (peer && peer->sta == sta) {
++		ath12k_warn(ar->ab, "Found peer entry %pM n vdev %i after it was supposedly removed\n",
++			    vif->addr, arvif->vdev_id);
++		peer->sta = NULL;
++
++		ath12k_dp_link_peer_free(peer);
++		ar->num_peers--;
++	}
++
++	spin_unlock_bh(&dp->dp_lock);
++}
++
++static int ath12k_mac_station_unauthorize(struct ath12k *ar,
++					  struct ath12k_link_vif *arvif,
++					  struct ath12k_link_sta *arsta)
++{
++	struct ath12k_dp_link_peer *peer;
++	int ret;
++	struct ath12k_dp *dp = ath12k_ab_to_dp(ar->ab);
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	spin_lock_bh(&dp->dp_lock);
++
++	peer = ath12k_dp_link_peer_find_by_vdev_and_addr(dp, arvif->vdev_id,
++							 arsta->addr);
++	if (peer)
++		peer->is_authorized = false;
++
++	spin_unlock_bh(&dp->dp_lock);
++
++	/* Driver must clear the keys during the state change from
++	 * IEEE80211_STA_AUTHORIZED to IEEE80211_STA_ASSOC, since after
++	 * returning from here, mac80211 is going to delete the keys
++	 * in __sta_info_destroy_part2(). This will ensure that the driver does
++	 * not retain stale key references after mac80211 deletes the keys.
++	 */
++	ret = ath12k_clear_peer_keys(arvif, arsta->addr);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to clear all peer keys for vdev %i: %d\n",
++			    arvif->vdev_id, ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static int ath12k_mac_station_authorize(struct ath12k *ar,
++					struct ath12k_link_vif *arvif,
++					struct ath12k_link_sta *arsta)
++{
++	struct ath12k_dp_link_peer *peer;
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	int ret;
++	struct ath12k_dp *dp = ath12k_ab_to_dp(ar->ab);
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	spin_lock_bh(&dp->dp_lock);
++
++	peer = ath12k_dp_link_peer_find_by_vdev_and_addr(dp, arvif->vdev_id,
++							 arsta->addr);
++	if (peer)
++		peer->is_authorized = true;
++
++	spin_unlock_bh(&dp->dp_lock);
++
++	if (vif->type == NL80211_IFTYPE_STATION && arvif->is_up) {
++		ret = ath12k_wmi_set_peer_param(ar, arsta->addr,
++						arvif->vdev_id,
++						WMI_PEER_AUTHORIZE,
++						1);
++		if (ret) {
++			ath12k_warn(ar->ab, "Unable to authorize peer %pM vdev %d: %d\n",
++				    arsta->addr, arvif->vdev_id, ret);
++			return ret;
++		}
++	}
++
++	return 0;
++}
++
++static int ath12k_mac_station_remove(struct ath12k *ar,
++				     struct ath12k_link_vif *arvif,
++				     struct ath12k_link_sta *arsta)
++{
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	int ret = 0;
++	struct ath12k_link_sta *temp_arsta;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	wiphy_work_cancel(ar->ah->hw->wiphy, &arsta->update_wk);
++
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_STA) {
++		ath12k_bss_disassoc(ar, arvif);
++		ret = ath12k_mac_vdev_stop(arvif);
++		if (ret)
++			ath12k_warn(ar->ab, "failed to stop vdev %i: %d\n",
++				    arvif->vdev_id, ret);
++	}
++
++	if (sta->mlo)
++		return ret;
++
++	ath12k_dp_peer_cleanup(ar, arvif->vdev_id, arsta->addr);
++
++	ret = ath12k_peer_delete(ar, arvif->vdev_id, arsta->addr);
++	if (ret)
++		ath12k_warn(ar->ab, "Failed to delete peer: %pM for VDEV: %d\n",
++			    arsta->addr, arvif->vdev_id);
++	else
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "Removed peer: %pM for VDEV: %d\n",
++			   arsta->addr, arvif->vdev_id);
++
++	ath12k_mac_station_post_remove(ar, arvif, arsta);
++
++	spin_lock_bh(&ar->ab->base_lock);
++
++	/* To handle roaming and split phy scenario */
++	temp_arsta = ath12k_link_sta_find_by_addr(ar->ab, arsta->addr);
++	if (temp_arsta && temp_arsta->arvif->ar == ar)
++		ath12k_link_sta_rhash_delete(ar->ab, arsta);
++
++	spin_unlock_bh(&ar->ab->base_lock);
++
++	if (sta->valid_links)
++		ath12k_mac_free_unassign_link_sta(ahvif->ah,
++						  arsta->ahsta, arsta->link_id);
++
++	return ret;
++}
++
++static int ath12k_mac_station_add(struct ath12k *ar,
++				  struct ath12k_link_vif *arvif,
++				  struct ath12k_link_sta *arsta)
++{
++	struct ath12k_base *ab = ar->ab;
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(arsta->ahsta);
++	struct ath12k_wmi_peer_create_arg peer_param = {};
++	int ret;
++	struct ath12k_link_sta *temp_arsta;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	ret = ath12k_mac_inc_num_stations(arvif, arsta);
++	if (ret) {
++		ath12k_warn(ab, "refusing to associate station: too many connected already (%d)\n",
++			    ar->max_num_stations);
++		goto exit;
++	}
++
++	spin_lock_bh(&ab->base_lock);
++
++	/*
++	 * In case of Split PHY and roaming scenario, pdev idx
++	 * might differ but both the pdev will share same rhash
++	 * table. In that case update the rhash table if link_sta is
++	 * already present
++	 */
++	temp_arsta = ath12k_link_sta_find_by_addr(ab, arsta->addr);
++	if (temp_arsta && temp_arsta->arvif->ar != ar)
++		ath12k_link_sta_rhash_delete(ab, temp_arsta);
++
++	ret = ath12k_link_sta_rhash_add(ab, arsta);
++	spin_unlock_bh(&ab->base_lock);
++	if (ret) {
++		ath12k_warn(ab, "Failed to add arsta: %pM to hash table, ret: %d",
++			    arsta->addr, ret);
++		goto dec_num_station;
++	}
++
++	peer_param.vdev_id = arvif->vdev_id;
++	peer_param.peer_addr = arsta->addr;
++	peer_param.peer_type = WMI_PEER_TYPE_DEFAULT;
++	peer_param.ml_enabled = sta->mlo;
++
++	ret = ath12k_peer_create(ar, arvif, sta, &peer_param);
++	if (ret) {
++		ath12k_warn(ab, "Failed to add peer: %pM for VDEV: %d\n",
++			    arsta->addr, arvif->vdev_id);
++		goto free_peer;
++	}
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC, "Added peer: %pM for VDEV: %d\n",
++		   arsta->addr, arvif->vdev_id);
++
++	if (ieee80211_vif_is_mesh(vif)) {
++		ret = ath12k_wmi_set_peer_param(ar, arsta->addr,
++						arvif->vdev_id,
++						WMI_PEER_USE_4ADDR, 1);
++		if (ret) {
++			ath12k_warn(ab, "failed to STA %pM 4addr capability: %d\n",
++				    arsta->addr, ret);
++			goto free_peer;
++		}
++	}
++
++	ret = ath12k_dp_peer_setup(ar, arvif->vdev_id, arsta->addr);
++	if (ret) {
++		ath12k_warn(ab, "failed to setup dp for peer %pM on vdev %i (%d)\n",
++			    arsta->addr, arvif->vdev_id, ret);
++		goto free_peer;
++	}
++
++	if (ab->hw_params->vdev_start_delay &&
++	    !arvif->is_started &&
++	    arvif->ahvif->vdev_type != WMI_VDEV_TYPE_AP) {
++		ret = ath12k_start_vdev_delay(ar, arvif);
++		if (ret) {
++			ath12k_warn(ab, "failed to delay vdev start: %d\n", ret);
++			goto free_peer;
++		}
++	}
++
++	return 0;
++
++free_peer:
++	ath12k_peer_delete(ar, arvif->vdev_id, arsta->addr);
++	spin_lock_bh(&ab->base_lock);
++	ath12k_link_sta_rhash_delete(ab, arsta);
++	spin_unlock_bh(&ab->base_lock);
++dec_num_station:
++	ath12k_mac_dec_num_stations(arvif, arsta);
++exit:
++	return ret;
++}
++
++static int ath12k_mac_assign_link_sta(struct ath12k_hw *ah,
++				      struct ath12k_sta *ahsta,
++				      struct ath12k_link_sta *arsta,
++				      struct ath12k_vif *ahvif,
++				      u8 link_id)
++{
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(ahsta);
++	struct ieee80211_link_sta *link_sta;
++	struct ath12k_link_vif *arvif;
++	int link_idx;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	if (!arsta || link_id >= IEEE80211_MLD_MAX_NUM_LINKS)
++		return -EINVAL;
++
++	arvif = wiphy_dereference(ah->hw->wiphy, ahvif->link[link_id]);
++	if (!arvif)
++		return -EINVAL;
++
++	memset(arsta, 0, sizeof(*arsta));
++
++	link_sta = wiphy_dereference(ah->hw->wiphy, sta->link[link_id]);
++	if (!link_sta)
++		return -EINVAL;
++
++	ether_addr_copy(arsta->addr, link_sta->addr);
++
++	if (!ahsta->free_logical_link_idx_map)
++		return -ENOSPC;
++
++	/*
++	 * Allocate a logical link index by selecting the first available bit
++	 * from the free logical index map
++	 */
++	link_idx = __ffs(ahsta->free_logical_link_idx_map);
++	ahsta->free_logical_link_idx_map &= ~BIT(link_idx);
++	arsta->link_idx = link_idx;
++
++	arsta->link_id = link_id;
++	ahsta->links_map |= BIT(arsta->link_id);
++	arsta->arvif = arvif;
++	arsta->ahsta = ahsta;
++	ahsta->ahvif = ahvif;
++
++	wiphy_work_init(&arsta->update_wk, ath12k_sta_rc_update_wk);
++
++	rcu_assign_pointer(ahsta->link[link_id], arsta);
++
++	return 0;
++}
++
++static void ath12k_mac_ml_station_remove(struct ath12k_vif *ahvif,
++					 struct ath12k_sta *ahsta)
++{
++	struct ieee80211_sta *sta = ath12k_ahsta_to_sta(ahsta);
++	struct ath12k_hw *ah = ahvif->ah;
++	struct ath12k_link_vif *arvif;
++	struct ath12k_link_sta *arsta;
++	unsigned long links;
++	struct ath12k *ar;
++	u8 link_id;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	ath12k_peer_mlo_link_peers_delete(ahvif, ahsta);
++
++	/* validate link station removal and clear arsta links */
++	links = ahsta->links_map;
++	for_each_set_bit(link_id, &links, IEEE80211_MLD_MAX_NUM_LINKS) {
++		arvif = wiphy_dereference(ah->hw->wiphy, ahvif->link[link_id]);
++		arsta = wiphy_dereference(ah->hw->wiphy, ahsta->link[link_id]);
++		if (!arvif || !arsta)
++			continue;
++
++		ar = arvif->ar;
++
++		ath12k_mac_station_post_remove(ar, arvif, arsta);
++
++		spin_lock_bh(&ar->ab->base_lock);
++		ath12k_link_sta_rhash_delete(ar->ab, arsta);
++		spin_unlock_bh(&ar->ab->base_lock);
++
++		ath12k_mac_free_unassign_link_sta(ah, ahsta, link_id);
++	}
++
++	if (sta->mlo) {
++		clear_bit(ahsta->ml_peer_id, ah->free_ml_peer_id_map);
++		ahsta->ml_peer_id = ATH12K_MLO_PEER_ID_INVALID;
++	}
++}
++
++static int ath12k_mac_handle_link_sta_state(struct ieee80211_hw *hw,
++					    struct ath12k_link_vif *arvif,
++					    struct ath12k_link_sta *arsta,
++					    enum ieee80211_sta_state old_state,
++					    enum ieee80211_sta_state new_state)
++{
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_bss_conf *link_conf;
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_reg_info *reg_info;
++	struct ath12k_base *ab = ar->ab;
++	int ret = 0;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC, "mac handle link %u sta %pM state %d -> %d\n",
++		   arsta->link_id, arsta->addr, old_state, new_state);
++
++	/* IEEE80211_STA_NONE -> IEEE80211_STA_NOTEXIST: Remove the station
++	 * from driver
++	 */
++	if ((old_state == IEEE80211_STA_NONE &&
++	     new_state == IEEE80211_STA_NOTEXIST)) {
++		ret = ath12k_mac_station_remove(ar, arvif, arsta);
++		if (ret) {
++			ath12k_warn(ab, "Failed to remove station: %pM for VDEV: %d\n",
++				    arsta->addr, arvif->vdev_id);
++			goto exit;
++		}
++	}
++
++	/* IEEE80211_STA_NOTEXIST -> IEEE80211_STA_NONE: Add new station to driver */
++	if (old_state == IEEE80211_STA_NOTEXIST &&
++	    new_state == IEEE80211_STA_NONE) {
++		ret = ath12k_mac_station_add(ar, arvif, arsta);
++		if (ret)
++			ath12k_warn(ab, "Failed to add station: %pM for VDEV: %d\n",
++				    arsta->addr, arvif->vdev_id);
++
++	/* IEEE80211_STA_AUTH -> IEEE80211_STA_ASSOC: Send station assoc command for
++	 * peer associated to AP/Mesh/ADHOC vif type.
++	 */
++	} else if (old_state == IEEE80211_STA_AUTH &&
++		   new_state == IEEE80211_STA_ASSOC &&
++		   (vif->type == NL80211_IFTYPE_AP ||
++		    vif->type == NL80211_IFTYPE_MESH_POINT ||
++		    vif->type == NL80211_IFTYPE_ADHOC)) {
++		ret = ath12k_mac_station_assoc(ar, arvif, arsta, false);
++		if (ret)
++			ath12k_warn(ab, "Failed to associate station: %pM\n",
++				    arsta->addr);
++
++	/* IEEE80211_STA_ASSOC -> IEEE80211_STA_AUTHORIZED: set peer status as
++	 * authorized
++	 */
++	} else if (old_state == IEEE80211_STA_ASSOC &&
++		   new_state == IEEE80211_STA_AUTHORIZED) {
++		ret = ath12k_mac_station_authorize(ar, arvif, arsta);
++		if (ret) {
++			ath12k_warn(ab, "Failed to authorize station: %pM\n",
++				    arsta->addr);
++			goto exit;
++		}
++
++		if (ath12k_wmi_supports_6ghz_cc_ext(ar) &&
++		    arvif->ahvif->vdev_type == WMI_VDEV_TYPE_STA) {
++			link_conf = ath12k_mac_get_link_bss_conf(arvif);
++			reg_info = ab->reg_info[ar->pdev_idx];
++			ath12k_dbg(ab, ATH12K_DBG_MAC, "connection done, update reg rules\n");
++			ath12k_hw_to_ah(hw)->regd_updated = false;
++			ath12k_reg_handle_chan_list(ab, reg_info, arvif->ahvif->vdev_type,
++						    link_conf->power_type);
++		}
++
++	/* IEEE80211_STA_AUTHORIZED -> IEEE80211_STA_ASSOC: station may be in removal,
++	 * deauthorize it.
++	 */
++	} else if (old_state == IEEE80211_STA_AUTHORIZED &&
++		   new_state == IEEE80211_STA_ASSOC) {
++		ath12k_mac_station_unauthorize(ar, arvif, arsta);
++
++	/* IEEE80211_STA_ASSOC -> IEEE80211_STA_AUTH: disassoc peer connected to
++	 * AP/mesh/ADHOC vif type.
++	 */
++	} else if (old_state == IEEE80211_STA_ASSOC &&
++		   new_state == IEEE80211_STA_AUTH &&
++		   (vif->type == NL80211_IFTYPE_AP ||
++		    vif->type == NL80211_IFTYPE_MESH_POINT ||
++		    vif->type == NL80211_IFTYPE_ADHOC)) {
++		ret = ath12k_mac_station_disassoc(ar, arvif, arsta);
++		if (ret)
++			ath12k_warn(ab, "Failed to disassociate station: %pM\n",
++				    arsta->addr);
++	}
++
++exit:
++	return ret;
++}
++
++static bool ath12k_mac_is_freq_on_mac(struct ath12k_hw_mode_freq_range_arg *freq_range,
++				      u32 freq, u8 mac_id)
++{
++	return (freq >= freq_range[mac_id].low_2ghz_freq &&
++		freq <= freq_range[mac_id].high_2ghz_freq) ||
++	       (freq >= freq_range[mac_id].low_5ghz_freq &&
++		freq <= freq_range[mac_id].high_5ghz_freq);
++}
++
++static bool
++ath12k_mac_2_freq_same_mac_in_freq_range(struct ath12k_base *ab,
++					 struct ath12k_hw_mode_freq_range_arg *freq_range,
++					 u32 freq_link1, u32 freq_link2)
++{
++	u8 i;
++
++	for (i = 0; i < MAX_RADIOS; i++) {
++		if (ath12k_mac_is_freq_on_mac(freq_range, freq_link1, i) &&
++		    ath12k_mac_is_freq_on_mac(freq_range, freq_link2, i))
++			return true;
++	}
++
++	return false;
++}
++
++static bool ath12k_mac_is_hw_dbs_capable(struct ath12k_base *ab)
++{
++	return test_bit(WMI_TLV_SERVICE_DUAL_BAND_SIMULTANEOUS_SUPPORT,
++			ab->wmi_ab.svc_map) &&
++	       ab->wmi_ab.hw_mode_info.support_dbs;
++}
++
++static bool ath12k_mac_2_freq_same_mac_in_dbs(struct ath12k_base *ab,
++					      u32 freq_link1, u32 freq_link2)
++{
++	struct ath12k_hw_mode_freq_range_arg *freq_range;
++
++	if (!ath12k_mac_is_hw_dbs_capable(ab))
++		return true;
++
++	freq_range = ab->wmi_ab.hw_mode_info.freq_range_caps[ATH12K_HW_MODE_DBS];
++	return ath12k_mac_2_freq_same_mac_in_freq_range(ab, freq_range,
++							freq_link1, freq_link2);
++}
++
++static bool ath12k_mac_is_hw_sbs_capable(struct ath12k_base *ab)
++{
++	return test_bit(WMI_TLV_SERVICE_DUAL_BAND_SIMULTANEOUS_SUPPORT,
++			ab->wmi_ab.svc_map) &&
++	       ab->wmi_ab.hw_mode_info.support_sbs;
++}
++
++static bool ath12k_mac_2_freq_same_mac_in_sbs(struct ath12k_base *ab,
++					      u32 freq_link1, u32 freq_link2)
++{
++	struct ath12k_hw_mode_info *info = &ab->wmi_ab.hw_mode_info;
++	struct ath12k_hw_mode_freq_range_arg *sbs_uppr_share;
++	struct ath12k_hw_mode_freq_range_arg *sbs_low_share;
++	struct ath12k_hw_mode_freq_range_arg *sbs_range;
++
++	if (!ath12k_mac_is_hw_sbs_capable(ab))
++		return true;
++
++	if (ab->wmi_ab.sbs_lower_band_end_freq) {
++		sbs_uppr_share = info->freq_range_caps[ATH12K_HW_MODE_SBS_UPPER_SHARE];
++		sbs_low_share = info->freq_range_caps[ATH12K_HW_MODE_SBS_LOWER_SHARE];
++
++		return ath12k_mac_2_freq_same_mac_in_freq_range(ab, sbs_low_share,
++								freq_link1, freq_link2) ||
++		       ath12k_mac_2_freq_same_mac_in_freq_range(ab, sbs_uppr_share,
++								freq_link1, freq_link2);
++	}
++
++	sbs_range = info->freq_range_caps[ATH12K_HW_MODE_SBS];
++	return ath12k_mac_2_freq_same_mac_in_freq_range(ab, sbs_range,
++							freq_link1, freq_link2);
++}
++
++static bool ath12k_mac_freqs_on_same_mac(struct ath12k_base *ab,
++					 u32 freq_link1, u32 freq_link2)
++{
++	return ath12k_mac_2_freq_same_mac_in_dbs(ab, freq_link1, freq_link2) &&
++	       ath12k_mac_2_freq_same_mac_in_sbs(ab, freq_link1, freq_link2);
++}
++
++static int ath12k_mac_mlo_sta_set_link_active(struct ath12k_base *ab,
++					      enum wmi_mlo_link_force_reason reason,
++					      enum wmi_mlo_link_force_mode mode,
++					      u8 *mlo_vdev_id_lst,
++					      u8 num_mlo_vdev,
++					      u8 *mlo_inactive_vdev_lst,
++					      u8 num_mlo_inactive_vdev)
++{
++	struct wmi_mlo_link_set_active_arg param = {};
++	u32 entry_idx, entry_offset, vdev_idx;
++	u8 vdev_id;
++
++	param.reason = reason;
++	param.force_mode = mode;
++
++	for (vdev_idx = 0; vdev_idx < num_mlo_vdev; vdev_idx++) {
++		vdev_id = mlo_vdev_id_lst[vdev_idx];
++		entry_idx = vdev_id / 32;
++		entry_offset = vdev_id % 32;
++		if (entry_idx >= WMI_MLO_LINK_NUM_SZ) {
++			ath12k_warn(ab, "Invalid entry_idx %d num_mlo_vdev %d vdev %d",
++				    entry_idx, num_mlo_vdev, vdev_id);
++			return -EINVAL;
++		}
++		param.vdev_bitmap[entry_idx] |= 1 << entry_offset;
++		/* update entry number if entry index changed */
++		if (param.num_vdev_bitmap < entry_idx + 1)
++			param.num_vdev_bitmap = entry_idx + 1;
++	}
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC,
++		   "num_vdev_bitmap %d vdev_bitmap[0] = 0x%x, vdev_bitmap[1] = 0x%x",
++		   param.num_vdev_bitmap, param.vdev_bitmap[0], param.vdev_bitmap[1]);
++
++	if (mode == WMI_MLO_LINK_FORCE_MODE_ACTIVE_INACTIVE) {
++		for (vdev_idx = 0; vdev_idx < num_mlo_inactive_vdev; vdev_idx++) {
++			vdev_id = mlo_inactive_vdev_lst[vdev_idx];
++			entry_idx = vdev_id / 32;
++			entry_offset = vdev_id % 32;
++			if (entry_idx >= WMI_MLO_LINK_NUM_SZ) {
++				ath12k_warn(ab, "Invalid entry_idx %d num_mlo_vdev %d vdev %d",
++					    entry_idx, num_mlo_inactive_vdev, vdev_id);
++				return -EINVAL;
++			}
++			param.inactive_vdev_bitmap[entry_idx] |= 1 << entry_offset;
++			/* update entry number if entry index changed */
++			if (param.num_inactive_vdev_bitmap < entry_idx + 1)
++				param.num_inactive_vdev_bitmap = entry_idx + 1;
++		}
++
++		ath12k_dbg(ab, ATH12K_DBG_MAC,
++			   "num_vdev_bitmap %d inactive_vdev_bitmap[0] = 0x%x, inactive_vdev_bitmap[1] = 0x%x",
++			   param.num_inactive_vdev_bitmap,
++			   param.inactive_vdev_bitmap[0],
++			   param.inactive_vdev_bitmap[1]);
++	}
++
++	if (mode == WMI_MLO_LINK_FORCE_MODE_ACTIVE_LINK_NUM ||
++	    mode == WMI_MLO_LINK_FORCE_MODE_INACTIVE_LINK_NUM) {
++		param.num_link_entry = 1;
++		param.link_num[0].num_of_link = num_mlo_vdev - 1;
++	}
++
++	return ath12k_wmi_send_mlo_link_set_active_cmd(ab, &param);
++}
++
++static int ath12k_mac_mlo_sta_update_link_active(struct ath12k_base *ab,
++						 struct ieee80211_hw *hw,
++						 struct ath12k_vif *ahvif)
++{
++	u8 mlo_vdev_id_lst[IEEE80211_MLD_MAX_NUM_LINKS] = {};
++	u32 mlo_freq_list[IEEE80211_MLD_MAX_NUM_LINKS] = {};
++	unsigned long links = ahvif->links_map;
++	enum wmi_mlo_link_force_reason reason;
++	struct ieee80211_chanctx_conf *conf;
++	enum wmi_mlo_link_force_mode mode;
++	struct ieee80211_bss_conf *info;
++	struct ath12k_link_vif *arvif;
++	u8 num_mlo_vdev = 0;
++	u8 link_id;
++
++	for_each_set_bit(link_id, &links, IEEE80211_MLD_MAX_NUM_LINKS) {
++		arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++		/* make sure vdev is created on this device */
++		if (!arvif || !arvif->is_created || arvif->ar->ab != ab)
++			continue;
++
++		info = ath12k_mac_get_link_bss_conf(arvif);
++		conf = wiphy_dereference(hw->wiphy, info->chanctx_conf);
++		mlo_freq_list[num_mlo_vdev] = conf->def.chan->center_freq;
++
++		mlo_vdev_id_lst[num_mlo_vdev] = arvif->vdev_id;
++		num_mlo_vdev++;
++	}
++
++	/* It is not allowed to activate more links than a single device
++	 * supported. Something goes wrong if we reach here.
++	 */
++	if (num_mlo_vdev > ATH12K_NUM_MAX_ACTIVE_LINKS_PER_DEVICE) {
++		WARN_ON_ONCE(1);
++		return -EINVAL;
++	}
++
++	/* if 2 links are established and both link channels fall on the
++	 * same hardware MAC, send command to firmware to deactivate one
++	 * of them.
++	 */
++	if (num_mlo_vdev == 2 &&
++	    ath12k_mac_freqs_on_same_mac(ab, mlo_freq_list[0],
++					 mlo_freq_list[1])) {
++		mode = WMI_MLO_LINK_FORCE_MODE_INACTIVE_LINK_NUM;
++		reason = WMI_MLO_LINK_FORCE_REASON_NEW_CONNECT;
++		return ath12k_mac_mlo_sta_set_link_active(ab, reason, mode,
++							  mlo_vdev_id_lst, num_mlo_vdev,
++							  NULL, 0);
++	}
++
++	return 0;
++}
++
++static bool ath12k_mac_are_sbs_chan(struct ath12k_base *ab, u32 freq_1, u32 freq_2)
++{
++	if (!ath12k_mac_is_hw_sbs_capable(ab))
++		return false;
++
++	if (ath12k_is_2ghz_channel_freq(freq_1) ||
++	    ath12k_is_2ghz_channel_freq(freq_2))
++		return false;
++
++	return !ath12k_mac_2_freq_same_mac_in_sbs(ab, freq_1, freq_2);
++}
++
++static bool ath12k_mac_are_dbs_chan(struct ath12k_base *ab, u32 freq_1, u32 freq_2)
++{
++	if (!ath12k_mac_is_hw_dbs_capable(ab))
++		return false;
++
++	return !ath12k_mac_2_freq_same_mac_in_dbs(ab, freq_1, freq_2);
++}
++
++static int ath12k_mac_select_links(struct ath12k_base *ab,
++				   struct ieee80211_vif *vif,
++				   struct ieee80211_hw *hw,
++				   u16 *selected_links)
++{
++	unsigned long useful_links = ieee80211_vif_usable_links(vif);
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	u8 num_useful_links = hweight_long(useful_links);
++	struct ieee80211_chanctx_conf *chanctx;
++	struct ath12k_link_vif *assoc_arvif;
++	u32 assoc_link_freq, partner_freq;
++	u16 sbs_links = 0, dbs_links = 0;
++	struct ieee80211_bss_conf *info;
++	struct ieee80211_channel *chan;
++	struct ieee80211_sta *sta;
++	struct ath12k_sta *ahsta;
++	u8 link_id;
++
++	/* activate all useful links if less than max supported */
++	if (num_useful_links <= ATH12K_NUM_MAX_ACTIVE_LINKS_PER_DEVICE) {
++		*selected_links = useful_links;
++		return 0;
++	}
++
++	/* only in station mode we can get here, so it's safe
++	 * to use ap_addr
++	 */
++	rcu_read_lock();
++	sta = ieee80211_find_sta(vif, vif->cfg.ap_addr);
++	if (!sta) {
++		rcu_read_unlock();
++		ath12k_warn(ab, "failed to find sta with addr %pM\n", vif->cfg.ap_addr);
++		return -EINVAL;
++	}
++
++	ahsta = ath12k_sta_to_ahsta(sta);
++	assoc_arvif = wiphy_dereference(hw->wiphy, ahvif->link[ahsta->assoc_link_id]);
++	info = ath12k_mac_get_link_bss_conf(assoc_arvif);
++	chanctx = rcu_dereference(info->chanctx_conf);
++	assoc_link_freq = chanctx->def.chan->center_freq;
++	rcu_read_unlock();
++	ath12k_dbg(ab, ATH12K_DBG_MAC, "assoc link %u freq %u\n",
++		   assoc_arvif->link_id, assoc_link_freq);
++
++	/* assoc link is already activated and has to be kept active,
++	 * only need to select a partner link from others.
++	 */
++	useful_links &= ~BIT(assoc_arvif->link_id);
++	for_each_set_bit(link_id, &useful_links, IEEE80211_MLD_MAX_NUM_LINKS) {
++		info = wiphy_dereference(hw->wiphy, vif->link_conf[link_id]);
++		if (!info) {
++			ath12k_warn(ab, "failed to get link info for link: %u\n",
++				    link_id);
++			return -ENOLINK;
++		}
++
++		chan = info->chanreq.oper.chan;
++		if (!chan) {
++			ath12k_warn(ab, "failed to get chan for link: %u\n", link_id);
++			return -EINVAL;
++		}
++
++		partner_freq = chan->center_freq;
++		if (ath12k_mac_are_sbs_chan(ab, assoc_link_freq, partner_freq)) {
++			sbs_links |= BIT(link_id);
++			ath12k_dbg(ab, ATH12K_DBG_MAC, "new SBS link %u freq %u\n",
++				   link_id, partner_freq);
++			continue;
++		}
++
++		if (ath12k_mac_are_dbs_chan(ab, assoc_link_freq, partner_freq)) {
++			dbs_links |= BIT(link_id);
++			ath12k_dbg(ab, ATH12K_DBG_MAC, "new DBS link %u freq %u\n",
++				   link_id, partner_freq);
++			continue;
++		}
++
++		ath12k_dbg(ab, ATH12K_DBG_MAC, "non DBS/SBS link %u freq %u\n",
++			   link_id, partner_freq);
++	}
++
++	/* choose the first candidate no matter how many is in the list */
++	if (sbs_links)
++		link_id = __ffs(sbs_links);
++	else if (dbs_links)
++		link_id = __ffs(dbs_links);
++	else
++		link_id = ffs(useful_links) - 1;
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC, "select partner link %u\n", link_id);
++
++	*selected_links = BIT(assoc_arvif->link_id) | BIT(link_id);
++
++	return 0;
++}
++
++int ath12k_mac_op_sta_state(struct ieee80211_hw *hw,
++			    struct ieee80211_vif *vif,
++			    struct ieee80211_sta *sta,
++			    enum ieee80211_sta_state old_state,
++			    enum ieee80211_sta_state new_state)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(sta);
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k_base *prev_ab = NULL, *ab;
++	struct ath12k_link_vif *arvif;
++	struct ath12k_link_sta *arsta;
++	unsigned long valid_links;
++	u16 selected_links = 0;
++	u8 link_id = 0, i;
++	struct ath12k *ar;
++	int ret = -EINVAL;
++	struct ath12k_dp_peer_create_params dp_params = {};
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (ieee80211_vif_is_mld(vif) && sta->valid_links) {
++		WARN_ON(!sta->mlo && hweight16(sta->valid_links) != 1);
++		link_id = ffs(sta->valid_links) - 1;
++	}
++
++	/* IEEE80211_STA_NOTEXIST -> IEEE80211_STA_NONE:
++	 * New station add received. If this is a ML station then
++	 * ahsta->links_map will be zero and sta->valid_links will be 1.
++	 * Assign default link to the first link sta.
++	 */
++	if (old_state == IEEE80211_STA_NOTEXIST &&
++	    new_state == IEEE80211_STA_NONE) {
++		memset(ahsta, 0, sizeof(*ahsta));
++		ahsta->free_logical_link_idx_map = U16_MAX;
++
++		arsta = &ahsta->deflink;
++
++		/* ML sta */
++		if (sta->mlo && !ahsta->links_map &&
++		    (hweight16(sta->valid_links) == 1)) {
++			ahsta->ml_peer_id = ath12k_peer_ml_alloc(ah);
++			if (ahsta->ml_peer_id == ATH12K_MLO_PEER_ID_INVALID) {
++				ath12k_hw_warn(ah, "unable to allocate ML peer id for sta %pM",
++					       sta->addr);
++				goto exit;
++			}
++
++			dp_params.is_mlo = true;
++			dp_params.peer_id = ahsta->ml_peer_id | ATH12K_PEER_ML_ID_VALID;
++		}
++
++		dp_params.sta = sta;
++
++		if (vif->type == NL80211_IFTYPE_AP)
++			dp_params.ucast_ra_only = true;
++
++		ret = ath12k_dp_peer_create(&ah->dp_hw, sta->addr, &dp_params);
++		if (ret) {
++			ath12k_hw_warn(ah, "unable to create ath12k_dp_peer for sta %pM, ret: %d",
++				       sta->addr, ret);
++
++			goto ml_peer_id_clear;
++		}
++
++		ret = ath12k_mac_assign_link_sta(ah, ahsta, arsta, ahvif,
++						 link_id);
++		if (ret) {
++			ath12k_hw_warn(ah, "unable assign link %d for sta %pM",
++				       link_id, sta->addr);
++			goto peer_delete;
++		}
++
++		/* above arsta will get memset, hence do this after assign
++		 * link sta
++		 */
++		if (sta->mlo) {
++			/* For station mode, arvif->is_sta_assoc_link has been set when
++			 * vdev starts. Make sure the arvif/arsta pair have same setting
++			 */
++			if (vif->type == NL80211_IFTYPE_STATION &&
++			    !arsta->arvif->is_sta_assoc_link) {
++				ath12k_hw_warn(ah, "failed to verify assoc link setting with link id %u\n",
++					       link_id);
++				ret = -EINVAL;
++				goto exit;
++			}
++
++			arsta->is_assoc_link = true;
++			ahsta->assoc_link_id = link_id;
++		}
++	}
++
++	/* In the ML station scenario, activate all partner links once the
++	 * client is transitioning to the associated state.
++	 *
++	 * FIXME: Ideally, this activation should occur when the client
++	 * transitions to the authorized state. However, there are some
++	 * issues with handling this in the firmware. Until the firmware
++	 * can manage it properly, activate the links when the client is
++	 * about to move to the associated state.
++	 */
++	if (ieee80211_vif_is_mld(vif) && vif->type == NL80211_IFTYPE_STATION &&
++	    old_state == IEEE80211_STA_AUTH && new_state == IEEE80211_STA_ASSOC) {
++		/* TODO: for now only do link selection for single device
++		 * MLO case. Other cases would be handled in the future.
++		 */
++		ab = ah->radio[0].ab;
++		if (ab->ag->num_devices == 1) {
++			ret = ath12k_mac_select_links(ab, vif, hw, &selected_links);
++			if (ret) {
++				ath12k_warn(ab,
++					    "failed to get selected links: %d\n", ret);
++				goto exit;
++			}
++		} else {
++			selected_links = ieee80211_vif_usable_links(vif);
++		}
++
++		ieee80211_set_active_links(vif, selected_links);
++	}
++
++	/* Handle all the other state transitions in generic way */
++	valid_links = ahsta->links_map;
++	for_each_set_bit(link_id, &valid_links, IEEE80211_MLD_MAX_NUM_LINKS) {
++		arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++		arsta = wiphy_dereference(hw->wiphy, ahsta->link[link_id]);
++		/* some assumptions went wrong! */
++		if (WARN_ON(!arvif || !arsta))
++			continue;
++
++		/* vdev might be in deleted */
++		if (WARN_ON(!arvif->ar))
++			continue;
++
++		ret = ath12k_mac_handle_link_sta_state(hw, arvif, arsta,
++						       old_state, new_state);
++		if (ret) {
++			ath12k_hw_warn(ah, "unable to move link sta %d of sta %pM from state %d to %d",
++				       link_id, arsta->addr, old_state, new_state);
++
++			if (old_state == IEEE80211_STA_NOTEXIST &&
++			    new_state == IEEE80211_STA_NONE)
++				goto peer_delete;
++			else
++				goto exit;
++		}
++	}
++
++	if (ieee80211_vif_is_mld(vif) && vif->type == NL80211_IFTYPE_STATION &&
++	    old_state == IEEE80211_STA_ASSOC && new_state == IEEE80211_STA_AUTHORIZED) {
++		for_each_ar(ah, ar, i) {
++			ab = ar->ab;
++			if (prev_ab == ab)
++				continue;
++
++			ret = ath12k_mac_mlo_sta_update_link_active(ab, hw, ahvif);
++			if (ret) {
++				ath12k_warn(ab,
++					    "failed to update link active state on connect %d\n",
++					    ret);
++				goto exit;
++			}
++
++			prev_ab = ab;
++		}
++	}
++	/* IEEE80211_STA_NONE -> IEEE80211_STA_NOTEXIST:
++	 * Remove the station from driver (handle ML sta here since that
++	 * needs special handling. Normal sta will be handled in generic
++	 * handler below
++	 */
++	if (old_state == IEEE80211_STA_NONE &&
++	    new_state == IEEE80211_STA_NOTEXIST) {
++		if (sta->mlo)
++			ath12k_mac_ml_station_remove(ahvif, ahsta);
++
++		ath12k_dp_peer_delete(&ah->dp_hw, sta->addr, sta);
++	}
++
++	ret = 0;
++	goto exit;
++
++peer_delete:
++	ath12k_dp_peer_delete(&ah->dp_hw, sta->addr, sta);
++ml_peer_id_clear:
++	if (sta->mlo) {
++		clear_bit(ahsta->ml_peer_id, ah->free_ml_peer_id_map);
++		ahsta->ml_peer_id = ATH12K_MLO_PEER_ID_INVALID;
++	}
++exit:
++	/* update the state if everything went well */
++	if (!ret)
++		ahsta->state = new_state;
++
++	return ret;
++}
++EXPORT_SYMBOL(ath12k_mac_op_sta_state);
++
++int ath12k_mac_op_sta_set_txpwr(struct ieee80211_hw *hw,
++				struct ieee80211_vif *vif,
++				struct ieee80211_sta *sta)
++{
++	struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(sta);
++	struct ath12k *ar;
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_link_vif *arvif;
++	struct ath12k_link_sta *arsta;
++	u8 link_id;
++	int ret;
++	s16 txpwr;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	/* TODO: use link id from mac80211 once that's implemented */
++	link_id = 0;
++
++	arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++	arsta = wiphy_dereference(hw->wiphy, ahsta->link[link_id]);
++
++	if (sta->deflink.txpwr.type == NL80211_TX_POWER_AUTOMATIC) {
++		txpwr = 0;
++	} else {
++		txpwr = sta->deflink.txpwr.power;
++		if (!txpwr) {
++			ret = -EINVAL;
++			goto out;
++		}
++	}
++
++	if (txpwr > ATH12K_TX_POWER_MAX_VAL || txpwr < ATH12K_TX_POWER_MIN_VAL) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	ar = arvif->ar;
++
++	ret = ath12k_wmi_set_peer_param(ar, arsta->addr, arvif->vdev_id,
++					WMI_PEER_USE_FIXED_PWR, txpwr);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set tx power for station ret: %d\n",
++			    ret);
++		goto out;
++	}
++
++out:
++	return ret;
++}
++EXPORT_SYMBOL(ath12k_mac_op_sta_set_txpwr);
++
++void ath12k_mac_op_link_sta_rc_update(struct ieee80211_hw *hw,
++				      struct ieee80211_vif *vif,
++				      struct ieee80211_link_sta *link_sta,
++				      u32 changed)
++{
++	struct ieee80211_sta *sta = link_sta->sta;
++	struct ath12k *ar;
++	struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(sta);
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k_link_sta *arsta;
++	struct ath12k_link_vif *arvif;
++	struct ath12k_dp_link_peer *peer;
++	u32 bw, smps;
++	struct ath12k_dp *dp;
++
++	rcu_read_lock();
++	arvif = rcu_dereference(ahvif->link[link_sta->link_id]);
++	if (!arvif) {
++		ath12k_hw_warn(ah, "mac sta rc update failed to fetch link vif on link id %u for peer %pM\n",
++			       link_sta->link_id, sta->addr);
++		rcu_read_unlock();
++		return;
++	}
++
++	ar = arvif->ar;
++	dp = ath12k_ab_to_dp(ar->ab);
++
++	arsta = rcu_dereference(ahsta->link[link_sta->link_id]);
++	if (!arsta) {
++		rcu_read_unlock();
++		ath12k_warn(ar->ab, "mac sta rc update failed to fetch link sta on link id %u for peer %pM\n",
++			    link_sta->link_id, sta->addr);
++		return;
++	}
++	spin_lock_bh(&dp->dp_lock);
++
++	peer = ath12k_dp_link_peer_find_by_vdev_and_addr(dp, arvif->vdev_id,
++							 arsta->addr);
++	if (!peer) {
++		spin_unlock_bh(&dp->dp_lock);
++		rcu_read_unlock();
++		ath12k_warn(ar->ab, "mac sta rc update failed to find peer %pM on vdev %i\n",
++			    arsta->addr, arvif->vdev_id);
++		return;
++	}
++
++	spin_unlock_bh(&dp->dp_lock);
++
++	if (arsta->link_id >= IEEE80211_MLD_MAX_NUM_LINKS) {
++		rcu_read_unlock();
++		return;
++	}
++
++	link_sta = rcu_dereference(sta->link[arsta->link_id]);
++	if (!link_sta) {
++		rcu_read_unlock();
++		ath12k_warn(ar->ab, "unable to access link sta in rc update for sta %pM link %u\n",
++			    sta->addr, arsta->link_id);
++		return;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac sta rc update for %pM changed %08x bw %d nss %d smps %d\n",
++		   arsta->addr, changed, link_sta->bandwidth, link_sta->rx_nss,
++		   link_sta->smps_mode);
++
++	spin_lock_bh(&ar->data_lock);
++
++	if (changed & IEEE80211_RC_BW_CHANGED) {
++		bw = ath12k_mac_ieee80211_sta_bw_to_wmi(ar, link_sta);
++		arsta->bw_prev = arsta->bw;
++		arsta->bw = bw;
++	}
++
++	if (changed & IEEE80211_RC_NSS_CHANGED)
++		arsta->nss = link_sta->rx_nss;
++
++	if (changed & IEEE80211_RC_SMPS_CHANGED) {
++		smps = WMI_PEER_SMPS_PS_NONE;
++
++		switch (link_sta->smps_mode) {
++		case IEEE80211_SMPS_AUTOMATIC:
++		case IEEE80211_SMPS_OFF:
++			smps = WMI_PEER_SMPS_PS_NONE;
++			break;
++		case IEEE80211_SMPS_STATIC:
++			smps = WMI_PEER_SMPS_STATIC;
++			break;
++		case IEEE80211_SMPS_DYNAMIC:
++			smps = WMI_PEER_SMPS_DYNAMIC;
++			break;
++		default:
++			ath12k_warn(ar->ab, "Invalid smps %d in sta rc update for %pM link %u\n",
++				    link_sta->smps_mode, arsta->addr, link_sta->link_id);
++			smps = WMI_PEER_SMPS_PS_NONE;
++			break;
++		}
++
++		arsta->smps = smps;
++	}
++
++	arsta->changed |= changed;
++
++	spin_unlock_bh(&ar->data_lock);
++
++	wiphy_work_queue(hw->wiphy, &arsta->update_wk);
++
++	rcu_read_unlock();
++}
++EXPORT_SYMBOL(ath12k_mac_op_link_sta_rc_update);
++
++static struct ath12k_link_sta *ath12k_mac_alloc_assign_link_sta(struct ath12k_hw *ah,
++								struct ath12k_sta *ahsta,
++								struct ath12k_vif *ahvif,
++								u8 link_id)
++{
++	struct ath12k_link_sta *arsta;
++	int ret;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	if (link_id >= IEEE80211_MLD_MAX_NUM_LINKS)
++		return NULL;
++
++	arsta = wiphy_dereference(ah->hw->wiphy, ahsta->link[link_id]);
++	if (arsta)
++		return NULL;
++
++	arsta = kmalloc_obj(*arsta);
++	if (!arsta)
++		return NULL;
++
++	ret = ath12k_mac_assign_link_sta(ah, ahsta, arsta, ahvif, link_id);
++	if (ret) {
++		kfree(arsta);
++		return NULL;
++	}
++
++	return arsta;
++}
++
++int ath12k_mac_op_change_sta_links(struct ieee80211_hw *hw,
++				   struct ieee80211_vif *vif,
++				   struct ieee80211_sta *sta,
++				   u16 old_links, u16 new_links)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(sta);
++	struct ath12k_hw *ah = hw->priv;
++	struct ath12k_link_vif *arvif;
++	struct ath12k_link_sta *arsta;
++	unsigned long valid_links;
++	struct ath12k *ar;
++	u8 link_id;
++	int ret;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (!sta->valid_links)
++		return -EINVAL;
++
++	/* Firmware does not support removal of one of link stas. All sta
++	 * would be removed during ML STA delete in sta_state(), hence link
++	 * sta removal is not handled here.
++	 */
++	if (new_links < old_links)
++		return 0;
++
++	if (ahsta->ml_peer_id == ATH12K_MLO_PEER_ID_INVALID) {
++		ath12k_hw_warn(ah, "unable to add link for ml sta %pM", sta->addr);
++		return -EINVAL;
++	}
++
++	/* this op is expected only after initial sta insertion with default link */
++	if (WARN_ON(ahsta->links_map == 0))
++		return -EINVAL;
++
++	valid_links = new_links;
++	for_each_set_bit(link_id, &valid_links, IEEE80211_MLD_MAX_NUM_LINKS) {
++		if (ahsta->links_map & BIT(link_id))
++			continue;
++
++		arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++		if (!arvif || !arvif->is_created)
++			continue;
++
++		arsta = ath12k_mac_alloc_assign_link_sta(ah, ahsta, ahvif, link_id);
++		if (!arsta) {
++			ath12k_hw_warn(ah, "Failed to alloc/assign link sta");
++			continue;
++		}
++
++		ar = arvif->ar;
++
++		ret = ath12k_mac_station_add(ar, arvif, arsta);
++		if (ret) {
++			ath12k_warn(ar->ab, "Failed to add station: %pM for VDEV: %d\n",
++				    arsta->addr, arvif->vdev_id);
++			ath12k_mac_free_unassign_link_sta(ah, ahsta, link_id);
++			return ret;
++		}
++	}
++
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_change_sta_links);
++
++bool ath12k_mac_op_can_activate_links(struct ieee80211_hw *hw,
++				      struct ieee80211_vif *vif,
++				      u16 active_links)
++{
++	/* TODO: Handle recovery case */
++
++	return true;
++}
++EXPORT_SYMBOL(ath12k_mac_op_can_activate_links);
++
++static int ath12k_conf_tx_uapsd(struct ath12k_link_vif *arvif,
++				u16 ac, bool enable)
++{
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	u32 value;
++	int ret;
++
++	if (ahvif->vdev_type != WMI_VDEV_TYPE_STA)
++		return 0;
++
++	switch (ac) {
++	case IEEE80211_AC_VO:
++		value = WMI_STA_PS_UAPSD_AC3_DELIVERY_EN |
++			WMI_STA_PS_UAPSD_AC3_TRIGGER_EN;
++		break;
++	case IEEE80211_AC_VI:
++		value = WMI_STA_PS_UAPSD_AC2_DELIVERY_EN |
++			WMI_STA_PS_UAPSD_AC2_TRIGGER_EN;
++		break;
++	case IEEE80211_AC_BE:
++		value = WMI_STA_PS_UAPSD_AC1_DELIVERY_EN |
++			WMI_STA_PS_UAPSD_AC1_TRIGGER_EN;
++		break;
++	case IEEE80211_AC_BK:
++		value = WMI_STA_PS_UAPSD_AC0_DELIVERY_EN |
++			WMI_STA_PS_UAPSD_AC0_TRIGGER_EN;
++		break;
++	}
++
++	if (enable)
++		ahvif->u.sta.uapsd |= value;
++	else
++		ahvif->u.sta.uapsd &= ~value;
++
++	ret = ath12k_wmi_set_sta_ps_param(ar, arvif->vdev_id,
++					  WMI_STA_PS_PARAM_UAPSD,
++					  ahvif->u.sta.uapsd);
++	if (ret) {
++		ath12k_warn(ar->ab, "could not set uapsd params %d\n", ret);
++		goto exit;
++	}
++
++	if (ahvif->u.sta.uapsd)
++		value = WMI_STA_PS_RX_WAKE_POLICY_POLL_UAPSD;
++	else
++		value = WMI_STA_PS_RX_WAKE_POLICY_WAKE;
++
++	ret = ath12k_wmi_set_sta_ps_param(ar, arvif->vdev_id,
++					  WMI_STA_PS_PARAM_RX_WAKE_POLICY,
++					  value);
++	if (ret)
++		ath12k_warn(ar->ab, "could not set rx wake param %d\n", ret);
++
++exit:
++	return ret;
++}
++
++static int ath12k_mac_conf_tx(struct ath12k_link_vif *arvif, u16 ac,
++			      const struct ieee80211_tx_queue_params *params)
++{
++	struct wmi_wmm_params_arg *p = NULL;
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_base *ab = ar->ab;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	switch (ac) {
++	case IEEE80211_AC_VO:
++		p = &arvif->wmm_params.ac_vo;
++		break;
++	case IEEE80211_AC_VI:
++		p = &arvif->wmm_params.ac_vi;
++		break;
++	case IEEE80211_AC_BE:
++		p = &arvif->wmm_params.ac_be;
++		break;
++	case IEEE80211_AC_BK:
++		p = &arvif->wmm_params.ac_bk;
++		break;
++	}
++
++	if (WARN_ON(!p)) {
++		ret = -EINVAL;
++		goto exit;
++	}
++
++	p->cwmin = params->cw_min;
++	p->cwmax = params->cw_max;
++	p->aifs = params->aifs;
++	p->txop = params->txop;
++
++	ret = ath12k_wmi_send_wmm_update_cmd(ar, arvif->vdev_id,
++					     &arvif->wmm_params);
++	if (ret) {
++		ath12k_warn(ab, "pdev idx %d failed to set wmm params: %d\n",
++			    ar->pdev_idx, ret);
++		goto exit;
++	}
++
++	ret = ath12k_conf_tx_uapsd(arvif, ac, params->uapsd);
++	if (ret)
++		ath12k_warn(ab, "pdev idx %d failed to set sta uapsd: %d\n",
++			    ar->pdev_idx, ret);
++
++exit:
++	return ret;
++}
++
++int ath12k_mac_op_conf_tx(struct ieee80211_hw *hw,
++			  struct ieee80211_vif *vif,
++			  unsigned int link_id, u16 ac,
++			  const struct ieee80211_tx_queue_params *params)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_link_vif *arvif;
++	struct ath12k_vif_cache *cache;
++	int ret;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (link_id >= IEEE80211_MLD_MAX_NUM_LINKS)
++		return -EINVAL;
++
++	arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++	if (!arvif || !arvif->is_created) {
++		cache = ath12k_ahvif_get_link_cache(ahvif, link_id);
++		if (!cache)
++			return -ENOSPC;
++
++		cache->tx_conf.changed = true;
++		cache->tx_conf.ac = ac;
++		cache->tx_conf.tx_queue_params = *params;
++
++		return 0;
++	}
++
++	ret = ath12k_mac_conf_tx(arvif, ac, params);
++
++	return ret;
++}
++EXPORT_SYMBOL(ath12k_mac_op_conf_tx);
++
++static struct ieee80211_sta_ht_cap
++ath12k_create_ht_cap(struct ath12k *ar, u32 ar_ht_cap, u32 rate_cap_rx_chainmask)
++{
++	int i;
++	struct ieee80211_sta_ht_cap ht_cap = {};
++	u32 ar_vht_cap = ar->pdev->cap.vht_cap;
++
++	if (!(ar_ht_cap & WMI_HT_CAP_ENABLED))
++		return ht_cap;
++
++	ht_cap.ht_supported = 1;
++	ht_cap.ampdu_factor = IEEE80211_HT_MAX_AMPDU_64K;
++	ht_cap.ampdu_density = IEEE80211_HT_MPDU_DENSITY_NONE;
++	ht_cap.cap |= IEEE80211_HT_CAP_SUP_WIDTH_20_40;
++	ht_cap.cap |= IEEE80211_HT_CAP_DSSSCCK40;
++	ht_cap.cap |= WLAN_HT_CAP_SM_PS_STATIC << IEEE80211_HT_CAP_SM_PS_SHIFT;
++
++	if (ar_ht_cap & WMI_HT_CAP_HT20_SGI)
++		ht_cap.cap |= IEEE80211_HT_CAP_SGI_20;
++
++	if (ar_ht_cap & WMI_HT_CAP_HT40_SGI)
++		ht_cap.cap |= IEEE80211_HT_CAP_SGI_40;
++
++	if (ar_ht_cap & WMI_HT_CAP_DYNAMIC_SMPS) {
++		u32 smps;
++
++		smps   = WLAN_HT_CAP_SM_PS_DYNAMIC;
++		smps <<= IEEE80211_HT_CAP_SM_PS_SHIFT;
++
++		ht_cap.cap |= smps;
++	}
++
++	if (ar_ht_cap & WMI_HT_CAP_TX_STBC)
++		ht_cap.cap |= IEEE80211_HT_CAP_TX_STBC;
++
++	if (ar_ht_cap & WMI_HT_CAP_RX_STBC) {
++		u32 stbc;
++
++		stbc   = ar_ht_cap;
++		stbc  &= WMI_HT_CAP_RX_STBC;
++		stbc >>= WMI_HT_CAP_RX_STBC_MASK_SHIFT;
++		stbc <<= IEEE80211_HT_CAP_RX_STBC_SHIFT;
++		stbc  &= IEEE80211_HT_CAP_RX_STBC;
++
++		ht_cap.cap |= stbc;
++	}
++
++	if (ar_ht_cap & WMI_HT_CAP_RX_LDPC)
++		ht_cap.cap |= IEEE80211_HT_CAP_LDPC_CODING;
++
++	if (ar_ht_cap & WMI_HT_CAP_L_SIG_TXOP_PROT)
++		ht_cap.cap |= IEEE80211_HT_CAP_LSIG_TXOP_PROT;
++
++	if (ar_vht_cap & WMI_VHT_CAP_MAX_MPDU_LEN_MASK)
++		ht_cap.cap |= IEEE80211_HT_CAP_MAX_AMSDU;
++
++	for (i = 0; i < ar->num_rx_chains; i++) {
++		if (rate_cap_rx_chainmask & BIT(i))
++			ht_cap.mcs.rx_mask[i] = 0xFF;
++	}
++
++	ht_cap.mcs.tx_params |= IEEE80211_HT_MCS_TX_DEFINED;
++
++	return ht_cap;
++}
++
++static int ath12k_mac_set_txbf_conf(struct ath12k_link_vif *arvif)
++{
++	u32 value = 0;
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	int nsts;
++	int sound_dim;
++	u32 vht_cap = ar->pdev->cap.vht_cap;
++	u32 vdev_param = WMI_VDEV_PARAM_TXBF;
++
++	if (vht_cap & (IEEE80211_VHT_CAP_SU_BEAMFORMEE_CAPABLE)) {
++		nsts = vht_cap & IEEE80211_VHT_CAP_BEAMFORMEE_STS_MASK;
++		nsts >>= IEEE80211_VHT_CAP_BEAMFORMEE_STS_SHIFT;
++		value |= SM(nsts, WMI_TXBF_STS_CAP_OFFSET);
++	}
++
++	if (vht_cap & (IEEE80211_VHT_CAP_SU_BEAMFORMER_CAPABLE)) {
++		sound_dim = vht_cap &
++			    IEEE80211_VHT_CAP_SOUNDING_DIMENSIONS_MASK;
++		sound_dim >>= IEEE80211_VHT_CAP_SOUNDING_DIMENSIONS_SHIFT;
++		if (sound_dim > (ar->num_tx_chains - 1))
++			sound_dim = ar->num_tx_chains - 1;
++		value |= SM(sound_dim, WMI_BF_SOUND_DIM_OFFSET);
++	}
++
++	if (!value)
++		return 0;
++
++	if (vht_cap & IEEE80211_VHT_CAP_SU_BEAMFORMER_CAPABLE) {
++		value |= WMI_VDEV_PARAM_TXBF_SU_TX_BFER;
++
++		if ((vht_cap & IEEE80211_VHT_CAP_MU_BEAMFORMER_CAPABLE) &&
++		    ahvif->vdev_type == WMI_VDEV_TYPE_AP)
++			value |= WMI_VDEV_PARAM_TXBF_MU_TX_BFER;
++	}
++
++	if (vht_cap & IEEE80211_VHT_CAP_SU_BEAMFORMEE_CAPABLE) {
++		value |= WMI_VDEV_PARAM_TXBF_SU_TX_BFEE;
++
++		if ((vht_cap & IEEE80211_VHT_CAP_MU_BEAMFORMEE_CAPABLE) &&
++		    ahvif->vdev_type == WMI_VDEV_TYPE_STA)
++			value |= WMI_VDEV_PARAM_TXBF_MU_TX_BFEE;
++	}
++
++	return ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					     vdev_param, value);
++}
++
++static void ath12k_set_vht_txbf_cap(struct ath12k *ar, u32 *vht_cap)
++{
++	bool subfer, subfee;
++	int sound_dim = 0;
++
++	subfer = !!(*vht_cap & (IEEE80211_VHT_CAP_SU_BEAMFORMER_CAPABLE));
++	subfee = !!(*vht_cap & (IEEE80211_VHT_CAP_SU_BEAMFORMEE_CAPABLE));
++
++	if (ar->num_tx_chains < 2) {
++		*vht_cap &= ~(IEEE80211_VHT_CAP_SU_BEAMFORMER_CAPABLE);
++		subfer = false;
++	}
++
++	/* If SU Beaformer is not set, then disable MU Beamformer Capability */
++	if (!subfer)
++		*vht_cap &= ~(IEEE80211_VHT_CAP_MU_BEAMFORMER_CAPABLE);
++
++	/* If SU Beaformee is not set, then disable MU Beamformee Capability */
++	if (!subfee)
++		*vht_cap &= ~(IEEE80211_VHT_CAP_MU_BEAMFORMEE_CAPABLE);
++
++	sound_dim = u32_get_bits(*vht_cap,
++				 IEEE80211_VHT_CAP_SOUNDING_DIMENSIONS_MASK);
++	*vht_cap = u32_replace_bits(*vht_cap, 0,
++				    IEEE80211_VHT_CAP_SOUNDING_DIMENSIONS_MASK);
++
++	/* TODO: Need to check invalid STS and Sound_dim values set by FW? */
++
++	/* Enable Sounding Dimension Field only if SU BF is enabled */
++	if (subfer) {
++		if (sound_dim > (ar->num_tx_chains - 1))
++			sound_dim = ar->num_tx_chains - 1;
++
++		*vht_cap = u32_replace_bits(*vht_cap, sound_dim,
++					    IEEE80211_VHT_CAP_SOUNDING_DIMENSIONS_MASK);
++	}
++
++	/* Use the STS advertised by FW unless SU Beamformee is not supported*/
++	if (!subfee)
++		*vht_cap &= ~(IEEE80211_VHT_CAP_BEAMFORMEE_STS_MASK);
++}
++
++static struct ieee80211_sta_vht_cap
++ath12k_create_vht_cap(struct ath12k *ar, u32 rate_cap_tx_chainmask,
++		      u32 rate_cap_rx_chainmask)
++{
++	struct ieee80211_sta_vht_cap vht_cap = {};
++	u16 txmcs_map, rxmcs_map;
++	int i;
++
++	vht_cap.vht_supported = 1;
++	vht_cap.cap = ar->pdev->cap.vht_cap;
++
++	if (ar->pdev->cap.nss_ratio_enabled)
++		vht_cap.vht_mcs.tx_highest |=
++			cpu_to_le16(IEEE80211_VHT_EXT_NSS_BW_CAPABLE);
++
++	ath12k_set_vht_txbf_cap(ar, &vht_cap.cap);
++
++	/* 80P80 is not supported */
++	vht_cap.cap &= ~IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_160_80PLUS80MHZ;
++
++	rxmcs_map = 0;
++	txmcs_map = 0;
++	for (i = 0; i < 8; i++) {
++		if (i < ar->num_tx_chains && rate_cap_tx_chainmask & BIT(i))
++			txmcs_map |= IEEE80211_VHT_MCS_SUPPORT_0_9 << (i * 2);
++		else
++			txmcs_map |= IEEE80211_VHT_MCS_NOT_SUPPORTED << (i * 2);
++
++		if (i < ar->num_rx_chains && rate_cap_rx_chainmask & BIT(i))
++			rxmcs_map |= IEEE80211_VHT_MCS_SUPPORT_0_9 << (i * 2);
++		else
++			rxmcs_map |= IEEE80211_VHT_MCS_NOT_SUPPORTED << (i * 2);
++	}
++
++	if (rate_cap_tx_chainmask <= 1)
++		vht_cap.cap &= ~IEEE80211_VHT_CAP_TXSTBC;
++
++	vht_cap.vht_mcs.rx_mcs_map = cpu_to_le16(rxmcs_map);
++	vht_cap.vht_mcs.tx_mcs_map = cpu_to_le16(txmcs_map);
++
++	/* Check if the HW supports 1:1 NSS ratio and reset
++	 * EXT NSS BW Support field to 0 to indicate 1:1 ratio
++	 */
++	if (ar->pdev->cap.nss_ratio_info == WMI_NSS_RATIO_1_NSS)
++		vht_cap.cap &= ~IEEE80211_VHT_CAP_EXT_NSS_BW_MASK;
++
++	return vht_cap;
++}
++
++static void ath12k_mac_setup_ht_vht_cap(struct ath12k *ar,
++					struct ath12k_pdev_cap *cap,
++					u32 *ht_cap_info)
++{
++	struct ieee80211_supported_band *band;
++	u32 rate_cap_tx_chainmask;
++	u32 rate_cap_rx_chainmask;
++	u32 ht_cap;
++
++	rate_cap_tx_chainmask = ar->cfg_tx_chainmask >> cap->tx_chain_mask_shift;
++	rate_cap_rx_chainmask = ar->cfg_rx_chainmask >> cap->rx_chain_mask_shift;
++
++	if (cap->supported_bands & WMI_HOST_WLAN_2GHZ_CAP) {
++		band = &ar->mac.sbands[NL80211_BAND_2GHZ];
++		ht_cap = cap->band[NL80211_BAND_2GHZ].ht_cap_info;
++		if (ht_cap_info)
++			*ht_cap_info = ht_cap;
++		band->ht_cap = ath12k_create_ht_cap(ar, ht_cap,
++						    rate_cap_rx_chainmask);
++	}
++
++	if (cap->supported_bands & WMI_HOST_WLAN_5GHZ_CAP &&
++	    (ar->ab->hw_params->single_pdev_only ||
++	     !ar->supports_6ghz)) {
++		band = &ar->mac.sbands[NL80211_BAND_5GHZ];
++		ht_cap = cap->band[NL80211_BAND_5GHZ].ht_cap_info;
++		if (ht_cap_info)
++			*ht_cap_info = ht_cap;
++		band->ht_cap = ath12k_create_ht_cap(ar, ht_cap,
++						    rate_cap_rx_chainmask);
++		band->vht_cap = ath12k_create_vht_cap(ar, rate_cap_tx_chainmask,
++						      rate_cap_rx_chainmask);
++	}
++}
++
++static int ath12k_check_chain_mask(struct ath12k *ar, u32 ant, bool is_tx_ant)
++{
++	/* TODO: Check the request chainmask against the supported
++	 * chainmask table which is advertised in extented_service_ready event
++	 */
++
++	return 0;
++}
++
++static void ath12k_gen_ppe_thresh(struct ath12k_wmi_ppe_threshold_arg *fw_ppet,
++				  u8 *he_ppet)
++{
++	int nss, ru;
++	u8 bit = 7;
++
++	he_ppet[0] = fw_ppet->numss_m1 & IEEE80211_PPE_THRES_NSS_MASK;
++	he_ppet[0] |= (fw_ppet->ru_bit_mask <<
++		       IEEE80211_PPE_THRES_RU_INDEX_BITMASK_POS) &
++		      IEEE80211_PPE_THRES_RU_INDEX_BITMASK_MASK;
++	for (nss = 0; nss <= fw_ppet->numss_m1; nss++) {
++		for (ru = 0; ru < 4; ru++) {
++			u8 val;
++			int i;
++
++			if ((fw_ppet->ru_bit_mask & BIT(ru)) == 0)
++				continue;
++			val = (fw_ppet->ppet16_ppet8_ru3_ru0[nss] >> (ru * 6)) &
++			       0x3f;
++			val = ((val >> 3) & 0x7) | ((val & 0x7) << 3);
++			for (i = 5; i >= 0; i--) {
++				he_ppet[bit / 8] |=
++					((val >> i) & 0x1) << ((bit % 8));
++				bit++;
++			}
++		}
++	}
++}
++
++static void
++ath12k_mac_filter_he_cap_mesh(struct ieee80211_he_cap_elem *he_cap_elem)
++{
++	u8 m;
++
++	m = IEEE80211_HE_MAC_CAP0_TWT_RES |
++	    IEEE80211_HE_MAC_CAP0_TWT_REQ;
++	he_cap_elem->mac_cap_info[0] &= ~m;
++
++	m = IEEE80211_HE_MAC_CAP2_TRS |
++	    IEEE80211_HE_MAC_CAP2_BCAST_TWT |
++	    IEEE80211_HE_MAC_CAP2_MU_CASCADING;
++	he_cap_elem->mac_cap_info[2] &= ~m;
++
++	m = IEEE80211_HE_MAC_CAP3_FLEX_TWT_SCHED |
++	    IEEE80211_HE_MAC_CAP2_BCAST_TWT |
++	    IEEE80211_HE_MAC_CAP2_MU_CASCADING;
++	he_cap_elem->mac_cap_info[3] &= ~m;
++
++	m = IEEE80211_HE_MAC_CAP4_BSRP_BQRP_A_MPDU_AGG |
++	    IEEE80211_HE_MAC_CAP4_BQR;
++	he_cap_elem->mac_cap_info[4] &= ~m;
++
++	m = IEEE80211_HE_MAC_CAP5_SUBCHAN_SELECTIVE_TRANSMISSION |
++	    IEEE80211_HE_MAC_CAP5_UL_2x996_TONE_RU |
++	    IEEE80211_HE_MAC_CAP5_PUNCTURED_SOUNDING |
++	    IEEE80211_HE_MAC_CAP5_HT_VHT_TRIG_FRAME_RX;
++	he_cap_elem->mac_cap_info[5] &= ~m;
++
++	m = IEEE80211_HE_PHY_CAP2_UL_MU_FULL_MU_MIMO |
++	    IEEE80211_HE_PHY_CAP2_UL_MU_PARTIAL_MU_MIMO;
++	he_cap_elem->phy_cap_info[2] &= ~m;
++
++	m = IEEE80211_HE_PHY_CAP3_RX_PARTIAL_BW_SU_IN_20MHZ_MU |
++	    IEEE80211_HE_PHY_CAP3_DCM_MAX_CONST_TX_MASK |
++	    IEEE80211_HE_PHY_CAP3_DCM_MAX_CONST_RX_MASK;
++	he_cap_elem->phy_cap_info[3] &= ~m;
++
++	m = IEEE80211_HE_PHY_CAP4_MU_BEAMFORMER;
++	he_cap_elem->phy_cap_info[4] &= ~m;
++
++	m = IEEE80211_HE_PHY_CAP5_NG16_MU_FEEDBACK;
++	he_cap_elem->phy_cap_info[5] &= ~m;
++
++	m = IEEE80211_HE_PHY_CAP6_CODEBOOK_SIZE_75_MU |
++	    IEEE80211_HE_PHY_CAP6_TRIG_MU_BEAMFORMING_PARTIAL_BW_FB |
++	    IEEE80211_HE_PHY_CAP6_TRIG_CQI_FB |
++	    IEEE80211_HE_PHY_CAP6_PARTIAL_BANDWIDTH_DL_MUMIMO;
++	he_cap_elem->phy_cap_info[6] &= ~m;
++
++	m = IEEE80211_HE_PHY_CAP7_PSR_BASED_SR |
++	    IEEE80211_HE_PHY_CAP7_POWER_BOOST_FACTOR_SUPP |
++	    IEEE80211_HE_PHY_CAP7_STBC_TX_ABOVE_80MHZ |
++	    IEEE80211_HE_PHY_CAP7_STBC_RX_ABOVE_80MHZ;
++	he_cap_elem->phy_cap_info[7] &= ~m;
++
++	m = IEEE80211_HE_PHY_CAP8_HE_ER_SU_PPDU_4XLTF_AND_08_US_GI |
++	    IEEE80211_HE_PHY_CAP8_20MHZ_IN_40MHZ_HE_PPDU_IN_2G |
++	    IEEE80211_HE_PHY_CAP8_20MHZ_IN_160MHZ_HE_PPDU |
++	    IEEE80211_HE_PHY_CAP8_80MHZ_IN_160MHZ_HE_PPDU;
++	he_cap_elem->phy_cap_info[8] &= ~m;
++
++	m = IEEE80211_HE_PHY_CAP9_LONGER_THAN_16_SIGB_OFDM_SYM |
++	    IEEE80211_HE_PHY_CAP9_NON_TRIGGERED_CQI_FEEDBACK |
++	    IEEE80211_HE_PHY_CAP9_RX_1024_QAM_LESS_THAN_242_TONE_RU |
++	    IEEE80211_HE_PHY_CAP9_TX_1024_QAM_LESS_THAN_242_TONE_RU |
++	    IEEE80211_HE_PHY_CAP9_RX_FULL_BW_SU_USING_MU_WITH_COMP_SIGB |
++	    IEEE80211_HE_PHY_CAP9_RX_FULL_BW_SU_USING_MU_WITH_NON_COMP_SIGB;
++	he_cap_elem->phy_cap_info[9] &= ~m;
++}
++
++static __le16 ath12k_mac_setup_he_6ghz_cap(struct ath12k_pdev_cap *pcap,
++					   struct ath12k_band_cap *bcap)
++{
++	u8 val;
++
++	bcap->he_6ghz_capa = IEEE80211_HT_MPDU_DENSITY_NONE;
++	if (bcap->ht_cap_info & WMI_HT_CAP_DYNAMIC_SMPS)
++		bcap->he_6ghz_capa |=
++			u32_encode_bits(WLAN_HT_CAP_SM_PS_DYNAMIC,
++					IEEE80211_HE_6GHZ_CAP_SM_PS);
++	else
++		bcap->he_6ghz_capa |=
++			u32_encode_bits(WLAN_HT_CAP_SM_PS_DISABLED,
++					IEEE80211_HE_6GHZ_CAP_SM_PS);
++	val = u32_get_bits(pcap->vht_cap,
++			   IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK);
++	bcap->he_6ghz_capa |=
++		u32_encode_bits(val, IEEE80211_HE_6GHZ_CAP_MAX_AMPDU_LEN_EXP);
++	val = u32_get_bits(pcap->vht_cap,
++			   IEEE80211_VHT_CAP_MAX_MPDU_MASK);
++	bcap->he_6ghz_capa |=
++		u32_encode_bits(val, IEEE80211_HE_6GHZ_CAP_MAX_MPDU_LEN);
++	if (pcap->vht_cap & IEEE80211_VHT_CAP_RX_ANTENNA_PATTERN)
++		bcap->he_6ghz_capa |= IEEE80211_HE_6GHZ_CAP_RX_ANTPAT_CONS;
++	if (pcap->vht_cap & IEEE80211_VHT_CAP_TX_ANTENNA_PATTERN)
++		bcap->he_6ghz_capa |= IEEE80211_HE_6GHZ_CAP_TX_ANTPAT_CONS;
++
++	return cpu_to_le16(bcap->he_6ghz_capa);
++}
++
++static void ath12k_mac_set_hemcsmap(struct ath12k *ar,
++				    struct ath12k_pdev_cap *cap,
++				    struct ieee80211_sta_he_cap *he_cap)
++{
++	struct ieee80211_he_mcs_nss_supp *mcs_nss = &he_cap->he_mcs_nss_supp;
++	u8 maxtxnss_160 = ath12k_get_nss_160mhz(ar, ar->num_tx_chains);
++	u8 maxrxnss_160 = ath12k_get_nss_160mhz(ar, ar->num_rx_chains);
++	u16 txmcs_map_160 = 0, rxmcs_map_160 = 0;
++	u16 txmcs_map = 0, rxmcs_map = 0;
++	u32 i;
++
++	for (i = 0; i < 8; i++) {
++		if (i < ar->num_tx_chains &&
++		    (ar->cfg_tx_chainmask >> cap->tx_chain_mask_shift) & BIT(i))
++			txmcs_map |= IEEE80211_HE_MCS_SUPPORT_0_11 << (i * 2);
++		else
++			txmcs_map |= IEEE80211_HE_MCS_NOT_SUPPORTED << (i * 2);
++
++		if (i < ar->num_rx_chains &&
++		    (ar->cfg_rx_chainmask >> cap->tx_chain_mask_shift) & BIT(i))
++			rxmcs_map |= IEEE80211_HE_MCS_SUPPORT_0_11 << (i * 2);
++		else
++			rxmcs_map |= IEEE80211_HE_MCS_NOT_SUPPORTED << (i * 2);
++
++		if (i < maxtxnss_160 &&
++		    (ar->cfg_tx_chainmask >> cap->tx_chain_mask_shift) & BIT(i))
++			txmcs_map_160 |= IEEE80211_HE_MCS_SUPPORT_0_11 << (i * 2);
++		else
++			txmcs_map_160 |= IEEE80211_HE_MCS_NOT_SUPPORTED << (i * 2);
++
++		if (i < maxrxnss_160 &&
++		    (ar->cfg_tx_chainmask >> cap->tx_chain_mask_shift) & BIT(i))
++			rxmcs_map_160 |= IEEE80211_HE_MCS_SUPPORT_0_11 << (i * 2);
++		else
++			rxmcs_map_160 |= IEEE80211_HE_MCS_NOT_SUPPORTED << (i * 2);
++	}
++
++	mcs_nss->rx_mcs_80 = cpu_to_le16(rxmcs_map & 0xffff);
++	mcs_nss->tx_mcs_80 = cpu_to_le16(txmcs_map & 0xffff);
++	mcs_nss->rx_mcs_160 = cpu_to_le16(rxmcs_map_160 & 0xffff);
++	mcs_nss->tx_mcs_160 = cpu_to_le16(txmcs_map_160 & 0xffff);
++}
++
++static void ath12k_mac_copy_he_cap(struct ath12k *ar,
++				   struct ath12k_band_cap *band_cap,
++				   int iftype, u8 num_tx_chains,
++				   struct ieee80211_sta_he_cap *he_cap)
++{
++	struct ieee80211_he_cap_elem *he_cap_elem = &he_cap->he_cap_elem;
++
++	he_cap->has_he = true;
++	memcpy(he_cap_elem->mac_cap_info, band_cap->he_cap_info,
++	       sizeof(he_cap_elem->mac_cap_info));
++	memcpy(he_cap_elem->phy_cap_info, band_cap->he_cap_phy_info,
++	       sizeof(he_cap_elem->phy_cap_info));
++
++	he_cap_elem->mac_cap_info[1] &=
++		IEEE80211_HE_MAC_CAP1_TF_MAC_PAD_DUR_MASK;
++	he_cap_elem->phy_cap_info[0] &=
++		IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_40MHZ_IN_2G |
++		IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_40MHZ_80MHZ_IN_5G |
++		IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_160MHZ_IN_5G;
++	/* 80PLUS80 is not supported */
++	he_cap_elem->phy_cap_info[0] &=
++		~IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_80PLUS80_MHZ_IN_5G;
++	he_cap_elem->phy_cap_info[5] &=
++		~IEEE80211_HE_PHY_CAP5_BEAMFORMEE_NUM_SND_DIM_UNDER_80MHZ_MASK;
++	he_cap_elem->phy_cap_info[5] |= num_tx_chains - 1;
++
++	switch (iftype) {
++	case NL80211_IFTYPE_AP:
++		he_cap_elem->mac_cap_info[2] &=
++			~IEEE80211_HE_MAC_CAP2_BCAST_TWT;
++		he_cap_elem->phy_cap_info[3] &=
++			~IEEE80211_HE_PHY_CAP3_DCM_MAX_CONST_TX_MASK;
++		he_cap_elem->phy_cap_info[9] |=
++			IEEE80211_HE_PHY_CAP9_RX_1024_QAM_LESS_THAN_242_TONE_RU;
++		break;
++	case NL80211_IFTYPE_STATION:
++		he_cap_elem->mac_cap_info[0] &= ~IEEE80211_HE_MAC_CAP0_TWT_RES;
++		he_cap_elem->mac_cap_info[0] |= IEEE80211_HE_MAC_CAP0_TWT_REQ;
++		he_cap_elem->phy_cap_info[9] |=
++			IEEE80211_HE_PHY_CAP9_TX_1024_QAM_LESS_THAN_242_TONE_RU;
++		break;
++	case NL80211_IFTYPE_MESH_POINT:
++		ath12k_mac_filter_he_cap_mesh(he_cap_elem);
++		break;
++	}
++
++	ath12k_mac_set_hemcsmap(ar, &ar->pdev->cap, he_cap);
++	memset(he_cap->ppe_thres, 0, sizeof(he_cap->ppe_thres));
++	if (he_cap_elem->phy_cap_info[6] &
++	    IEEE80211_HE_PHY_CAP6_PPE_THRESHOLD_PRESENT)
++		ath12k_gen_ppe_thresh(&band_cap->he_ppet, he_cap->ppe_thres);
++}
++
++static void
++ath12k_mac_copy_eht_mcs_nss(struct ath12k_band_cap *band_cap,
++			    struct ieee80211_eht_mcs_nss_supp *mcs_nss,
++			    const struct ieee80211_he_cap_elem *he_cap,
++			    const struct ieee80211_eht_cap_elem_fixed *eht_cap)
++{
++	if ((he_cap->phy_cap_info[0] &
++	     (IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_40MHZ_IN_2G |
++	      IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_40MHZ_80MHZ_IN_5G |
++	      IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_160MHZ_IN_5G |
++	      IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_80PLUS80_MHZ_IN_5G)) == 0)
++		memcpy(&mcs_nss->only_20mhz, &band_cap->eht_mcs_20_only,
++		       sizeof(struct ieee80211_eht_mcs_nss_supp_20mhz_only));
++
++	if (he_cap->phy_cap_info[0] &
++	    (IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_40MHZ_IN_2G |
++	     IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_40MHZ_80MHZ_IN_5G))
++		memcpy(&mcs_nss->bw._80, &band_cap->eht_mcs_80,
++		       sizeof(struct ieee80211_eht_mcs_nss_supp_bw));
++
++	if (he_cap->phy_cap_info[0] &
++	    IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_160MHZ_IN_5G)
++		memcpy(&mcs_nss->bw._160, &band_cap->eht_mcs_160,
++		       sizeof(struct ieee80211_eht_mcs_nss_supp_bw));
++
++	if (eht_cap->phy_cap_info[0] & IEEE80211_EHT_PHY_CAP0_320MHZ_IN_6GHZ)
++		memcpy(&mcs_nss->bw._320, &band_cap->eht_mcs_320,
++		       sizeof(struct ieee80211_eht_mcs_nss_supp_bw));
++}
++
++static void ath12k_mac_copy_eht_ppe_thresh(struct ath12k_wmi_ppe_threshold_arg *fw_ppet,
++					   struct ieee80211_sta_eht_cap *cap)
++{
++	u16 bit = IEEE80211_EHT_PPE_THRES_INFO_HEADER_SIZE;
++	u8 i, nss, ru, ppet_bit_len_per_ru = IEEE80211_EHT_PPE_THRES_INFO_PPET_SIZE * 2;
++
++	u8p_replace_bits(&cap->eht_ppe_thres[0], fw_ppet->numss_m1,
++			 IEEE80211_EHT_PPE_THRES_NSS_MASK);
++
++	u16p_replace_bits((u16 *)&cap->eht_ppe_thres[0], fw_ppet->ru_bit_mask,
++			  IEEE80211_EHT_PPE_THRES_RU_INDEX_BITMASK_MASK);
++
++	for (nss = 0; nss <= fw_ppet->numss_m1; nss++) {
++		for (ru = 0;
++		     ru < hweight16(IEEE80211_EHT_PPE_THRES_RU_INDEX_BITMASK_MASK);
++		     ru++) {
++			u32 val = 0;
++
++			if ((fw_ppet->ru_bit_mask & BIT(ru)) == 0)
++				continue;
++
++			u32p_replace_bits(&val, fw_ppet->ppet16_ppet8_ru3_ru0[nss] >>
++						(ru * ppet_bit_len_per_ru),
++					  GENMASK(ppet_bit_len_per_ru - 1, 0));
++
++			for (i = 0; i < ppet_bit_len_per_ru; i++) {
++				cap->eht_ppe_thres[bit / 8] |=
++					(((val >> i) & 0x1) << ((bit % 8)));
++				bit++;
++			}
++		}
++	}
++}
++
++static void
++ath12k_mac_filter_eht_cap_mesh(struct ieee80211_eht_cap_elem_fixed
++			       *eht_cap_elem)
++{
++	u8 m;
++
++	m = IEEE80211_EHT_MAC_CAP0_EPCS_PRIO_ACCESS;
++	eht_cap_elem->mac_cap_info[0] &= ~m;
++
++	m = IEEE80211_EHT_PHY_CAP0_PARTIAL_BW_UL_MU_MIMO;
++	eht_cap_elem->phy_cap_info[0] &= ~m;
++
++	m = IEEE80211_EHT_PHY_CAP3_NG_16_MU_FEEDBACK |
++	    IEEE80211_EHT_PHY_CAP3_CODEBOOK_7_5_MU_FDBK |
++	    IEEE80211_EHT_PHY_CAP3_TRIG_MU_BF_PART_BW_FDBK |
++	    IEEE80211_EHT_PHY_CAP3_TRIG_CQI_FDBK;
++	eht_cap_elem->phy_cap_info[3] &= ~m;
++
++	m = IEEE80211_EHT_PHY_CAP4_PART_BW_DL_MU_MIMO |
++	    IEEE80211_EHT_PHY_CAP4_PSR_SR_SUPP |
++	    IEEE80211_EHT_PHY_CAP4_POWER_BOOST_FACT_SUPP |
++	    IEEE80211_EHT_PHY_CAP4_EHT_MU_PPDU_4_EHT_LTF_08_GI;
++	eht_cap_elem->phy_cap_info[4] &= ~m;
++
++	m = IEEE80211_EHT_PHY_CAP5_NON_TRIG_CQI_FEEDBACK |
++	    IEEE80211_EHT_PHY_CAP5_TX_LESS_242_TONE_RU_SUPP |
++	    IEEE80211_EHT_PHY_CAP5_RX_LESS_242_TONE_RU_SUPP |
++	    IEEE80211_EHT_PHY_CAP5_MAX_NUM_SUPP_EHT_LTF_MASK;
++	eht_cap_elem->phy_cap_info[5] &= ~m;
++
++	m = IEEE80211_EHT_PHY_CAP6_MAX_NUM_SUPP_EHT_LTF_MASK;
++	eht_cap_elem->phy_cap_info[6] &= ~m;
++
++	m = IEEE80211_EHT_PHY_CAP7_NON_OFDMA_UL_MU_MIMO_80MHZ |
++	    IEEE80211_EHT_PHY_CAP7_NON_OFDMA_UL_MU_MIMO_160MHZ |
++	    IEEE80211_EHT_PHY_CAP7_NON_OFDMA_UL_MU_MIMO_320MHZ |
++	    IEEE80211_EHT_PHY_CAP7_MU_BEAMFORMER_80MHZ |
++	    IEEE80211_EHT_PHY_CAP7_MU_BEAMFORMER_160MHZ |
++	    IEEE80211_EHT_PHY_CAP7_MU_BEAMFORMER_320MHZ;
++	eht_cap_elem->phy_cap_info[7] &= ~m;
++}
++
++static void ath12k_mac_copy_eht_cap(struct ath12k *ar,
++				    struct ath12k_band_cap *band_cap,
++				    struct ieee80211_he_cap_elem *he_cap_elem,
++				    int iftype,
++				    struct ieee80211_sta_eht_cap *eht_cap)
++{
++	struct ieee80211_eht_cap_elem_fixed *eht_cap_elem = &eht_cap->eht_cap_elem;
++
++	memset(eht_cap, 0, sizeof(struct ieee80211_sta_eht_cap));
++
++	if (!(test_bit(WMI_TLV_SERVICE_11BE, ar->ab->wmi_ab.svc_map)) ||
++	    ath12k_acpi_get_disable_11be(ar->ab))
++		return;
++
++	eht_cap->has_eht = true;
++	memcpy(eht_cap_elem->mac_cap_info, band_cap->eht_cap_mac_info,
++	       sizeof(eht_cap_elem->mac_cap_info));
++	memcpy(eht_cap_elem->phy_cap_info, band_cap->eht_cap_phy_info,
++	       sizeof(eht_cap_elem->phy_cap_info));
++
++	switch (iftype) {
++	case NL80211_IFTYPE_AP:
++		eht_cap_elem->phy_cap_info[0] &=
++			~IEEE80211_EHT_PHY_CAP0_242_TONE_RU_GT20MHZ;
++		eht_cap_elem->phy_cap_info[4] &=
++			~IEEE80211_EHT_PHY_CAP4_PART_BW_DL_MU_MIMO;
++		eht_cap_elem->phy_cap_info[5] &=
++			~IEEE80211_EHT_PHY_CAP5_TX_LESS_242_TONE_RU_SUPP;
++		break;
++	case NL80211_IFTYPE_STATION:
++		eht_cap_elem->phy_cap_info[7] &=
++			~(IEEE80211_EHT_PHY_CAP7_NON_OFDMA_UL_MU_MIMO_80MHZ |
++			  IEEE80211_EHT_PHY_CAP7_NON_OFDMA_UL_MU_MIMO_160MHZ |
++			  IEEE80211_EHT_PHY_CAP7_NON_OFDMA_UL_MU_MIMO_320MHZ);
++		eht_cap_elem->phy_cap_info[7] &=
++			~(IEEE80211_EHT_PHY_CAP7_MU_BEAMFORMER_80MHZ |
++			  IEEE80211_EHT_PHY_CAP7_MU_BEAMFORMER_160MHZ |
++			  IEEE80211_EHT_PHY_CAP7_MU_BEAMFORMER_320MHZ);
++		break;
++	case NL80211_IFTYPE_MESH_POINT:
++		ath12k_mac_filter_eht_cap_mesh(eht_cap_elem);
++		break;
++	default:
++		break;
++	}
++
++	ath12k_mac_copy_eht_mcs_nss(band_cap, &eht_cap->eht_mcs_nss_supp,
++				    he_cap_elem, eht_cap_elem);
++
++	if (eht_cap_elem->phy_cap_info[5] &
++	    IEEE80211_EHT_PHY_CAP5_PPE_THRESHOLD_PRESENT)
++		ath12k_mac_copy_eht_ppe_thresh(&band_cap->eht_ppet, eht_cap);
++}
++
++static int ath12k_mac_copy_sband_iftype_data(struct ath12k *ar,
++					     struct ath12k_pdev_cap *cap,
++					     struct ieee80211_sband_iftype_data *data,
++					     int band)
++{
++	struct ath12k_band_cap *band_cap = &cap->band[band];
++	int i, idx = 0;
++
++	for (i = 0; i < NUM_NL80211_IFTYPES; i++) {
++		struct ieee80211_sta_he_cap *he_cap = &data[idx].he_cap;
++
++		switch (i) {
++		case NL80211_IFTYPE_STATION:
++		case NL80211_IFTYPE_AP:
++		case NL80211_IFTYPE_MESH_POINT:
++			break;
++
++		default:
++			continue;
++		}
++
++		data[idx].types_mask = BIT(i);
++
++		ath12k_mac_copy_he_cap(ar, band_cap, i, ar->num_tx_chains, he_cap);
++		if (band == NL80211_BAND_6GHZ) {
++			data[idx].he_6ghz_capa.capa =
++				ath12k_mac_setup_he_6ghz_cap(cap, band_cap);
++		}
++		ath12k_mac_copy_eht_cap(ar, band_cap, &he_cap->he_cap_elem, i,
++					&data[idx].eht_cap);
++		idx++;
++	}
++
++	return idx;
++}
++
++static void ath12k_mac_setup_sband_iftype_data(struct ath12k *ar,
++					       struct ath12k_pdev_cap *cap)
++{
++	struct ieee80211_supported_band *sband;
++	enum nl80211_band band;
++	int count;
++
++	if (cap->supported_bands & WMI_HOST_WLAN_2GHZ_CAP) {
++		band = NL80211_BAND_2GHZ;
++		count = ath12k_mac_copy_sband_iftype_data(ar, cap,
++							  ar->mac.iftype[band],
++							  band);
++		sband = &ar->mac.sbands[band];
++		_ieee80211_set_sband_iftype_data(sband, ar->mac.iftype[band],
++						 count);
++	}
++
++	if (cap->supported_bands & WMI_HOST_WLAN_5GHZ_CAP) {
++		band = NL80211_BAND_5GHZ;
++		count = ath12k_mac_copy_sband_iftype_data(ar, cap,
++							  ar->mac.iftype[band],
++							  band);
++		sband = &ar->mac.sbands[band];
++		_ieee80211_set_sband_iftype_data(sband, ar->mac.iftype[band],
++						 count);
++	}
++
++	if (cap->supported_bands & WMI_HOST_WLAN_5GHZ_CAP &&
++	    ar->supports_6ghz) {
++		band = NL80211_BAND_6GHZ;
++		count = ath12k_mac_copy_sband_iftype_data(ar, cap,
++							  ar->mac.iftype[band],
++							  band);
++		sband = &ar->mac.sbands[band];
++		_ieee80211_set_sband_iftype_data(sband, ar->mac.iftype[band],
++						 count);
++	}
++}
++
++static int __ath12k_set_antenna(struct ath12k *ar, u32 tx_ant, u32 rx_ant)
++{
++	struct ath12k_hw *ah = ath12k_ar_to_ah(ar);
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (ath12k_check_chain_mask(ar, tx_ant, true))
++		return -EINVAL;
++
++	if (ath12k_check_chain_mask(ar, rx_ant, false))
++		return -EINVAL;
++
++	/* Since we advertised the max cap of all radios combined during wiphy
++	 * registration, ensure we don't set the antenna config higher than the
++	 * limits
++	 */
++	tx_ant = min_t(u32, tx_ant, ar->pdev->cap.tx_chain_mask);
++	rx_ant = min_t(u32, rx_ant, ar->pdev->cap.rx_chain_mask);
++
++	ar->cfg_tx_chainmask = tx_ant;
++	ar->cfg_rx_chainmask = rx_ant;
++
++	if (ah->state != ATH12K_HW_STATE_ON &&
++	    ah->state != ATH12K_HW_STATE_RESTARTED)
++		return 0;
++
++	ret = ath12k_wmi_pdev_set_param(ar, WMI_PDEV_PARAM_TX_CHAIN_MASK,
++					tx_ant, ar->pdev->pdev_id);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set tx-chainmask: %d, req 0x%x\n",
++			    ret, tx_ant);
++		return ret;
++	}
++
++	ar->num_tx_chains = hweight32(tx_ant);
++
++	ret = ath12k_wmi_pdev_set_param(ar, WMI_PDEV_PARAM_RX_CHAIN_MASK,
++					rx_ant, ar->pdev->pdev_id);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set rx-chainmask: %d, req 0x%x\n",
++			    ret, rx_ant);
++		return ret;
++	}
++
++	ar->num_rx_chains = hweight32(rx_ant);
++
++	/* Reload HT/VHT/HE capability */
++	ath12k_mac_setup_ht_vht_cap(ar, &ar->pdev->cap, NULL);
++	ath12k_mac_setup_sband_iftype_data(ar, &ar->pdev->cap);
++
++	return 0;
++}
++
++static void ath12k_mgmt_over_wmi_tx_drop(struct ath12k *ar, struct sk_buff *skb)
++{
++	int num_mgmt;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	ieee80211_free_txskb(ath12k_ar_to_hw(ar), skb);
++
++	num_mgmt = atomic_dec_if_positive(&ar->num_pending_mgmt_tx);
++
++	if (num_mgmt < 0)
++		WARN_ON_ONCE(1);
++
++	if (!num_mgmt)
++		wake_up(&ar->txmgmt_empty_waitq);
++}
++
++static void ath12k_mac_tx_mgmt_free(struct ath12k *ar, int buf_id)
++{
++	struct sk_buff *msdu;
++	struct ieee80211_tx_info *info;
++
++	spin_lock_bh(&ar->txmgmt_idr_lock);
++	msdu = idr_remove(&ar->txmgmt_idr, buf_id);
++	spin_unlock_bh(&ar->txmgmt_idr_lock);
++
++	if (!msdu)
++		return;
++
++	dma_unmap_single(ar->ab->dev, ATH12K_SKB_CB(msdu)->paddr, msdu->len,
++			 DMA_TO_DEVICE);
++
++	info = IEEE80211_SKB_CB(msdu);
++	memset(&info->status, 0, sizeof(info->status));
++
++	ath12k_mgmt_over_wmi_tx_drop(ar, msdu);
++}
++
++int ath12k_mac_tx_mgmt_pending_free(int buf_id, void *skb, void *ctx)
++{
++	struct ath12k *ar = ctx;
++
++	ath12k_mac_tx_mgmt_free(ar, buf_id);
++
++	return 0;
++}
++
++static int ath12k_mac_vif_txmgmt_idr_remove(int buf_id, void *skb, void *ctx)
++{
++	struct ieee80211_vif *vif = ctx;
++	struct ath12k_skb_cb *skb_cb = ATH12K_SKB_CB(skb);
++	struct ath12k *ar = skb_cb->ar;
++
++	if (skb_cb->vif == vif)
++		ath12k_mac_tx_mgmt_free(ar, buf_id);
++
++	return 0;
++}
++
++static int ath12k_mac_mgmt_tx_wmi(struct ath12k *ar, struct ath12k_link_vif *arvif,
++				  struct sk_buff *skb)
++{
++	struct ath12k_base *ab = ar->ab;
++	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)skb->data;
++	struct ath12k_skb_cb *skb_cb = ATH12K_SKB_CB(skb);
++	struct ieee80211_tx_info *info;
++	enum hal_encrypt_type enctype;
++	unsigned int mic_len;
++	dma_addr_t paddr;
++	int buf_id;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	skb_cb->ar = ar;
++	spin_lock_bh(&ar->txmgmt_idr_lock);
++	buf_id = idr_alloc(&ar->txmgmt_idr, skb, 0,
++			   ATH12K_TX_MGMT_NUM_PENDING_MAX, GFP_ATOMIC);
++	spin_unlock_bh(&ar->txmgmt_idr_lock);
++	if (buf_id < 0)
++		return -ENOSPC;
++
++	info = IEEE80211_SKB_CB(skb);
++	if ((skb_cb->flags & ATH12K_SKB_CIPHER_SET) &&
++	    !(info->flags & IEEE80211_TX_CTL_HW_80211_ENCAP)) {
++		if ((ieee80211_is_action(hdr->frame_control) ||
++		     ieee80211_is_deauth(hdr->frame_control) ||
++		     ieee80211_is_disassoc(hdr->frame_control)) &&
++		     ieee80211_has_protected(hdr->frame_control)) {
++			enctype = ath12k_dp_tx_get_encrypt_type(skb_cb->cipher);
++			mic_len = ath12k_dp_rx_crypto_mic_len(ab->dp, enctype);
++			skb_put(skb, mic_len);
++		}
++	}
++
++	paddr = dma_map_single(ab->dev, skb->data, skb->len, DMA_TO_DEVICE);
++	if (dma_mapping_error(ab->dev, paddr)) {
++		ath12k_warn(ab, "failed to DMA map mgmt Tx buffer\n");
++		ret = -EIO;
++		goto err_free_idr;
++	}
++
++	skb_cb->paddr = paddr;
++
++	ret = ath12k_wmi_mgmt_send(arvif, buf_id, skb);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to send mgmt frame: %d\n", ret);
++		goto err_unmap_buf;
++	}
++
++	return 0;
++
++err_unmap_buf:
++	dma_unmap_single(ab->dev, skb_cb->paddr,
++			 skb->len, DMA_TO_DEVICE);
++err_free_idr:
++	spin_lock_bh(&ar->txmgmt_idr_lock);
++	idr_remove(&ar->txmgmt_idr, buf_id);
++	spin_unlock_bh(&ar->txmgmt_idr_lock);
++
++	return ret;
++}
++
++static void ath12k_mgmt_over_wmi_tx_purge(struct ath12k *ar)
++{
++	struct sk_buff *skb;
++
++	while ((skb = skb_dequeue(&ar->wmi_mgmt_tx_queue)) != NULL)
++		ath12k_mgmt_over_wmi_tx_drop(ar, skb);
++}
++
++static int ath12k_mac_mgmt_action_frame_fill_elem_data(struct ath12k_link_vif *arvif,
++						       struct sk_buff *skb)
++{
++	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)skb->data;
++	u8 category, *buf, iv_len, action_code, dialog_token;
++	struct ieee80211_bss_conf *link_conf;
++	struct ieee80211_chanctx_conf *conf;
++	int cur_tx_power, max_tx_power;
++	struct ath12k *ar = arvif->ar;
++	struct ieee80211_hw *hw = ath12k_ar_to_hw(ar);
++	struct wiphy *wiphy = hw->wiphy;
++	struct ath12k_skb_cb *skb_cb;
++	struct ieee80211_mgmt *mgmt;
++	unsigned int remaining_len;
++	bool has_protected;
++
++	lockdep_assert_wiphy(wiphy);
++
++	/* make sure category field is present */
++	if (skb->len < IEEE80211_MIN_ACTION_SIZE(category))
++		return -EINVAL;
++
++	remaining_len = skb->len - IEEE80211_MIN_ACTION_SIZE(category);
++	has_protected = ieee80211_has_protected(hdr->frame_control);
++
++	/* In case of SW crypto and hdr protected (PMF), packet will already be encrypted,
++	 * we can't put in data in this case
++	 */
++	if (test_bit(ATH12K_FLAG_HW_CRYPTO_DISABLED, &ar->ab->dev_flags) &&
++	    has_protected)
++		return 0;
++
++	mgmt = (struct ieee80211_mgmt *)hdr;
++	buf = (u8 *)&mgmt->u.action;
++
++	/* FCTL_PROTECTED frame might have extra space added for HDR_LEN. Offset that
++	 * many bytes if it is there
++	 */
++	if (has_protected) {
++		skb_cb = ATH12K_SKB_CB(skb);
++
++		switch (skb_cb->cipher) {
++		/* Cipher suite having flag %IEEE80211_KEY_FLAG_GENERATE_IV_MGMT set in
++		 * key needs to be processed. See ath12k_install_key()
++		 */
++		case WLAN_CIPHER_SUITE_CCMP:
++		case WLAN_CIPHER_SUITE_CCMP_256:
++		case WLAN_CIPHER_SUITE_GCMP:
++		case WLAN_CIPHER_SUITE_GCMP_256:
++			iv_len = IEEE80211_CCMP_HDR_LEN;
++			break;
++		case WLAN_CIPHER_SUITE_TKIP:
++			iv_len = 0;
++			break;
++		default:
++			return -EINVAL;
++		}
++
++		if (remaining_len < iv_len)
++			return -EINVAL;
++
++		buf += iv_len;
++		remaining_len -= iv_len;
++	}
++
++	category = *buf++;
++	/* category code is already taken care in %IEEE80211_MIN_ACTION_SIZE hence
++	 * no need to adjust remaining_len
++	 */
++
++	switch (category) {
++	case WLAN_CATEGORY_RADIO_MEASUREMENT:
++		/* need action code and dialog token */
++		if (remaining_len < 2)
++			return -EINVAL;
++
++		/* Packet Format:
++		 *	Action Code | Dialog Token | Variable Len (based on Action Code)
++		 */
++		action_code = *buf++;
++		dialog_token = *buf++;
++		remaining_len -= 2;
++
++		link_conf = ath12k_mac_get_link_bss_conf(arvif);
++		if (!link_conf) {
++			ath12k_warn(ar->ab,
++				    "failed to get bss link conf for vdev %d in RM handling\n",
++				    arvif->vdev_id);
++			return -EINVAL;
++		}
++
++		conf = wiphy_dereference(wiphy, link_conf->chanctx_conf);
++		if (!conf)
++			return -ENOENT;
++
++		cur_tx_power = link_conf->txpower;
++		max_tx_power = min(conf->def.chan->max_reg_power,
++				   (int)ar->max_tx_power / 2);
++
++		ath12k_mac_op_get_txpower(hw, arvif->ahvif->vif, arvif->link_id,
++					  &cur_tx_power);
++
++		switch (action_code) {
++		case WLAN_RM_ACTION_LINK_MEASUREMENT_REQUEST:
++			/* need variable fields to be present in len */
++			if (remaining_len < 2)
++				return -EINVAL;
++
++			/* Variable length format as defined in IEEE 802.11-2024,
++			 * Figure 9-1187-Link Measurement Request frame Action field
++			 * format.
++			 *	Transmit Power | Max Tx Power
++			 * We fill both of these.
++			 */
++			*buf++ = cur_tx_power;
++			*buf = max_tx_power;
++
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++				   "RRM: Link Measurement Req dialog_token %u cur_tx_power %d max_tx_power %d\n",
++				   dialog_token, cur_tx_power, max_tx_power);
++			break;
++		case WLAN_RM_ACTION_LINK_MEASUREMENT_REPORT:
++			/* need variable fields to be present in len */
++			if (remaining_len < 3)
++				return -EINVAL;
++
++			/* Variable length format as defined in IEEE 802.11-2024,
++			 * Figure 9-1188-Link Measurement Report frame Action field format
++			 *	TPC Report | Variable Fields
++			 *
++			 * TPC Report Format:
++			 *	Element ID | Len | Tx Power | Link Margin
++			 *
++			 * We fill Tx power in the TPC Report (2nd index)
++			 */
++			buf[2] = cur_tx_power;
++
++			/* TODO: At present, Link margin data is not present so can't
++			 * really fill it now. Once it is available, it can be added
++			 * here
++			 */
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++				   "RRM: Link Measurement Report dialog_token %u cur_tx_power %d\n",
++				   dialog_token, cur_tx_power);
++			break;
++		default:
++			return -EINVAL;
++		}
++		break;
++	default:
++		/* nothing to fill */
++		return 0;
++	}
++
++	return 0;
++}
++
++static int ath12k_mac_mgmt_frame_fill_elem_data(struct ath12k_link_vif *arvif,
++						struct sk_buff *skb)
++{
++	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)skb->data;
++
++	if (!ieee80211_is_action(hdr->frame_control))
++		return 0;
++
++	return ath12k_mac_mgmt_action_frame_fill_elem_data(arvif, skb);
++}
++
++static void ath12k_mgmt_over_wmi_tx_work(struct wiphy *wiphy, struct wiphy_work *work)
++{
++	struct ath12k *ar = container_of(work, struct ath12k, wmi_mgmt_tx_work);
++	struct ath12k_hw *ah = ar->ah;
++	struct ath12k_skb_cb *skb_cb;
++	struct ath12k_vif *ahvif;
++	struct ath12k_link_vif *arvif;
++	struct sk_buff *skb;
++	int ret;
++
++	lockdep_assert_wiphy(wiphy);
++
++	while ((skb = skb_dequeue(&ar->wmi_mgmt_tx_queue)) != NULL) {
++		skb_cb = ATH12K_SKB_CB(skb);
++		if (!skb_cb->vif) {
++			ath12k_warn(ar->ab, "no vif found for mgmt frame\n");
++			ath12k_mgmt_over_wmi_tx_drop(ar, skb);
++			continue;
++		}
++
++		ahvif = ath12k_vif_to_ahvif(skb_cb->vif);
++		if (!(ahvif->links_map & BIT(skb_cb->link_id))) {
++			ath12k_warn(ar->ab,
++				    "invalid linkid %u in mgmt over wmi tx with linkmap 0x%x\n",
++				    skb_cb->link_id, ahvif->links_map);
++			ath12k_mgmt_over_wmi_tx_drop(ar, skb);
++			continue;
++		}
++
++		arvif = wiphy_dereference(ah->hw->wiphy, ahvif->link[skb_cb->link_id]);
++		if (ar->allocated_vdev_map & (1LL << arvif->vdev_id)) {
++			/* Fill in the data which is required to be filled by the driver
++			 * For example: Max Tx power in Link Measurement Request/Report
++			 */
++			ret = ath12k_mac_mgmt_frame_fill_elem_data(arvif, skb);
++			if (ret) {
++				/* If we couldn't fill the data due to any reason,
++				 * let's not discard transmitting the packet.
++				 * For example: Software crypto and PMF case
++				 */
++				ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++					   "Failed to fill the required data for the mgmt packet err %d\n",
++					   ret);
++			}
++
++			ret = ath12k_mac_mgmt_tx_wmi(ar, arvif, skb);
++			if (ret) {
++				ath12k_warn(ar->ab, "failed to tx mgmt frame, vdev_id %d :%d\n",
++					    arvif->vdev_id, ret);
++				ath12k_mgmt_over_wmi_tx_drop(ar, skb);
++			}
++		} else {
++			ath12k_warn(ar->ab,
++				    "dropping mgmt frame for vdev %d link %u is_started %d\n",
++				    arvif->vdev_id,
++				    skb_cb->link_id,
++				    arvif->is_started);
++			ath12k_mgmt_over_wmi_tx_drop(ar, skb);
++		}
++	}
++}
++
++int ath12k_mac_mgmt_tx(struct ath12k *ar, struct sk_buff *skb,
++		       bool is_prb_rsp)
++{
++	struct sk_buff_head *q = &ar->wmi_mgmt_tx_queue;
++
++	if (test_bit(ATH12K_FLAG_CRASH_FLUSH, &ar->ab->dev_flags))
++		return -ESHUTDOWN;
++
++	/* Drop probe response packets when the pending management tx
++	 * count has reached a certain threshold, so as to prioritize
++	 * other mgmt packets like auth and assoc to be sent on time
++	 * for establishing successful connections.
++	 */
++	if (is_prb_rsp &&
++	    atomic_read(&ar->num_pending_mgmt_tx) > ATH12K_PRB_RSP_DROP_THRESHOLD) {
++		ath12k_warn(ar->ab,
++			    "dropping probe response as pending queue is almost full\n");
++		return -ENOSPC;
++	}
++
++	if (skb_queue_len_lockless(q) >= ATH12K_TX_MGMT_NUM_PENDING_MAX) {
++		ath12k_warn(ar->ab, "mgmt tx queue is full\n");
++		return -ENOSPC;
++	}
++
++	skb_queue_tail(q, skb);
++	atomic_inc(&ar->num_pending_mgmt_tx);
++	wiphy_work_queue(ath12k_ar_to_hw(ar)->wiphy, &ar->wmi_mgmt_tx_work);
++
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_mgmt_tx);
++
++void ath12k_mac_add_p2p_noa_ie(struct ath12k *ar,
++			       struct ieee80211_vif *vif,
++			       struct sk_buff *skb,
++			       bool is_prb_rsp)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++
++	if (likely(!is_prb_rsp))
++		return;
++
++	spin_lock_bh(&ar->data_lock);
++
++	if (ahvif->u.ap.noa_data &&
++	    !pskb_expand_head(skb, 0, ahvif->u.ap.noa_len,
++			      GFP_ATOMIC))
++		skb_put_data(skb, ahvif->u.ap.noa_data,
++			     ahvif->u.ap.noa_len);
++
++	spin_unlock_bh(&ar->data_lock);
++}
++EXPORT_SYMBOL(ath12k_mac_add_p2p_noa_ie);
++
++/* Note: called under rcu_read_lock() */
++void ath12k_mlo_mcast_update_tx_link_address(struct ieee80211_vif *vif,
++					     u8 link_id, struct sk_buff *skb,
++					     u32 info_flags)
++{
++	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)skb->data;
++	struct ieee80211_bss_conf *bss_conf;
++
++	if (info_flags & IEEE80211_TX_CTL_HW_80211_ENCAP)
++		return;
++
++	bss_conf = rcu_dereference(vif->link_conf[link_id]);
++	if (bss_conf)
++		ether_addr_copy(hdr->addr2, bss_conf->addr);
++}
++EXPORT_SYMBOL(ath12k_mlo_mcast_update_tx_link_address);
++
++/* Note: called under rcu_read_lock() */
++u8 ath12k_mac_get_tx_link(struct ieee80211_sta *sta, struct ieee80211_vif *vif,
++			  u8 link, struct sk_buff *skb, u32 info_flags)
++{
++	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)skb->data;
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ieee80211_link_sta *link_sta;
++	struct ieee80211_bss_conf *bss_conf;
++	struct ath12k_sta *ahsta;
++
++	/* Use the link id passed or the default vif link */
++	if (!sta) {
++		if (link != IEEE80211_LINK_UNSPECIFIED)
++			return link;
++
++		return ahvif->deflink.link_id;
++	}
++
++	ahsta = ath12k_sta_to_ahsta(sta);
++
++	/* Below translation ensures we pass proper A2 & A3 for non ML clients.
++	 * Also it assumes for now support only for MLO AP in this path
++	 */
++	if (!sta->mlo) {
++		link = ahsta->deflink.link_id;
++
++		if (info_flags & IEEE80211_TX_CTL_HW_80211_ENCAP)
++			return link;
++
++		bss_conf = rcu_dereference(vif->link_conf[link]);
++		if (bss_conf) {
++			ether_addr_copy(hdr->addr2, bss_conf->addr);
++			if (!ieee80211_has_tods(hdr->frame_control) &&
++			    !ieee80211_has_fromds(hdr->frame_control))
++				ether_addr_copy(hdr->addr3, bss_conf->addr);
++		}
++
++		return link;
++	}
++
++	/* enqueue eth enacap & data frames on primary link, FW does link
++	 * selection and address translation.
++	 */
++	if (info_flags & IEEE80211_TX_CTL_HW_80211_ENCAP ||
++	    ieee80211_is_data(hdr->frame_control))
++		return ahsta->assoc_link_id;
++
++	/* 802.11 frame cases */
++	if (link == IEEE80211_LINK_UNSPECIFIED)
++		link = ahsta->deflink.link_id;
++
++	if (!ieee80211_is_mgmt(hdr->frame_control))
++		return link;
++
++	/* Perform address conversion for ML STA Tx */
++	bss_conf = rcu_dereference(vif->link_conf[link]);
++	link_sta = rcu_dereference(sta->link[link]);
++
++	if (bss_conf && link_sta) {
++		ether_addr_copy(hdr->addr1, link_sta->addr);
++		ether_addr_copy(hdr->addr2, bss_conf->addr);
++
++		if (vif->type == NL80211_IFTYPE_STATION && bss_conf->bssid)
++			ether_addr_copy(hdr->addr3, bss_conf->bssid);
++		else if (vif->type == NL80211_IFTYPE_AP)
++			ether_addr_copy(hdr->addr3, bss_conf->addr);
++
++		return link;
++	}
++
++	if (bss_conf) {
++		/* In certain cases where a ML sta associated and added subset of
++		 * links on which the ML AP is active, but now sends some frame
++		 * (ex. Probe request) on a different link which is active in our
++		 * MLD but was not added during previous association, we can
++		 * still honor the Tx to that ML STA via the requested link.
++		 * The control would reach here in such case only when that link
++		 * address is same as the MLD address or in worst case clients
++		 * used MLD address at TA wrongly which would have helped
++		 * identify the ML sta object and pass it here.
++		 * If the link address of that STA is different from MLD address,
++		 * then the sta object would be NULL and control won't reach
++		 * here but return at the start of the function itself with !sta
++		 * check. Also this would not need any translation at hdr->addr1
++		 * from MLD to link address since the RA is the MLD address
++		 * (same as that link address ideally) already.
++		 */
++		ether_addr_copy(hdr->addr2, bss_conf->addr);
++
++		if (vif->type == NL80211_IFTYPE_STATION && bss_conf->bssid)
++			ether_addr_copy(hdr->addr3, bss_conf->bssid);
++		else if (vif->type == NL80211_IFTYPE_AP)
++			ether_addr_copy(hdr->addr3, bss_conf->addr);
++	}
++
++	return link;
++}
++EXPORT_SYMBOL(ath12k_mac_get_tx_link);
++
++void ath12k_mac_drain_tx(struct ath12k *ar)
++{
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	/* make sure rcu-protected mac80211 tx path itself is drained */
++	synchronize_net();
++
++	wiphy_work_cancel(ath12k_ar_to_hw(ar)->wiphy, &ar->wmi_mgmt_tx_work);
++	ath12k_mgmt_over_wmi_tx_purge(ar);
++}
++
++static int ath12k_mac_config_mon_status_default(struct ath12k *ar, bool enable)
++{
++	struct htt_rx_ring_tlv_filter tlv_filter = {};
++	struct ath12k_base *ab = ar->ab;
++	u32 ring_id, i;
++	int ret = 0;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (!ab->hw_params->rxdma1_enable)
++		return ret;
++
++	if (enable) {
++		tlv_filter = ath12k_mac_mon_status_filter_default;
++
++		if (ath12k_debugfs_rx_filter(ar))
++			tlv_filter.rx_filter = ath12k_debugfs_rx_filter(ar);
++	} else {
++		tlv_filter.rxmon_disable = true;
++	}
++
++	for (i = 0; i < ab->hw_params->num_rxdma_per_pdev; i++) {
++		ring_id = ar->dp.rxdma_mon_dst_ring[i].ring_id;
++		ret = ath12k_dp_tx_htt_rx_filter_setup(ab, ring_id,
++						       ar->dp.mac_id + i,
++						       HAL_RXDMA_MONITOR_DST,
++						       DP_RXDMA_REFILL_RING_SIZE,
++						       &tlv_filter);
++		if (ret) {
++			ath12k_err(ab,
++				   "failed to setup filter for monitor buf %d\n",
++				   ret);
++		}
++	}
++
++	return ret;
++}
++
++static int ath12k_mac_start(struct ath12k *ar)
++{
++	struct ath12k_hw *ah = ar->ah;
++	struct ath12k_base *ab = ar->ab;
++	struct ath12k_pdev *pdev = ar->pdev;
++	int ret;
++
++	lockdep_assert_held(&ah->hw_mutex);
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	ret = ath12k_wmi_pdev_set_param(ar, WMI_PDEV_PARAM_PMF_QOS,
++					1, pdev->pdev_id);
++
++	if (ret) {
++		ath12k_err(ab, "failed to enable PMF QOS: %d\n", ret);
++		goto err;
++	}
++
++	ret = ath12k_wmi_pdev_set_param(ar, WMI_PDEV_PARAM_DYNAMIC_BW, 1,
++					pdev->pdev_id);
++	if (ret) {
++		ath12k_err(ab, "failed to enable dynamic bw: %d\n", ret);
++		goto err;
++	}
++
++	ret = ath12k_wmi_pdev_set_param(ar, WMI_PDEV_PARAM_ARP_AC_OVERRIDE,
++					0, pdev->pdev_id);
++	if (ret) {
++		ath12k_err(ab, "failed to set ac override for ARP: %d\n",
++			   ret);
++		goto err;
++	}
++
++	ret = ath12k_wmi_send_dfs_phyerr_offload_enable_cmd(ar, pdev->pdev_id);
++	if (ret) {
++		ath12k_err(ab, "failed to offload radar detection: %d\n",
++			   ret);
++		goto err;
++	}
++
++	ret = ath12k_dp_tx_htt_h2t_ppdu_stats_req(ar,
++						  HTT_PPDU_STATS_TAG_DEFAULT);
++	if (ret) {
++		ath12k_err(ab, "failed to req ppdu stats: %d\n", ret);
++		goto err;
++	}
++
++	ret = ath12k_wmi_pdev_set_param(ar, WMI_PDEV_PARAM_MESH_MCAST_ENABLE,
++					1, pdev->pdev_id);
++
++	if (ret) {
++		ath12k_err(ab, "failed to enable MESH MCAST ENABLE: (%d\n", ret);
++		goto err;
++	}
++
++	__ath12k_set_antenna(ar, ar->cfg_tx_chainmask, ar->cfg_rx_chainmask);
++
++	/* TODO: Do we need to enable ANI? */
++
++	ret = ath12k_reg_update_chan_list(ar, false);
++
++	/* The ar state alone can be turned off for non supported country
++	 * without returning the error value. As we need to update the channel
++	 * for the next ar.
++	 */
++	if (ret) {
++		if (ret == -EINVAL)
++			ret = 0;
++		goto err;
++	}
++
++	ar->num_started_vdevs = 0;
++	ar->num_created_vdevs = 0;
++	ar->num_peers = 0;
++	ar->allocated_vdev_map = 0;
++	ar->chan_tx_pwr = ATH12K_PDEV_TX_POWER_INVALID;
++
++	/* Configure monitor status ring with default rx_filter to get rx status
++	 * such as rssi, rx_duration.
++	 */
++	ret = ath12k_mac_config_mon_status_default(ar, true);
++	if (ret && (ret != -EOPNOTSUPP)) {
++		ath12k_err(ab, "failed to configure monitor status ring with default rx_filter: (%d)\n",
++			   ret);
++		goto err;
++	}
++
++	if (ret == -EOPNOTSUPP)
++		ath12k_dbg(ab, ATH12K_DBG_MAC,
++			   "monitor status config is not yet supported");
++
++	/* Configure the hash seed for hash based reo dest ring selection */
++	ath12k_wmi_pdev_lro_cfg(ar, ar->pdev->pdev_id);
++
++	/* allow device to enter IMPS */
++	if (ab->hw_params->idle_ps) {
++		ret = ath12k_wmi_pdev_set_param(ar, WMI_PDEV_PARAM_IDLE_PS_CONFIG,
++						1, pdev->pdev_id);
++		if (ret) {
++			ath12k_err(ab, "failed to enable idle ps: %d\n", ret);
++			goto err;
++		}
++	}
++
++	rcu_assign_pointer(ab->pdevs_active[ar->pdev_idx],
++			   &ab->pdevs[ar->pdev_idx]);
++
++	return 0;
++err:
++
++	return ret;
++}
++
++static void ath12k_drain_tx(struct ath12k_hw *ah)
++{
++	struct ath12k *ar;
++	int i;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	for_each_ar(ah, ar, i)
++		ath12k_mac_drain_tx(ar);
++}
++
++int ath12k_mac_op_start(struct ieee80211_hw *hw)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k *ar;
++	int ret, i;
++
++	if (ath12k_ftm_mode)
++		return -EPERM;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	ath12k_drain_tx(ah);
++
++	guard(mutex)(&ah->hw_mutex);
++
++	switch (ah->state) {
++	case ATH12K_HW_STATE_OFF:
++		ah->state = ATH12K_HW_STATE_ON;
++		break;
++	case ATH12K_HW_STATE_RESTARTING:
++		ah->state = ATH12K_HW_STATE_RESTARTED;
++		break;
++	case ATH12K_HW_STATE_RESTARTED:
++	case ATH12K_HW_STATE_WEDGED:
++	case ATH12K_HW_STATE_ON:
++	case ATH12K_HW_STATE_TM:
++		ah->state = ATH12K_HW_STATE_OFF;
++
++		WARN_ON(1);
++		return -EINVAL;
++	}
++
++	for_each_ar(ah, ar, i) {
++		ret = ath12k_mac_start(ar);
++		if (ret) {
++			ah->state = ATH12K_HW_STATE_OFF;
++
++			ath12k_err(ar->ab, "fail to start mac operations in pdev idx %d ret %d\n",
++				   ar->pdev_idx, ret);
++			goto fail_start;
++		}
++	}
++
++	return 0;
++
++fail_start:
++	for (; i > 0; i--) {
++		ar = ath12k_ah_to_ar(ah, i - 1);
++		ath12k_mac_stop(ar);
++	}
++
++	return ret;
++}
++EXPORT_SYMBOL(ath12k_mac_op_start);
++
++int ath12k_mac_rfkill_config(struct ath12k *ar)
++{
++	struct ath12k_base *ab = ar->ab;
++	u32 param;
++	int ret;
++
++	if (ab->hw_params->rfkill_pin == 0)
++		return -EOPNOTSUPP;
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC,
++		   "mac rfkill_pin %d rfkill_cfg %d rfkill_on_level %d",
++		   ab->hw_params->rfkill_pin, ab->hw_params->rfkill_cfg,
++		   ab->hw_params->rfkill_on_level);
++
++	param = u32_encode_bits(ab->hw_params->rfkill_on_level,
++				WMI_RFKILL_CFG_RADIO_LEVEL) |
++		u32_encode_bits(ab->hw_params->rfkill_pin,
++				WMI_RFKILL_CFG_GPIO_PIN_NUM) |
++		u32_encode_bits(ab->hw_params->rfkill_cfg,
++				WMI_RFKILL_CFG_PIN_AS_GPIO);
++
++	ret = ath12k_wmi_pdev_set_param(ar, WMI_PDEV_PARAM_HW_RFKILL_CONFIG,
++					param, ar->pdev->pdev_id);
++	if (ret) {
++		ath12k_warn(ab,
++			    "failed to set rfkill config 0x%x: %d\n",
++			    param, ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++int ath12k_mac_rfkill_enable_radio(struct ath12k *ar, bool enable)
++{
++	enum wmi_rfkill_enable_radio param;
++	int ret;
++
++	if (enable)
++		param = WMI_RFKILL_ENABLE_RADIO_ON;
++	else
++		param = WMI_RFKILL_ENABLE_RADIO_OFF;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac %d rfkill enable %d",
++		   ar->pdev_idx, param);
++
++	ret = ath12k_wmi_pdev_set_param(ar, WMI_PDEV_PARAM_RFKILL_ENABLE,
++					param, ar->pdev->pdev_id);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set rfkill enable param %d: %d\n",
++			    param, ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static void ath12k_mac_stop(struct ath12k *ar)
++{
++	struct ath12k_pdev_dp *dp_pdev = &ar->dp;
++	struct ath12k_hw *ah = ar->ah;
++	struct htt_ppdu_stats_info *ppdu_stats, *tmp;
++	struct ath12k_wmi_scan_chan_list_arg *arg;
++	int ret;
++
++	lockdep_assert_held(&ah->hw_mutex);
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	ret = ath12k_mac_config_mon_status_default(ar, false);
++	if (ret && (ret != -EOPNOTSUPP))
++		ath12k_err(ar->ab, "failed to clear rx_filter for monitor status ring: (%d)\n",
++			   ret);
++
++	clear_bit(ATH12K_FLAG_CAC_RUNNING, &ar->dev_flags);
++
++	cancel_delayed_work_sync(&ar->scan.timeout);
++	wiphy_work_cancel(ath12k_ar_to_hw(ar)->wiphy, &ar->scan.vdev_clean_wk);
++	cancel_work_sync(&ar->regd_channel_update_work);
++	cancel_work_sync(&ar->regd_update_work);
++	cancel_work_sync(&ar->ab->rfkill_work);
++	cancel_work_sync(&ar->ab->update_11d_work);
++	ar->state_11d = ATH12K_11D_IDLE;
++	complete(&ar->completed_11d_scan);
++
++	spin_lock_bh(&dp_pdev->ppdu_list_lock);
++	list_for_each_entry_safe(ppdu_stats, tmp, &dp_pdev->ppdu_stats_info, list) {
++		list_del(&ppdu_stats->list);
++		kfree(ppdu_stats);
++	}
++	spin_unlock_bh(&dp_pdev->ppdu_list_lock);
++
++	spin_lock_bh(&ar->data_lock);
++	while ((arg = list_first_entry_or_null(&ar->regd_channel_update_queue,
++					       struct ath12k_wmi_scan_chan_list_arg,
++					       list))) {
++		list_del(&arg->list);
++		kfree(arg);
++	}
++	spin_unlock_bh(&ar->data_lock);
++
++	rcu_assign_pointer(ar->ab->pdevs_active[ar->pdev_idx], NULL);
++
++	synchronize_rcu();
++
++	atomic_set(&ar->num_pending_mgmt_tx, 0);
++}
++
++void ath12k_mac_op_stop(struct ieee80211_hw *hw, bool suspend)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k *ar;
++	int i;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	ath12k_drain_tx(ah);
++
++	mutex_lock(&ah->hw_mutex);
++
++	ah->state = ATH12K_HW_STATE_OFF;
++
++	for_each_ar(ah, ar, i)
++		ath12k_mac_stop(ar);
++
++	mutex_unlock(&ah->hw_mutex);
++}
++EXPORT_SYMBOL(ath12k_mac_op_stop);
++
++static u8
++ath12k_mac_get_vdev_stats_id(struct ath12k_link_vif *arvif)
++{
++	struct ath12k_base *ab = arvif->ar->ab;
++	u8 vdev_stats_id = 0;
++
++	do {
++		if (ab->free_vdev_stats_id_map & (1LL << vdev_stats_id)) {
++			vdev_stats_id++;
++			if (vdev_stats_id >= ATH12K_MAX_VDEV_STATS_ID) {
++				vdev_stats_id = ATH12K_INVAL_VDEV_STATS_ID;
++				break;
++			}
++		} else {
++			ab->free_vdev_stats_id_map |= (1LL << vdev_stats_id);
++			break;
++		}
++	} while (vdev_stats_id);
++
++	arvif->vdev_stats_id = vdev_stats_id;
++	return vdev_stats_id;
++}
++
++static int ath12k_mac_setup_vdev_params_mbssid(struct ath12k_link_vif *arvif,
++					       u32 *flags, u32 *tx_vdev_id)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ieee80211_bss_conf *link_conf;
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_link_vif *tx_arvif;
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf) {
++		ath12k_warn(ar->ab, "unable to access bss link conf in set mbssid params for vif %pM link %u\n",
++			    ahvif->vif->addr, arvif->link_id);
++		return -ENOLINK;
++	}
++
++	tx_arvif = ath12k_mac_get_tx_arvif(arvif, link_conf);
++	if (!tx_arvif)
++		return 0;
++
++	if (link_conf->nontransmitted) {
++		if (ath12k_ar_to_hw(ar)->wiphy !=
++		    ath12k_ar_to_hw(tx_arvif->ar)->wiphy)
++			return -EINVAL;
++
++		*flags = WMI_VDEV_MBSSID_FLAGS_NON_TRANSMIT_AP;
++		*tx_vdev_id = tx_arvif->vdev_id;
++	} else if (tx_arvif == arvif) {
++		*flags = WMI_VDEV_MBSSID_FLAGS_TRANSMIT_AP;
++	} else {
++		return -EINVAL;
++	}
++
++	if (link_conf->ema_ap)
++		*flags |= WMI_VDEV_MBSSID_FLAGS_EMA_MODE;
++
++	return 0;
++}
++
++static int ath12k_mac_setup_vdev_create_arg(struct ath12k_link_vif *arvif,
++					    struct ath12k_wmi_vdev_create_arg *arg)
++{
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_pdev *pdev = ar->pdev;
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	arg->if_id = arvif->vdev_id;
++	arg->type = ahvif->vdev_type;
++	arg->subtype = ahvif->vdev_subtype;
++	arg->pdev_id = pdev->pdev_id;
++
++	arg->mbssid_flags = WMI_VDEV_MBSSID_FLAGS_NON_MBSSID_AP;
++	arg->mbssid_tx_vdev_id = 0;
++	if (!test_bit(WMI_TLV_SERVICE_MBSS_PARAM_IN_VDEV_START_SUPPORT,
++		      ar->ab->wmi_ab.svc_map)) {
++		ret = ath12k_mac_setup_vdev_params_mbssid(arvif,
++							  &arg->mbssid_flags,
++							  &arg->mbssid_tx_vdev_id);
++		if (ret)
++			return ret;
++	}
++
++	if (pdev->cap.supported_bands & WMI_HOST_WLAN_2GHZ_CAP) {
++		arg->chains[NL80211_BAND_2GHZ].tx = ar->num_tx_chains;
++		arg->chains[NL80211_BAND_2GHZ].rx = ar->num_rx_chains;
++	}
++	if (pdev->cap.supported_bands & WMI_HOST_WLAN_5GHZ_CAP) {
++		arg->chains[NL80211_BAND_5GHZ].tx = ar->num_tx_chains;
++		arg->chains[NL80211_BAND_5GHZ].rx = ar->num_rx_chains;
++	}
++	if (pdev->cap.supported_bands & WMI_HOST_WLAN_5GHZ_CAP &&
++	    ar->supports_6ghz) {
++		arg->chains[NL80211_BAND_6GHZ].tx = ar->num_tx_chains;
++		arg->chains[NL80211_BAND_6GHZ].rx = ar->num_rx_chains;
++	}
++
++	arg->if_stats_id = ath12k_mac_get_vdev_stats_id(arvif);
++
++	if (ath12k_mac_is_ml_arvif(arvif)) {
++		if (hweight16(ahvif->vif->valid_links) > ATH12K_WMI_MLO_MAX_LINKS) {
++			ath12k_warn(ar->ab, "too many MLO links during setting up vdev: %d",
++				    ahvif->vif->valid_links);
++			return -EINVAL;
++		}
++
++		ether_addr_copy(arg->mld_addr, ahvif->vif->addr);
++	}
++
++	return 0;
++}
++
++static void ath12k_mac_update_vif_offload(struct ath12k_link_vif *arvif)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(ahvif);
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_base *ab = ar->ab;
++	u32 param_id, param_value;
++	int ret;
++
++	param_id = WMI_VDEV_PARAM_TX_ENCAP_TYPE;
++	if (vif->type != NL80211_IFTYPE_STATION &&
++	    vif->type != NL80211_IFTYPE_AP)
++		vif->offload_flags &= ~(IEEE80211_OFFLOAD_ENCAP_ENABLED |
++					IEEE80211_OFFLOAD_DECAP_ENABLED);
++
++	if (vif->offload_flags & IEEE80211_OFFLOAD_ENCAP_ENABLED)
++		ahvif->dp_vif.tx_encap_type = ATH12K_HW_TXRX_ETHERNET;
++	else if (test_bit(ATH12K_FLAG_RAW_MODE, &ab->dev_flags))
++		ahvif->dp_vif.tx_encap_type = ATH12K_HW_TXRX_RAW;
++	else
++		ahvif->dp_vif.tx_encap_type = ATH12K_HW_TXRX_NATIVE_WIFI;
++
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    param_id, ahvif->dp_vif.tx_encap_type);
++	if (ret) {
++		ath12k_warn(ab, "failed to set vdev %d tx encap mode: %d\n",
++			    arvif->vdev_id, ret);
++		vif->offload_flags &= ~IEEE80211_OFFLOAD_ENCAP_ENABLED;
++	}
++
++	param_id = WMI_VDEV_PARAM_RX_DECAP_TYPE;
++	if (vif->offload_flags & IEEE80211_OFFLOAD_DECAP_ENABLED)
++		param_value = ATH12K_HW_TXRX_ETHERNET;
++	else if (test_bit(ATH12K_FLAG_RAW_MODE, &ab->dev_flags))
++		param_value = ATH12K_HW_TXRX_RAW;
++	else
++		param_value = ATH12K_HW_TXRX_NATIVE_WIFI;
++
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    param_id, param_value);
++	if (ret) {
++		ath12k_warn(ab, "failed to set vdev %d rx decap mode: %d\n",
++			    arvif->vdev_id, ret);
++		vif->offload_flags &= ~IEEE80211_OFFLOAD_DECAP_ENABLED;
++	}
++}
++
++void ath12k_mac_op_update_vif_offload(struct ieee80211_hw *hw,
++				      struct ieee80211_vif *vif)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_link_vif *arvif;
++	unsigned long links;
++	int link_id;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (vif->valid_links) {
++		links = vif->valid_links;
++		for_each_set_bit(link_id, &links, IEEE80211_MLD_MAX_NUM_LINKS) {
++			arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++			if (!(arvif && arvif->ar))
++				continue;
++
++			ath12k_mac_update_vif_offload(arvif);
++		}
++
++		return;
++	}
++
++	ath12k_mac_update_vif_offload(&ahvif->deflink);
++}
++EXPORT_SYMBOL(ath12k_mac_op_update_vif_offload);
++
++static bool ath12k_mac_vif_ap_active_any(struct ath12k_base *ab)
++{
++	struct ath12k *ar;
++	struct ath12k_pdev *pdev;
++	struct ath12k_link_vif *arvif;
++	int i;
++
++	for (i = 0; i < ab->num_radios; i++) {
++		pdev = &ab->pdevs[i];
++		ar = pdev->ar;
++		list_for_each_entry(arvif, &ar->arvifs, list) {
++			if (arvif->is_up &&
++			    arvif->ahvif->vdev_type == WMI_VDEV_TYPE_AP)
++				return true;
++		}
++	}
++	return false;
++}
++
++void ath12k_mac_11d_scan_start(struct ath12k *ar, u32 vdev_id)
++{
++	struct wmi_11d_scan_start_arg arg;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (ar->regdom_set_by_user)
++		goto fin;
++
++	if (ar->vdev_id_11d_scan != ATH12K_11D_INVALID_VDEV_ID)
++		goto fin;
++
++	if (!test_bit(WMI_TLV_SERVICE_11D_OFFLOAD, ar->ab->wmi_ab.svc_map))
++		goto fin;
++
++	if (ath12k_mac_vif_ap_active_any(ar->ab))
++		goto fin;
++
++	arg.vdev_id = vdev_id;
++	arg.start_interval_msec = 0;
++	arg.scan_period_msec = ATH12K_SCAN_11D_INTERVAL;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac start 11d scan for vdev %d\n", vdev_id);
++
++	ret = ath12k_wmi_send_11d_scan_start_cmd(ar, &arg);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to start 11d scan vdev %d ret: %d\n",
++			    vdev_id, ret);
++	} else {
++		ar->vdev_id_11d_scan = vdev_id;
++		if (ar->state_11d == ATH12K_11D_PREPARING)
++			ar->state_11d = ATH12K_11D_RUNNING;
++	}
++
++fin:
++	if (ar->state_11d == ATH12K_11D_PREPARING) {
++		ar->state_11d = ATH12K_11D_IDLE;
++		complete(&ar->completed_11d_scan);
++	}
++}
++
++void ath12k_mac_11d_scan_stop(struct ath12k *ar)
++{
++	int ret;
++	u32 vdev_id;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (!test_bit(WMI_TLV_SERVICE_11D_OFFLOAD, ar->ab->wmi_ab.svc_map))
++		return;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac stop 11d for vdev %d\n",
++		   ar->vdev_id_11d_scan);
++
++	if (ar->state_11d == ATH12K_11D_PREPARING) {
++		ar->state_11d = ATH12K_11D_IDLE;
++		complete(&ar->completed_11d_scan);
++	}
++
++	if (ar->vdev_id_11d_scan != ATH12K_11D_INVALID_VDEV_ID) {
++		vdev_id = ar->vdev_id_11d_scan;
++
++		ret = ath12k_wmi_send_11d_scan_stop_cmd(ar, vdev_id);
++		if (ret) {
++			ath12k_warn(ar->ab,
++				    "failed to stopt 11d scan vdev %d ret: %d\n",
++				    vdev_id, ret);
++		} else {
++			ar->vdev_id_11d_scan = ATH12K_11D_INVALID_VDEV_ID;
++			ar->state_11d = ATH12K_11D_IDLE;
++			complete(&ar->completed_11d_scan);
++		}
++	}
++}
++
++void ath12k_mac_11d_scan_stop_all(struct ath12k_base *ab)
++{
++	struct ath12k *ar;
++	struct ath12k_pdev *pdev;
++	int i;
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC, "mac stop soc 11d scan\n");
++
++	for (i = 0; i < ab->num_radios; i++) {
++		pdev = &ab->pdevs[i];
++		ar = pdev->ar;
++
++		ath12k_mac_11d_scan_stop(ar);
++	}
++}
++
++static void ath12k_mac_determine_vdev_type(struct ieee80211_vif *vif,
++					   struct ath12k_vif *ahvif)
++{
++	ahvif->vdev_subtype = WMI_VDEV_SUBTYPE_NONE;
++
++	switch (vif->type) {
++	case NL80211_IFTYPE_UNSPECIFIED:
++	case NL80211_IFTYPE_STATION:
++		ahvif->vdev_type = WMI_VDEV_TYPE_STA;
++
++		if (vif->p2p)
++			ahvif->vdev_subtype = WMI_VDEV_SUBTYPE_P2P_CLIENT;
++
++		break;
++	case NL80211_IFTYPE_MESH_POINT:
++		ahvif->vdev_subtype = WMI_VDEV_SUBTYPE_MESH_11S;
++		fallthrough;
++	case NL80211_IFTYPE_AP:
++		ahvif->vdev_type = WMI_VDEV_TYPE_AP;
++
++		if (vif->p2p)
++			ahvif->vdev_subtype = WMI_VDEV_SUBTYPE_P2P_GO;
++
++		break;
++	case NL80211_IFTYPE_MONITOR:
++		ahvif->vdev_type = WMI_VDEV_TYPE_MONITOR;
++		break;
++	case NL80211_IFTYPE_P2P_DEVICE:
++		ahvif->vdev_type = WMI_VDEV_TYPE_STA;
++		ahvif->vdev_subtype = WMI_VDEV_SUBTYPE_P2P_DEVICE;
++		break;
++	default:
++		WARN_ON(1);
++		break;
++	}
++}
++
++int ath12k_mac_vdev_create(struct ath12k *ar, struct ath12k_link_vif *arvif)
++{
++	struct ath12k_hw *ah = ar->ah;
++	struct ath12k_base *ab = ar->ab;
++	struct ieee80211_hw *hw = ah->hw;
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(ahvif);
++	struct ath12k_wmi_vdev_create_arg vdev_arg = {};
++	struct ath12k_wmi_peer_create_arg peer_param = {};
++	struct ieee80211_bss_conf *link_conf = NULL;
++	u32 param_id, param_value;
++	u16 nss;
++	int i;
++	int ret, vdev_id;
++	u8 link_id;
++	struct ath12k_dp_link_vif *dp_link_vif = NULL;
++	struct ath12k_dp_peer_create_params params = {};
++	bool dp_peer_created = false;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	/* In NO_VIRTUAL_MONITOR, its necessary to restrict only one monitor
++	 * interface in each radio
++	 */
++	if (vif->type == NL80211_IFTYPE_MONITOR && ar->monitor_vdev_created)
++		return -EINVAL;
++
++	if (ar->num_created_vdevs >= TARGET_NUM_VDEVS(ab)) {
++		ath12k_warn(ab, "failed to create vdev, reached max vdev limit %d\n",
++			    TARGET_NUM_VDEVS(ab));
++		return -ENOSPC;
++	}
++
++	link_id = arvif->link_id;
++
++	if (link_id < IEEE80211_MLD_MAX_NUM_LINKS) {
++		link_conf = wiphy_dereference(hw->wiphy, vif->link_conf[link_id]);
++		if (!link_conf) {
++			ath12k_warn(ar->ab, "unable to access bss link conf in vdev create for vif %pM link %u\n",
++				    vif->addr, arvif->link_id);
++			return -ENOLINK;
++		}
++	}
++
++	if (link_conf)
++		memcpy(arvif->bssid, link_conf->addr, ETH_ALEN);
++	else
++		memcpy(arvif->bssid, vif->addr, ETH_ALEN);
++
++	arvif->ar = ar;
++	vdev_id = __ffs64(ab->free_vdev_map);
++	arvif->vdev_id = vdev_id;
++	if (vif->type == NL80211_IFTYPE_MONITOR)
++		ar->monitor_vdev_id = vdev_id;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac vdev create id %d type %d subtype %d map %llx\n",
++		   arvif->vdev_id, ahvif->vdev_type, ahvif->vdev_subtype,
++		   ab->free_vdev_map);
++
++	vif->cab_queue = arvif->vdev_id % (ATH12K_HW_MAX_QUEUES - 1);
++	for (i = 0; i < ARRAY_SIZE(vif->hw_queue); i++)
++		vif->hw_queue[i] = i % (ATH12K_HW_MAX_QUEUES - 1);
++
++	ret = ath12k_mac_setup_vdev_create_arg(arvif, &vdev_arg);
++	if (ret) {
++		ath12k_warn(ab, "failed to create vdev parameters %d: %d\n",
++			    arvif->vdev_id, ret);
++		goto err;
++	}
++
++	ret = ath12k_wmi_vdev_create(ar, arvif->bssid, &vdev_arg);
++	if (ret) {
++		ath12k_warn(ab, "failed to create WMI vdev %d: %d\n",
++			    arvif->vdev_id, ret);
++		goto err;
++	}
++
++	ar->num_created_vdevs++;
++	arvif->is_created = true;
++	ath12k_dbg(ab, ATH12K_DBG_MAC, "vdev %pM created, vdev_id %d\n",
++		   vif->addr, arvif->vdev_id);
++	ar->allocated_vdev_map |= 1LL << arvif->vdev_id;
++	ab->free_vdev_map &= ~(1LL << arvif->vdev_id);
++
++	spin_lock_bh(&ar->data_lock);
++	list_add(&arvif->list, &ar->arvifs);
++	spin_unlock_bh(&ar->data_lock);
++
++	ath12k_mac_update_vif_offload(arvif);
++
++	nss = hweight32(ar->cfg_tx_chainmask) ? : 1;
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    WMI_VDEV_PARAM_NSS, nss);
++	if (ret) {
++		ath12k_warn(ab, "failed to set vdev %d chainmask 0x%x, nss %d :%d\n",
++			    arvif->vdev_id, ar->cfg_tx_chainmask, nss, ret);
++		goto err_vdev_del;
++	}
++
++	dp_link_vif = ath12k_dp_vif_to_dp_link_vif(&ahvif->dp_vif, arvif->link_id);
++
++	dp_link_vif->vdev_id = arvif->vdev_id;
++	dp_link_vif->lmac_id = ar->lmac_id;
++	dp_link_vif->pdev_idx = ar->pdev_idx;
++
++	switch (ahvif->vdev_type) {
++	case WMI_VDEV_TYPE_AP:
++		params.ucast_ra_only = true;
++
++		if (arvif->link_id < IEEE80211_MLD_MAX_NUM_LINKS) {
++			ret = ath12k_dp_peer_create(&ah->dp_hw, arvif->bssid, &params);
++			if (ret) {
++				ath12k_warn(ab, "failed to vdev %d create dp_peer for AP: %d\n",
++					    arvif->vdev_id, ret);
++				goto err_vdev_del;
++			}
++			dp_peer_created = true;
++		}
++
++		peer_param.vdev_id = arvif->vdev_id;
++		peer_param.peer_addr = arvif->bssid;
++		peer_param.peer_type = WMI_PEER_TYPE_DEFAULT;
++		ret = ath12k_peer_create(ar, arvif, NULL, &peer_param);
++		if (ret) {
++			ath12k_warn(ab, "failed to vdev %d create peer for AP: %d\n",
++				    arvif->vdev_id, ret);
++			goto err_dp_peer_del;
++		}
++
++		ret = ath12k_mac_set_kickout(arvif);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to set vdev %i kickout parameters: %d\n",
++				    arvif->vdev_id, ret);
++			goto err_peer_del;
++		}
++		ath12k_mac_11d_scan_stop_all(ar->ab);
++		break;
++	case WMI_VDEV_TYPE_STA:
++		param_id = WMI_STA_PS_PARAM_RX_WAKE_POLICY;
++		param_value = WMI_STA_PS_RX_WAKE_POLICY_WAKE;
++		ret = ath12k_wmi_set_sta_ps_param(ar, arvif->vdev_id,
++						  param_id, param_value);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to set vdev %d RX wake policy: %d\n",
++				    arvif->vdev_id, ret);
++			goto err_peer_del;
++		}
++
++		param_id = WMI_STA_PS_PARAM_TX_WAKE_THRESHOLD;
++		param_value = WMI_STA_PS_TX_WAKE_THRESHOLD_ALWAYS;
++		ret = ath12k_wmi_set_sta_ps_param(ar, arvif->vdev_id,
++						  param_id, param_value);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to set vdev %d TX wake threshold: %d\n",
++				    arvif->vdev_id, ret);
++			goto err_peer_del;
++		}
++
++		param_id = WMI_STA_PS_PARAM_PSPOLL_COUNT;
++		param_value = WMI_STA_PS_PSPOLL_COUNT_NO_MAX;
++		ret = ath12k_wmi_set_sta_ps_param(ar, arvif->vdev_id,
++						  param_id, param_value);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to set vdev %d pspoll count: %d\n",
++				    arvif->vdev_id, ret);
++			goto err_peer_del;
++		}
++
++		ret = ath12k_wmi_pdev_set_ps_mode(ar, arvif->vdev_id, false);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to disable vdev %d ps mode: %d\n",
++				    arvif->vdev_id, ret);
++			goto err_peer_del;
++		}
++
++		if (test_bit(WMI_TLV_SERVICE_11D_OFFLOAD, ab->wmi_ab.svc_map) &&
++		    ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
++		    ahvif->vdev_subtype == WMI_VDEV_SUBTYPE_NONE) {
++			reinit_completion(&ar->completed_11d_scan);
++			ar->state_11d = ATH12K_11D_PREPARING;
++		}
++		break;
++	case WMI_VDEV_TYPE_MONITOR:
++		ar->monitor_vdev_created = true;
++		break;
++	default:
++		break;
++	}
++
++	if (link_conf)
++		arvif->txpower = link_conf->txpower;
++	else
++		arvif->txpower = NL80211_TX_POWER_AUTOMATIC;
++
++	ret = ath12k_mac_txpower_recalc(ar);
++	if (ret)
++		goto err_peer_del;
++
++	param_id = WMI_VDEV_PARAM_RTS_THRESHOLD;
++	param_value = hw->wiphy->rts_threshold;
++	ar->rts_threshold = param_value;
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    param_id, param_value);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set rts threshold for vdev %d: %d\n",
++			    arvif->vdev_id, ret);
++	}
++
++	ath12k_dp_vdev_tx_attach(ar, arvif);
++
++	return ret;
++
++err_peer_del:
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_AP) {
++		reinit_completion(&ar->peer_delete_done);
++
++		ret = ath12k_wmi_send_peer_delete_cmd(ar, arvif->bssid,
++						      arvif->vdev_id);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to delete peer vdev_id %d addr %pM\n",
++				    arvif->vdev_id, arvif->bssid);
++			goto err_dp_peer_del;
++		}
++
++		ret = ath12k_wait_for_peer_delete_done(ar, arvif->vdev_id,
++						       arvif->bssid);
++		if (ret)
++			goto err_dp_peer_del;
++
++		ar->num_peers--;
++	}
++
++err_dp_peer_del:
++	if (dp_peer_created)
++		ath12k_dp_peer_delete(&ah->dp_hw, arvif->bssid, NULL);
++
++err_vdev_del:
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_MONITOR) {
++		ar->monitor_vdev_id = -1;
++		ar->monitor_vdev_created = false;
++	}
++
++	ath12k_wmi_vdev_delete(ar, arvif->vdev_id);
++	ar->num_created_vdevs--;
++	ar->allocated_vdev_map &= ~(1LL << arvif->vdev_id);
++	ab->free_vdev_map |= 1LL << arvif->vdev_id;
++	ab->free_vdev_stats_id_map &= ~(1LL << arvif->vdev_stats_id);
++	spin_lock_bh(&ar->data_lock);
++	list_del(&arvif->list);
++	spin_unlock_bh(&ar->data_lock);
++
++err:
++	arvif->is_created = false;
++	arvif->ar = NULL;
++	return ret;
++}
++
++static void ath12k_mac_vif_flush_key_cache(struct ath12k_link_vif *arvif)
++{
++	struct ath12k_key_conf *key_conf, *tmp;
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ath12k_hw *ah = ahvif->ah;
++	struct ath12k_sta *ahsta;
++	struct ath12k_link_sta *arsta;
++	struct ath12k_vif_cache *cache = ahvif->cache[arvif->link_id];
++	int ret;
++
++	lockdep_assert_wiphy(ah->hw->wiphy);
++
++	list_for_each_entry_safe(key_conf, tmp, &cache->key_conf.list, list) {
++		arsta = NULL;
++		if (key_conf->sta) {
++			ahsta = ath12k_sta_to_ahsta(key_conf->sta);
++			arsta = wiphy_dereference(ah->hw->wiphy,
++						  ahsta->link[arvif->link_id]);
++			if (!arsta)
++				goto free_cache;
++		}
++
++		ret = ath12k_mac_set_key(arvif->ar, key_conf->cmd,
++					 arvif, arsta,
++					 key_conf->key);
++		if (ret)
++			ath12k_warn(arvif->ar->ab, "unable to apply set key param to vdev %d ret %d\n",
++				    arvif->vdev_id, ret);
++free_cache:
++		list_del(&key_conf->list);
++		kfree(key_conf);
++	}
++}
++
++static void ath12k_mac_vif_cache_flush(struct ath12k *ar, struct ath12k_link_vif *arvif)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(ahvif);
++	struct ath12k_vif_cache *cache = ahvif->cache[arvif->link_id];
++	struct ath12k_base *ab = ar->ab;
++	struct ieee80211_bss_conf *link_conf;
++
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (!cache)
++		return;
++
++	if (cache->tx_conf.changed) {
++		ret = ath12k_mac_conf_tx(arvif, cache->tx_conf.ac,
++					 &cache->tx_conf.tx_queue_params);
++		if (ret)
++			ath12k_warn(ab,
++				    "unable to apply tx config parameters to vdev %d\n",
++				    ret);
++	}
++
++	if (cache->bss_conf_changed) {
++		link_conf = ath12k_mac_get_link_bss_conf(arvif);
++		if (!link_conf) {
++			ath12k_warn(ar->ab, "unable to access bss link conf in cache flush for vif %pM link %u\n",
++				    vif->addr, arvif->link_id);
++			return;
++		}
++		ath12k_mac_bss_info_changed(ar, arvif, link_conf,
++					    cache->bss_conf_changed);
++	}
++
++	if (!list_empty(&cache->key_conf.list))
++		ath12k_mac_vif_flush_key_cache(arvif);
++
++	ath12k_ahvif_put_link_cache(ahvif, arvif->link_id);
++}
++
++static struct ath12k *ath12k_mac_assign_vif_to_vdev(struct ieee80211_hw *hw,
++						    struct ath12k_link_vif *arvif,
++						    struct ieee80211_chanctx_conf *ctx)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(ahvif);
++	struct ath12k_link_vif *scan_arvif;
++	struct ath12k_hw *ah = hw->priv;
++	struct ath12k *ar;
++	struct ath12k_base *ab;
++	u8 link_id = arvif->link_id, scan_link_id;
++	unsigned long scan_link_map;
++	int ret;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (ah->num_radio == 1)
++		ar = ah->radio;
++	else if (ctx)
++		ar = ath12k_get_ar_by_ctx(hw, ctx);
++	else
++		return NULL;
++
++	if (!ar)
++		return NULL;
++
++	/* cleanup the scan vdev if we are done scan on that ar
++	 * and now we want to create for actual usage.
++	 */
++	if (ieee80211_vif_is_mld(vif)) {
++		scan_link_map = ahvif->links_map & ATH12K_SCAN_LINKS_MASK;
++		for_each_set_bit(scan_link_id, &scan_link_map, ATH12K_NUM_MAX_LINKS) {
++			scan_arvif = wiphy_dereference(hw->wiphy,
++						       ahvif->link[scan_link_id]);
++			if (scan_arvif && scan_arvif->ar == ar) {
++				ar->scan.arvif = NULL;
++				ath12k_mac_remove_link_interface(hw, scan_arvif);
++				ath12k_mac_unassign_link_vif(scan_arvif);
++				break;
++			}
++		}
++	}
++
++	if (arvif->ar) {
++		/* This is not expected really */
++		if (WARN_ON(!arvif->is_created)) {
++			arvif->ar = NULL;
++			return NULL;
++		}
++
++		if (ah->num_radio == 1)
++			return arvif->ar;
++
++		/* This can happen as scan vdev gets created during multiple scans
++		 * across different radios before a vdev is brought up in
++		 * a certain radio.
++		 */
++		if (ar != arvif->ar) {
++			if (WARN_ON(arvif->is_started))
++				return NULL;
++
++			ath12k_mac_remove_link_interface(hw, arvif);
++			ath12k_mac_unassign_link_vif(arvif);
++		}
++	}
++
++	ab = ar->ab;
++
++	/* Assign arvif again here since previous radio switch block
++	 * would've unassigned and cleared it.
++	 */
++	arvif = ath12k_mac_assign_link_vif(ah, vif, link_id);
++	if (vif->type == NL80211_IFTYPE_AP &&
++	    ar->num_peers > (ar->max_num_peers - 1)) {
++		ath12k_warn(ab, "failed to create vdev due to insufficient peer entry resource in firmware\n");
++		goto unlock;
++	}
++
++	if (arvif->is_created)
++		goto flush;
++
++	ret = ath12k_mac_vdev_create(ar, arvif);
++	if (ret) {
++		ath12k_warn(ab, "failed to create vdev %pM ret %d", vif->addr, ret);
++		goto unlock;
++	}
++
++flush:
++	/* If the vdev is created during channel assign and not during
++	 * add_interface(), Apply any parameters for the vdev which were received
++	 * after add_interface, corresponding to this vif.
++	 */
++	ath12k_mac_vif_cache_flush(ar, arvif);
++unlock:
++	return arvif->ar;
++}
++
++int ath12k_mac_op_add_interface(struct ieee80211_hw *hw,
++				struct ieee80211_vif *vif)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_reg_info *reg_info;
++	struct ath12k_link_vif *arvif;
++	struct ath12k_base *ab;
++	struct ath12k *ar;
++	int i;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	memset(ahvif, 0, sizeof(*ahvif));
++
++	ahvif->ah = ah;
++	ahvif->vif = vif;
++	arvif = &ahvif->deflink;
++
++	ath12k_mac_init_arvif(ahvif, arvif, -1);
++
++	/* Allocate Default Queue now and reassign during actual vdev create */
++	vif->cab_queue = ATH12K_HW_DEFAULT_QUEUE;
++	for (i = 0; i < ARRAY_SIZE(vif->hw_queue); i++)
++		vif->hw_queue[i] = ATH12K_HW_DEFAULT_QUEUE;
++
++	vif->driver_flags |= IEEE80211_VIF_SUPPORTS_UAPSD;
++
++	ath12k_mac_determine_vdev_type(vif, ahvif);
++
++	for_each_ar(ah, ar, i) {
++		if (!ath12k_wmi_supports_6ghz_cc_ext(ar))
++			continue;
++
++		ab = ar->ab;
++		reg_info = ab->reg_info[ar->pdev_idx];
++		ath12k_dbg(ab, ATH12K_DBG_MAC, "interface added to change reg rules\n");
++		ah->regd_updated = false;
++		ath12k_reg_handle_chan_list(ab, reg_info, ahvif->vdev_type,
++					    IEEE80211_REG_UNSET_AP);
++		break;
++	}
++
++	/* Defer vdev creation until assign_chanctx or hw_scan is initiated as driver
++	 * will not know if this interface is an ML vif at this point.
++	 */
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_add_interface);
++
++static void ath12k_mac_vif_unref(struct ath12k_dp *dp, struct ieee80211_vif *vif)
++{
++	struct ath12k_tx_desc_info *tx_desc_info;
++	struct ath12k_skb_cb *skb_cb;
++	struct sk_buff *skb;
++	int i;
++
++	for (i = 0; i < ATH12K_HW_MAX_QUEUES; i++) {
++		spin_lock_bh(&dp->tx_desc_lock[i]);
++
++		list_for_each_entry(tx_desc_info, &dp->tx_desc_used_list[i],
++				    list) {
++			skb = tx_desc_info->skb;
++			if (!skb)
++				continue;
++
++			skb_cb = ATH12K_SKB_CB(skb);
++			if (skb_cb->vif == vif)
++				skb_cb->vif = NULL;
++		}
++
++		spin_unlock_bh(&dp->tx_desc_lock[i]);
++	}
++}
++
++static int ath12k_mac_vdev_delete(struct ath12k *ar, struct ath12k_link_vif *arvif)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(ahvif);
++	struct ath12k_dp_link_vif *dp_link_vif;
++	struct ath12k_base *ab = ar->ab;
++	unsigned long time_left;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	reinit_completion(&ar->vdev_delete_done);
++
++	ret = ath12k_wmi_vdev_delete(ar, arvif->vdev_id);
++	if (ret) {
++		ath12k_warn(ab, "failed to delete WMI vdev %d: %d\n",
++			    arvif->vdev_id, ret);
++		goto err_vdev_del;
++	}
++
++	time_left = wait_for_completion_timeout(&ar->vdev_delete_done,
++						ATH12K_VDEV_DELETE_TIMEOUT_HZ);
++	if (time_left == 0) {
++		ath12k_warn(ab, "Timeout in receiving vdev delete response\n");
++		goto err_vdev_del;
++	}
++
++	ab->free_vdev_map |= 1LL << arvif->vdev_id;
++	ar->allocated_vdev_map &= ~(1LL << arvif->vdev_id);
++	ar->num_created_vdevs--;
++
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_MONITOR) {
++		ar->monitor_vdev_id = -1;
++		ar->monitor_vdev_created = false;
++	}
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC, "vdev %pM deleted, vdev_id %d\n",
++		   vif->addr, arvif->vdev_id);
++
++err_vdev_del:
++	spin_lock_bh(&ar->data_lock);
++	list_del(&arvif->list);
++	spin_unlock_bh(&ar->data_lock);
++
++	ath12k_peer_cleanup(ar, arvif->vdev_id);
++	ath12k_ahvif_put_link_cache(ahvif, arvif->link_id);
++
++	idr_for_each(&ar->txmgmt_idr,
++		     ath12k_mac_vif_txmgmt_idr_remove, vif);
++
++	ath12k_mac_vif_unref(ath12k_ab_to_dp(ab), vif);
++
++	dp_link_vif = ath12k_dp_vif_to_dp_link_vif(&ahvif->dp_vif, arvif->link_id);
++	ath12k_dp_tx_put_bank_profile(ath12k_ab_to_dp(ab), dp_link_vif->bank_id);
++
++	/* Recalc txpower for remaining vdev */
++	ath12k_mac_txpower_recalc(ar);
++
++	/* TODO: recal traffic pause state based on the available vdevs */
++	arvif->is_created = false;
++	arvif->ar = NULL;
++
++	return ret;
++}
++
++void ath12k_mac_op_remove_interface(struct ieee80211_hw *hw,
++				    struct ieee80211_vif *vif)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_link_vif *arvif;
++	struct ath12k *ar;
++	u8 link_id;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	for (link_id = 0; link_id < ATH12K_NUM_MAX_LINKS; link_id++) {
++		/* if we cached some config but never received assign chanctx,
++		 * free the allocated cache.
++		 */
++		ath12k_ahvif_put_link_cache(ahvif, link_id);
++		arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++		if (!arvif || !arvif->is_created)
++			continue;
++
++		ar = arvif->ar;
++
++		/* Scan abortion is in progress since before this, cancel_hw_scan()
++		 * is expected to be executed. Since link is anyways going to be removed
++		 * now, just cancel the worker and send the scan aborted to user space
++		 */
++		if (ar->scan.arvif == arvif) {
++			wiphy_work_cancel(hw->wiphy, &ar->scan.vdev_clean_wk);
++
++			spin_lock_bh(&ar->data_lock);
++			ar->scan.arvif = NULL;
++			if (!ar->scan.is_roc) {
++				struct cfg80211_scan_info info = {
++					.aborted = true,
++				};
++
++				ath12k_mac_scan_send_complete(ar, &info);
++			}
++
++			ar->scan.state = ATH12K_SCAN_IDLE;
++			ar->scan_channel = NULL;
++			ar->scan.roc_freq = 0;
++			spin_unlock_bh(&ar->data_lock);
++		}
++
++		ath12k_mac_remove_link_interface(hw, arvif);
++		ath12k_mac_unassign_link_vif(arvif);
++	}
++}
++EXPORT_SYMBOL(ath12k_mac_op_remove_interface);
++
++/* FIXME: Has to be verified. */
++#define SUPPORTED_FILTERS			\
++	(FIF_ALLMULTI |				\
++	FIF_CONTROL |				\
++	FIF_PSPOLL |				\
++	FIF_OTHER_BSS |				\
++	FIF_BCN_PRBRESP_PROMISC |		\
++	FIF_PROBE_REQ |				\
++	FIF_FCSFAIL)
++
++void ath12k_mac_op_configure_filter(struct ieee80211_hw *hw,
++				    unsigned int changed_flags,
++				    unsigned int *total_flags,
++				    u64 multicast)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k *ar;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	ar = ath12k_ah_to_ar(ah, 0);
++
++	*total_flags &= SUPPORTED_FILTERS;
++	ar->filter_flags = *total_flags;
++}
++EXPORT_SYMBOL(ath12k_mac_op_configure_filter);
++
++int ath12k_mac_op_get_antenna(struct ieee80211_hw *hw, int radio_idx,
++			      u32 *tx_ant, u32 *rx_ant)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	int antennas_rx = 0, antennas_tx = 0;
++	struct ath12k *ar;
++	int i;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	for_each_ar(ah, ar, i) {
++		antennas_rx = max_t(u32, antennas_rx, ar->cfg_rx_chainmask);
++		antennas_tx = max_t(u32, antennas_tx, ar->cfg_tx_chainmask);
++	}
++
++	*tx_ant = antennas_tx;
++	*rx_ant = antennas_rx;
++
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_get_antenna);
++
++int ath12k_mac_op_set_antenna(struct ieee80211_hw *hw, int radio_idx,
++			      u32 tx_ant, u32 rx_ant)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k *ar;
++	int ret = 0;
++	int i;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	for_each_ar(ah, ar, i) {
++		ret = __ath12k_set_antenna(ar, tx_ant, rx_ant);
++		if (ret)
++			break;
++	}
++
++	return ret;
++}
++EXPORT_SYMBOL(ath12k_mac_op_set_antenna);
++
++static int ath12k_mac_ampdu_action(struct ieee80211_hw *hw,
++				   struct ieee80211_vif *vif,
++				   struct ieee80211_ampdu_params *params,
++				   u8 link_id)
++{
++	struct ath12k *ar;
++	int ret = -EINVAL;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	ar = ath12k_get_ar_by_vif(hw, vif, link_id);
++	if (!ar)
++		return -EINVAL;
++
++	switch (params->action) {
++	case IEEE80211_AMPDU_RX_START:
++		ret = ath12k_dp_rx_ampdu_start(ar, params, link_id);
++		break;
++	case IEEE80211_AMPDU_RX_STOP:
++		ret = ath12k_dp_rx_ampdu_stop(ar, params, link_id);
++		break;
++	case IEEE80211_AMPDU_TX_START:
++	case IEEE80211_AMPDU_TX_STOP_CONT:
++	case IEEE80211_AMPDU_TX_STOP_FLUSH:
++	case IEEE80211_AMPDU_TX_STOP_FLUSH_CONT:
++	case IEEE80211_AMPDU_TX_OPERATIONAL:
++		/* Tx A-MPDU aggregation offloaded to hw/fw so deny mac80211
++		 * Tx aggregation requests.
++		 */
++		ret = -EOPNOTSUPP;
++		break;
++	}
++
++	if (ret)
++		ath12k_warn(ar->ab, "unable to perform ampdu action %d for vif %pM link %u ret %d\n",
++			    params->action, vif->addr, link_id, ret);
++
++	return ret;
++}
++
++int ath12k_mac_op_ampdu_action(struct ieee80211_hw *hw,
++			       struct ieee80211_vif *vif,
++			       struct ieee80211_ampdu_params *params)
++{
++	struct ieee80211_sta *sta = params->sta;
++	struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(sta);
++	unsigned long links_map = ahsta->links_map;
++	int ret = -EINVAL;
++	u8 link_id;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (WARN_ON(!links_map))
++		return ret;
++
++	for_each_set_bit(link_id, &links_map, IEEE80211_MLD_MAX_NUM_LINKS) {
++		ret = ath12k_mac_ampdu_action(hw, vif, params, link_id);
++		if (ret)
++			return ret;
++	}
++
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_ampdu_action);
++
++int ath12k_mac_op_add_chanctx(struct ieee80211_hw *hw,
++			      struct ieee80211_chanctx_conf *ctx)
++{
++	struct ath12k *ar;
++	struct ath12k_base *ab;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	ar = ath12k_get_ar_by_ctx(hw, ctx);
++	if (!ar)
++		return -EINVAL;
++
++	ab = ar->ab;
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC,
++		   "mac chanctx add freq %u width %d ptr %p\n",
++		   ctx->def.chan->center_freq, ctx->def.width, ctx);
++
++	spin_lock_bh(&ar->data_lock);
++	/* TODO: In case of multiple channel context, populate rx_channel from
++	 * Rx PPDU desc information.
++	 */
++	ar->rx_channel = ctx->def.chan;
++	spin_unlock_bh(&ar->data_lock);
++	ar->chan_tx_pwr = ATH12K_PDEV_TX_POWER_INVALID;
++
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_add_chanctx);
++
++void ath12k_mac_op_remove_chanctx(struct ieee80211_hw *hw,
++				  struct ieee80211_chanctx_conf *ctx)
++{
++	struct ath12k *ar;
++	struct ath12k_base *ab;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	ar = ath12k_get_ar_by_ctx(hw, ctx);
++	if (!ar)
++		return;
++
++	ab = ar->ab;
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC,
++		   "mac chanctx remove freq %u width %d ptr %p\n",
++		   ctx->def.chan->center_freq, ctx->def.width, ctx);
++
++	spin_lock_bh(&ar->data_lock);
++	/* TODO: In case of there is one more channel context left, populate
++	 * rx_channel with the channel of that remaining channel context.
++	 */
++	ar->rx_channel = NULL;
++	spin_unlock_bh(&ar->data_lock);
++	ar->chan_tx_pwr = ATH12K_PDEV_TX_POWER_INVALID;
++}
++EXPORT_SYMBOL(ath12k_mac_op_remove_chanctx);
++
++static enum wmi_phy_mode
++ath12k_mac_check_down_grade_phy_mode(struct ath12k *ar,
++				     enum wmi_phy_mode mode,
++				     enum nl80211_band band,
++				     enum nl80211_iftype type)
++{
++	struct ieee80211_sta_eht_cap *eht_cap = NULL;
++	enum wmi_phy_mode down_mode;
++	int n = ar->mac.sbands[band].n_iftype_data;
++	int i;
++	struct ieee80211_sband_iftype_data *data;
++
++	if (mode < MODE_11BE_EHT20)
++		return mode;
++
++	data = ar->mac.iftype[band];
++	for (i = 0; i < n; i++) {
++		if (data[i].types_mask & BIT(type)) {
++			eht_cap = &data[i].eht_cap;
++			break;
++		}
++	}
++
++	if (eht_cap && eht_cap->has_eht)
++		return mode;
++
++	switch (mode) {
++	case MODE_11BE_EHT20:
++		down_mode = MODE_11AX_HE20;
++		break;
++	case MODE_11BE_EHT40:
++		down_mode = MODE_11AX_HE40;
++		break;
++	case MODE_11BE_EHT80:
++		down_mode = MODE_11AX_HE80;
++		break;
++	case MODE_11BE_EHT80_80:
++		down_mode = MODE_11AX_HE80_80;
++		break;
++	case MODE_11BE_EHT160:
++	case MODE_11BE_EHT160_160:
++	case MODE_11BE_EHT320:
++		down_mode = MODE_11AX_HE160;
++		break;
++	case MODE_11BE_EHT20_2G:
++		down_mode = MODE_11AX_HE20_2G;
++		break;
++	case MODE_11BE_EHT40_2G:
++		down_mode = MODE_11AX_HE40_2G;
++		break;
++	default:
++		down_mode = mode;
++		break;
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac vdev start phymode %s downgrade to %s\n",
++		   ath12k_mac_phymode_str(mode),
++		   ath12k_mac_phymode_str(down_mode));
++
++	return down_mode;
++}
++
++static void
++ath12k_mac_mlo_get_vdev_args(struct ath12k_link_vif *arvif,
++			     struct wmi_ml_arg *ml_arg)
++{
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct wmi_ml_partner_info *partner_info;
++	struct ieee80211_bss_conf *link_conf;
++	struct ath12k_link_vif *arvif_p;
++	unsigned long links;
++	u8 link_id;
++
++	lockdep_assert_wiphy(ahvif->ah->hw->wiphy);
++
++	if (!ath12k_mac_is_ml_arvif(arvif))
++		return;
++
++	if (hweight16(ahvif->vif->valid_links) > ATH12K_WMI_MLO_MAX_LINKS)
++		return;
++
++	ml_arg->enabled = true;
++
++	/* Driver always add a new link via VDEV START, FW takes
++	 * care of internally adding this link to existing
++	 * link vdevs which are advertised as partners below
++	 */
++	ml_arg->link_add = true;
++
++	ml_arg->assoc_link = arvif->is_sta_assoc_link;
++
++	partner_info = ml_arg->partner_info;
++
++	links = ahvif->links_map;
++	for_each_set_bit(link_id, &links, IEEE80211_MLD_MAX_NUM_LINKS) {
++		arvif_p = wiphy_dereference(ahvif->ah->hw->wiphy, ahvif->link[link_id]);
++
++		if (WARN_ON(!arvif_p))
++			continue;
++
++		if (arvif == arvif_p)
++			continue;
++
++		if (!arvif_p->is_started)
++			continue;
++
++		link_conf = wiphy_dereference(ahvif->ah->hw->wiphy,
++					      ahvif->vif->link_conf[arvif_p->link_id]);
++
++		if (!link_conf)
++			continue;
++
++		partner_info->vdev_id = arvif_p->vdev_id;
++		partner_info->hw_link_id = arvif_p->ar->pdev->hw_link_id;
++		ether_addr_copy(partner_info->addr, link_conf->addr);
++		ml_arg->num_partner_links++;
++		partner_info++;
++	}
++}
++
++static int
++ath12k_mac_vdev_start_restart(struct ath12k_link_vif *arvif,
++			      struct ieee80211_chanctx_conf *ctx,
++			      bool restart)
++{
++	struct ath12k *ar = arvif->ar;
++	struct ath12k_base *ab = ar->ab;
++	struct wmi_vdev_start_req_arg arg = {};
++	const struct cfg80211_chan_def *chandef = &ctx->def;
++	struct ieee80211_hw *hw = ath12k_ar_to_hw(ar);
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ieee80211_bss_conf *link_conf;
++	unsigned int dfs_cac_time;
++	int ret;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf) {
++		ath12k_warn(ar->ab, "unable to access bss link conf in vdev start for vif %pM link %u\n",
++			    ahvif->vif->addr, arvif->link_id);
++		return -ENOLINK;
++	}
++
++	reinit_completion(&ar->vdev_setup_done);
++
++	arg.vdev_id = arvif->vdev_id;
++	arg.dtim_period = arvif->dtim_period;
++	arg.bcn_intval = arvif->beacon_interval;
++	arg.punct_bitmap = ~arvif->punct_bitmap;
++
++	arg.freq = chandef->chan->center_freq;
++	arg.band_center_freq1 = chandef->center_freq1;
++	arg.band_center_freq2 = chandef->center_freq2;
++	arg.mode = ath12k_phymodes[chandef->chan->band][chandef->width];
++
++	arg.mode = ath12k_mac_check_down_grade_phy_mode(ar, arg.mode,
++							chandef->chan->band,
++							ahvif->vif->type);
++	arg.min_power = 0;
++	arg.max_power = chandef->chan->max_power;
++	arg.max_reg_power = chandef->chan->max_reg_power;
++	arg.max_antenna_gain = chandef->chan->max_antenna_gain;
++
++	arg.pref_tx_streams = ar->num_tx_chains;
++	arg.pref_rx_streams = ar->num_rx_chains;
++
++	arg.mbssid_flags = WMI_VDEV_MBSSID_FLAGS_NON_MBSSID_AP;
++	arg.mbssid_tx_vdev_id = 0;
++	if (test_bit(WMI_TLV_SERVICE_MBSS_PARAM_IN_VDEV_START_SUPPORT,
++		     ar->ab->wmi_ab.svc_map)) {
++		ret = ath12k_mac_setup_vdev_params_mbssid(arvif,
++							  &arg.mbssid_flags,
++							  &arg.mbssid_tx_vdev_id);
++		if (ret)
++			return ret;
++	}
++
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_AP) {
++		arg.ssid = ahvif->u.ap.ssid;
++		arg.ssid_len = ahvif->u.ap.ssid_len;
++		arg.hidden_ssid = ahvif->u.ap.hidden_ssid;
++
++		/* For now allow DFS for AP mode */
++		arg.chan_radar = !!(chandef->chan->flags & IEEE80211_CHAN_RADAR);
++
++		arg.freq2_radar = ctx->radar_enabled;
++
++		arg.passive = arg.chan_radar;
++
++		spin_lock_bh(&ab->base_lock);
++		arg.regdomain = ar->ab->dfs_region;
++		spin_unlock_bh(&ab->base_lock);
++
++		/* TODO: Notify if secondary 80Mhz also needs radar detection */
++	}
++
++	arg.passive |= !!(chandef->chan->flags & IEEE80211_CHAN_NO_IR);
++
++	if (!restart)
++		ath12k_mac_mlo_get_vdev_args(arvif, &arg.ml);
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC,
++		   "mac vdev %d start center_freq %d phymode %s punct_bitmap 0x%x\n",
++		   arg.vdev_id, arg.freq,
++		   ath12k_mac_phymode_str(arg.mode), arg.punct_bitmap);
++
++	ret = ath12k_wmi_vdev_start(ar, &arg, restart);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to %s WMI vdev %i\n",
++			    restart ? "restart" : "start", arg.vdev_id);
++		return ret;
++	}
++
++	ret = ath12k_mac_vdev_setup_sync(ar);
++	if (ret) {
++		ath12k_warn(ab, "failed to synchronize setup for vdev %i %s: %d\n",
++			    arg.vdev_id, restart ? "restart" : "start", ret);
++		return ret;
++	}
++
++	/* TODO: For now we only set TPC power here. However when
++	 * channel changes, say CSA, it should be updated again.
++	 */
++	if (ath12k_mac_supports_tpc(ar, ahvif, chandef)) {
++		ath12k_mac_fill_reg_tpc_info(ar, arvif, ctx);
++		ath12k_wmi_send_vdev_set_tpc_power(ar, arvif->vdev_id,
++						   &arvif->reg_tpc_info);
++	}
++
++	ar->num_started_vdevs++;
++	ath12k_dbg(ab, ATH12K_DBG_MAC,  "vdev %pM started, vdev_id %d\n",
++		   ahvif->vif->addr, arvif->vdev_id);
++
++	/* Enable CAC Running Flag in the driver by checking all sub-channel's DFS
++	 * state as NL80211_DFS_USABLE which indicates CAC needs to be
++	 * done before channel usage. This flag is used to drop rx packets.
++	 * during CAC.
++	 */
++	/* TODO: Set the flag for other interface types as required */
++	if (arvif->ahvif->vdev_type == WMI_VDEV_TYPE_AP && ctx->radar_enabled &&
++	    cfg80211_chandef_dfs_usable(hw->wiphy, chandef)) {
++		set_bit(ATH12K_FLAG_CAC_RUNNING, &ar->dev_flags);
++		dfs_cac_time = cfg80211_chandef_dfs_cac_time(hw->wiphy, chandef);
++
++		ath12k_dbg(ab, ATH12K_DBG_MAC,
++			   "CAC started dfs_cac_time %u center_freq %d center_freq1 %d for vdev %d\n",
++			   dfs_cac_time, arg.freq, arg.band_center_freq1, arg.vdev_id);
++	}
++
++	ret = ath12k_mac_set_txbf_conf(arvif);
++	if (ret)
++		ath12k_warn(ab, "failed to set txbf conf for vdev %d: %d\n",
++			    arvif->vdev_id, ret);
++
++	return 0;
++}
++
++static int ath12k_mac_vdev_start(struct ath12k_link_vif *arvif,
++				 struct ieee80211_chanctx_conf *ctx)
++{
++	return ath12k_mac_vdev_start_restart(arvif, ctx, false);
++}
++
++static int ath12k_mac_vdev_restart(struct ath12k_link_vif *arvif,
++				   struct ieee80211_chanctx_conf *ctx)
++{
++	return ath12k_mac_vdev_start_restart(arvif, ctx, true);
++}
++
++struct ath12k_mac_change_chanctx_arg {
++	struct ieee80211_chanctx_conf *ctx;
++	struct ieee80211_vif_chanctx_switch *vifs;
++	int n_vifs;
++	int next_vif;
++	struct ath12k *ar;
++};
++
++static void
++ath12k_mac_change_chanctx_cnt_iter(void *data, u8 *mac,
++				   struct ieee80211_vif *vif)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_mac_change_chanctx_arg *arg = data;
++	struct ieee80211_bss_conf *link_conf;
++	struct ath12k_link_vif *arvif;
++	unsigned long links_map;
++	u8 link_id;
++
++	lockdep_assert_wiphy(ahvif->ah->hw->wiphy);
++
++	links_map = ahvif->links_map;
++	for_each_set_bit(link_id, &links_map, IEEE80211_MLD_MAX_NUM_LINKS) {
++		arvif = wiphy_dereference(ahvif->ah->hw->wiphy, ahvif->link[link_id]);
++		if (WARN_ON(!arvif))
++			continue;
++
++		if (!arvif->is_created || arvif->ar != arg->ar)
++			continue;
++
++		link_conf = wiphy_dereference(ahvif->ah->hw->wiphy,
++					      vif->link_conf[link_id]);
++		if (WARN_ON(!link_conf))
++			continue;
++
++		if (rcu_access_pointer(link_conf->chanctx_conf) != arg->ctx)
++			continue;
++
++		arg->n_vifs++;
++	}
++}
++
++static void
++ath12k_mac_change_chanctx_fill_iter(void *data, u8 *mac,
++				    struct ieee80211_vif *vif)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_mac_change_chanctx_arg *arg = data;
++	struct ieee80211_bss_conf *link_conf;
++	struct ieee80211_chanctx_conf *ctx;
++	struct ath12k_link_vif *arvif;
++	unsigned long links_map;
++	u8 link_id;
++
++	lockdep_assert_wiphy(ahvif->ah->hw->wiphy);
++
++	links_map = ahvif->links_map;
++	for_each_set_bit(link_id, &links_map, IEEE80211_MLD_MAX_NUM_LINKS) {
++		arvif = wiphy_dereference(ahvif->ah->hw->wiphy, ahvif->link[link_id]);
++		if (WARN_ON(!arvif))
++			continue;
++
++		if (!arvif->is_created || arvif->ar != arg->ar)
++			continue;
++
++		link_conf = wiphy_dereference(ahvif->ah->hw->wiphy,
++					      vif->link_conf[arvif->link_id]);
++		if (WARN_ON(!link_conf))
++			continue;
++
++		ctx = rcu_access_pointer(link_conf->chanctx_conf);
++		if (ctx != arg->ctx)
++			continue;
++
++		if (WARN_ON(arg->next_vif == arg->n_vifs))
++			return;
++
++		arg->vifs[arg->next_vif].vif = vif;
++		arg->vifs[arg->next_vif].old_ctx = ctx;
++		arg->vifs[arg->next_vif].new_ctx = ctx;
++		arg->vifs[arg->next_vif].link_conf = link_conf;
++		arg->next_vif++;
++	}
++}
++
++static u32 ath12k_mac_nlwidth_to_wmiwidth(enum nl80211_chan_width width)
++{
++	switch (width) {
++	case NL80211_CHAN_WIDTH_20:
++		return WMI_CHAN_WIDTH_20;
++	case NL80211_CHAN_WIDTH_40:
++		return WMI_CHAN_WIDTH_40;
++	case NL80211_CHAN_WIDTH_80:
++		return WMI_CHAN_WIDTH_80;
++	case NL80211_CHAN_WIDTH_160:
++		return WMI_CHAN_WIDTH_160;
++	case NL80211_CHAN_WIDTH_80P80:
++		return WMI_CHAN_WIDTH_80P80;
++	case NL80211_CHAN_WIDTH_5:
++		return WMI_CHAN_WIDTH_5;
++	case NL80211_CHAN_WIDTH_10:
++		return WMI_CHAN_WIDTH_10;
++	case NL80211_CHAN_WIDTH_320:
++		return WMI_CHAN_WIDTH_320;
++	default:
++		WARN_ON(1);
++		return WMI_CHAN_WIDTH_20;
++	}
++}
++
++static int ath12k_mac_update_peer_puncturing_width(struct ath12k *ar,
++						   struct ath12k_link_vif *arvif,
++						   struct cfg80211_chan_def def)
++{
++	u32 param_id, param_value;
++	int ret;
++
++	if (arvif->ahvif->vdev_type != WMI_VDEV_TYPE_STA)
++		return 0;
++
++	param_id = WMI_PEER_CHWIDTH_PUNCTURE_20MHZ_BITMAP;
++	param_value = ath12k_mac_nlwidth_to_wmiwidth(def.width) |
++		u32_encode_bits((~def.punctured),
++				WMI_PEER_PUNCTURE_BITMAP);
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "punctured bitmap %02x width %d vdev %d\n",
++		   def.punctured, def.width, arvif->vdev_id);
++
++	ret = ath12k_wmi_set_peer_param(ar, arvif->bssid,
++					arvif->vdev_id, param_id,
++					param_value);
++
++	return ret;
++}
++
++static void
++ath12k_mac_update_vif_chan(struct ath12k *ar,
++			   struct ieee80211_vif_chanctx_switch *vifs,
++			   int n_vifs)
++{
++	struct ath12k_wmi_vdev_up_params params = {};
++	struct ieee80211_bss_conf *link_conf;
++	struct ath12k_base *ab = ar->ab;
++	struct ath12k_link_vif *arvif;
++	struct ieee80211_vif *vif;
++	struct ath12k_vif *ahvif;
++	u8 link_id;
++	int ret;
++	int i;
++	bool monitor_vif = false;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	for (i = 0; i < n_vifs; i++) {
++		vif = vifs[i].vif;
++		ahvif = ath12k_vif_to_ahvif(vif);
++		link_conf = vifs[i].link_conf;
++		link_id = link_conf->link_id;
++		arvif = wiphy_dereference(ath12k_ar_to_hw(ar)->wiphy,
++					  ahvif->link[link_id]);
++
++		if (vif->type == NL80211_IFTYPE_MONITOR) {
++			monitor_vif = true;
++			continue;
++		}
++
++		ath12k_dbg(ab, ATH12K_DBG_MAC,
++			   "mac chanctx switch vdev_id %i freq %u->%u width %d->%d\n",
++			   arvif->vdev_id,
++			   vifs[i].old_ctx->def.chan->center_freq,
++			   vifs[i].new_ctx->def.chan->center_freq,
++			   vifs[i].old_ctx->def.width,
++			   vifs[i].new_ctx->def.width);
++
++		if (WARN_ON(!arvif->is_started))
++			continue;
++
++		arvif->punct_bitmap = vifs[i].new_ctx->def.punctured;
++
++		/* Firmware expect vdev_restart only if vdev is up.
++		 * If vdev is down then it expect vdev_stop->vdev_start.
++		 */
++		if (arvif->is_up) {
++			ret = ath12k_mac_vdev_restart(arvif, vifs[i].new_ctx);
++			if (ret) {
++				ath12k_warn(ab, "failed to restart vdev %d: %d\n",
++					    arvif->vdev_id, ret);
++				continue;
++			}
++		} else {
++			ret = ath12k_mac_vdev_stop(arvif);
++			if (ret) {
++				ath12k_warn(ab, "failed to stop vdev %d: %d\n",
++					    arvif->vdev_id, ret);
++				continue;
++			}
++
++			ret = ath12k_mac_vdev_start(arvif, vifs[i].new_ctx);
++			if (ret)
++				ath12k_warn(ab, "failed to start vdev %d: %d\n",
++					    arvif->vdev_id, ret);
++			continue;
++		}
++
++		ret = ath12k_mac_update_peer_puncturing_width(arvif->ar, arvif,
++							      vifs[i].new_ctx->def);
++		if (ret) {
++			ath12k_warn(ar->ab,
++				    "failed to update puncturing bitmap %02x and width %d: %d\n",
++				    vifs[i].new_ctx->def.punctured,
++				    vifs[i].new_ctx->def.width, ret);
++			continue;
++		}
++
++		/* Defer VDEV bring-up during CSA to avoid installing stale
++		 * beacon templates. The beacon content is updated only
++		 * after CSA finalize, so we mark CSA in progress and skip
++		 * VDEV_UP for now. It will be handled later in
++		 * bss_info_changed().
++		 */
++		if (link_conf->csa_active &&
++		    arvif->ahvif->vdev_type == WMI_VDEV_TYPE_AP) {
++			arvif->is_csa_in_progress = true;
++			continue;
++		}
++
++		ret = ath12k_mac_setup_bcn_tmpl(arvif);
++		if (ret)
++			ath12k_warn(ab, "failed to update bcn tmpl during csa: %d\n",
++				    ret);
++
++		memset(&params, 0, sizeof(params));
++		params.vdev_id = arvif->vdev_id;
++		params.aid = ahvif->aid;
++		params.bssid = arvif->bssid;
++		params.tx_bssid = ath12k_mac_get_tx_bssid(arvif);
++		if (params.tx_bssid) {
++			params.nontx_profile_idx = link_conf->bssid_index;
++			params.nontx_profile_cnt = 1 << link_conf->bssid_indicator;
++		}
++		ret = ath12k_wmi_vdev_up(arvif->ar, &params);
++		if (ret) {
++			ath12k_warn(ab, "failed to bring vdev up %d: %d\n",
++				    arvif->vdev_id, ret);
++			continue;
++		}
++	}
++
++	/* Restart the internal monitor vdev on new channel */
++	if (!monitor_vif && ar->monitor_vdev_created) {
++		if (!ath12k_mac_monitor_stop(ar))
++			ath12k_mac_monitor_start(ar);
++	}
++}
++
++static void
++ath12k_mac_update_active_vif_chan(struct ath12k *ar,
++				  struct ieee80211_chanctx_conf *ctx)
++{
++	struct ath12k_mac_change_chanctx_arg arg = { .ctx = ctx, .ar = ar };
++	struct ieee80211_hw *hw = ath12k_ar_to_hw(ar);
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	ieee80211_iterate_active_interfaces_atomic(hw,
++						   IEEE80211_IFACE_ITER_NORMAL,
++						   ath12k_mac_change_chanctx_cnt_iter,
++						   &arg);
++	if (arg.n_vifs == 0)
++		return;
++
++	arg.vifs = kzalloc_objs(arg.vifs[0], arg.n_vifs);
++	if (!arg.vifs)
++		return;
++
++	ieee80211_iterate_active_interfaces_atomic(hw,
++						   IEEE80211_IFACE_ITER_NORMAL,
++						   ath12k_mac_change_chanctx_fill_iter,
++						   &arg);
++
++	ath12k_mac_update_vif_chan(ar, arg.vifs, arg.n_vifs);
++
++	kfree(arg.vifs);
++}
++
++void ath12k_mac_op_change_chanctx(struct ieee80211_hw *hw,
++				  struct ieee80211_chanctx_conf *ctx,
++				  u32 changed)
++{
++	struct ath12k *ar;
++	struct ath12k_base *ab;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	ar = ath12k_get_ar_by_ctx(hw, ctx);
++	if (!ar)
++		return;
++
++	ab = ar->ab;
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC,
++		   "mac chanctx change freq %u width %d ptr %p changed %x\n",
++		   ctx->def.chan->center_freq, ctx->def.width, ctx, changed);
++
++	/* This shouldn't really happen because channel switching should use
++	 * switch_vif_chanctx().
++	 */
++	if (WARN_ON(changed & IEEE80211_CHANCTX_CHANGE_CHANNEL))
++		return;
++
++	if (changed & IEEE80211_CHANCTX_CHANGE_WIDTH ||
++	    changed & IEEE80211_CHANCTX_CHANGE_RADAR ||
++	    changed & IEEE80211_CHANCTX_CHANGE_PUNCTURING)
++		ath12k_mac_update_active_vif_chan(ar, ctx);
++
++	/* TODO: Recalc radar detection */
++}
++EXPORT_SYMBOL(ath12k_mac_op_change_chanctx);
++
++static int ath12k_start_vdev_delay(struct ath12k *ar,
++				   struct ath12k_link_vif *arvif)
++{
++	struct ath12k_base *ab = ar->ab;
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	struct ieee80211_vif *vif = ath12k_ahvif_to_vif(arvif->ahvif);
++	struct ieee80211_chanctx_conf *chanctx;
++	struct ieee80211_bss_conf *link_conf;
++	int ret;
++
++	if (WARN_ON(arvif->is_started))
++		return -EBUSY;
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf) {
++		ath12k_warn(ab, "failed to get link conf for vdev %u\n", arvif->vdev_id);
++		return -EINVAL;
++	}
++
++	chanctx	= wiphy_dereference(ath12k_ar_to_hw(arvif->ar)->wiphy,
++				    link_conf->chanctx_conf);
++	ret = ath12k_mac_vdev_start(arvif, chanctx);
++	if (ret) {
++		ath12k_warn(ab, "failed to start vdev %i addr %pM on freq %d: %d\n",
++			    arvif->vdev_id, vif->addr,
++			    chanctx->def.chan->center_freq, ret);
++		return ret;
++	}
++
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_MONITOR) {
++		ret = ath12k_monitor_vdev_up(ar, arvif->vdev_id);
++		if (ret) {
++			ath12k_warn(ab, "failed put monitor up: %d\n", ret);
++			return ret;
++		}
++	}
++
++	arvif->is_started = true;
++
++	/* TODO: Setup ps and cts/rts protection */
++	return 0;
++}
++
++static u8 ath12k_mac_get_num_pwr_levels(struct cfg80211_chan_def *chan_def)
++{
++	if (chan_def->chan->flags & IEEE80211_CHAN_PSD) {
++		switch (chan_def->width) {
++		case NL80211_CHAN_WIDTH_20:
++			return 1;
++		case NL80211_CHAN_WIDTH_40:
++			return 2;
++		case NL80211_CHAN_WIDTH_80:
++			return 4;
++		case NL80211_CHAN_WIDTH_160:
++			return 8;
++		case NL80211_CHAN_WIDTH_320:
++			return 16;
++		default:
++			return 1;
++		}
++	} else {
++		switch (chan_def->width) {
++		case NL80211_CHAN_WIDTH_20:
++			return 1;
++		case NL80211_CHAN_WIDTH_40:
++			return 2;
++		case NL80211_CHAN_WIDTH_80:
++			return 3;
++		case NL80211_CHAN_WIDTH_160:
++			return 4;
++		case NL80211_CHAN_WIDTH_320:
++			return 5;
++		default:
++			return 1;
++		}
++	}
++}
++
++static u16 ath12k_mac_get_6ghz_start_frequency(struct cfg80211_chan_def *chan_def)
++{
++	u16 diff_seq;
++
++	/* It is to get the lowest channel number's center frequency of the chan.
++	 * For example,
++	 * bandwidth=40 MHz, center frequency is 5965, lowest channel is 1
++	 * with center frequency 5955, its diff is 5965 - 5955 = 10.
++	 * bandwidth=80 MHz, center frequency is 5985, lowest channel is 1
++	 * with center frequency 5955, its diff is 5985 - 5955 = 30.
++	 * bandwidth=160 MHz, center frequency is 6025, lowest channel is 1
++	 * with center frequency 5955, its diff is 6025 - 5955 = 70.
++	 * bandwidth=320 MHz, center frequency is 6105, lowest channel is 1
++	 * with center frequency 5955, its diff is 6105 - 5955 = 70.
++	 */
++	switch (chan_def->width) {
++	case NL80211_CHAN_WIDTH_320:
++		diff_seq = 150;
++		break;
++	case NL80211_CHAN_WIDTH_160:
++		diff_seq = 70;
++		break;
++	case NL80211_CHAN_WIDTH_80:
++		diff_seq = 30;
++		break;
++	case NL80211_CHAN_WIDTH_40:
++		diff_seq = 10;
++		break;
++	default:
++		diff_seq = 0;
++	}
++
++	return chan_def->center_freq1 - diff_seq;
++}
++
++static u16 ath12k_mac_get_seg_freq(struct cfg80211_chan_def *chan_def,
++				   u16 start_seq, u8 seq)
++{
++	u16 seg_seq;
++
++	/* It is to get the center frequency of the specific bandwidth.
++	 * start_seq means the lowest channel number's center frequency.
++	 * seq 0/1/2/3 means 20 MHz/40 MHz/80 MHz/160 MHz.
++	 * For example,
++	 * lowest channel is 1, its center frequency 5955,
++	 * center frequency is 5955 when bandwidth=20 MHz, its diff is 5955 - 5955 = 0.
++	 * lowest channel is 1, its center frequency 5955,
++	 * center frequency is 5965 when bandwidth=40 MHz, its diff is 5965 - 5955 = 10.
++	 * lowest channel is 1, its center frequency 5955,
++	 * center frequency is 5985 when bandwidth=80 MHz, its diff is 5985 - 5955 = 30.
++	 * lowest channel is 1, its center frequency 5955,
++	 * center frequency is 6025 when bandwidth=160 MHz, its diff is 6025 - 5955 = 70.
++	 */
++	seg_seq = 10 * (BIT(seq) - 1);
++	return seg_seq + start_seq;
++}
++
++static void ath12k_mac_get_psd_channel(struct ath12k *ar,
++				       u16 step_freq,
++				       u16 *start_freq,
++				       u16 *center_freq,
++				       u8 i,
++				       struct ieee80211_channel **temp_chan,
++				       s8 *tx_power)
++{
++	/* It is to get the center frequency for each 20 MHz.
++	 * For example, if the chan is 160 MHz and center frequency is 6025,
++	 * then it include 8 channels, they are 1/5/9/13/17/21/25/29,
++	 * channel number 1's center frequency is 5955, it is parameter start_freq.
++	 * parameter i is the step of the 8 channels. i is 0~7 for the 8 channels.
++	 * the channel 1/5/9/13/17/21/25/29 maps i=0/1/2/3/4/5/6/7,
++	 * and maps its center frequency is 5955/5975/5995/6015/6035/6055/6075/6095,
++	 * the gap is 20 for each channel, parameter step_freq means the gap.
++	 * after get the center frequency of each channel, it is easy to find the
++	 * struct ieee80211_channel of it and get the max_reg_power.
++	 */
++	*center_freq = *start_freq + i * step_freq;
++	*temp_chan = ieee80211_get_channel(ar->ah->hw->wiphy, *center_freq);
++	*tx_power = (*temp_chan)->max_reg_power;
++}
++
++static void ath12k_mac_get_eirp_power(struct ath12k *ar,
++				      u16 *start_freq,
++				      u16 *center_freq,
++				      u8 i,
++				      struct ieee80211_channel **temp_chan,
++				      struct cfg80211_chan_def *def,
++				      s8 *tx_power)
++{
++	/* It is to get the center frequency for 20 MHz/40 MHz/80 MHz/
++	 * 160 MHz bandwidth, and then plus 10 to the center frequency,
++	 * it is the center frequency of a channel number.
++	 * For example, when configured channel number is 1.
++	 * center frequency is 5965 when bandwidth=40 MHz, after plus 10, it is 5975,
++	 * then it is channel number 5.
++	 * center frequency is 5985 when bandwidth=80 MHz, after plus 10, it is 5995,
++	 * then it is channel number 9.
++	 * center frequency is 6025 when bandwidth=160 MHz, after plus 10, it is 6035,
++	 * then it is channel number 17.
++	 * after get the center frequency of each channel, it is easy to find the
++	 * struct ieee80211_channel of it and get the max_reg_power.
++	 */
++	*center_freq = ath12k_mac_get_seg_freq(def, *start_freq, i);
++
++	/* For the 20 MHz, its center frequency is same with same channel */
++	if (i != 0)
++		*center_freq += 10;
++
++	*temp_chan = ieee80211_get_channel(ar->ah->hw->wiphy, *center_freq);
++	*tx_power = (*temp_chan)->max_reg_power;
++}
++
++void ath12k_mac_fill_reg_tpc_info(struct ath12k *ar,
++				  struct ath12k_link_vif *arvif,
++				  struct ieee80211_chanctx_conf *ctx)
++{
++	struct ath12k_base *ab = ar->ab;
++	struct ath12k_reg_tpc_power_info *reg_tpc_info = &arvif->reg_tpc_info;
++	struct ieee80211_bss_conf *bss_conf = ath12k_mac_get_link_bss_conf(arvif);
++	struct ieee80211_channel *chan, *temp_chan;
++	u8 pwr_lvl_idx, num_pwr_levels, pwr_reduction;
++	bool is_psd_power = false, is_tpe_present = false;
++	s8 max_tx_power[ATH12K_NUM_PWR_LEVELS], psd_power, tx_power;
++	s8 eirp_power = 0;
++	struct ath12k_vif *ahvif = arvif->ahvif;
++	u16 start_freq, center_freq;
++	u8 reg_6ghz_power_mode;
++
++	chan = ctx->def.chan;
++	start_freq = ath12k_mac_get_6ghz_start_frequency(&ctx->def);
++	pwr_reduction = bss_conf->pwr_reduction;
++
++	if (arvif->reg_tpc_info.num_pwr_levels) {
++		is_tpe_present = true;
++		num_pwr_levels = arvif->reg_tpc_info.num_pwr_levels;
++	} else {
++		num_pwr_levels = ath12k_mac_get_num_pwr_levels(&ctx->def);
++	}
++
++	for (pwr_lvl_idx = 0; pwr_lvl_idx < num_pwr_levels; pwr_lvl_idx++) {
++		/* STA received TPE IE*/
++		if (is_tpe_present) {
++			/* local power is PSD power*/
++			if (chan->flags & IEEE80211_CHAN_PSD) {
++				/* Connecting AP is psd power */
++				if (reg_tpc_info->is_psd_power) {
++					is_psd_power = true;
++					ath12k_mac_get_psd_channel(ar, 20,
++								   &start_freq,
++								   &center_freq,
++								   pwr_lvl_idx,
++								   &temp_chan,
++								   &tx_power);
++					psd_power = temp_chan->psd;
++					eirp_power = tx_power;
++					max_tx_power[pwr_lvl_idx] =
++						min_t(s8,
++						      psd_power,
++						      reg_tpc_info->tpe[pwr_lvl_idx]);
++				/* Connecting AP is not psd power */
++				} else {
++					ath12k_mac_get_eirp_power(ar,
++								  &start_freq,
++								  &center_freq,
++								  pwr_lvl_idx,
++								  &temp_chan,
++								  &ctx->def,
++								  &tx_power);
++					psd_power = temp_chan->psd;
++					/* convert psd power to EIRP power based
++					 * on channel width
++					 */
++					tx_power =
++						min_t(s8, tx_power,
++						      psd_power + 13 + pwr_lvl_idx * 3);
++					max_tx_power[pwr_lvl_idx] =
++						min_t(s8,
++						      tx_power,
++						      reg_tpc_info->tpe[pwr_lvl_idx]);
++				}
++			/* local power is not PSD power */
++			} else {
++				/* Connecting AP is psd power */
++				if (reg_tpc_info->is_psd_power) {
++					is_psd_power = true;
++					ath12k_mac_get_psd_channel(ar, 20,
++								   &start_freq,
++								   &center_freq,
++								   pwr_lvl_idx,
++								   &temp_chan,
++								   &tx_power);
++					eirp_power = tx_power;
++					max_tx_power[pwr_lvl_idx] =
++						reg_tpc_info->tpe[pwr_lvl_idx];
++				/* Connecting AP is not psd power */
++				} else {
++					ath12k_mac_get_eirp_power(ar,
++								  &start_freq,
++								  &center_freq,
++								  pwr_lvl_idx,
++								  &temp_chan,
++								  &ctx->def,
++								  &tx_power);
++					max_tx_power[pwr_lvl_idx] =
++						min_t(s8,
++						      tx_power,
++						      reg_tpc_info->tpe[pwr_lvl_idx]);
++				}
++			}
++		/* STA not received TPE IE */
++		} else {
++			/* local power is PSD power*/
++			if (chan->flags & IEEE80211_CHAN_PSD) {
++				is_psd_power = true;
++				ath12k_mac_get_psd_channel(ar, 20,
++							   &start_freq,
++							   &center_freq,
++							   pwr_lvl_idx,
++							   &temp_chan,
++							   &tx_power);
++				psd_power = temp_chan->psd;
++				eirp_power = tx_power;
++				max_tx_power[pwr_lvl_idx] = psd_power;
++			} else {
++				ath12k_mac_get_eirp_power(ar,
++							  &start_freq,
++							  &center_freq,
++							  pwr_lvl_idx,
++							  &temp_chan,
++							  &ctx->def,
++							  &tx_power);
++				max_tx_power[pwr_lvl_idx] = tx_power;
++			}
++		}
++
++		if (is_psd_power) {
++			/* If AP local power constraint is present */
++			if (pwr_reduction)
++				eirp_power = eirp_power - pwr_reduction;
++
++			/* If firmware updated max tx power is non zero, then take
++			 * the min of firmware updated ap tx power
++			 * and max power derived from above mentioned parameters.
++			 */
++			ath12k_dbg(ab, ATH12K_DBG_MAC,
++				   "eirp power : %d firmware report power : %d\n",
++				   eirp_power, ar->max_allowed_tx_power);
++			/* Firmware reports lower max_allowed_tx_power during vdev
++			 * start response. In case of 6 GHz, firmware is not aware
++			 * of EIRP power unless driver sets EIRP power through WMI
++			 * TPC command. So radio which does not support idle power
++			 * save can set maximum calculated EIRP power directly to
++			 * firmware through TPC command without min comparison with
++			 * vdev start response's max_allowed_tx_power.
++			 */
++			if (ar->max_allowed_tx_power && ab->hw_params->idle_ps)
++				eirp_power = min_t(s8,
++						   eirp_power,
++						   ar->max_allowed_tx_power);
++		} else {
++			/* If AP local power constraint is present */
++			if (pwr_reduction)
++				max_tx_power[pwr_lvl_idx] =
++					max_tx_power[pwr_lvl_idx] - pwr_reduction;
++			/* If firmware updated max tx power is non zero, then take
++			 * the min of firmware updated ap tx power
++			 * and max power derived from above mentioned parameters.
++			 */
++			if (ar->max_allowed_tx_power && ab->hw_params->idle_ps)
++				max_tx_power[pwr_lvl_idx] =
++					min_t(s8,
++					      max_tx_power[pwr_lvl_idx],
++					      ar->max_allowed_tx_power);
++		}
++		reg_tpc_info->chan_power_info[pwr_lvl_idx].chan_cfreq = center_freq;
++		reg_tpc_info->chan_power_info[pwr_lvl_idx].tx_power =
++			max_tx_power[pwr_lvl_idx];
++	}
++
++	reg_tpc_info->num_pwr_levels = num_pwr_levels;
++	reg_tpc_info->is_psd_power = is_psd_power;
++	reg_tpc_info->eirp_power = eirp_power;
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_STA)
++		reg_6ghz_power_mode = bss_conf->power_type;
++	else
++		/* For now, LPI is the only supported AP power mode */
++		reg_6ghz_power_mode = IEEE80211_REG_LPI_AP;
++
++	reg_tpc_info->ap_power_type =
++		ath12k_reg_ap_pwr_convert(reg_6ghz_power_mode);
++}
++
++static void ath12k_mac_parse_tx_pwr_env(struct ath12k *ar,
++					struct ath12k_link_vif *arvif)
++{
++	struct ieee80211_bss_conf *bss_conf = ath12k_mac_get_link_bss_conf(arvif);
++	struct ath12k_reg_tpc_power_info *tpc_info = &arvif->reg_tpc_info;
++	struct ieee80211_parsed_tpe_eirp *local_non_psd, *reg_non_psd;
++	struct ieee80211_parsed_tpe_psd *local_psd, *reg_psd;
++	struct ieee80211_parsed_tpe *tpe = &bss_conf->tpe;
++	enum wmi_reg_6g_client_type client_type;
++	struct ath12k_reg_info *reg_info;
++	struct ath12k_base *ab = ar->ab;
++	bool psd_valid, non_psd_valid;
++	int i;
++
++	reg_info = ab->reg_info[ar->pdev_idx];
++	client_type = reg_info->client_type;
++
++	local_psd = &tpe->psd_local[client_type];
++	reg_psd = &tpe->psd_reg_client[client_type];
++	local_non_psd = &tpe->max_local[client_type];
++	reg_non_psd = &tpe->max_reg_client[client_type];
++
++	psd_valid = local_psd->valid | reg_psd->valid;
++	non_psd_valid = local_non_psd->valid | reg_non_psd->valid;
++
++	if (!psd_valid && !non_psd_valid) {
++		ath12k_warn(ab,
++			    "no transmit power envelope match client power type %d\n",
++			    client_type);
++		return;
++	}
++
++	if (psd_valid) {
++		tpc_info->is_psd_power = true;
++
++		tpc_info->num_pwr_levels = max(local_psd->count,
++					       reg_psd->count);
++		tpc_info->num_pwr_levels =
++				min3(tpc_info->num_pwr_levels,
++				     IEEE80211_TPE_PSD_ENTRIES_320MHZ,
++				     ATH12K_NUM_PWR_LEVELS);
++
++		for (i = 0; i < tpc_info->num_pwr_levels; i++) {
++			tpc_info->tpe[i] = min(local_psd->power[i],
++					       reg_psd->power[i]) / 2;
++			ath12k_dbg(ab, ATH12K_DBG_MAC,
++				   "TPE PSD power[%d] : %d\n",
++				   i, tpc_info->tpe[i]);
++		}
++	} else {
++		tpc_info->is_psd_power = false;
++		tpc_info->eirp_power = 0;
++
++		tpc_info->num_pwr_levels = max(local_non_psd->count,
++					       reg_non_psd->count);
++		tpc_info->num_pwr_levels =
++				min3(tpc_info->num_pwr_levels,
++				     IEEE80211_TPE_EIRP_ENTRIES_320MHZ,
++				     ATH12K_NUM_PWR_LEVELS);
++
++		for (i = 0; i < tpc_info->num_pwr_levels; i++) {
++			tpc_info->tpe[i] = min(local_non_psd->power[i],
++					       reg_non_psd->power[i]) / 2;
++			ath12k_dbg(ab, ATH12K_DBG_MAC,
++				   "non PSD power[%d] : %d\n",
++				   i, tpc_info->tpe[i]);
++		}
++	}
++}
++
++int
++ath12k_mac_op_assign_vif_chanctx(struct ieee80211_hw *hw,
++				 struct ieee80211_vif *vif,
++				 struct ieee80211_bss_conf *link_conf,
++				 struct ieee80211_chanctx_conf *ctx)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k *ar;
++	struct ath12k_base *ab;
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	u8 link_id = link_conf->link_id;
++	struct ath12k_link_vif *arvif;
++	int ret;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	/* For multi radio wiphy, the vdev was not created during add_interface
++	 * create now since we have a channel ctx now to assign to a specific ar/fw
++	 */
++	arvif = ath12k_mac_assign_link_vif(ah, vif, link_id);
++	if (!arvif) {
++		WARN_ON(1);
++		return -ENOMEM;
++	}
++
++	ar = ath12k_mac_assign_vif_to_vdev(hw, arvif, ctx);
++	if (!ar) {
++		ath12k_hw_warn(ah, "failed to assign chanctx for vif %pM link id %u link vif is already started",
++			       vif->addr, link_id);
++		return -EINVAL;
++	}
++
++	ab = ar->ab;
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC,
++		   "mac chanctx assign ptr %p vdev_id %i\n",
++		   ctx, arvif->vdev_id);
++
++	if (ath12k_wmi_supports_6ghz_cc_ext(ar) &&
++	    ctx->def.chan->band == NL80211_BAND_6GHZ &&
++	    ahvif->vdev_type == WMI_VDEV_TYPE_STA)
++		ath12k_mac_parse_tx_pwr_env(ar, arvif);
++
++	arvif->punct_bitmap = ctx->def.punctured;
++
++	/* for some targets bss peer must be created before vdev_start */
++	if (ab->hw_params->vdev_start_delay &&
++	    ahvif->vdev_type != WMI_VDEV_TYPE_AP &&
++	    ahvif->vdev_type != WMI_VDEV_TYPE_MONITOR &&
++	    !ath12k_dp_link_peer_exist_by_vdev_id(ath12k_ab_to_dp(ab), arvif->vdev_id)) {
++		ret = 0;
++		goto out;
++	}
++
++	if (WARN_ON(arvif->is_started)) {
++		ret = -EBUSY;
++		goto out;
++	}
++
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_MONITOR) {
++		ret = ath12k_mac_monitor_start(ar);
++		if (ret) {
++			ath12k_mac_monitor_vdev_delete(ar);
++			goto out;
++		}
++
++		arvif->is_started = true;
++		goto out;
++	}
++
++	ret = ath12k_mac_vdev_start(arvif, ctx);
++	if (ret) {
++		ath12k_warn(ab, "failed to start vdev %i addr %pM on freq %d: %d\n",
++			    arvif->vdev_id, vif->addr,
++			    ctx->def.chan->center_freq, ret);
++		goto out;
++	}
++
++	arvif->is_started = true;
++
++	/* TODO: Setup ps and cts/rts protection */
++
++out:
++	return ret;
++}
++EXPORT_SYMBOL(ath12k_mac_op_assign_vif_chanctx);
++
++void
++ath12k_mac_op_unassign_vif_chanctx(struct ieee80211_hw *hw,
++				   struct ieee80211_vif *vif,
++				   struct ieee80211_bss_conf *link_conf,
++				   struct ieee80211_chanctx_conf *ctx)
++{
++	struct ath12k *ar;
++	struct ath12k_base *ab;
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_link_vif *arvif;
++	u8 link_id = link_conf->link_id;
++	int ret;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++
++	/* The vif is expected to be attached to an ar's VDEV.
++	 * We leave the vif/vdev in this function as is
++	 * and not delete the vdev symmetric to assign_vif_chanctx()
++	 * the VDEV will be deleted and unassigned either during
++	 * remove_interface() or when there is a change in channel
++	 * that moves the vif to a new ar
++	 */
++	if (!arvif || !arvif->is_created)
++		return;
++
++	ar = arvif->ar;
++	ab = ar->ab;
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC,
++		   "mac chanctx unassign ptr %p vdev_id %i\n",
++		   ctx, arvif->vdev_id);
++
++	WARN_ON(!arvif->is_started);
++
++	if (ahvif->vdev_type == WMI_VDEV_TYPE_MONITOR) {
++		ret = ath12k_mac_monitor_stop(ar);
++		if (ret)
++			return;
++
++		arvif->is_started = false;
++	}
++
++	if (ahvif->vdev_type != WMI_VDEV_TYPE_STA &&
++	    ahvif->vdev_type != WMI_VDEV_TYPE_MONITOR) {
++		ath12k_bss_disassoc(ar, arvif);
++		ret = ath12k_mac_vdev_stop(arvif);
++		if (ret)
++			ath12k_warn(ab, "failed to stop vdev %i: %d\n",
++				    arvif->vdev_id, ret);
++	}
++	arvif->is_started = false;
++
++	if (test_bit(WMI_TLV_SERVICE_11D_OFFLOAD, ab->wmi_ab.svc_map) &&
++	    ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
++	    ahvif->vdev_subtype == WMI_VDEV_SUBTYPE_NONE &&
++	    ar->state_11d != ATH12K_11D_PREPARING) {
++		reinit_completion(&ar->completed_11d_scan);
++		ar->state_11d = ATH12K_11D_PREPARING;
++	}
++
++	if (ar->scan.arvif == arvif && ar->scan.state == ATH12K_SCAN_RUNNING) {
++		ath12k_scan_abort(ar);
++		ar->scan.arvif = NULL;
++	}
++}
++EXPORT_SYMBOL(ath12k_mac_op_unassign_vif_chanctx);
++
++int
++ath12k_mac_op_switch_vif_chanctx(struct ieee80211_hw *hw,
++				 struct ieee80211_vif_chanctx_switch *vifs,
++				 int n_vifs,
++				 enum ieee80211_chanctx_switch_mode mode)
++{
++	struct ath12k *ar;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	ar = ath12k_get_ar_by_ctx(hw, vifs->old_ctx);
++	if (!ar)
++		return -EINVAL;
++
++	/* Switching channels across radio is not allowed */
++	if (ar != ath12k_get_ar_by_ctx(hw, vifs->new_ctx))
++		return -EINVAL;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac chanctx switch n_vifs %d mode %d\n",
++		   n_vifs, mode);
++	ath12k_mac_update_vif_chan(ar, vifs, n_vifs);
++
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_switch_vif_chanctx);
++
++static int
++ath12k_set_vdev_param_to_all_vifs(struct ath12k *ar, int param, u32 value)
++{
++	struct ath12k_link_vif *arvif;
++	int ret = 0;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	list_for_each_entry(arvif, &ar->arvifs, list) {
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "setting mac vdev %d param %d value %d\n",
++			   param, arvif->vdev_id, value);
++
++		ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++						    param, value);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to set param %d for vdev %d: %d\n",
++				    param, arvif->vdev_id, ret);
++			break;
++		}
++	}
++
++	return ret;
++}
++
++/* mac80211 stores device specific RTS/Fragmentation threshold value,
++ * this is set interface specific to firmware from ath12k driver
++ */
++int ath12k_mac_op_set_rts_threshold(struct ieee80211_hw *hw,
++				    int radio_idx, u32 value)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct wiphy *wiphy = hw->wiphy;
++	struct ath12k *ar;
++	int param_id = WMI_VDEV_PARAM_RTS_THRESHOLD;
++	int ret = 0, ret_err, i;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (radio_idx >= wiphy->n_radio || radio_idx < -1)
++		return -EINVAL;
++
++	if (radio_idx != -1) {
++		/* Update RTS threshold in specified radio */
++		ar = ath12k_ah_to_ar(ah, radio_idx);
++		ret = ath12k_set_vdev_param_to_all_vifs(ar, param_id, value);
++		if (ret) {
++			ath12k_warn(ar->ab,
++				    "failed to set RTS config for all vdevs of pdev %d",
++				    ar->pdev->pdev_id);
++			return ret;
++		}
++
++		ar->rts_threshold = value;
++		return 0;
++	}
++
++	/* Radio_index passed is -1, so set RTS threshold for all radios. */
++	for_each_ar(ah, ar, i) {
++		ret = ath12k_set_vdev_param_to_all_vifs(ar, param_id, value);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to set RTS config for all vdevs of pdev %d",
++				    ar->pdev->pdev_id);
++			break;
++		}
++	}
++	if (!ret) {
++		/* Setting new RTS threshold for vdevs of all radios passed, so update
++		 * the RTS threshold value for all radios
++		 */
++		for_each_ar(ah, ar, i)
++			ar->rts_threshold = value;
++		return 0;
++	}
++
++	/* RTS threshold config failed, revert to the previous RTS threshold */
++	for (i = i - 1; i >= 0; i--) {
++		ar = ath12k_ah_to_ar(ah, i);
++		ret_err = ath12k_set_vdev_param_to_all_vifs(ar, param_id,
++							    ar->rts_threshold);
++		if (ret_err)
++			ath12k_warn(ar->ab,
++				    "failed to restore RTS threshold for all vdevs of pdev %d",
++				    ar->pdev->pdev_id);
++	}
++
++	return ret;
++}
++EXPORT_SYMBOL(ath12k_mac_op_set_rts_threshold);
++
++int ath12k_mac_op_set_frag_threshold(struct ieee80211_hw *hw,
++				     int radio_idx, u32 value)
++{
++	/* Even though there's a WMI vdev param for fragmentation threshold no
++	 * known firmware actually implements it. Moreover it is not possible to
++	 * rely frame fragmentation to mac80211 because firmware clears the
++	 * "more fragments" bit in frame control making it impossible for remote
++	 * devices to reassemble frames.
++	 *
++	 * Hence implement a dummy callback just to say fragmentation isn't
++	 * supported. This effectively prevents mac80211 from doing frame
++	 * fragmentation in software.
++	 */
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	return -EOPNOTSUPP;
++}
++EXPORT_SYMBOL(ath12k_mac_op_set_frag_threshold);
++
++static int ath12k_mac_flush(struct ath12k *ar)
++{
++	long time_left;
++	int ret = 0;
++
++	time_left = wait_event_timeout(ar->dp.tx_empty_waitq,
++				       (atomic_read(&ar->dp.num_tx_pending) == 0),
++				       ATH12K_FLUSH_TIMEOUT);
++	if (time_left == 0) {
++		ath12k_warn(ar->ab,
++			    "failed to flush transmit queue, data pkts pending %d\n",
++			    atomic_read(&ar->dp.num_tx_pending));
++		ret = -ETIMEDOUT;
++	}
++
++	time_left = wait_event_timeout(ar->txmgmt_empty_waitq,
++				       (atomic_read(&ar->num_pending_mgmt_tx) == 0),
++				       ATH12K_FLUSH_TIMEOUT);
++	if (time_left == 0) {
++		ath12k_warn(ar->ab,
++			    "failed to flush mgmt transmit queue, mgmt pkts pending %d\n",
++			    atomic_read(&ar->num_pending_mgmt_tx));
++		ret = -ETIMEDOUT;
++	}
++
++	return ret;
++}
++
++int ath12k_mac_wait_tx_complete(struct ath12k *ar)
++{
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	ath12k_mac_drain_tx(ar);
++	return ath12k_mac_flush(ar);
++}
++
++void ath12k_mac_op_flush(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
++			 u32 queues, bool drop)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k_link_vif *arvif;
++	struct ath12k_vif *ahvif;
++	unsigned long links;
++	struct ath12k *ar;
++	u8 link_id;
++	int i;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (drop)
++		return;
++
++	for_each_ar(ah, ar, i)
++		wiphy_work_flush(hw->wiphy, &ar->wmi_mgmt_tx_work);
++
++	/* vif can be NULL when flush() is considered for hw */
++	if (!vif) {
++		for_each_ar(ah, ar, i)
++			ath12k_mac_flush(ar);
++		return;
++	}
++
++	ahvif = ath12k_vif_to_ahvif(vif);
++	links = ahvif->links_map;
++	for_each_set_bit(link_id, &links, IEEE80211_MLD_MAX_NUM_LINKS) {
++		arvif = wiphy_dereference(hw->wiphy, ahvif->link[link_id]);
++		if (!(arvif && arvif->ar))
++			continue;
++
++		ath12k_mac_flush(arvif->ar);
++	}
++}
++EXPORT_SYMBOL(ath12k_mac_op_flush);
++
++static int
++ath12k_mac_bitrate_mask_num_ht_rates(struct ath12k *ar,
++				     enum nl80211_band band,
++				     const struct cfg80211_bitrate_mask *mask)
++{
++	int num_rates = 0;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].ht_mcs); i++)
++		num_rates += hweight16(mask->control[band].ht_mcs[i]);
++
++	return num_rates;
++}
++
++static bool
++ath12k_mac_has_single_legacy_rate(struct ath12k *ar,
++				  enum nl80211_band band,
++				  const struct cfg80211_bitrate_mask *mask)
++{
++	int num_rates = 0;
++
++	num_rates = hweight32(mask->control[band].legacy);
++
++	if (ath12k_mac_bitrate_mask_num_ht_rates(ar, band, mask))
++		return false;
++
++	if (ath12k_mac_bitrate_mask_num_vht_rates(ar, band, mask))
++		return false;
++
++	if (ath12k_mac_bitrate_mask_num_he_rates(ar, band, mask))
++		return false;
++
++	if (ath12k_mac_bitrate_mask_num_eht_rates(ar, band, mask))
++		return false;
++
++	return num_rates == 1;
++}
++
++static __le16
++ath12k_mac_get_tx_mcs_map(const struct ieee80211_sta_he_cap *he_cap)
++{
++	if (he_cap->he_cap_elem.phy_cap_info[0] &
++	    IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_160MHZ_IN_5G)
++		return he_cap->he_mcs_nss_supp.tx_mcs_160;
++
++	return he_cap->he_mcs_nss_supp.tx_mcs_80;
++}
++
++static bool
++ath12k_mac_bitrate_mask_get_single_nss(struct ath12k *ar,
++				       struct ieee80211_vif *vif,
++				       enum nl80211_band band,
++				       const struct cfg80211_bitrate_mask *mask,
++				       int *nss)
++{
++	struct ieee80211_supported_band *sband = &ar->mac.sbands[band];
++	u16 vht_mcs_map = le16_to_cpu(sband->vht_cap.vht_mcs.tx_mcs_map);
++	const struct ieee80211_sband_iftype_data *data;
++	const struct ieee80211_sta_he_cap *he_cap;
++	u16 he_mcs_map = 0;
++	u16 eht_mcs_map = 0;
++	u8 ht_nss_mask = 0;
++	u8 vht_nss_mask = 0;
++	u8 he_nss_mask = 0;
++	u8 eht_nss_mask = 0;
++	u8 mcs_nss_len;
++	int i;
++
++	/* No need to consider legacy here. Basic rates are always present
++	 * in bitrate mask
++	 */
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].ht_mcs); i++) {
++		if (mask->control[band].ht_mcs[i] == 0)
++			continue;
++		else if (mask->control[band].ht_mcs[i] ==
++			 sband->ht_cap.mcs.rx_mask[i])
++			ht_nss_mask |= BIT(i);
++		else
++			return false;
++	}
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].vht_mcs); i++) {
++		if (mask->control[band].vht_mcs[i] == 0)
++			continue;
++		else if (mask->control[band].vht_mcs[i] ==
++			 ath12k_mac_get_max_vht_mcs_map(vht_mcs_map, i))
++			vht_nss_mask |= BIT(i);
++		else
++			return false;
++	}
++
++	he_cap = ieee80211_get_he_iftype_cap_vif(sband, vif);
++	if (!he_cap)
++		return false;
++
++	he_mcs_map = le16_to_cpu(ath12k_mac_get_tx_mcs_map(he_cap));
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].he_mcs); i++) {
++		if (mask->control[band].he_mcs[i] == 0)
++			continue;
++
++		if (mask->control[band].he_mcs[i] ==
++		    ath12k_mac_get_max_he_mcs_map(he_mcs_map, i))
++			he_nss_mask |= BIT(i);
++		else
++			return false;
++	}
++
++	data = ieee80211_get_sband_iftype_data(sband, vif->type);
++
++	mcs_nss_len = ieee80211_eht_mcs_nss_size(&data->he_cap.he_cap_elem,
++						 &data->eht_cap.eht_cap_elem,
++						 false);
++	if (mcs_nss_len == 4) {
++		/* 20 MHz only STA case */
++		const struct ieee80211_eht_mcs_nss_supp_20mhz_only *eht_mcs_nss =
++			&data->eht_cap.eht_mcs_nss_supp.only_20mhz;
++		if (eht_mcs_nss->rx_tx_mcs13_max_nss)
++			eht_mcs_map = 0x1fff;
++		else if (eht_mcs_nss->rx_tx_mcs11_max_nss)
++			eht_mcs_map = 0x07ff;
++		else if (eht_mcs_nss->rx_tx_mcs9_max_nss)
++			eht_mcs_map = 0x01ff;
++		else
++			eht_mcs_map = 0x007f;
++	} else {
++		const struct ieee80211_eht_mcs_nss_supp_bw *eht_mcs_nss;
++
++		switch (mcs_nss_len) {
++		case 9:
++			eht_mcs_nss = &data->eht_cap.eht_mcs_nss_supp.bw._320;
++			break;
++		case 6:
++			eht_mcs_nss = &data->eht_cap.eht_mcs_nss_supp.bw._160;
++			break;
++		case 3:
++			eht_mcs_nss = &data->eht_cap.eht_mcs_nss_supp.bw._80;
++			break;
++		default:
++			return false;
++		}
++
++		if (eht_mcs_nss->rx_tx_mcs13_max_nss)
++			eht_mcs_map = 0x1fff;
++		else if (eht_mcs_nss->rx_tx_mcs11_max_nss)
++			eht_mcs_map = 0x7ff;
++		else
++			eht_mcs_map = 0x1ff;
++	}
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].eht_mcs); i++) {
++		if (mask->control[band].eht_mcs[i] == 0)
++			continue;
++
++		if (mask->control[band].eht_mcs[i] < eht_mcs_map)
++			eht_nss_mask |= BIT(i);
++		else
++			return false;
++	}
++
++	if (ht_nss_mask != vht_nss_mask || ht_nss_mask != he_nss_mask ||
++	    ht_nss_mask != eht_nss_mask)
++		return false;
++
++	if (ht_nss_mask == 0)
++		return false;
++
++	if (BIT(fls(ht_nss_mask)) - 1 != ht_nss_mask)
++		return false;
++
++	*nss = fls(ht_nss_mask);
++
++	return true;
++}
++
++static int
++ath12k_mac_get_single_legacy_rate(struct ath12k *ar,
++				  enum nl80211_band band,
++				  const struct cfg80211_bitrate_mask *mask,
++				  u32 *rate, u8 *nss)
++{
++	int rate_idx;
++	u16 bitrate;
++	u8 preamble;
++	u8 hw_rate;
++
++	if (hweight32(mask->control[band].legacy) != 1)
++		return -EINVAL;
++
++	rate_idx = ffs(mask->control[band].legacy) - 1;
++
++	if (band == NL80211_BAND_5GHZ || band == NL80211_BAND_6GHZ)
++		rate_idx += ATH12K_MAC_FIRST_OFDM_RATE_IDX;
++
++	hw_rate = ath12k_legacy_rates[rate_idx].hw_value;
++	bitrate = ath12k_legacy_rates[rate_idx].bitrate;
++
++	if (ath12k_mac_bitrate_is_cck(bitrate))
++		preamble = WMI_RATE_PREAMBLE_CCK;
++	else
++		preamble = WMI_RATE_PREAMBLE_OFDM;
++
++	*nss = 1;
++	*rate = ATH12K_HW_RATE_CODE(hw_rate, 0, preamble);
++
++	return 0;
++}
++
++static int
++ath12k_mac_set_fixed_rate_gi_ltf(struct ath12k_link_vif *arvif, u8 gi, u8 ltf,
++				 u32 param)
++{
++	struct ath12k *ar = arvif->ar;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	/* 0.8 = 0, 1.6 = 2 and 3.2 = 3. */
++	if (gi && gi != 0xFF)
++		gi += 1;
++
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    WMI_VDEV_PARAM_SGI, gi);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set GI:%d, error:%d\n",
++			    gi, ret);
++		return ret;
++	}
++
++	if (param == WMI_VDEV_PARAM_HE_LTF) {
++		/* HE values start from 1 */
++		if (ltf != 0xFF)
++			ltf += 1;
++	} else {
++		/* EHT values start from 5 */
++		if (ltf != 0xFF)
++			ltf += 4;
++	}
++
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    param, ltf);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set LTF:%d, error:%d\n",
++			    ltf, ret);
++		return ret;
++	}
++	return 0;
++}
++
++static int
++ath12k_mac_set_auto_rate_gi_ltf(struct ath12k_link_vif *arvif, u16 gi, u8 ltf)
++{
++	struct ath12k *ar = arvif->ar;
++	int ret;
++	u32 ar_gi_ltf;
++
++	if (gi != 0xFF) {
++		switch (gi) {
++		case ATH12K_RATE_INFO_GI_0_8:
++			gi = WMI_AUTORATE_800NS_GI;
++			break;
++		case ATH12K_RATE_INFO_GI_1_6:
++			gi = WMI_AUTORATE_1600NS_GI;
++			break;
++		case ATH12K_RATE_INFO_GI_3_2:
++			gi = WMI_AUTORATE_3200NS_GI;
++			break;
++		default:
++			ath12k_warn(ar->ab, "Invalid GI\n");
++			return -EINVAL;
++		}
++	}
++
++	if (ltf != 0xFF) {
++		switch (ltf) {
++		case ATH12K_RATE_INFO_1XLTF:
++			ltf = WMI_AUTORATE_LTF_1X;
++			break;
++		case ATH12K_RATE_INFO_2XLTF:
++			ltf = WMI_AUTORATE_LTF_2X;
++			break;
++		case ATH12K_RATE_INFO_4XLTF:
++			ltf = WMI_AUTORATE_LTF_4X;
++			break;
++		default:
++			ath12k_warn(ar->ab, "Invalid LTF\n");
++			return -EINVAL;
++		}
++	}
++
++	ar_gi_ltf = gi | ltf;
++
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    WMI_VDEV_PARAM_AUTORATE_MISC_CFG,
++					    ar_gi_ltf);
++	if (ret) {
++		ath12k_warn(ar->ab,
++			    "failed to set autorate GI:%u, LTF:%u params, error:%d\n",
++			    gi, ltf, ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static u32 ath12k_mac_nlgi_to_wmigi(enum nl80211_txrate_gi gi)
++{
++	switch (gi) {
++	case NL80211_TXRATE_DEFAULT_GI:
++		return WMI_GI_400_NS;
++	case NL80211_TXRATE_FORCE_LGI:
++		return WMI_GI_800_NS;
++	default:
++		return WMI_GI_400_NS;
++	}
++}
++
++static int ath12k_mac_set_rate_params(struct ath12k_link_vif *arvif,
++				      u32 rate, u8 nss, u8 sgi, u8 ldpc,
++				      u8 he_gi, u8 he_ltf, bool he_fixed_rate,
++				      u8 eht_gi, u8 eht_ltf,
++				      bool eht_fixed_rate)
++{
++	struct ieee80211_bss_conf *link_conf;
++	struct ath12k *ar = arvif->ar;
++	bool he_support, eht_support, gi_ltf_set = false;
++	u32 vdev_param;
++	u32 param_value;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	link_conf = ath12k_mac_get_link_bss_conf(arvif);
++	if (!link_conf)
++		return -EINVAL;
++
++	he_support = link_conf->he_support;
++	eht_support = link_conf->eht_support;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac set rate params vdev %i rate 0x%02x nss 0x%02x sgi 0x%02x ldpc 0x%02x\n",
++		   arvif->vdev_id, rate, nss, sgi, ldpc);
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "he_gi 0x%02x he_ltf 0x%02x he_fixed_rate %d\n", he_gi,
++		   he_ltf, he_fixed_rate);
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "eht_gi 0x%02x eht_ltf 0x%02x eht_fixed_rate %d\n",
++		   eht_gi, eht_ltf, eht_fixed_rate);
++
++	if (!he_support && !eht_support) {
++		vdev_param = WMI_VDEV_PARAM_FIXED_RATE;
++		ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++						    vdev_param, rate);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to set fixed rate param 0x%02x: %d\n",
++				    rate, ret);
++			return ret;
++		}
++	}
++
++	vdev_param = WMI_VDEV_PARAM_NSS;
++
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    vdev_param, nss);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set nss param %d: %d\n",
++			    nss, ret);
++		return ret;
++	}
++
++	ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++					    WMI_VDEV_PARAM_LDPC, ldpc);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set ldpc param %d: %d\n",
++			    ldpc, ret);
++		return ret;
++	}
++
++	if (eht_support) {
++		if (eht_fixed_rate)
++			ret = ath12k_mac_set_fixed_rate_gi_ltf(arvif, eht_gi, eht_ltf,
++							       WMI_VDEV_PARAM_EHT_LTF);
++		else
++			ret = ath12k_mac_set_auto_rate_gi_ltf(arvif, eht_gi, eht_ltf);
++
++		if (ret) {
++			ath12k_warn(ar->ab,
++				    "failed to set EHT LTF/GI params %d/%d: %d\n",
++				    eht_gi, eht_ltf, ret);
++			return ret;
++		}
++		gi_ltf_set = true;
++	}
++
++	if (he_support) {
++		if (he_fixed_rate)
++			ret = ath12k_mac_set_fixed_rate_gi_ltf(arvif, he_gi, he_ltf,
++							       WMI_VDEV_PARAM_HE_LTF);
++		else
++			ret = ath12k_mac_set_auto_rate_gi_ltf(arvif, he_gi, he_ltf);
++		if (ret)
++			return ret;
++		gi_ltf_set = true;
++	}
++
++	if (!gi_ltf_set) {
++		vdev_param = WMI_VDEV_PARAM_SGI;
++		param_value = ath12k_mac_nlgi_to_wmigi(sgi);
++		ret = ath12k_wmi_vdev_set_param_cmd(ar, arvif->vdev_id,
++						    vdev_param, param_value);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to set sgi param %d: %d\n",
++				    sgi, ret);
++			return ret;
++		}
++	}
++
++	return 0;
++}
++
++static bool
++ath12k_mac_vht_mcs_range_present(struct ath12k *ar,
++				 enum nl80211_band band,
++				 const struct cfg80211_bitrate_mask *mask)
++{
++	int i;
++	u16 vht_mcs;
++
++	for (i = 0; i < NL80211_VHT_NSS_MAX; i++) {
++		vht_mcs = mask->control[band].vht_mcs[i];
++
++		switch (vht_mcs) {
++		case 0:
++		case BIT(8) - 1:
++		case BIT(9) - 1:
++		case BIT(10) - 1:
++			break;
++		default:
++			return false;
++		}
++	}
++
++	return true;
++}
++
++static bool
++ath12k_mac_he_mcs_range_present(struct ath12k *ar,
++				enum nl80211_band band,
++				const struct cfg80211_bitrate_mask *mask)
++{
++	int i;
++	u16 he_mcs;
++
++	for (i = 0; i < NL80211_HE_NSS_MAX; i++) {
++		he_mcs = mask->control[band].he_mcs[i];
++
++		switch (he_mcs) {
++		case 0:
++		case BIT(8) - 1:
++		case BIT(10) - 1:
++		case BIT(12) - 1:
++			break;
++		default:
++			return false;
++		}
++	}
++
++	return true;
++}
++
++static bool
++ath12k_mac_eht_mcs_range_present(struct ath12k *ar,
++				 enum nl80211_band band,
++				 const struct cfg80211_bitrate_mask *mask)
++{
++	u16 eht_mcs;
++	int i;
++
++	for (i = 0; i < NL80211_EHT_NSS_MAX; i++) {
++		eht_mcs = mask->control[band].eht_mcs[i];
++
++		switch (eht_mcs) {
++		case 0:
++		case BIT(8) - 1:
++		case BIT(10) - 1:
++		case BIT(12) - 1:
++		case BIT(14) - 1:
++			break;
++		case BIT(15) - 1:
++		case BIT(16) - 1:
++		case BIT(16) - BIT(14) - 1:
++			if (i != 0)
++				return false;
++			break;
++		default:
++			return false;
++		}
++	}
++
++	return true;
++}
++
++static void ath12k_mac_set_bitrate_mask_iter(void *data,
++					     struct ieee80211_sta *sta)
++{
++	struct ath12k_link_vif *arvif = data;
++	struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(sta);
++	struct ath12k_link_sta *arsta;
++	struct ath12k *ar = arvif->ar;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	arsta = wiphy_dereference(ath12k_ar_to_hw(ar)->wiphy,
++				  ahsta->link[arvif->link_id]);
++	if (!arsta || arsta->arvif != arvif)
++		return;
++
++	spin_lock_bh(&ar->data_lock);
++	arsta->changed |= IEEE80211_RC_SUPP_RATES_CHANGED;
++	spin_unlock_bh(&ar->data_lock);
++
++	wiphy_work_queue(ath12k_ar_to_hw(ar)->wiphy, &arsta->update_wk);
++}
++
++static void ath12k_mac_disable_peer_fixed_rate(void *data,
++					       struct ieee80211_sta *sta)
++{
++	struct ath12k_link_vif *arvif = data;
++	struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(sta);
++	struct ath12k_link_sta *arsta;
++	struct ath12k *ar = arvif->ar;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	arsta = wiphy_dereference(ath12k_ar_to_hw(ar)->wiphy,
++				  ahsta->link[arvif->link_id]);
++
++	if (!arsta || arsta->arvif != arvif)
++		return;
++
++	ret = ath12k_wmi_set_peer_param(ar, arsta->addr,
++					arvif->vdev_id,
++					WMI_PEER_PARAM_FIXED_RATE,
++					WMI_FIXED_RATE_NONE);
++	if (ret)
++		ath12k_warn(ar->ab,
++			    "failed to disable peer fixed rate for STA %pM ret %d\n",
++			    arsta->addr, ret);
++}
++
++static bool
++ath12k_mac_validate_fixed_rate_settings(struct ath12k *ar, enum nl80211_band band,
++					const struct cfg80211_bitrate_mask *mask,
++					unsigned int link_id)
++{
++	bool eht_fixed_rate = false, he_fixed_rate = false, vht_fixed_rate = false;
++	const u16 *vht_mcs_mask, *he_mcs_mask, *eht_mcs_mask;
++	struct ieee80211_link_sta *link_sta;
++	struct ath12k_dp_link_peer *peer, *tmp;
++	u8 vht_nss, he_nss, eht_nss;
++	int ret = true;
++	struct ath12k_base *ab = ar->ab;
++	struct ath12k_dp *dp = ath12k_ab_to_dp(ab);
++
++	vht_mcs_mask = mask->control[band].vht_mcs;
++	he_mcs_mask = mask->control[band].he_mcs;
++	eht_mcs_mask = mask->control[band].eht_mcs;
++
++	if (ath12k_mac_bitrate_mask_num_vht_rates(ar, band, mask) == 1)
++		vht_fixed_rate = true;
++
++	if (ath12k_mac_bitrate_mask_num_he_rates(ar, band, mask) == 1)
++		he_fixed_rate = true;
++
++	if (ath12k_mac_bitrate_mask_num_eht_rates(ar, band, mask) == 1)
++		eht_fixed_rate = true;
++
++	if (!vht_fixed_rate && !he_fixed_rate && !eht_fixed_rate)
++		return true;
++
++	vht_nss = ath12k_mac_max_vht_nss(vht_mcs_mask);
++	he_nss =  ath12k_mac_max_he_nss(he_mcs_mask);
++	eht_nss = ath12k_mac_max_eht_nss(eht_mcs_mask);
++
++	rcu_read_lock();
++	spin_lock_bh(&dp->dp_lock);
++	list_for_each_entry_safe(peer, tmp, &dp->peers, list) {
++		if (peer->sta) {
++			link_sta = rcu_dereference(peer->sta->link[link_id]);
++			if (!link_sta) {
++				ret = false;
++				goto exit;
++			}
++
++			if (vht_fixed_rate && (!link_sta->vht_cap.vht_supported ||
++					       link_sta->rx_nss < vht_nss)) {
++				ret = false;
++				goto exit;
++			}
++			if (he_fixed_rate && (!link_sta->he_cap.has_he ||
++					      link_sta->rx_nss < he_nss)) {
++				ret = false;
++				goto exit;
++			}
++			if (eht_fixed_rate && (!link_sta->eht_cap.has_eht ||
++					       link_sta->rx_nss < eht_nss)) {
++				ret = false;
++				goto exit;
++			}
++		}
++	}
++exit:
++	spin_unlock_bh(&dp->dp_lock);
++	rcu_read_unlock();
++	return ret;
++}
++
++int
++ath12k_mac_op_set_bitrate_mask(struct ieee80211_hw *hw,
++			       struct ieee80211_vif *vif,
++			       const struct cfg80211_bitrate_mask *mask)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_link_vif *arvif;
++	struct cfg80211_chan_def def;
++	struct ath12k *ar;
++	enum nl80211_band band;
++	const u8 *ht_mcs_mask;
++	const u16 *vht_mcs_mask;
++	const u16 *he_mcs_mask;
++	const u16 *eht_mcs_mask;
++	u8 he_ltf = 0;
++	u8 he_gi = 0;
++	u8 eht_ltf = 0, eht_gi = 0;
++	u32 rate;
++	u8 nss, mac_nss;
++	u8 sgi;
++	u8 ldpc;
++	int single_nss;
++	int ret;
++	int num_rates;
++	bool he_fixed_rate = false;
++	bool eht_fixed_rate = false;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	arvif = &ahvif->deflink;
++
++	ar = arvif->ar;
++	if (ath12k_mac_vif_link_chan(vif, arvif->link_id, &def)) {
++		ret = -EPERM;
++		goto out;
++	}
++
++	band = def.chan->band;
++	ht_mcs_mask = mask->control[band].ht_mcs;
++	vht_mcs_mask = mask->control[band].vht_mcs;
++	he_mcs_mask = mask->control[band].he_mcs;
++	eht_mcs_mask = mask->control[band].eht_mcs;
++	ldpc = !!(ar->ht_cap_info & WMI_HT_CAP_LDPC);
++
++	sgi = mask->control[band].gi;
++	if (sgi == NL80211_TXRATE_FORCE_SGI) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	he_gi = mask->control[band].he_gi;
++	he_ltf = mask->control[band].he_ltf;
++
++	eht_gi = mask->control[band].eht_gi;
++	eht_ltf = mask->control[band].eht_ltf;
++
++	/* mac80211 doesn't support sending a fixed HT/VHT MCS alone, rather it
++	 * requires passing at least one of used basic rates along with them.
++	 * Fixed rate setting across different preambles(legacy, HT, VHT) is
++	 * not supported by the FW. Hence use of FIXED_RATE vdev param is not
++	 * suitable for setting single HT/VHT rates.
++	 * But, there could be a single basic rate passed from userspace which
++	 * can be done through the FIXED_RATE param.
++	 */
++	if (ath12k_mac_has_single_legacy_rate(ar, band, mask)) {
++		ret = ath12k_mac_get_single_legacy_rate(ar, band, mask, &rate,
++							&nss);
++		if (ret) {
++			ath12k_warn(ar->ab, "failed to get single legacy rate for vdev %i: %d\n",
++				    arvif->vdev_id, ret);
++			goto out;
++		}
++
++		ieee80211_iterate_stations_mtx(hw,
++					       ath12k_mac_disable_peer_fixed_rate,
++					       arvif);
++	} else if (ath12k_mac_bitrate_mask_get_single_nss(ar, vif, band, mask,
++							  &single_nss)) {
++		rate = WMI_FIXED_RATE_NONE;
++		nss = single_nss;
++		arvif->bitrate_mask = *mask;
++
++		ieee80211_iterate_stations_atomic(hw,
++						  ath12k_mac_set_bitrate_mask_iter,
++						  arvif);
++	} else {
++		rate = WMI_FIXED_RATE_NONE;
++
++		if (!ath12k_mac_validate_fixed_rate_settings(ar, band,
++							     mask, arvif->link_id))
++			ath12k_warn(ar->ab,
++				    "failed to update fixed rate settings due to mcs/nss incompatibility\n");
++
++		mac_nss = max(max3(ath12k_mac_max_ht_nss(ht_mcs_mask),
++				   ath12k_mac_max_vht_nss(vht_mcs_mask),
++				   ath12k_mac_max_he_nss(he_mcs_mask)),
++			       ath12k_mac_max_eht_nss(eht_mcs_mask));
++		nss = min_t(u32, ar->num_tx_chains, mac_nss);
++
++		/* If multiple rates across different preambles are given
++		 * we can reconfigure this info with all peers using PEER_ASSOC
++		 * command with the below exception cases.
++		 * - Single VHT Rate : peer_assoc command accommodates only MCS
++		 * range values i.e 0-7, 0-8, 0-9 for VHT. Though mac80211
++		 * mandates passing basic rates along with HT/VHT rates, FW
++		 * doesn't allow switching from VHT to Legacy. Hence instead of
++		 * setting legacy and VHT rates using RATEMASK_CMD vdev cmd,
++		 * we could set this VHT rate as peer fixed rate param, which
++		 * will override FIXED rate and FW rate control algorithm.
++		 * If single VHT rate is passed along with HT rates, we select
++		 * the VHT rate as fixed rate for vht peers.
++		 * - Multiple VHT Rates : When Multiple VHT rates are given,this
++		 * can be set using RATEMASK CMD which uses FW rate-ctl alg.
++		 * TODO: Setting multiple VHT MCS and replacing peer_assoc with
++		 * RATEMASK_CMDID can cover all use cases of setting rates
++		 * across multiple preambles and rates within same type.
++		 * But requires more validation of the command at this point.
++		 */
++
++		num_rates = ath12k_mac_bitrate_mask_num_vht_rates(ar, band,
++								  mask);
++
++		if (!ath12k_mac_vht_mcs_range_present(ar, band, mask) &&
++		    num_rates > 1) {
++			/* TODO: Handle multiple VHT MCS values setting using
++			 * RATEMASK CMD
++			 */
++			ath12k_warn(ar->ab,
++				    "Setting more than one MCS Value in bitrate mask not supported\n");
++			ret = -EINVAL;
++			goto out;
++		}
++
++		num_rates = ath12k_mac_bitrate_mask_num_he_rates(ar, band, mask);
++		if (num_rates == 1)
++			he_fixed_rate = true;
++
++		if (!ath12k_mac_he_mcs_range_present(ar, band, mask) &&
++		    num_rates > 1) {
++			ath12k_warn(ar->ab,
++				    "Setting more than one HE MCS Value in bitrate mask not supported\n");
++			ret = -EINVAL;
++			goto out;
++		}
++
++		num_rates = ath12k_mac_bitrate_mask_num_eht_rates(ar, band,
++								  mask);
++		if (num_rates == 1)
++			eht_fixed_rate = true;
++
++		if (!ath12k_mac_eht_mcs_range_present(ar, band, mask) &&
++		    num_rates > 1) {
++			ath12k_warn(ar->ab,
++				    "Setting more than one EHT MCS Value in bitrate mask not supported\n");
++			ret = -EINVAL;
++			goto out;
++		}
++
++		ieee80211_iterate_stations_mtx(hw,
++					       ath12k_mac_disable_peer_fixed_rate,
++					       arvif);
++
++		arvif->bitrate_mask = *mask;
++		ieee80211_iterate_stations_mtx(hw,
++					       ath12k_mac_set_bitrate_mask_iter,
++					       arvif);
++	}
++
++	ret = ath12k_mac_set_rate_params(arvif, rate, nss, sgi, ldpc, he_gi,
++					 he_ltf, he_fixed_rate, eht_gi, eht_ltf,
++					 eht_fixed_rate);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set rate params on vdev %i: %d\n",
++			    arvif->vdev_id, ret);
++	}
++
++out:
++	return ret;
++}
++EXPORT_SYMBOL(ath12k_mac_op_set_bitrate_mask);
++
++void
++ath12k_mac_op_reconfig_complete(struct ieee80211_hw *hw,
++				enum ieee80211_reconfig_type reconfig_type)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k *ar;
++	struct ath12k_base *ab;
++	struct ath12k_vif *ahvif;
++	struct ath12k_link_vif *arvif;
++	int recovery_count, i;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (reconfig_type != IEEE80211_RECONFIG_TYPE_RESTART)
++		return;
++
++	guard(mutex)(&ah->hw_mutex);
++
++	if (ah->state != ATH12K_HW_STATE_RESTARTED)
++		return;
++
++	ah->state = ATH12K_HW_STATE_ON;
++	ieee80211_wake_queues(hw);
++
++	for_each_ar(ah, ar, i) {
++		ab = ar->ab;
++
++		ath12k_warn(ar->ab, "pdev %d successfully recovered\n",
++			    ar->pdev->pdev_id);
++
++		if (ar->ab->hw_params->current_cc_support &&
++		    ar->alpha2[0] != 0 && ar->alpha2[1] != 0) {
++			struct wmi_set_current_country_arg arg = {};
++
++			memcpy(&arg.alpha2, ar->alpha2, 2);
++			reinit_completion(&ar->regd_update_completed);
++			ath12k_wmi_send_set_current_country_cmd(ar, &arg);
++		}
++
++		if (ab->is_reset) {
++			recovery_count = atomic_inc_return(&ab->recovery_count);
++
++			ath12k_dbg(ab, ATH12K_DBG_BOOT, "recovery count %d\n",
++				   recovery_count);
++
++			/* When there are multiple radios in an SOC,
++			 * the recovery has to be done for each radio
++			 */
++			if (recovery_count == ab->num_radios) {
++				atomic_dec(&ab->reset_count);
++				complete(&ab->reset_complete);
++				ab->is_reset = false;
++				atomic_set(&ab->fail_cont_count, 0);
++				ath12k_dbg(ab, ATH12K_DBG_BOOT, "reset success\n");
++			}
++		}
++
++		list_for_each_entry(arvif, &ar->arvifs, list) {
++			ahvif = arvif->ahvif;
++			ath12k_dbg(ab, ATH12K_DBG_BOOT,
++				   "reconfig cipher %d up %d vdev type %d\n",
++				   ahvif->dp_vif.key_cipher,
++				   arvif->is_up,
++				   ahvif->vdev_type);
++
++			/* After trigger disconnect, then upper layer will
++			 * trigger connect again, then the PN number of
++			 * upper layer will be reset to keep up with AP
++			 * side, hence PN number mismatch will not happen.
++			 */
++			if (arvif->is_up &&
++			    ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
++			    ahvif->vdev_subtype == WMI_VDEV_SUBTYPE_NONE) {
++				ieee80211_hw_restart_disconnect(ahvif->vif);
++
++				ath12k_dbg(ab, ATH12K_DBG_BOOT,
++					   "restart disconnect\n");
++			}
++		}
++	}
++}
++EXPORT_SYMBOL(ath12k_mac_op_reconfig_complete);
++
++static void
++ath12k_mac_update_bss_chan_survey(struct ath12k *ar,
++				  struct ieee80211_channel *channel)
++{
++	int ret;
++	enum wmi_bss_chan_info_req_type type = WMI_BSS_SURVEY_REQ_TYPE_READ;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (!test_bit(WMI_TLV_SERVICE_BSS_CHANNEL_INFO_64, ar->ab->wmi_ab.svc_map) ||
++	    ar->rx_channel != channel)
++		return;
++
++	if (ar->scan.state != ATH12K_SCAN_IDLE) {
++		ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++			   "ignoring bss chan info req while scanning..\n");
++		return;
++	}
++
++	reinit_completion(&ar->bss_survey_done);
++
++	ret = ath12k_wmi_pdev_bss_chan_info_request(ar, type);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to send pdev bss chan info request\n");
++		return;
++	}
++
++	ret = wait_for_completion_timeout(&ar->bss_survey_done, 3 * HZ);
++	if (ret == 0)
++		ath12k_warn(ar->ab, "bss channel survey timed out\n");
++}
++
++int ath12k_mac_op_get_survey(struct ieee80211_hw *hw, int idx,
++			     struct survey_info *survey)
++{
++	struct ath12k *ar;
++	struct ieee80211_supported_band *sband;
++	struct survey_info *ar_survey;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	if (idx >= ATH12K_NUM_CHANS)
++		return -ENOENT;
++
++	sband = hw->wiphy->bands[NL80211_BAND_2GHZ];
++	if (sband && idx >= sband->n_channels) {
++		idx -= sband->n_channels;
++		sband = NULL;
++	}
++
++	if (!sband)
++		sband = hw->wiphy->bands[NL80211_BAND_5GHZ];
++	if (sband && idx >= sband->n_channels) {
++		idx -= sband->n_channels;
++		sband = NULL;
++	}
++
++	if (!sband)
++		sband = hw->wiphy->bands[NL80211_BAND_6GHZ];
++
++	if (!sband || idx >= sband->n_channels)
++		return -ENOENT;
++
++	ar = ath12k_mac_get_ar_by_chan(hw, &sband->channels[idx]);
++	if (!ar) {
++		if (sband->channels[idx].flags & IEEE80211_CHAN_DISABLED) {
++			memset(survey, 0, sizeof(*survey));
++			return 0;
++		}
++		return -ENOENT;
++	}
++
++	ar_survey = &ar->survey[idx];
++
++	ath12k_mac_update_bss_chan_survey(ar, &sband->channels[idx]);
++
++	spin_lock_bh(&ar->data_lock);
++	memcpy(survey, ar_survey, sizeof(*survey));
++	spin_unlock_bh(&ar->data_lock);
++
++	survey->channel = &sband->channels[idx];
++
++	if (ar->rx_channel == survey->channel)
++		survey->filled |= SURVEY_INFO_IN_USE;
++
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_get_survey);
++
++static void ath12k_mac_put_chain_rssi(struct station_info *sinfo,
++				      struct ath12k_link_sta *arsta)
++{
++	s8 rssi;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(sinfo->chain_signal); i++) {
++		sinfo->chains &= ~BIT(i);
++		rssi = arsta->chain_signal[i];
++
++		if (rssi != ATH12K_DEFAULT_NOISE_FLOOR &&
++		    rssi != ATH12K_INVALID_RSSI_FULL &&
++		    rssi != ATH12K_INVALID_RSSI_EMPTY &&
++		    rssi != 0) {
++			sinfo->chain_signal[i] = rssi;
++			sinfo->chains |= BIT(i);
++			sinfo->filled |= BIT_ULL(NL80211_STA_INFO_CHAIN_SIGNAL);
++		}
++	}
++}
++
++void ath12k_mac_op_sta_statistics(struct ieee80211_hw *hw,
++				  struct ieee80211_vif *vif,
++				  struct ieee80211_sta *sta,
++				  struct station_info *sinfo)
++{
++	struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(sta);
++	struct ath12k_dp_link_peer_rate_info rate_info = {};
++	struct ath12k_fw_stats_req_params params = {};
++	struct ath12k_dp_link_peer *peer;
++	struct ath12k_link_sta *arsta;
++	s8 signal, noise_floor;
++	struct ath12k_dp *dp;
++	struct ath12k *ar;
++	bool db2dbm;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	arsta = &ahsta->deflink;
++	ar = ath12k_get_ar_by_vif(hw, vif, arsta->link_id);
++	if (!ar)
++		return;
++
++	dp = ath12k_ab_to_dp(ar->ab);
++	ath12k_dp_link_peer_get_sta_rate_info_stats(dp, arsta->addr, &rate_info);
++
++	db2dbm = test_bit(WMI_TLV_SERVICE_HW_DB2DBM_CONVERSION_SUPPORT,
++			  ar->ab->wmi_ab.svc_map);
++
++	sinfo->rx_duration = rate_info.rx_duration;
++	sinfo->filled |= BIT_ULL(NL80211_STA_INFO_RX_DURATION);
++
++	sinfo->tx_duration = rate_info.tx_duration;
++	sinfo->filled |= BIT_ULL(NL80211_STA_INFO_TX_DURATION);
++
++	if (rate_info.txrate.legacy || rate_info.txrate.nss) {
++		if (rate_info.txrate.legacy) {
++			sinfo->txrate.legacy = rate_info.txrate.legacy;
++		} else {
++			sinfo->txrate.mcs = rate_info.txrate.mcs;
++			sinfo->txrate.nss = rate_info.txrate.nss;
++			sinfo->txrate.bw = rate_info.txrate.bw;
++			sinfo->txrate.he_gi = rate_info.txrate.he_gi;
++			sinfo->txrate.he_dcm = rate_info.txrate.he_dcm;
++			sinfo->txrate.he_ru_alloc = rate_info.txrate.he_ru_alloc;
++			sinfo->txrate.eht_gi = rate_info.txrate.eht_gi;
++			sinfo->txrate.eht_ru_alloc = rate_info.txrate.eht_ru_alloc;
++		}
++		sinfo->txrate.flags = rate_info.txrate.flags;
++		sinfo->filled |= BIT_ULL(NL80211_STA_INFO_TX_BITRATE);
++	}
++
++	/* TODO: Use real NF instead of default one. */
++	signal = rate_info.rssi_comb;
++
++	params.pdev_id = ath12k_mac_get_target_pdev_id(ar);
++	params.vdev_id = 0;
++	params.stats_id = WMI_REQUEST_VDEV_STAT;
++
++	if (!signal &&
++	    ahsta->ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
++	    !(ath12k_mac_get_fw_stats(ar, &params))) {
++		signal = arsta->rssi_beacon;
++		ath12k_fw_stats_reset(ar);
++	}
++
++	params.stats_id = WMI_REQUEST_RSSI_PER_CHAIN_STAT;
++	if (!(sinfo->filled & BIT_ULL(NL80211_STA_INFO_CHAIN_SIGNAL)) &&
++	    ahsta->ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
++	    !(ath12k_mac_get_fw_stats(ar, &params))) {
++		ath12k_mac_put_chain_rssi(sinfo, arsta);
++		ath12k_fw_stats_reset(ar);
++	}
++
++	spin_lock_bh(&ar->data_lock);
++	noise_floor = ath12k_pdev_get_noise_floor(ar);
++	spin_unlock_bh(&ar->data_lock);
++
++	if (signal) {
++		sinfo->signal = db2dbm ? signal : signal + noise_floor;
++		sinfo->filled |= BIT_ULL(NL80211_STA_INFO_SIGNAL);
++	}
++
++	sinfo->signal_avg = rate_info.signal_avg;
++
++	if (!db2dbm)
++		sinfo->signal_avg += noise_floor;
++
++	sinfo->filled |= BIT_ULL(NL80211_STA_INFO_SIGNAL_AVG);
++
++	spin_lock_bh(&dp->dp_lock);
++	peer = ath12k_dp_link_peer_find_by_addr(dp, arsta->addr);
++	if (!peer) {
++		spin_unlock_bh(&dp->dp_lock);
++		return;
++	}
++
++	sinfo->tx_retries = peer->tx_retry_count;
++	sinfo->tx_failed = peer->tx_retry_failed;
++	sinfo->filled |= BIT_ULL(NL80211_STA_INFO_TX_RETRIES);
++	sinfo->filled |= BIT_ULL(NL80211_STA_INFO_TX_FAILED);
++
++	spin_unlock_bh(&dp->dp_lock);
++}
++EXPORT_SYMBOL(ath12k_mac_op_sta_statistics);
++
++void ath12k_mac_op_link_sta_statistics(struct ieee80211_hw *hw,
++				       struct ieee80211_vif *vif,
++				       struct ieee80211_link_sta *link_sta,
++				       struct link_station_info *link_sinfo)
++{
++	struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(link_sta->sta);
++	struct ath12k_fw_stats_req_params params = {};
++	struct ath12k_dp_link_peer *peer;
++	struct ath12k_link_sta *arsta;
++	struct ath12k *ar;
++	s8 signal;
++	bool db2dbm;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	arsta = wiphy_dereference(hw->wiphy, ahsta->link[link_sta->link_id]);
++
++	if (!arsta)
++		return;
++
++	ar = ath12k_get_ar_by_vif(hw, vif, arsta->link_id);
++	if (!ar)
++		return;
++
++	db2dbm = test_bit(WMI_TLV_SERVICE_HW_DB2DBM_CONVERSION_SUPPORT,
++			  ar->ab->wmi_ab.svc_map);
++
++	spin_lock_bh(&ar->ab->dp->dp_lock);
++	peer = ath12k_dp_link_peer_find_by_addr(ar->ab->dp, arsta->addr);
++	if (!peer) {
++		spin_unlock_bh(&ar->ab->dp->dp_lock);
++		return;
++	}
++
++	link_sinfo->rx_duration = peer->rx_duration;
++	link_sinfo->filled |= BIT_ULL(NL80211_STA_INFO_RX_DURATION);
++
++	link_sinfo->tx_duration = peer->tx_duration;
++	link_sinfo->filled |= BIT_ULL(NL80211_STA_INFO_TX_DURATION);
++
++	if (peer->txrate.legacy || peer->txrate.nss) {
++		if (peer->txrate.legacy) {
++			link_sinfo->txrate.legacy = peer->txrate.legacy;
++		} else {
++			link_sinfo->txrate.mcs = peer->txrate.mcs;
++			link_sinfo->txrate.nss = peer->txrate.nss;
++			link_sinfo->txrate.bw = peer->txrate.bw;
++			link_sinfo->txrate.he_gi = peer->txrate.he_gi;
++			link_sinfo->txrate.he_dcm = peer->txrate.he_dcm;
++			link_sinfo->txrate.he_ru_alloc =
++				peer->txrate.he_ru_alloc;
++			link_sinfo->txrate.eht_gi = peer->txrate.eht_gi;
++			link_sinfo->txrate.eht_ru_alloc =
++				peer->txrate.eht_ru_alloc;
++		}
++		link_sinfo->txrate.flags = peer->txrate.flags;
++		link_sinfo->filled |= BIT_ULL(NL80211_STA_INFO_TX_BITRATE);
++	}
++
++	link_sinfo->signal_avg = ewma_avg_rssi_read(&peer->avg_rssi);
++
++	if (!db2dbm)
++		link_sinfo->signal_avg += ATH12K_DEFAULT_NOISE_FLOOR;
++
++	link_sinfo->filled |= BIT_ULL(NL80211_STA_INFO_SIGNAL_AVG);
++
++	link_sinfo->tx_retries = peer->tx_retry_count;
++	link_sinfo->tx_failed = peer->tx_retry_failed;
++	link_sinfo->filled |= BIT_ULL(NL80211_STA_INFO_TX_RETRIES);
++	link_sinfo->filled |= BIT_ULL(NL80211_STA_INFO_TX_FAILED);
++
++	/* TODO: Use real NF instead of default one. */
++	signal = peer->rssi_comb;
++
++	spin_unlock_bh(&ar->ab->dp->dp_lock);
++
++	if (!signal && ahsta->ahvif->vdev_type == WMI_VDEV_TYPE_STA) {
++		params.pdev_id = ath12k_mac_get_target_pdev_id(ar);
++		params.vdev_id = 0;
++		params.stats_id = WMI_REQUEST_VDEV_STAT;
++
++		if (!ath12k_mac_get_fw_stats(ar, &params)) {
++			signal = arsta->rssi_beacon;
++			ath12k_fw_stats_reset(ar);
++		}
++	}
++
++	if (signal) {
++		link_sinfo->signal =
++			db2dbm ? signal : signal + ATH12K_DEFAULT_NOISE_FLOOR;
++		link_sinfo->filled |= BIT_ULL(NL80211_STA_INFO_SIGNAL);
++	}
++}
++EXPORT_SYMBOL(ath12k_mac_op_link_sta_statistics);
++
++int ath12k_mac_op_cancel_remain_on_channel(struct ieee80211_hw *hw,
++					   struct ieee80211_vif *vif)
++{
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k *ar;
++
++	ar = ath12k_ah_to_ar(ah, 0);
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	spin_lock_bh(&ar->data_lock);
++	ar->scan.roc_notify = false;
++	spin_unlock_bh(&ar->data_lock);
++
++	ath12k_scan_abort(ar);
++
++	cancel_delayed_work_sync(&ar->scan.timeout);
++	wiphy_work_flush(hw->wiphy, &ar->scan.vdev_clean_wk);
++
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_cancel_remain_on_channel);
++
++int ath12k_mac_op_remain_on_channel(struct ieee80211_hw *hw,
++				    struct ieee80211_vif *vif,
++				    struct ieee80211_channel *chan,
++				    int duration,
++				    enum ieee80211_roc_type type)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k_link_vif *arvif;
++	struct ath12k *ar;
++	u32 scan_time_msec;
++	bool create = true;
++	u8 link_id;
++	int ret;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	ar = ath12k_mac_select_scan_device(hw, vif, chan->center_freq);
++	if (!ar)
++		return -EINVAL;
++
++	/* check if any of the links of ML VIF is already started on
++	 * radio(ar) corresponding to given scan frequency and use it,
++	 * if not use deflink(link 0) for scan purpose.
++	 */
++
++	link_id = ath12k_mac_find_link_id_by_ar(ahvif, ar);
++	arvif = ath12k_mac_assign_link_vif(ah, vif, link_id);
++	/* If the vif is already assigned to a specific vdev of an ar,
++	 * check whether its already started, vdev which is started
++	 * are not allowed to switch to a new radio.
++	 * If the vdev is not started, but was earlier created on a
++	 * different ar, delete that vdev and create a new one. We don't
++	 * delete at the scan stop as an optimization to avoid redundant
++	 * delete-create vdev's for the same ar, in case the request is
++	 * always on the same band for the vif
++	 */
++	if (arvif->is_created) {
++		if (WARN_ON(!arvif->ar))
++			return -EINVAL;
++
++		if (ar != arvif->ar && arvif->is_started)
++			return -EBUSY;
++
++		if (ar != arvif->ar) {
++			ath12k_mac_remove_link_interface(hw, arvif);
++			ath12k_mac_unassign_link_vif(arvif);
++		} else {
++			create = false;
++		}
++	}
++
++	if (create) {
++		arvif = ath12k_mac_assign_link_vif(ah, vif, link_id);
++
++		ret = ath12k_mac_vdev_create(ar, arvif);
++		if (ret) {
++			ath12k_warn(ar->ab, "unable to create scan vdev for roc: %d\n",
++				    ret);
++			ath12k_mac_unassign_link_vif(arvif);
++			return ret;
++		}
++	}
++
++	spin_lock_bh(&ar->data_lock);
++
++	switch (ar->scan.state) {
++	case ATH12K_SCAN_IDLE:
++		reinit_completion(&ar->scan.started);
++		reinit_completion(&ar->scan.completed);
++		reinit_completion(&ar->scan.on_channel);
++		ar->scan.state = ATH12K_SCAN_STARTING;
++		ar->scan.is_roc = true;
++		ar->scan.arvif = arvif;
++		ar->scan.roc_freq = chan->center_freq;
++		ar->scan.roc_notify = true;
++		ret = 0;
++		break;
++	case ATH12K_SCAN_STARTING:
++	case ATH12K_SCAN_RUNNING:
++	case ATH12K_SCAN_ABORTING:
++		ret = -EBUSY;
++		break;
++	}
++
++	spin_unlock_bh(&ar->data_lock);
++
++	if (ret)
++		return ret;
++
++	scan_time_msec = hw->wiphy->max_remain_on_channel_duration * 2;
++
++	struct ath12k_wmi_scan_req_arg *arg __free(kfree) =
++					kzalloc_obj(*arg);
++	if (!arg)
++		return -ENOMEM;
++
++	ath12k_wmi_start_scan_init(ar, arg);
++	arg->num_chan = 1;
++
++	u32 *chan_list __free(kfree) = kcalloc(arg->num_chan, sizeof(*chan_list),
++					       GFP_KERNEL);
++	if (!chan_list)
++		return -ENOMEM;
++
++	arg->chan_list = chan_list;
++	arg->vdev_id = arvif->vdev_id;
++	arg->scan_id = ATH12K_SCAN_ID;
++	arg->chan_list[0] = chan->center_freq;
++	arg->dwell_time_active = scan_time_msec;
++	arg->dwell_time_passive = scan_time_msec;
++	arg->max_scan_time = scan_time_msec;
++	arg->scan_f_passive = 1;
++	arg->burst_duration = duration;
++
++	ret = ath12k_start_scan(ar, arg);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to start roc scan: %d\n", ret);
++
++		spin_lock_bh(&ar->data_lock);
++		ar->scan.state = ATH12K_SCAN_IDLE;
++		spin_unlock_bh(&ar->data_lock);
++		return ret;
++	}
++
++	ret = wait_for_completion_timeout(&ar->scan.on_channel, 3 * HZ);
++	if (ret == 0) {
++		ath12k_warn(ar->ab, "failed to switch to channel for roc scan\n");
++		ret = ath12k_scan_stop(ar);
++		if (ret)
++			ath12k_warn(ar->ab, "failed to stop scan: %d\n", ret);
++		return -ETIMEDOUT;
++	}
++
++	ieee80211_queue_delayed_work(hw, &ar->scan.timeout,
++				     msecs_to_jiffies(duration));
++
++	return 0;
++}
++EXPORT_SYMBOL(ath12k_mac_op_remain_on_channel);
++
++void ath12k_mac_op_set_rekey_data(struct ieee80211_hw *hw,
++				  struct ieee80211_vif *vif,
++				  struct cfg80211_gtk_rekey_data *data)
++{
++	struct ath12k_vif *ahvif = ath12k_vif_to_ahvif(vif);
++	struct ath12k_rekey_data *rekey_data;
++	struct ath12k_hw *ah = ath12k_hw_to_ah(hw);
++	struct ath12k *ar = ath12k_ah_to_ar(ah, 0);
++	struct ath12k_link_vif *arvif;
++
++	lockdep_assert_wiphy(hw->wiphy);
++
++	arvif = &ahvif->deflink;
++	rekey_data = &arvif->rekey_data;
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac set rekey data vdev %d\n",
++		   arvif->vdev_id);
++
++	memcpy(rekey_data->kck, data->kck, NL80211_KCK_LEN);
++	memcpy(rekey_data->kek, data->kek, NL80211_KEK_LEN);
++
++	/* The supplicant works on big-endian, the firmware expects it on
++	 * little endian.
++	 */
++	rekey_data->replay_ctr = get_unaligned_be64(data->replay_ctr);
++
++	arvif->rekey_data.enable_offload = true;
++
++	ath12k_dbg_dump(ar->ab, ATH12K_DBG_MAC, "kck", NULL,
++			rekey_data->kck, NL80211_KCK_LEN);
++	ath12k_dbg_dump(ar->ab, ATH12K_DBG_MAC, "kek", NULL,
++			rekey_data->kck, NL80211_KEK_LEN);
++	ath12k_dbg_dump(ar->ab, ATH12K_DBG_MAC, "replay ctr", NULL,
++			&rekey_data->replay_ctr, sizeof(rekey_data->replay_ctr));
++}
++EXPORT_SYMBOL(ath12k_mac_op_set_rekey_data);
++
++void ath12k_mac_update_freq_range(struct ath12k *ar,
++				  u32 freq_low, u32 freq_high)
++{
++	if (!(freq_low && freq_high))
++		return;
++
++	if (ar->freq_range.start_freq || ar->freq_range.end_freq) {
++		ar->freq_range.start_freq = min(ar->freq_range.start_freq,
++						MHZ_TO_KHZ(freq_low));
++		ar->freq_range.end_freq = max(ar->freq_range.end_freq,
++					      MHZ_TO_KHZ(freq_high));
++	} else {
++		ar->freq_range.start_freq = MHZ_TO_KHZ(freq_low);
++		ar->freq_range.end_freq = MHZ_TO_KHZ(freq_high);
++	}
++
++	ath12k_dbg(ar->ab, ATH12K_DBG_MAC,
++		   "mac pdev %u freq limit updated. New range %u->%u MHz\n",
++		   ar->pdev->pdev_id, KHZ_TO_MHZ(ar->freq_range.start_freq),
++		   KHZ_TO_MHZ(ar->freq_range.end_freq));
++}
++
++static void ath12k_mac_update_ch_list(struct ath12k *ar,
++				      struct ieee80211_supported_band *band,
++				      u32 freq_low, u32 freq_high)
++{
++	int i;
++
++	if (!(freq_low && freq_high))
++		return;
++
++	for (i = 0; i < band->n_channels; i++) {
++		if (band->channels[i].center_freq < freq_low ||
++		    band->channels[i].center_freq > freq_high)
++			band->channels[i].flags |= IEEE80211_CHAN_DISABLED;
++	}
++}
++
++static u32 ath12k_get_phy_id(struct ath12k *ar, u32 band)
++{
++	struct ath12k_pdev *pdev = ar->pdev;
++	struct ath12k_pdev_cap *pdev_cap = &pdev->cap;
++
++	if (band == WMI_HOST_WLAN_2GHZ_CAP)
++		return pdev_cap->band[NL80211_BAND_2GHZ].phy_id;
++
++	if (band == WMI_HOST_WLAN_5GHZ_CAP)
++		return pdev_cap->band[NL80211_BAND_5GHZ].phy_id;
++
++	ath12k_warn(ar->ab, "unsupported phy cap:%d\n", band);
++
++	return 0;
++}
++
++static int ath12k_mac_update_band(struct ath12k *ar,
++				  struct ieee80211_supported_band *orig_band,
++				  struct ieee80211_supported_band *new_band)
++{
++	int i;
++
++	if (!orig_band || !new_band)
++		return -EINVAL;
++
++	if (orig_band->band != new_band->band)
++		return -EINVAL;
++
++	for (i = 0; i < new_band->n_channels; i++) {
++		if (new_band->channels[i].flags & IEEE80211_CHAN_DISABLED)
++			continue;
++		/* An enabled channel in new_band should not be already enabled
++		 * in the orig_band
++		 */
++		if (WARN_ON(!(orig_band->channels[i].flags &
++			      IEEE80211_CHAN_DISABLED)))
++			return -EINVAL;
++		orig_band->channels[i].flags &= ~IEEE80211_CHAN_DISABLED;
++	}
++	return 0;
++}
++
++static int ath12k_mac_setup_channels_rates(struct ath12k *ar,
++					   u32 supported_bands,
++					   struct ieee80211_supported_band *bands[])
++{
++	struct ieee80211_supported_band *band;
++	struct ath12k_wmi_hal_reg_capabilities_ext_arg *reg_cap;
++	struct ath12k_base *ab = ar->ab;
++	u32 phy_id, freq_low, freq_high;
++	struct ath12k_hw *ah = ar->ah;
++	void *channels;
++	int ret;
++
++	BUILD_BUG_ON((ARRAY_SIZE(ath12k_2ghz_channels) +
++		      ARRAY_SIZE(ath12k_5ghz_channels) +
++		      ARRAY_SIZE(ath12k_6ghz_channels)) !=
++		     ATH12K_NUM_CHANS);
++
++	reg_cap = &ab->hal_reg_cap[ar->pdev_idx];
++
++	if (supported_bands & WMI_HOST_WLAN_2GHZ_CAP) {
++		channels = kmemdup(ath12k_2ghz_channels,
++				   sizeof(ath12k_2ghz_channels),
++				   GFP_KERNEL);
++		if (!channels)
++			return -ENOMEM;
++
++		band = &ar->mac.sbands[NL80211_BAND_2GHZ];
++		band->band = NL80211_BAND_2GHZ;
++		band->n_channels = ARRAY_SIZE(ath12k_2ghz_channels);
++		band->channels = channels;
++		band->n_bitrates = ath12k_g_rates_size;
++		band->bitrates = ath12k_g_rates;
++
++		if (ab->hw_params->single_pdev_only) {
++			phy_id = ath12k_get_phy_id(ar, WMI_HOST_WLAN_2GHZ_CAP);
++			reg_cap = &ab->hal_reg_cap[phy_id];
++		}
++
++		freq_low = max(reg_cap->low_2ghz_chan,
++			       ab->reg_freq_2ghz.start_freq);
++		freq_high = min(reg_cap->high_2ghz_chan,
++				ab->reg_freq_2ghz.end_freq);
++
++		ath12k_mac_update_ch_list(ar, band,
++					  reg_cap->low_2ghz_chan,
++					  reg_cap->high_2ghz_chan);
++
++		ath12k_mac_update_freq_range(ar, freq_low, freq_high);
++
++		if (!bands[NL80211_BAND_2GHZ]) {
++			bands[NL80211_BAND_2GHZ] = band;
++		} else {
++			/* Split mac in same band under same wiphy */
++			ret = ath12k_mac_update_band(ar, bands[NL80211_BAND_2GHZ], band);
++			if (ret) {
++				kfree(channels);
++				band->channels = NULL;
++				return ret;
++			}
++			ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac pdev %u identified as 2 GHz split mac with start freq %d end freq %d",
++				   ar->pdev->pdev_id,
++				   KHZ_TO_MHZ(ar->freq_range.start_freq),
++				   KHZ_TO_MHZ(ar->freq_range.end_freq));
++		}
++	}
++
++	if (supported_bands & WMI_HOST_WLAN_5GHZ_CAP) {
++		if (reg_cap->high_5ghz_chan >= ATH12K_MIN_6GHZ_FREQ) {
++			channels = kmemdup(ath12k_6ghz_channels,
++					   sizeof(ath12k_6ghz_channels), GFP_KERNEL);
++			if (!channels) {
++				kfree(ar->mac.sbands[NL80211_BAND_2GHZ].channels);
++				return -ENOMEM;
++			}
++
++			ar->supports_6ghz = true;
++			band = &ar->mac.sbands[NL80211_BAND_6GHZ];
++			band->band = NL80211_BAND_6GHZ;
++			band->n_channels = ARRAY_SIZE(ath12k_6ghz_channels);
++			band->channels = channels;
++			band->n_bitrates = ath12k_a_rates_size;
++			band->bitrates = ath12k_a_rates;
++
++			freq_low = max(reg_cap->low_5ghz_chan,
++				       ab->reg_freq_6ghz.start_freq);
++			freq_high = min(reg_cap->high_5ghz_chan,
++					ab->reg_freq_6ghz.end_freq);
++
++			ath12k_mac_update_ch_list(ar, band,
++						  reg_cap->low_5ghz_chan,
++						  reg_cap->high_5ghz_chan);
++
++			ath12k_mac_update_freq_range(ar, freq_low, freq_high);
++			ah->use_6ghz_regd = true;
++
++			if (!bands[NL80211_BAND_6GHZ]) {
++				bands[NL80211_BAND_6GHZ] = band;
++			} else {
++				/* Split mac in same band under same wiphy */
++				ret = ath12k_mac_update_band(ar,
++							     bands[NL80211_BAND_6GHZ],
++							     band);
++				if (ret) {
++					kfree(ar->mac.sbands[NL80211_BAND_2GHZ].channels);
++					ar->mac.sbands[NL80211_BAND_2GHZ].channels = NULL;
++					kfree(channels);
++					band->channels = NULL;
++					return ret;
++				}
++				ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac pdev %u identified as 6 GHz split mac with start freq %d end freq %d",
++					   ar->pdev->pdev_id,
++					   KHZ_TO_MHZ(ar->freq_range.start_freq),
++					   KHZ_TO_MHZ(ar->freq_range.end_freq));
++			}
++		}
++
++		if (reg_cap->low_5ghz_chan < ATH12K_MIN_6GHZ_FREQ) {
++			channels = kmemdup(ath12k_5ghz_channels,
++					   sizeof(ath12k_5ghz_channels),
++					   GFP_KERNEL);
++			if (!channels) {
++				kfree(ar->mac.sbands[NL80211_BAND_2GHZ].channels);
++				kfree(ar->mac.sbands[NL80211_BAND_6GHZ].channels);
++				return -ENOMEM;
++			}
++
++			band = &ar->mac.sbands[NL80211_BAND_5GHZ];
++			band->band = NL80211_BAND_5GHZ;
++			band->n_channels = ARRAY_SIZE(ath12k_5ghz_channels);
++			band->channels = channels;
++			band->n_bitrates = ath12k_a_rates_size;
++			band->bitrates = ath12k_a_rates;
++
++			if (ab->hw_params->single_pdev_only) {
++				phy_id = ath12k_get_phy_id(ar, WMI_HOST_WLAN_5GHZ_CAP);
++				reg_cap = &ab->hal_reg_cap[phy_id];
++			}
++
++			freq_low = max(reg_cap->low_5ghz_chan,
++				       ab->reg_freq_5ghz.start_freq);
++			freq_high = min(reg_cap->high_5ghz_chan,
++					ab->reg_freq_5ghz.end_freq);
++
++			ath12k_mac_update_ch_list(ar, band,
++						  reg_cap->low_5ghz_chan,
++						  reg_cap->high_5ghz_chan);
++
++			ath12k_mac_update_freq_range(ar, freq_low, freq_high);
++
++			if (!bands[NL80211_BAND_5GHZ]) {
++				bands[NL80211_BAND_5GHZ] = band;
++			} else {
++				/* Split mac in same band under same wiphy */
++				ret = ath12k_mac_update_band(ar,
++							     bands[NL80211_BAND_5GHZ],
++							     band);
++				if (ret) {
++					kfree(ar->mac.sbands[NL80211_BAND_2GHZ].channels);
++					ar->mac.sbands[NL80211_BAND_2GHZ].channels = NULL;
++					kfree(ar->mac.sbands[NL80211_BAND_6GHZ].channels);
++					ar->mac.sbands[NL80211_BAND_2GHZ].channels = NULL;
++					kfree(channels);
++					band->channels = NULL;
++					return ret;
++				}
++				ath12k_dbg(ar->ab, ATH12K_DBG_MAC, "mac pdev %u identified as 5 GHz split mac with start freq %d end freq %d",
++					   ar->pdev->pdev_id,
++					   KHZ_TO_MHZ(ar->freq_range.start_freq),
++					   KHZ_TO_MHZ(ar->freq_range.end_freq));
++			}
++		}
++	}
++
++	return 0;
++}
++
++static u16 ath12k_mac_get_ifmodes(struct ath12k_hw *ah)
++{
++	struct ath12k *ar;
++	int i;
++	u16 interface_modes = U16_MAX;
++
++	for_each_ar(ah, ar, i)
++		interface_modes &= ar->ab->hw_params->interface_modes;
++
++	return interface_modes == U16_MAX ? 0 : interface_modes;
++}
++
++static bool ath12k_mac_is_iface_mode_enable(struct ath12k_hw *ah,
++					    enum nl80211_iftype type)
++{
++	struct ath12k *ar;
++	int i;
++	u16 interface_modes, mode = 0;
++	bool is_enable = false;
++
++	if (type == NL80211_IFTYPE_MESH_POINT) {
++		if (IS_ENABLED(CONFIG_MAC80211_MESH))
++			mode = BIT(type);
++	} else {
++		mode = BIT(type);
++	}
++
++	for_each_ar(ah, ar, i) {
++		interface_modes = ar->ab->hw_params->interface_modes;
++		if (interface_modes & mode) {
++			is_enable = true;
++			break;
++		}
++	}
++
++	return is_enable;
++}
++
++static int
++ath12k_mac_setup_radio_iface_comb(struct ath12k *ar,
++				  struct ieee80211_iface_combination *comb)
++{
++	u16 interface_modes = ar->ab->hw_params->interface_modes;
++	struct ieee80211_iface_limit *limits;
++	int n_limits, max_interfaces;
++	bool ap, mesh, p2p;
++
++	ap = interface_modes & BIT(NL80211_IFTYPE_AP);
++	p2p = interface_modes & BIT(NL80211_IFTYPE_P2P_DEVICE);
++
++	mesh = IS_ENABLED(CONFIG_MAC80211_MESH) &&
++	       (interface_modes & BIT(NL80211_IFTYPE_MESH_POINT));
++
++	if ((ap || mesh) && !p2p) {
++		n_limits = 2;
++		max_interfaces = 16;
++	} else if (p2p) {
++		n_limits = 3;
++		if (ap || mesh)
++			max_interfaces = 16;
++		else
++			max_interfaces = 3;
++	} else {
++		n_limits = 1;
++		max_interfaces = 1;
++	}
++
++	limits = kzalloc_objs(*limits, n_limits);
++	if (!limits)
++		return -ENOMEM;
++
++	limits[0].max = 1;
++	limits[0].types |= BIT(NL80211_IFTYPE_STATION);
++
++	if (ap || mesh || p2p)
++		limits[1].max = max_interfaces;
++
++	if (ap)
++		limits[1].types |= BIT(NL80211_IFTYPE_AP);
++
++	if (mesh)
++		limits[1].types |= BIT(NL80211_IFTYPE_MESH_POINT);
++
++	if (p2p) {
++		limits[1].types |= BIT(NL80211_IFTYPE_P2P_CLIENT) |
++					BIT(NL80211_IFTYPE_P2P_GO);
++		limits[2].max = 1;
++		limits[2].types |= BIT(NL80211_IFTYPE_P2P_DEVICE);
++	}
++
++	comb[0].limits = limits;
++	comb[0].n_limits = n_limits;
++	comb[0].max_interfaces = max_interfaces;
++	comb[0].beacon_int_infra_match = true;
++	comb[0].beacon_int_min_gcd = 100;
++
++	comb[0].num_different_channels = 1;
++	comb[0].radar_detect_widths = BIT(NL80211_CHAN_WIDTH_20_NOHT) |
++				      BIT(NL80211_CHAN_WIDTH_20) |
++				      BIT(NL80211_CHAN_WIDTH_40) |
++				      BIT(NL80211_CHAN_WIDTH_80) |
++				      BIT(NL80211_CHAN_WIDTH_160);
++
++	return 0;
++}
++
++static int
++ath12k_mac_setup_global_iface_comb(struct ath12k_hw *ah,
++				   struct wiphy_radio *radio,
++				   u8 n_radio,
++				   struct ieee80211_iface_combination *comb)
++{
++	const struct ieee80211_iface_combination *iter_comb;
++	struct ieee80211_iface_limit *limits;
++	int i, j, n_limits;
++	bool ap, mesh, p2p;
++
++	if (!n_radio)
++		return 0;
++
++	ap = ath12k_mac_is_iface_mode_enable(ah, NL80211_IFTYPE_AP);
++	p2p = ath12k_mac_is_iface_mode_enable(ah, NL80211_IFTYPE_P2P_DEVICE);
++	mesh = ath12k_mac_is_iface_mode_enable(ah, NL80211_IFTYPE_MESH_POINT);
++
++	if ((ap || mesh) && !p2p)
++		n_limits = 2;
++	else if (p2p)
++		n_limits = 3;
++	else
++		n_limits = 1;
++
++	limits = kzalloc_objs(*limits, n_limits);
++	if (!limits)
++		return -ENOMEM;
++
++	for (i = 0; i < n_radio; i++) {
++		iter_comb = radio[i].iface_combinations;
++		for (j = 0; j < iter_comb->n_limits && j < n_limits; j++) {
++			limits[j].types |= iter_comb->limits[j].types;
++			limits[j].max += iter_comb->limits[j].max;
++		}
++
++		comb->max_interfaces += iter_comb->max_interfaces;
++		comb->num_different_channels += iter_comb->num_different_channels;
++		comb->radar_detect_widths |= iter_comb->radar_detect_widths;
++	}
++
++	comb->limits = limits;
++	comb->n_limits = n_limits;
++	comb->beacon_int_infra_match = true;
++	comb->beacon_int_min_gcd = 100;
++
++	return 0;
++}
++
++static
++void ath12k_mac_cleanup_iface_comb(const struct ieee80211_iface_combination *iface_comb)
++{
++	kfree(iface_comb[0].limits);
++	kfree(iface_comb);
++}
++
++static void ath12k_mac_cleanup_iface_combinations(struct ath12k_hw *ah)
++{
++	struct wiphy *wiphy = ah->hw->wiphy;
++	const struct wiphy_radio *radio;
++	int i;
++
++	if (wiphy->n_radio > 0) {
++		radio = wiphy->radio;
++		for (i = 0; i < wiphy->n_radio; i++)
++			ath12k_mac_cleanup_iface_comb(radio[i].iface_combinations);
++
++		kfree(wiphy->radio);
++	}
++
++	ath12k_mac_cleanup_iface_comb(wiphy->iface_combinations);
++}
++
++static int ath12k_mac_setup_iface_combinations(struct ath12k_hw *ah)
++{
++	struct ieee80211_iface_combination *combinations, *comb;
++	struct wiphy *wiphy = ah->hw->wiphy;
++	struct wiphy_radio *radio;
++	int n_combinations = 1;
++	struct ath12k *ar;
++	int i, ret;
++
++	if (ah->num_radio == 1) {
++		ar = &ah->radio[0];
++
++		if (ar->ab->hw_params->single_pdev_only)
++			n_combinations = 2;
++
++		combinations = kzalloc_objs(*combinations, n_combinations);
++		if (!combinations)
++			return -ENOMEM;
++
++		ret = ath12k_mac_setup_radio_iface_comb(ar, combinations);
++		if (ret) {
++			ath12k_hw_warn(ah, "failed to setup radio interface combinations for one radio: %d",
++				       ret);
++			goto err_free_combinations;
++		}
++
++		if (ar->ab->hw_params->single_pdev_only) {
++			comb = combinations + 1;
++			memcpy(comb, combinations, sizeof(*comb));
++			comb->num_different_channels = 2;
++			comb->radar_detect_widths = 0;
++		}
++
++		goto out;
++	}
++
++	combinations = kzalloc_objs(*combinations, n_combinations);
++	if (!combinations)
++		return -ENOMEM;
++
++	/* there are multiple radios */
++
++	radio = kzalloc_objs(*radio, ah->num_radio);
++	if (!radio) {
++		ret = -ENOMEM;
++		goto err_free_combinations;
++	}
++
++	for_each_ar(ah, ar, i) {
++		comb = kzalloc_obj(*comb);
++		if (!comb) {
++			ret = -ENOMEM;
++			goto err_free_radios;
++		}
++
++		ret = ath12k_mac_setup_radio_iface_comb(ar, comb);
++		if (ret) {
++			ath12k_hw_warn(ah, "failed to setup radio interface combinations for radio %d: %d",
++				       i, ret);
++			kfree(comb);
++			goto err_free_radios;
++		}
++
++		radio[i].freq_range = &ar->freq_range;
++		radio[i].n_freq_range = 1;
++
++		radio[i].iface_combinations = comb;
++		radio[i].n_iface_combinations = 1;
++	}
++
++	ret = ath12k_mac_setup_global_iface_comb(ah, radio, ah->num_radio, combinations);
++	if (ret) {
++		ath12k_hw_warn(ah, "failed to setup global interface combinations: %d",
++			       ret);
++		goto err_free_all_radios;
++	}
++
++	wiphy->radio = radio;
++	wiphy->n_radio = ah->num_radio;
++
++out:
++	wiphy->iface_combinations = combinations;
++	wiphy->n_iface_combinations = n_combinations;
++
++	return 0;
++
++err_free_all_radios:
++	i = ah->num_radio;
++
++err_free_radios:
++	while (i--)
++		ath12k_mac_cleanup_iface_comb(radio[i].iface_combinations);
++
++	kfree(radio);
++
++err_free_combinations:
++	kfree(combinations);
++
++	return ret;
++}
++
++static const u8 ath12k_if_types_ext_capa[] = {
++	[0] = WLAN_EXT_CAPA1_EXT_CHANNEL_SWITCHING,
++	[2] = WLAN_EXT_CAPA3_MULTI_BSSID_SUPPORT,
++	[7] = WLAN_EXT_CAPA8_OPMODE_NOTIF,
++};
++
++static const u8 ath12k_if_types_ext_capa_sta[] = {
++	[0] = WLAN_EXT_CAPA1_EXT_CHANNEL_SWITCHING,
++	[2] = WLAN_EXT_CAPA3_MULTI_BSSID_SUPPORT,
++	[7] = WLAN_EXT_CAPA8_OPMODE_NOTIF,
++	[9] = WLAN_EXT_CAPA10_TWT_REQUESTER_SUPPORT,
++};
++
++static const u8 ath12k_if_types_ext_capa_ap[] = {
++	[0] = WLAN_EXT_CAPA1_EXT_CHANNEL_SWITCHING,
++	[2] = WLAN_EXT_CAPA3_MULTI_BSSID_SUPPORT,
++	[7] = WLAN_EXT_CAPA8_OPMODE_NOTIF,
++	[9] = WLAN_EXT_CAPA10_TWT_RESPONDER_SUPPORT,
++	[10] = WLAN_EXT_CAPA11_EMA_SUPPORT,
++};
++
++static struct wiphy_iftype_ext_capab ath12k_iftypes_ext_capa[] = {
++	{
++		.extended_capabilities = ath12k_if_types_ext_capa,
++		.extended_capabilities_mask = ath12k_if_types_ext_capa,
++		.extended_capabilities_len = sizeof(ath12k_if_types_ext_capa),
++	}, {
++		.iftype = NL80211_IFTYPE_STATION,
++		.extended_capabilities = ath12k_if_types_ext_capa_sta,
++		.extended_capabilities_mask = ath12k_if_types_ext_capa_sta,
++		.extended_capabilities_len =
++				sizeof(ath12k_if_types_ext_capa_sta),
++	}, {
++		.iftype = NL80211_IFTYPE_AP,
++		.extended_capabilities = ath12k_if_types_ext_capa_ap,
++		.extended_capabilities_mask = ath12k_if_types_ext_capa_ap,
++		.extended_capabilities_len =
++				sizeof(ath12k_if_types_ext_capa_ap),
++		.eml_capabilities = 0,
++		.mld_capa_and_ops = 0,
++	},
++};
++
++static void ath12k_mac_cleanup_unregister(struct ath12k *ar)
++{
++	idr_for_each(&ar->txmgmt_idr, ath12k_mac_tx_mgmt_pending_free, ar);
++	idr_destroy(&ar->txmgmt_idr);
++
++	kfree(ar->mac.sbands[NL80211_BAND_2GHZ].channels);
++	kfree(ar->mac.sbands[NL80211_BAND_5GHZ].channels);
++	kfree(ar->mac.sbands[NL80211_BAND_6GHZ].channels);
++}
++
++static void ath12k_mac_hw_unregister(struct ath12k_hw *ah)
++{
++	struct ieee80211_hw *hw = ah->hw;
++	struct ath12k *ar;
++	int i;
++
++	for_each_ar(ah, ar, i) {
++		cancel_work_sync(&ar->regd_channel_update_work);
++		cancel_work_sync(&ar->regd_update_work);
++		ath12k_debugfs_unregister(ar);
++		ath12k_fw_stats_reset(ar);
++	}
++
++	ieee80211_unregister_hw(hw);
++
++	for_each_ar(ah, ar, i)
++		ath12k_mac_cleanup_unregister(ar);
++
++	ath12k_mac_cleanup_iface_combinations(ah);
++
++	SET_IEEE80211_DEV(hw, NULL);
++}
++
++static int ath12k_mac_setup_register(struct ath12k *ar,
++				     u32 *ht_cap,
++				     struct ieee80211_supported_band *bands[])
++{
++	struct ath12k_pdev_cap *cap = &ar->pdev->cap;
++	int ret;
++
++	init_waitqueue_head(&ar->txmgmt_empty_waitq);
++	idr_init(&ar->txmgmt_idr);
++	spin_lock_init(&ar->txmgmt_idr_lock);
++
++	ath12k_pdev_caps_update(ar);
++
++	ret = ath12k_mac_setup_channels_rates(ar,
++					      cap->supported_bands,
++					      bands);
++	if (ret)
++		return ret;
++
++	ath12k_mac_setup_ht_vht_cap(ar, cap, ht_cap);
++	ath12k_mac_setup_sband_iftype_data(ar, cap);
++
++	ar->max_num_stations = ath12k_core_get_max_station_per_radio(ar->ab);
++	ar->max_num_peers = ath12k_core_get_max_peers_per_radio(ar->ab);
++
++	ar->rssi_info.min_nf_dbm = ATH12K_DEFAULT_NOISE_FLOOR;
++	ar->rssi_info.temp_offset = 0;
++	ar->rssi_info.noise_floor = ar->rssi_info.min_nf_dbm + ar->rssi_info.temp_offset;
++
++	return 0;
++}
++
++static int ath12k_mac_hw_register(struct ath12k_hw *ah)
++{
++	struct ieee80211_hw *hw = ah->hw;
++	struct wiphy *wiphy = hw->wiphy;
++	struct ath12k *ar = ath12k_ah_to_ar(ah, 0);
++	struct ath12k_base *ab = ar->ab;
++	struct ath12k_pdev *pdev;
++	struct ath12k_pdev_cap *cap;
++	static const u32 cipher_suites[] = {
++		WLAN_CIPHER_SUITE_TKIP,
++		WLAN_CIPHER_SUITE_CCMP,
++		WLAN_CIPHER_SUITE_AES_CMAC,
++		WLAN_CIPHER_SUITE_BIP_CMAC_256,
++		WLAN_CIPHER_SUITE_BIP_GMAC_128,
++		WLAN_CIPHER_SUITE_BIP_GMAC_256,
++		WLAN_CIPHER_SUITE_GCMP,
++		WLAN_CIPHER_SUITE_GCMP_256,
++		WLAN_CIPHER_SUITE_CCMP_256,
++	};
++	int ret, i, j;
++	u32 ht_cap = U32_MAX, antennas_rx = 0, antennas_tx = 0;
++	bool is_6ghz = false, is_raw_mode = false, is_monitor_disable = false;
++	u8 *mac_addr = NULL;
++	u8 mbssid_max_interfaces = 0;
++
++	wiphy->max_ap_assoc_sta = 0;
++
++	for_each_ar(ah, ar, i) {
++		u32 ht_cap_info = 0;
++
++		pdev = ar->pdev;
++		if (ar->ab->pdevs_macaddr_valid) {
++			ether_addr_copy(ar->mac_addr, pdev->mac_addr);
++		} else {
++			ether_addr_copy(ar->mac_addr, ar->ab->mac_addr);
++			ar->mac_addr[4] += ar->pdev_idx;
++		}
++
++		ret = ath12k_mac_setup_register(ar, &ht_cap_info, hw->wiphy->bands);
++		if (ret)
++			goto err_cleanup_unregister;
++
++		/* 6 GHz does not support HT Cap, hence do not consider it */
++		if (!ar->supports_6ghz)
++			ht_cap &= ht_cap_info;
++
++		wiphy->max_ap_assoc_sta += ar->max_num_stations;
++
++		/* Advertise the max antenna support of all radios, driver can handle
++		 * per pdev specific antenna setting based on pdev cap when antenna
++		 * changes are made
++		 */
++		cap = &pdev->cap;
++
++		antennas_rx = max_t(u32, antennas_rx, cap->rx_chain_mask);
++		antennas_tx = max_t(u32, antennas_tx, cap->tx_chain_mask);
++
++		if (ar->supports_6ghz)
++			is_6ghz = true;
++
++		if (test_bit(ATH12K_FLAG_RAW_MODE, &ar->ab->dev_flags))
++			is_raw_mode = true;
++
++		if (!ar->ab->hw_params->supports_monitor)
++			is_monitor_disable = true;
++
++		if (i == 0)
++			mac_addr = ar->mac_addr;
++		else
++			mac_addr = ab->mac_addr;
++
++		mbssid_max_interfaces += TARGET_NUM_VDEVS(ar->ab);
++	}
++
++	wiphy->available_antennas_rx = antennas_rx;
++	wiphy->available_antennas_tx = antennas_tx;
++
++	SET_IEEE80211_PERM_ADDR(hw, mac_addr);
++	SET_IEEE80211_DEV(hw, ab->dev);
++
++	ret = ath12k_mac_setup_iface_combinations(ah);
++	if (ret) {
++		ath12k_err(ab, "failed to setup interface combinations: %d\n", ret);
++		goto err_complete_cleanup_unregister;
++	}
++
++	wiphy->interface_modes = ath12k_mac_get_ifmodes(ah);
++
++	if (ah->num_radio == 1 &&
++	    wiphy->bands[NL80211_BAND_2GHZ] &&
++	    wiphy->bands[NL80211_BAND_5GHZ] &&
++	    wiphy->bands[NL80211_BAND_6GHZ])
++		ieee80211_hw_set(hw, SINGLE_SCAN_ON_ALL_BANDS);
++
++	ieee80211_hw_set(hw, SIGNAL_DBM);
++	ieee80211_hw_set(hw, SUPPORTS_PS);
++	ieee80211_hw_set(hw, SUPPORTS_DYNAMIC_PS);
++	ieee80211_hw_set(hw, MFP_CAPABLE);
++	ieee80211_hw_set(hw, REPORTS_TX_ACK_STATUS);
++	ieee80211_hw_set(hw, HAS_RATE_CONTROL);
++	ieee80211_hw_set(hw, AP_LINK_PS);
++	ieee80211_hw_set(hw, SPECTRUM_MGMT);
++	ieee80211_hw_set(hw, CONNECTION_MONITOR);
++	ieee80211_hw_set(hw, SUPPORTS_PER_STA_GTK);
++	ieee80211_hw_set(hw, CHANCTX_STA_CSA);
++	ieee80211_hw_set(hw, QUEUE_CONTROL);
++	ieee80211_hw_set(hw, SUPPORTS_TX_FRAG);
++	ieee80211_hw_set(hw, REPORTS_LOW_ACK);
++	ieee80211_hw_set(hw, NO_VIRTUAL_MONITOR);
++
++	if (test_bit(WMI_TLV_SERVICE_ETH_OFFLOAD, ar->wmi->wmi_ab->svc_map)) {
++		ieee80211_hw_set(hw, SUPPORTS_TX_ENCAP_OFFLOAD);
++		ieee80211_hw_set(hw, SUPPORTS_RX_DECAP_OFFLOAD);
++	}
++
++	if (cap->nss_ratio_enabled)
++		ieee80211_hw_set(hw, SUPPORTS_VHT_EXT_NSS_BW);
++
++	if ((ht_cap & WMI_HT_CAP_ENABLED) || is_6ghz) {
++		ieee80211_hw_set(hw, AMPDU_AGGREGATION);
++		ieee80211_hw_set(hw, TX_AMPDU_SETUP_IN_HW);
++		ieee80211_hw_set(hw, SUPPORTS_REORDERING_BUFFER);
++		ieee80211_hw_set(hw, SUPPORTS_AMSDU_IN_AMPDU);
++		ieee80211_hw_set(hw, USES_RSS);
++	}
++
++	wiphy->features |= NL80211_FEATURE_STATIC_SMPS;
++	wiphy->flags |= WIPHY_FLAG_IBSS_RSN;
++
++	/* TODO: Check if HT capability advertised from firmware is different
++	 * for each band for a dual band capable radio. It will be tricky to
++	 * handle it when the ht capability different for each band.
++	 */
++	if (ht_cap & WMI_HT_CAP_DYNAMIC_SMPS ||
++	    (is_6ghz && ab->hw_params->supports_dynamic_smps_6ghz))
++		wiphy->features |= NL80211_FEATURE_DYNAMIC_SMPS;
++
++	wiphy->max_scan_ssids = WLAN_SCAN_PARAMS_MAX_SSID;
++	wiphy->max_scan_ie_len = WLAN_SCAN_PARAMS_MAX_IE_LEN;
++
++	hw->max_listen_interval = ATH12K_MAX_HW_LISTEN_INTERVAL;
++
++	wiphy->flags |= WIPHY_FLAG_HAS_REMAIN_ON_CHANNEL;
++	wiphy->flags |= WIPHY_FLAG_HAS_CHANNEL_SWITCH;
++	wiphy->max_remain_on_channel_duration = 5000;
++
++	wiphy->flags |= WIPHY_FLAG_AP_UAPSD;
++	wiphy->features |= NL80211_FEATURE_AP_MODE_CHAN_WIDTH_CHANGE |
++				   NL80211_FEATURE_AP_SCAN;
++
++	wiphy->features |= NL80211_FEATURE_TX_POWER_INSERTION;
++
++	/* MLO is not yet supported so disable Wireless Extensions for now
++	 * to make sure ath12k users don't use it. This flag can be removed
++	 * once WIPHY_FLAG_SUPPORTS_MLO is enabled.
++	 */
++	wiphy->flags |= WIPHY_FLAG_DISABLE_WEXT;
++
++	/* Copy over MLO related capabilities received from
++	 * WMI_SERVICE_READY_EXT2_EVENT if single_chip_mlo_supp is set.
++	 */
++	if (ab->ag->mlo_capable) {
++		ath12k_iftypes_ext_capa[2].eml_capabilities = cap->eml_cap;
++		ath12k_iftypes_ext_capa[2].mld_capa_and_ops = cap->mld_cap;
++		wiphy->flags |= WIPHY_FLAG_SUPPORTS_MLO;
++
++		ieee80211_hw_set(hw, MLO_MCAST_MULTI_LINK_TX);
++	}
++
++	hw->queues = ATH12K_HW_MAX_QUEUES;
++	wiphy->tx_queue_len = ATH12K_QUEUE_LEN;
++	hw->offchannel_tx_hw_queue = ATH12K_HW_MAX_QUEUES - 1;
++	hw->max_rx_aggregation_subframes = IEEE80211_MAX_AMPDU_BUF_EHT;
++
++	hw->vif_data_size = sizeof(struct ath12k_vif);
++	hw->sta_data_size = sizeof(struct ath12k_sta);
++	hw->extra_tx_headroom = ab->hw_params->iova_mask;
++
++	wiphy_ext_feature_set(wiphy, NL80211_EXT_FEATURE_CQM_RSSI_LIST);
++	wiphy_ext_feature_set(wiphy, NL80211_EXT_FEATURE_STA_TX_PWR);
++	wiphy_ext_feature_set(wiphy, NL80211_EXT_FEATURE_ACK_SIGNAL_SUPPORT);
++	if (test_bit(WMI_TLV_SERVICE_BSS_COLOR_OFFLOAD,
++		     ab->wmi_ab.svc_map)) {
++		wiphy_ext_feature_set(wiphy, NL80211_EXT_FEATURE_BSS_COLOR);
++		ieee80211_hw_set(hw, DETECTS_COLOR_COLLISION);
++	}
++
++	wiphy->cipher_suites = cipher_suites;
++	wiphy->n_cipher_suites = ARRAY_SIZE(cipher_suites);
++
++	wiphy->iftype_ext_capab = ath12k_iftypes_ext_capa;
++	wiphy->num_iftype_ext_capab = ARRAY_SIZE(ath12k_iftypes_ext_capa);
++
++	wiphy->mbssid_max_interfaces = mbssid_max_interfaces;
++	wiphy->ema_max_profile_periodicity = TARGET_EMA_MAX_PROFILE_PERIOD;
++	ieee80211_hw_set(hw, SUPPORTS_MULTI_BSSID);
++
++	if (is_6ghz) {
++		wiphy_ext_feature_set(wiphy,
++				      NL80211_EXT_FEATURE_FILS_DISCOVERY);
++		wiphy_ext_feature_set(wiphy,
++				      NL80211_EXT_FEATURE_UNSOL_BCAST_PROBE_RESP);
++	}
++
++	wiphy_ext_feature_set(wiphy, NL80211_EXT_FEATURE_PUNCT);
++	if (test_bit(WMI_TLV_SERVICE_BEACON_PROTECTION_SUPPORT, ab->wmi_ab.svc_map))
++		wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_BEACON_PROTECTION);
++
++	ath12k_reg_init(hw);
++
++	if (!is_raw_mode) {
++		hw->netdev_features = NETIF_F_HW_CSUM;
++		ieee80211_hw_set(hw, SW_CRYPTO_CONTROL);
++		ieee80211_hw_set(hw, SUPPORT_FAST_XMIT);
++	}
++
++	if (test_bit(WMI_TLV_SERVICE_NLO, ar->wmi->wmi_ab->svc_map)) {
++		wiphy->max_sched_scan_ssids = WMI_PNO_MAX_SUPP_NETWORKS;
++		wiphy->max_match_sets = WMI_PNO_MAX_SUPP_NETWORKS;
++		wiphy->max_sched_scan_ie_len = WMI_PNO_MAX_IE_LENGTH;
++		wiphy->max_sched_scan_plans = WMI_PNO_MAX_SCHED_SCAN_PLANS;
++		wiphy->max_sched_scan_plan_interval =
++					WMI_PNO_MAX_SCHED_SCAN_PLAN_INT;
++		wiphy->max_sched_scan_plan_iterations =
++					WMI_PNO_MAX_SCHED_SCAN_PLAN_ITRNS;
++		wiphy->features |= NL80211_FEATURE_ND_RANDOM_MAC_ADDR;
++	}
++
++	ret = ath12k_wow_init(ar);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to init wow: %d\n", ret);
++		goto err_cleanup_if_combs;
++	}
++
++	/* Boot-time regulatory updates have already been processed.
++	 * Mark them as complete now, because after registration,
++	 * cfg80211 will notify us again if there are any pending hints.
++	 * We need to wait for those hints to be processed, so it's
++	 * important to mark the boot-time updates as complete before
++	 * proceeding with registration.
++	 */
++	for_each_ar(ah, ar, i)
++		complete_all(&ar->regd_update_completed);
++
++	ret = ieee80211_register_hw(hw);
++	if (ret) {
++		ath12k_err(ab, "ieee80211 registration failed: %d\n", ret);
++		goto err_cleanup_if_combs;
++	}
++
++	if (is_monitor_disable)
++		/* There's a race between calling ieee80211_register_hw()
++		 * and here where the monitor mode is enabled for a little
++		 * while. But that time is so short and in practice it doesn't make
++		 * a difference in real life.
++		 */
++		wiphy->interface_modes &= ~BIT(NL80211_IFTYPE_MONITOR);
++
++	for_each_ar(ah, ar, i) {
++		/* Apply the regd received during initialization */
++		ret = ath12k_regd_update(ar, true);
++		if (ret) {
++			ath12k_err(ar->ab, "ath12k regd update failed: %d\n", ret);
++			goto err_unregister_hw;
++		}
++
++		if (ar->ab->hw_params->current_cc_support && ab->new_alpha2[0]) {
++			struct wmi_set_current_country_arg current_cc = {};
++
++			memcpy(&current_cc.alpha2, ab->new_alpha2, 2);
++			memcpy(&ar->alpha2, ab->new_alpha2, 2);
++
++			reinit_completion(&ar->regd_update_completed);
++
++			ret = ath12k_wmi_send_set_current_country_cmd(ar, &current_cc);
++			if (ret)
++				ath12k_warn(ar->ab,
++					    "failed set cc code for mac register: %d\n",
++					    ret);
++		}
++
++		ath12k_fw_stats_init(ar);
++		ath12k_debugfs_register(ar);
++	}
++
++	return 0;
++
++err_unregister_hw:
++	for_each_ar(ah, ar, i)
++		ath12k_debugfs_unregister(ar);
++
++	ieee80211_unregister_hw(hw);
++
++err_cleanup_if_combs:
++	ath12k_mac_cleanup_iface_combinations(ah);
++
++err_complete_cleanup_unregister:
++	i = ah->num_radio;
++
++err_cleanup_unregister:
++	for (j = 0; j < i; j++) {
++		ar = ath12k_ah_to_ar(ah, j);
++		ath12k_mac_cleanup_unregister(ar);
++	}
++
++	SET_IEEE80211_DEV(hw, NULL);
++
++	return ret;
++}
++
++static void ath12k_mac_setup(struct ath12k *ar)
++{
++	struct ath12k_base *ab = ar->ab;
++	struct ath12k_pdev *pdev = ar->pdev;
++	u8 pdev_idx = ar->pdev_idx;
++
++	ar->lmac_id = ath12k_hw_get_mac_from_pdev_id(ab->hw_params, pdev_idx);
++
++	ar->wmi = &ab->wmi_ab.wmi[pdev_idx];
++	/* FIXME: wmi[0] is already initialized during attach,
++	 * Should we do this again?
++	 */
++	ath12k_wmi_pdev_attach(ab, pdev_idx);
++
++	ar->cfg_tx_chainmask = pdev->cap.tx_chain_mask;
++	ar->cfg_rx_chainmask = pdev->cap.rx_chain_mask;
++	ar->num_tx_chains = hweight32(pdev->cap.tx_chain_mask);
++	ar->num_rx_chains = hweight32(pdev->cap.rx_chain_mask);
++	ar->scan.arvif = NULL;
++	ar->vdev_id_11d_scan = ATH12K_11D_INVALID_VDEV_ID;
++
++	spin_lock_init(&ar->data_lock);
++	spin_lock_init(&ar->dp.ppdu_list_lock);
++	INIT_LIST_HEAD(&ar->arvifs);
++	INIT_LIST_HEAD(&ar->dp.ppdu_stats_info);
++
++	init_completion(&ar->vdev_setup_done);
++	init_completion(&ar->vdev_delete_done);
++	init_completion(&ar->peer_assoc_done);
++	init_completion(&ar->peer_delete_done);
++	init_completion(&ar->install_key_done);
++	init_completion(&ar->bss_survey_done);
++	init_completion(&ar->scan.started);
++	init_completion(&ar->scan.completed);
++	init_completion(&ar->scan.on_channel);
++	init_completion(&ar->mlo_setup_done);
++	init_completion(&ar->completed_11d_scan);
++	init_completion(&ar->regd_update_completed);
++	init_completion(&ar->thermal.wmi_sync);
++
++	ar->thermal.temperature = 0;
++	ar->thermal.hwmon_dev = NULL;
++
++	INIT_DELAYED_WORK(&ar->scan.timeout, ath12k_scan_timeout_work);
++	wiphy_work_init(&ar->scan.vdev_clean_wk, ath12k_scan_vdev_clean_work);
++	INIT_WORK(&ar->regd_channel_update_work, ath12k_regd_update_chan_list_work);
++	INIT_LIST_HEAD(&ar->regd_channel_update_queue);
++	INIT_WORK(&ar->regd_update_work, ath12k_regd_update_work);
++
++	wiphy_work_init(&ar->wmi_mgmt_tx_work, ath12k_mgmt_over_wmi_tx_work);
++	skb_queue_head_init(&ar->wmi_mgmt_tx_queue);
++
++	ar->monitor_vdev_id = -1;
++	ar->monitor_vdev_created = false;
++	ar->monitor_started = false;
++}
++
++static int __ath12k_mac_mlo_setup(struct ath12k *ar)
++{
++	u8 num_link = 0, partner_link_id[ATH12K_GROUP_MAX_RADIO] = {};
++	struct ath12k_base *partner_ab, *ab = ar->ab;
++	struct ath12k_hw_group *ag = ab->ag;
++	struct wmi_mlo_setup_arg mlo = {};
++	struct ath12k_pdev *pdev;
++	unsigned long time_left;
++	int i, j, ret;
++
++	lockdep_assert_held(&ag->mutex);
++
++	reinit_completion(&ar->mlo_setup_done);
++
++	for (i = 0; i < ag->num_devices; i++) {
++		partner_ab = ag->ab[i];
++
++		for (j = 0; j < partner_ab->num_radios; j++) {
++			pdev = &partner_ab->pdevs[j];
++
++			/* Avoid the self link */
++			if (ar == pdev->ar)
++				continue;
++
++			partner_link_id[num_link] = pdev->hw_link_id;
++			num_link++;
++
++			ath12k_dbg(ab, ATH12K_DBG_MAC, "device %d pdev %d hw_link_id %d num_link %d\n",
++				   i, j, pdev->hw_link_id, num_link);
++		}
++	}
++
++	if (num_link == 0)
++		return 0;
++
++	mlo.group_id = cpu_to_le32(ag->id);
++	mlo.partner_link_id = partner_link_id;
++	mlo.num_partner_links = num_link;
++	ar->mlo_setup_status = 0;
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC, "group id %d num_link %d\n", ag->id, num_link);
++
++	ret = ath12k_wmi_mlo_setup(ar, &mlo);
++	if (ret) {
++		ath12k_err(ab, "failed to send  setup MLO WMI command for pdev %d: %d\n",
++			   ar->pdev_idx, ret);
++		return ret;
++	}
++
++	time_left = wait_for_completion_timeout(&ar->mlo_setup_done,
++						WMI_MLO_CMD_TIMEOUT_HZ);
++
++	if (!time_left || ar->mlo_setup_status)
++		return ar->mlo_setup_status ? : -ETIMEDOUT;
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC, "mlo setup done for pdev %d\n", ar->pdev_idx);
++
++	return 0;
++}
++
++static int __ath12k_mac_mlo_teardown(struct ath12k *ar)
++{
++	struct ath12k_base *ab = ar->ab;
++	int ret;
++	u8 num_link;
++
++	if (test_bit(ATH12K_FLAG_RECOVERY, &ab->dev_flags))
++		return 0;
++
++	num_link = ath12k_get_num_partner_link(ar);
++
++	if (num_link == 0)
++		return 0;
++
++	ret = ath12k_wmi_mlo_teardown(ar);
++	if (ret) {
++		ath12k_warn(ab, "failed to send MLO teardown WMI command for pdev %d: %d\n",
++			    ar->pdev_idx, ret);
++		return ret;
++	}
++
++	ath12k_dbg(ab, ATH12K_DBG_MAC, "mlo teardown for pdev %d\n", ar->pdev_idx);
++
++	return 0;
++}
++
++int ath12k_mac_mlo_setup(struct ath12k_hw_group *ag)
++{
++	struct ath12k_hw *ah;
++	struct ath12k *ar;
++	int ret;
++	int i, j;
++
++	for (i = 0; i < ag->num_hw; i++) {
++		ah = ag->ah[i];
++		if (!ah)
++			continue;
++
++		for_each_ar(ah, ar, j) {
++			ar = &ah->radio[j];
++			ret = __ath12k_mac_mlo_setup(ar);
++			if (ret) {
++				ath12k_err(ar->ab, "failed to setup MLO: %d\n", ret);
++				goto err_setup;
++			}
++		}
++	}
++
++	return 0;
++
++err_setup:
++	for (i = i - 1; i >= 0; i--) {
++		ah = ag->ah[i];
++		if (!ah)
++			continue;
++
++		for (j = j - 1; j >= 0; j--) {
++			ar = &ah->radio[j];
++			if (!ar)
++				continue;
++
++			__ath12k_mac_mlo_teardown(ar);
++		}
++	}
++
++	return ret;
++}
++
++void ath12k_mac_mlo_teardown(struct ath12k_hw_group *ag)
++{
++	struct ath12k_hw *ah;
++	struct ath12k *ar;
++	int ret, i, j;
++
++	for (i = 0; i < ag->num_hw; i++) {
++		ah = ag->ah[i];
++		if (!ah)
++			continue;
++
++		for_each_ar(ah, ar, j) {
++			ar = &ah->radio[j];
++			ret = __ath12k_mac_mlo_teardown(ar);
++			if (ret) {
++				ath12k_err(ar->ab, "failed to teardown MLO: %d\n", ret);
++				break;
++			}
++		}
++	}
++}
++
++int ath12k_mac_register(struct ath12k_hw_group *ag)
++{
++	struct ath12k_hw *ah;
++	int i;
++	int ret;
++
++	for (i = 0; i < ag->num_hw; i++) {
++		ah = ath12k_ag_to_ah(ag, i);
++
++		ret = ath12k_mac_hw_register(ah);
++		if (ret)
++			goto err;
++	}
++
++	return 0;
++
++err:
++	for (i = i - 1; i >= 0; i--) {
++		ah = ath12k_ag_to_ah(ag, i);
++		if (!ah)
++			continue;
++
++		ath12k_mac_hw_unregister(ah);
++	}
++
++	return ret;
++}
++
++void ath12k_mac_unregister(struct ath12k_hw_group *ag)
++{
++	struct ath12k_hw *ah;
++	int i;
++
++	for (i = ag->num_hw - 1; i >= 0; i--) {
++		ah = ath12k_ag_to_ah(ag, i);
++		if (!ah)
++			continue;
++
++		ath12k_mac_hw_unregister(ah);
++	}
++}
++
++static void ath12k_mac_hw_destroy(struct ath12k_hw *ah)
++{
++	ieee80211_free_hw(ah->hw);
++}
++
++static struct ath12k_hw *ath12k_mac_hw_allocate(struct ath12k_hw_group *ag,
++						struct ath12k_pdev_map *pdev_map,
++						u8 num_pdev_map)
++{
++	struct ieee80211_hw *hw;
++	struct ath12k *ar;
++	struct ath12k_base *ab;
++	struct ath12k_pdev *pdev;
++	struct ath12k_hw *ah;
++	int i;
++	u8 pdev_idx;
++
++	hw = ieee80211_alloc_hw(struct_size(ah, radio, num_pdev_map),
++				pdev_map->ab->ath12k_ops);
++	if (!hw)
++		return NULL;
++
++	ah = ath12k_hw_to_ah(hw);
++	ah->hw = hw;
++	ah->num_radio = num_pdev_map;
++
++	mutex_init(&ah->hw_mutex);
++
++	spin_lock_init(&ah->dp_hw.peer_lock);
++	INIT_LIST_HEAD(&ah->dp_hw.dp_peers_list);
++
++	for (i = 0; i < num_pdev_map; i++) {
++		ab = pdev_map[i].ab;
++		pdev_idx = pdev_map[i].pdev_idx;
++		pdev = &ab->pdevs[pdev_idx];
++
++		ar = ath12k_ah_to_ar(ah, i);
++		ar->ah = ah;
++		ar->ab = ab;
++		ar->hw_link_id = pdev->hw_link_id;
++		ar->pdev = pdev;
++		ar->pdev_idx = pdev_idx;
++		ar->radio_idx = i;
++		pdev->ar = ar;
++
++		ag->hw_links[ar->hw_link_id].device_id = ab->device_id;
++		ag->hw_links[ar->hw_link_id].pdev_idx = pdev_idx;
++
++		ath12k_mac_setup(ar);
++		ath12k_dp_pdev_pre_alloc(ar);
++	}
++
++	return ah;
++}
++
++void ath12k_mac_destroy(struct ath12k_hw_group *ag)
++{
++	struct ath12k_pdev *pdev;
++	struct ath12k_base *ab = ag->ab[0];
++	int i, j;
++	struct ath12k_hw *ah;
++
++	for (i = 0; i < ag->num_devices; i++) {
++		ab = ag->ab[i];
++		if (!ab)
++			continue;
++
++		for (j = 0; j < ab->num_radios; j++) {
++			pdev = &ab->pdevs[j];
++			if (!pdev->ar)
++				continue;
++			pdev->ar = NULL;
++		}
++	}
++
++	for (i = 0; i < ag->num_hw; i++) {
++		ah = ath12k_ag_to_ah(ag, i);
++		if (!ah)
++			continue;
++
++		ath12k_mac_hw_destroy(ah);
++		ath12k_ag_set_ah(ag, i, NULL);
++	}
++}
++
++static void ath12k_mac_set_device_defaults(struct ath12k_base *ab)
++{
++	int total_vdev;
++
++	/* Initialize channel counters frequency value in hertz */
++	ab->cc_freq_hz = 320000;
++	total_vdev = ab->num_radios * TARGET_NUM_VDEVS(ab);
++	ab->free_vdev_map = (1LL << total_vdev) - 1;
++}
++
++int ath12k_mac_allocate(struct ath12k_hw_group *ag)
++{
++	struct ath12k_pdev_map pdev_map[ATH12K_GROUP_MAX_RADIO];
++	int mac_id, device_id, total_radio, num_hw;
++	struct ath12k_base *ab;
++	struct ath12k_hw *ah;
++	int ret, i, j;
++	u8 radio_per_hw;
++
++	total_radio = 0;
++	for (i = 0; i < ag->num_devices; i++) {
++		ab = ag->ab[i];
++		if (!ab)
++			continue;
++
++		ath12k_mac_set_device_defaults(ab);
++		total_radio += ab->num_radios;
++	}
++
++	if (!total_radio)
++		return -EINVAL;
++
++	if (WARN_ON(total_radio > ATH12K_GROUP_MAX_RADIO))
++		return -ENOSPC;
++
++	/* All pdev get combined and register as single wiphy based on
++	 * hardware group which participate in multi-link operation else
++	 * each pdev get register separately.
++	 */
++	if (ag->mlo_capable)
++		radio_per_hw = total_radio;
++	else
++		radio_per_hw = 1;
++
++	num_hw = total_radio / radio_per_hw;
++
++	ag->num_hw = 0;
++	device_id = 0;
++	mac_id = 0;
++	for (i = 0; i < num_hw; i++) {
++		for (j = 0; j < radio_per_hw; j++) {
++			if (device_id >= ag->num_devices || !ag->ab[device_id]) {
++				ret = -ENOSPC;
++				goto err;
++			}
++
++			ab = ag->ab[device_id];
++			pdev_map[j].ab = ab;
++			pdev_map[j].pdev_idx = mac_id;
++			mac_id++;
++
++			/* If mac_id falls beyond the current device MACs then
++			 * move to next device
++			 */
++			if (mac_id >= ab->num_radios) {
++				mac_id = 0;
++				device_id++;
++			}
++		}
++
++		ab = pdev_map->ab;
++
++		ah = ath12k_mac_hw_allocate(ag, pdev_map, radio_per_hw);
++		if (!ah) {
++			ath12k_warn(ab, "failed to allocate mac80211 hw device for hw_idx %d\n",
++				    i);
++			ret = -ENOMEM;
++			goto err;
++		}
++
++		ah->dev = ab->dev;
++
++		ag->ah[i] = ah;
++		ag->num_hw++;
++	}
++
++	return 0;
++
++err:
++	for (i = i - 1; i >= 0; i--) {
++		ah = ath12k_ag_to_ah(ag, i);
++		if (!ah)
++			continue;
++
++		ath12k_mac_hw_destroy(ah);
++		ath12k_ag_set_ah(ag, i, NULL);
++	}
++
++	return ret;
++}
++
++int ath12k_mac_vif_set_keepalive(struct ath12k_link_vif *arvif,
++				 enum wmi_sta_keepalive_method method,
++				 u32 interval)
++{
++	struct wmi_sta_keepalive_arg arg = {};
++	struct ath12k *ar = arvif->ar;
++	int ret;
++
++	lockdep_assert_wiphy(ath12k_ar_to_hw(ar)->wiphy);
++
++	if (arvif->ahvif->vdev_type != WMI_VDEV_TYPE_STA)
++		return 0;
++
++	if (!test_bit(WMI_TLV_SERVICE_STA_KEEP_ALIVE, ar->ab->wmi_ab.svc_map))
++		return 0;
++
++	arg.vdev_id = arvif->vdev_id;
++	arg.enabled = 1;
++	arg.method = method;
++	arg.interval = interval;
++
++	ret = ath12k_wmi_sta_keepalive(ar, &arg);
++	if (ret) {
++		ath12k_warn(ar->ab, "failed to set keepalive on vdev %i: %d\n",
++			    arvif->vdev_id, ret);
++		return ret;
++	}
++
++	return 0;
++}
+diff --git a/drivers/soc/qcom/socinfo.c.orig b/drivers/soc/qcom/socinfo.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/soc/qcom/socinfo.c.orig
+@@ -0,0 +1,943 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) 2009-2017, The Linux Foundation. All rights reserved.
++ * Copyright (c) 2017-2019, Linaro Ltd.
++ */
++
++#include <linux/debugfs.h>
++#include <linux/err.h>
++#include <linux/module.h>
++#include <linux/platform_device.h>
++#include <linux/random.h>
++#include <linux/slab.h>
++#include <linux/soc/qcom/smem.h>
++#include <linux/soc/qcom/socinfo.h>
++#include <linux/string.h>
++#include <linux/stringify.h>
++#include <linux/sys_soc.h>
++#include <linux/types.h>
++
++#include <linux/unaligned.h>
++
++#include <dt-bindings/arm/qcom,ids.h>
++
++/* Helper macros to create soc_id table */
++#define qcom_board_id(id) QCOM_ID_ ## id, __stringify(id)
++#define qcom_board_id_named(id, name) QCOM_ID_ ## id, (name)
++
++#ifdef CONFIG_DEBUG_FS
++#define SMEM_IMAGE_VERSION_BLOCKS_COUNT        32
++#define SMEM_IMAGE_VERSION_SIZE                4096
++#define SMEM_IMAGE_VERSION_NAME_SIZE           75
++#define SMEM_IMAGE_VERSION_VARIANT_SIZE        20
++#define SMEM_IMAGE_VERSION_OEM_SIZE            32
++
++/*
++ * SMEM Image table indices
++ */
++#define SMEM_IMAGE_TABLE_BOOT_INDEX     0
++#define SMEM_IMAGE_TABLE_TZ_INDEX       1
++#define SMEM_IMAGE_TABLE_TZSECAPP_INDEX	2
++#define SMEM_IMAGE_TABLE_RPM_INDEX      3
++#define SMEM_IMAGE_TABLE_SDI_INDEX      4
++#define SMEM_IMAGE_TABLE_HYP_INDEX      5
++#define SMEM_IMAGE_TABLE_ADSP1_INDEX	6
++#define SMEM_IMAGE_TABLE_ADSP2_INDEX	7
++#define SMEM_IMAGE_TABLE_CDSP2_INDEX	8
++#define SMEM_IMAGE_TABLE_APPSBL_INDEX	9
++#define SMEM_IMAGE_TABLE_APPS_INDEX     10
++#define SMEM_IMAGE_TABLE_MPSS_INDEX     11
++#define SMEM_IMAGE_TABLE_ADSP_INDEX     12
++#define SMEM_IMAGE_TABLE_CNSS_INDEX     13
++#define SMEM_IMAGE_TABLE_VIDEO_INDEX    14
++#define SMEM_IMAGE_TABLE_DSPS_INDEX     15
++#define SMEM_IMAGE_TABLE_CDSP_INDEX     16
++#define SMEM_IMAGE_TABLE_NPU_INDEX	17
++#define SMEM_IMAGE_TABLE_WPSS_INDEX     18
++#define SMEM_IMAGE_TABLE_CDSP1_INDEX    19
++#define SMEM_IMAGE_TABLE_GPDSP_INDEX    20
++#define SMEM_IMAGE_TABLE_GPDSP1_INDEX   21
++#define SMEM_IMAGE_TABLE_SENSORPD_INDEX	22
++#define SMEM_IMAGE_TABLE_AUDIOPD_INDEX	23
++#define SMEM_IMAGE_TABLE_OEMPD_INDEX	24
++#define SMEM_IMAGE_TABLE_CHARGERPD_INDEX	25
++#define SMEM_IMAGE_TABLE_OISPD_INDEX	26
++#define SMEM_IMAGE_TABLE_SOCCP_INDEX	27
++#define SMEM_IMAGE_TABLE_TME_INDEX	28
++#define SMEM_IMAGE_TABLE_GEARVM_INDEX	29
++#define SMEM_IMAGE_TABLE_UEFI_INDEX	30
++#define SMEM_IMAGE_TABLE_CDSP3_INDEX	31
++#define SMEM_IMAGE_TABLE_AUDIOPD_ADSP1_INDEX	32
++#define SMEM_IMAGE_TABLE_AUDIOPD_ADSP2_INDEX	33
++#define SMEM_IMAGE_TABLE_DCP_INDEX	34
++#define SMEM_IMAGE_TABLE_OOBS_INDEX	35
++#define SMEM_IMAGE_TABLE_OOBNS_INDEX	36
++#define SMEM_IMAGE_TABLE_DEVCFG_INDEX	37
++#define SMEM_IMAGE_TABLE_BTPD_INDEX	38
++#define SMEM_IMAGE_TABLE_QECP_INDEX	39
++
++#define SMEM_IMAGE_VERSION_TABLE       469
++#define SMEM_IMAGE_VERSION_TABLE_2	667
++
++/*
++ * SMEM Image table names
++ */
++static const char *const socinfo_image_names[] = {
++	[SMEM_IMAGE_TABLE_ADSP1_INDEX] = "adsp1",
++	[SMEM_IMAGE_TABLE_ADSP2_INDEX] = "adsp2",
++	[SMEM_IMAGE_TABLE_ADSP_INDEX] = "adsp",
++	[SMEM_IMAGE_TABLE_APPSBL_INDEX] = "appsbl",
++	[SMEM_IMAGE_TABLE_APPS_INDEX] = "apps",
++	[SMEM_IMAGE_TABLE_AUDIOPD_INDEX] = "audiopd",
++	[SMEM_IMAGE_TABLE_AUDIOPD_ADSP1_INDEX] = "audiopd_adsp1",
++	[SMEM_IMAGE_TABLE_AUDIOPD_ADSP2_INDEX] = "audiopd_adsp2",
++	[SMEM_IMAGE_TABLE_BOOT_INDEX] = "boot",
++	[SMEM_IMAGE_TABLE_BTPD_INDEX] = "btpd",
++	[SMEM_IMAGE_TABLE_CDSP1_INDEX] = "cdsp1",
++	[SMEM_IMAGE_TABLE_CDSP2_INDEX] = "cdsp2",
++	[SMEM_IMAGE_TABLE_CDSP3_INDEX] = "cdsp3",
++	[SMEM_IMAGE_TABLE_CDSP_INDEX] = "cdsp",
++	[SMEM_IMAGE_TABLE_CHARGERPD_INDEX] = "chargerpd",
++	[SMEM_IMAGE_TABLE_CNSS_INDEX] = "cnss",
++	[SMEM_IMAGE_TABLE_DCP_INDEX] = "dcp",
++	[SMEM_IMAGE_TABLE_DEVCFG_INDEX] = "devcfg",
++	[SMEM_IMAGE_TABLE_DSPS_INDEX] = "dsps",
++	[SMEM_IMAGE_TABLE_GEARVM_INDEX] = "gearvm",
++	[SMEM_IMAGE_TABLE_GPDSP1_INDEX] = "gpdsp1",
++	[SMEM_IMAGE_TABLE_GPDSP_INDEX] = "gpdsp",
++	[SMEM_IMAGE_TABLE_HYP_INDEX] = "hyp",
++	[SMEM_IMAGE_TABLE_MPSS_INDEX] = "mpss",
++	[SMEM_IMAGE_TABLE_NPU_INDEX] = "npu",
++	[SMEM_IMAGE_TABLE_OEMPD_INDEX] = "oempd",
++	[SMEM_IMAGE_TABLE_OISPD_INDEX] = "oispd",
++	[SMEM_IMAGE_TABLE_OOBNS_INDEX] = "oobns",
++	[SMEM_IMAGE_TABLE_OOBS_INDEX] = "oobs",
++	[SMEM_IMAGE_TABLE_QECP_INDEX] = "qecp",
++	[SMEM_IMAGE_TABLE_RPM_INDEX] = "rpm",
++	[SMEM_IMAGE_TABLE_SDI_INDEX] = "sdi",
++	[SMEM_IMAGE_TABLE_SENSORPD_INDEX] = "sensorpd",
++	[SMEM_IMAGE_TABLE_SOCCP_INDEX] = "soccp",
++	[SMEM_IMAGE_TABLE_TME_INDEX] = "tme",
++	[SMEM_IMAGE_TABLE_TZ_INDEX] = "tz",
++	[SMEM_IMAGE_TABLE_TZSECAPP_INDEX] = "tzsecapp",
++	[SMEM_IMAGE_TABLE_UEFI_INDEX] = "uefi",
++	[SMEM_IMAGE_TABLE_VIDEO_INDEX] = "video",
++	[SMEM_IMAGE_TABLE_WPSS_INDEX] = "wpss",
++};
++
++static const char *const pmic_models[] = {
++	[0]  = "Unknown PMIC model",
++	[1]  = "PM8941",
++	[2]  = "PM8841",
++	[3]  = "PM8019",
++	[4]  = "PM8226",
++	[5]  = "PM8110",
++	[6]  = "PMA8084",
++	[7]  = "PMI8962",
++	[8]  = "PMD9635",
++	[9]  = "PM8994",
++	[10] = "PMI8994",
++	[11] = "PM8916",
++	[12] = "PM8004",
++	[13] = "PM8909/PM8058",
++	[14] = "PM8028",
++	[15] = "PM8901",
++	[16] = "PM8950/PM8027",
++	[17] = "PMI8950/ISL9519",
++	[18] = "PMK8001/PM8921",
++	[19] = "PMI8996/PM8018",
++	[20] = "PM8998/PM8015",
++	[21] = "PMI8998/PM8014",
++	[22] = "PM8821",
++	[23] = "PM8038",
++	[24] = "PM8005/PM8922",
++	[25] = "PM8917/PM8937",
++	[26] = "PM660L",
++	[27] = "PM660",
++	[30] = "PM8150",
++	[31] = "PM8150L",
++	[32] = "PM8150B",
++	[33] = "PMK8002",
++	[36] = "PM8009",
++	[37] = "PMI632",
++	[38] = "PM8150C",
++	[40] = "PM6150",
++	[41] = "SMB2351",
++	[44] = "PM8008",
++	[45] = "PM6125",
++	[46] = "PM7250B",
++	[47] = "PMK8350",
++	[48] = "PM8350",
++	[49] = "PM8350C",
++	[50] = "PM8350B",
++	[51] = "PMR735A",
++	[52] = "PMR735B",
++	[54] = "PM6350",
++	[55] = "PM4125",
++	[58] = "PM8450",
++	[65] = "PM8010",
++	[69] = "PM8550VS",
++	[70] = "PM8550VE",
++	[71] = "PM8550B",
++	[72] = "PMR735D",
++	[73] = "PM8550",
++	[74] = "PMK8550",
++	[76] = "PM7550BA",
++	[78] = "PMM8650AU",
++	[79] = "PMM8650AU_PSAIL",
++	[80] = "PM7550",
++	[82] = "PMC8380",
++	[83] = "SMB2360",
++	[91] = "PMIV0108",
++};
++
++struct socinfo_params {
++	u32 raw_device_family;
++	u32 hw_plat_subtype;
++	u32 accessory_chip;
++	u32 raw_device_num;
++	u32 chip_family;
++	u32 foundry_id;
++	u32 plat_ver;
++	u32 raw_ver;
++	u32 hw_plat;
++	u32 fmt;
++	u32 nproduct_id;
++	u32 num_clusters;
++	u32 ncluster_array_offset;
++	u32 num_subset_parts;
++	u32 nsubset_parts_array_offset;
++	u32 nmodem_supported;
++	u32 feature_code;
++	u32 pcode;
++	u32 oem_variant;
++	u32 num_func_clusters;
++	u32 boot_cluster;
++	u32 boot_core;
++	u32 raw_package_type;
++};
++
++struct smem_image_version {
++	char name[SMEM_IMAGE_VERSION_NAME_SIZE];
++	char variant[SMEM_IMAGE_VERSION_VARIANT_SIZE];
++	char pad;
++	char oem[SMEM_IMAGE_VERSION_OEM_SIZE];
++};
++#endif /* CONFIG_DEBUG_FS */
++
++struct qcom_socinfo {
++	struct soc_device *soc_dev;
++	struct soc_device_attribute attr;
++#ifdef CONFIG_DEBUG_FS
++	struct dentry *dbg_root;
++	struct socinfo_params info;
++#endif /* CONFIG_DEBUG_FS */
++};
++
++struct soc_id {
++	unsigned int id;
++	const char *name;
++};
++
++static const struct soc_id soc_id[] = {
++	{ qcom_board_id(MSM8260) },
++	{ qcom_board_id(MSM8660) },
++	{ qcom_board_id(APQ8060) },
++	{ qcom_board_id(MSM8960) },
++	{ qcom_board_id(APQ8064) },
++	{ qcom_board_id(MSM8930) },
++	{ qcom_board_id(MSM8630) },
++	{ qcom_board_id(MSM8230) },
++	{ qcom_board_id(APQ8030) },
++	{ qcom_board_id(MSM8627) },
++	{ qcom_board_id(MSM8227) },
++	{ qcom_board_id(MSM8660A) },
++	{ qcom_board_id(MSM8260A) },
++	{ qcom_board_id(APQ8060A) },
++	{ qcom_board_id(MSM8974) },
++	{ qcom_board_id(MSM8225) },
++	{ qcom_board_id(MSM8625) },
++	{ qcom_board_id(MPQ8064) },
++	{ qcom_board_id(MSM8960AB) },
++	{ qcom_board_id(APQ8060AB) },
++	{ qcom_board_id(MSM8260AB) },
++	{ qcom_board_id(MSM8660AB) },
++	{ qcom_board_id(MSM8930AA) },
++	{ qcom_board_id(MSM8630AA) },
++	{ qcom_board_id(MSM8230AA) },
++	{ qcom_board_id(MSM8626) },
++	{ qcom_board_id(MSM8610) },
++	{ qcom_board_id(APQ8064AB) },
++	{ qcom_board_id(MSM8930AB) },
++	{ qcom_board_id(MSM8630AB) },
++	{ qcom_board_id(MSM8230AB) },
++	{ qcom_board_id(APQ8030AB) },
++	{ qcom_board_id(MSM8226) },
++	{ qcom_board_id(MSM8526) },
++	{ qcom_board_id(APQ8030AA) },
++	{ qcom_board_id(MSM8110) },
++	{ qcom_board_id(MSM8210) },
++	{ qcom_board_id(MSM8810) },
++	{ qcom_board_id(MSM8212) },
++	{ qcom_board_id(MSM8612) },
++	{ qcom_board_id(MSM8112) },
++	{ qcom_board_id(MSM8125) },
++	{ qcom_board_id(MSM8225Q) },
++	{ qcom_board_id(MSM8625Q) },
++	{ qcom_board_id(MSM8125Q) },
++	{ qcom_board_id(APQ8064AA) },
++	{ qcom_board_id(APQ8084) },
++	{ qcom_board_id(MSM8130) },
++	{ qcom_board_id(MSM8130AA) },
++	{ qcom_board_id(MSM8130AB) },
++	{ qcom_board_id(MSM8627AA) },
++	{ qcom_board_id(MSM8227AA) },
++	{ qcom_board_id(APQ8074) },
++	{ qcom_board_id(MSM8274) },
++	{ qcom_board_id(MSM8674) },
++	{ qcom_board_id(MDM9635) },
++	{ qcom_board_id_named(MSM8974PRO_AC, "MSM8974PRO-AC") },
++	{ qcom_board_id(MSM8126) },
++	{ qcom_board_id(APQ8026) },
++	{ qcom_board_id(MSM8926) },
++	{ qcom_board_id(IPQ8062) },
++	{ qcom_board_id(IPQ8064) },
++	{ qcom_board_id(IPQ8066) },
++	{ qcom_board_id(IPQ8068) },
++	{ qcom_board_id(MSM8326) },
++	{ qcom_board_id(MSM8916) },
++	{ qcom_board_id(MSM8994) },
++	{ qcom_board_id_named(APQ8074PRO_AA, "APQ8074PRO-AA") },
++	{ qcom_board_id_named(APQ8074PRO_AB, "APQ8074PRO-AB") },
++	{ qcom_board_id_named(APQ8074PRO_AC, "APQ8074PRO-AC") },
++	{ qcom_board_id_named(MSM8274PRO_AA, "MSM8274PRO-AA") },
++	{ qcom_board_id_named(MSM8274PRO_AB, "MSM8274PRO-AB") },
++	{ qcom_board_id_named(MSM8274PRO_AC, "MSM8274PRO-AC") },
++	{ qcom_board_id_named(MSM8674PRO_AA, "MSM8674PRO-AA") },
++	{ qcom_board_id_named(MSM8674PRO_AB, "MSM8674PRO-AB") },
++	{ qcom_board_id_named(MSM8674PRO_AC, "MSM8674PRO-AC") },
++	{ qcom_board_id_named(MSM8974PRO_AA, "MSM8974PRO-AA") },
++	{ qcom_board_id_named(MSM8974PRO_AB, "MSM8974PRO-AB") },
++	{ qcom_board_id(APQ8028) },
++	{ qcom_board_id(MSM8128) },
++	{ qcom_board_id(MSM8228) },
++	{ qcom_board_id(MSM8528) },
++	{ qcom_board_id(MSM8628) },
++	{ qcom_board_id(MSM8928) },
++	{ qcom_board_id(MSM8510) },
++	{ qcom_board_id(MSM8512) },
++	{ qcom_board_id(MSM8936) },
++	{ qcom_board_id(MDM9640) },
++	{ qcom_board_id(MSM8939) },
++	{ qcom_board_id(APQ8036) },
++	{ qcom_board_id(APQ8039) },
++	{ qcom_board_id(MSM8236) },
++	{ qcom_board_id(MSM8636) },
++	{ qcom_board_id(MSM8909) },
++	{ qcom_board_id(MSM8996) },
++	{ qcom_board_id(APQ8016) },
++	{ qcom_board_id(MSM8216) },
++	{ qcom_board_id(MSM8116) },
++	{ qcom_board_id(MSM8616) },
++	{ qcom_board_id(MSM8992) },
++	{ qcom_board_id(APQ8092) },
++	{ qcom_board_id(APQ8094) },
++	{ qcom_board_id(MSM8209) },
++	{ qcom_board_id(MSM8208) },
++	{ qcom_board_id(MDM9209) },
++	{ qcom_board_id(MDM9309) },
++	{ qcom_board_id(MDM9609) },
++	{ qcom_board_id(MSM8239) },
++	{ qcom_board_id(MSM8952) },
++	{ qcom_board_id(APQ8009) },
++	{ qcom_board_id(MSM8956) },
++	{ qcom_board_id(MSM8929) },
++	{ qcom_board_id(MSM8629) },
++	{ qcom_board_id(MSM8229) },
++	{ qcom_board_id(APQ8029) },
++	{ qcom_board_id(APQ8056) },
++	{ qcom_board_id(MSM8609) },
++	{ qcom_board_id(APQ8076) },
++	{ qcom_board_id(MSM8976) },
++	{ qcom_board_id(IPQ8065) },
++	{ qcom_board_id(IPQ8069) },
++	{ qcom_board_id(MDM9650) },
++	{ qcom_board_id(MDM9655) },
++	{ qcom_board_id(MDM9250) },
++	{ qcom_board_id(MDM9255) },
++	{ qcom_board_id(MDM9350) },
++	{ qcom_board_id(APQ8052) },
++	{ qcom_board_id(MDM9607) },
++	{ qcom_board_id(APQ8096) },
++	{ qcom_board_id(MSM8998) },
++	{ qcom_board_id(MSM8953) },
++	{ qcom_board_id(MSM8937) },
++	{ qcom_board_id(APQ8037) },
++	{ qcom_board_id(MDM8207) },
++	{ qcom_board_id(MDM9207) },
++	{ qcom_board_id(MDM9307) },
++	{ qcom_board_id(MDM9628) },
++	{ qcom_board_id(MSM8909W) },
++	{ qcom_board_id(APQ8009W) },
++	{ qcom_board_id(MSM8996L) },
++	{ qcom_board_id(MSM8917) },
++	{ qcom_board_id(APQ8053) },
++	{ qcom_board_id(MSM8996SG) },
++	{ qcom_board_id(APQ8017) },
++	{ qcom_board_id(MSM8217) },
++	{ qcom_board_id(MSM8617) },
++	{ qcom_board_id(MSM8996AU) },
++	{ qcom_board_id(APQ8096AU) },
++	{ qcom_board_id(APQ8096SG) },
++	{ qcom_board_id(MSM8940) },
++	{ qcom_board_id(SDX201) },
++	{ qcom_board_id(SDM660) },
++	{ qcom_board_id(SDM630) },
++	{ qcom_board_id(APQ8098) },
++	{ qcom_board_id(MSM8920) },
++	{ qcom_board_id(SDM845) },
++	{ qcom_board_id(MDM9206) },
++	{ qcom_board_id(IPQ8074) },
++	{ qcom_board_id(SDA660) },
++	{ qcom_board_id(SDM658) },
++	{ qcom_board_id(SDA658) },
++	{ qcom_board_id(SDA630) },
++	{ qcom_board_id(MSM8905) },
++	{ qcom_board_id(SDX202) },
++	{ qcom_board_id(SDM670) },
++	{ qcom_board_id(SDM450) },
++	{ qcom_board_id(SM8150) },
++	{ qcom_board_id(SDA845) },
++	{ qcom_board_id(IPQ8072) },
++	{ qcom_board_id(IPQ8076) },
++	{ qcom_board_id(IPQ8078) },
++	{ qcom_board_id(SDM636) },
++	{ qcom_board_id(SDA636) },
++	{ qcom_board_id(SDM632) },
++	{ qcom_board_id(SDA632) },
++	{ qcom_board_id(SDA450) },
++	{ qcom_board_id(SDM439) },
++	{ qcom_board_id(SDM429) },
++	{ qcom_board_id(SM8250) },
++	{ qcom_board_id(SA8155) },
++	{ qcom_board_id(SDA439) },
++	{ qcom_board_id(SDA429) },
++	{ qcom_board_id(SM7150) },
++	{ qcom_board_id(SM7150P) },
++	{ qcom_board_id(IPQ8070) },
++	{ qcom_board_id(IPQ8071) },
++	{ qcom_board_id(QM215) },
++	{ qcom_board_id(IPQ8072A) },
++	{ qcom_board_id(IPQ8074A) },
++	{ qcom_board_id(IPQ8076A) },
++	{ qcom_board_id(IPQ8078A) },
++	{ qcom_board_id(SM6125) },
++	{ qcom_board_id(IPQ8070A) },
++	{ qcom_board_id(IPQ8071A) },
++	{ qcom_board_id(IPQ8172) },
++	{ qcom_board_id(IPQ8173) },
++	{ qcom_board_id(IPQ8174) },
++	{ qcom_board_id(IPQ6018) },
++	{ qcom_board_id(IPQ6028) },
++	{ qcom_board_id(SDM429W) },
++	{ qcom_board_id(SM4250) },
++	{ qcom_board_id(IPQ6000) },
++	{ qcom_board_id(IPQ6010) },
++	{ qcom_board_id(SC7180) },
++	{ qcom_board_id(SM6350) },
++	{ qcom_board_id(QCM2150) },
++	{ qcom_board_id(SDA429W) },
++	{ qcom_board_id(SM8350) },
++	{ qcom_board_id(QCM2290) },
++	{ qcom_board_id(SM7125) },
++	{ qcom_board_id(SM6115) },
++	{ qcom_board_id(IPQ5010) },
++	{ qcom_board_id(IPQ5018) },
++	{ qcom_board_id(IPQ5028) },
++	{ qcom_board_id(SC8280XP) },
++	{ qcom_board_id(IPQ6005) },
++	{ qcom_board_id(QRB5165) },
++	{ qcom_board_id(SM8450) },
++	{ qcom_board_id(SM7225) },
++	{ qcom_board_id(SA8295P) },
++	{ qcom_board_id(SA8540P) },
++	{ qcom_board_id(QCM4290) },
++	{ qcom_board_id(QCS4290) },
++	{ qcom_board_id(SM7325) },
++	{ qcom_board_id_named(SM8450_2, "SM8450") },
++	{ qcom_board_id_named(SM8450_3, "SM8450") },
++	{ qcom_board_id(SC7280) },
++	{ qcom_board_id(SC7180P) },
++	{ qcom_board_id(QCM6490) },
++	{ qcom_board_id(QCS6490) },
++	{ qcom_board_id(SM7325P) },
++	{ qcom_board_id(IPQ5000) },
++	{ qcom_board_id(IPQ0509) },
++	{ qcom_board_id(IPQ0518) },
++	{ qcom_board_id(SM7450) },
++	{ qcom_board_id(SM6375) },
++	{ qcom_board_id(IPQ9514) },
++	{ qcom_board_id(IPQ9550) },
++	{ qcom_board_id(IPQ9554) },
++	{ qcom_board_id(IPQ9570) },
++	{ qcom_board_id(IPQ9574) },
++	{ qcom_board_id(SM8550) },
++	{ qcom_board_id(IPQ5016) },
++	{ qcom_board_id(IPQ9510) },
++	{ qcom_board_id(QRB4210) },
++	{ qcom_board_id(QRB2210) },
++	{ qcom_board_id(SAR2130P) },
++	{ qcom_board_id(SM8475) },
++	{ qcom_board_id(SM8475P) },
++	{ qcom_board_id(SA8255P) },
++	{ qcom_board_id(SA8650P) },
++	{ qcom_board_id(SA8775P) },
++	{ qcom_board_id(QRU1000) },
++	{ qcom_board_id(SM8475_2) },
++	{ qcom_board_id(QDU1000) },
++	{ qcom_board_id(SM7450P) },
++	{ qcom_board_id(X1E80100) },
++	{ qcom_board_id(SM8650) },
++	{ qcom_board_id(SM4450) },
++	{ qcom_board_id(SAR1130P) },
++	{ qcom_board_id(QDU1010) },
++	{ qcom_board_id(QRU1032) },
++	{ qcom_board_id(QRU1052) },
++	{ qcom_board_id(QRU1062) },
++	{ qcom_board_id(IPQ5332) },
++	{ qcom_board_id(IPQ5322) },
++	{ qcom_board_id(IPQ5312) },
++	{ qcom_board_id(IPQ5302) },
++	{ qcom_board_id(QCS8550) },
++	{ qcom_board_id(QCM8550) },
++	{ qcom_board_id(SM8750)  },
++	{ qcom_board_id(IPQ5300) },
++	{ qcom_board_id(SM7635) },
++	{ qcom_board_id(SM6650) },
++	{ qcom_board_id(SM6650P) },
++	{ qcom_board_id(IPQ5321) },
++	{ qcom_board_id(IPQ5424) },
++	{ qcom_board_id(QCM6690) },
++	{ qcom_board_id(QCS6690) },
++	{ qcom_board_id(SM8850) },
++	{ qcom_board_id(IPQ5404) },
++	{ qcom_board_id(QCS9100) },
++	{ qcom_board_id(CQ8725S) },
++	{ qcom_board_id(QCS8300) },
++	{ qcom_board_id(QCS8275) },
++	{ qcom_board_id(QCS9075) },
++	{ qcom_board_id(QCS615) },
++	{ qcom_board_id(CQ7790M) },
++	{ qcom_board_id(CQ7790S) },
++	{ qcom_board_id(IPQ5200) },
++	{ qcom_board_id(IPQ5210) },
++	{ qcom_board_id(QCF2200) },
++	{ qcom_board_id(QCF3200) },
++	{ qcom_board_id(QCF3210) },
++};
++
++static const char *socinfo_machine(struct device *dev, unsigned int id)
++{
++	int idx;
++
++	for (idx = 0; idx < ARRAY_SIZE(soc_id); idx++) {
++		if (soc_id[idx].id == id)
++			return soc_id[idx].name;
++	}
++
++	return NULL;
++}
++
++#ifdef CONFIG_DEBUG_FS
++
++#define QCOM_OPEN(name, _func)						\
++static int qcom_open_##name(struct inode *inode, struct file *file)	\
++{									\
++	return single_open(file, _func, inode->i_private);		\
++}									\
++									\
++static const struct file_operations qcom_ ##name## _ops = {		\
++	.open = qcom_open_##name,					\
++	.read = seq_read,						\
++	.llseek = seq_lseek,						\
++	.release = single_release,					\
++}
++
++#define DEBUGFS_ADD(info, name)						\
++	debugfs_create_file(__stringify(name), 0444,			\
++			    qcom_socinfo->dbg_root,			\
++			    info, &qcom_ ##name## _ops)
++
++
++static int qcom_show_build_id(struct seq_file *seq, void *p)
++{
++	struct socinfo *socinfo = seq->private;
++
++	seq_printf(seq, "%s\n", socinfo->build_id);
++
++	return 0;
++}
++
++static int qcom_show_pmic_model(struct seq_file *seq, void *p)
++{
++	struct socinfo *socinfo = seq->private;
++	int model = SOCINFO_MINOR(le32_to_cpu(socinfo->pmic_model));
++
++	if (model < 0)
++		return -EINVAL;
++
++	if (model < ARRAY_SIZE(pmic_models) && pmic_models[model])
++		seq_printf(seq, "%s\n", pmic_models[model]);
++	else
++		seq_printf(seq, "unknown (%d)\n", model);
++
++	return 0;
++}
++
++static int qcom_show_pmic_model_array(struct seq_file *seq, void *p)
++{
++	struct socinfo *socinfo = seq->private;
++	unsigned int num_pmics = le32_to_cpu(socinfo->num_pmics);
++	unsigned int pmic_array_offset = le32_to_cpu(socinfo->pmic_array_offset);
++	int i;
++	void *ptr = socinfo;
++
++	ptr += pmic_array_offset;
++
++	/* No need for bounds checking, it happened at socinfo_debugfs_init */
++	for (i = 0; i < num_pmics; i++) {
++		unsigned int model = SOCINFO_MINOR(get_unaligned_le32(ptr + 2 * i * sizeof(u32)));
++		unsigned int die_rev = get_unaligned_le32(ptr + (2 * i + 1) * sizeof(u32));
++
++		if (model < ARRAY_SIZE(pmic_models) && pmic_models[model])
++			seq_printf(seq, "%s %u.%u\n", pmic_models[model],
++				   SOCINFO_MAJOR(die_rev),
++				   SOCINFO_MINOR(die_rev));
++		else
++			seq_printf(seq, "unknown (%d)\n", model);
++	}
++
++	return 0;
++}
++
++static int qcom_show_pmic_die_revision(struct seq_file *seq, void *p)
++{
++	struct socinfo *socinfo = seq->private;
++
++	seq_printf(seq, "%u.%u\n",
++		   SOCINFO_MAJOR(le32_to_cpu(socinfo->pmic_die_rev)),
++		   SOCINFO_MINOR(le32_to_cpu(socinfo->pmic_die_rev)));
++
++	return 0;
++}
++
++static int qcom_show_chip_id(struct seq_file *seq, void *p)
++{
++	struct socinfo *socinfo = seq->private;
++
++	seq_printf(seq, "%s\n", socinfo->chip_id);
++
++	return 0;
++}
++
++QCOM_OPEN(build_id, qcom_show_build_id);
++QCOM_OPEN(pmic_model, qcom_show_pmic_model);
++QCOM_OPEN(pmic_model_array, qcom_show_pmic_model_array);
++QCOM_OPEN(pmic_die_rev, qcom_show_pmic_die_revision);
++QCOM_OPEN(chip_id, qcom_show_chip_id);
++
++#define DEFINE_IMAGE_OPS(type)					\
++static int show_image_##type(struct seq_file *seq, void *p)		  \
++{								  \
++	struct smem_image_version *image_version = seq->private;  \
++	if (image_version->type[0] != '\0')			  \
++		seq_printf(seq, "%s\n", image_version->type);	  \
++	return 0;						  \
++}								  \
++static int open_image_##type(struct inode *inode, struct file *file)	  \
++{									  \
++	return single_open(file, show_image_##type, inode->i_private); \
++}									  \
++									  \
++static const struct file_operations qcom_image_##type##_ops = {	  \
++	.open = open_image_##type,					  \
++	.read = seq_read,						  \
++	.llseek = seq_lseek,						  \
++	.release = single_release,					  \
++}
++
++DEFINE_IMAGE_OPS(name);
++DEFINE_IMAGE_OPS(variant);
++DEFINE_IMAGE_OPS(oem);
++
++static void socinfo_debugfs_init(struct qcom_socinfo *qcom_socinfo,
++				 struct socinfo *info, size_t info_size)
++{
++	struct smem_image_version *versions;
++	struct dentry *dentry;
++	size_t size;
++	int i, j;
++	unsigned int num_pmics;
++	unsigned int pmic_array_offset;
++
++	qcom_socinfo->dbg_root = debugfs_create_dir("qcom_socinfo", NULL);
++
++	qcom_socinfo->info.fmt = __le32_to_cpu(info->fmt);
++
++	debugfs_create_x32("info_fmt", 0444, qcom_socinfo->dbg_root,
++			   &qcom_socinfo->info.fmt);
++
++	switch (qcom_socinfo->info.fmt) {
++	case SOCINFO_VERSION(0, 23):
++	case SOCINFO_VERSION(0, 22):
++	case SOCINFO_VERSION(0, 21):
++	case SOCINFO_VERSION(0, 20):
++		qcom_socinfo->info.raw_package_type = __le32_to_cpu(info->raw_package_type);
++		debugfs_create_u32("raw_package_type", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.raw_package_type);
++		fallthrough;
++	case SOCINFO_VERSION(0, 19):
++		qcom_socinfo->info.num_func_clusters = __le32_to_cpu(info->num_func_clusters);
++		qcom_socinfo->info.boot_cluster = __le32_to_cpu(info->boot_cluster);
++		qcom_socinfo->info.boot_core = __le32_to_cpu(info->boot_core);
++
++		debugfs_create_u32("num_func_clusters", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.num_func_clusters);
++		debugfs_create_u32("boot_cluster", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.boot_cluster);
++		debugfs_create_u32("boot_core", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.boot_core);
++		fallthrough;
++	case SOCINFO_VERSION(0, 18):
++	case SOCINFO_VERSION(0, 17):
++		qcom_socinfo->info.oem_variant = __le32_to_cpu(info->oem_variant);
++		debugfs_create_u32("oem_variant", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.oem_variant);
++		fallthrough;
++	case SOCINFO_VERSION(0, 16):
++		qcom_socinfo->info.feature_code = __le32_to_cpu(info->feature_code);
++		qcom_socinfo->info.pcode = __le32_to_cpu(info->pcode);
++
++		debugfs_create_u32("feature_code", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.feature_code);
++		debugfs_create_u32("pcode", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.pcode);
++		fallthrough;
++	case SOCINFO_VERSION(0, 15):
++		qcom_socinfo->info.nmodem_supported = __le32_to_cpu(info->nmodem_supported);
++
++		debugfs_create_u32("nmodem_supported", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.nmodem_supported);
++		fallthrough;
++	case SOCINFO_VERSION(0, 14):
++		qcom_socinfo->info.num_clusters = __le32_to_cpu(info->num_clusters);
++		qcom_socinfo->info.ncluster_array_offset = __le32_to_cpu(info->ncluster_array_offset);
++		qcom_socinfo->info.num_subset_parts = __le32_to_cpu(info->num_subset_parts);
++		qcom_socinfo->info.nsubset_parts_array_offset =
++			__le32_to_cpu(info->nsubset_parts_array_offset);
++
++		debugfs_create_u32("num_clusters", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.num_clusters);
++		debugfs_create_u32("ncluster_array_offset", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.ncluster_array_offset);
++		debugfs_create_u32("num_subset_parts", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.num_subset_parts);
++		debugfs_create_u32("nsubset_parts_array_offset", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.nsubset_parts_array_offset);
++		fallthrough;
++	case SOCINFO_VERSION(0, 13):
++		qcom_socinfo->info.nproduct_id = __le32_to_cpu(info->nproduct_id);
++
++		debugfs_create_u32("nproduct_id", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.nproduct_id);
++		DEBUGFS_ADD(info, chip_id);
++		fallthrough;
++	case SOCINFO_VERSION(0, 12):
++		qcom_socinfo->info.chip_family =
++			__le32_to_cpu(info->chip_family);
++		qcom_socinfo->info.raw_device_family =
++			__le32_to_cpu(info->raw_device_family);
++		qcom_socinfo->info.raw_device_num =
++			__le32_to_cpu(info->raw_device_num);
++
++		debugfs_create_x32("chip_family", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.chip_family);
++		debugfs_create_x32("raw_device_family", 0444,
++				   qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.raw_device_family);
++		debugfs_create_x32("raw_device_number", 0444,
++				   qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.raw_device_num);
++		fallthrough;
++	case SOCINFO_VERSION(0, 11):
++		num_pmics = le32_to_cpu(info->num_pmics);
++		pmic_array_offset = le32_to_cpu(info->pmic_array_offset);
++		if (pmic_array_offset + 2 * num_pmics * sizeof(u32) <= info_size)
++			DEBUGFS_ADD(info, pmic_model_array);
++		fallthrough;
++	case SOCINFO_VERSION(0, 10):
++	case SOCINFO_VERSION(0, 9):
++		qcom_socinfo->info.foundry_id = __le32_to_cpu(info->foundry_id);
++
++		debugfs_create_u32("foundry_id", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.foundry_id);
++		fallthrough;
++	case SOCINFO_VERSION(0, 8):
++	case SOCINFO_VERSION(0, 7):
++		DEBUGFS_ADD(info, pmic_model);
++		DEBUGFS_ADD(info, pmic_die_rev);
++		fallthrough;
++	case SOCINFO_VERSION(0, 6):
++		qcom_socinfo->info.hw_plat_subtype =
++			__le32_to_cpu(info->hw_plat_subtype);
++
++		debugfs_create_u32("hardware_platform_subtype", 0444,
++				   qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.hw_plat_subtype);
++		fallthrough;
++	case SOCINFO_VERSION(0, 5):
++		qcom_socinfo->info.accessory_chip =
++			__le32_to_cpu(info->accessory_chip);
++
++		debugfs_create_u32("accessory_chip", 0444,
++				   qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.accessory_chip);
++		fallthrough;
++	case SOCINFO_VERSION(0, 4):
++		qcom_socinfo->info.plat_ver = __le32_to_cpu(info->plat_ver);
++
++		debugfs_create_u32("platform_version", 0444,
++				   qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.plat_ver);
++		fallthrough;
++	case SOCINFO_VERSION(0, 3):
++		qcom_socinfo->info.hw_plat = __le32_to_cpu(info->hw_plat);
++
++		debugfs_create_u32("hardware_platform", 0444,
++				   qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.hw_plat);
++		fallthrough;
++	case SOCINFO_VERSION(0, 2):
++		qcom_socinfo->info.raw_ver  = __le32_to_cpu(info->raw_ver);
++
++		debugfs_create_u32("raw_version", 0444, qcom_socinfo->dbg_root,
++				   &qcom_socinfo->info.raw_ver);
++		fallthrough;
++	case SOCINFO_VERSION(0, 1):
++		DEBUGFS_ADD(info, build_id);
++		break;
++	}
++
++	for (i = 0, j = 0; i < ARRAY_SIZE(socinfo_image_names); i++, j++) {
++		if (!socinfo_image_names[i])
++			continue;
++
++		if (i == 0) {
++			versions = qcom_smem_get(QCOM_SMEM_HOST_ANY,
++						 SMEM_IMAGE_VERSION_TABLE,
++						 &size);
++		} else if (i == 32) {
++			versions = qcom_smem_get(QCOM_SMEM_HOST_ANY,
++						 SMEM_IMAGE_VERSION_TABLE_2,
++						 &size);
++			if (IS_ERR(versions))
++				break;
++
++			j = 0;
++		}
++
++		dentry = debugfs_create_dir(socinfo_image_names[i],
++					    qcom_socinfo->dbg_root);
++		debugfs_create_file("name", 0444, dentry, &versions[j],
++				    &qcom_image_name_ops);
++		debugfs_create_file("variant", 0444, dentry, &versions[j],
++				    &qcom_image_variant_ops);
++		debugfs_create_file("oem", 0444, dentry, &versions[j],
++				    &qcom_image_oem_ops);
++	}
++}
++
++static void socinfo_debugfs_exit(struct qcom_socinfo *qcom_socinfo)
++{
++	debugfs_remove_recursive(qcom_socinfo->dbg_root);
++}
++#else
++static void socinfo_debugfs_init(struct qcom_socinfo *qcom_socinfo,
++				 struct socinfo *info, size_t info_size)
++{
++}
++static void socinfo_debugfs_exit(struct qcom_socinfo *qcom_socinfo) {  }
++#endif /* CONFIG_DEBUG_FS */
++
++static int qcom_socinfo_probe(struct platform_device *pdev)
++{
++	struct qcom_socinfo *qs;
++	struct socinfo *info;
++	size_t item_size;
++
++	info = qcom_smem_get(QCOM_SMEM_HOST_ANY, SMEM_HW_SW_BUILD_ID,
++			      &item_size);
++	if (IS_ERR(info)) {
++		dev_err(&pdev->dev, "Couldn't find socinfo\n");
++		return PTR_ERR(info);
++	}
++
++	qs = devm_kzalloc(&pdev->dev, sizeof(*qs), GFP_KERNEL);
++	if (!qs)
++		return -ENOMEM;
++
++	qs->attr.family = "Snapdragon";
++	qs->attr.machine = socinfo_machine(&pdev->dev,
++					   le32_to_cpu(info->id));
++	qs->attr.soc_id = devm_kasprintf(&pdev->dev, GFP_KERNEL, "%u",
++					 le32_to_cpu(info->id));
++	qs->attr.revision = devm_kasprintf(&pdev->dev, GFP_KERNEL, "%u.%u",
++					   SOCINFO_MAJOR(le32_to_cpu(info->ver)),
++					   SOCINFO_MINOR(le32_to_cpu(info->ver)));
++	if (!qs->attr.soc_id || !qs->attr.revision)
++		return -ENOMEM;
++
++	if (offsetofend(struct socinfo, serial_num) <= item_size) {
++		qs->attr.serial_number = devm_kasprintf(&pdev->dev, GFP_KERNEL,
++							"%u",
++							le32_to_cpu(info->serial_num));
++		if (!qs->attr.serial_number)
++			return -ENOMEM;
++	}
++
++	qs->soc_dev = soc_device_register(&qs->attr);
++	if (IS_ERR(qs->soc_dev))
++		return PTR_ERR(qs->soc_dev);
++
++	socinfo_debugfs_init(qs, info, item_size);
++
++	/* Feed the soc specific unique data into entropy pool */
++	add_device_randomness(info, item_size);
++
++	platform_set_drvdata(pdev, qs);
++
++	return 0;
++}
++
++static void qcom_socinfo_remove(struct platform_device *pdev)
++{
++	struct qcom_socinfo *qs = platform_get_drvdata(pdev);
++
++	soc_device_unregister(qs->soc_dev);
++
++	socinfo_debugfs_exit(qs);
++}
++
++static struct platform_driver qcom_socinfo_driver = {
++	.probe = qcom_socinfo_probe,
++	.remove = qcom_socinfo_remove,
++	.driver  = {
++		.name = "qcom-socinfo",
++	},
++};
++
++module_platform_driver(qcom_socinfo_driver);
++
++MODULE_DESCRIPTION("Qualcomm SoCinfo driver");
++MODULE_LICENSE("GPL v2");
++MODULE_ALIAS("platform:qcom-socinfo");
+diff --git a/drivers/usb/typec/ucsi/ucsi.c.orig b/drivers/usb/typec/ucsi/ucsi.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/drivers/usb/typec/ucsi/ucsi.c.orig
+@@ -0,0 +1,2368 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * USB Type-C Connector System Software Interface driver
++ *
++ * Copyright (C) 2017, Intel Corporation
++ * Author: Heikki Krogerus <heikki.krogerus@linux.intel.com>
++ */
++
++#include <linux/completion.h>
++#include <linux/property.h>
++#include <linux/device.h>
++#include <linux/module.h>
++#include <linux/delay.h>
++#include <linux/slab.h>
++#include <linux/usb/typec_dp.h>
++#include <linux/usb/typec_tbt.h>
++
++#include "ucsi.h"
++#include "trace.h"
++
++/*
++ * UCSI_TIMEOUT_MS - PPM communication timeout
++ *
++ * Ideally we could use MIN_TIME_TO_RESPOND_WITH_BUSY (which is defined in UCSI
++ * specification) here as reference, but unfortunately we can't. It is very
++ * difficult to estimate the time it takes for the system to process the command
++ * before it is actually passed to the PPM.
++ */
++#define UCSI_TIMEOUT_MS		10000
++
++/*
++ * UCSI_SWAP_TIMEOUT_MS - Timeout for role swap requests
++ *
++ * 5 seconds is close to the time it takes for CapsCounter to reach 0, so even
++ * if the PPM does not generate Connector Change events before that with
++ * partners that do not support USB Power Delivery, this should still work.
++ */
++#define UCSI_SWAP_TIMEOUT_MS	5000
++
++void ucsi_notify_common(struct ucsi *ucsi, u32 cci)
++{
++	/* Ignore bogus data in CCI if busy indicator is set. */
++	if (cci & UCSI_CCI_BUSY)
++		return;
++
++	if (UCSI_CCI_CONNECTOR(cci)) {
++		if (!ucsi->cap.num_connectors ||
++		    UCSI_CCI_CONNECTOR(cci) <= ucsi->cap.num_connectors)
++			ucsi_connector_change(ucsi, UCSI_CCI_CONNECTOR(cci));
++		else
++			dev_err(ucsi->dev, "bogus connector number in CCI: %lu\n",
++				UCSI_CCI_CONNECTOR(cci));
++	}
++
++	if (cci & UCSI_CCI_ACK_COMPLETE &&
++	    test_and_clear_bit(ACK_PENDING, &ucsi->flags))
++		complete(&ucsi->complete);
++
++	if (cci & UCSI_CCI_COMMAND_COMPLETE &&
++	    test_and_clear_bit(COMMAND_PENDING, &ucsi->flags))
++		complete(&ucsi->complete);
++}
++EXPORT_SYMBOL_GPL(ucsi_notify_common);
++
++int ucsi_sync_control_common(struct ucsi *ucsi, u64 command, u32 *cci,
++			     void *data, size_t size)
++{
++	bool ack = UCSI_COMMAND(command) == UCSI_ACK_CC_CI;
++	int ret;
++
++	if (ack)
++		set_bit(ACK_PENDING, &ucsi->flags);
++	else
++		set_bit(COMMAND_PENDING, &ucsi->flags);
++
++	reinit_completion(&ucsi->complete);
++
++	ret = ucsi->ops->async_control(ucsi, command);
++	if (ret)
++		goto out_clear_bit;
++
++	if (!wait_for_completion_timeout(&ucsi->complete, 5 * HZ))
++		ret = -ETIMEDOUT;
++
++out_clear_bit:
++	if (ack)
++		clear_bit(ACK_PENDING, &ucsi->flags);
++	else
++		clear_bit(COMMAND_PENDING, &ucsi->flags);
++
++	if (!ret && cci)
++		ret = ucsi->ops->read_cci(ucsi, cci);
++
++	if (!ret && data &&
++	    (*cci & UCSI_CCI_COMMAND_COMPLETE))
++		ret = ucsi->ops->read_message_in(ucsi, data, size);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(ucsi_sync_control_common);
++
++static int ucsi_acknowledge(struct ucsi *ucsi, bool conn_ack)
++{
++	u64 ctrl;
++
++	ctrl = UCSI_ACK_CC_CI;
++	ctrl |= UCSI_ACK_COMMAND_COMPLETE;
++	if (conn_ack) {
++		clear_bit(EVENT_PENDING, &ucsi->flags);
++		ctrl |= UCSI_ACK_CONNECTOR_CHANGE;
++	}
++
++	return ucsi->ops->sync_control(ucsi, ctrl, NULL, NULL, 0);
++}
++
++static int ucsi_run_command(struct ucsi *ucsi, u64 command, u32 *cci,
++			    void *data, size_t size, bool conn_ack)
++{
++	int ret, err;
++
++	*cci = 0;
++
++	if (size > UCSI_MAX_DATA_LENGTH(ucsi))
++		return -EINVAL;
++
++	ret = ucsi->ops->sync_control(ucsi, command, cci, data, size);
++
++	if (*cci & UCSI_CCI_BUSY)
++		return ucsi_run_command(ucsi, UCSI_CANCEL, cci, NULL, 0, false) ?: -EBUSY;
++	if (ret)
++		return ret;
++
++	if (!(*cci & UCSI_CCI_COMMAND_COMPLETE))
++		return -EIO;
++
++	if (*cci & UCSI_CCI_NOT_SUPPORTED)
++		err = -EOPNOTSUPP;
++	else if (*cci & UCSI_CCI_ERROR)
++		err = -EIO;
++	else
++		err = 0;
++
++	/*
++	 * Don't ACK connection change if there was an error.
++	 */
++	ret = ucsi_acknowledge(ucsi, err ? false : conn_ack);
++	if (ret)
++		return ret;
++
++	return err ?: UCSI_CCI_LENGTH(*cci);
++}
++
++static int ucsi_read_error(struct ucsi *ucsi, u8 connector_num)
++{
++	u64 command;
++	u16 error;
++	u32 cci;
++	int ret;
++
++	command = UCSI_GET_ERROR_STATUS | UCSI_CONNECTOR_NUMBER(connector_num);
++	ret = ucsi_run_command(ucsi, command, &cci, &error, sizeof(error), false);
++	if (ret < 0)
++		return ret;
++
++	switch (error) {
++	case UCSI_ERROR_INCOMPATIBLE_PARTNER:
++		return -EOPNOTSUPP;
++	case UCSI_ERROR_CC_COMMUNICATION_ERR:
++		return -ECOMM;
++	case UCSI_ERROR_CONTRACT_NEGOTIATION_FAIL:
++		return -EPROTO;
++	case UCSI_ERROR_DEAD_BATTERY:
++		dev_warn(ucsi->dev, "Dead battery condition!\n");
++		return -EPERM;
++	case UCSI_ERROR_INVALID_CON_NUM:
++	case UCSI_ERROR_UNREGONIZED_CMD:
++	case UCSI_ERROR_INVALID_CMD_ARGUMENT:
++		dev_err(ucsi->dev, "possible UCSI driver bug %u\n", error);
++		return -EINVAL;
++	case UCSI_ERROR_OVERCURRENT:
++		dev_warn(ucsi->dev, "Overcurrent condition\n");
++		break;
++	case UCSI_ERROR_PARTNER_REJECTED_SWAP:
++		dev_warn(ucsi->dev, "Partner rejected swap\n");
++		break;
++	case UCSI_ERROR_HARD_RESET:
++		dev_warn(ucsi->dev, "Hard reset occurred\n");
++		break;
++	case UCSI_ERROR_PPM_POLICY_CONFLICT:
++		dev_warn(ucsi->dev, "PPM Policy conflict\n");
++		break;
++	case UCSI_ERROR_SWAP_REJECTED:
++		dev_warn(ucsi->dev, "Swap rejected\n");
++		break;
++	case UCSI_ERROR_REVERSE_CURRENT_PROTECTION:
++		dev_warn(ucsi->dev, "Reverse Current Protection detected\n");
++		break;
++	case UCSI_ERROR_SET_SINK_PATH_REJECTED:
++		dev_warn(ucsi->dev, "Set Sink Path rejected\n");
++		break;
++	case UCSI_ERROR_UNDEFINED:
++	default:
++		dev_err(ucsi->dev, "unknown error %u\n", error);
++		break;
++	}
++
++	return -EIO;
++}
++
++static int ucsi_send_command_common(struct ucsi *ucsi, u64 cmd,
++				    void *data, size_t size, bool conn_ack)
++{
++	u8 connector_num;
++	u32 cci;
++	int ret;
++
++	if (ucsi->version > UCSI_VERSION_1_2) {
++		switch (UCSI_COMMAND(cmd)) {
++		case UCSI_GET_ALTERNATE_MODES:
++			connector_num = UCSI_GET_ALTMODE_GET_CONNECTOR_NUMBER(cmd);
++			break;
++		case UCSI_PPM_RESET:
++		case UCSI_CANCEL:
++		case UCSI_ACK_CC_CI:
++		case UCSI_SET_NOTIFICATION_ENABLE:
++		case UCSI_GET_CAPABILITY:
++			connector_num = 0;
++			break;
++		default:
++			connector_num = UCSI_DEFAULT_GET_CONNECTOR_NUMBER(cmd);
++			break;
++		}
++	} else {
++		connector_num = 0;
++	}
++
++	mutex_lock(&ucsi->ppm_lock);
++
++	ret = ucsi_run_command(ucsi, cmd, &cci, data, size, conn_ack);
++
++	if (cci & UCSI_CCI_ERROR)
++		ret = ucsi_read_error(ucsi, connector_num);
++
++	trace_ucsi_run_command(cmd, ret);
++
++	mutex_unlock(&ucsi->ppm_lock);
++	return ret;
++}
++
++int ucsi_send_command(struct ucsi *ucsi, u64 command,
++		      void *data, size_t size)
++{
++	return ucsi_send_command_common(ucsi, command, data, size, false);
++}
++EXPORT_SYMBOL_GPL(ucsi_send_command);
++
++/* -------------------------------------------------------------------------- */
++
++struct ucsi_work {
++	struct delayed_work work;
++	struct list_head node;
++	unsigned long delay;
++	unsigned int count;
++	struct ucsi_connector *con;
++	int (*cb)(struct ucsi_connector *);
++};
++
++static void ucsi_poll_worker(struct work_struct *work)
++{
++	struct ucsi_work *uwork = container_of(work, struct ucsi_work, work.work);
++	struct ucsi_connector *con = uwork->con;
++	int ret;
++
++	mutex_lock(&con->lock);
++
++	if (!con->partner) {
++		list_del(&uwork->node);
++		mutex_unlock(&con->lock);
++		kfree(uwork);
++		return;
++	}
++
++	ret = uwork->cb(con);
++
++	if (uwork->count-- && (ret == -EBUSY || ret == -ETIMEDOUT)) {
++		queue_delayed_work(con->wq, &uwork->work, uwork->delay);
++	} else {
++		list_del(&uwork->node);
++		kfree(uwork);
++	}
++
++	mutex_unlock(&con->lock);
++}
++
++static int ucsi_partner_task(struct ucsi_connector *con,
++			     int (*cb)(struct ucsi_connector *),
++			     int retries, unsigned long delay)
++{
++	struct ucsi_work *uwork;
++
++	if (!con->partner)
++		return 0;
++
++	uwork = kzalloc_obj(*uwork);
++	if (!uwork)
++		return -ENOMEM;
++
++	INIT_DELAYED_WORK(&uwork->work, ucsi_poll_worker);
++	uwork->count = retries;
++	uwork->delay = delay;
++	uwork->con = con;
++	uwork->cb = cb;
++
++	list_add_tail(&uwork->node, &con->partner_tasks);
++	queue_delayed_work(con->wq, &uwork->work, delay);
++
++	return 0;
++}
++
++/* -------------------------------------------------------------------------- */
++
++void ucsi_altmode_update_active(struct ucsi_connector *con)
++{
++	const struct typec_altmode *altmode = NULL;
++	u64 command;
++	u16 svid = 0;
++	int ret;
++	u8 cur;
++	int i;
++
++	command = UCSI_GET_CURRENT_CAM | UCSI_CONNECTOR_NUMBER(con->num);
++	ret = ucsi_send_command(con->ucsi, command, &cur, sizeof(cur));
++	if (ret < 0) {
++		if (con->ucsi->version > 0x0100) {
++			dev_err(con->ucsi->dev,
++				"GET_CURRENT_CAM command failed\n");
++			return;
++		}
++		cur = 0xff;
++	}
++
++	if (cur < UCSI_MAX_ALTMODES)
++		altmode = typec_altmode_get_partner(con->port_altmode[cur]);
++
++	for (i = 0; con->partner_altmode[i]; i++)
++		typec_altmode_update_active(con->partner_altmode[i],
++					    con->partner_altmode[i] == altmode);
++
++	if (altmode)
++		svid = altmode->svid;
++	typec_altmode_state_update(con->partner, svid, 0);
++}
++
++static int ucsi_altmode_next_mode(struct typec_altmode **alt, u16 svid)
++{
++	u8 mode = 1;
++	int i;
++
++	for (i = 0; alt[i]; i++) {
++		if (i > MODE_DISCOVERY_MAX)
++			return -ERANGE;
++
++		if (alt[i]->svid == svid)
++			mode++;
++	}
++
++	return mode;
++}
++
++static int ucsi_next_altmode(struct typec_altmode **alt)
++{
++	int i = 0;
++
++	for (i = 0; i < UCSI_MAX_ALTMODES; i++)
++		if (!alt[i])
++			return i;
++
++	return -ENOENT;
++}
++
++static int ucsi_get_num_altmode(struct typec_altmode **alt)
++{
++	int i;
++
++	for (i = 0; i < UCSI_MAX_ALTMODES; i++)
++		if (!alt[i])
++			break;
++
++	return i;
++}
++
++static int ucsi_register_altmode(struct ucsi_connector *con,
++				 struct typec_altmode_desc *desc,
++				 u8 recipient)
++{
++	struct typec_altmode *alt;
++	bool override;
++	int ret;
++	int i;
++
++	override = !!(con->ucsi->cap.features & UCSI_CAP_ALT_MODE_OVERRIDE);
++
++	switch (recipient) {
++	case UCSI_RECIPIENT_CON:
++		i = ucsi_next_altmode(con->port_altmode);
++		if (i < 0) {
++			ret = i;
++			goto err;
++		}
++
++		ret = ucsi_altmode_next_mode(con->port_altmode, desc->svid);
++		if (ret < 0)
++			return ret;
++
++		desc->mode = ret;
++
++		switch (desc->svid) {
++		case USB_TYPEC_DP_SID:
++			alt = ucsi_register_displayport(con, override, i, desc);
++			break;
++		case USB_TYPEC_NVIDIA_VLINK_SID:
++			if (desc->vdo == USB_TYPEC_NVIDIA_VLINK_DBG_VDO)
++				alt = typec_port_register_altmode(con->port,
++								  desc);
++			else
++				alt = ucsi_register_displayport(con, override,
++								i, desc);
++			break;
++		case USB_TYPEC_TBT_SID:
++			alt = ucsi_register_thunderbolt(con, override, i, desc);
++			break;
++		default:
++			alt = typec_port_register_altmode(con->port, desc);
++			break;
++		}
++
++		if (IS_ERR(alt)) {
++			ret = PTR_ERR(alt);
++			goto err;
++		}
++
++		con->port_altmode[i] = alt;
++		break;
++	case UCSI_RECIPIENT_SOP:
++		i = ucsi_next_altmode(con->partner_altmode);
++		if (i < 0) {
++			ret = i;
++			goto err;
++		}
++
++		ret = ucsi_altmode_next_mode(con->partner_altmode, desc->svid);
++		if (ret < 0)
++			return ret;
++
++		desc->mode = ret;
++
++		alt = typec_partner_register_altmode(con->partner, desc);
++		if (IS_ERR(alt)) {
++			ret = PTR_ERR(alt);
++			goto err;
++		}
++
++		con->partner_altmode[i] = alt;
++		break;
++	case UCSI_RECIPIENT_SOP_P:
++		i = ucsi_next_altmode(con->plug_altmode);
++		if (i < 0) {
++			ret = i;
++			goto err;
++		}
++
++		ret = ucsi_altmode_next_mode(con->plug_altmode, desc->svid);
++		if (ret < 0)
++			return ret;
++
++		desc->mode = ret;
++
++		alt = typec_plug_register_altmode(con->plug, desc);
++		if (IS_ERR(alt)) {
++			ret = PTR_ERR(alt);
++			goto err;
++		}
++
++		con->plug_altmode[i] = alt;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	trace_ucsi_register_altmode(recipient, alt);
++
++	return 0;
++
++err:
++	dev_err(con->ucsi->dev, "failed to registers svid 0x%04x mode %d\n",
++		desc->svid, desc->mode);
++
++	return ret;
++}
++
++static void ucsi_dump_duplicate_altmode(struct ucsi_connector *con,
++					u8 recipient, u16 svid,
++					u32 existing_vdo, u32 new_vdo,
++					int offset)
++{
++	static const char * const recipient_names[] = {
++		[UCSI_RECIPIENT_CON]    = "port",
++		[UCSI_RECIPIENT_SOP]    = "partner",
++		[UCSI_RECIPIENT_SOP_P]  = "plug",
++		[UCSI_RECIPIENT_SOP_PP] = "cable plug prime",
++	};
++
++	dev_warn(con->ucsi->dev,
++		 "con%d: Firmware bug: duplicate %s altmode SVID 0x%04x at offset %d, ignoring but please contact the BIOS vendor to fix this issue.\n",
++		 con->num, recipient_names[recipient], svid, offset);
++
++	if (existing_vdo != new_vdo)
++		dev_warn(con->ucsi->dev,
++			 "con%d: VDO mismatch: 0x%08x vs 0x%08x\n",
++			 con->num, existing_vdo, new_vdo);
++}
++
++/* Count altmodes in @altmodes that advertise @svid. */
++static int ucsi_altmode_count_svid(struct typec_altmode **altmodes, u16 svid)
++{
++	int count = 0;
++	int k;
++
++	for (k = 0; k < UCSI_MAX_ALTMODES; k++) {
++		if (!altmodes[k])
++			break;
++		if (altmodes[k]->svid == svid)
++			count++;
++	}
++
++	return count;
++}
++
++/*
++ * Check if an altmode is a duplicate. Some firmware implementations
++ * incorrectly return the same altmode multiple times, causing sysfs errors.
++ * Returns true if the altmode should be skipped.
++ *
++ * The matching rules differ by recipient:
++ *
++ *   - UCSI_RECIPIENT_CON (port) and UCSI_RECIPIENT_SOP_P (plug):
++ *     Two altmodes with identical SVID and VDO are byte-for-byte duplicates
++ *     and the second has no observable function. Drop them.
++ *
++ *   - UCSI_RECIPIENT_SOP (partner):
++ *     The typec class binds each partner altmode to a port altmode of the
++ *     same SVID via altmode_match()/device_find_child(), which returns the
++ *     first port altmode with a matching SVID. If the partner advertises
++ *     more altmodes for SVID X than the port advertises, the surplus
++ *     partner altmode(s) collapse onto an already-paired port altmode and
++ *     trigger a "duplicate filename .../partner" sysfs error during
++ *     typec_altmode_create_links(). Use the port-side altmode count for
++ *     SVID X as the authoritative cap and reject any partner altmode that
++ *     would exceed it. This preserves legitimate multi-Mode partner
++ *     altmodes (e.g. vendor SVIDs that the port really does advertise
++ *     twice) while filtering the firmware-generated duplicates that have
++ *     no port counterpart.
++ */
++static bool ucsi_altmode_is_duplicate(struct ucsi_connector *con, u8 recipient,
++				      const struct ucsi_altmode *alt_batch, int batch_idx,
++				      u16 svid, u32 vdo, int offset)
++{
++	struct typec_altmode **altmodes;
++	int port_count, partner_count;
++	int k;
++
++	/* Check for duplicates within the current batch first */
++	for (k = 0; k < batch_idx; k++) {
++		if (alt_batch[k].svid == svid && alt_batch[k].mid == vdo) {
++			ucsi_dump_duplicate_altmode(con, recipient, svid,
++						    vdo, vdo, offset);
++			return true;
++		}
++	}
++
++	switch (recipient) {
++	case UCSI_RECIPIENT_SOP:
++		/*
++		 * Cap partner altmodes per SVID by the port-side count:
++		 * any further partner altmode for that SVID would alias an
++		 * already-paired port altmode and break typec sysfs.
++		 */
++		port_count = ucsi_altmode_count_svid(con->port_altmode, svid);
++		partner_count = ucsi_altmode_count_svid(con->partner_altmode,
++							svid);
++		if (port_count && partner_count >= port_count) {
++			ucsi_dump_duplicate_altmode(con, recipient, svid,
++						    con->partner_altmode[partner_count - 1]->vdo,
++						    vdo, offset);
++			return true;
++		}
++		return false;
++	case UCSI_RECIPIENT_CON:
++		altmodes = con->port_altmode;
++		break;
++	case UCSI_RECIPIENT_SOP_P:
++		altmodes = con->plug_altmode;
++		break;
++	default:
++		return false;
++	}
++
++	/* CON and SOP_P: drop only exact SVID+VDO duplicates. */
++	for (k = 0; k < UCSI_MAX_ALTMODES; k++) {
++		if (!altmodes[k])
++			break;
++
++		if (altmodes[k]->svid != svid || altmodes[k]->vdo != vdo)
++			continue;
++
++		ucsi_dump_duplicate_altmode(con, recipient, svid,
++					    altmodes[k]->vdo, vdo, offset);
++		return true;
++	}
++
++	return false;
++}
++
++static int
++ucsi_register_altmodes_nvidia(struct ucsi_connector *con, u8 recipient)
++{
++	int max_altmodes = UCSI_MAX_ALTMODES;
++	struct typec_altmode_desc desc;
++	struct ucsi_altmode alt;
++	struct ucsi_altmode orig[UCSI_MAX_ALTMODES];
++	struct ucsi_altmode updated[UCSI_MAX_ALTMODES];
++	struct ucsi *ucsi = con->ucsi;
++	bool multi_dp = false;
++	u64 command;
++	int ret;
++	int len;
++	int i;
++	int k = 0;
++
++	if (recipient == UCSI_RECIPIENT_CON)
++		max_altmodes = con->ucsi->cap.num_alt_modes;
++
++	memset(orig, 0, sizeof(orig));
++	memset(updated, 0, sizeof(updated));
++
++	/* First get all the alternate modes */
++	for (i = 0; i < max_altmodes; i++) {
++		memset(&alt, 0, sizeof(alt));
++		command = UCSI_GET_ALTERNATE_MODES;
++		command |= UCSI_GET_ALTMODE_RECIPIENT(recipient);
++		command |= UCSI_GET_ALTMODE_CONNECTOR_NUMBER(con->num);
++		command |= UCSI_GET_ALTMODE_OFFSET(i);
++		len = ucsi_send_command(con->ucsi, command, &alt, sizeof(alt));
++		/*
++		 * We are collecting all altmodes first and then registering.
++		 * Some type-C device will return zero length data beyond last
++		 * alternate modes. We should not return if length is zero.
++		 */
++		if (len < 0)
++			return len;
++
++		/* We got all altmodes, now break out and register them */
++		if (!len || !alt.svid)
++			break;
++
++		orig[k].mid = alt.mid;
++		orig[k].svid = alt.svid;
++		k++;
++	}
++	/*
++	 * Update the original altmode table as some ppms may report
++	 * multiple DP altmodes.
++	 */
++	multi_dp = ucsi->ops->update_altmodes(ucsi, recipient, orig, updated);
++
++	/* now register altmodes */
++	for (i = 0; i < max_altmodes; i++) {
++		struct ucsi_altmode *altmode_array = multi_dp ? updated : orig;
++
++		if (!altmode_array[i].svid)
++			return 0;
++
++		/*
++		 * Check for duplicates in current array and already
++		 * registered altmodes. Skip if duplicate found.
++		 */
++		if (ucsi_altmode_is_duplicate(con, recipient, altmode_array, i,
++					      altmode_array[i].svid,
++					      altmode_array[i].mid, i))
++			continue;
++
++		memset(&desc, 0, sizeof(desc));
++		desc.svid = altmode_array[i].svid;
++		desc.vdo = altmode_array[i].mid;
++		desc.roles = TYPEC_PORT_DRD;
++
++		ret = ucsi_register_altmode(con, &desc, recipient);
++		if (ret)
++			return ret;
++	}
++
++	return 0;
++}
++
++static int ucsi_register_altmodes(struct ucsi_connector *con, u8 recipient)
++{
++	int max_altmodes = UCSI_MAX_ALTMODES;
++	struct typec_altmode_desc desc;
++	struct ucsi_altmode alt[2];
++	u64 command;
++	int num;
++	int ret;
++	int len;
++	int j;
++	int i;
++
++	if (!(con->ucsi->cap.features & UCSI_CAP_ALT_MODE_DETAILS))
++		return 0;
++
++	if (recipient == UCSI_RECIPIENT_SOP && con->partner_altmode[0])
++		return 0;
++
++	if (con->ucsi->ops->update_altmodes)
++		return ucsi_register_altmodes_nvidia(con, recipient);
++
++	if (recipient == UCSI_RECIPIENT_CON)
++		max_altmodes = con->ucsi->cap.num_alt_modes;
++
++	for (i = 0; i < max_altmodes;) {
++		memset(alt, 0, sizeof(alt));
++		command = UCSI_GET_ALTERNATE_MODES;
++		command |= UCSI_GET_ALTMODE_RECIPIENT(recipient);
++		command |= UCSI_GET_ALTMODE_CONNECTOR_NUMBER(con->num);
++		command |= UCSI_GET_ALTMODE_OFFSET(i);
++		len = ucsi_send_command(con->ucsi, command, alt, sizeof(alt));
++		if (len == -EBUSY)
++			continue;
++		if (len <= 0)
++			return len;
++
++		/*
++		 * This code is requesting one alt mode at a time, but some PPMs
++		 * may still return two. If that happens both alt modes need be
++		 * registered and the offset for the next alt mode has to be
++		 * incremented.
++		 */
++		num = len / sizeof(alt[0]);
++		i += num;
++
++		for (j = 0; j < num; j++) {
++			if (!alt[j].svid)
++				return 0;
++
++			/*
++			 * Check for duplicates in current batch and already
++			 * registered altmodes. Skip if duplicate found.
++			 */
++			if (ucsi_altmode_is_duplicate(con, recipient, alt, j,
++						      alt[j].svid, alt[j].mid,
++						      i - num + j))
++				continue;
++
++			memset(&desc, 0, sizeof(desc));
++			desc.vdo = alt[j].mid;
++			desc.svid = alt[j].svid;
++			desc.roles = TYPEC_PORT_DRD;
++			desc.mode_selection = con->ucsi->ops->add_partner_altmodes &&
++					!con->typec_cap.no_mode_control;
++
++			ret = ucsi_register_altmode(con, &desc, recipient);
++			if (ret)
++				return ret;
++		}
++	}
++
++	return 0;
++}
++
++static void ucsi_unregister_altmodes(struct ucsi_connector *con, u8 recipient)
++{
++	const struct typec_altmode *pdev;
++	struct typec_altmode **adev;
++	int i = 0;
++
++	switch (recipient) {
++	case UCSI_RECIPIENT_CON:
++		adev = con->port_altmode;
++		break;
++	case UCSI_RECIPIENT_SOP:
++		adev = con->partner_altmode;
++		break;
++	case UCSI_RECIPIENT_SOP_P:
++		adev = con->plug_altmode;
++		break;
++	default:
++		return;
++	}
++
++	while (adev[i]) {
++		if (recipient == UCSI_RECIPIENT_SOP) {
++			pdev = typec_altmode_get_partner(adev[i]);
++
++			if (adev[i]->svid == USB_TYPEC_DP_SID ||
++			    (adev[i]->svid == USB_TYPEC_NVIDIA_VLINK_SID &&
++			     adev[i]->vdo != USB_TYPEC_NVIDIA_VLINK_DBG_VDO))
++				ucsi_displayport_remove_partner((void *)pdev);
++			else if (adev[i]->svid == USB_TYPEC_TBT_SID)
++				ucsi_thunderbolt_remove_partner((void *)pdev);
++		}
++		typec_unregister_altmode(adev[i]);
++		adev[i++] = NULL;
++	}
++}
++
++static int ucsi_get_connector_status(struct ucsi_connector *con, bool conn_ack)
++{
++	u64 command = UCSI_GET_CONNECTOR_STATUS | UCSI_CONNECTOR_NUMBER(con->num);
++	size_t size = min(sizeof(con->status),
++			  UCSI_MAX_DATA_LENGTH(con->ucsi));
++	int ret;
++
++	ret = ucsi_send_command_common(con->ucsi, command, &con->status, size, conn_ack);
++
++	return ret < 0 ? ret : 0;
++}
++
++static int ucsi_read_pdos(struct ucsi_connector *con,
++			  enum typec_role role, int is_partner,
++			  u32 *pdos, int offset, int num_pdos)
++{
++	struct ucsi *ucsi = con->ucsi;
++	u64 command;
++	int ret;
++
++	if (is_partner &&
++	    ucsi->quirks & UCSI_NO_PARTNER_PDOS &&
++	    (UCSI_CONSTAT(con, PWR_DIR) || !is_source(role)))
++		return 0;
++
++	command = UCSI_COMMAND(UCSI_GET_PDOS) | UCSI_CONNECTOR_NUMBER(con->num);
++	command |= UCSI_GET_PDOS_PARTNER_PDO(is_partner);
++	command |= UCSI_GET_PDOS_PDO_OFFSET(offset);
++	command |= UCSI_GET_PDOS_NUM_PDOS(num_pdos - 1);
++	command |= is_source(role) ? UCSI_GET_PDOS_SRC_PDOS : 0;
++	ret = ucsi_send_command(ucsi, command, pdos + offset,
++				num_pdos * sizeof(u32));
++	if (ret < 0 && ret != -ETIMEDOUT)
++		dev_err(ucsi->dev, "UCSI_GET_PDOS failed (%d)\n", ret);
++
++	return ret;
++}
++
++static int ucsi_get_pdos(struct ucsi_connector *con, enum typec_role role,
++			 int is_partner, u32 *pdos)
++{
++	struct ucsi *ucsi = con->ucsi;
++	u8 num_pdos;
++	int ret;
++
++	if (!(ucsi->cap.features & UCSI_CAP_PDO_DETAILS))
++		return 0;
++
++	/* UCSI max payload means only getting at most 4 PDOs at a time */
++	ret = ucsi_read_pdos(con, role, is_partner, pdos, 0, UCSI_MAX_PDOS);
++	if (ret < 0)
++		return ret;
++
++	num_pdos = ret / sizeof(u32); /* number of bytes to 32-bit PDOs */
++	if (num_pdos < UCSI_MAX_PDOS)
++		return num_pdos;
++
++	/* get the remaining PDOs, if any */
++	ret = ucsi_read_pdos(con, role, is_partner, pdos, UCSI_MAX_PDOS,
++			     PDO_MAX_OBJECTS - UCSI_MAX_PDOS);
++	if (ret < 0)
++		return ret;
++
++	return ret / sizeof(u32) + num_pdos;
++}
++
++static int ucsi_get_src_pdos(struct ucsi_connector *con)
++{
++	int ret;
++
++	ret = ucsi_get_pdos(con, TYPEC_SOURCE, 1, con->src_pdos);
++	if (ret < 0)
++		return ret;
++
++	con->num_pdos = ret;
++
++	ucsi_port_psy_changed(con);
++
++	return ret;
++}
++
++static struct usb_power_delivery_capabilities *ucsi_get_pd_caps(struct ucsi_connector *con,
++								enum typec_role role,
++								bool is_partner)
++{
++	struct usb_power_delivery_capabilities_desc pd_caps;
++	int ret;
++
++	ret = ucsi_get_pdos(con, role, is_partner, pd_caps.pdo);
++	if (ret <= 0)
++		return ERR_PTR(ret);
++
++	if (ret < PDO_MAX_OBJECTS)
++		pd_caps.pdo[ret] = 0;
++
++	pd_caps.role = role;
++
++	return usb_power_delivery_register_capabilities(is_partner ? con->partner_pd : con->pd,
++							&pd_caps);
++}
++
++static int ucsi_get_pd_message(struct ucsi_connector *con, u8 recipient,
++			       size_t bytes, void *data, u8 type)
++{
++	size_t len = min(bytes, UCSI_MAX_DATA_LENGTH(con->ucsi));
++	u64 command;
++	u8 offset;
++	int ret;
++
++	for (offset = 0; offset < bytes; offset += len) {
++		len = min(len, bytes - offset);
++
++		command = UCSI_COMMAND(UCSI_GET_PD_MESSAGE) | UCSI_CONNECTOR_NUMBER(con->num);
++		command |= UCSI_GET_PD_MESSAGE_RECIPIENT(recipient);
++		command |= UCSI_GET_PD_MESSAGE_OFFSET(offset);
++		command |= UCSI_GET_PD_MESSAGE_BYTES(len);
++		command |= UCSI_GET_PD_MESSAGE_TYPE(type);
++
++		ret = ucsi_send_command(con->ucsi, command, data + offset, len);
++		if (ret < 0)
++			return ret;
++	}
++
++	return 0;
++}
++
++static int ucsi_get_partner_identity(struct ucsi_connector *con)
++{
++	u32 vdo[7] = {};
++	int ret;
++
++	ret = ucsi_get_pd_message(con, UCSI_RECIPIENT_SOP, sizeof(vdo), vdo,
++				  UCSI_GET_PD_MESSAGE_TYPE_IDENTITY);
++	if (ret < 0)
++		return ret;
++
++	/* VDM Header is not part of struct usb_pd_identity, so dropping it. */
++	con->partner_identity = *(struct usb_pd_identity *)&vdo[1];
++
++	ret = typec_partner_set_identity(con->partner);
++	if (ret < 0)
++		dev_err(con->ucsi->dev, "Failed to set partner identity (%d)\n", ret);
++
++	return ret;
++}
++
++static int ucsi_get_cable_identity(struct ucsi_connector *con)
++{
++	u32 vdo[7] = {};
++	int ret;
++
++	ret = ucsi_get_pd_message(con, UCSI_RECIPIENT_SOP_P, sizeof(vdo), vdo,
++				  UCSI_GET_PD_MESSAGE_TYPE_IDENTITY);
++	if (ret < 0)
++		return ret;
++
++	con->cable_identity = *(struct usb_pd_identity *)&vdo[1];
++
++	ret = typec_cable_set_identity(con->cable);
++	if (ret < 0)
++		dev_err(con->ucsi->dev, "Failed to set cable identity (%d)\n", ret);
++
++	return ret;
++}
++
++static int ucsi_check_altmodes(struct ucsi_connector *con)
++{
++	int ret, num_partner_am;
++
++	ret = ucsi_register_altmodes(con, UCSI_RECIPIENT_SOP);
++	if (ret && ret != -ETIMEDOUT)
++		dev_err(con->ucsi->dev,
++			"con%d: failed to register partner alt modes (%d)\n",
++			con->num, ret);
++
++	/* Ignoring the errors in this case. */
++	if (con->partner_altmode[0]) {
++		num_partner_am = ucsi_get_num_altmode(con->partner_altmode);
++		typec_partner_set_num_altmodes(con->partner, num_partner_am);
++		if (con->ucsi->ops->add_partner_altmodes)
++			con->ucsi->ops->add_partner_altmodes(con);
++		ucsi_altmode_update_active(con);
++		return 0;
++	} else {
++		typec_partner_set_num_altmodes(con->partner, 0);
++	}
++
++	return ret;
++}
++
++static void ucsi_register_device_pdos(struct ucsi_connector *con)
++{
++	struct ucsi *ucsi = con->ucsi;
++	struct usb_power_delivery_desc desc = { ucsi->cap.pd_version };
++	struct usb_power_delivery_capabilities *pd_cap;
++
++	if (con->pd)
++		return;
++
++	con->pd = usb_power_delivery_register(ucsi->dev, &desc);
++
++	pd_cap = ucsi_get_pd_caps(con, TYPEC_SOURCE, false);
++	if (!IS_ERR(pd_cap))
++		con->port_source_caps = pd_cap;
++
++	pd_cap = ucsi_get_pd_caps(con, TYPEC_SINK, false);
++	if (!IS_ERR(pd_cap))
++		con->port_sink_caps = pd_cap;
++
++	typec_port_set_usb_power_delivery(con->port, con->pd);
++}
++
++static int ucsi_register_partner_pdos(struct ucsi_connector *con)
++{
++	struct usb_power_delivery_desc desc = { con->ucsi->cap.pd_version };
++	struct usb_power_delivery_capabilities *cap;
++
++	if (con->partner_pd)
++		return 0;
++
++	con->partner_pd = typec_partner_usb_power_delivery_register(con->partner, &desc);
++	if (IS_ERR(con->partner_pd))
++		return PTR_ERR(con->partner_pd);
++
++	cap = ucsi_get_pd_caps(con, TYPEC_SOURCE, true);
++	if (IS_ERR(cap))
++	    return PTR_ERR(cap);
++
++	con->partner_source_caps = cap;
++
++	cap = ucsi_get_pd_caps(con, TYPEC_SINK, true);
++	if (IS_ERR(cap))
++	    return PTR_ERR(cap);
++
++	con->partner_sink_caps = cap;
++
++	return typec_partner_set_usb_power_delivery(con->partner, con->partner_pd);
++}
++
++static void ucsi_unregister_partner_pdos(struct ucsi_connector *con)
++{
++	usb_power_delivery_unregister_capabilities(con->partner_sink_caps);
++	con->partner_sink_caps = NULL;
++	usb_power_delivery_unregister_capabilities(con->partner_source_caps);
++	con->partner_source_caps = NULL;
++	usb_power_delivery_unregister(con->partner_pd);
++	con->partner_pd = NULL;
++}
++
++static int ucsi_register_plug(struct ucsi_connector *con)
++{
++	struct typec_plug *plug;
++	struct typec_plug_desc desc = {.index = TYPEC_PLUG_SOP_P};
++
++	plug = typec_register_plug(con->cable, &desc);
++	if (IS_ERR(plug)) {
++		dev_err(con->ucsi->dev,
++			"con%d: failed to register plug (%ld)\n", con->num,
++			PTR_ERR(plug));
++		return PTR_ERR(plug);
++	}
++
++	con->plug = plug;
++	return 0;
++}
++
++static void ucsi_unregister_plug(struct ucsi_connector *con)
++{
++	if (!con->plug)
++		return;
++
++	ucsi_unregister_altmodes(con, UCSI_RECIPIENT_SOP_P);
++	typec_unregister_plug(con->plug);
++	con->plug = NULL;
++}
++
++static int ucsi_register_cable(struct ucsi_connector *con)
++{
++	struct ucsi_cable_property cable_prop;
++	struct typec_cable *cable;
++	struct typec_cable_desc desc = {};
++	u64 command;
++	int ret;
++
++	command = UCSI_GET_CABLE_PROPERTY | UCSI_CONNECTOR_NUMBER(con->num);
++	ret = ucsi_send_command(con->ucsi, command, &cable_prop, sizeof(cable_prop));
++	if (ret < 0) {
++		dev_err(con->ucsi->dev, "GET_CABLE_PROPERTY failed (%d)\n", ret);
++		return ret;
++	}
++
++	switch (UCSI_CABLE_PROP_FLAG_PLUG_TYPE(cable_prop.flags)) {
++	case UCSI_CABLE_PROPERTY_PLUG_TYPE_A:
++		desc.type = USB_PLUG_TYPE_A;
++		break;
++	case UCSI_CABLE_PROPERTY_PLUG_TYPE_B:
++		desc.type = USB_PLUG_TYPE_B;
++		break;
++	case UCSI_CABLE_PROPERTY_PLUG_TYPE_C:
++		desc.type = USB_PLUG_TYPE_C;
++		break;
++	default:
++		desc.type = USB_PLUG_NONE;
++		break;
++	}
++
++	if (con->ucsi->cap.features & UCSI_CAP_GET_PD_MESSAGE)
++		desc.identity = &con->cable_identity;
++	desc.active = !!(UCSI_CABLE_PROP_FLAG_ACTIVE_CABLE & cable_prop.flags);
++
++	if (con->ucsi->version >= UCSI_VERSION_2_1)
++		desc.pd_revision = UCSI_CABLE_PROP_FLAG_PD_MAJOR_REV_AS_BCD(cable_prop.flags);
++
++	cable = typec_register_cable(con->port, &desc);
++	if (IS_ERR(cable)) {
++		dev_err(con->ucsi->dev,
++			"con%d: failed to register cable (%ld)\n", con->num,
++			PTR_ERR(cable));
++		return PTR_ERR(cable);
++	}
++
++	con->cable = cable;
++	return 0;
++}
++
++static void ucsi_unregister_cable(struct ucsi_connector *con)
++{
++	if (!con->cable)
++		return;
++
++	ucsi_unregister_plug(con);
++	typec_unregister_cable(con->cable);
++	memset(&con->cable_identity, 0, sizeof(con->cable_identity));
++	con->cable = NULL;
++}
++
++static int ucsi_check_connector_capability(struct ucsi_connector *con)
++{
++	u64 pd_revision;
++	u64 command;
++	int ret;
++
++	if (!con->partner || con->ucsi->version < UCSI_VERSION_2_1)
++		return 0;
++
++	command = UCSI_GET_CONNECTOR_CAPABILITY | UCSI_CONNECTOR_NUMBER(con->num);
++	ret = ucsi_send_command(con->ucsi, command, &con->cap, sizeof(con->cap));
++	if (ret < 0) {
++		dev_err(con->ucsi->dev, "GET_CONNECTOR_CAPABILITY failed (%d)\n", ret);
++		return ret;
++	}
++
++	pd_revision = UCSI_CONCAP(con, PARTNER_PD_REVISION_V2_1);
++	typec_partner_set_pd_revision(con->partner, UCSI_SPEC_REVISION_TO_BCD(pd_revision));
++
++	return ret;
++}
++
++static void ucsi_orientation(struct ucsi_connector *con)
++{
++	if (con->ucsi->version < UCSI_VERSION_2_0)
++		return;
++
++	if (!UCSI_CONSTAT(con, CONNECTED)) {
++		typec_set_orientation(con->port, TYPEC_ORIENTATION_NONE);
++		return;
++	}
++
++	switch (UCSI_CONSTAT(con, ORIENTATION)) {
++	case UCSI_CONSTAT_ORIENTATION_NORMAL:
++		typec_set_orientation(con->port, TYPEC_ORIENTATION_NORMAL);
++		break;
++	case UCSI_CONSTAT_ORIENTATION_REVERSE:
++		typec_set_orientation(con->port, TYPEC_ORIENTATION_REVERSE);
++		break;
++	default:
++		break;
++	}
++}
++
++static void ucsi_pwr_opmode_change(struct ucsi_connector *con)
++{
++	switch (UCSI_CONSTAT(con, PWR_OPMODE)) {
++	case UCSI_CONSTAT_PWR_OPMODE_PD:
++		con->rdo = UCSI_CONSTAT(con, RDO);
++		typec_set_pwr_opmode(con->port, TYPEC_PWR_MODE_PD);
++		ucsi_partner_task(con, ucsi_get_src_pdos, 30, 0);
++		ucsi_partner_task(con, ucsi_check_altmodes, 30, HZ);
++		ucsi_partner_task(con, ucsi_register_partner_pdos, 1, HZ);
++		ucsi_partner_task(con, ucsi_check_connector_capability, 1, HZ);
++		break;
++	case UCSI_CONSTAT_PWR_OPMODE_TYPEC1_5:
++		con->rdo = 0;
++		typec_set_pwr_opmode(con->port, TYPEC_PWR_MODE_1_5A);
++		ucsi_port_psy_changed(con);
++		break;
++	case UCSI_CONSTAT_PWR_OPMODE_TYPEC3_0:
++		con->rdo = 0;
++		typec_set_pwr_opmode(con->port, TYPEC_PWR_MODE_3_0A);
++		ucsi_port_psy_changed(con);
++		break;
++	default:
++		con->rdo = 0;
++		typec_set_pwr_opmode(con->port, TYPEC_PWR_MODE_USB);
++		ucsi_port_psy_changed(con);
++		break;
++	}
++}
++
++static int ucsi_register_partner(struct ucsi_connector *con)
++{
++	u8 pwr_opmode = UCSI_CONSTAT(con, PWR_OPMODE);
++	struct typec_partner_desc desc;
++	struct typec_partner *partner;
++
++	if (con->partner)
++		return 0;
++
++	memset(&desc, 0, sizeof(desc));
++
++	switch (UCSI_CONSTAT(con, PARTNER_TYPE)) {
++	case UCSI_CONSTAT_PARTNER_TYPE_DEBUG:
++		desc.accessory = TYPEC_ACCESSORY_DEBUG;
++		break;
++	case UCSI_CONSTAT_PARTNER_TYPE_AUDIO:
++		desc.accessory = TYPEC_ACCESSORY_AUDIO;
++		break;
++	default:
++		break;
++	}
++
++	if (pwr_opmode == UCSI_CONSTAT_PWR_OPMODE_PD)
++		ucsi_register_device_pdos(con);
++
++	if (con->ucsi->cap.features & UCSI_CAP_GET_PD_MESSAGE)
++		desc.identity = &con->partner_identity;
++	desc.usb_pd = pwr_opmode == UCSI_CONSTAT_PWR_OPMODE_PD;
++
++	if (con->ucsi->version >= UCSI_VERSION_2_1) {
++		u64 pd_revision = UCSI_CONCAP(con, PARTNER_PD_REVISION_V2_1);
++		desc.pd_revision = UCSI_SPEC_REVISION_TO_BCD(pd_revision);
++	}
++
++	partner = typec_register_partner(con->port, &desc);
++	if (IS_ERR(partner)) {
++		dev_err(con->ucsi->dev,
++			"con%d: failed to register partner (%ld)\n", con->num,
++			PTR_ERR(partner));
++		return PTR_ERR(partner);
++	}
++
++	con->partner = partner;
++
++	if (con->ucsi->version >= UCSI_VERSION_3_0 &&
++	    UCSI_CONSTAT(con, PARTNER_FLAG_USB4_GEN4))
++		typec_partner_set_usb_mode(partner, USB_MODE_USB4);
++	else if (con->ucsi->version >= UCSI_VERSION_2_0 &&
++		 UCSI_CONSTAT(con, PARTNER_FLAG_USB4_GEN3))
++		typec_partner_set_usb_mode(partner, USB_MODE_USB4);
++
++	return 0;
++}
++
++static void ucsi_unregister_partner(struct ucsi_connector *con)
++{
++	if (!con->partner)
++		return;
++
++	typec_set_mode(con->port, TYPEC_STATE_SAFE);
++	if (con->ucsi->ops->remove_partner_altmodes)
++		con->ucsi->ops->remove_partner_altmodes(con);
++
++	typec_partner_set_usb_power_delivery(con->partner, NULL);
++	ucsi_unregister_partner_pdos(con);
++	ucsi_unregister_altmodes(con, UCSI_RECIPIENT_SOP);
++	ucsi_unregister_cable(con);
++	typec_unregister_partner(con->partner);
++	memset(&con->partner_identity, 0, sizeof(con->partner_identity));
++	con->partner = NULL;
++}
++
++static void ucsi_partner_change(struct ucsi_connector *con)
++{
++	enum usb_role u_role = USB_ROLE_NONE;
++	int ret;
++
++	switch (UCSI_CONSTAT(con, PARTNER_TYPE)) {
++	case UCSI_CONSTAT_PARTNER_TYPE_UFP:
++	case UCSI_CONSTAT_PARTNER_TYPE_CABLE_AND_UFP:
++		u_role = USB_ROLE_HOST;
++		fallthrough;
++	case UCSI_CONSTAT_PARTNER_TYPE_CABLE:
++		typec_set_data_role(con->port, TYPEC_HOST);
++		break;
++	case UCSI_CONSTAT_PARTNER_TYPE_DFP:
++		u_role = USB_ROLE_DEVICE;
++		typec_set_data_role(con->port, TYPEC_DEVICE);
++		break;
++	default:
++		break;
++	}
++
++	if (UCSI_CONSTAT(con, CONNECTED)) {
++		switch (UCSI_CONSTAT(con, PARTNER_TYPE)) {
++		case UCSI_CONSTAT_PARTNER_TYPE_DEBUG:
++			typec_set_mode(con->port, TYPEC_MODE_DEBUG);
++			break;
++		case UCSI_CONSTAT_PARTNER_TYPE_AUDIO:
++			typec_set_mode(con->port, TYPEC_MODE_AUDIO);
++			break;
++		default:
++			if (UCSI_CONSTAT(con, PARTNER_FLAG_USB))
++				typec_set_mode(con->port, TYPEC_STATE_USB);
++		}
++
++		if (((con->ucsi->version >= UCSI_VERSION_3_0 &&
++		    UCSI_CONSTAT(con, PARTNER_FLAG_USB4_GEN4)) ||
++		    (con->ucsi->version >= UCSI_VERSION_2_0 &&
++		    UCSI_CONSTAT(con, PARTNER_FLAG_USB4_GEN3))) && con->partner)
++			typec_partner_set_usb_mode(con->partner, USB_MODE_USB4);
++	}
++
++	if ((!UCSI_CONSTAT(con, PARTNER_FLAG_USB)) &&
++	    ((con->ucsi->quirks & UCSI_USB4_IMPLIES_USB) &&
++	     (!(UCSI_CONSTAT(con, PARTNER_FLAG_USB4_GEN3) ||
++		UCSI_CONSTAT(con, PARTNER_FLAG_USB4_GEN4)))))
++		u_role = USB_ROLE_NONE;
++
++	ret = usb_role_switch_set_role(con->usb_role_sw, u_role);
++	if (ret)
++		dev_err(con->ucsi->dev, "con:%d: failed to set usb role:%d\n",
++			con->num, u_role);
++}
++
++static int ucsi_check_connection(struct ucsi_connector *con)
++{
++	u8 prev_state = UCSI_CONSTAT(con, CONNECTED);
++	int ret;
++
++	ret = ucsi_get_connector_status(con, false);
++	if (ret) {
++		dev_err(con->ucsi->dev, "GET_CONNECTOR_STATUS failed (%d)\n", ret);
++		return ret;
++	}
++
++	if (UCSI_CONSTAT(con, CONNECTED)) {
++		if (prev_state)
++			return 0;
++		ucsi_register_partner(con);
++		ucsi_pwr_opmode_change(con);
++		ucsi_partner_change(con);
++	} else {
++		ucsi_partner_change(con);
++		ucsi_port_psy_changed(con);
++		ucsi_unregister_partner(con);
++	}
++
++	return 0;
++}
++
++static int ucsi_check_cable(struct ucsi_connector *con)
++{
++	int ret, num_plug_am;
++
++	if (con->cable)
++		return 0;
++
++	ret = ucsi_register_cable(con);
++	if (ret < 0)
++		return ret;
++
++	if (con->ucsi->cap.features & UCSI_CAP_GET_PD_MESSAGE) {
++		ret = ucsi_get_cable_identity(con);
++		if (ret < 0)
++			return ret;
++	}
++
++	if (con->ucsi->cap.features & UCSI_CAP_ALT_MODE_DETAILS) {
++		ret = ucsi_register_plug(con);
++		if (ret < 0)
++			return ret;
++
++		ret = ucsi_register_altmodes(con, UCSI_RECIPIENT_SOP_P);
++		if (ret < 0)
++			return ret;
++
++		if (con->plug_altmode[0]) {
++			num_plug_am = ucsi_get_num_altmode(con->plug_altmode);
++			typec_plug_set_num_altmodes(con->plug, num_plug_am);
++		} else {
++			typec_plug_set_num_altmodes(con->plug, 0);
++		}
++	}
++
++	return 0;
++}
++
++static void ucsi_handle_connector_change(struct work_struct *work)
++{
++	struct ucsi_connector *con = container_of(work, struct ucsi_connector,
++						  work);
++	struct ucsi *ucsi = con->ucsi;
++	u8 curr_scale, volt_scale;
++	enum typec_role role, prev_role;
++	u16 change;
++	int ret;
++	u32 val;
++
++	mutex_lock(&con->lock);
++
++	if (!test_and_set_bit(EVENT_PENDING, &ucsi->flags))
++		dev_err_once(ucsi->dev, "%s entered without EVENT_PENDING\n",
++			     __func__);
++
++	prev_role = UCSI_CONSTAT(con, PWR_DIR);
++
++	ret = ucsi_get_connector_status(con, true);
++	if (ret) {
++		dev_err(ucsi->dev, "%s: GET_CONNECTOR_STATUS failed (%d)\n",
++			__func__, ret);
++		clear_bit(EVENT_PENDING, &con->ucsi->flags);
++		goto out_unlock;
++	}
++
++	trace_ucsi_connector_change(con->num, con);
++
++	if (ucsi->ops->connector_status)
++		ucsi->ops->connector_status(con);
++
++	change = UCSI_CONSTAT(con, CHANGE);
++	role = UCSI_CONSTAT(con, PWR_DIR);
++
++	if ((change & UCSI_CONSTAT_POWER_DIR_CHANGE) && role != prev_role) {
++		typec_set_pwr_role(con->port, role);
++
++		/* Some power_supply properties vary depending on the power direction when
++		 * connected
++		 */
++		if (UCSI_CONSTAT(con, CONNECTED))
++			ucsi_port_psy_changed(con);
++
++		/* Complete pending power role swap */
++		if (!completion_done(&con->complete))
++			complete(&con->complete);
++	}
++
++	if (change & UCSI_CONSTAT_CONNECT_CHANGE) {
++		typec_set_pwr_role(con->port, role);
++		ucsi_port_psy_changed(con);
++		ucsi_partner_change(con);
++		ucsi_orientation(con);
++
++		if (UCSI_CONSTAT(con, CONNECTED)) {
++			ucsi_register_partner(con);
++			ucsi_partner_task(con, ucsi_check_connection, 1, HZ);
++			if (con->ucsi->cap.features & UCSI_CAP_GET_PD_MESSAGE)
++				ucsi_partner_task(con, ucsi_get_partner_identity, 1, HZ);
++			if (con->ucsi->cap.features & UCSI_CAP_CABLE_DETAILS)
++				ucsi_partner_task(con, ucsi_check_cable, 1, HZ);
++
++			if (UCSI_CONSTAT(con, PWR_OPMODE) == UCSI_CONSTAT_PWR_OPMODE_PD) {
++				ucsi_partner_task(con, ucsi_register_partner_pdos, 1, HZ);
++				ucsi_partner_task(con, ucsi_check_connector_capability, 1, HZ);
++			}
++		} else {
++			ucsi_unregister_partner(con);
++		}
++	}
++
++	if (change & (UCSI_CONSTAT_POWER_OPMODE_CHANGE | UCSI_CONSTAT_POWER_LEVEL_CHANGE))
++		ucsi_pwr_opmode_change(con);
++
++	if (con->partner && (change & UCSI_CONSTAT_PARTNER_CHANGE)) {
++		ucsi_partner_change(con);
++		ucsi_altmode_update_active(con);
++
++		/* Complete pending data role swap */
++		if (!completion_done(&con->complete))
++			complete(&con->complete);
++	}
++
++	if (change & UCSI_CONSTAT_CAM_CHANGE)
++		ucsi_partner_task(con, ucsi_check_altmodes, 1, HZ);
++
++	if (change & (UCSI_CONSTAT_BC_CHANGE | UCSI_CONSTAT_SINK_PATH_CHANGE))
++		ucsi_port_psy_changed(con);
++
++	if (con->ucsi->version >= UCSI_VERSION_2_1 &&
++	    UCSI_CONSTAT(con, PWR_READING_READY_V2_1)) {
++		curr_scale = UCSI_CONSTAT(con, CURRENT_SCALE_V2_1);
++		volt_scale = UCSI_CONSTAT(con, VOLTAGE_SCALE_V2_1);
++
++		val = UCSI_CONSTAT(con, PEAK_CURRENT_V2_1);
++		con->peak_current = UCSI_CONSTAT_CURR_SCALE_MULT * curr_scale * val;
++
++		val = UCSI_CONSTAT(con, AVG_CURRENT_V2_1);
++		con->avg_current = UCSI_CONSTAT_CURR_SCALE_MULT * curr_scale * val;
++
++		val = UCSI_CONSTAT(con, VBUS_VOLTAGE_V2_1);
++		con->vbus_voltage = UCSI_CONSTAT_VOLT_SCALE_MULT * volt_scale * val;
++	}
++
++out_unlock:
++	mutex_unlock(&con->lock);
++}
++
++/**
++ * ucsi_connector_change - Process Connector Change Event
++ * @ucsi: UCSI Interface
++ * @num: Connector number
++ */
++void ucsi_connector_change(struct ucsi *ucsi, u8 num)
++{
++	struct ucsi_connector *con;
++
++	if (!(ucsi->ntfy & UCSI_ENABLE_NTFY_CONNECTOR_CHANGE)) {
++		dev_dbg(ucsi->dev, "Early connector change event\n");
++		return;
++	}
++
++	if (!num || num > ucsi->cap.num_connectors) {
++		dev_warn_ratelimited(ucsi->dev,
++				     "Bogus connector change on %u (max %u)\n",
++				     num, ucsi->cap.num_connectors);
++		return;
++	}
++
++	con = &ucsi->connector[num - 1];
++
++	if (!test_and_set_bit(EVENT_PENDING, &ucsi->flags))
++		schedule_work(&con->work);
++}
++EXPORT_SYMBOL_GPL(ucsi_connector_change);
++
++/* -------------------------------------------------------------------------- */
++
++/*
++ * Hard Reset bit field was defined with value 1 in UCSI spec version 1.0.
++ * Starting with spec version 1.1, Hard Reset bit field was removed from the
++ * CONNECTOR_RESET command, until spec 2.0 reintroduced it with value 0, so, in effect,
++ * the value to pass in to the command for a Hard Reset is different depending
++ * on the supported UCSI version by the LPM.
++ *
++ * For performing a Data Reset on LPMs supporting version 2.0 and greater,
++ * this function needs to be called with the second argument set to 0.
++ */
++static int ucsi_reset_connector(struct ucsi_connector *con, bool hard)
++{
++	u64 command;
++
++	command = UCSI_CONNECTOR_RESET | UCSI_CONNECTOR_NUMBER(con->num);
++
++	if (con->ucsi->version < UCSI_VERSION_1_1)
++		command |= hard ? UCSI_CONNECTOR_RESET_HARD_VER_1_0 : 0;
++	else if (con->ucsi->version >= UCSI_VERSION_2_0)
++		command |= hard ? 0 : UCSI_CONNECTOR_RESET_DATA_VER_2_0;
++
++	return ucsi_send_command(con->ucsi, command, NULL, 0);
++}
++
++static int ucsi_reset_ppm(struct ucsi *ucsi)
++{
++	u64 command;
++	unsigned long tmo;
++	u32 cci;
++	int ret;
++
++	mutex_lock(&ucsi->ppm_lock);
++
++	ret = ucsi->ops->poll_cci(ucsi, &cci);
++	if (ret < 0)
++		goto out;
++
++	/*
++	 * If UCSI_CCI_RESET_COMPLETE is already set we must clear
++	 * the flag before we start another reset. Send a
++	 * UCSI_SET_NOTIFICATION_ENABLE command to achieve this.
++	 * Ignore a timeout and try the reset anyway if this fails.
++	 */
++	if (cci & UCSI_CCI_RESET_COMPLETE) {
++		command = UCSI_SET_NOTIFICATION_ENABLE;
++		ret = ucsi->ops->async_control(ucsi, command);
++		if (ret < 0)
++			goto out;
++
++		tmo = jiffies + msecs_to_jiffies(UCSI_TIMEOUT_MS);
++		do {
++			ret = ucsi->ops->poll_cci(ucsi, &cci);
++			if (ret < 0)
++				goto out;
++			if (cci & UCSI_CCI_COMMAND_COMPLETE)
++				break;
++			if (time_is_before_jiffies(tmo))
++				break;
++			msleep(20);
++		} while (1);
++
++		WARN_ON(cci & UCSI_CCI_RESET_COMPLETE);
++	}
++
++	command = UCSI_PPM_RESET;
++	ret = ucsi->ops->async_control(ucsi, command);
++	if (ret < 0)
++		goto out;
++
++	tmo = jiffies + msecs_to_jiffies(UCSI_TIMEOUT_MS);
++
++	do {
++		if (time_is_before_jiffies(tmo)) {
++			ret = -ETIMEDOUT;
++			goto out;
++		}
++
++		/* Give the PPM time to process a reset before reading CCI */
++		msleep(20);
++
++		ret = ucsi->ops->poll_cci(ucsi, &cci);
++		if (ret)
++			goto out;
++
++		/* If the PPM is still doing something else, reset it again. */
++		if (cci & ~UCSI_CCI_RESET_COMPLETE) {
++			ret = ucsi->ops->async_control(ucsi, command);
++			if (ret < 0)
++				goto out;
++		}
++
++	} while (!(cci & UCSI_CCI_RESET_COMPLETE));
++
++out:
++	mutex_unlock(&ucsi->ppm_lock);
++	return ret;
++}
++
++static int ucsi_role_cmd(struct ucsi_connector *con, u64 command)
++{
++	int ret;
++
++	ret = ucsi_send_command(con->ucsi, command, NULL, 0);
++	if (ret == -ETIMEDOUT) {
++		u64 c;
++
++		/* PPM most likely stopped responding. Resetting everything. */
++		ucsi_reset_ppm(con->ucsi);
++
++		c = UCSI_SET_NOTIFICATION_ENABLE | con->ucsi->ntfy;
++		ucsi_send_command(con->ucsi, c, NULL, 0);
++
++		ucsi_reset_connector(con, true);
++	}
++
++	return ret;
++}
++
++static int ucsi_dr_swap(struct typec_port *port, enum typec_data_role role)
++{
++	struct ucsi_connector *con = typec_get_drvdata(port);
++	u8 partner_type;
++	u64 command;
++	int ret = 0;
++
++	mutex_lock(&con->lock);
++
++	if (!con->partner) {
++		ret = -ENOTCONN;
++		goto out_unlock;
++	}
++
++	partner_type = UCSI_CONSTAT(con, PARTNER_TYPE);
++	if ((partner_type == UCSI_CONSTAT_PARTNER_TYPE_DFP &&
++	     role == TYPEC_DEVICE) ||
++	    (partner_type == UCSI_CONSTAT_PARTNER_TYPE_UFP &&
++	     role == TYPEC_HOST))
++		goto out_unlock;
++
++	reinit_completion(&con->complete);
++
++	command = UCSI_SET_UOR | UCSI_CONNECTOR_NUMBER(con->num);
++	command |= UCSI_SET_UOR_ROLE(role);
++	command |= UCSI_SET_UOR_ACCEPT_ROLE_SWAPS;
++	ret = ucsi_role_cmd(con, command);
++	if (ret < 0)
++		goto out_unlock;
++
++	mutex_unlock(&con->lock);
++
++	if (!wait_for_completion_timeout(&con->complete,
++					 msecs_to_jiffies(UCSI_SWAP_TIMEOUT_MS)))
++		return -ETIMEDOUT;
++
++	return 0;
++
++out_unlock:
++	mutex_unlock(&con->lock);
++
++	return ret;
++}
++
++static int ucsi_pr_swap(struct typec_port *port, enum typec_role role)
++{
++	struct ucsi_connector *con = typec_get_drvdata(port);
++	enum typec_role cur_role;
++	u64 command;
++	int ret = 0;
++
++	mutex_lock(&con->lock);
++
++	if (!con->partner) {
++		ret = -ENOTCONN;
++		goto out_unlock;
++	}
++
++	cur_role = UCSI_CONSTAT(con, PWR_DIR);
++
++	if (cur_role == role)
++		goto out_unlock;
++
++	reinit_completion(&con->complete);
++
++	command = UCSI_SET_PDR | UCSI_CONNECTOR_NUMBER(con->num);
++	command |= UCSI_SET_PDR_ROLE(role);
++	command |= UCSI_SET_PDR_ACCEPT_ROLE_SWAPS;
++	ret = ucsi_role_cmd(con, command);
++	if (ret < 0)
++		goto out_unlock;
++
++	mutex_unlock(&con->lock);
++
++	if (!wait_for_completion_timeout(&con->complete,
++					 msecs_to_jiffies(UCSI_SWAP_TIMEOUT_MS)))
++		return -ETIMEDOUT;
++
++	mutex_lock(&con->lock);
++
++	/* Something has gone wrong while swapping the role */
++	if (UCSI_CONSTAT(con, PWR_OPMODE) != UCSI_CONSTAT_PWR_OPMODE_PD) {
++		ucsi_reset_connector(con, true);
++		ret = -EPROTO;
++	}
++
++out_unlock:
++	mutex_unlock(&con->lock);
++
++	return ret;
++}
++
++static const struct typec_operations ucsi_ops = {
++	.dr_set = ucsi_dr_swap,
++	.pr_set = ucsi_pr_swap
++};
++
++/* Caller must call fwnode_handle_put() after use */
++static struct fwnode_handle *ucsi_find_fwnode(struct ucsi_connector *con)
++{
++	struct fwnode_handle *fwnode;
++	int i = 1;
++
++	device_for_each_child_node(con->ucsi->dev, fwnode)
++		if (i++ == con->num)
++			return fwnode;
++	return NULL;
++}
++
++static int ucsi_register_port(struct ucsi *ucsi, struct ucsi_connector *con)
++{
++	struct typec_capability *cap = &con->typec_cap;
++	enum typec_accessory *accessory = cap->accessory;
++	enum usb_role u_role = USB_ROLE_NONE;
++	u64 command;
++	char *name;
++	int ret;
++
++	name = kasprintf(GFP_KERNEL, "%s-con%d", dev_name(ucsi->dev), con->num);
++	if (!name)
++		return -ENOMEM;
++
++	con->wq = create_singlethread_workqueue(name);
++	kfree(name);
++	if (!con->wq)
++		return -ENOMEM;
++
++	INIT_WORK(&con->work, ucsi_handle_connector_change);
++	init_completion(&con->complete);
++	mutex_init(&con->lock);
++	lockdep_set_class(&con->lock, &con->lock_key);
++	INIT_LIST_HEAD(&con->partner_tasks);
++	con->ucsi = ucsi;
++
++	cap->fwnode = ucsi_find_fwnode(con);
++	con->usb_role_sw = fwnode_usb_role_switch_get(cap->fwnode);
++	if (IS_ERR(con->usb_role_sw))
++		return dev_err_probe(ucsi->dev, PTR_ERR(con->usb_role_sw),
++			"con%d: failed to get usb role switch\n", con->num);
++
++	/* Delay other interactions with the con until registration is complete */
++	mutex_lock(&con->lock);
++
++	/* Get connector capability */
++	command = UCSI_GET_CONNECTOR_CAPABILITY;
++	command |= UCSI_CONNECTOR_NUMBER(con->num);
++	ret = ucsi_send_command(ucsi, command, &con->cap, sizeof(con->cap));
++	if (ret < 0)
++		goto out_unlock;
++
++	if (UCSI_CONCAP(con, OPMODE_DRP))
++		cap->data = TYPEC_PORT_DRD;
++	else if (UCSI_CONCAP(con, OPMODE_DFP))
++		cap->data = TYPEC_PORT_DFP;
++	else if (UCSI_CONCAP(con, OPMODE_UFP))
++		cap->data = TYPEC_PORT_UFP;
++
++	if (UCSI_CONCAP(con, PROVIDER) && UCSI_CONCAP(con, CONSUMER))
++		cap->type = TYPEC_PORT_DRP;
++	else if (UCSI_CONCAP(con, PROVIDER))
++		cap->type = TYPEC_PORT_SRC;
++	else if (UCSI_CONCAP(con, CONSUMER))
++		cap->type = TYPEC_PORT_SNK;
++
++	cap->revision = ucsi->cap.typec_version;
++	cap->pd_revision = ucsi->cap.pd_version;
++	cap->svdm_version = SVDM_VER_2_0;
++	cap->prefer_role = TYPEC_NO_PREFERRED_ROLE;
++
++	if (UCSI_CONCAP(con, OPMODE_AUDIO_ACCESSORY))
++		*accessory++ = TYPEC_ACCESSORY_AUDIO;
++	if (UCSI_CONCAP(con, OPMODE_DEBUG_ACCESSORY))
++		*accessory = TYPEC_ACCESSORY_DEBUG;
++
++	if (UCSI_CONCAP_USB2_SUPPORT(con))
++		cap->usb_capability |= USB_CAPABILITY_USB2;
++	if (UCSI_CONCAP_USB3_SUPPORT(con))
++		cap->usb_capability |= USB_CAPABILITY_USB3;
++	if (UCSI_CONCAP_USB4_SUPPORT(con))
++		cap->usb_capability |= USB_CAPABILITY_USB4;
++
++	cap->driver_data = con;
++	cap->ops = &ucsi_ops;
++	cap->no_mode_control = !(con->ucsi->cap.features & UCSI_CAP_ALT_MODE_OVERRIDE);
++
++	if (ucsi->version >= UCSI_VERSION_2_0)
++		con->typec_cap.orientation_aware = true;
++
++	if (ucsi->ops->update_connector)
++		ucsi->ops->update_connector(con);
++
++	ret = ucsi_register_port_psy(con);
++	if (ret)
++		goto out;
++
++	/* Register the connector */
++	con->port = typec_register_port(ucsi->dev, cap);
++	if (IS_ERR(con->port)) {
++		ret = PTR_ERR(con->port);
++		goto out;
++	}
++
++	if (!(ucsi->quirks & UCSI_DELAY_DEVICE_PDOS))
++		ucsi_register_device_pdos(con);
++
++	/* Alternate modes */
++	ret = ucsi_register_altmodes(con, UCSI_RECIPIENT_CON);
++	if (ret) {
++		dev_err(ucsi->dev, "con%d: failed to register alt modes\n",
++			con->num);
++		goto out;
++	}
++
++	/* Get the status */
++	ret = ucsi_get_connector_status(con, false);
++	if (ret) {
++		dev_err(ucsi->dev, "con%d: failed to get status\n", con->num);
++		goto out;
++	}
++
++	if (ucsi->ops->connector_status)
++		ucsi->ops->connector_status(con);
++
++	switch (UCSI_CONSTAT(con, PARTNER_TYPE)) {
++	case UCSI_CONSTAT_PARTNER_TYPE_UFP:
++	case UCSI_CONSTAT_PARTNER_TYPE_CABLE_AND_UFP:
++		u_role = USB_ROLE_HOST;
++		fallthrough;
++	case UCSI_CONSTAT_PARTNER_TYPE_CABLE:
++		typec_set_data_role(con->port, TYPEC_HOST);
++		break;
++	case UCSI_CONSTAT_PARTNER_TYPE_DFP:
++		u_role = USB_ROLE_DEVICE;
++		typec_set_data_role(con->port, TYPEC_DEVICE);
++		break;
++	default:
++		break;
++	}
++
++	/* Check if there is already something connected */
++	if (UCSI_CONSTAT(con, CONNECTED)) {
++		typec_set_pwr_role(con->port, UCSI_CONSTAT(con, PWR_DIR));
++		ucsi_register_partner(con);
++		ucsi_pwr_opmode_change(con);
++		ucsi_orientation(con);
++		ucsi_port_psy_changed(con);
++		if (con->ucsi->cap.features & UCSI_CAP_GET_PD_MESSAGE)
++			ucsi_get_partner_identity(con);
++		if (con->ucsi->cap.features & UCSI_CAP_CABLE_DETAILS)
++			ucsi_check_cable(con);
++	}
++
++	/* Only notify USB controller if partner supports USB data */
++	if (!(UCSI_CONSTAT(con, PARTNER_FLAG_USB)))
++		u_role = USB_ROLE_NONE;
++
++	ret = usb_role_switch_set_role(con->usb_role_sw, u_role);
++	if (ret) {
++		dev_err(ucsi->dev, "con:%d: failed to set usb role:%d\n",
++			con->num, u_role);
++		ret = 0;
++	}
++
++	if (con->partner && UCSI_CONSTAT(con, PWR_OPMODE) == UCSI_CONSTAT_PWR_OPMODE_PD) {
++		ucsi_register_device_pdos(con);
++		ucsi_get_src_pdos(con);
++		ucsi_check_altmodes(con);
++		ucsi_check_connector_capability(con);
++	}
++
++	trace_ucsi_register_port(con->num, con);
++
++out:
++	fwnode_handle_put(cap->fwnode);
++out_unlock:
++	mutex_unlock(&con->lock);
++
++	if (ret && con->wq) {
++		destroy_workqueue(con->wq);
++		con->wq = NULL;
++	}
++
++	return ret;
++}
++
++static void ucsi_unregister_port(struct ucsi_connector *con)
++{
++	struct ucsi_work *uwork;
++
++	if (con->wq) {
++		mutex_lock(&con->lock);
++		ucsi_unregister_partner(con);
++		/*
++		 * queue delayed items immediately so they can execute
++		 * and free themselves before the wq is destroyed
++		 */
++		list_for_each_entry(uwork, &con->partner_tasks, node) {
++			if (cancel_delayed_work(&uwork->work))
++				queue_delayed_work(con->wq, &uwork->work, 0);
++		}
++		mutex_unlock(&con->lock);
++
++		destroy_workqueue(con->wq);
++		con->wq = NULL;
++	} else {
++		ucsi_unregister_partner(con);
++	}
++
++	ucsi_unregister_altmodes(con, UCSI_RECIPIENT_CON);
++	ucsi_unregister_port_psy(con);
++
++	usb_power_delivery_unregister_capabilities(con->port_sink_caps);
++	con->port_sink_caps = NULL;
++	usb_power_delivery_unregister_capabilities(con->port_source_caps);
++	con->port_source_caps = NULL;
++	usb_power_delivery_unregister(con->pd);
++	con->pd = NULL;
++	typec_unregister_port(con->port);
++	con->port = NULL;
++}
++
++static u64 ucsi_get_supported_notifications(struct ucsi *ucsi)
++{
++	u16 features = ucsi->cap.features;
++	u64 ntfy = UCSI_ENABLE_NTFY_ALL;
++
++	if (!(features & UCSI_CAP_ALT_MODE_DETAILS))
++		ntfy &= ~UCSI_ENABLE_NTFY_CAM_CHANGE;
++
++	if (!(features & UCSI_CAP_PDO_DETAILS))
++		ntfy &= ~(UCSI_ENABLE_NTFY_PWR_LEVEL_CHANGE |
++			  UCSI_ENABLE_NTFY_CAP_CHANGE);
++
++	if (!(features & UCSI_CAP_EXT_SUPPLY_NOTIFICATIONS))
++		ntfy &= ~UCSI_ENABLE_NTFY_EXT_PWR_SRC_CHANGE;
++
++	if (!(features & UCSI_CAP_PD_RESET))
++		ntfy &= ~UCSI_ENABLE_NTFY_PD_RESET_COMPLETE;
++
++	if (ucsi->version <= UCSI_VERSION_1_2)
++		return ntfy;
++
++	ntfy |= UCSI_ENABLE_NTFY_SINK_PATH_STS_CHANGE;
++
++	if (features & UCSI_CAP_GET_ATTENTION_VDO)
++		ntfy |= UCSI_ENABLE_NTFY_ATTENTION;
++
++	if (features & UCSI_CAP_FW_UPDATE_REQUEST)
++		ntfy |= UCSI_ENABLE_NTFY_LPM_FW_UPDATE_REQ;
++
++	if (features & UCSI_CAP_SECURITY_REQUEST)
++		ntfy |= UCSI_ENABLE_NTFY_SECURITY_REQ_PARTNER;
++
++	if (features & UCSI_CAP_SET_RETIMER_MODE)
++		ntfy |= UCSI_ENABLE_NTFY_SET_RETIMER_MODE;
++
++	return ntfy;
++}
++
++/**
++ * ucsi_init - Initialize UCSI interface
++ * @ucsi: UCSI to be initialized
++ *
++ * Registers all ports @ucsi has and enables all notification events.
++ */
++static int ucsi_init(struct ucsi *ucsi)
++{
++	struct ucsi_connector *con, *connector;
++	u64 command, ntfy;
++	u32 cci;
++	int ret;
++	int i;
++
++	/* Reset the PPM */
++	ret = ucsi_reset_ppm(ucsi);
++	if (ret) {
++		dev_err(ucsi->dev, "failed to reset PPM!\n");
++		goto err;
++	}
++
++	/* Enable basic notifications */
++	ntfy = UCSI_ENABLE_NTFY_CMD_COMPLETE | UCSI_ENABLE_NTFY_ERROR;
++	command = UCSI_SET_NOTIFICATION_ENABLE | ntfy;
++	ret = ucsi_send_command(ucsi, command, NULL, 0);
++	if (ret < 0)
++		goto err_reset;
++
++	/* Get PPM capabilities */
++	command = UCSI_GET_CAPABILITY;
++	ret = ucsi_send_command(ucsi, command, &ucsi->cap,
++				BITS_TO_BYTES(UCSI_GET_CAPABILITY_SIZE));
++	if (ret < 0)
++		goto err_reset;
++
++	if (!ucsi->cap.num_connectors) {
++		ret = -ENODEV;
++		goto err_reset;
++	}
++	/* Check if reserved bit set. This is out of spec but happens in buggy FW */
++	if (ucsi->cap.num_connectors & 0x80) {
++		dev_warn(ucsi->dev, "UCSI: Invalid num_connectors %d. Likely buggy FW\n",
++			 ucsi->cap.num_connectors);
++		ucsi->cap.num_connectors &= 0x7f; // clear bit and carry on
++	}
++
++	/* Allocate the connectors. Released in ucsi_unregister() */
++	connector = kzalloc_objs(*connector, ucsi->cap.num_connectors + 1);
++	if (!connector) {
++		ret = -ENOMEM;
++		goto err_reset;
++	}
++
++	for (i = 0; i < ucsi->cap.num_connectors; i++)
++		lockdep_register_key(&connector[i].lock_key);
++
++	/* Register all connectors */
++	for (i = 0; i < ucsi->cap.num_connectors; i++) {
++		connector[i].num = i + 1;
++		ret = ucsi_register_port(ucsi, &connector[i]);
++		if (ret)
++			goto err_unregister;
++	}
++
++	/* Enable all supported notifications */
++	ntfy = ucsi_get_supported_notifications(ucsi);
++	command = UCSI_SET_NOTIFICATION_ENABLE | ntfy;
++	ret = ucsi_send_command(ucsi, command, NULL, 0);
++	if (ret < 0)
++		goto err_unregister;
++
++	ucsi->connector = connector;
++	ucsi->ntfy = ntfy;
++
++	mutex_lock(&ucsi->ppm_lock);
++	ret = ucsi->ops->read_cci(ucsi, &cci);
++	mutex_unlock(&ucsi->ppm_lock);
++	if (ret)
++		return ret;
++	if (UCSI_CCI_CONNECTOR(cci))
++		ucsi_connector_change(ucsi, UCSI_CCI_CONNECTOR(cci));
++
++	return 0;
++
++err_unregister:
++	for (con = connector; con->port; con++)
++		ucsi_unregister_port(con);
++	for (i = 0; i < ucsi->cap.num_connectors; i++)
++		lockdep_unregister_key(&connector[i].lock_key);
++
++	kfree(connector);
++err_reset:
++	memset(&ucsi->cap, 0, sizeof(ucsi->cap));
++	ucsi_reset_ppm(ucsi);
++err:
++	return ret;
++}
++
++static void ucsi_resume_work(struct work_struct *work)
++{
++	struct ucsi *ucsi = container_of(work, struct ucsi, resume_work);
++	struct ucsi_connector *con;
++	u64 command;
++	int ret;
++
++	/* Restore UCSI notification enable mask after system resume */
++	command = UCSI_SET_NOTIFICATION_ENABLE | ucsi->ntfy;
++	ret = ucsi_send_command(ucsi, command, NULL, 0);
++	if (ret < 0) {
++		dev_err(ucsi->dev, "failed to re-enable notifications (%d)\n", ret);
++		return;
++	}
++
++	for (con = ucsi->connector; con->port; con++) {
++		mutex_lock(&con->lock);
++		ucsi_partner_task(con, ucsi_check_connection, 1, 0);
++		mutex_unlock(&con->lock);
++	}
++}
++
++int ucsi_suspend(struct ucsi *ucsi)
++{
++	int i;
++
++	/*
++	 * Cancel pending work so it cannot access the firmware after the ACPI
++	 * EC is stopped for suspend; state is re-read on resume.
++	 */
++	cancel_delayed_work_sync(&ucsi->work);
++
++	if (!ucsi->connector)
++		return 0;
++
++	for (i = 0; i < ucsi->cap.num_connectors; i++)
++		cancel_work_sync(&ucsi->connector[i].work);
++
++	return 0;
++}
++EXPORT_SYMBOL_GPL(ucsi_suspend);
++
++int ucsi_resume(struct ucsi *ucsi)
++{
++	if (ucsi->connector)
++		queue_work(system_long_wq, &ucsi->resume_work);
++	return 0;
++}
++EXPORT_SYMBOL_GPL(ucsi_resume);
++
++static void ucsi_init_work(struct work_struct *work)
++{
++	struct ucsi *ucsi = container_of(work, struct ucsi, work.work);
++	int ret;
++
++	ret = ucsi_init(ucsi);
++	if (ret)
++		dev_err_probe(ucsi->dev, ret, "PPM init failed\n");
++
++	if (ret == -EPROBE_DEFER) {
++		if (ucsi->work_count++ > UCSI_ROLE_SWITCH_WAIT_COUNT) {
++			dev_err(ucsi->dev, "PPM init failed, stop trying\n");
++			return;
++		}
++
++		queue_delayed_work(system_long_wq, &ucsi->work,
++				   UCSI_ROLE_SWITCH_INTERVAL);
++	}
++}
++
++/**
++ * ucsi_get_drvdata - Return private driver data pointer
++ * @ucsi: UCSI interface
++ */
++void *ucsi_get_drvdata(struct ucsi *ucsi)
++{
++	return ucsi->driver_data;
++}
++EXPORT_SYMBOL_GPL(ucsi_get_drvdata);
++
++/**
++ * ucsi_set_drvdata - Assign private driver data pointer
++ * @ucsi: UCSI interface
++ * @data: Private data pointer
++ */
++void ucsi_set_drvdata(struct ucsi *ucsi, void *data)
++{
++	ucsi->driver_data = data;
++}
++EXPORT_SYMBOL_GPL(ucsi_set_drvdata);
++
++/**
++ * ucsi_con_mutex_lock - Acquire the connector mutex
++ * @con: The connector interface to lock
++ *
++ * Returns true on success, false if the connector is disconnected
++ */
++bool ucsi_con_mutex_lock(struct ucsi_connector *con)
++{
++	bool mutex_locked = false;
++	bool connected = true;
++
++	while (connected && !mutex_locked) {
++		mutex_locked = mutex_trylock(&con->lock) != 0;
++		connected = UCSI_CONSTAT(con, CONNECTED);
++		if (connected && !mutex_locked)
++			msleep(20);
++	}
++
++	connected = connected && con->partner;
++	if (!connected && mutex_locked)
++		mutex_unlock(&con->lock);
++
++	return connected;
++}
++
++/**
++ * ucsi_con_mutex_unlock - Release the connector mutex
++ * @con: The connector interface to unlock
++ */
++void ucsi_con_mutex_unlock(struct ucsi_connector *con)
++{
++	mutex_unlock(&con->lock);
++}
++
++/**
++ * ucsi_create - Allocate UCSI instance
++ * @dev: Device interface to the PPM (Platform Policy Manager)
++ * @ops: I/O routines
++ */
++struct ucsi *ucsi_create(struct device *dev, const struct ucsi_operations *ops)
++{
++	struct ucsi *ucsi;
++
++	if (!ops ||
++	    !ops->read_version || !ops->read_cci || !ops->poll_cci ||
++	    !ops->read_message_in || !ops->sync_control || !ops->async_control)
++		return ERR_PTR(-EINVAL);
++
++	ucsi = kzalloc_obj(*ucsi);
++	if (!ucsi)
++		return ERR_PTR(-ENOMEM);
++
++	INIT_WORK(&ucsi->resume_work, ucsi_resume_work);
++	INIT_DELAYED_WORK(&ucsi->work, ucsi_init_work);
++	mutex_init(&ucsi->ppm_lock);
++	init_completion(&ucsi->complete);
++	ucsi->dev = dev;
++	ucsi->ops = ops;
++
++	return ucsi;
++}
++EXPORT_SYMBOL_GPL(ucsi_create);
++
++/**
++ * ucsi_destroy - Free UCSI instance
++ * @ucsi: UCSI instance to be freed
++ */
++void ucsi_destroy(struct ucsi *ucsi)
++{
++	ucsi_debugfs_unregister(ucsi);
++	kfree(ucsi);
++}
++EXPORT_SYMBOL_GPL(ucsi_destroy);
++
++/**
++ * ucsi_register - Register UCSI interface
++ * @ucsi: UCSI instance
++ */
++int ucsi_register(struct ucsi *ucsi)
++{
++	int ret;
++
++	ret = ucsi->ops->read_version(ucsi, &ucsi->version);
++	if (ret)
++		return ret;
++
++	if (!ucsi->version)
++		return -ENODEV;
++
++	/*
++	 * Version format is JJ.M.N (JJ = Major version, M = Minor version,
++	 * N = sub-minor version).
++	 */
++	dev_dbg(ucsi->dev, "Registered UCSI interface with version %x.%x.%x",
++		UCSI_BCD_GET_MAJOR(ucsi->version),
++		UCSI_BCD_GET_MINOR(ucsi->version),
++		UCSI_BCD_GET_SUBMINOR(ucsi->version));
++
++	queue_delayed_work(system_long_wq, &ucsi->work, 0);
++
++	ucsi_debugfs_register(ucsi);
++	return 0;
++}
++EXPORT_SYMBOL_GPL(ucsi_register);
++
++/**
++ * ucsi_unregister - Unregister UCSI interface
++ * @ucsi: UCSI interface to be unregistered
++ *
++ * Unregister UCSI interface that was created with ucsi_register().
++ */
++void ucsi_unregister(struct ucsi *ucsi)
++{
++	u64 cmd = UCSI_SET_NOTIFICATION_ENABLE;
++	int i;
++
++	/* Make sure that we are not in the middle of driver initialization */
++	cancel_delayed_work_sync(&ucsi->work);
++	cancel_work_sync(&ucsi->resume_work);
++
++	/* Disable notifications */
++	ucsi->ops->async_control(ucsi, cmd);
++
++	if (!ucsi->connector)
++		return;
++
++	for (i = 0; i < ucsi->cap.num_connectors; i++) {
++		cancel_work_sync(&ucsi->connector[i].work);
++		ucsi_unregister_port(&ucsi->connector[i]);
++		lockdep_unregister_key(&ucsi->connector[i].lock_key);
++	}
++
++	kfree(ucsi->connector);
++}
++EXPORT_SYMBOL_GPL(ucsi_unregister);
++
++static int __init ucsi_module_init(void)
++{
++	ucsi_debugfs_init();
++	return 0;
++}
++module_init(ucsi_module_init);
++
++static void __exit ucsi_module_exit(void)
++{
++	ucsi_debugfs_exit();
++}
++module_exit(ucsi_module_exit);
++
++MODULE_AUTHOR("Heikki Krogerus <heikki.krogerus@linux.intel.com>");
++MODULE_LICENSE("GPL v2");
++MODULE_DESCRIPTION("USB Type-C Connector System Software Interface driver");
+diff --git a/include/linux/sched.h.orig b/include/linux/sched.h.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/include/linux/sched.h.orig
+@@ -0,0 +1,2532 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef _LINUX_SCHED_H
++#define _LINUX_SCHED_H
++
++/*
++ * Define 'struct task_struct' and provide the main scheduler
++ * APIs (schedule(), wakeup variants, etc.)
++ */
++
++#include <uapi/linux/sched.h>
++
++#include <asm/current.h>
++#include <asm/processor.h>
++#include <linux/thread_info.h>
++#include <linux/preempt.h>
++#include <linux/cpumask_types.h>
++
++#include <linux/cache.h>
++#include <linux/irqflags_types.h>
++#include <linux/smp_types.h>
++#include <linux/pid_types.h>
++#include <linux/sem_types.h>
++#include <linux/shm.h>
++#include <linux/kmsan_types.h>
++#include <linux/mutex_types.h>
++#include <linux/plist_types.h>
++#include <linux/hrtimer_types.h>
++#include <linux/timer_types.h>
++#include <linux/seccomp_types.h>
++#include <linux/nodemask_types.h>
++#include <linux/refcount_types.h>
++#include <linux/resource.h>
++#include <linux/latencytop.h>
++#include <linux/sched/prio.h>
++#include <linux/sched/types.h>
++#include <linux/signal_types.h>
++#include <linux/spinlock.h>
++#include <linux/syscall_user_dispatch_types.h>
++#include <linux/mm_types_task.h>
++#include <linux/netdevice_xmit.h>
++#include <linux/task_io_accounting.h>
++#include <linux/posix-timers_types.h>
++#include <linux/restart_block.h>
++#include <linux/rseq_types.h>
++#include <linux/seqlock_types.h>
++#include <linux/kcsan.h>
++#include <linux/rv.h>
++#include <linux/uidgid_types.h>
++#include <linux/tracepoint-defs.h>
++#include <linux/unwind_deferred_types.h>
++#include <asm/kmap_size.h>
++#include <linux/time64.h>
++#ifndef COMPILE_OFFSETS
++#include <generated/rq-offsets.h>
++#endif
++
++/* task_struct member predeclarations (sorted alphabetically): */
++struct audit_context;
++struct bio_list;
++struct blk_plug;
++struct bpf_local_storage;
++struct bpf_run_ctx;
++struct bpf_net_context;
++struct capture_control;
++struct cfs_rq;
++struct fs_struct;
++struct futex_pi_state;
++struct io_context;
++struct io_uring_task;
++struct mempolicy;
++struct nameidata;
++struct nsproxy;
++struct perf_event_context;
++struct perf_ctx_data;
++struct pid_namespace;
++struct pipe_inode_info;
++struct rcu_node;
++struct reclaim_state;
++struct robust_list_head;
++struct root_domain;
++struct rq;
++struct sched_attr;
++struct sched_dl_entity;
++struct seq_file;
++struct sighand_struct;
++struct signal_struct;
++struct task_delay_info;
++struct task_group;
++struct task_struct;
++struct timespec64;
++struct user_event_mm;
++
++#include <linux/sched/ext.h>
++
++/*
++ * Task state bitmask. NOTE! These bits are also
++ * encoded in fs/proc/array.c: get_task_state().
++ *
++ * We have two separate sets of flags: task->__state
++ * is about runnability, while task->exit_state are
++ * about the task exiting. Confusing, but this way
++ * modifying one set can't modify the other one by
++ * mistake.
++ */
++
++/* Used in tsk->__state: */
++#define TASK_RUNNING			0x00000000
++#define TASK_INTERRUPTIBLE		0x00000001
++#define TASK_UNINTERRUPTIBLE		0x00000002
++#define __TASK_STOPPED			0x00000004
++#define __TASK_TRACED			0x00000008
++/* Used in tsk->exit_state: */
++#define EXIT_DEAD			0x00000010
++#define EXIT_ZOMBIE			0x00000020
++#define EXIT_TRACE			(EXIT_ZOMBIE | EXIT_DEAD)
++/* Used in tsk->__state again: */
++#define TASK_PARKED			0x00000040
++#define TASK_DEAD			0x00000080
++#define TASK_WAKEKILL			0x00000100
++#define TASK_WAKING			0x00000200
++#define TASK_NOLOAD			0x00000400
++#define TASK_NEW			0x00000800
++#define TASK_RTLOCK_WAIT		0x00001000
++#define TASK_FREEZABLE			0x00002000
++#define __TASK_FREEZABLE_UNSAFE	       (0x00004000 * IS_ENABLED(CONFIG_LOCKDEP))
++#define TASK_FROZEN			0x00008000
++#define TASK_STATE_MAX			0x00010000
++
++#define TASK_ANY			(TASK_STATE_MAX-1)
++
++/*
++ * DO NOT ADD ANY NEW USERS !
++ */
++#define TASK_FREEZABLE_UNSAFE		(TASK_FREEZABLE | __TASK_FREEZABLE_UNSAFE)
++
++/* Convenience macros for the sake of set_current_state: */
++#define TASK_KILLABLE			(TASK_WAKEKILL | TASK_UNINTERRUPTIBLE)
++#define TASK_STOPPED			(TASK_WAKEKILL | __TASK_STOPPED)
++#define TASK_TRACED			__TASK_TRACED
++
++#define TASK_IDLE			(TASK_UNINTERRUPTIBLE | TASK_NOLOAD)
++
++/* Convenience macros for the sake of wake_up(): */
++#define TASK_NORMAL			(TASK_INTERRUPTIBLE | TASK_UNINTERRUPTIBLE)
++
++/* get_task_state(): */
++#define TASK_REPORT			(TASK_RUNNING | TASK_INTERRUPTIBLE | \
++					 TASK_UNINTERRUPTIBLE | __TASK_STOPPED | \
++					 __TASK_TRACED | EXIT_DEAD | EXIT_ZOMBIE | \
++					 TASK_PARKED)
++
++#define task_is_running(task)		(READ_ONCE((task)->__state) == TASK_RUNNING)
++
++#define task_is_traced(task)		((READ_ONCE(task->jobctl) & JOBCTL_TRACED) != 0)
++#define task_is_stopped(task)		((READ_ONCE(task->jobctl) & JOBCTL_STOPPED) != 0)
++#define task_is_stopped_or_traced(task)	((READ_ONCE(task->jobctl) & (JOBCTL_STOPPED | JOBCTL_TRACED)) != 0)
++
++/*
++ * Special states are those that do not use the normal wait-loop pattern. See
++ * the comment with set_special_state().
++ */
++#define is_special_task_state(state)					\
++	((state) & (__TASK_STOPPED | __TASK_TRACED | TASK_PARKED |	\
++		    TASK_DEAD | TASK_FROZEN))
++
++#ifdef CONFIG_DEBUG_ATOMIC_SLEEP
++# define debug_normal_state_change(state_value)				\
++	do {								\
++		WARN_ON_ONCE(is_special_task_state(state_value));	\
++		current->task_state_change = _THIS_IP_;			\
++	} while (0)
++
++# define debug_special_state_change(state_value)			\
++	do {								\
++		WARN_ON_ONCE(!is_special_task_state(state_value));	\
++		current->task_state_change = _THIS_IP_;			\
++	} while (0)
++
++# define debug_rtlock_wait_set_state()					\
++	do {								 \
++		current->saved_state_change = current->task_state_change;\
++		current->task_state_change = _THIS_IP_;			 \
++	} while (0)
++
++# define debug_rtlock_wait_restore_state()				\
++	do {								 \
++		current->task_state_change = current->saved_state_change;\
++	} while (0)
++
++#else
++# define debug_normal_state_change(cond)	do { } while (0)
++# define debug_special_state_change(cond)	do { } while (0)
++# define debug_rtlock_wait_set_state()		do { } while (0)
++# define debug_rtlock_wait_restore_state()	do { } while (0)
++#endif
++
++#define trace_set_current_state(state_value)                     \
++	do {                                                     \
++		if (tracepoint_enabled(sched_set_state_tp))      \
++			__trace_set_current_state(state_value); \
++	} while (0)
++
++/*
++ * set_current_state() includes a barrier so that the write of current->__state
++ * is correctly serialised wrt the caller's subsequent test of whether to
++ * actually sleep:
++ *
++ *   for (;;) {
++ *	set_current_state(TASK_UNINTERRUPTIBLE);
++ *	if (CONDITION)
++ *	   break;
++ *
++ *	schedule();
++ *   }
++ *   __set_current_state(TASK_RUNNING);
++ *
++ * If the caller does not need such serialisation (because, for instance, the
++ * CONDITION test and condition change and wakeup are under the same lock) then
++ * use __set_current_state().
++ *
++ * The above is typically ordered against the wakeup, which does:
++ *
++ *   CONDITION = 1;
++ *   wake_up_state(p, TASK_UNINTERRUPTIBLE);
++ *
++ * where wake_up_state()/try_to_wake_up() executes a full memory barrier before
++ * accessing p->__state.
++ *
++ * Wakeup will do: if (@state & p->__state) p->__state = TASK_RUNNING, that is,
++ * once it observes the TASK_UNINTERRUPTIBLE store the waking CPU can issue a
++ * TASK_RUNNING store which can collide with __set_current_state(TASK_RUNNING).
++ *
++ * However, with slightly different timing the wakeup TASK_RUNNING store can
++ * also collide with the TASK_UNINTERRUPTIBLE store. Losing that store is not
++ * a problem either because that will result in one extra go around the loop
++ * and our @cond test will save the day.
++ *
++ * Also see the comments of try_to_wake_up().
++ */
++#define __set_current_state(state_value)				\
++	do {								\
++		debug_normal_state_change((state_value));		\
++		trace_set_current_state(state_value);			\
++		WRITE_ONCE(current->__state, (state_value));		\
++	} while (0)
++
++#define set_current_state(state_value)					\
++	do {								\
++		debug_normal_state_change((state_value));		\
++		trace_set_current_state(state_value);			\
++		smp_store_mb(current->__state, (state_value));		\
++	} while (0)
++
++/*
++ * set_special_state() should be used for those states when the blocking task
++ * can not use the regular condition based wait-loop. In that case we must
++ * serialize against wakeups such that any possible in-flight TASK_RUNNING
++ * stores will not collide with our state change.
++ */
++#define set_special_state(state_value)					\
++	do {								\
++		unsigned long flags; /* may shadow */			\
++									\
++		raw_spin_lock_irqsave(&current->pi_lock, flags);	\
++		debug_special_state_change((state_value));		\
++		trace_set_current_state(state_value);			\
++		WRITE_ONCE(current->__state, (state_value));		\
++		raw_spin_unlock_irqrestore(&current->pi_lock, flags);	\
++	} while (0)
++
++/*
++ * PREEMPT_RT specific variants for "sleeping" spin/rwlocks
++ *
++ * RT's spin/rwlock substitutions are state preserving. The state of the
++ * task when blocking on the lock is saved in task_struct::saved_state and
++ * restored after the lock has been acquired.  These operations are
++ * serialized by task_struct::pi_lock against try_to_wake_up(). Any non RT
++ * lock related wakeups while the task is blocked on the lock are
++ * redirected to operate on task_struct::saved_state to ensure that these
++ * are not dropped. On restore task_struct::saved_state is set to
++ * TASK_RUNNING so any wakeup attempt redirected to saved_state will fail.
++ *
++ * The lock operation looks like this:
++ *
++ *	current_save_and_set_rtlock_wait_state();
++ *	for (;;) {
++ *		if (try_lock())
++ *			break;
++ *		raw_spin_unlock_irq(&lock->wait_lock);
++ *		schedule_rtlock();
++ *		raw_spin_lock_irq(&lock->wait_lock);
++ *		set_current_state(TASK_RTLOCK_WAIT);
++ *	}
++ *	current_restore_rtlock_saved_state();
++ */
++#define current_save_and_set_rtlock_wait_state()			\
++	do {								\
++		lockdep_assert_irqs_disabled();				\
++		raw_spin_lock(&current->pi_lock);			\
++		current->saved_state = current->__state;		\
++		debug_rtlock_wait_set_state();				\
++		trace_set_current_state(TASK_RTLOCK_WAIT);		\
++		WRITE_ONCE(current->__state, TASK_RTLOCK_WAIT);		\
++		raw_spin_unlock(&current->pi_lock);			\
++	} while (0);
++
++#define current_restore_rtlock_saved_state()				\
++	do {								\
++		lockdep_assert_irqs_disabled();				\
++		raw_spin_lock(&current->pi_lock);			\
++		debug_rtlock_wait_restore_state();			\
++		trace_set_current_state(current->saved_state);		\
++		WRITE_ONCE(current->__state, current->saved_state);	\
++		current->saved_state = TASK_RUNNING;			\
++		raw_spin_unlock(&current->pi_lock);			\
++	} while (0);
++
++#define get_current_state()	READ_ONCE(current->__state)
++
++/*
++ * Define the task command name length as enum, then it can be visible to
++ * BPF programs.
++ */
++enum {
++	TASK_COMM_LEN = 16,
++};
++
++extern void sched_tick(void);
++
++#define	MAX_SCHEDULE_TIMEOUT		LONG_MAX
++
++extern long schedule_timeout(long timeout);
++extern long schedule_timeout_interruptible(long timeout);
++extern long schedule_timeout_killable(long timeout);
++extern long schedule_timeout_uninterruptible(long timeout);
++extern long schedule_timeout_idle(long timeout);
++asmlinkage void schedule(void);
++extern void schedule_preempt_disabled(void);
++asmlinkage void preempt_schedule_irq(void);
++#ifdef CONFIG_PREEMPT_RT
++ extern void schedule_rtlock(void);
++#endif
++
++extern int __must_check io_schedule_prepare(void);
++extern void io_schedule_finish(int token);
++extern long io_schedule_timeout(long timeout);
++extern void io_schedule(void);
++
++/* wrapper functions to trace from this header file */
++DECLARE_TRACEPOINT(sched_set_state_tp);
++extern void __trace_set_current_state(int state_value);
++DECLARE_TRACEPOINT(sched_set_need_resched_tp);
++extern void __trace_set_need_resched(struct task_struct *curr, int tif);
++
++/**
++ * struct prev_cputime - snapshot of system and user cputime
++ * @utime: time spent in user mode
++ * @stime: time spent in system mode
++ * @lock: protects the above two fields
++ *
++ * Stores previous user/system time values such that we can guarantee
++ * monotonicity.
++ */
++struct prev_cputime {
++#ifndef CONFIG_VIRT_CPU_ACCOUNTING_NATIVE
++	u64				utime;
++	u64				stime;
++	raw_spinlock_t			lock;
++#endif
++};
++
++enum vtime_state {
++	/* Task is sleeping or running in a CPU with VTIME inactive: */
++	VTIME_INACTIVE = 0,
++	/* Task is idle */
++	VTIME_IDLE,
++	/* Task runs in kernelspace in a CPU with VTIME active: */
++	VTIME_SYS,
++	/* Task runs in userspace in a CPU with VTIME active: */
++	VTIME_USER,
++	/* Task runs as guests in a CPU with VTIME active: */
++	VTIME_GUEST,
++};
++
++struct vtime {
++	seqcount_t		seqcount;
++	unsigned long long	starttime;
++	enum vtime_state	state;
++	unsigned int		cpu;
++	u64			utime;
++	u64			stime;
++	u64			gtime;
++};
++
++/*
++ * Utilization clamp constraints.
++ * @UCLAMP_MIN:	Minimum utilization
++ * @UCLAMP_MAX:	Maximum utilization
++ * @UCLAMP_CNT:	Utilization clamp constraints count
++ */
++enum uclamp_id {
++	UCLAMP_MIN = 0,
++	UCLAMP_MAX,
++	UCLAMP_CNT
++};
++
++extern struct root_domain def_root_domain;
++extern struct mutex sched_domains_mutex;
++extern void sched_domains_mutex_lock(void);
++extern void sched_domains_mutex_unlock(void);
++
++struct sched_param {
++	int sched_priority;
++};
++
++struct sched_info {
++#ifdef CONFIG_SCHED_INFO
++	/* Cumulative counters: */
++
++	/* # of times we have run on this CPU: */
++	unsigned long			pcount;
++
++	/* Time spent waiting on a runqueue: */
++	unsigned long long		run_delay;
++
++	/* Max time spent waiting on a runqueue: */
++	unsigned long long		max_run_delay;
++
++	/* Min time spent waiting on a runqueue: */
++	unsigned long long		min_run_delay;
++
++	/* Timestamps: */
++
++	/* When did we last run on a CPU? */
++	unsigned long long		last_arrival;
++
++	/* When were we last queued to run? */
++	unsigned long long		last_queued;
++
++	/* Timestamp of max time spent waiting on a runqueue: */
++	struct timespec64		max_run_delay_ts;
++
++#endif /* CONFIG_SCHED_INFO */
++};
++
++/*
++ * Integer metrics need fixed point arithmetic, e.g., sched/fair
++ * has a few: load, load_avg, util_avg, freq, and capacity.
++ *
++ * We define a basic fixed point arithmetic range, and then formalize
++ * all these metrics based on that basic range.
++ */
++# define SCHED_FIXEDPOINT_SHIFT		10
++# define SCHED_FIXEDPOINT_SCALE		(1L << SCHED_FIXEDPOINT_SHIFT)
++
++/* Increase resolution of cpu_capacity calculations */
++# define SCHED_CAPACITY_SHIFT		SCHED_FIXEDPOINT_SHIFT
++# define SCHED_CAPACITY_SCALE		(1L << SCHED_CAPACITY_SHIFT)
++
++struct load_weight {
++	unsigned long			weight;
++	u32				inv_weight;
++};
++
++/*
++ * The load/runnable/util_avg accumulates an infinite geometric series
++ * (see __update_load_avg_cfs_rq() in kernel/sched/pelt.c).
++ *
++ * [load_avg definition]
++ *
++ *   load_avg = runnable% * scale_load_down(load)
++ *
++ * [runnable_avg definition]
++ *
++ *   runnable_avg = runnable% * SCHED_CAPACITY_SCALE
++ *
++ * [util_avg definition]
++ *
++ *   util_avg = running% * SCHED_CAPACITY_SCALE
++ *
++ * where runnable% is the time ratio that a sched_entity is runnable and
++ * running% the time ratio that a sched_entity is running.
++ *
++ * For cfs_rq, they are the aggregated values of all runnable and blocked
++ * sched_entities.
++ *
++ * The load/runnable/util_avg doesn't directly factor frequency scaling and CPU
++ * capacity scaling. The scaling is done through the rq_clock_pelt that is used
++ * for computing those signals (see update_rq_clock_pelt())
++ *
++ * N.B., the above ratios (runnable% and running%) themselves are in the
++ * range of [0, 1]. To do fixed point arithmetics, we therefore scale them
++ * to as large a range as necessary. This is for example reflected by
++ * util_avg's SCHED_CAPACITY_SCALE.
++ *
++ * [Overflow issue]
++ *
++ * The 64-bit load_sum can have 4353082796 (=2^64/47742/88761) entities
++ * with the highest load (=88761), always runnable on a single cfs_rq,
++ * and should not overflow as the number already hits PID_MAX_LIMIT.
++ *
++ * For all other cases (including 32-bit kernels), struct load_weight's
++ * weight will overflow first before we do, because:
++ *
++ *    Max(load_avg) <= Max(load.weight)
++ *
++ * Then it is the load_weight's responsibility to consider overflow
++ * issues.
++ */
++struct sched_avg {
++	u64				last_update_time;
++	u64				load_sum;
++	u64				runnable_sum;
++	u32				util_sum;
++	u32				period_contrib;
++	unsigned long			load_avg;
++	unsigned long			runnable_avg;
++	unsigned long			util_avg;
++	unsigned int			util_est;
++} ____cacheline_aligned;
++
++/*
++ * The UTIL_AVG_UNCHANGED flag is used to synchronize util_est with util_avg
++ * updates. When a task is dequeued, its util_est should not be updated if its
++ * util_avg has not been updated in the meantime.
++ * This information is mapped into the MSB bit of util_est at dequeue time.
++ * Since max value of util_est for a task is 1024 (PELT util_avg for a task)
++ * it is safe to use MSB.
++ */
++#define UTIL_EST_WEIGHT_SHIFT		2
++#define UTIL_AVG_UNCHANGED		0x80000000
++
++struct sched_statistics {
++#ifdef CONFIG_SCHEDSTATS
++	u64				wait_start;
++	u64				wait_max;
++	u64				wait_count;
++	u64				wait_sum;
++	u64				iowait_count;
++	u64				iowait_sum;
++
++	u64				sleep_start;
++	u64				sleep_max;
++	s64				sum_sleep_runtime;
++
++	u64				block_start;
++	u64				block_max;
++	s64				sum_block_runtime;
++
++	s64				exec_max;
++	u64				slice_max;
++
++	u64				nr_migrations_cold;
++	u64				nr_failed_migrations_affine;
++	u64				nr_failed_migrations_running;
++	u64				nr_failed_migrations_hot;
++	u64				nr_forced_migrations;
++
++	u64				nr_wakeups;
++	u64				nr_wakeups_sync;
++	u64				nr_wakeups_migrate;
++	u64				nr_wakeups_local;
++	u64				nr_wakeups_remote;
++	u64				nr_wakeups_affine;
++	u64				nr_wakeups_affine_attempts;
++	u64				nr_wakeups_passive;
++	u64				nr_wakeups_idle;
++
++#ifdef CONFIG_SCHED_CORE
++	u64				core_forceidle_sum;
++#endif
++#endif /* CONFIG_SCHEDSTATS */
++} ____cacheline_aligned;
++
++struct sched_entity {
++	/* For load-balancing: */
++	struct load_weight		load;
++	struct rb_node			run_node;
++	u64				deadline;
++	u64				min_vruntime;
++	u64				min_slice;
++	u64				max_slice;
++
++	struct list_head		group_node;
++	unsigned char			on_rq;
++	unsigned char			sched_delayed;
++	unsigned char			rel_deadline;
++	unsigned char			custom_slice;
++					/* hole */
++
++	u64				exec_start;
++	u64				sum_exec_runtime;
++	u64				prev_sum_exec_runtime;
++	u64				vruntime;
++	/* Approximated virtual lag: */
++	s64				vlag;
++	/* 'Protected' deadline, to give out minimum quantums: */
++	u64				vprot;
++	u64				slice;
++
++	u64				nr_migrations;
++
++#ifdef CONFIG_FAIR_GROUP_SCHED
++	int				depth;
++	struct sched_entity		*parent;
++	/* rq on which this entity is (to be) queued: */
++	struct cfs_rq			*cfs_rq;
++	/* rq "owned" by this entity/group: */
++	struct cfs_rq			*my_q;
++	/* cached value of my_q->h_nr_running */
++	unsigned long			runnable_weight;
++#endif
++
++	/*
++	 * Per entity load average tracking.
++	 *
++	 * Put into separate cache line so it does not
++	 * collide with read-mostly values above.
++	 */
++	struct sched_avg		avg;
++};
++
++struct sched_rt_entity {
++	struct list_head		run_list;
++	unsigned long			timeout;
++	unsigned long			watchdog_stamp;
++	unsigned int			time_slice;
++	unsigned short			on_rq;
++	unsigned short			on_list;
++
++	struct sched_rt_entity		*back;
++#ifdef CONFIG_RT_GROUP_SCHED
++	struct sched_rt_entity		*parent;
++	/* rq on which this entity is (to be) queued: */
++	struct rt_rq			*rt_rq;
++	/* rq "owned" by this entity/group: */
++	struct rt_rq			*my_q;
++#endif
++} __randomize_layout;
++
++struct rq_flags;
++typedef struct task_struct *(*dl_server_pick_f)(struct sched_dl_entity *, struct rq_flags *rf);
++
++struct sched_dl_entity {
++	struct rb_node			rb_node;
++
++	/*
++	 * Original scheduling parameters. Copied here from sched_attr
++	 * during sched_setattr(), they will remain the same until
++	 * the next sched_setattr().
++	 */
++	u64				dl_runtime;	/* Maximum runtime for each instance	*/
++	u64				dl_deadline;	/* Relative deadline of each instance	*/
++	u64				dl_period;	/* Separation of two instances (period) */
++	u64				dl_bw;		/* dl_runtime / dl_period		*/
++	u64				dl_density;	/* dl_runtime / dl_deadline		*/
++
++	/*
++	 * Actual scheduling parameters. Initialized with the values above,
++	 * they are continuously updated during task execution. Note that
++	 * the remaining runtime could be < 0 in case we are in overrun.
++	 */
++	s64				runtime;	/* Remaining runtime for this instance	*/
++	u64				deadline;	/* Absolute deadline for this instance	*/
++	unsigned int			flags;		/* Specifying the scheduler behaviour	*/
++
++	/*
++	 * Some bool flags:
++	 *
++	 * @dl_throttled tells if we exhausted the runtime. If so, the
++	 * task has to wait for a replenishment to be performed at the
++	 * next firing of dl_timer.
++	 *
++	 * @dl_yielded tells if task gave up the CPU before consuming
++	 * all its available runtime during the last job.
++	 *
++	 * @dl_non_contending tells if the task is inactive while still
++	 * contributing to the active utilization. In other words, it
++	 * indicates if the inactive timer has been armed and its handler
++	 * has not been executed yet. This flag is useful to avoid race
++	 * conditions between the inactive timer handler and the wakeup
++	 * code.
++	 *
++	 * @dl_overrun tells if the task asked to be informed about runtime
++	 * overruns.
++	 *
++	 * @dl_server tells if this is a server entity.
++	 *
++	 * @dl_server_active tells if the dlserver is active(started).
++	 * dlserver is started on first cfs enqueue on an idle runqueue
++	 * and is stopped when a dequeue results in 0 cfs tasks on the
++	 * runqueue. In other words, dlserver is active only when cpu's
++	 * runqueue has atleast one cfs task.
++	 *
++	 * @dl_defer tells if this is a deferred or regular server. For
++	 * now only defer server exists.
++	 *
++	 * @dl_defer_armed tells if the deferrable server is waiting
++	 * for the replenishment timer to activate it.
++	 *
++	 * @dl_defer_running tells if the deferrable server is actually
++	 * running, skipping the defer phase.
++	 *
++	 * @dl_defer_idle tracks idle state
++	 */
++	unsigned int			dl_throttled      : 1;
++	unsigned int			dl_yielded        : 1;
++	unsigned int			dl_non_contending : 1;
++	unsigned int			dl_overrun	  : 1;
++	unsigned int			dl_server         : 1;
++	unsigned int			dl_server_active  : 1;
++	unsigned int			dl_defer	  : 1;
++	unsigned int			dl_defer_armed	  : 1;
++	unsigned int			dl_defer_running  : 1;
++	unsigned int			dl_defer_idle     : 1;
++
++	/*
++	 * Bandwidth enforcement timer. Each -deadline task has its
++	 * own bandwidth to be enforced, thus we need one timer per task.
++	 */
++	struct hrtimer			dl_timer;
++
++	/*
++	 * Inactive timer, responsible for decreasing the active utilization
++	 * at the "0-lag time". When a -deadline task blocks, it contributes
++	 * to GRUB's active utilization until the "0-lag time", hence a
++	 * timer is needed to decrease the active utilization at the correct
++	 * time.
++	 */
++	struct hrtimer			inactive_timer;
++
++	/*
++	 * Bits for DL-server functionality. Also see the comment near
++	 * dl_server_update().
++	 *
++	 * @rq the runqueue this server is for
++	 */
++	struct rq			*rq;
++	dl_server_pick_f		server_pick_task;
++
++#ifdef CONFIG_RT_MUTEXES
++	/*
++	 * Priority Inheritance. When a DEADLINE scheduling entity is boosted
++	 * pi_se points to the donor, otherwise points to the dl_se it belongs
++	 * to (the original one/itself).
++	 */
++	struct sched_dl_entity *pi_se;
++#endif
++};
++
++#ifdef CONFIG_UCLAMP_TASK
++/* Number of utilization clamp buckets (shorter alias) */
++#define UCLAMP_BUCKETS CONFIG_UCLAMP_BUCKETS_COUNT
++
++/*
++ * Utilization clamp for a scheduling entity
++ * @value:		clamp value "assigned" to a se
++ * @bucket_id:		bucket index corresponding to the "assigned" value
++ * @active:		the se is currently refcounted in a rq's bucket
++ * @user_defined:	the requested clamp value comes from user-space
++ *
++ * The bucket_id is the index of the clamp bucket matching the clamp value
++ * which is pre-computed and stored to avoid expensive integer divisions from
++ * the fast path.
++ *
++ * The active bit is set whenever a task has got an "effective" value assigned,
++ * which can be different from the clamp value "requested" from user-space.
++ * This allows to know a task is refcounted in the rq's bucket corresponding
++ * to the "effective" bucket_id.
++ *
++ * The user_defined bit is set whenever a task has got a task-specific clamp
++ * value requested from userspace, i.e. the system defaults apply to this task
++ * just as a restriction. This allows to relax default clamps when a less
++ * restrictive task-specific value has been requested, thus allowing to
++ * implement a "nice" semantic. For example, a task running with a 20%
++ * default boost can still drop its own boosting to 0%.
++ */
++struct uclamp_se {
++	unsigned int value		: bits_per(SCHED_CAPACITY_SCALE);
++	unsigned int bucket_id		: bits_per(UCLAMP_BUCKETS);
++	unsigned int active		: 1;
++	unsigned int user_defined	: 1;
++};
++#endif /* CONFIG_UCLAMP_TASK */
++
++union rcu_special {
++	struct {
++		u8			blocked;
++		u8			need_qs;
++		u8			exp_hint; /* Hint for performance. */
++		u8			need_mb; /* Readers need smp_mb(). */
++	} b; /* Bits. */
++	u32 s; /* Set of bits. */
++};
++
++enum perf_event_task_context {
++	perf_invalid_context = -1,
++	perf_hw_context = 0,
++	perf_sw_context,
++	perf_nr_task_contexts,
++};
++
++/*
++ * Number of contexts where an event can trigger:
++ *      task, softirq, hardirq, nmi.
++ */
++#define PERF_NR_CONTEXTS	4
++
++struct wake_q_node {
++	struct wake_q_node *next;
++};
++
++struct kmap_ctrl {
++#ifdef CONFIG_KMAP_LOCAL
++	int				idx;
++	pte_t				pteval[KM_MAX_IDX];
++#endif
++};
++
++struct task_struct {
++#ifdef CONFIG_THREAD_INFO_IN_TASK
++	/*
++	 * For reasons of header soup (see current_thread_info()), this
++	 * must be the first element of task_struct.
++	 */
++	struct thread_info		thread_info;
++#endif
++	unsigned int			__state;
++
++	/* saved state for "spinlock sleepers" */
++	unsigned int			saved_state;
++
++	/*
++	 * This begins the randomizable portion of task_struct. Only
++	 * scheduling-critical items should be added above here.
++	 */
++	randomized_struct_fields_start
++
++	void				*stack;
++	refcount_t			usage;
++	/* Per task flags (PF_*), defined further below: */
++	unsigned int			flags;
++	unsigned int			ptrace;
++
++#ifdef CONFIG_MEM_ALLOC_PROFILING
++	struct alloc_tag		*alloc_tag;
++#endif
++
++	int				on_cpu;
++	struct __call_single_node	wake_entry;
++	unsigned int			wakee_flips;
++	unsigned long			wakee_flip_decay_ts;
++	struct task_struct		*last_wakee;
++
++	/*
++	 * recent_used_cpu is initially set as the last CPU used by a task
++	 * that wakes affine another task. Waker/wakee relationships can
++	 * push tasks around a CPU where each wakeup moves to the next one.
++	 * Tracking a recently used CPU allows a quick search for a recently
++	 * used CPU that may be idle.
++	 */
++	int				recent_used_cpu;
++	int				wake_cpu;
++	int				on_rq;
++
++	int				prio;
++	int				static_prio;
++	int				normal_prio;
++	unsigned int			rt_priority;
++
++	struct sched_entity		se;
++	struct sched_rt_entity		rt;
++	struct sched_dl_entity		dl;
++	struct sched_dl_entity		*dl_server;
++#ifdef CONFIG_SCHED_CLASS_EXT
++	struct sched_ext_entity		scx;
++#endif
++	const struct sched_class	*sched_class;
++
++#ifdef CONFIG_SCHED_CORE
++	struct rb_node			core_node;
++	unsigned long			core_cookie;
++	unsigned int			core_occupation;
++#endif
++
++#ifdef CONFIG_CGROUP_SCHED
++	struct task_group		*sched_task_group;
++#ifdef CONFIG_CFS_BANDWIDTH
++	struct callback_head		sched_throttle_work;
++	struct list_head		throttle_node;
++	bool				throttled;
++#endif
++#endif
++
++
++#ifdef CONFIG_UCLAMP_TASK
++	/*
++	 * Clamp values requested for a scheduling entity.
++	 * Must be updated with task_rq_lock() held.
++	 */
++	struct uclamp_se		uclamp_req[UCLAMP_CNT];
++	/*
++	 * Effective clamp values used for a scheduling entity.
++	 * Must be updated with task_rq_lock() held.
++	 */
++	struct uclamp_se		uclamp[UCLAMP_CNT];
++#endif
++
++	struct sched_statistics         stats;
++
++#ifdef CONFIG_PREEMPT_NOTIFIERS
++	/* List of struct preempt_notifier: */
++	struct hlist_head		preempt_notifiers;
++#endif
++
++#ifdef CONFIG_BLK_DEV_IO_TRACE
++	unsigned int			btrace_seq;
++#endif
++
++	unsigned int			policy;
++	unsigned long			max_allowed_capacity;
++	int				nr_cpus_allowed;
++	const cpumask_t			*cpus_ptr;
++	cpumask_t			*user_cpus_ptr;
++	cpumask_t			cpus_mask;
++	void				*migration_pending;
++	unsigned short			migration_disabled;
++	unsigned short			migration_flags;
++
++#ifdef CONFIG_PREEMPT_RCU
++	int				rcu_read_lock_nesting;
++	union rcu_special		rcu_read_unlock_special;
++	struct list_head		rcu_node_entry;
++	struct rcu_node			*rcu_blocked_node;
++#endif /* #ifdef CONFIG_PREEMPT_RCU */
++
++#ifdef CONFIG_TASKS_RCU
++	unsigned long			rcu_tasks_nvcsw;
++	u8				rcu_tasks_holdout;
++	u8				rcu_tasks_idx;
++	int				rcu_tasks_idle_cpu;
++	struct list_head		rcu_tasks_holdout_list;
++	int				rcu_tasks_exit_cpu;
++	struct list_head		rcu_tasks_exit_list;
++#endif /* #ifdef CONFIG_TASKS_RCU */
++
++#ifdef CONFIG_TASKS_TRACE_RCU
++	int				trc_reader_nesting;
++	struct srcu_ctr __percpu	*trc_reader_scp;
++#endif /* #ifdef CONFIG_TASKS_TRACE_RCU */
++
++#ifdef CONFIG_TRIVIAL_PREEMPT_RCU
++	int				rcu_trivial_preempt_nesting;
++#endif /* #ifdef CONFIG_TRIVIAL_PREEMPT_RCU */
++
++	struct sched_info		sched_info;
++
++	struct list_head		tasks;
++	struct plist_node		pushable_tasks;
++	struct rb_node			pushable_dl_tasks;
++
++	struct mm_struct		*mm;
++	struct mm_struct		*active_mm;
++
++	int				exit_state;
++	int				exit_code;
++	int				exit_signal;
++	/* The signal sent when the parent dies: */
++	int				pdeath_signal;
++	/* JOBCTL_*, siglock protected: */
++	unsigned long			jobctl;
++
++	/* Used for emulating ABI behavior of previous Linux versions: */
++	unsigned int			personality;
++
++	/* Scheduler bits, serialized by scheduler locks: */
++	unsigned			sched_reset_on_fork:1;
++	unsigned			sched_contributes_to_load:1;
++	unsigned			sched_migrated:1;
++	unsigned			sched_task_hot:1;
++
++	/* Force alignment to the next boundary: */
++	unsigned			:0;
++
++	/* Unserialized, strictly 'current' */
++
++	/*
++	 * This field must not be in the scheduler word above due to wakelist
++	 * queueing no longer being serialized by p->on_cpu. However:
++	 *
++	 * p->XXX = X;			ttwu()
++	 * schedule()			  if (p->on_rq && ..) // false
++	 *   smp_mb__after_spinlock();	  if (smp_load_acquire(&p->on_cpu) && //true
++	 *   deactivate_task()		      ttwu_queue_wakelist())
++	 *     p->on_rq = 0;			p->sched_remote_wakeup = Y;
++	 *
++	 * guarantees all stores of 'current' are visible before
++	 * ->sched_remote_wakeup gets used, so it can be in this word.
++	 */
++	unsigned			sched_remote_wakeup:1;
++#ifdef CONFIG_RT_MUTEXES
++	unsigned			sched_rt_mutex:1;
++#endif
++
++	/* Save user-dumpable when mm goes away */
++	unsigned			user_dumpable:1;
++
++	/* Bit to tell TOMOYO we're in execve(): */
++	unsigned			in_execve:1;
++	unsigned			in_iowait:1;
++#ifndef TIF_RESTORE_SIGMASK
++	unsigned			restore_sigmask:1;
++#endif
++#ifdef CONFIG_MEMCG_V1
++	unsigned			in_user_fault:1;
++#endif
++#ifdef CONFIG_LRU_GEN
++	/* whether the LRU algorithm may apply to this access */
++	unsigned			in_lru_fault:1;
++#endif
++#ifdef CONFIG_COMPAT_BRK
++	unsigned			brk_randomized:1;
++#endif
++#ifdef CONFIG_CGROUPS
++	/* disallow userland-initiated cgroup migration */
++	unsigned			no_cgroup_migration:1;
++	/* task is frozen/stopped (used by the cgroup freezer) */
++	unsigned			frozen:1;
++#endif
++#ifdef CONFIG_BLK_CGROUP
++	unsigned			use_memdelay:1;
++#endif
++#ifdef CONFIG_PSI
++	/* Stalled due to lack of memory */
++	unsigned			in_memstall:1;
++#endif
++#ifdef CONFIG_PAGE_OWNER
++	/* Used by page_owner=on to detect recursion in page tracking. */
++	unsigned			in_page_owner:1;
++#endif
++#ifdef CONFIG_EVENTFD
++	/* Recursion prevention for eventfd_signal() */
++	unsigned			in_eventfd:1;
++#endif
++#ifdef CONFIG_ARCH_HAS_CPU_PASID
++	unsigned			pasid_activated:1;
++#endif
++#ifdef CONFIG_X86_BUS_LOCK_DETECT
++	unsigned			reported_split_lock:1;
++#endif
++#ifdef CONFIG_TASK_DELAY_ACCT
++	/* delay due to memory thrashing */
++	unsigned                        in_thrashing:1;
++#endif
++	unsigned			in_nf_duplicate:1;
++#ifdef CONFIG_PREEMPT_RT
++	struct netdev_xmit		net_xmit;
++#endif
++	unsigned long			atomic_flags; /* Flags requiring atomic access. */
++
++	struct restart_block		restart_block;
++
++	pid_t				pid;
++	pid_t				tgid;
++
++#ifdef CONFIG_STACKPROTECTOR
++	/* Canary value for the -fstack-protector GCC feature: */
++	unsigned long			stack_canary;
++#endif
++	/*
++	 * Pointers to the (original) parent process, youngest child, younger sibling,
++	 * older sibling, respectively.  (p->father can be replaced with
++	 * p->real_parent->pid)
++	 */
++
++	/* Real parent process: */
++	struct task_struct __rcu	*real_parent;
++
++	/* Recipient of SIGCHLD, wait4() reports: */
++	struct task_struct __rcu	*parent;
++
++	/*
++	 * Children/sibling form the list of natural children:
++	 */
++	struct list_head		children;
++	struct list_head		sibling;
++	struct task_struct		*group_leader;
++
++	/*
++	 * 'ptraced' is the list of tasks this task is using ptrace() on.
++	 *
++	 * This includes both natural children and PTRACE_ATTACH targets.
++	 * 'ptrace_entry' is this task's link on the p->parent->ptraced list.
++	 */
++	struct list_head		ptraced;
++	struct list_head		ptrace_entry;
++
++	/* PID/PID hash table linkage. */
++	struct pid			*thread_pid;
++	struct hlist_node		pid_links[PIDTYPE_MAX];
++	struct list_head		thread_node;
++
++	struct completion		*vfork_done;
++
++	/* CLONE_CHILD_SETTID: */
++	int __user			*set_child_tid;
++
++	/* CLONE_CHILD_CLEARTID: */
++	int __user			*clear_child_tid;
++
++	/* PF_KTHREAD | PF_IO_WORKER */
++	void				*worker_private;
++
++	u64				utime;
++	u64				stime;
++#ifdef CONFIG_ARCH_HAS_SCALED_CPUTIME
++	u64				utimescaled;
++	u64				stimescaled;
++#endif
++	u64				gtime;
++	struct prev_cputime		prev_cputime;
++#ifdef CONFIG_VIRT_CPU_ACCOUNTING_GEN
++	struct vtime			vtime;
++#endif
++
++#ifdef CONFIG_NO_HZ_FULL
++	atomic_t			tick_dep_mask;
++#endif
++	/* Context switch counts: */
++	unsigned long			nvcsw;
++	unsigned long			nivcsw;
++
++	/* Monotonic time in nsecs: */
++	u64				start_time;
++
++	/* Boot based time in nsecs: */
++	u64				start_boottime;
++
++	/* MM fault and swap info: this can arguably be seen as either mm-specific or thread-specific: */
++	unsigned long			min_flt;
++	unsigned long			maj_flt;
++
++	/* Empty if CONFIG_POSIX_CPUTIMERS=n */
++	struct posix_cputimers		posix_cputimers;
++
++#ifdef CONFIG_POSIX_CPU_TIMERS_TASK_WORK
++	struct posix_cputimers_work	posix_cputimers_work;
++#endif
++
++	/* Process credentials: */
++
++	/* Tracer's credentials at attach: */
++	const struct cred __rcu		*ptracer_cred;
++
++	/* Objective and real subjective task credentials (COW): */
++	const struct cred __rcu		*real_cred;
++
++	/* Effective (overridable) subjective task credentials (COW): */
++	const struct cred __rcu		*cred;
++
++#ifdef CONFIG_KEYS
++	/* Cached requested key. */
++	struct key			*cached_requested_key;
++#endif
++
++	/*
++	 * executable name, excluding path.
++	 *
++	 * - normally initialized by begin_new_exec()
++	 * - set it with set_task_comm() to ensure it is always
++	 *   NUL-terminated and zero-padded
++	 */
++	char				comm[TASK_COMM_LEN];
++
++	struct nameidata		*nameidata;
++
++#ifdef CONFIG_SYSVIPC
++	struct sysv_sem			sysvsem;
++	struct sysv_shm			sysvshm;
++#endif
++#ifdef CONFIG_DETECT_HUNG_TASK
++	unsigned long			last_switch_count;
++	unsigned long			last_switch_time;
++#endif
++	/* Filesystem information: */
++	struct fs_struct		*fs;
++
++	/* Open file information: */
++	struct files_struct		*files;
++
++#ifdef CONFIG_IO_URING
++	struct io_uring_task		*io_uring;
++	struct io_restriction		*io_uring_restrict;
++#endif
++
++	/* Namespaces: */
++	struct nsproxy			*nsproxy;
++
++	/* Signal handlers: */
++	struct signal_struct		*signal;
++	struct sighand_struct __rcu		*sighand;
++	sigset_t			blocked;
++	sigset_t			real_blocked;
++	/* Restored if set_restore_sigmask() was used: */
++	sigset_t			saved_sigmask;
++	struct sigpending		pending;
++	unsigned long			sas_ss_sp;
++	size_t				sas_ss_size;
++	unsigned int			sas_ss_flags;
++
++	struct callback_head		*task_works;
++
++#ifdef CONFIG_AUDIT
++#ifdef CONFIG_AUDITSYSCALL
++	struct audit_context		*audit_context;
++#endif
++	kuid_t				loginuid;
++	unsigned int			sessionid;
++#endif
++	struct seccomp			seccomp;
++	struct syscall_user_dispatch	syscall_dispatch;
++
++	/* Thread group tracking: */
++	u64				parent_exec_id;
++	u64				self_exec_id;
++
++	/* Protection against (de-)allocation: mm, files, fs, tty, keyrings, mems_allowed, mempolicy: */
++	spinlock_t			alloc_lock;
++
++	/* Protection of the PI data structures: */
++	raw_spinlock_t			pi_lock;
++
++	struct wake_q_node		wake_q;
++
++#ifdef CONFIG_RT_MUTEXES
++	/* PI waiters blocked on a rt_mutex held by this task: */
++	struct rb_root_cached		pi_waiters;
++	/* Updated under owner's pi_lock and rq lock */
++	struct task_struct		*pi_top_task;
++	/* Deadlock detection and priority inheritance handling: */
++	struct rt_mutex_waiter		*pi_blocked_on;
++#endif
++
++	struct mutex			*blocked_on;	/* lock we're blocked on */
++	raw_spinlock_t			blocked_lock;
++
++#ifdef CONFIG_DETECT_HUNG_TASK_BLOCKER
++	/*
++	 * Encoded lock address causing task block (lower 2 bits = type from
++	 * <linux/hung_task.h>). Accessed via hung_task_*() helpers.
++	 */
++	unsigned long			blocker;
++#endif
++
++#ifdef CONFIG_DEBUG_ATOMIC_SLEEP
++	int				non_block_count;
++#endif
++
++#ifdef CONFIG_TRACE_IRQFLAGS
++	struct irqtrace_events		irqtrace;
++	unsigned int			hardirq_threaded;
++	u64				hardirq_chain_key;
++	int				softirqs_enabled;
++	int				softirq_context;
++	int				irq_config;
++#endif
++#ifdef CONFIG_PREEMPT_RT
++	int				softirq_disable_cnt;
++#endif
++
++#ifdef CONFIG_LOCKDEP
++# define MAX_LOCK_DEPTH			48UL
++	u64				curr_chain_key;
++	int				lockdep_depth;
++	unsigned int			lockdep_recursion;
++	struct held_lock		held_locks[MAX_LOCK_DEPTH];
++#endif
++
++#if defined(CONFIG_UBSAN) && !defined(CONFIG_UBSAN_TRAP)
++	unsigned int			in_ubsan;
++#endif
++
++	/* Journalling filesystem info: */
++	void				*journal_info;
++
++	/* Stacked block device info: */
++	struct bio_list			*bio_list;
++
++	/* Stack plugging: */
++	struct blk_plug			*plug;
++
++	/* VM state: */
++	struct reclaim_state		*reclaim_state;
++
++	struct io_context		*io_context;
++
++#ifdef CONFIG_COMPACTION
++	struct capture_control		*capture_control;
++#endif
++	/* Ptrace state: */
++	unsigned long			ptrace_message;
++	kernel_siginfo_t		*last_siginfo;
++
++	struct task_io_accounting	ioac;
++#ifdef CONFIG_PSI
++	/* Pressure stall state */
++	unsigned int			psi_flags;
++#endif
++#ifdef CONFIG_TASK_XACCT
++	/* Accumulated RSS usage: */
++	u64				acct_rss_mem1;
++	/* Accumulated virtual memory usage: */
++	u64				acct_vm_mem1;
++	/* stime + utime since last update: */
++	u64				acct_timexpd;
++#endif
++#ifdef CONFIG_CPUSETS
++	/* Protected by ->alloc_lock: */
++	nodemask_t			mems_allowed;
++	/* Sequence number to catch updates: */
++	seqcount_spinlock_t		mems_allowed_seq;
++	int				cpuset_mem_spread_rotor;
++#endif
++#ifdef CONFIG_CGROUPS
++	/* Control Group info protected by css_set_lock: */
++	struct css_set __rcu		*cgroups;
++	/* cg_list protected by css_set_lock and tsk->alloc_lock: */
++	struct list_head		cg_list;
++#ifdef CONFIG_PREEMPT_RT
++	struct llist_node		cg_dead_lnode;
++#endif	/* CONFIG_PREEMPT_RT */
++#endif	/* CONFIG_CGROUPS */
++#ifdef CONFIG_X86_CPU_RESCTRL
++	u32				closid;
++	u32				rmid;
++#endif
++#ifdef CONFIG_FUTEX
++	struct robust_list_head __user	*robust_list;
++#ifdef CONFIG_COMPAT
++	struct compat_robust_list_head __user *compat_robust_list;
++#endif
++	struct list_head		pi_state_list;
++	struct futex_pi_state		*pi_state_cache;
++	struct mutex			futex_exit_mutex;
++	unsigned int			futex_state;
++#endif
++#ifdef CONFIG_PERF_EVENTS
++	u8				perf_recursion[PERF_NR_CONTEXTS];
++	struct perf_event_context	*perf_event_ctxp;
++	struct mutex			perf_event_mutex;
++	struct list_head		perf_event_list;
++	struct perf_ctx_data __rcu	*perf_ctx_data;
++#endif
++#ifdef CONFIG_DEBUG_PREEMPT
++	unsigned long			preempt_disable_ip;
++#endif
++#ifdef CONFIG_NUMA
++	/* Protected by alloc_lock: */
++	struct mempolicy		*mempolicy;
++	short				il_prev;
++	u8				il_weight;
++	short				pref_node_fork;
++#endif
++#ifdef CONFIG_NUMA_BALANCING
++	int				numa_scan_seq;
++	unsigned int			numa_scan_period;
++	unsigned int			numa_scan_period_max;
++	int				numa_preferred_nid;
++	unsigned long			numa_migrate_retry;
++	/* Migration stamp: */
++	u64				node_stamp;
++	u64				last_task_numa_placement;
++	u64				last_sum_exec_runtime;
++	struct callback_head		numa_work;
++
++	/*
++	 * This pointer is only modified for current in syscall and
++	 * pagefault context (and for tasks being destroyed), so it can be read
++	 * from any of the following contexts:
++	 *  - RCU read-side critical section
++	 *  - current->numa_group from everywhere
++	 *  - task's runqueue locked, task not running
++	 */
++	struct numa_group __rcu		*numa_group;
++
++	/*
++	 * numa_faults is an array split into four regions:
++	 * faults_memory, faults_cpu, faults_memory_buffer, faults_cpu_buffer
++	 * in this precise order.
++	 *
++	 * faults_memory: Exponential decaying average of faults on a per-node
++	 * basis. Scheduling placement decisions are made based on these
++	 * counts. The values remain static for the duration of a PTE scan.
++	 * faults_cpu: Track the nodes the process was running on when a NUMA
++	 * hinting fault was incurred.
++	 * faults_memory_buffer and faults_cpu_buffer: Record faults per node
++	 * during the current scan window. When the scan completes, the counts
++	 * in faults_memory and faults_cpu decay and these values are copied.
++	 */
++	unsigned long			*numa_faults;
++	unsigned long			total_numa_faults;
++
++	/*
++	 * numa_faults_locality tracks if faults recorded during the last
++	 * scan window were remote/local or failed to migrate. The task scan
++	 * period is adapted based on the locality of the faults with different
++	 * weights depending on whether they were shared or private faults
++	 */
++	unsigned long			numa_faults_locality[3];
++
++	unsigned long			numa_pages_migrated;
++#endif /* CONFIG_NUMA_BALANCING */
++
++	struct rseq_data		rseq;
++	struct sched_mm_cid		mm_cid;
++
++	struct tlbflush_unmap_batch	tlb_ubc;
++
++	/* Cache last used pipe for splice(): */
++	struct pipe_inode_info		*splice_pipe;
++
++	struct page_frag		task_frag;
++
++#ifdef CONFIG_ARCH_HAS_LAZY_MMU_MODE
++	struct lazy_mmu_state		lazy_mmu_state;
++#endif
++
++#ifdef CONFIG_TASK_DELAY_ACCT
++	struct task_delay_info		*delays;
++#endif
++
++#ifdef CONFIG_FAULT_INJECTION
++	int				make_it_fail;
++	unsigned int			fail_nth;
++#endif
++	/*
++	 * When (nr_dirtied >= nr_dirtied_pause), it's time to call
++	 * balance_dirty_pages() for a dirty throttling pause:
++	 */
++	int				nr_dirtied;
++	int				nr_dirtied_pause;
++	/* Start of a write-and-pause period: */
++	unsigned long			dirty_paused_when;
++
++#ifdef CONFIG_LATENCYTOP
++	int				latency_record_count;
++	struct latency_record		latency_record[LT_SAVECOUNT];
++#endif
++	/*
++	 * Time slack values; these are used to round up poll() and
++	 * select() etc timeout values. These are in nanoseconds.
++	 */
++	u64				timer_slack_ns;
++	u64				default_timer_slack_ns;
++
++#if defined(CONFIG_KASAN_GENERIC) || defined(CONFIG_KASAN_SW_TAGS)
++	unsigned int			kasan_depth;
++#endif
++
++#ifdef CONFIG_KCSAN
++	struct kcsan_ctx		kcsan_ctx;
++#ifdef CONFIG_TRACE_IRQFLAGS
++	struct irqtrace_events		kcsan_save_irqtrace;
++#endif
++#ifdef CONFIG_KCSAN_WEAK_MEMORY
++	int				kcsan_stack_depth;
++#endif
++#endif
++
++#ifdef CONFIG_KMSAN
++	struct kmsan_ctx		kmsan_ctx;
++#endif
++
++#if IS_ENABLED(CONFIG_KUNIT)
++	struct kunit			*kunit_test;
++#endif
++
++#ifdef CONFIG_FUNCTION_GRAPH_TRACER
++	/* Index of current stored address in ret_stack: */
++	int				curr_ret_stack;
++	int				curr_ret_depth;
++
++	/* Stack of return addresses for return function tracing: */
++	unsigned long			*ret_stack;
++
++	/* Timestamp for last schedule: */
++	unsigned long long		ftrace_timestamp;
++	unsigned long long		ftrace_sleeptime;
++
++	/*
++	 * Number of functions that haven't been traced
++	 * because of depth overrun:
++	 */
++	atomic_t			trace_overrun;
++
++	/* Pause tracing: */
++	atomic_t			tracing_graph_pause;
++#endif
++
++#ifdef CONFIG_TRACING
++	/* Bitmask and counter of trace recursion: */
++	unsigned long			trace_recursion;
++#endif /* CONFIG_TRACING */
++
++#ifdef CONFIG_KCOV
++	/* See kernel/kcov.c for more details. */
++
++	/* Coverage collection mode enabled for this task (0 if disabled): */
++	unsigned int			kcov_mode;
++
++	/* Size of the kcov_area: */
++	unsigned int			kcov_size;
++
++	/* Buffer for coverage collection: */
++	void				*kcov_area;
++
++	/* KCOV descriptor wired with this task or NULL: */
++	struct kcov			*kcov;
++
++	/* KCOV common handle for remote coverage collection: */
++	u64				kcov_handle;
++
++	/* KCOV sequence number: */
++	int				kcov_sequence;
++
++	/* Collect coverage from softirq context: */
++	unsigned int			kcov_softirq;
++
++	/* Temporary storage for preempting remote coverage collection: */
++	unsigned int			kcov_saved_mode;
++	unsigned int			kcov_saved_size;
++	void				*kcov_saved_area;
++	struct kcov			*kcov_saved_kcov;
++	int				kcov_saved_sequence;
++
++#endif
++
++#ifdef CONFIG_MEMCG_V1
++	struct mem_cgroup		*memcg_in_oom;
++#endif
++
++#ifdef CONFIG_MEMCG
++	/* Number of pages to reclaim on returning to userland: */
++	unsigned int			memcg_nr_pages_over_high;
++
++	/* Used by memcontrol for targeted memcg charge: */
++	struct mem_cgroup		*active_memcg;
++
++	/* Cache for current->cgroups->memcg->nodeinfo[nid]->objcg lookups: */
++	struct obj_cgroup		*objcg;
++#endif
++
++#ifdef CONFIG_BLK_CGROUP
++	struct gendisk			*throttle_disk;
++#endif
++
++#ifdef CONFIG_UPROBES
++	struct uprobe_task		*utask;
++#endif
++#if defined(CONFIG_BCACHE) || defined(CONFIG_BCACHE_MODULE)
++	unsigned int			sequential_io;
++	unsigned int			sequential_io_avg;
++#endif
++	struct kmap_ctrl		kmap_ctrl;
++#ifdef CONFIG_DEBUG_ATOMIC_SLEEP
++	unsigned long			task_state_change;
++# ifdef CONFIG_PREEMPT_RT
++	unsigned long			saved_state_change;
++# endif
++#endif
++	struct rcu_head			rcu;
++	refcount_t			rcu_users;
++	int				pagefault_disabled;
++#ifdef CONFIG_MMU
++	struct task_struct		*oom_reaper_list;
++	struct timer_list		oom_reaper_timer;
++#endif
++#ifdef CONFIG_VMAP_STACK
++	struct vm_struct		*stack_vm_area;
++#endif
++#ifdef CONFIG_THREAD_INFO_IN_TASK
++	/* A live task holds one reference: */
++	refcount_t			stack_refcount;
++#endif
++#ifdef CONFIG_LIVEPATCH
++	int patch_state;
++#endif
++#ifdef CONFIG_SECURITY
++	/* Used by LSM modules for access restriction: */
++	void				*security;
++#endif
++#ifdef CONFIG_BPF_SYSCALL
++	/* Used by BPF task local storage */
++	struct bpf_local_storage __rcu	*bpf_storage;
++	/* Used for BPF run context */
++	struct bpf_run_ctx		*bpf_ctx;
++#endif
++	/* Used by BPF for per-TASK xdp storage */
++	struct bpf_net_context		*bpf_net_context;
++
++#ifdef CONFIG_KSTACK_ERASE
++	unsigned long			lowest_stack;
++#endif
++#ifdef CONFIG_KSTACK_ERASE_METRICS
++	unsigned long			prev_lowest_stack;
++#endif
++
++#ifdef CONFIG_X86_MCE
++	void __user			*mce_vaddr;
++	__u64				mce_kflags;
++	u64				mce_addr;
++	__u64				mce_ripv : 1,
++					mce_whole_page : 1,
++					__mce_reserved : 62;
++	struct callback_head		mce_kill_me;
++	int				mce_count;
++#endif
++
++#ifdef CONFIG_KRETPROBES
++	struct llist_head               kretprobe_instances;
++#endif
++#ifdef CONFIG_RETHOOK
++	struct llist_head               rethooks;
++#endif
++
++#ifdef CONFIG_ARCH_HAS_PARANOID_L1D_FLUSH
++	/*
++	 * If L1D flush is supported on mm context switch
++	 * then we use this callback head to queue kill work
++	 * to kill tasks that are not running on SMT disabled
++	 * cores
++	 */
++	struct callback_head		l1d_flush_kill;
++#endif
++
++#ifdef CONFIG_RV
++	/*
++	 * Per-task RV monitor, fixed in CONFIG_RV_PER_TASK_MONITORS.
++	 * If memory becomes a concern, we can think about a dynamic method.
++	 */
++	union rv_task_monitor		rv[CONFIG_RV_PER_TASK_MONITORS];
++#endif
++
++#ifdef CONFIG_USER_EVENTS
++	struct user_event_mm		*user_event_mm;
++#endif
++
++#ifdef CONFIG_UNWIND_USER
++	struct unwind_task_info		unwind_info;
++#endif
++
++	/* CPU-specific state of this task: */
++	struct thread_struct		thread;
++
++	/*
++	 * New fields for task_struct should be added above here, so that
++	 * they are included in the randomized portion of task_struct.
++	 */
++	randomized_struct_fields_end
++} __attribute__ ((aligned (64)));
++
++#ifdef CONFIG_SCHED_PROXY_EXEC
++DECLARE_STATIC_KEY_TRUE(__sched_proxy_exec);
++static inline bool sched_proxy_exec(void)
++{
++	return static_branch_likely(&__sched_proxy_exec);
++}
++#else
++static inline bool sched_proxy_exec(void)
++{
++	return false;
++}
++#endif
++
++#define TASK_REPORT_IDLE	(TASK_REPORT + 1)
++#define TASK_REPORT_MAX		(TASK_REPORT_IDLE << 1)
++
++static inline unsigned int __task_state_index(unsigned int tsk_state,
++					      unsigned int tsk_exit_state)
++{
++	unsigned int state = (tsk_state | tsk_exit_state) & TASK_REPORT;
++
++	BUILD_BUG_ON_NOT_POWER_OF_2(TASK_REPORT_MAX);
++
++	if ((tsk_state & TASK_IDLE) == TASK_IDLE)
++		state = TASK_REPORT_IDLE;
++
++	/*
++	 * We're lying here, but rather than expose a completely new task state
++	 * to userspace, we can make this appear as if the task has gone through
++	 * a regular rt_mutex_lock() call.
++	 * Report frozen tasks as uninterruptible.
++	 */
++	if ((tsk_state & TASK_RTLOCK_WAIT) || (tsk_state & TASK_FROZEN))
++		state = TASK_UNINTERRUPTIBLE;
++
++	return fls(state);
++}
++
++static inline unsigned int task_state_index(struct task_struct *tsk)
++{
++	return __task_state_index(READ_ONCE(tsk->__state), tsk->exit_state);
++}
++
++static inline char task_index_to_char(unsigned int state)
++{
++	static const char state_char[] = "RSDTtXZPI";
++
++	BUILD_BUG_ON(TASK_REPORT_MAX * 2 != 1 << (sizeof(state_char) - 1));
++
++	return state_char[state];
++}
++
++static inline char task_state_to_char(struct task_struct *tsk)
++{
++	return task_index_to_char(task_state_index(tsk));
++}
++
++#ifdef CONFIG_ARCH_HAS_LAZY_MMU_MODE
++/**
++ * __task_lazy_mmu_mode_active() - Test the lazy MMU mode state for a task.
++ * @tsk: The task to check.
++ *
++ * Test whether @tsk has its lazy MMU mode state set to active (i.e. enabled
++ * and not paused).
++ *
++ * This function only considers the state saved in task_struct; to test whether
++ * current actually is in lazy MMU mode, is_lazy_mmu_mode_active() should be
++ * used instead.
++ *
++ * This function is intended for architectures that implement the lazy MMU
++ * mode; it must not be called from generic code.
++ */
++static inline bool __task_lazy_mmu_mode_active(struct task_struct *tsk)
++{
++	struct lazy_mmu_state *state = &tsk->lazy_mmu_state;
++
++	return state->enable_count > 0 && state->pause_count == 0;
++}
++
++/**
++ * is_lazy_mmu_mode_active() - Test whether we are currently in lazy MMU mode.
++ *
++ * Test whether the current context is in lazy MMU mode. This is true if both:
++ * 1. We are not in interrupt context
++ * 2. Lazy MMU mode is active for the current task
++ *
++ * This function is intended for architectures that implement the lazy MMU
++ * mode; it must not be called from generic code.
++ */
++static inline bool is_lazy_mmu_mode_active(void)
++{
++	if (in_interrupt())
++		return false;
++
++	return __task_lazy_mmu_mode_active(current);
++}
++#endif
++
++extern struct pid *cad_pid;
++
++/*
++ * Per process flags
++ */
++#define PF_VCPU			0x00000001	/* I'm a virtual CPU */
++#define PF_IDLE			0x00000002	/* I am an IDLE thread */
++#define PF_EXITING		0x00000004	/* Getting shut down */
++#define PF_POSTCOREDUMP		0x00000008	/* Coredumps should ignore this task */
++#define PF_IO_WORKER		0x00000010	/* Task is an IO worker */
++#define PF_WQ_WORKER		0x00000020	/* I'm a workqueue worker */
++#define PF_FORKNOEXEC		0x00000040	/* Forked but didn't exec */
++#define PF_MCE_PROCESS		0x00000080      /* Process policy on mce errors */
++#define PF_SUPERPRIV		0x00000100	/* Used super-user privileges */
++#define PF_DUMPCORE		0x00000200	/* Dumped core */
++#define PF_SIGNALED		0x00000400	/* Killed by a signal */
++#define PF_MEMALLOC		0x00000800	/* Allocating memory to free memory. See memalloc_noreclaim_save() */
++#define PF_NPROC_EXCEEDED	0x00001000	/* set_user() noticed that RLIMIT_NPROC was exceeded */
++#define PF_USED_MATH		0x00002000	/* If unset the fpu must be initialized before use */
++#define PF_USER_WORKER		0x00004000	/* Kernel thread cloned from userspace thread */
++#define PF_NOFREEZE		0x00008000	/* This thread should not be frozen */
++#define PF_KCOMPACTD		0x00010000	/* I am kcompactd */
++#define PF_KSWAPD		0x00020000	/* I am kswapd */
++#define PF_MEMALLOC_NOFS	0x00040000	/* All allocations inherit GFP_NOFS. See memalloc_nfs_save() */
++#define PF_MEMALLOC_NOIO	0x00080000	/* All allocations inherit GFP_NOIO. See memalloc_noio_save() */
++#define PF_LOCAL_THROTTLE	0x00100000	/* Throttle writes only against the bdi I write to,
++						 * I am cleaning dirty pages from some other bdi. */
++#define PF_KTHREAD		0x00200000	/* I am a kernel thread */
++#define PF_RANDOMIZE		0x00400000	/* Randomize virtual address space */
++#define PF__HOLE__00800000	0x00800000
++#define PF__HOLE__01000000	0x01000000
++#define PF__HOLE__02000000	0x02000000
++#define PF_NO_SETAFFINITY	0x04000000	/* Userland is not allowed to meddle with cpus_mask */
++#define PF_MCE_EARLY		0x08000000      /* Early kill for mce process policy */
++#define PF_MEMALLOC_PIN		0x10000000	/* Allocations constrained to zones which allow long term pinning.
++						 * See memalloc_pin_save() */
++#define PF_BLOCK_TS		0x20000000	/* plug has ts that needs updating */
++#define PF__HOLE__40000000	0x40000000
++#define PF_SUSPEND_TASK		0x80000000      /* This thread called freeze_processes() and should not be frozen */
++
++/*
++ * Only the _current_ task can read/write to tsk->flags, but other
++ * tasks can access tsk->flags in readonly mode for example
++ * with tsk_used_math (like during threaded core dumping).
++ * There is however an exception to this rule during ptrace
++ * or during fork: the ptracer task is allowed to write to the
++ * child->flags of its traced child (same goes for fork, the parent
++ * can write to the child->flags), because we're guaranteed the
++ * child is not running and in turn not changing child->flags
++ * at the same time the parent does it.
++ */
++#define clear_stopped_child_used_math(child)	do { (child)->flags &= ~PF_USED_MATH; } while (0)
++#define set_stopped_child_used_math(child)	do { (child)->flags |= PF_USED_MATH; } while (0)
++#define clear_used_math()			clear_stopped_child_used_math(current)
++#define set_used_math()				set_stopped_child_used_math(current)
++
++#define conditional_stopped_child_used_math(condition, child) \
++	do { (child)->flags &= ~PF_USED_MATH, (child)->flags |= (condition) ? PF_USED_MATH : 0; } while (0)
++
++#define conditional_used_math(condition)	conditional_stopped_child_used_math(condition, current)
++
++#define copy_to_stopped_child_used_math(child) \
++	do { (child)->flags &= ~PF_USED_MATH, (child)->flags |= current->flags & PF_USED_MATH; } while (0)
++
++/* NOTE: this will return 0 or PF_USED_MATH, it will never return 1 */
++#define tsk_used_math(p)			((p)->flags & PF_USED_MATH)
++#define used_math()				tsk_used_math(current)
++
++static __always_inline bool is_percpu_thread(void)
++{
++	return (current->flags & PF_NO_SETAFFINITY) &&
++		(current->nr_cpus_allowed  == 1);
++}
++
++static __always_inline bool is_user_task(struct task_struct *task)
++{
++	return task->mm && !(task->flags & (PF_KTHREAD | PF_USER_WORKER));
++}
++
++/* Per-process atomic flags. */
++#define PFA_NO_NEW_PRIVS		0	/* May not gain new privileges. */
++#define PFA_SPREAD_PAGE			1	/* Spread page cache over cpuset */
++#define PFA_SPREAD_SLAB			2	/* Spread some slab caches over cpuset */
++#define PFA_SPEC_SSB_DISABLE		3	/* Speculative Store Bypass disabled */
++#define PFA_SPEC_SSB_FORCE_DISABLE	4	/* Speculative Store Bypass force disabled*/
++#define PFA_SPEC_IB_DISABLE		5	/* Indirect branch speculation restricted */
++#define PFA_SPEC_IB_FORCE_DISABLE	6	/* Indirect branch speculation permanently restricted */
++#define PFA_SPEC_SSB_NOEXEC		7	/* Speculative Store Bypass clear on execve() */
++
++#define TASK_PFA_TEST(name, func)					\
++	static inline bool task_##func(struct task_struct *p)		\
++	{ return test_bit(PFA_##name, &p->atomic_flags); }
++
++#define TASK_PFA_SET(name, func)					\
++	static inline void task_set_##func(struct task_struct *p)	\
++	{ set_bit(PFA_##name, &p->atomic_flags); }
++
++#define TASK_PFA_CLEAR(name, func)					\
++	static inline void task_clear_##func(struct task_struct *p)	\
++	{ clear_bit(PFA_##name, &p->atomic_flags); }
++
++TASK_PFA_TEST(NO_NEW_PRIVS, no_new_privs)
++TASK_PFA_SET(NO_NEW_PRIVS, no_new_privs)
++
++TASK_PFA_TEST(SPREAD_PAGE, spread_page)
++TASK_PFA_SET(SPREAD_PAGE, spread_page)
++TASK_PFA_CLEAR(SPREAD_PAGE, spread_page)
++
++TASK_PFA_TEST(SPREAD_SLAB, spread_slab)
++TASK_PFA_SET(SPREAD_SLAB, spread_slab)
++TASK_PFA_CLEAR(SPREAD_SLAB, spread_slab)
++
++TASK_PFA_TEST(SPEC_SSB_DISABLE, spec_ssb_disable)
++TASK_PFA_SET(SPEC_SSB_DISABLE, spec_ssb_disable)
++TASK_PFA_CLEAR(SPEC_SSB_DISABLE, spec_ssb_disable)
++
++TASK_PFA_TEST(SPEC_SSB_NOEXEC, spec_ssb_noexec)
++TASK_PFA_SET(SPEC_SSB_NOEXEC, spec_ssb_noexec)
++TASK_PFA_CLEAR(SPEC_SSB_NOEXEC, spec_ssb_noexec)
++
++TASK_PFA_TEST(SPEC_SSB_FORCE_DISABLE, spec_ssb_force_disable)
++TASK_PFA_SET(SPEC_SSB_FORCE_DISABLE, spec_ssb_force_disable)
++
++TASK_PFA_TEST(SPEC_IB_DISABLE, spec_ib_disable)
++TASK_PFA_SET(SPEC_IB_DISABLE, spec_ib_disable)
++TASK_PFA_CLEAR(SPEC_IB_DISABLE, spec_ib_disable)
++
++TASK_PFA_TEST(SPEC_IB_FORCE_DISABLE, spec_ib_force_disable)
++TASK_PFA_SET(SPEC_IB_FORCE_DISABLE, spec_ib_force_disable)
++
++static inline void
++current_restore_flags(unsigned long orig_flags, unsigned long flags)
++{
++	current->flags &= ~flags;
++	current->flags |= orig_flags & flags;
++}
++
++extern int cpuset_cpumask_can_shrink(const struct cpumask *cur, const struct cpumask *trial);
++extern int task_can_attach(struct task_struct *p);
++extern int dl_bw_alloc(int cpu, u64 dl_bw);
++extern void dl_bw_free(int cpu, u64 dl_bw);
++
++/* set_cpus_allowed_force() - consider using set_cpus_allowed_ptr() instead */
++extern void set_cpus_allowed_force(struct task_struct *p, const struct cpumask *new_mask);
++
++/**
++ * set_cpus_allowed_ptr - set CPU affinity mask of a task
++ * @p: the task
++ * @new_mask: CPU affinity mask
++ *
++ * Return: zero if successful, or a negative error code
++ */
++extern int set_cpus_allowed_ptr(struct task_struct *p, const struct cpumask *new_mask);
++extern int dup_user_cpus_ptr(struct task_struct *dst, struct task_struct *src, int node);
++extern void release_user_cpus_ptr(struct task_struct *p);
++extern int dl_task_check_affinity(struct task_struct *p, const struct cpumask *mask);
++extern void force_compatible_cpus_allowed_ptr(struct task_struct *p);
++extern void relax_compatible_cpus_allowed_ptr(struct task_struct *p);
++
++extern int yield_to(struct task_struct *p, bool preempt);
++extern void set_user_nice(struct task_struct *p, long nice);
++extern int task_prio(const struct task_struct *p);
++
++/**
++ * task_nice - return the nice value of a given task.
++ * @p: the task in question.
++ *
++ * Return: The nice value [ -20 ... 0 ... 19 ].
++ */
++static inline int task_nice(const struct task_struct *p)
++{
++	return PRIO_TO_NICE((p)->static_prio);
++}
++
++extern int can_nice(const struct task_struct *p, const int nice);
++extern int task_curr(const struct task_struct *p);
++extern int idle_cpu(int cpu);
++extern int sched_setscheduler(struct task_struct *, int, const struct sched_param *);
++extern int sched_setscheduler_nocheck(struct task_struct *, int, const struct sched_param *);
++extern void sched_set_fifo(struct task_struct *p);
++extern void sched_set_fifo_low(struct task_struct *p);
++extern void sched_set_fifo_secondary(struct task_struct *p);
++extern void sched_set_normal(struct task_struct *p, int nice);
++extern int sched_setattr(struct task_struct *, const struct sched_attr *);
++extern int sched_setattr_nocheck(struct task_struct *, const struct sched_attr *);
++extern struct task_struct *idle_task(int cpu);
++
++/**
++ * is_idle_task - is the specified task an idle task?
++ * @p: the task in question.
++ *
++ * Return: 1 if @p is an idle task. 0 otherwise.
++ */
++static __always_inline bool is_idle_task(const struct task_struct *p)
++{
++	return !!(p->flags & PF_IDLE);
++}
++
++extern struct task_struct *curr_task(int cpu);
++extern void ia64_set_curr_task(int cpu, struct task_struct *p);
++
++void yield(void);
++
++union thread_union {
++	struct task_struct task;
++#ifndef CONFIG_THREAD_INFO_IN_TASK
++	struct thread_info thread_info;
++#endif
++	unsigned long stack[THREAD_SIZE/sizeof(long)];
++};
++
++#ifndef CONFIG_THREAD_INFO_IN_TASK
++extern struct thread_info init_thread_info;
++#endif
++
++extern unsigned long init_stack[THREAD_SIZE / sizeof(unsigned long)];
++
++#ifdef CONFIG_THREAD_INFO_IN_TASK
++# define task_thread_info(task)	(&(task)->thread_info)
++#else
++# define task_thread_info(task)	((struct thread_info *)(task)->stack)
++#endif
++
++/*
++ * find a task by one of its numerical ids
++ *
++ * find_task_by_pid_ns():
++ *      finds a task by its pid in the specified namespace
++ * find_task_by_vpid():
++ *      finds a task by its virtual pid
++ *
++ * see also find_vpid() etc in include/linux/pid.h
++ */
++
++extern struct task_struct *find_task_by_vpid(pid_t nr);
++extern struct task_struct *find_task_by_pid_ns(pid_t nr, struct pid_namespace *ns);
++
++/*
++ * find a task by its virtual pid and get the task struct
++ */
++extern struct task_struct *find_get_task_by_vpid(pid_t nr);
++
++extern int wake_up_state(struct task_struct *tsk, unsigned int state);
++extern int wake_up_process(struct task_struct *tsk);
++extern void wake_up_new_task(struct task_struct *tsk);
++
++extern void kick_process(struct task_struct *tsk);
++
++extern void __set_task_comm(struct task_struct *tsk, const char *from, bool exec);
++#define set_task_comm(tsk, from) ({			\
++	BUILD_BUG_ON(sizeof(from) != TASK_COMM_LEN);	\
++	__set_task_comm(tsk, from, false);		\
++})
++
++/*
++ * - Why not use task_lock()?
++ *   User space can randomly change their names anyway, so locking for readers
++ *   doesn't make sense. For writers, locking is probably necessary, as a race
++ *   condition could lead to long-term mixed results.
++ *   The strscpy_pad() in __set_task_comm() can ensure that the task comm is
++ *   always NUL-terminated and zero-padded. Therefore the race condition between
++ *   reader and writer is not an issue.
++ *
++ * - BUILD_BUG_ON() can help prevent the buf from being truncated.
++ *   Since the callers don't perform any return value checks, this safeguard is
++ *   necessary.
++ */
++#define get_task_comm(buf, tsk) ({			\
++	BUILD_BUG_ON(sizeof(buf) < TASK_COMM_LEN);	\
++	strscpy_pad(buf, (tsk)->comm);			\
++	buf;						\
++})
++
++static __always_inline void scheduler_ipi(void)
++{
++	/*
++	 * Fold TIF_NEED_RESCHED into the preempt_count; anybody setting
++	 * TIF_NEED_RESCHED remotely (for the first time) will also send
++	 * this IPI.
++	 */
++	preempt_fold_need_resched();
++}
++
++extern unsigned long wait_task_inactive(struct task_struct *, unsigned int match_state);
++
++/*
++ * Set thread flags in other task's structures.
++ * See asm/thread_info.h for TIF_xxxx flags available:
++ */
++static inline void set_tsk_thread_flag(struct task_struct *tsk, int flag)
++{
++	set_ti_thread_flag(task_thread_info(tsk), flag);
++}
++
++static inline void clear_tsk_thread_flag(struct task_struct *tsk, int flag)
++{
++	clear_ti_thread_flag(task_thread_info(tsk), flag);
++}
++
++static inline void update_tsk_thread_flag(struct task_struct *tsk, int flag,
++					  bool value)
++{
++	update_ti_thread_flag(task_thread_info(tsk), flag, value);
++}
++
++static inline int test_and_set_tsk_thread_flag(struct task_struct *tsk, int flag)
++{
++	return test_and_set_ti_thread_flag(task_thread_info(tsk), flag);
++}
++
++static inline int test_and_clear_tsk_thread_flag(struct task_struct *tsk, int flag)
++{
++	return test_and_clear_ti_thread_flag(task_thread_info(tsk), flag);
++}
++
++static inline int test_tsk_thread_flag(struct task_struct *tsk, int flag)
++{
++	return test_ti_thread_flag(task_thread_info(tsk), flag);
++}
++
++static inline void set_tsk_need_resched(struct task_struct *tsk)
++{
++	if (tracepoint_enabled(sched_set_need_resched_tp) &&
++	    !test_tsk_thread_flag(tsk, TIF_NEED_RESCHED))
++		__trace_set_need_resched(tsk, TIF_NEED_RESCHED);
++	set_tsk_thread_flag(tsk,TIF_NEED_RESCHED);
++}
++
++static inline void clear_tsk_need_resched(struct task_struct *tsk)
++{
++	atomic_long_andnot(_TIF_NEED_RESCHED | _TIF_NEED_RESCHED_LAZY,
++			   (atomic_long_t *)&task_thread_info(tsk)->flags);
++}
++
++static inline int test_tsk_need_resched(struct task_struct *tsk)
++{
++	return unlikely(test_tsk_thread_flag(tsk,TIF_NEED_RESCHED));
++}
++
++static inline void set_need_resched_current(void)
++{
++	lockdep_assert_irqs_disabled();
++	set_tsk_need_resched(current);
++	set_preempt_need_resched();
++}
++
++/*
++ * cond_resched() and cond_resched_lock(): latency reduction via
++ * explicit rescheduling in places that are safe. The return
++ * value indicates whether a reschedule was done in fact.
++ * cond_resched_lock() will drop the spinlock before scheduling,
++ */
++#if !defined(CONFIG_PREEMPTION) || defined(CONFIG_PREEMPT_DYNAMIC)
++extern int __cond_resched(void);
++
++#if defined(CONFIG_PREEMPT_DYNAMIC) && defined(CONFIG_HAVE_PREEMPT_DYNAMIC_CALL)
++
++DECLARE_STATIC_CALL(cond_resched, __cond_resched);
++
++static __always_inline int _cond_resched(void)
++{
++	return static_call_mod(cond_resched)();
++}
++
++#elif defined(CONFIG_PREEMPT_DYNAMIC) && defined(CONFIG_HAVE_PREEMPT_DYNAMIC_KEY)
++
++extern int dynamic_cond_resched(void);
++
++static __always_inline int _cond_resched(void)
++{
++	return dynamic_cond_resched();
++}
++
++#else /* !CONFIG_PREEMPTION */
++
++static inline int _cond_resched(void)
++{
++	return __cond_resched();
++}
++
++#endif /* PREEMPT_DYNAMIC && CONFIG_HAVE_PREEMPT_DYNAMIC_CALL */
++
++#else /* CONFIG_PREEMPTION && !CONFIG_PREEMPT_DYNAMIC */
++
++static inline int _cond_resched(void)
++{
++	return 0;
++}
++
++#endif /* !CONFIG_PREEMPTION || CONFIG_PREEMPT_DYNAMIC */
++
++#define cond_resched() ({			\
++	__might_resched(__FILE__, __LINE__, 0);	\
++	_cond_resched();			\
++})
++
++extern int __cond_resched_lock(spinlock_t *lock) __must_hold(lock);
++extern int __cond_resched_rwlock_read(rwlock_t *lock) __must_hold_shared(lock);
++extern int __cond_resched_rwlock_write(rwlock_t *lock) __must_hold(lock);
++
++#define MIGHT_RESCHED_RCU_SHIFT		8
++#define MIGHT_RESCHED_PREEMPT_MASK	((1U << MIGHT_RESCHED_RCU_SHIFT) - 1)
++
++#ifndef CONFIG_PREEMPT_RT
++/*
++ * Non RT kernels have an elevated preempt count due to the held lock,
++ * but are not allowed to be inside a RCU read side critical section
++ */
++# define PREEMPT_LOCK_RESCHED_OFFSETS	PREEMPT_LOCK_OFFSET
++#else
++/*
++ * spin/rw_lock() on RT implies rcu_read_lock(). The might_sleep() check in
++ * cond_resched*lock() has to take that into account because it checks for
++ * preempt_count() and rcu_preempt_depth().
++ */
++# define PREEMPT_LOCK_RESCHED_OFFSETS	\
++	(PREEMPT_LOCK_OFFSET + (1U << MIGHT_RESCHED_RCU_SHIFT))
++#endif
++
++#define cond_resched_lock(lock) ({						\
++	__might_resched(__FILE__, __LINE__, PREEMPT_LOCK_RESCHED_OFFSETS);	\
++	__cond_resched_lock(lock);						\
++})
++
++#define cond_resched_rwlock_read(lock) ({					\
++	__might_resched(__FILE__, __LINE__, PREEMPT_LOCK_RESCHED_OFFSETS);	\
++	__cond_resched_rwlock_read(lock);					\
++})
++
++#define cond_resched_rwlock_write(lock) ({					\
++	__might_resched(__FILE__, __LINE__, PREEMPT_LOCK_RESCHED_OFFSETS);	\
++	__cond_resched_rwlock_write(lock);					\
++})
++
++#ifndef CONFIG_PREEMPT_RT
++
++/*
++ * With proxy exec, if a task has been proxy-migrated, it may be a donor
++ * on a cpu that it can't actually run on. Thus we need a special state
++ * to denote that the task is being woken, but that it needs to be
++ * evaluated for return-migration before it is run. So if the task is
++ * blocked_on PROXY_WAKING, return migrate it before running it.
++ */
++#define PROXY_WAKING ((struct mutex *)(-1L))
++
++static inline struct mutex *__get_task_blocked_on(struct task_struct *p)
++{
++	lockdep_assert_held_once(&p->blocked_lock);
++	return p->blocked_on == PROXY_WAKING ? NULL : p->blocked_on;
++}
++
++static inline void __set_task_blocked_on(struct task_struct *p, struct mutex *m)
++{
++	WARN_ON_ONCE(!m);
++	/* The task should only be setting itself as blocked */
++	WARN_ON_ONCE(p != current);
++	/* Currently we serialize blocked_on under the task::blocked_lock */
++	lockdep_assert_held_once(&p->blocked_lock);
++	/*
++	 * Check ensure we don't overwrite existing mutex value
++	 * with a different mutex. Note, setting it to the same
++	 * lock repeatedly is ok.
++	 */
++	WARN_ON_ONCE(p->blocked_on && p->blocked_on != m);
++	p->blocked_on = m;
++}
++
++static inline void __clear_task_blocked_on(struct task_struct *p, struct mutex *m)
++{
++	/* Currently we serialize blocked_on under the task::blocked_lock */
++	lockdep_assert_held_once(&p->blocked_lock);
++	/*
++	 * There may be cases where we re-clear already cleared
++	 * blocked_on relationships, but make sure we are not
++	 * clearing the relationship with a different lock.
++	 */
++	WARN_ON_ONCE(m && p->blocked_on && p->blocked_on != m && p->blocked_on != PROXY_WAKING);
++	p->blocked_on = NULL;
++}
++
++static inline void clear_task_blocked_on(struct task_struct *p, struct mutex *m)
++{
++	guard(raw_spinlock_irqsave)(&p->blocked_lock);
++	__clear_task_blocked_on(p, m);
++}
++
++static inline void __set_task_blocked_on_waking(struct task_struct *p, struct mutex *m)
++{
++	/* Currently we serialize blocked_on under the task::blocked_lock */
++	lockdep_assert_held_once(&p->blocked_lock);
++
++	if (!sched_proxy_exec()) {
++		__clear_task_blocked_on(p, m);
++		return;
++	}
++
++	/* Don't set PROXY_WAKING if blocked_on was already cleared */
++	if (!p->blocked_on)
++		return;
++	/*
++	 * There may be cases where we set PROXY_WAKING on tasks that were
++	 * already set to waking, but make sure we are not changing
++	 * the relationship with a different lock.
++	 */
++	WARN_ON_ONCE(m && p->blocked_on != m && p->blocked_on != PROXY_WAKING);
++	p->blocked_on = PROXY_WAKING;
++}
++
++static inline void set_task_blocked_on_waking(struct task_struct *p, struct mutex *m)
++{
++	guard(raw_spinlock_irqsave)(&p->blocked_lock);
++	__set_task_blocked_on_waking(p, m);
++}
++
++#else
++static inline void __clear_task_blocked_on(struct task_struct *p, struct rt_mutex *m)
++{
++}
++
++static inline void clear_task_blocked_on(struct task_struct *p, struct rt_mutex *m)
++{
++}
++
++static inline void __set_task_blocked_on_waking(struct task_struct *p, struct rt_mutex *m)
++{
++}
++
++static inline void set_task_blocked_on_waking(struct task_struct *p, struct rt_mutex *m)
++{
++}
++#endif /* !CONFIG_PREEMPT_RT */
++
++static __always_inline bool need_resched(void)
++{
++	return unlikely(tif_need_resched());
++}
++
++/*
++ * Wrappers for p->thread_info->cpu access. No-op on UP.
++ */
++#ifdef CONFIG_SMP
++
++static inline unsigned int task_cpu(const struct task_struct *p)
++{
++	return READ_ONCE(task_thread_info(p)->cpu);
++}
++
++extern void set_task_cpu(struct task_struct *p, unsigned int cpu);
++
++#else
++
++static inline unsigned int task_cpu(const struct task_struct *p)
++{
++	return 0;
++}
++
++static inline void set_task_cpu(struct task_struct *p, unsigned int cpu)
++{
++}
++
++#endif /* CONFIG_SMP */
++
++static inline bool task_is_runnable(struct task_struct *p)
++{
++	return p->on_rq && !p->se.sched_delayed;
++}
++
++extern bool sched_task_on_rq(struct task_struct *p);
++extern unsigned long get_wchan(struct task_struct *p);
++extern struct task_struct *cpu_curr_snapshot(int cpu);
++
++/*
++ * In order to reduce various lock holder preemption latencies provide an
++ * interface to see if a vCPU is currently running or not.
++ *
++ * This allows us to terminate optimistic spin loops and block, analogous to
++ * the native optimistic spin heuristic of testing if the lock owner task is
++ * running or not.
++ */
++#ifndef vcpu_is_preempted
++static inline bool vcpu_is_preempted(int cpu)
++{
++	return false;
++}
++#endif
++
++extern long sched_setaffinity(pid_t pid, const struct cpumask *new_mask);
++extern long sched_getaffinity(pid_t pid, struct cpumask *mask);
++
++#ifndef TASK_SIZE_OF
++#define TASK_SIZE_OF(tsk)	TASK_SIZE
++#endif
++
++static inline bool owner_on_cpu(struct task_struct *owner)
++{
++	/*
++	 * As lock holder preemption issue, we both skip spinning if
++	 * task is not on cpu or its cpu is preempted
++	 */
++	return READ_ONCE(owner->on_cpu) && !vcpu_is_preempted(task_cpu(owner));
++}
++
++/* Returns effective CPU energy utilization, as seen by the scheduler */
++unsigned long sched_cpu_util(int cpu);
++
++#ifdef CONFIG_SCHED_CORE
++extern void sched_core_free(struct task_struct *tsk);
++extern void sched_core_fork(struct task_struct *p);
++extern int sched_core_share_pid(unsigned int cmd, pid_t pid, enum pid_type type,
++				unsigned long uaddr);
++extern int sched_core_idle_cpu(int cpu);
++#else
++static inline void sched_core_free(struct task_struct *tsk) { }
++static inline void sched_core_fork(struct task_struct *p) { }
++static inline int sched_core_idle_cpu(int cpu) { return idle_cpu(cpu); }
++#endif
++
++extern void sched_set_stop_task(int cpu, struct task_struct *stop);
++
++#ifdef CONFIG_MEM_ALLOC_PROFILING
++static __always_inline struct alloc_tag *alloc_tag_save(struct alloc_tag *tag)
++{
++	swap(current->alloc_tag, tag);
++	return tag;
++}
++
++static __always_inline void alloc_tag_restore(struct alloc_tag *tag, struct alloc_tag *old)
++{
++#ifdef CONFIG_MEM_ALLOC_PROFILING_DEBUG
++	WARN(current->alloc_tag != tag, "current->alloc_tag was changed:\n");
++#endif
++	current->alloc_tag = old;
++}
++#else
++#define alloc_tag_save(_tag)			NULL
++#define alloc_tag_restore(_tag, _old)		do {} while (0)
++#endif
++
++/* Avoids recursive inclusion hell */
++#ifdef CONFIG_SCHED_MM_CID
++void sched_mm_cid_before_execve(struct task_struct *t);
++void sched_mm_cid_after_execve(struct task_struct *t);
++void sched_mm_cid_exit(struct task_struct *t);
++static __always_inline int task_mm_cid(struct task_struct *t)
++{
++	return t->mm_cid.cid & ~(MM_CID_ONCPU | MM_CID_TRANSIT);
++}
++#else
++static inline void sched_mm_cid_before_execve(struct task_struct *t) { }
++static inline void sched_mm_cid_after_execve(struct task_struct *t) { }
++static inline void sched_mm_cid_exit(struct task_struct *t) { }
++static __always_inline int task_mm_cid(struct task_struct *t)
++{
++	/*
++	 * Use the processor id as a fall-back when the mm cid feature is
++	 * disabled. This provides functional per-cpu data structure accesses
++	 * in user-space, althrough it won't provide the memory usage benefits.
++	 */
++	return task_cpu(t);
++}
++#endif
++
++#ifndef MODULE
++#ifndef COMPILE_OFFSETS
++
++extern void ___migrate_enable(void);
++
++struct rq;
++DECLARE_PER_CPU_SHARED_ALIGNED(struct rq, runqueues);
++
++/*
++ * The "struct rq" is not available here, so we can't access the
++ * "runqueues" with this_cpu_ptr(), as the compilation will fail in
++ * this_cpu_ptr() -> raw_cpu_ptr() -> __verify_pcpu_ptr():
++ *   typeof((ptr) + 0)
++ *
++ * So use arch_raw_cpu_ptr()/PERCPU_PTR() directly here.
++ */
++#ifdef CONFIG_SMP
++#define this_rq_raw() arch_raw_cpu_ptr(&runqueues)
++#else
++#define this_rq_raw() PERCPU_PTR(&runqueues)
++#endif
++#define this_rq_pinned() (*(unsigned int *)((void *)this_rq_raw() + RQ_nr_pinned))
++
++static inline void __migrate_enable(void)
++{
++	struct task_struct *p = current;
++
++#ifdef CONFIG_DEBUG_PREEMPT
++	/*
++	 * Check both overflow from migrate_disable() and superfluous
++	 * migrate_enable().
++	 */
++	if (WARN_ON_ONCE((s16)p->migration_disabled <= 0))
++		return;
++#endif
++
++	if (p->migration_disabled > 1) {
++		p->migration_disabled--;
++		return;
++	}
++
++	/*
++	 * Ensure stop_task runs either before or after this, and that
++	 * __set_cpus_allowed_ptr(SCA_MIGRATE_ENABLE) doesn't schedule().
++	 */
++	guard(preempt)();
++	if (unlikely(p->cpus_ptr != &p->cpus_mask))
++		___migrate_enable();
++	/*
++	 * Mustn't clear migration_disabled() until cpus_ptr points back at the
++	 * regular cpus_mask, otherwise things that race (eg.
++	 * select_fallback_rq) get confused.
++	 */
++	barrier();
++	p->migration_disabled = 0;
++	this_rq_pinned()--;
++}
++
++static inline void __migrate_disable(void)
++{
++	struct task_struct *p = current;
++
++	if (p->migration_disabled) {
++#ifdef CONFIG_DEBUG_PREEMPT
++		/*
++		 *Warn about overflow half-way through the range.
++		 */
++		WARN_ON_ONCE((s16)p->migration_disabled < 0);
++#endif
++		p->migration_disabled++;
++		return;
++	}
++
++	guard(preempt)();
++	this_rq_pinned()++;
++	p->migration_disabled = 1;
++}
++#else /* !COMPILE_OFFSETS */
++static inline void __migrate_disable(void) { }
++static inline void __migrate_enable(void) { }
++#endif /* !COMPILE_OFFSETS */
++
++/*
++ * So that it is possible to not export the runqueues variable, define and
++ * export migrate_enable/migrate_disable in kernel/sched/core.c too, and use
++ * them for the modules. The macro "INSTANTIATE_EXPORTED_MIGRATE_DISABLE" will
++ * be defined in kernel/sched/core.c.
++ */
++#ifndef INSTANTIATE_EXPORTED_MIGRATE_DISABLE
++static __always_inline void migrate_disable(void)
++{
++	__migrate_disable();
++}
++
++static __always_inline void migrate_enable(void)
++{
++	__migrate_enable();
++}
++#else /* INSTANTIATE_EXPORTED_MIGRATE_DISABLE */
++extern void migrate_disable(void);
++extern void migrate_enable(void);
++#endif /* INSTANTIATE_EXPORTED_MIGRATE_DISABLE */
++
++#else /* MODULE */
++extern void migrate_disable(void);
++extern void migrate_enable(void);
++#endif /* MODULE */
++
++DEFINE_LOCK_GUARD_0(migrate, migrate_disable(), migrate_enable())
++
++#endif
+diff --git a/include/uapi/linux/prctl.h.orig b/include/uapi/linux/prctl.h.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/include/uapi/linux/prctl.h.orig
+@@ -0,0 +1,419 @@
++/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
++#ifndef _LINUX_PRCTL_H
++#define _LINUX_PRCTL_H
++
++#include <linux/types.h>
++
++/* Values to pass as first argument to prctl() */
++
++#define PR_SET_PDEATHSIG  1  /* Second arg is a signal */
++#define PR_GET_PDEATHSIG  2  /* Second arg is a ptr to return the signal */
++
++/* Get/set current->mm->dumpable */
++#define PR_GET_DUMPABLE   3
++#define PR_SET_DUMPABLE   4
++
++/* Get/set unaligned access control bits (if meaningful) */
++#define PR_GET_UNALIGN	  5
++#define PR_SET_UNALIGN	  6
++# define PR_UNALIGN_NOPRINT	1	/* silently fix up unaligned user accesses */
++# define PR_UNALIGN_SIGBUS	2	/* generate SIGBUS on unaligned user access */
++
++/* Get/set whether or not to drop capabilities on setuid() away from
++ * uid 0 (as per security/commoncap.c) */
++#define PR_GET_KEEPCAPS   7
++#define PR_SET_KEEPCAPS   8
++
++/* Get/set floating-point emulation control bits (if meaningful) */
++#define PR_GET_FPEMU  9
++#define PR_SET_FPEMU 10
++# define PR_FPEMU_NOPRINT	1	/* silently emulate fp operations accesses */
++# define PR_FPEMU_SIGFPE	2	/* don't emulate fp operations, send SIGFPE instead */
++
++/* Get/set floating-point exception mode (if meaningful) */
++#define PR_GET_FPEXC	11
++#define PR_SET_FPEXC	12
++# define PR_FP_EXC_SW_ENABLE	0x80	/* Use FPEXC for FP exception enables */
++# define PR_FP_EXC_DIV		0x010000	/* floating point divide by zero */
++# define PR_FP_EXC_OVF		0x020000	/* floating point overflow */
++# define PR_FP_EXC_UND		0x040000	/* floating point underflow */
++# define PR_FP_EXC_RES		0x080000	/* floating point inexact result */
++# define PR_FP_EXC_INV		0x100000	/* floating point invalid operation */
++# define PR_FP_EXC_DISABLED	0	/* FP exceptions disabled */
++# define PR_FP_EXC_NONRECOV	1	/* async non-recoverable exc. mode */
++# define PR_FP_EXC_ASYNC	2	/* async recoverable exception mode */
++# define PR_FP_EXC_PRECISE	3	/* precise exception mode */
++
++/* Get/set whether we use statistical process timing or accurate timestamp
++ * based process timing */
++#define PR_GET_TIMING   13
++#define PR_SET_TIMING   14
++# define PR_TIMING_STATISTICAL  0       /* Normal, traditional,
++                                                   statistical process timing */
++# define PR_TIMING_TIMESTAMP    1       /* Accurate timestamp based
++                                                   process timing */
++
++#define PR_SET_NAME    15		/* Set process name */
++#define PR_GET_NAME    16		/* Get process name */
++
++/* Get/set process endian */
++#define PR_GET_ENDIAN	19
++#define PR_SET_ENDIAN	20
++# define PR_ENDIAN_BIG		0
++# define PR_ENDIAN_LITTLE	1	/* True little endian mode */
++# define PR_ENDIAN_PPC_LITTLE	2	/* "PowerPC" pseudo little endian */
++
++/* Get/set process seccomp mode */
++#define PR_GET_SECCOMP	21
++#define PR_SET_SECCOMP	22
++
++/* Get/set the capability bounding set (as per security/commoncap.c) */
++#define PR_CAPBSET_READ 23
++#define PR_CAPBSET_DROP 24
++
++/* Get/set the process' ability to use the timestamp counter instruction */
++#define PR_GET_TSC 25
++#define PR_SET_TSC 26
++# define PR_TSC_ENABLE		1	/* allow the use of the timestamp counter */
++# define PR_TSC_SIGSEGV		2	/* throw a SIGSEGV instead of reading the TSC */
++
++/* Get/set securebits (as per security/commoncap.c) */
++#define PR_GET_SECUREBITS 27
++#define PR_SET_SECUREBITS 28
++
++/*
++ * Get/set the timerslack as used by poll/select/nanosleep
++ * A value of 0 means "use default"
++ */
++#define PR_SET_TIMERSLACK 29
++#define PR_GET_TIMERSLACK 30
++
++#define PR_TASK_PERF_EVENTS_DISABLE		31
++#define PR_TASK_PERF_EVENTS_ENABLE		32
++
++/*
++ * Set early/late kill mode for hwpoison memory corruption.
++ * This influences when the process gets killed on a memory corruption.
++ */
++#define PR_MCE_KILL	33
++# define PR_MCE_KILL_CLEAR   0
++# define PR_MCE_KILL_SET     1
++
++# define PR_MCE_KILL_LATE    0
++# define PR_MCE_KILL_EARLY   1
++# define PR_MCE_KILL_DEFAULT 2
++
++#define PR_MCE_KILL_GET 34
++
++/*
++ * Tune up process memory map specifics.
++ */
++#define PR_SET_MM		35
++# define PR_SET_MM_START_CODE		1
++# define PR_SET_MM_END_CODE		2
++# define PR_SET_MM_START_DATA		3
++# define PR_SET_MM_END_DATA		4
++# define PR_SET_MM_START_STACK		5
++# define PR_SET_MM_START_BRK		6
++# define PR_SET_MM_BRK			7
++# define PR_SET_MM_ARG_START		8
++# define PR_SET_MM_ARG_END		9
++# define PR_SET_MM_ENV_START		10
++# define PR_SET_MM_ENV_END		11
++# define PR_SET_MM_AUXV			12
++# define PR_SET_MM_EXE_FILE		13
++# define PR_SET_MM_MAP			14
++# define PR_SET_MM_MAP_SIZE		15
++
++/*
++ * This structure provides new memory descriptor
++ * map which mostly modifies /proc/pid/stat[m]
++ * output for a task. This mostly done in a
++ * sake of checkpoint/restore functionality.
++ */
++struct prctl_mm_map {
++	__u64	start_code;		/* code section bounds */
++	__u64	end_code;
++	__u64	start_data;		/* data section bounds */
++	__u64	end_data;
++	__u64	start_brk;		/* heap for brk() syscall */
++	__u64	brk;
++	__u64	start_stack;		/* stack starts at */
++	__u64	arg_start;		/* command line arguments bounds */
++	__u64	arg_end;
++	__u64	env_start;		/* environment variables bounds */
++	__u64	env_end;
++	__u64	*auxv;			/* auxiliary vector */
++	__u32	auxv_size;		/* vector size */
++	__u32	exe_fd;			/* /proc/$pid/exe link file */
++};
++
++/*
++ * Set specific pid that is allowed to ptrace the current task.
++ * A value of 0 mean "no process".
++ */
++#define PR_SET_PTRACER 0x59616d61
++# define PR_SET_PTRACER_ANY ((unsigned long)-1)
++
++#define PR_SET_CHILD_SUBREAPER	36
++#define PR_GET_CHILD_SUBREAPER	37
++
++/*
++ * If no_new_privs is set, then operations that grant new privileges (i.e.
++ * execve) will either fail or not grant them.  This affects suid/sgid,
++ * file capabilities, and LSMs.
++ *
++ * Operations that merely manipulate or drop existing privileges (setresuid,
++ * capset, etc.) will still work.  Drop those privileges if you want them gone.
++ *
++ * Changing LSM security domain is considered a new privilege.  So, for example,
++ * asking selinux for a specific new context (e.g. with runcon) will result
++ * in execve returning -EPERM.
++ *
++ * See Documentation/userspace-api/no_new_privs.rst for more details.
++ */
++#define PR_SET_NO_NEW_PRIVS	38
++#define PR_GET_NO_NEW_PRIVS	39
++
++#define PR_GET_TID_ADDRESS	40
++
++/*
++ * Flags for PR_SET_THP_DISABLE are only applicable when disabling. Bit 0
++ * is reserved, so PR_GET_THP_DISABLE can return "1 | flags", to effectively
++ * return "1" when no flags were specified for PR_SET_THP_DISABLE.
++ */
++#define PR_SET_THP_DISABLE	41
++/*
++ * Don't disable THPs when explicitly advised (e.g., MADV_HUGEPAGE /
++ * VM_HUGEPAGE, MADV_COLLAPSE).
++ */
++# define PR_THP_DISABLE_EXCEPT_ADVISED	(1 << 1)
++#define PR_GET_THP_DISABLE	42
++
++/*
++ * No longer implemented, but left here to ensure the numbers stay reserved:
++ */
++#define PR_MPX_ENABLE_MANAGEMENT  43
++#define PR_MPX_DISABLE_MANAGEMENT 44
++
++#define PR_SET_FP_MODE		45
++#define PR_GET_FP_MODE		46
++# define PR_FP_MODE_FR		(1 << 0)	/* 64b FP registers */
++# define PR_FP_MODE_FRE		(1 << 1)	/* 32b compatibility */
++
++/* Control the ambient capability set */
++#define PR_CAP_AMBIENT			47
++# define PR_CAP_AMBIENT_IS_SET		1
++# define PR_CAP_AMBIENT_RAISE		2
++# define PR_CAP_AMBIENT_LOWER		3
++# define PR_CAP_AMBIENT_CLEAR_ALL	4
++
++/* arm64 Scalable Vector Extension controls */
++/* Flag values must be kept in sync with ptrace NT_ARM_SVE interface */
++#define PR_SVE_SET_VL			50	/* set task vector length */
++# define PR_SVE_SET_VL_ONEXEC		(1 << 18) /* defer effect until exec */
++#define PR_SVE_GET_VL			51	/* get task vector length */
++/* Bits common to PR_SVE_SET_VL and PR_SVE_GET_VL */
++# define PR_SVE_VL_LEN_MASK		0xffff
++# define PR_SVE_VL_INHERIT		(1 << 17) /* inherit across exec */
++
++/* Per task speculation control */
++#define PR_GET_SPECULATION_CTRL		52
++#define PR_SET_SPECULATION_CTRL		53
++/* Speculation control variants */
++# define PR_SPEC_STORE_BYPASS		0
++# define PR_SPEC_INDIRECT_BRANCH	1
++# define PR_SPEC_L1D_FLUSH		2
++/* Return and control values for PR_SET/GET_SPECULATION_CTRL */
++# define PR_SPEC_NOT_AFFECTED		0
++# define PR_SPEC_PRCTL			(1UL << 0)
++# define PR_SPEC_ENABLE			(1UL << 1)
++# define PR_SPEC_DISABLE		(1UL << 2)
++# define PR_SPEC_FORCE_DISABLE		(1UL << 3)
++# define PR_SPEC_DISABLE_NOEXEC		(1UL << 4)
++
++/* Reset arm64 pointer authentication keys */
++#define PR_PAC_RESET_KEYS		54
++# define PR_PAC_APIAKEY			(1UL << 0)
++# define PR_PAC_APIBKEY			(1UL << 1)
++# define PR_PAC_APDAKEY			(1UL << 2)
++# define PR_PAC_APDBKEY			(1UL << 3)
++# define PR_PAC_APGAKEY			(1UL << 4)
++
++/* Tagged user address controls for arm64 and RISC-V */
++#define PR_SET_TAGGED_ADDR_CTRL		55
++#define PR_GET_TAGGED_ADDR_CTRL		56
++# define PR_TAGGED_ADDR_ENABLE		(1UL << 0)
++/* MTE tag check fault modes */
++# define PR_MTE_TCF_NONE		0UL
++# define PR_MTE_TCF_SYNC		(1UL << 1)
++# define PR_MTE_TCF_ASYNC		(1UL << 2)
++# define PR_MTE_TCF_MASK		(PR_MTE_TCF_SYNC | PR_MTE_TCF_ASYNC)
++/* MTE tag inclusion mask */
++# define PR_MTE_TAG_SHIFT		3
++# define PR_MTE_TAG_MASK		(0xffffUL << PR_MTE_TAG_SHIFT)
++/* Unused; kept only for source compatibility */
++# define PR_MTE_TCF_SHIFT		1
++/* MTE tag check store only */
++# define PR_MTE_STORE_ONLY		(1UL << 19)
++/* RISC-V pointer masking tag length */
++# define PR_PMLEN_SHIFT			24
++# define PR_PMLEN_MASK			(0x7fUL << PR_PMLEN_SHIFT)
++
++/* Control reclaim behavior when allocating memory */
++#define PR_SET_IO_FLUSHER		57
++#define PR_GET_IO_FLUSHER		58
++
++/* Dispatch syscalls to a userspace handler */
++#define PR_SET_SYSCALL_USER_DISPATCH	59
++# define PR_SYS_DISPATCH_OFF		0
++/* Enable dispatch except for the specified range */
++# define PR_SYS_DISPATCH_EXCLUSIVE_ON	1
++/* Enable dispatch for the specified range */
++# define PR_SYS_DISPATCH_INCLUSIVE_ON	2
++/* Legacy name for backwards compatibility */
++# define PR_SYS_DISPATCH_ON		PR_SYS_DISPATCH_EXCLUSIVE_ON
++/* The control values for the user space selector when dispatch is enabled */
++# define SYSCALL_DISPATCH_FILTER_ALLOW	0
++# define SYSCALL_DISPATCH_FILTER_BLOCK	1
++
++/* Set/get enabled arm64 pointer authentication keys */
++#define PR_PAC_SET_ENABLED_KEYS		60
++#define PR_PAC_GET_ENABLED_KEYS		61
++
++/* Request the scheduler to share a core */
++#define PR_SCHED_CORE			62
++# define PR_SCHED_CORE_GET		0
++# define PR_SCHED_CORE_CREATE		1 /* create unique core_sched cookie */
++# define PR_SCHED_CORE_SHARE_TO		2 /* push core_sched cookie to pid */
++# define PR_SCHED_CORE_SHARE_FROM	3 /* pull core_sched cookie to pid */
++# define PR_SCHED_CORE_MAX		4
++# define PR_SCHED_CORE_SCOPE_THREAD		0
++# define PR_SCHED_CORE_SCOPE_THREAD_GROUP	1
++# define PR_SCHED_CORE_SCOPE_PROCESS_GROUP	2
++
++/* arm64 Scalable Matrix Extension controls */
++/* Flag values must be in sync with SVE versions */
++#define PR_SME_SET_VL			63	/* set task vector length */
++# define PR_SME_SET_VL_ONEXEC		(1 << 18) /* defer effect until exec */
++#define PR_SME_GET_VL			64	/* get task vector length */
++/* Bits common to PR_SME_SET_VL and PR_SME_GET_VL */
++# define PR_SME_VL_LEN_MASK		0xffff
++# define PR_SME_VL_INHERIT		(1 << 17) /* inherit across exec */
++
++/* Memory deny write / execute */
++#define PR_SET_MDWE			65
++# define PR_MDWE_REFUSE_EXEC_GAIN	(1UL << 0)
++# define PR_MDWE_NO_INHERIT		(1UL << 1)
++
++#define PR_GET_MDWE			66
++
++#define PR_SET_VMA		0x53564d41
++# define PR_SET_VMA_ANON_NAME		0
++
++#define PR_GET_AUXV			0x41555856
++
++#define PR_SET_MEMORY_MERGE		67
++#define PR_GET_MEMORY_MERGE		68
++
++#define PR_RISCV_V_SET_CONTROL		69
++#define PR_RISCV_V_GET_CONTROL		70
++# define PR_RISCV_V_VSTATE_CTRL_DEFAULT		0
++# define PR_RISCV_V_VSTATE_CTRL_OFF		1
++# define PR_RISCV_V_VSTATE_CTRL_ON		2
++# define PR_RISCV_V_VSTATE_CTRL_INHERIT		(1 << 4)
++# define PR_RISCV_V_VSTATE_CTRL_CUR_MASK	0x3
++# define PR_RISCV_V_VSTATE_CTRL_NEXT_MASK	0xc
++# define PR_RISCV_V_VSTATE_CTRL_MASK		0x1f
++
++#define PR_RISCV_SET_ICACHE_FLUSH_CTX	71
++# define PR_RISCV_CTX_SW_FENCEI_ON	0
++# define PR_RISCV_CTX_SW_FENCEI_OFF	1
++# define PR_RISCV_SCOPE_PER_PROCESS	0
++# define PR_RISCV_SCOPE_PER_THREAD	1
++
++/* PowerPC Dynamic Execution Control Register (DEXCR) controls */
++#define PR_PPC_GET_DEXCR		72
++#define PR_PPC_SET_DEXCR		73
++/* DEXCR aspect to act on */
++# define PR_PPC_DEXCR_SBHE		0 /* Speculative branch hint enable */
++# define PR_PPC_DEXCR_IBRTPD		1 /* Indirect branch recurrent target prediction disable */
++# define PR_PPC_DEXCR_SRAPD		2 /* Subroutine return address prediction disable */
++# define PR_PPC_DEXCR_NPHIE		3 /* Non-privileged hash instruction enable */
++/* Action to apply / return */
++# define PR_PPC_DEXCR_CTRL_EDITABLE	 0x1 /* Aspect can be modified with PR_PPC_SET_DEXCR */
++# define PR_PPC_DEXCR_CTRL_SET		 0x2 /* Set the aspect for this process */
++# define PR_PPC_DEXCR_CTRL_CLEAR	 0x4 /* Clear the aspect for this process */
++# define PR_PPC_DEXCR_CTRL_SET_ONEXEC	 0x8 /* Set the aspect on exec */
++# define PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC	0x10 /* Clear the aspect on exec */
++# define PR_PPC_DEXCR_CTRL_MASK		0x1f
++
++/*
++ * Get the current shadow stack configuration for the current thread,
++ * this will be the value configured via PR_SET_SHADOW_STACK_STATUS.
++ */
++#define PR_GET_SHADOW_STACK_STATUS      74
++
++/*
++ * Set the current shadow stack configuration.  Enabling the shadow
++ * stack will cause a shadow stack to be allocated for the thread.
++ */
++#define PR_SET_SHADOW_STACK_STATUS      75
++# define PR_SHADOW_STACK_ENABLE         (1UL << 0)
++# define PR_SHADOW_STACK_WRITE		(1UL << 1)
++# define PR_SHADOW_STACK_PUSH		(1UL << 2)
++
++/*
++ * Prevent further changes to the specified shadow stack
++ * configuration.  All bits may be locked via this call, including
++ * undefined bits.
++ */
++#define PR_LOCK_SHADOW_STACK_STATUS      76
++
++/*
++ * Controls the mode of timer_create() for CRIU restore operations.
++ * Enabling this allows CRIU to restore timers with explicit IDs.
++ *
++ * Don't use for normal operations as the result might be undefined.
++ */
++#define PR_TIMER_CREATE_RESTORE_IDS		77
++# define PR_TIMER_CREATE_RESTORE_IDS_OFF	0
++# define PR_TIMER_CREATE_RESTORE_IDS_ON		1
++# define PR_TIMER_CREATE_RESTORE_IDS_GET	2
++
++/* FUTEX hash management */
++#define PR_FUTEX_HASH			78
++# define PR_FUTEX_HASH_SET_SLOTS	1
++# define PR_FUTEX_HASH_GET_SLOTS	2
++
++/* RSEQ time slice extensions */
++#define PR_RSEQ_SLICE_EXTENSION			79
++# define PR_RSEQ_SLICE_EXTENSION_GET		1
++# define PR_RSEQ_SLICE_EXTENSION_SET		2
++/*
++ * Bits for RSEQ_SLICE_EXTENSION_GET/SET
++ * PR_RSEQ_SLICE_EXT_ENABLE:	Enable
++ */
++# define PR_RSEQ_SLICE_EXT_ENABLE		0x01
++
++/*
++ * Get or set the control flow integrity (CFI) configuration for the
++ * current thread.
++ *
++ * Some per-thread control flow integrity settings are not yet
++ * controlled through this prctl(); see for example
++ * PR_{GET,SET,LOCK}_SHADOW_STACK_STATUS
++ */
++#define PR_GET_CFI	80
++#define PR_SET_CFI	81
++/*
++ * Forward-edge CFI variants (excluding ARM64 BTI, which has its own
++ * prctl()s).
++ */
++#define PR_CFI_BRANCH_LANDING_PADS	0
++/* Return and control values for PR_{GET,SET}_CFI */
++# define PR_CFI_ENABLE		_BITUL(0)
++# define PR_CFI_DISABLE		_BITUL(1)
++# define PR_CFI_LOCK		_BITUL(2)
++
++#endif /* _LINUX_PRCTL_H */
+diff --git a/kernel/sys.c.orig b/kernel/sys.c.orig
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/kernel/sys.c.orig
+@@ -0,0 +1,3074 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ *  linux/kernel/sys.c
++ *
++ *  Copyright (C) 1991, 1992  Linus Torvalds
++ */
++
++#include <linux/export.h>
++#include <linux/mm.h>
++#include <linux/mm_inline.h>
++#include <linux/utsname.h>
++#include <linux/mman.h>
++#include <linux/reboot.h>
++#include <linux/prctl.h>
++#include <linux/highuid.h>
++#include <linux/fs.h>
++#include <linux/kmod.h>
++#include <linux/ksm.h>
++#include <linux/perf_event.h>
++#include <linux/resource.h>
++#include <linux/kernel.h>
++#include <linux/workqueue.h>
++#include <linux/capability.h>
++#include <linux/device.h>
++#include <linux/key.h>
++#include <linux/times.h>
++#include <linux/posix-timers.h>
++#include <linux/security.h>
++#include <linux/random.h>
++#include <linux/suspend.h>
++#include <linux/tty.h>
++#include <linux/signal.h>
++#include <linux/cn_proc.h>
++#include <linux/task_io_accounting_ops.h>
++#include <linux/seccomp.h>
++#include <linux/cpu.h>
++#include <linux/personality.h>
++#include <linux/ptrace.h>
++#include <linux/fs_struct.h>
++#include <linux/file.h>
++#include <linux/mount.h>
++#include <linux/gfp.h>
++#include <linux/syscore_ops.h>
++#include <linux/version.h>
++#include <linux/ctype.h>
++#include <linux/syscall_user_dispatch.h>
++
++#include <linux/compat.h>
++#include <linux/syscalls.h>
++#include <linux/kprobes.h>
++#include <linux/user_namespace.h>
++#include <linux/time_namespace.h>
++#include <linux/binfmts.h>
++#include <linux/futex.h>
++#include <linux/rseq.h>
++
++#include <linux/sched.h>
++#include <linux/sched/autogroup.h>
++#include <linux/sched/loadavg.h>
++#include <linux/sched/stat.h>
++#include <linux/sched/mm.h>
++#include <linux/sched/coredump.h>
++#include <linux/sched/task.h>
++#include <linux/sched/cputime.h>
++#include <linux/rcupdate.h>
++#include <linux/uidgid.h>
++#include <linux/cred.h>
++
++#include <linux/nospec.h>
++
++#include <linux/kmsg_dump.h>
++/* Move somewhere else to avoid recompiling? */
++#include <generated/utsrelease.h>
++
++#include <linux/uaccess.h>
++#include <asm/io.h>
++#include <asm/unistd.h>
++
++#include <trace/events/task.h>
++
++#include "uid16.h"
++
++#ifndef SET_UNALIGN_CTL
++# define SET_UNALIGN_CTL(a, b)	(-EINVAL)
++#endif
++#ifndef GET_UNALIGN_CTL
++# define GET_UNALIGN_CTL(a, b)	(-EINVAL)
++#endif
++#ifndef SET_FPEMU_CTL
++# define SET_FPEMU_CTL(a, b)	(-EINVAL)
++#endif
++#ifndef GET_FPEMU_CTL
++# define GET_FPEMU_CTL(a, b)	(-EINVAL)
++#endif
++#ifndef SET_FPEXC_CTL
++# define SET_FPEXC_CTL(a, b)	(-EINVAL)
++#endif
++#ifndef GET_FPEXC_CTL
++# define GET_FPEXC_CTL(a, b)	(-EINVAL)
++#endif
++#ifndef GET_ENDIAN
++# define GET_ENDIAN(a, b)	(-EINVAL)
++#endif
++#ifndef SET_ENDIAN
++# define SET_ENDIAN(a, b)	(-EINVAL)
++#endif
++#ifndef GET_TSC_CTL
++# define GET_TSC_CTL(a)		(-EINVAL)
++#endif
++#ifndef SET_TSC_CTL
++# define SET_TSC_CTL(a)		(-EINVAL)
++#endif
++#ifndef GET_FP_MODE
++# define GET_FP_MODE(a)		(-EINVAL)
++#endif
++#ifndef SET_FP_MODE
++# define SET_FP_MODE(a,b)	(-EINVAL)
++#endif
++#ifndef SVE_SET_VL
++# define SVE_SET_VL(a)		(-EINVAL)
++#endif
++#ifndef SVE_GET_VL
++# define SVE_GET_VL()		(-EINVAL)
++#endif
++#ifndef SME_SET_VL
++# define SME_SET_VL(a)		(-EINVAL)
++#endif
++#ifndef SME_GET_VL
++# define SME_GET_VL()		(-EINVAL)
++#endif
++#ifndef PAC_RESET_KEYS
++# define PAC_RESET_KEYS(a, b)	(-EINVAL)
++#endif
++#ifndef PAC_SET_ENABLED_KEYS
++# define PAC_SET_ENABLED_KEYS(a, b, c)	(-EINVAL)
++#endif
++#ifndef PAC_GET_ENABLED_KEYS
++# define PAC_GET_ENABLED_KEYS(a)	(-EINVAL)
++#endif
++#ifndef SET_TAGGED_ADDR_CTRL
++# define SET_TAGGED_ADDR_CTRL(a)	(-EINVAL)
++#endif
++#ifndef GET_TAGGED_ADDR_CTRL
++# define GET_TAGGED_ADDR_CTRL()		(-EINVAL)
++#endif
++#ifndef RISCV_V_SET_CONTROL
++# define RISCV_V_SET_CONTROL(a)		(-EINVAL)
++#endif
++#ifndef RISCV_V_GET_CONTROL
++# define RISCV_V_GET_CONTROL()		(-EINVAL)
++#endif
++#ifndef RISCV_SET_ICACHE_FLUSH_CTX
++# define RISCV_SET_ICACHE_FLUSH_CTX(a, b)	(-EINVAL)
++#endif
++#ifndef PPC_GET_DEXCR_ASPECT
++# define PPC_GET_DEXCR_ASPECT(a, b)	(-EINVAL)
++#endif
++#ifndef PPC_SET_DEXCR_ASPECT
++# define PPC_SET_DEXCR_ASPECT(a, b, c)	(-EINVAL)
++#endif
++
++/*
++ * this is where the system-wide overflow UID and GID are defined, for
++ * architectures that now have 32-bit UID/GID but didn't in the past
++ */
++
++int overflowuid = DEFAULT_OVERFLOWUID;
++int overflowgid = DEFAULT_OVERFLOWGID;
++
++EXPORT_SYMBOL(overflowuid);
++EXPORT_SYMBOL(overflowgid);
++
++/*
++ * the same as above, but for filesystems which can only store a 16-bit
++ * UID and GID. as such, this is needed on all architectures
++ */
++
++int fs_overflowuid = DEFAULT_FS_OVERFLOWUID;
++int fs_overflowgid = DEFAULT_FS_OVERFLOWGID;
++
++EXPORT_SYMBOL(fs_overflowuid);
++EXPORT_SYMBOL(fs_overflowgid);
++
++static const struct ctl_table overflow_sysctl_table[] = {
++	{
++		.procname	= "overflowuid",
++		.data		= &overflowuid,
++		.maxlen		= sizeof(int),
++		.mode		= 0644,
++		.proc_handler	= proc_dointvec_minmax,
++		.extra1		= SYSCTL_ZERO,
++		.extra2		= SYSCTL_MAXOLDUID,
++	},
++	{
++		.procname	= "overflowgid",
++		.data		= &overflowgid,
++		.maxlen		= sizeof(int),
++		.mode		= 0644,
++		.proc_handler	= proc_dointvec_minmax,
++		.extra1		= SYSCTL_ZERO,
++		.extra2		= SYSCTL_MAXOLDUID,
++	},
++};
++
++static int __init init_overflow_sysctl(void)
++{
++	register_sysctl_init("kernel", overflow_sysctl_table);
++	return 0;
++}
++
++postcore_initcall(init_overflow_sysctl);
++
++/*
++ * Returns true if current's euid is same as p's uid or euid,
++ * or has CAP_SYS_NICE to p's user_ns.
++ *
++ * Called with rcu_read_lock, creds are safe
++ */
++static bool set_one_prio_perm(struct task_struct *p)
++{
++	const struct cred *cred = current_cred(), *pcred = __task_cred(p);
++
++	if (uid_eq(pcred->uid,  cred->euid) ||
++	    uid_eq(pcred->euid, cred->euid))
++		return true;
++	if (ns_capable(pcred->user_ns, CAP_SYS_NICE))
++		return true;
++	return false;
++}
++
++/*
++ * set the priority of a task
++ * - the caller must hold the RCU read lock
++ */
++static int set_one_prio(struct task_struct *p, int niceval, int error)
++{
++	int no_nice;
++
++	if (!set_one_prio_perm(p)) {
++		error = -EPERM;
++		goto out;
++	}
++	if (niceval < task_nice(p) && !can_nice(p, niceval)) {
++		error = -EACCES;
++		goto out;
++	}
++	no_nice = security_task_setnice(p, niceval);
++	if (no_nice) {
++		error = no_nice;
++		goto out;
++	}
++	if (error == -ESRCH)
++		error = 0;
++	set_user_nice(p, niceval);
++out:
++	return error;
++}
++
++SYSCALL_DEFINE3(setpriority, int, which, int, who, int, niceval)
++{
++	struct task_struct *g, *p;
++	struct user_struct *user;
++	const struct cred *cred = current_cred();
++	int error = -EINVAL;
++	struct pid *pgrp;
++	kuid_t uid;
++
++	if (which > PRIO_USER || which < PRIO_PROCESS)
++		goto out;
++
++	/* normalize: avoid signed division (rounding problems) */
++	error = -ESRCH;
++	if (niceval < MIN_NICE)
++		niceval = MIN_NICE;
++	if (niceval > MAX_NICE)
++		niceval = MAX_NICE;
++
++	rcu_read_lock();
++	switch (which) {
++	case PRIO_PROCESS:
++		if (who)
++			p = find_task_by_vpid(who);
++		else
++			p = current;
++		if (p)
++			error = set_one_prio(p, niceval, error);
++		break;
++	case PRIO_PGRP:
++		if (who)
++			pgrp = find_vpid(who);
++		else
++			pgrp = task_pgrp(current);
++		read_lock(&tasklist_lock);
++		do_each_pid_thread(pgrp, PIDTYPE_PGID, p) {
++			error = set_one_prio(p, niceval, error);
++		} while_each_pid_thread(pgrp, PIDTYPE_PGID, p);
++		read_unlock(&tasklist_lock);
++		break;
++	case PRIO_USER:
++		uid = make_kuid(cred->user_ns, who);
++		user = cred->user;
++		if (!who)
++			uid = cred->uid;
++		else if (!uid_eq(uid, cred->uid)) {
++			user = find_user(uid);
++			if (!user)
++				goto out_unlock;	/* No processes for this user */
++		}
++		for_each_process_thread(g, p) {
++			if (uid_eq(task_uid(p), uid) && task_pid_vnr(p))
++				error = set_one_prio(p, niceval, error);
++		}
++		if (!uid_eq(uid, cred->uid))
++			free_uid(user);		/* For find_user() */
++		break;
++	}
++out_unlock:
++	rcu_read_unlock();
++out:
++	return error;
++}
++
++/*
++ * Ugh. To avoid negative return values, "getpriority()" will
++ * not return the normal nice-value, but a negated value that
++ * has been offset by 20 (ie it returns 40..1 instead of -20..19)
++ * to stay compatible.
++ */
++SYSCALL_DEFINE2(getpriority, int, which, int, who)
++{
++	struct task_struct *g, *p;
++	struct user_struct *user;
++	const struct cred *cred = current_cred();
++	long niceval, retval = -ESRCH;
++	struct pid *pgrp;
++	kuid_t uid;
++
++	if (which > PRIO_USER || which < PRIO_PROCESS)
++		return -EINVAL;
++
++	rcu_read_lock();
++	switch (which) {
++	case PRIO_PROCESS:
++		if (who)
++			p = find_task_by_vpid(who);
++		else
++			p = current;
++		if (p) {
++			niceval = nice_to_rlimit(task_nice(p));
++			if (niceval > retval)
++				retval = niceval;
++		}
++		break;
++	case PRIO_PGRP:
++		if (who)
++			pgrp = find_vpid(who);
++		else
++			pgrp = task_pgrp(current);
++		read_lock(&tasklist_lock);
++		do_each_pid_thread(pgrp, PIDTYPE_PGID, p) {
++			niceval = nice_to_rlimit(task_nice(p));
++			if (niceval > retval)
++				retval = niceval;
++		} while_each_pid_thread(pgrp, PIDTYPE_PGID, p);
++		read_unlock(&tasklist_lock);
++		break;
++	case PRIO_USER:
++		uid = make_kuid(cred->user_ns, who);
++		user = cred->user;
++		if (!who)
++			uid = cred->uid;
++		else if (!uid_eq(uid, cred->uid)) {
++			user = find_user(uid);
++			if (!user)
++				goto out_unlock;	/* No processes for this user */
++		}
++		for_each_process_thread(g, p) {
++			if (uid_eq(task_uid(p), uid) && task_pid_vnr(p)) {
++				niceval = nice_to_rlimit(task_nice(p));
++				if (niceval > retval)
++					retval = niceval;
++			}
++		}
++		if (!uid_eq(uid, cred->uid))
++			free_uid(user);		/* for find_user() */
++		break;
++	}
++out_unlock:
++	rcu_read_unlock();
++
++	return retval;
++}
++
++/*
++ * Unprivileged users may change the real gid to the effective gid
++ * or vice versa.  (BSD-style)
++ *
++ * If you set the real gid at all, or set the effective gid to a value not
++ * equal to the real gid, then the saved gid is set to the new effective gid.
++ *
++ * This makes it possible for a setgid program to completely drop its
++ * privileges, which is often a useful assertion to make when you are doing
++ * a security audit over a program.
++ *
++ * The general idea is that a program which uses just setregid() will be
++ * 100% compatible with BSD.  A program which uses just setgid() will be
++ * 100% compatible with POSIX with saved IDs.
++ *
++ * SMP: There are not races, the GIDs are checked only by filesystem
++ *      operations (as far as semantic preservation is concerned).
++ */
++#ifdef CONFIG_MULTIUSER
++long __sys_setregid(gid_t rgid, gid_t egid)
++{
++	struct user_namespace *ns = current_user_ns();
++	const struct cred *old;
++	struct cred *new;
++	int retval;
++	kgid_t krgid, kegid;
++
++	krgid = make_kgid(ns, rgid);
++	kegid = make_kgid(ns, egid);
++
++	if ((rgid != (gid_t) -1) && !gid_valid(krgid))
++		return -EINVAL;
++	if ((egid != (gid_t) -1) && !gid_valid(kegid))
++		return -EINVAL;
++
++	new = prepare_creds();
++	if (!new)
++		return -ENOMEM;
++	old = current_cred();
++
++	retval = -EPERM;
++	if (rgid != (gid_t) -1) {
++		if (gid_eq(old->gid, krgid) ||
++		    gid_eq(old->egid, krgid) ||
++		    ns_capable_setid(old->user_ns, CAP_SETGID))
++			new->gid = krgid;
++		else
++			goto error;
++	}
++	if (egid != (gid_t) -1) {
++		if (gid_eq(old->gid, kegid) ||
++		    gid_eq(old->egid, kegid) ||
++		    gid_eq(old->sgid, kegid) ||
++		    ns_capable_setid(old->user_ns, CAP_SETGID))
++			new->egid = kegid;
++		else
++			goto error;
++	}
++
++	if (rgid != (gid_t) -1 ||
++	    (egid != (gid_t) -1 && !gid_eq(kegid, old->gid)))
++		new->sgid = new->egid;
++	new->fsgid = new->egid;
++
++	retval = security_task_fix_setgid(new, old, LSM_SETID_RE);
++	if (retval < 0)
++		goto error;
++
++	return commit_creds(new);
++
++error:
++	abort_creds(new);
++	return retval;
++}
++
++SYSCALL_DEFINE2(setregid, gid_t, rgid, gid_t, egid)
++{
++	return __sys_setregid(rgid, egid);
++}
++
++/*
++ * setgid() is implemented like SysV w/ SAVED_IDS
++ *
++ * SMP: Same implicit races as above.
++ */
++long __sys_setgid(gid_t gid)
++{
++	struct user_namespace *ns = current_user_ns();
++	const struct cred *old;
++	struct cred *new;
++	int retval;
++	kgid_t kgid;
++
++	kgid = make_kgid(ns, gid);
++	if (!gid_valid(kgid))
++		return -EINVAL;
++
++	new = prepare_creds();
++	if (!new)
++		return -ENOMEM;
++	old = current_cred();
++
++	retval = -EPERM;
++	if (ns_capable_setid(old->user_ns, CAP_SETGID))
++		new->gid = new->egid = new->sgid = new->fsgid = kgid;
++	else if (gid_eq(kgid, old->gid) || gid_eq(kgid, old->sgid))
++		new->egid = new->fsgid = kgid;
++	else
++		goto error;
++
++	retval = security_task_fix_setgid(new, old, LSM_SETID_ID);
++	if (retval < 0)
++		goto error;
++
++	return commit_creds(new);
++
++error:
++	abort_creds(new);
++	return retval;
++}
++
++SYSCALL_DEFINE1(setgid, gid_t, gid)
++{
++	return __sys_setgid(gid);
++}
++
++/*
++ * change the user struct in a credentials set to match the new UID
++ */
++static int set_user(struct cred *new)
++{
++	struct user_struct *new_user;
++
++	new_user = alloc_uid(new->uid);
++	if (!new_user)
++		return -EAGAIN;
++
++	free_uid(new->user);
++	new->user = new_user;
++	return 0;
++}
++
++static void flag_nproc_exceeded(struct cred *new)
++{
++	if (new->ucounts == current_ucounts())
++		return;
++
++	/*
++	 * We don't fail in case of NPROC limit excess here because too many
++	 * poorly written programs don't check set*uid() return code, assuming
++	 * it never fails if called by root.  We may still enforce NPROC limit
++	 * for programs doing set*uid()+execve() by harmlessly deferring the
++	 * failure to the execve() stage.
++	 */
++	if (is_rlimit_overlimit(new->ucounts, UCOUNT_RLIMIT_NPROC, rlimit(RLIMIT_NPROC)) &&
++			new->user != INIT_USER)
++		current->flags |= PF_NPROC_EXCEEDED;
++	else
++		current->flags &= ~PF_NPROC_EXCEEDED;
++}
++
++/*
++ * Unprivileged users may change the real uid to the effective uid
++ * or vice versa.  (BSD-style)
++ *
++ * If you set the real uid at all, or set the effective uid to a value not
++ * equal to the real uid, then the saved uid is set to the new effective uid.
++ *
++ * This makes it possible for a setuid program to completely drop its
++ * privileges, which is often a useful assertion to make when you are doing
++ * a security audit over a program.
++ *
++ * The general idea is that a program which uses just setreuid() will be
++ * 100% compatible with BSD.  A program which uses just setuid() will be
++ * 100% compatible with POSIX with saved IDs.
++ */
++long __sys_setreuid(uid_t ruid, uid_t euid)
++{
++	struct user_namespace *ns = current_user_ns();
++	const struct cred *old;
++	struct cred *new;
++	int retval;
++	kuid_t kruid, keuid;
++
++	kruid = make_kuid(ns, ruid);
++	keuid = make_kuid(ns, euid);
++
++	if ((ruid != (uid_t) -1) && !uid_valid(kruid))
++		return -EINVAL;
++	if ((euid != (uid_t) -1) && !uid_valid(keuid))
++		return -EINVAL;
++
++	new = prepare_creds();
++	if (!new)
++		return -ENOMEM;
++	old = current_cred();
++
++	retval = -EPERM;
++	if (ruid != (uid_t) -1) {
++		new->uid = kruid;
++		if (!uid_eq(old->uid, kruid) &&
++		    !uid_eq(old->euid, kruid) &&
++		    !ns_capable_setid(old->user_ns, CAP_SETUID))
++			goto error;
++	}
++
++	if (euid != (uid_t) -1) {
++		new->euid = keuid;
++		if (!uid_eq(old->uid, keuid) &&
++		    !uid_eq(old->euid, keuid) &&
++		    !uid_eq(old->suid, keuid) &&
++		    !ns_capable_setid(old->user_ns, CAP_SETUID))
++			goto error;
++	}
++
++	if (!uid_eq(new->uid, old->uid)) {
++		retval = set_user(new);
++		if (retval < 0)
++			goto error;
++	}
++	if (ruid != (uid_t) -1 ||
++	    (euid != (uid_t) -1 && !uid_eq(keuid, old->uid)))
++		new->suid = new->euid;
++	new->fsuid = new->euid;
++
++	retval = security_task_fix_setuid(new, old, LSM_SETID_RE);
++	if (retval < 0)
++		goto error;
++
++	retval = set_cred_ucounts(new);
++	if (retval < 0)
++		goto error;
++
++	flag_nproc_exceeded(new);
++	return commit_creds(new);
++
++error:
++	abort_creds(new);
++	return retval;
++}
++
++SYSCALL_DEFINE2(setreuid, uid_t, ruid, uid_t, euid)
++{
++	return __sys_setreuid(ruid, euid);
++}
++
++/*
++ * setuid() is implemented like SysV with SAVED_IDS
++ *
++ * Note that SAVED_ID's is deficient in that a setuid root program
++ * like sendmail, for example, cannot set its uid to be a normal
++ * user and then switch back, because if you're root, setuid() sets
++ * the saved uid too.  If you don't like this, blame the bright people
++ * in the POSIX committee and/or USG.  Note that the BSD-style setreuid()
++ * will allow a root program to temporarily drop privileges and be able to
++ * regain them by swapping the real and effective uid.
++ */
++long __sys_setuid(uid_t uid)
++{
++	struct user_namespace *ns = current_user_ns();
++	const struct cred *old;
++	struct cred *new;
++	int retval;
++	kuid_t kuid;
++
++	kuid = make_kuid(ns, uid);
++	if (!uid_valid(kuid))
++		return -EINVAL;
++
++	new = prepare_creds();
++	if (!new)
++		return -ENOMEM;
++	old = current_cred();
++
++	retval = -EPERM;
++	if (ns_capable_setid(old->user_ns, CAP_SETUID)) {
++		new->suid = new->uid = kuid;
++		if (!uid_eq(kuid, old->uid)) {
++			retval = set_user(new);
++			if (retval < 0)
++				goto error;
++		}
++	} else if (!uid_eq(kuid, old->uid) && !uid_eq(kuid, new->suid)) {
++		goto error;
++	}
++
++	new->fsuid = new->euid = kuid;
++
++	retval = security_task_fix_setuid(new, old, LSM_SETID_ID);
++	if (retval < 0)
++		goto error;
++
++	retval = set_cred_ucounts(new);
++	if (retval < 0)
++		goto error;
++
++	flag_nproc_exceeded(new);
++	return commit_creds(new);
++
++error:
++	abort_creds(new);
++	return retval;
++}
++
++SYSCALL_DEFINE1(setuid, uid_t, uid)
++{
++	return __sys_setuid(uid);
++}
++
++
++/*
++ * This function implements a generic ability to update ruid, euid,
++ * and suid.  This allows you to implement the 4.4 compatible seteuid().
++ */
++long __sys_setresuid(uid_t ruid, uid_t euid, uid_t suid)
++{
++	struct user_namespace *ns = current_user_ns();
++	const struct cred *old;
++	struct cred *new;
++	int retval;
++	kuid_t kruid, keuid, ksuid;
++	bool ruid_new, euid_new, suid_new;
++
++	kruid = make_kuid(ns, ruid);
++	keuid = make_kuid(ns, euid);
++	ksuid = make_kuid(ns, suid);
++
++	if ((ruid != (uid_t) -1) && !uid_valid(kruid))
++		return -EINVAL;
++
++	if ((euid != (uid_t) -1) && !uid_valid(keuid))
++		return -EINVAL;
++
++	if ((suid != (uid_t) -1) && !uid_valid(ksuid))
++		return -EINVAL;
++
++	old = current_cred();
++
++	/* check for no-op */
++	if ((ruid == (uid_t) -1 || uid_eq(kruid, old->uid)) &&
++	    (euid == (uid_t) -1 || (uid_eq(keuid, old->euid) &&
++				    uid_eq(keuid, old->fsuid))) &&
++	    (suid == (uid_t) -1 || uid_eq(ksuid, old->suid)))
++		return 0;
++
++	ruid_new = ruid != (uid_t) -1        && !uid_eq(kruid, old->uid) &&
++		   !uid_eq(kruid, old->euid) && !uid_eq(kruid, old->suid);
++	euid_new = euid != (uid_t) -1        && !uid_eq(keuid, old->uid) &&
++		   !uid_eq(keuid, old->euid) && !uid_eq(keuid, old->suid);
++	suid_new = suid != (uid_t) -1        && !uid_eq(ksuid, old->uid) &&
++		   !uid_eq(ksuid, old->euid) && !uid_eq(ksuid, old->suid);
++	if ((ruid_new || euid_new || suid_new) &&
++	    !ns_capable_setid(old->user_ns, CAP_SETUID))
++		return -EPERM;
++
++	new = prepare_creds();
++	if (!new)
++		return -ENOMEM;
++
++	if (ruid != (uid_t) -1) {
++		new->uid = kruid;
++		if (!uid_eq(kruid, old->uid)) {
++			retval = set_user(new);
++			if (retval < 0)
++				goto error;
++		}
++	}
++	if (euid != (uid_t) -1)
++		new->euid = keuid;
++	if (suid != (uid_t) -1)
++		new->suid = ksuid;
++	new->fsuid = new->euid;
++
++	retval = security_task_fix_setuid(new, old, LSM_SETID_RES);
++	if (retval < 0)
++		goto error;
++
++	retval = set_cred_ucounts(new);
++	if (retval < 0)
++		goto error;
++
++	flag_nproc_exceeded(new);
++	return commit_creds(new);
++
++error:
++	abort_creds(new);
++	return retval;
++}
++
++SYSCALL_DEFINE3(setresuid, uid_t, ruid, uid_t, euid, uid_t, suid)
++{
++	return __sys_setresuid(ruid, euid, suid);
++}
++
++SYSCALL_DEFINE3(getresuid, uid_t __user *, ruidp, uid_t __user *, euidp, uid_t __user *, suidp)
++{
++	const struct cred *cred = current_cred();
++	int retval;
++	uid_t ruid, euid, suid;
++
++	ruid = from_kuid_munged(cred->user_ns, cred->uid);
++	euid = from_kuid_munged(cred->user_ns, cred->euid);
++	suid = from_kuid_munged(cred->user_ns, cred->suid);
++
++	retval = put_user(ruid, ruidp);
++	if (!retval) {
++		retval = put_user(euid, euidp);
++		if (!retval)
++			return put_user(suid, suidp);
++	}
++	return retval;
++}
++
++/*
++ * Same as above, but for rgid, egid, sgid.
++ */
++long __sys_setresgid(gid_t rgid, gid_t egid, gid_t sgid)
++{
++	struct user_namespace *ns = current_user_ns();
++	const struct cred *old;
++	struct cred *new;
++	int retval;
++	kgid_t krgid, kegid, ksgid;
++	bool rgid_new, egid_new, sgid_new;
++
++	krgid = make_kgid(ns, rgid);
++	kegid = make_kgid(ns, egid);
++	ksgid = make_kgid(ns, sgid);
++
++	if ((rgid != (gid_t) -1) && !gid_valid(krgid))
++		return -EINVAL;
++	if ((egid != (gid_t) -1) && !gid_valid(kegid))
++		return -EINVAL;
++	if ((sgid != (gid_t) -1) && !gid_valid(ksgid))
++		return -EINVAL;
++
++	old = current_cred();
++
++	/* check for no-op */
++	if ((rgid == (gid_t) -1 || gid_eq(krgid, old->gid)) &&
++	    (egid == (gid_t) -1 || (gid_eq(kegid, old->egid) &&
++				    gid_eq(kegid, old->fsgid))) &&
++	    (sgid == (gid_t) -1 || gid_eq(ksgid, old->sgid)))
++		return 0;
++
++	rgid_new = rgid != (gid_t) -1        && !gid_eq(krgid, old->gid) &&
++		   !gid_eq(krgid, old->egid) && !gid_eq(krgid, old->sgid);
++	egid_new = egid != (gid_t) -1        && !gid_eq(kegid, old->gid) &&
++		   !gid_eq(kegid, old->egid) && !gid_eq(kegid, old->sgid);
++	sgid_new = sgid != (gid_t) -1        && !gid_eq(ksgid, old->gid) &&
++		   !gid_eq(ksgid, old->egid) && !gid_eq(ksgid, old->sgid);
++	if ((rgid_new || egid_new || sgid_new) &&
++	    !ns_capable_setid(old->user_ns, CAP_SETGID))
++		return -EPERM;
++
++	new = prepare_creds();
++	if (!new)
++		return -ENOMEM;
++
++	if (rgid != (gid_t) -1)
++		new->gid = krgid;
++	if (egid != (gid_t) -1)
++		new->egid = kegid;
++	if (sgid != (gid_t) -1)
++		new->sgid = ksgid;
++	new->fsgid = new->egid;
++
++	retval = security_task_fix_setgid(new, old, LSM_SETID_RES);
++	if (retval < 0)
++		goto error;
++
++	return commit_creds(new);
++
++error:
++	abort_creds(new);
++	return retval;
++}
++
++SYSCALL_DEFINE3(setresgid, gid_t, rgid, gid_t, egid, gid_t, sgid)
++{
++	return __sys_setresgid(rgid, egid, sgid);
++}
++
++SYSCALL_DEFINE3(getresgid, gid_t __user *, rgidp, gid_t __user *, egidp, gid_t __user *, sgidp)
++{
++	const struct cred *cred = current_cred();
++	int retval;
++	gid_t rgid, egid, sgid;
++
++	rgid = from_kgid_munged(cred->user_ns, cred->gid);
++	egid = from_kgid_munged(cred->user_ns, cred->egid);
++	sgid = from_kgid_munged(cred->user_ns, cred->sgid);
++
++	retval = put_user(rgid, rgidp);
++	if (!retval) {
++		retval = put_user(egid, egidp);
++		if (!retval)
++			retval = put_user(sgid, sgidp);
++	}
++
++	return retval;
++}
++
++
++/*
++ * "setfsuid()" sets the fsuid - the uid used for filesystem checks. This
++ * is used for "access()" and for the NFS daemon (letting nfsd stay at
++ * whatever uid it wants to). It normally shadows "euid", except when
++ * explicitly set by setfsuid() or for access..
++ */
++long __sys_setfsuid(uid_t uid)
++{
++	const struct cred *old;
++	struct cred *new;
++	uid_t old_fsuid;
++	kuid_t kuid;
++
++	old = current_cred();
++	old_fsuid = from_kuid_munged(old->user_ns, old->fsuid);
++
++	kuid = make_kuid(old->user_ns, uid);
++	if (!uid_valid(kuid))
++		return old_fsuid;
++
++	new = prepare_creds();
++	if (!new)
++		return old_fsuid;
++
++	if (uid_eq(kuid, old->uid)  || uid_eq(kuid, old->euid)  ||
++	    uid_eq(kuid, old->suid) || uid_eq(kuid, old->fsuid) ||
++	    ns_capable_setid(old->user_ns, CAP_SETUID)) {
++		if (!uid_eq(kuid, old->fsuid)) {
++			new->fsuid = kuid;
++			if (security_task_fix_setuid(new, old, LSM_SETID_FS) == 0)
++				goto change_okay;
++		}
++	}
++
++	abort_creds(new);
++	return old_fsuid;
++
++change_okay:
++	commit_creds(new);
++	return old_fsuid;
++}
++
++SYSCALL_DEFINE1(setfsuid, uid_t, uid)
++{
++	return __sys_setfsuid(uid);
++}
++
++/*
++ * Samma på svenska..
++ */
++long __sys_setfsgid(gid_t gid)
++{
++	const struct cred *old;
++	struct cred *new;
++	gid_t old_fsgid;
++	kgid_t kgid;
++
++	old = current_cred();
++	old_fsgid = from_kgid_munged(old->user_ns, old->fsgid);
++
++	kgid = make_kgid(old->user_ns, gid);
++	if (!gid_valid(kgid))
++		return old_fsgid;
++
++	new = prepare_creds();
++	if (!new)
++		return old_fsgid;
++
++	if (gid_eq(kgid, old->gid)  || gid_eq(kgid, old->egid)  ||
++	    gid_eq(kgid, old->sgid) || gid_eq(kgid, old->fsgid) ||
++	    ns_capable_setid(old->user_ns, CAP_SETGID)) {
++		if (!gid_eq(kgid, old->fsgid)) {
++			new->fsgid = kgid;
++			if (security_task_fix_setgid(new,old,LSM_SETID_FS) == 0)
++				goto change_okay;
++		}
++	}
++
++	abort_creds(new);
++	return old_fsgid;
++
++change_okay:
++	commit_creds(new);
++	return old_fsgid;
++}
++
++SYSCALL_DEFINE1(setfsgid, gid_t, gid)
++{
++	return __sys_setfsgid(gid);
++}
++#endif /* CONFIG_MULTIUSER */
++
++/**
++ * sys_getpid - return the thread group id of the current process
++ *
++ * Note, despite the name, this returns the tgid not the pid.  The tgid and
++ * the pid are identical unless CLONE_THREAD was specified on clone() in
++ * which case the tgid is the same in all threads of the same group.
++ *
++ * This is SMP safe as current->tgid does not change.
++ */
++SYSCALL_DEFINE0(getpid)
++{
++	return task_tgid_vnr(current);
++}
++
++/* Thread ID - the internal kernel "pid" */
++SYSCALL_DEFINE0(gettid)
++{
++	return task_pid_vnr(current);
++}
++
++/*
++ * Accessing ->real_parent is not SMP-safe, it could
++ * change from under us. However, we can use a stale
++ * value of ->real_parent under rcu_read_lock(), see
++ * release_task()->call_rcu(delayed_put_task_struct).
++ */
++SYSCALL_DEFINE0(getppid)
++{
++	int pid;
++
++	rcu_read_lock();
++	pid = task_tgid_vnr(rcu_dereference(current->real_parent));
++	rcu_read_unlock();
++
++	return pid;
++}
++
++SYSCALL_DEFINE0(getuid)
++{
++	/* Only we change this so SMP safe */
++	return from_kuid_munged(current_user_ns(), current_uid());
++}
++
++SYSCALL_DEFINE0(geteuid)
++{
++	/* Only we change this so SMP safe */
++	return from_kuid_munged(current_user_ns(), current_euid());
++}
++
++SYSCALL_DEFINE0(getgid)
++{
++	/* Only we change this so SMP safe */
++	return from_kgid_munged(current_user_ns(), current_gid());
++}
++
++SYSCALL_DEFINE0(getegid)
++{
++	/* Only we change this so SMP safe */
++	return from_kgid_munged(current_user_ns(), current_egid());
++}
++
++static void do_sys_times(struct tms *tms)
++{
++	u64 tgutime, tgstime, cutime, cstime;
++
++	thread_group_cputime_adjusted(current, &tgutime, &tgstime);
++	cutime = current->signal->cutime;
++	cstime = current->signal->cstime;
++	tms->tms_utime = nsec_to_clock_t(tgutime);
++	tms->tms_stime = nsec_to_clock_t(tgstime);
++	tms->tms_cutime = nsec_to_clock_t(cutime);
++	tms->tms_cstime = nsec_to_clock_t(cstime);
++}
++
++SYSCALL_DEFINE1(times, struct tms __user *, tbuf)
++{
++	if (tbuf) {
++		struct tms tmp;
++
++		do_sys_times(&tmp);
++		if (copy_to_user(tbuf, &tmp, sizeof(struct tms)))
++			return -EFAULT;
++	}
++	force_successful_syscall_return();
++	return (long) jiffies_64_to_clock_t(get_jiffies_64());
++}
++
++#ifdef CONFIG_COMPAT
++static compat_clock_t clock_t_to_compat_clock_t(clock_t x)
++{
++	return compat_jiffies_to_clock_t(clock_t_to_jiffies(x));
++}
++
++COMPAT_SYSCALL_DEFINE1(times, struct compat_tms __user *, tbuf)
++{
++	if (tbuf) {
++		struct tms tms;
++		struct compat_tms tmp;
++
++		do_sys_times(&tms);
++		/* Convert our struct tms to the compat version. */
++		tmp.tms_utime = clock_t_to_compat_clock_t(tms.tms_utime);
++		tmp.tms_stime = clock_t_to_compat_clock_t(tms.tms_stime);
++		tmp.tms_cutime = clock_t_to_compat_clock_t(tms.tms_cutime);
++		tmp.tms_cstime = clock_t_to_compat_clock_t(tms.tms_cstime);
++		if (copy_to_user(tbuf, &tmp, sizeof(tmp)))
++			return -EFAULT;
++	}
++	force_successful_syscall_return();
++	return compat_jiffies_to_clock_t(jiffies);
++}
++#endif
++
++/*
++ * This needs some heavy checking ...
++ * I just haven't the stomach for it. I also don't fully
++ * understand sessions/pgrp etc. Let somebody who does explain it.
++ *
++ * OK, I think I have the protection semantics right.... this is really
++ * only important on a multi-user system anyway, to make sure one user
++ * can't send a signal to a process owned by another.  -TYT, 12/12/91
++ *
++ * !PF_FORKNOEXEC check to conform completely to POSIX.
++ */
++SYSCALL_DEFINE2(setpgid, pid_t, pid, pid_t, pgid)
++{
++	struct task_struct *p;
++	struct task_struct *group_leader = current->group_leader;
++	struct pid *pids[PIDTYPE_MAX] = { 0 };
++	struct pid *pgrp;
++	int err;
++
++	if (!pid)
++		pid = task_pid_vnr(group_leader);
++	if (!pgid)
++		pgid = pid;
++	if (pgid < 0)
++		return -EINVAL;
++	rcu_read_lock();
++
++	/* From this point forward we keep holding onto the tasklist lock
++	 * so that our parent does not change from under us. -DaveM
++	 */
++	write_lock_irq(&tasklist_lock);
++
++	err = -ESRCH;
++	p = find_task_by_vpid(pid);
++	if (!p)
++		goto out;
++
++	err = -EINVAL;
++	if (!thread_group_leader(p))
++		goto out;
++
++	if (same_thread_group(p->real_parent, group_leader)) {
++		err = -EPERM;
++		if (task_session(p) != task_session(group_leader))
++			goto out;
++		err = -EACCES;
++		if (!(p->flags & PF_FORKNOEXEC))
++			goto out;
++	} else {
++		err = -ESRCH;
++		if (p != group_leader)
++			goto out;
++	}
++
++	err = -EPERM;
++	if (p->signal->leader)
++		goto out;
++
++	pgrp = task_pid(p);
++	if (pgid != pid) {
++		struct task_struct *g;
++
++		pgrp = find_vpid(pgid);
++		g = pid_task(pgrp, PIDTYPE_PGID);
++		if (!g || task_session(g) != task_session(group_leader))
++			goto out;
++	}
++
++	err = security_task_setpgid(p, pgid);
++	if (err)
++		goto out;
++
++	if (task_pgrp(p) != pgrp)
++		change_pid(pids, p, PIDTYPE_PGID, pgrp);
++
++	err = 0;
++out:
++	/* All paths lead to here, thus we are safe. -DaveM */
++	write_unlock_irq(&tasklist_lock);
++	rcu_read_unlock();
++	free_pids(pids);
++	return err;
++}
++
++static int do_getpgid(pid_t pid)
++{
++	struct task_struct *p;
++	struct pid *grp;
++	int retval;
++
++	rcu_read_lock();
++	if (!pid)
++		grp = task_pgrp(current);
++	else {
++		retval = -ESRCH;
++		p = find_task_by_vpid(pid);
++		if (!p)
++			goto out;
++		grp = task_pgrp(p);
++		if (!grp)
++			goto out;
++
++		retval = security_task_getpgid(p);
++		if (retval)
++			goto out;
++	}
++	retval = pid_vnr(grp);
++out:
++	rcu_read_unlock();
++	return retval;
++}
++
++SYSCALL_DEFINE1(getpgid, pid_t, pid)
++{
++	return do_getpgid(pid);
++}
++
++#ifdef __ARCH_WANT_SYS_GETPGRP
++
++SYSCALL_DEFINE0(getpgrp)
++{
++	return do_getpgid(0);
++}
++
++#endif
++
++SYSCALL_DEFINE1(getsid, pid_t, pid)
++{
++	struct task_struct *p;
++	struct pid *sid;
++	int retval;
++
++	rcu_read_lock();
++	if (!pid)
++		sid = task_session(current);
++	else {
++		retval = -ESRCH;
++		p = find_task_by_vpid(pid);
++		if (!p)
++			goto out;
++		sid = task_session(p);
++		if (!sid)
++			goto out;
++
++		retval = security_task_getsid(p);
++		if (retval)
++			goto out;
++	}
++	retval = pid_vnr(sid);
++out:
++	rcu_read_unlock();
++	return retval;
++}
++
++static void set_special_pids(struct pid **pids, struct pid *pid)
++{
++	struct task_struct *curr = current->group_leader;
++
++	if (task_session(curr) != pid)
++		change_pid(pids, curr, PIDTYPE_SID, pid);
++
++	if (task_pgrp(curr) != pid)
++		change_pid(pids, curr, PIDTYPE_PGID, pid);
++}
++
++int ksys_setsid(void)
++{
++	struct task_struct *group_leader = current->group_leader;
++	struct pid *sid = task_pid(group_leader);
++	struct pid *pids[PIDTYPE_MAX] = { 0 };
++	pid_t session = pid_vnr(sid);
++	int err = -EPERM;
++
++	write_lock_irq(&tasklist_lock);
++	/* Fail if I am already a session leader */
++	if (group_leader->signal->leader)
++		goto out;
++
++	/* Fail if a process group id already exists that equals the
++	 * proposed session id.
++	 */
++	if (pid_task(sid, PIDTYPE_PGID))
++		goto out;
++
++	group_leader->signal->leader = 1;
++	set_special_pids(pids, sid);
++
++	proc_clear_tty(group_leader);
++
++	err = session;
++out:
++	write_unlock_irq(&tasklist_lock);
++	free_pids(pids);
++	if (err > 0) {
++		proc_sid_connector(group_leader);
++		sched_autogroup_create_attach(group_leader);
++	}
++	return err;
++}
++
++SYSCALL_DEFINE0(setsid)
++{
++	return ksys_setsid();
++}
++
++DECLARE_RWSEM(uts_sem);
++
++#ifdef COMPAT_UTS_MACHINE
++#define override_architecture(name) \
++	(personality(current->personality) == PER_LINUX32 && \
++	 copy_to_user(name->machine, COMPAT_UTS_MACHINE, \
++		      sizeof(COMPAT_UTS_MACHINE)))
++#else
++#define override_architecture(name)	0
++#endif
++
++/*
++ * Work around broken programs that cannot handle "Linux 3.0".
++ * Instead we map 3.x to 2.6.40+x, so e.g. 3.0 would be 2.6.40
++ * And we map 4.x and later versions to 2.6.60+x, so 4.0/5.0/6.0/... would be
++ * 2.6.60.
++ */
++static int override_release(char __user *release, size_t len)
++{
++	int ret = 0;
++
++	if (current->personality & UNAME26) {
++		const char *rest = UTS_RELEASE;
++		char buf[65] = { 0 };
++		int ndots = 0;
++		unsigned v;
++		size_t copy;
++
++		while (*rest) {
++			if (*rest == '.' && ++ndots >= 3)
++				break;
++			if (!isdigit(*rest) && *rest != '.')
++				break;
++			rest++;
++		}
++		v = LINUX_VERSION_PATCHLEVEL + 60;
++		copy = clamp_t(size_t, len, 1, sizeof(buf));
++		copy = scnprintf(buf, copy, "2.6.%u%s", v, rest);
++		ret = copy_to_user(release, buf, copy + 1);
++	}
++	return ret;
++}
++
++SYSCALL_DEFINE1(newuname, struct new_utsname __user *, name)
++{
++	struct new_utsname tmp;
++
++	down_read(&uts_sem);
++	memcpy(&tmp, utsname(), sizeof(tmp));
++	up_read(&uts_sem);
++	if (copy_to_user(name, &tmp, sizeof(tmp)))
++		return -EFAULT;
++
++	if (override_release(name->release, sizeof(name->release)))
++		return -EFAULT;
++	if (override_architecture(name))
++		return -EFAULT;
++	return 0;
++}
++
++#ifdef __ARCH_WANT_SYS_OLD_UNAME
++/*
++ * Old cruft
++ */
++SYSCALL_DEFINE1(uname, struct old_utsname __user *, name)
++{
++	struct old_utsname tmp;
++
++	if (!name)
++		return -EFAULT;
++
++	down_read(&uts_sem);
++	memcpy(&tmp, utsname(), sizeof(tmp));
++	up_read(&uts_sem);
++	if (copy_to_user(name, &tmp, sizeof(tmp)))
++		return -EFAULT;
++
++	if (override_release(name->release, sizeof(name->release)))
++		return -EFAULT;
++	if (override_architecture(name))
++		return -EFAULT;
++	return 0;
++}
++
++SYSCALL_DEFINE1(olduname, struct oldold_utsname __user *, name)
++{
++	struct oldold_utsname tmp;
++
++	if (!name)
++		return -EFAULT;
++
++	memset(&tmp, 0, sizeof(tmp));
++
++	down_read(&uts_sem);
++	memcpy(&tmp.sysname, &utsname()->sysname, __OLD_UTS_LEN);
++	memcpy(&tmp.nodename, &utsname()->nodename, __OLD_UTS_LEN);
++	memcpy(&tmp.release, &utsname()->release, __OLD_UTS_LEN);
++	memcpy(&tmp.version, &utsname()->version, __OLD_UTS_LEN);
++	memcpy(&tmp.machine, &utsname()->machine, __OLD_UTS_LEN);
++	up_read(&uts_sem);
++	if (copy_to_user(name, &tmp, sizeof(tmp)))
++		return -EFAULT;
++
++	if (override_architecture(name))
++		return -EFAULT;
++	if (override_release(name->release, sizeof(name->release)))
++		return -EFAULT;
++	return 0;
++}
++#endif
++
++SYSCALL_DEFINE2(sethostname, char __user *, name, int, len)
++{
++	int errno;
++	char tmp[__NEW_UTS_LEN];
++
++	if (!ns_capable(current->nsproxy->uts_ns->user_ns, CAP_SYS_ADMIN))
++		return -EPERM;
++
++	if (len < 0 || len > __NEW_UTS_LEN)
++		return -EINVAL;
++	errno = -EFAULT;
++	if (!copy_from_user(tmp, name, len)) {
++		struct new_utsname *u;
++
++		add_device_randomness(tmp, len);
++		down_write(&uts_sem);
++		u = utsname();
++		memcpy(u->nodename, tmp, len);
++		memset(u->nodename + len, 0, sizeof(u->nodename) - len);
++		errno = 0;
++		uts_proc_notify(UTS_PROC_HOSTNAME);
++		up_write(&uts_sem);
++	}
++	return errno;
++}
++
++#ifdef __ARCH_WANT_SYS_GETHOSTNAME
++
++SYSCALL_DEFINE2(gethostname, char __user *, name, int, len)
++{
++	int i;
++	struct new_utsname *u;
++	char tmp[__NEW_UTS_LEN + 1];
++
++	if (len < 0)
++		return -EINVAL;
++	down_read(&uts_sem);
++	u = utsname();
++	i = 1 + strlen(u->nodename);
++	if (i > len)
++		i = len;
++	memcpy(tmp, u->nodename, i);
++	up_read(&uts_sem);
++	if (copy_to_user(name, tmp, i))
++		return -EFAULT;
++	return 0;
++}
++
++#endif
++
++/*
++ * Only setdomainname; getdomainname can be implemented by calling
++ * uname()
++ */
++SYSCALL_DEFINE2(setdomainname, char __user *, name, int, len)
++{
++	int errno;
++	char tmp[__NEW_UTS_LEN];
++
++	if (!ns_capable(current->nsproxy->uts_ns->user_ns, CAP_SYS_ADMIN))
++		return -EPERM;
++	if (len < 0 || len > __NEW_UTS_LEN)
++		return -EINVAL;
++
++	errno = -EFAULT;
++	if (!copy_from_user(tmp, name, len)) {
++		struct new_utsname *u;
++
++		add_device_randomness(tmp, len);
++		down_write(&uts_sem);
++		u = utsname();
++		memcpy(u->domainname, tmp, len);
++		memset(u->domainname + len, 0, sizeof(u->domainname) - len);
++		errno = 0;
++		uts_proc_notify(UTS_PROC_DOMAINNAME);
++		up_write(&uts_sem);
++	}
++	return errno;
++}
++
++/* make sure you are allowed to change @tsk limits before calling this */
++static int do_prlimit(struct task_struct *tsk, unsigned int resource,
++		      struct rlimit *new_rlim, struct rlimit *old_rlim)
++{
++	struct rlimit *rlim;
++	int retval = 0;
++
++	if (resource >= RLIM_NLIMITS)
++		return -EINVAL;
++	resource = array_index_nospec(resource, RLIM_NLIMITS);
++
++	if (new_rlim) {
++		if (new_rlim->rlim_cur > new_rlim->rlim_max)
++			return -EINVAL;
++		if (resource == RLIMIT_NOFILE &&
++				new_rlim->rlim_max > sysctl_nr_open)
++			return -EPERM;
++	}
++
++	/* Holding a refcount on tsk protects tsk->signal from disappearing. */
++	rlim = tsk->signal->rlim + resource;
++	task_lock(tsk->group_leader);
++	if (new_rlim) {
++		/*
++		 * Keep the capable check against init_user_ns until cgroups can
++		 * contain all limits.
++		 */
++		if (new_rlim->rlim_max > rlim->rlim_max &&
++				!capable(CAP_SYS_RESOURCE))
++			retval = -EPERM;
++		if (!retval)
++			retval = security_task_setrlimit(tsk, resource, new_rlim);
++	}
++	if (!retval) {
++		if (old_rlim)
++			*old_rlim = *rlim;
++		if (new_rlim)
++			*rlim = *new_rlim;
++	}
++	task_unlock(tsk->group_leader);
++
++	/*
++	 * RLIMIT_CPU handling. Arm the posix CPU timer if the limit is not
++	 * infinite. In case of RLIM_INFINITY the posix CPU timer code
++	 * ignores the rlimit.
++	 */
++	if (!retval && new_rlim && resource == RLIMIT_CPU &&
++	    new_rlim->rlim_cur != RLIM_INFINITY &&
++	    IS_ENABLED(CONFIG_POSIX_TIMERS)) {
++		/*
++		 * update_rlimit_cpu can fail if the task is exiting, but there
++		 * may be other tasks in the thread group that are not exiting,
++		 * and they need their cpu timers adjusted.
++		 *
++		 * The group_leader is the last task to be released, so if we
++		 * cannot update_rlimit_cpu on it, then the entire process is
++		 * exiting and we do not need to update at all.
++		 */
++		update_rlimit_cpu(tsk->group_leader, new_rlim->rlim_cur);
++	}
++
++	return retval;
++}
++
++SYSCALL_DEFINE2(getrlimit, unsigned int, resource, struct rlimit __user *, rlim)
++{
++	struct rlimit value;
++	int ret;
++
++	ret = do_prlimit(current, resource, NULL, &value);
++	if (!ret)
++		ret = copy_to_user(rlim, &value, sizeof(*rlim)) ? -EFAULT : 0;
++
++	return ret;
++}
++
++#ifdef CONFIG_COMPAT
++
++COMPAT_SYSCALL_DEFINE2(setrlimit, unsigned int, resource,
++		       struct compat_rlimit __user *, rlim)
++{
++	struct rlimit r;
++	struct compat_rlimit r32;
++
++	if (copy_from_user(&r32, rlim, sizeof(struct compat_rlimit)))
++		return -EFAULT;
++
++	if (r32.rlim_cur == COMPAT_RLIM_INFINITY)
++		r.rlim_cur = RLIM_INFINITY;
++	else
++		r.rlim_cur = r32.rlim_cur;
++	if (r32.rlim_max == COMPAT_RLIM_INFINITY)
++		r.rlim_max = RLIM_INFINITY;
++	else
++		r.rlim_max = r32.rlim_max;
++	return do_prlimit(current, resource, &r, NULL);
++}
++
++COMPAT_SYSCALL_DEFINE2(getrlimit, unsigned int, resource,
++		       struct compat_rlimit __user *, rlim)
++{
++	struct rlimit r;
++	int ret;
++
++	ret = do_prlimit(current, resource, NULL, &r);
++	if (!ret) {
++		struct compat_rlimit r32;
++		if (r.rlim_cur > COMPAT_RLIM_INFINITY)
++			r32.rlim_cur = COMPAT_RLIM_INFINITY;
++		else
++			r32.rlim_cur = r.rlim_cur;
++		if (r.rlim_max > COMPAT_RLIM_INFINITY)
++			r32.rlim_max = COMPAT_RLIM_INFINITY;
++		else
++			r32.rlim_max = r.rlim_max;
++
++		if (copy_to_user(rlim, &r32, sizeof(struct compat_rlimit)))
++			return -EFAULT;
++	}
++	return ret;
++}
++
++#endif
++
++#ifdef __ARCH_WANT_SYS_OLD_GETRLIMIT
++
++/*
++ *	Back compatibility for getrlimit. Needed for some apps.
++ */
++SYSCALL_DEFINE2(old_getrlimit, unsigned int, resource,
++		struct rlimit __user *, rlim)
++{
++	struct rlimit x;
++	if (resource >= RLIM_NLIMITS)
++		return -EINVAL;
++
++	resource = array_index_nospec(resource, RLIM_NLIMITS);
++	task_lock(current->group_leader);
++	x = current->signal->rlim[resource];
++	task_unlock(current->group_leader);
++	if (x.rlim_cur > 0x7FFFFFFF)
++		x.rlim_cur = 0x7FFFFFFF;
++	if (x.rlim_max > 0x7FFFFFFF)
++		x.rlim_max = 0x7FFFFFFF;
++	return copy_to_user(rlim, &x, sizeof(x)) ? -EFAULT : 0;
++}
++
++#ifdef CONFIG_COMPAT
++COMPAT_SYSCALL_DEFINE2(old_getrlimit, unsigned int, resource,
++		       struct compat_rlimit __user *, rlim)
++{
++	struct rlimit r;
++
++	if (resource >= RLIM_NLIMITS)
++		return -EINVAL;
++
++	resource = array_index_nospec(resource, RLIM_NLIMITS);
++	task_lock(current->group_leader);
++	r = current->signal->rlim[resource];
++	task_unlock(current->group_leader);
++	if (r.rlim_cur > 0x7FFFFFFF)
++		r.rlim_cur = 0x7FFFFFFF;
++	if (r.rlim_max > 0x7FFFFFFF)
++		r.rlim_max = 0x7FFFFFFF;
++
++	if (put_user(r.rlim_cur, &rlim->rlim_cur) ||
++	    put_user(r.rlim_max, &rlim->rlim_max))
++		return -EFAULT;
++	return 0;
++}
++#endif
++
++#endif
++
++static inline bool rlim64_is_infinity(__u64 rlim64)
++{
++#if BITS_PER_LONG < 64
++	return rlim64 >= ULONG_MAX;
++#else
++	return rlim64 == RLIM64_INFINITY;
++#endif
++}
++
++static void rlim_to_rlim64(const struct rlimit *rlim, struct rlimit64 *rlim64)
++{
++	if (rlim->rlim_cur == RLIM_INFINITY)
++		rlim64->rlim_cur = RLIM64_INFINITY;
++	else
++		rlim64->rlim_cur = rlim->rlim_cur;
++	if (rlim->rlim_max == RLIM_INFINITY)
++		rlim64->rlim_max = RLIM64_INFINITY;
++	else
++		rlim64->rlim_max = rlim->rlim_max;
++}
++
++static void rlim64_to_rlim(const struct rlimit64 *rlim64, struct rlimit *rlim)
++{
++	if (rlim64_is_infinity(rlim64->rlim_cur))
++		rlim->rlim_cur = RLIM_INFINITY;
++	else
++		rlim->rlim_cur = (unsigned long)rlim64->rlim_cur;
++	if (rlim64_is_infinity(rlim64->rlim_max))
++		rlim->rlim_max = RLIM_INFINITY;
++	else
++		rlim->rlim_max = (unsigned long)rlim64->rlim_max;
++}
++
++/* rcu lock must be held */
++static int check_prlimit_permission(struct task_struct *task,
++				    unsigned int flags)
++{
++	const struct cred *cred = current_cred(), *tcred;
++	bool id_match;
++
++	if (current == task)
++		return 0;
++
++	tcred = __task_cred(task);
++	id_match = (uid_eq(cred->uid, tcred->euid) &&
++		    uid_eq(cred->uid, tcred->suid) &&
++		    uid_eq(cred->uid, tcred->uid)  &&
++		    gid_eq(cred->gid, tcred->egid) &&
++		    gid_eq(cred->gid, tcred->sgid) &&
++		    gid_eq(cred->gid, tcred->gid));
++	if (!id_match && !ns_capable(tcred->user_ns, CAP_SYS_RESOURCE))
++		return -EPERM;
++
++	return security_task_prlimit(cred, tcred, flags);
++}
++
++SYSCALL_DEFINE4(prlimit64, pid_t, pid, unsigned int, resource,
++		const struct rlimit64 __user *, new_rlim,
++		struct rlimit64 __user *, old_rlim)
++{
++	struct rlimit64 old64, new64;
++	struct rlimit old, new;
++	struct task_struct *tsk;
++	unsigned int checkflags = 0;
++	bool need_tasklist;
++	int ret;
++
++	if (old_rlim)
++		checkflags |= LSM_PRLIMIT_READ;
++
++	if (new_rlim) {
++		if (copy_from_user(&new64, new_rlim, sizeof(new64)))
++			return -EFAULT;
++		rlim64_to_rlim(&new64, &new);
++		checkflags |= LSM_PRLIMIT_WRITE;
++	}
++
++	rcu_read_lock();
++	tsk = pid ? find_task_by_vpid(pid) : current;
++	if (!tsk) {
++		rcu_read_unlock();
++		return -ESRCH;
++	}
++	ret = check_prlimit_permission(tsk, checkflags);
++	if (ret) {
++		rcu_read_unlock();
++		return ret;
++	}
++	get_task_struct(tsk);
++	rcu_read_unlock();
++
++	need_tasklist = !same_thread_group(tsk, current);
++	if (need_tasklist) {
++		/*
++		 * Ensure we can't race with group exit or de_thread(),
++		 * so tsk->group_leader can't be freed or changed until
++		 * read_unlock(tasklist_lock) below.
++		 */
++		read_lock(&tasklist_lock);
++		if (!pid_alive(tsk))
++			ret = -ESRCH;
++	}
++
++	if (!ret) {
++		ret = do_prlimit(tsk, resource, new_rlim ? &new : NULL,
++				old_rlim ? &old : NULL);
++	}
++
++	if (need_tasklist)
++		read_unlock(&tasklist_lock);
++
++	if (!ret && old_rlim) {
++		rlim_to_rlim64(&old, &old64);
++		if (copy_to_user(old_rlim, &old64, sizeof(old64)))
++			ret = -EFAULT;
++	}
++
++	put_task_struct(tsk);
++	return ret;
++}
++
++SYSCALL_DEFINE2(setrlimit, unsigned int, resource, struct rlimit __user *, rlim)
++{
++	struct rlimit new_rlim;
++
++	if (copy_from_user(&new_rlim, rlim, sizeof(*rlim)))
++		return -EFAULT;
++	return do_prlimit(current, resource, &new_rlim, NULL);
++}
++
++/*
++ * It would make sense to put struct rusage in the task_struct,
++ * except that would make the task_struct be *really big*.  After
++ * task_struct gets moved into malloc'ed memory, it would
++ * make sense to do this.  It will make moving the rest of the information
++ * a lot simpler!  (Which we're not doing right now because we're not
++ * measuring them yet).
++ *
++ * When sampling multiple threads for RUSAGE_SELF, under SMP we might have
++ * races with threads incrementing their own counters.  But since word
++ * reads are atomic, we either get new values or old values and we don't
++ * care which for the sums.  We always take the siglock to protect reading
++ * the c* fields from p->signal from races with exit.c updating those
++ * fields when reaping, so a sample either gets all the additions of a
++ * given child after it's reaped, or none so this sample is before reaping.
++ *
++ * Locking:
++ * We need to take the siglock for CHILDEREN, SELF and BOTH
++ * for  the cases current multithreaded, non-current single threaded
++ * non-current multithreaded.  Thread traversal is now safe with
++ * the siglock held.
++ * Strictly speaking, we donot need to take the siglock if we are current and
++ * single threaded,  as no one else can take our signal_struct away, no one
++ * else can  reap the  children to update signal->c* counters, and no one else
++ * can race with the signal-> fields. If we do not take any lock, the
++ * signal-> fields could be read out of order while another thread was just
++ * exiting. So we should  place a read memory barrier when we avoid the lock.
++ * On the writer side,  write memory barrier is implied in  __exit_signal
++ * as __exit_signal releases  the siglock spinlock after updating the signal->
++ * fields. But we don't do this yet to keep things simple.
++ *
++ */
++
++static void accumulate_thread_rusage(struct task_struct *t, struct rusage *r)
++{
++	r->ru_nvcsw += t->nvcsw;
++	r->ru_nivcsw += t->nivcsw;
++	r->ru_minflt += t->min_flt;
++	r->ru_majflt += t->maj_flt;
++	r->ru_inblock += task_io_get_inblock(t);
++	r->ru_oublock += task_io_get_oublock(t);
++}
++
++void getrusage(struct task_struct *p, int who, struct rusage *r)
++{
++	struct task_struct *t;
++	unsigned long flags;
++	u64 tgutime, tgstime, utime, stime;
++	unsigned long maxrss;
++	struct mm_struct *mm;
++	struct signal_struct *sig = p->signal;
++	unsigned int seq = 0;
++
++retry:
++	memset(r, 0, sizeof(*r));
++	utime = stime = 0;
++	maxrss = 0;
++
++	if (who == RUSAGE_THREAD) {
++		task_cputime_adjusted(current, &utime, &stime);
++		accumulate_thread_rusage(p, r);
++		maxrss = sig->maxrss;
++		goto out_thread;
++	}
++
++	flags = read_seqbegin_or_lock_irqsave(&sig->stats_lock, &seq);
++
++	switch (who) {
++	case RUSAGE_BOTH:
++	case RUSAGE_CHILDREN:
++		utime = sig->cutime;
++		stime = sig->cstime;
++		r->ru_nvcsw = sig->cnvcsw;
++		r->ru_nivcsw = sig->cnivcsw;
++		r->ru_minflt = sig->cmin_flt;
++		r->ru_majflt = sig->cmaj_flt;
++		r->ru_inblock = sig->cinblock;
++		r->ru_oublock = sig->coublock;
++		maxrss = sig->cmaxrss;
++
++		if (who == RUSAGE_CHILDREN)
++			break;
++		fallthrough;
++
++	case RUSAGE_SELF:
++		r->ru_nvcsw += sig->nvcsw;
++		r->ru_nivcsw += sig->nivcsw;
++		r->ru_minflt += sig->min_flt;
++		r->ru_majflt += sig->maj_flt;
++		r->ru_inblock += sig->inblock;
++		r->ru_oublock += sig->oublock;
++		if (maxrss < sig->maxrss)
++			maxrss = sig->maxrss;
++
++		rcu_read_lock();
++		__for_each_thread(sig, t)
++			accumulate_thread_rusage(t, r);
++		rcu_read_unlock();
++
++		break;
++
++	default:
++		BUG();
++	}
++
++	if (need_seqretry(&sig->stats_lock, seq)) {
++		seq = 1;
++		goto retry;
++	}
++	done_seqretry_irqrestore(&sig->stats_lock, seq, flags);
++
++	if (who == RUSAGE_CHILDREN)
++		goto out_children;
++
++	thread_group_cputime_adjusted(p, &tgutime, &tgstime);
++	utime += tgutime;
++	stime += tgstime;
++
++out_thread:
++	mm = get_task_mm(p);
++	if (mm) {
++		setmax_mm_hiwater_rss(&maxrss, mm);
++		mmput(mm);
++	}
++
++out_children:
++	r->ru_maxrss = maxrss * (PAGE_SIZE / 1024); /* convert pages to KBs */
++	r->ru_utime = ns_to_kernel_old_timeval(utime);
++	r->ru_stime = ns_to_kernel_old_timeval(stime);
++}
++
++SYSCALL_DEFINE2(getrusage, int, who, struct rusage __user *, ru)
++{
++	struct rusage r;
++
++	if (who != RUSAGE_SELF && who != RUSAGE_CHILDREN &&
++	    who != RUSAGE_THREAD)
++		return -EINVAL;
++
++	getrusage(current, who, &r);
++	return copy_to_user(ru, &r, sizeof(r)) ? -EFAULT : 0;
++}
++
++#ifdef CONFIG_COMPAT
++COMPAT_SYSCALL_DEFINE2(getrusage, int, who, struct compat_rusage __user *, ru)
++{
++	struct rusage r;
++
++	if (who != RUSAGE_SELF && who != RUSAGE_CHILDREN &&
++	    who != RUSAGE_THREAD)
++		return -EINVAL;
++
++	getrusage(current, who, &r);
++	return put_compat_rusage(&r, ru);
++}
++#endif
++
++SYSCALL_DEFINE1(umask, int, mask)
++{
++	mask = xchg(&current->fs->umask, mask & S_IRWXUGO);
++	return mask;
++}
++
++static int prctl_set_mm_exe_file(struct mm_struct *mm, unsigned int fd)
++{
++	CLASS(fd, exe)(fd);
++	struct inode *inode;
++	int err;
++
++	if (fd_empty(exe))
++		return -EBADF;
++
++	inode = file_inode(fd_file(exe));
++
++	/*
++	 * Because the original mm->exe_file points to executable file, make
++	 * sure that this one is executable as well, to avoid breaking an
++	 * overall picture.
++	 */
++	if (!S_ISREG(inode->i_mode) || path_noexec(&fd_file(exe)->f_path))
++		return -EACCES;
++
++	err = file_permission(fd_file(exe), MAY_EXEC);
++	if (err)
++		return err;
++
++	return replace_mm_exe_file(mm, fd_file(exe));
++}
++
++/*
++ * Check arithmetic relations of passed addresses.
++ *
++ * WARNING: we don't require any capability here so be very careful
++ * in what is allowed for modification from userspace.
++ */
++static int validate_prctl_map_addr(struct prctl_mm_map *prctl_map)
++{
++	unsigned long mmap_max_addr = TASK_SIZE;
++	int error = -EINVAL, i;
++
++	static const unsigned char offsets[] = {
++		offsetof(struct prctl_mm_map, start_code),
++		offsetof(struct prctl_mm_map, end_code),
++		offsetof(struct prctl_mm_map, start_data),
++		offsetof(struct prctl_mm_map, end_data),
++		offsetof(struct prctl_mm_map, start_brk),
++		offsetof(struct prctl_mm_map, brk),
++		offsetof(struct prctl_mm_map, start_stack),
++		offsetof(struct prctl_mm_map, arg_start),
++		offsetof(struct prctl_mm_map, arg_end),
++		offsetof(struct prctl_mm_map, env_start),
++		offsetof(struct prctl_mm_map, env_end),
++	};
++
++	/*
++	 * Make sure the members are not somewhere outside
++	 * of allowed address space.
++	 */
++	for (i = 0; i < ARRAY_SIZE(offsets); i++) {
++		u64 val = *(u64 *)((char *)prctl_map + offsets[i]);
++
++		if ((unsigned long)val >= mmap_max_addr ||
++		    (unsigned long)val < mmap_min_addr)
++			goto out;
++	}
++
++	/*
++	 * Make sure the pairs are ordered.
++	 */
++#define __prctl_check_order(__m1, __op, __m2)				\
++	((unsigned long)prctl_map->__m1 __op				\
++	 (unsigned long)prctl_map->__m2) ? 0 : -EINVAL
++	error  = __prctl_check_order(start_code, <, end_code);
++	error |= __prctl_check_order(start_data,<=, end_data);
++	error |= __prctl_check_order(start_brk, <=, brk);
++	error |= __prctl_check_order(arg_start, <=, arg_end);
++	error |= __prctl_check_order(env_start, <=, env_end);
++	if (error)
++		goto out;
++#undef __prctl_check_order
++
++	error = -EINVAL;
++
++	/*
++	 * Neither we should allow to override limits if they set.
++	 */
++	if (check_data_rlimit(rlimit(RLIMIT_DATA), prctl_map->brk,
++			      prctl_map->start_brk, prctl_map->end_data,
++			      prctl_map->start_data))
++			goto out;
++
++	error = 0;
++out:
++	return error;
++}
++
++#ifdef CONFIG_CHECKPOINT_RESTORE
++static int prctl_set_mm_map(int opt, const void __user *addr, unsigned long data_size)
++{
++	struct prctl_mm_map prctl_map = { .exe_fd = (u32)-1, };
++	unsigned long user_auxv[AT_VECTOR_SIZE];
++	struct mm_struct *mm = current->mm;
++	int error;
++
++	BUILD_BUG_ON(sizeof(user_auxv) != sizeof(mm->saved_auxv));
++	BUILD_BUG_ON(sizeof(struct prctl_mm_map) > 256);
++
++	if (opt == PR_SET_MM_MAP_SIZE)
++		return put_user((unsigned int)sizeof(prctl_map),
++				(unsigned int __user *)addr);
++
++	if (data_size != sizeof(prctl_map))
++		return -EINVAL;
++
++	if (copy_from_user(&prctl_map, addr, sizeof(prctl_map)))
++		return -EFAULT;
++
++	error = validate_prctl_map_addr(&prctl_map);
++	if (error)
++		return error;
++
++	if (prctl_map.auxv_size) {
++		/*
++		 * Someone is trying to cheat the auxv vector.
++		 */
++		if (!prctl_map.auxv ||
++				prctl_map.auxv_size > sizeof(mm->saved_auxv))
++			return -EINVAL;
++
++		memset(user_auxv, 0, sizeof(user_auxv));
++		if (copy_from_user(user_auxv,
++				   (const void __user *)prctl_map.auxv,
++				   prctl_map.auxv_size))
++			return -EFAULT;
++
++		/* Last entry must be AT_NULL as specification requires */
++		user_auxv[AT_VECTOR_SIZE - 2] = AT_NULL;
++		user_auxv[AT_VECTOR_SIZE - 1] = AT_NULL;
++	}
++
++	if (prctl_map.exe_fd != (u32)-1) {
++		/*
++		 * Check if the current user is checkpoint/restore capable.
++		 * At the time of this writing, it checks for CAP_SYS_ADMIN
++		 * or CAP_CHECKPOINT_RESTORE.
++		 * Note that a user with access to ptrace can masquerade an
++		 * arbitrary program as any executable, even setuid ones.
++		 * This may have implications in the tomoyo subsystem.
++		 */
++		if (!checkpoint_restore_ns_capable(current_user_ns()))
++			return -EPERM;
++
++		error = prctl_set_mm_exe_file(mm, prctl_map.exe_fd);
++		if (error)
++			return error;
++	}
++
++	/*
++	 * arg_lock protects concurrent updates but we still need mmap_lock for
++	 * read to exclude races with sys_brk.
++	 */
++	mmap_read_lock(mm);
++
++	/*
++	 * We don't validate if these members are pointing to
++	 * real present VMAs because application may have correspond
++	 * VMAs already unmapped and kernel uses these members for statistics
++	 * output in procfs mostly, except
++	 *
++	 *  - @start_brk/@brk which are used in do_brk_flags but kernel lookups
++	 *    for VMAs when updating these members so anything wrong written
++	 *    here cause kernel to swear at userspace program but won't lead
++	 *    to any problem in kernel itself
++	 */
++
++	spin_lock(&mm->arg_lock);
++	mm->start_code	= prctl_map.start_code;
++	mm->end_code	= prctl_map.end_code;
++	mm->start_data	= prctl_map.start_data;
++	mm->end_data	= prctl_map.end_data;
++	mm->start_brk	= prctl_map.start_brk;
++	mm->brk		= prctl_map.brk;
++	mm->start_stack	= prctl_map.start_stack;
++	mm->arg_start	= prctl_map.arg_start;
++	mm->arg_end	= prctl_map.arg_end;
++	mm->env_start	= prctl_map.env_start;
++	mm->env_end	= prctl_map.env_end;
++	spin_unlock(&mm->arg_lock);
++
++	/*
++	 * Note this update of @saved_auxv is lockless thus
++	 * if someone reads this member in procfs while we're
++	 * updating -- it may get partly updated results. It's
++	 * known and acceptable trade off: we leave it as is to
++	 * not introduce additional locks here making the kernel
++	 * more complex.
++	 */
++	if (prctl_map.auxv_size)
++		memcpy(mm->saved_auxv, user_auxv, sizeof(user_auxv));
++
++	mmap_read_unlock(mm);
++	return 0;
++}
++#endif /* CONFIG_CHECKPOINT_RESTORE */
++
++static int prctl_set_auxv(struct mm_struct *mm, unsigned long addr,
++			  unsigned long len)
++{
++	/*
++	 * This doesn't move the auxiliary vector itself since it's pinned to
++	 * mm_struct, but it permits filling the vector with new values.  It's
++	 * up to the caller to provide sane values here, otherwise userspace
++	 * tools which use this vector might be unhappy.
++	 */
++	unsigned long user_auxv[AT_VECTOR_SIZE] = {};
++
++	if (len > sizeof(user_auxv))
++		return -EINVAL;
++
++	if (copy_from_user(user_auxv, (const void __user *)addr, len))
++		return -EFAULT;
++
++	/* Make sure the last entry is always AT_NULL */
++	user_auxv[AT_VECTOR_SIZE - 2] = 0;
++	user_auxv[AT_VECTOR_SIZE - 1] = 0;
++
++	BUILD_BUG_ON(sizeof(user_auxv) != sizeof(mm->saved_auxv));
++
++	task_lock(current);
++	memcpy(mm->saved_auxv, user_auxv, len);
++	task_unlock(current);
++
++	return 0;
++}
++
++static int prctl_set_mm(int opt, unsigned long addr,
++			unsigned long arg4, unsigned long arg5)
++{
++	struct mm_struct *mm = current->mm;
++	struct prctl_mm_map prctl_map = {
++		.auxv = NULL,
++		.auxv_size = 0,
++		.exe_fd = -1,
++	};
++	struct vm_area_struct *vma;
++	int error;
++
++	if (arg5 || (arg4 && (opt != PR_SET_MM_AUXV &&
++			      opt != PR_SET_MM_MAP &&
++			      opt != PR_SET_MM_MAP_SIZE)))
++		return -EINVAL;
++
++#ifdef CONFIG_CHECKPOINT_RESTORE
++	if (opt == PR_SET_MM_MAP || opt == PR_SET_MM_MAP_SIZE)
++		return prctl_set_mm_map(opt, (const void __user *)addr, arg4);
++#endif
++
++	if (!capable(CAP_SYS_RESOURCE))
++		return -EPERM;
++
++	if (opt == PR_SET_MM_EXE_FILE)
++		return prctl_set_mm_exe_file(mm, (unsigned int)addr);
++
++	if (opt == PR_SET_MM_AUXV)
++		return prctl_set_auxv(mm, addr, arg4);
++
++	if (addr >= TASK_SIZE || addr < mmap_min_addr)
++		return -EINVAL;
++
++	error = -EINVAL;
++
++	/*
++	 * arg_lock protects concurrent updates of arg boundaries, we need
++	 * mmap_lock for a) concurrent sys_brk, b) finding VMA for addr
++	 * validation.
++	 */
++	mmap_read_lock(mm);
++	vma = find_vma(mm, addr);
++
++	spin_lock(&mm->arg_lock);
++	prctl_map.start_code	= mm->start_code;
++	prctl_map.end_code	= mm->end_code;
++	prctl_map.start_data	= mm->start_data;
++	prctl_map.end_data	= mm->end_data;
++	prctl_map.start_brk	= mm->start_brk;
++	prctl_map.brk		= mm->brk;
++	prctl_map.start_stack	= mm->start_stack;
++	prctl_map.arg_start	= mm->arg_start;
++	prctl_map.arg_end	= mm->arg_end;
++	prctl_map.env_start	= mm->env_start;
++	prctl_map.env_end	= mm->env_end;
++
++	switch (opt) {
++	case PR_SET_MM_START_CODE:
++		prctl_map.start_code = addr;
++		break;
++	case PR_SET_MM_END_CODE:
++		prctl_map.end_code = addr;
++		break;
++	case PR_SET_MM_START_DATA:
++		prctl_map.start_data = addr;
++		break;
++	case PR_SET_MM_END_DATA:
++		prctl_map.end_data = addr;
++		break;
++	case PR_SET_MM_START_STACK:
++		prctl_map.start_stack = addr;
++		break;
++	case PR_SET_MM_START_BRK:
++		prctl_map.start_brk = addr;
++		break;
++	case PR_SET_MM_BRK:
++		prctl_map.brk = addr;
++		break;
++	case PR_SET_MM_ARG_START:
++		prctl_map.arg_start = addr;
++		break;
++	case PR_SET_MM_ARG_END:
++		prctl_map.arg_end = addr;
++		break;
++	case PR_SET_MM_ENV_START:
++		prctl_map.env_start = addr;
++		break;
++	case PR_SET_MM_ENV_END:
++		prctl_map.env_end = addr;
++		break;
++	default:
++		goto out;
++	}
++
++	error = validate_prctl_map_addr(&prctl_map);
++	if (error)
++		goto out;
++
++	switch (opt) {
++	/*
++	 * If command line arguments and environment
++	 * are placed somewhere else on stack, we can
++	 * set them up here, ARG_START/END to setup
++	 * command line arguments and ENV_START/END
++	 * for environment.
++	 */
++	case PR_SET_MM_START_STACK:
++	case PR_SET_MM_ARG_START:
++	case PR_SET_MM_ARG_END:
++	case PR_SET_MM_ENV_START:
++	case PR_SET_MM_ENV_END:
++		if (!vma) {
++			error = -EFAULT;
++			goto out;
++		}
++	}
++
++	mm->start_code	= prctl_map.start_code;
++	mm->end_code	= prctl_map.end_code;
++	mm->start_data	= prctl_map.start_data;
++	mm->end_data	= prctl_map.end_data;
++	mm->start_brk	= prctl_map.start_brk;
++	mm->brk		= prctl_map.brk;
++	mm->start_stack	= prctl_map.start_stack;
++	mm->arg_start	= prctl_map.arg_start;
++	mm->arg_end	= prctl_map.arg_end;
++	mm->env_start	= prctl_map.env_start;
++	mm->env_end	= prctl_map.env_end;
++
++	error = 0;
++out:
++	spin_unlock(&mm->arg_lock);
++	mmap_read_unlock(mm);
++	return error;
++}
++
++#ifdef CONFIG_CHECKPOINT_RESTORE
++static int prctl_get_tid_address(struct task_struct *me, int __user * __user *tid_addr)
++{
++	return put_user(me->clear_child_tid, tid_addr);
++}
++#else
++static int prctl_get_tid_address(struct task_struct *me, int __user * __user *tid_addr)
++{
++	return -EINVAL;
++}
++#endif
++
++static int propagate_has_child_subreaper(struct task_struct *p, void *data)
++{
++	/*
++	 * If task has has_child_subreaper - all its descendants
++	 * already have these flag too and new descendants will
++	 * inherit it on fork, skip them.
++	 *
++	 * If we've found child_reaper - skip descendants in
++	 * it's subtree as they will never get out pidns.
++	 */
++	if (p->signal->has_child_subreaper ||
++	    is_child_reaper(task_pid(p)))
++		return 0;
++
++	p->signal->has_child_subreaper = 1;
++	return 1;
++}
++
++int __weak arch_prctl_spec_ctrl_get(struct task_struct *t, unsigned long which)
++{
++	return -EINVAL;
++}
++
++int __weak arch_prctl_spec_ctrl_set(struct task_struct *t, unsigned long which,
++				    unsigned long ctrl)
++{
++	return -EINVAL;
++}
++
++int __weak arch_get_shadow_stack_status(struct task_struct *t, unsigned long __user *status)
++{
++	return -EINVAL;
++}
++
++int __weak arch_set_shadow_stack_status(struct task_struct *t, unsigned long status)
++{
++	return -EINVAL;
++}
++
++int __weak arch_lock_shadow_stack_status(struct task_struct *t, unsigned long status)
++{
++	return -EINVAL;
++}
++
++int __weak arch_prctl_get_branch_landing_pad_state(struct task_struct *t,
++						   unsigned long __user *state)
++{
++	return -EINVAL;
++}
++
++int __weak arch_prctl_set_branch_landing_pad_state(struct task_struct *t, unsigned long state)
++{
++	return -EINVAL;
++}
++
++int __weak arch_prctl_lock_branch_landing_pad_state(struct task_struct *t)
++{
++	return -EINVAL;
++}
++
++#define PR_IO_FLUSHER (PF_MEMALLOC_NOIO | PF_LOCAL_THROTTLE)
++
++static int prctl_set_vma(unsigned long opt, unsigned long addr,
++			 unsigned long size, unsigned long arg)
++{
++	int error;
++
++	switch (opt) {
++	case PR_SET_VMA_ANON_NAME:
++		error = set_anon_vma_name(addr, size, (const char __user *)arg);
++		break;
++	default:
++		error = -EINVAL;
++	}
++
++	return error;
++}
++
++static inline unsigned long get_current_mdwe(void)
++{
++	unsigned long ret = 0;
++
++	if (mm_flags_test(MMF_HAS_MDWE, current->mm))
++		ret |= PR_MDWE_REFUSE_EXEC_GAIN;
++	if (mm_flags_test(MMF_HAS_MDWE_NO_INHERIT, current->mm))
++		ret |= PR_MDWE_NO_INHERIT;
++
++	return ret;
++}
++
++static inline int prctl_set_mdwe(unsigned long bits, unsigned long arg3,
++				 unsigned long arg4, unsigned long arg5)
++{
++	unsigned long current_bits;
++
++	if (arg3 || arg4 || arg5)
++		return -EINVAL;
++
++	if (bits & ~(PR_MDWE_REFUSE_EXEC_GAIN | PR_MDWE_NO_INHERIT))
++		return -EINVAL;
++
++	/* NO_INHERIT only makes sense with REFUSE_EXEC_GAIN */
++	if (bits & PR_MDWE_NO_INHERIT && !(bits & PR_MDWE_REFUSE_EXEC_GAIN))
++		return -EINVAL;
++
++	/*
++	 * EOPNOTSUPP might be more appropriate here in principle, but
++	 * existing userspace depends on EINVAL specifically.
++	 */
++	if (!arch_memory_deny_write_exec_supported())
++		return -EINVAL;
++
++	current_bits = get_current_mdwe();
++	if (current_bits && current_bits != bits)
++		return -EPERM; /* Cannot unset the flags */
++
++	if (bits & PR_MDWE_NO_INHERIT)
++		mm_flags_set(MMF_HAS_MDWE_NO_INHERIT, current->mm);
++	if (bits & PR_MDWE_REFUSE_EXEC_GAIN)
++		mm_flags_set(MMF_HAS_MDWE, current->mm);
++
++	return 0;
++}
++
++static inline int prctl_get_mdwe(unsigned long arg2, unsigned long arg3,
++				 unsigned long arg4, unsigned long arg5)
++{
++	if (arg2 || arg3 || arg4 || arg5)
++		return -EINVAL;
++	return get_current_mdwe();
++}
++
++static int prctl_get_auxv(void __user *addr, unsigned long len)
++{
++	struct mm_struct *mm = current->mm;
++	unsigned long size = min_t(unsigned long, sizeof(mm->saved_auxv), len);
++
++	if (size && copy_to_user(addr, mm->saved_auxv, size))
++		return -EFAULT;
++	return sizeof(mm->saved_auxv);
++}
++
++static int prctl_get_thp_disable(unsigned long arg2, unsigned long arg3,
++				 unsigned long arg4, unsigned long arg5)
++{
++	struct mm_struct *mm = current->mm;
++
++	if (arg2 || arg3 || arg4 || arg5)
++		return -EINVAL;
++
++	/* If disabled, we return "1 | flags", otherwise 0. */
++	if (mm_flags_test(MMF_DISABLE_THP_COMPLETELY, mm))
++		return 1;
++	else if (mm_flags_test(MMF_DISABLE_THP_EXCEPT_ADVISED, mm))
++		return 1 | PR_THP_DISABLE_EXCEPT_ADVISED;
++	return 0;
++}
++
++static int prctl_set_thp_disable(bool thp_disable, unsigned long flags,
++				 unsigned long arg4, unsigned long arg5)
++{
++	struct mm_struct *mm = current->mm;
++
++	if (arg4 || arg5)
++		return -EINVAL;
++
++	/* Flags are only allowed when disabling. */
++	if ((!thp_disable && flags) || (flags & ~PR_THP_DISABLE_EXCEPT_ADVISED))
++		return -EINVAL;
++	if (mmap_write_lock_killable(current->mm))
++		return -EINTR;
++	if (thp_disable) {
++		if (flags & PR_THP_DISABLE_EXCEPT_ADVISED) {
++			mm_flags_clear(MMF_DISABLE_THP_COMPLETELY, mm);
++			mm_flags_set(MMF_DISABLE_THP_EXCEPT_ADVISED, mm);
++		} else {
++			mm_flags_set(MMF_DISABLE_THP_COMPLETELY, mm);
++			mm_flags_clear(MMF_DISABLE_THP_EXCEPT_ADVISED, mm);
++		}
++	} else {
++		mm_flags_clear(MMF_DISABLE_THP_COMPLETELY, mm);
++		mm_flags_clear(MMF_DISABLE_THP_EXCEPT_ADVISED, mm);
++	}
++	mmap_write_unlock(current->mm);
++	return 0;
++}
++
++SYSCALL_DEFINE5(prctl, int, option, unsigned long, arg2, unsigned long, arg3,
++		unsigned long, arg4, unsigned long, arg5)
++{
++	struct task_struct *me = current;
++	unsigned char comm[sizeof(me->comm)];
++	long error;
++
++	error = security_task_prctl(option, arg2, arg3, arg4, arg5);
++	if (error != -ENOSYS)
++		return error;
++
++	error = 0;
++	switch (option) {
++	case PR_SET_PDEATHSIG:
++		if (!valid_signal(arg2)) {
++			error = -EINVAL;
++			break;
++		}
++		/*
++		 * Ensure that either:
++		 *
++		 * 1. Subsequent getppid() calls reflect the parent process having died.
++		 * 2. forget_original_parent() will send the new me->pdeath_signal.
++		 *
++		 * Also prevent the read of me->pdeath_signal from being a data race.
++		 */
++		read_lock(&tasklist_lock);
++		me->pdeath_signal = arg2;
++		read_unlock(&tasklist_lock);
++		break;
++	case PR_GET_PDEATHSIG:
++		error = put_user(me->pdeath_signal, (int __user *)arg2);
++		break;
++	case PR_GET_DUMPABLE:
++		error = get_dumpable(me->mm);
++		break;
++	case PR_SET_DUMPABLE:
++		if (arg2 != SUID_DUMP_DISABLE && arg2 != SUID_DUMP_USER) {
++			error = -EINVAL;
++			break;
++		}
++		set_dumpable(me->mm, arg2);
++		break;
++
++	case PR_SET_UNALIGN:
++		error = SET_UNALIGN_CTL(me, arg2);
++		break;
++	case PR_GET_UNALIGN:
++		error = GET_UNALIGN_CTL(me, arg2);
++		break;
++	case PR_SET_FPEMU:
++		error = SET_FPEMU_CTL(me, arg2);
++		break;
++	case PR_GET_FPEMU:
++		error = GET_FPEMU_CTL(me, arg2);
++		break;
++	case PR_SET_FPEXC:
++		error = SET_FPEXC_CTL(me, arg2);
++		break;
++	case PR_GET_FPEXC:
++		error = GET_FPEXC_CTL(me, arg2);
++		break;
++	case PR_GET_TIMING:
++		error = PR_TIMING_STATISTICAL;
++		break;
++	case PR_SET_TIMING:
++		if (arg2 != PR_TIMING_STATISTICAL)
++			error = -EINVAL;
++		break;
++	case PR_SET_NAME:
++		comm[sizeof(me->comm) - 1] = 0;
++		if (strncpy_from_user(comm, (char __user *)arg2,
++				      sizeof(me->comm) - 1) < 0)
++			return -EFAULT;
++		set_task_comm(me, comm);
++		proc_comm_connector(me);
++		break;
++	case PR_GET_NAME:
++		get_task_comm(comm, me);
++		if (copy_to_user((char __user *)arg2, comm, sizeof(comm)))
++			return -EFAULT;
++		break;
++	case PR_GET_ENDIAN:
++		error = GET_ENDIAN(me, arg2);
++		break;
++	case PR_SET_ENDIAN:
++		error = SET_ENDIAN(me, arg2);
++		break;
++	case PR_GET_SECCOMP:
++		error = prctl_get_seccomp();
++		break;
++	case PR_SET_SECCOMP:
++		error = prctl_set_seccomp(arg2, (char __user *)arg3);
++		break;
++	case PR_GET_TSC:
++		error = GET_TSC_CTL(arg2);
++		break;
++	case PR_SET_TSC:
++		error = SET_TSC_CTL(arg2);
++		break;
++	case PR_TASK_PERF_EVENTS_DISABLE:
++		error = perf_event_task_disable();
++		break;
++	case PR_TASK_PERF_EVENTS_ENABLE:
++		error = perf_event_task_enable();
++		break;
++	case PR_GET_TIMERSLACK:
++		if (current->timer_slack_ns > ULONG_MAX)
++			error = ULONG_MAX;
++		else
++			error = current->timer_slack_ns;
++		break;
++	case PR_SET_TIMERSLACK:
++		if (rt_or_dl_task_policy(current))
++			break;
++		if (arg2 <= 0)
++			current->timer_slack_ns =
++					current->default_timer_slack_ns;
++		else
++			current->timer_slack_ns = arg2;
++		break;
++	case PR_MCE_KILL:
++		if (arg4 | arg5)
++			return -EINVAL;
++		switch (arg2) {
++		case PR_MCE_KILL_CLEAR:
++			if (arg3 != 0)
++				return -EINVAL;
++			current->flags &= ~PF_MCE_PROCESS;
++			break;
++		case PR_MCE_KILL_SET:
++			current->flags |= PF_MCE_PROCESS;
++			if (arg3 == PR_MCE_KILL_EARLY)
++				current->flags |= PF_MCE_EARLY;
++			else if (arg3 == PR_MCE_KILL_LATE)
++				current->flags &= ~PF_MCE_EARLY;
++			else if (arg3 == PR_MCE_KILL_DEFAULT)
++				current->flags &=
++						~(PF_MCE_EARLY|PF_MCE_PROCESS);
++			else
++				return -EINVAL;
++			break;
++		default:
++			return -EINVAL;
++		}
++		break;
++	case PR_MCE_KILL_GET:
++		if (arg2 | arg3 | arg4 | arg5)
++			return -EINVAL;
++		if (current->flags & PF_MCE_PROCESS)
++			error = (current->flags & PF_MCE_EARLY) ?
++				PR_MCE_KILL_EARLY : PR_MCE_KILL_LATE;
++		else
++			error = PR_MCE_KILL_DEFAULT;
++		break;
++	case PR_SET_MM:
++		error = prctl_set_mm(arg2, arg3, arg4, arg5);
++		break;
++	case PR_GET_TID_ADDRESS:
++		error = prctl_get_tid_address(me, (int __user * __user *)arg2);
++		break;
++	case PR_SET_CHILD_SUBREAPER:
++		me->signal->is_child_subreaper = !!arg2;
++		if (!arg2)
++			break;
++
++		walk_process_tree(me, propagate_has_child_subreaper, NULL);
++		break;
++	case PR_GET_CHILD_SUBREAPER:
++		error = put_user(me->signal->is_child_subreaper,
++				 (int __user *)arg2);
++		break;
++	case PR_SET_NO_NEW_PRIVS:
++		if (arg2 != 1 || arg3 || arg4 || arg5)
++			return -EINVAL;
++
++		task_set_no_new_privs(current);
++		break;
++	case PR_GET_NO_NEW_PRIVS:
++		if (arg2 || arg3 || arg4 || arg5)
++			return -EINVAL;
++		return task_no_new_privs(current) ? 1 : 0;
++	case PR_GET_THP_DISABLE:
++		error = prctl_get_thp_disable(arg2, arg3, arg4, arg5);
++		break;
++	case PR_SET_THP_DISABLE:
++		error = prctl_set_thp_disable(arg2, arg3, arg4, arg5);
++		break;
++	case PR_MPX_ENABLE_MANAGEMENT:
++	case PR_MPX_DISABLE_MANAGEMENT:
++		/* No longer implemented: */
++		return -EINVAL;
++	case PR_SET_FP_MODE:
++		error = SET_FP_MODE(me, arg2);
++		break;
++	case PR_GET_FP_MODE:
++		error = GET_FP_MODE(me);
++		break;
++	case PR_SVE_SET_VL:
++		error = SVE_SET_VL(arg2);
++		break;
++	case PR_SVE_GET_VL:
++		error = SVE_GET_VL();
++		break;
++	case PR_SME_SET_VL:
++		error = SME_SET_VL(arg2);
++		break;
++	case PR_SME_GET_VL:
++		error = SME_GET_VL();
++		break;
++	case PR_GET_SPECULATION_CTRL:
++		if (arg3 || arg4 || arg5)
++			return -EINVAL;
++		error = arch_prctl_spec_ctrl_get(me, arg2);
++		break;
++	case PR_SET_SPECULATION_CTRL:
++		if (arg4 || arg5)
++			return -EINVAL;
++		error = arch_prctl_spec_ctrl_set(me, arg2, arg3);
++		break;
++	case PR_PAC_RESET_KEYS:
++		if (arg3 || arg4 || arg5)
++			return -EINVAL;
++		error = PAC_RESET_KEYS(me, arg2);
++		break;
++	case PR_PAC_SET_ENABLED_KEYS:
++		if (arg4 || arg5)
++			return -EINVAL;
++		error = PAC_SET_ENABLED_KEYS(me, arg2, arg3);
++		break;
++	case PR_PAC_GET_ENABLED_KEYS:
++		if (arg2 || arg3 || arg4 || arg5)
++			return -EINVAL;
++		error = PAC_GET_ENABLED_KEYS(me);
++		break;
++	case PR_SET_TAGGED_ADDR_CTRL:
++		if (arg3 || arg4 || arg5)
++			return -EINVAL;
++		error = SET_TAGGED_ADDR_CTRL(arg2);
++		break;
++	case PR_GET_TAGGED_ADDR_CTRL:
++		if (arg2 || arg3 || arg4 || arg5)
++			return -EINVAL;
++		error = GET_TAGGED_ADDR_CTRL();
++		break;
++	case PR_SET_IO_FLUSHER:
++		if (!capable(CAP_SYS_RESOURCE))
++			return -EPERM;
++
++		if (arg3 || arg4 || arg5)
++			return -EINVAL;
++
++		if (arg2 == 1)
++			current->flags |= PR_IO_FLUSHER;
++		else if (!arg2)
++			current->flags &= ~PR_IO_FLUSHER;
++		else
++			return -EINVAL;
++		break;
++	case PR_GET_IO_FLUSHER:
++		if (!capable(CAP_SYS_RESOURCE))
++			return -EPERM;
++
++		if (arg2 || arg3 || arg4 || arg5)
++			return -EINVAL;
++
++		error = (current->flags & PR_IO_FLUSHER) == PR_IO_FLUSHER;
++		break;
++	case PR_SET_SYSCALL_USER_DISPATCH:
++		error = set_syscall_user_dispatch(arg2, arg3, arg4,
++						  (char __user *) arg5);
++		break;
++#ifdef CONFIG_SCHED_CORE
++	case PR_SCHED_CORE:
++		error = sched_core_share_pid(arg2, arg3, arg4, arg5);
++		break;
++#endif
++	case PR_SET_MDWE:
++		error = prctl_set_mdwe(arg2, arg3, arg4, arg5);
++		break;
++	case PR_GET_MDWE:
++		error = prctl_get_mdwe(arg2, arg3, arg4, arg5);
++		break;
++	case PR_PPC_GET_DEXCR:
++		if (arg3 || arg4 || arg5)
++			return -EINVAL;
++		error = PPC_GET_DEXCR_ASPECT(me, arg2);
++		break;
++	case PR_PPC_SET_DEXCR:
++		if (arg4 || arg5)
++			return -EINVAL;
++		error = PPC_SET_DEXCR_ASPECT(me, arg2, arg3);
++		break;
++	case PR_SET_VMA:
++		error = prctl_set_vma(arg2, arg3, arg4, arg5);
++		break;
++	case PR_GET_AUXV:
++		if (arg4 || arg5)
++			return -EINVAL;
++		error = prctl_get_auxv((void __user *)arg2, arg3);
++		break;
++#ifdef CONFIG_KSM
++	case PR_SET_MEMORY_MERGE:
++		if (arg3 || arg4 || arg5)
++			return -EINVAL;
++		if (mmap_write_lock_killable(me->mm))
++			return -EINTR;
++
++		if (arg2)
++			error = ksm_enable_merge_any(me->mm);
++		else
++			error = ksm_disable_merge_any(me->mm);
++		mmap_write_unlock(me->mm);
++		break;
++	case PR_GET_MEMORY_MERGE:
++		if (arg2 || arg3 || arg4 || arg5)
++			return -EINVAL;
++
++		error = !!mm_flags_test(MMF_VM_MERGE_ANY, me->mm);
++		break;
++#endif
++	case PR_RISCV_V_SET_CONTROL:
++		error = RISCV_V_SET_CONTROL(arg2);
++		break;
++	case PR_RISCV_V_GET_CONTROL:
++		error = RISCV_V_GET_CONTROL();
++		break;
++	case PR_RISCV_SET_ICACHE_FLUSH_CTX:
++		error = RISCV_SET_ICACHE_FLUSH_CTX(arg2, arg3);
++		break;
++	case PR_GET_SHADOW_STACK_STATUS:
++		if (arg3 || arg4 || arg5)
++			return -EINVAL;
++		error = arch_get_shadow_stack_status(me, (unsigned long __user *) arg2);
++		break;
++	case PR_SET_SHADOW_STACK_STATUS:
++		if (arg3 || arg4 || arg5)
++			return -EINVAL;
++		error = arch_set_shadow_stack_status(me, arg2);
++		break;
++	case PR_LOCK_SHADOW_STACK_STATUS:
++		if (arg3 || arg4 || arg5)
++			return -EINVAL;
++		error = arch_lock_shadow_stack_status(me, arg2);
++		break;
++	case PR_TIMER_CREATE_RESTORE_IDS:
++		if (arg3 || arg4 || arg5)
++			return -EINVAL;
++		error = posixtimer_create_prctl(arg2);
++		break;
++	case PR_FUTEX_HASH:
++		error = futex_hash_prctl(arg2, arg3, arg4);
++		break;
++	case PR_RSEQ_SLICE_EXTENSION:
++		if (arg4 || arg5)
++			return -EINVAL;
++		error = rseq_slice_extension_prctl(arg2, arg3);
++		break;
++	case PR_GET_CFI:
++		if (arg2 != PR_CFI_BRANCH_LANDING_PADS)
++			return -EINVAL;
++		if (arg4 || arg5)
++			return -EINVAL;
++		error = arch_prctl_get_branch_landing_pad_state(me, (unsigned long __user *)arg3);
++		break;
++	case PR_SET_CFI:
++		if (arg2 != PR_CFI_BRANCH_LANDING_PADS)
++			return -EINVAL;
++		if (arg4 || arg5)
++			return -EINVAL;
++		error = arch_prctl_set_branch_landing_pad_state(me, arg3);
++		if (error)
++			break;
++		if (arg3 & PR_CFI_LOCK && !(arg3 & PR_CFI_DISABLE))
++			error = arch_prctl_lock_branch_landing_pad_state(me);
++		break;
++	default:
++		trace_task_prctl_unknown(option, arg2, arg3, arg4, arg5);
++		error = -EINVAL;
++		break;
++	}
++	return error;
++}
++
++SYSCALL_DEFINE3(getcpu, unsigned __user *, cpup, unsigned __user *, nodep, void __user *, unused)
++{
++	int err = 0;
++	int cpu = raw_smp_processor_id();
++
++	if (cpup)
++		err |= put_user(cpu, cpup);
++	if (nodep)
++		err |= put_user(cpu_to_node(cpu), nodep);
++	return err ? -EFAULT : 0;
++}
++
++/**
++ * do_sysinfo - fill in sysinfo struct
++ * @info: pointer to buffer to fill
++ */
++static int do_sysinfo(struct sysinfo *info)
++{
++	unsigned long mem_total, sav_total;
++	unsigned int mem_unit, bitcount;
++	struct timespec64 tp;
++
++	memset(info, 0, sizeof(struct sysinfo));
++
++	ktime_get_boottime_ts64(&tp);
++	timens_add_boottime(&tp);
++	info->uptime = tp.tv_sec + (tp.tv_nsec ? 1 : 0);
++
++	get_avenrun(info->loads, 0, SI_LOAD_SHIFT - FSHIFT);
++
++	info->procs = nr_threads;
++
++	si_meminfo(info);
++	si_swapinfo(info);
++
++	/*
++	 * If the sum of all the available memory (i.e. ram + swap)
++	 * is less than can be stored in a 32 bit unsigned long then
++	 * we can be binary compatible with 2.2.x kernels.  If not,
++	 * well, in that case 2.2.x was broken anyways...
++	 *
++	 *  -Erik Andersen <andersee@debian.org>
++	 */
++
++	mem_total = info->totalram + info->totalswap;
++	if (mem_total < info->totalram || mem_total < info->totalswap)
++		goto out;
++	bitcount = 0;
++	mem_unit = info->mem_unit;
++	while (mem_unit > 1) {
++		bitcount++;
++		mem_unit >>= 1;
++		sav_total = mem_total;
++		mem_total <<= 1;
++		if (mem_total < sav_total)
++			goto out;
++	}
++
++	/*
++	 * If mem_total did not overflow, multiply all memory values by
++	 * info->mem_unit and set it to 1.  This leaves things compatible
++	 * with 2.2.x, and also retains compatibility with earlier 2.4.x
++	 * kernels...
++	 */
++
++	info->mem_unit = 1;
++	info->totalram <<= bitcount;
++	info->freeram <<= bitcount;
++	info->sharedram <<= bitcount;
++	info->bufferram <<= bitcount;
++	info->totalswap <<= bitcount;
++	info->freeswap <<= bitcount;
++	info->totalhigh <<= bitcount;
++	info->freehigh <<= bitcount;
++
++out:
++	return 0;
++}
++
++SYSCALL_DEFINE1(sysinfo, struct sysinfo __user *, info)
++{
++	struct sysinfo val;
++
++	do_sysinfo(&val);
++
++	if (copy_to_user(info, &val, sizeof(struct sysinfo)))
++		return -EFAULT;
++
++	return 0;
++}
++
++#ifdef CONFIG_COMPAT
++struct compat_sysinfo {
++	s32 uptime;
++	u32 loads[3];
++	u32 totalram;
++	u32 freeram;
++	u32 sharedram;
++	u32 bufferram;
++	u32 totalswap;
++	u32 freeswap;
++	u16 procs;
++	u16 pad;
++	u32 totalhigh;
++	u32 freehigh;
++	u32 mem_unit;
++	char _f[20-2*sizeof(u32)-sizeof(int)];
++};
++
++COMPAT_SYSCALL_DEFINE1(sysinfo, struct compat_sysinfo __user *, info)
++{
++	struct sysinfo s;
++	struct compat_sysinfo s_32;
++
++	do_sysinfo(&s);
++
++	/* Check to see if any memory value is too large for 32-bit and scale
++	 *  down if needed
++	 */
++	if (upper_32_bits(s.totalram) || upper_32_bits(s.totalswap)) {
++		int bitcount = 0;
++
++		while (s.mem_unit < PAGE_SIZE) {
++			s.mem_unit <<= 1;
++			bitcount++;
++		}
++
++		s.totalram >>= bitcount;
++		s.freeram >>= bitcount;
++		s.sharedram >>= bitcount;
++		s.bufferram >>= bitcount;
++		s.totalswap >>= bitcount;
++		s.freeswap >>= bitcount;
++		s.totalhigh >>= bitcount;
++		s.freehigh >>= bitcount;
++	}
++
++	memset(&s_32, 0, sizeof(s_32));
++	s_32.uptime = s.uptime;
++	s_32.loads[0] = s.loads[0];
++	s_32.loads[1] = s.loads[1];
++	s_32.loads[2] = s.loads[2];
++	s_32.totalram = s.totalram;
++	s_32.freeram = s.freeram;
++	s_32.sharedram = s.sharedram;
++	s_32.bufferram = s.bufferram;
++	s_32.totalswap = s.totalswap;
++	s_32.freeswap = s.freeswap;
++	s_32.procs = s.procs;
++	s_32.totalhigh = s.totalhigh;
++	s_32.freehigh = s.freehigh;
++	s_32.mem_unit = s.mem_unit;
++	if (copy_to_user(info, &s_32, sizeof(s_32)))
++		return -EFAULT;
++	return 0;
++}
++#endif /* CONFIG_COMPAT */
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0602-ROCKNIX-odin3-rtc-persist-offset-sdam.patch
+++ b/patch/kernel/archive/sm8750-7.1/0602-ROCKNIX-odin3-rtc-persist-offset-sdam.patch
@@ -1,0 +1,33 @@
+Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn-common: SDAM RTC offset
+
+RTC regs are TZ-locked; rtc-pm8xxx stores wall-clock as an offset.
+Android maintains that offset in userspace (time_daemon, persisted
+to /persist), which ROCKNIX does not inherit, so the clock resets
+to epoch every boot.
+
+Back it with an nvmem cell in the always-on PMK8550 SDAM at 0x72,
+a free 4-byte slot below the ADSP-owned alarm-log at 0x76-0x7b,
+verified on Odin 3 to survive cold power-off.
+---
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+--- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+@@ -1268,3 +1268,18 @@
+ 
+ 	status = "okay";
+ };
++
++/* RTC regs are TZ-locked; persist the wall-clock offset in an SDAM
++ * nvmem cell (Android keeps it in userspace, not shared with us).
++ * 0x72 sits just below the ADSP-owned alarm-log at 0x76-0x7b.
++ */
++&pmk8550_rtc {
++	nvmem-cells = <&rtc_offset>;
++	nvmem-cell-names = "offset";
++};
++
++&pmk8550_sdam_2 {
++	rtc_offset: rtc-offset@72 {
++		reg = <0x72 0x4>;
++	};
++};

--- a/patch/kernel/archive/sm8750-7.1/0602-ROCKNIX-odin3-rtc-persist-offset-sdam.patch
+++ b/patch/kernel/archive/sm8750-7.1/0602-ROCKNIX-odin3-rtc-persist-offset-sdam.patch
@@ -1,18 +1,30 @@
-Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn-common: SDAM RTC offset
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: ROCKNIX odin3 rtc persist offset sdam
 
-RTC regs are TZ-locked; rtc-pm8xxx stores wall-clock as an offset.
-Android maintains that offset in userspace (time_daemon, persisted
-to /persist), which ROCKNIX does not inherit, so the clock resets
-to epoch every boot.
-
-Back it with an nvmem cell in the always-on PMK8550 SDAM at 0x72,
-a free 4-byte slot below the ADSP-owned alarm-log at 0x76-0x7b,
-verified on Odin 3 to survive cold power-off.
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi | 15 ++++++++++
+ 1 file changed, 15 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
-@@ -1268,3 +1268,18 @@
+@@ -1269,3 +1269,18 @@ &usb_hsphy {
  
  	status = "okay";
  };
@@ -31,3 +43,6 @@ diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/
 +		reg = <0x72 0x4>;
 +	};
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0603-ASoC-codecs-wcd939x-keep-the-codec-resumed-while-a-ja.patch
+++ b/patch/kernel/archive/sm8750-7.1/0603-ASoC-codecs-wcd939x-keep-the-codec-resumed-while-a-ja.patch
@@ -1,41 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anze <aanzdev@gmail.com>
-Subject: [PATCH] ASoC: codecs: wcd939x: keep the codec resumed while a jack is set
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: ASoC: codecs: wcd939x: keep the codec resumed while a jack is set
 
-Headset detection reports nothing at all on an AYN Odin 3. MBHC is armed
-correctly - ANA_MBHC_MECH reads 0xbd with L_DET_EN set and the plug-type
-polarity matching the vendor DT - the interrupts are mapped, and yet
-plugging headphones produces no interrupt whatsoever and "Headphone
-Jack" stays off.
-
-The codec is runtime suspended essentially all the time: nothing
-streams, so it autosuspends a second after probe and stays there.
-Suspending puts its regmap in cache-only mode and lets the SoundWire
-link stop its clock, and the codec then has no way to signal anything.
-MBHC is powered and watching; its interrupt has nowhere to go.
-
-Resuming both SoundWire devices makes detection work immediately and
-completely:
-
-  wcd939x_wcd_mbhc_calc_impedance: impedance on HPH_L = 41(ohms)
-  wcd939x_wcd_mbhc_calc_impedance: impedance on HPH_R = 43(ohms)
-  wcd939x_wcd_mbhc_calc_impedance: stereo plug type detected
-
-with SW_HEADPHONE_INSERT set on the jack input device and the mechanical
-interrupt firing on every plug and unplug.
-
-Keep them resumed for as long as a jack is registered. pm_runtime_forbid()
-rather than a get/put pair: a plain reference is not enough here, the
-bus suspends the devices again anyway, and forbid is exactly what
-writing "on" to power/control does - which is what was verified on the
-device.
-
-Signed-off-by: Anze <aanzdev@gmail.com>
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ sound/soc/codecs/wcd939x.c | 16 +++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
 diff --git a/sound/soc/codecs/wcd939x.c b/sound/soc/codecs/wcd939x.c
-index 2d0c3ec77..cb119f85c 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/wcd939x.c
 +++ b/sound/soc/codecs/wcd939x.c
-@@ -3391,11 +3391,25 @@ static int wcd939x_codec_set_jack(struct snd_soc_component *comp,
+@@ -3396,11 +3396,25 @@ static int wcd939x_codec_set_jack(struct snd_soc_component *comp,
  {
  	struct wcd939x_priv *wcd = dev_get_drvdata(comp->dev);
  
@@ -62,3 +51,6 @@ index 2d0c3ec77..cb119f85c 100644
  	return 0;
  }
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0603-ASoC-codecs-wcd939x-keep-the-codec-resumed-while-a-ja.patch
+++ b/patch/kernel/archive/sm8750-7.1/0603-ASoC-codecs-wcd939x-keep-the-codec-resumed-while-a-ja.patch
@@ -1,0 +1,64 @@
+From: Anze <aanzdev@gmail.com>
+Subject: [PATCH] ASoC: codecs: wcd939x: keep the codec resumed while a jack is set
+
+Headset detection reports nothing at all on an AYN Odin 3. MBHC is armed
+correctly - ANA_MBHC_MECH reads 0xbd with L_DET_EN set and the plug-type
+polarity matching the vendor DT - the interrupts are mapped, and yet
+plugging headphones produces no interrupt whatsoever and "Headphone
+Jack" stays off.
+
+The codec is runtime suspended essentially all the time: nothing
+streams, so it autosuspends a second after probe and stays there.
+Suspending puts its regmap in cache-only mode and lets the SoundWire
+link stop its clock, and the codec then has no way to signal anything.
+MBHC is powered and watching; its interrupt has nowhere to go.
+
+Resuming both SoundWire devices makes detection work immediately and
+completely:
+
+  wcd939x_wcd_mbhc_calc_impedance: impedance on HPH_L = 41(ohms)
+  wcd939x_wcd_mbhc_calc_impedance: impedance on HPH_R = 43(ohms)
+  wcd939x_wcd_mbhc_calc_impedance: stereo plug type detected
+
+with SW_HEADPHONE_INSERT set on the jack input device and the mechanical
+interrupt firing on every plug and unplug.
+
+Keep them resumed for as long as a jack is registered. pm_runtime_forbid()
+rather than a get/put pair: a plain reference is not enough here, the
+bus suspends the devices again anyway, and forbid is exactly what
+writing "on" to power/control does - which is what was verified on the
+device.
+
+Signed-off-by: Anze <aanzdev@gmail.com>
+---
+diff --git a/sound/soc/codecs/wcd939x.c b/sound/soc/codecs/wcd939x.c
+index 2d0c3ec77..cb119f85c 100644
+--- a/sound/soc/codecs/wcd939x.c
++++ b/sound/soc/codecs/wcd939x.c
+@@ -3391,11 +3391,25 @@ static int wcd939x_codec_set_jack(struct snd_soc_component *comp,
+ {
+ 	struct wcd939x_priv *wcd = dev_get_drvdata(comp->dev);
+ 
+-	if (jack)
++	if (jack) {
++		/*
++		 * MBHC can only report while the SoundWire devices stay
++		 * resumed: suspending them lets the link stop its clock, and
++		 * the codec's interrupt then has nowhere to go - detection
++		 * goes completely silent even though MBHC itself is armed and
++		 * powered. Hold them up for as long as a jack is registered.
++		 */
++		pm_runtime_forbid(wcd->rxdev);
++		pm_runtime_forbid(wcd->txdev);
++
+ 		return wcd_mbhc_start(wcd->wcd_mbhc, &wcd->mbhc_cfg, jack);
++	}
+ 
+ 	wcd_mbhc_stop(wcd->wcd_mbhc);
+ 
++	pm_runtime_allow(wcd->txdev);
++	pm_runtime_allow(wcd->rxdev);
++
+ 	return 0;
+ }
+ 

--- a/patch/kernel/archive/sm8750-7.1/0604-arm64-dts-qcom-cq8725s-ayn-enable-swr1-PCM-port-mask.patch
+++ b/patch/kernel/archive/sm8750-7.1/0604-arm64-dts-qcom-cq8725s-ayn-enable-swr1-PCM-port-mask.patch
@@ -1,25 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Anze <aanzdev@gmail.com>
-Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn: set swr1 PCM port mask
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: arm64: dts: qcom: cq8725s-ayn: set swr1 PCM port mask
 
-The WCD939x HPH PCM ("HiFi") path carries the headphone stream as
-384 kHz PCM on SoundWire master port 9, and the qcom controller only
-enables the PCM data port format for the ports listed in
-qcom,pcm-ports-mask. Without it the codec waits for PCM on port 9 and
-nothing ever arrives: turning on the HPH PCM mode kcontrols gives
-complete silence on the jack instead of the PDM path's constant hiss.
-
-The AYN swr1 node is otherwise identical to the KONKR Pocket FIT
-Elite's, which carries this property, and the RX port mapping already
-ends on port 9. The property is inert unless the HPH PCM mode
-kcontrols are enabled, so it changes nothing on its own.
-
-Signed-off-by: Anze <aanzdev@gmail.com>
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
-index f91e6db9b..8723da2c9 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
-@@ -1068,6 +1068,12 @@ &sdhc_2 {
+@@ -1069,6 +1069,12 @@ &sdhc_2 {
  &swr1 {
  	status = "okay";
  
@@ -32,3 +37,6 @@ index f91e6db9b..8723da2c9 100644
  	wcd_rx: codec@0,4 {
  		compatible = "sdw20217010e00";
  		reg = <0 4>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0604-arm64-dts-qcom-cq8725s-ayn-enable-swr1-PCM-port-mask.patch
+++ b/patch/kernel/archive/sm8750-7.1/0604-arm64-dts-qcom-cq8725s-ayn-enable-swr1-PCM-port-mask.patch
@@ -1,0 +1,34 @@
+From: Anze <aanzdev@gmail.com>
+Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn: set swr1 PCM port mask
+
+The WCD939x HPH PCM ("HiFi") path carries the headphone stream as
+384 kHz PCM on SoundWire master port 9, and the qcom controller only
+enables the PCM data port format for the ports listed in
+qcom,pcm-ports-mask. Without it the codec waits for PCM on port 9 and
+nothing ever arrives: turning on the HPH PCM mode kcontrols gives
+complete silence on the jack instead of the PDM path's constant hiss.
+
+The AYN swr1 node is otherwise identical to the KONKR Pocket FIT
+Elite's, which carries this property, and the RX port mapping already
+ends on port 9. The property is inert unless the HPH PCM mode
+kcontrols are enabled, so it changes nothing on its own.
+
+Signed-off-by: Anze <aanzdev@gmail.com>
+---
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+index f91e6db9b..8723da2c9 100644
+--- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+@@ -1068,6 +1068,12 @@ &sdhc_2 {
+ &swr1 {
+ 	status = "okay";
+ 
++	/* Master port 9 carries the WCD939x HIFI_PCM headphone stream
++	 * (384 kHz PCM), so the controller needs its per-port PCM format
++	 * enable set for it. Inert unless the HPH PCM mode kcontrols are
++	 * enabled. */
++	qcom,pcm-ports-mask = <0x200>;
++
+ 	wcd_rx: codec@0,4 {
+ 		compatible = "sdw20217010e00";
+ 		reg = <0 4>;

--- a/patch/kernel/archive/sm8750-7.1/0606-phy-qcom-qmp-pcie-switch-pipe-clk-mux-to-phy.patch
+++ b/patch/kernel/archive/sm8750-7.1/0606-phy-qcom-qmp-pcie-switch-pipe-clk-mux-to-phy.patch
@@ -1,0 +1,57 @@
+From: Patrick Hennig <patrick.hennig@uu.se>
+Date: Fri, 31 Jul 2026 22:20:00 +0200
+Subject: [PATCH] phy: qcom: qmp-pcie: switch the pipe clk mux to the PHY source
+
+The 7.2 merge window rewrote clk_regmap_phy_mux_ops: .enable/.disable/
+.is_enabled were replaced by .recalc_rate/.determine_rate/.set_rate, so
+selecting the PHY source now requires clk_set_rate(clk, ULONG_MAX) rather
+than simply enabling the clock. No caller was added - grep for
+clk_set_rate(..., ULONG_MAX) across drivers/phy, drivers/pci and drivers/usb
+comes back empty - and this driver still only does clk_bulk_prepare_enable()
+on its pipe clocks, exactly as in 7.1.3 where .enable did the switching.
+
+On SM8750 the result is that gcc_pcie_0_pipe_clk_src never leaves the XO
+reference:
+
+  pcie0_pipe_clk                 125000000   (PHY locked, pipe clock present)
+     gcc_pcie_0_pipe_clk_src      19200000   (mux still on XO)
+        gcc_pcie_0_pipe_clk        19200000   (consumed by 1c06000.phy)
+
+With the controller's PIPE interface clocked at 19.2MHz instead of 125MHz,
+link training cannot complete: the WCN7860 is powered, out of reset and
+asserting CLKREQ#, but LTSSM parks in Poll.Active and
+dw_pcie_wait_for_link() reports "Device found, but not active", so the
+endpoint never enumerates and ath12k is never bound. USB3 is unaffected
+because gcc_usb3_prim_phy_pipe_clk_src uses clk_regmap_mux_closest_ops.
+
+Request the rate after the PCS reports ready, not at the pipe-clock enable:
+clk_bulk_prepare_enable() runs before SERDES_START, so at that point the PHY
+is not yet driving the pipe clock and switching the mux onto it stalls the
+bus (observed as a hard hang during boot). gcc_pcie_0_pipe_clk carries
+CLK_SET_RATE_PARENT, so the request reaches the mux. Failure is warned about
+rather than fatal, since the link may still train on platforms whose mux
+defaults to the PHY source.
+
+Signed-off-by: Patrick Hennig <patrick.hennig@uu.se>
+---
+--- a/drivers/phy/qualcomm/phy-qcom-qmp-pcie.c
++++ b/drivers/phy/qualcomm/phy-qcom-qmp-pcie.c
+@@ -5009,6 +5009,18 @@
+ 		goto err_disable_pipe_clk;
+ 	}
+ 
++	/*
++	 * Move the GCC pipe clk mux off the XO reference and onto the PHY pipe
++	 * clock. Since 7.2 clk_regmap_phy_mux_ops switches on set_rate instead
++	 * of on enable, so enabling the pipe clock above is no longer enough.
++	 * Do it here rather than at the enable, because the PHY only starts
++	 * driving the pipe clock once SERDES_START has completed - switching
++	 * the mux onto a source that is not yet running stalls the bus.
++	 */
++	ret = clk_set_rate(qmp->pipe_clks[0].clk, ULONG_MAX);
++	if (ret)
++		dev_warn(qmp->dev, "failed to switch pipe clk to PHY source: %d\n", ret);
++
+ 	return 0;
+ 
+ err_disable_pipe_clk:

--- a/patch/kernel/archive/sm8750-7.1/0606-phy-qcom-qmp-pcie-switch-pipe-clk-mux-to-phy.patch
+++ b/patch/kernel/archive/sm8750-7.1/0606-phy-qcom-qmp-pcie-switch-pipe-clk-mux-to-phy.patch
@@ -1,42 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Patrick Hennig <patrick.hennig@uu.se>
-Date: Fri, 31 Jul 2026 22:20:00 +0200
-Subject: [PATCH] phy: qcom: qmp-pcie: switch the pipe clk mux to the PHY source
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: phy: qcom: qmp-pcie: switch the pipe clk mux to the PHY source
 
-The 7.2 merge window rewrote clk_regmap_phy_mux_ops: .enable/.disable/
-.is_enabled were replaced by .recalc_rate/.determine_rate/.set_rate, so
-selecting the PHY source now requires clk_set_rate(clk, ULONG_MAX) rather
-than simply enabling the clock. No caller was added - grep for
-clk_set_rate(..., ULONG_MAX) across drivers/phy, drivers/pci and drivers/usb
-comes back empty - and this driver still only does clk_bulk_prepare_enable()
-on its pipe clocks, exactly as in 7.1.3 where .enable did the switching.
-
-On SM8750 the result is that gcc_pcie_0_pipe_clk_src never leaves the XO
-reference:
-
-  pcie0_pipe_clk                 125000000   (PHY locked, pipe clock present)
-     gcc_pcie_0_pipe_clk_src      19200000   (mux still on XO)
-        gcc_pcie_0_pipe_clk        19200000   (consumed by 1c06000.phy)
-
-With the controller's PIPE interface clocked at 19.2MHz instead of 125MHz,
-link training cannot complete: the WCN7860 is powered, out of reset and
-asserting CLKREQ#, but LTSSM parks in Poll.Active and
-dw_pcie_wait_for_link() reports "Device found, but not active", so the
-endpoint never enumerates and ath12k is never bound. USB3 is unaffected
-because gcc_usb3_prim_phy_pipe_clk_src uses clk_regmap_mux_closest_ops.
-
-Request the rate after the PCS reports ready, not at the pipe-clock enable:
-clk_bulk_prepare_enable() runs before SERDES_START, so at that point the PHY
-is not yet driving the pipe clock and switching the mux onto it stalls the
-bus (observed as a hard hang during boot). gcc_pcie_0_pipe_clk carries
-CLK_SET_RATE_PARENT, so the request reaches the mux. Failure is warned about
-rather than fatal, since the link may still train on platforms whose mux
-defaults to the PHY source.
-
-Signed-off-by: Patrick Hennig <patrick.hennig@uu.se>
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ drivers/phy/qualcomm/phy-qcom-qmp-pcie.c | 12 ++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/phy/qualcomm/phy-qcom-qmp-pcie.c b/drivers/phy/qualcomm/phy-qcom-qmp-pcie.c
+index 111111111111..222222222222 100644
 --- a/drivers/phy/qualcomm/phy-qcom-qmp-pcie.c
 +++ b/drivers/phy/qualcomm/phy-qcom-qmp-pcie.c
-@@ -5009,6 +5009,18 @@
+@@ -4876,6 +4876,18 @@ static int qmp_pcie_power_on(struct phy *phy)
  		goto err_disable_pipe_clk;
  	}
  
@@ -55,3 +43,6 @@ Signed-off-by: Patrick Hennig <patrick.hennig@uu.se>
  	return 0;
  
  err_disable_pipe_clk:
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0612-ROCKNIX-odin3-q6apm-start-mi2s-port-at-prepare.patch
+++ b/patch/kernel/archive/sm8750-7.1/0612-ROCKNIX-odin3-q6apm-start-mi2s-port-at-prepare.patch
@@ -1,0 +1,33 @@
+Subject: [PATCH] ASoC: qdsp6: q6apm-lpass: start RX port at prepare
+
+Port start moved from .prepare to .trigger, so the MI2S bit-clock now
+starts after the codec DAPM widgets power up. The Odin3 aw88166 amps
+check their PLL against BCLK at DAPM PRE_PMU, before the trigger, and
+fail PLL lock with no clock, leaving the speakers silent.
+
+Start the playback port at prepare again so BCLK is up before PRE_PMU.
+The trigger's !is_port_started guard no-ops; capture is unchanged.
+---
+--- a/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c
++++ b/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c
+@@ -224,6 +224,20 @@
+ 		dev_err(dai->dev, "Failed to prepare Graph %d\n", rc);
+ 		goto err;
+ 	}
++
++	/*
++	 * aw88166 checks its PLL against BCLK at DAPM PRE_PMU, before the
++	 * PCM trigger; start the port here so BCLK is up in time. The
++	 * trigger's !is_port_started guard then no-ops. Playback only.
++	 */
++	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK) {
++		rc = q6apm_graph_start(dai_data->graph[dai->id]);
++		if (rc < 0) {
++			dev_err(dai->dev, "Failed to start APM port %d\n", dai->id);
++			goto err;
++		}
++		dai_data->is_port_started[dai->id] = true;
++	}
+ 	return 0;
+ err:
+ 	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK) {

--- a/patch/kernel/archive/sm8750-7.1/0612-ROCKNIX-odin3-q6apm-start-mi2s-port-at-prepare.patch
+++ b/patch/kernel/archive/sm8750-7.1/0612-ROCKNIX-odin3-q6apm-start-mi2s-port-at-prepare.patch
@@ -1,16 +1,30 @@
-Subject: [PATCH] ASoC: qdsp6: q6apm-lpass: start RX port at prepare
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: ROCKNIX odin3 q6apm start mi2s port at prepare
 
-Port start moved from .prepare to .trigger, so the MI2S bit-clock now
-starts after the codec DAPM widgets power up. The Odin3 aw88166 amps
-check their PLL against BCLK at DAPM PRE_PMU, before the trigger, and
-fail PLL lock with no clock, leaving the speakers silent.
-
-Start the playback port at prepare again so BCLK is up before PRE_PMU.
-The trigger's !is_port_started guard no-ops; capture is unchanged.
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ sound/soc/qcom/qdsp6/q6apm-lpass-dais.c | 14 ++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c b/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c
+index 111111111111..222222222222 100644
 --- a/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c
 +++ b/sound/soc/qcom/qdsp6/q6apm-lpass-dais.c
-@@ -224,6 +224,20 @@
+@@ -224,6 +224,20 @@ static int q6apm_lpass_dai_prepare(struct snd_pcm_substream *substream, struct s
  		dev_err(dai->dev, "Failed to prepare Graph %d\n", rc);
  		goto err;
  	}
@@ -31,3 +45,6 @@ The trigger's !is_port_started guard no-ops; capture is unchanged.
  	return 0;
  err:
  	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK) {
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/0700-armbian-dispcc-sm8750-knockdown-block-resets-on-probe.patch
+++ b/patch/kernel/archive/sm8750-7.1/0700-armbian-dispcc-sm8750-knockdown-block-resets-on-probe.patch
@@ -1,8 +1,7 @@
-From 218dc2152e1c72f1dd90eb12748d2f48b4282fbe Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SuperKali <hello@superkali.me>
 Date: Sat, 29 Aug 2026 11:14:57 +0200
-Subject: [PATCH] clk: qcom: dispcc-sm8750: knock down display block resets on
- probe
+Subject: clk: qcom: dispcc-sm8750: knock down display block resets on probe
 
 Some bootloaders (e.g. stock AYN UEFI on the AYN Odin 3) leave the
 display block fully active at ExitBootServices: dispcc PLLs locked,
@@ -20,11 +19,11 @@ way they would on a cold boot.
 
 Signed-off-by: SuperKali <hello@superkali.me>
 ---
- drivers/clk/qcom/dispcc-sm8750.c | 24 ++++++++++++++++++++++++
+ drivers/clk/qcom/dispcc-sm8750.c | 24 ++++++++++
  1 file changed, 24 insertions(+)
 
 diff --git a/drivers/clk/qcom/dispcc-sm8750.c b/drivers/clk/qcom/dispcc-sm8750.c
-index ca09da111a50..cf3ac55e04b1 100644
+index 111111111111..222222222222 100644
 --- a/drivers/clk/qcom/dispcc-sm8750.c
 +++ b/drivers/clk/qcom/dispcc-sm8750.c
 @@ -5,6 +5,7 @@
@@ -66,5 +65,5 @@ index ca09da111a50..cf3ac55e04b1 100644
  	clk_taycan_elu_pll_configure(&disp_cc_pll1, regmap, &disp_cc_pll1_config);
  	clk_pongo_elu_pll_configure(&disp_cc_pll2, regmap, &disp_cc_pll2_config);
 -- 
-2.47.3
+Armbian
 

--- a/patch/kernel/archive/sm8750-7.1/0700-armbian-dispcc-sm8750-knockdown-block-resets-on-probe.patch
+++ b/patch/kernel/archive/sm8750-7.1/0700-armbian-dispcc-sm8750-knockdown-block-resets-on-probe.patch
@@ -1,0 +1,70 @@
+From 218dc2152e1c72f1dd90eb12748d2f48b4282fbe Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 29 Aug 2026 11:14:57 +0200
+Subject: [PATCH] clk: qcom: dispcc-sm8750: knock down display block resets on
+ probe
+
+Some bootloaders (e.g. stock AYN UEFI on the AYN Odin 3) leave the
+display block fully active at ExitBootServices: dispcc PLLs locked,
+MDSS core/int2/rscc out of reset and downstream branches running.
+The kernel's later mdss_reset()/PLL configure happens on top of this
+live state and the DPU command-mode panel gets stuck (kickoff timeout
+/ encoder reset failure). Renegade LinuxLoader documents the same as
+the dispcc "DisableDisplayHW" workaround on the bootloader side.
+
+Mirror that workaround from the kernel: assert the three dispcc block
+resets so MDSS core / INT2 / RSCC come up in a known-zero state, hold
+for one full ~30 Hz frame, then release. clk_*_pll_configure() and
+qcom_cc_really_probe() then program the block from scratch the same
+way they would on a cold boot.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ drivers/clk/qcom/dispcc-sm8750.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/drivers/clk/qcom/dispcc-sm8750.c b/drivers/clk/qcom/dispcc-sm8750.c
+index ca09da111a50..cf3ac55e04b1 100644
+--- a/drivers/clk/qcom/dispcc-sm8750.c
++++ b/drivers/clk/qcom/dispcc-sm8750.c
+@@ -5,6 +5,7 @@
+  */
+ 
+ #include <linux/clk-provider.h>
++#include <linux/delay.h>
+ #include <linux/err.h>
+ #include <linux/kernel.h>
+ #include <linux/mod_devicetable.h>
+@@ -1920,6 +1921,29 @@ static int disp_cc_sm8750_probe(struct platform_device *pdev)
+ 		goto err_put_rpm;
+ 	}
+ 
++	/*
++	 * Some bootloaders (e.g. stock AYN UEFI on the AYN Odin 3) leave the
++	 * display block fully active at ExitBootServices: dispcc PLLs locked,
++	 * MDSS core/int2/rscc out of reset and downstream branches running.
++	 * The kernel's later mdss_reset()/PLL configure happens on top of this
++	 * live state and the DPU command-mode panel gets stuck (kickoff timeout
++	 * / encoder reset failure). Renegade LinuxLoader documents the same as
++	 * the dispcc "DisableDisplayHW" workaround on the bootloader side.
++	 *
++	 * Mirror that workaround from the kernel: assert the three dispcc block
++	 * resets so MDSS core / INT2 / RSCC come up in a known-zero state, hold
++	 * for one full ~30 Hz frame, then release. clk_*_pll_configure() and
++	 * qcom_cc_really_probe() then program the block from scratch the same
++	 * way they would on a cold boot.
++	 */
++	regmap_write(regmap, 0x8000, 0x1); /* DISP_CC_MDSS_CORE_BCR */
++	regmap_write(regmap, 0xa000, 0x1); /* DISP_CC_MDSS_CORE_INT2_BCR */
++	regmap_write(regmap, 0xc000, 0x1); /* DISP_CC_MDSS_RSCC_BCR */
++	msleep(50);
++	regmap_write(regmap, 0xc000, 0x0);
++	regmap_write(regmap, 0xa000, 0x0);
++	regmap_write(regmap, 0x8000, 0x0);
++
+ 	clk_taycan_elu_pll_configure(&disp_cc_pll0, regmap, &disp_cc_pll0_config);
+ 	clk_taycan_elu_pll_configure(&disp_cc_pll1, regmap, &disp_cc_pll1_config);
+ 	clk_pongo_elu_pll_configure(&disp_cc_pll2, regmap, &disp_cc_pll2_config);
+-- 
+2.47.3
+

--- a/patch/kernel/archive/sm8750-7.1/1000-input-misc-qcom-hv-haptics-sm8750.patch
+++ b/patch/kernel/archive/sm8750-7.1/1000-input-misc-qcom-hv-haptics-sm8750.patch
@@ -1,5 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: input misc qcom hv haptics sm8750
+
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
+---
+ drivers/input/misc/Kconfig                  |   14 +
+ drivers/input/misc/Makefile                 |    1 +
+ drivers/input/misc/qcom-hv-haptics.c        | 6736 ++++++++++
+ include/dt-bindings/input/qcom,hv-haptics.h |   37 +
+ include/linux/qpnp/qpnp-pbs.h               |   33 +
+ include/linux/soc/qcom/battery_charger.h    |   45 +
+ include/linux/soc/qcom/qcom_hv_haptics.h    |   41 +
+ include/trace/events/qcom_haptics.h         |   98 +
+ 8 files changed, 7005 insertions(+)
+
 diff --git a/drivers/input/misc/Kconfig b/drivers/input/misc/Kconfig
-index c0383376f..1089bb694 100644
+index 111111111111..222222222222 100644
 --- a/drivers/input/misc/Kconfig
 +++ b/drivers/input/misc/Kconfig
 @@ -236,6 +236,20 @@ config INPUT_PMIC8XXX_PWRKEY
@@ -24,7 +53,7 @@ index c0383376f..1089bb694 100644
  	tristate "SPARC Speaker support"
  	depends on PCI && SPARC64
 diff --git a/drivers/input/misc/Makefile b/drivers/input/misc/Makefile
-index 314d56864..689d5bc1c 100644
+index 111111111111..222222222222 100644
 --- a/drivers/input/misc/Makefile
 +++ b/drivers/input/misc/Makefile
 @@ -67,6 +67,7 @@ obj-$(CONFIG_INPUT_PF1550_ONKEY)	+= pf1550-onkey.o
@@ -37,7 +66,7 @@ index 314d56864..689d5bc1c 100644
  obj-$(CONFIG_INPUT_PWM_VIBRA)		+= pwm-vibra.o
 diff --git a/drivers/input/misc/qcom-hv-haptics.c b/drivers/input/misc/qcom-hv-haptics.c
 new file mode 100644
-index 000000000..a6e50d50e
+index 000000000000..111111111111
 --- /dev/null
 +++ b/drivers/input/misc/qcom-hv-haptics.c
 @@ -0,0 +1,6736 @@
@@ -6779,7 +6808,7 @@ index 000000000..a6e50d50e
 +MODULE_LICENSE("GPL");
 diff --git a/include/dt-bindings/input/qcom,hv-haptics.h b/include/dt-bindings/input/qcom,hv-haptics.h
 new file mode 100644
-index 000000000..8453d2ae9
+index 000000000000..111111111111
 --- /dev/null
 +++ b/include/dt-bindings/input/qcom,hv-haptics.h
 @@ -0,0 +1,37 @@
@@ -6822,7 +6851,7 @@ index 000000000..8453d2ae9
 +#define S_PERIOD_F_48KHZ		13
 diff --git a/include/linux/qpnp/qpnp-pbs.h b/include/linux/qpnp/qpnp-pbs.h
 new file mode 100644
-index 000000000..1834381a2
+index 000000000000..111111111111
 --- /dev/null
 +++ b/include/linux/qpnp/qpnp-pbs.h
 @@ -0,0 +1,33 @@
@@ -6861,7 +6890,7 @@ index 000000000..1834381a2
 +#endif
 diff --git a/include/linux/soc/qcom/battery_charger.h b/include/linux/soc/qcom/battery_charger.h
 new file mode 100644
-index 000000000..47382d8e0
+index 000000000000..111111111111
 --- /dev/null
 +++ b/include/linux/soc/qcom/battery_charger.h
 @@ -0,0 +1,45 @@
@@ -6912,7 +6941,7 @@ index 000000000..47382d8e0
 +#endif
 diff --git a/include/linux/soc/qcom/qcom_hv_haptics.h b/include/linux/soc/qcom/qcom_hv_haptics.h
 new file mode 100644
-index 000000000..e32deab3a
+index 000000000000..111111111111
 --- /dev/null
 +++ b/include/linux/soc/qcom/qcom_hv_haptics.h
 @@ -0,0 +1,41 @@
@@ -6960,7 +6989,7 @@ index 000000000..e32deab3a
 \ No newline at end of file
 diff --git a/include/trace/events/qcom_haptics.h b/include/trace/events/qcom_haptics.h
 new file mode 100644
-index 000000000..883f6e3b4
+index 000000000000..111111111111
 --- /dev/null
 +++ b/include/trace/events/qcom_haptics.h
 @@ -0,0 +1,98 @@
@@ -7062,3 +7091,6 @@ index 000000000..883f6e3b4
 +#endif /* _TRACE_QCOM_HAPTICS_H */
 +
 +#include <trace/define_trace.h>
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/1000-input-misc-qcom-hv-haptics-sm8750.patch
+++ b/patch/kernel/archive/sm8750-7.1/1000-input-misc-qcom-hv-haptics-sm8750.patch
@@ -1,0 +1,7064 @@
+diff --git a/drivers/input/misc/Kconfig b/drivers/input/misc/Kconfig
+index c0383376f..1089bb694 100644
+--- a/drivers/input/misc/Kconfig
++++ b/drivers/input/misc/Kconfig
+@@ -236,6 +236,20 @@ config INPUT_PMIC8XXX_PWRKEY
+ 	  To compile this driver as a module, choose M here: the
+ 	  module will be called pmic8xxx-pwrkey.
+ 
++config INPUT_QCOM_HV_HAPTICS
++	tristate "QTI High Voltage Haptics support"
++	depends on MFD_SPMI_PMIC
++   depends on ARCH_QCOM || COMPILE_TEST
++   depends on QCOM_SMEM
++   depends on QCOM_RPROC_COMMON
++	help
++	  This option enables device driver support for the high voltage haptics
++	  peripheral found on Qualcomm Technologies, Inc. PMICs.  The high voltage
++	  haptics peripheral is capable of driving either LRA or ERM vibrators with
++	  drive voltage up to 10 V, and its 5 integrated pattern sources can be used
++	  for playing different vibration effects. To compile this driver as a module,
++	  choose M here: the module will be called qcom-hv-haptics.
++
+ config INPUT_SPARCSPKR
+ 	tristate "SPARC Speaker support"
+ 	depends on PCI && SPARC64
+diff --git a/drivers/input/misc/Makefile b/drivers/input/misc/Makefile
+index 314d56864..689d5bc1c 100644
+--- a/drivers/input/misc/Makefile
++++ b/drivers/input/misc/Makefile
+@@ -67,6 +67,7 @@ obj-$(CONFIG_INPUT_PF1550_ONKEY)	+= pf1550-onkey.o
+ obj-$(CONFIG_INPUT_PM8941_PWRKEY)	+= pm8941-pwrkey.o
+ obj-$(CONFIG_INPUT_PM8XXX_VIBRATOR)	+= pm8xxx-vibrator.o
+ obj-$(CONFIG_INPUT_PMIC8XXX_PWRKEY)	+= pmic8xxx-pwrkey.o
++obj-$(CONFIG_INPUT_QCOM_HV_HAPTICS)	+= qcom-hv-haptics.o
+ obj-$(CONFIG_INPUT_POWERMATE)		+= powermate.o
+ obj-$(CONFIG_INPUT_PWM_BEEPER)		+= pwm-beeper.o
+ obj-$(CONFIG_INPUT_PWM_VIBRA)		+= pwm-vibra.o
+diff --git a/drivers/input/misc/qcom-hv-haptics.c b/drivers/input/misc/qcom-hv-haptics.c
+new file mode 100644
+index 000000000..a6e50d50e
+--- /dev/null
++++ b/drivers/input/misc/qcom-hv-haptics.c
+@@ -0,0 +1,6736 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) 2020-2021, The Linux Foundation. All rights reserved.
++ * Copyright (c) 2021-2024, Qualcomm Innovation Center, Inc. All rights reserved.
++ */
++
++#include <linux/atomic.h>
++#include <linux/debugfs.h>
++#include <linux/device.h>
++#include <linux/err.h>
++#include <linux/fs.h>
++#include <linux/hrtimer.h>
++#include <linux/init.h>
++#include <linux/input.h>
++#include <linux/interrupt.h>
++#include <linux/jiffies.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/nvmem-consumer.h>
++#include <linux/of.h>
++#include <linux/of_address.h>
++#include <linux/of_device.h>
++#include <linux/platform_device.h>
++#include <linux/pm_runtime.h>
++#include <linux/regmap.h>
++#include <linux/regulator/driver.h>
++#include <linux/slab.h>
++#include <linux/suspend.h>
++#include <linux/types.h>
++#include <linux/uaccess.h>
++#include <linux/workqueue.h>
++#include <linux/vmalloc.h>
++#include <linux/qpnp/qpnp-pbs.h>
++#include <linux/remoteproc/qcom_rproc.h>
++#include <linux/soc/qcom/battery_charger.h>
++#include <linux/soc/qcom/qcom_hv_haptics.h>
++
++#define CREATE_TRACE_POINTS
++#include <trace/events/qcom_haptics.h>
++
++/* status register definitions in HAPTICS_CFG module */
++#define HAP_CFG_REVISION1_REG			0x00
++#define HAP_CFG_REVISION2_REG			0x01
++#define HAP_CFG_V1				0x1
++#define HAP_CFG_V2				0x2
++#define HAP_CFG_V3				0x3
++#define HAP_CFG_V4				0x4
++#define HAP_CFG_V5				0x5
++#define MAJOR_REV(rev)				((rev) >> 8)
++
++#define HAP_CFG_REV_LSB_MASK			GENMASK(7, 0)
++#define HAP_CFG_STATUS_DATA_MSB_REG		0x09
++/* STATUS_DATA_MSB definitions while MOD_STATUS_SEL is 0 */
++#define AUTO_RES_CAL_DONE_BIT			BIT(5)
++#define CAL_TLRA_CL_STS_MSB_MASK		GENMASK(4, 0)
++/* STATUS_DATA_MSB definition while MOD_STATUS_SEL is 3 */
++#define LAST_GOOD_TLRA_CL_MSB_MASK		GENMASK(4, 0)
++/* STATUS_DATA_MSB definition while MOD_STATUS_SEL is 4 */
++#define TLRA_CL_ERR_MSB_MASK			GENMASK(4, 0)
++/* STATUS_DATA_MSB when MOD_STATUS_SEL is 5 and MOD_STATUS_XT.SEL is 1 */
++#define FIFO_REAL_TIME_FILL_STATUS_MSB_MASK_V2	GENMASK(1, 0)
++#define FIFO_REAL_TIME_FILL_STATUS_MSB_MASK_V3	GENMASK(2, 0)
++#define FIFO_REAL_TIME_FILL_STATUS_MSB_MASK_V4	GENMASK(3, 0)
++#define FIFO_REAL_TIME_FILL_STATUS_MSB_MASK_V5	GENMASK(4, 0)
++#define FIFO_EMPTY_FLAG_BIT			BIT(6)
++#define FIFO_FULL_FLAG_BIT			BIT(5)
++
++#define HAP_CFG_STATUS_DATA_LSB_REG		0x0A
++/* STATUS_DATA_LSB definition while MOD_STATUS_SEL is 0 */
++#define CAL_TLRA_CL_STS_LSB_MASK		GENMASK(7, 0)
++/* STATUS_DATA_LSB when MOD_STATUS_SEL is 5 and MOD_STATUS_XT.SEL is 1 */
++#define FIFO_REAL_TIME_FILL_STATUS_LSB_MASK	GENMASK(7, 0)
++/* STATUS_DATA_LSB when MOD_STATUS_SEL is 5 and MOD_STATUS_XT.SEL is 0 */
++#define HAP_DRV_PATTERN_SRC_STATUS_MASK		GENMASK(2, 0)
++
++#define HAP_CFG_FAULT_STATUS_REG		0x0C
++#define SC_FLAG_BIT				BIT(2)
++#define AUTO_RES_ERROR_BIT			BIT(1)
++#define HPRW_RDY_FAULT_BIT			BIT(0)
++
++/* For HAP525_HV and later */
++#define HAP_CFG_HPWR_INTF_REG                   0x0B
++#define HPWR_INTF_STATUS_MASK                   GENMASK(1, 0)
++#define HPWR_DISABLED                           0
++#define HPWR_READY                              3
++
++#define HAP_CFG_REAL_TIME_LRA_IMPEDANCE_REG	0x0E
++#define LRA_IMPEDANCE_MOHMS_LSB			250
++#define HAP530_LRA_IMPEDANCE_MOHMS_LSB		200
++
++#define HAP_CFG_INT_RT_STS_REG			0x10
++#define FIFO_EMPTY_BIT				BIT(1)
++
++/* config register definitions in HAPTICS_CFG module */
++#define HAP_CFG_EN_CTL_REG			0x46
++#define HAPTICS_EN_BIT				BIT(7)
++
++#define HAP_CFG_DRV_CTRL_REG			0x47
++#define PSTG_DLY_MASK				GENMASK(7, 6)
++#define DRV_SLEW_RATE_MASK			GENMASK(2, 0)
++
++#define HAP_CFG_VMAX_REG			0x48
++#define VMAX_HV_STEP_MV				50
++#define VMAX_MV_STEP_MV				32
++#define MAX_VMAX_MV				11000
++#define MAX_HV_VMAX_MV				10000
++#define MAX_MV_VMAX_MV				6000
++#define CLAMPED_VMAX_MV				5000
++#define DEFAULT_VMAX_MV				5000
++
++#define HAP_CFG_DRV_WF_SEL_REG			0x49
++#define DRV_WF_FMT_BIT				BIT(4)
++#define DRV_WF_SEL_MASK				GENMASK(1, 0)
++
++#define HAP_CFG_AUTO_SHUTDOWN_CFG_REG		0x4A
++#define EN_WFHOLD_FIFO_BIT			BIT(2) /* For haptics HAP525_HV and later */
++
++#define HAP_CFG_TRIG_PRIORITY_REG		0x4B
++#define SWR_IGNORE_BIT				BIT(4)
++
++#define HAP_CFG_SPMI_PLAY_REG			0x4C
++#define PLAY_EN_BIT				BIT(7)
++#define PATX_MEM_SEL_MASK			GENMASK(5, 4) /* This is only for HAP525_HV */
++#define BRAKE_EN_BIT				BIT(3)
++#define PAT_SRC_MASK				GENMASK(2, 0)
++
++#define HAP_CFG_EXT_TRIG_REG			0x4D
++
++#define HAP_CFG_SWR_ACCESS_REG			0x4E
++#define SWR_PAT_CFG_EN_BIT			BIT(7)
++#define SWR_PAT_INPUT_EN_BIT			BIT(6)
++#define SWR_PAT_RES_N_BIT			BIT(5)
++
++#define HAP_CFG_BRAKE_MODE_CFG_REG		0x50
++#define BRAKE_MODE_MASK				GENMASK(7, 6)
++#define BRAKE_MODE_SHIFT			6
++#define BRAKE_SINE_GAIN_MASK			GENMASK(3, 2)
++#define BRAKE_SINE_GAIN_SHIFT			2
++#define BRAKE_WF_SEL_MASK			GENMASK(1, 0)
++
++#define HAP_CFG_CL_BRAKE_CFG_REG		0x51
++#define HAP_CFG_CL_BRAKE_CAL_PARAM_REG		0x52
++#define HAP_CFG_CL_BRAKE_RSET_REG		0x53
++#define HAP_CFG_PWM_CFG_REG			0x5A
++
++/* Only for HAP530_HV */
++
++#define HAP_CFG_CL_BRAKE_RCAL_REG		0x52
++#define CL_BRAKE_RCAL_MASK			GENMASK(5, 0)
++
++/* For HAP_CFG_CL_BRAKE_RSET_REG */
++#define FORCE_RNAT_RCAL_PARAM_MASK		BIT(0)
++
++#define HAP_CFG_CL_BRAKE_RNAT_REG		0x54
++#define CL_BRAKE_RNAT_MASK			GENMASK(5, 0)
++
++/* End HAP530_HV */
++
++#define HAP_CFG_TLRA_OL_HIGH_REG		0x5C
++#define TLRA_OL_MSB_MASK			GENMASK(3, 0)
++#define HAP_CFG_TLRA_OL_LOW_REG			0x5D
++#define TLRA_OL_LSB_MASK			GENMASK(7, 0)
++#define TLRA_STEP_US				5
++#define TLRA_MAX_US				20475
++
++#define HAP_CFG_RC_CLK_CAL_COUNT_MSB_REG	0x5E
++#define RC_CLK_CAL_COUNT_MSB_MASK		GENMASK(1, 0)
++#define HAP_CFG_RC_CLK_CAL_COUNT_LSB_REG	0x5F
++#define RC_CLK_CAL_COUNT_LSB_MASK		GENMASK(7, 0)
++
++#define HAP_CFG_DRV_DUTY_CFG_REG		0x60
++#define ADT_DRV_DUTY_EN_BIT			BIT(7)
++#define ADT_BRK_DUTY_EN_BIT			BIT(6)
++#define DRV_DUTY_MASK				GENMASK(5, 3)
++#define DRV_DUTY_62P5_PCT			2
++#define DRV_DUTY_SHIFT				3
++#define BRK_DUTY_MASK				GENMASK(2, 0)
++#define BRK_DUTY_75_PCT			6
++
++#define HAP_CFG_ADT_DRV_DUTY_CFG_REG		0x61
++#define HAP_CFG_ZX_WIND_CFG_REG			0x62
++
++#define HAP_CFG_AUTORES_CFG_REG			0x63
++#define AUTORES_EN_BIT				BIT(7)
++#define AUTORES_EN_DLY_MASK			GENMASK(5, 2)
++#define AUTORES_EN_DLY(cycles)			((cycles) * 2)
++#define AUTORES_EN_DLY_6_CYCLES			AUTORES_EN_DLY(6)
++#define AUTORES_EN_DLY_7_CYCLES			AUTORES_EN_DLY(7)
++#define AUTORES_EN_DLY_SHIFT			2
++#define AUTORES_ERR_WINDOW_MASK			GENMASK(1, 0)
++#define AUTORES_ERR_WINDOW_12P5_PERCENT		0x0
++#define AUTORES_ERR_WINDOW_25_PERCENT		0x1
++#define AUTORES_ERR_WINDOW_50_PERCENT		0x2
++#define AUTORES_ERR_WINDOW_100_PERCENT		0x3
++
++#define HAP_CFG_AUTORES_ERR_RECOVERY_REG	0x64
++#define EN_HW_RECOVERY_BIT			BIT(1)
++#define SW_ERR_DRV_FREQ_BIT			BIT(0)
++
++#define HAP_CFG_ISC_CFG_REG			0x65
++#define ILIM_CC_EN_BIT				BIT(7)
++/* Following bits are only for HAP525_HV */
++#define EN_SC_DET_P_HAP525_HV_BIT		BIT(6)
++#define EN_SC_DET_N_HAP525_HV_BIT		BIT(5)
++#define EN_IMP_DET_HAP525_HV_BIT		BIT(4)
++#define ILIM_PULSE_DENSITY_MASK			GENMASK(3, 2)
++#define ILIM_DENSITY_8_OVER_64_CYCLES		0
++
++#define HAP_CFG_FAULT_CLR_REG			0x66
++#define HAP_ZX_TO_FAULT_CLR_BIT			BIT(4) /* only for HAP530_HV */
++#define SC_CLR_BIT				BIT(2)
++#define AUTO_RES_ERR_CLR_BIT			BIT(1)
++#define HPWR_RDY_FAULT_CLR_BIT			BIT(0)
++
++#define HAP_CFG_VMAX_HDRM_REG			0x67
++#define VMAX_HDRM_MASK				GENMASK(6, 0)
++#define VMAX_HDRM_STEP_MV			50
++#define VMAX_HDRM_MAX_MV			6350
++
++#define HAP_CFG_VSET_CFG_REG			0x68
++#define FORCE_VSET_ACK_BIT			BIT(1) /* This is only for HAP525_HV */
++#define FORCE_VREG_RDY_BIT			BIT(0)
++
++#define HAP_CFG_ZX_SYNC_CFG			0x6F /* only for HAP530_HV */
++#define EN_PDN_ZX_TO_FAULT_BIT			BIT(2)
++
++#define HAP_CFG_MOD_STATUS_SEL_REG		0x70
++#define HAP_CFG_MOD_STATUS_XT_REG		0x71
++
++#define HAP_CFG_CAL_EN_REG			0x72
++#define CAL_RC_CLK_MASK				GENMASK(3, 2)
++#define CAL_RC_CLK_SHIFT			2
++#define CAL_RC_CLK_DISABLED_VAL			0
++#define CAL_RC_CLK_AUTO_VAL			1
++#define CAL_RC_CLK_MANUAL_VAL			2
++#define BRAKE_CAL_MASK				GENMASK(1, 0)
++#define BRAKE_CAL_NONE				0
++#define BRAKE_CAL_CL_NATURAL			1
++#define BRAKE_CAL_CL_FORCED			2
++#define BRAKE_CAL_CL_RECAL			3
++
++/* For HAP520_MV and HAP525_HV */
++#define HAP_CFG_ISC_CFG2_REG			0x77
++#define EN_SC_DET_P_HAP520_MV_BIT		BIT(6)
++#define EN_SC_DET_N_HAP520_MV_BIT		BIT(5)
++#define ISC_THRESH_HAP520_MV_MASK		GENMASK(2, 0)
++#define ISC_THRESH_HAP520_MV_140MA		0x01
++#define ISC_THRESH_HAP525_HV_MASK		GENMASK(4, 0)
++#define ISC_THRESH_HAP525_HV_125MA		0x11
++#define ISC_THRESH_HAP525_HV_250MA		0x12
++
++/* These registers are only applicable for HAP520_MV */
++#define HAP_CFG_HW_CONFIG_REG			0x0D
++#define HV_HAP_DRIVER_BIT			BIT(1)
++
++#define HAP_CFG_HPWR_INTF_CTL_REG		0x80
++#define INTF_CTL_MASK				GENMASK(1, 0)
++#define INTF_CTL_BOB				1
++#define INTF_CTL_BHARGER			2
++
++#define HAP_CFG_VHPWR_REG			0x84
++#define VHPWR_STEP_MV				32
++
++/* Only for HAP525_HV */
++#define HAP_CFG_RT_LRA_IMPD_MEAS_CFG_REG	0xA4
++#define LRA_IMPEDANCE_MEAS_EN_BIT		BIT(7)
++#define LRA_IMPEDANCE_MEAS_CURRENT_SEL_BIT	BIT(0)
++#define CURRENT_SEL_VAL_125MA			0
++#define CURRENT_SEL_VAL_250MA			1
++
++/* Only for HAP530 */
++#define HAP_CFG_DIG_SPARE_REG			0xB8
++#define EN_FE_PU_CHECK_BIT			BIT(3)
++
++#define HAP_CFG_ICOMP_AVG_CTL1_REG		0xC0
++#define ICOMP_THRESH_MASK			GENMASK(6, 0)
++#define ICOMP_THRESH_STEP_NA			7812500
++
++#define HAP_CFG_ICOMP_AVG_CTL2_REG		0xC1
++
++#define HAP_CFG_RSENSE_MEAS_LSB_REG		0xC4
++#define LRA_IMPEDANCE_VISENSE_MOHMS		25
++#define HAP_CFG_RSENSE_MEAS_MSB_MASK		GENMASK(3, 0)
++
++#define HAP_CFG_VISENSE_PEAK_DET_CTL_REG	0xC7
++#define VISENSE_PEAK_DET_EN_BIT			BIT(7)
++#define VISENSE_PEAK_DET_MODE			BIT(6)
++#define VISENSE_INST_DET_EN_BIT			BIT(4)
++
++#define HAP_CFG_VSENSE_PEAK_LSB_REG		0xC8
++#define HAP_CFG_VSENSE_PEAK_MSB_MASK		GENMASK(5, 0)
++
++#define HAP_CFG_ISENSE_PEAK_LSB_REG		0xCA
++#define HAP_CFG_ISENSE_PEAK_MSB_MASK		GENMASK(4, 0)
++
++/* version register definitions for HAPTICS_PATTERN module */
++#define HAP_PTN_REVISION1_REG			0x00
++#define HAP_PTN_REVISION2_REG			0x01
++#define HAP_PTN_V1				0x1
++#define HAP_PTN_V2				0x2
++#define HAP_PTN_V3				0x3
++#define HAP_PTN_V4				0x4
++#define HAP_PTN_V5				0x5
++#define HAP_PTN_PATX_PLAY_CFG_SUPPORT_MIN_REV	0x501
++
++/* status register definition for HAPTICS_PATTERN module */
++#define HAP_PTN_FIFO_READY_STS_REG		0x08
++#define FIFO_READY_BIT				BIT(0)
++
++#define HAP_PTN_NUM_PAT_REG			0x09
++
++/* config register definition for HAPTICS_PATTERN module */
++#define HAP_PTN_FIFO_DIN_0_REG			0x20
++#define HAP_PTN_FIFO_DIN_NUM			4
++
++#define HAP_PTN_FIFO_PLAY_RATE_REG		0x24
++#define PAT_MEM_PLAY_RATE_MASK			GENMASK(7, 4)
++#define FIFO_PLAY_RATE_MASK			GENMASK(3, 0)
++
++#define HAP_PTN_AUTORES_CAL_CFG_REG		0x28
++#define AUTORES_CAL_TRIG_BIT			BIT(7)
++#define AUTORES_CAL_TIMER_4_HALF_CYCLES		4
++#define AUTORES_CAL_TIMER_6_HALF_CYCLES		6
++
++#define HAP_PTN_FIFO_EMPTY_CFG_REG		0x2A
++#define HAP520_EMPTY_THRESH_MASK		GENMASK(3, 0)
++#define HAP520_MV_EMPTY_THRESH_MASK		GENMASK(4, 0)
++#define HAP525_EMPTY_THRESH_MASK		GENMASK(5, 0)
++#define HAP530_EMPTY_THRESH_MASK		GENMASK(6, 0)
++#define HAP_PTN_FIFO_THRESH_LSB			40
++
++#define HAP_PTN_FIFO_DEPTH_CFG_REG		0x2B
++#define HAP_PTN_FIFO_DIN_1B_REG			0x2C
++
++#define HAP_PTN_DIRECT_PLAY_REG			0x26
++#define DIRECT_PLAY_MAX_AMPLITUDE		0xFF
++
++#define HAP_PTN_AUTORES_CAL_CFG_REG		0x28
++
++#define HAP_PTN_PTRN1_TLRA_MSB_REG		0x30
++#define HAP_PTN_PTRN1_TLRA_LSB_REG		0x31
++#define HAP_PTN_PTRN2_TLRA_MSB_REG		0x32
++#define HAP_PTN_PTRN2_TLRA_LSB_REG		0x33
++
++#define HAP_PTN_PTRN1_CFG_REG			0x34
++#define PTRN_FLRA2X_SHIFT			7
++#define PTRN_SAMPLE_PER_MASK			GENMASK(2, 0)
++
++#define PTRN_AMP_MSB_MASK			BIT(0)
++#define PTRN_AMP_LSB_MASK			GENMASK(7, 0)
++
++/* For HAP530_HV */
++#define HAP_PTN_VISENSE_ADC_CFG			0x47
++#define EN_VISENSE_PD_PROT_BIT			BIT(3)
++
++#define HAP_PTN_CL_VDRIVE_CTL_REG		0x4A
++#define EN_CL_VDRIVE_BIT			BIT(7)
++/* End for HAP530_HV */
++
++#define HAP_PTN_PTRN2_CFG_REG			0x50
++
++#define HAP_PTN_BRAKE_AMP_REG			0x70
++
++/* HAPTICS_PATTERN registers only present in HAP525_HV */
++#define HAP_PTN_MEM_OP_ACCESS_REG		0x2D
++#define MEM_PAT_ACCESS_BIT			BIT(7)
++#define MEM_PAT_RW_SEL_MASK			GENMASK(5, 4)
++#define MEM_FLUSH_RELOAD_BIT			BIT(0)
++
++#define HAP_PTN_MMAP_FIFO_REG			0xA0
++#define MMAP_FIFO_EXIST_BIT			BIT(7)
++#define MMAP_FIFO_LEN_MASK			GENMASK(3, 0)
++#define HAP530_MMAP_FIFO_LEN_MASK		GENMASK(6, 0)
++#define MMAP_FIFO_LEN_PER_LSB			128
++#define HAP530_MMAP_FIFO_LEN_PER_LSB		64
++
++#define HAP_PTN_MMAP_PAT1_REG			0xA1
++#define MMAP_PAT_LEN_PER_LSB			32
++#define HAP530_MMAP_PAT_LEN_PER_LSB		4
++#define MMAP_PAT1_LEN_MASK			GENMASK(6, 0)
++#define MMAP_PAT2_LEN_MASK			GENMASK(5, 0)
++#define MMAP_PAT3_PAT4_LEN_MASK			GENMASK(4, 0)
++
++#define HAP_PTN_PATX_PLAY_CFG			0xA2
++#define HAP530_V2_MMAP_PAT_LEN_PER_LSB		1
++
++/* HAPTICS_PATTERN registers only present in HAP530_HV */
++#define HAP_PTN_FORCE_TWIND_CAL_MSB		0x30
++#define HAP_PTN_TWIND_CAL_MSB_MASK		GENMASK(3, 0)
++
++#define HAP_PTN_FORCE_TWIND_CAL_LSB		0x31
++
++#define HAP_PTN_VISENSE_EN_REG			0x46
++#define HAP_PTN_VISENSE_EN_BIT			BIT(7)
++
++#define HAP_PTN_PATX_MEM_WR_START_ADDR_REG	0x50
++#define HAP_PTN_BRAKE_AMP_0_REG			0x70
++#define HAP_PTN_SPMI_PATX_MEM_START_ADDR_REG	0xA4
++#define HAP_PTN_SPMI_PATX_MEM_LEN_LSB_REG	0xA6
++#define HAP_PTN_PATX_MEM_LEN_HI_MASK		GENMASK(2, 0)
++#define HAP530_V2_PTN_PATX_MEM_LEN_HI_MASK	GENMASK(4, 0)
++#define HAP_PTN_PATX_MEM_LEN_LO_MASK		GENMASK(7, 0)
++#define HAP_PTN_PATX_MEM_LEN_HI_SHIFT		8
++
++#define HAP_PTN_VSENSE_ADC_CTL_REG		0x68
++#define HAP_PTN_ISENSE_ADC_CTL_REG		0x69
++#define HAP_PTN_VISENSE_ADC_CTL_MASK		GENMASK(7, 0)
++
++#define HAP_PTN_VGAIN_ERR_COMP_LSB		0xF1
++#define HAP_PTN_IGAIN_ERR_COMP_LSB		0xF3
++
++/* register in HBOOST module */
++#define HAP_BOOST_REVISION1			0x00
++#define HAP_BOOST_REVISION2			0x01
++#define HAP_BOOST_V0P0				0x0000
++#define HAP_BOOST_V0P1				0x0001
++#define HAP_BOOST_V0P2				0x0002
++
++#define HAP_BOOST_STATUS4_REG			0x0B
++#define BOOST_DTEST1_STATUS_BIT			BIT(0)
++
++#define HAP_BOOST_HW_CTRL_FOLLOW_REG		0x41
++#define FOLLOW_HW_EN_BIT			BIT(7)
++#define FOLLOW_HW_CCM_BIT			BIT(6)
++#define FOLLOW_HW_VSET_BIT			BIT(5)
++
++#define HAP_BOOST_VREG_EN_REG			0x46
++#define VREG_EN_BIT				BIT(7)
++
++#define HAP_BOOST_CLAMP_REG			0x70
++#define CLAMP_5V_BIT				BIT(0)
++
++/* haptics SDAM registers offset definition */
++#define HAP_STATUS_DATA_MSB_SDAM_OFFSET		0x46
++#define HAP_AUTO_BRAKE_CAL_VMAX_OFFSET		0x4B
++#define HAP_AUTO_BRAKE_CAL_PTRN1_CFG0_OFFSET	0x4C
++#define HAP_AUTO_BRAKE_CAL_PTRN1_LSB0_OFFSET	0x52
++#define HAP_LRA_PTRN1_TLRA_LSB_OFFSET		0x64
++#define HAP_LRA_PTRN1_TLRA_MSB_OFFSET		0x65
++#define HAP_LRA_NOMINAL_OHM_SDAM_OFFSET		0x75
++#define HAP_LRA_DETECTED_OHM_SDAM_OFFSET	0x76
++#define HAP_AUTO_BRAKE_CAL_DONE_OFFSET		0x7E
++
++#define AUTO_BRAKE_CAL_DONE			0x80
++
++#define PBS_ARG_REG				0x42
++#define PBS_TRIG_SET_REG			0xE5
++#define PBS_TRIG_CLR_REG			0xE6
++#define PBS_TRIG_SET_VAL			0x1
++#define PBS_TRIG_CLR_VAL			0x1
++
++/*
++ * haptics SDAM register offset definitions for HAP530 that overrides some
++ * definitions above.
++ */
++
++#define HAP_AUTO_BRAKE_CAL_CL_BRAKE_RSET_OFFSET	0x52
++#define HAP_AUTO_BRAKE_CAL_BRAKE_AMP0_OFFSET	0x53
++#define HAP_AUTO_BRAKE_RNAT_DEFAULT_OFFSET	0x61
++#define HAP_AUTO_BRAKE_RCAL_DEFAULT_OFFSET	0x62
++#define HAP_AUTO_BRAKE_T_WIND_MSB_DEF_OFFSET	0x63
++#define HAP_AUTO_BRAKE_T_WIND_LSB_DEF_OFFSET	0x64
++#define HAP_AUTO_BRAKE_T_WIND_STS_MSB_OFFSET	0x6E
++#define HAP_AUTO_BRAKE_T_WIND_STS_LSB_OFFSET	0x6F
++#define HAP_AUTO_BRAKE_RNAT_OFFSET		0x78
++#define HAP_AUTO_BRAKE_RCAL_OFFSET		0x79
++
++/* constant parameters */
++#define SAMPLES_PER_PATTERN			8
++#define BRAKE_SAMPLE_COUNT			8
++#define DEFAULT_ERM_PLAY_RATE_US		5000
++#define MAX_EFFECT_COUNT			64
++#define FIFO_READY_TIMEOUT_MS			1000
++#define CHAR_PER_PATTERN_S			48
++#define CHAR_PER_SAMPLE				8
++#define CHAR_MSG_HEADER				16
++#define CHAR_BRAKE_MODE				24
++#define HW_BRAKE_MAX_CYCLES			16
++#define F_LRA_VARIATION_HZ			5
++#define NON_HBOOST_MAX_VMAX_MV			4000
++#define FIFO_EMPTY_THRESH_RATIO_NUM		45
++#define FIFO_EMPTY_THRESH_RATIO_DEN		100
++/* below definitions are only for HAP525_HV */
++#define MMAP_NUM_BYTES				2048
++#define MMAP_FIFO_MIN_SIZE			640
++#define FIFO_PRGM_INIT_SIZE			320
++
++/* below definitions are only for HAP530_HV */
++#define HAP530_MMAP_NUM_BYTES			8192
++#define VMAX_HDRM_MV_DEFAULT			1500
++
++#define is_between(val, min, max)	\
++	(((min) <= (max)) && ((min) <= (val)) && ((val) <= (max)))
++
++enum hap_status_sel {
++	CAL_TLRA_CL_STS = 0x00,
++	T_WIND_STS,
++	T_WIND_STS_PREV,
++	LAST_GOOD_TLRA_CL_STS,
++	TLRA_CL_ERR_STS,
++	HAP_DRV_STS,
++	RNAT_RCAL_INT,
++	BRAKE_CAL_SCALAR = 0x07,
++	CLAMPED_DUTY_CYCLE_STS = 0x8003,
++	FIFO_REAL_TIME_STS = 0x8005,
++	AUTO_BRAKE_CAL_STS = 0x8006,
++};
++
++enum hap_pbs_type {
++	HAP_VREG_ON_PBS = 0x1,
++	HAP_VREG_OFF_PBS = 0x2,
++	HAP_AUTO_BRAKE_CAL_PBS = 0x3,
++	HAP_HBST_OVP_TRIM_PBS = 0x10,
++};
++
++enum drv_sig_shape {
++	WF_SQUARE,
++	WF_SINE,
++	WF_NO_MODULATION,
++	WF_RESERVED,
++};
++
++enum brake_mode {
++	OL_BRAKE,
++	CL_BRAKE,
++	PREDICT_BRAKE,
++	AUTO_BRAKE,
++};
++
++enum brake_sine_gain {
++	BRAKE_SINE_GAIN_X1,
++	BRAKE_SINE_GAIN_X2,
++	BRAKE_SINE_GAIN_X4,
++	BRAKE_SINE_GAIN_X8,
++};
++
++enum pat_mem_sel {
++	PAT1_MEM,
++	PAT2_MEM,
++	PAT3_MEM,
++	PAT4_MEM,
++	PAT_MEM_MAX,
++};
++
++enum pattern_src {
++	FIFO,
++	DIRECT_PLAY,
++	PATTERN1,
++	PATTERN2,
++	SWR,
++	PATTERN_MEM,
++	SRC_RESERVED,
++};
++
++enum s_period {
++	T_LRA = 0,
++	T_LRA_DIV_2,
++	T_LRA_DIV_4,
++	T_LRA_DIV_8,
++	T_LRA_X_2,
++	T_LRA_X_4,
++	T_LRA_X_8,
++	T_RESERVED,
++	/* F_xKHZ definitions are for FIFO only */
++	F_8KHZ,
++	F_16KHZ,
++	F_24KHZ,
++	F_32KHZ,
++	F_44P1KHZ,
++	F_48KHZ,
++	F_RESERVED,
++};
++
++enum custom_effect_param {
++	CUSTOM_DATA_EFFECT_IDX,
++	CUSTOM_DATA_TIMEOUT_SEC_IDX,
++	CUSTOM_DATA_TIMEOUT_MSEC_IDX,
++	CUSTOM_DATA_LEN,
++};
++
++/*
++ * HW type of the haptics module, the type value follows the
++ * revision value of the HAPTICS_CFG/HAPTICS_PATTERN modules
++ */
++enum haptics_hw_type {
++	HAP520 = 0x2,  /* PM8350B */
++	HAP520_MV = 0x3,  /* PM5100 */
++	HAP525_HV = 0x4,  /* PM8550B */
++	HAP530_HV = 0x5,  /* PMIH010X */
++};
++
++enum wa_flags {
++	TOGGLE_CAL_RC_CLK = BIT(0),
++	SW_CTRL_HBST = BIT(1),
++	SLEEP_CLK_32K_SCALE = BIT(2),
++	TOGGLE_EN_TO_FLUSH_FIFO = BIT(3),
++	RECOVER_SWR_SLAVE = BIT(4),
++	TOGGLE_MODULE_EN = BIT(5),
++	EN_RUNTIME_PM = BIT(6),
++	VISENSE_RECOVERY_EN = BIT(7),
++	IGNORE_SWR_IN_SPMI_PLAY = BIT(8),
++	DISCHARGE_VNDRV_LDO = BIT(9),
++	RESTORE_VMAX_HDRM_1P5V = BIT(10),
++};
++
++static const char * const src_str[] = {
++	"FIFO",
++	"DIRECT_PLAY",
++	"PATTERN1",
++	"PATTERN2",
++	"SWR",
++	"PATTERN_MEM",
++	"reserved",
++};
++
++static const char * const brake_str[] = {
++	"open-loop-brake",
++	"close-loop-brake",
++	"predictive-brake",
++	"auto-brake",
++};
++
++static const char * const period_str[] = {
++	"T_LRA",
++	"T_LRA_DIV_2",
++	"T_LRA_DIV_4",
++	"T_LRA_DIV_8",
++	"T_LRA_X_2",
++	"T_LRA_X_4",
++	"T_LRA_X_8",
++	"reserved_1",
++	"F_8KHZ",
++	"F_16HKZ",
++	"F_24KHZ",
++	"F_32KHZ",
++	"F_44P1KHZ",
++	"F_48KHZ",
++	"reserved_2",
++};
++
++struct pattern_s {
++	u16			amplitude;
++	enum s_period		period;
++	bool			f_lra_x2;
++};
++
++struct pattern_cfg {
++	struct pattern_s	samples[SAMPLES_PER_PATTERN];
++	u32			play_rate_us;
++	u32			play_length_us;
++	bool			preload;
++};
++
++struct fifo_cfg {
++	u8			*samples;
++	u32			num_s;
++	enum s_period		period_per_s;
++	u32			play_length_us;
++	bool			preload;
++};
++
++struct brake_cfg {
++	u8			samples[BRAKE_SAMPLE_COUNT];
++	enum brake_mode		mode;
++	enum drv_sig_shape	brake_wf;
++	enum brake_sine_gain	sine_gain;
++	u32			play_length_us;
++	bool			disabled;
++};
++
++struct haptics_effect {
++	struct pattern_cfg	*pattern;
++	struct fifo_cfg		*fifo;
++	struct brake_cfg	*brake;
++	struct list_head	node;
++	u32			id;
++	u32			vmax_mv;
++	u32			t_lra_us;
++	enum pattern_src	src;
++	u32			pat_sel;
++	bool			auto_res_disable;
++};
++
++struct mmap_partition {
++	u32	max_size;
++	u32	length;
++	u32	start_addr;
++	bool	in_use;
++};
++
++struct mmap_hw_info {
++	u32	memory_size;
++	u32	pat_mem_step;
++	u32	pat_mem_play_step;
++	u8	pat_mem_play_len_msb;
++	u32	fifo_mem_step;
++	u8	fifo_mem_mask;
++};
++
++struct haptics_mmap {
++	struct mmap_partition	fifo_mmap;
++	struct mmap_partition	*pat_sel_mmap;
++	struct mmap_hw_info	hw_info;
++	enum s_period		pat_play_rate;
++};
++
++/**
++ * struct fifo_play_status - Data used for recording the FIFO playing status
++ *
++ * @samples_written:	The number of the samples that has been written into
++ *			FIFO memory.
++ * @written_done:	The flag to indicate if all of the FIFO samples has
++ *			been written to the FIFO memory.
++ * @is_busy:		The flag to indicate if it's in the middle of FIFO
++ *			playing.
++ * @cancelled:		The flag to indicate if FIFO playing is cancelled due
++ *			to a stopping command arrived in the middle of playing.
++ */
++struct fifo_play_status {
++	u32			samples_written;
++	atomic_t		written_done;
++	atomic_t		is_busy;
++	atomic_t		cancelled;
++};
++
++struct haptics_play_info {
++	struct haptics_effect	*effect;
++	struct brake_cfg	*brake;
++	struct fifo_play_status	fifo_status;
++	struct mutex		lock;
++	atomic_t		gain;
++	u32			vmax_mv;
++	u32			length_us;
++	enum pattern_src	pattern_src;
++	bool			in_calibration;
++};
++
++struct haptics_hw_config {
++	struct brake_cfg	brake;
++	u32			vmax_mv;
++	u32			t_lra_us;
++	u32			cl_t_lra_us;
++	u32			lra_min_mohms;
++	u32			lra_max_mohms;
++	u32			lra_open_mohms;
++	u32			lra_measured_mohms;
++	u32			preload_effect;
++	u32			fifo_empty_thresh;
++	u16			rc_clk_cal_count;
++	enum drv_sig_shape	drv_wf;
++	bool			is_erm;
++	bool			measure_lra_impedance;
++	bool			sw_cmd_freq_det;
++	bool			hbst_ovp_trim;
++};
++
++struct custom_fifo_data {
++	u32	idx;
++	u32	length;
++	u32	play_rate_hz;
++	u8	*data;
++};
++
++struct fifo_hw_info {
++	u32	max_fifo_samples;
++	u32	fifo_empty_threshold;
++	u32	fifo_threshold_per_bit;
++	u8	fifo_empty_threshold_mask;
++};
++
++struct haptics_chip {
++	struct device			*dev;
++	struct regmap			*regmap;
++	struct input_dev		*input_dev;
++	struct haptics_hw_config	config;
++	struct haptics_effect		*effects;
++	struct haptics_effect		*primitives;
++	struct haptics_effect		*custom_effect;
++	struct haptics_play_info	play;
++	struct haptics_mmap		mmap;
++	const struct fifo_hw_info	*fifo_info;
++	struct dentry			*debugfs_dir;
++	struct delayed_work		stop_work;
++	struct regulator_dev		*swr_slave_rdev;
++	struct nvmem_cell		*cl_brake_nvmem;
++	struct nvmem_device		*hap_cfg_nvmem;
++	struct device_node		*pbs_node;
++	struct class			hap_class;
++	struct regulator		*hpwr_vreg;
++	struct hrtimer			hbst_off_timer;
++	struct notifier_block		hboost_nb;
++	struct notifier_block		lpass_ssr_nb;
++	struct mutex			vmax_lock;
++	struct work_struct		set_gain_work;
++	struct list_head		mmap_effect_list;
++	int				fifo_empty_irq;
++	u32				hpwr_voltage_mv;
++	u32				effects_count;
++	u32				primitives_count;
++	u32				mmap_effect_count;
++	u32				cfg_addr_base;
++	u32				ptn_addr_base;
++	u32				hbst_addr_base;
++	u32				clamped_vmax_mv;
++	u32				wa_flags;
++	u32				primitive_duration;
++	u16				cfg_revision;
++	u16				ptn_revision;
++	u8				hpwr_intf_ctl;
++	u16				hbst_revision;
++	u16				max_vmax_mv;
++	enum haptics_hw_type		hw_type;
++	bool				fifo_empty_irq_en;
++	bool				swr_slave_enabled;
++	bool				clamp_at_5v;
++	bool				hpwr_vreg_enabled;
++	bool				is_hv_haptics;
++	bool				hboost_enabled;
++	bool				visense_enabled;
++	bool				visense_hs_disabled;
++	ktime_t				pattern_start_time;
++	void				*lpass_ssr_handle;
++};
++
++struct haptics_reg_info {
++	u8 addr;
++	u8 val;
++};
++
++static const struct fifo_hw_info hap520_fifo = {
++	.max_fifo_samples	= 640,
++	.fifo_empty_threshold	= 280,
++	.fifo_threshold_per_bit = 40,
++	.fifo_empty_threshold_mask = HAP520_EMPTY_THRESH_MASK,
++};
++
++static const struct fifo_hw_info hap520_mv_fifo = {
++	.max_fifo_samples	= 1024,
++	.fifo_empty_threshold	= 288,
++	.fifo_threshold_per_bit = 32,
++	.fifo_empty_threshold_mask = HAP520_MV_EMPTY_THRESH_MASK,
++};
++
++static const struct fifo_hw_info hap525_fifo = {
++	.max_fifo_samples	= 2048,
++	.fifo_empty_threshold	= 288,
++	.fifo_threshold_per_bit	= 32,
++	.fifo_empty_threshold_mask = HAP525_EMPTY_THRESH_MASK,
++};
++
++static const struct fifo_hw_info hap530_fifo = {
++	.max_fifo_samples	= 8912,
++	.fifo_empty_threshold	= 320,
++	.fifo_threshold_per_bit	= 64,
++	.fifo_empty_threshold_mask = HAP530_EMPTY_THRESH_MASK,
++};
++
++static struct haptics_chip *phapchip;
++
++bool qcom_haptics_vi_sense_is_enabled(void)
++{
++	if (!phapchip)
++		return false;
++
++	return phapchip->visense_enabled;
++}
++EXPORT_SYMBOL_GPL(qcom_haptics_vi_sense_is_enabled);
++
++static inline int get_max_fifo_samples(struct haptics_chip *chip)
++{
++	return chip->mmap.fifo_mmap.length ?
++		chip->mmap.fifo_mmap.length : chip->fifo_info->max_fifo_samples;
++}
++
++static bool is_haptics_external_powered(struct haptics_chip *chip)
++{
++	/* SW based explicit vote */
++	if (chip->hpwr_vreg)
++		return true;
++
++	/* Implicit voting by HW */
++	if (chip->hw_type == HAP520_MV)
++		return true;
++
++	/* Powered by HBOOST */
++	return false;
++}
++
++static int haptics_read(struct haptics_chip *chip,
++		u16 base, u8 offset, u8 *val, u32 length)
++{
++	int rc = 0;
++	u16 addr = base + offset;
++
++	rc = regmap_bulk_read(chip->regmap, addr, val, length);
++	if (rc < 0) {
++		dev_err(chip->dev, "read addr %#x failed, rc=%d\n", addr, rc);
++	}
++
++	return rc;
++}
++
++static int haptics_write(struct haptics_chip *chip,
++		u16 base, u8 offset, u8 *val, u32 length)
++{
++	int rc = 0;
++	u16 addr = base + offset;
++
++	rc = regmap_bulk_write(chip->regmap, addr, val, length);
++	if (rc < 0) {
++		dev_err(chip->dev, "write addr %#x failed, rc=%d\n", addr, rc);
++	}
++
++	return rc;
++}
++
++static int haptics_masked_write(struct haptics_chip *chip,
++		u16 base, u8 offset, u8 mask, u8 val)
++{
++	int rc = 0;
++	u16 addr = base + offset;
++
++	regmap_update_bits(chip->regmap, addr, mask, val);
++	if (rc < 0)
++		dev_err(chip->dev, "update addr %#x failed, rc=%d\n", addr, rc);
++
++	return rc;
++}
++
++static void __dump_effects(struct haptics_chip *chip,
++				struct haptics_effect *effects, int effects_count)
++{
++	struct haptics_effect *effect;
++	struct pattern_s *sample;
++	char *str;
++	u32 size, pos;
++	int i, j;
++
++	for (i = 0; i < effects_count; i++) {
++		effect = &effects[i];
++		if (!effect)
++			return;
++
++		dev_dbg(chip->dev, "effect %d\n", effect->id);
++		dev_dbg(chip->dev, "vmax_mv = %d\n", effect->vmax_mv);
++		if (effect->pattern) {
++			for (j = 0; j < SAMPLES_PER_PATTERN; j++) {
++				sample = &effect->pattern->samples[j];
++				dev_dbg(chip->dev, "pattern = %d, period = %s, f_lra_x2 = %d\n",
++						sample->amplitude,
++						period_str[sample->period],
++						sample->f_lra_x2);
++			}
++
++			dev_dbg(chip->dev, "pattern play_rate_us = %d\n",
++					effect->pattern->play_rate_us);
++			dev_dbg(chip->dev, "pattern play_length_us = %d\n",
++					effect->pattern->play_length_us);
++			dev_dbg(chip->dev, "pattern preload = %d\n",
++					effect->pattern->preload);
++		}
++
++		if (effect->fifo) {
++			size = effect->fifo->num_s * CHAR_PER_SAMPLE
++							+ CHAR_MSG_HEADER;
++			str = kzalloc(size, GFP_KERNEL);
++			if (str == NULL) {
++				return;
++			}
++			pos = 0;
++			pos += scnprintf(str, size, "%s", "FIFO data: ");
++			for (j = 0; j < effect->fifo->num_s; j++)
++				pos += scnprintf(str + pos, size - pos, "%d ",
++						(s8)effect->fifo->samples[j]);
++
++			dev_dbg(chip->dev, "%s\n", str);
++			kfree(str);
++			dev_dbg(chip->dev, "FIFO data preload: %d, play rate: %s, play length: %uus\n",
++					effect->fifo->preload,
++					period_str[effect->fifo->period_per_s],
++					effect->fifo->play_length_us);
++		}
++
++		if (effect->brake && !effect->brake->disabled) {
++			size = BRAKE_SAMPLE_COUNT * CHAR_PER_SAMPLE
++						+ CHAR_MSG_HEADER;
++			str = kzalloc(size, GFP_KERNEL);
++			if (str == NULL) {
++				return;
++			}
++
++			pos = 0;
++			pos += scnprintf(str, size, "%s", "brake pattern: ");
++			for (j = 0; j < BRAKE_SAMPLE_COUNT; j++)
++				pos += scnprintf(str + pos, size - pos, "%#x ",
++						effect->brake->samples[j]);
++
++			dev_dbg(chip->dev, "%s\n", str);
++			kfree(str);
++			dev_dbg(chip->dev, "brake mode: %s\n",
++					brake_str[effect->brake->mode]);
++			dev_dbg(chip->dev, "brake play length: %dus\n",
++					effect->brake->play_length_us);
++		}
++
++		dev_dbg(chip->dev, "pattern src: %s\n", src_str[effect->src]);
++		dev_dbg(chip->dev, "auto resonance %s\n",
++				effect->auto_res_disable ?
++				"disabled" : "enabled");
++	}
++}
++
++static void verify_brake_samples(struct brake_cfg *brake)
++{
++	int i;
++
++	if (brake->mode == PREDICT_BRAKE || brake->mode == AUTO_BRAKE)
++		return;
++
++	for (i = BRAKE_SAMPLE_COUNT - 1; i > 0; i--) {
++		if (brake->samples[i] != 0) {
++			brake->disabled = false;
++			return;
++		}
++	}
++
++	brake->disabled = true;
++}
++
++static int get_pattern_play_length_us(struct pattern_cfg *pattern)
++{
++	int i = SAMPLES_PER_PATTERN - 1, j;
++	u32 us_per_sample, total_length_us = 0;
++
++	if (!pattern)
++		return -EINVAL;
++
++	for (; i >= 0; i--)
++		if (pattern->samples[i].amplitude != 0)
++			break;
++
++	for (j = 0; j <= i; j++) {
++		us_per_sample = pattern->play_rate_us;
++		switch (pattern->samples[j].period) {
++		case T_LRA:
++			break;
++		case T_LRA_DIV_2:
++			us_per_sample /= 2;
++			break;
++		case T_LRA_DIV_4:
++			us_per_sample /= 4;
++			break;
++		case T_LRA_DIV_8:
++			us_per_sample /= 8;
++			break;
++		case T_LRA_X_2:
++			us_per_sample *= 2;
++			break;
++		case T_LRA_X_4:
++			us_per_sample *= 4;
++			break;
++		case T_LRA_X_8:
++			us_per_sample *= 8;
++			break;
++		default:
++			return -EINVAL;
++		}
++
++		if (pattern->samples[j].f_lra_x2)
++			us_per_sample /= 2;
++
++		total_length_us += us_per_sample;
++	}
++
++	return total_length_us;
++}
++
++static int get_fifo_play_length_us(struct fifo_cfg *fifo, u32 t_lra_us)
++{
++	u32 length_us;
++	int i;
++
++	if (!fifo)
++		return -EINVAL;
++
++	for (i = fifo->num_s - 1; i > 0; i--)
++		if (fifo->samples[i] != 0)
++			break;
++
++	length_us = (i + 1) * t_lra_us;
++	switch (fifo->period_per_s) {
++	case T_LRA:
++		break;
++	case T_LRA_DIV_2:
++		length_us /= 2;
++		break;
++	case T_LRA_DIV_4:
++		length_us /= 4;
++		break;
++	case T_LRA_DIV_8:
++		length_us /= 8;
++		break;
++	case T_LRA_X_2:
++		length_us *= 2;
++		break;
++	case T_LRA_X_4:
++		length_us *= 4;
++		break;
++	case T_LRA_X_8:
++		length_us *= 8;
++		break;
++	case F_8KHZ:
++		length_us = 1000 * fifo->num_s / 8;
++		break;
++	case F_16KHZ:
++		length_us = 1000 * fifo->num_s / 16;
++		break;
++	case F_24KHZ:
++		length_us = 1000 * fifo->num_s / 24;
++		break;
++	case F_32KHZ:
++		length_us = 1000 * fifo->num_s / 32;
++		break;
++	case F_44P1KHZ:
++		length_us = 10000 * fifo->num_s / 441;
++		break;
++	case F_48KHZ:
++		length_us = 1000 * fifo->num_s / 48;
++		break;
++	default:
++		length_us = -EINVAL;
++		break;
++	}
++
++	return length_us;
++}
++
++static int get_brake_play_length_us(struct brake_cfg *brake, u32 t_lra_us)
++{
++	int i = BRAKE_SAMPLE_COUNT - 1;
++
++	if (!brake || brake->disabled)
++		return 0;
++
++	if (brake->mode == PREDICT_BRAKE || brake->mode == AUTO_BRAKE)
++		return HW_BRAKE_MAX_CYCLES * t_lra_us / 2;
++
++	for (; i >= 0; i--)
++		if (brake->samples[i] != 0)
++			break;
++
++	return t_lra_us * (i + 1) / 2;
++}
++
++static int haptics_get_status_data(struct haptics_chip *chip,
++			enum hap_status_sel sel, u8 data[])
++{
++	int rc;
++	u8 mod_sel_val[2];
++	const char *hap_status_name[BRAKE_CAL_SCALAR + 1] = {
++		"CAL_TLRA_CL_STS",
++		"T_WIND_STS",
++		"T_WIND_STS_PREV",
++		"LAST_GOOD_TLRA_CL_STS",
++		"TLRA_CL_ERR_STS",
++		"HAP_DRV_STS",
++		"RNAT_RCAL_INT",
++		"BRAKE_CAL_SCALAR",
++	};
++	const char *name;
++
++	mod_sel_val[0] = sel & 0xff;
++	mod_sel_val[1] = (sel >> 8) & 0xff;
++	rc = haptics_write(chip, chip->cfg_addr_base,
++			HAP_CFG_MOD_STATUS_XT_REG, &mod_sel_val[1], 1);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_write(chip, chip->cfg_addr_base,
++			HAP_CFG_MOD_STATUS_SEL_REG, mod_sel_val, 1);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_read(chip, chip->cfg_addr_base,
++			HAP_CFG_STATUS_DATA_MSB_REG, data, 2);
++	if (rc < 0)
++		return rc;
++
++	if (sel <= BRAKE_CAL_SCALAR)
++		name = hap_status_name[sel];
++	else if (sel == CLAMPED_DUTY_CYCLE_STS)
++		name = "CLAMPED_DUTY_CYCLE_STS";
++	else if (sel == FIFO_REAL_TIME_STS)
++		name = "FIFO_REAL_TIME_STS";
++	else if (sel == AUTO_BRAKE_CAL_STS)
++		name = "AUTO_BRAKE_CAL_STS";
++
++	trace_qcom_haptics_status(name, data[0], data[1]);
++	return 0;
++}
++
++#define AUTO_CAL_CLK_SCALE_DEN		1000
++#define AUTO_CAL_CLK_SCALE_NUM		1024
++static int haptics_adjust_lra_period(struct haptics_chip *chip, u32 *t_lra_us)
++{
++	int rc;
++	u8 val;
++
++	if (chip->wa_flags & SLEEP_CLK_32K_SCALE) {
++		rc = haptics_read(chip, chip->cfg_addr_base,
++				HAP_CFG_CAL_EN_REG, &val, 1);
++		if (rc < 0)
++			return rc;
++
++		if ((val & CAL_RC_CLK_MASK) ==
++				(CAL_RC_CLK_AUTO_VAL << CAL_RC_CLK_SHIFT))
++			*t_lra_us = div_u64((u64)(*t_lra_us) * AUTO_CAL_CLK_SCALE_NUM,
++					AUTO_CAL_CLK_SCALE_DEN);
++	}
++
++	return 0;
++}
++
++/* constant definitions for calculating TLRA */
++#define TLRA_AUTO_RES_ERR_NO_CAL_STEP_PSEC	1667000
++#define TLRA_AUTO_RES_NO_CAL_STEP_PSEC		3333000
++#define TLRA_AUTO_RES_ERR_AUTO_CAL_STEP_PSEC	\
++	((chip->wa_flags & SLEEP_CLK_32K_SCALE) ? 1627700 : 1666667)
++#define TLRA_AUTO_RES_AUTO_CAL_STEP_PSEC	\
++	((chip->wa_flags & SLEEP_CLK_32K_SCALE) ? 813850 : 833333)
++#define SLEEP_CLK_CAL_DIVIDER			\
++	((chip->wa_flags & SLEEP_CLK_32K_SCALE) ? 600 : 586)
++#define CL_TLRA_ERROR_RANGE_PCT			20
++
++static int haptics_get_closeloop_lra_period(
++		struct haptics_chip *chip, bool in_boot)
++{
++	struct haptics_hw_config *config = &chip->config;
++	u16 cal_tlra_cl_sts, tlra_cl_err_sts, tlra_ol, last_good_tlra_cl_sts;
++	u8 val[2], rc_clk_cal;
++	bool auto_res_done;
++	u64 tmp;
++	int rc;
++
++	/* read RC_CLK_CAL enabling mode */
++	rc = haptics_read(chip, chip->cfg_addr_base,
++			HAP_CFG_CAL_EN_REG, val, 1);
++	if (rc < 0)
++		return rc;
++
++	rc_clk_cal = ((val[0] & CAL_RC_CLK_MASK) >> CAL_RC_CLK_SHIFT);
++	/* read auto resonance calibration result */
++	if (in_boot && ((chip->hw_type == HAP520) || (chip->hw_type == HAP520_MV))) {
++		if (chip->hap_cfg_nvmem == NULL) {
++			dev_dbg(chip->dev, "nvmem device for hap_cfg is not defined\n");
++			return -EINVAL;
++		}
++
++		rc = nvmem_device_read(chip->hap_cfg_nvmem,
++				HAP_STATUS_DATA_MSB_SDAM_OFFSET, 2, val);
++		if (rc < 0) {
++			dev_err(chip->dev, "read SDAM %#x failed, rc=%d\n",
++					HAP_STATUS_DATA_MSB_SDAM_OFFSET, rc);
++			return rc;
++		}
++	} else {
++		rc = haptics_get_status_data(chip, CAL_TLRA_CL_STS, val);
++		if (rc < 0)
++			return rc;
++	}
++
++	auto_res_done = !!(val[0] & AUTO_RES_CAL_DONE_BIT);
++
++	cal_tlra_cl_sts =
++		((val[0] & CAL_TLRA_CL_STS_MSB_MASK) << 8) | val[1];
++
++	/* read auto resonance calibration error status */
++	rc = haptics_get_status_data(chip, TLRA_CL_ERR_STS, val);
++	if (rc < 0)
++		return rc;
++
++	tlra_cl_err_sts =
++		((val[0] & TLRA_CL_ERR_MSB_MASK) << 8) | val[1];
++
++	dev_dbg(chip->dev, "rc_clk_cal = %u, auto_res_done = %d\n",
++			rc_clk_cal, auto_res_done);
++
++	if (rc_clk_cal == CAL_RC_CLK_DISABLED_VAL && !auto_res_done) {
++		/* TLRA_CL_ERR(us) = TLRA_CL_ERR_STS * 1.667 us */
++		tmp = tlra_cl_err_sts * TLRA_AUTO_RES_ERR_NO_CAL_STEP_PSEC;
++		dev_dbg(chip->dev, "tlra_cl_err_sts = %#x\n", tlra_cl_err_sts);
++		config->cl_t_lra_us = div_u64(tmp, 1000000);
++	} else if (rc_clk_cal == CAL_RC_CLK_DISABLED_VAL && auto_res_done) {
++		/*
++		 * CAL_TLRA_CL_STS_NO_CAL = CAL_TLRA_CL_STS
++		 * TLRA_AUTO_RES(us) = CAL_TLRA_CL_STS_NO_CAL * 3.333 us
++		 */
++		tmp = cal_tlra_cl_sts * TLRA_AUTO_RES_NO_CAL_STEP_PSEC;
++		dev_dbg(chip->dev, "cal_tlra_cl_sts = %#x\n", cal_tlra_cl_sts);
++		config->cl_t_lra_us = div_u64(tmp, 1000000);
++	} else if (rc_clk_cal == CAL_RC_CLK_AUTO_VAL && !auto_res_done) {
++		/*
++		 * CAL_TLRA_OL = CAL_TLRA_CL_STS;
++		 * TLRA_CL_ERR(us) = TLRA_CL_ERR_STS *
++		 *     (TLRA_OL / CAL_TLRA_OL) * TLRA_AUTO_RES_ERR_AUTO_CAL_STEP_US
++		 */
++
++		/* read the TLRA_OL setting */
++		rc = haptics_read(chip, chip->cfg_addr_base,
++				HAP_CFG_TLRA_OL_HIGH_REG, val, 2);
++		if (rc < 0)
++			return rc;
++
++		tlra_ol = (val[0] & TLRA_OL_MSB_MASK) << 8 | val[1];
++		dev_dbg(chip->dev, "tlra_ol = %#x, tlra_cl_err_sts = %#x, cal_tlra_cl_sts = %#x\n",
++				tlra_ol, tlra_cl_err_sts, cal_tlra_cl_sts);
++
++		tmp = tlra_cl_err_sts * tlra_ol;
++		tmp *= TLRA_AUTO_RES_ERR_AUTO_CAL_STEP_PSEC;
++		tmp = div_u64(tmp, cal_tlra_cl_sts);
++		config->cl_t_lra_us = div_u64(tmp, 1000000);
++
++		/* calculate RC_CLK_CAL_COUNT */
++		if (!config->t_lra_us || !config->cl_t_lra_us)
++			return -EINVAL;
++		/*
++		 * RC_CLK_CAL_COUNT = SLEEP_CLK_CAL_DIVIDER * (CAL_TLRA_OL / TLRA_OL)
++		 *		* (SLEEP_CLK_CAL_DIVIDER / 586) * (CL_T_TLRA_US / OL_T_LRA_US)
++		 */
++		tmp = SLEEP_CLK_CAL_DIVIDER * SLEEP_CLK_CAL_DIVIDER;
++		tmp *= cal_tlra_cl_sts * config->cl_t_lra_us;
++		tmp = div_u64(tmp, tlra_ol);
++		tmp = div_u64(tmp, 586);
++		config->rc_clk_cal_count = div_u64(tmp, config->t_lra_us);
++	} else if (rc_clk_cal == CAL_RC_CLK_AUTO_VAL && auto_res_done) {
++		/*
++		 * CAL_TLRA_CL_STS_W_CAL = CAL_TLRA_CL_STS;
++		 * TLRA_AUTO_RES(us) = LAST_GOOD_TLRA_CL_STS *
++		 *      TLRA_AUTO_RES_AUTO_CAL_STEP_US *
++		 *     (LAST_GOOD_TLRA_CL_STS / CAL_TLRA_CL_STS_AUTO_CAL)
++		 */
++
++		/* read LAST_GOOD_TLRA_CL_STS */
++		rc = haptics_get_status_data(chip, LAST_GOOD_TLRA_CL_STS, val);
++		if (rc < 0)
++			return rc;
++
++		last_good_tlra_cl_sts =
++			((val[0] & LAST_GOOD_TLRA_CL_MSB_MASK) << 8) | val[1];
++
++		dev_dbg(chip->dev, "last_good_tlra_cl_sts = %#x, cal_tlra_cl_sts = %#x\n",
++				last_good_tlra_cl_sts, cal_tlra_cl_sts);
++
++		tmp = last_good_tlra_cl_sts * last_good_tlra_cl_sts;
++		tmp *= TLRA_AUTO_RES_AUTO_CAL_STEP_PSEC;
++		tmp = div_u64(tmp, cal_tlra_cl_sts);
++		config->cl_t_lra_us = div_u64(tmp, 1000000);
++
++		/* calculate RC_CLK_CAL_COUNT */
++		if (!config->t_lra_us || !config->cl_t_lra_us)
++			return -EINVAL;
++
++		/*
++		 * RC_CLK_CAL_COUNT =
++		 *	SLEEP_CLK_CAL_DIVIDER * (CAL_TLRA_CL_STS_AUTO_CAL / LAST_GOOD_TLRA_CL_STS)
++		 *		* (SLEEP_CLK_CAL_DIVIDER / 293) * (CL_T_TLRA_US / OL_T_LRA_US)
++		 */
++		tmp = SLEEP_CLK_CAL_DIVIDER * SLEEP_CLK_CAL_DIVIDER;
++		tmp *= cal_tlra_cl_sts * config->cl_t_lra_us;
++		tmp = div_u64(tmp, last_good_tlra_cl_sts);
++		tmp = div_u64(tmp, 293);
++		config->rc_clk_cal_count = div_u64(tmp, config->t_lra_us);
++	} else {
++		dev_err(chip->dev, "Can't get close-loop LRA period in rc_clk_cal mode %u\n",
++				rc_clk_cal);
++		return -EINVAL;
++	}
++
++	if ((abs(config->t_lra_us - config->cl_t_lra_us) * 100 / config->t_lra_us) >
++			CL_TLRA_ERROR_RANGE_PCT) {
++		dev_warn(chip->dev, "The calibrated period (%d us) has large variation, use open-loop LRA period (%d us) instead\n",
++				config->cl_t_lra_us, config->t_lra_us);
++	}
++
++	dev_dbg(chip->dev, "OL_TLRA %u us, CL_TLRA %u us, RC_CLK_CAL_COUNT %#x\n",
++		chip->config.t_lra_us, chip->config.cl_t_lra_us,
++		chip->config.rc_clk_cal_count);
++	return 0;
++}
++
++static int haptics_module_enable(struct haptics_chip *chip, bool enable)
++{
++	u8 val;
++	int rc;
++	unsigned int delay_us = 100;
++
++	/*
++	 * Increase the delay to 500us for HAP530_HV to remove the potential
++	 * overshoot on VNDRV when there is a rapid haptics module enable and
++	 * disable sequence.
++	 */
++	if (chip->hw_type >= HAP530_HV)
++		delay_us = 500;
++
++	/*
++	 * Delay for a while before enabling haptics module to avoid
++	 * it's mistakenly blocked by HW debounce logic.
++	 */
++	if (enable)
++		usleep_range(delay_us, delay_us + 1);
++
++	val = enable ? HAPTICS_EN_BIT : 0;
++	rc = haptics_write(chip, chip->cfg_addr_base,
++		HAP_CFG_EN_CTL_REG, &val, 1);
++	if (rc < 0)
++		return rc;
++
++	dev_dbg(chip->dev, "haptics module %s\n",
++		enable ? "enabled" : "disabled");
++	return 0;
++}
++
++static int haptics_toggle_module_enable(struct haptics_chip *chip)
++{
++	int rc;
++
++	/*
++	 * Updating HAPTICS_EN would vote hBoost enable status. Add 100us
++	 * delay before updating HAPTICS_EN for hBoost to have enough time
++	 * to handle its power transition.
++	 */
++	usleep_range(100, 101);
++	rc = haptics_module_enable(chip, false);
++	if (rc < 0)
++		return rc;
++
++	return haptics_module_enable(chip, true);
++}
++
++#define VMAX_SETTLE_COUNT	10
++static int haptics_check_hpwr_status(struct haptics_chip *chip)
++{
++	int i, rc = 0;
++	u8 val;
++
++	/* Apply the HPWR_READY check for haptics module revision HAP525_HV and later. */
++	if (chip->hw_type < HAP525_HV)
++		return 0;
++
++	for (i = 0; i < VMAX_SETTLE_COUNT; i++) {
++		rc = haptics_read(chip, chip->cfg_addr_base, HAP_CFG_HPWR_INTF_REG, &val, 1);
++		if (rc < 0)
++			break;
++
++		val &= HPWR_INTF_STATUS_MASK;
++
++		if (chip->wa_flags & DISCHARGE_VNDRV_LDO) {
++			/*
++			 * Haptics VNDRV LDO has already been disabled when HPWR_DISABLED
++			 * status is set, delay 500us here to discharge the VNDRV voltage.
++			 */
++			if ((val == HPWR_DISABLED) || (val == HPWR_READY)) {
++				udelay(500);
++				break;
++			}
++		} else {
++			if ((val == HPWR_DISABLED) || (val == HPWR_READY))
++				break;
++		}
++
++		udelay(1000);
++	}
++
++	if (!rc && i == VMAX_SETTLE_COUNT) {
++		haptics_toggle_module_enable(chip);
++		dev_err(chip->dev, "set Vmax failed, toggle HAPTICS_EN to restore HW status\n");
++		rc = -EBUSY;
++	}
++
++	return rc;
++}
++
++static int haptics_get_lra_nominal_impedance(struct haptics_chip *chip, u32 *nominal_ohm)
++{
++	u8 val;
++	int rc;
++
++	if (!chip->hap_cfg_nvmem) {
++		dev_dbg(chip->dev, "nvmem is not defined, couldn't get defined LRA nominal impedance\n");
++		return -EINVAL;
++	}
++
++	rc = nvmem_device_read(chip->hap_cfg_nvmem,
++			HAP_LRA_NOMINAL_OHM_SDAM_OFFSET, 1, &val);
++	if (rc > 0) {
++		*nominal_ohm = (val * LRA_IMPEDANCE_MOHMS_LSB) / 1000;
++		dev_dbg(chip->dev, "LRA nominal impedance is %d ohm\n", *nominal_ohm);
++	}
++
++	return rc > 0 ? 0 : rc;
++}
++
++static int haptics_clear_fault(struct haptics_chip *chip)
++{
++	u8 val;
++
++	val = SC_CLR_BIT | AUTO_RES_ERR_CLR_BIT |
++		HPWR_RDY_FAULT_CLR_BIT;
++
++	if (chip->hw_type >= HAP530_HV)
++		val |= HAP_ZX_TO_FAULT_CLR_BIT;
++
++	return haptics_write(chip, chip->cfg_addr_base,
++			HAP_CFG_FAULT_CLR_REG, &val, 1);
++}
++
++static int haptics_set_vmax_headroom_mv(struct haptics_chip *chip, u32 hdrm_mv)
++{
++	int rc = 0;
++	u8 val;
++
++	if (hdrm_mv > VMAX_HDRM_MAX_MV) {
++		dev_err(chip->dev, "headroom (%d) exceed the max value: %d\n",
++					hdrm_mv, VMAX_HDRM_MAX_MV);
++		return -EINVAL;
++	}
++
++	val = hdrm_mv / VMAX_HDRM_STEP_MV;
++	rc = haptics_write(chip, chip->cfg_addr_base,
++			HAP_CFG_VMAX_HDRM_REG, &val, 1);
++	if (rc < 0)
++		dev_err(chip->dev, "config VMAX_HDRM failed, rc=%d\n", rc);
++
++	return rc;
++}
++
++static int haptics_get_vmax_headroom_mv(struct haptics_chip *chip, u32 *hdrm_mv)
++{
++	int rc;
++	u8 val;
++
++	rc = haptics_read(chip, chip->cfg_addr_base,
++			HAP_CFG_VMAX_HDRM_REG, &val, 1);
++	if (rc < 0) {
++		dev_err(chip->dev, "Get Vmax HDRM failed, rc=%d\n",
++				rc);
++		return rc;
++	}
++
++	*hdrm_mv = (val & VMAX_HDRM_MASK) * VMAX_HDRM_STEP_MV;
++	return 0;
++}
++
++static int __haptics_set_vmax_mv(struct haptics_chip *chip, u32 vmax_mv)
++{
++	int rc = 0;
++	u8 val, vmax_step;
++
++	if (vmax_mv > chip->max_vmax_mv) {
++		dev_dbg(chip->dev, "vmax (%d) exceed the max value: %d\n",
++					vmax_mv, chip->max_vmax_mv);
++		vmax_mv = chip->max_vmax_mv;
++	}
++
++	vmax_step = (chip->is_hv_haptics) ? VMAX_HV_STEP_MV : VMAX_MV_STEP_MV;
++	val = vmax_mv / vmax_step;
++	rc = haptics_write(chip, chip->cfg_addr_base,
++			HAP_CFG_VMAX_REG, &val, 1);
++	if (rc < 0) {
++		dev_err(chip->dev, "config VMAX failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	dev_dbg(chip->dev, "Set Vmax to %u mV\n", vmax_mv);
++	rc = haptics_check_hpwr_status(chip);
++	if (rc < 0)
++		dev_err(chip->dev, "check hpwr_status failed, rc=%d\n", rc);
++
++	return rc;
++}
++
++static int haptics_ignore_swr_play(struct haptics_chip *chip, bool enable)
++{
++	int rc;
++	u8 val = enable ? SWR_IGNORE_BIT : 0;
++
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_TRIG_PRIORITY_REG, SWR_IGNORE_BIT, val);
++	if (rc < 0)
++		dev_err(chip->dev, "update SWR_IGNORE_BIT failed, rc=%d\n", rc);
++
++	return rc;
++}
++
++static int haptics_set_vmax_mv(struct haptics_chip *chip, u32 vmax_mv)
++{
++	int rc = 0;
++	u32 nominal_ohm, vmax_hdrm_mv;
++	u8 cl_vdrv_ctl;
++
++	mutex_lock(&chip->vmax_lock);
++	if (vmax_mv > chip->clamped_vmax_mv)
++		vmax_mv = chip->clamped_vmax_mv;
++
++	if (chip->clamp_at_5v && (vmax_mv > CLAMPED_VMAX_MV))
++		vmax_mv = CLAMPED_VMAX_MV;
++
++	rc = haptics_get_lra_nominal_impedance(chip, &nominal_ohm);
++	if (!rc && (chip->hw_type >= HAP525_HV)) {
++		if ((nominal_ohm >= 15) && (vmax_mv > 4500))
++			vmax_hdrm_mv = 1000;
++		else if ((nominal_ohm < 15) && (vmax_mv > 7000))
++			vmax_hdrm_mv = 1500;
++		else if ((nominal_ohm < 15) && (vmax_mv > 3500))
++			vmax_hdrm_mv = 1000;
++		else
++			vmax_hdrm_mv = 500;
++
++		if ((vmax_mv + vmax_hdrm_mv) > MAX_VMAX_MV)
++			vmax_mv = MAX_VMAX_MV - vmax_hdrm_mv;
++
++		rc = haptics_set_vmax_headroom_mv(chip, vmax_hdrm_mv);
++		if (rc < 0)
++			goto unlock;
++
++		dev_dbg(chip->dev, "update VMAX_HDRM to %d mv\n", vmax_hdrm_mv);
++	}
++
++	if (chip->hw_type == HAP530_HV) {
++		rc = haptics_masked_write(chip, chip->cfg_addr_base,
++				HAP_CFG_ZX_SYNC_CFG,
++				EN_PDN_ZX_TO_FAULT_BIT,
++				EN_PDN_ZX_TO_FAULT_BIT);
++		if (rc < 0) {
++			dev_err(chip->dev, "enable PDM_ZX_TO_FAULT failed, rc=%d\n", rc);
++			goto unlock;
++		}
++
++		rc = haptics_read(chip, chip->ptn_addr_base,
++				HAP_PTN_CL_VDRIVE_CTL_REG, &cl_vdrv_ctl, 1);
++		if (rc < 0) {
++			dev_err(chip->dev, "Read CL_VDRIVE_CTL failed, rc=%d\n", rc);
++			goto unlock;
++		}
++
++		rc = haptics_masked_write(chip, chip->ptn_addr_base,
++				HAP_PTN_CL_VDRIVE_CTL_REG,
++				EN_CL_VDRIVE_BIT, 0);
++		if (rc < 0) {
++			dev_err(chip->dev, "disable CL_VDRIVE_CTL failed, rc=%d\n", rc);
++			goto unlock;
++		}
++
++		rc = haptics_clear_fault(chip);
++		if (rc < 0)
++			goto unlock;
++	}
++
++	rc = __haptics_set_vmax_mv(chip, vmax_mv);
++	if (rc < 0)
++		goto unlock;
++
++	if (chip->hw_type == HAP530_HV) {
++		rc = haptics_masked_write(chip, chip->cfg_addr_base,
++				HAP_CFG_ZX_SYNC_CFG,
++				EN_PDN_ZX_TO_FAULT_BIT, 0);
++		if (rc < 0) {
++			dev_err(chip->dev, "disable PDM_ZX_TO_FAULT failed, rc=%d\n", rc);
++			goto unlock;
++		}
++
++		rc = haptics_write(chip, chip->ptn_addr_base,
++				HAP_PTN_CL_VDRIVE_CTL_REG, &cl_vdrv_ctl, 1);
++		if (rc < 0)
++			dev_err(chip->dev, "restore CL_VDRIVE_CTL failed, rc=%d\n", rc);
++	}
++
++unlock:
++	mutex_unlock(&chip->vmax_lock);
++	return rc;
++}
++
++static int haptics_enable_autores(struct haptics_chip *chip, bool en)
++{
++	int rc;
++
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_AUTORES_CFG_REG, AUTORES_EN_BIT,
++			en ? AUTORES_EN_BIT : 0);
++	if (rc < 0)
++		dev_err(chip->dev, "%s auto resonance failed, rc=%d\n",
++				en ? "enable" : "disable", rc);
++
++	return rc;
++}
++
++static int haptics_set_direct_play(struct haptics_chip *chip, u8 amplitude)
++{
++	int rc;
++
++	rc = haptics_write(chip, chip->ptn_addr_base,
++			HAP_PTN_DIRECT_PLAY_REG, &amplitude, 1);
++	if (rc < 0)
++		dev_err(chip->dev, "config DIRECT_PLAY failed, rc=%d\n", rc);
++
++	return rc;
++}
++
++static int haptics_trigger_pbs(struct haptics_chip *chip, enum hap_pbs_type type)
++{
++	int rc;
++	u8 val;
++
++	val = (u8)type;
++	rc = nvmem_device_write(chip->hap_cfg_nvmem, PBS_ARG_REG, 1, &val);
++	if (rc < 0) {
++		dev_err(chip->dev, "set PBS_ARG for auto brake cal failed, rc=%d\n",
++			rc);
++		return rc;
++	}
++
++	val = PBS_TRIG_CLR_VAL;
++	rc = nvmem_device_write(chip->hap_cfg_nvmem, PBS_TRIG_CLR_REG, 1, &val);
++	if (rc < 0) {
++		dev_err(chip->dev, "clear PBS_TRIG for auto brake cal failed, rc=%d\n",
++			rc);
++		return rc;
++	}
++
++	val = PBS_TRIG_SET_VAL;
++	rc = nvmem_device_write(chip->hap_cfg_nvmem, PBS_TRIG_SET_REG, 1, &val);
++	if (rc < 0)
++		dev_err(chip->dev, "set PBS_TRIG for auto brake cal failed, rc=%d\n",
++			rc);
++
++	return rc;
++}
++
++static bool is_boost_vreg_enabled_in_open_loop(struct haptics_chip *chip)
++{
++	int rc;
++	u8 val;
++
++	if (is_haptics_external_powered(chip))
++		return false;
++
++	rc = haptics_read(chip, chip->hbst_addr_base, HAP_BOOST_VREG_EN_REG, &val, 1);
++	if (rc < 0)
++		return false;
++
++	chip->hboost_enabled = (val & VREG_EN_BIT);
++	rc = haptics_read(chip, chip->hbst_addr_base, HAP_BOOST_HW_CTRL_FOLLOW_REG, &val, 1);
++	if (rc < 0)
++		return false;
++
++	if (!(val & FOLLOW_HW_EN_BIT) && chip->hboost_enabled) {
++		dev_dbg(chip->dev, "HBoost is enabled in open loop condition\n");
++		return true;
++	}
++
++	return false;
++}
++
++static int haptics_boost_vreg_enable(struct haptics_chip *chip, bool en)
++{
++	int rc;
++	enum hap_pbs_type type;
++
++	if (is_haptics_external_powered(chip))
++		return 0;
++
++	if (!(chip->wa_flags & SW_CTRL_HBST))
++		return 0;
++
++	if (chip->hap_cfg_nvmem == NULL) {
++		dev_dbg(chip->dev, "nvmem device for hap_cfg is not defined\n");
++		return 0;
++	}
++
++	if (is_boost_vreg_enabled_in_open_loop(chip)) {
++		dev_dbg(chip->dev, "Ignore %s hBoost while it's enabled in open-loop mode\n",
++				en ? "enabling" : "disabling");
++		return 0;
++	}
++
++	if (chip->hboost_enabled == en)
++		return 0;
++
++	type = en ? HAP_VREG_ON_PBS : HAP_VREG_OFF_PBS;
++	rc = haptics_trigger_pbs(chip, type);
++	if (rc < 0) {
++		dev_err(chip->dev, "trigger HAP_VREG_ON/OFF PBS failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	chip->hboost_enabled = en;
++	return 0;
++}
++
++static bool is_swr_play_enabled(struct haptics_chip *chip)
++{
++	int rc;
++	u8 val[2];
++
++	rc = haptics_get_status_data(chip, HAP_DRV_STS, val);
++	if (rc < 0)
++		return false;
++
++	if ((val[1] & HAP_DRV_PATTERN_SRC_STATUS_MASK) == SWR)
++		return true;
++
++	return false;
++}
++
++#define HBOOST_WAIT_READY_COUNT		100
++#define HBOOST_WAIT_READY_INTERVAL_US	200
++static int haptics_wait_hboost_ready(struct haptics_chip *chip)
++{
++	int i, rc;
++	u8 val;
++
++	if (is_haptics_external_powered(chip))
++		return 0;
++
++	if (!(chip->wa_flags & SW_CTRL_HBST))
++		return 0;
++
++	if ((hrtimer_get_remaining(&chip->hbst_off_timer) > 0) ||
++			hrtimer_active(&chip->hbst_off_timer)) {
++		hrtimer_cancel(&chip->hbst_off_timer);
++		dev_dbg(chip->dev, "hboost is still on, ignore\n");
++		return 0;
++	}
++
++	/*
++	 * Wait ~20ms until hBoost is ready, otherwise
++	 * bail out and return -EBUSY
++	 */
++	for (i = 0; i < HBOOST_WAIT_READY_COUNT; i++) {
++		/* HBoost is always ready when working in open loop mode */
++		if (is_boost_vreg_enabled_in_open_loop(chip))
++			return 0;
++
++		/*
++		 * If there is already a SWR play in the background, then HBoost
++		 * will be kept as on hence no need to wait its ready.
++		 */
++		mutex_lock(&chip->play.lock);
++		if (is_swr_play_enabled(chip)) {
++			dev_dbg(chip->dev, "Ignore waiting hBoost when SWR play is in progress\n");
++			mutex_unlock(&chip->play.lock);
++			return 0;
++		}
++		mutex_unlock(&chip->play.lock);
++
++		/* Check if HBoost is in standby (disabled) state */
++		rc = haptics_read(chip, chip->hbst_addr_base,
++				HAP_BOOST_VREG_EN_REG, &val, 1);
++		if (!rc && !(val & VREG_EN_BIT)) {
++			rc = haptics_read(chip, chip->hbst_addr_base,
++					HAP_BOOST_STATUS4_REG, &val, 1);
++			if (!rc && !(val & BOOST_DTEST1_STATUS_BIT))
++				return 0;
++		}
++
++		dev_dbg(chip->dev, "hBoost is busy, wait %d\n", i);
++		usleep_range(HBOOST_WAIT_READY_INTERVAL_US,
++				HBOOST_WAIT_READY_INTERVAL_US + 1);
++	}
++
++	if (i == HBOOST_WAIT_READY_COUNT) {
++		dev_err(chip->dev, "hboost is not ready for haptics play\n");
++		return -EBUSY;
++	}
++
++	return 0;
++}
++
++static int haptics_enable_hpwr_vreg(struct haptics_chip *chip, bool en)
++{
++	int rc;
++
++	if (chip->hpwr_vreg == NULL || chip->hpwr_vreg_enabled == en)
++		return 0;
++
++	if (en) {
++		rc = regulator_set_voltage(chip->hpwr_vreg,
++				chip->hpwr_voltage_mv * 1000, INT_MAX);
++		if (rc < 0) {
++			dev_err(chip->dev, "Set hpwr voltage failed, rc=%d\n",
++					rc);
++			return rc;
++		}
++
++		rc = regulator_enable(chip->hpwr_vreg);
++		if (rc < 0) {
++			dev_err(chip->dev, "Enable hpwr failed, rc=%d\n",
++					rc);
++			regulator_set_voltage(chip->hpwr_vreg, 0, INT_MAX);
++			return rc;
++		}
++	} else {
++		rc = regulator_disable(chip->hpwr_vreg);
++		if (rc < 0) {
++			dev_err(chip->dev, "Disable hpwr failed, rc=%d\n",
++					rc);
++			return rc;
++		}
++
++		rc = regulator_set_voltage(chip->hpwr_vreg, 0, INT_MAX);
++		if (rc < 0) {
++			dev_err(chip->dev, "Set hpwr voltage failed, rc=%d\n",
++					rc);
++			return rc;
++		}
++	}
++
++	dev_dbg(chip->dev, "%s hpwr vreg\n", en ? "enabled" : "disabled");
++	chip->hpwr_vreg_enabled = en;
++	return 0;
++}
++
++static int haptics_force_vreg_ready(struct haptics_chip *chip, bool ready)
++{
++	u8 mask;
++
++	mask = FORCE_VREG_RDY_BIT;
++	if (chip->hw_type >= HAP525_HV)
++		mask |= FORCE_VSET_ACK_BIT;
++
++	return haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_VSET_CFG_REG, mask, ready ? mask : 0);
++}
++
++static int haptics_open_loop_drive_config(struct haptics_chip *chip, bool en)
++{
++	int rc = 0;
++	u8 val;
++
++	if ((is_boost_vreg_enabled_in_open_loop(chip) ||
++			chip->hboost_enabled || is_haptics_external_powered(chip)) && en) {
++		/*
++		 * Only set force-VREG-ready here if hBoost is not used by charger firmware.
++		 * In the case of charger firmware enabling hBoost, force-VREG-ready will be
++		 * set/reset based on the VMAX_CLAMP notification.
++		 */
++		if (chip->clamped_vmax_mv == MAX_HV_VMAX_MV) {
++			rc = haptics_force_vreg_ready(chip, true);
++			if (rc < 0)
++				return rc;
++		}
++
++		/* Toggle RC_CLK_CAL_EN if it's in auto mode */
++		rc = haptics_read(chip, chip->cfg_addr_base,
++				HAP_CFG_CAL_EN_REG, &val, 1);
++		if (rc < 0)
++			return rc;
++
++		if ((chip->wa_flags & TOGGLE_CAL_RC_CLK) &&
++		    ((val & CAL_RC_CLK_MASK) ==
++		      CAL_RC_CLK_AUTO_VAL << CAL_RC_CLK_SHIFT)) {
++			val = CAL_RC_CLK_DISABLED_VAL << CAL_RC_CLK_SHIFT;
++			rc = haptics_masked_write(chip, chip->cfg_addr_base,
++					HAP_CFG_CAL_EN_REG, CAL_RC_CLK_MASK,
++					val);
++			if (rc < 0)
++				return rc;
++
++			val = CAL_RC_CLK_AUTO_VAL << CAL_RC_CLK_SHIFT;
++			rc = haptics_masked_write(chip, chip->cfg_addr_base,
++					HAP_CFG_CAL_EN_REG, CAL_RC_CLK_MASK,
++					val);
++			if (rc < 0)
++				return rc;
++
++			dev_dbg(chip->dev, "Toggle CAL_EN in open-loop-VREG playing\n");
++		}
++	} else if (!is_haptics_external_powered(chip) &&
++			(chip->clamped_vmax_mv == MAX_HV_VMAX_MV)) {
++		/*
++		 * Reset force-VREG-ready only when hBoost is not
++		 * used by charger firmware.
++		 */
++		rc = haptics_force_vreg_ready(chip, false);
++		if (rc < 0)
++			return rc;
++	}
++
++	return 0;
++}
++
++static int haptics_visense_handshake_enable(struct haptics_chip *chip, bool enable)
++{
++	u8 mask, val;
++	int rc;
++
++	if (chip->visense_hs_disabled != enable)
++		return 0;
++
++	mask = EN_FE_PU_CHECK_BIT;
++	val = enable ? mask : 0;
++	rc = haptics_masked_write(chip, chip->cfg_addr_base, HAP_CFG_DIG_SPARE_REG, mask, val);
++	if (rc < 0)
++		return rc;
++
++	mask = EN_VISENSE_PD_PROT_BIT;
++	val = enable ? mask : 0;
++	rc = haptics_masked_write(chip, chip->ptn_addr_base, HAP_PTN_VISENSE_ADC_CFG, mask, val);
++	if (rc < 0)
++		return rc;
++
++	mask = EN_CL_VDRIVE_BIT;
++	val = enable ? mask : 0;
++	rc = haptics_masked_write(chip, chip->ptn_addr_base, HAP_PTN_CL_VDRIVE_CTL_REG, mask, val);
++	if (rc < 0)
++		return rc;
++
++	chip->visense_hs_disabled = !enable;
++	return 0;
++}
++
++static int haptics_wait_brake_complete(struct haptics_chip *chip)
++{
++	struct haptics_play_info *play = &chip->play;
++	u32 brake_length_us, t_lra_us, timeout, delay_us;
++	int rc;
++	u8 val;
++
++	/*
++	 * Apply the brake synchronization delay for haptics module
++	 * revision HAP525_HV and later.
++	 */
++	if (chip->hw_type < HAP525_HV)
++		return 0;
++
++	t_lra_us = (chip->config.cl_t_lra_us) ?
++		chip->config.cl_t_lra_us : chip->config.t_lra_us;
++
++	brake_length_us = get_brake_play_length_us(play->brake, t_lra_us);
++
++	/* add a cycle to give some margin for brake synchronization */
++	brake_length_us += t_lra_us;
++	delay_us = t_lra_us / 2;
++	timeout = brake_length_us / delay_us + 1;
++	dev_dbg(chip->dev, "wait %d us for brake pattern to complete\n", brake_length_us);
++
++	/* poll HPWR_DISABLED to guarantee the brake pattern has been played completely */
++	do {
++		udelay(delay_us);
++		rc = haptics_read(chip, chip->cfg_addr_base, HAP_CFG_HPWR_INTF_REG, &val, 1);
++		if (rc < 0) {
++			dev_err(chip->dev, "read HPWR_INTF failed, rc=%d\n", rc);
++			return rc;
++		}
++
++		if ((val & HPWR_INTF_STATUS_MASK) == HPWR_DISABLED) {
++			/* Delay 500us to discharge the VNDRV voltage after play is stopped */
++			if (chip->wa_flags & DISCHARGE_VNDRV_LDO)
++				udelay(500);
++
++			dev_dbg(chip->dev, "stopped play completely");
++			break;
++		}
++
++		dev_dbg(chip->dev, "polling HPWR_INTF timeout %d, value = %d\n",
++				timeout, val);
++	} while (--timeout);
++
++	if (timeout == 0) {
++		/*
++		 * If there is a SWR play in the background, HPWR_DISABLED
++		 * bit won't be set and toggling HAPTICS_EN will re-initiate
++		 * the voltage requested from hBoost, it would cause potential
++		 * glitches on hBoost output which is unexpected, hence ignore
++		 * doing that in such case.
++		 */
++		if (is_swr_play_enabled(chip))
++			return 0;
++
++		dev_warn(chip->dev, "poll HPWR_DISABLED failed after stopped play\n");
++		return haptics_toggle_module_enable(chip);
++	}
++
++	return 0;
++}
++
++#define BOOST_VREG_OFF_DELAY_SECONDS	2
++static int haptics_enable_play(struct haptics_chip *chip, bool en)
++{
++	struct haptics_play_info *play = &chip->play;
++	int rc;
++	u8 val;
++
++	if (en) {
++		rc = haptics_clear_fault(chip);
++		if (rc < 0)
++			goto restore;
++	}
++
++	rc = haptics_open_loop_drive_config(chip, en);
++	if (rc < 0)
++		goto restore;
++
++	val = play->pattern_src;
++	if (chip->hw_type == HAP525_HV && play->pattern_src == PATTERN_MEM)
++		val |= FIELD_PREP(PATX_MEM_SEL_MASK, play->effect->pat_sel);
++
++	if (play->brake && !play->brake->disabled)
++		val |= BRAKE_EN_BIT;
++
++	if (en)
++		val |= PLAY_EN_BIT;
++
++	rc = haptics_write(chip, chip->cfg_addr_base,
++			HAP_CFG_SPMI_PLAY_REG, &val, 1);
++	if (rc < 0) {
++		dev_err(chip->dev, "Write SPMI_PLAY failed, rc=%d\n", rc);
++		goto restore;
++	}
++
++	haptics_read(chip, chip->hbst_addr_base, 0x09, &val, 1);
++	dev_dbg(chip->dev, "haptics_enable_play, 0xf209=0x%x\n", val);
++
++	if (!en)
++		haptics_wait_brake_complete(chip);
++
++	if (chip->wa_flags & SW_CTRL_HBST) {
++		if (en) {
++			rc = haptics_boost_vreg_enable(chip, true);
++			if (rc < 0) {
++				dev_err(chip->dev, "Keep boost vreg on failed, rc=%d\n",
++						rc);
++				goto restore;
++			}
++		} else {
++			hrtimer_start(&chip->hbst_off_timer,
++					ktime_set(BOOST_VREG_OFF_DELAY_SECONDS, 0),
++					HRTIMER_MODE_REL);
++		}
++	}
++
++	if ((chip->wa_flags & TOGGLE_MODULE_EN) && !en)
++		rc = haptics_toggle_module_enable(chip);
++
++	trace_qcom_haptics_play(en);
++restore:
++	/* Restore SWR play mode after SPMI play mode is done or any faults */
++	if ((!en || rc) && (chip->wa_flags & IGNORE_SWR_IN_SPMI_PLAY))
++		haptics_ignore_swr_play(chip, false);
++
++	return rc;
++}
++
++static int haptics_set_brake(struct haptics_chip *chip, struct brake_cfg *brake)
++{
++	int rc = 0;
++	u8 val;
++
++	if (brake->disabled)
++		return 0;
++
++	val = brake->mode << BRAKE_MODE_SHIFT |
++		brake->sine_gain << BRAKE_SINE_GAIN_SHIFT;
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_BRAKE_MODE_CFG_REG,
++			BRAKE_MODE_MASK | BRAKE_SINE_GAIN_MASK, val);
++	if (rc < 0) {
++		dev_err(chip->dev, "set brake CFG failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	rc = haptics_write(chip, chip->ptn_addr_base, HAP_PTN_BRAKE_AMP_REG,
++			brake->samples, BRAKE_SAMPLE_COUNT);
++	if (rc < 0) {
++		dev_err(chip->dev, "set brake pattern failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	return 0;
++}
++
++static int haptics_set_pattern(struct haptics_chip *chip,
++		struct pattern_cfg *pattern,
++		enum pattern_src src)
++{
++	struct pattern_s *sample;
++	u8 values[SAMPLES_PER_PATTERN * 3] = { 0 };
++	u8 ptn_tlra_addr, ptn_cfg_addr;
++	int i, rc, tmp;
++	u32 play_rate_us;
++
++	if (chip->hw_type >= HAP530_HV) {
++		dev_dbg(chip->dev, "haptics module with revision %d no longer supports PATTERNx mode, ignore parsing pattern effect DT\n",
++				chip->hw_type);
++		return 0;
++	}
++
++	if (src != PATTERN1 && src != PATTERN2) {
++		dev_err(chip->dev, "no pattern src specified!\n");
++		return -EINVAL;
++	}
++
++	ptn_tlra_addr = HAP_PTN_PTRN1_TLRA_MSB_REG;
++	ptn_cfg_addr = HAP_PTN_PTRN1_CFG_REG;
++	if (src == PATTERN2) {
++		ptn_tlra_addr = HAP_PTN_PTRN2_TLRA_MSB_REG;
++		ptn_cfg_addr = HAP_PTN_PTRN2_CFG_REG;
++	}
++
++	/* Adjust T_LRA before programming it into HW */
++	play_rate_us = pattern->play_rate_us;
++	rc = haptics_adjust_lra_period(chip, &play_rate_us);
++	if (rc < 0)
++		return rc;
++
++	/* Configure T_LRA for this pattern */
++	tmp = play_rate_us / TLRA_STEP_US;
++	values[0] = (tmp >> 8) & TLRA_OL_MSB_MASK;
++	values[1] = tmp & TLRA_OL_LSB_MASK;
++	rc = haptics_write(chip, chip->ptn_addr_base, ptn_tlra_addr,
++			values, 2);
++	if (rc < 0) {
++		dev_err(chip->dev, "update pattern TLRA failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	/* Configure pattern registers */
++	for (i = 0; i < SAMPLES_PER_PATTERN; i++) {
++		sample = &pattern->samples[i];
++		values[i * 3] = sample->f_lra_x2 << PTRN_FLRA2X_SHIFT;
++		values[i * 3] |= sample->period & PTRN_SAMPLE_PER_MASK;
++		values[i * 3 + 1] =
++			(sample->amplitude >> 8) & PTRN_AMP_MSB_MASK;
++		values[i * 3 + 2] = sample->amplitude & PTRN_AMP_LSB_MASK;
++	}
++
++	rc = haptics_write(chip, chip->ptn_addr_base, ptn_cfg_addr,
++			values, SAMPLES_PER_PATTERN * 3);
++	if (rc < 0) {
++		dev_err(chip->dev, "write pattern data failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	return 0;
++
++}
++
++static int haptics_update_memory_data(struct haptics_chip *chip,
++					u8 *data, u32 length)
++{
++	int rc, count, i;
++	u32 left;
++	u8 tmp[HAP_PTN_FIFO_DIN_NUM] = {0};
++
++	if (!length)
++		return 0;
++
++	count = length / HAP_PTN_FIFO_DIN_NUM;
++	for (i = 0; i < count; i++) {
++		rc = haptics_write(chip, chip->ptn_addr_base,
++				HAP_PTN_FIFO_DIN_0_REG, data,
++				HAP_PTN_FIFO_DIN_NUM);
++		if (rc < 0) {
++			dev_err(chip->dev, "bulk write FIFO_DIN failed, rc=%d\n",
++					rc);
++			return rc;
++		}
++
++		data += HAP_PTN_FIFO_DIN_NUM;
++	}
++
++	left = length % HAP_PTN_FIFO_DIN_NUM;
++	if (left) {
++		/*
++		 * In HAP520 module, when 1-byte FIFO write clashes
++		 * with the HW FIFO read operation, the HW will only read
++		 * 1 valid byte in every 4 bytes FIFO samples. So avoid
++		 * this by keeping the samples 4-byte aligned and always
++		 * use 4-byte write for HAP520 module.
++		 */
++		if (chip->hw_type == HAP520) {
++			memcpy(tmp, data, left);
++			rc = haptics_write(chip, chip->ptn_addr_base,
++					HAP_PTN_FIFO_DIN_0_REG, tmp,
++					HAP_PTN_FIFO_DIN_NUM);
++			if (rc < 0)
++				dev_err(chip->dev, "write FIFO_DIN failed, rc=%d\n", rc);
++
++			return rc;
++		}
++
++		for (i = 0; i < left; i++) {
++			rc = haptics_write(chip, chip->ptn_addr_base,
++					HAP_PTN_FIFO_DIN_1B_REG,
++					(data + i), 1);
++			if (rc < 0) {
++				dev_err(chip->dev, "write FIFO_DIN_1B failed, rc=%d\n",
++						rc);
++				return rc;
++			}
++		}
++	}
++
++	return 0;
++}
++
++static int haptics_update_fifo_samples(struct haptics_chip *chip,
++					u8 *samples, u32 length, bool refill)
++{
++	int rc;
++	u8 val;
++
++	if (!samples) {
++		dev_err(chip->dev, "no data available to update FIFO\n");
++		return -EINVAL;
++	}
++
++	if ((chip->hw_type >= HAP525_HV) && !refill) {
++		val = MEM_FLUSH_RELOAD_BIT;
++		rc = haptics_write(chip, chip->ptn_addr_base,
++				HAP_PTN_MEM_OP_ACCESS_REG, &val, 1);
++		if (rc < 0)
++			return rc;
++
++		val = 0;
++		rc = haptics_write(chip, chip->ptn_addr_base,
++				HAP_PTN_MEM_OP_ACCESS_REG, &val, 1);
++		if (rc < 0)
++			return rc;
++	}
++
++	return haptics_update_memory_data(chip, samples, length);
++}
++
++static int haptics_update_pat_mem_samples(struct haptics_chip *chip,
++		u32 pat_sel, u8 *samples, u32 length)
++{
++	u8 val[4] = {0}, zero_samples[HAP_PTN_FIFO_DIN_NUM] = {0};
++	u32 addr, size;
++	int zero_padding, rc;
++
++	if (!samples) {
++		dev_err(chip->dev, "no data available to update PAT_MEM\n");
++		return -EINVAL;
++	}
++
++	/* Haptics module revision HAP525_HV and above support PATx_MEM pattern source */
++	if (chip->hw_type < HAP525_HV) {
++		dev_dbg(chip->dev, "HW type %d doesn't support PATx_MEM pattern source\n",
++				chip->hw_type);
++		return 0;
++	}
++
++	/*
++	 * For HAP530_HV module, start address and length for each partition
++	 * need to be set before programming pattern memory
++	 */
++	if (chip->hw_type == HAP530_HV) {
++		size = chip->mmap.pat_sel_mmap[pat_sel].length / HAP530_MMAP_PAT_LEN_PER_LSB;
++		addr = chip->mmap.pat_sel_mmap[pat_sel].start_addr / HAP530_MMAP_PAT_LEN_PER_LSB;
++		val[0] = addr & HAP_PTN_PATX_MEM_LEN_LO_MASK;
++		val[1] = (addr >> HAP_PTN_PATX_MEM_LEN_HI_SHIFT) & HAP_PTN_PATX_MEM_LEN_HI_MASK;
++		val[2] = size & HAP_PTN_PATX_MEM_LEN_LO_MASK;
++		val[3] = (size >> HAP_PTN_PATX_MEM_LEN_HI_SHIFT) & HAP_PTN_PATX_MEM_LEN_HI_MASK;
++
++		rc = haptics_write(chip, chip->ptn_addr_base,
++				HAP_PTN_PATX_MEM_WR_START_ADDR_REG, val, 4);
++		if (rc < 0)
++			return rc;
++	}
++
++	val[0] = 0;
++	if (chip->hw_type == HAP525_HV)
++		val[0] = FIELD_PREP(MEM_PAT_RW_SEL_MASK, pat_sel);
++
++	val[0] |= MEM_PAT_ACCESS_BIT | MEM_FLUSH_RELOAD_BIT;
++	rc = haptics_write(chip, chip->ptn_addr_base,
++			HAP_PTN_MEM_OP_ACCESS_REG, val, 1);
++	if (rc < 0)
++		return rc;
++
++	val[0] &= ~MEM_FLUSH_RELOAD_BIT;
++	rc = haptics_write(chip, chip->ptn_addr_base,
++			HAP_PTN_MEM_OP_ACCESS_REG, val, 1);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_update_memory_data(chip, samples, length);
++	if (rc < 0)
++		return rc;
++
++	zero_padding = chip->mmap.pat_sel_mmap[pat_sel].length - length;
++	while (zero_padding > 0) {
++		rc = haptics_update_memory_data(chip, zero_samples,
++				zero_padding > HAP_PTN_FIFO_DIN_NUM ?
++				HAP_PTN_FIFO_DIN_NUM : zero_padding);
++		if (rc < 0)
++			return rc;
++
++		zero_padding -= HAP_PTN_FIFO_DIN_NUM;
++	}
++
++	return haptics_masked_write(chip, chip->ptn_addr_base,
++			HAP_PTN_MEM_OP_ACCESS_REG, MEM_PAT_ACCESS_BIT, 0);
++}
++
++static int haptics_get_fifo_fill_status(struct haptics_chip *chip, u32 *fill)
++{
++	int rc;
++	u8 val[2], fill_status_mask;
++	u32 filled, available;
++	bool empty = false, full = false;
++
++	rc = haptics_get_status_data(chip, FIFO_REAL_TIME_STS, val);
++	if (rc < 0)
++		return rc;
++
++	switch (chip->hw_type) {
++	case HAP520:
++		fill_status_mask = FIFO_REAL_TIME_FILL_STATUS_MSB_MASK_V2;
++		break;
++	case HAP520_MV:
++		fill_status_mask = FIFO_REAL_TIME_FILL_STATUS_MSB_MASK_V3;
++		break;
++	case HAP525_HV:
++		fill_status_mask = FIFO_REAL_TIME_FILL_STATUS_MSB_MASK_V4;
++		break;
++	case HAP530_HV:
++		fill_status_mask = FIFO_REAL_TIME_FILL_STATUS_MSB_MASK_V5;
++		break;
++	default:
++		dev_err(chip->dev, "HW type %d is not supported\n",
++				chip->hw_type);
++		return -EINVAL;
++	}
++
++	filled = ((val[0] & fill_status_mask) << 8) | val[1];
++	empty = !!(val[0] & FIFO_EMPTY_FLAG_BIT);
++	full = !!(val[0] & FIFO_FULL_FLAG_BIT);
++	available = get_max_fifo_samples(chip) - filled;
++
++	trace_qcom_haptics_fifo_hw_status(filled, available, full, empty);
++	*fill = filled;
++	return 0;
++}
++
++static int haptics_get_available_fifo_memory(struct haptics_chip *chip)
++{
++	int rc;
++	u32 fill, available;
++
++	rc = haptics_get_fifo_fill_status(chip, &fill);
++	if (rc < 0)
++		return rc;
++
++	if (fill > get_max_fifo_samples(chip)) {
++		dev_err(chip->dev, "Filled FIFO number %d exceed the max %d\n",
++				fill, get_max_fifo_samples(chip));
++		return -EINVAL;
++	} else if (fill == get_max_fifo_samples(chip)) {
++		dev_err(chip->dev, "no FIFO space available\n");
++		return -EBUSY;
++	}
++
++	available = get_max_fifo_samples(chip) - fill;
++	return available;
++}
++
++static int haptics_set_manual_rc_clk_cal(struct haptics_chip *chip)
++{
++	int rc;
++	u16 cal_count = chip->config.rc_clk_cal_count;
++	u8 val[2];
++
++	if (cal_count == 0) {
++		dev_dbg(chip->dev, "Ignore setting RC_CLK_CAL_COUNT\n");
++		return 0;
++	}
++
++	val[0] = (cal_count >> 8) & RC_CLK_CAL_COUNT_MSB_MASK;
++	val[1] = cal_count & RC_CLK_CAL_COUNT_LSB_MASK;
++	rc = haptics_write(chip, chip->cfg_addr_base,
++			HAP_CFG_RC_CLK_CAL_COUNT_MSB_REG, val, 2);
++	if (rc < 0)
++		return rc;
++
++	val[0] = CAL_RC_CLK_MANUAL_VAL << CAL_RC_CLK_SHIFT;
++	return haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_CAL_EN_REG, CAL_RC_CLK_MASK,
++			val[0]);
++}
++
++static int haptics_set_fifo_playrate(struct haptics_chip *chip,
++				enum s_period period_per_s)
++{
++	int rc;
++
++	rc = haptics_masked_write(chip, chip->ptn_addr_base,
++			HAP_PTN_FIFO_PLAY_RATE_REG,
++			FIFO_PLAY_RATE_MASK, period_per_s);
++	if (rc < 0)
++		dev_err(chip->dev, "Set FIFO play rate failed, rc=%d\n", rc);
++
++	return rc;
++}
++
++static int haptics_set_fifo_empty_threshold(struct haptics_chip *chip,
++							u32 thresh)
++{
++	u8 thresh_per_bit, thresh_mask;
++	int rc;
++
++	thresh_per_bit = chip->fifo_info->fifo_threshold_per_bit;
++	thresh_mask = chip->fifo_info->fifo_empty_threshold_mask;
++	rc = haptics_masked_write(chip, chip->ptn_addr_base,
++			HAP_PTN_FIFO_EMPTY_CFG_REG,
++			thresh_mask, (thresh / thresh_per_bit));
++	if (rc < 0)
++		dev_err(chip->dev, "Set FIFO empty threshold failed, rc=%d\n",
++				rc);
++
++	return rc;
++}
++
++static void haptics_fifo_empty_irq_config(struct haptics_chip *chip,
++						bool enable)
++{
++	if (!chip->fifo_empty_irq_en && enable) {
++		enable_irq(chip->fifo_empty_irq);
++		chip->fifo_empty_irq_en = true;
++	} else if (chip->fifo_empty_irq_en && !enable) {
++		disable_irq_nosync(chip->fifo_empty_irq);
++		chip->fifo_empty_irq_en = false;
++	}
++}
++
++static int haptics_set_fifo(struct haptics_chip *chip, struct fifo_cfg *fifo)
++{
++	struct fifo_play_status *status = &chip->play.fifo_status;
++	u32 num, fifo_thresh;
++	int rc, available;
++
++	if (atomic_read(&status->is_busy) == 1) {
++		dev_err(chip->dev, "FIFO is busy\n");
++		return -EBUSY;
++	}
++
++	/* Configure FIFO play rate */
++	rc = haptics_set_fifo_playrate(chip, fifo->period_per_s);
++	if (rc < 0)
++		return rc;
++
++	if (fifo->period_per_s >= F_8KHZ) {
++		/* Set manual RC CLK CAL when playing FIFO */
++		rc = haptics_set_manual_rc_clk_cal(chip);
++		if (rc < 0)
++			return rc;
++	}
++
++	atomic_set(&status->written_done, 0);
++	atomic_set(&status->cancelled, 0);
++	status->samples_written = 0;
++
++	/*
++	 * Write the 1st set of the data into FIFO if there are
++	 * more than MAX_FIFO_SAMPLES samples, the rest will be
++	 * written if any FIFO memory is available after playing.
++	 */
++	num = min_t(u32, fifo->num_s, get_max_fifo_samples(chip));
++	available = haptics_get_available_fifo_memory(chip);
++	if (available < 0)
++		return available;
++
++	num = min_t(u32, available, num);
++	num = min_t(u32, num, FIFO_PRGM_INIT_SIZE);
++	/* Keep the FIFO programming 4-byte aligned if FIFO refilling is needed */
++	if ((num < fifo->num_s) && (num % HAP_PTN_FIFO_DIN_NUM))
++		num = round_down(num, HAP_PTN_FIFO_DIN_NUM);
++
++	rc = haptics_update_fifo_samples(chip, fifo->samples, num, false);
++	if (rc < 0) {
++		dev_err(chip->dev, "write FIFO samples failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	atomic_set(&status->is_busy, 1);
++	status->samples_written = num;
++	trace_qcom_haptics_fifo_prgm_status(fifo->num_s, status->samples_written, num);
++	if (num == fifo->num_s) {
++		fifo_thresh = 0;
++		atomic_set(&status->written_done, 1);
++	} else {
++		fifo_thresh = chip->config.fifo_empty_thresh;
++	}
++
++	/*
++	 * Set FIFO empty threshold here. FIFO empty IRQ will
++	 * be enabled after playing FIFO samples so that more
++	 * FIFO samples can be written (if available) when
++	 * FIFO empty IRQ is triggered.
++	 */
++	rc = haptics_set_fifo_empty_threshold(chip, fifo_thresh);
++	if (rc < 0)
++		return rc;
++
++	haptics_fifo_empty_irq_config(chip, true);
++
++	return 0;
++}
++
++static int haptics_load_constant_effect(struct haptics_chip *chip, u8 amplitude)
++{
++	struct haptics_play_info *play = &chip->play;
++	u32 hdrm_mv, vmax_mv = chip->config.vmax_mv;
++	int rc = 0;
++
++	mutex_lock(&chip->play.lock);
++	if (chip->play.in_calibration) {
++		dev_err(chip->dev, "calibration in progress, ignore playing constant effect\n");
++		rc = -EBUSY;
++		goto unlock;
++	}
++
++	/* No effect data when playing constant waveform */
++	play->effect = NULL;
++
++	/* Fix Vmax to (hpwr_vreg_mv - hdrm_mv) in non-HBOOST regulator case */
++	if (is_haptics_external_powered(chip)) {
++		rc = haptics_get_vmax_headroom_mv(chip, &hdrm_mv);
++		if (rc < 0)
++			goto unlock;
++
++		vmax_mv = chip->hpwr_voltage_mv - hdrm_mv;
++	}
++
++	/* configure VMAX in case it was changed in previous effect playing */
++	rc = haptics_set_vmax_mv(chip, vmax_mv);
++	if (rc < 0)
++		goto unlock;
++
++	/* Config brake settings if it's necessary */
++	play->brake = &chip->config.brake;
++	if (play->brake) {
++		rc = haptics_set_brake(chip, play->brake);
++		if (rc < 0)
++			goto unlock;
++	}
++
++	rc = haptics_set_direct_play(chip, amplitude);
++	if (rc < 0)
++		goto unlock;
++
++	rc = haptics_enable_autores(chip, false);
++
++	if (rc < 0)
++		goto unlock;
++
++	play->pattern_src = DIRECT_PLAY;
++unlock:
++	mutex_unlock(&chip->play.lock);
++	return rc;
++}
++
++static int haptics_load_predefined_effect(struct haptics_chip *chip,
++					struct haptics_effect *effect)
++{
++	struct haptics_play_info *play = &chip->play;
++	struct mmap_partition *pat_sel_mmap;
++	u32 addr, length;
++	u8 val[4] = {0};
++	int rc;
++
++	if (effect == NULL)
++		return -EINVAL;
++
++	play->effect = effect;
++	/* Clamp VMAX for different vibration strength */
++	rc = haptics_set_vmax_mv(chip, play->vmax_mv);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_enable_autores(chip, !play->effect->auto_res_disable);
++
++	if (rc < 0)
++		return rc;
++
++	play->brake = play->effect->brake;
++	/* Config brake settings if it's necessary */
++	if (play->brake) {
++		rc = haptics_set_brake(chip, play->brake);
++		if (rc < 0)
++			return rc;
++	}
++
++	play->pattern_src = play->effect->src;
++	switch (play->pattern_src) {
++	case PATTERN1:
++	case PATTERN2:
++		if (chip->hw_type >= HAP530_HV) {
++			dev_dbg(chip->dev, "haptics module with revision %d no longer supports PATTERNx mode, ignore parsing pattern effect DT\n",
++					chip->hw_type);
++			return 0;
++		}
++
++		if (play->effect->pattern->preload) {
++			dev_dbg(chip->dev, "Ignore preloaded PATTERNx effect: %d\n",
++					play->effect->id);
++			break;
++		}
++
++		rc = haptics_set_pattern(chip, play->effect->pattern,
++						play->pattern_src);
++		if (rc < 0)
++			return rc;
++		break;
++	case FIFO:
++		if (chip->wa_flags & TOGGLE_EN_TO_FLUSH_FIFO) {
++			/* Toggle HAPTICS_EN for a clear start point of FIFO playing */
++			rc = haptics_toggle_module_enable(chip);
++			if (rc < 0)
++				return rc;
++
++			usleep_range(100, 101);
++		}
++
++		rc = haptics_set_fifo(chip, play->effect->fifo);
++		if (rc < 0)
++			return rc;
++		break;
++	case PATTERN_MEM:
++		if (!chip->mmap.pat_sel_mmap)
++			return 0;
++
++		if (!play->effect->fifo->preload) {
++			dev_err(chip->dev, "effect %d has PATTERN_MEM src but not preloaded\n",
++					play->effect->id);
++			return -EINVAL;
++		}
++
++		if (chip->hw_type == HAP530_HV) {
++			/*
++			 * Update length to 0 to avoid the end address
++			 * calculation getting messed up if the previous
++			 * pattern is still under playing.
++			 */
++			rc = haptics_write(chip, chip->ptn_addr_base,
++					HAP_PTN_SPMI_PATX_MEM_LEN_LSB_REG, val, 2);
++			if (rc < 0)
++				return rc;
++
++			pat_sel_mmap = &chip->mmap.pat_sel_mmap[effect->pat_sel];
++			length = pat_sel_mmap->length /
++					chip->mmap.hw_info.pat_mem_play_step;
++			addr = pat_sel_mmap->start_addr / HAP530_MMAP_PAT_LEN_PER_LSB;
++			val[0] = addr & HAP_PTN_PATX_MEM_LEN_LO_MASK;
++			val[1] = (addr >> HAP_PTN_PATX_MEM_LEN_HI_SHIFT)
++					& HAP_PTN_PATX_MEM_LEN_HI_MASK;
++			val[2] = length & HAP_PTN_PATX_MEM_LEN_LO_MASK;
++			val[3] = (length >> HAP_PTN_PATX_MEM_LEN_HI_SHIFT)
++					& chip->mmap.hw_info.pat_mem_play_len_msb;
++
++			rc = haptics_write(chip, chip->ptn_addr_base,
++					HAP_PTN_SPMI_PATX_MEM_START_ADDR_REG, val, 4);
++			if (rc < 0)
++				return rc;
++		}
++
++		/* disable auto resonance for PATx_MEM mode */
++		rc = haptics_enable_autores(chip, false);
++		if (rc < 0)
++			return rc;
++
++		dev_dbg(chip->dev, "Ignore loading data for preload FIFO effect: %d\n",
++				play->effect->id);
++		break;
++	case DIRECT_PLAY:
++	case SWR:
++	default:
++		dev_err(chip->dev, "pattern src %d can't be used for predefined effect\n",
++				play->pattern_src);
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int haptics_init_custom_effect(struct haptics_chip *chip)
++{
++	chip->custom_effect = devm_kzalloc(chip->dev,
++			sizeof(*chip->custom_effect), GFP_KERNEL);
++	if (!chip->custom_effect)
++		return -ENOMEM;
++
++	chip->custom_effect->fifo = devm_kzalloc(chip->dev,
++			sizeof(*chip->custom_effect->fifo), GFP_KERNEL);
++	if (!chip->custom_effect->fifo)
++		return -ENOMEM;
++
++	/* custom effect will be played in FIFO mode without brake */
++	chip->custom_effect->pattern = NULL;
++	chip->custom_effect->brake = NULL;
++	chip->custom_effect->id = UINT_MAX;
++	chip->custom_effect->vmax_mv = chip->config.vmax_mv;
++	chip->custom_effect->t_lra_us = chip->config.t_lra_us;
++	chip->custom_effect->src = FIFO;
++	chip->custom_effect->auto_res_disable = true;
++
++	return 0;
++}
++
++static int haptics_convert_sample_period(struct haptics_chip *chip,
++						u32 play_rate_hz)
++{
++	enum s_period period;
++	u32 f_lra, f_lra_min, f_lra_max;
++
++	if (chip->config.t_lra_us == 0)
++		return -EINVAL;
++
++	f_lra = USEC_PER_SEC / chip->config.t_lra_us;
++	if (f_lra == 0 || f_lra < F_LRA_VARIATION_HZ)
++		return -EINVAL;
++
++	f_lra_min = f_lra - F_LRA_VARIATION_HZ;
++	f_lra_max = f_lra + F_LRA_VARIATION_HZ;
++
++	if (play_rate_hz == 8000)
++		period = F_8KHZ;
++	else if (play_rate_hz == 16000)
++		period = F_16KHZ;
++	else if (play_rate_hz == 24000)
++		period = F_24KHZ;
++	else if (play_rate_hz == 32000)
++		period = F_32KHZ;
++	else if (play_rate_hz == 44100)
++		period = F_44P1KHZ;
++	else if (play_rate_hz == 48000)
++		period = F_48KHZ;
++	else if (is_between(play_rate_hz, f_lra_min, f_lra_max))
++		period = T_LRA;
++	else if (is_between(play_rate_hz / 2, f_lra_min, f_lra_max))
++		period = T_LRA_DIV_2;
++	else if (is_between(play_rate_hz / 4, f_lra_min, f_lra_max))
++		period = T_LRA_DIV_4;
++	else if (is_between(play_rate_hz / 8, f_lra_min, f_lra_max))
++		period = T_LRA_DIV_8;
++	else if (is_between(play_rate_hz * 2, f_lra_min, f_lra_max))
++		period = T_LRA_X_2;
++	else if (is_between(play_rate_hz * 4, f_lra_min, f_lra_max))
++		period = T_LRA_X_4;
++	else if (is_between(play_rate_hz * 8, f_lra_min, f_lra_max))
++		period = T_LRA_X_8;
++	else
++		return -EINVAL;
++
++	return period;
++}
++
++static int haptics_load_custom_effect(struct haptics_chip *chip,
++			s16 __user *data, u32 length, s16 magnitude)
++{
++	struct haptics_play_info *play = &chip->play;
++	struct custom_fifo_data custom_data = {};
++	struct fifo_cfg *fifo;
++	int rc;
++
++	if (!chip->custom_effect || !chip->custom_effect->fifo)
++		return -ENOMEM;
++
++	fifo = chip->custom_effect->fifo;
++	if (copy_from_user(&custom_data, data, sizeof(custom_data)))
++		return -EFAULT;
++
++	dev_dbg(chip->dev, "custom data length %d with play-rate %d Hz\n",
++			custom_data.length, custom_data.play_rate_hz);
++
++	rc = haptics_convert_sample_period(chip, custom_data.play_rate_hz);
++	if (rc < 0) {
++		dev_err(chip->dev, "Can't support play rate: %d Hz\n",
++				custom_data.play_rate_hz);
++		return rc;
++	}
++
++	mutex_lock(&chip->play.lock);
++	fifo->period_per_s = rc;
++	/*
++	 * Before allocating samples buffer, free the old sample
++	 * buffer first if it's not been freed.
++	 */
++	kvfree(fifo->samples);
++	fifo->samples = kcalloc(custom_data.length, sizeof(u8), GFP_KERNEL);
++	if (!fifo->samples) {
++		fifo->samples = vmalloc(custom_data.length);
++		if (!fifo->samples) {
++			rc = -ENOMEM;
++			goto unlock;
++		}
++	}
++
++	if (copy_from_user(fifo->samples,
++				(u8 __user *)custom_data.data,
++				custom_data.length)) {
++		rc = -EFAULT;
++		goto cleanup;
++	}
++
++	dev_dbg(chip->dev, "Copy custom FIFO samples successfully\n");
++	fifo->num_s = custom_data.length;
++	fifo->play_length_us = get_fifo_play_length_us(fifo,
++			chip->custom_effect->t_lra_us);
++
++	if (chip->play.in_calibration) {
++		dev_err(chip->dev, "calibration in progress, ignore playing custom effect\n");
++		rc = -EBUSY;
++		goto cleanup;
++	}
++
++	play->effect = chip->custom_effect;
++	play->brake = NULL;
++	play->vmax_mv = (magnitude * chip->custom_effect->vmax_mv) / 0x7fff;
++	rc = haptics_set_vmax_mv(chip, play->vmax_mv);
++	if (rc < 0)
++		goto cleanup;
++
++	/* Toggle HAPTICS_EN for a clear start point of FIFO playing */
++	if (chip->wa_flags & TOGGLE_EN_TO_FLUSH_FIFO) {
++		rc = haptics_toggle_module_enable(chip);
++		if (rc < 0)
++			goto cleanup;
++	}
++
++	rc = haptics_enable_autores(chip, !play->effect->auto_res_disable);
++	if (rc < 0)
++		goto cleanup;
++
++	play->pattern_src = FIFO;
++	rc = haptics_set_fifo(chip, play->effect->fifo);
++	if (rc < 0)
++		goto cleanup;
++
++	mutex_unlock(&chip->play.lock);
++	return 0;
++cleanup:
++	kvfree(fifo->samples);
++	fifo->samples = NULL;
++unlock:
++	mutex_unlock(&chip->play.lock);
++	return rc;
++}
++
++static u32 get_play_length_effect_us(struct haptics_effect *effect)
++{
++	u32 length_us = 0;
++
++	if (effect->brake)
++		length_us = effect->brake->play_length_us;
++
++	if ((effect->src == PATTERN1 || effect->src == PATTERN2)
++			&& effect->pattern)
++		length_us += effect->pattern->play_length_us;
++	else if ((effect->src == FIFO || effect->src == PATTERN_MEM) && effect->fifo)
++		length_us += effect->fifo->play_length_us;
++
++	return length_us;
++}
++
++static inline u32 get_play_length_us(struct haptics_play_info *play)
++{
++	return get_play_length_effect_us(play->effect);
++}
++
++#define PRIMITIVE_EFFECT_ID_BIT		BIT(15)
++#define PRIMITIVE_EFFECT_ID_MASK	GENMASK(14, 0)
++static int haptics_load_periodic_effect(struct haptics_chip *chip,
++			s16 __user *data, u32 length, s16 magnitude)
++{
++	struct haptics_play_info *play = &chip->play;
++	s16 custom_data[CUSTOM_DATA_LEN] = { 0 };
++	struct haptics_effect *effects = NULL;
++	s16 custom_id = 0;
++	int effects_count = 0;
++	int rc, i;
++	bool primitive;
++
++	if (copy_from_user(custom_data, data, sizeof(custom_data)))
++		return -EFAULT;
++
++	primitive = !!(custom_data[CUSTOM_DATA_EFFECT_IDX] & PRIMITIVE_EFFECT_ID_BIT);
++
++	if (primitive) {
++		if (chip->primitives_count == 0)
++			return -EINVAL;
++
++		custom_id = custom_data[CUSTOM_DATA_EFFECT_IDX] & PRIMITIVE_EFFECT_ID_MASK;
++		effects = chip->primitives;
++		effects_count = chip->primitives_count;
++	} else {
++		if (chip->effects_count == 0)
++			return -EINVAL;
++
++		custom_id = custom_data[CUSTOM_DATA_EFFECT_IDX];
++		effects = chip->effects;
++		effects_count = chip->effects_count;
++	}
++
++	for (i = 0; i < effects_count; i++)
++		if (effects[i].id == custom_id)
++			break;
++
++	if (i == effects_count) {
++		dev_err(chip->dev, "effect%d is not supported!\n",
++				custom_data[CUSTOM_DATA_EFFECT_IDX]);
++		return -EINVAL;
++	}
++
++	mutex_lock(&chip->play.lock);
++	if (chip->play.in_calibration) {
++		dev_err(chip->dev, "calibration in progress, ignore playing predefined effect\n");
++		rc = -EBUSY;
++		goto unlock;
++	}
++
++	play->vmax_mv = (magnitude * effects[i].vmax_mv) / 0x7fff;
++	dev_dbg(chip->dev, "upload %s effect %d, vmax=%d\n", primitive ? "primitive" : "predefined",
++			effects[i].id, play->vmax_mv);
++
++	rc = haptics_load_predefined_effect(chip, &effects[i]);
++	if (rc < 0) {
++		dev_err(chip->dev, "Play predefined effect%d failed, rc=%d\n",
++				effects[i].id, rc);
++		goto unlock;
++	}
++	mutex_unlock(&chip->play.lock);
++
++	play->length_us = get_play_length_us(play);
++	custom_data[CUSTOM_DATA_TIMEOUT_SEC_IDX] =
++		play->length_us / USEC_PER_SEC;
++	custom_data[CUSTOM_DATA_TIMEOUT_MSEC_IDX] =
++		(play->length_us % USEC_PER_SEC) / USEC_PER_MSEC;
++
++	if (copy_to_user(data, custom_data, length))
++		return -EFAULT;
++
++	return 0;
++unlock:
++	mutex_unlock(&chip->play.lock);
++	return rc;
++}
++
++static u8 get_direct_play_max_amplitude(struct haptics_chip *chip)
++{
++	u32 amplitude = DIRECT_PLAY_MAX_AMPLITUDE, hdrm_mv;
++	int rc;
++
++	if (is_haptics_external_powered(chip)) {
++		rc = haptics_get_vmax_headroom_mv(chip, &hdrm_mv);
++		if (rc < 0)
++			return 0;
++
++		amplitude *= chip->config.vmax_mv;
++		amplitude /= (chip->hpwr_voltage_mv - hdrm_mv);
++		if (amplitude > DIRECT_PLAY_MAX_AMPLITUDE)
++			amplitude = DIRECT_PLAY_MAX_AMPLITUDE;
++	}
++
++	dev_dbg(chip->dev, "max amplitude for direct play: %#x\n", amplitude);
++	return (u8)amplitude;
++}
++
++static int haptics_stop_fifo_play(struct haptics_chip *chip)
++{
++	int rc;
++	u8 val;
++
++	if (atomic_read(&chip->play.fifo_status.is_busy) == 0) {
++		dev_dbg(chip->dev, "FIFO playing is not in progress\n");
++		return 0;
++	}
++
++	rc = haptics_enable_play(chip, false);
++	if (rc < 0)
++		return rc;
++
++	/* restore FIFO play rate back to T_LRA */
++	rc = haptics_set_fifo_playrate(chip, T_LRA);
++	if (rc < 0)
++		return rc;
++
++	haptics_fifo_empty_irq_config(chip, false);
++	kvfree(chip->custom_effect->fifo->samples);
++	chip->custom_effect->fifo->samples = NULL;
++
++	atomic_set(&chip->play.fifo_status.is_busy, 0);
++
++	/*
++	 * All other playing modes would use AUTO mode RC
++	 * calibration except FIFO streaming mode, so restore
++	 * back to AUTO RC calibration after FIFO playing.
++	 */
++	val = CAL_RC_CLK_AUTO_VAL << CAL_RC_CLK_SHIFT;
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_CAL_EN_REG, CAL_RC_CLK_MASK, val);
++	if (rc < 0)
++		return rc;
++
++	dev_dbg(chip->dev, "stopped FIFO playing successfully\n");
++	return 0;
++}
++
++static void haptics_stop_constant_effect_play(struct work_struct *work)
++{
++	struct haptics_chip *chip = container_of(work, struct haptics_chip, stop_work.work);
++	int rc = 0;
++
++	rc = haptics_enable_play(chip, false);
++	if (rc < 0)
++		dev_err(chip->dev, "stop constant effect play failed\n");
++
++	rc = haptics_enable_hpwr_vreg(chip, false);
++	if (rc < 0)
++		dev_err(chip->dev, "disable hpwr_vreg failed\n");
++}
++
++static inline bool is_haptics_runtime_pm_enabled(struct haptics_chip *chip)
++{
++	return !!(chip->wa_flags & EN_RUNTIME_PM);
++}
++
++#define HAPTICS_AUTO_SUSPEND_MS			1000
++
++static void haptics_runtime_disable_action(void *data)
++{
++	pm_runtime_dont_use_autosuspend(data);
++	pm_runtime_disable(data);
++}
++
++static int haptics_runtime_pm_init(struct haptics_chip *chip)
++{
++	int rc;
++
++	if (!is_haptics_runtime_pm_enabled(chip))
++		return 0;
++
++	pm_runtime_use_autosuspend(chip->dev);
++	pm_runtime_set_autosuspend_delay(chip->dev, HAPTICS_AUTO_SUSPEND_MS);
++	pm_runtime_set_active(chip->dev);
++	pm_runtime_enable(chip->dev);
++
++	rc = __devm_add_action(chip->dev, haptics_runtime_disable_action,
++			chip->dev, "haptics_runtime_disable_action");
++	if (rc < 0)
++		haptics_runtime_disable_action(chip->dev);
++
++	return rc;
++}
++
++static int haptics_runtime_resume_get(struct haptics_chip *chip)
++{
++	if (!is_haptics_runtime_pm_enabled(chip))
++		return 0;
++
++	return pm_runtime_resume_and_get(chip->dev);
++}
++
++static void haptics_runtime_autosuspend_put(struct haptics_chip *chip)
++{
++	if (!is_haptics_runtime_pm_enabled(chip))
++		return;
++
++	pm_runtime_mark_last_busy(chip->dev);
++	pm_runtime_put_autosuspend(chip->dev);
++}
++
++static void haptics_runtime_autosuspend(struct haptics_chip *chip)
++{
++	if (!is_haptics_runtime_pm_enabled(chip))
++		return;
++
++	pm_runtime_mark_last_busy(chip->dev);
++	pm_runtime_autosuspend(chip->dev);
++}
++
++static int haptics_upload_effect(struct input_dev *dev,
++		struct ff_effect *effect, struct ff_effect *old)
++{
++	struct haptics_chip *chip = input_get_drvdata(dev);
++	u32 length_ms, tmp;
++	s16 level;
++	u8 amplitude;
++	int rc = 0;
++
++	rc = haptics_runtime_resume_get(chip);
++	if (rc < 0)
++		return rc;
++
++	/*
++	 * When switching between SWR and SPMI play, the haptics module doesn't
++	 * set HPWR_DISABLED status especially if triggering a SPMI play before
++	 * SWR play is not de-asserted. This triggers haptics enable toggling
++	 * workaround trying to recover the HW in multiple places and it is
++	 * unexpected.
++	 *
++	 * To avoid this, set SWR_IGNORE before triggering a SPMI play, and
++	 * unset SWR_IGNORE after the SPMI play is stopped.
++	 */
++	if (chip->wa_flags & IGNORE_SWR_IN_SPMI_PLAY) {
++		rc = haptics_ignore_swr_play(chip, true);
++		if (rc < 0)
++			goto auto_suspend;
++	}
++
++	switch (effect->type) {
++	case FF_CONSTANT:
++		length_ms = effect->replay.length;
++		level = effect->u.constant.level;
++		tmp = get_direct_play_max_amplitude(chip);
++		tmp *= level;
++		amplitude = tmp / 0x7fff;
++		dev_dbg(chip->dev, "upload constant effect, length = %dms, amplitude = %#x\n",
++				length_ms, amplitude);
++		schedule_delayed_work(&chip->stop_work, msecs_to_jiffies(length_ms));
++		haptics_load_constant_effect(chip, amplitude);
++		if (rc < 0) {
++			dev_err(chip->dev, "set direct play failed, rc=%d\n",
++					rc);
++			goto restore;
++		}
++
++		break;
++	case FF_PERIODIC:
++		if (effect->u.periodic.waveform != FF_CUSTOM) {
++			dev_err(chip->dev, "Only support custom waveforms\n");
++			rc = -EINVAL;
++			goto restore;
++		}
++		if (effect->u.periodic.custom_len ==
++				sizeof(struct custom_fifo_data)) {
++			rc = haptics_load_custom_effect(chip,
++					effect->u.periodic.custom_data,
++					effect->u.periodic.custom_len,
++					effect->u.periodic.magnitude);
++			if (rc < 0) {
++				dev_err(chip->dev, "Upload custom FIFO data failed rc=%d\n",
++						rc);
++				goto restore;;
++			}
++		} else if (effect->u.periodic.custom_len ==
++				sizeof(s16) * CUSTOM_DATA_LEN) {
++			rc = haptics_load_periodic_effect(chip,
++					effect->u.periodic.custom_data,
++					effect->u.periodic.custom_len,
++					effect->u.periodic.magnitude);
++			if (rc < 0) {
++				dev_err(chip->dev, "Upload periodic effect failed rc=%d\n",
++						rc);
++				goto restore;
++			}
++		}
++
++		break;
++	default:
++		dev_err(chip->dev, "%d effect is not supported\n",
++				effect->type);
++		rc = -EINVAL;
++		goto restore;
++	}
++
++	rc = haptics_enable_hpwr_vreg(chip, true);
++	if (rc < 0) {
++		dev_err(chip->dev, "enable hpwr_vreg failed, rc=%d\n", rc);
++		goto restore;
++	}
++
++	rc = haptics_wait_hboost_ready(chip);
++	if (rc < 0 && chip->play.pattern_src == FIFO) {
++		/*
++		 * Call haptics_stop_fifo_play(chip) explicitly if hBoost is
++		 * not ready for the FIFO play. This drops current FIFO play
++		 * but it restores the SW back to initial status so that the
++		 * following FIFO play requests can still be served.
++		 */
++		dev_dbg(chip->dev, "stop FIFO play explicitly to restore SW status\n");
++		mutex_lock(&chip->play.lock);
++		haptics_stop_fifo_play(chip);
++		mutex_unlock(&chip->play.lock);
++		goto restore;
++	}
++
++	return 0;
++
++restore:
++	if (chip->wa_flags & IGNORE_SWR_IN_SPMI_PLAY)
++		haptics_ignore_swr_play(chip, false);
++auto_suspend:
++	haptics_runtime_autosuspend_put(chip);
++	return rc;
++}
++
++static int haptics_playback(struct input_dev *dev, int effect_id, int val)
++{
++	struct haptics_chip *chip = input_get_drvdata(dev);
++
++	dev_dbg(chip->dev, "playback val = %d\n", val);
++	if (!!val) {
++		if (chip->config.measure_lra_impedance && chip->visense_enabled)
++			chip->pattern_start_time = ktime_get_boottime();
++
++		return haptics_enable_play(chip, true);
++	}
++
++	return 0;
++}
++
++#define AVG_RSENSE_MEAS_PER_CYCLE		4
++static int haptics_measure_visense_lra_impedance(struct haptics_chip *chip, int pattern_run_time)
++{
++	u32 avg_rsense_meas, icomp_thresh_na, r_typical_ohm, vmax_mv;
++	u32 i_peak_ma, rsense_mohm, v_peak_mv;
++	u32 play_rsense_meas;
++	u8 val[2];
++	int rc;
++
++	rc = haptics_read(chip, chip->cfg_addr_base, HAP_CFG_ICOMP_AVG_CTL1_REG, val, 1);
++	if (rc < 0)
++		return rc;
++	icomp_thresh_na = (val[0] & ICOMP_THRESH_MASK) * ICOMP_THRESH_STEP_NA;
++
++	rc = haptics_get_lra_nominal_impedance(chip, &r_typical_ohm);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_read(chip, chip->cfg_addr_base, HAP_CFG_VMAX_REG, val, 1);
++	if (rc < 0)
++		return rc;
++	vmax_mv = val[0] * ((chip->is_hv_haptics) ? VMAX_HV_STEP_MV : VMAX_MV_STEP_MV);
++
++	rc = haptics_read(chip, chip->cfg_addr_base, HAP_CFG_ICOMP_AVG_CTL2_REG, val, 1);
++	if (rc < 0)
++		return rc;
++	avg_rsense_meas = 1 << val[0];
++
++	play_rsense_meas = (pattern_run_time * AVG_RSENSE_MEAS_PER_CYCLE) / chip->config.t_lra_us;
++
++	/*
++	 * If vmax is higher than ICOMP_THRESH * R_typical and play length is
++	 * longer than #N of measurement time use rsense directly otherwise use
++	 * v_peak and i_peak to calculate rsense
++	 */
++	if ((u64)vmax_mv * 1000000 > (u64)icomp_thresh_na * r_typical_ohm &&
++	    play_rsense_meas >= avg_rsense_meas) {
++		/* LRA Resistance = RSENSE_MEAS * 0.025 Ohms */
++		rc = haptics_read(chip, chip->cfg_addr_base, HAP_CFG_RSENSE_MEAS_LSB_REG, val, 2);
++		if (rc < 0)
++			return rc;
++		rsense_mohm = ((val[1] & HAP_CFG_RSENSE_MEAS_MSB_MASK) << 8) | val[0];
++
++		dev_dbg(chip->dev, "measured rsense: %#x mohm\n", rsense_mohm);
++
++		chip->config.lra_measured_mohms = rsense_mohm * LRA_IMPEDANCE_VISENSE_MOHMS;
++	} else {
++		/* Measured Voltage Peak = VSENSE_MEAS * 50mV/2^6 */
++		rc = haptics_read(chip, chip->cfg_addr_base, HAP_CFG_VSENSE_PEAK_LSB_REG, val, 2);
++		if (rc < 0)
++			return rc;
++		v_peak_mv = ((val[1] & HAP_CFG_VSENSE_PEAK_MSB_MASK) << 8) | val[0];
++		v_peak_mv = (v_peak_mv * 50) / 64;
++
++		/* Measured Current Peak = ISENSE_MEAS * 1A/2^12 */
++		rc = haptics_read(chip, chip->cfg_addr_base, HAP_CFG_ISENSE_PEAK_LSB_REG, val, 2);
++		if (rc < 0)
++			return rc;
++		i_peak_ma = ((val[1] & HAP_CFG_ISENSE_PEAK_MSB_MASK) << 8) | val[0];
++		i_peak_ma = (i_peak_ma * 1000) / 4096;
++
++		dev_dbg(chip->dev, "measured voltage peak: %#x mv, current peak = %#x ma\n",
++			v_peak_mv, i_peak_ma);
++
++		/* LRA Resistance = VPEAK / IPEAK */
++		chip->config.lra_measured_mohms = (v_peak_mv * 1000) / i_peak_ma;
++	}
++
++	dev_dbg(chip->dev, "measured LRA impedance: %u mohm\n", chip->config.lra_measured_mohms);
++	return 0;
++}
++
++static int haptics_erase(struct input_dev *dev, int effect_id)
++{
++	struct haptics_chip *chip = input_get_drvdata(dev);
++	struct haptics_play_info *play = &chip->play;
++	ktime_t pattern_run_time;
++	int rc;
++
++	dev_dbg(chip->dev, "erase effect, really stop play\n");
++	cancel_work_sync(&chip->set_gain_work);
++	mutex_lock(&play->lock);
++	cancel_delayed_work_sync(&chip->stop_work);
++	pattern_run_time = ktime_us_delta(ktime_get_boottime(), chip->pattern_start_time);
++	if ((play->pattern_src == FIFO) &&
++			atomic_read(&play->fifo_status.is_busy)) {
++		if (atomic_read(&play->fifo_status.written_done) == 0) {
++			dev_dbg(chip->dev, "cancelling FIFO playing\n");
++			atomic_set(&play->fifo_status.cancelled, 1);
++		}
++
++		rc = haptics_stop_fifo_play(chip);
++		if (rc < 0) {
++			dev_err(chip->dev, "stop FIFO playing failed, rc=%d\n",
++					rc);
++			mutex_unlock(&play->lock);
++			goto restore;
++		}
++	} else {
++		rc = haptics_enable_play(chip, false);
++		if (rc < 0) {
++			dev_err(chip->dev, "stop play failed, rc=%d\n", rc);
++			mutex_unlock(&play->lock);
++			goto restore;
++		}
++	}
++	mutex_unlock(&play->lock);
++
++	rc = haptics_enable_hpwr_vreg(chip, false);
++	if (rc < 0)
++		dev_err(chip->dev, "disable hpwr_vreg failed, rc=%d\n", rc);
++
++	if (chip->config.measure_lra_impedance && chip->visense_enabled) {
++		rc = haptics_measure_visense_lra_impedance(chip, pattern_run_time);
++		if (rc < 0)
++			dev_err(chip->dev, "visense lra impedance measurement failed, rc=%d\n", rc);
++	}
++
++restore:
++	/* Restore Vmax headroom to 1.5V after SPMI play is done */
++	if (chip->wa_flags & RESTORE_VMAX_HDRM_1P5V) {
++		rc = haptics_set_vmax_headroom_mv(chip, VMAX_HDRM_MV_DEFAULT);
++		if (rc)
++			return rc;
++	}
++
++	/* Restore SWR play mode after SPMI play is done or any faults */
++	if (chip->wa_flags & IGNORE_SWR_IN_SPMI_PLAY)
++		haptics_ignore_swr_play(chip, false);
++
++	haptics_runtime_autosuspend_put(chip);
++	return rc;
++}
++
++static void haptics_set_gain_work(struct work_struct *work)
++{
++	struct haptics_chip *chip =
++		container_of(work, struct haptics_chip, set_gain_work);
++	struct haptics_hw_config *config = &chip->config;
++	struct haptics_play_info *play = &chip->play;
++	u32 vmax_mv, amplitude;
++	u16 gain;
++
++	mutex_lock(&play->lock);
++	gain = atomic_read(&play->gain);
++	/* scale amplitude when playing in DIRECT_PLAY mode */
++	if (chip->play.pattern_src == DIRECT_PLAY) {
++		amplitude = get_direct_play_max_amplitude(chip);
++		amplitude *= gain;
++		amplitude /= 0x7fff;
++
++		dev_dbg(chip->dev, "Set amplitude: %#x\n", amplitude);
++		haptics_set_direct_play(chip, (u8)amplitude);
++		mutex_unlock(&play->lock);
++		return;
++	}
++
++	/* scale Vmax when playing in other modes */
++	vmax_mv = config->vmax_mv;
++	if (play->effect)
++		vmax_mv = play->effect->vmax_mv;
++
++	if (chip->clamp_at_5v && (vmax_mv > CLAMPED_VMAX_MV))
++		vmax_mv = CLAMPED_VMAX_MV;
++
++	play->vmax_mv = ((u32)(gain * vmax_mv)) / 0x7fff;
++	haptics_set_vmax_mv(chip, play->vmax_mv);
++	mutex_unlock(&play->lock);
++}
++
++static void haptics_set_gain(struct input_dev *dev, u16 gain)
++{
++	struct haptics_chip *chip = input_get_drvdata(dev);
++	struct haptics_play_info *play = &chip->play;
++
++	if (gain == 0)
++		return;
++
++	if (gain > 0x7fff)
++		gain = 0x7fff;
++
++	atomic_set(&play->gain, gain);
++	schedule_work(&chip->set_gain_work);
++	dev_dbg(chip->dev, "Set gain: %#x\n", gain);
++}
++
++static int haptics_store_cl_brake_settings(struct haptics_chip *chip)
++{
++	int rc = 0;
++	u8 val[2];
++
++	if (!chip->cl_brake_nvmem)
++		return 0;
++
++	rc = haptics_get_status_data(chip, RNAT_RCAL_INT, val);
++	if (rc < 0)
++		return rc;
++
++	rc = nvmem_cell_write(chip->cl_brake_nvmem, &val[1], 1);
++	if (rc < 0)
++		dev_err(chip->dev, "store RNAT/RCAL to SDAM failed, rc=%d\n", rc);
++
++	return rc;
++}
++
++static int haptics_config_openloop_lra_period(struct haptics_chip *chip,
++							u32 t_lra_us)
++{
++	u32 tmp;
++	u8 val[2];
++	int rc;
++
++	rc = haptics_adjust_lra_period(chip, &t_lra_us);
++	if (rc < 0)
++		return rc;
++
++	tmp = t_lra_us / TLRA_STEP_US;
++	val[0] = (tmp >> 8) & TLRA_OL_MSB_MASK;
++	val[1] = tmp & TLRA_OL_LSB_MASK;
++
++	return haptics_write(chip, chip->cfg_addr_base,
++			HAP_CFG_TLRA_OL_HIGH_REG, val, 2);
++}
++
++static int haptics_config_preload_fifo_effect(struct haptics_chip *chip,
++				struct haptics_effect *effect)
++{
++	int rc;
++
++	if (!effect->fifo->preload) {
++		dev_err(chip->dev, "effect %d doesn't support preload\n",
++				effect->id);
++		return -EINVAL;
++	}
++
++	if (effect->src != PATTERN_MEM) {
++		dev_err(chip->dev, "effect %d pattern_src is not PATTERN_MEM\n",
++				effect->id);
++		return -EINVAL;
++	}
++
++	rc = haptics_update_pat_mem_samples(chip, effect->pat_sel,
++			effect->fifo->samples, effect->fifo->num_s);
++	if (!rc)
++		dev_dbg(chip->dev, "effect %d is preloaded in PAT_MEM %d\n",
++				effect->id, effect->pat_sel);
++	return rc;
++}
++
++static int haptics_mmap_config(struct haptics_chip *chip)
++{
++	int rc, i, left;
++	u32 empty_thresh_allowed;
++	u8 val[4];
++
++	/* config PATx_PLAY_RATE */
++	rc = haptics_masked_write(chip, chip->ptn_addr_base,
++			HAP_PTN_FIFO_PLAY_RATE_REG, PAT_MEM_PLAY_RATE_MASK,
++			FIELD_PREP(PAT_MEM_PLAY_RATE_MASK, chip->mmap.pat_play_rate));
++	if (rc < 0) {
++		dev_err(chip->dev, "Set pat_mem play rate failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	/*
++	 * Make the FIFO memory with step size aligned, and append
++	 * the leftover memory bytes to PAT1_MEM.
++	 */
++	left = chip->mmap.fifo_mmap.length % chip->mmap.hw_info.fifo_mem_step;
++	if (left) {
++		chip->mmap.fifo_mmap.length -= left;
++		chip->mmap.pat_sel_mmap[0].length += left;
++		chip->mmap.pat_sel_mmap[0].start_addr = chip->mmap.fifo_mmap.length;
++		dev_dbg(chip->dev, "PAT_MEM partition 0 is updated: start_addr %#x, length %#x\n",
++				chip->mmap.pat_sel_mmap[0].start_addr,
++				chip->mmap.pat_sel_mmap[0].length);
++	}
++
++	empty_thresh_allowed = chip->mmap.fifo_mmap.length *
++		FIFO_EMPTY_THRESH_RATIO_NUM / FIFO_EMPTY_THRESH_RATIO_DEN;
++	if (chip->config.fifo_empty_thresh > empty_thresh_allowed) {
++		chip->config.fifo_empty_thresh = empty_thresh_allowed;
++		dev_dbg(chip->dev, "Update FIFO empty threshold after MMAP allocation\n");
++	}
++
++	dev_dbg(chip->dev, "FIFO memory length: %d, empty threshold: %d\n",
++			chip->mmap.fifo_mmap.length, chip->config.fifo_empty_thresh);
++	/* config MMAP_FIFO */
++	val[0] = chip->mmap.fifo_mmap.length / chip->mmap.hw_info.fifo_mem_step;
++	if (!val[0]--) {
++		dev_err(chip->dev, "fifo length %d is less than %d\n",
++				chip->mmap.fifo_mmap.length, MMAP_FIFO_LEN_PER_LSB);
++		return -EINVAL;
++	}
++
++	val[0] &= chip->mmap.hw_info.fifo_mem_mask;
++	val[0] |= MMAP_FIFO_EXIST_BIT;
++	rc = haptics_write(chip, chip->ptn_addr_base,
++			HAP_PTN_MMAP_FIFO_REG, val, 1);
++	if (rc < 0)
++		return rc;
++
++	/*
++	 * Explicit HW indexed PATx_MEM partition is only supported in HAP525_HV
++	 * and it's deprecated in HAP530_HV.
++	 */
++	if (chip->hw_type == HAP525_HV) {
++		/* config MMAP_PAT1/2/3/4 */
++		for (i = PAT1_MEM; i <= PAT4_MEM; i++)
++			val[i] = min(chip->mmap.pat_sel_mmap[i].length,
++				   chip->mmap.pat_sel_mmap[i].max_size) / MMAP_PAT_LEN_PER_LSB;
++
++		rc = haptics_write(chip, chip->ptn_addr_base,
++				HAP_PTN_MMAP_PAT1_REG, val, 4);
++		if (rc < 0)
++			return rc;
++
++		dev_dbg(chip->dev, "haptics memory map configured with FIFO: %d, PAT1:%d, PAT2: %d, PAT3: %d, PAT4: %d\n",
++				chip->mmap.fifo_mmap.length,
++				chip->mmap.pat_sel_mmap[PAT1_MEM].length,
++				chip->mmap.pat_sel_mmap[PAT2_MEM].length,
++				chip->mmap.pat_sel_mmap[PAT3_MEM].length,
++				chip->mmap.pat_sel_mmap[PAT4_MEM].length);
++	}
++
++	return 0;
++}
++
++static int haptics_mmap_preload_fifo_effect(struct haptics_chip *chip,
++				struct haptics_effect *effect)
++{
++	u32 length, fifo_length;
++	u32 end_addr, max_size;
++	int i, num_pat;
++
++	if (!effect->fifo->preload) {
++		dev_err(chip->dev, "effect %d doesn't support preload\n",
++			effect->id);
++		return -EINVAL;
++	}
++
++	if (!chip->mmap.pat_sel_mmap)
++		return 0;
++
++	if (chip->mmap.pat_play_rate == F_RESERVED) {
++		chip->mmap.pat_play_rate = effect->fifo->period_per_s;
++	} else if (chip->mmap.pat_play_rate != effect->fifo->period_per_s) {
++		dev_warn(chip->dev, "PATx_MEM sources only support one play rate\n");
++		goto mmap_failed;
++	}
++
++	length = roundup(effect->fifo->num_s, chip->mmap.hw_info.pat_mem_step);
++	fifo_length = chip->mmap.fifo_mmap.length - length;
++	if (fifo_length < MMAP_FIFO_MIN_SIZE) {
++		dev_warn(chip->dev, "not enough space for MMAP effect ID: %d, length: %d\n",
++				effect->id, length);
++		goto mmap_failed;
++	}
++
++	if (chip->hw_type == HAP525_HV)
++		num_pat = PAT_MEM_MAX - 1;
++	else
++		num_pat = chip->mmap_effect_count - 1;
++
++	for (i = num_pat; i >= 0; i--) {
++		if (!chip->mmap.pat_sel_mmap[i].in_use &&
++				(length <= chip->mmap.pat_sel_mmap[i].max_size))
++			break;
++	}
++
++	if (i < 0) {
++		dev_warn(chip->dev, "no PAT_MEM source available for MMAP effect ID: %d, length: %d\n",
++				effect->id, length);
++		effect->fifo->preload = false;
++		goto mmap_failed;
++	}
++
++	/*
++	 * The end address of the last partition is the end address of the memory
++	 * space. For other partitions, the end address is prior to the start
++	 * address of the next partition.
++	 */
++	if (i == num_pat)
++		end_addr = chip->mmap.hw_info.memory_size - 1;
++	else
++		end_addr = chip->mmap.pat_sel_mmap[i + 1].start_addr - 1;
++
++	/* update the mmap configuration */
++	chip->mmap.pat_sel_mmap[i].in_use = true;
++	chip->mmap.pat_sel_mmap[i].length = length;
++	chip->mmap.pat_sel_mmap[i].start_addr = end_addr - length + 1;
++	chip->mmap.fifo_mmap.length = fifo_length;
++
++	/* Update the effect pattern_src and pat_sel for the preload effect */
++	effect->src = PATTERN_MEM;
++	effect->pat_sel = i;
++
++	if (chip->hw_type == HAP525_HV)
++		return 0;
++
++	/* Update max size for the preceding partition */
++	if (i > 0) {
++		max_size = chip->mmap.pat_sel_mmap[i].max_size - length;
++		chip->mmap.pat_sel_mmap[i - 1].max_size = max_size;
++	}
++
++	dev_dbg(chip->dev, "PAT_MEM partition %d: start_addr %#x, length %#x\n", i,
++			chip->mmap.pat_sel_mmap[i].start_addr,
++			chip->mmap.pat_sel_mmap[i].length);
++	return 0;
++
++	/* if mmap is failed then the effect couldn't be preloaded */
++mmap_failed:
++	effect->fifo->preload = false;
++	return -ENOSPC;
++}
++
++static void haptics_mmap_init(struct haptics_chip *chip)
++{
++	u32 max_pat_mem_size;
++
++	if (!chip->mmap.pat_sel_mmap)
++		return;
++
++	max_pat_mem_size = chip->mmap.hw_info.memory_size - MMAP_FIFO_MIN_SIZE;
++	/* Assume that all memory space is used for FIFO mode by default */
++	chip->mmap.fifo_mmap.in_use = true;
++	chip->mmap.fifo_mmap.length = chip->mmap.hw_info.memory_size;
++	chip->mmap.fifo_mmap.max_size = chip->mmap.hw_info.memory_size;
++
++	chip->mmap.pat_play_rate = F_RESERVED;
++	if (chip->hw_type != HAP525_HV) {
++		/*
++		 * To keep the mmap allocation logic backward compatible, the
++		 * allocation will be started from the last partition with highest
++		 * address. Thus, update the max_size of the last partition to
++		 * the total size. The max_size of the following partitions
++		 * will be updated according to the bytes in the available space.
++		 */
++		chip->mmap.pat_sel_mmap[chip->mmap_effect_count - 1].max_size = max_pat_mem_size;
++		return;
++	}
++
++	/* In HAP525_HV, different PATx_MEM partition has different maximum size */
++	chip->mmap.pat_sel_mmap[PAT1_MEM].max_size = min(max_pat_mem_size,
++			(u32)MMAP_PAT1_LEN_MASK * MMAP_PAT_LEN_PER_LSB);
++	chip->mmap.pat_sel_mmap[PAT2_MEM].max_size = min(max_pat_mem_size,
++			(u32)MMAP_PAT2_LEN_MASK * MMAP_PAT_LEN_PER_LSB);
++	chip->mmap.pat_sel_mmap[PAT3_MEM].max_size = min(max_pat_mem_size,
++			(u32)MMAP_PAT3_PAT4_LEN_MASK * MMAP_PAT_LEN_PER_LSB);
++	chip->mmap.pat_sel_mmap[PAT4_MEM].max_size = min(max_pat_mem_size,
++			(u32)MMAP_PAT3_PAT4_LEN_MASK * MMAP_PAT_LEN_PER_LSB);
++}
++
++static int haptics_init_fifo_memory(struct haptics_chip *chip)
++{
++	struct haptics_effect *effect;
++	struct mmap_partition *partitions;
++	int counts;
++	int rc;
++	u8 val;
++
++	/* HAP525_HV haptics module and above support PATx_MEM pattern source */
++	if (chip->hw_type < HAP525_HV) {
++		dev_dbg(chip->dev, "HW type %d doesn't support mmap\n",
++				chip->hw_type);
++		return 0;
++	}
++
++	if (chip->hw_type == HAP525_HV) {
++		counts = PAT_MEM_MAX;
++		chip->mmap.hw_info.memory_size = MMAP_NUM_BYTES;
++		chip->mmap.hw_info.pat_mem_step = MMAP_PAT_LEN_PER_LSB;
++		chip->mmap.hw_info.fifo_mem_step = MMAP_FIFO_LEN_PER_LSB;
++		chip->mmap.hw_info.fifo_mem_mask = MMAP_FIFO_LEN_MASK;
++	} else {
++		counts = chip->mmap_effect_count;
++		chip->mmap.hw_info.memory_size = HAP530_MMAP_NUM_BYTES;
++		chip->mmap.hw_info.pat_mem_step = HAP530_MMAP_PAT_LEN_PER_LSB;
++		chip->mmap.hw_info.pat_mem_play_step = HAP530_MMAP_PAT_LEN_PER_LSB;
++		chip->mmap.hw_info.pat_mem_play_len_msb = HAP_PTN_PATX_MEM_LEN_HI_MASK;
++		chip->mmap.hw_info.fifo_mem_step = HAP530_MMAP_FIFO_LEN_PER_LSB;
++		chip->mmap.hw_info.fifo_mem_mask = HAP530_MMAP_FIFO_LEN_MASK;
++
++		if (chip->ptn_revision >= HAP_PTN_PATX_PLAY_CFG_SUPPORT_MIN_REV) {
++			val = HAP530_V2_MMAP_PAT_LEN_PER_LSB;
++			rc = haptics_write(chip, chip->ptn_addr_base,
++					HAP_PTN_PATX_PLAY_CFG, &val, 1);
++			if (rc < 0)
++				return rc;
++			chip->mmap.hw_info.pat_mem_play_step =
++					HAP530_V2_MMAP_PAT_LEN_PER_LSB;
++			chip->mmap.hw_info.pat_mem_play_len_msb =
++					HAP530_V2_PTN_PATX_MEM_LEN_HI_MASK;
++		}
++	}
++
++	if (!counts) {
++		dev_dbg(chip->dev, "no PAT_MEM effect is defined, skip MMAP config\n");
++		return 0;
++	}
++
++	partitions = devm_kcalloc(chip->dev, sizeof(*partitions), counts, GFP_KERNEL);
++	if (!partitions)
++		return -ENOMEM;
++
++	chip->mmap.pat_sel_mmap = partitions;
++	haptics_mmap_init(chip);
++
++	list_for_each_entry(effect, &chip->mmap_effect_list, node) {
++		rc = haptics_mmap_preload_fifo_effect(chip, effect);
++		if (rc < 0 && rc != -ENOSPC)
++			return rc;
++	}
++
++	rc = haptics_mmap_config(chip);
++	if (rc < 0)
++		return rc;
++
++	list_for_each_entry(effect, &chip->mmap_effect_list, node) {
++		rc = haptics_config_preload_fifo_effect(chip, effect);
++		if (rc < 0)
++			return rc;
++	}
++
++	return 0;
++}
++
++static int haptics_init_preload_pattern_effect(struct haptics_chip *chip)
++{
++	struct haptics_hw_config *config = &chip->config;
++	struct haptics_effect *effect;
++	int i;
++
++	if (config->preload_effect == -EINVAL)
++		return 0;
++
++	for (i = 0; i < chip->effects_count; i++)
++		if (chip->effects[i].id == config->preload_effect)
++			break;
++
++	if (i == chip->effects_count) {
++		dev_err(chip->dev, "preload effect %d is not found\n",
++				config->preload_effect);
++		return -EINVAL;
++	}
++
++	effect = &chip->effects[i];
++	return haptics_set_pattern(chip, effect->pattern, effect->src);
++}
++
++static int haptics_init_lra_period_config(struct haptics_chip *chip)
++{
++	int rc = 0;
++	u8 val;
++	u32 t_lra_us;
++
++	/* set AUTO_mode RC CLK calibration by default */
++	val = FIELD_PREP(CAL_RC_CLK_MASK, CAL_RC_CLK_AUTO_VAL);
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_CAL_EN_REG, CAL_RC_CLK_MASK, val);
++	if (rc < 0)
++		return rc;
++
++	/* get calibrated close loop period */
++	t_lra_us = chip->config.t_lra_us;
++	rc = haptics_get_closeloop_lra_period(chip, true);
++	if (!rc && chip->config.cl_t_lra_us != 0)
++		t_lra_us = chip->config.cl_t_lra_us;
++	else
++		dev_warn(chip->dev, "get closeloop LRA period failed, rc=%d\n", rc);
++
++	/* Config T_LRA */
++	return haptics_config_openloop_lra_period(chip, t_lra_us);
++}
++
++static int haptics_init_hpwr_config(struct haptics_chip *chip)
++{
++	int rc;
++	u8 val;
++
++	if ((chip->hw_type == HAP520_MV) && !chip->hpwr_vreg) {
++		/* Indicates if HPWR is BOB or Bharger */
++		rc = haptics_read(chip, chip->cfg_addr_base,
++			HAP_CFG_HPWR_INTF_CTL_REG, &val, 1);
++		if (rc < 0)
++			return rc;
++
++		chip->hpwr_intf_ctl = val & INTF_CTL_MASK;
++
++		/* Read HPWR voltage to adjust the VMAX */
++		if (chip->hpwr_voltage_mv == 0 &&
++				chip->hpwr_intf_ctl == INTF_CTL_BOB) {
++			rc = haptics_read(chip, chip->cfg_addr_base,
++				HAP_CFG_VHPWR_REG, &val, 1);
++			if (rc < 0)
++				return rc;
++
++			chip->hpwr_voltage_mv = val * VHPWR_STEP_MV;
++		}
++	}
++
++	/* Force VREG_RDY if non-HBoost is used for powering haptics */
++	if (is_haptics_external_powered(chip))
++		return haptics_masked_write(chip, chip->cfg_addr_base,
++				HAP_CFG_VSET_CFG_REG, FORCE_VREG_RDY_BIT,
++				FORCE_VREG_RDY_BIT);
++
++	return 0;
++}
++
++static int haptics_init_drive_config(struct haptics_chip *chip)
++{
++	struct haptics_hw_config *config = &chip->config;
++	int rc;
++	u8 val;
++
++	/* Config driver waveform shape and use 2's complement data format */
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_DRV_WF_SEL_REG,
++			DRV_WF_SEL_MASK | DRV_WF_FMT_BIT, config->drv_wf);
++	if (rc < 0)
++		return rc;
++
++	/* Config brake mode and waveform shape */
++	val = FIELD_PREP(BRAKE_MODE_MASK, config->brake.mode);
++	val |= FIELD_PREP(BRAKE_SINE_GAIN_MASK, config->brake.sine_gain);
++	val |= FIELD_PREP(BRAKE_WF_SEL_MASK, config->brake.brake_wf);
++
++	return haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_BRAKE_MODE_CFG_REG,
++			BRAKE_MODE_MASK | BRAKE_SINE_GAIN_MASK
++			| BRAKE_WF_SEL_MASK, val);
++}
++
++static int haptics_init_vmax_config(struct haptics_chip *chip)
++{
++	int rc;
++	u8 val;
++
++	if (!is_haptics_external_powered(chip)) {
++		rc = haptics_read(chip, chip->hbst_addr_base,
++				HAP_BOOST_CLAMP_REG, &val, 1);
++		if (rc < 0)
++			return rc;
++
++		chip->clamp_at_5v = val & CLAMP_5V_BIT;
++	}
++
++	chip->is_hv_haptics = true;
++	chip->max_vmax_mv = MAX_VMAX_MV;
++	if (chip->hw_type > HAP520_MV) {
++		rc = haptics_read(chip, chip->cfg_addr_base,
++			HAP_CFG_HW_CONFIG_REG, &val, 1);
++		if (rc < 0)
++			return rc;
++
++		chip->is_hv_haptics = val & HV_HAP_DRIVER_BIT;
++		chip->max_vmax_mv = (chip->is_hv_haptics) ?
++					MAX_HV_VMAX_MV : MAX_MV_VMAX_MV;
++	}
++
++	/* Set the initial clamped vmax value when hBoost is used by charger firmware */
++	chip->clamped_vmax_mv = MAX_HV_VMAX_MV;
++	/* Config VMAX */
++	return haptics_set_vmax_mv(chip, chip->config.vmax_mv);
++}
++
++static int haptics_config_wa(struct haptics_chip *chip)
++{
++	switch (chip->hw_type) {
++	case HAP520:
++		chip->wa_flags |= TOGGLE_CAL_RC_CLK | SW_CTRL_HBST | SLEEP_CLK_32K_SCALE |
++			TOGGLE_EN_TO_FLUSH_FIFO | RECOVER_SWR_SLAVE;
++		break;
++	case HAP520_MV:
++		chip->wa_flags |= SLEEP_CLK_32K_SCALE;
++		if (!(chip->cfg_revision & HAP_CFG_REV_LSB_MASK))
++			chip->wa_flags |= TOGGLE_MODULE_EN;
++		break;
++	case HAP525_HV:
++		if (chip->hbst_revision == HAP_BOOST_V0P1)
++			chip->wa_flags |= SW_CTRL_HBST;
++		break;
++	case HAP530_HV:
++		chip->wa_flags |= VISENSE_RECOVERY_EN |
++			IGNORE_SWR_IN_SPMI_PLAY | DISCHARGE_VNDRV_LDO |
++			RESTORE_VMAX_HDRM_1P5V;
++		break;
++	default:
++		dev_err(chip->dev, "HW type %d does not match\n",
++			chip->hw_type);
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int haptics_visense_enable(struct haptics_chip *chip, bool enable)
++{
++	u8 val = enable ? HAP_PTN_VISENSE_ADC_CTL_MASK : 0;
++	int rc;
++
++	rc = haptics_write(chip, chip->ptn_addr_base, HAP_PTN_VSENSE_ADC_CTL_REG, &val, 1);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_write(chip, chip->ptn_addr_base, HAP_PTN_ISENSE_ADC_CTL_REG, &val, 1);
++	if (rc < 0)
++		return rc;
++
++	return 0;
++}
++
++static int haptics_init_visense_config(struct haptics_chip *chip)
++{
++	int rc;
++	u8 val, mask;
++
++	if (chip->hw_type < HAP530_HV)
++		return 0;
++
++	rc = haptics_read(chip, chip->ptn_addr_base, HAP_PTN_VISENSE_EN_REG, &val, 1);
++	if (!rc)
++		chip->visense_enabled = val & HAP_PTN_VISENSE_EN_BIT;
++
++	if (chip->visense_enabled) {
++		rc = haptics_visense_enable(chip, true);
++		if (rc < 0)
++			return rc;
++
++		if (chip->config.measure_lra_impedance) {
++			mask = VISENSE_PEAK_DET_EN_BIT | VISENSE_PEAK_DET_MODE |
++				VISENSE_INST_DET_EN_BIT;
++			val = VISENSE_PEAK_DET_EN_BIT | VISENSE_PEAK_DET_MODE;
++			rc = haptics_masked_write(chip, chip->cfg_addr_base,
++				HAP_CFG_VISENSE_PEAK_DET_CTL_REG, mask, val);
++		}
++	}
++
++	return rc;
++}
++
++static int haptics_init_fifo_config(struct haptics_chip *chip)
++{
++	/*
++	 * WF_HOLD_FIFO keeps haptics output to the previous value when FIFO runs dry.
++	 * It is helpful to keep haptics play continuously when we have a small FIFO
++	 * space and slow SW response to refill the FIFO samples. However, it also
++	 * brings a side effect that haptics would continue to output if FIFO play
++	 * ends with a non-zero sample while the SPMI_PLAY bit is not de-asserted
++	 * timely. Further, with the default minimal FIFO space of 640 bytes, we have
++	 * never run into the situation when FIFO runs dry because of SW couldn't
++	 * refill the FIFO samples. Hence, keep WF_HOLD_FIFO as disabled.
++	 */
++	if (chip->hw_type >= HAP525_HV)
++		return haptics_masked_write(chip, chip->cfg_addr_base,
++				HAP_CFG_AUTO_SHUTDOWN_CFG_REG, EN_WFHOLD_FIFO_BIT, 0);
++
++	return 0;
++}
++
++static int haptics_auto_brake_manual_config(struct haptics_chip *chip);
++
++static int haptics_hbst_ovp_trim_pbs_trigger(struct haptics_chip *chip)
++{
++	return haptics_trigger_pbs(chip, HAP_HBST_OVP_TRIM_PBS);
++}
++
++static int haptics_hw_init(struct haptics_chip *chip)
++{
++	int rc;
++
++	rc = haptics_config_wa(chip);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_store_cl_brake_settings(chip);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_init_vmax_config(chip);
++	if (rc < 0)
++		return rc;
++
++	if (chip->wa_flags & RESTORE_VMAX_HDRM_1P5V) {
++		rc = haptics_set_vmax_headroom_mv(chip, VMAX_HDRM_MV_DEFAULT);
++		if (rc)
++			return rc;
++	}
++
++	rc = haptics_init_drive_config(chip);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_init_hpwr_config(chip);
++	if (rc < 0)
++		return rc;
++
++	if (chip->config.hbst_ovp_trim) {
++		rc = haptics_hbst_ovp_trim_pbs_trigger(chip);
++		if (rc < 0)
++			return rc;
++	}
++
++	if (chip->config.is_erm)
++		return 0;
++
++	rc = haptics_init_lra_period_config(chip);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_init_preload_pattern_effect(chip);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_init_visense_config(chip);
++	if (rc < 0)
++		return rc;
++
++	if (chip->visense_enabled) {
++		rc = haptics_auto_brake_manual_config(chip);
++		if (rc < 0)
++			return rc;
++	}
++
++	rc = haptics_init_fifo_config(chip);
++	if (rc < 0)
++		return rc;
++
++	return haptics_init_fifo_memory(chip);
++}
++
++static irqreturn_t fifo_empty_irq_handler(int irq, void *data)
++{
++	struct haptics_chip *chip = data;
++	struct fifo_cfg *fifo;
++	struct fifo_play_status *status;
++	u32 samples_left;
++	u8 *samples, val;
++	int rc, num;
++
++	rc = haptics_read(chip, chip->cfg_addr_base,
++			HAP_CFG_INT_RT_STS_REG, &val, 1);
++	if (rc < 0)
++		return IRQ_HANDLED;
++
++	if (!(val & FIFO_EMPTY_BIT))
++		return IRQ_HANDLED;
++
++	mutex_lock(&chip->play.lock);
++	status = &chip->play.fifo_status;
++	if (atomic_read(&status->written_done) == 1) {
++		/*
++		 * Check the FIFO real time fill status before stopping
++		 * play to make sure that all FIFO samples can be played
++		 * successfully. If there are still samples left in FIFO
++		 * memory, defer the stop into erase() function.
++		 */
++		num = haptics_get_available_fifo_memory(chip);
++		if (num != get_max_fifo_samples(chip)) {
++			dev_dbg(chip->dev, "%d FIFO samples still in playing\n",
++					get_max_fifo_samples(chip) - num);
++			goto unlock;
++		}
++		rc = haptics_stop_fifo_play(chip);
++		if (rc < 0)
++			goto unlock;
++
++		dev_dbg(chip->dev, "FIFO playing is done\n");
++	} else {
++		if (atomic_read(&status->cancelled) == 1) {
++			dev_dbg(chip->dev, "FIFO programming got cancelled\n");
++			goto unlock;
++		}
++
++		if (!chip->play.effect)
++			goto unlock;
++
++		fifo = chip->play.effect->fifo;
++		if (!fifo || !fifo->samples) {
++			dev_err(chip->dev, "no FIFO samples available\n");
++			goto unlock;
++		}
++
++		samples_left = fifo->num_s - status->samples_written;
++		num = haptics_get_available_fifo_memory(chip);
++		if (num < 0)
++			goto unlock;
++
++		samples = fifo->samples + status->samples_written;
++
++		/*
++		 * Always use 4-byte burst write in the middle of FIFO programming to
++		 * avoid HW padding zeros during 1-byte write which would cause the HW
++		 * stop driving for the unexpected padding zeros.
++		 */
++		if (num < samples_left)
++			num = round_down(num, HAP_PTN_FIFO_DIN_NUM);
++		else
++			num = samples_left;
++
++		rc = haptics_update_fifo_samples(chip, samples, num, true);
++		if (rc < 0) {
++			dev_err(chip->dev, "Update FIFO samples failed, rc=%d\n",
++					rc);
++			goto unlock;
++		}
++
++		status->samples_written += num;
++		trace_qcom_haptics_fifo_prgm_status(fifo->num_s, status->samples_written, num);
++		if (status->samples_written == fifo->num_s) {
++			dev_dbg(chip->dev, "FIFO programming is done\n");
++			atomic_set(&chip->play.fifo_status.written_done, 1);
++			haptics_set_fifo_empty_threshold(chip, 0);
++		}
++	}
++
++unlock:
++	mutex_unlock(&chip->play.lock);
++	return IRQ_HANDLED;
++}
++
++static int haptics_parse_effect_pattern_data(struct haptics_chip *chip,
++		struct device_node *node, struct haptics_effect *effect)
++{
++	struct haptics_hw_config *config = &chip->config;
++	u32 data[SAMPLES_PER_PATTERN * 3];
++	int rc, tmp, i;
++
++	if (chip->hw_type >= HAP530_HV) {
++		dev_dbg(chip->dev, "haptics module with revision %d no longer supports PATTERNx mode, ignore parsing pattern effect DT\n",
++				chip->hw_type);
++		return 0;
++	}
++
++	effect->t_lra_us = config->t_lra_us;
++	tmp = of_property_count_elems_of_size(node,
++			"qcom,wf-pattern-data", sizeof(u32));
++	if (tmp <= 0) {
++		dev_dbg(chip->dev, "qcom,wf-pattern-data is not defined properly for effect %d\n",
++				effect->id);
++		return 0;
++	}
++
++	if (tmp > SAMPLES_PER_PATTERN * 3) {
++		dev_err(chip->dev, "Pattern src can only play 8 samples at max\n");
++		return -EINVAL;
++	}
++
++	effect->pattern = devm_kzalloc(chip->dev,
++			sizeof(*effect->pattern), GFP_KERNEL);
++	if (!effect->pattern)
++		return -ENOMEM;
++
++	rc = of_property_read_u32_array(node,
++			"qcom,wf-pattern-data", data, tmp);
++	if (rc < 0) {
++		dev_err(chip->dev, "Read wf-pattern-data failed, rc=%d\n",
++				rc);
++		return rc;
++	}
++
++	for (i = 0; i < tmp / 3; i++) {
++		if (data[3 * i] > 0x1ff || data[3 * i + 1] > T_LRA_X_8
++				|| data[3 * i + 2] > 1) {
++			dev_err(chip->dev, "allowed tuples: [amplitude(<= 0x1ff) period(<=6(T_LRA_X_8)) f_lra_x2(0,1)]\n");
++			return -EINVAL;
++		}
++
++		effect->pattern->samples[i].amplitude =
++			(u16)data[3 * i];
++		effect->pattern->samples[i].period =
++			(enum s_period)data[3 * i + 1];
++		effect->pattern->samples[i].f_lra_x2 =
++			(bool)data[3 * i + 2];
++	}
++
++	effect->pattern->preload = of_property_read_bool(node,
++			"qcom,wf-pattern-preload");
++	/*
++	 * Use PATTERN1 src by default, effect with preloaded
++	 * pattern will use PATTERN2 by default and only the
++	 * 1st preloaded pattern will be served.
++	 */
++	effect->src = PATTERN1;
++	if (effect->pattern->preload) {
++		if (config->preload_effect != -EINVAL) {
++			dev_err(chip->dev, "effect %d has been defined as preloaded\n",
++					config->preload_effect);
++			effect->pattern->preload = false;
++		} else {
++			config->preload_effect = effect->id;
++			effect->src = PATTERN2;
++		}
++	}
++
++	if (config->is_erm)
++		effect->pattern->play_rate_us = DEFAULT_ERM_PLAY_RATE_US;
++	else
++		effect->pattern->play_rate_us = config->t_lra_us;
++
++	rc = of_property_read_u32(node, "qcom,wf-pattern-period-us", &tmp);
++	if (rc < 0)
++		dev_dbg(chip->dev, "Read qcom,wf-pattern-period-us failed, rc=%d\n",
++				rc);
++	else
++		effect->pattern->play_rate_us = tmp;
++
++	if (effect->pattern->play_rate_us > TLRA_MAX_US) {
++		dev_err(chip->dev, "qcom,wf-pattern-period-us (%d) exceed the max value: %d\n",
++				effect->pattern->play_rate_us,
++				TLRA_MAX_US);
++		return -EINVAL;
++	}
++
++	effect->pattern->play_length_us = get_pattern_play_length_us(effect->pattern);
++	if (effect->pattern->play_length_us == -EINVAL) {
++		dev_err(chip->dev, "get pattern play length failed\n");
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int haptics_parse_effect_fifo_data(struct haptics_chip *chip,
++		struct device_node *node, struct haptics_effect *effect)
++{
++	struct haptics_hw_config *config = &chip->config;
++	int rc, tmp;
++
++	if (effect->pattern) {
++		dev_dbg(chip->dev, "ignore parsing FIFO effect when pattern effect is present\n");
++		return 0;
++	}
++
++	INIT_LIST_HEAD(&effect->node);
++	tmp = of_property_count_u8_elems(node, "qcom,wf-fifo-data");
++	if (tmp <= 0) {
++		dev_dbg(chip->dev, "qcom,wf-fifo-data is not defined properly for effect %d\n",
++				effect->id);
++		return 0;
++	}
++
++	effect->fifo = devm_kzalloc(chip->dev,
++			sizeof(*effect->fifo), GFP_KERNEL);
++	if (!effect->fifo)
++		return -ENOMEM;
++
++	effect->fifo->samples = devm_kcalloc(chip->dev,
++			tmp, sizeof(u8), GFP_KERNEL);
++	if (!effect->fifo->samples)
++		return -ENOMEM;
++
++	rc = of_property_read_u8_array(node, "qcom,wf-fifo-data",
++			effect->fifo->samples, tmp);
++	if (rc < 0) {
++		dev_err(chip->dev, "Read wf-fifo-data failed, rc=%d\n",
++				rc);
++		return rc;
++	}
++
++	effect->fifo->num_s = tmp;
++	effect->fifo->period_per_s = T_LRA;
++	rc = of_property_read_u32(node, "qcom,wf-fifo-period", &tmp);
++	if (rc < 0) {
++		dev_err(chip->dev, "Get qcom,wf-fifo-period failed, rc=%d\n", rc);
++		return rc;
++	} else if (tmp > F_48KHZ) {
++		dev_err(chip->dev, "FIFO playing period %d is not supported\n",
++				tmp);
++		return -EINVAL;
++	}
++
++	effect->fifo->period_per_s = tmp;
++	effect->fifo->play_length_us =
++		get_fifo_play_length_us(effect->fifo, config->t_lra_us);
++	if (effect->fifo->play_length_us == -EINVAL) {
++		dev_err(chip->dev, "get fifo play length failed\n");
++		return -EINVAL;
++	}
++
++	effect->src = FIFO;
++	effect->fifo->preload = of_property_read_bool(node,
++					"qcom,wf-fifo-preload");
++	if (effect->fifo->preload) {
++		list_add_tail(&effect->node, &chip->mmap_effect_list);
++		chip->mmap_effect_count++;
++	}
++
++	return 0;
++}
++
++static int haptics_parse_effect_brake_data(struct haptics_chip *chip,
++		struct device_node *node, struct haptics_effect *effect)
++{
++	struct haptics_hw_config *config = &chip->config;
++	int rc, tmp;
++
++	effect->brake = devm_kzalloc(chip->dev,
++			sizeof(*effect->brake), GFP_KERNEL);
++	if (!effect->brake)
++		return -ENOMEM;
++
++	memcpy(effect->brake, &config->brake, sizeof(*effect->brake));
++
++	of_property_read_u32(node, "qcom,wf-brake-mode", &effect->brake->mode);
++	if (effect->brake->mode > AUTO_BRAKE) {
++		dev_err(chip->dev, "can't support brake mode: %d\n",
++				effect->brake->mode);
++		return -EINVAL;
++	}
++
++	if (effect->brake->brake_wf == WF_SINE) {
++		of_property_read_u32(node, "qcom,wf-brake-sine-gain",
++				&effect->brake->sine_gain);
++		if (effect->brake->sine_gain > BRAKE_SINE_GAIN_X8) {
++			dev_err(chip->dev, "can't support brake sine gain: %d\n",
++					effect->brake->sine_gain);
++			return -EINVAL;
++		}
++	}
++
++	effect->brake->disabled =
++		of_property_read_bool(node, "qcom,wf-brake-disable");
++	tmp = of_property_count_u8_elems(node, "qcom,wf-brake-pattern");
++	if (tmp > BRAKE_SAMPLE_COUNT) {
++		dev_err(chip->dev, "more than %d brake samples\n",
++				BRAKE_SAMPLE_COUNT);
++		return -EINVAL;
++	}
++
++	if (tmp > 0) {
++		memset(effect->brake->samples, 0,
++				sizeof(u8) * BRAKE_SAMPLE_COUNT);
++		rc = of_property_read_u8_array(node, "qcom,wf-brake-pattern",
++				effect->brake->samples, tmp);
++		if (rc < 0) {
++			dev_err(chip->dev, "Read wf-brake-pattern failed, rc=%d\n",
++					rc);
++			return rc;
++		}
++		verify_brake_samples(effect->brake);
++	} else {
++		if (effect->brake->mode == OL_BRAKE ||
++				effect->brake->mode == CL_BRAKE)
++			effect->brake->disabled = true;
++	}
++
++	effect->brake->play_length_us =
++		get_brake_play_length_us(effect->brake, config->t_lra_us);
++
++	return 0;
++}
++
++static int haptics_parse_per_effect_dt(struct haptics_chip *chip,
++		struct device_node *node, struct haptics_effect *effect)
++{
++	struct haptics_hw_config *config = &chip->config;
++	int rc, tmp;
++
++	if (!effect)
++		return -EINVAL;
++
++	effect->vmax_mv = config->vmax_mv;
++	rc = of_property_read_u32(node, "qcom,wf-vmax-mv", &tmp);
++	if (rc < 0)
++		dev_dbg(chip->dev, "read qcom,wf-vmax-mv failed, rc=%d\n",
++				rc);
++	else
++		effect->vmax_mv = tmp;
++
++	if (effect->vmax_mv > MAX_VMAX_MV) {
++		dev_err(chip->dev, "qcom,wf-vmax-mv (%d) exceed the max value: %d\n",
++				effect->vmax_mv, MAX_VMAX_MV);
++		return -EINVAL;
++	}
++
++	rc = haptics_parse_effect_pattern_data(chip, node, effect);
++	if (rc < 0) {
++		dev_err(chip->dev, "parse effect PATTERN data failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	rc = haptics_parse_effect_fifo_data(chip, node, effect);
++	if (rc < 0) {
++		dev_err(chip->dev, "parse effect FIFO data failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	if (!effect->pattern && !effect->fifo) {
++		dev_err(chip->dev, "no pattern specified for effect %d\n",
++				effect->id);
++		return -EINVAL;
++	}
++
++	rc = haptics_parse_effect_brake_data(chip, node, effect);
++	if (rc < 0) {
++		dev_err(chip->dev, "parse effect brake data failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	if (!config->is_erm)
++		effect->auto_res_disable = of_property_read_bool(node,
++				"qcom,wf-auto-res-disable");
++
++	return 0;
++}
++
++static int haptics_parse_primitives_dt(struct haptics_chip *chip)
++{
++	struct device_node *node = chip->dev->of_node;
++	struct device_node *child;
++	int rc, i = 0, num = 0;
++
++	for_each_available_child_of_node(node, child) {
++		if (of_find_property(child, "qcom,primitive-id", NULL))
++			num++;
++	}
++	if (!num)
++		return 0;
++
++	chip->primitives = devm_kcalloc(chip->dev, num,
++			sizeof(*chip->effects), GFP_KERNEL);
++	if (!chip->primitives)
++		return -ENOMEM;
++
++	for_each_available_child_of_node(node, child) {
++		if (!of_find_property(child, "qcom,primitive-id", NULL))
++			continue;
++
++		rc = of_property_read_u32(child, "qcom,primitive-id", &(chip->primitives[i].id));
++		if (rc < 0) {
++			dev_err(chip->dev, "Read qcom,primitive-id failed, rc=%d\n",
++					rc);
++			of_node_put(child);
++			return rc;
++		}
++
++		rc = haptics_parse_per_effect_dt(chip, child,
++					&chip->primitives[i]);
++		if (rc < 0) {
++			dev_err(chip->dev, "parse primitive %d failed, rc=%d\n",
++					i, rc);
++			of_node_put(child);
++			return rc;
++		}
++		i++;
++	}
++
++	chip->primitives_count = i;
++	dev_dbg(chip->dev, "Dump primitive effect settings as following\n");
++	__dump_effects(chip, chip->primitives, chip->primitives_count);
++
++	return 0;
++}
++
++static int haptics_parse_effects_dt(struct haptics_chip *chip)
++{
++	struct device_node *node = chip->dev->of_node;
++	struct device_node *child;
++	int rc, i = 0, num = 0;
++
++	for_each_available_child_of_node(node, child) {
++		if (of_find_property(child, "qcom,effect-id", NULL))
++			num++;
++	}
++	if (num == 0)
++		return 0;
++
++	chip->effects = devm_kcalloc(chip->dev, num,
++			sizeof(*chip->effects), GFP_KERNEL);
++	if (!chip->effects)
++		return -ENOMEM;
++
++	for_each_available_child_of_node(node, child) {
++		if (!of_find_property(child, "qcom,effect-id", NULL))
++			continue;
++
++		rc = of_property_read_u32(child, "qcom,effect-id", &(chip->effects[i].id));
++		if (rc < 0) {
++			dev_err(chip->dev, "Read qcom,effect-id failed, rc=%d\n",
++					rc);
++			of_node_put(child);
++			return rc;
++		}
++
++		rc = haptics_parse_per_effect_dt(chip, child,
++					&chip->effects[i]);
++		if (rc < 0) {
++			dev_err(chip->dev, "parse effect %d failed, rc=%d\n",
++					i, rc);
++			of_node_put(child);
++			return rc;
++		}
++		i++;
++	}
++
++	chip->effects_count = i;
++	dev_dbg(chip->dev, "Dump predefined effect settings as following\n");
++	__dump_effects(chip, chip->effects, chip->effects_count);
++
++	return 0;
++}
++
++static int haptics_parse_lra_dt(struct haptics_chip *chip)
++{
++	struct haptics_hw_config *config = &chip->config;
++	struct device_node *node = chip->dev->of_node;
++	int rc;
++
++	rc = of_property_read_u32(node, "qcom,lra-period-us",
++					&config->t_lra_us);
++	if (rc < 0) {
++		dev_err(chip->dev, "Read T-LRA failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	if (config->t_lra_us > TLRA_MAX_US) {
++		dev_err(chip->dev, "qcom,lra-period-us (%d) exceed the max value: %d\n",
++				config->t_lra_us, TLRA_MAX_US);
++		return -EINVAL;
++	}
++
++	config->drv_wf = WF_SINE;
++	of_property_read_u32(node, "qcom,drv-sig-shape", &config->drv_wf);
++	if (config->drv_wf >= WF_RESERVED) {
++		dev_err(chip->dev, "Can't support drive shape: %d\n",
++				config->drv_wf);
++		return -EINVAL;
++	}
++
++	config->brake.brake_wf = WF_SINE;
++	of_property_read_u32(node, "qcom,brake-sig-shape",
++			&config->brake.brake_wf);
++	if (config->brake.brake_wf >= WF_RESERVED) {
++		dev_err(chip->dev, "Can't support brake shape: %d\n",
++				config->brake.brake_wf);
++		return -EINVAL;
++	}
++
++	if (config->brake.brake_wf == WF_SINE) {
++		config->brake.sine_gain = BRAKE_SINE_GAIN_X1;
++		of_property_read_u32(node, "qcom,brake-sine-gain",
++				&config->brake.sine_gain);
++		if (config->brake.sine_gain > BRAKE_SINE_GAIN_X8) {
++			dev_err(chip->dev, "Can't support brake sine gain: %d\n",
++					config->brake.sine_gain);
++			return -EINVAL;
++		}
++	}
++
++	if (chip->hw_type >= HAP525_HV)
++		config->measure_lra_impedance = of_property_read_bool(node,
++				"qcom,rt-imp-detect");
++
++	config->sw_cmd_freq_det = of_property_read_bool(node, "qcom,sw-cmd-freq-detect");
++
++	return 0;
++}
++
++static int haptics_get_revision(struct haptics_chip *chip)
++{
++	struct device_node *node = chip->dev->of_node;
++	const __be32 *addr;
++	int rc;
++	u8 val[2];
++
++	/* Get HAP_CFG module revision */
++	addr = of_get_address(node, 0, NULL, NULL);
++	if (!addr) {
++		dev_err(chip->dev, "Read HAPTICS_CFG address failed\n");
++		return -EINVAL;
++	}
++
++	chip->cfg_addr_base = be32_to_cpu(*addr);
++	rc = haptics_read(chip, chip->cfg_addr_base,
++			HAP_CFG_REVISION1_REG, val, 2);
++	if (rc < 0)
++		return rc;
++
++	chip->cfg_revision = (val[1] << 8) | val[0];
++
++	/* Get HAP_PTN module revision */
++	addr = of_get_address(node, 1, NULL, NULL);
++	if (!addr) {
++		dev_err(chip->dev, "Read HAPTICS_PATTERN address failed\n");
++		return -EINVAL;
++	}
++
++	chip->ptn_addr_base = be32_to_cpu(*addr);
++	rc = haptics_read(chip, chip->ptn_addr_base,
++			HAP_PTN_REVISION1_REG, val, 2);
++	if (rc < 0)
++		return rc;
++
++	chip->ptn_revision = (val[1] << 8) | val[0];
++
++	/* Get hw_type based on HAP_CFG and HAP_PTN revision combination */
++	if ((MAJOR_REV(chip->cfg_revision) == HAP_CFG_V2) &&
++			(MAJOR_REV(chip->ptn_revision) == HAP_PTN_V2)) {
++		chip->hw_type = HAP520;
++		chip->fifo_info = &hap520_fifo;
++	} else if ((MAJOR_REV(chip->cfg_revision) == HAP_CFG_V3) &&
++			(MAJOR_REV(chip->ptn_revision) == HAP_PTN_V3)) {
++		chip->hw_type = HAP520_MV;
++		chip->fifo_info = &hap520_mv_fifo;
++	} else if ((MAJOR_REV(chip->cfg_revision) == HAP_CFG_V4) &&
++			(MAJOR_REV(chip->ptn_revision) == HAP_PTN_V4)) {
++		chip->hw_type = HAP525_HV;
++		chip->fifo_info = &hap525_fifo;
++	} else if ((MAJOR_REV(chip->cfg_revision) == HAP_CFG_V5) &&
++			(MAJOR_REV(chip->ptn_revision) == HAP_PTN_V5)) {
++		chip->hw_type = HAP530_HV;
++		chip->fifo_info = &hap530_fifo;
++	} else {
++		dev_err(chip->dev, "haptics revision is not supported\n");
++		return -EOPNOTSUPP;
++	}
++
++	if (is_haptics_external_powered(chip)) {
++		dev_info(chip->dev, "haptics revision: HAP_CFG %#x, HAP_PTN %#x, hw_type %d\n",
++			chip->cfg_revision, chip->ptn_revision, chip->hw_type);
++		return 0;
++	}
++
++	/* Get HAP_HBST revision */
++	addr = of_get_address(node, 2, NULL, NULL);
++	if (!addr) {
++		dev_err(chip->dev, "Read HAPTICS_HBOOST address failed\n");
++		return -EINVAL;
++	}
++
++	chip->hbst_addr_base = be32_to_cpu(*addr);
++	rc = haptics_read(chip, chip->hbst_addr_base,
++			HAP_BOOST_REVISION1, val, 2);
++	if (rc < 0)
++		return rc;
++
++	chip->hbst_revision = (val[1] << 8) | val[0];
++	dev_info(chip->dev, "haptics revision: HAP_CFG %#x, HAP_PTN %#x, HAP_HBST %#x, hw_type %d\n",
++		chip->cfg_revision, chip->ptn_revision, chip->hbst_revision, chip->hw_type);
++
++	return 0;
++}
++
++static int haptics_parse_hpwr_vreg_dt(struct haptics_chip *chip)
++{
++	struct device_node *node = chip->dev->of_node;
++	int rc;
++
++	if (!of_find_property(node, "qcom,hpwr-supply", NULL))
++		return 0;
++
++	chip->hpwr_vreg = devm_regulator_get(chip->dev, "qcom,hpwr");
++	if (IS_ERR(chip->hpwr_vreg)) {
++		rc = PTR_ERR(chip->hpwr_vreg);
++		if (rc != -EPROBE_DEFER)
++			dev_err(chip->dev, "Failed to get qcom,hpwr-supply, rc=%d\n",
++					rc);
++		return rc;
++	}
++
++	rc = of_property_read_u32(node, "qcom,hpwr-voltage-mv",
++			&chip->hpwr_voltage_mv);
++	if (rc < 0) {
++		dev_err(chip->dev, "Failed to read qcom,hpwr-voltage-mv, rc=%d\n",
++				rc);
++		return rc;
++	}
++
++	if (chip->hpwr_voltage_mv == 0 ||
++			chip->hpwr_voltage_mv > NON_HBOOST_MAX_VMAX_MV)
++		return -EINVAL;
++
++	return 0;
++}
++
++static int haptics_parse_dt(struct haptics_chip *chip)
++{
++	struct haptics_hw_config *config = &chip->config;
++	struct device_node *node = chip->dev->of_node;
++	struct platform_device *pdev = to_platform_device(chip->dev);
++	int rc = 0, tmp;
++
++	rc = haptics_parse_hpwr_vreg_dt(chip);
++	if (rc < 0)
++		return rc;
++
++	if (of_find_property(node, "nvmem-cells", NULL)) {
++		chip->cl_brake_nvmem = devm_nvmem_cell_get(chip->dev,
++						"hap_cl_brake");
++		if (IS_ERR(chip->cl_brake_nvmem)) {
++			rc = PTR_ERR(chip->cl_brake_nvmem);
++			if (rc != -EPROBE_DEFER)
++				dev_err(chip->dev, "Failed to get nvmem-cells, rc=%d\n",
++							rc);
++
++			return rc;
++		}
++	}
++
++	if (of_find_property(node, "nvmem", NULL)) {
++		chip->hap_cfg_nvmem =
++			devm_nvmem_device_get(chip->dev, "hap_cfg_sdam");
++		if (IS_ERR(chip->hap_cfg_nvmem)) {
++			rc = PTR_ERR(chip->hap_cfg_nvmem);
++			if (rc != -EPROBE_DEFER)
++				dev_err(chip->dev, "Failed to get hap_cfg nvmem device, rc=%d\n",
++						rc);
++			return rc;
++		}
++	}
++
++	if (of_find_property(node, "qcom,pbs-client", NULL)) {
++		chip->pbs_node = of_parse_phandle(node, "qcom,pbs-client", 0);
++		if (!chip->pbs_node) {
++			dev_err(chip->dev, "Failed to get PBS client\n");
++			return -ENODEV;
++		}
++	}
++
++	rc = haptics_get_revision(chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "Get revision failed, rc=%d\n", rc);
++		goto free_pbs;
++	}
++
++	chip->fifo_empty_irq = platform_get_irq_byname(pdev, "fifo-empty");
++	if (!chip->fifo_empty_irq) {
++		dev_err(chip->dev, "Get fifo-empty IRQ failed\n");
++		rc = -EINVAL;
++		goto free_pbs;
++	}
++
++	config->vmax_mv = DEFAULT_VMAX_MV;
++	of_property_read_u32(node, "qcom,vmax-mv", &config->vmax_mv);
++	if (config->vmax_mv >= MAX_VMAX_MV) {
++		dev_err(chip->dev, "qcom,vmax-mv (%d) exceed the max value: %d\n",
++				config->vmax_mv, MAX_VMAX_MV);
++		rc = -EINVAL;
++		goto free_pbs;
++	}
++
++	config->fifo_empty_thresh = chip->fifo_info->fifo_empty_threshold;
++	of_property_read_u32(node, "qcom,fifo-empty-threshold",
++			&config->fifo_empty_thresh);
++	if (config->fifo_empty_thresh >= get_max_fifo_samples(chip)) {
++		dev_err(chip->dev, "FIFO empty threshold (%d) should be less than %d\n",
++			config->fifo_empty_thresh, get_max_fifo_samples(chip));
++		rc = -EINVAL;
++		goto free_pbs;
++	}
++
++	config->brake.mode = AUTO_BRAKE;
++	of_property_read_u32(node, "qcom,brake-mode", &config->brake.mode);
++	if (config->brake.mode > AUTO_BRAKE) {
++		dev_err(chip->dev, "Can't support brake mode: %d\n",
++				config->brake.mode);
++		rc = -EINVAL;
++		goto free_pbs;
++	}
++
++	config->brake.disabled =
++		of_property_read_bool(node, "qcom,brake-disable");
++	tmp = of_property_count_u8_elems(node, "qcom,brake-pattern");
++	if (tmp > BRAKE_SAMPLE_COUNT) {
++		dev_err(chip->dev, "more than %d brake samples\n",
++				BRAKE_SAMPLE_COUNT);
++		rc = -EINVAL;
++		goto free_pbs;
++	}
++
++	if (tmp > 0) {
++		rc = of_property_read_u8_array(node, "qcom,brake-pattern",
++				config->brake.samples, tmp);
++		if (rc < 0) {
++			dev_err(chip->dev, "Read brake-pattern failed, rc=%d\n",
++					rc);
++			goto free_pbs;
++		}
++		verify_brake_samples(&config->brake);
++	} else {
++		if (config->brake.mode == OL_BRAKE ||
++				config->brake.mode == CL_BRAKE)
++			config->brake.disabled = true;
++	}
++
++	config->is_erm = of_property_read_bool(node, "qcom,use-erm");
++	if (config->is_erm) {
++		config->drv_wf = WF_NO_MODULATION;
++		config->brake.brake_wf = WF_NO_MODULATION;
++	} else {
++		rc = haptics_parse_lra_dt(chip);
++		if (rc < 0) {
++			dev_err(chip->dev, "Parse device-tree for LRA failed, rc=%d\n",
++					rc);
++			goto free_pbs;
++		}
++	}
++
++	if (chip->hw_type >= HAP525_HV)
++		config->hbst_ovp_trim = of_property_read_bool(node, "qcom,hbst-ovp-trim");
++
++	config->preload_effect = -EINVAL;
++	rc = haptics_parse_effects_dt(chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "Parse device-tree for effects failed, rc=%d\n",
++				 rc);
++		goto free_pbs;
++	}
++
++	rc = haptics_parse_primitives_dt(chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "Parse device-tree for primitives failed, rc=%d\n",
++				rc);
++		goto free_pbs;
++	}
++
++	return 0;
++free_pbs:
++	if (chip->pbs_node) {
++		of_node_put(chip->pbs_node);
++		chip->pbs_node = NULL;
++	}
++
++	return rc;
++}
++
++static int swr_slave_reg_enable(struct regulator_dev *rdev)
++{
++	struct haptics_chip *chip = rdev_get_drvdata(rdev);
++	int rc;
++	u8 mask = SWR_PAT_INPUT_EN_BIT | SWR_PAT_RES_N_BIT | SWR_PAT_CFG_EN_BIT;
++
++	if (chip->swr_slave_enabled)
++		return 0;
++
++	rc = haptics_runtime_resume_get(chip);
++	if (rc < 0)
++		return rc;
++
++	if (chip->wa_flags & VISENSE_RECOVERY_EN) {
++		rc = haptics_visense_handshake_enable(chip, true);
++		if (rc < 0)
++			goto auto_suspend;
++	}
++
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_SWR_ACCESS_REG, mask, mask);
++	if (rc < 0) {
++		dev_err(chip->dev, "Failed to enable SWR_PAT, rc=%d\n",
++				rc);
++		goto auto_suspend;
++	}
++
++	if (!(chip->wa_flags & RECOVER_SWR_SLAVE))
++		goto done;
++
++	/*
++	 * If haptics has already been in SWR mode when enabling the SWR
++	 * slave, it means that the haptics module was stuck in prevous
++	 * SWR play. Then toggle HAPTICS_EN to reset haptics module and
++	 * ignore SWR mode until next SWR slave enable request is coming.
++	 */
++	if (is_swr_play_enabled(chip)) {
++		rc = haptics_ignore_swr_play(chip, true);
++		if (rc < 0)
++			goto auto_suspend;
++
++		rc = haptics_toggle_module_enable(chip);
++		if (rc < 0)
++			goto auto_suspend;
++	} else {
++		rc = haptics_ignore_swr_play(chip, false);
++		if (rc < 0)
++			goto auto_suspend;
++	}
++done:
++	chip->swr_slave_enabled = true;
++	return 0;
++auto_suspend:
++	haptics_runtime_autosuspend_put(chip);
++	return rc;
++}
++
++static int swr_slave_reg_disable(struct regulator_dev *rdev)
++{
++	struct haptics_chip *chip = rdev_get_drvdata(rdev);
++	int rc = 0;
++
++	if (!chip->swr_slave_enabled)
++		return 0;
++
++	/* Keep SWR slave always enabled for HAP530_HV */
++	if (chip->hw_type == HAP530_HV)
++		goto done;
++
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_SWR_ACCESS_REG,
++			SWR_PAT_INPUT_EN_BIT | SWR_PAT_RES_N_BIT |
++			SWR_PAT_CFG_EN_BIT, 0);
++	if (rc < 0) {
++		dev_err(chip->dev, "Failed to disable SWR_PAT, rc=%d\n", rc);
++		goto auto_suspend;
++	}
++done:
++	chip->swr_slave_enabled = false;
++auto_suspend:
++	haptics_runtime_autosuspend_put(chip);
++	return rc;
++}
++
++static int swr_slave_reg_is_enabled(struct regulator_dev *rdev)
++{
++	struct haptics_chip *chip = rdev_get_drvdata(rdev);
++
++	return chip->swr_slave_enabled;
++}
++
++static const struct regulator_ops swr_slave_reg_ops = {
++	.enable		= swr_slave_reg_enable,
++	.disable	= swr_slave_reg_disable,
++	.is_enabled	= swr_slave_reg_is_enabled,
++};
++
++static struct regulator_desc swr_slave_reg_rdesc = {
++	.owner		= THIS_MODULE,
++	.of_match	= "qcom,hap-swr-slave-reg",
++	.name		= "hap-swr-slave-reg",
++	.type		= REGULATOR_VOLTAGE,
++	.ops		= &swr_slave_reg_ops,
++};
++
++static int haptics_init_swr_slave_regulator(struct haptics_chip *chip)
++{
++	struct regulator_config cfg = {};
++	u8 val, mask;
++	int rc = 0;
++
++	if (chip->hw_type != HAP530_HV) {
++		rc = haptics_read(chip, chip->cfg_addr_base,
++				HAP_CFG_SWR_ACCESS_REG, &val, 1);
++		if (rc < 0) {
++			dev_err(chip->dev, "Failed to read SWR_ACCESS, rc=%d\n",
++					rc);
++			return rc;
++		}
++
++		mask = SWR_PAT_INPUT_EN_BIT | SWR_PAT_RES_N_BIT | SWR_PAT_CFG_EN_BIT;
++		val &= mask;
++		chip->swr_slave_enabled = ((val == mask) ? true : false);
++	}
++
++	cfg.dev = chip->dev;
++	cfg.driver_data = chip;
++	chip->swr_slave_rdev = devm_regulator_register(chip->dev,
++			&swr_slave_reg_rdesc, &cfg);
++	if (IS_ERR(chip->swr_slave_rdev)) {
++		rc = PTR_ERR(chip->swr_slave_rdev);
++		chip->swr_slave_rdev = NULL;
++
++		if (rc != -EPROBE_DEFER)
++			dev_err(chip->dev, "register swr-slave-reg regulator failed, rc=%d\n",
++					rc);
++	}
++
++	return rc;
++}
++
++static int haptics_pbs_trigger_isc_config(struct haptics_chip *chip)
++{
++	int rc;
++
++	if (chip->pbs_node == NULL) {
++		dev_err(chip->dev, "PBS device is not defined\n");
++		return -ENODEV;
++	}
++
++	rc = qpnp_pbs_trigger_single_event(chip->pbs_node);
++	if (rc < 0)
++		dev_err(chip->dev, "Trigger PBS to config ISC failed, rc=%d\n",
++				rc);
++
++	return rc;
++}
++
++#define MAX_SWEEP_STEPS		5
++#define MIN_DUTY_MILLI_PCT	0
++#define MAX_DUTY_MILLI_PCT	100000
++#define LRA_CONFIG_REGS		2
++static u32 get_lra_impedance_capable_max(struct haptics_chip *chip)
++{
++	u32 mohms;
++	u32 max_vmax_mv, min_isc_ma;
++
++	switch (chip->hw_type) {
++	case HAP520:
++		min_isc_ma = 250;
++		if (chip->clamp_at_5v)
++			max_vmax_mv = 5000;
++		else
++			max_vmax_mv = 10000;
++		break;
++	case HAP520_MV:
++		max_vmax_mv = 5000;
++		min_isc_ma = 140;
++		break;
++	case HAP525_HV:
++	case HAP530_HV:
++		if (chip->clamp_at_5v) {
++			max_vmax_mv = 5000;
++			min_isc_ma = 125;
++		} else {
++			max_vmax_mv = 10000;
++			min_isc_ma = 250;
++		}
++		break;
++	default:
++		return 0;
++	}
++
++	mohms = (max_vmax_mv * 1000) / min_isc_ma;
++	if (is_haptics_external_powered(chip))
++		mohms = (chip->hpwr_voltage_mv * 1000) / min_isc_ma;
++
++	dev_dbg(chip->dev, "LRA impedance capable max: %u mohms\n", mohms);
++	return mohms;
++}
++
++#define RT_IMPD_DET_VMAX_DEFAULT_MV		4500
++static int haptics_measure_realtime_lra_impedance(struct haptics_chip *chip)
++{
++	u32 vmax_mv, nominal_ohm, current_ma, vmax_margin_mv, play_length_us, lsb_mohm;
++	struct pattern_cfg pattern = {
++		.samples = {
++			    {0xff, T_LRA, false},
++			    {0, 0, 0},
++			    {0, 0, 0},
++			    {0, 0, 0},
++			    {0, 0, 0},
++			    {0, 0, 0},
++			    {0, 0, 0},
++			    {0, 0, 0},
++			   },
++		.play_rate_us = chip->config.t_lra_us + 2000, /* drive off resonance of the LRA */
++		.play_length_us = chip->config.t_lra_us + 2000, /* drive it at least 1 cycle */
++		.preload = false,
++	};
++	u8 samples[4] = {0x7f, 0x7f, 0, 0};
++	u32 t_lra_us = (chip->config.cl_t_lra_us * 3) / 2; /* drive off resonance in FIFO mode */
++	struct fifo_cfg fifo = {
++		.samples = samples,
++		.num_s = ARRAY_SIZE(samples),
++		.period_per_s = T_LRA_DIV_2, /* half cycle with T_LRA */
++		.play_length_us = t_lra_us + 2000,
++		.preload = false,
++	};
++	u8 val, current_sel;
++	int rc;
++
++	/* calculate Vmax according to nominal resistance */
++	vmax_mv = RT_IMPD_DET_VMAX_DEFAULT_MV;
++	current_sel = chip->clamp_at_5v ? CURRENT_SEL_VAL_125MA : CURRENT_SEL_VAL_250MA;
++	if (chip->hap_cfg_nvmem != NULL) {
++		rc = haptics_get_lra_nominal_impedance(chip, &nominal_ohm);
++		if (!rc) {
++			/*
++			 * use 250mA current_sel when nominal impedance is lower than 15 Ohms
++			 * and use 125mA detection when nominal impedance is higher than 40 Ohms
++			 */
++			if (nominal_ohm < 15)
++				current_sel = CURRENT_SEL_VAL_250MA;
++			else if (nominal_ohm > 40)
++				current_sel = CURRENT_SEL_VAL_125MA;
++
++			/*
++			 * give 8 Ohms margin (1000mV / 125mA, or 2000mV / 250mA) for wider
++			 * detectability
++			 */
++			if (current_sel == CURRENT_SEL_VAL_125MA) {
++				current_ma = 125;
++				vmax_margin_mv = 1000;
++			} else {
++				current_ma = 250;
++				vmax_margin_mv = 2000;
++			}
++
++			vmax_mv = max(vmax_mv, nominal_ohm * current_ma + vmax_margin_mv);
++		}
++	}
++
++	dev_dbg(chip->dev, "Set %u mV Vmax for impedance detection\n", vmax_mv);
++	rc = haptics_set_vmax_mv(chip, vmax_mv);
++	if (rc < 0)
++		return rc;
++
++	/* set current for imp_det comparator and enable it */
++	val = LRA_IMPEDANCE_MEAS_EN_BIT | current_sel;
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_RT_LRA_IMPD_MEAS_CFG_REG,
++			LRA_IMPEDANCE_MEAS_EN_BIT |
++			LRA_IMPEDANCE_MEAS_CURRENT_SEL_BIT, val);
++	if (rc < 0)
++		return rc;
++
++	/* disconnect imp_det comparator to avoid it impact SC behavior */
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_ISC_CFG_REG, EN_IMP_DET_HAP525_HV_BIT, 0);
++	if (rc < 0)
++		goto restore;
++
++	if (chip->hw_type >= HAP530_HV) {
++		/* drive off resonance of the LRA */
++		rc = haptics_config_openloop_lra_period(chip, t_lra_us);
++		if (rc < 0)
++			goto restore;
++
++		rc = haptics_enable_autores(chip, false);
++		if (rc < 0)
++			goto restore;
++
++		chip->play.brake = NULL;
++		rc = haptics_set_fifo(chip, &fifo);
++		if (rc < 0)
++			goto restore;
++
++		chip->play.pattern_src = FIFO;
++		play_length_us = fifo.play_length_us;
++	} else {
++		/* play 1 drive cycle using PATTERN1 source */
++		rc = haptics_set_pattern(chip, &pattern, PATTERN1);
++		if (rc < 0)
++			goto restore;
++
++		chip->play.pattern_src = PATTERN1;
++		play_length_us = pattern.play_length_us;
++	}
++
++	rc = haptics_enable_play(chip, true);
++	if (rc < 0)
++		goto restore;
++
++	usleep_range(play_length_us, play_length_us + 1);
++
++	if (chip->hw_type >= HAP530_HV) {
++		rc = haptics_stop_fifo_play(chip);
++		if (rc < 0)
++			goto restore;
++
++		val = 0;
++		rc = haptics_write(chip, chip->cfg_addr_base,
++				HAP_CFG_MOD_STATUS_SEL_REG, &val, 1);
++	} else {
++		rc = haptics_enable_play(chip, false);
++	}
++	if (rc < 0)
++		goto restore;
++
++	/* read the measured LRA impedance */
++	rc = haptics_read(chip, chip->cfg_addr_base,
++			HAP_CFG_REAL_TIME_LRA_IMPEDANCE_REG, &val, 1);
++	if (rc < 0)
++		goto restore;
++
++	lsb_mohm = LRA_IMPEDANCE_MOHMS_LSB;
++	if (chip->hw_type >= HAP530_HV)
++		lsb_mohm = HAP530_LRA_IMPEDANCE_MOHMS_LSB;
++
++	chip->config.lra_measured_mohms = val * lsb_mohm;
++	dev_dbg(chip->dev, "measured LRA impedance: %u mohm",
++			chip->config.lra_measured_mohms);
++	/* store the detected LRA impedance into SDAM for future usage */
++	if (chip->hap_cfg_nvmem != NULL) {
++		rc = nvmem_device_write(chip->hap_cfg_nvmem,
++				HAP_LRA_DETECTED_OHM_SDAM_OFFSET, 1, &val);
++		if (rc < 0)
++			dev_err(chip->dev, "write measured impedance value into SDAM failed, rc=%d\n",
++					rc);
++	}
++restore:
++	if (rc < 0)
++		dev_err(chip->dev, "measure LRA impedance failed, rc=%d\n", rc);
++
++	/* restore T_LRA */
++	if (chip->hw_type >= HAP530_HV) {
++		rc = haptics_config_openloop_lra_period(chip, chip->config.cl_t_lra_us);
++		if (rc)
++			return rc;
++	}
++
++	return haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_RT_LRA_IMPD_MEAS_CFG_REG,
++			LRA_IMPEDANCE_MEAS_EN_BIT, 0);
++}
++
++static int haptics_lra_impedance_sweeping(struct haptics_chip *chip, u32 *low, u32 *high)
++{
++	u32 amplitude, duty_milli_pct, low_milli_pct, high_milli_pct;
++	int i, rc;
++	u8 val;
++
++	low_milli_pct = MIN_DUTY_MILLI_PCT;
++	high_milli_pct = MAX_DUTY_MILLI_PCT;
++	/* Sweep duty cycle using binary approach */
++	for (i = 0; i < MAX_SWEEP_STEPS; i++) {
++		/* Set direct play amplitude */
++		duty_milli_pct = (low_milli_pct + high_milli_pct) / 2;
++		amplitude = (duty_milli_pct * DIRECT_PLAY_MAX_AMPLITUDE)
++						/ 100000;
++		rc = haptics_set_direct_play(chip, (u8)amplitude);
++		if (rc < 0)
++			return rc;
++
++		dev_dbg(chip->dev, "sweeping milli_pct %u, amplitude %#x\n",
++				duty_milli_pct, amplitude);
++		/* Enable play */
++		chip->play.pattern_src = DIRECT_PLAY;
++		rc = haptics_enable_play(chip, true);
++		if (rc < 0)
++			return rc;
++
++		/* Play a cycle then read SC fault status */
++		usleep_range(chip->config.t_lra_us,
++				chip->config.t_lra_us + 1000);
++		rc = haptics_read(chip, chip->cfg_addr_base,
++				HAP_CFG_FAULT_STATUS_REG, &val, 1);
++		if (rc < 0)
++			return rc;
++
++		if (val & SC_FLAG_BIT)
++			high_milli_pct = duty_milli_pct;
++		else
++			low_milli_pct = duty_milli_pct;
++
++		/* Disable play */
++		rc = haptics_enable_play(chip, false);
++		if (rc < 0)
++			return rc;
++
++		/* Sleep 4ms */
++		usleep_range(4000, 5000);
++	}
++
++	*low = low_milli_pct;
++	*high = high_milli_pct;
++	return 0;
++}
++
++static int haptics_detect_lra_impedance(struct haptics_chip *chip)
++{
++	int rc, i;
++	struct haptics_reg_info lra_config[LRA_CONFIG_REGS] = {
++		{ HAP_CFG_DRV_WF_SEL_REG, 0x10 },
++		{ HAP_CFG_VMAX_HDRM_REG, 0x00 },
++	};
++	struct haptics_reg_info backup[LRA_CONFIG_REGS];
++	u8 cfg1, cfg2, reg1, reg2, mask1, mask2, val1, val2;
++	u32 lra_min_mohms, lra_max_mohms, capability_mohms;
++	u32 low_milli_pct, high_milli_pct;
++
++	/* Backup default register values */
++	memcpy(backup, lra_config, sizeof(backup));
++	for (i = 0; i < LRA_CONFIG_REGS; i++) {
++		rc = haptics_read(chip, chip->cfg_addr_base,
++				backup[i].addr, &backup[i].val, 1);
++		if (rc < 0)
++			return rc;
++	}
++
++	if (chip->hw_type == HAP520) {
++		/* Trigger PBS to config 250mA ISC setting */
++		rc = haptics_pbs_trigger_isc_config(chip);
++		if (rc < 0)
++			return rc;
++	} else {
++		 /* Config ISC_CFG settings for LRA impedance_detection */
++		switch (chip->hw_type) {
++		case HAP520_MV:
++			reg1 = HAP_CFG_ISC_CFG_REG;
++			mask1 = ILIM_CC_EN_BIT;
++			val1 = ILIM_CC_EN_BIT;
++			reg2 = HAP_CFG_ISC_CFG2_REG;
++			mask2 = EN_SC_DET_P_HAP520_MV_BIT |
++				EN_SC_DET_N_HAP520_MV_BIT |
++				ISC_THRESH_HAP520_MV_MASK;
++			val2 = EN_SC_DET_P_HAP520_MV_BIT|
++				EN_SC_DET_N_HAP520_MV_BIT|
++				ISC_THRESH_HAP520_MV_140MA;
++			break;
++		case HAP525_HV:
++		case HAP530_HV:
++			reg1 = HAP_CFG_ISC_CFG_REG;
++			mask1 = EN_SC_DET_P_HAP525_HV_BIT | EN_SC_DET_N_HAP525_HV_BIT |
++				EN_IMP_DET_HAP525_HV_BIT | ILIM_PULSE_DENSITY_MASK;
++			val1 = EN_IMP_DET_HAP525_HV_BIT |
++				FIELD_PREP(ILIM_PULSE_DENSITY_MASK, ILIM_DENSITY_8_OVER_64_CYCLES);
++			reg2 = HAP_CFG_RT_LRA_IMPD_MEAS_CFG_REG;
++			mask2 = LRA_IMPEDANCE_MEAS_EN_BIT | LRA_IMPEDANCE_MEAS_CURRENT_SEL_BIT;
++			val2 = chip->clamp_at_5v ? CURRENT_SEL_VAL_125MA : CURRENT_SEL_VAL_250MA;
++			val2 |= LRA_IMPEDANCE_MEAS_EN_BIT;
++			break;
++		default:
++			dev_err(chip->dev, "unsupported HW type: %d\n",
++					chip->hw_type);
++			return -EOPNOTSUPP;
++		}
++
++		 /* save ISC_CFG default settings */
++		rc = haptics_read(chip, chip->cfg_addr_base, reg1, &cfg1, 1);
++		if (rc < 0)
++			return rc;
++
++		rc = haptics_read(chip, chip->cfg_addr_base, reg2, &cfg2, 1);
++		if (rc < 0)
++			return rc;
++
++		/* update ISC_CFG settings for the detection */
++		rc = haptics_masked_write(chip, chip->cfg_addr_base, reg1, mask1, val1);
++		if (rc < 0)
++			return rc;
++
++		rc = haptics_masked_write(chip, chip->cfg_addr_base, reg2, mask2, val2);
++		if (rc < 0)
++			goto restore;
++	}
++
++	/* Set square drive waveform, 10V Vmax, no HDRM */
++	rc = __haptics_set_vmax_mv(chip, 10000);
++	if (rc < 0)
++		goto restore;
++
++	for (i = 0; i < LRA_CONFIG_REGS; i++) {
++		rc = haptics_write(chip, chip->cfg_addr_base,
++				lra_config[i].addr, &lra_config[i].val, 1);
++		if (rc < 0)
++			goto restore;
++	}
++
++	rc = haptics_enable_hpwr_vreg(chip, true);
++	if (rc < 0)
++		goto restore;
++
++
++	rc = haptics_lra_impedance_sweeping(chip, &low_milli_pct, &high_milli_pct);
++	if (rc < 0)
++		goto restore;
++
++	capability_mohms = get_lra_impedance_capable_max(chip);
++	lra_min_mohms = low_milli_pct * capability_mohms / 100000;
++	lra_max_mohms = high_milli_pct * capability_mohms / 100000;
++	if (lra_min_mohms == 0)
++		dev_warn(chip->dev, "Short circuit detected!\n");
++	else if (lra_max_mohms >= capability_mohms)
++		dev_warn(chip->dev, "Open circuit detected!\n");
++	else
++		dev_dbg(chip->dev, "LRA impedance is between %u - %u mohms\n",
++				lra_min_mohms, lra_max_mohms);
++
++	chip->config.lra_min_mohms = lra_min_mohms;
++	chip->config.lra_max_mohms = lra_max_mohms;
++	chip->config.lra_open_mohms = capability_mohms;
++restore:
++	/* Disable play in case it's not been disabled */
++	haptics_enable_play(chip, false);
++	rc = haptics_enable_hpwr_vreg(chip, false);
++	if (rc < 0)
++		return rc;
++
++	if (chip->hw_type == HAP520) {
++		/* Trigger PBS to restore 1500mA ISC setting */
++		rc = haptics_pbs_trigger_isc_config(chip);
++		if (rc < 0)
++			return rc;
++	} else {
++		/* restore ISC_CFG settings to default */
++		rc = haptics_write(chip, chip->cfg_addr_base, reg1, &cfg1, 1);
++		if (rc < 0)
++			return rc;
++
++		rc = haptics_write(chip, chip->cfg_addr_base, reg2, &cfg2, 1);
++		if (rc < 0)
++			return rc;
++	}
++
++	/* Restore driver waveform, Vmax, HDRM settings */
++	for (i = 0; i < LRA_CONFIG_REGS; i++) {
++		rc = haptics_write(chip, chip->cfg_addr_base,
++				backup[i].addr, &backup[i].val, 1);
++		if (rc < 0)
++			break;
++	}
++
++	return rc;
++}
++
++static int haptics_enable_autores_cal(struct haptics_chip *chip, bool enable)
++{
++	u8 val = 0;
++	int rc;
++
++	if (enable)
++		val = AUTORES_CAL_TRIG_BIT | AUTORES_CAL_TIMER_6_HALF_CYCLES;
++	else
++		val = AUTORES_CAL_TIMER_4_HALF_CYCLES;
++
++	rc = haptics_write(chip, chip->ptn_addr_base,
++			HAP_PTN_AUTORES_CAL_CFG_REG, &val, 1);
++
++	return rc;
++}
++
++#define LRA_CALIBRATION_VMAX_HDRM_MV	500
++static int haptics_detect_lra_frequency(struct haptics_chip *chip)
++{
++	int rc;
++	u8 autores_cfg, drv_duty_cfg, amplitude, mask, val = 0;
++	u32 vmax_mv = chip->config.vmax_mv;
++
++	rc = haptics_read(chip, chip->cfg_addr_base,
++			HAP_CFG_AUTORES_CFG_REG, &autores_cfg, 1);
++	if (rc < 0) {
++		dev_err(chip->dev, "Read AUTORES_CFG failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	rc = haptics_read(chip, chip->cfg_addr_base,
++			HAP_CFG_DRV_DUTY_CFG_REG, &drv_duty_cfg, 1);
++	if (rc < 0) {
++		dev_err(chip->dev, "Read DRV_DUTY_CFG failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	if (!chip->config.sw_cmd_freq_det)
++		val = AUTORES_EN_BIT;
++
++	if (chip->hw_type >= HAP525_HV) {
++		val |= AUTORES_EN_DLY_7_CYCLES << AUTORES_EN_DLY_SHIFT |
++			AUTORES_ERR_WINDOW_25_PERCENT;
++	} else {
++		val |= AUTORES_EN_DLY_6_CYCLES << AUTORES_EN_DLY_SHIFT|
++			AUTORES_ERR_WINDOW_50_PERCENT;
++	}
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_AUTORES_CFG_REG, AUTORES_EN_BIT |
++			AUTORES_EN_DLY_MASK | AUTORES_ERR_WINDOW_MASK,
++			val);
++	if (rc < 0)
++		return rc;
++
++	if (chip->hw_type >= HAP525_HV) {
++		mask = ADT_DRV_DUTY_EN_BIT | ADT_BRK_DUTY_EN_BIT |
++			DRV_DUTY_MASK | BRK_DUTY_MASK;
++		val = DRV_DUTY_62P5_PCT << DRV_DUTY_SHIFT | BRK_DUTY_75_PCT;
++	} else {
++		mask = ADT_DRV_DUTY_EN_BIT;
++		val = 0;
++	}
++
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_DRV_DUTY_CFG_REG, mask, val);
++	if (rc < 0)
++		goto restore;
++
++	rc = haptics_config_openloop_lra_period(chip, chip->config.t_lra_us);
++	if (rc < 0)
++		goto restore;
++
++	rc = haptics_set_vmax_headroom_mv(chip, LRA_CALIBRATION_VMAX_HDRM_MV);
++	if (rc < 0)
++		goto restore;
++
++	/* Fix Vmax to (hpwr_vreg_mv - hdrm_mv) in non-HBOOST regulator case */
++	if (is_haptics_external_powered(chip))
++		vmax_mv = chip->hpwr_voltage_mv - LRA_CALIBRATION_VMAX_HDRM_MV;
++
++	rc = haptics_set_vmax_mv(chip, vmax_mv);
++
++	if (rc < 0)
++		goto restore;
++
++	amplitude = get_direct_play_max_amplitude(chip);
++	rc = haptics_set_direct_play(chip, amplitude);
++	if (rc < 0)
++		goto restore;
++
++	rc = haptics_enable_hpwr_vreg(chip, true);
++	if (rc < 0)
++		goto restore;
++
++	chip->play.pattern_src = DIRECT_PLAY;
++	rc = haptics_enable_play(chip, true);
++	if (rc < 0)
++		goto restore;
++
++	if (chip->config.sw_cmd_freq_det) {
++		msleep(60);
++		/* Enable SW based auto resonance */
++		rc = haptics_enable_autores_cal(chip, true);
++		if (rc < 0)
++			goto restore;
++
++		msleep(20);
++
++		/* Get the 1st detected frequency */
++		rc = haptics_get_closeloop_lra_period(chip, false);
++		if (rc < 0)
++			goto restore;
++
++		msleep(50);
++
++		/* Reset SW based auto resonance */
++		rc = haptics_enable_autores_cal(chip, false);
++		if (rc < 0)
++			goto restore;
++
++		rc = haptics_enable_autores_cal(chip, true);
++		if (rc < 0)
++			goto restore;
++
++		msleep(20);
++
++		/* Get the 2nd detected frequency */
++		rc = haptics_get_closeloop_lra_period(chip, false);
++		if (rc < 0)
++			goto restore;
++
++		usleep_range(4000, 4001);
++
++	} else {
++		/* Wait for ~150ms to get the LRA calibration result */
++		msleep(150);
++
++		rc = haptics_get_closeloop_lra_period(chip, false);
++		if (rc < 0)
++			goto restore;
++	}
++
++	rc = haptics_enable_play(chip, false);
++	if (rc < 0)
++		goto restore;
++
++	if (chip->config.sw_cmd_freq_det)
++		haptics_enable_autores_cal(chip, false);
++
++	haptics_config_openloop_lra_period(chip, chip->config.cl_t_lra_us);
++
++restore:
++	/* Disable play in case it's not been disabled */
++	haptics_enable_play(chip, false);
++	rc = haptics_enable_hpwr_vreg(chip, false);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_write(chip, chip->cfg_addr_base,
++			HAP_CFG_AUTORES_CFG_REG, &autores_cfg, 1);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_write(chip, chip->cfg_addr_base,
++			HAP_CFG_DRV_DUTY_CFG_REG, &drv_duty_cfg, 1);
++
++	return rc;
++}
++
++static int haptics_auto_brake_manual_config(struct haptics_chip *chip)
++{
++	bool auto_brake_cal_done = false;
++	unsigned int addr;
++	u8 val[2];
++	int rc;
++
++	if (chip->config.brake.mode != AUTO_BRAKE)
++		return 0;
++
++	if (!chip->hap_cfg_nvmem)
++		return -EOPNOTSUPP;
++
++	rc = nvmem_device_read(chip->hap_cfg_nvmem,
++				HAP_AUTO_BRAKE_CAL_DONE_OFFSET, 1, val);
++	if (rc <= 0) {
++		dev_err(chip->dev, "read AUTO_BRAKE_CAL_DONE failed, rc=%d\n",
++			rc);
++		return rc;
++	}
++
++	auto_brake_cal_done = val[0] & AUTO_BRAKE_CAL_DONE;
++	dev_dbg(chip->dev, "auto_brake_cal_done: %u\n", auto_brake_cal_done);
++
++	/* Read RNAT and RCAL values from SDAM and write to HAP_CFG */
++	addr = auto_brake_cal_done ? HAP_AUTO_BRAKE_RNAT_OFFSET :
++		HAP_AUTO_BRAKE_RNAT_DEFAULT_OFFSET;
++	rc = nvmem_device_read(chip->hap_cfg_nvmem, addr, 2, val);
++	if (rc < 0) {
++		dev_err(chip->dev, "Error reading RNAT/RCAL values, rc=%d\n",
++			rc);
++		return rc;
++	}
++
++	val[0] &= CL_BRAKE_RNAT_MASK;
++	rc = haptics_write(chip, chip->cfg_addr_base, HAP_CFG_CL_BRAKE_RNAT_REG,
++			&val[0], 1);
++	if (rc < 0)
++		return rc;
++
++	val[1] &= CL_BRAKE_RCAL_MASK;
++	rc = haptics_write(chip, chip->cfg_addr_base, HAP_CFG_CL_BRAKE_RCAL_REG,
++			&val[1], 1);
++	if (rc < 0)
++		return rc;
++
++	/* Read T_WIND_STS values from SDAM and write to HAP_PTN */
++	addr = auto_brake_cal_done ? HAP_AUTO_BRAKE_T_WIND_STS_MSB_OFFSET :
++		HAP_AUTO_BRAKE_T_WIND_MSB_DEF_OFFSET;
++	rc = nvmem_device_read(chip->hap_cfg_nvmem, addr, 2, val);
++	if (rc < 0) {
++		dev_err(chip->dev, "Error reading T_WIND_STS values, rc=%d\n",
++			rc);
++		return rc;
++	}
++
++	val[0] &= HAP_PTN_TWIND_CAL_MSB_MASK;
++	rc = haptics_write(chip, chip->ptn_addr_base,
++			HAP_PTN_FORCE_TWIND_CAL_MSB, val, 2);
++	if (rc < 0)
++		return rc;
++
++	/* Read BRAKE_AMP_0 value from SDAM and write to HAP_PTN */
++	rc = nvmem_device_read(chip->hap_cfg_nvmem,
++			HAP_AUTO_BRAKE_CAL_BRAKE_AMP0_OFFSET, 1, val);
++	if (rc < 0) {
++		dev_err(chip->dev, "Error reading BRAKE_AMP0 value, rc=%d\n",
++			rc);
++		return rc;
++	}
++
++	rc = haptics_write(chip, chip->ptn_addr_base, HAP_PTN_BRAKE_AMP_0_REG,
++			&val[0], 1);
++	if (rc < 0)
++		return rc;
++
++	/* Read BRAKE_RSET value from SDAM and write to HAP_CFG */
++	rc = nvmem_device_read(chip->hap_cfg_nvmem,
++			HAP_AUTO_BRAKE_CAL_CL_BRAKE_RSET_OFFSET, 1, val);
++	if (rc < 0) {
++		dev_err(chip->dev, "Error reading BRAKE_RSET value, rc=%d\n",
++			rc);
++		return rc;
++	}
++
++	val[0] &= FORCE_RNAT_RCAL_PARAM_MASK;
++	rc = haptics_masked_write(chip, chip->cfg_addr_base,
++			HAP_CFG_CL_BRAKE_RSET_REG, FORCE_RNAT_RCAL_PARAM_MASK,
++			val[0]);
++	if (rc < 0)
++		return rc;
++
++	/* Run auto brake re-calibration */
++	val[0] = BRAKE_CAL_CL_RECAL;
++	rc = haptics_masked_write(chip, chip->cfg_addr_base, HAP_CFG_CAL_EN_REG,
++			BRAKE_CAL_MASK, val[0]);
++	if (rc < 0)
++		return rc;
++
++	/* As per HW recommendation, wait for 5 uS before clearing BRAKE_CAL */
++	udelay(5);
++
++	val[0] = BRAKE_CAL_NONE;
++	rc = haptics_masked_write(chip, chip->cfg_addr_base, HAP_CFG_CAL_EN_REG,
++			BRAKE_CAL_MASK, val[0]);
++
++	/*
++	 * Read back whether BRAKE_CAL_DONE is high and the calibration is
++	 * successful or not.
++	 */
++	rc = haptics_get_status_data(chip, AUTO_BRAKE_CAL_STS, val);
++	if (!rc)
++		dev_dbg(chip->dev, "Manual AUTO_BRAKE_CAL_DONE: %#x %s\n",
++			 val[1], val[1] & BIT(2) ? "Success" : "Fail");
++
++	return rc;
++}
++
++#define AUTO_BRAKE_CAL_POLLING_COUNT	10
++#define AUTO_BRAKE_CAL_POLLING_STEP_US	20000
++#define AUTO_BRAKE_CAL_WAIT_MS		800
++
++static int haptics_auto_brake_pbs_trigger(struct haptics_chip *chip)
++{
++	u32 retry_count = AUTO_BRAKE_CAL_POLLING_COUNT;
++	int rc;
++	u8 val;
++
++	rc = haptics_clear_fault(chip);
++	if (rc < 0)
++		return rc;
++
++	rc = haptics_trigger_pbs(chip, HAP_AUTO_BRAKE_CAL_PBS);
++	if (rc < 0) {
++		dev_err(chip->dev, "trigger AUTO_BRAKE_CAL PBS failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	/*
++	 * wait for ~800ms and then poll auto brake cal done flag with ~200ms
++	 * timeout
++	 */
++	msleep(AUTO_BRAKE_CAL_WAIT_MS);
++
++	while (retry_count--) {
++		rc = nvmem_device_read(chip->hap_cfg_nvmem,
++				HAP_AUTO_BRAKE_CAL_DONE_OFFSET, 1, &val);
++		if (rc < 0) {
++			dev_err(chip->dev, "read auto brake cal done flag failed, rc=%d\n",
++				rc);
++			return rc;
++		}
++
++		if (val & AUTO_BRAKE_CAL_DONE) {
++			dev_info(chip->dev, "auto brake calibration is done\n");
++			break;
++		}
++
++		usleep_range(AUTO_BRAKE_CAL_POLLING_STEP_US,
++				AUTO_BRAKE_CAL_POLLING_STEP_US + 1);
++	}
++
++	return rc;
++}
++
++#define AUTO_BRAKE_CAL_DRIVE_CYCLES	6
++
++static int haptics_auto_brake_calibration_customize(struct haptics_chip *chip)
++{
++	struct haptics_reg_info lra_config[4] = {
++		{ HAP_CFG_DRV_DUTY_CFG_REG, 0x55 },
++		{ HAP_CFG_BRAKE_MODE_CFG_REG, 0xC1 },
++		{ HAP_CFG_CL_BRAKE_CFG_REG, 0xE1 },
++		{ HAP_CFG_ADT_DRV_DUTY_CFG_REG, 0x3B },
++	};
++	struct haptics_reg_info backup[4];
++	u32 t_lra_us, tmp;
++	u8 val[AUTO_BRAKE_CAL_DRIVE_CYCLES] = {};
++	int rc, i;
++
++	t_lra_us = chip->config.t_lra_us;
++	/* Update T_LRA into SDAM */
++	if (chip->config.cl_t_lra_us != 0)
++		t_lra_us = chip->config.cl_t_lra_us;
++
++	tmp = t_lra_us / TLRA_STEP_US;
++	val[0] = tmp & TLRA_OL_LSB_MASK;
++	val[1] = (tmp >> 8) & TLRA_OL_MSB_MASK;
++	rc = nvmem_device_write(chip->hap_cfg_nvmem, HAP_LRA_PTRN1_TLRA_LSB_OFFSET, 2, val);
++	if (rc < 0) {
++		dev_err(chip->dev, "set T_LRA for auto brake cal failed,rc=%d\n", rc);
++		return rc;
++	}
++
++	/* Set Vmax to 4.5V with 50mV per step */
++	val[0] = 0x5A;
++	rc = nvmem_device_write(chip->hap_cfg_nvmem, HAP_AUTO_BRAKE_CAL_VMAX_OFFSET, 1, val);
++	if (rc < 0) {
++		dev_err(chip->dev, "set Vmax for auto brake cal failed,rc=%d\n", rc);
++		return rc;
++	}
++
++	/* Set PTRN1_CFGx for each cycle in the 6-cycle drive calibration */
++	memset(val, 0, sizeof(val));
++	rc = nvmem_device_write(chip->hap_cfg_nvmem, HAP_AUTO_BRAKE_CAL_PTRN1_CFG0_OFFSET,
++			AUTO_BRAKE_CAL_DRIVE_CYCLES, val);
++	if (rc < 0) {
++		dev_err(chip->dev, "set PTRN1_CFGx for auto brake cal failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	/*
++	 * Set amplitude for 6-cycle drive calibration
++	 *   1 cycle over-drive with 4.5V VMAX + 0.5V VMAX_HDRM
++	 *   2 cycles intermediate drive with VMAX close to 3.5V
++	 *   3 cycles steady drive with VMAX close to Vrms
++	 */
++	val[0] = 0xFF;
++	val[1] = val[2] = 0xC9;
++	val[3] = val[4] = val[5] = chip->config.vmax_mv * 0xFF / 4500;
++	rc = nvmem_device_write(chip->hap_cfg_nvmem, HAP_AUTO_BRAKE_CAL_PTRN1_LSB0_OFFSET,
++			AUTO_BRAKE_CAL_DRIVE_CYCLES, val);
++	if (rc < 0) {
++		dev_err(chip->dev, "set PTRN1_LSBx for auto brake cal failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	/* cache several registers setting before configure them for auto brake calibration */
++	memcpy(backup, lra_config, sizeof(backup));
++	for (i = 0; i < 4; i++) {
++		rc = haptics_read(chip, chip->cfg_addr_base,
++				backup[i].addr, &backup[i].val, 1);
++		if (rc < 0)
++			return rc;
++	}
++
++	/* Set 62.5% BRK_DUTY, enable AUTO brake, etc */
++	for (i = 0; i < 4; i++) {
++		rc = haptics_write(chip, chip->cfg_addr_base,
++				lra_config[i].addr, &lra_config[i].val, 1);
++		if (rc < 0)
++			goto restore;
++	}
++
++	/* Clear calibration done flag 1st */
++	val[0] = 0;
++	rc = nvmem_device_write(chip->hap_cfg_nvmem, HAP_AUTO_BRAKE_CAL_DONE_OFFSET, 1, val);
++	if (rc < 0) {
++		dev_err(chip->dev, "clear auto brake cal done flag failed, rc=%d\n", rc);
++		goto restore;
++	}
++
++	rc = haptics_auto_brake_pbs_trigger(chip);
++
++restore:
++	/* restore haptics settings after auto brake calibration */
++	for (i = 0; i < 4; i++)
++		haptics_write(chip, chip->cfg_addr_base,
++				backup[i].addr, &backup[i].val, 1);
++
++	return rc;
++}
++
++static int haptics_start_auto_brake_calibration(struct haptics_chip *chip)
++{
++	/* Auto brake calibration is supported only if AUTO_BRAKE mode is specified */
++	if (chip->config.brake.mode != AUTO_BRAKE)
++		return 0;
++
++	/* Ignore calibration if nvmem is not assigned */
++	if (!chip->hap_cfg_nvmem)
++		return -EOPNOTSUPP;
++
++	/*
++	 * Auto brake calibration is supported only for HAP525_HV
++	 * and HAP530_HV.
++	 */
++	if (chip->hw_type < HAP525_HV)
++		return -EOPNOTSUPP;
++
++	if (chip->hw_type == HAP525_HV)
++		return haptics_auto_brake_calibration_customize(chip);
++
++	return haptics_auto_brake_pbs_trigger(chip);
++}
++
++static int haptics_start_lra_calibrate(struct haptics_chip *chip)
++{
++	int rc;
++
++	rc = haptics_runtime_resume_get(chip);
++	if (rc < 0)
++		return rc;
++
++	mutex_lock(&chip->play.lock);
++	/*
++	 * Ignore calibration if it's in FIFO playing to avoid
++	 * messing up the FIFO playing status
++	 */
++	if ((chip->play.pattern_src == FIFO) &&
++			atomic_read(&chip->play.fifo_status.is_busy)) {
++		dev_err(chip->dev, "In FIFO playing, ignore calibration\n");
++		rc = -EBUSY;
++		goto unlock;
++	}
++
++	/* Stop other mode playing if there is any */
++	rc = haptics_enable_play(chip, false);
++	if (rc < 0) {
++		dev_err(chip->dev, "Stop playing failed, rc=%d\n", rc);
++		goto unlock;
++	}
++
++	chip->play.in_calibration = true;
++	rc = haptics_detect_lra_frequency(chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "Detect LRA frequency failed, rc=%d\n", rc);
++		goto unlock;
++	}
++
++	/* Sleep 50ms to stabilize the LRA from frequency detection */
++	msleep(50);
++	if (chip->config.measure_lra_impedance)
++		rc = haptics_measure_realtime_lra_impedance(chip);
++	else
++		rc = haptics_detect_lra_impedance(chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "Detect LRA impedance failed, rc=%d\n", rc);
++		goto unlock;
++	}
++
++	/* Sleep 50ms to stabilize the LRA from impedance detection */
++	msleep(50);
++
++	rc = haptics_start_auto_brake_calibration(chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "Run auto brake calibration failed, rc=%d\n", rc);
++		goto unlock;
++	}
++
++unlock:
++	if (chip->wa_flags & RESTORE_VMAX_HDRM_1P5V)
++		haptics_set_vmax_headroom_mv(chip, VMAX_HDRM_MV_DEFAULT);
++
++	haptics_clear_fault(chip);
++	chip->play.in_calibration = false;
++	mutex_unlock(&chip->play.lock);
++	haptics_runtime_autosuspend_put(chip);
++	return rc;
++}
++
++static ssize_t lra_calibration_store(const struct class *c,
++		const struct class_attribute *attr, const char *buf, size_t count)
++{
++	struct haptics_chip *chip = container_of(c,
++			struct haptics_chip, hap_class);
++	bool val;
++	int rc;
++
++	if (kstrtobool(buf, &val))
++		return -EINVAL;
++
++	if (val) {
++		rc = haptics_start_lra_calibrate(chip);
++		if (rc < 0)
++			return rc;
++	}
++
++	return count;
++}
++static CLASS_ATTR_WO(lra_calibration);
++
++static ssize_t lra_frequency_hz_show(const struct class *c,
++		const struct class_attribute *attr, char *buf)
++{
++	struct haptics_chip *chip = container_of(c,
++			struct haptics_chip, hap_class);
++	u32 cl_f_lra;
++
++	if (chip->config.cl_t_lra_us == 0)
++		return -EINVAL;
++
++	cl_f_lra = USEC_PER_SEC / chip->config.cl_t_lra_us;
++
++	return scnprintf(buf, PAGE_SIZE, "%d Hz\n", cl_f_lra);
++}
++static CLASS_ATTR_RO(lra_frequency_hz);
++
++static ssize_t lra_impedance_show(const struct class *c,
++		const struct class_attribute *attr, char *buf)
++{
++	struct haptics_chip *chip = container_of(c,
++			struct haptics_chip, hap_class);
++
++	if (chip->config.measure_lra_impedance)
++		return scnprintf(buf, PAGE_SIZE, "measured %u mohms\n",
++				chip->config.lra_measured_mohms);
++
++	if (chip->config.lra_min_mohms == 0 && chip->config.lra_max_mohms == 0)
++		return -EINVAL;
++	else if (chip->config.lra_min_mohms == 0)
++		return scnprintf(buf, PAGE_SIZE, "%s\n", "Short circuit");
++	else if (chip->config.lra_max_mohms >= chip->config.lra_open_mohms)
++		return scnprintf(buf, PAGE_SIZE, "%s\n", "Open circuit");
++	else
++		return scnprintf(buf, PAGE_SIZE, "%u ~ %u mohms\n",
++				chip->config.lra_min_mohms,
++				chip->config.lra_max_mohms);
++}
++static CLASS_ATTR_RO(lra_impedance);
++
++static ssize_t primitive_duration_show(const struct class *c,
++		const struct class_attribute *attr, char *buf)
++{
++	struct haptics_chip *chip = container_of(c,
++			struct haptics_chip, hap_class);
++
++	return scnprintf(buf, PAGE_SIZE, "%d\n", chip->primitive_duration);
++}
++
++static ssize_t primitive_duration_store(const struct class *c,
++		const struct class_attribute *attr, const char *buf, size_t count)
++{
++	struct haptics_chip *chip = container_of(c,
++			struct haptics_chip, hap_class);
++	u16 primitive_id = 0;
++	int i = 0;
++
++	if (kstrtou16(buf, 0, &primitive_id))
++		return -EINVAL;
++
++	for (i = 0; i < chip->primitives_count; i++) {
++		if (chip->primitives[i].id == primitive_id)
++			break;
++	}
++
++	if (i == chip->primitives_count) {
++		pr_err("Primitive id specified is incorrect\n");
++		return -EINVAL;
++	}
++
++	chip->primitive_duration = get_play_length_effect_us(&chip->primitives[i]);
++
++	return count;
++}
++
++static CLASS_ATTR_RW(primitive_duration);
++
++static ssize_t visense_enabled_show(const struct class *c,
++		const struct class_attribute *attr, char *buf)
++{
++	struct haptics_chip *chip = container_of(c,
++			struct haptics_chip, hap_class);
++
++	return scnprintf(buf, PAGE_SIZE, "%d\n", chip->visense_enabled);
++}
++static CLASS_ATTR_RO(visense_enabled);
++
++static ssize_t v_gain_error_show(const struct class *c,
++		const struct class_attribute *attr, char *buf)
++{
++	struct haptics_chip *chip = container_of(c,
++			struct haptics_chip, hap_class);
++	u8 v_gain_error[2] = { 0 };
++	int rc;
++
++	rc = haptics_read(chip, chip->ptn_addr_base,
++			HAP_PTN_VGAIN_ERR_COMP_LSB, v_gain_error, 2);
++	if (rc < 0)
++		return rc;
++
++	return scnprintf(buf, PAGE_SIZE, "%#x\n", (v_gain_error[1] << 8 | v_gain_error[0]));
++}
++static const CLASS_ATTR_RO(v_gain_error);
++
++static ssize_t i_gain_error_show(const struct class *c,
++		const struct class_attribute *attr, char *buf)
++{
++	struct haptics_chip *chip = container_of(c,
++			struct haptics_chip, hap_class);
++	u8 i_gain_error[2] = { 0 };
++	int rc;
++
++	rc = haptics_read(chip, chip->ptn_addr_base,
++			HAP_PTN_IGAIN_ERR_COMP_LSB, i_gain_error, 2);
++	if (rc < 0)
++		return rc;
++
++	return scnprintf(buf, PAGE_SIZE, "%#x\n", (i_gain_error[1] << 8 | i_gain_error[0]));
++}
++static const CLASS_ATTR_RO(i_gain_error);
++
++static struct attribute *hap_class_attrs[] = {
++	&class_attr_lra_calibration.attr,
++	&class_attr_lra_frequency_hz.attr,
++	&class_attr_lra_impedance.attr,
++	&class_attr_primitive_duration.attr,
++	&class_attr_visense_enabled.attr,
++	NULL,
++};
++ATTRIBUTE_GROUPS(hap_class);
++
++static bool is_swr_supported(struct haptics_chip *chip)
++{
++	/* HAP520_MV does not support soundwire */
++	if (chip->hw_type == HAP520_MV)
++		return false;
++
++	return true;
++}
++
++static enum hrtimer_restart haptics_disable_hbst_timer(struct hrtimer *timer)
++{
++	struct haptics_chip *chip = container_of(timer,
++			struct haptics_chip, hbst_off_timer);
++	int rc;
++
++	rc = haptics_boost_vreg_enable(chip, false);
++	if (rc < 0)
++		dev_err(chip->dev, "disable boost vreg failed, rc=%d\n", rc);
++	else
++		dev_dbg(chip->dev, "boost vreg is disabled\n");
++
++	return HRTIMER_NORESTART;
++}
++
++static int haptics_boost_notifier(struct notifier_block *nb, unsigned long event, void *val)
++{
++	struct haptics_chip *chip = container_of(nb, struct haptics_chip, hboost_nb);
++	u32 vmax_mv;
++	int rc;
++
++	switch (event) {
++	case VMAX_CLAMP:
++		vmax_mv = *(u32 *)val;
++		if (vmax_mv > MAX_HV_VMAX_MV) {
++			dev_err(chip->dev, "voted Vmax (%u mV) is higher than maximum (%u mV)\n",
++					vmax_mv, MAX_HV_VMAX_MV);
++			return -EINVAL;
++		}
++
++		chip->clamped_vmax_mv = vmax_mv;
++		dev_dbg(chip->dev, "Vmax is clamped at %u mV to support hBoost concurrency\n",
++				vmax_mv);
++		rc = haptics_force_vreg_ready(chip, vmax_mv != MAX_HV_VMAX_MV);
++		if (rc < 0)
++			return rc;
++		break;
++	default:
++		break;
++	}
++
++	return 0;
++}
++
++static int haptics_lpass_ssr_notifier(struct notifier_block *nb, unsigned long event, void *data)
++{
++	struct haptics_chip *chip = container_of(nb, struct haptics_chip, lpass_ssr_nb);
++	u8 val;
++	int rc;
++
++	if (!(chip->wa_flags & VISENSE_RECOVERY_EN))
++		return NOTIFY_DONE;
++
++	if (!is_swr_play_enabled(chip)) {
++		dev_dbg(chip->dev, "ignore VISENSE recovery if not in SWR play\n");
++		return NOTIFY_DONE;
++	}
++
++	switch (event) {
++	case QCOM_SSR_BEFORE_SHUTDOWN:
++		/*
++		 * Enable HAPTICS_EN to keep haptics module clock on during ADSP
++		 * SSR. It's needed for keeping haptics SPMI and SWR data port in
++		 * correct state, and it could be disabled after ADSP SSR.
++		 */
++		rc = haptics_runtime_resume_get(chip);
++		if (rc < 0)
++			return rc;
++
++		val = 0;
++		rc = haptics_write(chip, chip->cfg_addr_base, HAP_CFG_SWR_ACCESS_REG,  &val, 1);
++		if (rc < 0)
++			return rc;
++
++		rc = haptics_visense_handshake_enable(chip, false);
++		if (rc < 0)
++			return rc;
++
++		dev_dbg(chip->dev, "QCOM_SSR_BEFORE_SHUTDOWN is handled\n");
++		break;
++	case QCOM_SSR_BEFORE_POWERUP:
++		val = SWR_PAT_INPUT_EN_BIT | SWR_PAT_RES_N_BIT | SWR_PAT_CFG_EN_BIT;
++		rc = haptics_write(chip, chip->cfg_addr_base, HAP_CFG_SWR_ACCESS_REG,  &val, 1);
++		if (rc < 0)
++			return rc;
++
++		haptics_runtime_autosuspend_put(chip);
++		dev_dbg(chip->dev, "QCOM_SSR_BEFORE_POWERUP is handled\n");
++		break;
++	default:
++		break;
++	}
++
++	return NOTIFY_DONE;
++}
++
++static int haptics_probe(struct platform_device *pdev)
++{
++	struct haptics_chip *chip;
++	struct input_dev *input_dev;
++	struct ff_device *ff_dev;
++	int rc, count;
++
++	chip = devm_kzalloc(&pdev->dev, sizeof(*chip), GFP_KERNEL);
++	if (!chip)
++		return -ENOMEM;
++
++	input_dev = devm_input_allocate_device(&pdev->dev);
++	if (!input_dev)
++		return -ENOMEM;
++
++	chip->dev = &pdev->dev;
++	dev_set_drvdata(chip->dev, chip);
++	chip->regmap = dev_get_regmap(chip->dev->parent, NULL);
++	if (!chip->regmap) {
++		dev_err(chip->dev, "Get regmap failed\n");
++		return -ENXIO;
++	}
++
++	INIT_LIST_HEAD(&chip->mmap_effect_list);
++	rc = haptics_parse_dt(chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "Parse device-tree failed, rc = %d\n", rc);
++		return rc;
++	}
++
++	rc = haptics_init_custom_effect(chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "Init custom effect failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	mutex_init(&chip->vmax_lock);
++
++	rc = haptics_hw_init(chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "Initialize HW failed, rc = %d\n", rc);
++		return rc;
++	}
++
++	rc = haptics_runtime_pm_init(chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "Runtime PM initialize failed, rc=%d\n", rc);
++		return rc;
++	}
++
++	if (is_swr_supported(chip)) {
++		rc = haptics_init_swr_slave_regulator(chip);
++		if (rc < 0) {
++			dev_err(chip->dev, "Initialize swr slave regulator failed, rc = %d\n",
++					rc);
++			return rc;
++		}
++	}
++
++	rc = devm_request_threaded_irq(chip->dev, chip->fifo_empty_irq,
++			NULL, fifo_empty_irq_handler,
++			IRQF_ONESHOT, "fifo-empty", chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "request fifo-empty IRQ failed, rc=%d\n",
++				rc);
++		return rc;
++	}
++
++	mutex_init(&chip->play.lock);
++	disable_irq_nosync(chip->fifo_empty_irq);
++	chip->fifo_empty_irq_en = false;
++	hrtimer_setup(&chip->hbst_off_timer, haptics_disable_hbst_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
++	INIT_DELAYED_WORK(&chip->stop_work, haptics_stop_constant_effect_play);
++	INIT_WORK(&chip->set_gain_work, haptics_set_gain_work);
++
++	atomic_set(&chip->play.fifo_status.is_busy, 0);
++	atomic_set(&chip->play.fifo_status.written_done, 0);
++	atomic_set(&chip->play.fifo_status.cancelled, 0);
++	input_dev->name = "qcom-hv-haptics";
++	input_set_drvdata(input_dev, chip);
++	chip->input_dev = input_dev;
++
++	input_set_capability(input_dev, EV_FF, FF_CONSTANT);
++	input_set_capability(input_dev, EV_FF, FF_GAIN);
++	if ((chip->effects_count != 0) || (chip->primitives_count != 0)) {
++		input_set_capability(input_dev, EV_FF, FF_PERIODIC);
++		input_set_capability(input_dev, EV_FF, FF_CUSTOM);
++	}
++
++	if (chip->effects_count + chip->primitives_count > MAX_EFFECT_COUNT)
++		dev_err(chip->dev, "Effects count cannot be more than %d\n", MAX_EFFECT_COUNT);
++
++	count = min_t(u32, chip->effects_count + chip->primitives_count + 1, MAX_EFFECT_COUNT);
++
++	rc = input_ff_create(input_dev, count);
++	if (rc < 0) {
++		dev_err(chip->dev, "create input FF device failed, rc=%d\n",
++				rc);
++		return rc;
++	}
++
++	ff_dev = input_dev->ff;
++	ff_dev->upload = haptics_upload_effect;
++	ff_dev->playback = haptics_playback;
++	ff_dev->erase = haptics_erase;
++	ff_dev->set_gain = haptics_set_gain;
++	rc = input_register_device(input_dev);
++	if (rc < 0) {
++		dev_err(chip->dev, "register input device failed, rc=%d\n",
++				rc);
++		goto destroy_ff;
++	}
++
++	chip->hap_class.name = "qcom-haptics";
++	chip->hap_class.class_groups = hap_class_groups;
++	rc = class_register(&chip->hap_class);
++	if (rc < 0) {
++		dev_err(chip->dev, "register hap_class failed, rc=%d\n", rc);
++		goto destroy_ff;
++	}
++
++	if (chip->hw_type >= HAP530_HV && chip->visense_enabled) {
++		rc = class_create_file(&chip->hap_class, &class_attr_i_gain_error);
++		if (rc) {
++			dev_err(chip->dev, "failed to add i_gain_error, rc=%d\n", rc);
++			goto destroy_ff;
++		}
++
++		rc = class_create_file(&chip->hap_class, &class_attr_v_gain_error);
++		if (rc) {
++			dev_err(chip->dev, "failed to add v_gain_error, rc=%d\n", rc);
++			goto remove_i_gain_error;
++		}
++	}
++
++	chip->hboost_nb.notifier_call = haptics_boost_notifier;
++	register_hboost_event_notifier(&chip->hboost_nb);
++
++	if (chip->hw_type == HAP530_HV) {
++		chip->lpass_ssr_nb.notifier_call = haptics_lpass_ssr_notifier;
++		chip->lpass_ssr_handle =
++			qcom_register_ssr_notifier("lpass", &chip->lpass_ssr_nb);
++		if (IS_ERR(chip->lpass_ssr_handle)) {
++			rc = PTR_ERR(chip->lpass_ssr_handle);
++			dev_err(chip->dev, "register SSR notifier failed, rc=%d\n", rc);
++			if (chip->visense_enabled)
++				goto remove_v_gain_error;
++			else
++				goto destroy_ff;
++		}
++	}
++
++//	rc = haptics_create_debugfs(chip);
++//	if (rc < 0)
++//		dev_err(chip->dev, "Creating debugfs failed, rc=%d\n", rc);
++
++	haptics_runtime_autosuspend(chip);
++	phapchip = chip;
++	return 0;
++
++remove_v_gain_error:
++	class_remove_file(&chip->hap_class, &class_attr_v_gain_error);
++remove_i_gain_error:
++	class_remove_file(&chip->hap_class, &class_attr_i_gain_error);
++destroy_ff:
++	input_ff_destroy(chip->input_dev);
++	return rc;
++}
++
++static void haptics_remove(struct platform_device *pdev)
++{
++	struct haptics_chip *chip = dev_get_drvdata(&pdev->dev);
++
++	phapchip = NULL;
++	if (chip->pbs_node)
++		of_node_put(chip->pbs_node);
++
++	if (chip->hw_type == HAP530_HV)
++		qcom_unregister_ssr_notifier(chip->lpass_ssr_handle, &chip->lpass_ssr_nb);
++
++	unregister_hboost_event_notifier(&chip->hboost_nb);
++	class_unregister(&chip->hap_class);
++	//haptics_remove_debugfs(chip);
++	input_unregister_device(chip->input_dev);
++	dev_set_drvdata(chip->dev, NULL);
++
++	return;
++}
++
++static void haptics_ds_suspend_config(struct device *dev)
++{
++	struct haptics_chip *chip = dev_get_drvdata(dev);
++
++	if (chip->fifo_empty_irq > 0)
++		devm_free_irq(dev, chip->fifo_empty_irq, chip);
++}
++
++static int haptics_ds_resume_config(struct device *dev)
++{
++	struct haptics_chip *chip = dev_get_drvdata(dev);
++	int rc = 0;
++
++	rc = haptics_hw_init(chip);
++	if (rc < 0) {
++		dev_err(chip->dev, "Initialize HW failed, rc = %d\n", rc);
++		return rc;
++	}
++
++	if (chip->fifo_empty_irq > 0) {
++		rc = devm_request_threaded_irq(chip->dev, chip->fifo_empty_irq,
++					NULL, fifo_empty_irq_handler,
++					IRQF_ONESHOT, "fifo-empty", chip);
++		if (rc < 0) {
++			dev_err(chip->dev, "request fifo-empty IRQ failed, rc=%d\n",
++					rc);
++			return rc;
++		}
++
++		disable_irq_nosync(chip->fifo_empty_irq);
++		chip->fifo_empty_irq_en = false;
++	}
++
++	return rc;
++}
++
++static int haptics_suspend_config(struct device *dev)
++{
++	struct haptics_chip *chip = dev_get_drvdata(dev);
++	struct haptics_play_info *play = &chip->play;
++	int rc;
++
++	mutex_lock(&play->lock);
++	if ((play->pattern_src == FIFO) &&
++			atomic_read(&play->fifo_status.is_busy)) {
++		if (atomic_read(&play->fifo_status.written_done) == 0) {
++			dev_dbg(chip->dev, "cancelling FIFO playing\n");
++			atomic_set(&play->fifo_status.cancelled, 1);
++		}
++
++		rc = haptics_stop_fifo_play(chip);
++		if (rc < 0) {
++			dev_err(chip->dev, "stop FIFO playing failed, rc=%d\n", rc);
++			mutex_unlock(&play->lock);
++			return rc;
++		}
++	} else {
++		rc = haptics_enable_play(chip, false);
++		if (rc < 0) {
++			mutex_unlock(&play->lock);
++			return rc;
++		}
++	}
++	mutex_unlock(&play->lock);
++
++	/*
++	 * Cancel the hBoost turning off timer and disable
++	 * hBoost if it's still enabled
++	 */
++	if (chip->wa_flags & SW_CTRL_HBST) {
++		hrtimer_cancel(&chip->hbst_off_timer);
++		haptics_boost_vreg_enable(chip, false);
++	}
++
++	rc = haptics_enable_hpwr_vreg(chip, false);
++	if (rc < 0)
++		return rc;
++
++	return haptics_module_enable(chip, false);
++}
++
++static int __maybe_unused haptics_runtime_suspend(struct device *dev)
++{
++	struct haptics_chip *chip = dev_get_drvdata(dev);
++
++	/*
++	 * Don't check return values, disable haptics module
++	 * to minimize the quiescent current.
++	 */
++	haptics_visense_enable(chip, false);
++	haptics_module_enable(chip, false);
++
++	return 0;
++}
++
++static int __maybe_unused haptics_runtime_resume(struct device *dev)
++{
++	struct haptics_chip *chip = dev_get_drvdata(dev);
++	int rc = 0;
++
++	rc = haptics_module_enable(chip, true);
++	if (rc < 0)
++		return rc;
++
++	return haptics_visense_enable(chip, true);
++}
++
++static int __maybe_unused haptics_suspend(struct device *dev)
++{
++	struct haptics_chip *chip = dev_get_drvdata(dev);
++	int rc = 0;
++
++	if (MAJOR_REV(chip->cfg_revision) == HAP_CFG_V1)
++		return 0;
++
++	rc = haptics_suspend_config(dev);
++	if (rc < 0)
++		return rc;
++
++	return 0;
++}
++
++static int __maybe_unused haptics_resume(struct device *dev)
++{
++	struct haptics_chip *chip = dev_get_drvdata(dev);
++	
++	if (is_haptics_runtime_pm_enabled(chip))
++		return 0;
++
++	return haptics_module_enable(chip, true);
++}
++
++static int __maybe_unused haptics_freeze(struct device *dev)
++{
++	int rc = 0;
++
++	rc = haptics_suspend_config(dev);
++	if (rc < 0)
++		return rc;
++
++	haptics_ds_suspend_config(dev);
++
++	return 0;
++}
++
++static int __maybe_unused haptics_restore(struct device *dev)
++{
++	struct haptics_chip *chip = dev_get_drvdata(dev);
++	int rc = 0;
++
++	rc = haptics_ds_resume_config(dev);
++	if (rc < 0)
++		return rc;
++
++	if (is_haptics_runtime_pm_enabled(chip))
++		return 0;
++
++	return haptics_module_enable(chip, true);
++
++}
++
++static void haptics_shutdown(struct platform_device *pdev)
++{
++	struct haptics_chip *chip = platform_get_drvdata(pdev);
++
++	haptics_suspend_config(chip->dev);
++
++	haptics_ds_suspend_config(chip->dev);
++}
++
++int qcom_spmi_haptics_global_upload(struct ff_effect *effect) {
++	int ret;
++
++	if (!phapchip)
++		return -ENODEV;
++
++	spin_lock_irq(&phapchip->input_dev->event_lock);
++
++	ret = phapchip->input_dev->ff->upload(phapchip->input_dev, effect, NULL);
++
++	spin_unlock_irq(&phapchip->input_dev->event_lock);
++
++	return ret;
++}
++
++int qcom_spmi_haptics_global_playback(int effect_id, int val) {
++	int ret;
++
++	if (!phapchip)
++		return -ENODEV;
++
++	spin_lock_irq(&phapchip->input_dev->event_lock);
++
++	if (val != 0)
++		ret = phapchip->input_dev->ff->playback(phapchip->input_dev, effect_id, val);
++	else
++		ret = phapchip->input_dev->ff->erase(phapchip->input_dev, effect_id);
++
++	if (ret)
++		pr_warn("%s called for %s, error in return (%d)\n", __func__, (val!=0 ? "Playback" : "Erase"), ret);
++
++	spin_unlock_irq(&phapchip->input_dev->event_lock);
++
++	return ret;
++}
++
++int qcom_spmi_haptics_global_set_gain(u16 gain) {
++	if (!phapchip)
++		return -ENODEV;
++
++	spin_lock_irq(&phapchip->input_dev->event_lock);
++
++	//max is 0x7fff, and minimum is 0x4000 the same values android uses
++	gain = clamp(gain, 0x4000, 0x7fff);
++
++	phapchip->input_dev->ff->set_gain(phapchip->input_dev, gain);
++
++	spin_unlock_irq(&phapchip->input_dev->event_lock);
++
++	return 0;
++}
++
++EXPORT_SYMBOL_GPL(qcom_spmi_haptics_global_upload);
++EXPORT_SYMBOL_GPL(qcom_spmi_haptics_global_playback);
++EXPORT_SYMBOL_GPL(qcom_spmi_haptics_global_set_gain);
++
++static const struct dev_pm_ops __maybe_unused haptics_pm_ops = {
++	.runtime_suspend = pm_ptr(haptics_runtime_suspend),
++	.runtime_resume = pm_ptr(haptics_runtime_resume),
++	.suspend = pm_ptr(haptics_suspend),
++	.resume = pm_ptr(haptics_resume),
++	.freeze = pm_ptr(haptics_freeze),
++	.restore = pm_ptr(haptics_restore),
++};
++
++static const struct of_device_id haptics_match_table[] = {
++	{
++		.compatible = "qcom,hv-haptics",
++	},
++	{
++		.compatible = "qcom,pm8350b-haptics",
++	},
++	{
++		.compatible = "qcom,pm5100-haptics",
++	},
++	{},
++};
++
++static struct platform_driver haptics_driver = {
++	.driver		= {
++		.name = "qcom-hv-haptics",
++		.of_match_table = haptics_match_table,
++		.pm		= pm_ptr(&haptics_pm_ops),
++	},
++	.probe		= haptics_probe,
++	.shutdown	= haptics_shutdown,
++	.remove		= haptics_remove,
++};
++module_platform_driver(haptics_driver);
++
++MODULE_DESCRIPTION("Qualcomm Technologies, Inc. High-Voltage Haptics driver");
++MODULE_LICENSE("GPL");
+diff --git a/include/dt-bindings/input/qcom,hv-haptics.h b/include/dt-bindings/input/qcom,hv-haptics.h
+new file mode 100644
+index 000000000..8453d2ae9
+--- /dev/null
++++ b/include/dt-bindings/input/qcom,hv-haptics.h
+@@ -0,0 +1,37 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++/*
++ * Copyright (c) 2020 The Linux Foundation. All rights reserved.
++ */
++
++/* definitions for drive waveform shape */
++#define WF_SQUARE			0   /* LRA only */
++#define WF_SINE				1   /* LRA only */
++#define WF_NO_MODULATION		2   /* ERM only */
++
++/* definitions for brake mode */
++#define BRAKE_OPEN_LOOP			0
++#define BRAKE_CLOSE_LOOP		1
++#define BRAKE_PREDICTIVE		2
++#define BRAKE_AUTO			3
++
++/* definitions for brake sine signal gain */
++#define BRAKE_SINE_GAIN_X1		0
++#define BRAKE_SINE_GAIN_X2		1
++#define BRAKE_SINE_GAIN_X4		2
++#define BRAKE_SINE_GAIN_X8		3
++
++/* definitions for pattern sample period */
++#define S_PERIOD_T_LRA			0
++#define S_PERIOD_T_LRA_DIV_2		1
++#define S_PERIOD_T_LRA_DIV_4		2
++#define S_PERIOD_T_LRA_DIV_8		3
++#define S_PERIOD_T_LRA_X_2		4
++#define S_PERIOD_T_LRA_X_4		5
++#define S_PERIOD_T_LRA_X_8		6
++/* F_8KHZ to F_48KHZ periods can only be specified for FIFO based effects */
++#define S_PERIOD_F_8KHZ			8
++#define S_PERIOD_F_16KHZ		9
++#define S_PERIOD_F_24KHZ		10
++#define S_PERIOD_F_32KHZ		11
++#define S_PERIOD_F_44P1KHZ		12
++#define S_PERIOD_F_48KHZ		13
+diff --git a/include/linux/qpnp/qpnp-pbs.h b/include/linux/qpnp/qpnp-pbs.h
+new file mode 100644
+index 000000000..1834381a2
+--- /dev/null
++++ b/include/linux/qpnp/qpnp-pbs.h
+@@ -0,0 +1,33 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++/*
++ * Copyright (c) 2017-2018, 2020-2021, The Linux Foundation.
++ * All rights reserved.
++ */
++
++#ifndef _QPNP_PBS_H
++#define _QPNP_PBS_H
++
++#include <linux/errno.h>
++#include <linux/types.h>
++
++struct device_node;
++
++#if IS_ENABLED(CONFIG_QPNP_PBS)
++int qpnp_pbs_trigger_event(struct device_node *dev_node, u8 bitmap);
++int qpnp_pbs_trigger_single_event(struct device_node *dev_node);
++#else
++static inline int qpnp_pbs_trigger_event(struct device_node *dev_node,
++						 u8 bitmap)
++{
++	return -ENODEV;
++}
++
++static inline int qpnp_pbs_trigger_single_event(
++					struct device_node *dev_node)
++{
++	return -ENODEV;
++}
++
++#endif
++
++#endif
+diff --git a/include/linux/soc/qcom/battery_charger.h b/include/linux/soc/qcom/battery_charger.h
+new file mode 100644
+index 000000000..47382d8e0
+--- /dev/null
++++ b/include/linux/soc/qcom/battery_charger.h
+@@ -0,0 +1,45 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++/*
++ * Copyright (c) 2020, The Linux Foundation. All rights reserved.
++ * Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
++ */
++
++#ifndef _BATTERY_CHARGER_H
++#define _BATTERY_CHARGER_H
++
++#include <linux/notifier.h>
++
++enum battery_charger_prop {
++	BATTERY_RESISTANCE,
++	BATTERY_CHARGER_PROP_MAX,
++};
++
++enum bc_hboost_event {
++	VMAX_CLAMP,
++};
++
++#if IS_ENABLED(CONFIG_QTI_BATTERY_CHARGER)
++int qti_battery_charger_get_prop(const char *name,
++				enum battery_charger_prop prop_id, int *val);
++int register_hboost_event_notifier(struct notifier_block *nb);
++int unregister_hboost_event_notifier(struct notifier_block *nb);
++#else
++static inline int
++qti_battery_charger_get_prop(const char *name,
++				enum battery_charger_prop prop_id, int *val)
++{
++	return -EINVAL;
++}
++
++static inline int register_hboost_event_notifier(struct notifier_block *nb)
++{
++	return -EOPNOTSUPP;
++}
++
++static inline int unregister_hboost_event_notifier(struct notifier_block *nb)
++{
++	return -EOPNOTSUPP;
++}
++#endif
++
++#endif
+diff --git a/include/linux/soc/qcom/qcom_hv_haptics.h b/include/linux/soc/qcom/qcom_hv_haptics.h
+new file mode 100644
+index 000000000..e32deab3a
+--- /dev/null
++++ b/include/linux/soc/qcom/qcom_hv_haptics.h
+@@ -0,0 +1,41 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++/*
++ * Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
++ */
++
++#ifndef _QCOM_HV_HAPTICS_H
++#define _QCOM_HV_HAPTICS_H
++
++#include <linux/input.h>
++#include <linux/remoteproc/qcom_rproc.h>
++#include <linux/platform_device.h>
++
++#if IS_ENABLED(CONFIG_INPUT_QCOM_HV_HAPTICS)
++bool qcom_haptics_vi_sense_is_enabled(void);
++
++int qcom_spmi_haptics_global_upload(struct ff_effect *effect);
++int qcom_spmi_haptics_global_playback(int effect_id, int val);
++int qcom_spmi_haptics_global_set_gain(u16 gain);
++#else
++static inline bool qcom_haptics_vi_sense_is_enabled(void)
++{
++	return false;
++}
++
++static inline int qcom_spmi_haptics_global_upload(struct ff_effect *effect)
++{
++    return 0;
++}
++
++static inline int qcom_spmi_haptics_global_playback(int effect_id, int val)
++{
++    return 0;
++}
++
++static inline int qcom_spmi_haptics_global_set_gain(u16 gain)
++{
++    return 0;
++}
++#endif
++
++#endif
+\ No newline at end of file
+diff --git a/include/trace/events/qcom_haptics.h b/include/trace/events/qcom_haptics.h
+new file mode 100644
+index 000000000..883f6e3b4
+--- /dev/null
++++ b/include/trace/events/qcom_haptics.h
+@@ -0,0 +1,98 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++/*
++ * Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
++ */
++
++#undef TRACE_SYSTEM
++#define TRACE_SYSTEM qcom_haptics
++
++#if !defined(_TRACE_QCOM_HAPTICS_H) || defined(TRACE_HEADER_MULTI_READ)
++#define _TRACE_QCOM_HAPTICS_H
++
++#include <linux/tracepoint.h>
++
++TRACE_EVENT(qcom_haptics_fifo_hw_status,
++	TP_PROTO(u32 filled, u32 available, bool full, bool empty),
++
++	TP_ARGS(filled, available, full, empty),
++
++	TP_STRUCT__entry(
++		__field(u32, filled)
++		__field(u32, available)
++		__field(bool, full)
++		__field(bool, empty)
++	),
++
++	TP_fast_assign(
++		__entry->filled = filled;
++		__entry->available = available;
++		__entry->full = full;
++		__entry->empty = empty;
++	),
++
++	TP_printk("FIFO HW status: filled = %u, available = %u, full = %d, empty = %d\n",
++		__entry->filled, __entry->available, __entry->full, __entry->empty)
++);
++
++TRACE_EVENT(qcom_haptics_fifo_prgm_status,
++	TP_PROTO(u32 total, u32 written, u32 num_bytes),
++
++	TP_ARGS(total, written, num_bytes),
++
++	TP_STRUCT__entry(
++		__field(u32, total)
++		__field(u32, written)
++		__field(u32, num_bytes)
++	),
++
++	TP_fast_assign(
++		__entry->total = total;
++		__entry->written = written;
++		__entry->num_bytes = num_bytes;
++	),
++
++	TP_printk("FIFO program status: writing %u bytes, written %u bytes, total %u bytes\n",
++		__entry->num_bytes, __entry->written, __entry->total)
++);
++
++
++TRACE_EVENT(qcom_haptics_play,
++	TP_PROTO(bool enable),
++
++	TP_ARGS(enable),
++
++	TP_STRUCT__entry(
++		__field(bool, enable)
++	),
++
++	TP_fast_assign(
++		__entry->enable = enable;
++	),
++
++	TP_printk("play enable: %d\n", __entry->enable)
++);
++
++TRACE_EVENT(qcom_haptics_status,
++	TP_PROTO(const char *name, u8 msb, u8 lsb),
++
++	TP_ARGS(name, msb, lsb),
++
++	TP_STRUCT__entry(
++		__string(id_name, name)
++		__field(u8, msb)
++		__field(u8, lsb)
++	),
++
++	TP_fast_assign(
++		__assign_str(id_name);
++		__entry->msb = msb;
++		__entry->lsb = lsb;
++	),
++
++	TP_printk("haptics %s status: MSB %#x, LSB %#x\n", __get_str(id_name),
++		__entry->msb, __entry->lsb)
++);
++
++#endif /* _TRACE_QCOM_HAPTICS_H */
++
++#include <trace/define_trace.h>

--- a/patch/kernel/archive/sm8750-7.1/1001-haptics-driver-support-periodic-sine-and-fixes.patch
+++ b/patch/kernel/archive/sm8750-7.1/1001-haptics-driver-support-periodic-sine-and-fixes.patch
@@ -1,0 +1,205 @@
+--- a/drivers/input/misc/qcom-hv-haptics.c
++++ b/drivers/input/misc/qcom-hv-haptics.c
+@@ -792,6 +792,8 @@
+ 	struct notifier_block		lpass_ssr_nb;
+ 	struct mutex			vmax_lock;
+ 	struct work_struct		set_gain_work;
++	volatile bool			chip_effect_loaded;
++	volatile bool			chip_is_playing;
+ 	struct list_head		mmap_effect_list;
+ 	int				fifo_empty_irq;
+ 	u32				hpwr_voltage_mv;
+@@ -2092,6 +2094,8 @@
+ 	u8 val;
+ 
+ 	if (en) {
++		chip->chip_is_playing = true;
++
+ 		rc = haptics_clear_fault(chip);
+ 		if (rc < 0)
+ 			goto restore;
+@@ -2121,9 +2125,12 @@
+ 	haptics_read(chip, chip->hbst_addr_base, 0x09, &val, 1);
+ 	dev_dbg(chip->dev, "haptics_enable_play, 0xf209=0x%x\n", val);
+ 
+-	if (!en)
++	if (!en) {
+ 		haptics_wait_brake_complete(chip);
+ 
++		chip->chip_is_playing = false;
++	}
++
+ 	if (chip->wa_flags & SW_CTRL_HBST) {
+ 		if (en) {
+ 			rc = haptics_boost_vreg_enable(chip, true);
+@@ -3181,12 +3188,36 @@
+ }
+ 
+ static int haptics_upload_effect(struct input_dev *dev,
++		struct ff_effect *effect, struct ff_effect *old);
++
++static int haptics_upload_ff_periodic_sine(struct input_dev *dev,
++		struct ff_effect *effect, struct ff_effect *old)
++{
++	//This function just converts FF_PERIODIC (Sine) into FF_CONSTANT
++	struct ff_effect new_effect;
++
++	memset(&new_effect, 0, sizeof(new_effect));
++	new_effect.type = FF_CONSTANT;
++	new_effect.id = effect->id; //Not used
++
++	if (effect->replay.length != 0)
++		new_effect.replay.length = effect->replay.length;
++	else
++		new_effect.replay.length = 30000; //30 s (it should be infinite)
++
++	new_effect.u.constant.level = clamp(effect->u.periodic.magnitude, 0, 0x7FFF); //Maximum is 0x7FFF
++
++	return haptics_upload_effect(dev, &new_effect, old);
++}
++
++static int haptics_upload_effect(struct input_dev *dev,
+ 		struct ff_effect *effect, struct ff_effect *old)
+ {
+ 	struct haptics_chip *chip = input_get_drvdata(dev);
+ 	u32 length_ms, tmp;
+ 	s16 level;
+ 	u8 amplitude;
++	u16 gain;
+ 	int rc = 0;
+ 
+ 	rc = haptics_runtime_resume_get(chip);
+@@ -3209,6 +3240,36 @@
+ 			goto auto_suspend;
+ 	}
+ 
++	if (chip->chip_is_playing && effect->type == FF_CONSTANT) {
++		gain = effect->u.constant.level;
++
++		cancel_delayed_work_sync(&chip->stop_work);
++
++		pr_debug("tried to upload an effect while the chip was busy playing, setting gain...\n");
++
++		if (gain == 0) {
++			//The purpose of scheduling a stop_work work is that if the program calls playback afterwards, it will play
++			// for a very short time using the previous gain
++			// ( Like Aethersx2, it likes to call playback with zero value EVEN when amplitude is zero)
++			//We cant stop the playback now, so schedule rumble stop after 5s
++			//and set the gain to a low value (essentially zero)
++
++			dev_dbg(chip->dev, "scheduling stop after 500ms, because gain is zero\n");
++
++			dev->ff->set_gain(dev, 1);
++			schedule_delayed_work(&chip->stop_work, msecs_to_jiffies(5000));
++		} else {
++			dev_dbg(chip->dev, "Setting gain to %hu...\n", gain);
++
++			dev->ff->set_gain(dev, gain);
++
++			//Also, reschedule the stop_work timer
++			schedule_delayed_work(&chip->stop_work, msecs_to_jiffies(effect->replay.length));
++		}
++
++		return 0;
++	}
++
+ 	switch (effect->type) {
+ 	case FF_CONSTANT:
+ 		length_ms = effect->replay.length;
+@@ -3228,11 +3289,17 @@
+ 
+ 		break;
+ 	case FF_PERIODIC:
+-		if (effect->u.periodic.waveform != FF_CUSTOM) {
+-			dev_err(chip->dev, "Only support custom waveforms\n");
+-			rc = -EINVAL;
+-			goto restore;
+-		}
++		switch (effect->u.periodic.waveform) {
++			case FF_SINE:
++				return haptics_upload_ff_periodic_sine(dev, effect, old);
++
++			case FF_CUSTOM:
++				break;
++
++			default:
++				dev_err(chip->dev, "Only support custom waveforms\n");
++				return -EINVAL;
++ 		}
+ 		if (effect->u.periodic.custom_len ==
+ 				sizeof(struct custom_fifo_data)) {
+ 			rc = haptics_load_custom_effect(chip,
+@@ -3286,6 +3353,8 @@
+ 		goto restore;
+ 	}
+ 
++	chip->chip_effect_loaded = true;
++
+ 	return 0;
+ 
+ restore:
+@@ -3301,7 +3370,10 @@
+ 	struct haptics_chip *chip = input_get_drvdata(dev);
+ 
+ 	dev_dbg(chip->dev, "playback val = %d\n", val);
+-	if (!!val) {
++	if (!!val && !chip->chip_is_playing) {
++		if (!chip->chip_effect_loaded)
++			dev_warn(chip->dev, "Trying to playback while no effect is loaded!\n");
++
+ 		if (chip->config.measure_lra_impedance && chip->visense_enabled)
+ 			chip->pattern_start_time = ktime_get_boottime();
+ 
+@@ -3417,6 +3489,9 @@
+ 			goto restore;
+ 		}
+ 	}
++
++	chip->chip_effect_loaded = false;
++
+ 	mutex_unlock(&play->lock);
+ 
+ 	rc = haptics_enable_hpwr_vreg(chip, false);
+@@ -4903,6 +4978,12 @@
+ 	if (config->is_erm) {
+ 		config->drv_wf = WF_NO_MODULATION;
+ 		config->brake.brake_wf = WF_NO_MODULATION;
++
++		rc = of_property_read_u32(node, "qcom,lra-period-us", &config->t_lra_us); //Used internally by the driver
++		if (rc < 0) {
++			dev_warn(chip->dev, "Parse device-tree for LRA period failed (rc=%d), using default 5880\n", rc);
++			config->t_lra_us = 5880;
++		}
+ 	} else {
+ 		rc = haptics_parse_lra_dt(chip);
+ 		if (rc < 0) {
+@@ -6365,18 +6446,25 @@
+ 	input_set_drvdata(input_dev, chip);
+ 	chip->input_dev = input_dev;
+ 
++	chip->chip_effect_loaded = false;
++	chip->chip_is_playing = false;
++
+ 	input_set_capability(input_dev, EV_FF, FF_CONSTANT);
++	//if ((chip->effects_count != 0) || (chip->primitives_count != 0)) {
++	input_set_capability(input_dev, EV_FF, FF_PERIODIC);
++	//input_set_capability(input_dev, EV_FF, FF_CUSTOM); //Drop FF_CUSTOM
++	//}
+ 	input_set_capability(input_dev, EV_FF, FF_GAIN);
+-	if ((chip->effects_count != 0) || (chip->primitives_count != 0)) {
+-		input_set_capability(input_dev, EV_FF, FF_PERIODIC);
+-		input_set_capability(input_dev, EV_FF, FF_CUSTOM);
+-	}
+ 
+ 	if (chip->effects_count + chip->primitives_count > MAX_EFFECT_COUNT)
+ 		dev_err(chip->dev, "Effects count cannot be more than %d\n", MAX_EFFECT_COUNT);
+ 
+ 	count = min_t(u32, chip->effects_count + chip->primitives_count + 1, MAX_EFFECT_COUNT);
+ 
++	//This driver does not actually support multiple effects
++	//effect_id is not used ANYWHERE
++	count = 1;
++
+ 	rc = input_ff_create(input_dev, count);
+ 	if (rc < 0) {
+ 		dev_err(chip->dev, "create input FF device failed, rc=%d\n",

--- a/patch/kernel/archive/sm8750-7.1/1001-haptics-driver-support-periodic-sine-and-fixes.patch
+++ b/patch/kernel/archive/sm8750-7.1/1001-haptics-driver-support-periodic-sine-and-fixes.patch
@@ -1,6 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: haptics driver support periodic sine and fixes
+
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
+---
+ drivers/input/misc/qcom-hv-haptics.c | 110 +++++++++-
+ 1 file changed, 99 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/input/misc/qcom-hv-haptics.c b/drivers/input/misc/qcom-hv-haptics.c
+index 111111111111..222222222222 100644
 --- a/drivers/input/misc/qcom-hv-haptics.c
 +++ b/drivers/input/misc/qcom-hv-haptics.c
-@@ -792,6 +792,8 @@
+@@ -792,6 +792,8 @@ struct haptics_chip {
  	struct notifier_block		lpass_ssr_nb;
  	struct mutex			vmax_lock;
  	struct work_struct		set_gain_work;
@@ -9,7 +33,7 @@
  	struct list_head		mmap_effect_list;
  	int				fifo_empty_irq;
  	u32				hpwr_voltage_mv;
-@@ -2092,6 +2094,8 @@
+@@ -2092,6 +2094,8 @@ static int haptics_enable_play(struct haptics_chip *chip, bool en)
  	u8 val;
  
  	if (en) {
@@ -18,7 +42,7 @@
  		rc = haptics_clear_fault(chip);
  		if (rc < 0)
  			goto restore;
-@@ -2121,9 +2125,12 @@
+@@ -2121,9 +2125,12 @@ static int haptics_enable_play(struct haptics_chip *chip, bool en)
  	haptics_read(chip, chip->hbst_addr_base, 0x09, &val, 1);
  	dev_dbg(chip->dev, "haptics_enable_play, 0xf209=0x%x\n", val);
  
@@ -32,10 +56,11 @@
  	if (chip->wa_flags & SW_CTRL_HBST) {
  		if (en) {
  			rc = haptics_boost_vreg_enable(chip, true);
-@@ -3181,12 +3188,36 @@
+@@ -3180,6 +3187,29 @@ static void haptics_runtime_autosuspend(struct haptics_chip *chip)
+ 	pm_runtime_autosuspend(chip->dev);
  }
  
- static int haptics_upload_effect(struct input_dev *dev,
++static int haptics_upload_effect(struct input_dev *dev,
 +		struct ff_effect *effect, struct ff_effect *old);
 +
 +static int haptics_upload_ff_periodic_sine(struct input_dev *dev,
@@ -58,10 +83,10 @@
 +	return haptics_upload_effect(dev, &new_effect, old);
 +}
 +
-+static int haptics_upload_effect(struct input_dev *dev,
+ static int haptics_upload_effect(struct input_dev *dev,
  		struct ff_effect *effect, struct ff_effect *old)
  {
- 	struct haptics_chip *chip = input_get_drvdata(dev);
+@@ -3187,6 +3217,7 @@ static int haptics_upload_effect(struct input_dev *dev,
  	u32 length_ms, tmp;
  	s16 level;
  	u8 amplitude;
@@ -69,7 +94,7 @@
  	int rc = 0;
  
  	rc = haptics_runtime_resume_get(chip);
-@@ -3209,6 +3240,36 @@
+@@ -3209,6 +3240,36 @@ static int haptics_upload_effect(struct input_dev *dev,
  			goto auto_suspend;
  	}
  
@@ -106,7 +131,7 @@
  	switch (effect->type) {
  	case FF_CONSTANT:
  		length_ms = effect->replay.length;
-@@ -3228,11 +3289,17 @@
+@@ -3228,11 +3289,17 @@ static int haptics_upload_effect(struct input_dev *dev,
  
  		break;
  	case FF_PERIODIC:
@@ -129,7 +154,7 @@
  		if (effect->u.periodic.custom_len ==
  				sizeof(struct custom_fifo_data)) {
  			rc = haptics_load_custom_effect(chip,
-@@ -3286,6 +3353,8 @@
+@@ -3286,6 +3353,8 @@ static int haptics_upload_effect(struct input_dev *dev,
  		goto restore;
  	}
  
@@ -138,7 +163,7 @@
  	return 0;
  
  restore:
-@@ -3301,7 +3370,10 @@
+@@ -3301,7 +3370,10 @@ static int haptics_playback(struct input_dev *dev, int effect_id, int val)
  	struct haptics_chip *chip = input_get_drvdata(dev);
  
  	dev_dbg(chip->dev, "playback val = %d\n", val);
@@ -150,7 +175,7 @@
  		if (chip->config.measure_lra_impedance && chip->visense_enabled)
  			chip->pattern_start_time = ktime_get_boottime();
  
-@@ -3417,6 +3489,9 @@
+@@ -3417,6 +3489,9 @@ static int haptics_erase(struct input_dev *dev, int effect_id)
  			goto restore;
  		}
  	}
@@ -160,7 +185,7 @@
  	mutex_unlock(&play->lock);
  
  	rc = haptics_enable_hpwr_vreg(chip, false);
-@@ -4903,6 +4978,12 @@
+@@ -4903,6 +4978,12 @@ static int haptics_parse_dt(struct haptics_chip *chip)
  	if (config->is_erm) {
  		config->drv_wf = WF_NO_MODULATION;
  		config->brake.brake_wf = WF_NO_MODULATION;
@@ -173,7 +198,7 @@
  	} else {
  		rc = haptics_parse_lra_dt(chip);
  		if (rc < 0) {
-@@ -6365,18 +6446,25 @@
+@@ -6365,18 +6446,25 @@ static int haptics_probe(struct platform_device *pdev)
  	input_set_drvdata(input_dev, chip);
  	chip->input_dev = input_dev;
  
@@ -203,3 +228,6 @@
  	rc = input_ff_create(input_dev, count);
  	if (rc < 0) {
  		dev_err(chip->dev, "create input FF device failed, rc=%d\n",
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/1002-input-rsinput-sm8750-ff.patch
+++ b/patch/kernel/archive/sm8750-7.1/1002-input-rsinput-sm8750-ff.patch
@@ -1,25 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Based on work by Gianni Spadoni <me@gio.blue>
-Date: Tue, 21 Jul 2026 18:00:00 +0800
-Subject: [PATCH] input: rsinput: add force feedback bridge to qcom hv-haptics
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: input: rsinput: add force feedback bridge to qcom hv-haptics
 
-Add FF_PERIODIC support to the RSInput gamepad driver. Rumble events
-received on the gamepad evdev node are forwarded to the Qualcomm HV
-haptics driver via its exported global upload/playback API, so games
-that write rumble to the controller (routed back by InputPlumber) reach
-the PMIH0108 LRA actuator on AYN Odin 3 and similar SM8750 devices.
-
-This mirrors the approach used on SM8550 (r3claimer's 1003-rsinput-add-ff)
-but targets the rewritten rsinput driver that shipped in ROCKNIX next.
-
-A module parameter `rumble_enable` (default: true) is exposed to allow
-userspace to disable rumble at runtime.
-
-Signed-off-by: Adapted for ROCKNIX next rsinput rewrite
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
- drivers/input/joystick/rsinput.c | 42 ++++++++++++++++++++++++++++++++
- 1 file changed, 42 insertions(+)
+ drivers/input/joystick/rsinput.c | 32 ++++++++++
+ 1 file changed, 32 insertions(+)
 
 diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
+index 111111111111..222222222222 100644
 --- a/drivers/input/joystick/rsinput.c
 +++ b/drivers/input/joystick/rsinput.c
 @@ -17,6 +17,7 @@
@@ -30,21 +32,20 @@ diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
  #include <uapi/linux/sched/types.h>
  
  static int update_params=0;
-@@ -137,6 +138,9 @@
-     uint8_t rx_buf[1024];
+@@ -138,6 +139,9 @@ struct rsinput_driver {
      uint8_t sequence_number;
  };
-+
+ 
 +static bool rumble_enable = true;
 +module_param(rumble_enable, bool, 0660);
- 
++
  static const unsigned int keymap[] = {
      BTN_DPAD_UP, BTN_DPAD_DOWN, BTN_DPAD_LEFT, BTN_DPAD_RIGHT,
-@@ -401,7 +405,24 @@
- static const struct serdev_device_ops rsinput_rx_ops = {
+     BTN_NORTH,   BTN_WEST,	    BTN_EAST,	   BTN_SOUTH,
+@@ -402,6 +406,23 @@ static const struct serdev_device_ops rsinput_rx_ops = {
      .receive_buf = rsinput_rx,
  };
-+
+ 
 +static int rsinput_rumble_upload(struct input_dev *dev, struct ff_effect *effect,
 +                                 struct ff_effect *old)
 +{
@@ -58,14 +59,14 @@ diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
 +{
 +    if (!rumble_enable)
 +        return 0;
- 
++
 +    return qcom_spmi_haptics_global_playback(effect_id, val);
 +}
 +
  static int rsinput_probe(struct serdev_device *serdev) {
      struct rsinput_driver *drv;
      u32 gamepad_bus = 0;
-@@ -528,6 +549,17 @@
+@@ -536,6 +557,17 @@ static int rsinput_probe(struct serdev_device *serdev) {
      input_set_abs_params(drv->input, ABS_Z, 0, trigger_left_max - trigger_left_antideadzone, 0, 30);
      input_set_abs_params(drv->input, ABS_RZ, 0, trigger_right_max - trigger_right_antideadzone, 0, 30);
  
@@ -81,5 +82,8 @@ diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
 +    drv->input->ff->playback = rsinput_rumble_play;
 +
      error = input_register_device(drv->input);
-     if (error)
-         return error;
+     if (error) {
+ 	serdev_device_close(serdev);
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/1002-input-rsinput-sm8750-ff.patch
+++ b/patch/kernel/archive/sm8750-7.1/1002-input-rsinput-sm8750-ff.patch
@@ -1,0 +1,85 @@
+From: Based on work by Gianni Spadoni <me@gio.blue>
+Date: Tue, 21 Jul 2026 18:00:00 +0800
+Subject: [PATCH] input: rsinput: add force feedback bridge to qcom hv-haptics
+
+Add FF_PERIODIC support to the RSInput gamepad driver. Rumble events
+received on the gamepad evdev node are forwarded to the Qualcomm HV
+haptics driver via its exported global upload/playback API, so games
+that write rumble to the controller (routed back by InputPlumber) reach
+the PMIH0108 LRA actuator on AYN Odin 3 and similar SM8750 devices.
+
+This mirrors the approach used on SM8550 (r3claimer's 1003-rsinput-add-ff)
+but targets the rewritten rsinput driver that shipped in ROCKNIX next.
+
+A module parameter `rumble_enable` (default: true) is exposed to allow
+userspace to disable rumble at runtime.
+
+Signed-off-by: Adapted for ROCKNIX next rsinput rewrite
+---
+ drivers/input/joystick/rsinput.c | 42 ++++++++++++++++++++++++++++++++
+ 1 file changed, 42 insertions(+)
+
+diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
+--- a/drivers/input/joystick/rsinput.c
++++ b/drivers/input/joystick/rsinput.c
+@@ -17,6 +17,7 @@
+ #include <linux/regulator/consumer.h>
+ #include <linux/serdev.h>
+ #include <linux/slab.h>
++#include <linux/soc/qcom/qcom_hv_haptics.h>
+ #include <uapi/linux/sched/types.h>
+ 
+ static int update_params=0;
+@@ -137,6 +138,9 @@
+     uint8_t rx_buf[1024];
+     uint8_t sequence_number;
+ };
++
++static bool rumble_enable = true;
++module_param(rumble_enable, bool, 0660);
+ 
+ static const unsigned int keymap[] = {
+     BTN_DPAD_UP, BTN_DPAD_DOWN, BTN_DPAD_LEFT, BTN_DPAD_RIGHT,
+@@ -401,7 +405,24 @@
+ static const struct serdev_device_ops rsinput_rx_ops = {
+     .receive_buf = rsinput_rx,
+ };
++
++static int rsinput_rumble_upload(struct input_dev *dev, struct ff_effect *effect,
++                                 struct ff_effect *old)
++{
++    if (!rumble_enable)
++        return 0;
++
++    return qcom_spmi_haptics_global_upload(effect);
++}
++
++static int rsinput_rumble_play(struct input_dev *dev, int effect_id, int val)
++{
++    if (!rumble_enable)
++        return 0;
+ 
++    return qcom_spmi_haptics_global_playback(effect_id, val);
++}
++
+ static int rsinput_probe(struct serdev_device *serdev) {
+     struct rsinput_driver *drv;
+     u32 gamepad_bus = 0;
+@@ -528,6 +549,17 @@
+     input_set_abs_params(drv->input, ABS_Z, 0, trigger_left_max - trigger_left_antideadzone, 0, 30);
+     input_set_abs_params(drv->input, ABS_RZ, 0, trigger_right_max - trigger_right_antideadzone, 0, 30);
+ 
++    input_set_capability(drv->input, EV_FF, FF_PERIODIC);
++
++    error = input_ff_create(drv->input, 1);
++    if (error) {
++        dev_err(&serdev->dev, "Unable to create force feedback device: %d\n", error);
++        return error;
++    }
++
++    drv->input->ff->upload = rsinput_rumble_upload;
++    drv->input->ff->playback = rsinput_rumble_play;
++
+     error = input_register_device(drv->input);
+     if (error)
+         return error;

--- a/patch/kernel/archive/sm8750-7.1/1003-arm64-dts-qcom-ayn-cq8725s-common-hv-haptics.patch
+++ b/patch/kernel/archive/sm8750-7.1/1003-arm64-dts-qcom-ayn-cq8725s-common-hv-haptics.patch
@@ -1,5 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: arm64 dts qcom ayn cq8725s common hv haptics
+
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi | 180 ++++++++++
+ 1 file changed, 180 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
-index 8723da2c9..33bbc27f9 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
 @@ -8,6 +8,7 @@
@@ -10,7 +32,7 @@ index 8723da2c9..33bbc27f9 100644
  #include "sm8750.dtsi"
  #include "pm8550.dtsi"
  #define PMK8550VE_SID 8
-@@ -1034,6 +1035,185 @@ &pon_resin {
+@@ -1035,6 +1036,185 @@ &pon_resin {
  	status = "okay";
  };
  
@@ -196,3 +218,6 @@ index 8723da2c9..33bbc27f9 100644
  &pmih0108_eusb2_repeater {
  	status = "okay";
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/1003-arm64-dts-qcom-ayn-cq8725s-common-hv-haptics.patch
+++ b/patch/kernel/archive/sm8750-7.1/1003-arm64-dts-qcom-ayn-cq8725s-common-hv-haptics.patch
@@ -1,0 +1,198 @@
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+index 8723da2c9..33bbc27f9 100644
+--- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+@@ -8,6 +8,7 @@
+ #include <dt-bindings/gpio/gpio.h>
+ #include <dt-bindings/leds/common.h>
+ #include <dt-bindings/regulator/qcom,rpmh-regulator.h>
++#include <dt-bindings/input/qcom,hv-haptics.h>
+ #include "sm8750.dtsi"
+ #include "pm8550.dtsi"
+ #define PMK8550VE_SID 8
+@@ -1034,6 +1035,185 @@ &pon_resin {
+ 	status = "okay";
+ };
+ 
++&pmk8550 {
++	pmk8550_sdam_9d00: nvram@9d00 {
++		compatible = "qcom,spmi-sdam";
++		reg = <0x9d00>;
++	};
++};
++
++&pmih0108 {
++	pmih0108_hv_haptics: qcom,hv-haptics@f000 {
++		compatible = "qcom,hv-haptics";
++		reg = <0xf000>, <0xf100>, <0xf200>;
++		interrupts = <0x07 0xf0 0x1 IRQ_TYPE_EDGE_RISING>;
++		interrupt-names = "fifo-empty";
++		qcom,vmax-mv = <1700>; // 0x6a4
++		qcom,brake-mode = <BRAKE_CLOSE_LOOP>;
++		qcom,lra-period-us = <5880>;
++		qcom,brake-pattern = /bits/ 8 <0xff 0x3f 0x1f>;
++		qcom,drv-sig-shape = <WF_SINE>;
++		qcom,brake-sig-shape = <WF_SINE>;
++		nvmem-names = "hap_cfg_sdam";
++		nvmem = <&pmk8550_sdam_9d00>;
++		status = "ok";
++
++		hap_swr_slave_reg: qcom,hap-swr-slave-reg {
++			regulator-name = "hap-swr-slave-reg";
++		};
++
++		effect_0 {
++			qcom,effect-id = <0x00>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = <0x7f7f7f7f>;
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		effect_1 {
++			qcom,effect-id = <0x01>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f 7f 7f 7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		effect_2 {
++			qcom,effect-id = <0x02>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		effect_3 {
++			qcom,effect-id = <0x03>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		effect_4 {
++			qcom,effect-id = <0x04>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		effect_5 {
++			qcom,effect-id = <0x05>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f 7f 7f 7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		primitive_0 {
++			qcom,primitive-id = <0x00>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = <0x00>;
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		primitive_1 {
++			qcom,primitive-id = <0x01>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		primitive_2 {
++			qcom,primitive-id = <0x02>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		primitive_3 {
++			qcom,primitive-id = <0x03>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		primitive_4 {
++			qcom,primitive-id = <0x04>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		primitive_5 {
++			qcom,primitive-id = <0x05>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		primitive_6 {
++			qcom,primitive-id = <0x06>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		primitive_7 {
++			qcom,primitive-id = <0x07>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++
++		primitive_8 {
++			qcom,primitive-id = <0x08>;
++			qcom,wf-vmax-mv = <0xe10>;
++			qcom,wf-fifo-preload;
++			qcom,wf-fifo-data = [7f 7f];
++			qcom,wf-fifo-period = <0x00>;
++			qcom,wf-auto-res-disable;
++			qcom,wf-brake-disable;
++		};
++	};
++};
++
+ &pmih0108_eusb2_repeater {
+ 	status = "okay";
+ 

--- a/patch/kernel/archive/sm8750-7.1/1004-input-qcom-hv-haptics-defer-rsinput-playback.patch
+++ b/patch/kernel/archive/sm8750-7.1/1004-input-qcom-hv-haptics-defer-rsinput-playback.patch
@@ -1,0 +1,186 @@
+From: gh123man <gh123man@users.noreply.github.com>
+Subject: [PATCH] input: qcom-hv-haptics: defer rsinput playback bridge
+
+The rsinput force-feedback playback callback runs below input_event(), with
+the input device event spinlock held and interrupts disabled.  The global
+Qualcomm haptics bridge calls haptics_erase() directly from that callback.
+haptics_erase() takes a mutex and synchronously cancels delayed work, which
+can sleep and produces "BUG: scheduling while atomic" during game rumble.
+
+Keep playback submission atomic by recording the latest request and applying
+it from a workqueue.  Serialize uploads, playback, and gain changes with a
+mutex in process context, and drain both playback work and delayed stop work
+before suspending the haptics device.
+
+---
+--- a/drivers/input/misc/qcom-hv-haptics.c
++++ b/drivers/input/misc/qcom-hv-haptics.c
+@@ -792,6 +792,12 @@
+ 	struct notifier_block		lpass_ssr_nb;
+ 	struct mutex			vmax_lock;
+ 	struct work_struct		set_gain_work;
++	struct mutex			global_ff_lock;
++	struct work_struct		global_playback_work;
++	spinlock_t			global_playback_lock;
++	u32				global_playback_seq;
++	int				global_effect_id;
++	int				global_playback_val;
+ 	volatile bool			chip_effect_loaded;
+ 	volatile bool			chip_is_playing;
+ 	struct list_head		mmap_effect_list;
+@@ -858,6 +864,7 @@
+ };
+ 
+ static struct haptics_chip *phapchip;
++static void haptics_global_playback_work(struct work_struct *work);
+ 
+ bool qcom_haptics_vi_sense_is_enabled(void)
+ {
+@@ -6438,6 +6445,9 @@
+ 	hrtimer_setup(&chip->hbst_off_timer, haptics_disable_hbst_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+ 	INIT_DELAYED_WORK(&chip->stop_work, haptics_stop_constant_effect_play);
+ 	INIT_WORK(&chip->set_gain_work, haptics_set_gain_work);
++	mutex_init(&chip->global_ff_lock);
++	spin_lock_init(&chip->global_playback_lock);
++	INIT_WORK(&chip->global_playback_work, haptics_global_playback_work);
+ 
+ 	atomic_set(&chip->play.fifo_status.is_busy, 0);
+ 	atomic_set(&chip->play.fifo_status.written_done, 0);
+@@ -6545,6 +6555,7 @@
+ 	struct haptics_chip *chip = dev_get_drvdata(&pdev->dev);
+ 
+ 	phapchip = NULL;
++	cancel_work_sync(&chip->global_playback_work);
+ 	if (chip->pbs_node)
+ 		of_node_put(chip->pbs_node);
+ 
+@@ -6602,6 +6613,9 @@
+ 	struct haptics_play_info *play = &chip->play;
+ 	int rc;
+ 
++	cancel_work_sync(&chip->global_playback_work);
++	cancel_delayed_work_sync(&chip->stop_work);
++
+ 	mutex_lock(&play->lock);
+ 	if ((play->pattern_src == FIFO) &&
+ 			atomic_read(&play->fifo_status.is_busy)) {
+@@ -6730,54 +6744,91 @@
+ 	haptics_ds_suspend_config(chip->dev);
+ }
+ 
+-int qcom_spmi_haptics_global_upload(struct ff_effect *effect) {
+-	int ret;
+-
+-	if (!phapchip)
+-		return -ENODEV;
+-
+-	spin_lock_irq(&phapchip->input_dev->event_lock);
++static void haptics_global_playback_work(struct work_struct *work)
++{
++	struct haptics_chip *chip = container_of(work, struct haptics_chip,
++						 global_playback_work);
++	unsigned long flags;
++	u32 sequence;
++	int effect_id, val, ret;
+ 
+-	ret = phapchip->input_dev->ff->upload(phapchip->input_dev, effect, NULL);
++	/*
++	 * Force-feedback playback is called with the input device event lock held,
++	 * so it cannot invoke the haptics callbacks directly: erase waits for the
++	 * delayed stop work and takes a mutex.  Apply the latest requested state
++	 * here instead, in sleepable workqueue context.  Loop if another event was
++	 * delivered while the hardware operation was in progress.
++	 */
++	do {
++		spin_lock_irqsave(&chip->global_playback_lock, flags);
++		sequence = chip->global_playback_seq;
++		effect_id = chip->global_effect_id;
++		val = chip->global_playback_val;
++		spin_unlock_irqrestore(&chip->global_playback_lock, flags);
++
++		mutex_lock(&chip->global_ff_lock);
++		if (val)
++			ret = haptics_playback(chip->input_dev, effect_id, val);
++		else
++			ret = haptics_erase(chip->input_dev, effect_id);
++		mutex_unlock(&chip->global_ff_lock);
+ 
+-	spin_unlock_irq(&phapchip->input_dev->event_lock);
++		if (ret)
++			dev_warn(chip->dev, "global %s failed: %d\n",
++				 val ? "playback" : "erase", ret);
+ 
+-	return ret;
++		spin_lock_irqsave(&chip->global_playback_lock, flags);
++		ret = sequence != chip->global_playback_seq;
++		spin_unlock_irqrestore(&chip->global_playback_lock, flags);
++	} while (ret);
+ }
+ 
+-int qcom_spmi_haptics_global_playback(int effect_id, int val) {
++int qcom_spmi_haptics_global_upload(struct ff_effect *effect)
++{
++	struct haptics_chip *chip = READ_ONCE(phapchip);
+ 	int ret;
+ 
+-	if (!phapchip)
++	if (!chip)
+ 		return -ENODEV;
+ 
+-	spin_lock_irq(&phapchip->input_dev->event_lock);
++	mutex_lock(&chip->global_ff_lock);
++	ret = haptics_upload_effect(chip->input_dev, effect, NULL);
++	mutex_unlock(&chip->global_ff_lock);
+ 
+-	if (val != 0)
+-		ret = phapchip->input_dev->ff->playback(phapchip->input_dev, effect_id, val);
+-	else
+-		ret = phapchip->input_dev->ff->erase(phapchip->input_dev, effect_id);
++	return ret;
++}
++
++int qcom_spmi_haptics_global_playback(int effect_id, int val)
++{
++	struct haptics_chip *chip = READ_ONCE(phapchip);
++	unsigned long flags;
+ 
+-	if (ret)
+-		pr_warn("%s called for %s, error in return (%d)\n", __func__, (val!=0 ? "Playback" : "Erase"), ret);
++	if (!chip)
++		return -ENODEV;
+ 
+-	spin_unlock_irq(&phapchip->input_dev->event_lock);
++	spin_lock_irqsave(&chip->global_playback_lock, flags);
++	chip->global_effect_id = effect_id;
++	chip->global_playback_val = val;
++	chip->global_playback_seq++;
++	spin_unlock_irqrestore(&chip->global_playback_lock, flags);
+ 
+-	return ret;
++	schedule_work(&chip->global_playback_work);
++	return 0;
+ }
+ 
+-int qcom_spmi_haptics_global_set_gain(u16 gain) {
+-	if (!phapchip)
+-		return -ENODEV;
++int qcom_spmi_haptics_global_set_gain(u16 gain)
++{
++	struct haptics_chip *chip = READ_ONCE(phapchip);
+ 
+-	spin_lock_irq(&phapchip->input_dev->event_lock);
++	if (!chip)
++		return -ENODEV;
+ 
+ 	//max is 0x7fff, and minimum is 0x4000 the same values android uses
+ 	gain = clamp(gain, 0x4000, 0x7fff);
+ 
+-	phapchip->input_dev->ff->set_gain(phapchip->input_dev, gain);
+-
+-	spin_unlock_irq(&phapchip->input_dev->event_lock);
++	mutex_lock(&chip->global_ff_lock);
++	haptics_set_gain(chip->input_dev, gain);
++	mutex_unlock(&chip->global_ff_lock);
+ 
+ 	return 0;
+ }

--- a/patch/kernel/archive/sm8750-7.1/1004-input-qcom-hv-haptics-defer-rsinput-playback.patch
+++ b/patch/kernel/archive/sm8750-7.1/1004-input-qcom-hv-haptics-defer-rsinput-playback.patch
@@ -1,21 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: gh123man <gh123man@users.noreply.github.com>
-Subject: [PATCH] input: qcom-hv-haptics: defer rsinput playback bridge
+Date: Sat, 29 Aug 2026 11:27:39 +0200
+Subject: input: qcom-hv-haptics: defer rsinput playback bridge
 
-The rsinput force-feedback playback callback runs below input_event(), with
-the input device event spinlock held and interrupts disabled.  The global
-Qualcomm haptics bridge calls haptics_erase() directly from that callback.
-haptics_erase() takes a mutex and synchronously cancels delayed work, which
-can sleep and produces "BUG: scheduling while atomic" during game rumble.
-
-Keep playback submission atomic by recording the latest request and applying
-it from a workqueue.  Serialize uploads, playback, and gain changes with a
-mutex in process context, and drain both playback work and delayed stop work
-before suspending the haptics device.
-
+> X-Git-Archeology: > recovered message: > Bring over the patches ROCKNIX still carries on top of the set imported
+> X-Git-Archeology: > recovered message: > in the bringup: the integrated-jack USBSS routing with the HPH PCM HiFi
+> X-Git-Archeology: > recovered message: > path, USB-C redriver and probe-defer fixes, the hv-haptics driver with
+> X-Git-Archeology: > recovered message: > the rsinput force feedback bridge, UFS support for the SM8750
+> X-Git-Archeology: > recovered message: > controller and the thermal, capacity and RTC DT bits. Patches aimed at
+> X-Git-Archeology: > recovered message: > other devices (KONKR, Ayaneo) are left out; the collided 0052 rpmhpd
+> X-Git-Archeology: > recovered message: > patch is renumbered to 0053.
+> X-Git-Archeology: > recovered message: > Signed-off-by: SuperKali <hello@superkali.me>
+> X-Git-Archeology: - Revision d7ac3357efedd9f44916dc489e9727e95a34f0b9: https://github.com/armbian/build/commit/d7ac3357efedd9f44916dc489e9727e95a34f0b9
+> X-Git-Archeology:   Date: Sat, 29 Aug 2026 11:27:39 +0200
+> X-Git-Archeology:   From: SuperKali <hello@superkali.me>
+> X-Git-Archeology:   Subject: kernel/sm8750: sync the remaining ROCKNIX patches
+> X-Git-Archeology:
 ---
+ drivers/input/misc/qcom-hv-haptics.c | 107 +++++++---
+ 1 file changed, 79 insertions(+), 28 deletions(-)
+
+diff --git a/drivers/input/misc/qcom-hv-haptics.c b/drivers/input/misc/qcom-hv-haptics.c
+index 111111111111..222222222222 100644
 --- a/drivers/input/misc/qcom-hv-haptics.c
 +++ b/drivers/input/misc/qcom-hv-haptics.c
-@@ -792,6 +792,12 @@
+@@ -792,6 +792,12 @@ struct haptics_chip {
  	struct notifier_block		lpass_ssr_nb;
  	struct mutex			vmax_lock;
  	struct work_struct		set_gain_work;
@@ -28,7 +37,7 @@ before suspending the haptics device.
  	volatile bool			chip_effect_loaded;
  	volatile bool			chip_is_playing;
  	struct list_head		mmap_effect_list;
-@@ -858,6 +864,7 @@
+@@ -858,6 +864,7 @@ static const struct fifo_hw_info hap530_fifo = {
  };
  
  static struct haptics_chip *phapchip;
@@ -36,7 +45,7 @@ before suspending the haptics device.
  
  bool qcom_haptics_vi_sense_is_enabled(void)
  {
-@@ -6438,6 +6445,9 @@
+@@ -6438,6 +6445,9 @@ static int haptics_probe(struct platform_device *pdev)
  	hrtimer_setup(&chip->hbst_off_timer, haptics_disable_hbst_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
  	INIT_DELAYED_WORK(&chip->stop_work, haptics_stop_constant_effect_play);
  	INIT_WORK(&chip->set_gain_work, haptics_set_gain_work);
@@ -46,7 +55,7 @@ before suspending the haptics device.
  
  	atomic_set(&chip->play.fifo_status.is_busy, 0);
  	atomic_set(&chip->play.fifo_status.written_done, 0);
-@@ -6545,6 +6555,7 @@
+@@ -6545,6 +6555,7 @@ static void haptics_remove(struct platform_device *pdev)
  	struct haptics_chip *chip = dev_get_drvdata(&pdev->dev);
  
  	phapchip = NULL;
@@ -54,7 +63,7 @@ before suspending the haptics device.
  	if (chip->pbs_node)
  		of_node_put(chip->pbs_node);
  
-@@ -6602,6 +6613,9 @@
+@@ -6602,6 +6613,9 @@ static int haptics_suspend_config(struct device *dev)
  	struct haptics_play_info *play = &chip->play;
  	int rc;
  
@@ -64,7 +73,7 @@ before suspending the haptics device.
  	mutex_lock(&play->lock);
  	if ((play->pattern_src == FIFO) &&
  			atomic_read(&play->fifo_status.is_busy)) {
-@@ -6730,54 +6744,91 @@
+@@ -6730,54 +6744,91 @@ static void haptics_shutdown(struct platform_device *pdev)
  	haptics_ds_suspend_config(chip->dev);
  }
  
@@ -184,3 +193,6 @@ before suspending the haptics device.
  
  	return 0;
  }
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/1300-input-rsinput-ranges.patch
+++ b/patch/kernel/archive/sm8750-7.1/1300-input-rsinput-ranges.patch
@@ -1,6 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Ling <ling_kasim@hotmail.com>
+Date: Sun, 9 Aug 2026 09:11:00 +0200
+Subject: input rsinput ranges
+
+> X-Git-Archeology: - Revision cd3cfe78bd00658dce3d89b584e9c1e2554ffb65: https://github.com/armbian/build/commit/cd3cfe78bd00658dce3d89b584e9c1e2554ffb65
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 09:11:00 +0200
+> X-Git-Archeology:   From: Alex Ling <ling_kasim@hotmail.com>
+> X-Git-Archeology:   Subject: sm8750: Import kernel 7.1 patches from ROCKNIX
+> X-Git-Archeology:
+---
+ drivers/input/joystick/rsinput.c | 46 +++++-----
+ 1 file changed, 23 insertions(+), 23 deletions(-)
+
+diff --git a/drivers/input/joystick/rsinput.c b/drivers/input/joystick/rsinput.c
+index 111111111111..222222222222 100644
 --- a/drivers/input/joystick/rsinput.c
 +++ b/drivers/input/joystick/rsinput.c
-@@ -29,29 +29,29 @@
+@@ -30,29 +30,29 @@ static int trigger_right_max=0x610;
  static int trigger_right_deadzone=0x0;
  static int trigger_right_antideadzone=0x0;
  
@@ -53,3 +69,6 @@
  
  module_param(update_params,int,0660);
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/sm8750-7.1/1301-arm64-dts-qcom-cq8725s-ayn-drive-the-fan-from-thermal-zones.patch
+++ b/patch/kernel/archive/sm8750-7.1/1301-arm64-dts-qcom-cq8725s-ayn-drive-the-fan-from-thermal-zones.patch
@@ -1,0 +1,295 @@
+From a7c2bfc24b3f8800bf88d0a1446a3f27a9f3cbe5 Mon Sep 17 00:00:00 2001
+From: SuperKali <hello@superkali.me>
+Date: Sat, 29 Aug 2026 14:30:35 +0200
+Subject: [PATCH] arm64: dts: qcom: cq8725s-ayn: drive the fan from the thermal
+ zones
+
+The fan node has cooling levels but no thermal trips wired to them, so
+the PWM sits at the boot default and the CPU throttles with the fan
+barely spinning. Give the four cpuss and the eight gpuss zones active
+trips from 40 to 80 degrees with 5 degrees of hysteresis, each stepping
+the fan one level up the cooling-levels table.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+---
+ .../boot/dts/qcom/cq8725s-ayn-common.dtsi     | 267 ++++++++++++++++++
+ 1 file changed, 267 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+index 4c0ee61d1478..0cee0f54b98b 100644
+--- a/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/cq8725s-ayn-common.dtsi
+@@ -1470,3 +1470,270 @@ rtc_offset: rtc-offset@72 {
+ 		reg = <0x72 0x4>;
+ 	};
+ };
++
++#define FAN_HYSTERESIS 5000
++
++&{/thermal-zones/cpuss-0-0-thermal} {
++	trips {
++		cpu00_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu00_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu00_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu00_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu00_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu00_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu00_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&cpu00_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&cpu00_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&cpu00_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&cpu00_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&cpu00_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&cpu00_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&cpu00_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&{/thermal-zones/cpuss-0-1-thermal} {
++	trips {
++		cpu01_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu01_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu01_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu01_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu01_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu01_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu01_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&cpu01_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&cpu01_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&cpu01_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&cpu01_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&cpu01_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&cpu01_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&cpu01_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&{/thermal-zones/cpuss-1-0-thermal} {
++	trips {
++		cpu10_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu10_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu10_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu10_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu10_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu10_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu10_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&cpu10_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&cpu10_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&cpu10_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&cpu10_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&cpu10_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&cpu10_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&cpu10_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&{/thermal-zones/cpuss-1-1-thermal} {
++	trips {
++		cpu11_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu11_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu11_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu11_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu11_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu11_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		cpu11_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&cpu11_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&cpu11_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&cpu11_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&cpu11_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&cpu11_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&cpu11_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&cpu11_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&{/thermal-zones/gpuss0-thermal} {
++	trips {
++		gpu0_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu0_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu0_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu0_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu0_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu0_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu0_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu0_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu0_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu0_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu0_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu0_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu0_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu0_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&{/thermal-zones/gpuss1-thermal} {
++	trips {
++		gpu1_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu1_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu1_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu1_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu1_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu1_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu1_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu1_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu1_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu1_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu1_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu1_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu1_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu1_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&{/thermal-zones/gpuss2-thermal} {
++	trips {
++		gpu2_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu2_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu2_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu2_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu2_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu2_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu2_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu2_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu2_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu2_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu2_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu2_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu2_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu2_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&{/thermal-zones/gpuss3-thermal} {
++	trips {
++		gpu3_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu3_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu3_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu3_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu3_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu3_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu3_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu3_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu3_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu3_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu3_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu3_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu3_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu3_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&{/thermal-zones/gpuss4-thermal} {
++	trips {
++		gpu4_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu4_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu4_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu4_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu4_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu4_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu4_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu4_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu4_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu4_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu4_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu4_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu4_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu4_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&{/thermal-zones/gpuss5-thermal} {
++	trips {
++		gpu5_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu5_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu5_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu5_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu5_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu5_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu5_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu5_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu5_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu5_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu5_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu5_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu5_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu5_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&{/thermal-zones/gpuss6-thermal} {
++	trips {
++		gpu6_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu6_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu6_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu6_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu6_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu6_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu6_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu6_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu6_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu6_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu6_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu6_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu6_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu6_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
++&{/thermal-zones/gpuss7-thermal} {
++	trips {
++		gpu7_fan0: trip-point-fan0 { temperature = <40000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu7_fan1: trip-point-fan1 { temperature = <50000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu7_fan2: trip-point-fan2 { temperature = <60000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu7_fan3: trip-point-fan3 { temperature = <65000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu7_fan4: trip-point-fan4 { temperature = <70000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu7_fan5: trip-point-fan5 { temperature = <75000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++		gpu7_fan6: trip-point-fan6 { temperature = <80000>; hysteresis = <FAN_HYSTERESIS>; type = "active"; };
++	};
++
++	cooling-maps {
++		map0 { trip = <&gpu7_fan0>; cooling-device = <&pwm_fan 0 1>; };
++		map1 { trip = <&gpu7_fan1>; cooling-device = <&pwm_fan 1 2>; };
++		map2 { trip = <&gpu7_fan2>; cooling-device = <&pwm_fan 2 3>; };
++		map3 { trip = <&gpu7_fan3>; cooling-device = <&pwm_fan 3 4>; };
++		map4 { trip = <&gpu7_fan4>; cooling-device = <&pwm_fan 4 5>; };
++		map5 { trip = <&gpu7_fan5>; cooling-device = <&pwm_fan 5 6>; };
++		map6 { trip = <&gpu7_fan6>; cooling-device = <&pwm_fan 6 7>; };
++	};
++};
++
+-- 
+2.47.3
+


### PR DESCRIPTION
# Description

The Odin 3 is a handheld console that ships with Android, and the merged bringup stands in the way of actually using it as one: it boots through an Android boot image and wants the ROCKNIX ABL flashed, which is the only step that breaks Android FOTA updates. The stock ABL already exposes UEFI and boots a GRUB image straight off the SD card, so I made that the default. The image is now a plain GPT disk with an ESP and BOOTAA64.EFI, Android and its FOTA partition stay untouched, and removing the card boots Android again. The boot image path still works behind `WITH_GRUB=no` and gets an `-abl` suffix in the filename, so nobody loses the old flow.

The first boot on stock UEFI gave me a black screen with DPU kickoff timeouts all over dmesg. The stock UEFI leaves the display block fully active at ExitBootServices and mainline dispcc cannot reprogram it on top of that state, so I ported the knockdown I had working on 7.0: assert the MDSS core, INT2 and RSCC block resets at probe, hold one frame, release. It is the same workaround custom loaders apply, and it is harmless on the boot image path where the block is already down.

While chasing audio I noticed the ROCKNIX patch set had drifted from what we carry for this console, so I synced the 25 missing patches: the integrated jack routing, the USB-C SuperSpeed redriver, the typec probe fixes, the hv-haptics driver with the rsinput force feedback bridge (the gamepad finally rumbles), UFS support, CPU thermal cooling and capacity, the RTC offset and a few stability fixes. I left out the patches aimed at other devices (KONKR, Ayaneo), and ran the whole series through the framework rewrite tool to give every file proper headers and context.

The jack itself needed two more fixes. The codec driver resolves the WCD9395 USBSS analog switch through a `qcom,usbss` phandle that no dts ever carried, so the switch never entered audio mode. I traced this on the device: the mux binds, MBHC detects the plug, but nothing ever switches. The phandle is now set in the AYN common dtsi, and I checked ROCKNIX: they are missing it too. Then the AYN UCM brought the amp up in CLS_H_ULP with the compander on, which distorted badly and collapsed at high volume. I vendored the UCM into the bsp with a Class-AB HiFi bring-up, HD2 compensation and the compander off, the same operating point radxa ships for the wcd938x on the Dragon Q8B, and added the entrypoint for the card name the UEFI boot composes.

The fan annoyed me the most, I think: it sat at whatever PWM the boot default set and never moved again, because the 7.1 ROCKNIX imports dropped the cooling maps. Active trips on the four cpuss and eight gpuss zones now step it through the eight cooling levels, 40 to 80 degrees with hysteresis. Watching cur_state climb under load was oddly satisfying.

The Adreno 830 also needs a Mesa newer than trixie ships, or the desktop falls back to llvmpipe. A dedicated hook installs the GL and Vulkan stack from trixie-backports on Debian and leaves other releases alone, and `FD_MESA_DEBUG=sysmem` works around the A830 GMEM defect that shows up as browser glitches.

I am also joining as board maintainer, since I developed and verified all of this on my Odin 3.

# How Has This Been Tested?

On my AYN Odin 3 (SM8750), trixie, edge 7.1.12, GNOME desktop image, stock ABL, nothing flashed.

- [x] Default image boots from SD through the stock ABL UEFI into GRUB; removing the media boots Android again, untouched
- [x] Display comes up through the kernel handoff with the dispcc knockdown (black screen without it)
- [x] Headphone jack routes, plays clean audio at usable volume, USB-C audio dongles unaffected
- [x] Fan steps through the cooling levels following CPU and GPU temperature instead of sitting at the boot PWM
- [x] GPU runs freedreno on the Adreno 830 once the backports Mesa is in, verified with eglinfo
- [x] `WITH_GRUB=no` still builds the Android boot image layout, with the `-abl` suffix in the filename
- [x] Kernel and both image variants build clean with the full 59 patch series

armbianmonitor: https://paste.armbian.com/xojebuqaca

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional GRUB boot support for AYN Odin 3 while preserving Android boot.
  - Added support for Odin 3 display, touchscreen, gamepad, haptics, audio, Wi‑Fi, Bluetooth, USB-C, and UFS hardware.
  - Added headphone PCM/HiFi audio, improved jack detection, RTC offset persistence, and force-feedback rumble.
  - Added suspend/resume gamepad handling, improved joystick calibration, stable network/Bluetooth addresses, and automatic CPU/GPU fan cooling.

- **Bug Fixes**
  - Improved display initialization, USB-C routing, wireless setup, power management, thermal protection, and suspend/resume reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->