### PR TITLE
grub: show the Armbian wallpaper on Debian images (desktop-base overwrites it)

### DIFF
--- a/extensions/grub.sh
+++ b/extensions/grub.sh
@@ -309,6 +309,7 @@ configure_grub() {
 		GRUB_TIMEOUT_STYLE=menu                                  # Show the menu with Kernel options (Armbian or -generic)...
 		GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT}                        # ... for ${UEFI_GRUB_TIMEOUT} seconds, then boot the Armbian default.
 		GRUB_DISTRIBUTOR="${UEFI_GRUB_DISTRO_NAME}"              # On GRUB menu will show up as "Armbian GNU/Linux" (will show up in some UEFI BIOS boot menu (F8?) as "armbian", not on others)
+		GRUB_BACKGROUND="/usr/share/images/grub/wallpaper.png"   # Armbian GRUB wallpaper. 05_debian_theme gives GRUB_BACKGROUND precedence over the WALLPAPER sourced from /usr/share/desktop-base/grub_background.sh, so the Armbian image wins even on Debian desktop images where desktop-base ships (and overwrites) that file to point at its own theme wallpaper (Trixie: ceratopsian). Ubuntu already showed the Armbian image; this makes it deterministic on both.
 		GRUB_DISABLE_SUBMENU=y                                   # Do not put all kernel options into a submenu, instead, list them all on the main menu.
 		GRUB_DISABLE_OS_PROBER=false                             # Have to be explicit about enabling os-prober
 		GRUB_FONT="/usr/share/grub/unicode.pf2"                  # Be explicit about the font to use so Ubuntu does not freak out and mess gfxterm


### PR DESCRIPTION
> **TL;DR** — Debian x86 desktop images showed *Debian's* GRUB wallpaper instead of Armbian's, because `desktop-base` overwrites the file Armbian was writing into. Setting `GRUB_BACKGROUND` in Armbian's own GRUB config takes precedence and fixes it. One line, Debian + Ubuntu both deterministic now.

## Cause

Armbian only appended its `WALLPAPER` to `/usr/share/desktop-base/grub_background.sh`. That file is shipped and owned by `desktop-base` as a conffile, so on Debian desktop images `desktop-base`'s version wins and points GRUB at its own theme image (Trixie: *ceratopsian*). Ubuntu doesn't overwrite that file, which is why the Armbian wallpaper survived there and the bug looked Debian-specific.

## Fix

Set `GRUB_BACKGROUND=/usr/share/images/grub/wallpaper.png` in Armbian's own `98-armbian.cfg`. `05_debian_theme` (from `grub-common`) gives `GRUB_BACKGROUND` precedence over the `WALLPAPER` it sources from `grub_background.sh`, so the Armbian image wins on both Debian and Ubuntu regardless of what `desktop-base` does.

One line, in `extensions/grub.sh`.

## Testing

Rebuilt a Debian Trixie x86 desktop image: GRUB shows the Armbian wallpaper, and `grep background_image /boot/grub/grub.cfg` resolves to `/usr/share/images/grub/wallpaper.png`. `bash -n` and editorconfig clean.

## Scope

This came out of investigating the Debian boot **splash** (Plymouth showing the Debian logo). The splash is a separate problem and is *not* addressed here — an earlier attempt in this PR to key the initrd cache on the Plymouth theme has been dropped, because it didn't fix the splash. This wallpaper change stands on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the Armbian wallpaper is displayed consistently in the GRUB boot menu across Ubuntu and Debian images.
  * Prevented Debian theme settings from replacing the intended boot wallpaper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->